### PR TITLE
mlx5 Data Direct support for RDMA VRAM registration (#3104)

### DIFF
--- a/comms/uniflow/drivers/DeviceAdapter.h
+++ b/comms/uniflow/drivers/DeviceAdapter.h
@@ -13,6 +13,19 @@ namespace uniflow {
 class CudaApi;
 class CudaDriverApi;
 
+/// How a device buffer is mapped when exported as a DMA-BUF.
+enum class DmaBufMapping {
+  /// Standard mapping. On Grace-based systems (e.g. GB300) NIC<->GPU traffic
+  /// traverses the C2C link.
+  Default,
+  /// mlx5 Data Direct: map the buffer over the NIC's PCIe BAR1 path so the NIC
+  /// DMAs straight to/from GPU HBM, bypassing the Grace C2C link. The exported
+  /// fd must back an `mlx5dv_reg_dmabuf_mr` with
+  /// `MLX5DV_REG_DMABUF_ACCESS_DATA_DIRECT`. Only meaningful on a Data-Direct-
+  /// capable NIC; requires CUDA >= 12.8.
+  DataDirect,
+};
+
 /// Description of a DMA-BUF region exported from device memory and
 /// suitable for use with `ibv_reg_dmabuf_mr`.
 ///
@@ -30,6 +43,10 @@ struct DmaBuff {
   /// Registration bbase for this DmaBuff to be used when creating WQEs.
   /// This is to be subtracted from a device pointer to form the WQE address.
   uint64_t registrationBase{0};
+  /// Full length of the exported dma-buf (page-aligned, covering `offset` +
+  /// `len`). mlx5 Data Direct registers the whole dma-buf from its aligned
+  /// base (offset 0), so the DD MR uses this length rather than `len`.
+  size_t dmaBufLen{0};
 };
 
 /// DeviceAdapter abstracts device-specific host pinned memory allocation
@@ -53,10 +70,16 @@ class DeviceAdapter {
   virtual Result<bool> isDmaBuffSupported(int deviceId) = 0;
 
   /// Export a DMA-BUF descriptor for `[ptr, ptr + len)` on `deviceId`.
+  /// `mapping` selects the NIC<->GPU route (see DmaBufMapping); `DataDirect`
+  /// requires a Data-Direct-capable NIC and, on GB300, a buffer whose base is
+  /// VMM-granularity (2 MB) aligned so the returned `offset` is 0.
   /// The caller must call `closeDmaBuff()` on the returned value once the
   /// resulting MR has been registered.
-  virtual Result<DmaBuff>
-  exportDmaBuff(int deviceId, void* ptr, size_t len) = 0;
+  virtual Result<DmaBuff> exportDmaBuff(
+      int deviceId,
+      void* ptr,
+      size_t len,
+      DmaBufMapping mapping = DmaBufMapping::Default) = 0;
 
   /// Translate a client-supplied device pointer (which may be an opaque
   /// allocation handle / UID) to the bare device address the NIC needs to

--- a/comms/uniflow/drivers/cuda/CudaDeviceAdapter.cpp
+++ b/comms/uniflow/drivers/cuda/CudaDeviceAdapter.cpp
@@ -40,14 +40,33 @@ bool isNvlinkAvailable() {
   return true;
 }
 
-Result<DmaBuff>
-CudaDeviceAdapter::exportDmaBuff(int /* deviceId */, void* ptr, size_t len) {
+Result<DmaBuff> CudaDeviceAdapter::exportDmaBuff(
+    int /* deviceId */,
+    void* ptr,
+    size_t len,
+    DmaBufMapping mapping) {
   if (!cudaDriverApi_) {
     return Err(
         ErrCode::DriverError, "CudaDeviceAdapter: CudaDriverApi unavailable");
   }
   if (ptr == nullptr || len == 0) {
     return Err(ErrCode::InvalidArgument, "exportDmaBuff: bad ptr or len");
+  }
+
+  /*
+   * Resolve the mapping flag. Data Direct maps the buffer over PCIe BAR1 so the
+   * NIC reaches GPU HBM directly (mlx5 GDAKI / NCCL_IB_DATA_DIRECT); it needs
+   * the CUDA 12.8 range flag, unavailable on older toolkits.
+   */
+  unsigned long long flags = 0;
+  if (mapping == DmaBufMapping::DataDirect) {
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12080
+    flags = CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE;
+#else
+    return Err(
+        ErrCode::DriverError,
+        "exportDmaBuff: Data Direct requires CUDA >= 12.8");
+#endif
   }
 
   // dma-buf registration requires a page-aligned base address. Align down
@@ -59,20 +78,18 @@ CudaDeviceAdapter::exportDmaBuff(int /* deviceId */, void* ptr, size_t len) {
       (len + dmaBufOffset + pageSize_ - 1) & ~(pageSize_ - 1);
 
   DmaBuff out;
-  // TODO: set CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE if a data-direct
-  // link is available.
-  constexpr unsigned long long kFlags = 0;
   auto status = cudaDriverApi_->cuMemGetHandleForAddressRange(
       &out.fd,
       toDevicePtr(alignedAddr),
       dmaBufLen,
       CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-      kFlags);
+      flags);
   CHECK_RETURN(status);
 
   out.offset = dmaBufOffset;
   out.len = len;
   out.iova = static_cast<uint64_t>(addr);
+  out.dmaBufLen = dmaBufLen;
   return out;
 }
 

--- a/comms/uniflow/drivers/cuda/CudaDeviceAdapter.h
+++ b/comms/uniflow/drivers/cuda/CudaDeviceAdapter.h
@@ -22,7 +22,11 @@ class CudaDeviceAdapter : public DeviceAdapter {
   Result<void*> hostGetDevicePointer(void* hostPtr) override;
 
   Result<bool> isDmaBuffSupported(int deviceId) override;
-  Result<DmaBuff> exportDmaBuff(int deviceId, void* ptr, size_t len) override;
+  Result<DmaBuff> exportDmaBuff(
+      int deviceId,
+      void* ptr,
+      size_t len,
+      DmaBufMapping mapping = DmaBufMapping::Default) override;
   Status closeDmaBuff(DmaBuff& buff) override;
 
  private:

--- a/comms/uniflow/drivers/cuda/tests/CudaDeviceAdapterTest.cpp
+++ b/comms/uniflow/drivers/cuda/tests/CudaDeviceAdapterTest.cpp
@@ -114,6 +114,54 @@ TEST(CudaDeviceAdapterTest, ExportDmaBuffPopulatesFdOffsetAndIova) {
   EXPECT_EQ(res->iova, reinterpret_cast<uint64_t>(ptr));
 }
 
+TEST(CudaDeviceAdapterTest, ExportDmaBuffDataDirectSelectsPcieMapping) {
+  /*
+   * The DmaBufMapping::DataDirect route must map the buffer over PCIe BAR1 so
+   * the exported fd can back an mlx5dv Data-Direct MR. The observable contract
+   * is the range flag handed to the driver: DataDirect => the PCIe flag,
+   * Default => 0 (asserted by ExportDmaBuffPopulatesFdOffsetAndIova). On CUDA
+   * older than 12.8 the PCIe mapping cannot be expressed, so DataDirect must
+   * fail cleanly rather than silently fall back to the C2C mapping.
+   */
+  auto cudaApi = std::make_shared<NiceMock<MockCudaApi>>();
+  auto driverApi = std::make_shared<NiceMock<MockCudaDriverApi>>();
+  CudaDeviceAdapter adapter(cudaApi, driverApi);
+
+  const size_t pageSize = static_cast<size_t>(::sysconf(_SC_PAGESIZE));
+  void* backingRaw = nullptr;
+  ASSERT_EQ(::posix_memalign(&backingRaw, pageSize, pageSize), 0);
+  std::unique_ptr<void, decltype(&::free)> backing(backingRaw, &::free);
+
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12080
+  constexpr int kFakeFd = 7;
+  EXPECT_CALL(
+      *driverApi,
+      cuMemGetHandleForAddressRange(
+          _,
+          _,
+          _,
+          CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+          static_cast<unsigned long long>(
+              CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE)))
+      .WillOnce([&](void* handle,
+                    CUdeviceptr,
+                    size_t,
+                    CUmemRangeHandleType,
+                    unsigned long long) {
+        *static_cast<int*>(handle) = kFakeFd;
+        return Ok();
+      });
+  auto res = adapter.exportDmaBuff(
+      /*deviceId=*/0, backing.get(), pageSize, DmaBufMapping::DataDirect);
+  ASSERT_FALSE(res.hasError());
+  EXPECT_EQ(res->fd, kFakeFd);
+#else
+  auto res = adapter.exportDmaBuff(
+      /*deviceId=*/0, backing.get(), pageSize, DmaBufMapping::DataDirect);
+  EXPECT_TRUE(res.hasError());
+#endif
+}
+
 TEST(CudaDeviceAdapterTest, ExportDmaBuffRejectsNullPtr) {
   auto cudaApi = std::make_shared<NiceMock<MockCudaApi>>();
   auto driverApi = std::make_shared<NiceMock<MockCudaDriverApi>>();

--- a/comms/uniflow/transport/rdma/RdmaResources.cpp
+++ b/comms/uniflow/transport/rdma/RdmaResources.cpp
@@ -2,6 +2,11 @@
 
 #include "comms/uniflow/transport/rdma/RdmaResources.h"
 
+#include <cctype>
+#include <cerrno>
+#include <cstdlib>
+#include <memory>
+
 #include "comms/uniflow/logging/Logger.h"
 
 namespace uniflow {
@@ -9,6 +14,36 @@ namespace uniflow {
 namespace {
 
 constexpr uint8_t kDefaultRoceV2GidIndex = 3;
+
+/// Parse a whole hex token to a non-negative value, or -1 if it is empty or not
+/// entirely valid hex (strtol otherwise silently yields 0 for non-hex input).
+long parseHexToken(const std::string& token) {
+  // Require the first character to be a hex digit: strtol would otherwise
+  // accept a leading '+'/'-' sign (e.g. "+ff") or skip leading whitespace, but
+  // a PCIe domain token is bare hex.
+  if (token.empty() ||
+      std::isxdigit(static_cast<unsigned char>(token[0])) == 0) {
+    return -1;
+  }
+  char* end = nullptr;
+  errno = 0;
+  long value = std::strtol(token.c_str(), &end, 16);
+  // Reject trailing junk, negatives, and overflow (ERANGE -> LONG_MAX).
+  if (end != token.c_str() + token.size() || value < 0 || errno == ERANGE) {
+    return -1;
+  }
+  return value;
+}
+
+/// Parse the hex PCIe domain from a "domain:bus:device.function" prefix (-1 if
+/// no ':' or the domain token is not valid hex).
+long parsePciDomainFromBusId(const std::string& busId) {
+  auto colon = busId.find(':');
+  if (colon == std::string::npos) {
+    return -1;
+  }
+  return parseHexToken(busId.substr(0, colon));
+}
 
 /// True if @p gid is an IPv4-mapped IPv6 address (::ffff:a.b.c.d).
 bool isIpv4MappedGid(const ibv_gid& gid) {
@@ -75,6 +110,17 @@ NicResources::NicResources(
     }
     dmaBufSupported = dmaBufResult.value();
 
+    /*
+     * Probe for mlx5 Data Direct: a NIC with a dedicated GPU<->NIC PCIe path
+     * exposes a data-direct sysfs path. Optional capability — a missing path
+     * (or an mlx5dv library without the symbol) simply leaves dataDirect false.
+     */
+    char ddPath[256] = {};
+    dataDirect =
+        !ibvApi->mlx5dvGetDataDirectSysfsPath(ctx, ddPath, sizeof(ddPath))
+             .hasError() &&
+        ddPath[0] != '\0';
+
     ibv_port_attr portAttr{};
     auto portStatus = ibvApi->queryPort(ctx, portNum, &portAttr);
     if (portStatus.hasError()) {
@@ -107,6 +153,7 @@ NicResources::NicResources(NicResources&& other) noexcept
       portNum(other.portNum),
       dmaBufSupported(other.dmaBufSupported),
       numaNode(other.numaNode),
+      dataDirect(other.dataDirect),
       ibvApi(std::move(other.ibvApi)) {
   other.ctx = nullptr;
   other.pd = nullptr;
@@ -230,6 +277,89 @@ uint8_t NicResources::resolveGidIndex(
       std::to_string(portNum) + " and default GID index " +
       std::to_string(kDefaultRoceV2GidIndex) + " out of range (gid_tbl_len=" +
       std::to_string(portAttr.gid_tbl_len) + ")");
+}
+
+// ---------------------------------------------------------------------------
+// Data Direct NIC selection
+// ---------------------------------------------------------------------------
+
+bool dataDirectDomainMatchesGpu(
+    const std::string& ddSysfsPath,
+    const std::string& gpuPciBusId) {
+  long gpuDomain = parsePciDomainFromBusId(gpuPciBusId);
+  if (gpuDomain < 0) {
+    return false;
+  }
+  /*
+   * A data-direct sysfs path looks like
+   * "/sys/devices/pci0008:00/0008:00:00.0/...": the PCIe domain is the hex
+   * token right after "/pci", up to the next ':'. Every device under a
+   * "/sys/devices/pciDDDD:BB" root shares that root's domain DDDD (a different
+   * domain lives under its own "pciEEEE:BB" root, i.e. a separate path), so the
+   * first (and only) "pci" component is authoritative — nested BDFs do not
+   * carry a "pci" prefix, so there is no deeper domain token to prefer.
+   */
+  auto pci = ddSysfsPath.find("/pci");
+  if (pci == std::string::npos) {
+    return false;
+  }
+  size_t domStart = pci + 4;
+  auto colon = ddSysfsPath.find(':', domStart);
+  if (colon == std::string::npos) {
+    return false;
+  }
+  long ddDomain = parseHexToken(ddSysfsPath.substr(domStart, colon - domStart));
+  return ddDomain >= 0 && gpuDomain == ddDomain;
+}
+
+std::vector<std::string> selectDataDirectNicsForGpu(
+    IbvApi& ibvApi,
+    const std::vector<std::string>& candidateNics,
+    const std::string& gpuPciBusId) {
+  std::vector<std::string> matched;
+  int numDevices = 0;
+  auto listResult = ibvApi.getDeviceList(&numDevices);
+  if (listResult.hasError()) {
+    return matched;
+  }
+  ibv_device** list = listResult.value();
+
+  for (const auto& name : candidateNics) {
+    ibv_device* device = nullptr;
+    for (int i = 0; i < numDevices; ++i) {
+      auto nameResult = ibvApi.getDeviceName(list[i]);
+      if (!nameResult.hasError() && name == nameResult.value()) {
+        device = list[i];
+        break;
+      }
+    }
+    if (device == nullptr) {
+      continue;
+    }
+    auto ctxResult = ibvApi.openDevice(device);
+    if (ctxResult.hasError()) {
+      continue;
+    }
+    ibv_context* ctx = ctxResult.value();
+    // Close the context on every exit path (incl. an exception from the
+    // dlopen'd mlx5dv call or the string parsing below), not just the success
+    // path.
+    auto closeCtx = [&ibvApi](ibv_context* c) noexcept {
+      (void)ibvApi.closeDevice(c);
+    };
+    std::unique_ptr<ibv_context, decltype(closeCtx)> ctxGuard(ctx, closeCtx);
+
+    char ddPath[256] = {};
+    auto ddStatus =
+        ibvApi.mlx5dvGetDataDirectSysfsPath(ctx, ddPath, sizeof(ddPath));
+    if (!ddStatus.hasError() &&
+        dataDirectDomainMatchesGpu(ddPath, gpuPciBusId)) {
+      matched.push_back(name);
+    }
+  }
+
+  ibvApi.freeDeviceList(list);
+  return matched;
 }
 
 } // namespace uniflow

--- a/comms/uniflow/transport/rdma/RdmaResources.h
+++ b/comms/uniflow/transport/rdma/RdmaResources.h
@@ -2,6 +2,9 @@
 
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "comms/uniflow/drivers/ibverbs/IbvApi.h"
 
 namespace uniflow {
@@ -26,6 +29,7 @@ struct NicResources {
   uint8_t portNum{1}; /* Physical port number on the HCA. */
   bool dmaBufSupported{false}; /* Kernel supports DMA-BUF MR registration. */
   int numaNode{-1}; /* NUMA node of the NIC, from Topology (-1 = unknown). */
+  bool dataDirect{false}; /* NIC exposes a data-direct sysfs path (mlx5 DD). */
 
   /*
    * Full-init constructor.
@@ -59,5 +63,25 @@ struct NicResources {
   void cleanup();
   std::shared_ptr<IbvApi> ibvApi{nullptr};
 };
+
+/// True if the mlx5 Data-Direct sysfs path (from
+/// mlx5dv_get_data_direct_sysfs_path) is in the same PCIe domain as the GPU at
+/// gpuPciBusId (nvidia-smi / cudaDeviceGetPCIBusId format, e.g.
+/// "00000008:06:00.0"). mlx5 Data-Direct MR registration only succeeds when the
+/// NIC's data-direct interface shares the GPU's PCIe domain; the NIC's own
+/// physical PCIe location does NOT imply the same data-direct domain.
+bool dataDirectDomainMatchesGpu(
+    const std::string& ddSysfsPath,
+    const std::string& gpuPciBusId);
+
+/// From candidateNics (device names), returns those whose mlx5 Data-Direct
+/// interface shares the GPU's PCIe domain (gpuPciBusId). Each candidate is
+/// opened to probe its data-direct sysfs path; candidates without a DD path, or
+/// in a different domain, are excluded. Input order is preserved. This is the
+/// NIC selection required for Data-Direct RDMA.
+std::vector<std::string> selectDataDirectNicsForGpu(
+    IbvApi& ibvApi,
+    const std::vector<std::string>& candidateNics,
+    const std::string& gpuPciBusId);
 
 } // namespace uniflow

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -6,6 +6,7 @@
 #include "comms/uniflow/drivers/TopologyDiscovery.h"
 #include "comms/uniflow/drivers/cuda/CudaDevicePtr.h"
 #include "comms/uniflow/drivers/cuda/CudaDriverApi.h"
+#include "comms/uniflow/drivers/ibverbs/Mlx5Core.h"
 #include "comms/uniflow/logging/Logger.h"
 #include "comms/uniflow/transport/rdma/RdmaRegistrationHandle.h"
 #include "comms/uniflow/transport/rdma/RdmaSlabPool.h"
@@ -1927,16 +1928,94 @@ RdmaTransportFactory::registerSegment(Segment& segment) {
   DmaBuffCloseGuard closeGuard{*deviceAdapter_, dmaBuff};
   uint64_t registrationBase = 0;
 
+  /*
+   * mlx5 Data Direct: route NIC<->GPU DMA over PCIe BAR1 (bypassing the Grace
+   * C2C link) when enabled AND every NIC is both Data-Direct- and dma-buf-
+   * capable. It is all-or-nothing: one PCIe-mapped dmabuf fd must be valid on
+   * every NIC's QP, so a mix of DD and non-DD NICs falls back to the standard
+   * path. dmaBufSupported is required here too because the per-NIC registration
+   * loop gates the DD MR on it; without it a DD-but-not-dmabuf NIC would
+   * silently take the standard path, producing exactly the mixed-route MR set
+   * this invariant avoids.
+   */
+  const bool useDataDirect = config_.dataDirect &&
+      std::all_of(nicsHandle_->begin(),
+                  nicsHandle_->end(),
+                  [](const NicResources& nic) {
+                    return nic.dataDirect && nic.dmaBufSupported;
+                  });
+
   if (segment.memType() == MemoryType::VRAM) {
+    // Data Direct only applies to VRAM (dmabuf) registration. Warn at most once
+    // if it was requested but can't be used: config_.dataDirect and NIC
+    // capabilities are per-transport invariants, so a single warning suffices
+    // and avoids per-registration log spam.
+    if (config_.dataDirect && !useDataDirect &&
+        !dataDirectFallbackWarned_.exchange(true)) {
+      UNIFLOW_LOG_WARN(
+          "registerSegment: Data Direct requested but not all NICs are "
+          "Data-Direct-capable; using the standard dmabuf path");
+    }
+
     auto dmaBufSupported =
         deviceAdapter_->isDmaBuffSupported(segment.deviceId());
     CHECK_RETURN(dmaBufSupported);
     if (dmaBufSupported.value()) {
       auto exportRes = deviceAdapter_->exportDmaBuff(
-          segment.deviceId(), segment.mutable_data(), segment.len());
+          segment.deviceId(),
+          segment.mutable_data(),
+          segment.len(),
+          useDataDirect ? DmaBufMapping::DataDirect : DmaBufMapping::Default);
       if (exportRes.hasValue()) {
         dmaBuff = std::move(exportRes).value();
         registrationBase = dmaBuff.registrationBase;
+        /*
+         * GB300 Data Direct rejects a non-zero dmabuf offset (EOPNOTSUPP): the
+         * buffer base must be VMM-granularity (2 MB) aligned. Fail clearly
+         * rather than let the mlx5dv registration below return an opaque errno.
+         */
+        if (useDataDirect && dmaBuff.offset != 0) {
+          return Err(
+              ErrCode::InvalidArgument,
+              "registerSegment: Data Direct requires a 2MB-aligned buffer "
+              "(dmabuf offset must be 0), got offset " +
+                  std::to_string(dmaBuff.offset));
+        }
+        /*
+         * Data Direct registers the whole dma-buf by length; dmaBufLen is only
+         * populated by adapters that support the PCIe-mapped export. Guard
+         * against a 0 length (which would create a useless zero-length MR) in
+         * case an adapter exports a DD dmabuf without setting it.
+         */
+        if (useDataDirect && dmaBuff.dmaBufLen == 0) {
+          return Err(
+              ErrCode::InvalidArgument,
+              "registerSegment: Data Direct requires a non-zero dmaBufLen from "
+              "exportDmaBuff");
+        }
+        if (useDataDirect) {
+          UNIFLOW_LOG_INFO(
+              "registerSegment: Data Direct active for VRAM segment "
+              "(device={}, len={}, dmabufOffset={}, nics={})",
+              segment.deviceId(),
+              segment.len(),
+              dmaBuff.offset,
+              nicsHandle_->size());
+        }
+      } else if (useDataDirect) {
+        /*
+         * Data Direct was explicitly requested; do not silently downgrade to a
+         * non-DD MR (that would misreport DD bandwidth and, with multiple NICs,
+         * mix routes on one QP).
+         */
+        UNIFLOW_LOG_ERROR(
+            "registerSegment: Data Direct dmabuf export failed for VRAM "
+            "segment (device={}, ptr=0x{:x}, len={}): {}",
+            segment.deviceId(),
+            reinterpret_cast<uint64_t>(segment.mutable_data()),
+            segment.len(),
+            exportRes.error().toString());
+        return std::move(exportRes).error();
       } else if (deviceAdapter_->allowsRegMrFallback()) {
         UNIFLOW_LOG_WARN(
             "registerSegment: exportDmaBuff failed for VRAM segment "
@@ -1988,8 +2067,24 @@ RdmaTransportFactory::registerSegment(Segment& segment) {
   mrs.reserve(nicsHandle_->size());
   for (const auto& nic : *nicsHandle_) {
     Result<ibv_mr*> mrResult = Err(ErrCode::NotImplemented);
-    if (nic.dmaBufSupported && dmaBuff.fd >= 0) {
-      // Accelerator memory: register via DMA-BUF for GPU Direct RDMA.
+    if (useDataDirect && nic.dmaBufSupported && dmaBuff.fd >= 0) {
+      /*
+       * GPU memory over Data Direct: register via mlx5dv with the DATA_DIRECT
+       * access flag so the NIC DMAs to/from GPU HBM over PCIe BAR1. Data Direct
+       * registers the whole exported dma-buf from its aligned base: pass
+       * offset 0, iova = the page-aligned base (iova - offset), and the full
+       * dma-buf length.
+       */
+      mrResult = ibvApi_->mlx5dvRegDmabufMr(
+          nic.pd,
+          /*offset=*/0,
+          /*length=*/dmaBuff.dmaBufLen,
+          /*iova=*/dmaBuff.iova - dmaBuff.offset,
+          dmaBuff.fd,
+          access,
+          MLX5DV_REG_DMABUF_ACCESS_DATA_DIRECT);
+    } else if (nic.dmaBufSupported && dmaBuff.fd >= 0) {
+      // GPU memory: standard DMA-BUF GPU Direct RDMA.
       mrResult = ibvApi_->regDmabufMr(
           nic.pd,
           dmaBuff.offset,

--- a/comms/uniflow/transport/rdma/RdmaTransport.h
+++ b/comms/uniflow/transport/rdma/RdmaTransport.h
@@ -62,6 +62,12 @@ struct RdmaTransportConfig {
   size_t chunkSize{512 * 1024}; /* Transfer chunk size in bytes (512KB). */
   uint16_t pipelineDepth{2}; /* Send/recv pipeline depth (D staging slabs). */
   RdmaSlabPoolConfig slabPoolConfig{.slabNum = 0}; /* Disabled by default. */
+  /* Register GPU memory over the mlx5 Data Direct path (NIC<->GPU via PCIe
+   * BAR1) instead of the standard dmabuf path (which traverses the Grace C2C
+   * link on GB300). Only applies to NICs that expose a data-direct sysfs path;
+   * other NICs fall back to the standard path. Default off = existing behavior.
+   */
+  bool dataDirect{false};
 };
 
 /*
@@ -686,6 +692,12 @@ class RdmaTransportFactory : public TransportFactory {
   std::shared_ptr<DeviceAdapter> deviceAdapter_;
   const RdmaTransportConfig config_;
   std::shared_ptr<RdmaSlabPool> slabPool_;
+
+  /// Set once the "Data Direct requested but unavailable" fallback has been
+  /// logged, so this per-factory-invariant warning fires at most once rather
+  /// than on every registerSegment call. Atomic so the check-then-set latch is
+  /// race-free if registerSegment is ever called concurrently.
+  std::atomic<bool> dataDirectFallbackWarned_{false};
 };
 
 } // namespace uniflow

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaRegistrationHandleTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaRegistrationHandleTest.cpp
@@ -260,7 +260,11 @@ class FakeDeviceAdapter : public DeviceAdapter {
   Result<bool> isDmaBuffSupported(int) override {
     return ErrCode::NotImplemented;
   }
-  Result<DmaBuff> exportDmaBuff(int, void*, size_t) override {
+  Result<DmaBuff> exportDmaBuff(
+      int,
+      void*,
+      size_t,
+      DmaBufMapping = DmaBufMapping::Default) override {
     return ErrCode::NotImplemented;
   }
   Status closeDmaBuff(DmaBuff&) override {

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaResourcesTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaResourcesTest.cpp
@@ -1,0 +1,183 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/transport/rdma/RdmaResources.h"
+
+#include <cstdio>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "comms/uniflow/drivers/ibverbs/mock/MockIbvApi.h"
+
+using namespace uniflow;
+using ::testing::_;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+// --- dataDirectDomainMatchesGpu ---
+
+TEST(DataDirectDomainMatchTest, MatchingDomain) {
+  EXPECT_TRUE(dataDirectDomainMatchesGpu(
+      "/sys/devices/pci0008:00/0008:00:00.0/infiniband/mlx5_4",
+      "00000008:06:00.0"));
+}
+
+TEST(DataDirectDomainMatchTest, MismatchingDomain) {
+  EXPECT_FALSE(dataDirectDomainMatchesGpu(
+      "/sys/devices/pci0009:00/0009:00:00.0/infiniband/mlx5_0",
+      "00000008:06:00.0"));
+}
+
+TEST(DataDirectDomainMatchTest, DiffersOnlyByLeadingZeros) {
+  /*
+   * The domain is compared as a hex value, so widths/leading zeros are
+   * irrelevant: GPU "8" matches data-direct "pci0008".
+   */
+  EXPECT_TRUE(dataDirectDomainMatchesGpu(
+      "/sys/devices/pci0008:00/0008:00:00.0", "0008:06:00.0"));
+}
+
+TEST(DataDirectDomainMatchTest, NonZeroDomains) {
+  EXPECT_TRUE(dataDirectDomainMatchesGpu(
+      "/sys/devices/pci0018:00/0018:00:00.0", "00000018:07:00.0"));
+  EXPECT_FALSE(dataDirectDomainMatchesGpu(
+      "/sys/devices/pci0018:00/0018:00:00.0", "00000019:07:00.0"));
+}
+
+TEST(DataDirectDomainMatchTest, MalformedInputsReturnFalse) {
+  // Missing ':' in the bus id.
+  EXPECT_FALSE(dataDirectDomainMatchesGpu(
+      "/sys/devices/pci0008:00/0008:00:00.0", "00000008"));
+  // No "/pci" token in the sysfs path.
+  EXPECT_FALSE(dataDirectDomainMatchesGpu(
+      "/sys/devices/no-domain-here", "0008:06:00.0"));
+  // Non-hex domain token must not silently parse to 0 and match a pci0000 path.
+  EXPECT_FALSE(dataDirectDomainMatchesGpu(
+      "/sys/devices/pci0000:00/0000:00:00.0", "zzzz:06:00.0"));
+  // A signed token (e.g. "+8") must be rejected, not accepted by strtol.
+  EXPECT_FALSE(dataDirectDomainMatchesGpu(
+      "/sys/devices/pci0008:00/0008:00:00.0", "+8:06:00.0"));
+  // An overflowing token (strtol ERANGE -> LONG_MAX) must be rejected, not
+  // accepted as a valid value.
+  EXPECT_FALSE(dataDirectDomainMatchesGpu(
+      "/sys/devices/pci0008:00/0008:00:00.0", "ffffffffffffffffffff:06:00.0"));
+  // Empty inputs.
+  EXPECT_FALSE(dataDirectDomainMatchesGpu("", ""));
+}
+
+// --- selectDataDirectNicsForGpu ---
+
+namespace {
+
+/*
+ * Configure a mock exposing three NICs: mlx5_0 (domain 0008), mlx5_1 (domain
+ * 0009), mlx5_2 (no data-direct path). The device/context handles are opaque —
+ * the code only compares these pointers, never dereferences them — so distinct
+ * fake addresses suffice. devList is a function-local static so getDeviceList
+ * can hand back a stable ibv_device** that outlives this setup call.
+ */
+void configureThreeNicMock(NiceMock<MockIbvApi>& mock) {
+  static ibv_device* devList[3] = {
+      reinterpret_cast<ibv_device*>(0x1001),
+      reinterpret_cast<ibv_device*>(0x1002),
+      reinterpret_cast<ibv_device*>(0x1003),
+  };
+  ibv_device* const dev0 = devList[0];
+  ibv_device* const dev1 = devList[1];
+  ibv_device* const dev2 = devList[2];
+  ibv_context* const ctx0 = reinterpret_cast<ibv_context*>(0x2001);
+  ibv_context* const ctx1 = reinterpret_cast<ibv_context*>(0x2002);
+  ibv_context* const ctx2 = reinterpret_cast<ibv_context*>(0x2003);
+
+  ON_CALL(mock, getDeviceList(_)).WillByDefault([](int* numDevices) {
+    *numDevices = 3;
+    return Result<ibv_device**>(devList);
+  });
+  ON_CALL(mock, freeDeviceList(_)).WillByDefault(Return(Ok()));
+  ON_CALL(mock, closeDevice(_)).WillByDefault(Return(Ok()));
+
+  ON_CALL(mock, getDeviceName(dev0))
+      .WillByDefault(Return(Result<const char*>("mlx5_0")));
+  ON_CALL(mock, getDeviceName(dev1))
+      .WillByDefault(Return(Result<const char*>("mlx5_1")));
+  ON_CALL(mock, getDeviceName(dev2))
+      .WillByDefault(Return(Result<const char*>("mlx5_2")));
+
+  ON_CALL(mock, openDevice(dev0))
+      .WillByDefault(Return(Result<ibv_context*>(ctx0)));
+  ON_CALL(mock, openDevice(dev1))
+      .WillByDefault(Return(Result<ibv_context*>(ctx1)));
+  ON_CALL(mock, openDevice(dev2))
+      .WillByDefault(Return(Result<ibv_context*>(ctx2)));
+
+  ON_CALL(mock, mlx5dvGetDataDirectSysfsPath(ctx0, _, _))
+      .WillByDefault([](ibv_context*, char* buf, size_t len) {
+        std::snprintf(buf, len, "/sys/devices/pci0008:00/0008:00:00.0");
+        return Ok();
+      });
+  ON_CALL(mock, mlx5dvGetDataDirectSysfsPath(ctx1, _, _))
+      .WillByDefault([](ibv_context*, char* buf, size_t len) {
+        std::snprintf(buf, len, "/sys/devices/pci0009:00/0009:00:00.0");
+        return Ok();
+      });
+  // mlx5_2 has no data-direct path.
+  ON_CALL(mock, mlx5dvGetDataDirectSysfsPath(ctx2, _, _))
+      .WillByDefault(Return(Status(ErrCode::NotImplemented)));
+}
+
+} // namespace
+
+TEST(SelectDataDirectNicsTest, KeepsOnlyDomainMatchedNic) {
+  NiceMock<MockIbvApi> mock;
+  configureThreeNicMock(mock);
+
+  auto matched = selectDataDirectNicsForGpu(
+      mock, {"mlx5_0", "mlx5_1", "mlx5_2"}, "00000008:06:00.0");
+
+  EXPECT_EQ(matched, std::vector<std::string>({"mlx5_0"}));
+}
+
+TEST(SelectDataDirectNicsTest, MatchesDifferentDomain) {
+  NiceMock<MockIbvApi> mock;
+  configureThreeNicMock(mock);
+
+  auto matched = selectDataDirectNicsForGpu(
+      mock, {"mlx5_0", "mlx5_1", "mlx5_2"}, "00000009:06:00.0");
+
+  EXPECT_EQ(matched, std::vector<std::string>({"mlx5_1"}));
+}
+
+TEST(SelectDataDirectNicsTest, NoMatchReturnsEmpty) {
+  NiceMock<MockIbvApi> mock;
+  configureThreeNicMock(mock);
+
+  auto matched = selectDataDirectNicsForGpu(
+      mock, {"mlx5_0", "mlx5_1", "mlx5_2"}, "00000018:06:00.0");
+
+  EXPECT_TRUE(matched.empty());
+}
+
+TEST(SelectDataDirectNicsTest, PreservesInputOrder) {
+  NiceMock<MockIbvApi> mock;
+  configureThreeNicMock(mock);
+
+  /*
+   * Both mlx5_0 and (hypothetically) another 0008 NIC would match; here only
+   * mlx5_0 does, but the candidate order must be respected in the output.
+   */
+  auto matched = selectDataDirectNicsForGpu(
+      mock, {"mlx5_2", "mlx5_1", "mlx5_0"}, "00000008:06:00.0");
+
+  EXPECT_EQ(matched, std::vector<std::string>({"mlx5_0"}));
+}
+
+TEST(SelectDataDirectNicsTest, SkipsUnknownCandidate) {
+  NiceMock<MockIbvApi> mock;
+  configureThreeNicMock(mock);
+
+  // "mlx5_99" is not in the device list; it is silently skipped.
+  auto matched = selectDataDirectNicsForGpu(
+      mock, {"mlx5_99", "mlx5_0"}, "00000008:06:00.0");
+
+  EXPECT_EQ(matched, std::vector<std::string>({"mlx5_0"}));
+}


### PR DESCRIPTION
Summary:

Adds opt-in mlx5 Data Direct support so RDMA registration of GPU (VRAM) segments can use the direct NIC<->GPU-HBM PCIe path, bypassing the Grace C2C link on GB300 — the same mechanism `p2p_engine` uses. Gated off by default (`dataDirect=false`); no behavior change unless enabled.

Driver layer:
- `DeviceAdapter`: new `DmaBufMapping` enum (`Default` | `DataDirect`); `exportDmaBuff` gains an optional `mapping` argument that defaults to `Default`, so existing callers are unchanged.
- `CudaDeviceAdapter`: `DataDirect` exports the dmabuf with `CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE` (CUDA >= 12.8); older CUDA returns an error.
- `MtiaDeviceAdapter`: `DataDirect` returns an error (unsupported on MTIA).

Transport layer:
- `RdmaTransportConfig::dataDirect` flag; per-NIC capability detection via `mlx5dv_get_data_direct_sysfs_path` (`NicResources::dataDirect`).
- When active, `registerSegment` exports a PCIe-mapped dmabuf (guarded to require dmabuf offset 0) and registers the MR via `mlx5dv_reg_dmabuf_mr(..., MLX5DV_REG_DMABUF_ACCESS_DATA_DIRECT)`.
- DD-aware NIC selection (`selectDataDirectNicsForGpu` / `dataDirectDomainMatchesGpu`): pick the per-GPU NICs whose data-direct sysfs PCIe domain matches the GPU's PCIe domain. DD MR registration only succeeds on domain-matched NICs, so this removes the need to hand-pick NICs. Unit-tested against a mock IbvApi.

Build:
- `drivers/ibverbs/BUCK`: `uniflow-rdma-deps` links a Data-Direct-capable static rdma-core by default; `-c uniflow.rdma_linkage=dynamic` opts into the host's `/usr/lib64` libmlx5/libibverbs at runtime, for hosts that ship a newer DD-capable libmlx5.

Reviewed By: saifhhasan

Differential Revision: D110935598


