### PR TITLE
[ctran][feature] Set up NVL CE-multicast on the ctwin/window registration path

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -7,8 +7,10 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <folly/Synchronized.h>

--- a/comms/ctran/algos/AllGather/AllGatherCtwin.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCtwin.cc
@@ -92,6 +92,14 @@ commResult_t createPersistentRequestFromWindow(
 
   pArgs.algo = agpVariant;
 
+  // NVL CE-multicast: if the window's data registration carries a multicast
+  // overlay (set up in CtranWin::exchange when win_register_multicast is on and
+  // the NVL group supports it), cache recvbuff's multicast write base so
+  // nvlCeBcast fans out via a single NVSwitch write instead of N-1 per-peer
+  // unicast copies. std::nullopt (unicast) when there is no overlay.
+  pArgs.mcWrite =
+      comm->ctran_->mapper->multicastWriteBase(win->dataRegHdl, recvbuff);
+
   auto request = std::make_unique<CtranPersistentRequest>(
       CtranPersistentRequest::Type::ALLGATHER_P, comm, stream);
   request->algo = algo.release();

--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -11,10 +11,15 @@
 #include "comms/ctran/mapper/CtranMapperTypes.h"
 #include "comms/ctran/regcache/IpcRegCache.h"
 #include "comms/ctran/regcache/RegCache.h"
+#include "comms/ctran/utils/CudaWrap.h"
+#include "comms/ctran/utils/DevMemType.h"
 
 #include <folly/ScopeGuard.h>
 
+#include <algorithm>
+#include <exception>
 #include <memory>
+#include <vector>
 
 using ctran::algos::GpeKernelSync;
 using ctran::allgatherp::AlgoImpl;
@@ -245,6 +250,10 @@ commResult_t AlgoImpl::destroy() {
     resource_.pipeSync->reset();
     resource_.pipeSync = nullptr;
   }
+  // No multicast teardown here: the overlay is owned by the recvbuff's
+  // registration (CtranIpcMem), not the request, and is released with that
+  // registration on the user thread (via recvRegHdl_ / cleanupInvalidImports).
+  // pArgs.mcWrite is just a cached pointer, so it needs no teardown.
   // Release the scoped NVL IPC imports and the scoped local recv registration.
   // Both are deferred/SW-only (no CUDA), so safe from the graph-destroy
   // callback. Later explicit cleanupInvalidImports() or access to regCache

--- a/comms/ctran/algos/AllGatherP/CommUtils.h
+++ b/comms/ctran/algos/AllGatherP/CommUtils.h
@@ -73,6 +73,9 @@ inline commResult_t exchangeIpcReg(CtranComm* comm, PersistArgs& pArgs) {
                            : pArgs.remoteIpcRegHdls_.at(i).toString());
   }
 
+  // NVL CE-multicast is set up on the window/ctwin registration path
+  // (CtranWin::exchange); the eager/graph AGP path here stays unicast, so
+  // pArgs.mcWrite is left std::nullopt.
   pArgs.initState = InitState::kInitialized;
   return commSuccess;
 }

--- a/comms/ctran/algos/AllGatherP/DirectImpl.cc
+++ b/comms/ctran/algos/AllGatherP/DirectImpl.cc
@@ -185,13 +185,18 @@ commResult_t AlgoImpl::execDirect(
 
   const auto sendSize = count * commTypeSize(datatype);
 
-  // Copy data to self for out-of-place allgather
-  FB_COMMCHECK(copyToSelf(
-      comm_,
-      sendbuff,
-      getPtr(pArgs.recvbuff, comm_->statex_->rank() * sendSize),
-      sendSize,
-      stream_));
+  // Copy data to self for out-of-place allgather. Skipped when multicast is
+  // engaged: the step-0 CE-multicast broadcast fans out to self too, so
+  // recvbuff[myRank] is already written (the GPE inter-node send sources its
+  // step-0 chunk from sendbuff, not recvbuff, so there is no early reader).
+  if (!pArgs.mcWrite) {
+    FB_COMMCHECK(copyToSelf(
+        comm_,
+        sendbuff,
+        getPtr(pArgs.recvbuff, comm_->statex_->rank() * sendSize),
+        sendSize,
+        stream_));
+  }
 
   // Wait till async init is done, so that we can schedule copy operations with
   // the remote address
@@ -213,7 +218,9 @@ commResult_t AlgoImpl::execDirect(
           myRank * sendSize,
           pArgs.remoteRecvBuffs,
           pArgs.remoteAccessKeys,
-          stream_));
+          stream_,
+          /*barrier=*/true,
+          pArgs.mcWrite));
     }
   }
 

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -282,13 +282,18 @@ commResult_t AlgoImpl::execPipeline(
     }
   }
 
-  // Copy data to self for out-of-place allgather
-  FB_COMMCHECK(copyToSelf(
-      comm_,
-      sendbuff,
-      getPtr(pArgs.recvbuff, comm_->statex_->rank() * sendSize),
-      sendSize,
-      stream_));
+  // Copy data to self for out-of-place allgather. Skipped when multicast is
+  // engaged: the step-0 CE-multicast broadcast fans out to self too, so
+  // recvbuff[myRank] is already written (the GPE inter-node ring sources its
+  // step-0 chunk from sendbuff, not recvbuff, so there is no early reader).
+  if (!pArgs.mcWrite) {
+    FB_COMMCHECK(copyToSelf(
+        comm_,
+        sendbuff,
+        getPtr(pArgs.recvbuff, comm_->statex_->rank() * sendSize),
+        sendSize,
+        stream_));
+  }
 
   // Submit intra-node copies in the pipeline
   if (nLocalRanks > 1) {
@@ -301,7 +306,9 @@ commResult_t AlgoImpl::execPipeline(
         myRank * sendSize,
         pArgs.remoteRecvBuffs,
         pArgs.remoteAccessKeys,
-        stream_));
+        stream_,
+        /*barrier=*/true,
+        pArgs.mcWrite));
 
     const int upPeer = (nRanks + myRank - nLocalRanks) & (nRanks - 1);
 
@@ -332,7 +339,9 @@ commResult_t AlgoImpl::execPipeline(
           offset,
           pArgs.remoteRecvBuffs,
           pArgs.remoteAccessKeys,
-          stream_));
+          stream_,
+          /*barrier=*/true,
+          pArgs.mcWrite));
     }
 
     PipeEndKernArgs kernArgs = {

--- a/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
@@ -289,7 +289,9 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
         myRank * sendSize,
         pArgs.remoteRecvBuffs,
         pArgs.remoteAccessKeys,
-        stream_));
+        stream_,
+        /*barrier=*/true,
+        pArgs.mcWrite));
 
     for (int step = 0; step < recvPlan.nSteps(); step++) {
       PipeSyncKernArgs syncArgs = {
@@ -316,7 +318,8 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
             pArgs.remoteRecvBuffs,
             pArgs.remoteAccessKeys,
             stream_,
-            chunkIndex++ == 0));
+            chunkIndex++ == 0,
+            pArgs.mcWrite));
       }
     }
 

--- a/comms/ctran/algos/AllGatherP/Types.h
+++ b/comms/ctran/algos/AllGatherP/Types.h
@@ -53,6 +53,19 @@ struct PersistArgs {
   // ctwin sets it per-comm by topology since a single cvar cannot express
   // multiple comms with different topologies.
   std::optional<enum NCCL_ALLGATHER_P_ALGO> algo;
+
+  // NVL CE-multicast broadcast state. Cache of the multicast write base: when
+  // engaged, mcWrite holds the multicast VA offset corresponding to recvbuff,
+  // and nvlCeBcast issues a single cudaMemcpyAsync to it instead of the N-1
+  // per-peer unicast fan-out. std::nullopt (unicast fallback) when multicast is
+  // disabled, unsupported, or the recvbuff is not a cuMem (VMM) allocation. Set
+  // on the GPE thread during init (published via the initState fence alongside
+  // remoteRecvBuffs) and read on the user thread at exec. Collapsing the enabled
+  // bit + pointer into one optional makes the (enabled, nullptr) state
+  // unrepresentable.
+  // TODO(ctwin rework): the setup source moves from the mapper NVL rendezvous
+  // to the window/ctwin registration path.
+  std::optional<void*> mcWrite;
 };
 
 struct Resource {

--- a/comms/ctran/algos/common/NvlUtils.h
+++ b/comms/ctran/algos/common/NvlUtils.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cuda_runtime.h>
+#include <optional>
 #include <vector>
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
@@ -133,7 +134,15 @@ inline commResult_t nvlCeBcast(
     const std::vector<void*>& remoteRecvBuffs,
     const std::vector<CtranMapperRemoteAccessKey>& remoteAccessKeys,
     cudaStream_t stream,
-    bool barrier = true) {
+    bool barrier = true,
+    // When mcWrite is engaged, broadcast via a single CE-multicast write to
+    // *mcWrite + recvOffset (NVSwitch fans it out to every NVL-domain peer,
+    // including self) instead of the N-1 per-peer unicast copies -- collapsing
+    // the per-peer Memcpy nodes into one CE node. *mcWrite already accounts for
+    // the recv buffer's offset within its multicast-bound allocation. Set up on
+    // the buffer's registration during the NVL rendezvous; std::nullopt on the
+    // unicast path (which makes the enabled-but-null state unrepresentable).
+    std::optional<void*> mcWrite = std::nullopt) {
   const auto statex = comm->statex_.get();
   const auto rank = statex->rank();
   const auto localRank = statex->localRank();
@@ -143,6 +152,24 @@ inline commResult_t nvlCeBcast(
   // avoid unwanted incast traffic congestion
   if (barrier) {
     nvlBarrier(comm, stream);
+  }
+
+  // CE-multicast fast path: one write fanned out by NVSwitch to all peers,
+  // captured as exactly one Memcpy node (vs numOps per-peer nodes below).
+  if (mcWrite) {
+    void* recvPtr = static_cast<char*>(*mcWrite) + recvOffset;
+    CLOGF_TRACE(
+        COLL,
+        "Rank {} CE multicast bcast, sendBuff {} -> mcRecvBuff {} (mcWrite {} + recvOffset {}), sendSize {}",
+        rank,
+        sendBuff,
+        recvPtr,
+        *mcWrite,
+        recvOffset,
+        sendSize);
+    FB_CUDACHECK(cudaMemcpyAsync(
+        recvPtr, sendBuff, sendSize, cudaMemcpyDeviceToDevice, stream));
+    return commSuccess;
   }
 
   const size_t numOps = nLocalRanks - 1;

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -18,6 +18,8 @@
 #include "comms/ctran/transport/ib/HostCbTransport.h"
 #include "comms/ctran/transport/ib/HostZcTransport.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranIpc.h"
+#include "comms/ctran/utils/CtranMulticast.h"
 #include "comms/utils/StrUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -1336,6 +1338,238 @@ commResult_t CtranMapper::allGatherCtrlImpl(
   }
 
   return commSuccess;
+}
+
+commResult_t CtranMapper::setupMulticastOverlay(
+    void* hdl,
+    const std::vector<int>& ranks,
+    bool* engaged) {
+  if (engaged != nullptr) {
+    *engaged = false;
+  }
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12040
+  // Multicast is fabric-only; fabric handles require CUDA 12.4+ and are not
+  // available on AMD. Leave the overlay unset (callers use unicast).
+  (void)hdl;
+  (void)ranks;
+  return commSuccess;
+#else
+  const auto& statex = comm->statex_;
+  const int rank = statex->rank();
+  const int cudaDev = statex->cudaDev();
+
+  // Locate the local buffer's registration; multicast is only possible over a
+  // cuMem/VMM allocation. The multicast object enumerates + retains its own
+  // segment handles via import() below (it does not borrow the registration's).
+  auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(hdl);
+  if (regElem == nullptr || regElem->ipcRegElem == nullptr) {
+    return commSuccess;
+  }
+  auto* ipcElem =
+      reinterpret_cast<ctran::regcache::IpcRegElem*>(regElem->ipcRegElem);
+  const void* buf = nullptr;
+  size_t bufLen = 0;
+  {
+    auto ipc = ipcElem->ipcMem.rlock();
+    if (!ipc->isCuMemBacked()) {
+      return commSuccess; // not a cuMem/VMM registration -> no multicast
+    }
+    buf = ipc->getBase();
+    bufLen = ipc->getRange();
+  }
+
+  // NVL group = self + NVL-backend peers of `ranks`, sorted ascending. Root is
+  // the lowest global rank; nvlLocalRank is our index within the group.
+  // INVARIANT: peers must agree symmetrically on NVL membership (else the
+  // group/ root/rank ordering diverges and the sequential rendezvous below
+  // mismatches), and every rank's registered buffer must be the same size (the
+  // object is sized to the root's mcSize and each rank binds/maps its own equal
+  // total) -- both hold for AllGatherP's symmetric recvbuff registration.
+  std::vector<int> group;
+  for (const auto peer : ranks) {
+    if (peer == rank ||
+        this->queryPeerBackend(regElem, peer) == CtranMapperBackend::NVL) {
+      group.push_back(peer);
+    }
+  }
+  std::sort(group.begin(), group.end());
+  const int nLocalRanks = static_cast<int>(group.size());
+  if (nLocalRanks <= 1) {
+    return commSuccess; // no NVL peers to multicast to
+  }
+  const int rootRank = group.front();
+  const bool isRoot = (rank == rootRank);
+  int nvlLocalRank = 0;
+  for (int i = 0; i < nLocalRanks; i++) {
+    if (group[i] == rank) {
+      nvlLocalRank = i;
+      break;
+    }
+  }
+
+  // Create the (standalone) multicast object for this team and import the local
+  // buffer: import() enumerates + RETAINS this object's own handle for each
+  // physical segment. The object is kept alive to function end; on any
+  // decline/failure path its dtor releases those handles.
+  auto mc = std::make_unique<ctran::utils::CtranMulticast>(
+      nvlLocalRank, nLocalRanks, cudaDev);
+  if (mc->import(buf, bufLen) != commSuccess) {
+    return commSuccess; // could not enumerate the backing segments -> unicast
+  }
+  const size_t mcSize = mc->importedSize();
+
+  // Local eligibility: device supports multicast and every segment (and the
+  // total) is multicast-granularity aligned.
+  bool localOk = ctran::utils::CtranMulticast::isSupported(cudaDev);
+  size_t gran = 0;
+  if (localOk &&
+      (ctran::utils::CtranMulticast::granularity(cudaDev, nLocalRanks, gran) !=
+           commSuccess ||
+       gran == 0 || (mcSize % gran) != 0)) {
+    localOk = false;
+  }
+  if (localOk && !mc->segmentsAlignedTo(gran)) {
+    localOk = false;
+  }
+
+  // Rendezvous payload broadcast root->peers after the support vote.
+  struct McRzv {
+    int ok{0};
+    ctran::utils::CtranIpcHandle handle{};
+  };
+
+  // Round 1: gather the support bit to the root; the group proceeds only if all
+  // ranks agree (keeps create/bind unanimous, avoiding a split that would
+  // hang).
+  bool groupOk = localOk;
+  if (isRoot) {
+    // Post all recvs, then wait, so the peer round-trips pipeline (matching
+    // allGatherCtrlImpl) instead of serializing one wait per peer. unique_ptr
+    // keeps each request's address stable across vector growth (the IB layer
+    // holds references into the request objects).
+    std::vector<std::unique_ptr<CtranMapperRequest>> reqs;
+    std::vector<int> peerOks(group.size(), 0);
+    for (size_t i = 0; i < group.size(); i++) {
+      if (group[i] == rank) {
+        continue;
+      }
+      reqs.push_back(std::make_unique<CtranMapperRequest>());
+      FB_COMMCHECK(this->irecvCtrlMsg(
+          &peerOks[i], sizeof(int), group[i], reqs.back().get()));
+    }
+    for (auto& req : reqs) {
+      FB_COMMCHECK(this->waitRequest(req.get()));
+    }
+    for (size_t i = 0; i < group.size(); i++) {
+      groupOk = groupOk && (group[i] == rank || peerOks[i] != 0);
+    }
+  } else {
+    int myOk = localOk ? 1 : 0;
+    CtranMapperRequest req;
+    FB_COMMCHECK(this->isendCtrlMsg(&myOk, sizeof(myOk), rootRank, &req));
+    FB_COMMCHECK(this->waitRequest(&req));
+  }
+
+  // Round 2: root creates the fabric multicast object (if the group agreed) and
+  // broadcasts the decision + fabric handle; non-roots import it.
+  McRzv rzv;
+  if (isRoot) {
+    if (groupOk) {
+      CUmemGenericAllocationHandle mcHandle = 0;
+      if (mc->createRoot(mcSize, CU_MEM_HANDLE_TYPE_FABRIC, mcHandle) ==
+              commSuccess &&
+          ctran::utils::exportShareableHandle(
+              mcHandle, rzv.handle, /*isFabric=*/true) == commSuccess) {
+        rzv.ok = 1;
+      }
+    }
+    // Post all sends, then wait (pipelined broadcast).
+    std::vector<std::unique_ptr<CtranMapperRequest>> reqs;
+    for (const auto peer : group) {
+      if (peer == rank) {
+        continue;
+      }
+      reqs.push_back(std::make_unique<CtranMapperRequest>());
+      FB_COMMCHECK(
+          this->isendCtrlMsg(&rzv, sizeof(rzv), peer, reqs.back().get()));
+    }
+    for (auto& req : reqs) {
+      FB_COMMCHECK(this->waitRequest(req.get()));
+    }
+  } else {
+    CtranMapperRequest req;
+    FB_COMMCHECK(this->irecvCtrlMsg(&rzv, sizeof(rzv), rootRank, &req));
+    FB_COMMCHECK(this->waitRequest(&req));
+    if (rzv.ok) {
+      CUmemGenericAllocationHandle mcHandle = 0;
+      // Fatal on failure: the regular NVL buffer import earlier in this same
+      // rendezvous already proved fabric/IMEX works, so a failure to import the
+      // multicast object handle (same mechanism) is an exceptional error, not
+      // an expected degrade.
+      FB_COMMCHECK(
+          ctran::utils::importShareableHandle(
+              rzv.handle, mcHandle, /*isFabric=*/true));
+      mc->adoptImported(mcHandle);
+    }
+  }
+
+  if (!rzv.ok) {
+    return commSuccess; // group declined or root create failed -> unicast
+  }
+
+  // Every rank: add local device, bind each segment, map the multicast VA, then
+  // hand the overlay to the registration, which owns its lifetime + teardown.
+  // Failures here are FATAL (FB_COMMCHECK propagates; the caller now
+  // FB_COMMCHECKs this function): post-vote, fabric import + VA mapping share
+  // the substrate the regular NVL buffer import already exercised earlier in
+  // this same rendezvous, so a failure means unicast is equally dead -- the
+  // same fatal class the regular path aborts on. Aborting loudly (vs a silent
+  // per-rank unicast fallback) also avoids divergent multicast membership,
+  // where a rank that fell back would never bind its device and silently drop
+  // peers' multicast writes.
+  FB_COMMCHECK(mc->addDeviceAndBind());
+  FB_COMMCHECK(mc->mapVA(mcSize, gran));
+  {
+    auto ipc = ipcElem->ipcMem.wlock();
+    ipc->setMulticastOverlay(std::move(mc));
+  }
+  if (engaged != nullptr) {
+    *engaged = true;
+  }
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "CTRAN-MC: rank {} bound multicast overlay over {} NVL ranks ({} bytes)",
+      rank,
+      nLocalRanks,
+      mcSize);
+  return commSuccess;
+#endif
+}
+
+std::optional<void*> CtranMapper::multicastWriteBase(
+    void* hdl,
+    const void* userPtr) {
+  auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(hdl);
+  if (regElem == nullptr || regElem->ipcRegElem == nullptr) {
+    return std::nullopt;
+  }
+  auto* ipcElem =
+      reinterpret_cast<ctran::regcache::IpcRegElem*>(regElem->ipcRegElem);
+  auto ipc = ipcElem->ipcMem.rlock();
+  if (!ipc->hasMulticast()) {
+    return std::nullopt;
+  }
+  auto* mcPtr = static_cast<char*>(ipc->getMulticastPtr());
+  auto* base = static_cast<char*>(ipc->getBase());
+  const auto* uptr = static_cast<const char*>(userPtr);
+  // userPtr must lie within the registered buffer; otherwise the offset into
+  // the multicast VA would be out of range. Fall back to unicast rather than
+  // hand back a bad pointer.
+  if (uptr < base || uptr >= base + ipc->getRange()) {
+    return std::nullopt;
+  }
+  return static_cast<void*>(mcPtr + (uptr - base));
 }
 
 commResult_t CtranMapper::barrier() {

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -562,6 +563,28 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperBackend backend = CtranMapperBackend::UNSET,
       bool recordExport = true,
       std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls = nullptr);
+
+  // Set up a CUDA NVSwitch multicast overlay over the NVL subset of `ranks` for
+  // the buffer registered under `hdl` (a RegElem*), storing it on that
+  // registration's CtranIpcMem. Runs an NVL-team rendezvous over the ctrl
+  // channel (support vote -> root createRoot+export -> broadcast -> peers
+  // adoptImported -> all import+bind+map). No-op / unicast-fallback if the
+  // group declines, multicast is unsupported, or the buffer is not
+  // cuMem-backed. Called from the window/ctwin registration path
+  // (CtranWin::exchange). `engaged` (optional out) is set true iff an overlay
+  // was actually bound (false on unicast-fallback / decline / non-cuMem), so
+  // the caller can log the outcome.
+  commResult_t setupMulticastOverlay(
+      void* hdl,
+      const std::vector<int>& ranks,
+      bool* engaged = nullptr);
+
+  // Return the multicast write base for a buffer whose registration carries a
+  // multicast overlay (set up by a prior setupMulticastOverlay):
+  // getMulticastPtr() + (userPtr - allocBase). Returns std::nullopt when the
+  // buffer has no overlay (multicast disabled/unsupported / not a cuMem
+  // buffer). userPtr must lie within the registered buffer.
+  std::optional<void*> multicastWriteBase(void* hdl, const void* userPtr);
 
   /* Convenient wrapper of isendCtrl/irecvCtrl to post a blocking barrier among
    * all local ranks of the mapper associated communicator.

--- a/comms/ctran/tests/CtranDistAllgatherPTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherPTests.cc
@@ -432,6 +432,10 @@ TEST_F(CtranAllgatherPTestParam, DynamicSendRegPipeline) {
   }
 }
 
+// NVL CE-multicast is now set up on the window/ctwin registration path
+// (win_register_multicast); its coverage lives with the ctwin window tests, not
+// this eager/graph AGP suite.
+
 TEST_F(CtranAllgatherPTest, InvalidPreq) {
   auto request = std::make_unique<CtranPersistentRequest>(
       CtranPersistentRequest::Type::ALLTOALL_P, ctranComm.get(), stream);

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -200,6 +200,18 @@ struct CtranWin {
     return symmetric_;
   }
 
+  // Opt-in (win_register_multicast): set up an NVL CE-multicast overlay over
+  // the window's data registration during exchange(), so ctwin AllGather fans
+  // out via a single NVSwitch write. Only takes effect on a symmetric,
+  // cuMem-backed window on multicast-capable HW; unicast fallback otherwise.
+  inline void setMulticast(bool val) {
+    multicast_ = val;
+  }
+
+  inline bool isMulticast() const {
+    return multicast_;
+  }
+
   inline uint64_t id() const {
     return id_;
   }
@@ -252,6 +264,9 @@ struct CtranWin {
   // peerBase + (buf - localBase). Records the upstream NCCL_WIN_COLL_SYMMETRIC
   // hint; consumed by a later window-based allgather. Cached only for now.
   bool symmetric_{false};
+  // Records the win_register_multicast hint; see setMulticast(). Consumed in
+  // exchange() to set up the NVL CE-multicast overlay.
+  bool multicast_{false};
   // Per-comm unique id assigned at exchange() (see CtranComm::assignWindowId).
   uint64_t id_{0};
   // rank: window::OpCountType as key

--- a/comms/ctran/window/WinHintUtils.cc
+++ b/comms/ctran/window/WinHintUtils.cc
@@ -13,6 +13,7 @@ const std::string kWindowSignalBufSize = "window_signal_bufsize";
 const std::string kWinRegisterIpcOnly = "win_register_ipc_only";
 const std::string kWinRegisterEnableSignal = "win_register_enable_signal";
 const std::string kWinRegisterSymmetric = "win_register_symmetric";
+const std::string kWinRegisterMulticast = "win_register_multicast";
 } // namespace
 
 void WinHintUtils::init(kvType& kv) {
@@ -45,6 +46,14 @@ WinHintUtils::set(const std::string& key, const std::string& val, kvType& kv) {
       return commInvalidArgument;
     }
   } else if (key == kWinRegisterSymmetric) {
+    if (val == "1" || val == "true") {
+      kv[key] = "1";
+    } else if (val == "0" || val == "false") {
+      kv[key] = "0";
+    } else {
+      return commInvalidArgument;
+    }
+  } else if (key == kWinRegisterMulticast) {
     if (val == "1" || val == "true") {
       kv[key] = "1";
     } else if (val == "0" || val == "false") {

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -360,6 +360,41 @@ commResult_t CtranWin::exchange() {
   // memory space while other ranks are still importing.
   FB_COMMCHECK(windowBarrier(comm, mapper));
 
+  // NVL CE-multicast overlay (opt-in via win_register_multicast). Runs an
+  // NVL-team rendezvous over the same ctrl channel and stashes a self-owning
+  // multicast object on the data registration's CtranIpcMem; ctwin's AGP
+  // request reads its write base via multicastWriteBase, so nvlCeBcast fans out
+  // with a single NVSwitch write. The entry condition is a per-window setting
+  // all ranks pass identically (symmetric + multicast hint), so the group
+  // enters in lockstep; setupMulticastOverlay's support vote handles any
+  // per-rank divergence and leaves the overlay unset (unicast) on decline /
+  // non-cuMem. The trailing barrier ensures every rank has bound before the
+  // window is used.
+  if (isSymmetric() && winDataPtr != nullptr && isMulticast()) {
+    bool mcEngaged = false;
+    FB_COMMCHECK(
+        mapper->setupMulticastOverlay(dataRegHdl, exchangeRanks, &mcEngaged));
+    FB_COMMCHECK(windowBarrier(comm, mapper));
+    if (mcEngaged) {
+      CLOGF_SUBSYS(
+          INFO,
+          INIT,
+          "CTRAN-WINDOW: Rank {} bound NVL CE-multicast overlay on win {} comm {} commHash {:x} ({} bytes)",
+          myRank,
+          (void*)this,
+          (void*)comm,
+          statex->commHash(),
+          dataBytes);
+    } else {
+      CLOGF_SUBSYS(
+          INFO,
+          INIT,
+          "CTRAN-WINDOW: Rank {} requested NVL CE-multicast on win {} but it did not engage (unicast fallback)",
+          myRank,
+          (void*)this);
+    }
+  }
+
   // Cache only symmetric windows: ctwin collective algos needs all ranks
   // locally compute peerAddr = peerBase + offset, meaning same offset from base
   // on all ranks.
@@ -771,6 +806,12 @@ commResult_t ctranWinRegister(
   if (hints.get("win_register_symmetric", symmetricVal) == commSuccess) {
     newWin->setSymmetric(
         meta::comms::hints::WinHintUtils::parseBool(symmetricVal));
+  }
+
+  std::string multicastVal;
+  if (hints.get("win_register_multicast", multicastVal) == commSuccess) {
+    newWin->setMulticast(
+        meta::comms::hints::WinHintUtils::parseBool(multicastVal));
   }
 
   FB_COMMCHECK(newWin->allocate((void*)databuf));

--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -274,6 +274,7 @@ Config::Config(const ncclConfig_t* config) {
   winRegisterIpcOnly = parseHintBool("win_register_ipc_only", false);
   winRegisterEnableSignal = parseHintBool("win_register_enable_signal", true);
   winRegisterSymmetric = parseHintBool("win_register_symmetric", false);
+  winRegisterMulticast = parseHintBool("win_register_multicast", false);
 
   auto parseAlgoHint = [&](const char* key, auto& field) {
     auto val = getHintStr(key);
@@ -334,6 +335,7 @@ ncclResult_t Config::update(const ncclx::Hints* hints) {
   parseBoolHint("win_register_ipc_only", winRegisterIpcOnly);
   parseBoolHint("win_register_enable_signal", winRegisterEnableSignal);
   parseBoolHint("win_register_symmetric", winRegisterSymmetric);
+  parseBoolHint("win_register_multicast", winRegisterMulticast);
 
   return ncclSuccess;
 }
@@ -400,6 +402,7 @@ void ncclxLogCommConfig(ncclComm_t comm) {
         fmt::format(
             "winRegisterEnableSignal={}", xCfg->winRegisterEnableSignal));
     append(fmt::format("winRegisterSymmetric={}", xCfg->winRegisterSymmetric));
+    append(fmt::format("winRegisterMulticast={}", xCfg->winRegisterMulticast));
     append(fmt::format("ibLazyConnect={}", xCfg->ibLazyConnect));
     appendAlgo("sendrecvAlgo", xCfg->sendrecvAlgo);
     appendAlgo("allgatherAlgo", xCfg->allgatherAlgo);

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -48,6 +48,12 @@ class Config {
   // commSetConfig.
   bool winRegisterSymmetric = false;
 
+  // When true, set up an NVL CE-multicast overlay over the window's data
+  // registration (win_register_multicast), so ctwin AllGather fans out via a
+  // single NVSwitch write. Only takes effect on a symmetric, cuMem-backed
+  // window on multicast-capable HW. Mutable via commSetConfig.
+  bool winRegisterMulticast = false;
+
   enum NCCL_SENDRECV_ALGO sendrecvAlgo = NCCL_SENDRECV_ALGO::orig;
   enum NCCL_ALLGATHER_ALGO allgatherAlgo = NCCL_ALLGATHER_ALGO::orig;
   enum NCCL_ALLREDUCE_ALGO allreduceAlgo = NCCL_ALLREDUCE_ALGO::orig;
@@ -102,6 +108,7 @@ inline const std::vector<std::string>& knownHintKeys() {
       "win_register_ipc_only",
       "win_register_enable_signal",
       "win_register_symmetric",
+      "win_register_multicast",
   };
   return keys;
 }
@@ -118,6 +125,7 @@ inline const std::vector<std::string>& mutableHintKeys() {
       "win_register_ipc_only",
       "win_register_enable_signal",
       "win_register_symmetric",
+      "win_register_multicast",
   };
   return keys;
 }

--- a/comms/ncclx/meta/tests/AllGatherCtwinTest.cc
+++ b/comms/ncclx/meta/tests/AllGatherCtwinTest.cc
@@ -5,6 +5,9 @@
 #include <gtest/gtest.h>
 #include <nccl.h>
 #include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
 #include <vector>
 
 #include "comm.h"
@@ -171,6 +174,197 @@ TEST_F(AllGatherCtwinTest, AllGatherCtwinUsedWhenWindowRegistered) {
   EXPECT_EQ(ncclCommWindowDeregister(comm, win), ncclSuccess);
   NCCLCHECK_TEST(ncclGlobalDeregisterWithPtr(winBase, totalBytes));
   testFreeBuf(winBase, totalBytes, kMemNcclMemAlloc);
+}
+
+// Same as above but with win_register_multicast=1: the window sets up an NVL
+// CE-multicast overlay in CtranWin::exchange, and ctwin's AllGatherP fans out
+// through the multicast VA (nvlCeBcast) instead of N-1 unicast copies. On HW
+// without multicast/fabric support the overlay setup declines and the path
+// falls back to unicast, so the result must be correct either way; either way
+// ctwin (CtranAllGatherP) must run.
+TEST_F(AllGatherCtwinTest, AllGatherCtwinMulticastWhenWindowRegistered) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skip test";
+  }
+
+  constexpr size_t count = 1024;
+  const size_t totalBytes = count * numRanks * sizeof(int);
+
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints(
+      {{"allgatherAlgo",
+        ncclx::algoconf::algoValToStr(NCCL_ALLGATHER_ALGO::ctwin)},
+       {"win_register_symmetric", "1"},
+       {"win_register_ipc_only", "1"},
+       {"win_register_multicast", "1"}});
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+  this->comm = commRaii.get();
+  ASSERT_NE(this->comm, nullptr);
+
+  if (comm->ctranComm_->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+
+  std::vector<TestMemSegment> winSegs;
+  void* winBase = testAllocBuf(totalBytes, kMemNcclMemAlloc, winSegs);
+  ASSERT_NE(winBase, nullptr);
+  // Mimic the CCA allocator hook so the window's acquireScopedRegister finds
+  // the buffer's segment cached.
+  NCCLCHECK_TEST(ncclGlobalRegisterWithPtr(winBase, totalBytes));
+  auto regGuard = folly::makeGuard([&]() {
+    NCCLCHECK_TEST(ncclGlobalDeregisterWithPtr(winBase, totalBytes));
+  });
+
+  ncclWindow_t win = nullptr;
+  ASSERT_EQ(
+      ncclCommWindowRegister(
+          comm, winBase, totalBytes, &win, NCCL_WIN_COLL_SYMMETRIC),
+      ncclSuccess);
+  ASSERT_NE(win, nullptr);
+  regGuard.dismiss();
+
+  // In-place layout required by ctwin: this rank's send chunk lives at its
+  // own offset within the recvbuf/window.
+  int* recvBuf = reinterpret_cast<int*>(winBase);
+  int* sendBuf = recvBuf + count * globalRank;
+
+  assignChunkValue(recvBuf, count * numRanks, -1);
+  assignChunkValue(sendBuf, count, globalRank + 1);
+
+  ASSERT_EQ(
+      ncclAllGather(sendBuf, recvBuf, count, ncclInt, comm, stream),
+      ncclSuccess);
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  for (int r = 0; r < numRanks; r++) {
+    int expectedVal = r + 1;
+    int errs = checkChunkValue(recvBuf + r * count, count, expectedVal);
+    EXPECT_EQ(errs, 0) << "rank " << globalRank << " checked chunk " << r
+                       << " at " << recvBuf + r * count << " with " << errs
+                       << " errors";
+  }
+
+  algoStats_.verify(comm, "AllGather", "CtranAllGatherP");
+
+  EXPECT_EQ(ncclCommWindowDeregister(comm, win), ncclSuccess);
+  NCCLCHECK_TEST(ncclGlobalDeregisterWithPtr(winBase, totalBytes));
+  testFreeBuf(winBase, totalBytes, kMemNcclMemAlloc);
+}
+
+// Standalone timed benchmark of ctwin AllGatherP over a symmetric window:
+// warmup, then a cudaEvent-timed loop of ncclAllGather, reporting busbw. Env
+// knobs (one binary covers the size sweep + MC-vs-unicast, no recompile):
+//   NCCLX_BENCH_BYTES     total recvbuf bytes (default 8 MiB)
+//   NCCLX_BENCH_ITERS     timed iterations (default 200)
+//   NCCLX_BENCH_WARMUP    warmup iterations (default 50)
+//   NCCLX_BENCH_MULTICAST "1" (default) sets win_register_multicast; "0" = the
+//                         ctwin-unicast control (isolates the multicast win)
+TEST_F(AllGatherCtwinTest, AllGatherCtwinPerf) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skip test";
+  }
+  auto envOr = [](const char* k, unsigned long long d) -> unsigned long long {
+    const char* v = getenv(k);
+    return (v != nullptr && *v != '\0') ? strtoull(v, nullptr, 10) : d;
+  };
+  const size_t totalBytes = envOr("NCCLX_BENCH_BYTES", 8ull << 20);
+  const int iters = static_cast<int>(envOr("NCCLX_BENCH_ITERS", 200));
+  const int warmup = static_cast<int>(envOr("NCCLX_BENCH_WARMUP", 50));
+  const char* mcEnv = getenv("NCCLX_BENCH_MULTICAST");
+  const std::string mc = (mcEnv != nullptr && *mcEnv != '\0') ? mcEnv : "1";
+  const size_t count = totalBytes / (numRanks * sizeof(int)); // per-rank chunk
+  ASSERT_GT(count, 0u);
+  const size_t winBytes = count * numRanks * sizeof(int);
+
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints(
+      {{"allgatherAlgo",
+        ncclx::algoconf::algoValToStr(NCCL_ALLGATHER_ALGO::ctwin)},
+       {"win_register_symmetric", "1"},
+       {"win_register_ipc_only", "1"},
+       {"win_register_multicast", mc}});
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+  this->comm = commRaii.get();
+  ASSERT_NE(this->comm, nullptr);
+  if (comm->ctranComm_->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+
+  std::vector<TestMemSegment> winSegs;
+  void* winBase = testAllocBuf(winBytes, kMemNcclMemAlloc, winSegs);
+  ASSERT_NE(winBase, nullptr);
+  NCCLCHECK_TEST(ncclGlobalRegisterWithPtr(winBase, winBytes));
+  auto regGuard = folly::makeGuard([&]() {
+    NCCLCHECK_TEST(ncclGlobalDeregisterWithPtr(winBase, winBytes));
+  });
+  ncclWindow_t win = nullptr;
+  ASSERT_EQ(
+      ncclCommWindowRegister(
+          comm, winBase, winBytes, &win, NCCL_WIN_COLL_SYMMETRIC),
+      ncclSuccess);
+  ASSERT_NE(win, nullptr);
+  regGuard.dismiss();
+
+  int* recvBuf = reinterpret_cast<int*>(winBase);
+  int* sendBuf = recvBuf + count * globalRank; // in-place layout ctwin requires
+  assignChunkValue(recvBuf, count * numRanks, -1);
+  assignChunkValue(sendBuf, count, globalRank + 1);
+
+  for (int i = 0; i < warmup; i++) {
+    ASSERT_EQ(
+        ncclAllGather(sendBuf, recvBuf, count, ncclInt, comm, stream),
+        ncclSuccess);
+  }
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  cudaEvent_t start, stop;
+  CUDACHECK_TEST(cudaEventCreate(&start));
+  CUDACHECK_TEST(cudaEventCreate(&stop));
+  CUDACHECK_TEST(cudaEventRecord(start, stream));
+  for (int i = 0; i < iters; i++) {
+    ASSERT_EQ(
+        ncclAllGather(sendBuf, recvBuf, count, ncclInt, comm, stream),
+        ncclSuccess);
+  }
+  CUDACHECK_TEST(cudaEventRecord(stop, stream));
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+  float ms = 0.f;
+  CUDACHECK_TEST(cudaEventElapsedTime(&ms, start, stop));
+
+  const double secPerIter = (ms / 1e3) / iters;
+  const double algbw = (double)winBytes / 1e9 / secPerIter; // GB/s
+  const double busbw = algbw * (double)(numRanks - 1) / (double)numRanks;
+
+  int errs = 0;
+  for (int r = 0; r < numRanks; r++) {
+    errs += checkChunkValue(recvBuf + r * count, count, r + 1);
+  }
+  EXPECT_EQ(errs, 0);
+
+  if (globalRank == 0) {
+    printf(
+        "# AGCTWIN-BENCH multicast=%s ranks=%d bytes=%zu iters=%d  time=%.2f us/op  algbw=%.2f GB/s  busbw=%.2f GB/s  errs=%d\n",
+        mc.c_str(),
+        numRanks,
+        winBytes,
+        iters,
+        secPerIter * 1e6,
+        algbw,
+        busbw,
+        errs);
+    fflush(stdout);
+  }
+  algoStats_.verify(comm, "AllGather", "CtranAllGatherP");
+
+  CUDACHECK_TEST(cudaEventDestroy(start));
+  CUDACHECK_TEST(cudaEventDestroy(stop));
+  EXPECT_EQ(ncclCommWindowDeregister(comm, win), ncclSuccess);
+  NCCLCHECK_TEST(ncclGlobalDeregisterWithPtr(winBase, winBytes));
+  testFreeBuf(winBase, winBytes, kMemNcclMemAlloc);
 }
 
 int main(int argc, char* argv[]) {

--- a/comms/ncclx/v2_29/src/dev_runtime.cc
+++ b/comms/ncclx/v2_29/src/dev_runtime.cc
@@ -1261,6 +1261,9 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
       NCCLCHECK(metaCommToNccl(winHints.set(
           "win_register_symmetric",
           NCCLX_CONFIG_FIELD(comm->config, winRegisterSymmetric) ? "1" : "0")));
+      NCCLCHECK(metaCommToNccl(winHints.set(
+          "win_register_multicast",
+          NCCLX_CONFIG_FIELD(comm->config, winRegisterMulticast) ? "1" : "0")));
       NCCLCHECK(metaCommToNccl(
           ctran::ctranWinRegister(
               buff,

--- a/comms/ncclx/v2_30/src/dev_runtime.cc
+++ b/comms/ncclx/v2_30/src/dev_runtime.cc
@@ -1497,6 +1497,9 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
       NCCLCHECK(metaCommToNccl(winHints.set(
           "win_register_symmetric",
           NCCLX_CONFIG_FIELD(comm->config, winRegisterSymmetric) ? "1" : "0")));
+      NCCLCHECK(metaCommToNccl(winHints.set(
+          "win_register_multicast",
+          NCCLX_CONFIG_FIELD(comm->config, winRegisterMulticast) ? "1" : "0")));
       NCCLCHECK(metaCommToNccl(
           ctran::ctranWinRegister(
               buff,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3241
* #3240
* #3239

Reworks NVL CE-multicast setup to live on the window/ctwin registration path
instead of the legacy AllGatherP mapper rendezvous, now that ctwin allgather is
landed + active (D112411735).

ctwin's `createPersistentRequestFromWindow` borrows the window's registration
and sets `initState=kInitialized`, so it never traverses
`exchangeIpcReg`/`intraAllGatherCtrl` -- the old fold-in setup would never fire
for ctwin. So:

- Setup: `CtranWin::exchange()` calls `mapper->setupMulticastOverlay(dataRegHdl,
  exchangeRanks)` after the handle exchange + barrier, gated by a new opt-in
  `win_register_multicast` hint (plus symmetric + cuMem-backed). Stores a
  self-owning `CtranMulticast` on the window's data registration.
- Consumption (mechanism unchanged): ctwin nLocalRanks>1 runs the AGP
  `execPipeline`/`execSRD` impls, whose `nvlCeBcast` fans out via
  `PersistArgs.mcWrite`. `createPersistentRequestFromWindow` populates `mcWrite`
  from the window overlay via `multicastWriteBase`.
- Removed the AGP-rendezvous setup: the `setupMulticast` flag threading through
  `allGatherCtrl`/`intraAllGatherCtrl`/`allGatherCtrlImpl`, the
  `NCCL_CTRAN_ALLGATHER_P_NVL_MULTICAST` cvar, and its 3 eager/graph AGP tests.
  The eager/graph AGP path stays unicast.
- ncclx plumbing: `win_register_multicast` hint -> `winRegisterMulticast` config
  field -> bridged into the ctran window hints in v2_29 + v2_30 dev_runtime,
  mirroring `win_register_symmetric`.

`setupMulticastOverlay` / `multicastWriteBase` are kept as reusable public
`CtranMapper` methods.

Differential Revision: [D112761232](https://our.internmc.facebook.com/intern/diff/D112761232/)