### PR TITLE
Bound client handshake recv timeout; harden cross-host handshake (#3121)

### DIFF
--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -172,7 +172,20 @@ Result<TransportInfo> MultiTransport::bind() {
   size_t totalSize = sizeof(uint8_t);
   totalSize += sizeof(uint32_t) * numTransport;
   for (auto& t : transports_) {
-    infoData.emplace_back(t->bind());
+    auto data = t->bind();
+    /*
+     * A successful bind always yields a non-empty serialized TransportInfo
+     * (header + QP/NIC info). An empty result means the underlying transport
+     * failed to acquire its resources (CQ/QP/MR) and set itself to Error.
+     * Surface that as a real error instead of packing an empty sub-info that
+     * the peer would fail to deserialize during connect().
+     */
+    if (data.empty()) {
+      return Err(
+          ErrCode::ConnectionFailed,
+          "MultiTransport::bind: a transport failed to bind (empty info)");
+    }
+    infoData.emplace_back(std::move(data));
     totalSize += infoData.back().size();
   }
 

--- a/comms/uniflow/Uniflow.cpp
+++ b/comms/uniflow/Uniflow.cpp
@@ -3,6 +3,7 @@
 #include "comms/uniflow/Uniflow.h"
 
 #include "comms/uniflow/controller/TcpController.h"
+#include "comms/uniflow/logging/Logger.h"
 
 namespace uniflow {
 
@@ -82,12 +83,23 @@ Result<std::unique_ptr<Connection>> UniflowAgent::establishConnection(
     bool sendFirst) {
   auto myTopo = factory_->getTopology();
 
+  /*
+   * The recv() calls below are bounded by the connected-socket timeout: if the
+   * peer's transport setup silently failed, a blocked recv now fails with
+   * ConnectionFailed instead of hanging forever. These DEBUG phase logs bracket
+   * each blocking exchange so, when enabled, a stall/timeout is attributable to
+   * a specific handshake step. Kept at DEBUG to avoid per-connection noise.
+   */
+  UNIFLOW_LOG_DEBUG("establishConnection: start (sendFirst={})", sendFirst);
+
   // Exchange topology
   std::vector<uint8_t> peerTopo;
   if (sendFirst) {
     CHECK_EXPR(ctrl->send({myTopo.begin(), myTopo.end()}).get());
+    UNIFLOW_LOG_DEBUG("establishConnection: topology sent, awaiting peer");
     CHECK_EXPR(ctrl->recv(peerTopo).get());
   } else {
+    UNIFLOW_LOG_DEBUG("establishConnection: awaiting peer topology");
     CHECK_EXPR(ctrl->recv(peerTopo).get());
     CHECK_EXPR(ctrl->send({myTopo.begin(), myTopo.end()}).get());
   }
@@ -98,6 +110,8 @@ Result<std::unique_ptr<Connection>> UniflowAgent::establishConnection(
   auto& transport = transportResult.value();
 
   // Bind and exchange transport info
+  UNIFLOW_LOG_DEBUG(
+      "establishConnection: topology exchanged, binding transport");
   auto bindResult = transport->bind();
   CHECK_RETURN(bindResult);
   auto& localInfo = bindResult.value();
@@ -105,14 +119,20 @@ Result<std::unique_ptr<Connection>> UniflowAgent::establishConnection(
   std::vector<uint8_t> remoteInfo;
   if (sendFirst) {
     CHECK_EXPR(ctrl->send(localInfo).get());
+    UNIFLOW_LOG_DEBUG(
+        "establishConnection: transport info sent, awaiting peer");
     CHECK_EXPR(ctrl->recv(remoteInfo).get());
   } else {
+    UNIFLOW_LOG_DEBUG("establishConnection: awaiting peer transport info");
     CHECK_EXPR(ctrl->recv(remoteInfo).get());
     CHECK_EXPR(ctrl->send(localInfo).get());
   }
 
   // Connect transport with remote endpoint info
+  UNIFLOW_LOG_DEBUG(
+      "establishConnection: transport info exchanged, connecting");
   CHECK_EXPR(transport->connect(remoteInfo));
+  UNIFLOW_LOG_DEBUG("establishConnection: connection established");
   return std::make_unique<Connection>(std::move(ctrl), std::move(transport));
 }
 

--- a/comms/uniflow/controller/TcpController.cpp
+++ b/comms/uniflow/controller/TcpController.cpp
@@ -1346,9 +1346,20 @@ Status configureClientSocket(int sock, const TcpSocketConfig& config) {
     int val = static_cast<int>(config.userTimeout->count());
     opt.set(IPPROTO_TCP, TCP_USER_TIMEOUT, val, "TCP_USER_TIMEOUT");
   }
-  if (config.connTimeout) {
+  /*
+   * Default the send/recv timeout to kConnectedTimeoutSec when the caller does
+   * not specify one, matching configureAcceptedSocket on the server side.
+   * Without this the client's connected socket blocks forever: a peer that
+   * accepts the TCP connection but stops responding mid-handshake (e.g. its
+   * transport setup failed) would wedge the client's blocking recv during the
+   * handshake exchange indefinitely, which is only reaped as an opaque
+   * process-unresponsive failure. Bounding it turns the hang into a surfaced
+   * ConnectionFailed error.
+   */
+  {
     struct timeval tv{};
-    tv.tv_sec = config.connTimeout->count();
+    tv.tv_sec =
+        config.connTimeout ? config.connTimeout->count() : kConnectedTimeoutSec;
     opt.set(SOL_SOCKET, SO_SNDTIMEO, tv, "SO_SNDTIMEO");
     opt.set(SOL_SOCKET, SO_RCVTIMEO, tv, "SO_RCVTIMEO");
   }

--- a/comms/uniflow/executor/ScopedEventBaseThread.h
+++ b/comms/uniflow/executor/ScopedEventBaseThread.h
@@ -4,11 +4,13 @@
 
 #include <pthread.h>
 
+#include <exception>
 #include <string>
 #include <thread>
 
 #include "comms/uniflow/executor/LockFreeEventBase.h"
 #include "comms/uniflow/executor/MutexEventBase.h" // IWYU pragma: keep
+#include "comms/uniflow/logging/Logger.h"
 
 namespace uniflow {
 
@@ -31,7 +33,26 @@ class TScopedEventBaseThread {
       if (!n.empty()) {
         pthread_setname_np(pthread_self(), n.substr(0, 15).c_str());
       }
-      evb_.loop();
+      /*
+       * loop() can throw (e.g. EpollEventBase::waitForEvents on an epoll_wait
+       * failure, or a resource-allocation path run on this thread). An escaping
+       * exception would otherwise reach std::terminate with no diagnostic and
+       * take the whole process down silently. Log it (and re-throw to preserve
+       * the fail-fast behavior) so the death is attributable.
+       */
+      try {
+        evb_.loop();
+      } catch (const std::exception& e) {
+        UNIFLOW_LOG_ERROR(
+            "EventBase thread '{}' terminating on uncaught exception: {}",
+            n,
+            e.what());
+        throw;
+      } catch (...) {
+        UNIFLOW_LOG_ERROR(
+            "EventBase thread '{}' terminating on unknown exception", n);
+        throw;
+      }
     });
     // Wait for the thread_ to start the loop.
     evb_.dispatchAndWait([]() noexcept {});


### PR DESCRIPTION
Summary:

Root-cause fix for the cross-host multi-volume handshake wedge (P2417456054), where a torchstore StorageVolume proc is reaped as unresponsive during the first weight sync when the generator fans a handshake out across many volumes (fails ~8, passes ~2).

Root cause: the client connected socket had no receive timeout. `configureAcceptedSocket` (server side) unconditionally sets `SO_RCVTIMEO = kConnectedTimeoutSec` (30s), but `configureClientSocket` set it only when the caller passed `connTimeout`, and `UniflowAgent` never does. So when a peer accepts the TCP connection but stops responding mid-handshake (e.g. its own transport setup failed), the client's blocking `recv` in `UniflowAgent::establishConnection` hangs forever. Under an N-way concurrent fan-out one unresponsive peer wedges the whole sync, which surfaces only as an opaque "process likely crashed" from the supervisor.

Fix: `configureClientSocket` now defaults `SO_RCVTIMEO`/`SO_SNDTIMEO` to `kConnectedTimeoutSec` when the caller does not specify one, symmetric with the server. A wedged handshake now fails with `ConnectionFailed` instead of blocking indefinitely.

Companion repro / regression harness: D111770030 (`comms/uniflow/tools/handshake_fanout_stress`) reproduces the N-way fan-out wedge and was used to verify this fix. Its `--dead-servers` mode points a client at peers that never respond; with this fix the fan-out fails cleanly with `ConnectionFailed` at the ~30s socket timeout instead of hanging forever.

Supporting hardening so a failure is attributable rather than silent:
- `ScopedEventBaseThread`: wrap the EventBase `loop()` in a try/catch that logs the exception before it reaches `std::terminate` (an uncaught throw on that thread otherwise kills the process with no diagnostic).
- `UniflowAgent::establishConnection`: phase logs bracket each blocking send/recv so a wedge points to a specific handshake step.
- `MultiTransport::bind`: a failed sub-transport bind (empty serialized info) now returns `ConnectionFailed` instead of shipping a malformed empty info the peer fails to deserialize.

Reviewed By: tanquer

Differential Revision: D111756794


