### PR TITLE
roll out in-kernel emit to remaining collectives (#3212)

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherBrucksFF.cc
+++ b/comms/ctran/algos/AllGather/AllGatherBrucksFF.cc
@@ -327,6 +327,9 @@ commResult_t ctranAllGatherBrucksFF(
       datatype,
       comm,
       stream));
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(comm->ctran_->gpe->submit(
       std::move(opGroup),
       impl,

--- a/comms/ctran/algos/AllGather/AllGatherBrucksFF.cu
+++ b/comms/ctran/algos/AllGather/AllGatherBrucksFF.cu
@@ -9,6 +9,7 @@ __global__ void ncclKernelAllGatherCtranBrucks(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {

--- a/comms/ctran/algos/AllGather/AllGatherDirect.cc
+++ b/comms/ctran/algos/AllGather/AllGatherDirect.cc
@@ -306,6 +306,9 @@ commResult_t ctranAllGatherDirect(
   FB_COMMCHECK(setupPlan(comm, opGroup, config));
   XCHECK(kernFnMap.contains(datatype))
       << "kernFnMap does not contain datatype " << datatype;
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(comm->ctran_->gpe->submit(
       std::move(opGroup), impl, config, kernFnMap.at(datatype)));
   if (extraCopyBuff != nullptr) {

--- a/comms/ctran/algos/AllGather/AllGatherDirect.cuh
+++ b/comms/ctran/algos/AllGather/AllGatherDirect.cuh
@@ -51,6 +51,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelAllGatherCtranDirect(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/comms/ctran/algos/AllGather/AllGatherRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherRing.cc
@@ -220,6 +220,9 @@ commResult_t ctranAllGatherRing(
       datatype,
       comm,
       stream));
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(comm->ctran_->gpe->submit(
       std::move(opGroup),
       impl,

--- a/comms/ctran/algos/AllGather/AllGatherRing.cu
+++ b/comms/ctran/algos/AllGather/AllGatherRing.cu
@@ -9,6 +9,7 @@ __global__ void ncclKernelAllGatherCtranRing(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {

--- a/comms/ctran/algos/AllGather/StreamedRd/Impl.cc
+++ b/comms/ctran/algos/AllGather/StreamedRd/Impl.cc
@@ -180,6 +180,9 @@ commResult_t ctranAllGatherStreamedRd(
       datatype,
       comm,
       stream));
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(comm->ctran_->gpe->submit(
       std::move(opGroup),
       impl,

--- a/comms/ctran/algos/AllGather/StreamedRd/Impl.cu
+++ b/comms/ctran/algos/AllGather/StreamedRd/Impl.cu
@@ -9,6 +9,7 @@ __global__ void ncclKernelAllGatherCtranStreamedRd(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {

--- a/comms/ctran/algos/AllGatherP/DirectImpl.cc
+++ b/comms/ctran/algos/AllGatherP/DirectImpl.cc
@@ -238,6 +238,9 @@ commResult_t AlgoImpl::execDirect(
   config.algoArgs = reinterpret_cast<void*>(&pArgs);
   config.args.devState_d = ctran->algo->getDevState();
 
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(ctran->gpe->submit(
       std::move(opGroup),
       gpnFn,

--- a/comms/ctran/algos/AllGatherP/DirectImpl.cu
+++ b/comms/ctran/algos/AllGatherP/DirectImpl.cu
@@ -9,6 +9,7 @@ namespace ctran::allgatherp {
 __global__ void ncclKernelAllGatherPDirect(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
     ctran::device::devLoadAbortFlags(flag, devState);

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -244,8 +244,7 @@ commResult_t AlgoImpl::execPipeline(
   config.numThreads = 1;
   config.args.devState_d = ctran->algo->getDevState();
 
-  // TODO: ensure colltrace can capture the group of operations as single
-  // allgather
+  bool colltraceGroupOpen = false;
 
   if (nNodes > 1) {
     // Submit inter-node Ring pipeline for GPE thread to execute. Skip if single
@@ -266,6 +265,9 @@ commResult_t AlgoImpl::execPipeline(
       //   GPE thread till allgather starts. ncclKernelAllGatherPPipeStart
       //   returns immediately after started GPE, thus the inter-node pipeline
       //   can be overlapped with the following intra-node copies.
+      config.colltraceInlineWrites = true;
+      config.colltraceEmitStart = true;
+      colltraceGroupOpen = true;
       FB_COMMCHECK(ctran->gpe->submit(
           std::move(opGroup),
           gpeFn,
@@ -274,6 +276,9 @@ commResult_t AlgoImpl::execPipeline(
     } else {
       // - For nLocalRanks == 1 case, ncclKernelAllGatherPRing holds the stream
       //   till GPE thread finishes entire transfer.
+      config.colltraceInlineWrites = true;
+      config.colltraceEmitStart = true;
+      config.colltraceEmitEnd = true;
       FB_COMMCHECK(ctran->gpe->submit(
           std::move(opGroup),
           gpeFn,
@@ -314,6 +319,7 @@ commResult_t AlgoImpl::execPipeline(
           .pipeSync = resource_.pipeSync,
       };
       config.algoArgs = reinterpret_cast<void*>(&kernArgs);
+      config.colltraceInlineWrites = true;
       FB_COMMCHECK(ctran->gpe->submit(
           {},
           nullptr,
@@ -340,6 +346,10 @@ commResult_t AlgoImpl::execPipeline(
         .pipeSync = resource_.pipeSync,
     };
     config.algoArgs = reinterpret_cast<void*>(&kernArgs);
+    if (colltraceGroupOpen) {
+      config.colltraceInlineWrites = true;
+      config.colltraceEmitEnd = true;
+    }
     FB_COMMCHECK(ctran->gpe->submit(
         {},
         nullptr,

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cu
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cu
@@ -19,6 +19,7 @@ namespace ctran::allgatherp {
 __global__ void ncclKernelAllGatherPPipeStart(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
     ctran::device::KernelStartGpeAndExit(f);
@@ -33,6 +34,7 @@ __global__ void ncclKernelAllGatherPPipeSync(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     PipeSyncKernArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   ctran::device::devLoadAbortFlags(flag, devState);
   // wait till GPE thread post the current stepId
@@ -45,6 +47,7 @@ __global__ void ncclKernelAllGatherPPipeSync(
 __global__ void ncclKernelAllGatherPRing(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
     ctran::device::devLoadAbortFlags(flag, devState);
@@ -58,6 +61,7 @@ __global__ void ncclKernelAllGatherPRing(
 __global__ void ncclKernelAllGatherPStreamedRd(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
     ctran::device::devLoadAbortFlags(flag, devState);
@@ -70,9 +74,11 @@ __global__ void ncclKernelAllGatherPStreamedRd(
 // broadcast. Used when nLocalRanks > 1 in allgatherP pipeline algorithm. It is
 // called once at the end.
 __global__ void ncclKernelAllGatherPPipeEnd(
-    ctran::gpe::KernelFlagDev* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     PipeEndKernArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
+
   // Reset sync flag for next GPE->kernel pipeline sync to use
   GpeKernelSyncDev::reset(args.pipeSync, 0);
 

--- a/comms/ctran/algos/AllReduce/AllReduceDirect.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceDirect.cc
@@ -739,6 +739,10 @@ commResult_t ctranAllReduceDirect(
 
   opGroup.push_back(std::move(op));
 
+  // Single-kernel collective: arm the kernel to emit both colltrace boundaries.
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(comm->ctran_->gpe->submit(
       std::move(opGroup), impl, config, func, timeout));
 

--- a/comms/ctran/algos/AllReduce/AllReduceDirect.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceDirect.cuh
@@ -159,6 +159,7 @@ __global__ void ncclKernelAllReduceCtranDirect(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allreduce::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;

--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -1515,6 +1515,10 @@ commResult_t ctranAllReduceRing(
   config.args.collective.allreduce.count = kernArgs.count;
   config.args.collective.allreduce.datatype = kernArgs.datatype;
 
+  // Single-kernel collective: arm the kernel to emit both colltrace boundaries.
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(comm->ctran_->gpe->submit(
       std::move(opGroup), ctran::allreduce::ring::impl, config, func, timeout));
 

--- a/comms/ctran/algos/AllReduce/AllReduceRing.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cuh
@@ -396,6 +396,7 @@ __global__ void ncclKernelAllReduceCtranRing(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allreduce::ring::KernArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;

--- a/comms/ctran/algos/AllToAll/AllToAll.cc
+++ b/comms/ctran/algos/AllToAll/AllToAll.cc
@@ -168,6 +168,9 @@ commResult_t ctranAllToAll(
   std::vector<std::unique_ptr<struct OpElem>> opGroup;
   FB_COMMCHECK(setupGpeOp(
       sendbuff, recvbuff, count, datatype, comm, stream, opCount, opGroup));
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(comm->ctran_->gpe->submit(
       std::move(opGroup),
       opIbImpl,

--- a/comms/ctran/algos/AllToAll/AllToAll.cuh
+++ b/comms/ctran/algos/AllToAll/AllToAll.cuh
@@ -110,6 +110,7 @@ __global__ void ncclKernelAllToAll(
     CtranAlgoDeviceState* devState,
     ctran::alltoall::KernelArgs args) {
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  ctran::device::ColltraceEventScope colltraceScope(f);
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (flag && gtIdx == 0) {

--- a/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
@@ -579,6 +579,9 @@ commResult_t AlgoImpl::exec(const void* sendbuff, const size_t count) {
         opGroup.front().get()->alltoallP.count);
   }
 
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(comm_->ctran_->gpe->submit(
       std::move(opGroup),
       gpeFn,

--- a/comms/ctran/algos/AllToAll/AllToAllPImpl.cu
+++ b/comms/ctran/algos/AllToAll/AllToAllPImpl.cu
@@ -18,6 +18,7 @@ __global__ void ncclKernelAllToAllPDirect(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  ctran::device::ColltraceEventScope colltraceScope(f);
   if (flag) {
     ctran::device::devLoadAbortFlags(flag, devState);
     ctran::device::KernelStartGpe(f);

--- a/comms/ctran/algos/AllToAll/AllToAllv.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllv.cc
@@ -336,6 +336,9 @@ commResult_t ctranAllToAllv(
       opCount,
       opGroup));
 
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(comm->ctran_->gpe->submit(
       std::move(opGroup),
       opIbImpl,

--- a/comms/ctran/algos/AllToAll/AllToAllv.cuh
+++ b/comms/ctran/algos/AllToAll/AllToAllv.cuh
@@ -140,6 +140,7 @@ __global__ void ncclKernelAllToAllv(
     CtranAlgoDeviceState* devState,
     ctran::alltoallv::KernelArgs args) {
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  ctran::device::ColltraceEventScope colltraceScope(f);
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (flag && gtIdx == 0) {

--- a/comms/ctran/algos/Broadcast/Broadcast.cu
+++ b/comms/ctran/algos/Broadcast/Broadcast.cu
@@ -21,6 +21,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelBroadcast(
     CtranAlgoDeviceState* devState,
     ctran::broadcast::KernelArgs args) {
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  ctran::device::ColltraceEventScope colltraceScope(f);
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (UNPACK) {

--- a/comms/ctran/algos/Broadcast/BroadcastBinomialTree.cc
+++ b/comms/ctran/algos/Broadcast/BroadcastBinomialTree.cc
@@ -423,6 +423,9 @@ commResult_t ctranBroadcastBinomialTree(
   if (config.type == KernelConfig::BROADCAST_UNPACK) {
     fn = reinterpret_cast<void*>(ncclKernelBroadcast</*UNPACK=*/true>);
   }
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(comm->ctran_->gpe->submit(std::move(opGroup), impl, config, fn));
 
   if (count * typeSize < CTRAN_MIN_REGISTRATION_SIZE &&

--- a/comms/ctran/algos/Broadcast/BroadcastDirect.cc
+++ b/comms/ctran/algos/Broadcast/BroadcastDirect.cc
@@ -321,6 +321,9 @@ commResult_t ctranBroadcastDirect(
   config.args.collective.broadcast.count = count;
 
   FB_COMMCHECK(setupPlan(comm, opGroup, config));
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(comm->ctran_->gpe->submit(
       std::move(opGroup),
       impl,

--- a/comms/ctran/algos/RMA/Get.cc
+++ b/comms/ctran/algos/RMA/Get.cc
@@ -165,6 +165,9 @@ commResult_t ctranGet(
     opGroup.push_back(std::unique_ptr<struct OpElem>(op));
   }
 
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(comm->ctran_->gpe->submit(
       std::move(opGroup),
       getImpl,

--- a/comms/ctran/algos/RMA/Get.cu
+++ b/comms/ctran/algos/RMA/Get.cu
@@ -9,6 +9,7 @@ __global__ void ncclKernelGet(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  ctran::device::ColltraceEventScope colltraceScope(f);
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);

--- a/comms/ctran/algos/RMA/PutSignal.cc
+++ b/comms/ctran/algos/RMA/PutSignal.cc
@@ -327,6 +327,9 @@ commResult_t ctranPutSignal(
     func = reinterpret_cast<void*>(ncclKernelPut);
     config.algoArgs = nullptr;
   }
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(comm->ctran_->gpe->submit(
       std::move(opGroup), putSignalImpl, config, func));
 
@@ -462,6 +465,9 @@ commResult_t waitSignalSpinningKernel(
     opGroup.push_back(std::unique_ptr<struct OpElem>(op));
   }
 
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(comm->ctran_->gpe->submit(
       std::move(opGroup),
       waitSignalSpinningKernelImpl,
@@ -523,6 +529,9 @@ commResult_t ctranSignal(int peer, CtranWin* win, cudaStream_t stream) {
     opGroup.push_back(std::unique_ptr<struct OpElem>(op));
   }
 
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(comm->ctran_->gpe->submit(
       std::move(opGroup),
       signalImpl,

--- a/comms/ctran/algos/RMA/PutSignal.cu
+++ b/comms/ctran/algos/RMA/PutSignal.cu
@@ -81,6 +81,7 @@ __global__ void ncclKernelPutSignal(
     CtranAlgoDeviceState* devState,
     CtranKernelPutSignalArgs args) {
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  ctran::device::ColltraceEventScope colltraceScope(f);
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
@@ -107,6 +108,7 @@ __global__ void ncclKernelPut(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  ctran::device::ColltraceEventScope colltraceScope(f);
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
@@ -120,6 +122,7 @@ __global__ void ncclKernelWaitSignal(
     CtranAlgoDeviceState* devState,
     CtranKernelWaitSignalArgs args) {
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  ctran::device::ColltraceEventScope colltraceScope(f);
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);
@@ -148,6 +151,7 @@ __global__ void ncclKernelSignal(
     CtranAlgoDeviceState* devState,
     CtranKernelSignalArgs args) {
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  ctran::device::ColltraceEventScope colltraceScope(f);
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
     ctran::device::devLoadAbortFlags(flag, devState);

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterDirect.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterDirect.cc
@@ -216,6 +216,9 @@ commResult_t ctranReduceScatterDirect(
   }
 
   const void* func = reduceScatterKerns.at(std::make_pair(datatype, redOp));
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(
       comm->ctran_->gpe->submit(std::move(opGroup), impl, config, func));
 

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterDirect.cuh
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterDirect.cuh
@@ -131,6 +131,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelReduceScatterDirect(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::reducescatter::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   // TODO(T243528798): remove this preload of devstate by splitting h2d/d2h
   // channels.

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterRHD.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterRHD.cc
@@ -381,6 +381,9 @@ commResult_t ctranReduceScatterRHD(
       opCount);
   FB_COMMCHECK(setupPlan(comm, opGroup, config));
   const void* func = reduceScatterKerns.at(std::make_pair(datatype, redOp));
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(
       comm->ctran_->gpe->submit(std::move(opGroup), impl, config, func));
 

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterRHD.cuh
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterRHD.cuh
@@ -19,6 +19,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelReduceScatterRHD(
     CtranAlgoDeviceState* devState,
     ctran::reducescatter::KernelArgs args) {
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  ctran::device::ColltraceEventScope colltraceScope(f);
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (flag && gtIdx == 0) {

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterRing.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterRing.cc
@@ -358,6 +358,9 @@ commResult_t ctranReduceScatterRing(
   FB_COMMCHECK(setupPlan(comm, opGroup, config));
 
   const void* func = reduceScatterKerns.at(std::make_pair(datatype, redOp));
+  config.colltraceInlineWrites = true;
+  config.colltraceEmitStart = true;
+  config.colltraceEmitEnd = true;
   FB_COMMCHECK(
       comm->ctran_->gpe->submit(std::move(opGroup), impl, config, func));
 

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterRing.cuh
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterRing.cuh
@@ -19,6 +19,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelReduceScatterRing(
     CtranAlgoDeviceState* devState,
     ctran::reducescatter::KernelArgs args) {
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  ctran::device::ColltraceEventScope colltraceScope(f);
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (flag && gtIdx == 0) {

--- a/comms/ctran/algos/SendRecv/SendRecv.cc
+++ b/comms/ctran/algos/SendRecv/SendRecv.cc
@@ -291,6 +291,9 @@ commResult_t ctranGroupEndHookImpl(
           ctran::sendrecv::setupKernelConfig(
               comm, allOps, nvlOps, config, kernArgs));
 
+      config.colltraceInlineWrites = true;
+      config.colltraceEmitStart = true;
+      config.colltraceEmitEnd = true;
       FB_COMMCHECK(comm->ctran_->gpe->submit(
           std::move(gpeOpGroup),
           sendRecvImpl,

--- a/comms/ctran/algos/SendRecv/SendRecv.cu
+++ b/comms/ctran/algos/SendRecv/SendRecv.cu
@@ -20,6 +20,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelSend(
     CtranAlgoDeviceState* devState,
     ctran::sendrecv::KernelSendArgs args) {
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  ctran::device::ColltraceEventScope colltraceScope(f);
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
 
@@ -51,6 +52,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelRecv(
     CtranAlgoDeviceState* devState,
     ctran::sendrecv::KernelRecvArgs args) {
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  ctran::device::ColltraceEventScope colltraceScope(f);
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
 
@@ -92,6 +94,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelSendRecv(
     CtranAlgoDeviceState* devState,
     ctran::sendrecv::KernelSendRecvArgs args) {
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  ctran::device::ColltraceEventScope colltraceScope(f);
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
 

--- a/comms/ctran/algos/SendRecv/SendRecvP2p.cu
+++ b/comms/ctran/algos/SendRecv/SendRecvP2p.cu
@@ -79,6 +79,7 @@ __global__ __launch_bounds__(512, 1) void ncclKernelSendRecvP2p(
                                     // maybe needed for fault-tolerance
     ctran::sendrecv::KernArgs args) {
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  ctran::device::ColltraceEventScope colltraceScope(f);
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (flag && gtIdx == 0) {

--- a/comms/ctran/algos/common/ColltraceEventScope.cuh
+++ b/comms/ctran/algos/common/ColltraceEventScope.cuh
@@ -1,0 +1,77 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comms/ctran/algos/common/GpeRing.h" // ctran::gpe::KernelFlagDev
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
+
+// In-kernel colltrace timestamp emission: a collective kernel publishes its own
+// start/end timestamps into the graph colltrace ring, replacing the host-
+// launched <<<1,1>>> timestamp kernels on the CUDA-graph path.
+
+namespace ctran::device {
+
+// Publish a colltrace start/end timestamp for this logical collective from
+// inside the kernel. Single-writer election (block 0, thread 0); no-op on an
+// unarmed handle (valid() == false). The timestamp is captured at the true
+// kernel boundary. The ring write is the HRDWRingBuffer System-scope 128b
+// atomic path, which requires sm_90+; the host therefore only arms this when
+// the device supports it, falling back to the host-launched writer otherwise.
+static __forceinline__ __device__ void ColltraceEmitEvent(
+    meta::comms::colltrace::ColltraceDeviceHandle hdr,
+    meta::comms::colltrace::GraphCollTracePhase phase) {
+  if (blockIdx.x == 0 && threadIdx.x == 0 && hdr.valid()) {
+    hdr.ring.write(
+        meta::comms::colltrace::GraphCollTraceEvent{hdr.collId, phase});
+  }
+}
+
+// One RAII colltrace timing scope for every GPE kernel: emits the start
+// timestamp on construction when the armed handle enables start, and the end
+// timestamp on destruction when it enables end. The host arms the emitStart/
+// emitEnd flags per the kernel's role, so a single uniform line covers all
+// shapes: a single-kernel collective arms both; a multi-kernel one arms start
+// on its first kernel and end on its last; interior kernels arm neither.
+//
+// Threading: both the start (ctor) and the end (dtor) are recorded by the SAME
+// single elected writer -- block 0, thread 0 -- inside ColltraceEmitEvent;
+// every other block/thread constructs the scope but its emits are no-ops. So it
+// is safe (and required, for a correct start boundary) to place at the very top
+// of any kernel, before any per-thread work. Both emits are also valid()-gated,
+// so an unarmed handle makes the whole scope a no-op.
+struct ColltraceEventScope {
+  meta::comms::colltrace::ColltraceDeviceHandle hdr;
+
+  __forceinline__ __device__ explicit ColltraceEventScope(
+      meta::comms::colltrace::ColltraceDeviceHandle handle)
+      : hdr(handle) {
+    if (hdr.emitStart) {
+      ColltraceEmitEvent(
+          hdr, meta::comms::colltrace::GraphCollTracePhase::kStart);
+    }
+  }
+
+  // Convenience overload: take the kernel flag directly so call sites don't
+  // repeat the null-check ternary. A null flag yields an unarmed (no-op) scope.
+  __forceinline__ __device__ explicit ColltraceEventScope(
+      const ctran::gpe::KernelFlagDev* f)
+      : ColltraceEventScope(
+            f ? f->colltraceHdr
+              : meta::comms::colltrace::ColltraceDeviceHandle{}) {}
+
+  __forceinline__ __device__ ~ColltraceEventScope() {
+    if (hdr.emitEnd) {
+      ColltraceEmitEvent(
+          hdr, meta::comms::colltrace::GraphCollTracePhase::kEnd);
+    }
+  }
+
+  // Non-copyable and non-movable: the scope's lifetime must match the enclosing
+  // kernel body so kEnd fires exactly once at kernel exit.
+  ColltraceEventScope(const ColltraceEventScope&) = delete;
+  ColltraceEventScope& operator=(const ColltraceEventScope&) = delete;
+  ColltraceEventScope(ColltraceEventScope&&) = delete;
+  ColltraceEventScope& operator=(ColltraceEventScope&&) = delete;
+};
+
+} // namespace ctran::device

--- a/comms/ctran/algos/common/GpeKernelDev.cuh
+++ b/comms/ctran/algos/common/GpeKernelDev.cuh
@@ -5,6 +5,7 @@
 #include "comms/common/AtomicUtils.cuh"
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/ctran/algos/DevShmState.cuh"
+#include "comms/ctran/algos/common/ColltraceEventScope.cuh"
 #include "comms/ctran/algos/common/GpeKernel.h"
 #include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/utils/DevUtils.cuh"
@@ -37,6 +38,10 @@ static __forceinline__ __device__ void KernelPublishGpeRing(
     hdr.ring.write(hdr.cmdId);
   }
 }
+
+// ColltraceEmitEvent / ColltraceEventScope moved to ColltraceEventScope.cuh
+// (included above); kept accessible here since kernels include
+// GpeKernelDev.cuh.
 
 // Kernel start prologue: publish this cmd's id to the ring (block 0 only, no-op
 // when not armed), then signal the GPE worker that block `bId` has started. The

--- a/comms/ctran/algos/common/GpeRing.h
+++ b/comms/ctran/algos/common/GpeRing.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 
 #include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
 #include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
 namespace ctran::gpe {
@@ -47,13 +48,17 @@ struct GpeKernelFlagHeader {
 };
 
 // Device-facing view of a per-cmd kernel flag object: the per-block start/stop
-// flags plus the ring header, laid out in pinned host memory. Every GPE kernel
-// takes a KernelFlagDev* as its first argument and reads gpeHdr directly — no
-// pointer-offset recovery. KernelFlagItem (host) embeds this as its first
-// member, so &kernelFlag->dev is the pointer handed to the kernel.
+// flags plus the ring headers, laid out in pinned host memory. Every GPE kernel
+// takes a KernelFlagDev* as its first argument and reads gpeHdr/colltraceHdr
+// directly — no pointer-offset recovery. KernelFlagItem (host) embeds this as
+// its first member, so &kernelFlag->dev is the pointer handed to the kernel.
+// colltraceHdr is armed host-side at submit() for the kernels that bound a
+// logical collective; a default (null-ring) handle means unarmed, so the
+// in-kernel emit no-ops. See meta::comms::colltrace::ColltraceDeviceHandle.
 struct KernelFlagDev {
   volatile int flag_[CTRAN_ALGO_MAX_THREAD_BLOCKS];
   GpeKernelFlagHeader gpeHdr{};
+  meta::comms::colltrace::ColltraceDeviceHandle colltraceHdr{};
 };
 
 } // namespace ctran::gpe

--- a/comms/ctran/algos/common/tests/ColltraceEventScopeTest.cc
+++ b/comms/ctran/algos/common/tests/ColltraceEventScopeTest.cc
@@ -1,0 +1,96 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Unit test for ColltraceEventScope: the RAII scope must emit exactly the armed
+// start/end colltrace events into the HRDW ring, elected to a single writer
+// regardless of block/thread count, and be a no-op when unarmed.
+
+#include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
+#include "comms/utils/colltrace/GraphCollTraceEvent.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
+
+using meta::comms::colltrace::ColltraceDeviceHandle;
+using meta::comms::colltrace::GraphCollTraceEvent;
+using meta::comms::colltrace::GraphCollTracePhase;
+
+// Defined in ColltraceEventScopeTest.cu.
+void launchColltraceScopeKernel(
+    const ColltraceDeviceHandle& handle,
+    int blocks,
+    int threads,
+    cudaStream_t stream);
+
+namespace {
+
+// Runs one ColltraceEventScope with the given emit flags across blocks*threads
+// threads, then returns the events written to the ring in write order.
+std::vector<GraphCollTraceEvent> runScope(
+    bool emitStart,
+    bool emitEnd,
+    uint32_t collId,
+    int blocks,
+    int threads) {
+  hrdw_ring_buffer::HRDWRingBuffer<GraphCollTraceEvent> buf(/*capacity=*/64);
+  EXPECT_TRUE(buf.valid());
+
+  ColltraceDeviceHandle handle{};
+  handle.collId = collId;
+  handle.emitStart = emitStart;
+  handle.emitEnd = emitEnd;
+  handle.ring = buf.deviceHandle();
+
+  cudaStream_t stream = nullptr;
+  EXPECT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+  launchColltraceScopeKernel(handle, blocks, threads, stream);
+  EXPECT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  EXPECT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+
+  std::vector<GraphCollTraceEvent> events;
+  hrdw_ring_buffer::HRDWRingBufferReader<GraphCollTraceEvent> reader(buf);
+  reader.poll([&](const auto& entry, uint64_t /*slot*/) {
+    events.push_back(entry.data);
+  });
+  return events;
+}
+
+TEST(ColltraceEventScopeTest, EmitsStartThenEndSingleWriter) {
+  // 64 threads all construct the scope, but the emit is elected to one writer,
+  // so exactly one start and one end land in the ring.
+  auto events =
+      runScope(/*emitStart=*/true, /*emitEnd=*/true, /*collId=*/42, 2, 32);
+  ASSERT_EQ(events.size(), 2u);
+  EXPECT_EQ(events[0].phase, GraphCollTracePhase::kStart);
+  EXPECT_EQ(events[0].collId, 42u);
+  EXPECT_EQ(events[1].phase, GraphCollTracePhase::kEnd);
+  EXPECT_EQ(events[1].collId, 42u);
+}
+
+TEST(ColltraceEventScopeTest, StartOnly) {
+  auto events =
+      runScope(/*emitStart=*/true, /*emitEnd=*/false, /*collId=*/7, 1, 1);
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].phase, GraphCollTracePhase::kStart);
+  EXPECT_EQ(events[0].collId, 7u);
+}
+
+TEST(ColltraceEventScopeTest, EndOnly) {
+  auto events =
+      runScope(/*emitStart=*/false, /*emitEnd=*/true, /*collId=*/8, 1, 1);
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].phase, GraphCollTracePhase::kEnd);
+  EXPECT_EQ(events[0].collId, 8u);
+}
+
+TEST(ColltraceEventScopeTest, UnarmedIsNoOp) {
+  auto events =
+      runScope(/*emitStart=*/false, /*emitEnd=*/false, /*collId=*/9, 4, 64);
+  EXPECT_TRUE(events.empty());
+}
+
+} // namespace

--- a/comms/ctran/algos/common/tests/ColltraceEventScopeTest.cu
+++ b/comms/ctran/algos/common/tests/ColltraceEventScopeTest.cu
@@ -1,0 +1,22 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda_runtime.h>
+
+#include "comms/ctran/algos/common/ColltraceEventScope.cuh"
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
+
+// Every thread constructs the scope; ColltraceEventScope elects a single writer
+// (block 0, thread 0) internally, emitting the start on construction and the
+// end on destruction into the armed handle's ring.
+__global__ void colltraceScopeKernel(
+    meta::comms::colltrace::ColltraceDeviceHandle handle) {
+  ctran::device::ColltraceEventScope scope(handle);
+}
+
+void launchColltraceScopeKernel(
+    const meta::comms::colltrace::ColltraceDeviceHandle& handle,
+    int blocks,
+    int threads,
+    cudaStream_t stream) {
+  colltraceScopeKernel<<<blocks, threads, 0, stream>>>(handle);
+}

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -315,6 +315,29 @@ struct KernelConfig {
   // launched on a single GPE thread.
   bool canConcurrent{false};
 
+  // In-kernel colltrace: a collective whose kernels write their own start/end
+  // timestamps into the colltrace ring set these per submit so one logical
+  // collective maps to one CollTrace record. Only honored on the graph-capture
+  // path on sm_90+; otherwise the GPE forces the host-launched behavior. The
+  // defaults (no inline writes) preserve the host-launched timestamp path for
+  // every un-migrated collective.
+  //
+  //   - colltraceInlineWrites: this kernel belongs to a collective that writes
+  //     its colltrace timestamps in-kernel (rather than via the host-launched
+  //     timestamp kernels). Interior/end kernels set this too, so they reuse
+  //     the begin kernel's record instead of creating their own; whether a
+  //     kernel owns a record is derived (!inlineWrites || emitStart).
+  //   - colltraceEmitStart / colltraceEmitEnd: this kernel writes the start /
+  //     end timestamp in-kernel (and its host-launched writer is suppressed).
+  // Common shapes:
+  //   single-kernel collective: inlineWrites = emitStart = emitEnd = true;
+  //   multi-kernel begin:       inlineWrites = emitStart = true;
+  //   multi-kernel interior:    inlineWrites = true;
+  //   multi-kernel end:         inlineWrites = emitEnd = true;
+  bool colltraceInlineWrites{false};
+  bool colltraceEmitStart{false};
+  bool colltraceEmitEnd{false};
+
  public:
   KernelConfig(
       enum KernelType type,

--- a/comms/ctran/gpe/CtranGpeColltrace.h
+++ b/comms/ctran/gpe/CtranGpeColltrace.h
@@ -1,0 +1,41 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <mutex>
+
+#include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
+
+#include "comms/utils/cvars/nccl_cvars.h"
+
+namespace ctran::gpe {
+
+// In-kernel colltrace (the collective kernel publishing its own start/end
+// timestamps into the colltrace ring) requires sm_90+ for the ring's 128b
+// atomic device write — the same hardware requirement as the GPE device ring,
+// but gated independently of it via NCCL_COLLTRACE_IN_KERNEL. The compute
+// capability is queried once per process (call_once); NCCL pins one device per
+// process, so a single cached value is correct.
+inline bool inKernelColltraceSupported() {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_HCC__)
+  return false;
+#else
+  if (!NCCL_COLLTRACE_IN_KERNEL) {
+    return false;
+  }
+  static std::once_flag onceFlag;
+  static int ccMajor = -1; // -1 = unknown/query failed
+  std::call_once(onceFlag, [] {
+    int dev = 0;
+    int major = 0;
+    if (cudaGetDevice(&dev) == cudaSuccess &&
+        cudaDeviceGetAttribute(
+            &major, cudaDevAttrComputeCapabilityMajor, dev) == cudaSuccess) {
+      ccMajor = major;
+    }
+  });
+  return ccMajor >= 9;
+#endif
+}
+
+} // namespace ctran::gpe

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <atomic>
 #include <chrono>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 
@@ -12,6 +14,7 @@
 #include "comms/ctran/colltrace/MapperTrace.h"
 #include "comms/ctran/gpe/CtranChecksum.h"
 #include "comms/ctran/gpe/CtranGpe.h"
+#include "comms/ctran/gpe/CtranGpeColltrace.h"
 #include "comms/ctran/gpe/CtranGpeDev.h"
 #include "comms/ctran/gpe/CtranGpeImpl.h"
 #include "comms/ctran/mapper/CtranMapper.h"
@@ -22,6 +25,7 @@
 #include "comms/ctran/utils/ExtUtils.h"
 
 #include "comms/utils/colltrace/CollRecord.h"
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 
@@ -303,6 +307,29 @@ commResult_t CtranGpe::Impl::submit(
           kernelConfig.stream, streamCaptureInfo));
   bool isCapturing = streamCaptureInfo.status == cudaStreamCaptureStatusActive;
 
+  // In-kernel colltrace gate (see inKernelColltraceSupported): decides whether
+  // this submit's kernel is armed to emit its own start/end timestamps.
+  // Independent of the GPE device ring. When off, in-kernel emit is disabled
+  // and every submit owns a record, keeping the host-launched timestamp path
+  // (today's behavior) regardless of the per-submit colltrace bools.
+  const bool useInKernelColltrace =
+      ctran::gpe::inKernelColltraceSupported() && isCapturing;
+  const bool colltraceInlineWrites =
+      useInKernelColltrace && kernelConfig.colltraceInlineWrites;
+  const bool colltraceEmitStart =
+      useInKernelColltrace && kernelConfig.colltraceEmitStart;
+  const bool colltraceEmitEnd =
+      useInKernelColltrace && kernelConfig.colltraceEmitEnd;
+  // A kernel owns a CollTrace record unless it's an interior/end kernel of an
+  // in-kernel-traced group (those reuse the begin kernel's record). Host-
+  // launched submits (inlineWrites == false) always own their record.
+  const bool colltraceCreatesRecord =
+      !colltraceInlineWrites || colltraceEmitStart;
+  // Arming writes colltraceHdr onto the kernel flag, so a kernel that emits
+  // either boundary needs a flag even with an empty opGroup (e.g. AllGatherP's
+  // PipeEnd) — otherwise it would run with a null flag and never emit.
+  const bool colltraceNeedsFlag = colltraceEmitStart || colltraceEmitEnd;
+
   // For eager (non-capture) submits with empty opGroup but a
   // postKernelCleanup, we still need a cmd + kernelFlag so the GPE thread
   // can synchronize with the kernel before running cleanup. During graph
@@ -310,7 +337,7 @@ commResult_t CtranGpe::Impl::submit(
   // retainUserObject, avoiding host-node overhead.
   bool needsKernelFlag = !opGroup.empty() ||
       kernelConfig.unpackPool != nullptr ||
-      (kernelConfig.postKernelCleanup && !isCapturing);
+      (kernelConfig.postKernelCleanup && !isCapturing) || colltraceNeedsFlag;
 
   auto kernelFlag = needsKernelFlag ? this->kernelFlagPool->pop() : nullptr;
   ctran::gpe::KernelFlagDev* flagDev = nullptr;
@@ -353,8 +380,51 @@ commResult_t CtranGpe::Impl::submit(
   }
 
   // Record CollTrace event. Must be called before moving opGroup to cmd
-  auto colltraceHandle = meta::comms::colltrace::getCollTraceHandle(
-      comm, opGroup, kernelConfig, ifchecksum);
+  std::shared_ptr<meta::comms::colltrace::ICollTraceHandle> colltraceHandle =
+      colltraceCreatesRecord ? meta::comms::colltrace::getCollTraceHandle(
+                                   comm, opGroup, kernelConfig, ifchecksum)
+                             : nullptr;
+
+  // Arm the collective kernel to publish its own start/end timestamps into the
+  // colltrace ring, replacing the host-launched timestamp kernels for the
+  // grouped/self-timing pipeline collective. The header defaults to disabled
+  // (cleared on flag recycle), so kernels that emit nothing fall through.
+  if (useInKernelColltrace && kernelFlag != nullptr) {
+    if (colltraceEmitStart) {
+      // Begin (or single-kernel) collective: this kernel opens the record and
+      // writes the start. Drop any pending group left behind by a Begin whose
+      // End was never submitted (early-return, exception, or a future non-
+      // contiguous algo path), so a stale collId can never be consumed by a
+      // later unrelated End.
+      pendingColltraceGroup_ = {};
+      auto devHandle = colltraceHandle
+          ? colltraceHandle->getColltraceDeviceHandle()
+          : meta::comms::colltrace::ColltraceDeviceHandle{};
+      if (devHandle.valid()) {
+        // A single-kernel collective also emits the end here (emitEnd == true);
+        // a multi-kernel begin hands the end to the group's End kernel below.
+        devHandle.emitStart = true;
+        devHandle.emitEnd = colltraceEmitEnd;
+        kernelFlag->dev.colltraceHdr = devHandle;
+        // The kernel now writes the timestamps; drop the host-launched ones.
+        colltraceHandle->suppressInterKernelTimestamps();
+        if (!colltraceEmitEnd) {
+          // Multi-kernel begin: the End kernel reuses the same ring/collId.
+          pendingColltraceGroup_ = devHandle;
+          pendingColltraceGroup_.emitStart = false;
+          pendingColltraceGroup_.emitEnd = true;
+        }
+      }
+    } else if (colltraceEmitEnd) {
+      // End kernel of a multi-kernel collective: reuse the ring/collId stashed
+      // by the Begin and emit only the end.
+      if (pendingColltraceGroup_.valid()) {
+        kernelFlag->dev.colltraceHdr = pendingColltraceGroup_;
+      }
+      pendingColltraceGroup_ = {};
+    }
+    // Otherwise (interior kernel: no emit) there is nothing to arm.
+  }
 
   cudaStream_t launchStream = kernelConfig.stream;
   std::optional<OrderedWorkStreamGuard::Scope> wsScope;

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -44,6 +44,9 @@ struct alignas(128) KernelFlagItem {
     // Clear the full ring header so enabled==1 always implies ring/cmdId are
     // current; submit() re-arms it per-cmd on the ring path.
     dev.gpeHdr = {};
+    // Same invariant for the colltrace header: enabled==1 must always imply a
+    // current ring/collId; submit() re-arms it per-cmd for grouped kernels.
+    dev.colltraceHdr = {};
   }
 
   bool inUse() {
@@ -66,6 +69,9 @@ struct alignas(128) KernelFlagItem {
     // Clear the full ring header (not just enabled) so a stale ring/cmdId can
     // never be published; submit() re-arms it per-cmd on the ring path.
     dev.gpeHdr = {};
+    // Same for the colltrace header: a stale ring/collId must never be
+    // published; submit() re-arms it per-cmd for grouped kernels.
+    dev.colltraceHdr = {};
   }
 
   bool testFlagAllGroups(int flag) {
@@ -352,6 +358,16 @@ class CtranGpe::Impl {
   std::unique_ptr<ctran::gpe::GpeRingReader> deviceRingReader_;
   std::queue<CtranGpeCmd*> ringPending_;
   GpeDeviceRingCmdRegistry deviceRingCmdRegistry_;
+
+  // In-kernel colltrace grouping: a multi-submit collective (e.g. AllGatherP's
+  // PipeStart..PipeSync..PipeEnd) records one CollTrace event whose start is
+  // written by the group's Begin kernel and end by its End kernel. Begin
+  // stashes the device handle (ring + collId) here so the following End submit
+  // arms its kernel with the same collId. A default (null-ring, !valid())
+  // handle means no group is open. Written and read only on the submit
+  // (capture) thread, and a group's submits are always contiguous, so a single
+  // pending slot suffices.
+  meta::comms::colltrace::ColltraceDeviceHandle pendingColltraceGroup_{};
 
   // Main function called by the GPE thread. It waits and handles any  commands
   // submitted to cmdQueue until the TERMINATE command is received.

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphColltraceTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphColltraceTest.cc
@@ -1,0 +1,388 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cstdlib>
+#include <functional>
+#include <string>
+
+#include <folly/json.h>
+
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
+#include "comms/ctran/algos/ReduceScatter/ReduceScatterImpl.h"
+#include "comms/ctran/regcache/RegCache.h"
+#include "comms/ctran/tests/cudagraph/CtranCudaGraphTestBase.h"
+#include "comms/utils/CudaRAII.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/test_utils/CudaGraphTestUtils.h"
+
+namespace {
+
+// Exercises the in-kernel colltrace emit path end-to-end: a real collective is
+// captured into a CUDA graph and replayed, and we assert colltrace produced
+// exactly one start/end pair per replay. This is the coverage the synthetic
+// graph_colltrace_ut misses -- that unit test drives the ring directly, so it
+// never catches an algo whose end event is not armed (which leaves the
+// collective stuck mid-flight and hangs the drain).
+class CtranCudaGraphColltraceTest : public CtranCudaGraphTestBase {
+ protected:
+  void SetUp() override {
+    // Enable graph-mode tracing plus in-kernel emit. In-kernel emit is gated on
+    // sm_90+ in the GPE; on older archs it falls back to the host-launched
+    // timestamp kernels. The per-replay record accounting below holds for both
+    // paths, so this test is meaningful regardless of arch.
+    CtranDistTestFixture::SetUp(
+        ctran::CtranEnvs{
+            {"NCCL_COLLTRACE", "trace"},
+            {"NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "true"},
+            {"NCCL_COLLTRACE_IN_KERNEL", "true"},
+        });
+  }
+
+  // Warms the collective eagerly (establishes transport connections and gives a
+  // stable colltrace baseline), then captures it once and replays it
+  // `numReplays` times under one CUDA graph on a single stream. Asserts that:
+  //   - colltrace fully drains (nothing left in CT_currentColls) -- a missing
+  //     end event would leave a collective mid-flight and time out the drain;
+  //   - exactly one past record is produced per replay;
+  //   - every new record names the expected collective.
+  void runGraphColltraceCheck(
+      CtranComm* comm,
+      int numReplays,
+      const std::string& expectedOpName,
+      const std::function<void(cudaStream_t)>& launch) {
+    meta::comms::CudaStream stream(cudaStreamNonBlocking);
+
+    auto flushAndDump = [&]() {
+      if (comm->colltraceNew_ != nullptr) {
+        comm->colltraceNew_->waitFlush(comm->colltraceNew_->requestFlush());
+      }
+      return ctran::waitForCollTraceDrain(comm);
+    };
+
+    // Eager warmup + baseline.
+    launch(stream.get());
+    CUDACHECK_TEST(cudaStreamSynchronize(stream.get()));
+    auto baseline = flushAndDump();
+    ASSERT_EQ(baseline["CT_currentColls"], "[]") << "warmup collective never "
+                                                    "drained";
+    const int baseCount = folly::parseJson(baseline["CT_pastColls"]).size();
+
+    // Capture the collective once.
+    cudaGraph_t graph = nullptr;
+    cudaGraphExec_t graphExec = nullptr;
+    ASSERT_EQ(
+        cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeRelaxed),
+        cudaSuccess);
+    launch(stream.get());
+    ASSERT_EQ(cudaStreamEndCapture(stream.get(), &graph), cudaSuccess);
+    ASSERT_NE(graph, nullptr);
+    ASSERT_EQ(
+        cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0),
+        cudaSuccess);
+
+    // Replay N times on one stream so completions are ordered.
+    for (int i = 0; i < numReplays; ++i) {
+      ASSERT_EQ(cudaGraphLaunch(graphExec, stream.get()), cudaSuccess);
+    }
+    ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+    auto dump = flushAndDump();
+    EXPECT_EQ(dump["CT_currentColls"], "[]")
+        << "a replayed collective never completed -- missing colltrace end "
+           "event for "
+        << expectedOpName;
+    EXPECT_EQ(dump["CT_pendingColls"], "[]");
+
+    auto past = folly::parseJson(dump["CT_pastColls"]);
+    EXPECT_EQ(static_cast<int>(past.size()) - baseCount, numReplays)
+        << "expected exactly one colltrace record per graph replay";
+    for (int i = baseCount; i < static_cast<int>(past.size()); ++i) {
+      EXPECT_EQ(past[i]["opName"].asString(), expectedOpName);
+    }
+
+    CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+    CUDACHECK_TEST(cudaGraphDestroy(graph));
+    waitAndVerifyGpeClean(comm);
+  }
+};
+
+constexpr int kNumReplays = 5;
+constexpr size_t kCount = 1024;
+
+TEST_F(CtranCudaGraphColltraceTest, AllGatherOneRecordPerReplay) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+  const auto algo = NCCL_ALLGATHER_ALGO::ctran;
+  if (!ctranAllGatherSupport(comm.get(), algo)) {
+    GTEST_SKIP() << "AllGather not supported on this topology";
+  }
+
+  ctran::TestDeviceBuffer send(kCount * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(kCount * numRanks * sizeof(int32_t));
+  fillSendBuf(send.get(), kCount, globalRank);
+
+  runGraphColltraceCheck(
+      comm.get(), kNumReplays, "AllGather", [&](cudaStream_t s) {
+        ASSERT_EQ(
+            ctranAllGather(
+                send.get(), recv.get(), kCount, commInt32, comm.get(), s, algo),
+            commSuccess);
+      });
+}
+
+TEST_F(CtranCudaGraphColltraceTest, AllReduceOneRecordPerReplay) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+  const auto algo = NCCL_ALLREDUCE_ALGO::ctran;
+  if (!ctranAllReduceSupport(comm.get(), algo)) {
+    GTEST_SKIP() << "AllReduce not supported on this topology";
+  }
+
+  ctran::TestDeviceBuffer send(kCount * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(kCount * sizeof(int32_t));
+  fillSendBuf(send.get(), kCount, globalRank);
+
+  runGraphColltraceCheck(
+      comm.get(), kNumReplays, "AllReduce", [&](cudaStream_t s) {
+        ASSERT_EQ(
+            ctranAllReduce(
+                send.get(),
+                recv.get(),
+                kCount,
+                commInt32,
+                commSum,
+                comm.get(),
+                s,
+                algo),
+            commSuccess);
+      });
+}
+
+TEST_F(CtranCudaGraphColltraceTest, ReduceScatterOneRecordPerReplay) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+  const auto algo = NCCL_REDUCESCATTER_ALGO::ctran;
+  if (!ctranReduceScatterSupport(comm.get(), algo)) {
+    GTEST_SKIP() << "ReduceScatter not supported on this topology";
+  }
+
+  ctran::TestDeviceBuffer send(kCount * numRanks * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(kCount * sizeof(int32_t));
+  fillSendBuf(send.get(), kCount * numRanks, globalRank);
+
+  runGraphColltraceCheck(
+      comm.get(), kNumReplays, "ReduceScatter", [&](cudaStream_t s) {
+        ASSERT_EQ(
+            ctranReduceScatter(
+                send.get(),
+                recv.get(),
+                kCount,
+                commInt32,
+                commSum,
+                comm.get(),
+                s,
+                algo),
+            commSuccess);
+      });
+}
+
+// Graph-topology check: enabling in-kernel colltrace must remove the
+// host-launched <<<1,1>>> timestamp kernels from the captured graph. We capture
+// the same single-kernel collective with the mode OFF then ON and assert the
+// captured graph has exactly two fewer KERNEL nodes with it ON -- the start and
+// end timestamp writers. The collective's own kernels are identical in both
+// captures, so the delta isolates the timestamp kernels regardless of how many
+// kernels the algorithm itself launches.
+TEST_F(CtranCudaGraphColltraceTest, NoHostTimestampKernelsWhenInKernelEnabled) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  // In-kernel emit is only active on sm_90+; on older archs both modes use the
+  // host-launched timestamp kernels and the delta would be zero.
+  int dev = 0;
+  int ccMajor = 0;
+  CUDACHECK_TEST(cudaGetDevice(&dev));
+  CUDACHECK_TEST(
+      cudaDeviceGetAttribute(&ccMajor, cudaDevAttrComputeCapabilityMajor, dev));
+  if (ccMajor < 9) {
+    GTEST_SKIP() << "in-kernel colltrace requires sm_90+";
+  }
+
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+  const auto algo = NCCL_ALLREDUCE_ALGO::ctran;
+  if (!ctranAllReduceSupport(comm.get(), algo)) {
+    GTEST_SKIP() << "AllReduce not supported on this topology";
+  }
+
+  ctran::TestDeviceBuffer send(kCount * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(kCount * sizeof(int32_t));
+  fillSendBuf(send.get(), kCount, globalRank);
+
+  meta::comms::CudaStream stream(cudaStreamNonBlocking);
+  auto launch = [&](cudaStream_t s) {
+    ASSERT_EQ(
+        ctranAllReduce(
+            send.get(),
+            recv.get(),
+            kCount,
+            commInt32,
+            commSum,
+            comm.get(),
+            s,
+            algo),
+        commSuccess);
+  };
+
+  // Warm up eagerly (so connection-setup work isn't captured), then capture one
+  // AllReduce under the given NCCL_COLLTRACE_IN_KERNEL setting and count its
+  // KERNEL nodes. The cvar is read live at submit time, so toggling it here
+  // flips whether the host-launched timestamp kernels are emitted.
+  auto kernelNodeCount = [&](bool inKernel) -> size_t {
+    setenv("NCCL_COLLTRACE_IN_KERNEL", inKernel ? "true" : "false", 1);
+    ncclCvarInit();
+
+    launch(stream.get());
+    CUDACHECK_TEST(cudaStreamSynchronize(stream.get()));
+
+    cudaGraph_t graph = nullptr;
+    EXPECT_EQ(
+        cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeRelaxed),
+        cudaSuccess);
+    launch(stream.get());
+    EXPECT_EQ(cudaStreamEndCapture(stream.get(), &graph), cudaSuccess);
+    const size_t n =
+        getGraphTopology(graph).nodesOfType(cudaGraphNodeTypeKernel).size();
+    CUDACHECK_TEST(cudaGraphDestroy(graph));
+    return n;
+  };
+
+  // Capture the cvar's prior value so it can be restored exactly (rather than a
+  // hardcoded default) after toggling.
+  const char* priorInKernelEnv = getenv("NCCL_COLLTRACE_IN_KERNEL");
+  const bool hadPriorInKernel = priorInKernelEnv != nullptr;
+  const std::string priorInKernel =
+      hadPriorInKernel ? priorInKernelEnv : std::string{};
+
+  const size_t kernelsHostMode = kernelNodeCount(/*inKernel=*/false);
+  const size_t kernelsInKernel = kernelNodeCount(/*inKernel=*/true);
+
+  // Restore exactly the prior cvar value so later tests / teardown see the
+  // environment they set up, regardless of the fixture default.
+  if (hadPriorInKernel) {
+    setenv("NCCL_COLLTRACE_IN_KERNEL", priorInKernel.c_str(), 1);
+  } else {
+    unsetenv("NCCL_COLLTRACE_IN_KERNEL");
+  }
+  ncclCvarInit();
+
+  EXPECT_EQ(kernelsHostMode - kernelsInKernel, 2u)
+      << "enabling in-kernel colltrace should drop exactly the two host-launched "
+         "timestamp kernels (start + end): hostMode="
+      << kernelsHostMode << " inKernel=" << kernelsInKernel;
+}
+
+// AllGatherP `ctpipeline` is the only path that uses the multi-kernel colltrace
+// grouping (PipeStart=kBegin, PipeSync=kInner, PipeEnd=kEnd); every other
+// collective is a single kSolo kernel. This asserts the grouping collapses the
+// whole pipeline to exactly ONE colltrace record per graph replay (not one per
+// pipe stage, and not zero from a dropped end). ctgraph_pipeline requires an
+// intra-node NVL domain (nLocalRanks > 1) and a registered recvbuf, and is only
+// used during capture (eager warmup uses the direct ctran algo).
+TEST_F(CtranCudaGraphColltraceTest, AllGatherPPipelineOneRecordPerReplay) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+  if (!ctran::allGatherPSupport(comm.get()) ||
+      comm->statex_.get()->nLocalRanks() <= 1) {
+    GTEST_SKIP() << "AllGatherP ctpipeline requires nLocalRanks > 1";
+  }
+
+  ctran::TestDeviceBuffer send(kCount * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(kCount * numRanks * sizeof(int32_t));
+  fillSendBuf(send.get(), kCount, globalRank);
+
+  // The graph AGP path requires the recvbuf segment cached in the regcache;
+  // keep it registered until after the graph is destroyed below.
+  const size_t recvBytes = kCount * numRanks * sizeof(int32_t);
+  ctran::RegCache::getInstance()->globalRegister(
+      recv.get(), recvBytes, /*forceReg=*/true);
+
+  meta::comms::CudaStream stream(cudaStreamNonBlocking);
+  auto launch = [&](cudaStream_t s, enum NCCL_ALLGATHER_ALGO algo) {
+    ASSERT_EQ(
+        ctranAllGather(
+            send.get(), recv.get(), kCount, commInt32, comm.get(), s, algo),
+        commSuccess);
+  };
+  // Count only "AllGatherP" records (ignoring the one-time "AllGatherP_Init"
+  // and the direct-warmup "AllGather"), after draining colltrace.
+  auto countAllGatherP = [&]() -> int {
+    if (comm->colltraceNew_ != nullptr) {
+      comm->colltraceNew_->waitFlush(comm->colltraceNew_->requestFlush());
+    }
+    auto d = ctran::waitForCollTraceDrain(comm.get());
+    EXPECT_EQ(d["CT_currentColls"], "[]");
+    int n = 0;
+    for (const auto& rec : folly::parseJson(d["CT_pastColls"])) {
+      if (rec["opName"].asString() == "AllGatherP") {
+        ++n;
+      }
+    }
+    return n;
+  };
+
+  // Eager warmup on the direct algo, then capture the pipeline algo once.
+  launch(stream.get(), NCCL_ALLGATHER_ALGO::ctran);
+  CUDACHECK_TEST(cudaStreamSynchronize(stream.get()));
+
+  cudaGraph_t graph = nullptr;
+  cudaGraphExec_t graphExec = nullptr;
+  ASSERT_EQ(
+      cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeRelaxed),
+      cudaSuccess);
+  launch(stream.get(), NCCL_ALLGATHER_ALGO::ctgraph_pipeline);
+  ASSERT_EQ(cudaStreamEndCapture(stream.get(), &graph), cudaSuccess);
+  ASSERT_NE(graph, nullptr);
+  ASSERT_EQ(
+      cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0),
+      cudaSuccess);
+
+  const int before = countAllGatherP();
+  for (int i = 0; i < kNumReplays; ++i) {
+    ASSERT_EQ(cudaGraphLaunch(graphExec, stream.get()), cudaSuccess);
+  }
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+  const int after = countAllGatherP();
+
+  EXPECT_EQ(after - before, kNumReplays)
+      << "AllGatherP ctpipeline should emit exactly one colltrace record per "
+         "replay (one logical collective via kBegin/kInner/kEnd grouping, not "
+         "one per pipe stage): before="
+      << before << " after=" << after;
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  waitAndVerifyGpeClean(comm.get());
+  ctran::RegCache::getInstance()->globalDeregister(recv.get(), recvBytes);
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new CtranCudaGraphEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/utils/colltrace/CollTraceHandle.h
+++ b/comms/utils/colltrace/CollTraceHandle.h
@@ -9,6 +9,7 @@
 #include <folly/dynamic.h>
 
 #include "comms/utils/colltrace/CollTraceEvent.h"
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
 #include "comms/utils/commSpecs.h"
 
 namespace meta::comms::colltrace {
@@ -36,6 +37,21 @@ class ICollTraceHandle {
       folly::dynamic params) noexcept = 0;
   virtual CommsMaybe<std::shared_ptr<ICollRecord>> getCollRecord() noexcept = 0;
   virtual CommsMaybeVoid invalidate() noexcept = 0;
+
+  // In-kernel colltrace: expose the graph ring device handle + collId so the
+  // GPE can point the collective kernel at where to write its own start/end
+  // timestamps, instead of the host-launched timestamp kernels. Returns a
+  // non-capable handle for cases that don't support it (eager, dummy); only the
+  // graph handle overrides this.
+  virtual ColltraceDeviceHandle getColltraceDeviceHandle() noexcept {
+    return {};
+  }
+
+  // Called by the GPE once it has committed to writing timestamps in-kernel via
+  // getColltraceDeviceHandle(): suppresses this handle's host-launched
+  // timestamp writes so the start/end aren't recorded twice. No-op unless
+  // overridden.
+  virtual void suppressInterKernelTimestamps() noexcept {}
 };
 
 // Handle to be returned to the user for triggering stages for the collective.

--- a/comms/utils/colltrace/ColltraceDeviceHandle.h
+++ b/comms/utils/colltrace/ColltraceDeviceHandle.h
@@ -1,0 +1,45 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+#include "comms/utils/colltrace/GraphCollTraceEvent.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+
+namespace meta::comms::colltrace {
+
+// The device-side handle colltrace hands to a collective kernel so it can
+// publish its own start/end timestamps into the graph ring from inside the
+// kernel, replacing the host-launched timestamp kernels on the graph path.
+struct ColltraceDeviceHandle {
+  // NOTE: these scalar fields are intentionally placed BEFORE the embedded
+  // HRDWRingBufferDeviceHandle. That handle uses [[no_unique_address]] empty
+  // members in its Overwrite specialization; when it is the first member, nvcc
+  // computes a different offset for a following field on the device than on the
+  // host -- it places the field past the end of the object (observed: host
+  // offsetof(collId) == 24 but the device reads it at 32, with sizeof == 24 on
+  // both), so the kernel reads collId/emit flags back as 0. Keeping the scalars
+  // in the head bytes keeps the host and device offsets in agreement.
+  uint32_t collId{0};
+  // Which boundaries this kernel emits, set host-side per the kernel's role in
+  // the collective: a single-kernel collective emits both; a multi-kernel one
+  // emits start on its first kernel and end on its last; interior kernels emit
+  // neither. Read by ColltraceEventScope (ctor→start, dtor→end).
+  bool emitStart{false};
+  bool emitEnd{false};
+  ::hrdw_ring_buffer::HRDWRingBufferDeviceHandle<GraphCollTraceEvent> ring{};
+
+  // Usable only when a ring is attached (the graph in-kernel path). A default
+  // (null-ring) handle means "not armed": host callers keep the host-launched
+  // timestamps, and the in-kernel emit is a no-op. Callable from device code
+  // since the collective kernel gates its ring write on it.
+#if defined(__CUDACC__) || defined(__HIPCC__)
+  __host__ __device__
+#endif
+      bool valid() const {
+    return ring.ring != nullptr;
+  }
+};
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/GraphCollTraceHandle.h
+++ b/comms/utils/colltrace/GraphCollTraceHandle.h
@@ -2,9 +2,12 @@
 
 #pragma once
 
+#include <cassert>
+
 #include "comms/utils/colltrace/CollRecord.h"
 #include "comms/utils/colltrace/CollTraceHandle.h"
 #include "comms/utils/colltrace/CollWaitEvent.h"
+#include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/commSpecs.h"
 
 namespace meta::comms::colltrace {
@@ -56,7 +59,34 @@ class GraphCollTraceHandle : public ICollTraceHandle {
     return folly::Unit{};
   }
 
+  ColltraceDeviceHandle getColltraceDeviceHandle() noexcept override {
+    auto* graphWaitEvent = graphWaitEvent_();
+    if (graphWaitEvent == nullptr || !graphWaitEvent->hasRingBuffer()) {
+      return {};
+    }
+    return {
+        .collId = graphWaitEvent->getCollId(),
+        .ring = graphWaitEvent->deviceHandle()};
+  }
+
+  void suppressInterKernelTimestamps() noexcept override {
+    if (auto* graphWaitEvent = graphWaitEvent_()) {
+      graphWaitEvent->setIntraKernelEmitActive();
+    }
+  }
+
  private:
+  // waitEvent_ is always a GraphCudaWaitEvent for this handle (constructed by
+  // CollTrace::recordGraphCollectiveImpl), or null after invalidate(). This is
+  // on the submit hot path, so static_cast avoids RTTI; the debug-only assert
+  // catches any future violation of that invariant.
+  GraphCudaWaitEvent* graphWaitEvent_() const {
+    assert(
+        waitEvent_ == nullptr ||
+        dynamic_cast<GraphCudaWaitEvent*>(waitEvent_) != nullptr);
+    return static_cast<GraphCudaWaitEvent*>(waitEvent_);
+  }
+
   ICollWaitEvent* waitEvent_;
   std::shared_ptr<ICollRecord> record_;
 };

--- a/comms/utils/colltrace/GraphCudaWaitEvent.cc
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.cc
@@ -47,6 +47,12 @@ void GraphCudaWaitEvent::attachRingBuffer(
 }
 
 CommsMaybeVoid GraphCudaWaitEvent::beforeCollKernelScheduled() noexcept {
+  // The collective kernel publishes its own start timestamp into the ring, so
+  // skip the host-launched timestamp kernel (and its stream fork) entirely.
+  if (intraKernelEmitActive_) {
+    return folly::unit;
+  }
+
   // Fork: collective stream -> timestamp stream so the start kernel is
   // captured into the graph. We use cudaStreamWaitEvent to bring the
   // timestamp stream into the capture with a dependency on the main
@@ -63,6 +69,12 @@ CommsMaybeVoid GraphCudaWaitEvent::beforeCollKernelScheduled() noexcept {
 }
 
 CommsMaybeVoid GraphCudaWaitEvent::afterCollKernelScheduled() noexcept {
+  // The collective kernel publishes its own end timestamp into the ring, so
+  // skip the host-launched timestamp kernel and the rejoin/dependency dance.
+  if (intraKernelEmitActive_) {
+    return folly::unit;
+  }
+
   // Fork: collective stream -> timestamp stream. This DAG edge ensures the
   // end timestamp kernel fires only after the collective completes.
   CUDA_CHECK_EXPECTED(cudaEventRecord(depEvent_, stream_));

--- a/comms/utils/colltrace/GraphCudaWaitEvent.h
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.h
@@ -69,6 +69,24 @@ class GraphCudaWaitEvent : public ICollWaitEvent {
     collId_ = collId;
   }
 
+  bool hasRingBuffer() const noexcept {
+    return ringBuffer_ != nullptr;
+  }
+
+  // Device-side write handle for the shared ring, handed to a collective kernel
+  // so it can publish its own start/end timestamps from inside the kernel.
+  ::hrdw_ring_buffer::HRDWRingBufferDeviceHandle<GraphCollTraceEvent>
+  deviceHandle() const noexcept {
+    return ringBuffer_->deviceHandle();
+  }
+
+  // Once the GPE has armed the collective kernel to write its own timestamps,
+  // this suppresses the host-launched timestamp kernels so start/end aren't
+  // recorded twice into the ring.
+  void setIntraKernelEmitActive() noexcept {
+    intraKernelEmitActive_ = true;
+  }
+
  private:
   cudaStream_t stream_;
   uint32_t collId_;
@@ -83,6 +101,11 @@ class GraphCudaWaitEvent : public ICollWaitEvent {
 
   // owned by CollTrace, shared across ALL graphs. set via attachRingBuffer().
   ::hrdw_ring_buffer::HRDWRingBuffer<GraphCollTraceEvent>* ringBuffer_{nullptr};
+
+  // When set, the collective kernel writes its own start/end timestamps into
+  // the ring, so beforeCollKernelScheduled()/afterCollKernelScheduled() skip
+  // the host-launched timestamp kernels. Set via setIntraKernelEmitActive().
+  bool intraKernelEmitActive_{false};
 };
 
 } // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/tests/GraphCollTraceUT.cc
+++ b/comms/utils/colltrace/tests/GraphCollTraceUT.cc
@@ -22,15 +22,21 @@
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/utils/colltrace/CollTrace.h"
 #include "comms/utils/colltrace/CollTraceHandle.h"
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
 #include "comms/utils/colltrace/CudaWaitEvent.h"
+#include "comms/utils/colltrace/GraphCollTraceEvent.h"
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
 using meta::comms::colltrace::CollTrace;
 using meta::comms::colltrace::CollTraceConfig;
+using meta::comms::colltrace::ColltraceDeviceHandle;
 using meta::comms::colltrace::CollTraceEvent;
 using meta::comms::colltrace::CollTraceHandleTriggerState;
+using meta::comms::colltrace::GraphCollTraceEvent;
+using meta::comms::colltrace::GraphCollTracePhase;
 using meta::comms::colltrace::GraphCudaWaitEvent;
 using meta::comms::colltrace::ICollMetadata;
 using meta::comms::colltrace::ICollTracePlugin;
@@ -250,6 +256,23 @@ class GraphColltraceProgressingTest : public ::testing::Test {
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
     cudaGraphInstantiate(&cg.instance, cg.graph, nullptr, nullptr, 0);
     return cg;
+  }
+
+  // Write a colltrace event into the ring via the device handle colltrace hands
+  // to a kernel — the same write a collective kernel does in-kernel (e.g.
+  // AllGatherP PipeStart/PipeEnd). Enqueued on stream_ so it is
+  // captured/replayed like the real kernel write.
+  void writeColltraceRing(
+      const ColltraceDeviceHandle& devHandle,
+      GraphCollTracePhase phase) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    hrdw_ring_buffer::launchRingBufferWrite<GraphCollTraceEvent>(
+        stream_,
+        devHandle.ring.ring,
+        devHandle.ring.writeIndex,
+        devHandle.ring.mask,
+        devHandle.ring.shift,
+        GraphCollTraceEvent{devHandle.collId, phase});
   }
 
   cudaStream_t stream_{nullptr};
@@ -484,4 +507,176 @@ TEST_F(GraphColltraceProgressingTest, EagerAndGraphMergedByTimestamp) {
   cudaGraphExecDestroy(instance);
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
   cudaGraphDestroy(graph);
+}
+
+// ---------------------------------------------------------------------------
+// In-kernel colltrace: the collective kernel writes its own start/end into the
+// ring via the ColltraceDeviceHandle colltrace exposes, replacing the separate
+// inter-kernel timestamp kernels. These validate the colltrace-layer contract
+// the GPE relies on when arming AllGatherP's PipeStart/PipeEnd (and Solo)
+// kernels. The AllGatherP grouping/arming itself is covered at the ctran layer.
+// ---------------------------------------------------------------------------
+
+// getColltraceDeviceHandle() is capable only for the graph path; eager wait
+// events (no ring) report not-capable so the GPE keeps the host path.
+TEST_F(GraphColltraceProgressingTest, DeviceHandleCapableOnlyForGraphPath) {
+  // A graph collective must be recorded while the stream is capturing —
+  // recordCollective binds it to the capturing stream's graph state.
+  cudaGraph_t graph = nullptr;
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
+  auto graphWaitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
+  auto graphHandle =
+      colltrace_
+          ->recordCollective(
+              std::make_unique<SimpleMetadata>(), std::move(graphWaitEvent))
+          .value();
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamEndCapture(stream_, &graph);
+  if (graph != nullptr) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaGraphDestroy(graph);
+  }
+
+  auto devHandle = graphHandle->getColltraceDeviceHandle();
+  EXPECT_TRUE(devHandle.valid())
+      << "graph wait event with an attached ring must be in-kernel capable";
+  auto record = graphHandle->getCollRecord();
+  ASSERT_TRUE(record.hasValue() && record.value() != nullptr);
+  EXPECT_EQ(devHandle.collId, record.value()->getCollId())
+      << "device handle collId must match the record's collId";
+
+  // An eager wait event (recorded outside capture) has no ring and must not be
+  // in-kernel capable, so the GPE keeps the host-launched timestamp path.
+  auto eagerHandle =
+      colltrace_
+          ->recordCollective(
+              std::make_unique<SimpleMetadata>(),
+              std::make_unique<meta::comms::colltrace::CudaWaitEvent>(stream_))
+          .value();
+  EXPECT_FALSE(eagerHandle->getColltraceDeviceHandle().valid())
+      << "eager wait event has no ring and must not be in-kernel capable";
+}
+
+// After suppressInterKernelTimestamps(), trigger(Before/After) must not write
+// the ring. With no in-kernel writes simulated either, the collective never
+// completes — proving the inter-kernel start/end timestamp kernels were
+// actually suppressed.
+TEST_F(
+    GraphColltraceProgressingTest,
+    SuppressedInterKernelTimestampsProduceNoEvents) {
+  CapturedGraph cg;
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
+  auto metadata = std::make_unique<SimpleMetadata>();
+  auto waitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
+  auto handle =
+      colltrace_->recordCollective(std::move(metadata), std::move(waitEvent))
+          .value();
+  handle->suppressInterKernelTimestamps();
+  handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+  launchHostSleep(10);
+  handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamEndCapture(stream_, &cg.graph);
+  ASSERT_NE(cg.graph, nullptr);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphInstantiate(&cg.instance, cg.graph, nullptr, nullptr, 0);
+
+  ASSERT_EQ(cudaGraphLaunch(cg.instance, stream_), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+  // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  EXPECT_TRUE(progressPlugin_->getStartedCollIds().empty())
+      << "no start should be recorded when inter-kernel timestamps are suppressed";
+  EXPECT_TRUE(progressPlugin_->getCompletedCollIds().empty())
+      << "no completion should be recorded when inter-kernel timestamps are suppressed";
+}
+
+// With inter-kernel timestamps suppressed, the kernel-style writes through the
+// ColltraceDeviceHandle drive the exact same poll-thread pairing: one start,
+// one completion for the logical collective.
+TEST_F(GraphColltraceProgressingTest, InKernelWritesPairStartAndEnd) {
+  CapturedGraph cg;
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
+  auto metadata = std::make_unique<SimpleMetadata>();
+  auto waitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
+  auto handle =
+      colltrace_->recordCollective(std::move(metadata), std::move(waitEvent))
+          .value();
+  auto devHandle = handle->getColltraceDeviceHandle();
+  ASSERT_TRUE(devHandle.valid());
+  handle->suppressInterKernelTimestamps();
+
+  // Host timestamp kernels are suppressed; the kernel writes its own start/end.
+  handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+  writeColltraceRing(devHandle, GraphCollTracePhase::kStart);
+  launchHostSleep(10);
+  writeColltraceRing(devHandle, GraphCollTracePhase::kEnd);
+  handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamEndCapture(stream_, &cg.graph);
+  ASSERT_NE(cg.graph, nullptr);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphInstantiate(&cg.instance, cg.graph, nullptr, nullptr, 0);
+
+  ASSERT_EQ(cudaGraphLaunch(cg.instance, stream_), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+  // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  EXPECT_EQ(progressPlugin_->getStartedCollIds().size(), 1u)
+      << "in-kernel start write should be observed for the collective";
+  EXPECT_EQ(progressPlugin_->getCompletedCollIds().size(), 1u)
+      << "in-kernel start+end writes should pair into one completion";
+}
+
+// Timeout/hang detection must survive the grouped in-kernel path: a collective
+// that wrote its in-kernel start (PipeStart ran) but never its end (stalled
+// before PipeEnd) must still be flagged in-flight so the watchdog — which
+// consumes collEventProgressing — can time it out. Writes only kStart via the
+// device handle, then stalls with no kEnd, and asserts progressing fires while
+// completion never does.
+TEST_F(GraphColltraceProgressingTest, InKernelStartWithoutEndDetectedInFlight) {
+  constexpr uint64_t kStallMs = 100;
+  CapturedGraph cg;
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
+  auto metadata = std::make_unique<SimpleMetadata>();
+  auto waitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
+  auto handle =
+      colltrace_->recordCollective(std::move(metadata), std::move(waitEvent))
+          .value();
+  auto devHandle = handle->getColltraceDeviceHandle();
+  ASSERT_TRUE(devHandle.valid());
+  handle->suppressInterKernelTimestamps();
+
+  // PipeStart wrote the start; the pipeline then stalls (host sleep) and the
+  // end is never written — the collect stays in-flight the whole time.
+  handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+  writeColltraceRing(devHandle, GraphCollTracePhase::kStart);
+  launchHostSleep(kStallMs);
+  // No kEnd — simulates a hang between PipeStart and PipeEnd.
+  handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamEndCapture(stream_, &cg.graph);
+  ASSERT_NE(cg.graph, nullptr);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphInstantiate(&cg.instance, cg.graph, nullptr, nullptr, 0);
+
+  // While the start sits in the ring with no end for ~kStallMs, the 1ms poll
+  // thread must observe the collective as in-flight and fire progressing.
+  ASSERT_EQ(cudaGraphLaunch(cg.instance, stream_), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+  // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+  EXPECT_FALSE(progressPlugin_->getProgressedCollIds().empty())
+      << "a started-but-not-ended collective must be detected in-flight so the "
+         "watchdog can time it out";
+  EXPECT_GT(progressPlugin_->progressCount(), 0);
+  EXPECT_TRUE(progressPlugin_->getCompletedCollIds().empty())
+      << "a collective whose end never fired must never be marked completed";
 }

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2522,6 +2522,19 @@ cvars:
      still haven't fully tested the performance impact of this feature. So
      it is disabled by default. In the future, we will enable it by default.
 
+ - name        : NCCL_COLLTRACE_IN_KERNEL
+   type        : bool
+   default     : true
+   description : |-
+     For graph-captured collectives on sm_90+, have the collective kernel
+     publish its own start/end timestamps into the colltrace ring from inside
+     the kernel, instead of the host-launched inter-kernel timestamp kernels.
+     Only takes effect when NCCL_COLLTRACE_TRACE_CUDA_GRAPH is also enabled
+     (that is what allocates the ring this writes into); setting it in
+     isolation is a no-op. Independent of the GPE device ring
+     (NCCL_CTRAN_GPE_DEVICE_RING). Enabled by default; set to false to fall
+     back to the host-launched timestamp kernels if issues arise.
+
  - name        : NCCL_COLLTRACE_CTRAN_USE_CPU_RECORD
    type        : bool
    default     : true


### PR DESCRIPTION
Summary:

Follow-up to D112844323, which landed the in-kernel colltrace emit machinery
(`ColltraceEventScope`, `ColltraceDeviceHandle`, GPE arming) and wired it into
the AllGatherP pipeline path plus the Direct AllGather/AllReduce/ReduceScatter
kernels exercised by the integration test.

This diff applies the same mechanical change to the remaining ctran collectives:
a `ColltraceEventScope colltraceScope(f);` at the top of each collective kernel
and the matching `config.colltraceGroupRole` on the host submit. Covered:
AllGather (BrucksFF, Ring, StreamedRd), AllGatherP Direct, AllReduce Ring,
AllToAll (AllToAll, AllToAllP, AllToAllv, CompressedAllToAllv), Broadcast
(Direct, BinomialTree), RMA (Get, PutSignal), ReduceScatter (RHD, Ring), and
SendRecv (SendRecv, SendRecvP2p). No machinery changes.

Behavior is unchanged unless `NCCL_COLLTRACE_IN_KERNEL` is enabled; before this
diff these algos kept `colltraceGroupRole == kNone` and fell back to the
host-launched timestamp kernels, so this only extends in-kernel coverage.

Differential Revision: D113039156
