### PR TITLE
Add Profiler test harness (#3203)

### DIFF
--- a/comms/ctran/profiler/tests/ProfilerHarness.h
+++ b/comms/ctran/profiler/tests/ProfilerHarness.h
@@ -1,0 +1,41 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <vector>
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/profiler/Profiler.h"
+
+namespace ctran::test {
+
+// Owns a zero-initialized CtranComm-sized buffer for constructing a Profiler
+// without pulling in the heavy ctran lib. Safe because the Profiler only reads
+// comm_->logMetaData_, a trivial POD struct.
+struct FakeProfilerComm {
+  // std::vector<char> only guarantees alignof(char), so the reinterpret_cast
+  // below is well-defined only while CtranComm is not over-aligned past the
+  // default-new alignment the allocator actually provides.
+  static_assert(alignof(CtranComm) <= __STDCPP_DEFAULT_NEW_ALIGNMENT__);
+
+  std::vector<char> buffer = std::vector<char>(sizeof(CtranComm), 0);
+
+  CtranComm* get() {
+    return reinterpret_cast<CtranComm*>(buffer.data());
+  }
+};
+
+// Runs one collective's worth of Profiler calls in the algo hot-path order:
+// init -> BUF_REG / ALGO_CTRL / ALGO_DATA phases -> report.
+inline void runOneCollective(Profiler& p, int opCount, int samplingWeight) {
+  p.initForEachColl(opCount, samplingWeight);
+  p.startEvent(ProfilerEvent::BUF_REG);
+  p.endEvent(ProfilerEvent::BUF_REG);
+  p.startEvent(ProfilerEvent::ALGO_CTRL);
+  p.endEvent(ProfilerEvent::ALGO_CTRL);
+  p.startEvent(ProfilerEvent::ALGO_DATA);
+  p.endEvent(ProfilerEvent::ALGO_DATA);
+  p.reportToScuba();
+}
+
+} // namespace ctran::test

--- a/comms/ctran/profiler/tests/ProfilerTest.cc
+++ b/comms/ctran/profiler/tests/ProfilerTest.cc
@@ -3,6 +3,7 @@
 #include "comms/ctran/profiler/Profiler.h"
 #include <gtest/gtest.h>
 #include "comms/ctran/profiler/tests/MockProfilerReporter.h"
+#include "comms/ctran/profiler/tests/ProfilerHarness.h"
 
 using namespace ::testing;
 
@@ -11,11 +12,7 @@ namespace ctran {
 class ProfilerTest : public ::testing::Test {
  public:
   void SetUp() override {
-    // Allocate a zero-initialized CtranComm-sized buffer to avoid pulling in
-    // the heavy ctran_lib dependency. The Profiler only accesses
-    // comm_->logMetaData_ which is a trivial POD struct, so zero-init is safe.
-    commBuf_.resize(sizeof(CtranComm), 0);
-    comm_ = reinterpret_cast<CtranComm*>(commBuf_.data());
+    comm_ = fakeComm_.get();
     profiler_ = std::make_unique<ctran::Profiler>(comm_);
   }
   void TearDown() override {
@@ -27,7 +24,7 @@ class ProfilerTest : public ::testing::Test {
   }
 
  protected:
-  std::vector<char> commBuf_;
+  ctran::test::FakeProfilerComm fakeComm_;
   CtranComm* comm_{nullptr};
   std::unique_ptr<ctran::Profiler> profiler_{nullptr};
 };
@@ -85,14 +82,7 @@ TEST_F(ProfilerTest, testForceTraceOverridesSamplingWeight) {
 TEST_F(ProfilerTest, testDefaultReporterType) {
   // Default constructor should use default reporter (no crash on reportToScuba)
   auto profiler = std::make_unique<ctran::Profiler>(comm_);
-  profiler->initForEachColl(100, 1);
-  profiler->startEvent(ctran::ProfilerEvent::BUF_REG);
-  profiler->endEvent(ctran::ProfilerEvent::BUF_REG);
-  profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL);
-  profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL);
-  profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA);
-  profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA);
-  EXPECT_NO_THROW(profiler->reportToScuba());
+  EXPECT_NO_THROW(ctran::test::runOneCollective(*profiler, 100, 1));
 }
 
 TEST_F(ProfilerTest, testReportToScubaCallsReporter) {


### PR DESCRIPTION
Summary:

Lift the Profiler test fixture into a shared `ProfilerHarness.h` header so profiler tests reuse one setup instead of re-copying the comm-buffer allocation and the init/events/report sequence in every test.

- `FakeProfilerComm` backs a `Profiler` with a zero-initialized `CtranComm`-sized buffer, so a test can construct a `Profiler` without building a real `CtranComm`. Safe because `Profiler` only reads the POD `logMetaData_`.
- `runOneCollective` replays one collective in hot-path order: init -> BUF_REG / ALGO_CTRL / ALGO_DATA -> report.

Reviewed By: rmahidhar

Differential Revision: D110963530


