### PR TITLE
Fix UAF in getLastCommsError by returning std::string by value (#3162)

### DIFF
--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -3480,7 +3480,13 @@ const char* ncclGetErrorString(ncclResult_t code) {
  */
 NCCL_API(const char*, ncclGetLastError, const ncclComm_t comm);
 const char* ncclGetLastError(ncclComm_t comm) {
-  return meta::comms::logger::getLastCommsError();
+  thread_local static std::string lastErrorStorage;
+  try {
+    lastErrorStorage = meta::comms::logger::getLastCommsError();
+  } catch (...) {
+    lastErrorStorage.clear();
+  }
+  return lastErrorStorage.c_str();
 }
 
 NCCL_API(ncclResult_t, ncclCommGetAsyncError, ncclComm_t comm, ncclResult_t *asyncError);

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -3642,7 +3642,13 @@ const char* ncclGetErrorString(ncclResult_t code) {
  */
 NCCL_API(const char*, ncclGetLastError, const ncclComm_t comm);
 const char* ncclGetLastError(ncclComm_t comm) {
-  return meta::comms::logger::getLastCommsError();
+  thread_local static std::string lastErrorStorage;
+  try {
+    lastErrorStorage = meta::comms::logger::getLastCommsError();
+  } catch (...) {
+    lastErrorStorage.clear();
+  }
+  return lastErrorStorage.c_str();
 }
 
 NCCL_API(ncclResult_t, ncclCommGetAsyncError, ncclComm_t comm, ncclResult_t *asyncError);

--- a/comms/utils/logger/LoggingFormat.cc
+++ b/comms/utils/logger/LoggingFormat.cc
@@ -43,12 +43,6 @@ struct LastErrorInfo {
 
 static folly::Synchronized<LastErrorInfo> lastCommsError{};
 
-// Using char array to ensure compatibility with NCCL GetLastError API. Note
-// that since we will return the pointer to the array, reading the array while
-// another thread is writing to it is not safe.
-static folly::Synchronized<std::array<char, 4096>> lastCommsErrorStr{
-    std::array<char, 4096>{'\0'}};
-
 void logLastError(std::string_view message) {
   lastCommsError.wlock()->lastErrorMessage = message;
 }
@@ -334,8 +328,7 @@ std::string NcclLogFormatter::formatMessage(
   return buffer;
 }
 
-const char* getLastCommsError() {
-  // Only write the error message to the buffer once requested
+std::string getLastCommsError() {
   std::ostringstream ss;
   {
     auto lastCommsErrorRLocked = lastCommsError.rlock();
@@ -344,17 +337,7 @@ const char* getLastCommsError() {
       ss << '\n' << stack;
     }
   }
-
-  auto fullError = std::move(ss).str();
-
-  // Write the error message to the buffer
-  auto lastCommsErrorStrWLocked = lastCommsErrorStr.wlock();
-  std::snprintf(
-      lastCommsErrorStrWLocked->data(),
-      lastCommsErrorStrWLocked->size(),
-      "%s",
-      fullError.c_str());
-  return lastCommsErrorStrWLocked->data();
+  return ss.str();
 }
 
 void appendErrorToStack(std::string error) {

--- a/comms/utils/logger/LoggingFormat.h
+++ b/comms/utils/logger/LoggingFormat.h
@@ -69,7 +69,7 @@ void initThreadMetaData(std::string_view threadName);
 
 fmt::memory_buffer getLogPrefix(LogLevel level);
 
-const char* getLastCommsError();
+std::string getLastCommsError();
 
 void appendErrorToStack(std::string error);
 

--- a/comms/utils/logger/tests/FormatterUT.cc
+++ b/comms/utils/logger/tests/FormatterUT.cc
@@ -198,9 +198,9 @@ TEST(LoggingFormat, getLastCommsErrorBasic) {
 
   formatter.formatMessage(errorMsg, category);
 
-  const char* lastError = meta::comms::logger::getLastCommsError();
-  EXPECT_NE(lastError, nullptr);
-  std::string errorStr(lastError);
+  auto lastError = meta::comms::logger::getLastCommsError();
+  EXPECT_FALSE(lastError.empty());
+  const auto& errorStr = lastError;
   EXPECT_TRUE(errorStr.find("Test error message") != std::string::npos);
   EXPECT_TRUE(errorStr.find("NCCL Stack trace:") != std::string::npos);
 }
@@ -228,9 +228,9 @@ TEST(LoggingFormat, getLastCommsErrorWithStack) {
   meta::comms::logger::appendErrorToStack("Stack frame 2");
   meta::comms::logger::appendErrorToStack("Stack frame 3");
 
-  const char* lastError = meta::comms::logger::getLastCommsError();
-  EXPECT_NE(lastError, nullptr);
-  std::string errorStr(lastError);
+  auto lastError = meta::comms::logger::getLastCommsError();
+  EXPECT_FALSE(lastError.empty());
+  const auto& errorStr = lastError;
   EXPECT_TRUE(errorStr.find("Error with stack") != std::string::npos);
   EXPECT_TRUE(errorStr.find("NCCL Stack trace:") != std::string::npos);
   EXPECT_TRUE(errorStr.find("Stack frame 1") != std::string::npos);
@@ -261,9 +261,9 @@ TEST(LoggingFormat, appendErrorToStackOrder) {
   meta::comms::logger::appendErrorToStack("Second");
   meta::comms::logger::appendErrorToStack("Third");
 
-  const char* lastError = meta::comms::logger::getLastCommsError();
-  EXPECT_NE(lastError, nullptr);
-  std::string errorStr(lastError);
+  auto lastError = meta::comms::logger::getLastCommsError();
+  EXPECT_FALSE(lastError.empty());
+  const auto& errorStr = lastError;
 
   size_t firstPos = errorStr.find("First");
   size_t secondPos = errorStr.find("Second");
@@ -295,9 +295,9 @@ TEST(LoggingFormat, getLastCommsErrorEmptyStack) {
 
   formatter.formatMessage(errorMsg, category);
 
-  const char* lastError = meta::comms::logger::getLastCommsError();
-  EXPECT_NE(lastError, nullptr);
-  std::string errorStr(lastError);
+  auto lastError = meta::comms::logger::getLastCommsError();
+  EXPECT_FALSE(lastError.empty());
+  const auto& errorStr = lastError;
   EXPECT_TRUE(errorStr.find("Error without stack") != std::string::npos);
   EXPECT_TRUE(errorStr.find("NCCL Stack trace:") != std::string::npos);
 }
@@ -331,9 +331,9 @@ TEST(LoggingFormat, nonErrorMessageDoesNotUpdateLastError) {
       "This is just info"};
   formatter.formatMessage(infoMsg, category);
 
-  const char* lastError = meta::comms::logger::getLastCommsError();
-  EXPECT_NE(lastError, nullptr);
-  std::string errorStr(lastError);
+  auto lastError = meta::comms::logger::getLastCommsError();
+  EXPECT_FALSE(lastError.empty());
+  const auto& errorStr = lastError;
   EXPECT_TRUE(errorStr.find("Initial error") != std::string::npos);
   EXPECT_FALSE(errorStr.find("This is just info") != std::string::npos);
 }


### PR DESCRIPTION
Summary:

Devmate review on D111436360 correctly noted previous laundering via local pointer did not fix underlying issue: getLastCommsError returned const char pointer pointing into buffer owned by folly Synchronized lock guard which is released on return, so concurrent writer can overwrite buffer while caller reads -> heap-use-after-free race. Previous version in this series changed to return std::string but still copied via intermediate shared buffer which could truncate at 4096 bytes.

Fix: change getLastCommsError signature to return std::string by value, copy under lock before returning, remove static lastCommsErrorStr buffer entirely to avoid truncation risk and simplify to return ss.str() directly. Update header, implementation, tests to expect std::string not nullptr (EXPECT_FALSE empty, const auto ref to avoid copy lint), and NCCL C API wrappers to maintain C ABI via thread_local static std::string storage holding copy and returning c_str() with try catch for noexcept safety. Remove dead static buffer definition and update header documentation.

Reviewed By: minsii

Differential Revision: D111447386


