### PR TITLE
Ctran preq pipeSync release before GPE teardown (#3117)

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -4,10 +4,13 @@
 
 #include <cuda_runtime.h>
 
+#include <folly/container/F14Set.h>
+
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/CtranPipes.h"
 #include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/algos/PersistentCleanup.h"
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/regcache/RegCache.h"
@@ -138,6 +141,24 @@ void CtranComm::recordAlgoStats(
   }
 }
 
+void CtranComm::registerPersistentCleanup(
+    std::shared_ptr<PersistentCleanup> cleanup) {
+  persistentCleanups_.wlock()->insert(std::move(cleanup));
+}
+
+void CtranComm::unregisterPersistentCleanup(
+    const std::shared_ptr<PersistentCleanup>& cleanup) {
+  persistentCleanups_.wlock()->erase(cleanup);
+}
+
+void CtranComm::drainPersistentCleanups() {
+  folly::F14FastSet<std::shared_ptr<PersistentCleanup>> local;
+  persistentCleanups_.withWLock([&local](auto& set) { local.swap(set); });
+  for (const auto& cleanup : local) {
+    cleanup->run();
+  }
+}
+
 commResult_t ctranInit(
     CtranComm* comm,
     std::unique_ptr<ctran::IProfilerReporter> reporter,
@@ -209,6 +230,11 @@ void CtranComm::destroy() {
   // multiPeerTransport_ holds a non-owning reference to it).
   multiPeerTransport_.reset();
 #endif // defined(ENABLE_PRIMS)
+  // Release every outstanding persistent request's pooled pipeSync + scoped
+  // registration before ctran_.reset() (which triggers CtranGpe::terminate()'s
+  // pool-drain spin-wait). Runs each cleanup token at most once; tokens already
+  // run by an eager free / graph-destroy callback no-op here.
+  drainPersistentCleanups();
   ctran_.reset();
   bootstrap_.reset();
   colltraceNew_.reset();

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -12,6 +12,8 @@
 #include <vector>
 
 #include <folly/Synchronized.h>
+#include <folly/container/F14Set.h>
+#include "comms/ctran/algos/PersistentCleanup.h"
 #include "comms/ctran/bootstrap/ICtranBootstrap.h"
 #include "comms/ctran/commstate/CommStateX.h"
 #include "comms/ctran/interfaces/ICtran.h"
@@ -250,6 +252,18 @@ class CtranComm {
   };
   CudagraphDeferredCleanup cudagraphDeferredCleanup;
 
+  // Registry of persistent-request cleanup tokens (see PersistentCleanup.h).
+  // Each token releases one persistent request's pooled GpeKernelSync
+  // (pipeSync) + scoped registration. destroy() drains this set (running each
+  // token once) BEFORE ctran_.reset() -> CtranGpe::terminate(), guaranteeing
+  // every pooled pipeSync is returned before terminate()'s pool-drain
+  // spin-wait -- no matter which teardown path (eager free, graph-destroy
+  // callback, comm cleanup) fires first.
+  void registerPersistentCleanup(std::shared_ptr<PersistentCleanup> cleanup);
+  void unregisterPersistentCleanup(
+      const std::shared_ptr<PersistentCleanup>& cleanup);
+  void drainPersistentCleanups();
+
  private:
   friend class CtranGpe;
   friend commResult_t ctranInit(
@@ -273,4 +287,7 @@ class CtranComm {
   std::shared_ptr<AsyncError> asyncErr_;
   std::shared_ptr<Abort> abort_;
   uint64_t ctranOpCount_{0};
+
+  folly::Synchronized<folly::F14FastSet<std::shared_ptr<PersistentCleanup>>>
+      persistentCleanups_;
 };

--- a/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
@@ -270,7 +270,8 @@ commResult_t ctranAllGatherCudagraphAware(
 
       CtranPersistentRequest* request = nullptr;
       FB_COMMCHECK(createPersistentRequest(comm, stream, &request));
-      auto cleanupGuard = folly::makeGuard([request]() {
+      auto cleanupGuard = folly::makeGuard([request, comm]() {
+        comm->unregisterPersistentCleanup(request->cleanup_);
         FB_COMMCHECKIGNORE(destroyPersistentRequest(request));
         delete request;
       });
@@ -288,9 +289,25 @@ commResult_t ctranAllGatherCudagraphAware(
       // collective ops: if op capture fails, the graph tears down the request
       // via this callback instead of releasing its NVL imports / registration
       // while the captured graph still references them.
+      //
+      // Release the pooled pipeSync + scoped registration through the shared
+      // cleanup token (runs at most once). If the comm was destroyed first
+      // (comm-then-graph ordering), the comm drain already ran the token and
+      // this no-ops -- the token's shared_ptr lives in the request, which the
+      // comm drain does NOT delete, so it is safe to touch here. Never
+      // unregister from the comm registry in this callback: it may run after
+      // the comm is gone. The spent token therefore lingers in the comm's
+      // persistentCleanups_ registry until CtranComm::destroy() drains it;
+      // this is bounded by the number of distinct graph captures sharing (and
+      // destroyed during the lifetime of) this comm -- typically O(1) in
+      // steady-state training (capture once, replay many) -- so it is an
+      // acceptable bounded retention, not an unbounded leak. The graph owns the
+      // request object (never returned to the user), so this callback deletes
+      // it after releasing resources.
       auto destroyCb = [](void* p) {
         auto* req = static_cast<CtranPersistentRequest*>(p);
-        FB_COMMCHECKIGNORE(destroyPersistentRequest(req));
+        DCHECK(req->cleanup_ != nullptr);
+        req->cleanup_->run();
         delete req;
       };
       FB_COMMCHECK(registerGraphDestroyCallback(stream, request, destroyCb));

--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -117,6 +117,21 @@ commResult_t createPersistentRequest(
       CtranPersistentRequest::Type::ALLGATHER_P, comm, stream);
   request->algo = algo.release();
   *out = request.release();
+
+  // Route teardown through the §9 one-shot cleanup token: it releases the
+  // pooled pipeSync + scoped registration (via destroyPersistentRequest),
+  // running at most once regardless of which path (eager free, graph-destroy
+  // callback, comm drain before terminate()) fires first. It does NOT delete
+  // the request object -- that stays with the object's owner. The closure
+  // captures the RAW request pointer (NOT a shared_ptr) so the token does not
+  // co-own the request -- no ownership cycle. The token is co-owned by the
+  // request (cleanup_), the comm registry, and (for graph) the graph
+  // user-object.
+  auto cleanup = std::make_shared<PersistentCleanup>([request = *out]() {
+    FB_COMMCHECKIGNORE(destroyPersistentRequest(request));
+  });
+  (*out)->cleanup_ = cleanup;
+  comm->registerPersistentCleanup(cleanup);
   return commSuccess;
 }
 
@@ -249,7 +264,8 @@ commResult_t allGatherPInit(
   }
 
   FB_COMMCHECK(createPersistentRequest(comm, stream, &request));
-  auto requestGuard = folly::makeGuard([&request] {
+  auto requestGuard = folly::makeGuard([&request, comm] {
+    comm->unregisterPersistentCleanup(request->cleanup_);
     FB_COMMCHECKIGNORE(destroyPersistentRequest(request));
     delete request;
     request = nullptr;
@@ -306,11 +322,21 @@ commResult_t allGatherPExec(
 commResult_t allGatherPDestroy(CtranPersistentRequest* request) {
   CHECK_VALID_PREQ(request);
 
-  // No need to dereg handles now since user should call explicit
-  // commDeregister before buffer is freed
-  FB_COMMCHECK(destroyPersistentRequest(request));
+  // Route the resource release through the shared cleanup token so it runs at
+  // most once across {eager free, graph-destroy callback, comm drain before
+  // terminate()}. If the comm was already destroyed (comm-then-free ordering),
+  // the token was already run by the comm drain and this no-ops -- no hang, no
+  // double release. The request object itself is still owned/deleted by the
+  // caller (unchanged contract); the token releases only the pooled pipeSync +
+  // scoped registration. Keep the token alive across run(), then drop the
+  // comm's registry entry (comm is alive on this eager path).
+  auto token = request->cleanup_;
+  auto* comm = request->comm_;
+  DCHECK(token != nullptr);
+  token->run();
+  comm->unregisterPersistentCleanup(token);
 
-  // destroyPersistentRequest released this request's remote NVL IPC imports
+  // The cleanup token released this request's remote NVL IPC imports
   // deferred (SW-only, so the shared teardown is also safe from the
   // graph-destroy callback). This is a user thread, so drain the parked
   // cuMemUnmaps now rather than leaving them for the next IpcRegCache entry /

--- a/comms/ctran/algos/CtranAlgo.h
+++ b/comms/ctran/algos/CtranAlgo.h
@@ -259,6 +259,14 @@ class CtranPersistentRequest {
   cudaStream_t stream;
   void* segHdl{nullptr};
 
+  // One-shot cleanup token co-owned by this request, the comm registry, and
+  // (for graph requests) the CUDA graph user-object. The eager free path
+  // reaches the token through here; running it releases the pooled pipeSync +
+  // scoped registration (via destroyPersistentRequest), at most once across all
+  // teardown paths. The token does NOT delete this request object -- that stays
+  // with the object's owner -- so ~CtranPersistentRequest stays defaulted.
+  std::shared_ptr<PersistentCleanup> cleanup_;
+
   CtranPersistentRequest(
       Type type,
       CtranComm* comm,

--- a/comms/ctran/algos/PersistentCleanup.h
+++ b/comms/ctran/algos/PersistentCleanup.h
@@ -1,0 +1,31 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <functional>
+#include <mutex>
+#include <utility>
+
+// A one-shot cleanup token for a persistent request. The cleanup closure
+// releases the request's pooled GpeKernelSync (pipeSync) + scoped registration
+// (via destroyPersistentRequest); it does NOT free/delete the request object
+// itself. The request is deleted by its external owner (ncclx::pFree, tests,
+// bench, or the graph-destroy callback). The token must run EXACTLY ONCE, no
+// matter which teardown path fires first (eager preq free, CUDA graph-destroy
+// callback, or comm cleanup before CtranGpe::terminate()).
+//
+// The token is heap-managed via shared_ptr and OUTLIVES both the request object
+// and the comm: a late graph-destroy callback (after the comm already drained
+// and freed the request) must still be able to call run() safely -- it just
+// no-ops. std::call_once gives cross-thread "exactly once" since the
+// graph-destroy callback may run on a different thread than the comm/preq free.
+struct PersistentCleanup {
+  std::once_flag flag_;
+  std::function<void()> fn_;
+
+  explicit PersistentCleanup(std::function<void()> fn) : fn_(std::move(fn)) {}
+
+  void run() {
+    std::call_once(flag_, [this] { fn_(); });
+  }
+};

--- a/comms/ctran/tests/CtranDistAllgatherPTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherPTests.cc
@@ -798,6 +798,103 @@ TEST_F(CtranAllgatherPTest, DestroyOneShareRecvBuf) {
   cumemBufCleanUp(localSendBuf, localRecvBuf);
 }
 
+// Validates the ctran-level persistent-request teardown-safety mechanism: a
+// request's pooled pipeSync must be released before CtranGpe::terminate()'s
+// pool-drain spin-wait, regardless of whether the CtranComm or the persistent
+// request is destroyed first. Without the comm-drain-before-terminate fix, the
+// "comm before preq" sub-case would hang forever in terminate().
+TEST_F(CtranAllgatherPTest, CommDestroyBeforePreqDestroy) {
+  SysEnvRAII algoEnv("NCCL_ALLGATHER_P_ALGO", "ctpipeline");
+  if (ncclIsCuMemSupported() == false) {
+    GTEST_SKIP() << "CuMem not supported, skipping this test";
+  } else if (ctranComm->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+
+  const auto recvCount = 2097152UL * numRanks;
+  const auto sendCount = recvCount / numRanks;
+  const auto sendRegBytes = sendCount * commTypeSize(dt);
+  const auto recvRegBytes = recvCount * commTypeSize(dt);
+  const auto initMaxRecvCount =
+      recvCount * commTypeSize(dt) / commTypeSize(commInt8);
+  const auto initDt = commInt8;
+
+  // Creates a comm + persistent request over a freshly allocated recvbuf, runs
+  // exactly one exec, and returns the pieces so the caller controls teardown
+  // ordering. Buffers are freed by the caller after the request is destroyed.
+  auto makeReqAndExec = [&](std::unique_ptr<CtranComm>& comm,
+                            CtranPersistentRequest*& request,
+                            char*& sendBuf,
+                            char*& recvBuf,
+                            void*& sendHdl,
+                            void*& recvHdl) {
+    comm = makeCtranComm();
+    cumemBufSetup(sendCount, recvCount, &sendBuf, &recvBuf);
+
+    // allGatherPInit resolves the recvbuf's registration via searchRegHandle,
+    // so the recvbuf must be pre-registered on this comm; mirror the sibling
+    // AGP tests by also registering the sendbuf used by exec.
+    COMMCHECK_TEST(comm->ctran_->commRegister(recvBuf, recvRegBytes, &recvHdl));
+    COMMCHECK_TEST(comm->ctran_->commRegister(sendBuf, sendRegBytes, &sendHdl));
+
+    meta::comms::Hints hints;
+    COMMCHECK_TEST(
+        ctran::allGatherPInit(
+            recvBuf,
+            initMaxRecvCount,
+            hints,
+            initDt,
+            comm.get(),
+            stream,
+            request));
+    ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+    std::vector<char> sendVals(sendRegBytes, static_cast<char>(globalRank));
+    ASSERT_EQ(
+        cudaMemcpyAsync(
+            sendBuf, sendVals.data(), sendRegBytes, cudaMemcpyDefault, stream),
+        cudaSuccess);
+    ASSERT_EQ(
+        ctran::allGatherPExec(sendBuf, sendCount, dt, request), commSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  };
+
+  // Sub-case 1: normal ordering -- destroy the preq (comm alive), then the
+  // comm. The comm drain then finds the token already spent (no-op).
+  {
+    std::unique_ptr<CtranComm> comm;
+    CtranPersistentRequest* request = nullptr;
+    char *sendBuf = nullptr, *recvBuf = nullptr;
+    void *sendHdl = nullptr, *recvHdl = nullptr;
+    makeReqAndExec(comm, request, sendBuf, recvBuf, sendHdl, recvHdl);
+
+    ASSERT_EQ(ctran::allGatherPDestroy(request), commSuccess);
+    delete request;
+    COMMCHECK_TEST(comm->ctran_->commDeregister(sendHdl));
+    COMMCHECK_TEST(comm->ctran_->commDeregister(recvHdl));
+    comm.reset();
+    cumemBufCleanUp(sendBuf, recvBuf);
+  }
+
+  // Sub-case 2: the hang case -- destroy the COMM before the preq. The comm
+  // drain must release the pooled pipeSync before terminate() so this returns
+  // instead of spinning forever. The user then only frees the request object
+  // (the comm is gone; allGatherPDestroy is not valid post-comm-destroy).
+  {
+    std::unique_ptr<CtranComm> comm;
+    CtranPersistentRequest* request = nullptr;
+    char *sendBuf = nullptr, *recvBuf = nullptr;
+    void *sendHdl = nullptr, *recvHdl = nullptr;
+    makeReqAndExec(comm, request, sendBuf, recvBuf, sendHdl, recvHdl);
+
+    // The comm is destroyed first; its drain releases the registrations, so no
+    // explicit commDeregister is valid post-comm-destroy.
+    comm.reset();
+    delete request;
+    cumemBufCleanUp(sendBuf, recvBuf);
+  }
+}
+
 inline std::string getTestName(
     const testing::TestParamInfo<CtranAllgatherPTestParam::ParamType>& info) {
   return std::to_string(std::get<0>(info.param)) + "maxSendCount_" +


### PR DESCRIPTION
Summary:

Persistent collectives (AllGatherP today, AllToAllP next) hold a pooled GpeKernelSync (pipeSync) for their lifetime. If a request outlives its comm, CtranGpe::terminate() spins forever in its pool-drain wait because the pipeSync is never returned. This adds a ctran-level, run-exactly-once cleanup so a request's pooled pipeSync + scoped registration are always released before terminate(), no matter which teardown path fires first (eager preq free, CUDA graph-destroy callback, or comm cleanup). This covers all surfaces uniformly (ncclx PG, torchcomms, direct ctran) and all eager+graph collectives, replacing per-surface teardown hacks:
- Add PersistentCleanup: a std::call_once one-shot token, heap-managed via shared_ptr so it outlives both the request object and the comm (a late graph-destroy callback after comm teardown safely no-ops).
- CtranComm owns a folly::Synchronized<F14FastSet<shared_ptr<PersistentCleanup>>> registry with registerPersistentCleanup / unregisterPersistentCleanup / drainPersistentCleanups (declared in CtranComm.h, defined in Ctran.cc). CtranComm::destroy() drains the registry (running each token once) BEFORE ctran_.reset() -> CtranGpe::terminate(), guaranteeing every pooled pipeSync is returned before the pool-drain spin-wait.
- The token releases resources only (via destroyPersistentRequest); it does NOT delete the request object -- deletion stays with the existing owner (ncclx::pFree, tests, bench, or the graph-destroy callback), keeping the change purely additive with no double-free risk.
- Wire AllGatherP through it: createPersistentRequest builds+registers the token; allGatherPDestroy runs the token then unregisters (eager path, comm alive -- a pre-existing contract since allGatherPDestroy already dereferences request->comm_; cleanup_ is always set, so a DCHECK guards the unconditional run); the graph-destroy callback runs the token then deletes its request object (also DCHECK-guarded). A spent graph token lingers in the registry until comm drain, bounded by the number of distinct graph captures per comm (O(1) in steady-state training) -- acceptable bounded retention.
- The ncclx PG "release preq before mempool release" fix stays: it releases outstanding persistent requests before the comm's own abort / mempool segment deregistration (commDeregister errors on an in-use scoped RegHdl), which this ctran-level drain does not cover -- the two are complementary, not redundant.

## Why not let preq hold shared ptr of GPE/CtranComm:
The teardown problem here is fundamentally about resource return ordering (the pooled pipeSync must be returned before CtranGpe::terminate()'s pool-drain spin-wait), not about lifetime extension (keeping the pool alive until the pipeSync is returned). A shared_ptr-based approach (e.g., preq holds shared_ptr<CtranGpe> to keep the pool alive) was considered but rejected because CtranGpe's ownership graph has structural constraints that make lifetime extension unsafe:
- CtranGpe::Impl holds a raw back-pointer to CtranComm — extending CtranGpe past comm destruction creates a dangling pointer reachable by the still-running GPE thread
- ICtran requires CtranGpe destroyed before CtranAlgo (CUDA resource ordering) — shared_ptr lifetime extension breaks this invariant

Differential Revision: D111641528


