### PR TITLE
MCCL AllReduce: add native single-node direct algorithm (#3202)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceImpl.h
+++ b/comms/ctran/algos/AllReduce/AllReduceImpl.h
@@ -65,6 +65,8 @@ static inline const std::string allReduceAlgoName(
       return "CtranAllReduceTreeDirect";
     case NCCL_ALLREDUCE_ALGO::cthierarchical_ring:
       return "CtranAllReduceHierarchicalRingDirect";
+    case NCCL_ALLREDUCE_ALGO::ctmdirect:
+      return "McclAllReduceDirect";
     default:
       return "Unknown";
   }

--- a/comms/ncclx/meta/algoconf/AlgoStrConv.h
+++ b/comms/ncclx/meta/algoconf/AlgoStrConv.h
@@ -75,6 +75,8 @@ inline void algoStrToVal(
     val = NCCL_ALLREDUCE_ALGO::ctree;
   } else if (str == "cthierarchical_ring") {
     val = NCCL_ALLREDUCE_ALGO::cthierarchical_ring;
+  } else if (str == "ctmdirect") {
+    val = NCCL_ALLREDUCE_ALGO::ctmdirect;
   } else {
     val = NCCL_ALLREDUCE_ALGO::orig;
   }
@@ -184,6 +186,8 @@ inline std::string algoValToStr(enum NCCL_ALLREDUCE_ALGO val) {
       return "ctree";
     case NCCL_ALLREDUCE_ALGO::cthierarchical_ring:
       return "cthierarchical_ring";
+    case NCCL_ALLREDUCE_ALGO::ctmdirect:
+      return "ctmdirect";
   }
   return "unknown";
 }

--- a/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
+++ b/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
@@ -116,6 +116,9 @@ void checkAlgoStrToVal(enum NCCL_ALLREDUCE_ALGO algo) {
     case NCCL_ALLREDUCE_ALGO::cthierarchical_ring:
       str = "cthierarchical_ring";
       break;
+    case NCCL_ALLREDUCE_ALGO::ctmdirect:
+      str = "ctmdirect";
+      break;
   }
   enum NCCL_ALLREDUCE_ALGO result;
   algoStrToVal(str, result);
@@ -222,6 +225,7 @@ TEST(AlgoStrConvTest, AllReduceCompleteness) {
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctring);
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctree);
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::cthierarchical_ring);
+  checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctmdirect);
 }
 
 TEST(AlgoStrConvTest, AllToAllVCompleteness) {

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2709,7 +2709,7 @@ cvars:
  - name        : NCCL_ALLREDUCE_ALGO
    type        : enum
    default     : orig
-   choices     : orig, ctran, ctdirect, ctring, ctree, cthierarchical_ring
+   choices     : orig, ctran, ctdirect, ctring, ctree, cthierarchical_ring, ctmdirect
    description : |-
      The algorithm to use for Allreduce communication
      orig - Copy-based algorithm
@@ -2718,6 +2718,7 @@ cvars:
      ctring - ctran-based ring algorithm
      ctree - Ctran-based tree algorithm (Pipes-native)
      cthierarchical_ring - Ctran-based hierarchical ring algorithm (Prims-native): NVL ReduceScatter + inter-node IBGDA ring + NVL AllGather
+     ctmdirect - MCCL-native direct algorithm (Prims-native): NVL ReduceScatter + flat rail-based inter-node IB + NVL AllGather
 
  - name        : NCCL_ALLREDUCE_TYPE
    type        : enum


### PR DESCRIPTION
Summary:

Adds the native MCCL-hosted AllReduce `direct` algorithm as the single-node foundation for the direct stack. The implementation composes the shared NVL direct reduce-scatter and all-gather phases around an intentionally empty inter-node seam; multi-node rail communication is outside this diff.

The algorithm reports the canonical MCCL name `direct`. Until `MCCL_ALGO` is wired into this suite, `NCCL_ALLREDUCE_ALGO=ctmdirect` remains only the legacy compatibility selector, kept distinct from CTRAN `ctdirect` for clean A/B comparison. Explicit unsupported requests return an MCCL error and never fall back to CTRAN.

This diff intentionally contains only the single-node implementation and its selection, correctness, and benchmark scaffolding. The separate multi-node diff is not merged into this change.

Reviewed By: snarayankh

Differential Revision: D112943527


