### PR TITLE
[ctran][util] NVL multicast setup helper + registration-owned overlay storage

### DIFF
--- a/comms/ctran/utils/CtranIpc.cc
+++ b/comms/ctran/utils/CtranIpc.cc
@@ -85,6 +85,55 @@ static inline CUmemAllocationHandleType getCuMemExportHandleType(
   return exportHandleType;
 }
 
+// Export/import of a single VMM allocation handle -- FABRIC (the multicast
+// object, or MNNVL buffers) or POSIX-fd -- selected by isFabric. Shared by the
+// regular per-segment registration and the multicast rendezvous. Defined
+// unqualified inside the file's `namespace ctran::utils` (opened at the top).
+commResult_t exportShareableHandle(
+    CUmemGenericAllocationHandle handle,
+    CtranIpcHandle& out,
+    bool isFabric) {
+  if (isFabric) {
+#if CUDART_VERSION >= 12040
+    FB_CUCHECK(cuMemExportToShareableHandle(
+        &out.handle, handle, CU_MEM_HANDLE_TYPE_FABRIC, 0));
+    return commSuccess;
+#else
+    (void)handle;
+    (void)out;
+    FB_ERRORRETURN(
+        commInternalError, "CTRAN-IPC: fabric export requires CUDA 12.4+");
+#endif
+  }
+  FB_CUCHECK(cuMemExportToShareableHandle(
+      &out.fd, handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0));
+  return commSuccess;
+}
+
+commResult_t importShareableHandle(
+    const CtranIpcHandle& in,
+    CUmemGenericAllocationHandle& out,
+    bool isFabric) {
+  CtranIpcHandle tmp = in;
+  if (isFabric) {
+#if CUDART_VERSION >= 12040
+    FB_CUCHECK(cuMemImportFromShareableHandle(
+        &out, (void*)&tmp.handle, CU_MEM_HANDLE_TYPE_FABRIC));
+    return commSuccess;
+#else
+    (void)in;
+    (void)out;
+    FB_ERRORRETURN(
+        commInternalError, "CTRAN-IPC: fabric import requires CUDA 12.4+");
+#endif
+  }
+  FB_CUCHECK(cuMemImportFromShareableHandle(
+      &out,
+      reinterpret_cast<void*>(tmp.fd),
+      CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR));
+  return commSuccess;
+}
+
 commResult_t ctran::utils::CtranIpcMem::ipcExport(CtranIpcDesc& ipcDesc) {
   std::vector<CtranIpcSegDesc> extraSegments;
   FB_COMMCHECK(ipcExport(ipcDesc, extraSegments));
@@ -110,19 +159,8 @@ inline commResult_t ctran::utils::CtranIpcMem::exportSegmentSharedHandle(
 #if CUDART_VERSION >= 12040
     isCumemFabric = (exportHandleType == CU_MEM_HANDLE_TYPE_FABRIC);
 #endif
-    if (isCumemFabric) {
-      FB_CUCHECK(cuMemExportToShareableHandle(
-          &sharedHandles_[segIdx].handle,
-          allocHandles_[segIdx],
-          exportHandleType,
-          0));
-    } else {
-      FB_CUCHECK(cuMemExportToShareableHandle(
-          &sharedHandles_[segIdx].fd,
-          allocHandles_[segIdx],
-          CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR,
-          0));
-    }
+    FB_COMMCHECK(exportShareableHandle(
+        allocHandles_[segIdx], sharedHandles_[segIdx], isCumemFabric));
   } else if (memType_ == DevMemType::kCudaMalloc) {
     void* p = (void*)pbase_;
     FB_CUDACHECK(cudaIpcGetMemHandle(&sharedHandles_[segIdx].cudaIpcHandle, p));
@@ -423,6 +461,13 @@ commResult_t ctran::utils::CtranIpcMem::free() {
 }
 
 inline commResult_t CtranIpcMem::freeCuMem() {
+  // Release any multicast object first. It retains its OWN segment handles, so
+  // this ordering is not required for correctness (and its cuMulticastUnbind RM
+  // errors are ignored regardless, see ~CtranMulticast) -- we reset here so the
+  // object is torn down promptly on dereg rather than lingering to the implicit
+  // dtor.
+  mcOverlay_.reset();
+
   for (int i = 0; i < allocHandles_.size(); i++) {
     if (mode_ == CtranIpcMem::Mode::LOAD) {
       // An explicit release is required in case of CtranIpcMem::Mode::LOAD
@@ -543,14 +588,12 @@ commResult_t CtranIpcRemMem::importCuMem(const CtranIpcDesc& ipcDesc) {
           ipcDesc.pid,
           remHandles_[i].fd,
           reinterpret_cast<int*>(&importedHandle.fd)));
-      FB_CUCHECK(cuMemImportFromShareableHandle(
-          &allocHandles_[i],
-          reinterpret_cast<void*>(importedHandle.fd),
-          cuMemHandleType_));
+      FB_COMMCHECK(importShareableHandle(
+          importedHandle, allocHandles_[i], /*isFabric=*/false));
 #if CUDART_VERSION >= 12040
     } else if (cuMemHandleType_ == CU_MEM_HANDLE_TYPE_FABRIC) {
-      FB_CUCHECK(cuMemImportFromShareableHandle(
-          &allocHandles_[i], (void*)&importedHandle.handle, cuMemHandleType_));
+      FB_COMMCHECK(importShareableHandle(
+          importedHandle, allocHandles_[i], /*isFabric=*/true));
 #endif
     } else {
       FB_ERRORRETURN(

--- a/comms/ctran/utils/CtranIpc.h
+++ b/comms/ctran/utils/CtranIpc.h
@@ -4,9 +4,12 @@
 #define CTRAN_IPC_H_
 
 #include <algorithm>
+#include <memory>
 #include <sstream>
+#include <utility>
 #include <vector>
 
+#include "comms/ctran/utils/CtranMulticast.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/utils/DevMemType.h"
 #include "comms/utils/commSpecs.h"
@@ -210,6 +213,30 @@ class CtranIpcMem {
     return range_;
   }
 
+  // Whether this registration is backed by cuMem/VMM allocations -- a
+  // precondition for binding the buffer into a CUDA multicast object. False for
+  // cudaMalloc / not-yet-loaded.
+  inline bool isCuMemBacked() const {
+    return memType_ == DevMemType::kCumem;
+  }
+
+  // Optional standalone multicast object covering this buffer. Set up during
+  // the NVL registration rendezvous (CtranMapper::setupMulticastOverlay) when
+  // multicast is requested and the NVL group supports it; null otherwise. The
+  // CtranMulticast is fully self-owning -- it retains its own segment handles
+  // via import() -- so it is held here only to tie its lifetime to the
+  // registration's; teardown order relative to this CtranIpcMem's own segment
+  // handles does not matter.
+  inline bool hasMulticast() const {
+    return mcOverlay_ != nullptr;
+  }
+  inline void* getMulticastPtr() const {
+    return mcOverlay_ ? mcOverlay_->getMulticastPtr() : nullptr;
+  }
+  inline void setMulticastOverlay(std::shared_ptr<CtranMulticast> overlay) {
+    mcOverlay_ = std::move(overlay);
+  }
+
   inline const char* getDesc() {
     return desc_;
   }
@@ -268,6 +295,14 @@ class CtranIpcMem {
   // Type of the memory  to be used for importing and exporting.
   DevMemType memType_{DevMemType::kCudaMalloc};
   CUmemAllocationHandleType cuMemHandleType_{CU_MEM_HANDLE_TYPE_NONE};
+
+  // Optional standalone multicast object covering this buffer (see accessors
+  // above). shared_ptr (not unique_ptr) so CtranIpcMem stays movable/copyable
+  // for folly::Synchronized's construction (an empty temp is moved in at
+  // registration; the object is only ever attached later, in-place). Because
+  // the CtranMulticast retains its own segment handles (import()), its
+  // destruction order relative to allocHandles_ is irrelevant.
+  std::shared_ptr<CtranMulticast> mcOverlay_;
 };
 
 class CtranIpcRemMem {
@@ -359,6 +394,23 @@ class CtranIpcRemMem {
   const DevMemType memType_{DevMemType::kHostUnregistered};
   const CUmemAllocationHandleType cuMemHandleType_{CU_MEM_HANDLE_TYPE_NONE};
 };
+
+// Export/import a single cuMem (VMM) allocation handle to/from a shareable
+// handle: FABRIC (`isFabric=true` -- the multicast object, or MNNVL buffers) or
+// POSIX file descriptor (`isFabric=false`). Shared by the regular per-segment
+// buffer registration (CtranIpcMem) and the multicast rendezvous in
+// CtranMapper::allGatherCtrlImpl, which moves the object handle over the same
+// control channel as the buffer handles. For fabric, `out.handle` carries the
+// fabric bytes; for posix-fd, `out.fd`/`in.fd` carries the descriptor (the
+// caller owns the pidfd import/close dance around the fd itself).
+commResult_t exportShareableHandle(
+    CUmemGenericAllocationHandle handle,
+    CtranIpcHandle& out,
+    bool isFabric);
+commResult_t importShareableHandle(
+    const CtranIpcHandle& in,
+    CUmemGenericAllocationHandle& out,
+    bool isFabric);
 
 // Return the number of active IPC memory objects and IPC remote memory objects.
 // Used to check resource leak in UT.

--- a/comms/ctran/utils/CtranMulticast.cc
+++ b/comms/ctran/utils/CtranMulticast.cc
@@ -1,0 +1,226 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and
+// proprietary.
+
+#include "comms/ctran/utils/CtranMulticast.h"
+
+#include "comms/ctran/utils/Checks.h" // FB_COMMCHECK
+#include "comms/ctran/utils/CudaWrap.h"
+#include "comms/utils/logger/LogUtils.h"
+
+namespace ctran::utils {
+
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12010
+
+CtranMulticast::CtranMulticast(int nvlLocalRank, int nLocalRanks, int cudaDev)
+    : nvlLocalRank_(nvlLocalRank),
+      nLocalRanks_(nLocalRanks),
+      cudaDev_(cudaDev) {}
+
+CtranMulticast::~CtranMulticast() {
+  // Safe teardown: cuMulticastUnbind can return an RM error if the backing
+  // buffer was already freed by the user (see NCCL's "safe to ignore" note);
+  // ignore all teardown errors so a partially-created or user-freed overlay
+  // never aborts. Order (unmap -> unbind -> release) is a belt; correctness
+  // rests on ignoring the unbind error.
+  if (mcVA_ != 0) {
+    FB_CUCHECKIGNORE(cuMemUnmap(mcVA_, mcSize_));
+    FB_CUCHECKIGNORE(cuMemAddressFree(mcVA_, mcSize_));
+  }
+  for (const auto& b : bound_) {
+    FB_CUCHECKIGNORE(cuMulticastUnbind(mcHandle_, cuDev_, b.offset, b.size));
+  }
+  if (mcHandle_ != 0) {
+    FB_CUCHECKIGNORE(cuMemRelease(mcHandle_));
+  }
+  // Release our own retained segment handles (from import()). Because these are
+  // this object's own references, teardown order relative to any other owner of
+  // the same backing allocation does not matter.
+  for (const auto& seg : segments_) {
+    FB_CUCHECKIGNORE(cuMemRelease(seg.handle));
+  }
+}
+
+bool CtranMulticast::isSupported(int cudaDev) {
+  // Memoized: driver PFN presence + the device multicast attribute are
+  // invariant for a rank's device, so query once and log the unsupported
+  // reason at most once (one device per rank in practice, so a function-local
+  // static is effectively once-per-device-per-rank).
+  static const bool supported = [cudaDev]() -> bool {
+    // Driver-version gate: the multicast entry points are loaded (non-null).
+    if (FB_CUPFN(cuMulticastCreate) == nullptr ||
+        FB_CUPFN(cuMulticastAddDevice) == nullptr ||
+        FB_CUPFN(cuMulticastBindMem) == nullptr ||
+        FB_CUPFN(cuMulticastGetGranularity) == nullptr ||
+        FB_CUPFN(cuMulticastUnbind) == nullptr) {
+      CLOGF(
+          WARN,
+          "CTRAN-MC: multicast disabled -- driver multicast entry points unavailable (needs a newer CUDA driver)");
+      return false;
+    }
+    // HW gate: the device reports multicast support. No arch conditional.
+    CUdevice cuDev = 0;
+    FB_CUCHECK_RETURN(cuDeviceGet(&cuDev, cudaDev), false);
+    int sup = 0;
+    FB_CUCHECK_RETURN(
+        cuDeviceGetAttribute(
+            &sup, CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, cuDev),
+        false);
+    if (sup == 0) {
+      CLOGF(
+          WARN,
+          "CTRAN-MC: multicast disabled -- device {} reports no multicast support",
+          cudaDev);
+    }
+    return sup != 0;
+  }();
+  return supported;
+}
+
+commResult_t
+CtranMulticast::granularity(int cudaDev, int nLocalRanks, size_t& gran) {
+  (void)cudaDev;
+  CUmulticastObjectProp prop = {};
+  prop.numDevices = static_cast<unsigned int>(nLocalRanks);
+  prop.size = 0;
+  prop.handleTypes = 0;
+  prop.flags = 0;
+  // MINIMUM is the actual bind/map alignment requirement. (RECOMMENDED is a
+  // padding hint for allocation sizing -- e.g. ncclMemAlloc under
+  // NCCL_MEM_ENABLE_MC_ALIGNMENT -- and is irrelevant here: binding/mapping an
+  // already-allocated buffer succeeds as long as its segments meet MINIMUM.)
+  FB_CUCHECK(cuMulticastGetGranularity(
+      &gran, &prop, CU_MULTICAST_GRANULARITY_MINIMUM));
+  return commSuccess;
+}
+
+commResult_t CtranMulticast::createRoot(
+    size_t mcSize,
+    CUmemAllocationHandleType handleType,
+    CUmemGenericAllocationHandle& outHandle) {
+  CUmulticastObjectProp prop = {};
+  prop.numDevices = static_cast<unsigned int>(nLocalRanks_);
+  prop.size = mcSize;
+  prop.handleTypes = handleType;
+  prop.flags = 0;
+  FB_CUCHECK(cuMulticastCreate(&mcHandle_, &prop));
+  mcSize_ = mcSize;
+  outHandle = mcHandle_;
+  return commSuccess;
+}
+
+void CtranMulticast::adoptImported(CUmemGenericAllocationHandle handle) {
+  // Single-use: an instance is either the root (createRoot) or a non-root
+  // (adoptImported), each exactly once. Release any handle we already hold
+  // before overwriting so a misuse (double-adopt, or adopt after createRoot)
+  // cannot silently drop -- and leak -- the previously-held multicast object.
+  if (mcHandle_ != 0) {
+    FB_CUCHECKIGNORE(cuMemRelease(mcHandle_));
+  }
+  mcHandle_ = handle;
+}
+
+commResult_t CtranMulticast::import(const void* dptr, size_t len) {
+  // Single-use: one instance imports exactly one buffer's segments (like
+  // createRoot/adoptImported). Re-importing would silently drop the prior
+  // import's segments, so reject it as an explicit misuse.
+  if (!segments_.empty()) {
+    return commInvalidUsage;
+  }
+  // enumerateCuMemSegments retains one allocation handle per segment; segments_
+  // now owns them and the dtor releases each (even on a partial failure here,
+  // since any handles retained before the error are left in segments_).
+  FB_COMMCHECK(enumerateCuMemSegments(dptr, len, segments_));
+  if (segments_.empty()) {
+    // Zero-length or non-cuMem-backed buffer: nothing to bind into a multicast
+    // object.
+    return commInvalidUsage;
+  }
+  totalSize_ = 0;
+  for (const auto& seg : segments_) {
+    totalSize_ += seg.size;
+  }
+  return commSuccess;
+}
+
+bool CtranMulticast::segmentsAlignedTo(size_t gran) const {
+  if (gran == 0) {
+    return false;
+  }
+  for (const auto& seg : segments_) {
+    if ((seg.size % gran) != 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+commResult_t CtranMulticast::addDeviceAndBind() {
+  FB_CUCHECK(cuDeviceGet(&cuDev_, cudaDev_));
+  FB_CUCHECK(cuMulticastAddDevice(mcHandle_, cuDev_));
+  size_t offset = 0;
+  for (const auto& seg : segments_) {
+    FB_CUCHECK(cuMulticastBindMem(
+        mcHandle_, offset, seg.handle, /*memOffset=*/0, seg.size, /*flags=*/0));
+    bound_.push_back({offset, seg.size});
+    offset += seg.size;
+  }
+  // Non-root ranks learn the object size from their local segments.
+  if (mcSize_ == 0) {
+    mcSize_ = offset;
+  }
+  return commSuccess;
+}
+
+commResult_t CtranMulticast::mapVA(size_t mcSize, size_t gran) {
+  FB_CUCHECK(cuMemAddressReserve(
+      &mcVA_, mcSize, /*alignment=*/gran, /*addr=*/0, /*flags=*/0));
+  FB_CUCHECK(cuMemMap(mcVA_, mcSize, /*offset=*/0, mcHandle_, /*flags=*/0));
+  CUmemAccessDesc accessDesc = {};
+  accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  accessDesc.location.id = cudaDev_;
+  accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  FB_CUCHECK(cuMemSetAccess(mcVA_, mcSize, &accessDesc, /*count=*/1));
+  mcSize_ = mcSize;
+  return commSuccess;
+}
+
+#else // multicast unsupported at compile time (AMD or CUDA < 12.1)
+
+CtranMulticast::CtranMulticast(int nvlLocalRank, int nLocalRanks, int cudaDev)
+    : nvlLocalRank_(nvlLocalRank),
+      nLocalRanks_(nLocalRanks),
+      cudaDev_(cudaDev) {}
+CtranMulticast::~CtranMulticast() = default;
+bool CtranMulticast::isSupported(int /*cudaDev*/) {
+  return false;
+}
+commResult_t CtranMulticast::granularity(
+    int /*cudaDev*/,
+    int /*nLocalRanks*/,
+    size_t& gran) {
+  gran = 0;
+  return commInternalError;
+}
+commResult_t CtranMulticast::createRoot(
+    size_t /*mcSize*/,
+    CUmemAllocationHandleType /*handleType*/,
+    CUmemGenericAllocationHandle& /*outHandle*/) {
+  return commInternalError;
+}
+void CtranMulticast::adoptImported(CUmemGenericAllocationHandle /*handle*/) {}
+commResult_t CtranMulticast::import(const void* /*dptr*/, size_t /*len*/) {
+  return commInternalError;
+}
+bool CtranMulticast::segmentsAlignedTo(size_t /*gran*/) const {
+  return false;
+}
+commResult_t CtranMulticast::addDeviceAndBind() {
+  return commInternalError;
+}
+commResult_t CtranMulticast::mapVA(size_t /*mcSize*/, size_t /*gran*/) {
+  return commInternalError;
+}
+
+#endif
+
+} // namespace ctran::utils

--- a/comms/ctran/utils/CtranMulticast.h
+++ b/comms/ctran/utils/CtranMulticast.h
@@ -1,0 +1,125 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and
+// proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+// CudaWrap.h pulls in <cuda.h> (or the HIP shims on AMD) so the CU* handle
+// types below resolve on both platforms, and provides the FB_CUPFN wrappers.
+#include "comms/ctran/utils/CudaWrap.h"
+#include "comms/ctran/utils/DevMemType.h" // CuMemSegment, enumerateCuMemSegments
+#include "comms/utils/commSpecs.h"
+
+namespace ctran::utils {
+
+// A standalone NVSwitch multicast object bound over a local buffer's physical
+// backing segments, plus its mapped multicast VA. Self-contained: import()
+// enumerates the buffer's VMM segments and RETAINS ITS OWN allocation handles
+// (via enumerateCuMemSegments), so this object neither depends on nor borrows
+// from CtranIpc -- it owns everything it binds and releases it all at teardown,
+// in any order relative to other owners of the same backing allocation.
+//
+// This class encapsulates ONLY the LOCAL (per-rank) CUDA operations + RAII
+// teardown; the collective exchange of the multicast object handle across the
+// NVL team is driven by the caller (e.g. CtranMapper::setupMulticastOverlay),
+// which uses the CtranIpc export/importShareableHandle helpers to move the
+// handle this class produces (createRoot) / consumes (adoptImported).
+//
+// NOTE: not internally locked; the caller serializes access.
+class CtranMulticast {
+ public:
+  CtranMulticast(int nvlLocalRank, int nLocalRanks, int cudaDev);
+  ~CtranMulticast();
+
+  CtranMulticast(const CtranMulticast&) = delete;
+  CtranMulticast& operator=(const CtranMulticast&) = delete;
+  CtranMulticast(CtranMulticast&&) = delete;
+  CtranMulticast& operator=(CtranMulticast&&) = delete;
+
+  // Runtime support gate (no arch/compute-capability conditional): the
+  // cuMulticast* driver entry points are present AND the device reports
+  // CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED. Mirrors PyTorch
+  // deviceSupportsMulticast and prims isMultimemSupported.
+  static bool isSupported(int cudaDev);
+
+  // Multicast-object allocation granularity for the device+team; mcSize and
+  // every segment size/offset must be a multiple of it.
+  static commResult_t granularity(int cudaDev, int nLocalRanks, size_t& gran);
+
+  // NVL-team root only: create the multicast object (mcSize bytes, agreed
+  // handle type) and return the raw object handle for the caller to
+  // export+broadcast.
+  commResult_t createRoot(
+      size_t mcSize,
+      CUmemAllocationHandleType handleType,
+      CUmemGenericAllocationHandle& outHandle);
+
+  // Non-root: adopt the object handle the caller imported from the root.
+  void adoptImported(CUmemGenericAllocationHandle handle);
+
+  // Every rank: enumerate the physical VMM segments backing [dptr, dptr+len)
+  // and RETAIN this object's own allocation handle for each (via
+  // enumerateCuMemSegments; each released at teardown). Must be a cuMem/VMM
+  // allocation. Call once before addDeviceAndBind(); importedSize() and
+  // segmentsAlignedTo() are valid afterwards.
+  commResult_t import(const void* dptr, size_t len);
+
+  // Sum of the imported segments' sizes -- the multicast object size this rank
+  // requires (== root's createRoot mcSize for a symmetric team). Valid after
+  // import().
+  size_t importedSize() const {
+    return totalSize_;
+  }
+
+  // True iff every imported segment size is a multiple of gran (a bind
+  // precondition). Valid after import().
+  bool segmentsAlignedTo(size_t gran) const;
+
+  // Every rank: add the local device to the object, then bind each imported
+  // backing segment at its running multicast offset (address order). Requires a
+  // prior import() and createRoot()/adoptImported().
+  commResult_t addDeviceAndBind();
+
+  // Every rank: reserve + map + grant device access to one contiguous
+  // multicast VA spanning mcSize; getMulticastPtr() is valid afterwards.
+  commResult_t mapVA(size_t mcSize, size_t gran);
+
+  // The multicast device VA (nullptr until mapVA succeeds).
+  void* getMulticastPtr() const {
+    return reinterpret_cast<void*>(mcVA_);
+  }
+  size_t getMulticastSize() const {
+    return mcSize_;
+  }
+
+ private:
+  const int nvlLocalRank_{-1};
+  const int nLocalRanks_{0};
+  const int cudaDev_{-1};
+  CUdevice cuDev_{0}; // driver device handle for this cudaDev_
+
+  CUmemGenericAllocationHandle mcHandle_{0}; // the multicast object
+  CUdeviceptr mcVA_{0}; // mapped multicast VA (0 until mapVA)
+  size_t mcSize_{0};
+
+  // Per-segment (offset, size) recorded at bind time so teardown can unbind
+  // each segment. cuMulticastUnbind errors are IGNORED at teardown (the backing
+  // buffer may already be freed by the user), so ordering is a belt not the
+  // guarantee.
+  struct BoundSeg {
+    size_t offset{0};
+    size_t size{0};
+  };
+  std::vector<BoundSeg> bound_;
+
+  // Physical VMM segments backing the local buffer, in address order. Each
+  // allocation handle is RETAINED by this object in import() and released
+  // (cuMemRelease) at teardown -- making the object self-owning. totalSize_ =
+  // sum of the segment sizes.
+  std::vector<CuMemSegment> segments_;
+  size_t totalSize_{0};
+};
+
+} // namespace ctran::utils

--- a/comms/ctran/utils/tests/CtranMulticastDistTest.cc
+++ b/comms/ctran/utils/tests/CtranMulticastDistTest.cc
@@ -1,0 +1,192 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "nccl.h"
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/utils/Alloc.h"
+#include "comms/ctran/utils/CtranIpc.h"
+#include "comms/ctran/utils/CtranMulticast.h"
+#include "comms/ctran/utils/CudaWrap.h"
+#include "comms/testinfra/TestUtils.h"
+#include "comms/utils/commSpecs.h"
+
+// Distributed test for the NVL CE-multicast registration mechanism, driven the
+// way production drives it: one rank per GPU. The root createRoot()s the
+// multicast object and broadcasts its fabric handle over allGatherNvlDomain;
+// every peer importShareableHandle()s + adoptImported()s it; each rank
+// import()s its own buffer -- self-detecting + retaining its own segment
+// handles -- then addDeviceAndBind()s and mapVA()s. A single multicast write
+// from the root must then fan out (via NVSwitch) into every rank's own buffer
+// -- the nvlCeBcast primitive. Requires >= 2 GPUs in one NVL domain with
+// fabric; skipped otherwise.
+
+using ctran::utils::CtranIpcHandle;
+using ctran::utils::CtranIpcMem;
+using ctran::utils::CtranMulticast;
+
+namespace {
+
+size_t roundUp(size_t size, size_t align) {
+  return ((size + align - 1) / align) * align;
+}
+
+} // namespace
+
+class MulticastDistTest : public ctran::CtranDistTestFixture {
+ public:
+  void SetUp() override {
+    setenv("NCCL_CTRAN_ENABLE", "1", 0);
+    ctran::CtranDistTestFixture::SetUp();
+    COMMCHECK_TEST(ctran::utils::commCudaLibraryInit());
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+    comm_ = makeCtranComm();
+  }
+
+  void TearDown() override {
+    comm_.reset();
+    ctran::CtranDistTestFixture::TearDown();
+  }
+
+ protected:
+  std::unique_ptr<CtranComm> comm_;
+  const char* desc_{"MulticastDistTest"};
+
+  // Drive the full create -> export -> allGatherNvlDomain -> import ->
+  // addDeviceAndBind -> mapVA -> broadcast-fanout path over a recvbuff backed
+  // by `numSegments` disjoint physical segments. numSegments>1 exercises
+  // addDeviceAndBind's per-segment running-offset bind and a multicast write
+  // that must fan out across every segment.
+  void runCreateBindBroadcast(int numSegments) {
+    const int rank = comm_->statex_->rank();
+    const int nRanks = comm_->statex_->nRanks();
+    const int lRank = comm_->statex_->localRank();
+    const int nLocalRanks = comm_->statex_->nLocalRanks();
+
+    if (nRanks < 2 || comm_->statex_->nNodes() > 1) {
+      GTEST_SKIP() << "requires >= 2 ranks in a single NVL domain, got nRanks="
+                   << nRanks << " nNodes=" << comm_->statex_->nNodes();
+    }
+    if (!ctran::utils::getCuMemSysSupported() ||
+        !CtranMulticast::isSupported(lRank)) {
+      GTEST_SKIP() << "cuMem + multicast not supported on this device";
+    }
+    if ((ctran::utils::getCuMemAllocHandleType() & CU_MEM_HANDLE_TYPE_FABRIC) ==
+        0) {
+      GTEST_SKIP()
+          << "FABRIC handle type required to share the multicast object";
+    }
+
+    size_t gran = 0;
+    COMMCHECK_TEST(CtranMulticast::granularity(lRank, nLocalRanks, gran));
+    ASSERT_GT(gran, 0u);
+    // Each disjoint segment must be aligned to both cuMem (2MB) and the
+    // multicast granularity.
+    const size_t segSize = roundUp(2 * 1024 * 1024, gran);
+    std::vector<size_t> segSizes(numSegments, segSize);
+    const size_t total = segSize * numSegments;
+
+    // Each rank: a `numSegments`-segment cuMem recvbuff on its own GPU.
+    void* buf = nullptr;
+    std::vector<TestMemSegment> allocSegs;
+    COMMCHECK_TEST(
+        ctran::commMemAllocDisjoint(
+            &buf,
+            segSizes,
+            allocSegs,
+            true,
+            ctran::utils::getCuMemAllocHandleType()));
+    auto ipcMem = std::make_unique<CtranIpcMem>(lRank, desc_);
+    bool supported = false;
+    COMMCHECK_TEST(ipcMem->tryLoad(buf, total, supported, false));
+    ASSERT_TRUE(supported);
+
+    // Root (rank 0) creates the object sized to the summed segments; its fabric
+    // handle is all-gathered so peers import a distinct reference.
+    constexpr int kRoot = 0;
+    auto mc = std::make_shared<CtranMulticast>(lRank, nLocalRanks, lRank);
+    std::vector<CtranIpcHandle> handles(nLocalRanks);
+    std::memset(handles.data(), 0, handles.size() * sizeof(CtranIpcHandle));
+    if (rank == kRoot) {
+      CUmemGenericAllocationHandle rootHandle{};
+      COMMCHECK_TEST(
+          mc->createRoot(total, CU_MEM_HANDLE_TYPE_FABRIC, rootHandle));
+      COMMCHECK_TEST(
+          ctran::utils::exportShareableHandle(
+              rootHandle, handles[lRank], /*isFabric=*/true));
+    }
+    allGatherNvlDomain(comm_.get(), handles);
+    if (rank != kRoot) {
+      CUmemGenericAllocationHandle imported{};
+      COMMCHECK_TEST(
+          ctran::utils::importShareableHandle(
+              handles[kRoot], imported, /*isFabric=*/true));
+      mc->adoptImported(imported);
+    }
+
+    // Each rank imports its own buffer's segments (self-detect + retain its own
+    // handles, independent of ipcMem's registration above), then binds them and
+    // maps the multicast VA. Both are local ops needing no cross-rank barrier.
+    COMMCHECK_TEST(mc->import(buf, total));
+    EXPECT_EQ(mc->importedSize(), total) << "import should enumerate the full "
+                                         << numSegments << "-segment buffer";
+    COMMCHECK_TEST(mc->addDeviceAndBind());
+    COMMCHECK_TEST(mc->mapVA(total, gran));
+    ASSERT_NE(mc->getMulticastPtr(), nullptr);
+    // Every rank must have bound its device before the root broadcasts below:
+    // cuMulticast only fans a write out to devices bound at write time, so a
+    // peer still in addDeviceAndBind would silently miss the pattern.
+    barrierNvlDomain(comm_.get());
+
+    // Root multicasts a pattern across the whole (multi-segment) VA; every rank
+    // must observe it across its entire buffer -- i.e. every bound segment.
+    constexpr uint8_t kPattern = 0x5A;
+    if (rank == kRoot) {
+      CUDACHECK_TEST(cudaMemset(mc->getMulticastPtr(), kPattern, total));
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+    }
+    barrierNvlDomain(comm_.get());
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<uint8_t> observed(total, 0x00);
+    CUDACHECK_TEST(cudaMemcpy(
+        observed.data(), ipcMem->getBase(), total, cudaMemcpyDeviceToHost));
+    const std::vector<uint8_t> expected(total, kPattern);
+    EXPECT_EQ(observed, expected)
+        << "rank " << rank << " missed the multicast broadcast across "
+        << numSegments << " segment(s)";
+
+    // Tear the overlay down before freeing its backing.
+    barrierNvlDomain(comm_.get());
+    mc.reset();
+    ipcMem.reset();
+    ctran::commMemFreeDisjoint(buf, segSizes);
+  }
+};
+
+TEST_F(MulticastDistTest, CreateBindBroadcast) {
+  runCreateBindBroadcast(/*numSegments=*/1);
+}
+
+// Multi-segment: a recvbuff backed by 2 disjoint physical segments exercises
+// addDeviceAndBind's per-segment running-offset bind, and the broadcast must
+// fan out across both segments.
+TEST_F(MulticastDistTest, CreateBindBroadcastMultiSegment) {
+  runCreateBindBroadcast(/*numSegments=*/2);
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new ctran::CtranDistEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ctran/utils/tests/CtranMulticastTest.cc
+++ b/comms/ctran/utils/tests/CtranMulticastTest.cc
@@ -1,0 +1,163 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "comms/ctran/tests/CtranTestUtils.h"
+#include "comms/ctran/utils/Alloc.h"
+#include "comms/ctran/utils/CtranIpc.h"
+#include "comms/ctran/utils/CtranMulticast.h"
+#include "comms/ctran/utils/CudaWrap.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/commSpecs.h"
+
+// Single-process unit tests for the NVL-multicast registration surface: the
+// CtranMulticast support/granularity gates and its self-detecting import()
+// (physical VMM segment enumeration + retention of its own handles), plus the
+// CtranIpcMem cuMem-backed check + overlay accessors. The full multicast object
+// data-path (create/bind/map + the fabric handle exchange + NVSwitch fan-out)
+// needs a real >=2-GPU NVL group and is covered by the distributed test
+// CtranMulticastDistTest.cc (1 rank/GPU).
+
+using namespace ctran::utils;
+
+class CtranMulticastTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    ncclCvarInit();
+    COMMCHECK_TEST(commCudaLibraryInit());
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+
+  void TearDown() override {}
+
+ protected:
+  const char* desc_ = "CtranMulticastTest";
+};
+
+// The unicast (non-cuMem) case: a cudaMalloc-backed buffer has no physical VMM
+// segments, so a multicast object cannot be bound over it. CtranIpcMem reports
+// it is not cuMem-backed, import() fails, and the overlay accessors report "no
+// overlay" (the caller falls back to unicast).
+TEST_F(CtranMulticastTest, CudaMallocBufferCannotImport) {
+  constexpr size_t size = 2 * 1024 * 1024;
+  void* ptr = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&ptr, size));
+
+  auto ipcMem = std::make_unique<CtranIpcMem>(0, desc_);
+  bool supported = false;
+  (void)ipcMem->tryLoad(ptr, size, supported, /*shouldSupportCudaMalloc=*/true);
+
+  EXPECT_FALSE(ipcMem->isCuMemBacked())
+      << "cudaMalloc buffer must not be cuMem-backed for multicast binding";
+  EXPECT_FALSE(ipcMem->hasMulticast());
+  EXPECT_EQ(ipcMem->getMulticastPtr(), nullptr);
+
+  CtranMulticast mc(/*nvlLocalRank=*/0, /*nLocalRanks=*/2, /*cudaDev=*/0);
+  EXPECT_NE(mc.import(ptr, size), commSuccess)
+      << "import must fail on a non-cuMem (cudaMalloc) buffer";
+
+  CUDACHECK_TEST(cudaFree(ptr));
+}
+
+// A cuMem (VMM) buffer can be import()ed into a standalone CtranMulticast,
+// which enumerates and RETAINS ITS OWN handle for each physical segment
+// (released in the dtor at scope exit). importedSize() must cover the whole
+// allocation (what addDeviceAndBind would bind).
+TEST_F(CtranMulticastTest, CuMemBufferImportCoversAllocation) {
+  if (!getCuMemSysSupported()) {
+    GTEST_SKIP() << "cuMem (VMM) not supported on this device";
+  }
+  const CUmemAllocationHandleType htype = getCuMemAllocHandleType();
+  if (htype == CU_MEM_HANDLE_TYPE_NONE) {
+    GTEST_SKIP() << "no shareable cuMem handle type on this system";
+  }
+
+  constexpr size_t size = 2 * 1024 * 1024;
+  std::vector<size_t> segmentSizes = {size};
+  std::vector<TestMemSegment> segments;
+  void* ptr = nullptr;
+  auto allocRes =
+      ctran::commMemAllocDisjoint(&ptr, segmentSizes, segments, true, htype);
+  if (allocRes != commSuccess || ptr == nullptr) {
+    GTEST_SKIP() << "failed to allocate cuMem buffer";
+  }
+
+  {
+    CtranMulticast mc(/*nvlLocalRank=*/0, /*nLocalRanks=*/2, /*cudaDev=*/0);
+    COMMCHECK_TEST(mc.import(ptr, size));
+    EXPECT_GE(mc.importedSize(), size)
+        << "imported segments must cover the whole allocation";
+  } // mc dtor releases its own retained segment handles here
+
+  ctran::commMemFreeDisjoint(ptr, segmentSizes);
+}
+
+// Multi-segment coverage (the rework's capability over the old single-segment
+// limit): importing a cuMem buffer backed by multiple physical VMM segments
+// enumerates + retains all of them, so importedSize() covers the whole
+// allocation (addDeviceAndBind binds each at running offsets).
+TEST_F(CtranMulticastTest, CuMemMultiSegmentImportCoversAllocation) {
+  if (!getCuMemSysSupported()) {
+    GTEST_SKIP() << "cuMem (VMM) not supported on this device";
+  }
+  const CUmemAllocationHandleType htype = getCuMemAllocHandleType();
+  if (htype == CU_MEM_HANDLE_TYPE_NONE) {
+    GTEST_SKIP() << "no shareable cuMem handle type on this system";
+  }
+
+  // Two disjoint 2MB (min cuMem granularity) segments.
+  constexpr size_t kSegSize = 2 * 1024 * 1024;
+  std::vector<size_t> segmentSizes = {kSegSize, kSegSize};
+  const size_t total = kSegSize * segmentSizes.size();
+  std::vector<TestMemSegment> segments;
+  void* ptr = nullptr;
+  auto allocRes =
+      ctran::commMemAllocDisjoint(&ptr, segmentSizes, segments, true, htype);
+  if (allocRes != commSuccess || ptr == nullptr) {
+    GTEST_SKIP() << "failed to allocate multi-segment cuMem buffer";
+  }
+
+  {
+    CtranMulticast mc(/*nvlLocalRank=*/0, /*nLocalRanks=*/2, /*cudaDev=*/0);
+    COMMCHECK_TEST(mc.import(ptr, total));
+    EXPECT_GE(mc.importedSize(), total)
+        << "all physical segments must be enumerated + retained";
+  } // mc dtor releases its own retained segment handles here
+
+  ctran::commMemFreeDisjoint(ptr, segmentSizes);
+}
+
+// import() is single-use: once an instance has loaded a buffer's segments, a
+// second import() must be rejected (commInvalidUsage) rather than silently
+// dropping the first buffer's retained segment handles and re-enumerating.
+TEST_F(CtranMulticastTest, ImportIsSingleUse) {
+  if (!getCuMemSysSupported()) {
+    GTEST_SKIP() << "cuMem (VMM) not supported on this device";
+  }
+  const CUmemAllocationHandleType htype = getCuMemAllocHandleType();
+  if (htype == CU_MEM_HANDLE_TYPE_NONE) {
+    GTEST_SKIP() << "no shareable cuMem handle type on this system";
+  }
+
+  constexpr size_t size = 2 * 1024 * 1024;
+  std::vector<size_t> segmentSizes = {size};
+  std::vector<TestMemSegment> segments;
+  void* ptr = nullptr;
+  auto allocRes =
+      ctran::commMemAllocDisjoint(&ptr, segmentSizes, segments, true, htype);
+  if (allocRes != commSuccess || ptr == nullptr) {
+    GTEST_SKIP() << "failed to allocate cuMem buffer";
+  }
+
+  {
+    CtranMulticast mc(/*nvlLocalRank=*/0, /*nLocalRanks=*/2, /*cudaDev=*/0);
+    COMMCHECK_TEST(mc.import(ptr, size));
+    EXPECT_NE(mc.import(ptr, size), commSuccess)
+        << "a second import() must be rejected, not silently re-loaded";
+  }
+
+  ctran::commMemFreeDisjoint(ptr, segmentSizes);
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3241
* __->__ #3240
* #3239

Add ctran::utils::CtranMulticast, a standalone wrapper over cuMulticast*/cuMem* that owns one NVSwitch multicast object bound over a buffer's physical segments plus its mapped multicast VA (mcVA_), with ignore-error RAII teardown;
`import(buf, len)` detects the cuMem segments and retains its own handles.

Refactor the fabric/posix-fd shareable-handle export/import out of CtranIpc.cc into reusable exportShareableHandle/importShareableHandle free functions.

On CtranIpcMem, only declare the slot the next diff populates: a std::shared_ptr<CtranMulticast> mcOverlay_ member + setMulticastOverlay/hasMulticast/getMulticastPtr accessors, plus an isCuMemBacked() predicate.

Helpers and tests only, no behavior change.

Differential Revision: [D112761231](https://our.internmc.facebook.com/intern/diff/D112761231/)