### PR TITLE
Low-latency dispatch/combine over hybrid IPC + IBGDA (internode) (#3113)

### DIFF
--- a/comms/prims/collectives/moe_ep/cpp/Buffer.cc
+++ b/comms/prims/collectives/moe_ep/cpp/Buffer.cc
@@ -31,6 +31,7 @@
 #include "comms/prims/collectives/moe_ep/cpp/low_latency/kernels/Dispatch.cuh"
 #include "comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelConfigs.cuh"
 #include "comms/prims/memory/GpuMemHandler.h"
+#include "secure_lib/secure_string.h"
 
 namespace comms::prims::moe_ep {
 
@@ -83,6 +84,90 @@ class StubBootstrap : public meta::comms::IBootstrap {
   const int nRanks_;
 };
 
+/**
+ * PyAllGatherBootstrap — IBootstrap that delegates allGather to a Python
+ * callable. The callable receives the local data slot as bytes and must
+ * return concatenated `nranks * len` bytes (peer i's data at offset i*len).
+ *
+ * This is how Python `dist.all_gather_object` (or similar) gets bridged
+ * into MultipeerIbgdaTransport's QP-info exchange. The callback runs with
+ * the GIL held, so it can safely invoke Python collective APIs.
+ *
+ * `barrier` is a no-op; assumes Python pre-barriered. send/recv unsupported.
+ */
+class PyAllGatherBootstrap : public meta::comms::IBootstrap {
+ public:
+  PyAllGatherBootstrap(int rank, int nRanks, py::object allGatherCb)
+      : rank_(rank), nRanks_(nRanks), allGatherCb_(std::move(allGatherCb)) {}
+
+  ~PyAllGatherBootstrap() override {
+    // Py_DECREF of the callback requires the GIL, but this object can be
+    // destroyed while the GIL is released (the last shared_ptr reference may
+    // be dropped inside setupIbgda under gil_scoped_release, possibly on
+    // another thread). Reset the member here under an explicit guard: a bare
+    // gil_scoped_acquire would not help since the member is destroyed after
+    // the destructor body, once the guard is already gone.
+    py::gil_scoped_acquire gil;
+    allGatherCb_ = py::object();
+  }
+
+  // Owned via shared_ptr and never copied/moved; declared to satisfy the
+  // rule-of-five now that a destructor is user-provided.
+  PyAllGatherBootstrap(const PyAllGatherBootstrap&) = delete;
+  PyAllGatherBootstrap& operator=(const PyAllGatherBootstrap&) = delete;
+  PyAllGatherBootstrap(PyAllGatherBootstrap&&) = delete;
+  PyAllGatherBootstrap& operator=(PyAllGatherBootstrap&&) = delete;
+
+  folly::SemiFuture<int> allGather(void* buf, int len, int rank, int nranks)
+      override {
+    if (rank != rank_ || nranks != nRanks_) {
+      return folly::makeSemiFuture<int>(
+          std::runtime_error("PyAllGatherBootstrap: rank/nranks mismatch"));
+    }
+    try {
+      // Extract local data slot, call Python, marshal gathered result back.
+      py::gil_scoped_acquire gil;
+      const char* localData =
+          static_cast<const char*>(buf) + static_cast<std::size_t>(rank) * len;
+      py::bytes localBytes(localData, len);
+      py::object result = allGatherCb_(localBytes);
+      std::string gathered = result.cast<std::string>();
+      const std::size_t expected = static_cast<std::size_t>(nranks) * len;
+      if (gathered.size() != expected) {
+        throw std::runtime_error(
+            "PyAllGatherBootstrap: Python callback returned " +
+            std::to_string(gathered.size()) + " bytes, expected " +
+            std::to_string(expected));
+      }
+      checked_memcpy(buf, expected, gathered.data(), expected);
+    } catch (const std::exception& e) {
+      return folly::makeSemiFuture<int>(std::runtime_error(e.what()));
+    }
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int> barrier(int /*rank*/, int /*nranks*/) override {
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int>
+  send(void* /*buf*/, int /*len*/, int /*peer*/, int /*tag*/) override {
+    return folly::makeSemiFuture<int>(
+        std::runtime_error("PyAllGatherBootstrap: send not supported"));
+  }
+
+  folly::SemiFuture<int>
+  recv(void* /*buf*/, int /*len*/, int /*peer*/, int /*tag*/) override {
+    return folly::makeSemiFuture<int>(
+        std::runtime_error("PyAllGatherBootstrap: recv not supported"));
+  }
+
+ private:
+  const int rank_;
+  const int nRanks_;
+  py::object allGatherCb_;
+};
+
 } // namespace
 
 Buffer::Buffer(
@@ -108,14 +193,16 @@ Buffer::Buffer(
   if (numRanks_ <= 0) {
     throw std::invalid_argument("Buffer: numRanks must be > 0");
   }
-  // Intranode-only dispatch / combine paths cap at NUM_MAX_NVL_PEERS.
-  // Multi-node LL mode allows numRanks > NUM_MAX_NVL_PEERS: cross-node
-  // peers go through IBGDA in LowLatencyRuntime; same-node peers still
-  // use NVL-IPC (peerIpcBuffers_[i] nullptr for cross-node, populated for
-  // same-node — see sync()).
-  if (numRanks_ > NUM_MAX_NVL_PEERS && !lowLatencyMode_) {
+  // For non-low-latency intranode mode, only one NVL node is supported
+  // (the intranode kernel addresses peers via the per-rank `buffer_ptrs`
+  // table sized at NUM_MAX_NVL_PEERS). Low-latency mode supports
+  // cross-node via the hybrid IPC+IBGDA path — same-node peers go via
+  // NVLink IPC, cross-node peers via `MultipeerIbgdaTransport` (wired
+  // up by `setup_low_latency_ibgda()` post-sync).
+  if (!lowLatencyMode_ && numRanks_ > NUM_MAX_NVL_PEERS) {
     throw std::invalid_argument(
-        "Buffer: numRanks > NUM_MAX_NVL_PEERS requires low_latency_mode=True");
+        "Buffer: numRanks > NUM_MAX_NVL_PEERS requires low_latency_mode=True "
+        "(internode intranode_dispatch/combine kernel is not yet implemented)");
   }
 
   checkCuda(cudaGetDevice(&deviceId_), "Buffer: cudaGetDevice failed");
@@ -294,10 +381,24 @@ void Buffer::sync(
     cudaIpcMemHandle_t peerHandle{};
     std::memcpy(&peerHandle, handleBytes.data(), sizeof(peerHandle));
     void* peerPtr = nullptr;
-    checkCuda(
-        cudaIpcOpenMemHandle(
-            &peerPtr, peerHandle, cudaIpcMemLazyEnablePeerAccess),
-        "Buffer::sync: cudaIpcOpenMemHandle failed");
+    // For LL mode, cross-node peers' IPC opens fail (P2P not available).
+    // Leave peerIpcBuffers_[i] = nullptr so the LL kernel's hybrid branch
+    // routes to the IBGDA path. For intranode mode, all peers must succeed
+    // (single-node-only requirement).
+    cudaError_t ipcErr = cudaIpcOpenMemHandle(
+        &peerPtr, peerHandle, cudaIpcMemLazyEnablePeerAccess);
+    if (ipcErr != cudaSuccess) {
+      if (lowLatencyMode_) {
+        // Cross-node peer: clear the sticky CUDA error so subsequent
+        // cudaMalloc / kernel launches don't fail with the stale error,
+        // then leave peerIpcBuffers_[i] = nullptr — kernel routes via IBGDA.
+        (void)cudaGetLastError();
+        continue;
+      }
+      throw std::runtime_error(
+          std::string("Buffer::sync: cudaIpcOpenMemHandle failed for peer ") +
+          std::to_string(i) + ": " + cudaGetErrorString(ipcErr));
+    }
     peerIpcBuffers_[i] = peerPtr;
   }
 
@@ -305,11 +406,11 @@ void Buffer::sync(
   // GpuMemHandler/transport entirely since Python already gathered IPC
   // handles for us.
   //
-  // Skip on multi-node LL mode (numRanks > NUM_MAX_NVL_PEERS) — only the
-  // LL path is reachable across nodes; the IntranodeRuntime ctor enforces
-  // its own (legitimate) NVL-peer cap and `intranode_dispatch` /
-  // `intranode_combine` are not callable in that mode.
-  if (numRanks_ <= NUM_MAX_NVL_PEERS) {
+  // Skip when low_latency_mode + numRanks > NUM_MAX_NVL_PEERS —
+  // IntranodeRuntime itself checks numRanks <= NUM_MAX_NVL_PEERS, and LL
+  // kernels don't use the intranode runtime at all (they use LowLatencyRuntime,
+  // constructed lazily on first low_latency_dispatch call).
+  if (!lowLatencyMode_ || numRanks_ <= NUM_MAX_NVL_PEERS) {
     intranode_ = std::make_unique<IntranodeRuntime>(
         rank_,
         numRanks_,
@@ -327,9 +428,9 @@ void Buffer::sync(
   // When low_latency_mode=true, also stand up the LL runtime
   // (owns the symmetric LL buffer, atomic counters, IBGDA transport).
   // The dispatch tokens / hidden / num_experts are not known at sync()
-  // time — those land on the first dispatch call. For now we lazily
-  // construct LowLatencyRuntime in `low_latency_dispatch` when needed
-  // and keep this branch as a placeholder to assert the mode.
+  // time — those land on the first dispatch call. LowLatencyRuntime is
+  // constructed lazily in `low_latency_dispatch`; this branch only
+  // validates the mode's invariants.
   if (lowLatencyMode_ && numRdmaBytes_ <= 0) {
     throw std::runtime_error(
         "Buffer::sync: low_latency_mode requires num_rdma_bytes > 0");
@@ -460,10 +561,10 @@ py::tuple Buffer::intranode_dispatch(
     x = xTuple[0].cast<torch::Tensor>();
     xScales = xTuple[1].cast<torch::Tensor>();
     isFp8 = true;
-    // FP8 scale path is deferred: the kernel derives num_scales from
+    // FP8 scale path is not yet supported: the kernel derives num_scales from
     // scale_hidden_stride (Dispatch.cu), which collapses to 1 for contiguous
     // scales and silently under-fills the recv-scale buffer. Reject the
-    // (data, scales) tuple until the FP8-enablement diff threads num_scales.
+    // (data, scales) tuple until the FP8 scale path threads num_scales.
     TORCH_CHECK(
         !isFp8,
         "intranode_dispatch: FP8 (x=(data, scales)) is not supported yet; the "
@@ -893,9 +994,8 @@ Buffer::intranode_combine(
 //
 // Lazily construct the LowLatencyRuntime on first call (the dispatch
 // dimensions aren't known at sync() time). These methods set up the
-// runtime, allocate
-// the output tensors, and call into the (no-op) kernel stubs so the
-// Python-side surface and tensor shapes are validated end-to-end.
+// runtime, allocate the output tensors, and call into the low-latency
+// kernels.
 
 py::tuple Buffer::low_latency_dispatch(
     const torch::Tensor& x,
@@ -971,11 +1071,18 @@ py::tuple Buffer::low_latency_dispatch(
 
   // Wire peer data pointers for NVLink IPC writes. Offset each peer's
   // base pointer to the LL RDMA region within the shared IPC buffer.
+  // For cross-node peers (peerIpcBuffers_[i] == nullptr because
+  // cudaIpcOpenMemHandle failed), keep the entry nullptr — the kernel
+  // branches on this to route to the IBGDA path. Adding llRdmaOffset_ to
+  // nullptr would produce a small invalid address that passes the kernel's
+  // `!= nullptr` check and triggers a memory fault on the IPC write.
   if (lowLatency_->getPeerDataPtrsDevice() == nullptr &&
       !peerIpcBuffers_.empty()) {
     std::vector<void*> llPeerPtrs(numRanks_);
     for (int i = 0; i < numRanks_; ++i) {
-      llPeerPtrs[i] = static_cast<uint8_t*>(peerIpcBuffers_[i]) + llRdmaOffset_;
+      llPeerPtrs[i] = (peerIpcBuffers_[i] != nullptr)
+          ? static_cast<uint8_t*>(peerIpcBuffers_[i]) + llRdmaOffset_
+          : nullptr;
     }
     lowLatency_->setPeerDataPtrs(llPeerPtrs);
   }
@@ -1034,6 +1141,13 @@ py::tuple Buffer::low_latency_dispatch(
       false, // roundScale
       false, // useUe8m0
       lowLatency_->getPeerDataPtrsDevice(),
+      // IBGDA cross-node descriptors. Populated by setupIbgda() (for
+      // multi-node configs); nullptr on single-node where all peers are
+      // P2P-capable and the kernel takes the IPC fast path.
+      lowLatency_->getIbgdaDeviceTransport(),
+      lowLatency_->getLocalRdmaXBufDevice(),
+      lowLatency_->getPeerRemoteRecvXDevice(),
+      lowLatency_->getPeerRemoteRecvCountDevice(),
       phase,
       stream);
 
@@ -1149,6 +1263,11 @@ py::tuple Buffer::low_latency_combine(
       numRanks_,
       lowLatency_->getCombineWorkspace(),
       lowLatency_->getPeerDataPtrsDevice(),
+      // IBGDA cross-node descriptors. nullptr on single-node.
+      lowLatency_->getIbgdaDeviceTransport(),
+      lowLatency_->getLocalCombineXBufDevice(),
+      lowLatency_->getPeerRemoteCombineRecvXDevice(),
+      lowLatency_->getPeerRemoteCombineRecvFlagDevice(),
       phase,
       false, // zero_copy
       stream);
@@ -1201,6 +1320,47 @@ void Buffer::set_low_latency_buffer_idx(int idx) {
         "Buffer::set_low_latency_buffer_idx: idx must be 0 or 1");
   }
   lowLatencyBufferIdx_ = idx;
+}
+
+void Buffer::setup_low_latency_ibgda(
+    int numMaxDispatchTokensPerRank,
+    int hidden,
+    int numExperts,
+    py::object allGatherCallback) {
+  if (!available_) {
+    throw std::runtime_error("Buffer::setup_low_latency_ibgda: not synced yet");
+  }
+  if (!lowLatencyMode_) {
+    throw std::runtime_error(
+        "Buffer::setup_low_latency_ibgda: requires low_latency_mode=True");
+  }
+  if (numRanks_ < 2) {
+    return; // single-rank: no peers, nothing to set up
+  }
+  // Eagerly construct the LL runtime so cross-node QPs can be set up before
+  // the first dispatch — otherwise the kernel would try to send to cross-node
+  // peers with no IBGDA wired.
+  if (!lowLatency_) {
+    const int numLocalExperts = numExperts / numRanks_;
+    auto bootstrap = std::make_shared<StubBootstrap>(rank_, numRanks_);
+    void* llBuffer = static_cast<uint8_t*>(localIpcBuffer_) + llRdmaOffset_;
+    lowLatency_ = std::make_unique<LowLatencyRuntime>(
+        bootstrap,
+        rank_,
+        numRanks_,
+        static_cast<std::size_t>(numRdmaBytes_),
+        numMaxDispatchTokensPerRank,
+        hidden,
+        numExperts,
+        /*numQpsPerRank=*/numLocalExperts,
+        /*externalRdmaBuffer=*/llBuffer);
+  }
+  auto bootstrap = std::make_shared<PyAllGatherBootstrap>(
+      rank_, numRanks_, std::move(allGatherCallback));
+  // Release GIL during the C++ collective so the Python callback can
+  // re-acquire it; the bootstrap re-acquires per-call.
+  py::gil_scoped_release release;
+  lowLatency_->setupIbgda(std::move(bootstrap));
 }
 
 void Buffer::notImplemented(const char* methodName) const {

--- a/comms/prims/collectives/moe_ep/cpp/Buffer.h
+++ b/comms/prims/collectives/moe_ep/cpp/Buffer.h
@@ -188,10 +188,31 @@ class Buffer {
    *  slots used to overlap dispatch / combine. */
   void set_low_latency_buffer_idx(int idx);
 
+  /**
+   * `setup_low_latency_ibgda` — construct LowLatencyRuntime (if not already
+   * built) and wire MultipeerIbgdaTransport for cross-node IBGDA RDMA. The
+   * dispatch shape parameters are needed up front so the runtime's symmetric
+   * buffer layout, atomic counters, and per-expert workspace match the actual
+   * dispatch calls that follow.
+   *
+   * Required for multi-node configs (must be called before the first
+   * low_latency_dispatch). Single-node configs may skip this call entirely
+   * — the kernel takes the IPC fast path for all peers.
+   *
+   * Caller responsibility: `allGatherCallback` must do the equivalent of
+   * `dist.all_gather_object(local_bytes)` and return concatenated bytes
+   * `[rank_0_bytes, rank_1_bytes, ..., rank_n_bytes]`.
+   */
+  void setup_low_latency_ibgda(
+      int numMaxDispatchTokensPerRank,
+      int hidden,
+      int numExperts,
+      pybind11::object allGatherCallback);
+
   // ---- Internode ----
   // These are bound through the same pybind module (so the Python `Buffer`
-  // class's full method surface stays addressable), but throw at runtime
-  // until the matching kernels land. Concrete signatures + bindings live
+  // class's full method surface stays addressable); unsupported
+  // configurations throw at runtime. Concrete signatures + bindings live
   // in PyBindings.cpp.
   [[noreturn]] void notImplemented(const char* methodName) const;
 

--- a/comms/prims/collectives/moe_ep/cpp/PyBindings.cc
+++ b/comms/prims/collectives/moe_ep/cpp/PyBindings.cc
@@ -198,5 +198,12 @@ PYBIND11_MODULE(_cpp, m) {
       .def(
           "set_low_latency_buffer_idx",
           &Buffer::set_low_latency_buffer_idx,
-          py::arg("idx"));
+          py::arg("idx"))
+      .def(
+          "setup_low_latency_ibgda",
+          &Buffer::setup_low_latency_ibgda,
+          py::arg("num_max_dispatch_tokens_per_rank"),
+          py::arg("hidden"),
+          py::arg("num_experts"),
+          py::arg("all_gather_callback"));
 }

--- a/comms/prims/collectives/moe_ep/cpp/low_latency/Runtime.cc
+++ b/comms/prims/collectives/moe_ep/cpp/low_latency/Runtime.cc
@@ -2,8 +2,11 @@
 
 #include "comms/prims/collectives/moe_ep/cpp/low_latency/Runtime.h"
 
+#include <cstdlib>
 #include <stdexcept>
 #include <string>
+
+#include <folly/CppAttributes.h>
 
 #ifdef __HIP_PLATFORM_AMD__
 #include "comms/prims/transport/amd/HipHostCompat.h"
@@ -12,6 +15,8 @@
 #endif
 
 #include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/prims/transport/ibgda/IbgdaBuffer.h"
+#include "comms/prims/transport/ibgda/MultipeerIbgdaDeviceTransport.cuh"
 #include "comms/prims/transport/ibgda/MultipeerIbgdaTransport.h"
 
 namespace comms::prims::moe_ep {
@@ -109,7 +114,8 @@ LowLatencyRuntime::LowLatencyRuntime(
       "LowLatencyRuntime: cudaMemset(atomicFinishCounterPerExpert) failed");
 
   // 3. `next_clean` persistent buffer — used by combine to defer the next
-  //    dispatch's clean. Sized at numRanks*numLocalExperts*8B.
+  //    dispatch's clean. Sized at numRanks*numLocalExperts*8B (one int64 slot
+  //    per (rank, local expert)).
   nextCleanBufferIntCount_ = numRanks_ * numLocalExperts;
   checkCuda(
       cudaMalloc(
@@ -138,8 +144,7 @@ LowLatencyRuntime::LowLatencyRuntime(
       cudaStreamCreate(&commStream_),
       "LowLatencyRuntime: cudaStreamCreate(comm) failed");
 
-  // 6. MultipeerIbgdaTransport setup is deferred until the LL kernel
-  //    implementations are wired through. The transport requires
+  // 6. MultipeerIbgdaTransport setup is deferred to setupIbgda(), which needs
   //    `bootstrap->allGather` for per-peer QP exchange.
   (void)numQpsPerRank_;
 }
@@ -169,7 +174,33 @@ LowLatencyRuntime::~LowLatencyRuntime() {
   if (rdmaBufferPtr_ != nullptr && ownsRdmaBuffer_) {
     (void)cudaFree(rdmaBufferPtr_);
   }
-  // ibgdaTransport_ destructor handles its own cleanup.
+  // Free IBGDA device-side arrays. ibgdaTransport_ destructor cleans up
+  // the host-side transport (QPs, MRs, NIC contexts).
+  if (ibgdaPeerRemoteCombineRecvFlagDevice_ != nullptr) {
+    (void)cudaFree(ibgdaPeerRemoteCombineRecvFlagDevice_);
+  }
+  if (ibgdaPeerRemoteCombineRecvXDevice_ != nullptr) {
+    (void)cudaFree(ibgdaPeerRemoteCombineRecvXDevice_);
+  }
+  if (ibgdaPeerRemoteRecvCountDevice_ != nullptr) {
+    (void)cudaFree(ibgdaPeerRemoteRecvCountDevice_);
+  }
+  if (ibgdaPeerRemoteRecvXDevice_ != nullptr) {
+    (void)cudaFree(ibgdaPeerRemoteRecvXDevice_);
+  }
+  if (ibgdaLocalCombineXBufDevice_ != nullptr) {
+    (void)cudaFree(ibgdaLocalCombineXBufDevice_);
+  }
+  if (ibgdaLocalRdmaXBufDevice_ != nullptr) {
+    (void)cudaFree(ibgdaLocalRdmaXBufDevice_);
+  }
+  // ibgdaDeviceTransportPtr_ is the wrapper struct (small) allocated
+  // explicitly above; the per-peer P2pIbgdaTransportDevice array it points
+  // to is owned by the transport (allocated via buildDeviceTransportsOnGpu),
+  // freed by transport dtor.
+  if (ibgdaDeviceTransportPtr_ != nullptr) {
+    (void)cudaFree(ibgdaDeviceTransportPtr_);
+  }
 }
 
 void LowLatencyRuntime::setPeerDataPtrs(const std::vector<void*>& peerPtrs) {
@@ -190,6 +221,185 @@ void LowLatencyRuntime::setPeerDataPtrs(const std::vector<void*>& peerPtrs) {
           peerPtrs.size() * sizeof(void*),
           cudaMemcpyHostToDevice),
       "LowLatencyRuntime: cudaMemcpy(peerDataPtrsDevice) failed");
+}
+
+namespace {
+
+// Helper: copy a host vector of T into a freshly-allocated device array.
+// Returns nullptr if vec is empty.
+template <typename T>
+T* FOLLY_NULLABLE uploadToDevice(const std::vector<T>& vec, const char* what) {
+  if (vec.empty()) {
+    return nullptr;
+  }
+  T* devPtr = nullptr;
+  if (cudaMalloc(&devPtr, vec.size() * sizeof(T)) != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("LowLatencyRuntime: cudaMalloc(") + what + ") failed");
+  }
+  if (cudaMemcpy(
+          devPtr, vec.data(), vec.size() * sizeof(T), cudaMemcpyHostToDevice) !=
+      cudaSuccess) {
+    (void)cudaFree(devPtr);
+    throw std::runtime_error(
+        std::string("LowLatencyRuntime: cudaMemcpy(") + what + ") failed");
+  }
+  return devPtr;
+}
+
+// Helper: pad peer-rank-indexed remote buffer vector (size = numRanks - 1,
+// excludes self) to a numRanks-indexed array (self slot zero-init). Lets
+// the kernel index by global rank without remap.
+std::vector<comms::prims::IbgdaRemoteBuffer> padPeerRemote(
+    const std::vector<comms::prims::IbgdaRemoteBuffer>& peerBufs,
+    int rank,
+    int numRanks) {
+  std::vector<comms::prims::IbgdaRemoteBuffer> out(numRanks);
+  for (int i = 0; i < numRanks; ++i) {
+    if (i == rank) {
+      continue; // self slot left default-initialized
+    }
+    int peerIndex = (i < rank) ? i : (i - 1);
+    out[i] = peerBufs[peerIndex];
+  }
+  return out;
+}
+
+} // namespace
+
+void LowLatencyRuntime::setupIbgda(
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap) {
+  if (numRanks_ < 2) {
+    // Single-rank: no peers, nothing to set up.
+    return;
+  }
+  if (ibgdaTransport_ != nullptr) {
+    throw std::runtime_error("LowLatencyRuntime::setupIbgda: already set up");
+  }
+
+  // 1. Construct the transport. NIC discovery happens here (local op).
+  // Use the currently-active CUDA device (set by the caller via
+  // `torch.cuda.set_device(local_rank)`) — using `rank_` directly only works
+  // single-host, since on multi-host rank ≥ num_local_ranks has no matching
+  // GPU ordinal on the local host.
+  int currentDevice = 0;
+  cudaError_t devErr = cudaGetDevice(&currentDevice);
+  if (devErr != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("LowLatencyRuntime::setupIbgda: cudaGetDevice failed: ") +
+        cudaGetErrorString(devErr));
+  }
+  comms::prims::MultipeerIbgdaTransportConfig cfg{};
+  cfg.cudaDevice = currentDevice;
+  // The kernel routes each block's puts through the QP indexed by its block_id,
+  // which it sets to dst_expert_local_idx (range [0, numLocalExperts)), so
+  // maxGroups must span the expert-index range. numQpsPerRank_ carries
+  // numLocalExperts.
+  cfg.maxGroups = numQpsPerRank_;
+  // Give each expert as many QPs/NIC as the transport's eager-exchange budget
+  // allows (maxGroups * qpsPerBlockPerNic <= kMaxEagerExchangeQpsPerPeerPerNic)
+  // to spread per-QP spinlock contention across more QPs and recover
+  // throughput. Safe with >1 QP/expert: the data->count (dispatch) and
+  // data->flag (combine) ordering is completion-based — the synchronous BNXT
+  // put drains each CQE before the per-expert finish counter / __syncthreads
+  // that gates the count/flag put — not same-QP FIFO.
+  const int qpsPerExpert =
+      comms::prims::kMaxEagerExchangeQpsPerPeerPerNic / numQpsPerRank_;
+  cfg.qpsPerBlockPerNic = qpsPerExpert > 0 ? qpsPerExpert : 1;
+  // Honor NCCL_IB_HCA from env so deployments can pin the NIC family /
+  // specific NICs. MultipeerIbgdaTransport reads `cfg.ibHca` and passes
+  // it to NicDiscovery as the filter; an empty string means "any NIC
+  // by best affinity".
+  if (const char* hca = std::getenv("NCCL_IB_HCA"); hca != nullptr) {
+    cfg.ibHca = hca;
+  }
+  ibgdaTransport_ = std::make_unique<comms::prims::MultipeerIbgdaTransport>(
+      rank_, numRanks_, std::move(bootstrap), cfg);
+
+  // 2. Exchange QP info (calls bootstrap->allGather under the hood).
+  ibgdaTransport_->exchange();
+
+  // 3. Register the LL RDMA buffer with the transport. The four LL regions
+  //    (dispatch_recv_x, dispatch_recv_count, combine_recv_x,
+  //    combine_recv_flag) live inside numRdmaBytes_ at known offsets; we
+  //    register the whole buffer once and use sub-buffer offsets.
+  auto localBuf =
+      ibgdaTransport_->registerBuffer(rdmaBufferPtr_, numRdmaBytes_);
+
+  // 4. Exchange remote buffer descriptors. One round-trip — every peer learns
+  //    every other peer's buffer addr+rkey for the same registered region.
+  auto peerRemote = ibgdaTransport_->exchangeBuffer(localBuf);
+
+  // 5. Build per-region per-peer arrays. The kernel indexes into these by
+  //    global rank, so pad with self-rank zero-init.
+  std::vector<comms::prims::IbgdaRemoteBuffer> peerRemoteRecvX(numRanks_);
+  std::vector<comms::prims::IbgdaRemoteBuffer> peerRemoteRecvCount(numRanks_);
+  std::vector<comms::prims::IbgdaRemoteBuffer> peerRemoteCombineRecvX(
+      numRanks_);
+  std::vector<comms::prims::IbgdaRemoteBuffer> peerRemoteCombineRecvFlag(
+      numRanks_);
+  // padPeerRemote returns exactly numRanks_ entries; the per-rank accesses
+  // below use padded.at(i) so an unexpected size throws instead of reading OOB.
+  auto padded = padPeerRemote(peerRemote, rank_, numRanks_);
+  for (int i = 0; i < numRanks_; ++i) {
+    if (i == rank_) {
+      continue;
+    }
+    peerRemoteRecvX[i] = padded.at(i).subBuffer(layout_.dispatchRecvXOffset);
+    peerRemoteRecvCount[i] =
+        padded.at(i).subBuffer(layout_.dispatchRecvCountOffset);
+    peerRemoteCombineRecvX[i] =
+        padded.at(i).subBuffer(layout_.combineRecvXOffset);
+    peerRemoteCombineRecvFlag[i] =
+        padded.at(i).subBuffer(layout_.combineRecvFlagOffset);
+  }
+
+  // 6. Build the local-buffer descriptors at the relevant offsets.
+  std::vector<comms::prims::IbgdaLocalBuffer> localRdmaXVec{
+      localBuf.subBuffer(layout_.dispatchSendXOffset)};
+  // Combine's RDMA source is the registered `combine_send_x` region (NOT the
+  // user `x` tensor, which isn't RDMA-registered). The combine kernel stages
+  // each token's hidden data into a `combine_send_x` slot and RDMAs from
+  // there. Register a local descriptor over that region so the kernel's
+  // cross-node branch has a valid lkey.
+  std::vector<comms::prims::IbgdaLocalBuffer> localCombineXVec{
+      localBuf.subBuffer(layout_.combineSendXOffset)};
+
+  // 7. Upload all device-resident arrays.
+  ibgdaLocalRdmaXBufDevice_ =
+      uploadToDevice(localRdmaXVec, "ibgdaLocalRdmaXBuf");
+  ibgdaLocalCombineXBufDevice_ =
+      uploadToDevice(localCombineXVec, "ibgdaLocalCombineXBuf");
+  ibgdaPeerRemoteRecvXDevice_ =
+      uploadToDevice(peerRemoteRecvX, "ibgdaPeerRemoteRecvX");
+  ibgdaPeerRemoteRecvCountDevice_ =
+      uploadToDevice(peerRemoteRecvCount, "ibgdaPeerRemoteRecvCount");
+  ibgdaPeerRemoteCombineRecvXDevice_ =
+      uploadToDevice(peerRemoteCombineRecvX, "ibgdaPeerRemoteCombineRecvX");
+  ibgdaPeerRemoteCombineRecvFlagDevice_ = uploadToDevice(
+      peerRemoteCombineRecvFlag, "ibgdaPeerRemoteCombineRecvFlag");
+
+  // 8. Allocate a MultipeerIbgdaDeviceTransport on device for the kernel.
+  //    getDeviceTransport() returns the wrapper by value (it just bundles
+  //    the per-peer P2pIbgdaTransportDevice array span). Copy that wrapper
+  //    to device memory so the kernel can dereference it.
+  auto wrapper = ibgdaTransport_->getDeviceTransport();
+  if (cudaMalloc(
+          &ibgdaDeviceTransportPtr_,
+          sizeof(comms::prims::MultipeerIbgdaDeviceTransport)) != cudaSuccess) {
+    throw std::runtime_error(
+        "LowLatencyRuntime: cudaMalloc(deviceTransport) failed");
+  }
+  if (cudaMemcpy(
+          ibgdaDeviceTransportPtr_,
+          &wrapper,
+          sizeof(comms::prims::MultipeerIbgdaDeviceTransport),
+          cudaMemcpyHostToDevice) != cudaSuccess) {
+    (void)cudaFree(ibgdaDeviceTransportPtr_);
+    ibgdaDeviceTransportPtr_ = nullptr;
+    throw std::runtime_error(
+        "LowLatencyRuntime: cudaMemcpy(deviceTransport) failed");
+  }
 }
 
 } // namespace comms::prims::moe_ep

--- a/comms/prims/collectives/moe_ep/cpp/low_latency/Runtime.h
+++ b/comms/prims/collectives/moe_ep/cpp/low_latency/Runtime.h
@@ -25,6 +25,9 @@ namespace comms::prims {
 class MultipeerIbgdaTransport;
 class MultiPeerNvlTransport;
 class GpuMemHandler;
+struct MultipeerIbgdaDeviceTransport;
+struct IbgdaLocalBuffer;
+struct IbgdaRemoteBuffer;
 } // namespace comms::prims
 
 namespace comms::prims::moe_ep {
@@ -136,6 +139,63 @@ class LowLatencyRuntime {
    *  Buffer after sync() to wire the NVLink peer-mapped buffers. */
   void setPeerDataPtrs(const std::vector<void*>& peerPtrs);
 
+  /**
+   * Set up MultipeerIbgdaTransport for the cross-node IBGDA path.
+   *
+   * Constructs the transport with the given bootstrap, calls exchange()
+   * (which uses bootstrap->allGather), registers the LL RDMA buffer, and
+   * exchanges per-peer remote buffer descriptors for the four LL regions.
+   *
+   * Caller responsibility: provide a bootstrap that can perform the
+   * required allGathers. PreExchangedBootstrap is the typical choice when
+   * Python pre-gathers QP info via dist.all_gather_object.
+   *
+   * Idempotent in the sense that it must only be called once (transport
+   * setup is destructive). Subsequent dispatch/combine calls will see
+   * non-null device transport + per-peer remote buffers.
+   *
+   * Skipped silently when called on a single-rank setup.
+   */
+  void setupIbgda(std::shared_ptr<meta::comms::IBootstrap> bootstrap);
+
+  /** Whether IBGDA is set up and the device transport is available. */
+  bool hasIbgda() const noexcept {
+    return ibgdaDeviceTransportPtr_ != nullptr;
+  }
+
+  /** Returns nullptr if IBGDA wasn't set up. */
+  comms::prims::MultipeerIbgdaDeviceTransport* getIbgdaDeviceTransport()
+      const noexcept {
+    return ibgdaDeviceTransportPtr_;
+  }
+
+  /** Per-peer arrays (numRanks entries; self-rank entry zero-init). nullptr
+   *  if IBGDA not set up. */
+  const comms::prims::IbgdaLocalBuffer* getLocalRdmaXBufDevice()
+      const noexcept {
+    return ibgdaLocalRdmaXBufDevice_;
+  }
+  const comms::prims::IbgdaLocalBuffer* getLocalCombineXBufDevice()
+      const noexcept {
+    return ibgdaLocalCombineXBufDevice_;
+  }
+  const comms::prims::IbgdaRemoteBuffer* getPeerRemoteRecvXDevice()
+      const noexcept {
+    return ibgdaPeerRemoteRecvXDevice_;
+  }
+  const comms::prims::IbgdaRemoteBuffer* getPeerRemoteRecvCountDevice()
+      const noexcept {
+    return ibgdaPeerRemoteRecvCountDevice_;
+  }
+  const comms::prims::IbgdaRemoteBuffer* getPeerRemoteCombineRecvXDevice()
+      const noexcept {
+    return ibgdaPeerRemoteCombineRecvXDevice_;
+  }
+  const comms::prims::IbgdaRemoteBuffer* getPeerRemoteCombineRecvFlagDevice()
+      const noexcept {
+    return ibgdaPeerRemoteCombineRecvFlagDevice_;
+  }
+
  private:
   const int rank_;
   const int numRanks_;
@@ -147,6 +207,19 @@ class LowLatencyRuntime {
   LowLatencyLayout layout_;
 
   std::unique_ptr<comms::prims::MultipeerIbgdaTransport> ibgdaTransport_;
+  // Device-resident IBGDA descriptors. Populated by setupIbgda().
+  // Per-peer arrays are device-allocated copies of the corresponding host
+  // vectors returned by transport.exchangeBuffer(). Indexed by peer rank
+  // [0..numRanks); self-rank entry is zero-initialized.
+  comms::prims::MultipeerIbgdaDeviceTransport* ibgdaDeviceTransportPtr_{
+      nullptr};
+  comms::prims::IbgdaLocalBuffer* ibgdaLocalRdmaXBufDevice_{nullptr};
+  comms::prims::IbgdaLocalBuffer* ibgdaLocalCombineXBufDevice_{nullptr};
+  comms::prims::IbgdaRemoteBuffer* ibgdaPeerRemoteRecvXDevice_{nullptr};
+  comms::prims::IbgdaRemoteBuffer* ibgdaPeerRemoteRecvCountDevice_{nullptr};
+  comms::prims::IbgdaRemoteBuffer* ibgdaPeerRemoteCombineRecvXDevice_{nullptr};
+  comms::prims::IbgdaRemoteBuffer* ibgdaPeerRemoteCombineRecvFlagDevice_{
+      nullptr};
 
   // The big LL data buffer — uncached on AMD (BNXT dma-buf parity).
   // If ownsRdmaBuffer_ is false, the buffer is externally owned.

--- a/comms/prims/collectives/moe_ep/cpp/low_latency/kernels/Combine.cu
+++ b/comms/prims/collectives/moe_ep/cpp/low_latency/kernels/Combine.cu
@@ -10,6 +10,9 @@
 #include "comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelConfigs.cuh"
 #include "comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelUtils.cuh"
 #include "comms/prims/collectives/moe_ep/cpp/shared/kernels/Launch.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/transport/ibgda/MultipeerIbgdaDeviceTransport.cuh"
+#include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
 
 namespace comms::prims::moe_ep::kernels {
 
@@ -78,6 +81,10 @@ __launch_bounds__(kNumWarpGroups * kNumWarpsPerGroup * kWarpSize, 1) void ll_com
     int rank,
     int num_ranks,
     void** buffer_ptrs,
+    comms::prims::MultipeerIbgdaDeviceTransport* device_transport,
+    const comms::prims::IbgdaLocalBuffer* local_x_buf,
+    const comms::prims::IbgdaRemoteBuffer* peer_remote_recv_x,
+    const comms::prims::IbgdaRemoteBuffer* peer_remote_recv_flag,
     int phases,
     bool zero_copy) {
   const int sm_id = static_cast<int>(blockIdx.x);
@@ -133,25 +140,92 @@ __launch_bounds__(kNumWarpGroups * kNumWarpsPerGroup * kWarpSize, 1) void ll_com
       const auto* x_int4 = local_x + token_idx * hidden_bf16_int4;
       int src_idx = __ldg(local_src_info + token_idx);
 
-      // Write to peer's rdma_recv_x via NVLink IPC
-      auto* peer_base = reinterpret_cast<uint8_t*>(buffer_ptrs[dst_rank]);
-      // Compute offset in peer's symmetric buffer
-      uintptr_t recv_x_offset = reinterpret_cast<uintptr_t>(rdma_recv_x) -
-          reinterpret_cast<uintptr_t>(buffer_ptrs[rank]);
-      auto* dst_ptr = reinterpret_cast<int4*>(
-          peer_base + recv_x_offset +
-          (global_expert_idx * num_max_dispatch_tokens_per_rank + src_idx) *
-              num_bytes_per_slot +
-          sizeof(int4));
+      // Hybrid path — same-node IPC vs cross-node IBGDA.
+      if (buffer_ptrs[dst_rank] != nullptr) {
+        // Same-node: NVLink IPC write into peer's symmetric buffer.
+        auto* peer_base = reinterpret_cast<uint8_t*>(buffer_ptrs[dst_rank]);
+        uintptr_t recv_x_offset = reinterpret_cast<uintptr_t>(rdma_recv_x) -
+            reinterpret_cast<uintptr_t>(buffer_ptrs[rank]);
+        auto* dst_ptr = reinterpret_cast<int4*>(
+            peer_base + recv_x_offset +
+            (global_expert_idx * num_max_dispatch_tokens_per_rank + src_idx) *
+                num_bytes_per_slot +
+            sizeof(int4));
 
-      MOE_EP_UNROLLED_WARP_COPY(
-          kIntranodeUnrollFactor,
-          lane_id,
-          static_cast<int>(hidden_bf16_int4),
-          dst_ptr,
-          x_int4,
-          ld_nc_global,
-          st_na_global);
+        MOE_EP_UNROLLED_WARP_COPY(
+            kIntranodeUnrollFactor,
+            lane_id,
+            static_cast<int>(hidden_bf16_int4),
+            dst_ptr,
+            x_int4,
+            ld_nc_global,
+            st_na_global);
+      } else if (
+          device_transport != nullptr && local_x_buf != nullptr &&
+          peer_remote_recv_x != nullptr) {
+        // Cross-node IBGDA RDMA put. The user `x` tensor is NOT
+        // RDMA-registered, so we first stage this token's hidden data into
+        // the registered `combine_send_x` slot, then RDMA from there.
+        auto& peer_transport = device_transport->get(dst_rank);
+        // Stage x[token] -> rdma_send_x slot (data area, past the int4 header).
+        const std::size_t send_slot =
+            static_cast<std::size_t>(local_expert_idx) * num_ranks *
+                num_max_dispatch_tokens_per_rank +
+            static_cast<std::size_t>(token_idx);
+        auto* stage_ptr = reinterpret_cast<int4*>(
+            reinterpret_cast<uint8_t*>(rdma_send_x) +
+            send_slot * num_bytes_per_slot + sizeof(int4));
+        MOE_EP_UNROLLED_WARP_COPY(
+            kIntranodeUnrollFactor,
+            lane_id,
+            static_cast<int>(hidden_bf16_int4),
+            stage_ptr,
+            x_int4,
+            ld_nc_global,
+            st_na_global);
+        syncwarp();
+#ifdef __HIP_PLATFORM_AMD__
+        // Retire the non-coherent VMEM stores above before the RDMA reads them.
+        __atomic_signal_fence(__ATOMIC_SEQ_CST);
+        __builtin_amdgcn_s_waitcnt(0);
+        __atomic_signal_fence(__ATOMIC_SEQ_CST);
+#endif
+        // Local source: the staged slot in the registered combine_send_x.
+        auto local_buf = local_x_buf->subBuffer(
+            send_slot * num_bytes_per_slot + sizeof(int4));
+        // Remote dest: peer's combine_recv_x slot for [global_expert_idx,
+        // src_idx], offset past the int4 slot header.
+        std::size_t remote_offset =
+            (static_cast<std::size_t>(global_expert_idx) *
+                 num_max_dispatch_tokens_per_rank +
+             static_cast<std::size_t>(src_idx)) *
+                num_bytes_per_slot +
+            sizeof(int4);
+        auto remote_slot =
+            peer_remote_recv_x[dst_rank].subBuffer(remote_offset);
+        auto warp_grp = make_warp_group();
+        // Key on this expert via block_id (the transport indexes QPs by
+        // block_id; see Dispatch.cu rationale): spreads QP-spinlock contention
+        // across the per-expert QP band. Data-before-flag ordering comes from
+        // the synchronous put drain + the __syncthreads below, not same-QP
+        // FIFO.
+        warp_grp.block_id = static_cast<uint32_t>(local_expert_idx);
+        peer_transport.put(
+            warp_grp,
+            local_buf,
+            remote_slot,
+            kHidden * sizeof(uint16_t),
+            IbgdaRemoteBuffer{}); // flag write below, same QP, ordered after
+      } else {
+        if (lane_id == 0) {
+          printf(
+              "moe_ep LL combine: cross-node peer with no IBGDA transport "
+              "(rank=%d, dst_rank=%d).\n",
+              rank,
+              dst_rank);
+          trap_kernel();
+        }
+      }
     }
 
     __syncthreads();
@@ -159,21 +233,70 @@ __launch_bounds__(kNumWarpGroups * kNumWarpsPerGroup * kWarpSize, 1) void ll_com
       while (ld_volatile_global(atomic_clean_flag) == 0) {
       }
 
-      // Write completion flag to peer's rdma_recv_flag via NVLink
-      auto* peer_base = reinterpret_cast<uint8_t*>(buffer_ptrs[dst_rank]);
-      uintptr_t flag_offset = reinterpret_cast<uintptr_t>(rdma_recv_flag) -
-          reinterpret_cast<uintptr_t>(buffer_ptrs[rank]);
-      auto* peer_flag = reinterpret_cast<int64_t*>(peer_base + flag_offset);
+      // Write completion flag to peer's rdma_recv_flag.
+      // Hybrid: NVLink IPC store for same-node, IBGDA store for cross-node.
+      if (buffer_ptrs[dst_rank] != nullptr) {
+        auto* peer_base = reinterpret_cast<uint8_t*>(buffer_ptrs[dst_rank]);
+        uintptr_t flag_offset = reinterpret_cast<uintptr_t>(rdma_recv_flag) -
+            reinterpret_cast<uintptr_t>(buffer_ptrs[rank]);
+        auto* peer_flag = reinterpret_cast<int64_t*>(peer_base + flag_offset);
 #ifdef __HIP_PLATFORM_AMD__
-      __hip_atomic_store(
-          peer_flag + global_expert_idx,
-          static_cast<int64_t>(1),
-          __ATOMIC_RELEASE,
-          __HIP_MEMORY_SCOPE_SYSTEM);
+        __hip_atomic_store(
+            peer_flag + global_expert_idx,
+            static_cast<int64_t>(1),
+            __ATOMIC_RELEASE,
+            __HIP_MEMORY_SCOPE_SYSTEM);
 #else
-      *(peer_flag + global_expert_idx) = 1;
-      __threadfence_system();
+        *(peer_flag + global_expert_idx) = 1;
+        __threadfence_system();
 #endif
+      } else if (
+          device_transport != nullptr && peer_remote_recv_flag != nullptr &&
+          local_x_buf != nullptr) {
+        // Cross-node IBGDA. Use a regular RDMA Write (8B inline) of the
+        // flag value (1) instead of atomic-FA. The receiver only checks
+        // `flag != 0` — atomicity isn't required, and plain put is the
+        // most-validated cross-host RDMA path on AMD.
+        auto& peer_transport = device_transport->get(dst_rank);
+        std::size_t flag_offset =
+            static_cast<std::size_t>(global_expert_idx) * sizeof(int64_t);
+        auto remote_slot =
+            peer_remote_recv_flag[dst_rank].subBuffer(flag_offset);
+        int64_t local_flag = 1;
+        comms::prims::IbgdaLocalBuffer local_buf = local_x_buf->subBuffer(0);
+        // INVARIANT: local_flag is a device stack variable OUTSIDE the
+        // RDMA-registered combine_send_x region; we borrow local_x_buf's lkey
+        // only to fill a valid WQE lkey field. This is safe ONLY because a
+        // single 8B RDMA write is inline-encoded into the WQE at prepare time,
+        // so the backend reads *local_buf.ptr synchronously on this thread and
+        // never hands the (unregistered) stack address to the NIC for DMA. A
+        // larger payload would spill out of the inline segment and DMA the
+        // unregistered address (LOCAL_PROT / garbage), so pin the size here.
+        static_assert(
+            sizeof(local_flag) == sizeof(int64_t),
+            "cross-node combine flag must stay a single 8B inline-encoded word; "
+            "a larger payload would DMA the unregistered local_flag stack "
+            "address through the borrowed lkey");
+        local_buf.ptr = &local_flag;
+        auto thr = make_thread_solo();
+        // Key on this expert via block_id (same expert QP band as its data
+        // puts). The flag is ordered after the data by the synchronous put
+        // drain + __syncthreads above, not by same-QP FIFO. 8B INLINE-encoded.
+        thr.block_id = static_cast<uint32_t>(local_expert_idx);
+        peer_transport.put(
+            thr,
+            local_buf,
+            remote_slot,
+            sizeof(int64_t),
+            comms::prims::IbgdaRemoteBuffer{});
+      } else {
+        printf(
+            "moe_ep LL combine flag: cross-node peer with no IBGDA "
+            "transport (rank=%d, dst_rank=%d).\n",
+            rank,
+            dst_rank);
+        trap_kernel();
+      }
       atomicAdd(atomic_clean_flag, -1);
     }
   }
@@ -276,6 +399,10 @@ void low_latency_combine(
     int num_ranks,
     void* workspace,
     void** buffer_ptrs,
+    comms::prims::MultipeerIbgdaDeviceTransport* device_transport,
+    const comms::prims::IbgdaLocalBuffer* local_x_buf,
+    const comms::prims::IbgdaRemoteBuffer* peer_remote_recv_x,
+    const comms::prims::IbgdaRemoteBuffer* peer_remote_recv_flag,
     int phase,
     bool zero_copy,
     cudaStream_t stream) {
@@ -320,6 +447,10 @@ void low_latency_combine(
       rank,                                                                   \
       num_ranks,                                                              \
       buffer_ptrs,                                                            \
+      device_transport,                                                       \
+      local_x_buf,                                                            \
+      peer_remote_recv_x,                                                     \
+      peer_remote_recv_flag,                                                  \
       phase,                                                                  \
       zero_copy)
 

--- a/comms/prims/collectives/moe_ep/cpp/low_latency/kernels/Combine.cuh
+++ b/comms/prims/collectives/moe_ep/cpp/low_latency/kernels/Combine.cuh
@@ -10,11 +10,17 @@
 #include <cuda_runtime.h>
 #endif
 
+namespace comms::prims {
+struct MultipeerIbgdaDeviceTransport;
+struct IbgdaRemoteBuffer;
+struct IbgdaLocalBuffer;
+} // namespace comms::prims
+
 namespace comms::prims::moe_ep::kernels {
 
 /**
  * Low-latency combine — return post-MoE results to source ranks via NVLink
- * peer-mapped IPC buffers.
+ * peer-mapped IPC buffers (same-node) or IBGDA RDMA (cross-node).
  */
 void low_latency_combine(
     void* combined_x,
@@ -38,6 +44,14 @@ void low_latency_combine(
     int num_ranks,
     void* workspace,
     void** buffer_ptrs,
+    // IBGDA cross-node hybrid path. May be nullptr (single-node mode).
+    // local_x_buf: local x tensor as registered IbgdaLocalBuffer.
+    // peer_remote_recv_x: each peer's combine_recv_x descriptor.
+    // peer_remote_recv_flag: each peer's combine_recv_flag descriptor.
+    comms::prims::MultipeerIbgdaDeviceTransport* device_transport,
+    const comms::prims::IbgdaLocalBuffer* local_x_buf,
+    const comms::prims::IbgdaRemoteBuffer* peer_remote_recv_x,
+    const comms::prims::IbgdaRemoteBuffer* peer_remote_recv_flag,
     int phase,
     bool zero_copy,
     cudaStream_t stream);

--- a/comms/prims/collectives/moe_ep/cpp/low_latency/kernels/Dispatch.cu
+++ b/comms/prims/collectives/moe_ep/cpp/low_latency/kernels/Dispatch.cu
@@ -12,12 +12,15 @@
 #include "comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelConfigs.cuh"
 #include "comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelUtils.cuh"
 #include "comms/prims/collectives/moe_ep/cpp/shared/kernels/Launch.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/transport/ibgda/MultipeerIbgdaDeviceTransport.cuh"
+#include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
 
 namespace comms::prims::moe_ep::kernels {
 
 namespace {
 
-// Phase flags for the send / recv phases.
+// Phase flags selecting the send and/or receive stage of the kernel.
 constexpr int kLLSendPhase = 1;
 constexpr int kLLRecvPhase = 2;
 
@@ -78,6 +81,10 @@ __launch_bounds__(kNumWarpGroups * kNumWarpsPerGroup * kWarpSize, 1) void ll_dis
     int rank,
     int num_ranks,
     void** buffer_ptrs,
+    comms::prims::MultipeerIbgdaDeviceTransport* device_transport,
+    const comms::prims::IbgdaLocalBuffer* local_rdma_x_buf,
+    const comms::prims::IbgdaRemoteBuffer* peer_remote_recv_x,
+    const comms::prims::IbgdaRemoteBuffer* peer_remote_recv_count,
     int phases) {
   const int sm_id = static_cast<int>(blockIdx.x);
   const int thread_id = static_cast<int>(threadIdx.x);
@@ -148,29 +155,92 @@ __launch_bounds__(kNumWarpGroups * kNumWarpsPerGroup * kWarpSize, 1) void ll_dis
         const auto* src_int4_ptr =
             reinterpret_cast<const int4*>(rdma_x_src_idx);
 
-        // Destination: peer's rdma_recv_x buffer via IPC.
-        // Compute the offset of rdma_recv_x within the symmetric buffer,
-        // then apply the same offset to the peer's buffer base.
-        uintptr_t recv_x_off = reinterpret_cast<uintptr_t>(rdma_recv_x) -
-            reinterpret_cast<uintptr_t>(buffer_ptrs[rank]);
-        auto* dst_ptr = reinterpret_cast<int4*>(
-            reinterpret_cast<uint8_t*>(buffer_ptrs[dst_rank]) + recv_x_off +
-            dst_expert_local_idx * num_ranks *
-                num_max_dispatch_tokens_per_rank * num_bytes_per_msg +
-            rank * num_max_dispatch_tokens_per_rank * num_bytes_per_msg +
-            slot_idx * num_bytes_per_msg);
+        // Hybrid path.
+        // Same-node peers (P2P-capable): NVLink IPC fast path via
+        // UNROLLED_WARP_COPY into the peer's symmetric buffer.
+        // Cross-node peers: RDMA via MultipeerIbgdaTransport.
+        if (buffer_ptrs[dst_rank] != nullptr) {
+          // Destination: peer's rdma_recv_x buffer via IPC.
+          // Compute the offset of rdma_recv_x within the symmetric buffer,
+          // then apply the same offset to the peer's buffer base.
+          uintptr_t recv_x_off = reinterpret_cast<uintptr_t>(rdma_recv_x) -
+              reinterpret_cast<uintptr_t>(buffer_ptrs[rank]);
+          auto* dst_ptr = reinterpret_cast<int4*>(
+              reinterpret_cast<uint8_t*>(buffer_ptrs[dst_rank]) + recv_x_off +
+              dst_expert_local_idx * num_ranks *
+                  num_max_dispatch_tokens_per_rank * num_bytes_per_msg +
+              rank * num_max_dispatch_tokens_per_rank * num_bytes_per_msg +
+              slot_idx * num_bytes_per_msg);
 
-        // NVLink copy (same as intranode UNROLLED_WARP_COPY)
-        MOE_EP_UNROLLED_WARP_COPY(
-            kIntranodeUnrollFactor,
-            lane_id,
-            static_cast<int>(num_int4_per_msg),
-            dst_ptr,
-            src_int4_ptr,
-            ld_nc_global,
-            st_na_global);
+          // NVLink copy (same as intranode UNROLLED_WARP_COPY)
+          MOE_EP_UNROLLED_WARP_COPY(
+              kIntranodeUnrollFactor,
+              lane_id,
+              static_cast<int>(num_int4_per_msg),
+              dst_ptr,
+              src_int4_ptr,
+              ld_nc_global,
+              st_na_global);
+        } else {
+          // Cross-node IBGDA RDMA path: warp-collective put of the token
+          // message to the peer's recv buffer.
+          if (device_transport != nullptr && local_rdma_x_buf != nullptr &&
+              peer_remote_recv_x != nullptr) {
+            auto& peer_transport = device_transport->get(dst_rank);
+            // Local source: the rdma_x staging slot for this token
+            auto local_buf = local_rdma_x_buf->subBuffer(
+                static_cast<std::size_t>(token_idx) * num_bytes_per_msg);
+            // Remote dest: peer's rdma_recv_x slot for [dst_expert_local_idx,
+            // src_rank=rank, slot_idx]
+            std::size_t remote_offset =
+                static_cast<std::size_t>(dst_expert_local_idx) * num_ranks *
+                    num_max_dispatch_tokens_per_rank * num_bytes_per_msg +
+                static_cast<std::size_t>(rank) *
+                    num_max_dispatch_tokens_per_rank * num_bytes_per_msg +
+                static_cast<std::size_t>(slot_idx) * num_bytes_per_msg;
+            auto remote_slot =
+                peer_remote_recv_x[dst_rank].subBuffer(remote_offset);
+            auto warp_grp = make_warp_group();
+            // Key each put on the destination expert via block_id (the
+            // transport indexes QPs by block_id, giving expert E its own band
+            // of qpsPerBlockPerNic QPs per NIC). This spreads QP-spinlock
+            // contention across the per-expert QPs — pinning everything to one
+            // QP funnels every warp in the grid onto a single GPU spinlock
+            // whose holder may be a non-resident wavefront -> deadlock under
+            // load. Data-before-count does NOT depend on same-QP FIFO: the
+            // synchronous BNXT put drains each token's CQE before its
+            // finish-counter bump, and the count put (below) only fires once
+            // the counter shows all of this expert's data has landed.
+            warp_grp.block_id = static_cast<uint32_t>(dst_expert_local_idx);
+            peer_transport.put(
+                warp_grp,
+                local_buf,
+                remote_slot,
+                num_bytes_per_msg,
+                IbgdaRemoteBuffer{}); // no signal; count put below, same QP
+          } else {
+            // Should be unreachable in well-formed runs (caller passes
+            // either valid IBGDA or all peers same-node). Trap to surface
+            // misconfiguration.
+            if (lane_id == 0) {
+              printf(
+                  "moe_ep LL dispatch: cross-node peer with no IBGDA "
+                  "transport (rank=%d, dst_rank=%d). Configure with "
+                  "MultipeerIbgdaTransport or use single-node mode.\n",
+                  rank,
+                  dst_rank);
+              trap_kernel();
+            }
+          }
+        }
 
-        // Signal completion
+        // Signal completion. The AMD path needs `s_waitcnt` to retire any
+        // VMEM stores still in-flight (the IPC `MOE_EP_UNROLLED_WARP_COPY`
+        // above is non-coherent and would otherwise still be pending when
+        // the next warp/SM reads the destination). The signal-fence pair
+        // around it forces the compiler not to reorder unrelated writes
+        // across the barrier. NVIDIA doesn't need any of this — its store
+        // ordering is already strict enough for this pattern.
         syncwarp();
 #ifdef __HIP_PLATFORM_AMD__
         __atomic_signal_fence(__ATOMIC_SEQ_CST);
@@ -235,23 +305,71 @@ __launch_bounds__(kNumWarpGroups * kNumWarpsPerGroup * kWarpSize, 1) void ll_dis
            FINISHED_SUM_TAG) {
     }
 
-    // Write token count to peer's rdma_recv_count via NVLink.
+    // Write token count to peer's rdma_recv_count.
     // Encode as a single int64: -(count+1) so 0 means "not yet sent".
-    auto* peer_recv_count = reinterpret_cast<int64_t*>(
-        reinterpret_cast<uint8_t*>(buffer_ptrs[dst_rank]) +
-        reinterpret_cast<uintptr_t>(rdma_recv_count) -
-        reinterpret_cast<uintptr_t>(buffer_ptrs[rank]));
+    // Hybrid path: NVLink IPC store for same-node, IBGDA store for
+    // cross-node.
     int64_t encoded = -static_cast<int64_t>(num_tokens_sent) - 1;
+    if (buffer_ptrs[dst_rank] != nullptr) {
+      auto* peer_recv_count = reinterpret_cast<int64_t*>(
+          reinterpret_cast<uint8_t*>(buffer_ptrs[dst_rank]) +
+          reinterpret_cast<uintptr_t>(rdma_recv_count) -
+          reinterpret_cast<uintptr_t>(buffer_ptrs[rank]));
 #ifdef __HIP_PLATFORM_AMD__
-    __hip_atomic_store(
-        peer_recv_count + dst_expert_local_idx * num_ranks + rank,
-        encoded,
-        __ATOMIC_RELEASE,
-        __HIP_MEMORY_SCOPE_SYSTEM);
+      __hip_atomic_store(
+          peer_recv_count + dst_expert_local_idx * num_ranks + rank,
+          encoded,
+          __ATOMIC_RELEASE,
+          __HIP_MEMORY_SCOPE_SYSTEM);
 #else
-    *(peer_recv_count + dst_expert_local_idx * num_ranks + rank) = encoded;
-    __threadfence_system();
+      *(peer_recv_count + dst_expert_local_idx * num_ranks + rank) = encoded;
+      __threadfence_system();
 #endif
+    } else if (
+        device_transport != nullptr && peer_remote_recv_count != nullptr &&
+        local_rdma_x_buf != nullptr) {
+      // Cross-node IBGDA. Use a regular RDMA Write (8B inline) of the
+      // `encoded` value instead of atomic-FA. Each (src_rank, dst_expert)
+      // pair has a unique destination slot — atomicity is not needed.
+      // Plain put is the most-validated cross-host RDMA path on AMD; the
+      // atomic-FA path is reportedly flaky for AMD+GPU-direct on MI300X.
+      auto& peer_transport = device_transport->get(dst_rank);
+      std::size_t slot_offset =
+          (static_cast<std::size_t>(dst_expert_local_idx) * num_ranks +
+           static_cast<std::size_t>(rank)) *
+          sizeof(int64_t);
+      auto remote_slot =
+          peer_remote_recv_count[dst_rank].subBuffer(slot_offset);
+      // Stage `encoded` in a local int64. Address is GPU-readable (stack
+      // register-spill or local memory). For 8B writes the BNXT/MLX5
+      // backends use INLINE encoding — the data is copied into the WQE
+      // at prepare time and never DMA-fetched from this address, so the
+      // lkey we pass is irrelevant. We borrow `local_rdma_x_buf`'s lkeys
+      // to satisfy IbgdaLocalBuffer's structural requirement.
+      int64_t local_encoded = encoded;
+      comms::prims::IbgdaLocalBuffer local_buf = local_rdma_x_buf->subBuffer(0);
+      local_buf.ptr = &local_encoded;
+      auto thr = make_thread_solo();
+      // Key on this expert via block_id (same expert QP band as its data puts).
+      // The count is ordered after all of the expert's data by the finish
+      // counter above + the synchronous put drain, not by same-QP FIFO. The 8B
+      // value is INLINE-encoded by the BNXT/MLX5 backend (<=16B), so
+      // local_buf's lkey is irrelevant.
+      thr.block_id = static_cast<uint32_t>(dst_expert_local_idx);
+      peer_transport.put(
+          thr,
+          local_buf,
+          remote_slot,
+          sizeof(int64_t),
+          comms::prims::IbgdaRemoteBuffer{});
+    } else {
+      printf(
+          "moe_ep LL dispatch count signal: cross-node peer with no IBGDA "
+          "transport (rank=%d, dst_rank=%d).\n",
+          rank,
+          dst_rank);
+      trap_kernel();
+    }
 
     // Clean workspace
     atomic_counter_per_expert[responsible_expert_idx] = 0;
@@ -295,15 +413,19 @@ LL_DISPATCH_RECV:
     if (sub_warp_id == 0 && lane_id == 0) {
       long long start_time = wall_clock64_compat();
       int64_t recv_val = 0;
-      while ((recv_val = *reinterpret_cast<volatile int64_t*>(
-                  rdma_recv_count + local_expert_idx * num_ranks + src_rank)) ==
-             0) {
+      auto* slot_ptr = reinterpret_cast<volatile int64_t*>(
+          rdma_recv_count + local_expert_idx * num_ranks + src_rank);
+      while ((recv_val = *slot_ptr) == 0) {
         long long elapsed = wall_clock64_compat() - start_time;
         if (elapsed > NUM_TIMEOUT_CYCLES) {
           printf(
-              "moe_ep LL dispatch recv timeout rank=%d expert=%d\n",
+              "moe_ep LL dispatch recv timeout rank=%d expert=%d "
+              "slot_ptr=%p slot_val=%lld src_rank=%d\n",
               rank,
-              local_expert_idx);
+              local_expert_idx,
+              const_cast<int64_t*>(slot_ptr),
+              (long long)recv_val,
+              src_rank);
           trap_kernel();
         }
       }
@@ -314,7 +436,7 @@ LL_DISPATCH_RECV:
           atomicAdd(packed_recv_count + local_expert_idx, num_recv_tokens);
       shared_num_recv_tokens[warp_group_id] = num_recv_tokens;
       shared_recv_token_begin_idx[warp_group_id] = recv_token_begin_idx;
-      // Pack layout range: (begin_idx << 32) | count
+      // Pack layout range: (begin_idx << 32) | count.
       recv_range[src_rank] =
           (static_cast<int64_t>(recv_token_begin_idx) << 32) |
           static_cast<int64_t>(num_recv_tokens);
@@ -378,6 +500,10 @@ void low_latency_dispatch(
     bool round_scale,
     bool use_ue8m0,
     void** buffer_ptrs,
+    comms::prims::MultipeerIbgdaDeviceTransport* device_transport,
+    const comms::prims::IbgdaLocalBuffer* local_rdma_x_buf,
+    const comms::prims::IbgdaRemoteBuffer* peer_remote_recv_x,
+    const comms::prims::IbgdaRemoteBuffer* peer_remote_recv_count,
     int phase,
     cudaStream_t stream) {
   if (use_fp8) {
@@ -422,6 +548,10 @@ void low_latency_dispatch(
       rank,                                                       \
       num_ranks,                                                  \
       buffer_ptrs,                                                \
+      device_transport,                                           \
+      local_rdma_x_buf,                                           \
+      peer_remote_recv_x,                                         \
+      peer_remote_recv_count,                                     \
       phase)
 
   SWITCH_HIDDEN(LL_DISPATCH_LAUNCH);

--- a/comms/prims/collectives/moe_ep/cpp/low_latency/kernels/Dispatch.cuh
+++ b/comms/prims/collectives/moe_ep/cpp/low_latency/kernels/Dispatch.cuh
@@ -10,6 +10,12 @@
 #include <cuda_runtime.h>
 #endif
 
+namespace comms::prims {
+struct MultipeerIbgdaDeviceTransport;
+struct IbgdaRemoteBuffer;
+struct IbgdaLocalBuffer;
+} // namespace comms::prims
+
 namespace comms::prims::moe_ep::kernels {
 
 /**
@@ -43,6 +49,10 @@ void low_latency_dispatch(
     bool round_scale,
     bool use_ue8m0,
     void** buffer_ptrs,
+    comms::prims::MultipeerIbgdaDeviceTransport* device_transport,
+    const comms::prims::IbgdaLocalBuffer* local_rdma_x_buf,
+    const comms::prims::IbgdaRemoteBuffer* peer_remote_recv_x,
+    const comms::prims::IbgdaRemoteBuffer* peer_remote_recv_count,
     int phase,
     cudaStream_t stream);
 

--- a/comms/prims/collectives/moe_ep/cpp/shared/PreExchangedBootstrap.h
+++ b/comms/prims/collectives/moe_ep/cpp/shared/PreExchangedBootstrap.h
@@ -1,0 +1,105 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <queue>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <folly/futures/Future.h>
+
+#include "comms/common/bootstrap/IBootstrap.h"
+
+namespace comms::prims::moe_ep {
+
+/**
+ * PreExchangedBootstrap — IBootstrap impl that returns pre-gathered
+ * allGather results in FIFO order.
+ *
+ * Use case: the LL runtime needs `MultipeerIbgdaTransport::exchange()` and
+ * `exchangeBuffer()` to succeed, both of which call `bootstrap->allGather`.
+ * On our backend we don't have a runtime collective layer plumbed into the
+ * C++ Buffer ctor — Python-side `dist.all_gather_object` is the only
+ * collective available. This bootstrap bridges the two: Python pre-gathers
+ * the relevant byte arrays in advance and queues them; the transport's
+ * sequential `allGather` calls pop from the queue.
+ *
+ * Ordering contract: caller MUST queue allGather results in the exact
+ * order that `MultipeerIbgdaTransport::exchange()` and the subsequent
+ * `exchangeBuffer()` calls will consume them. Mismatched sizes throw.
+ *
+ * `barrier` is a no-op; assumes Python-side `dist.barrier()` was called
+ * before construction. `send/recv` are unsupported (throw).
+ */
+class PreExchangedBootstrap : public meta::comms::IBootstrap {
+ public:
+  PreExchangedBootstrap(int rank, int nRanks) : rank_(rank), nRanks_(nRanks) {}
+
+  /**
+   * Push a pre-gathered allGather result. `data.size()` must equal
+   * `nRanks * len` for the corresponding allGather call. Each rank's slot
+   * occupies `len` bytes.
+   */
+  void pushGather(std::vector<uint8_t> data) {
+    std::lock_guard<std::mutex> lock(mu_);
+    queue_.push(std::move(data));
+  }
+
+  folly::SemiFuture<int> allGather(void* buf, int len, int rank, int nranks)
+      override {
+    if (rank != rank_ || nranks != nRanks_) {
+      return folly::makeSemiFuture<int>(
+          std::runtime_error("PreExchangedBootstrap: rank/nranks mismatch"));
+    }
+    std::vector<uint8_t> data;
+    {
+      std::lock_guard<std::mutex> lock(mu_);
+      if (queue_.empty()) {
+        return folly::makeSemiFuture<int>(std::runtime_error(
+            "PreExchangedBootstrap: no pre-gathered data queued for this "
+            "allGather call (rank " +
+            std::to_string(rank_) + ")"));
+      }
+      data = std::move(queue_.front());
+      queue_.pop();
+    }
+    const std::size_t expected = static_cast<std::size_t>(nranks) * len;
+    if (data.size() != expected) {
+      return folly::makeSemiFuture<int>(std::runtime_error(
+          "PreExchangedBootstrap: gathered size mismatch (got " +
+          std::to_string(data.size()) + ", expected " +
+          std::to_string(expected) + ")"));
+    }
+    std::memcpy(buf, data.data(), expected);
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int> barrier(int /*rank*/, int /*nranks*/) override {
+    // No-op; assume Python pre-barriered before passing data to C++.
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int>
+  send(void* /*buf*/, int /*len*/, int /*peer*/, int /*tag*/) override {
+    return folly::makeSemiFuture<int>(
+        std::runtime_error("PreExchangedBootstrap: send not supported"));
+  }
+
+  folly::SemiFuture<int>
+  recv(void* /*buf*/, int /*len*/, int /*peer*/, int /*tag*/) override {
+    return folly::makeSemiFuture<int>(
+        std::runtime_error("PreExchangedBootstrap: recv not supported"));
+  }
+
+ private:
+  const int rank_;
+  const int nRanks_;
+  std::mutex mu_;
+  std::queue<std::vector<uint8_t>> queue_;
+};
+
+} // namespace comms::prims::moe_ep

--- a/comms/prims/collectives/moe_ep/moe_ep/buffer.py
+++ b/comms/prims/collectives/moe_ep/moe_ep/buffer.py
@@ -13,7 +13,6 @@ methods that are not yet wired raise `NotImplementedError`.
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any, Callable
 
 import torch
@@ -80,9 +79,9 @@ class Buffer:
     - **Low-latency** all-to-all (dispatch + combine, RDMA)
     - **High-throughput internode** all-to-all (dispatch + combine, RDMA + NVLink)
 
-    Mirrors the `Buffer` API surface so the canonical
+    Provides the `Buffer` API surface used by the
     `test_intranode.py` / `test_low_latency.py` / `test_internode.py` scripts
-    run unchanged through the `conftest.py` import shim in
+    through the `conftest.py` import shim in
     `comms/prims/collectives/moe_ep/tests/`.
     """
 
@@ -556,17 +555,15 @@ class Buffer:
         use_ue8m0: bool = False,
         async_finish: bool = False,
         return_recv_hook: bool = False,
-        # Diagnostic tensors — accepted for API parity, currently
+        # Diagnostic tensors — accepted for API compatibility, currently
         # ignored (the diagnostic counters are filled by the kernel impl).
         cumulative_local_expert_recv_stats: torch.Tensor | None = None,
         dispatch_wait_recv_cost_stats: torch.Tensor | None = None,
     ) -> tuple[Any, ...]:
         """Low-latency dispatch (IBGDA).
 
-        Routes through the C++ runtime which constructs `LowLatencyRuntime`
-        on first call. The kernel launch raises NotImplementedError; the
-        host-side scaffolding (RDMA buffer allocation, atomic counters,
-        output tensor allocation) is wired.
+        Routes through the C++ runtime, which constructs `LowLatencyRuntime`
+        on first call.
         """
         return self.runtime.low_latency_dispatch(
             x,
@@ -589,7 +586,7 @@ class Buffer:
         use_logfmt: bool = False,
         async_finish: bool = False,
         return_recv_hook: bool = False,
-        # Diagnostic / zero-copy controls — currently parity-only.
+        # Diagnostic / zero-copy controls — accepted for API compatibility.
         zero_copy: bool = False,
         out: torch.Tensor | None = None,
         combine_wait_recv_cost_stats: torch.Tensor | None = None,
@@ -619,10 +616,42 @@ class Buffer:
     def get_next_low_latency_combine_buffer(
         self, handle: tuple[Any, ...]
     ) -> torch.Tensor:
-        """Return a buffer matching packed_recv_x shape for zero_copy combine.
-
-        Our kernel currently ignores the zero_copy flag, so this is a scratch
-        tensor that the test writes to but the kernel doesn't read from.
-        """
+        """Return a buffer matching packed_recv_x shape for zero_copy combine."""
         packed_recv_x_ref = handle[2]
         return torch.empty_like(packed_recv_x_ref)
+
+    def setup_low_latency_ibgda(
+        self,
+        num_max_dispatch_tokens_per_rank: int,
+        hidden: int,
+        num_experts: int,
+    ) -> None:
+        """Construct LowLatencyRuntime + wire MultipeerIbgdaTransport for
+        cross-node LL dispatch/combine.
+
+        Required for multi-node configs. Must be called BEFORE the first
+        low_latency_dispatch — the IBGDA QPs need to be wired before the
+        kernel issues any cross-node sends. On single-node setups this is a
+        no-op (the kernel takes the NVLink-IPC fast path for all peers).
+
+        Constructs a Python `dist.all_gather_object`-backed bootstrap and
+        passes it (plus the dispatch shape) to the C++ runtime, which
+        allocates the LL workspace, registers the LL RDMA buffer, and
+        exchanges QP info + buffer descriptors across all ranks.
+        """
+        if self.group_size < 2:
+            return
+
+        def _all_gather_bytes(local_bytes: bytes) -> bytes:
+            # Gather the bytes from all ranks via PyTorch dist, return
+            # concatenated `[rank0_bytes, rank1_bytes, ..., rankN_bytes]`.
+            gathered: list[bytes] = [b""] * self.group_size
+            dist.all_gather_object(gathered, local_bytes, group=self.group)
+            return b"".join(gathered)
+
+        self.runtime.setup_low_latency_ibgda(
+            num_max_dispatch_tokens_per_rank,
+            hidden,
+            num_experts,
+            _all_gather_bytes,
+        )

--- a/comms/prims/collectives/moe_ep/tests/test_low_latency.py
+++ b/comms/prims/collectives/moe_ep/tests/test_low_latency.py
@@ -1,6 +1,7 @@
 # pyre-ignore-all-errors
 
 import argparse
+import os
 import random
 import sys
 from functools import partial
@@ -460,6 +461,23 @@ def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         allow_mnnvl=args.allow_mnnvl,
         enable_shrink=args.shrink_test,
     )
+
+    # Multi-node: wire IBGDA QPs across hosts so the kernel's hybrid branch
+    # can route cross-node peers via RDMA. Must run BEFORE any dispatch so
+    # the kernel doesn't issue cross-node sends with an uninitialized
+    # transport. Single-node runs (WORLD_SIZE=1) take the NVLink-IPC fast
+    # path for all peers and skip IBGDA setup entirely.
+    num_nodes = int(os.getenv("WORLD_SIZE", "1"))
+    if num_nodes > 1:
+        buffer.setup_low_latency_ibgda(num_tokens, hidden, num_experts)
+        dist.barrier(group=group)
+        if rank == 0:
+            print(
+                f"[setup] IBGDA wired up across {num_nodes} nodes "
+                f"({num_ranks} ranks total)",
+                flush=True,
+            )
+
     test_main(
         num_tokens,
         hidden,
@@ -555,6 +573,18 @@ if __name__ == "__main__":
         help="Whether to simulate failure and test shrink mode",
     )
     args = parser.parse_args()
+
+    # Early-load diagnostic: confirm the Python binary actually started
+    # and report which node/rank we are. Helps when mpirun reports a
+    # rank crashed but the per-rank stdout is empty.
+    print(
+        f"[startup] node_rank={os.getenv('RANK', '0')} "
+        f"world_size={os.getenv('WORLD_SIZE', '1')} "
+        f"master={os.getenv('MASTER_ADDR', '127.0.0.1')}:"
+        f"{os.getenv('MASTER_PORT', '8361')} "
+        f"num_processes={args.num_processes}",
+        flush=True,
+    )
 
     num_processes = args.num_processes
     torch.multiprocessing.spawn(

--- a/comms/prims/transport/amd/nic/BnxtNicBackend.h
+++ b/comms/prims/transport/amd/nic/BnxtNicBackend.h
@@ -46,6 +46,74 @@ struct BnxtNicBackend {
     return hostKey; // bnxt uses native byte order
   }
 
+  // Spinlock around bnxt_re's per-QP shared state (msn, sq_tail, sq_flags
+  // epoch bit). Concurrent warps that update those fields without holding
+  // the lock corrupt the MSN-table tail and produce doorbell values with
+  // the wrong epoch, which surfaces on the device as `Memory access fault
+  // by GPU on address (nil)`.
+  __device__ void lockQp(pipes_gda_gpu_dev_verbs_qp* qp) {
+    int expected;
+    do {
+      expected = 0;
+    } while (0 ==
+             __hip_atomic_compare_exchange_strong(
+                 &qp->nic.bnxt.sq_lock,
+                 &expected,
+                 1,
+                 __ATOMIC_ACQUIRE,
+                 __ATOMIC_ACQUIRE,
+                 __HIP_MEMORY_SCOPE_SYSTEM));
+  }
+
+  __device__ void unlockQp(pipes_gda_gpu_dev_verbs_qp* qp) {
+    __hip_atomic_store(
+        &qp->nic.bnxt.sq_lock, 0, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+  }
+
+  // Back-pressure: spin until the SQ has at least `requestedSlots` free
+  // entries. Without it, warps can submit WQEs faster than the NIC completes
+  // them; the producer index then wraps past the consumer, new WQEs overwrite
+  // slots still owned by the NIC, and the resulting NIC-side fault surfaces
+  // as `Memory access fault by GPU on address (nil)`.
+  // Caller must hold the QP spinlock.
+  __device__ void waitForSqSlots(
+      pipes_gda_gpu_dev_verbs_qp* qp,
+      uint32_t requestedSlots) {
+    uint32_t sqDepth = qp->nic.bnxt.sq_depth;
+    if (sqDepth == 0) {
+      return;
+    }
+    volatile char* cqeBase =
+        reinterpret_cast<volatile char*>(qp->cq_sq.cqe_daddr);
+    volatile pipes_gda_bnxt_req_cqe* cqe =
+        reinterpret_cast<volatile pipes_gda_bnxt_req_cqe*>(cqeBase);
+    // Bounded spin: an SQ that never drains means the NIC has stopped
+    // completing WQEs (link down or QP in error), so an unbounded spin would
+    // hang the kernel forever. Trap once exhausted so the stall surfaces.
+    constexpr uint64_t kMaxSpins = 10000000ULL;
+    for (uint64_t spins = 0; spins < kMaxSpins; ++spins) {
+      uint32_t conIdx = cqe->con_indx & 0xFFFF;
+      uint32_t sqHead = (conIdx * PIPES_GDA_BNXT_GDA_WQE_SLOT_COUNT) % sqDepth;
+      uint32_t sqTail = qp->nic.bnxt.sq_tail;
+      uint32_t consumed = (sqTail - sqHead + sqDepth) % sqDepth;
+      uint32_t available = sqDepth - consumed;
+      if (available >= requestedSlots) {
+        return;
+      }
+    }
+    printf(
+        "BNXT waitForSqSlots TIMEOUT: requested=%u sq_depth=%u sq_tail=%u "
+        "con_indx=%u sq_id=%u\n",
+        requestedSlots,
+        sqDepth,
+        qp->nic.bnxt.sq_tail,
+        cqe->con_indx & 0xFFFF,
+        qp->nic.bnxt.sq_id);
+    // __builtin_trap() is the portable device trap (s_trap on AMDGPU); the
+    // CUDA-only __trap() intrinsic is not declared in this HIP header context.
+    __builtin_trap();
+  }
+
   __device__ void* getBnxtWqeSlot(
       pipes_gda_gpu_dev_verbs_qp* qp,
       uint32_t slotIdx) const {
@@ -206,6 +274,8 @@ struct BnxtNicBackend {
       uint64_t localAddr,
       uint32_t localKey,
       std::size_t size) {
+    // Back-pressure to keep producer behind NIC consumer (caller holds lock).
+    waitForSqSlots(qp, PIPES_GDA_BNXT_GDA_WQE_SLOT_COUNT);
     uint32_t slotIdx = bnxtWqeIdxToSlot(qp, wqeIdx);
 
     pipes_gda_bnxt_bsqe* hdr =
@@ -281,6 +351,8 @@ struct BnxtNicBackend {
       uint64_t localAddr,
       uint32_t localKey,
       uint64_t addVal) {
+    // Back-pressure to keep producer behind NIC consumer (caller holds lock).
+    waitForSqSlots(qp, PIPES_GDA_BNXT_GDA_WQE_SLOT_COUNT);
     uint32_t slotIdx = bnxtWqeIdxToSlot(qp, wqeIdx);
 
     pipes_gda_bnxt_bsqe* hdr =

--- a/comms/prims/transport/amd/pipes_gda/PipesGdaHost.cc
+++ b/comms/prims/transport/amd/pipes_gda/PipesGdaHost.cc
@@ -129,9 +129,15 @@ static bool ensureHsaInitialized() {
   return g_hsaInitSuccess;
 }
 
-#ifdef NIC_MLX5
-// mlx5-only: the BNXT path doesn't need HSA UAR mapping (it uses
-// alloc_db_region's host-mapped DBR + hipHostRegister instead).
+// hsa_amd_memory_lock_to_pool gives a GPU-accessible alias for a host
+// pointer. Required for both:
+//   - mlx5: BlueFlame UAR doorbell page (was already using this).
+//   - bnxt: alloc_db_region's MMIO doorbell page. The hipHostRegister
+//     path that BNXT previously used produces a GPU-side mapping that
+//     is READ-ONLY on this ROCm release; the kernel's atomic store to
+//     `qp->nic.bnxt.dbr` then faults with `(nil)` / `Write access to
+//     a read-only page`. hsa_amd_memory_lock_to_pool produces a
+//     writable GPU alias, matching how mlx5's BlueFlame UAR is mapped.
 static bool
 hsaMemoryLockToGpu(void* hostPtr, size_t size, void** gpuPtr, int gpuId) {
   if (!ensureHsaInitialized()) {
@@ -153,15 +159,14 @@ hsaMemoryLockToGpu(void* hostPtr, size_t size, void** gpuPtr, int gpuId) {
       gpuPtr);
   return st == HSA_STATUS_SUCCESS;
 }
-#endif // NIC_MLX5
 
 #ifdef NIC_BNXT
 // ===========================================================================
 // SysIbv — dlopen wrapper for system libibverbs.so.1 (PABI 34)
 // ===========================================================================
 //
-// fbcode third-party/rdma-core stablev60 (PABI 59) statically links a BNXT
-// provider that only supports kernel uverbs ABI 1. The kernel bnxt_re module
+// A statically-linked rdma-core (PABI 59) bundles a BNXT provider that only
+// supports kernel uverbs ABI 1. The kernel bnxt_re module
 // on AMD/BNXT hosts reports uverbs ABI 8, so the static provider rejects every
 // device. The system /lib64/libibverbs.so.1 (PABI 34) +
 // /lib64/libbnxt_re-rdmav34.so DO support ABI 8 — we dlopen them at runtime
@@ -191,8 +196,8 @@ static SysIbv* getSysIbv() {
   static bool s_loaded = false;
   std::call_once(s_once, []() {
     // Force the SYSTEM libibverbs (PABI 34, supports kernel uverbs ABI 8).
-    // fbcode's /usr/local/fbcode/platform010/lib/libibverbs.so.1 (PABI 59)
-    // would otherwise win the search.
+    // A statically-linked libibverbs earlier in the loader search order
+    // (PABI 59) would otherwise win the search.
     void* lib = dlopen("/lib64/libibverbs.so.1", RTLD_LAZY | RTLD_GLOBAL);
     if (!lib) {
       lib = dlopen("libibverbs.so.1", RTLD_LAZY | RTLD_GLOBAL);
@@ -350,8 +355,11 @@ struct AmdBnxtQpInternal {
   void* rq_buf{nullptr};
   size_t rq_buf_size{0};
 
-  // Host-mapped DBR page we hipHostRegister'd so the GPU can store to it.
-  void* registered_dbr_page{nullptr};
+  // MMIO doorbell page registered via `hipHostRegister(Default)` so the GPU
+  // can issue 64-bit atomic stores. Released via `hipHostUnregister` in
+  // `freeQpResources`. Pointer is `dbRegion->dbr`, which is stored
+  // independently in the `bnxt_re_dv_db_region_attr*` referenced by the QP.
+  bool dbr_host_registered{false};
 };
 #else
 struct AmdQpInternal {
@@ -459,10 +467,10 @@ pipes_gda_error_t pipes_gda_gpu_mem_alloc(
 // ===========================================================================
 // ibverbs wrappers
 //
-// BNXT: route through SysIbv (system /lib64/libibverbs.so.1) — fbcode's
-// static libibverbs (PABI 59) cannot register the system BNXT provider
-// (PABI 34).
-// mlx5: direct calls into fbcode's static libibverbs.
+// BNXT: route through SysIbv (system /lib64/libibverbs.so.1) — the
+// statically-linked libibverbs (PABI 59) cannot register the system BNXT
+// provider (PABI 34).
+// mlx5: direct calls into the statically-linked libibverbs.
 // ===========================================================================
 
 pipes_gda_error_t pipes_gda_verbs_wrapper_ibv_get_device_list(
@@ -961,8 +969,8 @@ pipes_gda_error_t pipes_gda_verbs_qp_modify(
 
   // RC QP responder/initiator depths are required by the kernel for the
   // INIT->RTR and RTR->RTS transitions, but NVIDIA DOCA's public API does
-  // not expose setters for `max_dest_rd_atomic` / `max_rd_atomic`. The
-  // deleted `MultipeerIbgdaTransportAmd::connectQp` set both to 16.
+  // not expose setters for `max_dest_rd_atomic` / `max_rd_atomic`. We set
+  // both to 16.
   if ((mask & IBV_QP_STATE) != 0) {
     if (ibvAttr.qp_state == IBV_QPS_RTR) {
       ibvAttr.max_dest_rd_atomic = 16;
@@ -1048,13 +1056,12 @@ pipes_gda_error_t pipes_gda_gpu_verbs_create_qp_hl(
   size_t rqBufSize = 0;
   void* cqBuf = nullptr;
   size_t cqBufSize = 0;
-  bool dbrReg = false;
-  void* dbrPage = nullptr;
+  bool dbrRegistered = false; // hipHostUnregister on unwind if true
   size_t pageSize = sysconf(_SC_PAGESIZE);
 
   auto unwind = [&]() {
-    if (dbrReg && dbrPage) {
-      hipHostUnregister(dbrPage);
+    if (dbRegion && dbrRegistered) {
+      hipHostUnregister(dbRegion->dbr);
     }
     if (qp && dv->destroy_qp) {
       dv->destroy_qp(qp);
@@ -1105,7 +1112,7 @@ pipes_gda_error_t pipes_gda_gpu_verbs_create_qp_hl(
   // CQ buffer in GPU device memory (uncached): GPU poll loop reads local
   // HBM (~100ns) instead of PCIe-mapped host memory (~1us).
   hipError_t herr =
-      hipExtMallocWithFlags(&cqBuf, cqBufSize, hipDeviceMallocUncached);
+      hipExtMallocWithFlags(&cqBuf, cqBufSize, hipDeviceMallocFinegrained);
   if (herr != hipSuccess || !cqBuf) {
     fprintf(
         stderr,
@@ -1207,9 +1214,14 @@ pipes_gda_error_t pipes_gda_gpu_verbs_create_qp_hl(
   }
   rqBufSize = memInfo.rq_len;
 
-  // SQ in GPU device memory (uncached). Same rationale as CQ: GPU writes
-  // (WQE prep) hit local HBM at ~100ns/store rather than ~1us/PCIe write.
-  herr = hipExtMallocWithFlags(&sqBuf, sqBufSize, hipDeviceMallocUncached);
+  // SQ in GPU device memory. Use `hipDeviceMallocFinegrained` to match
+  // rocSHMEM's QP buffer allocator (`HIPAllocatorFinegrained`).
+  // We previously used `hipDeviceMallocUncached`, but on AMD MI300X
+  // multiple-warp WQE writes to that memory type fault with `Memory
+  // access fault by GPU on (nil)` / `Write access to a read-only page`.
+  // Fine-grained coherent memory accepts the concurrent writes correctly
+  // and is what rocSHMEM (the validated baseline) uses for SQ/CQ/RQ.
+  herr = hipExtMallocWithFlags(&sqBuf, sqBufSize, hipDeviceMallocFinegrained);
   if (herr != hipSuccess || !sqBuf) {
     fprintf(
         stderr,
@@ -1222,7 +1234,7 @@ pipes_gda_error_t pipes_gda_gpu_verbs_create_qp_hl(
   hipMemset(sqBuf, 0, sqBufSize);
 
   if (rqBufSize > 0) {
-    herr = hipExtMallocWithFlags(&rqBuf, rqBufSize, hipDeviceMallocUncached);
+    herr = hipExtMallocWithFlags(&rqBuf, rqBufSize, hipDeviceMallocFinegrained);
     if (herr != hipSuccess || !rqBuf) {
       fprintf(
           stderr,
@@ -1349,32 +1361,43 @@ pipes_gda_error_t pipes_gda_gpu_verbs_create_qp_hl(
   void* gpuSqBuf = sqBuf;
   void* gpuCqBuf = cqBuf;
 
-  // The DBR pointer returned by alloc_db_region is host-mapped; register
-  // its containing page so the GPU can issue 64-bit atomic stores to it.
-  dbrPage = reinterpret_cast<void*>(
-      reinterpret_cast<uintptr_t>(dbRegion->dbr) & ~(pageSize - 1));
-  hipError_t herr2 = hipHostRegister(dbrPage, pageSize, hipHostRegisterDefault);
-  if (herr2 != hipSuccess) {
+  // Map MMIO doorbell to GPU via `hipHostRegister(dbr, pagesize, Default)`
+  // + `hipHostGetDevicePointer`, mirroring rocSHMEM's BNXT GDA backend.
+  // This is the validated
+  // production path on BNXT MI300X: GPU writes directly to MMIO from the
+  // device-side `ringDoorbell` — no CPU relay involved.
+  long pageSizeForDbr = sysconf(_SC_PAGESIZE);
+  if (pageSizeForDbr <= 0) {
+    pageSizeForDbr = 4096;
+  }
+  hipError_t dbrRegErr = hipHostRegister(
+      dbRegion->dbr,
+      static_cast<size_t>(pageSizeForDbr),
+      hipHostRegisterDefault);
+  if (dbrRegErr != hipSuccess) {
     fprintf(
         stderr,
-        "[BNXT] hipHostRegister(dbrPage=%p sz=%zu) failed: %s\n",
-        dbrPage,
-        pageSize,
-        hipGetErrorString(herr2));
+        "[BNXT] hipHostRegister(dbr=%p, pagesize=%ld, Default) failed: %s\n",
+        dbRegion->dbr,
+        pageSizeForDbr,
+        hipGetErrorString(dbrRegErr));
     unwind();
     return PIPES_GDA_ERROR_DRIVER;
   }
-  dbrReg = true;
-  void* gpuDbrPage = nullptr;
-  if (hipHostGetDevicePointer(&gpuDbrPage, dbrPage, 0) != hipSuccess) {
-    fprintf(stderr, "[BNXT] hipHostGetDevicePointer(dbrPage) failed\n");
+  dbrRegistered = true;
+  void* gpuDbrPtr = nullptr;
+  hipError_t dbrGetErr = hipHostGetDevicePointer(&gpuDbrPtr, dbRegion->dbr, 0);
+  if (dbrGetErr != hipSuccess || gpuDbrPtr == nullptr) {
+    fprintf(
+        stderr,
+        "[BNXT] hipHostGetDevicePointer(dbr=%p) failed: %s (gpuDbrPtr=%p)\n",
+        dbRegion->dbr,
+        hipGetErrorString(dbrGetErr),
+        gpuDbrPtr);
     unwind();
     return PIPES_GDA_ERROR_DRIVER;
   }
-  size_t dbrOffset = reinterpret_cast<uintptr_t>(dbRegion->dbr) -
-      reinterpret_cast<uintptr_t>(dbrPage);
-  uint64_t* gpuDbr = reinterpret_cast<uint64_t*>(
-      reinterpret_cast<uintptr_t>(gpuDbrPage) + dbrOffset);
+  uint64_t* gpuDbr = reinterpret_cast<uint64_t*>(gpuDbrPtr);
 
   // ---- Step 10: Compute MSN table location (tail of SQ buffer) ----
   size_t msnOffset =
@@ -1429,10 +1452,10 @@ pipes_gda_error_t pipes_gda_gpu_verbs_create_qp_hl(
   ibv_port_attr portAttr{};
   uint32_t activeMtuBytes = 4096;
   // BNXT: route through `pipes_gda_verbs_wrapper_ibv_query_port` (which
-  // dispatches to `SysIbv->query_port`) rather than calling the fbcode
-  // static `ibv_query_port` directly — `ctx` was created via the SysIbv
-  // (system `libibverbs.so.1`, PABI 34) path, so calling fbcode's static
-  // libibverbs (PABI 59) on it risks an ABI mismatch.
+  // dispatches to `SysIbv->query_port`) rather than calling the
+  // statically-linked `ibv_query_port` directly — `ctx` was created via the
+  // SysIbv (system `libibverbs.so.1`, PABI 34) path, so calling the
+  // statically-linked libibverbs (PABI 59) on it risks an ABI mismatch.
   if (ctx &&
       pipes_gda_verbs_wrapper_ibv_query_port(ctx, /*port_num=*/1, &portAttr) ==
           PIPES_GDA_SUCCESS) {
@@ -1492,7 +1515,7 @@ pipes_gda_error_t pipes_gda_gpu_verbs_create_qp_hl(
   internal->cq_buf_size = cqBufSize;
   internal->rq_buf = rqBuf;
   internal->rq_buf_size = rqBufSize;
-  internal->registered_dbr_page = dbrPage;
+  internal->dbr_host_registered = dbrRegistered;
 
   auto* out = new (std::nothrow) pipes_gda_gpu_verbs_qp_hl();
   if (!out) {
@@ -1519,7 +1542,7 @@ pipes_gda_error_t pipes_gda_gpu_verbs_create_qp_hl(
   sqBuf = nullptr;
   cqBuf = nullptr;
   rqBuf = nullptr;
-  dbrReg = false;
+  dbrRegistered = false; // ownership transferred to `internal`
   return PIPES_GDA_SUCCESS;
 }
 
@@ -1812,10 +1835,10 @@ static void freeQpResources(pipes_gda_gpu_verbs_qp_hl* qp) {
     if (qp->qp && dv && dv->destroy_qp) {
       dv->destroy_qp(qp->qp);
     }
-    // Unregister the DBR host page BEFORE free_db_region: kernel-side
-    // bnxt_re holds the page mapping until destroy_qp completes.
-    if (internal->registered_dbr_page) {
-      hipHostUnregister(internal->registered_dbr_page);
+    // Unregister the GPU mapping of the MMIO doorbell page BEFORE freeing
+    // the bnxt_re DB region (the DB region owns the underlying mmap).
+    if (internal->dbr_host_registered && internal->db_region) {
+      hipHostUnregister(internal->db_region->dbr);
     }
     if (internal->db_region && dv && dv->free_db_region && ctx) {
       dv->free_db_region(ctx, internal->db_region);

--- a/comms/prims/transport/amd/pipes_gda/PipesGdaOps.h
+++ b/comms/prims/transport/amd/pipes_gda/PipesGdaOps.h
@@ -260,6 +260,19 @@ __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_put(
   if (numChunks == 0)
     numChunks = 1;
 
+#ifdef NIC_BNXT
+  // BNXT: hold the per-QP spinlock across the ENTIRE put — slot reservation,
+  // every WQE prepare (each advances the shared MSN table / sq_tail / epoch
+  // and MUST run in slot order), the doorbell, and the synchronous CQE drain.
+  // Reserving slots OUTSIDE the lock let concurrent thread-blocks grab slots
+  // and then prepare them OUT OF ORDER under a per-chunk lock, corrupting the
+  // MSN table -> NIC fault (GPU exception 0x1016) at moderate scale / hang at
+  // large scale. The single-block path only worked because it had no
+  // concurrency. Holding the lock across reserve+prepare makes preparation
+  // strictly in-order. Matches rocSHMEM's `lock(&bnxt_sq.lock)` pattern.
+  nic.lockQp(qp);
+#endif
+
   uint64_t baseIdx =
       pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, qp, numChunks);
   std::size_t remaining = size;
@@ -285,19 +298,22 @@ __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_put(
     remaining -= chunkSize;
 
 #ifdef NIC_BNXT
-    // BNXT: per-WQE doorbell + per-chunk CQE drain. The mlx5 batched
-    // doorbell pattern desyncs the NIC, and overlapping chunks trigger
-    // LOC_QP_OP. The caller drains the last chunk's CQE.
+    // BNXT CQ is ncqe=1: the NIC cannot complete the next WQE until this WQE's
+    // CQE is consumed (advance cqe_ci + ring the CQ doorbell). Drain EVERY
+    // chunk — including the last — synchronously (still under the lock) so the
+    // single CQE slot is always free and each put is fully self-contained.
     pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, qp, wqeIdx, wqeIdx);
     pipes_gda_gpu_dev_verbs_submit(nic, qp, wqeIdx + 1);
-    if (i + 1 < numChunks) {
-      spin_poll_or_trap(nic, &qp->cq_sq, wqeIdx);
-      qp->cq_sq.cqe_ci = wqeIdx + 1;
-    }
+    spin_poll_or_trap(nic, &qp->cq_sq, wqeIdx);
+    qp->cq_sq.cqe_ci = wqeIdx + 1;
+    nic.bnxtUpdateCqDbrec(qp);
 #endif
   }
 
   uint64_t lastIdx = baseIdx + numChunks - 1;
+#ifdef NIC_BNXT
+  nic.unlockQp(qp);
+#endif
 #ifdef NIC_MLX5
   // Mlx5: batched doorbell — single ring after all chunks prepared.
   // Uses fast submit with ctrl segment captured on GPU stack (avoids
@@ -323,6 +339,10 @@ __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_signal(
     uint64_t sig_val,
     uint64_t* out_ticket) {
   uint64_t wqeIdx = pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, qp, 1);
+
+#ifdef NIC_BNXT
+  nic.lockQp(qp);
+#endif
   auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, qp, wqeIdx);
 
   pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
@@ -341,6 +361,9 @@ __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_signal(
 
   pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, qp, wqeIdx, wqeIdx);
   pipes_gda_gpu_dev_verbs_submit(nic, qp, wqeIdx + 1);
+#ifdef NIC_BNXT
+  nic.unlockQp(qp);
+#endif
 
   *out_ticket = wqeIdx;
 }
@@ -378,6 +401,9 @@ __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_put_signal(
         ? PIPES_GDA_VERBS_MAX_TRANSFER_SIZE
         : remaining;
 
+#ifdef NIC_BNXT
+    nic.lockQp(qp);
+#endif
     auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, qp, wqeIdx);
     pipes_gda_gpu_dev_verbs_wqe_prepare_write(
         nic,
@@ -398,10 +424,14 @@ __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_put_signal(
     pipes_gda_gpu_dev_verbs_submit(nic, qp, wqeIdx + 1);
     spin_poll_or_trap(nic, &qp->cq_sq, wqeIdx);
     qp->cq_sq.cqe_ci = wqeIdx + 1;
+    nic.unlockQp(qp);
 #endif
   }
 
   uint64_t sigIdx = baseIdx + numChunks;
+#ifdef NIC_BNXT
+  nic.lockQp(qp);
+#endif
   auto* sigWqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, qp, sigIdx);
   pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
       nic,
@@ -421,6 +451,7 @@ __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_put_signal(
   // BNXT: per-WQE doorbell for the signal WQE too.
   pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, qp, sigIdx, sigIdx);
   pipes_gda_gpu_dev_verbs_submit(nic, qp, sigIdx + 1);
+  nic.unlockQp(qp);
 #else
   pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, qp, baseIdx, sigIdx);
   pipes_gda_gpu_dev_verbs_submit(nic, qp, sigIdx + 1);
@@ -444,11 +475,17 @@ __device__ __forceinline__ void pipes_gda_fence(
     NicBackend& nic,
     pipes_gda_gpu_dev_verbs_qp* qp) {
   uint64_t wqeIdx = pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, qp, 1);
+#ifdef NIC_BNXT
+  nic.lockQp(qp);
+#endif
   auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, qp, wqeIdx);
 
   pipes_gda_gpu_dev_verbs_wqe_prepare_nop(nic, qp, wqe, wqeIdx);
   pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, qp, wqeIdx, wqeIdx);
   pipes_gda_gpu_dev_verbs_submit(nic, qp, wqeIdx + 1);
+#ifdef NIC_BNXT
+  nic.unlockQp(qp);
+#endif
   pipes_gda_gpu_dev_verbs_wait(nic, qp, wqeIdx);
 }
 
@@ -493,6 +530,9 @@ __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_p(
     T value,
     uint64_t* out_ticket) {
   uint64_t wqeIdx = pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, qp, 1);
+#ifdef NIC_BNXT
+  nic.lockQp(qp);
+#endif
   auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, qp, wqeIdx);
 
   nic.prepareInlineWriteWqe(
@@ -506,6 +546,9 @@ __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_p(
 
   pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, qp, wqeIdx, wqeIdx);
   pipes_gda_gpu_dev_verbs_submit(nic, qp, wqeIdx + 1);
+#ifdef NIC_BNXT
+  nic.unlockQp(qp);
+#endif
 
   *out_ticket = wqeIdx;
 }
@@ -579,6 +622,9 @@ __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_put_signal_counter(
         ? PIPES_GDA_VERBS_MAX_TRANSFER_SIZE
         : remaining;
 
+#ifdef NIC_BNXT
+    nic.lockQp(mainQp);
+#endif
     auto* wqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, mainQp, wqeIdx);
     pipes_gda_gpu_dev_verbs_wqe_prepare_write(
         nic,
@@ -599,12 +645,16 @@ __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_put_signal_counter(
     pipes_gda_gpu_dev_verbs_submit(nic, mainQp, wqeIdx + 1);
     spin_poll_or_trap(nic, &mainQp->cq_sq, wqeIdx);
     mainQp->cq_sq.cqe_ci = wqeIdx + 1;
+    nic.unlockQp(mainQp);
 #endif
   }
 
   uint64_t lastIdx;
   if (hasSignal) {
     uint64_t sigIdx = mainBase + numChunks;
+#ifdef NIC_BNXT
+    nic.lockQp(mainQp);
+#endif
     auto* sigWqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, mainQp, sigIdx);
     pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
         nic,
@@ -625,6 +675,7 @@ __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_put_signal_counter(
 #ifdef NIC_BNXT
     pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, mainQp, sigIdx, sigIdx);
     pipes_gda_gpu_dev_verbs_submit(nic, mainQp, sigIdx + 1);
+    nic.unlockQp(mainQp);
 #endif
   } else {
     lastIdx = mainBase + numChunks - 1;
@@ -742,6 +793,9 @@ __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_signal_counter(
 
   // Main QP: signal atomic
   uint64_t sigIdx = pipes_gda_gpu_dev_verbs_reserve_wq_slots(nic, mainQp, 1);
+#ifdef NIC_BNXT
+  nic.lockQp(mainQp);
+#endif
   auto* sigWqe = pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, mainQp, sigIdx);
   pipes_gda_gpu_dev_verbs_wqe_prepare_atomic(
       nic,
@@ -759,6 +813,9 @@ __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_signal_counter(
 
   pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, mainQp, sigIdx, sigIdx);
   pipes_gda_gpu_dev_verbs_submit(nic, mainQp, sigIdx + 1);
+#ifdef NIC_BNXT
+  nic.unlockQp(mainQp);
+#endif
 
 #if defined(__HIP_PLATFORM_AMD__)
   // AMD: signal-with-real-target path. Spin-poll on mainQp's CQ con_indx,


### PR DESCRIPTION
Summary:

Extends the low-latency dispatch/combine kernels to run across nodes, so `test_low_latency` works beyond a single node. The path is per-peer hybrid: same-node peers use NVLink IPC; cross-node peers use IBGDA RDMA via `MultipeerIbgdaTransport`, with token data sent by RDMA put and the count/flag as an 8-byte inline write, keyed per destination expert so a given expert's data and its flag stay ordered on one QP. The host runtime builds the transport, exchanges QP info and per-peer buffer descriptors, and `sync()` falls back to the RDMA branch when cross-node IPC opens are unavailable. Also hardens the AMD BNXT `pipes_gda` put for concurrent multi-block use: the QP lock is held across the whole put so concurrent blocks can't reorder WQEs and corrupt the MSN table. Builds and runs on AMD (BNXT) and NVIDIA; validated cross-node on AMD/BNXT. The IBGDA infrastructure and BNXT put fixes are reusable by the non-LL internode kernel.

Reviewed By: srinathb-meta

Differential Revision: D105385298
