### PR TITLE
Block-owned QP send-queues with per-group lane state + NIC stagger

### DIFF
--- a/comms/prims/tests/MultipeerIbgdaDeviceTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaDeviceTransportTest.cu
@@ -1,5 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <cstdint>
+#include <vector>
+
 #include "comms/prims/tests/MultipeerIbgdaDeviceTransportTest.cuh"
 #include "comms/prims/transport/ibgda/MultipeerIbgdaDeviceTransport.cuh"
 
@@ -58,6 +61,159 @@ void runTestRankMappingKernel(
     bool* d_success) {
   testRankMappingKernel<<<1, 1>>>(
       myRank, nRanks, d_results, d_expected, numTestCases, d_success);
+}
+
+// =============================================================================
+// V4 QP-ownership lane-mapping test
+//
+// Verifies that select_put_lane() maps a ThreadGroup to a lane per the
+// block-owned-QP + per-group-staggered-NIC model (no IB hardware needed —
+// select_put_lane only reads QP-pointer values and the per-channel cursor):
+//   - physical QP slot is owned by group.block_id (groups in a block share it)
+//   - the NIC lane is staggered by group.group_id (co-resident groups spread)
+// =============================================================================
+
+// Grants the test kernel access to the private select_put_lane(). Returns the
+// chosen lane's (nic, qp-slot) as a public V4LaneResult so callers never name
+// the private IbgdaLane type.
+struct IbgdaLaneTestAccess {
+  __device__ static V4LaneResult
+  select(P2pIbgdaTransportDevice& t, ThreadGroup& g, IbDirection dir) {
+    const auto lane = t.select_put_lane(g, dir);
+    return V4LaneResult{
+        static_cast<int>(lane.nic_id), static_cast<int>(lane.qp_slot_per_nic)};
+  }
+};
+
+__global__ void testV4LaneMappingKernel(
+    NicDeviceIbgdaResources* nicResources,
+    int numNics,
+    IbLocalChannel* localChannels,
+    int maxChannels,
+    int qpsPerConn,
+    int qpDirCount,
+    int numBlocks,
+    int groupsPerBlock,
+    int* outNicId, // indexed by group_id, size maxChannels
+    int* outQpSlot) {
+  P2pIbgdaTransportDevice transport(
+      DeviceSpan<NicDeviceIbgdaResources>(nicResources, numNics),
+      /*ownedRemoteSignalBuf=*/{},
+      /*ownedLocalSignalBuf=*/{},
+      /*ownedCounterBuf=*/{},
+      /*numSignalSlots=*/0,
+      /*numCounterSlots=*/0,
+      maxChannels,
+      qpsPerConn,
+      qpDirCount,
+      DeviceSpan<IbLocalChannel>(localChannels, maxChannels),
+      /*channelLayout=*/{});
+
+  for (int b = 0; b < numBlocks; ++b) {
+    for (int j = 0; j < groupsPerBlock; ++j) {
+      ThreadGroup g{};
+      g.thread_id_in_group = 0;
+      g.group_size = 1;
+      g.group_id = static_cast<uint32_t>(b * groupsPerBlock + j);
+      g.block_id = static_cast<uint32_t>(b);
+      g.total_groups = static_cast<uint32_t>(maxChannels);
+      g.scope = SyncScope::MULTIWARP;
+      const V4LaneResult r =
+          IbgdaLaneTestAccess::select(transport, g, IbDirection::Send);
+      outNicId[g.group_id] = r.nic_id;
+      outQpSlot[g.group_id] = r.qp_slot_per_nic;
+    }
+  }
+}
+
+void runV4LaneMappingTest(
+    int numNics,
+    int numBlocks,
+    int groupsPerBlock,
+    int qpsPerConn,
+    std::vector<V4LaneResult>& outResults) {
+  const int maxChannels = numBlocks * groupsPerBlock;
+  const int qpDirCount = kIbDirections;
+  const int perNicQps = maxChannels * qpDirCount * qpsPerConn;
+
+  // Fake, non-null QP pointers. select_put_lane only reads the pointer value
+  // (stored into IbgdaLane.qp) and never dereferences it.
+  std::vector<doca_gpu_dev_verbs_qp*> h_qps(
+      static_cast<std::size_t>(numNics) * perNicQps);
+  for (std::size_t i = 0; i < h_qps.size(); ++i) {
+    h_qps[i] = reinterpret_cast<doca_gpu_dev_verbs_qp*>(
+        static_cast<std::uintptr_t>(i + 1));
+  }
+  const std::size_t qpBytes = h_qps.size() * sizeof(doca_gpu_dev_verbs_qp*);
+  doca_gpu_dev_verbs_qp** d_qps = nullptr;
+  doca_gpu_dev_verbs_qp** d_comp = nullptr;
+  cudaMalloc(&d_qps, qpBytes);
+  cudaMalloc(&d_comp, qpBytes);
+  cudaMemcpy(d_qps, h_qps.data(), qpBytes, cudaMemcpyHostToDevice);
+  cudaMemcpy(d_comp, h_qps.data(), qpBytes, cudaMemcpyHostToDevice);
+
+  std::vector<NicDeviceIbgdaResources> h_nic;
+  h_nic.reserve(numNics);
+  for (int n = 0; n < numNics; ++n) {
+    h_nic.push_back(
+        NicDeviceIbgdaResources{
+            DeviceSpan<doca_gpu_dev_verbs_qp*>(
+                d_qps + n * perNicQps, perNicQps),
+            DeviceSpan<doca_gpu_dev_verbs_qp*>(
+                d_comp + n * perNicQps, perNicQps),
+            NetworkLKey{},
+            n});
+  }
+  NicDeviceIbgdaResources* d_nic = nullptr;
+  cudaMalloc(&d_nic, numNics * sizeof(NicDeviceIbgdaResources));
+  cudaMemcpy(
+      d_nic,
+      h_nic.data(),
+      numNics * sizeof(NicDeviceIbgdaResources),
+      cudaMemcpyHostToDevice);
+
+  IbLocalChannel* d_channels = nullptr;
+  cudaMalloc(&d_channels, maxChannels * sizeof(IbLocalChannel));
+  cudaMemset(d_channels, 0, maxChannels * sizeof(IbLocalChannel));
+
+  int* d_nicId = nullptr;
+  int* d_qpSlot = nullptr;
+  cudaMalloc(&d_nicId, maxChannels * sizeof(int));
+  cudaMalloc(&d_qpSlot, maxChannels * sizeof(int));
+
+  testV4LaneMappingKernel<<<1, 1>>>(
+      d_nic,
+      numNics,
+      d_channels,
+      maxChannels,
+      qpsPerConn,
+      qpDirCount,
+      numBlocks,
+      groupsPerBlock,
+      d_nicId,
+      d_qpSlot);
+  cudaDeviceSynchronize();
+
+  std::vector<int> nicId(maxChannels);
+  std::vector<int> qpSlot(maxChannels);
+  cudaMemcpy(
+      nicId.data(), d_nicId, maxChannels * sizeof(int), cudaMemcpyDeviceToHost);
+  cudaMemcpy(
+      qpSlot.data(),
+      d_qpSlot,
+      maxChannels * sizeof(int),
+      cudaMemcpyDeviceToHost);
+  outResults.resize(maxChannels);
+  for (int i = 0; i < maxChannels; ++i) {
+    outResults[i] = V4LaneResult{nicId[i], qpSlot[i]};
+  }
+
+  cudaFree(d_qps);
+  cudaFree(d_comp);
+  cudaFree(d_nic);
+  cudaFree(d_channels);
+  cudaFree(d_nicId);
+  cudaFree(d_qpSlot);
 }
 
 } // namespace comms::prims::tests

--- a/comms/prims/tests/MultipeerIbgdaDeviceTransportTest.cuh
+++ b/comms/prims/tests/MultipeerIbgdaDeviceTransportTest.cuh
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cstdint>
+#include <vector>
 
 namespace comms::prims::tests {
 
@@ -15,5 +16,23 @@ void runTestRankMappingKernel(
     int* d_expected,
     int numTestCases,
     bool* d_success);
+
+// Which NIC and physical QP slot a group's put was mapped to.
+struct V4LaneResult {
+  int nic_id;
+  int qp_slot_per_nic;
+};
+
+// Runs select_put_lane() for every (block, group) over a
+// P2pIbgdaTransportDevice built with fake NIC resources, returning the chosen
+// lane per group_id (outResults[group_id]). Hardware-free; exercises the V4
+// block-owned-QP + group-staggered-NIC mapping. Uses qpDirectionCount =
+// kIbDirections.
+void runV4LaneMappingTest(
+    int numNics,
+    int numBlocks,
+    int groupsPerBlock,
+    int qpsPerConn,
+    std::vector<V4LaneResult>& outResults);
 
 } // namespace comms::prims::tests

--- a/comms/prims/tests/MultipeerIbgdaDeviceTransportTestMain.cc
+++ b/comms/prims/tests/MultipeerIbgdaDeviceTransportTestMain.cc
@@ -8,7 +8,9 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <set>
 #include <vector>
 
 #include "comms/prims/tests/MultipeerIbgdaDeviceTransportTest.cuh"
@@ -206,6 +208,54 @@ INSTANTIATE_TEST_SUITE_P(
     [](const ::testing::TestParamInfo<int>& info) {
       return std::to_string(info.param) + "Ranks";
     });
+
+// =============================================================================
+// V4 QP-ownership lane-mapping test
+//
+// select_put_lane() must map a ThreadGroup to a lane such that:
+//   (a) the physical QP slot is owned by block_id — all groups sharing a block
+//       resolve to the SAME qp_slot_per_nic (so the NIC sees only num_blocks
+//       active QPs per rail), and distinct blocks use distinct slots;
+//   (b) the NIC lane is staggered by group_id — the groups sharing a block
+//       spread across all NICs instead of colliding on one.
+// A channelId/qpOwnerChannel swap breaks (a); a dropped stagger breaks (b).
+// qpsPerConnection == 1 (the GB300 config) so each block owns exactly one QP
+// per NIC per direction.
+// =============================================================================
+TEST(V4LaneMappingTest, BlockOwnedQpAndGroupStagger) {
+  const int numNics = 2;
+  const int numBlocks = 4;
+  const int groupsPerBlock = 4;
+  const int qpsPerConn = 1;
+
+  std::vector<V4LaneResult> res;
+  runV4LaneMappingTest(numNics, numBlocks, groupsPerBlock, qpsPerConn, res);
+  ASSERT_EQ(res.size(), static_cast<std::size_t>(numBlocks * groupsPerBlock));
+
+  std::set<int> blockSlots;
+  for (int b = 0; b < numBlocks; ++b) {
+    const int blockSlot = res[b * groupsPerBlock].qp_slot_per_nic;
+    std::set<int> nicIds;
+    for (int j = 0; j < groupsPerBlock; ++j) {
+      const V4LaneResult& r = res[b * groupsPerBlock + j];
+      // (a) block-owned QP: every group in the block shares one physical slot.
+      EXPECT_EQ(r.qp_slot_per_nic, blockSlot)
+          << "block " << b << " group " << j
+          << " resolved to a different QP slot (" << r.qp_slot_per_nic
+          << " != " << blockSlot << ") — QP is not block-owned";
+      nicIds.insert(r.nic_id);
+    }
+    // (b) group stagger: the block's groups spread across all NICs.
+    EXPECT_EQ(nicIds.size(), static_cast<std::size_t>(numNics))
+        << "block " << b << " groups did not spread across all " << numNics
+        << " NICs (stagger missing)";
+    // (a cont.) distinct blocks own distinct physical slots.
+    EXPECT_EQ(blockSlots.count(blockSlot), 0u)
+        << "block " << b << " shares QP slot " << blockSlot
+        << " with another block";
+    blockSlots.insert(blockSlot);
+  }
+}
 
 } // namespace comms::prims::tests
 

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -37,6 +37,13 @@ namespace comms::prims {
 
 struct Memcpy;
 
+namespace tests {
+// Test-only accessor for private lane selection
+// (MultipeerIbgdaDeviceTransportTest verifies the block-owned-QP + group-
+// staggered-NIC mapping).
+struct IbgdaLaneTestAccess;
+} // namespace tests
+
 inline constexpr uint64_t kDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
 
 // `PIPES_DEVICE_TRAP()` is defined in `comms/prims/core/DeviceMacros.cuh` and
@@ -98,18 +105,21 @@ struct NicDeviceIbgdaResources {
  *
  * Every method has two overloads:
  *   Group-scope: put(group, ...) — all threads in group must call.
- *     QP selection is owned by the physical CUDA block. The block
- *     round-robins put operations across NIC-first QP lanes and preserves
- *     signal/flush ordering for operations issued by the same block_id.
- *     Data transfer uses the exact buffer span supplied by the caller.
- *     Threads in the group coordinate the operation; callers that want the
- *     transport to shard a larger buffer should use put_cooperative().
- *     Signal/counter/flush are leader-only with group.sync().
+ *     The physical QP send-queue is owned by the CUDA block (block_id): the
+ *     groups in a block share the block's QP on each NIC. The round-robin
+ *     cursor and flush bookkeeping are owned per group (group_id), and the NIC
+ *     lane is staggered by group_id so co-resident groups spread across NICs.
+ *     For single-group-per-block kernels group_id == block_id. See
+ *     qp_owner_channel/lane_state_channel. Data transfer uses the exact buffer
+ *     span supplied by the caller; callers that want the transport to shard a
+ *     larger buffer should use put_cooperative(). Signal/counter/flush are
+ *     leader-only with group.sync().
  *
- *   Thread-scope: put(...) — single thread calls.
- *     QP selection uses the caller's physical blockIdx.x. Implemented as a
- *     thin wrapper: creates a solo ThreadGroup with block_id=blockIdx.x, then
- *     forwards to the group-scope implementation.
+ *   Thread-scope: put(...) — single thread calls. Creates a solo ThreadGroup
+ *     and forwards to the group-scope implementation. NOTE: the solo group's
+ *     group_id is the global thread id, which is a valid flow-control channel
+ *     only when it is < maxChannels; fixed-channel callers must use the
+ *     group-scope APIs (which carry a real group_id/block_id).
  *
  * CRITICAL: Do not rely on scope-family mixing for synchronization.
  *   Thread-scope wrappers do not synchronize with other threads in the block.
@@ -149,6 +159,10 @@ struct NicDeviceIbgdaResources {
  *      Buffer ptr==nullptr means "disabled" (no signal/counter).
  */
 class P2pIbgdaTransportDevice {
+  // Test-only access to private lane selection (block-owned QP + group
+  // stagger).
+  friend struct tests::IbgdaLaneTestAccess;
+
  public:
   // Default ctor required so an array of these can be cudaMemcpy'd from host
   // (see MultipeerIbgdaTransportCuda.cu::buildDeviceTransportsOnGpu). Do not
@@ -843,7 +857,8 @@ class P2pIbgdaTransportDevice {
           "cluster-scope ThreadGroup yet\n");
       PIPES_DEVICE_TRAP();
     }
-    validate_channel_id(group.group_id);
+    validate_channel_id(lane_state_channel(group));
+    validate_channel_id(qp_owner_channel(group));
   }
 
   __device__ __forceinline__ IbQpState& qp_state(
@@ -854,11 +869,42 @@ class P2pIbgdaTransportDevice {
     return direction == IbDirection::Send ? channel.sendQp : channel.recvQp;
   }
 
+  // QP ownership vs. flow-control state.
+  //
+  // Physical QP send-queues are owned by the CUDA block (block_id): the groups
+  // in a block share the block's QP on each NIC, so the NIC sees only
+  // num_blocks active QPs per rail (deep per-QP WQE batching) regardless of how
+  // many multiwarp groups a block runs. The round-robin cursor and flush
+  // bookkeeping are owned per group (group_id), so each group advances its NIC
+  // lane independently; the lane is staggered by group_id (see select_put_lane)
+  // so the groups sharing a block spread across NICs instead of all landing on
+  // the same NIC each step. For single-group-per-block kernels group_id ==
+  // block_id, so this reduces to block-owned QPs with a per-block lane stagger.
+  //
+  // Invariant relied on here: a given group_id is driven from exactly one
+  // block_id (DATA_READY/SLOT_FREE/NIC_DONE are all group_id-indexed), so a
+  // group's flush tickets — recorded in its per-group IbQpState but waited on
+  // via the block's physical QP — always target that block's QP.
+  __device__ __forceinline__ uint32_t
+  qp_owner_channel(const ThreadGroup& group) const {
+    return group.block_id;
+  }
+  __device__ __forceinline__ uint32_t
+  lane_state_channel(const ThreadGroup& group) const {
+    return group.group_id;
+  }
+
+  // stateChannel owns the flow-control state (cursor/flush IbQpState) and is
+  // the returned lane's channel_id; the physical QP is resolved from
+  // qpOwnerChannel. They differ when a block runs multiple groups (see
+  // qp_owner_channel/lane_state_channel).
   __device__ __forceinline__ IbgdaLane lane_from_ordinal(
-      uint32_t channelId,
+      uint32_t stateChannel,
+      uint32_t qpOwnerChannel,
       IbDirection direction,
       uint32_t laneOrdinal) const {
-    validate_channel_id(channelId);
+    validate_channel_id(stateChannel);
+    validate_channel_id(qpOwnerChannel);
     const uint32_t numNics = static_cast<uint32_t>(nicDevices_.size());
     if (numNics == 0) {
       printf(
@@ -887,7 +933,7 @@ class P2pIbgdaTransportDevice {
       PIPES_DEVICE_TRAP();
     }
     const uint32_t qpSlotPerNic =
-        ((channelId * static_cast<uint32_t>(qpDirectionCount_) +
+        ((qpOwnerChannel * static_cast<uint32_t>(qpDirectionCount_) +
           directionIndex) *
          static_cast<uint32_t>(qpsPerConnection_)) +
         qpIndex;
@@ -897,9 +943,11 @@ class P2pIbgdaTransportDevice {
         qpSlotPerNic >= nic.qps.size() ||
         companionSlotPerNic >= nic.companion_qps.size()) {
       printf(
-          "[PIPES] FATAL: invalid IBGDA lane channel=%u direction=%u nic=%u "
-          "qpIndex=%u qpsPerConnection=%d qps=%u companionQps=%u\n",
-          channelId,
+          "[PIPES] FATAL: invalid IBGDA lane stateChannel=%u qpChannel=%u "
+          "direction=%u nic=%u qpIndex=%u qpsPerConnection=%d qps=%u "
+          "companionQps=%u\n",
+          stateChannel,
+          qpOwnerChannel,
           directionIndex,
           nicId,
           qpIndex,
@@ -912,17 +960,19 @@ class P2pIbgdaTransportDevice {
         .nic_id = nicId,
         .qp_index = qpIndex,
         .lane_ordinal = laneOrdinal,
-        .channel_id = channelId,
+        .channel_id = stateChannel,
         .qp_slot_per_nic = qpSlotPerNic,
         .companion_slot_per_nic = companionSlotPerNic,
         .direction = direction,
-        .qp_state = &qp_state(channelId, direction),
+        .qp_state = &qp_state(stateChannel, direction),
         .qp = nic.qps[qpSlotPerNic],
         .companion_qp = nic.companion_qps[companionSlotPerNic]};
   }
 
-  __device__ __forceinline__ uint32_t
-  select_put_lane_ordinal(uint32_t channelId, IbDirection direction) {
+  __device__ __forceinline__ uint32_t select_put_lane_ordinal(
+      uint32_t channelId,
+      IbDirection direction,
+      uint32_t staggerOffset) {
     validate_channel_id(channelId);
     if (nicDevices_.empty()) {
       printf(
@@ -944,20 +994,27 @@ class P2pIbgdaTransportDevice {
     if (numLanes == 1) {
       return 0;
     }
+    // Per-group cursor: the group leader is the only writer, so a plain
+    // increment is sufficient (no atomic). staggerOffset (group_id) fans the
+    // groups sharing a block across NICs so they do not collide on one NIC.
     uint32_t seq = qp_state(channelId, direction).cursor++;
-    return seq % numLanes;
+    return (seq + staggerOffset) % numLanes;
   }
 
   __device__ __forceinline__ IbgdaLane
   select_put_lane(ThreadGroup& group, IbDirection direction) {
-    const uint32_t channelId = group.group_id;
+    const uint32_t stateChannel = lane_state_channel(group);
+    const uint32_t qpOwnerChannel = qp_owner_channel(group);
+    const uint32_t laneOrdinal =
+        select_put_lane_ordinal(stateChannel, direction, group.group_id);
     return lane_from_ordinal(
-        channelId, direction, select_put_lane_ordinal(channelId, direction));
+        stateChannel, qpOwnerChannel, direction, laneOrdinal);
   }
 
   __device__ __forceinline__ IbgdaLane
   control_lane(ThreadGroup& group, IbDirection direction) const {
-    return lane_from_ordinal(group.group_id, direction, 0);
+    return lane_from_ordinal(
+        lane_state_channel(group), qp_owner_channel(group), direction, 0);
   }
 
   __device__ __forceinline__ uint32_t num_qp_lanes() const {
@@ -1028,7 +1085,8 @@ class P2pIbgdaTransportDevice {
   }
 
   __device__ void wait_lanes(
-      uint32_t channelId,
+      uint32_t stateChannel,
+      uint32_t qpOwnerChannel,
       IbDirection direction,
       uint64_t mask,
       const uint64_t* tickets) {
@@ -1037,15 +1095,22 @@ class P2pIbgdaTransportDevice {
       if ((mask & (1ULL << laneId)) == 0) {
         continue;
       }
-      IbgdaLane lane = lane_from_ordinal(channelId, direction, laneId);
+      IbgdaLane lane =
+          lane_from_ordinal(stateChannel, qpOwnerChannel, direction, laneId);
       wait_local_on_qp(lane.qp, tickets[laneId]);
     }
   }
 
   __device__ void drain_flush_lanes(ThreadGroup& group, IbDirection direction) {
-    auto& state = qp_state(group.group_id, direction);
+    const uint32_t stateChannel = lane_state_channel(group);
+    auto& state = qp_state(stateChannel, direction);
     const uint64_t mask = atomic_exchange_u64(&state.pendingFlushLanesMask, 0);
-    wait_lanes(group.group_id, direction, mask, state.lastFlushWqe);
+    wait_lanes(
+        stateChannel,
+        qp_owner_channel(group),
+        direction,
+        mask,
+        state.lastFlushWqe);
   }
 
   __device__ void put_impl(
@@ -1124,13 +1189,16 @@ class P2pIbgdaTransportDevice {
 
     uint32_t laneOrdinal = 0;
     uint64_t lastPutWqeIdx = 0;
+    const uint32_t stateChannel = lane_state_channel(group);
+    const uint32_t qpOwnerChannel = qp_owner_channel(group);
     if (group.is_leader()) {
       validate_group_scope(group);
-      laneOrdinal = select_put_lane_ordinal(group.group_id, IbDirection::Send);
+      laneOrdinal = select_put_lane_ordinal(
+          stateChannel, IbDirection::Send, group.group_id);
     }
     laneOrdinal = group.broadcast<uint32_t>(laneOrdinal);
-    IbgdaLane lane =
-        lane_from_ordinal(group.group_id, IbDirection::Send, laneOrdinal);
+    IbgdaLane lane = lane_from_ordinal(
+        stateChannel, qpOwnerChannel, IbDirection::Send, laneOrdinal);
 
     lastPutWqeIdx =
         put_cooperative_data_impl(group, lane, localBuf, remoteBuf, nbytes);
@@ -1241,11 +1309,12 @@ class P2pIbgdaTransportDevice {
       const uint16_t qp_depth = __ldg(&qp->sq_wqe_num);
       if (group.group_size > qp_depth) {
         printf(
-            "[PIPES] FATAL: put group_size (%u) > QP depth (%u). "
-            "Set NCCL_CTRAN_IBGDA_QP_DEPTH >= %u to avoid deadlock.\n",
+            "[PIPES] FATAL: put_cooperative group_size (%u) > QP depth (%u). "
+            "This QP is block-owned (shared by all groups in the block), so "
+            "NCCL_CTRAN_IBGDA_QP_DEPTH must be >= (groups per block) * "
+            "group_size * in-flight puts to avoid send-queue overrun.\n",
             group.group_size,
-            qp_depth,
-            group.group_size);
+            qp_depth);
         PIPES_DEVICE_TRAP();
       }
     }


### PR DESCRIPTION
Summary:
The IBGDA transport indexes both the physical QP send-queue and the per-lane flow-control state (the `IbQpState` round-robin cursor + flush bookkeeping) by a single `channelId`. For multi-group-per-block kernels — notably the bottom-up log(N) reduce-scatter, which runs 4 multiwarp groups per block — indexing everything by `group_id` gives each of the 32 groups its own physical QP and its own cursor, which hurts GB300 inter-node bandwidth two ways:

1. NIC imbalance: the 32 per-group cursors start at 0 and advance in lockstep, so at every step all groups select the same NIC (`cursor % numLanes`), leaving the other rail idle.
2. QP fan-out: 32 active QPs/NIC/direction (vs 8 when owned per block) makes the NIC context-switch across many shallowly-fed send-queues instead of few deeply-fed ones.

This change decouples the two concerns without moving the transport's logical channel off `group_id`:

- Physical QP send-queues are owned by the CUDA block (`block_id`): the groups in a block share the block's QP on each NIC, so the NIC sees only `num_blocks` (8) active QPs per rail with deep per-QP WQE batching.
- The round-robin cursor and flush state stay owned per group (`group_id`), so each group advances its NIC lane independently and per-group flow-control/flush semantics are preserved (no cross-group flush consolidation).
- The lane is staggered by `group_id` so the groups sharing a block spread across NICs instead of colliding on one NIC each step.

Concretely, `lane_from_ordinal`/`wait_lanes` now take the QP-owner channel (`block_id`) separately from the flow-control state channel (`stateChannel` = `group_id`); `select_put_lane_ordinal` takes a per-group stagger offset. New helpers `qp_owner_channel`/`lane_state_channel` name the two channels. For single-group-per-block kernels `group_id == block_id`, so this reduces to block-owned QPs with a per-block lane stagger.

Why not just index everything by `block_id`: that also recovers the bandwidth but collapses the flow-control state per block, which (a) drops `group_id` as the transport's logical channel (it is the unit for the send/recv protocol state — DATA_READY/SLOT_FREE/NIC_DONE — so keeping it consistent is cleaner) and (b) would share the flush mask across the groups in a block, introducing a cross-group flush-consolidation hazard for any collective that uses flush()/fence() with multiple groups per block. This keeps `group_id` ownership and matches block-level performance.

Correctness: multiple groups posting to the same block-owned QP is safe — WQE-slot reservation is atomic (DOCA RESOURCE_SHARING_MODE_GPU) and completion is tracked by per-group NIC_DONE/SLOT_FREE/DATA_READY counters/signals, independent of which QP a put used. This is the same QP sharing the existing block-owned path already relies on; the non-atomic per-group cursor is single-writer (leader-only, unique group_id).

Behavior change for single-group-per-block collectives (ctdirect_ib / ring / allgather): the added `group_id` (== `block_id`) stagger makes block b start on NIC `b % numLanes` instead of NIC 0. This is correctness-neutral (every buffer is registered on all NICs; the put target VA is NIC-independent) but changes rail balance from the first step. Validate with the device-API MAST runs below before landing.

Differential Revision: D111943744


