### PR TITLE
Thread memory kind when exporting memory (#3129)

### DIFF
--- a/comms/uniflow/transport/rdma/RdmaRegistrationHandle.cpp
+++ b/comms/uniflow/transport/rdma/RdmaRegistrationHandle.cpp
@@ -54,6 +54,7 @@ std::vector<uint8_t> RdmaRegistrationHandle::serialize() const {
       .domainId = domainId_,
       .registrationBase = registrationBase_,
       .numMrs = static_cast<uint8_t>(mrs_.size()),
+      .isDeviceMemory = static_cast<uint8_t>(deviceId_ >= 0 ? 1 : 0),
   };
   std::memcpy(buf.data(), &header, sizeof(header));
 
@@ -81,26 +82,26 @@ RdmaRemoteRegistrationHandle::RdmaRemoteRegistrationHandle(
     std::vector<uint32_t> rkeys,
     uint64_t domainId,
     uint64_t registrationBase,
+    bool isDeviceMemory,
     std::shared_ptr<DeviceAdapter> deviceAdapter)
     : rkeys_(std::move(rkeys)),
       domainId_(domainId),
       registrationBase_(registrationBase),
+      isDeviceMemory_(isDeviceMemory),
       deviceAdapter_(std::move(deviceAdapter)) {
-  // toWireAddr() dereferences deviceAdapter_ whenever registrationBase_ != 0,
-  // so a translated handle must be given a non-null adapter. Enforced in
-  // release builds too: a null adapter here is a programming error, not a
-  // runtime input.
+  // toWireAddr() dereferences deviceAdapter_ whenever the target is device
+  // memory, so a device-backed handle must be given a non-null adapter.
+  // Enforced in release builds too: a null adapter here is a programming error,
+  // not a runtime input.
   CHECK_THROW_EXCEPTION(
-      registrationBase_ == 0 || deviceAdapter_ != nullptr,
-      std::invalid_argument);
+      !isDeviceMemory_ || deviceAdapter_ != nullptr, std::invalid_argument);
 }
 
 uint64_t RdmaRemoteRegistrationHandle::toWireAddr(const void* ptr) const {
-  /// Remote handles don't carry information on whether the target is a device
-  /// ptr or not So we use the fact that only targets that have a non-zero
-  /// registrationBase require pointer translation
-  auto devAddr = registrationBase_ ? deviceAdapter_->resolveDevicePointer(ptr)
-                                   : reinterpret_cast<uint64_t>(ptr);
+  // Remote handles carry an explicit isDeviceMemory flag from the exporting
+  // peer; only device targets need pointer translation via the adapter.
+  auto devAddr = isDeviceMemory_ ? deviceAdapter_->resolveDevicePointer(ptr)
+                                 : reinterpret_cast<uint64_t>(ptr);
   return devAddr - registrationBase_;
 }
 

--- a/comms/uniflow/transport/rdma/RdmaRegistrationHandle.h
+++ b/comms/uniflow/transport/rdma/RdmaRegistrationHandle.h
@@ -33,6 +33,7 @@ class RdmaRegistrationHandle : public RegistrationHandle {
     uint64_t domainId{0}; // Factory instance key
     uint64_t registrationBase{0}; // VA → wire-address offset
     uint8_t numMrs{0}; // Number of MRs (one per NIC)
+    uint8_t isDeviceMemory{0}; // 1 if the region is device (VRAM) memory
     // Followed by numMrs uint32_t rkeys.
   };
 
@@ -124,6 +125,7 @@ class RdmaRemoteRegistrationHandle : public RemoteRegistrationHandle {
       std::vector<uint32_t> rkeys,
       uint64_t domainId,
       uint64_t registrationBase = 0,
+      bool isDeviceMemory = false,
       std::shared_ptr<DeviceAdapter> deviceAdapter = nullptr);
 
   ~RdmaRemoteRegistrationHandle() override = default;
@@ -154,14 +156,23 @@ class RdmaRemoteRegistrationHandle : public RemoteRegistrationHandle {
     return registrationBase_;
   }
 
-  /// Translate a client-supplied pointer to the wire address the NIC
-  /// expects in an SGE (`sge.addr`). Folds two platform-specific steps.
+  /// Whether the remote region is device (VRAM) memory, as advertised by the
+  /// exporting peer. Gates device-pointer resolution in toWireAddr().
+  bool isDeviceMemory() const noexcept {
+    return isDeviceMemory_;
+  }
+
+  /// Translate a remote pointer to the wire address the NIC expects in
+  /// `wr.rdma.remote_addr`. When the remote region is device memory, the
+  /// pointer is resolved to a bare device address via the adapter; base is
+  /// then subtracted.
   uint64_t toWireAddr(const void* ptr) const;
 
  private:
   std::vector<uint32_t> rkeys_;
   uint64_t domainId_;
   uint64_t registrationBase_{0};
+  bool isDeviceMemory_{false};
   std::shared_ptr<DeviceAdapter> deviceAdapter_;
 };
 

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -1843,13 +1843,15 @@ RdmaTransportFactory::RdmaTransportFactory(
     std::shared_ptr<IbvApi> ibvApi,
     std::shared_ptr<CudaDriverApi> cudaDriverApi,
     std::shared_ptr<CudaApi> cudaApi,
-    std::optional<uint8_t> portNum)
+    std::optional<uint8_t> portNum,
+    std::shared_ptr<DeviceAdapter> deviceAdapter)
     : TransportFactory(TransportType::RDMA),
       ibvApi_(std::move(ibvApi)),
       cudaDriverApi_(std::move(cudaDriverApi)),
       cudaApi_(std::move(cudaApi)),
       evb_(evb),
       nicsHandle_(std::make_shared<std::vector<NicResources>>()),
+      deviceAdapter_(std::move(deviceAdapter)),
       config_(config) {
   assert(evb_ != nullptr);
   if (deviceNames.empty()) {
@@ -1865,7 +1867,9 @@ RdmaTransportFactory::RdmaTransportFactory(
     cudaApi_ = std::make_shared<CudaApi>();
   }
 
-  deviceAdapter_ = createDeviceAdapter(cudaApi_, cudaDriverApi_);
+  if (!deviceAdapter_) {
+    deviceAdapter_ = createDeviceAdapter(cudaApi_, cudaDriverApi_);
+  }
 
   // Generate a random domain id to identify handles from this factory.
   std::mt19937_64 rng{std::random_device{}()};
@@ -2154,7 +2158,11 @@ RdmaTransportFactory::importSegment(
 
   uint64_t domainId = header.domainId;
   return std::make_unique<RdmaRemoteRegistrationHandle>(
-      std::move(rkeys), domainId, header.registrationBase, deviceAdapter_);
+      std::move(rkeys),
+      domainId,
+      header.registrationBase,
+      header.isDeviceMemory != 0,
+      deviceAdapter_);
 }
 
 Result<std::unique_ptr<Transport>> RdmaTransportFactory::createTransport(

--- a/comms/uniflow/transport/rdma/RdmaTransport.h
+++ b/comms/uniflow/transport/rdma/RdmaTransport.h
@@ -22,7 +22,7 @@
 
 namespace uniflow {
 
-constexpr uint8_t kRdmaVersion{2};
+constexpr uint8_t kRdmaVersion{3};
 
 // Forward declarations.
 class RdmaRegistrationHandle;
@@ -646,7 +646,8 @@ class RdmaTransportFactory : public TransportFactory {
       std::shared_ptr<IbvApi> ibvApi = nullptr,
       std::shared_ptr<CudaDriverApi> cudaDriverApi = nullptr,
       std::shared_ptr<CudaApi> cudaApi = nullptr,
-      std::optional<uint8_t> portNum = std::nullopt);
+      std::optional<uint8_t> portNum = std::nullopt,
+      std::shared_ptr<DeviceAdapter> deviceAdapter = nullptr);
 
   ~RdmaTransportFactory() override = default;
 

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaRegistrationHandleTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaRegistrationHandleTest.cpp
@@ -94,6 +94,7 @@ TEST_F(RdmaRegistrationHandleTest, SerializeSingleMr) {
   std::memcpy(&header, serialized.data(), sizeof(header));
   EXPECT_EQ(header.domainId, 42u);
   EXPECT_EQ(header.numMrs, 1u);
+  EXPECT_EQ(header.isDeviceMemory, 0u);
 
   uint32_t rkey;
   std::memcpy(
@@ -203,12 +204,16 @@ TEST_F(RdmaRegistrationHandleTest, SerializeDeserializeRoundTrip) {
 
   // addr and length are provided by the caller, not from the wire.
   RdmaRemoteRegistrationHandle remote(
-      std::move(rkeys), header.domainId, header.registrationBase);
+      std::move(rkeys),
+      header.domainId,
+      header.registrationBase,
+      header.isDeviceMemory != 0);
 
   EXPECT_EQ(remote.numMrs(), handle.numMrs());
   EXPECT_EQ(remote.rkey(0), handle.rkey(0));
   EXPECT_EQ(remote.rkey(1), handle.rkey(1));
   EXPECT_EQ(remote.registrationBase(), handle.registrationBase());
+  EXPECT_FALSE(remote.isDeviceMemory());
 }
 
 TEST_F(RdmaRegistrationHandleTest, RegistrationBaseDefaultsToZero) {
@@ -308,25 +313,54 @@ TEST_F(
   EXPECT_EQ(handle.toWireAddr(buf), kDevAddr - kBase);
 }
 
-// Remote handle with zero base: wire address is the raw pointer (no adapter
-// dereference, so a null adapter is fine).
+// Remote host handle with zero base: wire address is the raw pointer.
 TEST(RdmaRemoteRegistrationHandleTest, ToWireAddrZeroBaseReturnsRawAddr) {
   char buf[16]{};
   RdmaRemoteRegistrationHandle handle({0x1}, 42);
   EXPECT_EQ(handle.toWireAddr(buf), reinterpret_cast<uint64_t>(buf));
 }
 
-// Remote handle with a non-zero base: the adapter resolves the address, then
-// base is subtracted.
+// Remote host handle (isDeviceMemory=false) with a non-zero base: no adapter
+// resolution, base is simply subtracted.
+TEST(RdmaRemoteRegistrationHandleTest, ToWireAddrHostNonZeroBaseSubtractsBase) {
+  char buf[16]{};
+  constexpr uint64_t kBase = 0x1000;
+  RdmaRemoteRegistrationHandle handle(
+      {0x1}, 42, kBase, /*isDeviceMemory=*/false);
+  EXPECT_EQ(handle.toWireAddr(buf), reinterpret_cast<uint64_t>(buf) - kBase);
+}
+
+// Remote device handle (isDeviceMemory=true): the adapter resolves the address,
+// then base is subtracted. The input pointer is opaque to the adapter.
 TEST(
     RdmaRemoteRegistrationHandleTest,
-    ToWireAddrNonZeroBaseResolvesThenSubtractsBase) {
+    ToWireAddrDeviceMemoryResolvesThenSubtractsBase) {
   char buf[16]{};
   constexpr uint64_t kDevAddr = 0x7f0000005000ULL;
   constexpr uint64_t kBase = 0x7f0000000000ULL;
   auto adapter = std::make_shared<FakeDeviceAdapter>(kDevAddr);
-  RdmaRemoteRegistrationHandle handle({0x1}, 42, kBase, adapter);
+  RdmaRemoteRegistrationHandle handle(
+      {0x1}, 42, kBase, /*isDeviceMemory=*/true, adapter);
   EXPECT_EQ(handle.toWireAddr(buf), kDevAddr - kBase);
+}
+
+// A device-backed local handle (deviceId >= 0) serializes isDeviceMemory=1.
+TEST_F(RdmaRegistrationHandleTest, SerializeDeviceHandleSetsDeviceMemoryFlag) {
+  ibv_mr mr{};
+  mr.rkey = 0x99;
+  auto adapter = std::make_shared<FakeDeviceAdapter>(0x1234);
+  RdmaRegistrationHandle handle(
+      {&mr},
+      ibv_,
+      42,
+      /*registrationBase=*/0,
+      adapter,
+      /*deviceId=*/0);
+
+  auto serialized = handle.serialize();
+  RdmaRegistrationHandle::Header header;
+  std::memcpy(&header, serialized.data(), sizeof(header));
+  EXPECT_EQ(header.isDeviceMemory, 1u);
 }
 
 // --- Factory registerSegment/importSegment tests ---
@@ -379,7 +413,16 @@ class RdmaFactoryRegistrationTest : public ::testing::Test {
         &evb_,
         RdmaTransportConfig{},
         ibv_,
-        cudaDriver_);
+        cudaDriver_,
+        /*cudaApi=*/nullptr,
+        /*portNum=*/std::nullopt,
+        makeDeviceAdapter());
+  }
+
+  // Overridable so a derived fixture can inject a fake DeviceAdapter. Returning
+  // nullptr keeps the factory's default (real) adapter.
+  virtual std::shared_ptr<DeviceAdapter> makeDeviceAdapter() {
+    return nullptr;
   }
 
   std::shared_ptr<NiceMock<MockIbvApi>> ibv_;
@@ -509,6 +552,7 @@ TEST_F(RdmaFactoryRegistrationTest, ImportSegmentSucceeds) {
       dynamic_cast<RdmaRemoteRegistrationHandle*>(result.value().get());
   ASSERT_NE(remote, nullptr);
   EXPECT_EQ(remote->rkey(0), 0xAAAAu);
+  EXPECT_FALSE(remote->isDeviceMemory());
 }
 
 TEST_F(RdmaFactoryRegistrationTest, ImportSegmentRejectsTooSmallPayload) {
@@ -573,6 +617,44 @@ TEST_F(RdmaFactoryRegistrationTest, RegisterAndImportRoundTrip) {
   ASSERT_NE(local, nullptr);
   EXPECT_EQ(remote->rkey(0), local->rkey(0));
   EXPECT_EQ(remote->domainId(), local->domainId());
+}
+
+// Injects a FakeDeviceAdapter into the factory so a device-memory import drives
+// the full deserialize → toWireAddr device-resolution path with a controllable
+// adapter. This is exactly the path that regressed on MTIA.
+class RdmaFactoryDeviceAdapterTest : public RdmaFactoryRegistrationTest {
+ protected:
+  static constexpr uint64_t kResolvedDevAddr = 0x7f0000009000ULL;
+
+  std::shared_ptr<DeviceAdapter> makeDeviceAdapter() override {
+    return std::make_shared<FakeDeviceAdapter>(kResolvedDevAddr);
+  }
+};
+
+TEST_F(RdmaFactoryDeviceAdapterTest, ImportDeviceMemoryResolvesViaAdapter) {
+  constexpr uint64_t kBase = 0x7f0000000000ULL;
+  RdmaRegistrationHandle::Header header{
+      .domainId = 99,
+      .registrationBase = kBase,
+      .numMrs = 1,
+      .isDeviceMemory = 1,
+  };
+  uint32_t rkey = 0xAAAA;
+  std::vector<uint8_t> data(sizeof(header) + sizeof(rkey));
+  std::memcpy(data.data(), &header, sizeof(header));
+  std::memcpy(data.data() + sizeof(header), &rkey, sizeof(rkey));
+
+  char fakeBuf[8192]{};
+  auto result = factory_->importSegment(sizeof(fakeBuf), data);
+  ASSERT_TRUE(result.hasValue());
+
+  auto* remote =
+      dynamic_cast<RdmaRemoteRegistrationHandle*>(result.value().get());
+  ASSERT_NE(remote, nullptr);
+  EXPECT_TRUE(remote->isDeviceMemory());
+
+  char somePtr[16]{};
+  EXPECT_EQ(remote->toWireAddr(somePtr), kResolvedDevAddr - kBase);
 }
 
 // --- Multi-NIC partial failure tests ---


### PR DESCRIPTION
Summary:

MTIA accelerators encode device pointers as an UID that must be resolved to an actual device pointer prior to passing it to ibverbs.

The current solution relies on RdmaRemoteRegistrationHandle::registrationBase_ to know whether the pointer is from a device and needs to be resolved.

This is fragile and can potentially break in the future if any of the implicit conditions change.

To address that problem, we explicitly encode the kind of pointer in RdmaRegistrationHandle::Header, this allows RdmaRemoteRegistrationHandle to make a principled decision when decoding the pointer.


A side note on alternative approaches.

We explored resolving the device pointer at registration time and export the resolved address.
This breaks `Segment::span(void *, size_t)` which allows the user to slice the remote registration usign a device pointer.

Why it breaks?
The RegisteredSegment would have a raw device pointer and if the user passes a tagged pointer, they will diff by a lot (tags are on high bits) and trigger some constency checks.

We can't fix that because Segment is part of the public API and there's no path to allow it to reason about those special kind of device pointers.

Differential Revision: D108929174


