### PR TITLE
comms/dsl: add minimal local and MAST NCU profiling entry

### DIFF
--- a/comms/dsl/__init__.py
+++ b/comms/dsl/__init__.py
@@ -1,0 +1,23 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""comms/dsl — NVLink all_to_all over PyTorch symmetric memory.
+
+Exposes the user-owned transport contract: :class:`NvlTransport` +
+:func:`nvl_rendezvous` (staging buffer, signal pad, and graph-safe step counters
+created once via a single collective rendezvous), the device-side
+:class:`PeerTable` that a fused schedule indexes by peer in-kernel, and the pre-launch
+:func:`check_transfer` validator.
+"""
+
+from __future__ import annotations
+
+from .transport import check_transfer, nvl_rendezvous, NvlTransport, PeerTable
+
+__all__ = [
+    "NvlTransport",
+    "PeerTable",
+    "nvl_rendezvous",
+    "check_transfer",
+]

--- a/comms/dsl/cute/__init__.py
+++ b/comms/dsl/cute/__init__.py
@@ -1,0 +1,34 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""CuTe collective backend over the shared NVLink transport.
+
+Symbols are exposed lazily so importing the package does not eagerly load the CuTe DSL.
+"""
+
+from importlib import import_module
+from typing import Any
+
+__all__ = [
+    "nvl_ops",
+]
+
+# Exported name -> (submodule, attribute). ``attr is None`` exports the submodule
+# itself (e.g. ``nvl_ops``).
+_LAZY: dict[str, tuple[str, str | None]] = {
+    "nvl_ops": ("nvl_ops", None),
+}
+
+
+def __getattr__(name: str) -> Any:
+    entry = _LAZY.get(name)
+    if entry is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    mod_name, attr = entry
+    mod = import_module(f".{mod_name}", __name__)
+    return mod if attr is None else getattr(mod, attr)
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/comms/dsl/cute/__init__.py
+++ b/comms/dsl/cute/__init__.py
@@ -11,12 +11,13 @@ from importlib import import_module
 from typing import Any
 
 __all__ = [
+    "all_to_all",
     "nvl_ops",
 ]
 
-# Exported name -> (submodule, attribute). ``attr is None`` exports the submodule
-# itself (e.g. ``nvl_ops``).
+# Exported name -> (submodule, attribute). ``attr is None`` exports the submodule.
 _LAZY: dict[str, tuple[str, str | None]] = {
+    "all_to_all": ("a2a.host", "all_to_all"),
     "nvl_ops": ("nvl_ops", None),
 }
 

--- a/comms/dsl/cute/a2a/__init__.py
+++ b/comms/dsl/cute/a2a/__init__.py
@@ -1,0 +1,5 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""CuTe all_to_all collective: device kernels (``schedules``) + host entry (``host``)."""

--- a/comms/dsl/cute/a2a/host.py
+++ b/comms/dsl/cute/a2a/host.py
@@ -1,0 +1,323 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Public host entry for the fused all_to_all in the CuTe DSL (symmetric-memory NVLink).
+
+The host half of the CuTe all_to_all: :func:`all_to_all` (staging copy schedule, writes
+the caller's output). It resolves a ``CuteA2AConfig`` (explicit or the analytic default),
+picks the analytic launch shape (``_pick_tile`` / ``_pick_slots``), and
+``cute.compile`` / launches the device kernel in :mod:`comms.dsl.cute.a2a.schedules`.
+
+Persistent counters plus HEAD/TAIL credits make fixed-geometry calls and CUDA Graph
+replays safe back-to-back. :func:`comms.dsl.tuning_base.check_geometry` rejects staging
+ownership changes on a reused transport. The fused signal-spinning grid must be fully
+co-resident, so :func:`all_to_all` rejects a grid above the conservative capacity rather
+than risking deadlock.
+"""
+
+import logging
+import os
+from importlib import import_module
+from typing import Any
+
+import torch
+from comms.dsl.transport import check_transfer, NvlTransport
+from comms.dsl.tuning_base import check_geometry
+
+# Importing send_recv runs the one-time CuTe setup (CUTE_DSL_ARCH detection +
+# cuda-bindings shim) AND imports cutlass; the os.environ statement below is a barrier so
+# the formatter cannot hoist the cutlass imports above this setup.
+from ..send_recv import (
+    _ensure_cuda_rt_compat,
+    _pick_slots,
+    _pick_tile,
+    _resolve_cute_dsl_arch,
+)
+
+os.environ.setdefault("CUTE_DSL_ARCH", _resolve_cute_dsl_arch())
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.runtime import from_dlpack
+
+from .schedules import _A2ACfg, _launch_a2a
+from .tuning import (
+    _max_coresident_ctas,
+    CUTE_A2A_GEOMETRY_FIELDS,
+    CuteA2AConfig,
+    DEFAULT_A2A_CONFIG,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+_cuda_driver: Any = import_module("cuda.bindings.driver")
+
+_MAX_PORTABLE_CLUSTER: int = 8  # Hopper/Blackwell portable cluster cap
+
+
+# Minimal dtype support: (cutlass dtype, bits-per-element).
+_CUTLASS_DTYPE: dict[torch.dtype, tuple[Any, int]] = {
+    torch.float32: (cutlass.Float32, 32),
+    torch.bfloat16: (cutlass.BFloat16, 16),
+}
+
+_COMPILED: dict[tuple[Any, ...], object] = {}
+
+
+def _env_int(name: str, default: int) -> int:
+    """int() of env ``name`` with a clear error naming the offending knob (dev/tuning knobs)."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        raise ValueError(f"env {name}={raw!r} must be an integer") from None
+
+
+def all_to_all(  # noqa: C901
+    transport: NvlTransport,
+    output: torch.Tensor,
+    input: torch.Tensor,
+    *,
+    config: CuteA2AConfig | None = None,
+) -> None:
+    """Equal-split all_to_all_single via the fused CuTe copy kernel.
+
+    Launch tunables come from ``config`` (a ``CuteA2AConfig``); ``config is None`` uses the
+    analytic adaptive defaults (``DEFAULT_A2A_CONFIG``). ``numel`` must be divisible by the
+    world size (equal split). Input and output must not overlap. Fixed-geometry calls may
+    run back-to-back, but one transport must not execute concurrently on multiple streams.
+    """
+    if not (input.is_cuda and output.is_cuda):
+        raise ValueError("cute a2a requires CUDA input/output tensors")
+    if not (input.is_contiguous() and output.is_contiguous()):
+        raise ValueError("cute a2a requires contiguous input/output tensors")
+    if input.dtype != output.dtype:
+        raise ValueError("cute a2a requires matching input/output dtype")
+    if input.device != output.device:
+        raise ValueError("cute a2a requires input/output on the same CUDA device")
+    if input.device.index != torch.cuda.current_device():
+        raise ValueError(
+            "cute a2a requires the input device to be the current CUDA device"
+        )
+    if input.dtype not in _CUTLASS_DTYPE:
+        raise ValueError(f"cute a2a supports {list(_CUTLASS_DTYPE)}, got {input.dtype}")
+    if input.data_ptr() % 16 or output.data_ptr() % 16:
+        raise ValueError("cute a2a requires 16-byte-aligned input/output tensors")
+    if transport.per_peer_bytes % 16:
+        raise ValueError("cute a2a requires a 16-byte-aligned per-peer staging stride")
+    ws = transport.world_size
+    numel = input.numel()
+    if numel != output.numel():
+        raise ValueError("cute a2a requires input.numel() == output.numel()")
+    span_bytes = numel * input.element_size()
+    if max(input.data_ptr(), output.data_ptr()) < min(
+        input.data_ptr() + span_bytes, output.data_ptr() + span_bytes
+    ):
+        raise ValueError("cute a2a requires non-overlapping input/output tensors")
+    if numel == 0:
+        raise ValueError("cute a2a requires non-empty input/output tensors")
+    if numel % ws != 0:
+        raise ValueError("equal-split requires numel % world_size == 0")
+    chunk = numel // ws
+    cdtype, dbits = _CUTLASS_DTYPE[input.dtype]
+    if config is None:
+        config = DEFAULT_A2A_CONFIG
+    if config.primitive != "copy":
+        raise ValueError(
+            f"primitive {config.primitive!r} is unsupported; only 'copy' is available"
+        )
+    nb = config.num_blocks
+    num_threads, vec = _pick_tile(chunk, dbits, nb * ws)
+    # num_threads: analytic _pick_tile, overridden by a tuned/explicit config (0 = analytic),
+    # an env knob winning over the config; the override cascades into num_tiles / num_slots.
+    if "A2A_CUTE_NT" not in os.environ and config.num_threads:
+        units = chunk // vec
+        nt = min(config.num_threads, units, 1024)  # CUDA threads/block hardware cap
+        while nt > 1 and units % nt:
+            nt -= 1
+        num_threads = nt
+    # Co-residency guard: the fused kernel spins on cross-CTA signals, so all nb*ws CTAs
+    # must be simultaneously resident or a resident CTA can wait forever on a signal from a
+    # never-scheduled one (a systematic deadlock at high world_size, e.g. NVL72). Reject a
+    # grid that provably cannot co-reside rather than hang.
+    props = torch.cuda.get_device_properties(input.device)
+    grid_ctas = nb * ws
+    cap = min(
+        props.multi_processor_count,
+        _max_coresident_ctas(
+            props.multi_processor_count,
+            props.max_threads_per_multi_processor,
+            num_threads,
+        ),
+    )
+    if grid_ctas > cap:
+        raise ValueError(
+            f"cute a2a grid {grid_ctas} CTAs (num_blocks={nb} x world_size={ws}) exceeds "
+            f"the conservative signal-spin CTA capacity {cap} (num_threads={num_threads}) on "
+            f"{props.name}; the signal-spin kernel needs every CTA co-resident or it "
+            "deadlocks -- reduce num_blocks."
+        )
+    num_tiles = chunk // (num_threads * vec)
+    num_slots, tiles_per_slot = _pick_slots(num_tiles, chunk * input.element_size())
+    if "A2A_CUTE_SLOTS" not in os.environ and config.num_slots:
+        want = max(1, min(config.num_slots, num_tiles))
+        tiles_per_slot = (num_tiles + want - 1) // want
+        num_slots = (num_tiles + tiles_per_slot - 1) // tiles_per_slot
+    check_transfer(transport, chunk, input.dtype, nb)
+    cap_elems = transport.per_peer_bytes // input.element_size()
+    mbp = transport.max_blocks_per_peer
+
+    table = transport.endpoints_device()
+    if table.buffer_ptrs.device != input.device:
+        raise ValueError("cute a2a transport and input must be on the same CUDA device")
+    send_ctr, recv_ctr = transport.step_state()
+
+    in2d = from_dlpack(input.view(ws, chunk), assumed_align=16)
+    out2d = from_dlpack(output.view(ws, chunk), assumed_align=16)
+    buf_c = from_dlpack(table.buffer_ptrs, assumed_align=8)
+    sig_c = from_dlpack(table.signal_pad_ptrs, assumed_align=8)
+    send_c = from_dlpack(send_ctr, assumed_align=8)
+    recv_c = from_dlpack(recv_ctr, assumed_align=8)
+    stream = _cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    # Register-blocking unroll for the NVLink store loop (in-flight stores/thread): the
+    # per-SM injection lever. Default to 8 once the per-peer chunk is large enough for the
+    # unrolled body to engage (tiny sizes keep 1); a tuned/explicit config (0 = analytic)
+    # overrides, an env knob winning over it.
+    _u_default = 8 if chunk * input.element_size() >= 64 * 1024 else 1
+    unroll = max(1, _env_int("A2A_CUTE_UNROLL", _u_default))
+    if "A2A_CUTE_UNROLL" not in os.environ and config.unroll:
+        unroll = max(1, config.unroll)
+    # CGA cluster size along the block axis (co-locate the blocks targeting one peer on one
+    # GPC): raises the per-SM NVLink send rate at the >=256MB band but regresses the mid
+    # band, so 0 = analytic default (cluster the large band, else off), -1 = max, >0 =
+    # explicit. Capped at the portable cluster size and collapsed to 1 unless it divides
+    # num_blocks (so a large SM-budget nb runs cluster-off instead of tripping
+    # CUDA_ERROR_INVALID_CLUSTER_SIZE). An env knob wins over the config.
+    _cl_default = 0 if chunk * input.element_size() >= 64 * 1024 * 1024 else 1
+    _cl = _env_int("A2A_CUTE_CLUSTER", config.cluster or _cl_default)
+    cluster = min(nb if _cl <= 0 else _cl, _MAX_PORTABLE_CLUSTER)
+    # cluster_y is capped by the portable cluster size too (like cluster): an uncapped large
+    # value would combine with cluster on the block axis to exceed the hardware cluster cap
+    # and trip CUDA_ERROR_INVALID_CLUSTER_SIZE instead of collapsing gracefully.
+    cluster_y = min(
+        max(1, _env_int("A2A_CUTE_CLUSTER_Y", config.cluster_y)), _MAX_PORTABLE_CLUSTER
+    )
+    if nb % cluster:
+        cluster = 1
+    if ws % cluster_y:
+        cluster_y = 1
+
+    # Verify/commit the geometry baseline now that every OTHER pre-dispatch guard (primitive /
+    # co-residency / check_transfer) has passed, but BEFORE the expensive cute.compile: a call
+    # that will be rejected for a geometry switch should not pay compile cost or populate
+    # _COMPILED for a key that never dispatches. check_geometry does not seed the baseline on
+    # rejection, so this still cannot pollute a reused transport.
+    check_geometry(
+        transport,
+        config,
+        CUTE_A2A_GEOMETRY_FIELDS,
+        resolved=(
+            ("chunk", chunk),
+            ("dtype", input.dtype),
+            ("num_threads", num_threads),
+            ("vec", vec),
+            ("num_slots", num_slots),
+            ("tiles_per_slot", tiles_per_slot),
+        ),
+    )
+    transport._record_a2a_launch_metadata(
+        {
+            "primitive": config.primitive,
+            "grid_ctas": grid_ctas,
+            "num_blocks": nb,
+            "num_threads": num_threads,
+            "vec": vec,
+            "num_slots": num_slots,
+            "tiles_per_slot": tiles_per_slot,
+            "unroll": unroll,
+            "cluster": cluster,
+            "cluster_y": cluster_y,
+            "per_peer_bytes": transport.per_peer_bytes,
+        }
+    )
+
+    key = (
+        "a2a",
+        # Arch is baked into the compiled kernel: a runtime CUTE_DSL_ARCH change must not reuse
+        # a kernel built for a different arch (matches send_recv's cache key).
+        os.environ.get("CUTE_DSL_ARCH"),
+        nb,
+        num_threads,
+        vec,
+        input.dtype,
+        ws,
+        chunk,
+        cap_elems,
+        mbp,
+        num_slots,
+        tiles_per_slot,
+        unroll,
+        cluster,
+        cluster_y,
+    )
+    compiled: Any = _COMPILED.get(key)
+    if compiled is None:
+        _ensure_cuda_rt_compat()  # lazy: shim cuda-bindings before this cute.compile path
+        logger.info(
+            "compiling cute a2a: ws=%s chunk=%s nb=%s nt=%s vec=%s",
+            ws,
+            chunk,
+            nb,
+            num_threads,
+            vec,
+        )
+        # The cfg is UNPACKED into individual constexpr args at the cute.compile boundary --
+        # never passed as a single Constexpr object (cute's tree-walk would crash on dtype).
+        cfg = _A2ACfg(
+            num_blocks=nb,
+            num_threads=num_threads,
+            vec=vec,
+            dtype=cdtype,
+            dbits=dbits,
+            world_size=ws,
+            local_rank=transport.local_rank,
+            chunk=chunk,
+            cap_elems=cap_elems,
+            mbp=mbp,
+            num_slots=num_slots,
+            tiles_per_slot=tiles_per_slot,
+            unroll=unroll,
+            cluster=cluster,
+            cluster_y=cluster_y,
+        )
+        compiled = cute.compile(
+            _launch_a2a,
+            in2d,
+            out2d,
+            buf_c,
+            sig_c,
+            send_c,
+            recv_c,
+            cfg.num_blocks,
+            cfg.num_threads,
+            cfg.vec,
+            cfg.dtype,
+            cfg.dbits,
+            cfg.world_size,
+            cfg.local_rank,
+            cfg.chunk,
+            cfg.cap_elems,
+            cfg.mbp,
+            cfg.num_slots,
+            cfg.tiles_per_slot,
+            cfg.unroll,
+            cfg.cluster,
+            cfg.cluster_y,
+            stream,
+        )
+        _COMPILED[key] = compiled
+    compiled(in2d, out2d, buf_c, sig_c, send_c, recv_c, stream)

--- a/comms/dsl/cute/a2a/schedules.py
+++ b/comms/dsl/cute/a2a/schedules.py
@@ -1,0 +1,305 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# pyre-ignore-all-errors[6, 35, 58]: @cute.kernel / @cute.jit constexpr params are
+# annotated cutlass.Constexpr; pyre models that as Constexpr[Any] and rejects the
+# arithmetic / range() / dataclass-field uses the kernel bodies do on them -- the values
+# are real compile-time ints at trace time.
+
+"""Device kernels for the fused all_to_all in the CuTe DSL (symmetric-memory NVLink).
+
+The on-device half of the CuTe all_to_all: the fused ``@cute.kernel`` copy schedule
+(``_a2a_kernel``), its ``@cute.jit`` launcher (``_launch_a2a``), and the host-side
+launch-constant bundle ``_A2ACfg``. The tile/slot sizing (``_pick_tile`` /
+``_pick_slots``) and the copy leaf / slot primitives are shared from
+``cute/send_recv.py``. The public host entry that resolves a config and
+``cute.compile`` / launches this kernel lives in :mod:`comms.dsl.cute.a2a.host`.
+
+Each ``(peer, block)`` program streams its sub-chunk to the peer's staging over NVLink,
+publishes a data-ready signal, then drains the peer's matching staging slot into the
+output. Device-side peer addressing uses ``cute.make_ptr`` over the transport's int64
+peer table, so a single fused launch selects the peer on device via ``block_idx``
+instead of one launch per peer.
+
+Graph-safe: signalling uses the transport's persistent monotonic per-(peer, block) step
+counters, so a transport is reusable across calls / CUDA-graph replays (with a cross-rank
+sync between reused calls; see :func:`comms.dsl.cute.a2a.host.all_to_all`). The slot
+pipeline overlaps send/drain on top of a single-shot stage-then-drain.
+
+Scope: equal-split ``all_to_all_single``, identity copy (bf16/fp32), ``numel`` divisible
+by ``world_size`` and the per-(peer, block) tile by the thread count.
+"""
+
+# Annotations are evaluated eagerly (no ``from __future__ import annotations``): the
+# @cute.kernel / @cute.jit launchers classify their compile-time params via the real
+# ``cutlass.Constexpr`` annotation object, which inspect.getfullargspec only exposes when
+# annotations are NOT stringized -- stringized annotations leave cute unable to tell a
+# constexpr from a dynamic arg and it mis-marshals the dtype.
+import os
+from dataclasses import dataclass
+from typing import Any
+
+# Importing send_recv runs its one-time setup (CUTE_DSL_ARCH detection +
+# cuda-bindings shim) AND imports cutlass; the os.environ statement below is a
+# barrier so the formatter cannot hoist the cutlass imports above this setup.
+from ..send_recv import _resolve_cute_dsl_arch
+
+os.environ.setdefault("CUTE_DSL_ARCH", _resolve_cute_dsl_arch())
+
+import cutlass
+import cutlass.cute as cute
+
+
+@dataclass
+class _A2ACfg:
+    """Host-side bundle of the fused all_to_all launch constants, for readability at the
+    call site. It is NEVER passed as a single ``cutlass.Constexpr`` -- cute's tree-walk
+    would call ``__extract_mlir_values__`` on the ``dtype`` (a cutlass NumericMeta) and
+    crash on the tiny/odd-chunk paths. Always UNPACK it into individual positional args at
+    the ``cute.compile`` / ``.launch`` boundary."""
+
+    num_blocks: int
+    num_threads: int
+    vec: int
+    dtype: Any
+    dbits: int
+    world_size: int
+    local_rank: int
+    chunk: int
+    cap_elems: int
+    mbp: int
+    num_slots: int
+    tiles_per_slot: int
+    unroll: int = 1
+    cluster: int = 1
+    cluster_y: int = 1
+
+
+from .. import nvl_ops  # noqa: E402
+
+# The shared CuTe send/recv substrate (copy leaves, per-slot credit primitives, and
+# tile/slot sizing) lives in ``cute/send_recv.py``. This schedule composes those helpers
+# and owns the collective-specific peer mapping, barriers, and counter progression.
+from ..send_recv import _copy_atom, _copy_u, _recv_slot, _send_slot  # noqa: E402
+
+
+@cute.jit
+def _launch_a2a(
+    in2d,
+    out2d,
+    buf_ptrs,
+    sig_ptrs,
+    send_ctr,
+    recv_ctr,
+    num_blocks: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    vec: cutlass.Constexpr,
+    dtype: cutlass.Constexpr,
+    dbits: cutlass.Constexpr,
+    world_size: cutlass.Constexpr,
+    local_rank: cutlass.Constexpr,
+    chunk: cutlass.Constexpr,
+    cap_elems: cutlass.Constexpr,
+    mbp: cutlass.Constexpr,
+    num_slots: cutlass.Constexpr,
+    tiles_per_slot: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+    cluster: cutlass.Constexpr,
+    cluster_y: cutlass.Constexpr,
+    stream,
+) -> None:
+    # in2d / out2d are [world_size, chunk] views; per-peer chunk = row peer.
+    # CGA cluster dims (None == off); host guarantees the grid is divisible.
+    cl = (
+        [cluster, cluster_y, 1]
+        if cutlass.const_expr(cluster > 1 or cluster_y > 1)
+        else None
+    )
+    _a2a_kernel(
+        in2d,
+        out2d,
+        buf_ptrs,
+        sig_ptrs,
+        send_ctr,
+        recv_ctr,
+        dtype,
+        vec,
+        dbits,
+        num_blocks,
+        num_threads,
+        world_size,
+        local_rank,
+        chunk,
+        cap_elems,
+        mbp,
+        num_slots,
+        tiles_per_slot,
+        unroll,
+    ).launch(
+        grid=(num_blocks, world_size, 1),
+        block=(num_threads, 1, 1),
+        cluster=cl,
+        stream=stream,
+    )
+
+
+@cute.kernel
+def _a2a_kernel(  # noqa: C901
+    in2d,
+    out2d,
+    buf_ptrs,
+    sig_ptrs,
+    send_ctr,
+    recv_ctr,
+    dtype: cutlass.Constexpr,
+    vec: cutlass.Constexpr,
+    dbits: cutlass.Constexpr,
+    num_blocks: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    world_size: cutlass.Constexpr,
+    local_rank: cutlass.Constexpr,
+    chunk: cutlass.Constexpr,
+    cap_elems: cutlass.Constexpr,
+    mbp: cutlass.Constexpr,
+    num_slots: cutlass.Constexpr,
+    tiles_per_slot: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+) -> None:
+    tidx = cute.arch.thread_idx()[0]
+    b = cute.arch.block_idx()[0]
+    peer = cute.arch.block_idx()[1]
+    u = unroll
+    nb = num_blocks
+
+    # Vectorized copy: each thread moves VEC contiguous elements per copy, so the NVLink
+    # store is a vectorized st.global (up to 128-bit) instead of a scalar store -- the
+    # single biggest copy-bandwidth lever. (num_threads, VEC) are chosen per chunk by the
+    # host (`_pick_tile`) so any size tiles exactly (VEC drops to scalar for small/odd
+    # chunks, covering the whole 32B-2GB ladder with no tail). Tiler = num_threads*VEC.
+    copy_atom = _copy_atom(dtype, vec, dbits)
+    tiled_copy = cute.make_tiled_copy_tv(
+        copy_atom, cute.make_layout(num_threads), cute.make_layout(vec)
+    )
+    thr_copy = tiled_copy.get_slice(tidx)
+
+    # This peer's contiguous input/output chunk (row `peer` of the [ws, chunk] views).
+    in_chunk = in2d[(peer, None)]
+    out_chunk = out2d[(peer, None)]
+    tiler = cute.make_layout(num_threads * vec)
+    g_in = cute.zipped_divide(in_chunk, tiler)
+    g_out = cute.zipped_divide(out_chunk, tiler)
+    # Tile count from the actual divided layout (the authoritative value): the host also
+    # derives it for _pick_slots, but recomputing here keeps the kernel's tile bound tied
+    # to its own zipped_divide and never out of step with a host value.
+    num_tiles = cute.size(g_in, mode=[1])
+
+    # CuTe forbids early `return` in a kernel, so the diagonal (local) and the comm path
+    # are an if/else (peer is a runtime block index, not constexpr).
+    if peer == local_rank:
+        # Diagonal: local copy in_chunk -> out_chunk (no comm). Grid-stride `while` stays
+        # inline (CuTe captures control flow only here); the unrolled body is `_copy_u`.
+        t = b
+        while t + (u - 1) * nb < num_tiles:
+            _copy_u(thr_copy, copy_atom, g_in, g_out, t, u, num_blocks)
+            t += u * nb
+        while t < num_tiles:
+            _copy_u(thr_copy, copy_atom, g_in, g_out, t, 1, num_blocks)
+            t += nb
+    else:
+        # --- device-side symm-mem addressing for this peer ---
+        peer_buf_addr = buf_ptrs[peer]
+        my_buf_addr = buf_ptrs[local_rank]
+        peer_sig_addr = sig_ptrs[peer]
+        my_sig_addr = sig_ptrs[local_rank]
+
+        # Staging regions (elem layout [chunk]); sender `s` occupies the byte slot
+        # `s * cap_elems * elem_bytes` in a rank's buffer. SEND -> my sender slot inside
+        # peer's buffer; RECV -> peer's sender slot inside my buffer (int64 byte addrs).
+        elem_bytes = dbits // 8
+        cap_bytes = cap_elems * elem_bytes
+        send_addr = peer_buf_addr + local_rank * cap_bytes
+        recv_addr = my_buf_addr + peer * cap_bytes
+        send_ptr = cute.make_ptr(
+            dtype, send_addr, cute.AddressSpace.gmem, assumed_align=16
+        )
+        recv_ptr = cute.make_ptr(
+            dtype, recv_addr, cute.AddressSpace.gmem, assumed_align=16
+        )
+        send_region = cute.make_tensor(send_ptr, cute.make_layout(chunk))
+        recv_region = cute.make_tensor(recv_ptr, cute.make_layout(chunk))
+        g_send = cute.zipped_divide(send_region, tiler)
+        g_recv = cute.zipped_divide(recv_region, tiler)
+
+        step_idx = peer * mbp + b
+        start_send = send_ctr[step_idx]
+        start_recv = recv_ctr[step_idx]
+        # This (peer, block)'s own signal counters: block b sends ITS tile subset to the
+        # peer and signals its own counter; the peer's block b waits the matching counter
+        # and drains the SAME subset -- so the pipeline is independent across blocks.
+        tail_remote = peer_sig_addr + (local_rank * mbp + b) * 8
+        tail_local = my_sig_addr + (peer * mbp + b) * 8
+        head_off = world_size * mbp
+        head_remote = peer_sig_addr + (head_off + local_rank * mbp + b) * 8
+        head_local = my_sig_addr + (head_off + peer * mbp + b) * 8
+
+        if tidx == 0:
+            nvl_ops.wait_free(head_local, start_send)
+        cute.arch.barrier()
+
+        # Slot pipeline, composed from the shared per-slot primitives: send slot s (NVLink
+        # store + TAIL) then drain slot s-1 (local HBM) so the still-in-flight stores of
+        # slot s overlap the drain. Disjoint regions (my-staging drain vs peer-staging
+        # store) -> no false dependency. num_slots is constexpr so this loop unrolls.
+        for s in range(num_slots):
+            _send_slot(
+                thr_copy,
+                copy_atom,
+                g_in,
+                g_send,
+                tail_remote,
+                start_send,
+                b,
+                tidx,
+                s,
+                tiles_per_slot,
+                num_tiles,
+                num_blocks,
+                unroll,
+            )
+            if s >= 1:
+                _recv_slot(
+                    thr_copy,
+                    copy_atom,
+                    g_recv,
+                    g_out,
+                    tail_local,
+                    start_recv,
+                    b,
+                    tidx,
+                    s - 1,
+                    tiles_per_slot,
+                    num_tiles,
+                    num_blocks,
+                    unroll,
+                )
+        # Drain the final slot (no later send to overlap it).
+        _recv_slot(
+            thr_copy,
+            copy_atom,
+            g_recv,
+            g_out,
+            tail_local,
+            start_recv,
+            b,
+            tidx,
+            num_slots - 1,
+            tiles_per_slot,
+            num_tiles,
+            num_blocks,
+            unroll,
+        )
+        cute.arch.barrier()
+        if tidx == 0:
+            nvl_ops.signal_free(head_remote, start_recv + num_slots)
+            send_ctr[step_idx] = start_send + num_slots
+            recv_ctr[step_idx] = start_recv + num_slots

--- a/comms/dsl/cute/a2a/tuning.py
+++ b/comms/dsl/cute/a2a/tuning.py
@@ -1,0 +1,82 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# pyre-ignore-all-errors[35]: pyre mis-flags this frozen-dataclass-subclass's fields as
+# illegal annotation targets; the dataclass is correct and runtime-validated.
+
+"""Tunable Config for the CuTe all_to_all copy schedule.
+
+A frozen ``CuteA2AConfig`` of launch tunables + a safe ``DEFAULT_A2A_CONFIG``. A field
+left at its ``0`` sentinel means "use the analytic adaptive pick" (``_pick_tile`` /
+``_pick_slots`` in ``a2a.schedules`` / ``cute.send_recv``), so the default config
+reproduces the size-aware analytic defaults exactly. The public host entry accepts an
+explicit config or falls back to ``DEFAULT_A2A_CONFIG``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ...tuning_base import BaseTunableConfig as _BaseConfig
+
+
+@dataclass(frozen=True)
+class CuteA2AConfig(_BaseConfig):
+    """Launch tunables for the copy schedule (perf axis only).
+
+    ``num_blocks`` is the block count per peer (device grid = ``world_size *
+    num_blocks``; one CTA per ``(peer, block)`` streams its sub-chunk). The remaining
+    knobs default to ``0`` = "use the analytic adaptive pick", so the default config
+    reproduces the size-aware analytic defaults exactly:
+
+    * ``num_threads`` -- threads/CTA (``0`` -> ``_pick_tile``); the per-thread vector
+      width is always the widest the chunk allows and is not independently tuned.
+    * ``num_slots`` -- send/drain pipeline slots (``0`` -> ``_pick_slots``);
+      ``tiles_per_slot`` is derived from it.
+    * ``unroll`` -- register-blocking unroll of the NVLink store loop (``0`` ->
+      size-aware default, 8 once the per-peer chunk is large enough else 1).
+    * ``cluster`` -- CGA thread-block cluster size along the block axis (``0`` ->
+      size-aware default; ``-1`` = max = ``num_blocks``; ``>0`` = explicit).
+    * ``cluster_y`` -- CGA cluster size along the peer (grid-y) axis; ``1`` = off
+      (the default). Collapsed to 1 unless it divides ``world_size``.
+
+    ``primitive`` selects the transfer schedule; this revision supports only ``"copy"``
+    (the slot-pipelined per-thread staging copy).
+    """
+
+    num_blocks: int = 8
+    num_threads: int = 0
+    num_slots: int = 0
+    unroll: int = 0
+    primitive: str = "copy"
+    cluster: int = 0
+    cluster_y: int = 1
+
+
+# Fields whose value changes the physical staging geometry (grid partition / output
+# semantics) rather than launch-only packing; switching one on a reused transport is the
+# documented hazard the runtime geometry guard catches. The tile/slot/unroll/cluster knobs
+# are launch-only and free to sweep.
+CUTE_A2A_GEOMETRY_FIELDS: frozenset[str] = frozenset({"num_blocks", "primitive"})
+
+# Safe analytic default (every adaptive knob at its 0 sentinel).
+DEFAULT_A2A_CONFIG: CuteA2AConfig = CuteA2AConfig()
+
+# Max thread-blocks that can be co-resident per SM (Volta+ hardware cap); the true limit
+# is the min of this and the thread / register / smem occupancy.
+_MAX_BLOCKS_PER_SM: int = 32
+
+
+def _max_coresident_ctas(sm_count: int, threads_per_sm: int, num_threads: int) -> int:
+    """Optimistic upper bound on CTAs that can be simultaneously resident on the device.
+
+    The fused a2a kernel spins on cross-CTA signals, so EVERY launched CTA must be
+    co-resident or a resident CTA can wait forever on a signal from a never-scheduled one
+    -- a systematic deadlock at high world_size (e.g. NVL72). This is the thread-limited
+    occupancy bound (blocks/SM = ``threads_per_sm // num_threads``, capped at the hardware
+    ``_MAX_BLOCKS_PER_SM``) times the SM count. It ignores register / smem pressure, so it
+    is a ceiling: a grid above it definitely cannot co-reside (the host guard rejects it),
+    while a grid below it may still be occupancy-limited in practice.
+    """
+    blocks_per_sm = min(_MAX_BLOCKS_PER_SM, threads_per_sm // max(1, num_threads))
+    return sm_count * max(1, blocks_per_sm)

--- a/comms/dsl/cute/device_utils.py
+++ b/comms/dsl/cute/device_utils.py
@@ -1,0 +1,99 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Inline-PTX signalling primitives for the CuTe backend.
+
+Cross-rank int64 signalling over symmetric memory via ``@dsl_user_op`` and
+``llvm.inline_asm``. TAIL data-ready publication uses release/acquire ordering; HEAD
+slot-free credits use a relaxed store and volatile poll because they transfer ownership
+without publishing payload.
+"""
+
+from __future__ import annotations
+
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.typing import Int64
+from cutlass.cutlass_dsl import dsl_user_op
+
+
+@dsl_user_op
+def wait_ge(addr: Int64, target: Int64, *, loc=None, ip=None) -> None:
+    """Acquire-poll int64 until ``*addr >= target`` (local read)."""
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int64(target).ir_value(loc=loc, ip=ip)],
+        """{
+            .reg .u64   %tmp64;
+            .reg .pred  %p;
+            _fw_wait_ge:
+                ld.global.acquire.sys.b64 %tmp64, [$0];
+                setp.lt.u64 %p, %tmp64, $1;
+                @%p bra _fw_wait_ge;
+        }""",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def wait_ge_volatile(addr: Int64, target: Int64, *, loc=None, ip=None) -> None:
+    """Volatile-poll until ``*addr >= target`` for a HEAD slot-free credit."""
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int64(target).ir_value(loc=loc, ip=ip)],
+        """{
+            .reg .u64   %tmp64;
+            .reg .pred  %p;
+            _fw_wait_ge_vol:
+                ld.volatile.global.u64 %tmp64, [$0];
+                setp.lt.u64 %p, %tmp64, $1;
+                @%p bra _fw_wait_ge_vol;
+        }""",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def remote_store_release_i64(addr: Int64, val: Int64, *, loc=None, ip=None) -> None:
+    """Publish prior memory accesses with one system-scope release store."""
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int64(val).ir_value(loc=loc, ip=ip)],
+        """{
+            st.global.release.sys.b64 [$0], $1;
+        }""",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def remote_store_i64_relaxed(addr: Int64, val: Int64, *, loc=None, ip=None) -> None:
+    """Return a HEAD slot-free credit without payload-publication ordering."""
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int64(val).ir_value(loc=loc, ip=ip)],
+        """{
+            st.global.relaxed.sys.b64 [$0], $1;
+        }""",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )

--- a/comms/dsl/cute/nvl_ops.py
+++ b/comms/dsl/cute/nvl_ops.py
@@ -1,0 +1,52 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""NVLink device transport-ops for the CuTe send/recv seam.
+
+The concrete data movement plus TAIL data-ready and HEAD slot-free operations for the
+symmetric-memory transport, in cute-native signatures.
+"""
+
+from __future__ import annotations
+
+import cutlass.cute as cute
+
+from .device_utils import (
+    remote_store_i64_relaxed,
+    remote_store_release_i64,
+    wait_ge,
+    wait_ge_volatile,
+)
+
+
+def put(atom, frag, dst_part):
+    """Write a produced fragment into the peer's staging partition (remote store)."""
+    cute.copy(atom, frag, dst_part)
+
+
+def get(atom, src_part):
+    """Read a received tile from the local staging partition into a fragment."""
+    frag = cute.make_fragment_like(src_part)
+    cute.copy(atom, src_part, frag)
+    return frag
+
+
+def signal(addr, seq):
+    """Publish "data ready" to the peer with a system-scope release store."""
+    remote_store_release_i64(addr, seq)
+
+
+def wait(addr, seq):
+    """Wait until the peer published data-ready ``seq`` with an acquire poll."""
+    wait_ge(addr, seq)
+
+
+def signal_free(addr, seq):
+    """Return HEAD slot ownership with a relaxed remote store."""
+    remote_store_i64_relaxed(addr, seq)
+
+
+def wait_free(addr, seq):
+    """Wait for a HEAD slot-free credit with a volatile poll."""
+    wait_ge_volatile(addr, seq)

--- a/comms/dsl/cute/send_recv.py
+++ b/comms/dsl/cute/send_recv.py
@@ -1,0 +1,301 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# pyre-ignore-all-errors[6, 35, 58]: @cute.kernel / @cute.jit constexpr params are
+# annotated cutlass.Constexpr; pyre models that as Constexpr[Any] and rejects the
+# arithmetic / range() / dataclass-field uses the kernel bodies do on them -- the values
+# are real compile-time ints at trace time.
+
+"""Shared CuTe device substrate for collectives over ``NvlTransport``.
+
+The module owns vectorized copy leaves, per-slot send/receive primitives, CUDA DSL setup,
+and analytic tile/slot sizing. Collective schedules compose these helpers and supply their
+own peer ownership, address mapping, barriers, and counter progression.
+"""
+
+# NOTE: do NOT add ``from __future__ import annotations`` here. The @cute.jit
+# functions below (``_send_slot`` / ``_recv_slot``) classify their compile-time params via the REAL
+# ``cutlass.Constexpr`` annotation object, which ``inspect.getfullargspec`` only exposes
+# when annotations are NOT stringized -- stringizing makes cute marshal a constexpr dtype
+# as a dynamic arg and crash (Float32.__c_pointers__ TypeError).
+import logging
+import os
+from importlib import import_module
+from typing import Any
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _resolve_cute_dsl_arch() -> str:
+    """``sm_<major><minor>[a]`` for the local device; honors CUTE_DSL_ARCH."""
+    explicit = os.environ.get("CUTE_DSL_ARCH")
+    if explicit:
+        return explicit
+    try:
+        import torch as _torch
+
+        major, minor = _torch.cuda.get_device_capability(_torch.cuda.current_device())
+    except (ImportError, RuntimeError, AssertionError) as e:
+        logger.warning(
+            "could not detect CUDA device capability (%s); "
+            "defaulting CUTE_DSL_ARCH to sm_90a",
+            e,
+        )
+        return "sm_90a"
+    if (major, minor) == (9, 0):
+        return "sm_90a"
+    if (major, minor) in {(10, 0), (10, 1)}:
+        return "sm_100a"
+    if (major, minor) == (8, 0):
+        return "sm_80"
+    return f"sm_{major}{minor}"
+
+
+# Must be set before importing cutlass.cute.
+os.environ.setdefault("CUTE_DSL_ARCH", _resolve_cute_dsl_arch())
+
+import cutlass
+import cutlass.cute as cute
+
+from . import nvl_ops
+
+_cuda_rt: Any = import_module("cuda.bindings.runtime")
+
+
+def _ensure_cuda_rt_compat() -> None:
+    """Idempotently shim cuda-bindings symbols the cutlass DSL JIT executor expects.
+
+    Some cuda-bindings versions lack ``cudaLibrary_t`` / ``cudaLibraryUnload``, so kernel
+    compilation cannot load the cuda library. This patches them in on first use (NOT at
+    import scope, per the don't-mutate-imported-module-attributes-at-import rule).
+    The installed ``cudaLibraryUnload`` is a process-wide no-op, so it can leak library
+    handles for OTHER callers of cuda.bindings.runtime -- we log a warning when installing
+    it so that side effect is visible rather than silent. Invoked lazily from the JIT paths
+    (just before cute.compile)."""
+    if hasattr(_cuda_rt, "cudaLibrary_t"):
+        return
+
+    class _cudaLibrary_t:
+        __slots__ = ("value",)
+
+        def __init__(self, value: int = 0) -> None:
+            self.value = value
+
+    logger.warning(
+        "installing process-wide cuda.bindings.runtime shim (cudaLibrary_t + "
+        "no-op cudaLibraryUnload); cudaLibraryUnload becomes a no-op for ALL callers"
+    )
+    _cuda_rt.cudaLibrary_t = _cudaLibrary_t
+    _cuda_rt.cudaLibraryUnload = lambda lib: (_cuda_rt.cudaError_t(0),)
+
+
+# ---------------------------------------------------------------------------
+# Shared CuTe send/recv substrate: the vectorized copy leaf + the per-slot
+# credit-ring primitives (``_send_slot`` / ``_recv_slot``). This is the backend
+# substrate home. A schedule composes these primitives by supplying its own per-peer
+# region/offset math, so a perf/codegen change here lands once and every composer
+# inherits it. The dependency is one-way: a composer imports these from here; nothing
+# here imports a schedule.
+# ---------------------------------------------------------------------------
+
+
+def _copy_atom(dtype: Any, vec: int, dbits: int):
+    """The vectorized gmem copy atom every schedule shares: VEC contiguous elems per
+    thread per copy, so the NVLink store is a vectorized st.global (up to 128-bit)
+    instead of a scalar store -- the single biggest copy-bandwidth lever (mirrors the
+    Triton 128-bit-store fix). The TV-tiled copy is built per schedule on top of it."""
+    return cute.make_copy_atom(
+        cute.nvgpu.CopyUniversalOp(),
+        dtype,
+        num_bits_per_copy=vec * dbits,
+    )
+
+
+def _copy_u(thr_copy, copy_atom, g_src, g_dst, t, n, num_blocks):
+    """Copy ``n`` consecutive (stride ``num_blocks``) tiles starting at ``t``:
+    issue all ``n`` loads, then all ``n`` stores, so ``n`` NVLink stores are in
+    flight per thread (mirrors NCCL's ``COLL_UNROLL`` -- the per-SM-extraction
+    lever Triton/TLX could not use because the wider per-thread footprint
+    spilled). STRAIGHT-LINE only (``n`` is constexpr; no control flow) so it is
+    safe to call from the kernel body -- CuTe only rewrites control flow in the
+    ``@cute.kernel`` function itself, so the grid-stride ``while`` stays inline
+    there. Correctness is unroll-independent: src and dst share one ``thr_copy``
+    partition, so any order copies the same elements."""
+    nb = num_blocks
+    frags = [
+        nvl_ops.get(copy_atom, thr_copy.partition_S(g_src[(None, t + i * nb)]))
+        for i in range(n)
+    ]
+    for i in range(n):
+        nvl_ops.put(
+            copy_atom, frags[i], thr_copy.partition_D(g_dst[(None, t + i * nb)])
+        )
+
+
+@cute.jit
+def _send_slot(
+    thr_copy,
+    copy_atom,
+    g_in,
+    g_send,
+    tail_remote,
+    start_send,
+    b,
+    tidx,
+    s: cutlass.Constexpr,
+    tiles_per_slot: cutlass.Constexpr,
+    num_tiles: cutlass.Constexpr,
+    num_blocks: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+) -> None:
+    """One credit-ring SEND slot: stage slot ``s`` into the peer's staging over NVLink,
+    then publish its data-ready TAIL.
+
+    Extracted as a ``@cute.jit`` device sub-function so every schedule composes the SAME
+    slot primitive. It carries the runtime grid-stride ``while`` + barrier + leader
+    signal, so it MUST be ``@cute.jit`` -- a plain helper would not get CuTe's
+    control-flow rewrite (see ``_copy_u``)."""
+    u = unroll
+    nb = num_blocks
+    s_lo = s * tiles_per_slot
+    s_hi = min((s + 1) * tiles_per_slot, num_tiles)
+    t = s_lo + b
+    while t + (u - 1) * nb < s_hi:
+        _copy_u(thr_copy, copy_atom, g_in, g_send, t, u, num_blocks)
+        t += u * nb
+    while t < s_hi:
+        _copy_u(thr_copy, copy_atom, g_in, g_send, t, 1, num_blocks)
+        t += nb
+    cute.arch.barrier()
+    if tidx == 0:
+        # data-ready for slots 0..s (monotonic counter).
+        nvl_ops.signal(tail_remote, start_send + s + 1)
+
+
+@cute.jit
+def _recv_slot(
+    thr_copy,
+    copy_atom,
+    g_recv,
+    g_out,
+    tail_local,
+    start_recv,
+    b,
+    tidx,
+    s: cutlass.Constexpr,
+    tiles_per_slot: cutlass.Constexpr,
+    num_tiles: cutlass.Constexpr,
+    num_blocks: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+) -> None:
+    """One credit-ring RECV slot: wait the peer's data-ready TAIL for slot ``s``, then
+    drain its matching staging slot into the output. Symmetric twin of :func:`_send_slot`;
+    same ``@cute.jit`` rationale."""
+    u = unroll
+    nb = num_blocks
+    p_lo = s * tiles_per_slot
+    p_hi = min((s + 1) * tiles_per_slot, num_tiles)
+    if tidx == 0:
+        nvl_ops.wait(tail_local, start_recv + s + 1)
+    cute.arch.barrier()
+    t = p_lo + b
+    while t + (u - 1) * nb < p_hi:
+        _copy_u(thr_copy, copy_atom, g_recv, g_out, t, u, num_blocks)
+        t += u * nb
+    while t < p_hi:
+        _copy_u(thr_copy, copy_atom, g_recv, g_out, t, 1, num_blocks)
+        t += nb
+
+
+# ---------------------------------------------------------------------------
+# Pipelined credit-ring send/recv collective (graph-safe), composed from the shared
+# _send_slot / _recv_slot substrate above. Single-peer-pair whole-buffer transfer,
+# keeping the slot send/drain overlap. uni (send-only / recv-only) and bidir are selected
+# by the do_send / do_recv constexprs. Graph-safe via the transport's persistent monotonic
+# counters + the symmetric-memory signal pad.
+# ---------------------------------------------------------------------------
+
+
+# Analytic tile / slot sizing for the pipelined send/recv geometry. Owned here so the
+# send/recv collective is self-contained; a fused multi-peer schedule reuses these.
+_SATURATION_THREADS: int = 32768
+_MIN_TILES: int = 32  # keep at least this many tiles so the pipeline has slots
+# Target number of pipeline slots per (peer, block) once pipelining is on. The
+# send/drain overlap approaches the send-only NVLink ceiling as slots grow (the
+# un-overlapped tail is one slot's drain), with diminishing returns vs per-slot
+# signal overhead; ~8 is the measured knee on H100. Overridable for the autotuner.
+_NUM_SLOTS: int = 8
+# Only pipeline when the per-peer chunk is large enough that the bandwidth-bound
+# send/drain overlap win beats the per-slot sync overhead. Below this the message
+# is latency-bound and a single shot (no extra barriers/signals/waits) is faster.
+# Measured on 8xH100: chunks <4MB regress under pipelining, >=8MB chunks gain
+# ~15-25%. Gated on bytes, not tiles -- 16MB and 64MB land at the same tile count
+# but opposite optima, so absolute size is the right signal.
+_MIN_PIPELINE_CHUNK_BYTES: int = 4 * 1024 * 1024
+# Per-peer chunk at/above which the deep (8-slot) run-ahead beats the shallow
+# (4-slot) one -- below it the deeper pipeline's per-slot sub-chunk is too small and
+# the sync overhead dominates (GB300, unroll=8). 64 MiB chunk.
+_DEEP_PIPELINE_CHUNK_BYTES: int = 64 * 1024 * 1024
+
+
+def _pick_tile(chunk: int, dbits: int, total_ctas: int) -> tuple[int, int]:
+    """Pick (num_threads, vec) so the per-(peer,block) chunk tiles EXACTLY.
+
+    Vec is the widest 128-bit-down-to-scalar copy the chunk allows (vec drops to 1
+    for tiny/odd chunks, so the whole 32B-2GB ladder tiles with no tail). Threads
+    are chosen CTA-aware: ``_SATURATION_THREADS / total_ctas`` (more warps per CTA
+    when few CTAs are in the SM budget), bounded so a small chunk keeps
+    ``_MIN_TILES`` tiles, floored so a chunk with real work is not under-threaded,
+    and capped at the 1024 hardware limit. An explicit ``A2A_CUTE_NT`` env overrides
+    the analytic pick (for sweeps / the autotuner).
+    """
+    env_nt = os.environ.get("A2A_CUTE_NT")
+    for vbits in (128, 64, 32, 16):
+        if vbits < dbits:
+            continue
+        vec = vbits // dbits
+        if chunk % vec:
+            continue
+        units = chunk // vec  # number of vectors to copy across the whole chunk
+        if env_nt is not None:
+            # Floor at 1 and cap at 1024 (mirrors the analytic branch): A2A_CUTE_NT="0" would
+            # otherwise return nt=0 and divide-by-zero in the caller's num_tiles math, and
+            # A2A_CUTE_NT>1024 would exceed the CUDA per-block thread cap and fail the launch.
+            nt = max(1, min(int(env_nt), units, 1024))
+        else:
+            nt = max(1, _SATURATION_THREADS // max(1, total_ctas))
+            nt = min(nt, max(1, units // _MIN_TILES))  # leave enough tiles
+            nt = min(nt, 1024)  # hardware cap
+            nt = max(nt, min(256, units))  # don't under-thread a chunk with work
+        nt = min(nt, units)
+        while nt > 1 and units % nt:
+            nt -= 1
+        # Final floor: the `min(nt, units)` above re-introduces nt=0 when units==0
+        # (chunk==0), which would divide-by-zero in the caller's num_tiles math.
+        return max(1, nt), vec
+    return 1, 1  # scalar fallback (chunk not a multiple of any vec width)
+
+
+def _pick_slots(num_tiles: int, chunk_bytes: int) -> tuple[int, int]:
+    """Split ``num_tiles`` into (num_slots, tiles_per_slot) for the send/drain
+    pipeline. Returns ``(1, num_tiles)`` (single shot, no pipeline) for per-peer
+    chunks below ``_MIN_PIPELINE_CHUNK_BYTES`` -- latency-bound sizes are faster
+    without the per-slot sync. An explicit ``A2A_CUTE_SLOTS`` env forces the slot
+    count (for sweeps / the autotuner)."""
+    if num_tiles <= 1:
+        return 1, 1
+    env_slots = os.environ.get("A2A_CUTE_SLOTS")
+    if env_slots is not None:
+        want = max(1, min(int(env_slots), num_tiles))
+    elif chunk_bytes < _MIN_PIPELINE_CHUNK_BYTES:
+        return 1, num_tiles  # single shot: latency-bound band
+    else:
+        # The mid-large band over-pipelines at 8 slots -- each slot's sub-chunk gets
+        # too small and the per-slot sync dominates, so 4 slots is the knee there; the
+        # >=64MB chunk band keeps 8 (the deeper run-ahead still wins).
+        want = min(
+            4 if chunk_bytes < _DEEP_PIPELINE_CHUNK_BYTES else _NUM_SLOTS, num_tiles
+        )
+    tps = (num_tiles + want - 1) // want
+    slots = (num_tiles + tps - 1) // tps  # re-derive exact slot count for this tps
+    return slots, tps

--- a/comms/dsl/tests/_bench_common.py
+++ b/comms/dsl/tests/_bench_common.py
@@ -1,0 +1,268 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# (suppression) Benchmark helpers over untyped torch.distributed / cute symbols pyre cannot
+# model; strict typing adds no value here (not shipped code).
+
+"""Backend-agnostic a2a benchmark helpers: CUDA-graph capture/replay timing, bus-bandwidth
+math, the probed NCCL runtime-grid table + num_blocks policy, and the NCCL baseline."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import statistics
+from typing import Any, Callable
+
+import torch
+import torch.distributed as dist
+
+
+_DTYPE: torch.dtype = torch.bfloat16
+
+
+# NCCL all_to_all actual LAUNCHED a2a-kernel grid (ncclDevKernel_SendRecv gridDim.x; block is a
+# fixed 640 threads, send+recv fused in one CTA) per (per-rank msg bytes, NCCL channel cap).
+# Used to SM-match the framework grid (ws * num_blocks) to NCCL for an apple-to-apple compare.
+#
+# `cap` is the NCCL channel cap in force (NCCL_MAX_NCHANNELS=NCCL_MIN_NCHANNELS=cap); the value
+# is the grid NCCL ACTUALLY launches under it. This is a real per-(size, cap) measurement, NOT
+# min(natural, cap): NCCL's scheduleP2pTasksToPlan adaptively drops the active grid BELOW the
+# cap/allocation for small messages, so the (size, cap) matrix does not collapse to a single
+# per-size number. (NCCL_DEBUG=INFO "N p2p channels" is the ALLOCATION, which over-reports this
+# launched grid.)
+#
+# Measured via tests/_probe_nccl_grid.py (torch.profiler launched-kernel grid; run once per cap
+# with NCCL_MAX_NCHANNELS=NCCL_MIN_NCHANNELS=cap), cross-checked against nsys cuda_gpu_trace
+# (64KB -> grid 8, block 640; both agree). Re-run on an NCCL version OR NVLink-topology change
+# (the ceiling is topology-derived, not GPU-arch-derived -- NCCL's p2p channel math has no
+# SM-count / sm_90-vs-sm_100 dependence). Validated on:
+#   - NCCL/NCCLX version : 2.30.7
+#   - topology           : 8-GPU single-node NVLink
+_NCCL_A2A_GRID_TABLE: dict[tuple[int, int], int] = {
+    (65536, 8): 8,  # 64KB
+    (65536, 16): 8,
+    (65536, 32): 8,
+    (262144, 8): 8,  # 256KB
+    (262144, 16): 8,
+    (262144, 32): 8,
+    (1048576, 8): 8,  # 1MB
+    (1048576, 16): 16,
+    (1048576, 32): 16,
+    (8388608, 8): 8,  # 8MB
+    (8388608, 16): 16,
+    (8388608, 32): 32,
+    (50331648, 8): 8,  # 48MB
+    (50331648, 16): 16,
+    (50331648, 32): 32,
+    (67108864, 8): 8,  # 64MB
+    (67108864, 16): 16,
+    (67108864, 32): 32,
+    (100663296, 8): 8,  # 96MB
+    (100663296, 16): 16,
+    (100663296, 32): 32,
+    (268435456, 8): 8,  # 256MB
+    (268435456, 16): 16,
+    (268435456, 32): 32,
+    (536870912, 8): 8,  # 512MB
+    (536870912, 16): 16,
+    (536870912, 32): 32,
+    (1073741824, 8): 8,  # 1GB
+    (1073741824, 16): 16,
+    (1073741824, 32): 32,
+    (2147483648, 8): 8,  # 2GB
+    (2147483648, 16): 16,
+    (2147483648, 32): 32,
+}
+
+
+_WARMUP_ITERS: int = 20
+
+
+_CAPTURE_WARMUP_ITERS: int = 3
+
+
+def _iters_for_size(msg_bytes: int) -> int:
+    if msg_bytes <= 64 * 1024:
+        return 500
+    if msg_bytes <= 64 * 1024 * 1024:
+        return 200
+    return 50
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _capture_one_call(fn: Callable[[], None]) -> torch.cuda.CUDAGraph:
+    """Warm up ``fn`` on a side stream, then capture a single call into a graph."""
+    side_stream = torch.cuda.Stream()
+    side_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side_stream):
+        for _ in range(_CAPTURE_WARMUP_ITERS):
+            fn()
+    torch.cuda.current_stream().wait_stream(side_stream)
+
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g, stream=side_stream):
+        fn()
+    return g
+
+
+def _time_replays(
+    g: torch.cuda.CUDAGraph,
+    iters: int,
+    device: torch.device,
+    group: dist.ProcessGroup,
+    windows: int | None = None,
+) -> float:
+    """Steady-state us/iter: median over ``windows`` warmed, re-barriered windows.
+
+    Each window event-times ``iters`` graph replays after a fresh ``dist.barrier``
+    re-aligns both ranks, and the median across windows rejects the occasional bad window
+    (a transient SM-clock dip or neighbour kernel) that a single long mean would bake in.
+    """
+    if windows is None:
+        # Read lazily (not at module scope). `or "5"` covers an EMPTY value (env plumbing
+        # often sets ""), try/except covers a non-numeric typo, and max(1, ...) floors
+        # 0/negative -- so a bad A2A_PERF_WINDOWS falls back to 5 instead of crashing.
+        try:
+            windows = max(1, int(os.environ.get("A2A_PERF_WINDOWS") or "5"))
+        except ValueError:
+            windows = 5
+    # The inner `iters` loop free-runs graph replays with NO per-iter cross-rank barrier
+    # (only a per-window one), which looks like the reused-transport hazard the a2a docs warn
+    # about. It is safe HERE: correctness is already gated before capture (in the caller), so
+    # the timing loop only measures steady-state throughput -- a staging write-after-read
+    # during timing corrupts data we never re-check. It cannot hang either: the transport's
+    # monotonic step counters mean every device wait eventually sees its (ever-increasing)
+    # signal even under rank drift. The per-window dist.barrier re-aligns both ranks so each
+    # window's median is clean.
+    for _ in range(_WARMUP_ITERS):
+        g.replay()
+    torch.cuda.synchronize(device)
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    samples = []
+    for _ in range(windows):
+        dist.barrier(group)
+        torch.cuda.synchronize(device)
+        start.record()
+        for _ in range(iters):
+            g.replay()
+        end.record()
+        torch.cuda.synchronize(device)
+        samples.append((start.elapsed_time(end) * 1000.0) / iters)
+    return statistics.median(samples)
+
+
+def _max_rank_latency(
+    lat_us: float, device: torch.device, group: dist.ProcessGroup
+) -> float:
+    latency = torch.tensor([lat_us], dtype=torch.float64, device=device)
+    dist.all_reduce(latency, op=dist.ReduceOp.MAX, group=group)
+    return float(latency.item())
+
+
+def _bus_bytes(numel: int, ws: int) -> int:
+    """Per-rank NVLink-traversing bytes (diagonal chunk excluded)."""
+    chunk = numel // ws
+    return chunk * (ws - 1) * torch.tensor([], dtype=_DTYPE).element_size()
+
+
+def _bw_gbps(numel: int, ws: int, lat_us: float) -> float:
+    return (_bus_bytes(numel, ws) / 1e9) / (lat_us / 1e6) if lat_us > 0 else 0.0
+
+
+def _fmt_size(nbytes: int) -> str:
+    """Human-readable per-rank byte size for the result table, e.g. 65536 -> ``64KB``,
+    50331648 -> ``48MB``, 2147483648 -> ``2GB``."""
+    x = float(nbytes)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if x < 1024.0:
+            return f"{x:.0f}{unit}" if x == int(x) else f"{x:.1f}{unit}"
+        x /= 1024.0
+    return f"{x:.1f}PB"
+
+
+def _make_input(rank: int, numel: int, device: torch.device) -> torch.Tensor:
+    base = (rank + 1) * 4096
+    return (base + torch.arange(numel, device=device, dtype=torch.float32)).to(_DTYPE)
+
+
+def _max_num_blocks(ws: int, device: torch.device, mbp: int) -> int:
+    # Grid is ws * num_blocks (one CTA per (peer, block)), so the SM budget bounds
+    # num_blocks at sm // ws.
+    sm = torch.cuda.get_device_properties(device).multi_processor_count
+    return max(min(mbp, sm // ws), 1)
+
+
+def _framework_num_blocks(
+    msg_bytes: int, cap: int, ws: int, device: torch.device, mbp: int
+) -> tuple[int, int | None]:
+    """Pick framework num_blocks to track NCCL's runtime grid (SM-matched).
+
+    Returns ``(num_blocks, nccl_grid_or_None)``. The framework device grid is
+    ``ws * num_blocks``, matched to NCCL's active SMs via ``num_blocks ~= nccl_grid / ws``,
+    where ``nccl_grid`` is NCCL's actual launched grid for this (size, cap) from
+    ``_NCCL_A2A_GRID_TABLE``. If the (size, cap) has not been probed, fall back to the
+    SM-budget ceiling and return ``None`` so the row is flagged as not-yet-matched.
+    """
+    nb_cap = _max_num_blocks(ws, device, mbp)
+    nccl_grid = _NCCL_A2A_GRID_TABLE.get((msg_bytes, cap))
+    if nccl_grid is None:
+        return nb_cap, None
+    # Framework grid = ws * num_blocks; match it to NCCL's active SMs.
+    nb = max(round(nccl_grid / ws), 1)
+    return min(nb, nb_cap), nccl_grid
+
+
+def _bench_nccl(
+    msg_bytes: int, rank: int, ws: int, group: dist.ProcessGroup
+) -> tuple[float, float]:
+    device = torch.device("cuda", torch.cuda.current_device())
+    numel = max(msg_bytes // torch.tensor([], dtype=_DTYPE).element_size(), ws)
+    numel -= numel % ws
+    inp: torch.Tensor = _make_input(rank, numel, device)
+    out: torch.Tensor = torch.empty_like(inp)
+
+    def fn() -> None:
+        dist.all_to_all_single(out, inp, group=group)
+
+    fn()
+    dist.barrier(group)
+    g = _capture_one_call(fn)
+    dist.barrier(group)
+
+    iters = _iters_for_size(msg_bytes)
+    lat = _max_rank_latency(_time_replays(g, iters, device, group), device, group)
+    return lat, _bw_gbps(numel, ws, lat)
+
+
+_RESULT_TAG: str = "A2A_RESULT_JSON"
+
+
+def emit_result_rows(rows: list[dict[str, Any]]) -> None:
+    """DSL-agnostic durable result sink: print one compact JSON object per row to stdout,
+    each tagged with a stable prefix.
+
+    This is the channel the AnyBench parser (``anybench_a2a_cute_parser.py``) reads back
+    from each rank's ``$ANYBENCH_LOGS_DIR/rank_*/stdout.log`` and pushes to the
+    ``anybench_parser_output`` Scuba dataset. stdout is durable on MAST via the AnyBench log
+    capture, so no benchmark-side Scuba/Scribe dependency is needed. Best-effort: never
+    raises into the benchmark."""
+    for row in rows:
+        try:
+            print(f"{_RESULT_TAG} " + json.dumps(row, sort_keys=True), flush=True)
+        except (TypeError, ValueError, OSError) as e:
+            # Best-effort sink: an unserializable row (TypeError/ValueError) or a broken
+            # stdout (OSError/BrokenPipeError, e.g. MAST log rotation) must not abort the
+            # benchmark. The fallback print can itself hit the broken stream, so guard it too.
+            try:
+                print(f"(emit_result_rows skipped a row: {e})", flush=True)
+            except OSError:
+                pass

--- a/comms/dsl/tests/_dist_harness.py
+++ b/comms/dsl/tests/_dist_harness.py
@@ -1,0 +1,39 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Shared multi-rank scaffolding for the distributed correctness suites.
+
+The small helpers every distributed test repeats: a free-port picker, the bit-exact
+input builder, and the cross-rank PASS/FAIL min-reduce + reporter. Kept here so the
+scaffolding lives in one place.
+"""
+
+import socket
+
+import torch
+import torch.distributed as dist
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _make_input(rank: int, numel: int, device: torch.device) -> torch.Tensor:
+    idx = torch.arange(numel, device=device, dtype=torch.int64)
+    return ((rank + 1) * 1_000_000 + idx).to(torch.float32)
+
+
+def _all_ok(local_ok: bool, device: torch.device, group: dist.ProcessGroup) -> bool:
+    status = torch.tensor([1 if local_ok else 0], dtype=torch.int32, device=device)
+    dist.all_reduce(status, op=dist.ReduceOp.MIN, group=group)
+    return bool(status.item())
+
+
+def _report(name: str, local_ok: bool, device, group, rank: int) -> bool:
+    ok = _all_ok(local_ok, device, group)
+    if rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: {name}", flush=True)
+    return ok

--- a/comms/dsl/tests/_dist_harness.py
+++ b/comms/dsl/tests/_dist_harness.py
@@ -26,6 +26,20 @@ def _make_input(rank: int, numel: int, device: torch.device) -> torch.Tensor:
     return ((rank + 1) * 1_000_000 + idx).to(torch.float32)
 
 
+def _golden(group: dist.ProcessGroup, inp: torch.Tensor) -> torch.Tensor:
+    """Reference equal-split all_to_all via ``dist.all_to_all_single``."""
+    out = torch.empty_like(inp)
+    dist.all_to_all_single(out, inp, group=group)
+    return out
+
+
+def _rendezvous(group: dist.ProcessGroup, device: torch.device, chunk: int):
+    """Rendezvous a transport sized for a per-peer fp32 chunk (the a2a test contract)."""
+    from comms.dsl import nvl_rendezvous
+
+    return nvl_rendezvous(group, device, per_peer_bytes=chunk * 4)
+
+
 def _all_ok(local_ok: bool, device: torch.device, group: dist.ProcessGroup) -> bool:
     status = torch.tensor([1 if local_ok else 0], dtype=torch.int32, device=device)
     dist.all_reduce(status, op=dist.ReduceOp.MIN, group=group)

--- a/comms/dsl/tests/_probe_nccl_grid.py
+++ b/comms/dsl/tests/_probe_nccl_grid.py
@@ -1,0 +1,119 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Dev tool: measure NCCL all_to_all_single's real active-SM grid (kernel gridDim) per
+per-rank message size (single node). Provenance for the values in
+``_bench_common._NCCL_A2A_GRID_TABLE`` (the actual launched grid per (size, cap); run once per
+cap with NCCL_MAX_NCHANNELS=NCCL_MIN_NCHANNELS=cap to fill the matrix); re-run when
+NCCL / hardware changes:
+
+    buck2 run @fbcode//mode/opt //comms/dsl/tests:_probe_nccl_grid
+
+Method: run a2a under torch.profiler and read the max gridDim.x over the NCCL kernels from the
+chrome trace -- the actual launched grid (ncclDevKernel_SendRecv, block=640, send+recv fused in
+one CTA), not the allocated channel count. Cross-checked against nsys cuda_gpu_trace (64KB ->
+grid 8, block 640; both agree). Do NOT run this under nsys -- nsys and torch.profiler conflict
+(the chrome trace comes back without grid); use one or the other.
+"""
+
+import json
+import os
+import socket
+import tempfile
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+_DTYPE = torch.bfloat16
+# per-rank message sizes to probe (the estimated rows + a few known ones to validate method).
+_SIZES = [
+    ("64KB", 65536),  # known natural=8
+    ("1MB", 1048576),  # known natural=16
+    ("8MB", 8388608),  # known natural=32
+    ("48MB", 50331648),  # was ESTIMATED
+    ("64MB", 67108864),  # known natural=32
+    ("96MB", 100663296),  # was ESTIMATED
+    ("256MB", 268435456),  # known natural=32
+    ("512MB", 536870912),  # was ESTIMATED
+    ("1GB", 1073741824),  # was ESTIMATED
+    ("2GB", 2147483648),  # was fallback (not in table)
+]
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _grid_from_trace(path: str) -> int:
+    """Max gridDim.x over NCCL a2a/sendrecv kernels in a chrome trace."""
+    with open(path) as f:
+        tr = json.load(f)
+    best = 0
+    for e in tr.get("traceEvents", []):
+        name = str(e.get("name", "")).lower()
+        if "nccl" not in name and "sendrecv" not in name and "alltoall" not in name:
+            continue
+        g = e.get("args", {}).get("grid")
+        if isinstance(g, list) and g:
+            best = max(best, int(g[0]))
+    return best
+
+
+def _worker(rank: int, ws: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=ws)
+    device = torch.device(f"cuda:{rank}")
+    try:
+        for label, msg in _SIZES:
+            numel = max(msg // 2, ws)
+            numel -= numel % ws
+            inp = torch.randn(numel, dtype=_DTYPE, device=device)
+            out = torch.empty_like(inp)
+            for _ in range(5):  # warm up / let NCCL settle channels
+                dist.all_to_all_single(out, inp)
+            torch.cuda.synchronize()
+            with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tf:
+                tpath = tf.name
+            try:
+                with torch.profiler.profile(
+                    activities=[torch.profiler.ProfilerActivity.CUDA]
+                ) as prof:
+                    for _ in range(3):
+                        dist.all_to_all_single(out, inp)
+                    torch.cuda.synchronize()
+                prof.export_chrome_trace(tpath)
+                grid = _grid_from_trace(tpath)
+            finally:
+                if os.path.exists(tpath):
+                    os.remove(tpath)
+            # A 0 means no NCCL kernel grid was found (renamed kernel / changed trace schema),
+            # NOT a real measurement -- fail loud so a bad probe is never copied into the table.
+            if grid == 0:
+                raise RuntimeError(
+                    f"probe failed for {label} (msg={msg}): no NCCL kernel gridDim found in "
+                    "the profiler trace -- kernel name filter or trace schema may have changed."
+                )
+            if rank == 0:
+                print(f"PROBE {label:>6} msg={msg} nccl_grid={grid}", flush=True)
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+def main() -> None:
+    ws = min(torch.cuda.device_count(), 8)
+    print(
+        f"probing NCCL a2a grid on {ws} GPUs ({torch.cuda.get_device_name(0)})",
+        flush=True,
+    )
+    mp.spawn(_worker, args=(ws, _find_free_port()), nprocs=ws, join=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/dsl/tests/anybench_a2a_cute.json
+++ b/comms/dsl/tests/anybench_a2a_cute.json
@@ -1,0 +1,32 @@
+{
+  "mast_job_request": {
+    "user_label": "AnyBench comms/dsl CuTe a2a (copy) vs NCCL (8x GB300)",
+    "hpc_cluster": "MastProdCluster",
+    "scheduler": "MAST",
+    "num_hosts": [2],
+    "entitlement": "infra_projects",
+    "hardware": "T20_CIC_GB300_278GB_HBM3E_NVLSO_DSF",
+    "benchmark_config": {
+      "anybench_test_config": [
+        {
+          "fbpkg_name": "comms.dsl.benchmark_a2a.aarch64.gb300",
+          "binary_path": "penv.par",
+          "binary_args": "",
+          "env_vars": {
+            "A2A_CAPS": "32",
+            "DISABLE_OILFS": "1",
+            "TRITON_CACHE_DIR": "/tmp/triton_cache"
+          },
+          "iteration": 1,
+          "timeout": 1800,
+          "ppn": 4,
+          "parser": {
+            "command": "python3 $ANYBENCH_PARSER",
+            "parser_path": "comms/dsl/tests/anybench_a2a_cute_parser.py",
+            "timeout": 120
+          }
+        }
+      ]
+    }
+  }
+}

--- a/comms/dsl/tests/anybench_a2a_cute_parser.py
+++ b/comms/dsl/tests/anybench_a2a_cute_parser.py
@@ -1,0 +1,109 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""AnyBench parser for the CuTe a2a (copy) benchmark -- the UniBench result sink.
+
+AnyBench runs ``benchmark_a2a_cute`` on MAST, then invokes this parser via ``bash -c`` with
+``$ANYBENCH_LOGS_DIR`` pointing at ``<dir>/rank_<n>/stdout.log`` per rank. The benchmark's
+rank 0 prints one ``A2A_RESULT_JSON {<json>}`` line per size via
+``comms.dsl.tests._bench_common.emit_result_rows``; this parser scrapes those lines and
+prints a SINGLE JSON object to stdout, which AnyBench pushes to the ``anybench_parser_output``
+Scuba dataset (top-level keys become columns).
+
+Contract: read logs, print exactly one JSON object, exit 0. A parse miss is reported in the
+object (never a nonzero exit) so it does not fail the benchmark run.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import sys
+from typing import Any
+
+_TAG = "A2A_RESULT_JSON "
+
+
+def _collect_rows(logs_dir: str) -> list[dict[str, Any]]:
+    """Every ``A2A_RESULT_JSON`` row across all per-rank stdout logs (rank 0 emits them)."""
+    rows: list[dict[str, Any]] = []
+    for log in sorted(glob.glob(os.path.join(logs_dir, "rank_*", "stdout.log"))):
+        try:
+            with open(log, "r", errors="replace") as f:
+                for line in f:
+                    idx = line.find(_TAG)
+                    if idx == -1:
+                        continue
+                    try:
+                        obj = json.loads(line[idx + len(_TAG) :].strip())
+                    except json.JSONDecodeError:
+                        continue
+                    # json.loads can return a list/number/string; keep only dict rows so
+                    # _summarize's r.get(...) never hits a non-dict (never-fail contract).
+                    if isinstance(obj, dict):
+                        rows.append(obj)
+        except OSError:
+            continue
+    return rows
+
+
+def _summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate per-size copy rows into one AnyBench result object.
+
+    Emits the perf verdict (min busbw ratio vs NCCL, whether every size cleared NCCL) plus
+    per-size arrays and the raw rows (JSON-encoded)."""
+    perf = [r for r in rows if r.get("backend") == "cute" and "ratio" in r]
+    errors = [r for r in rows if r.get("backend") == "cute_error"]
+    copy_rows = sorted(
+        (r for r in perf if r.get("variant") == "copy"),
+        key=lambda r: int(r.get("size_bytes", 0)),
+    )
+    # Include ALL copy rows (not `if r.get("ratio")`): a ratio of 0.0 is the sentinel the
+    # benchmark emits when NCCL timing failed/was unavailable for that size, so a truthy
+    # filter would silently drop the failed sizes and let min_ratio / all_clear_nccl
+    # over-report. Keep the 0.0s (they sink min_ratio and fail the >=1.0 check) and surface
+    # the count as a coverage gap.
+    ratios = [float(r["ratio"]) for r in copy_rows]
+    n_nccl_failed = sum(1 for x in ratios if x <= 0.0)
+    out: dict[str, Any] = {
+        "n_result_rows": len(copy_rows),
+        "n_errors": len(errors),
+        "n_nccl_failed": n_nccl_failed,
+        # world_size from the first copy row: one AnyBench job == one benchmark invocation at
+        # a single world_size, so every row agrees.
+        "world_size": int(copy_rows[0].get("world_size", 0)) if copy_rows else 0,
+        "min_ratio_busbw": min(ratios) if ratios else 0.0,
+        "all_clear_nccl": bool(ratios) and all(x >= 1.0 for x in ratios),
+        "size_bytes": [int(r.get("size_bytes", 0)) for r in copy_rows],
+        "cute_us": [float(r.get("cute_us", 0.0)) for r in copy_rows],
+        "nccl_us": [float(r.get("nccl_us", 0.0)) for r in copy_rows],
+        "cute_busbw_gbps": [float(r.get("cute_busbw_gbps", 0.0)) for r in copy_rows],
+        "nccl_busbw_gbps": [float(r.get("nccl_busbw_gbps", 0.0)) for r in copy_rows],
+        "ratio": [float(r.get("ratio", 0.0)) for r in copy_rows],
+        # Full per-size matrix for ad-hoc querying (JSON-encoded column).
+        "rows_json": json.dumps(perf, sort_keys=True),
+    }
+    if errors:
+        out["first_error"] = str(errors[0].get("error", ""))[:900]
+    return out
+
+
+def main() -> None:
+    # Honor the never-fail contract end-to-end: a malformed row value (wrong type / non-numeric)
+    # could still raise inside _summarize, so wrap it and always emit ONE JSON object + exit 0.
+    logs_dir = os.environ.get("ANYBENCH_LOGS_DIR", "")
+    try:
+        rows = _collect_rows(logs_dir) if logs_dir else []
+        result = _summarize(rows)
+    except Exception as e:  # noqa: BLE001 -- parser must never fail the benchmark run
+        result = {"parse_note": f"summarize error: {type(e).__name__}: {e}"[:900]}
+    if not logs_dir:
+        result["parse_note"] = "ANYBENCH_LOGS_DIR unset"
+    print(json.dumps(result, sort_keys=True))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/dsl/tests/benchmark_a2a_cute.py
+++ b/comms/dsl/tests/benchmark_a2a_cute.py
@@ -54,6 +54,12 @@ from ._bench_common import (
     _time_replays,
     emit_result_rows,
 )
+from .ncu_common import (
+    build_driver_shim,
+    NCU_DEFAULT_METRICS,
+    ncu_wrap_argv,
+    resolve_ncu_bin,
+)
 
 # 32 B -> 2 GB per rank, 2x stepping (27 sizes) plus 48 MB / 96 MB for mid-band resolution
 # = 29 sizes.
@@ -342,13 +348,81 @@ def _torchrun_main() -> None:
         sys.exit(1)
 
 
-def main() -> None:
-    if "RANK" in os.environ and "WORLD_SIZE" in os.environ:
-        _torchrun_main()
+def _maybe_reexec_under_ncu(args: argparse.Namespace, is_torchrun: bool) -> None:
+    """Re-exec this benchmark once under NCU when requested."""
+    if not args.ncu or os.environ.get("A2A_UNDER_NCU") == "1":
         return
+    os.makedirs(os.path.dirname(args.ncu_out) or ".", exist_ok=True)
+    if (
+        any(
+            not metric.strip().startswith("launch__")
+            for metric in args.ncu_metrics.split(",")
+            if metric.strip()
+        )
+        and not args.ncu_kernel_regex
+    ):
+        print(
+            "[ncu] WARNING: non-launch__ metrics need kernel replay, which can DEADLOCK "
+            "the a2a comm kernel (no lockstep until NCU 2026.1.1+). Target a non-comm "
+            "kernel with --ncu-kernel-regex, or expect a hang.",
+            flush=True,
+        )
+    env = {**os.environ, "A2A_UNDER_NCU": "1"}
+    if args.ncu_driver_shim:
+        env.update(build_driver_shim(args.ncu_driver_shim))
+    program = (
+        [sys.executable, "-m", "comms.dsl.tests.benchmark_a2a_cute"]
+        if sys.argv[0].endswith(".py")
+        else [sys.argv[0]]
+    )
+    # world-size is currently the only non-NCU benchmark option that the child needs.
+    inner = program if is_torchrun else program + ["--world-size", str(args.world_size)]
+    argv = ncu_wrap_argv(
+        inner,
+        ncu_bin=resolve_ncu_bin(args.ncu_path),
+        out_prefix=args.ncu_out,
+        metrics=args.ncu_metrics,
+        launch_count=args.ncu_launch_count,
+        kernel_regex=args.ncu_kernel_regex,
+    )
+    print(f"[ncu] re-exec: {' '.join(argv)}", flush=True)
+    os.execvpe(argv[0], argv, env)
+
+
+def main() -> None:
+    is_torchrun = "RANK" in os.environ and "WORLD_SIZE" in os.environ
     p = argparse.ArgumentParser()
     p.add_argument("--world-size", type=int, default=min(torch.cuda.device_count(), 8))
-    args = p.parse_args()
+    p.add_argument(
+        "--ncu",
+        action="store_true",
+        help="re-exec under Nsight Compute. Local: ncu --target-processes all covers every "
+        "mp.spawn rank. torchrun/MAST: each rank re-execs itself under ncu. Single-pass "
+        "launch metrics only -- multi-pass replay deadlocks the comm kernel (need 2026.1.1+).",
+    )
+    p.add_argument("--ncu-metrics", default=NCU_DEFAULT_METRICS)
+    p.add_argument("--ncu-launch-count", type=int, default=1)
+    p.add_argument("--ncu-out", default="/tmp/ncu_a2a")
+    p.add_argument("--ncu-kernel-regex", default="")
+    p.add_argument("--ncu-path", default="")
+    p.add_argument(
+        "--ncu-driver-shim",
+        default="",
+        help="platform driver lib dir to build a narrow NCU driver shim from (needed in "
+        "MAST containers, e.g. /usr/local/fbcode/platform010-aarch64/lib); empty skips it "
+        "(local dev, driver already resolvable).",
+    )
+    # Strict locally (catch typo'd flags); tolerant only under torchrun, which may append
+    # its own launcher args to the program argv.
+    if is_torchrun:
+        args, _ = p.parse_known_args()
+    else:
+        args = p.parse_args()
+    _maybe_reexec_under_ncu(args, is_torchrun)
+
+    if is_torchrun:
+        _torchrun_main()
+        return
     if args.world_size < 2:
         print("needs >=2 GPUs")
         return

--- a/comms/dsl/tests/benchmark_a2a_cute.py
+++ b/comms/dsl/tests/benchmark_a2a_cute.py
@@ -1,0 +1,364 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# Benchmark harness (not shipped code): exercises untyped cutlass/cute DSL kernels + dynamic
+# torch.distributed symbols that pyre cannot model, so strict typing adds no value here.
+
+"""Apple-to-apple all_to_all benchmark: CuTe-DSL copy kernel vs NCCL.
+
+Runtime-SM matched (the framework grid ``world_size * num_blocks`` is set to NCCL's probed
+active-SM count for each size, via ``_framework_num_blocks``), CUDA-graph timed, median of
+windows -- so the CuTe copy kernel is compared to ``dist.all_to_all_single`` on the same SM
+budget. Sweeps 32 B -> 2 GB per rank (2x step) plus 48 MB / 96 MB for mid-band resolution.
+
+Both metrics are reported per size: **latency** (us/call) is the meaningful comparison at
+small (latency-bound) sizes, **bus bandwidth** (GB/s/dir) at large (bandwidth-bound) sizes.
+Every runnable size is correctness-gated against NCCL gold before timing. All tensors are
+bf16 (the perf-relevant a2a dtype; see ``_bench_common._DTYPE``).
+
+The SM match uses a probed NCCL active-SM grid table
+(``_bench_common._NCCL_A2A_GRID_TABLE``, measured via ``tests/_probe_nccl_grid.py``). Only the
+probed anchor sizes in that table are SM-matched; any other sweep size (below 64 KiB, and the
+in-between 2x steps such as 128 KiB / 2 MB / 16 MB / 128 MB) falls back to the SM-budget
+ceiling and is reported with ``nccl_grid=0`` -- indicative, not SM-matched.
+
+Runs single-node (``mp.spawn``, default) for the local feedback loop, or one-process-per-rank
+under ``torchrun`` / the conda launcher for GB300 2x4.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from ._bench_common import (
+    _bench_nccl,
+    _bw_gbps,
+    _capture_one_call,
+    _DTYPE,
+    _find_free_port,
+    _fmt_size,
+    _framework_num_blocks,
+    _iters_for_size,
+    _make_input,
+    _max_rank_latency,
+    _time_replays,
+    emit_result_rows,
+)
+
+# 32 B -> 2 GB per rank, 2x stepping (27 sizes) plus 48 MB / 96 MB for mid-band resolution
+# = 29 sizes.
+_DEFAULT_SIZES: list[int] = [
+    32,
+    64,
+    128,
+    256,
+    512,
+    1024,
+    2 * 1024,
+    4 * 1024,
+    8 * 1024,
+    16 * 1024,
+    32 * 1024,
+    64 * 1024,
+    128 * 1024,
+    256 * 1024,
+    512 * 1024,
+    1 * 1024 * 1024,
+    2 * 1024 * 1024,
+    4 * 1024 * 1024,
+    8 * 1024 * 1024,
+    16 * 1024 * 1024,
+    32 * 1024 * 1024,
+    48 * 1024 * 1024,
+    64 * 1024 * 1024,
+    96 * 1024 * 1024,
+    128 * 1024 * 1024,
+    256 * 1024 * 1024,
+    512 * 1024 * 1024,
+    1024 * 1024 * 1024,
+    2 * 1024 * 1024 * 1024,
+]
+
+# Below this per-rank size latency is the meaningful metric (latency-bound); at/above it
+# bus bandwidth is (bandwidth-bound). Only affects which ratio the table highlights.
+_LATENCY_BAND_BYTES: int = 1 * 1024 * 1024
+
+
+def _get_sizes() -> list[int]:
+    """Size ladder, overridable via A2A_SIZES=csv. Read lazily (not at import) per python.md."""
+    env = os.environ.get("A2A_SIZES", "")
+    if env:
+        return [int(x) for x in env.split(",") if x]
+    return _DEFAULT_SIZES
+
+
+def _get_cap() -> int:
+    """SM cap, overridable via A2A_CAPS. Read lazily (not at import) per python.md."""
+    return int(os.environ.get("A2A_CAPS", "32"))
+
+
+def _bench_cute(transport, msg_bytes, rank, ws, group, *, num_blocks):
+    """CuTe copy a2a (latency_us, busbw) at this size. NCCL-gold correctness gate.
+
+    The copy schedule uses the analytic adaptive config pinned to ``num_blocks`` (the
+    SM-matched grid)."""
+    from comms.dsl.cute import all_to_all
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+    device = torch.device("cuda", torch.cuda.current_device())
+    elem = torch.tensor([], dtype=_DTYPE).element_size()
+    numel = max(msg_bytes // elem, ws)
+    numel -= numel % ws  # largest multiple of ws <= numel; always >= ws >= 1
+    inp = _make_input(rank, numel, device)
+    gold = torch.empty_like(inp)
+    dist.all_to_all_single(gold, inp, group=group)
+    out = torch.empty_like(inp)
+
+    def fn():
+        all_to_all(transport, out, inp, config=CuteA2AConfig(num_blocks=num_blocks))
+
+    fn()
+    torch.cuda.synchronize(device)
+    # Decide correctness COLLECTIVELY before entering any follow-up collective. torch.equal is
+    # a LOCAL check, so a kernel bug that corrupts only some ranks' output would have the
+    # mismatching ranks raise here while the passing ranks march into _capture_one_call's
+    # collectives -- a split that hangs the job. All-reduce the verdict so every rank raises
+    # together and the caller's flag mechanism stays in sync.
+    correct = bool(torch.equal(out, gold))
+    verdict = torch.tensor([0 if correct else 1], device=device)
+    dist.all_reduce(verdict, group=group)
+    if verdict.item() > 0:
+        raise AssertionError(
+            f"cute a2a INCORRECT at msg_bytes={msg_bytes}, nb={num_blocks}"
+        )
+    g = _capture_one_call(fn)
+    dist.barrier(group)
+    iters = _iters_for_size(msg_bytes)
+    lat = _max_rank_latency(_time_replays(g, iters, device, group), device, group)
+    return lat, _bw_gbps(numel, ws, lat)
+
+
+def _run(rank, ws, group, device) -> bool:  # noqa: C901
+    from comms.dsl import nvl_rendezvous
+
+    mbp = 32
+    # Re-rendezvous one transport per size, sized to that size's chunk, so geometry stays
+    # uniform across the sweep.
+    rows: list[tuple[Any, ...]] = []
+    ok = True
+    for msg_bytes in _get_sizes():
+        elem = torch.tensor([], dtype=_DTYPE).element_size()
+        numel = max(msg_bytes // elem, ws)
+        numel -= numel % ws  # largest multiple of ws <= numel; always >= ws >= 1
+        chunk = numel // ws
+        # _framework_num_blocks already returns min(nb, _max_num_blocks(ws, device, mbp)).
+        nb, nccl_grid = _framework_num_blocks(msg_bytes, _get_cap(), ws, device, mbp)
+        t = nvl_rendezvous(group, device, per_peer_bytes=chunk * elem)
+        failed = False
+        try:
+            cute_lat, cute_bw = _bench_cute(
+                t, msg_bytes, rank, ws, group, num_blocks=nb
+            )
+        except Exception as e:  # noqa: BLE001
+            if rank == 0:
+                msg = f"{type(e).__name__}: {e}"
+                print(f"  # {_fmt_size(msg_bytes)} FAILED: {msg}", flush=True)
+                emit_result_rows(
+                    [
+                        {
+                            "backend": "cute_error",
+                            "size_bytes": int(msg_bytes),
+                            "error": msg[:900],
+                        }
+                    ]
+                )
+            ok = False
+            cute_lat = cute_bw = None
+            failed = True
+        # Make the per-rank _bench_cute failure GLOBAL immediately after the raising call: a
+        # mid-collective raise on one rank desyncs NCCL, so a surviving rank must NOT march
+        # into the following barrier / _bench_nccl while a peer aborted. MAX-reduce the flag
+        # and, on ANY rank's failure, stop the sweep on ALL ranks in lockstep.
+        flag = torch.tensor([1.0 if failed else 0.0], device=device)
+        dist.all_reduce(flag, group=group)
+        if flag.item() > 0:
+            ok = False
+            break
+        dist.barrier(group)
+        nccl_lat, nccl_bw = _bench_nccl(msg_bytes, rank, ws, group)
+        dist.barrier(group)
+        if rank == 0:
+            rows.append(
+                (msg_bytes, nb, nccl_grid, cute_lat, nccl_lat, cute_bw, nccl_bw)
+            )
+
+    if rank == 0:
+        _print_table(rows, ws)
+        emit_result_rows(
+            [
+                {
+                    "backend": "cute",
+                    "variant": "copy",
+                    "world_size": ws,
+                    "size_bytes": int(msg_bytes),
+                    "fw_ctas": int((nb or 0) * ws),
+                    "nccl_grid": int(grid or 0),
+                    "cute_us": float(cute_lat),
+                    "nccl_us": float(nccl_lat or 0.0),
+                    "cute_busbw_gbps": float(cute_bw),
+                    "nccl_busbw_gbps": float(nccl_bw or 0.0),
+                    "ratio": float(cute_bw / nccl_bw) if nccl_bw else 0.0,
+                }
+                for msg_bytes, nb, grid, cute_lat, nccl_lat, cute_bw, nccl_bw in rows
+                if cute_bw is not None
+            ]
+        )
+    return ok
+
+
+def _print_table(rows, ws) -> None:
+    """One row per size with both metrics; ``x`` is the size-appropriate ratio (latency for
+    the latency-bound band, bus bandwidth above it), always >1 == CuTe faster."""
+    lines = [
+        "=== CuTe a2a (copy) vs NCCL -- SM-matched "
+        "(x=latency<1MB / busbw>=1MB, >1=cute faster) ==="
+    ]
+    lines.append(
+        f"{'size/rank':>10} {'fw_ctas':>7} {'nccl_grid':>9} {'cute_us':>9} "
+        f"{'nccl_us':>9} {'cute_GB/s':>9} {'nccl_GB/s':>9} {'x':>6} {'metric':>6}"
+    )
+    for msg_bytes, nb, grid, cute_lat, nccl_lat, cute_bw, nccl_bw in rows:
+        if cute_bw is None:
+            lines.append(f"{_fmt_size(msg_bytes):>10} {'n/a':>7}")
+            continue
+        if msg_bytes < _LATENCY_BAND_BYTES:
+            metric = "lat"
+            ratio = (nccl_lat / cute_lat) if cute_lat else 0.0
+        else:
+            metric = "bw"
+            ratio = (cute_bw / nccl_bw) if nccl_bw else 0.0
+        ctas = (nb or 0) * ws
+        flag = "" if ratio >= 1.0 else "  <NCCL"
+        lines.append(
+            f"{_fmt_size(msg_bytes):>10} {ctas:>7} {grid or 0:>9} {cute_lat:>9.1f} "
+            f"{nccl_lat or 0.0:>9.1f} {cute_bw:>9.1f} {nccl_bw or 0.0:>9.1f} "
+            f"{ratio:>5.2f}x {metric:>6}{flag}"
+        )
+    table = "\n".join(lines)
+    print("\n" + table, flush=True)
+    # Mirror to stderr: torchx keeps each worker's STDERR but truncates/drops STDOUT, so the
+    # table is only reliably fetchable from the MAST job's stderr log.
+    print("\n" + table, file=sys.stderr, flush=True)
+    result_file = os.environ.get("A2A_RESULT_FILE")
+    if result_file:
+        try:
+            with open(result_file, "w") as f:
+                f.write(table + "\n")
+        except OSError as e:
+            print(f"(could not write A2A_RESULT_FILE: {e})", flush=True)
+    _upload_result_to_manifold(table)
+
+
+def _upload_result_to_manifold(table: str) -> None:
+    """Best-effort upload of the result table to ``$A2A_RESULT_MANIFOLD`` (a
+    ``manifold://bucket/tree/...`` path). No-op if the env is unset; never raises."""
+    dest = os.environ.get("A2A_RESULT_MANIFOLD")
+    if not dest:
+        return
+    # The MAST conda env has no `manifold` on PATH; the conda launcher installs the
+    # `manifold.cli:prod` fbpkg at /packages/manifold.cli/manifold for exactly this.
+    mf = "/packages/manifold.cli/manifold"
+    if not os.path.exists(mf):
+        mf = shutil.which("manifold") or "manifold"
+    local = None
+    try:
+        with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as f:
+            f.write(table + "\n")
+            local = f.name
+        out = subprocess.run(
+            [mf, "put", "--overwrite", local, dest],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if out.returncode == 0:
+            print(f"(uploaded result to {dest})", flush=True)
+        else:
+            print(
+                f"(manifold put failed rc={out.returncode}: {out.stderr})", flush=True
+            )
+    except (OSError, subprocess.SubprocessError) as e:
+        print(f"(manifold upload error: {e})", flush=True)
+    finally:
+        # delete=False above, so remove the temp file on every path (MAST would otherwise
+        # leak a /tmp/tmpXXXX.txt per invocation).
+        if local:
+            try:
+                os.remove(local)
+            except OSError:
+                pass
+
+
+def _worker(rank: int, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    device = torch.device(f"cuda:{rank}")
+    ok = False
+    try:
+        ok = _run(rank, world_size, dist.group.WORLD, device)
+        dist.barrier(dist.group.WORLD)
+    finally:
+        dist.destroy_process_group()  # always tear down, even if _run raises
+    if not ok:
+        sys.exit(1)
+
+
+def _torchrun_main() -> None:
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    device = torch.device(f"cuda:{local_rank}")
+    ok = False
+    try:
+        ok = _run(rank, world_size, dist.group.WORLD, device)
+        dist.barrier(dist.group.WORLD)
+    finally:
+        dist.destroy_process_group()  # always tear down, even if _run raises
+    if not ok:
+        sys.exit(1)
+
+
+def main() -> None:
+    if "RANK" in os.environ and "WORLD_SIZE" in os.environ:
+        _torchrun_main()
+        return
+    p = argparse.ArgumentParser()
+    p.add_argument("--world-size", type=int, default=min(torch.cuda.device_count(), 8))
+    args = p.parse_args()
+    if args.world_size < 2:
+        print("needs >=2 GPUs")
+        return
+    mp.spawn(
+        _worker,
+        args=(args.world_size, _find_free_port()),
+        nprocs=args.world_size,
+        join=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/dsl/tests/mast_launch.py
+++ b/comms/dsl/tests/mast_launch.py
@@ -53,6 +53,7 @@ import uuid
 from typing import Any
 
 import torchx.components.fb.conda as conda
+from comms.dsl.tests.ncu_common import NCU_DEFAULT_METRICS
 from torchx.components.fb.dist import hpc as fb_dist_hpc
 from torchx.runner import get_runner
 from torchx.specs import AppDef, CfgVal, named_resources, Workspace
@@ -76,6 +77,11 @@ _DEFAULT_MODULE = "comms.dsl.tests.benchmark_a2a_cute"
 # fbcode). The benchmark only needs comms/dsl. `comms` is a PEP-420 namespace package, so
 # mapping to "comms/dsl" keeps ``import comms.dsl.*`` working.
 _DEFAULT_OVERLAYS = ["comms/dsl:comms/dsl"]
+
+# NCU: the MAST base image that ships Nsight Compute (the default image has only cuda-gdb);
+# and the GB300 (aarch64) platform driver lib dir the per-rank NCU driver shim is built from.
+_NCU_BASE_IMAGE_FBPKG = "tupperware.image.sendstream.mast_environments:stable"
+_NCU_GB300_DRIVER_LIB_DIR = "/usr/local/fbcode/platform010-aarch64/lib"
 
 
 def _parse_envs(env_str: str | None) -> dict[str, str]:
@@ -209,6 +215,28 @@ def _build_fbpkg(args: argparse.Namespace) -> tuple[AppDef, dict[str, CfgVal]]:
     return app, cfg
 
 
+def _ncu_bench_args(args: argparse.Namespace) -> list[str]:
+    """The ``--ncu`` flags forwarded to the per-rank benchmark ([] if --ncu is not set).
+
+    Pure (host-testable). The benchmark's own --ncu re-exec builds the driver shim + wraps
+    itself in ncu; here we only pass the knobs through.
+    """
+    if not args.ncu:
+        return []
+    out = [
+        "--ncu",
+        "--ncu-driver-shim",
+        _NCU_GB300_DRIVER_LIB_DIR,
+        "--ncu-metrics",
+        args.ncu_metrics,
+        "--ncu-launch-count",
+        str(args.ncu_launch_count),
+    ]
+    if args.ncu_kernel_regex:
+        out += ["--ncu-kernel-regex", args.ncu_kernel_regex]
+    return out
+
+
 def _build_conda(
     args: argparse.Namespace,
 ) -> tuple[AppDef, dict[str, CfgVal]]:
@@ -228,6 +256,11 @@ def _build_conda(
     env["PPN"] = str(args.ppn)
 
     bench_args = args.bench_args.split() if args.bench_args else []
+    # --ncu: run each rank's benchmark under Nsight Compute. The benchmark's own --ncu
+    # re-exec builds the driver shim + wraps itself in ncu (see benchmark_a2a_cute /
+    # ncu_common); here we only pass the flags through and (below) swap to the NCU-capable
+    # base image so the `ncu` binary is present in the container.
+    bench_args += _ncu_bench_args(args)
     job_name = _job_name(args)
     module = args.module
 
@@ -299,6 +332,10 @@ def _build_conda(
     }
     if args.flex_pool_id:
         cfg["forceSingleRegion"] = False
+    # --ncu: swap to the MAST base image that ships Nsight Compute (default image lacks it).
+    # The mast_conda scheduler reads cfg["hpcBaseImagePackage"] (mast_scheduler_common).
+    if args.ncu:
+        cfg["hpcBaseImagePackage"] = _NCU_BASE_IMAGE_FBPKG
     return job_spec, cfg
 
 
@@ -306,6 +343,13 @@ def build_app_and_cfg(
     args: argparse.Namespace,
 ) -> tuple[AppDef, dict[str, CfgVal], str, str]:
     """Dispatch on ``--delivery``; return (app, cfg, scheduler, resolved_module)."""
+    # --ncu needs the mast_environments base-image swap, which only the conda path wires up.
+    # Fail loud rather than silently run an un-profiled fbpkg job.
+    if args.ncu and args.delivery != "conda":
+        raise SystemExit(
+            f"--ncu is only supported with --delivery conda (needs the NCU-capable "
+            f"base-image swap); got --delivery {args.delivery}."
+        )
     if args.delivery == "fbpkg":
         app, cfg = _build_fbpkg(args)
         return app, cfg, "mast", args.module
@@ -505,6 +549,18 @@ def _init_argparse() -> argparse.ArgumentParser:
         default=None,
         help="args forwarded to the module (space-separated)",
     )
+    # --- NCU profiling (conda delivery) ---
+    p.add_argument(
+        "--ncu",
+        action="store_true",
+        default=False,
+        help="profile each rank under Nsight Compute (swaps to the NCU-capable MAST base "
+        "image + builds a per-rank driver shim). Single-pass launch metrics only -- "
+        "multi-pass replay deadlocks the comm kernel until the image has NCU 2026.1.1+.",
+    )
+    p.add_argument("--ncu-metrics", default=NCU_DEFAULT_METRICS)
+    p.add_argument("--ncu-launch-count", type=int, default=1)
+    p.add_argument("--ncu-kernel-regex", default="")
     p.add_argument(
         "--submit",
         action="store_true",

--- a/comms/dsl/tests/mast_launch.py
+++ b/comms/dsl/tests/mast_launch.py
@@ -1,0 +1,526 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""MAST launcher for the comms/dsl CuTe a2a benchmark (GB300).
+
+One launcher, two image-delivery paths selected by ``--delivery``:
+
+- ``--delivery fbpkg`` (canonical): submit a pre-built aarch64 GB300 ``fbpkg`` via
+  torchx ``fb.dist.hpc`` one-process-per-rank (scheduler ``mast``). Needs a full
+  ``buck2`` cross-build of the package (``--img`` required). Best for a stable,
+  reproducible perf run.
+- ``--delivery conda`` (fast iteration, default): the torchx ``mast_conda`` scheduler with a
+  :class:`~torchx.specs.Workspace` source overlay -- the remote conda env comes from a
+  pre-built conda ``fbpkg`` and the local ``fbcode/comms`` source is shipped at
+  submit-time as an ephemeral workspace fbpkg (CAF upload, no buck compile). Iterate on
+  the kernel and re-launch in seconds-to-a-minute.
+
+Capacity / access: ``--entitlement`` (rmAttribution, a tenant leaf that holds GPU quota) and
+``--identity`` / ``--oncall`` are caller/team-specific and have **no baked-in default** -- pass
+them as flags or via the ``$MAST_RM_ATTRIBUTION`` / ``$MAST_HPC_IDENTITY`` / ``$MAST_HPC_ONCALL``
+env vars (required for ``--submit``). ``--hw gb300_dsf`` is the sub-type MastProdCluster registers
+(the quota path). ``--flex-pool-id`` defaults to '' (the quota path); pass a pool id only if you
+have one -- flexpools are typically temporary, so none is hardcoded here.
+
+NVL co-placement: MAST has no NVLink-domain locality flag, so the trainer role overlays
+``HpcTaskGroupSpec.topologyConstraints = [{"domain": {"multiple": <nvl_hosts>}}]``.
+``multiple`` is a HOST count, so 2 GB300 hosts (8 GPUs) in one NVL72 domain is
+``--nvl-hosts 2``.
+
+Dry-run by default (assembles + prints the MAST job spec -- and for conda, builds the
+workspace fbpkg -- but consumes NO capacity). Pass ``--submit`` to schedule.
+
+Examples::
+
+    # conda fast-iteration dry-run (validate spec + workspace build; consumes no capacity)
+    buck2 run @fbcode//mode/opt --prefer-local //comms/dsl/tests:mast_launch -- \\
+        --delivery conda --env "A2A_CAPS=32"
+
+    # fbpkg submit (needs a published --img and your entitlement/identity/oncall)
+    buck2 run @fbcode//mode/opt --prefer-local //comms/dsl/tests:mast_launch -- \\
+        --delivery fbpkg --img comms.dsl.benchmark_a2a.aarch64.gb300:<ver> \\
+        --entitlement <tenant> --identity <data-project> --oncall <oncall> --submit
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import uuid
+from typing import Any
+
+import torchx.components.fb.conda as conda
+from torchx.components.fb.dist import hpc as fb_dist_hpc
+from torchx.runner import get_runner
+from torchx.specs import AppDef, CfgVal, named_resources, Workspace
+from torchx.specs.fb.named_resources import MAST_WHOLE_HOST_FEATURE
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+_MAST_TIER_MAPPING: dict[str, str] = {
+    "PROD": "mast.api.write",
+    "STAGING": "mast.api.write.staging",
+    "RC": "mast.api.write.rc",
+}
+
+# The conda workspace overlay names the ephemeral *workspace* fbpkg after role.image[0];
+# reuse the already-ACL'd benchmark package so no separate `fbpkg create` is needed.
+_DEFAULT_WS_PKG = "comms.dsl.benchmark_a2a.aarch64.gb300"
+# Pre-built GB300 (aarch64, CUDA 13.0) conda env.
+# @oss-disable[end= ]: _DEFAULT_CONDA = "xlformers_msl_rl_gb300_conda:20"
+_DEFAULT_MODULE = "comms.dsl.tests.benchmark_a2a_cute"
+# Source dirs overlaid into the ephemeral workspace, as ``relpath:remote`` (relpath is under
+# fbcode). The benchmark only needs comms/dsl. `comms` is a PEP-420 namespace package, so
+# mapping to "comms/dsl" keeps ``import comms.dsl.*`` working.
+_DEFAULT_OVERLAYS = ["comms/dsl:comms/dsl"]
+
+
+def _parse_envs(env_str: str | None) -> dict[str, str]:
+    """Parse a ``K=V;K2=V2`` string into a dict (forwarded to every rank)."""
+    envs: dict[str, str] = {}
+    if not env_str:
+        return envs
+    for raw in env_str.split(";"):
+        entry = raw.strip()
+        if not entry:
+            continue
+        if "=" not in entry:
+            logger.warning("skipping malformed --env entry (no '='): %r", entry)
+            continue
+        key, _, val = entry.partition("=")
+        envs[key] = val
+    return envs
+
+
+def _job_name(args: argparse.Namespace) -> str:
+    if args.job_name:
+        return args.job_name
+    tag = "conda-gb300" if args.delivery == "conda" else "gb300"
+    return f"a2a-{tag}-n{args.nnode}x{args.ppn}-{uuid.uuid4().hex[0:6]}"
+
+
+def _locality(args: argparse.Namespace) -> list[str] | None:
+    """Region localityConstraints, or None. A flexpool already pins placement to its hosts,
+    so a region constraint is dropped when a flexpool is set (avoids a region/pool clash)."""
+    if args.flex_pool_id:
+        return None
+    return ["region", args.region] if args.region else None
+
+
+def _fbcode_root() -> str:
+    """Absolute path to this checkout's SOURCE ``fbcode`` dir (works in any worktree).
+
+    The workspace overlay does a literal ``shutil.copytree`` of the project dir, so it
+    MUST point at the source tree -- NOT the ``buck-out`` link-tree where ``__file__``
+    lives when run via ``buck2 run``. ``buck2 run`` preserves the caller's cwd, so derive
+    the root from cwd (or the buck-provided project root). Override with ``--src-fbcode``.
+    """
+    candidates = [os.environ.get("BUCK_PROJECT_ROOT"), os.getcwd()]
+    for base in candidates:
+        if not base:
+            continue
+        p = os.path.abspath(base)
+        # cwd may be fbcode itself, a subdir of it, or the repo root (has fbcode/).
+        while True:
+            if os.path.basename(p) == "fbcode" and os.path.isdir(
+                os.path.join(p, "comms")
+            ):
+                return p
+            if os.path.isdir(os.path.join(p, "fbcode", "comms")):
+                return os.path.join(p, "fbcode")
+            parent = os.path.dirname(p)
+            if parent == p:
+                break
+            p = parent
+    raise RuntimeError(
+        "could not locate source fbcode root from cwd; pass --src-fbcode <path>"
+    )
+
+
+def _build_fbpkg(args: argparse.Namespace) -> tuple[AppDef, dict[str, CfgVal]]:
+    """Assemble the torchx AppDef + MAST cfg for the pre-built fbpkg delivery path."""
+    if not args.img:
+        raise ValueError("--delivery fbpkg requires --img (the benchmark fbpkg)")
+    tier = _MAST_TIER_MAPPING.get(args.tier, args.tier)
+    if not tier.startswith("mast."):
+        raise ValueError(f"unrecognized MAST tier: {args.tier}")
+
+    rsrc = named_resources[args.hw]
+    env = _parse_envs(args.env)
+    env.setdefault("LOGLEVEL", "INFO")
+    # The fbpkg mount is read-only on the host; the CuTe JIT must write its compiled
+    # artifacts to a writable cache dir.
+    env.setdefault("TRITON_CACHE_DIR", "/tmp/triton_cache")
+    env["PPN"] = str(args.ppn)
+    env["LOCAL_SIZE"] = str(rsrc.gpu)
+
+    bench_args = args.bench_args.split() if args.bench_args else []
+    job_name = _job_name(args)
+    module = args.module
+
+    app = fb_dist_hpc(
+        *bench_args,
+        m=module,
+        img=args.img,
+        name=job_name,
+        h=args.hw,
+        j=f"{args.nnode}x{args.ppn}",
+        env=env,
+        max_retries=args.max_retries,
+        metadata={
+            "rmAttribution": args.entitlement,
+            "hpcIdentity": args.dp,
+            "hpcClusterUuid": args.cluster,
+            "hpcJobOncall": args.oncall,
+            "smcTier": tier,
+        },
+    )
+
+    # NVL co-placement: pin all hosts into one NVLink (NVL72) domain. multiple is a HOST
+    # count (GB300 = 4 GPU/host), so 2 hosts = 8 GPUs in one domain.
+    trainer = app.roles[0]  # pyre-ignore[16]
+    tg_spec: dict[str, Any] = {
+        "topologyConstraints": [{"domain": {"multiple": args.nvl_hosts}}],
+    }
+    if args.flex_pool_id:
+        tg_spec["flexPoolId"] = args.flex_pool_id
+    trainer.metadata["mast"] = {"HpcTaskGroupSpec": tg_spec}
+    # Domain/topology constraints require whole-host allocation; ppn == GPUs/host already
+    # selects the full resource, but set it explicitly for clarity.
+    trainer.resource.capabilities[MAST_WHOLE_HOST_FEATURE] = True
+
+    cfg: dict[str, CfgVal] = {
+        "localityConstraints": _locality(args),
+        "rmAttribution": args.entitlement,
+        "hpcIdentity": args.dp,
+        "hpcClusterUuid": args.cluster,
+        "hpcJobOncall": args.oncall,
+        "smcTier": tier,
+        "runningTimeoutSec": args.timeout,
+        "useStrictName": True,
+        "enableGracefulPreemption": True,
+        "runtimeAppMetadataJson": json.dumps(app.metadata),  # pyre-ignore[16]
+    }
+    if args.flex_pool_id:
+        cfg["forceSingleRegion"] = False
+    return app, cfg
+
+
+def _build_conda(
+    args: argparse.Namespace,
+) -> tuple[AppDef, dict[str, CfgVal]]:
+    """Assemble the torchx AppDef (conda.torchrun + workspace overlay) + mast_conda cfg."""
+    tier = _MAST_TIER_MAPPING.get(args.tier, args.tier)
+    if not tier.startswith("mast."):
+        raise ValueError(f"unrecognized MAST tier: {args.tier}")
+
+    env = _parse_envs(args.env)
+    env.setdefault("LOGLEVEL", "INFO")
+    # JIT must write its compiled artifacts to a writable dir (conda fbpkg is read-only).
+    env.setdefault("TRITON_CACHE_DIR", "/tmp/triton_cache")
+    # The conda_on_mast default mounts an OILFS warm-storage dir; the a2a benchmark needs no
+    # warm storage, and our region has no WS cluster mapping, so the scheduler rejects the
+    # spec ("WarmStorageSpec ... missing clusters field"). Disable it.
+    env.setdefault("DISABLE_OILFS", "1")
+    env["PPN"] = str(args.ppn)
+
+    bench_args = args.bench_args.split() if args.bench_args else []
+    job_name = _job_name(args)
+    module = args.module
+
+    # torchrun runs `python -m <module> <prog_args>` one proc/rank.
+    torchrun_args = [
+        "--tee",
+        "3",
+        "--nnodes",
+        str(args.nnode),
+        "--nproc-per-node",
+        str(args.ppn),
+        "-m",
+        module,
+        *bench_args,
+    ]
+
+    job_spec = conda.torchrun(
+        *torchrun_args,
+        name=job_name,
+        h=args.hw,
+        env=env,
+        run_as_root=True,
+        torchrun_fbpkg_id="torchx_torchrun:stable",
+        conda_mast_core_fbpkg_id="conda_mast_core:stable",
+    )
+
+    role = job_spec.roles[0]  # pyre-ignore[16]
+
+    # Leave role.image as conda.torchrun produced it (torchx_torchrun + conda_mast_core).
+    # The conda workspace scheduler ADDS the conda env (conda_fbpkg_id) and the freshly
+    # built source-overlay (workspace_fbpkg_name) to the image itself via _get_image. Do
+    # NOT also put them in role.image ("Can't have 2 versions of the same package!").
+
+    # Source overlay: ship only the needed source dirs (fast CAF upload). Each --overlay is
+    # `relpath:remote` (relpath under fbcode).
+    fbcode_root = args.src_fbcode or _fbcode_root()
+    projects: dict[str, str] = {}
+    for entry in args.overlay:
+        relpath, _, remote = entry.partition(":")
+        projects[os.path.join(fbcode_root, relpath)] = remote or relpath
+    role.workspace = Workspace(projects=projects)
+
+    # NVL co-placement: pin all hosts into one NVLink (NVL72) domain (whole-host a2a).
+    tg_spec: dict[str, Any] = {
+        "topologyConstraints": [{"domain": {"multiple": args.nvl_hosts}}],
+    }
+    if args.flex_pool_id:
+        tg_spec["flexPoolId"] = args.flex_pool_id
+    role.metadata["mast"] = {"HpcTaskGroupSpec": tg_spec}
+    role.resource.capabilities[MAST_WHOLE_HOST_FEATURE] = True
+
+    cfg: dict[str, CfgVal] = {
+        "localityConstraints": _locality(args),
+        "rmAttribution": args.entitlement,
+        "hpcIdentity": args.dp,
+        "hpcClusterUuid": args.cluster,
+        "hpcJobOncall": args.oncall,
+        "smcTier": tier,
+        "runningTimeoutSec": args.timeout,
+        "useStrictName": True,
+        "enableGracefulPreemption": True,
+        # --- conda workspace scheduler knobs ---
+        "conda_fbpkg_id": args.conda,
+        "conda_path_in_fbpkg": "conda",
+        "workspace_fbpkg_name": args.ws_pkg,
+        "activate_conda": True,
+        "git": False,
+        "fbpkg_ids": [],
+    }
+    if args.flex_pool_id:
+        cfg["forceSingleRegion"] = False
+    return job_spec, cfg
+
+
+def build_app_and_cfg(
+    args: argparse.Namespace,
+) -> tuple[AppDef, dict[str, CfgVal], str, str]:
+    """Dispatch on ``--delivery``; return (app, cfg, scheduler, resolved_module)."""
+    if args.delivery == "fbpkg":
+        app, cfg = _build_fbpkg(args)
+        return app, cfg, "mast", args.module
+    app, cfg = _build_conda(args)
+    return app, cfg, "mast_conda", args.module
+
+
+def _print_spec_summary(args: argparse.Namespace, app: object, module: str) -> None:
+    """Human-readable summary of the assembled job (shown even in dry-run)."""
+    role = app.roles[0]  # pyre-ignore[16]
+    tg = role.metadata["mast"]["HpcTaskGroupSpec"]
+    print("=" * 80)
+    print(f"MAST job spec (assembled, delivery={args.delivery}):")
+    print(f"  name             = {app.name}")  # pyre-ignore[16]
+    print(f"  module           = {module}")
+    if args.delivery == "fbpkg":
+        print(f"  img              = {args.img}")
+    else:
+        print(f"  overlay          = {args.overlay}")
+        print(f"  role image       = {role.image}")
+        print(f"  conda fbpkg      = {args.conda}")
+        print(f"  workspace fbpkg  = {args.ws_pkg} (overlay: {role.workspace})")
+    print(
+        f"  hw / j           = {args.hw} / {args.nnode}x{args.ppn} "
+        f"(world_size={args.nnode * args.ppn})"
+    )
+    print(f"  cluster          = {args.cluster}")
+    print(f"  region           = {args.region}")
+    print(f"  entitlement      = {args.entitlement}")
+    print(f"  hpcIdentity      = {args.dp}")
+    print(f"  oncall           = {args.oncall}")
+    print(f"  topologyConstraints = {tg.get('topologyConstraints')}")
+    print(f"  flexPoolId       = {tg.get('flexPoolId')}")
+    print(f"  env              = {args.env}")
+    print(f"  bench_args       = {args.bench_args}")
+    print("=" * 80)
+
+
+def launch(args: argparse.Namespace) -> None:
+    # The access knobs are caller-specific (no baked default), so a real submit needs them; a
+    # dry-run does not (it only assembles + prints the spec). Fail fast with a clear message.
+    if args.submit:
+        missing = [
+            flag
+            for flag, val in (
+                ("--entitlement ($MAST_RM_ATTRIBUTION)", args.entitlement),
+                ("--identity ($MAST_HPC_IDENTITY)", args.dp),
+                ("--oncall ($MAST_HPC_ONCALL)", args.oncall),
+            )
+            if not val
+        ]
+        if missing:
+            raise SystemExit(
+                "--submit requires caller-specific access knobs with no default: "
+                + ", ".join(missing)
+                + ". Pass the flag(s) or export the env var(s)."
+            )
+    app, cfg, scheduler, module = build_app_and_cfg(args)
+    _print_spec_summary(args, app, module)
+    runner = get_runner()
+    try:
+        dryrun_info = runner.dryrun(app=app, scheduler=scheduler, cfg=cfg)
+    except ValueError as e:
+        # fbpkg dry-run: an unpublished fbpkg is expected (the spec itself is valid); surface
+        # it instead of crashing so the summary above is still useful.
+        if args.delivery == "fbpkg" and not args.submit and "do not exist" in str(e):
+            print(f"DRY-RUN: spec validated up to packaging; fbpkg not published: {e}")
+            return
+        raise
+    print(f"MAST dry-run (validated job request, scheduler={scheduler}):")
+    print(dryrun_info)
+    print("=" * 80)
+    if not args.submit:
+        print("DRY-RUN ONLY (pass --submit to schedule). No capacity consumed.")
+        return
+    app_handle = runner.schedule(dryrun_info)
+    status = runner.status(app_handle)
+    assert status, f"failed to get job status for {app_handle}"
+    print(f"SUBMITTED: {app_handle}")
+    print(f"UI: {status.ui_url}")
+
+
+def _init_argparse() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="MAST launcher for the comms/dsl CuTe a2a benchmark (GB300)"
+    )
+    p.add_argument(
+        "--delivery",
+        default="conda",
+        choices=["fbpkg", "conda"],
+        help="image delivery: 'fbpkg' (pre-built package, needs --img) or 'conda' "
+        "(fast-iteration conda env + workspace source overlay). Default: conda.",
+    )
+    p.add_argument("--nnode", type=int, default=2, help="number of hosts")
+    p.add_argument(
+        "--ppn",
+        type=int,
+        default=4,
+        choices=[1, 2, 4, 8],
+        help="processes/GPUs per host (GB300 = 4)",
+    )
+    p.add_argument(
+        "--nvl-hosts",
+        type=int,
+        default=2,
+        help="hosts that must share one NVLink (NVL72) domain "
+        "(topologyConstraints domain.multiple; HOST count, not GPU)",
+    )
+    p.add_argument(
+        "--hw",
+        default="gb300_dsf",
+        help="torchx named resource. `gb300_dsf` is the sub-type MastProdCluster registers "
+        "(the quota path).",
+    )
+    p.add_argument("--cluster", default="MastProdCluster", help="hpcClusterUuid")
+    p.add_argument(
+        "--region",
+        default="uco",
+        help="region for localityConstraints (ignored when --flex-pool-id is set)",
+    )
+    # Caller/team-specific access knobs: NO hardcoded default (this launcher lands for everyone).
+    # Supply via flag or the $MAST_* env var; required for --submit (validated in launch()).
+    p.add_argument(
+        "--dp",
+        "--identity",
+        dest="dp",
+        default=os.environ.get("MAST_HPC_IDENTITY"),
+        help="hpcIdentity (data project / ACL). No default; flag or $MAST_HPC_IDENTITY.",
+    )
+    p.add_argument(
+        "--entitlement",
+        "--rm-attribution",
+        dest="entitlement",
+        default=os.environ.get("MAST_RM_ATTRIBUTION"),
+        help="rmAttribution (entitlement = tenant leaf holding GPU quota). No default; flag "
+        "or $MAST_RM_ATTRIBUTION.",
+    )
+    p.add_argument(
+        "--oncall",
+        default=os.environ.get("MAST_HPC_ONCALL"),
+        help="hpcJobOncall. No default; flag or $MAST_HPC_ONCALL.",
+    )
+    p.add_argument(
+        "--tier",
+        default="PROD",
+        choices=["PROD", "STAGING", "RC"],
+        help="MAST environment",
+    )
+    p.add_argument("--timeout", type=int, default=3600, help="runningTimeoutSec")
+    p.add_argument("--max-retries", type=int, default=1, help="MAST retries (fbpkg)")
+    p.add_argument(
+        "--flex-pool-id",
+        default="",
+        help="optional flexpool id for placement; default '' uses the quota path "
+        "(--entitlement). Pass a pool id only if you have one.",
+    )
+    p.add_argument(
+        "--module",
+        default=_DEFAULT_MODULE,
+        help=f"python -m module to run under torchrun (default: {_DEFAULT_MODULE})",
+    )
+    # --- fbpkg delivery ---
+    p.add_argument(
+        "--img",
+        default=None,
+        help="benchmark fbpkg (REQUIRED for --delivery fbpkg), e.g. "
+        "comms.dsl.benchmark_a2a.aarch64.gb300:<ver>",
+    )
+    # --- conda delivery ---
+    p.add_argument(
+        "--conda",
+        default=_DEFAULT_CONDA,
+        help=f"conda env fbpkg (conda delivery; default: {_DEFAULT_CONDA})",
+    )
+    p.add_argument(
+        "--ws-pkg",
+        default=_DEFAULT_WS_PKG,
+        help="fbpkg NAME used for the ephemeral source-overlay workspace build "
+        f"(must be ACL-writable; default: {_DEFAULT_WS_PKG})",
+    )
+    p.add_argument(
+        "--overlay",
+        action="append",
+        default=None,
+        help="source dir to overlay as 'relpath:remote' (relpath under fbcode); "
+        f"repeatable (conda delivery). Default: {_DEFAULT_OVERLAYS}.",
+    )
+    p.add_argument(
+        "--src-fbcode",
+        default=None,
+        help="source fbcode dir to overlay comms/ from (default: auto-detect from cwd)",
+    )
+    p.add_argument("--job-name", default=None, help="override the generated job name")
+    p.add_argument("--env", default=None, help="extra env as 'K=V;K2=V2' (per rank)")
+    p.add_argument(
+        "--bench-args",
+        default=None,
+        help="args forwarded to the module (space-separated)",
+    )
+    p.add_argument(
+        "--submit",
+        action="store_true",
+        default=False,
+        help="actually schedule the job (default: dry-run only, no capacity used)",
+    )
+    return p
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, force=True)
+    args = _init_argparse().parse_args()
+    if args.overlay is None:
+        args.overlay = _DEFAULT_OVERLAYS
+    launch(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/dsl/tests/ncu_common.py
+++ b/comms/dsl/tests/ncu_common.py
@@ -1,0 +1,167 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Shared Nsight Compute (NCU) profiling boilerplate for the a2a benchmark.
+
+One place that builds the ``ncu`` wrapper argv, so the local path
+(``benchmark_a2a_cute --ncu`` re-execs itself under ncu) and the MAST path
+(``mast_launch --ncu`` wraps the torchrun program) emit an identical invocation.
+Mirrors the validated genai ``ops/mast.py --ncu`` mechanism (D104906945).
+
+NCU version caveat: the MAST base image ships Nsight Compute 2025.3.1, which does NOT
+support the ``--communicator`` / ``--lockstep-kernel-launch`` distributed replay flags
+(need 2026.1.1+). So multi-pass metrics that require replaying a kernel will DEADLOCK on
+the a2a comm kernel (a replayed rank spins on signals from peers that are not replaying in
+lockstep). Default to single-pass **launch** metrics (``launch__registers_per_thread``,
+grid/occupancy), which ncu collects without replay -- safe for the comm kernel.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+# Single-pass launch metrics: collected WITHOUT replaying the kernel body, so they are safe
+# on the signal-spinning a2a comm kernel under the current (2025.3.1) MAST NCU.
+NCU_DEFAULT_METRICS: str = (
+    "launch__registers_per_thread,launch__grid_size,launch__block_size,"
+    "launch__waves_per_multiprocessor"
+)
+
+# NCU binary candidates, newest CUDA / NCU first (mirrors genai's discovery order).
+_NCU_CANDIDATES: tuple[str, ...] = (
+    "/usr/local/cuda-13.0/bin/ncu",
+    "/usr/local/cuda-12.8/bin/ncu",
+    "/usr/local/cuda/bin/ncu",
+    "/opt/nvidia/nsight-compute/2025.3.1/ncu",
+)
+
+
+def resolve_ncu_bin(explicit: str = "") -> str:
+    """Absolute path to an ``ncu`` binary: explicit > $PATH > known install dirs.
+
+    Raises ``FileNotFoundError`` if none is found so the caller fails loud instead of
+    launching an un-profiled run that silently produces no report.
+    """
+    if explicit:
+        return explicit
+    found = shutil.which("ncu")
+    if found:
+        return found
+    for cand in _NCU_CANDIDATES:
+        if os.path.exists(cand):
+            return cand
+    raise FileNotFoundError(
+        "no ncu binary found (looked on $PATH and "
+        f"{', '.join(_NCU_CANDIDATES)}); pass --ncu-path or use a MAST image with "
+        "Nsight Compute (mast_launch --ncu swaps to one)."
+    )
+
+
+# The driver libs NCU needs to connect to the CUDA driver inside a MAST container.
+_NCU_DRIVER_LIBS: tuple[str, ...] = (
+    "libcuda.so",
+    "libcuda.so.1",
+    "libnvidia-ml.so",
+    "libnvidia-ml.so.1",
+    "libnvidia-ptxjitcompiler.so",
+    "libnvidia-ptxjitcompiler.so.1",
+)
+
+
+def _materialize_driver_links(platform_driver_lib_dir: str, shim_dir: str) -> None:
+    os.makedirs(shim_dir, exist_ok=True)
+    for lib in _NCU_DRIVER_LIBS:
+        src = os.path.join(platform_driver_lib_dir, lib)
+        dst = os.path.join(shim_dir, lib)
+        if not os.path.exists(src):
+            continue
+        if os.path.lexists(dst) and not os.path.exists(dst):
+            try:
+                os.unlink(dst)
+            except FileNotFoundError:
+                pass
+        if not os.path.lexists(dst):
+            try:
+                os.symlink(src, dst)
+            except FileExistsError:
+                pass
+
+
+def _find_driver_lib(shim_dir: str, base: str) -> str | None:
+    for candidate in (base, base + ".1"):
+        path = os.path.join(shim_dir, candidate)
+        if os.path.exists(path):
+            return path
+    return None
+
+
+def build_driver_shim(
+    platform_driver_lib_dir: str, shim_dir: str = "/tmp/cuda_driver_ncu"
+) -> dict[str, str]:
+    """Create a narrow CUDA-driver shim dir and return the env NCU needs (mirrors genai).
+
+    Symlinks ONLY the driver / NVML / ptxjit libs from the platform driver dir into
+    ``shim_dir``, and returns ``LD_LIBRARY_PATH`` / ``LD_PRELOAD`` / ``TRITON_LIBCUDA_PATH``
+    pointing at it. Putting the FULL platform driver dir on ``LD_LIBRARY_PATH`` crashes
+    Python (D104906945); the narrow shim lets NCU connect without that. Returns ``{}`` if
+    the platform driver dir is absent (e.g. local dev where the driver is already resolvable).
+    """
+    if not os.path.isdir(platform_driver_lib_dir):
+        return {}
+    _materialize_driver_links(platform_driver_lib_dir, shim_dir)
+    libcuda = _find_driver_lib(shim_dir, "libcuda.so")
+    if libcuda is None:
+        raise FileNotFoundError(
+            f"{platform_driver_lib_dir} contains neither libcuda.so nor libcuda.so.1"
+        )
+    preload = [libcuda]
+    nvml = _find_driver_lib(shim_dir, "libnvidia-ml.so")
+    if nvml is not None:
+        preload.append(nvml)
+    existing_path = os.environ.get("LD_LIBRARY_PATH")
+    library_path = f"{shim_dir}:{existing_path}" if existing_path else shim_dir
+    existing_preload = os.environ.get("LD_PRELOAD")
+    if existing_preload:
+        preload.append(existing_preload)
+    return {
+        "LD_LIBRARY_PATH": library_path,
+        "LD_PRELOAD": ":".join(preload),
+        "TRITON_LIBCUDA_PATH": libcuda,
+    }
+
+
+def ncu_wrap_argv(
+    program_argv: list[str],
+    *,
+    ncu_bin: str,
+    out_prefix: str,
+    metrics: str = NCU_DEFAULT_METRICS,
+    launch_count: int = 1,
+    kernel_regex: str = "",
+) -> list[str]:
+    """Wrap ``program_argv`` with an ``ncu`` invocation.
+
+    ``out_prefix`` gets ``_%p`` appended (one report per profiled process). Uses
+    ``--target-processes all`` so ncu profiles torchrun / mp.spawn child ranks, and
+    ``--launch-count`` to bound the number of profiled launches. Returns the full argv
+    (``[ncu, ...ncu-flags..., *program_argv]``).
+    """
+    argv = [
+        ncu_bin,
+        "--target-processes",
+        "all",
+        "--replay-mode",
+        "kernel",
+        "--launch-count",
+        str(launch_count),
+        "--metrics",
+        metrics,
+        "-f",
+        "-o",
+        f"{out_prefix}_%p",
+    ]
+    if kernel_regex:
+        argv += ["-k", kernel_regex, "--kernel-name-base", "function"]
+    return argv + list(program_argv)

--- a/comms/dsl/tests/test_bench_common.py
+++ b/comms/dsl/tests/test_bench_common.py
@@ -1,0 +1,122 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Host-only unit tests for the benchmark pure helpers + the AnyBench parser summary.
+
+No GPU / distributed dependency: these exercise the pure sizing / bandwidth / SM-match /
+result-aggregation logic that the multi-GPU benchmark itself cannot gate under CI.
+"""
+
+import unittest
+from unittest import mock
+
+from comms.dsl.tests._bench_common import (
+    _bus_bytes,
+    _bw_gbps,
+    _fmt_size,
+    _framework_num_blocks,
+    _iters_for_size,
+)
+from comms.dsl.tests.anybench_a2a_cute_parser import _summarize
+
+
+class FmtSizeTest(unittest.TestCase):
+    def test_units(self) -> None:
+        self.assertEqual(_fmt_size(32), "32B")
+        self.assertEqual(_fmt_size(65536), "64KB")
+        self.assertEqual(_fmt_size(50331648), "48MB")
+        self.assertEqual(_fmt_size(2147483648), "2GB")
+
+
+class BwGbpsTest(unittest.TestCase):
+    def test_zero_latency_is_zero(self) -> None:
+        # lat=0 must not divide-by-zero; the sentinel is 0.0 busbw.
+        self.assertEqual(_bw_gbps(1 << 20, 8, 0.0), 0.0)
+
+    def test_bus_bytes_excludes_diagonal(self) -> None:
+        # chunk = numel // ws; bus bytes = chunk * (ws - 1) * elem (bf16 = 2 bytes).
+        self.assertEqual(_bus_bytes(8 * 1024, 8), 1024 * 7 * 2)
+
+
+class ItersForSizeTest(unittest.TestCase):
+    def test_bands(self) -> None:
+        self.assertEqual(_iters_for_size(64 * 1024), 500)
+        self.assertEqual(_iters_for_size(64 * 1024 * 1024), 200)
+        self.assertEqual(_iters_for_size(1 << 30), 50)
+
+
+class FrameworkNumBlocksTest(unittest.TestCase):
+    # _max_num_blocks reads torch.cuda device props (GPU-only), so patch it to a fixed SM cap.
+    @mock.patch("comms.dsl.tests._bench_common._max_num_blocks", return_value=16)
+    def test_probed_matches_nccl_grid(self, _cap: mock.MagicMock) -> None:
+        # (1 MB, cap=32) -> nccl_grid 16; nb = round(16 / 8) = 2, capped at 16.
+        nb, grid = _framework_num_blocks(1048576, 32, 8, mock.MagicMock(), 32)
+        self.assertEqual((nb, grid), (2, 16))
+
+    @mock.patch("comms.dsl.tests._bench_common._max_num_blocks", return_value=16)
+    def test_unprobed_falls_back_to_cap(self, _cap: mock.MagicMock) -> None:
+        # An unprobed (msg, cap) returns the SM-budget cap + None (row flagged not-matched).
+        nb, grid = _framework_num_blocks(999, 32, 8, mock.MagicMock(), 32)
+        self.assertEqual((nb, grid), (16, None))
+
+
+class SummarizeTest(unittest.TestCase):
+    def test_zero_ratio_sentinel_is_kept(self) -> None:
+        # A ratio of 0.0 (NCCL timing failed) must NOT be filtered out: it sinks min_ratio,
+        # fails all_clear_nccl, and is surfaced as n_nccl_failed. This protects the
+        # keep-the-0.0-sentinel logic from regressing to a truthy filter.
+        rows = [
+            {
+                "backend": "cute",
+                "variant": "copy",
+                "size_bytes": 1024,
+                "ratio": 0.0,
+                "world_size": 8,
+            },
+            {
+                "backend": "cute",
+                "variant": "copy",
+                "size_bytes": 2048,
+                "ratio": 1.5,
+                "world_size": 8,
+            },
+        ]
+        out = _summarize(rows)
+        self.assertFalse(out["all_clear_nccl"])
+        self.assertEqual(out["n_nccl_failed"], 1)
+        self.assertEqual(out["min_ratio_busbw"], 0.0)
+        self.assertEqual(out["n_result_rows"], 2)
+
+        clear = _summarize(
+            [
+                {
+                    "backend": "cute",
+                    "variant": "copy",
+                    "size_bytes": 1024,
+                    "ratio": 1.2,
+                    "world_size": 8,
+                },
+            ]
+        )
+        self.assertTrue(clear["all_clear_nccl"])
+        self.assertEqual(clear["n_nccl_failed"], 0)
+
+    def test_error_rows_counted(self) -> None:
+        rows = [
+            {"backend": "cute_error", "size_bytes": 1024, "error": "boom"},
+        ]
+        out = _summarize(rows)
+        self.assertEqual(out["n_errors"], 1)
+        self.assertEqual(out["first_error"], "boom")
+
+    def test_n_result_rows_counts_copy_only(self) -> None:
+        # n_result_rows tracks the per-size (copy) arrays, not all cute rows, so it stays
+        # consistent once non-copy variants (direct/ce) start being emitted alongside copy.
+        rows = [
+            {"backend": "cute", "variant": "copy", "size_bytes": 1024, "ratio": 1.1},
+            {"backend": "cute", "variant": "direct", "size_bytes": 1024, "ratio": 1.4},
+        ]
+        out = _summarize(rows)
+        self.assertEqual(out["n_result_rows"], 1)
+        self.assertEqual(len(out["size_bytes"]), 1)

--- a/comms/dsl/tests/test_cute_a2a_correctness.py
+++ b/comms/dsl/tests/test_cute_a2a_correctness.py
@@ -1,0 +1,119 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# Distributed correctness test: the worker runs under mp.spawn and touches untyped cutlass /
+# symmetric-memory symbols that pyre cannot model, so strict typing adds no value here.
+
+"""Correctness test for the fused CuTe all_to_all (vs dist.all_to_all_single).
+
+Bit-exact gold check across a few sizes / block counts / dtypes, eager and under
+CUDA-graph replay (the persistent-counter graph-safety contract). Covers fp32 + bf16, a
+single-shot and a pipelined size, small and ``num_blocks == max_blocks_per_peer``. HEAD
+slot-free credits protect free-running transport reuse across graph replays. Skipped unless
+>=2 GPUs are present.
+"""
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from comms.dsl.tests._dist_harness import _find_free_port, _golden, _make_input
+
+# (numel factor per rank, num_blocks, dtype, elem_bytes): tiny (scalar-ish), small multi-
+# block, a pipelined 8 MiB fp32 chunk (num_slots > 1), num_blocks == mbp (=32) boundary,
+# and the bf16 path.
+_CASES: tuple[tuple[int, int, torch.dtype, int], ...] = (
+    (4, 1, torch.float32, 4),
+    (2048, 2, torch.float32, 4),
+    (2 * 1024 * 1024, 4, torch.float32, 4),
+    (2048, 32, torch.float32, 4),
+    (2048, 2, torch.bfloat16, 2),
+)
+
+
+def _dtype_input(rank: int, numel: int, device: torch.device, dtype: torch.dtype):
+    if dtype == torch.float32:
+        return _make_input(rank, numel, device)  # integer-valued fp32, exact
+    # bf16-exact per-rank, position-varying pattern (values 0..250 < 256); a pure copy
+    # preserves it bit-exactly, so torch.equal is valid.
+    idx = torch.arange(numel, device=device, dtype=torch.int64)
+    return ((idx + rank * 131) % 251).to(dtype)
+
+
+def _worker(rank: int, world_size: int, port: int, result_q) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    try:
+        device = torch.device(f"cuda:{rank}")
+        group = dist.group.WORLD
+        assert group is not None
+
+        from comms.dsl import nvl_rendezvous
+        from comms.dsl.cute.a2a.host import all_to_all
+        from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+        ok = True
+        for factor, nb, dtype, elem in _CASES:
+            numel = world_size * factor
+            chunk = numel // world_size
+            t = nvl_rendezvous(group, device, per_peer_bytes=chunk * elem)
+            inp = _dtype_input(rank, numel, device, dtype)
+            gold = _golden(group, inp)
+            out = torch.empty_like(inp)
+
+            all_to_all(t, out, inp, config=CuteA2AConfig(num_blocks=nb))
+            torch.cuda.synchronize(device)
+            eager_ok = torch.equal(out, gold)
+
+            # Graph replay with distinct data exercises persistent counter progression and
+            # HEAD credit protection without a cross-rank barrier between replays.
+            buf = inp.clone()
+
+            def fn(out=out, buf=buf, t=t, nb=nb):
+                all_to_all(t, out, buf, config=CuteA2AConfig(num_blocks=nb))
+
+            fn()
+            torch.cuda.synchronize(device)
+            dist.barrier(group)
+            g = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(g):
+                fn()
+            graph_ok = True
+            for i in range(3):
+                inp2 = _dtype_input(rank + 11 * (i + 1), numel, device, dtype)
+                buf.copy_(inp2)
+                out.zero_()
+                g.replay()
+                torch.cuda.synchronize(device)
+                graph_ok = graph_ok and torch.equal(out, _golden(group, inp2))
+            ok = ok and eager_ok and graph_ok
+            if rank == 0:
+                print(
+                    f"  numel={numel} nb={nb} dtype={dtype}: "
+                    f"eager={'ok' if eager_ok else 'FAIL'} "
+                    f"graph={'ok' if graph_ok else 'FAIL'}",
+                    flush=True,
+                )
+            dist.barrier(group)
+
+        result_q.put((rank, ok))
+    finally:
+        dist.barrier()
+        dist.destroy_process_group()
+
+
+class A2ACuteTest(unittest.TestCase):
+    def test_cute_a2a(self) -> None:
+        if torch.cuda.device_count() < 2:
+            self.skipTest("needs >=2 GPUs")
+        ws = min(torch.cuda.device_count(), 4)
+        ctx = mp.get_context("spawn")
+        result_q = ctx.SimpleQueue()
+        mp.spawn(_worker, args=(ws, _find_free_port(), result_q), nprocs=ws, join=True)
+        results = sorted(result_q.get() for _ in range(ws))
+        self.assertEqual([r for r, _ in results], list(range(ws)))
+        self.assertTrue(all(ok for _, ok in results), f"per-rank pass flags: {results}")

--- a/comms/dsl/tests/test_cute_a2a_robust.py
+++ b/comms/dsl/tests/test_cute_a2a_robust.py
@@ -1,0 +1,217 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# Distributed test: runs under mp.spawn and touches untyped cutlass / symmetric-memory symbols
+# that pyre cannot model, so strict typing adds no value here.
+
+"""Robustness tests for the CuTe-DSL all_to_all copy schedule.
+
+* **Concurrent transports** -- two independent transports interleaved on the same ranks
+  must not cross-talk; each keeps its own staging buffer + signal pad + step counters.
+* **Geometry guard** -- switching a geometry field (``num_blocks``) on a reused transport
+  must FIRE the runtime guard (``check_geometry``) before dispatch.
+
+HEAD slot-free credits protect fixed-geometry reused transports without host barriers.
+Gold is ``dist.all_to_all_single``. Skipped unless >=2 GPUs are present.
+"""
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from comms.dsl.tests._dist_harness import (
+    _find_free_port,
+    _golden,
+    _make_input,
+    _rendezvous,
+    _report,
+)
+
+
+def _case_concurrent_transports(group, rank, ws, device) -> bool:
+    """Two independent CuTe transports interleaved on the same ranks must not cross-talk --
+    each keeps its own staging buffer + signal pad + step counters, so interleaving their
+    collectives stays bit-exact."""
+    from comms.dsl.cute.a2a.host import all_to_all
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+    numel = ws * 8192
+    chunk = numel // ws
+    t1 = _rendezvous(group, device, chunk)
+    t2 = _rendezvous(group, device, chunk)
+    inp = _make_input(rank, numel, device)
+    gold = _golden(group, inp)
+    o1 = torch.empty_like(inp)
+    o2 = torch.empty_like(inp)
+    cfg = CuteA2AConfig(num_blocks=2)
+    all_to_all(t1, o1, inp, config=cfg)
+    all_to_all(t2, o2, inp, config=cfg)
+    torch.cuda.synchronize(device)
+    all_to_all(t1, o1, inp, config=cfg)
+    all_to_all(t2, o2, inp, config=cfg)
+    torch.cuda.synchronize(device)
+    ok = torch.equal(o1, gold) and torch.equal(o2, gold)
+    dist.barrier(group)
+    return _report("concurrent_transports", ok, device, group, rank)
+
+
+def _case_geometry_switch_guard(group, rank, ws, device) -> bool:
+    """The geometry guard must FIRE when a geometry field (``num_blocks``) changes on a
+    reused transport. The first call primes the geometry (num_blocks=2) and must SUCCEED;
+    the second differs ONLY in ``num_blocks`` (2 -> 4, same numel) so ``check_geometry`` --
+    a hard error by default (no runtime drain) -- raises ValueError before dispatch."""
+    from comms.dsl.cute.a2a.host import all_to_all
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+    numel = ws * 4096
+    chunk = numel // ws
+    t = _rendezvous(group, device, chunk)
+    inp = _make_input(rank, numel, device)
+    out = torch.empty_like(inp)
+
+    all_to_all(t, out, inp, config=CuteA2AConfig(num_blocks=2))
+    torch.cuda.synchronize(device)
+    primed_ok = torch.equal(out, _golden(group, inp))
+
+    raised = False
+    try:
+        all_to_all(t, out, inp, config=CuteA2AConfig(num_blocks=4))
+    except ValueError:
+        raised = True
+
+    dist.barrier(group)
+    return _report("geometry_switch_guard", primed_ok and raised, device, group, rank)
+
+
+def _case_cluster(group, rank, ws, device) -> bool:
+    """The CGA cluster launch path (untested elsewhere): forcing ``cluster>1`` must stay
+    bit-exact, and a cluster that does not divide ``num_blocks`` must collapse to 1 (the
+    host guard) rather than trip CUDA_ERROR_INVALID_CLUSTER_SIZE."""
+    from comms.dsl.cute.a2a.host import all_to_all
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+    numel = ws * 8192
+    chunk = numel // ws
+    inp = _make_input(rank, numel, device)
+    gold = _golden(group, inp)
+
+    # CGA on: num_blocks (4) divisible by cluster (2) -> cluster stays 2.
+    t1 = _rendezvous(group, device, chunk)
+    o1 = torch.empty_like(inp)
+    all_to_all(t1, o1, inp, config=CuteA2AConfig(num_blocks=4, cluster=2))
+    torch.cuda.synchronize(device)
+    dist.barrier(group)
+    # Collapse: num_blocks (3) NOT divisible by cluster (2) -> host collapses to 1.
+    t2 = _rendezvous(group, device, chunk)
+    o2 = torch.empty_like(inp)
+    all_to_all(t2, o2, inp, config=CuteA2AConfig(num_blocks=3, cluster=2))
+    torch.cuda.synchronize(device)
+    ok = torch.equal(o1, gold) and torch.equal(o2, gold)
+    dist.barrier(group)
+    return _report("cluster_and_collapse", ok, device, group, rank)
+
+
+def _case_allow_geometry_switch(group, rank, ws, device) -> bool:
+    """``COMMS_DSL_ALLOW_GEOMETRY_SWITCH=1`` downgrades the geometry guard to a silent
+    advance for sync-separated callers: a num_blocks 2 -> 4 switch on a reused transport
+    must NOT raise and must stay bit-exact (a device sync + barrier separates the calls, so
+    no bytes are in flight across the switch)."""
+    from comms.dsl.cute.a2a.host import all_to_all
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+    numel = ws * 4096
+    chunk = numel // ws
+    inp = _make_input(rank, numel, device)
+    gold = _golden(group, inp)
+    t = _rendezvous(group, device, chunk)
+    out = torch.empty_like(inp)
+
+    prev = os.environ.get("COMMS_DSL_ALLOW_GEOMETRY_SWITCH")
+    ok = False
+    try:
+        os.environ["COMMS_DSL_ALLOW_GEOMETRY_SWITCH"] = "1"
+        all_to_all(t, out, inp, config=CuteA2AConfig(num_blocks=2))
+        torch.cuda.synchronize(device)
+        first_ok = torch.equal(out, gold)
+        dist.barrier(group)
+        # Geometry switch (num_blocks 2 -> 4) must be allowed (no raise) under the env.
+        all_to_all(t, out, inp, config=CuteA2AConfig(num_blocks=4))
+        torch.cuda.synchronize(device)
+        ok = first_ok and torch.equal(out, gold)
+    finally:
+        if prev is None:
+            os.environ.pop("COMMS_DSL_ALLOW_GEOMETRY_SWITCH", None)
+        else:
+            os.environ["COMMS_DSL_ALLOW_GEOMETRY_SWITCH"] = prev
+    dist.barrier(group)
+    return _report("allow_geometry_switch", ok, device, group, rank)
+
+
+def _case_rejected_call_no_baseline_pollution(group, rank, ws, device) -> bool:
+    """A call rejected by a pre-dispatch guard must NOT seed the geometry baseline: the
+    geometry commit happens only just before dispatch. Here the first call is rejected
+    (primitive='direct' is not shipped) and a subsequent legit copy call on the SAME
+    transport must succeed rather than spuriously raise 'geometry changed'."""
+    from comms.dsl.cute.a2a.host import all_to_all
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+    numel = ws * 4096
+    chunk = numel // ws
+    inp = _make_input(rank, numel, device)
+    gold = _golden(group, inp)
+    t = _rendezvous(group, device, chunk)
+    out = torch.empty_like(inp)
+
+    rejected = False
+    try:
+        all_to_all(t, out, inp, config=CuteA2AConfig(primitive="direct"))
+    except ValueError:
+        rejected = True
+    # The rejected call dispatched nothing, so this legit copy call must succeed.
+    all_to_all(t, out, inp, config=CuteA2AConfig(num_blocks=2))
+    torch.cuda.synchronize(device)
+    ok = rejected and torch.equal(out, gold)
+    dist.barrier(group)
+    return _report("rejected_call_no_baseline_pollution", ok, device, group, rank)
+
+
+def _run_cases(group, rank, ws, device) -> list[bool]:
+    return [
+        _case_concurrent_transports(group, rank, ws, device),
+        _case_geometry_switch_guard(group, rank, ws, device),
+        _case_cluster(group, rank, ws, device),
+        _case_allow_geometry_switch(group, rank, ws, device),
+        _case_rejected_call_no_baseline_pollution(group, rank, ws, device),
+    ]
+
+
+def _mp_worker(rank: int, world_size: int, port: int, result_q) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    try:
+        device = torch.device(f"cuda:{rank}")
+        group = dist.group.WORLD
+        assert group is not None
+        result_q.put((rank, all(_run_cases(group, rank, world_size, device))))
+    finally:
+        dist.barrier()
+        dist.destroy_process_group()
+
+
+class A2ACuteRobustTest(unittest.TestCase):
+    def test_robustness(self) -> None:
+        if torch.cuda.device_count() < 2:
+            self.skipTest("needs >=2 GPUs")
+        ws = min(torch.cuda.device_count(), 8)
+        ctx = mp.get_context("spawn")
+        result_q = ctx.SimpleQueue()
+        mp.spawn(
+            _mp_worker, args=(ws, _find_free_port(), result_q), nprocs=ws, join=True
+        )
+        results = sorted(result_q.get() for _ in range(ws))
+        self.assertEqual([r for r, _ in results], list(range(ws)))
+        self.assertTrue(all(ok for _, ok in results), f"per-rank pass flags: {results}")

--- a/comms/dsl/tests/test_mast_launch.py
+++ b/comms/dsl/tests/test_mast_launch.py
@@ -7,7 +7,12 @@
 import argparse
 import unittest
 
-from comms.dsl.tests.mast_launch import _parse_envs, launch
+from comms.dsl.tests.mast_launch import (
+    _ncu_bench_args,
+    _parse_envs,
+    build_app_and_cfg,
+    launch,
+)
 
 
 class ParseEnvsTest(unittest.TestCase):
@@ -31,3 +36,43 @@ class SubmitAccessKnobGuardTest(unittest.TestCase):
         args = argparse.Namespace(submit=True, entitlement=None, dp=None, oncall=None)
         with self.assertRaises(SystemExit):
             launch(args)
+
+
+class NcuBenchArgsTest(unittest.TestCase):
+    def test_empty_when_ncu_off(self) -> None:
+        self.assertEqual(_ncu_bench_args(argparse.Namespace(ncu=False)), [])
+
+    def test_injects_flags(self) -> None:
+        out = _ncu_bench_args(
+            argparse.Namespace(
+                ncu=True,
+                ncu_metrics="launch__x",
+                ncu_launch_count=2,
+                ncu_kernel_regex="",
+            )
+        )
+        adjacent = set(zip(out, out[1:]))
+        self.assertIn("--ncu", out)
+        self.assertIn("--ncu-driver-shim", out)
+        self.assertIn(("--ncu-metrics", "launch__x"), adjacent)
+        self.assertIn(("--ncu-launch-count", "2"), adjacent)
+        self.assertNotIn("--ncu-kernel-regex", out)  # omitted when empty
+
+    def test_kernel_regex_forwarded(self) -> None:
+        out = _ncu_bench_args(
+            argparse.Namespace(
+                ncu=True,
+                ncu_metrics="m",
+                ncu_launch_count=1,
+                ncu_kernel_regex="_a2a_kernel",
+            )
+        )
+        self.assertIn(("--ncu-kernel-regex", "_a2a_kernel"), set(zip(out, out[1:])))
+
+
+class NcuDeliveryGuardTest(unittest.TestCase):
+    def test_fbpkg_plus_ncu_fails_loud(self) -> None:
+        # --ncu needs the conda base-image swap; combining it with --delivery fbpkg must raise
+        # rather than silently run an un-profiled job.
+        with self.assertRaises(SystemExit):
+            build_app_and_cfg(argparse.Namespace(ncu=True, delivery="fbpkg"))

--- a/comms/dsl/tests/test_mast_launch.py
+++ b/comms/dsl/tests/test_mast_launch.py
@@ -1,0 +1,33 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Host-only unit tests for the MAST launcher's pure arg-parsing + access-knob guard."""
+
+import argparse
+import unittest
+
+from comms.dsl.tests.mast_launch import _parse_envs, launch
+
+
+class ParseEnvsTest(unittest.TestCase):
+    def test_parses_pairs(self) -> None:
+        self.assertEqual(_parse_envs("A=1;B=2"), {"A": "1", "B": "2"})
+
+    def test_skips_malformed_and_empty(self) -> None:
+        # An entry without '=' is skipped (logged), not fatal; blanks are ignored.
+        self.assertEqual(_parse_envs("A=1;bad;;B=2"), {"A": "1", "B": "2"})
+        self.assertEqual(_parse_envs(""), {})
+        self.assertEqual(_parse_envs(None), {})
+
+    def test_value_may_contain_equals(self) -> None:
+        self.assertEqual(_parse_envs("K=a=b"), {"K": "a=b"})
+
+
+class SubmitAccessKnobGuardTest(unittest.TestCase):
+    def test_submit_without_access_knobs_exits(self) -> None:
+        # --submit with no entitlement/identity/oncall must fail fast (before any spec
+        # assembly or capacity use). Only the fields the guard reads are needed here.
+        args = argparse.Namespace(submit=True, entitlement=None, dp=None, oncall=None)
+        with self.assertRaises(SystemExit):
+            launch(args)

--- a/comms/dsl/tests/test_ncu_common.py
+++ b/comms/dsl/tests/test_ncu_common.py
@@ -1,0 +1,160 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Host-only unit tests for the NCU wrapper boilerplate (no GPU / ncu binary needed)."""
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from comms.dsl.tests.ncu_common import (
+    build_driver_shim,
+    NCU_DEFAULT_METRICS,
+    ncu_wrap_argv,
+    resolve_ncu_bin,
+)
+
+
+class NcuWrapArgvTest(unittest.TestCase):
+    def test_wraps_program_with_ncu_flags(self) -> None:
+        argv = ncu_wrap_argv(
+            ["mybin", "--x"],
+            ncu_bin="/usr/bin/ncu",
+            out_prefix="/tmp/o",
+            metrics="m1,m2",
+            launch_count=3,
+        )
+        self.assertEqual(argv[0], "/usr/bin/ncu")
+        self.assertEqual(argv[-2:], ["mybin", "--x"])  # program appended last
+        self.assertIn("all", argv[argv.index("--target-processes") + 1 :])
+        self.assertEqual(argv[argv.index("--launch-count") + 1], "3")
+        self.assertEqual(argv[argv.index("--metrics") + 1], "m1,m2")
+        self.assertEqual(argv[argv.index("-o") + 1], "/tmp/o_%p")  # %p per-process
+
+    def test_default_metrics_are_single_pass_launch(self) -> None:
+        # Default metrics must be launch__ (no-replay) so the comm kernel does not deadlock.
+        for m in NCU_DEFAULT_METRICS.split(","):
+            self.assertTrue(m.startswith("launch__"), m)
+
+    def test_kernel_regex_added_when_given(self) -> None:
+        argv = ncu_wrap_argv(
+            ["b"], ncu_bin="/ncu", out_prefix="/o", kernel_regex="_a2a_kernel"
+        )
+        self.assertIn("-k", argv)
+        self.assertEqual(argv[argv.index("-k") + 1], "_a2a_kernel")
+
+    def test_kernel_regex_omitted_by_default(self) -> None:
+        self.assertNotIn("-k", ncu_wrap_argv(["b"], ncu_bin="/ncu", out_prefix="/o"))
+
+
+class ResolveNcuBinTest(unittest.TestCase):
+    def test_explicit_wins(self) -> None:
+        self.assertEqual(resolve_ncu_bin("/custom/ncu"), "/custom/ncu")
+
+    @mock.patch("comms.dsl.tests.ncu_common.os.path.exists", return_value=False)
+    @mock.patch("comms.dsl.tests.ncu_common.shutil.which", return_value=None)
+    def test_raises_when_absent(
+        self, _which: mock.MagicMock, _exists: mock.MagicMock
+    ) -> None:
+        with self.assertRaises(FileNotFoundError):
+            resolve_ncu_bin()
+
+    @mock.patch("comms.dsl.tests.ncu_common.shutil.which", return_value="/path/ncu")
+    def test_path_lookup(self, _which: mock.MagicMock) -> None:
+        self.assertEqual(resolve_ncu_bin(), "/path/ncu")
+
+
+class BuildDriverShimTest(unittest.TestCase):
+    def test_absent_platform_dir_returns_empty(self) -> None:
+        # Local dev: no platform driver dir -> no shim, driver already resolvable.
+        self.assertEqual(build_driver_shim("/no/such/dir", shim_dir="/tmp/nope"), {})
+
+    def test_present_dir_symlinks_libs_and_sets_env(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as src,
+            tempfile.TemporaryDirectory() as base,
+        ):
+            for lib in ("libcuda.so", "libcuda.so.1", "libnvidia-ml.so"):
+                open(os.path.join(src, lib), "w").close()
+            shim = os.path.join(base, "cuda_driver_ncu")
+            env = build_driver_shim(src, shim_dir=shim)
+            self.assertTrue(env["LD_LIBRARY_PATH"].startswith(shim))
+            self.assertIn(f"{shim}/libcuda.so", env["LD_PRELOAD"])
+            self.assertEqual(env["TRITON_LIBCUDA_PATH"], f"{shim}/libcuda.so")
+            self.assertTrue(os.path.islink(os.path.join(shim, "libcuda.so")))
+            self.assertTrue(os.path.islink(os.path.join(shim, "libnvidia-ml.so")))
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    def test_unset_library_path_has_no_empty_component(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as src,
+            tempfile.TemporaryDirectory() as base,
+        ):
+            open(os.path.join(src, "libcuda.so"), "w").close()
+            shim = os.path.join(base, "cuda_driver_ncu")
+            env = build_driver_shim(src, shim_dir=shim)
+            self.assertEqual(shim, env["LD_LIBRARY_PATH"])
+
+    @mock.patch.dict(os.environ, {"LD_PRELOAD": "/existing/injector.so"}, clear=True)
+    def test_existing_preload_is_preserved(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as src,
+            tempfile.TemporaryDirectory() as base,
+        ):
+            open(os.path.join(src, "libcuda.so"), "w").close()
+            shim = os.path.join(base, "cuda_driver_ncu")
+            env = build_driver_shim(src, shim_dir=shim)
+            self.assertEqual(
+                f"{shim}/libcuda.so:/existing/injector.so", env["LD_PRELOAD"]
+            )
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    def test_missing_optional_nvml_is_omitted(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as src,
+            tempfile.TemporaryDirectory() as base,
+        ):
+            open(os.path.join(src, "libcuda.so"), "w").close()
+            shim = os.path.join(base, "cuda_driver_ncu")
+            env = build_driver_shim(src, shim_dir=shim)
+            self.assertEqual(f"{shim}/libcuda.so", env["LD_PRELOAD"])
+
+    def test_dangling_symlink_is_repaired(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as src,
+            tempfile.TemporaryDirectory() as base,
+        ):
+            source = os.path.join(src, "libcuda.so")
+            open(source, "w").close()
+            shim = os.path.join(base, "cuda_driver_ncu")
+            os.makedirs(shim)
+            link = os.path.join(shim, "libcuda.so")
+            os.symlink("/missing/libcuda.so", link)
+            env = build_driver_shim(src, shim_dir=shim)
+            self.assertEqual(source, os.readlink(link))
+            self.assertEqual(link, env["TRITON_LIBCUDA_PATH"])
+
+    def test_missing_libcuda_raises(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as src,
+            tempfile.TemporaryDirectory() as base,
+        ):
+            open(os.path.join(src, "libnvidia-ml.so"), "w").close()
+            with self.assertRaisesRegex(FileNotFoundError, "libcuda"):
+                build_driver_shim(src, shim_dir=os.path.join(base, "cuda_driver_ncu"))
+
+    def test_versioned_only_lib_falls_back_in_preload(self) -> None:
+        # Some driver installs ship only libcuda.so.1 (no unversioned name); LD_PRELOAD must
+        # point at the versioned lib that exists, not a dangling unversioned path.
+        with (
+            tempfile.TemporaryDirectory() as src,
+            tempfile.TemporaryDirectory() as base,
+        ):
+            for lib in ("libcuda.so.1", "libnvidia-ml.so.1"):
+                open(os.path.join(src, lib), "w").close()
+            shim = os.path.join(base, "cuda_driver_ncu")
+            env = build_driver_shim(src, shim_dir=shim)
+            self.assertIn(f"{shim}/libcuda.so.1", env["LD_PRELOAD"])
+            self.assertEqual(env["TRITON_LIBCUDA_PATH"], f"{shim}/libcuda.so.1")

--- a/comms/dsl/tests/test_transport.py
+++ b/comms/dsl/tests/test_transport.py
@@ -1,0 +1,108 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Host-side (CPU, no device) coverage for transport host validation.
+
+``check_transfer`` and ``_require_signal_pad`` are pure host validation -- they
+read only ints (per_peer_bytes / max_blocks_per_peer / dtype.itemsize / a pad
+size) -- so their invariants are exercisable without a symmetric-memory process group.
+The device rendezvous path requires a real symmetric-memory-capable group and is outside
+this host-only test target.
+"""
+
+import unittest
+from dataclasses import dataclass
+from typing import cast
+
+import torch
+from comms.dsl import check_transfer, NvlTransport
+from comms.dsl.transport import _require_signal_pad
+
+
+@dataclass
+class _StubTransport:
+    """Minimal stub carrying only the fields ``check_transfer`` reads."""
+
+    per_peer_bytes: int
+    max_blocks_per_peer: int
+
+
+def _stub(per_peer_bytes: int, max_blocks_per_peer: int = 8) -> NvlTransport:
+    return cast(
+        NvlTransport,
+        _StubTransport(
+            per_peer_bytes=per_peer_bytes, max_blocks_per_peer=max_blocks_per_peer
+        ),
+    )
+
+
+class TransportCheckTransferTest(unittest.TestCase):
+    def test_dtype_not_divisible_raises(self) -> None:
+        # per_peer_bytes must be a whole multiple of the dtype itemsize:
+        # 65 bytes is not divisible by bfloat16's 2-byte itemsize.
+        with self.assertRaises(ValueError):
+            check_transfer(_stub(65), numel=1, dtype=torch.bfloat16, num_blocks=1)
+
+    def test_numel_overrun_raises(self) -> None:
+        # per_peer_bytes=64 holds 64 uint8 / 32 bf16 elems; one past capacity raises.
+        for dtype, cap in ((torch.uint8, 64), (torch.bfloat16, 32)):
+            with self.assertRaises(ValueError):
+                check_transfer(_stub(64), numel=cap + 1, dtype=dtype, num_blocks=1)
+
+    def test_num_blocks_out_of_range_raises(self) -> None:
+        t = _stub(64)
+        with self.assertRaises(ValueError):
+            check_transfer(t, numel=1, dtype=torch.uint8, num_blocks=0)
+        with self.assertRaises(ValueError):
+            check_transfer(
+                t, numel=1, dtype=torch.uint8, num_blocks=t.max_blocks_per_peer + 1
+            )
+
+    def test_divisibility_checked_before_capacity(self) -> None:
+        # When per_peer_bytes is both non-divisible AND too small for numel, the
+        # divisibility error must win: cap_elems = per_peer_bytes // itemsize would be
+        # computed from a garbage (floored) capacity otherwise. Kernel addressing relies
+        # on this order.
+        with self.assertRaisesRegex(ValueError, "not a multiple"):
+            check_transfer(
+                _stub(65), numel=10_000_000, dtype=torch.bfloat16, num_blocks=1
+            )
+
+    def test_min_capacity_boundary(self) -> None:
+        # per_peer_bytes == itemsize -> cap_elems == 1: exactly 1 elem fits, 2 overruns.
+        t = _stub(2)  # 1 bf16 elem
+        self.assertIsNone(
+            check_transfer(t, numel=1, dtype=torch.bfloat16, num_blocks=1)
+        )
+        with self.assertRaises(ValueError):
+            check_transfer(t, numel=2, dtype=torch.bfloat16, num_blocks=1)
+
+    def test_valid_transfer_passes(self) -> None:
+        # check_transfer returns None on success; assert that (and that it does not
+        # raise) for every valid (dtype, numel, num_blocks) combination. numel == 0
+        # (empty transfer) is allowed.
+        t = _stub(64)
+        for dtype, cap in ((torch.uint8, 64), (torch.bfloat16, 32)):
+            self.assertIsNone(check_transfer(t, numel=0, dtype=dtype, num_blocks=1))
+            self.assertIsNone(check_transfer(t, numel=cap, dtype=dtype, num_blocks=1))
+            self.assertIsNone(
+                check_transfer(
+                    t, numel=cap, dtype=dtype, num_blocks=t.max_blocks_per_peer
+                )
+            )
+
+
+class RequireSignalPadTest(unittest.TestCase):
+    def test_pad_too_small_raises(self) -> None:
+        # need = 2 * ws * mbp; one int64 short must raise.
+        ws, mbp = 8, 32
+        need = 2 * ws * mbp
+        with self.assertRaisesRegex(RuntimeError, "signal pad too small"):
+            _require_signal_pad(need - 1, ws, mbp)
+
+    def test_pad_exact_and_larger_pass(self) -> None:
+        ws, mbp = 8, 32
+        need = 2 * ws * mbp
+        self.assertIsNone(_require_signal_pad(need, ws, mbp))
+        self.assertIsNone(_require_signal_pad(need + 1, ws, mbp))

--- a/comms/dsl/tests/test_transport.py
+++ b/comms/dsl/tests/test_transport.py
@@ -17,6 +17,7 @@ from typing import cast
 
 import torch
 from comms.dsl import check_transfer, NvlTransport
+from comms.dsl.cute.a2a.tuning import _max_coresident_ctas
 from comms.dsl.transport import _require_signal_pad
 
 
@@ -106,3 +107,17 @@ class RequireSignalPadTest(unittest.TestCase):
         need = 2 * ws * mbp
         self.assertIsNone(_require_signal_pad(need, ws, mbp))
         self.assertIsNone(_require_signal_pad(need + 1, ws, mbp))
+
+
+class MaxCoresidentCtasTest(unittest.TestCase):
+    def test_thread_limited(self) -> None:
+        # 2048 threads/SM, 1024 threads/CTA -> 2 blocks/SM; 132 SMs -> 264.
+        self.assertEqual(_max_coresident_ctas(132, 2048, 1024), 264)
+
+    def test_block_cap_limited(self) -> None:
+        # 2048 // 32 = 64 blocks/SM but the hardware cap is 32; 100 SMs -> 3200.
+        self.assertEqual(_max_coresident_ctas(100, 2048, 32), 100 * 32)
+
+    def test_floors_at_one_block_per_sm(self) -> None:
+        # num_threads > threads/SM -> still at least 1 block/SM (never 0).
+        self.assertEqual(_max_coresident_ctas(10, 2048, 4096), 10)

--- a/comms/dsl/transport.py
+++ b/comms/dsl/transport.py
@@ -1,0 +1,282 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""User-owned NVLink transport for the comms/dsl all_to_all kernels.
+
+:class:`NvlTransport` owns all transport state behind one object: the
+symmetric-memory staging buffer, the signal pad, and the persistent per-(peer,
+block) step counters. A device schedule consumes the device-side
+:class:`PeerTable` (every peer's staging-buffer + signal-pad base pointer,
+indexed by peer id in-kernel). The transport contains no collective algorithm.
+
+Design points realized here:
+
+* **User-owned, one rendezvous.** :func:`nvl_rendezvous` does a single collective
+  rendezvous for the whole group and returns an object the user holds (reused
+  across CUDA-graph replays). There is no hidden module-level cache.
+* **Graph-safe signalling.** The signal pad plus persistent monotonic step
+  counters let a reused transport / captured graph replay without ever reading a
+  stale signal slot (see :meth:`NvlTransport.step_state`).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from torch._C._distributed_c10d import _SymmetricMemory
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+_SR_DEBUG: bool | None = None
+
+
+def _sr_debug() -> bool:
+    global _SR_DEBUG
+    if _SR_DEBUG is None:
+        _SR_DEBUG = os.environ.get("SENDRECV_DEBUG", "0") == "1"
+    return _SR_DEBUG
+
+
+def _rdv_dbg(group: dist.ProcessGroup, msg: str) -> None:
+    if _sr_debug():
+        logger.debug("[r%d] rdv: %s", dist.get_rank(group), msg)
+
+
+# Shape-independent default; the staging region per peer must hold the message.
+_DEFAULT_MAX_BLOCKS_PER_PEER: int = 32
+
+
+@dataclass(frozen=True)
+class PeerTable:
+    """Device-side addressing for the fused multi-peer schedule.
+
+    Every peer's staging-buffer and signal-pad base pointer as an int64 device
+    tensor, indexed by peer id (cast int->ptr) inside the kernel, so a fused
+    multi-peer schedule picks the peer on device via ``program_id`` instead of
+    pre-slicing per-peer state on the host. The per-peer staging region for
+    sender ``s`` inside a rank's buffer is at ``s * (per_peer_bytes // elem)``,
+    and signal-pad slots for sender ``s`` start at ``s * max_blocks_per_peer``.
+    """
+
+    buffer_ptrs: torch.Tensor  # int64[world_size]: peer -> staging-buffer base
+    signal_pad_ptrs: torch.Tensor  # int64[world_size]: peer -> signal-pad base
+
+
+@dataclass
+class NvlTransport:
+    """Symmetric-memory NVLink transport (real, minimal).
+
+    Owns the ``_SymmetricMemory`` handle. The buffer is ``per_peer_bytes`` per
+    peer (``per_peer_bytes * world_size`` total); the signal pad holds two int64
+    regions of ``world_size * max_blocks_per_peer`` entries each (tail then head),
+    laid out by ``[sender_rank * max_blocks_per_peer + block]``. Tail = sender
+    "data ready" (polled by the receiver); head = receiver "slot free" credit
+    (polled by the sender before overwriting reusable staging).
+    """
+
+    handle: _SymmetricMemory
+    world_size: int
+    # Rank within the NVLink rendezvous group (``dist.get_rank(group)``), i.e. the
+    # index used to address this rank's slot in the symmetric-memory buffer. This is
+    # NOT the node-local rank (``LOCAL_RANK`` env / ``get_node_local_rank``): on an
+    # NVL fabric the rendezvous group may span trays, so it is a group-relative rank.
+    local_rank: int
+    per_peer_bytes: int
+    max_blocks_per_peer: int = _DEFAULT_MAX_BLOCKS_PER_PEER
+    _endpoints_device_cache: PeerTable | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+    _step_state_cache: tuple[torch.Tensor, torch.Tensor] | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+    _last_a2a_launch_metadata: dict[str, Any] | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+
+    def _record_a2a_launch_metadata(self, metadata: dict[str, Any]) -> None:
+        self._last_a2a_launch_metadata = dict(metadata)
+
+    def _get_a2a_launch_metadata(self) -> dict[str, Any]:
+        if self._last_a2a_launch_metadata is None:
+            raise RuntimeError("transport has no resolved a2a launch metadata")
+        return dict(self._last_a2a_launch_metadata)
+
+    def endpoints_device(self) -> PeerTable:
+        """All peers' buffer + signal-pad base pointers as a device :class:`PeerTable`.
+
+        Index by peer on device (cast int->ptr) instead of pre-slicing per-peer
+        state on the host. Symm-mem base addresses are fixed after rendezvous, so
+        build once and cache: repeated fused-schedule calls and CUDA-graph capture
+        must not re-allocate / re-copy.
+        """
+        if self._endpoints_device_cache is None:
+            # Device is the transport's own symm-mem device, not the caller's
+            # current device.
+            dev = self.handle.get_buffer(
+                self.local_rank, sizes=[1], dtype=torch.uint8
+            ).device
+            self._endpoints_device_cache = PeerTable(
+                buffer_ptrs=torch.tensor(
+                    self.handle.buffer_ptrs, dtype=torch.int64, device=dev
+                ),
+                signal_pad_ptrs=torch.tensor(
+                    self.handle.signal_pad_ptrs, dtype=torch.int64, device=dev
+                ),
+            )
+        return self._endpoints_device_cache
+
+    def step_state(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """Persistent monotonic step counters for graph-safe signalling.
+
+        Returns ``(sender_step, recver_step)``, each an int64 device tensor of
+        ``world_size * max_blocks_per_peer`` entries indexed by
+        ``peer * max_blocks_per_peer + block``. Each slot has exactly one writer
+        (the local send leg writes ``sender_step``; the local recv leg writes
+        ``recver_step``), so no atomics are needed.
+
+        The schedule signals an absolute, monotonically increasing sequence
+        number per call and the kernel advances these counters itself, so a
+        reused transport / CUDA-graph replay never reads a stale signal slot.
+        Allocated once and cached (zero-initialized; the signal pad is zeroed at
+        rendezvous, so the first wait for sequence 1 is race-free).
+        """
+        if self._step_state_cache is None:
+            dev = self.handle.get_buffer(
+                self.local_rank, sizes=[1], dtype=torch.uint8
+            ).device
+            n = self.world_size * self.max_blocks_per_peer
+            self._step_state_cache = (
+                torch.zeros(n, dtype=torch.int64, device=dev),
+                torch.zeros(n, dtype=torch.int64, device=dev),
+            )
+        return self._step_state_cache
+
+
+def _require_signal_pad(
+    sig_numel: int, world_size: int, max_blocks_per_peer: int
+) -> None:
+    """Raise if the symm-mem signal pad cannot hold the tail+head regions.
+
+    The pad needs two int64 regions of ``world_size * max_blocks_per_peer`` entries
+    each (tail then head). Extracted so the invariant is unit-testable host-only.
+    """
+    need = 2 * world_size * max_blocks_per_peer
+    if sig_numel < need:
+        raise RuntimeError(
+            f"signal pad too small: {sig_numel} int64 < required {need} "
+            f"(2 x world_size={world_size} x max_blocks_per_peer={max_blocks_per_peer})"
+        )
+
+
+def nvl_rendezvous(
+    group: dist.ProcessGroup,
+    device: torch.device,
+    per_peer_bytes: int,
+    max_blocks_per_peer: int = _DEFAULT_MAX_BLOCKS_PER_PEER,
+) -> NvlTransport:
+    """One collective rendezvous; returns a user-owned :class:`NvlTransport`.
+
+    Allocates ``per_peer_bytes * world_size`` of symmetric memory (one per-peer
+    staging region per peer). Zeroes the signal pad so the first wait for sequence 1
+    is race-free after the barrier.
+    """
+    world_size = dist.get_world_size(group)
+    local_rank = dist.get_rank(group)
+    total = per_peer_bytes * world_size
+    logger.info(
+        "nvl_rendezvous on PG %s: allocating %d bytes (%d peers x %d)",
+        group.group_desc,
+        total,
+        world_size,
+        per_peer_bytes,
+    )
+    _rdv_dbg(group, f"symm_mem.empty({total}B) start")
+    raw = symm_mem.empty(total, dtype=torch.uint8, device=device)
+    _rdv_dbg(group, "symm_mem.empty done; symm_mem.rendezvous start")
+    handle = symm_mem.rendezvous(raw, group=group)
+    _rdv_dbg(group, "symm_mem.rendezvous done")
+
+    # The transport addresses every symm-mem slot by local_rank (= group rank), so the
+    # handle's own rank convention must agree, else this rank would zero / index a peer's
+    # region. Enforce it (raise, not assert -- survives -O) rather than assume equality.
+    if handle.rank != local_rank:
+        raise RuntimeError(
+            f"symm-mem handle rank {handle.rank} != group rank {local_rank}"
+        )
+
+    # Signal pad holds two int64 regions per (sender, block) slot:
+    #   tail [0 .. ws*MBP): sender publishes "data ready" (polled by receiver)
+    #   head [ws*MBP .. 2*ws*MBP): receiver publishes "slot free" before reuse.
+    sig = handle.get_signal_pad(local_rank).view(torch.int64)
+    _require_signal_pad(sig.numel(), world_size, max_blocks_per_peer)
+    sig.zero_()
+    _rdv_dbg(group, "sig.zero_ done; barrier start")
+    dist.barrier(group)
+    _rdv_dbg(group, "barrier done")
+    transport = NvlTransport(
+        handle=handle,
+        world_size=world_size,
+        local_rank=local_rank,
+        per_peer_bytes=per_peer_bytes,
+        max_blocks_per_peer=max_blocks_per_peer,
+    )
+    # Eagerly materialize the device-side caches (peer table + step counters) now,
+    # so the first collective can be issued inside a CUDA-graph capture without the
+    # lazy allocation happening during capture.
+    transport.endpoints_device()
+    _rdv_dbg(group, "endpoints_device done")
+    transport.step_state()
+    _rdv_dbg(group, "step_state done")
+    return transport
+
+
+def check_transfer(
+    transport: NvlTransport,
+    numel: int,
+    dtype: torch.dtype,
+    num_blocks: int,
+) -> None:
+    """Validate a transfer against the transport before launch (fail loud).
+
+    Three invariants whose violation would otherwise cause **silent remote
+    corruption** (a kernel writing past a per-peer region overruns the next
+    peer's staging or signal-pad region on the remote rank):
+
+    * ``per_peer_bytes`` must be a whole multiple of the dtype itemsize, so the
+      per-peer region holds whole elements.
+    * ``numel`` must fit the per-peer staging region (``per_peer_bytes``).
+    * ``num_blocks`` must fit the per-peer signal-pad slots
+      (``max_blocks_per_peer``), since each block signals slot ``block_id``.
+
+    ``numel`` is the **per-peer** element count (the elements that must fit one peer's
+    staging region), not the whole-tensor total. ``numel == 0`` (empty transfer) is
+    allowed; it corrupts nothing.
+    """
+    elem = dtype.itemsize
+    # A per-peer region that is not a whole number of elements would otherwise pass here
+    # and later silently mis-slice the symm-mem buffer.
+    if transport.per_peer_bytes % elem != 0:
+        raise ValueError(
+            f"per_peer_bytes={transport.per_peer_bytes} not a multiple of dtype itemsize "
+            f"{elem} ({dtype}); the per-peer region cannot hold whole elements"
+        )
+    cap_elems = transport.per_peer_bytes // elem
+    if numel > cap_elems:
+        raise ValueError(
+            f"transfer numel={numel} exceeds per-peer capacity={cap_elems} elems "
+            f"(per_peer_bytes={transport.per_peer_bytes}, dtype={dtype}); "
+            f"increase per_peer_bytes at rendezvous"
+        )
+    mbp = transport.max_blocks_per_peer
+    if not (1 <= num_blocks <= mbp):
+        raise ValueError(
+            f"num_blocks={num_blocks} must be in [1, {mbp}] "
+            f"(one signal-pad slot per block per peer)"
+        )

--- a/comms/dsl/tuning_base.py
+++ b/comms/dsl/tuning_base.py
@@ -1,0 +1,101 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""DSL-agnostic tuning base: the shared tunable Config + reused-transport geometry guard.
+
+Owns the runtime pieces shared by tunable collectives: the base config dataclass,
+geometry signatures, and the reused-transport geometry guard.
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+def geometry_signature(
+    config: Any,
+    fields: frozenset[str],
+    resolved: tuple[tuple[str, Any], ...] = (),
+) -> tuple:
+    """Geometry-defining field values: two configs with the same signature can reuse one
+    transport back-to-back; a different signature on a reused transport is the documented
+    hazard the runtime geometry guard catches. ``fields`` is the per-collective set of
+    knobs that change the physical staging geometry. ``resolved`` carries runtime-derived
+    geometry such as the effective vector width or shape."""
+    return tuple(getattr(config, f) for f in sorted(fields)) + tuple(
+        value for _, value in resolved
+    )
+
+
+def check_geometry(
+    transport: Any,
+    config: Any,
+    fields: frozenset[str],
+    label: str = "all_to_all",
+    *,
+    resolved: tuple[tuple[str, Any], ...] = (),
+) -> None:
+    """Guard against an unsafe staging-geometry switch on a reused transport.
+
+    ``label`` names the collective in the error message (this helper is DSL/collective-
+    agnostic; later collectives pass their own name).
+
+    The kernel's persistent step counters + shared staging buffer make back-to-back
+    launches safe only when the geometry-defining ``fields`` are unchanged (see
+    ``geometry_signature``). Switching geometry on the same transport without a drain
+    reinterprets in-flight bytes; the framework has no runtime drain, so this guard
+    surfaces the hazard.
+
+    A geometry switch on a reused transport is a hard error by default: there is no
+    runtime drain, so reinterpreting in-flight bytes silently corrupts staging data and a
+    warn-and-proceed default would let that corruption through unnoticed.
+    ``COMMS_DSL_ALLOW_GEOMETRY_SWITCH=1`` downgrades it to a silent advance for callers
+    whose successive launches are device-sync-separated (a benchmark / tuner sweeping
+    configs at one size) -- they know no bytes are in flight across the switch. The
+    transport is a non-frozen dataclass, so we stash the last accepted geometry on it
+    directly (private attr).
+    """
+    sig = geometry_signature(config, fields, resolved)
+    prev = getattr(transport, "_last_geometry_signature", None)
+    # The cache advances only on an accepted switch: reseeding the baseline before the
+    # raise would let the next (still hazardous) switch slip through unflagged.
+    if prev is None or prev == sig:
+        transport._last_geometry_signature = sig
+        return
+    # Forgiving parse of the documented escape hatch: accept 1/true/yes (case-insensitive,
+    # whitespace-trimmed); warn (not silently ignore) on a present-but-unrecognized value.
+    _allow = os.environ.get("COMMS_DSL_ALLOW_GEOMETRY_SWITCH", "").strip().lower()
+    if _allow in ("1", "true", "yes"):
+        transport._last_geometry_signature = sig
+        return
+    if _allow not in ("", "0", "false", "no"):
+        warnings.warn(
+            f"COMMS_DSL_ALLOW_GEOMETRY_SWITCH={_allow!r} unrecognized; treating as unset "
+            "(use 1/true/yes to enable).",
+            stacklevel=2,
+        )
+    names = sorted(fields) + [name for name, _ in resolved]
+    raise ValueError(
+        f"{label}: staging geometry changed on a reused transport "
+        f"({dict(zip(names, prev))} -> {dict(zip(names, sig))}). There is no runtime drain "
+        "yet, so back-to-back calls of differing geometry on one transport (without an "
+        "intervening device sync) would corrupt in-flight staging data. Use a fresh "
+        "transport per geometry/shape, or set COMMS_DSL_ALLOW_GEOMETRY_SWITCH=1 if your "
+        "calls are sync-separated."
+    )
+
+
+@dataclass(frozen=True)
+class BaseTunableConfig:
+    """Base tunable config shared across backends. Subclasses add core fields."""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "BaseTunableConfig":
+        return cls(**data)  # type: ignore[arg-type]


### PR DESCRIPTION
Summary:
Adds the maintained Nsight Compute entry for the current a2a benchmark:

- ncu_common resolves the NCU binary, constructs a single-pass command, and creates the
  narrow CUDA driver shim required by the MAST image.
- benchmark_a2a_cute can re-exec once under NCU and profile all worker processes.
- mast_launch can select the NCU-capable image and forward the minimal profiling options.

The default metrics are single-pass launch metrics so the distributed signal-spinning
kernel is not replayed by the profiler. This diff does not contain algorithm-specific
profiles, experiment matrices, result validation, or evidence tooling.

Differential Revision: D112202388
