### PR TITLE
Add multi-QP NIC_DONE sendrecv tests

### DIFF
--- a/comms/prims/collectives/benchmarks/IbSendRecvBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/IbSendRecvBenchmark.cc
@@ -15,9 +15,12 @@
 #include <gtest/gtest.h>
 #include <nccl.h> // @manual
 
+#include <algorithm>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -51,6 +54,108 @@ constexpr int kMeasureIters = 100;
 constexpr size_t KB = 1024;
 constexpr size_t MB = 1024 * 1024;
 constexpr size_t GB = 1024UL * 1024 * 1024;
+constexpr size_t kMismatchCopyChunkBytes = 4 * MB;
+
+bool expect_cuda_success(cudaError_t result, const char* expr) {
+  if (result == cudaSuccess) {
+    return true;
+  }
+  ADD_FAILURE() << expr << " failed: " << cudaGetErrorString(result);
+  return false;
+}
+
+#define CUDA_EXPECT_SUCCESS(cmd)            \
+  do {                                      \
+    (void)expect_cuda_success((cmd), #cmd); \
+  } while (0)
+
+namespace ib_bench = comms::prims::ib::benchmark;
+
+template <typename T>
+class DeviceScratch {
+ public:
+  explicit DeviceScratch(size_t count) {
+    CUDA_EXPECT_SUCCESS(cudaMalloc(&ptr_, count * sizeof(T)));
+  }
+
+  ~DeviceScratch() {
+    if (ptr_ != nullptr) {
+      CUDA_EXPECT_SUCCESS(cudaFree(ptr_));
+    }
+  }
+
+  DeviceScratch(const DeviceScratch&) = delete;
+  DeviceScratch& operator=(const DeviceScratch&) = delete;
+
+  T* get() const {
+    return ptr_;
+  }
+
+  T* at(size_t index) const {
+    return ptr_ + index;
+  }
+
+ private:
+  T* ptr_{nullptr};
+};
+
+class IterationEvents {
+ public:
+  explicit IterationEvents(int iterations)
+      : starts_(iterations), stops_(iterations) {
+    for (int i = 0; i < iterations; ++i) {
+      CUDA_EXPECT_SUCCESS(cudaEventCreate(&starts_[i]));
+      CUDA_EXPECT_SUCCESS(cudaEventCreate(&stops_[i]));
+    }
+  }
+
+  ~IterationEvents() {
+    for (auto event : starts_) {
+      if (event != nullptr) {
+        CUDA_EXPECT_SUCCESS(cudaEventDestroy(event));
+      }
+    }
+    for (auto event : stops_) {
+      if (event != nullptr) {
+        CUDA_EXPECT_SUCCESS(cudaEventDestroy(event));
+      }
+    }
+  }
+
+  IterationEvents(const IterationEvents&) = delete;
+  IterationEvents& operator=(const IterationEvents&) = delete;
+
+  cudaEvent_t start(int iteration) const {
+    return starts_[iteration];
+  }
+
+  cudaEvent_t stop(int iteration) const {
+    return stops_[iteration];
+  }
+
+  int iterations() const {
+    return static_cast<int>(starts_.size());
+  }
+
+ private:
+  std::vector<cudaEvent_t> starts_;
+  std::vector<cudaEvent_t> stops_;
+};
+
+void poison_destination(void* data, size_t nbytes, cudaStream_t stream) {
+  CUDA_EXPECT_SUCCESS(cudaMemsetAsync(data, 0xa5, nbytes, stream));
+}
+
+float sum_elapsed_ms(const IterationEvents& events) {
+  float elapsed_ms = 0;
+  for (int i = 0; i < events.iterations(); ++i) {
+    float iteration_ms = 0;
+    CUDA_EXPECT_SUCCESS(
+        cudaEventElapsedTime(&iteration_ms, events.start(i), events.stop(i)));
+    elapsed_ms += iteration_ms;
+  }
+  return elapsed_ms;
+}
 
 std::string format_size(size_t bytes) {
   if (bytes >= GB) {
@@ -63,6 +168,127 @@ std::string format_size(size_t bytes) {
     return std::to_string(bytes / KB) + "KB";
   }
   return std::to_string(bytes) + "B";
+}
+
+struct ByteMismatch {
+  size_t byte_index;
+  std::uint8_t observed;
+  std::uint8_t expected;
+};
+
+std::optional<ByteMismatch> find_first_rank_pattern_mismatch(
+    const void* data,
+    size_t nbytes,
+    int expected_rank,
+    cudaStream_t stream) {
+  if (nbytes == 0) {
+    return std::nullopt;
+  }
+
+  const auto* bytes = static_cast<const std::uint8_t*>(data);
+  std::vector<std::uint8_t> host(std::min(kMismatchCopyChunkBytes, nbytes));
+  for (size_t offset = 0; offset < nbytes; offset += host.size()) {
+    const size_t chunk_bytes = std::min(host.size(), nbytes - offset);
+    if (!expect_cuda_success(
+            cudaMemcpyAsync(
+                host.data(),
+                bytes + offset,
+                chunk_bytes,
+                cudaMemcpyDeviceToHost,
+                stream),
+            "cudaMemcpyAsync(mismatch chunk)")) {
+      return std::nullopt;
+    }
+    if (!expect_cuda_success(
+            cudaStreamSynchronize(stream),
+            "cudaStreamSynchronize(mismatch chunk)")) {
+      return std::nullopt;
+    }
+    for (size_t i = 0; i < chunk_bytes; ++i) {
+      const size_t byte_index = offset + i;
+      const std::uint8_t expected =
+          comms::prims::ib::benchmark::expected_rank_pattern_byte(
+              expected_rank, byte_index);
+      if (host[i] != expected) {
+        return ByteMismatch{
+            .byte_index = byte_index,
+            .observed = host[i],
+            .expected = expected,
+        };
+      }
+    }
+  }
+
+  return std::nullopt;
+}
+
+std::string describe_first_mismatch(
+    const std::optional<ByteMismatch>& mismatch) {
+  if (!mismatch.has_value()) {
+    return " firstMismatchByte=not-found";
+  }
+  return " firstMismatchByte=" + std::to_string(mismatch->byte_index) +
+      " observed=" + std::to_string(static_cast<int>(mismatch->observed)) +
+      " expected=" + std::to_string(static_cast<int>(mismatch->expected));
+}
+
+std::optional<ByteMismatch> find_first_mismatch_from_records(
+    const std::vector<ib_bench::MismatchRecord>& mismatch_partials,
+    int iteration) {
+  const size_t offset =
+      static_cast<size_t>(iteration) * ib_bench::kChecksumPartialBlocks;
+  uint64_t index = ib_bench::kNoMismatchIndex;
+  uint32_t observed = 0;
+  uint32_t expected = 0;
+  for (int i = 0; i < ib_bench::kChecksumPartialBlocks; ++i) {
+    const auto& record = mismatch_partials[offset + i];
+    if (record.index < index) {
+      index = record.index;
+      observed = record.observed;
+      expected = record.expected;
+    }
+  }
+
+  if (index == ib_bench::kNoMismatchIndex) {
+    return std::nullopt;
+  }
+  return ByteMismatch{
+      .byte_index = static_cast<size_t>(index),
+      .observed = static_cast<uint8_t>(observed),
+      .expected = static_cast<uint8_t>(expected),
+  };
+}
+
+struct ChecksumVerification {
+  int wrong{0};
+  int first_wrong_iteration{-1};
+  uint64_t observed_checksum{0};
+  uint64_t expected_checksum{0};
+  std::optional<ByteMismatch> mismatch;
+};
+
+ChecksumVerification verify_checksums(
+    const std::vector<uint64_t>& observed_checksums,
+    uint64_t expected_checksum,
+    const std::vector<ib_bench::MismatchRecord>& mismatch_partials) {
+  ChecksumVerification result;
+  result.expected_checksum = expected_checksum;
+  if (!observed_checksums.empty()) {
+    result.observed_checksum = observed_checksums.front();
+  }
+
+  for (int i = 0; i < static_cast<int>(observed_checksums.size()); ++i) {
+    if (observed_checksums[i] != expected_checksum) {
+      ++result.wrong;
+      if (result.first_wrong_iteration < 0) {
+        result.first_wrong_iteration = i;
+        result.observed_checksum = observed_checksums[i];
+        result.mismatch =
+            find_first_mismatch_from_records(mismatch_partials, i);
+      }
+    }
+  }
+  return result;
 }
 
 struct WindowSetup {
@@ -188,6 +414,9 @@ class IbSendRecvBenchmark : public ::testing::Test {
     int iterations;
     float elapsed_ms;
     double bw_gbps;
+    int wrong;
+    uint64_t observed_checksum;
+    uint64_t expected_checksum;
   };
 
   BenchResult run_put_benchmark(size_t total_bytes, int num_blocks) {
@@ -249,7 +478,7 @@ class IbSendRecvBenchmark : public ::testing::Test {
     cudaEventDestroy(stop);
     teardown_window(s, torchcomm_);
 
-    return {total_bytes, num_blocks, kMeasureIters, elapsed_ms, bw};
+    return {total_bytes, num_blocks, kMeasureIters, elapsed_ms, bw, 0, 0, 0};
   }
 
   BenchResult run_send_recv_benchmark(
@@ -307,15 +536,20 @@ class IbSendRecvBenchmark : public ::testing::Test {
     float* win_ptr = win_tensor.data_ptr<float>();
     float* dst_ptr = dst_tensor.data_ptr<float>();
 
-    // Persistent step state: 2 * num_blocks (senders + receivers).
-    int64_t* step_state = nullptr;
-    cudaMalloc(&step_state, 2 * num_blocks * sizeof(int64_t));
-    cudaMemset(step_state, 0, 2 * num_blocks * sizeof(int64_t));
-
-    // Warmup
     {
       c10::cuda::CUDAStreamGuard guard(stream);
-      for (int i = 0; i < kWarmupIters; i++) {
+      comms::prims::ib::benchmark::launch_init_rank_pattern_kernel(
+          src_ptr, total_bytes, rank_, stream.stream());
+    }
+
+    // Persistent step state: 2 * num_blocks (senders + receivers).
+    DeviceScratch<int64_t> step_state(2 * num_blocks);
+    CUDA_EXPECT_SUCCESS(
+        cudaMemset(step_state.get(), 0, 2 * num_blocks * sizeof(int64_t)));
+
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      for (int i = 0; i < kWarmupIters; ++i) {
         comms::prims::ib::launch_send_recv_kernel(
             dev_win,
             staging_buf,
@@ -329,22 +563,43 @@ class IbSendRecvBenchmark : public ::testing::Test {
             dst_rank,
             src_rank,
             num_blocks,
-            step_state,
+            step_state.get(),
             stream.stream());
       }
     }
     stream.synchronize();
     torchcomm_->barrier(false);
 
-    // Timed run
-    cudaEvent_t start, stop;
-    cudaEventCreate(&start);
-    cudaEventCreate(&stop);
+    DeviceScratch<uint64_t> expected_checksum_device(1);
+    DeviceScratch<uint64_t> expected_partials_device(
+        ib_bench::kChecksumPartialBlocks);
+    DeviceScratch<uint64_t> observed_checksums_device(kMeasureIters);
+    DeviceScratch<uint64_t> observed_partials_device(
+        kMeasureIters * ib_bench::kChecksumPartialBlocks);
+    DeviceScratch<ib_bench::MismatchRecord> mismatch_partials_device(
+        kMeasureIters * ib_bench::kChecksumPartialBlocks);
 
     {
       c10::cuda::CUDAStreamGuard guard(stream);
-      cudaEventRecord(start, stream.stream());
-      for (int i = 0; i < kMeasureIters; i++) {
+      ib_bench::launch_rank_pattern_checksum(
+          total_bytes,
+          src_rank,
+          expected_checksum_device.get(),
+          expected_partials_device.get(),
+          stream.stream());
+    }
+
+    IterationEvents events(kMeasureIters);
+    std::vector<uint64_t> observed_checksums(kMeasureIters);
+    std::vector<ib_bench::MismatchRecord> mismatch_partials(
+        kMeasureIters * ib_bench::kChecksumPartialBlocks);
+    uint64_t expectedChecksum = 0;
+
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      for (int i = 0; i < kMeasureIters; ++i) {
+        poison_destination(dst_ptr, total_bytes, stream.stream());
+        CUDA_EXPECT_SUCCESS(cudaEventRecord(events.start(i), stream.stream()));
         comms::prims::ib::launch_send_recv_kernel(
             dev_win,
             staging_buf,
@@ -358,22 +613,55 @@ class IbSendRecvBenchmark : public ::testing::Test {
             dst_rank,
             src_rank,
             num_blocks,
-            step_state,
+            step_state.get(),
             stream.stream());
+        CUDA_EXPECT_SUCCESS(cudaEventRecord(events.stop(i), stream.stream()));
+        ib_bench::launch_buffer_checksum(
+            dst_ptr,
+            total_bytes,
+            src_rank,
+            observed_checksums_device.at(i),
+            observed_partials_device.at(
+                static_cast<size_t>(i) * ib_bench::kChecksumPartialBlocks),
+            mismatch_partials_device.at(
+                static_cast<size_t>(i) * ib_bench::kChecksumPartialBlocks),
+            stream.stream());
+        poison_destination(dst_ptr, total_bytes, stream.stream());
       }
-      cudaEventRecord(stop, stream.stream());
+      CUDA_EXPECT_SUCCESS(cudaMemcpyAsync(
+          observed_checksums.data(),
+          observed_checksums_device.get(),
+          observed_checksums.size() * sizeof(uint64_t),
+          cudaMemcpyDeviceToHost,
+          stream.stream()));
+      CUDA_EXPECT_SUCCESS(cudaMemcpyAsync(
+          &expectedChecksum,
+          expected_checksum_device.get(),
+          sizeof(uint64_t),
+          cudaMemcpyDeviceToHost,
+          stream.stream()));
+      CUDA_EXPECT_SUCCESS(cudaMemcpyAsync(
+          mismatch_partials.data(),
+          mismatch_partials_device.get(),
+          mismatch_partials.size() * sizeof(ib_bench::MismatchRecord),
+          cudaMemcpyDeviceToHost,
+          stream.stream()));
     }
-    cudaEventSynchronize(stop);
+    stream.synchronize();
 
-    float elapsed_ms = 0;
-    cudaEventElapsedTime(&elapsed_ms, start, stop);
-
+    float elapsed_ms = sum_elapsed_ms(events);
     double total_data = static_cast<double>(total_bytes) * kMeasureIters;
     double bw = total_data / (elapsed_ms / 1000.0) / 1e9;
-
-    cudaEventDestroy(start);
-    cudaEventDestroy(stop);
-    cudaFree(step_state);
+    const auto verification = verify_checksums(
+        observed_checksums, expectedChecksum, mismatch_partials);
+    EXPECT_EQ(verification.wrong, 0)
+        << "SendRecv checksum mismatch for total=" << format_size(total_bytes)
+        << " section=" << format_size(section_bytes) << " pd=" << pipeline_depth
+        << " nblk=" << num_blocks << " wrong=" << verification.wrong
+        << " firstWrongIteration=" << verification.first_wrong_iteration
+        << " observedChecksum=" << verification.observed_checksum
+        << " expectedChecksum=" << verification.expected_checksum
+        << describe_first_mismatch(verification.mismatch);
 
     // Teardown
     win->deregister_local_buffer(staging_buf);
@@ -382,7 +670,15 @@ class IbSendRecvBenchmark : public ::testing::Test {
     mem_pool.reset();
     torchcomm_->barrier(false);
 
-    return {total_bytes, num_blocks, kMeasureIters, elapsed_ms, bw};
+    return {
+        total_bytes,
+        num_blocks,
+        kMeasureIters,
+        elapsed_ms,
+        bw,
+        verification.wrong,
+        verification.observed_checksum,
+        verification.expected_checksum};
   }
 
   BenchResult run_nccl_baseline(size_t total_bytes) {
@@ -396,66 +692,140 @@ class IbSendRecvBenchmark : public ::testing::Test {
     auto recv_tensor = at::zeros({static_cast<int64_t>(total_count)}, options);
 
     auto stream = at::cuda::getStreamFromPool(false, device_index_);
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      comms::prims::ib::benchmark::launch_init_rank_pattern_kernel(
+          send_tensor.data_ptr(), total_bytes, rank_, stream.stream());
+    }
 
-    // Warmup
-    for (int i = 0; i < kWarmupIters; i++) {
-      ncclGroupStart();
-      ncclSend(
-          send_tensor.data_ptr(),
-          total_bytes,
-          ncclChar,
-          peer_rank,
-          nccl_comm_,
-          stream.stream());
-      ncclRecv(
-          recv_tensor.data_ptr(),
-          total_bytes,
-          ncclChar,
-          peer_rank,
-          nccl_comm_,
-          stream.stream());
-      ncclGroupEnd();
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      for (int i = 0; i < kWarmupIters; ++i) {
+        ncclGroupStart();
+        ncclSend(
+            send_tensor.data_ptr(),
+            total_bytes,
+            ncclChar,
+            peer_rank,
+            nccl_comm_,
+            stream.stream());
+        ncclRecv(
+            recv_tensor.data_ptr(),
+            total_bytes,
+            ncclChar,
+            peer_rank,
+            nccl_comm_,
+            stream.stream());
+        ncclGroupEnd();
+      }
     }
     stream.synchronize();
     torchcomm_->barrier(false);
 
-    // Timed run
-    cudaEvent_t start, stop;
-    cudaEventCreate(&start);
-    cudaEventCreate(&stop);
+    DeviceScratch<uint64_t> expected_checksum_device(1);
+    DeviceScratch<uint64_t> expected_partials_device(
+        ib_bench::kChecksumPartialBlocks);
+    DeviceScratch<uint64_t> observed_checksums_device(kMeasureIters);
+    DeviceScratch<uint64_t> observed_partials_device(
+        kMeasureIters * ib_bench::kChecksumPartialBlocks);
+    DeviceScratch<ib_bench::MismatchRecord> mismatch_partials_device(
+        kMeasureIters * ib_bench::kChecksumPartialBlocks);
 
-    cudaEventRecord(start, stream.stream());
-    for (int i = 0; i < kMeasureIters; i++) {
-      ncclGroupStart();
-      ncclSend(
-          send_tensor.data_ptr(),
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      ib_bench::launch_rank_pattern_checksum(
           total_bytes,
-          ncclChar,
           peer_rank,
-          nccl_comm_,
+          expected_checksum_device.get(),
+          expected_partials_device.get(),
           stream.stream());
-      ncclRecv(
-          recv_tensor.data_ptr(),
-          total_bytes,
-          ncclChar,
-          peer_rank,
-          nccl_comm_,
-          stream.stream());
-      ncclGroupEnd();
     }
-    cudaEventRecord(stop, stream.stream());
-    cudaEventSynchronize(stop);
 
-    float elapsed_ms = 0;
-    cudaEventElapsedTime(&elapsed_ms, start, stop);
+    IterationEvents events(kMeasureIters);
+    std::vector<uint64_t> observed_checksums(kMeasureIters);
+    std::vector<ib_bench::MismatchRecord> mismatch_partials(
+        kMeasureIters * ib_bench::kChecksumPartialBlocks);
+    uint64_t expectedChecksum = 0;
 
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      for (int i = 0; i < kMeasureIters; ++i) {
+        poison_destination(
+            recv_tensor.data_ptr(), total_bytes, stream.stream());
+        CUDA_EXPECT_SUCCESS(cudaEventRecord(events.start(i), stream.stream()));
+        ncclGroupStart();
+        ncclSend(
+            send_tensor.data_ptr(),
+            total_bytes,
+            ncclChar,
+            peer_rank,
+            nccl_comm_,
+            stream.stream());
+        ncclRecv(
+            recv_tensor.data_ptr(),
+            total_bytes,
+            ncclChar,
+            peer_rank,
+            nccl_comm_,
+            stream.stream());
+        ncclGroupEnd();
+        CUDA_EXPECT_SUCCESS(cudaEventRecord(events.stop(i), stream.stream()));
+        ib_bench::launch_buffer_checksum(
+            recv_tensor.data_ptr(),
+            total_bytes,
+            peer_rank,
+            observed_checksums_device.at(i),
+            observed_partials_device.at(
+                static_cast<size_t>(i) * ib_bench::kChecksumPartialBlocks),
+            mismatch_partials_device.at(
+                static_cast<size_t>(i) * ib_bench::kChecksumPartialBlocks),
+            stream.stream());
+        poison_destination(
+            recv_tensor.data_ptr(), total_bytes, stream.stream());
+      }
+      CUDA_EXPECT_SUCCESS(cudaMemcpyAsync(
+          observed_checksums.data(),
+          observed_checksums_device.get(),
+          observed_checksums.size() * sizeof(uint64_t),
+          cudaMemcpyDeviceToHost,
+          stream.stream()));
+      CUDA_EXPECT_SUCCESS(cudaMemcpyAsync(
+          &expectedChecksum,
+          expected_checksum_device.get(),
+          sizeof(uint64_t),
+          cudaMemcpyDeviceToHost,
+          stream.stream()));
+      CUDA_EXPECT_SUCCESS(cudaMemcpyAsync(
+          mismatch_partials.data(),
+          mismatch_partials_device.get(),
+          mismatch_partials.size() * sizeof(ib_bench::MismatchRecord),
+          cudaMemcpyDeviceToHost,
+          stream.stream()));
+    }
+    stream.synchronize();
+
+    float elapsed_ms = sum_elapsed_ms(events);
     double total_data = static_cast<double>(total_bytes) * kMeasureIters;
     double bw = total_data / (elapsed_ms / 1000.0) / 1e9;
+    const auto verification = verify_checksums(
+        observed_checksums, expectedChecksum, mismatch_partials);
+    EXPECT_EQ(verification.wrong, 0)
+        << "NCCL SendRecv checksum mismatch for total="
+        << format_size(total_bytes) << " wrong=" << verification.wrong
+        << " firstWrongIteration=" << verification.first_wrong_iteration
+        << " observedChecksum=" << verification.observed_checksum
+        << " expectedChecksum=" << verification.expected_checksum
+        << describe_first_mismatch(verification.mismatch);
 
-    cudaEventDestroy(start);
-    cudaEventDestroy(stop);
-
-    return {total_bytes, 0, kMeasureIters, elapsed_ms, bw};
+    return {
+        total_bytes,
+        0,
+        kMeasureIters,
+        elapsed_ms,
+        bw,
+        verification.wrong,
+        verification.observed_checksum,
+        verification.expected_checksum};
   }
 
   std::unique_ptr<TorchCommTestWrapper> wrapper_;
@@ -827,11 +1197,7 @@ TEST_F(IbSendRecvBenchmark, SendRecvCorrectness) {
     c10::cuda::CUDACachingAllocator::endAllocateToPool(
         mem_pool->device(), mem_pool->id());
 
-    // Fill src with rank-specific pattern: src[i] = rank * 1000000 + i
-    auto src_tensor =
-        at::arange(
-            static_cast<int64_t>(total_count), options.dtype(at::kFloat)) +
-        static_cast<float>(rank_) * 1000000.0f;
+    auto src_tensor = at::zeros({static_cast<int64_t>(total_count)}, options);
     auto staging_tensor =
         at::zeros({static_cast<int64_t>(ring_count)}, options);
     auto dst_tensor = at::zeros({static_cast<int64_t>(total_count)}, options);
@@ -849,6 +1215,11 @@ TEST_F(IbSendRecvBenchmark, SendRecvCorrectness) {
     cudaDeviceSynchronize();
 
     auto stream = at::cuda::getStreamFromPool(false, device_index_);
+    {
+      c10::cuda::CUDAStreamGuard guard(stream);
+      comms::prims::ib::benchmark::launch_init_rank_pattern_kernel(
+          src_tensor.data_ptr<float>(), cfg.total, rank_, stream.stream());
+    }
 
     // Persistent step state for correctness test (single launch).
     int64_t* step_state = nullptr;
@@ -877,40 +1248,38 @@ TEST_F(IbSendRecvBenchmark, SendRecvCorrectness) {
     torchcomm_->barrier(false);
     cudaFree(step_state);
 
-    // Verify: dst should contain src_rank's pattern
-    auto expected =
-        at::arange(
-            static_cast<int64_t>(total_count), options.dtype(at::kFloat)) +
-        static_cast<float>(src_rank) * 1000000.0f;
-    auto dst_cpu = dst_tensor.cpu();
-    auto exp_cpu = expected.cpu();
-
-    bool match = at::allclose(dst_cpu, exp_cpu);
+    const uint64_t observedChecksum =
+        comms::prims::ib::benchmark::compute_buffer_checksum(
+            dst_tensor.data_ptr<float>(), cfg.total, stream.stream());
+    const uint64_t expectedChecksum =
+        comms::prims::ib::benchmark::compute_rank_pattern_checksum(
+            cfg.total, src_rank, stream.stream());
+    const bool match = observedChecksum == expectedChecksum;
+    const auto mismatch = match ? std::optional<ByteMismatch>{}
+                                : find_first_rank_pattern_mismatch(
+                                      dst_tensor.data_ptr<float>(),
+                                      cfg.total,
+                                      src_rank,
+                                      stream.stream());
     EXPECT_TRUE(match) << "Correctness FAILED for total="
                        << format_size(cfg.total)
                        << " section=" << format_size(cfg.section)
-                       << " pd=" << cfg.pd << " nblk=" << cfg.nblk;
+                       << " pd=" << cfg.pd << " nblk=" << cfg.nblk
+                       << " observedChecksum=" << observedChecksum
+                       << " expectedChecksum=" << expectedChecksum
+                       << describe_first_mismatch(mismatch);
     if (rank_ == 0) {
+      const std::string mismatch_details =
+          match ? "" : describe_first_mismatch(mismatch);
       printf(
-          "Correctness: total=%-8s section=%-8s pd=%d nblk=%-4d %s\n",
+          "Correctness: total=%-8s section=%-8s pd=%d nblk=%-4d wrong=%d %s%s\n",
           format_size(cfg.total).c_str(),
           format_size(cfg.section).c_str(),
           cfg.pd,
           cfg.nblk,
-          match ? "PASS" : "FAIL");
-    }
-    if (!match) {
-      auto diff = (dst_cpu - exp_cpu).abs();
-      auto max_diff = diff.max().item<float>();
-      auto mismatch_idx = diff.argmax().item<int64_t>();
-      if (rank_ == 0) {
-        printf(
-            "  max_diff=%.1f at idx=%ld got=%.1f expected=%.1f\n",
-            max_diff,
-            mismatch_idx,
-            dst_cpu[mismatch_idx].item<float>(),
-            exp_cpu[mismatch_idx].item<float>());
-      }
+          match ? 0 : 1,
+          match ? "PASS" : "FAIL",
+          mismatch_details.c_str());
     }
 
     win->deregister_local_buffer(staging_buf);
@@ -919,6 +1288,15 @@ TEST_F(IbSendRecvBenchmark, SendRecvCorrectness) {
     mem_pool.reset();
     torchcomm_->barrier(false);
   }
+}
+
+TEST_F(IbSendRecvBenchmark, NcclSendRecvMeasuredLoopCorrectnessSmall) {
+  constexpr size_t total = 64 * KB;
+
+  auto nccl_r = run_nccl_baseline(total);
+
+  EXPECT_EQ(nccl_r.wrong, 0);
+  EXPECT_GT(nccl_r.elapsed_ms, 0);
 }
 
 TEST_F(IbSendRecvBenchmark, SendRecvVsNccl) {

--- a/comms/prims/collectives/benchmarks/IbSendRecvBenchmarkKernels.cu
+++ b/comms/prims/collectives/benchmarks/IbSendRecvBenchmarkKernels.cu
@@ -5,6 +5,14 @@
 
 #include "comms/prims/collectives/benchmarks/IbSendRecvBenchmarkKernels.cuh"
 
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
 #include "comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh"
 
 namespace comms::prims::ib::benchmark {
@@ -14,6 +22,175 @@ using torchcomms::device::CoopScope;
 using torchcomms::device::DeviceWindowNCCL;
 using torchcomms::device::RegisteredBufferNCCL;
 using torchcomms::device::SignalOp;
+
+namespace {
+
+constexpr int kPatternThreads = 256;
+constexpr int kMaxPatternBlocks = 4096;
+constexpr int kChecksumThreads = 256;
+
+void check_cuda(cudaError_t result, const char* message) {
+  if (result != cudaSuccess) {
+    std::fprintf(stderr, "%s: %s\n", message, cudaGetErrorString(result));
+    std::abort();
+  }
+}
+
+struct CudaFreeDeleter {
+  void operator()(void* ptr) const {
+    if (ptr != nullptr) {
+      check_cuda(cudaFree(ptr), "checksum partial free failed");
+    }
+  }
+};
+
+template <typename T>
+std::unique_ptr<T, CudaFreeDeleter> make_device_scratch(size_t count) {
+  T* ptr = nullptr;
+  check_cuda(
+      cudaMalloc(&ptr, count * sizeof(T)),
+      "checksum partial allocation failed");
+  return std::unique_ptr<T, CudaFreeDeleter>(ptr);
+}
+
+__host__ __device__ __forceinline__ uint64_t
+mix_checksum(uint64_t acc, uint64_t value) {
+  acc ^= value + 0x9e3779b97f4a7c15ULL + (acc << 6) + (acc >> 2);
+  return acc * 0x100000001b3ULL;
+}
+
+__host__ __device__ __forceinline__ uint64_t splitmix64(uint64_t value) {
+  value += 0x9e3779b97f4a7c15ULL;
+  value = (value ^ (value >> 30)) * 0xbf58476d1ce4e5b9ULL;
+  value = (value ^ (value >> 27)) * 0x94d049bb133111ebULL;
+  return value ^ (value >> 31);
+}
+
+__host__ __device__ __forceinline__ uint8_t
+rank_pattern_byte(int rank, size_t index) {
+  const uint64_t rankSeed = static_cast<uint64_t>(static_cast<uint32_t>(rank))
+      << 48;
+  return static_cast<uint8_t>(
+      splitmix64(rankSeed ^ static_cast<uint64_t>(index)));
+}
+
+__global__ void
+init_rank_pattern_kernel(uint8_t* data, size_t nbytes, int rank) {
+  const size_t stride =
+      static_cast<size_t>(gridDim.x) * static_cast<size_t>(blockDim.x);
+  for (size_t i = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       i < nbytes;
+       i += stride) {
+    data[i] = rank_pattern_byte(rank, i);
+  }
+}
+
+template <bool UseExpectedPattern>
+__global__ void byte_checksum_kernel(
+    const uint8_t* data,
+    size_t nbytes,
+    int rank,
+    int expected_rank,
+    uint64_t* partials,
+    MismatchRecord* mismatch_partials) {
+  __shared__ uint64_t blockPartials[kChecksumThreads];
+  __shared__ uint64_t mismatchIndices[kChecksumThreads];
+  __shared__ uint32_t mismatchObserved[kChecksumThreads];
+  __shared__ uint32_t mismatchExpected[kChecksumThreads];
+
+  const size_t globalThread =
+      static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const size_t stride =
+      static_cast<size_t>(gridDim.x) * static_cast<size_t>(blockDim.x);
+  uint64_t local = 0xcbf29ce484222325ULL ^
+      (static_cast<uint64_t>(blockIdx.x) << 40) ^
+      (static_cast<uint64_t>(threadIdx.x) << 32) ^ nbytes;
+  uint64_t localMismatchIndex = kNoMismatchIndex;
+  uint32_t localMismatchObserved = 0;
+  uint32_t localMismatchExpected = 0;
+
+  for (size_t i = globalThread; i < nbytes; i += stride) {
+    uint8_t value = 0;
+    if constexpr (UseExpectedPattern) {
+      value = rank_pattern_byte(rank, i);
+    } else {
+      value = data[i];
+    }
+    const uint64_t taggedValue =
+        (static_cast<uint64_t>(value) << 32) ^ static_cast<uint64_t>(i);
+    local = mix_checksum(local, taggedValue);
+
+    if (expected_rank >= 0) {
+      const uint8_t expected = rank_pattern_byte(expected_rank, i);
+      if (value != expected && i < localMismatchIndex) {
+        localMismatchIndex = i;
+        localMismatchObserved = value;
+        localMismatchExpected = expected;
+      }
+    }
+  }
+
+  blockPartials[threadIdx.x] = local;
+  mismatchIndices[threadIdx.x] = localMismatchIndex;
+  mismatchObserved[threadIdx.x] = localMismatchObserved;
+  mismatchExpected[threadIdx.x] = localMismatchExpected;
+  __syncthreads();
+
+  for (int strideInBlock = kChecksumThreads / 2; strideInBlock > 0;
+       strideInBlock >>= 1) {
+    if (threadIdx.x < strideInBlock) {
+      blockPartials[threadIdx.x] = mix_checksum(
+          blockPartials[threadIdx.x],
+          blockPartials[threadIdx.x + strideInBlock]);
+      if (mismatchIndices[threadIdx.x + strideInBlock] <
+          mismatchIndices[threadIdx.x]) {
+        mismatchIndices[threadIdx.x] =
+            mismatchIndices[threadIdx.x + strideInBlock];
+        mismatchObserved[threadIdx.x] =
+            mismatchObserved[threadIdx.x + strideInBlock];
+        mismatchExpected[threadIdx.x] =
+            mismatchExpected[threadIdx.x + strideInBlock];
+      }
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    partials[blockIdx.x] = blockPartials[0];
+    if (mismatch_partials != nullptr) {
+      MismatchRecord record;
+      record.index = mismatchIndices[0];
+      record.observed = mismatchObserved[0];
+      record.expected = mismatchExpected[0];
+      mismatch_partials[blockIdx.x] = record;
+    }
+  }
+}
+
+__global__ void checksum_reduce_kernel(
+    const uint64_t* partials,
+    uint64_t* checksum) {
+  __shared__ uint64_t blockPartials[kChecksumPartialBlocks];
+
+  blockPartials[threadIdx.x] = partials[threadIdx.x];
+  __syncthreads();
+
+  for (int strideInBlock = kChecksumPartialBlocks / 2; strideInBlock > 0;
+       strideInBlock >>= 1) {
+    if (threadIdx.x < strideInBlock) {
+      blockPartials[threadIdx.x] = mix_checksum(
+          blockPartials[threadIdx.x],
+          blockPartials[threadIdx.x + strideInBlock]);
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    *checksum = mix_checksum(
+        0xcbf29ce484222325ULL ^ static_cast<uint64_t>(kChecksumPartialBlocks),
+        blockPartials[0]);
+  }
+}
 
 __global__ void put_bw_kernel(
     DeviceWindowNCCL* win,
@@ -59,6 +236,8 @@ __global__ void put_bw_kernel(
   }
 }
 
+} // namespace
+
 void launch_put_bw_kernel(
     DeviceWindowNCCL* win,
     RegisteredBufferNCCL src_buf,
@@ -73,6 +252,146 @@ void launch_put_bw_kernel(
       win, src_buf, total_bytes, dst_rank, src_rank, signal_base, iterations);
   cudaError_t err = cudaGetLastError();
   assert(err == cudaSuccess && "put_bw_kernel launch failed");
+}
+
+void launch_init_rank_pattern_kernel(
+    void* data,
+    size_t nbytes,
+    int rank,
+    cudaStream_t stream) {
+  if (nbytes == 0) {
+    return;
+  }
+  const int numBlocks = static_cast<int>(std::min<size_t>(
+      kMaxPatternBlocks, (nbytes + kPatternThreads - 1) / kPatternThreads));
+  init_rank_pattern_kernel<<<numBlocks, kPatternThreads, 0, stream>>>(
+      static_cast<uint8_t*>(data), nbytes, rank);
+  cudaError_t err = cudaGetLastError();
+  assert(err == cudaSuccess && "init_rank_pattern_kernel launch failed");
+}
+
+uint8_t expected_rank_pattern_byte(int rank, size_t index) {
+  return rank_pattern_byte(rank, index);
+}
+
+namespace {
+
+template <bool UseExpectedPattern>
+void launch_checksum_impl(
+    const void* data,
+    size_t nbytes,
+    int rank,
+    int expected_rank,
+    uint64_t* checksum,
+    uint64_t* partials,
+    MismatchRecord* mismatch_partials,
+    cudaStream_t stream) {
+  if (nbytes == 0) {
+    check_cuda(
+        cudaMemsetAsync(checksum, 0, sizeof(uint64_t), stream),
+        "zero checksum write failed");
+    return;
+  }
+
+  byte_checksum_kernel<UseExpectedPattern>
+      <<<kChecksumPartialBlocks, kChecksumThreads, 0, stream>>>(
+          static_cast<const uint8_t*>(data),
+          nbytes,
+          rank,
+          expected_rank,
+          partials,
+          mismatch_partials);
+  check_cuda(cudaGetLastError(), "byte_checksum_kernel launch failed");
+
+  checksum_reduce_kernel<<<1, kChecksumPartialBlocks, 0, stream>>>(
+      partials, checksum);
+  check_cuda(cudaGetLastError(), "checksum_reduce_kernel launch failed");
+}
+
+template <bool UseExpectedPattern>
+uint64_t compute_checksum_impl(
+    const void* data,
+    size_t nbytes,
+    int rank,
+    cudaStream_t stream) {
+  if (nbytes == 0) {
+    return 0;
+  }
+
+  auto deviceChecksum = make_device_scratch<uint64_t>(1);
+  auto devicePartials = make_device_scratch<uint64_t>(kChecksumPartialBlocks);
+  launch_checksum_impl<UseExpectedPattern>(
+      data,
+      nbytes,
+      rank,
+      /*expected_rank=*/-1,
+      deviceChecksum.get(),
+      devicePartials.get(),
+      /*mismatch_partials=*/nullptr,
+      stream);
+
+  uint64_t hostChecksum = 0;
+  check_cuda(
+      cudaMemcpyAsync(
+          &hostChecksum,
+          deviceChecksum.get(),
+          sizeof(uint64_t),
+          cudaMemcpyDeviceToHost,
+          stream),
+      "checksum copy failed");
+  check_cuda(cudaStreamSynchronize(stream), "checksum stream sync failed");
+
+  return hostChecksum;
+}
+
+} // namespace
+
+void launch_buffer_checksum(
+    const void* data,
+    size_t nbytes,
+    int expected_rank,
+    uint64_t* checksum,
+    uint64_t* partials,
+    MismatchRecord* mismatch_partials,
+    cudaStream_t stream) {
+  launch_checksum_impl</*UseExpectedPattern=*/false>(
+      data,
+      nbytes,
+      /*rank=*/0,
+      expected_rank,
+      checksum,
+      partials,
+      mismatch_partials,
+      stream);
+}
+
+void launch_rank_pattern_checksum(
+    size_t nbytes,
+    int rank,
+    uint64_t* checksum,
+    uint64_t* partials,
+    cudaStream_t stream) {
+  launch_checksum_impl</*UseExpectedPattern=*/true>(
+      nullptr,
+      nbytes,
+      rank,
+      /*expected_rank=*/-1,
+      checksum,
+      partials,
+      /*mismatch_partials=*/nullptr,
+      stream);
+}
+
+uint64_t
+compute_buffer_checksum(const void* data, size_t nbytes, cudaStream_t stream) {
+  return compute_checksum_impl</*UseExpectedPattern=*/false>(
+      data, nbytes, /*rank=*/0, stream);
+}
+
+uint64_t
+compute_rank_pattern_checksum(size_t nbytes, int rank, cudaStream_t stream) {
+  return compute_checksum_impl</*UseExpectedPattern=*/true>(
+      nullptr, nbytes, rank, stream);
 }
 
 } // namespace comms::prims::ib::benchmark

--- a/comms/prims/collectives/benchmarks/IbSendRecvBenchmarkKernels.cuh
+++ b/comms/prims/collectives/benchmarks/IbSendRecvBenchmarkKernels.cuh
@@ -5,13 +5,26 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+
 #include <cuda_runtime.h>
+
 #include "comms/torchcomms/device/ncclx/TorchCommDeviceNCCLXTypes.hpp"
 
 namespace comms::prims::ib::benchmark {
 
 using torchcomms::device::DeviceWindowNCCL;
 using torchcomms::device::RegisteredBufferNCCL;
+
+constexpr int kChecksumPartialBlocks = 32;
+constexpr uint64_t kNoMismatchIndex = UINT64_MAX;
+
+struct MismatchRecord {
+  uint64_t index{kNoMismatchIndex};
+  uint32_t observed{0};
+  uint32_t expected{0};
+};
 
 /**
  * Launch a zero-copy put BW kernel (benchmark only).
@@ -41,5 +54,35 @@ void launch_put_bw_kernel(
     int signal_base,
     int iterations,
     cudaStream_t stream);
+
+void launch_init_rank_pattern_kernel(
+    void* data,
+    size_t nbytes,
+    int rank,
+    cudaStream_t stream);
+
+uint8_t expected_rank_pattern_byte(int rank, size_t index);
+
+void launch_buffer_checksum(
+    const void* data,
+    size_t nbytes,
+    int expected_rank,
+    uint64_t* checksum,
+    uint64_t* partials,
+    MismatchRecord* mismatch_partials,
+    cudaStream_t stream);
+
+void launch_rank_pattern_checksum(
+    size_t nbytes,
+    int rank,
+    uint64_t* checksum,
+    uint64_t* partials,
+    cudaStream_t stream);
+
+uint64_t
+compute_buffer_checksum(const void* data, size_t nbytes, cudaStream_t stream);
+
+uint64_t
+compute_rank_pattern_checksum(size_t nbytes, int rank, cudaStream_t stream);
 
 } // namespace comms::prims::ib::benchmark

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -1867,6 +1867,233 @@ TEST_F(
   }
 }
 
+void runNicDoneMultiQpSendRecvStress(
+    int globalRank,
+    int localRank,
+    int numRanks,
+    std::size_t chunkSize) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+  if (!test::supportsProgressSendRecv()) {
+    GTEST_SKIP() << "progress send/recv is not supported for this build";
+  }
+
+  constexpr std::size_t nbytes = 2ULL * 1024 * 1024 * 1024; // 2 GiB
+  constexpr int kIterations = 100;
+  constexpr std::size_t dataBufferSize = 8ULL * 1024 * 1024;
+  constexpr int numBlocks = 8;
+  constexpr int blockSize = 128;
+  constexpr int pipelineDepth = 2;
+  constexpr int qpsPerConnection = 2;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+
+  try {
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .perChannelSize = dataBufferSize / numBlocks,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
+        .qpsPerConnection = qpsPerConnection,
+    };
+
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    auto transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, numRanks, bootstrap, config);
+    transport->exchange();
+
+    P2pIbgdaTransportDevice* peerTransportPtr =
+        transport->getP2pTransportDevice(peerRank);
+    DeviceBuffer sendBuffer(nbytes);
+    DeviceBuffer recvBuffer(nbytes);
+    DeviceBuffer errorCountBuf(sizeof(int));
+    auto* d_errorCount = static_cast<int*>(errorCountBuf.get());
+    const bool isSender = globalRank == 0;
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    for (int iter = 0; iter < kIterations; ++iter) {
+      SCOPED_TRACE(
+          ::testing::Message()
+          << "chunkSize=" << chunkSize << " iteration=" << iter);
+      const uint8_t testPattern = static_cast<uint8_t>(0x30 + (iter & 0x7F));
+      if (isSender) {
+        test::fillBufferWithPattern(
+            sendBuffer.get(), nbytes, testPattern, numBlocks, blockSize);
+      } else {
+        CUDACHECK_TEST(cudaMemset(recvBuffer.get(), 0, nbytes));
+      }
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      test::testSendRecv(
+          peerTransportPtr,
+          isSender ? sendBuffer.get() : recvBuffer.get(),
+          nbytes,
+          chunkSize,
+          isSender,
+          numBlocks,
+          blockSize);
+      const cudaError_t syncErr = cudaDeviceSynchronize();
+      ASSERT_EQ(syncErr, cudaSuccess)
+          << "rank " << globalRank
+          << " send/recv failed: " << cudaGetErrorString(syncErr);
+
+      if (!isSender) {
+        CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+        test::verifyBufferPattern(
+            recvBuffer.get(),
+            nbytes,
+            testPattern,
+            d_errorCount,
+            numBlocks,
+            blockSize);
+        CUDACHECK_TEST(cudaDeviceSynchronize());
+
+        int h_errorCount = 0;
+        CUDACHECK_TEST(cudaMemcpy(
+            &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
+        ASSERT_EQ(h_errorCount, 0) << "multi-QP NIC_DONE send/recv corrupted "
+                                   << h_errorCount << " bytes";
+      }
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    }
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+TEST_F(
+    MultipeerIbgdaTransportTestFixture,
+    NicDoneMultiQpSendRecv512KiBNoCorruption) {
+  runNicDoneMultiQpSendRecvStress(
+      globalRank, localRank, numRanks, 512ULL * 1024);
+}
+
+TEST_F(
+    MultipeerIbgdaTransportTestFixture,
+    NicDoneMultiQpSendRecv64KiBNoCorruption) {
+  runNicDoneMultiQpSendRecvStress(
+      globalRank, localRank, numRanks, 64ULL * 1024);
+}
+
+void runNicDoneMultiQpMutableMaxSignalBytes(
+    int globalRank,
+    int localRank,
+    int numRanks) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+  if (!test::supportsProgressSendRecv()) {
+    GTEST_SKIP() << "progress send/recv is not supported for this build";
+  }
+
+  constexpr std::size_t nbytes = 64ULL * 1024 * 1024;
+  constexpr int kIterations = 40;
+  constexpr std::size_t dataBufferSize = 8ULL * 1024 * 1024;
+  constexpr int numBlocks = 8;
+  constexpr int blockSize = 128;
+  constexpr int pipelineDepth = 2;
+  constexpr int qpsPerConnection = 2;
+  constexpr std::size_t perBlockSlot =
+      (dataBufferSize / numBlocks) / pipelineDepth;
+  const std::array<std::size_t, 2> maxSignalBytes = {
+      64ULL * 1024,
+      perBlockSlot,
+  };
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+
+  try {
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .perChannelSize = dataBufferSize / numBlocks,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
+        .qpsPerConnection = qpsPerConnection,
+    };
+
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    auto transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, numRanks, bootstrap, config);
+    transport->exchange();
+
+    P2pIbgdaTransportDevice* peerTransportPtr =
+        transport->getP2pTransportDevice(peerRank);
+    DeviceBuffer sendBuffer(nbytes);
+    DeviceBuffer recvBuffer(nbytes);
+    DeviceBuffer errorCountBuf(sizeof(int));
+    auto* d_errorCount = static_cast<int*>(errorCountBuf.get());
+    const bool isSender = globalRank == 0;
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    for (int iter = 0; iter < kIterations; ++iter) {
+      for (std::size_t phase = 0; phase < maxSignalBytes.size(); ++phase) {
+        const std::size_t chunkSize = maxSignalBytes[phase];
+        SCOPED_TRACE(
+            ::testing::Message() << "chunkSize=" << chunkSize << " iteration="
+                                 << iter << " phase=" << phase);
+        const uint8_t testPattern =
+            static_cast<uint8_t>(0x80 + ((iter * 2 + phase) & 0x7F));
+        if (isSender) {
+          test::fillBufferWithPattern(
+              sendBuffer.get(), nbytes, testPattern, numBlocks, blockSize);
+        } else {
+          CUDACHECK_TEST(cudaMemset(recvBuffer.get(), 0, nbytes));
+        }
+        CUDACHECK_TEST(cudaDeviceSynchronize());
+        MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+        test::testSendRecv(
+            peerTransportPtr,
+            isSender ? sendBuffer.get() : recvBuffer.get(),
+            nbytes,
+            chunkSize,
+            isSender,
+            numBlocks,
+            blockSize);
+        const cudaError_t syncErr = cudaDeviceSynchronize();
+        ASSERT_EQ(syncErr, cudaSuccess)
+            << "rank " << globalRank
+            << " send/recv failed: " << cudaGetErrorString(syncErr);
+
+        if (!isSender) {
+          CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+          test::verifyBufferPattern(
+              recvBuffer.get(),
+              nbytes,
+              testPattern,
+              d_errorCount,
+              numBlocks,
+              blockSize);
+          CUDACHECK_TEST(cudaDeviceSynchronize());
+
+          int h_errorCount = 0;
+          CUDACHECK_TEST(cudaMemcpy(
+              &h_errorCount,
+              d_errorCount,
+              sizeof(int),
+              cudaMemcpyDeviceToHost));
+          ASSERT_EQ(h_errorCount, 0)
+              << "multi-QP mutable max_signal_bytes send/recv corrupted "
+              << h_errorCount << " bytes";
+        }
+        MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+      }
+    }
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+TEST_F(
+    MultipeerIbgdaTransportTestFixture,
+    NicDoneMultiQpMutableMaxSignalBytesNoCorruption) {
+  runNicDoneMultiQpMutableMaxSignalBytes(globalRank, localRank, numRanks);
+}
+
 // =============================================================================
 // Reset Signal Test - Tests resetting signals for reuse
 // =============================================================================


### PR DESCRIPTION
Summary: Add IBGDA send/recv regression coverage that forces `qpsPerConnection=2` and reuses staging slots for 100 iterations with 512 KiB and 64 KiB chunks. This targets the multi-QP `NIC_DONE` race where a shared completion counter can hide a slow lane.

Reviewed By: Scusemua

Differential Revision: D112859027


