### PR TITLE
Fix cudaMemcpyBatchAsync const build break on CUDA 12.8

### DIFF
--- a/comms/ctran/algos/common/NvlUtils.h
+++ b/comms/ctran/algos/common/NvlUtils.h
@@ -66,19 +66,18 @@ inline commResult_t nvlCeMemcpyBatch(
     cudaMemcpyAttributes attr = {};
     attr.srcAccessOrder = cudaMemcpySrcAccessOrderStream;
     attr.flags = cudaMemcpyFlagPreferOverlapWithCompute;
+    // cudaMemcpyBatchAsync takes non-const dst/src/size arrays but treats them
+    // as inputs, so casting away const on our const inputs is safe.
+    void** dstsPtr = const_cast<void**>(dsts.data());
+    void** srcsPtr = const_cast<void**>(srcs.data());
+    size_t* sizesPtr = const_cast<size_t*>(sizes.data());
 #if CUDART_VERSION < 13000
     size_t failIdx = 0;
     FB_CUDACHECK(cudaMemcpyBatchAsync(
-        dsts.data(),
-        srcs.data(),
-        sizes.data(),
-        numOps,
-        attr,
-        &failIdx,
-        stream));
+        dstsPtr, srcsPtr, sizesPtr, numOps, attr, &failIdx, stream));
 #else
-    FB_CUDACHECK(cudaMemcpyBatchAsync(
-        dsts.data(), srcs.data(), sizes.data(), numOps, attr, stream));
+    FB_CUDACHECK(
+        cudaMemcpyBatchAsync(dstsPtr, srcsPtr, sizesPtr, numOps, attr, stream));
 #endif
     batchCopied = true;
   }


### PR DESCRIPTION
Summary:
D111755169 added `nvlCeMemcpyBatch()` in
`comms/ctran/algos/common/NvlUtils.h`, which dispatches intra-node NVL
copy-engine copies via `cudaMemcpyBatchAsync` on CUDA >= 12.8.

`nvlCeMemcpyBatch` receives its buffers by const ref, so `dsts.data()` /
`srcs.data()` are `void* const*` and `sizes.data()` is `const size_t*`.
CUDA 12.8's `cudaMemcpyBatchAsync` takes non-const `void**` / `size_t*`,
so no overload matches and compilation fails:

  NvlUtils.h: error: no matching function for call to 'cudaMemcpyBatchAsync'
  note: 3rd argument ('const unsigned long *') would lose const qualifier
  note: deduced type 'void **' of 1st parameter does not match adjusted
        type 'void *const *' of argument

This broke the trunk build of `//comms/ctran:hetero_ctran_lib` for every
CUDA-12.8 config (h100 x86_64, b200 aarch64), failing the
`torchcomm_device_test_launcher_h100` and
`hpc_comms_ncclx_nccl_tests_mast_launcher_aarch64_latest` build-service
workflows.

`cudaMemcpyBatchAsync` only reads `dsts` / `srcs` / `sizes` as inputs, so
adapt them to the non-const pointers the C API requires via `const_cast`
at the call site (both the CUDA < 13.0 and >= 13.0 branches). No
behavioral change.

Differential Revision: D112650564


