### PR TITLE
Decouple tuner test getChunkSize gate from stable flags

### DIFF
--- a/comms/ncclx/meta/tuner/tests/MetaTunerTest.cpp
+++ b/comms/ncclx/meta/tuner/tests/MetaTunerTest.cpp
@@ -677,7 +677,7 @@ TEST_F(MetaTunerTest, MissingFileIsNoOp) {
   EXPECT_EQ(table.at(NCCL_ALGO_RING, NCCL_PROTO_LL128), 1.0F);
   EXPECT_EQ(nChannels, 5);
 
-#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+#ifdef META_TUNER_UT_HAS_GETCHUNKSIZE
   size_t chunkSize = 16384;
   kMetaTuner.getChunkSize(
       context,
@@ -693,7 +693,7 @@ TEST_F(MetaTunerTest, MissingFileIsNoOp) {
   kMetaTuner.finalize(context);
 }
 
-#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+#ifdef META_TUNER_UT_HAS_GETCHUNKSIZE
 // Case 9: getChunkSize override -- chunkSize != 0 sets it; 0/omitted leaves it.
 TEST_F(MetaTunerTest, ChunkSizeOverride) {
   const TunerConfigFile config(
@@ -771,7 +771,7 @@ TEST_F(MetaTunerTest, ChunkSizeAlgoProtoKey) {
 
   kMetaTuner.finalize(context);
 }
-#endif // NCCLX_TUNER_HAS_GETCHUNKSIZE
+#endif // META_TUNER_UT_HAS_GETCHUNKSIZE
 
 // Case 1: CSV parsing with comments, blank lines and omitted optional columns.
 TEST_F(MetaTunerTest, CsvParsingWithCommentsAndOmittedColumns) {
@@ -824,13 +824,13 @@ TEST_F(MetaTunerTest, CsvParsingWithCommentsAndOmittedColumns) {
 struct RuleProbe {
   float matchedCost;
   int channels;
-#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+#ifdef META_TUNER_UT_HAS_GETCHUNKSIZE
   size_t chunkSize;
 #endif
 
   bool operator==(const RuleProbe& other) const {
     return matchedCost == other.matchedCost && channels == other.channels
-#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+#ifdef META_TUNER_UT_HAS_GETCHUNKSIZE
         && chunkSize == other.chunkSize
 #endif
         ;
@@ -858,7 +858,7 @@ RuleProbe probeRule(
       /* regBuff */ 0,
       &channels);
 
-#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+#ifdef META_TUNER_UT_HAS_GETCHUNKSIZE
   size_t chunkSize = 0;
   kMetaTuner.getChunkSize(
       context, collType, nBytes, algo, proto, /* nChannels */ 1, &chunkSize);
@@ -914,7 +914,7 @@ TEST_F(MetaTunerTest, JsonParsingEquivalentToCsv) {
   const RuleProbe jsonRow0 = probeRule(
       jsonContext, ncclFuncAllReduce, 1024, NCCL_ALGO_RING, NCCL_PROTO_LL128);
   EXPECT_EQ(csvRow0, jsonRow0);
-#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+#ifdef META_TUNER_UT_HAS_GETCHUNKSIZE
   EXPECT_EQ(csvRow0, (RuleProbe{0.0F, 4, 65536}));
 #else
   EXPECT_EQ(csvRow0, (RuleProbe{0.0F, 4}));
@@ -925,7 +925,7 @@ TEST_F(MetaTunerTest, JsonParsingEquivalentToCsv) {
   const RuleProbe jsonRow1 = probeRule(
       jsonContext, ncclFuncAllGather, 1024, NCCL_ALGO_TREE, NCCL_PROTO_SIMPLE);
   EXPECT_EQ(csvRow1, jsonRow1);
-#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+#ifdef META_TUNER_UT_HAS_GETCHUNKSIZE
   EXPECT_EQ(csvRow1, (RuleProbe{0.0F, -1, 0}));
 #else
   EXPECT_EQ(csvRow1, (RuleProbe{0.0F, -1}));
@@ -946,7 +946,7 @@ TEST_F(MetaTunerTest, JsonParsingEquivalentToCsv) {
       NCCL_ALGO_RING,
       NCCL_PROTO_LL128);
   EXPECT_EQ(csvRow2, jsonRow2);
-#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+#ifdef META_TUNER_UT_HAS_GETCHUNKSIZE
   EXPECT_EQ(csvRow2, (RuleProbe{0.0F, -1, 0}));
 #else
   EXPECT_EQ(csvRow2, (RuleProbe{0.0F, -1}));
@@ -1038,7 +1038,7 @@ TEST_F(MetaTunerTest, ExampleCsvConfigLoads) {
       &channels);
   EXPECT_EQ(smallTable.at(NCCL_ALGO_RING, NCCL_PROTO_LL128), 0.0F);
 
-#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+#ifdef META_TUNER_UT_HAS_GETCHUNKSIZE
   // Large allreduce: per-rank shard above 1 MiB (16 MiB total / 8 ranks =
   // 2 MiB/rank) -> ring/simple carries a 524288-byte chunkSize override.
   size_t chunkSize = 16384;


### PR DESCRIPTION
Summary:
The meta tuner unit test `meta_tuner_ut` gates its v6-only `getChunkSize` calls on
`NCCLX_TUNER_HAS_GETCHUNKSIZE`. That macro is added to `NCCL_COMPILER_FLAGS` only for
v2.30 (tuner API v6) in `fbcode/comms/ncclx/v2_30/def_build.bzl`, and
`fbcode/comms/testinfra/def_test.bzl` applies the floating `stable` build's
`NCCL_COMPILER_FLAGS` to every `nccl_cpp_unittest`'s own compile, regardless of the
test's pinned backend version.

So once the `stable` tag points at v2.30, `meta_tuner_ut_v2_29` inherits
`-DNCCLX_TUNER_HAS_GETCHUNKSIZE` from the stable flags even though its pinned
`nccl2.29-internal` headers resolve `kMetaTuner` to `ncclTuner_v5_t` (no
`getChunkSize`), producing `error: no member named 'getChunkSize' in 'ncclTuner_v5_t'`.

This diff gives the test its own gate macro `META_TUNER_UT_HAS_GETCHUNKSIZE`, driven
purely by the tuner test's `version_compiler_flags` (which keys on the pinned
version). The implementation (`MetaTuner.cc` / `MetaTuner.h`) keeps
`NCCLX_TUNER_HAS_GETCHUNKSIZE`, which it correctly receives from its own per-version
compile. This decouples the test from the `stable` tag, so promoting v2.30 to stable
no longer breaks the v2.29 tuner unit test.

Prerequisite for D107211271 (`[ncclx] Move stable tag from v2.29 to v2.30`); safe to
land while `stable` is still v2.29.

___

Differential Revision: D112411780


