### PR TITLE
[ci failures] Fix the inductor lowering changes related failures

### DIFF
--- a/comms/torchcomms/functional/inductor_lowering.py
+++ b/comms/torchcomms/functional/inductor_lowering.py
@@ -9,6 +9,28 @@ import torch
 
 logger = logging.getLogger(__name__)
 
+
+def _unpack_process_kernel(result):
+    """Normalize ``ExternKernel.process_kernel`` output to the legacy 5-tuple
+
+    PyTorch (pytorch/pytorch#189258, ~2026-07) changed ``process_kernel`` to
+    return a frozen ``ProcessKernelResult`` dataclass instead of the positional
+    5-tuple ``(example_output, tensor_args, non_tensor_args, unflatten_args,
+    unbacked_bindings)``. The dataclass exposes the same values under the same
+    names and in the same order. Accept both so we work across PyTorch
+    versions.
+    """
+    if isinstance(result, tuple):
+        return result
+    return (
+        result.example_output,
+        result.tensor_args,
+        result.non_tensor_args,
+        result.unflatten_args,
+        result.unbacked_bindings,
+    )
+
+
 try:  # noqa: C901
     from torch._inductor import ir
     from torch._inductor.lowering import register_lowering
@@ -138,7 +160,9 @@ try:  # noqa: C901
                     non_tensor_args,
                     unflatten_args,
                     unbacked_bindings,
-                ) = ir._CollectiveKernel.process_kernel(inplace_op.default, *args)
+                ) = _unpack_process_kernel(
+                    ir._CollectiveKernel.process_kernel(inplace_op.default, *args)
+                )
             assert not unbacked_bindings, f"{inplace_op} {unbacked_bindings}"
 
             # Create the collective kernel
@@ -325,9 +349,11 @@ try:  # noqa: C901
                     non_tensor_args,
                     unflatten_args,
                     unbacked_bindings,
-                ) = ir._WaitKernel.process_kernel(
-                    torch.ops.torchcomms.torchcomm_wait_tensors_.default,
-                    flat_inputs,
+                ) = _unpack_process_kernel(
+                    ir._WaitKernel.process_kernel(
+                        torch.ops.torchcomms.torchcomm_wait_tensors_.default,
+                        flat_inputs,
+                    )
                 )
             assert not unbacked_bindings
 

--- a/comms/torchcomms/functional/registry.py
+++ b/comms/torchcomms/functional/registry.py
@@ -728,6 +728,7 @@ def _register_lowerings() -> None:  # noqa: C901
     try:
         from torch._inductor import ir
         from torch._inductor.lowering import register_lowering
+        from torchcomms.functional.inductor_lowering import _unpack_process_kernel
     except ImportError:
         logger.info("torch._inductor not available, skipping lowering registration")
         return
@@ -785,8 +786,10 @@ def _register_lowerings() -> None:  # noqa: C901
                             non_tensor_args,
                             unflatten_args,
                             unbacked_bindings,
-                        ) = ir._CollectiveKernel.process_kernel(
-                            captured_torch_op.default, *args
+                        ) = _unpack_process_kernel(
+                            ir._CollectiveKernel.process_kernel(
+                                captured_torch_op.default, *args
+                            )
                         )
                     assert not unbacked_bindings
 


### PR DESCRIPTION
## Summary
PyTorch's Inductor changed `ExternKernel.process_kernel` (inherited by `_CollectiveKernel` and `_WaitKernel`) to return a frozen `ProcessKernelResult` dataclass instead of the positional 5-tuple it used to return (pytorch/pytorch#189258, landed ~2026-07-11). torchcomms' Inductor lowerings unpack that return value as a tuple in three places, so on recent nightlies every compiled collective / wait op fails to lower with:
```
torch._inductor.exc.InductorError: LoweringException:
TypeError: cannot unpack non-iterable ProcessKernelResult object
```
This is what broke the `run_py_tests (… cuda 13.0 nightly …)` CI jobs — 9 tests in `FullgraphCompileAutogradTest` (`test_all_reduce_backward_compiled`, `test_all_gather_backward_compiled`, `test_reduce_scatter_backward_compiled`, `test_wait_tensors_grad_chain_compiled`, `test_retain_graph_compiled`, …). It is drift from PyTorch nightly, not a regression in torchcomms.
## Root cause
`process_kernel` previously returned:
```python
(example_output, tensor_args, non_tensor_args, unflatten_args, unbacked_bindings)
```
It now returns a frozen dataclass with the **same fields, same order**, but which is no longer iterable:
```python
ProcessKernelResult(example_output, tensor_args, non_tensor_args, unflatten_args, unbacked_bindings)
```
so `a, b, c, d, e = ir._CollectiveKernel.process_kernel(...)` raises `TypeError`.
## Changes
Added a small compatibility shim `_unpack_process_kernel()` in `inductor_lowering.py` that accepts both the new dataclass and the legacy tuple (same field order), and routed all three unpack sites through it:
- `comms/torchcomms/functional/inductor_lowering.py`
  - new `_unpack_process_kernel()` helper
  - `_inplace_lowering` — `_CollectiveKernel.process_kernel`
  - `_wait_tensors_inplace_lowering` — `_WaitKernel.process_kernel`
- `comms/torchcomms/functional/registry.py`
  - captured-op lowering — `_CollectiveKernel.process_kernel`
The `isinstance(result, tuple)` fast-path keeps this working on older/stable PyTorch too, so there's no hard version floor.
## Test plan
Built torchcomms against PyTorch nightly (`torch 2.14.0.dev+cu130`) and ran the previously-failing suite on 2× GB200:
```
TEST_BACKEND=nccl torchrun --nproc_per_node=2 \
  comms/torchcomms/tests/integration/py/FullgraphCompileAutogradTest.py
```
- Before: `9 failed, 25 passed` — all 9 failures the `ProcessKernelResult` unpack error.
- After: **`Ran 34 tests … OK`** (34/34) on both ranks.
`lintrunner` / ruff clean on the changed files.