### PR TITLE
device-emit + pipeline support (#3211)

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherBrucksFF.cu
+++ b/comms/ctran/algos/AllGather/AllGatherBrucksFF.cu
@@ -9,6 +9,7 @@ __global__ void ncclKernelAllGatherCtranBrucks(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {

--- a/comms/ctran/algos/AllGather/AllGatherDirect.cuh
+++ b/comms/ctran/algos/AllGather/AllGatherDirect.cuh
@@ -51,6 +51,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelAllGatherCtranDirect(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/comms/ctran/algos/AllGather/AllGatherRing.cu
+++ b/comms/ctran/algos/AllGather/AllGatherRing.cu
@@ -9,6 +9,7 @@ __global__ void ncclKernelAllGatherCtranRing(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {

--- a/comms/ctran/algos/AllGather/StreamedRd/Impl.cu
+++ b/comms/ctran/algos/AllGather/StreamedRd/Impl.cu
@@ -9,6 +9,7 @@ __global__ void ncclKernelAllGatherCtranStreamedRd(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {

--- a/comms/ctran/algos/AllGatherP/DirectImpl.cu
+++ b/comms/ctran/algos/AllGatherP/DirectImpl.cu
@@ -9,6 +9,7 @@ namespace ctran::allgatherp {
 __global__ void ncclKernelAllGatherPDirect(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
     ctran::device::devLoadAbortFlags(flag, devState);

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -244,8 +244,7 @@ commResult_t AlgoImpl::execPipeline(
   config.numThreads = 1;
   config.args.devState_d = ctran->algo->getDevState();
 
-  // TODO: ensure colltrace can capture the group of operations as single
-  // allgather
+  bool colltraceGroupOpen = false;
 
   if (nNodes > 1) {
     // Submit inter-node Ring pipeline for GPE thread to execute. Skip if single
@@ -266,6 +265,11 @@ commResult_t AlgoImpl::execPipeline(
       //   GPE thread till allgather starts. ncclKernelAllGatherPPipeStart
       //   returns immediately after started GPE, thus the inter-node pipeline
       //   can be overlapped with the following intra-node copies.
+      // Multi-kernel begin: emit the start boundary and open the group; the
+      // PipeEnd kernel below reuses this record and emits the end.
+      config.colltraceEmitStart = true;
+      config.colltraceEmitEnd = false;
+      colltraceGroupOpen = true;
       FB_COMMCHECK(ctran->gpe->submit(
           std::move(opGroup),
           gpeFn,
@@ -274,6 +278,10 @@ commResult_t AlgoImpl::execPipeline(
     } else {
       // - For nLocalRanks == 1 case, ncclKernelAllGatherPRing holds the stream
       //   till GPE thread finishes entire transfer.
+      // Single-kernel collective: emit both boundaries explicitly rather than
+      // relying on the reused `config`'s KernelConfig defaults.
+      config.colltraceEmitStart = true;
+      config.colltraceEmitEnd = true;
       FB_COMMCHECK(ctran->gpe->submit(
           std::move(opGroup),
           gpeFn,
@@ -321,6 +329,11 @@ commResult_t AlgoImpl::execPipeline(
           .pipeSync = resource_.pipeSync,
       };
       config.algoArgs = reinterpret_cast<void*>(&kernArgs);
+      // Interior kernel: emits neither boundary and reuses the begin kernel's
+      // record. Overwrite the values leaked from the reused `config` (set on
+      // the PipeStart submit above).
+      config.colltraceEmitStart = false;
+      config.colltraceEmitEnd = false;
       FB_COMMCHECK(ctran->gpe->submit(
           {},
           nullptr,
@@ -349,6 +362,15 @@ commResult_t AlgoImpl::execPipeline(
         .pipeSync = resource_.pipeSync,
     };
     config.algoArgs = reinterpret_cast<void*>(&kernArgs);
+    if (colltraceGroupOpen) {
+      // Close the record opened by PipeStart.
+      config.colltraceEmitStart = false;
+      config.colltraceEmitEnd = true;
+    } else {
+      // With no PipeStart, PipeEnd bounds the whole collective.
+      config.colltraceEmitStart = true;
+      config.colltraceEmitEnd = true;
+    }
     FB_COMMCHECK(ctran->gpe->submit(
         {},
         nullptr,

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cu
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cu
@@ -19,6 +19,7 @@ namespace ctran::allgatherp {
 __global__ void ncclKernelAllGatherPPipeStart(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
     ctran::device::KernelStartGpeAndExit(f);
@@ -33,6 +34,7 @@ __global__ void ncclKernelAllGatherPPipeSync(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     PipeSyncKernArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   ctran::device::devLoadAbortFlags(flag, devState);
   // wait till GPE thread post the current stepId
@@ -45,6 +47,7 @@ __global__ void ncclKernelAllGatherPPipeSync(
 __global__ void ncclKernelAllGatherPRing(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
     ctran::device::devLoadAbortFlags(flag, devState);
@@ -58,6 +61,7 @@ __global__ void ncclKernelAllGatherPRing(
 __global__ void ncclKernelAllGatherPStreamedRd(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
     ctran::device::devLoadAbortFlags(flag, devState);
@@ -70,9 +74,11 @@ __global__ void ncclKernelAllGatherPStreamedRd(
 // broadcast. Used when nLocalRanks > 1 in allgatherP pipeline algorithm. It is
 // called once at the end.
 __global__ void ncclKernelAllGatherPPipeEnd(
-    ctran::gpe::KernelFlagDev* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     PipeEndKernArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
+
   // Reset sync flag for next GPE->kernel pipeline sync to use
   GpeKernelSyncDev::reset(args.pipeSync, 0);
 
@@ -89,6 +95,7 @@ __global__ void ncclKernelAllGatherPPipeEnd(
 __global__ void ncclKernelAllGatherPSrdPipeStart(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
     ctran::device::KernelStartGpeAndExit(f);
@@ -99,6 +106,7 @@ __global__ void ncclKernelAllGatherPSrdPipeSync(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     PipeSyncKernArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   ctran::device::devLoadAbortFlags(flag, devState);
   // wait till GPE thread post the current stepId
@@ -109,6 +117,7 @@ __global__ void ncclKernelAllGatherPSrdPipeEnd(
     ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     PipeEndKernArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(flag);
   // Reset sync flag for next GPE->kernel pipeline sync to use
   GpeKernelSyncDev::reset(args.pipeSync, 0);
 

--- a/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
@@ -245,6 +245,12 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
   config.numThreads = 1;
   config.args.devState_d = ctran->algo->getDevState();
 
+  // In-kernel colltrace grouping across the Srd multi-kernel collective
+  // (SrdPipeStart..SrdPipeSync..SrdPipeEnd): the begin kernel emits the start
+  // boundary and opens the group; the end kernel emits the end. Set explicitly
+  // per submit because the reused KernelConfig defaults its emit flags to true.
+  bool colltraceGroupOpen = false;
+
   // The streamed GPE path sources every outgoing chunk from recvbuff, including
   // the local rank's own chunk. Keep the copy stream-ordered before PipeStart.
   FB_COMMCHECK(copyToSelf(
@@ -267,12 +273,21 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
     opGroup.push_back(std::move(op));
 
     if (nLocalRanks > 1) {
+      // Multi-kernel begin: emit the start boundary and open the group; the
+      // SrdPipeEnd kernel below reuses this record and emits the end.
+      config.colltraceEmitStart = true;
+      config.colltraceEmitEnd = false;
+      colltraceGroupOpen = true;
       FB_COMMCHECK(ctran->gpe->submit(
           std::move(opGroup),
           gpeFn,
           config,
           reinterpret_cast<void*>(ncclKernelAllGatherPSrdPipeStart)));
     } else {
+      // Single-kernel collective: emit both boundaries explicitly rather than
+      // relying on the reused config's KernelConfig defaults.
+      config.colltraceEmitStart = true;
+      config.colltraceEmitEnd = true;
       FB_COMMCHECK(ctran->gpe->submit(
           std::move(opGroup),
           gpeFn,
@@ -299,6 +314,10 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
           .pipeSync = resource_.pipeSync,
       };
       config.algoArgs = reinterpret_cast<void*>(&syncArgs);
+      // Interior kernel: emits neither boundary and reuses the begin kernel's
+      // record. Overwrite the values leaked from the reused `config`.
+      config.colltraceEmitStart = false;
+      config.colltraceEmitEnd = false;
       FB_COMMCHECK(ctran->gpe->submit(
           {},
           nullptr,
@@ -327,6 +346,17 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
         .pipeSync = resource_.pipeSync,
     };
     config.algoArgs = reinterpret_cast<void*>(&endArgs);
+    if (colltraceGroupOpen) {
+      // Multi-kernel end: close the group opened by SrdPipeStart and emit only
+      // the end boundary.
+      config.colltraceEmitStart = false;
+      config.colltraceEmitEnd = true;
+    } else {
+      // No inter-node begin ran (nNodes == 1), so this end kernel represents
+      // the whole intra-node collective: emit both boundaries.
+      config.colltraceEmitStart = true;
+      config.colltraceEmitEnd = true;
+    }
     FB_COMMCHECK(ctran->gpe->submit(
         {},
         nullptr,

--- a/comms/ctran/algos/AllReduce/AllReduceDirect.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceDirect.cuh
@@ -159,6 +159,7 @@ __global__ void ncclKernelAllReduceCtranDirect(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allreduce::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;

--- a/comms/ctran/algos/AllReduce/AllReduceRing.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cuh
@@ -396,6 +396,7 @@ __global__ void ncclKernelAllReduceCtranRing(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allreduce::ring::KernArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;

--- a/comms/ctran/algos/AllToAll/AllToAll.cc
+++ b/comms/ctran/algos/AllToAll/AllToAll.cc
@@ -324,6 +324,12 @@ commResult_t ctranDeviceAllToAllv(
       ? ncclKernelDeviceAllToAllvPipes<PipeProtocol::LL128>
       : ncclKernelDeviceAllToAllvPipes<PipeProtocol::Simple>;
 
+  // This NVLink-only device kernel does not use the GPE flag mechanism and does
+  // not construct a ColltraceEventScope, so do not arm an in-kernel colltrace
+  // record for it — otherwise the reused config's default emit flags would
+  // create a record that never receives its start/end and stays in-flight.
+  config.colltraceEmitStart = false;
+  config.colltraceEmitEnd = false;
   FB_COMMCHECK(comm->ctran_->gpe->submit(
       std::move(opGroup), nullptr, config, reinterpret_cast<void*>(kernel)));
 

--- a/comms/ctran/algos/AllToAll/AllToAll.cuh
+++ b/comms/ctran/algos/AllToAll/AllToAll.cuh
@@ -109,6 +109,7 @@ __global__ void ncclKernelAllToAll(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::alltoall::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/comms/ctran/algos/AllToAll/AllToAllPImpl.cu
+++ b/comms/ctran/algos/AllToAll/AllToAllPImpl.cu
@@ -17,6 +17,7 @@ namespace ctran::alltoallp {
 __global__ void ncclKernelAllToAllPDirect(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
     ctran::device::devLoadAbortFlags(flag, devState);

--- a/comms/ctran/algos/AllToAll/AllToAllv.cuh
+++ b/comms/ctran/algos/AllToAll/AllToAllv.cuh
@@ -139,6 +139,7 @@ __global__ void ncclKernelAllToAllv(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::alltoallv::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/comms/ctran/algos/Broadcast/Broadcast.cu
+++ b/comms/ctran/algos/Broadcast/Broadcast.cu
@@ -20,6 +20,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelBroadcast(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::broadcast::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/comms/ctran/algos/RMA/Get.cu
+++ b/comms/ctran/algos/RMA/Get.cu
@@ -8,6 +8,7 @@
 __global__ void ncclKernelGet(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {

--- a/comms/ctran/algos/RMA/PutSignal.cu
+++ b/comms/ctran/algos/RMA/PutSignal.cu
@@ -80,6 +80,7 @@ __global__ void ncclKernelPutSignal(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     CtranKernelPutSignalArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
@@ -106,6 +107,7 @@ __global__ void ncclKernelPutSignal(
 __global__ void ncclKernelPut(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
@@ -119,6 +121,7 @@ __global__ void ncclKernelWaitSignal(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     CtranKernelWaitSignalArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
@@ -147,6 +150,7 @@ __global__ void ncclKernelSignal(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     CtranKernelSignalArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterDirect.cuh
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterDirect.cuh
@@ -131,6 +131,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelReduceScatterDirect(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::reducescatter::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   // TODO(T243528798): remove this preload of devstate by splitting h2d/d2h
   // channels.

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterRHD.cuh
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterRHD.cuh
@@ -18,6 +18,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelReduceScatterRHD(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::reducescatter::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterRing.cuh
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterRing.cuh
@@ -18,6 +18,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelReduceScatterRing(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::reducescatter::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/comms/ctran/algos/SendRecv/SendRecv.cu
+++ b/comms/ctran/algos/SendRecv/SendRecv.cu
@@ -19,6 +19,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelSend(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::sendrecv::KernelSendArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
@@ -50,6 +51,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelRecv(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::sendrecv::KernelRecvArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
@@ -91,6 +93,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelSendRecv(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::sendrecv::KernelSendRecvArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;

--- a/comms/ctran/algos/SendRecv/SendRecvP2p.cu
+++ b/comms/ctran/algos/SendRecv/SendRecvP2p.cu
@@ -78,6 +78,7 @@ __global__ __launch_bounds__(512, 1) void ncclKernelSendRecvP2p(
     CtranAlgoDeviceState* devState, // TODO: this is not needed for now, but
                                     // maybe needed for fault-tolerance
     ctran::sendrecv::KernArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/comms/ctran/algos/common/ColltraceEventScope.cuh
+++ b/comms/ctran/algos/common/ColltraceEventScope.cuh
@@ -1,0 +1,46 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comms/ctran/algos/common/GpeRing.h" // ctran::gpe::KernelFlagDev
+#include "comms/utils/colltrace/ColltraceDeviceEventScope.cuh"
+
+// In-kernel colltrace timestamp emission for ctran GPE kernels. The generic
+// device writer (single-writer election + RAII start/end) is shared with the
+// baseline ncclx kernels in ColltraceDeviceEventScope.cuh; this
+// header only adds the ctran-specific convenience of arming directly from a
+// KernelFlagDev so call sites don't repeat the null-check ternary.
+
+namespace ctran::device {
+
+// Re-expose the shared emitter under the ctran::device namespace that existing
+// ctran call sites use.
+using meta::comms::colltrace::ColltraceEmitEvent;
+
+struct ColltraceEventScope : meta::comms::colltrace::ColltraceDeviceEventScope {
+  __forceinline__ __device__ explicit ColltraceEventScope(
+      meta::comms::colltrace::ColltraceDeviceHandle handle,
+      unsigned int startWriterThreadIdxX = 0,
+      unsigned int endWriterThreadIdxX = 0)
+      : meta::comms::colltrace::ColltraceDeviceEventScope(
+            handle,
+            startWriterThreadIdxX,
+            endWriterThreadIdxX) {}
+
+  // Convenience overload: take the kernel flag directly. A null flag yields an
+  // unarmed (no-op) scope. startWriterThreadIdxX / endWriterThreadIdxX pick the
+  // elected writer lane for the start (ctor) and end (dtor) emits; both default
+  // to thread 0. Keep the end lane at 0 in GPE kernels where only thread 0
+  // waits for completion (see the base ColltraceEventScope note).
+  __forceinline__ __device__ explicit ColltraceEventScope(
+      const ctran::gpe::KernelFlagDev* f,
+      unsigned int startWriterThreadIdxX = 0,
+      unsigned int endWriterThreadIdxX = 0)
+      : meta::comms::colltrace::ColltraceDeviceEventScope(
+            f ? f->colltraceHdr
+              : meta::comms::colltrace::ColltraceDeviceHandle{},
+            startWriterThreadIdxX,
+            endWriterThreadIdxX) {}
+};
+
+} // namespace ctran::device

--- a/comms/ctran/algos/common/GpeKernelDev.cuh
+++ b/comms/ctran/algos/common/GpeKernelDev.cuh
@@ -5,6 +5,7 @@
 #include "comms/common/AtomicUtils.cuh"
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/ctran/algos/DevShmState.cuh"
+#include "comms/ctran/algos/common/ColltraceEventScope.cuh"
 #include "comms/ctran/algos/common/GpeKernel.h"
 #include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/utils/DevUtils.cuh"
@@ -28,15 +29,22 @@ static inline __device__ void devLoadAbortFlags(
 }
 
 // Publish this launch's cmd id to the device ring in GPU execution order.
-// Single-writer election (block 0, thread 0); no-op when not armed
-// (hdr.enabled == 0). The GPE worker consumes the ring to order started cmds.
-// The ring write is the HRDWRingBuffer System-scope 128b atomic path.
+// Single-writer election (the one thread with all block and thread indices zero
+// across x/y/z, so a 2D/3D launch still elects exactly one writer); no-op when
+// not armed (hdr.enabled == 0). The GPE worker consumes the ring to order
+// started cmds. The ring write is the HRDWRingBuffer System-scope 128b atomic
+// path.
 static __forceinline__ __device__ void KernelPublishGpeRing(
     ctran::gpe::GpeKernelFlagHeader hdr) {
-  if (blockIdx.x == 0 && threadIdx.x == 0 && hdr.enabled) {
+  if (blockIdx.x == 0 && blockIdx.y == 0 && blockIdx.z == 0 &&
+      threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0 && hdr.enabled) {
     hdr.ring.write(hdr.cmdId);
   }
 }
+
+// ColltraceEmitEvent / ColltraceEventScope moved to ColltraceEventScope.cuh
+// (included above); kept accessible here since kernels include
+// GpeKernelDev.cuh.
 
 // Kernel start prologue: publish this cmd's id to the ring (block 0 only, no-op
 // when not armed), then signal the GPE worker that block `bId` has started. The

--- a/comms/ctran/algos/common/GpeRing.h
+++ b/comms/ctran/algos/common/GpeRing.h
@@ -3,9 +3,11 @@
 #ifndef CTRAN_GPE_RING_H_
 #define CTRAN_GPE_RING_H_
 
+#include <cstddef>
 #include <cstdint>
 
 #include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
 #include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
 namespace ctran::gpe {
@@ -41,19 +43,39 @@ using GpeRingHandle = hrdw_ring_buffer::
 // KernelStartGpe prologue reads it via KernelFlagDev::gpeHdr and publishes
 // cmdId to the ring.
 struct GpeKernelFlagHeader {
-  GpeRingHandle ring{};
+  // NOTE: the scalar fields are intentionally placed BEFORE the embedded ring
+  // handle. That handle uses [[no_unique_address]] empty members; when it is
+  // the first member, nvcc computes a different device offset for a following
+  // scalar than the host does (placing it past the end of the object), so a
+  // kernel reads cmdId/enabled back as garbage -- e.g. a nonzero `enabled` on
+  // an unarmed header, which drives KernelPublishGpeRing to write to a null
+  // ring and hang/crash the kernel. Keeping the scalars in the head bytes keeps
+  // the host and device offsets in agreement. Same workaround as
+  // meta::comms::colltrace::ColltraceDeviceHandle.
   GpeCmdId cmdId{0};
   uint32_t enabled{0};
+  GpeRingHandle ring{};
 };
+static_assert(
+    offsetof(GpeKernelFlagHeader, cmdId) <
+            offsetof(GpeKernelFlagHeader, ring) &&
+        offsetof(GpeKernelFlagHeader, enabled) <
+            offsetof(GpeKernelFlagHeader, ring),
+    "GpeKernelFlagHeader scalars (cmdId/enabled) must precede the ring handle "
+    "to keep host/device offsetof in agreement; see the note above.");
 
 // Device-facing view of a per-cmd kernel flag object: the per-block start/stop
-// flags plus the ring header, laid out in pinned host memory. Every GPE kernel
-// takes a KernelFlagDev* as its first argument and reads gpeHdr directly — no
-// pointer-offset recovery. KernelFlagItem (host) embeds this as its first
-// member, so &kernelFlag->dev is the pointer handed to the kernel.
+// flags plus the ring headers, laid out in pinned host memory. Every GPE kernel
+// takes a KernelFlagDev* as its first argument and reads gpeHdr/colltraceHdr
+// directly — no pointer-offset recovery. KernelFlagItem (host) embeds this as
+// its first member, so &kernelFlag->dev is the pointer handed to the kernel.
+// colltraceHdr is armed host-side at submit() for the kernels that bound a
+// logical collective; a default (null-ring) handle means unarmed, so the
+// in-kernel emit no-ops. See meta::comms::colltrace::ColltraceDeviceHandle.
 struct KernelFlagDev {
   volatile int flag_[CTRAN_ALGO_MAX_THREAD_BLOCKS];
   GpeKernelFlagHeader gpeHdr{};
+  meta::comms::colltrace::ColltraceDeviceHandle colltraceHdr{};
 };
 
 } // namespace ctran::gpe

--- a/comms/ctran/algos/common/tests/ColltraceEventScopeTest.cc
+++ b/comms/ctran/algos/common/tests/ColltraceEventScopeTest.cc
@@ -1,0 +1,96 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Unit test for ColltraceEventScope: the RAII scope must emit exactly the armed
+// start/end colltrace events into the HRDW ring, elected to a single writer
+// regardless of block/thread count, and be a no-op when unarmed.
+
+#include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
+#include "comms/utils/colltrace/GraphCollTraceEvent.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
+
+using meta::comms::colltrace::ColltraceDeviceHandle;
+using meta::comms::colltrace::GraphCollTraceEvent;
+using meta::comms::colltrace::GraphCollTracePhase;
+
+// Defined in ColltraceEventScopeTest.cu.
+void launchColltraceScopeKernel(
+    const ColltraceDeviceHandle& handle,
+    int blocks,
+    int threads,
+    cudaStream_t stream);
+
+namespace {
+
+// Runs one ColltraceEventScope with the given emit flags across blocks*threads
+// threads, then returns the events written to the ring in write order.
+std::vector<GraphCollTraceEvent> runScope(
+    bool emitStart,
+    bool emitEnd,
+    uint32_t collId,
+    int blocks,
+    int threads) {
+  hrdw_ring_buffer::HRDWRingBuffer<GraphCollTraceEvent> buf(/*capacity=*/64);
+  EXPECT_TRUE(buf.valid());
+
+  ColltraceDeviceHandle handle{};
+  handle.collId = collId;
+  handle.emitStart = emitStart;
+  handle.emitEnd = emitEnd;
+  handle.ring = buf.deviceHandle();
+
+  cudaStream_t stream = nullptr;
+  EXPECT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+  launchColltraceScopeKernel(handle, blocks, threads, stream);
+  EXPECT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  EXPECT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+
+  std::vector<GraphCollTraceEvent> events;
+  hrdw_ring_buffer::HRDWRingBufferReader<GraphCollTraceEvent> reader(buf);
+  reader.poll([&](const auto& entry, uint64_t /*slot*/) {
+    events.push_back(entry.data);
+  });
+  return events;
+}
+
+TEST(ColltraceEventScopeTest, EmitsStartThenEndSingleWriter) {
+  // 64 threads all construct the scope, but the emit is elected to one writer,
+  // so exactly one start and one end land in the ring.
+  auto events =
+      runScope(/*emitStart=*/true, /*emitEnd=*/true, /*collId=*/42, 2, 32);
+  ASSERT_EQ(events.size(), 2u);
+  EXPECT_EQ(events[0].phase, GraphCollTracePhase::kStart);
+  EXPECT_EQ(events[0].collId, 42u);
+  EXPECT_EQ(events[1].phase, GraphCollTracePhase::kEnd);
+  EXPECT_EQ(events[1].collId, 42u);
+}
+
+TEST(ColltraceEventScopeTest, StartOnly) {
+  auto events =
+      runScope(/*emitStart=*/true, /*emitEnd=*/false, /*collId=*/7, 1, 1);
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].phase, GraphCollTracePhase::kStart);
+  EXPECT_EQ(events[0].collId, 7u);
+}
+
+TEST(ColltraceEventScopeTest, EndOnly) {
+  auto events =
+      runScope(/*emitStart=*/false, /*emitEnd=*/true, /*collId=*/8, 1, 1);
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].phase, GraphCollTracePhase::kEnd);
+  EXPECT_EQ(events[0].collId, 8u);
+}
+
+TEST(ColltraceEventScopeTest, UnarmedIsNoOp) {
+  auto events =
+      runScope(/*emitStart=*/false, /*emitEnd=*/false, /*collId=*/9, 4, 64);
+  EXPECT_TRUE(events.empty());
+}
+
+} // namespace

--- a/comms/ctran/algos/common/tests/ColltraceEventScopeTest.cu
+++ b/comms/ctran/algos/common/tests/ColltraceEventScopeTest.cu
@@ -1,0 +1,22 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda_runtime.h>
+
+#include "comms/ctran/algos/common/ColltraceEventScope.cuh"
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
+
+// Every thread constructs the scope; ColltraceEventScope elects a single writer
+// (block 0, thread 0) internally, emitting the start on construction and the
+// end on destruction into the armed handle's ring.
+__global__ void colltraceScopeKernel(
+    meta::comms::colltrace::ColltraceDeviceHandle handle) {
+  ctran::device::ColltraceEventScope scope(handle);
+}
+
+void launchColltraceScopeKernel(
+    const meta::comms::colltrace::ColltraceDeviceHandle& handle,
+    int blocks,
+    int threads,
+    cudaStream_t stream) {
+  colltraceScopeKernel<<<blocks, threads, 0, stream>>>(handle);
+}

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -315,6 +315,18 @@ struct KernelConfig {
   // launched on a single GPE thread.
   bool canConcurrent{false};
 
+  // In-kernel colltrace: on the graph-capture path (sm_90+), the collective
+  // kernel writes its own start/end timestamps into the colltrace ring so one
+  // logical collective maps to one CollTrace record. A single-kernel collective
+  // emits both boundaries (the defaults). A multi-kernel collective (e.g. the
+  // AllGatherP pipeline) sets these per kernel: the begin kernel emits the
+  // start and opens the record, interior kernels emit neither (and reuse the
+  // record), and the end kernel emits the end. A kernel owns the record iff it
+  // emits the start; interior/end kernels reuse the begin kernel's. Off the
+  // in-kernel path (eager, pre-sm_90, HIP) these are ignored.
+  bool colltraceEmitStart{true};
+  bool colltraceEmitEnd{true};
+
  public:
   KernelConfig(
       enum KernelType type,

--- a/comms/ctran/gpe/CtranGpeColltrace.h
+++ b/comms/ctran/gpe/CtranGpeColltrace.h
@@ -1,0 +1,105 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <mutex>
+
+#include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
+
+#include "comms/ctran/algos/common/GpeRing.h" // ctran::gpe::KernelFlagDev
+#include "comms/utils/colltrace/CollTraceHandle.h" // ICollTraceHandle
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h" // ColltraceDeviceHandle
+
+namespace ctran::gpe {
+
+// In-kernel colltrace (the collective kernel publishing its own start/end
+// timestamps into the colltrace ring) requires sm_90+ for the ring's 128b
+// atomic device write — the same hardware requirement as the GPE device ring,
+// but determined independently of it. The compute capability is queried once
+// per process (call_once); NCCL pins one device per process, so a single cached
+// value is correct.
+inline bool inKernelColltraceSupported() {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_HCC__)
+  return false;
+#else
+  static std::once_flag onceFlag;
+  static int ccMajor = -1; // -1 = unknown/query failed
+  std::call_once(onceFlag, [] {
+    int dev = 0;
+    int major = 0;
+    if (cudaGetDevice(&dev) == cudaSuccess &&
+        cudaDeviceGetAttribute(
+            &major, cudaDevAttrComputeCapabilityMajor, dev) == cudaSuccess) {
+      ccMajor = major;
+    }
+  });
+  return ccMajor >= 9;
+#endif
+}
+
+// Arm a kernel flag for in-kernel colltrace start/end emission and maintain the
+// cross-submit grouping state (`pendingGroup`) for multi-kernel collectives.
+//
+// A multi-kernel collective (e.g. AllGatherP's PipeStart..PipeSync..PipeEnd)
+// records one CollTrace event: its Begin kernel writes the start and stashes
+// the device handle (ring + collId) in `pendingGroup`, and its End kernel
+// reuses that handle to write the end. A single-kernel collective arms both
+// boundaries on the same kernel; interior kernels emit neither and leave
+// `pendingGroup` untouched.
+//
+// Precondition: the caller has already gated on inKernelColltraceSupported()
+// and a live kernel flag. `colltraceHandle` may be null (no record was
+// created).
+inline void armInKernelColltrace(
+    meta::comms::colltrace::ColltraceDeviceHandle& pendingGroup,
+    KernelFlagDev& flagDev,
+    meta::comms::colltrace::ICollTraceHandle* colltraceHandle,
+    bool emitStart,
+    bool emitEnd) {
+  if (emitStart) {
+    // Begin (or single-kernel) collective: this kernel opens the record and
+    // writes the start. Drop any pending group left behind by a Begin whose End
+    // was never submitted (early-return, exception, or a future non-contiguous
+    // algo path), so a stale collId can never be consumed by a later unrelated
+    // End.
+    pendingGroup = {};
+    auto devHandle = colltraceHandle
+        ? colltraceHandle->getColltraceDeviceHandle()
+        : meta::comms::colltrace::ColltraceDeviceHandle{};
+    if (devHandle.valid()) {
+      // A single-kernel collective also emits the end here (emitEnd == true); a
+      // multi-kernel begin hands the end to the group's End kernel below.
+      devHandle.emitStart = true;
+      devHandle.emitEnd = emitEnd;
+      flagDev.colltraceHdr = devHandle;
+      // Tell this collective's graph wait event it self-emits, so it skips the
+      // host-launched timestamp path (the two must never both write the ring).
+      // TEMPORARY: the host path is deleted at the in-kernel cutover.
+      colltraceHandle->markInKernelEmit();
+      if (!emitEnd) {
+        // Multi-kernel begin: the End kernel reuses the same ring/collId.
+        pendingGroup = devHandle;
+        pendingGroup.emitStart = false;
+        pendingGroup.emitEnd = true;
+      }
+    }
+  } else if (emitEnd) {
+    // End kernel of a multi-kernel collective: reuse the ring/collId stashed by
+    // the Begin and emit only the end.
+    if (pendingGroup.valid()) {
+      flagDev.colltraceHdr = pendingGroup;
+      // TEMPORARY (removed at the in-kernel cutover): keep the host path off
+      // for the End kernel's wait event too, if it has one.
+      if (colltraceHandle) {
+        colltraceHandle->markInKernelEmit();
+      }
+    }
+    // The group is closed once its End is armed; clear it so a later unrelated
+    // End (a Begin whose End was dropped, then this collective's End) can never
+    // consume this collective's stale collId.
+    pendingGroup = {};
+  }
+  // Otherwise (interior kernel: no emit) there is nothing to arm.
+}
+
+} // namespace ctran::gpe

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <atomic>
 #include <chrono>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 
@@ -12,6 +14,7 @@
 #include "comms/ctran/colltrace/MapperTrace.h"
 #include "comms/ctran/gpe/CtranChecksum.h"
 #include "comms/ctran/gpe/CtranGpe.h"
+#include "comms/ctran/gpe/CtranGpeColltrace.h"
 #include "comms/ctran/gpe/CtranGpeDev.h"
 #include "comms/ctran/gpe/CtranGpeImpl.h"
 #include "comms/ctran/mapper/CtranMapper.h"
@@ -22,6 +25,7 @@
 #include "comms/ctran/utils/ExtUtils.h"
 
 #include "comms/utils/colltrace/CollRecord.h"
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 
@@ -146,6 +150,20 @@ commResult_t CtranGpe::Impl::submit(
           kernelConfig.stream, streamCaptureInfo));
   bool isCapturing = streamCaptureInfo.status == cudaStreamCaptureStatusActive;
 
+  // Only graph tracing on sm_90+ creates the ring consumed by the kernel.
+  const bool useInKernelColltrace = ctran::gpe::inKernelColltraceSupported() &&
+      isCapturing && NCCL_COLLTRACE_TRACE_CUDA_GRAPH;
+  // Single-kernel collectives emit both boundaries (the KernelConfig defaults);
+  // multi-kernel collectives (the AllGatherP pipeline) set these per kernel.
+  const bool colltraceEmitStart =
+      useInKernelColltrace && kernelConfig.colltraceEmitStart;
+  const bool colltraceEmitEnd =
+      useInKernelColltrace && kernelConfig.colltraceEmitEnd;
+  // Multi-kernel graph collectives create one record at their start boundary.
+  const bool colltraceCreatesRecord = !isCapturing || colltraceEmitStart;
+  // Boundary-only kernels still need a flag to carry colltraceHdr.
+  const bool colltraceNeedsFlag = colltraceEmitStart || colltraceEmitEnd;
+
   // For eager (non-capture) submits with empty opGroup but a
   // postKernelCleanup, we still need a cmd + kernelFlag so the GPE thread
   // can synchronize with the kernel before running cleanup. During graph
@@ -153,7 +171,13 @@ commResult_t CtranGpe::Impl::submit(
   // retainUserObject, avoiding host-node overhead.
   bool needsKernelFlag = !opGroup.empty() ||
       kernelConfig.unpackPool != nullptr ||
-      (kernelConfig.postKernelCleanup && !isCapturing);
+      (kernelConfig.postKernelCleanup && !isCapturing) || colltraceNeedsFlag;
+
+  // A boundary-only kernel never signals KERNEL_STARTED; retain its flag on
+  // the graph instead of routing it through the GPE worker.
+  const bool colltraceOnlyFlag = isCapturing && needsKernelFlag &&
+      opGroup.empty() && func == nullptr &&
+      kernelConfig.unpackPool == nullptr && !kernelConfig.postKernelCleanup;
 
   auto kernelFlag = needsKernelFlag ? this->kernelFlagPool->pop() : nullptr;
   ctran::gpe::KernelFlagDev* flagDev = nullptr;
@@ -196,8 +220,23 @@ commResult_t CtranGpe::Impl::submit(
   }
 
   // Record CollTrace event. Must be called before moving opGroup to cmd
-  auto colltraceHandle = meta::comms::colltrace::getCollTraceHandle(
-      comm, opGroup, kernelConfig, ifchecksum);
+  std::shared_ptr<meta::comms::colltrace::ICollTraceHandle> colltraceHandle =
+      colltraceCreatesRecord ? meta::comms::colltrace::getCollTraceHandle(
+                                   comm, opGroup, kernelConfig, ifchecksum)
+                             : nullptr;
+
+  // Arm the collective kernel to publish its own start/end timestamps into the
+  // colltrace ring, replacing the host-launched timestamp kernels for the
+  // grouped/self-timing pipeline collective. The header defaults to disabled
+  // (cleared on flag recycle), so kernels that emit nothing fall through.
+  if (useInKernelColltrace && kernelFlag != nullptr) {
+    ctran::gpe::armInKernelColltrace(
+        pendingColltraceGroup_,
+        kernelFlag->dev,
+        colltraceHandle.get(),
+        colltraceEmitStart,
+        colltraceEmitEnd);
+  }
 
   cudaStream_t launchStream = kernelConfig.stream;
   std::optional<ctran::algos::OrderedWorkStreamGuard::Scope> wsScope;
@@ -221,7 +260,7 @@ commResult_t CtranGpe::Impl::submit(
   size_t opGroupSize = 0;
   // Enqueue op to gpeThread if any op is appended, or if there is a
   // postKernelCleanup that needs to run after the kernel completes.
-  if (needsKernelFlag) {
+  if (needsKernelFlag && !colltraceOnlyFlag) {
     // record opGroup size before moving the object
     opGroupSize = opGroup.size();
     class CtranGpeCmd* cmd = new class CtranGpeCmd;
@@ -286,6 +325,26 @@ commResult_t CtranGpe::Impl::submit(
     }
   } else {
     FB_COMMCHECK(maybeAcquireWorkStreamScope());
+  }
+
+  // Colltrace-only graph flag: no GPE cmd is created (the kernel does no GPE
+  // work and never signals the flag), so retain the armed flag on the graph and
+  // reclaim it on destroy — clearPersistent()+reset() makes it reclaimable by
+  // the pool, mirroring what ~CtranGpeCmd does for the cmd path.
+  if (colltraceOnlyFlag) {
+    kernelFlag->setPersistent();
+    FB_COMMCHECKGOTO(
+        utils::cudagraph::retainUserObject(
+            /*obj=*/kernelFlag,
+            /*destroyCallback=*/
+            [](void* p) {
+              auto* f = static_cast<KernelFlagItem*>(p);
+              f->clearPersistent();
+              f->reset();
+            },
+            streamCaptureInfo),
+        res,
+        fail);
   }
 
   // For the no-cmd path during graph capture, retain cleanup on the graph.
@@ -474,6 +533,10 @@ fail:
   if (kernelFlag != nullptr) {
     kernelFlag->reset();
   }
+  // A failure after arming a Begin would leave an open colltrace group whose
+  // End never submits; clear it so a later collective's End can't consume this
+  // collective's stale collId.
+  pendingColltraceGroup_ = {};
   return res;
 }
 
@@ -574,6 +637,9 @@ void CtranGpe::Impl::start() {
 }
 
 void CtranGpe::Impl::terminate() {
+  // Let the worker's kernel-start waits (gpeThreadFn) bail out so a cmd whose
+  // kernel never launches cannot block join() forever.
+  terminating_.store(true, std::memory_order_relaxed);
   class CtranGpeCmd* cmd = new class CtranGpeCmd;
   cmd->type = CtranGpeCmd::TypeEnum::TERMINATE;
 
@@ -733,9 +799,11 @@ void CtranGpe::Impl::gpeThreadFn() {
         volatile int* flag_d = kernelFlag->dev.flag_;
         // Here we check just flag_d[0]. This is ok because Kernel Start signal
         // is only used for tracing purposes. Before the flags are freed below
-        // with reset, all block flags are checked.
+        // with reset, all block flags are checked. Bail out on terminate() so a
+        // cmd whose kernel never launches cannot wedge teardown.
         while (flag_d[0] != KERNEL_STARTED &&
-               flag_d[0] != KERNEL_STARTED_AND_EXIT) {
+               flag_d[0] != KERNEL_STARTED_AND_EXIT &&
+               !terminating_.load(std::memory_order_relaxed)) {
           std::this_thread::yield();
         }
       }

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -3,6 +3,7 @@
 #ifndef CTRAN_GPE_IMPL_H_
 #define CTRAN_GPE_IMPL_H_
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstddef>
@@ -41,9 +42,10 @@ struct alignas(128) KernelFlagItem {
     for (int i = 0; i < numGroups_; i++) {
       dev.flag_[i] = KERNEL_UNSET;
     }
-    // Clear the full ring header so enabled==1 always implies ring/cmdId are
-    // current; submit() re-arms it per-cmd on the ring path.
+    // Clear the full ring + colltrace headers (not just enabled) so a stale
+    // ring/cmdId/collId can never be published; submit() re-arms them per-cmd.
     dev.gpeHdr = {};
+    dev.colltraceHdr = {};
   }
 
   bool inUse() {
@@ -63,9 +65,10 @@ struct alignas(128) KernelFlagItem {
       dev.flag_[i] = KERNEL_SCHEDULED;
     }
     numGroups_ = 1;
-    // Clear the full ring header (not just enabled) so a stale ring/cmdId can
-    // never be published; submit() re-arms it per-cmd on the ring path.
+    // Clear the full ring + colltrace headers (not just enabled) so a stale
+    // ring/cmdId/collId can never be published; submit() re-arms them per-cmd.
     dev.gpeHdr = {};
+    dev.colltraceHdr = {};
   }
 
   bool testFlagAllGroups(int flag) {
@@ -282,6 +285,9 @@ class CtranGpe::Impl {
   folly::Synchronized<CmdQueue, std::mutex> cmdQueue_;
   std::condition_variable cmdQueueCv_;
   std::thread thread_;
+  // Set by terminate() so the worker's kernel-start waits bail out during
+  // teardown instead of blocking forever on a cmd whose kernel never launches.
+  std::atomic<bool> terminating_{false};
   ctran::algos::OrderedWorkStreamGuard ws_;
 
   // Device-ring dispatch state (NCCL_CTRAN_GPE_DEVICE_RING). Ring + reader are
@@ -291,6 +297,16 @@ class CtranGpe::Impl {
   std::unique_ptr<ctran::gpe::GpeRingReader> deviceRingReader_;
   std::queue<CtranGpeCmd*> ringPending_;
   GpeDeviceRingCmdRegistry deviceRingCmdRegistry_;
+
+  // In-kernel colltrace grouping: a multi-submit collective (e.g. AllGatherP's
+  // PipeStart..PipeSync..PipeEnd) records one CollTrace event whose start is
+  // written by the group's Begin kernel and end by its End kernel. Begin
+  // stashes the device handle (ring + collId) here so the following End submit
+  // arms its kernel with the same collId. A default (null-ring, !valid())
+  // handle means no group is open. Written and read only on the submit
+  // (capture) thread, and a group's submits are always contiguous, so a single
+  // pending slot suffices.
+  meta::comms::colltrace::ColltraceDeviceHandle pendingColltraceGroup_{};
 
   // Main function called by the GPE thread. It waits and handles any  commands
   // submitted to cmdQueue until the TERMINATE command is received.

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphColltraceTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphColltraceTest.cc
@@ -1,0 +1,290 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <functional>
+#include <string>
+
+#include <folly/json.h>
+
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
+#include "comms/ctran/algos/ReduceScatter/ReduceScatterImpl.h"
+#include "comms/ctran/regcache/RegCache.h"
+#include "comms/ctran/tests/cudagraph/CtranCudaGraphTestBase.h"
+#include "comms/utils/CudaRAII.h"
+
+namespace {
+
+// Exercises the in-kernel colltrace emit path end-to-end: a real collective is
+// captured into a CUDA graph and replayed, and we assert colltrace produced
+// exactly one start/end pair per replay. This is the coverage the synthetic
+// graph_colltrace_ut misses -- that unit test drives the ring directly, so it
+// never catches an algo whose end event is not armed (which leaves the
+// collective stuck mid-flight and hangs the drain).
+class CtranCudaGraphColltraceTest : public CtranCudaGraphTestBase {
+ protected:
+  void SetUp() override {
+    // Enable graph-mode colltrace tracing. In-kernel emit is the only graph
+    // timestamp path and is gated on sm_90+ in the GPE; on older archs
+    // graph-captured collectives are not colltrace-timestamped.
+    CtranDistTestFixture::SetUp(
+        ctran::CtranEnvs{
+            {"NCCL_COLLTRACE", "trace"},
+            {"NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "true"},
+            // In-kernel device write is off by default until the cutover diff,
+            // so enable it explicitly to exercise the in-kernel colltrace path.
+            {"NCCLX_COLLTRACE_DEVICE_WRITE", "true"},
+        });
+  }
+
+  // Warms the collective eagerly (establishes transport connections and gives a
+  // stable colltrace baseline), then captures it once and replays it
+  // `numReplays` times under one CUDA graph on a single stream. Asserts that:
+  //   - colltrace fully drains (nothing left in CT_currentColls) -- a missing
+  //     end event would leave a collective mid-flight and time out the drain;
+  //   - exactly one past record is produced per replay;
+  //   - every new record names the expected collective.
+  void runGraphColltraceCheck(
+      CtranComm* comm,
+      int numReplays,
+      const std::string& expectedOpName,
+      const std::function<void(cudaStream_t)>& launch) {
+    meta::comms::CudaStream stream(cudaStreamNonBlocking);
+
+    auto flushAndDump = [&]() {
+      if (comm->colltraceNew_ != nullptr) {
+        comm->colltraceNew_->waitFlush(comm->colltraceNew_->requestFlush());
+      }
+      return ctran::waitForCollTraceDrain(comm);
+    };
+
+    // Eager warmup + baseline.
+    launch(stream.get());
+    CUDACHECK_TEST(cudaStreamSynchronize(stream.get()));
+    auto baseline = flushAndDump();
+    ASSERT_EQ(baseline["CT_currentColls"], "[]") << "warmup collective never "
+                                                    "drained";
+    const int baseCount = folly::parseJson(baseline["CT_pastColls"]).size();
+
+    // Capture the collective once.
+    cudaGraph_t graph = nullptr;
+    cudaGraphExec_t graphExec = nullptr;
+    ASSERT_EQ(
+        cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeRelaxed),
+        cudaSuccess);
+    launch(stream.get());
+    ASSERT_EQ(cudaStreamEndCapture(stream.get(), &graph), cudaSuccess);
+    ASSERT_NE(graph, nullptr);
+    ASSERT_EQ(
+        cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0),
+        cudaSuccess);
+
+    // Replay N times on one stream so completions are ordered.
+    for (int i = 0; i < numReplays; ++i) {
+      ASSERT_EQ(cudaGraphLaunch(graphExec, stream.get()), cudaSuccess);
+    }
+    ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+    auto dump = flushAndDump();
+    EXPECT_EQ(dump["CT_currentColls"], "[]")
+        << "a replayed collective never completed -- missing colltrace end "
+           "event for "
+        << expectedOpName;
+    EXPECT_EQ(dump["CT_pendingColls"], "[]");
+
+    auto past = folly::parseJson(dump["CT_pastColls"]);
+    EXPECT_EQ(static_cast<int>(past.size()) - baseCount, numReplays)
+        << "expected exactly one colltrace record per graph replay";
+    for (int i = baseCount; i < static_cast<int>(past.size()); ++i) {
+      EXPECT_EQ(past[i]["opName"].asString(), expectedOpName);
+    }
+
+    CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+    CUDACHECK_TEST(cudaGraphDestroy(graph));
+    waitAndVerifyGpeClean(comm);
+  }
+};
+
+constexpr int kNumReplays = 5;
+constexpr size_t kCount = 1024;
+
+TEST_F(CtranCudaGraphColltraceTest, AllGatherOneRecordPerReplay) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+  const auto algo = NCCL_ALLGATHER_ALGO::ctran;
+  if (!ctranAllGatherSupport(comm.get(), algo)) {
+    GTEST_SKIP() << "AllGather not supported on this topology";
+  }
+
+  ctran::TestDeviceBuffer send(kCount * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(kCount * numRanks * sizeof(int32_t));
+  fillSendBuf(send.get(), kCount, globalRank);
+
+  runGraphColltraceCheck(
+      comm.get(), kNumReplays, "AllGather", [&](cudaStream_t s) {
+        ASSERT_EQ(
+            ctranAllGather(
+                send.get(), recv.get(), kCount, commInt32, comm.get(), s, algo),
+            commSuccess);
+      });
+}
+
+TEST_F(CtranCudaGraphColltraceTest, AllReduceOneRecordPerReplay) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+  const auto algo = NCCL_ALLREDUCE_ALGO::ctran;
+  if (!ctranAllReduceSupport(comm.get(), algo)) {
+    GTEST_SKIP() << "AllReduce not supported on this topology";
+  }
+
+  ctran::TestDeviceBuffer send(kCount * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(kCount * sizeof(int32_t));
+  fillSendBuf(send.get(), kCount, globalRank);
+
+  runGraphColltraceCheck(
+      comm.get(), kNumReplays, "AllReduce", [&](cudaStream_t s) {
+        ASSERT_EQ(
+            ctranAllReduce(
+                send.get(),
+                recv.get(),
+                kCount,
+                commInt32,
+                commSum,
+                comm.get(),
+                s,
+                algo),
+            commSuccess);
+      });
+}
+
+TEST_F(CtranCudaGraphColltraceTest, ReduceScatterOneRecordPerReplay) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+  const auto algo = NCCL_REDUCESCATTER_ALGO::ctran;
+  if (!ctranReduceScatterSupport(comm.get(), algo)) {
+    GTEST_SKIP() << "ReduceScatter not supported on this topology";
+  }
+
+  ctran::TestDeviceBuffer send(kCount * numRanks * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(kCount * sizeof(int32_t));
+  fillSendBuf(send.get(), kCount * numRanks, globalRank);
+
+  runGraphColltraceCheck(
+      comm.get(), kNumReplays, "ReduceScatter", [&](cudaStream_t s) {
+        ASSERT_EQ(
+            ctranReduceScatter(
+                send.get(),
+                recv.get(),
+                kCount,
+                commInt32,
+                commSum,
+                comm.get(),
+                s,
+                algo),
+            commSuccess);
+      });
+}
+
+// AllGatherP `ctpipeline` is the only path that uses the multi-kernel colltrace
+// grouping (PipeStart=kBegin, PipeSync=kInner, PipeEnd=kEnd); every other
+// collective is a single kSolo kernel. This asserts the grouping collapses the
+// whole pipeline to exactly ONE colltrace record per graph replay (not one per
+// pipe stage, and not zero from a dropped end). ctgraph_pipeline requires an
+// intra-node NVL domain (nLocalRanks > 1) and a registered recvbuf, and is only
+// used during capture (eager warmup uses the direct ctran algo).
+TEST_F(CtranCudaGraphColltraceTest, AllGatherPPipelineOneRecordPerReplay) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+  if (!ctran::allGatherPSupport(comm.get()) ||
+      comm->statex_.get()->nLocalRanks() <= 1) {
+    GTEST_SKIP() << "AllGatherP ctpipeline requires nLocalRanks > 1";
+  }
+
+  ctran::TestDeviceBuffer send(kCount * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(kCount * numRanks * sizeof(int32_t));
+  fillSendBuf(send.get(), kCount, globalRank);
+
+  // The graph AGP path requires the recvbuf segment cached in the regcache;
+  // keep it registered until after the graph is destroyed below.
+  const size_t recvBytes = kCount * numRanks * sizeof(int32_t);
+  ctran::RegCache::getInstance()->globalRegister(
+      recv.get(), recvBytes, /*forceReg=*/true);
+
+  meta::comms::CudaStream stream(cudaStreamNonBlocking);
+  auto launch = [&](cudaStream_t s, enum NCCL_ALLGATHER_ALGO algo) {
+    ASSERT_EQ(
+        ctranAllGather(
+            send.get(), recv.get(), kCount, commInt32, comm.get(), s, algo),
+        commSuccess);
+  };
+  // Count only "AllGatherP" records (ignoring the one-time "AllGatherP_Init"
+  // and the direct-warmup "AllGather"), after draining colltrace.
+  auto countAllGatherP = [&]() -> int {
+    if (comm->colltraceNew_ != nullptr) {
+      comm->colltraceNew_->waitFlush(comm->colltraceNew_->requestFlush());
+    }
+    auto d = ctran::waitForCollTraceDrain(comm.get());
+    EXPECT_EQ(d["CT_currentColls"], "[]");
+    int n = 0;
+    for (const auto& rec : folly::parseJson(d["CT_pastColls"])) {
+      if (rec["opName"].asString() == "AllGatherP") {
+        ++n;
+      }
+    }
+    return n;
+  };
+
+  // Eager warmup on the direct algo, then capture the pipeline algo once.
+  launch(stream.get(), NCCL_ALLGATHER_ALGO::ctran);
+  CUDACHECK_TEST(cudaStreamSynchronize(stream.get()));
+
+  cudaGraph_t graph = nullptr;
+  cudaGraphExec_t graphExec = nullptr;
+  ASSERT_EQ(
+      cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeRelaxed),
+      cudaSuccess);
+  launch(stream.get(), NCCL_ALLGATHER_ALGO::ctgraph_pipeline);
+  ASSERT_EQ(cudaStreamEndCapture(stream.get(), &graph), cudaSuccess);
+  ASSERT_NE(graph, nullptr);
+  ASSERT_EQ(
+      cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0),
+      cudaSuccess);
+
+  const int before = countAllGatherP();
+  for (int i = 0; i < kNumReplays; ++i) {
+    ASSERT_EQ(cudaGraphLaunch(graphExec, stream.get()), cudaSuccess);
+  }
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+  const int after = countAllGatherP();
+
+  EXPECT_EQ(after - before, kNumReplays)
+      << "AllGatherP ctpipeline should emit exactly one colltrace record per "
+         "replay (one logical collective via kBegin/kInner/kEnd grouping, not "
+         "one per pipe stage): before="
+      << before << " after=" << after;
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  waitAndVerifyGpeClean(comm.get());
+  ctran::RegCache::getInstance()->globalDeregister(recv.get(), recvBytes);
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new CtranCudaGraphEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/baseline_modification_docs/inkernel_colltrace_baseline.md
+++ b/comms/ncclx/meta/baseline_modification_docs/inkernel_colltrace_baseline.md
@@ -1,0 +1,155 @@
+# In-kernel colltrace emit for baseline collectives: Baseline Modifications
+
+## Background
+
+The colltrace graph watchdog (and graph-mode colltrace tracing generally) times
+graph-captured collectives by reading per-collective `kStart`/`kEnd` timestamps
+that the collective **kernel** publishes into a shared HRDW ring at replay. Only
+ctran GPE kernels emitted these timestamps (via
+`ctran::device::ColltraceEventScope`); baseline NCCL collectives (the `orig`
+algorithm path) did not, so a graph-captured baseline collective registered a
+`collId` on the host (`recordGraphCollectiveImpl`) but the ring stayed empty and
+the watchdog had nothing to observe.
+
+The host-side colltrace machinery is already backend-agnostic:
+
+- Registration + `collId` assignment for a graph-captured collective happens in
+  `collTraceBaselineGetHandle` → `getHandleFromNcclKernelPlan` →
+  `CollTrace::recordGraphCollectiveImpl` — shared with ctran.
+- `CollTrace::pollGraphEvents` reads `kStart`/`kEnd` from the ring keyed on
+  `collId`, agnostic to which kernel wrote them.
+- `ICollTraceHandle::getColltraceDeviceHandle()` already returns the armed,
+  ring-backed `ColltraceDeviceHandle` (ring + `collId`) on the graph path and an
+  unarmed `{}` otherwise.
+
+So the only missing piece for baseline was the **device-side write** plus arming
+the per-launch handle onto the kernel args. The device writer itself is shared:
+the generic `meta::comms::colltrace::ColltraceEventScope` lives in
+`comms/utils/colltrace/ColltraceEventScope.cuh` (ctran's
+`ctran::device::ColltraceEventScope` is a thin subclass adding a `KernelFlagDev`
+overload).
+
+## Versions Affected
+
+v2.29, v2.30
+
+## Baseline Files Modified
+
+Three baseline files per version, each a tagged, minimal hook. All logic lives in
+the Meta helper `ncclx::colltrace::armNcclInKernelColltrace`
+(`meta/colltrace/CollTraceWrapper.{h,cc}`), which is version-agnostic.
+
+1. `src/include/device.h` — one field on the per-launch arg struct plus its
+   include:
+   ```cpp
+   // [META] In-kernel colltrace gate, defined here and used by every
+   // colltraceHdr reference so the struct has one layout across all TUs.
+   #if !defined(NCCLX_NO_INKERNEL_COLLTRACE) && \
+       !(CUDART_VERSION >= 13000 && CUDART_VERSION < 13030)
+   #define NCCLX_INKERNEL_COLLTRACE 1
+   #endif
+
+   #ifdef NCCLX_INKERNEL_COLLTRACE
+   #include "comms/utils/colltrace/ColltraceDeviceHandle.h"
+   #endif
+   ...
+   struct alignas(16) ncclDevKernelArgs {
+     ...
+     void* workBuf;
+     // [META] ... armed host-side in armNcclInKernelColltrace() ...
+   #ifdef NCCLX_INKERNEL_COLLTRACE
+     meta::comms::colltrace::ColltraceDeviceHandle colltraceHdr;
+   #endif
+     // struct ncclDevWorkBatch batches[];  // trailing inline region
+   };
+   ```
+   The handle is the **last fixed field**, so the trailing inline work-batch /
+   work region (located at `kernelArgs+1` and via `batch.offsetBase`, both
+   `sizeof(ncclDevKernelArgs)`-relative on host and device) stays consistent.
+   `ColltraceDeviceHandle` is a trivially-copyable aggregate, so the word-by-word
+   arg→shmem copy in `ncclKernelMain` carries it correctly.
+
+2. `src/device/common.h` — one RAII scope in the single generic kernel
+   `ncclKernelMain`, right after the prologue publishes `ncclShmem`:
+   ```cpp
+   // [META] in-kernel colltrace ...
+   #ifdef NCCLX_INKERNEL_COLLTRACE
+   meta::comms::colltrace::ColltraceDeviceEventScope colltraceScope(
+       ncclShmem.args.colltraceHdr);
+   #endif
+   ```
+   ctor emits `kStart`; dtor emits `kEnd` at kernel exit. One scope covers
+   **every** baseline collective, since they all funnel through `ncclKernelMain`.
+   An unarmed handle makes it a no-op (single-writer election is block0/thread0).
+
+3. `src/enqueue.cc` — one tagged call in `ncclLaunchKernel`, next to the existing
+   `collTraceBaselineGetHandle` injection:
+   ```cpp
+   ncclx::colltrace::armNcclInKernelColltrace(
+       plan, colltraceHandle.get(), comm->compCap);
+   ```
+   This writes the ring/`collId` into `plan->kernelArgs->colltraceHdr` just
+   before `cuLaunchKernelEx`, so the `collId` assigned at capture is baked into
+   the graph node and re-emitted on every replay. The helper is a no-op unless a
+   graph is being captured (`getColltraceDeviceHandle().valid()`) on an sm_90+
+   device (the ring's 128b atomic requirement); symmetric-memory kernels use a
+   different arg layout and are skipped.
+
+## Platform gating: CUDA only
+
+`device.h` defines a single gate macro, `NCCLX_INKERNEL_COLLTRACE`, and all
+three touch points test it with `#ifdef`. It is left undefined when
+`NCCLX_NO_INKERNEL_COLLTRACE` is set, which `device_object`'s
+`propagated_pp_flags` does on `ovr_config//gpu:amd`
+(`comms/ncclx/nccl_build_config.bzl`). The same `select` also drops
+`colltrace_device_handle` from that target's `exported_deps`, so on AMD the
+header is neither included nor on the include path.
+
+It is also left undefined on CUDA 13.0-13.2, where an nvcc
+`[[no_unique_address]]` device-layout bug (fixed in 13.3) misaligns the
+`args->__shared__` copy of `ncclDevKernelArgs`; any kernel launch carrying those
+args then faults with `cudaErrorMisalignedAddress` (seen as "Failed to allocate
+barrier buffer: misaligned address" in the torchcomms integration tests). The
+guard lives in the same commit that adds the field, so no point in the stack
+builds a `colltraceHdr` that the toolchain will mislay.
+
+Two reasons for the AMD case:
+
+- **It cannot work on AMD.** The ring publishes a slot with `atom.exch.b128`
+  inline PTX, which has no HIP equivalent —
+  `HrdwRingBufferWriter::write` compiles to a trap under `__HIPCC__`, and
+  `comms/utils/hrdw_ring_buffer/BUCK` already states AMD "will fail at
+  compile/link time when actually exercised".
+- **It breaks the AMD build if left in.** `colltrace_device_handle` reaches
+  `//comms/utils:hrdw_ring_buffer`, a `gpu_cpp_library`, so on AMD hipify
+  rewrites that target's `<cuda_runtime.h>` into `<hip/hip_runtime.h>`. ncclx is
+  never hipified — under `mode/*-amd-gpu` it still compiles with `nvcc` — so its
+  `nccl.h` keeps the real CUDA runtime. Any consumer including `collectives.h`
+  then gets CUDA's and HIP's vector types in one TU and fails with ~20 `typedef
+  redefinition` errors (first seen in `comms/utils/tests:comm_specs_test`).
+  Before this change ncclx's public headers never reached a hipified header: the
+  handle was only ever a `shared_ptr<ICollTraceHandle>` used inside `.cc` files,
+  and a pointer to an abstract type needs no layout. Embedding the handle
+  by value is what put it on the exported header path.
+
+The flag is propagated from the same target and the same `select` as the dep so
+no consumer can disagree about whether `colltraceHdr` exists — a mismatch would
+silently change `ncclDevKernelArgs`'s layout between TUs.
+
+## Why in baseline
+
+The three touch points are structurally forced:
+
+- The `collId` is per-collective and must be baked into each graph node's arg
+  bytes at capture, so it must live in the per-launch `ncclDevKernelArgs` (a
+  comm-level slot would be overwritten by the next captured collective) — hence
+  the `device.h` field.
+- The emit must run inside the collective kernel, and `ncclKernelMain` is the one
+  generic entry every baseline collective shares — hence the `common.h` line.
+- The arm must happen at the launch site where `plan->kernelArgs` is baked into
+  the graph node — hence the `enqueue.cc` call, placed beside the existing
+  colltrace injection.
+
+All heavy logic is in the Meta helper; the baseline edits are a field, a scope,
+and a call, each `[META]`-tagged. No `CollTrace.cc` / `CollTraceWrapper` handle
+or poll changes were needed — baseline reuses the ctran path end to end.

--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
@@ -402,6 +402,16 @@ getMetadataFromNcclKernelPlan(ncclKernelPlan& plan, cudaStream_t stream) {
       planInfo.p2pType == KernelPlanType::none) {
     XLOG_FIRST_N(
         ERR, 3, "CollTrace: No coll or p2p task in the NCCL Kenrel Plan!");
+    if (isCapturingStream(stream)) {
+      // Deadlock safety: a graph-captured plan with no coll/p2p task has no
+      // kernel that will publish a start/end timestamp into the graph ring, so
+      // registering a graph colltrace record for it would never complete and
+      // would hang the poll thread on drain. Skip it --
+      // getHandleFromNcclKernelPlan falls back to a DummyCollTraceHandle.
+      // (Eager empty-task tracing, which completes normally on the stream, is
+      // unaffected.)
+      return nullptr;
+    }
     return getEmptyKernelTaskMetadata(plan, planInfo, stream);
   }
 
@@ -445,7 +455,7 @@ getHandleFromNcclKernelPlan(ncclKernelPlan& plan, cudaStream_t stream) {
 
   if (res.hasError()) {
     XLOG_FIRST_N(
-        ERR, 5, "Failed to get colltrace handle due to: ", res.error().message);
+        ERR, 1, "Failed to get colltrace handle due to: ", res.error().message);
     return std::make_unique<meta::comms::colltrace::DummyCollTraceHandle>();
   }
   return res.value();
@@ -551,10 +561,47 @@ std::optional<AlgoInfo> parseAlgoInfoFromNcclKernelPlan(ncclKernelPlan& plan) {
   };
 }
 
+void armNcclInKernelColltrace(
+    [[maybe_unused]] ncclKernelPlan& plan,
+    [[maybe_unused]] const std::shared_ptr<
+        meta::comms::colltrace::ICollTraceHandle>& handle,
+    [[maybe_unused]] int compCap) {
+  // `colltraceHdr` only exists when the in-kernel colltrace gate in device.h
+  // is on; arming is a no-op otherwise.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+  // Symmetric-memory kernels use a different arg layout; skip them.
+  if (plan.isSymColl || plan.kernelArgs == nullptr || handle == nullptr) {
+    return;
+  }
+  // Default to unarmed so the in-kernel scope is a no-op off the graph path.
+  plan.kernelArgs->colltraceHdr = {};
+  // The ring's 128b atomic write requires sm_90+; getColltraceDeviceHandle()
+  // returns a ring-backed handle only while capturing a CUDA graph.
+  if (compCap < 90) {
+    return;
+  }
+  auto devHandle = handle->getColltraceDeviceHandle();
+  if (!devHandle.valid()) {
+    return;
+  }
+  // Single-kernel baseline collective: emit both boundaries on this kernel.
+  devHandle.emitStart = true;
+  devHandle.emitEnd = true;
+  plan.kernelArgs->colltraceHdr = devHandle;
+  // Tell the graph wait event this collective self-emits so it skips the
+  // host-launched timestamp path (they must never both write the ring).
+  // TEMPORARY: the host path is deleted at the in-kernel cutover.
+  handle->markInKernelEmit();
+#endif
+}
+
 } // namespace
 
 std::shared_ptr<meta::comms::colltrace::ICollTraceHandle>
-collTraceBaselineGetHandle(ncclKernelPlan* plan, cudaStream_t stream) {
+prepareNcclKernelColltrace(
+    ncclKernelPlan* plan,
+    cudaStream_t stream,
+    int compCap) {
   if (plan->comm->algoStats) {
     auto algoInfo = parseAlgoInfoFromNcclKernelPlan(*plan);
     if (algoInfo.has_value()) {
@@ -563,9 +610,12 @@ collTraceBaselineGetHandle(ncclKernelPlan* plan, cudaStream_t stream) {
     }
   }
 
-  if (NCCL_COLLTRACE.empty()) {
-    return std::make_unique<meta::comms::colltrace::DummyCollTraceHandle>();
-  }
-  return meta::comms::ncclx::getHandleFromNcclKernelPlan(*plan, stream);
+  auto handle = NCCL_COLLTRACE.empty()
+      ? std::shared_ptr<
+            meta::comms::colltrace::ICollTraceHandle>{std::make_unique<
+            meta::comms::colltrace::DummyCollTraceHandle>()}
+      : meta::comms::ncclx::getHandleFromNcclKernelPlan(*plan, stream);
+  armNcclInKernelColltrace(*plan, handle, compCap);
+  return handle;
 }
 } // namespace ncclx::colltrace

--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.h
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.h
@@ -28,6 +28,9 @@ std::unordered_map<std::string, std::string> collTraceGetInfo();
 namespace ncclx::colltrace {
 
 std::shared_ptr<meta::comms::colltrace::ICollTraceHandle>
-collTraceBaselineGetHandle(ncclKernelPlan* plan, cudaStream_t stream);
+prepareNcclKernelColltrace(
+    ncclKernelPlan* plan,
+    cudaStream_t stream,
+    int compCap);
 
 } // namespace ncclx::colltrace

--- a/comms/ncclx/meta/colltrace/tests/BaselineCudaGraphColltraceTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/BaselineCudaGraphColltraceTest.cc
@@ -1,0 +1,173 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <chrono>
+#include <functional>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+#include <folly/init/Init.h>
+#include <folly/json/json.h>
+#include <gtest/gtest.h>
+
+#include "comm.h" // @manual
+#include "nccl.h" // @manual
+
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/testinfra/TestUtils.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/commDump.h"
+
+namespace {
+
+// Baseline (orig NCCL, non-ctran) analog of CtranCudaGraphColltraceTest:
+// capture a real collective into a CUDA graph, replay it, and assert baseline
+// colltrace produced exactly one start/end pair per replay via the in-kernel
+// emit path. The synthetic graph_colltrace_ut drives the ring directly, so it
+// never catches a baseline kernel whose end event is not armed -- which would
+// leave the collective stuck mid-flight and hang the drain. In-kernel emit is
+// the only graph timestamp path and is gated on sm_90+; on older archs
+// graph-captured collectives are not colltrace-timestamped.
+class BaselineCudaGraphColltraceTest : public NcclxBaseTestFixture {
+ protected:
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp({
+        {"WORLD_SIZE", "4"},
+        {"NCCL_COLLTRACE", "trace"},
+        {"NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "true"},
+        // In-kernel device write is off by default until the cutover diff, so
+        // enable it explicitly to exercise the in-kernel colltrace path.
+        {"NCCLX_COLLTRACE_DEVICE_WRITE", "true"},
+    });
+    CUDACHECK_TEST(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaStreamDestroy(stream_));
+    if (sendBuf_ != nullptr) {
+      CUDACHECK_TEST(cudaFree(sendBuf_));
+    }
+    if (recvBuf_ != nullptr) {
+      CUDACHECK_TEST(cudaFree(recvBuf_));
+    }
+    NcclxBaseTestFixture::TearDown();
+  }
+
+  std::unordered_map<std::string, std::string> flushAndDump(ncclComm_t comm) {
+    EXPECT_NE(comm->newCollTrace, nullptr);
+    if (comm->newCollTrace == nullptr) {
+      return {};
+    }
+    comm->newCollTrace->waitFlush(comm->newCollTrace->requestFlush());
+    EXPECT_TRUE(meta::comms::ncclx::waitForCollTraceDrain(*comm->newCollTrace));
+    return meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
+  }
+
+  // Warms the collective eagerly (establishes transport connections and a
+  // stable colltrace baseline), captures it once, and replays it `numReplays`
+  // times under one CUDA graph on a single stream. Asserts colltrace fully
+  // drains (nothing left mid-flight) and produces exactly one past record per
+  // replay.
+  void runGraphColltraceCheck(
+      ncclComm_t comm,
+      int numReplays,
+      const std::string& expectedOpName,
+      const std::function<void(cudaStream_t)>& launch) {
+    // Eager warmup + baseline record count.
+    launch(stream_);
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+    auto baseline = flushAndDump(comm);
+    ASSERT_EQ(baseline["CT_currentColls"], "[]") << "warmup never drained";
+    const int baseCount =
+        static_cast<int>(folly::parseJson(baseline["CT_pastColls"]).size());
+
+    // Capture the collective once.
+    cudaGraph_t graph = nullptr;
+    cudaGraphExec_t graphExec = nullptr;
+    ASSERT_EQ(
+        cudaStreamBeginCapture(stream_, cudaStreamCaptureModeRelaxed),
+        cudaSuccess);
+    launch(stream_);
+    ASSERT_EQ(cudaStreamEndCapture(stream_, &graph), cudaSuccess);
+    ASSERT_NE(graph, nullptr);
+    ASSERT_EQ(
+        cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0),
+        cudaSuccess);
+
+    // Replay N times on one stream so completions are ordered.
+    for (int i = 0; i < numReplays; ++i) {
+      ASSERT_EQ(cudaGraphLaunch(graphExec, stream_), cudaSuccess);
+    }
+    ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+    auto dump = flushAndDump(comm);
+    EXPECT_EQ(dump["CT_currentColls"], "[]")
+        << "a replayed collective never completed -- missing colltrace end "
+           "event for "
+        << expectedOpName;
+    EXPECT_EQ(dump["CT_pendingColls"], "[]");
+
+    auto past = folly::parseJson(dump["CT_pastColls"]);
+    EXPECT_EQ(static_cast<int>(past.size()) - baseCount, numReplays)
+        << "expected exactly one colltrace record per graph replay for "
+        << expectedOpName;
+
+    CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+    CUDACHECK_TEST(cudaGraphDestroy(graph));
+  }
+
+  cudaStream_t stream_{};
+  int* sendBuf_{nullptr};
+  int* recvBuf_{nullptr};
+};
+
+constexpr int kNumReplays = 5;
+constexpr int kCount = 1024;
+
+TEST_F(BaselineCudaGraphColltraceTest, AllReduceOneRecordPerReplay) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  // Force the baseline (orig NCCL) AllReduce kernel path, not ctran.
+  auto algoGuard = EnvRAII(NCCL_ALLREDUCE_ALGO, NCCL_ALLREDUCE_ALGO::orig);
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
+  ASSERT_TRUE(comm->newCollTrace != nullptr);
+
+  CUDACHECK_TEST(cudaMalloc(&sendBuf_, kCount * sizeof(int)));
+  CUDACHECK_TEST(cudaMalloc(&recvBuf_, kCount * sizeof(int)));
+
+  runGraphColltraceCheck(comm, kNumReplays, "AllReduce", [&](cudaStream_t s) {
+    NCCLCHECK_TEST(
+        ncclAllReduce(sendBuf_, recvBuf_, kCount, ncclInt, ncclSum, comm, s));
+  });
+}
+
+TEST_F(BaselineCudaGraphColltraceTest, AllGatherOneRecordPerReplay) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  // Force the baseline (orig NCCL) AllGather kernel path, not ctran.
+  auto algoGuard = EnvRAII(NCCL_ALLGATHER_ALGO, NCCL_ALLGATHER_ALGO::orig);
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
+  ASSERT_TRUE(comm->newCollTrace != nullptr);
+
+  CUDACHECK_TEST(cudaMalloc(&sendBuf_, kCount * sizeof(int)));
+  CUDACHECK_TEST(cudaMalloc(&recvBuf_, kCount * numRanks * sizeof(int)));
+
+  runGraphColltraceCheck(comm, kNumReplays, "AllGather", [&](cudaStream_t s) {
+    NCCLCHECK_TEST(ncclAllGather(sendBuf_, recvBuf_, kCount, ncclInt, comm, s));
+  });
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/v2_29/src/device/common.h
+++ b/comms/ncclx/v2_29/src/device/common.h
@@ -13,6 +13,11 @@
 #include "op128.h"
 #include "reduce_kernel.h"
 #include "network/unpack/unpack_defs.h"
+// [META] in-kernel colltrace emit in ncclKernelMain below; gate defined in
+// device.h, included above.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+#include "comms/utils/colltrace/ColltraceDeviceEventScope.cuh"
+#endif
 
 #define COLL_UNROLL (ncclCollUnroll())
 
@@ -390,6 +395,15 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
     } break;
   }
   __syncthreads(); // publish ncclShmem
+
+  // [META] in-kernel colltrace: emit a graph-ring kStart now and a kEnd when
+  // this scope leaves at kernel exit. Unarmed (non-graph / pre-sm_90) handles
+  // make this a no-op. One scope here covers every baseline collective, since
+  // they all funnel through ncclKernelMain.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+  meta::comms::colltrace::ColltraceDeviceEventScope colltraceScope(
+      ncclShmem.args.colltraceHdr);
+#endif
 
   while (ncclShmem.aborted == 0) {
     profiler(START);

--- a/comms/ncclx/v2_29/src/enqueue.cc
+++ b/comms/ncclx/v2_29/src/enqueue.cc
@@ -1740,9 +1740,9 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
     CU_LAUNCH_PARAM_BUFFER_SIZE, &plan->kernelArgsSize,
     CU_LAUNCH_PARAM_END
   };
-  // CollTrace Injected code here
-  auto colltraceHandle = ncclx::colltrace::collTraceBaselineGetHandle(plan, launchStream);
-
+  // [META] Colltrace handle creation and in-kernel graph timestamp arming.
+  auto colltraceHandle = ncclx::colltrace::prepareNcclKernelColltrace(
+      plan, launchStream, comm->compCap);
 
   int driverVersion;
   NCCLCHECKGOTO(ncclCudaDriverVersion(&driverVersion), ret, do_return);

--- a/comms/ncclx/v2_29/src/include/device.h
+++ b/comms/ncclx/v2_29/src/include/device.h
@@ -12,6 +12,23 @@
 #include "nccl_device/core.h"
 #include "nccl_tuner.h"
 #include "bitops.h"
+// [META] In-kernel colltrace gate. Defined here, and used by every reference to
+// colltraceHdr (see common.h and CollTraceWrapper.cc), so ncclDevKernelArgs has
+// one layout across all TUs. Compiled out when either:
+//   - AMD: see the note on device_object's exported_deps in
+//     comms/ncclx/nccl_build_config.bzl.
+//   - CUDA 13.0-13.2: an nvcc [[no_unique_address]] device-layout bug (fixed in
+//     13.3) misaligns the args->__shared__ copy of ncclDevKernelArgs, so any
+//     kernel launch carrying these args faults with cudaErrorMisalignedAddress.
+//     CUDART_VERSION comes from nccl.h above.
+#if !defined(NCCLX_NO_INKERNEL_COLLTRACE) && \
+    !(CUDART_VERSION >= 13000 && CUDART_VERSION < 13030)
+#define NCCLX_INKERNEL_COLLTRACE 1
+#endif
+
+#ifdef NCCLX_INKERNEL_COLLTRACE
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
+#endif
 #include <algorithm>
 #include <stdint.h>
 #include <sys/types.h>
@@ -474,6 +491,14 @@ struct alignas(16) ncclDevKernelArgs {
   enum ncclDevWorkStorageType workStorageType;
   uint32_t workMask;
   void* workBuf;
+  // [META] in-kernel colltrace graph timestamp handle (ring + collId + emit
+  // flags), armed host-side in armNcclInKernelColltrace() only on the
+  // CUDA-graph path (unarmed = no-op). Kept as the last fixed field so the
+  // trailing inline work-batch region stays sizeof(ncclDevKernelArgs)-relative
+  // on both host and device.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+  meta::comms::colltrace::ColltraceDeviceHandle colltraceHdr;
+#endif
   // A channel's first batch is at `blockIdx.x`. Use `nextJump` to follow rest of list.
   // struct ncclDevWorkBatch batches[];
 };

--- a/comms/ncclx/v2_30/src/device/common.h
+++ b/comms/ncclx/v2_30/src/device/common.h
@@ -13,6 +13,11 @@
 #include "op128.h"
 #include "reduce_kernel.h"
 #include "network/unpack/unpack_defs.h"
+// [META] in-kernel colltrace emit in ncclKernelMain below; gate defined in
+// device.h, included above.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+#include "comms/utils/colltrace/ColltraceDeviceEventScope.cuh"
+#endif
 
 #define COLL_UNROLL (ncclCollUnroll())
 
@@ -395,6 +400,15 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
     } break;
   }
   __syncthreads(); // publish ncclShmem
+
+  // [META] in-kernel colltrace: emit a graph-ring kStart now and a kEnd when
+  // this scope leaves at kernel exit. Unarmed (non-graph / pre-sm_90) handles
+  // make this a no-op. One scope here covers every baseline collective, since
+  // they all funnel through ncclKernelMain.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+  meta::comms::colltrace::ColltraceDeviceEventScope colltraceScope(
+      ncclShmem.args.colltraceHdr);
+#endif
 
   while (ncclShmem.aborted == 0) {
     profiler(START);

--- a/comms/ncclx/v2_30/src/enqueue.cc
+++ b/comms/ncclx/v2_30/src/enqueue.cc
@@ -1744,9 +1744,9 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
     CU_LAUNCH_PARAM_BUFFER_SIZE, &plan->kernelArgsSize,
     CU_LAUNCH_PARAM_END
   };
-  // CollTrace Injected code here
-  auto colltraceHandle = ncclx::colltrace::collTraceBaselineGetHandle(plan, launchStream);
-
+  // [META] Colltrace handle creation and in-kernel graph timestamp arming.
+  auto colltraceHandle = ncclx::colltrace::prepareNcclKernelColltrace(
+      plan, launchStream, comm->compCap);
 
   int driverVersion;
   NCCLCHECKGOTO(ncclCudaDriverVersion(&driverVersion), ret, do_return);

--- a/comms/ncclx/v2_30/src/include/device.h
+++ b/comms/ncclx/v2_30/src/include/device.h
@@ -12,6 +12,23 @@
 #include "nccl_device/core.h"
 #include "nccl_tuner.h"
 #include "bitops.h"
+// [META] In-kernel colltrace gate. Defined here, and used by every reference to
+// colltraceHdr (see common.h and CollTraceWrapper.cc), so ncclDevKernelArgs has
+// one layout across all TUs. Compiled out when either:
+//   - AMD: see the note on device_object's exported_deps in
+//     comms/ncclx/nccl_build_config.bzl.
+//   - CUDA 13.0-13.2: an nvcc [[no_unique_address]] device-layout bug (fixed in
+//     13.3) misaligns the args->__shared__ copy of ncclDevKernelArgs, so any
+//     kernel launch carrying these args faults with cudaErrorMisalignedAddress.
+//     CUDART_VERSION comes from nccl.h above.
+#if !defined(NCCLX_NO_INKERNEL_COLLTRACE) && \
+    !(CUDART_VERSION >= 13000 && CUDART_VERSION < 13030)
+#define NCCLX_INKERNEL_COLLTRACE 1
+#endif
+
+#ifdef NCCLX_INKERNEL_COLLTRACE
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
+#endif
 #include <algorithm>
 #include <stdint.h>
 #include <sys/types.h>
@@ -477,6 +494,14 @@ struct alignas(16) ncclDevKernelArgs {
   enum ncclDevWorkStorageType workStorageType;
   uint32_t workMask;
   void* workBuf;
+  // [META] in-kernel colltrace graph timestamp handle (ring + collId + emit
+  // flags), armed host-side in armNcclInKernelColltrace() only on the
+  // CUDA-graph path (unarmed = no-op). Kept as the last fixed field so the
+  // trailing inline work-batch region stays sizeof(ncclDevKernelArgs)-relative
+  // on both host and device.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+  meta::comms::colltrace::ColltraceDeviceHandle colltraceHdr;
+#endif
   // A channel's first batch is at `blockIdx.x`. Use `nextJump` to follow rest of list.
   // struct ncclDevWorkBatch batches[];
 };


### PR DESCRIPTION
Summary:

On the CUDA-graph path, colltrace previously timed each collective with a pair of host-launched `<<<1,1>>>` timestamp kernels forked onto a side stream around the collective kernel. That adds two extra kernel nodes (plus a stream fork/join) to every captured collective and perturbs the very timings it is meant to measure.

This diff lets the collective kernels emit their own start/end timestamps from inside the kernel, directly into the graph colltrace HRDW ring, removing the host-launched timestamp kernels on the graph path.

- `ColltraceEventScope` (`comms/ctran/algos/common/ColltraceEventScope.cuh`): an RAII scope placed at the top of a GPE kernel. It emits a start event on construction and an end event on destruction, single-writer-elected to block 0 / thread 0, and is a no-op unless armed. This diff wires it into the AllGatherP pipeline path (the multi-kernel begin/interior/end grouping, expressed per-submit via the `colltraceInlineWrites`/`colltraceEmitStart`/`colltraceEmitEnd` kernel-config flags) and the Direct AllGather/AllReduce/ReduceScatter kernels exercised by the integration test; the remaining collectives are migrated in a stacked follow-up to keep this diff's fan-out small (their behavior is unchanged until then -- an un-migrated algo leaves all three colltrace flags unset and keeps the host-launched timestamp path).
- The host arms a per-kernel `ColltraceDeviceHandle` (ring handle + `collId` + emit-start/emit-end flags) only while capturing and only when the device supports the required `sm_90+` 128-bit atomic ring-write path; otherwise it keeps the existing host-launched writer. The path is controlled by `NCCL_COLLTRACE_IN_KERNEL` (default on): on unsupported devices or in eager mode it falls back to the host-launched writer, and setting it false forces the host-launched path everywhere.
- The colltrace poll thread drains the ring and reconstructs exactly one record per graph replay.

Reviewed By: minsii

Differential Revision: D112844323
