### PR TITLE
GPE kernels take KernelFlagDev* instead of int* flag

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherBrucksFF.cc
+++ b/comms/ctran/algos/AllGather/AllGatherBrucksFF.cc
@@ -2,11 +2,12 @@
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/DevUtils.cuh"
 
 __global__ void ncclKernelAllGatherCtranBrucks(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args);
 

--- a/comms/ctran/algos/AllGather/AllGatherBrucksFF.cu
+++ b/comms/ctran/algos/AllGather/AllGatherBrucksFF.cu
@@ -6,13 +6,14 @@
 #include "comms/ctran/gpe/CtranGpeDev.h"
 
 __global__ void ncclKernelAllGatherCtranBrucks(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
     ctran::device::KernelWaitGpeTerminate(flag);
   }
 }

--- a/comms/ctran/algos/AllGather/AllGatherDirect.cuh
+++ b/comms/ctran/algos/AllGather/AllGatherDirect.cuh
@@ -8,6 +8,7 @@
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/ctran/algos/DevAlgoImpl.cuh"
 #include "comms/ctran/algos/DevCommon.cuh"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/gpe/CtranGpeDev.h"
 
 __device__ inline void prepareBcastArg(
@@ -47,14 +48,15 @@ static __device__ __forceinline__ void bcastOnPost(
 
 template <typename T>
 __global__ void __launch_bounds__(1024, 1) ncclKernelAllGatherCtranDirect(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
   }
 
   devStateLoadToShm(devState);
@@ -70,6 +72,6 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelAllGatherCtranDirect(
 
 #define DECL_CTRAN_ALLGATHERDIRECT_KERN(T)                    \
   template __global__ void ncclKernelAllGatherCtranDirect<T>( \
-      int* flag,                                              \
-      CtranAlgoDeviceState* devState,                         \
+      ctran::gpe::KernelFlagDev * flag,                       \
+      CtranAlgoDeviceState * devState,                        \
       ctran::allgather::KernelArgs args)

--- a/comms/ctran/algos/AllGather/AllGatherRing.cu
+++ b/comms/ctran/algos/AllGather/AllGatherRing.cu
@@ -6,13 +6,14 @@
 #include "comms/ctran/gpe/CtranGpeDev.h"
 
 __global__ void ncclKernelAllGatherCtranRing(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
     ctran::device::KernelWaitGpeTerminate(flag);
   }
 }

--- a/comms/ctran/algos/AllGather/StreamedRd/Impl.cc
+++ b/comms/ctran/algos/AllGather/StreamedRd/Impl.cc
@@ -7,11 +7,12 @@
 #include "comms/ctran/algos/AllGather/StreamedRd/Common.h"
 #include "comms/ctran/algos/AllGather/StreamedRd/Plan.h"
 #include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/DevUtils.cuh"
 
 __global__ void ncclKernelAllGatherCtranStreamedRd(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args);
 

--- a/comms/ctran/algos/AllGather/StreamedRd/Impl.cu
+++ b/comms/ctran/algos/AllGather/StreamedRd/Impl.cu
@@ -6,13 +6,14 @@
 #include "comms/ctran/gpe/CtranGpeDev.h"
 
 __global__ void ncclKernelAllGatherCtranStreamedRd(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
     ctran::device::KernelWaitGpeTerminate(flag);
   }
 }

--- a/comms/ctran/algos/AllGatherP/DirectImpl.cc
+++ b/comms/ctran/algos/AllGatherP/DirectImpl.cc
@@ -6,6 +6,7 @@
 #include "comms/ctran/algos/AllGatherP/AlgoImpl.h"
 #include "comms/ctran/algos/AllGatherP/CommUtils.h"
 #include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/ExtUtils.h"
 #include "comms/utils/checks.h"
@@ -159,7 +160,7 @@ commResult_t gpnFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
 
 namespace ctran::allgatherp {
 extern __global__ void ncclKernelAllGatherPDirect(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState);
 
 commResult_t AlgoImpl::execDirect(

--- a/comms/ctran/algos/AllGatherP/DirectImpl.cu
+++ b/comms/ctran/algos/AllGatherP/DirectImpl.cu
@@ -2,15 +2,17 @@
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/ctran/algos/DevCommon.cuh"
 #include "comms/ctran/algos/barrier.cuh"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/gpe/CtranGpeDev.h"
 
 namespace ctran::allgatherp {
 __global__ void ncclKernelAllGatherPDirect(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
   }
 
   devStateLoadToShm(devState);

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -6,6 +6,7 @@
 #include "comms/ctran/algos/AllGatherP/CommUtils.h"
 #include "comms/ctran/algos/AllGatherP/Types.h"
 #include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/ExtUtils.h"
@@ -161,18 +162,18 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
 
 namespace ctran::allgatherp {
 extern __global__ void ncclKernelAllGatherPPipeStart(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState);
 extern __global__ void ncclKernelAllGatherPPipeSync(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     PipeSyncKernArgs args);
 extern __global__ void ncclKernelAllGatherPPipeEnd(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     PipeEndKernArgs args);
 extern __global__ void ncclKernelAllGatherPPipe(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState);
 
 commResult_t AlgoImpl::execPipeline(

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cu
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cu
@@ -4,6 +4,7 @@
 #include "comms/ctran/algos/DevCommon.cuh"
 #include "comms/ctran/algos/barrier.cuh"
 #include "comms/ctran/algos/common/GpeKernelSyncDev.cuh"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/gpe/CtranGpeDev.h"
 
 using namespace ctran::algos;
@@ -16,10 +17,11 @@ namespace ctran::allgatherp {
 // Used when nLocalRanks > 1 in allgatherP pipeline algorithm. It is called once
 // to start the algorithm
 __global__ void ncclKernelAllGatherPPipeStart(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
-    ctran::device::KernelStartGpeAndExit(flag);
+    ctran::device::KernelStartGpeAndExit(f);
   }
 }
 
@@ -28,9 +30,10 @@ __global__ void ncclKernelAllGatherPPipeStart(
 // Used when nLocalRanks > 1 in allgatherP pipeline algorithm. It is called
 // nNode - 1 times.
 __global__ void ncclKernelAllGatherPPipeSync(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     PipeSyncKernArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   ctran::device::devLoadAbortFlags(flag, devState);
   // wait till GPE thread post the current stepId
   GpeKernelSyncDev::waitPost(args.pipeSync, 0, args.stepId);
@@ -39,11 +42,12 @@ __global__ void ncclKernelAllGatherPPipeSync(
 // Stub kernel to hold stream while GPE thread does inter-node transfer.
 // Used when nLocalRanks == 1 in allgatherP pipeline algorithm
 __global__ void ncclKernelAllGatherPPipe(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
     ctran::device::KernelWaitGpeTerminate(flag);
   }
 }
@@ -52,7 +56,7 @@ __global__ void ncclKernelAllGatherPPipe(
 // broadcast. Used when nLocalRanks > 1 in allgatherP pipeline algorithm. It is
 // called once at the end.
 __global__ void ncclKernelAllGatherPPipeEnd(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     PipeEndKernArgs args) {
   // Reset sync flag for next GPE->kernel pipeline sync to use

--- a/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
@@ -13,6 +13,7 @@
 #include "comms/ctran/algos/AllGatherP/Types.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/algos/IPersistPlan.h"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/DevUtils.cuh"
@@ -166,18 +167,18 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
 
 namespace ctran::allgatherp {
 extern __global__ void ncclKernelAllGatherPPipeStart(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState);
 extern __global__ void ncclKernelAllGatherPPipeSync(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     PipeSyncKernArgs args);
 extern __global__ void ncclKernelAllGatherPPipeEnd(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     PipeEndKernArgs args);
 extern __global__ void ncclKernelAllGatherPPipe(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState);
 
 commResult_t AlgoImpl::execStreamedRecursiveDoubling(

--- a/comms/ctran/algos/AllReduce/AllReduceDirect.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceDirect.cuh
@@ -156,16 +156,17 @@ __device__ void algoFn(
 
 template <typename T, commRedOp_t RedOp>
 __global__ void ncclKernelAllReduceCtranDirect(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allreduce::KernelArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
 
   devStateLoadToShm(&flag[bId], devState);
 
   if (flag && tId == 0) {
-    ctran::device::KernelStartGpe(&flag[bId]);
+    ctran::device::KernelStartGpe(f, bId);
   }
 
   // Run algorithm main body
@@ -181,8 +182,8 @@ __global__ void ncclKernelAllReduceCtranDirect(
 
 #define DECL_CTRAN_ALLREDUCEDIRECT_KERN(T, RedOp)                    \
   template __global__ void ncclKernelAllReduceCtranDirect<T, RedOp>( \
-      int* flag,                                                     \
-      CtranAlgoDeviceState* devState,                                \
+      ctran::gpe::KernelFlagDev * flag,                              \
+      CtranAlgoDeviceState * devState,                               \
       ctran::allreduce::KernelArgs args);
 
 #endif

--- a/comms/ctran/algos/AllReduce/AllReduceRing.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cuh
@@ -393,9 +393,10 @@ __device__ void algoFn(ctran::allreduce::ring::KernArgs& args) {
 // - false: IB path (no kernel-side unpack)
 template <typename T, commRedOp_t RedOp, bool EnableBidirAg, bool Unpack>
 __global__ void ncclKernelAllReduceCtranRing(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allreduce::ring::KernArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
 
@@ -404,7 +405,7 @@ __global__ void ncclKernelAllReduceCtranRing(
   devStateLoadToShm(&flag[bId], devState);
 
   if (flag && tId == 0) {
-    ctran::device::KernelStartGpe(&flag[bId]);
+    ctran::device::KernelStartGpe(f, bId);
   }
 
   // Run algorithm main body
@@ -424,24 +425,24 @@ __global__ void ncclKernelAllReduceCtranRing(
 #define DECL_CTRAN_ALLREDUCERING_KERN_BIDIR(T, RedOp)  \
   template __global__ void                             \
   ncclKernelAllReduceCtranRing<T, RedOp, true, false>( \
-      int* flag,                                       \
-      CtranAlgoDeviceState* devState,                  \
+      ctran::gpe::KernelFlagDev * flag,                \
+      CtranAlgoDeviceState * devState,                 \
       ctran::allreduce::ring::KernArgs args);
 
 // Instantiation macro for simple kernel (no bidir AG, lower register usage)
 #define DECL_CTRAN_ALLREDUCERING_KERN_SIMPLE(T, RedOp)  \
   template __global__ void                              \
   ncclKernelAllReduceCtranRing<T, RedOp, false, false>( \
-      int* flag,                                        \
-      CtranAlgoDeviceState* devState,                   \
+      ctran::gpe::KernelFlagDev * flag,                 \
+      CtranAlgoDeviceState * devState,                  \
       ctran::allreduce::ring::KernArgs args);
 
 // Instantiation macro for simple kernel with TCPDM unpack
 #define DECL_CTRAN_ALLREDUCERING_KERN_SIMPLE_UNPACK(T, RedOp) \
   template __global__ void                                    \
   ncclKernelAllReduceCtranRing<T, RedOp, false, true>(        \
-      int* flag,                                              \
-      CtranAlgoDeviceState* devState,                         \
+      ctran::gpe::KernelFlagDev * flag,                       \
+      CtranAlgoDeviceState * devState,                        \
       ctran::allreduce::ring::KernArgs args);
 
 // Combined macro to instantiate all kernel variants

--- a/comms/ctran/algos/AllReduce/AllReduceRingCommon.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceRingCommon.cuh
@@ -6,6 +6,7 @@
 #include <chrono>
 
 #include "comms/ctran/algos/common/GpeKernelSync.h"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/utils/DevAttribute.h"
 #include "comms/utils/commSpecs.h"
 
@@ -586,7 +587,7 @@ template <
     bool EnableBidirAg,
     bool Unpack = false>
 __global__ void ncclKernelAllReduceCtranRing(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::allreduce::ring::KernArgs args);
 

--- a/comms/ctran/algos/AllToAll/AllToAll.cc
+++ b/comms/ctran/algos/AllToAll/AllToAll.cc
@@ -14,6 +14,7 @@
 #include "comms/prims/transport/Transport.cuh"
 #endif
 #include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/utils/CtranPerf.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -21,7 +22,7 @@
 #if defined(ENABLE_PRIMS)
 template <PipeProtocol Proto>
 extern __global__ void ncclKernelDeviceAllToAllvPipes(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::device_alltoallv_pipes::KernArgs args);
 #endif

--- a/comms/ctran/algos/AllToAll/AllToAll.cuh
+++ b/comms/ctran/algos/AllToAll/AllToAll.cuh
@@ -106,14 +106,15 @@ enum { GROUP_SEND, GROUP_RECV };
 
 template <typename T>
 __global__ void ncclKernelAllToAll(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::alltoall::KernelArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
   }
 
   // count==0 means no work for the kernel (e.g. pure-IB path where the
@@ -161,6 +162,6 @@ __global__ void ncclKernelAllToAll(
 
 #define DECL_CTRAN_ALLTOALL_KERN(T)               \
   template __global__ void ncclKernelAllToAll<T>( \
-      int* flag,                                  \
-      CtranAlgoDeviceState* devState,             \
+      ctran::gpe::KernelFlagDev * flag,           \
+      CtranAlgoDeviceState * devState,            \
       ctran::alltoall::KernelArgs args)

--- a/comms/ctran/algos/AllToAll/AllToAllDedup.cuh
+++ b/comms/ctran/algos/AllToAll/AllToAllDedup.cuh
@@ -50,14 +50,15 @@ static __device__ __forceinline__ void bcastOnPost(
 
 template <typename T>
 __global__ void ncclKernelAllToAllDedup(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::alltoalldedup::KernelArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
   }
 
   devStateLoadToShm(devState);
@@ -83,6 +84,6 @@ __global__ void ncclKernelAllToAllDedup(
 
 #define DECL_CTRAN_ALLTOALLDEDUP_KERN(T)               \
   template __global__ void ncclKernelAllToAllDedup<T>( \
-      int* flag,                                       \
-      CtranAlgoDeviceState* devState,                  \
+      ctran::gpe::KernelFlagDev * flag,                \
+      CtranAlgoDeviceState * devState,                 \
       ctran::alltoalldedup::KernelArgs args)

--- a/comms/ctran/algos/AllToAll/AllToAllv.cuh
+++ b/comms/ctran/algos/AllToAll/AllToAllv.cuh
@@ -136,14 +136,15 @@ enum { GROUP_SEND, GROUP_RECV };
 
 template <typename T>
 __global__ void ncclKernelAllToAllv(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::alltoallv::KernelArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
   }
 
   // No work for the kernel when all three are true: no NVL sends, no NVL
@@ -200,6 +201,6 @@ __global__ void ncclKernelAllToAllv(
 
 #define DECL_CTRAN_ALLTOALLV_KERN(T)               \
   template __global__ void ncclKernelAllToAllv<T>( \
-      int* flag,                                   \
-      CtranAlgoDeviceState* devState,              \
+      ctran::gpe::KernelFlagDev * flag,            \
+      CtranAlgoDeviceState * devState,             \
       ctran::alltoallv::KernelArgs args)

--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include "comms/ctran/algos/AllToAll/Types.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/prims/core/TiledBuffer.cuh"
 #include "comms/prims/core/Timeout.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
@@ -97,7 +98,7 @@ __device__ __forceinline__ void recv_peer(
 
 template <PipeProtocol Proto>
 __global__ void ncclKernelDeviceAllToAllvPipes(
-    int* /* flag */,
+    ctran::gpe::KernelFlagDev* /* flag */,
     CtranAlgoDeviceState* /* devState */,
     ctran::device_alltoallv_pipes::KernArgs args) {
   const int nLocalRanks = args.nLocalRanks;
@@ -187,12 +188,12 @@ __global__ void ncclKernelDeviceAllToAllvPipes(
 
 // Explicit template instantiations for both protocols.
 template __global__ void ncclKernelDeviceAllToAllvPipes<PipeProtocol::Simple>(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::device_alltoallv_pipes::KernArgs args);
 
 template __global__ void ncclKernelDeviceAllToAllvPipes<PipeProtocol::LL128>(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::device_alltoallv_pipes::KernArgs args);
 

--- a/comms/ctran/algos/Broadcast/Broadcast.cu
+++ b/comms/ctran/algos/Broadcast/Broadcast.cu
@@ -17,22 +17,23 @@ __shared__ UnpackBlockState broadcastUnpack;
 
 template <bool UNPACK>
 __global__ void __launch_bounds__(1024, 1) ncclKernelBroadcast(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::broadcast::KernelArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (UNPACK) {
     // Per-block flag management (matches SendRecv pattern) to avoid race
     // where block 0 clears the shared flag before other blocks exit waitUnpack.
     if (flag && threadIdx.x == 0) {
-      ctran::device::KernelStartGpe(&flag[blockIdx.x]);
+      ctran::device::KernelStartGpe(f, blockIdx.x);
     }
     devStateLoadToShm(&flag[blockIdx.x], devState);
   } else {
     if (flag && gtIdx == 0) {
       ctran::device::devLoadAbortFlags(flag, devState);
-      ctran::device::KernelStartGpe(flag);
+      ctran::device::KernelStartGpe(f);
     }
     devStateLoadToShm(devState);
   }
@@ -76,8 +77,8 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelBroadcast(
 
 #define DECL_BROADCAST_KERN(UNPACK)                     \
   template __global__ void ncclKernelBroadcast<UNPACK>( \
-      int* flag,                                        \
-      CtranAlgoDeviceState* devState,                   \
+      ctran::gpe::KernelFlagDev * flag,                 \
+      CtranAlgoDeviceState * devState,                  \
       ctran::broadcast::KernelArgs args)
 
 DECL_BROADCAST_KERN(/*UNPACK=*/false);

--- a/comms/ctran/algos/RMA/Get.cc
+++ b/comms/ctran/algos/RMA/Get.cc
@@ -5,6 +5,7 @@
 #include "Types.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/colltrace/CollTraceWrapper.h"
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/mapper/CtranMapper.h"
@@ -14,7 +15,9 @@
 using namespace ctran;
 using ::meta::comms::colltrace::CollTraceHandleTriggerState;
 
-extern __global__ void ncclKernelGet(int* flag, CtranAlgoDeviceState* devState);
+extern __global__ void ncclKernelGet(
+    ctran::gpe::KernelFlagDev* flag,
+    CtranAlgoDeviceState* devState);
 
 static commResult_t getImpl(
     const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {

--- a/comms/ctran/algos/RMA/Get.cu
+++ b/comms/ctran/algos/RMA/Get.cu
@@ -5,11 +5,14 @@
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/ctran/algos/common/GpeKernelDev.cuh"
 
-__global__ void ncclKernelGet(int* flag, CtranAlgoDeviceState* devState) {
+__global__ void ncclKernelGet(
+    ctran::gpe::KernelFlagDev* f,
+    CtranAlgoDeviceState* devState) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
     ctran::device::KernelWaitGpeTerminate(flag);
   }
 }

--- a/comms/ctran/algos/RMA/PutSignal.cc
+++ b/comms/ctran/algos/RMA/PutSignal.cc
@@ -7,6 +7,7 @@
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/algos/RMA/Types.h"
 #include "comms/ctran/algos/RMA/WaitSignalImpl.h"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/colltrace/CollTraceWrapper.h"
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/mapper/CtranMapper.h"
@@ -18,29 +19,31 @@ using namespace ctran;
 using meta::comms::colltrace::CollTraceHandleTriggerState;
 
 extern __global__ void ncclKernelPutNotify(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::rma::KernelPutNotifyArgs args);
 
 extern __global__ void ncclKernelWaitNotify(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::rma::KernelWaitNotifyArgs args);
 
 extern __global__ void ncclKernelPutSignal(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     CtranKernelPutSignalArgs args);
 
-extern __global__ void ncclKernelPut(int* flag, CtranAlgoDeviceState* devState);
+extern __global__ void ncclKernelPut(
+    ctran::gpe::KernelFlagDev* flag,
+    CtranAlgoDeviceState* devState);
 
 extern __global__ void ncclKernelWaitSignal(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     CtranKernelWaitSignalArgs args);
 
 extern __global__ void ncclKernelSignal(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     CtranKernelSignalArgs args);
 

--- a/comms/ctran/algos/RMA/PutSignal.cu
+++ b/comms/ctran/algos/RMA/PutSignal.cu
@@ -14,13 +14,14 @@
 #include "comms/ctran/gpe/CtranGpeDev.h"
 
 __global__ void ncclKernelPutNotify(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::rma::KernelPutNotifyArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
   }
 
   // Avoid copy
@@ -45,13 +46,14 @@ __global__ void ncclKernelPutNotify(
 }
 
 __global__ void ncclKernelWaitNotify(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::rma::KernelWaitNotifyArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
   }
 
   const auto& statex_ = devState->statex;
@@ -75,13 +77,14 @@ __global__ void ncclKernelWaitNotify(
 }
 
 __global__ void ncclKernelPutSignal(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     CtranKernelPutSignalArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
   }
   // just atomic store
   if (gtIdx == 0 && args.signalAddr != nullptr) {
@@ -100,23 +103,27 @@ __global__ void ncclKernelPutSignal(
   }
 }
 
-__global__ void ncclKernelPut(int* flag, CtranAlgoDeviceState* devState) {
+__global__ void ncclKernelPut(
+    ctran::gpe::KernelFlagDev* f,
+    CtranAlgoDeviceState* devState) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
     ctran::device::KernelWaitGpeTerminate(flag);
   }
 }
 
 __global__ void ncclKernelWaitSignal(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     CtranKernelWaitSignalArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
   }
 
   if (args.signalAddr != nullptr && gtIdx == 0) {
@@ -137,13 +144,14 @@ __global__ void ncclKernelWaitSignal(
 }
 
 __global__ void ncclKernelSignal(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     CtranKernelSignalArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
   }
   if (gtIdx == 0 && args.signalAddr != nullptr) {
 #if defined(__HIP_PLATFORM_AMD__)

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterDirect.cuh
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterDirect.cuh
@@ -128,9 +128,10 @@ __device__ void reduceScatterDirect(ctran::reducescatter::KernelArgs& args) {
 
 template <typename T, commRedOp_t RedOp>
 __global__ void __launch_bounds__(1024, 1) ncclKernelReduceScatterDirect(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::reducescatter::KernelArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   // TODO(T243528798): remove this preload of devstate by splitting h2d/d2h
   // channels.
   shmDevState.enableCancellableWaits = devState->enableCancellableWaits;
@@ -138,7 +139,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelReduceScatterDirect(
 
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
   }
 
   devStateLoadToShm(devState);
@@ -156,8 +157,8 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelReduceScatterDirect(
 #define DECL_CTRAN_REDUCESCATTERDIRECT_KERN(T, RedOp) \
   template __global__ void __launch_bounds__(1024, 1) \
       ncclKernelReduceScatterDirect<T, RedOp>(        \
-          int* flag,                                  \
-          CtranAlgoDeviceState* devState,             \
+          ctran::gpe::KernelFlagDev * flag,           \
+          CtranAlgoDeviceState * devState,            \
           ctran::reducescatter::KernelArgs args)
 
 #endif

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterRHD.cuh
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterRHD.cuh
@@ -15,14 +15,15 @@
 
 template <typename T, commRedOp_t RedOp>
 __global__ void __launch_bounds__(1024, 1) ncclKernelReduceScatterRHD(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::reducescatter::KernelArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
   }
 
   devStateLoadToShm(devState);
@@ -45,8 +46,8 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelReduceScatterRHD(
 #define DECL_CTRAN_REDUCESCATTERRHD_KERN(T, RedOp)    \
   template __global__ void __launch_bounds__(1024, 1) \
       ncclKernelReduceScatterRHD<T, RedOp>(           \
-          int* flag,                                  \
-          CtranAlgoDeviceState* devState,             \
+          ctran::gpe::KernelFlagDev * flag,           \
+          CtranAlgoDeviceState * devState,            \
           ctran::reducescatter::KernelArgs args)
 
 #endif

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterRing.cuh
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterRing.cuh
@@ -15,14 +15,15 @@
 
 template <typename T, commRedOp_t RedOp>
 __global__ void __launch_bounds__(1024, 1) ncclKernelReduceScatterRing(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::reducescatter::KernelArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
   }
 
   devStateLoadToShm(devState);
@@ -45,8 +46,8 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelReduceScatterRing(
 #define DECL_CTRAN_REDUCESCATTERRING_KERN(T, RedOp)   \
   template __global__ void __launch_bounds__(1024, 1) \
       ncclKernelReduceScatterRing<T, RedOp>(          \
-          int* flag,                                  \
-          CtranAlgoDeviceState* devState,             \
+          ctran::gpe::KernelFlagDev * flag,           \
+          CtranAlgoDeviceState * devState,            \
           ctran::reducescatter::KernelArgs args)
 
 #endif

--- a/comms/ctran/algos/SendRecv/SendRecv.cu
+++ b/comms/ctran/algos/SendRecv/SendRecv.cu
@@ -16,14 +16,15 @@ __shared__ UnpackBlockState sendRecvUnpack;
 #endif
 
 __global__ void __launch_bounds__(1024, 1) ncclKernelSend(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::sendrecv::KernelSendArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
 
   if (flag && tId == 0) {
-    ctran::device::KernelStartGpe(&flag[bId]);
+    ctran::device::KernelStartGpe(f, bId);
   }
 
   // TODO(T243528798): remove this preload of devstate by splitting h2d/d2h
@@ -46,14 +47,15 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelSend(
 // it can potentially require unpack with TCP DM backend.
 template <bool UNPACK>
 __global__ void __launch_bounds__(1024, 1) ncclKernelRecv(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::sendrecv::KernelRecvArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
 
   if (flag && tId == 0) {
-    ctran::device::KernelStartGpe(&flag[bId]);
+    ctran::device::KernelStartGpe(f, bId);
   }
 
   // TODO(T243528798): remove this preload of devstate by splitting h2d/d2h
@@ -86,14 +88,15 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelRecv(
 
 template <bool UNPACK>
 __global__ void __launch_bounds__(1024, 1) ncclKernelSendRecv(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::sendrecv::KernelSendRecvArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
 
   if (flag && tId == 0) {
-    ctran::device::KernelStartGpe(&flag[bId]);
+    ctran::device::KernelStartGpe(f, bId);
   }
 
   // TODO(T243528798): remove this preload of devstate by splitting h2d/d2h
@@ -133,12 +136,12 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelSendRecv(
 
 #define DECL_SENDRECV_KERN(UNPACK)                     \
   template __global__ void ncclKernelRecv<UNPACK>(     \
-      int* flag,                                       \
-      CtranAlgoDeviceState* devState,                  \
+      ctran::gpe::KernelFlagDev * flag,                \
+      CtranAlgoDeviceState * devState,                 \
       ctran::sendrecv::KernelRecvArgs args);           \
   template __global__ void ncclKernelSendRecv<UNPACK>( \
-      int* flag,                                       \
-      CtranAlgoDeviceState* devState,                  \
+      ctran::gpe::KernelFlagDev * flag,                \
+      CtranAlgoDeviceState * devState,                 \
       ctran::sendrecv::KernelSendRecvArgs args)
 
 DECL_SENDRECV_KERN(/*UNPACK=*/false);

--- a/comms/ctran/algos/SendRecv/SendRecvP2p.cu
+++ b/comms/ctran/algos/SendRecv/SendRecvP2p.cu
@@ -74,15 +74,16 @@ __device__ __forceinline__ void recvImpl(
 }
 
 __global__ __launch_bounds__(512, 1) void ncclKernelSendRecvP2p(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState, // TODO: this is not needed for now, but
                                     // maybe needed for fault-tolerance
     ctran::sendrecv::KernArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
   }
 
   auto group = args.useBlockGroup ? comms::prims::make_block_group()

--- a/comms/ctran/algos/common/GpeKernelDev.cuh
+++ b/comms/ctran/algos/common/GpeKernelDev.cuh
@@ -3,8 +3,10 @@
 #pragma once
 
 #include "comms/common/AtomicUtils.cuh"
+#include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/ctran/algos/DevShmState.cuh"
 #include "comms/ctran/algos/common/GpeKernel.h"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/utils/DevUtils.cuh"
 
 // This file includes only functions to manage Gpe and device kernel lifecycles.
@@ -24,11 +26,36 @@ static inline __device__ void devLoadAbortFlags(
   kernelFlag = flag;
   kernelDoAbort = false;
 }
+
+// Publish this cmd's id to the per-comm device dispatch ring, in GPU execution
+// order, when the device-ring GPE path is armed for this launch. The ring
+// header (GpeKernelFlagHeader) is co-located in the KernelFlagItem immediately
+// after its flag array, so it is recovered from `flag` alone — no kernel needs
+// a dedicated ring parameter. Single-writer election (block 0, thread 0). A
+// no-op when the ring is not armed (enabled == 0), e.g. eager launches, so it
+// is safe to call unconditionally at kernel start. The GPE worker consumes the
+// ring to learn which command started and in what order. The ring write is the
+// HRDWRingBuffer System-scope 128b atomic path (requires sm_90+).
+static __forceinline__ __device__ void KernelPublishGpeRing(
+    volatile int* flag) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    // flag points at KernelFlagItem::flag_[0]; the header sits right after the
+    // CTRAN_ALGO_MAX_THREAD_BLOCKS-int flag array.
+    auto* hdr = reinterpret_cast<ctran::gpe::GpeKernelFlagHeader*>(
+        const_cast<int*>(flag + CTRAN_ALGO_MAX_THREAD_BLOCKS));
+    if (hdr->enabled) {
+      hdr->ring.write(hdr->cmdId);
+    }
+  }
+}
+
 static inline __device__ void KernelStartGpe(volatile int* flag) {
+  KernelPublishGpeRing(flag);
   comms::device::st_volatile_global(flag, KERNEL_STARTED);
 }
 
 static inline __device__ void KernelStartGpeAndExit(volatile int* flag) {
+  KernelPublishGpeRing(flag);
   comms::device::st_volatile_global(flag, KERNEL_STARTED_AND_EXIT);
 }
 

--- a/comms/ctran/algos/common/GpeKernelDev.cuh
+++ b/comms/ctran/algos/common/GpeKernelDev.cuh
@@ -27,36 +27,32 @@ static inline __device__ void devLoadAbortFlags(
   kernelDoAbort = false;
 }
 
-// Publish this cmd's id to the per-comm device dispatch ring, in GPU execution
-// order, when the device-ring GPE path is armed for this launch. The ring
-// header (GpeKernelFlagHeader) is co-located in the KernelFlagItem immediately
-// after its flag array, so it is recovered from `flag` alone — no kernel needs
-// a dedicated ring parameter. Single-writer election (block 0, thread 0). A
-// no-op when the ring is not armed (enabled == 0), e.g. eager launches, so it
-// is safe to call unconditionally at kernel start. The GPE worker consumes the
-// ring to learn which command started and in what order. The ring write is the
-// HRDWRingBuffer System-scope 128b atomic path (requires sm_90+).
+// Publish this launch's cmd id to the device ring in GPU execution order.
+// Single-writer election (block 0, thread 0); no-op when not armed
+// (hdr.enabled == 0). The GPE worker consumes the ring to order started cmds.
+// The ring write is the HRDWRingBuffer System-scope 128b atomic path.
 static __forceinline__ __device__ void KernelPublishGpeRing(
-    volatile int* flag) {
-  if (blockIdx.x == 0 && threadIdx.x == 0) {
-    // flag points at KernelFlagItem::flag_[0]; the header sits right after the
-    // CTRAN_ALGO_MAX_THREAD_BLOCKS-int flag array.
-    auto* hdr = reinterpret_cast<ctran::gpe::GpeKernelFlagHeader*>(
-        const_cast<int*>(flag + CTRAN_ALGO_MAX_THREAD_BLOCKS));
-    if (hdr->enabled) {
-      hdr->ring.write(hdr->cmdId);
-    }
+    ctran::gpe::GpeKernelFlagHeader hdr) {
+  if (blockIdx.x == 0 && threadIdx.x == 0 && hdr.enabled) {
+    hdr.ring.write(hdr.cmdId);
   }
 }
 
-static inline __device__ void KernelStartGpe(volatile int* flag) {
-  KernelPublishGpeRing(flag);
-  comms::device::st_volatile_global(flag, KERNEL_STARTED);
+// Kernel start prologue: publish this cmd's id to the ring (block 0 only, no-op
+// when not armed), then signal the GPE worker that block `bId` has started. The
+// ring header is read directly from f->gpeHdr — no pointer-offset recovery.
+static inline __device__ void KernelStartGpe(
+    ctran::gpe::KernelFlagDev* f,
+    int bId = 0) {
+  KernelPublishGpeRing(f->gpeHdr);
+  comms::device::st_volatile_global(&f->flag_[bId], KERNEL_STARTED);
 }
 
-static inline __device__ void KernelStartGpeAndExit(volatile int* flag) {
-  KernelPublishGpeRing(flag);
-  comms::device::st_volatile_global(flag, KERNEL_STARTED_AND_EXIT);
+static inline __device__ void KernelStartGpeAndExit(
+    ctran::gpe::KernelFlagDev* f,
+    int bId = 0) {
+  KernelPublishGpeRing(f->gpeHdr);
+  comms::device::st_volatile_global(&f->flag_[bId], KERNEL_STARTED_AND_EXIT);
 }
 
 static inline __device__ bool KernelTestHostAbort(volatile int* flag) {

--- a/comms/ctran/algos/common/GpeRing.h
+++ b/comms/ctran/algos/common/GpeRing.h
@@ -1,0 +1,52 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#ifndef CTRAN_GPE_RING_H_
+#define CTRAN_GPE_RING_H_
+
+#include <cstdint>
+
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+
+namespace ctran::gpe {
+
+// The GPE dispatch ring is System-scope (host worker polls concurrently) and
+// Blocking (lossless): a captured kernel that publishes its cmd id must never
+// have that publish silently overwritten before the worker consumes it, or the
+// cmd would never fire and its kernel would hang on KERNEL_TERMINATE. Declaring
+// the ring, reader, and handle from these shared constants makes "the worker
+// sees every publish" a structural property — the Blocking ring allocates the
+// consumer cursor and its reader publishes it, inseparably.
+inline constexpr auto kGpeRingScope =
+    hrdw_ring_buffer::MemoryCoherenceScope::System;
+inline constexpr auto kGpeRingPolicy = hrdw_ring_buffer::WritePolicy::Blocking;
+
+// Comm-local command id assigned at submit() time. 64-bit so a long-lived comm
+// can never wrap it back through the reserved 0 ("unassigned") sentinel or onto
+// a still-live id, even at millions of captured cmds/sec for the process
+// lifetime. It fits the ring's 16-byte entry either way, so the width is free.
+using GpeCmdId = uint64_t;
+
+// Ring entries carry a comm-local command id assigned at submit() time. The
+// GPE worker maps the id back to its CtranGpeCmd via the per-comm registry.
+// (GpeRingReader is host-only and lives in CtranGpeImpl.h — this header is
+// device-included and must not pull in the host reader.)
+using GpeRing =
+    hrdw_ring_buffer::HRDWRingBuffer<GpeCmdId, kGpeRingScope, kGpeRingPolicy>;
+using GpeRingHandle = hrdw_ring_buffer::
+    HRDWRingBufferDeviceHandle<GpeCmdId, kGpeRingScope, kGpeRingPolicy>;
+
+// Co-located in each per-cmd KernelFlagItem, immediately after its flag array.
+// The GPE fills these host-side at submit() on the device-ring path (per-cmd,
+// so no concurrent-kernel race); the kernel's KernelStartGpe prologue recovers
+// this header from the flag pointer and publishes cmdId to the ring. This is
+// how a kernel becomes ring-capable WITHOUT a dedicated ring parameter — every
+// GPE kernel already receives its flag and already calls KernelStartGpe.
+struct GpeKernelFlagHeader {
+  GpeRingHandle ring{};
+  GpeCmdId cmdId{0};
+  uint32_t enabled{0};
+};
+
+} // namespace ctran::gpe
+
+#endif // CTRAN_GPE_RING_H_

--- a/comms/ctran/algos/common/GpeRing.h
+++ b/comms/ctran/algos/common/GpeRing.h
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 
+#include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
 namespace ctran::gpe {
@@ -35,16 +36,24 @@ using GpeRing =
 using GpeRingHandle = hrdw_ring_buffer::
     HRDWRingBufferDeviceHandle<GpeCmdId, kGpeRingScope, kGpeRingPolicy>;
 
-// Co-located in each per-cmd KernelFlagItem, immediately after its flag array.
-// The GPE fills these host-side at submit() on the device-ring path (per-cmd,
-// so no concurrent-kernel race); the kernel's KernelStartGpe prologue recovers
-// this header from the flag pointer and publishes cmdId to the ring. This is
-// how a kernel becomes ring-capable WITHOUT a dedicated ring parameter — every
-// GPE kernel already receives its flag and already calls KernelStartGpe.
+// Per-cmd ring header. The GPE fills it host-side at submit() on the
+// device-ring path (per-cmd, so no concurrent-kernel race); the kernel's
+// KernelStartGpe prologue reads it via KernelFlagDev::gpeHdr and publishes
+// cmdId to the ring.
 struct GpeKernelFlagHeader {
   GpeRingHandle ring{};
   GpeCmdId cmdId{0};
   uint32_t enabled{0};
+};
+
+// Device-facing view of a per-cmd kernel flag object: the per-block start/stop
+// flags plus the ring header, laid out in pinned host memory. Every GPE kernel
+// takes a KernelFlagDev* as its first argument and reads gpeHdr directly — no
+// pointer-offset recovery. KernelFlagItem (host) embeds this as its first
+// member, so &kernelFlag->dev is the pointer handed to the kernel.
+struct KernelFlagDev {
+  volatile int flag_[CTRAN_ALGO_MAX_THREAD_BLOCKS];
+  GpeKernelFlagHeader gpeHdr{};
 };
 
 } // namespace ctran::gpe

--- a/comms/ctran/algos/tests/CtranDevWaitUT.cc
+++ b/comms/ctran/algos/tests/CtranDevWaitUT.cc
@@ -18,8 +18,10 @@ class CtranDeviceWaitUT : public CtranStandaloneFixture {
   void SetUp() override {
     CtranStandaloneFixture::SetUp();
 
-    FB_CUDACHECKTHROW_EX_NOCOMM(
-        cudaHostAlloc(&flag_, kNBlocks * sizeof(int), cudaHostAllocDefault));
+    FB_CUDACHECKTHROW_EX_NOCOMM(cudaHostAlloc(
+        &kfd_, sizeof(ctran::gpe::KernelFlagDev), cudaHostAllocDefault));
+    *kfd_ = {};
+    flag_ = const_cast<int*>(kfd_->flag_);
     for (int i = 0; i < kNBlocks; i++) {
       *flag_ = KERNEL_STARTED;
     }
@@ -62,7 +64,7 @@ class CtranDeviceWaitUT : public CtranStandaloneFixture {
         /*rank=*/0,
         /*commHash=*/0,
         /*commDesc=*/std::string(""));
-    FB_CUDACHECKTHROW_EX_NOCOMM(cudaFreeHost(flag_));
+    FB_CUDACHECKTHROW_EX_NOCOMM(cudaFreeHost(kfd_));
   }
 
   void waitStreamFor(bool expectFinish, std::chrono::seconds secs) {
@@ -90,7 +92,7 @@ class CtranDeviceWaitUT : public CtranStandaloneFixture {
         cudaMemcpyHostToDevice));
 
     std::array<void*, 3> kernelArgs;
-    kernelArgs.at(0) = (void*)&flag_;
+    kernelArgs.at(0) = (void*)&kfd_;
     kernelArgs.at(1) = (void*)&devState_;
     kernelArgs.at(2) = (void*)&args_;
     dim3 grid = {kNBlocks, 1, 1};
@@ -154,6 +156,7 @@ class CtranDeviceWaitUT : public CtranStandaloneFixture {
   }
 
   int* flag_;
+  ctran::gpe::KernelFlagDev* kfd_{nullptr};
   CtranAlgoDeviceState* devState_;
   CtranTestDeviceWaitArgs args_;
 

--- a/comms/ctran/algos/tests/CtranDevWaitUTKernels.cu
+++ b/comms/ctran/algos/tests/CtranDevWaitUTKernels.cu
@@ -2,6 +2,7 @@
 
 #include "comms/ctran/algos/DevCommon.cuh"
 #include "comms/ctran/algos/common/GpeKernelSyncDev.cuh"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/algos/tests/CtranDevWaitUTKernels.cuh"
 
 namespace ctran::testing {
@@ -44,10 +45,11 @@ __device__ void testDeviceWait(int bId, CtranTestDeviceWaitArgs& args) {
 } // namespace ctran::testing
 
 __global__ void ncclKernelTestDeviceWait(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     CtranTestDeviceWaitArgs args) {
   const auto bId = blockIdx.x;
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
 
   devStateLoadToShm(&flag[bId], devState);
 

--- a/comms/ctran/algos/tests/CtranDevWaitUTKernels.cuh
+++ b/comms/ctran/algos/tests/CtranDevWaitUTKernels.cuh
@@ -2,6 +2,7 @@
 
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/ctran/algos/common/GpeKernelSync.h"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/gpe/CtranGpeDev.h"
 
 // Enumerate functions to test
@@ -37,6 +38,6 @@ struct CtranTestDeviceWaitArgs {
 };
 
 extern __global__ void ncclKernelTestDeviceWait(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     CtranTestDeviceWaitArgs args);

--- a/comms/ctran/gpe/CtranGpe.cc
+++ b/comms/ctran/gpe/CtranGpe.cc
@@ -361,6 +361,7 @@ CtranGpe::CtranGpe(
   this->pimpl->comm = comm;
   this->pimpl->cudaDev = cudaDev;
   this->pimpl->gpe = this;
+  this->pimpl->initDeviceRing();
   // The cvar is the kill-switch at this integration layer. When false,
   // the reporter is nulled regardless of caller injection — production
   // operators always control whether Scuba rows flow. The profiler still

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -19,6 +19,7 @@
 #include "comms/ctran/algos/ReduceScatter/Types.h"
 #include "comms/ctran/algos/SendRecv/Types.h"
 #include "comms/ctran/algos/common/GpeKernelSync.h"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/gpe/CtranGpeDev.h"
 #include "comms/ctran/profiler/IGpeProfilerReporter.h"
 #include "comms/ctran/utils/PinnedHostPool.h"
@@ -464,82 +465,82 @@ ncclKernelNvlBarrier(int rank, int nLocalRanks, CtranAlgoDeviceState* devState);
 
 template <typename T>
 extern __global__ void ncclKernelAllGatherCtranDirect(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args);
 
 __global__ void ncclKernelAllGatherCtranRing(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args);
 
 template <typename T, commRedOp_t RedOp>
 __global__ void ncclKernelAllReduceCtranDirect(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::allreduce::KernelArgs args);
 
 extern __global__ void ncclKernelSend(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::sendrecv::KernelSendArgs args);
 
 template <bool UNPACK>
 extern __global__ void ncclKernelRecv(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::sendrecv::KernelRecvArgs args);
 
 template <bool UNPACK>
 extern __global__ void ncclKernelSendRecv(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::sendrecv::KernelSendRecvArgs args);
 
 extern __global__ void ncclKernelSendRecvP2p(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::sendrecv::KernArgs args);
 
 template <bool UNPACK>
 __global__ void ncclKernelBroadcast(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::broadcast::KernelArgs args);
 
 template <typename T>
 extern __global__ void ncclKernelAllToAll(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::alltoall::KernelArgs args);
 
 template <typename T>
 extern __global__ void ncclKernelAllToAllv(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::alltoallv::KernelArgs args);
 
 template <typename T>
 extern __global__ void ncclKernelAllToAllDedup(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::alltoalldedup::KernelArgs args);
 
 template <typename T, commRedOp_t RedOp>
 __global__ void ncclKernelReduceScatterDirect(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::reducescatter::KernelArgs args);
 
 template <typename T, commRedOp_t RedOp>
 __global__ void ncclKernelReduceScatterRing(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::reducescatter::KernelArgs args);
 
 template <typename T, commRedOp_t RedOp>
 __global__ void ncclKernelReduceScatterRHD(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::reducescatter::KernelArgs args);
 

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -156,10 +156,22 @@ void CUDART_CB CtranGpe::Impl::cmdDestroy(void* data) {
   if (!cmd->persistent) {
     CLOGF(WARN, "CTranGPE: cmd desctructor called for non-persistent cmd");
   }
+  // Erase the registry entry BEFORE waiting on inFlight: erase() and the
+  // worker's lookupAndFire() are mutually exclusive under the registry lock, so
+  // once erase returns no new ring fire can resolve to this cmd and inFlight
+  // can only fall to 0 and stay there. Erasing after the wait would let the
+  // worker fire the cmd between our inFlight check and the erase, then touch
+  // freed memory; a late/duplicate ring entry now becomes an ignored miss
+  // instead.
+  if (cmd->inDeviceRingRegistry && cmd->gpe != nullptr) {
+    cmd->gpe->pimpl->deviceRingCmdRegistry().erase(cmd->cmdId);
+  }
   // Wait for the GPE thread to finish processing any queued instances of
   // this cmd before deleting. With KERNEL_STARTED_AND_EXIT persistent cmds,
   // the GPE processes cmds instantly (stale flag), so cmdCb enqueues from
   // graph replays may still be in the GPE queue when the graph is destroyed.
+  // On the device-ring path the same inFlight guard covers a fire the GPE
+  // worker looked up from the ring but has not finished processing.
   while (cmd->inFlight.load(std::memory_order_acquire) > 0) {
     std::this_thread::yield();
   }
@@ -325,7 +337,10 @@ commResult_t CtranGpe::Impl::submit(
   }
 
   // Set first kernel argument as kernelFlag if GPE op is not empty.
-  // Check it before passing opGroup to cmd
+  // Check it before passing opGroup to cmd. Device-ring dispatch needs no
+  // kernel argument: the ring header is armed on the kernel's flag object
+  // (KernelFlagItem::gpeHdr) and the kernel recovers it in its KernelStartGpe
+  // prologue, so the arg list is just (flag, devState, algoArgs).
   std::array<void*, 3> kernelArgs;
   kernelArgs.at(0) = (void*)&flag;
   kernelArgs.at(1) = (void*)&kernelConfig.args.devState_d;
@@ -422,12 +437,8 @@ commResult_t CtranGpe::Impl::submit(
       cmd->gpe = this->gpe;
 
       FB_COMMCHECKGOTO(
-          utils::cudagraph::addHostNode(
-              /*data=*/cmd,
-              /*execCallback=*/cmdCb,
-              /*destroyCallback=*/cmdDestroy,
-              kernelConfig.stream,
-              streamCaptureInfo),
+          publishCapturedCmd(
+              cmd, kernelFlag, kernelConfig.stream, streamCaptureInfo),
           res,
           fail);
     } else {
@@ -626,6 +637,54 @@ fail:
   return res;
 }
 
+commResult_t CtranGpe::Impl::publishCapturedCmd(
+    CtranGpeCmd* cmd,
+    KernelFlagItem* kernelFlag,
+    cudaStream_t stream,
+    ctran::utils::cudagraph::StreamCaptureInfo& streamCaptureInfo) {
+  // Device-ring dispatch: when the ring is enabled and this cmd has a
+  // kernel flag (so its kernel runs the KernelStartGpe prologue and will
+  // publish), skip the in-graph HOST node entirely. Arm the ring via the
+  // flag's co-located header (GpeKernelFlagHeader) — no kernel parameter
+  // needed — then retain the cmd on the graph so it is freed at
+  // cudaGraphDestroy just as the host-node path retained it. The graph then
+  // self-drives via the ring at replay, avoiding the driver's blocking
+  // host-node launch. Cmds without a kernel flag (e.g. empty-opGroup sync
+  // kernels) never publish, so they keep the host-node path.
+  //
+  // No live-set sizing gate is needed: the ring is WritePolicy::Blocking,
+  // so a publish into a full ring backpressures the writer (spins until the
+  // GPE worker frees a slot) rather than lapping an unconsumed entry. The
+  // worker drains independently, so a blocked start-publish is always
+  // released; an undersized ring only throttles (logged), never loses a
+  // fire. cmdRegistry_ may therefore exceed the ring size and still use it.
+  const bool ringPath = deviceRingEnabled() && kernelFlag != nullptr;
+  if (ringPath) {
+    // Retain the cmd on the graph FIRST so a retain failure leaves no
+    // registry entry to clean up; only then register it and arm the ring
+    // header. (Registering before retain would leak a dangling registry
+    // entry on the fail path.)
+    FB_COMMCHECK(
+        utils::cudagraph::retainUserObject(
+            /*obj=*/cmd,
+            /*destroyCallback=*/cmdDestroy,
+            streamCaptureInfo));
+    ctran::gpe::GpeCmdId id = deviceRingCmdRegistry_.registerCmd(cmd);
+    kernelFlag->gpeHdr.ring = deviceRingHandle();
+    kernelFlag->gpeHdr.cmdId = id;
+    kernelFlag->gpeHdr.enabled = 1;
+  } else {
+    FB_COMMCHECK(
+        utils::cudagraph::addHostNode(
+            /*data=*/cmd,
+            /*execCallback=*/cmdCb,
+            /*destroyCallback=*/cmdDestroy,
+            stream,
+            streamCaptureInfo));
+  }
+  return commSuccess;
+}
+
 commResult_t CtranGpe::Impl::submitHost(
     CtranGpeCmd::TypeEnum type,
     std::vector<std::unique_ptr<struct OpElem>> opGroup,
@@ -679,6 +738,12 @@ void CtranGpe::Impl::terminate() {
   cmd->type = CtranGpeCmd::TypeEnum::TERMINATE;
 
   cmdEnqueue(cmd);
+  // Release any device writer still blocked in the ring's backpressure spin:
+  // once the worker stops draining it would never free their slot, hanging the
+  // kernel. The abort flag makes them publish-and-continue instead.
+  if (deviceRingEnabled()) {
+    deviceRing_->requestAbort();
+  }
   thread_.join();
 
   // Pool elements are released by CUDA's async cmdDestroy callback
@@ -756,7 +821,7 @@ void CtranGpe::Impl::gpeThreadFn() {
 
     while (1) {
       gpeProfiler_->mark(ctran::GpeTracePoint::ITER_START);
-      auto cmd = cmdDequeue();
+      auto cmd = acquireNextCmd();
       injectGpeProfilerMetadata(cmd);
       gpeProfiler_->mark(ctran::GpeTracePoint::CMD_DEQUEUE);
 
@@ -800,6 +865,16 @@ void CtranGpe::Impl::gpeThreadFn() {
 
       if (cmd->type == CtranGpeCmd::TypeEnum::TERMINATE) {
         gpeProfiler_->mark(ctran::GpeTracePoint::TERMINATE_CMD);
+        // TERMINATE preempts ringPending_, so cmds already fired from the ring
+        // (inFlight bumped in lookupAndFire) but not yet returned would strand
+        // with inFlight > 0 and hang cmdDestroy. Undo their bumps here.
+        while (!ringPending_.empty()) {
+          auto* pending = ringPending_.front();
+          ringPending_.pop();
+          if (pending->persistent) {
+            pending->inFlight.fetch_sub(1, std::memory_order_release);
+          }
+        }
         CLOGF_SUBSYS(
             INFO,
             INIT,

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -314,7 +314,7 @@ commResult_t CtranGpe::Impl::submit(
       (kernelConfig.postKernelCleanup && !isCapturing);
 
   auto kernelFlag = needsKernelFlag ? this->kernelFlagPool->pop() : nullptr;
-  volatile int* flag = nullptr;
+  ctran::gpe::KernelFlagDev* flagDev = nullptr;
   if (kernelFlag != nullptr) {
     // TODO: remove this allowlist once the per-block flag is enabled in all
     // kernels. This helps to reduce blast radius of the larger fix.
@@ -333,16 +333,15 @@ commResult_t CtranGpe::Impl::submit(
     } else {
       kernelFlag->numGroups_ = 1;
     }
-    flag = kernelFlag->flag_;
+    flagDev = &kernelFlag->dev;
   }
 
-  // Set first kernel argument as kernelFlag if GPE op is not empty.
-  // Check it before passing opGroup to cmd. Device-ring dispatch needs no
-  // kernel argument: the ring header is armed on the kernel's flag object
-  // (KernelFlagItem::gpeHdr) and the kernel recovers it in its KernelStartGpe
-  // prologue, so the arg list is just (flag, devState, algoArgs).
+  // First kernel argument is the KernelFlagDev* (per-block flags + ring
+  // header). The kernel reads flagDev->gpeHdr directly for ring dispatch;
+  // submit() arms it below on the ring path. Remaining args are (devState,
+  // algoArgs).
   std::array<void*, 3> kernelArgs;
-  kernelArgs.at(0) = (void*)&flag;
+  kernelArgs.at(0) = (void*)&flagDev;
   kernelArgs.at(1) = (void*)&kernelConfig.args.devState_d;
   if (kernelConfig.algoArgs) {
     // Use pointer to algoArgs if specified; otherwise, pass default
@@ -670,9 +669,9 @@ commResult_t CtranGpe::Impl::publishCapturedCmd(
             /*destroyCallback=*/cmdDestroy,
             streamCaptureInfo));
     ctran::gpe::GpeCmdId id = deviceRingCmdRegistry_.registerCmd(cmd);
-    kernelFlag->gpeHdr.ring = deviceRingHandle();
-    kernelFlag->gpeHdr.cmdId = id;
-    kernelFlag->gpeHdr.enabled = 1;
+    kernelFlag->dev.gpeHdr.ring = deviceRingHandle();
+    kernelFlag->dev.gpeHdr.cmdId = id;
+    kernelFlag->dev.gpeHdr.enabled = 1;
   } else {
     FB_COMMCHECK(
         utils::cudagraph::addHostNode(
@@ -890,7 +889,7 @@ void CtranGpe::Impl::gpeThreadFn() {
       // thus, wait for the kernel to launch
       KernelFlagItem* kernelFlag = cmd->kernelFlag;
       if (kernelFlag) {
-        volatile int* flag_d = kernelFlag->flag_;
+        volatile int* flag_d = kernelFlag->dev.flag_;
         // Here we check just flag_d[0]. This is ok because Kernel Start signal
         // is only used for tracing purposes. Before the flags are freed below
         // with reset, all block flags are checked.
@@ -994,7 +993,7 @@ void CtranGpe::Impl::gpeThreadFn() {
       gpeProfiler_->mark(ctran::GpeTracePoint::HOST_ALGO);
 
       if (kernelFlag) {
-        volatile int* flag_d = kernelFlag->flag_;
+        volatile int* flag_d = kernelFlag->dev.flag_;
         if (flag_d[0] == KERNEL_STARTED_AND_EXIT) {
           // Indicate kernel would exit without the terminate signal, thus free
           // the flag now

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -5,6 +5,8 @@
 
 #include <chrono>
 #include <condition_variable>
+#include <cstddef>
+#include <cstdint>
 #include <list>
 #include <mutex>
 #include <optional>
@@ -15,8 +17,10 @@
 #include <folly/Synchronized.h>
 #include "comms/ctran/algos/common/GpeKernel.h"
 #include "comms/ctran/algos/common/GpeKernelSync.h"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/gpe/CtranChecksum.h"
 #include "comms/ctran/gpe/CtranGpe.h"
+#include "comms/ctran/gpe/GpeDeviceRing.h"
 #include "comms/ctran/profiler/GpeProfiler.h"
 #include "comms/ctran/profiler/IGpeProfilerReporter.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
@@ -26,7 +30,7 @@
 
 struct CommLogData;
 
-struct KernelFlagItem {
+struct alignas(128) KernelFlagItem {
   using Self = KernelFlagItem;
 
   static const char* name() {
@@ -37,6 +41,9 @@ struct KernelFlagItem {
     for (int i = 0; i < numGroups_; i++) {
       flag_[i] = KERNEL_UNSET;
     }
+    // Clear the full ring header so enabled==1 always implies ring/cmdId are
+    // current; submit() re-arms it per-cmd on the ring path.
+    gpeHdr = {};
   }
 
   bool inUse() {
@@ -56,6 +63,9 @@ struct KernelFlagItem {
       flag_[i] = KERNEL_SCHEDULED;
     }
     numGroups_ = 1;
+    // Clear the full ring header (not just enabled) so a stale ring/cmdId can
+    // never be published; submit() re-arms it per-cmd on the ring path.
+    gpeHdr = {};
   }
 
   bool testFlagAllGroups(int flag) {
@@ -85,35 +95,24 @@ struct KernelFlagItem {
   }
 
   volatile int flag_[CTRAN_ALGO_MAX_THREAD_BLOCKS];
+  // Device-ring dispatch header. MUST be the first member after flag_: the
+  // kernel's KernelStartGpe prologue recovers it at
+  // flag + CTRAN_ALGO_MAX_THREAD_BLOCKS to publish its cmd id to the ring.
+  ctran::gpe::GpeKernelFlagHeader gpeHdr{};
   int numGroups_{1};
   // If true, inUse() always returns true — prevents reclaim() from stealing
   // the flag while a persistent cmd (graph capture) still owns it.
   // Not cleared by reset() — only cleared by clearPersistent().
   bool persistent_{false};
-  // padding for different KernelFlagItems to be on different cache lines.
-  static constexpr int kCacheLineSizeBytes = 128;
-  // -2 ints: one for numGroups_, one for persistent_ (padded to int)
-  int unused[(kCacheLineSizeBytes - 2 * sizeof(int)) / sizeof(int)];
 
   void _() {
     // Make sure KernelFlagItem satisfies the PinnedHostItem concept
     static_assert(PinnedHostItem<Self>);
 
-    // The following compile-time check is a hint of the memory usage
-    // KernelFlag uses 384 bytes of pinned memory
+    // gpeHdr must sit immediately after the flag array so the device prologue
+    // can recover it from the flag pointer via +CTRAN_ALGO_MAX_THREAD_BLOCKS.
     static_assert(
-        sizeof(Self) == 4 * CTRAN_ALGO_MAX_THREAD_BLOCKS + kCacheLineSizeBytes);
-
-    // Ensure two KernelFlagItems are on different cache lines.
-    //
-    // TODO(T238727523): evaluate the impact of multiple flags in the same
-    // KernelFlagItem on the same cache line. Each flag here is consumed by a
-    // separate block for Ctran device code.
-    //
-    // Note that the device side CancellableWaits feature is disabled by default
-    // for the device kernels, so these flags are used only for GPE <-> Kernel
-    // start and stop-syncs in such cases.
-    static_assert(sizeof(Self) % kCacheLineSizeBytes == 0);
+        offsetof(Self, gpeHdr) == sizeof(int) * CTRAN_ALGO_MAX_THREAD_BLOCKS);
   }
 };
 
@@ -155,6 +154,12 @@ class CtranGpeCmd {
   // deleting the cmd.
   std::atomic_uint32_t inFlight{0};
   CtranGpe* gpe{nullptr};
+
+  // Device-ring dispatch (NCCL_CTRAN_GPE_DEVICE_RING). cmdId is the comm-local
+  // id the kernel publishes to the ring; inDeviceRingRegistry marks that this
+  // cmd owns a registry entry cmdDestroy must erase. Set only on the ring path.
+  ctran::gpe::GpeCmdId cmdId{0};
+  bool inDeviceRingRegistry{false};
 
   std::optional<std::chrono::milliseconds> timeout{std::nullopt};
 
@@ -305,6 +310,30 @@ class CtranGpe::Impl {
   // terminate the GPE thread.
   void terminate();
 
+  // Allocate the per-comm device dispatch ring + reader when
+  // NCCL_CTRAN_GPE_DEVICE_RING is set (and supported). Called from the
+  // CtranGpe constructor once comm/cudaDev are wired. No-op (leaves the ring
+  // disabled) on HIP/pre-Hopper or if allocation fails, so callers silently
+  // fall back to the host-node path.
+  void initDeviceRing();
+
+  // True when the device-ring dispatch path is active for this comm.
+  bool deviceRingEnabled() const {
+    return deviceRing_ != nullptr;
+  }
+
+  // A lightweight device handle to the ring, stored in a cmd's KernelFlagItem
+  // header (GpeKernelFlagHeader) at submit. Only valid when
+  // deviceRingEnabled().
+  ctran::gpe::GpeRingHandle deviceRingHandle() const {
+    return deviceRing_->deviceHandle();
+  }
+
+  // Registry accessor used by submit() and the cmdDestroy callback.
+  GpeDeviceRingCmdRegistry& deviceRingCmdRegistry() {
+    return deviceRingCmdRegistry_;
+  }
+
   // Before enqueueing a command to the GPE, update the command if needed.
   // Currently, this is used for enabling cudagraph-aware AllToAll.
   inline commResult_t preLaunchGraphPrepare(
@@ -341,9 +370,35 @@ class CtranGpe::Impl {
   std::condition_variable cmdQueueCv_;
   std::thread thread_;
   OrderedWorkStreamGuard ws_;
+
+  // Device-ring dispatch state (NCCL_CTRAN_GPE_DEVICE_RING). Ring + reader are
+  // null unless the ring path is enabled. The reader and ringPending_ are
+  // owned exclusively by the GPE worker thread (single consumer).
+  std::unique_ptr<ctran::gpe::GpeRing> deviceRing_;
+  std::unique_ptr<ctran::gpe::GpeRingReader> deviceRingReader_;
+  std::queue<CtranGpeCmd*> ringPending_;
+  GpeDeviceRingCmdRegistry deviceRingCmdRegistry_;
+
   // Main function called by the GPE thread. It waits and handles any  commands
   // submitted to cmdQueue until the TERMINATE command is received.
   void gpeThreadFn();
+
+  // Return the next command for the GPE worker to process. Without the device
+  // ring this is exactly cmdDequeue() (blocking on the CPU FIFO). With the ring
+  // enabled it polls the CPU FIFO (for TERMINATE, eager, and non-ring cmds)
+  // and the device ring (for captured ring cmds, in GPU execution order),
+  // preferring the FIFO so TERMINATE/abort is never starved by ring traffic.
+  CtranGpeCmd* acquireNextCmd();
+
+  // Publish a captured (graph) cmd for replay: arm the device ring (no host
+  // node) when it is enabled, otherwise add an in-graph host node. Both retain
+  // the cmd on the graph so it is freed at cudaGraphDestroy. Extracted from
+  // submit() to keep that function short.
+  commResult_t publishCapturedCmd(
+      CtranGpeCmd* cmd,
+      KernelFlagItem* kernelFlag,
+      cudaStream_t stream,
+      ctran::utils::cudagraph::StreamCaptureInfo& streamCaptureInfo);
 
   // Enqueue a command and notify the GPE thread to wake up.
   inline void cmdEnqueue(CtranGpeCmd* cmd) {

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -39,11 +39,11 @@ struct alignas(128) KernelFlagItem {
 
   void reset() {
     for (int i = 0; i < numGroups_; i++) {
-      flag_[i] = KERNEL_UNSET;
+      dev.flag_[i] = KERNEL_UNSET;
     }
     // Clear the full ring header so enabled==1 always implies ring/cmdId are
     // current; submit() re-arms it per-cmd on the ring path.
-    gpeHdr = {};
+    dev.gpeHdr = {};
   }
 
   bool inUse() {
@@ -51,7 +51,7 @@ struct alignas(128) KernelFlagItem {
       return true;
     }
     for (int i = 0; i < numGroups_; i++) {
-      if (flag_[i] != KERNEL_UNSET) {
+      if (dev.flag_[i] != KERNEL_UNSET) {
         return true;
       }
     }
@@ -60,17 +60,17 @@ struct alignas(128) KernelFlagItem {
 
   void onPop() {
     for (int i = 0; i < CTRAN_ALGO_MAX_THREAD_BLOCKS; ++i) {
-      flag_[i] = KERNEL_SCHEDULED;
+      dev.flag_[i] = KERNEL_SCHEDULED;
     }
     numGroups_ = 1;
     // Clear the full ring header (not just enabled) so a stale ring/cmdId can
     // never be published; submit() re-arms it per-cmd on the ring path.
-    gpeHdr = {};
+    dev.gpeHdr = {};
   }
 
   bool testFlagAllGroups(int flag) {
     for (int i = 0; i < numGroups_; ++i) {
-      if (flag_[i] != flag) {
+      if (dev.flag_[i] != flag) {
         return false;
       }
     }
@@ -79,7 +79,7 @@ struct alignas(128) KernelFlagItem {
 
   void setFlagPerGroup(int flag) {
     for (int i = 0; i < numGroups_; ++i) {
-      flag_[i] = flag;
+      dev.flag_[i] = flag;
     }
   }
 
@@ -94,11 +94,10 @@ struct alignas(128) KernelFlagItem {
     persistent_ = false;
   }
 
-  volatile int flag_[CTRAN_ALGO_MAX_THREAD_BLOCKS];
-  // Device-ring dispatch header. MUST be the first member after flag_: the
-  // kernel's KernelStartGpe prologue recovers it at
-  // flag + CTRAN_ALGO_MAX_THREAD_BLOCKS to publish its cmd id to the ring.
-  ctran::gpe::GpeKernelFlagHeader gpeHdr{};
+  // Device-facing flag object (per-block flags + ring header). Passed to the
+  // kernel as &dev (a ctran::gpe::KernelFlagDev*); MUST be the first member so
+  // that pointer is at offset 0 of the KernelFlagItem.
+  ctran::gpe::KernelFlagDev dev;
   int numGroups_{1};
   // If true, inUse() always returns true — prevents reclaim() from stealing
   // the flag while a persistent cmd (graph capture) still owns it.
@@ -108,11 +107,6 @@ struct alignas(128) KernelFlagItem {
   void _() {
     // Make sure KernelFlagItem satisfies the PinnedHostItem concept
     static_assert(PinnedHostItem<Self>);
-
-    // gpeHdr must sit immediately after the flag array so the device prologue
-    // can recover it from the flag pointer via +CTRAN_ALGO_MAX_THREAD_BLOCKS.
-    static_assert(
-        offsetof(Self, gpeHdr) == sizeof(int) * CTRAN_ALGO_MAX_THREAD_BLOCKS);
   }
 };
 

--- a/comms/ctran/gpe/GpeDeviceRing.cc
+++ b/comms/ctran/gpe/GpeDeviceRing.cc
@@ -65,9 +65,9 @@ void GpeDeviceRingCmdRegistry::recordRingReplay(CtranGpeCmd* cmd) {
 
 void CtranGpe::Impl::initDeviceRing() {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_HCC__)
-  // System-scope 128b atomic exchange (the ring's device write) requires sm_90+
-  // NVIDIA hardware; on HIP the write traps. Keep the ring disabled so the
-  // host-node path is used, matching NVIDIA pre-Hopper behavior.
+  // System-scope 128b atomic exchange (the ring's device write) requires
+  // sm_90+ NVIDIA hardware; on HIP the write traps. Keep the ring disabled so
+  // the host-node path is used, matching NVIDIA pre-Hopper behavior.
   return;
 #else
   if (!NCCL_CTRAN_GPE_DEVICE_RING) {

--- a/comms/ctran/gpe/GpeDeviceRing.cc
+++ b/comms/ctran/gpe/GpeDeviceRing.cc
@@ -1,0 +1,206 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/ctran/gpe/GpeDeviceRing.h"
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+
+#include "comms/ctran/gpe/CtranGpeImpl.h"
+#include "comms/ctran/utils/CudaWrap.h"
+#include "comms/ctran/utils/Debug.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/LogUtils.h"
+
+ctran::gpe::GpeCmdId GpeDeviceRingCmdRegistry::registerCmd(CtranGpeCmd* cmd) {
+  ctran::gpe::GpeCmdId id = nextId_.fetch_add(1, std::memory_order_relaxed);
+  cmd->cmdId = id;
+  cmd->inDeviceRingRegistry = true;
+  map_.wlock()->insert_or_assign(id, cmd);
+  return id;
+}
+
+CtranGpeCmd* GpeDeviceRingCmdRegistry::lookup(ctran::gpe::GpeCmdId id) const {
+  auto locked = map_.rlock();
+  auto it = locked->find(id);
+  return it == locked->end() ? nullptr : it->second;
+}
+
+CtranGpeCmd* GpeDeviceRingCmdRegistry::lookupAndFire(ctran::gpe::GpeCmdId id) {
+  // Hold the map lock across BOTH the lookup and recordRingReplay so the pair
+  // is atomic with erase(): once erase() removes the entry, no further fire can
+  // be applied, so the cmd's inFlight can only fall to 0 and stay there. This
+  // makes the erase-then-wait teardown in cmdDestroy() safe — otherwise a fire
+  // looked up but not yet counted could bump inFlight after cmdDestroy's wait
+  // passed, and the worker would touch freed memory.
+  auto locked = map_.rlock();
+  auto it = locked->find(id);
+  if (it == locked->end()) {
+    return nullptr;
+  }
+  recordRingReplay(it->second);
+  return it->second;
+}
+
+void GpeDeviceRingCmdRegistry::erase(ctran::gpe::GpeCmdId id) {
+  map_.wlock()->erase(id);
+}
+
+size_t GpeDeviceRingCmdRegistry::size() const {
+  return map_.rlock()->size();
+}
+
+void GpeDeviceRingCmdRegistry::recordRingReplay(CtranGpeCmd* cmd) {
+  // Mirror cmdCb's per-replay bookkeeping: each ring entry is one fire (one
+  // graph replay), so bump inFlight (paired with the worker's fetch_sub and
+  // awaited by cmdDestroy) and advance each op's opCount.
+  if (!cmd->persistent) {
+    return;
+  }
+  cmd->inFlight.fetch_add(1, std::memory_order_release);
+  for (auto& op : cmd->coll.opGroup) {
+    ++op->opCount;
+  }
+}
+
+void CtranGpe::Impl::initDeviceRing() {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_HCC__)
+  // System-scope 128b atomic exchange (the ring's device write) requires sm_90+
+  // NVIDIA hardware; on HIP the write traps. Keep the ring disabled so the
+  // host-node path is used, matching NVIDIA pre-Hopper behavior.
+  return;
+#else
+  if (!NCCL_CTRAN_GPE_DEVICE_RING) {
+    return;
+  }
+  // The ring's device write is a System-scope 128b atomic exchange, which
+  // requires sm_90+ (Hopper). On older NVIDIA GPUs that instruction traps, so
+  // gate on the actual compute capability and fall back to the host-node path.
+  // Queried once per process (-1 = query failed).
+  static const int ccMajor = [] {
+    int dev = 0;
+    int major = 0;
+    if (cudaGetDevice(&dev) != cudaSuccess ||
+        cudaDeviceGetAttribute(
+            &major, cudaDevAttrComputeCapabilityMajor, dev) != cudaSuccess) {
+      return -1;
+    }
+    return major;
+  }();
+  if (ccMajor < 0) {
+    CLOGF(
+        WARN,
+        "CTRAN-GPE: could not query compute capability; leaving device ring disabled");
+    return;
+  }
+  if (ccMajor < 9) {
+    CLOGF_SUBSYS(
+        INFO,
+        INIT,
+        "CTRAN-GPE: device ring requires sm_90+ (found compute capability {}.x); using host-node dispatch",
+        ccMajor);
+    return;
+  }
+  // Validate the (signed) cvar before casting to uint32_t: a non-positive
+  // value would otherwise wrap to a huge size and attempt an absurd pinned
+  // allocation. Reject it with a clear diagnostic and fall back to host nodes.
+  const int configuredRingSize = NCCL_CTRAN_GPE_DEVICE_RING_SIZE;
+  if (configuredRingSize <= 0) {
+    CLOGF(
+        WARN,
+        "CTRAN-GPE: NCCL_CTRAN_GPE_DEVICE_RING_SIZE={} must be > 0; using host-node dispatch",
+        configuredRingSize);
+    return;
+  }
+  auto ring = std::make_unique<ctran::gpe::GpeRing>(
+      static_cast<uint32_t>(configuredRingSize));
+  if (!ring->valid()) {
+    CLOGF(
+        WARN,
+        "CTRAN-GPE: device ring allocation failed; falling back to host-node dispatch");
+    return;
+  }
+  deviceRingReader_ = std::make_unique<ctran::gpe::GpeRingReader>(*ring);
+  deviceRing_ = std::move(ring);
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "CTRAN-GPE: device-ring dispatch enabled (ring size {})",
+      deviceRing_->size());
+#endif
+}
+
+CtranGpeCmd* CtranGpe::Impl::acquireNextCmd() {
+  if (!deviceRingEnabled()) {
+    // Unchanged legacy path: block on the CPU FIFO.
+    return cmdDequeue();
+  }
+
+  // Ring path: consume from two sources without blocking on either. The CPU
+  // FIFO carries TERMINATE, eager submits, and captured cmds on the host-node
+  // path; the device ring carries captured ring cmds in GPU execution order.
+  //
+  // Block on the FIFO condvar so a control/eager submit (or TERMINATE/abort)
+  // wakes us immediately, but time out every poll interval to drain the ring,
+  // which cannot signal the condvar. This keeps an idle worker off-core (there
+  // is one GPE thread per comm) while bounding ring dispatch latency.
+  const auto pollInterval = std::chrono::microseconds(
+      NCCL_CTRAN_GPE_DEVICE_RING_POLL_US > 0
+          ? NCCL_CTRAN_GPE_DEVICE_RING_POLL_US
+          : 50);
+  for (;;) {
+    // Priority 1: control/eager cmds on the FIFO. Only wait when nothing is
+    // already pending from a prior ring poll. ringPending_ is owned solely by
+    // this worker thread, so reading it under the FIFO lock is race-free.
+    {
+      auto locked = cmdQueue_.lock();
+      if (locked->queue.empty() && ringPending_.empty()) {
+        cmdQueueCv_.wait_for(locked.as_lock(), pollInterval);
+      }
+      if (!locked->queue.empty()) {
+        auto* cmd = locked->queue.front();
+        locked->queue.pop();
+        return cmd;
+      }
+    }
+
+    // Priority 2: cmds drained from the ring on a prior poll, in exec order.
+    if (!ringPending_.empty()) {
+      auto* cmd = ringPending_.front();
+      ringPending_.pop();
+      return cmd;
+    }
+
+    // Poll the ring (FIFO lock released) for newly started kernels. poll()
+    // delivers every entry published since the last poll, in slot order.
+    auto pollResult = deviceRingReader_->poll([this](
+                                                  const auto& entry,
+                                                  uint64_t /*slot*/) {
+      // Look up and fire under the registry lock so the pair is atomic with
+      // cmdDestroy()'s erase (see GpeDeviceRingCmdRegistry::lookupAndFire).
+      CtranGpeCmd* cmd = deviceRingCmdRegistry_.lookupAndFire(entry.data);
+      if (cmd != nullptr) {
+        ringPending_.push(cmd);
+      } else {
+        // The cmd was destroyed (graph teardown) after publishing, or an id
+        // was never registered. Drop it — safe because a destroyed cmd's
+        // registry entry is erased before free.
+        CLOGF(
+            WARN,
+            "CTRAN-GPE: device ring entry cmd_id {} has no live registry entry; skipping",
+            entry.data);
+      }
+    });
+
+    // The ring was full when we polled: a kernel is stalled in write_blocking()
+    // waiting for us to drain, so device work is being throttled by the GPE
+    // consumer. Rate-limited so a sustained stall logs periodically.
+    if (pollResult.writerThrottled) {
+      CLOGF_EVERY_MS(
+          WARN,
+          1000,
+          "CTRAN-GPE: device ring full (size {}); kernel writes throttled — GPE consumer not draining fast enough",
+          deviceRing_->size());
+    }
+  }
+}

--- a/comms/ctran/gpe/GpeDeviceRing.h
+++ b/comms/ctran/gpe/GpeDeviceRing.h
@@ -1,0 +1,65 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#ifndef CTRAN_GPE_DEVICE_RING_H_
+#define CTRAN_GPE_DEVICE_RING_H_
+
+#include <atomic>
+#include <cstddef>
+
+#include <folly/Synchronized.h>
+#include <folly/container/F14Map.h>
+
+#include "comms/ctran/algos/common/GpeRing.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
+
+class CtranGpeCmd;
+
+namespace ctran::gpe {
+
+// Host-only reader over the device dispatch ring. Kept here rather than in
+// GpeRing.h because GpeRing.h is device-included and must not pull in the host
+// reader.
+using GpeRingReader = hrdw_ring_buffer::
+    HRDWRingBufferReader<GpeCmdId, kGpeRingScope, kGpeRingPolicy>;
+
+} // namespace ctran::gpe
+
+// Per-comm registry for device-ring dispatch (NCCL_CTRAN_GPE_DEVICE_RING).
+// Maps the comm-local id a kernel publishes to the ring back to its
+// CtranGpeCmd. Thread-safe: registerCmd on the main thread, erase on the CUDA
+// cmdDestroy callback thread, lookup on the GPE worker thread. Kept separate
+// from CtranGpe::Impl so id assignment, lookup, and per-fire bookkeeping are
+// unit-testable without a GPU.
+class GpeDeviceRingCmdRegistry {
+ public:
+  // Assign the next monotonic id (starting at 1; 0 = unassigned), store the
+  // cmd, and mark it registered. Returns the id (also written to cmd->cmdId).
+  ctran::gpe::GpeCmdId registerCmd(CtranGpeCmd* cmd);
+
+  // Return the cmd for id, or nullptr if absent (e.g. already erased).
+  CtranGpeCmd* lookup(ctran::gpe::GpeCmdId id) const;
+
+  // Look up the cmd for id and, if found, recordRingReplay() it atomically
+  // under the registry lock. Doing both under one lock closes the teardown race
+  // with erase()/cmdDestroy() (see the impl). Returns the cmd or nullptr.
+  CtranGpeCmd* lookupAndFire(ctran::gpe::GpeCmdId id);
+
+  // Remove the entry for id. Idempotent.
+  void erase(ctran::gpe::GpeCmdId id);
+
+  // Number of live entries.
+  size_t size() const;
+
+  // Apply the per-replay bookkeeping the host-node cmdCb would have done: bump
+  // inFlight (so cmdDestroy waits for the GPE to drain this fire) and advance
+  // each op's opCount. Only meaningful for persistent (captured) cmds.
+  static void recordRingReplay(CtranGpeCmd* cmd);
+
+ private:
+  std::atomic<ctran::gpe::GpeCmdId> nextId_{1};
+  mutable folly::Synchronized<
+      folly::F14FastMap<ctran::gpe::GpeCmdId, CtranGpeCmd*>>
+      map_;
+};
+
+#endif // CTRAN_GPE_DEVICE_RING_H_

--- a/comms/ctran/gpe/benchmarks/NoOpKernel.cu
+++ b/comms/ctran/gpe/benchmarks/NoOpKernel.cu
@@ -3,6 +3,6 @@
 #include "comms/ctran/gpe/benchmarks/NoOpKernel.h"
 
 __global__ void NoOpKernel(
-    int* /*flag*/,
+    ctran::gpe::KernelFlagDev* /*flag*/,
     CtranAlgoDeviceState* /*devState*/,
     ctran::allgather::KernelArgs /*args*/) {}

--- a/comms/ctran/gpe/benchmarks/NoOpKernel.h
+++ b/comms/ctran/gpe/benchmarks/NoOpKernel.h
@@ -4,9 +4,10 @@
 
 #include "comms/ctran/algos/AllGather/Types.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/gpe/CtranGpeDev.h"
 
 __global__ void NoOpKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args);

--- a/comms/ctran/gpe/tests/CtranGpeDeviceRingUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeDeviceRingUT.cc
@@ -1,0 +1,126 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Host-side unit tests for the device-ring GPE dispatch registry
+// (NCCL_CTRAN_GPE_DEVICE_RING). Covers the mockable core of the ring path: the
+// per-comm command registry (id assignment, lookup, erase) and the per-fire
+// bookkeeping the GPE worker applies for each ring entry. The device ring
+// transport itself (HRDWRingBuffer) is unit-tested in comms/utils/tests, and
+// the end-to-end ring consumer is exercised by the single-node GPE/ctran GPU
+// tests and multi-node MAST runs.
+
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+// CtranGpeCmd's coll.pObj is a std::variant holding a
+// std::unique_ptr<alltoallp::AlgoImpl>; constructing/destroying a CtranGpeCmd
+// in this TU needs the COMPLETE AlgoImpl type (as CtranGpeImpl.cc does), so
+// include its definition directly rather than relying on it being pulled in
+// transitively (which only happens under some build configs).
+#include "comms/ctran/algos/AllToAll/AllToAllPImpl.h"
+#include "comms/ctran/gpe/CtranGpeImpl.h"
+#include "comms/ctran/gpe/GpeDeviceRing.h"
+
+namespace {
+
+// A default-constructed CtranGpeCmd is safe to build and destroy on the host:
+// its destructor no-ops when kernelFlag and postKernelCleanup are null.
+std::unique_ptr<CtranGpeCmd> makeCmd(bool persistent) {
+  auto cmd = std::make_unique<CtranGpeCmd>();
+  cmd->persistent = persistent;
+  return cmd;
+}
+
+TEST(GpeDeviceRingCmdRegistryTest, AssignsMonotonicIdsStartingAtOne) {
+  GpeDeviceRingCmdRegistry registry;
+  auto a = makeCmd(/*persistent=*/true);
+  auto b = makeCmd(/*persistent=*/true);
+  auto c = makeCmd(/*persistent=*/true);
+
+  const std::vector<ctran::gpe::GpeCmdId> ids = {
+      registry.registerCmd(a.get()),
+      registry.registerCmd(b.get()),
+      registry.registerCmd(c.get())};
+
+  const std::vector<ctran::gpe::GpeCmdId> expected = {1, 2, 3};
+  EXPECT_EQ(ids, expected);
+  // Each cmd records its own id and is marked as owning a registry entry.
+  EXPECT_EQ(a->cmdId, 1u);
+  EXPECT_EQ(b->cmdId, 2u);
+  EXPECT_EQ(c->cmdId, 3u);
+  EXPECT_TRUE(a->inDeviceRingRegistry);
+  EXPECT_TRUE(b->inDeviceRingRegistry);
+  EXPECT_TRUE(c->inDeviceRingRegistry);
+  EXPECT_EQ(registry.size(), 3u);
+}
+
+TEST(GpeDeviceRingCmdRegistryTest, LookupResolvesIdToRegisteredCmd) {
+  GpeDeviceRingCmdRegistry registry;
+  auto a = makeCmd(/*persistent=*/true);
+  auto b = makeCmd(/*persistent=*/true);
+  const ctran::gpe::GpeCmdId idA = registry.registerCmd(a.get());
+  const ctran::gpe::GpeCmdId idB = registry.registerCmd(b.get());
+
+  EXPECT_EQ(registry.lookup(idA), a.get());
+  EXPECT_EQ(registry.lookup(idB), b.get());
+  // An id that was never registered resolves to nullptr, not garbage — the
+  // GPE worker relies on this to skip stale/destroyed ring entries.
+  EXPECT_EQ(registry.lookup(9999u), nullptr);
+}
+
+TEST(GpeDeviceRingCmdRegistryTest, EraseRemovesEntryAndIsIdempotent) {
+  GpeDeviceRingCmdRegistry registry;
+  auto a = makeCmd(/*persistent=*/true);
+  const ctran::gpe::GpeCmdId id = registry.registerCmd(a.get());
+  ASSERT_EQ(registry.lookup(id), a.get());
+
+  registry.erase(id);
+  EXPECT_EQ(registry.lookup(id), nullptr);
+  EXPECT_EQ(registry.size(), 0u);
+  // Erasing again (e.g. a late duplicate) must be safe.
+  registry.erase(id);
+  EXPECT_EQ(registry.size(), 0u);
+}
+
+TEST(GpeDeviceRingCmdRegistryTest, IdsAreUniqueAcrossManyRegistrations) {
+  GpeDeviceRingCmdRegistry registry;
+  std::vector<std::unique_ptr<CtranGpeCmd>> cmds;
+  std::unordered_set<ctran::gpe::GpeCmdId> ids;
+  constexpr int kN = 1000;
+  for (int i = 0; i < kN; ++i) {
+    cmds.push_back(makeCmd(/*persistent=*/true));
+    ids.insert(registry.registerCmd(cmds.back().get()));
+  }
+  EXPECT_EQ(ids.size(), static_cast<size_t>(kN));
+  EXPECT_EQ(registry.size(), static_cast<size_t>(kN));
+}
+
+TEST(
+    GpeDeviceRingCmdRegistryTest,
+    RecordRingReplayBumpsInFlightForPersistentCmd) {
+  // Each ring entry is one fire of a captured (persistent) cmd.
+  // recordRingReplay mirrors the host-node cmdCb: it bumps inFlight so
+  // cmdDestroy waits for the GPE worker to finish this fire before freeing the
+  // cmd.
+  auto cmd = makeCmd(/*persistent=*/true);
+  EXPECT_EQ(cmd->inFlight.load(), 0u);
+
+  GpeDeviceRingCmdRegistry::recordRingReplay(cmd.get());
+  EXPECT_EQ(cmd->inFlight.load(), 1u);
+
+  GpeDeviceRingCmdRegistry::recordRingReplay(cmd.get());
+  EXPECT_EQ(cmd->inFlight.load(), 2u);
+}
+
+TEST(GpeDeviceRingCmdRegistryTest, RecordRingReplayIsNoOpForNonPersistentCmd) {
+  // Non-persistent (eager) cmds never traverse the ring path, so
+  // recordRingReplay must not touch their inFlight (they are freed by the GPE
+  // worker directly).
+  auto cmd = makeCmd(/*persistent=*/false);
+  GpeDeviceRingCmdRegistry::recordRingReplay(cmd.get());
+  EXPECT_EQ(cmd->inFlight.load(), 0u);
+}
+
+} // namespace

--- a/comms/ctran/gpe/tests/CtranGpeUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeUT.cc
@@ -54,6 +54,7 @@ class CtranGpeTest : public ::testing::Test {
 class CtranGpeKernelTest : public ::testing::Test {
  public:
   volatile int* testFlag;
+  ctran::gpe::KernelFlagDev* testKfd{nullptr};
   CtranAlgoDeviceState* dummyDevState_d{nullptr};
   std::unique_ptr<ctran::TestCtranCommRAII> dummyCommRAII;
   CtranComm* dummyComm{nullptr};
@@ -71,14 +72,18 @@ class CtranGpeKernelTest : public ::testing::Test {
     dummyCommRAII = ctran::createDummyCtranComm();
     dummyComm = dummyCommRAII->ctranComm.get();
 
-    FB_CUDACHECKIGNORE(
-        cudaHostAlloc((void**)&testFlag, sizeof(int), cudaHostAllocDefault));
+    FB_CUDACHECKIGNORE(cudaHostAlloc(
+        (void**)&testKfd,
+        sizeof(ctran::gpe::KernelFlagDev),
+        cudaHostAllocDefault));
+    *testKfd = {};
+    testFlag = &testKfd->flag_[0];
     *testFlag = KERNEL_UNSET;
 
     CUDACHECK_TEST(cudaMalloc(&dummyDevState_d, sizeof(CtranAlgoDeviceState)));
   }
   void TearDown() override {
-    FB_CUDACHECKIGNORE(cudaFreeHost((void*)testFlag));
+    FB_CUDACHECKIGNORE(cudaFreeHost(testKfd));
     CUDACHECK_TEST(cudaFree(dummyDevState_d));
   }
 };
@@ -1821,7 +1826,7 @@ TEST_F(CtranGpeTest, SubmitCustomKernArgs) {
 TEST_F(CtranGpeKernelTest, launchTerminateStallKernel) {
   dim3 grid = {1, 1, 1};
   dim3 blocks = {1, 1, 1};
-  void* args[] = {&testFlag};
+  void* args[] = {&testKfd};
   ASSERT_EQ(
       cudaFuncSetAttribute(
           reinterpret_cast<void*>(CtranGpeTestTerminateKernel),

--- a/comms/ctran/gpe/tests/CtranGpeUTKernels.cu
+++ b/comms/ctran/gpe/tests/CtranGpeUTKernels.cu
@@ -8,16 +8,17 @@
 #include "comms/ctran/gpe/tests/CtranGpeUTKernels.h"
 
 __global__ void CtranGpeTestKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState_d,
     ctran::allgather::KernelArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   int* a = const_cast<int*>(reinterpret_cast<const int*>(args.sendbuff));
   int* expValInt = reinterpret_cast<int*>(args.recvbuff);
   // Assume data type = commInt8
   size_t count = args.count;
 
   if (flag) {
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
   }
 
   for (int i = 0; i < count; i++) {
@@ -30,7 +31,7 @@ __global__ void CtranGpeTestKernel(
 }
 
 __global__ void CtranGpeTestCustomArgsKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState_d,
     CtranKernelCustomArgs args) {
   const auto gtId = blockIdx.x * blockDim.x + threadIdx.x;
@@ -41,17 +42,18 @@ __global__ void CtranGpeTestCustomArgsKernel(
   __syncthreads();
 }
 
-__global__ void CtranGpeTestTerminateKernel(int* flag) {
-  ctran::device::KernelStartGpe(flag);
+__global__ void CtranGpeTestTerminateKernel(ctran::gpe::KernelFlagDev* f) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  ctran::device::KernelStartGpe(f);
   ctran::device::KernelWaitGpeTerminate(flag);
 }
 
-__global__ void CtranGpeTestStartAndExitKernel(int* flag) {
-  ctran::device::KernelStartGpeAndExit(flag);
+__global__ void CtranGpeTestStartAndExitKernel(ctran::gpe::KernelFlagDev* f) {
+  ctran::device::KernelStartGpeAndExit(f);
 }
 
 __global__ void CtranGpeTestKElemsKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState_d,
     ctran::allgather::KernelArgs args) {
   KernelElem* elemList = const_cast<KernelElem*>(
@@ -67,12 +69,13 @@ __global__ void CtranGpeTestKElemsKernel(
 }
 
 __global__ void CtranGpeTestOneFlagKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState_d,
     ctran::allgather::KernelArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   auto gtIdx = blockIdx.x * blockDim.x + threadIdx.x;
   if (flag && gtIdx == 0) {
-    ctran::device::KernelStartGpe(flag);
+    ctran::device::KernelStartGpe(f);
   }
 
   devStateLoadToShm(devState_d);
@@ -83,13 +86,14 @@ __global__ void CtranGpeTestOneFlagKernel(
 }
 
 __global__ void CtranGpeTestPerBlockFlagKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState_d,
     ctran::allgather::KernelArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   auto tId = threadIdx.x;
   auto bId = blockIdx.x;
   if (flag && tId == 0) {
-    ctran::device::KernelStartGpe(&flag[bId]);
+    ctran::device::KernelStartGpe(f, bId);
   }
 
   devStateLoadToShm(devState_d);
@@ -101,13 +105,14 @@ __global__ void CtranGpeTestPerBlockFlagKernel(
 }
 
 __global__ void CtranGpeTestFtDisabledOobTerminateKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState_d,
     CtranKernelFtArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
   if (flag && tId == 0) {
-    ctran::device::KernelStartGpe(&flag[bId]);
+    ctran::device::KernelStartGpe(f, bId);
   }
 
   devStateLoadToShm(devState_d);
@@ -122,13 +127,14 @@ __global__ void CtranGpeTestFtDisabledOobTerminateKernel(
 }
 
 __global__ void CtranGpeTestFtEnabledOobTerminateKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState_d,
     CtranKernelFtArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
   if (flag && tId == 0) {
-    ctran::device::KernelStartGpe(&flag[bId]);
+    ctran::device::KernelStartGpe(f, bId);
   }
 
   devStateLoadToShm(devState_d);
@@ -148,13 +154,14 @@ __global__ void CtranGpeTestFtEnabledOobTerminateKernel(
 }
 
 __global__ void CtranGpeTestFtBaseKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState_d,
     CtranKernelFtArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
   if (flag && tId == 0) {
-    ctran::device::KernelStartGpe(&flag[bId]);
+    ctran::device::KernelStartGpe(f, bId);
   }
 
   devStateLoadToShm(&flag[bId], devState_d);
@@ -169,13 +176,14 @@ __global__ void CtranGpeTestFtBaseKernel(
 }
 
 __global__ void CtranGpeTestFtShmAbortKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState_d,
     CtranKernelFtArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
   if (flag && tId == 0) {
-    ctran::device::KernelStartGpe(&flag[bId]);
+    ctran::device::KernelStartGpe(f, bId);
   }
 
   devStateLoadToShm(&flag[bId], devState_d);

--- a/comms/ctran/gpe/tests/CtranGpeUTKernels.h
+++ b/comms/ctran/gpe/tests/CtranGpeUTKernels.h
@@ -3,12 +3,13 @@
 
 #include "comms/ctran/algos/AllGather/Types.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/gpe/CtranGpeDev.h"
 
 constexpr int numKElems = 10;
 
 __global__ void CtranGpeTestKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState_d,
     ctran::allgather::KernelArgs args);
 
@@ -19,26 +20,26 @@ struct CtranKernelCustomArgs {
 };
 
 __global__ void CtranGpeTestCustomArgsKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState_d,
     CtranKernelCustomArgs args);
 
-__global__ void CtranGpeTestStartAndExitKernel(int* flag);
+__global__ void CtranGpeTestStartAndExitKernel(ctran::gpe::KernelFlagDev* flag);
 
-__global__ void CtranGpeTestTerminateKernel(int* flag);
+__global__ void CtranGpeTestTerminateKernel(ctran::gpe::KernelFlagDev* flag);
 
 __global__ void CtranGpeTestKElemsKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState_d,
     ctran::allgather::KernelArgs args);
 
 __global__ void CtranGpeTestOneFlagKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState_d,
     ctran::allgather::KernelArgs args);
 
 __global__ void CtranGpeTestPerBlockFlagKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState_d,
     ctran::allgather::KernelArgs args);
 
@@ -47,21 +48,21 @@ struct CtranKernelFtArgs {
 };
 
 __global__ void CtranGpeTestFtDisabledOobTerminateKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState_d,
     CtranKernelFtArgs args);
 
 __global__ void CtranGpeTestFtEnabledOobTerminateKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState_d,
     CtranKernelFtArgs args);
 
 __global__ void CtranGpeTestFtBaseKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState_d,
     CtranKernelFtArgs args);
 
 __global__ void CtranGpeTestFtShmAbortKernel(
-    int* flag,
+    ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState_d,
     CtranKernelFtArgs args);

--- a/comms/ctran/gpe/tests/KernelFlagCmdOwnershipUT.cc
+++ b/comms/ctran/gpe/tests/KernelFlagCmdOwnershipUT.cc
@@ -104,7 +104,7 @@ TEST_F(KernelFlagCmdOwnershipTest, UnprotectedFlagIsReclaimed) {
   // Simulate kernel writing KERNEL_UNSET after replay (the bug scenario:
   // setPersistent() not called, so the flag becomes reclaimable).
   for (int i = 0; i < flag->numGroups_; ++i) {
-    flag->flag_[i] = KERNEL_UNSET;
+    flag->dev.flag_[i] = KERNEL_UNSET;
   }
   EXPECT_FALSE(flag->inUse());
 

--- a/comms/ctran/gpe/tests/KernelFlagPoolUT.cc
+++ b/comms/ctran/gpe/tests/KernelFlagPoolUT.cc
@@ -34,7 +34,7 @@ class KernelFlagPoolTest : public ::testing::Test {
 
       flag->numGroups_ = numGroups;
       for (int j = 0; j < flag->numGroups_; ++j) {
-        flag->flag_[j] = KERNEL_SCHEDULED;
+        flag->dev.flag_[j] = KERNEL_SCHEDULED;
       }
       allocated_flags.push_back(flag);
     }
@@ -58,7 +58,7 @@ class KernelFlagPoolTest : public ::testing::Test {
           for (int i = 0; i < reclaimSize; ++i) {
             auto* allocated_flag = allocated_flags[i];
             for (int j = 0; j < allocated_flag->numGroups_; ++j) {
-              allocated_flag->flag_[j] = KERNEL_UNSET;
+              allocated_flag->dev.flag_[j] = KERNEL_UNSET;
             }
           }
         },
@@ -116,7 +116,7 @@ TEST_F(KernelFlagPoolTest, ReclaimTestHostAndDevice) {
           auto* allocated_flag = allocated_flags[i];
           allocated_flag->reset();
           for (int j = 0; j < allocated_flag->numGroups_; ++j) {
-            allocated_flag->flag_[j] = KERNEL_UNSET;
+            allocated_flag->dev.flag_[j] = KERNEL_UNSET;
           }
         }
       },
@@ -150,7 +150,7 @@ TEST_F(KernelFlagPoolTest, SetAndTestFlags) {
   allocated_flag->setFlagPerGroup(KERNEL_TERMINATE);
 
   for (int i = 0; i < numGroups; ++i) {
-    EXPECT_EQ(allocated_flag->flag_[i], KERNEL_TERMINATE)
+    EXPECT_EQ(allocated_flag->dev.flag_[i], KERNEL_TERMINATE)
         << "allocated_flag[" << i << "] not properly set";
   }
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -97,6 +97,49 @@ cvars:
      consolidated abort ERR line on stderr (gpeProfiler_->debugString())
      keeps producing per-phase latencies. Set true to enable Scuba flush.
 
+ - name        : NCCL_CTRAN_GPE_DEVICE_RING
+   type        : bool
+   default     : false
+   description : |-
+     Enable the device-ring GPE dispatch path (see
+     comms/ctran/gpe/docs/gpe_device_ring.md). When false (default), GPE
+     dispatch is unchanged: captured CUDA graphs use in-graph HOST nodes
+     that enqueue each command to the per-comm CPU FIFO on replay. When
+     true, ring-capable collective kernels publish their command id to a
+     per-comm host-mapped ring (HRDWRingBuffer) as they start, and the GPE
+     worker consumes the ring in true GPU execution order — no HOST nodes
+     are added to the graph, eliminating the driver's replay launch-blocking
+     bug while preserving the runtime-produced ordering that static
+     coalescing cannot reproduce. Requires sm_90+ (System-scope 128b atomic
+     exchange); ignored on HIP/pre-Hopper, where the host-node path is used.
+     The eager (non-capture) path is unchanged regardless of this setting.
+
+ - name        : NCCL_CTRAN_GPE_DEVICE_RING_SIZE
+   type        : int
+   default     : 8192
+   description : |-
+     Number of entries in the per-comm device dispatch ring used when
+     NCCL_CTRAN_GPE_DEVICE_RING is true. Rounded up to a power of two. The ring
+     is lossless (blocking write policy): an undersized ring never drops
+     entries. Instead a kernel that fills it stalls at start until the GPE
+     worker drains a slot, throttling device work (logged, rate-limited). Size
+     it to the maximum number of proxy-having collectives that can be
+     concurrently in flight on a single comm, so writers never stall. Each
+     entry is 16 bytes of pinned host memory.
+
+ - name        : NCCL_CTRAN_GPE_DEVICE_RING_POLL_US
+   type        : int
+   default     : 50
+   description : |-
+     Idle poll interval in microseconds for the device-ring GPE worker when
+     NCCL_CTRAN_GPE_DEVICE_RING is true. The worker blocks on the CPU FIFO
+     condvar and is woken immediately by control/eager submits (TERMINATE,
+     abort), but the device ring cannot signal the condvar, so it also wakes
+     every poll interval to drain the ring. This bounds device-ring dispatch
+     latency (and how long a full ring stalls the writer) while keeping an idle
+     worker off-core. Smaller = lower latency, more wakeups; larger = fewer
+     wakeups, higher latency. Ignored on the host-node path.
+
  - name        : NCCL_CTRAN_GPE_PROFILING_SAMPLING_WEIGHT
    type        : int
    default     : 1000


### PR DESCRIPTION
Summary: Replaces the `int* flag` first argument of every GPE kernel with a `ctran::gpe::KernelFlagDev*` — the per-cmd device flag object `{ volatile int flag_[CTRAN_ALGO_MAX_THREAD_BLOCKS]; GpeKernelFlagHeader gpeHdr; }` defined in `comms/ctran/algos/common/GpeRing.h`. The kernel's `KernelStartGpe` prologue now reads `flag->gpeHdr` directly, deleting the `flag + CTRAN_ALGO_MAX_THREAD_BLOCKS` pointer-offset recovery and the `offsetof(KernelFlagItem, gpeHdr)` static_assert that the device-ring parent diff (D111372162) relied on.

Differential Revision: D111953222
