### PR TITLE
Add CtranAvlTree::searchVal for atomic range-to-value lookup

### DIFF
--- a/comms/ctran/algos/RMA/PutSignal.cc
+++ b/comms/ctran/algos/RMA/PutSignal.cc
@@ -231,6 +231,11 @@ commResult_t ctranPutSignal(
     cudaStream_t stream,
     bool signal) {
   CtranComm* comm = win->comm;
+  if (signal && !win->isSignalEnabled()) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "ctranPutSignal: signal requested but signals are disabled for this window (win_register_enable_signal=0)");
+  }
   const auto winOpCount = win->updateOpCount(peer);
   const auto putOpCount = win->updateOpCount(peer, window::OpCountType::kPut);
   auto statex = comm->statex_.get();
@@ -467,6 +472,11 @@ commResult_t waitSignalSpinningKernel(
 
 commResult_t ctranSignal(int peer, CtranWin* win, cudaStream_t stream) {
   CtranComm* comm = win->comm;
+  if (!win->isSignalEnabled()) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "ctranSignal: signals are disabled for this window (win_register_enable_signal=0)");
+  }
   const auto winOpCount = win->updateOpCount(peer);
   const auto sigOpCount =
       win->updateOpCount(peer, window::OpCountType::kSignal);
@@ -526,6 +536,11 @@ commResult_t ctranSignal(int peer, CtranWin* win, cudaStream_t stream) {
 // Tries hardware wait first (CUDA 11.7+), falls back to spinning kernel
 commResult_t ctranWaitSignal(int peer, CtranWin* win, cudaStream_t stream) {
   CtranComm* comm = win->comm;
+  if (!win->isSignalEnabled()) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "ctranWaitSignal: signals are disabled for this window (win_register_enable_signal=0)");
+  }
   auto statex = comm->statex_.get();
 
   // Track op counts for BOTH implementations

--- a/comms/ctran/utils/CtranAvlTree.cc
+++ b/comms/ctran/utils/CtranAvlTree.cc
@@ -79,10 +79,9 @@ commResult_t CtranAvlTree::remove(void* hdl) {
   return commSuccess;
 }
 
-void* CtranAvlTree::search(const void* addr_, std::size_t len) const {
-  uintptr_t addr = reinterpret_cast<uintptr_t>(const_cast<void*>(addr_));
-  std::lock_guard<std::mutex> lock(this->mutex_);
-
+CtranAvlTree::TreeElem* CtranAvlTree::searchElemLocked(
+    uintptr_t addr,
+    std::size_t len) const {
   // First try to search in AVL tree
   CtranAvlTree::TreeElem* r = this->root_;
   while (r) {
@@ -108,6 +107,19 @@ void* CtranAvlTree::search(const void* addr_, std::size_t len) const {
     }
   }
   return r;
+}
+
+void* CtranAvlTree::search(const void* addr_, std::size_t len) const {
+  uintptr_t addr = reinterpret_cast<uintptr_t>(const_cast<void*>(addr_));
+  std::lock_guard<std::mutex> lock(this->mutex_);
+  return this->searchElemLocked(addr, len);
+}
+
+void* CtranAvlTree::searchVal(const void* addr_, std::size_t len) const {
+  uintptr_t addr = reinterpret_cast<uintptr_t>(const_cast<void*>(addr_));
+  std::lock_guard<std::mutex> lock(this->mutex_);
+  CtranAvlTree::TreeElem* r = this->searchElemLocked(addr, len);
+  return r != nullptr ? r->val : nullptr;
 }
 
 void* CtranAvlTree::lookup(void* hdl) const {

--- a/comms/ctran/utils/CtranAvlTree.h
+++ b/comms/ctran/utils/CtranAvlTree.h
@@ -36,6 +36,13 @@ class CtranAvlTree {
   // return nullptr.
   void* search(const void* addr, std::size_t len) const;
 
+  // Atomically search for the element whose range contains [addr, addr+len) and
+  // return its value (nullptr if none). Equivalent to search() followed by
+  // lookup() but performed under a single lock, so it is free of the ABA race a
+  // separate search()+lookup() would have if another thread removes and reuses
+  // the handle in between.
+  void* searchVal(const void* addr, std::size_t len) const;
+
   // Lookup the value of the provided handle.
   void* lookup(void* hdl) const;
 
@@ -67,6 +74,9 @@ class CtranAvlTree {
 
  private:
   class TreeElem;
+  // Find the element whose range contains [addr, addr+len), or nullptr if none.
+  // Caller must hold mutex_.
+  TreeElem* searchElemLocked(uintptr_t addr, std::size_t len) const;
   class TreeElem* root_{nullptr};
   std::vector<TreeElem*> list_;
   // Store all valid handles for fast handle validation.

--- a/comms/ctran/utils/tests/AvlTreeUT.cc
+++ b/comms/ctran/utils/tests/AvlTreeUT.cc
@@ -323,6 +323,34 @@ TEST_F(CtranUtilsAvlTreeTest, SearchNonOverlapRanges) {
   rangeRegistList.clear();
 }
 
+// searchVal is search()+lookup() done atomically; verify it returns the
+// containing element's value and nullptr for a miss.
+TEST_F(CtranUtilsAvlTreeTest, SearchVal) {
+  auto tree = std::make_unique<CtranAvlTree>();
+
+  void* valA = reinterpret_cast<void*>(0xA);
+  void* valB = reinterpret_cast<void*>(0xB);
+  void* hdlA = tree->insert(reinterpret_cast<void*>(0x1000), 0x100, valA);
+  void* hdlB = tree->insert(reinterpret_cast<void*>(0x2000), 0x100, valB);
+  ASSERT_NE(hdlA, nullptr);
+  ASSERT_NE(hdlB, nullptr);
+
+  // Exact and subrange lookups return the containing element's value.
+  EXPECT_EQ(tree->searchVal(reinterpret_cast<void*>(0x1000), 0x100), valA);
+  EXPECT_EQ(tree->searchVal(reinterpret_cast<void*>(0x1040), 0x10), valA);
+  EXPECT_EQ(tree->searchVal(reinterpret_cast<void*>(0x2000), 0x100), valB);
+  // Equivalent to a separate search() + lookup().
+  EXPECT_EQ(
+      tree->searchVal(reinterpret_cast<void*>(0x1000), 0x100),
+      tree->lookup(tree->search(reinterpret_cast<void*>(0x1000), 0x100)));
+  // Misses (gap, past all) return nullptr.
+  EXPECT_EQ(tree->searchVal(reinterpret_cast<void*>(0x1500), 0x10), nullptr);
+  EXPECT_EQ(tree->searchVal(reinterpret_cast<void*>(0x3000), 0x10), nullptr);
+
+  tree->remove(hdlA);
+  tree->remove(hdlB);
+}
+
 // Test ToString
 TEST_F(CtranUtilsAvlTreeTest, ToString) {
   auto tree = std::make_unique<CtranAvlTree>();

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -176,6 +176,14 @@ struct CtranWin {
     return enableSignal_;
   }
 
+  inline void setSymmetric(bool val) {
+    symmetric_ = val;
+  }
+
+  inline bool isSymmetric() const {
+    return symmetric_;
+  }
+
   // Check whether persistent allgather (allgatherP) is supported.
   // Returns true if ctran is initialized and all peers have configured
   // backends. Static variant allows checking before a window is created.
@@ -199,6 +207,11 @@ struct CtranWin {
   // rejected. Used by data-only collective windows (e.g. window-based
   // allgather) that never issue signals.
   bool enableSignal_{true};
+  // When true, every rank registers a buffer of identical size at an identical
+  // offset from the window base, so a peer address can be computed as
+  // peerBase + (buf - localBase). Records the upstream NCCL_WIN_COLL_SYMMETRIC
+  // hint; consumed by a later window-based allgather. Cached only for now.
+  bool symmetric_{false};
   // rank: window::OpCountType as key
   folly::Synchronized<
       std::unordered_map<std::pair<int, window::OpCountType>, uint64_t>>

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -168,6 +168,14 @@ struct CtranWin {
     ipcOnly_ = val;
   }
 
+  inline void setEnableSignal(bool val) {
+    enableSignal_ = val;
+  }
+
+  inline bool isSignalEnabled() const {
+    return enableSignal_;
+  }
+
   // Check whether persistent allgather (allgatherP) is supported.
   // Returns true if ctran is initialized and all peers have configured
   // backends. Static variant allows checking before a window is created.
@@ -186,6 +194,11 @@ struct CtranWin {
   // When true, registration exchanges only intra-node NVL/CUDA-IPC handles
   // and skips the IB rkey exchange.
   bool ipcOnly_{false};
+  // When false, the window carries no signal buffer: signal-buffer allocation
+  // and the signal-related control exchange are skipped, and signal RMA ops are
+  // rejected. Used by data-only collective windows (e.g. window-based
+  // allgather) that never issue signals.
+  bool enableSignal_{true};
   // rank: window::OpCountType as key
   folly::Synchronized<
       std::unordered_map<std::pair<int, window::OpCountType>, uint64_t>>

--- a/comms/ctran/window/WinHintUtils.cc
+++ b/comms/ctran/window/WinHintUtils.cc
@@ -11,6 +11,7 @@ namespace {
 const std::string kWindowBufferLocation = "window_buffer_location";
 const std::string kWindowSignalBufSize = "window_signal_bufsize";
 const std::string kWinRegisterIpcOnly = "win_register_ipc_only";
+const std::string kWinRegisterEnableSignal = "win_register_enable_signal";
 } // namespace
 
 void WinHintUtils::init(kvType& kv) {
@@ -27,6 +28,14 @@ WinHintUtils::set(const std::string& key, const std::string& val, kvType& kv) {
   } else if (key == kWindowSignalBufSize) {
     kv[key] = val;
   } else if (key == kWinRegisterIpcOnly) {
+    if (val == "1" || val == "true") {
+      kv[key] = "1";
+    } else if (val == "0" || val == "false") {
+      kv[key] = "0";
+    } else {
+      return commInvalidArgument;
+    }
+  } else if (key == kWinRegisterEnableSignal) {
     if (val == "1" || val == "true") {
       kv[key] = "1";
     } else if (val == "0" || val == "false") {

--- a/comms/ctran/window/WinHintUtils.cc
+++ b/comms/ctran/window/WinHintUtils.cc
@@ -12,6 +12,7 @@ const std::string kWindowBufferLocation = "window_buffer_location";
 const std::string kWindowSignalBufSize = "window_signal_bufsize";
 const std::string kWinRegisterIpcOnly = "win_register_ipc_only";
 const std::string kWinRegisterEnableSignal = "win_register_enable_signal";
+const std::string kWinRegisterSymmetric = "win_register_symmetric";
 } // namespace
 
 void WinHintUtils::init(kvType& kv) {
@@ -36,6 +37,14 @@ WinHintUtils::set(const std::string& key, const std::string& val, kvType& kv) {
       return commInvalidArgument;
     }
   } else if (key == kWinRegisterEnableSignal) {
+    if (val == "1" || val == "true") {
+      kv[key] = "1";
+    } else if (val == "0" || val == "false") {
+      kv[key] = "0";
+    } else {
+      return commInvalidArgument;
+    }
+  } else if (key == kWinRegisterSymmetric) {
     if (val == "1" || val == "true") {
       kv[key] = "1";
     } else if (val == "0" || val == "false") {

--- a/comms/ctran/window/tests/CtranWinTests.cc
+++ b/comms/ctran/window/tests/CtranWinTests.cc
@@ -912,6 +912,114 @@ TEST_F(CtranWinTest, ipcOnlyUserBufferRegister) {
       segments.end());
 }
 
+// enable_signal=0 window registration: the window carries no signal buffer, so
+// signal-buffer allocation and the signal-related control exchange are skipped.
+// Verifies that registration succeeds, signalSize is 0 with a null signal
+// pointer, no signal rkey/addr is exchanged for any peer, a basic NVL data
+// read-back plus free() complete without leaking imports, and that a signal RMA
+// op is rejected with commInvalidUsage.
+TEST_F(CtranWinTest, enableSignalDisabledUserBufferRegister) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skip enable_signal window test";
+  }
+
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  auto statex = comm->statex_.get();
+  ASSERT_NE(statex, nullptr);
+
+  constexpr size_t sizeBytes = 8192 * sizeof(int);
+  const MemAllocType bufType = MemAllocType::kMemCuMemAlloc;
+  void* userBuf = commMemAlloc(sizeBytes, bufType, segments);
+  ASSERT_NE(userBuf, nullptr);
+
+  // Fill the local buffer with a rank-specific pattern for the read-back below.
+  const size_t count = sizeBytes / sizeof(int);
+  std::vector<int> fillVals(count);
+  for (size_t i = 0; i < count; ++i) {
+    fillVals[i] = this->globalRank * 10000 + static_cast<int>(i);
+  }
+  CUDACHECK_TEST(
+      cudaMemcpy(userBuf, fillVals.data(), sizeBytes, cudaMemcpyHostToDevice));
+
+  // Simulate the CCA memory hook so acquireScopedRegister finds the segment.
+  COMMCHECK_TEST(
+      ctran::RegCache::getInstance()->globalRegister(userBuf, sizeBytes));
+
+  // Register the user buffer with the signal buffer disabled.
+  CtranWin* win = nullptr;
+  meta::comms::Hints hints;
+  ASSERT_EQ(hints.set("win_register_enable_signal", "0"), commSuccess);
+  auto res = ctranWinRegister(userBuf, sizeBytes, comm.get(), &win, hints);
+  ASSERT_EQ(res, commSuccess);
+  ASSERT_NE(win, nullptr);
+  ASSERT_EQ(win->remWinInfo.size(), static_cast<size_t>(this->numRanks));
+
+  // No signal buffer exists.
+  EXPECT_FALSE(win->isSignalEnabled());
+  EXPECT_EQ(win->signalSize, 0u);
+  EXPECT_THAT(win->winSignalPtr, ::testing::IsNull());
+
+  // No signal rkey / addr was exchanged for any peer, while data addresses are
+  // still populated for NVL peers.
+  for (int peer = 0; peer < this->numRanks; ++peer) {
+    const auto& info = win->remWinInfo[peer];
+    EXPECT_THAT(info.signalAddr, ::testing::IsNull());
+    EXPECT_EQ(info.signalRkey.backend, CtranMapperBackend::UNSET);
+    if (peer == statex->rank()) {
+      EXPECT_EQ(info.dataAddr, userBuf);
+    }
+  }
+
+  oobBarrier();
+
+  // Basic access: read back an NVL peer's window over the IPC mapping.
+  for (int peer = 0; peer < this->numRanks; ++peer) {
+    if (peer == this->globalRank || !win->nvlEnabled(peer)) {
+      continue;
+    }
+    void* remoteAddr = win->remWinInfo[peer].dataAddr;
+    ASSERT_NE(remoteAddr, nullptr);
+    std::vector<int> readBack(count);
+    CUDACHECK_TEST(cudaMemcpy(
+        readBack.data(), remoteAddr, sizeBytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < count; ++i) {
+      const int expected = peer * 10000 + static_cast<int>(i);
+      EXPECT_EQ(readBack[i], expected)
+          << "enable_signal=0 NVL read-back mismatch at " << i << " from peer "
+          << peer;
+    }
+  }
+
+  // A signal RMA op must be rejected since there is no signal buffer.
+  cudaStream_t stream;
+  CUDACHECK_TEST(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+  const int nextPeer = (this->globalRank + 1) % this->numRanks;
+  EXPECT_EQ(ctranWaitSignal(nextPeer, win, stream), commInvalidUsage);
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+
+  oobBarrier();
+
+  res = ctranWinFree(win);
+  EXPECT_EQ(res, commSuccess);
+
+  const auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  EXPECT_EQ(ipcRegCache->maxRemRegRefCount(), 0)
+      << "IpcRegCache still holds live NVL IPC imports after enable_signal free";
+
+  COMMCHECK_TEST(
+      ctran::RegCache::getInstance()->globalDeregister(userBuf, sizeBytes));
+  commMemFree(userBuf, sizeBytes, bufType);
+  segments.erase(
+      std::remove_if(
+          segments.begin(),
+          segments.end(),
+          [userBuf](const TestMemSegment& seg) { return seg.ptr == userBuf; }),
+      segments.end());
+}
+
 TEST_F(CtranWinTest, RegisterOverRangeUserBufferNoLeak) {
   // Reproduces a leak in ctranWinRegister: it constructs the CtranWin with a
   // raw `new`, then FB_COMMCHECK(exchange()). If exchange() fails, the early

--- a/comms/ctran/window/tests/CtranWinTests.cc
+++ b/comms/ctran/window/tests/CtranWinTests.cc
@@ -1020,6 +1020,72 @@ TEST_F(CtranWinTest, enableSignalDisabledUserBufferRegister) {
       segments.end());
 }
 
+// win_register_symmetric hint: the flag is cached on the window (no exchange or
+// behavior change yet). Verifies that a window registered with the hint reports
+// isSymmetric()==true, a window registered without it reports false, and that
+// registration/free complete without leaking imports.
+TEST_F(CtranWinTest, symmetricUserBufferRegister) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skip symmetric window test";
+  }
+
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  auto statex = comm->statex_.get();
+  ASSERT_NE(statex, nullptr);
+
+  constexpr size_t sizeBytes = 8192 * sizeof(int);
+  const MemAllocType bufType = MemAllocType::kMemCuMemAlloc;
+  void* userBuf = commMemAlloc(sizeBytes, bufType, segments);
+  ASSERT_NE(userBuf, nullptr);
+
+  // Simulate the CCA memory hook so acquireScopedRegister finds the segment.
+  COMMCHECK_TEST(
+      ctran::RegCache::getInstance()->globalRegister(userBuf, sizeBytes));
+
+  // Register the user buffer with the symmetric window hint enabled.
+  CtranWin* win = nullptr;
+  meta::comms::Hints hints;
+  ASSERT_EQ(hints.set("win_register_symmetric", "1"), commSuccess);
+  auto res = ctranWinRegister(userBuf, sizeBytes, comm.get(), &win, hints);
+  ASSERT_EQ(res, commSuccess);
+  ASSERT_NE(win, nullptr);
+  EXPECT_TRUE(win->isSymmetric());
+
+  oobBarrier();
+
+  res = ctranWinFree(win);
+  EXPECT_EQ(res, commSuccess);
+
+  // A window registered without the hint defaults to non-symmetric.
+  CtranWin* winDefault = nullptr;
+  res = ctranWinRegister(userBuf, sizeBytes, comm.get(), &winDefault);
+  ASSERT_EQ(res, commSuccess);
+  ASSERT_NE(winDefault, nullptr);
+  EXPECT_FALSE(winDefault->isSymmetric());
+
+  oobBarrier();
+
+  res = ctranWinFree(winDefault);
+  EXPECT_EQ(res, commSuccess);
+
+  const auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  EXPECT_EQ(ipcRegCache->maxRemRegRefCount(), 0)
+      << "IpcRegCache still holds live NVL IPC imports after symmetric free";
+
+  COMMCHECK_TEST(
+      ctran::RegCache::getInstance()->globalDeregister(userBuf, sizeBytes));
+  commMemFree(userBuf, sizeBytes, bufType);
+  segments.erase(
+      std::remove_if(
+          segments.begin(),
+          segments.end(),
+          [userBuf](const TestMemSegment& seg) { return seg.ptr == userBuf; }),
+      segments.end());
+}
+
 TEST_F(CtranWinTest, RegisterOverRangeUserBufferNoLeak) {
   // Reproduces a leak in ctranWinRegister: it constructs the CtranWin with a
   // raw `new`, then FB_COMMCHECK(exchange()). If exchange() fails, the early

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -189,14 +189,23 @@ commResult_t CtranWin::exchange() {
   CtranMapper* mapper = nullptr;
   FB_COMMCHECK(getWindowMapper(comm, &mapper));
   CtranMapperEpochRAII epochRAII(mapper);
+
+  // The base buffer holds the signal buffer (register path) or the combined
+  // data+signal buffer (allocate path). On the register path with signals
+  // disabled there is no base buffer, so its registration and control exchange
+  // are skipped entirely.
+  const bool exchangeBaseBuffer = allocDataBuf_ || enableSignal_;
+
   // Registration via ctran mapper.
-  FB_COMMCHECK(mapper->regMem(
-      winBasePtr,
-      range_,
-      &(baseSegHdl),
-      true,
-      true, /* NCCL managed buffer */
-      &baseRegHdl));
+  if (exchangeBaseBuffer) {
+    FB_COMMCHECK(mapper->regMem(
+        winBasePtr,
+        range_,
+        &(baseSegHdl),
+        true,
+        true, /* NCCL managed buffer */
+        &baseRegHdl));
+  }
 
   if (allocDataBuf_) {
     dataSegHdl = baseSegHdl;
@@ -277,12 +286,14 @@ commResult_t CtranWin::exchange() {
         outIpcHdls);
   };
 
-  FB_COMMCHECK(exchangeBuffer(
-      winBasePtr,
-      baseRegHdl,
-      remoteBaseBufs,
-      remoteBaseBufAccessKeys,
-      /*outIpcHdls=*/nullptr));
+  if (exchangeBaseBuffer) {
+    FB_COMMCHECK(exchangeBuffer(
+        winBasePtr,
+        baseRegHdl,
+        remoteBaseBufs,
+        remoteBaseBufAccessKeys,
+        /*outIpcHdls=*/nullptr));
+  }
 
   if (!allocDataBuf_) {
     // User-provided data buffer needs its own handle exchange round.
@@ -300,15 +311,21 @@ commResult_t CtranWin::exchange() {
     if (allocDataBuf_) {
       remWinInfo[r].dataAddr = remoteBaseBufs[exchangeRank];
       remWinInfo[r].dataRkey = remoteBaseBufAccessKeys[exchangeRank];
-      remWinInfo[r].signalAddr = reinterpret_cast<uint64_t*>(
-          reinterpret_cast<size_t>(remoteBaseBufs[exchangeRank]) +
-          allRankSizes[r]);
-      remWinInfo[r].signalRkey = remoteBaseBufAccessKeys[exchangeRank];
     } else {
       remWinInfo[r].dataAddr = remoteUserBufs[exchangeRank];
       remWinInfo[r].dataRkey = remoteUserBufAccessKeys[exchangeRank];
-      remWinInfo[r].signalAddr =
-          reinterpret_cast<uint64_t*>(remoteBaseBufs[exchangeRank]);
+    }
+    // With signals disabled there is no signal buffer, so leave signalAddr /
+    // signalRkey at their default (nullptr / UNSET).
+    if (enableSignal_) {
+      if (allocDataBuf_) {
+        remWinInfo[r].signalAddr = reinterpret_cast<uint64_t*>(
+            reinterpret_cast<size_t>(remoteBaseBufs[exchangeRank]) +
+            allRankSizes[r]);
+      } else {
+        remWinInfo[r].signalAddr =
+            reinterpret_cast<uint64_t*>(remoteBaseBufs[exchangeRank]);
+      }
       remWinInfo[r].signalRkey = remoteBaseBufAccessKeys[exchangeRank];
     }
   }
@@ -366,37 +383,51 @@ commResult_t CtranWin::allocate(void* userBufPtr) {
   // allocating a new buffer internally.
   allocDataBuf_ = userBufPtr == nullptr ? true : false;
 
+  // When signals are disabled the window carries no signal buffer.
+  if (!enableSignal_) {
+    signalSize = 0;
+  }
+
   void* addr = nullptr;
   CUmemGenericAllocationHandle allocHandle;
   auto signalBytes = signalSize * sizeof(uint64_t);
   size_t allocSize = allocDataBuf_ ? dataBytes + signalBytes : signalBytes;
-  if (isGpuMem()) {
-    FB_COMMCHECK(
-        utils::commCuMemAlloc(
-            &addr,
-            &allocHandle,
-            utils::getCuMemAllocHandleType(),
-            allocSize,
-            &comm->logMetaData_,
-            "allocate"));
+  // On the register path the base buffer holds only the signal buffer; with
+  // signals disabled there is nothing to allocate (allocSize == 0), so the base
+  // buffer stays null and no registration/exchange is done for it.
+  if (allocSize > 0) {
+    if (isGpuMem()) {
+      FB_COMMCHECK(
+          utils::commCuMemAlloc(
+              &addr,
+              &allocHandle,
+              utils::getCuMemAllocHandleType(),
+              allocSize,
+              &comm->logMetaData_,
+              "allocate"));
 
-    // query the actually allocated range of the memory
-    CUdeviceptr pbase = 0;
-    FB_CUCHECK(cuMemGetAddressRange(&pbase, &range_, (CUdeviceptr)addr));
-  } else {
-    FB_CUDACHECK(cudaMallocHost(&addr, allocSize));
-    range_ = allocSize;
+      // query the actually allocated range of the memory
+      CUdeviceptr pbase = 0;
+      FB_CUCHECK(cuMemGetAddressRange(&pbase, &range_, (CUdeviceptr)addr));
+    } else {
+      FB_CUDACHECK(cudaMallocHost(&addr, allocSize));
+      range_ = allocSize;
+    }
   }
 
   winBasePtr = addr;
 
   if (allocDataBuf_) {
     winDataPtr = addr;
-    winSignalPtr =
-        reinterpret_cast<uint64_t*>(reinterpret_cast<size_t>(addr) + dataBytes);
+    winSignalPtr = enableSignal_
+        ? reinterpret_cast<uint64_t*>(
+              reinterpret_cast<size_t>(addr) + dataBytes)
+        : nullptr;
   } else {
     winDataPtr = userBufPtr;
-    winSignalPtr = reinterpret_cast<uint64_t*>(reinterpret_cast<size_t>(addr));
+    winSignalPtr = enableSignal_
+        ? reinterpret_cast<uint64_t*>(reinterpret_cast<size_t>(addr))
+        : nullptr;
   }
 
   CLOGF_SUBSYS(
@@ -469,10 +500,17 @@ commResult_t CtranWin::free(bool skipBarrier) {
 
   // deregistr buffer
   deregMemIfNotNull(baseSegHdl);
-  // deregister remote buf
+  // deregister remote buf. The base buffer's remote import is tracked via
+  // signalRkey when signals are enabled (shared with dataRkey on the allocate
+  // path). With signals disabled the allocate path tracks it via dataRkey, and
+  // the register path has no base buffer to release.
   for (auto i = 0; i < nRanks; ++i) {
     if (i != statex->rank()) {
-      FB_COMMCHECK(mapper->deregRemReg(&remWinInfo[i].signalRkey));
+      if (enableSignal_) {
+        FB_COMMCHECK(mapper->deregRemReg(&remWinInfo[i].signalRkey));
+      } else if (allocDataBuf_) {
+        FB_COMMCHECK(mapper->deregRemReg(&remWinInfo[i].dataRkey));
+      }
     }
   }
 
@@ -496,7 +534,11 @@ commResult_t CtranWin::free(bool skipBarrier) {
   hostWindow_.reset();
 #endif
 
-  freeMem(winBasePtr);
+  // winBasePtr is null on the register path with signals disabled (nothing was
+  // allocated), so only free a real allocation.
+  if (winBasePtr != nullptr) {
+    freeMem(winBasePtr);
+  }
 
   return commSuccess;
 }
@@ -653,6 +695,12 @@ commResult_t ctranWinRegister(
   std::string ipcOnlyVal;
   if (hints.get("win_register_ipc_only", ipcOnlyVal) == commSuccess) {
     newWin->setIpcOnly(meta::comms::hints::WinHintUtils::parseBool(ipcOnlyVal));
+  }
+
+  std::string enableSignalVal;
+  if (hints.get("win_register_enable_signal", enableSignalVal) == commSuccess) {
+    newWin->setEnableSignal(
+        meta::comms::hints::WinHintUtils::parseBool(enableSignalVal));
   }
 
   FB_COMMCHECK(newWin->allocate((void*)databuf));

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -703,6 +703,12 @@ commResult_t ctranWinRegister(
         meta::comms::hints::WinHintUtils::parseBool(enableSignalVal));
   }
 
+  std::string symmetricVal;
+  if (hints.get("win_register_symmetric", symmetricVal) == commSuccess) {
+    newWin->setSymmetric(
+        meta::comms::hints::WinHintUtils::parseBool(symmetricVal));
+  }
+
   FB_COMMCHECK(newWin->allocate((void*)databuf));
 
   FB_COMMCHECK(newWin->exchange()); // register and exchange both signal

--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -272,6 +272,7 @@ Config::Config(const ncclConfig_t* config) {
   noLocal = parseHintBool("noLocal", false);
   winRegisterIpcOnly = parseHintBool("win_register_ipc_only", false);
   winRegisterEnableSignal = parseHintBool("win_register_enable_signal", true);
+  winRegisterSymmetric = parseHintBool("win_register_symmetric", false);
 
   auto parseAlgoHint = [&](const char* key, auto& field) {
     auto val = getHintStr(key);
@@ -329,6 +330,7 @@ ncclResult_t Config::update(const ncclx::Hints* hints) {
   };
   parseBoolHint("win_register_ipc_only", winRegisterIpcOnly);
   parseBoolHint("win_register_enable_signal", winRegisterEnableSignal);
+  parseBoolHint("win_register_symmetric", winRegisterSymmetric);
 
   return ncclSuccess;
 }
@@ -394,6 +396,7 @@ void ncclxLogCommConfig(ncclComm_t comm) {
     append(
         fmt::format(
             "winRegisterEnableSignal={}", xCfg->winRegisterEnableSignal));
+    append(fmt::format("winRegisterSymmetric={}", xCfg->winRegisterSymmetric));
     append(fmt::format("ibLazyConnect={}", xCfg->ibLazyConnect));
     appendAlgo("sendrecvAlgo", xCfg->sendrecvAlgo);
     appendAlgo("allgatherAlgo", xCfg->allgatherAlgo);

--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -271,6 +271,7 @@ Config::Config(const ncclConfig_t* config) {
   usePatAvg = parseHintBool("usePatAvg", NCCL_REDUCESCATTER_PAT_AVG_ENABLE);
   noLocal = parseHintBool("noLocal", false);
   winRegisterIpcOnly = parseHintBool("win_register_ipc_only", false);
+  winRegisterEnableSignal = parseHintBool("win_register_enable_signal", true);
 
   auto parseAlgoHint = [&](const char* key, auto& field) {
     auto val = getHintStr(key);
@@ -327,6 +328,7 @@ ncclResult_t Config::update(const ncclx::Hints* hints) {
     }
   };
   parseBoolHint("win_register_ipc_only", winRegisterIpcOnly);
+  parseBoolHint("win_register_enable_signal", winRegisterEnableSignal);
 
   return ncclSuccess;
 }
@@ -389,6 +391,9 @@ void ncclxLogCommConfig(ncclComm_t comm) {
     append(fmt::format("usePatAvg={}", xCfg->usePatAvg));
     append(fmt::format("noLocal={}", xCfg->noLocal));
     append(fmt::format("winRegisterIpcOnly={}", xCfg->winRegisterIpcOnly));
+    append(
+        fmt::format(
+            "winRegisterEnableSignal={}", xCfg->winRegisterEnableSignal));
     append(fmt::format("ibLazyConnect={}", xCfg->ibLazyConnect));
     appendAlgo("sendrecvAlgo", xCfg->sendrecvAlgo);
     appendAlgo("allgatherAlgo", xCfg->allgatherAlgo);

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -42,6 +42,12 @@ class Config {
   // via commSetConfig.
   bool winRegisterEnableSignal = true;
 
+  // When true, all ranks register a buffer of identical size at an identical
+  // offset from the window base (upstream NCCL_WIN_COLL_SYMMETRIC semantics),
+  // so a peer address is peerBase + (buf - localBase). Mutable via
+  // commSetConfig.
+  bool winRegisterSymmetric = false;
+
   enum NCCL_SENDRECV_ALGO sendrecvAlgo = NCCL_SENDRECV_ALGO::orig;
   enum NCCL_ALLGATHER_ALGO allgatherAlgo = NCCL_ALLGATHER_ALGO::orig;
   enum NCCL_ALLREDUCE_ALGO allreduceAlgo = NCCL_ALLREDUCE_ALGO::orig;
@@ -93,6 +99,7 @@ inline const std::vector<std::string>& knownHintKeys() {
       "ibLazyConnect",
       "win_register_ipc_only",
       "win_register_enable_signal",
+      "win_register_symmetric",
   };
   return keys;
 }
@@ -107,6 +114,7 @@ inline const std::vector<std::string>& mutableHintKeys() {
       "rmaAlgo",
       "win_register_ipc_only",
       "win_register_enable_signal",
+      "win_register_symmetric",
   };
   return keys;
 }

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -37,6 +37,11 @@ class Config {
   // handles and defer the IB rkey exchange. Mutable via commSetConfig.
   bool winRegisterIpcOnly = false;
 
+  // When false, windows registered on this comm skip signal-buffer allocation
+  // and the signal control exchange; signal RMA ops are then rejected. Mutable
+  // via commSetConfig.
+  bool winRegisterEnableSignal = true;
+
   enum NCCL_SENDRECV_ALGO sendrecvAlgo = NCCL_SENDRECV_ALGO::orig;
   enum NCCL_ALLGATHER_ALGO allgatherAlgo = NCCL_ALLGATHER_ALGO::orig;
   enum NCCL_ALLREDUCE_ALGO allreduceAlgo = NCCL_ALLREDUCE_ALGO::orig;
@@ -87,6 +92,7 @@ inline const std::vector<std::string>& knownHintKeys() {
       "ibQpsPerConnection",
       "ibLazyConnect",
       "win_register_ipc_only",
+      "win_register_enable_signal",
   };
   return keys;
 }
@@ -100,6 +106,7 @@ inline const std::vector<std::string>& mutableHintKeys() {
       "alltoallvAlgo",
       "rmaAlgo",
       "win_register_ipc_only",
+      "win_register_enable_signal",
   };
   return keys;
 }

--- a/comms/ncclx/meta/tests/CommSetConfigTest.cc
+++ b/comms/ncclx/meta/tests/CommSetConfigTest.cc
@@ -309,6 +309,52 @@ TEST_F(CommSetConfigTest, WinRegisterIpcOnlyNotResetByUnrelatedUpdate) {
   }
 }
 
+TEST_F(CommSetConfigTest, SetWinRegisterEnableSignal) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"win_register_enable_signal", "0"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_FALSE(NCCLX_CONFIG_FIELD(comm->config, winRegisterEnableSignal));
+  }
+
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"win_register_enable_signal", "1"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_TRUE(NCCLX_CONFIG_FIELD(comm->config, winRegisterEnableSignal));
+  }
+}
+
+TEST_F(CommSetConfigTest, WinRegisterEnableSignalNotResetByUnrelatedUpdate) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  // Disable signals first.
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"win_register_enable_signal", "0"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_FALSE(NCCLX_CONFIG_FIELD(comm->config, winRegisterEnableSignal));
+  }
+
+  // An unrelated update must not reset it (key absent and not pre-seeded).
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"allgatherAlgo", "ctdirect"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_FALSE(NCCLX_CONFIG_FIELD(comm->config, winRegisterEnableSignal));
+  }
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);

--- a/comms/ncclx/meta/tests/CommSetConfigTest.cc
+++ b/comms/ncclx/meta/tests/CommSetConfigTest.cc
@@ -355,6 +355,52 @@ TEST_F(CommSetConfigTest, WinRegisterEnableSignalNotResetByUnrelatedUpdate) {
   }
 }
 
+TEST_F(CommSetConfigTest, SetWinRegisterSymmetric) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"win_register_symmetric", "1"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_TRUE(NCCLX_CONFIG_FIELD(comm->config, winRegisterSymmetric));
+  }
+
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"win_register_symmetric", "0"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_FALSE(NCCLX_CONFIG_FIELD(comm->config, winRegisterSymmetric));
+  }
+}
+
+TEST_F(CommSetConfigTest, WinRegisterSymmetricNotResetByUnrelatedUpdate) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  // Enable symmetric first.
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"win_register_symmetric", "1"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_TRUE(NCCLX_CONFIG_FIELD(comm->config, winRegisterSymmetric));
+  }
+
+  // An unrelated update must not reset it (key absent and not pre-seeded).
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"allgatherAlgo", "ctdirect"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_TRUE(NCCLX_CONFIG_FIELD(comm->config, winRegisterSymmetric));
+  }
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);

--- a/comms/ncclx/v2_29/src/dev_runtime.cc
+++ b/comms/ncclx/v2_29/src/dev_runtime.cc
@@ -1254,6 +1254,10 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
       NCCLCHECK(metaCommToNccl(winHints.set(
           "win_register_ipc_only",
           NCCLX_CONFIG_FIELD(comm->config, winRegisterIpcOnly) ? "1" : "0")));
+      NCCLCHECK(metaCommToNccl(winHints.set(
+          "win_register_enable_signal",
+          NCCLX_CONFIG_FIELD(comm->config, winRegisterEnableSignal) ? "1"
+                                                                    : "0")));
       NCCLCHECK(metaCommToNccl(
           ctran::ctranWinRegister(
               buff,

--- a/comms/ncclx/v2_29/src/dev_runtime.cc
+++ b/comms/ncclx/v2_29/src/dev_runtime.cc
@@ -1258,6 +1258,9 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
           "win_register_enable_signal",
           NCCLX_CONFIG_FIELD(comm->config, winRegisterEnableSignal) ? "1"
                                                                     : "0")));
+      NCCLCHECK(metaCommToNccl(winHints.set(
+          "win_register_symmetric",
+          NCCLX_CONFIG_FIELD(comm->config, winRegisterSymmetric) ? "1" : "0")));
       NCCLCHECK(metaCommToNccl(
           ctran::ctranWinRegister(
               buff,

--- a/comms/ncclx/v2_30/src/dev_runtime.cc
+++ b/comms/ncclx/v2_30/src/dev_runtime.cc
@@ -1490,6 +1490,10 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
       NCCLCHECK(metaCommToNccl(winHints.set(
           "win_register_ipc_only",
           NCCLX_CONFIG_FIELD(comm->config, winRegisterIpcOnly) ? "1" : "0")));
+      NCCLCHECK(metaCommToNccl(winHints.set(
+          "win_register_enable_signal",
+          NCCLX_CONFIG_FIELD(comm->config, winRegisterEnableSignal) ? "1"
+                                                                    : "0")));
       NCCLCHECK(metaCommToNccl(
           ctran::ctranWinRegister(
               buff,

--- a/comms/ncclx/v2_30/src/dev_runtime.cc
+++ b/comms/ncclx/v2_30/src/dev_runtime.cc
@@ -1494,6 +1494,9 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
           "win_register_enable_signal",
           NCCLX_CONFIG_FIELD(comm->config, winRegisterEnableSignal) ? "1"
                                                                     : "0")));
+      NCCLCHECK(metaCommToNccl(winHints.set(
+          "win_register_symmetric",
+          NCCLX_CONFIG_FIELD(comm->config, winRegisterSymmetric) ? "1" : "0")));
       NCCLCHECK(metaCommToNccl(
           ctran::ctranWinRegister(
               buff,


### PR DESCRIPTION
Summary: Add `CtranAvlTree::searchVal(addr, len)`: an atomic (single-lock) interval-containment search that returns the stored value directly. The existing `search()` is refactored to share a lockless `searchElemLocked` helper with `searchVal()`, so both walk the tree identically. This lets a caller resolve an address range to its cached value in one lock acquisition instead of a racy `search()` + `lookup()` pair (two separate lock acquisitions). Consumed by the upcoming `WinCache` on the window-based allgather lookup path.

Reviewed By: pavanbalaji

Differential Revision: D112247500


