### PR TITLE
CMake: compile comms/prims into a prims OBJECT library (#3145)

### DIFF
--- a/comms/prims/CMakeLists.txt
+++ b/comms/prims/CMakeLists.txt
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+find_package(CUDA REQUIRED)
+
+file(GLOB_RECURSE PRIMS_SOURCES
+    "*.cc"
+    "*.cu"
+)
+
+# tests / benchmarks are gtest/MPI-dependent and not part of the library.
+list(FILTER PRIMS_SOURCES EXCLUDE REGEX ".*/tests/.*")
+list(FILTER PRIMS_SOURCES EXCLUDE REGEX ".*/benchmarks/.*")
+# AMD/HIP backend: the CUDA-only OSS build never defines __HIP_PLATFORM_AMD__,
+# so the transport/amd tree is excluded (it needs mlx5dv/bnxt direct-verbs
+# headers unavailable here).
+list(FILTER PRIMS_SOURCES EXCLUDE REGEX ".*/transport/amd/.*")
+# moe_ep is a self-contained Python `_cpp` extension (needs torch + pybind11),
+# not consumed by MCCL/ctran — build it separately if OSS ever needs MoE EP.
+list(FILTER PRIMS_SOURCES EXCLUDE REGEX ".*/collectives/moe_ep/.*")
+# triton is Python-only.
+list(FILTER PRIMS_SOURCES EXCLUDE REGEX ".*/triton/.*")
+
+add_library(prims OBJECT
+    ${PRIMS_SOURCES}
+)
+
+target_compile_features(prims PRIVATE cxx_std_20)
+target_compile_options(prims PRIVATE
+    -fPIC
+)
+# CUDA device-compile flags, mirroring comms/ctran and comms/mccl (from nccl).
+target_compile_options(prims PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:--expt-extended-lambda>
+    $<$<COMPILE_LANGUAGE:CUDA>:-Xptxas>
+    $<$<COMPILE_LANGUAGE:CUDA>:-maxrregcount=96>
+    $<$<COMPILE_LANGUAGE:CUDA>:-Xfatbin>
+    $<$<COMPILE_LANGUAGE:CUDA>:-compress-all>
+)
+
+set_target_properties(prims PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON
+    CUDA_RESOLVE_DEVICE_SYMBOLS ON
+    POSITION_INDEPENDENT_CODE ON
+)
+
+# ROOT (fbcode root) resolves comms/prims/..., comms/common/*.cuh (header-only
+# bits: AtomicUtils/DeviceConstants/BitOps), and comms/ctran/ibverbx/... .
+target_include_directories(prims PRIVATE
+    ${ROOT}
+    ${CONDA_INCLUDE}
+    ${CUDA_INCLUDE_DIRS}
+)


### PR DESCRIPTION
Summary:

First phase of enabling `ENABLE_PRIMS` in the OSS/Conda build (T279668987). Today the CMake build never compiles `comms/prims`, so prims-backed ctran (and other) code (fused ctree AllReduce, send/recv, hierarchical-ring AllToAll, windows) is dead in the OSS/conda binary.

This diff adds a CUDA-only CMake build for the core comms/prims tree:
- New `comms/prims/CMakeLists.txt` producing a prims OBJECT library, modeled on `comms/ctran/CMakeLists.txt`. It globs `*.cc/*.cu` and excludes tests/benchmarks, the AMD/HIP backend (`transport/amd`, since the OSS/conda build never defines `__HIP_PLATFORM_AMD__`), collectives/moe_ep (a separate torch/pybind11 `_cpp` extension), and triton (Python-only). It keeps the NVIDIA transports (ibgda/doca/rdma/ibrc/nvl), window, and memory code — the inverse of the ROCm/RCCL prims glob in `comms/rcclx/develop/projects/rccl/CMakeLists.txt`.

The prims objects are not yet linked or gated by `ENABLE_PRIMS`; that wiring lands in the next phase. ROOT (fbcode root) already resolves `comms/prims/...`, the header-only `comms/common` bits, and `comms/ctran/ibverbx` headers, so no new include roots are needed.

Reviewed By: saifhhasan, dboyda

Differential Revision: D111803976


