### PR TITLE
[ctran][util] Extract cuMem segment enumeration into DevMemType

### DIFF
--- a/comms/ctran/utils/CtranIpc.cc
+++ b/comms/ctran/utils/CtranIpc.cc
@@ -302,25 +302,23 @@ inline commResult_t ctran::utils::CtranIpcMem::tryLoadCuMem(
   //   the allocation's handle type. Used in LOAD mode to validate that
   //   user-provided memory can be exported.
 
-  // temp linear loop through physical allocations, could be faster to get
-  // from pytorch level
-  size_t cur_offset = 0;
-  while (cur_offset < len) {
-    const void* cur_ptr = (char*)ptr + cur_offset;
-    allocHandles_.emplace_back();
+  // Enumerate the physical cuMem segments backing [ptr, ptr+len). The shared
+  // helper retains one allocation handle per segment; take ownership of every
+  // handle into allocHandles_ up front (even on a partial failure) so
+  // freeCuMem() releases them all -- including when the IPC-export validation
+  // below rejects the buffer partway through.
+  std::vector<CuMemSegment> segs;
+  const commResult_t enumRes = enumerateCuMemSegments(ptr, len, segs);
+  for (const auto& seg : segs) {
+    allocHandles_.push_back(seg.handle);
     sharedHandles_.emplace_back();
     sharedHandlesInitialized_.emplace_back(false);
-    FB_CUCHECK(cuMemRetainAllocationHandle(
-        &allocHandles_.back(), const_cast<void*>(cur_ptr)));
+  }
+  FB_COMMCHECK(enumRes);
 
-    size_t cur_range;
-    CUdeviceptr cur_pbase;
-    FB_CUCHECK(
-        cuMemGetAddressRange(&cur_pbase, &cur_range, (CUdeviceptr)cur_ptr));
-
+  for (size_t i = 0; i < segs.size(); ++i) {
     CUmemAllocationProp prop;
-    FB_CUCHECK(
-        cuMemGetAllocationPropertiesFromHandle(&prop, allocHandles_.back()));
+    FB_CUCHECK(cuMemGetAllocationPropertiesFromHandle(&prop, segs[i].handle));
 
     // Set cuMemHandleType_ from first segment's allocation properties
     if (cuMemHandleType_ == CU_MEM_HANDLE_TYPE_NONE) {
@@ -348,8 +346,8 @@ inline commResult_t ctran::utils::CtranIpcMem::tryLoadCuMem(
           "has unsupported allocation properties for IPC export: "
           "handleType = {} ({}), supportedExportType = {} ({}), gpuDirectRDMACapable = {}, "
           "segmentHandleType = {} ({})",
-          cur_pbase,
-          cur_range,
+          segs[i].base,
+          segs[i].size,
           (void*)ptr,
           len,
           cuMemHandleTypeStr(cuMemHandleType_),
@@ -362,14 +360,11 @@ inline commResult_t ctran::utils::CtranIpcMem::tryLoadCuMem(
       return commInvalidUsage;
     }
 
-    if (cur_offset == 0) {
-      pbase_ = cur_pbase;
+    if (i == 0) {
+      pbase_ = segs[i].base;
     }
-    segmentRanges_.emplace_back(cur_range);
-    range_ += cur_range;
-
-    CUdeviceptr cur_end = ctran::utils::addDevicePtr(cur_pbase, cur_range);
-    cur_offset = (size_t)ctran::utils::subDevicePtr(cur_end, ptr);
+    segmentRanges_.emplace_back(segs[i].size);
+    range_ += segs[i].size;
   }
   supported = true;
   return commSuccess;

--- a/comms/ctran/utils/DevMemType.cc
+++ b/comms/ctran/utils/DevMemType.cc
@@ -111,3 +111,31 @@ commResult_t getCudaDevFromPtr(const void* addr, int& cudaDev) {
 
   return commSuccess;
 }
+
+commResult_t enumerateCuMemSegments(
+    const void* addr,
+    size_t len,
+    std::vector<CuMemSegment>& segments) {
+  if (addr == nullptr) {
+    return commInvalidUsage;
+  }
+
+  // temp linear loop through physical allocations, could be faster to get
+  // from pytorch level
+  size_t cur_offset = 0;
+  while (cur_offset < len) {
+    const void* cur_ptr = (const char*)addr + cur_offset;
+    CuMemSegment seg;
+    FB_CUCHECK(
+        cuMemRetainAllocationHandle(&seg.handle, const_cast<void*>(cur_ptr)));
+    // Record even if the range query below fails so the caller can release it.
+    segments.push_back(seg);
+    FB_CUCHECK(cuMemGetAddressRange(
+        &segments.back().base, &segments.back().size, (CUdeviceptr)cur_ptr));
+
+    CUdeviceptr cur_end =
+        ctran::utils::addDevicePtr(segments.back().base, segments.back().size);
+    cur_offset = (size_t)ctran::utils::subDevicePtr(cur_end, addr);
+  }
+  return commSuccess;
+}

--- a/comms/ctran/utils/DevMemType.h
+++ b/comms/ctran/utils/DevMemType.h
@@ -4,6 +4,8 @@
 
 #include <cuda.h>
 
+#include <vector>
+
 #include "comms/utils/commSpecs.h"
 
 enum DevMemType {
@@ -64,3 +66,47 @@ getDevMemType(const void* addr, const int cudaDev, DevMemType& memType);
  */
 __attribute__((visibility("default"))) commResult_t
 getCudaDevFromPtr(const void* addr, int& cudaDev);
+
+/**
+ * One physical VMM (cuMem) segment backing a virtual address range.
+ *
+ * `handle` is retained (cuMemRetainAllocationHandle) and OWNED BY THE CALLER --
+ * each must be paired with a cuMemRelease. `base`/`size` are the segment's full
+ * physical extent (from cuMemGetAddressRange), which may extend past the
+ * queried range's end for the last segment.
+ */
+struct CuMemSegment {
+  CUmemGenericAllocationHandle handle{};
+  CUdeviceptr base{};
+  size_t size{};
+};
+
+/**
+ * Enumerates the physical VMM (cuMem) segments backing the virtual address
+ * range [addr, addr + len). A range allocated by cuMem APIs may be stitched
+ * together from several physical allocations; this walks them in address order.
+ *
+ * For each segment it retains the allocation handle
+ * (cuMemRetainAllocationHandle) and records the segment's base + full physical
+ * extent (cuMemGetAddressRange), then advances to the next segment boundary.
+ *
+ * The retained handles are OWNED BY THE CALLER: every returned
+ * CuMemSegment::handle must be released with cuMemRelease. On error, any
+ * handles retained before the failure are still returned in `segments` (so the
+ * caller can release them); the caller should treat a non-success return as
+ * fatal for the range and release whatever was collected.
+ *
+ * `addr` must be cuMem-allocated memory (see getDevMemType == kCumem);
+ * behavior on other memory types is that of cuMemRetainAllocationHandle.
+ *
+ * @param addr Start of the range. Must not be nullptr.
+ * @param len  Length of the range in bytes.
+ * @param segments Output; appended to (not cleared). One entry per segment.
+ * @return commSuccess on success
+ *         commInvalidUsage if addr is nullptr
+ *         a CUDA error result if a driver call fails
+ */
+__attribute__((visibility("default"))) commResult_t enumerateCuMemSegments(
+    const void* addr,
+    size_t len,
+    std::vector<CuMemSegment>& segments);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3241
* #3240
* __->__ #3239

`CtranIpcMem::tryLoadCuMem` walks the physical VMM (cuMem) segments backing a
registered buffer -- retaining each allocation handle and reading its extent --
inline, entangled with the IPC-export validation. The upcoming standalone
`CtranMulticast` needs the same walk (to `cuMulticastBindMem` each segment), so
extract just the walk into a reusable helper rather than duplicating it.

Adds `enumerateCuMemSegments(addr, len, segments)` to `DevMemType.{h,cc}`: given
a virtual range, it enumerates the backing physical segments in address order,
retaining one `CUmemGenericAllocationHandle` per segment (each OWNED BY THE
CALLER -- must be paired with `cuMemRelease`) and recording each segment's base +
full physical extent. The IPC-specific validation (handle-type /
`gpuDirectRDMACapable` / mixed-type checks) stays in `tryLoadCuMem`.

`tryLoadCuMem` now calls the helper, then validates. It takes ownership of every
retained handle into `allocHandles_` up front (before validating), so
`freeCuMem()` releases them all even when validation rejects the buffer partway
through -- preserving the existing leak-free-on-error behavior. Pure refactor, no
behavior change for callers.

Differential Revision: [D112947488](https://our.internmc.facebook.com/intern/diff/D112947488/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D112947488/)!