### PR TITLE
Per-PG collective sequence number in BackendWrapper

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -172,6 +172,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::broadcast(
   } else {
     bopts.timeout = options_->timeout;
   }
+  ++seqCollective_;
   return c10::make_intrusive<WorkWrapper>(
       comm_->broadcast(
           tensors.at(0), static_cast<int>(opts.rootRank), opts.asyncOp, bopts),
@@ -192,6 +193,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::allreduce(
   } else {
     bopts.timeout = options_->timeout;
   }
+  ++seqCollective_;
   return c10::make_intrusive<WorkWrapper>(
       comm_->all_reduce(
           tensors.at(0), toReduceOp(opts.reduceOp), opts.asyncOp, bopts),
@@ -212,6 +214,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::allreduce_coalesced(
   } else {
     bopts.timeout = options_->timeout;
   }
+  ++seqCollective_;
   return c10::make_intrusive<WorkWrapper>(
       comm_->all_reduce(
           tensors.at(0), toReduceOp(opts.reduceOp), opts.asyncOp, bopts),
@@ -232,6 +235,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::reduce(
   } else {
     bopts.timeout = options_->timeout;
   }
+  ++seqCollective_;
   return c10::make_intrusive<WorkWrapper>(
       comm_->reduce(
           tensors.at(0),
@@ -269,6 +273,8 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::allgather(
   } else {
     bopts.timeout = options_->timeout;
   }
+
+  ++seqCollective_;
 
   // Fast path: when per-rank output tensors point to distinct memory,
   // delegate straight to the backend's list-based all_gather (no extra
@@ -318,6 +324,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::allgather_coalesced(
   } else {
     bopts.timeout = options_->timeout;
   }
+  ++seqCollective_;
   return c10::make_intrusive<WorkWrapper>(
       comm_->all_gather(
           outputTensorLists.at(0), inputTensors.at(0), opts.asyncOp, bopts),
@@ -345,6 +352,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::allgather_into_tensor_coalesced(
   } else {
     bopts.timeout = options_->timeout;
   }
+  ++seqCollective_;
   return c10::make_intrusive<WorkWrapper>(
       comm_->all_gather_single(
           output_tensors.at(0), inputTensors.at(0), opts.asyncOp, bopts),
@@ -361,6 +369,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::_allgather_base(
   } else {
     bopts.timeout = options_->timeout;
   }
+  ++seqCollective_;
   return c10::make_intrusive<WorkWrapper>(
       comm_->all_gather_single(outputTensor, inputTensor, opts.asyncOp, bopts),
       std::vector<at::Tensor>{outputTensor});
@@ -395,6 +404,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::gather(
   } else {
     bopts.timeout = options_->timeout;
   }
+  ++seqCollective_;
   return c10::make_intrusive<WorkWrapper>(
       comm_->gather(
           outputTensors.at(0),
@@ -430,6 +440,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::scatter(
     inputTensors = {};
     inputTensors.emplace_back();
   }
+  ++seqCollective_;
   return c10::make_intrusive<WorkWrapper>(
       comm_->scatter(
           outputTensors.at(0),
@@ -458,6 +469,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::reduce_scatter(
   } else {
     bopts.timeout = options_->timeout;
   }
+  ++seqCollective_;
   return c10::make_intrusive<WorkWrapper>(
       comm_->reduce_scatter(
           outputTensors.at(0),
@@ -489,6 +501,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::reduce_scatter_tensor_coalesced(
   } else {
     bopts.timeout = options_->timeout;
   }
+  ++seqCollective_;
   return c10::make_intrusive<WorkWrapper>(
       comm_->reduce_scatter_single(
           outputTensors.at(0),
@@ -509,6 +522,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::_reduce_scatter_base(
   } else {
     bopts.timeout = options_->timeout;
   }
+  ++seqCollective_;
   return c10::make_intrusive<WorkWrapper>(
       comm_->reduce_scatter_single(
           outputTensor,
@@ -525,6 +539,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::alltoall_base(
     std::vector<int64_t>& outputSplitSizes,
     std::vector<int64_t>& inputSplitSizes,
     const c10d::AllToAllOptions& opts) {
+  ++seqCollective_;
   if (outputSplitSizes.empty() && inputSplitSizes.empty()) {
     AllToAllSingleOptions bopts;
     if (opts.timeout != kUnsetTimeout) {
@@ -559,6 +574,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::alltoall(
     std::vector<at::Tensor>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
     const c10d::AllToAllOptions& opts) {
+  ++seqCollective_;
   AllToAllOptions bopts;
   if (opts.timeout != kUnsetTimeout) {
     bopts.timeout = opts.timeout;
@@ -587,6 +603,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::barrier(
   // barrier and TorchWork::wait() keep uniform semantics with every other
   // collective. Async barriers keep the non-blocking, stream-ordered behavior
   // via the work.
+  ++seqCollective_;
   auto work = comm_->barrier(opts.asyncOp, bopts);
   return c10::make_intrusive<WorkWrapper>(
       std::move(work),
@@ -850,6 +867,10 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::endCoalescing() {
 
 std::shared_ptr<TorchComm> BackendWrapper::getComm() const {
   return comm_;
+}
+
+uint64_t BackendWrapper::getSequenceNumberForGroup() {
+  return seqCollective_;
 }
 
 std::shared_ptr<c10::Allocator> BackendWrapper::getMemAllocator() {

--- a/comms/torchcomms/BackendWrapper.hpp
+++ b/comms/torchcomms/BackendWrapper.hpp
@@ -187,6 +187,13 @@ class BackendWrapper : public c10d::Backend {
   // reconfigurable mode and destructive abort otherwise.
   void abort() override;
 
+  // Monotonic count of collectives issued through this backend, exposed to
+  // Python via ProcessGroup._get_sequence_number_for_group(). Mirrors
+  // c10d::ProcessGroupNCCL::seqCollective_ semantics: counts collectives only
+  // (not P2P send/recv), starts at 0, and is a purely local per-PG counter
+  // (never synchronized across ranks).
+  uint64_t getSequenceNumberForGroup() override;
+
  private:
   std::shared_ptr<TorchComm> comm_;
   c10::intrusive_ptr<Options> options_;
@@ -205,6 +212,14 @@ class BackendWrapper : public c10d::Backend {
   // times per rank when unrelated PGs run concurrent barriers, yielding
   // mismatched send/recv tags across ranks.
   std::atomic<uint32_t> monitoredBarrierTagCounter_{0};
+
+  // Backs getSequenceNumberForGroup(). Bumped once per collective (see the
+  // getter's doc comment). Plain uint64_t, mirroring
+  // c10d::ProcessGroupNCCL::seqCollective_: per-PG collective launch is
+  // program-ordered (single writer), and an aligned 64-bit load/store is
+  // single-copy atomic on x86-64 and aarch64, so a concurrent getter never
+  // sees a torn value.
+  uint64_t seqCollective_{0};
 };
 
 } // namespace torch::comms

--- a/comms/torchcomms/tests/integration/py/C10dSequenceNumberTest.py
+++ b/comms/torchcomms/tests/integration/py/C10dSequenceNumberTest.py
@@ -1,0 +1,97 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-unsafe
+
+"""Integration tests for ProcessGroup._get_sequence_number_for_group() routed
+through BackendWrapper.
+
+BackendWrapper mirrors c10d::ProcessGroupNCCL::seqCollective_: a per-PG
+monotonic counter bumped once per collective (never for P2P send/recv), exposed
+to Python via ProcessGroup._get_sequence_number_for_group(). These tests pin
+that contract -- each collective advances the counter by exactly one, and P2P
+leaves it untouched. They assert on deltas rather than an absolute starting
+value because init_process_group may issue its own collectives.
+"""
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+from torchcomms.tests.integration.helpers.TorchCommTestHelpers import (
+    get_device,
+    get_rank_and_size,
+)
+
+
+class TestC10dSequenceNumber(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        dist.config.use_torchcomms = True
+        rank, world_size = get_rank_and_size()
+        dist.init_process_group(
+            backend=os.environ["TEST_BACKEND"], rank=rank, world_size=world_size
+        )
+        device = get_device(os.environ["TEST_BACKEND"], dist.get_rank())
+        torch.set_default_device(device)
+
+    @classmethod
+    def tearDownClass(cls):
+        dist.destroy_process_group()
+
+    def setUp(self):
+        self.pg = dist.group.WORLD
+        self.rank = dist.get_rank()
+        self.world = dist.get_world_size()
+
+    def _seq(self) -> int:
+        return self.pg._get_sequence_number_for_group()
+
+    def test_all_reduce_increments_by_one_each(self):
+        """Each all_reduce bumps the collective counter by exactly one, matching
+        the c10d ProcessGroupNCCL contract."""
+        base = self._seq()
+        num_collectives = 5
+        for _ in range(num_collectives):
+            dist.all_reduce(torch.ones(4))
+        self.assertEqual(self._seq(), base + num_collectives)
+
+    def test_distinct_collectives_each_increment_by_one(self):
+        """Different collective types all funnel through the same counter, one
+        bump apiece."""
+        base = self._seq()
+        tensor = torch.ones(4)
+        dist.all_reduce(tensor)
+        dist.broadcast(tensor, src=0)
+        dist.reduce(tensor, dst=0)
+        dist.barrier()
+        self.assertEqual(self._seq(), base + 4)
+
+    def test_all_gather_increments_once(self):
+        """A single all_gather is one collective regardless of world size."""
+        base = self._seq()
+        output = [torch.empty(2) for _ in range(self.world)]
+        dist.all_gather(output, torch.ones(2) * self.rank)
+        self.assertEqual(self._seq(), base + 1)
+
+    def test_p2p_does_not_increment(self):
+        """send/recv are P2P, not collectives, so they must leave the collective
+        sequence number untouched (getSequenceNumberForGroup returns
+        seqCollective_ only, never seqP2P)."""
+        if self.world < 2:
+            self.skipTest("P2P test requires world_size >= 2")
+        peer_next = (self.rank + 1) % self.world
+        peer_prev = (self.rank - 1 + self.world) % self.world
+        base = self._seq()
+        send_tensor = torch.tensor([self.rank], dtype=torch.float32)
+        recv_tensor = torch.empty(1, dtype=torch.float32)
+        if self.rank % 2 == 0:
+            dist.send(send_tensor, dst=peer_next)
+            dist.recv(recv_tensor, src=peer_prev)
+        else:
+            dist.recv(recv_tensor, src=peer_prev)
+            dist.send(send_tensor, dst=peer_next)
+        self.assertEqual(self._seq(), base)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
`torch.distributed` exposes a per-process-group monotonic collective
counter via `ProcessGroup._get_sequence_number_for_group()`. When a
torchcomms `TorchComm` is driven as a c10d backend through
`BackendWrapper`, that call previously threw ("Backend torchcomms does
not yet support sequence numbers") because the base
`c10d::Backend::getSequenceNumberForGroup()` virtual was never
overridden.

This adds the equivalent of `c10d::ProcessGroupNCCL::seqCollective_` to
`BackendWrapper`: a per-PG `uint64_t seqCollective_` bumped once per
collective issued through the wrapper (not for P2P `send`/`recv`, the
coalescing hooks, or `monitoredBarrier`), and an override of
`getSequenceNumberForGroup()` returning it. Semantics match c10d:
per-group, collectives-only, starts at 0, purely local (never
synchronized across ranks). No Python binding work is needed --
`_get_sequence_number_for_group` is already bound on `c10d::Backend` /
`ProcessGroup`, so the call now resolves through the base virtual into
this override.

The counter is a plain `uint64_t` (not atomic), mirroring
`ProcessGroupNCCL`: per-PG collective launch is program-ordered (single
writer), and an aligned 64-bit load/store is single-copy atomic on
x86-64 and aarch64, so a concurrent getter never sees a torn value.

Reviewed By: kapilsh, d4l3k

Differential Revision: D113305447


