### PR TITLE
Expose Ctran AllGatherP (persistent AllGather) API for MCCL (#3158)

### DIFF
--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -609,6 +609,11 @@ CtranAlgoRMALogger::~CtranAlgoRMALogger() {
       (void*)comm_->ctran_.get());
 }
 
+// Defaulted, but defined out-of-line so the ~unique_ptr<OpElem> -> ~OpElem
+// instantiation happens here inside libctran rather than at every caller. See
+// the note at the declaration in CtranAlgo.h.
+CtranPersistentRequest::~CtranPersistentRequest() = default;
+
 const ctran::algos::IPersistPlan* CtranAlgo::getOrCreatePersistPlan(
     ctran::algos::PersistPlanKey key,
     std::function<std::unique_ptr<ctran::algos::IPersistPlan>()> createFn) {

--- a/comms/ctran/algos/CtranAlgo.h
+++ b/comms/ctran/algos/CtranAlgo.h
@@ -263,7 +263,8 @@ class CtranPersistentRequest {
   // reaches the token through here; running it releases the pooled pipeSync +
   // scoped registration (via destroyPersistentRequest), at most once across all
   // teardown paths. The token does NOT delete this request object -- that stays
-  // with the object's owner -- so ~CtranPersistentRequest stays defaulted.
+  // with the object's owner -- so ~CtranPersistentRequest remains a defaulted
+  // destructor (defined out-of-line; see the note at its declaration below).
   std::shared_ptr<PersistentCleanup> cleanup_;
 
   CtranPersistentRequest(
@@ -288,7 +289,14 @@ class CtranPersistentRequest {
   CtranPersistentRequest(Type type, CtranComm* comm, cudaStream_t stream)
       : type(type), comm_(comm), stream(stream) {}
 
-  ~CtranPersistentRequest() = default;
+  // Defaulted, but deliberately defined out-of-line (in CtranAlgo.cc) so the
+  // ~unique_ptr<OpElem> -> ~OpElem instantiation stays inside libctran. Do NOT
+  // re-inline this as `= default;` here: OpElem is a global-scope type, so an
+  // inline destructor forces callers outside libctran (e.g. MCCL / the OSS
+  // McclLinkTest) to export/resolve OpElem::~OpElem() across the .so boundary,
+  // silently breaking the OSS link. Buck CI will not catch it (it ignores the
+  // version script).
+  ~CtranPersistentRequest();
 };
 
 template <>


### PR DESCRIPTION
Summary:

Expose the persistent AllGather (`AllGatherP`) API from the ctran layer to the MCCL public interface. This was the only ctran algorithm with an existing implementation (`ctran/algos/AllGatherP/`) that was not yet wired up in MCCL.

The persistent AllGather amortizes the cost of RDMA memory registration and remote handle exchange by splitting the operation into three phases: `allGatherPInit` (one-time setup), `allGatherPExec` (repeated execution), and `allGatherPFree` (teardown). This is particularly beneficial for FSDP training loops where AllGather is called repeatedly with the same buffer layout.

**Changes:**
- `McclTypes.h`: Added `AllGatherPHandle`, `AllGatherPInitOpts`, `AllGatherPExecOpts` types and three pure virtual methods on `IComm`. `AllGatherPHandle` documents an explicit caller-owned / stale-after-`allGatherPFree()` ownership contract.
- `McclComm.h`: Added override declarations on `McclComm`
- `McclComm.cpp`: Implemented the three methods delegating to `ctran::allGatherPInit`, `ctran::allGatherPExec`, and `ctran::allGatherPDestroy`
- `MockMcclComm.h`: Added mock methods for the new API
- Unit test (`McclAllGatherPUT.cpp`): Tests init+free lifecycle, null-handle validation, and over-capacity rejection (`ExecCountExceedsMaxRecvCount`)
- Integration test (`AllGatherPTest.cpp`): Tests 4-rank AllGatherP with data validation and multiple persistent executions
- `McclUnitTestBase.h`: Shared unit-test fixture; one-time init runs in `SetUpTestSuite()` (once per fixture) rather than per-test `SetUp()`
- `CtranAlgo.h` / `CtranAlgo.cc`: Moved `CtranPersistentRequest::~CtranPersistentRequest()` out-of-line into `libctran`. `CtranPersistentRequest` owns a `std::unique_ptr<OpElem>` whose destructor is out-of-line in `libctran`; with the request destructor inline, `allGatherPFree`'s teardown instantiated `OpElem::~OpElem()` at the MCCL call site and broke the OSS `McclLinkTest` link (Buck unaffected). Defining the destructor out-of-line keeps that instantiation inside `libctran`.
- `version_script_ctran.txt`: Removed the `OpElem*` export — no longer needed now that `~CtranPersistentRequest()` is out-of-line, and it avoids exposing ctran-internal `OpElem` symbols. `~CtranPersistentRequest()` remains exported via the existing `Ctran*` pattern.

Reviewed By: dboyda

Differential Revision: D105640382


