### PR TITLE
comms/dsl: fused CuTe all_to_all copy schedule + host entry

### DIFF
--- a/comms/dsl/__init__.py
+++ b/comms/dsl/__init__.py
@@ -1,0 +1,23 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""comms/dsl — NVLink all_to_all over PyTorch symmetric memory.
+
+Exposes the user-owned transport contract: :class:`NvlTransport` +
+:func:`nvl_rendezvous` (staging buffer, signal pad, and graph-safe step counters
+created once via a single collective rendezvous), the device-side
+:class:`PeerTable` that a fused schedule indexes by peer in-kernel, and the pre-launch
+:func:`check_transfer` validator.
+"""
+
+from __future__ import annotations
+
+from .transport import check_transfer, nvl_rendezvous, NvlTransport, PeerTable
+
+__all__ = [
+    "NvlTransport",
+    "PeerTable",
+    "nvl_rendezvous",
+    "check_transfer",
+]

--- a/comms/dsl/cute/__init__.py
+++ b/comms/dsl/cute/__init__.py
@@ -1,0 +1,34 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""CuTe collective backend over the shared NVLink transport.
+
+Symbols are exposed lazily so importing the package does not eagerly load the CuTe DSL.
+"""
+
+from importlib import import_module
+from typing import Any
+
+__all__ = [
+    "nvl_ops",
+]
+
+# Exported name -> (submodule, attribute). ``attr is None`` exports the submodule
+# itself (e.g. ``nvl_ops``).
+_LAZY: dict[str, tuple[str, str | None]] = {
+    "nvl_ops": ("nvl_ops", None),
+}
+
+
+def __getattr__(name: str) -> Any:
+    entry = _LAZY.get(name)
+    if entry is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    mod_name, attr = entry
+    mod = import_module(f".{mod_name}", __name__)
+    return mod if attr is None else getattr(mod, attr)
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/comms/dsl/cute/__init__.py
+++ b/comms/dsl/cute/__init__.py
@@ -11,12 +11,13 @@ from importlib import import_module
 from typing import Any
 
 __all__ = [
+    "all_to_all",
     "nvl_ops",
 ]
 
-# Exported name -> (submodule, attribute). ``attr is None`` exports the submodule
-# itself (e.g. ``nvl_ops``).
+# Exported name -> (submodule, attribute). ``attr is None`` exports the submodule.
 _LAZY: dict[str, tuple[str, str | None]] = {
+    "all_to_all": ("a2a.host", "all_to_all"),
     "nvl_ops": ("nvl_ops", None),
 }
 

--- a/comms/dsl/cute/a2a/__init__.py
+++ b/comms/dsl/cute/a2a/__init__.py
@@ -1,0 +1,5 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""CuTe all_to_all collective: device kernels (``schedules``) + host entry (``host``)."""

--- a/comms/dsl/cute/a2a/host.py
+++ b/comms/dsl/cute/a2a/host.py
@@ -1,0 +1,323 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Public host entry for the fused all_to_all in the CuTe DSL (symmetric-memory NVLink).
+
+The host half of the CuTe all_to_all: :func:`all_to_all` (staging copy schedule, writes
+the caller's output). It resolves a ``CuteA2AConfig`` (explicit or the analytic default),
+picks the analytic launch shape (``_pick_tile`` / ``_pick_slots``), and
+``cute.compile`` / launches the device kernel in :mod:`comms.dsl.cute.a2a.schedules`.
+
+Persistent counters plus HEAD/TAIL credits make fixed-geometry calls and CUDA Graph
+replays safe back-to-back. :func:`comms.dsl.tuning_base.check_geometry` rejects staging
+ownership changes on a reused transport. The fused signal-spinning grid must be fully
+co-resident, so :func:`all_to_all` rejects a grid above the conservative capacity rather
+than risking deadlock.
+"""
+
+import logging
+import os
+from importlib import import_module
+from typing import Any
+
+import torch
+from comms.dsl.transport import check_transfer, NvlTransport
+from comms.dsl.tuning_base import check_geometry
+
+# Importing send_recv runs the one-time CuTe setup (CUTE_DSL_ARCH detection +
+# cuda-bindings shim) AND imports cutlass; the os.environ statement below is a barrier so
+# the formatter cannot hoist the cutlass imports above this setup.
+from ..send_recv import (
+    _ensure_cuda_rt_compat,
+    _pick_slots,
+    _pick_tile,
+    _resolve_cute_dsl_arch,
+)
+
+os.environ.setdefault("CUTE_DSL_ARCH", _resolve_cute_dsl_arch())
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.runtime import from_dlpack
+
+from .schedules import _A2ACfg, _launch_a2a
+from .tuning import (
+    _max_coresident_ctas,
+    CUTE_A2A_GEOMETRY_FIELDS,
+    CuteA2AConfig,
+    DEFAULT_A2A_CONFIG,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+_cuda_driver: Any = import_module("cuda.bindings.driver")
+
+_MAX_PORTABLE_CLUSTER: int = 8  # Hopper/Blackwell portable cluster cap
+
+
+# Minimal dtype support: (cutlass dtype, bits-per-element).
+_CUTLASS_DTYPE: dict[torch.dtype, tuple[Any, int]] = {
+    torch.float32: (cutlass.Float32, 32),
+    torch.bfloat16: (cutlass.BFloat16, 16),
+}
+
+_COMPILED: dict[tuple[Any, ...], object] = {}
+
+
+def _env_int(name: str, default: int) -> int:
+    """int() of env ``name`` with a clear error naming the offending knob (dev/tuning knobs)."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        raise ValueError(f"env {name}={raw!r} must be an integer") from None
+
+
+def all_to_all(  # noqa: C901
+    transport: NvlTransport,
+    output: torch.Tensor,
+    input: torch.Tensor,
+    *,
+    config: CuteA2AConfig | None = None,
+) -> None:
+    """Equal-split all_to_all_single via the fused CuTe copy kernel.
+
+    Launch tunables come from ``config`` (a ``CuteA2AConfig``); ``config is None`` uses the
+    analytic adaptive defaults (``DEFAULT_A2A_CONFIG``). ``numel`` must be divisible by the
+    world size (equal split). Input and output must not overlap. Fixed-geometry calls may
+    run back-to-back, but one transport must not execute concurrently on multiple streams.
+    """
+    if not (input.is_cuda and output.is_cuda):
+        raise ValueError("cute a2a requires CUDA input/output tensors")
+    if not (input.is_contiguous() and output.is_contiguous()):
+        raise ValueError("cute a2a requires contiguous input/output tensors")
+    if input.dtype != output.dtype:
+        raise ValueError("cute a2a requires matching input/output dtype")
+    if input.device != output.device:
+        raise ValueError("cute a2a requires input/output on the same CUDA device")
+    if input.device.index != torch.cuda.current_device():
+        raise ValueError(
+            "cute a2a requires the input device to be the current CUDA device"
+        )
+    if input.dtype not in _CUTLASS_DTYPE:
+        raise ValueError(f"cute a2a supports {list(_CUTLASS_DTYPE)}, got {input.dtype}")
+    if input.data_ptr() % 16 or output.data_ptr() % 16:
+        raise ValueError("cute a2a requires 16-byte-aligned input/output tensors")
+    if transport.per_peer_bytes % 16:
+        raise ValueError("cute a2a requires a 16-byte-aligned per-peer staging stride")
+    ws = transport.world_size
+    numel = input.numel()
+    if numel != output.numel():
+        raise ValueError("cute a2a requires input.numel() == output.numel()")
+    span_bytes = numel * input.element_size()
+    if max(input.data_ptr(), output.data_ptr()) < min(
+        input.data_ptr() + span_bytes, output.data_ptr() + span_bytes
+    ):
+        raise ValueError("cute a2a requires non-overlapping input/output tensors")
+    if numel == 0:
+        raise ValueError("cute a2a requires non-empty input/output tensors")
+    if numel % ws != 0:
+        raise ValueError("equal-split requires numel % world_size == 0")
+    chunk = numel // ws
+    cdtype, dbits = _CUTLASS_DTYPE[input.dtype]
+    if config is None:
+        config = DEFAULT_A2A_CONFIG
+    if config.primitive != "copy":
+        raise ValueError(
+            f"primitive {config.primitive!r} is unsupported; only 'copy' is available"
+        )
+    nb = config.num_blocks
+    num_threads, vec = _pick_tile(chunk, dbits, nb * ws)
+    # num_threads: analytic _pick_tile, overridden by a tuned/explicit config (0 = analytic),
+    # an env knob winning over the config; the override cascades into num_tiles / num_slots.
+    if "A2A_CUTE_NT" not in os.environ and config.num_threads:
+        units = chunk // vec
+        nt = min(config.num_threads, units, 1024)  # CUDA threads/block hardware cap
+        while nt > 1 and units % nt:
+            nt -= 1
+        num_threads = nt
+    # Co-residency guard: the fused kernel spins on cross-CTA signals, so all nb*ws CTAs
+    # must be simultaneously resident or a resident CTA can wait forever on a signal from a
+    # never-scheduled one (a systematic deadlock at high world_size, e.g. NVL72). Reject a
+    # grid that provably cannot co-reside rather than hang.
+    props = torch.cuda.get_device_properties(input.device)
+    grid_ctas = nb * ws
+    cap = min(
+        props.multi_processor_count,
+        _max_coresident_ctas(
+            props.multi_processor_count,
+            props.max_threads_per_multi_processor,
+            num_threads,
+        ),
+    )
+    if grid_ctas > cap:
+        raise ValueError(
+            f"cute a2a grid {grid_ctas} CTAs (num_blocks={nb} x world_size={ws}) exceeds "
+            f"the conservative signal-spin CTA capacity {cap} (num_threads={num_threads}) on "
+            f"{props.name}; the signal-spin kernel needs every CTA co-resident or it "
+            "deadlocks -- reduce num_blocks."
+        )
+    num_tiles = chunk // (num_threads * vec)
+    num_slots, tiles_per_slot = _pick_slots(num_tiles, chunk * input.element_size())
+    if "A2A_CUTE_SLOTS" not in os.environ and config.num_slots:
+        want = max(1, min(config.num_slots, num_tiles))
+        tiles_per_slot = (num_tiles + want - 1) // want
+        num_slots = (num_tiles + tiles_per_slot - 1) // tiles_per_slot
+    check_transfer(transport, chunk, input.dtype, nb)
+    cap_elems = transport.per_peer_bytes // input.element_size()
+    mbp = transport.max_blocks_per_peer
+
+    table = transport.endpoints_device()
+    if table.buffer_ptrs.device != input.device:
+        raise ValueError("cute a2a transport and input must be on the same CUDA device")
+    send_ctr, recv_ctr = transport.step_state()
+
+    in2d = from_dlpack(input.view(ws, chunk), assumed_align=16)
+    out2d = from_dlpack(output.view(ws, chunk), assumed_align=16)
+    buf_c = from_dlpack(table.buffer_ptrs, assumed_align=8)
+    sig_c = from_dlpack(table.signal_pad_ptrs, assumed_align=8)
+    send_c = from_dlpack(send_ctr, assumed_align=8)
+    recv_c = from_dlpack(recv_ctr, assumed_align=8)
+    stream = _cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    # Register-blocking unroll for the NVLink store loop (in-flight stores/thread): the
+    # per-SM injection lever. Default to 8 once the per-peer chunk is large enough for the
+    # unrolled body to engage (tiny sizes keep 1); a tuned/explicit config (0 = analytic)
+    # overrides, an env knob winning over it.
+    _u_default = 8 if chunk * input.element_size() >= 64 * 1024 else 1
+    unroll = max(1, _env_int("A2A_CUTE_UNROLL", _u_default))
+    if "A2A_CUTE_UNROLL" not in os.environ and config.unroll:
+        unroll = max(1, config.unroll)
+    # CGA cluster size along the block axis (co-locate the blocks targeting one peer on one
+    # GPC): raises the per-SM NVLink send rate at the >=256MB band but regresses the mid
+    # band, so 0 = analytic default (cluster the large band, else off), -1 = max, >0 =
+    # explicit. Capped at the portable cluster size and collapsed to 1 unless it divides
+    # num_blocks (so a large SM-budget nb runs cluster-off instead of tripping
+    # CUDA_ERROR_INVALID_CLUSTER_SIZE). An env knob wins over the config.
+    _cl_default = 0 if chunk * input.element_size() >= 64 * 1024 * 1024 else 1
+    _cl = _env_int("A2A_CUTE_CLUSTER", config.cluster or _cl_default)
+    cluster = min(nb if _cl <= 0 else _cl, _MAX_PORTABLE_CLUSTER)
+    # cluster_y is capped by the portable cluster size too (like cluster): an uncapped large
+    # value would combine with cluster on the block axis to exceed the hardware cluster cap
+    # and trip CUDA_ERROR_INVALID_CLUSTER_SIZE instead of collapsing gracefully.
+    cluster_y = min(
+        max(1, _env_int("A2A_CUTE_CLUSTER_Y", config.cluster_y)), _MAX_PORTABLE_CLUSTER
+    )
+    if nb % cluster:
+        cluster = 1
+    if ws % cluster_y:
+        cluster_y = 1
+
+    # Verify/commit the geometry baseline now that every OTHER pre-dispatch guard (primitive /
+    # co-residency / check_transfer) has passed, but BEFORE the expensive cute.compile: a call
+    # that will be rejected for a geometry switch should not pay compile cost or populate
+    # _COMPILED for a key that never dispatches. check_geometry does not seed the baseline on
+    # rejection, so this still cannot pollute a reused transport.
+    check_geometry(
+        transport,
+        config,
+        CUTE_A2A_GEOMETRY_FIELDS,
+        resolved=(
+            ("chunk", chunk),
+            ("dtype", input.dtype),
+            ("num_threads", num_threads),
+            ("vec", vec),
+            ("num_slots", num_slots),
+            ("tiles_per_slot", tiles_per_slot),
+        ),
+    )
+    transport._record_a2a_launch_metadata(
+        {
+            "primitive": config.primitive,
+            "grid_ctas": grid_ctas,
+            "num_blocks": nb,
+            "num_threads": num_threads,
+            "vec": vec,
+            "num_slots": num_slots,
+            "tiles_per_slot": tiles_per_slot,
+            "unroll": unroll,
+            "cluster": cluster,
+            "cluster_y": cluster_y,
+            "per_peer_bytes": transport.per_peer_bytes,
+        }
+    )
+
+    key = (
+        "a2a",
+        # Arch is baked into the compiled kernel: a runtime CUTE_DSL_ARCH change must not reuse
+        # a kernel built for a different arch (matches send_recv's cache key).
+        os.environ.get("CUTE_DSL_ARCH"),
+        nb,
+        num_threads,
+        vec,
+        input.dtype,
+        ws,
+        chunk,
+        cap_elems,
+        mbp,
+        num_slots,
+        tiles_per_slot,
+        unroll,
+        cluster,
+        cluster_y,
+    )
+    compiled: Any = _COMPILED.get(key)
+    if compiled is None:
+        _ensure_cuda_rt_compat()  # lazy: shim cuda-bindings before this cute.compile path
+        logger.info(
+            "compiling cute a2a: ws=%s chunk=%s nb=%s nt=%s vec=%s",
+            ws,
+            chunk,
+            nb,
+            num_threads,
+            vec,
+        )
+        # The cfg is UNPACKED into individual constexpr args at the cute.compile boundary --
+        # never passed as a single Constexpr object (cute's tree-walk would crash on dtype).
+        cfg = _A2ACfg(
+            num_blocks=nb,
+            num_threads=num_threads,
+            vec=vec,
+            dtype=cdtype,
+            dbits=dbits,
+            world_size=ws,
+            local_rank=transport.local_rank,
+            chunk=chunk,
+            cap_elems=cap_elems,
+            mbp=mbp,
+            num_slots=num_slots,
+            tiles_per_slot=tiles_per_slot,
+            unroll=unroll,
+            cluster=cluster,
+            cluster_y=cluster_y,
+        )
+        compiled = cute.compile(
+            _launch_a2a,
+            in2d,
+            out2d,
+            buf_c,
+            sig_c,
+            send_c,
+            recv_c,
+            cfg.num_blocks,
+            cfg.num_threads,
+            cfg.vec,
+            cfg.dtype,
+            cfg.dbits,
+            cfg.world_size,
+            cfg.local_rank,
+            cfg.chunk,
+            cfg.cap_elems,
+            cfg.mbp,
+            cfg.num_slots,
+            cfg.tiles_per_slot,
+            cfg.unroll,
+            cfg.cluster,
+            cfg.cluster_y,
+            stream,
+        )
+        _COMPILED[key] = compiled
+    compiled(in2d, out2d, buf_c, sig_c, send_c, recv_c, stream)

--- a/comms/dsl/cute/a2a/schedules.py
+++ b/comms/dsl/cute/a2a/schedules.py
@@ -1,0 +1,305 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# pyre-ignore-all-errors[6, 35, 58]: @cute.kernel / @cute.jit constexpr params are
+# annotated cutlass.Constexpr; pyre models that as Constexpr[Any] and rejects the
+# arithmetic / range() / dataclass-field uses the kernel bodies do on them -- the values
+# are real compile-time ints at trace time.
+
+"""Device kernels for the fused all_to_all in the CuTe DSL (symmetric-memory NVLink).
+
+The on-device half of the CuTe all_to_all: the fused ``@cute.kernel`` copy schedule
+(``_a2a_kernel``), its ``@cute.jit`` launcher (``_launch_a2a``), and the host-side
+launch-constant bundle ``_A2ACfg``. The tile/slot sizing (``_pick_tile`` /
+``_pick_slots``) and the copy leaf / slot primitives are shared from
+``cute/send_recv.py``. The public host entry that resolves a config and
+``cute.compile`` / launches this kernel lives in :mod:`comms.dsl.cute.a2a.host`.
+
+Each ``(peer, block)`` program streams its sub-chunk to the peer's staging over NVLink,
+publishes a data-ready signal, then drains the peer's matching staging slot into the
+output. Device-side peer addressing uses ``cute.make_ptr`` over the transport's int64
+peer table, so a single fused launch selects the peer on device via ``block_idx``
+instead of one launch per peer.
+
+Graph-safe: signalling uses the transport's persistent monotonic per-(peer, block) step
+counters, so a transport is reusable across calls / CUDA-graph replays (with a cross-rank
+sync between reused calls; see :func:`comms.dsl.cute.a2a.host.all_to_all`). The slot
+pipeline overlaps send/drain on top of a single-shot stage-then-drain.
+
+Scope: equal-split ``all_to_all_single``, identity copy (bf16/fp32), ``numel`` divisible
+by ``world_size`` and the per-(peer, block) tile by the thread count.
+"""
+
+# Annotations are evaluated eagerly (no ``from __future__ import annotations``): the
+# @cute.kernel / @cute.jit launchers classify their compile-time params via the real
+# ``cutlass.Constexpr`` annotation object, which inspect.getfullargspec only exposes when
+# annotations are NOT stringized -- stringized annotations leave cute unable to tell a
+# constexpr from a dynamic arg and it mis-marshals the dtype.
+import os
+from dataclasses import dataclass
+from typing import Any
+
+# Importing send_recv runs its one-time setup (CUTE_DSL_ARCH detection +
+# cuda-bindings shim) AND imports cutlass; the os.environ statement below is a
+# barrier so the formatter cannot hoist the cutlass imports above this setup.
+from ..send_recv import _resolve_cute_dsl_arch
+
+os.environ.setdefault("CUTE_DSL_ARCH", _resolve_cute_dsl_arch())
+
+import cutlass
+import cutlass.cute as cute
+
+
+@dataclass
+class _A2ACfg:
+    """Host-side bundle of the fused all_to_all launch constants, for readability at the
+    call site. It is NEVER passed as a single ``cutlass.Constexpr`` -- cute's tree-walk
+    would call ``__extract_mlir_values__`` on the ``dtype`` (a cutlass NumericMeta) and
+    crash on the tiny/odd-chunk paths. Always UNPACK it into individual positional args at
+    the ``cute.compile`` / ``.launch`` boundary."""
+
+    num_blocks: int
+    num_threads: int
+    vec: int
+    dtype: Any
+    dbits: int
+    world_size: int
+    local_rank: int
+    chunk: int
+    cap_elems: int
+    mbp: int
+    num_slots: int
+    tiles_per_slot: int
+    unroll: int = 1
+    cluster: int = 1
+    cluster_y: int = 1
+
+
+from .. import nvl_ops  # noqa: E402
+
+# The shared CuTe send/recv substrate (copy leaves, per-slot credit primitives, and
+# tile/slot sizing) lives in ``cute/send_recv.py``. This schedule composes those helpers
+# and owns the collective-specific peer mapping, barriers, and counter progression.
+from ..send_recv import _copy_atom, _copy_u, _recv_slot, _send_slot  # noqa: E402
+
+
+@cute.jit
+def _launch_a2a(
+    in2d,
+    out2d,
+    buf_ptrs,
+    sig_ptrs,
+    send_ctr,
+    recv_ctr,
+    num_blocks: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    vec: cutlass.Constexpr,
+    dtype: cutlass.Constexpr,
+    dbits: cutlass.Constexpr,
+    world_size: cutlass.Constexpr,
+    local_rank: cutlass.Constexpr,
+    chunk: cutlass.Constexpr,
+    cap_elems: cutlass.Constexpr,
+    mbp: cutlass.Constexpr,
+    num_slots: cutlass.Constexpr,
+    tiles_per_slot: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+    cluster: cutlass.Constexpr,
+    cluster_y: cutlass.Constexpr,
+    stream,
+) -> None:
+    # in2d / out2d are [world_size, chunk] views; per-peer chunk = row peer.
+    # CGA cluster dims (None == off); host guarantees the grid is divisible.
+    cl = (
+        [cluster, cluster_y, 1]
+        if cutlass.const_expr(cluster > 1 or cluster_y > 1)
+        else None
+    )
+    _a2a_kernel(
+        in2d,
+        out2d,
+        buf_ptrs,
+        sig_ptrs,
+        send_ctr,
+        recv_ctr,
+        dtype,
+        vec,
+        dbits,
+        num_blocks,
+        num_threads,
+        world_size,
+        local_rank,
+        chunk,
+        cap_elems,
+        mbp,
+        num_slots,
+        tiles_per_slot,
+        unroll,
+    ).launch(
+        grid=(num_blocks, world_size, 1),
+        block=(num_threads, 1, 1),
+        cluster=cl,
+        stream=stream,
+    )
+
+
+@cute.kernel
+def _a2a_kernel(  # noqa: C901
+    in2d,
+    out2d,
+    buf_ptrs,
+    sig_ptrs,
+    send_ctr,
+    recv_ctr,
+    dtype: cutlass.Constexpr,
+    vec: cutlass.Constexpr,
+    dbits: cutlass.Constexpr,
+    num_blocks: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    world_size: cutlass.Constexpr,
+    local_rank: cutlass.Constexpr,
+    chunk: cutlass.Constexpr,
+    cap_elems: cutlass.Constexpr,
+    mbp: cutlass.Constexpr,
+    num_slots: cutlass.Constexpr,
+    tiles_per_slot: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+) -> None:
+    tidx = cute.arch.thread_idx()[0]
+    b = cute.arch.block_idx()[0]
+    peer = cute.arch.block_idx()[1]
+    u = unroll
+    nb = num_blocks
+
+    # Vectorized copy: each thread moves VEC contiguous elements per copy, so the NVLink
+    # store is a vectorized st.global (up to 128-bit) instead of a scalar store -- the
+    # single biggest copy-bandwidth lever. (num_threads, VEC) are chosen per chunk by the
+    # host (`_pick_tile`) so any size tiles exactly (VEC drops to scalar for small/odd
+    # chunks, covering the whole 32B-2GB ladder with no tail). Tiler = num_threads*VEC.
+    copy_atom = _copy_atom(dtype, vec, dbits)
+    tiled_copy = cute.make_tiled_copy_tv(
+        copy_atom, cute.make_layout(num_threads), cute.make_layout(vec)
+    )
+    thr_copy = tiled_copy.get_slice(tidx)
+
+    # This peer's contiguous input/output chunk (row `peer` of the [ws, chunk] views).
+    in_chunk = in2d[(peer, None)]
+    out_chunk = out2d[(peer, None)]
+    tiler = cute.make_layout(num_threads * vec)
+    g_in = cute.zipped_divide(in_chunk, tiler)
+    g_out = cute.zipped_divide(out_chunk, tiler)
+    # Tile count from the actual divided layout (the authoritative value): the host also
+    # derives it for _pick_slots, but recomputing here keeps the kernel's tile bound tied
+    # to its own zipped_divide and never out of step with a host value.
+    num_tiles = cute.size(g_in, mode=[1])
+
+    # CuTe forbids early `return` in a kernel, so the diagonal (local) and the comm path
+    # are an if/else (peer is a runtime block index, not constexpr).
+    if peer == local_rank:
+        # Diagonal: local copy in_chunk -> out_chunk (no comm). Grid-stride `while` stays
+        # inline (CuTe captures control flow only here); the unrolled body is `_copy_u`.
+        t = b
+        while t + (u - 1) * nb < num_tiles:
+            _copy_u(thr_copy, copy_atom, g_in, g_out, t, u, num_blocks)
+            t += u * nb
+        while t < num_tiles:
+            _copy_u(thr_copy, copy_atom, g_in, g_out, t, 1, num_blocks)
+            t += nb
+    else:
+        # --- device-side symm-mem addressing for this peer ---
+        peer_buf_addr = buf_ptrs[peer]
+        my_buf_addr = buf_ptrs[local_rank]
+        peer_sig_addr = sig_ptrs[peer]
+        my_sig_addr = sig_ptrs[local_rank]
+
+        # Staging regions (elem layout [chunk]); sender `s` occupies the byte slot
+        # `s * cap_elems * elem_bytes` in a rank's buffer. SEND -> my sender slot inside
+        # peer's buffer; RECV -> peer's sender slot inside my buffer (int64 byte addrs).
+        elem_bytes = dbits // 8
+        cap_bytes = cap_elems * elem_bytes
+        send_addr = peer_buf_addr + local_rank * cap_bytes
+        recv_addr = my_buf_addr + peer * cap_bytes
+        send_ptr = cute.make_ptr(
+            dtype, send_addr, cute.AddressSpace.gmem, assumed_align=16
+        )
+        recv_ptr = cute.make_ptr(
+            dtype, recv_addr, cute.AddressSpace.gmem, assumed_align=16
+        )
+        send_region = cute.make_tensor(send_ptr, cute.make_layout(chunk))
+        recv_region = cute.make_tensor(recv_ptr, cute.make_layout(chunk))
+        g_send = cute.zipped_divide(send_region, tiler)
+        g_recv = cute.zipped_divide(recv_region, tiler)
+
+        step_idx = peer * mbp + b
+        start_send = send_ctr[step_idx]
+        start_recv = recv_ctr[step_idx]
+        # This (peer, block)'s own signal counters: block b sends ITS tile subset to the
+        # peer and signals its own counter; the peer's block b waits the matching counter
+        # and drains the SAME subset -- so the pipeline is independent across blocks.
+        tail_remote = peer_sig_addr + (local_rank * mbp + b) * 8
+        tail_local = my_sig_addr + (peer * mbp + b) * 8
+        head_off = world_size * mbp
+        head_remote = peer_sig_addr + (head_off + local_rank * mbp + b) * 8
+        head_local = my_sig_addr + (head_off + peer * mbp + b) * 8
+
+        if tidx == 0:
+            nvl_ops.wait_free(head_local, start_send)
+        cute.arch.barrier()
+
+        # Slot pipeline, composed from the shared per-slot primitives: send slot s (NVLink
+        # store + TAIL) then drain slot s-1 (local HBM) so the still-in-flight stores of
+        # slot s overlap the drain. Disjoint regions (my-staging drain vs peer-staging
+        # store) -> no false dependency. num_slots is constexpr so this loop unrolls.
+        for s in range(num_slots):
+            _send_slot(
+                thr_copy,
+                copy_atom,
+                g_in,
+                g_send,
+                tail_remote,
+                start_send,
+                b,
+                tidx,
+                s,
+                tiles_per_slot,
+                num_tiles,
+                num_blocks,
+                unroll,
+            )
+            if s >= 1:
+                _recv_slot(
+                    thr_copy,
+                    copy_atom,
+                    g_recv,
+                    g_out,
+                    tail_local,
+                    start_recv,
+                    b,
+                    tidx,
+                    s - 1,
+                    tiles_per_slot,
+                    num_tiles,
+                    num_blocks,
+                    unroll,
+                )
+        # Drain the final slot (no later send to overlap it).
+        _recv_slot(
+            thr_copy,
+            copy_atom,
+            g_recv,
+            g_out,
+            tail_local,
+            start_recv,
+            b,
+            tidx,
+            num_slots - 1,
+            tiles_per_slot,
+            num_tiles,
+            num_blocks,
+            unroll,
+        )
+        cute.arch.barrier()
+        if tidx == 0:
+            nvl_ops.signal_free(head_remote, start_recv + num_slots)
+            send_ctr[step_idx] = start_send + num_slots
+            recv_ctr[step_idx] = start_recv + num_slots

--- a/comms/dsl/cute/a2a/tuning.py
+++ b/comms/dsl/cute/a2a/tuning.py
@@ -1,0 +1,82 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# pyre-ignore-all-errors[35]: pyre mis-flags this frozen-dataclass-subclass's fields as
+# illegal annotation targets; the dataclass is correct and runtime-validated.
+
+"""Tunable Config for the CuTe all_to_all copy schedule.
+
+A frozen ``CuteA2AConfig`` of launch tunables + a safe ``DEFAULT_A2A_CONFIG``. A field
+left at its ``0`` sentinel means "use the analytic adaptive pick" (``_pick_tile`` /
+``_pick_slots`` in ``a2a.schedules`` / ``cute.send_recv``), so the default config
+reproduces the size-aware analytic defaults exactly. The public host entry accepts an
+explicit config or falls back to ``DEFAULT_A2A_CONFIG``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ...tuning_base import BaseTunableConfig as _BaseConfig
+
+
+@dataclass(frozen=True)
+class CuteA2AConfig(_BaseConfig):
+    """Launch tunables for the copy schedule (perf axis only).
+
+    ``num_blocks`` is the block count per peer (device grid = ``world_size *
+    num_blocks``; one CTA per ``(peer, block)`` streams its sub-chunk). The remaining
+    knobs default to ``0`` = "use the analytic adaptive pick", so the default config
+    reproduces the size-aware analytic defaults exactly:
+
+    * ``num_threads`` -- threads/CTA (``0`` -> ``_pick_tile``); the per-thread vector
+      width is always the widest the chunk allows and is not independently tuned.
+    * ``num_slots`` -- send/drain pipeline slots (``0`` -> ``_pick_slots``);
+      ``tiles_per_slot`` is derived from it.
+    * ``unroll`` -- register-blocking unroll of the NVLink store loop (``0`` ->
+      size-aware default, 8 once the per-peer chunk is large enough else 1).
+    * ``cluster`` -- CGA thread-block cluster size along the block axis (``0`` ->
+      size-aware default; ``-1`` = max = ``num_blocks``; ``>0`` = explicit).
+    * ``cluster_y`` -- CGA cluster size along the peer (grid-y) axis; ``1`` = off
+      (the default). Collapsed to 1 unless it divides ``world_size``.
+
+    ``primitive`` selects the transfer schedule; this revision supports only ``"copy"``
+    (the slot-pipelined per-thread staging copy).
+    """
+
+    num_blocks: int = 8
+    num_threads: int = 0
+    num_slots: int = 0
+    unroll: int = 0
+    primitive: str = "copy"
+    cluster: int = 0
+    cluster_y: int = 1
+
+
+# Fields whose value changes the physical staging geometry (grid partition / output
+# semantics) rather than launch-only packing; switching one on a reused transport is the
+# documented hazard the runtime geometry guard catches. The tile/slot/unroll/cluster knobs
+# are launch-only and free to sweep.
+CUTE_A2A_GEOMETRY_FIELDS: frozenset[str] = frozenset({"num_blocks", "primitive"})
+
+# Safe analytic default (every adaptive knob at its 0 sentinel).
+DEFAULT_A2A_CONFIG: CuteA2AConfig = CuteA2AConfig()
+
+# Max thread-blocks that can be co-resident per SM (Volta+ hardware cap); the true limit
+# is the min of this and the thread / register / smem occupancy.
+_MAX_BLOCKS_PER_SM: int = 32
+
+
+def _max_coresident_ctas(sm_count: int, threads_per_sm: int, num_threads: int) -> int:
+    """Optimistic upper bound on CTAs that can be simultaneously resident on the device.
+
+    The fused a2a kernel spins on cross-CTA signals, so EVERY launched CTA must be
+    co-resident or a resident CTA can wait forever on a signal from a never-scheduled one
+    -- a systematic deadlock at high world_size (e.g. NVL72). This is the thread-limited
+    occupancy bound (blocks/SM = ``threads_per_sm // num_threads``, capped at the hardware
+    ``_MAX_BLOCKS_PER_SM``) times the SM count. It ignores register / smem pressure, so it
+    is a ceiling: a grid above it definitely cannot co-reside (the host guard rejects it),
+    while a grid below it may still be occupancy-limited in practice.
+    """
+    blocks_per_sm = min(_MAX_BLOCKS_PER_SM, threads_per_sm // max(1, num_threads))
+    return sm_count * max(1, blocks_per_sm)

--- a/comms/dsl/cute/device_utils.py
+++ b/comms/dsl/cute/device_utils.py
@@ -1,0 +1,99 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Inline-PTX signalling primitives for the CuTe backend.
+
+Cross-rank int64 signalling over symmetric memory via ``@dsl_user_op`` and
+``llvm.inline_asm``. TAIL data-ready publication uses release/acquire ordering; HEAD
+slot-free credits use a relaxed store and volatile poll because they transfer ownership
+without publishing payload.
+"""
+
+from __future__ import annotations
+
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.typing import Int64
+from cutlass.cutlass_dsl import dsl_user_op
+
+
+@dsl_user_op
+def wait_ge(addr: Int64, target: Int64, *, loc=None, ip=None) -> None:
+    """Acquire-poll int64 until ``*addr >= target`` (local read)."""
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int64(target).ir_value(loc=loc, ip=ip)],
+        """{
+            .reg .u64   %tmp64;
+            .reg .pred  %p;
+            _fw_wait_ge:
+                ld.global.acquire.sys.b64 %tmp64, [$0];
+                setp.lt.u64 %p, %tmp64, $1;
+                @%p bra _fw_wait_ge;
+        }""",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def wait_ge_volatile(addr: Int64, target: Int64, *, loc=None, ip=None) -> None:
+    """Volatile-poll until ``*addr >= target`` for a HEAD slot-free credit."""
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int64(target).ir_value(loc=loc, ip=ip)],
+        """{
+            .reg .u64   %tmp64;
+            .reg .pred  %p;
+            _fw_wait_ge_vol:
+                ld.volatile.global.u64 %tmp64, [$0];
+                setp.lt.u64 %p, %tmp64, $1;
+                @%p bra _fw_wait_ge_vol;
+        }""",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def remote_store_release_i64(addr: Int64, val: Int64, *, loc=None, ip=None) -> None:
+    """Publish prior memory accesses with one system-scope release store."""
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int64(val).ir_value(loc=loc, ip=ip)],
+        """{
+            st.global.release.sys.b64 [$0], $1;
+        }""",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def remote_store_i64_relaxed(addr: Int64, val: Int64, *, loc=None, ip=None) -> None:
+    """Return a HEAD slot-free credit without payload-publication ordering."""
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int64(val).ir_value(loc=loc, ip=ip)],
+        """{
+            st.global.relaxed.sys.b64 [$0], $1;
+        }""",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )

--- a/comms/dsl/cute/nvl_ops.py
+++ b/comms/dsl/cute/nvl_ops.py
@@ -1,0 +1,52 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""NVLink device transport-ops for the CuTe send/recv seam.
+
+The concrete data movement plus TAIL data-ready and HEAD slot-free operations for the
+symmetric-memory transport, in cute-native signatures.
+"""
+
+from __future__ import annotations
+
+import cutlass.cute as cute
+
+from .device_utils import (
+    remote_store_i64_relaxed,
+    remote_store_release_i64,
+    wait_ge,
+    wait_ge_volatile,
+)
+
+
+def put(atom, frag, dst_part):
+    """Write a produced fragment into the peer's staging partition (remote store)."""
+    cute.copy(atom, frag, dst_part)
+
+
+def get(atom, src_part):
+    """Read a received tile from the local staging partition into a fragment."""
+    frag = cute.make_fragment_like(src_part)
+    cute.copy(atom, src_part, frag)
+    return frag
+
+
+def signal(addr, seq):
+    """Publish "data ready" to the peer with a system-scope release store."""
+    remote_store_release_i64(addr, seq)
+
+
+def wait(addr, seq):
+    """Wait until the peer published data-ready ``seq`` with an acquire poll."""
+    wait_ge(addr, seq)
+
+
+def signal_free(addr, seq):
+    """Return HEAD slot ownership with a relaxed remote store."""
+    remote_store_i64_relaxed(addr, seq)
+
+
+def wait_free(addr, seq):
+    """Wait for a HEAD slot-free credit with a volatile poll."""
+    wait_ge_volatile(addr, seq)

--- a/comms/dsl/cute/send_recv.py
+++ b/comms/dsl/cute/send_recv.py
@@ -1,0 +1,301 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# pyre-ignore-all-errors[6, 35, 58]: @cute.kernel / @cute.jit constexpr params are
+# annotated cutlass.Constexpr; pyre models that as Constexpr[Any] and rejects the
+# arithmetic / range() / dataclass-field uses the kernel bodies do on them -- the values
+# are real compile-time ints at trace time.
+
+"""Shared CuTe device substrate for collectives over ``NvlTransport``.
+
+The module owns vectorized copy leaves, per-slot send/receive primitives, CUDA DSL setup,
+and analytic tile/slot sizing. Collective schedules compose these helpers and supply their
+own peer ownership, address mapping, barriers, and counter progression.
+"""
+
+# NOTE: do NOT add ``from __future__ import annotations`` here. The @cute.jit
+# functions below (``_send_slot`` / ``_recv_slot``) classify their compile-time params via the REAL
+# ``cutlass.Constexpr`` annotation object, which ``inspect.getfullargspec`` only exposes
+# when annotations are NOT stringized -- stringizing makes cute marshal a constexpr dtype
+# as a dynamic arg and crash (Float32.__c_pointers__ TypeError).
+import logging
+import os
+from importlib import import_module
+from typing import Any
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _resolve_cute_dsl_arch() -> str:
+    """``sm_<major><minor>[a]`` for the local device; honors CUTE_DSL_ARCH."""
+    explicit = os.environ.get("CUTE_DSL_ARCH")
+    if explicit:
+        return explicit
+    try:
+        import torch as _torch
+
+        major, minor = _torch.cuda.get_device_capability(_torch.cuda.current_device())
+    except (ImportError, RuntimeError, AssertionError) as e:
+        logger.warning(
+            "could not detect CUDA device capability (%s); "
+            "defaulting CUTE_DSL_ARCH to sm_90a",
+            e,
+        )
+        return "sm_90a"
+    if (major, minor) == (9, 0):
+        return "sm_90a"
+    if (major, minor) in {(10, 0), (10, 1)}:
+        return "sm_100a"
+    if (major, minor) == (8, 0):
+        return "sm_80"
+    return f"sm_{major}{minor}"
+
+
+# Must be set before importing cutlass.cute.
+os.environ.setdefault("CUTE_DSL_ARCH", _resolve_cute_dsl_arch())
+
+import cutlass
+import cutlass.cute as cute
+
+from . import nvl_ops
+
+_cuda_rt: Any = import_module("cuda.bindings.runtime")
+
+
+def _ensure_cuda_rt_compat() -> None:
+    """Idempotently shim cuda-bindings symbols the cutlass DSL JIT executor expects.
+
+    Some cuda-bindings versions lack ``cudaLibrary_t`` / ``cudaLibraryUnload``, so kernel
+    compilation cannot load the cuda library. This patches them in on first use (NOT at
+    import scope, per the don't-mutate-imported-module-attributes-at-import rule).
+    The installed ``cudaLibraryUnload`` is a process-wide no-op, so it can leak library
+    handles for OTHER callers of cuda.bindings.runtime -- we log a warning when installing
+    it so that side effect is visible rather than silent. Invoked lazily from the JIT paths
+    (just before cute.compile)."""
+    if hasattr(_cuda_rt, "cudaLibrary_t"):
+        return
+
+    class _cudaLibrary_t:
+        __slots__ = ("value",)
+
+        def __init__(self, value: int = 0) -> None:
+            self.value = value
+
+    logger.warning(
+        "installing process-wide cuda.bindings.runtime shim (cudaLibrary_t + "
+        "no-op cudaLibraryUnload); cudaLibraryUnload becomes a no-op for ALL callers"
+    )
+    _cuda_rt.cudaLibrary_t = _cudaLibrary_t
+    _cuda_rt.cudaLibraryUnload = lambda lib: (_cuda_rt.cudaError_t(0),)
+
+
+# ---------------------------------------------------------------------------
+# Shared CuTe send/recv substrate: the vectorized copy leaf + the per-slot
+# credit-ring primitives (``_send_slot`` / ``_recv_slot``). This is the backend
+# substrate home. A schedule composes these primitives by supplying its own per-peer
+# region/offset math, so a perf/codegen change here lands once and every composer
+# inherits it. The dependency is one-way: a composer imports these from here; nothing
+# here imports a schedule.
+# ---------------------------------------------------------------------------
+
+
+def _copy_atom(dtype: Any, vec: int, dbits: int):
+    """The vectorized gmem copy atom every schedule shares: VEC contiguous elems per
+    thread per copy, so the NVLink store is a vectorized st.global (up to 128-bit)
+    instead of a scalar store -- the single biggest copy-bandwidth lever (mirrors the
+    Triton 128-bit-store fix). The TV-tiled copy is built per schedule on top of it."""
+    return cute.make_copy_atom(
+        cute.nvgpu.CopyUniversalOp(),
+        dtype,
+        num_bits_per_copy=vec * dbits,
+    )
+
+
+def _copy_u(thr_copy, copy_atom, g_src, g_dst, t, n, num_blocks):
+    """Copy ``n`` consecutive (stride ``num_blocks``) tiles starting at ``t``:
+    issue all ``n`` loads, then all ``n`` stores, so ``n`` NVLink stores are in
+    flight per thread (mirrors NCCL's ``COLL_UNROLL`` -- the per-SM-extraction
+    lever Triton/TLX could not use because the wider per-thread footprint
+    spilled). STRAIGHT-LINE only (``n`` is constexpr; no control flow) so it is
+    safe to call from the kernel body -- CuTe only rewrites control flow in the
+    ``@cute.kernel`` function itself, so the grid-stride ``while`` stays inline
+    there. Correctness is unroll-independent: src and dst share one ``thr_copy``
+    partition, so any order copies the same elements."""
+    nb = num_blocks
+    frags = [
+        nvl_ops.get(copy_atom, thr_copy.partition_S(g_src[(None, t + i * nb)]))
+        for i in range(n)
+    ]
+    for i in range(n):
+        nvl_ops.put(
+            copy_atom, frags[i], thr_copy.partition_D(g_dst[(None, t + i * nb)])
+        )
+
+
+@cute.jit
+def _send_slot(
+    thr_copy,
+    copy_atom,
+    g_in,
+    g_send,
+    tail_remote,
+    start_send,
+    b,
+    tidx,
+    s: cutlass.Constexpr,
+    tiles_per_slot: cutlass.Constexpr,
+    num_tiles: cutlass.Constexpr,
+    num_blocks: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+) -> None:
+    """One credit-ring SEND slot: stage slot ``s`` into the peer's staging over NVLink,
+    then publish its data-ready TAIL.
+
+    Extracted as a ``@cute.jit`` device sub-function so every schedule composes the SAME
+    slot primitive. It carries the runtime grid-stride ``while`` + barrier + leader
+    signal, so it MUST be ``@cute.jit`` -- a plain helper would not get CuTe's
+    control-flow rewrite (see ``_copy_u``)."""
+    u = unroll
+    nb = num_blocks
+    s_lo = s * tiles_per_slot
+    s_hi = min((s + 1) * tiles_per_slot, num_tiles)
+    t = s_lo + b
+    while t + (u - 1) * nb < s_hi:
+        _copy_u(thr_copy, copy_atom, g_in, g_send, t, u, num_blocks)
+        t += u * nb
+    while t < s_hi:
+        _copy_u(thr_copy, copy_atom, g_in, g_send, t, 1, num_blocks)
+        t += nb
+    cute.arch.barrier()
+    if tidx == 0:
+        # data-ready for slots 0..s (monotonic counter).
+        nvl_ops.signal(tail_remote, start_send + s + 1)
+
+
+@cute.jit
+def _recv_slot(
+    thr_copy,
+    copy_atom,
+    g_recv,
+    g_out,
+    tail_local,
+    start_recv,
+    b,
+    tidx,
+    s: cutlass.Constexpr,
+    tiles_per_slot: cutlass.Constexpr,
+    num_tiles: cutlass.Constexpr,
+    num_blocks: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+) -> None:
+    """One credit-ring RECV slot: wait the peer's data-ready TAIL for slot ``s``, then
+    drain its matching staging slot into the output. Symmetric twin of :func:`_send_slot`;
+    same ``@cute.jit`` rationale."""
+    u = unroll
+    nb = num_blocks
+    p_lo = s * tiles_per_slot
+    p_hi = min((s + 1) * tiles_per_slot, num_tiles)
+    if tidx == 0:
+        nvl_ops.wait(tail_local, start_recv + s + 1)
+    cute.arch.barrier()
+    t = p_lo + b
+    while t + (u - 1) * nb < p_hi:
+        _copy_u(thr_copy, copy_atom, g_recv, g_out, t, u, num_blocks)
+        t += u * nb
+    while t < p_hi:
+        _copy_u(thr_copy, copy_atom, g_recv, g_out, t, 1, num_blocks)
+        t += nb
+
+
+# ---------------------------------------------------------------------------
+# Pipelined credit-ring send/recv collective (graph-safe), composed from the shared
+# _send_slot / _recv_slot substrate above. Single-peer-pair whole-buffer transfer,
+# keeping the slot send/drain overlap. uni (send-only / recv-only) and bidir are selected
+# by the do_send / do_recv constexprs. Graph-safe via the transport's persistent monotonic
+# counters + the symmetric-memory signal pad.
+# ---------------------------------------------------------------------------
+
+
+# Analytic tile / slot sizing for the pipelined send/recv geometry. Owned here so the
+# send/recv collective is self-contained; a fused multi-peer schedule reuses these.
+_SATURATION_THREADS: int = 32768
+_MIN_TILES: int = 32  # keep at least this many tiles so the pipeline has slots
+# Target number of pipeline slots per (peer, block) once pipelining is on. The
+# send/drain overlap approaches the send-only NVLink ceiling as slots grow (the
+# un-overlapped tail is one slot's drain), with diminishing returns vs per-slot
+# signal overhead; ~8 is the measured knee on H100. Overridable for the autotuner.
+_NUM_SLOTS: int = 8
+# Only pipeline when the per-peer chunk is large enough that the bandwidth-bound
+# send/drain overlap win beats the per-slot sync overhead. Below this the message
+# is latency-bound and a single shot (no extra barriers/signals/waits) is faster.
+# Measured on 8xH100: chunks <4MB regress under pipelining, >=8MB chunks gain
+# ~15-25%. Gated on bytes, not tiles -- 16MB and 64MB land at the same tile count
+# but opposite optima, so absolute size is the right signal.
+_MIN_PIPELINE_CHUNK_BYTES: int = 4 * 1024 * 1024
+# Per-peer chunk at/above which the deep (8-slot) run-ahead beats the shallow
+# (4-slot) one -- below it the deeper pipeline's per-slot sub-chunk is too small and
+# the sync overhead dominates (GB300, unroll=8). 64 MiB chunk.
+_DEEP_PIPELINE_CHUNK_BYTES: int = 64 * 1024 * 1024
+
+
+def _pick_tile(chunk: int, dbits: int, total_ctas: int) -> tuple[int, int]:
+    """Pick (num_threads, vec) so the per-(peer,block) chunk tiles EXACTLY.
+
+    Vec is the widest 128-bit-down-to-scalar copy the chunk allows (vec drops to 1
+    for tiny/odd chunks, so the whole 32B-2GB ladder tiles with no tail). Threads
+    are chosen CTA-aware: ``_SATURATION_THREADS / total_ctas`` (more warps per CTA
+    when few CTAs are in the SM budget), bounded so a small chunk keeps
+    ``_MIN_TILES`` tiles, floored so a chunk with real work is not under-threaded,
+    and capped at the 1024 hardware limit. An explicit ``A2A_CUTE_NT`` env overrides
+    the analytic pick (for sweeps / the autotuner).
+    """
+    env_nt = os.environ.get("A2A_CUTE_NT")
+    for vbits in (128, 64, 32, 16):
+        if vbits < dbits:
+            continue
+        vec = vbits // dbits
+        if chunk % vec:
+            continue
+        units = chunk // vec  # number of vectors to copy across the whole chunk
+        if env_nt is not None:
+            # Floor at 1 and cap at 1024 (mirrors the analytic branch): A2A_CUTE_NT="0" would
+            # otherwise return nt=0 and divide-by-zero in the caller's num_tiles math, and
+            # A2A_CUTE_NT>1024 would exceed the CUDA per-block thread cap and fail the launch.
+            nt = max(1, min(int(env_nt), units, 1024))
+        else:
+            nt = max(1, _SATURATION_THREADS // max(1, total_ctas))
+            nt = min(nt, max(1, units // _MIN_TILES))  # leave enough tiles
+            nt = min(nt, 1024)  # hardware cap
+            nt = max(nt, min(256, units))  # don't under-thread a chunk with work
+        nt = min(nt, units)
+        while nt > 1 and units % nt:
+            nt -= 1
+        # Final floor: the `min(nt, units)` above re-introduces nt=0 when units==0
+        # (chunk==0), which would divide-by-zero in the caller's num_tiles math.
+        return max(1, nt), vec
+    return 1, 1  # scalar fallback (chunk not a multiple of any vec width)
+
+
+def _pick_slots(num_tiles: int, chunk_bytes: int) -> tuple[int, int]:
+    """Split ``num_tiles`` into (num_slots, tiles_per_slot) for the send/drain
+    pipeline. Returns ``(1, num_tiles)`` (single shot, no pipeline) for per-peer
+    chunks below ``_MIN_PIPELINE_CHUNK_BYTES`` -- latency-bound sizes are faster
+    without the per-slot sync. An explicit ``A2A_CUTE_SLOTS`` env forces the slot
+    count (for sweeps / the autotuner)."""
+    if num_tiles <= 1:
+        return 1, 1
+    env_slots = os.environ.get("A2A_CUTE_SLOTS")
+    if env_slots is not None:
+        want = max(1, min(int(env_slots), num_tiles))
+    elif chunk_bytes < _MIN_PIPELINE_CHUNK_BYTES:
+        return 1, num_tiles  # single shot: latency-bound band
+    else:
+        # The mid-large band over-pipelines at 8 slots -- each slot's sub-chunk gets
+        # too small and the per-slot sync dominates, so 4 slots is the knee there; the
+        # >=64MB chunk band keeps 8 (the deeper run-ahead still wins).
+        want = min(
+            4 if chunk_bytes < _DEEP_PIPELINE_CHUNK_BYTES else _NUM_SLOTS, num_tiles
+        )
+    tps = (num_tiles + want - 1) // want
+    slots = (num_tiles + tps - 1) // tps  # re-derive exact slot count for this tps
+    return slots, tps

--- a/comms/dsl/tests/_dist_harness.py
+++ b/comms/dsl/tests/_dist_harness.py
@@ -1,0 +1,39 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Shared multi-rank scaffolding for the distributed correctness suites.
+
+The small helpers every distributed test repeats: a free-port picker, the bit-exact
+input builder, and the cross-rank PASS/FAIL min-reduce + reporter. Kept here so the
+scaffolding lives in one place.
+"""
+
+import socket
+
+import torch
+import torch.distributed as dist
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _make_input(rank: int, numel: int, device: torch.device) -> torch.Tensor:
+    idx = torch.arange(numel, device=device, dtype=torch.int64)
+    return ((rank + 1) * 1_000_000 + idx).to(torch.float32)
+
+
+def _all_ok(local_ok: bool, device: torch.device, group: dist.ProcessGroup) -> bool:
+    status = torch.tensor([1 if local_ok else 0], dtype=torch.int32, device=device)
+    dist.all_reduce(status, op=dist.ReduceOp.MIN, group=group)
+    return bool(status.item())
+
+
+def _report(name: str, local_ok: bool, device, group, rank: int) -> bool:
+    ok = _all_ok(local_ok, device, group)
+    if rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: {name}", flush=True)
+    return ok

--- a/comms/dsl/tests/_dist_harness.py
+++ b/comms/dsl/tests/_dist_harness.py
@@ -26,6 +26,20 @@ def _make_input(rank: int, numel: int, device: torch.device) -> torch.Tensor:
     return ((rank + 1) * 1_000_000 + idx).to(torch.float32)
 
 
+def _golden(group: dist.ProcessGroup, inp: torch.Tensor) -> torch.Tensor:
+    """Reference equal-split all_to_all via ``dist.all_to_all_single``."""
+    out = torch.empty_like(inp)
+    dist.all_to_all_single(out, inp, group=group)
+    return out
+
+
+def _rendezvous(group: dist.ProcessGroup, device: torch.device, chunk: int):
+    """Rendezvous a transport sized for a per-peer fp32 chunk (the a2a test contract)."""
+    from comms.dsl import nvl_rendezvous
+
+    return nvl_rendezvous(group, device, per_peer_bytes=chunk * 4)
+
+
 def _all_ok(local_ok: bool, device: torch.device, group: dist.ProcessGroup) -> bool:
     status = torch.tensor([1 if local_ok else 0], dtype=torch.int32, device=device)
     dist.all_reduce(status, op=dist.ReduceOp.MIN, group=group)

--- a/comms/dsl/tests/test_cute_a2a_correctness.py
+++ b/comms/dsl/tests/test_cute_a2a_correctness.py
@@ -1,0 +1,119 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# Distributed correctness test: the worker runs under mp.spawn and touches untyped cutlass /
+# symmetric-memory symbols that pyre cannot model, so strict typing adds no value here.
+
+"""Correctness test for the fused CuTe all_to_all (vs dist.all_to_all_single).
+
+Bit-exact gold check across a few sizes / block counts / dtypes, eager and under
+CUDA-graph replay (the persistent-counter graph-safety contract). Covers fp32 + bf16, a
+single-shot and a pipelined size, small and ``num_blocks == max_blocks_per_peer``. HEAD
+slot-free credits protect free-running transport reuse across graph replays. Skipped unless
+>=2 GPUs are present.
+"""
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from comms.dsl.tests._dist_harness import _find_free_port, _golden, _make_input
+
+# (numel factor per rank, num_blocks, dtype, elem_bytes): tiny (scalar-ish), small multi-
+# block, a pipelined 8 MiB fp32 chunk (num_slots > 1), num_blocks == mbp (=32) boundary,
+# and the bf16 path.
+_CASES: tuple[tuple[int, int, torch.dtype, int], ...] = (
+    (4, 1, torch.float32, 4),
+    (2048, 2, torch.float32, 4),
+    (2 * 1024 * 1024, 4, torch.float32, 4),
+    (2048, 32, torch.float32, 4),
+    (2048, 2, torch.bfloat16, 2),
+)
+
+
+def _dtype_input(rank: int, numel: int, device: torch.device, dtype: torch.dtype):
+    if dtype == torch.float32:
+        return _make_input(rank, numel, device)  # integer-valued fp32, exact
+    # bf16-exact per-rank, position-varying pattern (values 0..250 < 256); a pure copy
+    # preserves it bit-exactly, so torch.equal is valid.
+    idx = torch.arange(numel, device=device, dtype=torch.int64)
+    return ((idx + rank * 131) % 251).to(dtype)
+
+
+def _worker(rank: int, world_size: int, port: int, result_q) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    try:
+        device = torch.device(f"cuda:{rank}")
+        group = dist.group.WORLD
+        assert group is not None
+
+        from comms.dsl import nvl_rendezvous
+        from comms.dsl.cute.a2a.host import all_to_all
+        from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+        ok = True
+        for factor, nb, dtype, elem in _CASES:
+            numel = world_size * factor
+            chunk = numel // world_size
+            t = nvl_rendezvous(group, device, per_peer_bytes=chunk * elem)
+            inp = _dtype_input(rank, numel, device, dtype)
+            gold = _golden(group, inp)
+            out = torch.empty_like(inp)
+
+            all_to_all(t, out, inp, config=CuteA2AConfig(num_blocks=nb))
+            torch.cuda.synchronize(device)
+            eager_ok = torch.equal(out, gold)
+
+            # Graph replay with distinct data exercises persistent counter progression and
+            # HEAD credit protection without a cross-rank barrier between replays.
+            buf = inp.clone()
+
+            def fn(out=out, buf=buf, t=t, nb=nb):
+                all_to_all(t, out, buf, config=CuteA2AConfig(num_blocks=nb))
+
+            fn()
+            torch.cuda.synchronize(device)
+            dist.barrier(group)
+            g = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(g):
+                fn()
+            graph_ok = True
+            for i in range(3):
+                inp2 = _dtype_input(rank + 11 * (i + 1), numel, device, dtype)
+                buf.copy_(inp2)
+                out.zero_()
+                g.replay()
+                torch.cuda.synchronize(device)
+                graph_ok = graph_ok and torch.equal(out, _golden(group, inp2))
+            ok = ok and eager_ok and graph_ok
+            if rank == 0:
+                print(
+                    f"  numel={numel} nb={nb} dtype={dtype}: "
+                    f"eager={'ok' if eager_ok else 'FAIL'} "
+                    f"graph={'ok' if graph_ok else 'FAIL'}",
+                    flush=True,
+                )
+            dist.barrier(group)
+
+        result_q.put((rank, ok))
+    finally:
+        dist.barrier()
+        dist.destroy_process_group()
+
+
+class A2ACuteTest(unittest.TestCase):
+    def test_cute_a2a(self) -> None:
+        if torch.cuda.device_count() < 2:
+            self.skipTest("needs >=2 GPUs")
+        ws = min(torch.cuda.device_count(), 4)
+        ctx = mp.get_context("spawn")
+        result_q = ctx.SimpleQueue()
+        mp.spawn(_worker, args=(ws, _find_free_port(), result_q), nprocs=ws, join=True)
+        results = sorted(result_q.get() for _ in range(ws))
+        self.assertEqual([r for r, _ in results], list(range(ws)))
+        self.assertTrue(all(ok for _, ok in results), f"per-rank pass flags: {results}")

--- a/comms/dsl/tests/test_cute_a2a_robust.py
+++ b/comms/dsl/tests/test_cute_a2a_robust.py
@@ -1,0 +1,217 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# Distributed test: runs under mp.spawn and touches untyped cutlass / symmetric-memory symbols
+# that pyre cannot model, so strict typing adds no value here.
+
+"""Robustness tests for the CuTe-DSL all_to_all copy schedule.
+
+* **Concurrent transports** -- two independent transports interleaved on the same ranks
+  must not cross-talk; each keeps its own staging buffer + signal pad + step counters.
+* **Geometry guard** -- switching a geometry field (``num_blocks``) on a reused transport
+  must FIRE the runtime guard (``check_geometry``) before dispatch.
+
+HEAD slot-free credits protect fixed-geometry reused transports without host barriers.
+Gold is ``dist.all_to_all_single``. Skipped unless >=2 GPUs are present.
+"""
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from comms.dsl.tests._dist_harness import (
+    _find_free_port,
+    _golden,
+    _make_input,
+    _rendezvous,
+    _report,
+)
+
+
+def _case_concurrent_transports(group, rank, ws, device) -> bool:
+    """Two independent CuTe transports interleaved on the same ranks must not cross-talk --
+    each keeps its own staging buffer + signal pad + step counters, so interleaving their
+    collectives stays bit-exact."""
+    from comms.dsl.cute.a2a.host import all_to_all
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+    numel = ws * 8192
+    chunk = numel // ws
+    t1 = _rendezvous(group, device, chunk)
+    t2 = _rendezvous(group, device, chunk)
+    inp = _make_input(rank, numel, device)
+    gold = _golden(group, inp)
+    o1 = torch.empty_like(inp)
+    o2 = torch.empty_like(inp)
+    cfg = CuteA2AConfig(num_blocks=2)
+    all_to_all(t1, o1, inp, config=cfg)
+    all_to_all(t2, o2, inp, config=cfg)
+    torch.cuda.synchronize(device)
+    all_to_all(t1, o1, inp, config=cfg)
+    all_to_all(t2, o2, inp, config=cfg)
+    torch.cuda.synchronize(device)
+    ok = torch.equal(o1, gold) and torch.equal(o2, gold)
+    dist.barrier(group)
+    return _report("concurrent_transports", ok, device, group, rank)
+
+
+def _case_geometry_switch_guard(group, rank, ws, device) -> bool:
+    """The geometry guard must FIRE when a geometry field (``num_blocks``) changes on a
+    reused transport. The first call primes the geometry (num_blocks=2) and must SUCCEED;
+    the second differs ONLY in ``num_blocks`` (2 -> 4, same numel) so ``check_geometry`` --
+    a hard error by default (no runtime drain) -- raises ValueError before dispatch."""
+    from comms.dsl.cute.a2a.host import all_to_all
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+    numel = ws * 4096
+    chunk = numel // ws
+    t = _rendezvous(group, device, chunk)
+    inp = _make_input(rank, numel, device)
+    out = torch.empty_like(inp)
+
+    all_to_all(t, out, inp, config=CuteA2AConfig(num_blocks=2))
+    torch.cuda.synchronize(device)
+    primed_ok = torch.equal(out, _golden(group, inp))
+
+    raised = False
+    try:
+        all_to_all(t, out, inp, config=CuteA2AConfig(num_blocks=4))
+    except ValueError:
+        raised = True
+
+    dist.barrier(group)
+    return _report("geometry_switch_guard", primed_ok and raised, device, group, rank)
+
+
+def _case_cluster(group, rank, ws, device) -> bool:
+    """The CGA cluster launch path (untested elsewhere): forcing ``cluster>1`` must stay
+    bit-exact, and a cluster that does not divide ``num_blocks`` must collapse to 1 (the
+    host guard) rather than trip CUDA_ERROR_INVALID_CLUSTER_SIZE."""
+    from comms.dsl.cute.a2a.host import all_to_all
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+    numel = ws * 8192
+    chunk = numel // ws
+    inp = _make_input(rank, numel, device)
+    gold = _golden(group, inp)
+
+    # CGA on: num_blocks (4) divisible by cluster (2) -> cluster stays 2.
+    t1 = _rendezvous(group, device, chunk)
+    o1 = torch.empty_like(inp)
+    all_to_all(t1, o1, inp, config=CuteA2AConfig(num_blocks=4, cluster=2))
+    torch.cuda.synchronize(device)
+    dist.barrier(group)
+    # Collapse: num_blocks (3) NOT divisible by cluster (2) -> host collapses to 1.
+    t2 = _rendezvous(group, device, chunk)
+    o2 = torch.empty_like(inp)
+    all_to_all(t2, o2, inp, config=CuteA2AConfig(num_blocks=3, cluster=2))
+    torch.cuda.synchronize(device)
+    ok = torch.equal(o1, gold) and torch.equal(o2, gold)
+    dist.barrier(group)
+    return _report("cluster_and_collapse", ok, device, group, rank)
+
+
+def _case_allow_geometry_switch(group, rank, ws, device) -> bool:
+    """``COMMS_DSL_ALLOW_GEOMETRY_SWITCH=1`` downgrades the geometry guard to a silent
+    advance for sync-separated callers: a num_blocks 2 -> 4 switch on a reused transport
+    must NOT raise and must stay bit-exact (a device sync + barrier separates the calls, so
+    no bytes are in flight across the switch)."""
+    from comms.dsl.cute.a2a.host import all_to_all
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+    numel = ws * 4096
+    chunk = numel // ws
+    inp = _make_input(rank, numel, device)
+    gold = _golden(group, inp)
+    t = _rendezvous(group, device, chunk)
+    out = torch.empty_like(inp)
+
+    prev = os.environ.get("COMMS_DSL_ALLOW_GEOMETRY_SWITCH")
+    ok = False
+    try:
+        os.environ["COMMS_DSL_ALLOW_GEOMETRY_SWITCH"] = "1"
+        all_to_all(t, out, inp, config=CuteA2AConfig(num_blocks=2))
+        torch.cuda.synchronize(device)
+        first_ok = torch.equal(out, gold)
+        dist.barrier(group)
+        # Geometry switch (num_blocks 2 -> 4) must be allowed (no raise) under the env.
+        all_to_all(t, out, inp, config=CuteA2AConfig(num_blocks=4))
+        torch.cuda.synchronize(device)
+        ok = first_ok and torch.equal(out, gold)
+    finally:
+        if prev is None:
+            os.environ.pop("COMMS_DSL_ALLOW_GEOMETRY_SWITCH", None)
+        else:
+            os.environ["COMMS_DSL_ALLOW_GEOMETRY_SWITCH"] = prev
+    dist.barrier(group)
+    return _report("allow_geometry_switch", ok, device, group, rank)
+
+
+def _case_rejected_call_no_baseline_pollution(group, rank, ws, device) -> bool:
+    """A call rejected by a pre-dispatch guard must NOT seed the geometry baseline: the
+    geometry commit happens only just before dispatch. Here the first call is rejected
+    (primitive='direct' is not shipped) and a subsequent legit copy call on the SAME
+    transport must succeed rather than spuriously raise 'geometry changed'."""
+    from comms.dsl.cute.a2a.host import all_to_all
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+    numel = ws * 4096
+    chunk = numel // ws
+    inp = _make_input(rank, numel, device)
+    gold = _golden(group, inp)
+    t = _rendezvous(group, device, chunk)
+    out = torch.empty_like(inp)
+
+    rejected = False
+    try:
+        all_to_all(t, out, inp, config=CuteA2AConfig(primitive="direct"))
+    except ValueError:
+        rejected = True
+    # The rejected call dispatched nothing, so this legit copy call must succeed.
+    all_to_all(t, out, inp, config=CuteA2AConfig(num_blocks=2))
+    torch.cuda.synchronize(device)
+    ok = rejected and torch.equal(out, gold)
+    dist.barrier(group)
+    return _report("rejected_call_no_baseline_pollution", ok, device, group, rank)
+
+
+def _run_cases(group, rank, ws, device) -> list[bool]:
+    return [
+        _case_concurrent_transports(group, rank, ws, device),
+        _case_geometry_switch_guard(group, rank, ws, device),
+        _case_cluster(group, rank, ws, device),
+        _case_allow_geometry_switch(group, rank, ws, device),
+        _case_rejected_call_no_baseline_pollution(group, rank, ws, device),
+    ]
+
+
+def _mp_worker(rank: int, world_size: int, port: int, result_q) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    try:
+        device = torch.device(f"cuda:{rank}")
+        group = dist.group.WORLD
+        assert group is not None
+        result_q.put((rank, all(_run_cases(group, rank, world_size, device))))
+    finally:
+        dist.barrier()
+        dist.destroy_process_group()
+
+
+class A2ACuteRobustTest(unittest.TestCase):
+    def test_robustness(self) -> None:
+        if torch.cuda.device_count() < 2:
+            self.skipTest("needs >=2 GPUs")
+        ws = min(torch.cuda.device_count(), 8)
+        ctx = mp.get_context("spawn")
+        result_q = ctx.SimpleQueue()
+        mp.spawn(
+            _mp_worker, args=(ws, _find_free_port(), result_q), nprocs=ws, join=True
+        )
+        results = sorted(result_q.get() for _ in range(ws))
+        self.assertEqual([r for r, _ in results], list(range(ws)))
+        self.assertTrue(all(ok for _, ok in results), f"per-rank pass flags: {results}")

--- a/comms/dsl/tests/test_transport.py
+++ b/comms/dsl/tests/test_transport.py
@@ -1,0 +1,108 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Host-side (CPU, no device) coverage for transport host validation.
+
+``check_transfer`` and ``_require_signal_pad`` are pure host validation -- they
+read only ints (per_peer_bytes / max_blocks_per_peer / dtype.itemsize / a pad
+size) -- so their invariants are exercisable without a symmetric-memory process group.
+The device rendezvous path requires a real symmetric-memory-capable group and is outside
+this host-only test target.
+"""
+
+import unittest
+from dataclasses import dataclass
+from typing import cast
+
+import torch
+from comms.dsl import check_transfer, NvlTransport
+from comms.dsl.transport import _require_signal_pad
+
+
+@dataclass
+class _StubTransport:
+    """Minimal stub carrying only the fields ``check_transfer`` reads."""
+
+    per_peer_bytes: int
+    max_blocks_per_peer: int
+
+
+def _stub(per_peer_bytes: int, max_blocks_per_peer: int = 8) -> NvlTransport:
+    return cast(
+        NvlTransport,
+        _StubTransport(
+            per_peer_bytes=per_peer_bytes, max_blocks_per_peer=max_blocks_per_peer
+        ),
+    )
+
+
+class TransportCheckTransferTest(unittest.TestCase):
+    def test_dtype_not_divisible_raises(self) -> None:
+        # per_peer_bytes must be a whole multiple of the dtype itemsize:
+        # 65 bytes is not divisible by bfloat16's 2-byte itemsize.
+        with self.assertRaises(ValueError):
+            check_transfer(_stub(65), numel=1, dtype=torch.bfloat16, num_blocks=1)
+
+    def test_numel_overrun_raises(self) -> None:
+        # per_peer_bytes=64 holds 64 uint8 / 32 bf16 elems; one past capacity raises.
+        for dtype, cap in ((torch.uint8, 64), (torch.bfloat16, 32)):
+            with self.assertRaises(ValueError):
+                check_transfer(_stub(64), numel=cap + 1, dtype=dtype, num_blocks=1)
+
+    def test_num_blocks_out_of_range_raises(self) -> None:
+        t = _stub(64)
+        with self.assertRaises(ValueError):
+            check_transfer(t, numel=1, dtype=torch.uint8, num_blocks=0)
+        with self.assertRaises(ValueError):
+            check_transfer(
+                t, numel=1, dtype=torch.uint8, num_blocks=t.max_blocks_per_peer + 1
+            )
+
+    def test_divisibility_checked_before_capacity(self) -> None:
+        # When per_peer_bytes is both non-divisible AND too small for numel, the
+        # divisibility error must win: cap_elems = per_peer_bytes // itemsize would be
+        # computed from a garbage (floored) capacity otherwise. Kernel addressing relies
+        # on this order.
+        with self.assertRaisesRegex(ValueError, "not a multiple"):
+            check_transfer(
+                _stub(65), numel=10_000_000, dtype=torch.bfloat16, num_blocks=1
+            )
+
+    def test_min_capacity_boundary(self) -> None:
+        # per_peer_bytes == itemsize -> cap_elems == 1: exactly 1 elem fits, 2 overruns.
+        t = _stub(2)  # 1 bf16 elem
+        self.assertIsNone(
+            check_transfer(t, numel=1, dtype=torch.bfloat16, num_blocks=1)
+        )
+        with self.assertRaises(ValueError):
+            check_transfer(t, numel=2, dtype=torch.bfloat16, num_blocks=1)
+
+    def test_valid_transfer_passes(self) -> None:
+        # check_transfer returns None on success; assert that (and that it does not
+        # raise) for every valid (dtype, numel, num_blocks) combination. numel == 0
+        # (empty transfer) is allowed.
+        t = _stub(64)
+        for dtype, cap in ((torch.uint8, 64), (torch.bfloat16, 32)):
+            self.assertIsNone(check_transfer(t, numel=0, dtype=dtype, num_blocks=1))
+            self.assertIsNone(check_transfer(t, numel=cap, dtype=dtype, num_blocks=1))
+            self.assertIsNone(
+                check_transfer(
+                    t, numel=cap, dtype=dtype, num_blocks=t.max_blocks_per_peer
+                )
+            )
+
+
+class RequireSignalPadTest(unittest.TestCase):
+    def test_pad_too_small_raises(self) -> None:
+        # need = 2 * ws * mbp; one int64 short must raise.
+        ws, mbp = 8, 32
+        need = 2 * ws * mbp
+        with self.assertRaisesRegex(RuntimeError, "signal pad too small"):
+            _require_signal_pad(need - 1, ws, mbp)
+
+    def test_pad_exact_and_larger_pass(self) -> None:
+        ws, mbp = 8, 32
+        need = 2 * ws * mbp
+        self.assertIsNone(_require_signal_pad(need, ws, mbp))
+        self.assertIsNone(_require_signal_pad(need + 1, ws, mbp))

--- a/comms/dsl/tests/test_transport.py
+++ b/comms/dsl/tests/test_transport.py
@@ -17,6 +17,7 @@ from typing import cast
 
 import torch
 from comms.dsl import check_transfer, NvlTransport
+from comms.dsl.cute.a2a.tuning import _max_coresident_ctas
 from comms.dsl.transport import _require_signal_pad
 
 
@@ -106,3 +107,17 @@ class RequireSignalPadTest(unittest.TestCase):
         need = 2 * ws * mbp
         self.assertIsNone(_require_signal_pad(need, ws, mbp))
         self.assertIsNone(_require_signal_pad(need + 1, ws, mbp))
+
+
+class MaxCoresidentCtasTest(unittest.TestCase):
+    def test_thread_limited(self) -> None:
+        # 2048 threads/SM, 1024 threads/CTA -> 2 blocks/SM; 132 SMs -> 264.
+        self.assertEqual(_max_coresident_ctas(132, 2048, 1024), 264)
+
+    def test_block_cap_limited(self) -> None:
+        # 2048 // 32 = 64 blocks/SM but the hardware cap is 32; 100 SMs -> 3200.
+        self.assertEqual(_max_coresident_ctas(100, 2048, 32), 100 * 32)
+
+    def test_floors_at_one_block_per_sm(self) -> None:
+        # num_threads > threads/SM -> still at least 1 block/SM (never 0).
+        self.assertEqual(_max_coresident_ctas(10, 2048, 4096), 10)

--- a/comms/dsl/transport.py
+++ b/comms/dsl/transport.py
@@ -1,0 +1,282 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""User-owned NVLink transport for the comms/dsl all_to_all kernels.
+
+:class:`NvlTransport` owns all transport state behind one object: the
+symmetric-memory staging buffer, the signal pad, and the persistent per-(peer,
+block) step counters. A device schedule consumes the device-side
+:class:`PeerTable` (every peer's staging-buffer + signal-pad base pointer,
+indexed by peer id in-kernel). The transport contains no collective algorithm.
+
+Design points realized here:
+
+* **User-owned, one rendezvous.** :func:`nvl_rendezvous` does a single collective
+  rendezvous for the whole group and returns an object the user holds (reused
+  across CUDA-graph replays). There is no hidden module-level cache.
+* **Graph-safe signalling.** The signal pad plus persistent monotonic step
+  counters let a reused transport / captured graph replay without ever reading a
+  stale signal slot (see :meth:`NvlTransport.step_state`).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from torch._C._distributed_c10d import _SymmetricMemory
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+_SR_DEBUG: bool | None = None
+
+
+def _sr_debug() -> bool:
+    global _SR_DEBUG
+    if _SR_DEBUG is None:
+        _SR_DEBUG = os.environ.get("SENDRECV_DEBUG", "0") == "1"
+    return _SR_DEBUG
+
+
+def _rdv_dbg(group: dist.ProcessGroup, msg: str) -> None:
+    if _sr_debug():
+        logger.debug("[r%d] rdv: %s", dist.get_rank(group), msg)
+
+
+# Shape-independent default; the staging region per peer must hold the message.
+_DEFAULT_MAX_BLOCKS_PER_PEER: int = 32
+
+
+@dataclass(frozen=True)
+class PeerTable:
+    """Device-side addressing for the fused multi-peer schedule.
+
+    Every peer's staging-buffer and signal-pad base pointer as an int64 device
+    tensor, indexed by peer id (cast int->ptr) inside the kernel, so a fused
+    multi-peer schedule picks the peer on device via ``program_id`` instead of
+    pre-slicing per-peer state on the host. The per-peer staging region for
+    sender ``s`` inside a rank's buffer is at ``s * (per_peer_bytes // elem)``,
+    and signal-pad slots for sender ``s`` start at ``s * max_blocks_per_peer``.
+    """
+
+    buffer_ptrs: torch.Tensor  # int64[world_size]: peer -> staging-buffer base
+    signal_pad_ptrs: torch.Tensor  # int64[world_size]: peer -> signal-pad base
+
+
+@dataclass
+class NvlTransport:
+    """Symmetric-memory NVLink transport (real, minimal).
+
+    Owns the ``_SymmetricMemory`` handle. The buffer is ``per_peer_bytes`` per
+    peer (``per_peer_bytes * world_size`` total); the signal pad holds two int64
+    regions of ``world_size * max_blocks_per_peer`` entries each (tail then head),
+    laid out by ``[sender_rank * max_blocks_per_peer + block]``. Tail = sender
+    "data ready" (polled by the receiver); head = receiver "slot free" credit
+    (polled by the sender before overwriting reusable staging).
+    """
+
+    handle: _SymmetricMemory
+    world_size: int
+    # Rank within the NVLink rendezvous group (``dist.get_rank(group)``), i.e. the
+    # index used to address this rank's slot in the symmetric-memory buffer. This is
+    # NOT the node-local rank (``LOCAL_RANK`` env / ``get_node_local_rank``): on an
+    # NVL fabric the rendezvous group may span trays, so it is a group-relative rank.
+    local_rank: int
+    per_peer_bytes: int
+    max_blocks_per_peer: int = _DEFAULT_MAX_BLOCKS_PER_PEER
+    _endpoints_device_cache: PeerTable | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+    _step_state_cache: tuple[torch.Tensor, torch.Tensor] | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+    _last_a2a_launch_metadata: dict[str, Any] | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+
+    def _record_a2a_launch_metadata(self, metadata: dict[str, Any]) -> None:
+        self._last_a2a_launch_metadata = dict(metadata)
+
+    def _get_a2a_launch_metadata(self) -> dict[str, Any]:
+        if self._last_a2a_launch_metadata is None:
+            raise RuntimeError("transport has no resolved a2a launch metadata")
+        return dict(self._last_a2a_launch_metadata)
+
+    def endpoints_device(self) -> PeerTable:
+        """All peers' buffer + signal-pad base pointers as a device :class:`PeerTable`.
+
+        Index by peer on device (cast int->ptr) instead of pre-slicing per-peer
+        state on the host. Symm-mem base addresses are fixed after rendezvous, so
+        build once and cache: repeated fused-schedule calls and CUDA-graph capture
+        must not re-allocate / re-copy.
+        """
+        if self._endpoints_device_cache is None:
+            # Device is the transport's own symm-mem device, not the caller's
+            # current device.
+            dev = self.handle.get_buffer(
+                self.local_rank, sizes=[1], dtype=torch.uint8
+            ).device
+            self._endpoints_device_cache = PeerTable(
+                buffer_ptrs=torch.tensor(
+                    self.handle.buffer_ptrs, dtype=torch.int64, device=dev
+                ),
+                signal_pad_ptrs=torch.tensor(
+                    self.handle.signal_pad_ptrs, dtype=torch.int64, device=dev
+                ),
+            )
+        return self._endpoints_device_cache
+
+    def step_state(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """Persistent monotonic step counters for graph-safe signalling.
+
+        Returns ``(sender_step, recver_step)``, each an int64 device tensor of
+        ``world_size * max_blocks_per_peer`` entries indexed by
+        ``peer * max_blocks_per_peer + block``. Each slot has exactly one writer
+        (the local send leg writes ``sender_step``; the local recv leg writes
+        ``recver_step``), so no atomics are needed.
+
+        The schedule signals an absolute, monotonically increasing sequence
+        number per call and the kernel advances these counters itself, so a
+        reused transport / CUDA-graph replay never reads a stale signal slot.
+        Allocated once and cached (zero-initialized; the signal pad is zeroed at
+        rendezvous, so the first wait for sequence 1 is race-free).
+        """
+        if self._step_state_cache is None:
+            dev = self.handle.get_buffer(
+                self.local_rank, sizes=[1], dtype=torch.uint8
+            ).device
+            n = self.world_size * self.max_blocks_per_peer
+            self._step_state_cache = (
+                torch.zeros(n, dtype=torch.int64, device=dev),
+                torch.zeros(n, dtype=torch.int64, device=dev),
+            )
+        return self._step_state_cache
+
+
+def _require_signal_pad(
+    sig_numel: int, world_size: int, max_blocks_per_peer: int
+) -> None:
+    """Raise if the symm-mem signal pad cannot hold the tail+head regions.
+
+    The pad needs two int64 regions of ``world_size * max_blocks_per_peer`` entries
+    each (tail then head). Extracted so the invariant is unit-testable host-only.
+    """
+    need = 2 * world_size * max_blocks_per_peer
+    if sig_numel < need:
+        raise RuntimeError(
+            f"signal pad too small: {sig_numel} int64 < required {need} "
+            f"(2 x world_size={world_size} x max_blocks_per_peer={max_blocks_per_peer})"
+        )
+
+
+def nvl_rendezvous(
+    group: dist.ProcessGroup,
+    device: torch.device,
+    per_peer_bytes: int,
+    max_blocks_per_peer: int = _DEFAULT_MAX_BLOCKS_PER_PEER,
+) -> NvlTransport:
+    """One collective rendezvous; returns a user-owned :class:`NvlTransport`.
+
+    Allocates ``per_peer_bytes * world_size`` of symmetric memory (one per-peer
+    staging region per peer). Zeroes the signal pad so the first wait for sequence 1
+    is race-free after the barrier.
+    """
+    world_size = dist.get_world_size(group)
+    local_rank = dist.get_rank(group)
+    total = per_peer_bytes * world_size
+    logger.info(
+        "nvl_rendezvous on PG %s: allocating %d bytes (%d peers x %d)",
+        group.group_desc,
+        total,
+        world_size,
+        per_peer_bytes,
+    )
+    _rdv_dbg(group, f"symm_mem.empty({total}B) start")
+    raw = symm_mem.empty(total, dtype=torch.uint8, device=device)
+    _rdv_dbg(group, "symm_mem.empty done; symm_mem.rendezvous start")
+    handle = symm_mem.rendezvous(raw, group=group)
+    _rdv_dbg(group, "symm_mem.rendezvous done")
+
+    # The transport addresses every symm-mem slot by local_rank (= group rank), so the
+    # handle's own rank convention must agree, else this rank would zero / index a peer's
+    # region. Enforce it (raise, not assert -- survives -O) rather than assume equality.
+    if handle.rank != local_rank:
+        raise RuntimeError(
+            f"symm-mem handle rank {handle.rank} != group rank {local_rank}"
+        )
+
+    # Signal pad holds two int64 regions per (sender, block) slot:
+    #   tail [0 .. ws*MBP): sender publishes "data ready" (polled by receiver)
+    #   head [ws*MBP .. 2*ws*MBP): receiver publishes "slot free" before reuse.
+    sig = handle.get_signal_pad(local_rank).view(torch.int64)
+    _require_signal_pad(sig.numel(), world_size, max_blocks_per_peer)
+    sig.zero_()
+    _rdv_dbg(group, "sig.zero_ done; barrier start")
+    dist.barrier(group)
+    _rdv_dbg(group, "barrier done")
+    transport = NvlTransport(
+        handle=handle,
+        world_size=world_size,
+        local_rank=local_rank,
+        per_peer_bytes=per_peer_bytes,
+        max_blocks_per_peer=max_blocks_per_peer,
+    )
+    # Eagerly materialize the device-side caches (peer table + step counters) now,
+    # so the first collective can be issued inside a CUDA-graph capture without the
+    # lazy allocation happening during capture.
+    transport.endpoints_device()
+    _rdv_dbg(group, "endpoints_device done")
+    transport.step_state()
+    _rdv_dbg(group, "step_state done")
+    return transport
+
+
+def check_transfer(
+    transport: NvlTransport,
+    numel: int,
+    dtype: torch.dtype,
+    num_blocks: int,
+) -> None:
+    """Validate a transfer against the transport before launch (fail loud).
+
+    Three invariants whose violation would otherwise cause **silent remote
+    corruption** (a kernel writing past a per-peer region overruns the next
+    peer's staging or signal-pad region on the remote rank):
+
+    * ``per_peer_bytes`` must be a whole multiple of the dtype itemsize, so the
+      per-peer region holds whole elements.
+    * ``numel`` must fit the per-peer staging region (``per_peer_bytes``).
+    * ``num_blocks`` must fit the per-peer signal-pad slots
+      (``max_blocks_per_peer``), since each block signals slot ``block_id``.
+
+    ``numel`` is the **per-peer** element count (the elements that must fit one peer's
+    staging region), not the whole-tensor total. ``numel == 0`` (empty transfer) is
+    allowed; it corrupts nothing.
+    """
+    elem = dtype.itemsize
+    # A per-peer region that is not a whole number of elements would otherwise pass here
+    # and later silently mis-slice the symm-mem buffer.
+    if transport.per_peer_bytes % elem != 0:
+        raise ValueError(
+            f"per_peer_bytes={transport.per_peer_bytes} not a multiple of dtype itemsize "
+            f"{elem} ({dtype}); the per-peer region cannot hold whole elements"
+        )
+    cap_elems = transport.per_peer_bytes // elem
+    if numel > cap_elems:
+        raise ValueError(
+            f"transfer numel={numel} exceeds per-peer capacity={cap_elems} elems "
+            f"(per_peer_bytes={transport.per_peer_bytes}, dtype={dtype}); "
+            f"increase per_peer_bytes at rendezvous"
+        )
+    mbp = transport.max_blocks_per_peer
+    if not (1 <= num_blocks <= mbp):
+        raise ValueError(
+            f"num_blocks={num_blocks} must be in [1, {mbp}] "
+            f"(one signal-pad slot per block per peer)"
+        )

--- a/comms/dsl/tuning_base.py
+++ b/comms/dsl/tuning_base.py
@@ -1,0 +1,101 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""DSL-agnostic tuning base: the shared tunable Config + reused-transport geometry guard.
+
+Owns the runtime pieces shared by tunable collectives: the base config dataclass,
+geometry signatures, and the reused-transport geometry guard.
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+def geometry_signature(
+    config: Any,
+    fields: frozenset[str],
+    resolved: tuple[tuple[str, Any], ...] = (),
+) -> tuple:
+    """Geometry-defining field values: two configs with the same signature can reuse one
+    transport back-to-back; a different signature on a reused transport is the documented
+    hazard the runtime geometry guard catches. ``fields`` is the per-collective set of
+    knobs that change the physical staging geometry. ``resolved`` carries runtime-derived
+    geometry such as the effective vector width or shape."""
+    return tuple(getattr(config, f) for f in sorted(fields)) + tuple(
+        value for _, value in resolved
+    )
+
+
+def check_geometry(
+    transport: Any,
+    config: Any,
+    fields: frozenset[str],
+    label: str = "all_to_all",
+    *,
+    resolved: tuple[tuple[str, Any], ...] = (),
+) -> None:
+    """Guard against an unsafe staging-geometry switch on a reused transport.
+
+    ``label`` names the collective in the error message (this helper is DSL/collective-
+    agnostic; later collectives pass their own name).
+
+    The kernel's persistent step counters + shared staging buffer make back-to-back
+    launches safe only when the geometry-defining ``fields`` are unchanged (see
+    ``geometry_signature``). Switching geometry on the same transport without a drain
+    reinterprets in-flight bytes; the framework has no runtime drain, so this guard
+    surfaces the hazard.
+
+    A geometry switch on a reused transport is a hard error by default: there is no
+    runtime drain, so reinterpreting in-flight bytes silently corrupts staging data and a
+    warn-and-proceed default would let that corruption through unnoticed.
+    ``COMMS_DSL_ALLOW_GEOMETRY_SWITCH=1`` downgrades it to a silent advance for callers
+    whose successive launches are device-sync-separated (a benchmark / tuner sweeping
+    configs at one size) -- they know no bytes are in flight across the switch. The
+    transport is a non-frozen dataclass, so we stash the last accepted geometry on it
+    directly (private attr).
+    """
+    sig = geometry_signature(config, fields, resolved)
+    prev = getattr(transport, "_last_geometry_signature", None)
+    # The cache advances only on an accepted switch: reseeding the baseline before the
+    # raise would let the next (still hazardous) switch slip through unflagged.
+    if prev is None or prev == sig:
+        transport._last_geometry_signature = sig
+        return
+    # Forgiving parse of the documented escape hatch: accept 1/true/yes (case-insensitive,
+    # whitespace-trimmed); warn (not silently ignore) on a present-but-unrecognized value.
+    _allow = os.environ.get("COMMS_DSL_ALLOW_GEOMETRY_SWITCH", "").strip().lower()
+    if _allow in ("1", "true", "yes"):
+        transport._last_geometry_signature = sig
+        return
+    if _allow not in ("", "0", "false", "no"):
+        warnings.warn(
+            f"COMMS_DSL_ALLOW_GEOMETRY_SWITCH={_allow!r} unrecognized; treating as unset "
+            "(use 1/true/yes to enable).",
+            stacklevel=2,
+        )
+    names = sorted(fields) + [name for name, _ in resolved]
+    raise ValueError(
+        f"{label}: staging geometry changed on a reused transport "
+        f"({dict(zip(names, prev))} -> {dict(zip(names, sig))}). There is no runtime drain "
+        "yet, so back-to-back calls of differing geometry on one transport (without an "
+        "intervening device sync) would corrupt in-flight staging data. Use a fresh "
+        "transport per geometry/shape, or set COMMS_DSL_ALLOW_GEOMETRY_SWITCH=1 if your "
+        "calls are sync-separated."
+    )
+
+
+@dataclass(frozen=True)
+class BaseTunableConfig:
+    """Base tunable config shared across backends. Subclasses add core fields."""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "BaseTunableConfig":
+        return cls(**data)  # type: ignore[arg-type]


### PR DESCRIPTION
Summary:
Adds a self-contained equal-split CuTe all_to_all copy collective over NvlTransport.

- schedules implements the fused classic grid with one CTA per (peer, block): diagonal
  chunks copy locally; remote chunks use the shared vectorized slot pipeline.
- HEAD slot-free and TAIL data-ready credits make fixed-geometry calls and CUDA Graph
  replays safe back-to-back without a host barrier.
- host validates device, dtype, contiguity, alignment, non-overlap, capacity, geometry,
  and conservative signal-spin co-residency before compile/launch.
- tuning_base records resolved runtime geometry so a reused transport cannot reinterpret
  staging ownership silently.

Only primitive='copy' is supported in this revision.

Differential Revision: D112061822


