### PR TITLE
IB reduce-scatter ring: launcher + datatypes (#3155)

### DIFF
--- a/comms/ctran/algos/ReduceScatter/ReduceScatter.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatter.cc
@@ -83,6 +83,10 @@ bool ctranReduceScatterSupport(
       break;
     case NCCL_REDUCESCATTER_ALGO::ctdirect_ib:
       return true;
+    case NCCL_REDUCESCATTER_ALGO::ctring_ib:
+      // Hosted by MCCL; CTRAN reports unsupported so non-MCCL callers fall
+      // back.
+      return false;
     case NCCL_REDUCESCATTER_ALGO::orig: // invalid query
       return false;
   }

--- a/comms/prims/collectives/RingReduceScatterInst_bf16.cu
+++ b/comms/prims/collectives/RingReduceScatterInst_bf16.cu
@@ -1,0 +1,13 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Explicit instantiations of ring_reduce_scatter_kernel for __nv_bfloat16.
+// One translation unit per datatype keeps each nvcc compile action small and
+// parallel (see RingReduceScatterKernel.cuh).
+
+#include "comms/prims/collectives/RingReduceScatterKernel.cuh"
+
+namespace comms::prims {
+
+INSTANTIATE_RING_REDUCE_SCATTER_FOR_TYPE(__nv_bfloat16);
+
+} // namespace comms::prims

--- a/comms/prims/collectives/RingReduceScatterInst_f16.cu
+++ b/comms/prims/collectives/RingReduceScatterInst_f16.cu
@@ -1,0 +1,13 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Explicit instantiations of ring_reduce_scatter_kernel for __half.
+// One translation unit per datatype keeps each nvcc compile action small and
+// parallel (see RingReduceScatterKernel.cuh).
+
+#include "comms/prims/collectives/RingReduceScatterKernel.cuh"
+
+namespace comms::prims {
+
+INSTANTIATE_RING_REDUCE_SCATTER_FOR_TYPE(__half);
+
+} // namespace comms::prims

--- a/comms/prims/collectives/RingReduceScatterInst_f32.cu
+++ b/comms/prims/collectives/RingReduceScatterInst_f32.cu
@@ -1,0 +1,13 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Explicit instantiations of ring_reduce_scatter_kernel for float.
+// One translation unit per datatype keeps each nvcc compile action small and
+// parallel (see RingReduceScatterKernel.cuh).
+
+#include "comms/prims/collectives/RingReduceScatterKernel.cuh"
+
+namespace comms::prims {
+
+INSTANTIATE_RING_REDUCE_SCATTER_FOR_TYPE(float);
+
+} // namespace comms::prims

--- a/comms/prims/collectives/RingReduceScatterInst_f64.cu
+++ b/comms/prims/collectives/RingReduceScatterInst_f64.cu
@@ -1,0 +1,13 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Explicit instantiations of ring_reduce_scatter_kernel for double.
+// One translation unit per datatype keeps each nvcc compile action small and
+// parallel (see RingReduceScatterKernel.cuh).
+
+#include "comms/prims/collectives/RingReduceScatterKernel.cuh"
+
+namespace comms::prims {
+
+INSTANTIATE_RING_REDUCE_SCATTER_FOR_TYPE(double);
+
+} // namespace comms::prims

--- a/comms/prims/collectives/RingReduceScatterInst_i32.cu
+++ b/comms/prims/collectives/RingReduceScatterInst_i32.cu
@@ -1,0 +1,13 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Explicit instantiations of ring_reduce_scatter_kernel for int32_t.
+// One translation unit per datatype keeps each nvcc compile action small and
+// parallel (see RingReduceScatterKernel.cuh).
+
+#include "comms/prims/collectives/RingReduceScatterKernel.cuh"
+
+namespace comms::prims {
+
+INSTANTIATE_RING_REDUCE_SCATTER_FOR_TYPE(int32_t);
+
+} // namespace comms::prims

--- a/comms/prims/collectives/RingReduceScatterInst_i64.cu
+++ b/comms/prims/collectives/RingReduceScatterInst_i64.cu
@@ -1,0 +1,13 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Explicit instantiations of ring_reduce_scatter_kernel for int64_t.
+// One translation unit per datatype keeps each nvcc compile action small and
+// parallel (see RingReduceScatterKernel.cuh).
+
+#include "comms/prims/collectives/RingReduceScatterKernel.cuh"
+
+namespace comms::prims {
+
+INSTANTIATE_RING_REDUCE_SCATTER_FOR_TYPE(int64_t);
+
+} // namespace comms::prims

--- a/comms/prims/collectives/RingReduceScatterInst_i8.cu
+++ b/comms/prims/collectives/RingReduceScatterInst_i8.cu
@@ -1,0 +1,13 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Explicit instantiations of ring_reduce_scatter_kernel for int8_t.
+// One translation unit per datatype keeps each nvcc compile action small and
+// parallel (see RingReduceScatterKernel.cuh).
+
+#include "comms/prims/collectives/RingReduceScatterKernel.cuh"
+
+namespace comms::prims {
+
+INSTANTIATE_RING_REDUCE_SCATTER_FOR_TYPE(int8_t);
+
+} // namespace comms::prims

--- a/comms/prims/collectives/RingReduceScatterInst_u32.cu
+++ b/comms/prims/collectives/RingReduceScatterInst_u32.cu
@@ -1,0 +1,13 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Explicit instantiations of ring_reduce_scatter_kernel for uint32_t.
+// One translation unit per datatype keeps each nvcc compile action small and
+// parallel (see RingReduceScatterKernel.cuh).
+
+#include "comms/prims/collectives/RingReduceScatterKernel.cuh"
+
+namespace comms::prims {
+
+INSTANTIATE_RING_REDUCE_SCATTER_FOR_TYPE(uint32_t);
+
+} // namespace comms::prims

--- a/comms/prims/collectives/RingReduceScatterInst_u64.cu
+++ b/comms/prims/collectives/RingReduceScatterInst_u64.cu
@@ -1,0 +1,13 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Explicit instantiations of ring_reduce_scatter_kernel for uint64_t.
+// One translation unit per datatype keeps each nvcc compile action small and
+// parallel (see RingReduceScatterKernel.cuh).
+
+#include "comms/prims/collectives/RingReduceScatterKernel.cuh"
+
+namespace comms::prims {
+
+INSTANTIATE_RING_REDUCE_SCATTER_FOR_TYPE(uint64_t);
+
+} // namespace comms::prims

--- a/comms/prims/collectives/RingReduceScatterInst_u8.cu
+++ b/comms/prims/collectives/RingReduceScatterInst_u8.cu
@@ -1,0 +1,13 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Explicit instantiations of ring_reduce_scatter_kernel for uint8_t.
+// One translation unit per datatype keeps each nvcc compile action small and
+// parallel (see RingReduceScatterKernel.cuh).
+
+#include "comms/prims/collectives/RingReduceScatterKernel.cuh"
+
+namespace comms::prims {
+
+INSTANTIATE_RING_REDUCE_SCATTER_FOR_TYPE(uint8_t);
+
+} // namespace comms::prims

--- a/comms/prims/collectives/RingReduceScatterKernel.cuh
+++ b/comms/prims/collectives/RingReduceScatterKernel.cuh
@@ -1,5 +1,18 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+// Definition of ring_reduce_scatter_kernel, factored out of a single .cu so the
+// explicit template instantiations can be split across one translation unit per
+// datatype (RingReduceScatterInst_*.cu). This keeps each nvcc compile action
+// small and parallel; compiling all datatype x op x ring-count instantiations
+// in one TU is a major build-speed regression. Include this ONLY from the
+// per-datatype instantiation .cu files -- not from the launcher, which needs
+// only the declaration in RingReduceScatter.cuh.
+
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
 #include "comms/prims/collectives/RingReduceScatter.cuh"
 #include "comms/prims/core/CopyOp.cuh"
 #include "comms/prims/core/CopyUtils.cuh"
@@ -83,18 +96,24 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_reduce_scatter_kernel(
 #endif
 }
 
-// Template instantiations
-template __global__ void
-ring_reduce_scatter_kernel<1, float, SumOp, 16384, 512>(
-    const __grid_constant__ RingReduceScatterArgs<1, float>,
-    Timeout);
-template __global__ void
-ring_reduce_scatter_kernel<2, float, SumOp, 16384, 512>(
-    const __grid_constant__ RingReduceScatterArgs<2, float>,
-    Timeout);
-template __global__ void
-ring_reduce_scatter_kernel<4, float, SumOp, 16384, 512>(
-    const __grid_constant__ RingReduceScatterArgs<4, float>,
-    Timeout);
-
 } // namespace comms::prims
+
+// Explicit-instantiation macros. Invoke
+// INSTANTIATE_RING_REDUCE_SCATTER_FOR_TYPE inside `namespace comms::prims { ...
+// }` from a per-datatype .cu. The instantiated set (NumRings in {1,2,4} x
+// {SumOp,MaxOp,MinOp}, tile 16384, block 512) is identical to the previous
+// single-file instantiation block.
+#define INSTANTIATE_RING_REDUCE_SCATTER(num_rings, type, op)   \
+  template __global__ void                                     \
+  ring_reduce_scatter_kernel<num_rings, type, op, 16384, 512>( \
+      const __grid_constant__ RingReduceScatterArgs<num_rings, type>, Timeout)
+
+#define INSTANTIATE_RING_REDUCE_SCATTER_OPS(num_rings, type) \
+  INSTANTIATE_RING_REDUCE_SCATTER(num_rings, type, SumOp);   \
+  INSTANTIATE_RING_REDUCE_SCATTER(num_rings, type, MaxOp);   \
+  INSTANTIATE_RING_REDUCE_SCATTER(num_rings, type, MinOp)
+
+#define INSTANTIATE_RING_REDUCE_SCATTER_FOR_TYPE(type) \
+  INSTANTIATE_RING_REDUCE_SCATTER_OPS(1, type);        \
+  INSTANTIATE_RING_REDUCE_SCATTER_OPS(2, type);        \
+  INSTANTIATE_RING_REDUCE_SCATTER_OPS(4, type)

--- a/comms/prims/collectives/RingReduceScatterLauncher.cu
+++ b/comms/prims/collectives/RingReduceScatterLauncher.cu
@@ -2,6 +2,8 @@
 
 #include "comms/prims/collectives/RingReduceScatterLauncher.h"
 
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
 #include <cuda_runtime.h>
 
 #include <stdexcept>
@@ -15,15 +17,16 @@ namespace comms::prims {
 
 namespace {
 
-template <int NumRings>
+template <int NumRings, typename T, typename AccumOp>
 void launch_impl(const RingReduceScatterLaunchParams& params, Timeout timeout) {
-  RingReduceScatterArgs<NumRings, float> args{};
-  args.my_rank = params.my_rank;
-  args.num_ranks = params.num_ranks;
-  args.chunk_elements = params.chunk_elements;
-  args.signaling_data_size = params.signaling_data_size;
-  args.input = params.input;
-  args.output = params.output;
+  RingReduceScatterArgs<NumRings, T> args{
+      .my_rank = params.my_rank,
+      .num_ranks = params.num_ranks,
+      .chunk_elements = params.chunk_elements,
+      .signaling_data_size = params.signaling_data_size,
+      .input = static_cast<const T*>(params.input),
+      .output = static_cast<T*>(params.output),
+  };
 
   for (int r = 0; r < NumRings; r++) {
     auto& src = params.rings[r];
@@ -35,8 +38,65 @@ void launch_impl(const RingReduceScatterLaunchParams& params, Timeout timeout) {
     };
   }
 
-  ring_reduce_scatter_kernel<NumRings, float, SumOp, 16384, 512>
-      <<<params.num_blocks, 512>>>(args, timeout);
+  ring_reduce_scatter_kernel<NumRings, T, AccumOp, 16384, 512>
+      <<<params.num_blocks, 512, 0, params.stream>>>(args, timeout);
+}
+
+template <int NumRings, typename T>
+void launch_type(const RingReduceScatterLaunchParams& params, Timeout timeout) {
+  switch (params.reduce_op) {
+    case RingReduceScatterReduceOp::kSum:
+      launch_impl<NumRings, T, SumOp>(params, timeout);
+      break;
+    case RingReduceScatterReduceOp::kMax:
+      launch_impl<NumRings, T, MaxOp>(params, timeout);
+      break;
+    case RingReduceScatterReduceOp::kMin:
+      launch_impl<NumRings, T, MinOp>(params, timeout);
+      break;
+    default:
+      throw std::runtime_error("Unsupported ring reduce-scatter reduce op");
+  }
+}
+
+template <int NumRings>
+void launch_dispatch(
+    const RingReduceScatterLaunchParams& params,
+    Timeout timeout) {
+  switch (params.data_type) {
+    case RingReduceScatterDataType::kInt8:
+      launch_type<NumRings, int8_t>(params, timeout);
+      break;
+    case RingReduceScatterDataType::kUint8:
+      launch_type<NumRings, uint8_t>(params, timeout);
+      break;
+    case RingReduceScatterDataType::kInt32:
+      launch_type<NumRings, int32_t>(params, timeout);
+      break;
+    case RingReduceScatterDataType::kUint32:
+      launch_type<NumRings, uint32_t>(params, timeout);
+      break;
+    case RingReduceScatterDataType::kInt64:
+      launch_type<NumRings, int64_t>(params, timeout);
+      break;
+    case RingReduceScatterDataType::kUint64:
+      launch_type<NumRings, uint64_t>(params, timeout);
+      break;
+    case RingReduceScatterDataType::kFloat32:
+      launch_type<NumRings, float>(params, timeout);
+      break;
+    case RingReduceScatterDataType::kFloat64:
+      launch_type<NumRings, double>(params, timeout);
+      break;
+    case RingReduceScatterDataType::kFloat16:
+      launch_type<NumRings, __half>(params, timeout);
+      break;
+    case RingReduceScatterDataType::kBfloat16:
+      launch_type<NumRings, __nv_bfloat16>(params, timeout);
+      break;
+    default:
+      throw std::runtime_error("Unsupported ring reduce-scatter data type");
+  }
 }
 
 } // namespace
@@ -51,13 +111,13 @@ void launch_ring_reduce_scatter(const RingReduceScatterLaunchParams& params) {
 
   switch (params.num_rings) {
     case 1:
-      launch_impl<1>(params, timeout);
+      launch_dispatch<1>(params, timeout);
       break;
     case 2:
-      launch_impl<2>(params, timeout);
+      launch_dispatch<2>(params, timeout);
       break;
     case 4:
-      launch_impl<4>(params, timeout);
+      launch_dispatch<4>(params, timeout);
       break;
     default:
       throw std::runtime_error(

--- a/comms/prims/collectives/RingReduceScatterLauncher.h
+++ b/comms/prims/collectives/RingReduceScatterLauncher.h
@@ -2,22 +2,46 @@
 
 #pragma once
 
+#include <cuda_runtime_api.h>
+
 #include <cstddef>
 
 #include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 
 namespace comms::prims {
 
+enum class RingReduceScatterDataType {
+  kInt8,
+  kUint8,
+  kInt32,
+  kUint32,
+  kInt64,
+  kUint64,
+  kFloat32,
+  kFloat64,
+  kFloat16,
+  kBfloat16,
+};
+
+enum class RingReduceScatterReduceOp {
+  kSum,
+  kMax,
+  kMin,
+};
+
 struct RingReduceScatterLaunchParams {
   int my_rank{0};
   int num_ranks{0};
   std::size_t chunk_elements{0};
   std::size_t signaling_data_size{0};
-  const float* input{nullptr};
-  float* output{nullptr};
+  const void* input{nullptr};
+  void* output{nullptr};
+  RingReduceScatterDataType data_type{RingReduceScatterDataType::kFloat32};
+  RingReduceScatterReduceOp reduce_op{RingReduceScatterReduceOp::kSum};
   int num_blocks{16};
   int num_rings{1};
   float timeout_ms{0.0f};
+  cudaStream_t stream{nullptr};
 
   struct RingParams {
     int prev_rank{0};

--- a/comms/prims/core/Tile.cuh
+++ b/comms/prims/core/Tile.cuh
@@ -91,6 +91,7 @@
 #include <cuda_fp16.h>
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 #include "comms/prims/core/ThreadGroup.cuh"
 
@@ -122,6 +123,59 @@ struct MinOp {};
 
 template <typename T>
 struct VecOps;
+
+template <typename T>
+struct IntegralVecOps {
+  static_assert(std::is_integral_v<T>);
+  static constexpr int kElemsPerVec = sizeof(uint4) / sizeof(T);
+  using UnsignedT = std::make_unsigned_t<T>;
+
+  __device__ __forceinline__ static void
+  reduce(SumOp, uint4& a, const uint4& b) {
+    T* va = reinterpret_cast<T*>(&a);
+    const T* vb = reinterpret_cast<const T*>(&b);
+#pragma unroll
+    for (int i = 0; i < kElemsPerVec; i++) {
+      va[i] = static_cast<T>(
+          static_cast<UnsignedT>(va[i]) + static_cast<UnsignedT>(vb[i]));
+    }
+  }
+
+  __device__ __forceinline__ static void
+  reduce(MaxOp, uint4& a, const uint4& b) {
+    T* va = reinterpret_cast<T*>(&a);
+    const T* vb = reinterpret_cast<const T*>(&b);
+#pragma unroll
+    for (int i = 0; i < kElemsPerVec; i++) {
+      va[i] = va[i] > vb[i] ? va[i] : vb[i];
+    }
+  }
+
+  __device__ __forceinline__ static void
+  reduce(MinOp, uint4& a, const uint4& b) {
+    T* va = reinterpret_cast<T*>(&a);
+    const T* vb = reinterpret_cast<const T*>(&b);
+#pragma unroll
+    for (int i = 0; i < kElemsPerVec; i++) {
+      va[i] = va[i] < vb[i] ? va[i] : vb[i];
+    }
+  }
+
+  __device__ __forceinline__ static void
+  reduce_scalar(SumOp, T& a, const T& b) {
+    a = static_cast<T>(static_cast<UnsignedT>(a) + static_cast<UnsignedT>(b));
+  }
+
+  __device__ __forceinline__ static void
+  reduce_scalar(MaxOp, T& a, const T& b) {
+    a = a > b ? a : b;
+  }
+
+  __device__ __forceinline__ static void
+  reduce_scalar(MinOp, T& a, const T& b) {
+    a = a < b ? a : b;
+  }
+};
 
 template <>
 struct VecOps<float> {
@@ -172,6 +226,63 @@ struct VecOps<float> {
     a = fminf(a, b);
   }
 };
+
+template <>
+struct VecOps<double> {
+  static constexpr int kElemsPerVec = sizeof(uint4) / sizeof(double); // 2
+
+  __device__ __forceinline__ static void
+  reduce(SumOp, uint4& a, const uint4& b) {
+    double2& va = reinterpret_cast<double2&>(a);
+    const double2& vb = reinterpret_cast<const double2&>(b);
+    va.x += vb.x;
+    va.y += vb.y;
+  }
+
+  __device__ __forceinline__ static void
+  reduce(MaxOp, uint4& a, const uint4& b) {
+    double2& va = reinterpret_cast<double2&>(a);
+    const double2& vb = reinterpret_cast<const double2&>(b);
+    va.x = fmax(va.x, vb.x);
+    va.y = fmax(va.y, vb.y);
+  }
+
+  __device__ __forceinline__ static void
+  reduce(MinOp, uint4& a, const uint4& b) {
+    double2& va = reinterpret_cast<double2&>(a);
+    const double2& vb = reinterpret_cast<const double2&>(b);
+    va.x = fmin(va.x, vb.x);
+    va.y = fmin(va.y, vb.y);
+  }
+
+  __device__ __forceinline__ static void
+  reduce_scalar(SumOp, double& a, const double& b) {
+    a += b;
+  }
+
+  __device__ __forceinline__ static void
+  reduce_scalar(MaxOp, double& a, const double& b) {
+    a = fmax(a, b);
+  }
+
+  __device__ __forceinline__ static void
+  reduce_scalar(MinOp, double& a, const double& b) {
+    a = fmin(a, b);
+  }
+};
+
+template <>
+struct VecOps<int8_t> : IntegralVecOps<int8_t> {};
+template <>
+struct VecOps<uint8_t> : IntegralVecOps<uint8_t> {};
+template <>
+struct VecOps<int32_t> : IntegralVecOps<int32_t> {};
+template <>
+struct VecOps<uint32_t> : IntegralVecOps<uint32_t> {};
+template <>
+struct VecOps<int64_t> : IntegralVecOps<int64_t> {};
+template <>
+struct VecOps<uint64_t> : IntegralVecOps<uint64_t> {};
 
 template <typename ScalarT, typename PackedT>
 struct HalfPrecisionVecOps {

--- a/comms/prims/tests/TileTest.cc
+++ b/comms/prims/tests/TileTest.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 #include <vector>
 
 #include "comms/prims/tests/TileTest.cuh"
@@ -20,7 +21,9 @@ namespace comms::prims {
 using comms::prims::test::kTileTest2DCols;
 using comms::prims::test::kTileTest2DRows;
 using comms::prims::test::kTileTestBlockSize;
+using comms::prims::test::kTileTestByteTileElems;
 using comms::prims::test::kTileTestTileElems;
+using comms::prims::test::test_tile_accumulate_dtype;
 using comms::prims::test::test_tile_accumulate_max_float;
 using comms::prims::test::test_tile_accumulate_max_half;
 using comms::prims::test::test_tile_accumulate_min_bf16;
@@ -40,6 +43,8 @@ using comms::prims::test::test_tile_partial_load_store_float;
 using comms::prims::test::test_tile_partial_load_tile_idx1_float;
 using comms::prims::test::test_tile_partial_store_float;
 using comms::prims::test::test_tile_zero_float;
+using comms::prims::test::TileTestDataType;
+using comms::prims::test::TileTestReduceOp;
 
 constexpr int kTileElems = kTileTestTileElems;
 constexpr int kNumTiles = 4;
@@ -301,6 +306,113 @@ TEST_F(TileTestFixture, AccumulateMin) {
       [](float a, float b) { return std::min(a, b); },
       a_h,
       b_h);
+}
+
+template <typename T>
+T make_accumulate_input_a(int index) {
+  if constexpr (std::is_floating_point_v<T>) {
+    return static_cast<T>((index % 101 - 50) * 0.25);
+  } else if constexpr (std::is_signed_v<T>) {
+    return static_cast<T>(index % 101 - 50);
+  } else {
+    return static_cast<T>(index % 101);
+  }
+}
+
+template <typename T>
+T make_accumulate_input_b(int index) {
+  if constexpr (std::is_floating_point_v<T>) {
+    return static_cast<T>(((index * 3 + 7) % 53 - 26) * 0.5);
+  } else if constexpr (std::is_signed_v<T>) {
+    return static_cast<T>((index * 3 + 7) % 37 - 18);
+  } else {
+    return static_cast<T>((index * 3 + 7) % 37);
+  }
+}
+
+template <typename T>
+T expected_accumulate(T a, T b, TileTestReduceOp op) {
+  switch (op) {
+    case TileTestReduceOp::kSum:
+      return static_cast<T>(a + b);
+    case TileTestReduceOp::kMax:
+      return std::max(a, b);
+    case TileTestReduceOp::kMin:
+      return std::min(a, b);
+  }
+  return a;
+}
+
+template <typename T>
+void run_accumulate_dtype_test(TileTestDataType dtype) {
+  constexpr int kDtypeTileElems =
+      sizeof(T) == 1 ? kTileTestByteTileElems : kTileElems;
+  constexpr int kDtypeNumTiles = kNumElems / kDtypeTileElems;
+  static_assert(kNumElems % kDtypeTileElems == 0);
+
+  std::vector<T> a_h(kNumElems), b_h(kNumElems);
+  for (int i = 0; i < kNumElems; i++) {
+    a_h[i] = make_accumulate_input_a<T>(i);
+    b_h[i] = make_accumulate_input_b<T>(i);
+  }
+
+  DeviceBuffer aBuf(kNumElems * sizeof(T));
+  DeviceBuffer bBuf(kNumElems * sizeof(T));
+  DeviceBuffer outBuf(kNumElems * sizeof(T));
+  auto* a_d = static_cast<T*>(aBuf.get());
+  auto* b_d = static_cast<T*>(bBuf.get());
+  auto* out_d = static_cast<T*>(outBuf.get());
+
+  CUDACHECK_TEST(cudaMemcpy(
+      a_d, a_h.data(), kNumElems * sizeof(T), cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemcpy(
+      b_d, b_h.data(), kNumElems * sizeof(T), cudaMemcpyHostToDevice));
+
+  for (TileTestReduceOp op :
+       {TileTestReduceOp::kSum,
+        TileTestReduceOp::kMax,
+        TileTestReduceOp::kMin}) {
+    CUDACHECK_TEST(cudaMemset(out_d, 0, kNumElems * sizeof(T)));
+    test_tile_accumulate_dtype(dtype, op, a_d, b_d, out_d, kDtypeNumTiles);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<T> output_h(kNumElems);
+    CUDACHECK_TEST(cudaMemcpy(
+        output_h.data(), out_d, kNumElems * sizeof(T), cudaMemcpyDeviceToHost));
+
+    for (int i = 0; i < kNumElems; i++) {
+      EXPECT_EQ(output_h[i], expected_accumulate(a_h[i], b_h[i], op))
+          << "mismatch at index " << i;
+    }
+  }
+}
+
+TEST_F(TileTestFixture, AccumulateInt8) {
+  run_accumulate_dtype_test<std::int8_t>(TileTestDataType::kInt8);
+}
+
+TEST_F(TileTestFixture, AccumulateUint8) {
+  run_accumulate_dtype_test<std::uint8_t>(TileTestDataType::kUint8);
+}
+
+TEST_F(TileTestFixture, AccumulateInt32) {
+  run_accumulate_dtype_test<std::int32_t>(TileTestDataType::kInt32);
+}
+
+TEST_F(TileTestFixture, AccumulateUint32) {
+  run_accumulate_dtype_test<std::uint32_t>(TileTestDataType::kUint32);
+}
+
+TEST_F(TileTestFixture, AccumulateInt64) {
+  run_accumulate_dtype_test<std::int64_t>(TileTestDataType::kInt64);
+}
+
+TEST_F(TileTestFixture, AccumulateUint64) {
+  run_accumulate_dtype_test<std::uint64_t>(TileTestDataType::kUint64);
+}
+
+TEST_F(TileTestFixture, AccumulateFloat64) {
+  run_accumulate_dtype_test<double>(TileTestDataType::kFloat64);
 }
 
 // =============================================================================

--- a/comms/prims/tests/TileTest.cu
+++ b/comms/prims/tests/TileTest.cu
@@ -4,6 +4,7 @@
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 #include <cstddef>
+#include <cstdint>
 
 #include "comms/prims/core/Tile.cuh"
 #include "comms/prims/tests/Checks.h"
@@ -27,6 +28,7 @@ using comms::prims::tile_zero;
 
 constexpr int kBS = kTileTestBlockSize;
 constexpr int kTE = kTileTestTileElems;
+constexpr int kByteTE = kTileTestByteTileElems;
 
 // ============================================================================
 // Load/Store roundtrip kernels
@@ -88,7 +90,7 @@ void test_tile_zero_float(float* output, std::size_t ntiles) {
 // Accumulate kernels
 // ============================================================================
 
-template <typename T, typename Op>
+template <typename T, typename Op, int TileElems = kTE>
 __global__ void tile_accumulate_kernel(
     const T* a_input,
     const T* b_input,
@@ -96,10 +98,10 @@ __global__ void tile_accumulate_kernel(
     std::size_t ntiles) {
   auto group = make_block_group();
   for (std::size_t t = 0; t < ntiles; t++) {
-    auto a = tile_load<T, kTE, kBS>(a_input, t, group);
-    auto b = tile_load<T, kTE, kBS>(b_input, t, group);
-    tile_accumulate<T, Op, kTE, kBS>(a, b);
-    tile_store<T, kTE, kBS>(output, t, a, group);
+    auto a = tile_load<T, TileElems, kBS>(a_input, t, group);
+    auto b = tile_load<T, TileElems, kBS>(b_input, t, group);
+    tile_accumulate<T, Op, TileElems, kBS>(a, b);
+    tile_store<T, TileElems, kBS>(output, t, a, group);
   }
 }
 
@@ -138,6 +140,68 @@ void test_tile_accumulate_min_float(
     std::size_t ntiles) {
   tile_accumulate_kernel<float, MinOp><<<1, kBS>>>(a, b, output, ntiles);
   PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+template <typename T>
+void launch_tile_accumulate_dtype(
+    TileTestReduceOp op,
+    const void* a,
+    const void* b,
+    void* output,
+    std::size_t ntiles) {
+  const auto* a_t = static_cast<const T*>(a);
+  const auto* b_t = static_cast<const T*>(b);
+  auto* output_t = static_cast<T*>(output);
+  constexpr int kTileElems = sizeof(T) == 1 ? kByteTE : kTE;
+  switch (op) {
+    case TileTestReduceOp::kSum:
+      tile_accumulate_kernel<T, SumOp, kTileElems>
+          <<<1, kBS>>>(a_t, b_t, output_t, ntiles);
+      PIPES_KERNEL_LAUNCH_CHECK();
+      break;
+    case TileTestReduceOp::kMax:
+      tile_accumulate_kernel<T, MaxOp, kTileElems>
+          <<<1, kBS>>>(a_t, b_t, output_t, ntiles);
+      PIPES_KERNEL_LAUNCH_CHECK();
+      break;
+    case TileTestReduceOp::kMin:
+      tile_accumulate_kernel<T, MinOp, kTileElems>
+          <<<1, kBS>>>(a_t, b_t, output_t, ntiles);
+      PIPES_KERNEL_LAUNCH_CHECK();
+      break;
+  }
+}
+
+void test_tile_accumulate_dtype(
+    TileTestDataType dtype,
+    TileTestReduceOp op,
+    const void* a,
+    const void* b,
+    void* output,
+    std::size_t ntiles) {
+  switch (dtype) {
+    case TileTestDataType::kInt8:
+      launch_tile_accumulate_dtype<std::int8_t>(op, a, b, output, ntiles);
+      break;
+    case TileTestDataType::kUint8:
+      launch_tile_accumulate_dtype<std::uint8_t>(op, a, b, output, ntiles);
+      break;
+    case TileTestDataType::kInt32:
+      launch_tile_accumulate_dtype<std::int32_t>(op, a, b, output, ntiles);
+      break;
+    case TileTestDataType::kUint32:
+      launch_tile_accumulate_dtype<std::uint32_t>(op, a, b, output, ntiles);
+      break;
+    case TileTestDataType::kInt64:
+      launch_tile_accumulate_dtype<std::int64_t>(op, a, b, output, ntiles);
+      break;
+    case TileTestDataType::kUint64:
+      launch_tile_accumulate_dtype<std::uint64_t>(op, a, b, output, ntiles);
+      break;
+    case TileTestDataType::kFloat64:
+      launch_tile_accumulate_dtype<double>(op, a, b, output, ntiles);
+      break;
+  }
 }
 
 // ============================================================================

--- a/comms/prims/tests/TileTest.cuh
+++ b/comms/prims/tests/TileTest.cuh
@@ -12,6 +12,23 @@ namespace comms::prims::test {
 
 constexpr int kTileTestBlockSize = 256;
 constexpr int kTileTestTileElems = 2048;
+constexpr int kTileTestByteTileElems = 4096;
+
+enum class TileTestDataType {
+  kInt8,
+  kUint8,
+  kInt32,
+  kUint32,
+  kInt64,
+  kUint64,
+  kFloat64,
+};
+
+enum class TileTestReduceOp {
+  kSum,
+  kMax,
+  kMin,
+};
 
 void test_tile_load_store_float(
     const float* input,
@@ -52,6 +69,14 @@ void test_tile_accumulate_min_float(
     const float* a,
     const float* b,
     float* output,
+    std::size_t ntiles);
+
+void test_tile_accumulate_dtype(
+    TileTestDataType dtype,
+    TileTestReduceOp op,
+    const void* a,
+    const void* b,
+    void* output,
     std::size_t ntiles);
 
 void test_tile_load_accumulate_sum_float(

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2282,7 +2282,7 @@ cvars:
  - name        : NCCL_REDUCESCATTER_ALGO
    type        : enum
    default     : orig
-   choices     : orig, ctran, ctdirect, ctdirect_ib, ctring, ctrhd
+   choices     : orig, ctran, ctdirect, ctdirect_ib, ctring, ctring_ib, ctrhd
    description : |-
      The algorithm to use for ReduceScatter communication
      orig - Copy-based ring algorithm
@@ -2290,6 +2290,7 @@ cvars:
      ctdirect - Ctran-based direct point-to-point algorithm
      ctdirect_ib - Ctran-based direct IB algorithm
      ctring - Ctran-based rail ring algorithm for inter-node only case
+     ctring_ib - Prims-native IBGDA ring algorithm
      ctrhd - Ctran-based recursive vector-halving distance-doubling algorithm
 
  - name        : NCCL_REDUCESCATTER_PAT_AVG_ENABLE


### PR DESCRIPTION
Summary:

Exposes the prims `RingReduceScatter` primitive for IBGDA out-of-place reduce-scatter, with stream propagation and the full non-fp8 datatype set for the primitive redops. The launcher dispatches `commFloat32`/`commFloat16`/`commBfloat16`, int/uint 8/32/64, and `commFloat64` with `commSum`/`commMax`/`commMin`; the tile reduction layer (`Tile.cuh`) gains the integer/half/bf16 op instantiations, covered by `TileTest`. The ring topology is built with `make_standard_rings` and launch args carry the concrete prev/next `P2pIbTransportDevice` handles. Also adds the `NCCL_REDUCESCATTER_ALGO=ctring_ib` cvar value so the algorithm can be selected.

The kernel definition (`ring_reduce_scatter_kernel`) lives in a shared header (`RingReduceScatterKernel.cuh`) and its explicit template instantiations are split into one translation unit per datatype (`RingReduceScatterInst_*.cu`). This is a build-speed measure: the full dispatch surface is num_rings x datatype x reduce-op (3 x 10 x 3 = 90 instantiations), and compiling all of them in a single `.cu` is a major nvcc build-speed regression (one large, serial compile action). One translation unit per datatype keeps each nvcc compile small and lets the datatypes build in parallel; the per-datatype `.cu` files each include the shared header and emit their instantiations via the `INSTANTIATE_RING_REDUCE_SCATTER_FOR_TYPE` macro.

This is the prims layer consumed by the MCCL-native reduce-scatter collective added in D111848474. There is no CTRAN reduce-scatter dispatch -- the algorithm is owned natively by MCCL, and CTRAN only reports `ctring_ib` as unsupported so any non-MCCL caller falls back to baseline. Reuses the prims work originally authored by subodh.

Reviewed By: Scusemua, saifhhasan

Differential Revision: D111523280


