### PR TITLE
Convert subdir suites to runtime nolocal; fix mapper intra skip guard

### DIFF
--- a/comms/ctran/mapper/tests/CtranDistMapperUT.cc
+++ b/comms/ctran/mapper/tests/CtranDistMapperUT.cc
@@ -641,6 +641,12 @@ TEST_F(CtranDistMapperTest, intraBarrier) {
 TEST_F(CtranDistMapperTest, intraBarrierWithCtrl) {
   auto mapper = comm_->ctran_->mapper.get();
   const auto& statex = comm_->statex_.get();
+
+  if (statex->nLocalRanks() < 2) {
+    GTEST_SKIP()
+        << "Test requires at least 2 localRanks on each node.  Skip test.";
+  }
+
   void* buf = nullptr;
   void* handle = nullptr;
   constexpr size_t bufSize = 8192;


### PR DESCRIPTION
Summary:
Complete the ctran nolocal/vnode test-infra migration for the remaining subdirectory dist-test suites, and fix a mapper intra-node test that failed once nolocal became effective.
- Converted the nolocal configs of `mapper/tests` (`ctran_dist_mapper_ut`, `ctran_dist_mapper_backend_ut`), `window/tests` (`ctran_win_tests`), `backends/ib/tests` (`ctran_ib_dist_ut`), `backends/socket/tests` (`ctran_socket_dist_ut`), `algos/AllToAll/fb/tests` (`ctran_dist_comp_alltoallv`), and `benchmarks` (`allgatherp_bench`) from the (ineffective) compile-time `-DNCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL` to runtime `envs`, preserving non-topo flags (init_none, socket/ib backend defines, conditional ENABLE_META_COMPRESSION). All these suites route topology through the shared `ctran_dist_test_utils` fixture, so the compile flag was a no-op. Pruned the now-unused `nolocal`/`nolocal_init_none` keys from `mapper/tests`' own `COMMOM_COMPILER_FLAGS` dict.
- Fixed a missing skip guard in `CtranDistMapperUT.cc` `intraBarrierWithCtrl`: it exchanges ctrl with the next/prev LOCAL rank, so at nLocalRanks==1 the peer degenerates to self and `ASSERT_TRUE(complete)` failed once nolocal became effective. Added the same `if (statex->nLocalRanks() < 2) GTEST_SKIP()` guard the other intra-node tests in the file already use.
- Note: `benchmarks/alltoallp_bench`'s `1x8_nolocal` uses a different macro (`A2AP_BENCH_NOLOCAL`, consumed in its own per-config TU) and was intentionally left unchanged.

Reviewed By: Regina8023

Differential Revision: D113181969


