### PR TITLE
Allow CpAsyncSmemReduce in pre-SM80 fatbin builds

### DIFF
--- a/comms/prims/collectives/ReduceScatterDirectIb.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIb.cu
@@ -144,6 +144,28 @@ void launch_direct_reduce_scatter_ib_impl(
   using ReduceOp = CpAsyncSmemReduce<float, SumOp, 8192, 384, 2>;
   constexpr std::size_t dynamic_smem = ReduceOp::smem_bytes();
   if constexpr (dynamic_smem > 0) {
+    int device = 0;
+    PIPES_CUDA_CHECK(cudaGetDevice(&device));
+
+    int compute_capability_major = 0;
+    PIPES_CUDA_CHECK(cudaDeviceGetAttribute(
+        &compute_capability_major, cudaDevAttrComputeCapabilityMajor, device));
+    if (compute_capability_major < 8) {
+      throw std::runtime_error(
+          "CpAsyncSmemReduce requires a GPU with compute capability 8.0 or "
+          "newer");
+    }
+
+    int max_dynamic_smem = 0;
+    PIPES_CUDA_CHECK(cudaDeviceGetAttribute(
+        &max_dynamic_smem, cudaDevAttrMaxSharedMemoryPerBlockOptin, device));
+    if (dynamic_smem > static_cast<std::size_t>(max_dynamic_smem)) {
+      throw std::runtime_error(
+          "CpAsyncSmemReduce requires " + std::to_string(dynamic_smem) +
+          " bytes of dynamic shared memory, but the GPU supports only " +
+          std::to_string(max_dynamic_smem));
+    }
+
     PIPES_CUDA_CHECK(cudaFuncSetAttribute(
         kernel,
         cudaFuncAttributeMaxDynamicSharedMemorySize,

--- a/comms/prims/core/CopyOp.cuh
+++ b/comms/prims/core/CopyOp.cuh
@@ -1148,8 +1148,7 @@ struct CpAsyncSmemReduce {
     }
     SmemTile::wait_prior(0);
 #elif defined(__CUDA_ARCH__)
-    static_assert(
-        __CUDA_ARCH__ >= 800, "CpAsyncSmemReduce requires cp.async support");
+    __trap();
 #endif
     return nbytes;
   }


### PR DESCRIPTION
Summary:
Llama4x H100 conda builds compile `ReduceScatterDirectIb.cu` for both
`compute_75` and `sm_90a`. The compile-time assertion in
`CpAsyncSmemReduce` rejects the SM75 fatbin pass even though this kernel is
only run on Hopper and Blackwell in the supported fleet.

Emit a device trap for unsupported architectures instead. Before launching,
explicitly require compute capability 8.0 or newer and enough opt-in dynamic
shared memory for the reduction policy. This keeps multi-architecture package
builds working while producing a clear host-side error on unsupported GPUs.

Reviewed By: athmasagar

Differential Revision: D113398759


