### PR TITLE
Add central Scuba error logging for ERR-level logs (#3224)

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -260,6 +260,12 @@ cvars:
    default     : False
    description : |-
      Enable logging of backend topology information to scuba.
+ - name        : NCCL_SCUBA_LOG_ERROR_ENABLED
+   type        : bool
+   default     : True
+   description : |-
+     Enable recording ERROR-level logs to the nccl_structured_logging Scuba
+     table.
 
 
  - name        : NCCL_SET_THREAD_NAME

--- a/comms/utils/logger/ErrorStackUtil.cc
+++ b/comms/utils/logger/ErrorStackUtil.cc
@@ -1,0 +1,80 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/ErrorStackUtil.h"
+
+#include <array>
+#include <sstream>
+#include <string_view>
+
+#if __has_include(<dwarf.h>)
+#include <folly/debugging/symbolizer/Symbolizer.h>
+#endif
+#include <folly/String.h>
+
+namespace {
+// Leading native-stack frames that belong to the logging / Scuba plumbing
+// rather than the real error site. We drop frames from the top of the captured
+// stack until the first frame that does NOT match any of these markers, so the
+// recorded stack starts near where the error was actually reported. A
+// name-based filter is used (instead of a fixed skip count) because setError()
+// is reached through several different call chains (direct CTRAN
+// ErrorStackTraceUtil, the NcclLogFormatter CTRAN hook, and the NCCL debug
+// path), each with a different amount of plumbing on top.
+constexpr std::array<std::string_view, 12> kInternalFrameMarkers = {
+    "folly::symbolizer",
+    "getStackTraceStr",
+    "NcclScubaSample",
+    "EventsScubaUtil",
+    "logErrorToScuba",
+    "ErrorStackTraceUtil",
+    "NcclLogFormatter",
+    "folly::LogStreamProcessor",
+    "folly::LogStreamVoidify",
+    "folly::LogStream",
+    "folly::XlogCategoryInfo",
+    "folly::LogCategory",
+};
+
+bool isInternalFrame(const std::string& frame) {
+  for (const auto& marker : kInternalFrameMarkers) {
+    if (frame.find(marker) != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Erase the leading plumbing frames (see kInternalFrameMarkers).
+void skipInternalFrames(std::vector<std::string>& frames) {
+  auto firstReal = frames.begin();
+  while (firstReal != frames.end() && isInternalFrame(*firstReal)) {
+    ++firstReal;
+  }
+  frames.erase(frames.begin(), firstReal);
+}
+} // namespace
+
+namespace meta::comms::logger {
+
+std::vector<std::string> captureNativeErrorStack() {
+  std::vector<std::string> stackTraceDemangled;
+
+  // Get stack trace (requires elfutils/libdwarf for folly Symbolizer)
+#if __has_include(<dwarf.h>)
+  std::stringstream ss;
+  ss << folly::symbolizer::getStackTraceStr();
+  // @lint-ignore CLANGTIDY
+  folly::split('\n', ss.str(), stackTraceDemangled);
+  for (auto& line : stackTraceDemangled) {
+    auto demangledLine = folly::demangle(line.c_str()).toStdString();
+    line.swap(demangledLine);
+  }
+  // Drop the leading logging / Scuba plumbing frames so the recorded stack
+  // starts near the real error site.
+  skipInternalFrames(stackTraceDemangled);
+#endif
+
+  return stackTraceDemangled;
+}
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/ErrorStackUtil.h
+++ b/comms/utils/logger/ErrorStackUtil.h
@@ -1,0 +1,17 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace meta::comms::logger {
+
+// Capture the native symbolized error stack once, dropping the leading logging
+// / Scuba plumbing frames. Returns the symbolized stack when symbolizer support
+// is available, and an empty vector when it is unavailable (no dwarf.h). The
+// result can be shared across all error reporters so the expensive capture runs
+// only once per error.
+std::vector<std::string> captureNativeErrorStack();
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/LoggingFormat.cc
+++ b/comms/utils/logger/LoggingFormat.cc
@@ -10,9 +10,14 @@
 #include <fmt/format.h>
 #include <folly/String.h>
 #include <folly/Synchronized.h>
+#include <folly/logging/LogCategory.h>
 #include <folly/logging/LogMessage.h>
 #include <folly/logging/LogName.h>
 #include <folly/synchronization/CallOnce.h>
+
+#include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
+#include "comms/utils/logger/EventsScubaUtil.h"
+#include "comms/utils/logger/NcclScubaSample.h"
 
 namespace {
 std::string getHostName(const char delim) {
@@ -38,14 +43,15 @@ static thread_local std::string myThreadName = "main";
 
 struct LastErrorInfo {
   std::string lastErrorMessage;
+  // Legacy per-frame error chain, still appended by v2_27/v2_29's debug.cc via
+  // appendErrorToStack(). Kept for backward compatibility.
   std::vector<std::string> lastErrorStack;
+  // Native symbolized stack captured at the error site by logErrorToScuba().
+  // Preferred by getLastCommsError() when present.
+  std::vector<std::string> lastErrorNativeStack;
 };
 
 static folly::Synchronized<LastErrorInfo> lastCommsError{};
-
-void logLastError(std::string_view message) {
-  lastCommsError.wlock()->lastErrorMessage = message;
-}
 } // Anonymous namespace
 
 namespace meta::comms::logger {
@@ -244,7 +250,16 @@ std::string NcclLogFormatter::formatMessage(
 
   bool isErrorMessage = message.getLevel() >= folly::LogLevel::ERR;
   if (isErrorMessage) {
-    logLastError(message.getMessage());
+    // Errors are recorded to Scuba at their call sites (ncclMetaDebugLogError
+    // for NCCL, CERR for CTRAN), each of which captures a fresh native stack
+    // via logErrorToScuba(). Clear any stale cached native stack here so
+    // getLastCommsError() does not pair this message with an unrelated stack;
+    // the call site's logErrorToScuba(), which runs after this formatter,
+    // re-sets it when present, and a bare XLOG(ERR) correctly falls back to the
+    // legacy per-frame chain.
+    auto lockedError = lastCommsError.wlock();
+    lockedError->lastErrorMessage = message.getMessage();
+    lockedError->lastErrorNativeStack.clear();
   }
 
   auto timeSinceEpoch = message.getTimestamp().time_since_epoch();
@@ -289,7 +304,7 @@ std::string NcclLogFormatter::formatMessage(
   // If this still isn't long enough the string will grow as necessary, so the
   // code will still be correct, but just slightly less efficient than if we
   // had allocated a large enough buffer the first time around.
-  size_t headerLengthGuess = 90 + basename.size();
+  std::size_t headerLengthGuess = 90 + basename.size();
 
   // Format the data into a buffer.
   std::string buffer;
@@ -301,7 +316,7 @@ std::string NcclLogFormatter::formatMessage(
     buffer.reserve(
         ((header.size() + 1) * message.getNumNewlines()) + msgData.size());
 
-    size_t idx = 0;
+    std::size_t idx = 0;
     while (true) {
       auto end = msgData.find('\n', idx);
       if (end == std::string_view::npos) {
@@ -328,12 +343,39 @@ std::string NcclLogFormatter::formatMessage(
   return buffer;
 }
 
+void logErrorToScuba(
+    const std::string& message,
+    const int code,
+    const std::string& errorName,
+    const std::vector<std::string>& stack) {
+  // Build one Scuba record for the whole error; the guard flushes it to
+  // nccl_structured_logging on scope exit and keeps the sticky-context columns.
+  auto sampleGuard = EVENTS_SCUBA_UTIL_SAMPLE_GUARD("ERROR");
+  auto& sample = sampleGuard.sample();
+  sample.setError(message, stack);
+  if (code != 0) {
+    sample.addNormal("error_code", fmt::format("{}:{}", code, errorName));
+  }
+}
+
+void setLastError(const std::string& message, std::vector<std::string> stack) {
+  auto w = lastCommsError.wlock();
+  w->lastErrorMessage = message;
+  w->lastErrorNativeStack = std::move(stack);
+}
+
 std::string getLastCommsError() {
   std::ostringstream ss;
   {
     auto lastCommsErrorRLocked = lastCommsError.rlock();
     ss << lastCommsErrorRLocked->lastErrorMessage << "\nNCCL Stack trace:";
-    for (const auto& stack : lastCommsErrorRLocked->lastErrorStack) {
+    // Prefer the native captured stack; fall back to the legacy per-frame
+    // chain (still populated by v2_27/v2_29) when no native stack is present.
+    const auto& stackTrace =
+        !lastCommsErrorRLocked->lastErrorNativeStack.empty()
+        ? lastCommsErrorRLocked->lastErrorNativeStack
+        : lastCommsErrorRLocked->lastErrorStack;
+    for (const auto& stack : stackTrace) {
       ss << '\n' << stack;
     }
   }

--- a/comms/utils/logger/LoggingFormat.h
+++ b/comms/utils/logger/LoggingFormat.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <vector>
 
 #include <fmt/format.h>
 #include <folly/Range.h>
@@ -72,6 +73,21 @@ fmt::memory_buffer getLogPrefix(LogLevel level);
 std::string getLastCommsError();
 
 void appendErrorToStack(std::string error);
+
+// Record an ERROR-level log to the nccl_structured_logging Scuba table as a
+// single error record (top-level message in the exception_message column,
+// native stack in the stack_trace column). The caller is responsible for gating
+// this on NCCL_SCUBA_LOG_ERROR_ENABLED and for capturing the native `stack`
+// once (via captureNativeErrorStack()) so it can be shared across reporters.
+void logErrorToScuba(
+    const std::string& message,
+    int code,
+    const std::string& errorName,
+    const std::vector<std::string>& stack);
+
+// Update the ncclGetLastError() state with the latest error message and its
+// pre-captured native stack. Unconditional; independent of Scuba error logging.
+void setLastError(const std::string& message, std::vector<std::string> stack);
 
 class NcclLogFormatter : public folly::LogFormatter {
  public:

--- a/comms/utils/logger/NcclScubaSample.cc
+++ b/comms/utils/logger/NcclScubaSample.cc
@@ -2,14 +2,11 @@
 
 #include "comms/utils/logger/NcclScubaSample.h"
 
-#include <sstream>
-
-#if __has_include(<dwarf.h>)
-#include <folly/debugging/symbolizer/Symbolizer.h>
-#endif
+#include <folly/String.h>
 #include <folly/json/json.h>
 
 #include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
+#include "comms/utils/logger/ErrorStackUtil.h"
 
 // Format uses these keys:
 // fbcode/rfe/scubadata/ScubaDataSample.cpp
@@ -61,22 +58,18 @@ void NcclScubaSample::setExceptionInfo(const std::exception& ex) {
 }
 
 void NcclScubaSample::setError(const std::string& error) {
-  // Get stack trace (requires elfutils/libdwarf for folly Symbolizer)
-#if __has_include(<dwarf.h>)
+  std::vector<std::string> stack;
   if (NCCL_SCUBA_STACK_TRACE_ON_ERROR_ENABLED) {
-    std::stringstream ss;
-    ss << folly::symbolizer::getStackTraceStr();
-    std::vector<std::string> stackTraceMangled;
-    // @lint-ignore CLANGTIDY
-    folly::split('\n', ss.str(), stackTraceMangled);
-    for (auto& line : stackTraceMangled) {
-      auto demangledLine = folly::demangle(line.c_str()).toStdString();
-      line.swap(demangledLine);
-    }
-    this->stackTrace = stackTraceMangled;
-    addNormVector("stack_trace", std::move(stackTraceMangled));
+    stack = ::meta::comms::logger::captureNativeErrorStack();
   }
-#endif
+  setError(error, stack);
+}
+
+void NcclScubaSample::setError(
+    const std::string& error,
+    const std::vector<std::string>& stack) {
+  this->stackTrace = stack;
+  addNormVector("stack_trace", stack);
 
   // Set attributes locally
   this->hasException = true;

--- a/comms/utils/logger/NcclScubaSample.h
+++ b/comms/utils/logger/NcclScubaSample.h
@@ -45,6 +45,13 @@ class NcclScubaSample {
   // Helper to include a custom error and collect stack trace
   void setError(const std::string& error);
 
+  // Helper to include a custom error using a pre-captured native stack instead
+  // of capturing one, so an expensive stack capture can be shared across
+  // multiple error reporters.
+  void setError(
+      const std::string& error,
+      const std::vector<std::string>& stack);
+
   // Set custom data attribute
   void setData(std::string data);
 

--- a/comms/utils/logger/tests/FormatterUT.cc
+++ b/comms/utils/logger/tests/FormatterUT.cc
@@ -302,6 +302,26 @@ TEST(LoggingFormat, getLastCommsErrorEmptyStack) {
   EXPECT_TRUE(errorStr.find("NCCL Stack trace:") != std::string::npos);
 }
 
+TEST(LoggingFormat, setLastErrorPrefersNativeStack) {
+  meta::comms::logger::setLastError(
+      "net timeout", {"stackFrame1", "stackFrame2"});
+
+  auto lastError = meta::comms::logger::getLastCommsError();
+  const auto messagePos = lastError.find("net timeout");
+  const auto headerPos = lastError.find("NCCL Stack trace:");
+  const auto frame1Pos = lastError.find("stackFrame1");
+  const auto frame2Pos = lastError.find("stackFrame2");
+
+  EXPECT_NE(messagePos, std::string::npos);
+  EXPECT_NE(headerPos, std::string::npos);
+  EXPECT_NE(frame1Pos, std::string::npos);
+  EXPECT_NE(frame2Pos, std::string::npos);
+
+  // The native stack is recorded after the message, in order.
+  EXPECT_LT(messagePos, frame1Pos);
+  EXPECT_LT(frame1Pos, frame2Pos);
+}
+
 TEST(LoggingFormat, nonErrorMessageDoesNotUpdateLastError) {
   LoggerDB db{LoggerDB::TESTING};
   auto* category = db.getCategory("test.info");

--- a/comms/utils/logger/tests/LogErrorToScubaTest.cc
+++ b/comms/utils/logger/tests/LogErrorToScubaTest.cc
@@ -1,0 +1,107 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/LoggingFormat.h"
+
+#include <sstream>
+#include <string>
+
+#include <folly/Singleton.h>
+#include <folly/init/Init.h>
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+#include <folly/portability/GTest.h>
+#include <folly/testing/TestUtil.h>
+
+#include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
+#include "comms/utils/logger/DataTableWrapper.h"
+#include "comms/utils/logger/EventMgr.h"
+#include "comms/utils/logger/tests/MockScubaTable.h"
+
+using meta::comms::logger::logErrorToScuba;
+
+namespace {
+
+// Drives logErrorToScuba() end-to-end into a mocked nccl_structured_logging
+// table so the flushed sample JSON can be inspected. The DataTableAllTables
+// singleton is replaced with MockScubaTable instances that capture the
+// serialized sample instead of writing it to a pipe/scuba sink.
+class LogErrorToScubaTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    savedLogFilePrefix_ = NCCL_SCUBA_LOG_FILE_PREFIX;
+    savedCommEventLogging_ = NCCL_COMM_EVENT_LOGGING;
+
+    // The nccl_structured_logging table is created only when its cvar names a
+    // "type:name" sink; point it at a pipe backed by a throwaway temp dir so
+    // the DataTable is constructed (and its writer thread runs) while the mock
+    // still captures every sample.
+    NCCL_SCUBA_LOG_FILE_PREFIX = tmpDir_.path().string();
+    NCCL_COMM_EVENT_LOGGING = "pipe:nccl_structured_logging";
+
+    folly::Singleton<const DataTableAllTables, DataTableAllTablesTag>::
+        make_mock([]() {
+          return new DataTableAllTables(
+              createAllMockTables(/*callParent=*/false));
+        });
+    DataTableWrapper::init();
+  }
+
+  void TearDown() override {
+    DataTableWrapper::shutdown();
+    NCCL_SCUBA_LOG_FILE_PREFIX = savedLogFilePrefix_;
+    NCCL_COMM_EVENT_LOGGING = savedCommEventLogging_;
+  }
+
+  // Flush the async writer thread and return the parsed JSON of the single
+  // sample logErrorToScuba() emitted.
+  folly::dynamic getLoggedSample() {
+    DataTableWrapper::shutdown();
+    std::istringstream iss(getMessages(LoggerEventType::CommEventType));
+    std::string line;
+    std::getline(iss, line);
+    return folly::parseJson(line);
+  }
+
+ private:
+  folly::test::TemporaryDirectory tmpDir_;
+  std::string savedLogFilePrefix_;
+  std::string savedCommEventLogging_;
+};
+
+// A non-zero code is recorded as "code:name", alongside the message and stack.
+TEST_F(LogErrorToScubaTest, RecordsErrorCodeMessageAndStack) {
+  logErrorToScuba("msg", 5, "ncclSystemError", {"f1", "f2"});
+
+  const auto json = getLoggedSample();
+
+  EXPECT_EQ(json["normal"]["error_code"].asString(), "5:ncclSystemError");
+  EXPECT_EQ(json["normal"]["exception_message"].asString(), "msg");
+  const auto expectedStack = folly::dynamic::array("f1", "f2");
+  EXPECT_EQ(json["normvector"]["stack_trace"], expectedStack);
+}
+
+// An empty error name still records the code with a trailing colon.
+TEST_F(LogErrorToScubaTest, ErrorCodeWithEmptyName) {
+  logErrorToScuba("msg", 5, "", {});
+
+  const auto json = getLoggedSample();
+
+  EXPECT_EQ(json["normal"]["error_code"].asString(), "5:");
+}
+
+// A zero code omits the error_code column entirely.
+TEST_F(LogErrorToScubaTest, NoErrorCodeWhenCodeIsZero) {
+  logErrorToScuba("msg", 0, "ncclSuccess", {});
+
+  const auto json = getLoggedSample();
+
+  EXPECT_EQ(json["normal"].count("error_code"), 0);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/utils/logger/tests/NcclScubaSampleTest.cc
+++ b/comms/utils/logger/tests/NcclScubaSampleTest.cc
@@ -1,0 +1,49 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/NcclScubaSample.h"
+
+#include <string>
+#include <vector>
+
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+#include <folly/portability/GTest.h>
+
+namespace {
+
+// setError() with a native stack records the frames in the stack_trace
+// normvector column and the plain top-level message in exception_message,
+// without duplicating the stack into the message.
+TEST(NcclScubaSampleTest, SetErrorRecordsStackAndMessage) {
+  const std::vector<std::string> stack{"frameA", "frameB"};
+  NcclScubaSample sample("ERROR");
+  sample.setError("boom", stack);
+
+  const auto json = folly::parseJson(sample.toJson());
+
+  const auto expectedStack = folly::dynamic::array("frameA", "frameB");
+  EXPECT_EQ(json["normvector"]["stack_trace"], expectedStack);
+
+  // The message column carries only the top-level message, not the stack.
+  const auto& message = json["normal"]["exception_message"].asString();
+  EXPECT_EQ(message, "boom");
+  EXPECT_EQ(message.find("frameA"), std::string::npos);
+  EXPECT_EQ(message.find("frameB"), std::string::npos);
+
+  EXPECT_EQ(json["int"]["exception_set"].asInt(), 1);
+}
+
+// setError() with an empty stack leaves stack_trace an empty normvector and
+// still records the message verbatim.
+TEST(NcclScubaSampleTest, SetErrorEmptyStack) {
+  NcclScubaSample sample("ERROR");
+  sample.setError("lonely error", {});
+
+  const auto json = folly::parseJson(sample.toJson());
+
+  EXPECT_TRUE(json["normvector"]["stack_trace"].empty());
+  EXPECT_EQ(json["normal"]["exception_message"].asString(), "lonely error");
+  EXPECT_EQ(json["int"]["exception_set"].asInt(), 1);
+}
+
+} // namespace


### PR DESCRIPTION
Summary:

First step of making NCCLX/CTRAN error logging consistent and queryable; this adds a shared, env-gated Scuba error-logging path in the comms logger layer, without touching per-version NCCL macros yet (that follows in later commits):
- Add cvar `NCCL_SCUBA_LOG_ERROR_ENABLED` (bool, default true) to gate error-to-Scuba recording.
- Add `logErrorToScuba()` in comms/utils/logger that records one error sample via `EVENTS_SCUBA_UTIL_SAMPLE_GUARD("ERROR")` to `nccl_structured_logging` (`exception_set=1`, `exception_message`=top-level message, `stack_trace`=native stack), plus a single `error_code` column formatted as `code:name` when a non-zero code is known, so one error is one queryable record.
- Add `setLastError()` to update the `ncclGetLastError()` state with the latest message and its pre-captured native stack.
- Extract native-stack capture into a standalone util `comms/utils/logger/ErrorStackUtil.{h,cc}` (`captureNativeErrorStack()`), decoupled from `NcclScubaSample`; it symbolizes the stack once (gated by `NCCL_SCUBA_STACK_TRACE_ON_ERROR_ENABLED`), drops the logging/Scuba plumbing frames so the stack starts at the real error site, and can be shared across reporters.
- `NcclScubaSample::setError()` records the native stack only in the `stack_trace` column and the plain top-level message in `exception_message` (no stack duplication across columns).
- On an ERR-level message, `NcclLogFormatter::formatMessage` saves the last-error text and clears any stale cached native stack, so `getLastCommsError()` pairs the message with the fresh stack captured at the error call site. Scuba error recording happens at the call sites that know the error code (the NCCL path via `ncclMetaDebugLogError`, CTRAN via `CERR`), each added in later commits - the formatter itself does not record to Scuba.
- `getLastCommsError()` (returns `std::string`) sources the stack from the native capture when fresh and otherwise falls back to the legacy per-frame chain (still populated by v2_27/v2_29); the legacy chain is left intact.

This commit is additive and safe for all ncclx versions.

Reviewed By: YulunW

Differential Revision: D112642436


