### PR TITLE
Bare-metal RDMA bandwidth runner (#3106)

### DIFF
--- a/comms/uniflow/benchmarks/BenchmarkRunner.h
+++ b/comms/uniflow/benchmarks/BenchmarkRunner.h
@@ -23,7 +23,20 @@ struct BenchmarkConfig {
   int numNics{0}; // 0 = use all topology-selected NICs
   size_t chunkSize{512 * 1024};
   int cudaDevice{-1};
+  /*
+   * Multiple GPU device indices for single-process multi-GPU runs. When
+   * non-empty, the benchmark drives one transport per device concurrently and
+   * reports aggregate bandwidth. Empty falls back to the single cudaDevice.
+   */
+  std::vector<int> cudaDevices;
+  /*
+   * Optional explicit NIC assignment per GPU (one inner list per cudaDevices
+   * entry). When set, each GPU uses its own NICs instead of topology selection,
+   * which avoids NICs being double-booked across adjacent GPUs.
+   */
+  std::vector<std::vector<std::string>> gpuNicGroups;
   bool bidirectional{false};
+  bool dataDirect{false}; // Register GPU memory over the mlx5 Data Direct path.
   std::string direction{"both"};
   std::vector<int> numStreams{1, 2, 4, 8};
   std::string topology{"fanout"}; // "fanout", "fanin"

--- a/comms/uniflow/benchmarks/bench/RdmaBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/RdmaBandwidthBenchmark.cpp
@@ -25,6 +25,7 @@
 #include "comms/uniflow/executor/ScopedEventBaseThread.h"
 #include "comms/uniflow/logging/Logger.h"
 #include "comms/uniflow/transport/Topology.h"
+#include "comms/uniflow/transport/rdma/RdmaResources.h"
 #include "comms/uniflow/transport/rdma/RdmaTransport.h"
 
 namespace uniflow::benchmark {
@@ -51,10 +52,16 @@ std::vector<std::string> discoverRdmaDevices(
 }
 
 struct BenchmarkBuffers {
-  // Per-NIC separate allocations to avoid PCIe DMA contention when
-  // multiple NICs read from the same GPU memory region simultaneously.
+  /*
+   * Per-NIC separate allocations to avoid PCIe DMA contention when multiple
+   * NICs read from the same GPU memory region simultaneously. srcs/dsts are the
+   * (aligned) registration pointers; rawAllocs holds the original allocation
+   * bases to free (an aligned buffer is an offset into a larger raw allocation,
+   * so free the raw base, not the aligned pointer).
+   */
   std::vector<void*> srcs;
   std::vector<void*> dsts;
+  std::vector<void*> rawAllocs;
   bool useGpu{false};
   MemoryType memType{MemoryType::DRAM};
   int gpuDevice{0};
@@ -67,6 +74,7 @@ struct BenchmarkBuffers {
   BenchmarkBuffers(BenchmarkBuffers&& o) noexcept
       : srcs(std::move(o.srcs)),
         dsts(std::move(o.dsts)),
+        rawAllocs(std::move(o.rawAllocs)),
         useGpu(o.useGpu),
         memType(o.memType),
         gpuDevice(o.gpuDevice) {}
@@ -77,7 +85,7 @@ struct BenchmarkBuffers {
 
  private:
   void release() noexcept {
-    auto freeOne = [this](void* p) {
+    for (auto* p : rawAllocs) {
       if (p) {
         if (useGpu) {
           // hipFree is [[nodiscard]] on HIP (cudaFree is not); we are in a
@@ -87,15 +95,10 @@ struct BenchmarkBuffers {
           std::free(p);
         }
       }
-    };
-    for (auto* p : srcs) {
-      freeOne(p);
-    }
-    for (auto* p : dsts) {
-      freeOne(p);
     }
     srcs.clear();
     dsts.clear();
+    rawAllocs.clear();
   }
 };
 
@@ -106,29 +109,53 @@ allocateBuffers(size_t maxSize, int cudaDevice, int rank, int numBuffers) {
   bufs.memType = bufs.useGpu ? MemoryType::VRAM : MemoryType::DRAM;
   bufs.gpuDevice = bufs.useGpu ? cudaDevice : 0;
 
+  /*
+   * mlx5 Data Direct on GB300 requires the registered buffer's *allocation
+   * base* to be aligned to the CUDA VMM granularity (2 MiB) so the exported
+   * dmabuf offset is 0; a non-zero offset makes
+   * mlx5dv_reg_dmabuf_mr(DATA_DIRECT) return EOPNOTSUPP. cudaMalloc returns a
+   * granularity-aligned base for allocations rounded up to the granularity (the
+   * driver large-allocation path), so round the request up and use the base
+   * directly -- aligning a pointer inside an over-allocation instead would
+   * leave a non-zero offset relative to the true allocation base. See
+   * D110262217.
+   */
+  constexpr size_t kVmmAlign = size_t{2} << 20; // 2 MiB VMM granularity
+  const size_t allocBytes = ((maxSize + kVmmAlign - 1) / kVmmAlign) * kVmmAlign;
+
+  /*
+   * Contract: on success *out holds the buffer and true is returned; on any
+   * failure *out is left nullptr. Raw allocations are tracked in bufs.rawAllocs
+   * for cleanup regardless, so *out is assigned only once the buffer is fully
+   * initialized.
+   */
   auto allocOne = [&](void** out, uint8_t fill) -> bool {
+    *out = nullptr;
     if (bufs.useGpu) {
-      auto ret = cudaMalloc(out, maxSize);
-      if (ret != cudaSuccess || *out == nullptr) {
+      void* raw = nullptr;
+      auto ret = cudaMalloc(&raw, allocBytes);
+      if (ret != cudaSuccess || raw == nullptr) {
         UNIFLOW_LOG_ERROR("RdmaBandwidthBenchmark: cudaMalloc failed");
         return false;
       }
-      ret = cudaMemset(*out, fill, maxSize);
+      bufs.rawAllocs.push_back(raw);
+      ret = cudaMemset(raw, fill, maxSize);
       if (ret != cudaSuccess) {
         UNIFLOW_LOG_ERROR(
             "RdmaBandwidthBenchmark: cudaMemset failed: {}",
             cudaGetErrorString(ret));
-        (void)cudaFree(*out);
-        *out = nullptr;
         return false;
       }
+      *out = raw;
     } else {
-      *out = std::malloc(maxSize);
-      if (*out == nullptr) {
+      void* raw = std::malloc(maxSize);
+      if (raw == nullptr) {
         UNIFLOW_LOG_ERROR("RdmaBandwidthBenchmark: malloc failed");
         return false;
       }
-      std::memset(*out, fill, maxSize);
+      bufs.rawAllocs.push_back(raw);
+      std::memset(raw, fill, maxSize);
+      *out = raw;
     }
     return true;
   };
@@ -336,10 +363,12 @@ std::optional<TransportSession> setupTransport(
     const std::shared_ptr<IbvApi>& ibvApi,
     PeerConnection& peer,
     const BootstrapConfig& bootstrap,
-    size_t chunkSize) {
+    size_t chunkSize,
+    bool dataDirect) {
   RdmaTransportConfig rdmaConfig{};
   rdmaConfig.chunkSize = chunkSize;
   rdmaConfig.numQps = static_cast<uint32_t>(devices.size());
+  rdmaConfig.dataDirect = dataDirect;
 
   auto cudaDriverApi = std::make_shared<CudaDriverApi>();
   auto factory = std::make_unique<RdmaTransportFactory>(
@@ -397,24 +426,193 @@ std::optional<TransportSession> setupTransport(
   return session;
 }
 
-/// Run batched put/get with pipelined submission (txDepth in-flight batches).
+/*
+ * A single GPU's transport plus its registered local/remote buffer sets.
+ * One RunUnit is driven by one worker thread during the concurrent run.
+ */
+struct RunUnit {
+  int cudaDevice{-1};
+  std::string label;
+  Transport* transport{nullptr};
+  std::vector<RegisteredSegment>* localRegs{nullptr};
+  std::vector<RemoteRegisteredSegment>* remoteRegs{nullptr};
+};
+
+// Outcome of transferring one message size on one RunUnit.
+struct TransferResult {
+  bool ok{false};
+  double bandwidthGBs{0};
+  double messageRateMops{0};
+  int totalOps{0};
+  std::vector<double> latenciesUs;
+};
+
+/// Transfer `size` bytes in direction `dir` ("put"/"get") on a single unit:
+/// warmup, then a pipelined timed loop keeping up to txDepth batches in flight.
+/// Self-contained (no shared mutable state) so it can run on its own thread,
+/// enabling concurrent multi-GPU aggregate measurement.
+TransferResult runTransfer(
+    RunUnit& unit,
+    size_t size,
+    const std::string& dir,
+    const BenchmarkConfig& config) {
+  using Clock = std::chrono::steady_clock;
+  using TimePoint = Clock::time_point;
+
+  /*
+   * The transport's RDMA path is host-initiated, but pin the worker to the
+   * owning GPU so any CUDA-context-sensitive calls resolve to the right device.
+   */
+  if (unit.cudaDevice >= 0) {
+    auto cudaRet = cudaSetDevice(unit.cudaDevice);
+    if (cudaRet != cudaSuccess) {
+      UNIFLOW_LOG_ERROR(
+          "RdmaBandwidthBenchmark: cudaSetDevice({}) failed: {}",
+          unit.cudaDevice,
+          cudaGetErrorString(cudaRet));
+      return {};
+    }
+  }
+
+  const int batchSize = std::max(1, config.batchSize);
+  const int txDepth = std::max(1, config.txDepth);
+  const int numBufs = static_cast<int>(unit.localRegs->size());
+  auto& localRegs = *unit.localRegs;
+  auto& remoteRegs = *unit.remoteRegs;
+  auto& transport = *unit.transport;
+
+  TransferResult out;
+
+  // Each request indexes localRegs/remoteRegs by NIC; both must be non-empty
+  // and equal-sized (they are one-per-NIC from setup). Guard so the indexing
+  // below can never touch an empty vector.
+  if (numBufs <= 0 || localRegs.size() != remoteRegs.size()) {
+    UNIFLOW_LOG_ERROR(
+        "RdmaBandwidthBenchmark: {} has no or mismatched registered segments",
+        unit.label);
+    return out;
+  }
+
+  /*
+   * Map each request to its NIC's buffer. Must match spray()'s contiguous
+   * chunk-to-QP assignment in the transport layer.
+   */
+  auto nicForRequest = [&](int requestIdx) {
+    return requestIdx * numBufs / batchSize;
+  };
+  std::vector<TransferRequest> batch;
+  batch.reserve(batchSize);
+  for (int i = 0; i < batchSize; ++i) {
+    int bufIdx = nicForRequest(i);
+    batch.push_back(
+        TransferRequest{
+            .local = localRegs.at(bufIdx).span(size_t{0}, size),
+            .remote = remoteRegs.at(bufIdx).span(size_t{0}, size),
+        });
+  }
+
+  int numBatches = std::max(1, (config.iterations + batchSize - 1) / batchSize);
+  int totalOps = numBatches * batchSize;
+
+  auto submitBatchAsync = [&]() -> std::future<Status> {
+    return (dir == "put") ? transport.put(batch, {}) : transport.get(batch, {});
+  };
+
+  for (int iter = 0; iter < config.warmupIterations; ++iter) {
+    auto status = submitBatchAsync().get();
+    if (status.hasError()) {
+      UNIFLOW_LOG_ERROR(
+          "RdmaBandwidthBenchmark: warmup {} failed on {} at size {}: {}",
+          dir,
+          unit.label,
+          size,
+          status.error().message());
+      return out;
+    }
+  }
+
+  /*
+   * Sliding window: keep up to txDepth batches in-flight.
+   * txDepth=1 degenerates to synchronous behavior.
+   */
+  std::deque<std::pair<std::future<Status>, TimePoint>> inflight;
+  std::vector<double> latenciesUs;
+  latenciesUs.reserve(numBatches);
+
+  /*
+   * Complete the oldest in-flight batch: get result, record latency.
+   * Returns false on error after draining all remaining futures.
+   */
+  auto completeOne = [&]() -> bool {
+    auto& [fut, submitTime] = inflight.front();
+    auto status = fut.get();
+    auto completeTime = Clock::now();
+    if (status.hasError()) {
+      inflight.pop_front();
+      UNIFLOW_LOG_ERROR(
+          "RdmaBandwidthBenchmark: {} failed on {} at size {}: {}",
+          dir,
+          unit.label,
+          size,
+          status.error().message());
+      for (auto& [f, _] : inflight) {
+        f.wait();
+      }
+      return false;
+    }
+    double batchUs =
+        std::chrono::duration<double, std::micro>(completeTime - submitTime)
+            .count();
+    latenciesUs.push_back(batchUs / batchSize);
+    inflight.pop_front();
+    return true;
+  };
+
+  auto overallStart = Clock::now();
+
+  for (int b = 0; b < numBatches; ++b) {
+    if (static_cast<int>(inflight.size()) >= txDepth) {
+      if (!completeOne()) {
+        return out;
+      }
+    }
+    inflight.emplace_back(submitBatchAsync(), Clock::now());
+  }
+
+  while (!inflight.empty()) {
+    if (!completeOne()) {
+      return out;
+    }
+  }
+
+  auto overallEnd = Clock::now();
+
+  double totalTimeSec =
+      std::chrono::duration<double>(overallEnd - overallStart).count();
+  double totalBytes = static_cast<double>(size) * static_cast<double>(totalOps);
+
+  out.ok = true;
+  out.bandwidthGBs = (totalTimeSec > 0) ? (totalBytes / totalTimeSec) / 1e9 : 0;
+  out.messageRateMops =
+      (totalTimeSec > 0) ? (totalOps / totalTimeSec) / 1e6 : 0;
+  out.totalOps = totalOps;
+  out.latenciesUs = std::move(latenciesUs);
+  return out;
+}
+
+/// Run the message-size sweep across all GPU units concurrently and report
+/// aggregate bandwidth (sum across units) per size. With a single unit this is
+/// identical to a plain single-GPU run.
 std::vector<BenchmarkResult> runBenchmarkLoop(
-    Transport& transport,
-    std::vector<RegisteredSegment>& localRegs,
-    std::vector<RemoteRegisteredSegment>& remoteRegs,
+    std::vector<RunUnit>& units,
     const BenchmarkConfig& config,
     std::vector<PeerConnection>& peers,
     const BootstrapConfig& bootstrap,
     const std::string& benchmarkName) {
-  using Clock = std::chrono::steady_clock;
-  using TimePoint = Clock::time_point;
-
   auto sizes = generateSizes(config.minSize, config.maxSize);
   std::vector<BenchmarkResult> results;
   const int batchSize = std::max(1, config.batchSize);
   const int txDepth = std::max(1, config.txDepth);
-  const int numBufs = static_cast<int>(localRegs.size());
-
   const bool isActiveRank = config.bidirectional || bootstrap.isRank0();
 
   auto runDirection = [&](const std::string& dir) {
@@ -431,129 +629,83 @@ std::vector<BenchmarkResult> runBenchmarkLoop(
         continue;
       }
 
-      // Map each request to its NIC's buffer. Must match spray()'s
-      // contiguous chunk-to-QP assignment in the transport layer.
-      auto nicForRequest = [&](int requestIdx) {
-        return requestIdx * numBufs / batchSize;
-      };
-      std::vector<TransferRequest> batch;
-      batch.reserve(batchSize);
-      for (int i = 0; i < batchSize; ++i) {
-        int bufIdx = nicForRequest(i);
-        batch.push_back(
-            TransferRequest{
-                .local = localRegs[bufIdx].span(size_t{0}, size),
-                .remote = remoteRegs[bufIdx].span(size_t{0}, size),
-            });
+      /*
+       * Launch one worker per GPU so all units transfer this size between the
+       * same pair of barriers; aggregate bandwidth is their sum.
+       */
+      std::vector<std::future<TransferResult>> futures;
+      futures.reserve(units.size());
+      for (auto& unit : units) {
+        futures.push_back(
+            std::async(std::launch::async, [&unit, size, dir, &config]() {
+              return runTransfer(unit, size, dir, config);
+            }));
       }
 
-      int numBatches =
-          std::max(1, (config.iterations + batchSize - 1) / batchSize);
-      int totalOps = numBatches * batchSize;
-
-      auto submitBatchAsync = [&]() -> std::future<Status> {
-        return (dir == "put") ? transport.put(batch, {})
-                              : transport.get(batch, {});
-      };
-
-      for (int iter = 0; iter < config.warmupIterations; ++iter) {
-        auto status = submitBatchAsync().get();
-        if (status.hasError()) {
-          UNIFLOW_LOG_ERROR(
-              "RdmaBandwidthBenchmark: warmup {} failed at size {}: {}",
-              dir,
-              size,
-              status.error().message());
-          return;
+      bool allOk = true;
+      double aggBandwidthGBs = 0;
+      double aggMsgRateMops = 0;
+      int aggOps = 0;
+      std::vector<double> pooledLatencies;
+      std::string perUnitBw;
+      /*
+       * runTransfer reports failures through TransferResult::ok rather than
+       * exceptions, so get() below does not throw on a failed transfer. Even if
+       * get() did throw (e.g. std::async failing to start a thread), unwinding
+       * destroys `futures`, and a std::async(launch::async) future joins its
+       * task in its destructor -- so every worker completes before the units it
+       * captured by reference go out of scope. No dangling reference results.
+       */
+      for (size_t u = 0; u < units.size(); ++u) {
+        auto r = futures[u].get();
+        if (!r.ok) {
+          allOk = false;
+          continue;
         }
+        aggBandwidthGBs += r.bandwidthGBs;
+        aggMsgRateMops += r.messageRateMops;
+        aggOps += r.totalOps;
+        pooledLatencies.insert(
+            pooledLatencies.end(), r.latenciesUs.begin(), r.latenciesUs.end());
+        if (!perUnitBw.empty()) {
+          perUnitBw += " ";
+        }
+        char bwBuf[32];
+        std::snprintf(bwBuf, sizeof(bwBuf), "%.2f", r.bandwidthGBs);
+        perUnitBw += units[u].label + "=" + bwBuf;
+      }
+      if (!allOk) {
+        return;
       }
 
-      // Sliding window: keep up to txDepth batches in-flight.
-      // txDepth=1 degenerates to synchronous behavior.
-      std::deque<std::pair<std::future<Status>, TimePoint>> inflight;
-      std::vector<double> latenciesUs;
-      latenciesUs.reserve(numBatches);
-
-      // Complete the oldest in-flight batch: get result, record latency.
-      // Returns false on error after draining all remaining futures.
-      auto completeOne = [&]() -> bool {
-        auto& [fut, submitTime] = inflight.front();
-        auto status = fut.get();
-        auto completeTime = Clock::now();
-        if (status.hasError()) {
-          inflight.pop_front();
-          UNIFLOW_LOG_ERROR(
-              "RdmaBandwidthBenchmark: {} failed at size {}: {}",
-              dir,
-              size,
-              status.error().message());
-          for (auto& [f, _] : inflight) {
-            f.wait();
-          }
-          return false;
-        }
-        double batchUs =
-            std::chrono::duration<double, std::micro>(completeTime - submitTime)
-                .count();
-        latenciesUs.push_back(batchUs / batchSize);
-        inflight.pop_front();
-        return true;
-      };
-
-      auto overallStart = Clock::now();
-
-      for (int b = 0; b < numBatches; ++b) {
-        if (static_cast<int>(inflight.size()) >= txDepth) {
-          if (!completeOne()) {
-            return;
-          }
-        }
-        inflight.emplace_back(submitBatchAsync(), Clock::now());
-      }
-
-      while (!inflight.empty()) {
-        if (!completeOne()) {
-          return;
-        }
-      }
-
-      auto overallEnd = Clock::now();
-
-      double totalTimeSec =
-          std::chrono::duration<double>(overallEnd - overallStart).count();
-      double totalBytes =
-          static_cast<double>(size) * static_cast<double>(totalOps);
-      double bandwidthGBs =
-          (totalTimeSec > 0) ? (totalBytes / totalTimeSec) / 1e9 : 0;
-      double msgRateMops =
-          (totalTimeSec > 0) ? (totalOps / totalTimeSec) / 1e6 : 0;
-
-      auto stats = Stats::compute(std::move(latenciesUs));
+      auto stats = Stats::compute(std::move(pooledLatencies));
 
       results.push_back({
           .benchmarkName = benchmarkName,
           .transport = "rdma",
           .direction = dir,
           .messageSize = size,
-          .iterations = totalOps,
+          .iterations = aggOps,
           .batchSize = batchSize,
           .txDepth = txDepth,
           .chunkSize = config.chunkSize,
-          .bandwidthGBs = bandwidthGBs,
+          .bandwidthGBs = aggBandwidthGBs,
           .latency = stats,
-          .messageRateMops = msgRateMops,
+          .messageRateMops = aggMsgRateMops,
       });
 
       UNIFLOW_LOG_WARN(
-          "[rank {}] {} size={:<10} batch={:<3} txdepth={:<3} iters={:<6} "
-          "bw={:.2f} GB/s  avg={:.1f} us  {}",
+          "[rank {}] {} size={:<10} gpus={} batch={:<3} txdepth={:<3} "
+          "iters={:<6} bw={:.2f} GB/s [{}] avg={:.1f} us {}",
           bootstrap.rank,
           dir,
           size,
+          units.size(),
           batchSize,
           txDepth,
-          totalOps,
-          bandwidthGBs,
+          aggOps,
+          aggBandwidthGBs,
+          perUnitBw,
           stats.avg,
           config.bidirectional ? "(bidirectional)" : "(unidirectional)");
     }
@@ -589,80 +741,227 @@ std::vector<BenchmarkResult> RdmaBandwidthBenchmark::run(
     return {};
   }
 
-  std::vector<std::string> deviceNames = rdmaDevices_;
-  if (deviceNames.empty()) {
-    deviceNames = discoverRdmaDevices(ibvApi);
+  std::vector<std::string> allDevices = rdmaDevices_;
+  if (allDevices.empty()) {
+    allDevices = discoverRdmaDevices(ibvApi);
   }
-  if (deviceNames.empty()) {
+  if (allDevices.empty()) {
     UNIFLOW_LOG_ERROR("RdmaBandwidthBenchmark: no RDMA devices found");
     return {};
   }
 
-  std::vector<std::string> myDevices;
-  if (!rdmaDevices_.empty()) {
-    myDevices = rdmaDevices_;
-  } else {
-    auto& topo = sharedTopology();
-    if (topo.available()) {
-      myDevices = (config.cudaDevice < 0)
-          ? topo.selectCpuNics()
-          : topo.selectGpuNics(config.cudaDevice);
-    }
-    if (myDevices.empty()) {
-      myDevices = deviceNames;
-    }
-    if (config.numNics > 0 &&
-        config.numNics < static_cast<int>(myDevices.size())) {
-      myDevices.resize(config.numNics);
-    }
+  /*
+   * Resolve the GPU device list: an explicit multi-GPU list, else the single
+   * --cuda-device (which may be -1 for CPU memory).
+   */
+  std::vector<int> gpuDevices = config.cudaDevices;
+  if (gpuDevices.empty()) {
+    gpuDevices.push_back(config.cudaDevice);
   }
-  {
-    std::string devList;
-    for (const auto& d : myDevices) {
-      if (!devList.empty()) {
-        devList += ", ";
-      }
-      devList += d;
-    }
+  const bool multiGpu = gpuDevices.size() > 1;
+
+  /*
+   * Data Direct is a GPU-memory (VRAM) feature. Reject it up front if any
+   * selected device is CPU (< 0): dataDirect is forwarded uniformly to every
+   * unit's transport, so a mixed list would carry a meaningless dataDirect=true
+   * into the CPU unit and fail later at MR registration with a less specific
+   * error. Requiring an all-GPU device list keeps the failure mode clear.
+   */
+  if (config.dataDirect &&
+      std::any_of(
+          gpuDevices.begin(), gpuDevices.end(), [](int d) { return d < 0; })) {
+    UNIFLOW_LOG_ERROR(
+        "RdmaBandwidthBenchmark: --data-direct requires all selected devices to "
+        "be GPUs (--cuda-device/--cuda-devices >= 0); it does not apply to CPU "
+        "memory");
+    return {};
+  }
+
+  /*
+   * An explicit per-GPU NIC map (--gpu-nics) takes precedence over topology: it
+   * gives each GPU its own NICs and avoids adjacent GPUs being assigned the
+   * same NICs. If provided, it must have exactly one group per GPU.
+   */
+  const auto& nicGroups = config.gpuNicGroups;
+  if (!nicGroups.empty() && nicGroups.size() != gpuDevices.size()) {
+    UNIFLOW_LOG_ERROR(
+        "RdmaBandwidthBenchmark: --gpu-nics has {} group(s) but there are {} "
+        "GPU(s)",
+        nicGroups.size(),
+        gpuDevices.size());
+    return {};
+  }
+  if (multiGpu && nicGroups.empty() && !rdmaDevices_.empty()) {
     UNIFLOW_LOG_WARN(
-        "RdmaBandwidthBenchmark: rank {} RDMA device(s): {}",
-        bootstrap.rank,
-        devList);
+        "RdmaBandwidthBenchmark: --rdma-devices is not used in multi-GPU mode "
+        "(it would double-book NICs across GPUs); topology selects each GPU's "
+        "NICs -- pass --gpu-nics for an explicit per-GPU map");
   }
 
-  int numNics = static_cast<int>(myDevices.size());
-  auto bufs = allocateBuffers(
-      config.maxSize, config.cudaDevice, bootstrap.rank, numNics);
-  if (!bufs) {
-    return {};
+  /*
+   * Select the NICs that serve the g-th GPU (device id `dev`). Precedence:
+   * explicit --gpu-nics map, then single-GPU --rdma-devices override, then
+   * topology selection. In Data Direct mode the candidate set is further
+   * restricted to NICs whose data-direct PCIe domain matches the GPU's.
+   */
+  auto selectNicsForDevice = [&](size_t g,
+                                 int dev) -> std::vector<std::string> {
+    std::vector<std::string> sel;
+    if (!nicGroups.empty()) {
+      sel = nicGroups[g];
+    } else if (!multiGpu && !rdmaDevices_.empty()) {
+      sel = rdmaDevices_;
+    } else {
+      auto& topo = sharedTopology();
+      if (topo.available()) {
+        sel = (dev < 0) ? topo.selectCpuNics() : topo.selectGpuNics(dev);
+      }
+      if (sel.empty()) {
+        // Falling back to the full device list assigns the same NICs to every
+        // GPU. That is fine for a single GPU, but in multi-GPU mode it would
+        // double-book NICs across GPUs and inflate the aggregate, so require an
+        // explicit --gpu-nics map instead of guessing.
+        if (multiGpu) {
+          UNIFLOW_LOG_ERROR(
+              "RdmaBandwidthBenchmark: no per-GPU NICs for gpu {} (topology "
+              "unavailable); pass --gpu-nics to give each GPU a distinct NIC set",
+              dev);
+          return {};
+        }
+        sel = allDevices;
+      }
+    }
+    /*
+     * Data Direct registers GPU memory over a dedicated NIC<->GPU PCIe path, so
+     * it only succeeds on NICs whose data-direct interface shares the GPU's
+     * PCIe domain. Physical/topology NIC adjacency does not imply the same
+     * domain, so filter the candidates to the domain-matched subset instead of
+     * relying on --gpu-nics.
+     */
+    if (config.dataDirect && dev >= 0) {
+      char busId[32] = {};
+      if (cudaDeviceGetPCIBusId(busId, sizeof(busId), dev) == cudaSuccess) {
+        auto ddNics = selectDataDirectNicsForGpu(*ibvApi, sel, busId);
+        if (!ddNics.empty()) {
+          sel = std::move(ddNics);
+        } else {
+          UNIFLOW_LOG_ERROR(
+              "RdmaBandwidthBenchmark: no Data-Direct-domain-matched NICs for "
+              "gpu {} ({}) among {} candidate(s); aborting (pass --gpu-nics to "
+              "override)",
+              dev,
+              busId,
+              sel.size());
+          return {};
+        }
+      } else {
+        /*
+         * Without the GPU's bus id the domain filter cannot run. Continuing
+         * with the unfiltered candidates would defer the failure to Data
+         * Direct MR registration (EOPNOTSUPP on out-of-domain NICs) with a
+         * less specific error, so abort here to match the no-match branch.
+         */
+        UNIFLOW_LOG_ERROR(
+            "RdmaBandwidthBenchmark: cudaDeviceGetPCIBusId failed for gpu {}; "
+            "cannot filter NICs by Data-Direct domain (pass --gpu-nics to "
+            "override)",
+            dev);
+        return {};
+      }
+    }
+    if (config.numNics > 0 && config.numNics < static_cast<int>(sel.size())) {
+      sel.resize(config.numNics);
+    }
+    return sel;
+  };
+
+  /*
+   * Declared so transports/MRs (sessions) are destroyed before the GPU buffers
+   * they reference, which are destroyed before the EventBase threads the
+   * factories hold. reserve() keeps element addresses stable across setup.
+   */
+  std::vector<std::unique_ptr<ScopedEventBaseThread>> evbThreads;
+  std::vector<BenchmarkBuffers> buffers;
+  std::vector<TransportSession> sessions;
+  evbThreads.reserve(gpuDevices.size());
+  buffers.reserve(gpuDevices.size());
+  sessions.reserve(gpuDevices.size());
+
+  for (size_t g = 0; g < gpuDevices.size(); ++g) {
+    int dev = gpuDevices[g];
+    auto nics = selectNicsForDevice(g, dev);
+    if (nics.empty()) {
+      UNIFLOW_LOG_ERROR(
+          "RdmaBandwidthBenchmark: no NICs selected for gpu {}", dev);
+      return {};
+    }
+    {
+      std::string devList;
+      for (const auto& d : nics) {
+        if (!devList.empty()) {
+          devList += ", ";
+        }
+        devList += d;
+      }
+      UNIFLOW_LOG_WARN(
+          "RdmaBandwidthBenchmark: rank {} gpu {} RDMA device(s): {}",
+          bootstrap.rank,
+          dev,
+          devList);
+    }
+
+    auto bufs = allocateBuffers(
+        config.maxSize, dev, bootstrap.rank, static_cast<int>(nics.size()));
+    if (!bufs) {
+      return {};
+    }
+    assert(
+        bufs->srcs.size() == nics.size() &&
+        "Buffer count must equal NIC/QP count");
+    buffers.push_back(std::move(*bufs));
+
+    evbThreads.push_back(
+        std::make_unique<ScopedEventBaseThread>(
+            "bench-evb-gpu" + std::to_string(dev)));
+
+    auto session = setupTransport(
+        nics,
+        buffers[g],
+        config.maxSize,
+        *evbThreads[g],
+        ibvApi,
+        peers[0],
+        bootstrap,
+        config.chunkSize,
+        config.dataDirect);
+    if (!session) {
+      return {};
+    }
+    sessions.push_back(std::move(*session));
   }
 
-  assert(
-      bufs->srcs.size() == myDevices.size() &&
-      "Buffer count must equal NIC/QP count");
-
-  ScopedEventBaseThread evbThread("bench-evb");
-  auto session = setupTransport(
-      myDevices,
-      *bufs,
-      config.maxSize,
-      evbThread,
-      ibvApi,
-      peers[0],
-      bootstrap,
-      config.chunkSize);
-  if (!session) {
-    return {};
+  std::vector<RunUnit> units;
+  units.reserve(sessions.size());
+  /*
+   * sessions is built 1:1 from gpuDevices (any failure returns early), so the
+   * sizes match; bound the loop by both and read each element through at() so
+   * the indexing is checked at the access site.
+   */
+  for (size_t g = 0; g < sessions.size() && g < gpuDevices.size(); ++g) {
+    const int dev = gpuDevices.at(g);
+    auto& session = sessions.at(g);
+    units.push_back(
+        RunUnit{
+            .cudaDevice = dev,
+            .label =
+                (dev < 0) ? std::string("cpu") : "gpu" + std::to_string(dev),
+            .transport = session.transport.get(),
+            .localRegs = &session.localRegs,
+            .remoteRegs = &session.remoteRegs,
+        });
   }
 
-  auto results = runBenchmarkLoop(
-      *session->transport,
-      session->localRegs,
-      session->remoteRegs,
-      config,
-      peers,
-      bootstrap,
-      name());
+  auto results = runBenchmarkLoop(units, config, peers, bootstrap, name());
 
   auto finalBarrier = barrier(peers, bootstrap);
   if (!finalBarrier) {
@@ -670,7 +969,9 @@ std::vector<BenchmarkResult> RdmaBandwidthBenchmark::run(
         "RdmaBandwidthBenchmark: final barrier failed: {}",
         finalBarrier.error().toString());
   }
-  session->transport->shutdown();
+  for (auto& session : sessions) {
+    session.transport->shutdown();
+  }
   return results;
 }
 

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -42,7 +42,10 @@ struct CliOptions {
   int numNics{0};
   size_t chunkSize{512 * 1024};
   int cudaDevice{-1};
+  std::vector<int> cudaDevices;
+  std::vector<std::vector<std::string>> gpuNicGroups;
   bool bidirectional{false};
+  bool dataDirect{false};
   std::vector<int> numStreams{1, 2, 4, 8};
   std::string topology{"fanout"};
   int pipelineDepth{2};
@@ -78,6 +81,34 @@ std::vector<std::string> parseStringList(const std::string& s) {
   return result;
 }
 
+/*
+ * Parse a per-GPU NIC map: groups separated by ';', NICs within a group by ','.
+ * e.g. "mlx5_0,mlx5_1;mlx5_2,mlx5_3" -> [[mlx5_0, mlx5_1], [mlx5_2, mlx5_3]].
+ */
+std::vector<std::vector<std::string>> parseNicGroups(const std::string& s) {
+  std::vector<std::vector<std::string>> groups;
+  std::istringstream iss(s);
+  std::string group;
+  while (std::getline(iss, group, ';')) {
+    /*
+     * Preserve empty groups (leading or adjacent ';'). Dropping them would
+     * silently collapse the map and shift each GPU's NICs onto the wrong GPU;
+     * keeping them lets the per-GPU count check and NIC selection report a
+     * clear error for the empty slot instead.
+     */
+    groups.push_back(parseStringList(group));
+  }
+  /*
+   * getline emits no token after a trailing ';', so a trailing empty group must
+   * be appended explicitly to stay consistent with leading/adjacent empties
+   * (e.g. "mlx5_0;" -> two groups, the second empty).
+   */
+  if (!s.empty() && s.back() == ';') {
+    groups.emplace_back();
+  }
+  return groups;
+}
+
 void printUsage(const char* prog) {
   std::cerr
       << "Usage: " << prog << " [OPTIONS]\n"
@@ -105,6 +136,9 @@ void printUsage(const char* prog) {
       << "  --pipeline-depth <n>   Send/recv staging pipeline depth (default: 2)\n"
       << "  --slab-size <bytes>    Staging slab size in bytes (default: chunk-size)\n"
       << "  --slab-num <n>         Number of staging slabs (default: pipeline-depth)\n"
+      << "  --cuda-devices <list>  Comma-separated GPU indices for single-process multi-GPU (overrides --cuda-device)\n"
+      << "  --gpu-nics <groups>    Per-GPU NIC map for multi-GPU: ';'-separated groups of comma-separated NICs, one per --cuda-devices entry\n"
+      << "  --data-direct          Register GPU memory over the mlx5 Data Direct path (default: off)\n"
       << "  --list                 List available benchmarks\n"
       << "  --help                 Show this help message\n"
       << "\n"
@@ -143,6 +177,9 @@ CliOptions parseArgs(int argc, char** argv) {
       {"pipeline-depth", required_argument, nullptr, 260},
       {"slab-size", required_argument, nullptr, 261},
       {"slab-num", required_argument, nullptr, 262},
+      {"data-direct", no_argument, nullptr, 263},
+      {"cuda-devices", required_argument, nullptr, 264},
+      {"gpu-nics", required_argument, nullptr, 265},
       {"list", no_argument, nullptr, 'l'},
       {"help", no_argument, nullptr, 'h'},
       {nullptr, 0, nullptr, 0},
@@ -202,6 +239,15 @@ CliOptions parseArgs(int argc, char** argv) {
         break;
       case 'B':
         opts.bidirectional = true;
+        break;
+      case 263:
+        opts.dataDirect = true;
+        break;
+      case 264:
+        opts.cudaDevices = parseIntList(optarg);
+        break;
+      case 265:
+        opts.gpuNicGroups = parseNicGroups(optarg);
         break;
       case 'd':
         opts.direction = optarg;
@@ -387,12 +433,15 @@ int main(int argc, char** argv) {
   config.warmupIterations = opts.warmup;
   config.loopCount = opts.loopCount;
   config.bidirectional = opts.bidirectional;
+  config.dataDirect = opts.dataDirect;
   config.direction = opts.direction;
   config.batchSize = opts.batchSize;
   config.txDepth = opts.txDepth;
   config.numNics = opts.numNics;
   config.chunkSize = opts.chunkSize;
   config.cudaDevice = opts.cudaDevice;
+  config.cudaDevices = opts.cudaDevices;
+  config.gpuNicGroups = opts.gpuNicGroups;
   config.numStreams = opts.numStreams;
   config.topology = opts.topology;
   config.pipelineDepth = opts.pipelineDepth;

--- a/comms/uniflow/benchmarks/scripts/compare_rdma_bandwidth.py
+++ b/comms/uniflow/benchmarks/scripts/compare_rdma_bandwidth.py
@@ -27,36 +27,73 @@ _verbose = False
 
 REMOTE_DIR = "/tmp/uniflow_compare"
 
-# SSH throttling mitigation: remote hosts enforce MaxStartups limits on
-# concurrent SSH connections. These delays prevent back-to-back sush2/suscp
-# calls from being rejected.
-SSH_THROTTLE_DELAY = 3  # seconds between SSH retries on throttle errors
+# SSH login user for sush2/suscp. Default "root" needs the root_<host> machine
+# ACL; set to your unixname via --ssh-user to authenticate with your own login.
+SSH_USER = "root"
+
 IB_SERVER_INIT_DELAY_LOCAL = 3  # seconds for ib_write_bw server startup (local)
 IB_SERVER_INIT_DELAY_REMOTE = 10  # seconds for ib_write_bw server startup (remote)
 IB_PER_SIZE_DELAY = 3  # seconds between sizes in ib_write_bw loop
 
+# Hard minimum wall-clock spacing between ANY two sush2/suscp invocations to a
+# remote host. Bare-metal SSH gateways permanently blacklist identities that
+# open connections too rapidly, so this is a safety floor, not a perf knob.
+# _ssh_gate() sleeps as needed before every remote SSH call; --ssh-interval can
+# raise it but is clamped to never go below this value.
+MIN_SSH_INTERVAL = 30
+_last_ssh_ts = 0.0
+
+
+def _ssh_gate():
+    """Block until >= MIN_SSH_INTERVAL seconds have elapsed since the last
+    remote SSH call, then stamp the current time. Call immediately before every
+    sush2/suscp subprocess launch to a remote host."""
+    global _last_ssh_ts
+    wait = MIN_SSH_INTERVAL - (time.monotonic() - _last_ssh_ts)
+    if wait > 0:
+        _log(
+            f"SSH gate: sleeping {wait:.0f}s to keep >= {MIN_SSH_INTERVAL}s between SSH calls"
+        )
+        time.sleep(wait)
+    _last_ssh_ts = time.monotonic()
+
+
 GPU_PATTERNS = [
     ("H100", "h100"),
     ("H200", "h200"),
+    ("GB300", "b300"),
     ("GB200", "b200"),
     ("B200", "b200"),
     ("A100", "a100"),
 ]
 
+# Per-GPU extra buck flags. GB300 (b300) is Grace/aarch64 with the b200a nvcc
+# arch and CUDA 13 (matches the uniflow_disagg/comms_rdma_bench MAST fbpkg).
+_B200_FLAGS = (
+    " -c fbcode.arch=aarch64"
+    " -c fbcode.enable_gpu_sections=true"
+    " -c fbcode.nvcc_arch=b200"
+    " -c fbcode.platform010_cuda_version=12.8"
+)
+_B300_FLAGS = (
+    " -c fbcode.arch=aarch64"
+    " -c fbcode.enable_gpu_sections=true"
+    " -c fbcode.nvcc_arch=b200a"
+    " -c fbcode.platform010_cuda_version=13.0"
+)
+
 BUILD_SPECS = {
     "uniflow_bench": {
         "target": "fbcode//comms/uniflow/benchmarks:uniflow_bench",
-        "b200_flags": (
-            " -c fbcode.arch=aarch64"
-            " -c fbcode.enable_gpu_sections=true"
-            " -c fbcode.nvcc_arch=b200"
-            " -c fbcode.platform010_cuda_version=12.8"
-        ),
-        "supported_gpus": ("h100", "b200"),
+        "arch_flags": {"b200": _B200_FLAGS, "b300": _B300_FLAGS},
+        "supported_gpus": ("h100", "b200", "b300"),
     },
     "ib_write_bw": {
         "target": "fbsource//third-party/perftest/25.07.0-0.104:ib_write_bw",
-        "b200_flags": " -c fbcode.arch=aarch64",
+        "arch_flags": {
+            "b200": " -c fbcode.arch=aarch64",
+            "b300": " -c fbcode.arch=aarch64",
+        },
         "supported_gpus": None,
     },
 }
@@ -74,11 +111,13 @@ IP=$(ip -4 addr show eth1 2>/dev/null | awk '/inet /{split($2,a,"/"); print a[1]
 [ -z "$IP" ] && IP=$(ip -4 addr show eth0 2>/dev/null | awk '/inet /{split($2,a,"/"); print a[1]; exit}')
 [ -z "$IP" ] && IP=$(hostname -i 2>/dev/null | awk '{print $1}')
 echo "IP:$IP"
-GID_NIC=${__NIC_OVERRIDE__:-$NIC}
+GID_NIC=__NIC_OVERRIDE__
+[ -z "$GID_NIC" ] && GID_NIC=$NIC
 GID=$(show_gids 2>/dev/null | awk "/$GID_NIC/ && /v2/ && !/fe80/ {print \\$3; exit}")
 echo "GID:${GID:-3}"
 test -x __REMOTE_DIR__/uniflow_bench && echo "HAS:uniflow_bench"
 test -x __REMOTE_DIR__/ib_write_bw && echo "HAS:ib_write_bw"
+echo "LINKAGE:$(cat __REMOTE_DIR__/uniflow_bench.linkage 2>/dev/null)"
 pkill -9 -f uniflow_bench 2>/dev/null
 pkill -9 -f ib_write_bw 2>/dev/null
 mkdir -p __REMOTE_DIR__
@@ -91,6 +130,7 @@ GID=$(show_gids 2>/dev/null | awk "/__NIC__/ && /v2/ && !/fe80/ {print \\$3; exi
 echo "GID:${GID:-3}"
 test -x __REMOTE_DIR__/uniflow_bench && echo "HAS:uniflow_bench"
 test -x __REMOTE_DIR__/ib_write_bw && echo "HAS:ib_write_bw"
+echo "LINKAGE:$(cat __REMOTE_DIR__/uniflow_bench.linkage 2>/dev/null)"
 pkill -9 -f uniflow_bench 2>/dev/null
 pkill -9 -f ib_write_bw 2>/dev/null
 mkdir -p __REMOTE_DIR__
@@ -163,7 +203,7 @@ class RemoteHost:
         remote = f"{{ {cmd} ; }} 2>&1"
         return (
             f"sush2 --reason 'RDMA bandwidth comparison'"
-            f" root@{self.hostname} {shlex.quote(remote)}"
+            f" {SSH_USER}@{self.hostname} {shlex.quote(remote)}"
         )
 
     @staticmethod
@@ -175,6 +215,8 @@ class RemoteHost:
         _log(f"[{self.hostname}] {cmd}")
         full = self._wrap(cmd)
         if not capture:
+            if not self.is_local:
+                _ssh_gate()
             subprocess.run(full, shell=True, timeout=timeout)
             return ""
         # Retry on SSH throttling (empty stdout + non-zero rc).
@@ -183,7 +225,8 @@ class RemoteHost:
         for attempt in range(3):
             if attempt > 0:
                 _log(f"sush2 retry {attempt + 1}/3 after SSH throttle delay")
-                time.sleep(SSH_THROTTLE_DELAY)
+            if not self.is_local:
+                _ssh_gate()
             r = subprocess.run(
                 full, shell=True, capture_output=True, text=True, timeout=timeout
             )
@@ -199,6 +242,8 @@ class RemoteHost:
     def run_bg(self, cmd, quiet=False):
         _log(f"[{self.hostname} bg] {cmd}")
         full = self._wrap(cmd)
+        if not self.is_local:
+            _ssh_gate()
         fd, log_path = tempfile.mkstemp(suffix=".log", prefix="uniflow_bg_", dir="/tmp")
         log_file = os.fdopen(fd, "w")
         p = subprocess.Popen(
@@ -230,7 +275,7 @@ class RemoteHost:
         for attempt in range(3):
             if attempt > 0:
                 _log(f"suscp retry {attempt + 1}/3 after SSH throttle delay")
-                time.sleep(SSH_THROTTLE_DELAY)
+            _ssh_gate()
             rc = subprocess.run(cmd, shell=True, timeout=timeout).returncode
             if rc == 0:
                 return
@@ -241,23 +286,31 @@ class RemoteHost:
     def copy_to(self, local_path, remote_name):
         self._suscp(
             local_path,
-            f"root@{self.hostname}:{REMOTE_DIR}/{remote_name}",
+            f"{SSH_USER}@{self.hostname}:{REMOTE_DIR}/{remote_name}",
             "copy benchmark binary",
         )
 
     def copy_from(self, remote_name, local_path):
         self._suscp(
-            f"root@{self.hostname}:{REMOTE_DIR}/{remote_name}",
+            f"{SSH_USER}@{self.hostname}:{REMOTE_DIR}/{remote_name}",
             local_path,
             "retrieve results",
             timeout=60,
         )
 
-    def verify_and_chmod(self, names):
+    def verify_and_chmod(self, names, uniflow_linkage=None):
         checks = " && ".join(
             f"test -f {REMOTE_DIR}/{n} && chmod +x {REMOTE_DIR}/{n}" for n in names
         )
-        out = self.run(f"{checks} && echo OK", timeout=15)
+        cmd = checks
+        if uniflow_linkage and "uniflow_bench" in names:
+            # Stamp the deployed linkage so a later run can detect a switch and
+            # re-copy instead of silently running a stale build.
+            cmd += (
+                f" && echo {shlex.quote(uniflow_linkage)} >"
+                f" {REMOTE_DIR}/uniflow_bench.linkage"
+            )
+        out = self.run(f"{cmd} && echo OK", timeout=15)
         if "OK" not in (out or ""):
             sys.exit(
                 f"ERROR: Binaries not found on {self.hostname} after copy."
@@ -266,7 +319,7 @@ class RemoteHost:
 
     def setup_primary(self, nic_override=""):
         script = SETUP_SCRIPT_HOST0.replace("__REMOTE_DIR__", REMOTE_DIR).replace(
-            "__NIC_OVERRIDE__", nic_override or ""
+            "__NIC_OVERRIDE__", shlex.quote(nic_override or "")
         )
         return self._parse_setup(_run_script_on_host(self, script))
 
@@ -316,13 +369,19 @@ class RemoteHost:
 CACHE_DIR = os.path.expanduser("~/.cache/uniflow_compare")
 
 
-def get_cached_binary(name, gpu):
-    path = os.path.join(CACHE_DIR, gpu, name)
+def _cache_subdir(gpu, linkage):
+    # Keep dynamic-linkage binaries in a separate dir so they never get confused
+    # with the default static build for the same GPU.
+    return gpu if linkage == "static" else f"{gpu}-{linkage}"
+
+
+def get_cached_binary(name, gpu, linkage="static"):
+    path = os.path.join(CACHE_DIR, _cache_subdir(gpu, linkage), name)
     return path if os.path.isfile(path) and os.access(path, os.X_OK) else None
 
 
-def build_binary(name, gpu, rebuild=False):
-    cached = get_cached_binary(name, gpu)
+def build_binary(name, gpu, rebuild=False, linkage="static"):
+    cached = get_cached_binary(name, gpu, linkage)
     if cached and not rebuild:
         print(f"  {name}: {cached} (cached)")
         return cached
@@ -332,7 +391,10 @@ def build_binary(name, gpu, rebuild=False):
         sys.exit(f"ERROR: Unsupported GPU for {name}: {gpu}")
 
     print(f"  Building {name}...")
-    extra = spec["b200_flags"] if gpu == "b200" else ""
+    extra = spec.get("arch_flags", {}).get(gpu, "")
+    # Only uniflow_bench honors the rdma_linkage toggle; ib_write_bw ignores it.
+    if name == "uniflow_bench" and linkage == "dynamic":
+        extra += " -c uniflow.rdma_linkage=dynamic"
     cmd = f"buck2 build @fbcode//mode/opt{extra} {spec['target']} --show-full-output"
     try:
         r = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=600)
@@ -347,7 +409,7 @@ def build_binary(name, gpu, rebuild=False):
     if not built or not os.path.isfile(built):
         sys.exit(f"ERROR: Build of {name} produced no output binary")
 
-    dest_dir = os.path.join(CACHE_DIR, gpu)
+    dest_dir = os.path.join(CACHE_DIR, _cache_subdir(gpu, linkage))
     os.makedirs(dest_dir, exist_ok=True)
     dest = os.path.join(dest_dir, name)
     shutil.copy2(built, dest)
@@ -367,11 +429,10 @@ class UniflowBenchmark:
         self.rank1_host = rank1_host
         self.binary_path = f"{REMOTE_DIR}/{self.binary_name}"
 
-    def run(self, dry_run=False):
-        print("--- Running uniflow ---")
+    def _build_bench_flags(self):
+        """Assemble the uniflow_bench CLI flags from args (shared by both ranks)."""
         a = self.args
-
-        bench_flags = (
+        flags = (
             f"--benchmark rdma_bandwidth --transport rdma"
             f" --iterations {a.iterations} --warmup {a.warmup}"
             f" --min-size {a.min_size} --max-size {a.max_size}"
@@ -381,11 +442,28 @@ class UniflowBenchmark:
             f" --format csv --output {REMOTE_DIR}/results.csv"
         )
         if a.num_nics > 0:
-            bench_flags += f" --num-nics {a.num_nics}"
+            flags += f" --num-nics {a.num_nics}"
         if a.use_cuda:
-            bench_flags += " --cuda-device 0"
+            if a.cuda_devices:
+                flags += f" --cuda-devices {shlex.quote(a.cuda_devices)}"
+            else:
+                flags += " --cuda-device 0"
+        if a.gpu_nics:
+            # shlex.quote the value for the REMOTE shell (sush2 runs the command
+            # through a shell on the far side): --gpu-nics contains ';' group
+            # separators that would otherwise be treated as command terminators.
+            flags += f" --gpu-nics {shlex.quote(a.gpu_nics)}"
         if a.nics:
-            bench_flags += f" --rdma-devices {a.nics}"
+            flags += f" --rdma-devices {shlex.quote(a.nics)}"
+        if a.data_direct:
+            flags += " --data-direct"
+        return flags
+
+    def run(self, dry_run=False):
+        print("--- Running uniflow ---")
+        a = self.args
+
+        bench_flags = self._build_bench_flags()
 
         env = f"MASTER_ADDR={a.master_ip} MASTER_PORT={a.master_port} WORLD_SIZE=2"
         if _verbose:
@@ -417,6 +495,11 @@ class UniflowBenchmark:
         # Prepend rm to the rank0 command to clear stale results within
         # the same sush2 session (zero extra SSH calls).
         r0_cmd_full = f"rm -f {REMOTE_DIR}/results.csv; {r0_cmd}"
+        # rank 1 (RANK=1, the connecting side) launches first in the background;
+        # rank 0 (RANK=0, the rendezvous server) follows. The 30s SSH gate makes
+        # host0.run() below wait ~30s before starting rank 0, so rank 1 must
+        # tolerate a ~30s rendezvous wait -- uniflow's TcpController connect-retry
+        # window covers this today. Revisit if MIN_SSH_INTERVAL grows.
         p1 = self.rank1_host.run_bg(r1_cmd)
         time.sleep(1)
         self.host0.run(r0_cmd_full, capture=False)
@@ -567,8 +650,8 @@ class IbWriteBwBenchmark:
         total = len(self.sizes)
 
         common = f"--report_gbits --CPU-freq -n {a.iterations}"
-        srv_flags = f"-x {a.gid0} {common} -d {a.nic0}"
-        cli_flags = f"-x {a.gid1} {common} -d {a.nic1}"
+        srv_flags = f"-x {a.gid0} {common} -d {shlex.quote(a.nic0)}"
+        cli_flags = f"-x {a.gid1} {common} -d {shlex.quote(a.nic1)}"
         for flag in [a.ipv6_flag, cuda_flag]:
             if flag:
                 srv_flags += f" {flag}"
@@ -732,6 +815,10 @@ def _setup_hosts(args):
 
     hosts[args.host0] = h0
     has_bins_all = dict.fromkeys(info0["has_bins"], True)
+    # rdma-core linkage stamped on the remote uniflow_bench, so a linkage switch
+    # forces a re-copy (the HAS check can't tell a static build from a dynamic
+    # one). Empty when no binary/stamp is present or the hosts disagree.
+    remote_linkage = info0.get("LINKAGE", "")
 
     if args.host1 != args.host0:
         h1 = RemoteHost(args.host1)
@@ -742,6 +829,8 @@ def _setup_hosts(args):
         for name in ("uniflow_bench", "ib_write_bw"):
             if name not in info1["has_bins"]:
                 has_bins_all.pop(name, None)
+        if info1.get("LINKAGE", "") != remote_linkage:
+            remote_linkage = ""  # hosts disagree → re-copy to both
     else:
         args.gid1 = args.gid0
 
@@ -752,6 +841,7 @@ def _setup_hosts(args):
 
     args._hosts = hosts
     args._has_remote_bins = has_bins_all
+    args._remote_uniflow_linkage = remote_linkage
 
 
 def _copy_binaries(args, benchmarks):
@@ -764,6 +854,14 @@ def _copy_binaries(args, benchmarks):
         need = b.binary_name not in has
         if force in ("both", b.name):
             need = True
+        # uniflow_bench's build depends on --rdma-linkage, but the remote HAS
+        # check only tests executability and can't tell a static build from a
+        # dynamic one. Re-copy when the linkage stamped on the remote differs
+        # from the requested one, so we never silently run a stale build.
+        if b.name == "uniflow" and (
+            getattr(args, "_remote_uniflow_linkage", "") != args.rdma_linkage
+        ):
+            need = True
         if need:
             to_copy.append(b)
         else:
@@ -773,18 +871,19 @@ def _copy_binaries(args, benchmarks):
         return
 
     print("  Copying binaries to remote hosts...")
+    # copy_to (via _suscp) and verify_and_chmod each call _ssh_gate(), which
+    # already enforces the MIN_SSH_INTERVAL floor between SSH calls, so no extra
+    # inter-copy sleep is needed here.
     for host in hosts:
-        for i, b in enumerate(to_copy):
-            if i > 0:
-                _log(f"sleeping {SSH_THROTTLE_DELAY}s to avoid SSH throttling")
-                time.sleep(SSH_THROTTLE_DELAY)
+        for b in to_copy:
             host.copy_to(b.local_binary_path, b.binary_name)
-        _log(f"sleeping {SSH_THROTTLE_DELAY}s to avoid SSH throttling")
-        time.sleep(SSH_THROTTLE_DELAY)
-        host.verify_and_chmod([b.binary_name for b in to_copy])
+        host.verify_and_chmod(
+            [b.binary_name for b in to_copy], uniflow_linkage=args.rdma_linkage
+        )
 
 
 def _parse_args():
+    global _verbose, SSH_USER, MIN_SSH_INTERVAL
     parser = argparse.ArgumentParser(
         description="Compare uniflow RDMA bandwidth against ib_write_bw (perftest)",
     )
@@ -796,7 +895,7 @@ def _parse_args():
     parser.add_argument(
         "--gpu",
         default="",
-        help="GPU type: h100 or b200 (default: auto-detect)",
+        help="GPU type: h100 | b200 | b300 (default: auto-detect)",
     )
     parser.add_argument(
         "--nics",
@@ -879,6 +978,65 @@ def _parse_args():
         help="Which tool(s) to run (default: uniflow)",
     )
     parser.add_argument(
+        "--cuda-devices",
+        default="",
+        help=(
+            "Comma-separated GPU indices for single-process multi-GPU aggregate"
+            " (e.g. 0,1,2,3), overriding the default single --cuda-device 0."
+            " uniflow only; each rank drives all listed GPUs and BW is summed."
+        ),
+    )
+    parser.add_argument(
+        "--gpu-nics",
+        default="",
+        help=(
+            "Per-GPU NIC map for --cuda-devices: ';'-separated groups of"
+            " comma-separated NICs, one group per GPU (e.g."
+            " 'mlx5_0,mlx5_1;mlx5_2,mlx5_3'). Omit to let the binary auto-select"
+            " NICs per GPU."
+        ),
+    )
+    parser.add_argument(
+        "--ssh-interval",
+        type=int,
+        default=MIN_SSH_INTERVAL,
+        help=(
+            "Minimum seconds between remote SSH calls (default and hard floor:"
+            f" {MIN_SSH_INTERVAL}). Values below the floor are clamped up to it to"
+            " avoid a permanent SSH blacklist."
+        ),
+    )
+    parser.add_argument(
+        "--ssh-user",
+        default="root",
+        help=(
+            "SSH login user for sush2/suscp (default: root, needs the"
+            " root_<host> machine ACL). Pass your unixname to authenticate with"
+            " your own login instead."
+        ),
+    )
+    parser.add_argument(
+        "--rdma-linkage",
+        default="static",
+        choices=["static", "dynamic"],
+        help=(
+            "uniflow rdma-core linkage. 'static' (default) links the pinned"
+            " fbsource third-party rdma-core. 'dynamic' builds with"
+            " -c uniflow.rdma_linkage=dynamic so the binary dlopens the HOST's"
+            " /usr/lib64 libibverbs/libmlx5 at runtime — use when the host ships"
+            " a newer mlx5 (e.g. GB300 Data Direct needing rdma-core > the pin)."
+        ),
+    )
+    parser.add_argument(
+        "--data-direct",
+        action="store_true",
+        help=(
+            "Enable mlx5 Data Direct (NIC<->GPU HBM over PCIe, bypassing Grace"
+            " C2C). Requires a DD-provisioned node and VRAM buffers; uniflow"
+            " only."
+        ),
+    )
+    parser.add_argument(
         "--rebuild",
         action="store_true",
         help="Force rebuild of binaries even if cached",
@@ -908,9 +1066,21 @@ def _parse_args():
     )
     args = parser.parse_args()
 
-    global _verbose
     _verbose = args.verbose
+    SSH_USER = args.ssh_user
+    if args.ssh_interval < MIN_SSH_INTERVAL:
+        print(
+            f"WARNING: --ssh-interval {args.ssh_interval}s is below the {MIN_SSH_INTERVAL}s"
+            f" safety floor; clamping to {MIN_SSH_INTERVAL}s to avoid an SSH blacklist."
+        )
+    else:
+        MIN_SSH_INTERVAL = args.ssh_interval
     args.use_cuda = not args.no_cuda
+
+    if args.data_direct and not args.use_cuda:
+        parser.error(
+            "--data-direct requires GPU buffers; do not combine with --no-cuda"
+        )
 
     if args.hosts:
         parts = [h.strip() for h in args.hosts.split(",") if h.strip()]
@@ -967,7 +1137,10 @@ def _create_benchmarks(args, sizes, host0, rank1_host):
     print()
     local_bins = {}
     for name in binary_names:
-        local_bins[name] = build_binary(name, args.gpu, rebuild=args.rebuild)
+        linkage = args.rdma_linkage if name == "uniflow_bench" else "static"
+        local_bins[name] = build_binary(
+            name, args.gpu, rebuild=args.rebuild, linkage=linkage
+        )
 
     benchmarks = []
     if args.tool in ("uniflow", "both"):

--- a/comms/uniflow/drivers/DeviceAdapter.h
+++ b/comms/uniflow/drivers/DeviceAdapter.h
@@ -13,6 +13,19 @@ namespace uniflow {
 class CudaApi;
 class CudaDriverApi;
 
+/// How a device buffer is mapped when exported as a DMA-BUF.
+enum class DmaBufMapping {
+  /// Standard mapping. On Grace-based systems (e.g. GB300) NIC<->GPU traffic
+  /// traverses the C2C link.
+  Default,
+  /// mlx5 Data Direct: map the buffer over the NIC's PCIe BAR1 path so the NIC
+  /// DMAs straight to/from GPU HBM, bypassing the Grace C2C link. The exported
+  /// fd must back an `mlx5dv_reg_dmabuf_mr` with
+  /// `MLX5DV_REG_DMABUF_ACCESS_DATA_DIRECT`. Only meaningful on a Data-Direct-
+  /// capable NIC; requires CUDA >= 12.8.
+  DataDirect,
+};
+
 /// Description of a DMA-BUF region exported from device memory and
 /// suitable for use with `ibv_reg_dmabuf_mr`.
 ///
@@ -30,6 +43,10 @@ struct DmaBuff {
   /// Registration bbase for this DmaBuff to be used when creating WQEs.
   /// This is to be subtracted from a device pointer to form the WQE address.
   uint64_t registrationBase{0};
+  /// Full length of the exported dma-buf (page-aligned, covering `offset` +
+  /// `len`). mlx5 Data Direct registers the whole dma-buf from its aligned
+  /// base (offset 0), so the DD MR uses this length rather than `len`.
+  size_t dmaBufLen{0};
 };
 
 /// DeviceAdapter abstracts device-specific host pinned memory allocation
@@ -53,10 +70,16 @@ class DeviceAdapter {
   virtual Result<bool> isDmaBuffSupported(int deviceId) = 0;
 
   /// Export a DMA-BUF descriptor for `[ptr, ptr + len)` on `deviceId`.
+  /// `mapping` selects the NIC<->GPU route (see DmaBufMapping); `DataDirect`
+  /// requires a Data-Direct-capable NIC and, on GB300, a buffer whose base is
+  /// VMM-granularity (2 MB) aligned so the returned `offset` is 0.
   /// The caller must call `closeDmaBuff()` on the returned value once the
   /// resulting MR has been registered.
-  virtual Result<DmaBuff>
-  exportDmaBuff(int deviceId, void* ptr, size_t len) = 0;
+  virtual Result<DmaBuff> exportDmaBuff(
+      int deviceId,
+      void* ptr,
+      size_t len,
+      DmaBufMapping mapping = DmaBufMapping::Default) = 0;
 
   /// Translate a client-supplied device pointer (which may be an opaque
   /// allocation handle / UID) to the bare device address the NIC needs to

--- a/comms/uniflow/drivers/cuda/CudaDeviceAdapter.cpp
+++ b/comms/uniflow/drivers/cuda/CudaDeviceAdapter.cpp
@@ -40,14 +40,33 @@ bool isNvlinkAvailable() {
   return true;
 }
 
-Result<DmaBuff>
-CudaDeviceAdapter::exportDmaBuff(int /* deviceId */, void* ptr, size_t len) {
+Result<DmaBuff> CudaDeviceAdapter::exportDmaBuff(
+    int /* deviceId */,
+    void* ptr,
+    size_t len,
+    DmaBufMapping mapping) {
   if (!cudaDriverApi_) {
     return Err(
         ErrCode::DriverError, "CudaDeviceAdapter: CudaDriverApi unavailable");
   }
   if (ptr == nullptr || len == 0) {
     return Err(ErrCode::InvalidArgument, "exportDmaBuff: bad ptr or len");
+  }
+
+  /*
+   * Resolve the mapping flag. Data Direct maps the buffer over PCIe BAR1 so the
+   * NIC reaches GPU HBM directly (mlx5 GDAKI / NCCL_IB_DATA_DIRECT); it needs
+   * the CUDA 12.8 range flag, unavailable on older toolkits.
+   */
+  unsigned long long flags = 0;
+  if (mapping == DmaBufMapping::DataDirect) {
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12080
+    flags = CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE;
+#else
+    return Err(
+        ErrCode::DriverError,
+        "exportDmaBuff: Data Direct requires CUDA >= 12.8");
+#endif
   }
 
   // dma-buf registration requires a page-aligned base address. Align down
@@ -59,20 +78,18 @@ CudaDeviceAdapter::exportDmaBuff(int /* deviceId */, void* ptr, size_t len) {
       (len + dmaBufOffset + pageSize_ - 1) & ~(pageSize_ - 1);
 
   DmaBuff out;
-  // TODO: set CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE if a data-direct
-  // link is available.
-  constexpr unsigned long long kFlags = 0;
   auto status = cudaDriverApi_->cuMemGetHandleForAddressRange(
       &out.fd,
       toDevicePtr(alignedAddr),
       dmaBufLen,
       CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-      kFlags);
+      flags);
   CHECK_RETURN(status);
 
   out.offset = dmaBufOffset;
   out.len = len;
   out.iova = static_cast<uint64_t>(addr);
+  out.dmaBufLen = dmaBufLen;
   return out;
 }
 

--- a/comms/uniflow/drivers/cuda/CudaDeviceAdapter.h
+++ b/comms/uniflow/drivers/cuda/CudaDeviceAdapter.h
@@ -22,7 +22,11 @@ class CudaDeviceAdapter : public DeviceAdapter {
   Result<void*> hostGetDevicePointer(void* hostPtr) override;
 
   Result<bool> isDmaBuffSupported(int deviceId) override;
-  Result<DmaBuff> exportDmaBuff(int deviceId, void* ptr, size_t len) override;
+  Result<DmaBuff> exportDmaBuff(
+      int deviceId,
+      void* ptr,
+      size_t len,
+      DmaBufMapping mapping = DmaBufMapping::Default) override;
   Status closeDmaBuff(DmaBuff& buff) override;
 
  private:

--- a/comms/uniflow/drivers/cuda/tests/CudaDeviceAdapterTest.cpp
+++ b/comms/uniflow/drivers/cuda/tests/CudaDeviceAdapterTest.cpp
@@ -114,6 +114,54 @@ TEST(CudaDeviceAdapterTest, ExportDmaBuffPopulatesFdOffsetAndIova) {
   EXPECT_EQ(res->iova, reinterpret_cast<uint64_t>(ptr));
 }
 
+TEST(CudaDeviceAdapterTest, ExportDmaBuffDataDirectSelectsPcieMapping) {
+  /*
+   * The DmaBufMapping::DataDirect route must map the buffer over PCIe BAR1 so
+   * the exported fd can back an mlx5dv Data-Direct MR. The observable contract
+   * is the range flag handed to the driver: DataDirect => the PCIe flag,
+   * Default => 0 (asserted by ExportDmaBuffPopulatesFdOffsetAndIova). On CUDA
+   * older than 12.8 the PCIe mapping cannot be expressed, so DataDirect must
+   * fail cleanly rather than silently fall back to the C2C mapping.
+   */
+  auto cudaApi = std::make_shared<NiceMock<MockCudaApi>>();
+  auto driverApi = std::make_shared<NiceMock<MockCudaDriverApi>>();
+  CudaDeviceAdapter adapter(cudaApi, driverApi);
+
+  const size_t pageSize = static_cast<size_t>(::sysconf(_SC_PAGESIZE));
+  void* backingRaw = nullptr;
+  ASSERT_EQ(::posix_memalign(&backingRaw, pageSize, pageSize), 0);
+  std::unique_ptr<void, decltype(&::free)> backing(backingRaw, &::free);
+
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12080
+  constexpr int kFakeFd = 7;
+  EXPECT_CALL(
+      *driverApi,
+      cuMemGetHandleForAddressRange(
+          _,
+          _,
+          _,
+          CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+          static_cast<unsigned long long>(
+              CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE)))
+      .WillOnce([&](void* handle,
+                    CUdeviceptr,
+                    size_t,
+                    CUmemRangeHandleType,
+                    unsigned long long) {
+        *static_cast<int*>(handle) = kFakeFd;
+        return Ok();
+      });
+  auto res = adapter.exportDmaBuff(
+      /*deviceId=*/0, backing.get(), pageSize, DmaBufMapping::DataDirect);
+  ASSERT_FALSE(res.hasError());
+  EXPECT_EQ(res->fd, kFakeFd);
+#else
+  auto res = adapter.exportDmaBuff(
+      /*deviceId=*/0, backing.get(), pageSize, DmaBufMapping::DataDirect);
+  EXPECT_TRUE(res.hasError());
+#endif
+}
+
 TEST(CudaDeviceAdapterTest, ExportDmaBuffRejectsNullPtr) {
   auto cudaApi = std::make_shared<NiceMock<MockCudaApi>>();
   auto driverApi = std::make_shared<NiceMock<MockCudaDriverApi>>();

--- a/comms/uniflow/transport/rdma/RdmaResources.cpp
+++ b/comms/uniflow/transport/rdma/RdmaResources.cpp
@@ -2,6 +2,11 @@
 
 #include "comms/uniflow/transport/rdma/RdmaResources.h"
 
+#include <cctype>
+#include <cerrno>
+#include <cstdlib>
+#include <memory>
+
 #include "comms/uniflow/logging/Logger.h"
 
 namespace uniflow {
@@ -9,6 +14,36 @@ namespace uniflow {
 namespace {
 
 constexpr uint8_t kDefaultRoceV2GidIndex = 3;
+
+/// Parse a whole hex token to a non-negative value, or -1 if it is empty or not
+/// entirely valid hex (strtol otherwise silently yields 0 for non-hex input).
+long parseHexToken(const std::string& token) {
+  // Require the first character to be a hex digit: strtol would otherwise
+  // accept a leading '+'/'-' sign (e.g. "+ff") or skip leading whitespace, but
+  // a PCIe domain token is bare hex.
+  if (token.empty() ||
+      std::isxdigit(static_cast<unsigned char>(token[0])) == 0) {
+    return -1;
+  }
+  char* end = nullptr;
+  errno = 0;
+  long value = std::strtol(token.c_str(), &end, 16);
+  // Reject trailing junk, negatives, and overflow (ERANGE -> LONG_MAX).
+  if (end != token.c_str() + token.size() || value < 0 || errno == ERANGE) {
+    return -1;
+  }
+  return value;
+}
+
+/// Parse the hex PCIe domain from a "domain:bus:device.function" prefix (-1 if
+/// no ':' or the domain token is not valid hex).
+long parsePciDomainFromBusId(const std::string& busId) {
+  auto colon = busId.find(':');
+  if (colon == std::string::npos) {
+    return -1;
+  }
+  return parseHexToken(busId.substr(0, colon));
+}
 
 /// True if @p gid is an IPv4-mapped IPv6 address (::ffff:a.b.c.d).
 bool isIpv4MappedGid(const ibv_gid& gid) {
@@ -75,6 +110,17 @@ NicResources::NicResources(
     }
     dmaBufSupported = dmaBufResult.value();
 
+    /*
+     * Probe for mlx5 Data Direct: a NIC with a dedicated GPU<->NIC PCIe path
+     * exposes a data-direct sysfs path. Optional capability — a missing path
+     * (or an mlx5dv library without the symbol) simply leaves dataDirect false.
+     */
+    char ddPath[256] = {};
+    dataDirect =
+        !ibvApi->mlx5dvGetDataDirectSysfsPath(ctx, ddPath, sizeof(ddPath))
+             .hasError() &&
+        ddPath[0] != '\0';
+
     ibv_port_attr portAttr{};
     auto portStatus = ibvApi->queryPort(ctx, portNum, &portAttr);
     if (portStatus.hasError()) {
@@ -107,6 +153,7 @@ NicResources::NicResources(NicResources&& other) noexcept
       portNum(other.portNum),
       dmaBufSupported(other.dmaBufSupported),
       numaNode(other.numaNode),
+      dataDirect(other.dataDirect),
       ibvApi(std::move(other.ibvApi)) {
   other.ctx = nullptr;
   other.pd = nullptr;
@@ -230,6 +277,89 @@ uint8_t NicResources::resolveGidIndex(
       std::to_string(portNum) + " and default GID index " +
       std::to_string(kDefaultRoceV2GidIndex) + " out of range (gid_tbl_len=" +
       std::to_string(portAttr.gid_tbl_len) + ")");
+}
+
+// ---------------------------------------------------------------------------
+// Data Direct NIC selection
+// ---------------------------------------------------------------------------
+
+bool dataDirectDomainMatchesGpu(
+    const std::string& ddSysfsPath,
+    const std::string& gpuPciBusId) {
+  long gpuDomain = parsePciDomainFromBusId(gpuPciBusId);
+  if (gpuDomain < 0) {
+    return false;
+  }
+  /*
+   * A data-direct sysfs path looks like
+   * "/sys/devices/pci0008:00/0008:00:00.0/...": the PCIe domain is the hex
+   * token right after "/pci", up to the next ':'. Every device under a
+   * "/sys/devices/pciDDDD:BB" root shares that root's domain DDDD (a different
+   * domain lives under its own "pciEEEE:BB" root, i.e. a separate path), so the
+   * first (and only) "pci" component is authoritative — nested BDFs do not
+   * carry a "pci" prefix, so there is no deeper domain token to prefer.
+   */
+  auto pci = ddSysfsPath.find("/pci");
+  if (pci == std::string::npos) {
+    return false;
+  }
+  size_t domStart = pci + 4;
+  auto colon = ddSysfsPath.find(':', domStart);
+  if (colon == std::string::npos) {
+    return false;
+  }
+  long ddDomain = parseHexToken(ddSysfsPath.substr(domStart, colon - domStart));
+  return ddDomain >= 0 && gpuDomain == ddDomain;
+}
+
+std::vector<std::string> selectDataDirectNicsForGpu(
+    IbvApi& ibvApi,
+    const std::vector<std::string>& candidateNics,
+    const std::string& gpuPciBusId) {
+  std::vector<std::string> matched;
+  int numDevices = 0;
+  auto listResult = ibvApi.getDeviceList(&numDevices);
+  if (listResult.hasError()) {
+    return matched;
+  }
+  ibv_device** list = listResult.value();
+
+  for (const auto& name : candidateNics) {
+    ibv_device* device = nullptr;
+    for (int i = 0; i < numDevices; ++i) {
+      auto nameResult = ibvApi.getDeviceName(list[i]);
+      if (!nameResult.hasError() && name == nameResult.value()) {
+        device = list[i];
+        break;
+      }
+    }
+    if (device == nullptr) {
+      continue;
+    }
+    auto ctxResult = ibvApi.openDevice(device);
+    if (ctxResult.hasError()) {
+      continue;
+    }
+    ibv_context* ctx = ctxResult.value();
+    // Close the context on every exit path (incl. an exception from the
+    // dlopen'd mlx5dv call or the string parsing below), not just the success
+    // path.
+    auto closeCtx = [&ibvApi](ibv_context* c) noexcept {
+      (void)ibvApi.closeDevice(c);
+    };
+    std::unique_ptr<ibv_context, decltype(closeCtx)> ctxGuard(ctx, closeCtx);
+
+    char ddPath[256] = {};
+    auto ddStatus =
+        ibvApi.mlx5dvGetDataDirectSysfsPath(ctx, ddPath, sizeof(ddPath));
+    if (!ddStatus.hasError() &&
+        dataDirectDomainMatchesGpu(ddPath, gpuPciBusId)) {
+      matched.push_back(name);
+    }
+  }
+
+  ibvApi.freeDeviceList(list);
+  return matched;
 }
 
 } // namespace uniflow

--- a/comms/uniflow/transport/rdma/RdmaResources.h
+++ b/comms/uniflow/transport/rdma/RdmaResources.h
@@ -2,6 +2,9 @@
 
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "comms/uniflow/drivers/ibverbs/IbvApi.h"
 
 namespace uniflow {
@@ -26,6 +29,7 @@ struct NicResources {
   uint8_t portNum{1}; /* Physical port number on the HCA. */
   bool dmaBufSupported{false}; /* Kernel supports DMA-BUF MR registration. */
   int numaNode{-1}; /* NUMA node of the NIC, from Topology (-1 = unknown). */
+  bool dataDirect{false}; /* NIC exposes a data-direct sysfs path (mlx5 DD). */
 
   /*
    * Full-init constructor.
@@ -59,5 +63,25 @@ struct NicResources {
   void cleanup();
   std::shared_ptr<IbvApi> ibvApi{nullptr};
 };
+
+/// True if the mlx5 Data-Direct sysfs path (from
+/// mlx5dv_get_data_direct_sysfs_path) is in the same PCIe domain as the GPU at
+/// gpuPciBusId (nvidia-smi / cudaDeviceGetPCIBusId format, e.g.
+/// "00000008:06:00.0"). mlx5 Data-Direct MR registration only succeeds when the
+/// NIC's data-direct interface shares the GPU's PCIe domain; the NIC's own
+/// physical PCIe location does NOT imply the same data-direct domain.
+bool dataDirectDomainMatchesGpu(
+    const std::string& ddSysfsPath,
+    const std::string& gpuPciBusId);
+
+/// From candidateNics (device names), returns those whose mlx5 Data-Direct
+/// interface shares the GPU's PCIe domain (gpuPciBusId). Each candidate is
+/// opened to probe its data-direct sysfs path; candidates without a DD path, or
+/// in a different domain, are excluded. Input order is preserved. This is the
+/// NIC selection required for Data-Direct RDMA.
+std::vector<std::string> selectDataDirectNicsForGpu(
+    IbvApi& ibvApi,
+    const std::vector<std::string>& candidateNics,
+    const std::string& gpuPciBusId);
 
 } // namespace uniflow

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -6,6 +6,7 @@
 #include "comms/uniflow/drivers/TopologyDiscovery.h"
 #include "comms/uniflow/drivers/cuda/CudaDevicePtr.h"
 #include "comms/uniflow/drivers/cuda/CudaDriverApi.h"
+#include "comms/uniflow/drivers/ibverbs/Mlx5Core.h"
 #include "comms/uniflow/logging/Logger.h"
 #include "comms/uniflow/transport/rdma/RdmaRegistrationHandle.h"
 #include "comms/uniflow/transport/rdma/RdmaSlabPool.h"
@@ -1927,16 +1928,94 @@ RdmaTransportFactory::registerSegment(Segment& segment) {
   DmaBuffCloseGuard closeGuard{*deviceAdapter_, dmaBuff};
   uint64_t registrationBase = 0;
 
+  /*
+   * mlx5 Data Direct: route NIC<->GPU DMA over PCIe BAR1 (bypassing the Grace
+   * C2C link) when enabled AND every NIC is both Data-Direct- and dma-buf-
+   * capable. It is all-or-nothing: one PCIe-mapped dmabuf fd must be valid on
+   * every NIC's QP, so a mix of DD and non-DD NICs falls back to the standard
+   * path. dmaBufSupported is required here too because the per-NIC registration
+   * loop gates the DD MR on it; without it a DD-but-not-dmabuf NIC would
+   * silently take the standard path, producing exactly the mixed-route MR set
+   * this invariant avoids.
+   */
+  const bool useDataDirect = config_.dataDirect &&
+      std::all_of(nicsHandle_->begin(),
+                  nicsHandle_->end(),
+                  [](const NicResources& nic) {
+                    return nic.dataDirect && nic.dmaBufSupported;
+                  });
+
   if (segment.memType() == MemoryType::VRAM) {
+    // Data Direct only applies to VRAM (dmabuf) registration. Warn at most once
+    // if it was requested but can't be used: config_.dataDirect and NIC
+    // capabilities are per-transport invariants, so a single warning suffices
+    // and avoids per-registration log spam.
+    if (config_.dataDirect && !useDataDirect &&
+        !dataDirectFallbackWarned_.exchange(true)) {
+      UNIFLOW_LOG_WARN(
+          "registerSegment: Data Direct requested but not all NICs are "
+          "Data-Direct-capable; using the standard dmabuf path");
+    }
+
     auto dmaBufSupported =
         deviceAdapter_->isDmaBuffSupported(segment.deviceId());
     CHECK_RETURN(dmaBufSupported);
     if (dmaBufSupported.value()) {
       auto exportRes = deviceAdapter_->exportDmaBuff(
-          segment.deviceId(), segment.mutable_data(), segment.len());
+          segment.deviceId(),
+          segment.mutable_data(),
+          segment.len(),
+          useDataDirect ? DmaBufMapping::DataDirect : DmaBufMapping::Default);
       if (exportRes.hasValue()) {
         dmaBuff = std::move(exportRes).value();
         registrationBase = dmaBuff.registrationBase;
+        /*
+         * GB300 Data Direct rejects a non-zero dmabuf offset (EOPNOTSUPP): the
+         * buffer base must be VMM-granularity (2 MB) aligned. Fail clearly
+         * rather than let the mlx5dv registration below return an opaque errno.
+         */
+        if (useDataDirect && dmaBuff.offset != 0) {
+          return Err(
+              ErrCode::InvalidArgument,
+              "registerSegment: Data Direct requires a 2MB-aligned buffer "
+              "(dmabuf offset must be 0), got offset " +
+                  std::to_string(dmaBuff.offset));
+        }
+        /*
+         * Data Direct registers the whole dma-buf by length; dmaBufLen is only
+         * populated by adapters that support the PCIe-mapped export. Guard
+         * against a 0 length (which would create a useless zero-length MR) in
+         * case an adapter exports a DD dmabuf without setting it.
+         */
+        if (useDataDirect && dmaBuff.dmaBufLen == 0) {
+          return Err(
+              ErrCode::InvalidArgument,
+              "registerSegment: Data Direct requires a non-zero dmaBufLen from "
+              "exportDmaBuff");
+        }
+        if (useDataDirect) {
+          UNIFLOW_LOG_INFO(
+              "registerSegment: Data Direct active for VRAM segment "
+              "(device={}, len={}, dmabufOffset={}, nics={})",
+              segment.deviceId(),
+              segment.len(),
+              dmaBuff.offset,
+              nicsHandle_->size());
+        }
+      } else if (useDataDirect) {
+        /*
+         * Data Direct was explicitly requested; do not silently downgrade to a
+         * non-DD MR (that would misreport DD bandwidth and, with multiple NICs,
+         * mix routes on one QP).
+         */
+        UNIFLOW_LOG_ERROR(
+            "registerSegment: Data Direct dmabuf export failed for VRAM "
+            "segment (device={}, ptr=0x{:x}, len={}): {}",
+            segment.deviceId(),
+            reinterpret_cast<uint64_t>(segment.mutable_data()),
+            segment.len(),
+            exportRes.error().toString());
+        return std::move(exportRes).error();
       } else if (deviceAdapter_->allowsRegMrFallback()) {
         UNIFLOW_LOG_WARN(
             "registerSegment: exportDmaBuff failed for VRAM segment "
@@ -1988,8 +2067,24 @@ RdmaTransportFactory::registerSegment(Segment& segment) {
   mrs.reserve(nicsHandle_->size());
   for (const auto& nic : *nicsHandle_) {
     Result<ibv_mr*> mrResult = Err(ErrCode::NotImplemented);
-    if (nic.dmaBufSupported && dmaBuff.fd >= 0) {
-      // Accelerator memory: register via DMA-BUF for GPU Direct RDMA.
+    if (useDataDirect && nic.dmaBufSupported && dmaBuff.fd >= 0) {
+      /*
+       * GPU memory over Data Direct: register via mlx5dv with the DATA_DIRECT
+       * access flag so the NIC DMAs to/from GPU HBM over PCIe BAR1. Data Direct
+       * registers the whole exported dma-buf from its aligned base: pass
+       * offset 0, iova = the page-aligned base (iova - offset), and the full
+       * dma-buf length.
+       */
+      mrResult = ibvApi_->mlx5dvRegDmabufMr(
+          nic.pd,
+          /*offset=*/0,
+          /*length=*/dmaBuff.dmaBufLen,
+          /*iova=*/dmaBuff.iova - dmaBuff.offset,
+          dmaBuff.fd,
+          access,
+          MLX5DV_REG_DMABUF_ACCESS_DATA_DIRECT);
+    } else if (nic.dmaBufSupported && dmaBuff.fd >= 0) {
+      // GPU memory: standard DMA-BUF GPU Direct RDMA.
       mrResult = ibvApi_->regDmabufMr(
           nic.pd,
           dmaBuff.offset,

--- a/comms/uniflow/transport/rdma/RdmaTransport.h
+++ b/comms/uniflow/transport/rdma/RdmaTransport.h
@@ -62,6 +62,12 @@ struct RdmaTransportConfig {
   size_t chunkSize{512 * 1024}; /* Transfer chunk size in bytes (512KB). */
   uint16_t pipelineDepth{2}; /* Send/recv pipeline depth (D staging slabs). */
   RdmaSlabPoolConfig slabPoolConfig{.slabNum = 0}; /* Disabled by default. */
+  /* Register GPU memory over the mlx5 Data Direct path (NIC<->GPU via PCIe
+   * BAR1) instead of the standard dmabuf path (which traverses the Grace C2C
+   * link on GB300). Only applies to NICs that expose a data-direct sysfs path;
+   * other NICs fall back to the standard path. Default off = existing behavior.
+   */
+  bool dataDirect{false};
 };
 
 /*
@@ -686,6 +692,12 @@ class RdmaTransportFactory : public TransportFactory {
   std::shared_ptr<DeviceAdapter> deviceAdapter_;
   const RdmaTransportConfig config_;
   std::shared_ptr<RdmaSlabPool> slabPool_;
+
+  /// Set once the "Data Direct requested but unavailable" fallback has been
+  /// logged, so this per-factory-invariant warning fires at most once rather
+  /// than on every registerSegment call. Atomic so the check-then-set latch is
+  /// race-free if registerSegment is ever called concurrently.
+  std::atomic<bool> dataDirectFallbackWarned_{false};
 };
 
 } // namespace uniflow

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaRegistrationHandleTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaRegistrationHandleTest.cpp
@@ -260,7 +260,11 @@ class FakeDeviceAdapter : public DeviceAdapter {
   Result<bool> isDmaBuffSupported(int) override {
     return ErrCode::NotImplemented;
   }
-  Result<DmaBuff> exportDmaBuff(int, void*, size_t) override {
+  Result<DmaBuff> exportDmaBuff(
+      int,
+      void*,
+      size_t,
+      DmaBufMapping = DmaBufMapping::Default) override {
     return ErrCode::NotImplemented;
   }
   Status closeDmaBuff(DmaBuff&) override {

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaResourcesTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaResourcesTest.cpp
@@ -1,0 +1,183 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/transport/rdma/RdmaResources.h"
+
+#include <cstdio>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "comms/uniflow/drivers/ibverbs/mock/MockIbvApi.h"
+
+using namespace uniflow;
+using ::testing::_;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+// --- dataDirectDomainMatchesGpu ---
+
+TEST(DataDirectDomainMatchTest, MatchingDomain) {
+  EXPECT_TRUE(dataDirectDomainMatchesGpu(
+      "/sys/devices/pci0008:00/0008:00:00.0/infiniband/mlx5_4",
+      "00000008:06:00.0"));
+}
+
+TEST(DataDirectDomainMatchTest, MismatchingDomain) {
+  EXPECT_FALSE(dataDirectDomainMatchesGpu(
+      "/sys/devices/pci0009:00/0009:00:00.0/infiniband/mlx5_0",
+      "00000008:06:00.0"));
+}
+
+TEST(DataDirectDomainMatchTest, DiffersOnlyByLeadingZeros) {
+  /*
+   * The domain is compared as a hex value, so widths/leading zeros are
+   * irrelevant: GPU "8" matches data-direct "pci0008".
+   */
+  EXPECT_TRUE(dataDirectDomainMatchesGpu(
+      "/sys/devices/pci0008:00/0008:00:00.0", "0008:06:00.0"));
+}
+
+TEST(DataDirectDomainMatchTest, NonZeroDomains) {
+  EXPECT_TRUE(dataDirectDomainMatchesGpu(
+      "/sys/devices/pci0018:00/0018:00:00.0", "00000018:07:00.0"));
+  EXPECT_FALSE(dataDirectDomainMatchesGpu(
+      "/sys/devices/pci0018:00/0018:00:00.0", "00000019:07:00.0"));
+}
+
+TEST(DataDirectDomainMatchTest, MalformedInputsReturnFalse) {
+  // Missing ':' in the bus id.
+  EXPECT_FALSE(dataDirectDomainMatchesGpu(
+      "/sys/devices/pci0008:00/0008:00:00.0", "00000008"));
+  // No "/pci" token in the sysfs path.
+  EXPECT_FALSE(dataDirectDomainMatchesGpu(
+      "/sys/devices/no-domain-here", "0008:06:00.0"));
+  // Non-hex domain token must not silently parse to 0 and match a pci0000 path.
+  EXPECT_FALSE(dataDirectDomainMatchesGpu(
+      "/sys/devices/pci0000:00/0000:00:00.0", "zzzz:06:00.0"));
+  // A signed token (e.g. "+8") must be rejected, not accepted by strtol.
+  EXPECT_FALSE(dataDirectDomainMatchesGpu(
+      "/sys/devices/pci0008:00/0008:00:00.0", "+8:06:00.0"));
+  // An overflowing token (strtol ERANGE -> LONG_MAX) must be rejected, not
+  // accepted as a valid value.
+  EXPECT_FALSE(dataDirectDomainMatchesGpu(
+      "/sys/devices/pci0008:00/0008:00:00.0", "ffffffffffffffffffff:06:00.0"));
+  // Empty inputs.
+  EXPECT_FALSE(dataDirectDomainMatchesGpu("", ""));
+}
+
+// --- selectDataDirectNicsForGpu ---
+
+namespace {
+
+/*
+ * Configure a mock exposing three NICs: mlx5_0 (domain 0008), mlx5_1 (domain
+ * 0009), mlx5_2 (no data-direct path). The device/context handles are opaque —
+ * the code only compares these pointers, never dereferences them — so distinct
+ * fake addresses suffice. devList is a function-local static so getDeviceList
+ * can hand back a stable ibv_device** that outlives this setup call.
+ */
+void configureThreeNicMock(NiceMock<MockIbvApi>& mock) {
+  static ibv_device* devList[3] = {
+      reinterpret_cast<ibv_device*>(0x1001),
+      reinterpret_cast<ibv_device*>(0x1002),
+      reinterpret_cast<ibv_device*>(0x1003),
+  };
+  ibv_device* const dev0 = devList[0];
+  ibv_device* const dev1 = devList[1];
+  ibv_device* const dev2 = devList[2];
+  ibv_context* const ctx0 = reinterpret_cast<ibv_context*>(0x2001);
+  ibv_context* const ctx1 = reinterpret_cast<ibv_context*>(0x2002);
+  ibv_context* const ctx2 = reinterpret_cast<ibv_context*>(0x2003);
+
+  ON_CALL(mock, getDeviceList(_)).WillByDefault([](int* numDevices) {
+    *numDevices = 3;
+    return Result<ibv_device**>(devList);
+  });
+  ON_CALL(mock, freeDeviceList(_)).WillByDefault(Return(Ok()));
+  ON_CALL(mock, closeDevice(_)).WillByDefault(Return(Ok()));
+
+  ON_CALL(mock, getDeviceName(dev0))
+      .WillByDefault(Return(Result<const char*>("mlx5_0")));
+  ON_CALL(mock, getDeviceName(dev1))
+      .WillByDefault(Return(Result<const char*>("mlx5_1")));
+  ON_CALL(mock, getDeviceName(dev2))
+      .WillByDefault(Return(Result<const char*>("mlx5_2")));
+
+  ON_CALL(mock, openDevice(dev0))
+      .WillByDefault(Return(Result<ibv_context*>(ctx0)));
+  ON_CALL(mock, openDevice(dev1))
+      .WillByDefault(Return(Result<ibv_context*>(ctx1)));
+  ON_CALL(mock, openDevice(dev2))
+      .WillByDefault(Return(Result<ibv_context*>(ctx2)));
+
+  ON_CALL(mock, mlx5dvGetDataDirectSysfsPath(ctx0, _, _))
+      .WillByDefault([](ibv_context*, char* buf, size_t len) {
+        std::snprintf(buf, len, "/sys/devices/pci0008:00/0008:00:00.0");
+        return Ok();
+      });
+  ON_CALL(mock, mlx5dvGetDataDirectSysfsPath(ctx1, _, _))
+      .WillByDefault([](ibv_context*, char* buf, size_t len) {
+        std::snprintf(buf, len, "/sys/devices/pci0009:00/0009:00:00.0");
+        return Ok();
+      });
+  // mlx5_2 has no data-direct path.
+  ON_CALL(mock, mlx5dvGetDataDirectSysfsPath(ctx2, _, _))
+      .WillByDefault(Return(Status(ErrCode::NotImplemented)));
+}
+
+} // namespace
+
+TEST(SelectDataDirectNicsTest, KeepsOnlyDomainMatchedNic) {
+  NiceMock<MockIbvApi> mock;
+  configureThreeNicMock(mock);
+
+  auto matched = selectDataDirectNicsForGpu(
+      mock, {"mlx5_0", "mlx5_1", "mlx5_2"}, "00000008:06:00.0");
+
+  EXPECT_EQ(matched, std::vector<std::string>({"mlx5_0"}));
+}
+
+TEST(SelectDataDirectNicsTest, MatchesDifferentDomain) {
+  NiceMock<MockIbvApi> mock;
+  configureThreeNicMock(mock);
+
+  auto matched = selectDataDirectNicsForGpu(
+      mock, {"mlx5_0", "mlx5_1", "mlx5_2"}, "00000009:06:00.0");
+
+  EXPECT_EQ(matched, std::vector<std::string>({"mlx5_1"}));
+}
+
+TEST(SelectDataDirectNicsTest, NoMatchReturnsEmpty) {
+  NiceMock<MockIbvApi> mock;
+  configureThreeNicMock(mock);
+
+  auto matched = selectDataDirectNicsForGpu(
+      mock, {"mlx5_0", "mlx5_1", "mlx5_2"}, "00000018:06:00.0");
+
+  EXPECT_TRUE(matched.empty());
+}
+
+TEST(SelectDataDirectNicsTest, PreservesInputOrder) {
+  NiceMock<MockIbvApi> mock;
+  configureThreeNicMock(mock);
+
+  /*
+   * Both mlx5_0 and (hypothetically) another 0008 NIC would match; here only
+   * mlx5_0 does, but the candidate order must be respected in the output.
+   */
+  auto matched = selectDataDirectNicsForGpu(
+      mock, {"mlx5_2", "mlx5_1", "mlx5_0"}, "00000008:06:00.0");
+
+  EXPECT_EQ(matched, std::vector<std::string>({"mlx5_0"}));
+}
+
+TEST(SelectDataDirectNicsTest, SkipsUnknownCandidate) {
+  NiceMock<MockIbvApi> mock;
+  configureThreeNicMock(mock);
+
+  // "mlx5_99" is not in the device list; it is silently skipped.
+  auto matched = selectDataDirectNicsForGpu(
+      mock, {"mlx5_99", "mlx5_0"}, "00000008:06:00.0");
+
+  EXPECT_EQ(matched, std::vector<std::string>({"mlx5_0"}));
+}


### PR DESCRIPTION
Summary:

`compare_rdma_bandwidth.py`: a standalone sush2/suscp runner that builds `uniflow_bench`, deploys it to two bare-metal hosts, and runs a rank0/rank1 RDMA bandwidth sweep — no MAST/torchx needed. Useful for quick GB300/H100 A/B runs over SSH.

- GB300 (aarch64 / b200a / CUDA 13) build support, plus H100 / B200.
- Flags: `--data-direct`, `--cuda-devices` / `--gpu-nics` (multi-GPU aggregate), `--ssh-user`, `--rdma-linkage {static,dynamic}`.
- Enforces a hard 30s minimum spacing between every sush2/suscp call (`--ssh-interval`, clamped to a floor) to avoid SSH-gateway blacklisting.

Reviewed By: saifhhasan

Differential Revision: D110937388


