### PR TITLE
Add ctwin window-aware AllToAll algorithm (#3250)

### DIFF
--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -126,7 +126,8 @@ bool ctranAllToAllSupport(
     commDataType_t datatype,
     CtranComm* comm,
     enum NCCL_ALLTOALL_ALGO algo,
-    cudaStream_t stream = nullptr);
+    cudaStream_t stream = nullptr,
+    void* recvbuff = nullptr);
 
 commResult_t ctranAllToAll(
     const void* sendbuff,

--- a/comms/ctran/algos/AllToAll/AllToAll.cc
+++ b/comms/ctran/algos/AllToAll/AllToAll.cc
@@ -150,6 +150,14 @@ commResult_t ctranAllToAll(
         allToAllAlgoName(algo));
   }
 
+  // Window-aware persistent path: the recvbuff lives in a registered symmetric
+  // window; reuse (or lazily build) a window-cached persistent AllToAllP
+  // request. Capture-safe without being a graph-aware algo.
+  if (algo == NCCL_ALLTOALL_ALGO::ctwin) {
+    return ctranAllToAllCtwin(
+        sendbuff, recvbuff, count, datatype, comm, stream, algo);
+  }
+
   // TODO: alltoallKerns perform poorly on HCM due to lack of NVL connection
   // between some GPUs We need detect topology and switch to use IB transport in
   // such a case
@@ -182,7 +190,8 @@ bool ctranAllToAllSupport(
     commDataType_t datatype,
     CtranComm* comm,
     enum NCCL_ALLTOALL_ALGO algo,
-    cudaStream_t stream) {
+    cudaStream_t stream,
+    void* recvbuff) {
   // Currently there is only one ctran algo for alltoall, but we pass algo as a
   // parameter for future extension and consistency across collectives.
   // Currently just return false if algo is set to orig
@@ -191,6 +200,14 @@ bool ctranAllToAllSupport(
   }
 
   const auto statex = comm->statex_.get();
+
+  // Window-aware persistent algo: recvbuff must sit in a symmetric AllToAllP
+  // window. Dormant (false) until a caller passes recvbuff.
+  if (algo == NCCL_ALLTOALL_ALGO::ctwin) {
+    const size_t recvBytes = count * statex->nRanks() * commTypeSize(datatype);
+    return checkCtranAllToAllCtwinSupport(
+        comm, recvbuff, recvBytes, algo, nullptr);
+  }
 
   // Cudagraph-aware algo requires an active CUDA graph capture on the stream.
   if (isGraphAwareAlgo(algo)) {

--- a/comms/ctran/algos/AllToAll/AllToAllCtwin.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllCtwin.cc
@@ -1,0 +1,206 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllToAll/AllToAllImpl.h"
+#include "comms/ctran/algos/AllToAll/AllToAllPImpl.h"
+#include "comms/ctran/algos/AllToAll/AllToAllvImpl.h"
+#include "comms/ctran/algos/AllToAll/HostTypes.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/algos/PersistentCleanup.h"
+#include "comms/ctran/mapper/CtranMapperTypes.h"
+#include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/window/CtranWin.h"
+#include "comms/utils/commSpecs.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/LogUtils.h"
+
+using ctran::alltoallp::AlgoImpl;
+using ctran::alltoallp::destroyPersistentRequest;
+using ctran::alltoallp::InitState;
+
+namespace {
+
+// Build a persistent AllToAllP request that BORROWS the window's registration
+// + NVL/IPC state instead of running AllToAllP's own IPC exchange. The window
+// owns and frees that state; this request's teardown only releases the
+// AllToAllP-owned resources.
+commResult_t createPersistentRequestFromWindow(
+    CtranComm* comm,
+    cudaStream_t stream,
+    ctran::CtranWin* win,
+    void* recvbuff,
+    const size_t count,
+    const commDataType_t datatype,
+    const size_t offset,
+    CtranPersistentRequest** out) {
+  *out = nullptr;
+  const auto nRanks = comm->statex_->nRanks();
+  const size_t maxRecvCount = count * nRanks;
+
+  // AllToAllP's AlgoImpl has no pooled resource init; construct it and fill
+  // pArgs directly from the window.
+  auto algo = std::make_unique<AlgoImpl>(comm, stream);
+
+  auto& pArgs = algo->pArgs;
+  pArgs.recvbuff = recvbuff;
+  pArgs.maxRecvCount = maxRecvCount;
+  pArgs.datatype = datatype;
+  // Borrow the window's local data registration; leave recvRegHdl null so
+  // teardown does not release the window-owned registration.
+  pArgs.recvHdl = win->dataRegHdl;
+  pArgs.skipCtrlMsg = false;
+
+  // Borrow peer recv buffers + access keys from the symmetric window.
+  // remoteIpcRegHdls stays empty (the NVL imports are owned by the window).
+  pArgs.remoteRecvBuffs.assign(nRanks, nullptr);
+  pArgs.remoteAccessKeys.clear();
+  pArgs.remoteAccessKeys.reserve(nRanks);
+  for (int r = 0; r < nRanks; r++) {
+    const auto& info = win->remWinInfo[r];
+    if (info.dataAddr != nullptr) {
+      // Peer r's window buffer base at the same window offset. exec adds this
+      // rank's own recv-slot offset internally (see ctranAllToAllPIbImpl).
+      pArgs.remoteRecvBuffs[r] = reinterpret_cast<void*>(
+          reinterpret_cast<uintptr_t>(info.dataAddr) + offset);
+    }
+    pArgs.remoteAccessKeys.push_back(info.dataRkey);
+  }
+
+  // NVL/IPC already exchanged by the window.
+  pArgs.initState = InitState::kInitialized;
+  // An ipc_only window has not exchanged inter-node IB rkeys yet, so let the
+  // first exec do it (as AllToAllP does). A full-exchange window already
+  // carries IB rkeys in remWinInfo, so skip that first-exec exchange.
+  pArgs.ibKeysExchanged = !win->isIpcOnly();
+
+  auto request = std::make_unique<CtranPersistentRequest>(
+      CtranPersistentRequest::Type::ALLTOALL_P, comm, stream);
+  request->algo = algo.release();
+  // Return request ownership to the window.
+  *out = request.release();
+
+  // Route teardown through a one-shot cleanup token (see PersistentCleanup.h):
+  // it releases only AllToAllP-owned resources; the borrowed window state is
+  // released later by the window's free().
+  auto cleanup = std::make_shared<PersistentCleanup>([request = *out]() {
+    FB_COMMCHECKIGNORE(destroyPersistentRequest(request));
+  });
+  (*out)->cleanup_ = cleanup;
+  // The token can fire from TWO sites: (a) the window's free() -- the primary
+  // path, which runs the token, unregisters it, and deletes the request; and
+  // (b) the comm's drainPersistentCleanups() at comm destroy -- a safety net if
+  // the window outlives its free(). The token is idempotent (call_once), so
+  // there is no double cleanup.
+  comm->registerPersistentCleanup(cleanup);
+  return commSuccess;
+}
+
+} // namespace
+
+bool checkCtranAllToAllCtwinSupport(
+    CtranComm* comm,
+    const void* recvbuff,
+    const size_t recvBytes,
+    const enum NCCL_ALLTOALL_ALGO algo,
+    ctran::CtranWin** winOut) {
+  if (winOut != nullptr) {
+    *winOut = nullptr;
+  }
+  // Dormant until a caller passes a non-empty recvbuff.
+  if (recvbuff == nullptr || recvBytes == 0) {
+    CLOGF_SUBSYS(
+        INFO,
+        COLL,
+        "AllToAll {} unsupported: needs a non-empty recvbuff (recvbuff={}, recvBytes={}).",
+        allToAllAlgoName(algo),
+        recvbuff,
+        recvBytes);
+    return false;
+  }
+  // Need a symmetric AllToAllP window covering the full recv range (exec
+  // computes each peer's recvbuf as its window buffer at the same offset).
+  auto* win = comm->findWindowForBuffer(recvbuff, recvBytes);
+  if (win == nullptr || !win->isSymmetric() || !ctran::AllToAllPSupport(comm)) {
+    CLOGF_SUBSYS(
+        INFO,
+        COLL,
+        "AllToAll {} unsupported: recvbuff {} ({} bytes) is not covered by a symmetric AllToAllP window.",
+        allToAllAlgoName(algo),
+        recvbuff,
+        recvBytes);
+    return false;
+  }
+  if (winOut != nullptr) {
+    *winOut = win;
+  }
+  return true;
+}
+
+commResult_t ctranAllToAllCtwin(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream,
+    enum NCCL_ALLTOALL_ALGO algo) {
+  // The persistent request is WINDOW-owned (cached in persistentReqs_, freed at
+  // window free()).
+  // LIFETIME CONTRACT: the window (and its cached request) MUST outlive any
+  // CUDA graph that captured a ctwin alltoall over it.
+  const auto nRanks = comm->statex_->nRanks();
+  const size_t typeSize = commTypeSize(datatype);
+  const size_t recvBytes = count * nRanks * typeSize;
+
+  ctran::CtranWin* win = nullptr;
+  if (!checkCtranAllToAllCtwinSupport(comm, recvbuff, recvBytes, algo, &win)) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "AllToAll {}: unsupported for recvbuff {} (len {} bytes) -- needs a "
+        "symmetric AllToAllP window.",
+        allToAllAlgoName(algo),
+        recvbuff,
+        recvBytes);
+  }
+
+  const size_t offset = reinterpret_cast<uintptr_t>(recvbuff) -
+      reinterpret_cast<uintptr_t>(win->winDataPtr);
+
+  // Log the resolved window id so a rank-divergent window pick (all ranks must
+  // resolve a buffer to the same window) is debuggable.
+  CLOGF_SUBSYS(
+      INFO,
+      COLL,
+      "AllToAll ctwin: rank {} resolved recvbuff {} ({} bytes, offset {}) to window id {}",
+      comm->statex_->rank(),
+      recvbuff,
+      recvBytes,
+      offset,
+      win->id());
+
+  // Reuse (or lazily build) the persistent request cached on the window, keyed
+  // by <offset, len, stream> so a request is reused only for sequential
+  // collectives with the same stream.
+  commResult_t createRes = commSuccess;
+  auto* request = win->getOrCreatePersistentRequest(
+      offset, recvBytes, stream, [&]() -> CtranPersistentRequest* {
+        CtranPersistentRequest* req = nullptr;
+        createRes = createPersistentRequestFromWindow(
+            comm, stream, win, recvbuff, count, datatype, offset, &req);
+        return createRes == commSuccess ? req : nullptr;
+      });
+  FB_COMMCHECK(createRes);
+  if (request == nullptr) {
+    FB_ERRORRETURN(
+        commInternalError,
+        "AllToAll ctwin: failed to obtain a persistent request for recvbuff {}.",
+        recvbuff);
+  }
+
+  return ctran::AllToAllPExec(sendbuff, count, request);
+}

--- a/comms/ctran/algos/AllToAll/AllToAllImpl.h
+++ b/comms/ctran/algos/AllToAll/AllToAllImpl.h
@@ -4,6 +4,10 @@
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/gpe/CtranGpe.h"
 
+namespace ctran {
+struct CtranWin;
+} // namespace ctran
+
 // Cudagraph-aware path: transparently converts a regular alltoall to the
 // persistent window-based AllToAllP algorithm during CUDA graph capture.
 commResult_t ctranAllToAllCudagraphAware(
@@ -14,6 +18,32 @@ commResult_t ctranAllToAllCudagraphAware(
     CtranComm* comm,
     cudaStream_t stream,
     enum NCCL_ALLTOALL_ALGO algo = NCCL_ALLTOALL_ALGO::ctgraph);
+
+// Window-based persistent alltoall (ctwin): converts an alltoall whose recvbuff
+// lives inside a registered symmetric CtranWin into a persistent AllToAllP
+// request that reuses the window's already-exchanged NVL/IPC state, caching the
+// request on the window for reuse across calls. Supports CUDA graph capture
+// inline: the window-owned request is built once and reused across replays (the
+// window must outlive any graph that captured over it).
+commResult_t ctranAllToAllCtwin(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream,
+    enum NCCL_ALLTOALL_ALGO algo);
+
+// True if a ctwin alltoall over [recvbuff, recvBytes) is supported: recvbuff
+// sits in a registered symmetric window that supports AllToAllP. On success
+// sets *winOut (if non-null) to the resolving window. A null recvbuff returns
+// false (ctwin is dormant until a caller opts in).
+bool checkCtranAllToAllCtwinSupport(
+    CtranComm* comm,
+    const void* recvbuff,
+    size_t recvBytes,
+    enum NCCL_ALLTOALL_ALGO algo,
+    ctran::CtranWin** winOut = nullptr);
 
 namespace ctran::alltoall {
 extern void* alltoallKerns[commNumTypes];

--- a/comms/ctran/algos/AllToAll/AllToAllPImpl.h
+++ b/comms/ctran/algos/AllToAll/AllToAllPImpl.h
@@ -33,6 +33,8 @@ class AlgoImpl {
         return "CtranAllToAllP";
       case NCCL_ALLTOALL_ALGO::ctgraph:
         return "CtranAllToAllPCtgraph";
+      case NCCL_ALLTOALL_ALGO::ctwin:
+        return "CtranAllToAllPCtwin";
       default:
         return "Unknown";
     }

--- a/comms/ctran/algos/AllToAll/AllToAllvImpl.h
+++ b/comms/ctran/algos/AllToAll/AllToAllvImpl.h
@@ -17,6 +17,8 @@ static inline const std::string allToAllAlgoName(enum NCCL_ALLTOALL_ALGO algo) {
       return "CtranAllToAll";
     case NCCL_ALLTOALL_ALGO::ctgraph:
       return "CtranCudagraphAware";
+    case NCCL_ALLTOALL_ALGO::ctwin:
+      return "CtranAllToAllCtwin";
     case NCCL_ALLTOALL_ALGO::orig:
       return "Baseline";
     default:

--- a/comms/ctran/tests/CtranDistAlltoAllCtwinTests.cc
+++ b/comms/ctran/tests/CtranDistAlltoAllCtwinTests.cc
@@ -1,0 +1,371 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <folly/init/Init.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <vector>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/regcache/IpcRegCache.h"
+#include "comms/ctran/regcache/RegCache.h"
+#include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/tests/CtranTestUtils.h"
+#include "comms/ctran/tests/VerifyAlgoStatsUtil.h"
+#include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/window/CtranWin.h"
+#include "comms/testinfra/TestsCuUtils.h"
+
+using namespace ctran;
+
+// Window-based persistent alltoall (ctwin). Registers a symmetric window over a
+// cumem recvbuf, runs alltoall with algo=ctwin, and verifies the result against
+// the alltoall reference (rank r's recv chunk i holds peer i's send chunk for
+// rank r). Also verifies that repeated calls over the same recvbuf sub-range
+// reuse one cached persistent request, that a distinct sub-range gets its own
+// request, and that ctranWinFree tears the cached requests down without leaking
+// imports.
+class CtranAllToAllCtwinTest : public ctran::CtranDistTestFixture {
+ public:
+  CtranAllToAllCtwinTest() = default;
+
+  commDataType_t dt = commInt32;
+  cudaStream_t stream = 0;
+  std::unique_ptr<CtranComm> ctranComm;
+  std::vector<TestMemSegment> segments;
+  ctran::test::VerifyAlgoStatsHelper algoStats_;
+
+  void SetUp() override {
+    setenv("NCCL_CTRAN_ENABLE", "1", 0);
+    algoStats_.enable();
+    ctran::CtranDistTestFixture::SetUp();
+    CUDACHECK_TEST(cudaStreamCreate(&stream));
+    ctranComm = makeCtranComm();
+  }
+
+  void TearDown() override {
+    // Every ctwin test frees its window(s) before returning; verify no NVL IPC
+    // imports leaked.
+    const auto ipcRegCache = ctran::IpcRegCache::getInstance();
+    // EXPECT (not ASSERT) so stream teardown below always runs.
+    EXPECT_NE(ipcRegCache, nullptr);
+    if (ipcRegCache != nullptr) {
+      EXPECT_EQ(ipcRegCache->maxRemRegRefCount(), 0)
+          << "IpcRegCache still holds live NVL IPC imports after test teardown";
+    }
+    CUDACHECK_TEST(cudaStreamDestroy(stream));
+    ctran::CtranDistTestFixture::TearDown();
+  }
+
+  // Register a symmetric window over a freshly cumem-allocated buffer.
+  // Symmetric because every rank allocates the same size at the same offset.
+  // When ipcOnly is true, inter-node IB rkeys are deferred to the first ctwin
+  // exec; when false, the full window exchange (including IB rkeys) happens at
+  // window creation.
+  void*
+  createSymmetricWindow(size_t bytes, CtranWin** winOut, bool ipcOnly = true) {
+    void* buf = commMemAlloc(bytes, MemAllocType::kMemCuMemAlloc, segments);
+    EXPECT_NE(buf, nullptr);
+    // Mimic the CCA allocator hook so the window's acquireScopedRegister finds
+    // the buffer's segment cached.
+    COMMCHECK_TEST(ctran::RegCache::getInstance()->globalRegister(buf, bytes));
+    meta::comms::Hints hints;
+    EXPECT_EQ(hints.set("win_register_symmetric", "1"), commSuccess);
+    if (ipcOnly) {
+      EXPECT_EQ(hints.set("win_register_ipc_only", "1"), commSuccess);
+    }
+    COMMCHECK_TEST(
+        ctranWinRegister(buf, bytes, ctranComm.get(), winOut, hints));
+    return buf;
+  }
+
+  void freeSymmetricWindow(CtranWin* win, void* buf, size_t bytes) {
+    COMMCHECK_TEST(ctranWinFree(win));
+    COMMCHECK_TEST(
+        ctran::RegCache::getInstance()->globalDeregister(buf, bytes));
+    commMemFree(buf, bytes, MemAllocType::kMemCuMemAlloc);
+    segments.erase(
+        std::remove_if(
+            segments.begin(),
+            segments.end(),
+            [buf](const TestMemSegment& seg) { return seg.ptr == buf; }),
+        segments.end());
+  }
+
+  // Value this rank sends to `dst` on iteration `iter`. Distinct per
+  // (srcRank, dst, iter) so a mis-routed chunk is caught.
+  static int sendVal(int srcRank, int dst, int iter) {
+    return srcRank * 100 + dst + 1 + iter * 100000;
+  }
+
+  // Fill a device sendbuf (numRanks chunks of `count`) with this rank's per-dst
+  // send values for iteration `iter`.
+  void fillSendBuf(void* sendbuf, size_t count, int iter) {
+    std::vector<int> host(count * numRanks);
+    for (int dst = 0; dst < numRanks; ++dst) {
+      std::fill(
+          host.begin() + dst * count,
+          host.begin() + (dst + 1) * count,
+          sendVal(globalRank, dst, iter));
+    }
+    CUDACHECK_TEST(cudaMemcpy(
+        sendbuf,
+        host.data(),
+        count * numRanks * commTypeSize(dt),
+        cudaMemcpyDefault));
+  }
+
+  // Verify a device recvbuf: chunk i must equal peer i's send value for this
+  // rank on iteration `iter`.
+  void verifyRecvBuf(void* recvbuf, size_t count, int iter) {
+    const size_t chunkBytes = count * commTypeSize(dt);
+    for (int peer = 0; peer < numRanks; ++peer) {
+      std::vector<int> observed(count, -1);
+      CUDACHECK_TEST(cudaMemcpy(
+          observed.data(),
+          static_cast<char*>(recvbuf) + peer * chunkBytes,
+          chunkBytes,
+          cudaMemcpyDefault));
+      const std::vector<int> expected(count, sendVal(peer, globalRank, iter));
+      EXPECT_EQ(observed, expected) << "at rank " << globalRank << " iter "
+                                    << iter << " chunk from peer " << peer;
+    }
+  }
+
+  // Run one out-of-place ctwin alltoall over the window sub-range at byteOffset
+  // on execStream and verify every received chunk.
+  void runAllToAllOnStream(
+      void* winBase,
+      size_t byteOffset,
+      size_t count,
+      int iter,
+      cudaStream_t execStream,
+      enum NCCL_ALLTOALL_ALGO algo = NCCL_ALLTOALL_ALGO::ctwin) {
+    const size_t typeSize = commTypeSize(dt);
+    const size_t totalBytes = count * numRanks * typeSize;
+    void* recvbuf = static_cast<char*>(winBase) + byteOffset;
+
+    // sendbuf is a plain (non-window) buffer: alltoall is out-of-place.
+    void* sendbuf = nullptr;
+    CUDACHECK_TEST(cudaMalloc(&sendbuf, totalBytes));
+
+    fillSendBuf(sendbuf, count, iter);
+    CUDACHECK_TEST(cudaMemset(recvbuf, 0xEE, totalBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    oobBarrier();
+
+    ASSERT_EQ(
+        ctranAllToAll(
+            sendbuf, recvbuf, count, dt, ctranComm.get(), execStream, algo),
+        commSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(execStream), cudaSuccess);
+
+    verifyRecvBuf(recvbuf, count, iter);
+    oobBarrier();
+
+    CUDACHECK_TEST(cudaFree(sendbuf));
+  }
+
+  // Convenience overload that runs on the fixture's default stream.
+  void runAllToAll(
+      void* winBase,
+      size_t byteOffset,
+      size_t count,
+      int iter,
+      enum NCCL_ALLTOALL_ALGO algo = NCCL_ALLTOALL_ALGO::ctwin) {
+    runAllToAllOnStream(winBase, byteOffset, count, iter, stream, algo);
+  }
+};
+
+TEST_F(CtranAllToAllCtwinTest, FullAndSubsetReuseAndFree) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skipping ctwin test";
+  }
+  if (ctranComm->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+
+  const size_t typeSize = commTypeSize(dt);
+  const size_t fullCount = 8192;
+  const size_t subCount = 2048;
+  const size_t fullTotalBytes = fullCount * numRanks * typeSize;
+  const size_t subTotalBytes = subCount * numRanks * typeSize;
+  // Window large enough for the full alltoall (at offset 0) plus a distinct
+  // subset alltoall placed after it.
+  const size_t windowBytes = fullTotalBytes + subTotalBytes;
+
+  CtranWin* win = nullptr;
+  void* winBase = createSymmetricWindow(windowBytes, &win);
+  ASSERT_NE(win, nullptr);
+  EXPECT_TRUE(win->isSymmetric());
+
+  // ctwin reports supported for a recvbuf that lives inside this window.
+  EXPECT_TRUE(ctranAllToAllSupport(
+      fullCount,
+      dt,
+      ctranComm.get(),
+      NCCL_ALLTOALL_ALGO::ctwin,
+      stream,
+      winBase));
+
+  // Full-window alltoall run twice: the second call must reuse the single
+  // cached persistent request rather than building a new one.
+  runAllToAll(winBase, /*byteOffset=*/0, fullCount, /*iter=*/0);
+  runAllToAll(winBase, /*byteOffset=*/0, fullCount, /*iter=*/1);
+  EXPECT_EQ(win->numPersistentRequests(), 1u);
+
+  // A distinct sub-range gets its own cached request; repeating it reuses it.
+  runAllToAll(winBase, fullTotalBytes, subCount, /*iter=*/2);
+  EXPECT_EQ(win->numPersistentRequests(), 2u);
+  runAllToAll(winBase, fullTotalBytes, subCount, /*iter=*/3);
+  EXPECT_EQ(win->numPersistentRequests(), 2u);
+
+  oobBarrier();
+
+  // ctwin executes via the persistent AllToAllP machinery, so the recorded algo
+  // name is "CtranAllToAllP" (not "CtranAllToAllCtwin"), confirming the ctwin
+  // path (not a fallback/other algo) executed.
+  algoStats_.verify(ctranComm.get(), "AllToAll", "CtranAllToAllP");
+
+  // Free must tear down the cached persistent requests and release all imports.
+  freeSymmetricWindow(win, winBase, windowBytes);
+}
+
+// A symmetric window registered WITHOUT ipc_only does the full window exchange
+// at creation -- including the inter-node IB rkey exchange -- so ctwin reuses
+// those rkeys (ibKeysExchanged=true) and skips the first-exec IB exchange.
+// Verifies a correct alltoall (with reuse) and that the ctwin (AllToAllP) path
+// ran.
+TEST_F(CtranAllToAllCtwinTest, FullExchangeSymmetricWindow) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skipping ctwin test";
+  }
+  if (ctranComm->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+
+  const size_t typeSize = commTypeSize(dt);
+  const size_t count = 8192;
+  const size_t windowBytes = count * numRanks * typeSize;
+
+  CtranWin* win = nullptr;
+  // Full-exchange symmetric window (NOT ipc_only): IB rkeys are exchanged at
+  // window creation.
+  void* winBase = createSymmetricWindow(windowBytes, &win, /*ipcOnly=*/false);
+  ASSERT_NE(win, nullptr);
+  EXPECT_TRUE(win->isSymmetric());
+  EXPECT_FALSE(win->isIpcOnly());
+
+  EXPECT_TRUE(ctranAllToAllSupport(
+      count, dt, ctranComm.get(), NCCL_ALLTOALL_ALGO::ctwin, stream, winBase));
+
+  // Run twice: the second call reuses the single cached persistent request.
+  runAllToAll(winBase, /*byteOffset=*/0, count, /*iter=*/0);
+  runAllToAll(winBase, /*byteOffset=*/0, count, /*iter=*/1);
+  EXPECT_EQ(win->numPersistentRequests(), 1u);
+
+  // Confirm the ctwin (AllToAllP) path actually ran.
+  algoStats_.verify(ctranComm.get(), "AllToAll", "CtranAllToAllP");
+
+  oobBarrier();
+  freeSymmetricWindow(win, winBase, windowBytes);
+}
+
+// Captures a ctwin alltoall over the symmetric window into a CUDA graph and
+// replays it several times, verifying the result each replay. Because ctwin's
+// persistent request is window-owned (not graph-owned), the request is built
+// once during capture and reused across replays; the graph is destroyed before
+// the window is freed (the required lifetime order).
+TEST_F(CtranAllToAllCtwinTest, GraphCaptureReplayReuseAndFree) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skipping ctwin graph test";
+  }
+  if (ctranComm->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+
+  const size_t typeSize = commTypeSize(dt);
+  const size_t count = 8192;
+  const size_t totalBytes = count * numRanks * typeSize;
+
+  CtranWin* win = nullptr;
+  void* winBase = createSymmetricWindow(totalBytes, &win);
+  ASSERT_NE(win, nullptr);
+  EXPECT_TRUE(win->isSymmetric());
+
+  // recvbuf lives in the window; sendbuf is a persistent (non-window) buffer
+  // captured by the graph and updated in place between replays.
+  void* recvbuf = winBase;
+  void* sendbuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&sendbuf, totalBytes));
+
+  cudaStream_t captureStream;
+  CUDACHECK_TEST(
+      cudaStreamCreateWithFlags(&captureStream, cudaStreamNonBlocking));
+
+  // Seed send/recv so the capture-time exec sees valid data (capture-time
+  // results are discarded; only replays are verified).
+  fillSendBuf(sendbuf, count, /*iter=*/0);
+  CUDACHECK_TEST(cudaMemset(recvbuf, 0xEE, totalBytes));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  oobBarrier();
+
+  // Capture the ctwin alltoall. request->stream == captureStream, so exec
+  // submits directly onto the captured stream.
+  cudaGraph_t graph = nullptr;
+  cudaGraphExec_t graphExec = nullptr;
+  ASSERT_EQ(
+      cudaStreamBeginCapture(captureStream, cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  ASSERT_EQ(
+      ctranAllToAll(
+          sendbuf,
+          recvbuf,
+          count,
+          dt,
+          ctranComm.get(),
+          captureStream,
+          NCCL_ALLTOALL_ALGO::ctwin),
+      commSuccess);
+  ASSERT_EQ(cudaStreamEndCapture(captureStream, &graph), cudaSuccess);
+  ASSERT_NE(graph, nullptr);
+  ASSERT_EQ(cudaGraphInstantiate(&graphExec, graph, 0), cudaSuccess);
+
+  // The persistent request built during capture is cached on the window.
+  EXPECT_EQ(win->numPersistentRequests(), 1u);
+
+  constexpr int kReplays = 3;
+  for (int r = 0; r < kReplays; ++r) {
+    const int iter = r + 1;
+    fillSendBuf(sendbuf, count, iter);
+    CUDACHECK_TEST(cudaMemset(recvbuf, 0xEE, totalBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    oobBarrier();
+
+    ASSERT_EQ(cudaGraphLaunch(graphExec, captureStream), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(captureStream), cudaSuccess);
+
+    verifyRecvBuf(recvbuf, count, iter);
+    // No new request is created across replays.
+    EXPECT_EQ(win->numPersistentRequests(), 1u);
+    oobBarrier();
+  }
+
+  // Correct lifetime order: destroy the graph BEFORE freeing the window (the
+  // window owns the request the graph captured).
+  ASSERT_EQ(cudaGraphExecDestroy(graphExec), cudaSuccess);
+  ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+  CUDACHECK_TEST(cudaFree(sendbuf));
+  CUDACHECK_TEST(cudaStreamDestroy(captureStream));
+
+  oobBarrier();
+  freeSymmetricWindow(win, winBase, totalBytes);
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new ctran::CtranDistEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/algoconf/AlgoStrConv.h
+++ b/comms/ncclx/meta/algoconf/AlgoStrConv.h
@@ -99,6 +99,8 @@ inline void algoStrToVal(const std::string& str, enum NCCL_ALLTOALL_ALGO& val) {
     val = NCCL_ALLTOALL_ALGO::ctran;
   } else if (str == "ctgraph") {
     val = NCCL_ALLTOALL_ALGO::ctgraph;
+  } else if (str == "ctwin") {
+    val = NCCL_ALLTOALL_ALGO::ctwin;
   } else {
     val = NCCL_ALLTOALL_ALGO::orig;
   }
@@ -208,6 +210,8 @@ inline std::string algoValToStr(enum NCCL_ALLTOALL_ALGO val) {
       return "ctran";
     case NCCL_ALLTOALL_ALGO::ctgraph:
       return "ctgraph";
+    case NCCL_ALLTOALL_ALGO::ctwin:
+      return "ctwin";
   }
   return "unknown";
 }

--- a/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
+++ b/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
@@ -159,6 +159,9 @@ void checkAlgoStrToVal(enum NCCL_ALLTOALL_ALGO algo) {
     case NCCL_ALLTOALL_ALGO::ctgraph:
       str = "ctgraph";
       break;
+    case NCCL_ALLTOALL_ALGO::ctwin:
+      str = "ctwin";
+      break;
   }
   enum NCCL_ALLTOALL_ALGO result;
   algoStrToVal(str, result);

--- a/comms/ncclx/v2_29/src/collectives.cc
+++ b/comms/ncclx/v2_29/src/collectives.cc
@@ -377,7 +377,7 @@ ncclResult_t ncclAllToAll(
 
   auto alltoallAlgo = NCCLX_CONFIG_FIELD(comm->config, alltoallAlgo);
   if ((alltoallAlgo != NCCL_ALLTOALL_ALGO::orig) &&
-      ctranAllToAllSupport(count, ncclToMetaComm(datatype), comm->ctranComm_.get(), alltoallAlgo, stream)) {
+      ctranAllToAllSupport(count, ncclToMetaComm(datatype), comm->ctranComm_.get(), alltoallAlgo, stream, recvbuff)) {
     return metaCommToNccl(ctranAllToAll(sendbuff, recvbuff, count, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, alltoallAlgo));
   }
 

--- a/comms/ncclx/v2_30/src/collectives.cc
+++ b/comms/ncclx/v2_30/src/collectives.cc
@@ -377,7 +377,7 @@ ncclResult_t ncclAllToAll(
 
   auto alltoallAlgo = NCCLX_CONFIG_FIELD(comm->config, alltoallAlgo);
   if ((alltoallAlgo != NCCL_ALLTOALL_ALGO::orig) &&
-      ctranAllToAllSupport(count, ncclToMetaComm(datatype), comm->ctranComm_.get(), alltoallAlgo, stream)) {
+      ctranAllToAllSupport(count, ncclToMetaComm(datatype), comm->ctranComm_.get(), alltoallAlgo, stream, recvbuff)) {
     return metaCommToNccl(ctranAllToAll(sendbuff, recvbuff, count, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, alltoallAlgo));
   }
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2232,12 +2232,13 @@ cvars:
  - name        : NCCL_ALLTOALL_ALGO
    type        : enum
    default     : orig
-   choices     : orig, ctran, ctgraph
+   choices     : orig, ctran, ctgraph, ctwin
    description : |-
      The algorithm to use for alltoall communication
      orig - Copy-based communication
      ctran - Ctran-based communication
      ctgraph - Cudagraph-aware Ctran-based communication (captured into a CUDA graph)
+     ctwin - Ctran window-aware: detects whether the recvbuf is in a registered symmetric window and dispatches to the persistent AllToAllP algorithm, similar to ctgraph but capture-safe via a window-cached persistent request.
 
  - name        : NCCL_ALLTOALLV_ALGO
    type        : enum


### PR DESCRIPTION
Summary:

Port the ctwin (Ctran window-aware) algorithm from AllGather to AllToAll. Like ctwin AllGather, this is a dispatch/adapter layer: when the recvbuf lives in a registered symmetric CtranWin, a one-shot AllToAll is converted into a persistent AllToAllP request that borrows the window's already-exchanged NVL/IPC peer buffers and rkeys instead of running AllToAllP's own IPC exchange. The request is cached on the window (keyed by <offset, len, stream>) and reused across calls and CUDA-graph replays, making the path capture-safe without being a graph-aware algo.
- New AllToAllCtwin.cc: checkCtranAllToAllCtwinSupport (requires a symmetric window covering the recvbuf and AllToAllPSupport), createPersistentRequestFromWindow (borrows win->dataRegHdl and win->remWinInfo[r].dataAddr/dataRkey into alltoallp::PersistArgs, initState=kInitialized, ibKeysExchanged=!isIpcOnly), and the ctranAllToAllCtwin entry that resolves the window request and calls AllToAllPExec.
- Unlike AllGather ctwin, AllToAllP has a single implementation (no pipeline/srd/ring variants), so only one ctwin enum value is added with no sub-variant routing.
- Dispatch: ctranAllToAll routes NCCL_ALLTOALL_ALGO::ctwin to ctranAllToAllCtwin; ctranAllToAllSupport gains a recvbuff parameter (consistent with ctranAllGatherSupport) so the support gate can resolve the window. Both ncclx v2_29 and v2_30 ncclAllToAll call sites pass recvbuff.
- Enum wiring: NCCL_ALLTOALL_ALGO gains ctwin in nccl_cvars.yaml, allToAllAlgoName, and the exhaustive AlgoStrConv switches.
- MCCL is intentionally not wired for ctwin (recvbuff not passed there); ctwin stays dormant on MCCL, consistent with the existing ctgraph behavior.

Test counts (AllToAll ctwin):
  Dist: 3 tests (request reuse+free, full-exchange window, graph capture/replay)

Reviewed By: dsjohns2

Differential Revision: D113353614


