### PR TITLE
Redesign send/recv buffer geometry (#3108)

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -31,8 +31,8 @@ int ctranPipesNvlMaxNumChannels() {
   return std::max(1, NCCL_CTRAN_MAX_NBLOCKS);
 }
 
-size_t alignDown(size_t value, size_t alignment) {
-  return (value / alignment) * alignment;
+size_t roundDownToMultiple(size_t value, size_t multiple) {
+  return multiple == 0 ? 0 : (value / multiple) * multiple;
 }
 
 } // namespace
@@ -90,14 +90,23 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         NCCL_CTRAN_HIER_AG_OVERLAP_ENABLE && comm->statex_->nLocalRanks() > 1;
     const size_t nvlSharedDevbufSize =
         ctranEffectiveP2pNvlSharedDevbufSize(comm->statex_->nLocalRanks());
-    const size_t nvlDataBufferSize = static_cast<size_t>(
-        nvlSharedDevbufSize / config.nvlConfig.pipelineDepth);
-
     config.nvlConfig.maxNumChannels = ctranPipesNvlMaxNumChannels();
-    config.nvlConfig.perChannelSize = alignDown(
-        nvlDataBufferSize /
-            static_cast<size_t>(config.nvlConfig.maxNumChannels),
-        16);
+    const size_t nvlMaxNumChannels =
+        static_cast<size_t>(config.nvlConfig.maxNumChannels);
+    const size_t nvlChannelAlign = 16ULL * config.nvlConfig.pipelineDepth;
+    config.nvlConfig.perChannelSize = roundDownToMultiple(
+        nvlSharedDevbufSize / nvlMaxNumChannels, nvlChannelAlign);
+    if (config.nvlConfig.perChannelSize == 0) {
+      CLOGF(
+          ERR,
+          "CTRAN-PRIMS: invalid NVL config; sharedDevbufSize={} maxNumChannels={} pipelineDepth={} cannot produce aligned perChannelSize",
+          nvlSharedDevbufSize,
+          config.nvlConfig.maxNumChannels,
+          config.nvlConfig.pipelineDepth);
+      return commInvalidArgument;
+    }
+    const size_t nvlDataBufferSize =
+        nvlMaxNumChannels * config.nvlConfig.perChannelSize;
 
     // LL128 buffer allocation for DeviceAllToAllv
     if (NCCL_CTRAN_DA2A_LL128_THRESHOLD > 0) {

--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -322,14 +322,32 @@ commResult_t CtranAlgo::initKernelResources() {
           &this->comm_->logMetaData_,
           "initKernelResources-nvlTransports"));
 
-  const size_t nvlPipelineSlotSize =
-      nvlSharedDevbufSize / NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH;
+  const size_t nvlPipelineDepth =
+      static_cast<size_t>(NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH);
+  const size_t nvlMaxNumChannels =
+      static_cast<size_t>(std::max(1, CTRAN_ALGO_MAX_THREAD_BLOCKS));
+  if (nvlPipelineDepth == 0) {
+    CLOGF(ERR, "CTRAN-ALGO: invalid NVL P2P config; pipelineDepth=0");
+    return commInvalidArgument;
+  }
+  const size_t nvlChannelAlign = 16ULL * nvlPipelineDepth;
+  const size_t nvlPerChannelBuffer =
+      alignDown(nvlSharedDevbufSize / nvlMaxNumChannels, nvlChannelAlign);
+  if (nvlPerChannelBuffer == 0) {
+    CLOGF(
+        ERR,
+        "CTRAN-ALGO: invalid NVL P2P config; sharedDevbufSize={} maxNumChannels={} pipelineDepth={} cannot produce aligned per-channel buffer",
+        nvlSharedDevbufSize,
+        nvlMaxNumChannels,
+        nvlPipelineDepth);
+    return commInvalidArgument;
+  }
   comms::prims::P2pNvlTransportOptions options{
-      .dataBufferSize = nvlPipelineSlotSize,
-      .pipelineDepth = NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH,
-      .per_channel_slot =
-          alignDown(nvlPipelineSlotSize / CTRAN_ALGO_MAX_THREAD_BLOCKS, 16),
-      .max_num_channels = CTRAN_ALGO_MAX_THREAD_BLOCKS};
+      .dataBufferSize = nvlMaxNumChannels * nvlPerChannelBuffer,
+      .pipelineDepth = nvlPipelineDepth,
+      .per_channel_buffer = nvlPerChannelBuffer,
+      .per_channel_slot = nvlPerChannelBuffer / nvlPipelineDepth,
+      .max_num_channels = static_cast<int>(nvlMaxNumChannels)};
 
   for (int peer = 0; peer < nLocalRanks; peer++) {
     // Skip self - slot remains default-constructed (unused)

--- a/comms/prims/docs/Channels.md
+++ b/comms/prims/docs/Channels.md
@@ -87,8 +87,10 @@ The same channel id exists on both ranks. Each rank owns its own
 
 NVLink uses fixed channel geometry. `maxNumChannels` and `perChannelSize` are
 selected at host transport construction and remain stable across kernel
-launches. This keeps the staging-buffer slice for channel `c` stable even when
-a later kernel uses fewer active groups.
+launches. Each channel owns one contiguous `perChannelSize` staging window,
+split into `pipelineDepth` slots of size `perChannelSize / pipelineDepth`.
+This keeps the staging-buffer window for channel `c` stable even when a later
+kernel uses fewer active groups.
 
 ## IB
 

--- a/comms/prims/docs/DirectIbReduceScatter.md
+++ b/comms/prims/docs/DirectIbReduceScatter.md
@@ -55,6 +55,9 @@ IB staging:
 - `pipelineDepth = 4`
 - `qpsPerConnection = 1`
 
+Here `perChannelSize` is the total staging window for one channel, so the
+transport chunk size is `perChannelSize / pipelineDepth = 128KB`.
+
 Each rank exchanges transport metadata, materializes every non-self peer, and
 passes the peer device handles to the launch params. The future CTran/MCCL hook
 should move that transport ownership to communicator lifetime so standard

--- a/comms/prims/tests/AllGatherTest.cc
+++ b/comms/prims/tests/AllGatherTest.cc
@@ -98,10 +98,18 @@ TEST_P(AllGatherTest, AllGatherBasic) {
   const size_t sendcount = numIntsPerRank * sizeof(int32_t);
   const size_t recvBufferSize = worldSize * sendcount;
 
+  constexpr std::size_t pipelineDepth = 4;
+  constexpr int maxNumChannels = 64;
+  const std::size_t requestedPerChannelSize =
+      (std::max(size_t(2048), recvBufferSize) + maxNumChannels - 1) /
+      maxNumChannels;
+  const std::size_t chunkAlign = 16 * pipelineDepth;
   MultiPeerNvlTransportConfig config{
-      .pipelineDepth = 4,
-      .maxNumChannels = 64,
-      .perChannelSize = (std::max(size_t(2048), recvBufferSize)) / 64,
+      .pipelineDepth = pipelineDepth,
+      .maxNumChannels = maxNumChannels,
+      .perChannelSize =
+          ((requestedPerChannelSize + chunkAlign - 1) / chunkAlign) *
+          chunkAlign,
   };
 
   // Create transport and exchange IPC handles

--- a/comms/prims/tests/ExternalStagingBuffersTest.cc
+++ b/comms/prims/tests/ExternalStagingBuffersTest.cc
@@ -117,8 +117,7 @@ TEST_F(ExternalStagingBuffersTestFixture, TransportUsesExternalBuffers) {
   }
 
   auto config = defaultConfig();
-  const std::size_t perPeerDataSize =
-      config.pipelineDepth * dataBufferSize(config);
+  const std::size_t perPeerDataSize = dataBufferSize(config);
   auto bootstrap = std::make_shared<MpiBootstrap>();
 
   // Allocate external buffers via IPC
@@ -174,8 +173,7 @@ TEST_F(ExternalStagingBuffersTestFixture, IpcMemAccessThroughExternalBuffers) {
   auto config = defaultConfig();
   config.maxNumChannels = 1;
   config.perChannelSize = sizeof(int) * kNumElements;
-  const std::size_t perPeerDataSize =
-      config.pipelineDepth * dataBufferSize(config);
+  const std::size_t perPeerDataSize = dataBufferSize(config);
   auto bootstrap = std::make_shared<MpiBootstrap>();
 
   // Allocate external buffers via IPC
@@ -287,8 +285,7 @@ TEST_F(ExternalStagingBuffersTestFixture, StateAndSignalBuffersStillAllocated) {
   }
 
   auto config = defaultConfig();
-  const std::size_t perPeerDataSize =
-      config.pipelineDepth * dataBufferSize(config);
+  const std::size_t perPeerDataSize = dataBufferSize(config);
   auto bootstrap = std::make_shared<MpiBootstrap>();
 
   auto extBuf = allocateExternalBuffers(bootstrap, perPeerDataSize);

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -278,6 +278,60 @@ TEST_P(MultipeerIbTransportTestFixture, ConstructAndExchange) {
   XLOGF(INFO, "Rank {}: ConstructAndExchange test completed", globalRank);
 }
 
+TEST_P(MultipeerIbTransportTestFixture, PipelineGeometry) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+
+  constexpr std::size_t perChannelBufferSize = 64 * 1024;
+  constexpr int maxGroups = 4;
+  constexpr int pipelineDepth = 4;
+  constexpr int numBlocks = 1;
+  constexpr int blockSize = 32;
+  constexpr std::size_t pipelineChunk =
+      perChannelBufferSize / static_cast<std::size_t>(pipelineDepth);
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+
+  try {
+    MultipeerIbTransportConfig config{
+        .cudaDevice = localRank,
+        .perChannelSize = perChannelBufferSize,
+        .max_num_channels = maxGroups,
+        .pipelineDepth = pipelineDepth,
+    };
+
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    TestIbTransport transport(
+        backend(), globalRank, numRanks, std::move(bootstrap), config);
+    DeviceBuffer outputBuffer(3 * sizeof(uint64_t));
+    auto* dOutput = static_cast<uint64_t*>(outputBuffer.get());
+    CUDACHECK_TEST(cudaMemset(dOutput, 0, 3 * sizeof(uint64_t)));
+
+    test::testPipelineGeometry(
+        transport.getP2pTransportDevice(peerRank),
+        dOutput,
+        numBlocks,
+        blockSize);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::array<uint64_t, 3> output{};
+    CUDACHECK_TEST(cudaMemcpy(
+        output.data(),
+        dOutput,
+        output.size() * sizeof(uint64_t),
+        cudaMemcpyDeviceToHost));
+
+    EXPECT_EQ(output[0], static_cast<uint64_t>(pipelineDepth));
+    EXPECT_EQ(output[1], static_cast<uint64_t>(perChannelBufferSize));
+    EXPECT_EQ(output[2], static_cast<uint64_t>(pipelineChunk));
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << backendName(backend())
+                 << " transport not available: " << e.what();
+  }
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
 // =============================================================================
 // Put/Signal Basic Test - Verifies RDMA data transfer correctness
 // =============================================================================
@@ -1437,9 +1491,9 @@ TEST_F(
     GTEST_SKIP() << "progress send/recv is not supported for this build";
   }
 
-  constexpr std::size_t dataBufferSize = 64 * 1024;
+  constexpr std::size_t perChannelBufferSize = 64 * 1024;
   constexpr int pipelineDepth = 2;
-  constexpr std::size_t nbytes = 4 * pipelineDepth * dataBufferSize;
+  constexpr std::size_t nbytes = 8 * perChannelBufferSize;
   constexpr std::size_t maxSignalBytes = 0;
   constexpr int numBlocks = 1;
   constexpr int blockSize = 128;
@@ -1450,7 +1504,7 @@ TEST_F(
   try {
     MultipeerIbgdaTransportConfig config{
         .cudaDevice = localRank,
-        .perChannelSize = dataBufferSize / numBlocks,
+        .perChannelSize = perChannelBufferSize / numBlocks,
         .max_num_channels = numBlocks,
         .pipelineDepth = pipelineDepth,
     };

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -311,6 +311,33 @@ void testPutOnly(
 }
 
 // =============================================================================
+// Kernel: Pipeline geometry snapshot
+// =============================================================================
+
+__global__ void pipelineGeometryKernel(
+    P2pIbTransportDevice transport,
+    uint64_t* output) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    output[0] = static_cast<uint64_t>(transport.pipeline_depth());
+    output[1] = static_cast<uint64_t>(transport.pipeline_window());
+    output[2] = static_cast<uint64_t>(transport.pipeline_chunk());
+  }
+}
+
+void testPipelineGeometry(
+    P2pIbTransportDevice transport,
+    uint64_t* output,
+    int numBlocks,
+    int blockSize) {
+  pipelineGeometryKernel<<<numBlocks, blockSize>>>(transport, output);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
+// =============================================================================
 // Kernel: Blocking send/recv and resumable progress send/recv
 // =============================================================================
 

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
@@ -71,6 +71,10 @@ __global__ void putOnlyKernel(
     IbgdaRemoteBuffer remoteBuf,
     std::size_t nbytes);
 
+__global__ void pipelineGeometryKernel(
+    P2pIbTransportDevice transport,
+    uint64_t* output);
+
 __global__ void sendRecvKernel(
     P2pIbgdaTransportDevice* transport,
     void* buffer,

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -123,6 +123,16 @@ void testPutOnly(
 bool supportsProgressSendRecv();
 
 /**
+ * Test kernel: snapshot send/recv pipeline geometry through the unified IB
+ * transport wrapper. Output: pipelineDepth, pipelineWindow, pipelineChunk.
+ */
+void testPipelineGeometry(
+    P2pIbTransportDevice transport,
+    uint64_t* output,
+    int numBlocks,
+    int blockSize);
+
+/**
  * Test kernel: Blocking pipelined send or recv.
  */
 void testSendRecv(

--- a/comms/prims/tests/P2pNvlTransportTest.cc
+++ b/comms/prims/tests/P2pNvlTransportTest.cc
@@ -38,13 +38,18 @@ class P2pNvlTransportTestFixture : public MpiBaseTestFixture {
 };
 
 MultiPeerNvlTransportConfig makeNvlConfig(
-    std::size_t perChannelSize,
+    std::size_t dataBufferSize,
     std::size_t pipelineDepth,
     int maxNumChannels = 1) {
+  const auto channels = static_cast<std::size_t>(maxNumChannels);
+  const std::size_t chunkAlign = 16 * std::max<std::size_t>(pipelineDepth, 1);
+  const std::size_t perChannelSize =
+      std::max<std::size_t>(16, ((dataBufferSize + channels - 1) / channels));
   return MultiPeerNvlTransportConfig{
       .pipelineDepth = pipelineDepth,
       .maxNumChannels = maxNumChannels,
-      .perChannelSize = (perChannelSize + 15) & ~15ULL,
+      .perChannelSize =
+          ((perChannelSize + chunkAlign - 1) / chunkAlign) * chunkAlign,
   };
 }
 
@@ -61,6 +66,33 @@ static void expectTwoCallPattern(
     int numBlocks,
     int sourceRank,
     const std::string& label);
+
+TEST_F(P2pNvlTransportTestFixture, PipelineGeometry) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  constexpr std::size_t perChannelBufferSize = 64 * 1024;
+  constexpr std::size_t pipelineDepth = 4;
+  constexpr int maxNumChannels = 8;
+  constexpr std::size_t pipelineChunk = perChannelBufferSize / pipelineDepth;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+
+  MultiPeerNvlTransportConfig config{
+      .pipelineDepth = pipelineDepth,
+      .maxNumChannels = maxNumChannels,
+      .perChannelSize = perChannelBufferSize,
+  };
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  auto p2p = transport.buildP2pTransportDevice(peerRank);
+
+  EXPECT_EQ(p2p.pipeline_depth(), pipelineDepth);
+  EXPECT_EQ(p2p.pipeline_window(), perChannelBufferSize);
+  EXPECT_EQ(p2p.pipeline_chunk(), pipelineChunk);
+}
 
 TEST_F(P2pNvlTransportTestFixture, IpcMemAccess) {
   // Only test with 2 ranks
@@ -653,7 +685,7 @@ static void expectPersistentTwoCallStagingPattern(
 }
 
 // Build a P2pNvlTransportDevice for tile tests that bypass
-// MultiPeerNvlTransport. The options must already have per_channel_slot and
+// MultiPeerNvlTransport. The options must already have channel geometry and
 // max_num_channels populated.
 static P2pNvlTransportDevice makeLocalTileDevice(
     const P2pNvlTransportOptions& options,
@@ -689,7 +721,7 @@ class LocalTileHarness {
   LocalTileHarness(const P2pNvlTransportOptions& options, int numBlocks)
       : options_(options),
         numBlocks_(numBlocks),
-        stagingBytes_(options.dataBufferSize * options.pipelineDepth),
+        stagingBytes_(options.dataBufferSize),
         channelBytes_(sizeof(NvlChannelState) * numBlocks),
         stagingBuf_(stagingBytes_),
         channelBuf_(channelBytes_) {
@@ -992,8 +1024,9 @@ TEST_F(
   const size_t totalBytes = tileBytes * numBlocks;
 
   P2pNvlTransportOptions options{
-      .dataBufferSize = tileBytes * numBlocks,
+      .dataBufferSize = tileBytes * 2 * numBlocks,
       .pipelineDepth = 2,
+      .per_channel_buffer = tileBytes * 2,
       .per_channel_slot = tileBytes,
       .max_num_channels = numBlocks,
   };
@@ -1102,8 +1135,9 @@ TEST_F(
                         perBlockSlotSize);
 
   P2pNvlTransportOptions options{
-      .dataBufferSize = perBlockSlotSize * numBlocks,
+      .dataBufferSize = perBlockSlotSize * 2 * numBlocks,
       .pipelineDepth = 2,
+      .per_channel_buffer = perBlockSlotSize * 2,
       .per_channel_slot = perBlockSlotSize,
       .max_num_channels = numBlocks,
   };
@@ -1222,8 +1256,9 @@ TEST_F(
                         perBlockSlotSize);
 
   P2pNvlTransportOptions options{
-      .dataBufferSize = perBlockSlotSize * numBlocks,
+      .dataBufferSize = perBlockSlotSize * 2 * numBlocks,
       .pipelineDepth = 2,
+      .per_channel_buffer = perBlockSlotSize * 2,
       .per_channel_slot = perBlockSlotSize,
       .max_num_channels = numBlocks,
   };
@@ -1325,8 +1360,9 @@ TEST_F(
   const size_t totalBytes = tileBytes * numBlocks;
 
   P2pNvlTransportOptions options{
-      .dataBufferSize = perBlockSlotSize * numBlocks,
+      .dataBufferSize = perBlockSlotSize * 2 * numBlocks,
       .pipelineDepth = 2,
+      .per_channel_buffer = perBlockSlotSize * 2,
       .per_channel_slot = perBlockSlotSize,
       .max_num_channels = numBlocks,
   };
@@ -1392,8 +1428,9 @@ TEST_F(
   const size_t totalBytes = tileBytes * numBlocks;
 
   P2pNvlTransportOptions options{
-      .dataBufferSize = perBlockSlotSize * numBlocks,
+      .dataBufferSize = perBlockSlotSize * 2 * numBlocks,
       .pipelineDepth = 2,
+      .per_channel_buffer = perBlockSlotSize * 2,
       .per_channel_slot = perBlockSlotSize,
       .max_num_channels = numBlocks,
   };
@@ -1554,8 +1591,9 @@ TEST_F(P2pNvlTransportTestFixture, TileSendAndForwardWaitForWrappedSubstepAck) {
   const unsigned char forwardPattern = 0x55;
 
   P2pNvlTransportOptions options{
-      .dataBufferSize = perBlockSlotSize * numBlocks,
+      .dataBufferSize = perBlockSlotSize * pipelineDepth * numBlocks,
       .pipelineDepth = pipelineDepth,
+      .per_channel_buffer = perBlockSlotSize * pipelineDepth,
       .per_channel_slot = perBlockSlotSize,
       .max_num_channels = numBlocks,
   };
@@ -2840,7 +2878,8 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardDesynchronizedStepState) {
     CUDACHECK_TEST(cudaMemset(
         p2pHost.getLocalState().dataBuffer,
         0,
-        config.pipelineDepth * kDataBufferSize));
+        static_cast<std::size_t>(config.maxNumChannels) *
+            config.perChannelSize));
     CUDACHECK_TEST(cudaDeviceSynchronize());
   }
 
@@ -2976,12 +3015,13 @@ TEST_F(
   const size_t totalBytes = tileBytes * numBlocks;
 
   P2pNvlTransportOptions options{
-      .dataBufferSize = tileBytes * numBlocks,
+      .dataBufferSize = tileBytes * 2 * numBlocks,
       .pipelineDepth = 2,
+      .per_channel_buffer = tileBytes * 2,
       .per_channel_slot = tileBytes,
       .max_num_channels = numBlocks,
   };
-  const size_t stagingBytes = options.dataBufferSize * options.pipelineDepth;
+  const size_t stagingBytes = options.dataBufferSize;
 
   DeviceBuffer sourceStagingBuf(stagingBytes);
   DeviceBuffer forwardedStagingBuf(stagingBytes);

--- a/comms/prims/tests/P2pNvlTransportTest.cu
+++ b/comms/prims/tests/P2pNvlTransportTest.cu
@@ -276,13 +276,13 @@ __device__ void check_wrapped_substep_with_existing_signals(
     unsigned char sentinel,
     int* observedEarlyOverwrite,
     const Timeout& timeout) {
-  const size_t slotSize = p2p.options().dataBufferSize;
+  const size_t perChannelBuffer = p2p.options().per_channel_buffer;
   const size_t perBlockSlotSize = p2p.options().per_channel_slot;
   const size_t effectiveChunk =
       maxSignalBytes > 0 && maxSignalBytes < perBlockSlotSize
       ? (maxSignalBytes & ~15ULL)
       : perBlockSlotSize;
-  const size_t pipelineBytes = perBlockSlotSize * p2p.options().pipelineDepth;
+  const size_t pipelineBytes = perChannelBuffer;
   // blockId 0 by construction in this test (kernel launched with 2 blocks,
   // block 0 is sender/forwarder, block 1 is this checker).
   const uint64_t streamStart =
@@ -295,7 +295,7 @@ __device__ void check_wrapped_substep_with_existing_signals(
   const size_t targetSlot = targetPipelineOff / perBlockSlotSize;
   const size_t targetChunkOff =
       targetPipelineOff - targetSlot * perBlockSlotSize;
-  const size_t targetOffset = targetSlot * slotSize + targetChunkOff;
+  const size_t targetOffset = targetSlot * perBlockSlotSize + targetChunkOff;
   const uint64_t targetStreamEnd = targetStreamStart + effectiveChunk;
   const uint64_t targetAckValue = targetStreamEnd - pipelineBytes;
 
@@ -369,15 +369,15 @@ __global__ void testPrepareTileStagingKernel(
   const int blockId = group.group_id;
   char* staging = p2p.local_state().dataBuffer;
 
-  const size_t slotSize = p2p.options().dataBufferSize;
+  const size_t perChannelBuffer = p2p.options().per_channel_buffer;
   const size_t perBlockSlotSize = p2p.options().per_channel_slot;
   const size_t chunkSize =
       maxSignalBytes > 0 && maxSignalBytes < perBlockSlotSize
       ? (maxSignalBytes & ~15ULL)
       : perBlockSlotSize;
   const size_t effectiveChunk = chunkSize > 0 ? chunkSize : perBlockSlotSize;
-  const size_t pipelineBytes = perBlockSlotSize * p2p.options().pipelineDepth;
-  const size_t stagingOff = blockId * perBlockSlotSize;
+  const size_t pipelineBytes = perChannelBuffer;
+  const size_t stagingOff = blockId * perChannelBuffer;
 
   uint64_t baseByte = 0;
   for (int call = 0; call < numCalls; ++call) {
@@ -399,7 +399,7 @@ __global__ void testPrepareTileStagingKernel(
         const size_t remaining = bytesPerCall - dataOff;
         validBytes = copyBytes < remaining ? copyBytes : remaining;
       }
-      const size_t bufferOff = slot * slotSize + stagingOff + chunkOff;
+      const size_t bufferOff = stagingOff + slot * perBlockSlotSize + chunkOff;
       for (size_t idx = group.thread_id_in_group; idx < validBytes;
            idx += group.group_size) {
         staging[bufferOff + idx] = pattern;
@@ -430,14 +430,14 @@ __global__ void testPrepareTileTwoCallStagingKernel(
   const int blockId = group.group_id;
   char* staging = p2p.local_state().dataBuffer;
 
-  const size_t slotSize = p2p.options().dataBufferSize;
+  const size_t perChannelBuffer = p2p.options().per_channel_buffer;
   const size_t perBlockSlotSize = p2p.options().per_channel_slot;
   const size_t effectiveChunk =
       maxSignalBytes > 0 && maxSignalBytes < perBlockSlotSize
       ? (maxSignalBytes & ~15ULL)
       : perBlockSlotSize;
-  const size_t pipelineBytes = perBlockSlotSize * p2p.options().pipelineDepth;
-  const size_t stagingOff = blockId * perBlockSlotSize;
+  const size_t pipelineBytes = perChannelBuffer;
+  const size_t stagingOff = blockId * perChannelBuffer;
 
   uint64_t baseByte = 0;
   for (int call = 0; call < 2; ++call) {
@@ -460,7 +460,7 @@ __global__ void testPrepareTileTwoCallStagingKernel(
         const size_t remaining = callBytes - dataOff;
         validBytes = copyBytes < remaining ? copyBytes : remaining;
       }
-      const size_t bufferOff = slot * slotSize + stagingOff + chunkOff;
+      const size_t bufferOff = stagingOff + slot * perBlockSlotSize + chunkOff;
       for (size_t idx = group.thread_id_in_group; idx < validBytes;
            idx += group.group_size) {
         staging[bufferOff + idx] = pattern;

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -365,21 +365,29 @@ void MultiPeerIbTransportBase::validateSendRecvConfig() const {
         "MultiPeerIbTransport: dataBufferSize must be > 0 when send/recv is "
         "enabled");
   }
-  if ((config_.dataBufferSize /
-       static_cast<std::size_t>(config_.max_num_channels)) < 16) {
+  if (config_.perChannelSize %
+          static_cast<std::size_t>(config_.pipelineDepth) !=
+      0) {
     throw std::invalid_argument(
         fmt::format(
-            "MultiPeerIbTransport: dataBufferSize / max_num_channels must be >= 16, "
-            "got {} / {} = {}",
-            config_.dataBufferSize,
-            config_.max_num_channels,
-            config_.dataBufferSize / config_.max_num_channels));
+            "MultiPeerIbTransport: perChannelSize must be divisible by pipelineDepth, got {} / {}",
+            config_.perChannelSize,
+            config_.pipelineDepth));
+  }
+  const std::size_t pipelineChunk =
+      config_.perChannelSize / static_cast<std::size_t>(config_.pipelineDepth);
+  if (pipelineChunk < 16 || pipelineChunk % 16 != 0) {
+    throw std::invalid_argument(
+        fmt::format(
+            "MultiPeerIbTransport: perChannelSize / pipelineDepth must be a 16-byte aligned chunk >= 16, got {} / {} = {}",
+            config_.perChannelSize,
+            config_.pipelineDepth,
+            pipelineChunk));
   }
 }
 
 std::size_t MultiPeerIbTransportBase::sendRecvStagingBytesPerPeer() const {
-  return static_cast<std::size_t>(config_.pipelineDepth) *
-      config_.dataBufferSize;
+  return config_.dataBufferSize;
 }
 
 std::size_t MultiPeerIbTransportBase::sendRecvSignalBytesPerPeer() const {
@@ -424,6 +432,7 @@ IbChannelLayout MultiPeerIbTransportBase::channelLayoutForPeer(
       .numLanes = numNics_ * config_.qpsPerConnection,
       .pipelineDepth = config_.pipelineDepth,
       .perChannelSize = config_.perChannelSize,
+      .perChannelBufferSize = config_.perChannelSize,
   };
 }
 

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -64,14 +64,14 @@ struct MultipeerIbTransportConfig {
   std::string ibHca;
 
   // Per-peer data buffer size in bytes for raw put()/signal() users. When
-  // perChannelSize is set for send()/recv(), the transport derives this as
-  // perChannelSize * max_num_channels.
+  // perChannelSize is set for send()/recv(), the transport derives this as the
+  // total fixed-channel staging size:
+  //   perChannelSize * max_num_channels
   std::size_t dataBufferSize{0};
 
-  // Fixed-channel send/recv staging slice size in bytes. When this is nonzero,
-  // send/recv staging geometry is:
-  //   dataBufferSize = perChannelSize * max_num_channels
-  // where dataBufferSize is the derived size of one pipeline slot across all
+  // Fixed-channel send/recv staging window size in bytes for one channel. When
+  // this is nonzero, pipelineDepth is the number of chunks within this channel
+  // window and dataBufferSize is derived as the total staging size across all
   // channels.
   std::size_t perChannelSize{0};
 
@@ -80,7 +80,7 @@ struct MultipeerIbTransportConfig {
   // scoped by (channel, direction, NIC).
   int max_num_channels{64};
 
-  // Fixed-channel send/recv pipeline depth.
+  // Fixed-channel send/recv slots/chunks per channel.
   int pipelineDepth{2};
 
   // Number of signal slots managed by the transport (per peer), for the
@@ -517,8 +517,8 @@ class MultiPeerIbTransportBase {
   // ---- shared send/recv staging-ring lifecycle (eager mode) ----
   // Backend-agnostic host send/recv buffer management, shared by IBGDA (Device
   // counter, NIC loopback atomic) and IBRC (Host counter, CPU proxy). Staging
-  // = pipelineDepth * dataBufferSize per direction; signal is sized off
-  // max_num_channels. Per-peer staging + signal are device-registered;
+  // = max_num_channels * perChannelSize per direction; signal is sized
+  // off max_num_channels. Per-peer staging + signal are device-registered;
   // recvStaging + signal are collectively exchanged so peers can RDMA into our
   // ring.
   bool sendRecvBuffersEnabled() const {

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -557,6 +557,21 @@ __device__ __forceinline__ std::size_t P2pIbTransportDevice::pipeline_window()
   return ibgda->pipeline_window();
 }
 
+__device__ __forceinline__ int P2pIbTransportDevice::pipeline_depth() const {
+  if (type == P2pIbBackendType::IBRC) {
+    return ibrc->pipeline_depth();
+  }
+  return ibgda->pipeline_depth();
+}
+
+__device__ __forceinline__ std::size_t P2pIbTransportDevice::pipeline_chunk()
+    const {
+  if (type == P2pIbBackendType::IBRC) {
+    return ibrc->pipeline_chunk();
+  }
+  return ibgda->pipeline_chunk();
+}
+
 __device__ __forceinline__ void P2pIbTransportDevice::init_send_progress(
     ThreadGroup& group,
     std::size_t nbytes,

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -96,6 +96,7 @@ struct ProgressGeometry {
   std::size_t payloadBytes;
   std::size_t protocolBytes;
   std::size_t perBlockSlot;
+  std::size_t perChannelBufferSize;
   std::size_t chunkSize;
   int pipelineDepth;
 };
@@ -132,6 +133,12 @@ tail_padding_for_signal_granularity(
     std::size_t maxSignalBytes,
     std::size_t perBlockSlot,
     std::size_t payloadBytes);
+
+__device__ __forceinline__ std::size_t pipeline_window(
+    const IbChannelLayout& channelLayout);
+
+__device__ __forceinline__ std::size_t pipeline_chunk(
+    const IbChannelLayout& channelLayout);
 
 __device__ __forceinline__ void assert_progress_slot_idle(
     ThreadGroup& group,
@@ -191,7 +198,6 @@ __device__ __forceinline__ ProgressChunk next_chunk(
  * `P2pIbrcTransportDevice` own the channel layout/state and use these helpers
  * only for the shared send/recv algorithm.
  */
-
 /**
  * Initialize transport-owned state for one pipelined send operation.
  *
@@ -731,7 +737,6 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
   }
   group.sync();
 
-  // SLOT_FREE, posted unbatched every chunk back to the sender.
   transport.signal(
       group, remoteChannel.slotFree, protocolBytesThis, IbDirection::Recv);
 
@@ -829,14 +834,14 @@ __device__ __forceinline__ void send(
     PIPES_DEVICE_TRAP();
   }
 
-  const std::size_t perBlockSlot = channelLayout.perChannelSize & ~15ULL;
+  const std::size_t perBlockSlot = pipeline_chunk(channelLayout);
   if (perBlockSlot == 0) {
     if (group.is_leader()) {
       printf(
           "[PIPES] FATAL: send perBlockSlot=0 "
-          "(dataBufferSize=%llu, maxGroups=%d)\n",
-          (unsigned long long)channelLayout.data_buffer_size(),
-          maxGroups);
+          "(perChannelBufferSize=%llu, pipelineDepth=%d)\n",
+          (unsigned long long)pipeline_window(channelLayout),
+          channelLayout.pipelineDepth);
     }
     PIPES_DEVICE_TRAP();
   }
@@ -849,8 +854,6 @@ __device__ __forceinline__ void send(
     chunkSize = perBlockSlot;
   }
 
-  const int pipelineDepth = channelLayout.pipelineDepth;
-  const std::size_t dataBufferSize = channelLayout.data_buffer_size();
   auto& state = progress_send_slot(transport, group);
   IbLocalChannel& localChannel =
       transport.local_channel(static_cast<uint32_t>(groupId));
@@ -866,7 +869,7 @@ __device__ __forceinline__ void send(
       baseByte, max_signal_bytes, perBlockSlot, nbytes);
   const uint64_t payloadBaseByte = baseByte;
   const std::size_t protocolBytes = payloadProtocolBytes + protocolTailPadding;
-  const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
+  const std::size_t pipelineBytes = pipeline_window(channelLayout);
   if (group.is_leader()) {
     state.activeStage = detail::IbSendRecvProgressStage::Busy;
     state.activeBaseStep = static_cast<int64_t>(baseByte);
@@ -879,7 +882,7 @@ __device__ __forceinline__ void send(
     const std::size_t pipelineOff =
         static_cast<std::size_t>(streamStart % pipelineBytes);
     const int slot = static_cast<int>(pipelineOff / perBlockSlot);
-    const std::size_t slotOff = slot * dataBufferSize;
+    const std::size_t slotOff = static_cast<std::size_t>(slot) * perBlockSlot;
     const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
     const std::size_t slotRemaining = perBlockSlot - chunkOff;
     const std::size_t dataRemaining = payloadProtocolBytes - dataOff;
@@ -889,7 +892,8 @@ __device__ __forceinline__ void send(
     const bool isFinalChunk = dataOff + bytesThis >= payloadProtocolBytes;
     const std::size_t protocolBytesThis =
         bytesThis + (isFinalChunk ? protocolTailPadding : 0);
-    const std::size_t stagingOff = slotOff + groupId * perBlockSlot + chunkOff;
+    const std::size_t stagingOff =
+        static_cast<std::size_t>(groupId) * pipelineBytes + slotOff + chunkOff;
     const uint64_t protocolStreamEnd = streamStart + protocolBytesThis;
 
     // (1) Wait for NIC to finish with this slot's local sendStaging.
@@ -1015,14 +1019,14 @@ __device__ __forceinline__ void recv(
     PIPES_DEVICE_TRAP();
   }
 
-  const std::size_t perBlockSlot = channelLayout.perChannelSize & ~15ULL;
+  const std::size_t perBlockSlot = pipeline_chunk(channelLayout);
   if (perBlockSlot == 0) {
     if (group.is_leader()) {
       printf(
           "[PIPES] FATAL: recv perBlockSlot=0 "
-          "(dataBufferSize=%llu, maxGroups=%d)\n",
-          (unsigned long long)channelLayout.data_buffer_size(),
-          maxGroups);
+          "(perChannelBufferSize=%llu, pipelineDepth=%d)\n",
+          (unsigned long long)pipeline_window(channelLayout),
+          channelLayout.pipelineDepth);
     }
     PIPES_DEVICE_TRAP();
   }
@@ -1035,8 +1039,6 @@ __device__ __forceinline__ void recv(
     chunkSize = perBlockSlot;
   }
 
-  const int pipelineDepth = channelLayout.pipelineDepth;
-  const std::size_t dataBufferSize = channelLayout.data_buffer_size();
   auto& state = progress_recv_slot(transport, group);
   IbLocalChannel& localChannel =
       transport.local_channel(static_cast<uint32_t>(groupId));
@@ -1049,7 +1051,7 @@ __device__ __forceinline__ void recv(
       baseByte, max_signal_bytes, perBlockSlot, nbytes);
   const uint64_t payloadBaseByte = baseByte;
   const std::size_t protocolBytes = payloadProtocolBytes + protocolTailPadding;
-  const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
+  const std::size_t pipelineBytes = pipeline_window(channelLayout);
   if (group.is_leader()) {
     state.activeStage = detail::IbSendRecvProgressStage::Busy;
     state.activeBaseStep = static_cast<int64_t>(baseByte);
@@ -1062,7 +1064,7 @@ __device__ __forceinline__ void recv(
     const std::size_t pipelineOff =
         static_cast<std::size_t>(streamStart % pipelineBytes);
     const int slot = static_cast<int>(pipelineOff / perBlockSlot);
-    const std::size_t slotOff = slot * dataBufferSize;
+    const std::size_t slotOff = static_cast<std::size_t>(slot) * perBlockSlot;
     const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
     const std::size_t slotRemaining = perBlockSlot - chunkOff;
     const std::size_t dataRemaining = payloadProtocolBytes - dataOff;
@@ -1072,7 +1074,8 @@ __device__ __forceinline__ void recv(
     const bool isFinalChunk = dataOff + bytesThis >= payloadProtocolBytes;
     const std::size_t protocolBytesThis =
         bytesThis + (isFinalChunk ? protocolTailPadding : 0);
-    const std::size_t stagingOff = slotOff + groupId * perBlockSlot + chunkOff;
+    const std::size_t stagingOff =
+        static_cast<std::size_t>(groupId) * pipelineBytes + slotOff + chunkOff;
 
     // (1) Wait for sender's DATA_READY on the specific round-robin lane that
     //     carried this chunk (mirrors the sender's per-channel Send cursor).
@@ -1098,9 +1101,6 @@ __device__ __forceinline__ void recv(
     }
     group.sync();
 
-    // (3) Signal SLOT_FREE to sender, posted unbatched every chunk. Sender
-    //     waits on the cumulative byte threshold before reusing remote
-    //     recvStaging at the same offset.
     transport.signal(
         group, remoteChannel.slotFree, protocolBytesThis, IbDirection::Recv);
     dataOff += bytesThis;
@@ -1164,7 +1164,8 @@ __device__ __forceinline__ void recv(
  *                        CopyOp handles it, e.g. reduce-scatter).
  * @param fwdTransport    Forward transport (sends to next peer in ring).
  * @param nbytes          Bytes to receive and forward.
- * @param max_signal_bytes Max bytes per signaled sub-chunk. 0 = perBlockSlot.
+ * @param max_signal_bytes Max bytes per signaled sub-chunk. 0 =
+ * perBlockSlot.
  * @param timeout         Optional timeout for wait operations.
  * @param args            Extra args forwarded to CopyOp::forward.
  */
@@ -1205,7 +1206,7 @@ __device__ __forceinline__ void forward(
     PIPES_DEVICE_TRAP();
   }
 
-  const std::size_t recvPerBlockSlot = channelLayout.perChannelSize & ~15ULL;
+  const std::size_t recvPerBlockSlot = pipeline_chunk(channelLayout);
   if (recvPerBlockSlot == 0) {
     if (group.is_leader()) {
       printf("[PIPES] FATAL: forward recvPerBlockSlot=0\n");
@@ -1225,7 +1226,7 @@ __device__ __forceinline__ void forward(
     PIPES_DEVICE_TRAP();
   }
 
-  const std::size_t fwdPerBlockSlot = fwdChannelLayout.perChannelSize & ~15ULL;
+  const std::size_t fwdPerBlockSlot = pipeline_chunk(fwdChannelLayout);
   if (fwdPerBlockSlot == 0) {
     if (group.is_leader()) {
       printf("[PIPES] FATAL: forward fwdPerBlockSlot=0\n");
@@ -1249,8 +1250,6 @@ __device__ __forceinline__ void forward(
     fwdChunkSize = fwdPerBlockSlot;
   }
 
-  const int recvPipelineDepth = channelLayout.pipelineDepth;
-  const std::size_t recvDataBufSize = channelLayout.data_buffer_size();
   auto& recvSlotState = progress_recv_slot(transport, group);
   IbLocalChannel& recvLocalChannel =
       transport.local_channel(static_cast<uint32_t>(groupId));
@@ -1265,10 +1264,8 @@ __device__ __forceinline__ void forward(
   const uint64_t recvPayloadBaseByte = recvBaseByte;
   const std::size_t recvProtocolBytes =
       payloadProtocolBytes + recvProtocolTailPadding;
-  const std::size_t recvPipelineBytes = recvPerBlockSlot * recvPipelineDepth;
+  const std::size_t recvPipelineBytes = pipeline_window(channelLayout);
 
-  const int fwdPipelineDepth = fwdChannelLayout.pipelineDepth;
-  const std::size_t fwdDataBufSize = fwdChannelLayout.data_buffer_size();
   auto& fwdSlotState = progress_send_slot(fwdTransport, group);
   IbLocalChannel& fwdLocalChannel =
       fwdTransport.local_channel(static_cast<uint32_t>(groupId));
@@ -1286,7 +1283,7 @@ __device__ __forceinline__ void forward(
   const uint64_t fwdPayloadBaseByte = fwdBaseByte;
   const std::size_t fwdProtocolBytes =
       payloadProtocolBytes + fwdProtocolTailPadding;
-  const std::size_t fwdPipelineBytes = fwdPerBlockSlot * fwdPipelineDepth;
+  const std::size_t fwdPipelineBytes = pipeline_window(fwdChannelLayout);
   if (group.is_leader()) {
     recvSlotState.activeStage = detail::IbSendRecvProgressStage::Busy;
     recvSlotState.activeBaseStep = static_cast<int64_t>(recvBaseByte);
@@ -1304,21 +1301,25 @@ __device__ __forceinline__ void forward(
     const std::size_t recvPipelineOff =
         static_cast<std::size_t>(recvStreamStart % recvPipelineBytes);
     const int recvSlot = static_cast<int>(recvPipelineOff / recvPerBlockSlot);
-    const std::size_t recvSlotOff = recvSlot * recvDataBufSize;
+    const std::size_t recvSlotOff =
+        static_cast<std::size_t>(recvSlot) * recvPerBlockSlot;
     const std::size_t recvChunkOff =
         recvPipelineOff - recvSlot * recvPerBlockSlot;
     const std::size_t recvStagingOff =
-        recvSlotOff + groupId * recvPerBlockSlot + recvChunkOff;
+        static_cast<std::size_t>(groupId) * recvPipelineBytes + recvSlotOff +
+        recvChunkOff;
 
     // --- Fwd side offsets ---
     const uint64_t fwdStreamStart = fwdPayloadBaseByte + dataOff;
     const std::size_t fwdPipelineOff =
         static_cast<std::size_t>(fwdStreamStart % fwdPipelineBytes);
     const int fwdSlot = static_cast<int>(fwdPipelineOff / fwdPerBlockSlot);
-    const std::size_t fwdSlotOff = fwdSlot * fwdDataBufSize;
+    const std::size_t fwdSlotOff =
+        static_cast<std::size_t>(fwdSlot) * fwdPerBlockSlot;
     const std::size_t fwdChunkOff = fwdPipelineOff - fwdSlot * fwdPerBlockSlot;
     const std::size_t fwdStagingOff =
-        fwdSlotOff + groupId * fwdPerBlockSlot + fwdChunkOff;
+        static_cast<std::size_t>(groupId) * fwdPipelineBytes + fwdSlotOff +
+        fwdChunkOff;
     const std::size_t recvSlotRemaining = recvPerBlockSlot - recvChunkOff;
     const std::size_t fwdSlotRemaining = fwdPerBlockSlot - fwdChunkOff;
     const std::size_t dataRemaining = payloadProtocolBytes - dataOff;
@@ -1369,8 +1370,6 @@ __device__ __forceinline__ void forward(
     }
     group.sync();
 
-    // (4) SLOT_FREE, posted unbatched every chunk. This must happen before
-    //     the step-5 wait to break circular ring dependency.
     transport.signal(
         group,
         recvRemoteChannel.slotFree,
@@ -1433,19 +1432,21 @@ __device__ __forceinline__ void forward(
 }
 
 /**
- * Maximum bytes a block can send without blocking on pipeline backpressure.
- *
- * The staging buffer is split into pipelineDepth slots, each with a fixed
- * per-channel partition. A block can fill all its slots before the NIC must
- * drain any of them, so the non-blocking window is:
- *   perChannelSize * pipelineDepth
- *
- * Callers should loop over their data in pipeline_window-sized chunks so
- * that send()/forward() never stall waiting for a free slot.
+ * Maximum bytes one channel can send without blocking on pipeline backpressure.
  */
 __device__ __forceinline__ std::size_t pipeline_window(
     const IbChannelLayout& channelLayout) {
-  return channelLayout.perChannelSize *
+  return channelLayout.perChannelBufferSize != 0
+      ? channelLayout.perChannelBufferSize
+      : channelLayout.perChannelSize;
+}
+
+__device__ __forceinline__ std::size_t pipeline_chunk(
+    const IbChannelLayout& channelLayout) {
+  if (channelLayout.pipelineDepth <= 0) {
+    return 0;
+  }
+  return pipeline_window(channelLayout) /
       static_cast<std::size_t>(channelLayout.pipelineDepth);
 }
 
@@ -1666,18 +1667,19 @@ __device__ __forceinline__ ProgressGeometry make_progress_geometry(
     PIPES_DEVICE_TRAP();
   }
 
-  const std::size_t perBlockSlot = channelLayout.perChannelSize & ~15ULL;
+  const std::size_t perBlockSlot = pipeline_chunk(channelLayout);
   if (perBlockSlot == 0) {
     if (group.is_leader()) {
       printf(
           "[PIPES] FATAL: %s perBlockSlot=0 "
-          "(dataBufferSize=%llu, maxGroups=%d)\n",
+          "(perChannelBufferSize=%llu, pipelineDepth=%d)\n",
           opName,
-          (unsigned long long)channelLayout.data_buffer_size(),
-          maxGroups);
+          (unsigned long long)pipeline_window(channelLayout),
+          channelLayout.pipelineDepth);
     }
     PIPES_DEVICE_TRAP();
   }
+  const std::size_t perChannelBufferSize = pipeline_window(channelLayout);
 
   const std::size_t protocolBytes = align_protocol_bytes(nbytes);
   std::size_t chunkSize =
@@ -1692,10 +1694,12 @@ __device__ __forceinline__ ProgressGeometry make_progress_geometry(
       .payloadBytes = nbytes,
       .protocolBytes = protocolBytes,
       .perBlockSlot = perBlockSlot,
+      .perChannelBufferSize = perChannelBufferSize,
       .chunkSize = chunkSize,
       .pipelineDepth = channelLayout.pipelineDepth,
   };
 #else
+  (void)channelLayout;
   (void)group;
   (void)nbytes;
   (void)max_signal_bytes;
@@ -1847,14 +1851,14 @@ __device__ __forceinline__ void transition_progress_stage(
  * Map the state's logical protocol byte cursor to the next staging-ring
  * chunk.
  *
- * The transport stores each logical slot as `dataBufferSize` bytes, split
- * into geometry-specific per-group partitions. The protocol cursor advances
- * in bytes, not slots, so `baseStep + nextByte` is reduced modulo
- * `perBlockSlot * pipelineDepth` to pick the ring slot and per-group offset.
+ * The transport stores each channel as one contiguous pipeline window split
+ * into `pipelineDepth` slots. The protocol cursor advances in bytes, not
+ * slots, so `baseStep + nextByte` is reduced modulo the per-channel window
+ * to pick the slot and offset.
  *
  * The returned chunk is clipped by three boundaries: the configured
  * sub-chunk size, remaining protocol bytes, and remaining bytes in the
- * current per-block staging partition. This keeps every progress call
+ * current per-channel staging slice. This keeps every progress call
  * bounded and prevents a single RDMA put or recv copy from spanning two
  * staging slots.
  */
@@ -1864,13 +1868,13 @@ __device__ __forceinline__ ProgressChunk next_chunk(
     const ProgressGeometry& geometry) {
   const uint64_t streamStart =
       static_cast<uint64_t>(state.activeBaseStep) + state.activeNextByte;
-  const std::size_t pipelineBytes = geometry.perBlockSlot *
-      static_cast<std::size_t>(channelLayout.pipelineDepth);
+  (void)channelLayout;
+  const std::size_t pipelineBytes = geometry.perChannelBufferSize;
   const std::size_t pipelineOff =
       static_cast<std::size_t>(streamStart % pipelineBytes);
   const int slot = static_cast<int>(pipelineOff / geometry.perBlockSlot);
   const std::size_t slotOff =
-      static_cast<std::size_t>(slot) * channelLayout.data_buffer_size();
+      static_cast<std::size_t>(slot) * geometry.perBlockSlot;
   const std::size_t chunkOff =
       pipelineOff - static_cast<std::size_t>(slot) * geometry.perBlockSlot;
   const std::size_t slotRemaining = geometry.perBlockSlot - chunkOff;
@@ -1880,9 +1884,8 @@ __device__ __forceinline__ ProgressChunk next_chunk(
       geometry.chunkSize < dataRemaining ? geometry.chunkSize : dataRemaining;
   bytes = bytes < slotRemaining ? bytes : slotRemaining;
   return ProgressChunk{
-      .stagingOff = slotOff +
-          static_cast<std::size_t>(geometry.groupId) * geometry.perBlockSlot +
-          chunkOff,
+      .stagingOff = static_cast<std::size_t>(geometry.groupId) * pipelineBytes +
+          slotOff + chunkOff,
       .dataOff = payloadNextByte,
       .bytes = bytes,
       .streamEnd = streamStart + bytes,
@@ -2100,8 +2103,14 @@ struct P2pIbTransportDevice {
       const Timeout& timeout = Timeout(),
       Args... args);
 
-  // Per-block pipelined staging window — forwarded to the active backend.
+  // Total staging bytes for one channel, forwarded to the active backend.
   __device__ __forceinline__ std::size_t pipeline_window() const;
+
+  // Slots per channel, forwarded to the active backend.
+  __device__ __forceinline__ int pipeline_depth() const;
+
+  // Slot/chunk bytes, forwarded to the active backend.
+  __device__ __forceinline__ std::size_t pipeline_chunk() const;
 
   __device__ __forceinline__ void init_send_progress(
       ThreadGroup& group,

--- a/comms/prims/transport/ibgda/IbgdaBuffer.h
+++ b/comms/prims/transport/ibgda/IbgdaBuffer.h
@@ -471,11 +471,14 @@ struct IbChannelLayout {
   int maxChannels{0}; ///< Layout size for channel-indexed resources
   int numLanes{1}; ///< QP lanes = numNics * qpsPerConnection; each lane owns a
                    ///< single-writer DATA_READY slot per channel
-  int pipelineDepth{0}; ///< Number of pipeline slots in the ring
-  std::size_t perChannelSize{0}; ///< Bytes per channel in one pipeline slot
+  int pipelineDepth{0}; ///< Number of slots/chunks in one channel
+  std::size_t perChannelSize{0}; ///< Backward-compatible channel window alias
+  std::size_t perChannelBufferSize{0}; ///< Total staging bytes for one channel
 
   __host__ __device__ std::size_t data_buffer_size() const {
-    return perChannelSize * static_cast<std::size_t>(maxChannels);
+    const std::size_t perChannel =
+        perChannelBufferSize != 0 ? perChannelBufferSize : perChannelSize;
+    return perChannel * static_cast<std::size_t>(maxChannels);
   }
 
   IBGDA_HOST_DEVICE int dataReadySignalSlot(int channelId) const {

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -1872,18 +1872,19 @@ class P2pIbgdaTransportDevice {
   //        ▲                                           │
   //        └───────────── SLOT_FREE signal ────────────┘
   //
-  // Signal protocol (per block, 3 primitives):
+  // Signal protocol (per channel/group, 3 primitives):
   //   DATA_READY  — piggybacked on put (sender → receiver's signalBuf)
   //   SLOT_FREE   — explicit signal    (receiver → sender's signalBuf)
   //   NIC_DONE    — loopback counter   (NIC → sender's counterBuf)
   //
   // Terminology used below:
-  //   slot             = one logical staging-ring entry of dataBufferSize
-  //                      bytes. There are pipelineDepth slots in the ring.
-  //   maxChannels      = fixed number of channel/group slots allocated for
-  //                      this peer at transport construction.
-  //   perBlockSlot     = one block-group's partition within a slot:
-  //                      channelLayout.perChannelSize & ~15ULL
+  //   channel window   = one channel's contiguous staging region. There are
+  //                      maxGroups channel windows in each per-peer staging
+  //                      buffer.
+  //   maxGroups        = configured logical channel count; group_id must be
+  //                      less than maxGroups.
+  //   perBlockSlot     = one pipeline slot within a channel window:
+  //                      perChannelBufferSize / pipelineDepth.
   //   sub-chunk        = one signaled byte range within a perBlockSlot. When
   //                      max_signal_bytes == 0, a sub-chunk is the whole
   //                      perBlockSlot. Otherwise:
@@ -1896,9 +1897,8 @@ class P2pIbgdaTransportDevice {
   //
   // Typical usage:
   //   auto [role, sub] = group.partition(2);
-  //   std::size_t sectionBytes =
-  //   transport->channel_layout().data_buffer_size(); for (std::size_t s = 0; s
-  //   < totalBytes / sectionBytes; ++s) {
+  //   std::size_t sectionBytes = transport->pipeline_window();
+  //   for (std::size_t s = 0; s < totalBytes / sectionBytes; ++s) {
   //     TiledBuffer<char> tiles(data + s * sectionBytes, sectionBytes, sub);
   //     if (role == 0)
   //       transport->send(sub, tiles.data(), tiles.bytes());
@@ -1913,10 +1913,10 @@ class P2pIbgdaTransportDevice {
    * send()/recv(). For a chunk with logical byte range [streamStart,
    * streamEnd), both APIs derive the same ring slot and staging offset from:
    *
-   *   pipelineBytes = perBlockSlot * pipelineDepth
+   *   pipelineBytes = perChannelBufferSize
    *   pipelineOff   = streamStart % pipelineBytes
    *   slot          = pipelineOff / perBlockSlot
-   *   stagingOff    = slot * dataBufferSize + groupId * perBlockSlot +
+   *   stagingOff    = groupId * pipelineBytes + slot * perBlockSlot +
    *                   (pipelineOff - slot * perBlockSlot)
    *
    * Sender chunk state machine:
@@ -1989,10 +1989,9 @@ class P2pIbgdaTransportDevice {
    * group while a previous send is outstanding traps with a diagnostic instead
    * of silently overwriting the in-flight byte range.
    *
-   * Channel count and per-channel staging geometry are fixed in the transport
-   * layout. `max_signal_bytes == 0` sends one signal per per-channel staging
-   * partition; smaller non-zero values split that partition into multiple
-   * signaled sub-chunks for finer overlap with the receiver.
+   * `max_signal_bytes == 0` sends one signal per per-channel staging slice;
+   * smaller non-zero values split that slice into multiple signaled sub-chunks
+   * for finer overlap with the receiver.
    *
    * Zero-byte sends mark the internal state `Done` without reading or
    * validating staging geometry. This matches the blocking `send()` no-op
@@ -2131,11 +2130,11 @@ class P2pIbgdaTransportDevice {
    * send — send one block's tile via pipelined RDMA.
    *
    * Copies src → sendStaging, then RDMA puts sendStaging → peer's recvStaging.
-   * For this call, each logical slot contributes one perBlockSlot-sized region
-   * for this group. If nbytes > perBlockSlot, send() advances through multiple
-   * ring positions. max_signal_bytes can further subdivide each perBlockSlot
-   * into multiple signaled sub-chunks, enabling finer-grained overlap at the
-   * receiver.
+   * For this call, each logical slot contributes one perBlockSlot-sized
+   * region for this group. If nbytes > perBlockSlot, send() advances through
+   * multiple ring positions. max_signal_bytes can further subdivide each
+   * perBlockSlot into multiple signaled sub-chunks, enabling finer-grained
+   * overlap at the receiver.
    *
    * Signaling protocol (per group):
    *   NIC_DONE   — loopback counter incremented by NIC after each RDMA put.
@@ -2150,9 +2149,9 @@ class P2pIbgdaTransportDevice {
    * allows callers to pipeline across repeated send() calls without a separate
    * drain.
    *
-   * The caller must keep the transport layout stable while a sequence is in
-   * flight. `max_signal_bytes` may vary across calls because it changes only
-   * sub-chunk signaling, not the fixed channel staging layout.
+   * The caller must keep the staging layout stable while a sequence is in
+   * flight. `max_signal_bytes` may vary across calls because it only changes
+   * the signal cadence within the fixed per-channel staging slice.
    *
    * @param group           ThreadGroup (all threads participate in memcpy,
    *                        leader does RDMA ops).
@@ -2162,7 +2161,8 @@ class P2pIbgdaTransportDevice {
    *                        consumed in perBlockSlot-sized pieces, or smaller
    *                        sub-chunks when max_signal_bytes is set.
    * @param max_signal_bytes Max bytes per signaled sub-chunk within one
-   *                        perBlockSlot. 0 means one signal per perBlockSlot.
+   *                        perBlockSlot. 0 means one signal per
+   * perBlockSlot.
    * @param timeout         Optional timeout for wait operations.
    */
   template <typename CopyOp = Memcpy, typename... Args>
@@ -2224,10 +2224,10 @@ class P2pIbgdaTransportDevice {
    * recv — receive one block's tile from pipelined RDMA.
    *
    * Waits for data to arrive in recvStaging, then copies recvStaging → dst.
-   * For this call, each logical slot contributes one perBlockSlot-sized region
-   * for this group. If nbytes > perBlockSlot, recv() advances through multiple
-   * ring positions. max_signal_bytes controls sub-chunk granularity and must
-   * match the sender.
+   * For this call, each logical slot contributes one perBlockSlot-sized
+   * region for this group. If nbytes > perBlockSlot, recv() advances through
+   * multiple ring positions. max_signal_bytes controls sub-chunk granularity
+   * and must match the sender.
    *
    * Signaling protocol (per group, symmetric with send):
    *   DATA_READY — sender increments by bytesThis after RDMA put completes.
@@ -2240,11 +2240,11 @@ class P2pIbgdaTransportDevice {
    * @param dst             Destination for this block's tile.
    * @param nbytes          Payload bytes to receive for this group. The
    *                        internal protocol byte count is rounded up to 16
-   *                        bytes and consumed in perBlockSlot-sized pieces, or
-   *                        smaller sub-chunks when max_signal_bytes is set.
+   *                        bytes and consumed in perBlockSlot-sized pieces,
+   * or smaller sub-chunks when max_signal_bytes is set.
    * @param max_signal_bytes Max bytes per signaled sub-chunk within one
-   *                        perBlockSlot. 0 means one signal per perBlockSlot.
-   *                        Must match the sender's value.
+   *                        perBlockSlot. 0 means one signal per
+   * perBlockSlot. Must match the sender's value.
    * @param timeout         Optional timeout for wait operations.
    */
   template <typename CopyOp = Memcpy, typename... Args>
@@ -2349,7 +2349,8 @@ class P2pIbgdaTransportDevice {
    * @param fwd             Forward transport (sends to next peer in ring).
    * @param nbytes          Payload bytes to receive and forward. The internal
    *                        protocol byte count is rounded up to 16 bytes.
-   * @param max_signal_bytes Max bytes per signaled sub-chunk. 0 = perBlockSlot.
+   * @param max_signal_bytes Max bytes per signaled sub-chunk. 0 =
+   * perBlockSlot.
    * @param timeout         Optional timeout for wait operations.
    * @param args            Extra args forwarded to CopyOp::forward.
    */
@@ -2420,18 +2421,34 @@ class P2pIbgdaTransportDevice {
   }
 
   /**
-   * Maximum bytes a block can send without blocking on pipeline backpressure.
+   * Total send/recv staging buffer bytes for one channel.
    *
-   * The staging buffer is split into pipelineDepth slots, each with a fixed
-   * per-channel partition. A block can fill all its slots before the NIC must
-   * drain any of them, so the non-blocking window is:
-   *   perChannelSize * pipelineDepth
-   *
-   * Callers should loop over their data in pipeline_window-sized chunks so
-   * that send()/forward() never stall waiting for a free slot.
+   * The channel window is split into pipelineDepth fixed chunks. Public
+   * geometry follows:
+   *   pipeline_chunk() = pipeline_window() / pipeline_depth()
    */
   __device__ __forceinline__ std::size_t pipeline_window() const {
-    return detail::pipeline_window(channelLayout_);
+    return channelLayout_.perChannelBufferSize != 0
+        ? channelLayout_.perChannelBufferSize
+        : channelLayout_.perChannelSize;
+  }
+
+  __device__ __forceinline__ std::size_t pipeline_window(
+      int active_blocks) const {
+    (void)active_blocks;
+    return pipeline_window();
+  }
+
+  __device__ __forceinline__ int pipeline_depth() const {
+    return channelLayout_.pipelineDepth;
+  }
+
+  __device__ __forceinline__ std::size_t pipeline_chunk() const {
+    if (channelLayout_.pipelineDepth <= 0) {
+      return 0;
+    }
+    return pipeline_window() /
+        static_cast<std::size_t>(channelLayout_.pipelineDepth);
   }
 
  private:

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -512,7 +512,27 @@ class P2pIbrcTransportDevice {
   }
 
   __device__ __forceinline__ std::size_t pipeline_window() const {
-    return detail::pipeline_window(channelLayout_);
+    return channelLayout_.perChannelBufferSize != 0
+        ? channelLayout_.perChannelBufferSize
+        : channelLayout_.perChannelSize;
+  }
+
+  __device__ __forceinline__ std::size_t pipeline_window(
+      int active_blocks) const {
+    (void)active_blocks;
+    return pipeline_window();
+  }
+
+  __device__ __forceinline__ int pipeline_depth() const {
+    return channelLayout_.pipelineDepth;
+  }
+
+  __device__ __forceinline__ std::size_t pipeline_chunk() const {
+    if (channelLayout_.pipelineDepth <= 0) {
+      return 0;
+    }
+    return pipeline_window() /
+        static_cast<std::size_t>(channelLayout_.pipelineDepth);
   }
 
   __device__ __forceinline__ void init_send_progress(

--- a/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
@@ -40,6 +40,19 @@ MultiPeerNvlTransportConfig normalizeChannelConfig(
     throw std::runtime_error(
         "tile send/recv requires perChannelSize to be 16-byte aligned");
   }
+  if (config.pipelineDepth < 1) {
+    throw std::runtime_error("tile send/recv requires pipelineDepth >= 1");
+  }
+  if (config.perChannelSize % config.pipelineDepth != 0) {
+    throw std::runtime_error(
+        "tile send/recv requires perChannelSize divisible by pipelineDepth");
+  }
+  const std::size_t pipelineChunk =
+      config.perChannelSize / config.pipelineDepth;
+  if (pipelineChunk < 16 || pipelineChunk % 16 != 0) {
+    throw std::runtime_error(
+        "tile send/recv requires perChannelSize / pipelineDepth to be a 16-byte aligned chunk >= 16");
+  }
   // Cap per-channel staging at 128MB (matches NCCL's max channel buffer). This
   // also keeps the derived per-slot staging size bounded for any sane channel
   // count.
@@ -81,9 +94,9 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
   // Allocation order: signal -> state
   // Each handler's destructor will free its GPU memory if constructed.
 
-  // Calculate per-peer buffer sizes with pipelining
+  // Calculate per-peer fixed-channel buffer sizes.
   dataBufferSize_ = dataBufferSize(config_);
-  perPeerDataBufferSize_ = config_.pipelineDepth * dataBufferSize_;
+  perPeerDataBufferSize_ = dataBufferSize_;
 
   perPeerSignalBufferSize_ = getSignalBufferSize(config_.p2pSignalCount);
 
@@ -191,14 +204,14 @@ void MultiPeerNvlTransport::setExternalDataBuffers(
           "setExternalDataBuffers: local buffer for peer " +
           std::to_string(peer) + " has size " + std::to_string(localSize) +
           " but requires at least " + std::to_string(perPeerDataBufferSize_) +
-          " (pipelineDepth * maxNumChannels * perChannelSize)");
+          " (maxNumChannels * perChannelSize)");
     }
     if (remoteSize < perPeerDataBufferSize_) {
       throw std::runtime_error(
           "setExternalDataBuffers: remote buffer for peer " +
           std::to_string(peer) + " has size " + std::to_string(remoteSize) +
           " but requires at least " + std::to_string(perPeerDataBufferSize_) +
-          " (pipelineDepth * maxNumChannels * perChannelSize)");
+          " (maxNumChannels * perChannelSize)");
     }
   }
   externalStagingBuffers_ = std::move(externalStagingBuffers);
@@ -275,13 +288,16 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
       remotePeerIndex * perPeerSignalBufferSize_;
 
   const int maxChannels = config_.maxNumChannels;
-  const std::size_t perChannelSlot =
+  const std::size_t perChannelBuffer =
       maxChannels > 0 ? config_.perChannelSize : 0;
+  const std::size_t perChannelSlot =
+      maxChannels > 0 ? config_.perChannelSize / config_.pipelineDepth : 0;
   P2pNvlTransportOptions options{
       .dataBufferSize = dataBufferSize_,
       .pipelineDepth = config_.pipelineDepth,
       .ll128BufferNumPackets = perPeerLl128BufferSize_ / kLl128PacketSize,
       .llBufferNumLines = perPeerLlBufferSize_ / kLlLineSize,
+      .per_channel_buffer = perChannelBuffer,
       .per_channel_slot = perChannelSlot,
       .max_num_channels = maxChannels,
   };

--- a/comms/prims/transport/nvl/MultiPeerNvlTransport.h
+++ b/comms/prims/transport/nvl/MultiPeerNvlTransport.h
@@ -37,13 +37,13 @@ struct Transport;
  * IMPORTANT: All ranks must use identical configuration values.
  *
  * For the fixed-channel tile protocol:
- *   one pipeline slot = maxNumChannels * perChannelSize
+ *   one channel window = perChannelSize
+ *   one channel chunk = perChannelSize / pipelineDepth
  *
- * Memory per rank = (nRanks - 1) * pipelineDepth * maxNumChannels *
- * perChannelSize
+ * Memory per rank = (nRanks - 1) * maxNumChannels * perChannelSize
  */
 struct MultiPeerNvlTransportConfig {
-  // Number of pipeline slots for overlapping communication.
+  // Number of slots/chunks within one channel.
   // Higher = better latency hiding but more memory.
   // Typical: 2-4 for most workloads.
   std::size_t pipelineDepth{0};
@@ -64,7 +64,7 @@ struct MultiPeerNvlTransportConfig {
   // send/recv use these without user-managed state.
   int maxNumChannels{64};
 
-  // Size of each channel's staging slice per pipeline slot (bytes).
+  // Total staging window size for one channel (bytes).
   // Must be 16-byte aligned when maxNumChannels > 0.
   std::size_t perChannelSize{kDefaultNvlPerChannelSize};
 
@@ -109,8 +109,8 @@ struct MultiPeerNvlTransportConfig {
  *
  * SIZE REQUIREMENTS:
  *   Each per-peer buffer must be at least
- *   (pipelineDepth * maxNumChannels * perChannelSize) bytes, matching the
- *   config passed to MultiPeerNvlTransport.
+ *   (maxNumChannels * perChannelSize) bytes, matching the config passed to
+ *   MultiPeerNvlTransport.
  *   setExternalDataBuffers() validates this and throws on mismatch.
  *
  * OWNERSHIP:

--- a/comms/prims/transport/nvl/NvlChannelState.cuh
+++ b/comms/prims/transport/nvl/NvlChannelState.cuh
@@ -30,11 +30,10 @@ namespace comms::prims {
  * Each channel's state is a single struct with named fields; the transport
  * indexes the channels array by group_id directly.
  *
- * Slot-major staging layout: channel c's slice at slot s lives at
- *   staging_base + s * (max_num_channels * per_channel_slot) + c *
- * per_channel_slot (Do not switch to channel-major without re-running the
- * slot-vs-channel-major NVL bandwidth benchmark — slot-major was measured ~5%
- * faster on H100.)
+ * Channel-major staging layout: channel c's slot s lives at
+ *   staging_base + c * per_channel_buffer + s * per_channel_slot.
+ * This keeps one channel's full pipeline window contiguous; benchmark the
+ * before/after bandwidth when changing this layout.
  */
 struct alignas(128) NvlChannelState {
   int64_t send_cursor{0};

--- a/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
@@ -62,10 +62,10 @@ struct RemoteState {
  * P2pNvlTransportOptions - Configuration for P2P NVLink transport
  *
  * Defines the derived buffer sizes for staged transfers.
- * - dataBufferSize: Size of ONE pipeline slot across all fixed channels
- * - pipelineDepth: Number of buffer slots for pipelining (typically 2-8)
+ * - dataBufferSize: Total fixed-channel staging bytes across all channels
+ * - pipelineDepth: Number of slots/chunks inside one channel
  *
- * Total memory allocated = pipelineDepth × dataBufferSize
+ * Total memory allocated = dataBufferSize
  */
 struct P2pNvlTransportOptions {
   std::size_t dataBufferSize{0};
@@ -77,17 +77,19 @@ struct P2pNvlTransportOptions {
   // from MultiPeerNvlTransportConfig. Used by send/recv/forward (the tile
   // path).
   //
-  // Slot-major staging layout: within each pipeline slot (size =
-  // dataBufferSize) each channel owns a fixed slice of size per_channel_slot.
-  // Channel c at pipeline slot s reads/writes
-  //   staging_base + s * dataBufferSize + c * per_channel_slot
+  // Channel-major staging layout: each channel owns a contiguous
+  // per_channel_buffer window split into pipelineDepth chunks of size
+  // per_channel_slot. Channel c at pipeline slot s reads/writes
+  //   staging_base + c * per_channel_buffer + s * per_channel_slot
   //
-  //   per_channel_slot = MultiPeerNvlTransportConfig.perChannelSize
-  //   dataBufferSize >= maxNumChannels * per_channel_slot
+  //   per_channel_buffer = MultiPeerNvlTransportConfig.perChannelSize
+  //   per_channel_slot = per_channel_buffer / pipelineDepth
+  //   dataBufferSize = maxNumChannels * per_channel_buffer
   //   max_num_channels = MultiPeerNvlTransportConfig.maxNumChannels
   //
   // max_num_channels must equal the array length of the per-peer
   // NvlChannelState arrays passed into the device transport.
+  std::size_t per_channel_buffer{0};
   std::size_t per_channel_slot{0};
   int max_num_channels{0};
 };
@@ -122,18 +124,17 @@ class P2pNvlTransportDevice {
 
   __host__ __device__ ~P2pNvlTransportDevice() = default;
 
-  // Largest single call that can be pipelined within the staging ring without a
-  // send()/recv() wrapping the ring and blocking on backpressure mid-call. In
-  // the fixed-channel (tile) model each channel pipelines through its own
-  // per_channel_slot ring (independent of the active block count), so the
-  // window must be bounded by that ring's capacity (per_channel_slot *
-  // safeDepth). A larger window lets a single call wrap the ring and wait for a
-  // slot_free the peer only produces after its own recv() — deadlocking the
-  // send-before-recv AllReduce pattern.
+  // Total staging bytes for one channel.
   __host__ __device__ std::size_t pipeline_window() const {
-    const std::size_t safeDepth =
-        options_.pipelineDepth > 1 ? options_.pipelineDepth - 1 : 1;
-    return options_.per_channel_slot * safeDepth;
+    return options_.per_channel_buffer;
+  }
+
+  __host__ __device__ std::size_t pipeline_depth() const {
+    return options_.pipelineDepth;
+  }
+
+  __host__ __device__ std::size_t pipeline_chunk() const {
+    return options_.per_channel_slot;
   }
 
   // Getters for testing
@@ -1070,15 +1071,15 @@ class P2pNvlTransportDevice {
       PIPES_DEVICE_TRAP();
     }
 
-    const std::size_t slotSize = options_.dataBufferSize;
+    const std::size_t perChannelBuffer = options_.per_channel_buffer;
     const std::size_t perChannelSlot = options_.per_channel_slot;
-    if (perChannelSlot == 0) {
+    if (perChannelBuffer == 0 || perChannelSlot == 0) {
       printf(
-          "%s: per_channel_slot is 0 (dataBufferSize=%llu, "
-          "max_num_channels=%d). Set perChannelSize when channels are "
-          "enabled.\n",
+          "%s: invalid channel geometry (per_channel_buffer=%llu, "
+          "per_channel_slot=%llu, max_num_channels=%d).\n",
           op,
-          (unsigned long long)slotSize,
+          (unsigned long long)perChannelBuffer,
+          (unsigned long long)perChannelSlot,
           maxChannels);
       PIPES_DEVICE_TRAP();
     }
@@ -1088,10 +1089,10 @@ class P2pNvlTransportDevice {
         ? (maxSignalBytes & ~15ULL)
         : perChannelSlot;
     return {
-        slotSize,
         perChannelSlot,
-        group.group_id * perChannelSlot,
-        perChannelSlot * options_.pipelineDepth,
+        perChannelSlot,
+        group.group_id * perChannelBuffer,
+        perChannelBuffer,
         chunkSize > 0 ? chunkSize : perChannelSlot,
     };
   }


### PR DESCRIPTION
Summary:

Redesign prims send/recv fixed-channel geometry around a channel-major buffer model. `pipelineDepth` is the number of slots/chunks inside one channel, `pipeline_window()` returns the total staging window for one channel, and `pipeline_chunk()` returns `pipeline_window() / pipeline_depth()`.

IB and NVL staging offsets now use `channel * pipeline_window() + slot * pipeline_chunk() + chunkOff`; per-peer send/recv staging is `max channels * pipeline_window()` per direction. Host validation enforces 16-byte aligned chunks, external NVL staging requirements use the total channel-major size, and CTRAN direct NVL plus pipes initialization derive an aligned channel window that fits within the existing shared devbuf.

This rebase removes the dependency on D111372913/D111372915, updates stale call sites after latest master, and fixes the D111372777 V4 failures in `allgather_test`, `alltoallv_test`, and the CTRAN distributed send/recv targets. V6 also restores source-compatible `pipeline_window(active_blocks)` overloads for standalone downstream builds; the overloads ignore `active_blocks` and delegate to the new no-arg per-channel `pipeline_window()` semantics. Design: https://prototypes.internalmeta.com/hub/detail/1521287756445312

Reviewed By: siyengar, Scusemua

Differential Revision: D111372777


