### PR TITLE
Add per-comm window range cache (recvbuf -> CtranWin lookup) (#3166)

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -14,7 +14,9 @@
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/regcache/RegCache.h"
+#include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/LogInit.h"
+#include "comms/ctran/window/CtranWin.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -20,6 +20,7 @@
 #include "comms/ctran/utils/Abort.h"
 #include "comms/ctran/utils/AsyncError.h"
 #include "comms/ctran/utils/Exception.h"
+#include "comms/ctran/window/WinCache.h"
 #include "comms/utils/colltrace/AlgoStats.h"
 #include "comms/utils/colltrace/CollTraceInterface.h"
 #include "comms/utils/commSpecs.h"
@@ -69,6 +70,9 @@ class memCacheAllocator;
 }
 namespace comms::prims {
 class MultiPeerTransport;
+}
+namespace ctran {
+struct CtranWin;
 }
 
 using ctran::utils::Abort;
@@ -150,6 +154,13 @@ class CtranComm {
 
   inline uint64_t getCtranOpCount() const {
     return ctranOpCount_;
+  }
+
+  // Monotonic per-comm window id. Windows are registered collectively in the
+  // same order on every rank, so a given window gets the same id on all ranks
+  // -- used to check/log that all ranks pick the same window.
+  inline uint64_t assignWindowId() {
+    return nextWinId_++;
   }
 
   inline bool isSplitShare() const {
@@ -274,8 +285,18 @@ class CtranComm {
       const std::shared_ptr<PersistentCleanup>& cleanup);
   void drainPersistentCleanups();
 
+  // Returns a cached window fully containing [addr, addr+bytes), or nullptr.
+  // Only symmetric windows are cached and they are registered collectively in
+  // the same order, so every rank resolves a buffer to the same window (needed
+  // for symmetric-offset math). Non-owning: do not free a window that a
+  // collective may still use.
+  ctran::CtranWin* findWindowForBuffer(const void* addr, size_t bytes) const {
+    return winCache_.find(addr, bytes);
+  }
+
  private:
   friend class CtranGpe;
+  friend struct ctran::CtranWin;
   friend commResult_t ctranInit(
       CtranComm* comm,
       std::unique_ptr<ctran::IProfilerReporter> reporter,
@@ -297,7 +318,11 @@ class CtranComm {
   std::shared_ptr<AsyncError> asyncErr_;
   std::shared_ptr<Abort> abort_;
   uint64_t ctranOpCount_{0};
+  uint64_t nextWinId_{0};
 
   folly::Synchronized<folly::F14FastSet<std::shared_ptr<PersistentCleanup>>>
       persistentCleanups_;
+
+  // Per-comm window range cache backing findWindowForBuffer() above.
+  ctran::WinCache winCache_;
 };

--- a/comms/ctran/utils/CtranAvlTree.cc
+++ b/comms/ctran/utils/CtranAvlTree.cc
@@ -79,10 +79,9 @@ commResult_t CtranAvlTree::remove(void* hdl) {
   return commSuccess;
 }
 
-void* CtranAvlTree::search(const void* addr_, std::size_t len) const {
-  uintptr_t addr = reinterpret_cast<uintptr_t>(const_cast<void*>(addr_));
-  std::lock_guard<std::mutex> lock(this->mutex_);
-
+CtranAvlTree::TreeElem* CtranAvlTree::searchElemLocked(
+    uintptr_t addr,
+    std::size_t len) const {
   // First try to search in AVL tree
   CtranAvlTree::TreeElem* r = this->root_;
   while (r) {
@@ -108,6 +107,19 @@ void* CtranAvlTree::search(const void* addr_, std::size_t len) const {
     }
   }
   return r;
+}
+
+void* CtranAvlTree::search(const void* addr_, std::size_t len) const {
+  uintptr_t addr = reinterpret_cast<uintptr_t>(const_cast<void*>(addr_));
+  std::lock_guard<std::mutex> lock(this->mutex_);
+  return this->searchElemLocked(addr, len);
+}
+
+void* CtranAvlTree::searchVal(const void* addr_, std::size_t len) const {
+  uintptr_t addr = reinterpret_cast<uintptr_t>(const_cast<void*>(addr_));
+  std::lock_guard<std::mutex> lock(this->mutex_);
+  CtranAvlTree::TreeElem* r = this->searchElemLocked(addr, len);
+  return r != nullptr ? r->val : nullptr;
 }
 
 void* CtranAvlTree::lookup(void* hdl) const {

--- a/comms/ctran/utils/CtranAvlTree.h
+++ b/comms/ctran/utils/CtranAvlTree.h
@@ -36,6 +36,13 @@ class CtranAvlTree {
   // return nullptr.
   void* search(const void* addr, std::size_t len) const;
 
+  // Atomically search for the element whose range contains [addr, addr+len) and
+  // return its value (nullptr if none). Equivalent to search() followed by
+  // lookup() but performed under a single lock, so it is free of the ABA race a
+  // separate search()+lookup() would have if another thread removes and reuses
+  // the handle in between.
+  void* searchVal(const void* addr, std::size_t len) const;
+
   // Lookup the value of the provided handle.
   void* lookup(void* hdl) const;
 
@@ -67,6 +74,9 @@ class CtranAvlTree {
 
  private:
   class TreeElem;
+  // Find the element whose range contains [addr, addr+len), or nullptr if none.
+  // Caller must hold mutex_.
+  TreeElem* searchElemLocked(uintptr_t addr, std::size_t len) const;
   class TreeElem* root_{nullptr};
   std::vector<TreeElem*> list_;
   // Store all valid handles for fast handle validation.

--- a/comms/ctran/utils/tests/AvlTreeUT.cc
+++ b/comms/ctran/utils/tests/AvlTreeUT.cc
@@ -323,6 +323,34 @@ TEST_F(CtranUtilsAvlTreeTest, SearchNonOverlapRanges) {
   rangeRegistList.clear();
 }
 
+// searchVal is search()+lookup() done atomically; verify it returns the
+// containing element's value and nullptr for a miss.
+TEST_F(CtranUtilsAvlTreeTest, SearchVal) {
+  auto tree = std::make_unique<CtranAvlTree>();
+
+  void* valA = reinterpret_cast<void*>(0xA);
+  void* valB = reinterpret_cast<void*>(0xB);
+  void* hdlA = tree->insert(reinterpret_cast<void*>(0x1000), 0x100, valA);
+  void* hdlB = tree->insert(reinterpret_cast<void*>(0x2000), 0x100, valB);
+  ASSERT_NE(hdlA, nullptr);
+  ASSERT_NE(hdlB, nullptr);
+
+  // Exact and subrange lookups return the containing element's value.
+  EXPECT_EQ(tree->searchVal(reinterpret_cast<void*>(0x1000), 0x100), valA);
+  EXPECT_EQ(tree->searchVal(reinterpret_cast<void*>(0x1040), 0x10), valA);
+  EXPECT_EQ(tree->searchVal(reinterpret_cast<void*>(0x2000), 0x100), valB);
+  // Equivalent to a separate search() + lookup().
+  EXPECT_EQ(
+      tree->searchVal(reinterpret_cast<void*>(0x1000), 0x100),
+      tree->lookup(tree->search(reinterpret_cast<void*>(0x1000), 0x100)));
+  // Misses (gap, past all) return nullptr.
+  EXPECT_EQ(tree->searchVal(reinterpret_cast<void*>(0x1500), 0x10), nullptr);
+  EXPECT_EQ(tree->searchVal(reinterpret_cast<void*>(0x3000), 0x10), nullptr);
+
+  tree->remove(hdlA);
+  tree->remove(hdlB);
+}
+
 // Test ToString
 TEST_F(CtranUtilsAvlTreeTest, ToString) {
   auto tree = std::make_unique<CtranAvlTree>();

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -176,6 +176,14 @@ struct CtranWin {
     return enableSignal_;
   }
 
+  inline void setSymmetric(bool val) {
+    symmetric_ = val;
+  }
+
+  inline bool isSymmetric() const {
+    return symmetric_;
+  }
+
   // Check whether persistent allgather (allgatherP) is supported.
   // Returns true if ctran is initialized and all peers have configured
   // backends. Static variant allows checking before a window is created.
@@ -199,6 +207,11 @@ struct CtranWin {
   // rejected. Used by data-only collective windows (e.g. window-based
   // allgather) that never issue signals.
   bool enableSignal_{true};
+  // When true, every rank registers a buffer of identical size at an identical
+  // offset from the window base, so a peer address can be computed as
+  // peerBase + (buf - localBase). Records the upstream NCCL_WIN_COLL_SYMMETRIC
+  // hint; consumed by a later window-based allgather. Cached only for now.
+  bool symmetric_{false};
   // rank: window::OpCountType as key
   folly::Synchronized<
       std::unordered_map<std::pair<int, window::OpCountType>, uint64_t>>

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -53,6 +53,10 @@ struct CtranWin {
   void* dataSegHdl{nullptr};
   // The ctran mapper handles for caching the data registration
   void* dataRegHdl{nullptr};
+  // WinCache/AVL handle for this window's cached data range; used to erase the
+  // entry directly at free (avoids range lookup resolving to a different
+  // overlapping window).
+  void* winCacheHdl{nullptr};
   // Scoped registration owning the user-provided data buffer's local
   // registration ref (SW refcnt only). dataRegHdl aliases its borrowed
   // RegElem* for the export ctrl path.
@@ -184,6 +188,10 @@ struct CtranWin {
     return symmetric_;
   }
 
+  inline uint64_t id() const {
+    return id_;
+  }
+
   // Check whether persistent allgather (allgatherP) is supported.
   // Returns true if ctran is initialized and all peers have configured
   // backends. Static variant allows checking before a window is created.
@@ -212,6 +220,8 @@ struct CtranWin {
   // peerBase + (buf - localBase). Records the upstream NCCL_WIN_COLL_SYMMETRIC
   // hint; consumed by a later window-based allgather. Cached only for now.
   bool symmetric_{false};
+  // Per-comm unique id assigned at exchange() (see CtranComm::assignWindowId).
+  uint64_t id_{0};
   // rank: window::OpCountType as key
   folly::Synchronized<
       std::unordered_map<std::pair<int, window::OpCountType>, uint64_t>>

--- a/comms/ctran/window/WinCache.cc
+++ b/comms/ctran/window/WinCache.cc
@@ -1,0 +1,36 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/window/WinCache.h"
+
+#include "comms/utils/logger/LogUtils.h"
+
+namespace ctran {
+
+commResult_t WinCache::insert(
+    const void* base,
+    std::size_t len,
+    CtranWin* win,
+    void** outHdl) {
+  *outHdl = nullptr;
+  if (win == nullptr) {
+    return commInvalidArgument;
+  }
+  // A zero-length range is not lookupable; nothing to cache.
+  if (len == 0) {
+    return commSuccess;
+  }
+  // Overlapping ranges are allowed (a buffer may be registered as multiple
+  // overlapping windows). CtranAvlTree keeps overlaps in a fallback list;
+  // find() returns any containing window -- fine here since ctwin requires
+  // symmetric.
+  *outHdl = tree_->insert(base, len, win);
+  return commSuccess;
+}
+
+void WinCache::erase(void* hdl) {
+  if (hdl != nullptr) {
+    (void)tree_->remove(hdl);
+  }
+}
+
+} // namespace ctran

--- a/comms/ctran/window/WinCache.h
+++ b/comms/ctran/window/WinCache.h
@@ -1,0 +1,50 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include "comms/ctran/utils/CtranAvlTree.h"
+#include "comms/utils/commSpecs.h"
+
+namespace ctran {
+
+struct CtranWin;
+
+// Per-comm cache mapping a registered window's data-buffer range
+// [base,base+len) to the owning CtranWin, so a buffer address resolves to its
+// containing window. Backed by CtranAvlTree (as RegCache): internally
+// synchronized, native interval containment; never dereferences CtranWin, so it
+// is standalone unit-testable.
+class WinCache {
+ public:
+  // Caches win's range [base, base+len) and returns the AVL handle for the new
+  // entry in *outHdl, so the caller can erase exactly this entry later. A null
+  // win returns commInvalidArgument; a zero-length range is skipped
+  // (commSuccess, not lookupable). *outHdl is set to nullptr on the zero-length
+  // skip and on error. Overlapping ranges are ALLOWED and all cached -- the
+  // same buffer may be registered as multiple overlapping windows.
+  commResult_t
+  insert(const void* base, std::size_t len, CtranWin* win, void** outHdl);
+
+  // Removes the entry identified by hdl (the handle returned by insert).
+  // A null handle is a safe no-op, so a never-cached window is safe to erase.
+  void erase(void* hdl);
+
+  // Returns a cached window whose range contains [addr, addr+bytes), or
+  // nullptr. Among overlapping matches the choice is deterministic (by
+  // insertion order and geometry). Non-owning: the cache does not keep the
+  // window alive.
+  CtranWin* find(const void* addr, std::size_t bytes) const {
+    return static_cast<CtranWin*>(tree_->searchVal(addr, bytes));
+  }
+
+ private:
+  // Address-range -> owning window; internally synchronized, O(log n) interval
+  // containment. Held by unique_ptr because CtranAvlTree has a std::mutex (not
+  // movable) and WinCache must stay movable (CtranComm holds it by value).
+  std::unique_ptr<CtranAvlTree> tree_{std::make_unique<CtranAvlTree>()};
+};
+
+} // namespace ctran

--- a/comms/ctran/window/WinHintUtils.cc
+++ b/comms/ctran/window/WinHintUtils.cc
@@ -12,6 +12,7 @@ const std::string kWindowBufferLocation = "window_buffer_location";
 const std::string kWindowSignalBufSize = "window_signal_bufsize";
 const std::string kWinRegisterIpcOnly = "win_register_ipc_only";
 const std::string kWinRegisterEnableSignal = "win_register_enable_signal";
+const std::string kWinRegisterSymmetric = "win_register_symmetric";
 } // namespace
 
 void WinHintUtils::init(kvType& kv) {
@@ -36,6 +37,14 @@ WinHintUtils::set(const std::string& key, const std::string& val, kvType& kv) {
       return commInvalidArgument;
     }
   } else if (key == kWinRegisterEnableSignal) {
+    if (val == "1" || val == "true") {
+      kv[key] = "1";
+    } else if (val == "0" || val == "false") {
+      kv[key] = "0";
+    } else {
+      return commInvalidArgument;
+    }
+  } else if (key == kWinRegisterSymmetric) {
     if (val == "1" || val == "true") {
       kv[key] = "1";
     } else if (val == "0" || val == "false") {

--- a/comms/ctran/window/tests/CtranWinTests.cc
+++ b/comms/ctran/window/tests/CtranWinTests.cc
@@ -1086,6 +1086,124 @@ TEST_F(CtranWinTest, symmetricUserBufferRegister) {
       segments.end());
 }
 
+// Window range cache: a symmetric window's range is resolvable by
+// findWindowForBuffer, including a sub-range within it, and stops resolving
+// once the window is freed.
+TEST_F(CtranWinTest, windowRangeLookup) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skip window range lookup test";
+  }
+
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  constexpr size_t sizeBytes = 8192 * sizeof(int);
+  const MemAllocType bufType = MemAllocType::kMemCuMemAlloc;
+  void* userBuf = commMemAlloc(sizeBytes, bufType, segments);
+  ASSERT_NE(userBuf, nullptr);
+
+  // Simulate the CCA memory hook so acquireScopedRegister finds the segment.
+  COMMCHECK_TEST(
+      ctran::RegCache::getInstance()->globalRegister(userBuf, sizeBytes));
+
+  // Register the user buffer with the symmetric window hint enabled.
+  CtranWin* win = nullptr;
+  meta::comms::Hints hints;
+  ASSERT_EQ(hints.set("win_register_symmetric", "1"), commSuccess);
+  auto res = ctranWinRegister(userBuf, sizeBytes, comm.get(), &win, hints);
+  ASSERT_EQ(res, commSuccess);
+  ASSERT_NE(win, nullptr);
+
+  // The full data buffer resolves to this window.
+  EXPECT_EQ(comm->findWindowForBuffer(userBuf, sizeBytes), win);
+  // A sub-range within the window also resolves to it.
+  auto* mid = static_cast<char*>(userBuf) + 128;
+  EXPECT_EQ(comm->findWindowForBuffer(mid, 256), win);
+  // A range extending one byte past the end resolves to nullptr.
+  EXPECT_EQ(comm->findWindowForBuffer(userBuf, sizeBytes + 1), nullptr);
+
+  oobBarrier();
+
+  ASSERT_EQ(ctranWinFree(win), commSuccess);
+
+  // After free the buffer no longer resolves to a window.
+  EXPECT_EQ(comm->findWindowForBuffer(userBuf, sizeBytes), nullptr);
+
+  freeWinBuf(true, userBuf, sizeBytes, bufType);
+}
+
+// Window range cache: overlapping symmetric windows registered over the same
+// buffer are all cached, and every rank resolves a given buffer to the SAME
+// window (verified via the per-comm window id), which is required for
+// consistent symmetric-offset math.
+TEST_F(CtranWinDistTest, windowRangeOverlapDeterministic) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skip window range overlap test";
+  }
+
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  auto statex = comm->statex_.get();
+  ASSERT_NE(statex, nullptr);
+
+  if (statex->nLocalRanks() < 2) {
+    GTEST_SKIP() << "need >=2 local ranks";
+  }
+
+  constexpr size_t sizeBytes = 8192 * sizeof(int);
+  const MemAllocType bufType = MemAllocType::kMemCuMemAlloc;
+  std::vector<TestMemSegment> distSegments;
+  void* userBuf = commMemAlloc(sizeBytes, bufType, distSegments);
+  ASSERT_NE(userBuf, nullptr);
+
+  // Simulate the CCA memory hook so acquireScopedRegister finds the segment.
+  COMMCHECK_TEST(
+      ctran::RegCache::getInstance()->globalRegister(userBuf, sizeBytes));
+
+  meta::comms::Hints hints;
+  ASSERT_EQ(hints.set("win_register_symmetric", "1"), commSuccess);
+
+  // Register two overlapping symmetric windows over the same buffer: one
+  // spanning the whole buffer, and one spanning only its prefix.
+  CtranWin* winWhole = nullptr;
+  auto res = ctranWinRegister(userBuf, sizeBytes, comm.get(), &winWhole, hints);
+  ASSERT_EQ(res, commSuccess);
+  ASSERT_NE(winWhole, nullptr);
+
+  CtranWin* winPrefix = nullptr;
+  res = ctranWinRegister(userBuf, sizeBytes / 2, comm.get(), &winPrefix, hints);
+  ASSERT_EQ(res, commSuccess);
+  ASSERT_NE(winPrefix, nullptr);
+
+  EXPECT_NE(winWhole->id(), winPrefix->id())
+      << "distinct windows must get distinct ids";
+
+  // A sub-range inside the overlap is contained by both windows; the cache
+  // must deterministically pick one.
+  auto* win = comm->findWindowForBuffer(userBuf, sizeBytes / 4);
+  ASSERT_NE(win, nullptr);
+
+  // Verify all ranks picked the same window via id.
+  std::vector<uint64_t> ids(statex->nLocalRanks(), 0);
+  ids[statex->localRank()] = win->id();
+  allGatherNvlDomain(comm.get(), ids);
+  for (int r = 0; r < statex->nLocalRanks(); ++r) {
+    EXPECT_EQ(ids[r], win->id())
+        << "rank " << r << " resolved the buffer to a different window";
+  }
+
+  oobBarrier();
+
+  ASSERT_EQ(ctranWinFree(winPrefix), commSuccess);
+  ASSERT_EQ(ctranWinFree(winWhole), commSuccess);
+
+  // Release the CCA-hook simulation registration and free the buffer.
+  COMMCHECK_TEST(
+      ctran::RegCache::getInstance()->globalDeregister(userBuf, sizeBytes));
+  commMemFree(userBuf, sizeBytes, bufType);
+}
+
 TEST_F(CtranWinTest, RegisterOverRangeUserBufferNoLeak) {
   // Reproduces a leak in ctranWinRegister: it constructs the CtranWin with a
   // raw `new`, then FB_COMMCHECK(exchange()). If exchange() fails, the early
@@ -1182,6 +1300,32 @@ TEST_F(CtranWinTest, RegisterUncachedUserBufferReturnsInvalidUsageNoLeak) {
           segments.end(),
           [userBuf](const TestMemSegment& seg) { return seg.ptr == userBuf; }),
       segments.end());
+}
+
+// A non-symmetric window is not cached (window-based collectives only use
+// symmetric windows), so findWindowForBuffer never resolves to it.
+TEST_F(CtranWinTest, findWindowForBufferNonSymmetric) {
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  CtranWin* win = nullptr;
+  const size_t sizeBytes = 8192 * sizeof(int);
+  void* winBase = nullptr;
+  // Allocate a default (non-symmetric) window.
+  auto res = ctranWinAllocate(sizeBytes, comm.get(), &winBase, &win);
+  ASSERT_EQ(res, commSuccess);
+  ASSERT_NE(winBase, nullptr);
+  ASSERT_FALSE(win->isSymmetric());
+
+  // Not cached: neither the whole buffer nor a sub-range resolves.
+  EXPECT_EQ(comm->findWindowForBuffer(winBase, sizeBytes), nullptr);
+  auto* subRange = static_cast<char*>(winBase) + 128;
+  EXPECT_EQ(comm->findWindowForBuffer(subRange, 256), nullptr);
+
+  oobBarrier();
+
+  res = ctranWinFree(win);
+  EXPECT_EQ(res, commSuccess);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/comms/ctran/window/tests/CtranWinTests.cc
+++ b/comms/ctran/window/tests/CtranWinTests.cc
@@ -1020,6 +1020,72 @@ TEST_F(CtranWinTest, enableSignalDisabledUserBufferRegister) {
       segments.end());
 }
 
+// win_register_symmetric hint: the flag is cached on the window (no exchange or
+// behavior change yet). Verifies that a window registered with the hint reports
+// isSymmetric()==true, a window registered without it reports false, and that
+// registration/free complete without leaking imports.
+TEST_F(CtranWinTest, symmetricUserBufferRegister) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skip symmetric window test";
+  }
+
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  auto statex = comm->statex_.get();
+  ASSERT_NE(statex, nullptr);
+
+  constexpr size_t sizeBytes = 8192 * sizeof(int);
+  const MemAllocType bufType = MemAllocType::kMemCuMemAlloc;
+  void* userBuf = commMemAlloc(sizeBytes, bufType, segments);
+  ASSERT_NE(userBuf, nullptr);
+
+  // Simulate the CCA memory hook so acquireScopedRegister finds the segment.
+  COMMCHECK_TEST(
+      ctran::RegCache::getInstance()->globalRegister(userBuf, sizeBytes));
+
+  // Register the user buffer with the symmetric window hint enabled.
+  CtranWin* win = nullptr;
+  meta::comms::Hints hints;
+  ASSERT_EQ(hints.set("win_register_symmetric", "1"), commSuccess);
+  auto res = ctranWinRegister(userBuf, sizeBytes, comm.get(), &win, hints);
+  ASSERT_EQ(res, commSuccess);
+  ASSERT_NE(win, nullptr);
+  EXPECT_TRUE(win->isSymmetric());
+
+  oobBarrier();
+
+  res = ctranWinFree(win);
+  EXPECT_EQ(res, commSuccess);
+
+  // A window registered without the hint defaults to non-symmetric.
+  CtranWin* winDefault = nullptr;
+  res = ctranWinRegister(userBuf, sizeBytes, comm.get(), &winDefault);
+  ASSERT_EQ(res, commSuccess);
+  ASSERT_NE(winDefault, nullptr);
+  EXPECT_FALSE(winDefault->isSymmetric());
+
+  oobBarrier();
+
+  res = ctranWinFree(winDefault);
+  EXPECT_EQ(res, commSuccess);
+
+  const auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  EXPECT_EQ(ipcRegCache->maxRemRegRefCount(), 0)
+      << "IpcRegCache still holds live NVL IPC imports after symmetric free";
+
+  COMMCHECK_TEST(
+      ctran::RegCache::getInstance()->globalDeregister(userBuf, sizeBytes));
+  commMemFree(userBuf, sizeBytes, bufType);
+  segments.erase(
+      std::remove_if(
+          segments.begin(),
+          segments.end(),
+          [userBuf](const TestMemSegment& seg) { return seg.ptr == userBuf; }),
+      segments.end());
+}
+
 TEST_F(CtranWinTest, RegisterOverRangeUserBufferNoLeak) {
   // Reproduces a leak in ctranWinRegister: it constructs the CtranWin with a
   // raw `new`, then FB_COMMCHECK(exchange()). If exchange() fails, the early

--- a/comms/ctran/window/tests/WinCacheTest.cc
+++ b/comms/ctran/window/tests/WinCacheTest.cc
@@ -1,0 +1,189 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/window/WinCache.h"
+
+using ctran::CtranWin;
+using ctran::WinCache;
+
+namespace {
+
+// WinCache never dereferences the window pointer, so opaque non-null addresses
+// stand in for real CtranWin objects.
+CtranWin* dummyWin(uintptr_t tag) {
+  return reinterpret_cast<CtranWin*>(tag);
+}
+
+const void* addr(uintptr_t value) {
+  return reinterpret_cast<const void*>(value);
+}
+
+// Inserts and asserts success, returning the AVL handle for the new entry.
+void* insertWin(
+    WinCache& cache,
+    const void* base,
+    std::size_t len,
+    CtranWin* win) {
+  void* hdl = nullptr;
+  EXPECT_EQ(cache.insert(base, len, win, &hdl), commSuccess);
+  return hdl;
+}
+
+} // namespace
+
+TEST(WinCacheTest, FindExactBase) {
+  WinCache cache;
+  auto* win = dummyWin(0x1000);
+  insertWin(cache, addr(0x10000), 0x100, win);
+  EXPECT_EQ(cache.find(addr(0x10000), 0x100), win);
+}
+
+TEST(WinCacheTest, FindSubrange) {
+  WinCache cache;
+  auto* win = dummyWin(0x1000);
+  insertWin(cache, addr(0x10000), 0x100, win);
+  // A strict subrange inside [0x10000, 0x10100) resolves to the window.
+  EXPECT_EQ(cache.find(addr(0x10040), 0x10), win);
+}
+
+TEST(WinCacheTest, FindMissEmptyMap) {
+  WinCache cache;
+  EXPECT_EQ(cache.find(addr(0x10000), 0x10), nullptr);
+}
+
+TEST(WinCacheTest, FindMissBeforeAfterAndGap) {
+  WinCache cache;
+  auto* winA = dummyWin(0x1000);
+  auto* winB = dummyWin(0x2000);
+  insertWin(cache, addr(0x10000), 0x100, winA);
+  insertWin(cache, addr(0x20000), 0x100, winB);
+  // Before all ranges.
+  EXPECT_EQ(cache.find(addr(0x0FFFF), 0x1), nullptr);
+  // In the gap between the two ranges.
+  EXPECT_EQ(cache.find(addr(0x10200), 0x10), nullptr);
+  // After all ranges.
+  EXPECT_EQ(cache.find(addr(0x30000), 0x10), nullptr);
+}
+
+TEST(WinCacheTest, FindBoundaryContainmentAndOnePast) {
+  WinCache cache;
+  auto* win = dummyWin(0x1000);
+  insertWin(cache, addr(0x10000), 0x100, win);
+  // addr + bytes == base + len is fully contained.
+  EXPECT_EQ(cache.find(addr(0x100F0), 0x10), win);
+  // One byte past the end is not contained.
+  EXPECT_EQ(cache.find(addr(0x100F1), 0x10), nullptr);
+}
+
+TEST(WinCacheTest, InsertNullWinRejected) {
+  WinCache cache;
+  void* hdl = reinterpret_cast<void*>(0xdead);
+  EXPECT_EQ(
+      cache.insert(addr(0x10000), 0x100, nullptr, &hdl), commInvalidArgument);
+  // On error the handle is cleared.
+  EXPECT_EQ(hdl, nullptr);
+  EXPECT_EQ(cache.find(addr(0x10000), 0x100), nullptr);
+}
+
+TEST(WinCacheTest, InsertZeroLenSkipped) {
+  WinCache cache;
+  auto* win = dummyWin(0x1000);
+  void* hdl = reinterpret_cast<void*>(0xdead);
+  EXPECT_EQ(cache.insert(addr(0x10000), 0, win, &hdl), commSuccess);
+  // Zero-length range is not cached and yields no handle.
+  EXPECT_EQ(hdl, nullptr);
+  EXPECT_EQ(cache.find(addr(0x10000), 0x1), nullptr);
+}
+
+TEST(WinCacheTest, OverlapPartialBothStored) {
+  WinCache cache;
+  auto* first = dummyWin(0x1000);
+  auto* second = dummyWin(0x2000);
+  // [0x10000, 0x10100) and [0x10080, 0x10180) partially overlap; both cached.
+  insertWin(cache, addr(0x10000), 0x100, first);
+  insertWin(cache, addr(0x10080), 0x100, second);
+  // A point only in first.
+  EXPECT_EQ(cache.find(addr(0x10000), 0x10), first);
+  // A point only in second (past first's end): second is cached, so resolvable.
+  EXPECT_EQ(cache.find(addr(0x10100), 0x10), second);
+  // A point in the overlap resolves to one of the containing windows.
+  auto* found = cache.find(addr(0x10080), 0x10);
+  EXPECT_TRUE(found == first || found == second);
+}
+
+TEST(WinCacheTest, OverlapNestedBothStored) {
+  WinCache cache;
+  auto* outer = dummyWin(0x1000);
+  auto* inner = dummyWin(0x2000);
+  insertWin(cache, addr(0x10000), 0x100, outer);
+  // [0x10040, 0x10050) is fully inside outer; both cached.
+  insertWin(cache, addr(0x10040), 0x10, inner);
+  // A sub-range inside inner resolves to a containing window.
+  auto* found = cache.find(addr(0x10040), 0x10);
+  EXPECT_TRUE(found == outer || found == inner);
+  // A point only in outer resolves to outer.
+  EXPECT_EQ(cache.find(addr(0x10000), 0x10), outer);
+}
+
+TEST(WinCacheTest, OverlapExactDuplicateBothStored) {
+  WinCache cache;
+  auto* first = dummyWin(0x1000);
+  auto* second = dummyWin(0x2000);
+  insertWin(cache, addr(0x10000), 0x100, first);
+  // Same range registered twice; both cached, a lookup returns one of them.
+  insertWin(cache, addr(0x10000), 0x100, second);
+  auto* found = cache.find(addr(0x10000), 0x100);
+  EXPECT_TRUE(found == first || found == second);
+}
+
+TEST(WinCacheTest, AdjacentRangesBothCached) {
+  WinCache cache;
+  auto* winA = dummyWin(0x1000);
+  auto* winB = dummyWin(0x2000);
+  insertWin(cache, addr(0x10000), 0x100, winA);
+  // base + len == next base: touching but not overlapping, both cached.
+  insertWin(cache, addr(0x10100), 0x100, winB);
+  EXPECT_EQ(cache.find(addr(0x100F0), 0x10), winA);
+  EXPECT_EQ(cache.find(addr(0x10100), 0x10), winB);
+}
+
+TEST(WinCacheTest, EraseByHandleIsIdempotent) {
+  WinCache cache;
+  auto* win = dummyWin(0x1000);
+  void* hdl = insertWin(cache, addr(0x10000), 0x100, win);
+  // Erase by handle removes the entry.
+  cache.erase(hdl);
+  EXPECT_EQ(cache.find(addr(0x10000), 0x100), nullptr);
+  // Erasing again with the same (stale) handle is a safe no-op.
+  cache.erase(hdl);
+  EXPECT_EQ(cache.find(addr(0x10000), 0x100), nullptr);
+  // A null handle is a safe no-op.
+  cache.erase(nullptr);
+}
+
+// Two overlapping windows register the same buffer. Erasing one by its handle
+// must remove only that window's entry, leaving the other resolvable. Range
+// lookup could resolve to the wrong entry, so handle-based erase is required to
+// avoid a dangling (use-after-free) entry for the still-alive window.
+TEST(WinCacheTest, EraseByHandleAmongOverlapsRemovesOnlyTarget) {
+  WinCache cache;
+  auto* first = dummyWin(0x1000);
+  auto* second = dummyWin(0x2000);
+  // Identical range: `first` lands in the AVL tree, `second` in the overlap
+  // list. A containment range lookup cannot distinguish them.
+  void* firstHdl = insertWin(cache, addr(0x10000), 0x100, first);
+  void* secondHdl = insertWin(cache, addr(0x10000), 0x100, second);
+
+  // Erase the list-resident window by handle. A range-based erase would
+  // misresolve the containment search to `first` (the tree node) and leave
+  // `second` dangling.
+  cache.erase(secondHdl);
+  // Erase the tree window too; if `second` were still dangling, find() would
+  // now resolve to the freed `second`.
+  cache.erase(firstHdl);
+
+  EXPECT_EQ(cache.find(addr(0x10000), 0x100), nullptr);
+}

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -152,6 +152,8 @@ commResult_t windowBarrier(CtranComm* comm, CtranMapper* mapper) {
 
 // Defined here (not in header) so that unique_ptr<HostWindow> destructor
 // sees the complete HostWindow type.
+// Invariant: free() must run before a CtranWin is deleted, so the comm's window
+// range cache never retains a dangling pointer to a destroyed window.
 CtranWin::~CtranWin() = default;
 
 CtranWin::CtranWin(CtranComm* comm, size_t size, DevMemType bufType)
@@ -160,6 +162,9 @@ CtranWin::CtranWin(CtranComm* comm, size_t size, DevMemType bufType)
     FB_CHECKABORT(
         commInternalError, "CtranWin: comm is nullptr when creating window.");
   }
+  // Per-comm unique id, assigned at construction (registration order is the
+  // same on all ranks, so a window gets the same id everywhere).
+  id_ = comm->assignWindowId();
   signalSize = comm->statex_.get()->nRanks();
   signalVal.resize(signalSize);
   waitSignalVal.resize(signalSize);
@@ -352,6 +357,14 @@ commResult_t CtranWin::exchange() {
   // A barrier among ranks after importing handles to prevent accessing window
   // memory space while other ranks are still importing.
   FB_COMMCHECK(windowBarrier(comm, mapper));
+
+  // Cache only symmetric windows: ctwin collective algos needs all ranks
+  // locally compute peerAddr = peerBase + offset, meaning same offset from base
+  // on all ranks.
+  if (isSymmetric() && winDataPtr != nullptr) {
+    FB_COMMCHECK(
+        comm->winCache_.insert(winDataPtr, dataBytes, this, &winCacheHdl));
+  }
   return commSuccess;
 }
 
@@ -467,6 +480,14 @@ commResult_t CtranWin::free(bool skipBarrier) {
       (void*)this,
       (void*)comm,
       statex->commHash());
+
+  // Drop this window's entry from the comm cache before tearing down buffers so
+  // a later lookup cannot resolve to a freed window. The handle is non-null
+  // only when this window was actually cached (i.e. symmetric).
+  if (winCacheHdl != nullptr) {
+    comm->winCache_.erase(winCacheHdl);
+    winCacheHdl = nullptr;
+  }
 
   // A barrier among ranks before freeing window to prevent peer ranks accessing
   // the window after it is freed. Skipped when called from deferred cleanup at

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -703,6 +703,12 @@ commResult_t ctranWinRegister(
         meta::comms::hints::WinHintUtils::parseBool(enableSignalVal));
   }
 
+  std::string symmetricVal;
+  if (hints.get("win_register_symmetric", symmetricVal) == commSuccess) {
+    newWin->setSymmetric(
+        meta::comms::hints::WinHintUtils::parseBool(symmetricVal));
+  }
+
   FB_COMMCHECK(newWin->allocate((void*)databuf));
 
   FB_COMMCHECK(newWin->exchange()); // register and exchange both signal

--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -272,6 +272,7 @@ Config::Config(const ncclConfig_t* config) {
   noLocal = parseHintBool("noLocal", false);
   winRegisterIpcOnly = parseHintBool("win_register_ipc_only", false);
   winRegisterEnableSignal = parseHintBool("win_register_enable_signal", true);
+  winRegisterSymmetric = parseHintBool("win_register_symmetric", false);
 
   auto parseAlgoHint = [&](const char* key, auto& field) {
     auto val = getHintStr(key);
@@ -329,6 +330,7 @@ ncclResult_t Config::update(const ncclx::Hints* hints) {
   };
   parseBoolHint("win_register_ipc_only", winRegisterIpcOnly);
   parseBoolHint("win_register_enable_signal", winRegisterEnableSignal);
+  parseBoolHint("win_register_symmetric", winRegisterSymmetric);
 
   return ncclSuccess;
 }
@@ -394,6 +396,7 @@ void ncclxLogCommConfig(ncclComm_t comm) {
     append(
         fmt::format(
             "winRegisterEnableSignal={}", xCfg->winRegisterEnableSignal));
+    append(fmt::format("winRegisterSymmetric={}", xCfg->winRegisterSymmetric));
     append(fmt::format("ibLazyConnect={}", xCfg->ibLazyConnect));
     appendAlgo("sendrecvAlgo", xCfg->sendrecvAlgo);
     appendAlgo("allgatherAlgo", xCfg->allgatherAlgo);

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -42,6 +42,12 @@ class Config {
   // via commSetConfig.
   bool winRegisterEnableSignal = true;
 
+  // When true, all ranks register a buffer of identical size at an identical
+  // offset from the window base (upstream NCCL_WIN_COLL_SYMMETRIC semantics),
+  // so a peer address is peerBase + (buf - localBase). Mutable via
+  // commSetConfig.
+  bool winRegisterSymmetric = false;
+
   enum NCCL_SENDRECV_ALGO sendrecvAlgo = NCCL_SENDRECV_ALGO::orig;
   enum NCCL_ALLGATHER_ALGO allgatherAlgo = NCCL_ALLGATHER_ALGO::orig;
   enum NCCL_ALLREDUCE_ALGO allreduceAlgo = NCCL_ALLREDUCE_ALGO::orig;
@@ -93,6 +99,7 @@ inline const std::vector<std::string>& knownHintKeys() {
       "ibLazyConnect",
       "win_register_ipc_only",
       "win_register_enable_signal",
+      "win_register_symmetric",
   };
   return keys;
 }
@@ -107,6 +114,7 @@ inline const std::vector<std::string>& mutableHintKeys() {
       "rmaAlgo",
       "win_register_ipc_only",
       "win_register_enable_signal",
+      "win_register_symmetric",
   };
   return keys;
 }

--- a/comms/ncclx/meta/tests/CommSetConfigTest.cc
+++ b/comms/ncclx/meta/tests/CommSetConfigTest.cc
@@ -355,6 +355,52 @@ TEST_F(CommSetConfigTest, WinRegisterEnableSignalNotResetByUnrelatedUpdate) {
   }
 }
 
+TEST_F(CommSetConfigTest, SetWinRegisterSymmetric) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"win_register_symmetric", "1"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_TRUE(NCCLX_CONFIG_FIELD(comm->config, winRegisterSymmetric));
+  }
+
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"win_register_symmetric", "0"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_FALSE(NCCLX_CONFIG_FIELD(comm->config, winRegisterSymmetric));
+  }
+}
+
+TEST_F(CommSetConfigTest, WinRegisterSymmetricNotResetByUnrelatedUpdate) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  // Enable symmetric first.
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"win_register_symmetric", "1"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_TRUE(NCCLX_CONFIG_FIELD(comm->config, winRegisterSymmetric));
+  }
+
+  // An unrelated update must not reset it (key absent and not pre-seeded).
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"allgatherAlgo", "ctdirect"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_TRUE(NCCLX_CONFIG_FIELD(comm->config, winRegisterSymmetric));
+  }
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);

--- a/comms/ncclx/v2_29/src/dev_runtime.cc
+++ b/comms/ncclx/v2_29/src/dev_runtime.cc
@@ -1258,6 +1258,9 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
           "win_register_enable_signal",
           NCCLX_CONFIG_FIELD(comm->config, winRegisterEnableSignal) ? "1"
                                                                     : "0")));
+      NCCLCHECK(metaCommToNccl(winHints.set(
+          "win_register_symmetric",
+          NCCLX_CONFIG_FIELD(comm->config, winRegisterSymmetric) ? "1" : "0")));
       NCCLCHECK(metaCommToNccl(
           ctran::ctranWinRegister(
               buff,

--- a/comms/ncclx/v2_30/src/dev_runtime.cc
+++ b/comms/ncclx/v2_30/src/dev_runtime.cc
@@ -1494,6 +1494,9 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
           "win_register_enable_signal",
           NCCLX_CONFIG_FIELD(comm->config, winRegisterEnableSignal) ? "1"
                                                                     : "0")));
+      NCCLCHECK(metaCommToNccl(winHints.set(
+          "win_register_symmetric",
+          NCCLX_CONFIG_FIELD(comm->config, winRegisterSymmetric) ? "1" : "0")));
       NCCLCHECK(metaCommToNccl(
           ctran::ctranWinRegister(
               buff,


### PR DESCRIPTION
Summary:

Add a per-`CtranComm` cache mapping a registered window's local data-buffer address range to the owning `CtranWin`, so a buffer address (e.g. a collective recvbuf) can be resolved back to its containing window. This is infrastructure for the upcoming window-based allgather (`ctwin`); nothing consumes the lookup yet.
- New `ctran::WinCache` class (`comms/ctran/utils`) backs the cache over a `CtranAvlTree` (the interval-range structure `RegCache` uses).
   - Resolving full interval containment since a recvbuf may be a sub-range of the window data buffer. 
   - `find()` is inline via `CtranAvlTree::searchVal`; among overlapping matches the choice is deterministic (a function of insertion order and geometry). 
- `CtranWin` manages cache entry: 
   - `CtranWin::exchange()` inserts its range and `CtranWin::free()` erases it
   - `CtranComm` exposes only `findWindowForBuffer` (no register/unregister wrappers) for collective path to query. 
   - Only SYMMETRIC windows are cached (`ctwin` needs peerAddr = peerBase + offset). 
   - Overlapping windows are allowed and all cached. Each rank always picks the same window based on deterministic searchVal().
   - Add per-comm unique id for each `CtranWin` for logging based check.

See `ctwin` usage in D112411736

Reviewed By: pavanbalaji

Differential Revision: D112269500


