### PR TITLE
Record training iteration on all nccl_structured_logging (CommEvent) records

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
@@ -170,6 +170,7 @@ commResult_t ctranAllGatherCudagraphAware(
           recvBytes,
           comm->statex_->cudaDev(),
           comm->ctran_->mapper->getBackends(),
+          comm->logMetaData_,
           localRecvReg));
 
       // Heap-own the scoped ref so a graph-destroy callback can release it.

--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -194,6 +194,26 @@ commResult_t createPersistentRequest(
       scopedRegisterUs,
       ipcExchangeUs);
 
+  // AgpCreate/IpcExchange is the createPersistentRequest-side wall time of the
+  // IPC exchange phase: for graph (waitForInit) it is the real blocking
+  // exchange, but for eager it is only the async submitHost latency -- the
+  // actual exchange runs later on the GPE thread and is captured by the
+  // AgpCreate/IpcExchange/Intra* child rows.
+  NcclScubaEvent(
+      std::make_unique<CommEvent>(
+          &comm->logMetaData_,
+          "AgpCreate/Reg",
+          std::string(),
+          scopedRegisterUs / 1000.0))
+      .record();
+  NcclScubaEvent(
+      std::make_unique<CommEvent>(
+          &comm->logMetaData_,
+          "AgpCreate/IpcExchange",
+          std::string(),
+          ipcExchangeUs / 1000.0))
+      .record();
+
   reqGuard.dismiss();
   *out = request.release();
 

--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -112,6 +112,7 @@ commResult_t createPersistentRequest(
       recvBytes,
       comm->statex_->cudaDev(),
       comm->ctran_->mapper->getBackends(),
+      comm->logMetaData_,
       localRecvReg));
   const double scopedRegisterUs = scopedRegisterTimer.durationUs();
 

--- a/comms/ctran/algos/AllGatherP/CommUtils.h
+++ b/comms/ctran/algos/AllGatherP/CommUtils.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <iostream>
+#include <memory>
 #include <vector>
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGatherP/Types.h"
@@ -12,6 +13,7 @@
 #include "comms/ctran/regcache/RegCache.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/ctran/utils/ExtUtils.h"
+#include "comms/utils/logger/ScubaLogger.h"
 
 namespace ctran::allgatherp {
 inline void* getPtr(void* base, size_t offset) {
@@ -58,6 +60,21 @@ inline commResult_t exchangeIpcReg(CtranComm* comm, PersistArgs& pArgs) {
       ctrlUs,
       barrierUs,
       statex->nLocalRanks());
+
+  NcclScubaEvent(
+      std::make_unique<CommEvent>(
+          &comm->logMetaData_,
+          "AgpCreate/IpcExchange/IntraAllGatherCtrl",
+          std::string(),
+          ctrlUs / 1000.0))
+      .record();
+  NcclScubaEvent(
+      std::make_unique<CommEvent>(
+          &comm->logMetaData_,
+          "AgpCreate/IpcExchange/IntraBarrier",
+          std::string(),
+          barrierUs / 1000.0))
+      .record();
 
   const int myRank = statex->rank();
   const int nLocalRanks = statex->nLocalRanks();

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -172,7 +172,7 @@ extern __global__ void ncclKernelAllGatherPPipeEnd(
     ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     PipeEndKernArgs args);
-extern __global__ void ncclKernelAllGatherPPipe(
+extern __global__ void ncclKernelAllGatherPRing(
     ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState);
 
@@ -263,22 +263,22 @@ commResult_t AlgoImpl::execPipeline(
 
     if (nLocalRanks > 1) {
       // - For nLocalRanks > 1 case, use ncclKernelAllGatherPPipeStart to hold
-      //   GPE thread till allgather starts. ncclKernelAllGatherPStart returns
-      //   immediately after started GPE, thus the inter-node pipeline can be
-      //   overlapped with the following intra-node copies.
+      //   GPE thread till allgather starts. ncclKernelAllGatherPPipeStart
+      //   returns immediately after started GPE, thus the inter-node pipeline
+      //   can be overlapped with the following intra-node copies.
       FB_COMMCHECK(ctran->gpe->submit(
           std::move(opGroup),
           gpeFn,
           config,
           reinterpret_cast<void*>(ncclKernelAllGatherPPipeStart)));
     } else {
-      // - For nLocalRanks == 1 case, ncclKernelAllGatherPPipe holds the stream
+      // - For nLocalRanks == 1 case, ncclKernelAllGatherPRing holds the stream
       //   till GPE thread finishes entire transfer.
       FB_COMMCHECK(ctran->gpe->submit(
           std::move(opGroup),
           gpeFn,
           config,
-          reinterpret_cast<void*>(ncclKernelAllGatherPPipe)));
+          reinterpret_cast<void*>(ncclKernelAllGatherPRing)));
     }
   }
 

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cu
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cu
@@ -39,9 +39,23 @@ __global__ void ncclKernelAllGatherPPipeSync(
   GpeKernelSyncDev::waitPost(args.pipeSync, 0, args.stepId);
 }
 
-// Stub kernel to hold stream while GPE thread does inter-node transfer.
-// Used when nLocalRanks == 1 in allgatherP pipeline algorithm
-__global__ void ncclKernelAllGatherPPipe(
+// Stream-holder stub for the ctpipeline (ring) variant at nLocalRanks==1: holds
+// the stream while the GPE thread runs the inter-node ring transfer.
+// Ring = ctpipeline nLocalRanks==1.
+__global__ void ncclKernelAllGatherPRing(
+    ctran::gpe::KernelFlagDev* f,
+    CtranAlgoDeviceState* devState) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  if (flag) {
+    ctran::device::devLoadAbortFlags(flag, devState);
+    ctran::device::KernelStartGpe(f);
+    ctran::device::KernelWaitGpeTerminate(flag);
+  }
+}
+
+// Stream-holder stub for the ctsrdpipeline (streamed recursive-doubling)
+// variant at nLocalRanks==1. StreamedRd = ctsrdpipeline nLocalRanks==1.
+__global__ void ncclKernelAllGatherPStreamedRd(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
@@ -56,6 +70,42 @@ __global__ void ncclKernelAllGatherPPipe(
 // broadcast. Used when nLocalRanks > 1 in allgatherP pipeline algorithm. It is
 // called once at the end.
 __global__ void ncclKernelAllGatherPPipeEnd(
+    ctran::gpe::KernelFlagDev* flag,
+    CtranAlgoDeviceState* devState,
+    PipeEndKernArgs args) {
+  // Reset sync flag for next GPE->kernel pipeline sync to use
+  GpeKernelSyncDev::reset(args.pipeSync, 0);
+
+  // Ensure nvl intra-node comm finishes
+  devStateLoadToShm(devState);
+  const auto localRank = statex->localRank();
+  const auto nLocalRanks = statex->nLocalRanks();
+  barrier(localRank, nLocalRanks);
+}
+
+// The ctsrdpipeline (streamed recursive-doubling) variant's nLocalRanks > 1
+// pipeline kernels. Bodies are identical to the ctpipeline PPipe* kernels
+// above; they exist as separate symbols so each variant owns its own kernels.
+__global__ void ncclKernelAllGatherPSrdPipeStart(
+    ctran::gpe::KernelFlagDev* f,
+    CtranAlgoDeviceState* devState) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  if (flag) {
+    ctran::device::KernelStartGpeAndExit(f);
+  }
+}
+
+__global__ void ncclKernelAllGatherPSrdPipeSync(
+    ctran::gpe::KernelFlagDev* f,
+    CtranAlgoDeviceState* devState,
+    PipeSyncKernArgs args) {
+  int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  ctran::device::devLoadAbortFlags(flag, devState);
+  // wait till GPE thread post the current stepId
+  GpeKernelSyncDev::waitPost(args.pipeSync, 0, args.stepId);
+}
+
+__global__ void ncclKernelAllGatherPSrdPipeEnd(
     ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     PipeEndKernArgs args) {

--- a/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
@@ -166,18 +166,18 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
 } // namespace
 
 namespace ctran::allgatherp {
-extern __global__ void ncclKernelAllGatherPPipeStart(
+extern __global__ void ncclKernelAllGatherPSrdPipeStart(
     ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState);
-extern __global__ void ncclKernelAllGatherPPipeSync(
+extern __global__ void ncclKernelAllGatherPSrdPipeSync(
     ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     PipeSyncKernArgs args);
-extern __global__ void ncclKernelAllGatherPPipeEnd(
+extern __global__ void ncclKernelAllGatherPSrdPipeEnd(
     ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     PipeEndKernArgs args);
-extern __global__ void ncclKernelAllGatherPPipe(
+extern __global__ void ncclKernelAllGatherPStreamedRd(
     ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState);
 
@@ -271,13 +271,13 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
           std::move(opGroup),
           gpeFn,
           config,
-          reinterpret_cast<void*>(ncclKernelAllGatherPPipeStart)));
+          reinterpret_cast<void*>(ncclKernelAllGatherPSrdPipeStart)));
     } else {
       FB_COMMCHECK(ctran->gpe->submit(
           std::move(opGroup),
           gpeFn,
           config,
-          reinterpret_cast<void*>(ncclKernelAllGatherPPipe)));
+          reinterpret_cast<void*>(ncclKernelAllGatherPStreamedRd)));
     }
   }
 
@@ -301,7 +301,7 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
           {},
           nullptr,
           config,
-          reinterpret_cast<void*>(ncclKernelAllGatherPPipeSync)));
+          reinterpret_cast<void*>(ncclKernelAllGatherPSrdPipeSync)));
 
       int chunkIndex = 0;
       for (const auto node : recvPlan.chunks(step)) {
@@ -328,7 +328,7 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
         {},
         nullptr,
         config,
-        reinterpret_cast<void*>(ncclKernelAllGatherPPipeEnd)));
+        reinterpret_cast<void*>(ncclKernelAllGatherPSrdPipeEnd)));
   }
 
   return commSuccess;

--- a/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
@@ -382,6 +382,7 @@ commResult_t createPersistentRequest(
       recvBytes,
       comm->statex_->cudaDev(),
       comm->ctran_->mapper->getBackends(),
+      comm->logMetaData_,
       localRecvReg));
 
   auto algo = std::make_unique<AlgoImpl>(comm, stream);

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -1340,6 +1340,7 @@ commResult_t ctran::RegCache::acquireScopedRegister(
     size_t len,
     int cudaDev,
     const std::vector<bool>& backends,
+    const CommLogData& logMetaData,
     ctran::ScopedRegHdl& scopedRegHdl) {
   if (buf == nullptr || len == 0) {
     CLOGF(ERR, "acquireScopedRegister: invalid buf {} len {}", (void*)buf, len);
@@ -1350,14 +1351,12 @@ commResult_t ctran::RegCache::acquireScopedRegister(
   // allocator; regRangeCachedImpl returns nullptr otherwise.
   bool didRegister = false;
   ctran::regcache::RegElem* regHdl = nullptr;
-  CommLogData scopedLogData{};
-  scopedLogData.commDesc = "scopedRegister";
   const auto regResult = regRangeCachedImpl(
       buf,
       len,
       cudaDev,
       "scopedRegister",
-      scopedLogData,
+      logMetaData,
       backends,
       didRegister,
       &regHdl,

--- a/comms/ctran/regcache/RegCache.h
+++ b/comms/ctran/regcache/RegCache.h
@@ -366,11 +366,15 @@ class RegCache {
   // returned ScopedRegHdl owns that use, releasing it SW-only in its
   // destructor. If the buffer is not backed by a cached segment,
   // commInvalidUsage is returned and the ScopedRegHdl stays empty.
+  // The caller passes the owning comm's log metadata (real commHash/commDesc)
+  // so memory-logging attribution reflects the real comm rather than a
+  // placeholder.
   commResult_t acquireScopedRegister(
       const void* buf,
       size_t len,
       int cudaDev,
       const std::vector<bool>& backends,
+      const CommLogData& logMetaData,
       ScopedRegHdl& scopedRegHdl);
 
   // Thread-safe functions to cache a buffer range into the global cache.

--- a/comms/ctran/regcache/tests/RegCacheUT.cc
+++ b/comms/ctran/regcache/tests/RegCacheUT.cc
@@ -1752,7 +1752,7 @@ TEST_F(RegCacheTest, ScopedRegisterSingleAcquireRelease) {
     ctran::ScopedRegHdl scopedRegHdl;
     EXPECT_EQ(
         regCache->acquireScopedRegister(
-            buf, bufSize, cudaDev, backends, scopedRegHdl),
+            buf, bufSize, cudaDev, backends, CommLogData{}, scopedRegHdl),
         commSuccess);
     EXPECT_TRUE(static_cast<bool>(scopedRegHdl));
     EXPECT_NE(scopedRegHdl.get(), nullptr);
@@ -1787,7 +1787,8 @@ TEST_F(RegCacheTest, ScopedRegisterNestedAcquire) {
 
   auto outer = std::make_unique<ctran::ScopedRegHdl>();
   EXPECT_EQ(
-      regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, *outer),
+      regCache->acquireScopedRegister(
+          buf, bufSize, cudaDev, backends, CommLogData{}, *outer),
       commSuccess);
   auto* regElem = outer->get();
   ASSERT_NE(regElem, nullptr);
@@ -1797,7 +1798,8 @@ TEST_F(RegCacheTest, ScopedRegisterNestedAcquire) {
   {
     ctran::ScopedRegHdl inner;
     EXPECT_EQ(
-        regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, inner),
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, CommLogData{}, inner),
         commSuccess);
     // Both handles refer to the same reused registration; inUseCnt 1 + 1 = 2.
     EXPECT_EQ(inner.get(), regElem);
@@ -1838,7 +1840,7 @@ TEST_F(RegCacheTest, ScopedRegisterSequentialAcquire) {
       ctran::ScopedRegHdl scopedRegHdl;
       EXPECT_EQ(
           regCache->acquireScopedRegister(
-              buf, bufSize, cudaDev, backends, scopedRegHdl),
+              buf, bufSize, cudaDev, backends, CommLogData{}, scopedRegHdl),
           commSuccess);
       auto* regElem = scopedRegHdl.get();
       ASSERT_NE(regElem, nullptr);
@@ -1873,7 +1875,7 @@ TEST_F(RegCacheTest, ScopedRegisterPreservesGlobalRegistration) {
     ctran::ScopedRegHdl scopedRegHdl;
     EXPECT_EQ(
         regCache->acquireScopedRegister(
-            buf, bufSize, cudaDev, backends, scopedRegHdl),
+            buf, bufSize, cudaDev, backends, CommLogData{}, scopedRegHdl),
         commSuccess);
     EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
   }
@@ -1903,7 +1905,7 @@ TEST_F(RegCacheTest, ScopedRegisterUncachedSegmentReturnsError) {
   ctran::ScopedRegHdl scopedRegHdl;
   EXPECT_EQ(
       regCache->acquireScopedRegister(
-          buf, bufSize, cudaDev, backends, scopedRegHdl),
+          buf, bufSize, cudaDev, backends, CommLogData{}, scopedRegHdl),
       commInvalidUsage);
 
   // The handle must stay empty since nothing was acquired.
@@ -1931,7 +1933,7 @@ TEST_F(RegCacheTest, GlobalDeregisterWhileScopedAliveReportsError) {
     ctran::ScopedRegHdl scopedRegHdl;
     EXPECT_EQ(
         regCache->acquireScopedRegister(
-            buf, bufSize, cudaDev, backends, scopedRegHdl),
+            buf, bufSize, cudaDev, backends, CommLogData{}, scopedRegHdl),
         commSuccess);
     EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
 
@@ -1975,7 +1977,7 @@ TEST_F(RegCacheTest, FreeSegmentWhileScopedAliveReturnsError) {
     ctran::ScopedRegHdl scopedRegHdl;
     EXPECT_EQ(
         regCache->acquireScopedRegister(
-            buf, bufSize, cudaDev, backends, scopedRegHdl),
+            buf, bufSize, cudaDev, backends, CommLogData{}, scopedRegHdl),
         commSuccess);
     auto* regElem = scopedRegHdl.get();
     ASSERT_NE(regElem, nullptr);
@@ -2070,7 +2072,7 @@ TEST_F(RegCacheTest, ScopedRegisterFirstAcquireCreatesRegElem) {
     // Scoped acquire is the first to register: it creates the RegElem.
     EXPECT_EQ(
         regCache->acquireScopedRegister(
-            buf, bufSize, cudaDev, backends, scopedRegHdl),
+            buf, bufSize, cudaDev, backends, CommLogData{}, scopedRegHdl),
         commSuccess);
     auto* regElem = scopedRegHdl.get();
     ASSERT_NE(regElem, nullptr);
@@ -2104,7 +2106,8 @@ TEST_F(RegCacheTest, ScopedRegisterMoveSemantics) {
 
   ctran::ScopedRegHdl a;
   EXPECT_EQ(
-      regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, a),
+      regCache->acquireScopedRegister(
+          buf, bufSize, cudaDev, backends, CommLogData{}, a),
       commSuccess);
   auto* regElem = a.get();
   ASSERT_NE(regElem, nullptr);
@@ -2126,7 +2129,8 @@ TEST_F(RegCacheTest, ScopedRegisterMoveSemantics) {
   // Acquire a second independent use into c (inUseCnt 1 -> 2).
   ctran::ScopedRegHdl c;
   EXPECT_EQ(
-      regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, c),
+      regCache->acquireScopedRegister(
+          buf, bufSize, cudaDev, backends, CommLogData{}, c),
       commSuccess);
   EXPECT_EQ(regElem->inUseCnt.load(), 2);
 

--- a/comms/ctran/tests/CtranDistAllgatherPTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherPTests.cc
@@ -13,6 +13,9 @@
 #endif
 
 #include <nccl.h>
+#include <filesystem>
+#include <set>
+#include <sstream>
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/algos/AllGatherP/AlgoImpl.h"
 #include "comms/ctran/profiler/Profiler.h"
@@ -22,6 +25,16 @@
 #include "comms/ctran/utils/MathUtils.h"
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
+
+#include <folly/Singleton.h>
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+#include <folly/testing/TestUtil.h>
+
+#include "comms/utils/StrUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/Logger.h"
+#include "comms/utils/logger/tests/MockScubaTable.h"
 // Test sources uses ncclMemAlloc API from nccl.h/rccl.h, so adding this check
 // macro here so to avoid including TestUtils.h which doesn't support
 // cross-platform
@@ -37,6 +50,21 @@
       exit(EXIT_FAILURE);                    \
     }                                        \
   } while (0)
+
+namespace {
+// The nccl_structured_logging pipe filename embeds an unpredictable timestamp
+// suffix, so locate this rank's file by its stable name prefix.
+std::string findStructuredLoggingFile(const std::string& dir) {
+  const std::string namePrefix =
+      "dedicated_log_structured_json.perfpipe_nccl_structured_logging";
+  for (const auto& entry : std::filesystem::directory_iterator(dir)) {
+    if (entry.path().filename().string().rfind(namePrefix, 0) == 0) {
+      return entry.path().string();
+    }
+  }
+  return "";
+}
+} // namespace
 
 class CtranAllgatherPTestEnv : public ctran::CtranEnvironmentBase {
  public:
@@ -615,6 +643,89 @@ TEST_F(CtranAllgatherPTest, InternalRegisteredMemory) {
 
   ASSERT_EQ(ctran::allGatherPDestroy(request), commSuccess);
   delete request;
+}
+
+// Verifies createPersistentRequest (AllGatherP.cc) and exchangeIpcReg
+// (CommUtils.h) record the AgpCreate IPC-exchange latency rows to the
+// nccl_structured_logging scuba table with the expected stage names and
+// comm-identity fields when NCCL_COMM_EVENT_LOGGING is enabled.
+TEST_F(CtranAllgatherPTest, StructuredLoggingRecordsAgpCreateFields) {
+  // Stop the logger started during comm creation, then route the CommEvents
+  // emitted by the AGP create path to a per-rank pipe file we read back below.
+  NcclLogger::close();
+
+  folly::test::TemporaryDirectory tmpDir;
+  // Both cvars are read from the C++ globals at record time; the cudaMalloc
+  // path below never triggers a ncclCvarInit, so EnvRAII (not SysEnvRAII) is
+  // required for the values to reach the logger.
+  EnvRAII fileEnv(NCCL_SCUBA_LOG_FILE_PREFIX, tmpDir.path().string());
+  EnvRAII eventEnv(
+      NCCL_COMM_EVENT_LOGGING, std::string("pipe:nccl_structured_logging"));
+
+  // make_mock is the only way to force the DataTableAllTables singleton to be
+  // rebuilt after the per-test cvars are set (comm creation may have baked in
+  // an empty prefix). callParent=true makes the mock delegate to the real
+  // DataTable so records are written to the pipe file.
+  folly::Singleton<const DataTableAllTables, DataTableAllTablesTag>::make_mock(
+      []() { return new DataTableAllTables(createAllMockTables(true)); });
+  folly::Singleton<const DataTableAllTables, DataTableAllTablesTag>::try_get();
+
+  // Re-init the logger so a fresh nccl_structured_logging DataTableWrapper
+  // resolves against the mock singleton on the first recorded event.
+  NcclLogger::init();
+
+  EnvRAII algoEnv(NCCL_ALLGATHER_P_ALGO, NCCL_ALLGATHER_P_ALGO::ctdirect);
+
+  // cudaMalloc (not ncclMemAlloc) keeps the logging cvars intact by avoiding
+  // ncclMemAlloc's ncclCvarInit.
+  run(1024, 1024, kTestOutOfPlace, kMemCudaMalloc, ctranComm.get());
+
+  // Flush the background logging thread and close the pipe file before reading.
+  NcclLogger::close();
+
+  const std::string logFile = findStructuredLoggingFile(tmpDir.path().string());
+  ASSERT_FALSE(logFile.empty()) << "no nccl_structured_logging pipe file under "
+                                << tmpDir.path().string();
+  const auto output = readFromFile(logFile);
+  ASSERT_NE(output, "");
+
+  std::set<std::string> stages;
+  std::string regCommDesc;
+  int64_t regCommHash = 0;
+  bool sawReg = false;
+  std::istringstream iss(output);
+  std::string line;
+  while (std::getline(iss, line)) {
+    if (line.empty()) {
+      continue;
+    }
+    const auto jsonLog = folly::parseJson(line);
+    const auto stage = jsonLog["normal"]["stage"].asString();
+    stages.insert(stage);
+    if (stage == "AgpCreate/Reg" && !sawReg) {
+      sawReg = true;
+      regCommDesc = jsonLog["normal"]["commDesc"].asString();
+      regCommHash = jsonLog["int"]["commHash"].asInt();
+      EXPECT_GE(jsonLog["double"]["timerDeltaMs"].asDouble(), 0.0);
+    }
+  }
+
+  const std::vector<std::string> expectedStages = {
+      "AgpCreate/Reg",
+      "AgpCreate/IpcExchange",
+      "AgpCreate/IpcExchange/IntraAllGatherCtrl",
+      "AgpCreate/IpcExchange/IntraBarrier"};
+  for (const auto& expected : expectedStages) {
+    EXPECT_TRUE(stages.count(expected) > 0)
+        << "missing AgpCreate stage: " << expected;
+  }
+
+  // The AgpCreate/Reg row must carry the owning comm's identity.
+  ASSERT_TRUE(sawReg);
+  EXPECT_FALSE(regCommDesc.empty());
+  EXPECT_EQ(regCommDesc, ctranComm->logMetaData_.commDesc);
+  EXPECT_EQ(
+      regCommHash, static_cast<int64_t>(ctranComm->logMetaData_.commHash));
 }
 
 TEST_F(CtranAllgatherPTest, SharePersistentBuffer) {

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -22,6 +22,7 @@
 #include "comms/prims/window/HostWindow.h"
 #endif
 #include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/ScubaLogger.h"
 
 using ctran::window::RemWinInfo;
 
@@ -176,6 +177,7 @@ CtranWin::CtranWin(CtranComm* comm, size_t size, DevMemType bufType)
 }
 
 commResult_t CtranWin::exchange() {
+  CtranMapperTimer exchangeTotalTimer;
   auto statex = comm->statex_.get();
   const auto nRanks = statex->nRanks();
   const auto myRank = statex->rank();
@@ -196,6 +198,13 @@ commResult_t CtranWin::exchange() {
   FB_COMMCHECK(getWindowMapper(comm, &mapper));
   CtranMapperEpochRAII epochRAII(mapper);
 
+  const auto recordWinStage = [&](const std::string& stage, double us) {
+    NcclScubaEvent(
+        std::make_unique<CommEvent>(
+            &comm->logMetaData_, stage, std::string(), us / 1000.0))
+        .record();
+  };
+
   // The base buffer holds the signal buffer (register path) or the combined
   // data+signal buffer (allocate path). On the register path with signals
   // disabled there is no base buffer, so its registration and control exchange
@@ -204,6 +213,7 @@ commResult_t CtranWin::exchange() {
 
   // Registration via ctran mapper.
   if (exchangeBaseBuffer) {
+    CtranMapperTimer baseRegTimer;
     FB_COMMCHECK(mapper->regMem(
         winBasePtr,
         range_,
@@ -211,6 +221,7 @@ commResult_t CtranWin::exchange() {
         true,
         true, /* NCCL managed buffer */
         &baseRegHdl));
+    recordWinStage("WinExchange/BaseReg", baseRegTimer.durationUs());
   }
 
   if (allocDataBuf_) {
@@ -225,6 +236,7 @@ commResult_t CtranWin::exchange() {
     // RegElem* for the allGatherCtrl handle exchange.
     auto regCache = ctran::RegCache::getInstance();
     ctran::CHECK_VALID_REGCACHE(regCache);
+    CtranMapperTimer userRegTimer;
     FB_COMMCHECK(regCache->acquireScopedRegister(
         winDataPtr,
         dataBytes,
@@ -233,15 +245,26 @@ commResult_t CtranWin::exchange() {
         comm->logMetaData_,
         dataScopedReg));
     dataRegHdl = dataScopedReg.get();
+    recordWinStage("WinExchange/UserReg", userRegTimer.durationUs());
   }
 
-  // Exchange each rank's data buffer size via bootstrap allGather
-  // This populates remWinInfo[r].dataBytes for all ranks
+  // Populate each rank's data buffer size. A symmetric window guarantees every
+  // rank registered the same size, so fill locally and skip the bootstrap
+  // allGather round-trip; otherwise gather each rank's size.
+  // FIXME(ctwin): confirm whether this size allGather is needed at all for the
+  // non-symmetric path (added in D87390033).
   std::vector<size_t> allRankSizes(nRanks);
-  allRankSizes[myRank] = dataBytes;
-  auto resFuture = comm->bootstrap_->allGather(
-      allRankSizes.data(), sizeof(size_t), myRank, nRanks);
-  FB_COMMCHECK(static_cast<commResult_t>(std::move(resFuture).get()));
+  if (isSymmetric()) {
+    allRankSizes.assign(nRanks, dataBytes);
+  } else {
+    CtranMapperTimer sizeAllGatherTimer;
+    allRankSizes[myRank] = dataBytes;
+    auto resFuture = comm->bootstrap_->allGather(
+        allRankSizes.data(), sizeof(size_t), myRank, nRanks);
+    FB_COMMCHECK(static_cast<commResult_t>(std::move(resFuture).get()));
+    recordWinStage(
+        "WinExchange/SizeAllGather", sizeAllGatherTimer.durationUs());
+  }
 
   // Handshake with other peers for registration exchange and network
   // connection setup
@@ -294,22 +317,26 @@ commResult_t CtranWin::exchange() {
   };
 
   if (exchangeBaseBuffer) {
+    CtranMapperTimer baseExchangeTimer;
     FB_COMMCHECK(exchangeBuffer(
         winBasePtr,
         baseRegHdl,
         remoteBaseBufs,
         remoteBaseBufAccessKeys,
         /*outIpcHdls=*/nullptr));
+    recordWinStage("WinExchange/BaseExchange", baseExchangeTimer.durationUs());
   }
 
   if (!allocDataBuf_) {
     // User-provided data buffer needs its own handle exchange round.
+    CtranMapperTimer userExchangeTimer;
     FB_COMMCHECK(exchangeBuffer(
         winDataPtr,
         dataRegHdl,
         remoteUserBufs,
         remoteUserBufAccessKeys,
         &dataScopedIpcRegHdls));
+    recordWinStage("WinExchange/UserExchange", userExchangeTimer.durationUs());
   }
 
   for (auto r = 0; r < nRanks; r++) {
@@ -358,7 +385,9 @@ commResult_t CtranWin::exchange() {
 
   // A barrier among ranks after importing handles to prevent accessing window
   // memory space while other ranks are still importing.
+  CtranMapperTimer barrierTimer;
   FB_COMMCHECK(windowBarrier(comm, mapper));
+  recordWinStage("WinExchange/Barrier", barrierTimer.durationUs());
 
   // Cache only symmetric windows: ctwin collective algos needs all ranks
   // locally compute peerAddr = peerBase + offset, meaning same offset from base
@@ -367,6 +396,7 @@ commResult_t CtranWin::exchange() {
     FB_COMMCHECK(
         comm->winCache_.insert(winDataPtr, dataBytes, this, &winCacheHdl));
   }
+  recordWinStage("WinExchange", exchangeTotalTimer.durationUs());
   return commSuccess;
 }
 

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -230,6 +230,7 @@ commResult_t CtranWin::exchange() {
         dataBytes,
         comm->statex_->cudaDev(),
         mapper->getBackends(),
+        comm->logMetaData_,
         dataScopedReg));
     dataRegHdl = dataScopedReg.get();
   }

--- a/comms/ncclx/meta/logger/tests/LoggerUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggerUT.cc
@@ -23,6 +23,7 @@
 #include "comms/utils/logger/EventMgr.h"
 #include "comms/utils/logger/Logger.h"
 #include "comms/utils/logger/tests/MockScubaTable.h"
+#include "comms/utils/trainer/TrainerContext.h"
 
 static constexpr std::string_view kHpcJobName = "jobUnitTest";
 static constexpr std::string_view kHpcJobVersion = "13";
@@ -239,6 +240,37 @@ TEST_F(NcclLoggerTest, CommEventScuba) {
 
   EXPECT_TRUE(getWriteCount(LoggerEventType::CommEventType) == 4);
   CommEventReadJson(getMessages(LoggerEventType::CommEventType));
+}
+
+TEST_F(NcclLoggerTest, CommEventIteration) {
+  folly::test::TemporaryDirectory tmpDir;
+  auto scubaLogDirGuard =
+      EnvRAII(NCCL_SCUBA_LOG_FILE_PREFIX, tmpDir.path().string());
+  auto eventGuard = EnvRAII(
+      NCCL_COMM_EVENT_LOGGING, std::string("pipe:nccl_structured_logging"));
+
+  // iteration is captured at CommEvent construction time from
+  // ncclxGetIteration(), so set the trainer step before emitting the event.
+  constexpr int64_t kIteration = 42;
+  ncclxSetIteration(kIteration);
+
+  initLogging();
+  NcclScubaEvent event(
+      std::make_unique<CommEvent>(
+          &kcommLogMetadata, keventStage[0], keventStage[0]));
+  event.record();
+  finishLogging();
+
+  // Reset the global step before asserting so a failed assertion cannot leak
+  // state into other tests.
+  ncclxSetIteration(-1);
+
+  const auto output = getMessages(LoggerEventType::CommEventType);
+  std::istringstream iss(output);
+  std::string line;
+  ASSERT_TRUE(std::getline(iss, line));
+  const auto jsonLog = folly::parseJson(line);
+  EXPECT_EQ(jsonLog["int"]["iteration"].asInt(), kIteration);
 }
 
 TEST_F(NcclLoggerTest, WarnLogTest) {

--- a/comms/ncclx/meta/tests/AllGatherCtwinTest.cc
+++ b/comms/ncclx/meta/tests/AllGatherCtwinTest.cc
@@ -1,0 +1,182 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <folly/ScopeGuard.h>
+#include <folly/init/Init.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <nccl.h>
+#include <cstddef>
+#include <vector>
+
+#include "comm.h"
+#include "comms/ctran/Ctran.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/ncclx/meta/tests/VerifyAlgoStatsUtil.h"
+#include "comms/testinfra/TestUtils.h"
+#include "comms/testinfra/TestsCuUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/algoconf/AlgoStrConv.h"
+
+// Verifies ctwin's automatic fallback behavior at the top-level ncclAllGather
+// entry point. In comms/ncclx/v2_30/src/collectives.cc, ncclAllGather runs
+// CTRAN's window-based AllGatherP path only when recvbuff lives inside a
+// registered symmetric window; otherwise it falls back to the baseline
+// algorithm. AlgoStats (recorded for both paths under the same per-comm map)
+// is used to prove which algorithm actually ran.
+class AllGatherCtwinTest : public NcclxBaseTestFixture {
+ public:
+  AllGatherCtwinTest() = default;
+
+  void SetUp() override {
+    NcclxEnvs envs = {
+        {"NCCL_CTRAN_ENABLE", "1"},
+        {"NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET", "1"},
+    };
+    NcclxBaseTestFixture::SetUp(envs);
+    algoStats_.enable();
+
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+    CUDACHECK_TEST(cudaStreamCreate(&stream));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaStreamDestroy(stream));
+    NcclxBaseTestFixture::TearDown();
+  }
+
+ protected:
+  ncclComm_t comm{};
+  cudaStream_t stream{};
+  ncclx::test::VerifyAlgoStatsHelper algoStats_;
+};
+
+// With allgatherAlgo=ctwin but a plain recvbuf (no window registered), ctwin
+// is not supported for this recvbuff, so ncclAllGather falls back to the
+// baseline algorithm. Verify correctness AND (via AlgoStats) that the
+// baseline path ran, not the CTRAN window path.
+TEST_F(AllGatherCtwinTest, AllGatherCtwinFallbackWhenNoWindow) {
+  constexpr size_t count = 1024;
+
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints(
+      {{"allgatherAlgo",
+        ncclx::algoconf::algoValToStr(NCCL_ALLGATHER_ALGO::ctwin)}});
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+  this->comm = commRaii.get();
+  ASSERT_NE(this->comm, nullptr);
+
+  std::vector<TestMemSegment> sendBufSegs, recvBufSegs;
+  int* recvBuf = reinterpret_cast<int*>(testAllocBuf(
+      count * numRanks * sizeof(int), kMemCudaMalloc, recvBufSegs));
+  ASSERT_NE(recvBuf, nullptr);
+  int* sendBuf = reinterpret_cast<int*>(
+      testAllocBuf(count * sizeof(int), kMemCudaMalloc, sendBufSegs));
+  ASSERT_NE(sendBuf, nullptr);
+
+  assignChunkValue(recvBuf, count * numRanks, -1);
+  assignChunkValue(sendBuf, count, globalRank + 1);
+
+  ASSERT_EQ(
+      ncclAllGather(sendBuf, recvBuf, count, ncclInt, comm, stream),
+      ncclSuccess);
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  for (int r = 0; r < numRanks; r++) {
+    int expectedVal = r + 1;
+    int errs = checkChunkValue(recvBuf + r * count, count, expectedVal);
+    EXPECT_EQ(errs, 0) << "rank " << globalRank << " checked chunk " << r
+                       << " at " << recvBuf + r * count << " with " << errs
+                       << " errors";
+  }
+
+  // ctwin has no window to run against here, so dispatch must fall back to
+  // the baseline algorithm rather than the CTRAN window path.
+  algoStats_.verify(comm, "AllGather", "Baseline");
+  algoStats_.verifyNot(comm, "AllGather", "CtranAllGatherP");
+
+  testFreeBuf(sendBuf, count * sizeof(int), kMemCudaMalloc);
+  testFreeBuf(recvBuf, count * numRanks * sizeof(int), kMemCudaMalloc);
+}
+
+// With allgatherAlgo=ctwin and recvbuff living inside a registered symmetric
+// window, ctwin's CTRAN AllGatherP path is selected. Verify correctness AND
+// (via AlgoStats) that the CtranAllGatherP path ran.
+TEST_F(AllGatherCtwinTest, AllGatherCtwinUsedWhenWindowRegistered) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skip test";
+  }
+
+  constexpr size_t count = 1024;
+  const size_t totalBytes = count * numRanks * sizeof(int);
+
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints(
+      {{"allgatherAlgo",
+        ncclx::algoconf::algoValToStr(NCCL_ALLGATHER_ALGO::ctwin)},
+       {"win_register_symmetric", "1"},
+       {"win_register_ipc_only", "1"}});
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+  this->comm = commRaii.get();
+  ASSERT_NE(this->comm, nullptr);
+
+  if (comm->ctranComm_->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+
+  std::vector<TestMemSegment> winSegs;
+  void* winBase = testAllocBuf(totalBytes, kMemNcclMemAlloc, winSegs);
+  ASSERT_NE(winBase, nullptr);
+  // Mimic the CCA allocator hook so the window's acquireScopedRegister finds
+  // the buffer's segment cached.
+  NCCLCHECK_TEST(ncclGlobalRegisterWithPtr(winBase, totalBytes));
+  auto regGuard = folly::makeGuard([&]() {
+    NCCLCHECK_TEST(ncclGlobalDeregisterWithPtr(winBase, totalBytes));
+  });
+
+  ncclWindow_t win = nullptr;
+  ASSERT_EQ(
+      ncclCommWindowRegister(
+          comm, winBase, totalBytes, &win, NCCL_WIN_COLL_SYMMETRIC),
+      ncclSuccess);
+  ASSERT_NE(win, nullptr);
+  regGuard.dismiss();
+
+  // In-place layout required by ctwin: this rank's send chunk lives at its
+  // own offset within the recvbuf/window.
+  int* recvBuf = reinterpret_cast<int*>(winBase);
+  int* sendBuf = recvBuf + count * globalRank;
+
+  assignChunkValue(recvBuf, count * numRanks, -1);
+  assignChunkValue(sendBuf, count, globalRank + 1);
+
+  ASSERT_EQ(
+      ncclAllGather(sendBuf, recvBuf, count, ncclInt, comm, stream),
+      ncclSuccess);
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  for (int r = 0; r < numRanks; r++) {
+    int expectedVal = r + 1;
+    int errs = checkChunkValue(recvBuf + r * count, count, expectedVal);
+    EXPECT_EQ(errs, 0) << "rank " << globalRank << " checked chunk " << r
+                       << " at " << recvBuf + r * count << " with " << errs
+                       << " errors";
+  }
+
+  algoStats_.verify(comm, "AllGather", "CtranAllGatherP");
+
+  EXPECT_EQ(ncclCommWindowDeregister(comm, win), ncclSuccess);
+  NCCLCHECK_TEST(ncclGlobalDeregisterWithPtr(winBase, totalBytes));
+  testFreeBuf(winBase, totalBytes, kMemNcclMemAlloc);
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/tests/MemoryTraceDistTest.cc
+++ b/comms/ncclx/meta/tests/MemoryTraceDistTest.cc
@@ -236,9 +236,36 @@ class MemoryTraceTestFixture : public NcclxBaseTestFixture,
                        << this->globalRank;
   }
 
+  void verifyScopedRegisterEvent(
+      const std::string& output,
+      uint64_t expectedCommHash,
+      const std::string& expectedCommDesc,
+      int expectedRank) {
+    bool found = false;
+    std::istringstream iss(output);
+    std::string line;
+    while (std::getline(iss, line)) {
+      folly::dynamic jsonLog = folly::parseJson(line);
+      if (jsonLog["normal"]["use"].asString() != "scopedRegister") {
+        continue;
+      }
+      found = true;
+      // Attribution must reflect the owning comm, not the old placeholder
+      // (commDesc "scopedRegister" / commHash sentinel 0xfaceb00c12345678).
+      EXPECT_EQ(
+          jsonLog["int"]["commHash"].asInt(),
+          static_cast<int64_t>(expectedCommHash));
+      EXPECT_EQ(jsonLog["normal"]["commDesc"].asString(), expectedCommDesc);
+      EXPECT_EQ(jsonLog["int"]["rank"].asInt(), expectedRank);
+    }
+    EXPECT_TRUE(found) << "no scopedRegister memory event logged on globalRank "
+                       << this->globalRank << std::endl;
+  }
+
  protected:
   void runNcclInternalBufferLogTest();
   void runUserBufferLoggingTest();
+  void runScopedRegisterLoggingTest();
 
   cudaStream_t stream;
   void* sendBuf{nullptr};
@@ -261,6 +288,10 @@ TEST_P(MemoryTraceTestFixture, ncclInternalBufferLogTest) {
 
 TEST_P(MemoryTraceTestFixture, userBufferLoggingTest) {
   runUserBufferLoggingTest();
+}
+
+TEST_P(MemoryTraceTestFixture, scopedRegisterLoggingTest) {
+  runScopedRegisterLoggingTest();
 }
 
 TEST_P(MemoryTraceNolocalTestFixture, ncclInternalBufferLogTest) {
@@ -446,6 +477,51 @@ void MemoryTraceTestFixture::runUserBufferLoggingTest() {
     // Expect other ranks to have no events logged
     EXPECT_EQ(output, "");
   }
+
+  NCCLCHECK_TEST(ncclCommDestroy(comm));
+}
+
+void MemoryTraceTestFixture::runScopedRegisterLoggingTest() {
+  folly::test::TemporaryDirectory tmpDir;
+  auto scubaLogDirGuard =
+      EnvRAII(NCCL_SCUBA_LOG_FILE_PREFIX, tmpDir.path().string());
+  // scopedRegister is a registration event; empty filter logs on all ranks.
+  auto memoryRegEventFilterGuard =
+      EnvRAII(NCCL_FILTER_MEM_REG_LOGGING_BY_RANKS, {});
+  auto logFileName = initLogger();
+
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  if (noLocal_) {
+    hints.set("noLocal", "1");
+  }
+  config.hints = &hints;
+  comm = ncclx::test::createNcclComm(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+
+  // Cache the buffer's segment (CCA-hook simulation) so the window's scoped
+  // register is the first real registration of the range and emits a record.
+  void* buf = nullptr;
+  constexpr size_t kBufferSize = 1024 * 1024;
+  NCCLCHECK_TEST(ncclMemAlloc(&buf, kBufferSize));
+  NCCLCHECK_TEST(ncclGlobalRegisterWithPtr(buf, kBufferSize));
+
+  // Register the user buffer as a window; this drives CtranWin::exchange()
+  // through acquireScopedRegister with the owning comm's logMetaData_.
+  ncclWindow_t win = nullptr;
+  NCCLCHECK_TEST(
+      ncclCommWindowRegister(comm, buf, kBufferSize, &win, NCCL_WIN_DEFAULT));
+  NCCLCHECK_TEST(ncclCommWindowDeregister(comm, win));
+  NCCLCHECK_TEST(ncclGlobalDeregisterWithPtr(buf, kBufferSize));
+  NCCLCHECK_TEST(ncclMemFree(buf));
+
+  // wait until memory logging completes
+  NcclLogger::close();
+  auto output = readFromFile(logFileName);
+  EXPECT_NE(output, "");
+
+  verifyScopedRegisterEvent(
+      output, comm->commHash, comm->logMetaData.commDesc, comm->rank);
 
   NCCLCHECK_TEST(ncclCommDestroy(comm));
 }

--- a/comms/ncclx/v2_29/src/collectives.cc
+++ b/comms/ncclx/v2_29/src/collectives.cc
@@ -102,7 +102,8 @@ ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcoun
 
   auto algo = NCCLX_CONFIG_FIELD(comm->config, allgatherAlgo);
 
-  if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo, stream)) {
+  if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo, stream,
+                                                  recvbuff, sendcount * comm->nRanks * ncclTypeSize(datatype))) {
     return metaCommToNccl(ctranAllGather(
         sendbuff, recvbuff, sendcount, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, algo));
   }

--- a/comms/ncclx/v2_30/src/collectives.cc
+++ b/comms/ncclx/v2_30/src/collectives.cc
@@ -102,7 +102,8 @@ ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcoun
 
   auto algo = NCCLX_CONFIG_FIELD(comm->config, allgatherAlgo);
 
-  if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo, stream)) {
+  if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo, stream,
+                                                  recvbuff, sendcount * comm->nRanks * ncclTypeSize(datatype))) {
     return metaCommToNccl(ctranAllGather(
         sendbuff, recvbuff, sendcount, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, algo));
   }

--- a/comms/utils/logger/EventMgr.cc
+++ b/comms/utils/logger/EventMgr.cc
@@ -24,6 +24,7 @@ NcclScubaSample CommEvent::toSample() {
   sample.addDouble("timerDeltaMs", timerDeltaMs);
   sample.addNormal("timestamp", timestamp);
 
+  sample.addInt("iteration", iteration);
   return sample;
 }
 
@@ -109,7 +110,6 @@ NcclScubaSample CtranProfilerAlgoEvent::toSample() {
   auto sample = CtranProfilerEvent::toSample();
   sample.addNormal("type", "CtranProfilerAlgoEvent");
   sample.addNormal("direction", direction);
-  sample.addInt("iteration", iteration);
   sample.addInt("opCount", opCount);
   sample.addInt("readyTs", readyTs);
   sample.addInt("controlTs", controlTs);
@@ -133,7 +133,6 @@ NcclScubaSample CtranProfilerGpeEvent::toSample() {
   sample.addInt("durationUs", durationUs_);
   sample.addInt("aborted", aborted_ ? 1 : 0);
   sample.addNormal("message", message_);
-  sample.addInt("iteration", iteration_);
   return sample;
 }
 

--- a/comms/utils/logger/EventMgr.h
+++ b/comms/utils/logger/EventMgr.h
@@ -60,7 +60,9 @@ class CommEvent : public LoggerEvent {
         nRanks(logMetaData ? logMetaData->nRanks : 0),
         stage(stage),
         split(split),
-        timerDeltaMs(delta) {}
+        timerDeltaMs(delta) {
+    iteration = ncclxGetIteration();
+  }
 
   CommEvent(
       const CommLogData* logMetaData,
@@ -74,7 +76,9 @@ class CommEvent : public LoggerEvent {
         nRanks(logMetaData ? logMetaData->nRanks : 0),
         localRank(localRank),
         localRanks(localRanks),
-        stage(stage) {}
+        stage(stage) {
+    iteration = ncclxGetIteration();
+  }
 
   ~CommEvent() override = default;
 
@@ -113,6 +117,9 @@ class CommEvent : public LoggerEvent {
   const std::string split;
   double timerDeltaMs = 0.0;
   std::string timestamp;
+  // training step. If not set by trainer, it is always -1. Also see
+  // ncclxGetIteration().
+  int64_t iteration = -1;
 };
 
 class MemoryEvent : public LoggerEvent {
@@ -319,9 +326,7 @@ class CtranProfilerAlgoEvent : public CtranProfilerEvent {
         readyTs(readyTs),
         controlTs(controlTs),
         timeFromDataToCollEndUs(timeFromDataToCollEndUs),
-        collectiveDurationUs(collectiveDurationUs) {
-    iteration = ncclxGetIteration();
-  }
+        collectiveDurationUs(collectiveDurationUs) {}
 
   ~CtranProfilerAlgoEvent() override = default;
 
@@ -338,9 +343,6 @@ class CtranProfilerAlgoEvent : public CtranProfilerEvent {
   uint64_t bufferRegistrationTimeUs;
   uint64_t controlSyncTimeUs;
   uint64_t dataTransferTimeUs;
-  // training step. If not set by trainer, it is always -1. Also see
-  // ncclxGetIteration().
-  int64_t iteration = -1;
   uint64_t opCount;
   uint64_t readyTs;
   uint64_t controlTs;
@@ -377,9 +379,7 @@ class CtranProfilerGpeEvent : public CommEvent {
         iterUs_(iterUs),
         durationUs_(durationUs),
         aborted_(aborted),
-        message_(message) {
-    iteration_ = ncclxGetIteration();
-  }
+        message_(message) {}
 
   ~CtranProfilerGpeEvent() override = default;
 
@@ -398,9 +398,6 @@ class CtranProfilerGpeEvent : public CommEvent {
   const uint64_t durationUs_;
   const bool aborted_;
   const std::string message_;
-  // training step. If not set by trainer, it is always -1. Also see
-  // ncclxGetIteration().
-  int64_t iteration_{-1};
 };
 
 class NetworkPerfMonitorEvent : public CommEvent {


### PR DESCRIPTION
Summary:
Add an `iteration` column (the current training step from `ncclxGetIteration()`) to the `CommEvent` base class so every record routed to the `nccl_structured_logging` Scuba table carries the iteration in which it was emitted, and consolidate the two pre-existing per-subclass iteration implementations into the base:
- `CommEvent` now captures `iteration = ncclxGetIteration()` in both constructors and emits it via `sample.addInt("iteration", ...)` in `CommEvent::toSample()`, so all CommEvent-derived events inherit a single iteration column.
- Remove the redundant `iteration` / `iteration_` members (and their `toSample()` additions) from `CtranProfilerAlgoEvent` and `CtranProfilerGpeEvent`; they now inherit the base column, which avoids emitting duplicate `iteration` Scuba columns.
- `MemoryEvent` (routed to `nccl_memory_logging`, not CommEvent-derived) is unchanged and keeps its own `iteration`.
- As a deliberate broadening, the CommEvent subclasses that previously had no iteration (`CtranProfilerEvent`, `CtranProfilerSlowRankEvent`, `NetworkPerfMonitorEvent`) now also carry the column. When no trainer sets the step, `ncclxGetIteration()` returns -1, matching existing behavior; adding a column to an existing Scuba table is backward-compatible.
- Add a `CommEventIteration` unit test (`LoggerUT.cc`) that sets `ncclxSetIteration(42)`, emits a `CommEvent`, and asserts the recorded `iteration` column equals 42 (proving a trainer-set step is captured, not just the -1 default).

Differential Revision: D112864062


