### PR TITLE
Move IB sendrecv state into backend devices

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -230,18 +230,29 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
             NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH);
         return commInvalidArgument;
       }
-      config.ibConfig.sendRecv =
-          comms::prims::MultipeerIbTransportConfig::SendRecvConfig{
-              .maxGroups = config.ibConfig.maxGroups,
-              .pipelineDepth = directIbReduceScatter
-                  ? ctran::reducescatter::direct_ib::kPipelineDepth
-                  : static_cast<int>(NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH),
-          };
+      if (!directIbReduceScatter) {
+        if (config.ibConfig.dataBufferSize %
+                static_cast<std::size_t>(config.ibConfig.maxGroups) !=
+            0) {
+          CLOGF(
+              ERR,
+              "IBGDA data-buffer size {} must be divisible by maxGroups {}",
+              config.ibConfig.dataBufferSize,
+              config.ibConfig.maxGroups);
+          return commInvalidArgument;
+        }
+        config.ibConfig.perChannelSize = config.ibConfig.dataBufferSize /
+            static_cast<std::size_t>(config.ibConfig.maxGroups);
+        config.ibConfig.max_num_channels = config.ibConfig.maxGroups;
+        config.ibConfig.pipelineDepth =
+            static_cast<int>(NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH);
+      }
       CLOGF(
           INFO,
-          "Prims IBGDA sendRecv configured: maxGroups={}, pipelineDepth={}, dataBufferSize={}, directIbReduceScatter={}",
-          config.ibConfig.sendRecv->maxGroups,
-          config.ibConfig.sendRecv->pipelineDepth,
+          "Prims IBGDA sendRecv configured: perChannelSize={}, maxNumChannels={}, pipelineDepth={}, dataBufferSize={}, directIbReduceScatter={}",
+          config.ibConfig.perChannelSize,
+          config.ibConfig.max_num_channels,
+          config.ibConfig.pipelineDepth,
           config.ibConfig.dataBufferSize,
           directIbReduceScatter);
     }

--- a/comms/prims/benchmarks/IbgdaForward.cu
+++ b/comms/prims/benchmarks/IbgdaForward.cu
@@ -30,22 +30,14 @@ __global__ void __launch_bounds__(512, 1) ibgda_forward_kernel(
 
     if (my_rank == 0) {
       TiledBuffer<char> tiles(src + offset, sectionBytes, group);
-      next_transport->send(
-          group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+      next_transport->send(group, tiles.data(), tiles.bytes(), 0, timeout);
     } else if (my_rank == 2) {
       TiledBuffer<char> tiles(dst + offset, sectionBytes, group);
-      prev_transport->recv(
-          group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+      prev_transport->recv(group, tiles.data(), tiles.bytes(), 0, timeout);
     } else {
       TiledBuffer<char> tiles(dst + offset, sectionBytes, group);
       prev_transport->forward(
-          group,
-          tiles.data(),
-          *next_transport,
-          tiles.bytes(),
-          numBlocks,
-          0,
-          timeout);
+          group, tiles.data(), *next_transport, tiles.bytes(), 0, timeout);
     }
   }
 }
@@ -74,18 +66,14 @@ __global__ void __launch_bounds__(512, 1) ibgda_recv_send_kernel(
 
     if (my_rank == 0) {
       TiledBuffer<char> tiles(src + offset, sectionBytes, group);
-      next_transport->send(
-          group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+      next_transport->send(group, tiles.data(), tiles.bytes(), 0, timeout);
     } else if (my_rank == 2) {
       TiledBuffer<char> tiles(dst + offset, sectionBytes, group);
-      prev_transport->recv(
-          group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+      prev_transport->recv(group, tiles.data(), tiles.bytes(), 0, timeout);
     } else {
       TiledBuffer<char> tiles(dst + offset, sectionBytes, group);
-      prev_transport->recv(
-          group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
-      next_transport->send(
-          group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+      prev_transport->recv(group, tiles.data(), tiles.bytes(), 0, timeout);
+      next_transport->send(group, tiles.data(), tiles.bytes(), 0, timeout);
     }
   }
 }

--- a/comms/prims/benchmarks/IbgdaForwardBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaForwardBenchmark.cc
@@ -21,8 +21,6 @@ using meta::comms::DeviceBuffer;
 
 namespace comms::prims::benchmark {
 
-using SendRecvConfig = MultipeerIbgdaTransportConfig::SendRecvConfig;
-
 class IbgdaForwardBenchmarkTest : public BenchmarkTestFixture {
  protected:
   void SetUp() override {
@@ -52,12 +50,9 @@ TEST_F(IbgdaForwardBenchmarkTest, Correctness) {
 
   MultipeerIbgdaTransportConfig transportConfig{
       .cudaDevice = localRank,
-      .dataBufferSize = kSlotSize,
-      .sendRecv =
-          SendRecvConfig{
-              .maxGroups = kNumBlocks,
-              .pipelineDepth = kPipelineDepth,
-          },
+      .perChannelSize = kSlotSize / kNumBlocks,
+      .max_num_channels = kNumBlocks,
+      .pipelineDepth = kPipelineDepth,
   };
 
   MultipeerIbgdaTransport transport(
@@ -141,12 +136,9 @@ TEST_F(IbgdaForwardBenchmarkTest, Bandwidth) {
 
   MultipeerIbgdaTransportConfig transportConfig{
       .cudaDevice = localRank,
-      .dataBufferSize = kSlotSize,
-      .sendRecv =
-          SendRecvConfig{
-              .maxGroups = kNumBlocks,
-              .pipelineDepth = kPipelineDepth,
-          },
+      .perChannelSize = kSlotSize / kNumBlocks,
+      .max_num_channels = kNumBlocks,
+      .pipelineDepth = kPipelineDepth,
   };
 
   MultipeerIbgdaTransport transport(

--- a/comms/prims/benchmarks/IbgdaSendRecv.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cu
@@ -27,7 +27,7 @@ __device__ __forceinline__ std::size_t section_bytes(
 __device__ __forceinline__ std::size_t
 protocol_bytes_for_tiled_group_per_launch(
     std::size_t totalBytes,
-    int activeBlocks,
+    int numBlocks,
     std::size_t slotSize,
     int groupId) {
   const std::size_t sectionBytes = min(slotSize, totalBytes);
@@ -37,7 +37,7 @@ protocol_bytes_for_tiled_group_per_launch(
 
   const std::size_t totalSections = totalBytes / sectionBytes;
   const std::size_t tileElements =
-      (((sectionBytes + activeBlocks - 1) / activeBlocks) + 15ULL) & ~15ULL;
+      (((sectionBytes + numBlocks - 1) / numBlocks) + 15ULL) & ~15ULL;
   const std::size_t tileOffset = groupId * tileElements;
   if (tileOffset >= sectionBytes) {
     return 0;
@@ -74,11 +74,11 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_recv_kernel(
     if (isSender) {
       TiledBuffer<char> tiles(src + offset, sectionBytes, sub);
       transport->send(
-          sub, tiles.data(), tiles.bytes(), numBlocks, maxSignalBytes, timeout);
+          sub, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
     } else {
       TiledBuffer<char> tiles(dst + offset, sectionBytes, sub);
       transport->recv(
-          sub, tiles.data(), tiles.bytes(), numBlocks, maxSignalBytes, timeout);
+          sub, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
     }
   }
 }
@@ -121,27 +121,17 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_send_recv_kernel(
 
     if (isSender) {
       TiledBuffer<char> tiles(src + offset, sectionBytes, sub);
-      transport->init_send_progress(
-          sub, tiles.bytes(), numBlocks, maxSignalBytes);
+      transport->init_send_progress(sub, tiles.bytes(), maxSignalBytes);
       while (transport->progress_send_once(
-                 sub,
-                 tiles.data(),
-                 tiles.bytes(),
-                 numBlocks,
-                 maxSignalBytes,
-                 timeout) != IbgdaSendRecvProgressStatus::Done) {
+                 sub, tiles.data(), tiles.bytes(), maxSignalBytes, timeout) !=
+             IbgdaSendRecvProgressStatus::Done) {
       }
     } else {
       TiledBuffer<char> tiles(dst + offset, sectionBytes, sub);
-      transport->init_recv_progress(
-          sub, tiles.bytes(), numBlocks, maxSignalBytes);
+      transport->init_recv_progress(sub, tiles.bytes(), maxSignalBytes);
       while (transport->progress_recv_once(
-                 sub,
-                 tiles.data(),
-                 tiles.bytes(),
-                 numBlocks,
-                 maxSignalBytes,
-                 timeout) != IbgdaSendRecvProgressStatus::Done) {
+                 sub, tiles.data(), tiles.bytes(), maxSignalBytes, timeout) !=
+             IbgdaSendRecvProgressStatus::Done) {
       }
     }
   }
@@ -197,37 +187,17 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_recv_two_call_kernel(
   if (isSender) {
     TiledBuffer<char> first(src, firstBytes, sub);
     transport->send(
-        sub,
-        first.data(),
-        first.bytes(),
-        numBlocks,
-        firstMaxSignalBytes,
-        timeout);
+        sub, first.data(), first.bytes(), firstMaxSignalBytes, timeout);
     TiledBuffer<char> second(src + firstBytes, secondBytes, sub);
     transport->send(
-        sub,
-        second.data(),
-        second.bytes(),
-        numBlocks,
-        secondMaxSignalBytes,
-        timeout);
+        sub, second.data(), second.bytes(), secondMaxSignalBytes, timeout);
   } else {
     TiledBuffer<char> first(dst, firstBytes, sub);
     transport->recv(
-        sub,
-        first.data(),
-        first.bytes(),
-        numBlocks,
-        firstMaxSignalBytes,
-        timeout);
+        sub, first.data(), first.bytes(), firstMaxSignalBytes, timeout);
     TiledBuffer<char> second(dst + firstBytes, secondBytes, sub);
     transport->recv(
-        sub,
-        second.data(),
-        second.bytes(),
-        numBlocks,
-        secondMaxSignalBytes,
-        timeout);
+        sub, second.data(), second.bytes(), secondMaxSignalBytes, timeout);
   }
 }
 
@@ -274,7 +244,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_kernel(
   for (std::size_t s = 0; s < totalSections; ++s) {
     TiledBuffer<char> tiles(src + s * sectionBytes, sectionBytes, group);
     transport->send(
-        group, tiles.data(), tiles.bytes(), numBlocks, maxSignalBytes, timeout);
+        group, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
   }
 }
 
@@ -293,7 +263,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_recv_kernel(
   for (std::size_t s = 0; s < totalSections; ++s) {
     TiledBuffer<char> tiles(dst + s * sectionBytes, sectionBytes, group);
     transport->recv(
-        group, tiles.data(), tiles.bytes(), numBlocks, maxSignalBytes, timeout);
+        group, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
   }
 }
 
@@ -331,12 +301,12 @@ void launch_ibgda_recv(
 
 __global__ void __launch_bounds__(512, 1) ibgda_drain_send_recv_kernel(
     P2pIbgdaTransportDevice* transport,
-    int activeBlocks,
+    int numBlocks,
     std::size_t totalBytes,
     int iterations,
     Timeout timeout) {
   auto group = make_block_group();
-  if (group.group_id >= static_cast<uint32_t>(activeBlocks)) {
+  if (group.group_id >= static_cast<uint32_t>(numBlocks)) {
     return;
   }
 
@@ -344,7 +314,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_drain_send_recv_kernel(
   const auto& state = transport->send_recv_state();
   const std::size_t expectedBytes =
       protocol_bytes_for_tiled_group_per_launch(
-          totalBytes, activeBlocks, state.dataBufferSize, groupId) *
+          totalBytes, numBlocks, state.dataBufferSize, groupId) *
       iterations;
   if (expectedBytes == 0) {
     return;
@@ -364,7 +334,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_drain_send_recv_kernel(
 
 void launch_ibgda_drain_send_recv(
     P2pIbgdaTransportDevice* transport,
-    int activeBlocks,
+    int numBlocks,
     std::size_t totalBytes,
     int iterations,
     cudaStream_t stream,
@@ -372,8 +342,8 @@ void launch_ibgda_drain_send_recv(
   if (totalBytes == 0 || iterations == 0) {
     return;
   }
-  ibgda_drain_send_recv_kernel<<<activeBlocks, 512, 0, stream>>>(
-      transport, activeBlocks, totalBytes, iterations, timeout);
+  ibgda_drain_send_recv_kernel<<<numBlocks, 512, 0, stream>>>(
+      transport, numBlocks, totalBytes, iterations, timeout);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf("[PIPES] Drain launch failed: %s\n", cudaGetErrorString(err));
@@ -440,15 +410,10 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_send_kernel(
 
   for (std::size_t s = 0; s < totalSections; ++s) {
     TiledBuffer<char> tiles(src + s * sectionBytes, sectionBytes, group);
-    transport->init_send_progress(
-        group, tiles.bytes(), numBlocks, maxSignalBytes);
+    transport->init_send_progress(group, tiles.bytes(), maxSignalBytes);
     while (transport->progress_send_once(
-               group,
-               tiles.data(),
-               tiles.bytes(),
-               numBlocks,
-               maxSignalBytes,
-               timeout) != IbgdaSendRecvProgressStatus::Done) {
+               group, tiles.data(), tiles.bytes(), maxSignalBytes, timeout) !=
+           IbgdaSendRecvProgressStatus::Done) {
     }
   }
 }
@@ -467,15 +432,10 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_recv_kernel(
 
   for (std::size_t s = 0; s < totalSections; ++s) {
     TiledBuffer<char> tiles(dst + s * sectionBytes, sectionBytes, group);
-    transport->init_recv_progress(
-        group, tiles.bytes(), numBlocks, maxSignalBytes);
+    transport->init_recv_progress(group, tiles.bytes(), maxSignalBytes);
     while (transport->progress_recv_once(
-               group,
-               tiles.data(),
-               tiles.bytes(),
-               numBlocks,
-               maxSignalBytes,
-               timeout) != IbgdaSendRecvProgressStatus::Done) {
+               group, tiles.data(), tiles.bytes(), maxSignalBytes, timeout) !=
+           IbgdaSendRecvProgressStatus::Done) {
     }
   }
 }

--- a/comms/prims/benchmarks/IbgdaSendRecv.h
+++ b/comms/prims/benchmarks/IbgdaSendRecv.h
@@ -101,7 +101,7 @@ void launch_ibgda_recv(
  */
 void launch_ibgda_drain_send_recv(
     P2pIbgdaTransportDevice* transport,
-    int activeBlocks,
+    int numBlocks,
     std::size_t totalBytes,
     int iterations,
     cudaStream_t stream,

--- a/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -211,12 +211,9 @@ class IbgdaSendRecvBenchmarkContext {
 
     MultipeerIbgdaTransportConfig transportConfig{
         .cudaDevice = localRank_,
-        .dataBufferSize = kSlotSize,
-        .sendRecv =
-            MultipeerIbgdaTransportConfig::SendRecvConfig{
-                .maxGroups = kNumBlocks,
-                .pipelineDepth = kPipelineDepth,
-            },
+        .perChannelSize = kSlotSize / kNumBlocks,
+        .max_num_channels = kNumBlocks,
+        .pipelineDepth = kPipelineDepth,
     };
     transport_ = std::make_unique<MultipeerIbgdaTransport>(
         globalRank_, worldSize_, bootstrap_, transportConfig);

--- a/comms/prims/benchmarks/TileSendRecv.cuh
+++ b/comms/prims/benchmarks/TileSendRecv.cuh
@@ -85,7 +85,7 @@
 // Because signals are monotonically increasing, old signal values from
 // previous calls are always < current expected values, so no ABA issue.
 // Since the cursor is in bytes, changing max_signal_bytes between calls with
-// the same active_blocks is safe. Changing active_blocks changes the staging
+// the same maxGroups is safe. Changing maxGroups changes the staging
 // layout and requires a barrier first.
 //
 // PRECONDITION: stepState must be zeroed before the first kernel launch.

--- a/comms/prims/collectives/AllGatherDirect.cu
+++ b/comms/prims/collectives/AllGatherDirect.cu
@@ -116,7 +116,7 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
   const auto& topo = args.ib_ring;
   auto& prev = *topo.prev;
   auto& next = *topo.next;
-  const std::size_t pipeline_window = next.pipeline_window(group.total_groups);
+  const std::size_t pipeline_window = next.pipeline_window();
   PIPES_DEVICE_CHECK_MSG(
       pipeline_window != 0,
       "hierarchical allgather IB pipeline window is zero");
@@ -130,13 +130,7 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
 
     const char* send_src = tile_src + off;
     next.template send<MemcpyAndSelfCopy>(
-        group,
-        send_src,
-        window,
-        group.total_groups,
-        max_sig,
-        timeout,
-        own_dst + off);
+        group, send_src, window, max_sig, timeout, own_dst + off);
 
     int fwd_current_rank = args.ib_rank;
     for (int step = 0; step < W - 1; step++) {
@@ -148,10 +142,9 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
           io_tile_offset + off;
 
       if (step < W - 2) {
-        prev.forward(
-            group, dst, next, window, group.total_groups, max_sig, timeout);
+        prev.forward(group, dst, next, window, max_sig, timeout);
       } else {
-        prev.recv(group, dst, window, group.total_groups, max_sig, timeout);
+        prev.recv(group, dst, window, max_sig, timeout);
       }
     }
   }
@@ -305,7 +298,7 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
       auto& prev = *topo.prev;
       auto& next = *topo.next;
       const int stride = (args.ib_rank - topo.prev_rank + W) % W;
-      const std::size_t ib_window = next.pipeline_window(args.ib_num_blocks);
+      const std::size_t ib_window = next.pipeline_window();
       PIPES_DEVICE_CHECK_MSG(
           ib_window != 0,
           "hierarchical allgather overlap IB pipeline window is zero");
@@ -320,7 +313,6 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
             group,
             send_src + chunk_off,
             window,
-            args.ib_num_blocks,
             args.ib_signaling_data_size,
             timeout,
             args.trace,
@@ -342,7 +334,6 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
                 dst,
                 next,
                 window,
-                args.ib_num_blocks,
                 args.ib_signaling_data_size,
                 timeout,
                 args.trace,
@@ -352,7 +343,6 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
                 group,
                 dst,
                 window,
-                args.ib_num_blocks,
                 args.ib_signaling_data_size,
                 timeout,
                 args.trace,

--- a/comms/prims/collectives/ReduceScatterDirectIb.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIb.cu
@@ -90,13 +90,7 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
           : output_bytes;
       auto transport = args.peers[peer];
       transport.template recv<ReduceOp>(
-          group,
-          output_bytes,
-          tile_bytes,
-          channels,
-          max_sig,
-          timeout,
-          local_input);
+          group, output_bytes, tile_bytes, max_sig, timeout, local_input);
     }
   } else {
     if (W <= 1) {
@@ -116,7 +110,6 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
           group,
           reinterpret_cast<const char*>(send_tile.data()),
           send_tile.bytes(),
-          channels,
           max_sig,
           timeout);
     }

--- a/comms/prims/collectives/RingAllgather.cu
+++ b/comms/prims/collectives/RingAllgather.cu
@@ -36,7 +36,7 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_allgather_kernel(
       ring_group.group_id * ring_tile.tile_elements;
   const std::size_t io_tile_bytes = ring_tile.bytes();
 
-  const std::size_t pipeline_window = next.pipeline_window(group.total_groups);
+  const std::size_t pipeline_window = next.pipeline_window();
 
   const int my_rank = args.my_rank;
   const int stride = (my_rank - topo.prev_rank + W) % W;
@@ -56,7 +56,7 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_allgather_kernel(
     // Step 0: Send own chunk to next.
     char* send_src = args.recvbuf + my_rank * chunk_bytes + ring_offset +
         io_tile_offset + off;
-    next.send(group, send_src, window, group.total_groups, max_sig, timeout);
+    next.send(group, send_src, window, max_sig, timeout);
 
     // Steps 1..W-1: receive and forward (or just receive on last step).
     int current_rank = my_rank;
@@ -66,10 +66,9 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_allgather_kernel(
           io_tile_offset + off;
 
       if (step < W - 2) {
-        prev.forward(
-            group, dst, next, window, group.total_groups, max_sig, timeout);
+        prev.forward(group, dst, next, window, max_sig, timeout);
       } else {
-        prev.recv(group, dst, window, group.total_groups, max_sig, timeout);
+        prev.recv(group, dst, window, max_sig, timeout);
       }
     }
   }

--- a/comms/prims/collectives/RingReduceScatter.cu
+++ b/comms/prims/collectives/RingReduceScatter.cu
@@ -43,7 +43,7 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_reduce_scatter_kernel(
       ring_group.group_id * ring_tile.tile_elements;
   const std::size_t io_tile_bytes = ring_tile.bytes();
 
-  const std::size_t pipeline_window = next.pipeline_window(group.total_groups);
+  const std::size_t pipeline_window = next.pipeline_window();
 
   const int my_rank = args.my_rank;
   const int stride = (my_rank - topo.prev_rank + W) % W;
@@ -61,7 +61,7 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_reduce_scatter_kernel(
     // Step 0: Send raw input chunk to next.
     const char* send_src = input_base + current_rank * chunk_bytes +
         ring_offset + io_tile_offset + off;
-    next.send(group, send_src, window, group.total_groups, max_sig, timeout);
+    next.send(group, send_src, window, max_sig, timeout);
 
     // W-1 receive steps: forward for intermediate, recv for final.
     for (int step = 0; step < W - 1; step++) {
@@ -71,25 +71,12 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_reduce_scatter_kernel(
 
       if (step < W - 2) {
         prev.template forward<ReduceOp>(
-            group,
-            nullptr,
-            next,
-            window,
-            group.total_groups,
-            max_sig,
-            timeout,
-            local_input);
+            group, nullptr, next, window, max_sig, timeout, local_input);
       } else {
         char* dst = reinterpret_cast<char*>(args.output) + ring_offset +
             io_tile_offset + off;
         prev.template recv<ReduceOp>(
-            group,
-            dst,
-            window,
-            group.total_groups,
-            max_sig,
-            timeout,
-            local_input);
+            group, dst, window, max_sig, timeout, local_input);
       }
     }
   }

--- a/comms/prims/collectives/benchmarks/HierarchicalAllGatherBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/HierarchicalAllGatherBenchmark.cc
@@ -337,14 +337,11 @@ class HierarchicalAllGatherBenchmarkFixture
     try {
       MultipeerIbgdaTransportConfig transport_config{
           .cudaDevice = localRank,
-          .dataBufferSize = config.data_buffer_size,
-          .maxGroups = config.num_blocks,
-          .sendRecv =
-              MultipeerIbgdaTransportConfig::SendRecvConfig{
-                  .maxGroups = config.num_blocks,
-                  .pipelineDepth = config.pipeline_depth,
-              },
-          .qpsPerBlockPerNic = config.num_qps,
+          .perChannelSize = config.data_buffer_size /
+              static_cast<std::size_t>(config.num_blocks),
+          .max_num_channels = config.num_blocks,
+          .pipelineDepth = config.pipeline_depth,
+          .qpsPerConnection = config.num_qps,
       };
       transport_config.ibHca = config.ib_hca;
       ib_transport = std::make_unique<MultipeerIbgdaTransport>(

--- a/comms/prims/collectives/benchmarks/RingAllGatherBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/RingAllGatherBenchmark.cc
@@ -158,13 +158,11 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     const int maxGroups = config.num_blocks * config.num_rings;
     MultipeerIbgdaTransportConfig transport_config{
         .cudaDevice = localRank,
-        .dataBufferSize = config.data_buffer_size,
-        .maxGroups = maxGroups,
-        .sendRecv =
-            MultipeerIbgdaTransportConfig::SendRecvConfig{
-                .pipelineDepth = config.pipeline_depth,
-            },
-        .qpsPerBlockPerNic = config.num_qps,
+        .perChannelSize =
+            config.data_buffer_size / static_cast<std::size_t>(maxGroups),
+        .max_num_channels = maxGroups,
+        .pipelineDepth = config.pipeline_depth,
+        .qpsPerConnection = config.num_qps,
     };
 
     if (config.use_ibrc) {

--- a/comms/prims/collectives/benchmarks/RingReduceScatterBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/RingReduceScatterBenchmark.cc
@@ -165,13 +165,11 @@ class RingReduceScatterBenchmarkFixture
     const int maxGroups = config.num_blocks * config.num_rings;
     MultipeerIbgdaTransportConfig transport_config{
         .cudaDevice = localRank,
-        .dataBufferSize = config.data_buffer_size,
-        .maxGroups = maxGroups,
-        .sendRecv =
-            MultipeerIbgdaTransportConfig::SendRecvConfig{
-                .pipelineDepth = config.pipeline_depth,
-            },
-        .qpsPerBlockPerNic = config.num_qps,
+        .perChannelSize =
+            config.data_buffer_size / static_cast<std::size_t>(maxGroups),
+        .max_num_channels = maxGroups,
+        .pipelineDepth = config.pipeline_depth,
+        .qpsPerConnection = config.num_qps,
     };
 
     if (config.use_ibrc) {

--- a/comms/prims/collectives/tests/HierarchicalAllGatherTest.cc
+++ b/comms/prims/collectives/tests/HierarchicalAllGatherTest.cc
@@ -39,12 +39,9 @@ class HierarchicalAllGatherTest : public AllGatherTestBase {
     try {
       MultipeerIbgdaTransportConfig ibConfig{
           .cudaDevice = localRank,
-          .dataBufferSize = 1024 * 1024,
-          .sendRecv =
-              MultipeerIbgdaTransportConfig::SendRecvConfig{
-                  .maxGroups = kNumBlocks,
-                  .pipelineDepth = 2,
-              },
+          .perChannelSize = (1024 * 1024) / kNumBlocks,
+          .max_num_channels = kNumBlocks,
+          .pipelineDepth = 2,
       };
       ibTransport = std::make_unique<MultipeerIbgdaTransport>(
           globalRank, worldSize, bootstrap, ibConfig);

--- a/comms/prims/collectives/tests/RingAllGatherTest.cc
+++ b/comms/prims/collectives/tests/RingAllGatherTest.cc
@@ -41,14 +41,13 @@ TEST_P(RingAllGatherTest, Correctness) {
 
   std::unique_ptr<MultipeerIbgdaTransport> transport;
   try {
+    const int maxChannels = config.num_blocks * params.num_rings;
     MultipeerIbgdaTransportConfig transportConfig{
         .cudaDevice = localRank,
-        .dataBufferSize = params.data_buffer_size,
-        .sendRecv =
-            MultipeerIbgdaTransportConfig::SendRecvConfig{
-                .maxGroups = config.num_blocks * params.num_rings,
-                .pipelineDepth = params.pipeline_depth,
-            },
+        .perChannelSize =
+            params.data_buffer_size / static_cast<std::size_t>(maxChannels),
+        .max_num_channels = maxChannels,
+        .pipelineDepth = params.pipeline_depth,
         .ibLazyConnect = params.ibLazyConnect,
     };
     transport = std::make_unique<MultipeerIbgdaTransport>(

--- a/comms/prims/collectives/tests/RingReduceScatterTest.cc
+++ b/comms/prims/collectives/tests/RingReduceScatterTest.cc
@@ -99,14 +99,13 @@ TEST_P(RingReduceScatterTest, Correctness) {
     GTEST_SKIP() << "Ring reduce-scatter requires at least 2 ranks";
   }
 
+  const int maxChannels = config.num_blocks * params.num_rings;
   MultipeerIbgdaTransportConfig transportConfig{
       .cudaDevice = localRank,
-      .dataBufferSize = params.data_buffer_size,
-      .sendRecv =
-          MultipeerIbgdaTransportConfig::SendRecvConfig{
-              .maxGroups = config.num_blocks * params.num_rings,
-              .pipelineDepth = params.pipeline_depth,
-          },
+      .perChannelSize =
+          params.data_buffer_size / static_cast<std::size_t>(maxChannels),
+      .max_num_channels = maxChannels,
+      .pipelineDepth = params.pipeline_depth,
       .ibLazyConnect = params.ibLazyConnect,
   };
   auto transport = std::make_unique<RingReduceScatterIbTransport>(

--- a/comms/prims/docs/tile_sendrecv.md
+++ b/comms/prims/docs/tile_sendrecv.md
@@ -8,10 +8,10 @@ and Triton kernels. Composable building blocks for collectives (allgather,
 alltoall, sendrecv) without users needing to manage staging, signals, slot
 rotation, or pipeline depth.
 
-**Target backends:** NVLink cpp, NVLink Triton, IB cpp, IB Triton. NVL has
-diverged to a per-channel state design (`NvlChannelState`, fixed at host
-init); IB still uses the per-call `active_blocks`/`tile_max_groups` design.
-The contract divergence is called out section-by-section below.
+**Target backends:** NVLink cpp, NVLink Triton, IB cpp, IB Triton. Both NVL
+and IB use fixed channel geometry chosen at host init. Callers select a
+channel with `group.group_id`; per-call arguments control transfer size and
+optional sub-chunk signaling, not staging layout.
 
 **In scope:** per-block tile send/recv with cooperative memcpy + pipelined staging.
 **Out of scope:** explicit user-visible drain (handled internally), multi-stream
@@ -32,44 +32,47 @@ The config carries the fixed-channel geometry explicitly:
 
 | Field | Role in tile API |
 |---|---|
-| `per_channel_size` | Bytes owned by one channel in one pipeline slot. |
-| `pipeline_depth` | Number of slots in the pipeline ring. |
-| `maxNumChannels` (was `tile_max_groups`) | Number of **channels** allocated per peer. Each channel owns one fixed `per_channel_size` staging slice in every pipeline slot, plus one `NvlChannelState` for cursors + signals. |
+| `perChannelSize` | Bytes owned by one channel in one pipeline slot. |
+| `pipelineDepth` | Number of slots in the pipeline ring. |
+| `maxNumChannels` | Number of **channels** allocated per peer. Each channel owns one fixed `perChannelSize` staging slice in every pipeline slot, plus one `NvlChannelState` for cursors + signals. |
 
-The host derives `data_buffer_size = per_channel_size * maxNumChannels` for the pipeline slot. Channel sizing is fixed at init — callers no longer pass `active_blocks` to NVL send/recv/forward (IB still does).
+The host derives `data_buffer_size = perChannelSize * maxNumChannels` for
+the pipeline slot. Channel sizing is fixed at init.
 
-### IB (`MultipeerIbgdaTransportConfig`)
+### IB (`MultipeerIbTransportConfig`)
 
-The existing config has `data_buffer_size` but lacks explicit pipeline depth and
-tile group count. Two fields are added:
+IB uses the same fixed-channel shape. The config exposes the first-order
+geometry and derives the total staging slot size:
 
 ```cpp
-struct MultipeerIbgdaTransportConfig {
-  // ... existing fields (data_buffer_size, qpDepth, etc.) ...
+struct MultipeerIbTransportConfig {
+  // ... existing fields (qpDepth, qpsPerConnection, etc.) ...
 
-  // Number of pipeline slots for tile send/recv staging.
-  // Default 2 (double-buffered). Must be >= 1.
-  std::size_t tile_pipeline_depth{2};
+  // Raw put()/signal() buffer size. For send()/recv(), this is derived as
+  // perChannelSize * max_num_channels when perChannelSize is set.
+  std::size_t dataBufferSize{0};
 
-  // Upper bound on the number of groups calling send/recv.
-  // Sizes signal pad and step state arrays. Must be >= 1.
-  int tile_max_groups{128};
+  // Bytes owned by one channel in one pipeline slot.
+  std::size_t perChannelSize{0};
+
+  // Number of channels allocated per peer.
+  int max_num_channels{64};
+
+  // Number of pipeline slots for send/recv staging.
+  int pipelineDepth{2};
 };
 ```
 
 ### Validation (throws at construction, both transports)
 
-- `pipeline_depth` (NVL) / `tile_pipeline_depth` (IB) `>= 1`
-- NVL `maxNumChannels >= 1`, IB `tile_max_groups >= 1`
-- `per_channel_size >= 16` and 16-byte aligned (NVL), or `(data_buffer_size /
-  tile_max_groups) >= 16` (IB) — per-channel/per-group slot must fit at
-  least one 16-byte vectorized memcpy.
+- `pipelineDepth >= 1`
+- `maxNumChannels` / `max_num_channels >= 1`
+- per-channel size is `>= 16` and 16-byte aligned, so each channel slot fits
+  at least one 16-byte vectorized memcpy.
 
-**Defaults rationale:** NVL defaults to `maxNumChannels=64`, matching the
-largest NCCL P2P channel count we expect to mirror. IB still defaults to
-`tile_max_groups=128`. With `per_channel_size=128 KiB`, NVL gets an 8 MiB
-pipeline slot; IB gets
-`per_block_slot_size = data_buffer_size / 128 = 64 KiB`.
+**Defaults rationale:** NVL and IB default to channel counts that cover the
+largest NCCL P2P channel counts we expect to mirror. With
+`perChannelSize=128 KiB` and `maxNumChannels=64`, one pipeline slot is 8 MiB.
 
 ---
 
@@ -115,59 +118,56 @@ NvlChannelState* remote_channels_;  // remote rank's endpoint via IPC; this rank
 Both arrays have length `options_.max_num_channels`. Both
 the channel index and the per-channel staging slice index are `group.group_id`.
 
-### `IbTransportTileState`
+### IB: `IbLocalChannel`, `IbRemoteChannel`, and `IbChannelLayout`
 
 ```cpp
-struct IbTransportTileState {
-  // Per-block step counters. Persistent across send/recv calls.
-  DeviceSpan<int64_t> step_state;   // [2 * max_groups]
-                                    //   [0..max_groups)         = sender step per block
-                                    //   [max_groups..2*max_groups) = receiver step per block
+struct IbLocalChannel {
+  IbChannelProgress sendProgress;
+  IbChannelProgress recvProgress;
+  // Local DATA_READY, SLOT_FREE, and NIC_DONE endpoints.
+  // Local send staging and channel-owned QP state.
+};
 
-  int tile_max_groups{0};
+struct IbRemoteChannel {
+  // Peer DATA_READY and SLOT_FREE endpoints.
+  // Peer recv staging slice and registration handles.
+};
 
-  // Signal pad. Receiver inbox + sender ack inbox.
-  DeviceSpan<uint64_t> signal_pad;  // [2 * max_groups]
-                                    //   [0..max_groups)         = DATA_READY (sender→receiver, "tail")
-                                    //   [max_groups..2*max_groups) = SLOT_FREE (receiver→sender, "head")
-
-  // NIC completion counters.
-  // Bumped by the companion-QP loopback when an RDMA put is delivered.
-  DeviceSpan<uint64_t> nic_done_counter;  // [max_groups]
-
-  // Local send staging buffer (registered MR for RDMA source).
-  DeviceSpan<std::byte> send_staging;  // [pipeline_depth * data_buffer_size]
+struct IbChannelLayout {
+  std::byte* sendStaging;
+  std::byte* recvStaging;
+  DeviceSpan<IbLocalChannel> localChannels;
+  DeviceSpan<IbRemoteChannel> remoteChannels;
+  int max_num_channels;
+  int pipelineDepth;
+  std::size_t perChannelSize;
 };
 ```
 
 **Per-slot layout** (one slot is `data_buffer_size` bytes, partitioned across
-channels for NVL or across the calling blocks for IB):
+fixed channels):
 
 ```
 slot k  (= step / chunks_per_slot % pipeline_depth):
 ┌──────────────┬──────────────┬─────┬────────────────────┐
 │ channel 0 row│ channel 1 row│ ... │ channel (N-1) row  │
 └──────────────┴──────────────┴─────┴────────────────────┘
-   NVL: N = maxNumChannels (fixed at init).
-        each row = per_channel_slot = per_channel_size
-   IB:  N = tile_max_groups; row width still varies with active_blocks.
-        each row = per_block_slot_size = (data_buffer_size / active_blocks) & ~15ULL
+   N = maxNumChannels / max_num_channels (fixed at init).
+   each row = per_channel_slot = per_channel_size
 ```
 
-For NVL the per-channel row size is fixed at host init; using fewer-than-max
-channels wastes the unused channels' slices but does not change live
-channels' bandwidth. For IB the per-block row size still scales with the
-per-call `active_blocks`.
+Using fewer-than-max channels wastes the unused channels' slices but does not
+change live channels' bandwidth.
 
 **Construction responsibilities (host):**
 - NVL: allocate one IPC-shared `NvlChannelState[nPeers * maxNumChannels]`
   buffer; exchange via `GpuMemHandler::exchangeMemPtrs()`. P2P-enable
   `recv_staging` access; exchange device pointers. Zero-init the channel
   buffer (zeros cursors and signals).
-- IB: allocate `step_state`, `signal_pad`, `nic_done_counter`, `send_staging`,
-  `recv_staging`. Register MRs for staging; exchange `recv_staging` rkeys +
-  `signal_pad` rkeys with each peer. Zero-init `step_state`, `signal_pad`,
-  `nic_done_counter`.
+- IB: allocate local channels, remote channel descriptors, send staging, and
+  recv staging. Register MRs for staging and signal/counter storage; exchange
+  peer channel descriptors and rkeys. Zero-init channel progress, signals, and
+  counters.
 
 **Destruction:** deregister MRs (IB), free buffers. Outstanding ops are the
 caller's responsibility (kernel must finish before the host destructor runs).
@@ -178,8 +178,8 @@ caller's responsibility (kernel must finish before the host destructor runs).
 
 ### Cpp
 
-NVL and IB no longer share a signature: NVL has dropped `active_blocks`
-(channel count is fixed at init), IB still takes it (per-call sizing).
+NVL and IB use the same call shape for blocking send/recv. Channel count is
+fixed at init.
 
 ```cpp
 class P2pNvlTransportDevice {
@@ -213,7 +213,6 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       const void* src,
       size_t nbytes,
-      int active_blocks = 0,
       size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout());
 
@@ -221,7 +220,6 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       void* dst,
       size_t nbytes,
-      int active_blocks = 0,
       size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout());
 };
@@ -233,18 +231,18 @@ class P2pIbgdaTransportDevice {
 @core.extern
 def send(
     src_ptr, nbytes,
-    block_id, active_blocks,
+    block_id,
     max_signal_bytes,
     timeout_ns,
     # Constexpr handles plumbed from host transport.
-    # Bundles staging ptrs, signal pad ptrs, step state ptr, transport config values.
+    # Bundles staging pointers, channel endpoints, and transport config values.
     # Exact constexpr/runtime split is an impl-time decision.
     transport_handle: tl.constexpr,
 ):
     ...
 
 @core.extern
-def recv(dst_ptr, nbytes, block_id, active_blocks, max_signal_bytes, timeout_ns,
+def recv(dst_ptr, nbytes, block_id, max_signal_bytes, timeout_ns,
               transport_handle: tl.constexpr):
     ...
 ```
@@ -255,26 +253,21 @@ def recv(dst_ptr, nbytes, block_id, active_blocks, max_signal_bytes, timeout_ns,
 |---|---|---|---|
 | `group` (cpp) / `block_id` (Triton) | yes | — | Identifies this calling block. Slot routing uses `group.group_id` (cpp) or the `block_id` arg (Triton). |
 | `src` / `dst` | yes | — | This block's pre-sliced data pointer. Caller computes per-block offset (see `TiledBuffer`). |
-| `nbytes` | yes | — | This block's data size. May exceed `per_block_slot_size` — chunked internally over pipeline slots. |
-| `active_blocks` | **IB only** | `0` → `tile_max_groups` | (IB only.) Number of blocks calling `send`/`recv` concurrently. Determines `per_block_slot_size = data_buffer_size / active_blocks`. Dropped for NVL — channel count is fixed at init. |
-| `max_signal_bytes` | no | `0` → `per_block_slot_size` | Hint for the maximum number of bytes between consecutive DATA_READY signals. The transport may signal more frequently if too many blocks share the data buffer. Capped at `per_block_slot_size` if larger (sub-slot signaling only). |
+| `nbytes` | yes | — | This block's data size. May exceed `per_channel_size` — chunked internally over pipeline slots. |
+| `max_signal_bytes` | no | `0` → `per_channel_size` | Hint for the maximum number of bytes between consecutive DATA_READY signals. Capped at `per_channel_size` if larger (sub-slot signaling only). |
 | `timeout` | no | `Timeout()` (no limit) | Per-wait timeout. Reuses `comms::prims::Timeout`. On expiry: `__trap()`. |
 
 ### Special values
 
 - **`nbytes == 0`** — block participates in convergent control flow but does no
-  copy and no signal; `step_state` does not advance. Sender and receiver MUST
+  copy and no signal; channel progress does not advance. Sender and receiver MUST
   both pass `nbytes==0` for the same `block_id` (per-block matching rule below).
-- **`max_signal_bytes > per_block_slot_size`** — silently capped to `per_block_slot_size`.
+- **`max_signal_bytes > per_channel_size`** — silently capped to `per_channel_size`.
   The protocol never signals less frequently than once per slot fill (sub-slot
   signaling only).
-- **NVL `group.total_groups > options.max_num_channels`** — `__trap()`.
-  Catches a kernel launching more groups than the host allocated channels
-  for, which would alias two groups onto the same channel and silently
-  corrupt data.
-- **IB `active_blocks > tile_max_groups`** — `__trap()`. The precondition
-  check at the top of the algorithm catches this and traps immediately
-  rather than silently aliasing staging rows.
+- **`group.group_id >= max_num_channels`** — `__trap()`. Catches a kernel
+  selecting a channel the host did not allocate, which would alias two groups
+  onto the same channel or corrupt adjacent state.
 
 ---
 
@@ -291,40 +284,32 @@ def recv(dst_ptr, nbytes, block_id, active_blocks, max_signal_bytes, timeout_ns,
    to `send` / `recv`, and `sub.group_id` (range `[0, sub.total_groups)`)
    is the slot row index.
 3. **Trap precondition (debug-mode `__trap`):**
-   - **NVL:** `group.total_groups <= options.max_num_channels`. The channel
-     index is `group.group_id`; launching more groups than channels would
-     alias two groups onto the same channel and silently corrupt data.
-   - **IB:** `group.group_id < (active_blocks > 0 ? active_blocks : tile_max_groups)`.
-     Violating this would alias two blocks onto the same staging row.
+   - `group.group_id < max_num_channels`. The channel index is
+     `group.group_id`; selecting a channel outside the allocated range would
+     alias state or corrupt adjacent staging.
 
 ### Cross-rank coordination
 
-- For each `group_id k`: sender block_k's `(nbytes, active_blocks, max_signal_bytes)`
-  MUST equal receiver block_k's. The protocol routes data through slot row `k`
-  on both sides; mismatched values cause deadlock (receiver waits for more
+- For each `group_id k`: sender block_k's `(nbytes, max_signal_bytes)` MUST
+  equal receiver block_k's. The protocol routes data through slot row `k` on
+  both sides; mismatched values cause deadlock (receiver waits for more
   signals) or silent drop (receiver consumes too few).
 - Across blocks within the same call: `nbytes` may differ per block (uneven tile
   partitions are supported as long as both sides agree per-block).
 
 ### Changing per-call sizing between calls
 
-- **NVL:** the per-channel slot size is fixed at host init
-  (`per_channel_size`), so consecutive calls cannot
-  change the staging layout — no barrier is needed.
-- **IB:** if `active_blocks` changes between consecutive `send`/`recv` calls
-  on the same transport, a **cross-rank barrier** is required between the
-  two calls. Changing `active_blocks` alters `per_block_slot_size` and
-  therefore the slot row layout; without a barrier, the receiver may still
-  be draining the old layout while the sender begins writing the new one,
-  corrupting staging data.
+The per-channel slot size is fixed at host init, so consecutive calls cannot
+change the staging layout. `max_signal_bytes` may vary between calls because
+progress is tracked in bytes rather than in a layout-dependent step count.
 
 ### Concurrency
 
 - **Single-stream sequential calls on the same transport are supported** —
-  internal `step_state` and `signal_pad` survive across calls; the next call
-  resumes the protocol monotonically.
+  internal channel progress and signal/counter state survive across calls; the
+  next call resumes the protocol monotonically.
 - **Multiple kernels on the same transport via different CUDA streams =
-  undefined behavior** — they would race on `step_state` and `signal_pad`.
+  undefined behavior** — they would race on channel progress and signals.
 
 ---
 
@@ -362,20 +347,18 @@ remote_ch       = remote_channels_[channel]           // this rank writes here v
 
 **IB:**
 ```text
-block_id        = group.group_id
-eff_active      = active_blocks > 0 ? active_blocks : tile_max_groups
-trap if eff_active > tile_max_groups   // signal/step_state arrays are sized to tile_max_groups
-trap if block_id >= eff_active
+channel         = group.group_id
+trap if channel >= max_num_channels
 
-per_block_slot  = (data_buffer_size / eff_active) & ~15ULL
+per_block_slot  = perChannelSize & ~15ULL
 trap if per_block_slot == 0
 chunk_size      = min(max_signal_bytes > 0 ? max_signal_bytes : per_block_slot,
                       per_block_slot)
 chunks_per_slot = per_block_slot / chunk_size      // sub-slot signaling factor
 total_chunks    = ceil(nbytes / chunk_size)
 
-tail_signal_id  = block_id                         // DATA_READY (sender → receiver)
-head_signal_id  = tile_max_groups + block_id       // SLOT_FREE  (receiver → sender)
+local_ch        = local_channels_[channel]
+remote_ch       = remote_channels_[channel]
 ```
 
 ### `send` (NVL)
@@ -481,7 +464,8 @@ group.sync()
 ```text
 if nbytes == 0: return
 
-step = step_state.sender[block_id]
+base_byte = local_ch.sendProgress.cursor
+pipeline_bytes = per_block_slot * pipeline_depth
 
 for s in [0, total_chunks):
     slot_step     = s / chunks_per_slot
@@ -489,15 +473,16 @@ for s in [0, total_chunks):
     slot          = slot_step % pipeline_depth
     slot_off      = slot * data_buffer_size
     chunk_off     = sub_step * chunk_size
-    staging_off   = slot_off + block_id * per_block_slot + chunk_off
+    staging_off   = slot_off + channel * per_block_slot + chunk_off
     data_off      = s * chunk_size
     bytes_this    = min(chunk_size, nbytes - data_off)
+    stream_end    = base_byte + data_off + bytes_this
 
     // (1) Wait for prior NIC use of this slot to drain (local staging is safe).
-    if step >= pipeline_depth * chunks_per_slot:
+    if stream_end > pipeline_bytes:
         wait_counter(group,
-                     nic_done_counter[block_id],
-                     step - pipeline_depth * chunks_per_slot + 1,
+                     local_ch.nic_done_counter,
+                     stream_end - pipeline_bytes,
                      timeout)
 
     // (2) Cooperative memcpy: src chunk -> local send_staging.
@@ -507,10 +492,10 @@ for s in [0, total_chunks):
     group.sync()
 
     // (3) Wait for receiver to free this slot — only at slot boundary.
-    if sub_step == 0 and step >= pipeline_depth * chunks_per_slot:
+    if sub_step == 0 and stream_end > pipeline_bytes:
         wait_signal(group,
-                    signal_pad[tile_max_groups + block_id],       // SLOT_FREE row
-                    step / chunks_per_slot - pipeline_depth + 1,
+                    local_ch.slot_free,
+                    stream_end - pipeline_bytes,
                     timeout)
 
     // (4) Fused RDMA put + remote DATA_READY signal + local NIC_DONE bump.
@@ -519,18 +504,16 @@ for s in [0, total_chunks):
             local_src     = send_staging        + staging_off,
             remote_dst    = recv_staging_remote + staging_off,
             nbytes        = bytes_this,
-            remote_signal = signal_pad_remote[block_id],       // DATA_READY row
-            signal_inc    = 1,
-            local_counter = nic_done_counter[block_id],
-            counter_inc   = 1)
+            remote_signal = remote_ch.data_ready,
+            signal_val    = stream_end,
+            local_counter = local_ch.nic_done_counter,
+            counter_val   = stream_end)
 
-    step++
-
-step_state.sender[block_id] = step
+local_ch.sendProgress.cursor = base_byte + protocol_bytes
 group.sync()
 
-// (5) Internal drain: wait for all RDMA puts on this block to complete.
-wait_counter(group, nic_done_counter[block_id], step, timeout)
+// (5) Internal drain: wait for all RDMA puts on this channel to complete.
+wait_counter(group, local_ch.nic_done_counter, base_byte + protocol_bytes, timeout)
 group.sync()
 ```
 
@@ -539,7 +522,7 @@ group.sync()
 ```text
 if nbytes == 0: return
 
-step = step_state.receiver[block_id]
+base_byte = local_ch.recvProgress.cursor
 
 for s in [0, total_chunks):
     slot_step     = s / chunks_per_slot
@@ -547,14 +530,15 @@ for s in [0, total_chunks):
     slot          = slot_step % pipeline_depth
     slot_off      = slot * data_buffer_size
     chunk_off     = sub_step * chunk_size
-    staging_off   = slot_off + block_id * per_block_slot + chunk_off
+    staging_off   = slot_off + channel * per_block_slot + chunk_off
     data_off      = s * chunk_size
     bytes_this    = min(chunk_size, nbytes - data_off)
+    stream_end    = base_byte + data_off + bytes_this
 
     // (1) Wait for sender's data.
     wait_signal(group,
-                signal_pad[block_id],                          // DATA_READY row
-                step + 1,
+                local_ch.data_ready,
+                stream_end,
                 timeout)
 
     // (2) Cooperative memcpy: local recv_staging -> dst.
@@ -567,12 +551,10 @@ for s in [0, total_chunks):
     bool last_in_slot = (sub_step == chunks_per_slot - 1)
                         or (s == total_chunks - 1)
     if last_in_slot and group.is_leader():
-        signal_remote(signal_pad_remote[tile_max_groups + block_id],  // SLOT_FREE row
-                      increment = 1)
+        signal_remote(remote_ch.slot_free,
+                      signal_val = stream_end)
 
-    step++
-
-step_state.receiver[block_id] = step
+local_ch.recvProgress.cursor = base_byte + protocol_bytes
 group.sync()
 ```
 
@@ -620,27 +602,25 @@ __global__ void bidirectional_send_recv_kernel(
         sub,
         tiles.data(),
         tiles.bytes(),
-        /*active_blocks=*/sub.total_groups,   // explicit — matches the partition size
-        /*max_signal_bytes=*/  0,                   // default = one signal per slot fill
+        /*max_signal_bytes=*/0,  // default = one signal per slot fill
         timeout);
   } else {
     transport->recv(
         sub,
         tiles.data(),
         tiles.bytes(),
-        /*active_blocks=*/sub.total_groups,
-        /*max_signal_bytes=*/  0,
+        /*max_signal_bytes=*/0,
         timeout);
   }
 }
 
 // Host side:
-MultipeerIbgdaTransportConfig cfg{
+MultipeerIbTransportConfig cfg{
     .cudaDevice = local_rank,
     // ... existing IB fields (qpDepth, etc.) ...
-    .data_buffer_size    = 8 * 1024 * 1024,
-    .tile_pipeline_depth = 2,
-    .tile_max_groups     = 64,    // we launch 128 blocks total = 64 senders + 64 receivers
+    .perChannelSize   = 128 * 1024,
+    .max_num_channels = 64, // 128 blocks total = 64 senders + 64 receivers
+    .pipelineDepth    = 2,
 };
 MultipeerIbgdaTransport transport(global_rank, world_size, bootstrap, cfg);
 transport.exchange();
@@ -651,8 +631,8 @@ bidirectional_send_recv_kernel<<<128, 256, 0, stream>>>(
 ```
 
 Notes on the example:
-- The `partition(2)` renumbers `sub.group_id` to `[0, 64)` for both senders and
-  receivers. The trap precondition is `sub.group_id < active_blocks=64`,
+- The `partition(2)` renumbers `sub.group_id` to `[0, 64)` for both senders
+  and receivers. The trap precondition is `sub.group_id < max_num_channels`,
   which is satisfied.
 - `TiledBuffer` partitions `total_bytes` evenly across the 64 sub-blocks; each
   block's `tiles.data()` is its own pre-sliced pointer, `tiles.bytes()` is its
@@ -669,8 +649,8 @@ Notes on the example:
   (step 5). May be exposed if users want to overlap NIC drain with other
   device-side work between consecutive `send` calls.
 - **Multi-stream concurrency on the same transport.** Currently undefined.
-  Would require per-stream `step_state` and `signal_pad` arenas.
-- **Per-call config overrides.** `pipeline_depth` and `data_buffer_size` are
+  Would require per-stream channel progress and signal/counter arenas.
+- **Per-call config overrides.** `pipelineDepth` and `perChannelSize` are
   construction-time only. Per-call overrides would require dynamic staging
   re-allocation.
 - **Cross-rank rendezvous.** Use a separate barrier primitive; not coupled to

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -1242,12 +1242,9 @@ TEST_F(
   try {
     MultipeerIbgdaTransportConfig config{
         .cudaDevice = localRank,
-        .dataBufferSize = dataBufferSize,
-        .sendRecv =
-            MultipeerIbgdaTransportConfig::SendRecvConfig{
-                .maxGroups = numBlocks,
-                .pipelineDepth = pipelineDepth,
-            },
+        .perChannelSize = dataBufferSize / numBlocks,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
     };
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
@@ -1262,13 +1259,7 @@ TEST_F(
     CUDACHECK_TEST(cudaMemset(d_output, 0, 2 * sizeof(int64_t)));
 
     test::testProgressReservations(
-        peerTransportPtr,
-        d_output,
-        sendBytes,
-        recvBytes,
-        numBlocks,
-        numBlocks,
-        blockSize);
+        peerTransportPtr, d_output, sendBytes, recvBytes, numBlocks, blockSize);
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
     std::array<int64_t, 2> output{};
@@ -1308,12 +1299,9 @@ TEST_F(
   try {
     MultipeerIbgdaTransportConfig config{
         .cudaDevice = localRank,
-        .dataBufferSize = dataBufferSize,
-        .sendRecv =
-            MultipeerIbgdaTransportConfig::SendRecvConfig{
-                .maxGroups = numBlocks,
-                .pipelineDepth = pipelineDepth,
-            },
+        .perChannelSize = dataBufferSize / numBlocks,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
     };
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
@@ -1342,7 +1330,6 @@ TEST_F(
           peerTransportPtr,
           sendBuffer.get(),
           nbytes,
-          numBlocks,
           maxSignalBytes,
           true,
           numBlocks,
@@ -1352,7 +1339,6 @@ TEST_F(
           peerTransportPtr,
           recvBuffer.get(),
           nbytes,
-          numBlocks,
           maxSignalBytes,
           false,
           numBlocks,
@@ -1394,7 +1380,6 @@ TEST_F(
           peerTransportPtr,
           sendBuffer.get(),
           nbytes,
-          numBlocks,
           maxSignalBytes,
           true,
           numBlocks,
@@ -1404,7 +1389,6 @@ TEST_F(
           peerTransportPtr,
           recvBuffer.get(),
           nbytes,
-          numBlocks,
           maxSignalBytes,
           false,
           numBlocks,
@@ -1459,12 +1443,9 @@ TEST_F(
   try {
     MultipeerIbgdaTransportConfig config{
         .cudaDevice = localRank,
-        .dataBufferSize = dataBufferSize,
-        .sendRecv =
-            MultipeerIbgdaTransportConfig::SendRecvConfig{
-                .maxGroups = numBlocks,
-                .pipelineDepth = pipelineDepth,
-            },
+        .perChannelSize = dataBufferSize / numBlocks,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
     };
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
@@ -1494,7 +1475,6 @@ TEST_F(
           peerTransportPtr,
           isSender ? sendBuffer.get() : recvBuffer.get(),
           nbytes,
-          numBlocks,
           maxSignalBytes,
           isSender,
           numBlocks,
@@ -1538,11 +1518,11 @@ TEST_F(MultipeerIbgdaTransportTestFixture, SendRecvReuseCreditCadence) {
     GTEST_SKIP() << "progress send/recv is not supported for this build";
   }
 
-  constexpr std::size_t dataBufferSize = 64 * 1024;
+  constexpr std::size_t perChannelSize = 64 * 1024;
   constexpr int pipelineDepth = 2;
   constexpr std::size_t protocolBytes = 16;
   constexpr int numBlocks = 1;
-  constexpr std::size_t perBlockSlot = dataBufferSize / numBlocks;
+  constexpr std::size_t perBlockSlot = perChannelSize;
   constexpr std::size_t nicDoneCreditQuantum =
       detail::ib_send_recv_nic_done_credit_quantum(perBlockSlot, pipelineDepth);
   constexpr std::size_t slotFreeCreditQuantum =
@@ -1615,12 +1595,9 @@ TEST_F(MultipeerIbgdaTransportTestFixture, SendRecvReuseCreditCadence) {
         << testCase.name << (useProgress ? " progress" : " blocking"));
     MultipeerIbgdaTransportConfig config{
         .cudaDevice = localRank,
-        .dataBufferSize = dataBufferSize,
-        .sendRecv =
-            MultipeerIbgdaTransportConfig::SendRecvConfig{
-                .maxGroups = numBlocks,
-                .pipelineDepth = pipelineDepth,
-            },
+        .perChannelSize = perChannelSize,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
     };
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -326,18 +326,15 @@ __global__ void sendRecvKernel(
     P2pIbgdaTransportDevice* transport,
     void* buffer,
     std::size_t nbytes,
-    int activeBlocks,
     std::size_t maxSignalBytes,
     bool send) {
   auto group = make_block_group();
   Timeout timeout(kDefaultDeviceTimeoutCycles);
   timeout.start();
   if (send) {
-    transport->send(
-        group, buffer, nbytes, activeBlocks, maxSignalBytes, timeout);
+    transport->send(group, buffer, nbytes, maxSignalBytes, timeout);
   } else {
-    transport->recv(
-        group, buffer, nbytes, activeBlocks, maxSignalBytes, timeout);
+    transport->recv(group, buffer, nbytes, maxSignalBytes, timeout);
   }
 }
 
@@ -345,13 +342,12 @@ void testSendRecv(
     P2pIbgdaTransportDevice* transport,
     void* buffer,
     std::size_t nbytes,
-    int activeBlocks,
     std::size_t maxSignalBytes,
     bool send,
     int numBlocks,
     int blockSize) {
   sendRecvKernel<<<numBlocks, blockSize>>>(
-      transport, buffer, nbytes, activeBlocks, maxSignalBytes, send);
+      transport, buffer, nbytes, maxSignalBytes, send);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(
@@ -364,22 +360,21 @@ __global__ void progressSendRecvKernel(
     P2pIbgdaTransportDevice* transport,
     void* buffer,
     std::size_t nbytes,
-    int activeBlocks,
     std::size_t maxSignalBytes,
     bool send) {
   auto group = make_block_group();
   Timeout timeout(kDefaultDeviceTimeoutCycles);
   timeout.start();
   if (send) {
-    transport->init_send_progress(group, nbytes, activeBlocks, maxSignalBytes);
+    transport->init_send_progress(group, nbytes, maxSignalBytes);
     while (transport->progress_send_once(
-               group, buffer, nbytes, activeBlocks, maxSignalBytes, timeout) !=
+               group, buffer, nbytes, maxSignalBytes, timeout) !=
            IbgdaSendRecvProgressStatus::Done) {
     }
   } else {
-    transport->init_recv_progress(group, nbytes, activeBlocks, maxSignalBytes);
+    transport->init_recv_progress(group, nbytes, maxSignalBytes);
     while (transport->progress_recv_once(
-               group, buffer, nbytes, activeBlocks, maxSignalBytes, timeout) !=
+               group, buffer, nbytes, maxSignalBytes, timeout) !=
            IbgdaSendRecvProgressStatus::Done) {
     }
   }
@@ -389,11 +384,10 @@ __global__ void progressReservationKernel(
     P2pIbgdaTransportDevice* transport,
     int64_t* output,
     std::size_t sendBytes,
-    std::size_t recvBytes,
-    int activeBlocks) {
+    std::size_t recvBytes) {
   auto group = make_block_group();
-  transport->init_send_progress(group, sendBytes, activeBlocks);
-  transport->init_recv_progress(group, recvBytes, activeBlocks);
+  transport->init_send_progress(group, sendBytes);
+  transport->init_recv_progress(group, recvBytes);
 
   if (group.is_leader()) {
     const auto& sendRecvState = transport->send_recv_state();
@@ -414,6 +408,7 @@ __global__ void sendRecvReuseCreditKernel(
     uint64_t waitExpectedNicDoneCredit,
     uint64_t waitExpectedSlotFreeCredit,
     uint64_t* output) {
+  (void)activeBlocks;
   auto group = make_block_group();
   Timeout timeout(kDefaultDeviceTimeoutCycles);
   timeout.start();
@@ -421,23 +416,23 @@ __global__ void sendRecvReuseCreditKernel(
   for (int i = 0; i < iterations; ++i) {
     if (useProgress) {
       if (send) {
-        transport->init_send_progress(group, nbytes, activeBlocks);
-        while (transport->progress_send_once(
-                   group, buffer, nbytes, activeBlocks, 0, timeout) !=
-               IbgdaSendRecvProgressStatus::Done) {
+        transport->init_send_progress(group, nbytes);
+        while (
+            transport->progress_send_once(group, buffer, nbytes, 0, timeout) !=
+            IbgdaSendRecvProgressStatus::Done) {
         }
       } else {
-        transport->init_recv_progress(group, nbytes, activeBlocks);
-        while (transport->progress_recv_once(
-                   group, buffer, nbytes, activeBlocks, 0, timeout) !=
-               IbgdaSendRecvProgressStatus::Done) {
+        transport->init_recv_progress(group, nbytes);
+        while (
+            transport->progress_recv_once(group, buffer, nbytes, 0, timeout) !=
+            IbgdaSendRecvProgressStatus::Done) {
         }
       }
     } else {
       if (send) {
-        transport->send(group, buffer, nbytes, activeBlocks, 0, timeout);
+        transport->send(group, buffer, nbytes, 0, timeout);
       } else {
-        transport->recv(group, buffer, nbytes, activeBlocks, 0, timeout);
+        transport->recv(group, buffer, nbytes, 0, timeout);
       }
     }
   }
@@ -475,7 +470,6 @@ void testProgressSendRecv(
     P2pIbgdaTransportDevice* transport,
     void* buffer,
     std::size_t nbytes,
-    int activeBlocks,
     std::size_t maxSignalBytes,
     bool send,
     int numBlocks,
@@ -484,7 +478,6 @@ void testProgressSendRecv(
   (void)transport;
   (void)buffer;
   (void)nbytes;
-  (void)activeBlocks;
   (void)maxSignalBytes;
   (void)send;
   (void)numBlocks;
@@ -492,7 +485,7 @@ void testProgressSendRecv(
   throw std::runtime_error("progress send/recv is NVIDIA-only");
 #else
   progressSendRecvKernel<<<numBlocks, blockSize>>>(
-      transport, buffer, nbytes, activeBlocks, maxSignalBytes, send);
+      transport, buffer, nbytes, maxSignalBytes, send);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(
@@ -555,7 +548,6 @@ void testProgressReservations(
     int64_t* output,
     std::size_t sendBytes,
     std::size_t recvBytes,
-    int activeBlocks,
     int numBlocks,
     int blockSize) {
 #ifdef __HIP_PLATFORM_AMD__
@@ -563,13 +555,12 @@ void testProgressReservations(
   (void)output;
   (void)sendBytes;
   (void)recvBytes;
-  (void)activeBlocks;
   (void)numBlocks;
   (void)blockSize;
   throw std::runtime_error("progress send/recv is NVIDIA-only");
 #else
   progressReservationKernel<<<numBlocks, blockSize>>>(
-      transport, output, sendBytes, recvBytes, activeBlocks);
+      transport, output, sendBytes, recvBytes);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
@@ -75,7 +75,6 @@ __global__ void sendRecvKernel(
     P2pIbgdaTransportDevice* transport,
     void* buffer,
     std::size_t nbytes,
-    int activeBlocks,
     std::size_t maxSignalBytes,
     bool send);
 
@@ -84,7 +83,6 @@ __global__ void progressSendRecvKernel(
     P2pIbgdaTransportDevice* transport,
     void* buffer,
     std::size_t nbytes,
-    int activeBlocks,
     std::size_t maxSignalBytes,
     bool send);
 
@@ -92,8 +90,7 @@ __global__ void progressReservationKernel(
     P2pIbgdaTransportDevice* transport,
     int64_t* output,
     std::size_t sendBytes,
-    std::size_t recvBytes,
-    int activeBlocks);
+    std::size_t recvBytes);
 
 __global__ void sendRecvReuseCreditKernel(
     P2pIbgdaTransportDevice* transport,

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -129,7 +129,6 @@ void testSendRecv(
     P2pIbgdaTransportDevice* transport,
     void* buffer,
     std::size_t nbytes,
-    int activeBlocks,
     std::size_t maxSignalBytes,
     bool send,
     int numBlocks,
@@ -142,7 +141,6 @@ void testProgressSendRecv(
     P2pIbgdaTransportDevice* transport,
     void* buffer,
     std::size_t nbytes,
-    int activeBlocks,
     std::size_t maxSignalBytes,
     bool send,
     int numBlocks,
@@ -157,7 +155,6 @@ void testProgressReservations(
     int64_t* output,
     std::size_t sendBytes,
     std::size_t recvBytes,
-    int activeBlocks,
     int numBlocks,
     int blockSize);
 

--- a/comms/prims/tests/RecvForwardChainTest.cc
+++ b/comms/prims/tests/RecvForwardChainTest.cc
@@ -23,8 +23,6 @@ using meta::comms::DeviceBuffer;
 
 namespace comms::prims::tests {
 
-using SendRecvConfig = MultipeerIbgdaTransportConfig::SendRecvConfig;
-
 class RecvForwardChainTest : public BenchmarkTestFixture {
  protected:
   void SetUp() override {
@@ -44,12 +42,9 @@ class RecvForwardChainTest : public BenchmarkTestFixture {
       int pipeline_depth = 2) {
     MultipeerIbgdaTransportConfig config{
         .cudaDevice = localRank,
-        .dataBufferSize = slot_size,
-        .sendRecv =
-            SendRecvConfig{
-                .maxGroups = max_groups,
-                .pipelineDepth = pipeline_depth,
-            },
+        .perChannelSize = slot_size / static_cast<std::size_t>(max_groups),
+        .max_num_channels = max_groups,
+        .pipelineDepth = pipeline_depth,
     };
     auto transport = std::make_unique<MultipeerIbgdaTransport>(
         globalRank, worldSize, bootstrap, config);

--- a/comms/prims/tests/RecvForwardChainTest.cu
+++ b/comms/prims/tests/RecvForwardChainTest.cu
@@ -34,16 +34,16 @@ __global__ void recv_forward_chain_kernel(
   if (my_rank == 0) {
     // First rank: send to next
     P2pIbgdaTransportDevice& next = *transports[next_rank];
-    next.send(group, send_buf + my_off, my_bytes, num_blocks);
+    next.send(group, send_buf + my_off, my_bytes);
   } else if (my_rank == world_size - 1) {
     // Last rank: receive from prev
     P2pIbgdaTransportDevice& prev = *transports[prev_rank];
-    prev.recv(group, recv_buf + my_off, my_bytes, num_blocks);
+    prev.recv(group, recv_buf + my_off, my_bytes);
   } else {
     P2pIbgdaTransportDevice& prev = *transports[prev_rank];
     P2pIbgdaTransportDevice& next = *transports[next_rank];
     char* dst = use_dst ? (recv_buf + my_off) : nullptr;
-    prev.forward(group, dst, next, my_bytes, num_blocks);
+    prev.forward(group, dst, next, my_bytes);
     if (out != nullptr && group.is_leader()) {
       const auto& prevState = prev.send_recv_state();
       const auto& nextState = next.send_recv_state();

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -244,23 +244,6 @@ MultiPeerIbTransportBase::MultiPeerIbTransportBase(
       nRanks_(nRanks),
       bootstrap_(std::move(bootstrap)),
       config_(std::move(config)) {
-  if (config_.sendRecv.has_value() && config_.sendRecv->maxGroups == 0) {
-    config_.sendRecv->maxGroups = config_.maxGroups;
-  }
-  if (config_.perChannelSize == 0 && config_.sendRecv.has_value()) {
-    config_.max_num_channels = config_.sendRecv->maxGroups;
-    if (config_.max_num_channels <= 0) {
-      throw std::invalid_argument(
-          "sendRecv.maxGroups must be positive for fixed-channel IB");
-    }
-    config_.pipelineDepth = config_.sendRecv->pipelineDepth;
-    const auto channels = static_cast<std::size_t>(config_.max_num_channels);
-    if (config_.dataBufferSize % channels != 0) {
-      throw std::invalid_argument(
-          "IB fixed-channel dataBufferSize must be divisible by max_num_channels");
-    }
-    config_.perChannelSize = config_.dataBufferSize / channels;
-  }
   if (config_.perChannelSize > 0) {
     if (config_.max_num_channels <= 0) {
       throw std::invalid_argument(
@@ -275,9 +258,6 @@ MultiPeerIbTransportBase::MultiPeerIbTransportBase(
           "IB fixed-channel perChannelSize must be 16-byte aligned");
     }
     config_.dataBufferSize = config_.fixedChannelDataBufferSize();
-    config_.sendRecv = MultipeerIbTransportConfig::SendRecvConfig{
-        .maxGroups = config_.max_num_channels,
-        .pipelineDepth = config_.pipelineDepth};
     config_.maxGroups = config_.max_num_channels;
   }
   if (myRank_ < 0 || myRank_ >= nRanks_) {
@@ -352,64 +332,57 @@ MultiPeerIbTransportBase::~MultiPeerIbTransportBase() = default;
 
 // ---- shared send/recv staging-ring lifecycle (eager mode) ----
 
-const MultipeerIbTransportConfig::SendRecvConfig&
-MultiPeerIbTransportBase::sendRecvConfig() const {
-  if (!config_.sendRecv.has_value()) {
+void MultiPeerIbTransportBase::validateSendRecvConfig() const {
+  if (!sendRecvBuffersEnabled()) {
     throw std::runtime_error("MultiPeerIbTransport: send/recv not configured");
   }
-  return *config_.sendRecv;
-}
-
-void MultiPeerIbTransportBase::validateSendRecvConfig() const {
-  const auto& sr = sendRecvConfig();
-  if (sr.pipelineDepth < 1) {
+  if (config_.pipelineDepth < 1) {
     throw std::invalid_argument(
-        "MultiPeerIbTransport: sendRecv.pipelineDepth must be >= 1");
+        "MultiPeerIbTransport: pipelineDepth must be >= 1");
   }
-  if (sr.maxGroups < 1) {
+  if (config_.max_num_channels < 1) {
     throw std::invalid_argument(
-        "MultiPeerIbTransport: sendRecv.maxGroups must be >= 1");
+        "MultiPeerIbTransport: max_num_channels must be >= 1");
   }
   if (config_.dataBufferSize == 0) {
     throw std::invalid_argument(
-        "MultiPeerIbTransport: dataBufferSize must be > 0 when sendRecv is "
+        "MultiPeerIbTransport: dataBufferSize must be > 0 when send/recv is "
         "enabled");
   }
-  if ((config_.dataBufferSize / static_cast<std::size_t>(sr.maxGroups)) < 16) {
+  if ((config_.dataBufferSize /
+       static_cast<std::size_t>(config_.max_num_channels)) < 16) {
     throw std::invalid_argument(
         fmt::format(
-            "MultiPeerIbTransport: dataBufferSize / maxGroups must be >= 16, "
+            "MultiPeerIbTransport: dataBufferSize / max_num_channels must be >= 16, "
             "got {} / {} = {}",
             config_.dataBufferSize,
-            sr.maxGroups,
-            config_.dataBufferSize / sr.maxGroups));
+            config_.max_num_channels,
+            config_.dataBufferSize / config_.max_num_channels));
   }
 }
 
 std::size_t MultiPeerIbTransportBase::sendRecvStagingBytesPerPeer() const {
-  const auto& sr = sendRecvConfig();
-  return static_cast<std::size_t>(sr.pipelineDepth) * config_.dataBufferSize;
+  return static_cast<std::size_t>(config_.pipelineDepth) *
+      config_.dataBufferSize;
 }
 
 std::size_t MultiPeerIbTransportBase::sendRecvSignalBytesPerPeer() const {
-  const auto& sr = sendRecvConfig();
-  return 2 * static_cast<std::size_t>(sr.maxGroups) * sizeof(uint64_t);
+  return 2 * static_cast<std::size_t>(config_.max_num_channels) *
+      sizeof(uint64_t);
 }
 
 std::size_t MultiPeerIbTransportBase::sendRecvCounterBytesPerPeer() const {
-  const auto& sr = sendRecvConfig();
-  return static_cast<std::size_t>(sr.maxGroups) * sizeof(uint64_t);
+  return static_cast<std::size_t>(config_.max_num_channels) * sizeof(uint64_t);
 }
 
 std::size_t MultiPeerIbTransportBase::sendRecvStateBytesPerPeer() const {
-  const auto& sr = sendRecvConfig();
-  return 2 * static_cast<std::size_t>(sr.maxGroups) *
+  return 2 * static_cast<std::size_t>(config_.max_num_channels) *
       sizeof(IbSendRecvState::ProgressSlot);
 }
 
 IbSendRecvState MultiPeerIbTransportBase::sendRecvStateForPeer(
     int peerIndex) const {
-  if (!config_.sendRecv.has_value() || sendRecvPeerBuffers_.empty() ||
+  if (!sendRecvBuffersEnabled() || sendRecvPeerBuffers_.empty() ||
       peerIndex < 0 ||
       peerIndex >= static_cast<int>(sendRecvPeerBuffers_.size())) {
     return {};
@@ -425,15 +398,15 @@ IbSendRecvState MultiPeerIbTransportBase::sendRecvStateForPeer(
       .localCounterBuf = pb.counter,
       .localCounterCompletionBuf = pb.counterCompletion,
       .state = pb.state.value_or(DeviceSpan<IbSendRecvState::ProgressSlot>()),
-      .maxGroups = config_.sendRecv->maxGroups,
-      .pipelineDepth = config_.sendRecv->pipelineDepth,
+      .maxGroups = config_.max_num_channels,
+      .pipelineDepth = config_.pipelineDepth,
       .dataBufferSize = config_.dataBufferSize,
   };
 }
 
 void MultiPeerIbTransportBase::allocateSendRecvBuffersEager(
     IbCounterStorage counterStorage) {
-  if (!config_.sendRecv.has_value()) {
+  if (!sendRecvBuffersEnabled()) {
     return;
   }
   validateSendRecvConfig();
@@ -450,7 +423,7 @@ void MultiPeerIbTransportBase::allocateSendRecvBuffersEager(
   const std::size_t statePerPeer = sendRecvStateBytesPerPeer();
   const auto stateSlotsPerPeer =
       static_cast<DeviceSpan<IbSendRecvState::ProgressSlot>::size_type>(
-          2 * config_.sendRecv->maxGroups);
+          2 * config_.max_num_channels);
 
   // Align every GPU bulk allocation to the CUDA VMM allocation granularity so
   // that any buffer which is later mlx5 Data-Direct (BAR1) registered has a 0
@@ -593,7 +566,7 @@ void MultiPeerIbTransportBase::allocateSendRecvBuffersEager(
 }
 
 void MultiPeerIbTransportBase::exchangeSendRecvBuffersEager() {
-  if (!config_.sendRecv.has_value() || sendRecvPeerBuffers_.empty()) {
+  if (!sendRecvBuffersEnabled() || sendRecvPeerBuffers_.empty()) {
     return;
   }
 
@@ -666,7 +639,7 @@ void MultiPeerIbTransportBase::allocateSendRecvBufferForPeer(
     int peerIndex,
     PeerBufferPayload& payload,
     IbCounterStorage counterStorage) {
-  if (!config_.sendRecv.has_value()) {
+  if (!sendRecvBuffersEnabled()) {
     return;
   }
   validateSendRecvConfig();
@@ -687,7 +660,7 @@ void MultiPeerIbTransportBase::allocateSendRecvBufferForPeer(
   const std::size_t statePerPeer = sendRecvStateBytesPerPeer();
   const auto stateSlots =
       static_cast<DeviceSpan<IbSendRecvState::ProgressSlot>::size_type>(
-          2 * config_.sendRecv->maxGroups);
+          2 * config_.max_num_channels);
   const bool deviceCounter = (counterStorage == IbCounterStorage::Device);
 
   // One contiguous device buffer: sendStaging | recvStaging | signal | state,
@@ -740,7 +713,7 @@ void MultiPeerIbTransportBase::allocateSendRecvBufferForPeer(
 void MultiPeerIbTransportBase::applyRemoteSendRecvBuffer(
     int peerIndex,
     const PeerBufferPayload& remotePayload) {
-  if (!config_.sendRecv.has_value() || peerIndex < 0 ||
+  if (!sendRecvBuffersEnabled() || peerIndex < 0 ||
       peerIndex >= static_cast<int>(sendRecvPeerBuffers_.size())) {
     return;
   }

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -63,9 +63,9 @@ struct MultipeerIbTransportConfig {
   // during auto-discovery (not when gpuNicMap has a mapping for the GPU).
   std::string ibHca;
 
-  // Per-peer data buffer size in bytes. Raw put()/signal() users interpret
-  // this as the exported per-peer RDMA buffer size; send()/recv() users
-  // interpret it as the size of one logical staging slot.
+  // Per-peer data buffer size in bytes for raw put()/signal() users. When
+  // perChannelSize is set for send()/recv(), the transport derives this as
+  // perChannelSize * max_num_channels.
   std::size_t dataBufferSize{0};
 
   // Fixed-channel send/recv staging slice size in bytes. When this is nonzero,
@@ -100,21 +100,6 @@ struct MultipeerIbTransportConfig {
   // qpsPerConnection with the fixed-channel helpers below; IBRC moves to the
   // fixed-channel shape in the following stack diff.
   int qpsPerBlockPerNic{1};
-
-  // Send/recv configuration. When set, the transport allocates a private
-  // pipelined staging ring plus private signal/counter state for send()/recv().
-  // When nullopt (default), only the raw put/signal APIs are available.
-  struct SendRecvConfig {
-    // Maximum number of block-groups that may participate in one send()/recv()
-    // call. Sizes the private signal/counter/step arrays and caps
-    // active_blocks. A value of 0 inherits the top-level maxGroups.
-    int maxGroups{0};
-
-    // Number of logical slots in the send/recv staging ring. Total staging
-    // bytes per peer per direction: pipelineDepth * dataBufferSize.
-    int pipelineDepth{2};
-  };
-  std::optional<SendRecvConfig> sendRecv;
 
   // Queue pair depth (outstanding WQEs per peer). BNXT bumps the default
   // because qpDepth also sizes msn_tbl_sz on bnxt_re.
@@ -186,7 +171,7 @@ struct MultipeerIbTransportConfig {
   }
 
   int fixedChannelDirectionCount() const {
-    return sendRecv.has_value() ? kIbDirections : 1;
+    return perChannelSize > 0 ? kIbDirections : 1;
   }
 
   // mlx5 Data-Direct: register MRs through the NIC's data-direct (BAR1) PCIe
@@ -536,10 +521,11 @@ class MultiPeerIbTransportBase {
   // Backend-agnostic host send/recv buffer management, shared by IBGDA (Device
   // counter, NIC loopback atomic) and IBRC (Host counter, CPU proxy). Staging
   // = pipelineDepth * dataBufferSize per direction; signal/state are sized off
-  // maxGroups. Per-peer staging + signal are device-registered; recvStaging +
-  // signal are collectively exchanged so peers can RDMA into our ring.
+  // max_num_channels. Per-peer staging + signal are device-registered;
+  // recvStaging + signal are collectively exchanged so peers can RDMA into our
+  // ring.
   bool sendRecvBuffersEnabled() const {
-    return config_.sendRecv.has_value();
+    return config_.perChannelSize > 0;
   }
   IbSendRecvState sendRecvStateForPeer(int peerIndex) const;
   // Allocate + register the per-peer staging/signal/state bulks and slice them.
@@ -571,7 +557,6 @@ class MultiPeerIbTransportBase {
   // its views. Safe on an unmaterialized peer.
   void cleanupSendRecvBufferForPeer(int peerIndex) noexcept;
 
-  const MultipeerIbTransportConfig::SendRecvConfig& sendRecvConfig() const;
   void validateSendRecvConfig() const;
   std::size_t sendRecvStagingBytesPerPeer() const;
   std::size_t sendRecvSignalBytesPerPeer() const;

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -496,16 +496,13 @@ __device__ __forceinline__ void P2pIbTransportDevice::send(
     ThreadGroup& group,
     const void* __restrict__ src,
     std::size_t nbytes,
-    int active_blocks,
     std::size_t max_signal_bytes,
     const Timeout& timeout,
     Args... args) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->send<CopyOp>(
-        group, src, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+    ibrc->send<CopyOp>(group, src, nbytes, max_signal_bytes, timeout, args...);
   } else {
-    ibgda->send<CopyOp>(
-        group, src, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+    ibgda->send<CopyOp>(group, src, nbytes, max_signal_bytes, timeout, args...);
   }
 }
 
@@ -514,16 +511,13 @@ __device__ __forceinline__ void P2pIbTransportDevice::recv(
     ThreadGroup& group,
     void* __restrict__ dst,
     std::size_t nbytes,
-    int active_blocks,
     std::size_t max_signal_bytes,
     const Timeout& timeout,
     Args... args) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->recv<CopyOp>(
-        group, dst, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+    ibrc->recv<CopyOp>(group, dst, nbytes, max_signal_bytes, timeout, args...);
   } else {
-    ibgda->recv<CopyOp>(
-        group, dst, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+    ibgda->recv<CopyOp>(group, dst, nbytes, max_signal_bytes, timeout, args...);
   }
 }
 
@@ -533,62 +527,45 @@ __device__ __forceinline__ void P2pIbTransportDevice::forward(
     void* __restrict__ dst,
     P2pIbTransportDevice& fwd,
     std::size_t nbytes,
-    int active_blocks,
     std::size_t max_signal_bytes,
     const Timeout& timeout,
     Args... args) {
   if (type == P2pIbBackendType::IBRC) {
     ibrc->forward<CopyOp>(
-        group,
-        dst,
-        *fwd.ibrc,
-        nbytes,
-        active_blocks,
-        max_signal_bytes,
-        timeout,
-        args...);
+        group, dst, *fwd.ibrc, nbytes, max_signal_bytes, timeout, args...);
   } else {
     ibgda->forward<CopyOp>(
-        group,
-        dst,
-        *fwd.ibgda,
-        nbytes,
-        active_blocks,
-        max_signal_bytes,
-        timeout,
-        args...);
+        group, dst, *fwd.ibgda, nbytes, max_signal_bytes, timeout, args...);
   }
 }
 
-__device__ __forceinline__ std::size_t P2pIbTransportDevice::pipeline_window(
-    int active_blocks) const {
+__device__ __forceinline__ std::size_t P2pIbTransportDevice::pipeline_window()
+    const {
   if (type == P2pIbBackendType::IBRC) {
-    return ibrc->pipeline_window(active_blocks);
+    return ibrc->pipeline_window();
   }
-  return ibgda->pipeline_window(active_blocks);
+  return ibgda->pipeline_window();
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::init_send_progress(
     ThreadGroup& group,
     std::size_t nbytes,
-    int active_blocks,
     std::size_t max_signal_bytes) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->init_send_progress(group, nbytes, active_blocks, max_signal_bytes);
+    ibrc->init_send_progress(group, nbytes, max_signal_bytes);
   } else {
-    ibgda->init_send_progress(group, nbytes, active_blocks, max_signal_bytes);
+    ibgda->init_send_progress(group, nbytes, max_signal_bytes);
   }
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::init_recv_progress(
     ThreadGroup& group,
     std::size_t nbytes,
-    int active_blocks,
     std::size_t max_signal_bytes) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->init_recv_progress(group, nbytes, active_blocks, max_signal_bytes);
+    ibrc->init_recv_progress(group, nbytes, max_signal_bytes);
   } else {
-    ibgda->init_recv_progress(group, nbytes, active_blocks, max_signal_bytes);
+    ibgda->init_recv_progress(group, nbytes, max_signal_bytes);
   }
 }
 
@@ -598,16 +575,15 @@ P2pIbTransportDevice::progress_send_once(
     ThreadGroup& group,
     const void* __restrict__ src,
     std::size_t nbytes,
-    int active_blocks,
     std::size_t max_signal_bytes,
     const Timeout& timeout,
     Args... args) {
   if (type == P2pIbBackendType::IBRC) {
     return ibrc->progress_send_once<CopyOp>(
-        group, src, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+        group, src, nbytes, max_signal_bytes, timeout, args...);
   }
   return ibgda->progress_send_once<CopyOp>(
-      group, src, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+      group, src, nbytes, max_signal_bytes, timeout, args...);
 }
 
 template <typename CopyOp, typename... Args>
@@ -616,16 +592,15 @@ P2pIbTransportDevice::progress_recv_once(
     ThreadGroup& group,
     void* __restrict__ dst,
     std::size_t nbytes,
-    int active_blocks,
     std::size_t max_signal_bytes,
     const Timeout& timeout,
     Args... args) {
   if (type == P2pIbBackendType::IBRC) {
     return ibrc->progress_recv_once<CopyOp>(
-        group, dst, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+        group, dst, nbytes, max_signal_bytes, timeout, args...);
   }
   return ibgda->progress_recv_once<CopyOp>(
-      group, dst, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+      group, dst, nbytes, max_signal_bytes, timeout, args...);
 }
 
 } // namespace comms::prims

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -102,25 +102,14 @@ __device__ __forceinline__ void trace_ibgda_event(
  * common explicit-buffer IB device ops `put` (fused signal+counter),
  * `signal`, `wait_signal`, `wait_counter`, `read_signal`, and `read_counter`.
  *
- * Every public method takes the owning transport as a `Transport& transport`
- * parameter and routes every transport op through it. `P2pIbgdaTransportDevice`
- * and `P2pIbrcTransportDevice` hold one `IbSendRecvDevice sendRecv_` member and
- * delegate their `send`/`recv`/`forward`/progress methods to it, passing
- * `*this` as the transport. The send/recv protocol state lives in
- * `sendRecvState_`, populated by the host transport builder.
+ * Every public method takes the backend-owned `IbSendRecvState` plus the owning
+ * transport as parameters and routes every transport op through that transport.
+ * `P2pIbgdaTransportDevice` and `P2pIbrcTransportDevice` own the state and use
+ * this helper only for the shared send/recv algorithm.
  */
 class IbSendRecvDevice {
  public:
-  IbSendRecvState sendRecvState_{};
-
   __host__ __device__ IbSendRecvDevice() = default;
-
-  __host__ __device__ explicit IbSendRecvDevice(IbSendRecvState initialState)
-      : sendRecvState_(initialState) {}
-
-  __host__ __device__ const IbSendRecvState& send_recv_state() const {
-    return sendRecvState_;
-  }
 
   /**
    * Initialize transport-owned state for one pipelined send operation.
@@ -149,12 +138,13 @@ class IbSendRecvDevice {
    * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
    */
   __device__ __forceinline__ void init_send_progress(
+      IbSendRecvState& sendRecvState,
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    const int progressIndex = progress_send_index(group);
-    auto& slot = progress_state_slot(group, progressIndex);
+    const int progressIndex = progress_send_index(sendRecvState, group);
+    auto& slot = progress_state_slot(sendRecvState, group, progressIndex);
     assert_progress_slot_idle(group, slot, "send");
     IbSendRecvState::ProgressSlot state{};
     state.reuseCreditStep = slot.reuseCreditStep;
@@ -162,15 +152,15 @@ class IbSendRecvDevice {
         ? detail::IbSendRecvProgressStage::Done
         : detail::IbSendRecvProgressStage::WaitNicDone;
     if (nbytes == 0) {
-      store_progress_state(group, progressIndex, state);
+      store_progress_state(sendRecvState, group, progressIndex, state);
       return;
     }
     // Validate the transfer before reserving the transport byte cursor.
     const ProgressGeometry geometry = make_progress_geometry(
-        group, nbytes, max_signal_bytes, "init_send_progress");
-    state.activeBaseStep =
-        reserve_progress_step(group, progressIndex, geometry.protocolBytes);
-    store_progress_state(group, progressIndex, state);
+        sendRecvState, group, nbytes, max_signal_bytes, "init_send_progress");
+    state.activeBaseStep = reserve_progress_step(
+        sendRecvState, group, progressIndex, geometry.protocolBytes);
+    store_progress_state(sendRecvState, group, progressIndex, state);
 #else
     (void)group;
     (void)nbytes;
@@ -203,12 +193,13 @@ class IbSendRecvDevice {
    * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
    */
   __device__ __forceinline__ void init_recv_progress(
+      IbSendRecvState& sendRecvState,
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    const int progressIndex = progress_recv_index(group);
-    auto& slot = progress_state_slot(group, progressIndex);
+    const int progressIndex = progress_recv_index(sendRecvState, group);
+    auto& slot = progress_state_slot(sendRecvState, group, progressIndex);
     assert_progress_slot_idle(group, slot, "recv");
     IbSendRecvState::ProgressSlot state{};
     state.reuseCreditStep = slot.reuseCreditStep;
@@ -216,15 +207,15 @@ class IbSendRecvDevice {
         ? detail::IbSendRecvProgressStage::Done
         : detail::IbSendRecvProgressStage::WaitDataReady;
     if (nbytes == 0) {
-      store_progress_state(group, progressIndex, state);
+      store_progress_state(sendRecvState, group, progressIndex, state);
       return;
     }
     // Validate the transfer before reserving the transport byte cursor.
     const ProgressGeometry geometry = make_progress_geometry(
-        group, nbytes, max_signal_bytes, "init_recv_progress");
-    state.activeBaseStep =
-        reserve_progress_step(group, progressIndex, geometry.protocolBytes);
-    store_progress_state(group, progressIndex, state);
+        sendRecvState, group, nbytes, max_signal_bytes, "init_recv_progress");
+    state.activeBaseStep = reserve_progress_step(
+        sendRecvState, group, progressIndex, geometry.protocolBytes);
+    store_progress_state(sendRecvState, group, progressIndex, state);
 #else
     (void)group;
     (void)nbytes;
@@ -266,6 +257,7 @@ class IbSendRecvDevice {
   template <typename Transport, typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
       Transport& transport,
+      IbSendRecvState& sendRecvState,
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
@@ -278,14 +270,14 @@ class IbSendRecvDevice {
         sizeof(CopyOp) == 0,
         "IbSendRecvDevice::progress_send_once() requires NVIDIA GPU");
 #endif
-    const int progressIndex = progress_send_index(group);
+    const int progressIndex = progress_send_index(sendRecvState, group);
     IbSendRecvState::ProgressSlot state =
-        progress_state_slot(group, progressIndex);
+        progress_state_slot(sendRecvState, group, progressIndex);
     if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
       return IbgdaSendRecvProgressStatus::Done;
     }
     const ProgressGeometry progress_params = make_progress_geometry(
-        group, nbytes, max_signal_bytes, "progress_send_once");
+        sendRecvState, group, nbytes, max_signal_bytes, "progress_send_once");
     if (state.activeNextByte >= progress_params.protocolBytes) {
       if (group.is_leader()) {
         printf(
@@ -301,17 +293,18 @@ class IbSendRecvDevice {
     const detail::IbSendRecvProgressStage initialStage = state.activeStage;
     const std::size_t initialNextByte = state.activeNextByte;
     const std::size_t pipelineBytes = progress_params.perBlockSlot *
-        static_cast<std::size_t>(sendRecvState_.pipelineDepth);
+        static_cast<std::size_t>(sendRecvState.pipelineDepth);
 
     if (state.activeStage == detail::IbSendRecvProgressStage::WaitNicDone) {
-      const ProgressChunk chunk = next_chunk(state, progress_params);
+      const ProgressChunk chunk =
+          next_chunk(sendRecvState, state, progress_params);
       if (chunk.streamEnd > pipelineBytes) {
         const uint64_t expected = chunk.streamEnd - pipelineBytes;
         uint32_t ready = 1;
         unsigned long long current = 0;
         if (group.is_leader()) {
           current = static_cast<unsigned long long>(
-              transport.read_counter(sendRecvState_.localCounterBuf.subBuffer(
+              transport.read_counter(sendRecvState.localCounterBuf.subBuffer(
                   progress_params.groupId * sizeof(uint64_t))));
           ready = current >= expected ? 1U : 0U;
           if (!ready) {
@@ -333,7 +326,7 @@ class IbSendRecvDevice {
           chunk.dataOff, chunk.bytes, progress_params.payloadBytes);
       if (validBytes > 0) {
         CopyOp::send(
-            sendRecvState_.sendStagingPtr + chunk.stagingOff,
+            sendRecvState.sendStagingPtr + chunk.stagingOff,
             static_cast<const char*>(src) + chunk.dataOff,
             validBytes,
             group,
@@ -346,15 +339,16 @@ class IbSendRecvDevice {
     }
 
     if (state.activeStage == detail::IbSendRecvProgressStage::WaitSlotFree) {
-      const ProgressChunk chunk = next_chunk(state, progress_params);
+      const ProgressChunk chunk =
+          next_chunk(sendRecvState, state, progress_params);
       if (chunk.streamEnd > pipelineBytes) {
         const uint64_t expected = chunk.streamEnd - pipelineBytes;
         uint32_t ready = 1;
         unsigned long long current = 0;
         if (group.is_leader()) {
           current = static_cast<unsigned long long>(
-              transport.read_signal(sendRecvState_.localSignalBuf.subBuffer(
-                  (sendRecvState_.maxGroups + progress_params.groupId) *
+              transport.read_signal(sendRecvState.localSignalBuf.subBuffer(
+                  (sendRecvState.maxGroups + progress_params.groupId) *
                   sizeof(uint64_t))));
           ready = current >= expected ? 1U : 0U;
           if (!ready) {
@@ -370,7 +364,7 @@ class IbSendRecvDevice {
         if (!ready) {
           if (state.activeStage != initialStage ||
               state.activeNextByte != initialNextByte) {
-            store_progress_state(group, progressIndex, state);
+            store_progress_state(sendRecvState, group, progressIndex, state);
             return IbgdaSendRecvProgressStatus::Progressed;
           }
           return IbgdaSendRecvProgressStatus::Waiting;
@@ -383,10 +377,13 @@ class IbSendRecvDevice {
       uint64_t counterVal = 0;
       if (group.is_leader()) {
         if (should_post_nic_done_credit(
-                chunk.streamEnd, state.reuseCreditStep, progress_params)) {
+                sendRecvState,
+                chunk.streamEnd,
+                state.reuseCreditStep,
+                progress_params)) {
           counterVal =
               reuse_credit_value(chunk.streamEnd, state.reuseCreditStep);
-          counterBuf = sendRecvState_.localCounterCompletionBuf.subBuffer(
+          counterBuf = sendRecvState.localCounterCompletionBuf.subBuffer(
               progress_params.groupId * sizeof(uint64_t));
           state.reuseCreditStep = static_cast<int64_t>(chunk.streamEnd);
         }
@@ -394,10 +391,10 @@ class IbSendRecvDevice {
             0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
         transport.put(
             solo,
-            sendRecvState_.sendStagingBuf.subBuffer(chunk.stagingOff),
-            sendRecvState_.recvStagingBuf.subBuffer(chunk.stagingOff),
+            sendRecvState.sendStagingBuf.subBuffer(chunk.stagingOff),
+            sendRecvState.recvStagingBuf.subBuffer(chunk.stagingOff),
             chunk.bytes,
-            sendRecvState_.remoteSignalBuf.subBuffer(
+            sendRecvState.remoteSignalBuf.subBuffer(
                 progress_params.groupId * sizeof(uint64_t)),
             chunk.bytes,
             counterBuf,
@@ -409,7 +406,7 @@ class IbSendRecvDevice {
       if (state.activeNextByte >= progress_params.protocolBytes) {
         transition_progress_stage(
             group, state, detail::IbSendRecvProgressStage::Done);
-        store_progress_state(group, progressIndex, state);
+        store_progress_state(sendRecvState, group, progressIndex, state);
         return IbgdaSendRecvProgressStatus::Done;
       }
       transition_progress_stage(
@@ -421,7 +418,7 @@ class IbSendRecvDevice {
     // advances. Check both fields so that case reports Progressed.
     if (state.activeStage != initialStage ||
         state.activeNextByte != initialNextByte) {
-      store_progress_state(group, progressIndex, state);
+      store_progress_state(sendRecvState, group, progressIndex, state);
       return IbgdaSendRecvProgressStatus::Progressed;
     }
     return IbgdaSendRecvProgressStatus::Waiting;
@@ -467,6 +464,7 @@ class IbSendRecvDevice {
   template <typename Transport, typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
       Transport& transport,
+      IbSendRecvState& sendRecvState,
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
@@ -479,14 +477,14 @@ class IbSendRecvDevice {
         sizeof(CopyOp) == 0,
         "IbSendRecvDevice::progress_recv_once() requires NVIDIA GPU");
 #endif
-    const int progressIndex = progress_recv_index(group);
+    const int progressIndex = progress_recv_index(sendRecvState, group);
     IbSendRecvState::ProgressSlot state =
-        progress_state_slot(group, progressIndex);
+        progress_state_slot(sendRecvState, group, progressIndex);
     if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
       return IbgdaSendRecvProgressStatus::Done;
     }
     const ProgressGeometry progress_params = make_progress_geometry(
-        group, nbytes, max_signal_bytes, "progress_recv_once");
+        sendRecvState, group, nbytes, max_signal_bytes, "progress_recv_once");
     if (state.activeNextByte >= progress_params.protocolBytes) {
       if (group.is_leader()) {
         printf(
@@ -499,13 +497,14 @@ class IbSendRecvDevice {
     }
     validate_recv_progress_stage(group, state);
 
-    const ProgressChunk chunk = next_chunk(state, progress_params);
+    const ProgressChunk chunk =
+        next_chunk(sendRecvState, state, progress_params);
     const uint64_t expected = chunk.streamEnd;
     uint32_t ready = 1;
     unsigned long long current = 0;
     if (group.is_leader()) {
       current = static_cast<unsigned long long>(
-          transport.read_signal(sendRecvState_.localSignalBuf.subBuffer(
+          transport.read_signal(sendRecvState.localSignalBuf.subBuffer(
               progress_params.groupId * sizeof(uint64_t))));
       ready = current >= expected ? 1U : 0U;
       if (!ready) {
@@ -527,7 +526,7 @@ class IbSendRecvDevice {
     if (validBytes > 0) {
       CopyOp::recv(
           static_cast<char*>(dst) + chunk.dataOff,
-          sendRecvState_.recvStagingPtr + chunk.stagingOff,
+          sendRecvState.recvStagingPtr + chunk.stagingOff,
           validBytes,
           group,
           chunk.dataOff,
@@ -538,7 +537,10 @@ class IbSendRecvDevice {
     uint64_t slotFreeVal = 0;
     if (group.is_leader()) {
       if (should_post_slot_free_credit(
-              chunk.streamEnd, state.reuseCreditStep, progress_params)) {
+              sendRecvState,
+              chunk.streamEnd,
+              state.reuseCreditStep,
+              progress_params)) {
         slotFreeVal =
             reuse_credit_value(chunk.streamEnd, state.reuseCreditStep);
         state.reuseCreditStep = static_cast<int64_t>(chunk.streamEnd);
@@ -548,8 +550,8 @@ class IbSendRecvDevice {
     if (slotFreeVal != 0) {
       transport.signal(
           group,
-          sendRecvState_.remoteSignalBuf.subBuffer(
-              (sendRecvState_.maxGroups + progress_params.groupId) *
+          sendRecvState.remoteSignalBuf.subBuffer(
+              (sendRecvState.maxGroups + progress_params.groupId) *
               sizeof(uint64_t)),
           slotFreeVal,
           IbDirection::Recv);
@@ -559,11 +561,11 @@ class IbSendRecvDevice {
     if (state.activeNextByte >= progress_params.protocolBytes) {
       transition_progress_stage(
           group, state, detail::IbSendRecvProgressStage::Done);
-      store_progress_state(group, progressIndex, state);
+      store_progress_state(sendRecvState, group, progressIndex, state);
       return IbgdaSendRecvProgressStatus::Done;
     }
 
-    store_progress_state(group, progressIndex, state);
+    store_progress_state(sendRecvState, group, progressIndex, state);
     return IbgdaSendRecvProgressStatus::Progressed;
 #else
     (void)transport;
@@ -616,6 +618,7 @@ class IbSendRecvDevice {
   template <typename Transport, typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void send(
       Transport& transport,
+      IbSendRecvState& sendRecvState,
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
@@ -636,7 +639,7 @@ class IbSendRecvDevice {
     const std::size_t protocolBytes = align_protocol_bytes(nbytes);
 
     const int groupId = group.group_id;
-    const int maxGroups = sendRecvState_.maxGroups;
+    const int maxGroups = sendRecvState.maxGroups;
     if (groupId >= maxGroups) {
       if (group.is_leader()) {
         printf(
@@ -648,13 +651,13 @@ class IbSendRecvDevice {
     }
 
     const std::size_t perBlockSlot =
-        (sendRecvState_.dataBufferSize / maxGroups) & ~15ULL;
+        (sendRecvState.dataBufferSize / maxGroups) & ~15ULL;
     if (perBlockSlot == 0) {
       if (group.is_leader()) {
         printf(
             "[PIPES] FATAL: send perBlockSlot=0 "
             "(dataBufferSize=%llu, maxGroups=%d)\n",
-            (unsigned long long)sendRecvState_.dataBufferSize,
+            (unsigned long long)sendRecvState.dataBufferSize,
             maxGroups);
       }
       PIPES_DEVICE_TRAP();
@@ -668,10 +671,10 @@ class IbSendRecvDevice {
       chunkSize = perBlockSlot;
     }
 
-    const int pipelineDepth = sendRecvState_.pipelineDepth;
-    const std::size_t dataBufferSize = sendRecvState_.dataBufferSize;
-    const int stateIndex = progress_send_index(group);
-    auto& state = progress_state_slot(group, stateIndex);
+    const int pipelineDepth = sendRecvState.pipelineDepth;
+    const std::size_t dataBufferSize = sendRecvState.dataBufferSize;
+    const int stateIndex = progress_send_index(sendRecvState, group);
+    auto& state = progress_state_slot(sendRecvState, group, stateIndex);
     assert_progress_slot_idle(group, state, "send");
     const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
     const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
@@ -701,8 +704,7 @@ class IbSendRecvDevice {
       if (streamEnd > pipelineBytes) {
         transport.wait_counter(
             group,
-            sendRecvState_.localCounterBuf.subBuffer(
-                groupId * sizeof(uint64_t)),
+            sendRecvState.localCounterBuf.subBuffer(groupId * sizeof(uint64_t)),
             streamEnd - pipelineBytes,
             timeout);
       }
@@ -712,7 +714,7 @@ class IbSendRecvDevice {
           valid_payload_bytes(dataOff, bytesThis, nbytes);
       if (validBytes > 0) {
         CopyOp::send(
-            sendRecvState_.sendStagingPtr + stagingOff,
+            sendRecvState.sendStagingPtr + stagingOff,
             static_cast<const char*>(src) + dataOff,
             validBytes,
             group,
@@ -726,7 +728,7 @@ class IbSendRecvDevice {
       if (streamEnd > pipelineBytes) {
         transport.wait_signal(
             group,
-            sendRecvState_.localSignalBuf.subBuffer(
+            sendRecvState.localSignalBuf.subBuffer(
                 (maxGroups + groupId) * sizeof(uint64_t)),
             streamEnd - pipelineBytes,
             timeout);
@@ -741,9 +743,12 @@ class IbSendRecvDevice {
         IbgdaLocalBuffer counterBuf{};
         uint64_t counterVal = 0;
         if (should_post_nic_done_credit(
-                streamEnd, state.reuseCreditStep, perBlockSlot)) {
+                sendRecvState,
+                streamEnd,
+                state.reuseCreditStep,
+                perBlockSlot)) {
           counterVal = reuse_credit_value(streamEnd, state.reuseCreditStep);
-          counterBuf = sendRecvState_.localCounterCompletionBuf.subBuffer(
+          counterBuf = sendRecvState.localCounterCompletionBuf.subBuffer(
               groupId * sizeof(uint64_t));
           state.reuseCreditStep = static_cast<int64_t>(streamEnd);
         }
@@ -751,11 +756,10 @@ class IbSendRecvDevice {
             0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
         transport.put(
             solo,
-            sendRecvState_.sendStagingBuf.subBuffer(stagingOff),
-            sendRecvState_.recvStagingBuf.subBuffer(stagingOff),
+            sendRecvState.sendStagingBuf.subBuffer(stagingOff),
+            sendRecvState.recvStagingBuf.subBuffer(stagingOff),
             bytesThis,
-            sendRecvState_.remoteSignalBuf.subBuffer(
-                groupId * sizeof(uint64_t)),
+            sendRecvState.remoteSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
             bytesThis,
             counterBuf,
             counterVal);
@@ -804,6 +808,7 @@ class IbSendRecvDevice {
   template <typename Transport, typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void recv(
       Transport& transport,
+      IbSendRecvState& sendRecvState,
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
@@ -824,7 +829,7 @@ class IbSendRecvDevice {
     const std::size_t protocolBytes = align_protocol_bytes(nbytes);
 
     const int groupId = group.group_id;
-    const int maxGroups = sendRecvState_.maxGroups;
+    const int maxGroups = sendRecvState.maxGroups;
     if (groupId >= maxGroups) {
       if (group.is_leader()) {
         printf(
@@ -836,13 +841,13 @@ class IbSendRecvDevice {
     }
 
     const std::size_t perBlockSlot =
-        (sendRecvState_.dataBufferSize / maxGroups) & ~15ULL;
+        (sendRecvState.dataBufferSize / maxGroups) & ~15ULL;
     if (perBlockSlot == 0) {
       if (group.is_leader()) {
         printf(
             "[PIPES] FATAL: recv perBlockSlot=0 "
             "(dataBufferSize=%llu, maxGroups=%d)\n",
-            (unsigned long long)sendRecvState_.dataBufferSize,
+            (unsigned long long)sendRecvState.dataBufferSize,
             maxGroups);
       }
       PIPES_DEVICE_TRAP();
@@ -856,10 +861,10 @@ class IbSendRecvDevice {
       chunkSize = perBlockSlot;
     }
 
-    const int pipelineDepth = sendRecvState_.pipelineDepth;
-    const std::size_t dataBufferSize = sendRecvState_.dataBufferSize;
-    const int stateIndex = progress_recv_index(group);
-    auto& state = progress_state_slot(group, stateIndex);
+    const int pipelineDepth = sendRecvState.pipelineDepth;
+    const std::size_t dataBufferSize = sendRecvState.dataBufferSize;
+    const int stateIndex = progress_recv_index(sendRecvState, group);
+    auto& state = progress_state_slot(sendRecvState, group, stateIndex);
     assert_progress_slot_idle(group, state, "recv");
     const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
     const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
@@ -888,7 +893,7 @@ class IbSendRecvDevice {
       // (1) Wait for sender's DATA_READY signal.
       transport.wait_signal(
           group,
-          sendRecvState_.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
+          sendRecvState.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
           streamEnd,
           timeout);
 
@@ -898,7 +903,7 @@ class IbSendRecvDevice {
       if (validBytes > 0) {
         CopyOp::recv(
             static_cast<char*>(dst) + dataOff,
-            sendRecvState_.recvStagingPtr + stagingOff,
+            sendRecvState.recvStagingPtr + stagingOff,
             validBytes,
             group,
             dataOff,
@@ -911,7 +916,10 @@ class IbSendRecvDevice {
       uint64_t slotFreeVal = 0;
       if (group.is_leader()) {
         if (should_post_slot_free_credit(
-                streamEnd, state.reuseCreditStep, perBlockSlot)) {
+                sendRecvState,
+                streamEnd,
+                state.reuseCreditStep,
+                perBlockSlot)) {
           slotFreeVal = reuse_credit_value(streamEnd, state.reuseCreditStep);
           state.reuseCreditStep = static_cast<int64_t>(streamEnd);
         }
@@ -920,7 +928,7 @@ class IbSendRecvDevice {
       if (slotFreeVal != 0) {
         transport.signal(
             group,
-            sendRecvState_.remoteSignalBuf.subBuffer(
+            sendRecvState.remoteSignalBuf.subBuffer(
                 (maxGroups + groupId) * sizeof(uint64_t)),
             slotFreeVal,
             IbDirection::Recv);
@@ -993,9 +1001,11 @@ class IbSendRecvDevice {
   template <typename CopyOp = Memcpy, typename Transport, typename... Args>
   __device__ __forceinline__ void forward(
       Transport& transport,
+      IbSendRecvState& sendRecvState,
       ThreadGroup& group,
       void* __restrict__ dst,
       IbSendRecvDevice& fwdDevice,
+      IbSendRecvState& fwdSendRecvState,
       Transport& fwdTransport,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
@@ -1015,7 +1025,7 @@ class IbSendRecvDevice {
     const int groupId = group.group_id;
 
     // --- recv side (this transport) ---
-    const int recvMaxGroups = sendRecvState_.maxGroups;
+    const int recvMaxGroups = sendRecvState.maxGroups;
     if (groupId >= recvMaxGroups) {
       if (group.is_leader()) {
         printf(
@@ -1027,7 +1037,7 @@ class IbSendRecvDevice {
     }
 
     const std::size_t recvPerBlockSlot =
-        (sendRecvState_.dataBufferSize / recvMaxGroups) & ~15ULL;
+        (sendRecvState.dataBufferSize / recvMaxGroups) & ~15ULL;
     if (recvPerBlockSlot == 0) {
       if (group.is_leader()) {
         printf("[PIPES] FATAL: forward recvPerBlockSlot=0\n");
@@ -1036,7 +1046,7 @@ class IbSendRecvDevice {
     }
 
     // --- fwd side (fwd transport) ---
-    const int fwdMaxGroups = fwdDevice.sendRecvState_.maxGroups;
+    const int fwdMaxGroups = fwdSendRecvState.maxGroups;
     if (groupId >= fwdMaxGroups) {
       if (group.is_leader()) {
         printf(
@@ -1048,7 +1058,7 @@ class IbSendRecvDevice {
     }
 
     const std::size_t fwdPerBlockSlot =
-        (fwdDevice.sendRecvState_.dataBufferSize / fwdMaxGroups) & ~15ULL;
+        (fwdSendRecvState.dataBufferSize / fwdMaxGroups) & ~15ULL;
     if (fwdPerBlockSlot == 0) {
       if (group.is_leader()) {
         printf("[PIPES] FATAL: forward fwdPerBlockSlot=0\n");
@@ -1072,18 +1082,21 @@ class IbSendRecvDevice {
       fwdChunkSize = fwdPerBlockSlot;
     }
 
-    const int recvPipelineDepth = sendRecvState_.pipelineDepth;
-    const std::size_t recvDataBufSize = sendRecvState_.dataBufferSize;
-    const int recvStateIndex = progress_recv_index(group);
-    auto& recvSlotState = progress_state_slot(group, recvStateIndex);
+    const int recvPipelineDepth = sendRecvState.pipelineDepth;
+    const std::size_t recvDataBufSize = sendRecvState.dataBufferSize;
+    const int recvStateIndex = progress_recv_index(sendRecvState, group);
+    auto& recvSlotState =
+        progress_state_slot(sendRecvState, group, recvStateIndex);
     assert_progress_slot_idle(group, recvSlotState, "forward recv");
     const uint64_t recvBaseByte = static_cast<uint64_t>(recvSlotState.nextStep);
     const std::size_t recvPipelineBytes = recvPerBlockSlot * recvPipelineDepth;
 
-    const int fwdPipelineDepth = fwdDevice.sendRecvState_.pipelineDepth;
-    const std::size_t fwdDataBufSize = fwdDevice.sendRecvState_.dataBufferSize;
-    const int fwdStateIndex = fwdDevice.progress_send_index(group);
-    auto& fwdSlotState = fwdDevice.progress_state_slot(group, fwdStateIndex);
+    const int fwdPipelineDepth = fwdSendRecvState.pipelineDepth;
+    const std::size_t fwdDataBufSize = fwdSendRecvState.dataBufferSize;
+    const int fwdStateIndex =
+        fwdDevice.progress_send_index(fwdSendRecvState, group);
+    auto& fwdSlotState =
+        fwdDevice.progress_state_slot(fwdSendRecvState, group, fwdStateIndex);
     fwdDevice.assert_progress_slot_idle(group, fwdSlotState, "forward send");
     const uint64_t fwdBaseByte = static_cast<uint64_t>(fwdSlotState.nextStep);
     const std::size_t fwdPipelineBytes = fwdPerBlockSlot * fwdPipelineDepth;
@@ -1132,7 +1145,7 @@ class IbSendRecvDevice {
       // (1) Wait for sender's DATA_READY.
       transport.wait_signal(
           group,
-          sendRecvState_.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
+          sendRecvState.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
           recvStreamEnd,
           timeout);
 
@@ -1140,7 +1153,7 @@ class IbSendRecvDevice {
       if (fwdStreamEnd > fwdPipelineBytes) {
         fwdTransport.wait_counter(
             group,
-            fwdDevice.sendRecvState_.localCounterBuf.subBuffer(
+            fwdSendRecvState.localCounterBuf.subBuffer(
                 groupId * sizeof(uint64_t)),
             fwdStreamEnd - fwdPipelineBytes,
             timeout);
@@ -1152,8 +1165,8 @@ class IbSendRecvDevice {
       if (validBytes > 0) {
         CopyOp::forward(
             dst ? static_cast<char*>(dst) + dataOff : nullptr,
-            fwdDevice.sendRecvState_.sendStagingPtr + fwdStagingOff,
-            sendRecvState_.recvStagingPtr + recvStagingOff,
+            fwdSendRecvState.sendStagingPtr + fwdStagingOff,
+            sendRecvState.recvStagingPtr + recvStagingOff,
             validBytes,
             group,
             dataOff,
@@ -1167,7 +1180,7 @@ class IbSendRecvDevice {
       //     computes reuse credit from a current cursor.
       transport.signal(
           group,
-          sendRecvState_.remoteSignalBuf.subBuffer(
+          sendRecvState.remoteSignalBuf.subBuffer(
               (recvMaxGroups + groupId) * sizeof(uint64_t)),
           bytesThis,
           IbDirection::Recv);
@@ -1180,7 +1193,7 @@ class IbSendRecvDevice {
       if (fwdStreamEnd > fwdPipelineBytes) {
         fwdTransport.wait_signal(
             group,
-            fwdDevice.sendRecvState_.localSignalBuf.subBuffer(
+            fwdSendRecvState.localSignalBuf.subBuffer(
                 (fwdMaxGroups + groupId) * sizeof(uint64_t)),
             fwdStreamEnd - fwdPipelineBytes,
             timeout);
@@ -1195,13 +1208,13 @@ class IbSendRecvDevice {
             0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
         fwdTransport.put(
             solo,
-            fwdDevice.sendRecvState_.sendStagingBuf.subBuffer(fwdStagingOff),
-            fwdDevice.sendRecvState_.recvStagingBuf.subBuffer(fwdStagingOff),
+            fwdSendRecvState.sendStagingBuf.subBuffer(fwdStagingOff),
+            fwdSendRecvState.recvStagingBuf.subBuffer(fwdStagingOff),
             bytesThis,
-            fwdDevice.sendRecvState_.remoteSignalBuf.subBuffer(
+            fwdSendRecvState.remoteSignalBuf.subBuffer(
                 groupId * sizeof(uint64_t)),
             bytesThis,
-            fwdDevice.sendRecvState_.localCounterCompletionBuf.subBuffer(
+            fwdSendRecvState.localCounterCompletionBuf.subBuffer(
                 groupId * sizeof(uint64_t)),
             bytesThis);
       }
@@ -1224,9 +1237,11 @@ class IbSendRecvDevice {
     group.sync();
 #else
     (void)transport;
+    (void)sendRecvState;
     (void)group;
     (void)dst;
     (void)fwdDevice;
+    (void)fwdSendRecvState;
     (void)fwdTransport;
     (void)nbytes;
     (void)max_signal_bytes;
@@ -1245,10 +1260,11 @@ class IbSendRecvDevice {
    * Callers should loop over their data in pipeline_window-sized chunks so
    * that send()/forward() never stall waiting for a free slot.
    */
-  __device__ __forceinline__ std::size_t pipeline_window() const {
+  __device__ __forceinline__ std::size_t pipeline_window(
+      const IbSendRecvState& sendRecvState) const {
     const std::size_t per_block_slot =
-        (sendRecvState_.dataBufferSize / sendRecvState_.maxGroups) & ~15ULL;
-    return per_block_slot * sendRecvState_.pipelineDepth;
+        (sendRecvState.dataBufferSize / sendRecvState.maxGroups) & ~15ULL;
+    return per_block_slot * sendRecvState.pipelineDepth;
   }
 
  private:
@@ -1312,10 +1328,13 @@ class IbSendRecvDevice {
   /**
    * Return the internal send progress slot index for `group`.
    */
-  __device__ __forceinline__ int progress_send_index(ThreadGroup& group) const {
+  __device__ __forceinline__ int progress_send_index(
+      const IbSendRecvState& sendRecvState,
+      ThreadGroup& group) const {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    return progress_index_for_group(group, 0);
+    return progress_index_for_group(sendRecvState, group, 0);
 #else
+    (void)sendRecvState;
     (void)group;
     return 0;
 #endif
@@ -1324,10 +1343,14 @@ class IbSendRecvDevice {
   /**
    * Return the internal recv progress slot index for `group`.
    */
-  __device__ __forceinline__ int progress_recv_index(ThreadGroup& group) const {
+  __device__ __forceinline__ int progress_recv_index(
+      const IbSendRecvState& sendRecvState,
+      ThreadGroup& group) const {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    return progress_index_for_group(group, sendRecvState_.maxGroups);
+    return progress_index_for_group(
+        sendRecvState, group, sendRecvState.maxGroups);
 #else
+    (void)sendRecvState;
     (void)group;
     return 0;
 #endif
@@ -1337,35 +1360,35 @@ class IbSendRecvDevice {
    * Validate a progress group and map it into the transport-owned slot array.
    */
   __device__ __forceinline__ int progress_index_for_group(
+      const IbSendRecvState& sendRecvState,
       ThreadGroup& group,
       int baseIndex) const {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    if (sendRecvState_.state.empty() ||
-        sendRecvState_.state.data() == nullptr) {
+    if (sendRecvState.state.empty() || sendRecvState.state.data() == nullptr) {
       if (group.is_leader()) {
         printf("[PIPES] FATAL: send/recv state is null\n");
       }
       PIPES_DEVICE_TRAP();
     }
-    if (sendRecvState_.maxGroups <= 0) {
+    if (sendRecvState.maxGroups <= 0) {
       if (group.is_leader()) {
         printf(
             "[PIPES] FATAL: send/recv maxGroups must be > 0, got %d\n",
-            sendRecvState_.maxGroups);
+            sendRecvState.maxGroups);
       }
       PIPES_DEVICE_TRAP();
     }
     const auto requiredStateSlots =
-        static_cast<uint32_t>(2 * sendRecvState_.maxGroups);
-    if (sendRecvState_.state.size() < requiredStateSlots ||
-        group.group_id >= static_cast<uint32_t>(sendRecvState_.maxGroups)) {
+        static_cast<uint32_t>(2 * sendRecvState.maxGroups);
+    if (sendRecvState.state.size() < requiredStateSlots ||
+        group.group_id >= static_cast<uint32_t>(sendRecvState.maxGroups)) {
       if (group.is_leader()) {
         printf(
             "[PIPES] FATAL: progress group_id=%u out of range [0, %d), "
             "state slots=%u\n",
             group.group_id,
-            sendRecvState_.maxGroups,
-            static_cast<unsigned>(sendRecvState_.state.size()));
+            sendRecvState.maxGroups,
+            static_cast<unsigned>(sendRecvState.state.size()));
       }
       PIPES_DEVICE_TRAP();
     }
@@ -1381,10 +1404,11 @@ class IbSendRecvDevice {
    * Return a reference to a transport-owned progress state slot.
    */
   __device__ __forceinline__ IbSendRecvState::ProgressSlot& progress_state_slot(
+      IbSendRecvState& sendRecvState,
       ThreadGroup& group,
       int progressIndex) const {
     (void)group;
-    return sendRecvState_.state[progressIndex];
+    return sendRecvState.state[progressIndex];
   }
 
   /**
@@ -1429,12 +1453,13 @@ class IbSendRecvDevice {
    * The trailing sync orders the leader's store before later group work.
    */
   __device__ __forceinline__ void store_progress_state(
+      IbSendRecvState& sendRecvState,
       ThreadGroup& group,
       int progressIndex,
       const IbSendRecvState::ProgressSlot& state) const {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (group.is_leader()) {
-      auto& slot = sendRecvState_.state[progressIndex];
+      auto& slot = sendRecvState.state[progressIndex];
       slot.reuseCreditStep = state.reuseCreditStep;
       slot.activeNextByte = state.activeNextByte;
       slot.activeBaseStep = state.activeBaseStep;
@@ -1469,6 +1494,7 @@ class IbSendRecvDevice {
    * protocol counts here; copy callbacks still see only valid payload bytes.
    */
   __device__ __forceinline__ ProgressGeometry make_progress_geometry(
+      const IbSendRecvState& sendRecvState,
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes,
@@ -1484,7 +1510,7 @@ class IbSendRecvDevice {
       PIPES_DEVICE_TRAP();
     }
     const int groupId = static_cast<int>(group.group_id);
-    const int maxGroups = sendRecvState_.maxGroups;
+    const int maxGroups = sendRecvState.maxGroups;
     if (groupId < 0 || groupId >= maxGroups) {
       if (group.is_leader()) {
         printf(
@@ -1497,14 +1523,14 @@ class IbSendRecvDevice {
     }
 
     const std::size_t perBlockSlot =
-        (sendRecvState_.dataBufferSize / maxGroups) & ~15ULL;
+        (sendRecvState.dataBufferSize / maxGroups) & ~15ULL;
     if (perBlockSlot == 0) {
       if (group.is_leader()) {
         printf(
             "[PIPES] FATAL: %s perBlockSlot=0 "
             "(dataBufferSize=%llu, maxGroups=%d)\n",
             opName,
-            (unsigned long long)sendRecvState_.dataBufferSize,
+            (unsigned long long)sendRecvState.dataBufferSize,
             maxGroups);
       }
       PIPES_DEVICE_TRAP();
@@ -1535,47 +1561,57 @@ class IbSendRecvDevice {
   }
 
   __device__ __forceinline__ std::size_t nic_done_credit_quantum(
+      const IbSendRecvState& sendRecvState,
       std::size_t perBlockSlot) const {
     return detail::ib_send_recv_nic_done_credit_quantum(
-        perBlockSlot, sendRecvState_.pipelineDepth);
+        perBlockSlot, sendRecvState.pipelineDepth);
   }
 
   __device__ __forceinline__ std::size_t slot_free_credit_quantum(
+      const IbSendRecvState& sendRecvState,
       std::size_t perBlockSlot) const {
     return detail::ib_send_recv_slot_free_credit_quantum(
-        perBlockSlot, sendRecvState_.pipelineDepth);
+        perBlockSlot, sendRecvState.pipelineDepth);
   }
 
   __device__ __forceinline__ bool should_post_nic_done_credit(
+      const IbSendRecvState& sendRecvState,
       uint64_t streamEnd,
       int64_t reuseCreditStep,
       const ProgressGeometry& geometry) const {
     return should_post_nic_done_credit(
-        streamEnd, reuseCreditStep, geometry.perBlockSlot);
+        sendRecvState, streamEnd, reuseCreditStep, geometry.perBlockSlot);
   }
 
   __device__ __forceinline__ bool should_post_nic_done_credit(
+      const IbSendRecvState& sendRecvState,
       uint64_t streamEnd,
       int64_t reuseCreditStep,
       std::size_t perBlockSlot) const {
     return should_post_credit_at_quantum(
-        streamEnd, reuseCreditStep, nic_done_credit_quantum(perBlockSlot));
+        streamEnd,
+        reuseCreditStep,
+        nic_done_credit_quantum(sendRecvState, perBlockSlot));
   }
 
   __device__ __forceinline__ bool should_post_slot_free_credit(
+      const IbSendRecvState& sendRecvState,
       uint64_t streamEnd,
       int64_t reuseCreditStep,
       const ProgressGeometry& geometry) const {
     return should_post_slot_free_credit(
-        streamEnd, reuseCreditStep, geometry.perBlockSlot);
+        sendRecvState, streamEnd, reuseCreditStep, geometry.perBlockSlot);
   }
 
   __device__ __forceinline__ bool should_post_slot_free_credit(
+      const IbSendRecvState& sendRecvState,
       uint64_t streamEnd,
       int64_t reuseCreditStep,
       std::size_t perBlockSlot) const {
     return should_post_credit_at_quantum(
-        streamEnd, reuseCreditStep, slot_free_credit_quantum(perBlockSlot));
+        streamEnd,
+        reuseCreditStep,
+        slot_free_credit_quantum(sendRecvState, perBlockSlot));
   }
 
   __device__ __forceinline__ bool should_post_credit_at_quantum(
@@ -1606,13 +1642,14 @@ class IbSendRecvDevice {
    * blocking calls start after all in-flight progress ranges.
    */
   __device__ __forceinline__ int64_t reserve_progress_step(
+      IbSendRecvState& sendRecvState,
       ThreadGroup& group,
       int stateIndex,
       std::size_t nbytes) const {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     uint64_t baseStep = 0;
     if (group.is_leader()) {
-      auto& slot = sendRecvState_.state[stateIndex];
+      auto& slot = sendRecvState.state[stateIndex];
       baseStep = static_cast<uint64_t>(slot.nextStep);
       slot.nextStep = static_cast<int64_t>(baseStep + nbytes);
     }
@@ -1737,17 +1774,18 @@ class IbSendRecvDevice {
    * staging slots.
    */
   __device__ __forceinline__ ProgressChunk next_chunk(
+      const IbSendRecvState& sendRecvState,
       const IbSendRecvState::ProgressSlot& state,
       const ProgressGeometry& geometry) const {
     const uint64_t streamStart =
         static_cast<uint64_t>(state.activeBaseStep) + state.activeNextByte;
     const std::size_t pipelineBytes = geometry.perBlockSlot *
-        static_cast<std::size_t>(sendRecvState_.pipelineDepth);
+        static_cast<std::size_t>(sendRecvState.pipelineDepth);
     const std::size_t pipelineOff =
         static_cast<std::size_t>(streamStart % pipelineBytes);
     const int slot = static_cast<int>(pipelineOff / geometry.perBlockSlot);
     const std::size_t slotOff =
-        static_cast<std::size_t>(slot) * sendRecvState_.dataBufferSize;
+        static_cast<std::size_t>(slot) * sendRecvState.dataBufferSize;
     const std::size_t chunkOff =
         pipelineOff - static_cast<std::size_t>(slot) * geometry.perBlockSlot;
     const std::size_t slotRemaining = geometry.perBlockSlot - chunkOff;

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -134,11 +134,11 @@ class IbSendRecvDevice {
    * group while a previous send is outstanding traps with a diagnostic instead
    * of silently overwriting the in-flight byte range.
    *
-   * `active_blocks == 0` means all configured groups participate. Non-zero
-   * values must match the peer's recv-side initialization for the same logical
-   * transfer. `max_signal_bytes == 0` sends one signal per per-block staging
-   * partition; smaller non-zero values split that partition into multiple
-   * signaled sub-chunks for finer overlap with the receiver.
+   * Channel count and per-channel staging geometry are fixed in
+   * `IbChannelLayout`. `max_signal_bytes == 0` sends one signal per
+   * per-channel staging partition; smaller non-zero values split that
+   * partition into multiple signaled sub-chunks for finer overlap with the
+   * receiver.
    *
    * Zero-byte sends mark the internal state `Done` without reading or
    * validating staging geometry. This matches the blocking `send()` no-op
@@ -146,13 +146,11 @@ class IbSendRecvDevice {
    *
    * @param group Thread group that will execute all later progress calls.
    * @param nbytes Number of user-buffer bytes to send for this group.
-   * @param active_blocks Number of participating groups, or 0 for maxGroups.
    * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
    */
   __device__ __forceinline__ void init_send_progress(
       ThreadGroup& group,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     const int progressIndex = progress_send_index(group);
@@ -169,14 +167,13 @@ class IbSendRecvDevice {
     }
     // Validate the transfer before reserving the transport byte cursor.
     const ProgressGeometry geometry = make_progress_geometry(
-        group, nbytes, active_blocks, max_signal_bytes, "init_send_progress");
+        group, nbytes, max_signal_bytes, "init_send_progress");
     state.activeBaseStep =
         reserve_progress_step(group, progressIndex, geometry.protocolBytes);
     store_progress_state(group, progressIndex, state);
 #else
     (void)group;
     (void)nbytes;
-    (void)active_blocks;
     (void)max_signal_bytes;
 #endif
   }
@@ -193,10 +190,9 @@ class IbSendRecvDevice {
    * group while a previous recv is outstanding traps with a diagnostic instead
    * of silently overwriting the in-flight byte range.
    *
-   * The sender and receiver must use the same `active_blocks` and compatible
-   * `max_signal_bytes` for a logical transfer. The staging offset and protocol
-   * signal values are derived from those values, so a mismatch can make one
-   * side wait on a different byte range than the other side produced.
+   * The sender and receiver must use compatible `max_signal_bytes` for a
+   * logical transfer. Channel count and staging geometry are fixed in the
+   * transport layout; `max_signal_bytes` only controls sub-chunk signaling.
    *
    * Zero-byte receives mark the internal state `Done` without reading or
    * validating staging geometry. This matches the blocking `recv()` no-op
@@ -204,13 +200,11 @@ class IbSendRecvDevice {
    *
    * @param group Thread group that will execute all later progress calls.
    * @param nbytes Number of user-buffer bytes to receive for this group.
-   * @param active_blocks Number of participating groups, or 0 for maxGroups.
    * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
    */
   __device__ __forceinline__ void init_recv_progress(
       ThreadGroup& group,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     const int progressIndex = progress_recv_index(group);
@@ -227,14 +221,13 @@ class IbSendRecvDevice {
     }
     // Validate the transfer before reserving the transport byte cursor.
     const ProgressGeometry geometry = make_progress_geometry(
-        group, nbytes, active_blocks, max_signal_bytes, "init_recv_progress");
+        group, nbytes, max_signal_bytes, "init_recv_progress");
     state.activeBaseStep =
         reserve_progress_step(group, progressIndex, geometry.protocolBytes);
     store_progress_state(group, progressIndex, state);
 #else
     (void)group;
     (void)nbytes;
-    (void)active_blocks;
     (void)max_signal_bytes;
 #endif
   }
@@ -266,7 +259,6 @@ class IbSendRecvDevice {
    * @param src Source user buffer. The range `[src, src + nbytes)` must remain
    *            valid until `Done`.
    * @param nbytes Number of user-buffer bytes from the matching init call.
-   * @param active_blocks Number of participating groups from init.
    * @param max_signal_bytes Maximum signaled sub-chunk size from init.
    * @param timeout Optional device timeout checked while dependencies wait.
    * @param args Additional arguments forwarded to `CopyOp::send`.
@@ -277,7 +269,6 @@ class IbSendRecvDevice {
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
@@ -294,7 +285,7 @@ class IbSendRecvDevice {
       return IbgdaSendRecvProgressStatus::Done;
     }
     const ProgressGeometry progress_params = make_progress_geometry(
-        group, nbytes, active_blocks, max_signal_bytes, "progress_send_once");
+        group, nbytes, max_signal_bytes, "progress_send_once");
     if (state.activeNextByte >= progress_params.protocolBytes) {
       if (group.is_leader()) {
         printf(
@@ -439,7 +430,6 @@ class IbSendRecvDevice {
     (void)group;
     (void)src;
     (void)nbytes;
-    (void)active_blocks;
     (void)max_signal_bytes;
     (void)timeout;
     return IbgdaSendRecvProgressStatus::Done;
@@ -470,7 +460,6 @@ class IbSendRecvDevice {
    * @param dst Destination user buffer. The range `[dst, dst + nbytes)` must
    *            remain valid until `Done`.
    * @param nbytes Number of user-buffer bytes from the matching init call.
-   * @param active_blocks Number of participating groups from init.
    * @param max_signal_bytes Maximum signaled sub-chunk size from init.
    * @param timeout Optional device timeout checked while dependencies wait.
    * @param args Additional arguments forwarded to `CopyOp::recv`.
@@ -481,7 +470,6 @@ class IbSendRecvDevice {
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
@@ -498,7 +486,7 @@ class IbSendRecvDevice {
       return IbgdaSendRecvProgressStatus::Done;
     }
     const ProgressGeometry progress_params = make_progress_geometry(
-        group, nbytes, active_blocks, max_signal_bytes, "progress_recv_once");
+        group, nbytes, max_signal_bytes, "progress_recv_once");
     if (state.activeNextByte >= progress_params.protocolBytes) {
       if (group.is_leader()) {
         printf(
@@ -582,7 +570,6 @@ class IbSendRecvDevice {
     (void)group;
     (void)dst;
     (void)nbytes;
-    (void)active_blocks;
     (void)max_signal_bytes;
     (void)timeout;
     return IbgdaSendRecvProgressStatus::Done;
@@ -611,10 +598,9 @@ class IbSendRecvDevice {
    * cursor and protocol sequence numbers on each invocation. This allows
    * callers to pipeline across repeated send() calls without a separate drain.
    *
-   * The caller must keep the staging layout stable while a sequence is in
-   * flight. Changing active_blocks changes the per-block staging partition, so
-   * both sides must perform a higher-level barrier/quiescence step first.
-   * max_signal_bytes may vary across calls with the same active_blocks.
+   * The caller must keep the transport layout stable while a sequence is in
+   * flight. `max_signal_bytes` may vary across calls because it changes only
+   * sub-chunk signaling, not the fixed channel staging layout.
    *
    * @param transport       Owning transport used for every transport op.
    * @param group           ThreadGroup (all threads participate in memcpy,
@@ -623,8 +609,6 @@ class IbSendRecvDevice {
    * @param nbytes          Bytes to send for this group. Internally consumed
    *                        in perBlockSlot-sized pieces, or smaller sub-chunks
    *                        when max_signal_bytes is set.
-   * @param active_blocks   Number of block-groups sharing each logical slot in
-   *                        this call. 0 means use maxGroups.
    * @param max_signal_bytes Max bytes per signaled sub-chunk within one
    *                        perBlockSlot. 0 means one signal per perBlockSlot.
    * @param timeout         Optional timeout for wait operations.
@@ -635,7 +619,6 @@ class IbSendRecvDevice {
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
@@ -644,7 +627,6 @@ class IbSendRecvDevice {
     (void)group;
     (void)src;
     (void)nbytes;
-    (void)active_blocks;
     (void)max_signal_bytes;
     (void)timeout;
 #else
@@ -654,7 +636,6 @@ class IbSendRecvDevice {
     const std::size_t protocolBytes = align_protocol_bytes(nbytes);
 
     const int groupId = group.group_id;
-    (void)active_blocks;
     const int maxGroups = sendRecvState_.maxGroups;
     if (groupId >= maxGroups) {
       if (group.is_leader()) {
@@ -815,8 +796,6 @@ class IbSendRecvDevice {
    * @param nbytes          Bytes to receive for this group. Internally
    *                        consumed in perBlockSlot-sized pieces, or smaller
    *                        sub-chunks when max_signal_bytes is set.
-   * @param active_blocks   Number of block-groups sharing each logical slot in
-   *                        this call. 0 means use maxGroups.
    * @param max_signal_bytes Max bytes per signaled sub-chunk within one
    *                        perBlockSlot. 0 means one signal per perBlockSlot.
    *                        Must match the sender's value.
@@ -828,7 +807,6 @@ class IbSendRecvDevice {
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
@@ -837,7 +815,6 @@ class IbSendRecvDevice {
     (void)group;
     (void)dst;
     (void)nbytes;
-    (void)active_blocks;
     (void)max_signal_bytes;
     (void)timeout;
 #else
@@ -847,7 +824,6 @@ class IbSendRecvDevice {
     const std::size_t protocolBytes = align_protocol_bytes(nbytes);
 
     const int groupId = group.group_id;
-    (void)active_blocks;
     const int maxGroups = sendRecvState_.maxGroups;
     if (groupId >= maxGroups) {
       if (group.is_leader()) {
@@ -988,22 +964,16 @@ class IbSendRecvDevice {
    * The signal protocol is wire-compatible:
    *
    *   Recv side (this transport):
-   *     - Reads state[maxGroups + groupId].nextStep (same index as recv)
-   *     - Waits DATA_READY on localSignalBuf[groupId] (matches send's
-   *       piggybacked signal on remoteSignalBuf[groupId])
-   *     - Signals SLOT_FREE on remoteSignalBuf[maxGroups + groupId]
-   *       (matches send's backpressure wait on localSignalBuf[maxGroups +
-   *       groupId])
+   *     - Uses this channel's recv progress cursor.
+   *     - Waits DATA_READY on this channel's local data-ready signal.
+   *     - Signals SLOT_FREE on the remote channel's slot-free signal.
    *
    *   Fwd side (fwd transport):
-   *     - Reads state[groupId].nextStep (same index as send)
-   *     - Waits NIC_DONE on localCounterBuf[groupId] (matches send's
-   *       self-counter)
-   *     - Waits SLOT_FREE on localSignalBuf[maxGroups + groupId]
-   *       (matches recv's backpressure release)
-   *     - RDMA puts with DATA_READY on remoteSignalBuf[groupId]
-   *       + NIC_DONE on localCounterBuf[groupId]
-   *       (matches recv's DATA_READY wait)
+   *     - Uses the forward channel's send progress cursor.
+   *     - Waits NIC_DONE on the forward channel's local completion counter.
+   *     - Waits SLOT_FREE on the forward channel's local slot-free signal.
+   *     - RDMA puts with DATA_READY on the forward remote channel and may
+   *       batch NIC_DONE credit to the local completion counter.
    *
    * Any chain of send → forward* → recv is therefore valid: each
    * forward consumes exactly the signals its predecessor produces
@@ -1016,8 +986,6 @@ class IbSendRecvDevice {
    * @param fwdDevice       Forward-side send/recv device (next peer).
    * @param fwdTransport    Forward transport (sends to next peer in ring).
    * @param nbytes          Bytes to receive and forward.
-   * @param active_blocks   Number of block-groups sharing the slot. 0 =
-   * maxGroups.
    * @param max_signal_bytes Max bytes per signaled sub-chunk. 0 = perBlockSlot.
    * @param timeout         Optional timeout for wait operations.
    * @param args            Extra args forwarded to CopyOp::forward.
@@ -1030,7 +998,6 @@ class IbSendRecvDevice {
       IbSendRecvDevice& fwdDevice,
       Transport& fwdTransport,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
@@ -1048,7 +1015,6 @@ class IbSendRecvDevice {
     const int groupId = group.group_id;
 
     // --- recv side (this transport) ---
-    (void)active_blocks;
     const int recvMaxGroups = sendRecvState_.maxGroups;
     if (groupId >= recvMaxGroups) {
       if (group.is_leader()) {
@@ -1263,7 +1229,6 @@ class IbSendRecvDevice {
     (void)fwdDevice;
     (void)fwdTransport;
     (void)nbytes;
-    (void)active_blocks;
     (void)max_signal_bytes;
     (void)timeout;
 #endif
@@ -1272,20 +1237,15 @@ class IbSendRecvDevice {
   /**
    * Maximum bytes a block can send without blocking on pipeline backpressure.
    *
-   * The staging buffer is split into pipelineDepth slots, each divided evenly
-   * across active_blocks. A block can fill all its slots before the NIC must
+   * The staging buffer is split into pipelineDepth slots, each with a fixed
+   * per-channel partition. A block can fill all its slots before the NIC must
    * drain any of them, so the non-blocking window is:
-   *   (dataBufferSize / active_blocks) * pipelineDepth
+   *   perChannelSize * pipelineDepth
    *
    * Callers should loop over their data in pipeline_window-sized chunks so
    * that send()/forward() never stall waiting for a free slot.
-   *
-   * @param active_blocks  Total blocks sharing this transport (typically
-   *                       gridDim.x).
    */
-  __device__ __forceinline__ std::size_t pipeline_window(
-      int active_blocks) const {
-    (void)active_blocks;
+  __device__ __forceinline__ std::size_t pipeline_window() const {
     const std::size_t per_block_slot =
         (sendRecvState_.dataBufferSize / sendRecvState_.maxGroups) & ~15ULL;
     return per_block_slot * sendRecvState_.pipelineDepth;
@@ -1511,7 +1471,6 @@ class IbSendRecvDevice {
   __device__ __forceinline__ ProgressGeometry make_progress_geometry(
       ThreadGroup& group,
       std::size_t nbytes,
-      int active_blocks,
       std::size_t max_signal_bytes,
       const char* opName) const {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
@@ -1525,7 +1484,6 @@ class IbSendRecvDevice {
       PIPES_DEVICE_TRAP();
     }
     const int groupId = static_cast<int>(group.group_id);
-    (void)active_blocks;
     const int maxGroups = sendRecvState_.maxGroups;
     if (groupId < 0 || groupId >= maxGroups) {
       if (group.is_leader()) {
@@ -1570,7 +1528,6 @@ class IbSendRecvDevice {
 #else
     (void)group;
     (void)nbytes;
-    (void)active_blocks;
     (void)max_signal_bytes;
     (void)opName;
     return {};
@@ -1996,7 +1953,6 @@ struct P2pIbTransportDevice {
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args);
@@ -2006,7 +1962,6 @@ struct P2pIbTransportDevice {
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args);
@@ -2017,25 +1972,21 @@ struct P2pIbTransportDevice {
       void* __restrict__ dst,
       P2pIbTransportDevice& fwd,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args);
 
   // Per-block pipelined staging window — forwarded to the active backend.
-  __device__ __forceinline__ std::size_t pipeline_window(
-      int active_blocks) const;
+  __device__ __forceinline__ std::size_t pipeline_window() const;
 
   __device__ __forceinline__ void init_send_progress(
       ThreadGroup& group,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0);
 
   __device__ __forceinline__ void init_recv_progress(
       ThreadGroup& group,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0);
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -2043,7 +1994,6 @@ struct P2pIbTransportDevice {
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args);
@@ -2053,7 +2003,6 @@ struct P2pIbTransportDevice {
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args);

--- a/comms/prims/transport/ibgda/IbgdaBuffer.h
+++ b/comms/prims/transport/ibgda/IbgdaBuffer.h
@@ -445,16 +445,14 @@ enum class IbSendRecvProgressStage : uint8_t {
  * Buffer layout:
  *   sendStaging / recvStaging: pipelineDepth * dataBufferSize bytes each.
  *     Logically divided into pipelineDepth slots of dataBufferSize bytes.
- *     For one send()/recv() call, a caller chooses active_blocks
- *     (1 <= active_blocks <= maxGroups). Each slot is then partitioned into
- *     active_blocks per-block regions:
- *       perBlockSlot = (dataBufferSize / active_blocks) & ~15ULL
+ *     Each slot is partitioned into maxGroups fixed channel regions:
+ *       perBlockSlot = (dataBufferSize / maxGroups) & ~15ULL
  *     If max_signal_bytes is smaller than perBlockSlot, each per-block region
  *     is further subdivided into signaled sub-chunks:
  *       chunkSize = floor16(min(perBlockSlot, max_signal_bytes))
  *     state[].nextStep counts 16-byte-aligned protocol bytes, not sub-chunks,
- *     so max_signal_bytes may change between calls as long as active_blocks is
- *     unchanged.
+ *     so max_signal_bytes may change between calls without changing the
+ *     staging layout.
  *
  *   signalBuf: 2 * maxGroups * sizeof(uint64_t).
  *     [0, maxGroups)             — DATA_READY (sender -> receiver)

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -710,11 +710,12 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
     allocateResources();
     registerMemory();
 
-    // Allocate send/recv staging buffers (if configured). Eager mode delegates
-    // to the shared base (Device counter: NIC loopback atomic); lazy mode only
-    // sizes the inherited per-peer view vector — the shared base
-    // allocateSendRecvBufferForPeer() fills it per peer at materialization.
-    if (config_.sendRecv.has_value()) {
+    // Allocate send/recv staging buffers when fixed channels are configured.
+    // Eager mode delegates to the shared base (Device counter: NIC loopback
+    // atomic); lazy mode only sizes the inherited per-peer view vector — the
+    // shared base allocateSendRecvBufferForPeer() fills it per peer at
+    // materialization.
+    if (sendRecvBuffersEnabled()) {
       if (!config_.ibLazyConnect) {
         allocateSendRecvBuffersEager(IbCounterStorage::Device);
       } else {

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -42,10 +42,9 @@ inline constexpr uint64_t kDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
 // `PIPES_DEVICE_TRAP()` is defined in `comms/prims/core/DeviceMacros.cuh` and
 // is intentionally available across all `comms/prims` device headers.
 //
-// `IbgdaSendRecvProgressStatus` and the pipelined send/recv algorithm now live
-// in the shared `IbSendRecvDevice` (P2pIbTransportDeviceDecl.cuh); this class
-// delegates its send/recv/forward/init/progress methods to a `sendRecv_`
-// member.
+// `IbgdaSendRecvProgressStatus` and the pipelined send/recv algorithm live in
+// the shared stateless `IbSendRecvDevice` (P2pIbTransportDeviceDecl.cuh);
+// backend-owned `sendRecvState_` carries the actual protocol state.
 
 // Slot-id bounds checks for the slot-index API. Catches both
 // out-of-range slot ids and slot-index calls made when the transport was
@@ -212,7 +211,7 @@ class P2pIbgdaTransportDevice {
         qpsPerConnection_(qpsPerConnection),
         qpDirectionCount_(qpDirectionCount),
         localChannels_(localChannels),
-        sendRecv_(sendRecvState) {}
+        sendRecvState_(sendRecvState) {}
 
   // =========================================================================
   // Slot-Index API (resolves owned buffers, forwards to explicit-buffer API)
@@ -1986,7 +1985,8 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0) {
-    sendRecv_.init_send_progress(group, nbytes, max_signal_bytes);
+    sendRecv_.init_send_progress(
+        sendRecvState_, group, nbytes, max_signal_bytes);
   }
 
   /**
@@ -2019,7 +2019,8 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0) {
-    sendRecv_.init_recv_progress(group, nbytes, max_signal_bytes);
+    sendRecv_.init_recv_progress(
+        sendRecvState_, group, nbytes, max_signal_bytes);
   }
 
   /**
@@ -2063,7 +2064,14 @@ class P2pIbgdaTransportDevice {
       const Timeout& timeout = Timeout(),
       Args... args) {
     return sendRecv_.progress_send_once<P2pIbgdaTransportDevice, CopyOp>(
-        *this, group, src, nbytes, max_signal_bytes, timeout, args...);
+        *this,
+        sendRecvState_,
+        group,
+        src,
+        nbytes,
+        max_signal_bytes,
+        timeout,
+        args...);
   }
 
   /**
@@ -2104,7 +2112,14 @@ class P2pIbgdaTransportDevice {
       const Timeout& timeout = Timeout(),
       Args... args) {
     return sendRecv_.progress_recv_once<P2pIbgdaTransportDevice, CopyOp>(
-        *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
+        *this,
+        sendRecvState_,
+        group,
+        dst,
+        nbytes,
+        max_signal_bytes,
+        timeout,
+        args...);
   }
 
   /**
@@ -2187,7 +2202,14 @@ class P2pIbgdaTransportDevice {
           static_cast<uint16_t>(group.group_id));
     }
     sendRecv_.send<P2pIbgdaTransportDevice, CopyOp>(
-        *this, group, src, nbytes, max_signal_bytes, timeout, args...);
+        *this,
+        sendRecvState_,
+        group,
+        src,
+        nbytes,
+        max_signal_bytes,
+        timeout,
+        args...);
     if (group.is_leader()) {
       trace_ibgda_event(
           trace,
@@ -2269,7 +2291,14 @@ class P2pIbgdaTransportDevice {
           static_cast<uint16_t>(group.group_id));
     }
     sendRecv_.recv<P2pIbgdaTransportDevice, CopyOp>(
-        *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
+        *this,
+        sendRecvState_,
+        group,
+        dst,
+        nbytes,
+        max_signal_bytes,
+        timeout,
+        args...);
     if (group.is_leader()) {
       trace_ibgda_event(
           trace,
@@ -2370,9 +2399,11 @@ class P2pIbgdaTransportDevice {
     }
     sendRecv_.forward<CopyOp>(
         *this,
+        sendRecvState_,
         group,
         dst,
         fwd.sendRecv_,
+        fwd.sendRecvState_,
         fwd,
         nbytes,
         max_signal_bytes,
@@ -2392,7 +2423,7 @@ class P2pIbgdaTransportDevice {
   // Send/recv state accessors
 
   __host__ __device__ const IbSendRecvState& send_recv_state() const {
-    return sendRecv_.send_recv_state();
+    return sendRecvState_;
   }
 
   /**
@@ -2407,7 +2438,7 @@ class P2pIbgdaTransportDevice {
    * that send()/forward() never stall waiting for a free slot.
    */
   __device__ __forceinline__ std::size_t pipeline_window() const {
-    return sendRecv_.pipeline_window();
+    return sendRecv_.pipeline_window(sendRecvState_);
   }
 
  private:
@@ -2427,6 +2458,7 @@ class P2pIbgdaTransportDevice {
   int qpDirectionCount_{kIbDirections};
   DeviceSpan<IbLocalChannel> localChannels_{};
 
+  IbSendRecvState sendRecvState_{};
   IbSendRecvDevice sendRecv_{};
 };
 

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -1861,10 +1861,10 @@ class P2pIbgdaTransportDevice {
   // Terminology used below:
   //   slot             = one logical staging-ring entry of dataBufferSize
   //                      bytes. There are pipelineDepth slots in the ring.
-  //   active_blocks    = number of participating block-groups in one
-  //                      send()/recv() call. Must be <= maxGroups.
+  //   maxChannels      = fixed number of channel/group slots allocated for
+  //                      this peer at transport construction.
   //   perBlockSlot     = one block-group's partition within a slot:
-  //                      (dataBufferSize / active_blocks) & ~15ULL
+  //                      channelLayout.perChannelSize & ~15ULL
   //   sub-chunk        = one signaled byte range within a perBlockSlot. When
   //                      max_signal_bytes == 0, a sub-chunk is the whole
   //                      perBlockSlot. Otherwise:
@@ -1881,9 +1881,9 @@ class P2pIbgdaTransportDevice {
   //   for (std::size_t s = 0; s < totalBytes / sectionBytes; ++s) {
   //     TiledBuffer<char> tiles(data + s * sectionBytes, sectionBytes, sub);
   //     if (role == 0)
-  //       transport->send(sub, tiles.data(), tiles.bytes(), active_blocks);
+  //       transport->send(sub, tiles.data(), tiles.bytes());
   //     else
-  //       transport->recv(sub, tiles.data(), tiles.bytes(), active_blocks);
+  //       transport->recv(sub, tiles.data(), tiles.bytes());
   //   }
 
   /**
@@ -1932,25 +1932,23 @@ class P2pIbgdaTransportDevice {
    * logical transfer, then calling the matching progress method with the same
    * static geometry until it returns `Done`:
    *
-   *   transport->init_send_progress(
-   *       group, nbytes, active_blocks, max_signal_bytes);
+   *   transport->init_send_progress(group, nbytes, max_signal_bytes);
    *   while (transport->progress_send_once(
-   *              group, src, nbytes, active_blocks, max_signal_bytes, timeout)
+   *              group, src, nbytes, max_signal_bytes, timeout)
    *          != IbgdaSendRecvProgressStatus::Done) {
    *     // Try another independent lane or return to the scheduler.
    *   }
    *
    * Receivers use the symmetric `init_recv_progress()` and
-   * `progress_recv_once()` pair with the same `nbytes`, `active_blocks`, and
-   * compatible `max_signal_bytes`. Zero-byte operations initialize directly to
-   * `Done`, so callers can use the same loop shape for empty and non-empty
-   * transfers.
+   * `progress_recv_once()` pair with the same `nbytes` and compatible
+   * `max_signal_bytes`. Zero-byte operations initialize directly to `Done`, so
+   * callers can use the same loop shape for empty and non-empty transfers.
    *
    * The transport-owned state slot stores the shared persistent protocol byte
    * cursor and only the active async stage, `activeNextByte`, and reserved
-   * stream base. Immutable geometry such as `nbytes`, active block count, and
-   * chunk sizing is intentionally kept out of HBM-backed state and recomputed
-   * by each progress call from its arguments.
+   * stream base. Immutable geometry such as `nbytes` and chunk sizing is
+   * intentionally kept out of HBM-backed state and recomputed by each progress
+   * call from its arguments and the fixed channel layout.
    *
    * The progress state is a property of this transport, indexed by
    * `group.group_id` and direction. A caller may have one send and one recv in
@@ -1971,9 +1969,8 @@ class P2pIbgdaTransportDevice {
    * group while a previous send is outstanding traps with a diagnostic instead
    * of silently overwriting the in-flight byte range.
    *
-   * `active_blocks == 0` means all configured groups participate. Non-zero
-   * values must match the peer's recv-side initialization for the same logical
-   * transfer. `max_signal_bytes == 0` sends one signal per per-block staging
+   * Channel count and per-channel staging geometry are fixed in the transport
+   * layout. `max_signal_bytes == 0` sends one signal per per-channel staging
    * partition; smaller non-zero values split that partition into multiple
    * signaled sub-chunks for finer overlap with the receiver.
    *
@@ -1983,17 +1980,13 @@ class P2pIbgdaTransportDevice {
    *
    * @param group Thread group that will execute all later progress calls.
    * @param nbytes Number of user-buffer bytes to send for this group.
-   * @param active_blocks Number of participating transport lanes, or 0 for
-   *                      maxGroups.
    * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
    */
   __device__ __forceinline__ void init_send_progress(
       ThreadGroup& group,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0) {
-    sendRecv_.init_send_progress(
-        group, nbytes, active_blocks, max_signal_bytes);
+    sendRecv_.init_send_progress(group, nbytes, max_signal_bytes);
   }
 
   /**
@@ -2010,10 +2003,9 @@ class P2pIbgdaTransportDevice {
    * group while a previous recv is outstanding traps with a diagnostic instead
    * of silently overwriting the in-flight byte range.
    *
-   * The sender and receiver must use the same `active_blocks` and compatible
-   * `max_signal_bytes` for a logical transfer. The staging offset and protocol
-   * signal values are derived from those values, so a mismatch can make one
-   * side wait on a different byte range than the other side produced.
+   * The sender and receiver must use compatible `max_signal_bytes` for a
+   * logical transfer. Channel count and staging geometry are fixed in the
+   * transport layout; `max_signal_bytes` only controls sub-chunk signaling.
    *
    * Zero-byte receives mark the internal state `Done` without reading or
    * validating staging geometry. This matches the blocking `recv()` no-op
@@ -2021,17 +2013,13 @@ class P2pIbgdaTransportDevice {
    *
    * @param group Thread group that will execute all later progress calls.
    * @param nbytes Number of user-buffer bytes to receive for this group.
-   * @param active_blocks Number of participating transport lanes, or 0 for
-   *                      maxGroups.
    * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
    */
   __device__ __forceinline__ void init_recv_progress(
       ThreadGroup& group,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0) {
-    sendRecv_.init_recv_progress(
-        group, nbytes, active_blocks, max_signal_bytes);
+    sendRecv_.init_recv_progress(group, nbytes, max_signal_bytes);
   }
 
   /**
@@ -2062,7 +2050,6 @@ class P2pIbgdaTransportDevice {
    * @param src Source user buffer. The range `[src, src + nbytes)` must remain
    *            valid until `Done`.
    * @param nbytes Number of user-buffer bytes from the matching init call.
-   * @param active_blocks Number of participating groups from init.
    * @param max_signal_bytes Maximum signaled sub-chunk size from init.
    * @param timeout Optional device timeout checked while dependencies wait.
    * @param args Additional arguments forwarded to `CopyOp::send`.
@@ -2072,19 +2059,11 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
     return sendRecv_.progress_send_once<P2pIbgdaTransportDevice, CopyOp>(
-        *this,
-        group,
-        src,
-        nbytes,
-        active_blocks,
-        max_signal_bytes,
-        timeout,
-        args...);
+        *this, group, src, nbytes, max_signal_bytes, timeout, args...);
   }
 
   /**
@@ -2112,7 +2091,6 @@ class P2pIbgdaTransportDevice {
    * @param dst Destination user buffer. The range `[dst, dst + nbytes)` must
    *            remain valid until `Done`.
    * @param nbytes Number of user-buffer bytes from the matching init call.
-   * @param active_blocks Number of participating groups from init.
    * @param max_signal_bytes Maximum signaled sub-chunk size from init.
    * @param timeout Optional device timeout checked while dependencies wait.
    * @param args Additional arguments forwarded to `CopyOp::recv`.
@@ -2122,19 +2100,11 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
     return sendRecv_.progress_recv_once<P2pIbgdaTransportDevice, CopyOp>(
-        *this,
-        group,
-        dst,
-        nbytes,
-        active_blocks,
-        max_signal_bytes,
-        timeout,
-        args...);
+        *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
   }
 
   /**
@@ -2159,10 +2129,9 @@ class P2pIbgdaTransportDevice {
    * cursor and protocol sequence numbers on each invocation. This allows
    * callers to pipeline across repeated send() calls without a separate drain.
    *
-   * The caller must keep the staging layout stable while a sequence is in
-   * flight. Changing active_blocks changes the per-block staging partition, so
-   * both sides must perform a higher-level barrier/quiescence step first.
-   * max_signal_bytes may vary across calls with the same active_blocks.
+   * The caller must keep the transport layout stable while a sequence is in
+   * flight. `max_signal_bytes` may vary across calls because it changes only
+   * sub-chunk signaling, not the fixed channel staging layout.
    *
    * @param group           ThreadGroup (all threads participate in memcpy,
    *                        leader does RDMA ops).
@@ -2171,8 +2140,6 @@ class P2pIbgdaTransportDevice {
    *                        protocol byte count is rounded up to 16 bytes and
    *                        consumed in perBlockSlot-sized pieces, or smaller
    *                        sub-chunks when max_signal_bytes is set.
-   * @param active_blocks   Number of block-groups sharing each logical slot in
-   *                        this call. 0 means use maxGroups.
    * @param max_signal_bytes Max bytes per signaled sub-chunk within one
    *                        perBlockSlot. 0 means one signal per perBlockSlot.
    * @param timeout         Optional timeout for wait operations.
@@ -2182,20 +2149,11 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
     sendWithTrace<CopyOp>(
-        group,
-        src,
-        nbytes,
-        active_blocks,
-        max_signal_bytes,
-        timeout,
-        {},
-        0,
-        args...);
+        group, src, nbytes, max_signal_bytes, timeout, {}, 0, args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -2203,7 +2161,6 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
-      int active_blocks,
       std::size_t max_signal_bytes,
       const Timeout& timeout,
       PipesTraceHandle trace,
@@ -2213,7 +2170,6 @@ class P2pIbgdaTransportDevice {
     (void)group;
     (void)src;
     (void)nbytes;
-    (void)active_blocks;
     (void)max_signal_bytes;
     (void)timeout;
     (void)trace;
@@ -2231,14 +2187,7 @@ class P2pIbgdaTransportDevice {
           static_cast<uint16_t>(group.group_id));
     }
     sendRecv_.send<P2pIbgdaTransportDevice, CopyOp>(
-        *this,
-        group,
-        src,
-        nbytes,
-        active_blocks,
-        max_signal_bytes,
-        timeout,
-        args...);
+        *this, group, src, nbytes, max_signal_bytes, timeout, args...);
     if (group.is_leader()) {
       trace_ibgda_event(
           trace,
@@ -2272,8 +2221,6 @@ class P2pIbgdaTransportDevice {
    *                        internal protocol byte count is rounded up to 16
    *                        bytes and consumed in perBlockSlot-sized pieces, or
    *                        smaller sub-chunks when max_signal_bytes is set.
-   * @param active_blocks   Number of block-groups sharing each logical slot in
-   *                        this call. 0 means use maxGroups.
    * @param max_signal_bytes Max bytes per signaled sub-chunk within one
    *                        perBlockSlot. 0 means one signal per perBlockSlot.
    *                        Must match the sender's value.
@@ -2284,20 +2231,11 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
     recvWithTrace<CopyOp>(
-        group,
-        dst,
-        nbytes,
-        active_blocks,
-        max_signal_bytes,
-        timeout,
-        {},
-        0,
-        args...);
+        group, dst, nbytes, max_signal_bytes, timeout, {}, 0, args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -2305,7 +2243,6 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
-      int active_blocks,
       std::size_t max_signal_bytes,
       const Timeout& timeout,
       PipesTraceHandle trace,
@@ -2315,7 +2252,6 @@ class P2pIbgdaTransportDevice {
     (void)group;
     (void)dst;
     (void)nbytes;
-    (void)active_blocks;
     (void)max_signal_bytes;
     (void)timeout;
     (void)trace;
@@ -2333,14 +2269,7 @@ class P2pIbgdaTransportDevice {
           static_cast<uint16_t>(group.group_id));
     }
     sendRecv_.recv<P2pIbgdaTransportDevice, CopyOp>(
-        *this,
-        group,
-        dst,
-        nbytes,
-        active_blocks,
-        max_signal_bytes,
-        timeout,
-        args...);
+        *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
     if (group.is_leader()) {
       trace_ibgda_event(
           trace,
@@ -2378,22 +2307,16 @@ class P2pIbgdaTransportDevice {
    * The signal protocol is wire-compatible:
    *
    *   Recv side (this transport):
-   *     - Reads state[maxGroups + groupId].nextStep (same index as recv)
-   *     - Waits DATA_READY on localSignalBuf[groupId] (matches send's
-   *       piggybacked signal on remoteSignalBuf[groupId])
-   *     - Signals SLOT_FREE on remoteSignalBuf[maxGroups + groupId]
-   *       (matches send's backpressure wait on localSignalBuf[maxGroups +
-   *       groupId])
+   *     - Uses this channel's recv progress cursor.
+   *     - Waits DATA_READY on this channel's local data-ready signal.
+   *     - Signals SLOT_FREE on the remote channel's slot-free signal.
    *
    *   Fwd side (fwd transport):
-   *     - Reads state[groupId].nextStep (same index as send)
-   *     - Waits NIC_DONE on localCounterBuf[groupId] (matches send's
-   *       self-counter)
-   *     - Waits SLOT_FREE on localSignalBuf[maxGroups + groupId]
-   *       (matches recv's backpressure release)
-   *     - RDMA puts with DATA_READY on remoteSignalBuf[groupId]
-   *       + NIC_DONE on localCounterBuf[groupId]
-   *       (matches recv's DATA_READY wait)
+   *     - Uses the forward channel's send progress cursor.
+   *     - Waits NIC_DONE on the forward channel's local completion counter.
+   *     - Waits SLOT_FREE on the forward channel's local slot-free signal.
+   *     - RDMA puts with DATA_READY on the forward remote channel and may
+   *       batch NIC_DONE credit to the local completion counter.
    *
    * Any chain of send → forward* → recv is therefore valid: each
    * forward consumes exactly the signals its predecessor produces
@@ -2405,8 +2328,6 @@ class P2pIbgdaTransportDevice {
    * @param fwd             Forward transport (sends to next peer in ring).
    * @param nbytes          Payload bytes to receive and forward. The internal
    *                        protocol byte count is rounded up to 16 bytes.
-   * @param active_blocks   Number of block-groups sharing the slot. 0 =
-   * maxGroups.
    * @param max_signal_bytes Max bytes per signaled sub-chunk. 0 = perBlockSlot.
    * @param timeout         Optional timeout for wait operations.
    * @param args            Extra args forwarded to CopyOp::forward.
@@ -2417,21 +2338,11 @@ class P2pIbgdaTransportDevice {
       void* __restrict__ dst,
       P2pIbgdaTransportDevice& fwd,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
     forwardWithTrace<CopyOp>(
-        group,
-        dst,
-        fwd,
-        nbytes,
-        active_blocks,
-        max_signal_bytes,
-        timeout,
-        {},
-        0,
-        args...);
+        group, dst, fwd, nbytes, max_signal_bytes, timeout, {}, 0, args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -2440,7 +2351,6 @@ class P2pIbgdaTransportDevice {
       void* __restrict__ dst,
       P2pIbgdaTransportDevice& fwd,
       std::size_t nbytes,
-      int active_blocks,
       std::size_t max_signal_bytes,
       const Timeout& timeout,
       PipesTraceHandle trace,
@@ -2465,7 +2375,6 @@ class P2pIbgdaTransportDevice {
         fwd.sendRecv_,
         fwd,
         nbytes,
-        active_blocks,
         max_signal_bytes,
         timeout,
         args...);
@@ -2489,20 +2398,16 @@ class P2pIbgdaTransportDevice {
   /**
    * Maximum bytes a block can send without blocking on pipeline backpressure.
    *
-   * The staging buffer is split into pipelineDepth slots, each divided evenly
-   * across active_blocks. A block can fill all its slots before the NIC must
+   * The staging buffer is split into pipelineDepth slots, each with a fixed
+   * per-channel partition. A block can fill all its slots before the NIC must
    * drain any of them, so the non-blocking window is:
-   *   (dataBufferSize / active_blocks) * pipelineDepth
+   *   perChannelSize * pipelineDepth
    *
    * Callers should loop over their data in pipeline_window-sized chunks so
    * that send()/forward() never stall waiting for a free slot.
-   *
-   * @param active_blocks  Total blocks sharing this transport (typically
-   *                       gridDim.x).
    */
-  __device__ __forceinline__ std::size_t pipeline_window(
-      int active_blocks) const {
-    return sendRecv_.pipeline_window(active_blocks);
+  __device__ __forceinline__ std::size_t pipeline_window() const {
+    return sendRecv_.pipeline_window();
   }
 
  private:

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -469,27 +469,22 @@ class P2pIbrcTransportDevice {
     return sendRecv_.send_recv_state();
   }
 
-  __device__ __forceinline__ std::size_t pipeline_window(
-      int active_blocks) const {
-    return sendRecv_.pipeline_window(active_blocks);
+  __device__ __forceinline__ std::size_t pipeline_window() const {
+    return sendRecv_.pipeline_window();
   }
 
   __device__ __forceinline__ void init_send_progress(
       ThreadGroup& group,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0) {
-    sendRecv_.init_send_progress(
-        group, nbytes, active_blocks, max_signal_bytes);
+    sendRecv_.init_send_progress(group, nbytes, max_signal_bytes);
   }
 
   __device__ __forceinline__ void init_recv_progress(
       ThreadGroup& group,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0) {
-    sendRecv_.init_recv_progress(
-        group, nbytes, active_blocks, max_signal_bytes);
+    sendRecv_.init_recv_progress(group, nbytes, max_signal_bytes);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -497,19 +492,11 @@ class P2pIbrcTransportDevice {
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
     return sendRecv_.progress_send_once<P2pIbrcTransportDevice, CopyOp>(
-        *this,
-        group,
-        src,
-        nbytes,
-        active_blocks,
-        max_signal_bytes,
-        timeout,
-        args...);
+        *this, group, src, nbytes, max_signal_bytes, timeout, args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -517,19 +504,11 @@ class P2pIbrcTransportDevice {
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
     return sendRecv_.progress_recv_once<P2pIbrcTransportDevice, CopyOp>(
-        *this,
-        group,
-        dst,
-        nbytes,
-        active_blocks,
-        max_signal_bytes,
-        timeout,
-        args...);
+        *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -537,19 +516,11 @@ class P2pIbrcTransportDevice {
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
     sendRecv_.send<P2pIbrcTransportDevice, CopyOp>(
-        *this,
-        group,
-        src,
-        nbytes,
-        active_blocks,
-        max_signal_bytes,
-        timeout,
-        args...);
+        *this, group, src, nbytes, max_signal_bytes, timeout, args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -557,19 +528,11 @@ class P2pIbrcTransportDevice {
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
     sendRecv_.recv<P2pIbrcTransportDevice, CopyOp>(
-        *this,
-        group,
-        dst,
-        nbytes,
-        active_blocks,
-        max_signal_bytes,
-        timeout,
-        args...);
+        *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -578,7 +541,6 @@ class P2pIbrcTransportDevice {
       void* __restrict__ dst,
       P2pIbrcTransportDevice& fwd,
       std::size_t nbytes,
-      int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
@@ -589,7 +551,6 @@ class P2pIbrcTransportDevice {
         fwd.sendRecv_,
         fwd,
         nbytes,
-        active_blocks,
         max_signal_bytes,
         timeout,
         args...);

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -92,7 +92,7 @@ class P2pIbrcTransportDevice {
         ownedCounterHostBuf_(ownedCounterHostBuf),
         numSignalSlots_(numSignalSlots),
         numCounterSlots_(numCounterSlots),
-        sendRecv_(sendRecvState) {}
+        sendRecvState_(sendRecvState) {}
 
   __device__ void put(
       ThreadGroup& group,
@@ -458,33 +458,36 @@ class P2pIbrcTransportDevice {
   }
 
   // ===========================================================================
-  // Pipelined send/recv — delegated to the shared IbSendRecvDevice.
+  // Pipelined send/recv — delegated to the shared stateless IbSendRecvDevice.
   // ===========================================================================
   //
   // The send/recv algorithm is transport-agnostic and lives in
-  // `IbSendRecvDevice` (P2pIbTransportDeviceDecl.cuh). Each method routes every
-  // transport op through `*this`, so IBRC reuses IBGDA's send/recv unchanged.
+  // `IbSendRecvDevice` (P2pIbTransportDeviceDecl.cuh). The protocol state is
+  // owned by this backend device; each method routes every transport op through
+  // `*this`, so IBRC reuses IBGDA's send/recv unchanged.
 
   __host__ __device__ const IbSendRecvState& send_recv_state() const {
-    return sendRecv_.send_recv_state();
+    return sendRecvState_;
   }
 
   __device__ __forceinline__ std::size_t pipeline_window() const {
-    return sendRecv_.pipeline_window();
+    return sendRecv_.pipeline_window(sendRecvState_);
   }
 
   __device__ __forceinline__ void init_send_progress(
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0) {
-    sendRecv_.init_send_progress(group, nbytes, max_signal_bytes);
+    sendRecv_.init_send_progress(
+        sendRecvState_, group, nbytes, max_signal_bytes);
   }
 
   __device__ __forceinline__ void init_recv_progress(
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0) {
-    sendRecv_.init_recv_progress(group, nbytes, max_signal_bytes);
+    sendRecv_.init_recv_progress(
+        sendRecvState_, group, nbytes, max_signal_bytes);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -496,7 +499,14 @@ class P2pIbrcTransportDevice {
       const Timeout& timeout = Timeout(),
       Args... args) {
     return sendRecv_.progress_send_once<P2pIbrcTransportDevice, CopyOp>(
-        *this, group, src, nbytes, max_signal_bytes, timeout, args...);
+        *this,
+        sendRecvState_,
+        group,
+        src,
+        nbytes,
+        max_signal_bytes,
+        timeout,
+        args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -508,7 +518,14 @@ class P2pIbrcTransportDevice {
       const Timeout& timeout = Timeout(),
       Args... args) {
     return sendRecv_.progress_recv_once<P2pIbrcTransportDevice, CopyOp>(
-        *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
+        *this,
+        sendRecvState_,
+        group,
+        dst,
+        nbytes,
+        max_signal_bytes,
+        timeout,
+        args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -520,7 +537,14 @@ class P2pIbrcTransportDevice {
       const Timeout& timeout = Timeout(),
       Args... args) {
     sendRecv_.send<P2pIbrcTransportDevice, CopyOp>(
-        *this, group, src, nbytes, max_signal_bytes, timeout, args...);
+        *this,
+        sendRecvState_,
+        group,
+        src,
+        nbytes,
+        max_signal_bytes,
+        timeout,
+        args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -532,7 +556,14 @@ class P2pIbrcTransportDevice {
       const Timeout& timeout = Timeout(),
       Args... args) {
     sendRecv_.recv<P2pIbrcTransportDevice, CopyOp>(
-        *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
+        *this,
+        sendRecvState_,
+        group,
+        dst,
+        nbytes,
+        max_signal_bytes,
+        timeout,
+        args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -546,9 +577,11 @@ class P2pIbrcTransportDevice {
       Args... args) {
     sendRecv_.forward<CopyOp>(
         *this,
+        sendRecvState_,
         group,
         dst,
         fwd.sendRecv_,
+        fwd.sendRecvState_,
         fwd,
         nbytes,
         max_signal_bytes,
@@ -892,6 +925,7 @@ class P2pIbrcTransportDevice {
   IbgdaLocalBuffer ownedCounterHostBuf_{};
   int numSignalSlots_{0};
   int numCounterSlots_{0};
+  IbSendRecvState sendRecvState_{};
   IbSendRecvDevice sendRecv_{};
 };
 

--- a/comms/torchcomms/triton/device_transport.cu
+++ b/comms/torchcomms/triton/device_transport.cu
@@ -84,12 +84,10 @@ __device__ __noinline__ int torchcomms_transport_send(
           static_cast<std::size_t>(max_signal_bytes));
       break;
     case TransportType::P2P_IBGDA:
-      // IBGDA's active_blocks defaults to 0 (use tile_max_groups).
       handle->get_ibgda(peer).send(
           group,
           src_ptr,
           static_cast<std::size_t>(nbytes),
-          /*active_blocks=*/0,
           static_cast<std::size_t>(max_signal_bytes));
       break;
     default:
@@ -117,12 +115,10 @@ __device__ __noinline__ int torchcomms_transport_recv(
           static_cast<std::size_t>(max_signal_bytes));
       break;
     case TransportType::P2P_IBGDA:
-      // IBGDA's active_blocks defaults to 0 (use tile_max_groups).
       handle->get_ibgda(peer).recv(
           group,
           dst_ptr,
           static_cast<std::size_t>(nbytes),
-          /*active_blocks=*/0,
           static_cast<std::size_t>(max_signal_bytes));
       break;
     default:


### PR DESCRIPTION
Summary: Continue the post-channel cleanup by making `IbSendRecvDevice` a stateless shared algorithm helper. `P2pIbgdaTransportDevice` and `P2pIbrcTransportDevice` now own their `IbSendRecvState` directly and pass it into the helper for send, recv, forward, progress, and pipeline-window operations. This keeps protocol state in the backend transport device instead of inside the reusable algorithm helper.

Reviewed By: saifhhasan

Differential Revision: D111372913
