### PR TITLE
Pin docs-CI gflags and fix torch.compile process_kernel unpacking

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -53,7 +53,10 @@ jobs:
         run: |
           set -eux
           conda install -y git
-          conda install -y -c conda-forge glog==0.4.0 gflags fmt
+          # gflags must match glog==0.4.0's ABI (built against gflags 2.2 ->
+          # needs libgflags.so.2.2). Leaving gflags unpinned floats it to 2.3.x,
+          # which ships libgflags.so.2.3 and breaks the runtime load.
+          conda install -y -c conda-forge glog==0.4.0 gflags==2.2.2 fmt
           pip install cmake==3.31.6
           pip install -r docs/requirements.txt
           export USE_NCCL=0

--- a/comms/torchcomms/functional/inductor_lowering.py
+++ b/comms/torchcomms/functional/inductor_lowering.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 try:  # noqa: C901
     from torch._inductor import ir
     from torch._inductor.lowering import register_lowering
+    from torchcomms.functional.registry import _unpack_process_kernel
 
     def register_torchcomms_lowerings():
         from torchcomms.functional import collectives
@@ -138,7 +139,9 @@ try:  # noqa: C901
                     non_tensor_args,
                     unflatten_args,
                     unbacked_bindings,
-                ) = ir._CollectiveKernel.process_kernel(inplace_op.default, *args)
+                ) = _unpack_process_kernel(
+                    ir._CollectiveKernel.process_kernel(inplace_op.default, *args)
+                )
             assert not unbacked_bindings, f"{inplace_op} {unbacked_bindings}"
 
             # Create the collective kernel
@@ -325,9 +328,11 @@ try:  # noqa: C901
                     non_tensor_args,
                     unflatten_args,
                     unbacked_bindings,
-                ) = ir._WaitKernel.process_kernel(
-                    torch.ops.torchcomms.torchcomm_wait_tensors_.default,
-                    flat_inputs,
+                ) = _unpack_process_kernel(
+                    ir._WaitKernel.process_kernel(
+                        torch.ops.torchcomms.torchcomm_wait_tensors_.default,
+                        flat_inputs,
+                    )
                 )
             assert not unbacked_bindings
 

--- a/comms/torchcomms/functional/registry.py
+++ b/comms/torchcomms/functional/registry.py
@@ -23,6 +23,25 @@ logger = logging.getLogger(__name__)
 _REGISTERED_COLLECTIVES: dict[str, dict[str, Any]] = {}
 
 
+def _unpack_process_kernel(result: Any) -> tuple:
+    """Normalize ExternKernel.process_kernel's result to the 5-tuple.
+
+    Newer PyTorch returns a frozen ProcessKernelResult dataclass (not
+    iterable); older versions returned the positional
+    (example_output, tensor_args, non_tensor_args, unflatten_args,
+    unbacked_bindings) tuple.
+    """
+    if isinstance(result, tuple):
+        return result
+    return (
+        result.example_output,
+        result.tensor_args,
+        result.non_tensor_args,
+        result.unflatten_args,
+        result.unbacked_bindings,
+    )
+
+
 def _pack_result(results: list) -> Any:
     """Pack a list of results into the appropriate return value.
 
@@ -785,8 +804,10 @@ def _register_lowerings() -> None:  # noqa: C901
                             non_tensor_args,
                             unflatten_args,
                             unbacked_bindings,
-                        ) = ir._CollectiveKernel.process_kernel(
-                            captured_torch_op.default, *args
+                        ) = _unpack_process_kernel(
+                            ir._CollectiveKernel.process_kernel(
+                                captured_torch_op.default, *args
+                            )
                         )
                     assert not unbacked_bindings
 


### PR DESCRIPTION
Summary:
Two independent CI fixes for the torchcomms OSS export, grouped as the base of the stack.

Docs CI: the `Build Documentation` job installs `glog==0.4.0` (an old conda-forge build compiled against gflags 2.2, so it needs `libgflags.so.2.2`) but left `gflags` unpinned, so conda floated it to 2.3.x which ships `libgflags.so.2.3`. When Sphinx imports `torchcomms` (via `torch`), loading `libtorchcomms.so` failed with `libgflags.so.2.2: cannot open shared object file`. Pin `gflags==2.2.2` to match glog 0.4.0 ABI.

torch.compile: newer PyTorch changed `ExternKernel.process_kernel` (inherited by `_CollectiveKernel`/`_WaitKernel`) to return a frozen `ProcessKernelResult` dataclass instead of the positional 5-tuple, causing `TypeError: cannot unpack non-iterable ProcessKernelResult object` in the XPU `FullgraphCompileAutogradTest` suite. Add a `_unpack_process_kernel` shim in `registry.py` that normalizes both the new dataclass and the legacy tuple, and route all three unpack sites (one in `registry.py`, two in `inductor_lowering.py`) through it.

Differential Revision: D112125029


