### PR TITLE
Replace legacy Pipes resource CVARs with per-channel MCCL controls (#3230)

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <limits>
 #include <memory>
 #include <set>
 
@@ -28,7 +29,7 @@ bool ctranPipesTraceEnabled() {
 }
 
 int ctranPipesNvlMaxNumChannels() {
-  return std::max(1, NCCL_CTRAN_MAX_NBLOCKS);
+  return std::max(1, MCCL_MAX_NBLOCKS);
 }
 
 size_t roundDownToMultiple(size_t value, size_t multiple) {
@@ -144,15 +145,31 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
       }
       config.ibConfig.ibHca = std::move(hcaStr);
     }
-    uint64_t ibgdaDataBufferSize = (pc.ibgdaDataBufferSize > 0)
-        ? static_cast<size_t>(pc.ibgdaDataBufferSize)
-        : static_cast<size_t>(NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE);
-    if (hierAgOverlapEnabled && NCCL_CTRAN_HIER_AG_IBGDA_DATA_BUFFER_SIZE > 0) {
-      ibgdaDataBufferSize = std::max(
-          ibgdaDataBufferSize, NCCL_CTRAN_HIER_AG_IBGDA_DATA_BUFFER_SIZE);
+    if (MCCL_MAX_NCHANNELS <= 0) {
+      CLOGF(
+          ERR,
+          "MCCL_MAX_NCHANNELS must be positive, got {}",
+          MCCL_MAX_NCHANNELS);
+      return commInvalidArgument;
+    }
+    const auto numChannels = static_cast<size_t>(MCCL_MAX_NCHANNELS);
+    size_t ibgdaDataBufferSize = 0;
+    if (pc.ibgdaDataBufferSize > 0) {
+      ibgdaDataBufferSize = static_cast<size_t>(pc.ibgdaDataBufferSize);
+    } else {
+      const auto perChannelSize = static_cast<size_t>(MCCL_CHANNEL_BUFFER_SIZE);
+      if (perChannelSize > std::numeric_limits<size_t>::max() / numChannels) {
+        CLOGF(
+            ERR,
+            "MCCL_CHANNEL_BUFFER_SIZE={} overflows total size for {} channels",
+            perChannelSize,
+            numChannels);
+        return commInvalidArgument;
+      }
+      ibgdaDataBufferSize = perChannelSize * numChannels;
     }
     config.ibConfig.dataBufferSize = static_cast<size_t>(ibgdaDataBufferSize);
-    config.ibConfig.qpDepth = NCCL_CTRAN_IBGDA_QP_DEPTH;
+    config.ibConfig.qpDepth = MCCL_IB_QP_DEPTH;
     if (NCCL_IB_TIMEOUT != NCCL_IB_TIMEOUT_DEFAULTCVARVALUE) {
       config.ibConfig.timeout = static_cast<uint8_t>(NCCL_IB_TIMEOUT);
     }
@@ -178,13 +195,6 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     config.ibConfig.ibLazyConnect = pc.ibLazyConnect;
     config.ibConfig.materializePeerTimeoutMs =
         NCCL_CTRAN_IBGDA_MATERIALIZE_PEER_TIMEOUT_MS;
-    if (NCCL_CTRAN_IB_MAX_GROUPS <= 0) {
-      CLOGF(
-          ERR,
-          "NCCL_CTRAN_IB_MAX_GROUPS must be positive, got {}",
-          NCCL_CTRAN_IB_MAX_GROUPS);
-      return commInvalidArgument;
-    }
     if (NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC <= 0) {
       CLOGF(
           ERR,
@@ -192,7 +202,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
           NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC);
       return commInvalidArgument;
     }
-    config.ibConfig.maxGroups = static_cast<int>(NCCL_CTRAN_IB_MAX_GROUPS);
+    config.ibConfig.maxGroups = static_cast<int>(MCCL_MAX_NCHANNELS);
     config.ibConfig.qpsPerConnection =
         static_cast<int>(NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC);
 
@@ -222,40 +232,36 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
           config.ibConfig.dataBufferSize);
     }
 
-    if (NCCL_CTRAN_IBGDA_SENDRECV_ENABLE || directIbReduceScatter) {
+    if (NCCL_CTRAN_IBGDA_SENDRECV_ENABLE && !directIbReduceScatter) {
       if (config.ibConfig.dataBufferSize == 0) {
         CLOGF(
             ERR,
-            "NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1 requires a positive "
-            "IBGDA data-buffer size via NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE "
-            "or the per-communicator IBGDA data-buffer override");
+            "send/recv requires a positive staging size via MCCL_CHANNEL_BUFFER_SIZE or pipesIbgdaDataBufferSize");
         return commInvalidArgument;
       }
-      if (!directIbReduceScatter &&
-          NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH <= 0) {
+      if (config.ibConfig.dataBufferSize % numChannels != 0) {
         CLOGF(
             ERR,
-            "NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH must be positive, got {}",
-            NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH);
+            "IB data-buffer size {} must be divisible by channel count {}",
+            config.ibConfig.dataBufferSize,
+            numChannels);
         return commInvalidArgument;
       }
-      if (!directIbReduceScatter) {
-        if (config.ibConfig.dataBufferSize %
-                static_cast<std::size_t>(config.ibConfig.maxGroups) !=
-            0) {
-          CLOGF(
-              ERR,
-              "IBGDA data-buffer size {} must be divisible by maxGroups {}",
-              config.ibConfig.dataBufferSize,
-              config.ibConfig.maxGroups);
-          return commInvalidArgument;
-        }
-        config.ibConfig.perChannelSize = config.ibConfig.dataBufferSize /
-            static_cast<std::size_t>(config.ibConfig.maxGroups);
-        config.ibConfig.max_num_channels = config.ibConfig.maxGroups;
-        config.ibConfig.pipelineDepth =
-            static_cast<int>(NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH);
+      const int pipelineDepth = static_cast<int>(MCCL_CHANNEL_PIPELINE_DEPTH);
+      if (pipelineDepth <= 0) {
+        CLOGF(
+            ERR,
+            "MCCL_CHANNEL_PIPELINE_DEPTH must be positive, got {}",
+            pipelineDepth);
+        return commInvalidArgument;
       }
+
+      config.ibConfig.perChannelSize =
+          config.ibConfig.dataBufferSize / numChannels;
+      config.ibConfig.max_num_channels = config.ibConfig.maxGroups;
+      config.ibConfig.pipelineDepth = pipelineDepth;
+    }
+    if (NCCL_CTRAN_IBGDA_SENDRECV_ENABLE || directIbReduceScatter) {
       CLOGF(
           INFO,
           "Prims IBGDA sendRecv configured: perChannelSize={}, maxNumChannels={}, pipelineDepth={}, dataBufferSize={}, directIbReduceScatter={}",
@@ -266,7 +272,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
           directIbReduceScatter);
     }
 
-    if (NCCL_CTRAN_PIPES_IB_MODE == NCCL_CTRAN_PIPES_IB_MODE::ibrc) {
+    if (MCCL_IB_MODE == MCCL_IB_MODE::ibrc) {
       config.ibMode = comms::prims::IbBackendMode::kIbrc;
     }
     config.disableIb = NCCL_CTRAN_PIPES_DISABLE_IB;

--- a/comms/ctran/benchmarks/AllGatherBench.cc
+++ b/comms/ctran/benchmarks/AllGatherBench.cc
@@ -212,7 +212,7 @@ class CtranAllGatherBenchmark : public ctran::CtranDistTestFixture {
     setenv("NCCL_CTRAN_ENABLE", "1", 0);
     setenv("NCCL_CTRAN_USE_PIPES", "1", 0);
     setenv("NCCL_CTRAN_IBGDA_SENDRECV_ENABLE", "1", 0);
-    setenv("NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE", "8388608", 0);
+    setenv("MCCL_CHANNEL_BUFFER_SIZE", "131072", 0);
     setenv("NCCL_DEBUG", "WARN", 0);
 
     ctran::CtranDistTestFixture::SetUp();

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -1262,7 +1262,7 @@ class P2pIbgdaTransportDevice {
       if (group.group_size > qp_depth) {
         printf(
             "[PIPES] FATAL: put group_size (%u) > QP depth (%u). "
-            "Set NCCL_CTRAN_IBGDA_QP_DEPTH >= %u to avoid deadlock.\n",
+            "Set MCCL_IB_QP_DEPTH >= %u to avoid deadlock.\n",
             group.group_size,
             qp_depth,
             group.group_size);

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1214,15 +1214,6 @@ cvars:
      and NVLink fanout scheduling. When zero, ctran selects a chunk size from
      {512KiB, 1MiB, 2MiB, 4MiB, 8MiB} based on the send message size.
 
- - name        : NCCL_CTRAN_HIER_AG_IBGDA_DATA_BUFFER_SIZE
-   type        : uint64_t
-   default     : 33554432
-   description : |-
-     Minimum IBGDA send/recv data-buffer size to use when the experimental
-     overlapped cthierarchical_ring AllGather kernel is enabled. 0 disables
-     this algorithm-specific minimum and uses NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE
-     or the per-communicator pipesIbgdaDataBufferSize directly.
-
  - name        : NCCL_CTRAN_HIER_AG_NVL_SHARED_DEVBUF_SIZE
    type        : uint64_t
    default     : 67108864
@@ -1883,19 +1874,6 @@ cvars:
      initialize MultiPeerTransport which provides unified NVLink and IBGDA
      transport for P2P communication.
 
- - name        : NCCL_CTRAN_MAX_NBLOCKS
-   type        : int
-   default     : 16
-   description : |-
-     Maximum number of logical CUDA blocks used by CTRAN collectives that support message-size-based block tuning.
-
- - name        : NCCL_CTRAN_TREE_FANOUT
-   type        : int
-   default     : 2
-   description : |-
-     Fanout used when building CTREE tree topologies for experimental benchmarking.
-     Valid values are 1 through the compile-time maximum tree children.
-
  - name        : NCCL_CTRAN_PIPES_TRACE_ENABLE
    type        : bool
    default     : false
@@ -1921,13 +1899,6 @@ cvars:
      the chance of losing events to ring wraparound on high-rate kernels at the
      cost of more frequent polling; a final drain always runs on teardown.
 
- - name        : NCCL_CTRAN_PIPES_NVL_CHUNK_SIZE
-   type        : uint64_t
-   default     : 524288
-   description : |-
-     Chunk size in bytes for NVL transport in Pipes MultiPeerTransport.
-     Controls the granularity of parallel copy operations over NVLink.
-
  - name        : NCCL_CTRAN_PIPES_DISABLE_IB
    type        : bool
    default     : false
@@ -1936,33 +1907,6 @@ cvars:
      IBGDA transport is never constructed and all non-self peers are assumed
      to be NVL-connected. All data movement and sync operations go over
      NVLink. Requires that all ranks are in the same NVL domain.
-
- - name        : NCCL_CTRAN_PIPES_IB_MODE
-   type        : enum
-   default     : ibgda
-   choices     : ibgda, ibrc
-   description : |-
-     Select the IB backend used by Pipes MultiPeerTransport for non-NVL peers.
-     ibgda - use GPU-posted IBGDA.
-     ibrc - use CPU-posted IBRC.
-
- - name        : NCCL_CTRAN_IBGDA_QP_DEPTH
-   type        : uint64_t
-   default     : 1024
-   description : |-
-     Queue pair depth (number of outstanding WQEs per peer) for IBGDA
-     transport in Pipes MultiPeerTransport. Must be >= the largest
-     ThreadGroup size used in group-scope put operations (e.g., 256 for
-     block-scope). Higher values allow more pipelining but use more
-     memory.
-
- - name        : NCCL_CTRAN_IB_MAX_GROUPS
-   type        : int
-   default     : 64
-   description : |-
-     Maximum number of physical CUDA block groups that may own IB QP
-     resources. Device-side IB QP selection uses ThreadGroup::block_id
-     and requires block_id < NCCL_CTRAN_IB_MAX_GROUPS.
 
  - name        : NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC
    type        : int
@@ -1978,15 +1922,6 @@ cvars:
      Number of signal slots per peer for IBGDA transport in Pipes
      MultiPeerTransport. Each slot is a 64-bit counter used for
      signaling between peers.
-
- - name        : NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE
-   type        : uint64_t
-   default     : 0
-   description : |-
-     Per-peer data buffer size in bytes for IBGDA transport in Pipes
-     MultiPeerTransport. This determines the maximum transfer size per
-     put_signal call. A value of 0 means no transport-managed data
-     buffer (users must register their own via registerBuffer).
 
  - name        : NCCL_CTRAN_IBGDA_MIN_RNR_TIMER
    type        : uint64_t
@@ -2025,19 +1960,12 @@ cvars:
    type        : bool
    default     : false
    description : |-
-     Enable send/recv staging buffers for IBGDA transport in Pipes
+     Enable send/recv staging buffers for prims IB transports in
      MultiPeerTransport. Required for cthierarchical_ring. When enabled,
-     allocates additional GPU memory for pipelined send/recv staging per
-     IBGDA peer. The effective IBGDA data-buffer size must be positive via
-     NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE or the per-communicator
+     allocates additional GPU memory for pipelined send/recv staging per IB
+     peer. The effective per-channel buffer must be positive via
+     MCCL_CHANNEL_BUFFER_SIZE or the per-communicator
      pipesIbgdaDataBufferSize hint.
-
- - name        : NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH
-   type        : int
-   default     : 2
-   description : |-
-     Pipeline depth (number of staging ring slots) for IBGDA send/recv.
-     Only used when NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1.
 
  - name        : NCCL_CTRAN_BACKENDS
    type        : enumlist
@@ -3214,6 +3142,68 @@ cvars:
    type        : string
    default     : ""
    description : Used to bind NCCL's network proxy threads to specific CPU cores.
+
+ - name        : MCCL_MAX_NBLOCKS
+   type        : int
+   default     : 16
+   description : |-
+     Maximum number of logical CUDA blocks used by MCCL collectives that
+     support message-size-based block tuning.
+
+ - name        : MCCL_TREE_FANOUT
+   type        : int
+   default     : 2
+   description : |-
+     Fanout used when building CTREE tree topologies for experimental
+     benchmarking. Valid values are 1 through the compile-time maximum tree
+     children.
+
+ - name        : MCCL_MAX_NCHANNELS
+   type        : int
+   default     : 64
+   description : |-
+     Maximum number of fixed prims IB channels per peer. Channels index
+     staging, signal, and QP resources through ThreadGroup::group_id and do
+     not necessarily map one-to-one to CUDA blocks; for example, ctree uses
+     two channels per block.
+
+ - name        : MCCL_IB_MODE
+   type        : enum
+   default     : ibgda
+   choices     : ibgda, ibrc
+   description : |-
+     Select the IB backend used by Pipes MultiPeerTransport for non-NVL peers.
+     ibgda - use GPU-posted IBGDA.
+     ibrc - use CPU-posted IBRC.
+
+ - name        : MCCL_IB_QP_DEPTH
+   type        : uint64_t
+   default     : 1024
+   description : |-
+     Queue pair depth (number of outstanding WQEs per peer) for prims IB
+     transports, shared by the IBGDA and IBRC backends. For IBGDA group-scope
+     puts, it must be >= the largest ThreadGroup size (e.g., 256 for
+     block-scope). Higher values allow more pipelining but use more memory.
+
+ - name        : MCCL_CHANNEL_BUFFER_SIZE
+   type        : uint64_t
+   default     : 0
+   description : |-
+     Per-channel prims IB send/recv staging size in bytes, shared by the IBGDA
+     and IBRC backends. Total staging per peer and direction is this value
+     multiplied by MCCL_MAX_NCHANNELS. Combined with
+     MCCL_CHANNEL_PIPELINE_DEPTH: chunk size = this / depth. A value of 0
+     provides no global staging size; a per-communicator
+     pipesIbgdaDataBufferSize total override may still provide an effective
+     total.
+
+ - name        : MCCL_CHANNEL_PIPELINE_DEPTH
+   type        : int
+   default     : 2
+   description : |-
+     Number of staging ring slots (pipeline depth) per prims IB channel,
+     shared by the IBGDA and IBRC backends. Chunk size is the per-channel
+     buffer size divided by this depth.
 
  - name        : MCCL_CTRAN_BACKENDS
    type        : enumlist


### PR DESCRIPTION
Summary:

Replace legacy CTRAN-scoped prims resource CVARs with MCCL controls:

- `NCCL_CTRAN_MAX_NBLOCKS` becomes `MCCL_MAX_NBLOCKS`.
- `NCCL_CTRAN_TREE_FANOUT` becomes `MCCL_TREE_FANOUT`.
- `NCCL_CTRAN_PIPES_NVL_CHUNK_SIZE` is removed because it has no consumers; NVL sizing continues to derive from the shared device-buffer geometry.
- `NCCL_CTRAN_PIPES_IB_MODE` becomes `MCCL_IB_MODE`.
- `NCCL_CTRAN_IBGDA_QP_DEPTH` becomes `MCCL_IB_QP_DEPTH`.
- `NCCL_CTRAN_IB_MAX_GROUPS` becomes `MCCL_MAX_NCHANNELS`.
- `NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE` becomes `MCCL_CHANNEL_BUFFER_SIZE`.
- `NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH` becomes `MCCL_CHANNEL_PIPELINE_DEPTH`.
- `NCCL_CTRAN_HIER_AG_IBGDA_DATA_BUFFER_SIZE` is removed.

The legacy names are intentionally removed without aliases or fallback behavior. All `MCCL_*` declarations are grouped together in `nccl_cvars.yaml`.

`MCCL_CHANNEL_BUFFER_SIZE` maps directly to the transport `perChannelSize` field. `CtranPipes` derives the total size with checked `size * MCCL_MAX_NCHANNELS` arithmetic. The per-communicator `pipesIbgdaDataBufferSize` override retains total-size semantics, with exact channel divisibility required when send/recv staging is enabled. `MCCL_CHANNEL_PIPELINE_DEPTH` controls the number of staging slots.

Migrate checked-in configurations without changing their geometry: 32 MiB over 64 channels becomes 512 KiB/channel, the 8 MiB AllGather benchmark becomes 128 KiB/channel, and 16-channel CTREE configurations use 2 MiB/channel. Standard paths retain depth 2; direct-IB ReduceScatter retains its fixed 8-channel, 512 KiB/channel, depth-4 geometry.

`MCCL_MAX_NCHANNELS` is transport capacity, not the number of channels every collective actively launches.

Reviewed By: saifhhasan

Differential Revision: D113178478


