### PR TITLE
Add win_register_enable_signal window hint (skip signal buffer) (#3171)

### DIFF
--- a/comms/ctran/algos/RMA/PutSignal.cc
+++ b/comms/ctran/algos/RMA/PutSignal.cc
@@ -231,6 +231,11 @@ commResult_t ctranPutSignal(
     cudaStream_t stream,
     bool signal) {
   CtranComm* comm = win->comm;
+  if (signal && !win->isSignalEnabled()) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "ctranPutSignal: signal requested but signals are disabled for this window (win_register_enable_signal=0)");
+  }
   const auto winOpCount = win->updateOpCount(peer);
   const auto putOpCount = win->updateOpCount(peer, window::OpCountType::kPut);
   auto statex = comm->statex_.get();
@@ -467,6 +472,11 @@ commResult_t waitSignalSpinningKernel(
 
 commResult_t ctranSignal(int peer, CtranWin* win, cudaStream_t stream) {
   CtranComm* comm = win->comm;
+  if (!win->isSignalEnabled()) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "ctranSignal: signals are disabled for this window (win_register_enable_signal=0)");
+  }
   const auto winOpCount = win->updateOpCount(peer);
   const auto sigOpCount =
       win->updateOpCount(peer, window::OpCountType::kSignal);
@@ -526,6 +536,11 @@ commResult_t ctranSignal(int peer, CtranWin* win, cudaStream_t stream) {
 // Tries hardware wait first (CUDA 11.7+), falls back to spinning kernel
 commResult_t ctranWaitSignal(int peer, CtranWin* win, cudaStream_t stream) {
   CtranComm* comm = win->comm;
+  if (!win->isSignalEnabled()) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "ctranWaitSignal: signals are disabled for this window (win_register_enable_signal=0)");
+  }
   auto statex = comm->statex_.get();
 
   // Track op counts for BOTH implementations

--- a/comms/ctran/hints/Hints.cc
+++ b/comms/ctran/hints/Hints.cc
@@ -22,7 +22,7 @@ commResult_t Hints::set(const std::string& key, const std::string& val) {
   if (key.starts_with("ncclx_alltoallp")) {
     FB_COMMCHECK(AllToAllPHintUtils::set(key, val, this->kv));
     return commSuccess;
-  } else if (key.starts_with(("window"))) {
+  } else if (key.starts_with(("win"))) {
     FB_COMMCHECK(WinHintUtils::set(key, val, this->kv));
     return commSuccess;
   } else {

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -164,6 +164,10 @@ struct CtranWin {
     atomicCapable_ = val;
   }
 
+  inline void setIpcOnly(bool val) {
+    ipcOnly_ = val;
+  }
+
   // Check whether persistent allgather (allgatherP) is supported.
   // Returns true if ctran is initialized and all peers have configured
   // backends. Static variant allows checking before a window is created.
@@ -179,6 +183,9 @@ struct CtranWin {
   // Whether this window's data buffer meets the alignment requirements
   // for IB/NVLink atomic operations (8-byte aligned address and size).
   bool atomicCapable_{false};
+  // When true, registration exchanges only intra-node NVL/CUDA-IPC handles
+  // and skips the IB rkey exchange.
+  bool ipcOnly_{false};
   // rank: window::OpCountType as key
   folly::Synchronized<
       std::unordered_map<std::pair<int, window::OpCountType>, uint64_t>>

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -168,6 +168,14 @@ struct CtranWin {
     ipcOnly_ = val;
   }
 
+  inline void setEnableSignal(bool val) {
+    enableSignal_ = val;
+  }
+
+  inline bool isSignalEnabled() const {
+    return enableSignal_;
+  }
+
   // Check whether persistent allgather (allgatherP) is supported.
   // Returns true if ctran is initialized and all peers have configured
   // backends. Static variant allows checking before a window is created.
@@ -186,6 +194,11 @@ struct CtranWin {
   // When true, registration exchanges only intra-node NVL/CUDA-IPC handles
   // and skips the IB rkey exchange.
   bool ipcOnly_{false};
+  // When false, the window carries no signal buffer: signal-buffer allocation
+  // and the signal-related control exchange are skipped, and signal RMA ops are
+  // rejected. Used by data-only collective windows (e.g. window-based
+  // allgather) that never issue signals.
+  bool enableSignal_{true};
   // rank: window::OpCountType as key
   folly::Synchronized<
       std::unordered_map<std::pair<int, window::OpCountType>, uint64_t>>

--- a/comms/ctran/window/WinHintUtils.cc
+++ b/comms/ctran/window/WinHintUtils.cc
@@ -11,6 +11,7 @@ namespace {
 const std::string kWindowBufferLocation = "window_buffer_location";
 const std::string kWindowSignalBufSize = "window_signal_bufsize";
 const std::string kWinRegisterIpcOnly = "win_register_ipc_only";
+const std::string kWinRegisterEnableSignal = "win_register_enable_signal";
 } // namespace
 
 void WinHintUtils::init(kvType& kv) {
@@ -27,6 +28,14 @@ WinHintUtils::set(const std::string& key, const std::string& val, kvType& kv) {
   } else if (key == kWindowSignalBufSize) {
     kv[key] = val;
   } else if (key == kWinRegisterIpcOnly) {
+    if (val == "1" || val == "true") {
+      kv[key] = "1";
+    } else if (val == "0" || val == "false") {
+      kv[key] = "0";
+    } else {
+      return commInvalidArgument;
+    }
+  } else if (key == kWinRegisterEnableSignal) {
     if (val == "1" || val == "true") {
       kv[key] = "1";
     } else if (val == "0" || val == "false") {

--- a/comms/ctran/window/WinHintUtils.cc
+++ b/comms/ctran/window/WinHintUtils.cc
@@ -10,6 +10,7 @@ namespace meta::comms::hints {
 namespace {
 const std::string kWindowBufferLocation = "window_buffer_location";
 const std::string kWindowSignalBufSize = "window_signal_bufsize";
+const std::string kWinRegisterIpcOnly = "win_register_ipc_only";
 } // namespace
 
 void WinHintUtils::init(kvType& kv) {
@@ -25,6 +26,14 @@ WinHintUtils::set(const std::string& key, const std::string& val, kvType& kv) {
     kv[key] = b;
   } else if (key == kWindowSignalBufSize) {
     kv[key] = val;
+  } else if (key == kWinRegisterIpcOnly) {
+    if (val == "1" || val == "true") {
+      kv[key] = "1";
+    } else if (val == "0" || val == "false") {
+      kv[key] = "0";
+    } else {
+      return commInvalidArgument;
+    }
   } else {
     return commInvalidArgument;
   }
@@ -37,6 +46,10 @@ const std::vector<std::string>& WinHintUtils::keys() {
       kWindowBufferLocation,
   };
   return kKeys;
+}
+
+bool WinHintUtils::parseBool(const std::string& val) {
+  return val == "1" || val == "true";
 }
 
 } // namespace meta::comms::hints

--- a/comms/ctran/window/WinHintUtils.h
+++ b/comms/ctran/window/WinHintUtils.h
@@ -19,6 +19,10 @@ class WinHintUtils {
   set(const std::string& key, const std::string& val, kvType& kv);
 
   static const std::vector<std::string>& keys();
+
+  // Parse a window hint value as a boolean. "1"/"true" map to true; any other
+  // value (including "0"/"false") maps to false.
+  static bool parseBool(const std::string& val);
 };
 
 } // namespace meta::comms::hints

--- a/comms/ctran/window/tests/CtranWinTests.cc
+++ b/comms/ctran/window/tests/CtranWinTests.cc
@@ -912,6 +912,114 @@ TEST_F(CtranWinTest, ipcOnlyUserBufferRegister) {
       segments.end());
 }
 
+// enable_signal=0 window registration: the window carries no signal buffer, so
+// signal-buffer allocation and the signal-related control exchange are skipped.
+// Verifies that registration succeeds, signalSize is 0 with a null signal
+// pointer, no signal rkey/addr is exchanged for any peer, a basic NVL data
+// read-back plus free() complete without leaking imports, and that a signal RMA
+// op is rejected with commInvalidUsage.
+TEST_F(CtranWinTest, enableSignalDisabledUserBufferRegister) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skip enable_signal window test";
+  }
+
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  auto statex = comm->statex_.get();
+  ASSERT_NE(statex, nullptr);
+
+  constexpr size_t sizeBytes = 8192 * sizeof(int);
+  const MemAllocType bufType = MemAllocType::kMemCuMemAlloc;
+  void* userBuf = commMemAlloc(sizeBytes, bufType, segments);
+  ASSERT_NE(userBuf, nullptr);
+
+  // Fill the local buffer with a rank-specific pattern for the read-back below.
+  const size_t count = sizeBytes / sizeof(int);
+  std::vector<int> fillVals(count);
+  for (size_t i = 0; i < count; ++i) {
+    fillVals[i] = this->globalRank * 10000 + static_cast<int>(i);
+  }
+  CUDACHECK_TEST(
+      cudaMemcpy(userBuf, fillVals.data(), sizeBytes, cudaMemcpyHostToDevice));
+
+  // Simulate the CCA memory hook so acquireScopedRegister finds the segment.
+  COMMCHECK_TEST(
+      ctran::RegCache::getInstance()->globalRegister(userBuf, sizeBytes));
+
+  // Register the user buffer with the signal buffer disabled.
+  CtranWin* win = nullptr;
+  meta::comms::Hints hints;
+  ASSERT_EQ(hints.set("win_register_enable_signal", "0"), commSuccess);
+  auto res = ctranWinRegister(userBuf, sizeBytes, comm.get(), &win, hints);
+  ASSERT_EQ(res, commSuccess);
+  ASSERT_NE(win, nullptr);
+  ASSERT_EQ(win->remWinInfo.size(), static_cast<size_t>(this->numRanks));
+
+  // No signal buffer exists.
+  EXPECT_FALSE(win->isSignalEnabled());
+  EXPECT_EQ(win->signalSize, 0u);
+  EXPECT_THAT(win->winSignalPtr, ::testing::IsNull());
+
+  // No signal rkey / addr was exchanged for any peer, while data addresses are
+  // still populated for NVL peers.
+  for (int peer = 0; peer < this->numRanks; ++peer) {
+    const auto& info = win->remWinInfo[peer];
+    EXPECT_THAT(info.signalAddr, ::testing::IsNull());
+    EXPECT_EQ(info.signalRkey.backend, CtranMapperBackend::UNSET);
+    if (peer == statex->rank()) {
+      EXPECT_EQ(info.dataAddr, userBuf);
+    }
+  }
+
+  oobBarrier();
+
+  // Basic access: read back an NVL peer's window over the IPC mapping.
+  for (int peer = 0; peer < this->numRanks; ++peer) {
+    if (peer == this->globalRank || !win->nvlEnabled(peer)) {
+      continue;
+    }
+    void* remoteAddr = win->remWinInfo[peer].dataAddr;
+    ASSERT_NE(remoteAddr, nullptr);
+    std::vector<int> readBack(count);
+    CUDACHECK_TEST(cudaMemcpy(
+        readBack.data(), remoteAddr, sizeBytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < count; ++i) {
+      const int expected = peer * 10000 + static_cast<int>(i);
+      EXPECT_EQ(readBack[i], expected)
+          << "enable_signal=0 NVL read-back mismatch at " << i << " from peer "
+          << peer;
+    }
+  }
+
+  // A signal RMA op must be rejected since there is no signal buffer.
+  cudaStream_t stream;
+  CUDACHECK_TEST(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+  const int nextPeer = (this->globalRank + 1) % this->numRanks;
+  EXPECT_EQ(ctranWaitSignal(nextPeer, win, stream), commInvalidUsage);
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+
+  oobBarrier();
+
+  res = ctranWinFree(win);
+  EXPECT_EQ(res, commSuccess);
+
+  const auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  EXPECT_EQ(ipcRegCache->maxRemRegRefCount(), 0)
+      << "IpcRegCache still holds live NVL IPC imports after enable_signal free";
+
+  COMMCHECK_TEST(
+      ctran::RegCache::getInstance()->globalDeregister(userBuf, sizeBytes));
+  commMemFree(userBuf, sizeBytes, bufType);
+  segments.erase(
+      std::remove_if(
+          segments.begin(),
+          segments.end(),
+          [userBuf](const TestMemSegment& seg) { return seg.ptr == userBuf; }),
+      segments.end());
+}
+
 TEST_F(CtranWinTest, RegisterOverRangeUserBufferNoLeak) {
   // Reproduces a leak in ctranWinRegister: it constructs the CtranWin with a
   // raw `new`, then FB_COMMCHECK(exchange()). If exchange() fails, the early

--- a/comms/ctran/window/tests/CtranWinTests.cc
+++ b/comms/ctran/window/tests/CtranWinTests.cc
@@ -806,6 +806,112 @@ TEST_F(CtranWinTest, multiSegmentWindowRegister) {
   COMMCHECK_TEST(commMemFreeDisjoint(disjointBuf, segSizes));
 }
 
+// ipc_only window registration: exchanges CUDA-IPC handles for the data buffer
+// only among intra-node NVL peers and defers inter-node IB rkeys. Verifies that
+// NVL/local peers get a valid remWinInfo dataAddr + NVL key while self keeps
+// the local ptr (UNSET key) and non-NVL/remote peers stay empty (nullptr /
+// UNSET), and that a basic NVL read-back plus free() complete without error. On
+// configs where all peers are non-local (e.g. *_nolocal), every non-self peer
+// is empty.
+TEST_F(CtranWinTest, ipcOnlyUserBufferRegister) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skip ipc_only window test";
+  }
+
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  auto statex = comm->statex_.get();
+  ASSERT_NE(statex, nullptr);
+
+  constexpr size_t sizeBytes = 8192 * sizeof(int);
+  const MemAllocType bufType = MemAllocType::kMemCuMemAlloc;
+  void* userBuf = commMemAlloc(sizeBytes, bufType, segments);
+  ASSERT_NE(userBuf, nullptr);
+
+  // Fill the local buffer with a rank-specific pattern for the read-back below.
+  const size_t count = sizeBytes / sizeof(int);
+  std::vector<int> fillVals(count);
+  for (size_t i = 0; i < count; ++i) {
+    fillVals[i] = this->globalRank * 10000 + static_cast<int>(i);
+  }
+  CUDACHECK_TEST(
+      cudaMemcpy(userBuf, fillVals.data(), sizeBytes, cudaMemcpyHostToDevice));
+
+  // Simulate the CCA memory hook so acquireScopedRegister finds the segment.
+  COMMCHECK_TEST(
+      ctran::RegCache::getInstance()->globalRegister(userBuf, sizeBytes));
+
+  // Register the user buffer with the ipc_only window hint enabled.
+  CtranWin* win = nullptr;
+  meta::comms::Hints hints;
+  ASSERT_EQ(hints.set("win_register_ipc_only", "1"), commSuccess);
+  auto res = ctranWinRegister(userBuf, sizeBytes, comm.get(), &win, hints);
+  ASSERT_EQ(res, commSuccess);
+  ASSERT_NE(win, nullptr);
+  ASSERT_EQ(win->remWinInfo.size(), static_cast<size_t>(this->numRanks));
+
+  for (int peer = 0; peer < this->numRanks; ++peer) {
+    const auto& info = win->remWinInfo[peer];
+    if (peer == statex->rank()) {
+      EXPECT_EQ(info.dataAddr, userBuf);
+      // Self's local base/signal addr is still set under ipc_only.
+      EXPECT_THAT(info.signalAddr, ::testing::NotNull());
+    } else if (win->nvlEnabled(peer)) {
+      EXPECT_THAT(info.dataAddr, ::testing::NotNull());
+      EXPECT_EQ(info.dataRkey.backend, CtranMapperBackend::NVL);
+      // The base buffer is also NVL-only exchanged under ipc_only.
+      EXPECT_THAT(info.signalAddr, ::testing::NotNull());
+      EXPECT_EQ(info.signalRkey.backend, CtranMapperBackend::NVL);
+    } else {
+      EXPECT_THAT(info.dataAddr, ::testing::IsNull());
+      EXPECT_EQ(info.dataRkey.backend, CtranMapperBackend::UNSET);
+      // Non-NVL peers: base/signal IB rkey deferred, not exchanged.
+      EXPECT_THAT(info.signalAddr, ::testing::IsNull());
+      EXPECT_EQ(info.signalRkey.backend, CtranMapperBackend::UNSET);
+    }
+  }
+
+  oobBarrier();
+
+  // Basic access: read back an NVL peer's window over the IPC mapping.
+  for (int peer = 0; peer < this->numRanks; ++peer) {
+    if (peer == this->globalRank || !win->nvlEnabled(peer)) {
+      continue;
+    }
+    void* remoteAddr = win->remWinInfo[peer].dataAddr;
+    ASSERT_NE(remoteAddr, nullptr);
+    std::vector<int> readBack(count);
+    CUDACHECK_TEST(cudaMemcpy(
+        readBack.data(), remoteAddr, sizeBytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < count; ++i) {
+      const int expected = peer * 10000 + static_cast<int>(i);
+      EXPECT_EQ(readBack[i], expected) << "ipc_only NVL read-back mismatch at "
+                                       << i << " from peer " << peer;
+    }
+  }
+
+  oobBarrier();
+
+  res = ctranWinFree(win);
+  EXPECT_EQ(res, commSuccess);
+
+  const auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  EXPECT_EQ(ipcRegCache->maxRemRegRefCount(), 0)
+      << "IpcRegCache still holds live NVL IPC imports after ipc_only free";
+
+  COMMCHECK_TEST(
+      ctran::RegCache::getInstance()->globalDeregister(userBuf, sizeBytes));
+  commMemFree(userBuf, sizeBytes, bufType);
+  segments.erase(
+      std::remove_if(
+          segments.begin(),
+          segments.end(),
+          [userBuf](const TestMemSegment& seg) { return seg.ptr == userBuf; }),
+      segments.end());
+}
+
 TEST_F(CtranWinTest, RegisterOverRangeUserBufferNoLeak) {
   // Reproduces a leak in ctranWinRegister: it constructs the CtranWin with a
   // raw `new`, then FB_COMMCHECK(exchange()). If exchange() fails, the early

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -189,14 +189,23 @@ commResult_t CtranWin::exchange() {
   CtranMapper* mapper = nullptr;
   FB_COMMCHECK(getWindowMapper(comm, &mapper));
   CtranMapperEpochRAII epochRAII(mapper);
+
+  // The base buffer holds the signal buffer (register path) or the combined
+  // data+signal buffer (allocate path). On the register path with signals
+  // disabled there is no base buffer, so its registration and control exchange
+  // are skipped entirely.
+  const bool exchangeBaseBuffer = allocDataBuf_ || enableSignal_;
+
   // Registration via ctran mapper.
-  FB_COMMCHECK(mapper->regMem(
-      winBasePtr,
-      range_,
-      &(baseSegHdl),
-      true,
-      true, /* NCCL managed buffer */
-      &baseRegHdl));
+  if (exchangeBaseBuffer) {
+    FB_COMMCHECK(mapper->regMem(
+        winBasePtr,
+        range_,
+        &(baseSegHdl),
+        true,
+        true, /* NCCL managed buffer */
+        &baseRegHdl));
+  }
 
   if (allocDataBuf_) {
     dataSegHdl = baseSegHdl;
@@ -277,12 +286,14 @@ commResult_t CtranWin::exchange() {
         outIpcHdls);
   };
 
-  FB_COMMCHECK(exchangeBuffer(
-      winBasePtr,
-      baseRegHdl,
-      remoteBaseBufs,
-      remoteBaseBufAccessKeys,
-      /*outIpcHdls=*/nullptr));
+  if (exchangeBaseBuffer) {
+    FB_COMMCHECK(exchangeBuffer(
+        winBasePtr,
+        baseRegHdl,
+        remoteBaseBufs,
+        remoteBaseBufAccessKeys,
+        /*outIpcHdls=*/nullptr));
+  }
 
   if (!allocDataBuf_) {
     // User-provided data buffer needs its own handle exchange round.
@@ -300,15 +311,21 @@ commResult_t CtranWin::exchange() {
     if (allocDataBuf_) {
       remWinInfo[r].dataAddr = remoteBaseBufs[exchangeRank];
       remWinInfo[r].dataRkey = remoteBaseBufAccessKeys[exchangeRank];
-      remWinInfo[r].signalAddr = reinterpret_cast<uint64_t*>(
-          reinterpret_cast<size_t>(remoteBaseBufs[exchangeRank]) +
-          allRankSizes[r]);
-      remWinInfo[r].signalRkey = remoteBaseBufAccessKeys[exchangeRank];
     } else {
       remWinInfo[r].dataAddr = remoteUserBufs[exchangeRank];
       remWinInfo[r].dataRkey = remoteUserBufAccessKeys[exchangeRank];
-      remWinInfo[r].signalAddr =
-          reinterpret_cast<uint64_t*>(remoteBaseBufs[exchangeRank]);
+    }
+    // With signals disabled there is no signal buffer, so leave signalAddr /
+    // signalRkey at their default (nullptr / UNSET).
+    if (enableSignal_) {
+      if (allocDataBuf_) {
+        remWinInfo[r].signalAddr = reinterpret_cast<uint64_t*>(
+            reinterpret_cast<size_t>(remoteBaseBufs[exchangeRank]) +
+            allRankSizes[r]);
+      } else {
+        remWinInfo[r].signalAddr =
+            reinterpret_cast<uint64_t*>(remoteBaseBufs[exchangeRank]);
+      }
       remWinInfo[r].signalRkey = remoteBaseBufAccessKeys[exchangeRank];
     }
   }
@@ -366,37 +383,51 @@ commResult_t CtranWin::allocate(void* userBufPtr) {
   // allocating a new buffer internally.
   allocDataBuf_ = userBufPtr == nullptr ? true : false;
 
+  // When signals are disabled the window carries no signal buffer.
+  if (!enableSignal_) {
+    signalSize = 0;
+  }
+
   void* addr = nullptr;
   CUmemGenericAllocationHandle allocHandle;
   auto signalBytes = signalSize * sizeof(uint64_t);
   size_t allocSize = allocDataBuf_ ? dataBytes + signalBytes : signalBytes;
-  if (isGpuMem()) {
-    FB_COMMCHECK(
-        utils::commCuMemAlloc(
-            &addr,
-            &allocHandle,
-            utils::getCuMemAllocHandleType(),
-            allocSize,
-            &comm->logMetaData_,
-            "allocate"));
+  // On the register path the base buffer holds only the signal buffer; with
+  // signals disabled there is nothing to allocate (allocSize == 0), so the base
+  // buffer stays null and no registration/exchange is done for it.
+  if (allocSize > 0) {
+    if (isGpuMem()) {
+      FB_COMMCHECK(
+          utils::commCuMemAlloc(
+              &addr,
+              &allocHandle,
+              utils::getCuMemAllocHandleType(),
+              allocSize,
+              &comm->logMetaData_,
+              "allocate"));
 
-    // query the actually allocated range of the memory
-    CUdeviceptr pbase = 0;
-    FB_CUCHECK(cuMemGetAddressRange(&pbase, &range_, (CUdeviceptr)addr));
-  } else {
-    FB_CUDACHECK(cudaMallocHost(&addr, allocSize));
-    range_ = allocSize;
+      // query the actually allocated range of the memory
+      CUdeviceptr pbase = 0;
+      FB_CUCHECK(cuMemGetAddressRange(&pbase, &range_, (CUdeviceptr)addr));
+    } else {
+      FB_CUDACHECK(cudaMallocHost(&addr, allocSize));
+      range_ = allocSize;
+    }
   }
 
   winBasePtr = addr;
 
   if (allocDataBuf_) {
     winDataPtr = addr;
-    winSignalPtr =
-        reinterpret_cast<uint64_t*>(reinterpret_cast<size_t>(addr) + dataBytes);
+    winSignalPtr = enableSignal_
+        ? reinterpret_cast<uint64_t*>(
+              reinterpret_cast<size_t>(addr) + dataBytes)
+        : nullptr;
   } else {
     winDataPtr = userBufPtr;
-    winSignalPtr = reinterpret_cast<uint64_t*>(reinterpret_cast<size_t>(addr));
+    winSignalPtr = enableSignal_
+        ? reinterpret_cast<uint64_t*>(reinterpret_cast<size_t>(addr))
+        : nullptr;
   }
 
   CLOGF_SUBSYS(
@@ -469,10 +500,17 @@ commResult_t CtranWin::free(bool skipBarrier) {
 
   // deregistr buffer
   deregMemIfNotNull(baseSegHdl);
-  // deregister remote buf
+  // deregister remote buf. The base buffer's remote import is tracked via
+  // signalRkey when signals are enabled (shared with dataRkey on the allocate
+  // path). With signals disabled the allocate path tracks it via dataRkey, and
+  // the register path has no base buffer to release.
   for (auto i = 0; i < nRanks; ++i) {
     if (i != statex->rank()) {
-      FB_COMMCHECK(mapper->deregRemReg(&remWinInfo[i].signalRkey));
+      if (enableSignal_) {
+        FB_COMMCHECK(mapper->deregRemReg(&remWinInfo[i].signalRkey));
+      } else if (allocDataBuf_) {
+        FB_COMMCHECK(mapper->deregRemReg(&remWinInfo[i].dataRkey));
+      }
     }
   }
 
@@ -496,7 +534,11 @@ commResult_t CtranWin::free(bool skipBarrier) {
   hostWindow_.reset();
 #endif
 
-  freeMem(winBasePtr);
+  // winBasePtr is null on the register path with signals disabled (nothing was
+  // allocated), so only free a real allocation.
+  if (winBasePtr != nullptr) {
+    freeMem(winBasePtr);
+  }
 
   return commSuccess;
 }
@@ -653,6 +695,12 @@ commResult_t ctranWinRegister(
   std::string ipcOnlyVal;
   if (hints.get("win_register_ipc_only", ipcOnlyVal) == commSuccess) {
     newWin->setIpcOnly(meta::comms::hints::WinHintUtils::parseBool(ipcOnlyVal));
+  }
+
+  std::string enableSignalVal;
+  if (hints.get("win_register_enable_signal", enableSignalVal) == commSuccess) {
+    newWin->setEnableSignal(
+        meta::comms::hints::WinHintUtils::parseBool(enableSignalVal));
   }
 
   FB_COMMCHECK(newWin->allocate((void*)databuf));

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -14,6 +14,7 @@
 #include "comms/ctran/utils/DevMemType.h"
 #include "comms/ctran/window/CtranWin.h"
 #include "comms/ctran/window/Types.h"
+#include "comms/ctran/window/WinHintUtils.h"
 #if defined(ENABLE_PRIMS)
 #include "comms/prims/transport/MultiPeerTransport.h"
 #include "comms/prims/window/DeviceWindow.cuh"
@@ -173,6 +174,16 @@ commResult_t CtranWin::exchange() {
   const auto nRanks = statex->nRanks();
   const auto myRank = statex->rank();
 
+  // ipc_only reuses AGP's intraAllGatherCtrl, which is hard-scoped to the
+  // resource comm's node-local ranks; on a splitShare comm those include
+  // non-window ranks, so the intra exchange would hang. Reject up front.
+  // FIXME(ctwin): a rank-subset-scoped ctrl-exchange API would lift this.
+  if (ipcOnly_ && comm->isSplitShare()) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "win_register_ipc_only is not supported on splitShare comms (intra exchange would deadlock over non-window resource-local ranks)");
+  }
+
   remWinInfo.resize(nRanks);
 
   CtranMapper* mapper = nullptr;
@@ -234,26 +245,52 @@ commResult_t CtranWin::exchange() {
     remoteUserBufAccessKeys.resize(resourceNRanks);
   }
 
-  FB_COMMCHECK(mapper->allGatherCtrl(
-      winBasePtr,
-      baseRegHdl,
-      exchangeRanks,
-      remoteBaseBufs,
-      remoteBaseBufAccessKeys,
-      CtranMapperBackend::UNSET,
-      /*recordExport=*/false));
-
-  if (!allocDataBuf_) {
-    // if data buffer is provided by user, extra round of handler exchange is
-    // needed
-    FB_COMMCHECK(mapper->allGatherCtrl(
-        winDataPtr,
-        dataRegHdl,
+  // Exchange a window buffer's registration handle with peers. When ipc_only,
+  // exchange CUDA-IPC handles only among intra-node NVL peers (inter-node peers
+  // left UNSET, their IB rkeys deferred to collective exec time); otherwise do
+  // the full per-peer (NVL + IB) exchange. Both paths fill the self slot with
+  // the local buffer address.
+  auto exchangeBuffer =
+      [&](const void* buf,
+          void* hdl,
+          std::vector<void*>& remoteBufs,
+          std::vector<struct CtranMapperRemoteAccessKey>& remoteKeys,
+          std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls) -> commResult_t {
+    if (ipcOnly_) {
+      return mapper->intraAllGatherCtrl(
+          buf,
+          hdl,
+          remoteBufs,
+          remoteKeys,
+          CtranMapperBackend::NVL,
+          /*recordExport=*/false,
+          outIpcHdls);
+    }
+    return mapper->allGatherCtrl(
+        buf,
+        hdl,
         exchangeRanks,
-        remoteUserBufs,
-        remoteUserBufAccessKeys,
+        remoteBufs,
+        remoteKeys,
         CtranMapperBackend::UNSET,
         /*recordExport=*/false,
+        outIpcHdls);
+  };
+
+  FB_COMMCHECK(exchangeBuffer(
+      winBasePtr,
+      baseRegHdl,
+      remoteBaseBufs,
+      remoteBaseBufAccessKeys,
+      /*outIpcHdls=*/nullptr));
+
+  if (!allocDataBuf_) {
+    // User-provided data buffer needs its own handle exchange round.
+    FB_COMMCHECK(exchangeBuffer(
+        winDataPtr,
+        dataRegHdl,
+        remoteUserBufs,
+        remoteUserBufAccessKeys,
         &dataScopedIpcRegHdls));
   }
 
@@ -612,6 +649,11 @@ commResult_t ctranWinRegister(
   newWin->setAtomicCapable(
       reinterpret_cast<uintptr_t>(databuf) % sizeof(uint64_t) == 0 &&
       size % sizeof(uint64_t) == 0);
+
+  std::string ipcOnlyVal;
+  if (hints.get("win_register_ipc_only", ipcOnlyVal) == commSuccess) {
+    newWin->setIpcOnly(meta::comms::hints::WinHintUtils::parseBool(ipcOnlyVal));
+  }
 
   FB_COMMCHECK(newWin->allocate((void*)databuf));
 

--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -271,6 +271,7 @@ Config::Config(const ncclConfig_t* config) {
   usePatAvg = parseHintBool("usePatAvg", NCCL_REDUCESCATTER_PAT_AVG_ENABLE);
   noLocal = parseHintBool("noLocal", false);
   winRegisterIpcOnly = parseHintBool("win_register_ipc_only", false);
+  winRegisterEnableSignal = parseHintBool("win_register_enable_signal", true);
 
   auto parseAlgoHint = [&](const char* key, auto& field) {
     auto val = getHintStr(key);
@@ -327,6 +328,7 @@ ncclResult_t Config::update(const ncclx::Hints* hints) {
     }
   };
   parseBoolHint("win_register_ipc_only", winRegisterIpcOnly);
+  parseBoolHint("win_register_enable_signal", winRegisterEnableSignal);
 
   return ncclSuccess;
 }
@@ -389,6 +391,9 @@ void ncclxLogCommConfig(ncclComm_t comm) {
     append(fmt::format("usePatAvg={}", xCfg->usePatAvg));
     append(fmt::format("noLocal={}", xCfg->noLocal));
     append(fmt::format("winRegisterIpcOnly={}", xCfg->winRegisterIpcOnly));
+    append(
+        fmt::format(
+            "winRegisterEnableSignal={}", xCfg->winRegisterEnableSignal));
     append(fmt::format("ibLazyConnect={}", xCfg->ibLazyConnect));
     appendAlgo("sendrecvAlgo", xCfg->sendrecvAlgo);
     appendAlgo("allgatherAlgo", xCfg->allgatherAlgo);

--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -270,6 +270,7 @@ Config::Config(const ncclConfig_t* config) {
   useCtran = parseHintBool("useCtran", NCCL_CTRAN_ENABLE);
   usePatAvg = parseHintBool("usePatAvg", NCCL_REDUCESCATTER_PAT_AVG_ENABLE);
   noLocal = parseHintBool("noLocal", false);
+  winRegisterIpcOnly = parseHintBool("win_register_ipc_only", false);
 
   auto parseAlgoHint = [&](const char* key, auto& field) {
     auto val = getHintStr(key);
@@ -316,6 +317,16 @@ ncclResult_t Config::update(const ncclx::Hints* hints) {
   parseAlgoHint("allreduceAlgo", allreduceAlgo);
   parseAlgoHint("alltoallvAlgo", alltoallvAlgo);
   parseAlgoHint("rmaAlgo", rmaAlgo);
+
+  // Mutable bool window hints: applied only when the key is present, so an
+  // unrelated commSetConfig does not reset them (win hints are not pre-seeded).
+  auto parseBoolHint = [&](const char* key, bool& field) {
+    std::string val;
+    if (hints->get(key, val) == ncclSuccess) {
+      field = (val == "1" || val == "true");
+    }
+  };
+  parseBoolHint("win_register_ipc_only", winRegisterIpcOnly);
 
   return ncclSuccess;
 }
@@ -377,6 +388,7 @@ void ncclxLogCommConfig(ncclComm_t comm) {
     append(fmt::format("useCtran={}", xCfg->useCtran));
     append(fmt::format("usePatAvg={}", xCfg->usePatAvg));
     append(fmt::format("noLocal={}", xCfg->noLocal));
+    append(fmt::format("winRegisterIpcOnly={}", xCfg->winRegisterIpcOnly));
     append(fmt::format("ibLazyConnect={}", xCfg->ibLazyConnect));
     appendAlgo("sendrecvAlgo", xCfg->sendrecvAlgo);
     appendAlgo("allgatherAlgo", xCfg->allgatherAlgo);

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -33,6 +33,10 @@ class Config {
   bool usePatAvg = false;
   bool noLocal = false;
 
+  // When true, windows registered on this comm exchange only intra-node NVL/IPC
+  // handles and defer the IB rkey exchange. Mutable via commSetConfig.
+  bool winRegisterIpcOnly = false;
+
   enum NCCL_SENDRECV_ALGO sendrecvAlgo = NCCL_SENDRECV_ALGO::orig;
   enum NCCL_ALLGATHER_ALGO allgatherAlgo = NCCL_ALLGATHER_ALGO::orig;
   enum NCCL_ALLREDUCE_ALGO allreduceAlgo = NCCL_ALLREDUCE_ALGO::orig;
@@ -82,6 +86,7 @@ inline const std::vector<std::string>& knownHintKeys() {
       "ibSplitDataOnQps",
       "ibQpsPerConnection",
       "ibLazyConnect",
+      "win_register_ipc_only",
   };
   return keys;
 }
@@ -94,6 +99,7 @@ inline const std::vector<std::string>& mutableHintKeys() {
       "allreduceAlgo",
       "alltoallvAlgo",
       "rmaAlgo",
+      "win_register_ipc_only",
   };
   return keys;
 }

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -37,6 +37,11 @@ class Config {
   // handles and defer the IB rkey exchange. Mutable via commSetConfig.
   bool winRegisterIpcOnly = false;
 
+  // When false, windows registered on this comm skip signal-buffer allocation
+  // and the signal control exchange; signal RMA ops are then rejected. Mutable
+  // via commSetConfig.
+  bool winRegisterEnableSignal = true;
+
   enum NCCL_SENDRECV_ALGO sendrecvAlgo = NCCL_SENDRECV_ALGO::orig;
   enum NCCL_ALLGATHER_ALGO allgatherAlgo = NCCL_ALLGATHER_ALGO::orig;
   enum NCCL_ALLREDUCE_ALGO allreduceAlgo = NCCL_ALLREDUCE_ALGO::orig;
@@ -87,6 +92,7 @@ inline const std::vector<std::string>& knownHintKeys() {
       "ibQpsPerConnection",
       "ibLazyConnect",
       "win_register_ipc_only",
+      "win_register_enable_signal",
   };
   return keys;
 }
@@ -100,6 +106,7 @@ inline const std::vector<std::string>& mutableHintKeys() {
       "alltoallvAlgo",
       "rmaAlgo",
       "win_register_ipc_only",
+      "win_register_enable_signal",
   };
   return keys;
 }

--- a/comms/ncclx/meta/hints/Hints.cc
+++ b/comms/ncclx/meta/hints/Hints.cc
@@ -45,7 +45,7 @@ Hints::set(const std::string& key, const std::string& val) {
   if (bareKey.starts_with("ncclx_alltoallp")) {
     NCCLCHECK(metaCommToNccl(AllToAllPHintUtils::set(bareKey, val, this->kv)));
     return ncclSuccess;
-  } else if (bareKey.starts_with(("window"))) {
+  } else if (bareKey.starts_with(("win"))) {
     NCCLCHECK(metaCommToNccl(WinHintUtils::set(bareKey, val, this->kv)));
     return ncclSuccess;
   } else {

--- a/comms/ncclx/meta/tests/CommSetConfigTest.cc
+++ b/comms/ncclx/meta/tests/CommSetConfigTest.cc
@@ -309,6 +309,52 @@ TEST_F(CommSetConfigTest, WinRegisterIpcOnlyNotResetByUnrelatedUpdate) {
   }
 }
 
+TEST_F(CommSetConfigTest, SetWinRegisterEnableSignal) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"win_register_enable_signal", "0"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_FALSE(NCCLX_CONFIG_FIELD(comm->config, winRegisterEnableSignal));
+  }
+
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"win_register_enable_signal", "1"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_TRUE(NCCLX_CONFIG_FIELD(comm->config, winRegisterEnableSignal));
+  }
+}
+
+TEST_F(CommSetConfigTest, WinRegisterEnableSignalNotResetByUnrelatedUpdate) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  // Disable signals first.
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"win_register_enable_signal", "0"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_FALSE(NCCLX_CONFIG_FIELD(comm->config, winRegisterEnableSignal));
+  }
+
+  // An unrelated update must not reset it (key absent and not pre-seeded).
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"allgatherAlgo", "ctdirect"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_FALSE(NCCLX_CONFIG_FIELD(comm->config, winRegisterEnableSignal));
+  }
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);

--- a/comms/ncclx/meta/tests/CommSetConfigTest.cc
+++ b/comms/ncclx/meta/tests/CommSetConfigTest.cc
@@ -263,6 +263,52 @@ TEST_F(CommSetConfigTest, SetConfigAfterCollective) {
   cudaFree(buf);
 }
 
+TEST_F(CommSetConfigTest, SetWinRegisterIpcOnly) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"win_register_ipc_only", "1"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_TRUE(NCCLX_CONFIG_FIELD(comm->config, winRegisterIpcOnly));
+  }
+
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"win_register_ipc_only", "0"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_FALSE(NCCLX_CONFIG_FIELD(comm->config, winRegisterIpcOnly));
+  }
+}
+
+TEST_F(CommSetConfigTest, WinRegisterIpcOnlyNotResetByUnrelatedUpdate) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  // Enable win_register_ipc_only.
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"win_register_ipc_only", "1"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_TRUE(NCCLX_CONFIG_FIELD(comm->config, winRegisterIpcOnly));
+  }
+
+  // An unrelated update must not reset it (key absent and not pre-seeded).
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"allgatherAlgo", "ctdirect"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_TRUE(NCCLX_CONFIG_FIELD(comm->config, winRegisterIpcOnly));
+  }
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);

--- a/comms/ncclx/v2_29/src/dev_runtime.cc
+++ b/comms/ncclx/v2_29/src/dev_runtime.cc
@@ -1248,12 +1248,19 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
       win_->comm = comm;
 
       auto guard = folly::makeGuard([win_] { delete win_; });
+      // Bridge the comm-level ncclx::win_register_ipc_only hint into the ctran
+      // window hints, as there is no per-window config path from Python today.
+      meta::comms::Hints winHints;
+      NCCLCHECK(metaCommToNccl(winHints.set(
+          "win_register_ipc_only",
+          NCCLX_CONFIG_FIELD(comm->config, winRegisterIpcOnly) ? "1" : "0")));
       NCCLCHECK(metaCommToNccl(
           ctran::ctranWinRegister(
               buff,
               size,
               comm->ctranComm_.get(),
-              &win_->ctranWindow)));
+              &win_->ctranWindow,
+              winHints)));
 
       // Create empty ncclWindow as handle and register mapping
       ncclWindow_t handle = new ncclWindow_vidmem();

--- a/comms/ncclx/v2_29/src/dev_runtime.cc
+++ b/comms/ncclx/v2_29/src/dev_runtime.cc
@@ -1254,6 +1254,10 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
       NCCLCHECK(metaCommToNccl(winHints.set(
           "win_register_ipc_only",
           NCCLX_CONFIG_FIELD(comm->config, winRegisterIpcOnly) ? "1" : "0")));
+      NCCLCHECK(metaCommToNccl(winHints.set(
+          "win_register_enable_signal",
+          NCCLX_CONFIG_FIELD(comm->config, winRegisterEnableSignal) ? "1"
+                                                                    : "0")));
       NCCLCHECK(metaCommToNccl(
           ctran::ctranWinRegister(
               buff,

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -377,7 +377,7 @@ $(BINDIR)/$(BINNAME): $(BINOBJ)
 $(BINDIR)/$(PARAMBIN): $(PARAMBINOBJ) $(LIBDIR)/$(LIBTARGET)
 	@printf "Linking    %-35s > %s\n" $(PARAMBIN) $@
 	mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) $< -o $@ -L$(LIBDIR) -L${CONDA_LIB_DIR} -lnccl -L${CUDA_LIB} -l$(CUDARTLIB) -lpthread -lrt -ldl
+	$(CXX) $(CXXFLAGS) $< -o $@ -L$(LIBDIR) -L${CONDA_LIB_DIR} -lnccl -L${CUDA_LIB} -l$(CUDARTLIB) -lpthread -lrt -ldl -latomic
 
 $(PKGDIR)/nccl.pc : nccl.pc.in
 	mkdir -p $(PKGDIR)

--- a/comms/ncclx/v2_30/src/dev_runtime.cc
+++ b/comms/ncclx/v2_30/src/dev_runtime.cc
@@ -1490,6 +1490,10 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
       NCCLCHECK(metaCommToNccl(winHints.set(
           "win_register_ipc_only",
           NCCLX_CONFIG_FIELD(comm->config, winRegisterIpcOnly) ? "1" : "0")));
+      NCCLCHECK(metaCommToNccl(winHints.set(
+          "win_register_enable_signal",
+          NCCLX_CONFIG_FIELD(comm->config, winRegisterEnableSignal) ? "1"
+                                                                    : "0")));
       NCCLCHECK(metaCommToNccl(
           ctran::ctranWinRegister(
               buff,

--- a/comms/ncclx/v2_30/src/dev_runtime.cc
+++ b/comms/ncclx/v2_30/src/dev_runtime.cc
@@ -1484,12 +1484,19 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
       win_->comm = comm;
 
       auto guard = folly::makeGuard([win_] { delete win_; });
+      // Bridge the comm-level ncclx::win_register_ipc_only hint into the ctran
+      // window hints, as there is no per-window config path from Python today.
+      meta::comms::Hints winHints;
+      NCCLCHECK(metaCommToNccl(winHints.set(
+          "win_register_ipc_only",
+          NCCLX_CONFIG_FIELD(comm->config, winRegisterIpcOnly) ? "1" : "0")));
       NCCLCHECK(metaCommToNccl(
           ctran::ctranWinRegister(
               buff,
               size,
               comm->ctranComm_.get(),
-              &win_->ctranWindow)));
+              &win_->ctranWindow,
+              winHints)));
 
       // Create empty ncclWindow as handle and register mapping
       ncclWindow_t handle = new ncclWindow_vidmem();

--- a/comms/ncclx/v2_30/src/device/Makefile
+++ b/comms/ncclx/v2_30/src/device/Makefile
@@ -28,7 +28,7 @@ INCFLAGS += -I${SHAREDDIR}/
 INCFLAGS  += -I$(BASE_DIR)
 INCFLAGS  += -I$(CONDA_INCLUDE_DIR)
 NVCUFLAGS += $(INCFLAGS) --compiler-options "-fPIC -fvisibility=hidden"
-CXXFLAGS  += $(INCFLAGS)
+CXXFLAGS  := $(INCFLAGS) $(CXXFLAGS)
 
 NVCUFLAGS_SYM += -ccbin $(CXX) $(CXXSTD) --expt-extended-lambda -Xptxas -maxrregcount=128 -Xfatbin -compress-all
 NVCUFLAGS_SYM += $(INCFLAGS) --compiler-options "-fPIC -fvisibility=hidden"


### PR DESCRIPTION
Summary:

Introduce a ctran window registration hint `win_register_enable_signal` (default true). When set false, the window carries no signal buffer: signal-buffer allocation and the signal-related control exchange are skipped, and signal RMA ops are rejected. This lets a data-only collective window (e.g. the upcoming window-based allgather `ctwin`) pay nothing for signals. Mirrors the `win_register_ipc_only` plumbing.
- `WinHintUtils`: new key `win_register_enable_signal` (bool "1"/"0", default "1").
- `CtranWin`: cache in `enableSignal_` (+ `setEnableSignal`/`isSignalEnabled`). In `exchange()`, gate the base-buffer `regMem` and base `allGatherCtrl` behind `exchangeBaseBuffer = allocDataBuf_ || enableSignal_` (on the register path the base buffer holds only the signal, so with signals disabled it is skipped entirely) and skip the `signalAddr`/`signalRkey` fills; in `allocate()` drop the signal bytes (allocSize can be 0 -> no base allocation); in `free()` dereg the signal rkey only when signals are enabled and null-guard `freeMem`. The `enableSignal_==true` path is unchanged.
- `RMA/PutSignal.cc`: `ctranSignal`, `ctranWaitSignal`, and `ctranPutSignal(signal=true)` return `commInvalidUsage` when signals are disabled (plain `ctranPut` still works).
- Comm-hint bridge: add `ncclx::Config::winRegisterEnableSignal` (default true) parsed from `ncclx::win_register_enable_signal`, injected into the ctran window hints at the `ncclCommWindowRegister` ctran branch (v2_29 + v2_30). Kept out of `knownHintKeys()` for the same reason as `win_register_ipc_only`.

Differential Revision: D112213501


