### PR TITLE
Remove CTRAN send/recv routing

### DIFF
--- a/comms/torchcomms/tests/integration/py/ReconfigureTest.py
+++ b/comms/torchcomms/tests/integration/py/ReconfigureTest.py
@@ -173,49 +173,6 @@ class ReconfigureTest(unittest.TestCase):
 
         comm.finalize()
 
-    def test_reconfigure_then_collective(self):
-        """Test that collective operations work after reconfigure."""
-        if not self._is_supported_backend():
-            self.skipTest(f"Backend {self.backend} does not support reconfigure()")
-
-        comm, _ = self._create_reconfigured_comm("reconfigure_collective", 2)
-
-        if self.world_size > 1:
-            my_rank = comm.get_rank()
-            count = 4
-            send_tensor = torch.ones(count, dtype=torch.float, device=self.device) * (
-                my_rank + 1
-            )
-            recv_tensor = torch.zeros(count, dtype=torch.float, device=self.device)
-
-            send_rank = (my_rank + 1) % self.world_size
-            recv_rank = (my_rank - 1 + self.world_size) % self.world_size
-
-            if my_rank % 2 == 0:
-                send_work = comm.send(send_tensor, send_rank, async_op=True)
-                recv_work = comm.recv(recv_tensor, recv_rank, async_op=True)
-            else:
-                recv_work = comm.recv(recv_tensor, recv_rank, async_op=True)
-                send_work = comm.send(send_tensor, send_rank, async_op=True)
-
-            send_work.wait()
-            recv_work.wait()
-
-            if self.device.type == "cuda":
-                torch.cuda.current_stream().synchronize()
-
-            expected = torch.ones(count, dtype=torch.float, device="cpu") * (
-                recv_rank + 1
-            )
-            self.assertTrue(
-                torch.allclose(recv_tensor.cpu(), expected),
-                f"[Rank {my_rank}] Send/recv after reconfigure failed",
-            )
-
-            print(f"[Rank {my_rank}] Send/recv after reconfigure succeeded")
-
-        comm.finalize()
-
     def test_reconfigure_then_allreduce(self):
         """Test that allreduce works after reconfigure."""
         if not self._is_supported_backend():
@@ -360,7 +317,7 @@ class ReconfigureTest(unittest.TestCase):
         expected = sum(range(1, new_size + 1))
         self.assertTrue(
             torch.allclose(tensor, torch.full_like(tensor, expected)),
-            f"AllReduce after middle-rank shrink failed",
+            "AllReduce after middle-rank shrink failed",
         )
 
         print(


### PR DESCRIPTION
Summary: MCCL send/recv currently routes through the CTRAN batched send/recv planner. This removes that routing from `McclComm` so MCCL no longer silently depends on the CTRAN send/recv implementation. Until the prims-backed MCCL send/recv path lands, `send`, `recv`, and `batchSendRecv` fail fast with an explicit "prims send/recv implementation" error. The old CTRAN-backed send/recv integration tests are deleted because they only validate the removed behavior; prims-backed coverage lands in the follow-up send/recv implementation diff.

Reviewed By: saifhhasan

Differential Revision: D110914201


