### PR TITLE
Restrict prims CUDA archs to sm_90+ (H100+)

### DIFF
--- a/comms/prims/CMakeLists.txt
+++ b/comms/prims/CMakeLists.txt
@@ -43,6 +43,14 @@ set_target_properties(prims PROPERTIES
     POSITION_INDEPENDENT_CODE ON
 )
 
+set(PRIMS_CUDA_ARCHS ${CMAKE_CUDA_ARCHITECTURES})
+list(FILTER PRIMS_CUDA_ARCHS EXCLUDE REGEX "^(5[0-9]|6[0-9]|7[0-9]|8[0-9])")
+if(NOT PRIMS_CUDA_ARCHS)
+    set(PRIMS_CUDA_ARCHS OFF)
+endif()
+set_target_properties(prims PROPERTIES CUDA_ARCHITECTURES "${PRIMS_CUDA_ARCHS}")
+message(STATUS "prims CUDA_ARCHITECTURES: ${PRIMS_CUDA_ARCHS} (from CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES})")
+
 # ROOT (fbcode root) resolves comms/prims/..., comms/common/*.cuh (header-only
 # bits: AtomicUtils/DeviceConstants/BitOps), and comms/ctran/ibverbx/... .
 target_include_directories(prims PRIVATE


### PR DESCRIPTION
Summary:
prims requires `cp.async` (sm_80+): e.g. `CpAsyncSmemReduce` static_asserts
`__CUDA_ARCH__ >= 800`, so a pre-Ampere device pass fails to compile
`ReduceScatterDirectIb.cu`.

In conda/feedstock builds the `cuda-nvcc` activation script exports `CUDAARCHS`
with a broad GPU matrix (`75;80;86;89;90a;100f;103f;120a;121f;121`), which CMake
uses as the default for `CMAKE_CUDA_ARCHITECTURES` whenever a project does not set
it. The mccl build overrides `NVCC_GENCODE` for the target GPU but never touches
`CMAKE_CUDA_ARCHITECTURES`, so the `prims` target (which sets no
`CUDA_ARCHITECTURES` of its own) inherits `sm_75` and fails to build.

Filter `CMAKE_CUDA_ARCHITECTURES` down to sm_90 (H100) and newer for the `prims`
target. Unlike `comms/ctran` (which strips `CMAKE_CUDA_FLAGS`), prims' stray
arches arrive via the `CUDA_ARCHITECTURES` channel, so we filter that. If nothing
remains (or it was unset/OFF), emit no per-target arch flags and rely on the
explicit `-gencode` flags from `NVCC_GENCODE`.



Ctran does manual strip similar to this. https://www.internalfb.com/code/fbsource/[c84e43cb8467]/fbcode/comms/ctran/CMakeLists.txt?lines=18-21

Differential Revision: D113426094


