### PR TITLE
IbgdaSendRecvBench: Enable passing GPU-NIC mapping to the benchmark (#3147)

### DIFF
--- a/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -11,6 +11,7 @@
 #include <array>
 #include <cstdint>
 #include <cstdlib>
+#include <fstream>
 #include <memory>
 #include <string>
 #include <utility>
@@ -52,6 +53,54 @@ bool isTcpEnvironment() {
   return std::getenv("MASTER_ADDR") != nullptr &&
       std::getenv("MASTER_PORT") != nullptr && std::getenv("RANK") != nullptr &&
       std::getenv("WORLD_SIZE") != nullptr;
+}
+
+// Read a KEY=VALUE from /etc/nccl.conf (NCCL's global config file). Returns the
+// trimmed value, or "" if the file is unreadable or the key is absent. Mirrors
+// NCCL's own fallback: an env var takes precedence, otherwise /etc/nccl.conf is
+// consulted. Minimal parser: skips blank/`#` lines, trims surrounding
+// whitespace around the key and value.
+std::string readNcclConf(const std::string& key) {
+  std::ifstream conf("/etc/nccl.conf");
+  if (!conf.is_open()) {
+    return std::string();
+  }
+  std::string line;
+  while (std::getline(conf, line)) {
+    const auto first = line.find_first_not_of(" \t");
+    if (first == std::string::npos || line[first] == '#') {
+      continue;
+    }
+    const auto eq = line.find('=', first);
+    if (eq == std::string::npos) {
+      continue;
+    }
+    const auto keyEnd = line.find_last_not_of(" \t", eq - 1);
+    if (keyEnd == std::string::npos ||
+        line.substr(first, keyEnd - first + 1) != key) {
+      continue;
+    }
+    const auto valFirst = line.find_first_not_of(" \t", eq + 1);
+    if (valFirst == std::string::npos) {
+      return std::string();
+    }
+    const auto valLast = line.find_last_not_of(" \t\r\n");
+    return line.substr(valFirst, valLast - valFirst + 1);
+  }
+  return std::string();
+}
+
+// NIC selection for the benchmark transport. Returns an NCCL_IB_HCA-style
+// filter string (e.g. "mlx5_0") for the transport, or "" for PCIe-topology
+// auto-discovery. Resolution order matches NCCL: the NCCL_IB_HCA env var wins;
+// if it is unset, fall back to /etc/nccl.conf. Needed to pin ranks onto
+// rail-aligned NICs (auto-discovery otherwise picks NICs that cannot reach each
+// other over RoCE).
+std::string benchIbHca() {
+  if (const char* hca = std::getenv("NCCL_IB_HCA")) {
+    return std::string(hca);
+  }
+  return readNcclConf("NCCL_IB_HCA");
 }
 
 class DistributedBenchmarkEnvironment {
@@ -215,6 +264,7 @@ class IbgdaSendRecvBenchmarkContext {
         .max_num_channels = kNumBlocks,
         .pipelineDepth = kPipelineDepth,
     };
+    transportConfig.ibHca = benchIbHca();
     transport_ = std::make_unique<MultipeerIbgdaTransport>(
         globalRank_, worldSize_, bootstrap_, transportConfig);
     transport_->exchange();


### PR DESCRIPTION
Summary:

The IBGDA send/recv benchmark (`IbgdaSendRecvBenchmark.cc`) auto-discovered an
RDMA NIC per GPU purely by PCIe/NUMA locality. However, when using multiple NICs on the GB200, there is an deadlock issue. Passing a new var to the benchmark allowing mapping the NIC config directly.

Reviewed By: saifhhasan

Differential Revision: D111154847
