### PR TITLE
Convert collective suites to runtime nolocal/vnode; fix broadcast/RS skip gate

### DIFF
--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -20,10 +20,10 @@ const auto myAlgo = NCCL_ALLGATHER_P_ALGO::ctpipeline;
 
 // Get the index of the chunk in recvBuff to receive from the internode Ring
 // neighbor in the rail. E.g., for nRanks = 8, nLocalRanks = 2, rank = 2, it
-// would receive chunkIdx 0, 6, 4 of the recvBuff in a 3-step Ring.
+// would receive chunkIdx 2, 0, 6 of the recvBuff in a 3-step Ring.
 inline size_t
 getRecvChunkIdxInRail(int rank, int step, int nLocalRanks, int nRanks) {
-  return (rank - step * nLocalRanks + nRanks) & (nRanks - 1);
+  return (rank - step * nLocalRanks + nRanks) % nRanks;
 }
 
 commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
@@ -303,7 +303,7 @@ commResult_t AlgoImpl::execPipeline(
         pArgs.remoteAccessKeys,
         stream_));
 
-    const int upPeer = (nRanks + myRank - nLocalRanks) & (nRanks - 1);
+    const int upPeer = (nRanks + myRank - nLocalRanks) % nRanks;
 
     // -  Remaining steps: broadcast received chunk from internode upPeer
     for (int step = 0; step < nNodes - 1; step++) {

--- a/comms/ctran/algos/barrier.cuh
+++ b/comms/ctran/algos/barrier.cuh
@@ -14,79 +14,59 @@
 #include "comms/ctran/algos/DevCommon.cuh"
 
 /*
- * This is a multi-step logarithmic complexity barrier algorithm that
- * is safe for non-power-of-two processes.
+ * Dissemination barrier: a logarithmic-step barrier that is correct for ANY
+ * number of ranks, including non-powers-of-two.
  *
- * Step 1: We form groups of 2.  Each group synchronizes within it.
- * Step 2: We form groups of 4.  In each group, the lower half of the
- *   processes do a pair-wise synchronization with the higher half of
- *   the processes.  At this point, everyone in the group is
- *   synchronized.
- * Steps 3 onward: We continue the same model with doubling group
- *   sizes.  After each step, all processes in the group are
- *   synchronized.
+ * At step k (k = 0, 1, ..., nsteps-1, with distance d = 2^k) every rank r:
+ *   - signals rank up   = (r + d)          % nranks, and
+ *   - waits on rank down = (r - d + nranks) % nranks.
+ * After ceil(log2(nranks)) steps the arrival of every rank has propagated to
+ * every other rank, so no rank exits before all ranks have arrived. Unlike a
+ * pairwise/butterfly barrier, no peer is ever skipped -- that skip is exactly
+ * what dropped synchronization edges (and thus broke correctness) for
+ * non-power-of-two rank counts.
  *
- * If a process does not have a peer (because the number of ranks is
- * not a power of two), that process simply skips that step.
+ * Each directed edge r -> up uses the mailbox that lives in up's memory and is
+ * dedicated to the (r -> up) channel: r posts via devSyncGetLoc<REMOTE>(up) and
+ * up consumes the very same slot via devSyncGetLoc<LOCAL>(r) (its down at the
+ * same step is r). A given physical mailbox is therefore touched by exactly one
+ * (writer, reader) pair, at exactly one step, per barrier() call.
  *
- * For synchronization, the lower rank process sets a flag on the
- * higher rank process' mailbox.  The higher rank process on
- * receiving this flag, resets the flag and sets a flag on the lower
- * rank process' mailbox.  The lower rank flag then resets its local
- * flag.  This approach avoids race conditions where the flag could be
- * overwritten before it is read by the other process.
+ * Reuse safety across repeated barrier() calls relies on the two-phase
+ * step/RESET handshake: the writer waits for the slot to read RESET (left so by
+ * the reader of the previous call, or by initialization) before posting `step`,
+ * and the reader restores RESET after consuming. A stale value can never
+ * satisfy a later call's wait -- the reader always resets its own slot before
+ * its next call, and the writer is blocked from overwriting until the previous
+ * value has been consumed.
+ *
+ * Each rank posts its outgoing signal before blocking on its incoming one.
+ * Posting only requires the target slot to already be RESET (guaranteed by
+ * initialization or the previous call, never by the current step), so every
+ * rank can post before any rank blocks; this breaks the cyclic wait that would
+ * otherwise deadlock the ring of edges within a step.
  */
 __device__ __forceinline__ void barrier(int rank, int nranks) {
-  CtranAlgoDeviceSync* sync;
-
   int nsteps = 0;
   while ((1 << nsteps) < nranks) {
     nsteps++;
   }
 
   for (int step = 0; step < nsteps; step++) {
-    int groupSize = 1 << (step + 1);
-    int group = rank / groupSize;
-    int groupRank = rank - group * groupSize;
+    const int dist = 1 << step;
+    const int up = (rank + dist) % nranks;
+    const int down = (rank - dist + nranks) % nranks;
 
-    if (groupRank < groupSize / 2) {
-      int peer = group * groupSize + groupRank + groupSize / 2;
+    // Signal `up`: post `step` into the slot in up's memory that belongs to
+    // this rank, once the previous call's reader has left it at RESET.
+    CtranAlgoDeviceSync* upSync = devSyncGetLoc<REMOTE>(up);
+    devSyncWaitStep(upSync, blockIdx.x, CTRAN_ALGO_STEP_RESET);
+    devSyncSetStep(upSync, blockIdx.x, step);
 
-      if (peer >= nranks) {
-        continue;
-      }
-
-      // Ping to remote peer
-      sync = devSyncGetLoc<REMOTE>(peer);
-      // First wait for CTRAN_ALGO_STEP_RESET ensures the completion of previous
-      // step or previous collective
-      devSyncWaitStep(sync, blockIdx.x, CTRAN_ALGO_STEP_RESET);
-      devSyncSetStep(sync, blockIdx.x, step);
-
-      // Pong from remote peer to local
-      sync = devSyncGetLoc<LOCAL>(peer);
-      devSyncWaitStep(sync, blockIdx.x, step);
-      // Mark this step has been synced, thus peer can use for next step
-      devSyncSetStep(sync, blockIdx.x, CTRAN_ALGO_STEP_RESET);
-    } else {
-      int peer = group * groupSize + groupRank - groupSize / 2;
-
-      if (peer >= nranks) {
-        continue;
-      }
-
-      // Pong from remote peer to local
-      sync = devSyncGetLoc<LOCAL>(peer);
-      devSyncWaitStep(sync, blockIdx.x, step);
-      // Mark this step has been synced, thus peer can use for next step
-      devSyncSetStep(sync, blockIdx.x, CTRAN_ALGO_STEP_RESET);
-
-      // Ping to remote peer
-      sync = devSyncGetLoc<REMOTE>(peer);
-      // First wait for CTRAN_ALGO_STEP_RESET ensures the completion of previous
-      // step or previous collective
-      devSyncWaitStep(sync, blockIdx.x, CTRAN_ALGO_STEP_RESET);
-      devSyncSetStep(sync, blockIdx.x, step);
-    }
+    // Wait on `down`: consume its signal from the slot in this rank's memory,
+    // then restore RESET so the next call's writer can reuse the slot.
+    CtranAlgoDeviceSync* downSync = devSyncGetLoc<LOCAL>(down);
+    devSyncWaitStep(downSync, blockIdx.x, step);
+    devSyncSetStep(downSync, blockIdx.x, CTRAN_ALGO_STEP_RESET);
   }
 }

--- a/comms/ctran/algos/tests/CtranDistAlgoDevUTKernels.cu
+++ b/comms/ctran/algos/tests/CtranDistAlgoDevUTKernels.cu
@@ -2,6 +2,7 @@
 
 #include "comms/ctran/algos/DevAlgoImpl.cuh"
 #include "comms/ctran/algos/DevCommon.cuh"
+#include "comms/ctran/algos/barrier.cuh"
 #include "comms/ctran/algos/localReduce.cuh"
 #include "comms/ctran/algos/tests/CtranDistAlgoDevUTKernels.h"
 
@@ -146,6 +147,80 @@ __global__ void __launch_bounds__(512, 1) testNaiveKernCopy(
       recvbuff[j] = sendbuff[j];
     }
   }
+}
+
+__global__ void __launch_bounds__(1024, 1) testKernNvlBarrierLoop(
+    int rank,
+    int nLocalRanks,
+    int nIters,
+    int* selfSlot,
+    int** peerSlots,
+    int* errCount,
+    CtranAlgoDeviceState* devState) {
+  devStateLoadToShm(devState);
+
+  for (int iter = 1; iter <= nIters; iter++) {
+    // Rotate the delayed ("laggard") rank across all ranks over iterations so
+    // every rank's incoming barrier edges are exercised as the last arrival.
+    const int laggard = iter % nLocalRanks;
+
+    if (threadIdx.x == 0) {
+      // The laggard busy-waits before publishing so it reliably enters the
+      // barrier LAST. A correct barrier forces every other rank to wait for
+      // it, so all read the fresh token; a barrier that drops an edge to the
+      // laggard lets some rank proceed and read the STALE token (iter-1, or the
+      // init value on the first iteration) -> a deterministic mismatch.
+      if (rank == laggard) {
+        __nanosleep(200000);
+      }
+      // Publish this iteration's token into this rank's NVL-visible slot. The
+      // token is always nonzero, so the zero-initialized buffer cannot
+      // masquerade as a valid token.
+      comms::device::st_release_sys_global(selfSlot, iter);
+    }
+
+    // Every rank must observe all tokens before any rank reads them.
+    barrier(rank, nLocalRanks);
+
+    // Verify every peer published exactly this iteration's token.
+    if (threadIdx.x == 0) {
+      for (int peer = 0; peer < nLocalRanks; peer++) {
+        const int val = comms::device::ld_acquire_sys_global(peerSlots[peer]);
+        if (val != iter) {
+          atomicAdd(errCount, 1);
+        }
+      }
+    }
+
+    // Prevent any rank from overwriting its slot for iter+1 before all peers
+    // have finished reading the current iteration's tokens.
+    barrier(rank, nLocalRanks);
+  }
+}
+
+cudaError_t testKernNvlBarrierLoopWrapper(
+    dim3 grid,
+    dim3 blocks,
+    cudaStream_t stream,
+    int rank,
+    int nLocalRanks,
+    int nIters,
+    int* selfSlot,
+    int** peerSlots,
+    int* errCount,
+    CtranAlgoDeviceState* devState) {
+  void* args[] = {
+      &rank,
+      &nLocalRanks,
+      &nIters,
+      &selfSlot,
+      &peerSlots,
+      &errCount,
+      &devState};
+  void* fn = reinterpret_cast<void*>(testKernNvlBarrierLoop);
+
+  return CUDA_LAUNCH_KERNEL_WITH_DYNAMIC_SHM_RETURN(
+      fn, grid, blocks, args, sizeof(CtranAlgoDeviceState), stream);
 }
 
 cudaError_t testKernMultiPutNotifyWrapper(

--- a/comms/ctran/algos/tests/CtranDistAlgoDevUTKernels.h
+++ b/comms/ctran/algos/tests/CtranDistAlgoDevUTKernels.h
@@ -51,6 +51,27 @@ cudaError_t testKernBcastWrapper(
     int nBcastBlocks,
     CtranAlgoDeviceState* devState);
 
+// Launch the barrier correctness test kernel. Each of `nIters` iterations picks
+// a rotating "laggard" rank (`iter % nLocalRanks`) that busy-waits before
+// publishing `iter` into its NVL-visible `selfSlot`, so it reliably enters the
+// barrier last. Every rank then barriers, reads every peer's slot via
+// `peerSlots` and increments `errCount` on any token that is not exactly
+// `iter`, then barriers again. A correct barrier makes all ranks wait for the
+// laggard (fresh tokens, `errCount == 0`); a barrier that drops synchronization
+// edges (e.g. for non-power-of-two ranks) lets a rank proceed early and read
+// the laggard's stale token, producing a non-zero `errCount`.
+cudaError_t testKernNvlBarrierLoopWrapper(
+    dim3 grid,
+    dim3 blocks,
+    cudaStream_t stream,
+    int rank,
+    int nLocalRanks,
+    int nIters,
+    int* selfSlot,
+    int** peerSlots,
+    int* errCount,
+    CtranAlgoDeviceState* devState);
+
 cudaError_t testKernDequantizedAllToAllReduceWrapper(
     const void* sendBuff,
     void* recvBuff,

--- a/comms/ctran/algos/tests/CtranDistBarrierTest.cc
+++ b/comms/ctran/algos/tests/CtranDistBarrierTest.cc
@@ -1,0 +1,87 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/algos/tests/CtranDistAlgoDevUTBase.h"
+#include "comms/ctran/algos/tests/CtranDistAlgoDevUTKernels.h"
+#include "comms/testinfra/TestUtils.h"
+
+// Directly exercises the NVL device barrier for whatever nLocalRanks the target
+// is configured with (see the ppn variants in BUCK, which include
+// non-powers-of-two). A barrier that drops synchronization edges lets some rank
+// exit early and observe a stale or future token, which this test detects.
+TEST_F(CtranDistAlgoDevTest, NvlBarrierManyIters) {
+  constexpr int kNumIters = 200;
+
+  const int localRankId = ctranComm_->statex_->localRank();
+  const int nLocalRanks = ctranComm_->statex_->nLocalRanks();
+
+  // Each rank exposes a single NVL-visible token slot in its IPC buffer.
+  initIpcBufs<int>(1);
+  CUDACHECK_TEST(cudaMemset(ipcBuf_, 0, sizeof(int)));
+
+  // Build the device array of per-rank slot pointers (self + imported peers).
+  std::vector<int*> peerSlotsHost(nLocalRanks, nullptr);
+  for (int peer = 0; peer < nLocalRanks; peer++) {
+    peerSlotsHost[peer] = (peer == localRankId)
+        ? reinterpret_cast<int*>(ipcBuf_)
+        : reinterpret_cast<int*>(ipcRemMem_.at(peer)->getBase());
+  }
+
+  int** peerSlots = nullptr;
+  int* errCount = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&peerSlots, nLocalRanks * sizeof(int*)));
+  CUDACHECK_TEST(cudaMalloc(&errCount, sizeof(int)));
+  CUDACHECK_TEST(cudaMemcpy(
+      peerSlots,
+      peerSlotsHost.data(),
+      nLocalRanks * sizeof(int*),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(errCount, 0, sizeof(int)));
+
+  // Ensure every rank has initialized its slot before any peer reads it.
+  barrierNvlDomain(ctranComm_.get());
+
+  cudaStream_t stream = nullptr;
+  CUDACHECK_TEST(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+
+  // Single block / single thread, mirroring the production nvlBarrier launch.
+  dim3 grid = {1, 1, 1};
+  dim3 blocks = {1, 1, 1};
+  CUDACHECK_TEST(testKernNvlBarrierLoopWrapper(
+      grid,
+      blocks,
+      stream,
+      localRankId,
+      nLocalRanks,
+      kNumIters,
+      reinterpret_cast<int*>(ipcBuf_),
+      peerSlots,
+      errCount,
+      ctranComm_->ctran_->algo->getDevState()));
+
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  int errCountHost = -1;
+  CUDACHECK_TEST(
+      cudaMemcpy(&errCountHost, errCount, sizeof(int), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(errCountHost, 0)
+      << "Rank " << globalRank << " observed " << errCountHost
+      << " stale/future tokens across " << kNumIters << " iterations with "
+      << nLocalRanks << " local ranks";
+
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+  CUDACHECK_TEST(cudaFree(peerSlots));
+  CUDACHECK_TEST(cudaFree(errCount));
+  freeIpcBufs();
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new ctran::CtranDistEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ctran/tests/CtranDistBroadcastTests.cc
+++ b/comms/ctran/tests/CtranDistBroadcastTests.cc
@@ -30,9 +30,6 @@ class CtranBroadcastTest : public ctran::CtranDistTestFixture,
     srand(time(NULL));
     ctranComm = makeCtranComm();
     segments.clear();
-    if (!ctranBroadcastSupport(ctranComm.get(), NCCL_BROADCAST_ALGO)) {
-      GTEST_SKIP() << "ctranBroadcastSupport returns false, skip test";
-    }
   }
 
   void TearDown() override {
@@ -98,6 +95,13 @@ TEST_P(CtranTestBroadcastFixture, Broadcast) {
     GTEST_SKIP() << "Socket backend does not support cudaMalloc";
   }
 #endif
+
+  const auto concreteAlgo = binomialTreeAlgo ? NCCL_BROADCAST_ALGO::ctbtree
+                                             : NCCL_BROADCAST_ALGO::ctdirect;
+  if (!ctranBroadcastSupport(ctranComm.get(), concreteAlgo)) {
+    GTEST_SKIP() << "ctranBroadcastSupport returns false for "
+                 << broadcastAlgoName(concreteAlgo) << ", skip test";
+  }
 
   // always allocate buffer in page size
   size_t bufSize =

--- a/comms/ctran/tests/CtranDistReduceScatterTest.cc
+++ b/comms/ctran/tests/CtranDistReduceScatterTest.cc
@@ -37,9 +37,6 @@ class CtranReduceScatterTest : public ctran::CtranDistTestFixture,
   void SetUp() override {
     ctran::CtranDistTestFixture::SetUp();
     ctranComm = makeCtranComm();
-    if (!ctranReduceScatterSupport(ctranComm.get(), NCCL_REDUCESCATTER_ALGO)) {
-      GTEST_SKIP() << "ctranReduceScatterSupport returns fails, skip test";
-    }
   }
 
   void TearDown() override {

--- a/comms/ctran/tests/CtranDistTestUtils.cc
+++ b/comms/ctran/tests/CtranDistTestUtils.cc
@@ -25,13 +25,6 @@ void CtranDistEnvironment::SetUp() {
   setenv("NCCL_CTRAN_ENABLE", "1", 0);
   setenv("NCCL_COLLTRACE", "trace", 0);
 
-#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
-  setenv("NCCL_COMM_STATE_DEBUG_TOPO", "nolocal", 1);
-#endif
-#ifdef NCCL_COMM_STATE_DEBUG_TOPO_VNODE
-  setenv("NCCL_COMM_STATE_DEBUG_TOPO", "vnode", 1);
-#endif
-
 #if defined(TEST_ENABLE_FASTINIT)
   setenv("NCCL_FASTINIT_MODE", "ring_hybrid", 1);
 #else
@@ -77,16 +70,31 @@ void CtranDistTestFixture::SetUp(const CtranEnvs& envs) {
 
   setenv("RANK", std::to_string(globalRank).c_str(), 1);
 
-#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
-  enableNolocal = true;
-#endif
-
   if (globalRank == 0) {
     XLOG(DBG) << "Testing with NCCL_COMM_STATE_DEBUG_TOPO="
               << (isNolocalTopo() ? "nolocal" : "default");
   }
 
   stream.emplace(cudaStreamNonBlocking);
+}
+
+void CtranDistTestFixture::assertExpectedTopology(CtranComm* comm) const {
+  const char* topo = getenv("NCCL_COMM_STATE_DEBUG_TOPO");
+  if (topo == nullptr) {
+    return; // default topology: no cross-config invariant to assert
+  }
+  const std::string mode{topo};
+  if (mode == "nolocal") {
+    EXPECT_EQ(comm->statex_->nLocalRanks(), 1);
+    EXPECT_EQ(comm->statex_->nNodes(), numRanks);
+  } else if (mode == "vnode") {
+    const char* nlr = getenv("NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS");
+    const int vnodeNLocalRanks = nlr ? std::atoi(nlr) : 2; // cvar default
+    EXPECT_EQ(comm->statex_->nLocalRanks(), vnodeNLocalRanks);
+    EXPECT_EQ(
+        comm->statex_->nNodes(),
+        (numRanks + vnodeNLocalRanks - 1) / vnodeNLocalRanks);
+  }
 }
 
 void CtranDistTestFixture::TearDown() {
@@ -147,6 +155,10 @@ std::unique_ptr<CtranComm> CtranDistTestFixture::makeCtranComm(
   // Always use bootstrap to get real pids. Virtual topology overrides
   // (nolocal, vnode, vClique) are applied inside setRankStatesTopologies.
   comm->statex_->initRankStatesTopology(commBootstrap.get());
+
+  // Verify the runtime topology matches the debug-topo env override (if any),
+  // so nolocal/vnode configs cannot silently run the real topology.
+  assertExpectedTopology(comm.get());
 
   comm->bootstrap_ = std::make_unique<ctran::testing::CtranTestBootstrap>(
       std::move(commBootstrap));

--- a/comms/ctran/tests/CtranDistTestUtils.h
+++ b/comms/ctran/tests/CtranDistTestUtils.h
@@ -76,6 +76,11 @@ class CtranDistTestFixture : public CtranTestFixtureBase,
       bool noLocal = false,
       bool ibLazyConnect = false);
 
+  // Asserts the comm's runtime topology matches the NCCL_COMM_STATE_DEBUG_TOPO
+  // env override (nolocal/vnode). Early-returns when the env is unset, so
+  // default-topology suites are unaffected.
+  void assertExpectedTopology(CtranComm* comm) const;
+
   // Intra-node (NVL domain) barrier using CtranComm's bootstrap
   void barrierNvlDomain(CtranComm* comm);
 
@@ -90,8 +95,6 @@ class CtranDistTestFixture : public CtranTestFixtureBase,
         comm->statex_->localRankToRanks());
     COMMCHECK_TEST(static_cast<commResult_t>(std::move(resFuture).get()));
   }
-
-  bool enableNolocal{false};
 
  private:
   std::unordered_map<std::string, std::optional<std::string>> savedEnvs_;


### PR DESCRIPTION
Summary:
Convert four ctran collective dist-test suites to the runtime topology-env mechanism, and fix a pre-existing harness bug that made Broadcast/ReduceScatter skip every case. Builds on the core nolocal/vnode runtime-env fix.
- Converted `ctran_dist_allreduce`, `ctran_dist_allgather_ctwin`, `ctran_dist_broadcast`, `ctran_dist_reducescatter` nolocal/vnode configs from the (ineffective) compile-time `compiler_flags` to runtime `envs` (`NCCL_COMM_STATE_DEBUG_TOPO=nolocal` / `vnode` + `NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS`), preserving non-topo flags (e.g. `init_none`). The topology now actually takes effect and is checked by `assertExpectedTopology`.
- Fixed a pre-existing test-harness bug: Broadcast (`CtranDistBroadcastTests.cc`) and ReduceScatter (`CtranDistReduceScatterTest.cc`) gated `SetUp()` on the DEFAULT algo cvar, which is `orig` (the baseline non-ctran algo) for which `ctranBroadcastSupport`/`ctranReduceScatterSupport` correctly return false. That skipped EVERY case in EVERY config, so both suites were effectively dead. Removed the baseline-default gate (mirroring AllReduce/AllGatherP); support is now checked against the concrete ctran algo in the test body (added a per-param check in Broadcast keyed on ctbtree/ctdirect; ReduceScatter's body already rechecks per algo). Unsupported (algo, topology) combinations still GTEST_SKIP gracefully.
- broadcast/reducescatter/broadcast_socket keep their existing `disabled` tag (unchanged), so they do not auto-run on CI; they were verified locally via `buck run` (see Test Plan). CI enablement is deferred.

Differential Revision: D113090674


