### PR TITLE
Set up NVL CE-multicast on the ctwin/window registration path (#3244)

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -7,8 +7,10 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <folly/Synchronized.h>

--- a/comms/ctran/algos/AllGather/AllGatherCtwin.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCtwin.cc
@@ -92,6 +92,13 @@ commResult_t createPersistentRequestFromWindow(
 
   pArgs.algo = agpVariant;
 
+  // NVL CE-multicast: if the window carries a standalone multicast object
+  // (set up in CtranWin::exchange when win_register_multicast is on and
+  // the NVL group supports it), cache recvbuff's multicast write base so
+  // nvlCeBcast fans out via a single NVSwitch write instead of N-1 per-peer
+  // unicast copies. std::nullopt (unicast) when there is no multicast object.
+  pArgs.mcWrite = win->multicastWriteBase(recvbuff);
+
   auto request = std::make_unique<CtranPersistentRequest>(
       CtranPersistentRequest::Type::ALLGATHER_P, comm, stream);
   request->algo = algo.release();

--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -11,10 +11,15 @@
 #include "comms/ctran/mapper/CtranMapperTypes.h"
 #include "comms/ctran/regcache/IpcRegCache.h"
 #include "comms/ctran/regcache/RegCache.h"
+#include "comms/ctran/utils/CudaWrap.h"
+#include "comms/ctran/utils/DevMemType.h"
 
 #include <folly/ScopeGuard.h>
 
+#include <algorithm>
+#include <exception>
 #include <memory>
+#include <vector>
 
 using ctran::algos::GpeKernelSync;
 using ctran::allgatherp::AlgoImpl;
@@ -265,6 +270,10 @@ commResult_t AlgoImpl::destroy() {
     resource_.pipeSync->reset();
     resource_.pipeSync = nullptr;
   }
+  // No multicast teardown here: the overlay is owned by the recvbuff's
+  // registration (CtranIpcMem), not the request, and is released with that
+  // registration on the user thread (via recvRegHdl_ / cleanupInvalidImports).
+  // pArgs.mcWrite is just a cached pointer, so it needs no teardown.
   // Release the scoped NVL IPC imports and the scoped local recv registration.
   // Both are deferred/SW-only (no CUDA), so safe from the graph-destroy
   // callback. Later explicit cleanupInvalidImports() or access to regCache

--- a/comms/ctran/algos/AllGatherP/CommUtils.h
+++ b/comms/ctran/algos/AllGatherP/CommUtils.h
@@ -90,6 +90,9 @@ inline commResult_t exchangeIpcReg(CtranComm* comm, PersistArgs& pArgs) {
                            : pArgs.remoteIpcRegHdls_.at(i).toString());
   }
 
+  // NVL CE-multicast is set up on the window/ctwin registration path
+  // (CtranWin::exchange); the eager/graph AGP path here stays unicast, so
+  // pArgs.mcWrite is left std::nullopt.
   pArgs.initState = InitState::kInitialized;
   return commSuccess;
 }

--- a/comms/ctran/algos/AllGatherP/DirectImpl.cc
+++ b/comms/ctran/algos/AllGatherP/DirectImpl.cc
@@ -185,13 +185,18 @@ commResult_t AlgoImpl::execDirect(
 
   const auto sendSize = count * commTypeSize(datatype);
 
-  // Copy data to self for out-of-place allgather
-  FB_COMMCHECK(copyToSelf(
-      comm_,
-      sendbuff,
-      getPtr(pArgs.recvbuff, comm_->statex_->rank() * sendSize),
-      sendSize,
-      stream_));
+  // Copy data to self for out-of-place allgather. Skipped when multicast is
+  // engaged: the step-0 CE-multicast broadcast fans out to self too, so
+  // recvbuff[myRank] is already written (the GPE inter-node send sources its
+  // step-0 chunk from sendbuff, not recvbuff, so there is no early reader).
+  if (!pArgs.mcWrite) {
+    FB_COMMCHECK(copyToSelf(
+        comm_,
+        sendbuff,
+        getPtr(pArgs.recvbuff, comm_->statex_->rank() * sendSize),
+        sendSize,
+        stream_));
+  }
 
   // Wait till async init is done, so that we can schedule copy operations with
   // the remote address
@@ -213,7 +218,9 @@ commResult_t AlgoImpl::execDirect(
           myRank * sendSize,
           pArgs.remoteRecvBuffs,
           pArgs.remoteAccessKeys,
-          stream_));
+          stream_,
+          /*barrier=*/true,
+          pArgs.mcWrite));
     }
   }
 

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -282,13 +282,18 @@ commResult_t AlgoImpl::execPipeline(
     }
   }
 
-  // Copy data to self for out-of-place allgather
-  FB_COMMCHECK(copyToSelf(
-      comm_,
-      sendbuff,
-      getPtr(pArgs.recvbuff, comm_->statex_->rank() * sendSize),
-      sendSize,
-      stream_));
+  // Copy data to self for out-of-place allgather. Skipped when multicast is
+  // engaged: the step-0 CE-multicast broadcast fans out to self too, so
+  // recvbuff[myRank] is already written (the GPE inter-node ring sources its
+  // step-0 chunk from sendbuff, not recvbuff, so there is no early reader).
+  if (!pArgs.mcWrite) {
+    FB_COMMCHECK(copyToSelf(
+        comm_,
+        sendbuff,
+        getPtr(pArgs.recvbuff, comm_->statex_->rank() * sendSize),
+        sendSize,
+        stream_));
+  }
 
   // Submit intra-node copies in the pipeline
   if (nLocalRanks > 1) {
@@ -301,7 +306,9 @@ commResult_t AlgoImpl::execPipeline(
         myRank * sendSize,
         pArgs.remoteRecvBuffs,
         pArgs.remoteAccessKeys,
-        stream_));
+        stream_,
+        /*barrier=*/true,
+        pArgs.mcWrite));
 
     const int upPeer = (nRanks + myRank - nLocalRanks) % nRanks;
 
@@ -332,7 +339,9 @@ commResult_t AlgoImpl::execPipeline(
           offset,
           pArgs.remoteRecvBuffs,
           pArgs.remoteAccessKeys,
-          stream_));
+          stream_,
+          /*barrier=*/true,
+          pArgs.mcWrite));
     }
 
     PipeEndKernArgs kernArgs = {

--- a/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
@@ -289,7 +289,9 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
         myRank * sendSize,
         pArgs.remoteRecvBuffs,
         pArgs.remoteAccessKeys,
-        stream_));
+        stream_,
+        /*barrier=*/true,
+        pArgs.mcWrite));
 
     for (int step = 0; step < recvPlan.nSteps(); step++) {
       PipeSyncKernArgs syncArgs = {
@@ -316,7 +318,8 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
             pArgs.remoteRecvBuffs,
             pArgs.remoteAccessKeys,
             stream_,
-            chunkIndex++ == 0));
+            chunkIndex++ == 0,
+            pArgs.mcWrite));
       }
     }
 

--- a/comms/ctran/algos/AllGatherP/Types.h
+++ b/comms/ctran/algos/AllGatherP/Types.h
@@ -53,6 +53,18 @@ struct PersistArgs {
   // ctwin sets it per-comm by topology since a single cvar cannot express
   // multiple comms with different topologies.
   std::optional<enum NCCL_ALLGATHER_P_ALGO> algo;
+
+  // NVL CE-multicast broadcast state. Cache of the multicast write base: when
+  // engaged, mcWrite holds the multicast VA offset corresponding to recvbuff,
+  // and nvlCeBcast issues a single cudaMemcpyAsync to it instead of the N-1
+  // per-peer unicast fan-out. std::nullopt (unicast fallback) when multicast is
+  // disabled, unsupported, or the recvbuff is not a cuMem (VMM) allocation.
+  // Set at request creation on the user thread: the ctwin/window path fills it
+  // from CtranWin::multicastWriteBase(recvbuff) (see AllGatherCtwin.cc) before
+  // initState=kInitialized; the non-window AGP path leaves it std::nullopt.
+  // Consumed by nvlCeBcast during exec. Collapsing the enabled bit + pointer
+  // into one optional makes the (enabled, nullptr) state unrepresentable.
+  std::optional<void*> mcWrite;
 };
 
 struct Resource {

--- a/comms/ctran/algos/common/NvlUtils.h
+++ b/comms/ctran/algos/common/NvlUtils.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cuda_runtime.h>
+#include <optional>
 #include <vector>
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
@@ -133,7 +134,15 @@ inline commResult_t nvlCeBcast(
     const std::vector<void*>& remoteRecvBuffs,
     const std::vector<CtranMapperRemoteAccessKey>& remoteAccessKeys,
     cudaStream_t stream,
-    bool barrier = true) {
+    bool barrier = true,
+    // When mcWrite is engaged, broadcast via a single CE-multicast write to
+    // *mcWrite + recvOffset (NVSwitch fans it out to every NVL-domain peer,
+    // including self) instead of the N-1 per-peer unicast copies -- collapsing
+    // the per-peer Memcpy nodes into one CE node. *mcWrite already accounts for
+    // the recv buffer's offset within its multicast-bound allocation. Set up on
+    // the buffer's registration during the NVL rendezvous; std::nullopt on the
+    // unicast path (which makes the enabled-but-null state unrepresentable).
+    std::optional<void*> mcWrite = std::nullopt) {
   const auto statex = comm->statex_.get();
   const auto rank = statex->rank();
   const auto localRank = statex->localRank();
@@ -143,6 +152,24 @@ inline commResult_t nvlCeBcast(
   // avoid unwanted incast traffic congestion
   if (barrier) {
     nvlBarrier(comm, stream);
+  }
+
+  // CE-multicast fast path: one write fanned out by NVSwitch to all peers,
+  // captured as exactly one Memcpy node (vs numOps per-peer nodes below).
+  if (mcWrite) {
+    void* recvPtr = static_cast<char*>(*mcWrite) + recvOffset;
+    CLOGF_TRACE(
+        COLL,
+        "Rank {} CE multicast bcast, sendBuff {} -> mcRecvBuff {} (mcWrite {} + recvOffset {}), sendSize {}",
+        rank,
+        sendBuff,
+        recvPtr,
+        *mcWrite,
+        recvOffset,
+        sendSize);
+    FB_CUDACHECK(cudaMemcpyAsync(
+        recvPtr, sendBuff, sendSize, cudaMemcpyDeviceToDevice, stream));
+    return commSuccess;
   }
 
   const size_t numOps = nLocalRanks - 1;

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -18,6 +18,8 @@
 #include "comms/ctran/transport/ib/HostCbTransport.h"
 #include "comms/ctran/transport/ib/HostZcTransport.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranIpc.h"
+#include "comms/ctran/utils/CtranMulticast.h"
 #include "comms/utils/StrUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -1336,6 +1338,204 @@ commResult_t CtranMapper::allGatherCtrlImpl(
   }
 
   return commSuccess;
+}
+
+commResult_t CtranMapper::setupMulticast(
+    void* hdl,
+    const std::vector<int>& ranks,
+    std::shared_ptr<ctran::utils::CtranMulticast>& outMulticast) {
+  outMulticast = nullptr;
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12040
+  // Multicast is fabric-only; fabric handles require CUDA 12.4+ and are not
+  // available on AMD. Leave the multicast unset (callers use unicast).
+  (void)hdl;
+  (void)ranks;
+  return commSuccess;
+#else
+  const auto& statex = comm->statex_;
+  const int rank = statex->rank();
+  const int cudaDev = statex->cudaDev();
+
+  // The multicast object enumerates + retains its own segment handles from the
+  // registered buffer via retainSegments() below, which self-detects the memory
+  // type and declines (unicast fallback) on a non-cuMem/VMM buffer -- so no
+  // separate cuMem check against the CtranIpc registration is needed here.
+  auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(hdl);
+  if (regElem == nullptr || regElem->ipcRegElem == nullptr) {
+    return commSuccess; // no NVL registration -> no multicast
+  }
+  const void* buf = regElem->buf;
+  const size_t bufLen = regElem->len;
+
+  // NVL group = self + NVL-backend peers of `ranks`, sorted ascending. Root is
+  // the lowest global rank; nvlLocalRank is our index within the group.
+  // INVARIANT: peers must agree symmetrically on NVL membership (else the
+  // group/ root/rank ordering diverges and the sequential rendezvous below
+  // mismatches), and every rank's registered buffer must be the same size (the
+  // object is sized to the root's mcSize and each rank binds/maps its own equal
+  // total) -- both hold for AllGatherP's symmetric recvbuff registration.
+  std::vector<int> group;
+  for (const auto peer : ranks) {
+    if (peer == rank ||
+        this->queryPeerBackend(regElem, peer) == CtranMapperBackend::NVL) {
+      group.push_back(peer);
+    }
+  }
+  std::sort(group.begin(), group.end());
+  const int nLocalRanks = static_cast<int>(group.size());
+  if (nLocalRanks <= 1) {
+    return commSuccess; // no NVL peers to multicast to
+  }
+  const int rootRank = group.front();
+  const bool isRoot = (rank == rootRank);
+  int nvlLocalRank = 0;
+  for (int i = 0; i < nLocalRanks; i++) {
+    if (group[i] == rank) {
+      nvlLocalRank = i;
+      break;
+    }
+  }
+
+  // Create the (standalone) multicast object for this team and retain the local
+  // buffer's segments: retainSegments() enumerates + RETAINS this object's own
+  // handle for each physical segment. The object is kept alive to function end;
+  // on any decline/failure path its dtor releases those handles.
+  auto mc = std::make_unique<ctran::utils::CtranMulticast>(
+      nvlLocalRank, nLocalRanks, cudaDev);
+  if (mc->retainSegments(buf, bufLen) != commSuccess) {
+    return commSuccess; // could not enumerate the backing segments -> unicast
+  }
+  const size_t mcSize = mc->retainedSize();
+
+  // Local eligibility: device supports multicast and every segment (and the
+  // total) is multicast-granularity aligned.
+  bool localOk = ctran::utils::CtranMulticast::isSupported(cudaDev);
+  size_t gran = 0;
+  if (localOk &&
+      (ctran::utils::CtranMulticast::granularity(cudaDev, nLocalRanks, gran) !=
+           commSuccess ||
+       gran == 0 || (mcSize % gran) != 0)) {
+    localOk = false;
+  }
+  if (localOk && !mc->segmentsAlignedTo(gran)) {
+    localOk = false;
+  }
+
+  // Rendezvous payload broadcast root->peers after the support vote.
+  struct McRzv {
+    int ok{0};
+    ctran::utils::CtranIpcHandle handle{};
+  };
+
+  // Round 1: gather the support bit to the root; the group proceeds only if all
+  // ranks agree (keeps create/bind unanimous, avoiding a split that would
+  // hang).
+  bool groupOk = localOk;
+  if (isRoot) {
+    // Post all recvs, then wait, so the peer round-trips pipeline (matching
+    // allGatherCtrlImpl) instead of serializing one wait per peer. unique_ptr
+    // keeps each request's address stable across vector growth (the IB layer
+    // holds references into the request objects).
+    std::vector<std::unique_ptr<CtranMapperRequest>> reqs;
+    std::vector<int> peerOks(group.size(), 0);
+    for (size_t i = 0; i < group.size(); i++) {
+      if (group[i] == rank) {
+        continue;
+      }
+      reqs.push_back(std::make_unique<CtranMapperRequest>());
+      FB_COMMCHECK(this->irecvCtrlMsg(
+          &peerOks[i], sizeof(int), group[i], reqs.back().get()));
+    }
+    for (auto& req : reqs) {
+      FB_COMMCHECK(this->waitRequest(req.get()));
+    }
+    for (size_t i = 0; i < group.size(); i++) {
+      groupOk = groupOk && (group[i] == rank || peerOks[i] != 0);
+    }
+  } else {
+    int myOk = localOk ? 1 : 0;
+    CtranMapperRequest req;
+    FB_COMMCHECK(this->isendCtrlMsg(&myOk, sizeof(myOk), rootRank, &req));
+    FB_COMMCHECK(this->waitRequest(&req));
+  }
+
+  // Round 2: root creates the fabric multicast object (if the group agreed) and
+  // broadcasts the decision + fabric handle; non-roots import it.
+  McRzv rzv;
+  if (isRoot) {
+    if (groupOk) {
+      CUmemGenericAllocationHandle mcHandle = 0;
+      if (mc->createRoot(mcSize, CU_MEM_HANDLE_TYPE_FABRIC, mcHandle) ==
+              commSuccess &&
+          ctran::utils::exportShareableHandle(
+              mcHandle, rzv.handle, /*isFabric=*/true) == commSuccess) {
+        rzv.ok = 1;
+      }
+    }
+    // Post all sends, then wait (pipelined broadcast).
+    std::vector<std::unique_ptr<CtranMapperRequest>> reqs;
+    for (const auto peer : group) {
+      if (peer == rank) {
+        continue;
+      }
+      reqs.push_back(std::make_unique<CtranMapperRequest>());
+      FB_COMMCHECK(
+          this->isendCtrlMsg(&rzv, sizeof(rzv), peer, reqs.back().get()));
+    }
+    for (auto& req : reqs) {
+      FB_COMMCHECK(this->waitRequest(req.get()));
+    }
+  } else {
+    CtranMapperRequest req;
+    FB_COMMCHECK(this->irecvCtrlMsg(&rzv, sizeof(rzv), rootRank, &req));
+    FB_COMMCHECK(this->waitRequest(&req));
+    if (rzv.ok) {
+      CUmemGenericAllocationHandle mcHandle = 0;
+      // Fatal on failure: the regular NVL buffer import earlier in this same
+      // rendezvous already proved fabric/IMEX works, so a failure to import the
+      // multicast object handle (same mechanism) is an exceptional error, not
+      // an expected degrade.
+      FB_COMMCHECK(
+          ctran::utils::importShareableHandle(
+              rzv.handle, mcHandle, /*isFabric=*/true));
+      mc->adoptImported(mcHandle);
+    }
+  }
+
+  if (!rzv.ok) {
+    // Group declined, or the root's createRoot/export failed -> unicast. `mc`
+    // goes out of scope here and its dtor releases any multicast object
+    // createRoot already allocated (createRoot stores it in mc's own
+    // mcHandle_), so the create-then-export-failure path does not leak.
+    return commSuccess;
+  }
+
+  // Every rank: add local device, bind each segment, map the multicast VA, then
+  // hand the multicast object back to the caller, which owns its lifetime +
+  // teardown.
+  // Failures here are FATAL (FB_COMMCHECK propagates; the caller now
+  // FB_COMMCHECKs this function): post-vote, fabric import + VA mapping share
+  // the substrate the regular NVL buffer import already exercised earlier in
+  // this same rendezvous, so a failure means unicast is equally dead -- the
+  // same fatal class the regular path aborts on. Aborting loudly (vs a silent
+  // per-rank unicast fallback) also avoids divergent multicast membership,
+  // where a rank that fell back would never bind its device and silently drop
+  // peers' multicast writes.
+  FB_COMMCHECK(mc->addDeviceAndBind());
+  FB_COMMCHECK(mc->mapVA(mcSize, gran));
+  // Hand the multicast object back to the caller (CtranWin::exchange), which
+  // owns its lifetime + teardown. Self-owning (retains its own segment
+  // handles), so no CtranIpc storage is involved.
+  outMulticast = std::move(mc);
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "CTRAN-MC: rank {} bound multicast over {} NVL ranks ({} bytes)",
+      rank,
+      nLocalRanks,
+      mcSize);
+  return commSuccess;
+#endif
 }
 
 commResult_t CtranMapper::barrier() {

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -40,6 +41,11 @@
 // Forward declaration for MapperTrace due to NVCC's lack of concepts support
 namespace ncclx::colltrace {
 class MapperTrace;
+}
+
+// Forward declaration: setupMulticast hands back a self-owning CtranMulticast.
+namespace ctran::utils {
+class CtranMulticast;
 }
 
 namespace ctran {
@@ -562,6 +568,21 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperBackend backend = CtranMapperBackend::UNSET,
       bool recordExport = true,
       std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls = nullptr);
+
+  // Set up a CUDA NVSwitch multicast overlay over the NVL subset of `ranks` for
+  // the buffer registered under `hdl` (a RegElem*) and hand it back to the
+  // caller. Runs an NVL-team rendezvous over the ctrl
+  // channel (support vote -> root createRoot+export -> broadcast -> peers
+  // adoptImported -> all retainSegments+bind+map). No-op / unicast-fallback if
+  // the group declines, multicast is unsupported, or the buffer is not
+  // cuMem-backed. Called from the window/ctwin registration path
+  // (CtranWin::exchange). On success, `outMulticast` receives the self-owning
+  // CtranMulticast (the window owns its lifetime); left null on
+  // unicast-fallback / decline / non-cuMem so the caller falls back to unicast.
+  commResult_t setupMulticast(
+      void* hdl,
+      const std::vector<int>& ranks,
+      std::shared_ptr<ctran::utils::CtranMulticast>& outMulticast);
 
   /* Convenient wrapper of isendCtrl/irecvCtrl to post a blocking barrier among
    * all local ranks of the mapper associated communicator.

--- a/comms/ctran/tests/CtranDistAllgatherPTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherPTests.cc
@@ -460,6 +460,10 @@ TEST_F(CtranAllgatherPTestParam, DynamicSendRegPipeline) {
   }
 }
 
+// NVL CE-multicast is now set up on the window/ctwin registration path
+// (win_register_multicast); its coverage lives with the ctwin window tests, not
+// this eager/graph AGP suite.
+
 TEST_F(CtranAllgatherPTest, InvalidPreq) {
   auto request = std::make_unique<CtranPersistentRequest>(
       CtranPersistentRequest::Type::ALLTOALL_P, ctranComm.get(), stream);

--- a/comms/ctran/utils/CtranIpc.cc
+++ b/comms/ctran/utils/CtranIpc.cc
@@ -85,6 +85,55 @@ static inline CUmemAllocationHandleType getCuMemExportHandleType(
   return exportHandleType;
 }
 
+// Export/import of a single VMM allocation handle -- FABRIC (the multicast
+// object, or MNNVL buffers) or POSIX-fd -- selected by isFabric. Shared by the
+// regular per-segment registration and the multicast rendezvous. Defined
+// unqualified inside the file's `namespace ctran::utils` (opened at the top).
+commResult_t exportShareableHandle(
+    CUmemGenericAllocationHandle handle,
+    CtranIpcHandle& out,
+    bool isFabric) {
+  if (isFabric) {
+#if CUDART_VERSION >= 12040
+    FB_CUCHECK(cuMemExportToShareableHandle(
+        &out.handle, handle, CU_MEM_HANDLE_TYPE_FABRIC, 0));
+    return commSuccess;
+#else
+    (void)handle;
+    (void)out;
+    FB_ERRORRETURN(
+        commInternalError, "CTRAN-IPC: fabric export requires CUDA 12.4+");
+#endif
+  }
+  FB_CUCHECK(cuMemExportToShareableHandle(
+      &out.fd, handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0));
+  return commSuccess;
+}
+
+commResult_t importShareableHandle(
+    const CtranIpcHandle& in,
+    CUmemGenericAllocationHandle& out,
+    bool isFabric) {
+  CtranIpcHandle tmp = in;
+  if (isFabric) {
+#if CUDART_VERSION >= 12040
+    FB_CUCHECK(cuMemImportFromShareableHandle(
+        &out, (void*)&tmp.handle, CU_MEM_HANDLE_TYPE_FABRIC));
+    return commSuccess;
+#else
+    (void)in;
+    (void)out;
+    FB_ERRORRETURN(
+        commInternalError, "CTRAN-IPC: fabric import requires CUDA 12.4+");
+#endif
+  }
+  FB_CUCHECK(cuMemImportFromShareableHandle(
+      &out,
+      reinterpret_cast<void*>(tmp.fd),
+      CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR));
+  return commSuccess;
+}
+
 commResult_t ctran::utils::CtranIpcMem::ipcExport(CtranIpcDesc& ipcDesc) {
   std::vector<CtranIpcSegDesc> extraSegments;
   FB_COMMCHECK(ipcExport(ipcDesc, extraSegments));
@@ -110,19 +159,8 @@ inline commResult_t ctran::utils::CtranIpcMem::exportSegmentSharedHandle(
 #if CUDART_VERSION >= 12040
     isCumemFabric = (exportHandleType == CU_MEM_HANDLE_TYPE_FABRIC);
 #endif
-    if (isCumemFabric) {
-      FB_CUCHECK(cuMemExportToShareableHandle(
-          &sharedHandles_[segIdx].handle,
-          allocHandles_[segIdx],
-          exportHandleType,
-          0));
-    } else {
-      FB_CUCHECK(cuMemExportToShareableHandle(
-          &sharedHandles_[segIdx].fd,
-          allocHandles_[segIdx],
-          CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR,
-          0));
-    }
+    FB_COMMCHECK(exportShareableHandle(
+        allocHandles_[segIdx], sharedHandles_[segIdx], isCumemFabric));
   } else if (memType_ == DevMemType::kCudaMalloc) {
     void* p = (void*)pbase_;
     FB_CUDACHECK(cudaIpcGetMemHandle(&sharedHandles_[segIdx].cudaIpcHandle, p));
@@ -543,14 +581,12 @@ commResult_t CtranIpcRemMem::importCuMem(const CtranIpcDesc& ipcDesc) {
           ipcDesc.pid,
           remHandles_[i].fd,
           reinterpret_cast<int*>(&importedHandle.fd)));
-      FB_CUCHECK(cuMemImportFromShareableHandle(
-          &allocHandles_[i],
-          reinterpret_cast<void*>(importedHandle.fd),
-          cuMemHandleType_));
+      FB_COMMCHECK(importShareableHandle(
+          importedHandle, allocHandles_[i], /*isFabric=*/false));
 #if CUDART_VERSION >= 12040
     } else if (cuMemHandleType_ == CU_MEM_HANDLE_TYPE_FABRIC) {
-      FB_CUCHECK(cuMemImportFromShareableHandle(
-          &allocHandles_[i], (void*)&importedHandle.handle, cuMemHandleType_));
+      FB_COMMCHECK(importShareableHandle(
+          importedHandle, allocHandles_[i], /*isFabric=*/true));
 #endif
     } else {
       FB_ERRORRETURN(

--- a/comms/ctran/utils/CtranIpc.h
+++ b/comms/ctran/utils/CtranIpc.h
@@ -360,6 +360,23 @@ class CtranIpcRemMem {
   const CUmemAllocationHandleType cuMemHandleType_{CU_MEM_HANDLE_TYPE_NONE};
 };
 
+// Export/import a single cuMem (VMM) allocation handle to/from a shareable
+// handle: FABRIC (`isFabric=true` -- the multicast object, or MNNVL buffers) or
+// POSIX file descriptor (`isFabric=false`). Shared by the regular per-segment
+// buffer registration (CtranIpcMem) and the multicast rendezvous in
+// CtranMapper::allGatherCtrlImpl, which moves the object handle over the same
+// control channel as the buffer handles. For fabric, `out.handle` carries the
+// fabric bytes; for posix-fd, `out.fd`/`in.fd` carries the descriptor (the
+// caller owns the pidfd import/close dance around the fd itself).
+commResult_t exportShareableHandle(
+    CUmemGenericAllocationHandle handle,
+    CtranIpcHandle& out,
+    bool isFabric);
+commResult_t importShareableHandle(
+    const CtranIpcHandle& in,
+    CUmemGenericAllocationHandle& out,
+    bool isFabric);
+
 // Return the number of active IPC memory objects and IPC remote memory objects.
 // Used to check resource leak in UT.
 size_t getActiveIpcMemCount();

--- a/comms/ctran/utils/CtranMulticast.cc
+++ b/comms/ctran/utils/CtranMulticast.cc
@@ -1,0 +1,262 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and
+// proprietary.
+
+#include "comms/ctran/utils/CtranMulticast.h"
+
+#include "comms/ctran/utils/Checks.h" // FB_COMMCHECK
+#include "comms/ctran/utils/CudaWrap.h"
+#include "comms/utils/logger/LogUtils.h"
+
+namespace ctran::utils {
+
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12010
+
+CtranMulticast::CtranMulticast(int nvlLocalRank, int nLocalRanks, int cudaDev)
+    : nvlLocalRank_(nvlLocalRank),
+      nLocalRanks_(nLocalRanks),
+      cudaDev_(cudaDev) {}
+
+CtranMulticast::~CtranMulticast() {
+  // Safe teardown: cuMulticastUnbind can return an RM error if the backing
+  // buffer was already freed by the user (see NCCL's "safe to ignore" note);
+  // ignore all teardown errors so a partially-created or user-freed overlay
+  // never aborts. Order (unmap -> unbind -> release) is a belt; correctness
+  // rests on ignoring the unbind error.
+  if (mcVA_ != 0) {
+    FB_CUCHECKIGNORE(cuMemUnmap(mcVA_, mcSize_));
+    FB_CUCHECKIGNORE(cuMemAddressFree(mcVA_, mcSize_));
+  }
+  for (const auto& b : bound_) {
+    FB_CUCHECKIGNORE(cuMulticastUnbind(mcHandle_, cuDev_, b.offset, b.size));
+  }
+  if (mcHandle_ != 0) {
+    FB_CUCHECKIGNORE(cuMemRelease(mcHandle_));
+  }
+  // Release our own retained segment handles (from retainSegments()). Because
+  // these are
+  // this object's own references, teardown order relative to any other owner of
+  // the same backing allocation does not matter.
+  for (const auto& seg : segments_) {
+    FB_CUCHECKIGNORE(cuMemRelease(seg.handle));
+  }
+}
+
+bool CtranMulticast::isSupported(int cudaDev) {
+  // Memoized process-wide (thread-safe static init), keyed off the first call's
+  // device. Caching one device's answer for all is correct: the multicast
+  // driver entry points are process-wide (the driver is loaded once), and
+  // CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED is uniform across a homogeneous
+  // NVLink domain (a single domain is never mixed-SKU -- so no
+  // multicast-capable/incapable split within a process). Also logs the
+  // unsupported reason at most once.
+  static const bool supported = [cudaDev]() -> bool {
+    // Driver-version gate: the multicast entry points are loaded (non-null).
+    if (FB_CUPFN(cuMulticastCreate) == nullptr ||
+        FB_CUPFN(cuMulticastAddDevice) == nullptr ||
+        FB_CUPFN(cuMulticastBindMem) == nullptr ||
+        FB_CUPFN(cuMulticastGetGranularity) == nullptr ||
+        FB_CUPFN(cuMulticastUnbind) == nullptr) {
+      CLOGF(
+          WARN,
+          "CTRAN-MC: multicast disabled -- driver multicast entry points unavailable (needs a newer CUDA driver)");
+      return false;
+    }
+    // HW gate: the device reports multicast support. No arch conditional.
+    CUdevice cuDev = 0;
+    FB_CUCHECK_RETURN(cuDeviceGet(&cuDev, cudaDev), false);
+    int sup = 0;
+    FB_CUCHECK_RETURN(
+        cuDeviceGetAttribute(
+            &sup, CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, cuDev),
+        false);
+    if (sup == 0) {
+      CLOGF(
+          WARN,
+          "CTRAN-MC: multicast disabled -- device {} reports no multicast support",
+          cudaDev);
+    }
+    return sup != 0;
+  }();
+  return supported;
+}
+
+commResult_t
+CtranMulticast::granularity(int cudaDev, int nLocalRanks, size_t& gran) {
+  (void)cudaDev;
+  CUmulticastObjectProp prop = {};
+  prop.numDevices = static_cast<unsigned int>(nLocalRanks);
+  prop.size = 0;
+  prop.handleTypes = 0;
+  prop.flags = 0;
+  // MINIMUM is the actual bind/map alignment requirement. (RECOMMENDED is a
+  // padding hint for allocation sizing -- e.g. ncclMemAlloc under
+  // NCCL_MEM_ENABLE_MC_ALIGNMENT -- and is irrelevant here: binding/mapping an
+  // already-allocated buffer succeeds as long as its segments meet MINIMUM.)
+  FB_CUCHECK(cuMulticastGetGranularity(
+      &gran, &prop, CU_MULTICAST_GRANULARITY_MINIMUM));
+  return commSuccess;
+}
+
+commResult_t CtranMulticast::createRoot(
+    size_t mcSize,
+    CUmemAllocationHandleType handleType,
+    CUmemGenericAllocationHandle& outHandle) {
+  // Single-use, symmetric with adoptImported(): release any handle we already
+  // hold before creating a new one, so a misuse (double createRoot, or
+  // createRoot after adoptImported) cannot silently drop -- and leak -- the
+  // previously-held multicast object.
+  if (mcHandle_ != 0) {
+    FB_CUCHECKIGNORE(cuMemRelease(mcHandle_));
+  }
+  CUmulticastObjectProp prop = {};
+  prop.numDevices = static_cast<unsigned int>(nLocalRanks_);
+  prop.size = mcSize;
+  prop.handleTypes = handleType;
+  prop.flags = 0;
+  FB_CUCHECK(cuMulticastCreate(&mcHandle_, &prop));
+  mcSize_ = mcSize;
+  outHandle = mcHandle_;
+  return commSuccess;
+}
+
+void CtranMulticast::adoptImported(CUmemGenericAllocationHandle handle) {
+  // Single-use: an instance is either the root (createRoot) or a non-root
+  // (adoptImported), each exactly once. Release any handle we already hold
+  // before overwriting so a misuse (double-adopt, or adopt after createRoot)
+  // cannot silently drop -- and leak -- the previously-held multicast object.
+  if (mcHandle_ != 0) {
+    FB_CUCHECKIGNORE(cuMemRelease(mcHandle_));
+  }
+  mcHandle_ = handle;
+}
+
+commResult_t CtranMulticast::retainSegments(const void* dptr, size_t len) {
+  // Single-use: one instance retains exactly one buffer's segments (like
+  // createRoot/adoptImported). Re-retaining would silently drop the prior
+  // call's segments, so reject it as an explicit misuse.
+  if (!segments_.empty()) {
+    return commInvalidUsage;
+  }
+  // Multicast requires a cuMem/VMM allocation. Detect the memory type up front
+  // and decline with a descriptive message on cudaMalloc (or an unknown type):
+  // otherwise enumerateCuMemSegments would fail deep inside
+  // cuMemRetainAllocationHandle with an opaque CUDA error. Keeps eligibility
+  // self-contained -- no external cuMem check (e.g. a CtranIpc registration) is
+  // required.
+  DevMemType memType{};
+  const commResult_t typeRes = getDevMemType(dptr, cudaDev_, memType);
+  if (typeRes != commSuccess) {
+    CLOGF(
+        WARN,
+        "CTRAN-MC: cannot set up multicast -- failed to classify memory at {} on cudaDev {}",
+        dptr,
+        cudaDev_);
+    return typeRes;
+  }
+  if (memType != DevMemType::kCumem) {
+    CLOGF(
+        WARN,
+        "CTRAN-MC: cannot set up multicast over {} -- it is {} memory, but multicast requires a cuMem/VMM allocation (e.g. ncclMemAlloc)",
+        dptr,
+        devMemTypeStr(memType));
+    return commInvalidUsage;
+  }
+  // enumerateCuMemSegments retains one allocation handle per segment; segments_
+  // now owns them and the dtor releases each (even on a partial failure here,
+  // since any handles retained before the error are left in segments_).
+  FB_COMMCHECK(enumerateCuMemSegments(dptr, len, segments_));
+  if (segments_.empty()) {
+    // Zero-length buffer: nothing to bind into a multicast object.
+    return commInvalidUsage;
+  }
+  totalSize_ = 0;
+  for (const auto& seg : segments_) {
+    totalSize_ += seg.size;
+  }
+  return commSuccess;
+}
+
+bool CtranMulticast::segmentsAlignedTo(size_t gran) const {
+  if (gran == 0) {
+    return false;
+  }
+  for (const auto& seg : segments_) {
+    if ((seg.size % gran) != 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+commResult_t CtranMulticast::addDeviceAndBind() {
+  FB_CUCHECK(cuDeviceGet(&cuDev_, cudaDev_));
+  FB_CUCHECK(cuMulticastAddDevice(mcHandle_, cuDev_));
+  size_t offset = 0;
+  for (const auto& seg : segments_) {
+    FB_CUCHECK(cuMulticastBindMem(
+        mcHandle_, offset, seg.handle, /*memOffset=*/0, seg.size, /*flags=*/0));
+    bound_.push_back({offset, seg.size});
+    offset += seg.size;
+  }
+  // Non-root ranks learn the object size from their local segments.
+  if (mcSize_ == 0) {
+    mcSize_ = offset;
+  }
+  return commSuccess;
+}
+
+commResult_t CtranMulticast::mapVA(size_t mcSize, size_t gran) {
+  FB_CUCHECK(cuMemAddressReserve(
+      &mcVA_, mcSize, /*alignment=*/gran, /*addr=*/0, /*flags=*/0));
+  FB_CUCHECK(cuMemMap(mcVA_, mcSize, /*offset=*/0, mcHandle_, /*flags=*/0));
+  CUmemAccessDesc accessDesc = {};
+  accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  accessDesc.location.id = cudaDev_;
+  accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  FB_CUCHECK(cuMemSetAccess(mcVA_, mcSize, &accessDesc, /*count=*/1));
+  mcSize_ = mcSize;
+  return commSuccess;
+}
+
+#else // multicast unsupported at compile time (AMD or CUDA < 12.1)
+
+CtranMulticast::CtranMulticast(int nvlLocalRank, int nLocalRanks, int cudaDev)
+    : nvlLocalRank_(nvlLocalRank),
+      nLocalRanks_(nLocalRanks),
+      cudaDev_(cudaDev) {}
+CtranMulticast::~CtranMulticast() = default;
+bool CtranMulticast::isSupported(int /*cudaDev*/) {
+  return false;
+}
+commResult_t CtranMulticast::granularity(
+    int /*cudaDev*/,
+    int /*nLocalRanks*/,
+    size_t& gran) {
+  gran = 0;
+  return commInternalError;
+}
+commResult_t CtranMulticast::createRoot(
+    size_t /*mcSize*/,
+    CUmemAllocationHandleType /*handleType*/,
+    CUmemGenericAllocationHandle& /*outHandle*/) {
+  return commInternalError;
+}
+void CtranMulticast::adoptImported(CUmemGenericAllocationHandle /*handle*/) {}
+commResult_t CtranMulticast::retainSegments(
+    const void* /*dptr*/,
+    size_t /*len*/) {
+  return commInternalError;
+}
+bool CtranMulticast::segmentsAlignedTo(size_t /*gran*/) const {
+  return false;
+}
+commResult_t CtranMulticast::addDeviceAndBind() {
+  return commInternalError;
+}
+commResult_t CtranMulticast::mapVA(size_t /*mcSize*/, size_t /*gran*/) {
+  return commInternalError;
+}
+
+#endif
+
+} // namespace ctran::utils

--- a/comms/ctran/utils/CtranMulticast.h
+++ b/comms/ctran/utils/CtranMulticast.h
@@ -1,0 +1,154 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and
+// proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+// CudaWrap.h pulls in <cuda.h> (or the HIP shims on AMD) so the CU* handle
+// types below resolve on both platforms, and provides the FB_CUPFN wrappers.
+#include "comms/ctran/utils/CudaWrap.h"
+#include "comms/ctran/utils/DevMemType.h" // CuMemSegment, enumerateCuMemSegments
+#include "comms/utils/commSpecs.h"
+
+namespace ctran::utils {
+
+// A standalone NVSwitch multicast object bound over a local buffer's physical
+// backing segments, plus its mapped multicast VA. Self-contained:
+// retainSegments() enumerates the buffer's VMM segments and RETAINS ITS OWN
+// allocation handles
+// (via enumerateCuMemSegments), so this object neither depends on nor borrows
+// from CtranIpc -- it owns everything it binds and releases it all at teardown,
+// in any order relative to other owners of the same backing allocation.
+//
+// This class encapsulates ONLY the LOCAL (per-rank) CUDA operations + RAII
+// teardown; the collective exchange of the multicast object handle across the
+// NVL team is driven by the caller (e.g. CtranMapper::setupMulticast),
+// which uses the CtranIpc export/importShareableHandle helpers to move the
+// handle this class produces (createRoot) / consumes (adoptImported).
+//
+// NOTE: not internally locked; the caller serializes access.
+class CtranMulticast {
+ public:
+  CtranMulticast(int nvlLocalRank, int nLocalRanks, int cudaDev);
+  ~CtranMulticast();
+
+  CtranMulticast(const CtranMulticast&) = delete;
+  CtranMulticast& operator=(const CtranMulticast&) = delete;
+  CtranMulticast(CtranMulticast&&) = delete;
+  CtranMulticast& operator=(CtranMulticast&&) = delete;
+
+  // Runtime support gate (no arch/compute-capability conditional): the
+  // cuMulticast* driver entry points are present AND the device reports
+  // CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED. Mirrors PyTorch
+  // deviceSupportsMulticast and prims isMultimemSupported.
+  static bool isSupported(int cudaDev);
+
+  // Multicast-object allocation granularity for the device+team; mcSize and
+  // every segment size/offset must be a multiple of it.
+  static commResult_t granularity(int cudaDev, int nLocalRanks, size_t& gran);
+
+  // NVL-team root only: create the multicast object (mcSize bytes, agreed
+  // handle type) and return the raw object handle for the caller to
+  // export+broadcast.
+  commResult_t createRoot(
+      size_t mcSize,
+      CUmemAllocationHandleType handleType,
+      CUmemGenericAllocationHandle& outHandle);
+
+  // Non-root: adopt the object handle the caller imported from the root.
+  void adoptImported(CUmemGenericAllocationHandle handle);
+
+  // Every rank: enumerate the physical VMM segments backing [dptr, dptr+len)
+  // and RETAIN this object's own allocation handle for each (via
+  // enumerateCuMemSegments; each released at teardown). Must be a cuMem/VMM
+  // allocation. Call once before addDeviceAndBind(); retainedSize() and
+  // segmentsAlignedTo() are valid afterwards.
+  commResult_t retainSegments(const void* dptr, size_t len);
+
+  // Sum of the retained segments' sizes -- the multicast object size this rank
+  // requires (== root's createRoot mcSize for a symmetric team). Valid after
+  // retainSegments().
+  size_t retainedSize() const {
+    return totalSize_;
+  }
+
+  // True iff every retained segment size is a multiple of gran (a bind
+  // precondition). Valid after retainSegments().
+  bool segmentsAlignedTo(size_t gran) const;
+
+  // Every rank: add the local device to the object, then bind each imported
+  // backing segment at its running multicast offset (address order). Requires a
+  // prior retainSegments() and createRoot()/adoptImported().
+  commResult_t addDeviceAndBind();
+
+  // Every rank: reserve + map + grant device access to one contiguous
+  // multicast VA spanning mcSize; getMulticastPtr() is valid afterwards.
+  commResult_t mapVA(size_t mcSize, size_t gran);
+
+  // The multicast device VA (nullptr until mapVA succeeds).
+  void* getMulticastPtr() const {
+    return reinterpret_cast<void*>(mcVA_);
+  }
+  size_t getMulticastSize() const {
+    return mcSize_;
+  }
+
+  // Base of the retained backing (first segment, address order) -- the origin
+  // the multicast VA is indexed against. nullptr before retainSegments().
+  void* getBase() const {
+    return segments_.empty() ? nullptr
+                             : reinterpret_cast<void*>(segments_[0].base);
+  }
+
+  // Multicast write target for a user pointer inside the imported range:
+  // getMulticastPtr() + (userPtr - getBase()). std::nullopt when there is no
+  // mapped VA yet or userPtr falls outside [getBase(),
+  // getBase()+retainedSize()). Lets the window/collective compute the fan-out
+  // address from the overlay alone -- no CtranIpc involvement.
+  std::optional<void*> writeBase(const void* userPtr) const {
+    void* mcPtr = getMulticastPtr();
+    void* base = getBase();
+    if (mcPtr == nullptr || base == nullptr) {
+      return std::nullopt;
+    }
+    const auto* b = static_cast<const char*>(base);
+    const auto* u = static_cast<const char*>(userPtr);
+    if (u < b || u >= b + totalSize_) {
+      return std::nullopt;
+    }
+    return static_cast<void*>(static_cast<char*>(mcPtr) + (u - b));
+  }
+
+ private:
+  const int nvlLocalRank_{-1};
+  const int nLocalRanks_{0};
+  const int cudaDev_{-1};
+  CUdevice cuDev_{0}; // driver device handle for this cudaDev_
+
+  CUmemGenericAllocationHandle mcHandle_{0}; // the multicast object
+  CUdeviceptr mcVA_{0}; // mapped multicast VA (0 until mapVA)
+  size_t mcSize_{0};
+
+  // Per-segment (offset, size) recorded at bind time so teardown can unbind
+  // each segment. cuMulticastUnbind errors are IGNORED at teardown (the backing
+  // buffer may already be freed by the user), so ordering is a belt not the
+  // guarantee.
+  struct BoundSeg {
+    size_t offset{0};
+    size_t size{0};
+  };
+  std::vector<BoundSeg> bound_;
+
+  // Physical VMM segments backing the local buffer, in address order. Each
+  // allocation handle is RETAINED by this object in retainSegments() and
+  // released
+  // (cuMemRelease) at teardown -- making the object self-owning. totalSize_ =
+  // sum of the segment sizes.
+  std::vector<CuMemSegment> segments_;
+  size_t totalSize_{0};
+};
+
+} // namespace ctran::utils

--- a/comms/ctran/utils/tests/CtranMulticastDistTest.cc
+++ b/comms/ctran/utils/tests/CtranMulticastDistTest.cc
@@ -1,0 +1,190 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "nccl.h"
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/utils/Alloc.h"
+#include "comms/ctran/utils/CtranIpc.h"
+#include "comms/ctran/utils/CtranMulticast.h"
+#include "comms/ctran/utils/CudaWrap.h"
+#include "comms/testinfra/TestUtils.h"
+#include "comms/utils/commSpecs.h"
+
+// Distributed test for the NVL CE-multicast registration mechanism, driven the
+// way production drives it: one rank per GPU. The root createRoot()s the
+// multicast object and broadcasts its fabric handle over allGatherNvlDomain;
+// every peer importShareableHandle()s + adoptImported()s it; each rank
+// retainSegments() its own buffer -- self-detecting + retaining its own segment
+// handles -- then addDeviceAndBind()s and mapVA()s. A single multicast write
+// from the root must then fan out (via NVSwitch) into every rank's own buffer
+// -- the nvlCeBcast primitive. Requires >= 2 GPUs in one NVL domain with
+// fabric; skipped otherwise.
+
+using ctran::utils::CtranIpcHandle;
+using ctran::utils::CtranIpcMem;
+using ctran::utils::CtranMulticast;
+
+namespace {
+
+size_t roundUp(size_t size, size_t align) {
+  return ((size + align - 1) / align) * align;
+}
+
+} // namespace
+
+class MulticastDistTest : public ctran::CtranDistTestFixture {
+ public:
+  void SetUp() override {
+    setenv("NCCL_CTRAN_ENABLE", "1", 0);
+    ctran::CtranDistTestFixture::SetUp();
+    COMMCHECK_TEST(ctran::utils::commCudaLibraryInit());
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+    comm_ = makeCtranComm();
+  }
+
+  void TearDown() override {
+    comm_.reset();
+    ctran::CtranDistTestFixture::TearDown();
+  }
+
+ protected:
+  std::unique_ptr<CtranComm> comm_;
+  const char* desc_{"MulticastDistTest"};
+
+  // Drive the full create -> export -> allGatherNvlDomain -> retainSegments ->
+  // addDeviceAndBind -> mapVA -> broadcast-fanout path over a recvbuff backed
+  // by `numSegments` disjoint physical segments. numSegments>1 exercises
+  // addDeviceAndBind's per-segment running-offset bind and a multicast write
+  // that must fan out across every segment.
+  void runCreateBindBroadcast(int numSegments) {
+    const int rank = comm_->statex_->rank();
+    const int nRanks = comm_->statex_->nRanks();
+    const int lRank = comm_->statex_->localRank();
+    const int nLocalRanks = comm_->statex_->nLocalRanks();
+
+    if (nRanks < 2 || comm_->statex_->nNodes() > 1) {
+      GTEST_SKIP() << "requires >= 2 ranks in a single NVL domain, got nRanks="
+                   << nRanks << " nNodes=" << comm_->statex_->nNodes();
+    }
+    if (!ctran::utils::getCuMemSysSupported() ||
+        !CtranMulticast::isSupported(lRank)) {
+      GTEST_SKIP() << "cuMem + multicast not supported on this device";
+    }
+    if ((ctran::utils::getCuMemAllocHandleType() & CU_MEM_HANDLE_TYPE_FABRIC) ==
+        0) {
+      GTEST_SKIP()
+          << "FABRIC handle type required to share the multicast object";
+    }
+
+    size_t gran = 0;
+    COMMCHECK_TEST(CtranMulticast::granularity(lRank, nLocalRanks, gran));
+    ASSERT_GT(gran, 0u);
+    // Each disjoint segment must be aligned to both cuMem (2MB) and the
+    // multicast granularity.
+    const size_t segSize = roundUp(2 * 1024 * 1024, gran);
+    std::vector<size_t> segSizes(numSegments, segSize);
+    const size_t total = segSize * numSegments;
+
+    // Each rank: a `numSegments`-segment cuMem recvbuff on its own GPU.
+    void* buf = nullptr;
+    std::vector<TestMemSegment> allocSegs;
+    COMMCHECK_TEST(
+        ctran::commMemAllocDisjoint(
+            &buf,
+            segSizes,
+            allocSegs,
+            true,
+            ctran::utils::getCuMemAllocHandleType()));
+
+    // Root (rank 0) creates the object sized to the summed segments; its fabric
+    // handle is all-gathered so peers import a distinct reference.
+    constexpr int kRoot = 0;
+    auto mc = std::make_shared<CtranMulticast>(lRank, nLocalRanks, lRank);
+    std::vector<CtranIpcHandle> handles(nLocalRanks);
+    std::memset(handles.data(), 0, handles.size() * sizeof(CtranIpcHandle));
+    if (rank == kRoot) {
+      CUmemGenericAllocationHandle rootHandle{};
+      COMMCHECK_TEST(
+          mc->createRoot(total, CU_MEM_HANDLE_TYPE_FABRIC, rootHandle));
+      COMMCHECK_TEST(
+          ctran::utils::exportShareableHandle(
+              rootHandle, handles[lRank], /*isFabric=*/true));
+    }
+    allGatherNvlDomain(comm_.get(), handles);
+    if (rank != kRoot) {
+      CUmemGenericAllocationHandle imported{};
+      COMMCHECK_TEST(
+          ctran::utils::importShareableHandle(
+              handles[kRoot], imported, /*isFabric=*/true));
+      mc->adoptImported(imported);
+    }
+
+    // Each rank retains its own buffer's segments (self-detect + retain its own
+    // handles), then binds them and maps the multicast VA. Both are local ops
+    // needing no cross-rank barrier.
+    COMMCHECK_TEST(mc->retainSegments(buf, total));
+    EXPECT_EQ(mc->retainedSize(), total)
+        << "retainSegments should enumerate the full " << numSegments
+        << "-segment buffer";
+    COMMCHECK_TEST(mc->addDeviceAndBind());
+    COMMCHECK_TEST(mc->mapVA(total, gran));
+    ASSERT_NE(mc->getMulticastPtr(), nullptr);
+    // Every rank must have bound its device before the root broadcasts below:
+    // cuMulticast only fans a write out to devices bound at write time, so a
+    // peer still in addDeviceAndBind would silently miss the pattern.
+    barrierNvlDomain(comm_.get());
+
+    // Root multicasts a pattern across the whole (multi-segment) VA; every rank
+    // must observe it across its entire buffer -- i.e. every bound segment.
+    constexpr uint8_t kPattern = 0x5A;
+    if (rank == kRoot) {
+      // cudaMemset is host-synchronous, so the write is complete on return --
+      // no explicit device sync needed before the barrier below.
+      CUDACHECK_TEST(cudaMemset(mc->getMulticastPtr(), kPattern, total));
+    }
+    barrierNvlDomain(comm_.get());
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<uint8_t> observed(total, 0x00);
+    CUDACHECK_TEST(
+        cudaMemcpy(observed.data(), buf, total, cudaMemcpyDeviceToHost));
+    const std::vector<uint8_t> expected(total, kPattern);
+    EXPECT_EQ(observed, expected)
+        << "rank " << rank << " missed the multicast broadcast across "
+        << numSegments << " segment(s)";
+
+    // Tear the overlay down before freeing its backing. No barrier needed: the
+    // line-157 barrier already synced all ranks past the broadcast, and each
+    // rank's teardown (unbind local device, unmap VA, release handle) is local.
+    mc.reset();
+    ctran::commMemFreeDisjoint(buf, segSizes);
+  }
+};
+
+TEST_F(MulticastDistTest, CreateBindBroadcast) {
+  runCreateBindBroadcast(/*numSegments=*/1);
+}
+
+// Multi-segment: a recvbuff backed by 2 disjoint physical segments exercises
+// addDeviceAndBind's per-segment running-offset bind, and the broadcast must
+// fan out across both segments.
+TEST_F(MulticastDistTest, CreateBindBroadcastMultiSegment) {
+  runCreateBindBroadcast(/*numSegments=*/2);
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new ctran::CtranDistEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ctran/utils/tests/CtranMulticastTest.cc
+++ b/comms/ctran/utils/tests/CtranMulticastTest.cc
@@ -1,0 +1,165 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "comms/ctran/tests/CtranTestUtils.h"
+#include "comms/ctran/utils/Alloc.h"
+#include "comms/ctran/utils/CtranMulticast.h"
+#include "comms/ctran/utils/CudaWrap.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/commSpecs.h"
+
+// Single-process unit tests for the NVL-multicast registration surface: the
+// CtranMulticast support/granularity gates and its self-detecting
+// retainSegments() (physical VMM segment enumeration + retention of its own
+// handles, declining cleanly on non-cuMem memory). The full multicast object
+// data-path (create/bind/map + the fabric handle exchange + NVSwitch fan-out)
+// needs a real >=2-GPU NVL group and is covered by the distributed test
+// CtranMulticastDistTest.cc (1 rank/GPU).
+
+using namespace ctran::utils;
+
+class CtranMulticastTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    ncclCvarInit();
+    COMMCHECK_TEST(commCudaLibraryInit());
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+
+  void TearDown() override {}
+};
+
+// The unicast (non-cuMem) case: a cudaMalloc-backed buffer has no physical VMM
+// segments, so retainSegments() detects the memory type and fails cleanly (the
+// caller falls back to unicast) -- no CtranIpc registration required.
+TEST_F(CtranMulticastTest, CudaMallocBufferCannotRetain) {
+  constexpr size_t size = 2 * 1024 * 1024;
+  void* ptr = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&ptr, size));
+
+  CtranMulticast mc(/*nvlLocalRank=*/0, /*nLocalRanks=*/2, /*cudaDev=*/0);
+  // Reject cleanly with a descriptive reason -- the specific commInvalidUsage
+  // from the up-front memory-type check plus a message naming the actual memory
+  // type -- NOT an opaque CUDA error bubbled up from
+  // cuMemRetainAllocationHandle deep inside enumerateCuMemSegments.
+  testing::internal::CaptureStderr();
+  const commResult_t rc = mc.retainSegments(ptr, size);
+  const std::string logs = testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(rc, commInvalidUsage)
+      << "retainSegments must reject a non-cuMem (cudaMalloc) buffer cleanly";
+  EXPECT_NE(logs.find("multicast requires a cuMem"), std::string::npos)
+      << "expected a descriptive 'requires cuMem' reason; got:\n"
+      << logs;
+  EXPECT_EQ(logs.find("cuMemRetainAllocationHandle"), std::string::npos)
+      << "must not leak the opaque cuMemRetainAllocationHandle CUDA error:\n"
+      << logs;
+
+  CUDACHECK_TEST(cudaFree(ptr));
+}
+
+// A cuMem (VMM) buffer's segments can be retained into a standalone
+// CtranMulticast, which enumerates and RETAINS ITS OWN handle for each physical
+// segment (released in the dtor at scope exit). retainedSize() must cover the
+// whole allocation (what addDeviceAndBind would bind).
+TEST_F(CtranMulticastTest, CuMemBufferRetainCoversAllocation) {
+  if (!getCuMemSysSupported()) {
+    GTEST_SKIP() << "cuMem (VMM) not supported on this device";
+  }
+  const CUmemAllocationHandleType htype = getCuMemAllocHandleType();
+  if (htype == CU_MEM_HANDLE_TYPE_NONE) {
+    GTEST_SKIP() << "no shareable cuMem handle type on this system";
+  }
+
+  constexpr size_t size = 2 * 1024 * 1024;
+  std::vector<size_t> segmentSizes = {size};
+  std::vector<TestMemSegment> segments;
+  void* ptr = nullptr;
+  auto allocRes =
+      ctran::commMemAllocDisjoint(&ptr, segmentSizes, segments, true, htype);
+  if (allocRes != commSuccess || ptr == nullptr) {
+    GTEST_SKIP() << "failed to allocate cuMem buffer";
+  }
+
+  {
+    CtranMulticast mc(/*nvlLocalRank=*/0, /*nLocalRanks=*/2, /*cudaDev=*/0);
+    COMMCHECK_TEST(mc.retainSegments(ptr, size));
+    EXPECT_GE(mc.retainedSize(), size)
+        << "retained segments must cover the whole allocation";
+  } // mc dtor releases its own retained segment handles here
+
+  ctran::commMemFreeDisjoint(ptr, segmentSizes);
+}
+
+// Multi-segment coverage (the rework's capability over the old single-segment
+// limit): retaining a cuMem buffer backed by multiple physical VMM segments
+// enumerates + retains all of them, so retainedSize() covers the whole
+// allocation (addDeviceAndBind binds each at running offsets).
+TEST_F(CtranMulticastTest, CuMemMultiSegmentRetainCoversAllocation) {
+  if (!getCuMemSysSupported()) {
+    GTEST_SKIP() << "cuMem (VMM) not supported on this device";
+  }
+  const CUmemAllocationHandleType htype = getCuMemAllocHandleType();
+  if (htype == CU_MEM_HANDLE_TYPE_NONE) {
+    GTEST_SKIP() << "no shareable cuMem handle type on this system";
+  }
+
+  // Two disjoint 2MB (min cuMem granularity) segments.
+  constexpr size_t kSegSize = 2 * 1024 * 1024;
+  std::vector<size_t> segmentSizes = {kSegSize, kSegSize};
+  const size_t total = kSegSize * segmentSizes.size();
+  std::vector<TestMemSegment> segments;
+  void* ptr = nullptr;
+  auto allocRes =
+      ctran::commMemAllocDisjoint(&ptr, segmentSizes, segments, true, htype);
+  if (allocRes != commSuccess || ptr == nullptr) {
+    GTEST_SKIP() << "failed to allocate multi-segment cuMem buffer";
+  }
+
+  {
+    CtranMulticast mc(/*nvlLocalRank=*/0, /*nLocalRanks=*/2, /*cudaDev=*/0);
+    COMMCHECK_TEST(mc.retainSegments(ptr, total));
+    EXPECT_GE(mc.retainedSize(), total)
+        << "all physical segments must be enumerated + retained";
+  } // mc dtor releases its own retained segment handles here
+
+  ctran::commMemFreeDisjoint(ptr, segmentSizes);
+}
+
+// retainSegments() is single-use: once an instance has loaded a buffer's
+// segments, a second call must be rejected (commInvalidUsage) rather than
+// silently dropping the first buffer's retained segment handles and
+// re-enumerating.
+TEST_F(CtranMulticastTest, RetainSegmentsIsSingleUse) {
+  if (!getCuMemSysSupported()) {
+    GTEST_SKIP() << "cuMem (VMM) not supported on this device";
+  }
+  const CUmemAllocationHandleType htype = getCuMemAllocHandleType();
+  if (htype == CU_MEM_HANDLE_TYPE_NONE) {
+    GTEST_SKIP() << "no shareable cuMem handle type on this system";
+  }
+
+  constexpr size_t size = 2 * 1024 * 1024;
+  std::vector<size_t> segmentSizes = {size};
+  std::vector<TestMemSegment> segments;
+  void* ptr = nullptr;
+  auto allocRes =
+      ctran::commMemAllocDisjoint(&ptr, segmentSizes, segments, true, htype);
+  if (allocRes != commSuccess || ptr == nullptr) {
+    GTEST_SKIP() << "failed to allocate cuMem buffer";
+  }
+
+  {
+    CtranMulticast mc(/*nvlLocalRank=*/0, /*nLocalRanks=*/2, /*cudaDev=*/0);
+    COMMCHECK_TEST(mc.retainSegments(ptr, size));
+    EXPECT_NE(mc.retainSegments(ptr, size), commSuccess)
+        << "a second retainSegments() must be rejected, not silently re-loaded";
+  }
+
+  ctran::commMemFreeDisjoint(ptr, segmentSizes);
+}

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -6,6 +6,8 @@
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <memory>
+#include <optional>
 #include <tuple>
 #include <unordered_map>
 #include <utility>
@@ -20,6 +22,7 @@
 #include "comms/ctran/regcache/RegCache.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/CtranIpc.h"
+#include "comms/ctran/utils/CtranMulticast.h"
 #include "comms/ctran/utils/DevMemType.h"
 #include "comms/ctran/window/Types.h"
 #if defined(ENABLE_PRIMS)
@@ -200,6 +203,26 @@ struct CtranWin {
     return symmetric_;
   }
 
+  // Opt-in (win_register_multicast): set up a standalone NVL CE-multicast
+  // object over the window's data buffer during exchange(), so ctwin AllGather
+  // fans out via a single NVSwitch write. Only takes effect on a symmetric,
+  // cuMem-backed window on multicast-capable HW; unicast fallback otherwise.
+  inline void setMulticast(bool val) {
+    multicast_ = val;
+  }
+
+  inline bool isMulticast() const {
+    return multicast_;
+  }
+
+  // Multicast write base for a user pointer in this window's data buffer, or
+  // std::nullopt when there is no multicast object (unicast). Computed from the
+  // multicast object alone -- no CtranIpc involvement -- so ctwin AllGather
+  // fans out via a single NVSwitch write.
+  inline std::optional<void*> multicastWriteBase(const void* userPtr) const {
+    return mc_ ? mc_->writeBase(userPtr) : std::nullopt;
+  }
+
   inline uint64_t id() const {
     return id_;
   }
@@ -252,6 +275,13 @@ struct CtranWin {
   // peerBase + (buf - localBase). Records the upstream NCCL_WIN_COLL_SYMMETRIC
   // hint; consumed by a later window-based allgather. Cached only for now.
   bool symmetric_{false};
+  // Records the win_register_multicast hint; see setMulticast(). Consumed in
+  // exchange() to set up the NVL CE-multicast object.
+  bool multicast_{false};
+  // The standalone NVL CE-multicast object for this window's data buffer, set
+  // in exchange() and read via multicastWriteBase(). Self-owning; released with
+  // the window. null unless win_register_multicast engaged.
+  std::shared_ptr<ctran::utils::CtranMulticast> mc_;
   // Per-comm unique id assigned at exchange() (see CtranComm::assignWindowId).
   uint64_t id_{0};
   // rank: window::OpCountType as key

--- a/comms/ctran/window/WinHintUtils.cc
+++ b/comms/ctran/window/WinHintUtils.cc
@@ -13,6 +13,7 @@ const std::string kWindowSignalBufSize = "window_signal_bufsize";
 const std::string kWinRegisterIpcOnly = "win_register_ipc_only";
 const std::string kWinRegisterEnableSignal = "win_register_enable_signal";
 const std::string kWinRegisterSymmetric = "win_register_symmetric";
+const std::string kWinRegisterMulticast = "win_register_multicast";
 } // namespace
 
 void WinHintUtils::init(kvType& kv) {
@@ -45,6 +46,14 @@ WinHintUtils::set(const std::string& key, const std::string& val, kvType& kv) {
       return commInvalidArgument;
     }
   } else if (key == kWinRegisterSymmetric) {
+    if (val == "1" || val == "true") {
+      kv[key] = "1";
+    } else if (val == "0" || val == "false") {
+      kv[key] = "0";
+    } else {
+      return commInvalidArgument;
+    }
+  } else if (key == kWinRegisterMulticast) {
     if (val == "1" || val == "true") {
       kv[key] = "1";
     } else if (val == "0" || val == "false") {

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -389,6 +389,52 @@ commResult_t CtranWin::exchange() {
   FB_COMMCHECK(windowBarrier(comm, mapper));
   recordWinStage("WinExchange/Barrier", barrierTimer.durationUs());
 
+  // NVL CE-multicast (opt-in via win_register_multicast). Runs an
+  // NVL-team rendezvous over the same ctrl channel and builds a self-owning
+  // standalone multicast object over the window's data buffer; ctwin's AGP
+  // request reads its write base via multicastWriteBase, so nvlCeBcast fans out
+  // with a single NVSwitch write.
+  //
+  // INVARIANT (must hold or the rendezvous + barrier below deadlock): all ranks
+  // enter this block together. Guaranteed because the gate is rank-uniform --
+  // symmetric + multicast are collective win_register_* hints applied
+  // identically on every rank, and winDataPtr is non-null for every
+  // registered/allocated window by the time exchange() runs. Note
+  // setupMulticast is itself collective (a support-vote rendezvous over
+  // exchangeRanks), so uniform entry is required for it, not just for the
+  // trailing barrier; its vote then handles per-rank multicast-support
+  // divergence, leaving the object unset (unicast) on decline / non-cuMem. The
+  // trailing barrier ensures every rank has bound before the window is used.
+  if (isSymmetric() && winDataPtr != nullptr && isMulticast()) {
+    std::shared_ptr<ctran::utils::CtranMulticast> mc;
+    FB_COMMCHECK(mapper->setupMulticast(dataRegHdl, exchangeRanks, mc));
+    const bool mcEngaged = (mc != nullptr);
+    if (mcEngaged) {
+      // exchange() is a CtranWin member; store the window's multicast object
+      // directly (the window owns its lifetime, torn down in free()).
+      mc_ = std::move(mc);
+    }
+    FB_COMMCHECK(windowBarrier(comm, mapper));
+    if (mcEngaged) {
+      CLOGF_SUBSYS(
+          INFO,
+          INIT,
+          "CTRAN-WINDOW: Rank {} bound NVL CE-multicast on win {} comm {} commHash {:x} ({} bytes)",
+          myRank,
+          (void*)this,
+          (void*)comm,
+          statex->commHash(),
+          dataBytes);
+    } else {
+      CLOGF_SUBSYS(
+          INFO,
+          INIT,
+          "CTRAN-WINDOW: Rank {} requested NVL CE-multicast on win {} but it did not engage (unicast fallback)",
+          myRank,
+          (void*)this);
+    }
+  }
+
   // Cache only symmetric windows: ctwin collective algos needs all ranks
   // locally compute peerAddr = peerBase + offset, meaning same offset from base
   // on all ranks.
@@ -532,6 +578,11 @@ commResult_t CtranWin::free(bool skipBarrier) {
     }
     reqs->clear();
   }
+
+  // Release the multicast object after the persistent requests that cached its
+  // write base are gone. Self-owning (its own segment handles + VA), so this is
+  // independent of the data-registration teardown below.
+  mc_.reset();
 
   // Drop this window's entry from the comm cache before tearing down buffers so
   // a later lookup cannot resolve to a freed window.
@@ -801,6 +852,12 @@ commResult_t ctranWinRegister(
   if (hints.get("win_register_symmetric", symmetricVal) == commSuccess) {
     newWin->setSymmetric(
         meta::comms::hints::WinHintUtils::parseBool(symmetricVal));
+  }
+
+  std::string multicastVal;
+  if (hints.get("win_register_multicast", multicastVal) == commSuccess) {
+    newWin->setMulticast(
+        meta::comms::hints::WinHintUtils::parseBool(multicastVal));
   }
 
   FB_COMMCHECK(newWin->allocate((void*)databuf));

--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -274,6 +274,7 @@ Config::Config(const ncclConfig_t* config) {
   winRegisterIpcOnly = parseHintBool("win_register_ipc_only", false);
   winRegisterEnableSignal = parseHintBool("win_register_enable_signal", true);
   winRegisterSymmetric = parseHintBool("win_register_symmetric", false);
+  winRegisterMulticast = parseHintBool("win_register_multicast", false);
 
   auto parseAlgoHint = [&](const char* key, auto& field) {
     auto val = getHintStr(key);
@@ -334,6 +335,7 @@ ncclResult_t Config::update(const ncclx::Hints* hints) {
   parseBoolHint("win_register_ipc_only", winRegisterIpcOnly);
   parseBoolHint("win_register_enable_signal", winRegisterEnableSignal);
   parseBoolHint("win_register_symmetric", winRegisterSymmetric);
+  parseBoolHint("win_register_multicast", winRegisterMulticast);
 
   return ncclSuccess;
 }
@@ -400,6 +402,7 @@ void ncclxLogCommConfig(ncclComm_t comm) {
         fmt::format(
             "winRegisterEnableSignal={}", xCfg->winRegisterEnableSignal));
     append(fmt::format("winRegisterSymmetric={}", xCfg->winRegisterSymmetric));
+    append(fmt::format("winRegisterMulticast={}", xCfg->winRegisterMulticast));
     append(fmt::format("ibLazyConnect={}", xCfg->ibLazyConnect));
     appendAlgo("sendrecvAlgo", xCfg->sendrecvAlgo);
     appendAlgo("allgatherAlgo", xCfg->allgatherAlgo);

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -48,6 +48,12 @@ class Config {
   // commSetConfig.
   bool winRegisterSymmetric = false;
 
+  // When true, set up an NVL CE-multicast overlay over the window's data
+  // registration (win_register_multicast), so ctwin AllGather fans out via a
+  // single NVSwitch write. Only takes effect on a symmetric, cuMem-backed
+  // window on multicast-capable HW. Mutable via commSetConfig.
+  bool winRegisterMulticast = false;
+
   enum NCCL_SENDRECV_ALGO sendrecvAlgo = NCCL_SENDRECV_ALGO::orig;
   enum NCCL_ALLGATHER_ALGO allgatherAlgo = NCCL_ALLGATHER_ALGO::orig;
   enum NCCL_ALLREDUCE_ALGO allreduceAlgo = NCCL_ALLREDUCE_ALGO::orig;
@@ -102,6 +108,7 @@ inline const std::vector<std::string>& knownHintKeys() {
       "win_register_ipc_only",
       "win_register_enable_signal",
       "win_register_symmetric",
+      "win_register_multicast",
   };
   return keys;
 }
@@ -118,6 +125,7 @@ inline const std::vector<std::string>& mutableHintKeys() {
       "win_register_ipc_only",
       "win_register_enable_signal",
       "win_register_symmetric",
+      "win_register_multicast",
   };
   return keys;
 }

--- a/comms/ncclx/meta/tests/AllGatherCtwinTest.cc
+++ b/comms/ncclx/meta/tests/AllGatherCtwinTest.cc
@@ -5,6 +5,9 @@
 #include <gtest/gtest.h>
 #include <nccl.h>
 #include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
 #include <vector>
 
 #include "comm.h"
@@ -171,6 +174,197 @@ TEST_F(AllGatherCtwinTest, AllGatherCtwinUsedWhenWindowRegistered) {
   EXPECT_EQ(ncclCommWindowDeregister(comm, win), ncclSuccess);
   NCCLCHECK_TEST(ncclGlobalDeregisterWithPtr(winBase, totalBytes));
   testFreeBuf(winBase, totalBytes, kMemNcclMemAlloc);
+}
+
+// Same as above but with win_register_multicast=1: the window sets up an NVL
+// CE-multicast overlay in CtranWin::exchange, and ctwin's AllGatherP fans out
+// through the multicast VA (nvlCeBcast) instead of N-1 unicast copies. On HW
+// without multicast/fabric support the overlay setup declines and the path
+// falls back to unicast, so the result must be correct either way; either way
+// ctwin (CtranAllGatherP) must run.
+TEST_F(AllGatherCtwinTest, AllGatherCtwinMulticastWhenWindowRegistered) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skip test";
+  }
+
+  constexpr size_t count = 1024;
+  const size_t totalBytes = count * numRanks * sizeof(int);
+
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints(
+      {{"allgatherAlgo",
+        ncclx::algoconf::algoValToStr(NCCL_ALLGATHER_ALGO::ctwin)},
+       {"win_register_symmetric", "1"},
+       {"win_register_ipc_only", "1"},
+       {"win_register_multicast", "1"}});
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+  this->comm = commRaii.get();
+  ASSERT_NE(this->comm, nullptr);
+
+  if (comm->ctranComm_->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+
+  std::vector<TestMemSegment> winSegs;
+  void* winBase = testAllocBuf(totalBytes, kMemNcclMemAlloc, winSegs);
+  ASSERT_NE(winBase, nullptr);
+  // Mimic the CCA allocator hook so the window's acquireScopedRegister finds
+  // the buffer's segment cached.
+  NCCLCHECK_TEST(ncclGlobalRegisterWithPtr(winBase, totalBytes));
+  auto regGuard = folly::makeGuard([&]() {
+    NCCLCHECK_TEST(ncclGlobalDeregisterWithPtr(winBase, totalBytes));
+  });
+
+  ncclWindow_t win = nullptr;
+  ASSERT_EQ(
+      ncclCommWindowRegister(
+          comm, winBase, totalBytes, &win, NCCL_WIN_COLL_SYMMETRIC),
+      ncclSuccess);
+  ASSERT_NE(win, nullptr);
+  regGuard.dismiss();
+
+  // In-place layout required by ctwin: this rank's send chunk lives at its
+  // own offset within the recvbuf/window.
+  int* recvBuf = reinterpret_cast<int*>(winBase);
+  int* sendBuf = recvBuf + count * globalRank;
+
+  assignChunkValue(recvBuf, count * numRanks, -1);
+  assignChunkValue(sendBuf, count, globalRank + 1);
+
+  ASSERT_EQ(
+      ncclAllGather(sendBuf, recvBuf, count, ncclInt, comm, stream),
+      ncclSuccess);
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  for (int r = 0; r < numRanks; r++) {
+    int expectedVal = r + 1;
+    int errs = checkChunkValue(recvBuf + r * count, count, expectedVal);
+    EXPECT_EQ(errs, 0) << "rank " << globalRank << " checked chunk " << r
+                       << " at " << recvBuf + r * count << " with " << errs
+                       << " errors";
+  }
+
+  algoStats_.verify(comm, "AllGather", "CtranAllGatherP");
+
+  EXPECT_EQ(ncclCommWindowDeregister(comm, win), ncclSuccess);
+  NCCLCHECK_TEST(ncclGlobalDeregisterWithPtr(winBase, totalBytes));
+  testFreeBuf(winBase, totalBytes, kMemNcclMemAlloc);
+}
+
+// Standalone timed benchmark of ctwin AllGatherP over a symmetric window:
+// warmup, then a cudaEvent-timed loop of ncclAllGather, reporting busbw. Env
+// knobs (one binary covers the size sweep + MC-vs-unicast, no recompile):
+//   NCCLX_BENCH_BYTES     total recvbuf bytes (default 8 MiB)
+//   NCCLX_BENCH_ITERS     timed iterations (default 200)
+//   NCCLX_BENCH_WARMUP    warmup iterations (default 50)
+//   NCCLX_BENCH_MULTICAST "1" (default) sets win_register_multicast; "0" = the
+//                         ctwin-unicast control (isolates the multicast win)
+TEST_F(AllGatherCtwinTest, AllGatherCtwinPerf) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skip test";
+  }
+  auto envOr = [](const char* k, unsigned long long d) -> unsigned long long {
+    const char* v = getenv(k);
+    return (v != nullptr && *v != '\0') ? strtoull(v, nullptr, 10) : d;
+  };
+  const size_t totalBytes = envOr("NCCLX_BENCH_BYTES", 8ull << 20);
+  const int iters = static_cast<int>(envOr("NCCLX_BENCH_ITERS", 200));
+  const int warmup = static_cast<int>(envOr("NCCLX_BENCH_WARMUP", 50));
+  const char* mcEnv = getenv("NCCLX_BENCH_MULTICAST");
+  const std::string mc = (mcEnv != nullptr && *mcEnv != '\0') ? mcEnv : "1";
+  const size_t count = totalBytes / (numRanks * sizeof(int)); // per-rank chunk
+  ASSERT_GT(count, 0u);
+  const size_t winBytes = count * numRanks * sizeof(int);
+
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints(
+      {{"allgatherAlgo",
+        ncclx::algoconf::algoValToStr(NCCL_ALLGATHER_ALGO::ctwin)},
+       {"win_register_symmetric", "1"},
+       {"win_register_ipc_only", "1"},
+       {"win_register_multicast", mc}});
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+  this->comm = commRaii.get();
+  ASSERT_NE(this->comm, nullptr);
+  if (comm->ctranComm_->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+
+  std::vector<TestMemSegment> winSegs;
+  void* winBase = testAllocBuf(winBytes, kMemNcclMemAlloc, winSegs);
+  ASSERT_NE(winBase, nullptr);
+  NCCLCHECK_TEST(ncclGlobalRegisterWithPtr(winBase, winBytes));
+  auto regGuard = folly::makeGuard([&]() {
+    NCCLCHECK_TEST(ncclGlobalDeregisterWithPtr(winBase, winBytes));
+  });
+  ncclWindow_t win = nullptr;
+  ASSERT_EQ(
+      ncclCommWindowRegister(
+          comm, winBase, winBytes, &win, NCCL_WIN_COLL_SYMMETRIC),
+      ncclSuccess);
+  ASSERT_NE(win, nullptr);
+  regGuard.dismiss();
+
+  int* recvBuf = reinterpret_cast<int*>(winBase);
+  int* sendBuf = recvBuf + count * globalRank; // in-place layout ctwin requires
+  assignChunkValue(recvBuf, count * numRanks, -1);
+  assignChunkValue(sendBuf, count, globalRank + 1);
+
+  for (int i = 0; i < warmup; i++) {
+    ASSERT_EQ(
+        ncclAllGather(sendBuf, recvBuf, count, ncclInt, comm, stream),
+        ncclSuccess);
+  }
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  cudaEvent_t start, stop;
+  CUDACHECK_TEST(cudaEventCreate(&start));
+  CUDACHECK_TEST(cudaEventCreate(&stop));
+  CUDACHECK_TEST(cudaEventRecord(start, stream));
+  for (int i = 0; i < iters; i++) {
+    ASSERT_EQ(
+        ncclAllGather(sendBuf, recvBuf, count, ncclInt, comm, stream),
+        ncclSuccess);
+  }
+  CUDACHECK_TEST(cudaEventRecord(stop, stream));
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+  float ms = 0.f;
+  CUDACHECK_TEST(cudaEventElapsedTime(&ms, start, stop));
+
+  const double secPerIter = (ms / 1e3) / iters;
+  const double algbw = (double)winBytes / 1e9 / secPerIter; // GB/s
+  const double busbw = algbw * (double)(numRanks - 1) / (double)numRanks;
+
+  int errs = 0;
+  for (int r = 0; r < numRanks; r++) {
+    errs += checkChunkValue(recvBuf + r * count, count, r + 1);
+  }
+  EXPECT_EQ(errs, 0);
+
+  if (globalRank == 0) {
+    printf(
+        "# AGCTWIN-BENCH multicast=%s ranks=%d bytes=%zu iters=%d  time=%.2f us/op  algbw=%.2f GB/s  busbw=%.2f GB/s  errs=%d\n",
+        mc.c_str(),
+        numRanks,
+        winBytes,
+        iters,
+        secPerIter * 1e6,
+        algbw,
+        busbw,
+        errs);
+    fflush(stdout);
+  }
+  algoStats_.verify(comm, "AllGather", "CtranAllGatherP");
+
+  CUDACHECK_TEST(cudaEventDestroy(start));
+  CUDACHECK_TEST(cudaEventDestroy(stop));
+  EXPECT_EQ(ncclCommWindowDeregister(comm, win), ncclSuccess);
+  NCCLCHECK_TEST(ncclGlobalDeregisterWithPtr(winBase, winBytes));
+  testFreeBuf(winBase, winBytes, kMemNcclMemAlloc);
 }
 
 int main(int argc, char* argv[]) {

--- a/comms/ncclx/v2_29/src/dev_runtime.cc
+++ b/comms/ncclx/v2_29/src/dev_runtime.cc
@@ -1261,6 +1261,9 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
       NCCLCHECK(metaCommToNccl(winHints.set(
           "win_register_symmetric",
           NCCLX_CONFIG_FIELD(comm->config, winRegisterSymmetric) ? "1" : "0")));
+      NCCLCHECK(metaCommToNccl(winHints.set(
+          "win_register_multicast",
+          NCCLX_CONFIG_FIELD(comm->config, winRegisterMulticast) ? "1" : "0")));
       NCCLCHECK(metaCommToNccl(
           ctran::ctranWinRegister(
               buff,

--- a/comms/ncclx/v2_30/src/dev_runtime.cc
+++ b/comms/ncclx/v2_30/src/dev_runtime.cc
@@ -1497,6 +1497,9 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
       NCCLCHECK(metaCommToNccl(winHints.set(
           "win_register_symmetric",
           NCCLX_CONFIG_FIELD(comm->config, winRegisterSymmetric) ? "1" : "0")));
+      NCCLCHECK(metaCommToNccl(winHints.set(
+          "win_register_multicast",
+          NCCLX_CONFIG_FIELD(comm->config, winRegisterMulticast) ? "1" : "0")));
       NCCLCHECK(metaCommToNccl(
           ctran::ctranWinRegister(
               buff,


### PR DESCRIPTION
Summary:


Reworks NVL CE-multicast setup to live on the window/ctwin registration path
instead of the legacy AllGatherP mapper rendezvous, now that ctwin allgather is
landed + active (D112411735).

ctwin's `createPersistentRequestFromWindow` borrows the window's registration
and sets `initState=kInitialized`, so it never traverses
`exchangeIpcReg`/`intraAllGatherCtrl` -- the old fold-in setup would never fire
for ctwin. So:

- Setup: `CtranWin::exchange()` calls `mapper->setupMulticastOverlay(dataRegHdl,
  exchangeRanks)` after the handle exchange + barrier, gated by a new opt-in
  `win_register_multicast` hint (plus symmetric + cuMem-backed). Stores a
  self-owning `CtranMulticast` on the window's data registration.
- Consumption (mechanism unchanged): ctwin nLocalRanks>1 runs the AGP
  `execPipeline`/`execSRD` impls, whose `nvlCeBcast` fans out via
  `PersistArgs.mcWrite`. `createPersistentRequestFromWindow` populates `mcWrite`
  from the window overlay via `multicastWriteBase`.
- Removed the AGP-rendezvous setup: the `setupMulticast` flag threading through
  `allGatherCtrl`/`intraAllGatherCtrl`/`allGatherCtrlImpl`, the
  `NCCL_CTRAN_ALLGATHER_P_NVL_MULTICAST` cvar, and its 3 eager/graph AGP tests.
  The eager/graph AGP path stays unicast.
- ncclx plumbing: `win_register_multicast` hint -> `winRegisterMulticast` config
  field -> bridged into the ctran window hints in v2_29 + v2_30 dev_runtime,
  mirroring `win_register_symmetric`.

`setupMulticastOverlay` / `multicastWriteBase` are kept as reusable public
`CtranMapper` methods.
ghstack-source-id: 405473100
exported-using-ghexport

Differential Revision: D112761232


