### PR TITLE
HRDWRingBuffer: add WritePolicy::Blocking (lossless backpressure) (#3119)

### DIFF
--- a/comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h
+++ b/comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h
@@ -12,6 +12,7 @@
 #include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
 
 #include <algorithm>
+#include <atomic>
 #if __cplusplus >= 202002L
 #include <bit>
 #endif
@@ -40,6 +41,42 @@ namespace hrdw_ring_buffer {
 //            cudaStreamSynchronize (no concurrent reader). Requires
 //            sm_90+ for atom.exch.b128.
 enum class MemoryCoherenceScope { System, Device };
+
+// Write policy — a structural property of the ring, like MemoryCoherenceScope.
+//
+//   Overwrite — the writer never blocks; a lapping write silently overwrites
+//               the oldest unconsumed slot (the reader detects loss via its
+//               writeIndex bound). The default; correct only when the consumer
+//               is guaranteed to keep up.
+//   Blocking  — lossless. The writer spins until the reader has consumed the
+//               slot it is about to reuse (backpressure against a published
+//               consumer cursor), so a write can never overwrite an unconsumed
+//               entry. A Blocking ring allocates the consumer cursor AND its
+//               reader publishes it — the two halves that make "the reader will
+//               see every write" a structural guarantee, inseparable by
+//               construction. Requires System scope (host-published cursor).
+enum class WritePolicy { Overwrite, Blocking };
+
+namespace detail {
+
+// An empty stand-in for an absent member. Templated on T to produce distinct
+// types so that multiple [[no_unique_address]] absent members each cost 0 bytes
+// (two subobjects of the same type would need distinct addresses).
+// Constructible from anything so the absent member silently ignores any
+// initializer.
+template <typename T>
+struct Nothing {
+  constexpr Nothing() noexcept = default;
+  template <typename... Args>
+  constexpr explicit Nothing(Args&&...) noexcept {}
+};
+
+// define_if<Cond, T> is T when Cond, otherwise an empty Nothing<T>.
+// Pair with [[no_unique_address]] so the absent member costs zero bytes.
+template <bool Cond, typename T>
+using define_if = std::conditional_t<Cond, T, Nothing<T>>;
+
+} // namespace detail
 
 // ==========================================================================
 // HRDWRingBuffer — Host-Read Device-Write ring buffer for GPU-to-CPU
@@ -183,6 +220,15 @@ struct HrdwRingBufferWriter {
       "HRDWEntry must be exactly 16 bytes (DataT must be <= 8 bytes)");
   static_assert(alignof(EntryT) == 16, "HRDWEntry must be 16-byte aligned");
 
+#if defined(__CUDACC__) && !defined(__HIPCC__)
+  // Atomic scope shared by every device access below: System for cross-host
+  // coherence, Device for intra-GPU. Guarded to mirror the <cuda/atomic>
+  // include above — cuda::thread_scope_* is unavailable under HIP.
+  static constexpr auto kScope = (C == MemoryCoherenceScope::System)
+      ? cuda::thread_scope_system
+      : cuda::thread_scope_device;
+#endif
+
 #if defined(__CUDACC__) || defined(__HIPCC__)
   __device__ __forceinline__ static void write(
       EntryT* ring,
@@ -208,11 +254,90 @@ struct HrdwRingBufferWriter {
     // slot publication is unnecessary (the reader's epoch check is
     // self-correcting if the writeIndex bump and the slot bytes become
     // host-visible in either order).
-    constexpr auto kScope = (C == MemoryCoherenceScope::System)
-        ? cuda::thread_scope_system
-        : cuda::thread_scope_device;
     uint64_t slot = cuda::atomic_ref<uint64_t, kScope>(*writeIndex)
                         .fetch_add(1ULL, cuda::memory_order_relaxed);
+    publishSlot(ring, slot, mask, shift, data);
+#endif
+  }
+
+  // Blocking variant of write(): after claiming a slot, spin until the reader
+  // has consumed the slot's prior occupant (i.e. the writer stays at most
+  // `size` = mask + 1 ahead of the host-published `readIndex`), so a publish
+  // can never lap an unconsumed entry. This makes the ring lossless regardless
+  // of consumer timing — the non-blocking write() silently overwrites under a
+  // slow/stalled consumer. `abortFlag` is the ring's device-visible abort flag
+  // (raised by requestAbort() on teardown): a non-zero value breaks the wait so
+  // a blocked writer can never hang the GPU once the consumer is gone. On abort
+  // we still publish rather than abandon the claimed slot, which would stall
+  // the in-order reader forever. Requires a valid host-published `readIndex`
+  // and `abortFlag` (System scope).
+  __device__ __forceinline__ static void write_blocking(
+      EntryT* ring,
+      uint64_t* writeIndex,
+      uint32_t mask,
+      [[maybe_unused]] uint32_t shift,
+      DataT data,
+      const uint64_t* readIndex,
+      const uint32_t* abortFlag,
+      uint32_t backoffNanos) {
+#if defined(__HIPCC__) || (defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 900)
+    (void)ring;
+    (void)writeIndex;
+    (void)mask;
+    (void)data;
+    (void)readIndex;
+    (void)abortFlag;
+    (void)backoffNanos;
+    printf(
+        "[HRDWRingBuffer] write_blocking unsupported on this GPU (requires sm_90+)\n");
+#if defined(__HIPCC__)
+    abort();
+#else
+    __trap();
+#endif
+#else
+    uint64_t slot = cuda::atomic_ref<uint64_t, kScope>(*writeIndex)
+                        .fetch_add(1ULL, cuda::memory_order_relaxed);
+    // Acquire-load pairs with the reader's release-store of its consumed
+    // cursor. slot - readIndex > mask means slot's prior occupant
+    // (slot - size) has not been consumed yet.
+    auto readRef =
+        cuda::atomic_ref<uint64_t, kScope>(*const_cast<uint64_t*>(readIndex));
+    auto abortRef =
+        cuda::atomic_ref<uint32_t, kScope>(*const_cast<uint32_t*>(abortFlag));
+    while ((slot - readRef.load(cuda::memory_order_acquire)) > mask) {
+      if (abortRef.load(cuda::memory_order_acquire) != 0) {
+        break;
+      }
+      __nanosleep(backoffNanos);
+    }
+    publishSlot(ring, slot, mask, shift, data);
+#endif
+  }
+
+  // Publish `data` at an already-claimed monotonic `slot`. Factored out so
+  // write() and write_blocking() share the single hand-tuned 128b atomic
+  // publication below.
+  __device__ __forceinline__ static void publishSlot(
+      EntryT* ring,
+      uint64_t slot,
+      uint32_t mask,
+      uint32_t shift,
+      DataT data) {
+#if defined(__HIPCC__) || (defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 900)
+    (void)ring;
+    (void)slot;
+    (void)mask;
+    (void)shift;
+    (void)data;
+    printf(
+        "[HRDWRingBuffer] publishSlot unsupported on this GPU (requires sm_90+)\n");
+#if defined(__HIPCC__)
+    abort();
+#else
+    __trap();
+#endif
+#else
     uint64_t idx = slot & mask;
 
     EntryT packed{};
@@ -294,19 +419,62 @@ struct HrdwRingBufferWriter {
 // Lightweight, trivially-copyable handle for writing into an HRDWRingBuffer
 // from device code. Pass by value to GPU kernels. See
 // HRDWRingBufferDeviceHandle.cuh for full documentation and usage examples.
-template <typename DataT, MemoryCoherenceScope C = MemoryCoherenceScope::System>
+template <
+    typename DataT,
+    MemoryCoherenceScope C = MemoryCoherenceScope::System,
+    WritePolicy W = WritePolicy::Overwrite>
 struct HRDWRingBufferDeviceHandle {
-  HRDWEntry<DataT, C>* ring;
-  uint64_t* writeIndex;
-  uint32_t mask;
-  uint32_t shift;
+  HRDWEntry<DataT, C>* ring{};
+  uint64_t* writeIndex{};
+  uint32_t mask{};
+  uint32_t shift{};
+  [[no_unique_address]] detail::
+      define_if<W == WritePolicy::Blocking, const uint64_t*> readIndex{};
+  [[no_unique_address]] detail::
+      define_if<W == WritePolicy::Blocking, const uint32_t*> abort{};
+  [[no_unique_address]] detail::define_if<W == WritePolicy::Blocking, uint32_t>
+      spinBackoffNanos{};
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
   __device__ __forceinline__ void write(DataT data) {
-    HrdwRingBufferWriter<DataT, C>::write(ring, writeIndex, mask, shift, data);
+    if constexpr (W == WritePolicy::Blocking) {
+      HrdwRingBufferWriter<DataT, C>::write_blocking(
+          ring,
+          writeIndex,
+          mask,
+          shift,
+          data,
+          readIndex,
+          abort,
+          spinBackoffNanos);
+    } else {
+      HrdwRingBufferWriter<DataT, C>::write(
+          ring, writeIndex, mask, shift, data);
+    }
   }
 #endif
 };
+
+namespace detail {
+using OverwriteHandleProbe = HRDWRingBufferDeviceHandle<
+    uint64_t,
+    MemoryCoherenceScope::System,
+    WritePolicy::Overwrite>;
+using BlockingHandleProbe = HRDWRingBufferDeviceHandle<
+    uint64_t,
+    MemoryCoherenceScope::System,
+    WritePolicy::Blocking>;
+static_assert(
+    std::is_trivially_copyable_v<OverwriteHandleProbe> &&
+        std::is_trivially_copyable_v<BlockingHandleProbe>,
+    "device handle must stay trivially copyable - it is passed by value to kernels");
+static_assert(
+    sizeof(OverwriteHandleProbe) == 24,
+    "Overwrite device handle regressed: expected 2 pointers + 2 uint32s = 24 bytes");
+static_assert(
+    sizeof(BlockingHandleProbe) == 48,
+    "Blocking device handle regressed: expected Overwrite + readIndex + abort + spin = 48 bytes");
+} // namespace detail
 
 // Templated kernel launch for host-side write(). The template definition
 // is available in .cu compilation units; .cc files link against explicit
@@ -399,28 +567,31 @@ struct HrdwRingBufferStorage<DataT, MemoryCoherenceScope::System> {
     return ring;
   }
 
-  static uint64_t* allocateWriteIndex() {
+  template <typename T>
+  static T* allocateDeviceScalar() {
     void* p = nullptr;
-    auto err = cudaHostAlloc(&p, sizeof(uint64_t), cudaHostAllocDefault);
+    auto err = cudaHostAlloc(&p, sizeof(T), cudaHostAllocDefault);
     if (err != cudaSuccess) {
       fprintf(
           stderr,
-          "HRDWRingBuffer: Failed to allocate write index: %s\n",
+          "HRDWRingBuffer: Failed to allocate %zu-byte device-visible scalar: %s\n",
+          sizeof(T),
           cudaGetErrorString(err));
       return nullptr;
     }
-    auto* idx = static_cast<uint64_t*>(p);
-    *idx = 0;
-    return idx;
+    auto* v = static_cast<T*>(p);
+    *v = 0;
+    return v;
   }
 
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
   static void freeRing(EntryT* ring) {
     (void)cudaFreeHost(ring);
   }
-  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-  static void freeWriteIndex(uint64_t* idx) {
-    (void)cudaFreeHost(idx);
+  template <typename T>
+  static void freeDeviceScalar(T* p) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    (void)cudaFreeHost(p);
   }
 
   static void
@@ -467,38 +638,42 @@ struct HrdwRingBufferStorage<DataT, MemoryCoherenceScope::Device> {
     return ring;
   }
 
-  static uint64_t* allocateWriteIndex() {
+  // Device scope backs each device-visible scalar with device global memory.
+  template <typename T>
+  static T* allocateDeviceScalar() {
     void* p = nullptr;
-    auto err = cudaMalloc(&p, sizeof(uint64_t));
+    auto err = cudaMalloc(&p, sizeof(T));
     if (err != cudaSuccess) {
       fprintf(
           stderr,
-          "HRDWRingBuffer: Failed to allocate write index: %s\n",
+          "HRDWRingBuffer: Failed to allocate %zu-byte device-visible scalar: %s\n",
+          sizeof(T),
           cudaGetErrorString(err));
       return nullptr;
     }
-    auto* idx = static_cast<uint64_t*>(p);
+    auto* v = static_cast<T*>(p);
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    auto memsetErr = cudaMemset(idx, 0, sizeof(uint64_t));
+    auto memsetErr = cudaMemset(v, 0, sizeof(T));
     if (memsetErr != cudaSuccess) {
       fprintf(
           stderr,
-          "HRDWRingBuffer: Failed to zero write index: %s\n",
+          "HRDWRingBuffer: Failed to zero device-visible scalar: %s\n",
           cudaGetErrorString(memsetErr));
       // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      (void)cudaFree(idx);
+      (void)cudaFree(v);
       return nullptr;
     }
-    return idx;
+    return v;
   }
 
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
   static void freeRing(EntryT* ring) {
     (void)cudaFree(ring);
   }
-  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-  static void freeWriteIndex(uint64_t* idx) {
-    (void)cudaFree(idx);
+  template <typename T>
+  static void freeDeviceScalar(T* p) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    (void)cudaFree(p);
   }
 
   // Teardown is a no-op: the ring lives in cudaMalloc'd device memory,
@@ -533,8 +708,15 @@ struct HrdwRingBufferStorage<DataT, MemoryCoherenceScope::Device> {
 //           of claim order. Requires sm_90+ for atom.exch.b128.
 //
 // Move-only — CUDA resources are not copyable.
-template <typename DataT, MemoryCoherenceScope C = MemoryCoherenceScope::System>
+template <
+    typename DataT,
+    MemoryCoherenceScope C = MemoryCoherenceScope::System,
+    WritePolicy W = WritePolicy::Overwrite>
 class HRDWRingBuffer {
+  static_assert(
+      W == WritePolicy::Overwrite || C == MemoryCoherenceScope::System,
+      "WritePolicy::Blocking requires MemoryCoherenceScope::System (the reader "
+      "publishes the consumer cursor into host-visible memory)");
   using Storage = detail::HrdwRingBufferStorage<DataT, C>;
   static constexpr bool isSystem = (C == MemoryCoherenceScope::System);
 
@@ -587,7 +769,22 @@ class HRDWRingBuffer {
     if (!ring_) {
       return;
     }
-    writeIndex_ = Storage::allocateWriteIndex();
+    writeIndex_ = Storage::template allocateDeviceScalar<uint64_t>();
+    if (!writeIndex_) {
+      return; // already-failed ring; skip the Blocking allocs (avoids noise)
+    }
+    if constexpr (W == WritePolicy::Blocking) {
+      readIndex_ = Storage::template allocateDeviceScalar<uint64_t>();
+      abortFlag_ = Storage::template allocateDeviceScalar<uint32_t>();
+    }
+  }
+
+  template <
+      WritePolicy WP = W,
+      std::enable_if_t<WP == WritePolicy::Blocking, int> = 0>
+  HRDWRingBuffer(uint32_t size, uint32_t spinBackoffNanos)
+      : HRDWRingBuffer(size) {
+    spinBackoffNanos_ = spinBackoffNanos;
   }
 
   ~HRDWRingBuffer() {
@@ -596,7 +793,15 @@ class HRDWRingBuffer {
       Storage::freeRing(ring_);
     }
     if (writeIndex_) {
-      Storage::freeWriteIndex(writeIndex_);
+      Storage::freeDeviceScalar(writeIndex_);
+    }
+    if constexpr (W == WritePolicy::Blocking) {
+      if (readIndex_) {
+        Storage::freeDeviceScalar(readIndex_);
+      }
+      if (abortFlag_) {
+        Storage::freeDeviceScalar(abortFlag_);
+      }
     }
   }
 
@@ -609,7 +814,13 @@ class HRDWRingBuffer {
         writeIndex_(std::exchange(other.writeIndex_, nullptr)),
         size_(other.size_),
         mask_(other.mask_),
-        shift_(other.shift_) {}
+        shift_(other.shift_) {
+    if constexpr (W == WritePolicy::Blocking) {
+      readIndex_ = std::exchange(other.readIndex_, nullptr);
+      abortFlag_ = std::exchange(other.abortFlag_, nullptr);
+      spinBackoffNanos_ = other.spinBackoffNanos_;
+    }
+  }
 
   HRDWRingBuffer& operator=(HRDWRingBuffer&& other) noexcept {
     if (this != &other) {
@@ -618,13 +829,26 @@ class HRDWRingBuffer {
         Storage::freeRing(ring_);
       }
       if (writeIndex_) {
-        Storage::freeWriteIndex(writeIndex_);
+        Storage::freeDeviceScalar(writeIndex_);
+      }
+      if constexpr (W == WritePolicy::Blocking) {
+        if (readIndex_) {
+          Storage::freeDeviceScalar(readIndex_);
+        }
+        if (abortFlag_) {
+          Storage::freeDeviceScalar(abortFlag_);
+        }
       }
       ring_ = std::exchange(other.ring_, nullptr);
       writeIndex_ = std::exchange(other.writeIndex_, nullptr);
       size_ = other.size_;
       mask_ = other.mask_;
       shift_ = other.shift_;
+      if constexpr (W == WritePolicy::Blocking) {
+        readIndex_ = std::exchange(other.readIndex_, nullptr);
+        abortFlag_ = std::exchange(other.abortFlag_, nullptr);
+        spinBackoffNanos_ = other.spinBackoffNanos_;
+      }
     }
     return *this;
   }
@@ -635,7 +859,28 @@ class HRDWRingBuffer {
 
   // Returns true if all allocations succeeded.
   bool valid() const {
-    return ring_ != nullptr && writeIndex_ != nullptr;
+    if (ring_ == nullptr || writeIndex_ == nullptr) {
+      return false;
+    }
+    if constexpr (W == WritePolicy::Blocking) {
+      return readIndex_ != nullptr && abortFlag_ != nullptr;
+    }
+    return true;
+  }
+
+  // Release every writer currently blocked in write_blocking() — call on
+  // teardown/abort, when the consumer will no longer drain, so a backpressured
+  // kernel can't hang the GPU forever. One-way: once aborted the ring stays
+  // aborted (writers publish without waiting). Blocking rings only.
+  void requestAbort() {
+    static_assert(
+        W == WritePolicy::Blocking,
+        "requestAbort() is only meaningful for a WritePolicy::Blocking ring");
+#if defined(__cpp_lib_atomic_ref)
+    std::atomic_ref<uint32_t>(*abortFlag_).store(1, std::memory_order_release);
+#else
+    __atomic_store_n(abortFlag_, uint32_t{1}, __ATOMIC_RELEASE);
+#endif
   }
 
   // Launch a single-thread kernel that atomically claims a slot and
@@ -649,15 +894,27 @@ class HRDWRingBuffer {
   // Return a lightweight, trivially-copyable handle that can be passed by
   // value to GPU kernels for inline device-side writes. See
   // HRDWRingBufferDeviceHandle.cuh for usage.
-  HRDWRingBufferDeviceHandle<DataT, C> deviceHandle() const {
+  HRDWRingBufferDeviceHandle<DataT, C, W> deviceHandle() const {
     assert(valid());
-    return {ring_, writeIndex_, mask_, shift_};
+    if constexpr (W == WritePolicy::Blocking) {
+      return {
+          ring_,
+          writeIndex_,
+          mask_,
+          shift_,
+          readIndex_,
+          abortFlag_,
+          spinBackoffNanos_};
+    } else {
+      // Blocking-only handle fields are absent (zero-size) here; omit them.
+      return {ring_, writeIndex_, mask_, shift_};
+    }
   }
 
  private:
-  template <typename, MemoryCoherenceScope>
+  template <typename, MemoryCoherenceScope, WritePolicy>
   friend class HRDWRingBufferReader;
-  template <typename, MemoryCoherenceScope>
+  template <typename, MemoryCoherenceScope, WritePolicy>
   friend class HRDWRingBufferReaderBase;
   template <typename, MemoryCoherenceScope>
   friend class HRDWRingBufferTestAccessor;
@@ -671,6 +928,21 @@ class HRDWRingBuffer {
   // log2(size_). Cached so the per-slot epoch is computed as
   // `(slot >> shift_) + 1` — a shift instead of a divide.
   uint32_t shift_{0};
+  // Blocking-only members, grouped last so the [[no_unique_address]] fields
+  // that vanish on Overwrite rings don't split the always-present layout.
+  //
+  // Consumer cursor for WritePolicy::Blocking backpressure (host-published by
+  // the reader, acquire-loaded by write_blocking).
+  [[no_unique_address]] detail::define_if<W == WritePolicy::Blocking, uint64_t*>
+      readIndex_{nullptr};
+  // Device-visible abort flag; requestAbort() raises it to release blocked
+  // writers on teardown. A 0/1 latch, so a uint32 (vs the uint64 cursors).
+  [[no_unique_address]] detail::define_if<W == WritePolicy::Blocking, uint32_t*>
+      abortFlag_{nullptr};
+  // Per-iteration __nanosleep() backoff for the write_blocking() spin.
+  // Configurable via the ctor; default 64 ns.
+  [[no_unique_address]] detail::define_if<W == WritePolicy::Blocking, uint32_t>
+      spinBackoffNanos_{64};
 };
 
 } // namespace hrdw_ring_buffer

--- a/comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h
+++ b/comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h
@@ -46,6 +46,11 @@ struct PollResult<MemoryCoherenceScope::System> {
   // True if poll() exited because the timeout elapsed before any new
   // entries arrived.
   bool timedOut{false};
+  // Blocking rings only: true if the ring was saturated at poll() entry, i.e.
+  // the device writer is (or just was) backpressured in write_blocking()
+  // waiting for the consumer to free a slot. Always false for Overwrite rings.
+  // The ring stays logging-free — consumers decide whether/how to surface it.
+  bool writerThrottled{false};
 };
 
 template <>
@@ -73,13 +78,16 @@ struct PollResult<MemoryCoherenceScope::Device> {
 //
 // Non-owning — the HRDWRingBuffer must outlive this reader. Single-
 // threaded (only one thread should call into the reader).
-template <typename DataT, MemoryCoherenceScope C = MemoryCoherenceScope::System>
+template <
+    typename DataT,
+    MemoryCoherenceScope C = MemoryCoherenceScope::System,
+    WritePolicy W = WritePolicy::Overwrite>
 class HRDWRingBufferReader;
 
 // State + ctor shared by the System and Device readers. The handle
 // fields (ring_, writeIndex_, size_, mask_, shift_) and the read
 // cursor are identical across scopes; only poll() differs.
-template <typename DataT, MemoryCoherenceScope C>
+template <typename DataT, MemoryCoherenceScope C, WritePolicy W>
 class HRDWRingBufferReaderBase {
  public:
   uint64_t lastReadIndex() const {
@@ -89,17 +97,31 @@ class HRDWRingBufferReaderBase {
  protected:
   using EntryT = HRDWEntry<DataT, C>;
 
-  explicit HRDWRingBufferReaderBase(const HRDWRingBuffer<DataT, C>& buffer)
+  explicit HRDWRingBufferReaderBase(const HRDWRingBuffer<DataT, C, W>& buffer)
       : ring_(buffer.ring_),
         writeIndex_(buffer.writeIndex_),
+        readIndex_(readIndexOf(buffer)),
         size_(buffer.size_),
         mask_(buffer.mask_),
         shift_(buffer.shift_) {
     assert(buffer.valid());
   }
 
+  static uint64_t* readIndexOf(const HRDWRingBuffer<DataT, C, W>& buffer) {
+    if constexpr (W == WritePolicy::Blocking) {
+      return buffer.readIndex_;
+    } else {
+      return nullptr;
+    }
+  }
+
   EntryT* ring_;
   uint64_t* writeIndex_;
+  // Consumer cursor for Blocking-ring backpressure; absent (zero bytes) on
+  // Overwrite readers via the same [[no_unique_address]]/define_if pattern the
+  // buffer and device handle use.
+  [[no_unique_address]] detail::define_if<W == WritePolicy::Blocking, uint64_t*>
+      readIndex_{};
   uint32_t size_;
   // size_ - 1. Cached so `slot & mask_` is one bitwise op per read
   // instead of `slot % size_`.
@@ -110,12 +132,13 @@ class HRDWRingBufferReaderBase {
   uint64_t lastReadIndex_{0};
 };
 
-template <typename DataT>
-class HRDWRingBufferReader<DataT, MemoryCoherenceScope::System>
-    : public HRDWRingBufferReaderBase<DataT, MemoryCoherenceScope::System> {
-  using Base = HRDWRingBufferReaderBase<DataT, MemoryCoherenceScope::System>;
+template <typename DataT, WritePolicy W>
+class HRDWRingBufferReader<DataT, MemoryCoherenceScope::System, W>
+    : public HRDWRingBufferReaderBase<DataT, MemoryCoherenceScope::System, W> {
+  using Base = HRDWRingBufferReaderBase<DataT, MemoryCoherenceScope::System, W>;
   using Base::lastReadIndex_;
   using Base::mask_;
+  using Base::readIndex_;
   using Base::ring_;
   using Base::shift_;
   using Base::size_;
@@ -126,7 +149,7 @@ class HRDWRingBufferReader<DataT, MemoryCoherenceScope::System>
   using Result = PollResult<MemoryCoherenceScope::System>;
 
   explicit HRDWRingBufferReader(
-      const HRDWRingBuffer<DataT, MemoryCoherenceScope::System>& buffer)
+      const HRDWRingBuffer<DataT, MemoryCoherenceScope::System, W>& buffer)
       : Base(buffer) {}
 
   enum class ReadResult { kSuccess, kOverwritten, kNotReady };
@@ -157,14 +180,22 @@ class HRDWRingBufferReader<DataT, MemoryCoherenceScope::System>
       return ReadResult::kSuccess;
     }
 
-    // Reader stays within size_ of head, so |actual - expected| ≤ 1
-    // (modular). Signed delta disambiguates earlier vs later writes and
-    // wraps correctly.
-    int32_t delta = static_cast<int32_t>(dest.epoch - expected);
-    if (dest.epoch != HRDW_RINGBUFFER_SLOT_EMPTY && delta > 0) {
-      return ReadResult::kOverwritten;
+    if constexpr (W == WritePolicy::Blocking) {
+      // Backpressure guarantees the writer never laps a slot the reader still
+      // holds the cursor at, so it can never be overwritten out from under us.
+      // A non-matching epoch is therefore only ever EMPTY or a stale prior-lap
+      // epoch — i.e. "not published yet", never overwritten.
+      return ReadResult::kNotReady;
+    } else {
+      // Reader stays within size_ of head, so |actual - expected| ≤ 1
+      // (modular). Signed delta disambiguates earlier vs later writes and
+      // wraps correctly.
+      int32_t delta = static_cast<int32_t>(dest.epoch - expected);
+      if (dest.epoch != HRDW_RINGBUFFER_SLOT_EMPTY && delta > 0) {
+        return ReadResult::kOverwritten;
+      }
+      return ReadResult::kNotReady;
     }
-    return ReadResult::kNotReady;
   }
 
   // Poll for new entries. Calls callback(entry, slot) for each valid entry.
@@ -180,13 +211,25 @@ class HRDWRingBufferReader<DataT, MemoryCoherenceScope::System>
       std::chrono::milliseconds timeout = std::chrono::milliseconds{0}) {
     Result result;
 
-    auto deadline = std::chrono::steady_clock::now() + timeout;
+    [[maybe_unused]] auto deadline = std::chrono::steady_clock::now() + timeout;
 
     // jump to the oldest valid entry if the reader fell behind by more than
     // size_ and returns the number of entries skipped (lost). also updates
     // head to the newest-read writeIndex_
     auto jumpToTail = [&](uint64_t& head) -> uint64_t {
       head = relaxedLoad(writeIndex_);
+      // A Blocking ring backpressures the writer, so the reader can never fall
+      // behind the published data by more than the ring size — it is lossless
+      // by construction. head may still sit one slot past that: a writer claims
+      // its slot with fetch_add(writeIndex) *before* blocking on backpressure,
+      // so a single blocked writer leaves writeIndex at readIndex + size + 1
+      // while the slot it is parked on stays unpublished (read as kNotReady,
+      // never lost). Applying the Overwrite skip here would drop that
+      // still-live entry and then release the writer to overwrite it — so never
+      // skip.
+      if constexpr (W == WritePolicy::Blocking) {
+        return 0;
+      }
       if (head > lastReadIndex_ && head - lastReadIndex_ > size_) {
         uint64_t lost = head - lastReadIndex_ - size_;
         lastReadIndex_ = head - size_;
@@ -196,6 +239,9 @@ class HRDWRingBufferReader<DataT, MemoryCoherenceScope::System>
     };
 
     auto head = relaxedLoad(writeIndex_);
+    if constexpr (W == WritePolicy::Blocking) {
+      result.writerThrottled = (head - lastReadIndex_) >= size_;
+    }
     if (head <= lastReadIndex_ /* no new entries since last read */) {
       return result;
     }
@@ -212,18 +258,26 @@ class HRDWRingBufferReader<DataT, MemoryCoherenceScope::System>
         case ReadResult::kSuccess:
           validEntries_.emplace_back(entry, lastReadIndex_);
           ++lastReadIndex_;
+          maybePublishConsumed(lastReadIndex_);
           break;
         case ReadResult::kOverwritten: {
-          auto lost = jumpToTail(head);
-          if (lost == 0 /* not lapped by full ring - just lost this entry */) {
-            ++lastReadIndex_;
-            lost = 1;
-          }
-          result.entriesLost += lost;
-          if (timeout.count() > 0 &&
-              std::chrono::steady_clock::now() > deadline) {
-            result.timedOut = true;
-            goto done;
+          if constexpr (W == WritePolicy::Overwrite) {
+            auto lost = jumpToTail(head);
+            if (lost ==
+                0 /* not lapped by full ring - just lost this entry */) {
+              ++lastReadIndex_;
+              lost = 1;
+            }
+            result.entriesLost += lost;
+            if (timeout.count() > 0 &&
+                std::chrono::steady_clock::now() > deadline) {
+              result.timedOut = true;
+              goto done;
+            }
+          } else {
+            assert(
+                false &&
+                "Blocking ring must never observe an overwritten slot");
           }
           break;
         }
@@ -242,6 +296,22 @@ class HRDWRingBufferReader<DataT, MemoryCoherenceScope::System>
   }
 
  private:
+  // Publish the consumer cursor so a Blocking ring's device writer can tell
+  // which slots are safe to reuse. Release-store pairs with the acquire load in
+  // write_blocking(). No-op for Overwrite rings, which never allocate
+  // readIndex_.
+  __attribute__((always_inline)) inline void maybePublishConsumed(
+      uint64_t consumedUpTo) const {
+    if constexpr (W == WritePolicy::Blocking) {
+#if defined(__cpp_lib_atomic_ref)
+      std::atomic_ref<uint64_t>(*readIndex_)
+          .store(consumedUpTo, std::memory_order_release);
+#else
+      __atomic_store_n(readIndex_, consumedUpTo, __ATOMIC_RELEASE);
+#endif
+    }
+  }
+
   // Reusable buffer for accumulated entries — avoids allocation per poll().
   std::vector<std::pair<EntryT, uint64_t>> validEntries_;
 };
@@ -251,10 +321,10 @@ class HRDWRingBufferReader<DataT, MemoryCoherenceScope::System>
 // callback for each fresh entry. The internal read cursor advances on
 // every poll, so successive calls only return entries written since
 // the previous one.
-template <typename DataT>
-class HRDWRingBufferReader<DataT, MemoryCoherenceScope::Device>
-    : public HRDWRingBufferReaderBase<DataT, MemoryCoherenceScope::Device> {
-  using Base = HRDWRingBufferReaderBase<DataT, MemoryCoherenceScope::Device>;
+template <typename DataT, WritePolicy W>
+class HRDWRingBufferReader<DataT, MemoryCoherenceScope::Device, W>
+    : public HRDWRingBufferReaderBase<DataT, MemoryCoherenceScope::Device, W> {
+  using Base = HRDWRingBufferReaderBase<DataT, MemoryCoherenceScope::Device, W>;
   using Base::lastReadIndex_;
   using Base::mask_;
   using Base::ring_;
@@ -267,7 +337,7 @@ class HRDWRingBufferReader<DataT, MemoryCoherenceScope::Device>
   using Result = PollResult<MemoryCoherenceScope::Device>;
 
   explicit HRDWRingBufferReader(
-      const HRDWRingBuffer<DataT, MemoryCoherenceScope::Device>& buffer)
+      const HRDWRingBuffer<DataT, MemoryCoherenceScope::Device, W>& buffer)
       : Base(buffer) {}
 
   // Poll for new entries since the last poll(). Synchronizes the stream,

--- a/comms/utils/tests/HRDWRingBufferUT.cu
+++ b/comms/utils/tests/HRDWRingBufferUT.cu
@@ -1,6 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <chrono>
 #include <cstdint>
+#include <thread>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -631,3 +633,198 @@ cudaError_t launchRingBufferWrite<CountedEvent>(
 }
 
 } // namespace hrdw_ring_buffer
+
+// ---------------------------------------------------------------------------
+// WritePolicy::Blocking — lossless device writes with reader backpressure.
+//
+// A Blocking ring pairs a device-side write_blocking() (spins until the reader
+// has consumed the slot being reused) with a reader that publishes its consume
+// cursor after each poll(). These tests exercise that end-to-end on the GPU:
+// the writer kernel is intentionally out-run by a slow host consumer, and a
+// correct Blocking ring loses nothing where an Overwrite ring would.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using hrdw_ring_buffer::MemoryCoherenceScope;
+using hrdw_ring_buffer::WritePolicy;
+
+using BlockingBuffer = HRDWRingBuffer<
+    TestEvent,
+    MemoryCoherenceScope::System,
+    WritePolicy::Blocking>;
+using BlockingReader = HRDWRingBufferReader<
+    TestEvent,
+    MemoryCoherenceScope::System,
+    WritePolicy::Blocking>;
+using BlockingHandle = hrdw_ring_buffer::HRDWRingBufferDeviceHandle<
+    TestEvent,
+    MemoryCoherenceScope::System,
+    WritePolicy::Blocking>;
+
+// Single-writer loop: publishes ids [0, n) via the unified write(). Because the
+// ring is WritePolicy::Blocking, write() backpressures against the reader; the
+// ring's abort flag (raised by requestAbort()) is what releases a blocked
+// writer — no per-call predicate.
+__global__ void blockingWriteLoopKernel(BlockingHandle handle, uint32_t n) {
+  for (uint32_t i = 0; i < n; ++i) {
+    handle.write(TestEvent{i});
+  }
+}
+
+cudaError_t launchBlockingWriteLoop(
+    cudaStream_t stream,
+    BlockingHandle handle,
+    uint32_t n) {
+  // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
+  blockingWriteLoopKernel<<<1, 1, 0, stream>>>(handle, n);
+  return cudaGetLastError();
+}
+
+} // namespace
+
+// A few writes that fit in the ring: no backpressure, plain round-trip.
+TEST(HRDWRingBufferBlockingTest, RoundTripWithinCapacity) {
+  BlockingBuffer buf(8);
+  ASSERT_TRUE(buf.valid());
+  BlockingReader reader(buf);
+
+  cudaStream_t stream;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+  ASSERT_EQ(
+      launchBlockingWriteLoop(stream, buf.deviceHandle(), 3), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+  std::vector<uint32_t> seen;
+  auto r = reader.poll(
+      [&](const TestEntry& e, uint64_t) { seen.push_back(e.data.tag); });
+  cudaStreamDestroy(stream);
+
+  EXPECT_EQ(r.entriesLost, 0u);
+  const std::vector<uint32_t> expected{0, 1, 2};
+  EXPECT_EQ(seen, expected);
+}
+
+// The core guarantee: publish far more entries than the ring holds while the
+// consumer drains slowly. Blocking backpressure means NOTHING is lost and the
+// ids arrive in order — an Overwrite ring would drop most of them here.
+TEST(HRDWRingBufferBlockingTest, LosslessUnderSlowConsumer) {
+  constexpr uint32_t kRingSize = 8;
+  constexpr uint32_t kN = 200; // 25x the ring
+  BlockingBuffer buf(kRingSize);
+  ASSERT_TRUE(buf.valid());
+  BlockingReader reader(buf);
+
+  cudaStream_t stream;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+  // Launch async and consume concurrently — the writer will block on the ring.
+  ASSERT_EQ(
+      launchBlockingWriteLoop(stream, buf.deviceHandle(), kN), cudaSuccess);
+
+  std::vector<uint32_t> seen;
+  uint64_t lost = 0;
+  bool observedThrottle = false;
+  // Deliberately slow consumer (sleep per poll) so the ring stays full and the
+  // writer is forced to backpressure. Bounded so a bug fails instead of hangs.
+  for (int iter = 0; iter < 100000 && seen.size() < kN; ++iter) {
+    auto r = reader.poll(
+        [&](const TestEntry& e, uint64_t) { seen.push_back(e.data.tag); });
+    lost += r.entriesLost;
+    observedThrottle |= r.writerThrottled;
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
+  }
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  // Final drain of anything published after the last poll.
+  auto r = reader.poll(
+      [&](const TestEntry& e, uint64_t) { seen.push_back(e.data.tag); });
+  lost += r.entriesLost;
+  cudaStreamDestroy(stream);
+
+  EXPECT_EQ(lost, 0u) << "Blocking ring must not drop entries";
+  ASSERT_EQ(seen.size(), static_cast<size_t>(kN));
+  for (uint32_t i = 0; i < kN; ++i) {
+    EXPECT_EQ(seen[i], i) << "entry " << i << " out of order or missing";
+  }
+  // Guard against a false pass: if the writer never actually saturated the
+  // ring, losslessness was never stressed through the backpressure path this
+  // test exists to cover.
+  EXPECT_TRUE(observedThrottle)
+      << "backpressure never engaged: writer was not throttled, so "
+         "losslessness was not actually exercised";
+}
+
+// A blocked writer (ring full, no consumer) must be released by requestAbort()
+// rather than hanging forever.
+TEST(HRDWRingBufferBlockingTest, AbortReleasesBlockedWriter) {
+  constexpr uint32_t kRingSize = 4;
+  BlockingBuffer buf(kRingSize);
+  ASSERT_TRUE(buf.valid());
+
+  cudaStream_t stream;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+  // Write more than the ring holds with NO consumer: the writer fills the ring
+  // then blocks in write().
+  ASSERT_EQ(
+      launchBlockingWriteLoop(stream, buf.deviceHandle(), kRingSize + 4),
+      cudaSuccess);
+
+  // Give the writer time to reach the blocked state, then abort the ring.
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  EXPECT_EQ(cudaStreamQuery(stream), cudaErrorNotReady)
+      << "writer should block";
+  buf.requestAbort();
+
+  // The writer must now finish. Bounded wait so a stuck writer fails the test.
+  bool done = false;
+  for (int i = 0; i < 5000; ++i) {
+    if (cudaStreamQuery(stream) == cudaSuccess) {
+      done = true;
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  cudaStreamSynchronize(stream);
+  cudaStreamDestroy(stream);
+  EXPECT_TRUE(done) << "requestAbort did not release the blocked writer";
+}
+
+// poll() reports Result::writerThrottled when the ring is saturated (the device
+// writer is parked in write_blocking()), and clears it once the ring drains.
+TEST(HRDWRingBufferBlockingTest, ThrottledFlagReportsBackpressure) {
+  constexpr uint32_t kRingSize = 4;
+  constexpr uint32_t kN = kRingSize * 2;
+  BlockingBuffer buf(kRingSize);
+  ASSERT_TRUE(buf.valid());
+  BlockingReader reader(buf);
+
+  cudaStream_t stream;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+  // No concurrent consumer: the writer fills the ring and blocks.
+  ASSERT_EQ(
+      launchBlockingWriteLoop(stream, buf.deviceHandle(), kN), cudaSuccess);
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+  std::vector<uint32_t> seen;
+  auto collect = [&](const TestEntry& e, uint64_t) {
+    seen.push_back(e.data.tag);
+  };
+
+  // First poll sees the ring full with the writer parked in write_blocking().
+  EXPECT_TRUE(reader.poll(collect).writerThrottled)
+      << "a full ring with a blocked writer must report throttling";
+
+  // Drain the rest so the writer completes, then a poll on the emptied ring
+  // must report no backpressure.
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  for (int i = 0; i < 100000 && seen.size() < kN; ++i) {
+    reader.poll(collect);
+  }
+  EXPECT_FALSE(reader.poll(collect).writerThrottled)
+      << "a drained ring must not report throttling";
+  cudaStreamDestroy(stream);
+
+  ASSERT_EQ(seen.size(), static_cast<size_t>(kN));
+  for (uint32_t i = 0; i < kN; ++i) {
+    EXPECT_EQ(seen[i], i) << "entry " << i << " out of order or missing";
+  }
+}


### PR DESCRIPTION
Summary:

Adds a `WritePolicy` template policy to `HRDWRingBuffer` (`comms/utils/hrdw_ring_buffer`), parallel to `MemoryCoherenceScope`: `Overwrite` (default, unchanged behavior) and `Blocking`.

A `Blocking` ring is lossless regardless of consumer timing. It allocates a host-published consumer cursor, its reader publishes that cursor (release) at the end of each `poll()`, and the device `write_blocking()` spins (acquire-loading the cursor) until the reader has consumed the slot it is about to reuse — so a device write can never overwrite an unconsumed entry. The policy binds both halves (writer backpressure + reader cursor-publish) into one type, so "the reader sees every write" is a structural guarantee. The spin is abort-cancellable from the caller at the ring level (safety net if reader dies while gpu work is still ongoing); on abort it still publishes rather than abandon a claimed slot (which would stall the in-order reader). `Blocking` requires `System` scope (host-published cursor); `write_blocking()` is `static_assert`-gated to `Blocking` rings.

`Overwrite` rings allocate no cursor and should be unchanged; the new 3rd template parameter is defaulted.

Consumed by the CTRAN GPE device-ring dispatch (child commit), which needs lossless publish as extra insurance so we can assert that a captured kernel's cmd-id can never be dropped.

Reviewed By: ngimel

Differential Revision: D111495096


