### PR TITLE
Prims: eagerly post padding credit for p2p sendrecv (#3164)

### DIFF
--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -100,6 +100,11 @@ class TestIbTransport {
     return ibgda_ ? ibgda_->qpsPerBlockPerNic() : config_.qpsPerBlockPerNic;
   }
 
+  std::size_t pipeline_window() const {
+    return config_.perChannelSize *
+        static_cast<std::size_t>(config_.pipelineDepth);
+  }
+
   int getGidIndex() const {
     return ibgda_ ? ibgda_->getGidIndex() : config_.gidIndex.value_or(-1);
   }
@@ -1269,8 +1274,10 @@ TEST_F(
         output.size() * sizeof(int64_t),
         cudaMemcpyDeviceToHost));
 
-    EXPECT_EQ(output[0], static_cast<int64_t>(sendBytes));
-    EXPECT_EQ(output[1], static_cast<int64_t>(recvBytes));
+    const int64_t expectedReservation =
+        static_cast<int64_t>(dataBufferSize / numBlocks);
+    EXPECT_EQ(output[0], expectedReservation);
+    EXPECT_EQ(output[1], expectedReservation);
   } catch (const std::exception& e) {
     GTEST_SKIP() << "IBGDA transport not available: " << e.what();
   }
@@ -1507,6 +1514,84 @@ TEST_F(
     runDirection(1, rank1Pattern);
   } catch (const std::exception& e) {
     GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+TEST_P(
+    MultipeerIbTransportTestFixture,
+    TwoCallSendThenRecvPaddingCreditNoDeadlock) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+
+  constexpr std::size_t dataBufferSize = 64 * 1024;
+  constexpr int pipelineDepth = 1;
+  constexpr std::size_t maxSignalBytes = 0;
+  constexpr int numBlocks = 1;
+  constexpr int blockSize = 128;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  const uint8_t myPattern = static_cast<uint8_t>(0x40 + globalRank * 0x20);
+  const uint8_t peerPattern = static_cast<uint8_t>(0x40 + peerRank * 0x20);
+
+  try {
+    MultipeerIbTransportConfig config{
+        .cudaDevice = localRank,
+        .perChannelSize = dataBufferSize / numBlocks,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
+    };
+
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    TestIbTransport transport(
+        backend(), globalRank, numRanks, std::move(bootstrap), config);
+
+    P2pIbTransportDevice peerTransport =
+        transport.getP2pTransportDevice(peerRank);
+    const std::size_t firstBytes = transport.pipeline_window() / 2;
+    const std::size_t secondBytes = transport.pipeline_window();
+    const std::size_t totalBytes = firstBytes + secondBytes;
+    DeviceBuffer sendBuffer(totalBytes);
+    DeviceBuffer recvBuffer(totalBytes);
+    DeviceBuffer errorCountBuf(sizeof(int));
+    auto* d_errorCount = static_cast<int*>(errorCountBuf.get());
+
+    test::fillBufferWithPattern(
+        sendBuffer.get(), totalBytes, myPattern, numBlocks, blockSize);
+    CUDACHECK_TEST(cudaMemset(recvBuffer.get(), 0, totalBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    test::testTwoCallSendThenRecv(
+        peerTransport,
+        sendBuffer.get(),
+        recvBuffer.get(),
+        firstBytes,
+        secondBytes,
+        maxSignalBytes,
+        numBlocks,
+        blockSize);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+    test::verifyBufferPattern(
+        recvBuffer.get(),
+        totalBytes,
+        peerPattern,
+        d_errorCount,
+        numBlocks,
+        blockSize);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    int h_errorCount = 0;
+    CUDACHECK_TEST(cudaMemcpy(
+        &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
+    EXPECT_EQ(h_errorCount, 0) << "two-call send-then-recv transfer corrupted "
+                               << h_errorCount << " bytes";
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << backendName(backend())
+                 << " transport not available: " << e.what();
   }
 }
 

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -338,6 +338,27 @@ __global__ void sendRecvKernel(
   }
 }
 
+__global__ void twoCallSendThenRecvKernel(
+    P2pIbTransportDevice transport,
+    const void* sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t maxSignalBytes) {
+  auto group = make_block_group();
+  Timeout timeout(kDefaultDeviceTimeoutCycles);
+  timeout.start();
+  auto* sendBytes = static_cast<const char*>(sendBuffer);
+  auto* recvBytes = static_cast<char*>(recvBuffer);
+
+  transport.send(group, sendBytes, firstBytes, maxSignalBytes, timeout);
+  transport.recv(group, recvBytes, firstBytes, maxSignalBytes, timeout);
+  transport.send(
+      group, sendBytes + firstBytes, secondBytes, maxSignalBytes, timeout);
+  transport.recv(
+      group, recvBytes + firstBytes, secondBytes, maxSignalBytes, timeout);
+}
+
 void testSendRecv(
     P2pIbgdaTransportDevice* transport,
     void* buffer,
@@ -348,6 +369,29 @@ void testSendRecv(
     int blockSize) {
   sendRecvKernel<<<numBlocks, blockSize>>>(
       transport, buffer, nbytes, maxSignalBytes, send);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
+void testTwoCallSendThenRecv(
+    P2pIbTransportDevice transport,
+    const void* sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t maxSignalBytes,
+    int numBlocks,
+    int blockSize) {
+  twoCallSendThenRecvKernel<<<numBlocks, blockSize>>>(
+      transport,
+      sendBuffer,
+      recvBuffer,
+      firstBytes,
+      secondBytes,
+      maxSignalBytes);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
@@ -78,6 +78,14 @@ __global__ void sendRecvKernel(
     std::size_t maxSignalBytes,
     bool send);
 
+__global__ void twoCallSendThenRecvKernel(
+    P2pIbTransportDevice transport,
+    const void* sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t maxSignalBytes);
+
 #ifndef __HIP_PLATFORM_AMD__
 __global__ void progressSendRecvKernel(
     P2pIbgdaTransportDevice* transport,

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -135,6 +135,19 @@ void testSendRecv(
     int blockSize);
 
 /**
+ * Test kernel: two sequential bidirectional blocking send/recv calls.
+ */
+void testTwoCallSendThenRecv(
+    P2pIbTransportDevice transport,
+    const void* sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t maxSignalBytes,
+    int numBlocks,
+    int blockSize);
+
+/**
  * Test kernel: Resumable pipelined send or recv progress loop.
  */
 void testProgressSendRecv(

--- a/comms/prims/tests/P2pNvlTransportTest.cc
+++ b/comms/prims/tests/P2pNvlTransportTest.cc
@@ -48,6 +48,20 @@ MultiPeerNvlTransportConfig makeNvlConfig(
   };
 }
 
+static std::vector<char> makeTwoCallPatternBuffer(
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    int numBlocks,
+    int rank);
+
+static void expectTwoCallPattern(
+    const std::vector<char>& data,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    int numBlocks,
+    int sourceRank,
+    const std::string& label);
+
 TEST_F(P2pNvlTransportTestFixture, IpcMemAccess) {
   // Only test with 2 ranks
   if (numRanks != 2) {
@@ -262,6 +276,74 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCall) {
   }
 }
 
+TEST_F(
+    P2pNvlTransportTestFixture,
+    TileTwoCallSendThenRecvPaddingCreditNoDeadlock) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
+  }
+
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  const int numBlocks = 1;
+  const int threadCount = 256;
+  const size_t perChannelSize = 1024 * 1024;
+  const size_t pipelineDepth = 1;
+  const size_t maxSignalBytes = 0;
+
+  auto config = makeNvlConfig(perChannelSize, pipelineDepth, numBlocks);
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  auto p2pHost = transport.buildP2pTransportDevice(peerRank);
+
+  const size_t firstCallBytes = p2pHost.pipeline_window() / 2;
+  const size_t secondCallBytes = p2pHost.pipeline_window();
+  const size_t tileBytes = firstCallBytes + secondCallBytes;
+  const size_t totalBytes = tileBytes * numBlocks;
+  const std::vector<char> hostSend = makeTwoCallPatternBuffer(
+      firstCallBytes, secondCallBytes, numBlocks, globalRank);
+
+  DeviceBuffer sendBuf(totalBytes);
+  DeviceBuffer recvBuf(totalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf.get(), hostSend.data(), totalBytes, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, totalBytes));
+
+  TiledBuffer<char> sendTiles(
+      static_cast<char*>(sendBuf.get()), totalBytes, numBlocks);
+  TiledBuffer<char> recvTiles(
+      static_cast<char*>(recvBuf.get()), totalBytes, numBlocks);
+
+  int device = 0;
+  CUDACHECK_TEST(cudaGetDevice(&device));
+  Timeout timeout = makeTimeout(5000, device);
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  test::testTileTwoCallSendThenRecv(
+      p2pHost,
+      sendTiles,
+      recvTiles,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      threadCount,
+      timeout);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  std::vector<char> hostRecv(totalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostRecv.data(), recvBuf.get(), totalBytes, cudaMemcpyDeviceToHost));
+  expectTwoCallPattern(
+      hostRecv,
+      firstCallBytes,
+      secondCallBytes,
+      numBlocks,
+      peerRank,
+      "tile send-then-recv padding credit");
+}
+
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvCudaGraphReplay) {
   if (numRanks != 2) {
     XLOGF(WARNING, "Skipping: requires 2 ranks, got {}", numRanks);
@@ -426,6 +508,35 @@ static size_t alignTileProtocolBytes(size_t nbytes) {
   return (nbytes + 15ULL) & ~15ULL;
 }
 
+static uint64_t roundUpToMultiple(uint64_t value, size_t alignment) {
+  if (alignment == 0) {
+    return value;
+  }
+  const uint64_t alignment64 = static_cast<uint64_t>(alignment);
+  return ((value + alignment64 - 1) / alignment64) * alignment64;
+}
+
+static size_t signalAlignment(size_t maxSignalBytes, size_t perBlockSlotSize) {
+  const bool usesPartialSlot =
+      maxSignalBytes > 0 && maxSignalBytes < perBlockSlotSize;
+  size_t alignment =
+      usesPartialSlot ? (maxSignalBytes & ~15ULL) : perBlockSlotSize;
+  return alignment == 0 ? perBlockSlotSize : alignment;
+}
+
+static size_t protocolStepBytes(
+    uint64_t baseByte,
+    size_t payloadBytes,
+    size_t maxSignalBytes,
+    size_t perBlockSlotSize) {
+  const size_t protocolBytes = alignTileProtocolBytes(payloadBytes);
+  const size_t alignment = signalAlignment(maxSignalBytes, perBlockSlotSize);
+  const uint64_t payloadEnd = baseByte + protocolBytes;
+  return protocolBytes +
+      static_cast<size_t>(
+             roundUpToMultiple(payloadEnd, alignment) - payloadEnd);
+}
+
 static size_t
 validPayloadBytes(size_t byteOffset, size_t chunkBytes, size_t payloadBytes) {
   if (byteOffset >= payloadBytes) {
@@ -535,7 +646,8 @@ static void expectPersistentTwoCallStagingPattern(
         }
         dataOff += chunkBytes;
       }
-      baseByte += protocolBytes;
+      baseByte += protocolStepBytes(
+          baseByte, callBytes[call], maxSignalBytes, perBlockSlotSize);
     }
   }
 }
@@ -981,8 +1093,13 @@ TEST_F(
   const size_t maxSignalBytes = 64;
   const size_t tileBytes = firstCallBytes + secondCallBytes;
   const size_t totalBytes = tileBytes * numBlocks;
-  const size_t expectedStep = alignTileProtocolBytes(firstCallBytes) +
-      alignTileProtocolBytes(secondCallBytes);
+  const size_t firstCallStepBytes =
+      protocolStepBytes(0, firstCallBytes, maxSignalBytes, perBlockSlotSize);
+  const size_t expectedStep = firstCallStepBytes +
+      protocolStepBytes(firstCallStepBytes,
+                        secondCallBytes,
+                        maxSignalBytes,
+                        perBlockSlotSize);
 
   P2pNvlTransportOptions options{
       .dataBufferSize = perBlockSlotSize * numBlocks,
@@ -1028,8 +1145,7 @@ TEST_F(
       numBlocks,
       0,
       "tile send unaligned protocol staging");
-  for (size_t i = firstCallBytes; i < alignTileProtocolBytes(firstCallBytes);
-       ++i) {
+  for (size_t i = firstCallBytes; i < firstCallStepBytes; ++i) {
     EXPECT_EQ(static_cast<unsigned char>(hostStaging[i]), 0)
         << "padding byte " << i
         << " between unaligned calls should stay transport-private";
@@ -1097,8 +1213,13 @@ TEST_F(
   const size_t maxSignalBytes = 64;
   const size_t tileBytes = firstCallBytes + secondCallBytes;
   const size_t totalBytes = tileBytes * numBlocks;
-  const size_t expectedStep = alignTileProtocolBytes(firstCallBytes) +
-      alignTileProtocolBytes(secondCallBytes);
+  const size_t firstCallStepBytes =
+      protocolStepBytes(0, firstCallBytes, maxSignalBytes, perBlockSlotSize);
+  const size_t expectedStep = firstCallStepBytes +
+      protocolStepBytes(firstCallStepBytes,
+                        secondCallBytes,
+                        maxSignalBytes,
+                        perBlockSlotSize);
 
   P2pNvlTransportOptions options{
       .dataBufferSize = perBlockSlotSize * numBlocks,
@@ -1165,8 +1286,7 @@ TEST_F(
       numBlocks,
       0,
       "tile forward unaligned protocol successor staging");
-  for (size_t i = firstCallBytes; i < alignTileProtocolBytes(firstCallBytes);
-       ++i) {
+  for (size_t i = firstCallBytes; i < firstCallStepBytes; ++i) {
     EXPECT_EQ(static_cast<unsigned char>(hostSuccStaging[i]), 0)
         << "forward padding byte " << i
         << " between unaligned calls should stay transport-private";

--- a/comms/prims/tests/P2pNvlTransportTest.cu
+++ b/comms/prims/tests/P2pNvlTransportTest.cu
@@ -19,6 +19,43 @@ __device__ inline ThreadGroup make_group(GroupType groupType) {
   }
 }
 
+__device__ inline size_t align_protocol_bytes(size_t nbytes) {
+  return (nbytes + 15ULL) & ~15ULL;
+}
+
+__device__ inline uint64_t round_up_to_multiple(
+    uint64_t value,
+    size_t alignment) {
+  if (alignment == 0) {
+    return value;
+  }
+  const uint64_t alignment64 = static_cast<uint64_t>(alignment);
+  return ((value + alignment64 - 1) / alignment64) * alignment64;
+}
+
+__device__ inline size_t signal_alignment(
+    size_t maxSignalBytes,
+    size_t perBlockSlotSize) {
+  const bool usesPartialSlot =
+      maxSignalBytes > 0 && maxSignalBytes < perBlockSlotSize;
+  size_t alignment =
+      usesPartialSlot ? (maxSignalBytes & ~15ULL) : perBlockSlotSize;
+  return alignment == 0 ? perBlockSlotSize : alignment;
+}
+
+__device__ inline size_t protocol_step_bytes(
+    uint64_t baseByte,
+    size_t payloadBytes,
+    size_t maxSignalBytes,
+    size_t perBlockSlotSize) {
+  const size_t protocolBytes = align_protocol_bytes(payloadBytes);
+  const size_t alignment = signal_alignment(maxSignalBytes, perBlockSlotSize);
+  const uint64_t payloadEnd = baseByte + protocolBytes;
+  return protocolBytes +
+      static_cast<size_t>(
+             round_up_to_multiple(payloadEnd, alignment) - payloadEnd);
+}
+
 __global__ void testTileSendKernel(
     P2pNvlTransportDevice p2p,
     void* src_d,
@@ -156,6 +193,37 @@ __global__ void testTileTwoCallVariableSignalSendRecvKernel(
         secondMaxSignalBytes,
         timeout);
   }
+}
+
+__global__ void testTileTwoCallSendThenRecvKernel(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t maxSignalBytes,
+    Timeout timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  const int blockId = group.group_id;
+  char* sendTile = sendTiles.tile_data(blockId);
+  char* recvTile = recvTiles.tile_data(blockId);
+
+  p2p.send(group, sendTile, firstCallBytes, maxSignalBytes, timeout);
+  p2p.recv(group, recvTile, firstCallBytes, maxSignalBytes, timeout);
+  p2p.send(
+      group,
+      sendTile + firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      timeout);
+  p2p.recv(
+      group,
+      recvTile + firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      timeout);
 }
 
 __global__ void testTileMultiCallSendOnlyKernel(
@@ -314,7 +382,7 @@ __global__ void testPrepareTileStagingKernel(
   uint64_t baseByte = 0;
   for (int call = 0; call < numCalls; ++call) {
     const char pattern = static_cast<char>(0x30 + sourceRank * 0x20 + call);
-    const size_t protocolBytes = (bytesPerCall + 15ULL) & ~15ULL;
+    const size_t protocolBytes = align_protocol_bytes(bytesPerCall);
     for (size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const size_t pipelineOff =
@@ -338,7 +406,8 @@ __global__ void testPrepareTileStagingKernel(
       }
       dataOff += copyBytes;
     }
-    baseByte += protocolBytes;
+    baseByte += protocol_step_bytes(
+        baseByte, bytesPerCall, maxSignalBytes, perBlockSlotSize);
   }
 
   group.sync();
@@ -374,7 +443,7 @@ __global__ void testPrepareTileTwoCallStagingKernel(
   for (int call = 0; call < 2; ++call) {
     const size_t callBytes = call == 0 ? firstCallBytes : secondCallBytes;
     const char pattern = static_cast<char>(0x30 + sourceRank * 0x20 + call);
-    const size_t protocolBytes = (callBytes + 15ULL) & ~15ULL;
+    const size_t protocolBytes = align_protocol_bytes(callBytes);
     for (size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const size_t pipelineOff =
@@ -398,7 +467,8 @@ __global__ void testPrepareTileTwoCallStagingKernel(
       }
       dataOff += copyBytes;
     }
-    baseByte += protocolBytes;
+    baseByte += protocol_step_bytes(
+        baseByte, callBytes, maxSignalBytes, perBlockSlotSize);
   }
 
   group.sync();
@@ -619,6 +689,28 @@ void testTileTwoCallVariableSignalSendRecv(
       firstMaxSignalBytes,
       secondMaxSignalBytes,
       waitForSecondCallSignal,
+      timeout);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testTileTwoCallSendThenRecv(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t maxSignalBytes,
+    int blockSize,
+    Timeout timeout,
+    cudaStream_t stream) {
+  testTileTwoCallSendThenRecvKernel<<<activeBlocks, blockSize, 0, stream>>>(
+      p2p,
+      sendTiles,
+      recvTiles,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
       timeout);
   PIPES_KERNEL_LAUNCH_CHECK();
 }

--- a/comms/prims/tests/P2pNvlTransportTest.cuh
+++ b/comms/prims/tests/P2pNvlTransportTest.cuh
@@ -65,6 +65,18 @@ void testTileTwoCallVariableSignalSendRecv(
     Timeout timeout = Timeout(),
     cudaStream_t stream = nullptr);
 
+void testTileTwoCallSendThenRecv(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t maxSignalBytes,
+    int blockSize,
+    Timeout timeout = Timeout(),
+    cudaStream_t stream = nullptr);
+
 void testTileMultiCallSendOnly(
     P2pNvlTransportDevice p2p,
     TiledBuffer<char> sendTiles,

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -122,7 +122,12 @@ __device__ __forceinline__ static uint64_t round_up_to_multiple(
     uint64_t value,
     std::size_t alignment);
 
-__device__ __forceinline__ static std::size_t padding_for_signal_granularity(
+__device__ __forceinline__ static std::size_t signal_alignment(
+    std::size_t maxSignalBytes,
+    std::size_t perBlockSlot);
+
+__device__ __forceinline__ static std::size_t
+tail_padding_for_signal_granularity(
     uint64_t baseByte,
     std::size_t maxSignalBytes,
     std::size_t perBlockSlot,
@@ -380,8 +385,12 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
   if (state.activeStage == detail::IbSendRecvProgressStage::WaitNicDone) {
     const ProgressChunk chunk =
         next_chunk(channelLayout, state, progress_params);
-    if (chunk.streamEnd > pipelineBytes) {
-      const uint64_t expected = chunk.streamEnd - pipelineBytes;
+    const bool isFinalChunk =
+        chunk.dataOff + chunk.bytes >= progress_params.protocolBytes;
+    const uint64_t protocolStreamEnd =
+        chunk.streamEnd + (isFinalChunk ? state.activeTailPadding : 0);
+    if (protocolStreamEnd > pipelineBytes) {
+      const uint64_t expected = protocolStreamEnd - pipelineBytes;
       uint32_t ready = 1;
       unsigned long long current = 0;
       if (group.is_leader()) {
@@ -422,8 +431,12 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
   if (state.activeStage == detail::IbSendRecvProgressStage::WaitSlotFree) {
     const ProgressChunk chunk =
         next_chunk(channelLayout, state, progress_params);
-    if (chunk.streamEnd > pipelineBytes) {
-      const uint64_t expected = chunk.streamEnd - pipelineBytes;
+    const bool isFinalChunk =
+        chunk.dataOff + chunk.bytes >= progress_params.protocolBytes;
+    const uint64_t protocolStreamEnd =
+        chunk.streamEnd + (isFinalChunk ? state.activeTailPadding : 0);
+    if (protocolStreamEnd > pipelineBytes) {
+      const uint64_t expected = protocolStreamEnd - pipelineBytes;
       uint32_t ready = 1;
       unsigned long long current = 0;
       if (group.is_leader()) {
@@ -455,15 +468,17 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
     if (group.is_leader()) {
       ThreadGroup solo{
           0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+      const std::size_t protocolBytesThis =
+          chunk.bytes + (isFinalChunk ? state.activeTailPadding : 0);
       transport.put(
           solo,
           channelLayout.sendStagingBuf.subBuffer(chunk.stagingOff),
           remoteChannel.recvStaging.subBuffer(chunk.stagingOff),
           chunk.bytes,
           remoteChannel.dataReady,
-          chunk.bytes + (chunk.dataOff == 0 ? state.activeProtocolPadding : 0),
+          protocolBytesThis,
           localNicDoneCompletion,
-          chunk.bytes + (chunk.dataOff == 0 ? state.activeProtocolPadding : 0),
+          protocolBytesThis,
           /*signalPerLane=*/true);
     }
     group.sync();
@@ -665,6 +680,10 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
   validate_recv_progress_stage(group, state);
 
   const ProgressChunk chunk = next_chunk(channelLayout, state, progress_params);
+  const bool isFinalChunk =
+      chunk.dataOff + chunk.bytes >= progress_params.protocolBytes;
+  const std::size_t protocolBytesThis =
+      chunk.bytes + (isFinalChunk ? state.activeTailPadding : 0);
   IbLocalChannel& localChannel =
       transport.local_channel(static_cast<uint32_t>(progress_params.groupId));
   const IbgdaLocalBuffer localDataReady = localChannel.dataReady;
@@ -680,8 +699,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
                 transport,
                 localChannel,
                 localDataReady,
-                chunk.bytes +
-                    (chunk.dataOff == 0 ? state.activeProtocolPadding : 0),
+                protocolBytesThis,
                 current,
                 expected)
         ? 1U
@@ -715,10 +733,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
 
   // SLOT_FREE, posted unbatched every chunk back to the sender.
   transport.signal(
-      group,
-      remoteChannel.slotFree,
-      chunk.bytes + (chunk.dataOff == 0 ? state.activeProtocolPadding : 0),
-      IbDirection::Recv);
+      group, remoteChannel.slotFree, protocolBytesThis, IbDirection::Recv);
 
   state.activeNextByte += chunk.bytes;
   if (active_payload_offset(state) >= progress_params.protocolBytes) {
@@ -847,16 +862,16 @@ __device__ __forceinline__ void send(
       makeIbRemoteChannel(channelLayout, groupId);
   assert_progress_slot_idle(group, state, "send");
   const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
-  const std::size_t protocolPadding = padding_for_signal_granularity(
+  const std::size_t protocolTailPadding = tail_padding_for_signal_granularity(
       baseByte, max_signal_bytes, perBlockSlot, nbytes);
-  const uint64_t payloadBaseByte = baseByte + protocolPadding;
-  const std::size_t protocolBytes = protocolPadding + payloadProtocolBytes;
+  const uint64_t payloadBaseByte = baseByte;
+  const std::size_t protocolBytes = payloadProtocolBytes + protocolTailPadding;
   const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
   if (group.is_leader()) {
     state.activeStage = detail::IbSendRecvProgressStage::Busy;
     state.activeBaseStep = static_cast<int64_t>(baseByte);
-    state.activeNextByte = protocolPadding;
-    state.activeProtocolPadding = protocolPadding;
+    state.activeNextByte = 0;
+    state.activeTailPadding = protocolTailPadding;
   }
 
   for (std::size_t dataOff = 0; dataOff < payloadProtocolBytes;) {
@@ -871,15 +886,16 @@ __device__ __forceinline__ void send(
     std::size_t bytesThis =
         chunkSize < dataRemaining ? chunkSize : dataRemaining;
     bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
+    const bool isFinalChunk = dataOff + bytesThis >= payloadProtocolBytes;
     const std::size_t protocolBytesThis =
-        bytesThis + (dataOff == 0 ? protocolPadding : 0);
+        bytesThis + (isFinalChunk ? protocolTailPadding : 0);
     const std::size_t stagingOff = slotOff + groupId * perBlockSlot + chunkOff;
-    const uint64_t streamEnd = streamStart + bytesThis;
+    const uint64_t protocolStreamEnd = streamStart + protocolBytesThis;
 
     // (1) Wait for NIC to finish with this slot's local sendStaging.
-    if (streamEnd > pipelineBytes) {
+    if (protocolStreamEnd > pipelineBytes) {
       transport.wait_counter(
-          group, localNicDoneWait, streamEnd - pipelineBytes, timeout);
+          group, localNicDoneWait, protocolStreamEnd - pipelineBytes, timeout);
     }
 
     // (2) Cooperative copy: src -> local sendStaging via CopyOp.
@@ -898,9 +914,9 @@ __device__ __forceinline__ void send(
 
     // (3) Backpressure: wait for receiver to free this byte range's
     //     recvStaging offset. Symmetric with DATA_READY.
-    if (streamEnd > pipelineBytes) {
+    if (protocolStreamEnd > pipelineBytes) {
       transport.wait_signal(
-          group, localSlotFree, streamEnd - pipelineBytes, timeout);
+          group, localSlotFree, protocolStreamEnd - pipelineBytes, timeout);
     }
 
     // (4) threadfence_system + leader-only single-WQE RDMA put with
@@ -931,7 +947,7 @@ __device__ __forceinline__ void send(
     state.activeStage = detail::IbSendRecvProgressStage::Done;
     state.activeBaseStep = 0;
     state.activeNextByte = 0;
-    state.activeProtocolPadding = 0;
+    state.activeTailPadding = 0;
   }
   group.sync();
 #endif
@@ -1029,16 +1045,16 @@ __device__ __forceinline__ void recv(
       makeIbRemoteChannel(channelLayout, groupId);
   assert_progress_slot_idle(group, state, "recv");
   const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
-  const std::size_t protocolPadding = padding_for_signal_granularity(
+  const std::size_t protocolTailPadding = tail_padding_for_signal_granularity(
       baseByte, max_signal_bytes, perBlockSlot, nbytes);
-  const uint64_t payloadBaseByte = baseByte + protocolPadding;
-  const std::size_t protocolBytes = protocolPadding + payloadProtocolBytes;
+  const uint64_t payloadBaseByte = baseByte;
+  const std::size_t protocolBytes = payloadProtocolBytes + protocolTailPadding;
   const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
   if (group.is_leader()) {
     state.activeStage = detail::IbSendRecvProgressStage::Busy;
     state.activeBaseStep = static_cast<int64_t>(baseByte);
-    state.activeNextByte = protocolPadding;
-    state.activeProtocolPadding = protocolPadding;
+    state.activeNextByte = 0;
+    state.activeTailPadding = protocolTailPadding;
   }
 
   for (std::size_t dataOff = 0; dataOff < payloadProtocolBytes;) {
@@ -1053,6 +1069,9 @@ __device__ __forceinline__ void recv(
     std::size_t bytesThis =
         chunkSize < dataRemaining ? chunkSize : dataRemaining;
     bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
+    const bool isFinalChunk = dataOff + bytesThis >= payloadProtocolBytes;
+    const std::size_t protocolBytesThis =
+        bytesThis + (isFinalChunk ? protocolTailPadding : 0);
     const std::size_t stagingOff = slotOff + groupId * perBlockSlot + chunkOff;
 
     // (1) Wait for sender's DATA_READY on the specific round-robin lane that
@@ -1062,7 +1081,7 @@ __device__ __forceinline__ void recv(
         group,
         localChannel,
         localDataReady,
-        bytesThis + (dataOff == 0 ? protocolPadding : 0),
+        protocolBytesThis,
         timeout);
 
     // (2) Cooperative copy: local recvStaging -> dst via CopyOp.
@@ -1083,10 +1102,7 @@ __device__ __forceinline__ void recv(
     //     waits on the cumulative byte threshold before reusing remote
     //     recvStaging at the same offset.
     transport.signal(
-        group,
-        remoteChannel.slotFree,
-        bytesThis + (dataOff == 0 ? protocolPadding : 0),
-        IbDirection::Recv);
+        group, remoteChannel.slotFree, protocolBytesThis, IbDirection::Recv);
     dataOff += bytesThis;
   }
 
@@ -1095,7 +1111,7 @@ __device__ __forceinline__ void recv(
     state.activeStage = detail::IbSendRecvProgressStage::Done;
     state.activeBaseStep = 0;
     state.activeNextByte = 0;
-    state.activeProtocolPadding = 0;
+    state.activeTailPadding = 0;
   }
   group.sync();
 #endif
@@ -1243,11 +1259,12 @@ __device__ __forceinline__ void forward(
       makeIbRemoteChannel(channelLayout, groupId);
   assert_progress_slot_idle(group, recvSlotState, "forward recv");
   const uint64_t recvBaseByte = static_cast<uint64_t>(recvSlotState.nextStep);
-  const std::size_t recvProtocolPadding = padding_for_signal_granularity(
-      recvBaseByte, max_signal_bytes, recvPerBlockSlot, nbytes);
-  const uint64_t recvPayloadBaseByte = recvBaseByte + recvProtocolPadding;
+  const std::size_t recvProtocolTailPadding =
+      tail_padding_for_signal_granularity(
+          recvBaseByte, max_signal_bytes, recvPerBlockSlot, nbytes);
+  const uint64_t recvPayloadBaseByte = recvBaseByte;
   const std::size_t recvProtocolBytes =
-      recvProtocolPadding + payloadProtocolBytes;
+      payloadProtocolBytes + recvProtocolTailPadding;
   const std::size_t recvPipelineBytes = recvPerBlockSlot * recvPipelineDepth;
 
   const int fwdPipelineDepth = fwdChannelLayout.pipelineDepth;
@@ -1263,21 +1280,22 @@ __device__ __forceinline__ void forward(
       makeIbRemoteChannel(fwdChannelLayout, groupId);
   assert_progress_slot_idle(group, fwdSlotState, "forward send");
   const uint64_t fwdBaseByte = static_cast<uint64_t>(fwdSlotState.nextStep);
-  const std::size_t fwdProtocolPadding = padding_for_signal_granularity(
-      fwdBaseByte, max_signal_bytes, fwdPerBlockSlot, nbytes);
-  const uint64_t fwdPayloadBaseByte = fwdBaseByte + fwdProtocolPadding;
+  const std::size_t fwdProtocolTailPadding =
+      tail_padding_for_signal_granularity(
+          fwdBaseByte, max_signal_bytes, fwdPerBlockSlot, nbytes);
+  const uint64_t fwdPayloadBaseByte = fwdBaseByte;
   const std::size_t fwdProtocolBytes =
-      fwdProtocolPadding + payloadProtocolBytes;
+      payloadProtocolBytes + fwdProtocolTailPadding;
   const std::size_t fwdPipelineBytes = fwdPerBlockSlot * fwdPipelineDepth;
   if (group.is_leader()) {
     recvSlotState.activeStage = detail::IbSendRecvProgressStage::Busy;
     recvSlotState.activeBaseStep = static_cast<int64_t>(recvBaseByte);
-    recvSlotState.activeNextByte = recvProtocolPadding;
-    recvSlotState.activeProtocolPadding = recvProtocolPadding;
+    recvSlotState.activeNextByte = 0;
+    recvSlotState.activeTailPadding = recvProtocolTailPadding;
     fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Busy;
     fwdSlotState.activeBaseStep = static_cast<int64_t>(fwdBaseByte);
-    fwdSlotState.activeNextByte = fwdProtocolPadding;
-    fwdSlotState.activeProtocolPadding = fwdProtocolPadding;
+    fwdSlotState.activeNextByte = 0;
+    fwdSlotState.activeTailPadding = fwdProtocolTailPadding;
   }
 
   for (std::size_t dataOff = 0; dataOff < payloadProtocolBytes;) {
@@ -1309,11 +1327,12 @@ __device__ __forceinline__ void forward(
     bytesThis = bytesThis < dataRemaining ? bytesThis : dataRemaining;
     bytesThis = bytesThis < recvSlotRemaining ? bytesThis : recvSlotRemaining;
     bytesThis = bytesThis < fwdSlotRemaining ? bytesThis : fwdSlotRemaining;
+    const bool isFinalChunk = dataOff + bytesThis >= payloadProtocolBytes;
     const std::size_t recvProtocolBytesThis =
-        bytesThis + (dataOff == 0 ? recvProtocolPadding : 0);
+        bytesThis + (isFinalChunk ? recvProtocolTailPadding : 0);
     const std::size_t fwdProtocolBytesThis =
-        bytesThis + (dataOff == 0 ? fwdProtocolPadding : 0);
-    const uint64_t fwdStreamEnd = fwdStreamStart + bytesThis;
+        bytesThis + (isFinalChunk ? fwdProtocolTailPadding : 0);
+    const uint64_t fwdProtocolStreamEnd = fwdStreamStart + fwdProtocolBytesThis;
 
     // (1) Wait for the upstream sender's DATA_READY on the specific round-robin
     //     lane that carried this chunk (mirrors the upstream sender's Send
@@ -1327,9 +1346,12 @@ __device__ __forceinline__ void forward(
         timeout);
 
     // (2) Wait for NIC_DONE on fwd's sendStaging (backpressure).
-    if (fwdStreamEnd > fwdPipelineBytes) {
+    if (fwdProtocolStreamEnd > fwdPipelineBytes) {
       fwdTransport.wait_counter(
-          group, fwdNicDoneWait, fwdStreamEnd - fwdPipelineBytes, timeout);
+          group,
+          fwdNicDoneWait,
+          fwdProtocolStreamEnd - fwdPipelineBytes,
+          timeout);
     }
 
     // (3) CopyOp::forward — transform recv staging -> dst + fwd staging.
@@ -1357,9 +1379,9 @@ __device__ __forceinline__ void forward(
 
     // (5) Wait for fwd receiver's SLOT_FREE (backpressure on fwd's
     //     recvStaging).
-    if (fwdStreamEnd > fwdPipelineBytes) {
+    if (fwdProtocolStreamEnd > fwdPipelineBytes) {
       fwdTransport.wait_signal(
-          group, fwdSlotFree, fwdStreamEnd - fwdPipelineBytes, timeout);
+          group, fwdSlotFree, fwdProtocolStreamEnd - fwdPipelineBytes, timeout);
     }
 
     // (6) threadfence_system + RDMA put via fwd transport.
@@ -1390,13 +1412,13 @@ __device__ __forceinline__ void forward(
     recvSlotState.activeStage = detail::IbSendRecvProgressStage::Done;
     recvSlotState.activeBaseStep = 0;
     recvSlotState.activeNextByte = 0;
-    recvSlotState.activeProtocolPadding = 0;
+    recvSlotState.activeTailPadding = 0;
     fwdSlotState.nextStep =
         static_cast<int64_t>(fwdBaseByte + fwdProtocolBytes);
     fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Done;
     fwdSlotState.activeBaseStep = 0;
     fwdSlotState.activeNextByte = 0;
-    fwdSlotState.activeProtocolPadding = 0;
+    fwdSlotState.activeTailPadding = 0;
   }
   group.sync();
 #else
@@ -1448,26 +1470,37 @@ __device__ __forceinline__ static uint64_t round_up_to_multiple(
   return ((value + alignment64 - 1) / alignment64) * alignment64;
 }
 
+__device__ __forceinline__ static std::size_t signal_alignment(
+    std::size_t maxSignalBytes,
+    std::size_t perBlockSlot) {
+  const bool usesPartialSlot =
+      maxSignalBytes > 0 && maxSignalBytes < perBlockSlot;
+  std::size_t alignment =
+      usesPartialSlot ? (maxSignalBytes & ~15ULL) : perBlockSlot;
+  return alignment == 0 ? perBlockSlot : alignment;
+}
+
 /**
- * Keep long transfers aligned to their signaling granularity when previous
- * calls leave the persistent stream cursor in the middle of that granularity.
- * Small payloads keep their natural cadence instead of paying a full-boundary
- * protocol advance.
+ * Pad the current operation's protocol byte stream to the signaling boundary.
+ *
+ * Padding is credit-only: payload copies and RDMA writes still cover only
+ * aligned payload protocol bytes. The final DATA_READY/NIC_DONE/SLOT_FREE
+ * update carries this tail padding so the next operation starts on an aligned
+ * protocol cursor without needing a future recv to publish padding credit.
  */
-__device__ __forceinline__ static std::size_t padding_for_signal_granularity(
+__device__ __forceinline__ static std::size_t
+tail_padding_for_signal_granularity(
     uint64_t baseByte,
     std::size_t maxSignalBytes,
     std::size_t perBlockSlot,
     std::size_t payloadBytes) {
-  const bool usesPartialSlot =
-      maxSignalBytes > 0 && maxSignalBytes < perBlockSlot;
-  const std::size_t alignment =
-      usesPartialSlot ? (maxSignalBytes & ~15ULL) : perBlockSlot;
-  if (alignment == 0 || align_protocol_bytes(payloadBytes) < alignment) {
+  const std::size_t alignment = signal_alignment(maxSignalBytes, perBlockSlot);
+  if (alignment == 0) {
     return 0;
   }
+  const uint64_t payloadEnd = baseByte + align_protocol_bytes(payloadBytes);
   return static_cast<std::size_t>(
-      round_up_to_multiple(baseByte, alignment) - baseByte);
+      round_up_to_multiple(payloadEnd, alignment) - payloadEnd);
 }
 
 __device__ __forceinline__ static std::size_t valid_payload_bytes(
@@ -1572,7 +1605,7 @@ __device__ __forceinline__ void store_progress_state(
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   if (group.is_leader()) {
     slot.activeNextByte = state.activeNextByte;
-    slot.activeProtocolPadding = state.activeProtocolPadding;
+    slot.activeTailPadding = state.activeTailPadding;
     slot.activeBaseStep = state.activeBaseStep;
     slot.activeStage = state.activeStage;
   }
@@ -1673,9 +1706,7 @@ __device__ __forceinline__ ProgressGeometry make_progress_geometry(
 
 __device__ __forceinline__ std::size_t active_payload_offset(
     const IbChannelProgress& state) {
-  return state.activeNextByte > state.activeProtocolPadding
-      ? state.activeNextByte - state.activeProtocolPadding
-      : 0;
+  return state.activeNextByte;
 }
 
 /**
@@ -1683,9 +1714,8 @@ __device__ __forceinline__ std::size_t active_payload_offset(
  *
  * Blocking send()/recv() read the channel cursor at call entry and commit it
  * at completion. Progress init reserves immediately because operations may
- * complete across many bounded calls. The active byte cursor starts after any
- * protocol-only padding, so progress copies begin at the first payload byte
- * while signals/counters still advance the full padded stream.
+ * complete across many bounded calls. The active byte cursor tracks payload
+ * protocol bytes; final signals/counters carry any tail padding reserved here.
  */
 __device__ __forceinline__ void reserve_progress_step(
     ThreadGroup& group,
@@ -1694,22 +1724,22 @@ __device__ __forceinline__ void reserve_progress_step(
     const ProgressGeometry& geometry) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint64_t baseStep = 0;
-  uint64_t protocolPadding = 0;
+  uint64_t protocolTailPadding = 0;
   if (group.is_leader()) {
     baseStep = static_cast<uint64_t>(slot.nextStep);
-    protocolPadding = padding_for_signal_granularity(
+    protocolTailPadding = tail_padding_for_signal_granularity(
         baseStep,
         geometry.chunkSize,
         geometry.perBlockSlot,
         geometry.payloadBytes);
     slot.nextStep = static_cast<int64_t>(
-        baseStep + protocolPadding + geometry.protocolBytes);
+        baseStep + geometry.protocolBytes + protocolTailPadding);
   }
   baseStep = group.broadcast<uint64_t>(baseStep);
-  protocolPadding = group.broadcast<uint64_t>(protocolPadding);
+  protocolTailPadding = group.broadcast<uint64_t>(protocolTailPadding);
   state.activeBaseStep = static_cast<int64_t>(baseStep);
-  state.activeNextByte = static_cast<std::size_t>(protocolPadding);
-  state.activeProtocolPadding = static_cast<std::size_t>(protocolPadding);
+  state.activeNextByte = 0;
+  state.activeTailPadding = static_cast<std::size_t>(protocolTailPadding);
 #else
   (void)group;
   (void)slot;

--- a/comms/prims/transport/ibgda/IbgdaBuffer.h
+++ b/comms/prims/transport/ibgda/IbgdaBuffer.h
@@ -443,7 +443,7 @@ enum class IbSendRecvProgressStage : uint8_t {
 struct IbChannelProgress {
   int64_t nextStep{0};
   std::size_t activeNextByte{0};
-  std::size_t activeProtocolPadding{0};
+  std::size_t activeTailPadding{0};
   int64_t activeBaseStep{0};
   detail::IbSendRecvProgressStage activeStage{
       detail::IbSendRecvProgressStage::Done};

--- a/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
@@ -511,21 +511,31 @@ class P2pNvlTransportDevice {
 
     const uint64_t baseByte = static_cast<uint64_t>(local_ch.send_cursor);
 
-    const std::size_t protocolBytes = align_tile_protocol_bytes(nbytes);
-    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
+    const std::size_t payloadProtocolBytes = align_tile_protocol_bytes(nbytes);
+    const std::size_t protocolTailPadding = tail_padding_for_signal_granularity(
+        baseByte, max_signal_bytes, layout.perChannelSlot, nbytes);
+    const std::size_t protocolBytes =
+        payloadProtocolBytes + protocolTailPadding;
+    for (std::size_t dataOff = 0; dataOff < payloadProtocolBytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const NvlPipelinePosition position = layout.position(streamStart);
-      const std::size_t dataRemaining = protocolBytes - dataOff;
+      const std::size_t dataRemaining = payloadProtocolBytes - dataOff;
       std::size_t copyBytes = layout.effectiveChunk < dataRemaining
           ? layout.effectiveChunk
           : dataRemaining;
       copyBytes = copyBytes < position.slotRemaining ? copyBytes
                                                      : position.slotRemaining;
+      const bool isFinalChunk = dataOff + copyBytes >= payloadProtocolBytes;
       const uint64_t streamEnd = streamStart + copyBytes;
+      const uint64_t protocolStreamEnd =
+          streamEnd + (isFinalChunk ? protocolTailPadding : 0);
 
-      if (streamEnd > layout.pipelineBytes) {
+      if (protocolStreamEnd > layout.pipelineBytes) {
         local_ch.slot_free.wait_until(
-            group, CmpOp::CMP_GE, streamEnd - layout.pipelineBytes, timeout);
+            group,
+            CmpOp::CMP_GE,
+            protocolStreamEnd - layout.pipelineBytes,
+            timeout);
       }
 
       const std::size_t validBytes =
@@ -540,7 +550,7 @@ class P2pNvlTransportDevice {
 
       group.sync();
       if (group.is_leader()) {
-        remote_ch.data_ready.signal(SignalOp::SIGNAL_SET, streamEnd);
+        remote_ch.data_ready.signal(SignalOp::SIGNAL_SET, protocolStreamEnd);
       }
       dataOff += copyBytes;
     }
@@ -577,17 +587,24 @@ class P2pNvlTransportDevice {
 
     const uint64_t baseByte = static_cast<uint64_t>(local_ch.recv_cursor);
 
-    const std::size_t protocolBytes = align_tile_protocol_bytes(nbytes);
-    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
+    const std::size_t payloadProtocolBytes = align_tile_protocol_bytes(nbytes);
+    const std::size_t protocolTailPadding = tail_padding_for_signal_granularity(
+        baseByte, max_signal_bytes, layout.perChannelSlot, nbytes);
+    const std::size_t protocolBytes =
+        payloadProtocolBytes + protocolTailPadding;
+    for (std::size_t dataOff = 0; dataOff < payloadProtocolBytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const NvlPipelinePosition position = layout.position(streamStart);
-      const std::size_t dataRemaining = protocolBytes - dataOff;
+      const std::size_t dataRemaining = payloadProtocolBytes - dataOff;
       std::size_t copyBytes = layout.effectiveChunk < dataRemaining
           ? layout.effectiveChunk
           : dataRemaining;
       copyBytes = copyBytes < position.slotRemaining ? copyBytes
                                                      : position.slotRemaining;
+      const bool isFinalChunk = dataOff + copyBytes >= payloadProtocolBytes;
       const uint64_t streamEnd = streamStart + copyBytes;
+      const uint64_t protocolStreamEnd =
+          streamEnd + (isFinalChunk ? protocolTailPadding : 0);
 
       local_ch.data_ready.wait_until(group, CmpOp::CMP_GE, streamEnd, timeout);
 
@@ -606,8 +623,8 @@ class P2pNvlTransportDevice {
       group.sync();
       if (group.is_leader()) {
         if (position.chunkOff + copyBytes == layout.perChannelSlot ||
-            dataOff + copyBytes == protocolBytes) {
-          remote_ch.slot_free.signal(SignalOp::SIGNAL_SET, streamEnd);
+            isFinalChunk) {
+          remote_ch.slot_free.signal(SignalOp::SIGNAL_SET, protocolStreamEnd);
         }
       }
       dataOff += copyBytes;
@@ -679,13 +696,23 @@ class P2pNvlTransportDevice {
     const uint64_t sendBaseByte =
         static_cast<uint64_t>(send_local_ch.send_cursor);
 
-    const std::size_t protocolBytes = align_tile_protocol_bytes(nbytes);
-    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
+    const std::size_t payloadProtocolBytes = align_tile_protocol_bytes(nbytes);
+    const std::size_t recvProtocolTailPadding =
+        tail_padding_for_signal_granularity(
+            recvBaseByte, max_signal_bytes, layout.perChannelSlot, nbytes);
+    const std::size_t sendProtocolTailPadding =
+        tail_padding_for_signal_granularity(
+            sendBaseByte, max_signal_bytes, layout.perChannelSlot, nbytes);
+    const std::size_t recvProtocolBytes =
+        payloadProtocolBytes + recvProtocolTailPadding;
+    const std::size_t sendProtocolBytes =
+        payloadProtocolBytes + sendProtocolTailPadding;
+    for (std::size_t dataOff = 0; dataOff < payloadProtocolBytes;) {
       const uint64_t recvStreamStart = recvBaseByte + dataOff;
       const NvlPipelinePosition recvPosition = layout.position(recvStreamStart);
       const uint64_t sendStreamStart = sendBaseByte + dataOff;
       const NvlPipelinePosition sendPosition = layout.position(sendStreamStart);
-      const std::size_t dataRemaining = protocolBytes - dataOff;
+      const std::size_t dataRemaining = payloadProtocolBytes - dataOff;
       std::size_t copyBytes = layout.effectiveChunk < dataRemaining
           ? layout.effectiveChunk
           : dataRemaining;
@@ -695,8 +722,13 @@ class P2pNvlTransportDevice {
       copyBytes = copyBytes < sendPosition.slotRemaining
           ? copyBytes
           : sendPosition.slotRemaining;
+      const bool isFinalChunk = dataOff + copyBytes >= payloadProtocolBytes;
       const uint64_t recvStreamEnd = recvStreamStart + copyBytes;
       const uint64_t sendStreamEnd = sendStreamStart + copyBytes;
+      const uint64_t recvProtocolStreamEnd =
+          recvStreamEnd + (isFinalChunk ? recvProtocolTailPadding : 0);
+      const uint64_t sendProtocolStreamEnd =
+          sendStreamEnd + (isFinalChunk ? sendProtocolTailPadding : 0);
 
       // 1. Wait for predecessor data to be ready (recv side, every step).
       recv_local_ch.data_ready.wait_until(
@@ -704,11 +736,11 @@ class P2pNvlTransportDevice {
 
       // 2. Wait for successor's staging slot to be free once we have wrapped
       //    around the pipeline.
-      if (sendStreamEnd > layout.pipelineBytes) {
+      if (sendProtocolStreamEnd > layout.pipelineBytes) {
         send_local_ch.slot_free.wait_until(
             group,
             CmpOp::CMP_GE,
-            sendStreamEnd - layout.pipelineBytes,
+            sendProtocolStreamEnd - layout.pipelineBytes,
             timeout);
       }
 
@@ -730,13 +762,15 @@ class P2pNvlTransportDevice {
       group.sync();
       if (group.is_leader()) {
         // 4. Signal successor that data is ready (send semantic: every step).
-        send_remote_ch.data_ready.signal(SignalOp::SIGNAL_SET, sendStreamEnd);
+        send_remote_ch.data_ready.signal(
+            SignalOp::SIGNAL_SET, sendProtocolStreamEnd);
 
         // 5. ACK predecessor that buffer is free (recv semantic: only at
         //    slot boundaries).
         if (recvPosition.chunkOff + copyBytes == layout.perChannelSlot ||
-            dataOff + copyBytes == protocolBytes) {
-          recv_remote_ch.slot_free.signal(SignalOp::SIGNAL_SET, recvStreamEnd);
+            isFinalChunk) {
+          recv_remote_ch.slot_free.signal(
+              SignalOp::SIGNAL_SET, recvProtocolStreamEnd);
         }
       }
       dataOff += copyBytes;
@@ -744,9 +778,9 @@ class P2pNvlTransportDevice {
 
     if (group.is_leader()) {
       recv_local_ch.recv_cursor =
-          static_cast<int64_t>(recvBaseByte + protocolBytes);
+          static_cast<int64_t>(recvBaseByte + recvProtocolBytes);
       send_local_ch.send_cursor =
-          static_cast<int64_t>(sendBaseByte + protocolBytes);
+          static_cast<int64_t>(sendBaseByte + sendProtocolBytes);
     }
     group.sync();
 #endif
@@ -1065,6 +1099,43 @@ class P2pNvlTransportDevice {
   __device__ __forceinline__ static std::size_t align_tile_protocol_bytes(
       std::size_t nbytes) {
     return (nbytes + 15ULL) & ~15ULL;
+  }
+
+  __device__ __forceinline__ static uint64_t round_up_to_multiple(
+      uint64_t value,
+      std::size_t alignment) {
+    if (alignment == 0) {
+      return value;
+    }
+    const uint64_t alignment64 = static_cast<uint64_t>(alignment);
+    return ((value + alignment64 - 1) / alignment64) * alignment64;
+  }
+
+  __device__ __forceinline__ static std::size_t signal_alignment(
+      std::size_t maxSignalBytes,
+      std::size_t perChannelSlot) {
+    const bool usesPartialSlot =
+        maxSignalBytes > 0 && maxSignalBytes < perChannelSlot;
+    std::size_t alignment =
+        usesPartialSlot ? (maxSignalBytes & ~15ULL) : perChannelSlot;
+    return alignment == 0 ? perChannelSlot : alignment;
+  }
+
+  __device__ __forceinline__ static std::size_t
+  tail_padding_for_signal_granularity(
+      uint64_t baseByte,
+      std::size_t maxSignalBytes,
+      std::size_t perChannelSlot,
+      std::size_t payloadBytes) {
+    const std::size_t alignment =
+        signal_alignment(maxSignalBytes, perChannelSlot);
+    if (alignment == 0) {
+      return 0;
+    }
+    const uint64_t payloadEnd =
+        baseByte + align_tile_protocol_bytes(payloadBytes);
+    return static_cast<std::size_t>(
+        round_up_to_multiple(payloadEnd, alignment) - payloadEnd);
   }
 
   __device__ __forceinline__ static std::size_t valid_payload_bytes(


### PR DESCRIPTION
Summary:

### Why
IB and NVL p2p send/recv protocol cursors need to remain aligned to the signaling granularity, but posting that padding lazily on a later recv can deadlock ring-style send phases. After a partial recv, all ranks may enter a pipeline_window-sized blocking send before any rank reaches the next recv, so the padding credit must already be visible.

### Key Changes
- Move protocol padding from leading padding on the next operation to tail padding on the current operation for IB blocking send/recv/forward, progress send/recv, and NVL send/recv/forward.
- Carry tail padding in the final DATA_READY/NIC_DONE/SLOT_FREE signal or counter value while keeping payload copies and RDMA writes bounded to the valid 16B-aligned payload protocol bytes.
- Use the padded final protocol end for sender-side NIC_DONE/SLOT_FREE flow-control waits when tail padding crosses the pipeline window.
- Add two-call send-then-recv deadlock regressions for NVL and IB: each rank sends and receives a partial first transfer, then all ranks send a pipeline-window second transfer before entering the second recv.
- Update NVL persistent-cursor staging expectations and IB progress reservation expectations to assert the new eager tail-padded cursor contract.

### Correctness
The padding is credit-only and is fused into the same final protocol update as the operation’s final payload chunk. No extra QP posting is introduced: IB still posts the same final RDMA WQE with payload bytes as the RDMA length and the padded byte count as the DATA_READY/NIC_DONE increment; NVL still uses the same final signal update with the padded protocol end. Receivers publish matching SLOT_FREE credit on their final recv-side update even though they copy only valid payload bytes.

Reviewed By: zhiyongww, Scusemua

Differential Revision: D112407940


