### PR TITLE
Fix cudaMemcpyBatchAsync const-qualifier build break (CUDA 12.8)

### DIFF
--- a/comms/ctran/algos/common/NvlUtils.h
+++ b/comms/ctran/algos/common/NvlUtils.h
@@ -68,10 +68,16 @@ inline commResult_t nvlCeMemcpyBatch(
     attr.flags = cudaMemcpyFlagPreferOverlapWithCompute;
 #if CUDART_VERSION < 13000
     size_t failIdx = 0;
+    // The CUDA 12.x attr-by-value overload takes non-const ``void**`` /
+    // ``void**`` / ``size_t*``, but ``dsts``/``srcs``/``sizes`` are const& here
+    // so their
+    // ``.data()`` is const-qualified (``void* const*`` / ``const size_t*``) and
+    // the template deduction/const-drop rejects the call. The API only reads
+    // these arrays, so the casts are safe.
     FB_CUDACHECK(cudaMemcpyBatchAsync(
-        dsts.data(),
-        srcs.data(),
-        sizes.data(),
+        const_cast<void**>(dsts.data()),
+        const_cast<void**>(srcs.data()),
+        const_cast<size_t*>(sizes.data()),
         numOps,
         attr,
         &failIdx,


### PR DESCRIPTION
Summary:
`nvlCeMemcpyBatch` fails to compile on platform010 CUDA 12.8: the attr-by-value
`cudaMemcpyBatchAsync` overload (cuda_runtime.h:939) takes `size_t* sizes`, but
`sizes` is a `const std::vector<size_t>&` so `sizes.data()` is `const size_t*`
and drops const -> "no matching function for call to 'cudaMemcpyBatchAsync'"
(the 9-arg overloads are rejected on arg count; `dsts`/`srcs` deduce fine via the
`T**`/`U**` templates). The API only reads the sizes, so const_cast the pointer.

This unblocks from-source vllm_media fbpkg builds (comms/ctran:hetero_ctran_lib).

fbpkg built with this fix: `smart.inference_platform_sp.llm_predictor_gpu_vllm_media.persistent:584c8ea3f299bf26a389731ccfb60197`.

Reviewed By: linrunwei

Differential Revision: D112622555


