### PR TITLE
Keep tiles in registers on the unaligned tile_load/tile_store path

### DIFF
--- a/comms/prims/core/Tile.cuh
+++ b/comms/prims/core/Tile.cuh
@@ -319,33 +319,31 @@ tile_load(
   TileType tile;
   const bool aligned = reinterpret_cast<uintptr_t>(ptr) % alignof(uint4) == 0;
   const std::size_t full_vecs = valid_elems / kEPV;
-  const int remainder = static_cast<int>(valid_elems % kEPV);
   const T* elem_base = ptr + tile_idx * kTileElems;
 
 #pragma unroll
   for (int k = 0; k < kVPT; k++) {
-    std::size_t idx = group.thread_id_in_group + k * group.group_size;
+    const std::size_t idx = group.thread_id_in_group + k * group.group_size;
+    const std::size_t elem_offset = idx * kEPV;
     if (aligned && idx < full_vecs) {
-      const uint4* src = reinterpret_cast<const uint4*>(elem_base);
-      tile.vecs[k] = src[idx];
-    } else if (!aligned && idx <= full_vecs) {
-      tile.vecs[k] = make_uint4(0, 0, 0, 0);
-      const T* elem_src = elem_base + idx * kEPV;
-      T* elem_dst = reinterpret_cast<T*>(&tile.vecs[k]);
-      const std::size_t elem_offset = idx * kEPV;
-      const int elems_this = elem_offset + kEPV <= valid_elems
-          ? kEPV
-          : static_cast<int>(valid_elems - elem_offset);
-      for (int e = 0; e < elems_this; e++) {
-        elem_dst[e] = elem_src[e];
+      // Fast path: fully-valid vector from an aligned base — 16-byte load.
+      tile.vecs[k] = reinterpret_cast<const uint4*>(elem_base)[idx];
+    } else if (elem_offset < valid_elems) {
+      // Boundary or unaligned vector: gather valid elements into a
+      // register-resident temporary, then assign the whole vector. kEPV is a
+      // compile-time constant so this loop fully unrolls and never indexes
+      // tile.vecs[] with a runtime value — keeping the tile in registers rather
+      // than spilling it to local memory.
+      uint4 tmp = make_uint4(0, 0, 0, 0);
+      T* tmp_elems = reinterpret_cast<T*>(&tmp);
+      const T* elem_src = elem_base + elem_offset;
+#pragma unroll
+      for (int e = 0; e < kEPV; e++) {
+        if (elem_offset + e < valid_elems) {
+          tmp_elems[e] = elem_src[e];
+        }
       }
-    } else if (idx == full_vecs && remainder > 0) {
-      tile.vecs[k] = make_uint4(0, 0, 0, 0);
-      const T* elem_src = elem_base + idx * kEPV;
-      T* elem_dst = reinterpret_cast<T*>(&tile.vecs[k]);
-      for (int e = 0; e < remainder; e++) {
-        elem_dst[e] = elem_src[e];
-      }
+      tile.vecs[k] = tmp;
     } else {
       tile.vecs[k] = make_uint4(0, 0, 0, 0);
     }
@@ -386,30 +384,27 @@ __device__ __forceinline__ void tile_store(
 
   const bool aligned = reinterpret_cast<uintptr_t>(ptr) % alignof(uint4) == 0;
   const std::size_t full_vecs = valid_elems / kEPV;
-  const int remainder = static_cast<int>(valid_elems % kEPV);
   T* elem_base = ptr + tile_idx * kTileElems;
 
 #pragma unroll
   for (int k = 0; k < kVPT; k++) {
-    std::size_t idx = group.thread_id_in_group + k * group.group_size;
+    const std::size_t idx = group.thread_id_in_group + k * group.group_size;
+    const std::size_t elem_offset = idx * kEPV;
     if (aligned && idx < full_vecs) {
-      uint4* dst = reinterpret_cast<uint4*>(elem_base);
-      dst[idx] = tile.vecs[k];
-    } else if (!aligned && idx <= full_vecs) {
-      const T* elem_src = reinterpret_cast<const T*>(&tile.vecs[k]);
-      T* elem_dst = elem_base + idx * kEPV;
-      const std::size_t elem_offset = idx * kEPV;
-      const int elems_this = elem_offset + kEPV <= valid_elems
-          ? kEPV
-          : static_cast<int>(valid_elems - elem_offset);
-      for (int e = 0; e < elems_this; e++) {
-        elem_dst[e] = elem_src[e];
-      }
-    } else if (idx == full_vecs && remainder > 0) {
-      const T* elem_src = reinterpret_cast<const T*>(&tile.vecs[k]);
-      T* elem_dst = elem_base + idx * kEPV;
-      for (int e = 0; e < remainder; e++) {
-        elem_dst[e] = elem_src[e];
+      // Fast path: fully-valid vector to an aligned base — 16-byte store.
+      reinterpret_cast<uint4*>(elem_base)[idx] = tile.vecs[k];
+    } else if (elem_offset < valid_elems) {
+      // Boundary or unaligned vector: scatter valid elements from a
+      // register-resident copy. The fully-unrolled compile-time loop keeps the
+      // tile in registers (no runtime-indexed reads of tile.vecs[]).
+      uint4 tmp = tile.vecs[k];
+      const T* tmp_elems = reinterpret_cast<const T*>(&tmp);
+      T* elem_dst = elem_base + elem_offset;
+#pragma unroll
+      for (int e = 0; e < kEPV; e++) {
+        if (elem_offset + e < valid_elems) {
+          elem_dst[e] = tmp_elems[e];
+        }
       }
     }
   }


### PR DESCRIPTION
Summary:
D111403483 added an unaligned base-pointer fallback to `tile_load`/`tile_store` in `comms/prims/core/Tile.cuh`. That fallback gathers/scatters scalar elements through `reinterpret_cast<T*>(&tile.vecs[k])` inside a runtime-bounded loop, on a path reachable for every vector `k` (not just the single boundary vector, as the pre-existing remainder branch was). A runtime-indexed store through a pointer aliased into the register-resident `tile.vecs[]` array forces `ptxas` to place the whole tile array in local memory.

This regressed `ctdirect_ib` (`direct_reduce_scatter_ib_kernel`, instantiated as `TileReduceStaged<float, SumOp, 24576, 384>` in `CopyOp.cuh`). That kernel keeps two full register tiles live (`acc` + `local`, `kVPT=16` uint4 each) and is compiled with `__launch_bounds__(512, 1)` (128-register cap), so once the tiles land in local memory every element round-trips through slow local memory and bandwidth drops.

Fix: on the boundary/unaligned path, gather (load) or scatter (store) through a register-resident local `uint4 tmp` using a `#pragma unroll` loop over the compile-time constant `kEPV`, masked by `elem_offset + e < valid_elems`. Because `tile.vecs[]` is never indexed with a runtime value anymore, the tile stays in registers. The aligned fast path is unchanged (16-byte vectorized load/store), and unaligned support is fully preserved.

Measured with a standalone repro of the exact `TileReduceStaged<float, SumOp, 24576, 384>` kernel (no `__launch_bounds__` cap, so natural demand is visible), `ptxas -v` for sm_90:

    aligned-only (pre-D111403483): 164 regs, 0 B local memory
    landed unaligned fallback:     128 regs, 512 B local memory (both tiles spilled)
    this fix:                      144 regs, 0 B local memory

512 B is exactly the two live tiles (2 x 16 x 16 B).

Differential Revision: D111933974


