### PR TITLE
Add NCCLX bindings to nccl4py for v2.30

### DIFF
--- a/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/cynccl.pxd
+++ b/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/cynccl.pxd
@@ -119,6 +119,12 @@ ctypedef struct ncclConfig_t 'ncclConfig_t':
     int graphUsageMode
     int numRmaCtx
     int maxP2pPeers
+    char* commDesc
+    int* splitGroupRanks
+    int splitGroupSize
+    int fastInitMode
+    void* hints
+    void* ncclxConfig
 
 ctypedef struct ncclSimInfo_t 'ncclSimInfo_t':
     size_t size

--- a/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/nccl.pyx
+++ b/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/nccl.pyx
@@ -205,8 +205,8 @@ cdef class UniqueId:
 cdef _get_config_dtype_offsets():
     cdef ncclConfig_t pod = ncclConfig_t()
     return _numpy.dtype({
-        'names': ['size_', 'magic', 'version', 'blocking', 'cga_cluster_size', 'min_ctas', 'max_ctas', 'net_name', 'split_share', 'traffic_class', 'comm_name', 'collnet_enable', 'cta_policy', 'shrink_share', 'nvls_ctas', 'n_channels_per_net_peer', 'nvlink_centric_sched', 'graph_usage_mode', 'num_rma_ctx', 'max_p2p_peers'],
-        'formats': [_numpy.uint64, _numpy.uint32, _numpy.uint32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.intp, _numpy.int32, _numpy.int32, _numpy.intp, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32],
+        'names': ['size_', 'magic', 'version', 'blocking', 'cga_cluster_size', 'min_ctas', 'max_ctas', 'net_name', 'split_share', 'traffic_class', 'comm_name', 'collnet_enable', 'cta_policy', 'shrink_share', 'nvls_ctas', 'n_channels_per_net_peer', 'nvlink_centric_sched', 'graph_usage_mode', 'num_rma_ctx', 'max_p2p_peers', 'comm_desc', 'split_group_ranks', 'split_group_size', 'fast_init_mode', 'hints', 'ncclx_config'],
+        'formats': [_numpy.uint64, _numpy.uint32, _numpy.uint32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.intp, _numpy.int32, _numpy.int32, _numpy.intp, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.intp, _numpy.intp, _numpy.int32, _numpy.int32, _numpy.intp, _numpy.intp],
         'offsets': [
             (<intptr_t>&(pod.size)) - (<intptr_t>&pod),
             (<intptr_t>&(pod.magic)) - (<intptr_t>&pod),
@@ -228,14 +228,25 @@ cdef _get_config_dtype_offsets():
             (<intptr_t>&(pod.graphUsageMode)) - (<intptr_t>&pod),
             (<intptr_t>&(pod.numRmaCtx)) - (<intptr_t>&pod),
             (<intptr_t>&(pod.maxP2pPeers)) - (<intptr_t>&pod),
+            (<intptr_t>&(pod.commDesc)) - (<intptr_t>&pod),
+            (<intptr_t>&(pod.splitGroupRanks)) - (<intptr_t>&pod),
+            (<intptr_t>&(pod.splitGroupSize)) - (<intptr_t>&pod),
+            (<intptr_t>&(pod.fastInitMode)) - (<intptr_t>&pod),
+            (<intptr_t>&(pod.hints)) - (<intptr_t>&pod),
+            (<intptr_t>&(pod.ncclxConfig)) - (<intptr_t>&pod),
         ],
         'itemsize': sizeof(ncclConfig_t),
     })
 
 config_dtype = _get_config_dtype_offsets()
 
+NCCL_API_MAGIC = 0xcafebeef
+NCCL_CONFIG_UNDEF_INT = -2147483648  # INT_MIN
+cdef void* NCCL_CONFIG_UNDEF_PTR = NULL
+
+
 cdef class Config:
-    """Empty-initialize an instance of `ncclConfig_t`.
+    """Initialize an instance of `ncclConfig_t` with NCCL_CONFIG_INITIALIZER defaults.
 
 
     .. seealso:: `ncclConfig_t`
@@ -255,6 +266,34 @@ cdef class Config:
         self._owned = True
         self._readonly = False
         self._refs = {}
+        cdef int ver
+        ncclGetVersion(&ver)
+        self._ptr.size = sizeof(ncclConfig_t)
+        self._ptr.magic = NCCL_API_MAGIC
+        self._ptr.version = ver
+        self._ptr.blocking = NCCL_CONFIG_UNDEF_INT
+        self._ptr.cgaClusterSize = NCCL_CONFIG_UNDEF_INT
+        self._ptr.minCTAs = NCCL_CONFIG_UNDEF_INT
+        self._ptr.maxCTAs = NCCL_CONFIG_UNDEF_INT
+        self._ptr.netName = NULL
+        self._ptr.splitShare = NCCL_CONFIG_UNDEF_INT
+        self._ptr.trafficClass = NCCL_CONFIG_UNDEF_INT
+        self._ptr.commName = NULL
+        self._ptr.collnetEnable = NCCL_CONFIG_UNDEF_INT
+        self._ptr.CTAPolicy = NCCL_CONFIG_UNDEF_INT
+        self._ptr.shrinkShare = NCCL_CONFIG_UNDEF_INT
+        self._ptr.nvlsCTAs = NCCL_CONFIG_UNDEF_INT
+        self._ptr.nChannelsPerNetPeer = NCCL_CONFIG_UNDEF_INT
+        self._ptr.nvlinkCentricSched = NCCL_CONFIG_UNDEF_INT
+        self._ptr.graphUsageMode = NCCL_CONFIG_UNDEF_INT
+        self._ptr.numRmaCtx = NCCL_CONFIG_UNDEF_INT
+        self._ptr.maxP2pPeers = NCCL_CONFIG_UNDEF_INT
+        self._ptr.commDesc = <char*>NCCL_CONFIG_UNDEF_PTR
+        self._ptr.splitGroupRanks = <int*>NCCL_CONFIG_UNDEF_PTR
+        self._ptr.splitGroupSize = NCCL_CONFIG_UNDEF_INT
+        self._ptr.fastInitMode = NCCL_CONFIG_UNDEF_INT
+        self._ptr.hints = NCCL_CONFIG_UNDEF_PTR
+        self._ptr.ncclxConfig = NCCL_CONFIG_UNDEF_PTR
 
     def __dealloc__(self):
         cdef ncclConfig_t *ptr
@@ -524,6 +563,13 @@ cdef class Config:
         if self._readonly:
             raise ValueError("This Config instance is read-only")
         self._ptr[0].numRmaCtx = val
+
+    def set_hints(self, hints_ptr: int, hints_obj=None) -> None:
+        if self._readonly:
+            raise ValueError("This Config instance is read-only")
+        self._ptr[0].hints = <void*><intptr_t>hints_ptr
+        if hints_obj is not None:
+            self._refs["_ncclx_hints"] = hints_obj
 
     @property
     def max_p2p_peers(self):

--- a/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx.py
+++ b/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx.py
@@ -1,0 +1,5 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Unified NCCLX bindings: re-exports the NCCL C API and NCCLx C++ namespace extensions.
+
+from nccl.bindings.nccl import *  # noqa: F401,F403
+from nccl.bindings.ncclx_internal import *  # noqa: F401,F403

--- a/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx_internal.pxd
+++ b/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx_internal.pxd
@@ -1,0 +1,66 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# NCCLx C++ namespace bindings (direct linkage, not dlsym)
+
+from libc.stdint cimport uint64_t
+from libcpp.string cimport string
+from libcpp.unordered_map cimport unordered_map
+
+
+cdef extern from "cuda_runtime_api.h" nogil:
+    ctypedef struct CUstream_st
+    ctypedef CUstream_st* cudaStream_t
+
+
+cdef extern from "nccl.h" nogil:
+    ctypedef unsigned int ncclResult_t
+    ctypedef int ncclDataType_t
+    ctypedef void* ncclComm_t
+    ctypedef void* ncclWindow_t
+    ctypedef int ncclRedOp_t
+
+    ctypedef int ncclWinAccessType
+    # Declared as a cppclass (rather than a plain struct) so the heap instance
+    # that ncclWinGetAttributes hands back can be released with `del` (C++
+    # delete), matching the `new` used in the C++ implementation.
+    cdef cppclass ncclWinAttr:
+        ncclWinAccessType accessType
+    ctypedef ncclWinAttr* ncclWinAttr_t
+
+    ncclResult_t ncclWinSharedQuery(
+        int rank, ncclComm_t comm, ncclWindow_t win, void** addr)
+    ncclResult_t ncclWinGetAttributes(
+        int rank, ncclWindow_t win, ncclWinAttr_t* attr)
+    ncclResult_t ncclReduceScatterQuantize(
+        const void* sendbuff, void* recvbuff, size_t recvcount,
+        ncclDataType_t inputType, ncclDataType_t transportType,
+        ncclRedOp_t op, uint64_t* seedPtr,
+        ncclComm_t comm, cudaStream_t stream)
+    ncclResult_t ncclAllToAllv(
+        const void* sendbuff, const size_t* sendcounts, const size_t* sdispls,
+        void* recvbuff, const size_t* recvcounts, const size_t* rdispls,
+        ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream)
+    ncclResult_t ncclCommDump(
+        ncclComm_t comm, unordered_map[string, string]& result)
+    ncclResult_t ncclCommDumpAll(
+        unordered_map[string, unordered_map[string, string]]& result)
+
+    ctypedef struct ncclConfig_t:
+        pass
+
+
+cdef extern from "nccl.h" namespace "ncclx" nogil:
+    # Hints class
+    cdef cppclass Hints:
+        Hints()
+        ncclResult_t set(const char* key, const char* val)
+        ncclResult_t get(const char* key, char* val)
+
+    ncclResult_t setGlobalHint(string key, string val)
+
+    # Window-based RMA put
+    ncclResult_t ncclPut(
+        const void* originBuff, size_t count, ncclDataType_t datatype,
+        int peer, size_t targetDisp, ncclWindow_t win, cudaStream_t stream)
+
+    # Live comm reconfiguration
+    ncclResult_t commSetConfig(ncclComm_t comm, const ncclConfig_t* config)

--- a/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx_internal.pyx
+++ b/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx_internal.pyx
@@ -1,0 +1,175 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# NCCLx C++ namespace bindings (direct linkage)
+
+from libc.stdint cimport intptr_t, uint64_t
+from libcpp.string cimport string
+from libcpp.unordered_map cimport unordered_map
+
+from .ncclx_internal cimport (
+    commSetConfig as _commSetConfig,
+    cudaStream_t,
+    Hints as CppHints,
+    ncclAllToAllv as _ncclAllToAllv,
+    ncclCommDump as _ncclCommDump,
+    ncclCommDumpAll as _ncclCommDumpAll,
+    ncclComm_t,
+    ncclConfig_t,
+    ncclDataType_t,
+    ncclPut as _ncclPut,
+    ncclRedOp_t,
+    ncclReduceScatterQuantize as _ncclReduceScatterQuantize,
+    ncclWindow_t,
+    ncclWinAttr,
+    ncclWinGetAttributes as _ncclWinGetAttributes,
+    ncclWinSharedQuery as _ncclWinSharedQuery,
+    setGlobalHint as _setGlobalHint,
+)
+
+from .nccl import check_status
+
+
+cpdef put(
+    intptr_t origin_buff, size_t count, int datatype,
+    int peer, size_t target_disp, intptr_t win, intptr_t stream,
+):
+    cdef int status
+    with nogil:
+        status = _ncclPut(
+            <const void*>origin_buff, count, <ncclDataType_t>datatype,
+            peer, target_disp, <ncclWindow_t>win, <cudaStream_t>stream,
+        )
+    check_status(status)
+
+
+cpdef intptr_t win_shared_query(
+    int rank, intptr_t comm, intptr_t win,
+) except? 0:
+    cdef void* addr = NULL
+    cdef int status
+    with nogil:
+        status = _ncclWinSharedQuery(
+            rank, <ncclComm_t>comm, <ncclWindow_t>win, &addr,
+        )
+    check_status(status)
+    return <intptr_t>addr
+
+
+cpdef int win_get_attributes(int rank, intptr_t win) except? -1:
+    # ncclWinGetAttributes heap-allocates the attr struct and transfers
+    # ownership to the caller through the out-pointer, so read the value out
+    # of the returned pointer (not a local) and free it here.
+    cdef ncclWinAttr* attr_ptr = NULL
+    cdef int status
+    cdef int access_type
+    with nogil:
+        status = _ncclWinGetAttributes(rank, <ncclWindow_t>win, &attr_ptr)
+    check_status(status)
+    access_type = <int>attr_ptr.accessType
+    del attr_ptr
+    return access_type
+
+
+cdef class NcclxHints:
+    cdef CppHints _hints
+
+    def __init__(self, dict hints=None):
+        if hints:
+            for k, v in hints.items():
+                _check_hints_status(self._hints.set(
+                    k.encode("utf-8"), _to_hint_str(v).encode("utf-8"),
+                ))
+
+    cdef CppHints* ptr(self):
+        return &self._hints
+
+    def as_ptr(self) -> int:
+        return <intptr_t>&self._hints
+
+
+def _to_hint_str(v) -> str:
+    """Stringify a hint value for the C++ Hints map.
+
+    NCCLX hints are string-typed at the C++ level. This helper accepts
+    natural Python types and renders them in the canonical hint format:
+      - bool -> "true"/"false" (lowercase)
+      - everything else -> str(v)
+    """
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    return str(v)
+
+
+cdef _check_hints_status(int status):
+    check_status(status)
+
+
+cpdef set_global_hint(str key, str value):
+    cdef string k = key.encode("utf-8")
+    cdef string v = value.encode("utf-8")
+    cdef int status
+    with nogil:
+        status = _setGlobalHint(k, v)
+    check_status(status)
+
+
+cpdef reduce_scatter_quantize(
+    intptr_t sendbuff, intptr_t recvbuff, size_t recvcount,
+    int input_type, int transport_type, int op,
+    intptr_t seed_ptr, intptr_t comm, intptr_t stream,
+):
+    cdef int status
+    with nogil:
+        status = _ncclReduceScatterQuantize(
+            <const void*>sendbuff, <void*>recvbuff, recvcount,
+            <ncclDataType_t>input_type, <ncclDataType_t>transport_type,
+            <ncclRedOp_t>op, <uint64_t*>seed_ptr,
+            <ncclComm_t>comm, <cudaStream_t>stream,
+        )
+    check_status(status)
+
+
+cpdef allto_allv(
+    intptr_t sendbuff, intptr_t sendcounts, intptr_t sdispls,
+    intptr_t recvbuff, intptr_t recvcounts, intptr_t rdispls,
+    int datatype, intptr_t comm, intptr_t stream,
+):
+    cdef int status
+    with nogil:
+        status = _ncclAllToAllv(
+            <const void*>sendbuff, <const size_t*>sendcounts, <const size_t*>sdispls,
+            <void*>recvbuff, <const size_t*>recvcounts, <const size_t*>rdispls,
+            <ncclDataType_t>datatype, <ncclComm_t>comm, <cudaStream_t>stream,
+        )
+    check_status(status)
+
+
+cpdef dict comm_dump(intptr_t comm):
+    cdef unordered_map[string, string] result
+    cdef int status
+    with nogil:
+        status = _ncclCommDump(<ncclComm_t>comm, result)
+    check_status(status)
+    return {k.decode("utf-8"): v.decode("utf-8") for k, v in result}
+
+
+cpdef dict comm_dump_all():
+    cdef unordered_map[string, unordered_map[string, string]] result
+    cdef int status
+    with nogil:
+        status = _ncclCommDumpAll(result)
+    check_status(status)
+    return {
+        k.decode("utf-8"): {
+            ik.decode("utf-8"): iv.decode("utf-8") for ik, iv in v.items()
+        }
+        for k, v in result
+    }
+
+
+cpdef comm_set_config(intptr_t comm, intptr_t config):
+    cdef int status
+    with nogil:
+        status = _commSetConfig(
+            <ncclComm_t>comm, <const ncclConfig_t*>config,
+        )
+    check_status(status)

--- a/comms/ncclx/v2_30/bindings/nccl4py/setup.py
+++ b/comms/ncclx/v2_30/bindings/nccl4py/setup.py
@@ -17,6 +17,13 @@ if not cuda_path.exists() or not cuda_path.is_dir():
     )
 CUDA_INC = str(cuda_path / "include")
 
+# NCCL include/lib paths for direct C++ linkage (NCCLx namespace bindings)
+_prefix = os.environ.get("PREFIX", "")
+NCCL_INC = os.environ.get(
+    "NCCL_INC", os.path.join(_prefix, "include") if _prefix else ""
+)
+NCCL_LIB = os.environ.get("NCCL_LIB", os.path.join(_prefix, "lib") if _prefix else "")
+
 ext_modules = ["nccl.bindings.nccl"]
 
 
@@ -86,6 +93,25 @@ def calculate_modules(module: str):
 
 # Note: the extension attributes are overwritten in build_extension()
 ext_modules = [e for ext in ext_modules for e in calculate_modules(ext)]
+
+# NCCLx C++ namespace bindings (direct linkage against libnccl)
+_ncclx_include_dirs = [CUDA_INC]
+_ncclx_library_dirs = []
+if NCCL_INC:
+    _ncclx_include_dirs.append(NCCL_INC)
+if NCCL_LIB:
+    _ncclx_library_dirs.append(NCCL_LIB)
+
+ncclx_ext = Extension(
+    "nccl.bindings.ncclx_internal",
+    sources=["nccl/bindings/ncclx_internal.pyx"],
+    include_dirs=_ncclx_include_dirs,
+    library_dirs=_ncclx_library_dirs,
+    language="c++",
+    extra_compile_args=["-std=c++17"],
+    libraries=["nccl"],
+)
+ext_modules.append(ncclx_ext)
 
 
 compiler_directives = {


### PR DESCRIPTION
Summary:
Extend the v2.30 `nccl4py` bindings with the NCCLX-specific surface that the
v2.30 base binding does not already provide, plus a unified `nccl.bindings.ncclx`
module that re-exports the base NCCL C API together with these extensions.

Add, via direct C++ linkage against `libnccl` (`nccl.bindings.ncclx_internal`):

- `comm_set_config` (`ncclx::commSetConfig`)
- `allto_allv` (`ncclAllToAllv`)
- `reduce_scatter_quantize` (`ncclReduceScatterQuantize`)
- `put` (`ncclx::ncclPut`)
- `win_shared_query` (`ncclWinSharedQuery`)
- `win_get_attributes` (`ncclWinGetAttributes`)
- `set_global_hint` (`ncclx::setGlobalHint`)
- `comm_dump` / `comm_dump_all` (`ncclCommDump` / `ncclCommDumpAll`)
- `NcclxHints` (wraps `ncclx::Hints`)

It also extends the base `Config` binding for the NCCLX config surface consumers
require: declare the NCCLX-specific `ncclConfig_t` fields (`commDesc`,
`splitGroupRanks`, `splitGroupSize`, `fastInitMode`, `hints`, `ncclxConfig`) in
`cynccl.pxd`; initialize the config with `NCCL_CONFIG_INITIALIZER` semantics
(`magic`/`size`/`version` + UNDEF defaults) in `Config.__init__`; and add
`Config.set_hints()` so an `NcclxHints` pointer can be attached to the config.

`setup.py` gains `NCCL_INC`/`NCCL_LIB` resolution (defaulting to `$PREFIX`) and a
single `nccl.bindings.ncclx_internal` Extension built with `-std=c++17` linked
against `libnccl`.

Differential Revision: D112890866


