### PR TITLE
Wire fp8 intranode dispatch (#3161)

### DIFF
--- a/comms/prims/collectives/moe_ep/cpp/Buffer.cc
+++ b/comms/prims/collectives/moe_ep/cpp/Buffer.cc
@@ -19,7 +19,10 @@
 #include "comms/utils/CudaRAII.h"
 #endif
 
+#ifndef MOE_EP_OSS_INTRANODE
+// internode + bootstrap closure — not staged in the OSS intranode build.
 #include "comms/common/bootstrap/IBootstrap.h"
+#endif
 #include "comms/prims/collectives/moe_ep/cpp/intranode/Runtime.h"
 #include "comms/prims/collectives/moe_ep/cpp/intranode/kernels/Combine.cuh"
 #include "comms/prims/collectives/moe_ep/cpp/intranode/kernels/Dispatch.cuh"
@@ -561,14 +564,9 @@ py::tuple Buffer::intranode_dispatch(
     x = xTuple[0].cast<torch::Tensor>();
     xScales = xTuple[1].cast<torch::Tensor>();
     isFp8 = true;
-    // FP8 scale path is not yet supported: the kernel derives num_scales from
-    // scale_hidden_stride (Dispatch.cu), which collapses to 1 for contiguous
-    // scales and silently under-fills the recv-scale buffer. Reject the
-    // (data, scales) tuple until the FP8 scale path threads num_scales.
-    TORCH_CHECK(
-        !isFp8,
-        "intranode_dispatch: FP8 (x=(data, scales)) is not supported yet; the "
-        "scale path is not implemented. Pass a bf16/fp16 tensor.");
+    // FP8 (x=(data, scales)) uses the same kernel as bf16: token bytes move
+    // opaquely and per-token scales travel in a separate symmetric buffer.
+    // num_scales comes from x_scales.size(1); x_scales must be contiguous.
   } else {
     // Tensor path — fall back on cast-or-throw to bypass unreliable
     // pybind11::isinstance<torch::Tensor>.
@@ -612,6 +610,9 @@ py::tuple Buffer::intranode_dispatch(
             xScales->scalar_type() == torch::kInt,
         "x_scales must be float32 or int32");
     TORCH_CHECK(xScales->dim() == 2, "x_scales must be 2D");
+    TORCH_CHECK(
+        xScales->is_contiguous(),
+        "x_scales must be contiguous [num_tokens, num_scales]");
     TORCH_CHECK(
         xScales->size(0) == numTokens,
         "x_scales.size(0) must equal num_tokens");
@@ -815,6 +816,7 @@ py::tuple Buffer::intranode_dispatch(
       hiddenInt4,
       numTopk,
       numExperts,
+      numScales,
       scaleTokenStride,
       scaleHiddenStride,
       intranode_->getPeerDataPtrsDevice(),

--- a/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Combine.cu
+++ b/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Combine.cu
@@ -145,7 +145,7 @@ __global__ void __launch_bounds__(kNumThreads, 1) intranode_combine_kernel(
             shifted_x_buffers,
             shifted_x,
             ld_nc_global,
-            st_na_global);
+            st_nt_global);
 
         if (lane_id == 0) {
           channel_src_idx_buffers[dst_slot_idx] =

--- a/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Dispatch.cu
+++ b/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Dispatch.cu
@@ -478,6 +478,7 @@ void intranode_dispatch(
     int hidden_int4,
     int num_topk,
     int num_experts,
+    int num_scales,
     int scale_token_stride,
     int scale_hidden_stride,
     void** buffer_ptrs,
@@ -492,9 +493,8 @@ void intranode_dispatch(
   EP_HOST_ASSERT(num_sms % 2 == 0);
   SETUP_LAUNCH_CONFIG(num_sms, kNumThreads, stream);
 
-  const int num_scales = (scale_token_stride > 0 || scale_hidden_stride > 0)
-      ? scale_hidden_stride
-      : 0;
+  // num_scales is threaded explicitly from the binding (x_scales.size(1)); it
+  // is 0 on the bf16 path, which makes every scale loop a no-op.
 
 #define INTRANODE_DISPATCH_CASE(ranks)                 \
   LAUNCH_KERNEL_NON_COOPERATIVE(                       \

--- a/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Dispatch.cu
+++ b/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Dispatch.cu
@@ -214,7 +214,7 @@ __global__ void __launch_bounds__(kNumThreads, 1) intranode_dispatch_kernel(
               shifted_dst,
               shifted_src,
               ld_cached_global,
-              st_na_global);
+              st_nt_global);
 
           if (send_lane_id == 0) {
             channel_src_idx_buffers[dst_slot_idx] = static_cast<int>(token_idx);
@@ -256,21 +256,17 @@ __global__ void __launch_bounds__(kNumThreads, 1) intranode_dispatch_kernel(
 
       // All sender warps for this dst_rank converge before publishing tail.
       __syncthreads();
-      // AMD/xGMI: the payload `st_na_global` writes (UNROLLED_WARP_COPY above)
-      // are non-temporal and not ordered against the tail publish below, so an
-      // explicit system fence flushes them to HBM before the tail becomes
-      // visible. The tail itself is then RELEASE-stored to pair with the
-      // receiver's acquire-load.
-#ifdef __HIP_PLATFORM_AMD__
-      memory_fence();
-#endif
+      // Payload is written with nontemporal stores (st_nt_global) that stream
+      // past L2 toward the peer, so no separate per-chunk system fence is
+      // issued on the dispatch path; the release-store tail publish below
+      // orders those writes ahead of the tail becoming visible.
       if (send_warp_id_in_rank == 0 && send_lane_id == 0) {
         // Release/acquire on both platforms. A relaxed tail store/load
         // handshake races on AMD: a relaxed read establishes no ordering, so
         // the receiver can observe the advanced tail but read stale/unwritten
-        // payload across xGMI → illegal access under async execution. The
-        // release store (plus the fence above for the non-temporal payload)
-        // carries the happens-before to the receiver's ld_acquire_sys_global.
+        // payload → illegal access under async execution. The release store
+        // orders the nontemporal payload writes ahead of it and carries the
+        // happens-before to the receiver's ld_acquire_sys_global.
         st_release_sys_global(
             channel_tail_idx.buffer(), cached_channel_tail_idx);
       }

--- a/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Dispatch.cuh
+++ b/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Dispatch.cuh
@@ -40,6 +40,7 @@ void intranode_dispatch(
     int hidden_int4,
     int num_topk,
     int num_experts,
+    int num_scales,
     int scale_token_stride,
     int scale_hidden_stride,
     void** buffer_ptrs,

--- a/comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelUtils.cuh
+++ b/comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelUtils.cuh
@@ -311,6 +311,24 @@ __device__ __forceinline__ void st_na_global(int4* ptr, int4 val) {
 #endif
 }
 
+// Nontemporal (cache-bypassing) 16B store for the sender's cross-device data
+// copy: streams the payload past L2 toward the peer as it is produced. Use for
+// sender->peer copies only; local receiver writes keep the plain st_na_global.
+__device__ __forceinline__ void st_nt_global(int4* ptr, int4 val) {
+#ifdef __HIP_PLATFORM_AMD__
+  int* p = reinterpret_cast<int*>(ptr);
+  __builtin_nontemporal_store(val.x, p + 0);
+  __builtin_nontemporal_store(val.y, p + 1);
+  __builtin_nontemporal_store(val.z, p + 2);
+  __builtin_nontemporal_store(val.w, p + 3);
+#else
+  asm volatile("st.global.cs.v4.s32 [%0], {%1, %2, %3, %4};"
+               :
+               : "l"(ptr), "r"(val.x), "r"(val.y), "r"(val.z), "r"(val.w)
+               : "memory");
+#endif
+}
+
 // Cached read for LOCAL data (sender's own input). On AMD, plain `__ldg`
 // suffices — local L1/L2 are coherent with the producer (CPU/torch). Using
 // `ld_nc_global` (cache-bypass) here would force every read to round-trip


### PR DESCRIPTION
Summary:

Enable fp8 for the intranode dispatch path. The dispatch kernel already handled fp8 (token bytes move opaquely and per-token scales travel in a separate symmetric buffer), but the Python binding rejected it: the host derived the scale count from the wrong field, which collapsed to 1 for contiguous scales and under-filled the receive-scale buffer. Pass the real scale count through to the kernel, drop the fp8 reject, and require the scales tensor to be contiguous. dispatch((data, scales)) now returns (recv_x, recv_x_scales) and moves roughly half the bytes of the bf16 path.

Also fix a pre-existing break in the intranode-only OSS build: an unguarded duplicate of the internode/bootstrap includes pulled in headers that build does not stage, so compilation failed. Guard the duplicate the same way the primary copy already is.

Differential Revision: D109955381


