### PR TITLE
Comms OSS/CMake: define ENABLE_PRIMS and link prims into ctran and others

### DIFF
--- a/comms/ctran/CMakeLists.txt
+++ b/comms/ctran/CMakeLists.txt
@@ -62,3 +62,11 @@ target_include_directories(ctran PRIVATE
     ${CONDA_INCLUDE}
     ${CUDA_INCLUDE_DIRS}
 )
+
+# ctran is the primary prims consumer: enabling this activates the (otherwise
+# compiled-out) prims-backed code — CtranPipes, CtranAlgo, AllToAll/SendRecv,
+# window, hierarchical ring — which #include "comms/prims/..." (resolved via
+# ROOT) and link against the prims OBJECT library.
+if(MCCL_ENABLE_PRIMS)
+    target_compile_definitions(ctran PRIVATE ENABLE_PRIMS=1)
+endif()

--- a/comms/prims/CMakeLists.txt
+++ b/comms/prims/CMakeLists.txt
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+find_package(CUDA REQUIRED)
+
+file(GLOB_RECURSE PRIMS_SOURCES
+    "*.cc"
+    "*.cu"
+)
+
+# tests / benchmarks are gtest/MPI-dependent and not part of the library.
+list(FILTER PRIMS_SOURCES EXCLUDE REGEX ".*/tests/.*")
+list(FILTER PRIMS_SOURCES EXCLUDE REGEX ".*/benchmarks/.*")
+# AMD/HIP backend: the CUDA-only OSS build never defines __HIP_PLATFORM_AMD__,
+# so the transport/amd tree is excluded (it needs mlx5dv/bnxt direct-verbs
+# headers unavailable here).
+list(FILTER PRIMS_SOURCES EXCLUDE REGEX ".*/transport/amd/.*")
+# moe_ep is a self-contained Python `_cpp` extension (needs torch + pybind11),
+# not consumed by MCCL/ctran — build it separately if OSS ever needs MoE EP.
+list(FILTER PRIMS_SOURCES EXCLUDE REGEX ".*/collectives/moe_ep/.*")
+# triton is Python-only.
+list(FILTER PRIMS_SOURCES EXCLUDE REGEX ".*/triton/.*")
+
+add_library(prims OBJECT
+    ${PRIMS_SOURCES}
+)
+
+target_compile_features(prims PRIVATE cxx_std_20)
+target_compile_options(prims PRIVATE
+    -fPIC
+)
+# CUDA device-compile flags, mirroring comms/ctran and comms/mccl (from nccl).
+target_compile_options(prims PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:--expt-extended-lambda>
+    $<$<COMPILE_LANGUAGE:CUDA>:-Xptxas>
+    $<$<COMPILE_LANGUAGE:CUDA>:-maxrregcount=96>
+    $<$<COMPILE_LANGUAGE:CUDA>:-Xfatbin>
+    $<$<COMPILE_LANGUAGE:CUDA>:-compress-all>
+)
+
+set_target_properties(prims PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON
+    CUDA_RESOLVE_DEVICE_SYMBOLS ON
+    POSITION_INDEPENDENT_CODE ON
+)
+
+# ROOT (fbcode root) resolves comms/prims/..., comms/common/*.cuh (header-only
+# bits: AtomicUtils/DeviceConstants/BitOps), and comms/ctran/ibverbx/... .
+target_include_directories(prims PRIVATE
+    ${ROOT}
+    ${CONDA_INCLUDE}
+    ${CUDA_INCLUDE_DIRS}
+)

--- a/comms/prims/CMakeLists.txt
+++ b/comms/prims/CMakeLists.txt
@@ -50,3 +50,53 @@ target_include_directories(prims PRIVATE
     ${CONDA_INCLUDE}
     ${CUDA_INCLUDE_DIRS}
 )
+
+# prims is only compiled when the top level does add_subdirectory(comms/prims),
+# so reaching this file means prims is enabled: set ENABLE_PRIMS unconditionally
+# rather than referencing the higher-level MCCL_ENABLE_PRIMS option. PRIVATE:
+# bakes the macro into prims' own objects. (Consumers that include ctran/mccl
+# headers set ENABLE_PRIMS themselves for the ODR/export boundary; see the
+# top-level CMakeLists.txt.)
+target_compile_definitions(prims PRIVATE ENABLE_PRIMS=1)
+
+# spdlog config for transport/rdma/NicDiscovery.cc (the only spdlog consumer in
+# prims; no prims header includes spdlog). Consume spdlog header-only:
+# SPDLOG_FMT_EXTERNAL uses the build's external fmt (not spdlog's bundled copy,
+# an ODR hazard), while NOT defining SPDLOG_COMPILED_LIB inlines all spdlog code
+# into NicDiscovery.o, so no libspdlog.a is linked. This sidesteps the static-
+# archive ordering trap that otherwise left compiled-lib symbols (e.g.
+# spdlog::logger::err_handler_) undefined in the shared module at dlopen.
+target_compile_definitions(prims PRIVATE SPDLOG_FMT_EXTERNAL)
+
+# Third-party link deps every consumer of the prims transports needs, declared
+# here so they propagate automatically to any target that links the `prims`
+# OBJECT library (PUBLIC = usage requirement). Resolved from CONDA_LIB (and
+# THIRD_PARTY_LIB when set). doca_gpunetio: IBGDA; ibverbs/mlx5: IB verbs;
+# dl: NVML dlopen. The CUDA driver (libcuda) is deliberately NOT linked: prims
+# (platform/CudaDriverLazy.cc) and ctran (CudaWrap.cc) resolve driver entry
+# points lazily via cudaGetDriverEntryPoint, so only CUDA::cudart is a link-time
+# dep. Hard-linking cuda_driver would add a libcuda.so.1 NEEDED that breaks
+# import on driverless build/verify hosts.
+target_link_directories(prims PUBLIC ${CONDA_LIB})
+if(DEFINED THIRD_PARTY_LIB)
+    target_link_directories(prims PUBLIC ${THIRD_PARTY_LIB})
+endif()
+target_link_libraries(prims PUBLIC
+    "-ldoca_gpunetio"
+    "-libverbs"
+    "-lmlx5"
+    "-ldl"
+)
+
+# Install prims' public headers (ctran's installed headers #include
+# "comms/prims/..." under ENABLE_PRIMS, so these must ship for the exported
+# Ctran/Mccl packages to compile). Owned here so prims specifies what/where to
+# install. The EXCLUDE list is an intentional lean-package boundary, kept
+# co-located with the source glob above (lines ~11-21) so both are maintained in
+# one place. DESTINATION must stay include/comms/prims to match those includes;
+# file(REAL_PATH) resolves the symlinked OSS source tree.
+file(REAL_PATH "${CMAKE_CURRENT_SOURCE_DIR}" _PRIMS_SRC_DIR)
+install(DIRECTORY ${_PRIMS_SRC_DIR}/ DESTINATION include/comms/prims
+    FILES_MATCHING PATTERN "*.h" PATTERN "*.cuh"
+    PATTERN "tests" EXCLUDE PATTERN "benchmarks" EXCLUDE
+    PATTERN "amd" EXCLUDE PATTERN "moe_ep" EXCLUDE PATTERN "triton" EXCLUDE)


### PR DESCRIPTION
Summary:
Enables the `prims` transport library in the OSS/CMake (Conda) build and turns on the prims-backed code paths in `ctran`. Previously the CMake build never compiled `comms/prims`, so prims-backed transports (send/recv, hierarchical-ring AllToAll, windows, fused collectives) were compiled out of the OSS binary. This change wires them in, and keeps all prims-specific build config owned by prims itself.

**Changes:**
- **`comms/prims/CMakeLists.txt`** — the `prims` OBJECT library owns all of its own build configuration:
  - defines `ENABLE_PRIMS=1` unconditionally on its own objects (if prims is being compiled, it is enabled);
  - declares its third-party link dependencies as PUBLIC usage requirements (`-ldoca_gpunetio`, `-libverbs`, `-lmlx5`, `-ldl`, resolved from the conda lib dir) so any target that links `prims` inherits them automatically. The CUDA driver (`libcuda`) is intentionally **not** linked — driver entry points are resolved lazily via `cudaGetDriverEntryPoint`, so only `CUDA::cudart` is a link-time dependency (this avoids a `libcuda.so.1` `NEEDED` entry that would break loading on hosts without an NVIDIA driver);
  - owns its own public-header `install()` rules.
  - spdlog is consumed header-only (`SPDLOG_FMT_EXTERNAL`; used only by the `transport/rdma` NIC-discovery code), so no spdlog archive is linked.

- **`comms/ctran/CMakeLists.txt`** — `ctran` defines `ENABLE_PRIMS=1` on its OBJECT library (gated on the build's prims option), which activates ctran's prims-backed code (CtranPipes / CtranAlgo / AllToAll / SendRecv / window / hierarchical ring). That code `#include`s `comms/prims/...` and links against the `prims` library.

Reviewed By: dboyda

Differential Revision: D111804077


