### PR TITLE
ncclx transport tweaks to let PAT transport connect respect NCCL_NETDEVS_POLICY

### DIFF
--- a/comms/ncclx/meta/baseline_modification_docs/pat_transport_netdevs_policy.md
+++ b/comms/ncclx/meta/baseline_modification_docs/pat_transport_netdevs_policy.md
@@ -1,0 +1,121 @@
+# PAT transport connect honors `NCCL_NETDEVS_POLICY`: Baseline Modifications
+
+## Background
+
+`ncclTransportPatConnect` (the eager binomial-tree connect path in
+`src/transport/generic.cc`, and its lazy Meta counterpart `ncclx::transportPatConnect`
+in `meta/transport/transportConnect.cc`) originally called
+`ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_TREE], 0)` for both the
+ReduceScatter and AllGather directions of each binomial-tree mask. Passing a
+non-NULL `graph` argument routes NIC selection through the "graph-based" branch
+of `ncclTopoGetNetDev` (`src/graph/search.cc:1325-1338`):
+
+```cpp
+if (graph) {
+  int channel = channelId % graph->nChannels;
+  int ngpus   = comm->topo->nodes[GPU].count;
+  int index   = graph->intra[channel*ngpus] == rank ? 0 : 1;
+  if (graph->pattern != NCCL_TOPO_PATTERN_NVLS) {
+    netId = graph->inter[channel*2 + index];
+  }
+  ...
+}
+```
+
+That branch reads a shared per-channel entry NIC from
+`graph->inter[channel*2 + index]`. For collectives like RING / TREE this is
+correct — each channel is a chain of GPUs that must agree on the entry NIC.
+**PAT is different:** each `(mask, direction)` opens a set of independent
+rank-to-rank connections (`prevPeer` / `nextPeer`), with no cross-rank
+consistency requirement. Every rank should be free to use its own local NIC.
+
+The consequence of routing PAT through the graph branch was two-fold:
+
+1. On a multi-rail node (e.g., GB300 4 GPUs × 4 bonded vNICs), the TREE graph
+   rotates the entry NIC across channels for aggregate-bandwidth optimization,
+   so all ranks on channel `c` land on the same NIC — which is local to only
+   one of them. `NCCL_NETDEVS_POLICY=MAX:1` had no effect: it caps the graph's
+   *candidate pool* but does not force per-rank local pinning inside the graph
+   branch.
+2. On an MNNVL clique that spans multiple hosts (multiple `systemId`s in one
+   fused topology), `graph->inter[]` can hold a netId whose `systemId` is not
+   the local rank's `systemId`. The runtime `ncclTopoIdToNetDev` strips the
+   `systemId` and returns the local rail index, so the plugin correctly opens
+   the local NIC — but the paired `ncclTopoCheckGdr` call in
+   `src/transport/net.cc:308` uses the full composite `netId` and looks up
+   `PATH_DIS` (0/0.0) in the topology, returning `useGdr=0`. Result: every
+   channel whose graph slot pointed at a cross-`systemId` NIC silently
+   degraded to a pinned-host-bounce path even though the actual local NIC is
+   GDR-capable.
+
+Passing `NULL` for the graph argument makes `ncclTopoGetNetDev` fall through
+to `ncclTopoGetLocalNet` (the `graph == NULL` branch at
+`src/graph/search.cc:1339+`). That branch honors `netsPerGpu` (which
+`NCCL_NETDEVS_POLICY=MAX:1` collapses to 1 on this hardware) and pins each
+rank to its own local NIC — which is what PAT's rank-to-rank connections
+actually want.
+
+## Versions Affected
+
+v2.29, v2.30
+
+## Baseline Files Modified
+
+Exactly ONE baseline file per version: `src/transport/generic.cc`. Two lines
+inside `ncclTransportPatConnect` (the eager, non-lazy path) — one flush after
+the RS-direction `ncclTransportP2pConnect` loop, one after the AG-direction
+loop:
+
+```cpp
+ncclResult_t ncclTransportPatConnect(struct ncclComm* comm) {
+  ...
+  for (int mask=1; mask<comm->nRanks; mask<<=1) {
+    ...
+    for (int c = 0; c < comm->nChannels; c++) {
+      NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &prevPeer, 1, &nextPeer, 0), ret, fail); // ReduceScatter
+    }
+    NCCLCHECKGOTO(ncclTransportP2pSetup(comm, nullptr, 0), ret, fail);  // [META]: pass nullptr, see meta/baseline_modification_docs/pat_transport_netdevs_policy.md
+    for (int c = 0; c < comm->nChannels; c++) {
+      NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &nextPeer, 1, &prevPeer, 0), ret, fail); // AllGather
+    }
+    NCCLCHECKGOTO(ncclTransportP2pSetup(comm, nullptr, 0), ret, fail);  // [META]: pass nullptr, see meta/baseline_modification_docs/pat_transport_netdevs_policy.md
+  }
+  ...
+}
+```
+
+The parallel change in the Meta lazy path (`meta/transport/transportConnect.cc`,
+function `ncclx::transportPatConnect`, two `ncclTransportP2pSetup` calls) is
+Meta-owned code and does not carry a `[META]` tag — the whole file is a Meta
+overlay. Both callers now consistently pass `nullptr`.
+
+All OTHER PAT call sites are UNCHANGED:
+- `ncclTransportP2pConnect` inside PAT still passes `connIndex=0` (the
+  collective slot). The graph argument was only ever consumed by the *setup*
+  step, not the *connect* bookkeeping step.
+- `net.cc`'s `sendSetup`/`recvSetup` and the plugin-side QP creation are
+  unchanged; they consume `req.netDev` (a local index) which is what the
+  `graph == NULL` branch now produces.
+
+## Why in baseline
+
+There is no clean overlay point. The `ncclTransportPatConnect` symbol is
+declared in the baseline (`src/include/transport.h`) and is what
+`ncclCollPreconnect` (`src/group.cc:190-193`, baseline) dispatches to on the
+`NCCL_ALGO_PAT` case. Replacing the whole function via a Meta wrapper would
+mean duplicating the entire binomial-tree loop and keeping it in sync with
+upstream on every rebase. A two-line edit at the exact `P2pSetup` call sites
+is the smallest possible footprint and follows the pattern in
+[`builtin_tuner.md`](./builtin_tuner.md) of narrow, tagged baseline hooks.
+
+The lazy Meta path already runs entirely inside `meta/transport/`, so it
+gets the same fix without any baseline touch.
+
+## Related upstream discussion
+
+We're proposing this upstream (see the draft email in the diff summary /
+task) because the root cause — PAT reusing the TREE graph even though its
+rank-to-rank connections don't need graph-consistent NICs — affects all
+users of PAT on multi-rail / MNNVL topologies with `NCCL_PXN_DISABLE=1`,
+not just Meta. If upstream accepts the change, the baseline hook can be
+removed on the next rebase.

--- a/comms/ncclx/meta/transport/transportConnect.cc
+++ b/comms/ncclx/meta/transport/transportConnect.cc
@@ -170,7 +170,7 @@ ncclResult_t transportPatConnect(struct ncclComm* comm, int nChannels) {
           rsSummary.toString().c_str(),
           c);
     }
-    NCCLCHECK(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_TREE], 0));
+    NCCLCHECK(ncclTransportP2pSetup(comm, nullptr, 0));
     for (int c = comm->algoConnectedChannels[NCCL_ALGO_PAT]; c < nChannels;
          c++) {
       connectionSummary agSummary;
@@ -190,7 +190,7 @@ ncclResult_t transportPatConnect(struct ncclComm* comm, int nChannels) {
           agSummary.toString().c_str(),
           c);
     }
-    NCCLCHECK(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_TREE], 0));
+    NCCLCHECK(ncclTransportP2pSetup(comm, nullptr, 0));
   }
   INFO(
       NCCL_INIT,

--- a/comms/ncclx/v2_29/src/transport/generic.cc
+++ b/comms/ncclx/v2_29/src/transport/generic.cc
@@ -86,11 +86,15 @@ ncclResult_t ncclTransportPatConnect(struct ncclComm* comm) {
       for (int c = 0; c < comm->nChannels; c++) {
         NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &prevPeer, 1, &nextPeer, 0), ret, fail); // ReduceScatter
       }
-      NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_TREE], 0), ret, fail);
+      // [META] pass nullptr so ncclTopoGetNetDev takes the graph==NULL branch and honors NCCL_NETDEVS_POLICY;
+      // see meta/baseline_modification_docs/pat_transport_netdevs_policy.md
+      NCCLCHECKGOTO(ncclTransportP2pSetup(comm, nullptr, 0), ret, fail);
       for (int c = 0; c < comm->nChannels; c++) {
         NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &nextPeer, 1, &prevPeer, 0), ret, fail); // AllGather
       }
-      NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_TREE], 0), ret, fail);
+      // [META] pass nullptr so ncclTopoGetNetDev takes the graph==NULL branch and honors NCCL_NETDEVS_POLICY;
+      // see meta/baseline_modification_docs/pat_transport_netdevs_policy.md
+      NCCLCHECKGOTO(ncclTransportP2pSetup(comm, nullptr, 0), ret, fail);
     }
     INFO(NCCL_INIT, "Connected binomial trees");
   }

--- a/comms/ncclx/v2_30/src/transport/generic.cc
+++ b/comms/ncclx/v2_30/src/transport/generic.cc
@@ -86,11 +86,15 @@ ncclResult_t ncclTransportPatConnect(struct ncclComm* comm) {
       for (int c = 0; c < comm->nChannels; c++) {
         NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &prevPeer, 1, &nextPeer, 0), ret, fail); // ReduceScatter
       }
-      NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_TREE], 0), ret, fail);
+      // [META] pass nullptr so ncclTopoGetNetDev takes the graph==NULL branch and honors NCCL_NETDEVS_POLICY;
+      // see meta/baseline_modification_docs/pat_transport_netdevs_policy.md
+      NCCLCHECKGOTO(ncclTransportP2pSetup(comm, nullptr, 0), ret, fail);
       for (int c = 0; c < comm->nChannels; c++) {
         NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &nextPeer, 1, &prevPeer, 0), ret, fail); // AllGather
       }
-      NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_TREE], 0), ret, fail);
+      // [META] pass nullptr so ncclTopoGetNetDev takes the graph==NULL branch and honors NCCL_NETDEVS_POLICY;
+      // see meta/baseline_modification_docs/pat_transport_netdevs_policy.md
+      NCCLCHECKGOTO(ncclTransportP2pSetup(comm, nullptr, 0), ret, fail);
     }
     INFO(NCCL_INIT, "Connected binomial trees");
   }


### PR DESCRIPTION
Summary:
On GB300 multi-rail / MNNVL topologies with `NCCL_PXN_DISABLE=1`, PAT collective connections silently degrade to pinned-host bounce even when the local NIC would support GDR. Root cause: `ncclTransportPatConnect` (and its lazy Meta counterpart `ncclx::transportPatConnect`) passed `&comm->graphs[NCCL_ALGO_TREE]` to `ncclTransportP2pSetup`, routing NIC selection through the "graph-based" branch of `ncclTopoGetNetDev` at `src/graph/search.cc:1325-1338`. That branch reads a shared per-channel entry NIC from `graph->inter[channel*2 + index]` — appropriate for RING/TREE where all ranks on a channel must agree, but wrong for PAT whose `(mask, direction)` connections are independent rank-to-rank pairs with no cross-rank consistency requirement.

Two symptoms observed in production:

1. **Multi-rail GB300 node** (4 GPUs / 4 bonded vNICs): the TREE graph rotates the entry NIC across channels for aggregate bandwidth. All ranks on channel `c` share that entry NIC — local to only one of them. `NCCL_NETDEVS_POLICY=MAX:1` had no effect because it only caps the graph's candidate pool, not the per-rank NIC choice inside the graph branch.

2. **MNNVL clique spanning multiple `systemId`s**: `graph->inter[]` can hold a netId whose `systemId` is not the local rank's `systemId`. `ncclTopoIdToNetDev` strips the systemId and returns the local rail index (so the plugin correctly opens a local NIC), but the paired `ncclTopoCheckGdr` call at `net.cc:308` uses the full composite netId, looks up `PATH_DIS` (0/0.0), and returns `useGdr=0` — silently disabling GDR on a NIC that would otherwise have supported it. Grep evidence from a rank-92 log on the production `nccl_pat_check_v17_...` run: 128 identical `paths.cc:529` verdicts `GPU Direct RDMA Disabled for GPU/0-8413184 (rank 2) - NET/1-9 (distance 11 > 5)`, all cross-`systemId`, and 138 paired Enabled verdicts for the local `NET/0-9`. Perfectly matches the "odd channel → non-GDR, even channel → GDRDMA(PCI)" alternation in the connect log.

**Fix:** pass `nullptr` for the graph argument so `ncclTopoGetNetDev` takes its `graph == NULL` branch (`search.cc:1339+`) and calls `ncclTopoGetLocalNet`, which honors `netsPerGpu` (set to 1 by `NCCL_NETDEVS_POLICY=MAX:1`) and pins each rank to its own local NIC. This is the same code path P2P sendrecv already uses (`ncclTransportP2pSetup(comm, NULL, 1)` at `group.cc:156` and `init.cc:1540`), so the graph-null path is well-tested.

**Scope:**
- `v2_29/src/transport/generic.cc` — baseline eager PAT path, 2 `ncclTransportP2pSetup` call sites, `[META]` comments pointing at the doc.
- `v2_30/src/transport/generic.cc` — same fix ported (v2_30 didn't yet have the earlier v2_29 fix).
- `meta/transport/transportConnect.cc` — Meta lazy PAT path, 2 sites (no `[META]` tag; the whole file is Meta-owned).
- `meta/baseline_modification_docs/pat_transport_netdevs_policy.md` — new doc explaining the Why, following the `builtin_tuner.md` style.

Prior version of this diff used `NULL` at the four call sites; this revision converts to `nullptr` for type safety. Both are null-pointer constants for `ncclTopoGraph*`, so runtime behavior is identical — the swap is a keyword-hygiene refinement.

We plan to propose the upstream fix as well (draft email prepared) because the root cause affects any PAT-on-multi-rail / MNNVL user with PXN disabled, not just Meta. If upstream accepts, the baseline hook can be dropped on the next rebase.

Differential Revision: D111179348


