### PR TITLE
Link -latomic for ncclparam binary in v2.30 OSS build

### DIFF
--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -377,7 +377,7 @@ $(BINDIR)/$(BINNAME): $(BINOBJ)
 $(BINDIR)/$(PARAMBIN): $(PARAMBINOBJ) $(LIBDIR)/$(LIBTARGET)
 	@printf "Linking    %-35s > %s\n" $(PARAMBIN) $@
 	mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) $< -o $@ -L$(LIBDIR) -L${CONDA_LIB_DIR} -lnccl -L${CUDA_LIB} -l$(CUDARTLIB) -lpthread -lrt -ldl
+	$(CXX) $(CXXFLAGS) $< -o $@ -L$(LIBDIR) -L${CONDA_LIB_DIR} -lnccl -L${CUDA_LIB} -l$(CUDARTLIB) -lpthread -lrt -ldl -latomic
 
 $(PKGDIR)/nccl.pc : nccl.pc.in
 	mkdir -p $(PKGDIR)


### PR DESCRIPTION
Summary:
Fix the GitHub OSS build link failure that surfaced after `stable` was promoted from v2.29 to v2.30 (D107211271), which pointed the OSS build (`comms/github/build_ncclx.sh` -> `comms/ncclx/stable`) at the v2.30 sources:
- Symptom: `undefined reference to '__atomic_load_16@LIBATOMIC_1.0'` while linking the `ncclparam` binary, surfaced through `build_ncclx.cmake:23` as `NCCLX build failed: 2`.
- Root cause: the `__atomic_load_16` symbol lives in `libnccl.so`, emitted by `comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h`'s `relaxedLoad<unsigned __int128>` (16-byte atomic load) which is pulled in via CollTrace. `libnccl.so` itself links fine because its rule inherits `$(LDFLAGS)`, which gets `-latomic` from `makefiles/common.mk`. The v2.30-new `ncclparam` binary rule hand-lists its libraries and neither inherits `$(LDFLAGS)` nor links `-latomic`, so the symbol is left unresolved at the executable link step.
- Why v2.29 was unaffected: v2.29 has no `ncclparam` binary target at all; the standalone `param/` subsystem and its binary are new in v2.30.
- Fix: append `-latomic` to the `ncclparam` link rule in `v2_30/src/Makefile`. Targeted addition rather than switching the rule to full `$(LDFLAGS)` to avoid over-linking (version-script, ibverbs/mlx5, doca).

Differential Revision: D112543492


