### PR TITLE
Log window/AGP IPC exchange latency breakdown to nccl_structured_logging (#3195)

### DIFF
--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -194,6 +194,26 @@ commResult_t createPersistentRequest(
       scopedRegisterUs,
       ipcExchangeUs);
 
+  // AgpCreate/IpcExchange is the createPersistentRequest-side wall time of the
+  // IPC exchange phase: for graph (waitForInit) it is the real blocking
+  // exchange, but for eager it is only the async submitHost latency -- the
+  // actual exchange runs later on the GPE thread and is captured by the
+  // AgpCreate/IpcExchange/Intra* child rows.
+  NcclScubaEvent(
+      std::make_unique<CommEvent>(
+          &comm->logMetaData_,
+          "AgpCreate/Reg",
+          std::string(),
+          scopedRegisterUs / 1000.0))
+      .record();
+  NcclScubaEvent(
+      std::make_unique<CommEvent>(
+          &comm->logMetaData_,
+          "AgpCreate/IpcExchange",
+          std::string(),
+          ipcExchangeUs / 1000.0))
+      .record();
+
   reqGuard.dismiss();
   *out = request.release();
 

--- a/comms/ctran/algos/AllGatherP/CommUtils.h
+++ b/comms/ctran/algos/AllGatherP/CommUtils.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <iostream>
+#include <memory>
 #include <vector>
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGatherP/Types.h"
@@ -12,6 +13,7 @@
 #include "comms/ctran/regcache/RegCache.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/ctran/utils/ExtUtils.h"
+#include "comms/utils/logger/ScubaLogger.h"
 
 namespace ctran::allgatherp {
 inline void* getPtr(void* base, size_t offset) {
@@ -58,6 +60,21 @@ inline commResult_t exchangeIpcReg(CtranComm* comm, PersistArgs& pArgs) {
       ctrlUs,
       barrierUs,
       statex->nLocalRanks());
+
+  NcclScubaEvent(
+      std::make_unique<CommEvent>(
+          &comm->logMetaData_,
+          "AgpCreate/IpcExchange/IntraAllGatherCtrl",
+          std::string(),
+          ctrlUs / 1000.0))
+      .record();
+  NcclScubaEvent(
+      std::make_unique<CommEvent>(
+          &comm->logMetaData_,
+          "AgpCreate/IpcExchange/IntraBarrier",
+          std::string(),
+          barrierUs / 1000.0))
+      .record();
 
   const int myRank = statex->rank();
   const int nLocalRanks = statex->nLocalRanks();

--- a/comms/ctran/tests/CtranDistAllgatherPTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherPTests.cc
@@ -13,6 +13,9 @@
 #endif
 
 #include <nccl.h>
+#include <filesystem>
+#include <set>
+#include <sstream>
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/algos/AllGatherP/AlgoImpl.h"
 #include "comms/ctran/profiler/Profiler.h"
@@ -22,6 +25,16 @@
 #include "comms/ctran/utils/MathUtils.h"
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
+
+#include <folly/Singleton.h>
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+#include <folly/testing/TestUtil.h>
+
+#include "comms/utils/StrUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/Logger.h"
+#include "comms/utils/logger/tests/MockScubaTable.h"
 // Test sources uses ncclMemAlloc API from nccl.h/rccl.h, so adding this check
 // macro here so to avoid including TestUtils.h which doesn't support
 // cross-platform
@@ -37,6 +50,21 @@
       exit(EXIT_FAILURE);                    \
     }                                        \
   } while (0)
+
+namespace {
+// The nccl_structured_logging pipe filename embeds an unpredictable timestamp
+// suffix, so locate this rank's file by its stable name prefix.
+std::string findStructuredLoggingFile(const std::string& dir) {
+  const std::string namePrefix =
+      "dedicated_log_structured_json.perfpipe_nccl_structured_logging";
+  for (const auto& entry : std::filesystem::directory_iterator(dir)) {
+    if (entry.path().filename().string().rfind(namePrefix, 0) == 0) {
+      return entry.path().string();
+    }
+  }
+  return "";
+}
+} // namespace
 
 class CtranAllgatherPTestEnv : public ctran::CtranEnvironmentBase {
  public:
@@ -615,6 +643,89 @@ TEST_F(CtranAllgatherPTest, InternalRegisteredMemory) {
 
   ASSERT_EQ(ctran::allGatherPDestroy(request), commSuccess);
   delete request;
+}
+
+// Verifies createPersistentRequest (AllGatherP.cc) and exchangeIpcReg
+// (CommUtils.h) record the AgpCreate IPC-exchange latency rows to the
+// nccl_structured_logging scuba table with the expected stage names and
+// comm-identity fields when NCCL_COMM_EVENT_LOGGING is enabled.
+TEST_F(CtranAllgatherPTest, StructuredLoggingRecordsAgpCreateFields) {
+  // Stop the logger started during comm creation, then route the CommEvents
+  // emitted by the AGP create path to a per-rank pipe file we read back below.
+  NcclLogger::close();
+
+  folly::test::TemporaryDirectory tmpDir;
+  // Both cvars are read from the C++ globals at record time; the cudaMalloc
+  // path below never triggers a ncclCvarInit, so EnvRAII (not SysEnvRAII) is
+  // required for the values to reach the logger.
+  EnvRAII fileEnv(NCCL_SCUBA_LOG_FILE_PREFIX, tmpDir.path().string());
+  EnvRAII eventEnv(
+      NCCL_COMM_EVENT_LOGGING, std::string("pipe:nccl_structured_logging"));
+
+  // make_mock is the only way to force the DataTableAllTables singleton to be
+  // rebuilt after the per-test cvars are set (comm creation may have baked in
+  // an empty prefix). callParent=true makes the mock delegate to the real
+  // DataTable so records are written to the pipe file.
+  folly::Singleton<const DataTableAllTables, DataTableAllTablesTag>::make_mock(
+      []() { return new DataTableAllTables(createAllMockTables(true)); });
+  folly::Singleton<const DataTableAllTables, DataTableAllTablesTag>::try_get();
+
+  // Re-init the logger so a fresh nccl_structured_logging DataTableWrapper
+  // resolves against the mock singleton on the first recorded event.
+  NcclLogger::init();
+
+  EnvRAII algoEnv(NCCL_ALLGATHER_P_ALGO, NCCL_ALLGATHER_P_ALGO::ctdirect);
+
+  // cudaMalloc (not ncclMemAlloc) keeps the logging cvars intact by avoiding
+  // ncclMemAlloc's ncclCvarInit.
+  run(1024, 1024, kTestOutOfPlace, kMemCudaMalloc, ctranComm.get());
+
+  // Flush the background logging thread and close the pipe file before reading.
+  NcclLogger::close();
+
+  const std::string logFile = findStructuredLoggingFile(tmpDir.path().string());
+  ASSERT_FALSE(logFile.empty()) << "no nccl_structured_logging pipe file under "
+                                << tmpDir.path().string();
+  const auto output = readFromFile(logFile);
+  ASSERT_NE(output, "");
+
+  std::set<std::string> stages;
+  std::string regCommDesc;
+  int64_t regCommHash = 0;
+  bool sawReg = false;
+  std::istringstream iss(output);
+  std::string line;
+  while (std::getline(iss, line)) {
+    if (line.empty()) {
+      continue;
+    }
+    const auto jsonLog = folly::parseJson(line);
+    const auto stage = jsonLog["normal"]["stage"].asString();
+    stages.insert(stage);
+    if (stage == "AgpCreate/Reg" && !sawReg) {
+      sawReg = true;
+      regCommDesc = jsonLog["normal"]["commDesc"].asString();
+      regCommHash = jsonLog["int"]["commHash"].asInt();
+      EXPECT_GE(jsonLog["double"]["timerDeltaMs"].asDouble(), 0.0);
+    }
+  }
+
+  const std::vector<std::string> expectedStages = {
+      "AgpCreate/Reg",
+      "AgpCreate/IpcExchange",
+      "AgpCreate/IpcExchange/IntraAllGatherCtrl",
+      "AgpCreate/IpcExchange/IntraBarrier"};
+  for (const auto& expected : expectedStages) {
+    EXPECT_TRUE(stages.count(expected) > 0)
+        << "missing AgpCreate stage: " << expected;
+  }
+
+  // The AgpCreate/Reg row must carry the owning comm's identity.
+  ASSERT_TRUE(sawReg);
+  EXPECT_FALSE(regCommDesc.empty());
+  EXPECT_EQ(regCommDesc, ctranComm->logMetaData_.commDesc);
+  EXPECT_EQ(
+      regCommHash, static_cast<int64_t>(ctranComm->logMetaData_.commHash));
 }
 
 TEST_F(CtranAllgatherPTest, SharePersistentBuffer) {

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -22,6 +22,7 @@
 #include "comms/prims/window/HostWindow.h"
 #endif
 #include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/ScubaLogger.h"
 
 using ctran::window::RemWinInfo;
 
@@ -176,6 +177,7 @@ CtranWin::CtranWin(CtranComm* comm, size_t size, DevMemType bufType)
 }
 
 commResult_t CtranWin::exchange() {
+  CtranMapperTimer exchangeTotalTimer;
   auto statex = comm->statex_.get();
   const auto nRanks = statex->nRanks();
   const auto myRank = statex->rank();
@@ -196,6 +198,13 @@ commResult_t CtranWin::exchange() {
   FB_COMMCHECK(getWindowMapper(comm, &mapper));
   CtranMapperEpochRAII epochRAII(mapper);
 
+  const auto recordWinStage = [&](const std::string& stage, double us) {
+    NcclScubaEvent(
+        std::make_unique<CommEvent>(
+            &comm->logMetaData_, stage, std::string(), us / 1000.0))
+        .record();
+  };
+
   // The base buffer holds the signal buffer (register path) or the combined
   // data+signal buffer (allocate path). On the register path with signals
   // disabled there is no base buffer, so its registration and control exchange
@@ -204,6 +213,7 @@ commResult_t CtranWin::exchange() {
 
   // Registration via ctran mapper.
   if (exchangeBaseBuffer) {
+    CtranMapperTimer baseRegTimer;
     FB_COMMCHECK(mapper->regMem(
         winBasePtr,
         range_,
@@ -211,6 +221,7 @@ commResult_t CtranWin::exchange() {
         true,
         true, /* NCCL managed buffer */
         &baseRegHdl));
+    recordWinStage("WinExchange/BaseReg", baseRegTimer.durationUs());
   }
 
   if (allocDataBuf_) {
@@ -225,6 +236,7 @@ commResult_t CtranWin::exchange() {
     // RegElem* for the allGatherCtrl handle exchange.
     auto regCache = ctran::RegCache::getInstance();
     ctran::CHECK_VALID_REGCACHE(regCache);
+    CtranMapperTimer userRegTimer;
     FB_COMMCHECK(regCache->acquireScopedRegister(
         winDataPtr,
         dataBytes,
@@ -233,15 +245,26 @@ commResult_t CtranWin::exchange() {
         comm->logMetaData_,
         dataScopedReg));
     dataRegHdl = dataScopedReg.get();
+    recordWinStage("WinExchange/UserReg", userRegTimer.durationUs());
   }
 
-  // Exchange each rank's data buffer size via bootstrap allGather
-  // This populates remWinInfo[r].dataBytes for all ranks
+  // Populate each rank's data buffer size. A symmetric window guarantees every
+  // rank registered the same size, so fill locally and skip the bootstrap
+  // allGather round-trip; otherwise gather each rank's size.
+  // FIXME(ctwin): confirm whether this size allGather is needed at all for the
+  // non-symmetric path (added in D87390033).
   std::vector<size_t> allRankSizes(nRanks);
-  allRankSizes[myRank] = dataBytes;
-  auto resFuture = comm->bootstrap_->allGather(
-      allRankSizes.data(), sizeof(size_t), myRank, nRanks);
-  FB_COMMCHECK(static_cast<commResult_t>(std::move(resFuture).get()));
+  if (isSymmetric()) {
+    allRankSizes.assign(nRanks, dataBytes);
+  } else {
+    CtranMapperTimer sizeAllGatherTimer;
+    allRankSizes[myRank] = dataBytes;
+    auto resFuture = comm->bootstrap_->allGather(
+        allRankSizes.data(), sizeof(size_t), myRank, nRanks);
+    FB_COMMCHECK(static_cast<commResult_t>(std::move(resFuture).get()));
+    recordWinStage(
+        "WinExchange/SizeAllGather", sizeAllGatherTimer.durationUs());
+  }
 
   // Handshake with other peers for registration exchange and network
   // connection setup
@@ -294,22 +317,26 @@ commResult_t CtranWin::exchange() {
   };
 
   if (exchangeBaseBuffer) {
+    CtranMapperTimer baseExchangeTimer;
     FB_COMMCHECK(exchangeBuffer(
         winBasePtr,
         baseRegHdl,
         remoteBaseBufs,
         remoteBaseBufAccessKeys,
         /*outIpcHdls=*/nullptr));
+    recordWinStage("WinExchange/BaseExchange", baseExchangeTimer.durationUs());
   }
 
   if (!allocDataBuf_) {
     // User-provided data buffer needs its own handle exchange round.
+    CtranMapperTimer userExchangeTimer;
     FB_COMMCHECK(exchangeBuffer(
         winDataPtr,
         dataRegHdl,
         remoteUserBufs,
         remoteUserBufAccessKeys,
         &dataScopedIpcRegHdls));
+    recordWinStage("WinExchange/UserExchange", userExchangeTimer.durationUs());
   }
 
   for (auto r = 0; r < nRanks; r++) {
@@ -358,7 +385,9 @@ commResult_t CtranWin::exchange() {
 
   // A barrier among ranks after importing handles to prevent accessing window
   // memory space while other ranks are still importing.
+  CtranMapperTimer barrierTimer;
   FB_COMMCHECK(windowBarrier(comm, mapper));
+  recordWinStage("WinExchange/Barrier", barrierTimer.durationUs());
 
   // Cache only symmetric windows: ctwin collective algos needs all ranks
   // locally compute peerAddr = peerBase + offset, meaning same offset from base
@@ -367,6 +396,7 @@ commResult_t CtranWin::exchange() {
     FB_COMMCHECK(
         comm->winCache_.insert(winDataPtr, dataBytes, this, &winCacheHdl));
   }
+  recordWinStage("WinExchange", exchangeTotalTimer.durationUs());
   return commSuccess;
 }
 


### PR DESCRIPTION
Summary:

Instrument the ctwin window setup and the persistent AllGatherP (AGP) IPC-exchange init paths with per-phase latency rows emitted to the `nccl_structured_logging` Scuba table, and skip a redundant size allGather for symmetric windows:
- window (`CtranWin::exchange`): emit a hierarchical `WinExchange` breakdown -- `WinExchange` (total wall time), `WinExchange/BaseReg`, `WinExchange/UserReg`, `WinExchange/BaseExchange`, `WinExchange/UserExchange`, `WinExchange/Barrier`, and (non-symmetric only) `WinExchange/SizeAllGather`.
- AGP (`createPersistentRequest` and `exchangeIpcReg`, shared by eager and graph): emit `AgpCreate/Reg` (scoped registration), `AgpCreate/IpcExchange`, and the GPE-thread child rows `AgpCreate/IpcExchange/IntraAllGatherCtrl` and `AgpCreate/IpcExchange/IntraBarrier`.
- All rows reuse the already-measured `CtranMapperTimer` values and are emitted via `NcclScubaEvent(std::make_unique<CommEvent>(&comm->logMetaData_, stage, "", deltaMs)).record()` (microseconds converted to milliseconds), attributed to the owning comm through `comm->logMetaData_` and routed to `nccl_structured_logging` by the `CommEvent` type. Only the IPC (NVL) path is logged; the deferred first-exec inter-node IB rkey exchange is not.
- Interpretation note (also documented in code): `AgpCreate/IpcExchange` is the createPersistentRequest-side wall time of the IPC exchange phase -- for graph (waitForInit) it is the real blocking exchange, but for eager it is only the async submitHost latency; the real eager exchange is captured by the `AgpCreate/IpcExchange/Intra*` child rows measured on the GPE thread.
- Optimization: a symmetric window (`win_register_symmetric`) guarantees every rank registered the same size, so the per-rank size bootstrap allGather in `CtranWin::exchange` is redundant; fill `allRankSizes` locally and skip the round-trip. The non-symmetric path keeps the allGather and times it as `WinExchange/SizeAllGather`. A `FIXME(ctwin)` marks the open question of whether that allGather is needed at all (added in D87390033).
- Add `StructuredLoggingRecordsAgpCreateFields` (CtranDistAllgatherPTests.cc): a pipe-mode test that sets `NCCL_COMM_EVENT_LOGGING=pipe:nccl_structured_logging` with a per-rank `NCCL_SCUBA_LOG_FILE_PREFIX` temp dir, runs a persistent AllGatherP, then reads back the written pipe file and asserts the four `AgpCreate/*` rows are recorded to `nccl_structured_logging` with the owning comm's `commDesc`/`commHash` and a non-negative `timerDeltaMs`. This exercises the real Scuba write path end-to-end (the `make_mock` singleton is retained only to rebuild `DataTableAllTables` against the per-test cvars and delegates to the real `DataTable` pipe writer).

Reviewed By: dsjohns2

Differential Revision: D112863254


