### PR TITLE
Add Comm switch for A2A (#3175)

### DIFF
--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -31,6 +31,7 @@ Config::Config(const ncclConfig_t* config) {
   sendrecvAlgo = NCCL_SENDRECV_ALGO;
   allgatherAlgo = NCCL_ALLGATHER_ALGO;
   allreduceAlgo = NCCL_ALLREDUCE_ALGO;
+  alltoallAlgo = NCCL_ALLTOALL_ALGO;
   alltoallvAlgo = NCCL_ALLTOALLV_ALGO;
   rmaAlgo = NCCL_RMA_ALGO;
 
@@ -283,6 +284,7 @@ Config::Config(const ncclConfig_t* config) {
   parseAlgoHint("sendrecvAlgo", sendrecvAlgo);
   parseAlgoHint("allgatherAlgo", allgatherAlgo);
   parseAlgoHint("allreduceAlgo", allreduceAlgo);
+  parseAlgoHint("alltoallAlgo", alltoallAlgo);
   parseAlgoHint("alltoallvAlgo", alltoallvAlgo);
   parseAlgoHint("rmaAlgo", rmaAlgo);
 }
@@ -317,6 +319,7 @@ ncclResult_t Config::update(const ncclx::Hints* hints) {
   parseAlgoHint("sendrecvAlgo", sendrecvAlgo);
   parseAlgoHint("allgatherAlgo", allgatherAlgo);
   parseAlgoHint("allreduceAlgo", allreduceAlgo);
+  parseAlgoHint("alltoallAlgo", alltoallAlgo);
   parseAlgoHint("alltoallvAlgo", alltoallvAlgo);
   parseAlgoHint("rmaAlgo", rmaAlgo);
 
@@ -401,6 +404,7 @@ void ncclxLogCommConfig(ncclComm_t comm) {
     appendAlgo("sendrecvAlgo", xCfg->sendrecvAlgo);
     appendAlgo("allgatherAlgo", xCfg->allgatherAlgo);
     appendAlgo("allreduceAlgo", xCfg->allreduceAlgo);
+    appendAlgo("alltoallAlgo", xCfg->alltoallAlgo);
     appendAlgo("alltoallvAlgo", xCfg->alltoallvAlgo);
     appendAlgo("rmaAlgo", xCfg->rmaAlgo);
     auto appendIfSet = [&](const char* name, const auto& opt) {
@@ -520,6 +524,7 @@ ncclx::commSetConfig(ncclComm_t comm, const ncclConfig_t* config) {
   appendIfSet("sendrecvAlgo", cfg->sendrecvAlgo);
   appendIfSet("allgatherAlgo", cfg->allgatherAlgo);
   appendIfSet("allreduceAlgo", cfg->allreduceAlgo);
+  appendIfSet("alltoallAlgo", cfg->alltoallAlgo);
   appendIfSet("alltoallvAlgo", cfg->alltoallvAlgo);
   appendIfSet("rmaAlgo", cfg->rmaAlgo);
 

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -51,6 +51,7 @@ class Config {
   enum NCCL_SENDRECV_ALGO sendrecvAlgo = NCCL_SENDRECV_ALGO::orig;
   enum NCCL_ALLGATHER_ALGO allgatherAlgo = NCCL_ALLGATHER_ALGO::orig;
   enum NCCL_ALLREDUCE_ALGO allreduceAlgo = NCCL_ALLREDUCE_ALGO::orig;
+  enum NCCL_ALLTOALL_ALGO alltoallAlgo = NCCL_ALLTOALL_ALGO::orig;
   enum NCCL_ALLTOALLV_ALGO alltoallvAlgo = NCCL_ALLTOALLV_ALGO::orig;
   enum NCCL_RMA_ALGO rmaAlgo = NCCL_RMA_ALGO::orig;
 
@@ -89,6 +90,7 @@ inline const std::vector<std::string>& knownHintKeys() {
       "allgatherAlgo",
       "allreduceAlgo",
       "pipesIbgdaDataBufferSize",
+      "alltoallAlgo",
       "alltoallvAlgo",
       "rmaAlgo",
       "pipesNvlChunkSize",
@@ -110,6 +112,7 @@ inline const std::vector<std::string>& mutableHintKeys() {
       "sendrecvAlgo",
       "allgatherAlgo",
       "allreduceAlgo",
+      "alltoallAlgo",
       "alltoallvAlgo",
       "rmaAlgo",
       "win_register_ipc_only",

--- a/comms/ncclx/meta/algoconf/AlgoStrConv.h
+++ b/comms/ncclx/meta/algoconf/AlgoStrConv.h
@@ -94,6 +94,16 @@ inline void algoStrToVal(
   }
 }
 
+inline void algoStrToVal(const std::string& str, enum NCCL_ALLTOALL_ALGO& val) {
+  if (str == "ctran") {
+    val = NCCL_ALLTOALL_ALGO::ctran;
+  } else if (str == "ctgraph") {
+    val = NCCL_ALLTOALL_ALGO::ctgraph;
+  } else {
+    val = NCCL_ALLTOALL_ALGO::orig;
+  }
+}
+
 inline void algoStrToVal(const std::string& str, enum NCCL_RMA_ALGO& val) {
   if (str == "ctran") {
     val = NCCL_RMA_ALGO::ctran;
@@ -186,6 +196,18 @@ inline std::string algoValToStr(enum NCCL_ALLTOALLV_ALGO val) {
       return "compCtran";
     case NCCL_ALLTOALLV_ALGO::bsCompCtran:
       return "bsCompCtran";
+  }
+  return "unknown";
+}
+
+inline std::string algoValToStr(enum NCCL_ALLTOALL_ALGO val) {
+  switch (val) {
+    case NCCL_ALLTOALL_ALGO::orig:
+      return "orig";
+    case NCCL_ALLTOALL_ALGO::ctran:
+      return "ctran";
+    case NCCL_ALLTOALL_ALGO::ctgraph:
+      return "ctgraph";
   }
   return "unknown";
 }

--- a/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
+++ b/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
@@ -147,6 +147,26 @@ void checkAlgoStrToVal(enum NCCL_ALLTOALLV_ALGO algo) {
   EXPECT_EQ(algoValToStr(algo), str) << "algoValToStr round-trip failed";
 }
 
+void checkAlgoStrToVal(enum NCCL_ALLTOALL_ALGO algo) {
+  std::string str = "UNHANDLED_ENUM_VALUE";
+  switch (algo) {
+    case NCCL_ALLTOALL_ALGO::orig:
+      str = "orig";
+      break;
+    case NCCL_ALLTOALL_ALGO::ctran:
+      str = "ctran";
+      break;
+    case NCCL_ALLTOALL_ALGO::ctgraph:
+      str = "ctgraph";
+      break;
+  }
+  enum NCCL_ALLTOALL_ALGO result;
+  algoStrToVal(str, result);
+  EXPECT_EQ(result, algo) << "algoStrToVal(\"" << str
+                          << "\") returned wrong value";
+  EXPECT_EQ(algoValToStr(algo), str) << "algoValToStr round-trip failed";
+}
+
 void checkAlgoStrToVal(enum NCCL_RMA_ALGO algo) {
   std::string str = "UNHANDLED_ENUM_VALUE";
   switch (algo) {
@@ -208,6 +228,12 @@ TEST(AlgoStrConvTest, AllToAllVCompleteness) {
   checkAlgoStrToVal(NCCL_ALLTOALLV_ALGO::bsCompCtran);
 }
 
+TEST(AlgoStrConvTest, AllToAllCompleteness) {
+  checkAlgoStrToVal(NCCL_ALLTOALL_ALGO::orig);
+  checkAlgoStrToVal(NCCL_ALLTOALL_ALGO::ctran);
+  checkAlgoStrToVal(NCCL_ALLTOALL_ALGO::ctgraph);
+}
+
 TEST(AlgoStrConvTest, RmaCompleteness) {
   checkAlgoStrToVal(NCCL_RMA_ALGO::orig);
   checkAlgoStrToVal(NCCL_RMA_ALGO::ctran);
@@ -229,6 +255,10 @@ TEST(AlgoStrConvTest, UnknownStringFallback) {
   enum NCCL_ALLTOALLV_ALGO alltoallv;
   algoStrToVal("nonexistent", alltoallv);
   EXPECT_EQ(alltoallv, NCCL_ALLTOALLV_ALGO::orig);
+
+  enum NCCL_ALLTOALL_ALGO alltoall;
+  algoStrToVal("nonexistent", alltoall);
+  EXPECT_EQ(alltoall, NCCL_ALLTOALL_ALGO::orig);
 
   enum NCCL_RMA_ALGO rma;
   algoStrToVal("nonexistent", rma);

--- a/comms/ncclx/meta/hints/GlobalHints.h
+++ b/comms/ncclx/meta/hints/GlobalHints.h
@@ -28,13 +28,14 @@ constexpr std::array<std::string_view, 3> kHintKeysArray = {
 // {deprecated GlobalHint key, replacement per-comm ncclx::Hints key}
 using DeprecatedHintKey = std::pair<std::string_view, std::string_view>;
 
-constexpr std::array<DeprecatedHintKey, 9> kDeprecatedCommHintKeys = {{
+constexpr std::array<DeprecatedHintKey, 10> kDeprecatedCommHintKeys = {{
     {"ncclx.comm.useCtran", "useCtran"},
     {"ncclx.comm.algo_reducescatter", "usePatAvg"},
     {"ncclx.comm.nolocal", "noLocal"},
     {"ncclx.comm.vCliqueSize", "vCliqueSize"},
     {"algo_allgather", "allgatherAlgo"},
     {"algo_allreduce", "allreduceAlgo"},
+    {"algo_alltoall", "alltoallAlgo"},
     {"algo_alltoallv", "alltoallvAlgo"},
     {"algo_rma", "rmaAlgo"},
     {"algo_sendrecv", "sendrecvAlgo"},

--- a/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
+++ b/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
@@ -29,6 +29,7 @@ TEST(ConfigHintsUT, NoHintsCreatesDefaults) {
   EXPECT_EQ(ncclxCfg->sendrecvAlgo, NCCL_SENDRECV_ALGO::orig);
   EXPECT_EQ(ncclxCfg->allgatherAlgo, NCCL_ALLGATHER_ALGO::orig);
   EXPECT_EQ(ncclxCfg->allreduceAlgo, NCCL_ALLREDUCE_ALGO::orig);
+  EXPECT_EQ(ncclxCfg->alltoallAlgo, NCCL_ALLTOALL_ALGO::orig);
   EXPECT_EQ(ncclxCfg->alltoallvAlgo, NCCL_ALLTOALLV_ALGO::orig);
   EXPECT_EQ(ncclxCfg->rmaAlgo, NCCL_RMA_ALGO::ctran);
 
@@ -443,6 +444,18 @@ TEST(ConfigHintsUT, AlltoallvAlgoHint) {
   ASSERT_NE(config.ncclxConfig, nullptr);
   EXPECT_EQ(
       NCCLX_CONFIG_FIELD(config, alltoallvAlgo), NCCL_ALLTOALLV_ALGO::ctran);
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, AlltoallAlgoHint) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("alltoallAlgo", "ctran");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_EQ(
+      NCCLX_CONFIG_FIELD(config, alltoallAlgo), NCCL_ALLTOALL_ALGO::ctran);
   delete static_cast<ncclx::Config*>(config.ncclxConfig);
 }
 

--- a/comms/ncclx/meta/tests/AllToAllTest.cc
+++ b/comms/ncclx/meta/tests/AllToAllTest.cc
@@ -11,9 +11,11 @@
 #include "checks.h"
 
 #include "comms/ctran/Ctran.h"
+#include "comms/ctran/tests/VerifyAlgoStatsUtil.h"
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/NcclxConfig.h"
 #include "meta/commDump.h"
 
 static const int kTotalColls = 5;
@@ -26,6 +28,7 @@ class AllToAllTest : public NcclxBaseTestFixture {
     setenv("NCCL_COLLTRACE", "trace", 0);
 #endif
     NcclxBaseTestFixture::SetUp();
+    ctranAlgoStats_.enable();
 
     this->comm = ncclx::test::createNcclComm(
         globalRank, numRanks, localRank, bootstrap_.get());
@@ -117,6 +120,7 @@ class AllToAllTest : public NcclxBaseTestFixture {
  protected:
   ncclComm_t comm;
   cudaStream_t stream;
+  ctran::test::VerifyAlgoStatsHelper ctranAlgoStats_;
 };
 
 TEST_F(AllToAllTest, OutOfPlace) {
@@ -125,8 +129,37 @@ TEST_F(AllToAllTest, OutOfPlace) {
 
 #ifdef TEST_ENABLE_CTRAN
 TEST_F(AllToAllTest, Ctran) {
-  auto envGuard = EnvRAII(NCCL_ALLTOALL_ALGO, NCCL_ALLTOALL_ALGO::ctran);
+  // Flip alltoallAlgo to ctran on the already-initialized comm via the
+  // per-comm mutable-update path.
+  ncclConfig_t updateConfig = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"alltoallAlgo", "ctran"}};
+  updateConfig.hints = &hints;
+  ASSERT_EQ(ncclSuccess, ncclx::commSetConfig(this->comm, &updateConfig));
+  EXPECT_EQ(
+      NCCL_ALLTOALL_ALGO::ctran,
+      NCCLX_CONFIG_FIELD(this->comm->config, alltoallAlgo));
+
   run();
+
+  ctranAlgoStats_.verify(comm->ctranComm_.get(), "AllToAll", "Ctran");
+}
+
+TEST_F(AllToAllTest, AllToAllWithHintOverride) {
+  // Recreate the comm with alltoallAlgo=ctran init-time hint.
+  NCCLCHECK_TEST(ncclCommDestroy(this->comm));
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"alltoallAlgo", "ctran"}};
+  config.hints = &hints;
+  this->comm = ncclx::test::createNcclComm(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+  ASSERT_NE(nullptr, this->comm);
+  EXPECT_EQ(
+      NCCL_ALLTOALL_ALGO::ctran,
+      NCCLX_CONFIG_FIELD(this->comm->config, alltoallAlgo));
+
+  run();
+
+  ctranAlgoStats_.verify(comm->ctranComm_.get(), "AllToAll", "Ctran");
 }
 #endif
 

--- a/comms/ncclx/meta/tests/CommSetConfigTest.cc
+++ b/comms/ncclx/meta/tests/CommSetConfigTest.cc
@@ -35,6 +35,7 @@ TEST_F(CommSetConfigTest, SetAllAlgoHints) {
       {"allgatherAlgo", "ctring"},
       {"allreduceAlgo", "ctdirect"},
       {"sendrecvAlgo", "ctran"},
+      {"alltoallAlgo", "ctran"},
       {"alltoallvAlgo", "ctran"},
       {"rmaAlgo", "ctran"},
   });
@@ -50,6 +51,9 @@ TEST_F(CommSetConfigTest, SetAllAlgoHints) {
   EXPECT_EQ(
       NCCL_SENDRECV_ALGO::ctran,
       NCCLX_CONFIG_FIELD(comm->config, sendrecvAlgo));
+  EXPECT_EQ(
+      NCCL_ALLTOALL_ALGO::ctran,
+      NCCLX_CONFIG_FIELD(comm->config, alltoallAlgo));
   EXPECT_EQ(
       NCCL_ALLTOALLV_ALGO::ctran,
       NCCLX_CONFIG_FIELD(comm->config, alltoallvAlgo));

--- a/comms/ncclx/v2_29/src/collectives.cc
+++ b/comms/ncclx/v2_29/src/collectives.cc
@@ -374,9 +374,10 @@ ncclResult_t ncclAllToAll(
         recvbuff);
   }
 
-  if ((NCCL_ALLTOALL_ALGO != NCCL_ALLTOALL_ALGO::orig) &&
-      ctranAllToAllSupport(count, ncclToMetaComm(datatype), comm->ctranComm_.get(), NCCL_ALLTOALL_ALGO, stream)) {
-    return metaCommToNccl(ctranAllToAll(sendbuff, recvbuff, count, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, NCCL_ALLTOALL_ALGO));
+  auto alltoallAlgo = NCCLX_CONFIG_FIELD(comm->config, alltoallAlgo);
+  if ((alltoallAlgo != NCCL_ALLTOALL_ALGO::orig) &&
+      ctranAllToAllSupport(count, ncclToMetaComm(datatype), comm->ctranComm_.get(), alltoallAlgo, stream)) {
+    return metaCommToNccl(ctranAllToAll(sendbuff, recvbuff, count, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, alltoallAlgo));
   }
 
   // fallback to baseline send/recv based alltoall

--- a/comms/ncclx/v2_30/src/collectives.cc
+++ b/comms/ncclx/v2_30/src/collectives.cc
@@ -374,9 +374,10 @@ ncclResult_t ncclAllToAll(
         recvbuff);
   }
 
-  if ((NCCL_ALLTOALL_ALGO != NCCL_ALLTOALL_ALGO::orig) &&
-      ctranAllToAllSupport(count, ncclToMetaComm(datatype), comm->ctranComm_.get(), NCCL_ALLTOALL_ALGO, stream)) {
-    return metaCommToNccl(ctranAllToAll(sendbuff, recvbuff, count, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, NCCL_ALLTOALL_ALGO));
+  auto alltoallAlgo = NCCLX_CONFIG_FIELD(comm->config, alltoallAlgo);
+  if ((alltoallAlgo != NCCL_ALLTOALL_ALGO::orig) &&
+      ctranAllToAllSupport(count, ncclToMetaComm(datatype), comm->ctranComm_.get(), alltoallAlgo, stream)) {
+    return metaCommToNccl(ctranAllToAll(sendbuff, recvbuff, count, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, alltoallAlgo));
   }
 
   // fallback to baseline send/recv based alltoall


### PR DESCRIPTION
Summary:

Promotes `alltoall` to a per-communicator algorithm hint, mirroring the pattern already in place for the other five collectives (`sendrecv`, `allgather`, `allreduce`, `alltoallv`, `rma`).

**Motivation.** `NcclxConfig` recently introduced a per-comm algo-selection surface: callers pass string-keyed `ncclx::Hints` at `ncclCommInitRankConfig` or via the mutable `ncclx::commSetConfig(comm, config)`, and each collective's dispatcher in `comms/ncclx/v2_2{9,30}/src/collectives.cc` reads the corresponding field via `NCCLX_CONFIG_FIELD(comm->config, <coll>Algo)` to decide whether to route to a CTRAN backend or fall through to baseline NCCL. `alltoall` was the odd one out — `ncclAllToAll` at `collectives.cc:377` still read the process-global CVAR `NCCL_ALLTOALL_ALGO`, so two comms in the same process could not pick different alltoall backends and the choice could not be flipped at runtime.

**Change (all mirror the `alltoallvAlgo` template exactly).**
- `comms/ncclx/meta/algoconf/AlgoStrConv.h` — add `algoStrToVal(NCCL_ALLTOALL_ALGO&)` and `algoValToStr(NCCL_ALLTOALL_ALGO)` overloads covering `orig`, `ctran`, `ctgraph` (the three values currently in the cvar).
- `comms/ncclx/meta/NcclxConfig.h` — add `enum NCCL_ALLTOALL_ALGO alltoallAlgo = ::orig;` field, plus `"alltoallAlgo"` in `knownHintKeys()` and `mutableHintKeys()` so it is both parseable and mutable post-init.
- `comms/ncclx/meta/NcclxConfig.cc` — env default seed, ctor + `update()` hint parsing, `ncclxLogCommConfig` line, `commSetConfig` `appendIfSet` line.
- `comms/ncclx/v2_29/src/collectives.cc:377` and `v2_30/src/collectives.cc:377` — swap the CVAR read for `NCCLX_CONFIG_FIELD(comm->config, alltoallAlgo)`, matching the `alltoallvAlgo` dispatcher at line 457 in the same file.
- `comms/ncclx/meta/hints/GlobalHints.h` — add `{"algo_alltoall", "alltoallAlgo"}` to `kDeprecatedCommHintKeys` (array size bumped 9 → 10) for parity with the other four algo hints' legacy global-hint aliases.

**Notes for reviewers.**
- The CVAR remains the process-wide *default* — the parsing ctor at `NcclxConfig.cc:34` seeds `alltoallAlgo` from `NCCL_ALLTOALL_ALGO`, so existing users who set the CVAR see no behavior change.
- The existing `TEST_F(AllToAllTest, Ctran)` was flipping the algo via `EnvRAII(NCCL_ALLTOALL_ALGO, ...)`; that would silently no-op after this change (the field is frozen at comm-init time). Converted it to `ncclx::commSetConfig`, which additionally covers the mutable-update path.
- Fixed-count `ctranAllToAll` and `ctranAllToAllv` share the same underlying `ctranAllToAllvIbImpl` template via `RETURN_ALLTOALLV_IB_IMPL`, so the new field is honored end-to-end for both entry points.
- MCCL still reads the global CVAR directly (`comms/mccl/mccl.cpp:35`, `McclComm.cpp:1157,1178`); giving MCCL per-comm config is a separate follow-up. `broadcastAlgo` and `reducescatterAlgo` still read the CVAR too — same pattern gap, separate diffs.
- `TorchCommNCCLX::setConfig()` (Python `torch_backend.set_config({...})`) needs no change — hints flow through automatically once the key is registered.

No behavior change for anyone not passing a new hint.

Reviewed By: dsjohns2

Differential Revision: D112621458


