### PR TITLE
Add CCA4Py: PyTorch CCA to NCCL memory registration

### DIFF
--- a/comms/cca4py/cca4py.cpp
+++ b/comms/cca4py/cca4py.cpp
@@ -1,0 +1,85 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/util/Exception.h>
+#include <nccl.h>
+#include <pybind11/pybind11.h>
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+
+namespace {
+
+std::once_flag g_init_flag;
+// Read from the is_initialized binding on arbitrary threads while do_init()
+// writes it, so it must be atomic (std::call_once only synchronizes threads
+// that pass through it).
+std::atomic<bool> g_initialized{false};
+
+void trace_hook(const c10::cuda::CUDACachingAllocator::TraceEntry& te) {
+  auto* addr = reinterpret_cast<void*>(static_cast<uintptr_t>(te.addr_));
+  auto len = te.size_;
+
+  using Action = c10::cuda::CUDACachingAllocator::TraceEntry::Action;
+  if (te.action_ == Action::SEGMENT_ALLOC ||
+      te.action_ == Action::SEGMENT_MAP) {
+    ncclResult_t result = ncclGlobalRegisterWithPtr(addr, len);
+    if (result != ncclSuccess) {
+      TORCH_WARN(
+          "cca4py: ncclGlobalRegisterWithPtr failed: ",
+          ncclGetErrorString(result));
+    }
+  } else if (
+      te.action_ == Action::SEGMENT_FREE ||
+      te.action_ == Action::SEGMENT_UNMAP) {
+    ncclResult_t result = ncclGlobalDeregisterWithPtr(addr, len);
+    if (result != ncclSuccess) {
+      TORCH_WARN(
+          "cca4py: ncclGlobalDeregisterWithPtr failed: ",
+          ncclGetErrorString(result));
+    }
+  }
+}
+
+void register_existing_segments() {
+  auto snapshot = c10::cuda::CUDACachingAllocator::snapshot();
+  for (const auto& seg : snapshot.segments) {
+    auto* addr = reinterpret_cast<void*>(seg.address);
+    ncclResult_t result = ncclGlobalRegisterWithPtr(addr, seg.total_size);
+    if (result != ncclSuccess) {
+      TORCH_WARN(
+          "cca4py: failed to register existing segment: ",
+          ncclGetErrorString(result));
+    }
+  }
+}
+
+void do_init() {
+  at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
+  // Attach the trace hook before snapshotting existing segments so a segment
+  // allocated concurrently during init isn't lost in the gap between the two.
+  // A segment observed by both paths is registered twice, which the NCCL
+  // registration layer dedupes.
+  c10::cuda::CUDACachingAllocator::attachAllocatorTraceTracker(&trace_hook);
+  register_existing_segments();
+  g_initialized.store(true, std::memory_order_release);
+}
+
+} // namespace
+
+PYBIND11_MODULE(cca4py, m) {
+  m.doc() = "CCA4Py: PyTorch CUDACachingAllocator ↔ NCCL memory registration";
+
+  m.def(
+      "init_hook",
+      []() { std::call_once(g_init_flag, do_init); },
+      "Attach CCA trace hook for automatic NCCL memory registration. "
+      "Safe to call multiple times (no-op after first).");
+
+  m.def(
+      "is_initialized",
+      []() { return g_initialized.load(std::memory_order_acquire); },
+      "Return True if the CCA hook has been initialized.");
+}

--- a/comms/cca4py/pyproject.toml
+++ b/comms/cca4py/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "cca4py"
+version = "0.1.0"
+requires-python = ">=3.10"
+description = "CCA4Py: PyTorch CUDACachingAllocator <-> NCCL memory registration"
+license = "MIT"
+authors = [
+    { name = "Meta Platforms, Inc." }
+]
+
+[build-system]
+requires = [
+    "setuptools>=77.0.3",
+    "pybind11>=2.11",
+]
+build-backend = "setuptools.build_meta"

--- a/comms/cca4py/setup.py
+++ b/comms/cca4py/setup.py
@@ -1,0 +1,60 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import os
+
+from pybind11.setup_helpers import Pybind11Extension
+from setuptools import setup
+
+BUILDDIR = os.environ.get("BUILDDIR", None)
+LIBDIR = None
+if BUILDDIR is not None:
+    LIBDIR = os.path.join(BUILDDIR, "lib")
+
+TORCH_DIR = None
+try:
+    import torch
+
+    TORCH_DIR = os.path.dirname(torch.__file__)
+except ImportError:
+    pass
+
+CUDA_HOME = os.environ.get("CUDA_HOME", "/usr/local/cuda")
+
+include_dirs = []
+library_dirs = []
+libraries = ["nccl"]
+
+if os.path.isdir(os.path.join(CUDA_HOME, "include")):
+    include_dirs.append(os.path.join(CUDA_HOME, "include"))
+    library_dirs.append(os.path.join(CUDA_HOME, "lib64"))
+
+if LIBDIR is not None:
+    library_dirs.append(LIBDIR)
+
+if TORCH_DIR is not None:
+    include_dirs.append(os.path.join(TORCH_DIR, "include"))
+    include_dirs.append(
+        os.path.join(TORCH_DIR, "include", "torch", "csrc", "api", "include")
+    )
+    library_dirs.append(os.path.join(TORCH_DIR, "lib"))
+    libraries.extend(["c10", "c10_cuda", "torch", "torch_cpu", "torch_cuda"])
+
+runtime_library_dirs = list(library_dirs)
+
+ext_modules = [
+    Pybind11Extension(
+        "cca4py",
+        ["cca4py.cpp"],
+        include_dirs=include_dirs,
+        library_dirs=library_dirs,
+        runtime_library_dirs=runtime_library_dirs,
+        libraries=libraries,
+    ),
+]
+
+setup(
+    name="cca4py",
+    version="0.1.0",
+    description="CCA4Py: PyTorch CUDACachingAllocator <-> NCCL memory registration",
+    ext_modules=ext_modules,
+)

--- a/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/cynccl.pxd
+++ b/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/cynccl.pxd
@@ -119,6 +119,12 @@ ctypedef struct ncclConfig_t 'ncclConfig_t':
     int graphUsageMode
     int numRmaCtx
     int maxP2pPeers
+    char* commDesc
+    int* splitGroupRanks
+    int splitGroupSize
+    int fastInitMode
+    void* hints
+    void* ncclxConfig
 
 ctypedef struct ncclSimInfo_t 'ncclSimInfo_t':
     size_t size

--- a/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/nccl.pyx
+++ b/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/nccl.pyx
@@ -205,8 +205,8 @@ cdef class UniqueId:
 cdef _get_config_dtype_offsets():
     cdef ncclConfig_t pod = ncclConfig_t()
     return _numpy.dtype({
-        'names': ['size_', 'magic', 'version', 'blocking', 'cga_cluster_size', 'min_ctas', 'max_ctas', 'net_name', 'split_share', 'traffic_class', 'comm_name', 'collnet_enable', 'cta_policy', 'shrink_share', 'nvls_ctas', 'n_channels_per_net_peer', 'nvlink_centric_sched', 'graph_usage_mode', 'num_rma_ctx', 'max_p2p_peers'],
-        'formats': [_numpy.uint64, _numpy.uint32, _numpy.uint32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.intp, _numpy.int32, _numpy.int32, _numpy.intp, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32],
+        'names': ['size_', 'magic', 'version', 'blocking', 'cga_cluster_size', 'min_ctas', 'max_ctas', 'net_name', 'split_share', 'traffic_class', 'comm_name', 'collnet_enable', 'cta_policy', 'shrink_share', 'nvls_ctas', 'n_channels_per_net_peer', 'nvlink_centric_sched', 'graph_usage_mode', 'num_rma_ctx', 'max_p2p_peers', 'comm_desc', 'split_group_ranks', 'split_group_size', 'fast_init_mode', 'hints', 'ncclx_config'],
+        'formats': [_numpy.uint64, _numpy.uint32, _numpy.uint32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.intp, _numpy.int32, _numpy.int32, _numpy.intp, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.int32, _numpy.intp, _numpy.intp, _numpy.int32, _numpy.int32, _numpy.intp, _numpy.intp],
         'offsets': [
             (<intptr_t>&(pod.size)) - (<intptr_t>&pod),
             (<intptr_t>&(pod.magic)) - (<intptr_t>&pod),
@@ -228,14 +228,25 @@ cdef _get_config_dtype_offsets():
             (<intptr_t>&(pod.graphUsageMode)) - (<intptr_t>&pod),
             (<intptr_t>&(pod.numRmaCtx)) - (<intptr_t>&pod),
             (<intptr_t>&(pod.maxP2pPeers)) - (<intptr_t>&pod),
+            (<intptr_t>&(pod.commDesc)) - (<intptr_t>&pod),
+            (<intptr_t>&(pod.splitGroupRanks)) - (<intptr_t>&pod),
+            (<intptr_t>&(pod.splitGroupSize)) - (<intptr_t>&pod),
+            (<intptr_t>&(pod.fastInitMode)) - (<intptr_t>&pod),
+            (<intptr_t>&(pod.hints)) - (<intptr_t>&pod),
+            (<intptr_t>&(pod.ncclxConfig)) - (<intptr_t>&pod),
         ],
         'itemsize': sizeof(ncclConfig_t),
     })
 
 config_dtype = _get_config_dtype_offsets()
 
+NCCL_API_MAGIC = 0xcafebeef
+NCCL_CONFIG_UNDEF_INT = -2147483648  # INT_MIN
+cdef void* NCCL_CONFIG_UNDEF_PTR = NULL
+
+
 cdef class Config:
-    """Empty-initialize an instance of `ncclConfig_t`.
+    """Initialize an instance of `ncclConfig_t` with NCCL_CONFIG_INITIALIZER defaults.
 
 
     .. seealso:: `ncclConfig_t`
@@ -255,6 +266,34 @@ cdef class Config:
         self._owned = True
         self._readonly = False
         self._refs = {}
+        cdef int ver
+        ncclGetVersion(&ver)
+        self._ptr.size = sizeof(ncclConfig_t)
+        self._ptr.magic = NCCL_API_MAGIC
+        self._ptr.version = ver
+        self._ptr.blocking = NCCL_CONFIG_UNDEF_INT
+        self._ptr.cgaClusterSize = NCCL_CONFIG_UNDEF_INT
+        self._ptr.minCTAs = NCCL_CONFIG_UNDEF_INT
+        self._ptr.maxCTAs = NCCL_CONFIG_UNDEF_INT
+        self._ptr.netName = NULL
+        self._ptr.splitShare = NCCL_CONFIG_UNDEF_INT
+        self._ptr.trafficClass = NCCL_CONFIG_UNDEF_INT
+        self._ptr.commName = NULL
+        self._ptr.collnetEnable = NCCL_CONFIG_UNDEF_INT
+        self._ptr.CTAPolicy = NCCL_CONFIG_UNDEF_INT
+        self._ptr.shrinkShare = NCCL_CONFIG_UNDEF_INT
+        self._ptr.nvlsCTAs = NCCL_CONFIG_UNDEF_INT
+        self._ptr.nChannelsPerNetPeer = NCCL_CONFIG_UNDEF_INT
+        self._ptr.nvlinkCentricSched = NCCL_CONFIG_UNDEF_INT
+        self._ptr.graphUsageMode = NCCL_CONFIG_UNDEF_INT
+        self._ptr.numRmaCtx = NCCL_CONFIG_UNDEF_INT
+        self._ptr.maxP2pPeers = NCCL_CONFIG_UNDEF_INT
+        self._ptr.commDesc = <char*>NCCL_CONFIG_UNDEF_PTR
+        self._ptr.splitGroupRanks = <int*>NCCL_CONFIG_UNDEF_PTR
+        self._ptr.splitGroupSize = NCCL_CONFIG_UNDEF_INT
+        self._ptr.fastInitMode = NCCL_CONFIG_UNDEF_INT
+        self._ptr.hints = NCCL_CONFIG_UNDEF_PTR
+        self._ptr.ncclxConfig = NCCL_CONFIG_UNDEF_PTR
 
     def __dealloc__(self):
         cdef ncclConfig_t *ptr
@@ -524,6 +563,13 @@ cdef class Config:
         if self._readonly:
             raise ValueError("This Config instance is read-only")
         self._ptr[0].numRmaCtx = val
+
+    def set_hints(self, hints_ptr: int, hints_obj=None) -> None:
+        if self._readonly:
+            raise ValueError("This Config instance is read-only")
+        self._ptr[0].hints = <void*><intptr_t>hints_ptr
+        if hints_obj is not None:
+            self._refs["_ncclx_hints"] = hints_obj
 
     @property
     def max_p2p_peers(self):

--- a/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx.py
+++ b/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx.py
@@ -1,0 +1,5 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Unified NCCLX bindings: re-exports the NCCL C API and NCCLx C++ namespace extensions.
+
+from nccl.bindings.nccl import *  # noqa: F401,F403
+from nccl.bindings.ncclx_internal import *  # noqa: F401,F403

--- a/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx_internal.pxd
+++ b/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx_internal.pxd
@@ -1,0 +1,66 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# NCCLx C++ namespace bindings (direct linkage, not dlsym)
+
+from libc.stdint cimport uint64_t
+from libcpp.string cimport string
+from libcpp.unordered_map cimport unordered_map
+
+
+cdef extern from "cuda_runtime_api.h" nogil:
+    ctypedef struct CUstream_st
+    ctypedef CUstream_st* cudaStream_t
+
+
+cdef extern from "nccl.h" nogil:
+    ctypedef unsigned int ncclResult_t
+    ctypedef int ncclDataType_t
+    ctypedef void* ncclComm_t
+    ctypedef void* ncclWindow_t
+    ctypedef int ncclRedOp_t
+
+    ctypedef int ncclWinAccessType
+    # Declared as a cppclass (rather than a plain struct) so the heap instance
+    # that ncclWinGetAttributes hands back can be released with `del` (C++
+    # delete), matching the `new` used in the C++ implementation.
+    cdef cppclass ncclWinAttr:
+        ncclWinAccessType accessType
+    ctypedef ncclWinAttr* ncclWinAttr_t
+
+    ncclResult_t ncclWinSharedQuery(
+        int rank, ncclComm_t comm, ncclWindow_t win, void** addr)
+    ncclResult_t ncclWinGetAttributes(
+        int rank, ncclWindow_t win, ncclWinAttr_t* attr)
+    ncclResult_t ncclReduceScatterQuantize(
+        const void* sendbuff, void* recvbuff, size_t recvcount,
+        ncclDataType_t inputType, ncclDataType_t transportType,
+        ncclRedOp_t op, uint64_t* seedPtr,
+        ncclComm_t comm, cudaStream_t stream)
+    ncclResult_t ncclAllToAllv(
+        const void* sendbuff, const size_t* sendcounts, const size_t* sdispls,
+        void* recvbuff, const size_t* recvcounts, const size_t* rdispls,
+        ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream)
+    ncclResult_t ncclCommDump(
+        ncclComm_t comm, unordered_map[string, string]& result)
+    ncclResult_t ncclCommDumpAll(
+        unordered_map[string, unordered_map[string, string]]& result)
+
+    ctypedef struct ncclConfig_t:
+        pass
+
+
+cdef extern from "nccl.h" namespace "ncclx" nogil:
+    # Hints class
+    cdef cppclass Hints:
+        Hints()
+        ncclResult_t set(const char* key, const char* val)
+        ncclResult_t get(const char* key, char* val)
+
+    ncclResult_t setGlobalHint(string key, string val)
+
+    # Window-based RMA put
+    ncclResult_t ncclPut(
+        const void* originBuff, size_t count, ncclDataType_t datatype,
+        int peer, size_t targetDisp, ncclWindow_t win, cudaStream_t stream)
+
+    # Live comm reconfiguration
+    ncclResult_t commSetConfig(ncclComm_t comm, const ncclConfig_t* config)

--- a/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx_internal.pyx
+++ b/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx_internal.pyx
@@ -1,0 +1,175 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# NCCLx C++ namespace bindings (direct linkage)
+
+from libc.stdint cimport intptr_t, uint64_t
+from libcpp.string cimport string
+from libcpp.unordered_map cimport unordered_map
+
+from .ncclx_internal cimport (
+    commSetConfig as _commSetConfig,
+    cudaStream_t,
+    Hints as CppHints,
+    ncclAllToAllv as _ncclAllToAllv,
+    ncclCommDump as _ncclCommDump,
+    ncclCommDumpAll as _ncclCommDumpAll,
+    ncclComm_t,
+    ncclConfig_t,
+    ncclDataType_t,
+    ncclPut as _ncclPut,
+    ncclRedOp_t,
+    ncclReduceScatterQuantize as _ncclReduceScatterQuantize,
+    ncclWindow_t,
+    ncclWinAttr,
+    ncclWinGetAttributes as _ncclWinGetAttributes,
+    ncclWinSharedQuery as _ncclWinSharedQuery,
+    setGlobalHint as _setGlobalHint,
+)
+
+from .nccl import check_status
+
+
+cpdef put(
+    intptr_t origin_buff, size_t count, int datatype,
+    int peer, size_t target_disp, intptr_t win, intptr_t stream,
+):
+    cdef int status
+    with nogil:
+        status = _ncclPut(
+            <const void*>origin_buff, count, <ncclDataType_t>datatype,
+            peer, target_disp, <ncclWindow_t>win, <cudaStream_t>stream,
+        )
+    check_status(status)
+
+
+cpdef intptr_t win_shared_query(
+    int rank, intptr_t comm, intptr_t win,
+) except? 0:
+    cdef void* addr = NULL
+    cdef int status
+    with nogil:
+        status = _ncclWinSharedQuery(
+            rank, <ncclComm_t>comm, <ncclWindow_t>win, &addr,
+        )
+    check_status(status)
+    return <intptr_t>addr
+
+
+cpdef int win_get_attributes(int rank, intptr_t win) except? -1:
+    # ncclWinGetAttributes heap-allocates the attr struct and transfers
+    # ownership to the caller through the out-pointer, so read the value out
+    # of the returned pointer (not a local) and free it here.
+    cdef ncclWinAttr* attr_ptr = NULL
+    cdef int status
+    cdef int access_type
+    with nogil:
+        status = _ncclWinGetAttributes(rank, <ncclWindow_t>win, &attr_ptr)
+    check_status(status)
+    access_type = <int>attr_ptr.accessType
+    del attr_ptr
+    return access_type
+
+
+cdef class NcclxHints:
+    cdef CppHints _hints
+
+    def __init__(self, dict hints=None):
+        if hints:
+            for k, v in hints.items():
+                _check_hints_status(self._hints.set(
+                    k.encode("utf-8"), _to_hint_str(v).encode("utf-8"),
+                ))
+
+    cdef CppHints* ptr(self):
+        return &self._hints
+
+    def as_ptr(self) -> int:
+        return <intptr_t>&self._hints
+
+
+def _to_hint_str(v) -> str:
+    """Stringify a hint value for the C++ Hints map.
+
+    NCCLX hints are string-typed at the C++ level. This helper accepts
+    natural Python types and renders them in the canonical hint format:
+      - bool -> "true"/"false" (lowercase)
+      - everything else -> str(v)
+    """
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    return str(v)
+
+
+cdef _check_hints_status(int status):
+    check_status(status)
+
+
+cpdef set_global_hint(str key, str value):
+    cdef string k = key.encode("utf-8")
+    cdef string v = value.encode("utf-8")
+    cdef int status
+    with nogil:
+        status = _setGlobalHint(k, v)
+    check_status(status)
+
+
+cpdef reduce_scatter_quantize(
+    intptr_t sendbuff, intptr_t recvbuff, size_t recvcount,
+    int input_type, int transport_type, int op,
+    intptr_t seed_ptr, intptr_t comm, intptr_t stream,
+):
+    cdef int status
+    with nogil:
+        status = _ncclReduceScatterQuantize(
+            <const void*>sendbuff, <void*>recvbuff, recvcount,
+            <ncclDataType_t>input_type, <ncclDataType_t>transport_type,
+            <ncclRedOp_t>op, <uint64_t*>seed_ptr,
+            <ncclComm_t>comm, <cudaStream_t>stream,
+        )
+    check_status(status)
+
+
+cpdef allto_allv(
+    intptr_t sendbuff, intptr_t sendcounts, intptr_t sdispls,
+    intptr_t recvbuff, intptr_t recvcounts, intptr_t rdispls,
+    int datatype, intptr_t comm, intptr_t stream,
+):
+    cdef int status
+    with nogil:
+        status = _ncclAllToAllv(
+            <const void*>sendbuff, <const size_t*>sendcounts, <const size_t*>sdispls,
+            <void*>recvbuff, <const size_t*>recvcounts, <const size_t*>rdispls,
+            <ncclDataType_t>datatype, <ncclComm_t>comm, <cudaStream_t>stream,
+        )
+    check_status(status)
+
+
+cpdef dict comm_dump(intptr_t comm):
+    cdef unordered_map[string, string] result
+    cdef int status
+    with nogil:
+        status = _ncclCommDump(<ncclComm_t>comm, result)
+    check_status(status)
+    return {k.decode("utf-8"): v.decode("utf-8") for k, v in result}
+
+
+cpdef dict comm_dump_all():
+    cdef unordered_map[string, unordered_map[string, string]] result
+    cdef int status
+    with nogil:
+        status = _ncclCommDumpAll(result)
+    check_status(status)
+    return {
+        k.decode("utf-8"): {
+            ik.decode("utf-8"): iv.decode("utf-8") for ik, iv in v.items()
+        }
+        for k, v in result
+    }
+
+
+cpdef comm_set_config(intptr_t comm, intptr_t config):
+    cdef int status
+    with nogil:
+        status = _commSetConfig(
+            <ncclComm_t>comm, <const ncclConfig_t*>config,
+        )
+    check_status(status)

--- a/comms/ncclx/v2_30/bindings/nccl4py/setup.py
+++ b/comms/ncclx/v2_30/bindings/nccl4py/setup.py
@@ -17,6 +17,13 @@ if not cuda_path.exists() or not cuda_path.is_dir():
     )
 CUDA_INC = str(cuda_path / "include")
 
+# NCCL include/lib paths for direct C++ linkage (NCCLx namespace bindings)
+_prefix = os.environ.get("PREFIX", "")
+NCCL_INC = os.environ.get(
+    "NCCL_INC", os.path.join(_prefix, "include") if _prefix else ""
+)
+NCCL_LIB = os.environ.get("NCCL_LIB", os.path.join(_prefix, "lib") if _prefix else "")
+
 ext_modules = ["nccl.bindings.nccl"]
 
 
@@ -86,6 +93,25 @@ def calculate_modules(module: str):
 
 # Note: the extension attributes are overwritten in build_extension()
 ext_modules = [e for ext in ext_modules for e in calculate_modules(ext)]
+
+# NCCLx C++ namespace bindings (direct linkage against libnccl)
+_ncclx_include_dirs = [CUDA_INC]
+_ncclx_library_dirs = []
+if NCCL_INC:
+    _ncclx_include_dirs.append(NCCL_INC)
+if NCCL_LIB:
+    _ncclx_library_dirs.append(NCCL_LIB)
+
+ncclx_ext = Extension(
+    "nccl.bindings.ncclx_internal",
+    sources=["nccl/bindings/ncclx_internal.pyx"],
+    include_dirs=_ncclx_include_dirs,
+    library_dirs=_ncclx_library_dirs,
+    language="c++",
+    extra_compile_args=["-std=c++17"],
+    libraries=["nccl"],
+)
+ext_modules.append(ncclx_ext)
 
 
 compiler_directives = {


### PR DESCRIPTION
Summary:
Add the `cca4py` package: a pybind11 extension that bridges the PyTorch CUDA
caching allocator to NCCL memory registration. It attaches a
`CUDACachingAllocator` trace tracker that calls `ncclGlobalRegisterWithPtr` on
SEGMENT_ALLOC/SEGMENT_MAP and `ncclGlobalDeregisterWithPtr` on
SEGMENT_FREE/SEGMENT_UNMAP, and registers any pre-existing segments at init.

Exposes `init_hook()` (idempotent via `std::call_once`) and `is_initialized()`.

Reviewed By: YangZhou1997

Differential Revision: D112890868


