### PR TITLE
CopyOp: normalize send/recv API + add fixed-size policy members (#3139)

### DIFF
--- a/comms/prims/core/CopyOp.cuh
+++ b/comms/prims/core/CopyOp.cuh
@@ -13,8 +13,15 @@ namespace comms::prims {
 
 template <typename T, typename AccumOp, int kTileElems, int kBlockSize>
 struct TileReduce {
+  // Fixed-size CopyOp policy (see AnsCompress for the variable-size one).
+  static constexpr bool kVariableSize = false;
+  static constexpr std::size_t kActivationThreshold = 0;
+  __host__ __device__ __forceinline__ static constexpr std::size_t
+  worst_case_chunk_stride(std::size_t chunkSize) {
+    return chunkSize;
+  }
   template <typename... Args>
-  __device__ __forceinline__ static void send(
+  __device__ __forceinline__ static std::size_t send(
       char* staging,
       const char* src,
       std::size_t nbytes,
@@ -22,10 +29,11 @@ struct TileReduce {
       std::size_t /*byte_offset*/,
       Args...) {
     memcpy_vectorized(staging, src, nbytes, group);
+    return nbytes;
   }
 
   template <typename... Args>
-  __device__ __forceinline__ static void recv(
+  __device__ __forceinline__ static std::size_t recv(
       char* dst,
       const char* staging,
       std::size_t nbytes,
@@ -51,6 +59,7 @@ struct TileReduce {
       tile_store<T, kTileElems, kBlockSize>(dst_t, t, acc, group, valid);
     }
 #endif
+    return nbytes;
   }
 
   template <typename... Args>
@@ -91,8 +100,15 @@ struct TileReduceStaged {
     return 0;
   }
 
+  // Fixed-size CopyOp policy (see AnsCompress for the variable-size one).
+  static constexpr bool kVariableSize = false;
+  static constexpr std::size_t kActivationThreshold = 0;
+  __host__ __device__ __forceinline__ static constexpr std::size_t
+  worst_case_chunk_stride(std::size_t chunkSize) {
+    return chunkSize;
+  }
   template <typename... Args>
-  __device__ __forceinline__ static void send(
+  __device__ __forceinline__ static std::size_t send(
       char* staging,
       const char* src,
       std::size_t nbytes,
@@ -100,10 +116,11 @@ struct TileReduceStaged {
       std::size_t /*byte_offset*/,
       Args...) {
     memcpy_vectorized(staging, src, nbytes, group);
+    return nbytes;
   }
 
   template <typename... Args>
-  __device__ __forceinline__ static void recv(
+  __device__ __forceinline__ static std::size_t recv(
       char* dst,
       const char* staging,
       std::size_t nbytes,
@@ -130,6 +147,7 @@ struct TileReduceStaged {
       tile_store<T, kTileElems, kBlockSize>(dst_t, t, acc, group, valid);
     }
 #endif
+    return nbytes;
   }
 
   template <typename... Args>

--- a/comms/prims/core/MemcpyCopyOp.cuh
+++ b/comms/prims/core/MemcpyCopyOp.cuh
@@ -10,8 +10,18 @@
 namespace comms::prims {
 
 struct Memcpy {
+  // Fixed-size CopyOp policy: the transport reserves exactly `chunkSize`
+  // per sub-chunk and emits exactly `nbytes`. See AnsCompress (CopyOp.cuh)
+  // for the variable-size counterpart that overrides these.
+  static constexpr bool kVariableSize = false;
+  static constexpr std::size_t kActivationThreshold = 0;
+  __host__ __device__ __forceinline__ static constexpr std::size_t
+  worst_case_chunk_stride(std::size_t chunkSize) {
+    return chunkSize;
+  }
+
   template <typename... Args>
-  __device__ __forceinline__ static void send(
+  __device__ __forceinline__ static std::size_t send(
       char* staging,
       const char* src,
       std::size_t nbytes,
@@ -19,10 +29,11 @@ struct Memcpy {
       std::size_t /*byte_offset*/,
       Args...) {
     memcpy_vectorized(staging, src, nbytes, group);
+    return nbytes;
   }
 
   template <typename... Args>
-  __device__ __forceinline__ static void recv(
+  __device__ __forceinline__ static std::size_t recv(
       char* dst,
       const char* staging,
       std::size_t nbytes,
@@ -30,6 +41,7 @@ struct Memcpy {
       std::size_t /*byte_offset*/,
       Args...) {
     memcpy_vectorized(dst, staging, nbytes, group);
+    return nbytes;
   }
 
   template <typename... Args>

--- a/comms/prims/tests/CopyOpContractTest.cc
+++ b/comms/prims/tests/CopyOpContractTest.cc
@@ -1,0 +1,16 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+namespace comms::prims {
+
+// The CopyOp fixed-size wire-bytes contract is enforced entirely at compile
+// time by the static_asserts in CopyOpContractTest.cu (compiled via the
+// :copy_op_contract_test_kernels dependency). Building this target IS the
+// check: a policy whose send()/recv() does not return std::size_t fails to
+// compile. This runtime body only makes the guard a discoverable test target.
+TEST(CopyOpContractTest, FixedSizePoliciesReturnWireBytes) {
+  SUCCEED();
+}
+
+} // namespace comms::prims

--- a/comms/prims/tests/CopyOpContractTest.cu
+++ b/comms/prims/tests/CopyOpContractTest.cu
@@ -1,0 +1,60 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+#include "comms/prims/core/CopyOp.cuh"
+#include "comms/prims/core/MemcpyCopyOp.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+
+namespace comms::prims {
+namespace {
+
+// Representative fixed-size policy instantiations, mirroring the concrete
+// template arguments used at the production reduce-scatter call sites in
+// collectives/*.cu.
+using TileReducePolicy = TileReduce<float, SumOp, 16384, 512>;
+using TileReduceStagedPolicy = TileReduceStaged<float, SumOp, 24576, 384>;
+
+// Return type of a policy's send()/recv() when invoked with the fixed-size
+// argument list every CopyOp policy accepts. Evaluated in an unevaluated
+// decltype context, so no device call is emitted.
+template <typename Policy>
+using send_result_t = decltype(Policy::send(
+    std::declval<char*>(),
+    std::declval<const char*>(),
+    std::declval<std::size_t>(),
+    std::declval<ThreadGroup&>(),
+    std::declval<std::size_t>()));
+
+template <typename Policy>
+using recv_result_t = decltype(Policy::recv(
+    std::declval<char*>(),
+    std::declval<const char*>(),
+    std::declval<std::size_t>(),
+    std::declval<ThreadGroup&>(),
+    std::declval<std::size_t>(),
+    std::declval<const char*>()));
+
+// The wire-bytes contract: a fixed-size CopyOp policy reports the number of
+// bytes it produced by returning std::size_t from send()/recv(). Every call
+// site discards this value, so without this compile-time guard a policy that
+// silently kept a void send()/recv() would still compile clean.
+template <typename Policy>
+constexpr bool has_fixed_size_wire_contract_v = !Policy::kVariableSize &&
+    std::is_same_v<send_result_t<Policy>, std::size_t> &&
+    std::is_same_v<recv_result_t<Policy>, std::size_t>;
+
+static_assert(
+    has_fixed_size_wire_contract_v<Memcpy>,
+    "Memcpy: fixed-size CopyOp send()/recv() must return std::size_t (wire bytes)");
+static_assert(
+    has_fixed_size_wire_contract_v<TileReducePolicy>,
+    "TileReduce: fixed-size CopyOp send()/recv() must return std::size_t (wire bytes)");
+static_assert(
+    has_fixed_size_wire_contract_v<TileReduceStagedPolicy>,
+    "TileReduceStaged: fixed-size CopyOp send()/recv() must return std::size_t (wire bytes)");
+
+} // namespace
+} // namespace comms::prims


### PR DESCRIPTION
Summary:

Second diff of the 5-way decomposition of D108485978. This is a **mechanical API/interface normalization** of the `CopyOp` policy contract, with no new feature and no runtime behavior change. It is kept separate from the `AnsCompress` implementation so the interface change (which touches every existing policy) is reviewed independently of the new compression code.

Two changes, applied uniformly to every existing fixed-size `CopyOp` policy (`Memcpy` in `core/MemcpyCopyOp.cuh`; `TileReduce` and `TileReduceStaged` in `core/CopyOp.cuh`):

1. `send()` and `recv()` now return `std::size_t` (the number of wire bytes produced) instead of `void`. For every fixed-size policy the returned value is exactly `nbytes` — i.e. byte-identical behavior. This return value is what a variable-size policy (`AnsCompress`, added next) uses to tell the transport the data-dependent compressed size; normalizing the signature here lets the transport call `Policy::send(...)` uniformly regardless of policy.

2. New compile-time policy members that let the transport query any policy uniformly:
   - `static constexpr bool kVariableSize = false;`
   - `static constexpr std::size_t kActivationThreshold = 0;`
   - `static constexpr std::size_t worst_case_chunk_stride(std::size_t chunkSize)` returning `chunkSize`.
   For fixed-size policies these encode the existing contract (the transport reserves exactly `chunkSize` per sub-chunk and emits exactly `nbytes`).

Invariants:
- Before: `CopyOp::send/recv` return `void`; the transport assumes every policy is fixed-size and reserves `chunkSize` per sub-chunk.
- After: identical runtime behavior for all existing policies. The return value equals `nbytes` and `worst_case_chunk_stride(chunkSize) == chunkSize`, so any transport that ignores the return and reserves `chunkSize` (i.e. the transport as it exists before the variable-size diff) is unaffected. Existing call sites that invoke `send/recv` as a statement compile unchanged (the returned `size_t` is discarded).
- The `kVariableSize == false` members are the fixed-size half of the contract that the variable-size transport diff keys off via a `copyop_variable_size_v` trait; a policy that omits these is still treated as fixed-size, so this diff is backward compatible with any out-of-tree policy.

Reviewed By: dboyda

Differential Revision: D111967120


