### PR TITLE
Move IB sendrecv state into channels (#3127)

### DIFF
--- a/comms/prims/benchmarks/IbgdaForward.cu
+++ b/comms/prims/benchmarks/IbgdaForward.cu
@@ -18,10 +18,10 @@ __global__ void __launch_bounds__(512, 1) ibgda_forward_kernel(
   auto group = make_block_group();
 
   const std::size_t sectionBytes = (my_rank == 1)
-      ? min(prev_transport->send_recv_state().dataBufferSize, totalBytes)
+      ? min(prev_transport->channel_layout().data_buffer_size(), totalBytes)
       : min((my_rank == 0 ? next_transport : prev_transport)
-                ->send_recv_state()
-                .dataBufferSize,
+                ->channel_layout()
+                .data_buffer_size(),
             totalBytes);
   const std::size_t totalSections = totalBytes / sectionBytes;
 
@@ -54,10 +54,10 @@ __global__ void __launch_bounds__(512, 1) ibgda_recv_send_kernel(
   auto group = make_block_group();
 
   const std::size_t sectionBytes = (my_rank == 1)
-      ? min(prev_transport->send_recv_state().dataBufferSize, totalBytes)
+      ? min(prev_transport->channel_layout().data_buffer_size(), totalBytes)
       : min((my_rank == 0 ? next_transport : prev_transport)
-                ->send_recv_state()
-                .dataBufferSize,
+                ->channel_layout()
+                .data_buffer_size(),
             totalBytes);
   const std::size_t totalSections = totalBytes / sectionBytes;
 

--- a/comms/prims/benchmarks/IbgdaSendRecv.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cu
@@ -21,7 +21,7 @@ __device__ __forceinline__ std::size_t benchmark_align_protocol_bytes(
 __device__ __forceinline__ std::size_t section_bytes(
     P2pIbgdaTransportDevice* transport,
     std::size_t totalBytes) {
-  return min(transport->send_recv_state().dataBufferSize, totalBytes);
+  return min(transport->channel_layout().data_buffer_size(), totalBytes);
 }
 
 __device__ __forceinline__ std::size_t
@@ -311,25 +311,17 @@ __global__ void __launch_bounds__(512, 1) ibgda_drain_send_recv_kernel(
   }
 
   const int groupId = static_cast<int>(group.group_id);
-  const auto& state = transport->send_recv_state();
+  const auto& layout = transport->channel_layout();
   const std::size_t expectedBytes =
       protocol_bytes_for_tiled_group_per_launch(
-          totalBytes, numBlocks, state.dataBufferSize, groupId) *
+          totalBytes, numBlocks, layout.data_buffer_size(), groupId) *
       iterations;
   if (expectedBytes == 0) {
     return;
   }
-  transport->wait_counter(
-      group,
-      state.localCounterBuf.subBuffer(groupId * sizeof(uint64_t)),
-      expectedBytes,
-      timeout);
-  transport->wait_signal(
-      group,
-      state.localSignalBuf.subBuffer(
-          (state.maxGroups + groupId) * sizeof(uint64_t)),
-      expectedBytes,
-      timeout);
+  auto& channel = transport->local_channel(static_cast<uint32_t>(groupId));
+  transport->wait_counter(group, channel.nicDoneWait, expectedBytes, timeout);
+  transport->wait_signal(group, channel.slotFree, expectedBytes, timeout);
 }
 
 void launch_ibgda_drain_send_recv(
@@ -353,20 +345,22 @@ void launch_ibgda_drain_send_recv(
 __global__ void __launch_bounds__(256, 1) ibgda_reset_send_recv_kernel(
     P2pIbgdaTransportDevice* transport,
     int maxGroups) {
-  const auto& state = transport->send_recv_state();
+  const auto& layout = transport->channel_layout();
   const auto idx = blockIdx.x * blockDim.x + threadIdx.x;
   const auto stride = blockDim.x * gridDim.x;
 
-  auto* signalSlots = static_cast<uint64_t*>(state.localSignalBuf.ptr);
-  auto* counterSlots = static_cast<uint64_t*>(state.localCounterBuf.ptr);
+  auto* signalSlots = static_cast<uint64_t*>(layout.localSignalBuf.ptr);
+  auto* counterSlots = static_cast<uint64_t*>(layout.localCounterBuf.ptr);
 
   for (auto slot = idx; slot < static_cast<uint32_t>(2 * maxGroups);
        slot += stride) {
     if (signalSlots != nullptr) {
       signalSlots[slot] = 0;
     }
-    if (slot < state.state.size()) {
-      state.state[slot] = IbSendRecvState::ProgressSlot{};
+    if (slot < static_cast<uint32_t>(maxGroups)) {
+      auto& channel = transport->local_channel(slot);
+      channel.sendProgress = IbChannelProgress{};
+      channel.recvProgress = IbChannelProgress{};
     }
   }
 
@@ -505,7 +499,14 @@ __global__ void ibgda_snapshot_step_state_kernel(
     int count) {
   const auto idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < count) {
-    dst[idx] = transport->send_recv_state().state[idx].nextStep;
+    const auto& layout = transport->channel_layout();
+    const auto maxChannels = static_cast<uint32_t>(layout.maxChannels);
+    if (idx < maxChannels) {
+      dst[idx] = transport->local_channel(idx).sendProgress.nextStep;
+    } else {
+      dst[idx] =
+          transport->local_channel(idx - maxChannels).recvProgress.nextStep;
+    }
   }
 }
 

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -390,10 +390,9 @@ __global__ void progressReservationKernel(
   transport->init_recv_progress(group, recvBytes);
 
   if (group.is_leader()) {
-    const auto& sendRecvState = transport->send_recv_state();
-    output[0] = sendRecvState.state[group.group_id].nextStep;
-    output[1] =
-        sendRecvState.state[sendRecvState.maxGroups + group.group_id].nextStep;
+    const auto& channel = transport->local_channel(group.group_id);
+    output[0] = channel.sendProgress.nextStep;
+    output[1] = channel.recvProgress.nextStep;
   }
 }
 
@@ -437,31 +436,21 @@ __global__ void sendRecvReuseCreditKernel(
     }
   }
 
-  const auto& state = transport->send_recv_state();
   const auto groupId = static_cast<int>(group.group_id);
+  auto& channel = transport->local_channel(static_cast<uint32_t>(groupId));
   if (send && waitExpectedNicDoneCredit != 0) {
     transport->wait_counter(
-        group,
-        state.localCounterBuf.subBuffer(groupId * sizeof(uint64_t)),
-        waitExpectedNicDoneCredit,
-        timeout);
+        group, channel.nicDoneWait, waitExpectedNicDoneCredit, timeout);
   }
   if (send && waitExpectedSlotFreeCredit != 0) {
     transport->wait_signal(
-        group,
-        state.localSignalBuf.subBuffer(
-            (state.maxGroups + groupId) * sizeof(uint64_t)),
-        waitExpectedSlotFreeCredit,
-        timeout);
+        group, channel.slotFree, waitExpectedSlotFreeCredit, timeout);
   }
 
   if (group.is_leader()) {
-    output[0] = transport->read_counter(
-        state.localCounterBuf.subBuffer(groupId * sizeof(uint64_t)));
-    output[1] = transport->read_signal(
-        state.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)));
-    output[2] = transport->read_signal(state.localSignalBuf.subBuffer(
-        (state.maxGroups + groupId) * sizeof(uint64_t)));
+    output[0] = transport->read_counter(channel.nicDoneWait);
+    output[1] = transport->read_signal(channel.dataReady);
+    output[2] = transport->read_signal(channel.slotFree);
   }
 }
 #endif

--- a/comms/prims/tests/RecvForwardChainTest.cu
+++ b/comms/prims/tests/RecvForwardChainTest.cu
@@ -45,13 +45,12 @@ __global__ void recv_forward_chain_kernel(
     char* dst = use_dst ? (recv_buf + my_off) : nullptr;
     prev.forward(group, dst, next, my_bytes);
     if (out != nullptr && group.is_leader()) {
-      const auto& prevState = prev.send_recv_state();
-      const auto& nextState = next.send_recv_state();
-      out[0] =
-          prevState.state[prevState.maxGroups + group.group_id].reuseCreditStep;
-      out[1] = prevState.state[prevState.maxGroups + group.group_id].nextStep;
-      out[2] = nextState.state[group.group_id].reuseCreditStep;
-      out[3] = nextState.state[group.group_id].nextStep;
+      const auto& prevChannel = prev.local_channel(group.group_id);
+      const auto& nextChannel = next.local_channel(group.group_id);
+      out[0] = prevChannel.recvProgress.reuseCreditStep;
+      out[1] = prevChannel.recvProgress.nextStep;
+      out[2] = nextChannel.sendProgress.reuseCreditStep;
+      out[3] = nextChannel.sendProgress.nextStep;
     }
   }
 }

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -375,12 +375,7 @@ std::size_t MultiPeerIbTransportBase::sendRecvCounterBytesPerPeer() const {
   return static_cast<std::size_t>(config_.max_num_channels) * sizeof(uint64_t);
 }
 
-std::size_t MultiPeerIbTransportBase::sendRecvStateBytesPerPeer() const {
-  return 2 * static_cast<std::size_t>(config_.max_num_channels) *
-      sizeof(IbSendRecvState::ProgressSlot);
-}
-
-IbSendRecvState MultiPeerIbTransportBase::sendRecvStateForPeer(
+IbChannelLayout MultiPeerIbTransportBase::channelLayoutForPeer(
     int peerIndex) const {
   if (!sendRecvBuffersEnabled() || sendRecvPeerBuffers_.empty() ||
       peerIndex < 0 ||
@@ -388,7 +383,7 @@ IbSendRecvState MultiPeerIbTransportBase::sendRecvStateForPeer(
     return {};
   }
   const auto& pb = sendRecvPeerBuffers_[peerIndex];
-  return IbSendRecvState{
+  return IbChannelLayout{
       .sendStagingBuf = pb.sendStaging,
       .recvStagingBuf = pb.remoteRecvStaging,
       .sendStagingPtr = static_cast<char*>(pb.sendStaging.ptr),
@@ -397,10 +392,9 @@ IbSendRecvState MultiPeerIbTransportBase::sendRecvStateForPeer(
       .remoteSignalBuf = pb.remoteSignal,
       .localCounterBuf = pb.counter,
       .localCounterCompletionBuf = pb.counterCompletion,
-      .state = pb.state.value_or(DeviceSpan<IbSendRecvState::ProgressSlot>()),
-      .maxGroups = config_.max_num_channels,
+      .maxChannels = config_.max_num_channels,
       .pipelineDepth = config_.pipelineDepth,
-      .dataBufferSize = config_.dataBufferSize,
+      .perChannelSize = config_.perChannelSize,
   };
 }
 
@@ -420,10 +414,6 @@ void MultiPeerIbTransportBase::allocateSendRecvBuffersEager(
   const std::size_t stagingPerPeer = sendRecvStagingBytesPerPeer();
   const std::size_t signalPerPeer = sendRecvSignalBytesPerPeer();
   const std::size_t counterPerPeer = sendRecvCounterBytesPerPeer();
-  const std::size_t statePerPeer = sendRecvStateBytesPerPeer();
-  const auto stateSlotsPerPeer =
-      static_cast<DeviceSpan<IbSendRecvState::ProgressSlot>::size_type>(
-          2 * config_.max_num_channels);
 
   // Align every GPU bulk allocation to the CUDA VMM allocation granularity so
   // that any buffer which is later mlx5 Data-Direct (BAR1) registered has a 0
@@ -476,9 +466,7 @@ void MultiPeerIbTransportBase::allocateSendRecvBuffersEager(
   // single granularity unit and share one aligned Data-Direct MR (offset 0),
   // instead of one aligned unit each. Region layout: [signal | (device
   // counter)], each 16B-aligned; the whole allocation rounded to the VMM
-  // granularity so the DD export offset is 0. The device-local progress state
-  // is never RDMA-registered or shared, so it needs no alignment and is
-  // allocated separately below at its natural size.
+  // granularity so the DD export offset is 0.
   const std::size_t signalTotal = signalPerPeer * numPeers;
   const bool deviceCounter = (counterStorage == IbCounterStorage::Device);
   const std::size_t counterTotal =
@@ -494,14 +482,6 @@ void MultiPeerIbTransportBase::allocateSendRecvBuffersEager(
       slotGpuMemset(sendRecvControlBulk_->get(), 0, controlBytes),
       "MultiPeerIbTransport: zero send/recv control bulk");
   char* controlBase = static_cast<char*>(sendRecvControlBulk_->get());
-
-  // Device-local progress state: separate allocation, natural size,
-  // unregistered.
-  sendRecvStateBulk_ =
-      std::make_unique<meta::comms::DeviceBuffer>(statePerPeer * numPeers);
-  checkSlotGpu(
-      slotGpuMemset(sendRecvStateBulk_->get(), 0, statePerPeer * numPeers),
-      "MultiPeerIbTransport: zero send/recv state bulk");
 
   // Staging is bulk data: opt into Relaxed Ordering. Signal/counter stay strict
   // so a flag write can't be reordered ahead of the data on the shared route.
@@ -553,9 +533,6 @@ void MultiPeerIbTransportBase::allocateSendRecvBuffersEager(
     pb.counter = counterBulkBuf.subBuffer(i * counterPerPeer);
     pb.counterCompletion =
         counterCompletionBulkBuf.subBuffer(i * counterPerPeer);
-    auto* statePtr = reinterpret_cast<IbSendRecvState::ProgressSlot*>(
-        static_cast<char*>(sendRecvStateBulk_->get()) + i * statePerPeer);
-    pb.state.emplace(statePtr, stateSlotsPerPeer);
   }
 
   VLOG(1) << "MultiPeerIbTransport: rank " << myRank_
@@ -616,7 +593,6 @@ void MultiPeerIbTransportBase::cleanupSendRecvBuffers() noexcept {
   sendRecvSendStagingBulk_.reset();
   sendRecvRecvStagingBulk_.reset();
   sendRecvControlBulk_.reset();
-  sendRecvStateBulk_.reset();
   freeCounterSlotAllocation(sendRecvHostCounterAllocation_);
   sendRecvRecvStagingBulkReg_ = IbgdaLocalBuffer{};
   sendRecvSignalBulkReg_ = IbgdaLocalBuffer{};
@@ -657,16 +633,12 @@ void MultiPeerIbTransportBase::allocateSendRecvBufferForPeer(
   const std::size_t stagingPerPeer = sendRecvStagingBytesPerPeer();
   const std::size_t signalPerPeer = sendRecvSignalBytesPerPeer();
   const std::size_t counterPerPeer = sendRecvCounterBytesPerPeer();
-  const std::size_t statePerPeer = sendRecvStateBytesPerPeer();
-  const auto stateSlots =
-      static_cast<DeviceSpan<IbSendRecvState::ProgressSlot>::size_type>(
-          2 * config_.max_num_channels);
   const bool deviceCounter = (counterStorage == IbCounterStorage::Device);
 
-  // One contiguous device buffer: sendStaging | recvStaging | signal | state,
+  // One contiguous device buffer: sendStaging | recvStaging | signal,
   // plus the counter when it is device-resident. A HostPinned counter is
   // allocated separately (host-mapped, never RDMA-registered).
-  std::size_t total = 2 * stagingPerPeer + signalPerPeer + statePerPeer;
+  std::size_t total = 2 * stagingPerPeer + signalPerPeer;
   if (deviceCounter) {
     total += counterPerPeer;
   }
@@ -687,9 +659,6 @@ void MultiPeerIbTransportBase::allocateSendRecvBufferForPeer(
   void* signalPtr = p + off;
   pb.signal = IbgdaLocalBuffer(signalPtr, reg.lkey_per_device);
   off += signalPerPeer;
-  auto* statePtr = reinterpret_cast<IbSendRecvState::ProgressSlot*>(p + off);
-  off += statePerPeer;
-  pb.state.emplace(statePtr, stateSlots);
   if (deviceCounter) {
     pb.counter = IbgdaLocalBuffer(p + off, reg.lkey_per_device);
     pb.counterCompletion = pb.counter;
@@ -742,16 +711,15 @@ void MultiPeerIbTransportBase::cleanupSendRecvBufferForPeer(
   if (peerIndex < static_cast<int>(lazySendRecvHostCounters_.size())) {
     freeCounterSlotAllocation(lazySendRecvHostCounters_[peerIndex]);
   }
-  // Reset the per-peer views field-wise (IbSendRecvPeerBuffers is not
-  // copy-assignable due to its optional<DeviceSpan> state member).
+  // Reset the per-peer views field-wise.
   auto& pb = sendRecvPeerBuffers_[peerIndex];
   pb.sendStaging = IbgdaLocalBuffer{};
   pb.recvStaging = IbgdaLocalBuffer{};
   pb.signal = IbgdaLocalBuffer{};
   pb.counter = IbgdaLocalBuffer{};
+  pb.counterCompletion = IbgdaLocalBuffer{};
   pb.remoteRecvStaging = IbgdaRemoteBuffer{};
   pb.remoteSignal = IbgdaRemoteBuffer{};
-  pb.state.reset();
 }
 
 void MultiPeerIbTransportBase::openNics() {

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -367,16 +367,13 @@ enum class IbCounterStorage {
 };
 
 // Per-peer send/recv staging-ring views. Eager mode owns the bulk allocations
-// and slices these; the device side reads them via sendRecvStateForPeer().
+// and slices these; the device side reads them via channelLayoutForPeer().
 struct IbSendRecvPeerBuffers {
   IbgdaLocalBuffer sendStaging;
   IbgdaLocalBuffer recvStaging;
   IbgdaLocalBuffer signal;
   IbgdaLocalBuffer counter;
   IbgdaLocalBuffer counterCompletion;
-  // DeviceSpan has a const data_ member (no copy-assign), so wrap in optional
-  // and emplace() the per-peer slice.
-  std::optional<DeviceSpan<IbSendRecvState::ProgressSlot>> state;
   IbgdaRemoteBuffer remoteRecvStaging;
   IbgdaRemoteBuffer remoteSignal;
 };
@@ -520,15 +517,15 @@ class MultiPeerIbTransportBase {
   // ---- shared send/recv staging-ring lifecycle (eager mode) ----
   // Backend-agnostic host send/recv buffer management, shared by IBGDA (Device
   // counter, NIC loopback atomic) and IBRC (Host counter, CPU proxy). Staging
-  // = pipelineDepth * dataBufferSize per direction; signal/state are sized off
+  // = pipelineDepth * dataBufferSize per direction; signal is sized off
   // max_num_channels. Per-peer staging + signal are device-registered;
   // recvStaging + signal are collectively exchanged so peers can RDMA into our
   // ring.
   bool sendRecvBuffersEnabled() const {
     return config_.perChannelSize > 0;
   }
-  IbSendRecvState sendRecvStateForPeer(int peerIndex) const;
-  // Allocate + register the per-peer staging/signal/state bulks and slice them.
+  IbChannelLayout channelLayoutForPeer(int peerIndex) const;
+  // Allocate + register the per-peer staging/signal bulks and slice them.
   // counterStorage selects the NIC_DONE counter: Device (transport-allocated,
   // registered) or HostPinned (transport-allocated host-mapped, never
   // registered).
@@ -561,7 +558,6 @@ class MultiPeerIbTransportBase {
   std::size_t sendRecvStagingBytesPerPeer() const;
   std::size_t sendRecvSignalBytesPerPeer() const;
   std::size_t sendRecvCounterBytesPerPeer() const;
-  std::size_t sendRecvStateBytesPerPeer() const;
 
   void allocateSignalCounterResources(
       IbCounterStorage counterStorage,
@@ -653,9 +649,6 @@ class MultiPeerIbTransportBase {
   // Host-counter configs put only the signal region here. See
   // allocateSendRecvBuffersEager.
   std::unique_ptr<meta::comms::DeviceBuffer> sendRecvControlBulk_;
-  // Device-local progress state (never RDMA-registered / shared): separate,
-  // natural size, no alignment needed.
-  std::unique_ptr<meta::comms::DeviceBuffer> sendRecvStateBulk_;
   IbgdaLocalBuffer sendRecvRecvStagingBulkReg_;
   IbgdaLocalBuffer sendRecvSignalBulkReg_;
   IbgdaLocalBuffer sendRecvCounterBulkReg_;

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -530,13 +530,20 @@ __device__ __forceinline__ void P2pIbTransportDevice::forward(
     std::size_t max_signal_bytes,
     const Timeout& timeout,
     Args... args) {
-  if (type == P2pIbBackendType::IBRC) {
+  if (type == P2pIbBackendType::IBRC && fwd.type == P2pIbBackendType::IBRC) {
     ibrc->forward<CopyOp>(
         group, dst, *fwd.ibrc, nbytes, max_signal_bytes, timeout, args...);
-  } else {
+    return;
+  }
+  if (type == P2pIbBackendType::IBGDA && fwd.type == P2pIbBackendType::IBGDA) {
     ibgda->forward<CopyOp>(
         group, dst, *fwd.ibgda, nbytes, max_signal_bytes, timeout, args...);
+    return;
   }
+  if (group.is_leader()) {
+    printf("[PIPES] FATAL: mixed IB backend forward is unsupported\n");
+  }
+  PIPES_DEVICE_TRAP();
 }
 
 __device__ __forceinline__ std::size_t P2pIbTransportDevice::pipeline_window()

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -92,1718 +92,1731 @@ __device__ __forceinline__ void trace_ibgda_event(
 }
 #endif
 
+namespace detail {
+
 /**
- * IbSendRecvDevice — transport-agnostic pipelined RDMA send/recv.
+ * Physical staging range for the next resumable progress step.
  *
- * This class owns master's full async send/recv algorithm: the blocking
- * `send`/`recv`/`forward`, the resumable `init_*_progress` /
- * `progress_*_once` pair, and all of their private helpers. The send/recv
- * algorithm is independent of the underlying transport: it only needs the
- * common explicit-buffer IB device ops `put` (fused signal+counter),
+ * `stagingOff` is an offset into the transport-owned send/recv staging
+ * buffers. `dataOff` is the matching protocol offset into the caller's user
+ * buffer. `bytes` never crosses a per-block staging partition or the
+ * reserved protocol byte count. `streamEnd` is the absolute protocol byte
+ * value after this chunk and is used as the DATA_READY, SLOT_FREE, and
+ * NIC_DONE readiness threshold. `dataOff` is a protocol offset; callers mask
+ * it against the payload byte count before invoking user-buffer copy
+ * callbacks.
+ */
+struct ProgressChunk {
+  std::size_t stagingOff;
+  std::size_t dataOff;
+  std::size_t bytes;
+  uint64_t streamEnd;
+};
+
+/**
+ * Register-only geometry for one resumable progress call.
+ *
+ * This is intentionally not stored in `IbChannelProgress`: callers pass the
+ * same static geometry to init and progress, and each progress call derives
+ * these values in registers instead of reloading duplicated fields from
+ * HBM-backed progress state.
+ */
+struct ProgressGeometry {
+  int groupId;
+  std::size_t payloadBytes;
+  std::size_t protocolBytes;
+  std::size_t perBlockSlot;
+  std::size_t chunkSize;
+  int pipelineDepth;
+};
+
+template <typename Transport>
+__device__ __forceinline__ IbChannelProgress& progress_send_slot(
+    Transport& transport,
+    ThreadGroup& group);
+
+template <typename Transport>
+__device__ __forceinline__ IbChannelProgress& progress_recv_slot(
+    Transport& transport,
+    ThreadGroup& group);
+
+__device__ __forceinline__ static std::size_t valid_payload_bytes(
+    std::size_t byteOffset,
+    std::size_t chunkBytes,
+    std::size_t payloadBytes);
+
+__device__ __forceinline__ static std::size_t align_protocol_bytes(
+    std::size_t nbytes);
+
+__device__ __forceinline__ void assert_progress_slot_idle(
+    ThreadGroup& group,
+    const IbChannelProgress& slot,
+    const char* opName);
+
+__device__ __forceinline__ void store_progress_state(
+    ThreadGroup& group,
+    IbChannelProgress& slot,
+    const IbChannelProgress& state);
+
+__device__ __forceinline__ ProgressGeometry make_progress_geometry(
+    const IbChannelLayout& channelLayout,
+    ThreadGroup& group,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const char* opName);
+
+__device__ __forceinline__ bool should_post_nic_done_credit(
+    uint64_t streamEnd,
+    int64_t reuseCreditStep,
+    const ProgressGeometry& geometry);
+
+__device__ __forceinline__ bool should_post_nic_done_credit(
+    uint64_t streamEnd,
+    int64_t reuseCreditStep,
+    std::size_t perBlockSlot,
+    int pipelineDepth);
+
+__device__ __forceinline__ bool should_post_slot_free_credit(
+    uint64_t streamEnd,
+    int64_t reuseCreditStep,
+    const ProgressGeometry& geometry);
+
+__device__ __forceinline__ bool should_post_slot_free_credit(
+    uint64_t streamEnd,
+    int64_t reuseCreditStep,
+    std::size_t perBlockSlot,
+    int pipelineDepth);
+
+__device__ __forceinline__ uint64_t
+reuse_credit_value(uint64_t streamEnd, int64_t reuseCreditStep);
+
+__device__ __forceinline__ int64_t reserve_progress_step(
+    ThreadGroup& group,
+    IbChannelProgress& slot,
+    std::size_t nbytes);
+
+__device__ __forceinline__ void validate_send_progress_stage(
+    ThreadGroup& group,
+    const IbChannelProgress& state);
+
+__device__ __forceinline__ void validate_recv_progress_stage(
+    ThreadGroup& group,
+    const IbChannelProgress& state);
+
+__device__ __forceinline__ void transition_progress_stage(
+    ThreadGroup& group,
+    IbChannelProgress& state,
+    detail::IbSendRecvProgressStage next);
+
+__device__ __forceinline__ ProgressChunk next_chunk(
+    const IbChannelLayout& channelLayout,
+    const IbChannelProgress& state,
+    const ProgressGeometry& geometry);
+
+/**
+ * Transport-agnostic pipelined RDMA send/recv helpers.
+ *
+ * These helpers implement the blocking `send`/`recv`/`forward`, the resumable
+ * `init_*_progress` / `progress_*_once` pair, and their private helpers. The
+ * send/recv algorithm is independent of the underlying transport: it only
+ * needs the common explicit-buffer IB device ops `put` (fused signal+counter),
  * `signal`, `wait_signal`, `wait_counter`, `read_signal`, and `read_counter`.
  *
- * Every public method takes the backend-owned `IbSendRecvState` plus the owning
- * transport as parameters and routes every transport op through that transport.
- * `P2pIbgdaTransportDevice` and `P2pIbrcTransportDevice` own the state and use
- * this helper only for the shared send/recv algorithm.
+ * Every public entry point takes the owning transport and routes every
+ * transport op through it. `P2pIbgdaTransportDevice` and
+ * `P2pIbrcTransportDevice` own the channel layout/state and use these helpers
+ * only for the shared send/recv algorithm.
  */
-class IbSendRecvDevice {
- public:
-  __host__ __device__ IbSendRecvDevice() = default;
 
-  /**
-   * Initialize transport-owned state for one pipelined send operation.
-   *
-   * The transport reserves the sender-side byte stream for `group.group_id`
-   * and starts the internal state in the sender state machine unless
-   * `nbytes == 0`. It does not capture the source pointer; callers pass the
-   * pointer to each `progress_send_once()` call.
-   *
-   * The send progress slot for this group must be idle. Re-initializing a
-   * group while a previous send is outstanding traps with a diagnostic instead
-   * of silently overwriting the in-flight byte range.
-   *
-   * Channel count and per-channel staging geometry are fixed in
-   * `IbChannelLayout`. `max_signal_bytes == 0` sends one signal per
-   * per-channel staging partition; smaller non-zero values split that
-   * partition into multiple signaled sub-chunks for finer overlap with the
-   * receiver.
-   *
-   * Zero-byte sends mark the internal state `Done` without reading or
-   * validating staging geometry. This matches the blocking `send()` no-op
-   * behavior and lets schedulers treat empty operations uniformly.
-   *
-   * @param group Thread group that will execute all later progress calls.
-   * @param nbytes Number of user-buffer bytes to send for this group.
-   * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
-   */
-  __device__ __forceinline__ void init_send_progress(
-      IbSendRecvState& sendRecvState,
-      ThreadGroup& group,
-      std::size_t nbytes,
-      std::size_t max_signal_bytes = 0) {
+/**
+ * Initialize transport-owned state for one pipelined send operation.
+ *
+ * The transport reserves the sender-side byte stream for `group.group_id`
+ * and starts the internal state in the sender state machine unless
+ * `nbytes == 0`. It does not capture the source pointer; callers pass the
+ * pointer to each `progress_send_once()` call.
+ *
+ * The send progress slot for this group must be idle. Re-initializing a
+ * group while a previous send is outstanding traps with a diagnostic instead
+ * of silently overwriting the in-flight byte range.
+ *
+ * Channel count and per-channel staging geometry are fixed in
+ * `IbChannelLayout`. `max_signal_bytes == 0` sends one signal per
+ * per-channel staging partition; smaller non-zero values split that
+ * partition into multiple signaled sub-chunks for finer overlap with the
+ * receiver.
+ *
+ * Zero-byte sends mark the internal state `Done` without reading or
+ * validating staging geometry. This matches the blocking `send()` no-op
+ * behavior and lets schedulers treat empty operations uniformly.
+ *
+ * @param group Thread group that will execute all later progress calls.
+ * @param nbytes Number of user-buffer bytes to send for this group.
+ * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
+ */
+template <typename Transport>
+__device__ __forceinline__ void init_send_progress(
+    Transport& transport,
+    ThreadGroup& group,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    const int progressIndex = progress_send_index(sendRecvState, group);
-    auto& slot = progress_state_slot(sendRecvState, group, progressIndex);
-    assert_progress_slot_idle(group, slot, "send");
-    IbSendRecvState::ProgressSlot state{};
-    state.reuseCreditStep = slot.reuseCreditStep;
-    state.activeStage = nbytes == 0
-        ? detail::IbSendRecvProgressStage::Done
-        : detail::IbSendRecvProgressStage::WaitNicDone;
-    if (nbytes == 0) {
-      store_progress_state(sendRecvState, group, progressIndex, state);
-      return;
-    }
-    // Validate the transfer before reserving the transport byte cursor.
-    const ProgressGeometry geometry = make_progress_geometry(
-        sendRecvState, group, nbytes, max_signal_bytes, "init_send_progress");
-    state.activeBaseStep = reserve_progress_step(
-        sendRecvState, group, progressIndex, geometry.protocolBytes);
-    store_progress_state(sendRecvState, group, progressIndex, state);
-#else
-    (void)group;
-    (void)nbytes;
-    (void)max_signal_bytes;
-#endif
+  auto& channelLayout = transport.channel_layout();
+  auto& slot = progress_send_slot(transport, group);
+  assert_progress_slot_idle(group, slot, "send");
+  IbChannelProgress state{};
+  state.reuseCreditStep = slot.reuseCreditStep;
+  state.activeStage = nbytes == 0
+      ? detail::IbSendRecvProgressStage::Done
+      : detail::IbSendRecvProgressStage::WaitNicDone;
+  if (nbytes == 0) {
+    store_progress_state(group, slot, state);
+    return;
   }
+  // Validate the transfer before reserving the transport byte cursor.
+  const ProgressGeometry geometry = make_progress_geometry(
+      channelLayout, group, nbytes, max_signal_bytes, "init_send_progress");
+  state.activeBaseStep =
+      reserve_progress_step(group, slot, geometry.protocolBytes);
+  store_progress_state(group, slot, state);
+#else
+  (void)transport;
+  (void)group;
+  (void)nbytes;
+  (void)max_signal_bytes;
+#endif
+}
 
-  /**
-   * Initialize transport-owned state for one pipelined recv operation.
-   *
-   * The transport reserves the receiver-side byte stream for `group.group_id`
-   * and starts the internal state in the receiver state machine unless
-   * `nbytes == 0`. It does not capture the destination pointer; callers pass
-   * the pointer to each `progress_recv_once()` call.
-   *
-   * The recv progress slot for this group must be idle. Re-initializing a
-   * group while a previous recv is outstanding traps with a diagnostic instead
-   * of silently overwriting the in-flight byte range.
-   *
-   * The sender and receiver must use compatible `max_signal_bytes` for a
-   * logical transfer. Channel count and staging geometry are fixed in the
-   * transport layout; `max_signal_bytes` only controls sub-chunk signaling.
-   *
-   * Zero-byte receives mark the internal state `Done` without reading or
-   * validating staging geometry. This matches the blocking `recv()` no-op
-   * behavior and lets schedulers treat empty operations uniformly.
-   *
-   * @param group Thread group that will execute all later progress calls.
-   * @param nbytes Number of user-buffer bytes to receive for this group.
-   * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
-   */
-  __device__ __forceinline__ void init_recv_progress(
-      IbSendRecvState& sendRecvState,
-      ThreadGroup& group,
-      std::size_t nbytes,
-      std::size_t max_signal_bytes = 0) {
+/**
+ * Initialize transport-owned state for one pipelined recv operation.
+ *
+ * The transport reserves the receiver-side byte stream for `group.group_id`
+ * and starts the internal state in the receiver state machine unless
+ * `nbytes == 0`. It does not capture the destination pointer; callers pass
+ * the pointer to each `progress_recv_once()` call.
+ *
+ * The recv progress slot for this group must be idle. Re-initializing a
+ * group while a previous recv is outstanding traps with a diagnostic instead
+ * of silently overwriting the in-flight byte range.
+ *
+ * The sender and receiver must use compatible `max_signal_bytes` for a
+ * logical transfer. Channel count and staging geometry are fixed in the
+ * transport layout; `max_signal_bytes` only controls sub-chunk signaling.
+ *
+ * Zero-byte receives mark the internal state `Done` without reading or
+ * validating staging geometry. This matches the blocking `recv()` no-op
+ * behavior and lets schedulers treat empty operations uniformly.
+ *
+ * @param group Thread group that will execute all later progress calls.
+ * @param nbytes Number of user-buffer bytes to receive for this group.
+ * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
+ */
+template <typename Transport>
+__device__ __forceinline__ void init_recv_progress(
+    Transport& transport,
+    ThreadGroup& group,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    const int progressIndex = progress_recv_index(sendRecvState, group);
-    auto& slot = progress_state_slot(sendRecvState, group, progressIndex);
-    assert_progress_slot_idle(group, slot, "recv");
-    IbSendRecvState::ProgressSlot state{};
-    state.reuseCreditStep = slot.reuseCreditStep;
-    state.activeStage = nbytes == 0
-        ? detail::IbSendRecvProgressStage::Done
-        : detail::IbSendRecvProgressStage::WaitDataReady;
-    if (nbytes == 0) {
-      store_progress_state(sendRecvState, group, progressIndex, state);
-      return;
-    }
-    // Validate the transfer before reserving the transport byte cursor.
-    const ProgressGeometry geometry = make_progress_geometry(
-        sendRecvState, group, nbytes, max_signal_bytes, "init_recv_progress");
-    state.activeBaseStep = reserve_progress_step(
-        sendRecvState, group, progressIndex, geometry.protocolBytes);
-    store_progress_state(sendRecvState, group, progressIndex, state);
-#else
-    (void)group;
-    (void)nbytes;
-    (void)max_signal_bytes;
-#endif
+  auto& channelLayout = transport.channel_layout();
+  auto& slot = progress_recv_slot(transport, group);
+  assert_progress_slot_idle(group, slot, "recv");
+  IbChannelProgress state{};
+  state.reuseCreditStep = slot.reuseCreditStep;
+  state.activeStage = nbytes == 0
+      ? detail::IbSendRecvProgressStage::Done
+      : detail::IbSendRecvProgressStage::WaitDataReady;
+  if (nbytes == 0) {
+    store_progress_state(group, slot, state);
+    return;
   }
+  // Validate the transfer before reserving the transport byte cursor.
+  const ProgressGeometry geometry = make_progress_geometry(
+      channelLayout, group, nbytes, max_signal_bytes, "init_recv_progress");
+  state.activeBaseStep =
+      reserve_progress_step(group, slot, geometry.protocolBytes);
+  store_progress_state(group, slot, state);
+#else
+  (void)transport;
+  (void)group;
+  (void)nbytes;
+  (void)max_signal_bytes;
+#endif
+}
 
-  /**
-   * Attempt bounded progress on one initialized send.
-   *
-   * This method advances at most one staged copy plus one RDMA put for the
-   * current chunk. It never spins on NIC_DONE or SLOT_FREE: if either
-   * dependency is not ready, it returns immediately so a higher-level scheduler
-   * can try another independent lane. If a `Timeout` is enabled, it is checked
-   * only at those readiness points and should already have been started by the
-   * caller.
-   *
-   * The send path first waits for NIC_DONE before reusing the local
-   * send-staging range, then copies user data into send-staging through
-   * `CopyOp::send`, waits for SLOT_FREE before reusing the peer's recv-staging
-   * range, and finally issues an RDMA put that piggybacks DATA_READY and may
-   * batch NIC_DONE into the local counter. Returning `Done` means the reserved
-   * byte range has completed.
-   *
-   * `CopyOp` must expose `send(dst, src, bytes, group, dataOffset, args...)`.
-   * The default `Memcpy` copies bytes cooperatively across the supplied
-   * `ThreadGroup`; custom copy ops may use `args` to pass reduction or
-   * conversion context.
-   *
-   * @param transport Owning transport used for every transport op.
-   * @param group Thread group matching the one used during initialization.
-   * @param src Source user buffer. The range `[src, src + nbytes)` must remain
-   *            valid until `Done`.
-   * @param nbytes Number of user-buffer bytes from the matching init call.
-   * @param max_signal_bytes Maximum signaled sub-chunk size from init.
-   * @param timeout Optional device timeout checked while dependencies wait.
-   * @param args Additional arguments forwarded to `CopyOp::send`.
-   */
-  template <typename Transport, typename CopyOp = Memcpy, typename... Args>
-  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
-      Transport& transport,
-      IbSendRecvState& sendRecvState,
-      ThreadGroup& group,
-      const void* __restrict__ src,
-      std::size_t nbytes,
-      std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
-      Args... args) {
+/**
+ * Attempt bounded progress on one initialized send.
+ *
+ * This method advances at most one staged copy plus one RDMA put for the
+ * current chunk. It never spins on NIC_DONE or SLOT_FREE: if either
+ * dependency is not ready, it returns immediately so a higher-level scheduler
+ * can try another independent lane. If a `Timeout` is enabled, it is checked
+ * only at those readiness points and should already have been started by the
+ * caller.
+ *
+ * The send path first waits for NIC_DONE before reusing the local
+ * send-staging range, then copies user data into send-staging through
+ * `CopyOp::send`, waits for SLOT_FREE before reusing the peer's recv-staging
+ * range, and finally issues an RDMA put that piggybacks DATA_READY and may
+ * batch NIC_DONE into the local counter. Returning `Done` means the reserved
+ * byte range has completed.
+ *
+ * `CopyOp` must expose `send(dst, src, bytes, group, dataOffset, args...)`.
+ * The default `Memcpy` copies bytes cooperatively across the supplied
+ * `ThreadGroup`; custom copy ops may use `args` to pass reduction or
+ * conversion context.
+ *
+ * @param transport Owning transport used for every transport op.
+ * @param group Thread group matching the one used during initialization.
+ * @param src Source user buffer. The range `[src, src + nbytes)` must remain
+ *            valid until `Done`.
+ * @param nbytes Number of user-buffer bytes from the matching init call.
+ * @param max_signal_bytes Maximum signaled sub-chunk size from init.
+ * @param timeout Optional device timeout checked while dependencies wait.
+ * @param args Additional arguments forwarded to `CopyOp::send`.
+ */
+template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
+    Transport& transport,
+    ThreadGroup& group,
+    const void* __restrict__ src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0,
+    const Timeout& timeout = Timeout(),
+    Args... args) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #ifdef __HIP_PLATFORM_AMD__
-    static_assert(
-        sizeof(CopyOp) == 0,
-        "IbSendRecvDevice::progress_send_once() requires NVIDIA GPU");
+  static_assert(
+      sizeof(CopyOp) == 0, "detail::progress_send_once() requires NVIDIA GPU");
 #endif
-    const int progressIndex = progress_send_index(sendRecvState, group);
-    IbSendRecvState::ProgressSlot state =
-        progress_state_slot(sendRecvState, group, progressIndex);
-    if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
-      return IbgdaSendRecvProgressStatus::Done;
-    }
-    const ProgressGeometry progress_params = make_progress_geometry(
-        sendRecvState, group, nbytes, max_signal_bytes, "progress_send_once");
-    if (state.activeNextByte >= progress_params.protocolBytes) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: progress_send_once nextByte=%llu >= "
-            "protocolBytes=%llu without Done stage\n",
-            static_cast<unsigned long long>(state.activeNextByte),
-            static_cast<unsigned long long>(progress_params.protocolBytes));
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    validate_send_progress_stage(group, state);
-
-    const detail::IbSendRecvProgressStage initialStage = state.activeStage;
-    const std::size_t initialNextByte = state.activeNextByte;
-    const std::size_t pipelineBytes = progress_params.perBlockSlot *
-        static_cast<std::size_t>(sendRecvState.pipelineDepth);
-
-    if (state.activeStage == detail::IbSendRecvProgressStage::WaitNicDone) {
-      const ProgressChunk chunk =
-          next_chunk(sendRecvState, state, progress_params);
-      if (chunk.streamEnd > pipelineBytes) {
-        const uint64_t expected = chunk.streamEnd - pipelineBytes;
-        uint32_t ready = 1;
-        unsigned long long current = 0;
-        if (group.is_leader()) {
-          current = static_cast<unsigned long long>(
-              transport.read_counter(sendRecvState.localCounterBuf.subBuffer(
-                  progress_params.groupId * sizeof(uint64_t))));
-          ready = current >= expected ? 1U : 0U;
-          if (!ready) {
-            TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
-                timeout,
-                "progress_send_once waiting for NIC_DONE expected>=%llu, "
-                "current=%llu",
-                static_cast<unsigned long long>(expected),
-                current);
-          }
-        }
-        ready = group.broadcast<uint32_t>(ready);
-        if (!ready) {
-          return IbgdaSendRecvProgressStatus::Waiting;
-        }
-      }
-
-      const std::size_t validBytes = valid_payload_bytes(
-          chunk.dataOff, chunk.bytes, progress_params.payloadBytes);
-      if (validBytes > 0) {
-        CopyOp::send(
-            sendRecvState.sendStagingPtr + chunk.stagingOff,
-            static_cast<const char*>(src) + chunk.dataOff,
-            validBytes,
-            group,
-            chunk.dataOff,
-            args...);
-      }
-      group.sync();
-      transition_progress_stage(
-          group, state, detail::IbSendRecvProgressStage::WaitSlotFree);
-    }
-
-    if (state.activeStage == detail::IbSendRecvProgressStage::WaitSlotFree) {
-      const ProgressChunk chunk =
-          next_chunk(sendRecvState, state, progress_params);
-      if (chunk.streamEnd > pipelineBytes) {
-        const uint64_t expected = chunk.streamEnd - pipelineBytes;
-        uint32_t ready = 1;
-        unsigned long long current = 0;
-        if (group.is_leader()) {
-          current = static_cast<unsigned long long>(
-              transport.read_signal(sendRecvState.localSignalBuf.subBuffer(
-                  (sendRecvState.maxGroups + progress_params.groupId) *
-                  sizeof(uint64_t))));
-          ready = current >= expected ? 1U : 0U;
-          if (!ready) {
-            TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
-                timeout,
-                "progress_send_once waiting for SLOT_FREE expected>=%llu, "
-                "current=%llu",
-                static_cast<unsigned long long>(expected),
-                current);
-          }
-        }
-        ready = group.broadcast<uint32_t>(ready);
-        if (!ready) {
-          if (state.activeStage != initialStage ||
-              state.activeNextByte != initialNextByte) {
-            store_progress_state(sendRecvState, group, progressIndex, state);
-            return IbgdaSendRecvProgressStatus::Progressed;
-          }
-          return IbgdaSendRecvProgressStatus::Waiting;
-        }
-      }
-
-      __threadfence_system();
-      group.sync();
-      IbgdaLocalBuffer counterBuf{};
-      uint64_t counterVal = 0;
-      if (group.is_leader()) {
-        if (should_post_nic_done_credit(
-                sendRecvState,
-                chunk.streamEnd,
-                state.reuseCreditStep,
-                progress_params)) {
-          counterVal =
-              reuse_credit_value(chunk.streamEnd, state.reuseCreditStep);
-          counterBuf = sendRecvState.localCounterCompletionBuf.subBuffer(
-              progress_params.groupId * sizeof(uint64_t));
-          state.reuseCreditStep = static_cast<int64_t>(chunk.streamEnd);
-        }
-        ThreadGroup solo{
-            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
-        transport.put(
-            solo,
-            sendRecvState.sendStagingBuf.subBuffer(chunk.stagingOff),
-            sendRecvState.recvStagingBuf.subBuffer(chunk.stagingOff),
-            chunk.bytes,
-            sendRecvState.remoteSignalBuf.subBuffer(
-                progress_params.groupId * sizeof(uint64_t)),
-            chunk.bytes,
-            counterBuf,
-            counterVal);
-      }
-      group.sync();
-
-      state.activeNextByte += chunk.bytes;
-      if (state.activeNextByte >= progress_params.protocolBytes) {
-        transition_progress_stage(
-            group, state, detail::IbSendRecvProgressStage::Done);
-        store_progress_state(sendRecvState, group, progressIndex, state);
-        return IbgdaSendRecvProgressStatus::Done;
-      }
-      transition_progress_stage(
-          group, state, detail::IbSendRecvProgressStage::WaitNicDone);
-    }
-
-    // A full non-final chunk can cycle WaitNicDone -> WaitSlotFree ->
-    // WaitNicDone in one call, leaving the stage unchanged while nextByte
-    // advances. Check both fields so that case reports Progressed.
-    if (state.activeStage != initialStage ||
-        state.activeNextByte != initialNextByte) {
-      store_progress_state(sendRecvState, group, progressIndex, state);
-      return IbgdaSendRecvProgressStatus::Progressed;
-    }
-    return IbgdaSendRecvProgressStatus::Waiting;
-#else
-    (void)transport;
-    (void)group;
-    (void)src;
-    (void)nbytes;
-    (void)max_signal_bytes;
-    (void)timeout;
+  auto& channelLayout = transport.channel_layout();
+  auto& progressSlot = progress_send_slot(transport, group);
+  IbChannelProgress state = progressSlot;
+  if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
     return IbgdaSendRecvProgressStatus::Done;
-#endif
   }
-
-  /**
-   * Attempt bounded progress on one initialized recv.
-   *
-   * This method advances at most one recv-staging copy for the current chunk.
-   * It never spins on DATA_READY: if the sender has not signaled the next
-   * chunk, it returns `Waiting` immediately. If a `Timeout` is enabled, it is
-   * checked only while the DATA_READY dependency is not ready and should
-   * already have been started by the caller.
-   *
-   * When DATA_READY reaches the chunk's `streamEnd`, the recv path copies from
-   * transport-owned recv-staging into the caller's destination through
-   * `CopyOp::recv`, then may signal batched SLOT_FREE credit back to the
-   * sender. Returning `Done` means the reserved byte range has completed.
-   *
-   * `CopyOp` must expose `recv(dst, src, bytes, group, dataOffset, args...)`.
-   * The default `Memcpy` copies bytes cooperatively across the supplied
-   * `ThreadGroup`; custom copy ops may use `args` to pass reduction or
-   * conversion context.
-   *
-   * @param transport Owning transport used for every transport op.
-   * @param group Thread group matching the one used during initialization.
-   * @param dst Destination user buffer. The range `[dst, dst + nbytes)` must
-   *            remain valid until `Done`.
-   * @param nbytes Number of user-buffer bytes from the matching init call.
-   * @param max_signal_bytes Maximum signaled sub-chunk size from init.
-   * @param timeout Optional device timeout checked while dependencies wait.
-   * @param args Additional arguments forwarded to `CopyOp::recv`.
-   */
-  template <typename Transport, typename CopyOp = Memcpy, typename... Args>
-  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
-      Transport& transport,
-      IbSendRecvState& sendRecvState,
-      ThreadGroup& group,
-      void* __restrict__ dst,
-      std::size_t nbytes,
-      std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
-      Args... args) {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-#ifdef __HIP_PLATFORM_AMD__
-    static_assert(
-        sizeof(CopyOp) == 0,
-        "IbSendRecvDevice::progress_recv_once() requires NVIDIA GPU");
-#endif
-    const int progressIndex = progress_recv_index(sendRecvState, group);
-    IbSendRecvState::ProgressSlot state =
-        progress_state_slot(sendRecvState, group, progressIndex);
-    if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
-      return IbgdaSendRecvProgressStatus::Done;
-    }
-    const ProgressGeometry progress_params = make_progress_geometry(
-        sendRecvState, group, nbytes, max_signal_bytes, "progress_recv_once");
-    if (state.activeNextByte >= progress_params.protocolBytes) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: progress_recv_once nextByte=%llu >= "
-            "protocolBytes=%llu without Done stage\n",
-            static_cast<unsigned long long>(state.activeNextByte),
-            static_cast<unsigned long long>(progress_params.protocolBytes));
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    validate_recv_progress_stage(group, state);
-
-    const ProgressChunk chunk =
-        next_chunk(sendRecvState, state, progress_params);
-    const uint64_t expected = chunk.streamEnd;
-    uint32_t ready = 1;
-    unsigned long long current = 0;
+  const ProgressGeometry progress_params = make_progress_geometry(
+      channelLayout, group, nbytes, max_signal_bytes, "progress_send_once");
+  if (state.activeNextByte >= progress_params.protocolBytes) {
     if (group.is_leader()) {
-      current = static_cast<unsigned long long>(
-          transport.read_signal(sendRecvState.localSignalBuf.subBuffer(
-              progress_params.groupId * sizeof(uint64_t))));
-      ready = current >= expected ? 1U : 0U;
-      if (!ready) {
-        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
-            timeout,
-            "progress_recv_once waiting for DATA_READY expected>=%llu, "
-            "current=%llu",
-            static_cast<unsigned long long>(expected),
-            current);
-      }
+      printf(
+          "[PIPES] FATAL: progress_send_once nextByte=%llu >= "
+          "protocolBytes=%llu without Done stage\n",
+          static_cast<unsigned long long>(state.activeNextByte),
+          static_cast<unsigned long long>(progress_params.protocolBytes));
     }
-    ready = group.broadcast<uint32_t>(ready);
-    if (!ready) {
-      return IbgdaSendRecvProgressStatus::Waiting;
+    PIPES_DEVICE_TRAP();
+  }
+  validate_send_progress_stage(group, state);
+
+  const detail::IbSendRecvProgressStage initialStage = state.activeStage;
+  const std::size_t initialNextByte = state.activeNextByte;
+  const std::size_t pipelineBytes = progress_params.perBlockSlot *
+      static_cast<std::size_t>(channelLayout.pipelineDepth);
+  IbLocalChannel& localChannel =
+      transport.local_channel(static_cast<uint32_t>(progress_params.groupId));
+  const IbgdaLocalBuffer localSlotFree = localChannel.slotFree;
+  const IbgdaLocalBuffer localNicDoneWait = localChannel.nicDoneWait;
+  const IbgdaLocalBuffer localNicDoneCompletion =
+      localChannel.nicDoneCompletion;
+  const IbRemoteChannel remoteChannel =
+      makeIbRemoteChannel(channelLayout, progress_params.groupId);
+
+  if (state.activeStage == detail::IbSendRecvProgressStage::WaitNicDone) {
+    const ProgressChunk chunk =
+        next_chunk(channelLayout, state, progress_params);
+    if (chunk.streamEnd > pipelineBytes) {
+      const uint64_t expected = chunk.streamEnd - pipelineBytes;
+      uint32_t ready = 1;
+      unsigned long long current = 0;
+      if (group.is_leader()) {
+        current = static_cast<unsigned long long>(
+            transport.read_counter(localNicDoneWait));
+        ready = current >= expected ? 1U : 0U;
+        if (!ready) {
+          TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+              timeout,
+              "progress_send_once waiting for NIC_DONE expected>=%llu, "
+              "current=%llu",
+              static_cast<unsigned long long>(expected),
+              current);
+        }
+      }
+      ready = group.broadcast<uint32_t>(ready);
+      if (!ready) {
+        return IbgdaSendRecvProgressStatus::Waiting;
+      }
     }
 
     const std::size_t validBytes = valid_payload_bytes(
         chunk.dataOff, chunk.bytes, progress_params.payloadBytes);
     if (validBytes > 0) {
-      CopyOp::recv(
-          static_cast<char*>(dst) + chunk.dataOff,
-          sendRecvState.recvStagingPtr + chunk.stagingOff,
+      CopyOp::send(
+          channelLayout.sendStagingPtr + chunk.stagingOff,
+          static_cast<const char*>(src) + chunk.dataOff,
           validBytes,
           group,
           chunk.dataOff,
           args...);
     }
     group.sync();
+    transition_progress_stage(
+        group, state, detail::IbSendRecvProgressStage::WaitSlotFree);
+  }
 
-    uint64_t slotFreeVal = 0;
-    if (group.is_leader()) {
-      if (should_post_slot_free_credit(
-              sendRecvState,
-              chunk.streamEnd,
-              state.reuseCreditStep,
-              progress_params)) {
-        slotFreeVal =
-            reuse_credit_value(chunk.streamEnd, state.reuseCreditStep);
-        state.reuseCreditStep = static_cast<int64_t>(chunk.streamEnd);
+  if (state.activeStage == detail::IbSendRecvProgressStage::WaitSlotFree) {
+    const ProgressChunk chunk =
+        next_chunk(channelLayout, state, progress_params);
+    if (chunk.streamEnd > pipelineBytes) {
+      const uint64_t expected = chunk.streamEnd - pipelineBytes;
+      uint32_t ready = 1;
+      unsigned long long current = 0;
+      if (group.is_leader()) {
+        current = static_cast<unsigned long long>(
+            transport.read_signal(localSlotFree));
+        ready = current >= expected ? 1U : 0U;
+        if (!ready) {
+          TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+              timeout,
+              "progress_send_once waiting for SLOT_FREE expected>=%llu, "
+              "current=%llu",
+              static_cast<unsigned long long>(expected),
+              current);
+        }
+      }
+      ready = group.broadcast<uint32_t>(ready);
+      if (!ready) {
+        if (state.activeStage != initialStage ||
+            state.activeNextByte != initialNextByte) {
+          store_progress_state(group, progressSlot, state);
+          return IbgdaSendRecvProgressStatus::Progressed;
+        }
+        return IbgdaSendRecvProgressStatus::Waiting;
       }
     }
-    slotFreeVal = group.broadcast<uint64_t>(slotFreeVal);
-    if (slotFreeVal != 0) {
-      transport.signal(
-          group,
-          sendRecvState.remoteSignalBuf.subBuffer(
-              (sendRecvState.maxGroups + progress_params.groupId) *
-              sizeof(uint64_t)),
-          slotFreeVal,
-          IbDirection::Recv);
+
+    __threadfence_system();
+    group.sync();
+    IbgdaLocalBuffer counterBuf{};
+    uint64_t counterVal = 0;
+    if (group.is_leader()) {
+      const bool isFinalChunk =
+          state.activeNextByte + chunk.bytes >= progress_params.protocolBytes;
+      if (isFinalChunk ||
+          should_post_nic_done_credit(
+              chunk.streamEnd, state.reuseCreditStep, progress_params)) {
+        counterVal = reuse_credit_value(chunk.streamEnd, state.reuseCreditStep);
+        counterBuf = localNicDoneCompletion;
+        state.reuseCreditStep = static_cast<int64_t>(chunk.streamEnd);
+      }
+      ThreadGroup solo{
+          0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+      transport.put(
+          solo,
+          channelLayout.sendStagingBuf.subBuffer(chunk.stagingOff),
+          remoteChannel.recvStaging.subBuffer(chunk.stagingOff),
+          chunk.bytes,
+          remoteChannel.dataReady,
+          chunk.bytes,
+          counterBuf,
+          counterVal);
     }
+    group.sync();
 
     state.activeNextByte += chunk.bytes;
     if (state.activeNextByte >= progress_params.protocolBytes) {
       transition_progress_stage(
           group, state, detail::IbSendRecvProgressStage::Done);
-      store_progress_state(sendRecvState, group, progressIndex, state);
+      store_progress_state(group, progressSlot, state);
       return IbgdaSendRecvProgressStatus::Done;
     }
+    transition_progress_stage(
+        group, state, detail::IbSendRecvProgressStage::WaitNicDone);
+  }
 
-    store_progress_state(sendRecvState, group, progressIndex, state);
+  // A full non-final chunk can cycle WaitNicDone -> WaitSlotFree ->
+  // WaitNicDone in one call, leaving the stage unchanged while nextByte
+  // advances. Check both fields so that case reports Progressed.
+  if (state.activeStage != initialStage ||
+      state.activeNextByte != initialNextByte) {
+    store_progress_state(group, progressSlot, state);
     return IbgdaSendRecvProgressStatus::Progressed;
-#else
-    (void)transport;
-    (void)group;
-    (void)dst;
-    (void)nbytes;
-    (void)max_signal_bytes;
-    (void)timeout;
-    return IbgdaSendRecvProgressStatus::Done;
-#endif
   }
-
-  /**
-   * send — send one block's tile via pipelined RDMA.
-   *
-   * Copies src -> sendStaging, then RDMA puts sendStaging -> peer's
-   * recvStaging. For this call, each logical slot contributes one
-   * perBlockSlot-sized region for this group. If nbytes > perBlockSlot, send()
-   * advances through multiple ring positions. max_signal_bytes can further
-   * subdivide each perBlockSlot into multiple signaled sub-chunks, enabling
-   * finer-grained overlap at the receiver.
-   *
-   * Signaling protocol (per group):
-   *   NIC_DONE   — loopback counter incremented by NIC after each RDMA put.
-   *                send waits on this before overwriting local sendStaging.
-   *   SLOT_FREE  — receiver increments by bytesThis for each signaled byte
-   *                range. send waits before overwriting recvStaging.
-   *   DATA_READY — sender increments by bytesThis, piggybacked on put.
-   *                recv waits on this before reading recvStaging.
-   *
-   * state[].nextStep persists across calls, so send() resumes the staging-ring
-   * cursor and protocol sequence numbers on each invocation. This allows
-   * callers to pipeline across repeated send() calls without a separate drain.
-   *
-   * The caller must keep the transport layout stable while a sequence is in
-   * flight. `max_signal_bytes` may vary across calls because it changes only
-   * sub-chunk signaling, not the fixed channel staging layout.
-   *
-   * @param transport       Owning transport used for every transport op.
-   * @param group           ThreadGroup (all threads participate in memcpy,
-   *                        leader does RDMA ops).
-   * @param src             Source data for this block's tile.
-   * @param nbytes          Bytes to send for this group. Internally consumed
-   *                        in perBlockSlot-sized pieces, or smaller sub-chunks
-   *                        when max_signal_bytes is set.
-   * @param max_signal_bytes Max bytes per signaled sub-chunk within one
-   *                        perBlockSlot. 0 means one signal per perBlockSlot.
-   * @param timeout         Optional timeout for wait operations.
-   */
-  template <typename Transport, typename CopyOp = Memcpy, typename... Args>
-  __device__ __forceinline__ void send(
-      Transport& transport,
-      IbSendRecvState& sendRecvState,
-      ThreadGroup& group,
-      const void* __restrict__ src,
-      std::size_t nbytes,
-      std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
-      Args... args) {
-#if !PIPES_IS_DEVICE_COMPILE
-    (void)transport;
-    (void)group;
-    (void)src;
-    (void)nbytes;
-    (void)max_signal_bytes;
-    (void)timeout;
+  return IbgdaSendRecvProgressStatus::Waiting;
 #else
-    if (nbytes == 0) {
-      return;
-    }
-    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
-
-    const int groupId = group.group_id;
-    const int maxGroups = sendRecvState.maxGroups;
-    if (groupId >= maxGroups) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: send group_id=%u >= maxGroups=%d\n",
-            groupId,
-            maxGroups);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    const std::size_t perBlockSlot =
-        (sendRecvState.dataBufferSize / maxGroups) & ~15ULL;
-    if (perBlockSlot == 0) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: send perBlockSlot=0 "
-            "(dataBufferSize=%llu, maxGroups=%d)\n",
-            (unsigned long long)sendRecvState.dataBufferSize,
-            maxGroups);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    std::size_t chunkSize =
-        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
-        ? (max_signal_bytes & ~15ULL)
-        : perBlockSlot;
-    if (chunkSize == 0) {
-      chunkSize = perBlockSlot;
-    }
-
-    const int pipelineDepth = sendRecvState.pipelineDepth;
-    const std::size_t dataBufferSize = sendRecvState.dataBufferSize;
-    const int stateIndex = progress_send_index(sendRecvState, group);
-    auto& state = progress_state_slot(sendRecvState, group, stateIndex);
-    assert_progress_slot_idle(group, state, "send");
-    const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
-    const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
-    if (group.is_leader()) {
-      state.activeStage = detail::IbSendRecvProgressStage::Busy;
-      state.activeBaseStep = static_cast<int64_t>(baseByte);
-      state.activeNextByte = 0;
-    }
-
-    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
-      const uint64_t streamStart = baseByte + dataOff;
-      const std::size_t pipelineOff =
-          static_cast<std::size_t>(streamStart % pipelineBytes);
-      const int slot = static_cast<int>(pipelineOff / perBlockSlot);
-      const std::size_t slotOff = slot * dataBufferSize;
-      const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
-      const std::size_t slotRemaining = perBlockSlot - chunkOff;
-      const std::size_t dataRemaining = protocolBytes - dataOff;
-      std::size_t bytesThis =
-          chunkSize < dataRemaining ? chunkSize : dataRemaining;
-      bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
-      const std::size_t stagingOff =
-          slotOff + groupId * perBlockSlot + chunkOff;
-      const uint64_t streamEnd = streamStart + bytesThis;
-
-      // (1) Wait for NIC to finish with this slot's local sendStaging.
-      if (streamEnd > pipelineBytes) {
-        transport.wait_counter(
-            group,
-            sendRecvState.localCounterBuf.subBuffer(groupId * sizeof(uint64_t)),
-            streamEnd - pipelineBytes,
-            timeout);
-      }
-
-      // (2) Cooperative copy: src -> local sendStaging via CopyOp.
-      const std::size_t validBytes =
-          valid_payload_bytes(dataOff, bytesThis, nbytes);
-      if (validBytes > 0) {
-        CopyOp::send(
-            sendRecvState.sendStagingPtr + stagingOff,
-            static_cast<const char*>(src) + dataOff,
-            validBytes,
-            group,
-            dataOff,
-            args...);
-      }
-      group.sync();
-
-      // (3) Backpressure: wait for receiver to free this byte range's
-      //     recvStaging offset. Symmetric with DATA_READY.
-      if (streamEnd > pipelineBytes) {
-        transport.wait_signal(
-            group,
-            sendRecvState.localSignalBuf.subBuffer(
-                (maxGroups + groupId) * sizeof(uint64_t)),
-            streamEnd - pipelineBytes,
-            timeout);
-      }
-
-      // (4) threadfence_system + leader-only single-WQE RDMA put with
-      //     fused signal+counter. All threads fence to ensure memcpy
-      //     stores are visible to the NIC before the leader posts the WQE.
-      __threadfence_system();
-      group.sync();
-      if (group.is_leader()) {
-        IbgdaLocalBuffer counterBuf{};
-        uint64_t counterVal = 0;
-        if (should_post_nic_done_credit(
-                sendRecvState,
-                streamEnd,
-                state.reuseCreditStep,
-                perBlockSlot)) {
-          counterVal = reuse_credit_value(streamEnd, state.reuseCreditStep);
-          counterBuf = sendRecvState.localCounterCompletionBuf.subBuffer(
-              groupId * sizeof(uint64_t));
-          state.reuseCreditStep = static_cast<int64_t>(streamEnd);
-        }
-        ThreadGroup solo{
-            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
-        transport.put(
-            solo,
-            sendRecvState.sendStagingBuf.subBuffer(stagingOff),
-            sendRecvState.recvStagingBuf.subBuffer(stagingOff),
-            bytesThis,
-            sendRecvState.remoteSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
-            bytesThis,
-            counterBuf,
-            counterVal);
-      }
-      group.sync();
-      dataOff += bytesThis;
-    }
-
-    if (group.is_leader()) {
-      state.nextStep = static_cast<int64_t>(baseByte + protocolBytes);
-      state.activeStage = detail::IbSendRecvProgressStage::Done;
-      state.activeBaseStep = 0;
-      state.activeNextByte = 0;
-    }
-    group.sync();
+  (void)transport;
+  (void)group;
+  (void)src;
+  (void)nbytes;
+  (void)max_signal_bytes;
+  (void)timeout;
+  return IbgdaSendRecvProgressStatus::Done;
 #endif
-  }
+}
 
-  /**
-   * recv — receive one block's tile from pipelined RDMA.
-   *
-   * Waits for data to arrive in recvStaging, then copies recvStaging -> dst.
-   * For this call, each logical slot contributes one perBlockSlot-sized region
-   * for this group. If nbytes > perBlockSlot, recv() advances through multiple
-   * ring positions. max_signal_bytes controls sub-chunk granularity and must
-   * match the sender.
-   *
-   * Signaling protocol (per group, symmetric with send):
-   *   DATA_READY — sender increments by bytesThis after RDMA put completes.
-   *                recv waits on this before copying from recvStaging.
-   *   SLOT_FREE  — recv increments by bytesThis (symmetric with DATA_READY)
-   *                to release backpressure on sender.
-   *
-   * @param transport       Owning transport used for every transport op.
-   * @param group           ThreadGroup (all threads participate in memcpy,
-   *                        leader does signal ops).
-   * @param dst             Destination for this block's tile.
-   * @param nbytes          Bytes to receive for this group. Internally
-   *                        consumed in perBlockSlot-sized pieces, or smaller
-   *                        sub-chunks when max_signal_bytes is set.
-   * @param max_signal_bytes Max bytes per signaled sub-chunk within one
-   *                        perBlockSlot. 0 means one signal per perBlockSlot.
-   *                        Must match the sender's value.
-   * @param timeout         Optional timeout for wait operations.
-   */
-  template <typename Transport, typename CopyOp = Memcpy, typename... Args>
-  __device__ __forceinline__ void recv(
-      Transport& transport,
-      IbSendRecvState& sendRecvState,
-      ThreadGroup& group,
-      void* __restrict__ dst,
-      std::size_t nbytes,
-      std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
-      Args... args) {
-#if !PIPES_IS_DEVICE_COMPILE
-    (void)transport;
-    (void)group;
-    (void)dst;
-    (void)nbytes;
-    (void)max_signal_bytes;
-    (void)timeout;
-#else
-    if (nbytes == 0) {
-      return;
-    }
-    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
-
-    const int groupId = group.group_id;
-    const int maxGroups = sendRecvState.maxGroups;
-    if (groupId >= maxGroups) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: recv group_id=%u >= maxGroups=%d\n",
-            groupId,
-            maxGroups);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    const std::size_t perBlockSlot =
-        (sendRecvState.dataBufferSize / maxGroups) & ~15ULL;
-    if (perBlockSlot == 0) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: recv perBlockSlot=0 "
-            "(dataBufferSize=%llu, maxGroups=%d)\n",
-            (unsigned long long)sendRecvState.dataBufferSize,
-            maxGroups);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    std::size_t chunkSize =
-        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
-        ? (max_signal_bytes & ~15ULL)
-        : perBlockSlot;
-    if (chunkSize == 0) {
-      chunkSize = perBlockSlot;
-    }
-
-    const int pipelineDepth = sendRecvState.pipelineDepth;
-    const std::size_t dataBufferSize = sendRecvState.dataBufferSize;
-    const int stateIndex = progress_recv_index(sendRecvState, group);
-    auto& state = progress_state_slot(sendRecvState, group, stateIndex);
-    assert_progress_slot_idle(group, state, "recv");
-    const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
-    const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
-    if (group.is_leader()) {
-      state.activeStage = detail::IbSendRecvProgressStage::Busy;
-      state.activeBaseStep = static_cast<int64_t>(baseByte);
-      state.activeNextByte = 0;
-    }
-
-    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
-      const uint64_t streamStart = baseByte + dataOff;
-      const std::size_t pipelineOff =
-          static_cast<std::size_t>(streamStart % pipelineBytes);
-      const int slot = static_cast<int>(pipelineOff / perBlockSlot);
-      const std::size_t slotOff = slot * dataBufferSize;
-      const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
-      const std::size_t slotRemaining = perBlockSlot - chunkOff;
-      const std::size_t dataRemaining = protocolBytes - dataOff;
-      std::size_t bytesThis =
-          chunkSize < dataRemaining ? chunkSize : dataRemaining;
-      bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
-      const std::size_t stagingOff =
-          slotOff + groupId * perBlockSlot + chunkOff;
-      const uint64_t streamEnd = streamStart + bytesThis;
-
-      // (1) Wait for sender's DATA_READY signal.
-      transport.wait_signal(
-          group,
-          sendRecvState.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
-          streamEnd,
-          timeout);
-
-      // (2) Cooperative copy: local recvStaging -> dst via CopyOp.
-      const std::size_t validBytes =
-          valid_payload_bytes(dataOff, bytesThis, nbytes);
-      if (validBytes > 0) {
-        CopyOp::recv(
-            static_cast<char*>(dst) + dataOff,
-            sendRecvState.recvStagingPtr + stagingOff,
-            validBytes,
-            group,
-            dataOff,
-            args...);
-      }
-      group.sync();
-
-      // (3) Signal SLOT_FREE to sender. Sender waits on the cumulative byte
-      //     threshold before reusing remote recvStaging at the same offset.
-      uint64_t slotFreeVal = 0;
-      if (group.is_leader()) {
-        if (should_post_slot_free_credit(
-                sendRecvState,
-                streamEnd,
-                state.reuseCreditStep,
-                perBlockSlot)) {
-          slotFreeVal = reuse_credit_value(streamEnd, state.reuseCreditStep);
-          state.reuseCreditStep = static_cast<int64_t>(streamEnd);
-        }
-      }
-      slotFreeVal = group.broadcast<uint64_t>(slotFreeVal);
-      if (slotFreeVal != 0) {
-        transport.signal(
-            group,
-            sendRecvState.remoteSignalBuf.subBuffer(
-                (maxGroups + groupId) * sizeof(uint64_t)),
-            slotFreeVal,
-            IbDirection::Recv);
-      }
-      dataOff += bytesThis;
-    }
-
-    if (group.is_leader()) {
-      state.nextStep = static_cast<int64_t>(baseByte + protocolBytes);
-      state.activeStage = detail::IbSendRecvProgressStage::Done;
-      state.activeBaseStep = 0;
-      state.activeNextByte = 0;
-    }
-    group.sync();
-#endif
-  }
-
-  /**
-   * forward — receive data and forward it to the next peer in a ring.
-   *
-   * Combines recv + send in a single method, sharing the staging buffer to
-   * avoid an extra copy. The CopyOp::forward() method receives three
-   * buffers: dst (application output), fwd_staging (next peer's send staging),
-   * and staging (this transport's recv staging). This enables fused
-   * receive-reduce-forward patterns.
-   *
-   * Signal ordering invariant (critical for ring deadlock avoidance):
-   *   1. Wait DATA_READY from sender (this transport)
-   *   2. Wait NIC_DONE on fwd transport's sendStaging (backpressure)
-   *   3. CopyOp::forward(dst, fwd_staging, staging, ...)
-   *   4. Signal SLOT_FREE to sender (this transport) — BEFORE step 5
-   *   5. Wait SLOT_FREE from fwd transport's receiver
-   *   6. threadfence_system + RDMA put via fwd transport
-   *
-   * Step 4 before step 5 breaks the circular dependency in rings: each rank
-   * releases its predecessor's staging before waiting on its successor.
-   *
-   * Protocol compatibility with send() and recv():
-   *
-   * forward acts as a recv on "this" transport and a send on "fwd".
-   * The signal protocol is wire-compatible:
-   *
-   *   Recv side (this transport):
-   *     - Uses this channel's recv progress cursor.
-   *     - Waits DATA_READY on this channel's local data-ready signal.
-   *     - Signals SLOT_FREE on the remote channel's slot-free signal.
-   *
-   *   Fwd side (fwd transport):
-   *     - Uses the forward channel's send progress cursor.
-   *     - Waits NIC_DONE on the forward channel's local completion counter.
-   *     - Waits SLOT_FREE on the forward channel's local slot-free signal.
-   *     - RDMA puts with DATA_READY on the forward remote channel and may
-   *       batch NIC_DONE credit to the local completion counter.
-   *
-   * Any chain of send → forward* → recv is therefore valid: each
-   * forward consumes exactly the signals its predecessor produces
-   * and produces exactly the signals its successor expects.
-   *
-   * @param transport       Recv-side transport (this peer's receiver).
-   * @param group           ThreadGroup (all threads participate).
-   * @param dst             Application destination (may be nullptr if
-   *                        CopyOp handles it, e.g. reduce-scatter).
-   * @param fwdDevice       Forward-side send/recv device (next peer).
-   * @param fwdTransport    Forward transport (sends to next peer in ring).
-   * @param nbytes          Bytes to receive and forward.
-   * @param max_signal_bytes Max bytes per signaled sub-chunk. 0 = perBlockSlot.
-   * @param timeout         Optional timeout for wait operations.
-   * @param args            Extra args forwarded to CopyOp::forward.
-   */
-  template <typename CopyOp = Memcpy, typename Transport, typename... Args>
-  __device__ __forceinline__ void forward(
-      Transport& transport,
-      IbSendRecvState& sendRecvState,
-      ThreadGroup& group,
-      void* __restrict__ dst,
-      IbSendRecvDevice& fwdDevice,
-      IbSendRecvState& fwdSendRecvState,
-      Transport& fwdTransport,
-      std::size_t nbytes,
-      std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
-      Args... args) {
-#if PIPES_IS_DEVICE_COMPILE
+/**
+ * Attempt bounded progress on one initialized recv.
+ *
+ * This method advances at most one recv-staging copy for the current chunk.
+ * It never spins on DATA_READY: if the sender has not signaled the next
+ * chunk, it returns `Waiting` immediately. If a `Timeout` is enabled, it is
+ * checked only while the DATA_READY dependency is not ready and should
+ * already have been started by the caller.
+ *
+ * When DATA_READY reaches the chunk's `streamEnd`, the recv path copies from
+ * transport-owned recv-staging into the caller's destination through
+ * `CopyOp::recv`, then may signal batched SLOT_FREE credit back to the
+ * sender. Returning `Done` means the reserved byte range has completed.
+ *
+ * `CopyOp` must expose `recv(dst, src, bytes, group, dataOffset, args...)`.
+ * The default `Memcpy` copies bytes cooperatively across the supplied
+ * `ThreadGroup`; custom copy ops may use `args` to pass reduction or
+ * conversion context.
+ *
+ * @param transport Owning transport used for every transport op.
+ * @param group Thread group matching the one used during initialization.
+ * @param dst Destination user buffer. The range `[dst, dst + nbytes)` must
+ *            remain valid until `Done`.
+ * @param nbytes Number of user-buffer bytes from the matching init call.
+ * @param max_signal_bytes Maximum signaled sub-chunk size from init.
+ * @param timeout Optional device timeout checked while dependencies wait.
+ * @param args Additional arguments forwarded to `CopyOp::recv`.
+ */
+template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
+    Transport& transport,
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0,
+    const Timeout& timeout = Timeout(),
+    Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #ifdef __HIP_PLATFORM_AMD__
-    static_assert(
-        sizeof(CopyOp) == 0,
-        "IbSendRecvDevice::forward() requires NVIDIA GPU (DOCA/IBGDA)");
+  static_assert(
+      sizeof(CopyOp) == 0, "detail::progress_recv_once() requires NVIDIA GPU");
 #endif
-    if (nbytes == 0) {
-      return;
-    }
-    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
-
-    const int groupId = group.group_id;
-
-    // --- recv side (this transport) ---
-    const int recvMaxGroups = sendRecvState.maxGroups;
-    if (groupId >= recvMaxGroups) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: forward recv maxGroups=%d groupId=%u\n",
-            recvMaxGroups,
-            groupId);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    const std::size_t recvPerBlockSlot =
-        (sendRecvState.dataBufferSize / recvMaxGroups) & ~15ULL;
-    if (recvPerBlockSlot == 0) {
-      if (group.is_leader()) {
-        printf("[PIPES] FATAL: forward recvPerBlockSlot=0\n");
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    // --- fwd side (fwd transport) ---
-    const int fwdMaxGroups = fwdSendRecvState.maxGroups;
-    if (groupId >= fwdMaxGroups) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: forward fwd maxGroups=%d groupId=%u\n",
-            fwdMaxGroups,
-            groupId);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    const std::size_t fwdPerBlockSlot =
-        (fwdSendRecvState.dataBufferSize / fwdMaxGroups) & ~15ULL;
-    if (fwdPerBlockSlot == 0) {
-      if (group.is_leader()) {
-        printf("[PIPES] FATAL: forward fwdPerBlockSlot=0\n");
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    // Chunk sizes for recv and fwd sides
-    std::size_t recvChunkSize =
-        (max_signal_bytes > 0 && max_signal_bytes < recvPerBlockSlot)
-        ? (max_signal_bytes & ~15ULL)
-        : recvPerBlockSlot;
-    if (recvChunkSize == 0) {
-      recvChunkSize = recvPerBlockSlot;
-    }
-    std::size_t fwdChunkSize =
-        (max_signal_bytes > 0 && max_signal_bytes < fwdPerBlockSlot)
-        ? (max_signal_bytes & ~15ULL)
-        : fwdPerBlockSlot;
-    if (fwdChunkSize == 0) {
-      fwdChunkSize = fwdPerBlockSlot;
-    }
-
-    const int recvPipelineDepth = sendRecvState.pipelineDepth;
-    const std::size_t recvDataBufSize = sendRecvState.dataBufferSize;
-    const int recvStateIndex = progress_recv_index(sendRecvState, group);
-    auto& recvSlotState =
-        progress_state_slot(sendRecvState, group, recvStateIndex);
-    assert_progress_slot_idle(group, recvSlotState, "forward recv");
-    const uint64_t recvBaseByte = static_cast<uint64_t>(recvSlotState.nextStep);
-    const std::size_t recvPipelineBytes = recvPerBlockSlot * recvPipelineDepth;
-
-    const int fwdPipelineDepth = fwdSendRecvState.pipelineDepth;
-    const std::size_t fwdDataBufSize = fwdSendRecvState.dataBufferSize;
-    const int fwdStateIndex =
-        fwdDevice.progress_send_index(fwdSendRecvState, group);
-    auto& fwdSlotState =
-        fwdDevice.progress_state_slot(fwdSendRecvState, group, fwdStateIndex);
-    fwdDevice.assert_progress_slot_idle(group, fwdSlotState, "forward send");
-    const uint64_t fwdBaseByte = static_cast<uint64_t>(fwdSlotState.nextStep);
-    const std::size_t fwdPipelineBytes = fwdPerBlockSlot * fwdPipelineDepth;
+  auto& channelLayout = transport.channel_layout();
+  auto& progressSlot = progress_recv_slot(transport, group);
+  IbChannelProgress state = progressSlot;
+  if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
+    return IbgdaSendRecvProgressStatus::Done;
+  }
+  const ProgressGeometry progress_params = make_progress_geometry(
+      channelLayout, group, nbytes, max_signal_bytes, "progress_recv_once");
+  if (state.activeNextByte >= progress_params.protocolBytes) {
     if (group.is_leader()) {
-      recvSlotState.activeStage = detail::IbSendRecvProgressStage::Busy;
-      recvSlotState.activeBaseStep = static_cast<int64_t>(recvBaseByte);
-      recvSlotState.activeNextByte = 0;
-      fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Busy;
-      fwdSlotState.activeBaseStep = static_cast<int64_t>(fwdBaseByte);
-      fwdSlotState.activeNextByte = 0;
+      printf(
+          "[PIPES] FATAL: progress_recv_once nextByte=%llu >= "
+          "protocolBytes=%llu without Done stage\n",
+          static_cast<unsigned long long>(state.activeNextByte),
+          static_cast<unsigned long long>(progress_params.protocolBytes));
     }
+    PIPES_DEVICE_TRAP();
+  }
+  validate_recv_progress_stage(group, state);
 
-    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
-      // --- Recv side offsets ---
-      const uint64_t recvStreamStart = recvBaseByte + dataOff;
-      const std::size_t recvPipelineOff =
-          static_cast<std::size_t>(recvStreamStart % recvPipelineBytes);
-      const int recvSlot = static_cast<int>(recvPipelineOff / recvPerBlockSlot);
-      const std::size_t recvSlotOff = recvSlot * recvDataBufSize;
-      const std::size_t recvChunkOff =
-          recvPipelineOff - recvSlot * recvPerBlockSlot;
-      const std::size_t recvStagingOff =
-          recvSlotOff + groupId * recvPerBlockSlot + recvChunkOff;
-
-      // --- Fwd side offsets ---
-      const uint64_t fwdStreamStart = fwdBaseByte + dataOff;
-      const std::size_t fwdPipelineOff =
-          static_cast<std::size_t>(fwdStreamStart % fwdPipelineBytes);
-      const int fwdSlot = static_cast<int>(fwdPipelineOff / fwdPerBlockSlot);
-      const std::size_t fwdSlotOff = fwdSlot * fwdDataBufSize;
-      const std::size_t fwdChunkOff =
-          fwdPipelineOff - fwdSlot * fwdPerBlockSlot;
-      const std::size_t fwdStagingOff =
-          fwdSlotOff + groupId * fwdPerBlockSlot + fwdChunkOff;
-      const std::size_t recvSlotRemaining = recvPerBlockSlot - recvChunkOff;
-      const std::size_t fwdSlotRemaining = fwdPerBlockSlot - fwdChunkOff;
-      const std::size_t dataRemaining = protocolBytes - dataOff;
-      std::size_t bytesThis =
-          recvChunkSize < fwdChunkSize ? recvChunkSize : fwdChunkSize;
-      bytesThis = bytesThis < dataRemaining ? bytesThis : dataRemaining;
-      bytesThis = bytesThis < recvSlotRemaining ? bytesThis : recvSlotRemaining;
-      bytesThis = bytesThis < fwdSlotRemaining ? bytesThis : fwdSlotRemaining;
-      const uint64_t recvStreamEnd = recvStreamStart + bytesThis;
-      const uint64_t fwdStreamEnd = fwdStreamStart + bytesThis;
-
-      // (1) Wait for sender's DATA_READY.
-      transport.wait_signal(
-          group,
-          sendRecvState.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
-          recvStreamEnd,
-          timeout);
-
-      // (2) Wait for NIC_DONE on fwd's sendStaging (backpressure).
-      if (fwdStreamEnd > fwdPipelineBytes) {
-        fwdTransport.wait_counter(
-            group,
-            fwdSendRecvState.localCounterBuf.subBuffer(
-                groupId * sizeof(uint64_t)),
-            fwdStreamEnd - fwdPipelineBytes,
-            timeout);
-      }
-
-      // (3) CopyOp::forward — transform recv staging -> dst + fwd staging.
-      const std::size_t validBytes =
-          valid_payload_bytes(dataOff, bytesThis, nbytes);
-      if (validBytes > 0) {
-        CopyOp::forward(
-            dst ? static_cast<char*>(dst) + dataOff : nullptr,
-            fwdSendRecvState.sendStagingPtr + fwdStagingOff,
-            sendRecvState.recvStagingPtr + recvStagingOff,
-            validBytes,
-            group,
-            dataOff,
-            args...);
-      }
-      group.sync();
-
-      // (4) SLOT_FREE, posted unbatched every chunk. This must happen before
-      //     the step-5 wait to break circular ring dependency. Advance
-      //     reuseCreditStep so an interleaved recv() on this shared slot
-      //     computes reuse credit from a current cursor.
-      transport.signal(
-          group,
-          sendRecvState.remoteSignalBuf.subBuffer(
-              (recvMaxGroups + groupId) * sizeof(uint64_t)),
-          bytesThis,
-          IbDirection::Recv);
-      if (group.is_leader()) {
-        recvSlotState.reuseCreditStep = static_cast<int64_t>(recvStreamEnd);
-      }
-
-      // (5) Wait for fwd receiver's SLOT_FREE (backpressure on fwd's
-      //     recvStaging).
-      if (fwdStreamEnd > fwdPipelineBytes) {
-        fwdTransport.wait_signal(
-            group,
-            fwdSendRecvState.localSignalBuf.subBuffer(
-                (fwdMaxGroups + groupId) * sizeof(uint64_t)),
-            fwdStreamEnd - fwdPipelineBytes,
-            timeout);
-      }
-
-      // (6) threadfence_system + RDMA put via fwd transport.
-      __threadfence_system();
-      group.sync();
-      if (group.is_leader()) {
-        fwdSlotState.reuseCreditStep = static_cast<int64_t>(fwdStreamEnd);
-        ThreadGroup solo{
-            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
-        fwdTransport.put(
-            solo,
-            fwdSendRecvState.sendStagingBuf.subBuffer(fwdStagingOff),
-            fwdSendRecvState.recvStagingBuf.subBuffer(fwdStagingOff),
-            bytesThis,
-            fwdSendRecvState.remoteSignalBuf.subBuffer(
-                groupId * sizeof(uint64_t)),
-            bytesThis,
-            fwdSendRecvState.localCounterCompletionBuf.subBuffer(
-                groupId * sizeof(uint64_t)),
-            bytesThis);
-      }
-      group.sync();
-      dataOff += bytesThis;
+  const ProgressChunk chunk = next_chunk(channelLayout, state, progress_params);
+  IbLocalChannel& localChannel =
+      transport.local_channel(static_cast<uint32_t>(progress_params.groupId));
+  const IbgdaLocalBuffer localDataReady = localChannel.dataReady;
+  const IbRemoteChannel remoteChannel =
+      makeIbRemoteChannel(channelLayout, progress_params.groupId);
+  const uint64_t expected = chunk.streamEnd;
+  uint32_t ready = 1;
+  unsigned long long current = 0;
+  if (group.is_leader()) {
+    current =
+        static_cast<unsigned long long>(transport.read_signal(localDataReady));
+    ready = current >= expected ? 1U : 0U;
+    if (!ready) {
+      TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+          timeout,
+          "progress_recv_once waiting for DATA_READY expected>=%llu, "
+          "current=%llu",
+          static_cast<unsigned long long>(expected),
+          current);
     }
+  }
+  ready = group.broadcast<uint32_t>(ready);
+  if (!ready) {
+    return IbgdaSendRecvProgressStatus::Waiting;
+  }
 
-    // Update shared byte cursors for both recv and fwd sides.
+  const std::size_t validBytes = valid_payload_bytes(
+      chunk.dataOff, chunk.bytes, progress_params.payloadBytes);
+  if (validBytes > 0) {
+    CopyOp::recv(
+        static_cast<char*>(dst) + chunk.dataOff,
+        channelLayout.recvStagingPtr + chunk.stagingOff,
+        validBytes,
+        group,
+        chunk.dataOff,
+        args...);
+  }
+  group.sync();
+
+  uint64_t slotFreeVal = 0;
+  if (group.is_leader()) {
+    if (should_post_slot_free_credit(
+            chunk.streamEnd, state.reuseCreditStep, progress_params)) {
+      slotFreeVal = reuse_credit_value(chunk.streamEnd, state.reuseCreditStep);
+      state.reuseCreditStep = static_cast<int64_t>(chunk.streamEnd);
+    }
+  }
+  slotFreeVal = group.broadcast<uint64_t>(slotFreeVal);
+  if (slotFreeVal != 0) {
+    transport.signal(
+        group, remoteChannel.slotFree, slotFreeVal, IbDirection::Recv);
+  }
+
+  state.activeNextByte += chunk.bytes;
+  if (state.activeNextByte >= progress_params.protocolBytes) {
+    transition_progress_stage(
+        group, state, detail::IbSendRecvProgressStage::Done);
+    store_progress_state(group, progressSlot, state);
+    return IbgdaSendRecvProgressStatus::Done;
+  }
+
+  store_progress_state(group, progressSlot, state);
+  return IbgdaSendRecvProgressStatus::Progressed;
+#else
+  (void)transport;
+  (void)group;
+  (void)dst;
+  (void)nbytes;
+  (void)max_signal_bytes;
+  (void)timeout;
+  return IbgdaSendRecvProgressStatus::Done;
+#endif
+}
+
+/**
+ * send — send one block's tile via pipelined RDMA.
+ *
+ * Copies src -> sendStaging, then RDMA puts sendStaging -> peer's
+ * recvStaging. For this call, each logical slot contributes one
+ * perBlockSlot-sized region for this group. If nbytes > perBlockSlot, send()
+ * advances through multiple ring positions. max_signal_bytes can further
+ * subdivide each perBlockSlot into multiple signaled sub-chunks, enabling
+ * finer-grained overlap at the receiver.
+ *
+ * Signaling protocol (per group):
+ *   NIC_DONE   — loopback counter incremented by NIC after each RDMA put.
+ *                send waits on this before overwriting local sendStaging.
+ *   SLOT_FREE  — receiver increments by bytesThis for each signaled byte
+ *                range. send waits before overwriting recvStaging.
+ *   DATA_READY — sender increments by bytesThis, piggybacked on put.
+ *                recv waits on this before reading recvStaging.
+ *
+ * The channel progress cursor persists across calls, so send() resumes the
+ * staging-ring cursor and protocol sequence numbers on each invocation. This
+ * allows callers to pipeline across repeated send() calls without a separate
+ * drain.
+ *
+ * The caller must keep the transport layout stable while a sequence is in
+ * flight. `max_signal_bytes` may vary across calls because it changes only
+ * sub-chunk signaling, not the fixed channel staging layout.
+ *
+ * @param transport       Owning transport used for every transport op.
+ * @param group           ThreadGroup (all threads participate in memcpy,
+ *                        leader does RDMA ops).
+ * @param src             Source data for this block's tile.
+ * @param nbytes          Bytes to send for this group. Internally consumed
+ *                        in perBlockSlot-sized pieces, or smaller sub-chunks
+ *                        when max_signal_bytes is set.
+ * @param max_signal_bytes Max bytes per signaled sub-chunk within one
+ *                        perBlockSlot. 0 means one signal per perBlockSlot.
+ * @param timeout         Optional timeout for wait operations.
+ */
+template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+__device__ __forceinline__ void send(
+    Transport& transport,
+    ThreadGroup& group,
+    const void* __restrict__ src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0,
+    const Timeout& timeout = Timeout(),
+    Args... args) {
+#if !PIPES_IS_DEVICE_COMPILE
+  (void)transport;
+  (void)group;
+  (void)src;
+  (void)nbytes;
+  (void)max_signal_bytes;
+  (void)timeout;
+#else
+  if (nbytes == 0) {
+    return;
+  }
+  auto& channelLayout = transport.channel_layout();
+  const std::size_t protocolBytes = align_protocol_bytes(nbytes);
+
+  const int groupId = group.group_id;
+  const int maxGroups = channelLayout.maxChannels;
+  if (groupId >= maxGroups) {
     if (group.is_leader()) {
-      recvSlotState.nextStep =
-          static_cast<int64_t>(recvBaseByte + protocolBytes);
-      recvSlotState.activeStage = detail::IbSendRecvProgressStage::Done;
-      recvSlotState.activeBaseStep = 0;
-      recvSlotState.activeNextByte = 0;
-      fwdSlotState.nextStep = static_cast<int64_t>(fwdBaseByte + protocolBytes);
-      fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Done;
-      fwdSlotState.activeBaseStep = 0;
-      fwdSlotState.activeNextByte = 0;
+      printf(
+          "[PIPES] FATAL: send group_id=%u >= maxGroups=%d\n",
+          groupId,
+          maxGroups);
     }
-    group.sync();
-#else
-    (void)transport;
-    (void)sendRecvState;
-    (void)group;
-    (void)dst;
-    (void)fwdDevice;
-    (void)fwdSendRecvState;
-    (void)fwdTransport;
-    (void)nbytes;
-    (void)max_signal_bytes;
-    (void)timeout;
-#endif
+    PIPES_DEVICE_TRAP();
   }
 
-  /**
-   * Maximum bytes a block can send without blocking on pipeline backpressure.
-   *
-   * The staging buffer is split into pipelineDepth slots, each with a fixed
-   * per-channel partition. A block can fill all its slots before the NIC must
-   * drain any of them, so the non-blocking window is:
-   *   perChannelSize * pipelineDepth
-   *
-   * Callers should loop over their data in pipeline_window-sized chunks so
-   * that send()/forward() never stall waiting for a free slot.
-   */
-  __device__ __forceinline__ std::size_t pipeline_window(
-      const IbSendRecvState& sendRecvState) const {
-    const std::size_t per_block_slot =
-        (sendRecvState.dataBufferSize / sendRecvState.maxGroups) & ~15ULL;
-    return per_block_slot * sendRecvState.pipelineDepth;
-  }
-
- private:
-  /**
-   * Physical staging range for the next resumable progress step.
-   *
-   * `stagingOff` is an offset into the transport-owned send/recv staging
-   * buffers. `dataOff` is the matching protocol offset into the caller's user
-   * buffer. `bytes` never crosses a per-block staging partition or the
-   * reserved protocol byte count. `streamEnd` is the absolute protocol byte
-   * value after this chunk and is used as the DATA_READY, SLOT_FREE, and
-   * NIC_DONE readiness threshold. `dataOff` is a protocol offset; callers mask
-   * it against the payload byte count before invoking user-buffer copy
-   * callbacks.
-   */
-  struct ProgressChunk {
-    std::size_t stagingOff;
-    std::size_t dataOff;
-    std::size_t bytes;
-    uint64_t streamEnd;
-  };
-
-  /**
-   * Register-only geometry for one resumable progress call.
-   *
-   * This is intentionally not stored in `IbSendRecvState::ProgressSlot`:
-   * callers pass the same static geometry to init and progress, and each
-   * progress call derives these values in registers instead of reloading
-   * duplicated fields from HBM-backed progress state.
-   */
-  struct ProgressGeometry {
-    int groupId;
-    std::size_t payloadBytes;
-    std::size_t protocolBytes;
-    std::size_t perBlockSlot;
-    std::size_t chunkSize;
-  };
-
-  /**
-   * Stateful send/recv cursors advance in 16-byte protocol quanta. That keeps
-   * the staging stream on the same granularity as the vectorized local staging
-   * copies while preserving caller-facing payload byte counts; padding is
-   * transport-private and is never exposed to CopyOp callbacks.
-   */
-  __device__ __forceinline__ static std::size_t align_protocol_bytes(
-      std::size_t nbytes) {
-    return (nbytes + 15ULL) & ~15ULL;
-  }
-
-  __device__ __forceinline__ static std::size_t valid_payload_bytes(
-      std::size_t byteOffset,
-      std::size_t chunkBytes,
-      std::size_t payloadBytes) {
-    if (byteOffset >= payloadBytes) {
-      return 0;
-    }
-    const std::size_t remaining = payloadBytes - byteOffset;
-    return chunkBytes < remaining ? chunkBytes : remaining;
-  }
-
-  /**
-   * Return the internal send progress slot index for `group`.
-   */
-  __device__ __forceinline__ int progress_send_index(
-      const IbSendRecvState& sendRecvState,
-      ThreadGroup& group) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    return progress_index_for_group(sendRecvState, group, 0);
-#else
-    (void)sendRecvState;
-    (void)group;
-    return 0;
-#endif
-  }
-
-  /**
-   * Return the internal recv progress slot index for `group`.
-   */
-  __device__ __forceinline__ int progress_recv_index(
-      const IbSendRecvState& sendRecvState,
-      ThreadGroup& group) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    return progress_index_for_group(
-        sendRecvState, group, sendRecvState.maxGroups);
-#else
-    (void)sendRecvState;
-    (void)group;
-    return 0;
-#endif
-  }
-
-  /**
-   * Validate a progress group and map it into the transport-owned slot array.
-   */
-  __device__ __forceinline__ int progress_index_for_group(
-      const IbSendRecvState& sendRecvState,
-      ThreadGroup& group,
-      int baseIndex) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    if (sendRecvState.state.empty() || sendRecvState.state.data() == nullptr) {
-      if (group.is_leader()) {
-        printf("[PIPES] FATAL: send/recv state is null\n");
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    if (sendRecvState.maxGroups <= 0) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: send/recv maxGroups must be > 0, got %d\n",
-            sendRecvState.maxGroups);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    const auto requiredStateSlots =
-        static_cast<uint32_t>(2 * sendRecvState.maxGroups);
-    if (sendRecvState.state.size() < requiredStateSlots ||
-        group.group_id >= static_cast<uint32_t>(sendRecvState.maxGroups)) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: progress group_id=%u out of range [0, %d), "
-            "state slots=%u\n",
-            group.group_id,
-            sendRecvState.maxGroups,
-            static_cast<unsigned>(sendRecvState.state.size()));
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    return baseIndex + static_cast<int>(group.group_id);
-#else
-    (void)group;
-    (void)baseIndex;
-    return 0;
-#endif
-  }
-
-  /**
-   * Return a reference to a transport-owned progress state slot.
-   */
-  __device__ __forceinline__ IbSendRecvState::ProgressSlot& progress_state_slot(
-      IbSendRecvState& sendRecvState,
-      ThreadGroup& group,
-      int progressIndex) const {
-    (void)group;
-    return sendRecvState.state[progressIndex];
-  }
-
-  /**
-   * Trap if a caller tries to start a second send/recv before the first ends.
-   *
-   * The broadcast is the ordering point for init callers: if the leader sees a
-   * non-idle slot, every thread traps before any caller can store new state.
-   */
-  __device__ __forceinline__ void assert_progress_slot_idle(
-      ThreadGroup& group,
-      const IbSendRecvState::ProgressSlot& state,
-      const char* direction) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    uint32_t idle = 1;
+  const std::size_t perBlockSlot = channelLayout.perChannelSize & ~15ULL;
+  if (perBlockSlot == 0) {
     if (group.is_leader()) {
-      const auto activeStage = state.activeStage;
-      idle = activeStage == detail::IbSendRecvProgressStage::Done ? 1U : 0U;
-      if (!idle) {
-        printf(
-            "[PIPES] FATAL: %s requested with outstanding %s progress "
-            "for group_id=%u stage=%d nextByte=%llu\n",
-            direction,
-            direction,
-            group.group_id,
-            static_cast<int>(activeStage),
-            static_cast<unsigned long long>(state.activeNextByte));
-      }
+      printf(
+          "[PIPES] FATAL: send perBlockSlot=0 "
+          "(dataBufferSize=%llu, maxGroups=%d)\n",
+          (unsigned long long)channelLayout.data_buffer_size(),
+          maxGroups);
     }
-    idle = group.broadcast<uint32_t>(idle);
-    if (!idle) {
-      PIPES_DEVICE_TRAP();
-    }
-#else
-    (void)group;
-    (void)state;
-    (void)direction;
-#endif
+    PIPES_DEVICE_TRAP();
   }
 
-  /**
-   * Commit an updated local progress state back to its transport-owned slot.
-   * The trailing sync orders the leader's store before later group work.
-   */
-  __device__ __forceinline__ void store_progress_state(
-      IbSendRecvState& sendRecvState,
-      ThreadGroup& group,
-      int progressIndex,
-      const IbSendRecvState::ProgressSlot& state) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    if (group.is_leader()) {
-      auto& slot = sendRecvState.state[progressIndex];
-      slot.reuseCreditStep = state.reuseCreditStep;
-      slot.activeNextByte = state.activeNextByte;
-      slot.activeBaseStep = state.activeBaseStep;
-      slot.activeStage = state.activeStage;
-    }
-    group.sync();
-#else
-    (void)group;
-    (void)progressIndex;
-    (void)state;
-#endif
+  std::size_t chunkSize =
+      (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
+      ? (max_signal_bytes & ~15ULL)
+      : perBlockSlot;
+  if (chunkSize == 0) {
+    chunkSize = perBlockSlot;
   }
 
-  /**
-   * Validate and return the static staging geometry for one progress call.
-   *
-   * This helper is called by the public init APIs and each progress attempt. It
-   * verifies that the group participates in this transfer and that the
-   * requested active block count can fit at least one 16-byte-aligned region in
-   * each staging slot.
-   *
-   * On success, `perBlockSlot` is the caller's partition within each logical
-   * staging slot and `chunkSize` is the maximum signaled sub-chunk size. A zero
-   * `maxSignalBytes` means one chunk per `perBlockSlot`; otherwise the value is
-   * rounded down to the same 16-byte alignment used by the blocking send/recv
-   * path. Invalid geometry traps on device because continuing would corrupt
-   * another block group's staging partition.
-   *
-   * The public init methods handle zero-byte operations before calling this
-   * helper. A progress call should only see zero bytes when its state is
-   * already `Done`. Non-empty payload byte counts are rounded up to 16-byte
-   * protocol counts here; copy callbacks still see only valid payload bytes.
-   */
-  __device__ __forceinline__ ProgressGeometry make_progress_geometry(
-      const IbSendRecvState& sendRecvState,
-      ThreadGroup& group,
-      std::size_t nbytes,
-      std::size_t max_signal_bytes,
-      const char* opName) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    if (nbytes == 0) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: %s saw non-Done progress state for zero-byte "
-            "transfer\n",
-            opName);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    const int groupId = static_cast<int>(group.group_id);
-    const int maxGroups = sendRecvState.maxGroups;
-    if (groupId < 0 || groupId >= maxGroups) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: %s group_id=%d >= maxGroups=%d\n",
-            opName,
-            groupId,
-            maxGroups);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    const std::size_t perBlockSlot =
-        (sendRecvState.dataBufferSize / maxGroups) & ~15ULL;
-    if (perBlockSlot == 0) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: %s perBlockSlot=0 "
-            "(dataBufferSize=%llu, maxGroups=%d)\n",
-            opName,
-            (unsigned long long)sendRecvState.dataBufferSize,
-            maxGroups);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
-    std::size_t chunkSize =
-        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
-        ? (max_signal_bytes & ~15ULL)
-        : perBlockSlot;
-    if (chunkSize == 0) {
-      chunkSize = perBlockSlot;
-    }
-    return ProgressGeometry{
-        .groupId = groupId,
-        .payloadBytes = nbytes,
-        .protocolBytes = protocolBytes,
-        .perBlockSlot = perBlockSlot,
-        .chunkSize = chunkSize,
-    };
-#else
-    (void)group;
-    (void)nbytes;
-    (void)max_signal_bytes;
-    (void)opName;
-    return {};
-#endif
+  const int pipelineDepth = channelLayout.pipelineDepth;
+  const std::size_t dataBufferSize = channelLayout.data_buffer_size();
+  auto& state = progress_send_slot(transport, group);
+  IbLocalChannel& localChannel =
+      transport.local_channel(static_cast<uint32_t>(groupId));
+  const IbgdaLocalBuffer localSlotFree = localChannel.slotFree;
+  const IbgdaLocalBuffer localNicDoneWait = localChannel.nicDoneWait;
+  const IbgdaLocalBuffer localNicDoneCompletion =
+      localChannel.nicDoneCompletion;
+  const IbRemoteChannel remoteChannel =
+      makeIbRemoteChannel(channelLayout, groupId);
+  assert_progress_slot_idle(group, state, "send");
+  const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
+  const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
+  if (group.is_leader()) {
+    state.activeStage = detail::IbSendRecvProgressStage::Busy;
+    state.activeBaseStep = static_cast<int64_t>(baseByte);
+    state.activeNextByte = 0;
   }
 
-  __device__ __forceinline__ std::size_t nic_done_credit_quantum(
-      const IbSendRecvState& sendRecvState,
-      std::size_t perBlockSlot) const {
-    return detail::ib_send_recv_nic_done_credit_quantum(
-        perBlockSlot, sendRecvState.pipelineDepth);
-  }
-
-  __device__ __forceinline__ std::size_t slot_free_credit_quantum(
-      const IbSendRecvState& sendRecvState,
-      std::size_t perBlockSlot) const {
-    return detail::ib_send_recv_slot_free_credit_quantum(
-        perBlockSlot, sendRecvState.pipelineDepth);
-  }
-
-  __device__ __forceinline__ bool should_post_nic_done_credit(
-      const IbSendRecvState& sendRecvState,
-      uint64_t streamEnd,
-      int64_t reuseCreditStep,
-      const ProgressGeometry& geometry) const {
-    return should_post_nic_done_credit(
-        sendRecvState, streamEnd, reuseCreditStep, geometry.perBlockSlot);
-  }
-
-  __device__ __forceinline__ bool should_post_nic_done_credit(
-      const IbSendRecvState& sendRecvState,
-      uint64_t streamEnd,
-      int64_t reuseCreditStep,
-      std::size_t perBlockSlot) const {
-    return should_post_credit_at_quantum(
-        streamEnd,
-        reuseCreditStep,
-        nic_done_credit_quantum(sendRecvState, perBlockSlot));
-  }
-
-  __device__ __forceinline__ bool should_post_slot_free_credit(
-      const IbSendRecvState& sendRecvState,
-      uint64_t streamEnd,
-      int64_t reuseCreditStep,
-      const ProgressGeometry& geometry) const {
-    return should_post_slot_free_credit(
-        sendRecvState, streamEnd, reuseCreditStep, geometry.perBlockSlot);
-  }
-
-  __device__ __forceinline__ bool should_post_slot_free_credit(
-      const IbSendRecvState& sendRecvState,
-      uint64_t streamEnd,
-      int64_t reuseCreditStep,
-      std::size_t perBlockSlot) const {
-    return should_post_credit_at_quantum(
-        streamEnd,
-        reuseCreditStep,
-        slot_free_credit_quantum(sendRecvState, perBlockSlot));
-  }
-
-  __device__ __forceinline__ bool should_post_credit_at_quantum(
-      uint64_t streamEnd,
-      int64_t reuseCreditStep,
-      std::size_t creditQuantum) const {
-    const uint64_t posted = reuse_credit_posted_step(reuseCreditStep);
-    return streamEnd > posted && streamEnd - posted >= creditQuantum;
-  }
-
-  __device__ __forceinline__ uint64_t
-  reuse_credit_value(uint64_t streamEnd, int64_t reuseCreditStep) const {
-    return streamEnd - reuse_credit_posted_step(reuseCreditStep);
-  }
-
-  __device__ __forceinline__ static uint64_t reuse_credit_posted_step(
-      int64_t reuseCreditStep) {
-    return reuseCreditStep > 0 ? static_cast<uint64_t>(reuseCreditStep) : 0ULL;
-  }
-
-  /**
-   * Reserve a non-overlapping protocol byte range for one progress state.
-   *
-   * Blocking send()/recv() read `state[].nextStep` at call entry and commit it
-   * at completion. Progress init cannot wait until completion because progress
-   * operations may complete across many bounded calls. Reserving at init gives
-   * the transport-owned state a stable byte-stream base and makes later
-   * blocking calls start after all in-flight progress ranges.
-   */
-  __device__ __forceinline__ int64_t reserve_progress_step(
-      IbSendRecvState& sendRecvState,
-      ThreadGroup& group,
-      int stateIndex,
-      std::size_t nbytes) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    uint64_t baseStep = 0;
-    if (group.is_leader()) {
-      auto& slot = sendRecvState.state[stateIndex];
-      baseStep = static_cast<uint64_t>(slot.nextStep);
-      slot.nextStep = static_cast<int64_t>(baseStep + nbytes);
-    }
-    baseStep = group.broadcast<uint64_t>(baseStep);
-    return static_cast<int64_t>(baseStep);
-#else
-    (void)group;
-    (void)stateIndex;
-    (void)nbytes;
-    return 0;
-#endif
-  }
-
-  /**
-   * Trap if a send progress state is not in a sender-owned stage.
-   *
-   * Without this check, corrupted or mismatched transport-owned state could
-   * return `Waiting` forever because no send-side transition would match.
-   * Trapping turns that misuse into an immediate device failure with a clear
-   * diagnostic.
-   */
-  __device__ __forceinline__ void validate_send_progress_stage(
-      ThreadGroup& group,
-      const IbSendRecvState::ProgressSlot& state) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    if (state.activeStage != detail::IbSendRecvProgressStage::WaitNicDone &&
-        state.activeStage != detail::IbSendRecvProgressStage::WaitSlotFree &&
-        state.activeStage != detail::IbSendRecvProgressStage::Done) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: progress_send_once invalid stage=%d\n",
-            static_cast<int>(state.activeStage));
-      }
-      PIPES_DEVICE_TRAP();
-    }
-#endif
-  }
-
-  /**
-   * Trap if a recv progress state is not in a receiver-owned stage.
-   *
-   * Receiver progress is only valid while waiting for DATA_READY. Sender
-   * stages are protocol misuse and cannot make progress on the recv path.
-   */
-  __device__ __forceinline__ void validate_recv_progress_stage(
-      ThreadGroup& group,
-      const IbSendRecvState::ProgressSlot& state) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    if (state.activeStage != detail::IbSendRecvProgressStage::WaitDataReady &&
-        state.activeStage != detail::IbSendRecvProgressStage::Done) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: progress_recv_once invalid stage=%d\n",
-            static_cast<int>(state.activeStage));
-      }
-      PIPES_DEVICE_TRAP();
-    }
-#endif
-  }
-
-  /**
-   * Return whether `current -> next` is a valid progress-state transition.
-   */
-  __device__ __forceinline__ bool is_valid_progress_transition(
-      detail::IbSendRecvProgressStage current,
-      detail::IbSendRecvProgressStage next) const {
-    switch (current) {
-      case detail::IbSendRecvProgressStage::WaitNicDone:
-        return next == detail::IbSendRecvProgressStage::WaitSlotFree;
-      case detail::IbSendRecvProgressStage::WaitSlotFree:
-        return next == detail::IbSendRecvProgressStage::WaitNicDone ||
-            next == detail::IbSendRecvProgressStage::Done;
-      case detail::IbSendRecvProgressStage::WaitDataReady:
-        return next == detail::IbSendRecvProgressStage::Done;
-      case detail::IbSendRecvProgressStage::Done:
-        return false;
-      case detail::IbSendRecvProgressStage::Busy:
-        return false;
-    }
-    return false;
-  }
-
-  /**
-   * Apply one legal progress-state transition.
-   *
-   * The explicit transition table keeps the send/recv state machine local and
-   * auditable. If future progress states are added, this switch must opt into
-   * each new legal edge instead of allowing silent fallthrough.
-   */
-  __device__ __forceinline__ void transition_progress_stage(
-      ThreadGroup& group,
-      IbSendRecvState::ProgressSlot& state,
-      detail::IbSendRecvProgressStage next) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    const detail::IbSendRecvProgressStage current = state.activeStage;
-    if (!is_valid_progress_transition(current, next)) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: invalid progress transition stage=%d -> %d\n",
-            static_cast<int>(current),
-            static_cast<int>(next));
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    state.activeStage = next;
-#endif
-  }
-
-  /**
-   * Map the state's logical protocol byte cursor to the next staging-ring
-   * chunk.
-   *
-   * The transport stores each logical slot as `dataBufferSize` bytes, split
-   * into geometry-specific per-group partitions. The protocol cursor advances
-   * in bytes, not slots, so `baseStep + nextByte` is reduced modulo
-   * `perBlockSlot * pipelineDepth` to pick the ring slot and per-group offset.
-   *
-   * The returned chunk is clipped by three boundaries: the configured
-   * sub-chunk size, remaining protocol bytes, and remaining bytes in the
-   * current per-block staging partition. This keeps every progress call
-   * bounded and prevents a single RDMA put or recv copy from spanning two
-   * staging slots.
-   */
-  __device__ __forceinline__ ProgressChunk next_chunk(
-      const IbSendRecvState& sendRecvState,
-      const IbSendRecvState::ProgressSlot& state,
-      const ProgressGeometry& geometry) const {
-    const uint64_t streamStart =
-        static_cast<uint64_t>(state.activeBaseStep) + state.activeNextByte;
-    const std::size_t pipelineBytes = geometry.perBlockSlot *
-        static_cast<std::size_t>(sendRecvState.pipelineDepth);
+  for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
+    const uint64_t streamStart = baseByte + dataOff;
     const std::size_t pipelineOff =
         static_cast<std::size_t>(streamStart % pipelineBytes);
-    const int slot = static_cast<int>(pipelineOff / geometry.perBlockSlot);
-    const std::size_t slotOff =
-        static_cast<std::size_t>(slot) * sendRecvState.dataBufferSize;
-    const std::size_t chunkOff =
-        pipelineOff - static_cast<std::size_t>(slot) * geometry.perBlockSlot;
-    const std::size_t slotRemaining = geometry.perBlockSlot - chunkOff;
-    const std::size_t dataRemaining =
-        geometry.protocolBytes - state.activeNextByte;
-    std::size_t bytes =
-        geometry.chunkSize < dataRemaining ? geometry.chunkSize : dataRemaining;
-    bytes = bytes < slotRemaining ? bytes : slotRemaining;
-    return ProgressChunk{
-        .stagingOff = slotOff +
-            static_cast<std::size_t>(geometry.groupId) * geometry.perBlockSlot +
-            chunkOff,
-        .dataOff = state.activeNextByte,
-        .bytes = bytes,
-        .streamEnd = streamStart + bytes,
-    };
+    const int slot = static_cast<int>(pipelineOff / perBlockSlot);
+    const std::size_t slotOff = slot * dataBufferSize;
+    const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
+    const std::size_t slotRemaining = perBlockSlot - chunkOff;
+    const std::size_t dataRemaining = protocolBytes - dataOff;
+    std::size_t bytesThis =
+        chunkSize < dataRemaining ? chunkSize : dataRemaining;
+    bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
+    const std::size_t stagingOff = slotOff + groupId * perBlockSlot + chunkOff;
+    const uint64_t streamEnd = streamStart + bytesThis;
+
+    // (1) Wait for NIC to finish with this slot's local sendStaging.
+    if (streamEnd > pipelineBytes) {
+      transport.wait_counter(
+          group, localNicDoneWait, streamEnd - pipelineBytes, timeout);
+    }
+
+    // (2) Cooperative copy: src -> local sendStaging via CopyOp.
+    const std::size_t validBytes =
+        valid_payload_bytes(dataOff, bytesThis, nbytes);
+    if (validBytes > 0) {
+      CopyOp::send(
+          channelLayout.sendStagingPtr + stagingOff,
+          static_cast<const char*>(src) + dataOff,
+          validBytes,
+          group,
+          dataOff,
+          args...);
+    }
+    group.sync();
+
+    // (3) Backpressure: wait for receiver to free this byte range's
+    //     recvStaging offset. Symmetric with DATA_READY.
+    if (streamEnd > pipelineBytes) {
+      transport.wait_signal(
+          group, localSlotFree, streamEnd - pipelineBytes, timeout);
+    }
+
+    // (4) threadfence_system + leader-only single-WQE RDMA put with
+    //     fused signal+counter. All threads fence to ensure memcpy
+    //     stores are visible to the NIC before the leader posts the WQE.
+    __threadfence_system();
+    group.sync();
+    if (group.is_leader()) {
+      IbgdaLocalBuffer counterBuf{};
+      uint64_t counterVal = 0;
+      const bool isFinalChunk = dataOff + bytesThis >= protocolBytes;
+      if (isFinalChunk ||
+          should_post_nic_done_credit(
+              streamEnd, state.reuseCreditStep, perBlockSlot, pipelineDepth)) {
+        counterVal = reuse_credit_value(streamEnd, state.reuseCreditStep);
+        counterBuf = localNicDoneCompletion;
+        state.reuseCreditStep = static_cast<int64_t>(streamEnd);
+      }
+      ThreadGroup solo{
+          0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+      transport.put(
+          solo,
+          channelLayout.sendStagingBuf.subBuffer(stagingOff),
+          remoteChannel.recvStaging.subBuffer(stagingOff),
+          bytesThis,
+          remoteChannel.dataReady,
+          bytesThis,
+          counterBuf,
+          counterVal);
+    }
+    group.sync();
+    dataOff += bytesThis;
   }
-};
+
+  if (group.is_leader()) {
+    state.nextStep = static_cast<int64_t>(baseByte + protocolBytes);
+    state.activeStage = detail::IbSendRecvProgressStage::Done;
+    state.activeBaseStep = 0;
+    state.activeNextByte = 0;
+  }
+  group.sync();
+#endif
+}
+
+/**
+ * recv — receive one block's tile from pipelined RDMA.
+ *
+ * Waits for data to arrive in recvStaging, then copies recvStaging -> dst.
+ * For this call, each logical slot contributes one perBlockSlot-sized region
+ * for this group. If nbytes > perBlockSlot, recv() advances through multiple
+ * ring positions. max_signal_bytes controls sub-chunk granularity and must
+ * match the sender.
+ *
+ * Signaling protocol (per group, symmetric with send):
+ *   DATA_READY — sender increments by bytesThis after RDMA put completes.
+ *                recv waits on this before copying from recvStaging.
+ *   SLOT_FREE  — recv increments by bytesThis (symmetric with DATA_READY)
+ *                to release backpressure on sender.
+ *
+ * @param transport       Owning transport used for every transport op.
+ * @param group           ThreadGroup (all threads participate in memcpy,
+ *                        leader does signal ops).
+ * @param dst             Destination for this block's tile.
+ * @param nbytes          Bytes to receive for this group. Internally
+ *                        consumed in perBlockSlot-sized pieces, or smaller
+ *                        sub-chunks when max_signal_bytes is set.
+ * @param max_signal_bytes Max bytes per signaled sub-chunk within one
+ *                        perBlockSlot. 0 means one signal per perBlockSlot.
+ *                        Must match the sender's value.
+ * @param timeout         Optional timeout for wait operations.
+ */
+template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+__device__ __forceinline__ void recv(
+    Transport& transport,
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0,
+    const Timeout& timeout = Timeout(),
+    Args... args) {
+#if !PIPES_IS_DEVICE_COMPILE
+  (void)transport;
+  (void)group;
+  (void)dst;
+  (void)nbytes;
+  (void)max_signal_bytes;
+  (void)timeout;
+#else
+  if (nbytes == 0) {
+    return;
+  }
+  auto& channelLayout = transport.channel_layout();
+  const std::size_t protocolBytes = align_protocol_bytes(nbytes);
+
+  const int groupId = group.group_id;
+  const int maxGroups = channelLayout.maxChannels;
+  if (groupId >= maxGroups) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: recv group_id=%u >= maxGroups=%d\n",
+          groupId,
+          maxGroups);
+    }
+    PIPES_DEVICE_TRAP();
+  }
+
+  const std::size_t perBlockSlot = channelLayout.perChannelSize & ~15ULL;
+  if (perBlockSlot == 0) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: recv perBlockSlot=0 "
+          "(dataBufferSize=%llu, maxGroups=%d)\n",
+          (unsigned long long)channelLayout.data_buffer_size(),
+          maxGroups);
+    }
+    PIPES_DEVICE_TRAP();
+  }
+
+  std::size_t chunkSize =
+      (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
+      ? (max_signal_bytes & ~15ULL)
+      : perBlockSlot;
+  if (chunkSize == 0) {
+    chunkSize = perBlockSlot;
+  }
+
+  const int pipelineDepth = channelLayout.pipelineDepth;
+  const std::size_t dataBufferSize = channelLayout.data_buffer_size();
+  auto& state = progress_recv_slot(transport, group);
+  IbLocalChannel& localChannel =
+      transport.local_channel(static_cast<uint32_t>(groupId));
+  const IbgdaLocalBuffer localDataReady = localChannel.dataReady;
+  const IbRemoteChannel remoteChannel =
+      makeIbRemoteChannel(channelLayout, groupId);
+  assert_progress_slot_idle(group, state, "recv");
+  const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
+  const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
+  if (group.is_leader()) {
+    state.activeStage = detail::IbSendRecvProgressStage::Busy;
+    state.activeBaseStep = static_cast<int64_t>(baseByte);
+    state.activeNextByte = 0;
+  }
+
+  for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
+    const uint64_t streamStart = baseByte + dataOff;
+    const std::size_t pipelineOff =
+        static_cast<std::size_t>(streamStart % pipelineBytes);
+    const int slot = static_cast<int>(pipelineOff / perBlockSlot);
+    const std::size_t slotOff = slot * dataBufferSize;
+    const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
+    const std::size_t slotRemaining = perBlockSlot - chunkOff;
+    const std::size_t dataRemaining = protocolBytes - dataOff;
+    std::size_t bytesThis =
+        chunkSize < dataRemaining ? chunkSize : dataRemaining;
+    bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
+    const std::size_t stagingOff = slotOff + groupId * perBlockSlot + chunkOff;
+    const uint64_t streamEnd = streamStart + bytesThis;
+
+    // (1) Wait for sender's DATA_READY signal.
+    transport.wait_signal(group, localDataReady, streamEnd, timeout);
+
+    // (2) Cooperative copy: local recvStaging -> dst via CopyOp.
+    const std::size_t validBytes =
+        valid_payload_bytes(dataOff, bytesThis, nbytes);
+    if (validBytes > 0) {
+      CopyOp::recv(
+          static_cast<char*>(dst) + dataOff,
+          channelLayout.recvStagingPtr + stagingOff,
+          validBytes,
+          group,
+          dataOff,
+          args...);
+    }
+    group.sync();
+
+    // (3) Signal SLOT_FREE to sender. Sender waits on the cumulative byte
+    //     threshold before reusing remote recvStaging at the same offset.
+    uint64_t slotFreeVal = 0;
+    if (group.is_leader()) {
+      if (should_post_slot_free_credit(
+              streamEnd, state.reuseCreditStep, perBlockSlot, pipelineDepth)) {
+        slotFreeVal = reuse_credit_value(streamEnd, state.reuseCreditStep);
+        state.reuseCreditStep = static_cast<int64_t>(streamEnd);
+      }
+    }
+    slotFreeVal = group.broadcast<uint64_t>(slotFreeVal);
+    if (slotFreeVal != 0) {
+      transport.signal(
+          group, remoteChannel.slotFree, slotFreeVal, IbDirection::Recv);
+    }
+    dataOff += bytesThis;
+  }
+
+  if (group.is_leader()) {
+    state.nextStep = static_cast<int64_t>(baseByte + protocolBytes);
+    state.activeStage = detail::IbSendRecvProgressStage::Done;
+    state.activeBaseStep = 0;
+    state.activeNextByte = 0;
+  }
+  group.sync();
+#endif
+}
+
+/**
+ * forward — receive data and forward it to the next peer in a ring.
+ *
+ * Combines recv + send in a single method, sharing the staging buffer to
+ * avoid an extra copy. The CopyOp::forward() method receives three
+ * buffers: dst (application output), fwd_staging (next peer's send staging),
+ * and staging (this transport's recv staging). This enables fused
+ * receive-reduce-forward patterns.
+ *
+ * Signal ordering invariant (critical for ring deadlock avoidance):
+ *   1. Wait DATA_READY from sender (this transport)
+ *   2. Wait NIC_DONE on fwd transport's sendStaging (backpressure)
+ *   3. CopyOp::forward(dst, fwd_staging, staging, ...)
+ *   4. Signal SLOT_FREE to sender (this transport) — BEFORE step 5
+ *   5. Wait SLOT_FREE from fwd transport's receiver
+ *   6. threadfence_system + RDMA put via fwd transport
+ *
+ * Step 4 before step 5 breaks the circular dependency in rings: each rank
+ * releases its predecessor's staging before waiting on its successor.
+ *
+ * Protocol compatibility with send() and recv():
+ *
+ * forward acts as a recv on "this" transport and a send on "fwd".
+ * The signal protocol is wire-compatible:
+ *
+ *   Recv side (this transport):
+ *     - Uses this channel's recv progress cursor.
+ *     - Waits DATA_READY on this channel's local data-ready signal.
+ *     - Signals SLOT_FREE on the remote channel's slot-free signal.
+ *
+ *   Fwd side (fwd transport):
+ *     - Uses the forward channel's send progress cursor.
+ *     - Waits NIC_DONE on the forward channel's local completion counter.
+ *     - Waits SLOT_FREE on the forward channel's local slot-free signal.
+ *     - RDMA puts with DATA_READY on the forward remote channel and may
+ *       batch NIC_DONE credit to the local completion counter.
+ *
+ * Any chain of send → forward* → recv is therefore valid: each
+ * forward consumes exactly the signals its predecessor produces
+ * and produces exactly the signals its successor expects.
+ *
+ * @param transport       Recv-side transport (this peer's receiver).
+ * @param group           ThreadGroup (all threads participate).
+ * @param dst             Application destination (may be nullptr if
+ *                        CopyOp handles it, e.g. reduce-scatter).
+ * @param fwdTransport    Forward transport (sends to next peer in ring).
+ * @param nbytes          Bytes to receive and forward.
+ * @param max_signal_bytes Max bytes per signaled sub-chunk. 0 = perBlockSlot.
+ * @param timeout         Optional timeout for wait operations.
+ * @param args            Extra args forwarded to CopyOp::forward.
+ */
+template <typename CopyOp = Memcpy, typename Transport, typename... Args>
+__device__ __forceinline__ void forward(
+    Transport& transport,
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    Transport& fwdTransport,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0,
+    const Timeout& timeout = Timeout(),
+    Args... args) {
+#if PIPES_IS_DEVICE_COMPILE
+#ifdef __HIP_PLATFORM_AMD__
+  static_assert(
+      sizeof(CopyOp) == 0,
+      "detail::forward() requires NVIDIA GPU (DOCA/IBGDA)");
+#endif
+  if (nbytes == 0) {
+    return;
+  }
+  auto& channelLayout = transport.channel_layout();
+  auto& fwdChannelLayout = fwdTransport.channel_layout();
+  const std::size_t protocolBytes = align_protocol_bytes(nbytes);
+
+  const int groupId = group.group_id;
+
+  // --- recv side (this transport) ---
+  const int recvMaxGroups = channelLayout.maxChannels;
+  if (groupId >= recvMaxGroups) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: forward recv maxGroups=%d groupId=%u\n",
+          recvMaxGroups,
+          groupId);
+    }
+    PIPES_DEVICE_TRAP();
+  }
+
+  const std::size_t recvPerBlockSlot = channelLayout.perChannelSize & ~15ULL;
+  if (recvPerBlockSlot == 0) {
+    if (group.is_leader()) {
+      printf("[PIPES] FATAL: forward recvPerBlockSlot=0\n");
+    }
+    PIPES_DEVICE_TRAP();
+  }
+
+  // --- fwd side (fwd transport) ---
+  const int fwdMaxGroups = fwdChannelLayout.maxChannels;
+  if (groupId >= fwdMaxGroups) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: forward fwd maxGroups=%d groupId=%u\n",
+          fwdMaxGroups,
+          groupId);
+    }
+    PIPES_DEVICE_TRAP();
+  }
+
+  const std::size_t fwdPerBlockSlot = fwdChannelLayout.perChannelSize & ~15ULL;
+  if (fwdPerBlockSlot == 0) {
+    if (group.is_leader()) {
+      printf("[PIPES] FATAL: forward fwdPerBlockSlot=0\n");
+    }
+    PIPES_DEVICE_TRAP();
+  }
+
+  // Chunk sizes for recv and fwd sides
+  std::size_t recvChunkSize =
+      (max_signal_bytes > 0 && max_signal_bytes < recvPerBlockSlot)
+      ? (max_signal_bytes & ~15ULL)
+      : recvPerBlockSlot;
+  if (recvChunkSize == 0) {
+    recvChunkSize = recvPerBlockSlot;
+  }
+  std::size_t fwdChunkSize =
+      (max_signal_bytes > 0 && max_signal_bytes < fwdPerBlockSlot)
+      ? (max_signal_bytes & ~15ULL)
+      : fwdPerBlockSlot;
+  if (fwdChunkSize == 0) {
+    fwdChunkSize = fwdPerBlockSlot;
+  }
+
+  const int recvPipelineDepth = channelLayout.pipelineDepth;
+  const std::size_t recvDataBufSize = channelLayout.data_buffer_size();
+  auto& recvSlotState = progress_recv_slot(transport, group);
+  IbLocalChannel& recvLocalChannel =
+      transport.local_channel(static_cast<uint32_t>(groupId));
+  const IbgdaLocalBuffer recvDataReady = recvLocalChannel.dataReady;
+  const IbRemoteChannel recvRemoteChannel =
+      makeIbRemoteChannel(channelLayout, groupId);
+  assert_progress_slot_idle(group, recvSlotState, "forward recv");
+  const uint64_t recvBaseByte = static_cast<uint64_t>(recvSlotState.nextStep);
+  const std::size_t recvPipelineBytes = recvPerBlockSlot * recvPipelineDepth;
+
+  const int fwdPipelineDepth = fwdChannelLayout.pipelineDepth;
+  const std::size_t fwdDataBufSize = fwdChannelLayout.data_buffer_size();
+  auto& fwdSlotState = progress_send_slot(fwdTransport, group);
+  IbLocalChannel& fwdLocalChannel =
+      fwdTransport.local_channel(static_cast<uint32_t>(groupId));
+  const IbgdaLocalBuffer fwdSlotFree = fwdLocalChannel.slotFree;
+  const IbgdaLocalBuffer fwdNicDoneWait = fwdLocalChannel.nicDoneWait;
+  const IbgdaLocalBuffer fwdNicDoneCompletion =
+      fwdLocalChannel.nicDoneCompletion;
+  const IbRemoteChannel fwdRemoteChannel =
+      makeIbRemoteChannel(fwdChannelLayout, groupId);
+  assert_progress_slot_idle(group, fwdSlotState, "forward send");
+  const uint64_t fwdBaseByte = static_cast<uint64_t>(fwdSlotState.nextStep);
+  const std::size_t fwdPipelineBytes = fwdPerBlockSlot * fwdPipelineDepth;
+  if (group.is_leader()) {
+    recvSlotState.activeStage = detail::IbSendRecvProgressStage::Busy;
+    recvSlotState.activeBaseStep = static_cast<int64_t>(recvBaseByte);
+    recvSlotState.activeNextByte = 0;
+    fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Busy;
+    fwdSlotState.activeBaseStep = static_cast<int64_t>(fwdBaseByte);
+    fwdSlotState.activeNextByte = 0;
+  }
+
+  for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
+    // --- Recv side offsets ---
+    const uint64_t recvStreamStart = recvBaseByte + dataOff;
+    const std::size_t recvPipelineOff =
+        static_cast<std::size_t>(recvStreamStart % recvPipelineBytes);
+    const int recvSlot = static_cast<int>(recvPipelineOff / recvPerBlockSlot);
+    const std::size_t recvSlotOff = recvSlot * recvDataBufSize;
+    const std::size_t recvChunkOff =
+        recvPipelineOff - recvSlot * recvPerBlockSlot;
+    const std::size_t recvStagingOff =
+        recvSlotOff + groupId * recvPerBlockSlot + recvChunkOff;
+
+    // --- Fwd side offsets ---
+    const uint64_t fwdStreamStart = fwdBaseByte + dataOff;
+    const std::size_t fwdPipelineOff =
+        static_cast<std::size_t>(fwdStreamStart % fwdPipelineBytes);
+    const int fwdSlot = static_cast<int>(fwdPipelineOff / fwdPerBlockSlot);
+    const std::size_t fwdSlotOff = fwdSlot * fwdDataBufSize;
+    const std::size_t fwdChunkOff = fwdPipelineOff - fwdSlot * fwdPerBlockSlot;
+    const std::size_t fwdStagingOff =
+        fwdSlotOff + groupId * fwdPerBlockSlot + fwdChunkOff;
+    const std::size_t recvSlotRemaining = recvPerBlockSlot - recvChunkOff;
+    const std::size_t fwdSlotRemaining = fwdPerBlockSlot - fwdChunkOff;
+    const std::size_t dataRemaining = protocolBytes - dataOff;
+    std::size_t bytesThis =
+        recvChunkSize < fwdChunkSize ? recvChunkSize : fwdChunkSize;
+    bytesThis = bytesThis < dataRemaining ? bytesThis : dataRemaining;
+    bytesThis = bytesThis < recvSlotRemaining ? bytesThis : recvSlotRemaining;
+    bytesThis = bytesThis < fwdSlotRemaining ? bytesThis : fwdSlotRemaining;
+    const uint64_t recvStreamEnd = recvStreamStart + bytesThis;
+    const uint64_t fwdStreamEnd = fwdStreamStart + bytesThis;
+
+    // (1) Wait for sender's DATA_READY.
+    transport.wait_signal(group, recvDataReady, recvStreamEnd, timeout);
+
+    // (2) Wait for NIC_DONE on fwd's sendStaging (backpressure).
+    if (fwdStreamEnd > fwdPipelineBytes) {
+      fwdTransport.wait_counter(
+          group, fwdNicDoneWait, fwdStreamEnd - fwdPipelineBytes, timeout);
+    }
+
+    // (3) CopyOp::forward — transform recv staging -> dst + fwd staging.
+    const std::size_t validBytes =
+        valid_payload_bytes(dataOff, bytesThis, nbytes);
+    if (validBytes > 0) {
+      CopyOp::forward(
+          dst ? static_cast<char*>(dst) + dataOff : nullptr,
+          fwdChannelLayout.sendStagingPtr + fwdStagingOff,
+          channelLayout.recvStagingPtr + recvStagingOff,
+          validBytes,
+          group,
+          dataOff,
+          args...);
+    }
+    group.sync();
+
+    // (4) SLOT_FREE, posted unbatched every chunk. This must happen before
+    //     the step-5 wait to break circular ring dependency.
+    transport.signal(
+        group, recvRemoteChannel.slotFree, bytesThis, IbDirection::Recv);
+    if (group.is_leader()) {
+      recvSlotState.reuseCreditStep = static_cast<int64_t>(recvStreamEnd);
+    }
+
+    // (5) Wait for fwd receiver's SLOT_FREE (backpressure on fwd's
+    //     recvStaging).
+    if (fwdStreamEnd > fwdPipelineBytes) {
+      fwdTransport.wait_signal(
+          group, fwdSlotFree, fwdStreamEnd - fwdPipelineBytes, timeout);
+    }
+
+    // (6) threadfence_system + RDMA put via fwd transport.
+    __threadfence_system();
+    group.sync();
+    if (group.is_leader()) {
+      IbgdaLocalBuffer counterBuf{};
+      uint64_t counterVal = 0;
+      const bool isFinalChunk = dataOff + bytesThis >= protocolBytes;
+      if (isFinalChunk ||
+          should_post_nic_done_credit(
+              fwdStreamEnd,
+              fwdSlotState.reuseCreditStep,
+              fwdPerBlockSlot,
+              fwdPipelineDepth)) {
+        counterVal =
+            reuse_credit_value(fwdStreamEnd, fwdSlotState.reuseCreditStep);
+        counterBuf = fwdNicDoneCompletion;
+        fwdSlotState.reuseCreditStep = static_cast<int64_t>(fwdStreamEnd);
+      }
+      ThreadGroup solo{
+          0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+      fwdTransport.put(
+          solo,
+          fwdChannelLayout.sendStagingBuf.subBuffer(fwdStagingOff),
+          fwdRemoteChannel.recvStaging.subBuffer(fwdStagingOff),
+          bytesThis,
+          fwdRemoteChannel.dataReady,
+          bytesThis,
+          counterBuf,
+          counterVal);
+    }
+    group.sync();
+    dataOff += bytesThis;
+  }
+
+  // Update shared byte cursors for both recv and fwd sides.
+  if (group.is_leader()) {
+    recvSlotState.nextStep = static_cast<int64_t>(recvBaseByte + protocolBytes);
+    recvSlotState.activeStage = detail::IbSendRecvProgressStage::Done;
+    recvSlotState.activeBaseStep = 0;
+    recvSlotState.activeNextByte = 0;
+    fwdSlotState.nextStep = static_cast<int64_t>(fwdBaseByte + protocolBytes);
+    fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Done;
+    fwdSlotState.activeBaseStep = 0;
+    fwdSlotState.activeNextByte = 0;
+  }
+  group.sync();
+#else
+  (void)transport;
+  (void)group;
+  (void)dst;
+  (void)fwdTransport;
+  (void)nbytes;
+  (void)max_signal_bytes;
+  (void)timeout;
+#endif
+}
+
+/**
+ * Maximum bytes a block can send without blocking on pipeline backpressure.
+ *
+ * The staging buffer is split into pipelineDepth slots, each with a fixed
+ * per-channel partition. A block can fill all its slots before the NIC must
+ * drain any of them, so the non-blocking window is:
+ *   perChannelSize * pipelineDepth
+ *
+ * Callers should loop over their data in pipeline_window-sized chunks so
+ * that send()/forward() never stall waiting for a free slot.
+ */
+__device__ __forceinline__ std::size_t pipeline_window(
+    const IbChannelLayout& channelLayout) {
+  return channelLayout.perChannelSize *
+      static_cast<std::size_t>(channelLayout.pipelineDepth);
+}
+
+/**
+ * Stateful send/recv cursors advance in 16-byte protocol quanta. That keeps
+ * the staging stream on the same granularity as the vectorized local staging
+ * copies while preserving caller-facing payload byte counts; padding is
+ * transport-private and is never exposed to CopyOp callbacks.
+ */
+__device__ __forceinline__ static std::size_t align_protocol_bytes(
+    std::size_t nbytes) {
+  return (nbytes + 15ULL) & ~15ULL;
+}
+
+__device__ __forceinline__ static std::size_t valid_payload_bytes(
+    std::size_t byteOffset,
+    std::size_t chunkBytes,
+    std::size_t payloadBytes) {
+  if (byteOffset >= payloadBytes) {
+    return 0;
+  }
+  const std::size_t remaining = payloadBytes - byteOffset;
+  return chunkBytes < remaining ? chunkBytes : remaining;
+}
+
+__device__ __forceinline__ void validate_progress_group(
+    const IbChannelLayout& channelLayout,
+    ThreadGroup& group) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  if (channelLayout.maxChannels <= 0) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: send/recv maxChannels must be > 0, got %d\n",
+          channelLayout.maxChannels);
+    }
+    PIPES_DEVICE_TRAP();
+  }
+  if (group.group_id >= static_cast<uint32_t>(channelLayout.maxChannels)) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: progress group_id=%u out of range [0, %d)\n",
+          group.group_id,
+          channelLayout.maxChannels);
+    }
+    PIPES_DEVICE_TRAP();
+  }
+#else
+  (void)channelLayout;
+  (void)group;
+#endif
+}
+
+template <typename Transport>
+__device__ __forceinline__ IbChannelProgress& progress_send_slot(
+    Transport& transport,
+    ThreadGroup& group) {
+  validate_progress_group(transport.channel_layout(), group);
+  return transport.local_channel(group).sendProgress;
+}
+
+template <typename Transport>
+__device__ __forceinline__ IbChannelProgress& progress_recv_slot(
+    Transport& transport,
+    ThreadGroup& group) {
+  validate_progress_group(transport.channel_layout(), group);
+  return transport.local_channel(group).recvProgress;
+}
+
+/**
+ * Trap if a caller tries to start a second send/recv before the first ends.
+ *
+ * The broadcast is the ordering point for init callers: if the leader sees a
+ * non-idle slot, every thread traps before any caller can store new state.
+ */
+__device__ __forceinline__ void assert_progress_slot_idle(
+    ThreadGroup& group,
+    const IbChannelProgress& state,
+    const char* direction) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  uint32_t idle = 1;
+  if (group.is_leader()) {
+    const auto activeStage = state.activeStage;
+    idle = activeStage == detail::IbSendRecvProgressStage::Done ? 1U : 0U;
+    if (!idle) {
+      printf(
+          "[PIPES] FATAL: %s requested with outstanding %s progress "
+          "for group_id=%u stage=%d nextByte=%llu\n",
+          direction,
+          direction,
+          group.group_id,
+          static_cast<int>(activeStage),
+          static_cast<unsigned long long>(state.activeNextByte));
+    }
+  }
+  idle = group.broadcast<uint32_t>(idle);
+  if (!idle) {
+    PIPES_DEVICE_TRAP();
+  }
+#else
+  (void)group;
+  (void)state;
+  (void)direction;
+#endif
+}
+
+/**
+ * Commit an updated local progress state back to its transport-owned slot.
+ * The trailing sync orders the leader's store before later group work.
+ */
+__device__ __forceinline__ void store_progress_state(
+    ThreadGroup& group,
+    IbChannelProgress& slot,
+    const IbChannelProgress& state) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  if (group.is_leader()) {
+    slot.reuseCreditStep = state.reuseCreditStep;
+    slot.activeNextByte = state.activeNextByte;
+    slot.activeBaseStep = state.activeBaseStep;
+    slot.activeStage = state.activeStage;
+  }
+  group.sync();
+#else
+  (void)group;
+  (void)slot;
+  (void)state;
+#endif
+}
+
+/**
+ * Validate and return the static staging geometry for one progress call.
+ *
+ * This helper is called by the public init APIs and each progress attempt. It
+ * verifies that the group participates in this transfer and that the
+ * requested active block count can fit at least one 16-byte-aligned region in
+ * each staging slot.
+ *
+ * On success, `perBlockSlot` is the caller's partition within each logical
+ * staging slot and `chunkSize` is the maximum signaled sub-chunk size. A zero
+ * `maxSignalBytes` means one chunk per `perBlockSlot`; otherwise the value is
+ * rounded down to the same 16-byte alignment used by the blocking send/recv
+ * path. Invalid geometry traps on device because continuing would corrupt
+ * another block group's staging partition.
+ *
+ * The public init methods handle zero-byte operations before calling this
+ * helper. A progress call should only see zero bytes when its state is
+ * already `Done`. Non-empty payload byte counts are rounded up to 16-byte
+ * protocol counts here; copy callbacks still see only valid payload bytes.
+ */
+__device__ __forceinline__ ProgressGeometry make_progress_geometry(
+    const IbChannelLayout& channelLayout,
+    ThreadGroup& group,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const char* opName) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  if (nbytes == 0) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: %s saw non-Done progress state for zero-byte "
+          "transfer\n",
+          opName);
+    }
+    PIPES_DEVICE_TRAP();
+  }
+  const int groupId = static_cast<int>(group.group_id);
+  const int maxGroups = channelLayout.maxChannels;
+  if (groupId < 0 || groupId >= maxGroups) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: %s group_id=%d >= maxGroups=%d\n",
+          opName,
+          groupId,
+          maxGroups);
+    }
+    PIPES_DEVICE_TRAP();
+  }
+
+  const std::size_t perBlockSlot = channelLayout.perChannelSize & ~15ULL;
+  if (perBlockSlot == 0) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: %s perBlockSlot=0 "
+          "(dataBufferSize=%llu, maxGroups=%d)\n",
+          opName,
+          (unsigned long long)channelLayout.data_buffer_size(),
+          maxGroups);
+    }
+    PIPES_DEVICE_TRAP();
+  }
+
+  const std::size_t protocolBytes = align_protocol_bytes(nbytes);
+  std::size_t chunkSize =
+      (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
+      ? (max_signal_bytes & ~15ULL)
+      : perBlockSlot;
+  if (chunkSize == 0) {
+    chunkSize = perBlockSlot;
+  }
+  return ProgressGeometry{
+      .groupId = groupId,
+      .payloadBytes = nbytes,
+      .protocolBytes = protocolBytes,
+      .perBlockSlot = perBlockSlot,
+      .chunkSize = chunkSize,
+      .pipelineDepth = channelLayout.pipelineDepth,
+  };
+#else
+  (void)group;
+  (void)nbytes;
+  (void)max_signal_bytes;
+  (void)opName;
+  return {};
+#endif
+}
+
+__device__ __forceinline__ std::size_t nic_done_credit_quantum(
+    std::size_t perBlockSlot,
+    int pipelineDepth) {
+  return detail::ib_send_recv_nic_done_credit_quantum(
+      perBlockSlot, pipelineDepth);
+}
+
+__device__ __forceinline__ std::size_t slot_free_credit_quantum(
+    std::size_t perBlockSlot,
+    int pipelineDepth) {
+  return detail::ib_send_recv_slot_free_credit_quantum(
+      perBlockSlot, pipelineDepth);
+}
+
+__device__ __forceinline__ static uint64_t reuse_credit_posted_step(
+    int64_t reuseCreditStep) {
+  return reuseCreditStep > 0 ? static_cast<uint64_t>(reuseCreditStep) : 0ULL;
+}
+
+__device__ __forceinline__ bool should_post_credit_at_quantum(
+    uint64_t streamEnd,
+    int64_t reuseCreditStep,
+    std::size_t creditQuantum) {
+  const uint64_t posted = reuse_credit_posted_step(reuseCreditStep);
+  return streamEnd > posted && streamEnd - posted >= creditQuantum;
+}
+
+__device__ __forceinline__ bool should_post_nic_done_credit(
+    uint64_t streamEnd,
+    int64_t reuseCreditStep,
+    std::size_t perBlockSlot,
+    int pipelineDepth) {
+  return should_post_credit_at_quantum(
+      streamEnd,
+      reuseCreditStep,
+      nic_done_credit_quantum(perBlockSlot, pipelineDepth));
+}
+
+__device__ __forceinline__ bool should_post_nic_done_credit(
+    uint64_t streamEnd,
+    int64_t reuseCreditStep,
+    const ProgressGeometry& geometry) {
+  return should_post_nic_done_credit(
+      streamEnd,
+      reuseCreditStep,
+      geometry.perBlockSlot,
+      geometry.pipelineDepth);
+}
+
+__device__ __forceinline__ bool should_post_slot_free_credit(
+    uint64_t streamEnd,
+    int64_t reuseCreditStep,
+    std::size_t perBlockSlot,
+    int pipelineDepth) {
+  return should_post_credit_at_quantum(
+      streamEnd,
+      reuseCreditStep,
+      slot_free_credit_quantum(perBlockSlot, pipelineDepth));
+}
+
+__device__ __forceinline__ bool should_post_slot_free_credit(
+    uint64_t streamEnd,
+    int64_t reuseCreditStep,
+    const ProgressGeometry& geometry) {
+  return should_post_slot_free_credit(
+      streamEnd,
+      reuseCreditStep,
+      geometry.perBlockSlot,
+      geometry.pipelineDepth);
+}
+
+__device__ __forceinline__ uint64_t
+reuse_credit_value(uint64_t streamEnd, int64_t reuseCreditStep) {
+  return streamEnd - reuse_credit_posted_step(reuseCreditStep);
+}
+
+/**
+ * Reserve a non-overlapping protocol byte range for one progress state.
+ *
+ * Blocking send()/recv() read the channel cursor at call entry and commit it
+ * at completion. Progress init cannot wait until completion because progress
+ * operations may complete across many bounded calls. Reserving at init gives
+ * the transport-owned channel state a stable byte-stream base and makes later
+ * blocking calls start after all in-flight progress ranges.
+ */
+__device__ __forceinline__ int64_t reserve_progress_step(
+    ThreadGroup& group,
+    IbChannelProgress& slot,
+    std::size_t nbytes) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  uint64_t baseStep = 0;
+  if (group.is_leader()) {
+    baseStep = static_cast<uint64_t>(slot.nextStep);
+    slot.nextStep = static_cast<int64_t>(baseStep + nbytes);
+  }
+  baseStep = group.broadcast<uint64_t>(baseStep);
+  return static_cast<int64_t>(baseStep);
+#else
+  (void)group;
+  (void)slot;
+  (void)nbytes;
+  return 0;
+#endif
+}
+
+/**
+ * Trap if a send progress state is not in a sender-owned stage.
+ *
+ * Without this check, corrupted or mismatched transport-owned state could
+ * return `Waiting` forever because no send-side transition would match.
+ * Trapping turns that misuse into an immediate device failure with a clear
+ * diagnostic.
+ */
+__device__ __forceinline__ void validate_send_progress_stage(
+    ThreadGroup& group,
+    const IbChannelProgress& state) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  if (state.activeStage != detail::IbSendRecvProgressStage::WaitNicDone &&
+      state.activeStage != detail::IbSendRecvProgressStage::WaitSlotFree &&
+      state.activeStage != detail::IbSendRecvProgressStage::Done) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: progress_send_once invalid stage=%d\n",
+          static_cast<int>(state.activeStage));
+    }
+    PIPES_DEVICE_TRAP();
+  }
+#endif
+}
+
+/**
+ * Trap if a recv progress state is not in a receiver-owned stage.
+ *
+ * Receiver progress is only valid while waiting for DATA_READY. Sender
+ * stages are protocol misuse and cannot make progress on the recv path.
+ */
+__device__ __forceinline__ void validate_recv_progress_stage(
+    ThreadGroup& group,
+    const IbChannelProgress& state) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  if (state.activeStage != detail::IbSendRecvProgressStage::WaitDataReady &&
+      state.activeStage != detail::IbSendRecvProgressStage::Done) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: progress_recv_once invalid stage=%d\n",
+          static_cast<int>(state.activeStage));
+    }
+    PIPES_DEVICE_TRAP();
+  }
+#endif
+}
+
+/**
+ * Return whether `current -> next` is a valid progress-state transition.
+ */
+__device__ __forceinline__ bool is_valid_progress_transition(
+    detail::IbSendRecvProgressStage current,
+    detail::IbSendRecvProgressStage next) {
+  switch (current) {
+    case detail::IbSendRecvProgressStage::WaitNicDone:
+      return next == detail::IbSendRecvProgressStage::WaitSlotFree;
+    case detail::IbSendRecvProgressStage::WaitSlotFree:
+      return next == detail::IbSendRecvProgressStage::WaitNicDone ||
+          next == detail::IbSendRecvProgressStage::Done;
+    case detail::IbSendRecvProgressStage::WaitDataReady:
+      return next == detail::IbSendRecvProgressStage::Done;
+    case detail::IbSendRecvProgressStage::Done:
+      return false;
+    case detail::IbSendRecvProgressStage::Busy:
+      return false;
+  }
+  return false;
+}
+
+/**
+ * Apply one legal progress-state transition.
+ *
+ * The explicit transition table keeps the send/recv state machine local and
+ * auditable. If future progress states are added, this switch must opt into
+ * each new legal edge instead of allowing silent fallthrough.
+ */
+__device__ __forceinline__ void transition_progress_stage(
+    ThreadGroup& group,
+    IbChannelProgress& state,
+    detail::IbSendRecvProgressStage next) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  const detail::IbSendRecvProgressStage current = state.activeStage;
+  if (!is_valid_progress_transition(current, next)) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: invalid progress transition stage=%d -> %d\n",
+          static_cast<int>(current),
+          static_cast<int>(next));
+    }
+    PIPES_DEVICE_TRAP();
+  }
+  state.activeStage = next;
+#endif
+}
+
+/**
+ * Map the state's logical protocol byte cursor to the next staging-ring
+ * chunk.
+ *
+ * The transport stores each logical slot as `dataBufferSize` bytes, split
+ * into geometry-specific per-group partitions. The protocol cursor advances
+ * in bytes, not slots, so `baseStep + nextByte` is reduced modulo
+ * `perBlockSlot * pipelineDepth` to pick the ring slot and per-group offset.
+ *
+ * The returned chunk is clipped by three boundaries: the configured
+ * sub-chunk size, remaining protocol bytes, and remaining bytes in the
+ * current per-block staging partition. This keeps every progress call
+ * bounded and prevents a single RDMA put or recv copy from spanning two
+ * staging slots.
+ */
+__device__ __forceinline__ ProgressChunk next_chunk(
+    const IbChannelLayout& channelLayout,
+    const IbChannelProgress& state,
+    const ProgressGeometry& geometry) {
+  const uint64_t streamStart =
+      static_cast<uint64_t>(state.activeBaseStep) + state.activeNextByte;
+  const std::size_t pipelineBytes = geometry.perBlockSlot *
+      static_cast<std::size_t>(channelLayout.pipelineDepth);
+  const std::size_t pipelineOff =
+      static_cast<std::size_t>(streamStart % pipelineBytes);
+  const int slot = static_cast<int>(pipelineOff / geometry.perBlockSlot);
+  const std::size_t slotOff =
+      static_cast<std::size_t>(slot) * channelLayout.data_buffer_size();
+  const std::size_t chunkOff =
+      pipelineOff - static_cast<std::size_t>(slot) * geometry.perBlockSlot;
+  const std::size_t slotRemaining = geometry.perBlockSlot - chunkOff;
+  const std::size_t dataRemaining =
+      geometry.protocolBytes - state.activeNextByte;
+  std::size_t bytes =
+      geometry.chunkSize < dataRemaining ? geometry.chunkSize : dataRemaining;
+  bytes = bytes < slotRemaining ? bytes : slotRemaining;
+  return ProgressChunk{
+      .stagingOff = slotOff +
+          static_cast<std::size_t>(geometry.groupId) * geometry.perBlockSlot +
+          chunkOff,
+      .dataOff = state.activeNextByte,
+      .bytes = bytes,
+      .streamEnd = streamStart + bytes,
+  };
+}
+} // namespace detail
 
 struct P2pIbTransportDevice {
   P2pIbBackendType type{P2pIbBackendType::IBGDA};
@@ -1985,7 +1998,7 @@ struct P2pIbTransportDevice {
 
   __device__ void fence();
 
-  // Pipelined send/recv — forwarded to the active backend's IbSendRecvDevice.
+  // Pipelined send/recv — forwarded to the active backend's shared helpers.
   template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void send(
       ThreadGroup& group,

--- a/comms/prims/transport/ibgda/IbgdaBuffer.h
+++ b/comms/prims/transport/ibgda/IbgdaBuffer.h
@@ -435,65 +435,16 @@ enum class IbSendRecvProgressStage : uint8_t {
 
 } // namespace detail
 
-/**
- * IbSendRecvState — device-side state for pipelined RDMA send/recv.
- *
- * Holds all buffer handles and config needed by send/recv.
- * All physical memory is allocated by MultipeerIbgdaTransport on the host;
- * this struct contains only pointers/handles into those allocations.
- *
- * Buffer layout:
- *   sendStaging / recvStaging: pipelineDepth * dataBufferSize bytes each.
- *     Logically divided into pipelineDepth slots of dataBufferSize bytes.
- *     Each slot is partitioned into maxGroups fixed channel regions:
- *       perBlockSlot = (dataBufferSize / maxGroups) & ~15ULL
- *     If max_signal_bytes is smaller than perBlockSlot, each per-block region
- *     is further subdivided into signaled sub-chunks:
- *       chunkSize = floor16(min(perBlockSlot, max_signal_bytes))
- *     state[].nextStep counts 16-byte-aligned protocol bytes, not sub-chunks,
- *     so max_signal_bytes may change between calls without changing the
- *     staging layout.
- *
- *   signalBuf: 2 * maxGroups * sizeof(uint64_t).
- *     [0, maxGroups)             — DATA_READY (sender -> receiver)
- *     [maxGroups, 2*maxGroups)   — SLOT_FREE (receiver -> sender)
- *
- *   counterBuf: maxGroups * sizeof(uint64_t).
- *     [0, maxGroups)             — NIC_DONE counters (loopback atomic)
- *
- *   state: 2 * maxGroups ProgressSlot entries.
- *     [0, maxGroups)             — sender state slots
- *     [maxGroups, 2*maxGroups)   — receiver state slots
- *
- *     nextStep is the persistent protocol-byte cursor used by both blocking
- *     and async send/recv APIs. The active* fields describe at most one
- *     outstanding async progress operation or blocking call in that
- *     direction/group.
- *     Static transfer geometry is passed to init/progress calls and computed
- *     in registers.
- */
-struct IbSendRecvState {
-  /**
-   * Internal protocol state for one transport-owned send/recv direction.
-   *
-   * The state is indexed by direction and transport group. `nextStep` is the
-   * shared byte-stream cursor used by blocking send/recv and async init.
-   * `reuseCreditStep` is the persistent byte cursor for reuse credits: NIC_DONE
-   * on sender slots and SLOT_FREE on receiver slots. It may lag `nextStep`
-   * because those credits can be batched without delaying DATA_READY
-   * visibility. `activeBaseStep`, `activeNextByte`, and `activeStage` track the
-   * currently initialized async operation or a blocking call in progress, if
-   * any.
-   */
-  struct ProgressSlot {
-    int64_t nextStep{0};
-    int64_t reuseCreditStep{0};
-    std::size_t activeNextByte{0};
-    int64_t activeBaseStep{0};
-    detail::IbSendRecvProgressStage activeStage{
-        detail::IbSendRecvProgressStage::Done};
-  };
+struct IbChannelProgress {
+  int64_t nextStep{0};
+  int64_t reuseCreditStep{0};
+  std::size_t activeNextByte{0};
+  int64_t activeBaseStep{0};
+  detail::IbSendRecvProgressStage activeStage{
+      detail::IbSendRecvProgressStage::Done};
+};
 
+struct IbChannelLayout {
   IbgdaLocalBuffer
       sendStagingBuf; ///< Registered sendStaging (lkey for put src)
   IbgdaRemoteBuffer recvStagingBuf; ///< Peer's recvStaging (rkey for put dst)
@@ -505,10 +456,13 @@ struct IbSendRecvState {
   IbgdaRemoteBuffer remoteSignalBuf; ///< Peer's signal inbox
   IbgdaLocalBuffer localCounterBuf; ///< GPU-readable NIC_DONE counter inbox
   IbgdaLocalBuffer localCounterCompletionBuf; ///< Transport completion target
-  DeviceSpan<ProgressSlot> state; ///< Protocol cursors + async state
-  int maxGroups{0}; ///< Layout size for signal/state arrays
+  int maxChannels{0}; ///< Layout size for channel-indexed resources
   int pipelineDepth{0}; ///< Number of pipeline slots in the ring
-  std::size_t dataBufferSize{0}; ///< Size of one pipeline slot in bytes
+  std::size_t perChannelSize{0}; ///< Bytes per channel in one pipeline slot
+
+  __host__ __device__ std::size_t data_buffer_size() const {
+    return perChannelSize * static_cast<std::size_t>(maxChannels);
+  }
 };
 
 enum class IbDirection : uint8_t {
@@ -526,8 +480,8 @@ struct IbQpState {
 };
 
 struct IbLocalChannel {
-  IbSendRecvState::ProgressSlot sendProgress;
-  IbSendRecvState::ProgressSlot recvProgress;
+  IbChannelProgress sendProgress;
+  IbChannelProgress recvProgress;
 
   IbgdaLocalBuffer dataReady;
   IbgdaLocalBuffer slotFree;
@@ -543,5 +497,34 @@ struct IbRemoteChannel {
   IbgdaRemoteBuffer slotFree;
   IbgdaRemoteBuffer recvStaging;
 };
+
+IBGDA_HOST_DEVICE inline IbLocalChannel makeIbLocalChannel(
+    const IbChannelLayout& layout,
+    int channelId) {
+  IbLocalChannel channel{};
+  channel.dataReady = layout.localSignalBuf.subBuffer(
+      static_cast<std::size_t>(channelId) * sizeof(uint64_t));
+  channel.slotFree = layout.localSignalBuf.subBuffer(
+      static_cast<std::size_t>(layout.maxChannels + channelId) *
+      sizeof(uint64_t));
+  channel.nicDoneWait = layout.localCounterBuf.subBuffer(
+      static_cast<std::size_t>(channelId) * sizeof(uint64_t));
+  channel.nicDoneCompletion = layout.localCounterCompletionBuf.subBuffer(
+      static_cast<std::size_t>(channelId) * sizeof(uint64_t));
+  return channel;
+}
+
+IBGDA_HOST_DEVICE inline IbRemoteChannel makeIbRemoteChannel(
+    const IbChannelLayout& layout,
+    int channelId) {
+  return IbRemoteChannel{
+      .dataReady = layout.remoteSignalBuf.subBuffer(
+          static_cast<std::size_t>(channelId) * sizeof(uint64_t)),
+      .slotFree = layout.remoteSignalBuf.subBuffer(
+          static_cast<std::size_t>(layout.maxChannels + channelId) *
+          sizeof(uint64_t)),
+      .recvStaging = layout.recvStagingBuf,
+  };
+}
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -561,9 +561,8 @@ P2pIbgdaTransportBuildParams MultipeerIbgdaTransport::buildPeerTransportParams(
     int peerIndex) const {
   const int mainQpsPerPeerPerNic = config_.fixedChannelMainQpsPerPeerPerNic();
   const int companionSlots = config_.fixedChannelCompanionQpsPerPeerPerNic();
-  // Build the device-side send/recv state from the shared base (delegates to
-  // the inherited sendRecvPeerBuffers_).
-  P2pIbgdaTransportBuildParams params(sendRecvStateForPeer(peerIndex));
+  // Build the device-side send/recv layout from the shared base.
+  P2pIbgdaTransportBuildParams params(channelLayoutForPeer(peerIndex));
   params.maxChannels = config_.max_num_channels;
   params.qpDirectionCount = config_.fixedChannelDirectionCount();
   params.qpsPerConnection = config_.qpsPerConnection;

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cu
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cu
@@ -137,9 +137,23 @@ P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
   CHECK(err == cudaSuccess)
       << "Failed to allocate GPU IB channel state: " << cudaGetErrorString(err);
   outGpuAllocations.push_back(d_allLocalChannels);
-  err = cudaMemset(d_allLocalChannels, 0, blockStateBytes);
-  CHECK(err == cudaSuccess)
-      << "Failed to zero GPU IB channel state: " << cudaGetErrorString(err);
+  std::vector<IbLocalChannel> h_localChannels(
+      static_cast<std::size_t>(numPeers) * params[0].maxChannels);
+  for (int i = 0; i < numPeers; ++i) {
+    for (int channel = 0; channel < params[i].maxChannels; ++channel) {
+      const auto channelIndex =
+          static_cast<std::size_t>(i) * params[0].maxChannels + channel;
+      h_localChannels[channelIndex] =
+          makeIbLocalChannel(params[i].channelLayout, channel);
+    }
+  }
+  err = cudaMemcpy(
+      d_allLocalChannels,
+      h_localChannels.data(),
+      blockStateBytes,
+      cudaMemcpyHostToDevice);
+  CHECK(err == cudaSuccess) << "Failed to initialize GPU IB channel state: "
+                            << cudaGetErrorString(err);
 
   std::vector<P2pIbgdaTransportDevice> h_transports;
   h_transports.reserve(numPeers);
@@ -159,7 +173,7 @@ P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
         DeviceSpan<IbLocalChannel>(
             d_allLocalChannels + i * params[i].maxChannels,
             params[i].maxChannels),
-        params[i].sendRecvState);
+        params[i].channelLayout);
   }
 
   // 4. Allocate and copy transport objects to GPU.
@@ -257,9 +271,19 @@ void writeDeviceTransportSlot(
   CHECK(err == cudaSuccess) << "Failed to allocate per-peer IB channel state: "
                             << cudaGetErrorString(err);
   outGpuAllocations.push_back(d_localChannels);
-  err = cudaMemset(d_localChannels, 0, blockStateBytes);
-  CHECK(err == cudaSuccess) << "Failed to zero per-peer IB channel state: "
-                            << cudaGetErrorString(err);
+  std::vector<IbLocalChannel> h_localChannels(params.maxChannels);
+  for (int channel = 0; channel < params.maxChannels; ++channel) {
+    h_localChannels[channel] =
+        makeIbLocalChannel(params.channelLayout, channel);
+  }
+  err = cudaMemcpy(
+      d_localChannels,
+      h_localChannels.data(),
+      blockStateBytes,
+      cudaMemcpyHostToDevice);
+  CHECK(err == cudaSuccess)
+      << "Failed to initialize per-peer IB channel state: "
+      << cudaGetErrorString(err);
 
   P2pIbgdaTransportDevice hostTransport(
       DeviceSpan<NicDeviceIbgdaResources>(d_nicResources, numNics),
@@ -272,7 +296,7 @@ void writeDeviceTransportSlot(
       params.qpsPerConnection,
       params.qpDirectionCount,
       DeviceSpan<IbLocalChannel>(d_localChannels, params.maxChannels),
-      params.sendRecvState);
+      params.channelLayout);
 
   err = cudaMemcpy(
       deviceArray + peerIndex,

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cuh
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cuh
@@ -58,8 +58,8 @@ struct NicDeviceIbgdaResourcesBuildSpec {
  */
 struct P2pIbgdaTransportBuildParams {
   P2pIbgdaTransportBuildParams() = default;
-  explicit P2pIbgdaTransportBuildParams(IbSendRecvState sendRecvStateIn)
-      : sendRecvState(sendRecvStateIn) {}
+  explicit P2pIbgdaTransportBuildParams(IbChannelLayout channelLayoutIn)
+      : channelLayout(channelLayoutIn) {}
 
   std::vector<NicDeviceIbgdaResourcesBuildSpec> h_nicDeviceIbgdaResources;
   IbgdaRemoteBuffer remoteSignalBuf{};
@@ -71,7 +71,7 @@ struct P2pIbgdaTransportBuildParams {
   int maxChannels{0};
   int qpsPerConnection{1};
   int qpDirectionCount{1};
-  IbSendRecvState sendRecvState{};
+  IbChannelLayout channelLayout{};
 };
 
 /**
@@ -80,7 +80,7 @@ struct P2pIbgdaTransportBuildParams {
  * For each peer, allocates GPU arrays for QP pointers, copies them,
  * then constructs P2pIbgdaTransportDevice objects in GPU memory.
  * All GPU allocations are pushed into outGpuAllocations for cleanup.
- * If sendRecvState is populated in the build params, it is passed through
+ * If channelLayout is populated in the build params, it is passed through
  * the transport constructor before copying to GPU.
  *
  * @param params Build parameters (one per peer)

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -43,8 +43,8 @@ inline constexpr uint64_t kDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
 // is intentionally available across all `comms/prims` device headers.
 //
 // `IbgdaSendRecvProgressStatus` and the pipelined send/recv algorithm live in
-// the shared stateless `IbSendRecvDevice` (P2pIbTransportDeviceDecl.cuh);
-// backend-owned `sendRecvState_` carries the actual protocol state.
+// private shared helpers in P2pIbTransportDeviceDecl.cuh; backend-owned
+// `channelLayout_` carries the actual protocol state.
 
 // Slot-id bounds checks for the slot-index API. Catches both
 // out-of-range slot ids and slot-index calls made when the transport was
@@ -186,7 +186,7 @@ class P2pIbgdaTransportDevice {
    * @param numCounterSlots       Number of uint64_t slots in the owned
    *                              counter buffer. Zero disables the
    *                              slot-index counter API.
-   * @param sendRecvState         Optional pipelined send/recv protocol state.
+   * @param channelLayout         Optional pipelined send/recv channel layout.
    *                              When empty, send()/recv() are unavailable.
    */
   __host__ __device__ P2pIbgdaTransportDevice(
@@ -200,7 +200,7 @@ class P2pIbgdaTransportDevice {
       int qpsPerConnection = 1,
       int qpDirectionCount = kIbDirections,
       DeviceSpan<IbLocalChannel> localChannels = {},
-      IbSendRecvState sendRecvState = {})
+      IbChannelLayout channelLayout = {})
       : nicDevices_(nicDevices),
         ownedRemoteSignalBuf_(ownedRemoteSignalBuf),
         ownedLocalSignalBuf_(ownedLocalSignalBuf),
@@ -211,7 +211,7 @@ class P2pIbgdaTransportDevice {
         qpsPerConnection_(qpsPerConnection),
         qpDirectionCount_(qpDirectionCount),
         localChannels_(localChannels),
-        sendRecvState_(sendRecvState) {}
+        channelLayout_(channelLayout) {}
 
   // =========================================================================
   // Slot-Index API (resolves owned buffers, forwards to explicit-buffer API)
@@ -1869,15 +1869,16 @@ class P2pIbgdaTransportDevice {
   //                      perBlockSlot. Otherwise:
   //                        chunkSize = floor16(min(perBlockSlot,
   //                                             max_signal_bytes))
-  //   state[].nextStep = persistent 16-byte-aligned protocol cursor.
-  //                      DATA_READY, SLOT_FREE, and NIC_DONE counters also
-  //                      advance by protocol bytes, which keeps cursor state
-  //                      independent of max_signal_bytes.
+  //   channel progress   = persistent 16-byte-aligned protocol cursor.
+  //                        DATA_READY, SLOT_FREE, and NIC_DONE counters also
+  //                        advance by protocol bytes, which keeps cursor state
+  //                        independent of max_signal_bytes.
   //
   // Typical usage:
   //   auto [role, sub] = group.partition(2);
-  //   std::size_t sectionBytes = transport->send_recv_state().dataBufferSize;
-  //   for (std::size_t s = 0; s < totalBytes / sectionBytes; ++s) {
+  //   std::size_t sectionBytes =
+  //   transport->channel_layout().data_buffer_size(); for (std::size_t s = 0; s
+  //   < totalBytes / sectionBytes; ++s) {
   //     TiledBuffer<char> tiles(data + s * sectionBytes, sectionBytes, sub);
   //     if (role == 0)
   //       transport->send(sub, tiles.data(), tiles.bytes());
@@ -1985,8 +1986,7 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0) {
-    sendRecv_.init_send_progress(
-        sendRecvState_, group, nbytes, max_signal_bytes);
+    detail::init_send_progress(*this, group, nbytes, max_signal_bytes);
   }
 
   /**
@@ -2019,8 +2019,7 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0) {
-    sendRecv_.init_recv_progress(
-        sendRecvState_, group, nbytes, max_signal_bytes);
+    detail::init_recv_progress(*this, group, nbytes, max_signal_bytes);
   }
 
   /**
@@ -2063,15 +2062,8 @@ class P2pIbgdaTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-    return sendRecv_.progress_send_once<P2pIbgdaTransportDevice, CopyOp>(
-        *this,
-        sendRecvState_,
-        group,
-        src,
-        nbytes,
-        max_signal_bytes,
-        timeout,
-        args...);
+    return detail::progress_send_once<P2pIbgdaTransportDevice, CopyOp>(
+        *this, group, src, nbytes, max_signal_bytes, timeout, args...);
   }
 
   /**
@@ -2111,15 +2103,8 @@ class P2pIbgdaTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-    return sendRecv_.progress_recv_once<P2pIbgdaTransportDevice, CopyOp>(
-        *this,
-        sendRecvState_,
-        group,
-        dst,
-        nbytes,
-        max_signal_bytes,
-        timeout,
-        args...);
+    return detail::progress_recv_once<P2pIbgdaTransportDevice, CopyOp>(
+        *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
   }
 
   /**
@@ -2140,9 +2125,10 @@ class P2pIbgdaTransportDevice {
    *   DATA_READY — sender increments by bytesThis, piggybacked on put.
    *                recv waits on this before reading recvStaging.
    *
-   * state[].nextStep persists across calls, so send() resumes the staging-ring
-   * cursor and protocol sequence numbers on each invocation. This allows
-   * callers to pipeline across repeated send() calls without a separate drain.
+   * The channel progress cursor persists across calls, so send() resumes the
+   * staging-ring cursor and protocol sequence numbers on each invocation. This
+   * allows callers to pipeline across repeated send() calls without a separate
+   * drain.
    *
    * The caller must keep the transport layout stable while a sequence is in
    * flight. `max_signal_bytes` may vary across calls because it changes only
@@ -2201,15 +2187,8 @@ class P2pIbgdaTransportDevice {
           /*step=*/0,
           static_cast<uint16_t>(group.group_id));
     }
-    sendRecv_.send<P2pIbgdaTransportDevice, CopyOp>(
-        *this,
-        sendRecvState_,
-        group,
-        src,
-        nbytes,
-        max_signal_bytes,
-        timeout,
-        args...);
+    detail::send<P2pIbgdaTransportDevice, CopyOp>(
+        *this, group, src, nbytes, max_signal_bytes, timeout, args...);
     if (group.is_leader()) {
       trace_ibgda_event(
           trace,
@@ -2290,15 +2269,8 @@ class P2pIbgdaTransportDevice {
           /*step=*/0,
           static_cast<uint16_t>(group.group_id));
     }
-    sendRecv_.recv<P2pIbgdaTransportDevice, CopyOp>(
-        *this,
-        sendRecvState_,
-        group,
-        dst,
-        nbytes,
-        max_signal_bytes,
-        timeout,
-        args...);
+    detail::recv<P2pIbgdaTransportDevice, CopyOp>(
+        *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
     if (group.is_leader()) {
       trace_ibgda_event(
           trace,
@@ -2397,18 +2369,8 @@ class P2pIbgdaTransportDevice {
           /*step=*/0,
           static_cast<uint16_t>(group.group_id));
     }
-    sendRecv_.forward<CopyOp>(
-        *this,
-        sendRecvState_,
-        group,
-        dst,
-        fwd.sendRecv_,
-        fwd.sendRecvState_,
-        fwd,
-        nbytes,
-        max_signal_bytes,
-        timeout,
-        args...);
+    detail::forward<CopyOp>(
+        *this, group, dst, fwd, nbytes, max_signal_bytes, timeout, args...);
     if (group.is_leader()) {
       trace_ibgda_event(
           trace,
@@ -2420,10 +2382,21 @@ class P2pIbgdaTransportDevice {
 #endif
   }
 
-  // Send/recv state accessors
+  __device__ __forceinline__ IbLocalChannel& local_channel(uint32_t channelId) {
+    validate_channel_id(channelId);
+    return localChannels_[channelId];
+  }
 
-  __host__ __device__ const IbSendRecvState& send_recv_state() const {
-    return sendRecvState_;
+  __device__ __forceinline__ IbLocalChannel& local_channel(ThreadGroup& group) {
+    return local_channel(group.group_id);
+  }
+
+  __host__ __device__ IbChannelLayout& channel_layout() {
+    return channelLayout_;
+  }
+
+  __host__ __device__ const IbChannelLayout& channel_layout() const {
+    return channelLayout_;
   }
 
   /**
@@ -2438,7 +2411,7 @@ class P2pIbgdaTransportDevice {
    * that send()/forward() never stall waiting for a free slot.
    */
   __device__ __forceinline__ std::size_t pipeline_window() const {
-    return sendRecv_.pipeline_window(sendRecvState_);
+    return detail::pipeline_window(channelLayout_);
   }
 
  private:
@@ -2458,8 +2431,7 @@ class P2pIbgdaTransportDevice {
   int qpDirectionCount_{kIbDirections};
   DeviceSpan<IbLocalChannel> localChannels_{};
 
-  IbSendRecvState sendRecvState_{};
-  IbSendRecvDevice sendRecv_{};
+  IbChannelLayout channelLayout_{};
 };
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -355,7 +355,7 @@ void MultipeerIbrcTransport::exchange() {
         IbCounterStorage::HostPinned, /*allocateDiscardSignal=*/false);
     // Allocate + collectively exchange send/recv staging before building the
     // device transports, so updatePeerDeviceTransport can embed the resulting
-    // IbSendRecvState. Delegated to the shared base; IBRC uses a host-mapped
+    // IbChannelLayout. Delegated to the shared base; IBRC uses a host-mapped
     // NIC_DONE counter (CPU proxy writes it) via the HostPinned counter
     // storage.
     allocateSendRecvBuffersEager(IbCounterStorage::HostPinned);
@@ -949,6 +949,11 @@ void MultipeerIbrcTransport::allocatePeerCmdQueues(int peerIndex) {
       static_cast<std::size_t>(config_.max_num_channels) *
           sizeof(IbLocalChannel),
       "per-peer channel state");
+  auto* channels = static_cast<IbLocalChannel*>(peer.channelState.host);
+  const IbChannelLayout channelLayout = channelLayoutForPeer(peerIndex);
+  for (int channel = 0; channel < config_.max_num_channels; ++channel) {
+    channels[channel] = makeIbLocalChannel(channelLayout, channel);
+  }
   peer.cmdQueues = std::move(cmdQueues);
   peer.cmdQueuesAllocated = true;
   updatePeerDeviceTransport(peerIndex);
@@ -1010,7 +1015,7 @@ void MultipeerIbrcTransport::updatePeerDeviceTransport(int peerIndex) noexcept {
       counterHostBuf,
       config_.numSignalSlots,
       config_.numCounterSlots,
-      sendRecvStateForPeer(peerIndex));
+      channelLayoutForPeer(peerIndex));
 }
 
 std::size_t MultipeerIbrcTransport::allocatedCmdQueueCount() const {
@@ -1057,11 +1062,11 @@ MultipeerIbrcTransport::MappedAllocation MultipeerIbrcTransport::allocateMapped(
   return allocation;
 }
 
-// Send/recv staging allocation, exchange, cleanup, and IbSendRecvState
+// Send/recv staging allocation, exchange, cleanup, and IbChannelLayout
 // construction are provided by MultiPeerIbTransportBase. IBRC delegates via
 // allocateSendRecvBuffersEager(IbCounterStorage::HostPinned) /
 // exchangeSendRecvBuffersEager() / cleanupSendRecvBuffers() /
-// sendRecvStateForPeer().
+// channelLayoutForPeer().
 
 void MultipeerIbrcTransport::destroyPeerQps(
     std::vector<PeerQpResource>& qpResources) noexcept {
@@ -1560,7 +1565,7 @@ void MultipeerIbrcTransport::doMaterializePeer(int peerRank) {
       /*allocateDiscardSignal=*/false);
   // Allocate this peer's send/recv rings on demand (HostPinned NIC_DONE
   // counter, CPU-proxy written) and publish them on the same bilateral round,
-  // so sendRecvStateForPeer(peerIndex) is populated when allocatePeerCmdQueues
+  // so channelLayoutForPeer(peerIndex) is populated when allocatePeerCmdQueues
   // -> updatePeerDeviceTransport bakes it into the device slot.
   allocateSendRecvBufferForPeer(
       peerIndex, localBuf, IbCounterStorage::HostPinned);

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cu
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cu
@@ -33,7 +33,7 @@ void writeIbrcDeviceSlot(
     IbgdaLocalBuffer counterHostBuf,
     int numSignalSlots,
     int numCounterSlots,
-    IbSendRecvState sendRecvState) {
+    IbChannelLayout channelLayout) {
   auto* slots = static_cast<P2pIbrcTransportDevice*>(slotsHost);
   new (&slots[peerIndex]) P2pIbrcTransportDevice(
       queues,
@@ -47,7 +47,7 @@ void writeIbrcDeviceSlot(
       counterHostBuf,
       numSignalSlots,
       numCounterSlots,
-      sendRecvState);
+      channelLayout);
 }
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cuh
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cuh
@@ -44,6 +44,6 @@ void writeIbrcDeviceSlot(
     IbgdaLocalBuffer counterHostBuf,
     int numSignalSlots,
     int numCounterSlots,
-    IbSendRecvState sendRecvState);
+    IbChannelLayout channelLayout);
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -80,7 +80,7 @@ class P2pIbrcTransportDevice {
       IbgdaLocalBuffer ownedCounterHostBuf = {},
       int numSignalSlots = 0,
       int numCounterSlots = 0,
-      IbSendRecvState sendRecvState = {})
+      IbChannelLayout channelLayout = {})
       : cmdQueues(queues),
         numNics(nics),
         maxChannels_(maxChannels),
@@ -92,7 +92,7 @@ class P2pIbrcTransportDevice {
         ownedCounterHostBuf_(ownedCounterHostBuf),
         numSignalSlots_(numSignalSlots),
         numCounterSlots_(numCounterSlots),
-        sendRecvState_(sendRecvState) {}
+        channelLayout_(channelLayout) {}
 
   __device__ void put(
       ThreadGroup& group,
@@ -458,36 +458,47 @@ class P2pIbrcTransportDevice {
   }
 
   // ===========================================================================
-  // Pipelined send/recv — delegated to the shared stateless IbSendRecvDevice.
+  // Pipelined send/recv — delegated to shared detail helpers.
   // ===========================================================================
   //
-  // The send/recv algorithm is transport-agnostic and lives in
-  // `IbSendRecvDevice` (P2pIbTransportDeviceDecl.cuh). The protocol state is
-  // owned by this backend device; each method routes every transport op through
-  // `*this`, so IBRC reuses IBGDA's send/recv unchanged.
+  // The send/recv algorithm is transport-agnostic and lives in private helpers
+  // in P2pIbTransportDeviceDecl.cuh. The protocol state is owned by this
+  // backend device; each method routes every transport op through `*this`, so
+  // IBRC reuses IBGDA's send/recv unchanged.
 
-  __host__ __device__ const IbSendRecvState& send_recv_state() const {
-    return sendRecvState_;
+  __device__ __forceinline__ IbLocalChannel& local_channel(uint32_t channelId) {
+    validate_channel_id(channelId);
+    return localChannels_[channelId];
+  }
+
+  __device__ __forceinline__ IbLocalChannel& local_channel(ThreadGroup& group) {
+    return local_channel(group.group_id);
+  }
+
+  __host__ __device__ IbChannelLayout& channel_layout() {
+    return channelLayout_;
+  }
+
+  __host__ __device__ const IbChannelLayout& channel_layout() const {
+    return channelLayout_;
   }
 
   __device__ __forceinline__ std::size_t pipeline_window() const {
-    return sendRecv_.pipeline_window(sendRecvState_);
+    return detail::pipeline_window(channelLayout_);
   }
 
   __device__ __forceinline__ void init_send_progress(
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0) {
-    sendRecv_.init_send_progress(
-        sendRecvState_, group, nbytes, max_signal_bytes);
+    detail::init_send_progress(*this, group, nbytes, max_signal_bytes);
   }
 
   __device__ __forceinline__ void init_recv_progress(
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0) {
-    sendRecv_.init_recv_progress(
-        sendRecvState_, group, nbytes, max_signal_bytes);
+    detail::init_recv_progress(*this, group, nbytes, max_signal_bytes);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -498,15 +509,8 @@ class P2pIbrcTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-    return sendRecv_.progress_send_once<P2pIbrcTransportDevice, CopyOp>(
-        *this,
-        sendRecvState_,
-        group,
-        src,
-        nbytes,
-        max_signal_bytes,
-        timeout,
-        args...);
+    return detail::progress_send_once<P2pIbrcTransportDevice, CopyOp>(
+        *this, group, src, nbytes, max_signal_bytes, timeout, args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -517,15 +521,8 @@ class P2pIbrcTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-    return sendRecv_.progress_recv_once<P2pIbrcTransportDevice, CopyOp>(
-        *this,
-        sendRecvState_,
-        group,
-        dst,
-        nbytes,
-        max_signal_bytes,
-        timeout,
-        args...);
+    return detail::progress_recv_once<P2pIbrcTransportDevice, CopyOp>(
+        *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -536,15 +533,8 @@ class P2pIbrcTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-    sendRecv_.send<P2pIbrcTransportDevice, CopyOp>(
-        *this,
-        sendRecvState_,
-        group,
-        src,
-        nbytes,
-        max_signal_bytes,
-        timeout,
-        args...);
+    detail::send<P2pIbrcTransportDevice, CopyOp>(
+        *this, group, src, nbytes, max_signal_bytes, timeout, args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -555,15 +545,8 @@ class P2pIbrcTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-    sendRecv_.recv<P2pIbrcTransportDevice, CopyOp>(
-        *this,
-        sendRecvState_,
-        group,
-        dst,
-        nbytes,
-        max_signal_bytes,
-        timeout,
-        args...);
+    detail::recv<P2pIbrcTransportDevice, CopyOp>(
+        *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -575,18 +558,8 @@ class P2pIbrcTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-    sendRecv_.forward<CopyOp>(
-        *this,
-        sendRecvState_,
-        group,
-        dst,
-        fwd.sendRecv_,
-        fwd.sendRecvState_,
-        fwd,
-        nbytes,
-        max_signal_bytes,
-        timeout,
-        args...);
+    detail::forward<CopyOp>(
+        *this, group, dst, fwd, nbytes, max_signal_bytes, timeout, args...);
   }
 
  private:
@@ -925,8 +898,7 @@ class P2pIbrcTransportDevice {
   IbgdaLocalBuffer ownedCounterHostBuf_{};
   int numSignalSlots_{0};
   int numCounterSlots_{0};
-  IbSendRecvState sendRecvState_{};
-  IbSendRecvDevice sendRecv_{};
+  IbChannelLayout channelLayout_{};
 };
 
 static_assert(std::is_standard_layout_v<P2pIbrcTransportDevice>);


### PR DESCRIPTION
Summary:

Post-channel cleanup for IB sendrecv state.

The previous IB cleanup diffs removed the legacy config knobs and moved sendrecv ownership into backend devices. This change finishes that direction by deleting the standalone `IbSendRecvState` / `IbSendRecvDevice` object model and storing sendrecv protocol progress in the IB channel objects instead.

Concretely, this introduces channel-owned progress/layout state, wires IBGDA and IBRC blocking/nonblocking sendrecv through the channel state, and updates benchmarks/tests to construct transports from the channel configuration rather than a separate sendrecv state. Public send/recv call sites continue to use the existing transport APIs; the state ownership is now aligned with the NVL channel model.

Perf note: GB300 Direct-IB reduce-scatter A/B on a 4-rank single-node run showed the current source-built cleanup is not slower than source-built immediate ancestors (`43700b03` and `06a21938` are also around 39.6 GB/s OOP busbw at 2GB). A stale pre-cleanup artifact can still reach around 89.8 GB/s OOP busbw on the same host and remains useful as an environment sanity signal, but the slowdown is already present in source-built ancestors and is not introduced by this diff.

Reviewed By: saifhhasan

Differential Revision: D111848041


