### PR TITLE
Add win_register_ipc_only window hint (NVL-only exchange) (#3170)

### DIFF
--- a/comms/ctran/hints/Hints.cc
+++ b/comms/ctran/hints/Hints.cc
@@ -22,7 +22,7 @@ commResult_t Hints::set(const std::string& key, const std::string& val) {
   if (key.starts_with("ncclx_alltoallp")) {
     FB_COMMCHECK(AllToAllPHintUtils::set(key, val, this->kv));
     return commSuccess;
-  } else if (key.starts_with(("window"))) {
+  } else if (key.starts_with(("win"))) {
     FB_COMMCHECK(WinHintUtils::set(key, val, this->kv));
     return commSuccess;
   } else {

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -164,6 +164,10 @@ struct CtranWin {
     atomicCapable_ = val;
   }
 
+  inline void setIpcOnly(bool val) {
+    ipcOnly_ = val;
+  }
+
   // Check whether persistent allgather (allgatherP) is supported.
   // Returns true if ctran is initialized and all peers have configured
   // backends. Static variant allows checking before a window is created.
@@ -179,6 +183,9 @@ struct CtranWin {
   // Whether this window's data buffer meets the alignment requirements
   // for IB/NVLink atomic operations (8-byte aligned address and size).
   bool atomicCapable_{false};
+  // When true, registration exchanges only intra-node NVL/CUDA-IPC handles
+  // and skips the IB rkey exchange.
+  bool ipcOnly_{false};
   // rank: window::OpCountType as key
   folly::Synchronized<
       std::unordered_map<std::pair<int, window::OpCountType>, uint64_t>>

--- a/comms/ctran/window/WinHintUtils.cc
+++ b/comms/ctran/window/WinHintUtils.cc
@@ -10,6 +10,7 @@ namespace meta::comms::hints {
 namespace {
 const std::string kWindowBufferLocation = "window_buffer_location";
 const std::string kWindowSignalBufSize = "window_signal_bufsize";
+const std::string kWinRegisterIpcOnly = "win_register_ipc_only";
 } // namespace
 
 void WinHintUtils::init(kvType& kv) {
@@ -25,6 +26,14 @@ WinHintUtils::set(const std::string& key, const std::string& val, kvType& kv) {
     kv[key] = b;
   } else if (key == kWindowSignalBufSize) {
     kv[key] = val;
+  } else if (key == kWinRegisterIpcOnly) {
+    if (val == "1" || val == "true") {
+      kv[key] = "1";
+    } else if (val == "0" || val == "false") {
+      kv[key] = "0";
+    } else {
+      return commInvalidArgument;
+    }
   } else {
     return commInvalidArgument;
   }
@@ -37,6 +46,10 @@ const std::vector<std::string>& WinHintUtils::keys() {
       kWindowBufferLocation,
   };
   return kKeys;
+}
+
+bool WinHintUtils::parseBool(const std::string& val) {
+  return val == "1" || val == "true";
 }
 
 } // namespace meta::comms::hints

--- a/comms/ctran/window/WinHintUtils.h
+++ b/comms/ctran/window/WinHintUtils.h
@@ -19,6 +19,10 @@ class WinHintUtils {
   set(const std::string& key, const std::string& val, kvType& kv);
 
   static const std::vector<std::string>& keys();
+
+  // Parse a window hint value as a boolean. "1"/"true" map to true; any other
+  // value (including "0"/"false") maps to false.
+  static bool parseBool(const std::string& val);
 };
 
 } // namespace meta::comms::hints

--- a/comms/ctran/window/tests/CtranWinTests.cc
+++ b/comms/ctran/window/tests/CtranWinTests.cc
@@ -806,6 +806,112 @@ TEST_F(CtranWinTest, multiSegmentWindowRegister) {
   COMMCHECK_TEST(commMemFreeDisjoint(disjointBuf, segSizes));
 }
 
+// ipc_only window registration: exchanges CUDA-IPC handles for the data buffer
+// only among intra-node NVL peers and defers inter-node IB rkeys. Verifies that
+// NVL/local peers get a valid remWinInfo dataAddr + NVL key while self keeps
+// the local ptr (UNSET key) and non-NVL/remote peers stay empty (nullptr /
+// UNSET), and that a basic NVL read-back plus free() complete without error. On
+// configs where all peers are non-local (e.g. *_nolocal), every non-self peer
+// is empty.
+TEST_F(CtranWinTest, ipcOnlyUserBufferRegister) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skip ipc_only window test";
+  }
+
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  auto statex = comm->statex_.get();
+  ASSERT_NE(statex, nullptr);
+
+  constexpr size_t sizeBytes = 8192 * sizeof(int);
+  const MemAllocType bufType = MemAllocType::kMemCuMemAlloc;
+  void* userBuf = commMemAlloc(sizeBytes, bufType, segments);
+  ASSERT_NE(userBuf, nullptr);
+
+  // Fill the local buffer with a rank-specific pattern for the read-back below.
+  const size_t count = sizeBytes / sizeof(int);
+  std::vector<int> fillVals(count);
+  for (size_t i = 0; i < count; ++i) {
+    fillVals[i] = this->globalRank * 10000 + static_cast<int>(i);
+  }
+  CUDACHECK_TEST(
+      cudaMemcpy(userBuf, fillVals.data(), sizeBytes, cudaMemcpyHostToDevice));
+
+  // Simulate the CCA memory hook so acquireScopedRegister finds the segment.
+  COMMCHECK_TEST(
+      ctran::RegCache::getInstance()->globalRegister(userBuf, sizeBytes));
+
+  // Register the user buffer with the ipc_only window hint enabled.
+  CtranWin* win = nullptr;
+  meta::comms::Hints hints;
+  ASSERT_EQ(hints.set("win_register_ipc_only", "1"), commSuccess);
+  auto res = ctranWinRegister(userBuf, sizeBytes, comm.get(), &win, hints);
+  ASSERT_EQ(res, commSuccess);
+  ASSERT_NE(win, nullptr);
+  ASSERT_EQ(win->remWinInfo.size(), static_cast<size_t>(this->numRanks));
+
+  for (int peer = 0; peer < this->numRanks; ++peer) {
+    const auto& info = win->remWinInfo[peer];
+    if (peer == statex->rank()) {
+      EXPECT_EQ(info.dataAddr, userBuf);
+      // Self's local base/signal addr is still set under ipc_only.
+      EXPECT_THAT(info.signalAddr, ::testing::NotNull());
+    } else if (win->nvlEnabled(peer)) {
+      EXPECT_THAT(info.dataAddr, ::testing::NotNull());
+      EXPECT_EQ(info.dataRkey.backend, CtranMapperBackend::NVL);
+      // The base buffer is also NVL-only exchanged under ipc_only.
+      EXPECT_THAT(info.signalAddr, ::testing::NotNull());
+      EXPECT_EQ(info.signalRkey.backend, CtranMapperBackend::NVL);
+    } else {
+      EXPECT_THAT(info.dataAddr, ::testing::IsNull());
+      EXPECT_EQ(info.dataRkey.backend, CtranMapperBackend::UNSET);
+      // Non-NVL peers: base/signal IB rkey deferred, not exchanged.
+      EXPECT_THAT(info.signalAddr, ::testing::IsNull());
+      EXPECT_EQ(info.signalRkey.backend, CtranMapperBackend::UNSET);
+    }
+  }
+
+  oobBarrier();
+
+  // Basic access: read back an NVL peer's window over the IPC mapping.
+  for (int peer = 0; peer < this->numRanks; ++peer) {
+    if (peer == this->globalRank || !win->nvlEnabled(peer)) {
+      continue;
+    }
+    void* remoteAddr = win->remWinInfo[peer].dataAddr;
+    ASSERT_NE(remoteAddr, nullptr);
+    std::vector<int> readBack(count);
+    CUDACHECK_TEST(cudaMemcpy(
+        readBack.data(), remoteAddr, sizeBytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < count; ++i) {
+      const int expected = peer * 10000 + static_cast<int>(i);
+      EXPECT_EQ(readBack[i], expected) << "ipc_only NVL read-back mismatch at "
+                                       << i << " from peer " << peer;
+    }
+  }
+
+  oobBarrier();
+
+  res = ctranWinFree(win);
+  EXPECT_EQ(res, commSuccess);
+
+  const auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  EXPECT_EQ(ipcRegCache->maxRemRegRefCount(), 0)
+      << "IpcRegCache still holds live NVL IPC imports after ipc_only free";
+
+  COMMCHECK_TEST(
+      ctran::RegCache::getInstance()->globalDeregister(userBuf, sizeBytes));
+  commMemFree(userBuf, sizeBytes, bufType);
+  segments.erase(
+      std::remove_if(
+          segments.begin(),
+          segments.end(),
+          [userBuf](const TestMemSegment& seg) { return seg.ptr == userBuf; }),
+      segments.end());
+}
+
 TEST_F(CtranWinTest, RegisterOverRangeUserBufferNoLeak) {
   // Reproduces a leak in ctranWinRegister: it constructs the CtranWin with a
   // raw `new`, then FB_COMMCHECK(exchange()). If exchange() fails, the early

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -14,6 +14,7 @@
 #include "comms/ctran/utils/DevMemType.h"
 #include "comms/ctran/window/CtranWin.h"
 #include "comms/ctran/window/Types.h"
+#include "comms/ctran/window/WinHintUtils.h"
 #if defined(ENABLE_PRIMS)
 #include "comms/prims/transport/MultiPeerTransport.h"
 #include "comms/prims/window/DeviceWindow.cuh"
@@ -173,6 +174,16 @@ commResult_t CtranWin::exchange() {
   const auto nRanks = statex->nRanks();
   const auto myRank = statex->rank();
 
+  // ipc_only reuses AGP's intraAllGatherCtrl, which is hard-scoped to the
+  // resource comm's node-local ranks; on a splitShare comm those include
+  // non-window ranks, so the intra exchange would hang. Reject up front.
+  // FIXME(ctwin): a rank-subset-scoped ctrl-exchange API would lift this.
+  if (ipcOnly_ && comm->isSplitShare()) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "win_register_ipc_only is not supported on splitShare comms (intra exchange would deadlock over non-window resource-local ranks)");
+  }
+
   remWinInfo.resize(nRanks);
 
   CtranMapper* mapper = nullptr;
@@ -234,26 +245,52 @@ commResult_t CtranWin::exchange() {
     remoteUserBufAccessKeys.resize(resourceNRanks);
   }
 
-  FB_COMMCHECK(mapper->allGatherCtrl(
-      winBasePtr,
-      baseRegHdl,
-      exchangeRanks,
-      remoteBaseBufs,
-      remoteBaseBufAccessKeys,
-      CtranMapperBackend::UNSET,
-      /*recordExport=*/false));
-
-  if (!allocDataBuf_) {
-    // if data buffer is provided by user, extra round of handler exchange is
-    // needed
-    FB_COMMCHECK(mapper->allGatherCtrl(
-        winDataPtr,
-        dataRegHdl,
+  // Exchange a window buffer's registration handle with peers. When ipc_only,
+  // exchange CUDA-IPC handles only among intra-node NVL peers (inter-node peers
+  // left UNSET, their IB rkeys deferred to collective exec time); otherwise do
+  // the full per-peer (NVL + IB) exchange. Both paths fill the self slot with
+  // the local buffer address.
+  auto exchangeBuffer =
+      [&](const void* buf,
+          void* hdl,
+          std::vector<void*>& remoteBufs,
+          std::vector<struct CtranMapperRemoteAccessKey>& remoteKeys,
+          std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls) -> commResult_t {
+    if (ipcOnly_) {
+      return mapper->intraAllGatherCtrl(
+          buf,
+          hdl,
+          remoteBufs,
+          remoteKeys,
+          CtranMapperBackend::NVL,
+          /*recordExport=*/false,
+          outIpcHdls);
+    }
+    return mapper->allGatherCtrl(
+        buf,
+        hdl,
         exchangeRanks,
-        remoteUserBufs,
-        remoteUserBufAccessKeys,
+        remoteBufs,
+        remoteKeys,
         CtranMapperBackend::UNSET,
         /*recordExport=*/false,
+        outIpcHdls);
+  };
+
+  FB_COMMCHECK(exchangeBuffer(
+      winBasePtr,
+      baseRegHdl,
+      remoteBaseBufs,
+      remoteBaseBufAccessKeys,
+      /*outIpcHdls=*/nullptr));
+
+  if (!allocDataBuf_) {
+    // User-provided data buffer needs its own handle exchange round.
+    FB_COMMCHECK(exchangeBuffer(
+        winDataPtr,
+        dataRegHdl,
+        remoteUserBufs,
+        remoteUserBufAccessKeys,
         &dataScopedIpcRegHdls));
   }
 
@@ -612,6 +649,11 @@ commResult_t ctranWinRegister(
   newWin->setAtomicCapable(
       reinterpret_cast<uintptr_t>(databuf) % sizeof(uint64_t) == 0 &&
       size % sizeof(uint64_t) == 0);
+
+  std::string ipcOnlyVal;
+  if (hints.get("win_register_ipc_only", ipcOnlyVal) == commSuccess) {
+    newWin->setIpcOnly(meta::comms::hints::WinHintUtils::parseBool(ipcOnlyVal));
+  }
 
   FB_COMMCHECK(newWin->allocate((void*)databuf));
 

--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -270,6 +270,7 @@ Config::Config(const ncclConfig_t* config) {
   useCtran = parseHintBool("useCtran", NCCL_CTRAN_ENABLE);
   usePatAvg = parseHintBool("usePatAvg", NCCL_REDUCESCATTER_PAT_AVG_ENABLE);
   noLocal = parseHintBool("noLocal", false);
+  winRegisterIpcOnly = parseHintBool("win_register_ipc_only", false);
 
   auto parseAlgoHint = [&](const char* key, auto& field) {
     auto val = getHintStr(key);
@@ -316,6 +317,16 @@ ncclResult_t Config::update(const ncclx::Hints* hints) {
   parseAlgoHint("allreduceAlgo", allreduceAlgo);
   parseAlgoHint("alltoallvAlgo", alltoallvAlgo);
   parseAlgoHint("rmaAlgo", rmaAlgo);
+
+  // Mutable bool window hints: applied only when the key is present, so an
+  // unrelated commSetConfig does not reset them (win hints are not pre-seeded).
+  auto parseBoolHint = [&](const char* key, bool& field) {
+    std::string val;
+    if (hints->get(key, val) == ncclSuccess) {
+      field = (val == "1" || val == "true");
+    }
+  };
+  parseBoolHint("win_register_ipc_only", winRegisterIpcOnly);
 
   return ncclSuccess;
 }
@@ -377,6 +388,7 @@ void ncclxLogCommConfig(ncclComm_t comm) {
     append(fmt::format("useCtran={}", xCfg->useCtran));
     append(fmt::format("usePatAvg={}", xCfg->usePatAvg));
     append(fmt::format("noLocal={}", xCfg->noLocal));
+    append(fmt::format("winRegisterIpcOnly={}", xCfg->winRegisterIpcOnly));
     append(fmt::format("ibLazyConnect={}", xCfg->ibLazyConnect));
     appendAlgo("sendrecvAlgo", xCfg->sendrecvAlgo);
     appendAlgo("allgatherAlgo", xCfg->allgatherAlgo);

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -33,6 +33,10 @@ class Config {
   bool usePatAvg = false;
   bool noLocal = false;
 
+  // When true, windows registered on this comm exchange only intra-node NVL/IPC
+  // handles and defer the IB rkey exchange. Mutable via commSetConfig.
+  bool winRegisterIpcOnly = false;
+
   enum NCCL_SENDRECV_ALGO sendrecvAlgo = NCCL_SENDRECV_ALGO::orig;
   enum NCCL_ALLGATHER_ALGO allgatherAlgo = NCCL_ALLGATHER_ALGO::orig;
   enum NCCL_ALLREDUCE_ALGO allreduceAlgo = NCCL_ALLREDUCE_ALGO::orig;
@@ -82,6 +86,7 @@ inline const std::vector<std::string>& knownHintKeys() {
       "ibSplitDataOnQps",
       "ibQpsPerConnection",
       "ibLazyConnect",
+      "win_register_ipc_only",
   };
   return keys;
 }
@@ -94,6 +99,7 @@ inline const std::vector<std::string>& mutableHintKeys() {
       "allreduceAlgo",
       "alltoallvAlgo",
       "rmaAlgo",
+      "win_register_ipc_only",
   };
   return keys;
 }

--- a/comms/ncclx/meta/hints/Hints.cc
+++ b/comms/ncclx/meta/hints/Hints.cc
@@ -45,7 +45,7 @@ Hints::set(const std::string& key, const std::string& val) {
   if (bareKey.starts_with("ncclx_alltoallp")) {
     NCCLCHECK(metaCommToNccl(AllToAllPHintUtils::set(bareKey, val, this->kv)));
     return ncclSuccess;
-  } else if (bareKey.starts_with(("window"))) {
+  } else if (bareKey.starts_with(("win"))) {
     NCCLCHECK(metaCommToNccl(WinHintUtils::set(bareKey, val, this->kv)));
     return ncclSuccess;
   } else {

--- a/comms/ncclx/meta/tests/CommSetConfigTest.cc
+++ b/comms/ncclx/meta/tests/CommSetConfigTest.cc
@@ -263,6 +263,52 @@ TEST_F(CommSetConfigTest, SetConfigAfterCollective) {
   cudaFree(buf);
 }
 
+TEST_F(CommSetConfigTest, SetWinRegisterIpcOnly) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"win_register_ipc_only", "1"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_TRUE(NCCLX_CONFIG_FIELD(comm->config, winRegisterIpcOnly));
+  }
+
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"win_register_ipc_only", "0"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_FALSE(NCCLX_CONFIG_FIELD(comm->config, winRegisterIpcOnly));
+  }
+}
+
+TEST_F(CommSetConfigTest, WinRegisterIpcOnlyNotResetByUnrelatedUpdate) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  // Enable win_register_ipc_only.
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"win_register_ipc_only", "1"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_TRUE(NCCLX_CONFIG_FIELD(comm->config, winRegisterIpcOnly));
+  }
+
+  // An unrelated update must not reset it (key absent and not pre-seeded).
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"allgatherAlgo", "ctdirect"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_TRUE(NCCLX_CONFIG_FIELD(comm->config, winRegisterIpcOnly));
+  }
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);

--- a/comms/ncclx/v2_29/src/dev_runtime.cc
+++ b/comms/ncclx/v2_29/src/dev_runtime.cc
@@ -1248,12 +1248,19 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
       win_->comm = comm;
 
       auto guard = folly::makeGuard([win_] { delete win_; });
+      // Bridge the comm-level ncclx::win_register_ipc_only hint into the ctran
+      // window hints, as there is no per-window config path from Python today.
+      meta::comms::Hints winHints;
+      NCCLCHECK(metaCommToNccl(winHints.set(
+          "win_register_ipc_only",
+          NCCLX_CONFIG_FIELD(comm->config, winRegisterIpcOnly) ? "1" : "0")));
       NCCLCHECK(metaCommToNccl(
           ctran::ctranWinRegister(
               buff,
               size,
               comm->ctranComm_.get(),
-              &win_->ctranWindow)));
+              &win_->ctranWindow,
+              winHints)));
 
       // Create empty ncclWindow as handle and register mapping
       ncclWindow_t handle = new ncclWindow_vidmem();

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -377,7 +377,7 @@ $(BINDIR)/$(BINNAME): $(BINOBJ)
 $(BINDIR)/$(PARAMBIN): $(PARAMBINOBJ) $(LIBDIR)/$(LIBTARGET)
 	@printf "Linking    %-35s > %s\n" $(PARAMBIN) $@
 	mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) $< -o $@ -L$(LIBDIR) -L${CONDA_LIB_DIR} -lnccl -L${CUDA_LIB} -l$(CUDARTLIB) -lpthread -lrt -ldl
+	$(CXX) $(CXXFLAGS) $< -o $@ -L$(LIBDIR) -L${CONDA_LIB_DIR} -lnccl -L${CUDA_LIB} -l$(CUDARTLIB) -lpthread -lrt -ldl -latomic
 
 $(PKGDIR)/nccl.pc : nccl.pc.in
 	mkdir -p $(PKGDIR)

--- a/comms/ncclx/v2_30/src/dev_runtime.cc
+++ b/comms/ncclx/v2_30/src/dev_runtime.cc
@@ -1484,12 +1484,19 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
       win_->comm = comm;
 
       auto guard = folly::makeGuard([win_] { delete win_; });
+      // Bridge the comm-level ncclx::win_register_ipc_only hint into the ctran
+      // window hints, as there is no per-window config path from Python today.
+      meta::comms::Hints winHints;
+      NCCLCHECK(metaCommToNccl(winHints.set(
+          "win_register_ipc_only",
+          NCCLX_CONFIG_FIELD(comm->config, winRegisterIpcOnly) ? "1" : "0")));
       NCCLCHECK(metaCommToNccl(
           ctran::ctranWinRegister(
               buff,
               size,
               comm->ctranComm_.get(),
-              &win_->ctranWindow)));
+              &win_->ctranWindow,
+              winHints)));
 
       // Create empty ncclWindow as handle and register mapping
       ncclWindow_t handle = new ncclWindow_vidmem();

--- a/comms/ncclx/v2_30/src/device/Makefile
+++ b/comms/ncclx/v2_30/src/device/Makefile
@@ -28,7 +28,7 @@ INCFLAGS += -I${SHAREDDIR}/
 INCFLAGS  += -I$(BASE_DIR)
 INCFLAGS  += -I$(CONDA_INCLUDE_DIR)
 NVCUFLAGS += $(INCFLAGS) --compiler-options "-fPIC -fvisibility=hidden"
-CXXFLAGS  += $(INCFLAGS)
+CXXFLAGS  := $(INCFLAGS) $(CXXFLAGS)
 
 NVCUFLAGS_SYM += -ccbin $(CXX) $(CXXSTD) --expt-extended-lambda -Xptxas -maxrregcount=128 -Xfatbin -compress-all
 NVCUFLAGS_SYM += $(INCFLAGS) --compiler-options "-fPIC -fvisibility=hidden"


### PR DESCRIPTION
Summary:

Add a ctran window registration hint `win_register_ipc_only` so a window can exchange only intra-node NVL/CUDA-IPC handles at registration and defer the inter-node IB rkey exchange to collective exec time. First building block for the window-based persistent allgather (ctwin).

Key design points: the ipc_only data-buffer exchange reuses AGP's `intraAllGatherCtrl` (NVL among node-local peers; non-NVL peers left for a later exec-time exchange); rejected on splitShare comms where that primitive would deadlock; driven for now by a comm-level hint `ncclx::win_register_ipc_only` translated into the ctran window hint at the ncclCommWindowRegister bridge (v2_29/v2_30).

Differential Revision: D112213499


