### PR TITLE
Combine redundant allRankSizes sizing in window.cc

### DIFF
--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -253,11 +253,12 @@ commResult_t CtranWin::exchange() {
   // allGather round-trip; otherwise gather each rank's size.
   // FIXME(ctwin): confirm whether this size allGather is needed at all for the
   // non-symmetric path (added in D87390033).
-  std::vector<size_t> allRankSizes(nRanks);
+  std::vector<size_t> allRankSizes;
   if (isSymmetric()) {
     allRankSizes.assign(nRanks, dataBytes);
   } else {
     CtranMapperTimer sizeAllGatherTimer;
+    allRankSizes.resize(nRanks);
     allRankSizes[myRank] = dataBytes;
     auto resFuture = comm->bootstrap_->allGather(
         allRankSizes.data(), sizeof(size_t), myRank, nRanks);


### PR DESCRIPTION
Summary:
Eliminate a redundant vector resize in the window registration size-exchange path:
- `allRankSizes` was constructed with `std::vector<size_t> allRankSizes(nRanks)` (sizing + zero-init to `nRanks`), and the symmetric branch then called `.assign(nRanks, dataBytes)`, re-sizing and re-filling the whole vector a second time.
- Declare the vector empty and size it exactly once per branch: the symmetric path sizes via `.assign(nRanks, dataBytes)`, and the non-symmetric path sizes via `.resize(nRanks)` before indexing and the bootstrap allGather.
- Pure cleanup; no behavioral change.

Differential Revision: D113336157


