### PR TITLE
Remove stale NVL transport staging config fields (#3110)

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -31,6 +31,10 @@ int ctranPipesNvlMaxNumChannels() {
   return std::max(1, NCCL_CTRAN_MAX_NBLOCKS);
 }
 
+size_t alignDown(size_t value, size_t alignment) {
+  return (value / alignment) * alignment;
+}
+
 } // namespace
 
 commResult_t ctran::ctranPreparePipesTrace(
@@ -76,10 +80,8 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         comm->bootstrap_.get(),
         [](meta::comms::IBootstrap*) {}); // no-op deleter
 
-    comms::prims::MultiPeerTransportConfig config{};
-
-    // NVL config: per-comm hint > CVAR default
     const auto& pc = comm->config_.pipesConfig;
+    comms::prims::MultiPeerTransportConfig config{};
 
     config.nvlConfig.pipelineDepth =
         static_cast<size_t>(NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH);
@@ -88,14 +90,14 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         NCCL_CTRAN_HIER_AG_OVERLAP_ENABLE && comm->statex_->nLocalRanks() > 1;
     const size_t nvlSharedDevbufSize =
         ctranEffectiveP2pNvlSharedDevbufSize(comm->statex_->nLocalRanks());
-    config.nvlConfig.dataBufferSize = static_cast<size_t>(
+    const size_t nvlDataBufferSize = static_cast<size_t>(
         nvlSharedDevbufSize / config.nvlConfig.pipelineDepth);
 
-    config.nvlConfig.chunkSize = (pc.nvlChunkSize > 0)
-        ? static_cast<size_t>(pc.nvlChunkSize)
-        : static_cast<size_t>(NCCL_CTRAN_PIPES_NVL_CHUNK_SIZE);
-
     config.nvlConfig.maxNumChannels = ctranPipesNvlMaxNumChannels();
+    config.nvlConfig.perChannelSize = alignDown(
+        nvlDataBufferSize /
+            static_cast<size_t>(config.nvlConfig.maxNumChannels),
+        16);
 
     // LL128 buffer allocation for DeviceAllToAllv
     if (NCCL_CTRAN_DA2A_LL128_THRESHOLD > 0) {
@@ -258,13 +260,13 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
 
     CLOGF(
         INFO,
-        "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlChunkSize={} nvlMaxNumChannels={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={} materializePeerTimeoutMs={}",
+        "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={} materializePeerTimeoutMs={}",
         comm->statex_->rank(),
         config.nvlConfig.pipelineDepth,
         nvlSharedDevbufSize,
-        config.nvlConfig.dataBufferSize,
-        config.nvlConfig.chunkSize,
+        nvlDataBufferSize,
         config.nvlConfig.maxNumChannels,
+        config.nvlConfig.perChannelSize,
         hierAgOverlapEnabled,
         config.disableIb,
         config.topoConfig.p2pDisable,

--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -131,6 +131,10 @@ static_assert(sizeof(NvlChannelState) == kNvlChannelStateSize);
 static_assert(alignof(NvlChannelState) == kNvlChannelStateAlign);
 #endif // defined(ENABLE_PRIMS)
 
+inline size_t alignDown(size_t value, size_t alignment) {
+  return (value / alignment) * alignment;
+}
+
 inline size_t getPerPeerChannelStatesSize() {
   return kNvlChannelStateSize * CTRAN_ALGO_MAX_THREAD_BLOCKS;
 }
@@ -318,14 +322,13 @@ commResult_t CtranAlgo::initKernelResources() {
           &this->comm_->logMetaData_,
           "initKernelResources-nvlTransports"));
 
+  const size_t nvlPipelineSlotSize =
+      nvlSharedDevbufSize / NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH;
   comms::prims::P2pNvlTransportOptions options{
-      .dataBufferSize =
-          nvlSharedDevbufSize / NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH,
-      .chunkSize = NCCL_CTRAN_PIPES_NVL_CHUNK_SIZE,
+      .dataBufferSize = nvlPipelineSlotSize,
       .pipelineDepth = NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH,
       .per_channel_slot =
-          (nvlSharedDevbufSize / NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH) /
-          CTRAN_ALGO_MAX_THREAD_BLOCKS,
+          alignDown(nvlPipelineSlotSize / CTRAN_ALGO_MAX_THREAD_BLOCKS, 16),
       .max_num_channels = CTRAN_ALGO_MAX_THREAD_BLOCKS};
 
   for (int peer = 0; peer < nLocalRanks; peer++) {

--- a/comms/prims/benchmarks/BarrierBench.cu
+++ b/comms/prims/benchmarks/BarrierBench.cu
@@ -35,7 +35,6 @@ void launchBarrierBenchKernel(
   // Create transport options (only barrier buffers are used)
   P2pNvlTransportOptions options{
       .dataBufferSize = 1024,
-      .chunkSize = 512,
       .pipelineDepth = 2,
   };
 

--- a/comms/prims/benchmarks/MultiPeerBenchmark.cc
+++ b/comms/prims/benchmarks/MultiPeerBenchmark.cc
@@ -323,8 +323,6 @@ TEST_F(MultiPeerBenchmarkFixture, BarrierLatency) {
   // Create transport once with max slot count
   int maxSlots = getMaxSlots(configs);
   MultiPeerNvlTransportConfig nvlConfig{
-      .dataBufferSize = 1,
-      .chunkSize = 1,
       .pipelineDepth = 1,
       .maxNumChannels = 0,
   };
@@ -394,8 +392,6 @@ TEST_F(MultiPeerBenchmarkFixture, SignalAllLatency) {
 
   int maxSlots = getMaxSlots(configs);
   MultiPeerNvlTransportConfig nvlConfig{
-      .dataBufferSize = 1,
-      .chunkSize = 1,
       .pipelineDepth = 1,
       .maxNumChannels = 0,
   };
@@ -465,8 +461,6 @@ TEST_F(MultiPeerBenchmarkFixture, SignalPingPongLatency) {
 
   int maxSlots = getMaxSlots(configs);
   MultiPeerNvlTransportConfig nvlConfig{
-      .dataBufferSize = 1,
-      .chunkSize = 1,
       .pipelineDepth = 1,
       .maxNumChannels = 0,
   };

--- a/comms/prims/benchmarks/P2pNvlLl128Benchmark.cc
+++ b/comms/prims/benchmarks/P2pNvlLl128Benchmark.cc
@@ -39,6 +39,8 @@ struct Ll128Config {
 // Threshold above which Simple gets its own transport with optimal chunking
 constexpr std::size_t kSimpleChunkThreshold = 8 * 1024;
 constexpr std::size_t kSimpleChunkSize = 8 * 1024;
+constexpr int kNvlMaxNumChannels = 64;
+constexpr std::size_t kNvlPerChannelSize = 64 * 1024;
 
 // Message sizes used by auto-tuned benchmarks (both uni- and bidirectional).
 static const std::vector<std::size_t> kAutoTuneMessageSizes = {
@@ -532,9 +534,9 @@ class P2pLl128BenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
       if (cfg.nBytes <= kSimpleChunkThreshold) {
         comms::prims::MultiPeerNvlTransportConfig p2pConfig{
-            .dataBufferSize = cfg.nBytes,
-            .chunkSize = cfg.nBytes,
             .pipelineDepth = 2,
+            .maxNumChannels = kNvlMaxNumChannels,
+            .perChannelSize = kNvlPerChannelSize,
             .ll128BufferSize = comms::prims::ll128_buffer_size(cfg.nBytes),
         };
 
@@ -560,9 +562,9 @@ class P2pLl128BenchmarkFixture : public meta::comms::BenchmarkTestFixture {
             runLl128Benchmark(p2p, benchConfig, result.ll128Time);
       } else {
         comms::prims::MultiPeerNvlTransportConfig ll128Config{
-            .dataBufferSize = cfg.nBytes,
-            .chunkSize = cfg.nBytes,
             .pipelineDepth = 2,
+            .maxNumChannels = kNvlMaxNumChannels,
+            .perChannelSize = kNvlPerChannelSize,
             .ll128BufferSize = comms::prims::ll128_buffer_size(cfg.nBytes),
         };
         comms::prims::MultiPeerNvlTransport ll128Transport(
@@ -570,9 +572,9 @@ class P2pLl128BenchmarkFixture : public meta::comms::BenchmarkTestFixture {
         ll128Transport.exchange();
 
         comms::prims::MultiPeerNvlTransportConfig simpleConfig{
-            .dataBufferSize = cfg.nBytes,
-            .chunkSize = kSimpleChunkSize,
             .pipelineDepth = 2,
+            .maxNumChannels = kNvlMaxNumChannels,
+            .perChannelSize = kNvlPerChannelSize,
         };
         comms::prims::MultiPeerNvlTransport simpleTransport(
             globalRank, worldSize, bootstrap, simpleConfig);
@@ -632,9 +634,9 @@ class P2pLl128BenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
       if (cfg.nBytes <= kSimpleChunkThreshold) {
         comms::prims::MultiPeerNvlTransportConfig p2pConfig{
-            .dataBufferSize = cfg.nBytes,
-            .chunkSize = cfg.nBytes,
             .pipelineDepth = 2,
+            .maxNumChannels = kNvlMaxNumChannels,
+            .perChannelSize = kNvlPerChannelSize,
             .ll128BufferSize = comms::prims::ll128_buffer_size(cfg.nBytes),
         };
 
@@ -660,9 +662,9 @@ class P2pLl128BenchmarkFixture : public meta::comms::BenchmarkTestFixture {
             runLl128BidirectionalBenchmark(p2p, benchConfig, result.ll128Time);
       } else {
         comms::prims::MultiPeerNvlTransportConfig ll128Config{
-            .dataBufferSize = cfg.nBytes,
-            .chunkSize = cfg.nBytes,
             .pipelineDepth = 2,
+            .maxNumChannels = kNvlMaxNumChannels,
+            .perChannelSize = kNvlPerChannelSize,
             .ll128BufferSize = comms::prims::ll128_buffer_size(cfg.nBytes),
         };
         comms::prims::MultiPeerNvlTransport ll128Transport(
@@ -670,9 +672,9 @@ class P2pLl128BenchmarkFixture : public meta::comms::BenchmarkTestFixture {
         ll128Transport.exchange();
 
         comms::prims::MultiPeerNvlTransportConfig simpleConfig{
-            .dataBufferSize = cfg.nBytes,
-            .chunkSize = kSimpleChunkSize,
             .pipelineDepth = 2,
+            .maxNumChannels = kNvlMaxNumChannels,
+            .perChannelSize = kNvlPerChannelSize,
         };
         comms::prims::MultiPeerNvlTransport simpleTransport(
             globalRank, worldSize, bootstrap, simpleConfig);
@@ -735,9 +737,9 @@ class P2pLl128BenchmarkFixture : public meta::comms::BenchmarkTestFixture {
           : comms::prims::ll128_buffer_size(cfg.nBytes);
 
       comms::prims::MultiPeerNvlTransportConfig ll128Config{
-          .dataBufferSize = cfg.nBytes,
-          .chunkSize = cfg.nBytes,
           .pipelineDepth = 2,
+          .maxNumChannels = kNvlMaxNumChannels,
+          .perChannelSize = kNvlPerChannelSize,
           .ll128BufferSize = ll128BufSize,
       };
       comms::prims::MultiPeerNvlTransport ll128Transport(
@@ -787,9 +789,9 @@ class P2pLl128BenchmarkFixture : public meta::comms::BenchmarkTestFixture {
           : comms::prims::ll128_buffer_size(cfg.nBytes);
 
       comms::prims::MultiPeerNvlTransportConfig ll128Config{
-          .dataBufferSize = cfg.nBytes,
-          .chunkSize = cfg.nBytes,
           .pipelineDepth = 2,
+          .maxNumChannels = kNvlMaxNumChannels,
+          .perChannelSize = kNvlPerChannelSize,
           .ll128BufferSize = ll128BufSize,
       };
       comms::prims::MultiPeerNvlTransport ll128Transport(

--- a/comms/prims/benchmarks/P2pNvlSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/P2pNvlSendRecvBenchmark.cc
@@ -695,8 +695,6 @@ TEST_F(P2pSendRecvBenchmarkFixture, UnidirectionalBenchmark) {
   for (const auto& config : configs) {
     // Create P2P transport for this configuration
     comms::prims::MultiPeerNvlTransportConfig p2pConfig{
-        .dataBufferSize = config.stagedBufferSize,
-        .chunkSize = config.chunkSize,
         .pipelineDepth = config.pipelineDepth,
         .maxNumChannels = kDefaultMaxNumChannels,
         .perChannelSize = config.stagedBufferSize / kDefaultMaxNumChannels,
@@ -919,8 +917,6 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
   for (const auto& config : configs) {
     // Create P2P transport for this configuration
     comms::prims::MultiPeerNvlTransportConfig p2pConfig{
-        .dataBufferSize = config.stagedBufferSize,
-        .chunkSize = config.chunkSize,
         .pipelineDepth = config.pipelineDepth,
         .maxNumChannels = kDefaultMaxNumChannels,
         .perChannelSize = config.stagedBufferSize / kDefaultMaxNumChannels,
@@ -1077,8 +1073,6 @@ TEST_F(P2pSendRecvBenchmarkFixture, MatchedBidirCtaBenchmark) {
   std::vector<BenchmarkResult> results;
   for (const auto& config : configs) {
     comms::prims::MultiPeerNvlTransportConfig p2pConfig{
-        .dataBufferSize = config.stagedBufferSize,
-        .chunkSize = config.chunkSize,
         .pipelineDepth = config.pipelineDepth,
         .maxNumChannels = config.numBlocks,
         .perChannelSize = config.chunkSize,

--- a/comms/prims/benchmarks/P2pNvlSignalBenchmark.cc
+++ b/comms/prims/benchmarks/P2pNvlSignalBenchmark.cc
@@ -190,8 +190,6 @@ TEST_F(P2pSignalBenchmarkFixture, SignalBenchmark) {
         : warmupConfig.numBlocks * (warmupConfig.numThreads / 32);
 
     comms::prims::MultiPeerNvlTransportConfig p2pConfig{
-        .dataBufferSize = 1,
-        .chunkSize = 1,
         .pipelineDepth = 1,
         .p2pSignalCount = signalCount,
         .maxNumChannels = 0,
@@ -217,8 +215,6 @@ TEST_F(P2pSignalBenchmarkFixture, SignalBenchmark) {
 
     // Create fresh P2P transport for each config to reset signal buffers
     comms::prims::MultiPeerNvlTransportConfig p2pConfig{
-        .dataBufferSize = 1,
-        .chunkSize = 1,
         .pipelineDepth = 1,
         .p2pSignalCount = signalCount,
         .maxNumChannels = 0,

--- a/comms/prims/collectives/AllGatherDirect.cu
+++ b/comms/prims/collectives/AllGatherDirect.cu
@@ -41,7 +41,7 @@ __global__ __launch_bounds__(kBlockSize, 1) void direct_allgather_nvl_kernel(
   }
 
   const std::size_t pipeline_window =
-      direct_pipeline_window(args.peers, my_rank, W, group.total_groups);
+      direct_pipeline_window(args.peers, my_rank, W);
   PIPES_DEVICE_CHECK_MSG(
       pipeline_window != 0, "direct NVLink allgather pipeline window is zero");
 
@@ -395,8 +395,8 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
       make_sub_block_group(base_group, nvl_group_id, args.nvl_num_blocks);
   const std::size_t total_tasks =
       static_cast<std::size_t>(args.ib_size) * total_chunks;
-  const std::size_t nvl_window = direct_pipeline_window(
-      args.nvl_peers, args.nvl_rank, args.nvl_size, args.nvl_num_blocks);
+  const std::size_t nvl_window =
+      direct_pipeline_window(args.nvl_peers, args.nvl_rank, args.nvl_size);
   PIPES_DEVICE_CHECK_MSG(
       nvl_window != 0,
       "hierarchical allgather overlap NVLink pipeline window is zero");

--- a/comms/prims/collectives/DirectCollectiveUtils.cuh
+++ b/comms/prims/collectives/DirectCollectiveUtils.cuh
@@ -30,14 +30,13 @@ struct MemcpyAndSelfCopy {
 __device__ __forceinline__ std::size_t direct_pipeline_window(
     const P2pNvlTransportDevice* peers,
     int my_rank,
-    int num_ranks,
-    int total_groups) {
+    int num_ranks) {
   std::size_t window = 0;
   for (int peer = 0; peer < num_ranks; ++peer) {
     if (peer == my_rank) {
       continue;
     }
-    const std::size_t peer_window = peers[peer].pipeline_window(total_groups);
+    const std::size_t peer_window = peers[peer].pipeline_window();
     window = window == 0 || peer_window < window ? peer_window : window;
   }
   return window;
@@ -61,7 +60,7 @@ hierarchical_allgather_nvl_broadcast_from_recvbuf(
   }
 
   const std::size_t pipeline_window =
-      direct_pipeline_window(peers, nvl_rank, nvl_size, group.total_groups);
+      direct_pipeline_window(peers, nvl_rank, nvl_size);
   PIPES_DEVICE_CHECK_MSG(
       pipeline_window != 0,
       "hierarchical allgather NVLink broadcast pipeline window is zero");

--- a/comms/prims/collectives/ReduceScatterDirect.cu
+++ b/comms/prims/collectives/ReduceScatterDirect.cu
@@ -41,7 +41,7 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_nvl_kernel(
   }
 
   const std::size_t pipeline_window =
-      direct_pipeline_window(args.peers, my_rank, W, group.total_groups);
+      direct_pipeline_window(args.peers, my_rank, W);
   PIPES_DEVICE_CHECK_MSG(
       pipeline_window != 0,
       "direct NVLink reduce-scatter pipeline window is zero");

--- a/comms/prims/collectives/benchmarks/AllGatherBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/AllGatherBenchmark.cc
@@ -205,9 +205,9 @@ class AllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
     // Setup P2P NVL transport
     MultiPeerNvlTransportConfig nvlConfig{
-        .dataBufferSize = config.dataBufferSize,
-        .chunkSize = config.chunkSize,
         .pipelineDepth = config.pipelineDepth,
+        .maxNumChannels = 64,
+        .perChannelSize = (config.dataBufferSize) / 64,
     };
 
     // Create transport with bootstrap and exchange IPC handles

--- a/comms/prims/collectives/benchmarks/AllToAllvBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/AllToAllvBenchmark.cc
@@ -40,7 +40,7 @@ struct AllToAllvBenchmarkConfig {
   int numThreads;
   std::size_t pipelineDepth = 4;
   std::size_t chunkSize = 512 * 1024; // 512KB default
-  std::size_t dataBufferSize = 2048; // Data buffer size for P2P transport
+  std::size_t perChannelSize = 32; // Per-channel staging size for NVL transport
   bool spreadClusterLaunch = false; // Use spread cluster kernel launch
   std::string name;
 };
@@ -248,9 +248,9 @@ class AllToAllvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
     // Setup P2P NVL transport
     MultiPeerNvlTransportConfig nvlConfig{
-        .dataBufferSize = config.dataBufferSize,
-        .chunkSize = config.chunkSize,
         .pipelineDepth = config.pipelineDepth,
+        .maxNumChannels = 64,
+        .perChannelSize = config.perChannelSize,
     };
 
     // Create transport with bootstrap and exchange IPC handles
@@ -470,7 +470,7 @@ TEST_F(AllToAllvBenchmarkFixture, OptimalConfigs) {
   }
 
   std::vector<AllToAllvBenchmarkConfig> configs;
-  std::size_t kDataBufferSize = 8 * 1024 * 1024; // 8MB
+  std::size_t kPerChannelSize = 128 * 1024;
 
   // === Block Count Tuning ===
   // Block counts are matched to NCCL channel counts for fair comparison.
@@ -496,7 +496,7 @@ TEST_F(AllToAllvBenchmarkFixture, OptimalConfigs) {
       .numThreads = 512,
       .pipelineDepth = 2,
       .chunkSize = 64 * 1024, // 64KB
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .spreadClusterLaunch = true,
       .name = "256K_8B",
   });
@@ -508,7 +508,7 @@ TEST_F(AllToAllvBenchmarkFixture, OptimalConfigs) {
       .numThreads = 512,
       .pipelineDepth = 2,
       .chunkSize = 64 * 1024, // 64KB
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .spreadClusterLaunch = true,
       .name = "512K_16B",
   });
@@ -520,7 +520,7 @@ TEST_F(AllToAllvBenchmarkFixture, OptimalConfigs) {
       .numThreads = 512,
       .pipelineDepth = 2,
       .chunkSize = 64 * 1024, // 64KB
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .spreadClusterLaunch = true,
       .name = "1M_16B",
   });
@@ -532,7 +532,7 @@ TEST_F(AllToAllvBenchmarkFixture, OptimalConfigs) {
       .numThreads = 512,
       .pipelineDepth = 2,
       .chunkSize = 128 * 1024, // 128KB
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .spreadClusterLaunch = true,
       .name = "2M_16B",
   });
@@ -544,7 +544,7 @@ TEST_F(AllToAllvBenchmarkFixture, OptimalConfigs) {
       .numThreads = 512,
       .pipelineDepth = 2,
       .chunkSize = 128 * 1024, // 128KB
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .spreadClusterLaunch = true,
       .name = "4M_16B",
   });
@@ -556,7 +556,7 @@ TEST_F(AllToAllvBenchmarkFixture, OptimalConfigs) {
       .numThreads = 512,
       .pipelineDepth = 2,
       .chunkSize = 128 * 1024, // 128KB
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .spreadClusterLaunch = true,
       .name = "8M_16B",
   });
@@ -568,7 +568,7 @@ TEST_F(AllToAllvBenchmarkFixture, OptimalConfigs) {
       .numThreads = 512,
       .pipelineDepth = 2,
       .chunkSize = 128 * 1024, // 128KB
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .spreadClusterLaunch = true,
       .name = "16M_16B",
   });
@@ -580,7 +580,7 @@ TEST_F(AllToAllvBenchmarkFixture, OptimalConfigs) {
       .numThreads = 512,
       .pipelineDepth = 2,
       .chunkSize = 128 * 1024, // 128KB
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .spreadClusterLaunch = true,
       .name = "32M_16B",
   });
@@ -592,7 +592,7 @@ TEST_F(AllToAllvBenchmarkFixture, OptimalConfigs) {
       .numThreads = 512,
       .pipelineDepth = 2,
       .chunkSize = 256 * 1024, // 256KB
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .spreadClusterLaunch = true,
       .name = "64M_16B",
   });
@@ -604,7 +604,7 @@ TEST_F(AllToAllvBenchmarkFixture, OptimalConfigs) {
       .numThreads = 512,
       .pipelineDepth = 2,
       .chunkSize = 256 * 1024, // 256KB
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .spreadClusterLaunch = true,
       .name = "128M_16B",
   });
@@ -616,7 +616,7 @@ TEST_F(AllToAllvBenchmarkFixture, OptimalConfigs) {
       .numThreads = 512,
       .pipelineDepth = 2,
       .chunkSize = 256 * 1024, // 256KB
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .spreadClusterLaunch = true,
       .name = "512M_32B",
   });
@@ -628,7 +628,7 @@ TEST_F(AllToAllvBenchmarkFixture, OptimalConfigs) {
       .numThreads = 512,
       .pipelineDepth = 2,
       .chunkSize = 256 * 1024, // 256KB
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .spreadClusterLaunch = true,
       .name = "1G_32B",
   });

--- a/comms/prims/collectives/benchmarks/AllToAllvLl128Benchmark.cc
+++ b/comms/prims/collectives/benchmarks/AllToAllvLl128Benchmark.cc
@@ -38,7 +38,7 @@ struct Ll128BenchmarkConfig {
   bool simpleSpreadCluster;
   std::size_t pipelineDepth;
   std::size_t chunkSize;
-  std::size_t dataBufferSize;
+  std::size_t perChannelSize;
   // LL128 protocol settings
   int ll128NumBlocks;
   int ll128NumThreads;
@@ -224,9 +224,9 @@ class AllToAllvLl128BenchmarkFixture
     CUDA_CHECK(cudaMemset(recvBuffer.get(), 0, totalBytes));
 
     MultiPeerNvlTransportConfig nvlConfig{
-        .dataBufferSize = config.dataBufferSize,
-        .chunkSize = config.chunkSize,
         .pipelineDepth = config.pipelineDepth,
+        .maxNumChannels = 64,
+        .perChannelSize = config.perChannelSize,
     };
 
     MultiPeerNvlTransport transport(globalRank, nranks, bootstrap, nvlConfig);
@@ -335,9 +335,9 @@ class AllToAllvLl128BenchmarkFixture
     CUDA_CHECK(cudaMemset(recvBuffer.get(), 0, totalBytes));
 
     MultiPeerNvlTransportConfig nvlConfig{
-        .dataBufferSize = config.dataBufferSize,
-        .chunkSize = config.chunkSize,
         .pipelineDepth = config.pipelineDepth,
+        .maxNumChannels = 64,
+        .perChannelSize = config.perChannelSize,
         .ll128BufferSize = ll128_buffer_size(bytesPerPeer),
     };
 
@@ -509,7 +509,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128VsSimpleVsNccl) {
   }
 
   std::vector<Ll128BenchmarkConfig> configs;
-  const std::size_t kDataBufferSize = 8 * 1024 * 1024; // 8MB
+  const std::size_t kPerChannelSize = 128 * 1024;
 
   // Message sizes focused on LL128's sweet spot
   // Simple protocol settings from AllToAllvBenchmark.cc for fair comparison
@@ -527,7 +527,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128VsSimpleVsNccl) {
       .simpleSpreadCluster = true,
       .pipelineDepth = 2,
       .chunkSize = 64 * 1024,
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .ll128NumBlocks = auto_ll128_blocks(128),
       .ll128NumThreads = 512,
       .name = "128B",
@@ -541,7 +541,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128VsSimpleVsNccl) {
       .simpleSpreadCluster = true,
       .pipelineDepth = 2,
       .chunkSize = 64 * 1024,
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .ll128NumBlocks = auto_ll128_blocks(256),
       .ll128NumThreads = 512,
       .name = "256B",
@@ -555,7 +555,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128VsSimpleVsNccl) {
       .simpleSpreadCluster = true,
       .pipelineDepth = 2,
       .chunkSize = 64 * 1024,
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .ll128NumBlocks = auto_ll128_blocks(512),
       .ll128NumThreads = 512,
       .name = "512B",
@@ -569,7 +569,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128VsSimpleVsNccl) {
       .simpleSpreadCluster = true,
       .pipelineDepth = 2,
       .chunkSize = 64 * 1024,
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .ll128NumBlocks = auto_ll128_blocks(1024),
       .ll128NumThreads = 512,
       .name = "1KB",
@@ -583,7 +583,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128VsSimpleVsNccl) {
       .simpleSpreadCluster = true,
       .pipelineDepth = 2,
       .chunkSize = 64 * 1024,
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .ll128NumBlocks = auto_ll128_blocks(4 * 1024),
       .ll128NumThreads = 512,
       .name = "4KB",
@@ -597,7 +597,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128VsSimpleVsNccl) {
       .simpleSpreadCluster = true,
       .pipelineDepth = 2,
       .chunkSize = 64 * 1024,
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .ll128NumBlocks = auto_ll128_blocks(16 * 1024),
       .ll128NumThreads = 512,
       .name = "16KB",
@@ -611,7 +611,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128VsSimpleVsNccl) {
       .simpleSpreadCluster = true,
       .pipelineDepth = 2,
       .chunkSize = 64 * 1024,
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .ll128NumBlocks = auto_ll128_blocks(64 * 1024),
       .ll128NumThreads = 512,
       .name = "64KB",
@@ -625,7 +625,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128VsSimpleVsNccl) {
       .simpleSpreadCluster = true,
       .pipelineDepth = 2,
       .chunkSize = 64 * 1024,
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .ll128NumBlocks = auto_ll128_blocks(256 * 1024),
       .ll128NumThreads = 512,
       .name = "256KB",
@@ -639,7 +639,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128VsSimpleVsNccl) {
       .simpleSpreadCluster = true,
       .pipelineDepth = 2,
       .chunkSize = 64 * 1024,
-      .dataBufferSize = kDataBufferSize,
+      .perChannelSize = kPerChannelSize,
       .ll128NumBlocks = auto_ll128_blocks(1024 * 1024),
       .ll128NumThreads = 512,
       .name = "1MB",
@@ -684,7 +684,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, LatencySweep) {
         << "\n=== LL128 vs Simple vs NCCL Latency Sweep (for Triton comparison) ===\n";
   }
 
-  const std::size_t kDataBufferSize = 8 * 1024 * 1024; // 8MB
+  const std::size_t kPerChannelSize = 128 * 1024;
 
   auto auto_ll128_blocks = [&](std::size_t bytesPerPeer) {
     return ll128_auto_tune_alltoallv(bytesPerPeer, worldSize).numBlocks;
@@ -738,7 +738,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, LatencySweep) {
         .simpleSpreadCluster = sz.simpleSpreadCluster,
         .pipelineDepth = 2,
         .chunkSize = sz.chunkSize,
-        .dataBufferSize = kDataBufferSize,
+        .perChannelSize = kPerChannelSize,
         .ll128NumBlocks = sz.runLl128 ? auto_ll128_blocks(sz.bytesPerPeer) : 1,
         .ll128NumThreads = 512,
         .name = sz.name,
@@ -900,7 +900,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128BlockThreadSweep) {
           .simpleSpreadCluster = false,
           .pipelineDepth = 2,
           .chunkSize = 64 * 1024,
-          .dataBufferSize = 8 * 1024 * 1024,
+          .perChannelSize = 128 * 1024,
           .ll128NumBlocks = numBlocks,
           .ll128NumThreads = 512,
           .name = "",
@@ -998,7 +998,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128ThreadSweep) {
             .simpleSpreadCluster = false,
             .pipelineDepth = 2,
             .chunkSize = 64 * 1024,
-            .dataBufferSize = 8 * 1024 * 1024,
+            .perChannelSize = 128 * 1024,
             .ll128NumBlocks = numBlocks,
             .ll128NumThreads = numThreads,
             .name = "",

--- a/comms/prims/collectives/benchmarks/HierarchicalAllGatherBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/HierarchicalAllGatherBenchmark.cc
@@ -367,8 +367,6 @@ class HierarchicalAllGatherBenchmarkFixture
         auto nvl_bootstrap = std::make_shared<NvlBootstrapAdapter>(
             bootstrap, std::move(nvl_rank_to_global));
         MultiPeerNvlTransportConfig transport_config{
-            .dataBufferSize = config.data_buffer_size,
-            .chunkSize = config.data_buffer_size,
             .pipelineDepth = static_cast<std::size_t>(config.pipeline_depth),
             .p2pSignalCount = static_cast<std::size_t>(config.num_blocks),
             .maxNumChannels = config.num_blocks,

--- a/comms/prims/collectives/moe_ep/cpp/intranode/Runtime.cc
+++ b/comms/prims/collectives/moe_ep/cpp/intranode/Runtime.cc
@@ -62,9 +62,9 @@ IntranodeRuntime::IntranodeRuntime(
   //    state buffers (chunked-send pipelining) — not the dispatch/combine
   //    data block (which lives in `memHandler_`).
   comms::prims::MultiPeerNvlTransportConfig nvlConfig{
-      .dataBufferSize = 1024UL * 1024UL, // 1 MiB transport state
-      .chunkSize = 1024,
       .pipelineDepth = 4,
+      .maxNumChannels = 64,
+      .perChannelSize = (1024UL * 1024UL) / 64,
       // numSignalSlots is dimensioned by callers; for Phase 1 dispatch +
       // combine we need ~num_channels*num_peers*2 slots. With num_sms=64,
       // num_channels=32 and 7 peers → ~448 slots. Bump to 1024 to avoid

--- a/comms/prims/collectives/tests/AllToAllvLl128Test.cc
+++ b/comms/prims/collectives/tests/AllToAllvLl128Test.cc
@@ -25,6 +25,11 @@ using meta::comms::DeviceBuffer;
 
 namespace comms::prims {
 
+namespace {
+constexpr int kNvlMaxNumChannels = 64;
+constexpr std::size_t kNvlPerChannelSize = 64 * 1024;
+} // namespace
+
 class AllToAllvLl128TestFixture : public BenchmarkTestFixture {
  protected:
   void SetUp() override {
@@ -74,9 +79,9 @@ TEST_P(AllToAllvLl128EqualSizeTest, AllToAllvLl128EqualSize) {
 
   // Transport config with LL128 buffers enabled
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = std::max(size_t(2048), bufferSize),
-      .chunkSize = 512,
       .pipelineDepth = 4,
+      .maxNumChannels = kNvlMaxNumChannels,
+      .perChannelSize = kNvlPerChannelSize,
       .ll128BufferSize = (params.ll128BufferNumPackets > 0)
           ? params.ll128BufferNumPackets * kLl128PacketSize
           : ll128_buffer_size(perPeerBytes),
@@ -477,15 +482,11 @@ TEST_P(AllToAllvLl128UnequalSizeTest, AllToAllvLl128UnequalSize) {
   size_t maxPerPeerInts = (2 * worldSize - 1) * base_ints;
   size_t maxPerPeerBytes = maxPerPeerInts * sizeof(int32_t);
 
-  // Calculate max total buffer needed for any rank
-  size_t max_total_ints = worldSize * (2 * worldSize - 1 + 1) / 2 * base_ints;
-  size_t max_buffer_size = max_total_ints * sizeof(int32_t);
-
   // Transport config with LL128 buffers
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = std::max(size_t(2048), max_buffer_size),
-      .chunkSize = 512,
       .pipelineDepth = 4,
+      .maxNumChannels = kNvlMaxNumChannels,
+      .perChannelSize = kNvlPerChannelSize,
       .ll128BufferSize = ll128_buffer_size(maxPerPeerBytes),
   };
 
@@ -687,14 +688,10 @@ TEST_P(AllToAllvLl128ZeroPeerTest, AllToAllvLl128ZeroPeer) {
   size_t maxPerPeerInts = (2 * worldSize - 2) * base_ints;
   size_t maxPerPeerBytes = maxPerPeerInts * sizeof(int32_t);
 
-  size_t max_total_ints = worldSize * (2 * worldSize - 2 + 0) / 2 * base_ints;
-  size_t max_buffer_size =
-      std::max(size_t(16), max_total_ints * sizeof(int32_t));
-
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = std::max(size_t(2048), max_buffer_size),
-      .chunkSize = 512,
       .pipelineDepth = 4,
+      .maxNumChannels = kNvlMaxNumChannels,
+      .perChannelSize = kNvlPerChannelSize,
       .ll128BufferSize =
           ll128_buffer_size(std::max(size_t(16), maxPerPeerBytes)),
   };
@@ -869,9 +866,9 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedMultiCall) {
   const size_t perPeerBytes = numIntsPerRank * sizeof(int32_t);
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = std::max(size_t(2048), bufferSize),
-      .chunkSize = 512,
       .pipelineDepth = 4,
+      .maxNumChannels = kNvlMaxNumChannels,
+      .perChannelSize = kNvlPerChannelSize,
       .ll128BufferSize = ll128_buffer_size(perPeerBytes),
   };
 
@@ -1005,9 +1002,9 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedMultiCallChunked) {
   const size_t perPeerBytes = numIntsPerRank * sizeof(int32_t);
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = std::max(size_t(2048), bufferSize),
-      .chunkSize = 512,
       .pipelineDepth = 4,
+      .maxNumChannels = kNvlMaxNumChannels,
+      .perChannelSize = kNvlPerChannelSize,
       .ll128BufferSize = ll128BufferNumPackets * kLl128PacketSize,
   };
 
@@ -1148,9 +1145,9 @@ TEST_F(AllToAllvLl128TestFixture, ChunkedBlockCountSweep) {
         numBlocks);
 
     MultiPeerNvlTransportConfig config{
-        .dataBufferSize = std::max(size_t(2048), bufferSize),
-        .chunkSize = 512,
         .pipelineDepth = 4,
+        .maxNumChannels = kNvlMaxNumChannels,
+        .perChannelSize = kNvlPerChannelSize,
         .ll128BufferSize = ll128BufferNumPackets * kLl128PacketSize,
     };
 
@@ -1307,9 +1304,9 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedVaryingSizes) {
   size_t maxBufferSize = maxTotalInts * sizeof(int32_t);
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = std::max(size_t(2048), maxBufferSize),
-      .chunkSize = 512,
       .pipelineDepth = 4,
+      .maxNumChannels = kNvlMaxNumChannels,
+      .perChannelSize = kNvlPerChannelSize,
       .ll128BufferSize = ll128_buffer_size(maxPerPeerBytes),
   };
 
@@ -1447,9 +1444,9 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedVaryingSizes_Chunked) {
   size_t maxBufferSize = maxTotalInts * sizeof(int32_t);
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = std::max(size_t(2048), maxBufferSize),
-      .chunkSize = 512,
       .pipelineDepth = 4,
+      .maxNumChannels = kNvlMaxNumChannels,
+      .perChannelSize = kNvlPerChannelSize,
       .ll128BufferSize = ll128BufferNumPackets * kLl128PacketSize,
   };
 
@@ -1577,9 +1574,9 @@ TEST_F(AllToAllvLl128TestFixture, AutoDispatch_1KB_UsesLl128) {
   const size_t perPeerBytes = numIntsPerRank * sizeof(int32_t);
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = std::max(size_t(2048), bufferSize),
-      .chunkSize = 512,
       .pipelineDepth = 4,
+      .maxNumChannels = kNvlMaxNumChannels,
+      .perChannelSize = kNvlPerChannelSize,
       .ll128BufferSize = ll128_buffer_size(perPeerBytes),
   };
 
@@ -1690,9 +1687,9 @@ TEST_F(AllToAllvLl128TestFixture, AutoDispatch_256KB_UsesLl128) {
   const size_t perPeerBytes = numIntsPerRank * sizeof(int32_t);
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = std::max(size_t(2048), bufferSize),
-      .chunkSize = 512,
       .pipelineDepth = 4,
+      .maxNumChannels = kNvlMaxNumChannels,
+      .perChannelSize = kNvlPerChannelSize,
       .ll128BufferSize = ll128_buffer_size(perPeerBytes),
   };
 
@@ -1803,9 +1800,9 @@ TEST_F(AllToAllvLl128TestFixture, AutoDispatch_512KB_UsesSimple) {
   const size_t perPeerBytes = numIntsPerRank * sizeof(int32_t);
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = std::max(size_t(2048), bufferSize),
-      .chunkSize = 512,
       .pipelineDepth = 4,
+      .maxNumChannels = kNvlMaxNumChannels,
+      .perChannelSize = kNvlPerChannelSize,
       .ll128BufferSize = ll128_buffer_size(256 * 1024),
   };
 

--- a/comms/prims/collectives/tests/AllToAllvLl128_2GpuTest.cc
+++ b/comms/prims/collectives/tests/AllToAllvLl128_2GpuTest.cc
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
+
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
 
@@ -17,6 +19,11 @@
 using namespace meta::comms;
 
 namespace comms::prims {
+
+namespace {
+constexpr int kNvlMaxNumChannels = 64;
+constexpr std::size_t kNvlPerChannelSize = 64 * 1024;
+} // namespace
 
 // =============================================================================
 // 2-GPU AllToAllV fixture — exercises minimum rank count (Gap 5)
@@ -50,9 +57,9 @@ TEST_F(AllToAllvLl128_2GpuTestFixture, EqualSize_2GPU_4KB) {
   const size_t perPeerBytes = numIntsPerRank * sizeof(int32_t);
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = std::max(size_t(2048), bufferSize),
-      .chunkSize = 512,
       .pipelineDepth = 4,
+      .maxNumChannels = kNvlMaxNumChannels,
+      .perChannelSize = kNvlPerChannelSize,
       .ll128BufferSize = ll128_buffer_size(perPeerBytes),
   };
 
@@ -177,9 +184,9 @@ TEST_F(AllToAllvLl128_2GpuTestFixture, EqualSize_2GPU_64KB) {
   const size_t perPeerBytes = numIntsPerRank * sizeof(int32_t);
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = std::max(size_t(2048), bufferSize),
-      .chunkSize = 512,
       .pipelineDepth = 4,
+      .maxNumChannels = kNvlMaxNumChannels,
+      .perChannelSize = kNvlPerChannelSize,
       .ll128BufferSize = ll128_buffer_size(perPeerBytes),
   };
 

--- a/comms/prims/collectives/tests/DirectNvlTest.cc
+++ b/comms/prims/collectives/tests/DirectNvlTest.cc
@@ -19,6 +19,8 @@ namespace comms::prims::test {
 
 namespace {
 
+constexpr std::size_t kNvlPerChannelSize = 128 * 1024;
+
 struct DirectNvlTestParams {
   std::size_t bytes{0};
   int num_blocks{8};
@@ -34,15 +36,13 @@ std::unique_ptr<MultiPeerNvlTransport> make_nvl_transport(
     int globalRank,
     int worldSize,
     std::shared_ptr<meta::comms::IBootstrap> bootstrap,
-    std::size_t dataBufferSize,
+    std::size_t perChannelSize,
     int numBlocks) {
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = dataBufferSize,
-      .chunkSize = dataBufferSize,
       .pipelineDepth = 2,
       .p2pSignalCount = static_cast<std::size_t>(numBlocks),
       .maxNumChannels = numBlocks,
-      .perChannelSize = dataBufferSize / static_cast<std::size_t>(numBlocks),
+      .perChannelSize = perChannelSize,
       .memSharingMode = MemSharingMode::kCudaIpc,
   };
   auto transport = std::make_unique<MultiPeerNvlTransport>(
@@ -70,7 +70,11 @@ TEST_P(DirectAllGatherNvlTest, Correctness) {
   std::unique_ptr<MultiPeerNvlTransport> transport;
   try {
     transport = make_nvl_transport(
-        globalRank, worldSize, bootstrap, 1024 * 1024, params.num_blocks);
+        globalRank,
+        worldSize,
+        bootstrap,
+        kNvlPerChannelSize,
+        params.num_blocks);
   } catch (const std::exception& e) {
     GTEST_SKIP() << "NVLink transport not available: " << e.what();
   }
@@ -123,7 +127,11 @@ TEST_P(DirectReduceScatterNvlTest, Correctness) {
   std::unique_ptr<MultiPeerNvlTransport> transport;
   try {
     transport = make_nvl_transport(
-        globalRank, worldSize, bootstrap, 1024 * 1024, params.num_blocks);
+        globalRank,
+        worldSize,
+        bootstrap,
+        kNvlPerChannelSize,
+        params.num_blocks);
   } catch (const std::exception& e) {
     GTEST_SKIP() << "NVLink transport not available: " << e.what();
   }

--- a/comms/prims/collectives/tests/HierarchicalAllGatherTest.cc
+++ b/comms/prims/collectives/tests/HierarchicalAllGatherTest.cc
@@ -56,8 +56,6 @@ class HierarchicalAllGatherTest : public AllGatherTestBase {
     std::unique_ptr<MultiPeerNvlTransport> nvlTransport;
     try {
       MultiPeerNvlTransportConfig nvlConfig{
-          .dataBufferSize = 1024 * 1024,
-          .chunkSize = 1024 * 1024,
           .pipelineDepth = 2,
           .p2pSignalCount = static_cast<std::size_t>(kNumBlocks),
           .maxNumChannels = kNumBlocks,

--- a/comms/prims/tests/AllGatherTest.cc
+++ b/comms/prims/tests/AllGatherTest.cc
@@ -99,9 +99,9 @@ TEST_P(AllGatherTest, AllGatherBasic) {
   const size_t recvBufferSize = worldSize * sendcount;
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = std::max(size_t(2048), recvBufferSize), // At least 2KB
-      .chunkSize = 512, // 512 byte chunk size
       .pipelineDepth = 4,
+      .maxNumChannels = 64,
+      .perChannelSize = (std::max(size_t(2048), recvBufferSize)) / 64,
   };
 
   // Create transport and exchange IPC handles
@@ -292,9 +292,10 @@ TEST_P(AllGatherLargeTest, AllGatherLarge) {
   const size_t recvBufferSize = worldSize * sendcount;
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = std::max(size_t(8 * 1024 * 1024), recvBufferSize),
-      .chunkSize = 64 * 1024, // 64KB chunk size for large messages
       .pipelineDepth = 4,
+      .maxNumChannels = 64,
+      .perChannelSize =
+          (std::max(size_t(8 * 1024 * 1024), recvBufferSize)) / 64,
   };
 
   MultiPeerNvlTransport transport(globalRank, worldSize, bootstrap, config);

--- a/comms/prims/tests/AllToAllvTest.cc
+++ b/comms/prims/tests/AllToAllvTest.cc
@@ -24,6 +24,9 @@ namespace comms::prims {
 
 namespace {
 // Helper function to print device buffer contents
+constexpr int kNvlMaxNumChannels = 64;
+constexpr std::size_t kNvlPerChannelSize = 64 * 1024;
+
 void printDeviceBuffer(
     const char* label,
     void* deviceBuffer,
@@ -103,9 +106,9 @@ TEST_P(AllToAllvEqualSizeTest, AllToAllvEqualSize) {
   const size_t bufferSize = totalInts * sizeof(int32_t);
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = std::max(size_t(2048), bufferSize), // At least 2KB
-      .chunkSize = 512, // 512 byte chunk size
       .pipelineDepth = 4,
+      .maxNumChannels = kNvlMaxNumChannels,
+      .perChannelSize = kNvlPerChannelSize,
   };
 
   // Create transport and exchange IPC handles
@@ -318,24 +321,10 @@ TEST_P(AllToAllvUnequalSizeTest, AllToAllvUnequalSize) {
       blockSize,
       base_ints);
 
-  // Calculate max buffer size needed for any rank
-  // Max size happens at the highest rank pair: (worldSize-1 + worldSize-1 + 1)
-  // * base_ints * sizeof(int32_t) Total for one rank = sum of (globalRank +
-  // rank
-  // + 1) for rank in [0, worldSize)
-  //                    = worldSize * globalRank + sum(rank) + worldSize
-  //                    = worldSize * globalRank + worldSize*(worldSize-1)/2 +
-  //                    worldSize
-  // Worst case (highest rank): worldSize * (worldSize-1) +
-  // worldSize*(worldSize-1)/2 + worldSize
-  size_t max_total_ints = worldSize * (2 * worldSize - 1 + 1) / 2 * base_ints;
-  size_t max_buffer_size = max_total_ints * sizeof(int32_t);
-
-  // Configuration for P2pNvlTransport - use dynamic buffer size
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = std::max(size_t(2048), max_buffer_size), // At least 2KB
-      .chunkSize = 512,
       .pipelineDepth = 4,
+      .maxNumChannels = kNvlMaxNumChannels,
+      .perChannelSize = kNvlPerChannelSize,
   };
 
   // Create transport and exchange IPC handles

--- a/comms/prims/tests/BarrierTest.cc
+++ b/comms/prims/tests/BarrierTest.cc
@@ -289,7 +289,6 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpu) {
   // Create transport options
   P2pNvlTransportOptions options{
       .dataBufferSize = 1024,
-      .chunkSize = 512,
       .pipelineDepth = 2,
   };
 
@@ -388,7 +387,6 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpuMultipleIds) {
 
   P2pNvlTransportOptions options{
       .dataBufferSize = 1024,
-      .chunkSize = 512,
       .pipelineDepth = 2,
   };
 
@@ -497,7 +495,6 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpuMultipleSyncs) {
 
   P2pNvlTransportOptions options{
       .dataBufferSize = 1024,
-      .chunkSize = 512,
       .pipelineDepth = 2,
   };
 
@@ -603,7 +600,6 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierSyncTwoGpuBlockGroups) {
 
   P2pNvlTransportOptions options{
       .dataBufferSize = 1024,
-      .chunkSize = 512,
       .pipelineDepth = 2,
   };
 
@@ -722,7 +718,6 @@ TEST_F(BarrierTwoGpuFixture, DeviceBarrierDataTransferVerification) {
 
   P2pNvlTransportOptions options{
       .dataBufferSize = 1024,
-      .chunkSize = 512,
       .pipelineDepth = 2,
   };
 

--- a/comms/prims/tests/ExternalStagingBuffersTest.cc
+++ b/comms/prims/tests/ExternalStagingBuffersTest.cc
@@ -27,9 +27,13 @@ namespace comms::prims::tests {
 
 namespace {
 constexpr std::size_t kDataBufferSize = 1024 * 1024; // 1MB per peer
-constexpr std::size_t kChunkSize = 1024;
 constexpr std::size_t kPipelineDepth = 4;
 constexpr std::size_t kNumElements = 256;
+
+std::size_t dataBufferSize(const MultiPeerNvlTransportConfig& config) {
+  return static_cast<std::size_t>(config.maxNumChannels) *
+      config.perChannelSize;
+}
 } // namespace
 
 class ExternalStagingBuffersTestFixture : public MpiBaseTestFixture {
@@ -46,9 +50,9 @@ class ExternalStagingBuffersTestFixture : public MpiBaseTestFixture {
 
   MultiPeerNvlTransportConfig defaultConfig() {
     return MultiPeerNvlTransportConfig{
-        .dataBufferSize = kDataBufferSize,
-        .chunkSize = kChunkSize,
         .pipelineDepth = kPipelineDepth,
+        .maxNumChannels = 64,
+        .perChannelSize = (kDataBufferSize) / 64,
     };
   }
 
@@ -114,7 +118,7 @@ TEST_F(ExternalStagingBuffersTestFixture, TransportUsesExternalBuffers) {
 
   auto config = defaultConfig();
   const std::size_t perPeerDataSize =
-      config.pipelineDepth * config.dataBufferSize;
+      config.pipelineDepth * dataBufferSize(config);
   auto bootstrap = std::make_shared<MpiBootstrap>();
 
   // Allocate external buffers via IPC
@@ -168,9 +172,10 @@ TEST_F(ExternalStagingBuffersTestFixture, IpcMemAccessThroughExternalBuffers) {
   const int peerRank = (globalRank == 0) ? 1 : 0;
 
   auto config = defaultConfig();
-  config.dataBufferSize = sizeof(int) * kNumElements;
+  config.maxNumChannels = 1;
+  config.perChannelSize = sizeof(int) * kNumElements;
   const std::size_t perPeerDataSize =
-      config.pipelineDepth * config.dataBufferSize;
+      config.pipelineDepth * dataBufferSize(config);
   auto bootstrap = std::make_shared<MpiBootstrap>();
 
   // Allocate external buffers via IPC
@@ -232,7 +237,8 @@ TEST_F(ExternalStagingBuffersTestFixture, DefaultPathAllocatesInternalBuffers) {
   const int peerRank = (globalRank == 0) ? 1 : 0;
 
   auto config = defaultConfig();
-  config.dataBufferSize = sizeof(int) * kNumElements;
+  config.maxNumChannels = 1;
+  config.perChannelSize = sizeof(int) * kNumElements;
   auto bootstrap = std::make_shared<MpiBootstrap>();
 
   // Create transport WITHOUT external buffers (default path)
@@ -282,7 +288,7 @@ TEST_F(ExternalStagingBuffersTestFixture, StateAndSignalBuffersStillAllocated) {
 
   auto config = defaultConfig();
   const std::size_t perPeerDataSize =
-      config.pipelineDepth * config.dataBufferSize;
+      config.pipelineDepth * dataBufferSize(config);
   auto bootstrap = std::make_shared<MpiBootstrap>();
 
   auto extBuf = allocateExternalBuffers(bootstrap, perPeerDataSize);

--- a/comms/prims/tests/HostWindowTest.cc
+++ b/comms/prims/tests/HostWindowTest.cc
@@ -35,9 +35,9 @@ class HostWindowTestFixture : public MpiBaseTestFixture {
   std::unique_ptr<MultiPeerTransport> createTransport() {
     auto bootstrap = std::make_shared<MpiBootstrap>();
     MultiPeerTransportConfig config;
-    config.nvlConfig.dataBufferSize = 1024 * 1024;
-    config.nvlConfig.chunkSize = 64 * 1024;
     config.nvlConfig.pipelineDepth = 2;
+    config.nvlConfig.maxNumChannels = 64;
+    config.nvlConfig.perChannelSize = 16 * 1024;
     auto transport = std::make_unique<MultiPeerTransport>(
         globalRank, numRanks, localRank, bootstrap, config);
     transport->exchange();

--- a/comms/prims/tests/MultiPeerNvlTransportIntegrationTest.cc
+++ b/comms/prims/tests/MultiPeerNvlTransportIntegrationTest.cc
@@ -34,7 +34,8 @@ namespace comms::prims::tests {
 
 namespace {
 // Default configuration for transport setup
-constexpr std::size_t kDefaultDataBufferSize = 1024 * 1024; // 1MB
+constexpr int kDefaultMaxNumChannels = 64;
+constexpr std::size_t kDefaultPerChannelSize = 16 * 1024;
 constexpr std::size_t kDefaultChunkSize = 1024;
 constexpr std::size_t kDefaultPipelineDepth = 4;
 
@@ -116,9 +117,9 @@ class MultiPeerNvlTransportIntegrationTestFixture : public MpiBaseTestFixture {
         transportName == nullptr ? "DeviceWindow" : transportName;
 
     MultiPeerNvlTransportConfig config{
-        .dataBufferSize = kDefaultDataBufferSize,
-        .chunkSize = kDefaultChunkSize,
         .pipelineDepth = kDefaultPipelineDepth,
+        .maxNumChannels = kDefaultMaxNumChannels,
+        .perChannelSize = kDefaultPerChannelSize,
     };
     WindowConfig wmConfig{
         .peerSignalCount = kDefaultSignalCount,
@@ -173,9 +174,9 @@ class MultiPeerNvlTransportIntegrationTestFixture : public MpiBaseTestFixture {
 
     constexpr std::size_t kTransferSize = 4096;
     MultiPeerNvlTransportConfig config{
-        .dataBufferSize = kDefaultDataBufferSize,
-        .chunkSize = kDefaultChunkSize,
         .pipelineDepth = kDefaultPipelineDepth,
+        .maxNumChannels = kDefaultMaxNumChannels,
+        .perChannelSize = kDefaultPerChannelSize,
     };
     WindowConfig wmConfig{
         .peerSignalCount = kDefaultSignalCount,
@@ -283,9 +284,9 @@ TEST_F(
     MultiPeerNvlTransportIntegrationTestFixture,
     GetMultiPeerDeviceTransport) {
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDefaultDataBufferSize,
-      .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kDefaultPerChannelSize,
   };
 
   auto [transport, window, dw] = createTransport(config);
@@ -327,9 +328,9 @@ TEST_F(
   // Test that MultiPeerDeviceTransport can be constructed multiple times
   // and returns consistent results
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDefaultDataBufferSize,
-      .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kDefaultPerChannelSize,
   };
 
   auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
@@ -399,11 +400,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BidirectionalSignalWait) {
     GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
   }
 
-  const size_t dataBufferSize = 1024 * 1024;
+  constexpr std::size_t kPerChannelSize = kDefaultPerChannelSize;
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = dataBufferSize,
-      .chunkSize = 1024,
       .pipelineDepth = 4,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kPerChannelSize,
   };
   WindowConfig wmConfig{
       .peerSignalCount = kDefaultSignalCount,
@@ -458,11 +459,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BidirectionalSignalWait) {
 // =============================================================================
 
 TEST_F(MultiPeerNvlTransportIntegrationTestFixture, Barrier) {
-  const size_t dataBufferSize = 1024 * 1024;
+  constexpr std::size_t kPerChannelSize = kDefaultPerChannelSize;
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = dataBufferSize,
-      .chunkSize = 1024,
       .pipelineDepth = 4,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kPerChannelSize,
   };
   WindowConfig wmConfig{
       .barrierCount = 1,
@@ -501,9 +502,9 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierPeer) {
   }
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDefaultDataBufferSize,
-      .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kDefaultPerChannelSize,
   };
   WindowConfig wmConfig{
       .barrierCount = 1,
@@ -544,13 +545,13 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierPeer) {
 // =============================================================================
 
 TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MultipleBarriers) {
-  const size_t dataBufferSize = 1024 * 1024;
+  constexpr std::size_t kPerChannelSize = kDefaultPerChannelSize;
   // Use multiple barrier slots to avoid state accumulation issues
   constexpr int kNumBarrierSlots = 4;
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = dataBufferSize,
-      .chunkSize = 1024,
       .pipelineDepth = 4,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kPerChannelSize,
   };
   WindowConfig wmConfig{
       .barrierCount = kNumBarrierSlots,
@@ -602,12 +603,12 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MultipleSignalSlots) {
     GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
   }
 
-  const size_t dataBufferSize = 1024 * 1024;
+  constexpr std::size_t kPerChannelSize = kDefaultPerChannelSize;
   const int numSignalSlots = 4;
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = dataBufferSize,
-      .chunkSize = 1024,
       .pipelineDepth = 4,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kPerChannelSize,
   };
   WindowConfig wmConfig{
       .peerSignalCount = numSignalSlots,
@@ -652,12 +653,12 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, ConcurrentSignalSlots) {
     GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
   }
 
-  const size_t dataBufferSize = 1024 * 1024;
+  constexpr std::size_t kPerChannelSize = kDefaultPerChannelSize;
   const int numSignalSlots = 4;
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = dataBufferSize,
-      .chunkSize = 1024,
       .pipelineDepth = 4,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kPerChannelSize,
   };
   WindowConfig wmConfig{
       .peerSignalCount = numSignalSlots,
@@ -709,12 +710,12 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, ConcurrentSignalSlots) {
 // =============================================================================
 
 TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MultipleBarrierSlots) {
-  const size_t dataBufferSize = 1024 * 1024;
+  constexpr std::size_t kPerChannelSize = kDefaultPerChannelSize;
   const int numBarrierSlots = 4;
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = dataBufferSize,
-      .chunkSize = 1024,
       .pipelineDepth = 4,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kPerChannelSize,
   };
   WindowConfig wmConfig{
       .barrierCount = numBarrierSlots,
@@ -751,13 +752,13 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MultipleBarrierSlots) {
 }
 
 TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierSlotStress) {
-  const size_t dataBufferSize = 1024 * 1024;
+  constexpr std::size_t kPerChannelSize = kDefaultPerChannelSize;
   const int numBarrierSlots = 4;
   const int numIterations = 20;
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = dataBufferSize,
-      .chunkSize = 1024,
       .pipelineDepth = 4,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kPerChannelSize,
   };
   WindowConfig wmConfig{
       .barrierCount = numBarrierSlots,
@@ -801,12 +802,12 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierSlotStress) {
 // =============================================================================
 
 TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierMonotonicCounters) {
-  const size_t dataBufferSize = 1024 * 1024;
+  constexpr std::size_t kPerChannelSize = kDefaultPerChannelSize;
   constexpr int kNumPhases = 3;
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = dataBufferSize,
-      .chunkSize = 1024,
       .pipelineDepth = 4,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kPerChannelSize,
   };
   WindowConfig wmConfig{
       .barrierCount = 1, // Single barrier slot, reused via monotonic counters
@@ -849,11 +850,11 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierMultiBlockStress) {
   constexpr int kNumBlocks = 8;
   constexpr int kNumBarrierSlots = 8;
 
-  const size_t dataBufferSize = 1024 * 1024;
+  constexpr std::size_t kPerChannelSize = kDefaultPerChannelSize;
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = dataBufferSize,
-      .chunkSize = 1024,
       .pipelineDepth = 4,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kPerChannelSize,
   };
   WindowConfig wmConfig{
       .barrierCount = kNumBarrierSlots,
@@ -904,13 +905,13 @@ TEST_F(
     GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
   }
 
-  const size_t dataBufferSize = 1024 * 1024;
+  constexpr std::size_t kPerChannelSize = kDefaultPerChannelSize;
   const int numSignalSlots = 4;
   const int numBarrierSlots = 2;
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = dataBufferSize,
-      .chunkSize = 1024,
       .pipelineDepth = 4,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kPerChannelSize,
   };
   WindowConfig wmConfig{
       .peerSignalCount = numSignalSlots,
@@ -1019,9 +1020,9 @@ TEST_F(
 
   constexpr int kNumBlocks = 4;
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDefaultDataBufferSize,
-      .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kDefaultPerChannelSize,
   };
   WindowConfig wmConfig{
       .peerSignalCount = kMultiSlotSignalCount,
@@ -1072,9 +1073,9 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalResetBetweenPhases) {
   }
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDefaultDataBufferSize,
-      .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kDefaultPerChannelSize,
   };
   WindowConfig wmConfig{
       .peerSignalCount = kMultiSlotSignalCount,
@@ -1138,9 +1139,9 @@ TEST_F(
   constexpr int kNumIterations = 5;
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDefaultDataBufferSize,
-      .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kDefaultPerChannelSize,
   };
   WindowConfig wmConfig{
       .peerSignalCount = kNumSignalSlots,
@@ -1202,9 +1203,9 @@ TEST_F(
   constexpr int kNumSignalSlots = 8; // More slots than warps to test modulo
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDefaultDataBufferSize,
-      .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kDefaultPerChannelSize,
   };
   WindowConfig wmConfig{
       .peerSignalCount = kNumSignalSlots,
@@ -1254,9 +1255,9 @@ TEST_F(
 TEST_F(MultiPeerNvlTransportIntegrationTestFixture, TransportAccessorTypes) {
   // Test that get_peer_transport/get_self_transport return correct types
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDefaultDataBufferSize,
-      .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kDefaultPerChannelSize,
   };
 
   auto [transport, window, dw] = createTransport(config);
@@ -1329,9 +1330,9 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalAll) {
   }
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDefaultDataBufferSize,
-      .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kDefaultPerChannelSize,
   };
   WindowConfig wmConfig{
       .peerSignalCount = kDefaultSignalCount,
@@ -1380,9 +1381,9 @@ TEST_F(
   }
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDefaultDataBufferSize,
-      .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kDefaultPerChannelSize,
   };
   WindowConfig wmConfig{
       .peerSignalCount = kDefaultSignalCount,
@@ -1430,9 +1431,9 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, WaitSignalFromAll) {
   }
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDefaultDataBufferSize,
-      .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kDefaultPerChannelSize,
   };
   WindowConfig wmConfig{
       .peerSignalCount = kDefaultSignalCount,
@@ -1479,9 +1480,9 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, WaitWithCmpEq) {
   }
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDefaultDataBufferSize,
-      .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kDefaultPerChannelSize,
   };
   WindowConfig wmConfig{
       .peerSignalCount = kDefaultSignalCount,
@@ -1531,9 +1532,9 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MonotonicWaitValues) {
   }
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDefaultDataBufferSize,
-      .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kDefaultPerChannelSize,
   };
   WindowConfig wmConfig{
       .peerSignalCount = kDefaultSignalCount,
@@ -1584,9 +1585,9 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalWithSet) {
   }
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDefaultDataBufferSize,
-      .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kDefaultPerChannelSize,
   };
   WindowConfig wmConfig{
       .peerSignalCount = kDefaultSignalCount,
@@ -1644,9 +1645,9 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, WaitSignalFromPeer) {
   }
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDefaultDataBufferSize,
-      .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kDefaultPerChannelSize,
   };
   WindowConfig wmConfig{
       .peerSignalCount = kDefaultSignalCount,
@@ -1695,9 +1696,9 @@ TEST_F(
   }
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDefaultDataBufferSize,
-      .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kDefaultPerChannelSize,
   };
   WindowConfig wmConfig{
       .peerSignalCount = kDefaultSignalCount,
@@ -1747,9 +1748,9 @@ TEST_F(
   }
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDefaultDataBufferSize,
-      .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kDefaultPerChannelSize,
   };
   WindowConfig wmConfig{
       .peerSignalCount = kDefaultSignalCount,
@@ -1797,9 +1798,9 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalWaitBlockScope) {
   }
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDefaultDataBufferSize,
-      .chunkSize = kDefaultChunkSize,
       .pipelineDepth = kDefaultPipelineDepth,
+      .maxNumChannels = kDefaultMaxNumChannels,
+      .perChannelSize = kDefaultPerChannelSize,
   };
   WindowConfig wmConfig{
       .peerSignalCount = kDefaultSignalCount,

--- a/comms/prims/tests/MultiPeerTransportIntegrationTest.cc
+++ b/comms/prims/tests/MultiPeerTransportIntegrationTest.cc
@@ -33,10 +33,10 @@ class MultiPeerIntegrationTestFixture : public MpiBaseTestFixture {
     MultiPeerTransportConfig config{
         .nvlConfig =
             {
-                .dataBufferSize = 256 * 1024,
-                .chunkSize = 512,
                 .pipelineDepth = 4,
                 .p2pSignalCount = 4,
+                .maxNumChannels = 64,
+                .perChannelSize = 4 * 1024,
             },
         .ibConfig =
             {

--- a/comms/prims/tests/MultiPeerTransportMultiNodeTest.cc
+++ b/comms/prims/tests/MultiPeerTransportMultiNodeTest.cc
@@ -108,10 +108,10 @@ class MultiPeerTransportMultiNodeFixture : public MpiBaseTestFixture {
     MultiPeerTransportConfig config{
         .nvlConfig =
             {
-                .dataBufferSize = 256 * 1024,
-                .chunkSize = 512,
                 .pipelineDepth = 4,
                 .p2pSignalCount = 4,
+                .maxNumChannels = 64,
+                .perChannelSize = 4 * 1024,
             },
         .ibConfig =
             {

--- a/comms/prims/tests/MultiPeerTransportTest.cc
+++ b/comms/prims/tests/MultiPeerTransportTest.cc
@@ -47,10 +47,10 @@ class MultiPeerTransportTestFixture : public MpiBaseTestFixture {
     MultiPeerTransportConfig config{
         .nvlConfig =
             {
-                .dataBufferSize = 256 * 1024,
-                .chunkSize = 512,
                 .pipelineDepth = 4,
                 .p2pSignalCount = 4,
+                .maxNumChannels = 64,
+                .perChannelSize = 4 * 1024,
             },
         .ibConfig =
             {
@@ -69,10 +69,10 @@ class MultiPeerTransportTestFixture : public MpiBaseTestFixture {
     MultiPeerTransportConfig config{
         .nvlConfig =
             {
-                .dataBufferSize = 256 * 1024,
-                .chunkSize = 512,
                 .pipelineDepth = 4,
                 .p2pSignalCount = 4,
+                .maxNumChannels = 64,
+                .perChannelSize = 4 * 1024,
             },
         .ibConfig =
             {

--- a/comms/prims/tests/P2pNvlTransportDeviceTest.cc
+++ b/comms/prims/tests/P2pNvlTransportDeviceTest.cc
@@ -127,7 +127,6 @@ class P2pNvlTransportDeviceTwoGpuFixture : public ::testing::Test {
     // Dummy options (required by constructor, not used by LL128 path)
     P2pNvlTransportOptions options{
         .dataBufferSize = 1024,
-        .chunkSize = 512,
         .pipelineDepth = 2,
         .ll128BufferNumPackets = ll128BufferNumPackets,
     };
@@ -512,7 +511,6 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpu) {
   // Create transport options
   P2pNvlTransportOptions options{
       .dataBufferSize = 1024,
-      .chunkSize = 512,
       .pipelineDepth = 2,
   };
 
@@ -611,7 +609,6 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuMultipleIds) {
 
   P2pNvlTransportOptions options{
       .dataBufferSize = 1024,
-      .chunkSize = 512,
       .pipelineDepth = 2,
   };
 
@@ -712,7 +709,6 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuAdd) {
 
   P2pNvlTransportOptions options{
       .dataBufferSize = 1024,
-      .chunkSize = 512,
       .pipelineDepth = 2,
   };
 
@@ -803,7 +799,6 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuBlockGroups) {
 
   P2pNvlTransportOptions options{
       .dataBufferSize = 1024,
-      .chunkSize = 512,
       .pipelineDepth = 2,
   };
 
@@ -904,7 +899,6 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceSignalTwoGpuPingPong) {
 
   P2pNvlTransportOptions options{
       .dataBufferSize = 1024,
-      .chunkSize = 512,
       .pipelineDepth = 2,
   };
 
@@ -1022,7 +1016,6 @@ TEST_F(P2pNvlTransportDeviceTestFixture, PutPerGroup) {
   // Minimal transport — put doesn't use any transport buffers
   P2pNvlTransportOptions options{
       .dataBufferSize = 1024,
-      .chunkSize = 512,
       .pipelineDepth = 2,
   };
   LocalState localState{
@@ -1086,7 +1079,6 @@ TEST_F(P2pNvlTransportDeviceTwoGpuFixture, DeviceResetSignalTwoGpu) {
 
   P2pNvlTransportOptions options{
       .dataBufferSize = 1024,
-      .chunkSize = 512,
       .pipelineDepth = 2,
   };
 

--- a/comms/prims/tests/P2pNvlTransportTest.cc
+++ b/comms/prims/tests/P2pNvlTransportTest.cc
@@ -37,6 +37,17 @@ class P2pNvlTransportTestFixture : public MpiBaseTestFixture {
   }
 };
 
+MultiPeerNvlTransportConfig makeNvlConfig(
+    std::size_t perChannelSize,
+    std::size_t pipelineDepth,
+    int maxNumChannels = 1) {
+  return MultiPeerNvlTransportConfig{
+      .pipelineDepth = pipelineDepth,
+      .maxNumChannels = maxNumChannels,
+      .perChannelSize = (perChannelSize + 15) & ~15ULL,
+  };
+}
+
 TEST_F(P2pNvlTransportTestFixture, IpcMemAccess) {
   // Only test with 2 ranks
   if (numRanks != 2) {
@@ -47,11 +58,7 @@ TEST_F(P2pNvlTransportTestFixture, IpcMemAccess) {
   int peerRank = (globalRank == 0) ? 1 : 0;
 
   const size_t numElements = 256;
-  MultiPeerNvlTransportConfig config{
-      .dataBufferSize = sizeof(int) * numElements,
-      .chunkSize = 256, // 256 bytes
-      .pipelineDepth = 4,
-  };
+  auto config = makeNvlConfig(sizeof(int) * numElements, 4);
 
   auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
@@ -196,11 +203,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCall) {
   const int numSendBlocks = 4;
   const int nIters = 5; // call sendrecv 5 times with different data
 
-  MultiPeerNvlTransportConfig config{
-      .dataBufferSize = 8 * 1024 * 1024, // 8MB slot
-      .chunkSize = 8 * 1024 * 1024,
-      .pipelineDepth = 2,
-  };
+  auto config = makeNvlConfig(2 * 1024 * 1024, 2, numSendBlocks);
 
   auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
@@ -270,11 +273,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvCudaGraphReplay) {
   const int numSendBlocks = 4;
   const size_t maxSignalBytes = 16 * 1024;
 
-  MultiPeerNvlTransportConfig config{
-      .dataBufferSize = 512 * 1024,
-      .chunkSize = 512 * 1024,
-      .pipelineDepth = 2,
-  };
+  auto config = makeNvlConfig(128 * 1024, 2, numSendBlocks);
 
   auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
@@ -351,7 +350,7 @@ static void runTileTest(
     int numRanks,
     std::shared_ptr<meta::comms::MpiBootstrap> bootstrap,
     size_t nBytes,
-    size_t dataBufferSize,
+    size_t perChannelSize,
     size_t chunkSize,
     size_t pipelineDepth,
     int numSendBlocks,
@@ -359,11 +358,7 @@ static void runTileTest(
     int threadCount = 256) {
   int peerRank = (globalRank == 0) ? 1 : 0;
 
-  MultiPeerNvlTransportConfig config{
-      .dataBufferSize = dataBufferSize,
-      .chunkSize = chunkSize,
-      .pipelineDepth = pipelineDepth,
-  };
+  auto config = makeNvlConfig(perChannelSize, pipelineDepth, numSendBlocks);
 
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
@@ -413,7 +408,7 @@ static void runTileTest(
           static_cast<unsigned char>(peerPattern))
           << "Iter " << iter << ": Mismatch at byte " << i
           << " (nBytes=" << nBytes << ", blocks=" << numSendBlocks
-          << ", slot=" << dataBufferSize << ", chunk=" << chunkSize
+          << ", perChannelSize=" << perChannelSize << ", chunk=" << chunkSize
           << ", pd=" << pipelineDepth << ")";
       if (static_cast<unsigned char>(hostBuf[i]) !=
           static_cast<unsigned char>(peerPattern)) {
@@ -886,7 +881,6 @@ TEST_F(
 
   P2pNvlTransportOptions options{
       .dataBufferSize = tileBytes * numBlocks,
-      .chunkSize = maxSignalBytes,
       .pipelineDepth = 2,
       .per_channel_slot = tileBytes,
       .max_num_channels = numBlocks,
@@ -992,7 +986,6 @@ TEST_F(
 
   P2pNvlTransportOptions options{
       .dataBufferSize = perBlockSlotSize * numBlocks,
-      .chunkSize = maxSignalBytes,
       .pipelineDepth = 2,
       .per_channel_slot = perBlockSlotSize,
       .max_num_channels = numBlocks,
@@ -1109,7 +1102,6 @@ TEST_F(
 
   P2pNvlTransportOptions options{
       .dataBufferSize = perBlockSlotSize * numBlocks,
-      .chunkSize = maxSignalBytes,
       .pipelineDepth = 2,
       .per_channel_slot = perBlockSlotSize,
       .max_num_channels = numBlocks,
@@ -1214,7 +1206,6 @@ TEST_F(
 
   P2pNvlTransportOptions options{
       .dataBufferSize = perBlockSlotSize * numBlocks,
-      .chunkSize = perBlockSlotSize,
       .pipelineDepth = 2,
       .per_channel_slot = perBlockSlotSize,
       .max_num_channels = numBlocks,
@@ -1282,7 +1273,6 @@ TEST_F(
 
   P2pNvlTransportOptions options{
       .dataBufferSize = perBlockSlotSize * numBlocks,
-      .chunkSize = perBlockSlotSize,
       .pipelineDepth = 2,
       .per_channel_slot = perBlockSlotSize,
       .max_num_channels = numBlocks,
@@ -1365,8 +1355,6 @@ TEST_F(
   const size_t nBytes = 512 * 1024;
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = perBlockSlotSize * activeBlocks,
-      .chunkSize = perBlockSlotSize,
       .pipelineDepth = 2,
       .maxNumChannels = activeBlocks,
       .perChannelSize = perBlockSlotSize,
@@ -1447,7 +1435,6 @@ TEST_F(P2pNvlTransportTestFixture, TileSendAndForwardWaitForWrappedSubstepAck) {
 
   P2pNvlTransportOptions options{
       .dataBufferSize = perBlockSlotSize * numBlocks,
-      .chunkSize = maxSignalBytes,
       .pipelineDepth = pipelineDepth,
       .per_channel_slot = perBlockSlotSize,
       .max_num_channels = numBlocks,
@@ -1671,11 +1658,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCallDifferentSizes) {
   int peerRank = (globalRank == 0) ? 1 : 0;
 
   const int numSendBlocks = 4;
-  MultiPeerNvlTransportConfig config{
-      .dataBufferSize = 8 * 1024 * 1024,
-      .chunkSize = 8 * 1024 * 1024,
-      .pipelineDepth = 2,
-  };
+  auto config = makeNvlConfig(2 * 1024 * 1024, 2, numSendBlocks);
 
   auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
@@ -1903,11 +1886,7 @@ TEST_F(P2pNvlTransportTestFixture, PutBasic) {
   }
 
   const size_t nbytes = 1024 * 1024; // 1MB
-  MultiPeerNvlTransportConfig config{
-      .dataBufferSize = nbytes,
-      .chunkSize = 1,
-      .pipelineDepth = 1,
-  };
+  auto config = makeNvlConfig(nbytes, 1);
 
   TransportTestHelper helper(globalRank, numRanks, localRank, config);
   auto p2p = helper.getDevicePtr();
@@ -1951,11 +1930,7 @@ TEST_P(PutTransferSizeTestFixture, Put) {
       params.name,
       params.nbytes);
 
-  MultiPeerNvlTransportConfig config{
-      .dataBufferSize = params.nbytes,
-      .chunkSize = 1,
-      .pipelineDepth = 1,
-  };
+  auto config = makeNvlConfig(params.nbytes, 1);
 
   TransportTestHelper helper(globalRank, numRanks, localRank, config);
   auto p2p = helper.getDevicePtr();
@@ -2042,11 +2017,7 @@ TEST_P(PutUnalignedTestFixture, Put) {
   // Allocate larger staging buffers to accommodate offsets
   const size_t dataBufferSize =
       params.nbytes + std::max(params.srcOffset, params.dstOffset);
-  MultiPeerNvlTransportConfig config{
-      .dataBufferSize = dataBufferSize,
-      .chunkSize = 1024,
-      .pipelineDepth = 4,
-  };
+  auto config = makeNvlConfig(dataBufferSize, 4);
 
   TransportTestHelper helper(globalRank, numRanks, localRank, config);
   auto p2p = helper.getDevicePtr();
@@ -2170,11 +2141,7 @@ TEST_F(P2pNvlTransportTestFixture, PutMultiChunkAccumulationRegression) {
   const size_t paddedSize = nbytes + 64; // Extra space to detect overflow
   const char sentinelValue = static_cast<char>(0xDE);
 
-  MultiPeerNvlTransportConfig config{
-      .dataBufferSize = paddedSize,
-      .chunkSize = 1,
-      .pipelineDepth = 1,
-  };
+  auto config = makeNvlConfig(paddedSize, 1);
 
   TransportTestHelper helper(globalRank, numRanks, localRank, config);
   auto* p2p = helper.getDevicePtr(); // device pointer for kernel calls
@@ -2246,12 +2213,8 @@ TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Enabled) {
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
-  MultiPeerNvlTransportConfig config{
-      .dataBufferSize = 4096,
-      .chunkSize = 256,
-      .pipelineDepth = 2,
-      .ll128BufferSize = ll128_buffer_size(4096),
-  };
+  auto config = makeNvlConfig(4096, 2);
+  config.ll128BufferSize = ll128_buffer_size(4096);
 
   auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
@@ -2280,11 +2243,7 @@ TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Disabled) {
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
-  MultiPeerNvlTransportConfig config{
-      .dataBufferSize = 4096,
-      .chunkSize = 256,
-      .pipelineDepth = 2,
-  };
+  auto config = makeNvlConfig(4096, 2);
 
   auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
@@ -2324,8 +2283,6 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvDynamicBlockCount) {
   constexpr int maxBlocks = 32;
 
   MultiPeerNvlTransportConfig config{
-      .dataBufferSize = 8 * 1024 * 1024, // 8MB slot
-      .chunkSize = 8 * 1024 * 1024,
       .pipelineDepth = 2,
       .p2pBarrierCount = static_cast<std::size_t>(maxBlocks),
       .maxNumChannels = maxBlocks,
@@ -2439,7 +2396,7 @@ static void runTileForwardTest(
     int numRanks,
     const std::shared_ptr<meta::comms::MpiBootstrap>& bootstrap,
     size_t nBytes,
-    size_t dataBufferSize,
+    size_t perChannelSize,
     size_t chunkSize,
     size_t pipelineDepth,
     int numSendBlocks,
@@ -2452,11 +2409,7 @@ static void runTileForwardTest(
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
-  MultiPeerNvlTransportConfig config{
-      .dataBufferSize = dataBufferSize,
-      .chunkSize = chunkSize,
-      .pipelineDepth = pipelineDepth,
-  };
+  auto config = makeNvlConfig(perChannelSize, pipelineDepth, numSendBlocks);
 
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
@@ -2530,7 +2483,7 @@ static void runTileForwardTest(
             static_cast<unsigned char>(pattern))
             << "Iter " << iter << " (rank 0 recv): Mismatch at byte " << i
             << " (nBytes=" << nBytes << ", blocks=" << numSendBlocks
-            << ", slot=" << dataBufferSize << ", chunk=" << chunkSize
+            << ", perChannelSize=" << perChannelSize << ", chunk=" << chunkSize
             << ", pd=" << pipelineDepth << ", dstOffset=" << dstOffset << ")";
         if (static_cast<unsigned char>(hostBuf[i]) !=
             static_cast<unsigned char>(pattern)) {
@@ -2562,7 +2515,7 @@ static void runTileForwardTest(
             static_cast<unsigned char>(pattern))
             << "Iter " << iter << " (rank 1 forward dst): Mismatch at byte "
             << i << " (nBytes=" << nBytes << ", blocks=" << numSendBlocks
-            << ", slot=" << dataBufferSize << ", chunk=" << chunkSize
+            << ", perChannelSize=" << perChannelSize << ", chunk=" << chunkSize
             << ", pd=" << pipelineDepth << ", dstOffset=" << dstOffset << ")";
         if (static_cast<unsigned char>(hostBuf[dstOffset + i]) !=
             static_cast<unsigned char>(pattern)) {
@@ -2755,11 +2708,7 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardDesynchronizedStepState) {
 
   auto bs = std::make_shared<meta::comms::MpiBootstrap>();
   const int peerRank = globalRank == 0 ? 1 : 0;
-  MultiPeerNvlTransportConfig config{
-      .dataBufferSize = kDataBufferSize,
-      .chunkSize = kDataBufferSize,
-      .pipelineDepth = 2,
-  };
+  auto config = makeNvlConfig(kPerBlockSlotSize, 2, kNumBlocks);
   MultiPeerNvlTransport transport(globalRank, numRanks, bs, config);
   transport.exchange();
   auto p2pHost = transport.buildP2pTransportDevice(peerRank);
@@ -2771,7 +2720,7 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardDesynchronizedStepState) {
     CUDACHECK_TEST(cudaMemset(
         p2pHost.getLocalState().dataBuffer,
         0,
-        config.pipelineDepth * config.dataBufferSize));
+        config.pipelineDepth * kDataBufferSize));
     CUDACHECK_TEST(cudaDeviceSynchronize());
   }
 
@@ -2908,7 +2857,6 @@ TEST_F(
 
   P2pNvlTransportOptions options{
       .dataBufferSize = tileBytes * numBlocks,
-      .chunkSize = maxSignalBytes,
       .pipelineDepth = 2,
       .per_channel_slot = tileBytes,
       .max_num_channels = numBlocks,
@@ -3086,7 +3034,7 @@ TEST_P(TileForwardUnalignedTestFixture, TileForward) {
       numRanks,
       bs,
       params.nbytes,
-      /*dataBufferSize=*/8 * 1024 * 1024,
+      /*perChannelSize=*/8 * 1024 * 1024,
       /*chunkSize=*/128 * 1024,
       /*pipelineDepth=*/2,
       /*numSendBlocks=*/4,
@@ -3147,12 +3095,8 @@ TEST_F(P2pNvlTransportTestFixture, LlBufferWiring_Enabled) {
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
-  MultiPeerNvlTransportConfig config{
-      .dataBufferSize = 4096,
-      .chunkSize = 256,
-      .pipelineDepth = 2,
-      .llBufferSize = ll_buffer_size(4096),
-  };
+  auto config = makeNvlConfig(4096, 2);
+  config.llBufferSize = ll_buffer_size(4096);
 
   auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
@@ -3181,11 +3125,7 @@ TEST_F(P2pNvlTransportTestFixture, LlBufferWiring_Disabled) {
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
-  MultiPeerNvlTransportConfig config{
-      .dataBufferSize = 4096,
-      .chunkSize = 256,
-      .pipelineDepth = 2,
-  };
+  auto config = makeNvlConfig(4096, 2);
 
   auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);

--- a/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
@@ -16,8 +16,9 @@ namespace comms::prims {
 
 namespace {
 
-std::size_t alignDown(std::size_t value, std::size_t alignment) {
-  return (value / alignment) * alignment;
+std::size_t dataBufferSize(const MultiPeerNvlTransportConfig& config) {
+  return static_cast<std::size_t>(config.maxNumChannels) *
+      config.perChannelSize;
 }
 
 MultiPeerNvlTransportConfig normalizeChannelConfig(
@@ -27,24 +28,10 @@ MultiPeerNvlTransportConfig normalizeChannelConfig(
     return config;
   }
 
-  const auto maxChannels = static_cast<std::size_t>(config.maxNumChannels);
-  const bool usesDefaultPerChannelSize = config.perChannelSize == 0 ||
-      config.perChannelSize == kDefaultNvlPerChannelSize;
   if (config.perChannelSize == 0) {
     config.perChannelSize = kDefaultNvlPerChannelSize;
   }
 
-  const std::size_t requiredDataBufferSize =
-      config.perChannelSize * maxChannels;
-  if (config.dataBufferSize == 0) {
-    config.dataBufferSize = requiredDataBufferSize;
-  } else if (config.dataBufferSize < requiredDataBufferSize) {
-    if (!usesDefaultPerChannelSize) {
-      throw std::runtime_error(
-          "tile send/recv requires dataBufferSize >= perChannelSize * maxNumChannels");
-    }
-    config.perChannelSize = alignDown(config.dataBufferSize / maxChannels, 16);
-  }
   if (config.perChannelSize < 16) {
     throw std::runtime_error("tile send/recv requires perChannelSize >= 16");
   }
@@ -53,8 +40,8 @@ MultiPeerNvlTransportConfig normalizeChannelConfig(
         "tile send/recv requires perChannelSize to be 16-byte aligned");
   }
   // Cap per-channel staging at 128MB (matches NCCL's max channel buffer). This
-  // also subsumes the dataBufferSize overflow guard: 128MB * maxNumChannels
-  // stays well within std::size_t for any sane channel count.
+  // also keeps the derived per-slot staging size bounded for any sane channel
+  // count.
   constexpr std::size_t kMaxPerChannelSize = 128ULL * 1024 * 1024;
   if (config.perChannelSize > kMaxPerChannelSize) {
     throw std::runtime_error("tile send/recv requires perChannelSize <= 128MB");
@@ -94,7 +81,8 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
   // Each handler's destructor will free its GPU memory if constructed.
 
   // Calculate per-peer buffer sizes with pipelining
-  perPeerDataBufferSize_ = config_.pipelineDepth * config_.dataBufferSize;
+  dataBufferSize_ = dataBufferSize(config_);
+  perPeerDataBufferSize_ = config_.pipelineDepth * dataBufferSize_;
 
   perPeerSignalBufferSize_ = getSignalBufferSize(config_.p2pSignalCount);
 
@@ -202,14 +190,14 @@ void MultiPeerNvlTransport::setExternalDataBuffers(
           "setExternalDataBuffers: local buffer for peer " +
           std::to_string(peer) + " has size " + std::to_string(localSize) +
           " but requires at least " + std::to_string(perPeerDataBufferSize_) +
-          " (pipelineDepth * dataBufferSize)");
+          " (pipelineDepth * maxNumChannels * perChannelSize)");
     }
     if (remoteSize < perPeerDataBufferSize_) {
       throw std::runtime_error(
           "setExternalDataBuffers: remote buffer for peer " +
           std::to_string(peer) + " has size " + std::to_string(remoteSize) +
           " but requires at least " + std::to_string(perPeerDataBufferSize_) +
-          " (pipelineDepth * dataBufferSize)");
+          " (pipelineDepth * maxNumChannels * perChannelSize)");
     }
   }
   externalStagingBuffers_ = std::move(externalStagingBuffers);
@@ -218,8 +206,8 @@ void MultiPeerNvlTransport::setExternalDataBuffers(
 void MultiPeerNvlTransport::exchange() {
   // Allocate and exchange data buffers when:
   // - No external buffers were provided, AND
-  // - dataBufferSize > 0 (staging buffers needed for send/recv)
-  if (!externalStagingBuffers_ && config_.dataBufferSize > 0) {
+  // - dataBufferSize_ > 0 (staging buffers needed for send/recv)
+  if (!externalStagingBuffers_ && dataBufferSize_ > 0) {
     const std::size_t totalDataBufferSize =
         perPeerDataBufferSize_ * (nRanks_ - 1);
     dataBufferHandler_ = std::make_unique<GpuMemHandler>(
@@ -286,8 +274,7 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
   const std::size_t perChannelSlot =
       maxChannels > 0 ? config_.perChannelSize : 0;
   P2pNvlTransportOptions options{
-      .dataBufferSize = config_.dataBufferSize,
-      .chunkSize = config_.chunkSize,
+      .dataBufferSize = dataBufferSize_,
       .pipelineDepth = config_.pipelineDepth,
       .ll128BufferNumPackets = perPeerLl128BufferSize_ / kLl128PacketSize,
       .llBufferNumLines = perPeerLlBufferSize_ / kLlLineSize,

--- a/comms/prims/transport/nvl/MultiPeerNvlTransport.h
+++ b/comms/prims/transport/nvl/MultiPeerNvlTransport.h
@@ -33,28 +33,18 @@ struct Transport;
  * IMPORTANT: All ranks must use identical configuration values.
  *
  * For the fixed-channel tile protocol:
- *   dataBufferSize >= maxNumChannels * perChannelSize
+ *   one pipeline slot = maxNumChannels * perChannelSize
  *
- * Memory per rank = (nRanks - 1) * pipelineDepth * dataBufferSize
+ * Memory per rank = (nRanks - 1) * pipelineDepth * maxNumChannels *
+ * perChannelSize
  */
 struct MultiPeerNvlTransportConfig {
-  // Size of staging buffer per pipeline slot across all channels (bytes).
-  // When this is 0 and maxNumChannels > 0, it is derived from perChannelSize
-  // and maxNumChannels during host transport construction.
-  std::size_t dataBufferSize{0};
-
-  // Chunk size for parallel processing (bytes).
-  // Smaller = more parallelism, larger = less sync overhead.
-  // Should be multiple of 16 bytes. Typical: 8 KB - 4 MB.
-  std::size_t chunkSize{0};
-
   // Number of pipeline slots for overlapping communication.
   // Higher = better latency hiding but more memory.
   // Typical: 2-4 for most workloads.
   std::size_t pipelineDepth{0};
 
   // Number of P2P signal slots per peer for chunk-level pipeline coordination.
-  // Used by signalBufferHandler_ and P2pNvlTransportDevice for send()/recv().
   // This is separate from WindowConfig.peerSignalCount (inbox model).
   // Typical: 1-num of blocks for most workloads.
   std::size_t p2pSignalCount{1};
@@ -105,8 +95,9 @@ struct MultiPeerNvlTransportConfig {
  *   buffer region that this rank writes into via NVLink.
  *
  * SIZE REQUIREMENTS:
- *   Each per-peer buffer must be at least (pipelineDepth * dataBufferSize)
- *   bytes, matching the config passed to MultiPeerNvlTransport.
+ *   Each per-peer buffer must be at least
+ *   (pipelineDepth * maxNumChannels * perChannelSize) bytes, matching the
+ *   config passed to MultiPeerNvlTransport.
  *   setExternalDataBuffers() validates this and throws on mismatch.
  *
  * OWNERSHIP:
@@ -376,6 +367,7 @@ class MultiPeerNvlTransport {
   std::unique_ptr<meta::comms::DeviceBuffer> transportsDevice_;
 
   // Per-peer buffer sizes for offset calculation
+  std::size_t dataBufferSize_{0};
   std::size_t perPeerDataBufferSize_{0};
   std::size_t perPeerSignalBufferSize_{0};
   std::size_t perPeerLl128BufferSize_{0};

--- a/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
@@ -61,17 +61,14 @@ struct RemoteState {
 /**
  * P2pNvlTransportOptions - Configuration for P2P NVLink transport
  *
- * Defines the buffer sizes and chunking parameters for staged transfers.
- * - dataBufferSize: Size of ONE pipeline slot (determines max per-step
- *   transfer)
- * - chunkSize: Size of each chunk for parallel processing
+ * Defines the derived buffer sizes for staged transfers.
+ * - dataBufferSize: Size of ONE pipeline slot across all fixed channels
  * - pipelineDepth: Number of buffer slots for pipelining (typically 2-8)
  *
  * Total memory allocated = pipelineDepth × dataBufferSize
  */
 struct P2pNvlTransportOptions {
   std::size_t dataBufferSize{0};
-  std::size_t chunkSize{0};
   std::size_t pipelineDepth{0};
   std::size_t ll128BufferNumPackets{0}; // 0 = no chunking
   std::size_t llBufferNumLines{0}; // 0 = no chunking
@@ -132,17 +129,11 @@ class P2pNvlTransportDevice {
   // window must be bounded by that ring's capacity (per_channel_slot *
   // safeDepth). A larger window lets a single call wrap the ring and wait for a
   // slot_free the peer only produces after its own recv() — deadlocking the
-  // send-before-recv AllReduce pattern. The legacy (non-channel) path keeps the
-  // historical per-block-slot arithmetic.
-  __host__ __device__ std::size_t pipeline_window(int totalGroups) const {
+  // send-before-recv AllReduce pattern.
+  __host__ __device__ std::size_t pipeline_window() const {
     const std::size_t safeDepth =
         options_.pipelineDepth > 1 ? options_.pipelineDepth - 1 : 1;
-    if (options_.max_num_channels > 0 && options_.per_channel_slot > 0) {
-      return options_.per_channel_slot * safeDepth;
-    }
-    const std::size_t perBlockSlotSize =
-        (options_.dataBufferSize / totalGroups) & ~15ULL;
-    return perBlockSlotSize * safeDepth;
+    return options_.per_channel_slot * safeDepth;
   }
 
   // Getters for testing


### PR DESCRIPTION
Summary:

Post-channel-state cleanup for NVL transport. Tile send/recv now derives its staging geometry from fixed channel state, so remove the old public `dataBufferSize` and `chunkSize` transport config fields, derive the per-slot staging bytes from `maxNumChannels * perChannelSize`, and drop the legacy `pipeline_window(totalGroups)` fallback that divided staging by the active group count.

Update NVL, CTRAN, tests, benchmarks, and direct collective callers to use the derived channel geometry. Keep unrelated benchmark-local `chunkSize` knobs and IB/IBGDA `dataBufferSize` semantics intact.

Reviewed By: saifhhasan

Differential Revision: D111368712
