### PR TITLE
Cacheline-pad send/recv sync flags (kSendRecvSignalSlotStride) (#3120)

### DIFF
--- a/comms/prims/benchmarks/IbgdaSendRecv.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cu
@@ -349,13 +349,10 @@ __global__ void __launch_bounds__(256, 1) ibgda_reset_send_recv_kernel(
   const auto idx = blockIdx.x * blockDim.x + threadIdx.x;
   const auto stride = blockDim.x * gridDim.x;
 
-  auto* signalSlots = static_cast<uint64_t*>(layout.localSignalBuf.ptr);
-  auto* counterSlots = static_cast<uint64_t*>(layout.localCounterBuf.ptr);
-
   for (auto slot = idx; slot < static_cast<uint32_t>(2 * maxGroups);
        slot += stride) {
-    if (signalSlots != nullptr) {
-      signalSlots[slot] = 0;
+    if (SignalState* signal = layout.localSignalState(static_cast<int>(slot))) {
+      signal->signal_ = 0;
     }
     if (slot < static_cast<uint32_t>(maxGroups)) {
       auto& channel = transport->local_channel(slot);
@@ -366,8 +363,9 @@ __global__ void __launch_bounds__(256, 1) ibgda_reset_send_recv_kernel(
 
   for (auto slot = idx; slot < static_cast<uint32_t>(maxGroups);
        slot += stride) {
-    if (counterSlots != nullptr) {
-      counterSlots[slot] = 0;
+    if (SignalState* counter =
+            layout.localCounterState(static_cast<int>(slot))) {
+      counter->signal_ = 0;
     }
   }
 }

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -233,6 +233,18 @@ void* checkedSlotAlloc(
   }
   return ptr;
 }
+
+std::size_t alignUp(std::size_t x, std::size_t a) {
+  return ((x + a - 1) / a) * a;
+}
+
+void checkSendRecvSignalAlignment(const void* ptr, const char* label) {
+  if (ptr != nullptr &&
+      reinterpret_cast<std::uintptr_t>(ptr) % alignof(SignalState) != 0) {
+    throw std::runtime_error(
+        fmt::format("{} must be {}-byte aligned", label, alignof(SignalState)));
+  }
+}
 } // namespace
 
 MultiPeerIbTransportBase::MultiPeerIbTransportBase(
@@ -367,12 +379,15 @@ std::size_t MultiPeerIbTransportBase::sendRecvStagingBytesPerPeer() const {
 }
 
 std::size_t MultiPeerIbTransportBase::sendRecvSignalBytesPerPeer() const {
+  // Slots are cacheline-strided (kSendRecvSignalSlotStride), not packed, to
+  // avoid cross-group false sharing of the send/recv sync flags.
   return 2 * static_cast<std::size_t>(config_.max_num_channels) *
-      sizeof(uint64_t);
+      kSendRecvSignalSlotStride;
 }
 
 std::size_t MultiPeerIbTransportBase::sendRecvCounterBytesPerPeer() const {
-  return static_cast<std::size_t>(config_.max_num_channels) * sizeof(uint64_t);
+  return static_cast<std::size_t>(config_.max_num_channels) *
+      kSendRecvSignalSlotStride;
 }
 
 IbChannelLayout MultiPeerIbTransportBase::channelLayoutForPeer(
@@ -465,16 +480,13 @@ void MultiPeerIbTransportBase::allocateSendRecvBuffersEager(
   // buffers; pack them into ONE granularity-aligned allocation so they cost a
   // single granularity unit and share one aligned Data-Direct MR (offset 0),
   // instead of one aligned unit each. Region layout: [signal | (device
-  // counter)], each 16B-aligned; the whole allocation rounded to the VMM
-  // granularity so the DD export offset is 0.
+  // counter)], each SignalState-aligned; the whole allocation rounded to the
+  // VMM granularity so the DD export offset is 0.
   const std::size_t signalTotal = signalPerPeer * numPeers;
   const bool deviceCounter = (counterStorage == IbCounterStorage::Device);
   const std::size_t counterTotal =
       deviceCounter ? counterPerPeer * numPeers : 0;
-  auto alignUp = [](std::size_t x, std::size_t a) {
-    return ((x + a - 1) / a) * a;
-  };
-  const std::size_t counterOff = alignUp(signalTotal, std::size_t{16});
+  const std::size_t counterOff = alignUp(signalTotal, alignof(SignalState));
   const std::size_t controlBytes = alignUp(counterOff + counterTotal, ddAlign);
   sendRecvControlBulk_ =
       std::make_unique<meta::comms::DeviceBuffer>(controlBytes);
@@ -482,6 +494,8 @@ void MultiPeerIbTransportBase::allocateSendRecvBuffersEager(
       slotGpuMemset(sendRecvControlBulk_->get(), 0, controlBytes),
       "MultiPeerIbTransport: zero send/recv control bulk");
   char* controlBase = static_cast<char*>(sendRecvControlBulk_->get());
+  checkSendRecvSignalAlignment(
+      controlBase, "MultiPeerIbTransport: send/recv signal base");
 
   // Staging is bulk data: opt into Relaxed Ordering. Signal/counter stay strict
   // so a flag write can't be reordered ahead of the data on the shared route.
@@ -506,6 +520,9 @@ void MultiPeerIbTransportBase::allocateSendRecvBuffersEager(
   if (deviceCounter) {
     // Device counter is a view into the control MR (same lkey). The NIC bumps
     // it via a loopback RDMA atomic (IBGDA).
+    checkSendRecvSignalAlignment(
+        controlBase + counterOff,
+        "MultiPeerIbTransport: send/recv counter base");
     sendRecvCounterBulkReg_ = sendRecvSignalBulkReg_.subBuffer(counterOff);
     counterBulkBuf = sendRecvCounterBulkReg_;
     counterCompletionBulkBuf = sendRecvCounterBulkReg_;
@@ -518,6 +535,12 @@ void MultiPeerIbTransportBase::allocateSendRecvBuffersEager(
         IbCounterStorage::HostPinned,
         counterPerPeer * numPeers,
         "send/recv host counter");
+    checkSendRecvSignalAlignment(
+        sendRecvHostCounterAllocation_.devicePtr,
+        "MultiPeerIbTransport: send/recv host counter device base");
+    checkSendRecvSignalAlignment(
+        sendRecvHostCounterAllocation_.hostPtr,
+        "MultiPeerIbTransport: send/recv host counter host base");
     counterBulkBuf = IbgdaLocalBuffer(
         sendRecvHostCounterAllocation_.devicePtr, NetworkLKeys{});
     counterCompletionBulkBuf = IbgdaLocalBuffer(
@@ -636,12 +659,25 @@ void MultiPeerIbTransportBase::allocateSendRecvBufferForPeer(
   const bool deviceCounter = (counterStorage == IbCounterStorage::Device);
 
   // One contiguous device buffer: sendStaging | recvStaging | signal,
-  // plus the counter when it is device-resident. A HostPinned counter is
-  // allocated separately (host-mapped, never RDMA-registered).
-  std::size_t total = 2 * stagingPerPeer + signalPerPeer;
+  // plus the counter when it is device-resident. SignalState-backed regions are
+  // padded before their starts so the first slot and every strided slot are
+  // aligned. A HostPinned counter is allocated separately (host-mapped, never
+  // RDMA-registered).
+  std::size_t off = 0;
+  const std::size_t sendStagingOff = off;
+  off += stagingPerPeer;
+  const std::size_t recvStagingOff = off;
+  off += stagingPerPeer;
+  off = alignUp(off, alignof(SignalState));
+  const std::size_t signalOff = off;
+  off += signalPerPeer;
+  std::size_t counterOff = 0;
   if (deviceCounter) {
-    total += counterPerPeer;
+    off = alignUp(off, alignof(SignalState));
+    counterOff = off;
+    off += counterPerPeer;
   }
+  const std::size_t total = off;
   auto buf = std::make_unique<meta::comms::DeviceBuffer>(total);
   checkSlotGpu(
       slotGpuMemset(buf->get(), 0, total),
@@ -649,24 +685,30 @@ void MultiPeerIbTransportBase::allocateSendRecvBufferForPeer(
   auto reg = registerBuffer(buf->get(), total);
 
   char* p = static_cast<char*>(buf->get());
-  std::size_t off = 0;
   auto& pb = sendRecvPeerBuffers_[peerIndex];
-  pb.sendStaging = IbgdaLocalBuffer(p + off, reg.lkey_per_device);
-  off += stagingPerPeer;
-  void* recvStagingPtr = p + off;
+  pb.sendStaging = IbgdaLocalBuffer(p + sendStagingOff, reg.lkey_per_device);
+  void* recvStagingPtr = p + recvStagingOff;
   pb.recvStaging = IbgdaLocalBuffer(recvStagingPtr, reg.lkey_per_device);
-  off += stagingPerPeer;
-  void* signalPtr = p + off;
+  void* signalPtr = p + signalOff;
+  checkSendRecvSignalAlignment(
+      signalPtr, "MultiPeerIbTransport: lazy send/recv signal base");
   pb.signal = IbgdaLocalBuffer(signalPtr, reg.lkey_per_device);
-  off += signalPerPeer;
   if (deviceCounter) {
-    pb.counter = IbgdaLocalBuffer(p + off, reg.lkey_per_device);
+    checkSendRecvSignalAlignment(
+        p + counterOff, "MultiPeerIbTransport: lazy send/recv counter base");
+    pb.counter = IbgdaLocalBuffer(p + counterOff, reg.lkey_per_device);
     pb.counterCompletion = pb.counter;
   } else {
     auto alloc = allocateCounterSlotAllocation(
         IbCounterStorage::HostPinned,
         counterPerPeer,
         "lazy send/recv host counter");
+    checkSendRecvSignalAlignment(
+        alloc.devicePtr,
+        "MultiPeerIbTransport: lazy send/recv host counter device base");
+    checkSendRecvSignalAlignment(
+        alloc.hostPtr,
+        "MultiPeerIbTransport: lazy send/recv host counter host base");
     pb.counter = IbgdaLocalBuffer(alloc.devicePtr, NetworkLKeys{});
     pb.counterCompletion = IbgdaLocalBuffer(alloc.hostPtr, NetworkLKeys{});
     lazySendRecvHostCounters_[peerIndex] = std::move(alloc);

--- a/comms/prims/transport/ibgda/IbgdaBuffer.h
+++ b/comms/prims/transport/ibgda/IbgdaBuffer.h
@@ -8,6 +8,7 @@
 
 #include <endian.h>
 
+#include "comms/prims/core/SignalState.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
 #include "comms/prims/transport/amd/HipHostCompat.h"
 #include "comms/prims/transport/rdma/NicConstants.h"
@@ -303,10 +304,12 @@ struct IbgdaLocalBuffer {
 
   /**
    * Create a sub-buffer at the given byte offset.
-   * Propagates all NICs' lkeys.
+   * Propagates all NICs' lkeys. A null base stays null for optional buffers.
    */
   IBGDA_HOST_DEVICE IbgdaLocalBuffer subBuffer(std::size_t offset) const {
-    return IbgdaLocalBuffer(static_cast<char*>(ptr) + offset, lkey_per_device);
+    return IbgdaLocalBuffer(
+        ptr == nullptr ? nullptr : static_cast<char*>(ptr) + offset,
+        lkey_per_device);
   }
 };
 
@@ -330,10 +333,12 @@ struct IbgdaRemoteBuffer {
 
   /**
    * Create a sub-buffer at the given byte offset.
-   * Propagates all NICs' rkeys.
+   * Propagates all NICs' rkeys. A null base stays null for optional buffers.
    */
   IBGDA_HOST_DEVICE IbgdaRemoteBuffer subBuffer(std::size_t offset) const {
-    return IbgdaRemoteBuffer(static_cast<char*>(ptr) + offset, rkey_per_device);
+    return IbgdaRemoteBuffer(
+        ptr == nullptr ? nullptr : static_cast<char*>(ptr) + offset,
+        rkey_per_device);
   }
 };
 
@@ -445,6 +450,13 @@ struct IbChannelProgress {
       detail::IbSendRecvProgressStage::Done};
 };
 
+inline constexpr std::size_t kSendRecvSignalSlotStride = sizeof(SignalState);
+
+IBGDA_HOST_DEVICE inline std::size_t sendRecvSignalSlotOffset(int slot) {
+  assert(slot >= 0);
+  return static_cast<std::size_t>(slot) * kSendRecvSignalSlotStride;
+}
+
 struct IbChannelLayout {
   IbgdaLocalBuffer
       sendStagingBuf; ///< Registered sendStaging (lkey for put src)
@@ -463,6 +475,68 @@ struct IbChannelLayout {
 
   __host__ __device__ std::size_t data_buffer_size() const {
     return perChannelSize * static_cast<std::size_t>(maxChannels);
+  }
+
+  IBGDA_HOST_DEVICE int dataReadySignalSlot(int channelId) const {
+    return channelId;
+  }
+
+  IBGDA_HOST_DEVICE int slotFreeSignalSlot(int channelId) const {
+    return maxChannels + channelId;
+  }
+
+  IBGDA_HOST_DEVICE int counterSlot(int channelId) const {
+    return channelId;
+  }
+
+  IBGDA_HOST_DEVICE IbgdaLocalBuffer localDataReadySignal(int channelId) const {
+    return localSignalBuf.subBuffer(
+        sendRecvSignalSlotOffset(dataReadySignalSlot(channelId)));
+  }
+
+  IBGDA_HOST_DEVICE IbgdaRemoteBuffer
+  remoteDataReadySignal(int channelId) const {
+    return remoteSignalBuf.subBuffer(
+        sendRecvSignalSlotOffset(dataReadySignalSlot(channelId)));
+  }
+
+  IBGDA_HOST_DEVICE IbgdaLocalBuffer localSlotFreeSignal(int channelId) const {
+    return localSignalBuf.subBuffer(
+        sendRecvSignalSlotOffset(slotFreeSignalSlot(channelId)));
+  }
+
+  IBGDA_HOST_DEVICE IbgdaRemoteBuffer
+  remoteSlotFreeSignal(int channelId) const {
+    return remoteSignalBuf.subBuffer(
+        sendRecvSignalSlotOffset(slotFreeSignalSlot(channelId)));
+  }
+
+  IBGDA_HOST_DEVICE IbgdaLocalBuffer localCounter(int channelId) const {
+    return localCounterBuf.subBuffer(
+        sendRecvSignalSlotOffset(counterSlot(channelId)));
+  }
+
+  IBGDA_HOST_DEVICE IbgdaLocalBuffer
+  localCompletionCounter(int channelId) const {
+    return localCounterCompletionBuf.subBuffer(
+        sendRecvSignalSlotOffset(counterSlot(channelId)));
+  }
+
+  IBGDA_HOST_DEVICE SignalState* localSignalState(int slot) const {
+    return signalStateAt(localSignalBuf.ptr, slot);
+  }
+
+  IBGDA_HOST_DEVICE SignalState* localCounterState(int channelId) const {
+    return signalStateAt(localCounterBuf.ptr, counterSlot(channelId));
+  }
+
+ private:
+  IBGDA_HOST_DEVICE static SignalState* signalStateAt(void* base, int slot) {
+    if (base == nullptr) {
+      return nullptr;
+    }
+    return reinterpret_cast<SignalState*>(
+        static_cast<char*>(base) + sendRecvSignalSlotOffset(slot));
   }
 };
 
@@ -503,15 +577,10 @@ IBGDA_HOST_DEVICE inline IbLocalChannel makeIbLocalChannel(
     const IbChannelLayout& layout,
     int channelId) {
   IbLocalChannel channel{};
-  channel.dataReady = layout.localSignalBuf.subBuffer(
-      static_cast<std::size_t>(channelId) * sizeof(uint64_t));
-  channel.slotFree = layout.localSignalBuf.subBuffer(
-      static_cast<std::size_t>(layout.maxChannels + channelId) *
-      sizeof(uint64_t));
-  channel.nicDoneWait = layout.localCounterBuf.subBuffer(
-      static_cast<std::size_t>(channelId) * sizeof(uint64_t));
-  channel.nicDoneCompletion = layout.localCounterCompletionBuf.subBuffer(
-      static_cast<std::size_t>(channelId) * sizeof(uint64_t));
+  channel.dataReady = layout.localDataReadySignal(channelId);
+  channel.slotFree = layout.localSlotFreeSignal(channelId);
+  channel.nicDoneWait = layout.localCounter(channelId);
+  channel.nicDoneCompletion = layout.localCompletionCounter(channelId);
   return channel;
 }
 
@@ -519,11 +588,8 @@ IBGDA_HOST_DEVICE inline IbRemoteChannel makeIbRemoteChannel(
     const IbChannelLayout& layout,
     int channelId) {
   return IbRemoteChannel{
-      .dataReady = layout.remoteSignalBuf.subBuffer(
-          static_cast<std::size_t>(channelId) * sizeof(uint64_t)),
-      .slotFree = layout.remoteSignalBuf.subBuffer(
-          static_cast<std::size_t>(layout.maxChannels + channelId) *
-          sizeof(uint64_t)),
+      .dataReady = layout.remoteDataReadySignal(channelId),
+      .slotFree = layout.remoteSlotFreeSignal(channelId),
       .recvStaging = layout.recvStagingBuf,
   };
 }


### PR DESCRIPTION
Summary:

The per-group send/recv sync flags (`DATA_READY`, `SLOT_FREE`, `NIC_DONE`) were packed 8 bytes apart in the signal/counter buffers, so up to 8 groups' flags shared a 64B cacheline (16 on a 128B line). This diff pads each flag onto its own cacheline via a single shared constant `kSendRecvSignalSlotStride` (128 bytes) in `IbgdaBuffer.h`, and updates every consumer of the layout in lockstep: host buffer sizing (`sendRecvSignalBytesPerPeer` / `sendRecvCounterBytesPerPeer`) and every device-side per-group slot offset — the shared `IbSendRecvDevice` protocol in `P2pIbTransportDeviceDecl.cuh` (18 offsets), the test kernels in `MultipeerIbgdaTransportTest.cu`, and the benchmark in `IbgdaSendRecv.cu` (including `ibgda_reset_send_recv_kernel`, which now byte-addresses each padded slot instead of indexing a `uint64_t*`).

On GB200 the NIC is on Grace and reaches GPU HBM over NVLink-C2C, and the receivers spin-poll these flags continuously; packing many groups' flags onto one line concentrates that poll traffic and adds cross-group coherence churn. Padding follows the existing comms/prims guidance to 128B-align synchronization primitives to avoid false sharing.

Scope note: this is a contention/false-sharing hygiene change. It reduces but does NOT by itself eliminate the GB200 sub-perBlockSlot chunking deadlock (measured: packed 8B deadlocks ~100% at `maxGroups=8`; 128B padding still deadlocks ~87%). That deadlock is driven by concurrent per-chunk RDMA atomics to GPU memory and is documented by the repro added in the follow-up diff and addressed by a separate signaling fix.

Reviewed By: saifhhasan

Differential Revision: D111770122


