### PR TITLE
Add local-completion tickets for blocking sendrecv (#3237)

### DIFF
--- a/comms/prims/benchmarks/IbgdaBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cc
@@ -640,8 +640,9 @@ TEST_P(IbgdaBenchmarkFixture, ThreadScopeMultiBlockPutFlush) {
   printResultsTable("IBGDA ThreadScope MultiBlock Put+Flush", results);
 }
 
-TEST_F(IbgdaBenchmarkFixture, PutWaitCounter) {
-  // Measures raw RDMA Write latency (put + transport counter-slot wait).
+TEST_P(IbgdaBenchmarkFixture, PutCompletionComparison) {
+  // Serialize every put with its completion wait to isolate the primitive
+  // completion cost. This does not model pipelined send/recv overlap.
   if (numRanks != 2) {
     XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
@@ -656,7 +657,8 @@ TEST_F(IbgdaBenchmarkFixture, PutWaitCounter) {
     maxBufferSize = std::max(maxBufferSize, config.nBytes);
   }
 
-  std::vector<IbgdaBenchmarkResult> results;
+  std::vector<IbgdaBenchmarkResult> counterResults;
+  std::vector<IbgdaBenchmarkResult> localResults;
 
   try {
     MultipeerIbgdaTransportConfig transportConfig{
@@ -725,7 +727,7 @@ TEST_F(IbgdaBenchmarkFixture, PutWaitCounter) {
         result.latency = cyclesToUs(totalCycles) / kIbgdaBatchIters;
         result.bandwidth = (config.nBytes / 1e9f) / (result.latency / 1e6f);
 
-        results.push_back(result);
+        counterResults.push_back(result);
 
         XLOGF(
             INFO,
@@ -734,6 +736,37 @@ TEST_F(IbgdaBenchmarkFixture, PutWaitCounter) {
             config.name,
             result.latency,
             result.bandwidth);
+
+        launchIbgdaPutWaitLocalBatch(
+            deviceTransport,
+            localDataBuf,
+            remoteDataBuf,
+            config.nBytes,
+            kIbgdaBatchIters,
+            d_totalCycles,
+            stream_);
+        CUDA_CHECK_VOID(cudaStreamSynchronize(stream_));
+        CUDA_CHECK_VOID(cudaMemcpy(
+            &totalCycles,
+            d_totalCycles,
+            sizeof(unsigned long long),
+            cudaMemcpyDeviceToHost));
+
+        IbgdaBenchmarkResult localResult;
+        localResult.testName = config.name;
+        localResult.messageSize = config.nBytes;
+        localResult.latency = cyclesToUs(totalCycles) / kIbgdaBatchIters;
+        localResult.bandwidth =
+            (config.nBytes / 1e9f) / (localResult.latency / 1e6f);
+        localResults.push_back(localResult);
+
+        XLOGF(
+            INFO,
+            "Rank {}: {} wait_local - Latency: {:.2f} us, BW: {:.2f} GB/s",
+            globalRank,
+            config.name,
+            localResult.latency,
+            localResult.bandwidth);
       }
 
       MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -745,7 +778,9 @@ TEST_F(IbgdaBenchmarkFixture, PutWaitCounter) {
     GTEST_SKIP() << "IB transport not available: " << e.what();
   }
 
-  printResultsTable(backendTitle("Put+WaitCounter (RDMA Write)"), results);
+  printResultsTable(
+      backendTitle("Put+WaitCounter (RDMA Write)"), counterResults);
+  printResultsTable(backendTitle("Put+WaitLocal (RDMA Write)"), localResults);
 }
 
 TEST_P(IbgdaBenchmarkFixture, PutSignalWaitCounter) {

--- a/comms/prims/benchmarks/IbgdaBenchmark.cu
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cu
@@ -82,6 +82,34 @@ __global__ void ibgdaPutWaitCounterBatchKernel(
   }
 }
 
+__global__ void ibgdaPutWaitLocalBatchKernel(
+    P2pIbTransportDevice transport,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    std::size_t nbytes,
+    int numIters,
+    unsigned long long* totalCycles) {
+  auto group = make_block_group();
+  if (group.is_global_leader()) {
+    auto solo = make_thread_solo();
+
+    for (int i = 0; i < 10; i++) {
+      const auto ticket =
+          transport.put(localBuf, remoteBuf, nbytes, IbgdaRemoteBuffer{}, 0);
+      transport.wait_local(solo, ticket);
+    }
+
+    const unsigned long long startCycle = BENCHMARK_CLOCK64();
+    for (int i = 0; i < numIters; i++) {
+      const auto ticket =
+          transport.put(localBuf, remoteBuf, nbytes, IbgdaRemoteBuffer{}, 0);
+      transport.wait_local(solo, ticket);
+    }
+    const unsigned long long endCycle = BENCHMARK_CLOCK64();
+    *totalCycles = endCycle - startCycle;
+  }
+}
+
 __global__ void ibgdaPutFlushBatchKernel(
     P2pIbTransportDevice transport,
     IbgdaLocalBuffer localBuf,
@@ -378,6 +406,23 @@ void launchIbgdaPutWaitCounterBatch(
     cudaStream_t stream) {
   ibgdaPutWaitCounterBatchKernel<<<1, 32, 0, stream>>>(
       transport, localBuf, remoteBuf, nbytes, counterId, numIters, totalCycles);
+}
+
+void launchIbgdaPutWaitLocalBatch(
+    P2pIbTransportDevice transport,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t nbytes,
+    int numIters,
+    unsigned long long* totalCycles,
+    cudaStream_t stream) {
+  ibgdaPutWaitLocalBatchKernel<<<1, 32, 0, stream>>>(
+      transport, localBuf, remoteBuf, nbytes, numIters, totalCycles);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
 }
 
 void launchIbgdaPutFlushBatch(

--- a/comms/prims/benchmarks/IbgdaBenchmark.cuh
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cuh
@@ -42,6 +42,14 @@ __global__ void ibgdaPutWaitCounterBatchKernel(
     int numIters,
     unsigned long long* totalCycles);
 
+__global__ void ibgdaPutWaitLocalBatchKernel(
+    P2pIbTransportDevice transport,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    std::size_t nbytes,
+    int numIters,
+    unsigned long long* totalCycles);
+
 __global__ void ibgdaPutFlushBatchKernel(
     P2pIbTransportDevice transport,
     IbgdaLocalBuffer localBuf,

--- a/comms/prims/benchmarks/IbgdaBenchmark.h
+++ b/comms/prims/benchmarks/IbgdaBenchmark.h
@@ -53,6 +53,17 @@ void launchIbgdaPutWaitCounterBatch(
     unsigned long long* totalCycles,
     cudaStream_t stream);
 
+/** Launch batched raw puts, waiting on each returned local-completion ticket.
+ */
+void launchIbgdaPutWaitLocalBatch(
+    P2pIbTransportDevice transport,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t nbytes,
+    int numIters,
+    unsigned long long* totalCycles,
+    cudaStream_t stream);
+
 /**
  * Launch batched kernel: Multiple put + flush iterations
  *

--- a/comms/prims/benchmarks/results/IbgdaBenchmarkResults.md
+++ b/comms/prims/benchmarks/results/IbgdaBenchmarkResults.md
@@ -1,0 +1,103 @@
+# IBGDA Benchmark Results
+
+## Local-Completion Comparison
+
+This benchmark compares serialized raw puts completed through the loopback
+counter path with puts completed through the local-completion ticket returned
+by `put()`. It isolates the completion primitive and does not represent the
+overlapped pipeline behavior of blocking send/recv.
+
+## H100
+
+### Hardware and Configuration
+
+| Field | Value |
+| --- | --- |
+| Run date | 2026-07-22 |
+| Host | `devgpu005` |
+| GPU | NVIDIA H100 80GB HBM3 |
+| Ranks | 2 local ranks |
+| Backend | IBGDA |
+| Warmup iterations | 10 |
+| Timed iterations | 1,000 |
+| Timing | Batched GPU kernel; kernel-launch overhead excluded |
+
+### Command
+
+```bash
+buck run @fbcode//mode/opt -c comms.hosts=localhost \
+  fbcode//comms/prims/benchmarks:ibgda_benchmark -- \
+  --gtest_filter='IbBackend/IbgdaBenchmarkFixture.PutCompletionComparison/IBGDA'
+```
+
+### Results
+
+Latency reduction is `(wait_counter - wait_local) / wait_counter`.
+
+| Message size | `put + wait_counter` (us) | `put + wait_local` (us) | Latency reduction |
+| ---: | ---: | ---: | ---: |
+| 8 B | 13.13 | 9.67 | 26.4% |
+| 1 KiB | 13.66 | 9.78 | 28.4% |
+| 64 KiB | 15.33 | 11.46 | 25.2% |
+| 1 MiB | 37.48 | 33.77 | 9.9% |
+| 8 MiB | 188.53 | 184.99 | 1.9% |
+| 64 MiB | 1,398.54 | 1,395.25 | 0.2% |
+| 1 GiB | 22,186.48 | 22,176.71 | <0.1% |
+
+The local-completion ticket removes approximately 3.5-3.9 us through 1 MiB.
+The relative benefit becomes negligible once payload transfer time dominates.
+
+## GB300
+
+### Hardware and Configuration
+
+| Field | Value |
+| --- | --- |
+| Run date | 2026-07-22 |
+| Host | `twshared0104.33.nlh2.facebook.com` |
+| GPU | NVIDIA GB300 |
+| Ranks | 2 local ranks |
+| Backend | IBGDA |
+| NIC | `mlx5_4`, 400 Gb/s |
+| Data Direct | Inactive on the selected NIC |
+| Warmup iterations | 10 |
+| Timed iterations | 1,000 |
+| Timing | Batched GPU kernel; kernel-launch overhead excluded |
+
+The benchmark uses the non-Data-Direct `mlx5_4` rail because the host rejects
+Data-Direct DMA-BUF registration for the benchmark's 8-byte allocation. The
+selected rail uses ordinary GPUDirect RDMA registration.
+
+### Command
+
+```bash
+buck2 run @fbcode//mode/opt \
+  -c hpc_comms.use_ncclx=2.29 \
+  -c fbcode.arch=aarch64 \
+  -c fbcode.enable_gpu_sections=true \
+  -c fbcode.nvcc_arch=b300 \
+  -c fbcode.platform010-aarch64_clang=17 \
+  -c fbcode.platform010_cuda_version=13.0 \
+  -m ovr_config//third-party/cuda/constraints:13.0 \
+  -c comms.hosts=twshared0104.33.nlh2.facebook.com \
+  -c comms.ifname=lo \
+  -c 'comms.envs=NCCL_IB_HCA=mlx5_4' \
+  fbcode//comms/prims/benchmarks:ibgda_benchmark -- \
+  --gtest_filter='IbBackend/IbgdaBenchmarkFixture.PutCompletionComparison/IBGDA'
+```
+
+### Results
+
+| Message size | `put + wait_counter` (us) | `put + wait_local` (us) | Latency reduction |
+| ---: | ---: | ---: | ---: |
+| 8 B | 11.38 | 7.90 | 30.6% |
+| 1 KiB | 12.41 | 8.01 | 35.5% |
+| 64 KiB | 13.87 | 9.55 | 31.1% |
+| 1 MiB | 35.25 | 31.06 | 11.9% |
+| 8 MiB | 182.91 | 178.94 | 2.2% |
+| 64 MiB | 1,371.40 | 1,362.10 | 0.7% |
+| 1 GiB | 22,021.93 | 22,060.31 | -0.2% |
+
+The fixed-cost reduction is approximately 3.5-4.4 us through 1 MiB. At large
+sizes the difference is within run-to-run noise because transfer time
+dominates.

--- a/comms/prims/benchmarks/results/IbrcBenchmarkResults.md
+++ b/comms/prims/benchmarks/results/IbrcBenchmarkResults.md
@@ -1,10 +1,18 @@
 # IBRC Benchmark Results
 
-Run date: 2026-06-16
+## Hardware and Configuration
 
-Hosts used: `rtptest2330.nha6`, `rtptest2334.nha6`
+| Field | Value |
+| --- | --- |
+| Run date | 2026-06-16 |
+| Hosts | `rtptest2330.nha6`, `rtptest2334.nha6` |
+| GPU | NVIDIA GB200 |
+| Nodes | 2 |
+| Ranks per node | 1 |
+| Network interface | `eth1` |
+| Backends | IBGDA and IBRC |
 
-Launcher:
+## Command
 
 ```bash
 python3 comms/testinfra/ncclx_test_launcher.py \
@@ -17,21 +25,15 @@ python3 comms/testinfra/ncclx_test_launcher.py \
   --testname /home/zhiyongww/worktrees/IBRC/buck-out/v2/art/fbcode/065941cadf27ce30/comms/prims/benchmarks/__ibgda_benchmark_binary__/ibgda_benchmark_binary
 ```
 
-The initially suggested hosts, `rtptest2347.nha6` and `rtptest2346.nha6`, were not usable for this run because CUDA context creation failed with `CUDA-capable device(s) is/are busy or unavailable`. The results below use the clean GB200 pair listed above.
+The initially suggested hosts, `rtptest2347.nha6` and `rtptest2346.nha6`, were
+not usable because CUDA context creation failed with `CUDA-capable device(s)
+is/are busy or unavailable`. The results below use the GB200 pair listed above.
 
 ## Current Counter-Slot Results
 
 These results are after switching the counter benchmarks from explicit counter buffers to the transport-owned counter-slot API. IBRC `PutWaitCounter`, `PutSignalWaitCounter`, and `PutSignalComparison` pass with this path.
 
-Current logs:
-
-| Run | Log |
-| --- | --- |
-| Expanded sweep through 1GB | `/tmp/ibrc_1gb_sweep.log` |
-| IBRC counter-slot retest | `/tmp/ibrc_counter_slot_tests.log` |
-| IBGDA counter-slot retest | `/tmp/ibgda_counter_slot_tests.log` |
-
-Summary:
+### Summary
 
 | Benchmark | IBGDA | IBRC |
 | --- | ---: | ---: |

--- a/comms/prims/benchmarks/results/README.md
+++ b/comms/prims/benchmarks/results/README.md
@@ -1,0 +1,13 @@
+# Benchmark Results
+
+This directory stores reproducible results for benchmarks in
+`comms/prims/benchmarks`.
+
+| Report | Scope | Hardware |
+| --- | --- | --- |
+| [IBGDA benchmark](IbgdaBenchmarkResults.md) | Local-completion microbenchmark | H100 |
+| [IBRC benchmark](IbrcBenchmarkResults.md) | IBGDA and IBRC transport microbenchmarks | GB200 |
+
+Each report records the hardware, command, benchmark configuration, and result
+tables. Results from collective-level benchmarks should be kept separately
+from these transport microbenchmarks.

--- a/comms/prims/collectives/benchmarks/results/README.md
+++ b/comms/prims/collectives/benchmarks/results/README.md
@@ -1,0 +1,5 @@
+# Collective Benchmark Results
+
+| Report | Hardware |
+| --- | --- |
+| [Send/recv](SendRecvBenchmarkResults.md) | H100 and GB300 |

--- a/comms/prims/collectives/benchmarks/results/SendRecvBenchmarkResults.md
+++ b/comms/prims/collectives/benchmarks/results/SendRecvBenchmarkResults.md
@@ -1,0 +1,131 @@
+# Send/Recv Benchmark Results
+
+These results compare NCCL and the MCCL IBGDA blocking send/recv path using the
+same `nccl_sendrecv_perf` binary. All rows are out-of-place results.
+
+## Configuration
+
+| Field | Value |
+| --- | --- |
+| Run date | 2026-07-22 |
+| Ranks | 2 local ranks |
+| Topology | `IB_ONLY` |
+| Data type | `uint8` |
+| Message sizes | 1 B through 64 MiB, factor 2 |
+| Warmup iterations | 5 |
+| Timed iterations | 20 |
+| Registered memory | Disabled |
+| Validation | Enabled |
+
+## H100
+
+Hardware: 2 NVIDIA H100 80GB HBM3 GPUs on `devgpu005`.
+
+### Command
+
+```bash
+fbcode/comms/mccl/benchmarks/benchmark_sendrecv_nccl_tests.sh \
+  --variants nccl,mccl-ibgda \
+  --topologies IB_ONLY \
+  --arch h100 \
+  --np 2 \
+  --hosts localhost:2 \
+  --min-bytes 1 \
+  --max-bytes 64M \
+  --factor 2 \
+  --iters 20 \
+  --warmup 5 \
+  --register 0
+```
+
+### Results
+
+| Size | NCCL latency (us) | NCCL BW (GB/s) | IBGDA latency (us) | IBGDA BW (GB/s) | Wrong |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 B | 31.70 | 0.00 | 52.96 | 0.00 | 0 |
+| 2 B | 29.01 | 0.00 | 35.98 | 0.00 | 0 |
+| 4 B | 29.23 | 0.00 | 48.73 | 0.00 | 0 |
+| 8 B | 27.43 | 0.00 | 86.27 | 0.00 | 0 |
+| 16 B | 26.79 | 0.00 | 61.90 | 0.00 | 0 |
+| 32 B | 31.72 | 0.00 | 64.89 | 0.00 | 0 |
+| 64 B | 25.50 | 0.00 | 35.96 | 0.00 | 0 |
+| 128 B | 29.51 | 0.00 | 36.87 | 0.00 | 0 |
+| 256 B | 48.06 | 0.01 | 39.17 | 0.01 | 0 |
+| 512 B | 31.64 | 0.02 | 36.18 | 0.01 | 0 |
+| 1 KiB | 31.29 | 0.03 | 36.34 | 0.03 | 0 |
+| 2 KiB | 42.07 | 0.05 | 36.25 | 0.06 | 0 |
+| 4 KiB | 26.80 | 0.15 | 36.36 | 0.11 | 0 |
+| 8 KiB | 33.74 | 0.24 | 38.01 | 0.22 | 0 |
+| 16 KiB | 41.81 | 0.39 | 48.96 | 0.33 | 0 |
+| 32 KiB | 36.34 | 0.90 | 44.55 | 0.74 | 0 |
+| 64 KiB | 41.85 | 1.57 | 43.81 | 1.50 | 0 |
+| 128 KiB | 135.6 | 0.97 | 47.70 | 2.75 | 0 |
+| 256 KiB | 57.35 | 4.57 | 49.58 | 5.29 | 0 |
+| 512 KiB | 61.58 | 8.51 | 60.23 | 8.70 | 0 |
+| 1 MiB | 620.5 | 1.69 | 80.31 | 13.06 | 0 |
+| 2 MiB | 98.83 | 21.22 | 128.5 | 16.32 | 0 |
+| 4 MiB | 199.7 | 21.01 | 152.6 | 27.49 | 0 |
+| 8 MiB | 374.2 | 22.42 | 259.7 | 32.30 | 0 |
+| 16 MiB | 1,477.9 | 11.35 | 472.2 | 35.53 | 0 |
+| 32 MiB | 1,511.5 | 22.20 | 900.7 | 37.26 | 0 |
+| 64 MiB | 2,181.1 | 30.77 | 1,756.4 | 38.21 | 0 |
+
+The isolated H100 sweep contains several NCCL latency outliers. Use repeated
+runs before treating these NCCL rows as a regression baseline.
+
+## GB300
+
+Hardware: 2 NVIDIA GB300 GPUs on `twshared0104.33.nlh2.facebook.com`.
+The IBGDA path used the host's Data-Direct-capable NICs.
+
+### Command
+
+```bash
+fbcode/comms/mccl/benchmarks/benchmark_sendrecv_nccl_tests.sh \
+  --variants nccl,mccl-ibgda \
+  --topologies IB_ONLY \
+  --arch gb300 \
+  --np 2 \
+  --hosts localhost:2 \
+  --remote-host twshared0104.33.nlh2.facebook.com \
+  --min-bytes 1 \
+  --max-bytes 64M \
+  --factor 2 \
+  --iters 20 \
+  --warmup 5 \
+  --register 0
+```
+
+### Results
+
+| Size | NCCL latency (us) | NCCL BW (GB/s) | IBGDA latency (us) | IBGDA BW (GB/s) | Wrong |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 B | 25.78 | 0.00 | 34.03 | 0.00 | 0 |
+| 2 B | 25.04 | 0.00 | 33.94 | 0.00 | 0 |
+| 4 B | 25.13 | 0.00 | 33.79 | 0.00 | 0 |
+| 8 B | 25.18 | 0.00 | 33.93 | 0.00 | 0 |
+| 16 B | 24.97 | 0.00 | 33.64 | 0.00 | 0 |
+| 32 B | 25.10 | 0.00 | 33.80 | 0.00 | 0 |
+| 64 B | 25.33 | 0.00 | 34.45 | 0.00 | 0 |
+| 128 B | 25.18 | 0.01 | 35.35 | 0.00 | 0 |
+| 256 B | 25.47 | 0.01 | 35.48 | 0.01 | 0 |
+| 512 B | 25.56 | 0.02 | 35.49 | 0.01 | 0 |
+| 1 KiB | 25.74 | 0.04 | 35.54 | 0.03 | 0 |
+| 2 KiB | 25.81 | 0.08 | 35.71 | 0.06 | 0 |
+| 4 KiB | 25.47 | 0.16 | 35.94 | 0.11 | 0 |
+| 8 KiB | 26.04 | 0.31 | 36.79 | 0.22 | 0 |
+| 16 KiB | 31.59 | 0.52 | 37.97 | 0.43 | 0 |
+| 32 KiB | 32.39 | 1.01 | 39.58 | 0.83 | 0 |
+| 64 KiB | 35.19 | 1.86 | 42.37 | 1.55 | 0 |
+| 128 KiB | 44.65 | 2.94 | 46.46 | 2.82 | 0 |
+| 256 KiB | 40.68 | 6.44 | 47.78 | 5.49 | 0 |
+| 512 KiB | 44.96 | 11.66 | 57.91 | 9.05 | 0 |
+| 1 MiB | 56.34 | 18.61 | 74.61 | 14.05 | 0 |
+| 2 MiB | 70.58 | 29.71 | 118.9 | 17.63 | 0 |
+| 4 MiB | 99.77 | 42.04 | 146.3 | 28.67 | 0 |
+| 8 MiB | 159.1 | 52.73 | 260.2 | 32.24 | 0 |
+| 16 MiB | 276.9 | 60.58 | 469.0 | 35.77 | 0 |
+| 32 MiB | 476.3 | 70.45 | 890.7 | 37.67 | 0 |
+| 64 MiB | 899.2 | 74.63 | 1,746.9 | 38.42 | 0 |
+
+Both variants completed every size with zero wrong counts.

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -30,7 +30,7 @@ __device__ __forceinline__ void P2pIbTransportDevice::signal(
   }
 }
 
-__device__ __forceinline__ void P2pIbTransportDevice::put(
+__device__ __forceinline__ IbLocalCompletionTicket P2pIbTransportDevice::put(
     ThreadGroup& group,
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer& remoteBuf,
@@ -40,7 +40,7 @@ __device__ __forceinline__ void P2pIbTransportDevice::put(
     int counterId,
     uint64_t counterVal) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->put(
+    return ibrc->put(
         group,
         localBuf,
         remoteBuf,
@@ -50,7 +50,7 @@ __device__ __forceinline__ void P2pIbTransportDevice::put(
         counterId,
         counterVal);
   } else {
-    ibgda->put(
+    return ibgda->put(
         group,
         localBuf,
         remoteBuf,
@@ -62,7 +62,7 @@ __device__ __forceinline__ void P2pIbTransportDevice::put(
   }
 }
 
-__device__ __forceinline__ void P2pIbTransportDevice::put(
+__device__ __forceinline__ IbLocalCompletionTicket P2pIbTransportDevice::put(
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer& remoteBuf,
     std::size_t nbytes,
@@ -71,7 +71,7 @@ __device__ __forceinline__ void P2pIbTransportDevice::put(
     int counterId,
     uint64_t counterVal) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->put(
+    return ibrc->put(
         localBuf,
         remoteBuf,
         nbytes,
@@ -80,7 +80,7 @@ __device__ __forceinline__ void P2pIbTransportDevice::put(
         counterId,
         counterVal);
   } else {
-    ibgda->put(
+    return ibgda->put(
         localBuf,
         remoteBuf,
         nbytes,
@@ -169,6 +169,17 @@ __device__ __forceinline__ void P2pIbTransportDevice::wait_counter(
   }
 }
 
+__device__ __forceinline__ void P2pIbTransportDevice::wait_local(
+    ThreadGroup& group,
+    const IbLocalCompletionTicket& ticket,
+    const Timeout& timeout) {
+  if (type == P2pIbBackendType::IBRC) {
+    ibrc->wait_local(group, ticket, timeout);
+  } else {
+    ibgda->wait_local(group, ticket, timeout);
+  }
+}
+
 __device__ __forceinline__ void P2pIbTransportDevice::reset_signal(
     ThreadGroup& group,
     int signalId) {
@@ -244,7 +255,7 @@ __device__ __forceinline__ void P2pIbTransportDevice::signal(
   }
 }
 
-__device__ __forceinline__ void P2pIbTransportDevice::put(
+__device__ __forceinline__ IbLocalCompletionTicket P2pIbTransportDevice::put(
     ThreadGroup& group,
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer& remoteBuf,
@@ -255,7 +266,7 @@ __device__ __forceinline__ void P2pIbTransportDevice::put(
     uint64_t counterVal,
     bool signalPerLane) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->put(
+    return ibrc->put(
         group,
         localBuf,
         remoteBuf,
@@ -266,7 +277,7 @@ __device__ __forceinline__ void P2pIbTransportDevice::put(
         counterVal,
         signalPerLane);
   } else {
-    ibgda->put(
+    return ibgda->put(
         group,
         localBuf,
         remoteBuf,
@@ -279,7 +290,7 @@ __device__ __forceinline__ void P2pIbTransportDevice::put(
   }
 }
 
-__device__ __forceinline__ void P2pIbTransportDevice::put(
+__device__ __forceinline__ IbLocalCompletionTicket P2pIbTransportDevice::put(
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer& remoteBuf,
     std::size_t nbytes,
@@ -288,7 +299,7 @@ __device__ __forceinline__ void P2pIbTransportDevice::put(
     const IbgdaLocalBuffer& counterBuf,
     uint64_t counterVal) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->put(
+    return ibrc->put(
         localBuf,
         remoteBuf,
         nbytes,
@@ -297,7 +308,7 @@ __device__ __forceinline__ void P2pIbTransportDevice::put(
         counterBuf,
         counterVal);
   } else {
-    ibgda->put(
+    return ibgda->put(
         localBuf,
         remoteBuf,
         nbytes,

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -190,13 +190,18 @@ __device__ __forceinline__ ProgressChunk next_chunk(
  * These helpers implement the blocking `send`/`recv`/`forward`, the resumable
  * `init_*_progress` / `progress_*_once` pair, and their private helpers. The
  * send/recv algorithm is independent of the underlying transport: it only
- * needs the common explicit-buffer IB device ops `put` (fused signal+counter),
+ * needs the common explicit-buffer IB device ops `put`, `wait_local`,
  * `signal`, `wait_signal`, `wait_counter`, `read_signal`, and `read_counter`.
  *
  * Every public entry point takes the owning transport and routes every
  * transport op through it. `P2pIbgdaTransportDevice` and
  * `P2pIbrcTransportDevice` own the channel layout/state and use these helpers
  * only for the shared send/recv algorithm.
+ *
+ * Blocking send/forward use put() completion tickets for local staging reuse.
+ * The resumable progress APIs retain counter completion for now. Until they
+ * migrate in a follow-up, callers must not mix blocking and progress sends on
+ * the same channel because their local-completion streams are independent.
  */
 /**
  * Initialize transport-owned state for one pipelined send operation.
@@ -772,8 +777,9 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
  * finer-grained overlap at the receiver.
  *
  * Signaling protocol (per group):
- *   NIC_DONE   — loopback counter incremented by NIC after each RDMA put.
- *                send waits on this before overwriting local sendStaging.
+ *   LOCAL_DONE — completion ticket returned by each RDMA put. Blocking send
+ *                waits on the latest channel frontier before overwriting
+ *                local sendStaging.
  *   SLOT_FREE  — receiver increments by bytesThis for each signaled byte
  *                range. send waits before overwriting recvStaging.
  *   DATA_READY — sender increments by bytesThis, piggybacked on put.
@@ -858,9 +864,6 @@ __device__ __forceinline__ void send(
   IbLocalChannel& localChannel =
       transport.local_channel(static_cast<uint32_t>(groupId));
   const IbgdaLocalBuffer localSlotFree = localChannel.slotFree;
-  const IbgdaLocalBuffer localNicDoneWait = localChannel.nicDoneWait;
-  const IbgdaLocalBuffer localNicDoneCompletion =
-      localChannel.nicDoneCompletion;
   const IbRemoteChannel remoteChannel =
       makeIbRemoteChannel(channelLayout, groupId);
   assert_progress_slot_idle(group, state, "send");
@@ -895,12 +898,10 @@ __device__ __forceinline__ void send(
     const std::size_t stagingOff =
         static_cast<std::size_t>(groupId) * pipelineBytes + slotOff + chunkOff;
     const uint64_t protocolStreamEnd = streamStart + protocolBytesThis;
+    const uint64_t pipelineCycle = streamStart / pipelineBytes;
 
     // (1) Wait for NIC to finish with this slot's local sendStaging.
-    if (protocolStreamEnd > pipelineBytes) {
-      transport.wait_counter(
-          group, localNicDoneWait, protocolStreamEnd - pipelineBytes, timeout);
-    }
+    transport.prepare_send_slot(group, slot, pipelineCycle, timeout);
 
     // (2) Cooperative copy: src -> local sendStaging via CopyOp.
     const std::size_t validBytes =
@@ -923,24 +924,25 @@ __device__ __forceinline__ void send(
           group, localSlotFree, protocolStreamEnd - pipelineBytes, timeout);
     }
 
-    // (4) threadfence_system + leader-only single-WQE RDMA put with
-    //     fused signal+counter. All threads fence to ensure memcpy
+    // (4) threadfence_system + leader-only RDMA put with fused signal.
     //     stores are visible to the NIC before the leader posts the WQE.
     __threadfence_system();
     group.sync();
     if (group.is_leader()) {
       ThreadGroup solo{
           0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
-      transport.put(
+      const auto completion = transport.put(
           solo,
           channelLayout.sendStagingBuf.subBuffer(stagingOff),
           remoteChannel.recvStaging.subBuffer(stagingOff),
           bytesThis,
           remoteChannel.dataReady,
           protocolBytesThis,
-          localNicDoneCompletion,
-          protocolBytesThis,
+          /*counterBuf=*/{},
+          /*counterVal=*/0,
           /*signalPerLane=*/true);
+      transport.record_send_completion(
+          static_cast<uint32_t>(groupId), slot, pipelineCycle, completion);
     }
     group.sync();
     dataOff += bytesThis;
@@ -1128,7 +1130,7 @@ __device__ __forceinline__ void recv(
  *
  * Signal ordering invariant (critical for ring deadlock avoidance):
  *   1. Wait DATA_READY from sender (this transport)
- *   2. Wait NIC_DONE on fwd transport's sendStaging (backpressure)
+ *   2. Wait for local completion on fwd transport's sendStaging
  *   3. CopyOp::forward(dst, fwd_staging, staging, ...)
  *   4. Signal SLOT_FREE to sender (this transport) — BEFORE step 5
  *   5. Wait SLOT_FREE from fwd transport's receiver
@@ -1149,10 +1151,10 @@ __device__ __forceinline__ void recv(
  *
  *   Fwd side (fwd transport):
  *     - Uses the forward channel's send progress cursor.
- *     - Waits NIC_DONE on the forward channel's local completion counter.
+ *     - Waits on the forward channel's local-completion ticket.
  *     - Waits SLOT_FREE on the forward channel's local slot-free signal.
  *     - RDMA puts with DATA_READY on the forward remote channel and
- *       posts NIC_DONE credit per chunk to the local completion counter.
+ *       returns a ticket covering local completion of the data put.
  *
  * Any chain of send → forward* → recv is therefore valid: each
  * forward consumes exactly the signals its predecessor produces
@@ -1270,9 +1272,6 @@ __device__ __forceinline__ void forward(
   IbLocalChannel& fwdLocalChannel =
       fwdTransport.local_channel(static_cast<uint32_t>(groupId));
   const IbgdaLocalBuffer fwdSlotFree = fwdLocalChannel.slotFree;
-  const IbgdaLocalBuffer fwdNicDoneWait = fwdLocalChannel.nicDoneWait;
-  const IbgdaLocalBuffer fwdNicDoneCompletion =
-      fwdLocalChannel.nicDoneCompletion;
   const IbRemoteChannel fwdRemoteChannel =
       makeIbRemoteChannel(fwdChannelLayout, groupId);
   assert_progress_slot_idle(group, fwdSlotState, "forward send");
@@ -1334,6 +1333,7 @@ __device__ __forceinline__ void forward(
     const std::size_t fwdProtocolBytesThis =
         bytesThis + (isFinalChunk ? fwdProtocolTailPadding : 0);
     const uint64_t fwdProtocolStreamEnd = fwdStreamStart + fwdProtocolBytesThis;
+    const uint64_t fwdPipelineCycle = fwdStreamStart / fwdPipelineBytes;
 
     // (1) Wait for the upstream sender's DATA_READY on the specific round-robin
     //     lane that carried this chunk (mirrors the upstream sender's Send
@@ -1346,14 +1346,8 @@ __device__ __forceinline__ void forward(
         recvProtocolBytesThis,
         timeout);
 
-    // (2) Wait for NIC_DONE on fwd's sendStaging (backpressure).
-    if (fwdProtocolStreamEnd > fwdPipelineBytes) {
-      fwdTransport.wait_counter(
-          group,
-          fwdNicDoneWait,
-          fwdProtocolStreamEnd - fwdPipelineBytes,
-          timeout);
-    }
+    // (2) Wait for local completion on fwd's sendStaging.
+    fwdTransport.prepare_send_slot(group, fwdSlot, fwdPipelineCycle, timeout);
 
     // (3) CopyOp::forward — transform recv staging -> dst + fwd staging.
     const std::size_t validBytes =
@@ -1389,16 +1383,21 @@ __device__ __forceinline__ void forward(
     if (group.is_leader()) {
       ThreadGroup solo{
           0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
-      fwdTransport.put(
+      const auto completion = fwdTransport.put(
           solo,
           fwdChannelLayout.sendStagingBuf.subBuffer(fwdStagingOff),
           fwdRemoteChannel.recvStaging.subBuffer(fwdStagingOff),
           bytesThis,
           fwdRemoteChannel.dataReady,
           fwdProtocolBytesThis,
-          fwdNicDoneCompletion,
-          fwdProtocolBytesThis,
+          /*counterBuf=*/{},
+          /*counterVal=*/0,
           /*signalPerLane=*/true);
+      fwdTransport.record_send_completion(
+          static_cast<uint32_t>(groupId),
+          fwdSlot,
+          fwdPipelineCycle,
+          completion);
     }
     group.sync();
     dataOff += bytesThis;
@@ -1916,8 +1915,8 @@ struct P2pIbTransportDevice {
   __device__ void
   signal(ThreadGroup& group, int signalId, uint64_t signalVal = 1);
 
-  __device__ void put(
-      ThreadGroup& group,
+  __device__ IbLocalCompletionTicket
+  put(ThreadGroup& group,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes,
@@ -1926,8 +1925,8 @@ struct P2pIbTransportDevice {
       int counterId = -1,
       uint64_t counterVal = 1);
 
-  __device__ void put(
-      const IbgdaLocalBuffer& localBuf,
+  __device__ IbLocalCompletionTicket
+  put(const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes,
       int signalId = -1,
@@ -1989,8 +1988,8 @@ struct P2pIbTransportDevice {
       const IbgdaRemoteBuffer& signalBuf,
       uint64_t signalVal = 1);
 
-  __device__ void put(
-      ThreadGroup& group,
+  __device__ IbLocalCompletionTicket
+  put(ThreadGroup& group,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes,
@@ -2000,8 +1999,8 @@ struct P2pIbTransportDevice {
       uint64_t counterVal = 1,
       bool signalPerLane = false);
 
-  __device__ void put(
-      const IbgdaLocalBuffer& localBuf,
+  __device__ IbLocalCompletionTicket
+  put(const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes,
       const IbgdaRemoteBuffer& signalBuf,
@@ -2048,6 +2047,11 @@ struct P2pIbTransportDevice {
   __device__ void wait_counter(
       const IbgdaLocalBuffer& counterBuf,
       uint64_t expected,
+      const Timeout& timeout = Timeout());
+
+  __device__ void wait_local(
+      ThreadGroup& group,
+      const IbLocalCompletionTicket& ticket,
       const Timeout& timeout = Timeout());
 
   __device__ void reset_signal(

--- a/comms/prims/transport/ibgda/IbgdaBuffer.h
+++ b/comms/prims/transport/ibgda/IbgdaBuffer.h
@@ -552,6 +552,23 @@ enum class IbDirection : uint8_t {
 inline constexpr int kIbDirections = 2;
 inline constexpr int kIbMaxQpLanesPerChannelDirection = 64;
 
+// Identifies a lane-local completion threshold returned by put().
+// completionId is the send-lane ordinal; value is complete once that lane's
+// backend-specific completion frontier reaches it.
+struct IbLocalCompletionTicket {
+  uint32_t completionId{0};
+  uint64_t value{0};
+};
+
+// Completion thresholds accumulated for one channel's pipeline slot.
+// generation identifies the slot use; laneMask selects valid values entries,
+// each the latest ticket value that must complete before the slot is reused.
+struct IbSendCompletionSlot {
+  uint64_t generation{0};
+  uint64_t laneMask{0};
+  uint64_t values[kIbMaxQpLanesPerChannelDirection]{};
+};
+
 struct IbQpState {
   uint32_t cursor{0};
   uint64_t pendingFlushLanesMask{0};
@@ -589,6 +606,8 @@ struct IbLocalChannel {
   IbgdaLocalBuffer nicDoneWait;
   IbgdaLocalBuffer nicDoneCompletion;
 
+  IbSendCompletionSlot* sendCompletionSlots{nullptr};
+
   IbQpState sendQp;
   IbQpState recvQp;
 };
@@ -601,12 +620,14 @@ struct IbRemoteChannel {
 
 IBGDA_HOST_DEVICE inline IbLocalChannel makeIbLocalChannel(
     const IbChannelLayout& layout,
-    int channelId) {
+    int channelId,
+    IbSendCompletionSlot* sendCompletionSlots = nullptr) {
   IbLocalChannel channel{};
   channel.dataReady = layout.localDataReadySignal(channelId);
   channel.slotFree = layout.localSlotFreeSignal(channelId);
   channel.nicDoneWait = layout.localCounter(channelId);
   channel.nicDoneCompletion = layout.localCompletionCounter(channelId);
+  channel.sendCompletionSlots = sendCompletionSlots;
   return channel;
 }
 

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cu
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cu
@@ -6,10 +6,26 @@
 #include <glog/logging.h>
 
 #include <cstring>
+#include <limits>
 
 #include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
 
 namespace comms::prims {
+namespace {
+
+std::size_t checkedAdd(std::size_t lhs, std::size_t rhs, const char* label) {
+  CHECK_LE(lhs, std::numeric_limits<std::size_t>::max() - rhs)
+      << label << " size overflow";
+  return lhs + rhs;
+}
+
+std::size_t checkedMul(std::size_t lhs, std::size_t rhs, const char* label) {
+  CHECK(lhs == 0 || rhs <= std::numeric_limits<std::size_t>::max() / lhs)
+      << label << " size overflow";
+  return lhs * rhs;
+}
+
+} // namespace
 
 P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
     const std::vector<P2pIbgdaTransportBuildParams>& params,
@@ -137,14 +153,48 @@ P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
   CHECK(err == cudaSuccess)
       << "Failed to allocate GPU IB channel state: " << cudaGetErrorString(err);
   outGpuAllocations.push_back(d_allLocalChannels);
+  std::size_t totalCompletionSlots = 0;
+  for (int i = 0; i < numPeers; ++i) {
+    const int pipelineDepth = params[i].channelLayout.pipelineDepth;
+    CHECK_GE(pipelineDepth, 0) << "pipelineDepth must not be negative";
+    const std::size_t peerCompletionSlots = checkedMul(
+        static_cast<std::size_t>(params[i].maxChannels),
+        static_cast<std::size_t>(pipelineDepth),
+        "send completion slots");
+    totalCompletionSlots = checkedAdd(
+        totalCompletionSlots, peerCompletionSlots, "send completion slots");
+  }
+  IbSendCompletionSlot* d_allCompletionSlots = nullptr;
+  const std::size_t completionSlotBytes = checkedMul(
+      totalCompletionSlots,
+      sizeof(IbSendCompletionSlot),
+      "send completion slots");
+  if (completionSlotBytes != 0) {
+    err = cudaMalloc(&d_allCompletionSlots, completionSlotBytes);
+    CHECK(err == cudaSuccess)
+        << "Failed to allocate GPU send completion slots: "
+        << cudaGetErrorString(err);
+    outGpuAllocations.push_back(d_allCompletionSlots);
+    err = cudaMemset(d_allCompletionSlots, 0, completionSlotBytes);
+    CHECK(err == cudaSuccess)
+        << "Failed to initialize GPU send completion slots: "
+        << cudaGetErrorString(err);
+  }
   std::vector<IbLocalChannel> h_localChannels(
       static_cast<std::size_t>(numPeers) * params[0].maxChannels);
+  std::size_t completionSlotOffset = 0;
   for (int i = 0; i < numPeers; ++i) {
     for (int channel = 0; channel < params[i].maxChannels; ++channel) {
       const auto channelIndex =
           static_cast<std::size_t>(i) * params[0].maxChannels + channel;
+      const std::size_t pipelineDepth =
+          static_cast<std::size_t>(params[i].channelLayout.pipelineDepth);
+      IbSendCompletionSlot* completionSlots = pipelineDepth == 0
+          ? nullptr
+          : d_allCompletionSlots + completionSlotOffset;
       h_localChannels[channelIndex] =
-          makeIbLocalChannel(params[i].channelLayout, channel);
+          makeIbLocalChannel(params[i].channelLayout, channel, completionSlots);
+      completionSlotOffset += pipelineDepth;
     }
   }
   err = cudaMemcpy(
@@ -271,10 +321,37 @@ void writeDeviceTransportSlot(
   CHECK(err == cudaSuccess) << "Failed to allocate per-peer IB channel state: "
                             << cudaGetErrorString(err);
   outGpuAllocations.push_back(d_localChannels);
+  CHECK_GE(params.channelLayout.pipelineDepth, 0)
+      << "pipelineDepth must not be negative";
+  const std::size_t pipelineDepth =
+      static_cast<std::size_t>(params.channelLayout.pipelineDepth);
+  const std::size_t completionSlotCount = checkedMul(
+      static_cast<std::size_t>(params.maxChannels),
+      pipelineDepth,
+      "send completion slots");
+  IbSendCompletionSlot* d_completionSlots = nullptr;
+  const std::size_t completionSlotBytes = checkedMul(
+      completionSlotCount,
+      sizeof(IbSendCompletionSlot),
+      "send completion slots");
+  if (completionSlotBytes != 0) {
+    err = cudaMalloc(&d_completionSlots, completionSlotBytes);
+    CHECK(err == cudaSuccess) << "Failed to allocate per-peer send completion "
+                                 "slots: "
+                              << cudaGetErrorString(err);
+    outGpuAllocations.push_back(d_completionSlots);
+    err = cudaMemset(d_completionSlots, 0, completionSlotBytes);
+    CHECK(err == cudaSuccess)
+        << "Failed to initialize per-peer send completion slots: "
+        << cudaGetErrorString(err);
+  }
   std::vector<IbLocalChannel> h_localChannels(params.maxChannels);
   for (int channel = 0; channel < params.maxChannels; ++channel) {
+    IbSendCompletionSlot* completionSlots = pipelineDepth == 0
+        ? nullptr
+        : d_completionSlots + static_cast<std::size_t>(channel) * pipelineDepth;
     h_localChannels[channel] =
-        makeIbLocalChannel(params.channelLayout, channel);
+        makeIbLocalChannel(params.channelLayout, channel, completionSlots);
   }
   err = cudaMemcpy(
       d_localChannels,

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -105,6 +105,8 @@ struct NicDeviceIbgdaResources {
  *     Threads in the group coordinate the operation; callers that want the
  *     transport to shard a larger buffer should use put_cooperative().
  *     Signal/counter/flush are leader-only with group.sync().
+ *     The returned ticket carries data only in the leader thread. A later
+ *     group-scope wait_local() consumes that leader's ticket collectively.
  *
  *   Thread-scope: put(...) — single thread calls.
  *     QP selection uses the caller's physical blockIdx.x. Implemented as a
@@ -140,7 +142,8 @@ struct NicDeviceIbgdaResources {
  * the same QP, so the signal covers that put. A standalone signal uses the
  * block's control lane and does not cover earlier round-robined puts unless
  * the caller explicitly calls fence()/flush() first.
- * put() returns void — completion via wait_signal/wait_counter/flush.
+ * put() returns a local-completion frontier. Callers may ignore it and use an
+ * optional counter or flush instead.
  *
  * Two API layers:
  *   1. Slot-index API: resolve owned buffers by slot index, then forward
@@ -242,8 +245,8 @@ class P2pIbgdaTransportDevice {
    *                    the counter. Bounds-checked against numCounterSlots_.
    * @param counterVal  Value added to the local counter slot.
    */
-  __device__ void put(
-      ThreadGroup& group,
+  __device__ IbLocalCompletionTicket
+  put(ThreadGroup& group,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes,
@@ -255,7 +258,8 @@ class P2pIbgdaTransportDevice {
         (signalId >= 0) ? remote_signal_slot(signalId) : IbgdaRemoteBuffer{};
     IbgdaLocalBuffer ctrSlot =
         (counterId >= 0) ? counter_slot(counterId) : IbgdaLocalBuffer{};
-    put(group,
+    return put(
+        group,
         localBuf,
         remoteBuf,
         nbytes,
@@ -304,8 +308,8 @@ class P2pIbgdaTransportDevice {
    * use the group-scope APIs because the solo group id is not a channel id.
    * Args match the group-scope overload.
    */
-  __device__ void put(
-      const IbgdaLocalBuffer& localBuf,
+  __device__ IbLocalCompletionTicket
+  put(const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes,
       int signalId = -1,
@@ -313,7 +317,8 @@ class P2pIbgdaTransportDevice {
       int counterId = -1,
       uint64_t counterVal = 1) {
     ThreadGroup solo = make_thread_solo();
-    put(solo,
+    return put(
+        solo,
         localBuf,
         remoteBuf,
         nbytes,
@@ -477,7 +482,8 @@ class P2pIbgdaTransportDevice {
    * larger user buffer. Use put_cooperative() for the convenience behavior that
    * splits the provided range across the group.
    *
-   * Returns void; completion is observed via wait_signal/wait_counter/flush.
+   * Returns a local-completion frontier. Callers may ignore it and use the
+   * optional counter or flush APIs instead.
    *
    * NOTE: signalBuf is intentionally NOT defaulted, even though `= {}` would
    * mean "no signal". Defaulting it would make put(group, local, remote, n)
@@ -497,8 +503,8 @@ class P2pIbgdaTransportDevice {
    *                   WQE through the companion QP.
    * @param counterVal Value added to *counterBuf.
    */
-  __device__ void put(
-      ThreadGroup& group,
+  __device__ IbLocalCompletionTicket
+  put(ThreadGroup& group,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes,
@@ -507,7 +513,7 @@ class P2pIbgdaTransportDevice {
       const IbgdaLocalBuffer& counterBuf = {},
       uint64_t counterVal = 1,
       bool signalPerLane = false) {
-    put_impl(
+    return put_impl(
         group,
         localBuf,
         remoteBuf,
@@ -526,8 +532,8 @@ class P2pIbgdaTransportDevice {
    *
    * signalBuf intentionally not defaulted (see group-scope sibling above).
    */
-  __device__ void put(
-      const IbgdaLocalBuffer& localBuf,
+  __device__ IbLocalCompletionTicket
+  put(const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes,
       const IbgdaRemoteBuffer& signalBuf,
@@ -535,7 +541,8 @@ class P2pIbgdaTransportDevice {
       const IbgdaLocalBuffer& counterBuf = {},
       uint64_t counterVal = 1) {
     ThreadGroup solo = make_thread_solo();
-    put(solo,
+    return put(
+        solo,
         localBuf,
         remoteBuf,
         nbytes,
@@ -660,6 +667,54 @@ class P2pIbgdaTransportDevice {
       uint64_t expected,
       const Timeout& timeout = Timeout()) {
     wait_counter_impl(group, counterBuf, expected, timeout);
+  }
+
+  __device__ void wait_local(
+      ThreadGroup& group,
+      const IbLocalCompletionTicket& ticket,
+      const Timeout& timeout = Timeout()) {
+    if (group.is_leader()) {
+      IbgdaLane lane = lane_from_ordinal(
+          group.group_id, IbDirection::Send, ticket.completionId);
+      wait_local_on_qp(lane.qp, ticket.value, timeout);
+    }
+    group.sync();
+  }
+
+  __device__ void prepare_send_slot(
+      ThreadGroup& group,
+      uint32_t slotId,
+      uint64_t generation,
+      const Timeout& timeout = Timeout()) {
+    if (group.is_leader()) {
+      auto& slot = localChannels_[group.group_id].sendCompletionSlots[slotId];
+      if (slot.generation != generation) {
+        const uint64_t laneMask = slot.laneMask;
+        const uint32_t numLanes = num_qp_lanes();
+        for (uint32_t laneId = 0; laneId < numLanes; ++laneId) {
+          if ((laneMask & (1ULL << laneId)) == 0) {
+            continue;
+          }
+          IbgdaLane lane =
+              lane_from_ordinal(group.group_id, IbDirection::Send, laneId);
+          wait_local_on_qp(lane.qp, slot.values[laneId], timeout);
+        }
+        slot.laneMask = 0;
+        slot.generation = generation;
+      }
+    }
+    group.sync();
+  }
+
+  __device__ __forceinline__ void record_send_completion(
+      uint32_t channelId,
+      uint32_t slotId,
+      uint64_t generation,
+      const IbLocalCompletionTicket& ticket) {
+    auto& slot = localChannels_[channelId].sendCompletionSlots[slotId];
+    slot.generation = generation;
+    slot.values[ticket.completionId] = ticket.value;
+    slot.laneMask |= 1ULL << ticket.completionId;
   }
 
   /** wait_counter (thread-scope) - Single-thread variant. */
@@ -1057,7 +1112,7 @@ class P2pIbgdaTransportDevice {
     wait_lanes(group.group_id, direction, mask, state.lastFlushWqe);
   }
 
-  __device__ void put_impl(
+  __device__ IbLocalCompletionTicket put_impl(
       ThreadGroup& group,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
@@ -1076,9 +1131,10 @@ class P2pIbgdaTransportDevice {
         PIPES_DEVICE_TRAP();
       }
       group.sync();
-      return;
+      return {};
     }
 
+    IbLocalCompletionTicket completion;
     if (group.is_leader()) {
       validate_group_scope(group);
       const bool hasCounter = counterBuf.ptr != nullptr;
@@ -1093,6 +1149,7 @@ class P2pIbgdaTransportDevice {
           (signalPerLane && signalBuf.ptr != nullptr)
           ? signalBuf.subBuffer(sendRecvSignalSlotOffset(lane.lane_ordinal))
           : signalBuf;
+      uint64_t dataTicket = 0;
       if (hasSignal && hasCounter) {
         const auto tickets = put_signal_counter_single_impl(
             lane,
@@ -1103,22 +1160,33 @@ class P2pIbgdaTransportDevice {
             signalVal,
             counterBuf,
             counterVal);
+        dataTicket = tickets.put_wqe;
+        record_put_wqe(lane, tickets.put_wqe);
         record_signal_wqe(lane, tickets.signal_wqe);
       } else if (hasSignal) {
         const auto tickets = put_signal_single_impl(
             lane, localBuf, remoteBuf, nbytes, effectiveSignalBuf, signalVal);
+        dataTicket = tickets.put_wqe;
+        record_put_wqe(lane, tickets.put_wqe);
         record_signal_wqe(lane, tickets.signal_wqe);
       } else if (hasCounter) {
         const uint64_t putTicket = put_counter_single_impl(
             lane, localBuf, remoteBuf, nbytes, counterBuf, counterVal);
+        dataTicket = putTicket;
         record_put_wqe(lane, putTicket);
       } else {
         const uint64_t putTicket =
             put_single_impl(lane, localBuf, remoteBuf, nbytes);
+        dataTicket = putTicket;
         record_put_wqe(lane, putTicket);
       }
+      completion = IbLocalCompletionTicket{
+          .completionId = lane.lane_ordinal,
+          .value = dataTicket,
+      };
     }
     group.sync();
+    return completion;
   }
 
   __device__ void put_cooperative_impl(

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -945,14 +945,43 @@ void MultipeerIbrcTransport::allocatePeerCmdQueues(int peerIndex) {
       peer.cmdQueueDevices.host,
       deviceCmdQueues.data(),
       deviceCmdQueues.size() * sizeof(IbrcCmdQueueDevice));
-  peer.channelState = allocateMapped(
+  const std::size_t channelBytes =
       static_cast<std::size_t>(config_.max_num_channels) *
-          sizeof(IbLocalChannel),
-      "per-peer channel state");
-  auto* channels = static_cast<IbLocalChannel*>(peer.channelState.host);
+      sizeof(IbLocalChannel);
+  const std::size_t completionSlotsOffset =
+      alignUp(channelBytes, alignof(IbSendCompletionSlot));
   const IbChannelLayout channelLayout = channelLayoutForPeer(peerIndex);
+  CHECK_GE(channelLayout.pipelineDepth, 0);
+  const std::size_t completionSlotCount = checkedMul(
+      static_cast<std::size_t>(config_.max_num_channels),
+      static_cast<std::size_t>(channelLayout.pipelineDepth),
+      "per-peer send completion slots");
+  const std::size_t completionSlotBytes = checkedMul(
+      completionSlotCount,
+      sizeof(IbSendCompletionSlot),
+      "per-peer send completion slots");
+  const std::size_t channelStateBytes = completionSlotBytes == 0
+      ? channelBytes
+      : checkedAdd(
+            completionSlotsOffset,
+            completionSlotBytes,
+            "per-peer channel state");
+  peer.channelState =
+      allocateMapped(channelStateBytes, "per-peer channel state");
+  auto* channels = static_cast<IbLocalChannel*>(peer.channelState.host);
+  auto* completionSlots = completionSlotBytes == 0
+      ? nullptr
+      : reinterpret_cast<IbSendCompletionSlot*>(
+            static_cast<std::byte*>(peer.channelState.device) +
+            completionSlotsOffset);
+  const uint32_t pipelineDepth =
+      static_cast<uint32_t>(channelLayout.pipelineDepth);
   for (int channel = 0; channel < config_.max_num_channels; ++channel) {
-    channels[channel] = makeIbLocalChannel(channelLayout, channel);
+    IbSendCompletionSlot* channelCompletionSlots = pipelineDepth == 0
+        ? nullptr
+        : completionSlots + static_cast<std::size_t>(channel) * pipelineDepth;
+    channels[channel] =
+        makeIbLocalChannel(channelLayout, channel, channelCompletionSlots);
   }
   peer.cmdQueues = std::move(cmdQueues);
   peer.cmdQueuesAllocated = true;

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -63,6 +63,8 @@ inline constexpr uint64_t kIbrcDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
  * ordering. The CPU progress thread consumes descriptors, posts the verbs work
  * requests on the matching QP, and advances ci after polling the CQE. Optional
  * local counters are updated by the CPU proxy after polling that CQE.
+ * Group-scope put() returns a completion ticket in the leader thread; a later
+ * group-scope wait_local() consumes that leader's ticket collectively.
  */
 class P2pIbrcTransportDevice {
  public:
@@ -106,8 +108,8 @@ class P2pIbrcTransportDevice {
   // detail::wait_recv_data_ready), which removes the cross-lane hazard where a
   // fast lane's later chunk masks a slow lane's not-yet-landed data.
 
-  __device__ void put(
-      ThreadGroup& group,
+  __device__ IbLocalCompletionTicket
+  put(ThreadGroup& group,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes,
@@ -119,7 +121,8 @@ class P2pIbrcTransportDevice {
         (signalId >= 0) ? remote_signal_slot(signalId) : IbgdaRemoteBuffer{};
     IbgdaLocalBuffer ctrSlot =
         (counterId >= 0) ? counter_host_slot(counterId) : IbgdaLocalBuffer{};
-    put(group,
+    return put(
+        group,
         localBuf,
         remoteBuf,
         nbytes,
@@ -129,8 +132,8 @@ class P2pIbrcTransportDevice {
         counterVal);
   }
 
-  __device__ void put(
-      const IbgdaLocalBuffer& localBuf,
+  __device__ IbLocalCompletionTicket
+  put(const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes,
       int signalId = -1,
@@ -138,7 +141,8 @@ class P2pIbrcTransportDevice {
       int counterId = -1,
       uint64_t counterVal = 1) {
     ThreadGroup solo = make_thread_solo();
-    put(solo,
+    return put(
+        solo,
         localBuf,
         remoteBuf,
         nbytes,
@@ -270,8 +274,8 @@ class P2pIbrcTransportDevice {
     signal(solo, signalBuf, signalVal, direction);
   }
 
-  __device__ void put(
-      ThreadGroup& group,
+  __device__ IbLocalCompletionTicket
+  put(ThreadGroup& group,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes,
@@ -291,6 +295,7 @@ class P2pIbrcTransportDevice {
     }
     group.sync();
 
+    IbLocalCompletionTicket completion;
     if (group.is_leader()) {
       validate_group_scope(group);
       const uint32_t queueId = select_put_queue_id(group, IbDirection::Send);
@@ -335,13 +340,18 @@ class P2pIbrcTransportDevice {
         desc.flags |= IBRC_HAS_COUNTER;
       }
 
-      enqueue(queueId, desc);
+      const uint64_t seq = enqueue(queueId, desc);
+      completion = IbLocalCompletionTicket{
+          .completionId = laneOrdinal,
+          .value = seq + 1,
+      };
     }
     group.sync();
+    return completion;
   }
 
-  __device__ void put(
-      const IbgdaLocalBuffer& localBuf,
+  __device__ IbLocalCompletionTicket
+  put(const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes,
       const IbgdaRemoteBuffer& signalBuf,
@@ -349,7 +359,8 @@ class P2pIbrcTransportDevice {
       const IbgdaLocalBuffer& counterBuf = {},
       uint64_t counterVal = 1) {
     ThreadGroup solo = make_thread_solo();
-    put(solo,
+    return put(
+        solo,
         localBuf,
         remoteBuf,
         nbytes,
@@ -357,6 +368,77 @@ class P2pIbrcTransportDevice {
         signalVal,
         counterBuf,
         counterVal);
+  }
+
+  __device__ void wait_local(
+      ThreadGroup& group,
+      const IbLocalCompletionTicket& ticket,
+      const Timeout& timeout = Timeout()) const {
+    if (group.is_leader()) {
+      const auto& queue = cmdQueues[queue_for_lane(
+          group.group_id, IbDirection::Send, ticket.completionId)];
+      while (static_cast<int64_t>(
+                 load_acquire_system_u64(queue.ci) - ticket.value) < 0) {
+        check_status(queue);
+        if (timeout.checkExpired()) {
+          printf(
+              "P2pIbrcTransportDevice: wait_local timed out lane=%u "
+              "expected=%llu\n",
+              ticket.completionId,
+              static_cast<unsigned long long>(ticket.value));
+          PIPES_DEVICE_TRAP();
+        }
+      }
+    }
+    group.sync();
+  }
+
+  __device__ void prepare_send_slot(
+      ThreadGroup& group,
+      uint32_t slotId,
+      uint64_t generation,
+      const Timeout& timeout = Timeout()) const {
+    if (group.is_leader()) {
+      auto& slot = localChannels_[group.group_id].sendCompletionSlots[slotId];
+      if (slot.generation != generation) {
+        const uint64_t laneMask = slot.laneMask;
+        const uint32_t lanes = num_qp_lanes();
+        for (uint32_t lane = 0; lane < lanes; ++lane) {
+          if ((laneMask & (1ULL << lane)) == 0) {
+            continue;
+          }
+          const auto& queue = cmdQueues[queue_for_lane(
+              group.group_id, IbDirection::Send, lane)];
+          while (static_cast<int64_t>(
+                     load_acquire_system_u64(queue.ci) - slot.values[lane]) <
+                 0) {
+            check_status(queue);
+            if (timeout.checkExpired()) {
+              printf(
+                  "P2pIbrcTransportDevice: send slot wait timed out lane=%u "
+                  "expected=%llu\n",
+                  lane,
+                  static_cast<unsigned long long>(slot.values[lane]));
+              PIPES_DEVICE_TRAP();
+            }
+          }
+        }
+        slot.laneMask = 0;
+        slot.generation = generation;
+      }
+    }
+    group.sync();
+  }
+
+  __device__ __forceinline__ void record_send_completion(
+      uint32_t channelId,
+      uint32_t slotId,
+      uint64_t generation,
+      const IbLocalCompletionTicket& ticket) const {
+    auto& slot = localChannels_[channelId].sendCompletionSlots[slotId];
+    slot.generation = generation;
+    slot.values[ticket.completionId] = ticket.value;
+    slot.laneMask |= 1ULL << ticket.completionId;
   }
 
   __device__ void put_cooperative(
@@ -775,15 +857,15 @@ class P2pIbrcTransportDevice {
     return seq;
   }
 
-  __device__ __forceinline__ void enqueue(
-      uint32_t queueId,
-      const IbrcDesc& desc) const {
+  __device__ __forceinline__ uint64_t
+  enqueue(uint32_t queueId, const IbrcDesc& desc) const {
     IbrcCmdQueueDevice& queue = cmdQueues[queueId];
     check_status(queue);
     const uint64_t seq = reserve(queue);
     IbrcDesc& slot = queue.descs[seq & queue.mask];
     slot = desc;
     store_release_system_u64(&slot.ready_seq, seq);
+    return seq;
   }
 
   __device__ __forceinline__ void check_status(


### PR DESCRIPTION
Summary:

## Overview

Replace counter polling for blocking IB send/forward staging reuse with an explicit local-completion ticket returned by `put()` and consumed by `wait_local()`.

Each `put()` returns a compact backend-neutral `{completionId, value}` ticket. Blocking send/forward merge those tickets into transport-owned state for the active channel slot and wait the prior slot generation before overwriting local send staging. This preserves correctness when `max_signal_bytes` splits one slot across multiple puts and QP lanes without copying a 64-lane aggregate through the hot path.

## Backend behavior

| Backend | Per-put ticket | Local completion wait |
| --- | --- | --- |
| IBGDA | Data WQE ticket and QP lane | Poll the corresponding GPU verbs CQ ticket |
| IBRC | Command sequence and QP queue | Wait for wrap-safe CPU-proxy `ci` retirement after CQE polling |

The per-slot lane mask and completion values remain transport internals. Slot storage is allocated from the runtime `pipelineDepth` for both eager and lazy IBGDA construction and from IBRC's existing mapped channel allocation.

Generic callers may ignore the returned ticket and continue using the optional counter buffer or `flush()`.

## Blocking sendrecv changes

- Blocking `send()` and `forward()` prepare the current staging slot, call the existing generic `put()`, and record its compact ticket.
- A slot generation accumulates the latest ticket for every lane used by all of its `max_signal_bytes` chunks.
- Slot reuse waits the prior generation's complete per-lane frontier before copying new payload into staging.
- Preserve the per-lane `DATA_READY` signaling and receiver lane cursor from `D112057265`.

## Scope

This diff intentionally covers **blocking sendrecv only**. The resumable/nonblocking progress APIs retain their counter-based completion path and will be supported separately in follow-up diffs. Until then, callers must not mix blocking and progress sends on the same channel.

## Performance

After rebasing onto fresh master, the 1-byte blocking unidirectional benchmark improved from `17.41-17.46 us` to `16.37-16.96 us` across repeated final runs, a **2.6-6.2% latency reduction**.

CUDA resource inspection also shows lower blocking-kernel stack usage, unchanged registers/local/shared memory, and removal of the prior 520-byte aggregate-ticket copy.

Reviewed By: saifhhasan

Differential Revision: D112689007
