### PR TITLE
comms/dsl: add shared CuTe send/recv device substrate

### DIFF
--- a/comms/dsl/__init__.py
+++ b/comms/dsl/__init__.py
@@ -1,0 +1,23 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""comms/dsl — NVLink all_to_all over PyTorch symmetric memory.
+
+Exposes the user-owned transport contract: :class:`NvlTransport` +
+:func:`nvl_rendezvous` (staging buffer, signal pad, and graph-safe step counters
+created once via a single collective rendezvous), the device-side
+:class:`PeerTable` that a fused schedule indexes by peer in-kernel, and the pre-launch
+:func:`check_transfer` validator.
+"""
+
+from __future__ import annotations
+
+from .transport import check_transfer, nvl_rendezvous, NvlTransport, PeerTable
+
+__all__ = [
+    "NvlTransport",
+    "PeerTable",
+    "nvl_rendezvous",
+    "check_transfer",
+]

--- a/comms/dsl/cute/__init__.py
+++ b/comms/dsl/cute/__init__.py
@@ -1,0 +1,34 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""CuTe collective backend over the shared NVLink transport.
+
+Symbols are exposed lazily so importing the package does not eagerly load the CuTe DSL.
+"""
+
+from importlib import import_module
+from typing import Any
+
+__all__ = [
+    "nvl_ops",
+]
+
+# Exported name -> (submodule, attribute). ``attr is None`` exports the submodule
+# itself (e.g. ``nvl_ops``).
+_LAZY: dict[str, tuple[str, str | None]] = {
+    "nvl_ops": ("nvl_ops", None),
+}
+
+
+def __getattr__(name: str) -> Any:
+    entry = _LAZY.get(name)
+    if entry is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    mod_name, attr = entry
+    mod = import_module(f".{mod_name}", __name__)
+    return mod if attr is None else getattr(mod, attr)
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/comms/dsl/cute/device_utils.py
+++ b/comms/dsl/cute/device_utils.py
@@ -1,0 +1,99 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Inline-PTX signalling primitives for the CuTe backend.
+
+Cross-rank int64 signalling over symmetric memory via ``@dsl_user_op`` and
+``llvm.inline_asm``. TAIL data-ready publication uses release/acquire ordering; HEAD
+slot-free credits use a relaxed store and volatile poll because they transfer ownership
+without publishing payload.
+"""
+
+from __future__ import annotations
+
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.typing import Int64
+from cutlass.cutlass_dsl import dsl_user_op
+
+
+@dsl_user_op
+def wait_ge(addr: Int64, target: Int64, *, loc=None, ip=None) -> None:
+    """Acquire-poll int64 until ``*addr >= target`` (local read)."""
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int64(target).ir_value(loc=loc, ip=ip)],
+        """{
+            .reg .u64   %tmp64;
+            .reg .pred  %p;
+            _fw_wait_ge:
+                ld.global.acquire.sys.b64 %tmp64, [$0];
+                setp.lt.u64 %p, %tmp64, $1;
+                @%p bra _fw_wait_ge;
+        }""",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def wait_ge_volatile(addr: Int64, target: Int64, *, loc=None, ip=None) -> None:
+    """Volatile-poll until ``*addr >= target`` for a HEAD slot-free credit."""
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int64(target).ir_value(loc=loc, ip=ip)],
+        """{
+            .reg .u64   %tmp64;
+            .reg .pred  %p;
+            _fw_wait_ge_vol:
+                ld.volatile.global.u64 %tmp64, [$0];
+                setp.lt.u64 %p, %tmp64, $1;
+                @%p bra _fw_wait_ge_vol;
+        }""",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def remote_store_release_i64(addr: Int64, val: Int64, *, loc=None, ip=None) -> None:
+    """Publish prior memory accesses with one system-scope release store."""
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int64(val).ir_value(loc=loc, ip=ip)],
+        """{
+            st.global.release.sys.b64 [$0], $1;
+        }""",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def remote_store_i64_relaxed(addr: Int64, val: Int64, *, loc=None, ip=None) -> None:
+    """Return a HEAD slot-free credit without payload-publication ordering."""
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int64(val).ir_value(loc=loc, ip=ip)],
+        """{
+            st.global.relaxed.sys.b64 [$0], $1;
+        }""",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )

--- a/comms/dsl/cute/nvl_ops.py
+++ b/comms/dsl/cute/nvl_ops.py
@@ -1,0 +1,52 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""NVLink device transport-ops for the CuTe send/recv seam.
+
+The concrete data movement plus TAIL data-ready and HEAD slot-free operations for the
+symmetric-memory transport, in cute-native signatures.
+"""
+
+from __future__ import annotations
+
+import cutlass.cute as cute
+
+from .device_utils import (
+    remote_store_i64_relaxed,
+    remote_store_release_i64,
+    wait_ge,
+    wait_ge_volatile,
+)
+
+
+def put(atom, frag, dst_part):
+    """Write a produced fragment into the peer's staging partition (remote store)."""
+    cute.copy(atom, frag, dst_part)
+
+
+def get(atom, src_part):
+    """Read a received tile from the local staging partition into a fragment."""
+    frag = cute.make_fragment_like(src_part)
+    cute.copy(atom, src_part, frag)
+    return frag
+
+
+def signal(addr, seq):
+    """Publish "data ready" to the peer with a system-scope release store."""
+    remote_store_release_i64(addr, seq)
+
+
+def wait(addr, seq):
+    """Wait until the peer published data-ready ``seq`` with an acquire poll."""
+    wait_ge(addr, seq)
+
+
+def signal_free(addr, seq):
+    """Return HEAD slot ownership with a relaxed remote store."""
+    remote_store_i64_relaxed(addr, seq)
+
+
+def wait_free(addr, seq):
+    """Wait for a HEAD slot-free credit with a volatile poll."""
+    wait_ge_volatile(addr, seq)

--- a/comms/dsl/cute/send_recv.py
+++ b/comms/dsl/cute/send_recv.py
@@ -1,0 +1,301 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# pyre-ignore-all-errors[6, 35, 58]: @cute.kernel / @cute.jit constexpr params are
+# annotated cutlass.Constexpr; pyre models that as Constexpr[Any] and rejects the
+# arithmetic / range() / dataclass-field uses the kernel bodies do on them -- the values
+# are real compile-time ints at trace time.
+
+"""Shared CuTe device substrate for collectives over ``NvlTransport``.
+
+The module owns vectorized copy leaves, per-slot send/receive primitives, CUDA DSL setup,
+and analytic tile/slot sizing. Collective schedules compose these helpers and supply their
+own peer ownership, address mapping, barriers, and counter progression.
+"""
+
+# NOTE: do NOT add ``from __future__ import annotations`` here. The @cute.jit
+# functions below (``_send_slot`` / ``_recv_slot``) classify their compile-time params via the REAL
+# ``cutlass.Constexpr`` annotation object, which ``inspect.getfullargspec`` only exposes
+# when annotations are NOT stringized -- stringizing makes cute marshal a constexpr dtype
+# as a dynamic arg and crash (Float32.__c_pointers__ TypeError).
+import logging
+import os
+from importlib import import_module
+from typing import Any
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _resolve_cute_dsl_arch() -> str:
+    """``sm_<major><minor>[a]`` for the local device; honors CUTE_DSL_ARCH."""
+    explicit = os.environ.get("CUTE_DSL_ARCH")
+    if explicit:
+        return explicit
+    try:
+        import torch as _torch
+
+        major, minor = _torch.cuda.get_device_capability(_torch.cuda.current_device())
+    except (ImportError, RuntimeError, AssertionError) as e:
+        logger.warning(
+            "could not detect CUDA device capability (%s); "
+            "defaulting CUTE_DSL_ARCH to sm_90a",
+            e,
+        )
+        return "sm_90a"
+    if (major, minor) == (9, 0):
+        return "sm_90a"
+    if (major, minor) in {(10, 0), (10, 1)}:
+        return "sm_100a"
+    if (major, minor) == (8, 0):
+        return "sm_80"
+    return f"sm_{major}{minor}"
+
+
+# Must be set before importing cutlass.cute.
+os.environ.setdefault("CUTE_DSL_ARCH", _resolve_cute_dsl_arch())
+
+import cutlass
+import cutlass.cute as cute
+
+from . import nvl_ops
+
+_cuda_rt: Any = import_module("cuda.bindings.runtime")
+
+
+def _ensure_cuda_rt_compat() -> None:
+    """Idempotently shim cuda-bindings symbols the cutlass DSL JIT executor expects.
+
+    Some cuda-bindings versions lack ``cudaLibrary_t`` / ``cudaLibraryUnload``, so kernel
+    compilation cannot load the cuda library. This patches them in on first use (NOT at
+    import scope, per the don't-mutate-imported-module-attributes-at-import rule).
+    The installed ``cudaLibraryUnload`` is a process-wide no-op, so it can leak library
+    handles for OTHER callers of cuda.bindings.runtime -- we log a warning when installing
+    it so that side effect is visible rather than silent. Invoked lazily from the JIT paths
+    (just before cute.compile)."""
+    if hasattr(_cuda_rt, "cudaLibrary_t"):
+        return
+
+    class _cudaLibrary_t:
+        __slots__ = ("value",)
+
+        def __init__(self, value: int = 0) -> None:
+            self.value = value
+
+    logger.warning(
+        "installing process-wide cuda.bindings.runtime shim (cudaLibrary_t + "
+        "no-op cudaLibraryUnload); cudaLibraryUnload becomes a no-op for ALL callers"
+    )
+    _cuda_rt.cudaLibrary_t = _cudaLibrary_t
+    _cuda_rt.cudaLibraryUnload = lambda lib: (_cuda_rt.cudaError_t(0),)
+
+
+# ---------------------------------------------------------------------------
+# Shared CuTe send/recv substrate: the vectorized copy leaf + the per-slot
+# credit-ring primitives (``_send_slot`` / ``_recv_slot``). This is the backend
+# substrate home. A schedule composes these primitives by supplying its own per-peer
+# region/offset math, so a perf/codegen change here lands once and every composer
+# inherits it. The dependency is one-way: a composer imports these from here; nothing
+# here imports a schedule.
+# ---------------------------------------------------------------------------
+
+
+def _copy_atom(dtype: Any, vec: int, dbits: int):
+    """The vectorized gmem copy atom every schedule shares: VEC contiguous elems per
+    thread per copy, so the NVLink store is a vectorized st.global (up to 128-bit)
+    instead of a scalar store -- the single biggest copy-bandwidth lever (mirrors the
+    Triton 128-bit-store fix). The TV-tiled copy is built per schedule on top of it."""
+    return cute.make_copy_atom(
+        cute.nvgpu.CopyUniversalOp(),
+        dtype,
+        num_bits_per_copy=vec * dbits,
+    )
+
+
+def _copy_u(thr_copy, copy_atom, g_src, g_dst, t, n, num_blocks):
+    """Copy ``n`` consecutive (stride ``num_blocks``) tiles starting at ``t``:
+    issue all ``n`` loads, then all ``n`` stores, so ``n`` NVLink stores are in
+    flight per thread (mirrors NCCL's ``COLL_UNROLL`` -- the per-SM-extraction
+    lever Triton/TLX could not use because the wider per-thread footprint
+    spilled). STRAIGHT-LINE only (``n`` is constexpr; no control flow) so it is
+    safe to call from the kernel body -- CuTe only rewrites control flow in the
+    ``@cute.kernel`` function itself, so the grid-stride ``while`` stays inline
+    there. Correctness is unroll-independent: src and dst share one ``thr_copy``
+    partition, so any order copies the same elements."""
+    nb = num_blocks
+    frags = [
+        nvl_ops.get(copy_atom, thr_copy.partition_S(g_src[(None, t + i * nb)]))
+        for i in range(n)
+    ]
+    for i in range(n):
+        nvl_ops.put(
+            copy_atom, frags[i], thr_copy.partition_D(g_dst[(None, t + i * nb)])
+        )
+
+
+@cute.jit
+def _send_slot(
+    thr_copy,
+    copy_atom,
+    g_in,
+    g_send,
+    tail_remote,
+    start_send,
+    b,
+    tidx,
+    s: cutlass.Constexpr,
+    tiles_per_slot: cutlass.Constexpr,
+    num_tiles: cutlass.Constexpr,
+    num_blocks: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+) -> None:
+    """One credit-ring SEND slot: stage slot ``s`` into the peer's staging over NVLink,
+    then publish its data-ready TAIL.
+
+    Extracted as a ``@cute.jit`` device sub-function so every schedule composes the SAME
+    slot primitive. It carries the runtime grid-stride ``while`` + barrier + leader
+    signal, so it MUST be ``@cute.jit`` -- a plain helper would not get CuTe's
+    control-flow rewrite (see ``_copy_u``)."""
+    u = unroll
+    nb = num_blocks
+    s_lo = s * tiles_per_slot
+    s_hi = min((s + 1) * tiles_per_slot, num_tiles)
+    t = s_lo + b
+    while t + (u - 1) * nb < s_hi:
+        _copy_u(thr_copy, copy_atom, g_in, g_send, t, u, num_blocks)
+        t += u * nb
+    while t < s_hi:
+        _copy_u(thr_copy, copy_atom, g_in, g_send, t, 1, num_blocks)
+        t += nb
+    cute.arch.barrier()
+    if tidx == 0:
+        # data-ready for slots 0..s (monotonic counter).
+        nvl_ops.signal(tail_remote, start_send + s + 1)
+
+
+@cute.jit
+def _recv_slot(
+    thr_copy,
+    copy_atom,
+    g_recv,
+    g_out,
+    tail_local,
+    start_recv,
+    b,
+    tidx,
+    s: cutlass.Constexpr,
+    tiles_per_slot: cutlass.Constexpr,
+    num_tiles: cutlass.Constexpr,
+    num_blocks: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+) -> None:
+    """One credit-ring RECV slot: wait the peer's data-ready TAIL for slot ``s``, then
+    drain its matching staging slot into the output. Symmetric twin of :func:`_send_slot`;
+    same ``@cute.jit`` rationale."""
+    u = unroll
+    nb = num_blocks
+    p_lo = s * tiles_per_slot
+    p_hi = min((s + 1) * tiles_per_slot, num_tiles)
+    if tidx == 0:
+        nvl_ops.wait(tail_local, start_recv + s + 1)
+    cute.arch.barrier()
+    t = p_lo + b
+    while t + (u - 1) * nb < p_hi:
+        _copy_u(thr_copy, copy_atom, g_recv, g_out, t, u, num_blocks)
+        t += u * nb
+    while t < p_hi:
+        _copy_u(thr_copy, copy_atom, g_recv, g_out, t, 1, num_blocks)
+        t += nb
+
+
+# ---------------------------------------------------------------------------
+# Pipelined credit-ring send/recv collective (graph-safe), composed from the shared
+# _send_slot / _recv_slot substrate above. Single-peer-pair whole-buffer transfer,
+# keeping the slot send/drain overlap. uni (send-only / recv-only) and bidir are selected
+# by the do_send / do_recv constexprs. Graph-safe via the transport's persistent monotonic
+# counters + the symmetric-memory signal pad.
+# ---------------------------------------------------------------------------
+
+
+# Analytic tile / slot sizing for the pipelined send/recv geometry. Owned here so the
+# send/recv collective is self-contained; a fused multi-peer schedule reuses these.
+_SATURATION_THREADS: int = 32768
+_MIN_TILES: int = 32  # keep at least this many tiles so the pipeline has slots
+# Target number of pipeline slots per (peer, block) once pipelining is on. The
+# send/drain overlap approaches the send-only NVLink ceiling as slots grow (the
+# un-overlapped tail is one slot's drain), with diminishing returns vs per-slot
+# signal overhead; ~8 is the measured knee on H100. Overridable for the autotuner.
+_NUM_SLOTS: int = 8
+# Only pipeline when the per-peer chunk is large enough that the bandwidth-bound
+# send/drain overlap win beats the per-slot sync overhead. Below this the message
+# is latency-bound and a single shot (no extra barriers/signals/waits) is faster.
+# Measured on 8xH100: chunks <4MB regress under pipelining, >=8MB chunks gain
+# ~15-25%. Gated on bytes, not tiles -- 16MB and 64MB land at the same tile count
+# but opposite optima, so absolute size is the right signal.
+_MIN_PIPELINE_CHUNK_BYTES: int = 4 * 1024 * 1024
+# Per-peer chunk at/above which the deep (8-slot) run-ahead beats the shallow
+# (4-slot) one -- below it the deeper pipeline's per-slot sub-chunk is too small and
+# the sync overhead dominates (GB300, unroll=8). 64 MiB chunk.
+_DEEP_PIPELINE_CHUNK_BYTES: int = 64 * 1024 * 1024
+
+
+def _pick_tile(chunk: int, dbits: int, total_ctas: int) -> tuple[int, int]:
+    """Pick (num_threads, vec) so the per-(peer,block) chunk tiles EXACTLY.
+
+    Vec is the widest 128-bit-down-to-scalar copy the chunk allows (vec drops to 1
+    for tiny/odd chunks, so the whole 32B-2GB ladder tiles with no tail). Threads
+    are chosen CTA-aware: ``_SATURATION_THREADS / total_ctas`` (more warps per CTA
+    when few CTAs are in the SM budget), bounded so a small chunk keeps
+    ``_MIN_TILES`` tiles, floored so a chunk with real work is not under-threaded,
+    and capped at the 1024 hardware limit. An explicit ``A2A_CUTE_NT`` env overrides
+    the analytic pick (for sweeps / the autotuner).
+    """
+    env_nt = os.environ.get("A2A_CUTE_NT")
+    for vbits in (128, 64, 32, 16):
+        if vbits < dbits:
+            continue
+        vec = vbits // dbits
+        if chunk % vec:
+            continue
+        units = chunk // vec  # number of vectors to copy across the whole chunk
+        if env_nt is not None:
+            # Floor at 1 and cap at 1024 (mirrors the analytic branch): A2A_CUTE_NT="0" would
+            # otherwise return nt=0 and divide-by-zero in the caller's num_tiles math, and
+            # A2A_CUTE_NT>1024 would exceed the CUDA per-block thread cap and fail the launch.
+            nt = max(1, min(int(env_nt), units, 1024))
+        else:
+            nt = max(1, _SATURATION_THREADS // max(1, total_ctas))
+            nt = min(nt, max(1, units // _MIN_TILES))  # leave enough tiles
+            nt = min(nt, 1024)  # hardware cap
+            nt = max(nt, min(256, units))  # don't under-thread a chunk with work
+        nt = min(nt, units)
+        while nt > 1 and units % nt:
+            nt -= 1
+        # Final floor: the `min(nt, units)` above re-introduces nt=0 when units==0
+        # (chunk==0), which would divide-by-zero in the caller's num_tiles math.
+        return max(1, nt), vec
+    return 1, 1  # scalar fallback (chunk not a multiple of any vec width)
+
+
+def _pick_slots(num_tiles: int, chunk_bytes: int) -> tuple[int, int]:
+    """Split ``num_tiles`` into (num_slots, tiles_per_slot) for the send/drain
+    pipeline. Returns ``(1, num_tiles)`` (single shot, no pipeline) for per-peer
+    chunks below ``_MIN_PIPELINE_CHUNK_BYTES`` -- latency-bound sizes are faster
+    without the per-slot sync. An explicit ``A2A_CUTE_SLOTS`` env forces the slot
+    count (for sweeps / the autotuner)."""
+    if num_tiles <= 1:
+        return 1, 1
+    env_slots = os.environ.get("A2A_CUTE_SLOTS")
+    if env_slots is not None:
+        want = max(1, min(int(env_slots), num_tiles))
+    elif chunk_bytes < _MIN_PIPELINE_CHUNK_BYTES:
+        return 1, num_tiles  # single shot: latency-bound band
+    else:
+        # The mid-large band over-pipelines at 8 slots -- each slot's sub-chunk gets
+        # too small and the per-slot sync dominates, so 4 slots is the knee there; the
+        # >=64MB chunk band keeps 8 (the deeper run-ahead still wins).
+        want = min(
+            4 if chunk_bytes < _DEEP_PIPELINE_CHUNK_BYTES else _NUM_SLOTS, num_tiles
+        )
+    tps = (num_tiles + want - 1) // want
+    slots = (num_tiles + tps - 1) // tps  # re-derive exact slot count for this tps
+    return slots, tps

--- a/comms/dsl/tests/_dist_harness.py
+++ b/comms/dsl/tests/_dist_harness.py
@@ -1,0 +1,39 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Shared multi-rank scaffolding for the distributed correctness suites.
+
+The small helpers every distributed test repeats: a free-port picker, the bit-exact
+input builder, and the cross-rank PASS/FAIL min-reduce + reporter. Kept here so the
+scaffolding lives in one place.
+"""
+
+import socket
+
+import torch
+import torch.distributed as dist
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _make_input(rank: int, numel: int, device: torch.device) -> torch.Tensor:
+    idx = torch.arange(numel, device=device, dtype=torch.int64)
+    return ((rank + 1) * 1_000_000 + idx).to(torch.float32)
+
+
+def _all_ok(local_ok: bool, device: torch.device, group: dist.ProcessGroup) -> bool:
+    status = torch.tensor([1 if local_ok else 0], dtype=torch.int32, device=device)
+    dist.all_reduce(status, op=dist.ReduceOp.MIN, group=group)
+    return bool(status.item())
+
+
+def _report(name: str, local_ok: bool, device, group, rank: int) -> bool:
+    ok = _all_ok(local_ok, device, group)
+    if rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: {name}", flush=True)
+    return ok

--- a/comms/dsl/tests/test_transport.py
+++ b/comms/dsl/tests/test_transport.py
@@ -1,0 +1,108 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Host-side (CPU, no device) coverage for transport host validation.
+
+``check_transfer`` and ``_require_signal_pad`` are pure host validation -- they
+read only ints (per_peer_bytes / max_blocks_per_peer / dtype.itemsize / a pad
+size) -- so their invariants are exercisable without a symmetric-memory process group.
+The device rendezvous path requires a real symmetric-memory-capable group and is outside
+this host-only test target.
+"""
+
+import unittest
+from dataclasses import dataclass
+from typing import cast
+
+import torch
+from comms.dsl import check_transfer, NvlTransport
+from comms.dsl.transport import _require_signal_pad
+
+
+@dataclass
+class _StubTransport:
+    """Minimal stub carrying only the fields ``check_transfer`` reads."""
+
+    per_peer_bytes: int
+    max_blocks_per_peer: int
+
+
+def _stub(per_peer_bytes: int, max_blocks_per_peer: int = 8) -> NvlTransport:
+    return cast(
+        NvlTransport,
+        _StubTransport(
+            per_peer_bytes=per_peer_bytes, max_blocks_per_peer=max_blocks_per_peer
+        ),
+    )
+
+
+class TransportCheckTransferTest(unittest.TestCase):
+    def test_dtype_not_divisible_raises(self) -> None:
+        # per_peer_bytes must be a whole multiple of the dtype itemsize:
+        # 65 bytes is not divisible by bfloat16's 2-byte itemsize.
+        with self.assertRaises(ValueError):
+            check_transfer(_stub(65), numel=1, dtype=torch.bfloat16, num_blocks=1)
+
+    def test_numel_overrun_raises(self) -> None:
+        # per_peer_bytes=64 holds 64 uint8 / 32 bf16 elems; one past capacity raises.
+        for dtype, cap in ((torch.uint8, 64), (torch.bfloat16, 32)):
+            with self.assertRaises(ValueError):
+                check_transfer(_stub(64), numel=cap + 1, dtype=dtype, num_blocks=1)
+
+    def test_num_blocks_out_of_range_raises(self) -> None:
+        t = _stub(64)
+        with self.assertRaises(ValueError):
+            check_transfer(t, numel=1, dtype=torch.uint8, num_blocks=0)
+        with self.assertRaises(ValueError):
+            check_transfer(
+                t, numel=1, dtype=torch.uint8, num_blocks=t.max_blocks_per_peer + 1
+            )
+
+    def test_divisibility_checked_before_capacity(self) -> None:
+        # When per_peer_bytes is both non-divisible AND too small for numel, the
+        # divisibility error must win: cap_elems = per_peer_bytes // itemsize would be
+        # computed from a garbage (floored) capacity otherwise. Kernel addressing relies
+        # on this order.
+        with self.assertRaisesRegex(ValueError, "not a multiple"):
+            check_transfer(
+                _stub(65), numel=10_000_000, dtype=torch.bfloat16, num_blocks=1
+            )
+
+    def test_min_capacity_boundary(self) -> None:
+        # per_peer_bytes == itemsize -> cap_elems == 1: exactly 1 elem fits, 2 overruns.
+        t = _stub(2)  # 1 bf16 elem
+        self.assertIsNone(
+            check_transfer(t, numel=1, dtype=torch.bfloat16, num_blocks=1)
+        )
+        with self.assertRaises(ValueError):
+            check_transfer(t, numel=2, dtype=torch.bfloat16, num_blocks=1)
+
+    def test_valid_transfer_passes(self) -> None:
+        # check_transfer returns None on success; assert that (and that it does not
+        # raise) for every valid (dtype, numel, num_blocks) combination. numel == 0
+        # (empty transfer) is allowed.
+        t = _stub(64)
+        for dtype, cap in ((torch.uint8, 64), (torch.bfloat16, 32)):
+            self.assertIsNone(check_transfer(t, numel=0, dtype=dtype, num_blocks=1))
+            self.assertIsNone(check_transfer(t, numel=cap, dtype=dtype, num_blocks=1))
+            self.assertIsNone(
+                check_transfer(
+                    t, numel=cap, dtype=dtype, num_blocks=t.max_blocks_per_peer
+                )
+            )
+
+
+class RequireSignalPadTest(unittest.TestCase):
+    def test_pad_too_small_raises(self) -> None:
+        # need = 2 * ws * mbp; one int64 short must raise.
+        ws, mbp = 8, 32
+        need = 2 * ws * mbp
+        with self.assertRaisesRegex(RuntimeError, "signal pad too small"):
+            _require_signal_pad(need - 1, ws, mbp)
+
+    def test_pad_exact_and_larger_pass(self) -> None:
+        ws, mbp = 8, 32
+        need = 2 * ws * mbp
+        self.assertIsNone(_require_signal_pad(need, ws, mbp))
+        self.assertIsNone(_require_signal_pad(need + 1, ws, mbp))

--- a/comms/dsl/transport.py
+++ b/comms/dsl/transport.py
@@ -1,0 +1,282 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""User-owned NVLink transport for the comms/dsl all_to_all kernels.
+
+:class:`NvlTransport` owns all transport state behind one object: the
+symmetric-memory staging buffer, the signal pad, and the persistent per-(peer,
+block) step counters. A device schedule consumes the device-side
+:class:`PeerTable` (every peer's staging-buffer + signal-pad base pointer,
+indexed by peer id in-kernel). The transport contains no collective algorithm.
+
+Design points realized here:
+
+* **User-owned, one rendezvous.** :func:`nvl_rendezvous` does a single collective
+  rendezvous for the whole group and returns an object the user holds (reused
+  across CUDA-graph replays). There is no hidden module-level cache.
+* **Graph-safe signalling.** The signal pad plus persistent monotonic step
+  counters let a reused transport / captured graph replay without ever reading a
+  stale signal slot (see :meth:`NvlTransport.step_state`).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from torch._C._distributed_c10d import _SymmetricMemory
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+_SR_DEBUG: bool | None = None
+
+
+def _sr_debug() -> bool:
+    global _SR_DEBUG
+    if _SR_DEBUG is None:
+        _SR_DEBUG = os.environ.get("SENDRECV_DEBUG", "0") == "1"
+    return _SR_DEBUG
+
+
+def _rdv_dbg(group: dist.ProcessGroup, msg: str) -> None:
+    if _sr_debug():
+        logger.debug("[r%d] rdv: %s", dist.get_rank(group), msg)
+
+
+# Shape-independent default; the staging region per peer must hold the message.
+_DEFAULT_MAX_BLOCKS_PER_PEER: int = 32
+
+
+@dataclass(frozen=True)
+class PeerTable:
+    """Device-side addressing for the fused multi-peer schedule.
+
+    Every peer's staging-buffer and signal-pad base pointer as an int64 device
+    tensor, indexed by peer id (cast int->ptr) inside the kernel, so a fused
+    multi-peer schedule picks the peer on device via ``program_id`` instead of
+    pre-slicing per-peer state on the host. The per-peer staging region for
+    sender ``s`` inside a rank's buffer is at ``s * (per_peer_bytes // elem)``,
+    and signal-pad slots for sender ``s`` start at ``s * max_blocks_per_peer``.
+    """
+
+    buffer_ptrs: torch.Tensor  # int64[world_size]: peer -> staging-buffer base
+    signal_pad_ptrs: torch.Tensor  # int64[world_size]: peer -> signal-pad base
+
+
+@dataclass
+class NvlTransport:
+    """Symmetric-memory NVLink transport (real, minimal).
+
+    Owns the ``_SymmetricMemory`` handle. The buffer is ``per_peer_bytes`` per
+    peer (``per_peer_bytes * world_size`` total); the signal pad holds two int64
+    regions of ``world_size * max_blocks_per_peer`` entries each (tail then head),
+    laid out by ``[sender_rank * max_blocks_per_peer + block]``. Tail = sender
+    "data ready" (polled by the receiver); head = receiver "slot free" credit
+    (polled by the sender before overwriting reusable staging).
+    """
+
+    handle: _SymmetricMemory
+    world_size: int
+    # Rank within the NVLink rendezvous group (``dist.get_rank(group)``), i.e. the
+    # index used to address this rank's slot in the symmetric-memory buffer. This is
+    # NOT the node-local rank (``LOCAL_RANK`` env / ``get_node_local_rank``): on an
+    # NVL fabric the rendezvous group may span trays, so it is a group-relative rank.
+    local_rank: int
+    per_peer_bytes: int
+    max_blocks_per_peer: int = _DEFAULT_MAX_BLOCKS_PER_PEER
+    _endpoints_device_cache: PeerTable | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+    _step_state_cache: tuple[torch.Tensor, torch.Tensor] | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+    _last_a2a_launch_metadata: dict[str, Any] | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+
+    def _record_a2a_launch_metadata(self, metadata: dict[str, Any]) -> None:
+        self._last_a2a_launch_metadata = dict(metadata)
+
+    def _get_a2a_launch_metadata(self) -> dict[str, Any]:
+        if self._last_a2a_launch_metadata is None:
+            raise RuntimeError("transport has no resolved a2a launch metadata")
+        return dict(self._last_a2a_launch_metadata)
+
+    def endpoints_device(self) -> PeerTable:
+        """All peers' buffer + signal-pad base pointers as a device :class:`PeerTable`.
+
+        Index by peer on device (cast int->ptr) instead of pre-slicing per-peer
+        state on the host. Symm-mem base addresses are fixed after rendezvous, so
+        build once and cache: repeated fused-schedule calls and CUDA-graph capture
+        must not re-allocate / re-copy.
+        """
+        if self._endpoints_device_cache is None:
+            # Device is the transport's own symm-mem device, not the caller's
+            # current device.
+            dev = self.handle.get_buffer(
+                self.local_rank, sizes=[1], dtype=torch.uint8
+            ).device
+            self._endpoints_device_cache = PeerTable(
+                buffer_ptrs=torch.tensor(
+                    self.handle.buffer_ptrs, dtype=torch.int64, device=dev
+                ),
+                signal_pad_ptrs=torch.tensor(
+                    self.handle.signal_pad_ptrs, dtype=torch.int64, device=dev
+                ),
+            )
+        return self._endpoints_device_cache
+
+    def step_state(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """Persistent monotonic step counters for graph-safe signalling.
+
+        Returns ``(sender_step, recver_step)``, each an int64 device tensor of
+        ``world_size * max_blocks_per_peer`` entries indexed by
+        ``peer * max_blocks_per_peer + block``. Each slot has exactly one writer
+        (the local send leg writes ``sender_step``; the local recv leg writes
+        ``recver_step``), so no atomics are needed.
+
+        The schedule signals an absolute, monotonically increasing sequence
+        number per call and the kernel advances these counters itself, so a
+        reused transport / CUDA-graph replay never reads a stale signal slot.
+        Allocated once and cached (zero-initialized; the signal pad is zeroed at
+        rendezvous, so the first wait for sequence 1 is race-free).
+        """
+        if self._step_state_cache is None:
+            dev = self.handle.get_buffer(
+                self.local_rank, sizes=[1], dtype=torch.uint8
+            ).device
+            n = self.world_size * self.max_blocks_per_peer
+            self._step_state_cache = (
+                torch.zeros(n, dtype=torch.int64, device=dev),
+                torch.zeros(n, dtype=torch.int64, device=dev),
+            )
+        return self._step_state_cache
+
+
+def _require_signal_pad(
+    sig_numel: int, world_size: int, max_blocks_per_peer: int
+) -> None:
+    """Raise if the symm-mem signal pad cannot hold the tail+head regions.
+
+    The pad needs two int64 regions of ``world_size * max_blocks_per_peer`` entries
+    each (tail then head). Extracted so the invariant is unit-testable host-only.
+    """
+    need = 2 * world_size * max_blocks_per_peer
+    if sig_numel < need:
+        raise RuntimeError(
+            f"signal pad too small: {sig_numel} int64 < required {need} "
+            f"(2 x world_size={world_size} x max_blocks_per_peer={max_blocks_per_peer})"
+        )
+
+
+def nvl_rendezvous(
+    group: dist.ProcessGroup,
+    device: torch.device,
+    per_peer_bytes: int,
+    max_blocks_per_peer: int = _DEFAULT_MAX_BLOCKS_PER_PEER,
+) -> NvlTransport:
+    """One collective rendezvous; returns a user-owned :class:`NvlTransport`.
+
+    Allocates ``per_peer_bytes * world_size`` of symmetric memory (one per-peer
+    staging region per peer). Zeroes the signal pad so the first wait for sequence 1
+    is race-free after the barrier.
+    """
+    world_size = dist.get_world_size(group)
+    local_rank = dist.get_rank(group)
+    total = per_peer_bytes * world_size
+    logger.info(
+        "nvl_rendezvous on PG %s: allocating %d bytes (%d peers x %d)",
+        group.group_desc,
+        total,
+        world_size,
+        per_peer_bytes,
+    )
+    _rdv_dbg(group, f"symm_mem.empty({total}B) start")
+    raw = symm_mem.empty(total, dtype=torch.uint8, device=device)
+    _rdv_dbg(group, "symm_mem.empty done; symm_mem.rendezvous start")
+    handle = symm_mem.rendezvous(raw, group=group)
+    _rdv_dbg(group, "symm_mem.rendezvous done")
+
+    # The transport addresses every symm-mem slot by local_rank (= group rank), so the
+    # handle's own rank convention must agree, else this rank would zero / index a peer's
+    # region. Enforce it (raise, not assert -- survives -O) rather than assume equality.
+    if handle.rank != local_rank:
+        raise RuntimeError(
+            f"symm-mem handle rank {handle.rank} != group rank {local_rank}"
+        )
+
+    # Signal pad holds two int64 regions per (sender, block) slot:
+    #   tail [0 .. ws*MBP): sender publishes "data ready" (polled by receiver)
+    #   head [ws*MBP .. 2*ws*MBP): receiver publishes "slot free" before reuse.
+    sig = handle.get_signal_pad(local_rank).view(torch.int64)
+    _require_signal_pad(sig.numel(), world_size, max_blocks_per_peer)
+    sig.zero_()
+    _rdv_dbg(group, "sig.zero_ done; barrier start")
+    dist.barrier(group)
+    _rdv_dbg(group, "barrier done")
+    transport = NvlTransport(
+        handle=handle,
+        world_size=world_size,
+        local_rank=local_rank,
+        per_peer_bytes=per_peer_bytes,
+        max_blocks_per_peer=max_blocks_per_peer,
+    )
+    # Eagerly materialize the device-side caches (peer table + step counters) now,
+    # so the first collective can be issued inside a CUDA-graph capture without the
+    # lazy allocation happening during capture.
+    transport.endpoints_device()
+    _rdv_dbg(group, "endpoints_device done")
+    transport.step_state()
+    _rdv_dbg(group, "step_state done")
+    return transport
+
+
+def check_transfer(
+    transport: NvlTransport,
+    numel: int,
+    dtype: torch.dtype,
+    num_blocks: int,
+) -> None:
+    """Validate a transfer against the transport before launch (fail loud).
+
+    Three invariants whose violation would otherwise cause **silent remote
+    corruption** (a kernel writing past a per-peer region overruns the next
+    peer's staging or signal-pad region on the remote rank):
+
+    * ``per_peer_bytes`` must be a whole multiple of the dtype itemsize, so the
+      per-peer region holds whole elements.
+    * ``numel`` must fit the per-peer staging region (``per_peer_bytes``).
+    * ``num_blocks`` must fit the per-peer signal-pad slots
+      (``max_blocks_per_peer``), since each block signals slot ``block_id``.
+
+    ``numel`` is the **per-peer** element count (the elements that must fit one peer's
+    staging region), not the whole-tensor total. ``numel == 0`` (empty transfer) is
+    allowed; it corrupts nothing.
+    """
+    elem = dtype.itemsize
+    # A per-peer region that is not a whole number of elements would otherwise pass here
+    # and later silently mis-slice the symm-mem buffer.
+    if transport.per_peer_bytes % elem != 0:
+        raise ValueError(
+            f"per_peer_bytes={transport.per_peer_bytes} not a multiple of dtype itemsize "
+            f"{elem} ({dtype}); the per-peer region cannot hold whole elements"
+        )
+    cap_elems = transport.per_peer_bytes // elem
+    if numel > cap_elems:
+        raise ValueError(
+            f"transfer numel={numel} exceeds per-peer capacity={cap_elems} elems "
+            f"(per_peer_bytes={transport.per_peer_bytes}, dtype={dtype}); "
+            f"increase per_peer_bytes at rendezvous"
+        )
+    mbp = transport.max_blocks_per_peer
+    if not (1 <= num_blocks <= mbp):
+        raise ValueError(
+            f"num_blocks={num_blocks} must be in [1, {mbp}] "
+            f"(one signal-pad slot per block per peer)"
+        )


### PR DESCRIPTION
Summary:
Adds the shared CuTe NVLink device substrate composed by collective schedules:

- device_utils and nvl_ops provide separate TAIL data-ready release/acquire operations
  and HEAD slot-free relaxed/volatile operations;
- send_recv owns vectorized copy atoms/leaves, slot send/receive primitives, CUDA DSL
  setup, and analytic tile/slot sizing;
- the substrate is schedule-neutral: callers provide peer ownership, staging addresses,
  barriers, and counter progression.

This diff intentionally exposes no standalone collective API. The public CuTe surface is
kept focused on collective schedules that consume these primitives.

Differential Revision: D112037410


