### PR TITLE
Add MCCL backend wrapper example (EasyCLA duplicate)

### DIFF
--- a/comms/torchcomms/ncclx/examples/AllGatherPBackendWrapper.py
+++ b/comms/torchcomms/ncclx/examples/AllGatherPBackendWrapper.py
@@ -59,12 +59,6 @@ def main() -> None:
     torch.cuda.set_device(local_rank)
     device = torch.device("cuda", local_rank)
 
-    # TorchComms constructs the backend below; c10d only needs the custom
-    # backend type so the CUDA NCCLX backend can be the default PG backend.
-    dist.Backend.backend_type_map.setdefault(
-        "ncclx",
-        dist.ProcessGroup.BackendType.CUSTOM,
-    )
     dist_config.use_torchcomms = True
     dist.init_process_group(
         backend="cuda:ncclx",


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/190798

This is an intentional duplicate of D111994473 to test whether the EasyCLA / github-export behavior changed after Linux Foundation and PyTorch contributor registration updates. Original diff: https://www.internalfb.com/diff/D111994473. Prefer the original diff for normal review/landing unless we explicitly decide to switch to this duplicate.

D111755956 proved the PTD -> TorchComms NCCLX path, but the example had to mutate c10d internals with dist.Backend.backend_type_map.setdefault("ncclx", CUSTOM) before calling dist.init_process_group(backend="cuda:ncclx"). That made the example work, but it pushed c10d bookkeeping onto every user of an otherwise valid TorchComms backend string.

Keep that policy in c10d instead: unknown device-qualified TorchComms backends are treated as CUSTOM when c10d selects the process-group default backend type. This lets backend="cuda:mccl" and backend="cuda:ncclx" initialize through PTD without mutating dist.Backend.backend_type_map in user code.

Refactor the default-backend type decision into a small helper near the backend-string parsing helpers and cover it in test_c10d_torchcomms with a synthetic backend name: TorchComms enabled maps the unknown device-qualified backend to CUSTOM, while TorchComms disabled keeps the existing GLOO fallback.

Remove the old NCCLX AllGatherP example-side backend_type_map workaround now that c10d owns the policy.

Add small straight-line MCCL examples that call dist.init_process_group(backend="cuda:mccl"), verify the PTD backend implementation is a TorchComms _BackendWrapper, and verify the underlying TorchComm backend is mccl / TorchCommMCCL. One example checks ordinary allreduce. The new AllGatherP example allocates through the MCCL TorchComms allocator, calls comm.all_gather_p_init/exec/free through wrapper.get_comm(), and verifies gathered rank chunks.

The multi-backend new_group case is intentionally left for a follow-up diff.

Differential Revision: D113287019


