### PR TITLE
Fix gin header shadowing in v2.30 OSS device build

### DIFF
--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -377,7 +377,7 @@ $(BINDIR)/$(BINNAME): $(BINOBJ)
 $(BINDIR)/$(PARAMBIN): $(PARAMBINOBJ) $(LIBDIR)/$(LIBTARGET)
 	@printf "Linking    %-35s > %s\n" $(PARAMBIN) $@
 	mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) $< -o $@ -L$(LIBDIR) -L${CONDA_LIB_DIR} -lnccl -L${CUDA_LIB} -l$(CUDARTLIB) -lpthread -lrt -ldl
+	$(CXX) $(CXXFLAGS) $< -o $@ -L$(LIBDIR) -L${CONDA_LIB_DIR} -lnccl -L${CUDA_LIB} -l$(CUDARTLIB) -lpthread -lrt -ldl -latomic
 
 $(PKGDIR)/nccl.pc : nccl.pc.in
 	mkdir -p $(PKGDIR)

--- a/comms/ncclx/v2_30/src/device/Makefile
+++ b/comms/ncclx/v2_30/src/device/Makefile
@@ -28,7 +28,7 @@ INCFLAGS += -I${SHAREDDIR}/
 INCFLAGS  += -I$(BASE_DIR)
 INCFLAGS  += -I$(CONDA_INCLUDE_DIR)
 NVCUFLAGS += $(INCFLAGS) --compiler-options "-fPIC -fvisibility=hidden"
-CXXFLAGS  += $(INCFLAGS)
+CXXFLAGS  := $(INCFLAGS) $(CXXFLAGS)
 
 NVCUFLAGS_SYM += -ccbin $(CXX) $(CXXSTD) --expt-extended-lambda -Xptxas -maxrregcount=128 -Xfatbin -compress-all
 NVCUFLAGS_SYM += $(INCFLAGS) --compiler-options "-fPIC -fvisibility=hidden"


### PR DESCRIPTION
Summary:
The OSS aarch64 wheel build of NCCLX v2.30 fails compiling the device sub-build host file `sym_kernels_host.cc` with `'NCCL_GIN_MAX_CONNECTIONS' was not declared in this scope` (at `nccl_device/impl/core__types.h:28` and `comm__types.h:47-48`), because the CUDA toolkit at `/usr/local/cuda-12.6/include` bundles its own `nccl_device/gin/gin_device_host_common.h` that shares the include guard `_NCCL_GIN_DEVICE_HOST_COMMON_H_` but defines `NCCL_GIN_MAX_CONTEXTS` instead of `NCCL_GIN_MAX_CONNECTIONS`. Details:
- `makefiles/common.mk` injects `-I $(CUDA_INC)` into `CXXFLAGS` early, and `src/device/Makefile` then appended ncclx's own `INCFLAGS` (`-I$(BUILDDIR)/include`, `-I../include`) via `CXXFLAGS += $(INCFLAGS)`, so the CUDA-bundled gin header won the quote-include and its guard blocked ncclx's own copy, leaving `NCCL_GIN_MAX_CONNECTIONS` undefined.
- Only the device sub-build's single host `.cc` (`sym_kernels_host.cc`) hit this: the `.cu` kernels go through nvcc (which searches its built-in CUDA include path last), and the top-level `src` build already orders `$(BUILDDIR)/include` before the CUDA include.
- Fix: prepend `INCFLAGS` (`CXXFLAGS := $(INCFLAGS) $(CXXFLAGS)`) so ncclx's own include dirs precede the CUDA toolkit include, matching the ordering the `src` build and the nvcc paths already use. `NVCUFLAGS`/`NVCUFLAGS_SYM` are unchanged.

Differential Revision: D112584848


