### PR TITLE
Add ctwin window-based persistent allgather (ctran) (#3176)

### DIFF
--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -84,7 +84,9 @@ commResult_t ctranGroupEndHook(
 bool ctranAllGatherSupport(
     CtranComm* comm,
     enum NCCL_ALLGATHER_ALGO algo,
-    cudaStream_t stream = nullptr);
+    cudaStream_t stream = nullptr,
+    const void* recvbuff = nullptr,
+    size_t recvBytes = 0);
 commResult_t ctranAllGather(
     const void* sendbuff,
     void* recvbuff,

--- a/comms/ctran/algos/AllGather/AllGather.cc
+++ b/comms/ctran/algos/AllGather/AllGather.cc
@@ -40,7 +40,9 @@ static bool isGraphAwareAlgo(enum NCCL_ALLGATHER_ALGO algo) {
 bool ctranAllGatherSupport(
     CtranComm* comm,
     enum NCCL_ALLGATHER_ALGO algo,
-    cudaStream_t stream) {
+    cudaStream_t stream,
+    const void* recvbuff,
+    size_t recvBytes) {
   if (!ctranInitialized(comm) || !comm->ctran_->mapper->hasBackend()) {
     return false;
   }
@@ -147,8 +149,10 @@ bool ctranAllGatherSupport(
     case NCCL_ALLGATHER_ALGO::ctwin_srd:
     case NCCL_ALLGATHER_ALGO::ctwin_pipeline:
     case NCCL_ALLGATHER_ALGO::ctwin_rdpipeline:
-      // TODO(ctwin): implemented in a later commit
-      supported = false;
+      // recvbuff must sit in a symmetric AllGatherP window; forced variants add
+      // topology constraints. Dormant (false) until a caller passes recvbuff.
+      supported =
+          checkCtranAllGatherCtwinSupport(comm, recvbuff, recvBytes, algo);
       break;
     case NCCL_ALLGATHER_ALGO::orig: // invalid query
       supported = false;
@@ -212,6 +216,14 @@ commResult_t ctranAllGather(
     case NCCL_ALLGATHER_ALGO::ctsrd:
       return ctranAllGatherStreamedRd(
           sendbuff, recvbuff, sendcount, datatype, comm, stream);
+
+    case NCCL_ALLGATHER_ALGO::ctwin:
+    case NCCL_ALLGATHER_ALGO::ctwin_ring:
+    case NCCL_ALLGATHER_ALGO::ctwin_srd:
+    case NCCL_ALLGATHER_ALGO::ctwin_pipeline:
+    case NCCL_ALLGATHER_ALGO::ctwin_rdpipeline:
+      return ctranAllGatherCtwin(
+          sendbuff, recvbuff, sendcount, datatype, comm, stream, algo);
 
     case NCCL_ALLGATHER_ALGO::ctdirect:
     default:

--- a/comms/ctran/algos/AllGather/AllGatherCtwin.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCtwin.cc
@@ -1,0 +1,307 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/algos/AllGatherP/AlgoImpl.h"
+#include "comms/ctran/algos/AllGatherP/Types.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/algos/PersistentCleanup.h"
+#include "comms/ctran/mapper/CtranMapperTypes.h"
+#include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/MathUtils.h"
+#include "comms/ctran/window/CtranWin.h"
+#include "comms/utils/commSpecs.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/LogUtils.h"
+
+using ctran::allgatherp::AlgoImpl;
+using ctran::allgatherp::destroyPersistentRequest;
+using ctran::allgatherp::InitState;
+
+namespace {
+
+// Auto-select the persistent AGP variant for the nLocalRanks>1 case by topology
+// (mirrors ctgraph's selectCtgraphAlgo). Called only for nLocalRanks>1; the
+// nLocalRanks==1 case routes to the dedicated ring/ctsrd instead (see
+// ctranAllGatherCtwin). ctwin cannot use the NCCL_ALLGATHER_P_ALGO cvar because
+// multiple comms with different topologies may enable it.
+enum NCCL_ALLGATHER_P_ALGO chooseAgpAlgo(
+    size_t sendBytes,
+    const ncclx::CommStateX* statex) {
+  const bool largeMessage = sendBytes >= NCCL_CTGRAPH_ALLGATHER_RING_THRESHOLD;
+  return (!largeMessage && ctran::utils::isPowerOfTwo(statex->nNodes()))
+      ? NCCL_ALLGATHER_P_ALGO::ctsrdpipeline
+      : NCCL_ALLGATHER_P_ALGO::ctpipeline;
+}
+
+// Build a persistent AllGatherP request that BORROWS the window's registration
+// + NVL/IPC state instead of running AGP's own IPC exchange. The window owns
+// and frees that state; this request's teardown only releases the AGP pooled
+// pipeSync.
+commResult_t createPersistentRequestFromWindow(
+    CtranComm* comm,
+    cudaStream_t stream,
+    ctran::CtranWin* win,
+    void* recvbuff,
+    const size_t sendcount,
+    const commDataType_t datatype,
+    const size_t offset,
+    const enum NCCL_ALLGATHER_P_ALGO agpVariant,
+    CtranPersistentRequest** out) {
+  *out = nullptr;
+  const auto nRanks = comm->statex_->nRanks();
+  const size_t maxRecvCount = sendcount * nRanks;
+
+  // initResources() allocates the pooled GpeKernelSync (pipeSync) used by exec.
+  auto algo = std::make_unique<AlgoImpl>(comm, stream);
+  FB_COMMCHECK(algo->initResources());
+
+  auto& pArgs = algo->pArgs;
+  pArgs.recvbuff = recvbuff;
+  pArgs.maxRecvCount = maxRecvCount;
+  pArgs.datatype = datatype;
+  // Borrow the window's local data registration; leave recvRegHdl_ null.
+  pArgs.recvHdl = win->dataRegHdl;
+  pArgs.recvRegHdl_ = nullptr;
+
+  // Borrow peer recv buffers + access keys from symmetric window.
+  // remoteIpcRegHdls_ stays empty.
+  pArgs.remoteRecvBuffs.assign(nRanks, nullptr);
+  pArgs.remoteAccessKeys.clear();
+  pArgs.remoteAccessKeys.reserve(nRanks);
+  for (int r = 0; r < nRanks; r++) {
+    const auto& info = win->remWinInfo[r];
+    if (info.dataAddr != nullptr) {
+      pArgs.remoteRecvBuffs[r] = reinterpret_cast<void*>(
+          reinterpret_cast<uintptr_t>(info.dataAddr) + offset);
+    }
+    pArgs.remoteAccessKeys.push_back(info.dataRkey);
+  }
+
+  // NVL/IPC already exchanged
+  pArgs.initState = InitState::kInitialized;
+  // An ipc_only window has not exchanged inter-node IB rkeys yet, so let the
+  // first exec do it (as AGP does). A full-exchange window already carries IB
+  // rkeys in remWinInfo, so skip that first-exec exchange.
+  pArgs.ibKeysExchanged = !win->isIpcOnly();
+
+  pArgs.algo = agpVariant;
+
+  auto request = std::make_unique<CtranPersistentRequest>(
+      CtranPersistentRequest::Type::ALLGATHER_P, comm, stream);
+  request->algo = algo.release();
+  // Return request ownership to window.
+  *out = request.release();
+
+  // Route teardown through a one-shot cleanup token (see PersistentCleanup.h):
+  // it only resets AGP-owned resources (pooled pipeSync, empty
+  // remoteIpcRegHdls_, null recvRegHdl_); the borrowed window state is released
+  // later by the window's free().
+  auto cleanup = std::make_shared<PersistentCleanup>([request = *out]() {
+    FB_COMMCHECKIGNORE(destroyPersistentRequest(request));
+  });
+  (*out)->cleanup_ = cleanup;
+  // The token can fire from TWO sites: (a) the window's free() -- the primary
+  // path, which runs the token, unregisters it, and deletes the request; and
+  // (b) the comm's drainPersistentCleanups() at comm destroy -- a safety net if
+  // the window outlives its free(), so the pooled pipeSync is returned before
+  // CtranGpe::terminate()'s pool drain. The token is idempotent (call_once), so
+  // there is no double cleanup.
+  comm->registerPersistentCleanup(cleanup);
+  return commSuccess;
+}
+
+} // namespace
+
+bool checkCtranAllGatherCtwinSupport(
+    CtranComm* comm,
+    const void* recvbuff,
+    const size_t recvBytes,
+    const enum NCCL_ALLGATHER_ALGO algo,
+    ctran::CtranWin** winOut) {
+  if (winOut != nullptr) {
+    *winOut = nullptr;
+  }
+  // Dormant until a caller passes a non-empty recvbuff.
+  if (recvbuff == nullptr || recvBytes == 0) {
+    CLOGF_SUBSYS(
+        INFO,
+        COLL,
+        "AllGather {} unsupported: needs a non-empty recvbuff (recvbuff={}, recvBytes={}).",
+        allGatherAlgoName(algo),
+        recvbuff,
+        recvBytes);
+    return false;
+  }
+  // Need a symmetric AllGatherP window covering the full recv range (exec
+  // computes each peer's recvbuf as its window buffer at the same offset).
+  auto* win = comm->findWindowForBuffer(recvbuff, recvBytes);
+  if (win == nullptr || !win->isSymmetric() || !win->allGatherPSupported()) {
+    CLOGF_SUBSYS(
+        INFO,
+        COLL,
+        "AllGather {} unsupported: recvbuff {} ({} bytes) is not covered by a symmetric AllGatherP window.",
+        allGatherAlgoName(algo),
+        recvbuff,
+        recvBytes);
+    return false;
+  }
+  // Forced dedicated variants need nLocalRanks==1; forced recursive-doubling
+  // variants need power-of-2 topology. Plain `ctwin` auto-selects a valid
+  // variant for any topology.
+  const auto* statex = comm->statex_.get();
+  if ((algo == NCCL_ALLGATHER_ALGO::ctwin_ring ||
+       algo == NCCL_ALLGATHER_ALGO::ctwin_srd) &&
+      statex->nLocalRanks() != 1) {
+    CLOGF_SUBSYS(
+        INFO,
+        COLL,
+        "AllGather {} unsupported: forced dedicated ring/streamed-RD requires nLocalRanks==1, got {}.",
+        allGatherAlgoName(algo),
+        statex->nLocalRanks());
+    return false;
+  }
+  if (algo == NCCL_ALLGATHER_ALGO::ctwin_srd &&
+      !ctran::utils::isPowerOfTwo(statex->nRanks())) {
+    CLOGF_SUBSYS(
+        INFO,
+        COLL,
+        "AllGather {} unsupported: forced streamed-RD requires power-of-2 nRanks, got {}.",
+        allGatherAlgoName(algo),
+        statex->nRanks());
+    return false;
+  }
+  if (algo == NCCL_ALLGATHER_ALGO::ctwin_rdpipeline &&
+      !ctran::utils::isPowerOfTwo(statex->nNodes())) {
+    CLOGF_SUBSYS(
+        INFO,
+        COLL,
+        "AllGather {} unsupported: forced rdpipeline requires power-of-2 nNodes, got {}.",
+        allGatherAlgoName(algo),
+        statex->nNodes());
+    return false;
+  }
+  if (winOut != nullptr) {
+    *winOut = win;
+  }
+  return true;
+}
+
+commResult_t ctranAllGatherCtwin(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t sendcount,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream,
+    enum NCCL_ALLGATHER_ALGO algo) {
+  // The persistent request is WINDOW-owned (cached in persistentReqs_, freed at
+  // window free()).
+  // LIFETIME CONTRACT: the window (and its cached request / pooled pipeSync)
+  // MUST outlive any CUDA graph that captured a ctwin allgather over it.
+  const auto nRanks = comm->statex_->nRanks();
+  const size_t typeSize = commTypeSize(datatype);
+  const size_t recvBytes = sendcount * nRanks * typeSize;
+
+  ctran::CtranWin* win = nullptr;
+  if (!checkCtranAllGatherCtwinSupport(comm, recvbuff, recvBytes, algo, &win)) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "AllGather {}: unsupported for recvbuff {} (len {} bytes) -- needs a "
+        "symmetric AllGatherP window and a compatible topology.",
+        allGatherAlgoName(algo),
+        recvbuff,
+        recvBytes);
+  }
+
+  // Route by algo. Plain `ctwin` auto-selects (mirroring ctgraph): at
+  // nLocalRanks==1 the dedicated ring/streamed-RD (better optimized than AGP's
+  // degenerate nLocalRanks==1 ring; the recvbuf's window registration keeps
+  // them capture-safe); at nLocalRanks>1 the persistent AGP path (reuses the
+  // window's NVL/IPC state). ctwin_* force a specific algo. Caveat: the
+  // dedicated path does a per-replay ctrl/rkey exchange, so the ctgraph
+  // capture/replay ordering constraint applies.
+  const auto* statex = comm->statex_.get();
+  const size_t sendBytes = sendcount * typeSize;
+  const bool largeMessage = sendBytes >= NCCL_CTGRAPH_ALLGATHER_RING_THRESHOLD;
+  const bool autoNLocal1 =
+      algo == NCCL_ALLGATHER_ALGO::ctwin && statex->nLocalRanks() == 1;
+
+  if (algo == NCCL_ALLGATHER_ALGO::ctwin_srd ||
+      (autoNLocal1 && !largeMessage &&
+       ctran::utils::isPowerOfTwo(statex->nRanks()))) {
+    return ctranAllGatherStreamedRd(
+        sendbuff, recvbuff, sendcount, datatype, comm, stream);
+  }
+  if (algo == NCCL_ALLGATHER_ALGO::ctwin_ring || autoNLocal1) {
+    // ctwin_ring forces the dedicated ring at any topology; auto @
+    // nLocalRanks==1 falls here for large or non-power-of-2 (ring is the
+    // general fallback).
+    return ctranAllGatherRing(
+        sendbuff, recvbuff, sendcount, datatype, comm, stream);
+  }
+
+  // Persistent AGP path: ctwin auto at nLocalRanks>1, or forced ctwin_pipeline
+  // / ctwin_rdpipeline.
+  enum NCCL_ALLGATHER_P_ALGO agpVariant;
+  switch (algo) {
+    case NCCL_ALLGATHER_ALGO::ctwin_pipeline:
+      agpVariant = NCCL_ALLGATHER_P_ALGO::ctpipeline;
+      break;
+    case NCCL_ALLGATHER_ALGO::ctwin_rdpipeline:
+      agpVariant = NCCL_ALLGATHER_P_ALGO::ctsrdpipeline;
+      break;
+    default: // ctwin auto, nLocalRanks>1
+      agpVariant = chooseAgpAlgo(sendBytes, statex);
+      break;
+  }
+
+  const size_t offset = reinterpret_cast<uintptr_t>(recvbuff) -
+      reinterpret_cast<uintptr_t>(win->winDataPtr);
+
+  // Log the resolved window id so a rank-divergent window pick (all ranks must
+  // resolve a buffer to the same window) is debuggable.
+  CLOGF_SUBSYS(
+      INFO,
+      COLL,
+      "AllGather ctwin: rank {} resolved recvbuff {} ({} bytes, offset {}) to window id {}",
+      comm->statex_->rank(),
+      recvbuff,
+      recvBytes,
+      offset,
+      win->id());
+
+  // Reuse (or lazily build) the persistent request cached on the window, keyed
+  // by <offset, len, stream> so a request is reused only for sequential
+  // collectives with the same stream.
+  commResult_t createRes = commSuccess;
+  auto* request = win->getOrCreatePersistentRequest(
+      offset, recvBytes, stream, [&]() -> CtranPersistentRequest* {
+        CtranPersistentRequest* req = nullptr;
+        createRes = createPersistentRequestFromWindow(
+            comm,
+            stream,
+            win,
+            recvbuff,
+            sendcount,
+            datatype,
+            offset,
+            agpVariant,
+            &req);
+        return createRes == commSuccess ? req : nullptr;
+      });
+  FB_COMMCHECK(createRes);
+  if (request == nullptr) {
+    FB_ERRORRETURN(
+        commInternalError,
+        "AllGather ctwin: failed to obtain a persistent request for recvbuff {}.",
+        recvbuff);
+  }
+
+  return ctran::allGatherPExec(sendbuff, sendcount, datatype, request);
+}

--- a/comms/ctran/algos/AllGather/AllGatherImpl.h
+++ b/comms/ctran/algos/AllGather/AllGatherImpl.h
@@ -6,6 +6,10 @@
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
+namespace ctran {
+struct CtranWin;
+} // namespace ctran
+
 commResult_t ctranAllGatherPDirect(CtranPersistentRequest* req);
 
 commResult_t ctranAllGatherDirect(
@@ -39,6 +43,35 @@ commResult_t ctranAllGatherBrucksFF(
     commDataType_t datatype,
     CtranComm* comm,
     cudaStream_t stream);
+
+// Window-based persistent allgather (ctwin): converts an allgather whose
+// recvbuff lives inside a registered symmetric CtranWin into a persistent
+// AllGatherP request that reuses the window's already-exchanged NVL/IPC state,
+// caching the request on the window for reuse across calls. Supports CUDA graph
+// capture inline: the window-owned request is built once and reused across
+// replays (the window must outlive any graph that captured over it).
+commResult_t ctranAllGatherCtwin(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t sendcount,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream,
+    enum NCCL_ALLGATHER_ALGO algo);
+
+// True if a ctwin-family allgather for `algo` over [recvbuff, recvBytes) is
+// supported: recvbuff sits in a registered symmetric window that supports
+// AllGatherP, and the topology satisfies the forced variant's constraints
+// (ctwin_ring/ctwin_srd need nLocalRanks==1; ctwin_srd needs power-of-2 nRanks;
+// ctwin_rdpipeline needs power-of-2 nNodes). On success sets *winOut (if
+// non-null) to the resolving window. A null recvbuff returns false (ctwin is
+// dormant until a caller opts in).
+bool checkCtranAllGatherCtwinSupport(
+    CtranComm* comm,
+    const void* recvbuff,
+    size_t recvBytes,
+    enum NCCL_ALLGATHER_ALGO algo,
+    ctran::CtranWin** winOut = nullptr);
 
 static inline const std::string allGatherAlgoName(
     enum NCCL_ALLGATHER_ALGO algo) {

--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -327,7 +327,9 @@ commResult_t allGatherPExec(
         algo->pArgs.datatype);
   }
 
-  switch (NCCL_ALLGATHER_P_ALGO) {
+  const enum NCCL_ALLGATHER_P_ALGO variant =
+      algo->pArgs.algo.value_or(NCCL_ALLGATHER_P_ALGO);
+  switch (variant) {
     case NCCL_ALLGATHER_P_ALGO::ctdirect:
       return algo->execDirect(sendbuff, count, datatype);
     case NCCL_ALLGATHER_P_ALGO::ctpipeline:

--- a/comms/ctran/algos/AllGatherP/Types.h
+++ b/comms/ctran/algos/AllGatherP/Types.h
@@ -3,10 +3,12 @@
 #pragma once
 #include <atomic>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "comms/ctran/algos/common/GpeKernelSync.h"
 #include "comms/utils/commSpecs.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 
 using ctran::algos::GpeKernelSync;
 
@@ -45,6 +47,12 @@ struct PersistArgs {
   // graph defer the rkey exchange to first exec -- so later execs only re-sync.
   // GPE-thread-only, so not atomic.
   bool ibKeysExchanged{false};
+
+  // Per-request AGP variant override. nullopt means "use the
+  // NCCL_ALLGATHER_P_ALGO cvar" (preserves behavior for all existing callers);
+  // ctwin sets it per-comm by topology since a single cvar cannot express
+  // multiple comms with different topologies.
+  std::optional<enum NCCL_ALLGATHER_P_ALGO> algo;
 };
 
 struct Resource {

--- a/comms/ctran/tests/CtranDistAllgatherCtwinTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherCtwinTests.cc
@@ -1,0 +1,647 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <folly/init/Init.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <vector>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/regcache/IpcRegCache.h"
+#include "comms/ctran/regcache/RegCache.h"
+#include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/tests/CtranTestUtils.h"
+#include "comms/ctran/tests/VerifyAlgoStatsUtil.h"
+#include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/window/CtranWin.h"
+#include "comms/testinfra/TestsCuUtils.h"
+
+using namespace ctran;
+
+// Window-based persistent allgather (ctwin). Registers a symmetric ipc_only
+// window over a cumem recvbuf, runs allgather with algo=ctwin (in-place, so the
+// window IS the recvbuf), and verifies the gathered result against a reference.
+// Also verifies that repeated calls over the same recvbuf sub-range reuse one
+// cached persistent request, that a distinct sub-range gets its own request,
+// and that ctranWinFree tears the cached requests down without leaking imports.
+class CtranAllgatherCtwinTest : public ctran::CtranDistTestFixture {
+ public:
+  CtranAllgatherCtwinTest() = default;
+
+  commDataType_t dt = commInt32;
+  cudaStream_t stream = 0;
+  std::unique_ptr<CtranComm> ctranComm;
+  std::vector<TestMemSegment> segments;
+  ctran::test::VerifyAlgoStatsHelper algoStats_;
+
+  void SetUp() override {
+    setenv("NCCL_CTRAN_ENABLE", "1", 0);
+    algoStats_.enable();
+    ctran::CtranDistTestFixture::SetUp();
+    CUDACHECK_TEST(cudaStreamCreate(&stream));
+    ctranComm = makeCtranComm();
+  }
+
+  void TearDown() override {
+    // Every ctwin test frees its window(s) before returning; verify no NVL IPC
+    // imports leaked.
+    const auto ipcRegCache = ctran::IpcRegCache::getInstance();
+    // EXPECT (not ASSERT) so stream/base teardown below always runs.
+    EXPECT_NE(ipcRegCache, nullptr);
+    if (ipcRegCache != nullptr) {
+      EXPECT_EQ(ipcRegCache->maxRemRegRefCount(), 0)
+          << "IpcRegCache still holds live NVL IPC imports after test teardown";
+    }
+    CUDACHECK_TEST(cudaStreamDestroy(stream));
+    ctran::CtranDistTestFixture::TearDown();
+  }
+
+  // Register a symmetric window over a freshly cumem-allocated buffer.
+  // Symmetric because every rank allocates the same size at the same offset.
+  // When ipcOnly is true, inter-node IB rkeys are deferred to the first ctwin
+  // exec; when false, the full window exchange (including IB rkeys) happens at
+  // window creation.
+  void*
+  createSymmetricWindow(size_t bytes, CtranWin** winOut, bool ipcOnly = true) {
+    void* buf = commMemAlloc(bytes, MemAllocType::kMemCuMemAlloc, segments);
+    EXPECT_NE(buf, nullptr);
+    // Mimic the CCA allocator hook so the window's acquireScopedRegister finds
+    // the buffer's segment cached.
+    COMMCHECK_TEST(ctran::RegCache::getInstance()->globalRegister(buf, bytes));
+    meta::comms::Hints hints;
+    EXPECT_EQ(hints.set("win_register_symmetric", "1"), commSuccess);
+    if (ipcOnly) {
+      EXPECT_EQ(hints.set("win_register_ipc_only", "1"), commSuccess);
+    }
+    COMMCHECK_TEST(
+        ctranWinRegister(buf, bytes, ctranComm.get(), winOut, hints));
+    return buf;
+  }
+
+  void freeSymmetricWindow(CtranWin* win, void* buf, size_t bytes) {
+    COMMCHECK_TEST(ctranWinFree(win));
+    COMMCHECK_TEST(
+        ctran::RegCache::getInstance()->globalDeregister(buf, bytes));
+    commMemFree(buf, bytes, MemAllocType::kMemCuMemAlloc);
+    segments.erase(
+        std::remove_if(
+            segments.begin(),
+            segments.end(),
+            [buf](const TestMemSegment& seg) { return seg.ptr == buf; }),
+        segments.end());
+  }
+
+  // Run one in-place allgather over the window sub-range at byteOffset on
+  // execStream using the given ctwin-family algo (default forces the persistent
+  // pipeline) and verify every peer chunk equals that peer's rank+iter-specific
+  // pattern.
+  void runGatherOnStream(
+      CtranWin* win,
+      void* winBase,
+      size_t byteOffset,
+      size_t sendCount,
+      int iter,
+      cudaStream_t execStream,
+      enum NCCL_ALLGATHER_ALGO algo = NCCL_ALLGATHER_ALGO::ctwin_pipeline) {
+    const size_t typeSize = commTypeSize(dt);
+    const size_t chunkBytes = sendCount * typeSize;
+    void* recvbuf = static_cast<char*>(winBase) + byteOffset;
+    // In-place: this rank's send data lives in its own chunk of the recvbuf.
+    void* sendbuf = static_cast<char*>(recvbuf) + globalRank * chunkBytes;
+
+    const int myVal = globalRank + iter * 100;
+    const std::vector<int> myChunk(sendCount, myVal);
+    CUDACHECK_TEST(cudaMemset(recvbuf, 0xEE, sendCount * numRanks * typeSize));
+    CUDACHECK_TEST(
+        cudaMemcpy(sendbuf, myChunk.data(), chunkBytes, cudaMemcpyDefault));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    oobBarrier();
+
+    ASSERT_EQ(
+        ctranAllGather(
+            sendbuf, recvbuf, sendCount, dt, ctranComm.get(), execStream, algo),
+        commSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(execStream), cudaSuccess);
+
+    for (int peer = 0; peer < numRanks; ++peer) {
+      std::vector<int> observed(sendCount, -1);
+      CUDACHECK_TEST(cudaMemcpy(
+          observed.data(),
+          static_cast<char*>(recvbuf) + peer * chunkBytes,
+          chunkBytes,
+          cudaMemcpyDefault));
+      const std::vector<int> expected(sendCount, peer + iter * 100);
+      EXPECT_EQ(observed, expected)
+          << "at rank " << globalRank << " iter " << iter << " byteOffset "
+          << byteOffset << " chunk from peer " << peer;
+    }
+    oobBarrier();
+  }
+
+  // Convenience overload that runs on the fixture's default stream.
+  void runGather(
+      CtranWin* win,
+      void* winBase,
+      size_t byteOffset,
+      size_t sendCount,
+      int iter,
+      enum NCCL_ALLGATHER_ALGO algo = NCCL_ALLGATHER_ALGO::ctwin_pipeline) {
+    runGatherOnStream(win, winBase, byteOffset, sendCount, iter, stream, algo);
+  }
+};
+
+TEST_F(CtranAllgatherCtwinTest, FullAndSubsetReuseAndFree) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skipping ctwin test";
+  }
+  if (ctranComm->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+
+  const size_t typeSize = commTypeSize(dt);
+  const size_t fullSendCount = 8192;
+  const size_t subSendCount = 2048;
+  const size_t fullTotalBytes = fullSendCount * numRanks * typeSize;
+  const size_t subTotalBytes = subSendCount * numRanks * typeSize;
+  // Window large enough for the full gather (at offset 0) plus a distinct
+  // subset gather placed after it.
+  const size_t windowBytes = fullTotalBytes + subTotalBytes;
+
+  CtranWin* win = nullptr;
+  void* winBase = createSymmetricWindow(windowBytes, &win);
+  ASSERT_NE(win, nullptr);
+  EXPECT_TRUE(win->isSymmetric());
+
+  // ctwin reports supported for a recvbuf that lives inside this window.
+  EXPECT_TRUE(ctranAllGatherSupport(
+      ctranComm.get(),
+      NCCL_ALLGATHER_ALGO::ctwin,
+      stream,
+      winBase,
+      fullTotalBytes));
+
+  // Full-window gather run twice: the second call must reuse the single cached
+  // persistent request rather than building a new one.
+  runGather(win, winBase, /*byteOffset=*/0, fullSendCount, /*iter=*/0);
+  runGather(win, winBase, /*byteOffset=*/0, fullSendCount, /*iter=*/1);
+  EXPECT_EQ(win->numPersistentRequests(), 1u);
+
+  // A distinct sub-range gets its own cached request; repeating it reuses it.
+  runGather(win, winBase, fullTotalBytes, subSendCount, /*iter=*/2);
+  EXPECT_EQ(win->numPersistentRequests(), 2u);
+  runGather(win, winBase, fullTotalBytes, subSendCount, /*iter=*/3);
+  EXPECT_EQ(win->numPersistentRequests(), 2u);
+
+  oobBarrier();
+
+  // ctwin executes via the persistent AllGatherP machinery, so the recorded
+  // algo name is "CtranAllGatherP<variant>" (not "CtranAllGatherWin"). The
+  // "CtranAllGatherP" prefix matches whichever AGP variant runs and confirms
+  // the ctwin path (not a fallback/other algo) executed.
+  algoStats_.verify(ctranComm.get(), "AllGather", "CtranAllGatherP");
+
+  // Free must tear down the cached persistent requests and release all imports.
+  freeSymmetricWindow(win, winBase, windowBytes);
+}
+
+// A symmetric window registered WITHOUT ipc_only does the full window exchange
+// at creation -- including the inter-node IB rkey exchange -- so ctwin reuses
+// those rkeys (ibKeysExchanged=true) and skips the first-exec IB exchange. This
+// path is exercised meaningfully on the nolocal/vnode configs (all-inter-node),
+// where the IB rkeys carried in the window are actually used. Verifies a
+// correct gather (with reuse) and that the ctwin (AllGatherP) path ran.
+TEST_F(CtranAllgatherCtwinTest, FullExchangeSymmetricWindow) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skipping ctwin test";
+  }
+  if (ctranComm->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+
+  const size_t typeSize = commTypeSize(dt);
+  const size_t sendCount = 8192;
+  const size_t windowBytes = sendCount * numRanks * typeSize;
+
+  CtranWin* win = nullptr;
+  // Full-exchange symmetric window (NOT ipc_only): IB rkeys are exchanged at
+  // window creation.
+  void* winBase = createSymmetricWindow(windowBytes, &win, /*ipcOnly=*/false);
+  ASSERT_NE(win, nullptr);
+  EXPECT_TRUE(win->isSymmetric());
+  EXPECT_FALSE(win->isIpcOnly());
+
+  EXPECT_TRUE(ctranAllGatherSupport(
+      ctranComm.get(),
+      NCCL_ALLGATHER_ALGO::ctwin,
+      stream,
+      winBase,
+      windowBytes));
+
+  // Run twice: the second call reuses the single cached persistent request.
+  runGather(win, winBase, /*byteOffset=*/0, sendCount, /*iter=*/0);
+  runGather(win, winBase, /*byteOffset=*/0, sendCount, /*iter=*/1);
+  EXPECT_EQ(win->numPersistentRequests(), 1u);
+
+  // Confirm the ctwin (AllGatherP) path actually ran.
+  algoStats_.verify(ctranComm.get(), "AllGather", "CtranAllGatherP");
+
+  oobBarrier();
+  freeSymmetricWindow(win, winBase, windowBytes);
+}
+
+// Captures a ctwin allgather over the symmetric window into a CUDA graph and
+// replays it several times, verifying the gathered result each replay. Because
+// ctwin's persistent request is window-owned (not graph-owned), the request is
+// built once during capture and reused across replays and the graph is
+// destroyed before the window is freed (the required lifetime order).
+TEST_F(CtranAllgatherCtwinTest, GraphCaptureReplayReuseAndFree) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skipping ctwin graph test";
+  }
+  if (ctranComm->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+
+  const size_t typeSize = commTypeSize(dt);
+  const size_t sendCount = 8192;
+  const size_t chunkBytes = sendCount * typeSize;
+  const size_t totalBytes = sendCount * numRanks * typeSize;
+
+  CtranWin* win = nullptr;
+  void* winBase = createSymmetricWindow(totalBytes, &win);
+  ASSERT_NE(win, nullptr);
+  EXPECT_TRUE(win->isSymmetric());
+
+  // In-place, full-window gather: this rank's send data lives in its own chunk.
+  void* recvbuf = winBase;
+  void* sendbuf = static_cast<char*>(recvbuf) + globalRank * chunkBytes;
+
+  cudaStream_t captureStream;
+  CUDACHECK_TEST(
+      cudaStreamCreateWithFlags(&captureStream, cudaStreamNonBlocking));
+
+  // Seed this rank's chunk so the capture-time exec sees valid data.
+  {
+    const std::vector<int> seed(sendCount, globalRank);
+    CUDACHECK_TEST(cudaMemset(recvbuf, 0xEE, totalBytes));
+    CUDACHECK_TEST(
+        cudaMemcpy(sendbuf, seed.data(), chunkBytes, cudaMemcpyDefault));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+  }
+  oobBarrier();
+
+  // Capture the ctwin allgather. request->stream == captureStream, so exec
+  // submits directly onto the captured stream (no fork/join needed).
+  cudaGraph_t graph = nullptr;
+  cudaGraphExec_t graphExec = nullptr;
+  ASSERT_EQ(
+      cudaStreamBeginCapture(captureStream, cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  ASSERT_EQ(
+      ctranAllGather(
+          sendbuf,
+          recvbuf,
+          sendCount,
+          dt,
+          ctranComm.get(),
+          captureStream,
+          NCCL_ALLGATHER_ALGO::ctwin_pipeline),
+      commSuccess);
+  ASSERT_EQ(cudaStreamEndCapture(captureStream, &graph), cudaSuccess);
+  ASSERT_NE(graph, nullptr);
+  ASSERT_EQ(cudaGraphInstantiate(&graphExec, graph, 0), cudaSuccess);
+
+  // The persistent request built during capture is cached on the window.
+  EXPECT_EQ(win->numPersistentRequests(), 1u);
+
+  constexpr int kReplays = 3;
+  for (int r = 0; r < kReplays; ++r) {
+    const int myVal = globalRank + r * 100;
+    const std::vector<int> myChunk(sendCount, myVal);
+    CUDACHECK_TEST(cudaMemset(recvbuf, 0xEE, totalBytes));
+    CUDACHECK_TEST(
+        cudaMemcpy(sendbuf, myChunk.data(), chunkBytes, cudaMemcpyDefault));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    oobBarrier();
+
+    ASSERT_EQ(cudaGraphLaunch(graphExec, captureStream), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(captureStream), cudaSuccess);
+
+    for (int peer = 0; peer < numRanks; ++peer) {
+      std::vector<int> observed(sendCount, -1);
+      CUDACHECK_TEST(cudaMemcpy(
+          observed.data(),
+          static_cast<char*>(recvbuf) + peer * chunkBytes,
+          chunkBytes,
+          cudaMemcpyDefault));
+      const std::vector<int> expected(sendCount, peer + r * 100);
+      EXPECT_EQ(observed, expected) << "at rank " << globalRank << " replay "
+                                    << r << " chunk from peer " << peer;
+    }
+    // No new request is created across replays.
+    EXPECT_EQ(win->numPersistentRequests(), 1u);
+    oobBarrier();
+  }
+
+  // Correct lifetime order: destroy the graph BEFORE freeing the window (the
+  // window owns the request that the graph captured).
+  ASSERT_EQ(cudaGraphExecDestroy(graphExec), cudaSuccess);
+  ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+  CUDACHECK_TEST(cudaStreamDestroy(captureStream));
+
+  oobBarrier();
+  freeSymmetricWindow(win, winBase, totalBytes);
+}
+
+// Warms up a ctwin allgather eagerly on one stream, then captures a CUDA graph
+// on a DIFFERENT stream that runs two ctwin allgathers over the same window:
+// region A reuses the eager warmup's range but on the capture stream, and
+// region B is a distinct range. Because a window-owned persistent request binds
+// its stream at creation, the cache is keyed by <offset, len, stream>: region A
+// on the capture stream must get its own request (distinct from the eager one)
+// so its work is captured on the capture stream instead of escaping to the
+// eager stream. Each in-graph allgather is followed by a captured device
+// copy-out into its own staging buffer, so every gather's result is verified
+// independently on every replay.
+TEST_F(CtranAllgatherCtwinTest, EagerThenGraphMultiGatherSharedWindow) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skipping ctwin graph test";
+  }
+  if (ctranComm->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+
+  const size_t typeSize = commTypeSize(dt);
+  const size_t sendCount = 8192;
+  const size_t chunkBytes = sendCount * typeSize;
+  const size_t regionBytes = sendCount * numRanks * typeSize;
+  // Two distinct full-gather regions (A then B) inside a single window.
+  const size_t offsetA = 0;
+  const size_t offsetB = regionBytes;
+  const size_t windowBytes = 2 * regionBytes;
+
+  CtranWin* win = nullptr;
+  void* winBase = createSymmetricWindow(windowBytes, &win);
+  ASSERT_NE(win, nullptr);
+  EXPECT_TRUE(win->isSymmetric());
+
+  void* regionA = static_cast<char*>(winBase) + offsetA;
+  void* regionB = static_cast<char*>(winBase) + offsetB;
+  void* sendA = static_cast<char*>(regionA) + globalRank * chunkBytes;
+  void* sendB = static_cast<char*>(regionB) + globalRank * chunkBytes;
+
+  // Eager execution stream, distinct from the graph capture stream below.
+  cudaStream_t eagerStream;
+  CUDACHECK_TEST(
+      cudaStreamCreateWithFlags(&eagerStream, cudaStreamNonBlocking));
+
+  // Eager warmup over region A on eagerStream. Running it twice reuses the one
+  // request cached for <offsetA, regionBytes, eagerStream> (same range + same
+  // stream).
+  runGatherOnStream(win, winBase, offsetA, sendCount, /*iter=*/0, eagerStream);
+  runGatherOnStream(win, winBase, offsetA, sendCount, /*iter=*/1, eagerStream);
+  EXPECT_EQ(win->numPersistentRequests(), 1u);
+
+  // Per-gather device staging buffers so each in-graph gather's result is
+  // captured before a later op could overwrite the window.
+  void* stagingA = nullptr;
+  void* stagingB = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&stagingA, regionBytes));
+  CUDACHECK_TEST(cudaMalloc(&stagingB, regionBytes));
+
+  // Seed both regions' send chunks so the capture-time execs see valid data
+  // (capture-time results are discarded; only replays are verified).
+  {
+    const std::vector<int> seed(sendCount, globalRank);
+    CUDACHECK_TEST(cudaMemset(regionA, 0xEE, regionBytes));
+    CUDACHECK_TEST(cudaMemset(regionB, 0xEE, regionBytes));
+    CUDACHECK_TEST(
+        cudaMemcpy(sendA, seed.data(), chunkBytes, cudaMemcpyDefault));
+    CUDACHECK_TEST(
+        cudaMemcpy(sendB, seed.data(), chunkBytes, cudaMemcpyDefault));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+  }
+  oobBarrier();
+
+  // Capture two ctwin allgathers over the shared window on a DEDICATED capture
+  // stream. Region A reuses the eager range but on captureStream, so a distinct
+  // request bound to captureStream is built during capture. Region B is a
+  // distinct range thus separate request.
+  cudaStream_t captureStream;
+  CUDACHECK_TEST(
+      cudaStreamCreateWithFlags(&captureStream, cudaStreamNonBlocking));
+
+  cudaGraph_t graph = nullptr;
+  cudaGraphExec_t graphExec = nullptr;
+  ASSERT_EQ(
+      cudaStreamBeginCapture(captureStream, cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  ASSERT_EQ(
+      ctranAllGather(
+          sendA,
+          regionA,
+          sendCount,
+          dt,
+          ctranComm.get(),
+          captureStream,
+          NCCL_ALLGATHER_ALGO::ctwin_pipeline),
+      commSuccess);
+  CUDACHECK_TEST(cudaMemcpyAsync(
+      stagingA, regionA, regionBytes, cudaMemcpyDeviceToDevice, captureStream));
+  ASSERT_EQ(
+      ctranAllGather(
+          sendB,
+          regionB,
+          sendCount,
+          dt,
+          ctranComm.get(),
+          captureStream,
+          NCCL_ALLGATHER_ALGO::ctwin_pipeline),
+      commSuccess);
+  CUDACHECK_TEST(cudaMemcpyAsync(
+      stagingB, regionB, regionBytes, cudaMemcpyDeviceToDevice, captureStream));
+  ASSERT_EQ(cudaStreamEndCapture(captureStream, &graph), cudaSuccess);
+  ASSERT_NE(graph, nullptr);
+  ASSERT_EQ(cudaGraphInstantiate(&graphExec, graph, 0), cudaSuccess);
+
+  // eagerStream's region-A request, plus captureStream's region-A and region-B
+  // requests: three distinct <offset, len, stream> entries.
+  EXPECT_EQ(win->numPersistentRequests(), 3u);
+
+  constexpr int kReplays = 3;
+  // Distinct additive bias for region B so a region mix-up is caught.
+  constexpr int kRegionBBias = 50;
+  for (int r = 0; r < kReplays; ++r) {
+    const std::vector<int> chunkA(sendCount, globalRank + r * 100);
+    const std::vector<int> chunkB(
+        sendCount, globalRank + r * 100 + kRegionBBias);
+    CUDACHECK_TEST(cudaMemset(regionA, 0xEE, regionBytes));
+    CUDACHECK_TEST(cudaMemset(regionB, 0xEE, regionBytes));
+    CUDACHECK_TEST(
+        cudaMemcpy(sendA, chunkA.data(), chunkBytes, cudaMemcpyDefault));
+    CUDACHECK_TEST(
+        cudaMemcpy(sendB, chunkB.data(), chunkBytes, cudaMemcpyDefault));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    oobBarrier();
+
+    ASSERT_EQ(cudaGraphLaunch(graphExec, captureStream), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(captureStream), cudaSuccess);
+
+    for (int peer = 0; peer < numRanks; ++peer) {
+      std::vector<int> observedA(sendCount, -1);
+      std::vector<int> observedB(sendCount, -1);
+      CUDACHECK_TEST(cudaMemcpy(
+          observedA.data(),
+          static_cast<char*>(stagingA) + peer * chunkBytes,
+          chunkBytes,
+          cudaMemcpyDefault));
+      CUDACHECK_TEST(cudaMemcpy(
+          observedB.data(),
+          static_cast<char*>(stagingB) + peer * chunkBytes,
+          chunkBytes,
+          cudaMemcpyDefault));
+      const std::vector<int> expectedA(sendCount, peer + r * 100);
+      const std::vector<int> expectedB(
+          sendCount, peer + r * 100 + kRegionBBias);
+      EXPECT_EQ(observedA, expectedA) << "region A at rank " << globalRank
+                                      << " replay " << r << " peer " << peer;
+      EXPECT_EQ(observedB, expectedB) << "region B at rank " << globalRank
+                                      << " replay " << r << " peer " << peer;
+    }
+    // No new requests are created across replays.
+    EXPECT_EQ(win->numPersistentRequests(), 3u);
+    oobBarrier();
+  }
+
+  // Correct lifetime order: destroy the graph BEFORE freeing the window (the
+  // window owns the requests the graph captured).
+  ASSERT_EQ(cudaGraphExecDestroy(graphExec), cudaSuccess);
+  ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+  CUDACHECK_TEST(cudaFree(stagingA));
+  CUDACHECK_TEST(cudaFree(stagingB));
+  CUDACHECK_TEST(cudaStreamDestroy(captureStream));
+  CUDACHECK_TEST(cudaStreamDestroy(eagerStream));
+
+  oobBarrier();
+  freeSymmetricWindow(win, winBase, windowBytes);
+}
+
+// Plain `ctwin` auto-selects by topology: at nLocalRanks>1 it uses the
+// persistent AGP path (which caches a window request); at nLocalRanks==1 it
+// routes to the dedicated ring/streamed-RD (no persistent request cached).
+// Result correctness is checked by runGatherOnStream in both cases.
+TEST_F(CtranAllgatherCtwinTest, AutoSelectByTopology) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skipping ctwin test";
+  }
+  if (ctranComm->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+
+  const size_t typeSize = commTypeSize(dt);
+  const size_t sendCount = 8192;
+  const size_t windowBytes = sendCount * numRanks * typeSize;
+
+  CtranWin* win = nullptr;
+  void* winBase = createSymmetricWindow(windowBytes, &win);
+  ASSERT_NE(win, nullptr);
+  EXPECT_TRUE(win->isSymmetric());
+
+  runGatherOnStream(
+      win,
+      winBase,
+      /*byteOffset=*/0,
+      sendCount,
+      /*iter=*/0,
+      stream,
+      NCCL_ALLGATHER_ALGO::ctwin);
+
+  if (ctranComm->statex_->nLocalRanks() > 1) {
+    // Persistent AGP path caches exactly one request for this range/stream.
+    EXPECT_EQ(win->numPersistentRequests(), 1u);
+    algoStats_.verify(ctranComm.get(), "AllGather", "CtranAllGatherP");
+  } else {
+    // Dedicated path caches no persistent request; small message + power-of-2
+    // nRanks selects streamed recursive-doubling (ctsrd).
+    EXPECT_EQ(win->numPersistentRequests(), 0u);
+    algoStats_.verify(ctranComm.get(), "AllGather", "CtranAllGatherStreamedRd");
+  }
+
+  oobBarrier();
+  freeSymmetricWindow(win, winBase, windowBytes);
+}
+
+// Forced ctwin_* variants: the two persistent ones (ctwin_pipeline,
+// ctwin_rdpipeline) each cache a window request; the two dedicated ones
+// (ctwin_ring, ctwin_srd, valid only at nLocalRanks==1) cache none. Each call
+// verifies its gather result via runGatherOnStream.
+TEST_F(CtranAllgatherCtwinTest, ForceVariants) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skipping ctwin test";
+  }
+  if (ctranComm->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+
+  const size_t typeSize = commTypeSize(dt);
+  const size_t sendCount = 8192;
+  const size_t regionBytes = sendCount * numRanks * typeSize;
+  const size_t windowBytes = 4 * regionBytes;
+
+  CtranWin* win = nullptr;
+  void* winBase = createSymmetricWindow(windowBytes, &win);
+  ASSERT_NE(win, nullptr);
+  EXPECT_TRUE(win->isSymmetric());
+
+  // Persistent forced variants: each caches a distinct window request.
+  runGatherOnStream(
+      win,
+      winBase,
+      /*byteOffset=*/0,
+      sendCount,
+      /*iter=*/0,
+      stream,
+      NCCL_ALLGATHER_ALGO::ctwin_pipeline);
+  runGatherOnStream(
+      win,
+      winBase,
+      /*byteOffset=*/regionBytes,
+      sendCount,
+      /*iter=*/1,
+      stream,
+      NCCL_ALLGATHER_ALGO::ctwin_rdpipeline);
+  EXPECT_EQ(win->numPersistentRequests(), 2u);
+
+  // Dedicated forced variants are valid only at nLocalRanks==1; they cache no
+  // persistent request.
+  if (ctranComm->statex_->nLocalRanks() == 1) {
+    runGatherOnStream(
+        win,
+        winBase,
+        /*byteOffset=*/2 * regionBytes,
+        sendCount,
+        /*iter=*/2,
+        stream,
+        NCCL_ALLGATHER_ALGO::ctwin_ring);
+    runGatherOnStream(
+        win,
+        winBase,
+        /*byteOffset=*/3 * regionBytes,
+        sendCount,
+        /*iter=*/3,
+        stream,
+        NCCL_ALLGATHER_ALGO::ctwin_srd);
+    EXPECT_EQ(win->numPersistentRequests(), 2u);
+  }
+
+  oobBarrier();
+  freeSymmetricWindow(win, winBase, windowBytes);
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new ctran::CtranDistEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -2,10 +2,16 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdint>
+#include <functional>
+#include <map>
+#include <tuple>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
+#include <cuda_runtime.h>
 #include <folly/Synchronized.h>
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/hints/Hints.h"
@@ -27,6 +33,8 @@ class HostWindow;
 struct WindowConfig;
 } // namespace comms::prims
 #endif
+
+class CtranPersistentRequest;
 
 namespace ctran {
 struct CtranWin {
@@ -172,6 +180,10 @@ struct CtranWin {
     ipcOnly_ = val;
   }
 
+  inline bool isIpcOnly() const {
+    return ipcOnly_;
+  }
+
   inline void setEnableSignal(bool val) {
     enableSignal_ = val;
   }
@@ -199,6 +211,26 @@ struct CtranWin {
   bool allGatherPSupported() const {
     return allGatherPSupported(comm);
   }
+
+  // Window-based persistent-request cache, keyed by <byteOffset, byteLen,
+  // stream> of the recvbuf sub-range. Creates the request via `factory` on a
+  // miss, otherwise reuses the cached one; returns nullptr if the factory
+  // fails. The request is per-stream, so two collectives sharing the same key
+  // are always serialized.
+  //
+  // LIFETIME CONTRACT: the returned request is WINDOW-owned and freed by the
+  // window's free(). The caller must ensure every collective that uses a
+  // returned request has completed (e.g. cudaStreamSynchronize) before freeing
+  // the window -- freeing while a ctwin collective is still in flight is
+  // undefined behavior.
+  CtranPersistentRequest* getOrCreatePersistentRequest(
+      size_t offset,
+      size_t len,
+      cudaStream_t stream,
+      const std::function<CtranPersistentRequest*()>& factory);
+
+  // Number of cached ctwin persistent requests (test/introspection helper).
+  size_t numPersistentRequests() const;
 
  private:
   DevMemType bufType_{DevMemType::kCumem};
@@ -228,6 +260,12 @@ struct CtranWin {
       opCountMap_;
   // Actual size allocated for the total buffer per rank in this window
   size_t range_{0};
+  // Window-based persistent-request cache; see getOrCreatePersistentRequest.
+  // Key is <byteOffset, byteLen, stream> of the recvbuf sub-range.
+  folly::Synchronized<std::map<
+      std::tuple<size_t, size_t, cudaStream_t>,
+      CtranPersistentRequest*>>
+      persistentReqs_;
 
 #if defined(ENABLE_PRIMS)
   std::unique_ptr<comms::prims::HostWindow> hostWindow_;

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -6,6 +6,7 @@
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/regcache/RegCache.h"
 #include "comms/ctran/utils/Alloc.h"
@@ -481,9 +482,28 @@ commResult_t CtranWin::free(bool skipBarrier) {
       (void*)comm,
       statex->commHash());
 
+  // Tear down cached window persistent requests before releasing the data
+  // registration / NVL IPC imports they borrow. LIFETIME CONTRACT: the caller
+  // must ensure all ctwin collectives over this window have completed before
+  // free() -- these requests are deleted here regardless of any in-flight use.
+  {
+    auto reqs = persistentReqs_.wlock();
+    for (auto& entry : *reqs) {
+      auto* req = entry.second;
+      if (req == nullptr) {
+        continue;
+      }
+      if (req->cleanup_ != nullptr) {
+        req->cleanup_->run();
+        comm->unregisterPersistentCleanup(req->cleanup_);
+      }
+      delete req;
+    }
+    reqs->clear();
+  }
+
   // Drop this window's entry from the comm cache before tearing down buffers so
-  // a later lookup cannot resolve to a freed window. The handle is non-null
-  // only when this window was actually cached (i.e. symmetric).
+  // a later lookup cannot resolve to a freed window.
   if (winCacheHdl != nullptr) {
     comm->winCache_.erase(winCacheHdl);
     winCacheHdl = nullptr;
@@ -562,6 +582,28 @@ commResult_t CtranWin::free(bool skipBarrier) {
   }
 
   return commSuccess;
+}
+
+CtranPersistentRequest* CtranWin::getOrCreatePersistentRequest(
+    size_t offset,
+    size_t len,
+    cudaStream_t stream,
+    const std::function<CtranPersistentRequest*()>& factory) {
+  auto reqs = persistentReqs_.wlock();
+  const auto key = std::make_tuple(offset, len, stream);
+  auto it = reqs->find(key);
+  if (it != reqs->end()) {
+    return it->second;
+  }
+  auto* req = factory();
+  if (req != nullptr) {
+    (*reqs)[key] = req;
+  }
+  return req;
+}
+
+size_t CtranWin::numPersistentRequests() const {
+  return persistentReqs_.rlock()->size();
 }
 
 bool CtranWin::nvlEnabled(int rank) const {


### PR DESCRIPTION
Summary:

Implement the `ctwin` allgather at the ctran level: when the recvbuf lives inside a registered symmetric window, the allgather is converted into a persistent AllGatherP (AGP) request that REUSES the window's already-exchanged NVL/IPC state instead of running AGP's own IPC handle exchange, and the request is cached on the window for reuse. Both eager and CUDA-graph-capture execution are supported. Stays dormant until a caller passes recvbuff (wired at the ncclx layer in a follow-up commit).

Key design points:
- The persistent request **BORROWS the window's registration + symmetric peer addresses/keys** (a peer's recvbuf is its window buffer at the same byte offset) rather than owning them; its teardown only releases AGP-owned pooled resources, while the window's registration / IPC imports are freed by the window itself. An ipc_only window defers the inter-node IB rkey exchange to the first exec; a full-exchange (symmetric, non-ipc_only) window already carries IB rkeys from window creation and reuses them.
- The **AGP variant (direct / pipeline / streamed-recursive-doubling) is auto-selected by topology** at dispatch (mirroring ctgraph's `selectCtgraphAlgo`) and stored per-request, NOT driven by the `NCCL_ALLGATHER_P_ALGO` cvar -- multiple comms with different topologies can enable ctwin, so a single cvar cannot express the choice. Non-ctwin AGP callers are unaffected (they still follow the cvar).
- **Persistent requests are cached per <recvbuf offset, len> on the window and torn down at window free()** before the borrowed state is released (a comm-level cleanup token is a safety net that returns the pooled pipeSync at comm destroy if a window outlives its free()). 
- **`ctranAllGatherSupport` takes recvbuff + its byte size and reports ctwin supported** only when the FULL recv range is covered by a symmetric window that supports AllGatherP -- so an **uncovered buffer falls back to the baseline algo** rather than failing later at exec.
- Graph capture is handled inline (not via ctranAllGatherCudagraphAware) because the request is window-owned, not graph-owned; the same path runs during capture and does strictly less work than ctgraph. Lifetime contract: the window must outlive any graph that captured a ctwin allgather over it.

Reviewed By: pavanbalaji

Differential Revision: D112411736


