### PR TITLE
Nontemporal sender stores + drop redundant dispatch xGMI fence (#3160)

### DIFF
--- a/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Combine.cu
+++ b/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Combine.cu
@@ -145,7 +145,7 @@ __global__ void __launch_bounds__(kNumThreads, 1) intranode_combine_kernel(
             shifted_x_buffers,
             shifted_x,
             ld_nc_global,
-            st_na_global);
+            st_nt_global);
 
         if (lane_id == 0) {
           channel_src_idx_buffers[dst_slot_idx] =

--- a/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Dispatch.cu
+++ b/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Dispatch.cu
@@ -214,7 +214,7 @@ __global__ void __launch_bounds__(kNumThreads, 1) intranode_dispatch_kernel(
               shifted_dst,
               shifted_src,
               ld_cached_global,
-              st_na_global);
+              st_nt_global);
 
           if (send_lane_id == 0) {
             channel_src_idx_buffers[dst_slot_idx] = static_cast<int>(token_idx);
@@ -256,21 +256,17 @@ __global__ void __launch_bounds__(kNumThreads, 1) intranode_dispatch_kernel(
 
       // All sender warps for this dst_rank converge before publishing tail.
       __syncthreads();
-      // AMD/xGMI: the payload `st_na_global` writes (UNROLLED_WARP_COPY above)
-      // are non-temporal and not ordered against the tail publish below, so an
-      // explicit system fence flushes them to HBM before the tail becomes
-      // visible. The tail itself is then RELEASE-stored to pair with the
-      // receiver's acquire-load.
-#ifdef __HIP_PLATFORM_AMD__
-      memory_fence();
-#endif
+      // Payload is written with nontemporal stores (st_nt_global) that stream
+      // past L2 toward the peer, so no separate per-chunk system fence is
+      // issued on the dispatch path; the release-store tail publish below
+      // orders those writes ahead of the tail becoming visible.
       if (send_warp_id_in_rank == 0 && send_lane_id == 0) {
         // Release/acquire on both platforms. A relaxed tail store/load
         // handshake races on AMD: a relaxed read establishes no ordering, so
         // the receiver can observe the advanced tail but read stale/unwritten
-        // payload across xGMI → illegal access under async execution. The
-        // release store (plus the fence above for the non-temporal payload)
-        // carries the happens-before to the receiver's ld_acquire_sys_global.
+        // payload → illegal access under async execution. The release store
+        // orders the nontemporal payload writes ahead of it and carries the
+        // happens-before to the receiver's ld_acquire_sys_global.
         st_release_sys_global(
             channel_tail_idx.buffer(), cached_channel_tail_idx);
       }

--- a/comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelUtils.cuh
+++ b/comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelUtils.cuh
@@ -311,6 +311,24 @@ __device__ __forceinline__ void st_na_global(int4* ptr, int4 val) {
 #endif
 }
 
+// Nontemporal (cache-bypassing) 16B store for the sender's cross-device data
+// copy: streams the payload past L2 toward the peer as it is produced. Use for
+// sender->peer copies only; local receiver writes keep the plain st_na_global.
+__device__ __forceinline__ void st_nt_global(int4* ptr, int4 val) {
+#ifdef __HIP_PLATFORM_AMD__
+  int* p = reinterpret_cast<int*>(ptr);
+  __builtin_nontemporal_store(val.x, p + 0);
+  __builtin_nontemporal_store(val.y, p + 1);
+  __builtin_nontemporal_store(val.z, p + 2);
+  __builtin_nontemporal_store(val.w, p + 3);
+#else
+  asm volatile("st.global.cs.v4.s32 [%0], {%1, %2, %3, %4};"
+               :
+               : "l"(ptr), "r"(val.x), "r"(val.y), "r"(val.z), "r"(val.w)
+               : "memory");
+#endif
+}
+
 // Cached read for LOCAL data (sender's own input). On AMD, plain `__ldg`
 // suffices — local L1/L2 are coherent with the producer (CPU/torch). Using
 // `ld_nc_global` (cache-bypass) here would force every read to round-trip


### PR DESCRIPTION
Summary:

Cut a redundant cross-GPU fence off the intranode dispatch critical path on AMD MI350X.

Before signalling the receiver, the dispatch sender issued a per-chunk system-scope fence whose only job was to flush the just-copied token payload out of L2 to the peer's HBM. This change writes the sender payload with cache-bypassing nontemporal stores, so it streams through L2 to the peer's HBM as it is produced: the payload is already landed by the time the tail is published, and the existing release/acquire tail handshake supplies the ordering. The per-chunk fence is therefore redundant on the dispatch path and is removed. This applies to both bf16 and fp8, since the sender payload copy is dtype-agnostic.

Combine keeps its current fence for now; giving it the same release/acquire treatment is a separate, riskier follow-up.

Differential Revision: D109955690


