### PR TITLE
Fix moe_ep test_low_latency type-check by moving pyre-ignore-all-errors into preamble

### DIFF
--- a/comms/prims/collectives/moe_ep/tests/test_low_latency.py
+++ b/comms/prims/collectives/moe_ep/tests/test_low_latency.py
@@ -1,10 +1,10 @@
+# pyre-ignore-all-errors
+
 import argparse
 import random
 import sys
 from functools import partial
 from typing import Literal, Set
-
-# pyre-ignore-all-errors
 
 # Alias in-tree modules before any `import deep_ep` / `import deep_ep_cpp`.
 import comms.prims.collectives.moe_ep._cpp as _moe_ep_cpp  # noqa: E402


### PR DESCRIPTION
Differential Revision: D111507637


