### PR TITLE
Fix NVL barrier for non-power-of-2 rank counts

### DIFF
--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -194,6 +194,26 @@ commResult_t createPersistentRequest(
       scopedRegisterUs,
       ipcExchangeUs);
 
+  // AgpCreate/IpcExchange is the createPersistentRequest-side wall time of the
+  // IPC exchange phase: for graph (waitForInit) it is the real blocking
+  // exchange, but for eager it is only the async submitHost latency -- the
+  // actual exchange runs later on the GPE thread and is captured by the
+  // AgpCreate/IpcExchange/Intra* child rows.
+  NcclScubaEvent(
+      std::make_unique<CommEvent>(
+          &comm->logMetaData_,
+          "AgpCreate/Reg",
+          std::string(),
+          scopedRegisterUs / 1000.0))
+      .record();
+  NcclScubaEvent(
+      std::make_unique<CommEvent>(
+          &comm->logMetaData_,
+          "AgpCreate/IpcExchange",
+          std::string(),
+          ipcExchangeUs / 1000.0))
+      .record();
+
   reqGuard.dismiss();
   *out = request.release();
 

--- a/comms/ctran/algos/AllGatherP/CommUtils.h
+++ b/comms/ctran/algos/AllGatherP/CommUtils.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <iostream>
+#include <memory>
 #include <vector>
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGatherP/Types.h"
@@ -12,6 +13,7 @@
 #include "comms/ctran/regcache/RegCache.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/ctran/utils/ExtUtils.h"
+#include "comms/utils/logger/ScubaLogger.h"
 
 namespace ctran::allgatherp {
 inline void* getPtr(void* base, size_t offset) {
@@ -58,6 +60,21 @@ inline commResult_t exchangeIpcReg(CtranComm* comm, PersistArgs& pArgs) {
       ctrlUs,
       barrierUs,
       statex->nLocalRanks());
+
+  NcclScubaEvent(
+      std::make_unique<CommEvent>(
+          &comm->logMetaData_,
+          "AgpCreate/IpcExchange/IntraAllGatherCtrl",
+          std::string(),
+          ctrlUs / 1000.0))
+      .record();
+  NcclScubaEvent(
+      std::make_unique<CommEvent>(
+          &comm->logMetaData_,
+          "AgpCreate/IpcExchange/IntraBarrier",
+          std::string(),
+          barrierUs / 1000.0))
+      .record();
 
   const int myRank = statex->rank();
   const int nLocalRanks = statex->nLocalRanks();

--- a/comms/ctran/algos/barrier.cuh
+++ b/comms/ctran/algos/barrier.cuh
@@ -14,79 +14,59 @@
 #include "comms/ctran/algos/DevCommon.cuh"
 
 /*
- * This is a multi-step logarithmic complexity barrier algorithm that
- * is safe for non-power-of-two processes.
+ * Dissemination barrier: a logarithmic-step barrier that is correct for ANY
+ * number of ranks, including non-powers-of-two.
  *
- * Step 1: We form groups of 2.  Each group synchronizes within it.
- * Step 2: We form groups of 4.  In each group, the lower half of the
- *   processes do a pair-wise synchronization with the higher half of
- *   the processes.  At this point, everyone in the group is
- *   synchronized.
- * Steps 3 onward: We continue the same model with doubling group
- *   sizes.  After each step, all processes in the group are
- *   synchronized.
+ * At step k (k = 0, 1, ..., nsteps-1, with distance d = 2^k) every rank r:
+ *   - signals rank up   = (r + d)          % nranks, and
+ *   - waits on rank down = (r - d + nranks) % nranks.
+ * After ceil(log2(nranks)) steps the arrival of every rank has propagated to
+ * every other rank, so no rank exits before all ranks have arrived. Unlike a
+ * pairwise/butterfly barrier, no peer is ever skipped -- that skip is exactly
+ * what dropped synchronization edges (and thus broke correctness) for
+ * non-power-of-two rank counts.
  *
- * If a process does not have a peer (because the number of ranks is
- * not a power of two), that process simply skips that step.
+ * Each directed edge r -> up uses the mailbox that lives in up's memory and is
+ * dedicated to the (r -> up) channel: r posts via devSyncGetLoc<REMOTE>(up) and
+ * up consumes the very same slot via devSyncGetLoc<LOCAL>(r) (its down at the
+ * same step is r). A given physical mailbox is therefore touched by exactly one
+ * (writer, reader) pair, at exactly one step, per barrier() call.
  *
- * For synchronization, the lower rank process sets a flag on the
- * higher rank process' mailbox.  The higher rank process on
- * receiving this flag, resets the flag and sets a flag on the lower
- * rank process' mailbox.  The lower rank flag then resets its local
- * flag.  This approach avoids race conditions where the flag could be
- * overwritten before it is read by the other process.
+ * Reuse safety across repeated barrier() calls relies on the two-phase
+ * step/RESET handshake: the writer waits for the slot to read RESET (left so by
+ * the reader of the previous call, or by initialization) before posting `step`,
+ * and the reader restores RESET after consuming. A stale value can never
+ * satisfy a later call's wait -- the reader always resets its own slot before
+ * its next call, and the writer is blocked from overwriting until the previous
+ * value has been consumed.
+ *
+ * Each rank posts its outgoing signal before blocking on its incoming one.
+ * Posting only requires the target slot to already be RESET (guaranteed by
+ * initialization or the previous call, never by the current step), so every
+ * rank can post before any rank blocks; this breaks the cyclic wait that would
+ * otherwise deadlock the ring of edges within a step.
  */
 __device__ __forceinline__ void barrier(int rank, int nranks) {
-  CtranAlgoDeviceSync* sync;
-
   int nsteps = 0;
   while ((1 << nsteps) < nranks) {
     nsteps++;
   }
 
   for (int step = 0; step < nsteps; step++) {
-    int groupSize = 1 << (step + 1);
-    int group = rank / groupSize;
-    int groupRank = rank - group * groupSize;
+    const int dist = 1 << step;
+    const int up = (rank + dist) % nranks;
+    const int down = (rank - dist + nranks) % nranks;
 
-    if (groupRank < groupSize / 2) {
-      int peer = group * groupSize + groupRank + groupSize / 2;
+    // Signal `up`: post `step` into the slot in up's memory that belongs to
+    // this rank, once the previous call's reader has left it at RESET.
+    CtranAlgoDeviceSync* upSync = devSyncGetLoc<REMOTE>(up);
+    devSyncWaitStep(upSync, blockIdx.x, CTRAN_ALGO_STEP_RESET);
+    devSyncSetStep(upSync, blockIdx.x, step);
 
-      if (peer >= nranks) {
-        continue;
-      }
-
-      // Ping to remote peer
-      sync = devSyncGetLoc<REMOTE>(peer);
-      // First wait for CTRAN_ALGO_STEP_RESET ensures the completion of previous
-      // step or previous collective
-      devSyncWaitStep(sync, blockIdx.x, CTRAN_ALGO_STEP_RESET);
-      devSyncSetStep(sync, blockIdx.x, step);
-
-      // Pong from remote peer to local
-      sync = devSyncGetLoc<LOCAL>(peer);
-      devSyncWaitStep(sync, blockIdx.x, step);
-      // Mark this step has been synced, thus peer can use for next step
-      devSyncSetStep(sync, blockIdx.x, CTRAN_ALGO_STEP_RESET);
-    } else {
-      int peer = group * groupSize + groupRank - groupSize / 2;
-
-      if (peer >= nranks) {
-        continue;
-      }
-
-      // Pong from remote peer to local
-      sync = devSyncGetLoc<LOCAL>(peer);
-      devSyncWaitStep(sync, blockIdx.x, step);
-      // Mark this step has been synced, thus peer can use for next step
-      devSyncSetStep(sync, blockIdx.x, CTRAN_ALGO_STEP_RESET);
-
-      // Ping to remote peer
-      sync = devSyncGetLoc<REMOTE>(peer);
-      // First wait for CTRAN_ALGO_STEP_RESET ensures the completion of previous
-      // step or previous collective
-      devSyncWaitStep(sync, blockIdx.x, CTRAN_ALGO_STEP_RESET);
-      devSyncSetStep(sync, blockIdx.x, step);
-    }
+    // Wait on `down`: consume its signal from the slot in this rank's memory,
+    // then restore RESET so the next call's writer can reuse the slot.
+    CtranAlgoDeviceSync* downSync = devSyncGetLoc<LOCAL>(down);
+    devSyncWaitStep(downSync, blockIdx.x, step);
+    devSyncSetStep(downSync, blockIdx.x, CTRAN_ALGO_STEP_RESET);
   }
 }

--- a/comms/ctran/algos/tests/CtranDistAlgoDevUTKernels.cu
+++ b/comms/ctran/algos/tests/CtranDistAlgoDevUTKernels.cu
@@ -2,6 +2,7 @@
 
 #include "comms/ctran/algos/DevAlgoImpl.cuh"
 #include "comms/ctran/algos/DevCommon.cuh"
+#include "comms/ctran/algos/barrier.cuh"
 #include "comms/ctran/algos/localReduce.cuh"
 #include "comms/ctran/algos/tests/CtranDistAlgoDevUTKernels.h"
 
@@ -146,6 +147,80 @@ __global__ void __launch_bounds__(512, 1) testNaiveKernCopy(
       recvbuff[j] = sendbuff[j];
     }
   }
+}
+
+__global__ void __launch_bounds__(1024, 1) testKernNvlBarrierLoop(
+    int rank,
+    int nLocalRanks,
+    int nIters,
+    int* selfSlot,
+    int** peerSlots,
+    int* errCount,
+    CtranAlgoDeviceState* devState) {
+  devStateLoadToShm(devState);
+
+  for (int iter = 1; iter <= nIters; iter++) {
+    // Rotate the delayed ("laggard") rank across all ranks over iterations so
+    // every rank's incoming barrier edges are exercised as the last arrival.
+    const int laggard = iter % nLocalRanks;
+
+    if (threadIdx.x == 0) {
+      // The laggard busy-waits before publishing so it reliably enters the
+      // barrier LAST. A correct barrier forces every other rank to wait for
+      // it, so all read the fresh token; a barrier that drops an edge to the
+      // laggard lets some rank proceed and read the STALE token (iter-1, or the
+      // init value on the first iteration) -> a deterministic mismatch.
+      if (rank == laggard) {
+        __nanosleep(200000);
+      }
+      // Publish this iteration's token into this rank's NVL-visible slot. The
+      // token is always nonzero, so the zero-initialized buffer cannot
+      // masquerade as a valid token.
+      comms::device::st_release_sys_global(selfSlot, iter);
+    }
+
+    // Every rank must observe all tokens before any rank reads them.
+    barrier(rank, nLocalRanks);
+
+    // Verify every peer published exactly this iteration's token.
+    if (threadIdx.x == 0) {
+      for (int peer = 0; peer < nLocalRanks; peer++) {
+        const int val = comms::device::ld_acquire_sys_global(peerSlots[peer]);
+        if (val != iter) {
+          atomicAdd(errCount, 1);
+        }
+      }
+    }
+
+    // Prevent any rank from overwriting its slot for iter+1 before all peers
+    // have finished reading the current iteration's tokens.
+    barrier(rank, nLocalRanks);
+  }
+}
+
+cudaError_t testKernNvlBarrierLoopWrapper(
+    dim3 grid,
+    dim3 blocks,
+    cudaStream_t stream,
+    int rank,
+    int nLocalRanks,
+    int nIters,
+    int* selfSlot,
+    int** peerSlots,
+    int* errCount,
+    CtranAlgoDeviceState* devState) {
+  void* args[] = {
+      &rank,
+      &nLocalRanks,
+      &nIters,
+      &selfSlot,
+      &peerSlots,
+      &errCount,
+      &devState};
+  void* fn = reinterpret_cast<void*>(testKernNvlBarrierLoop);
+
+  return CUDA_LAUNCH_KERNEL_WITH_DYNAMIC_SHM_RETURN(
+      fn, grid, blocks, args, sizeof(CtranAlgoDeviceState), stream);
 }
 
 cudaError_t testKernMultiPutNotifyWrapper(

--- a/comms/ctran/algos/tests/CtranDistAlgoDevUTKernels.h
+++ b/comms/ctran/algos/tests/CtranDistAlgoDevUTKernels.h
@@ -51,6 +51,27 @@ cudaError_t testKernBcastWrapper(
     int nBcastBlocks,
     CtranAlgoDeviceState* devState);
 
+// Launch the barrier correctness test kernel. Each of `nIters` iterations picks
+// a rotating "laggard" rank (`iter % nLocalRanks`) that busy-waits before
+// publishing `iter` into its NVL-visible `selfSlot`, so it reliably enters the
+// barrier last. Every rank then barriers, reads every peer's slot via
+// `peerSlots` and increments `errCount` on any token that is not exactly
+// `iter`, then barriers again. A correct barrier makes all ranks wait for the
+// laggard (fresh tokens, `errCount == 0`); a barrier that drops synchronization
+// edges (e.g. for non-power-of-two ranks) lets a rank proceed early and read
+// the laggard's stale token, producing a non-zero `errCount`.
+cudaError_t testKernNvlBarrierLoopWrapper(
+    dim3 grid,
+    dim3 blocks,
+    cudaStream_t stream,
+    int rank,
+    int nLocalRanks,
+    int nIters,
+    int* selfSlot,
+    int** peerSlots,
+    int* errCount,
+    CtranAlgoDeviceState* devState);
+
 cudaError_t testKernDequantizedAllToAllReduceWrapper(
     const void* sendBuff,
     void* recvBuff,

--- a/comms/ctran/algos/tests/CtranDistBarrierTest.cc
+++ b/comms/ctran/algos/tests/CtranDistBarrierTest.cc
@@ -1,0 +1,87 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/algos/tests/CtranDistAlgoDevUTBase.h"
+#include "comms/ctran/algos/tests/CtranDistAlgoDevUTKernels.h"
+#include "comms/testinfra/TestUtils.h"
+
+// Directly exercises the NVL device barrier for whatever nLocalRanks the target
+// is configured with (see the ppn variants in BUCK, which include
+// non-powers-of-two). A barrier that drops synchronization edges lets some rank
+// exit early and observe a stale or future token, which this test detects.
+TEST_F(CtranDistAlgoDevTest, NvlBarrierManyIters) {
+  constexpr int kNumIters = 200;
+
+  const int localRankId = ctranComm_->statex_->localRank();
+  const int nLocalRanks = ctranComm_->statex_->nLocalRanks();
+
+  // Each rank exposes a single NVL-visible token slot in its IPC buffer.
+  initIpcBufs<int>(1);
+  CUDACHECK_TEST(cudaMemset(ipcBuf_, 0, sizeof(int)));
+
+  // Build the device array of per-rank slot pointers (self + imported peers).
+  std::vector<int*> peerSlotsHost(nLocalRanks, nullptr);
+  for (int peer = 0; peer < nLocalRanks; peer++) {
+    peerSlotsHost[peer] = (peer == localRankId)
+        ? reinterpret_cast<int*>(ipcBuf_)
+        : reinterpret_cast<int*>(ipcRemMem_.at(peer)->getBase());
+  }
+
+  int** peerSlots = nullptr;
+  int* errCount = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&peerSlots, nLocalRanks * sizeof(int*)));
+  CUDACHECK_TEST(cudaMalloc(&errCount, sizeof(int)));
+  CUDACHECK_TEST(cudaMemcpy(
+      peerSlots,
+      peerSlotsHost.data(),
+      nLocalRanks * sizeof(int*),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(errCount, 0, sizeof(int)));
+
+  // Ensure every rank has initialized its slot before any peer reads it.
+  barrierNvlDomain(ctranComm_.get());
+
+  cudaStream_t stream = nullptr;
+  CUDACHECK_TEST(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+
+  // Single block / single thread, mirroring the production nvlBarrier launch.
+  dim3 grid = {1, 1, 1};
+  dim3 blocks = {1, 1, 1};
+  CUDACHECK_TEST(testKernNvlBarrierLoopWrapper(
+      grid,
+      blocks,
+      stream,
+      localRankId,
+      nLocalRanks,
+      kNumIters,
+      reinterpret_cast<int*>(ipcBuf_),
+      peerSlots,
+      errCount,
+      ctranComm_->ctran_->algo->getDevState()));
+
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  int errCountHost = -1;
+  CUDACHECK_TEST(
+      cudaMemcpy(&errCountHost, errCount, sizeof(int), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(errCountHost, 0)
+      << "Rank " << globalRank << " observed " << errCountHost
+      << " stale/future tokens across " << kNumIters << " iterations with "
+      << nLocalRanks << " local ranks";
+
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+  CUDACHECK_TEST(cudaFree(peerSlots));
+  CUDACHECK_TEST(cudaFree(errCount));
+  freeIpcBufs();
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new ctran::CtranDistEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ctran/tests/CtranDistAllgatherPTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherPTests.cc
@@ -13,6 +13,9 @@
 #endif
 
 #include <nccl.h>
+#include <filesystem>
+#include <set>
+#include <sstream>
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/algos/AllGatherP/AlgoImpl.h"
 #include "comms/ctran/profiler/Profiler.h"
@@ -22,6 +25,16 @@
 #include "comms/ctran/utils/MathUtils.h"
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
+
+#include <folly/Singleton.h>
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+#include <folly/testing/TestUtil.h>
+
+#include "comms/utils/StrUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/Logger.h"
+#include "comms/utils/logger/tests/MockScubaTable.h"
 // Test sources uses ncclMemAlloc API from nccl.h/rccl.h, so adding this check
 // macro here so to avoid including TestUtils.h which doesn't support
 // cross-platform
@@ -37,6 +50,21 @@
       exit(EXIT_FAILURE);                    \
     }                                        \
   } while (0)
+
+namespace {
+// The nccl_structured_logging pipe filename embeds an unpredictable timestamp
+// suffix, so locate this rank's file by its stable name prefix.
+std::string findStructuredLoggingFile(const std::string& dir) {
+  const std::string namePrefix =
+      "dedicated_log_structured_json.perfpipe_nccl_structured_logging";
+  for (const auto& entry : std::filesystem::directory_iterator(dir)) {
+    if (entry.path().filename().string().rfind(namePrefix, 0) == 0) {
+      return entry.path().string();
+    }
+  }
+  return "";
+}
+} // namespace
 
 class CtranAllgatherPTestEnv : public ctran::CtranEnvironmentBase {
  public:
@@ -615,6 +643,89 @@ TEST_F(CtranAllgatherPTest, InternalRegisteredMemory) {
 
   ASSERT_EQ(ctran::allGatherPDestroy(request), commSuccess);
   delete request;
+}
+
+// Verifies createPersistentRequest (AllGatherP.cc) and exchangeIpcReg
+// (CommUtils.h) record the AgpCreate IPC-exchange latency rows to the
+// nccl_structured_logging scuba table with the expected stage names and
+// comm-identity fields when NCCL_COMM_EVENT_LOGGING is enabled.
+TEST_F(CtranAllgatherPTest, StructuredLoggingRecordsAgpCreateFields) {
+  // Stop the logger started during comm creation, then route the CommEvents
+  // emitted by the AGP create path to a per-rank pipe file we read back below.
+  NcclLogger::close();
+
+  folly::test::TemporaryDirectory tmpDir;
+  // Both cvars are read from the C++ globals at record time; the cudaMalloc
+  // path below never triggers a ncclCvarInit, so EnvRAII (not SysEnvRAII) is
+  // required for the values to reach the logger.
+  EnvRAII fileEnv(NCCL_SCUBA_LOG_FILE_PREFIX, tmpDir.path().string());
+  EnvRAII eventEnv(
+      NCCL_COMM_EVENT_LOGGING, std::string("pipe:nccl_structured_logging"));
+
+  // make_mock is the only way to force the DataTableAllTables singleton to be
+  // rebuilt after the per-test cvars are set (comm creation may have baked in
+  // an empty prefix). callParent=true makes the mock delegate to the real
+  // DataTable so records are written to the pipe file.
+  folly::Singleton<const DataTableAllTables, DataTableAllTablesTag>::make_mock(
+      []() { return new DataTableAllTables(createAllMockTables(true)); });
+  folly::Singleton<const DataTableAllTables, DataTableAllTablesTag>::try_get();
+
+  // Re-init the logger so a fresh nccl_structured_logging DataTableWrapper
+  // resolves against the mock singleton on the first recorded event.
+  NcclLogger::init();
+
+  EnvRAII algoEnv(NCCL_ALLGATHER_P_ALGO, NCCL_ALLGATHER_P_ALGO::ctdirect);
+
+  // cudaMalloc (not ncclMemAlloc) keeps the logging cvars intact by avoiding
+  // ncclMemAlloc's ncclCvarInit.
+  run(1024, 1024, kTestOutOfPlace, kMemCudaMalloc, ctranComm.get());
+
+  // Flush the background logging thread and close the pipe file before reading.
+  NcclLogger::close();
+
+  const std::string logFile = findStructuredLoggingFile(tmpDir.path().string());
+  ASSERT_FALSE(logFile.empty()) << "no nccl_structured_logging pipe file under "
+                                << tmpDir.path().string();
+  const auto output = readFromFile(logFile);
+  ASSERT_NE(output, "");
+
+  std::set<std::string> stages;
+  std::string regCommDesc;
+  int64_t regCommHash = 0;
+  bool sawReg = false;
+  std::istringstream iss(output);
+  std::string line;
+  while (std::getline(iss, line)) {
+    if (line.empty()) {
+      continue;
+    }
+    const auto jsonLog = folly::parseJson(line);
+    const auto stage = jsonLog["normal"]["stage"].asString();
+    stages.insert(stage);
+    if (stage == "AgpCreate/Reg" && !sawReg) {
+      sawReg = true;
+      regCommDesc = jsonLog["normal"]["commDesc"].asString();
+      regCommHash = jsonLog["int"]["commHash"].asInt();
+      EXPECT_GE(jsonLog["double"]["timerDeltaMs"].asDouble(), 0.0);
+    }
+  }
+
+  const std::vector<std::string> expectedStages = {
+      "AgpCreate/Reg",
+      "AgpCreate/IpcExchange",
+      "AgpCreate/IpcExchange/IntraAllGatherCtrl",
+      "AgpCreate/IpcExchange/IntraBarrier"};
+  for (const auto& expected : expectedStages) {
+    EXPECT_TRUE(stages.count(expected) > 0)
+        << "missing AgpCreate stage: " << expected;
+  }
+
+  // The AgpCreate/Reg row must carry the owning comm's identity.
+  ASSERT_TRUE(sawReg);
+  EXPECT_FALSE(regCommDesc.empty());
+  EXPECT_EQ(regCommDesc, ctranComm->logMetaData_.commDesc);
+  EXPECT_EQ(
+      regCommHash, static_cast<int64_t>(ctranComm->logMetaData_.commHash));
 }
 
 TEST_F(CtranAllgatherPTest, SharePersistentBuffer) {

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -22,6 +22,7 @@
 #include "comms/prims/window/HostWindow.h"
 #endif
 #include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/ScubaLogger.h"
 
 using ctran::window::RemWinInfo;
 
@@ -176,6 +177,7 @@ CtranWin::CtranWin(CtranComm* comm, size_t size, DevMemType bufType)
 }
 
 commResult_t CtranWin::exchange() {
+  CtranMapperTimer exchangeTotalTimer;
   auto statex = comm->statex_.get();
   const auto nRanks = statex->nRanks();
   const auto myRank = statex->rank();
@@ -196,6 +198,13 @@ commResult_t CtranWin::exchange() {
   FB_COMMCHECK(getWindowMapper(comm, &mapper));
   CtranMapperEpochRAII epochRAII(mapper);
 
+  const auto recordWinStage = [&](const std::string& stage, double us) {
+    NcclScubaEvent(
+        std::make_unique<CommEvent>(
+            &comm->logMetaData_, stage, std::string(), us / 1000.0))
+        .record();
+  };
+
   // The base buffer holds the signal buffer (register path) or the combined
   // data+signal buffer (allocate path). On the register path with signals
   // disabled there is no base buffer, so its registration and control exchange
@@ -204,6 +213,7 @@ commResult_t CtranWin::exchange() {
 
   // Registration via ctran mapper.
   if (exchangeBaseBuffer) {
+    CtranMapperTimer baseRegTimer;
     FB_COMMCHECK(mapper->regMem(
         winBasePtr,
         range_,
@@ -211,6 +221,7 @@ commResult_t CtranWin::exchange() {
         true,
         true, /* NCCL managed buffer */
         &baseRegHdl));
+    recordWinStage("WinExchange/BaseReg", baseRegTimer.durationUs());
   }
 
   if (allocDataBuf_) {
@@ -225,6 +236,7 @@ commResult_t CtranWin::exchange() {
     // RegElem* for the allGatherCtrl handle exchange.
     auto regCache = ctran::RegCache::getInstance();
     ctran::CHECK_VALID_REGCACHE(regCache);
+    CtranMapperTimer userRegTimer;
     FB_COMMCHECK(regCache->acquireScopedRegister(
         winDataPtr,
         dataBytes,
@@ -233,15 +245,26 @@ commResult_t CtranWin::exchange() {
         comm->logMetaData_,
         dataScopedReg));
     dataRegHdl = dataScopedReg.get();
+    recordWinStage("WinExchange/UserReg", userRegTimer.durationUs());
   }
 
-  // Exchange each rank's data buffer size via bootstrap allGather
-  // This populates remWinInfo[r].dataBytes for all ranks
+  // Populate each rank's data buffer size. A symmetric window guarantees every
+  // rank registered the same size, so fill locally and skip the bootstrap
+  // allGather round-trip; otherwise gather each rank's size.
+  // FIXME(ctwin): confirm whether this size allGather is needed at all for the
+  // non-symmetric path (added in D87390033).
   std::vector<size_t> allRankSizes(nRanks);
-  allRankSizes[myRank] = dataBytes;
-  auto resFuture = comm->bootstrap_->allGather(
-      allRankSizes.data(), sizeof(size_t), myRank, nRanks);
-  FB_COMMCHECK(static_cast<commResult_t>(std::move(resFuture).get()));
+  if (isSymmetric()) {
+    allRankSizes.assign(nRanks, dataBytes);
+  } else {
+    CtranMapperTimer sizeAllGatherTimer;
+    allRankSizes[myRank] = dataBytes;
+    auto resFuture = comm->bootstrap_->allGather(
+        allRankSizes.data(), sizeof(size_t), myRank, nRanks);
+    FB_COMMCHECK(static_cast<commResult_t>(std::move(resFuture).get()));
+    recordWinStage(
+        "WinExchange/SizeAllGather", sizeAllGatherTimer.durationUs());
+  }
 
   // Handshake with other peers for registration exchange and network
   // connection setup
@@ -294,22 +317,26 @@ commResult_t CtranWin::exchange() {
   };
 
   if (exchangeBaseBuffer) {
+    CtranMapperTimer baseExchangeTimer;
     FB_COMMCHECK(exchangeBuffer(
         winBasePtr,
         baseRegHdl,
         remoteBaseBufs,
         remoteBaseBufAccessKeys,
         /*outIpcHdls=*/nullptr));
+    recordWinStage("WinExchange/BaseExchange", baseExchangeTimer.durationUs());
   }
 
   if (!allocDataBuf_) {
     // User-provided data buffer needs its own handle exchange round.
+    CtranMapperTimer userExchangeTimer;
     FB_COMMCHECK(exchangeBuffer(
         winDataPtr,
         dataRegHdl,
         remoteUserBufs,
         remoteUserBufAccessKeys,
         &dataScopedIpcRegHdls));
+    recordWinStage("WinExchange/UserExchange", userExchangeTimer.durationUs());
   }
 
   for (auto r = 0; r < nRanks; r++) {
@@ -358,7 +385,9 @@ commResult_t CtranWin::exchange() {
 
   // A barrier among ranks after importing handles to prevent accessing window
   // memory space while other ranks are still importing.
+  CtranMapperTimer barrierTimer;
   FB_COMMCHECK(windowBarrier(comm, mapper));
+  recordWinStage("WinExchange/Barrier", barrierTimer.durationUs());
 
   // Cache only symmetric windows: ctwin collective algos needs all ranks
   // locally compute peerAddr = peerBase + offset, meaning same offset from base
@@ -367,6 +396,7 @@ commResult_t CtranWin::exchange() {
     FB_COMMCHECK(
         comm->winCache_.insert(winDataPtr, dataBytes, this, &winCacheHdl));
   }
+  recordWinStage("WinExchange", exchangeTotalTimer.durationUs());
   return commSuccess;
 }
 


### PR DESCRIPTION
Summary:
Replace the recursive-doubling (butterfly) NVL device barrier with a dissemination barrier that correctly synchronizes any number of ranks:
- `barrier()` in `barrier.cuh` used a recursive-doubling scheme that silently skipped peers via `if (peer >= nranks) continue;` when `nranks` was not a power of two, dropping synchronization edges. For example at nLocalRanks=6 ranks 2 and 3 never synchronized with ranks 4 and 5, so ranks could exit the barrier before all had arrived.
- This is a real GPU data race: the barrier backs `nvlBarrier`/`nvlCeBcast` (AllGatherP), `nvlCeAllToAll` (AllToAllP), and the Direct kernel, so a non-power-of-2 intra-node collective could read a peer's buffer from the wrong iteration (stale or future data). It manifested as flaky wrong-iteration reads in AllGatherP at nLocalRanks=6.
- Replaced with a dissemination barrier: at step k (dist=2^k) each rank signals `(rank+dist)%nranks` and waits on `(rank-dist+nranks)%nranks` for ceil(log2(nranks)) steps. No peer is ever skipped, so it is correct for any nranks. It is reuse-safe across repeated calls via the existing step/RESET two-phase handshake and deadlock-free via signal-before-wait; `blockIdx.x` indexing is unchanged so multi-block callers are unaffected.
- Added `CtranDistBarrierTest` covering nLocalRanks 2-8 (including non-power-of-2 3, 5, 6, 7). A rotating "laggard" rank delays before the barrier so a dropped synchronization edge deterministically produces a stale-token mismatch.

Differential Revision: D112963421


