### PR TITLE
Use local completion tickets for progress sendrecv

### DIFF
--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -1329,7 +1329,7 @@ TEST_F(
         cudaMemcpyDeviceToHost));
 
     const int64_t expectedReservation =
-        static_cast<int64_t>(dataBufferSize / numBlocks);
+        static_cast<int64_t>(dataBufferSize / numBlocks / pipelineDepth);
     EXPECT_EQ(output[0], expectedReservation);
     EXPECT_EQ(output[1], expectedReservation);
   } catch (const std::exception& e) {
@@ -1519,7 +1519,9 @@ TEST_F(
     DeviceBuffer sendBuffer(nbytes);
     DeviceBuffer recvBuffer(nbytes);
     DeviceBuffer errorCountBuf(sizeof(int));
+    DeviceBuffer waitingCountBuf(numBlocks * sizeof(uint64_t));
     auto* d_errorCount = static_cast<int*>(errorCountBuf.get());
+    auto* d_waitingCount = static_cast<uint64_t*>(waitingCountBuf.get());
 
     auto runDirection = [&](int senderRank, uint8_t pattern) {
       const bool isSender = globalRank == senderRank;
@@ -1529,6 +1531,8 @@ TEST_F(
       } else {
         CUDACHECK_TEST(cudaMemset(recvBuffer.get(), 0, nbytes));
       }
+      CUDACHECK_TEST(
+          cudaMemset(d_waitingCount, 0, numBlocks * sizeof(uint64_t)));
       CUDACHECK_TEST(cudaDeviceSynchronize());
       MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
@@ -1539,9 +1543,22 @@ TEST_F(
           maxSignalBytes,
           isSender,
           numBlocks,
-          blockSize);
+          blockSize,
+          d_waitingCount);
       CUDACHECK_TEST(cudaDeviceSynchronize());
       MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      if (isSender) {
+        uint64_t waitingCount = 0;
+        CUDACHECK_TEST(cudaMemcpy(
+            &waitingCount,
+            d_waitingCount,
+            sizeof(waitingCount),
+            cudaMemcpyDeviceToHost));
+        EXPECT_GT(waitingCount, 0)
+            << "progress send did not observe backpressure across staging "
+               "reuse";
+      }
 
       if (!isSender) {
         CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -432,22 +432,31 @@ __global__ void progressSendRecvKernel(
     void* buffer,
     std::size_t nbytes,
     std::size_t maxSignalBytes,
-    bool send) {
+    bool send,
+    uint64_t* waitingCount) {
   auto group = make_block_group();
   Timeout timeout(kDefaultDeviceTimeoutCycles);
   timeout.start();
+  uint64_t waits = 0;
   if (send) {
     transport->init_send_progress(group, nbytes, maxSignalBytes);
-    while (transport->progress_send_once(
-               group, buffer, nbytes, maxSignalBytes, timeout) !=
-           IbgdaSendRecvProgressStatus::Done) {
-    }
+    IbgdaSendRecvProgressStatus status;
+    do {
+      status = transport->progress_send_once(
+          group, buffer, nbytes, maxSignalBytes, timeout);
+      waits += status == IbgdaSendRecvProgressStatus::Waiting;
+    } while (status != IbgdaSendRecvProgressStatus::Done);
   } else {
     transport->init_recv_progress(group, nbytes, maxSignalBytes);
-    while (transport->progress_recv_once(
-               group, buffer, nbytes, maxSignalBytes, timeout) !=
-           IbgdaSendRecvProgressStatus::Done) {
-    }
+    IbgdaSendRecvProgressStatus status;
+    do {
+      status = transport->progress_recv_once(
+          group, buffer, nbytes, maxSignalBytes, timeout);
+      waits += status == IbgdaSendRecvProgressStatus::Waiting;
+    } while (status != IbgdaSendRecvProgressStatus::Done);
+  }
+  if (waitingCount != nullptr && group.is_leader()) {
+    waitingCount[group.group_id] = waits;
   }
 }
 
@@ -476,7 +485,8 @@ void testProgressSendRecv(
     std::size_t maxSignalBytes,
     bool send,
     int numBlocks,
-    int blockSize) {
+    int blockSize,
+    uint64_t* waitingCount) {
 #ifdef __HIP_PLATFORM_AMD__
   (void)transport;
   (void)buffer;
@@ -485,10 +495,11 @@ void testProgressSendRecv(
   (void)send;
   (void)numBlocks;
   (void)blockSize;
+  (void)waitingCount;
   throw std::runtime_error("progress send/recv is NVIDIA-only");
 #else
   progressSendRecvKernel<<<numBlocks, blockSize>>>(
-      transport, buffer, nbytes, maxSignalBytes, send);
+      transport, buffer, nbytes, maxSignalBytes, send, waitingCount);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
@@ -96,7 +96,8 @@ __global__ void progressSendRecvKernel(
     void* buffer,
     std::size_t nbytes,
     std::size_t maxSignalBytes,
-    bool send);
+    bool send,
+    uint64_t* waitingCount);
 
 __global__ void progressReservationKernel(
     P2pIbgdaTransportDevice* transport,

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -167,7 +167,8 @@ void testProgressSendRecv(
     std::size_t maxSignalBytes,
     bool send,
     int numBlocks,
-    int blockSize);
+    int blockSize,
+    uint64_t* waitingCount = nullptr);
 
 /**
  * Test kernel: initialize transport-owned send/recv progress state and report

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -71,16 +71,19 @@ namespace detail {
  * buffers. `dataOff` is the matching protocol offset into the caller's user
  * buffer. `bytes` never crosses a per-block staging partition or the
  * reserved protocol byte count. `streamEnd` is the absolute protocol byte
- * value after this chunk and is used as the DATA_READY, SLOT_FREE, and
- * NIC_DONE readiness threshold. `dataOff` is a protocol offset; callers mask
- * it against the payload byte count before invoking user-buffer copy
- * callbacks.
+ * value after this chunk and is used as the DATA_READY and SLOT_FREE readiness
+ * threshold. `slotId` and `pipelineGeneration` identify the local completion
+ * frontier that protects this staging range. `dataOff` is a protocol offset;
+ * callers mask it against the payload byte count before invoking user-buffer
+ * copy callbacks.
  */
 struct ProgressChunk {
   std::size_t stagingOff;
   std::size_t dataOff;
   std::size_t bytes;
   uint64_t streamEnd;
+  uint32_t slotId;
+  uint64_t pipelineGeneration;
 };
 
 /**
@@ -184,6 +187,30 @@ __device__ __forceinline__ ProgressChunk next_chunk(
     const IbChannelProgress& state,
     const ProgressGeometry& geometry);
 
+template <typename Transport>
+__device__ __forceinline__ bool try_prepare_send_slot(
+    Transport& transport,
+    ThreadGroup& group,
+    uint32_t slotId,
+    uint64_t generation,
+    const Timeout& timeout = Timeout());
+
+template <typename Transport>
+__device__ __forceinline__ void prepare_send_slot(
+    Transport& transport,
+    ThreadGroup& group,
+    uint32_t slotId,
+    uint64_t generation,
+    const Timeout& timeout = Timeout());
+
+template <typename Transport>
+__device__ __forceinline__ void record_send_completion(
+    Transport& transport,
+    uint32_t channelId,
+    uint32_t slotId,
+    uint64_t generation,
+    const IbLocalCompletionTicket& ticket);
+
 /**
  * Transport-agnostic pipelined RDMA send/recv helpers.
  *
@@ -198,10 +225,8 @@ __device__ __forceinline__ ProgressChunk next_chunk(
  * `P2pIbrcTransportDevice` own the channel layout/state and use these helpers
  * only for the shared send/recv algorithm.
  *
- * Blocking send/forward use put() completion tickets for local staging reuse.
- * The resumable progress APIs retain counter completion for now. Until they
- * migrate in a follow-up, callers must not mix blocking and progress sends on
- * the same channel because their local-completion streams are independent.
+ * Blocking and resumable send/forward use the same put() completion-ticket
+ * stream for local staging reuse.
  */
 /**
  * Initialize transport-owned state for one pipelined send operation.
@@ -242,7 +267,7 @@ __device__ __forceinline__ void init_send_progress(
   IbChannelProgress state{};
   state.activeStage = nbytes == 0
       ? detail::IbSendRecvProgressStage::Done
-      : detail::IbSendRecvProgressStage::WaitNicDone;
+      : detail::IbSendRecvProgressStage::WaitLocalCompletion;
   if (nbytes == 0) {
     store_progress_state(group, slot, state);
     return;
@@ -319,18 +344,19 @@ __device__ __forceinline__ void init_recv_progress(
  * Attempt bounded progress on one initialized send.
  *
  * This method advances at most one staged copy plus one RDMA put for the
- * current chunk. It never spins on NIC_DONE or SLOT_FREE: if either
+ * current chunk. It never spins on local completion or SLOT_FREE: if either
  * dependency is not ready, it returns immediately so a higher-level scheduler
  * can try another independent lane. If a `Timeout` is enabled, it is checked
  * only at those readiness points and should already have been started by the
  * caller.
  *
- * The send path first waits for NIC_DONE before reusing the local
+ * The send path first checks local completion before reusing the local
  * send-staging range, then copies user data into send-staging through
  * `CopyOp::send`, waits for SLOT_FREE before reusing the peer's recv-staging
- * range, and finally issues an RDMA put that piggybacks DATA_READY and posts
- * NIC_DONE per chunk into the local counter. Returning `Done` means the
- * reserved byte range has completed.
+ * range, and finally issues an RDMA put that piggybacks DATA_READY and records
+ * the returned completion ticket per chunk. Returning `Done` means
+ * the reserved byte range has been posted; later slot reuse waits for local
+ * completion.
  *
  * `CopyOp` must expose `send(dst, src, bytes, group, dataOffset, args...)`.
  * The default `Memcpy` copies bytes cooperatively across the supplied
@@ -387,40 +413,20 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
   IbLocalChannel& localChannel =
       transport.local_channel(static_cast<uint32_t>(progress_params.groupId));
   const IbgdaLocalBuffer localSlotFree = localChannel.slotFree;
-  const IbgdaLocalBuffer localNicDoneWait = localChannel.nicDoneWait;
-  const IbgdaLocalBuffer localNicDoneCompletion =
-      localChannel.nicDoneCompletion;
   const IbRemoteChannel remoteChannel =
       makeIbRemoteChannel(channelLayout, progress_params.groupId);
 
-  if (state.activeStage == detail::IbSendRecvProgressStage::WaitNicDone) {
+  if (state.activeStage ==
+      detail::IbSendRecvProgressStage::WaitLocalCompletion) {
     const ProgressChunk chunk =
         next_chunk(channelLayout, state, progress_params);
-    const bool isFinalChunk =
-        chunk.dataOff + chunk.bytes >= progress_params.protocolBytes;
-    const uint64_t protocolStreamEnd =
-        chunk.streamEnd + (isFinalChunk ? state.activeTailPadding : 0);
-    if (protocolStreamEnd > pipelineBytes) {
-      const uint64_t expected = protocolStreamEnd - pipelineBytes;
-      uint32_t ready = 1;
-      unsigned long long current = 0;
-      if (group.is_leader()) {
-        current = static_cast<unsigned long long>(
-            transport.read_counter(localNicDoneWait));
-        ready = current >= expected ? 1U : 0U;
-        if (!ready) {
-          TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
-              timeout,
-              "progress_send_once waiting for NIC_DONE expected>=%llu, "
-              "current=%llu",
-              static_cast<unsigned long long>(expected),
-              current);
-        }
-      }
-      ready = group.broadcast<uint32_t>(ready);
-      if (!ready) {
-        return IbgdaSendRecvProgressStatus::Waiting;
-      }
+    if (!try_prepare_send_slot(
+            transport,
+            group,
+            chunk.slotId,
+            chunk.pipelineGeneration,
+            timeout)) {
+      return IbgdaSendRecvProgressStatus::Waiting;
     }
 
     const std::size_t validBytes = valid_payload_bytes(
@@ -481,16 +487,22 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
           0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
       const std::size_t protocolBytesThis =
           chunk.bytes + (isFinalChunk ? state.activeTailPadding : 0);
-      transport.put(
+      const auto completion = transport.put(
           solo,
           channelLayout.sendStagingBuf.subBuffer(chunk.stagingOff),
           remoteChannel.recvStaging.subBuffer(chunk.stagingOff),
           chunk.bytes,
           remoteChannel.dataReady,
           protocolBytesThis,
-          localNicDoneCompletion,
-          protocolBytesThis,
+          /*counterBuf=*/{},
+          /*counterVal=*/0,
           /*signalPerLane=*/true);
+      record_send_completion(
+          transport,
+          static_cast<uint32_t>(progress_params.groupId),
+          chunk.slotId,
+          chunk.pipelineGeneration,
+          completion);
     }
     group.sync();
 
@@ -502,11 +514,11 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
       return IbgdaSendRecvProgressStatus::Done;
     }
     transition_progress_stage(
-        group, state, detail::IbSendRecvProgressStage::WaitNicDone);
+        group, state, detail::IbSendRecvProgressStage::WaitLocalCompletion);
   }
 
-  // A full non-final chunk can cycle WaitNicDone -> WaitSlotFree ->
-  // WaitNicDone in one call, leaving the stage unchanged while nextByte
+  // A full non-final chunk can cycle WaitLocalCompletion -> WaitSlotFree ->
+  // WaitLocalCompletion in one call, leaving the stage unchanged while nextByte
   // advances. Check both fields so that case reports Progressed.
   if (state.activeStage != initialStage ||
       state.activeNextByte != initialNextByte) {
@@ -901,7 +913,7 @@ __device__ __forceinline__ void send(
     const uint64_t pipelineCycle = streamStart / pipelineBytes;
 
     // (1) Wait for NIC to finish with this slot's local sendStaging.
-    transport.prepare_send_slot(group, slot, pipelineCycle, timeout);
+    prepare_send_slot(transport, group, slot, pipelineCycle, timeout);
 
     // (2) Cooperative copy: src -> local sendStaging via CopyOp.
     const std::size_t validBytes =
@@ -941,8 +953,12 @@ __device__ __forceinline__ void send(
           /*counterBuf=*/{},
           /*counterVal=*/0,
           /*signalPerLane=*/true);
-      transport.record_send_completion(
-          static_cast<uint32_t>(groupId), slot, pipelineCycle, completion);
+      record_send_completion(
+          transport,
+          static_cast<uint32_t>(groupId),
+          slot,
+          pipelineCycle,
+          completion);
     }
     group.sync();
     dataOff += bytesThis;
@@ -1347,7 +1363,7 @@ __device__ __forceinline__ void forward(
         timeout);
 
     // (2) Wait for local completion on fwd's sendStaging.
-    fwdTransport.prepare_send_slot(group, fwdSlot, fwdPipelineCycle, timeout);
+    prepare_send_slot(fwdTransport, group, fwdSlot, fwdPipelineCycle, timeout);
 
     // (3) CopyOp::forward — transform recv staging -> dst + fwd staging.
     const std::size_t validBytes =
@@ -1393,7 +1409,8 @@ __device__ __forceinline__ void forward(
           /*counterBuf=*/{},
           /*counterVal=*/0,
           /*signalPerLane=*/true);
-      fwdTransport.record_send_completion(
+      record_send_completion(
+          fwdTransport,
           static_cast<uint32_t>(groupId),
           fwdSlot,
           fwdPipelineCycle,
@@ -1484,9 +1501,9 @@ __device__ __forceinline__ static std::size_t signal_alignment(
  * Pad the current operation's protocol byte stream to the signaling boundary.
  *
  * Padding is credit-only: payload copies and RDMA writes still cover only
- * aligned payload protocol bytes. The final DATA_READY/NIC_DONE/SLOT_FREE
- * update carries this tail padding so the next operation starts on an aligned
- * protocol cursor without needing a future recv to publish padding credit.
+ * aligned payload protocol bytes. The final DATA_READY/SLOT_FREE update carries
+ * this tail padding so the next operation starts on an aligned protocol cursor
+ * without needing a future recv to publish padding credit.
  */
 __device__ __forceinline__ static std::size_t
 tail_padding_for_signal_granularity(
@@ -1763,7 +1780,8 @@ __device__ __forceinline__ void validate_send_progress_stage(
     ThreadGroup& group,
     const IbChannelProgress& state) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-  if (state.activeStage != detail::IbSendRecvProgressStage::WaitNicDone &&
+  if (state.activeStage !=
+          detail::IbSendRecvProgressStage::WaitLocalCompletion &&
       state.activeStage != detail::IbSendRecvProgressStage::WaitSlotFree &&
       state.activeStage != detail::IbSendRecvProgressStage::Done) {
     if (group.is_leader()) {
@@ -1805,10 +1823,10 @@ __device__ __forceinline__ bool is_valid_progress_transition(
     detail::IbSendRecvProgressStage current,
     detail::IbSendRecvProgressStage next) {
   switch (current) {
-    case detail::IbSendRecvProgressStage::WaitNicDone:
+    case detail::IbSendRecvProgressStage::WaitLocalCompletion:
       return next == detail::IbSendRecvProgressStage::WaitSlotFree;
     case detail::IbSendRecvProgressStage::WaitSlotFree:
-      return next == detail::IbSendRecvProgressStage::WaitNicDone ||
+      return next == detail::IbSendRecvProgressStage::WaitLocalCompletion ||
           next == detail::IbSendRecvProgressStage::Done;
     case detail::IbSendRecvProgressStage::WaitDataReady:
       return next == detail::IbSendRecvProgressStage::Done;
@@ -1888,7 +1906,117 @@ __device__ __forceinline__ ProgressChunk next_chunk(
       .dataOff = payloadNextByte,
       .bytes = bytes,
       .streamEnd = streamStart + bytes,
+      .slotId = static_cast<uint32_t>(slot),
+      .pipelineGeneration = streamStart / pipelineBytes,
   };
+}
+
+template <typename Transport>
+__device__ __forceinline__ bool try_prepare_send_slot(
+    Transport& transport,
+    ThreadGroup& group,
+    uint32_t slotId,
+    uint64_t generation,
+    const Timeout& timeout) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  uint32_t ready = 1;
+  if (group.is_leader()) {
+    auto& slot =
+        transport.local_channel(group.group_id).sendCompletionSlots[slotId];
+    if (slot.generation != generation) {
+      uint64_t pending = slot.laneMask;
+      const uint32_t numLanes = transport.send_completion_lane_count();
+      for (uint32_t laneId = 0; laneId < numLanes; ++laneId) {
+        const uint64_t laneBit = 1ULL << laneId;
+        if ((pending & laneBit) == 0) {
+          continue;
+        }
+        const IbLocalCompletionTicket ticket{
+            .completionId = laneId,
+            .value = slot.values[laneId],
+        };
+        if (transport.is_local_completion_ready(group.group_id, ticket)) {
+          pending &= ~laneBit;
+        }
+      }
+      slot.laneMask = pending;
+      if (pending == 0) {
+        slot.generation = generation;
+      } else {
+        ready = 0;
+        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+            timeout,
+            "send slot local completion timed out slot=%u generation=%llu "
+            "pending=0x%llx",
+            slotId,
+            static_cast<unsigned long long>(generation),
+            static_cast<unsigned long long>(pending));
+      }
+    }
+  }
+  ready = group.broadcast<uint32_t>(ready);
+  return ready != 0;
+#else
+  (void)transport;
+  (void)group;
+  (void)slotId;
+  (void)generation;
+  (void)timeout;
+  return true;
+#endif
+}
+
+template <typename Transport>
+__device__ __forceinline__ void prepare_send_slot(
+    Transport& transport,
+    ThreadGroup& group,
+    uint32_t slotId,
+    uint64_t generation,
+    const Timeout& timeout) {
+  if (group.is_leader()) {
+    auto& slot =
+        transport.local_channel(group.group_id).sendCompletionSlots[slotId];
+    if (slot.generation != generation) {
+      const uint64_t pending = slot.laneMask;
+      const uint32_t numLanes = transport.send_completion_lane_count();
+      for (uint32_t laneId = 0; laneId < numLanes; ++laneId) {
+        if ((pending & (1ULL << laneId)) == 0) {
+          continue;
+        }
+        transport.wait_local_completion(
+            group.group_id,
+            IbLocalCompletionTicket{
+                .completionId = laneId,
+                .value = slot.values[laneId],
+            },
+            timeout);
+      }
+      slot.laneMask = 0;
+      slot.generation = generation;
+    }
+  }
+  group.sync();
+}
+
+template <typename Transport>
+__device__ __forceinline__ void record_send_completion(
+    Transport& transport,
+    uint32_t channelId,
+    uint32_t slotId,
+    uint64_t generation,
+    const IbLocalCompletionTicket& ticket) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  auto& slot = transport.local_channel(channelId).sendCompletionSlots[slotId];
+  slot.generation = generation;
+  slot.values[ticket.completionId] = ticket.value;
+  slot.laneMask |= 1ULL << ticket.completionId;
+#else
+  (void)transport;
+  (void)channelId;
+  (void)slotId;
+  (void)generation;
+  (void)ticket;
+#endif
 }
 } // namespace detail
 

--- a/comms/prims/transport/ibgda/IbgdaBuffer.h
+++ b/comms/prims/transport/ibgda/IbgdaBuffer.h
@@ -426,13 +426,13 @@ namespace detail {
  * Internal stage for one transport-owned resumable send/recv operation.
  *
  * `Done` is intentionally zero so freshly zeroed transport memory starts idle.
- * Send operations use `WaitNicDone` and `WaitSlotFree`; recv operations use
- * `WaitDataReady`. Blocking send/recv temporarily use `Busy` to make
- * same-direction overlap fail explicitly instead of sharing a cursor.
+ * Send operations use `WaitLocalCompletion` and `WaitSlotFree`; recv
+ * operations use `WaitDataReady`. Blocking send/recv temporarily use `Busy` to
+ * make same-direction overlap fail explicitly instead of sharing a cursor.
  */
 enum class IbSendRecvProgressStage : uint8_t {
   Done,
-  WaitNicDone,
+  WaitLocalCompletion,
   WaitSlotFree,
   WaitDataReady,
   Busy,

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -681,40 +681,41 @@ class P2pIbgdaTransportDevice {
     group.sync();
   }
 
-  __device__ void prepare_send_slot(
-      ThreadGroup& group,
-      uint32_t slotId,
-      uint64_t generation,
-      const Timeout& timeout = Timeout()) {
-    if (group.is_leader()) {
-      auto& slot = localChannels_[group.group_id].sendCompletionSlots[slotId];
-      if (slot.generation != generation) {
-        const uint64_t laneMask = slot.laneMask;
-        const uint32_t numLanes = num_qp_lanes();
-        for (uint32_t laneId = 0; laneId < numLanes; ++laneId) {
-          if ((laneMask & (1ULL << laneId)) == 0) {
-            continue;
-          }
-          IbgdaLane lane =
-              lane_from_ordinal(group.group_id, IbDirection::Send, laneId);
-          wait_local_on_qp(lane.qp, slot.values[laneId], timeout);
-        }
-        slot.laneMask = 0;
-        slot.generation = generation;
-      }
+  __device__ __forceinline__ bool is_local_completion_ready(
+      uint32_t channelId,
+      const IbLocalCompletionTicket& ticket) {
+    IbgdaLane lane =
+        lane_from_ordinal(channelId, IbDirection::Send, ticket.completionId);
+    const int status = doca_gpu_dev_verbs_poll_one_cq_at<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+        doca_gpu_dev_verbs_qp_get_cq_sq(lane.qp), ticket.value);
+    if (status == 0) {
+      return true;
     }
-    group.sync();
+    if (status == EBUSY) {
+      return false;
+    }
+    printf(
+        "P2pIbgdaTransportDevice: local completion failed lane=%u "
+        "ticket=%llu status=%d\n",
+        ticket.completionId,
+        static_cast<unsigned long long>(ticket.value),
+        status);
+    PIPES_DEVICE_TRAP();
+    return false;
   }
 
-  __device__ __forceinline__ void record_send_completion(
+  __device__ __forceinline__ void wait_local_completion(
       uint32_t channelId,
-      uint32_t slotId,
-      uint64_t generation,
-      const IbLocalCompletionTicket& ticket) {
-    auto& slot = localChannels_[channelId].sendCompletionSlots[slotId];
-    slot.generation = generation;
-    slot.values[ticket.completionId] = ticket.value;
-    slot.laneMask |= 1ULL << ticket.completionId;
+      const IbLocalCompletionTicket& ticket,
+      const Timeout& timeout) {
+    IbgdaLane lane =
+        lane_from_ordinal(channelId, IbDirection::Send, ticket.completionId);
+    wait_local_on_qp(lane.qp, ticket.value, timeout);
+  }
+
+  __device__ __forceinline__ uint32_t send_completion_lane_count() const {
+    return num_qp_lanes();
   }
 
   /** wait_counter (thread-scope) - Single-thread variant. */
@@ -1989,15 +1990,16 @@ class P2pIbgdaTransportDevice {
    *
    * Sender chunk state machine:
    *
-   *   WaitNicDone
+   *   WaitLocalCompletion
    *        |
    *        | local sendStaging is reusable; copy user src -> sendStaging
    *        v
    *   WaitSlotFree
    *        |
-   *        | remote recvStaging is reusable; RDMA put + DATA_READY + NIC_DONE
+   *        | remote recvStaging is reusable; RDMA put + DATA_READY
    *        v
-   *   Done for this chunk, then either WaitNicDone for next chunk or Done
+   *   Done for this chunk, then either WaitLocalCompletion for next chunk or
+   *   Done
    *
    * Receiver chunk state machine:
    *

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -393,52 +393,38 @@ class P2pIbrcTransportDevice {
     group.sync();
   }
 
-  __device__ void prepare_send_slot(
-      ThreadGroup& group,
-      uint32_t slotId,
-      uint64_t generation,
-      const Timeout& timeout = Timeout()) const {
-    if (group.is_leader()) {
-      auto& slot = localChannels_[group.group_id].sendCompletionSlots[slotId];
-      if (slot.generation != generation) {
-        const uint64_t laneMask = slot.laneMask;
-        const uint32_t lanes = num_qp_lanes();
-        for (uint32_t lane = 0; lane < lanes; ++lane) {
-          if ((laneMask & (1ULL << lane)) == 0) {
-            continue;
-          }
-          const auto& queue = cmdQueues[queue_for_lane(
-              group.group_id, IbDirection::Send, lane)];
-          while (static_cast<int64_t>(
-                     load_acquire_system_u64(queue.ci) - slot.values[lane]) <
-                 0) {
-            check_status(queue);
-            if (timeout.checkExpired()) {
-              printf(
-                  "P2pIbrcTransportDevice: send slot wait timed out lane=%u "
-                  "expected=%llu\n",
-                  lane,
-                  static_cast<unsigned long long>(slot.values[lane]));
-              PIPES_DEVICE_TRAP();
-            }
-          }
-        }
-        slot.laneMask = 0;
-        slot.generation = generation;
-      }
-    }
-    group.sync();
+  __device__ __forceinline__ bool is_local_completion_ready(
+      uint32_t channelId,
+      const IbLocalCompletionTicket& ticket) const {
+    const auto& queue = cmdQueues[queue_for_lane(
+        channelId, IbDirection::Send, ticket.completionId)];
+    check_status(queue);
+    return static_cast<int64_t>(
+               load_acquire_system_u64(queue.ci) - ticket.value) >= 0;
   }
 
-  __device__ __forceinline__ void record_send_completion(
+  __device__ __forceinline__ void wait_local_completion(
       uint32_t channelId,
-      uint32_t slotId,
-      uint64_t generation,
-      const IbLocalCompletionTicket& ticket) const {
-    auto& slot = localChannels_[channelId].sendCompletionSlots[slotId];
-    slot.generation = generation;
-    slot.values[ticket.completionId] = ticket.value;
-    slot.laneMask |= 1ULL << ticket.completionId;
+      const IbLocalCompletionTicket& ticket,
+      const Timeout& timeout) const {
+    const auto& queue = cmdQueues[queue_for_lane(
+        channelId, IbDirection::Send, ticket.completionId)];
+    while (static_cast<int64_t>(
+               load_acquire_system_u64(queue.ci) - ticket.value) < 0) {
+      check_status(queue);
+      if (timeout.checkExpired()) {
+        printf(
+            "P2pIbrcTransportDevice: local completion timed out lane=%u "
+            "expected=%llu\n",
+            ticket.completionId,
+            static_cast<unsigned long long>(ticket.value));
+        PIPES_DEVICE_TRAP();
+      }
+    }
+  }
+
+  __device__ __forceinline__ uint32_t send_completion_lane_count() const {
+    return num_qp_lanes();
   }
 
   __device__ void put_cooperative(


### PR DESCRIPTION
Summary:
Migrate resumable send/recv staging reuse from channel `NIC_DONE` counters to the same per-slot local-completion tickets used by blocking send/recv. Share generation and per-lane completion bookkeeping between blocking and progress paths while keeping backend-specific CQ/CI polling inside IBGDA and IBRC. Progress performs one bounded readiness scan and returns `Waiting` instead of spinning.

Add progress coverage across staging-slot wrap, validate retry behavior and payload integrity in both directions, and correct the progress reservation expectation to the per-pipeline-slot size.

Reviewed By: saifhhasan

Differential Revision: D113302268


