### PR TITLE
cthierarchical_ring: add chunk-based Phase-2 pipelining knob

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2039,6 +2039,18 @@ cvars:
      Pipeline depth (number of staging ring slots) for IBGDA send/recv.
      Only used when NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1.
 
+ - name        : NCCL_MCCL_HIERRING_PHASE2_CHUNKS_PER_OP
+   type        : int
+   default     : 0
+   description : |-
+     Per-op granularity for the MCCL cthierarchical_ring AllReduce Phase-2 IB
+     ring. <= 0 means the full channel window (baseline / current behavior). A
+     positive value is the number of transport chunks per send/recv/forward op;
+     it is clamped device-side to [1, pipeline_depth] against the communicator's
+     frozen transport depth, so an out-of-range value simply saturates to the
+     full window (never errors). MUST be set identically on every rank -- a
+     heterogeneous value desynchronizes the ring send/recv pairing and hangs.
+
  - name        : NCCL_CTRAN_BACKENDS
    type        : enumlist
    default     : ib, nvl, socket


### PR DESCRIPTION
Summary:
Adds a tunable per-op granularity knob (NCCL_MCCL_HIERRING_PHASE2_CHUNKS_PER_OP)
to the cthierarchical_ring AllReduce Phase-2 IB ring, subdividing the per-channel
window into `chunksPerOp` transport chunks. First step of the chunk-based
pipelining plan (draft on TOT, mirroring the tree's D111379603).

Design (single-lane, blocking APIs, on landed trunk):
- `reduceScatterRing`/`allGatherRing` stride by a `chunkStride` instead of the
  full `pipeline_window()`. `chunkStride = chunksPerOp * pipeline_chunk()`, with
  `chunksPerOp` device-clamped to [1, pipeline_depth] against the authoritative
  frozen transport depth (0 = full-window baseline, via a fast path with no depth
  query/divide). No host validation, no divisor rule, no device trap, and no
  CVAR-vs-frozen-depth disagreement (e.g. the ctdirect_ib depth override).
- Default (chunksPerOp <= 0) is data-path-equivalent to today's full-window ring.

Note for reviewers: in this single-lane blocking form the knob only subdivides the
window; it does NOT add cross-step overlap, so finer granularity is expected to be
flat-to-regressed vs the full window (a full-window op already depth-pipelines
internally). The value here is the scaffold plus measuring the single-lane
granularity curve; a real overlap win needs multi-lane + resumable forward.

Testing: adds cthierarchical_ring to the shared CollectiveTestSuite correctness
matrix via three fixtures (full-window / one-chunk @ depth 8, prod @ depth 2)
under a new all_reduce_hier_ring_full_test_suite (IB_ONLY_1x2), and a
cthierarchical_ring variant to benchmark_allreduce.sh.

Differential Revision: D112754712


