### PR TITLE
[ci failures] pin gflags==2.2.2 (and fmt) in docs / lint / RCCL jobs

### DIFF
--- a/.github/workflows/build_test_rccl.yaml
+++ b/.github/workflows/build_test_rccl.yaml
@@ -46,7 +46,7 @@ jobs:
         conda activate venv
         python -m pip install --upgrade pip
         conda install conda-forge::libopenssl-static conda-forge::rsync -y
-        conda install conda-forge::glog=0.4.0 conda-forge::gflags conda-forge::fmt -y
+        conda install conda-forge::glog=0.4.0 conda-forge::gflags=2.2.2 conda-forge::fmt=12.2.0 -y
 
         pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/rocm7.0
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -53,7 +53,7 @@ jobs:
         run: |
           set -eux
           conda install -y git
-          conda install -y -c conda-forge glog==0.4.0 gflags fmt
+          conda install -y -c conda-forge glog==0.4.0 gflags==2.2.2 fmt==12.2.0
           pip install cmake==3.31.6
           pip install -r docs/requirements.txt
           export USE_NCCL=0

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -52,7 +52,7 @@ jobs:
           set -eux
 
           conda install -y git
-          conda install -y -c conda-forge glog==0.4.0 gflags fmt
+          conda install -y -c conda-forge glog==0.4.0 gflags==2.2.2 fmt==12.2.0
           pip install cmake==3.31.6
           export USE_NCCL=0
           export USE_NCCLX=0


### PR DESCRIPTION
## Summary
The **Build Documentation**, **lint** (PYRE), and **RCCL build/test** CI jobs fail at `import torchcomms` time with:
```
OSError: libgflags.so.2.2: cannot open shared object file: No such file or directory
```
Root cause: conda-forge recently published `gflags 2.3.0`, whose soname is `libgflags.so.2.3`. But the pinned `glog 0.4.0` was built against gflags 2.2 and hard-requires `libgflags.so.2.2`. These jobs installed `gflags` **unpinned**, so they now pull 2.3.0, and loading `libtorchcomms.so` → `libglog.so` → `libgflags.so.2.2` fails.
`#3133` already fixed exactly this by pinning `gflags=2.2.2` — but only in `.github/scripts/xpu_test.sh`. The three jobs here still install it unpinned.
## Evidence
From the failing Build Documentation run:
```
gflags              conda-forge/linux-64::gflags-2.3.0-h54a6638_0
...
OSError: libgflags.so.2.2: cannot open shared object file: No such file or directory
```
i.e. the env resolved `gflags 2.3.0` (soname `libgflags.so.2.3`) while `glog 0.4.0` needs `libgflags.so.2.2`.
## Changes
Pin `gflags==2.2.2` and `fmt==12.2.0` (mirroring `#3133`) in the three remaining conda-install sites, matching each file's existing operator style:
- `.github/workflows/docs.yaml` — `glog==0.4.0 gflags==2.2.2 fmt==12.2.0`
- `.github/workflows/lint.yaml` — `glog==0.4.0 gflags==2.2.2 fmt==12.2.0`
- `.github/workflows/build_test_rccl.yaml` — `conda-forge::glog=0.4.0 conda-forge::gflags=2.2.2 conda-forge::fmt=12.2.0`
After this, no unpinned `gflags` remains in the repo (`xpu_test.sh` was already pinned by `#3133`).