### PR TITLE
Link libatomic in the OSS/CMake build to fix the wheel link

### DIFF
--- a/comms/ncclx/v2_29/src/CMakeLists.txt
+++ b/comms/ncclx/v2_29/src/CMakeLists.txt
@@ -168,6 +168,15 @@ target_link_libraries(nccl
     ${EXTRA_LIBS}
 )
 
+# ncclx core uses 16-byte (128-bit) atomics -- the COMPILER_ATOMIC_* helpers in
+# utils.h -- which the compiler lowers to __atomic_{load,store}_16 libcalls that
+# live in libatomic. Link it explicitly so the references are satisfied on
+# libnccl.so itself rather than surfacing as an unsatisfiable NEEDED on downstream
+# consumers (the OSS wheel extension link otherwise fails with "undefined
+# reference to __atomic_store_16"). In the fbcode Buck build libatomic is pulled
+# in transitively, so this only matters for the standalone CMake/OSS build.
+target_link_libraries(nccl PRIVATE atomic)
+
 # Add version script for symbol visibility control
 target_link_options(nccl PRIVATE
     "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libnccl.map"

--- a/comms/ncclx/v2_30/src/CMakeLists.txt
+++ b/comms/ncclx/v2_30/src/CMakeLists.txt
@@ -214,6 +214,15 @@ target_link_libraries(nccl
     ${EXTRA_LIBS}
 )
 
+# ncclx core uses 16-byte (128-bit) atomics -- the COMPILER_ATOMIC_* helpers in
+# utils.h -- which the compiler lowers to __atomic_{load,store}_16 libcalls that
+# live in libatomic. Link it explicitly so the references are satisfied on
+# libnccl.so itself rather than surfacing as an unsatisfiable NEEDED on downstream
+# consumers (the OSS wheel extension link otherwise fails with "undefined
+# reference to __atomic_store_16"). In the fbcode Buck build libatomic is pulled
+# in transitively, so this only matters for the standalone CMake/OSS build.
+target_link_libraries(nccl PRIVATE atomic)
+
 # Add version script for symbol visibility control
 target_link_options(nccl PRIVATE
     "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libnccl.map"

--- a/comms/torchcomms/ncclx/CMakeLists.txt
+++ b/comms/torchcomms/ncclx/CMakeLists.txt
@@ -193,6 +193,12 @@ if(CUDA_FOUND)
     target_link_libraries(torchcomms_comms_ncclx PRIVATE CUDA::cudart)
 endif()
 
+# NCCLX (whether linked as libnccl.so or the static archive) references 16-byte
+# atomics that lower to libatomic __atomic_*_16 libcalls. Link libatomic on the
+# extension too so those transitive references resolve at the final OSS wheel
+# link (covers both the USE_SYSTEM_LIBS and static NCCLX paths above).
+target_link_libraries(torchcomms_comms_ncclx PRIVATE atomic)
+
 # Link absl LAST — after the ncclx archive (NCCLX_STATIC_LIB) and the folly
 # archives above. The static absl_log_internal_* members that satisfy
 # ncclx's LOG / CHECK references (e.g. absl::log_internal::kCharNull) are only


### PR DESCRIPTION
Summary:
The `meta-pytorch/torchcomms` "Build Linux Wheels" job fails at link time with:

    warning: libatomic.so.1, needed by .../build/ncclx/lib/libnccl.so, not found
    libnccl.so: undefined reference to `__atomic_store_16@LIBATOMIC_1.0'
    libnccl.so: undefined reference to `__atomic_load_16@LIBATOMIC_1.0'
    collect2: error: ld returned 1 exit status

ncclx core uses 16-byte (128-bit) atomics -- the `COMPILER_ATOMIC_*` helpers in `utils.h` (the MPSC intrusive queue, refcounts) -- which the compiler lowers to `__atomic_load_16` / `__atomic_store_16` libcalls that live in `libatomic`. Nothing in the standalone CMake build put `libatomic` on the link line, so `libnccl.so`'s references stay unresolved and get pushed onto downstream consumers, where the wheel extension link cannot find `libatomic.so.1` and fails.

In the fbcode Buck build this never surfaces because `libatomic` is pulled in transitively (via folly and others), so it is purely an OSS/CMake-build gap.

Fix: link `libatomic` explicitly where the atomics originate -- on the `nccl` target (`libnccl.so`) in both the v2.29 and v2.30 CMake -- and on the `torchcomms._comms_ncclx` extension so the transitive references resolve at the final wheel link (covering both the `USE_SYSTEM_LIBS` shared-`libnccl.so` path and the static-archive path). CMake maps the `atomic` link item to `-latomic`, which the gcc driver resolves from its own toolchain lib dir.

This is independent of any collective work; it unblocks the OSS wheel build for any comms change that triggers it.

Differential Revision: D112840423


