### PR TITLE
Fix use-after-free of timed-out RdmaTransport works in CtranIb (#3252)

### DIFF
--- a/comms/torchcomms/transport/RdmaTransport.cpp
+++ b/comms/torchcomms/transport/RdmaTransport.cpp
@@ -175,6 +175,16 @@ struct RdmaTransport::Work {
   CtranIbRequest ibReq;
   folly::Promise<commResult_t> promise;
 
+  // The production Write/Read paths hand &ibReq to CtranIb (iput/iget),
+  // whose VC queues keep a raw pointer to it until the operation completes;
+  // such a Work must not be destroyed while the operation is outstanding
+  // (see retiredWorks_). Mock works and WaitForWrite never issue an IB
+  // operation.
+  bool hasIbOp() const {
+    return mockContext.type == RdmaTransport::MockType::None &&
+        (type == Type::Write || type == Type::Read);
+  }
+
   // Mock context for this work (type from setMockForTest)
   RdmaTransport::MockContext mockContext;
 
@@ -229,12 +239,22 @@ RdmaTransport::~RdmaTransport() {
             "~RdmaTransport: draining {} pending works with commUserAbort",
             numPending);
       }
+      auto retiredWorks = retiredWorks_.wlock();
       for (auto it = pendingWorks->begin(); it != pendingWorks->end();) {
-        (*it)->promise.setValue(commUserAbort);
+        auto work = std::move(*it);
         it = pendingWorks->erase(it);
+        work->promise.setValue(commUserAbort);
+        if (work->hasIbOp() && !work->ibReq.isComplete()) {
+          retiredWorks->emplace_back(std::move(work));
+        }
       }
     });
   }
+  // Destroy the IB instance before freeing retired works: CtranIb's VC
+  // queues hold raw pointers to their CtranIbRequests, so the works may
+  // only be freed once no CQE processing can dereference them.
+  ib_.reset();
+  retiredWorks_.wlock()->clear();
 }
 
 namespace {
@@ -298,6 +318,9 @@ folly::SemiFuture<commResult_t> RdmaTransport::write(
     const RdmaRemoteBuffer& remoteBuffer,
     bool notify,
     std::optional<std::chrono::milliseconds> timeout) {
+  if (broken_.load(std::memory_order_relaxed)) {
+    return commInternalError;
+  }
   auto currentMockType = mockContext_.rlock()->type;
 
   // Skip connected check when mock is enabled for testing
@@ -319,7 +342,7 @@ folly::SemiFuture<commResult_t> RdmaTransport::write(
     auto ibRemoteKey =
         CtranIbRemoteAccessKey::fromString(remoteBuffer.accessKey);
     CtranIbEpochRAII epochRAII(ib_.get());
-    FB_COMMCHECK(ib_->iput(
+    const auto ibRes = ib_->iput(
         localBuffer.data(),
         remoteBuffer.ptr,
         localBuffer.size(),
@@ -329,7 +352,21 @@ folly::SemiFuture<commResult_t> RdmaTransport::write(
         notify,
         nullptr,
         &work->ibReq,
-        false));
+        false);
+    if (ibRes != commSuccess && ibRes != commInProgress) {
+      XLOGF(
+          ERR,
+          "RdmaTransport::write: iput failed with {}",
+          static_cast<int>(ibRes));
+      // The IB instance can't be trusted anymore; fail all future
+      // operations fast so the owner tears the transport down.
+      broken_.store(true, std::memory_order_relaxed);
+      // iput may have stored a pointer to work->ibReq in the VC queues
+      // before failing; park the work instead of destroying it.
+      work->promise.setValue(ibRes);
+      retiredWorks_.wlock()->emplace_back(std::move(work));
+      return sf;
+    }
     // Capture timeout for production write timeout
     if (timeout.has_value()) {
       work->timeout = timeout;
@@ -353,6 +390,9 @@ folly::SemiFuture<commResult_t> RdmaTransport::write(
 }
 
 folly::SemiFuture<commResult_t> RdmaTransport::waitForWrite() {
+  if (broken_.load(std::memory_order_relaxed)) {
+    return commInternalError;
+  }
   CHECK_THROW(connected(), std::runtime_error);
   CHECK_THROW(evb_, std::runtime_error);
 
@@ -371,6 +411,9 @@ folly::SemiFuture<commResult_t> RdmaTransport::waitForWrite() {
 folly::SemiFuture<commResult_t> RdmaTransport::read(
     RdmaMemory::MutableView& localBuffer,
     const RdmaRemoteBuffer& remoteBuffer) {
+  if (broken_.load(std::memory_order_relaxed)) {
+    return commInternalError;
+  }
   CHECK_THROW(connected(), std::runtime_error);
   CHECK_THROW(evb_, std::runtime_error);
 
@@ -382,7 +425,7 @@ folly::SemiFuture<commResult_t> RdmaTransport::read(
 
   auto ibRemoteKey = CtranIbRemoteAccessKey::fromString(remoteBuffer.accessKey);
   CtranIbEpochRAII epochRAII(ib_.get());
-  FB_COMMCHECK(ib_->iget(
+  const auto ibRes = ib_->iget(
       remoteBuffer.ptr,
       localBuffer.mutable_data(),
       localBuffer.size(),
@@ -391,7 +434,21 @@ folly::SemiFuture<commResult_t> RdmaTransport::read(
       ibRemoteKey,
       nullptr,
       &work->ibReq,
-      false));
+      false);
+  if (ibRes != commSuccess && ibRes != commInProgress) {
+    XLOGF(
+        ERR,
+        "RdmaTransport::read: iget failed with {}",
+        static_cast<int>(ibRes));
+    // The IB instance can't be trusted anymore; fail all future
+    // operations fast so the owner tears the transport down.
+    broken_.store(true, std::memory_order_relaxed);
+    // iget may have stored a pointer to work->ibReq in the VC queues
+    // before failing; park the work instead of destroying it.
+    work->promise.setValue(ibRes);
+    retiredWorks_.wlock()->emplace_back(std::move(work));
+    return sf;
+  }
 
   // Add work to pending list and schedule progress
   auto pendingWorks = pendingWorks_.wlock();
@@ -408,17 +465,47 @@ void RdmaTransport::progress() {
   bool hasError = false;
   if (res != commSuccess && res != commInProgress) {
     hasError = true;
+    // The IB instance is in an unrecoverable state: works drained below may
+    // never complete and would stay retired until destruction. Fail all
+    // future operations fast so the owner tears the transport down.
+    broken_.store(true, std::memory_order_relaxed);
     LOG(ERROR) << "IB progress failed";
   }
 
+  // Reap retired works whose IB operation has since completed; only then is
+  // it safe to free their embedded CtranIbRequest. Works whose operation
+  // never completes (e.g. dead peer) are freed in the destructor after ib_
+  // is torn down.
+  {
+    auto retiredWorks = retiredWorks_.wlock();
+    for (auto it = retiredWorks->begin(); it != retiredWorks->end();) {
+      if ((*it)->ibReq.isComplete()) {
+        it = retiredWorks->erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+
   auto pendingWorks = pendingWorks_.wlock();
+  // Fulfill a work's promise and remove it from the pending list. A work
+  // whose IB operation is still outstanding must not be destroyed: CtranIb
+  // holds a raw pointer to work->ibReq and writes to it when the
+  // operation's CQEs arrive. Park such works in retiredWorks_ instead.
+  auto retire = [this, &pendingWorks](auto& it, commResult_t result) {
+    auto work = std::move(*it);
+    it = pendingWorks->erase(it);
+    work->promise.setValue(result);
+    if (work->hasIbOp() && !work->ibReq.isComplete()) {
+      retiredWorks_.wlock()->emplace_back(std::move(work));
+    }
+  };
   for (auto it = pendingWorks->begin(); it != pendingWorks->end();) {
     // Mock failure always takes precedence — return commInternalError
     // regardless of IB state
     auto& work = *it;
     if (work->mockContext.type == MockType::Failure) {
-      work->promise.setValue(commInternalError);
-      it = pendingWorks->erase(it);
+      retire(it, commInternalError);
       continue;
     }
 
@@ -428,8 +515,7 @@ void RdmaTransport::progress() {
       if (work->timeout.has_value()) {
         auto elapsed = std::chrono::steady_clock::now() - work->creationTime;
         if (elapsed >= work->timeout.value()) {
-          work->promise.setValue(commTimeout);
-          it = pendingWorks->erase(it);
+          retire(it, commTimeout);
           continue;
         }
       }
@@ -438,16 +524,14 @@ void RdmaTransport::progress() {
     }
 
     if (hasError) {
-      (*it)->promise.setValue(res);
-      it = pendingWorks->erase(it);
+      retire(it, res);
       continue;
     }
 
     // Check IB completion
     if (((*it)->type == Work::Type::Write || (*it)->type == Work::Type::Read) &&
         (*it)->ibReq.isComplete()) {
-      (*it)->promise.setValue(commSuccess);
-      it = pendingWorks->erase(it);
+      retire(it, commSuccess);
       continue;
     }
 
@@ -455,8 +539,7 @@ void RdmaTransport::progress() {
     if ((*it)->type == Work::Type::Write && (*it)->timeout.has_value()) {
       auto elapsed = std::chrono::steady_clock::now() - (*it)->creationTime;
       if (elapsed >= (*it)->timeout.value()) {
-        (*it)->promise.setValue(commTimeout);
-        it = pendingWorks->erase(it);
+        retire(it, commTimeout);
         continue;
       }
     }
@@ -465,8 +548,7 @@ void RdmaTransport::progress() {
       bool done = false;
       auto waitRes = ib_->checkNotify(kDummyRank, &done);
       if (waitRes != commSuccess || done) {
-        (*it)->promise.setValue(waitRes);
-        it = pendingWorks->erase(it);
+        retire(it, waitRes);
         continue;
       }
     }
@@ -489,6 +571,10 @@ void RdmaTransport::setMockForTest(MockContext context) {
 // TODO: Remove after upper layer removes calling abort().
 void RdmaTransport::abort() {
   XLOG(DBG) << "abort() called (no-op, cleanup deferred to destructor)";
+}
+
+void RdmaTransport::markBrokenForTest() {
+  broken_.store(true, std::memory_order_relaxed);
 }
 
 } // namespace torch::comms

--- a/comms/torchcomms/transport/RdmaTransport.h
+++ b/comms/torchcomms/transport/RdmaTransport.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <deque>
 #include <memory>
@@ -312,6 +313,9 @@ struct RdmaRemoteBuffer {
  *
  *   commInternalError — IB / transport-level failure:
  *     write(), read(), waitForWrite()
+ *     Any such failure permanently marks the transport as broken: all
+ *     subsequent async API calls fail immediately with commInternalError
+ *     without issuing IB operations. The owner should destroy the transport.
  *
  *   commUserAbort — transport was destroyed while operations were pending:
  *     write(), read(), waitForWrite()
@@ -447,6 +451,12 @@ class __attribute__((visibility("default"))) RdmaTransport {
    */
   void abort();
 
+  /*
+   * Force the transport into the broken state, as if an IB-level failure
+   * had occurred. Test-only.
+   */
+  void markBrokenForTest();
+
  private:
   /*
    * Drive the IB progress loop and drive completion of pending requests.
@@ -459,7 +469,20 @@ class __attribute__((visibility("default"))) RdmaTransport {
 
   struct Work;
   folly::Synchronized<std::deque<std::unique_ptr<Work>>> pendingWorks_;
+  // Works whose promise has already been fulfilled (timeout, IB error, or
+  // teardown) but whose IB operation is still outstanding. CtranIb's VC
+  // queues hold a raw pointer to the Work's embedded CtranIbRequest and
+  // write to it when the operation's CQEs arrive, so such Works must stay
+  // alive until the request completes or ib_ is destroyed. Lock order:
+  // pendingWorks_ before retiredWorks_.
+  folly::Synchronized<std::deque<std::unique_ptr<Work>>> retiredWorks_;
   std::unique_ptr<folly::AsyncTimeout> progressTimeout_;
+  // Set permanently once the transport hits an IB-level failure (progress
+  // error or a failed iput/iget). All subsequent write/read/waitForWrite
+  // calls fail fast with commInternalError without issuing IB operations,
+  // so the owner can promptly destroy the transport — which also frees any
+  // retired works whose operations will never complete.
+  std::atomic<bool> broken_{false};
   // Mock configuration for testing; updated by setMockForTest
   folly::Synchronized<MockContext> mockContext_;
 };

--- a/comms/torchcomms/transport/tests/cpp/RdmaTransportTest.cc
+++ b/comms/torchcomms/transport/tests/cpp/RdmaTransportTest.cc
@@ -993,6 +993,41 @@ TEST_F(RdmaTransportTest, DestructorCancelsPendingWorks) {
   EXPECT_EQ(cudaFree(buffer), cudaSuccess);
 }
 
+// A broken transport (any prior IB-level failure) must fail all subsequent
+// async APIs immediately with commInternalError, without issuing IB
+// operations. The transport is deliberately left unconnected: if any API
+// tried to issue an IB operation it would throw on the connected() check.
+TEST_F(RdmaTransportTest, BrokenTransportFailsFast) {
+  const size_t bufferSize = 1024;
+  const int cudaDev = 0;
+  EXPECT_EQ(cudaSetDevice(cudaDev), cudaSuccess);
+
+  auto evbThread = std::make_unique<folly::ScopedEventBaseThread>();
+  auto transport = std::make_unique<torch::comms::RdmaTransport>(
+      cudaDev, evbThread->getEventBase());
+  EXPECT_FALSE(transport->bind().empty());
+
+  void* buffer = nullptr;
+  EXPECT_EQ(cudaMalloc(&buffer, bufferSize), cudaSuccess);
+  torch::comms::RdmaMemory rdmaMemory(buffer, bufferSize, cudaDev);
+  torch::comms::RdmaRemoteBuffer remoteBuffer{
+      .ptr = buffer, .len = bufferSize, .accessKey = rdmaMemory.remoteKey()};
+
+  transport->markBrokenForTest();
+
+  auto writeFuture = transport->write(
+      rdmaMemory.createView(buffer, bufferSize), remoteBuffer, false);
+  EXPECT_EQ(std::move(writeFuture).get(), commInternalError);
+
+  auto readView = rdmaMemory.createMutableView(buffer, bufferSize);
+  auto readFuture = transport->read(readView, remoteBuffer);
+  EXPECT_EQ(std::move(readFuture).get(), commInternalError);
+
+  EXPECT_EQ(transport->waitForWrite().get(), commInternalError);
+
+  EXPECT_EQ(cudaFree(buffer), cudaSuccess);
+}
+
 // Test that a production write with a timeout returns commTimeout when IB
 // cannot complete the operation (peer has disconnected).
 TEST_F(RdmaTransportTest, WriteTimeoutProductionDisconnectedPeer) {
@@ -1086,4 +1121,119 @@ TEST_F(RdmaTransportTest, WriteTimeoutProductionDisconnectedPeer) {
   clientThread.join();
 
   EXPECT_EQ(writeResult, commTimeout);
+}
+
+// A production write whose timeout fires while the IB operation is still
+// outstanding must not free the operation's CtranIbRequest: CtranIb's VC
+// queues hold a raw pointer to it and write to it when the operation's CQE
+// later arrives. Flood a healthy peer with zero-timeout writes so the works
+// retire before their CQEs land, then keep progressing (a follow-up write)
+// and destroy the transport. Under ASAN this catches the use-after-free.
+TEST_F(RdmaTransportTest, WriteZeroTimeoutLateCompletionSafe) {
+  auto [urlPromise0, urlFuture0] = folly::makePromiseContract<std::string>();
+  auto [urlPromise1, urlFuture1] = folly::makePromiseContract<std::string>();
+  auto [memoryInfoPromise, memoryInfoFuture] =
+      folly::makePromiseContract<RdmaRemoteBuffer>();
+  // Synchronization: server tells client all writes are done
+  auto [donePromise, doneFuture] = folly::makePromiseContract<bool>();
+
+  // Large enough that a write cannot complete before the zero timeout is
+  // evaluated on the first progress pass.
+  const size_t bufferSize = 64 * 1024 * 1024;
+  const int numFloodWrites = 32;
+
+  std::thread serverThread([&]() {
+    EXPECT_EQ(cudaSetDevice(0), cudaSuccess);
+    auto evbThread = std::make_unique<folly::ScopedEventBaseThread>();
+    auto transport = std::make_unique<torch::comms::RdmaTransport>(
+        0, evbThread->getEventBase());
+
+    std::string myUrl = transport->bind();
+    EXPECT_FALSE(myUrl.empty());
+    urlPromise0.setValue(myUrl);
+
+    std::string peerUrl = std::move(urlFuture1).get();
+    EXPECT_EQ(transport->connect(peerUrl), commSuccess);
+
+    void* buffer = nullptr;
+    EXPECT_EQ(cudaMalloc(&buffer, bufferSize), cudaSuccess);
+    torch::comms::RdmaMemory rdmaMemory(buffer, bufferSize, 0);
+
+    auto clientMemInfo = std::move(memoryInfoFuture).get();
+
+    // Zero-timeout writes: each work retires on the first progress pass
+    // while its put is still on the wire; the CQE lands afterwards.
+    std::vector<folly::SemiFuture<commResult_t>> floodFutures;
+    floodFutures.reserve(numFloodWrites);
+    for (int i = 0; i < numFloodWrites; ++i) {
+      floodFutures.push_back(transport->write(
+          rdmaMemory.createView(buffer, bufferSize),
+          clientMemInfo,
+          false,
+          std::chrono::milliseconds(0)));
+    }
+    int numTimeouts = 0;
+    for (auto& future : floodFutures) {
+      auto result = std::move(future).get();
+      EXPECT_TRUE(result == commSuccess || result == commTimeout)
+          << "unexpected result " << result;
+      if (result == commTimeout) {
+        ++numTimeouts;
+      }
+    }
+    // The point of the test is exercising the retired-work path; with a
+    // 64MB payload and a 0ms timeout, writes cannot complete in time.
+    EXPECT_GE(numTimeouts, 1);
+
+    // A follow-up write keeps the progress loop running through the late
+    // CQEs of the timed-out writes and must still succeed.
+    auto finalFuture = transport->write(
+        rdmaMemory.createView(buffer, bufferSize),
+        clientMemInfo,
+        true,
+        std::chrono::seconds(30));
+    EXPECT_EQ(commSuccess, std::move(finalFuture).get());
+
+    donePromise.setValue(true);
+
+    // Destroy the transport; any works still retired are freed only after
+    // the IB instance is torn down.
+    transport.reset();
+    EXPECT_EQ(cudaFree(buffer), cudaSuccess);
+  });
+
+  std::thread clientThread([&]() {
+    EXPECT_EQ(cudaSetDevice(1), cudaSuccess);
+    auto evbThread = std::make_unique<folly::ScopedEventBaseThread>();
+    auto transport = std::make_unique<torch::comms::RdmaTransport>(
+        1, evbThread->getEventBase());
+
+    std::string myUrl = transport->bind();
+    EXPECT_FALSE(myUrl.empty());
+    urlPromise1.setValue(myUrl);
+
+    std::string peerUrl = std::move(urlFuture0).get();
+    EXPECT_EQ(transport->connect(peerUrl), commSuccess);
+
+    void* buffer = nullptr;
+    EXPECT_EQ(cudaMalloc(&buffer, bufferSize), cudaSuccess);
+    torch::comms::RdmaMemory rdmaMemory(buffer, bufferSize, 1);
+
+    RdmaRemoteBuffer myMemInfo{
+        .ptr = buffer, .len = bufferSize, .accessKey = rdmaMemory.remoteKey()};
+    memoryInfoPromise.setValue(myMemInfo);
+
+    // Wait for the notify of the server's final write.
+    auto waitFuture = transport->waitForWrite();
+    EXPECT_EQ(commSuccess, std::move(waitFuture).get());
+
+    // Keep the transport and buffer alive until the server is done writing.
+    std::move(doneFuture).get();
+
+    transport.reset();
+    EXPECT_EQ(cudaFree(buffer), cudaSuccess);
+  });
+
+  serverThread.join();
+  clientThread.join();
 }


### PR DESCRIPTION
Summary:

`RdmaTransport::Work` embeds `CtranIbRequest ibReq` by value and passes `&work->ibReq` to `CtranIb::iput`/`iget`, which stores that raw pointer in its VC queues (`PutInfo.req`, `GetInfo.req`, `NotifyInfo.req`) and calls `req->complete()` when the operation's CQEs arrive. `RdmaTransport::progress()` destroyed the `Work` when a write timed out, or when `ib_->progress()` returned an error, while the IB operation was still outstanding in those queues. If the operation later completed — a stalled-then-recovered peer; error CQEs return early via `CQE_ERROR_CHECK`, but success CQEs proceed to `processCqeImpl` — `CtranIbVirtualConn::burnDownPuts()` wrote through the dangling `putInfo.req` into freed memory, corrupting the heap.

This is the root cause of two trainer crashes in `KIKI_GCP_tier6_256x16_rev2-t77sj1s2` (2026-07-17), both on the `RdmaTransport::progress()` EventBase thread minutes apart during elastic replica churn (stalled inter-replica tensor transfers, 30s write timeouts firing, then the fabric draining): a glibc `corrupted double-linked list` SIGABRT under `CtranIbVirtualConn::burnDownPuts()` on trainer_0, and a SIGSEGV in `Promise::setTry -> RequestContext::setContext` on trainer_1. The new regression test reproduces the exact production stack as an ASAN heap-use-after-free without this fix.

The fix keeps the request alive for as long as CtranIb may dereference it:
- A fulfilled work whose IB operation is still incomplete (`ibOpIssued && !ibReq.isComplete()`) is parked in a new `retiredWorks_` list instead of being destroyed — on the write-timeout, IB-error, and `iput`/`iget`-failure paths, and in the destructor drain.
- Retired works are reaped on subsequent `progress()` passes once `ibReq.isComplete()`.
- The destructor resets `ib_` before freeing any leftover retired works, so no CQE processing can dereference a freed request.

Related prior fixes in the same lifetime bug class: D97514810 (dangling `CtranIbRequest` in abort teardown), D105881135 (tensor_transfer raw `RdmaTransport*` across `co_await`), D92867065 (abort vs EventBase progress timer).

Known remaining limitation (follow-up): on timeout, queued-but-not-yet-posted puts still reference the caller's registered buffer and can DMA from it later; fully cancelling them requires a CTRAN-level cancel API.

Differential Revision: D113083158


