### PR TITLE
Route v2_30 subsystem fatal WARN to ERR (#3259)

### DIFF
--- a/comms/ncclx/meta/NcclxPerCommConfig.h
+++ b/comms/ncclx/meta/NcclxPerCommConfig.h
@@ -17,15 +17,18 @@ inline ncclResult_t ncclxValidatePerCommConfig(const ncclConfig_t& config) {
   auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
 
   if (ncclxCfg->ncclBuffSize.has_value()) {
-    ERR("Per-comm ncclBuffSize override is not supported with splitShare=1");
+    ERR(ncclInvalidArgument,
+        "Per-comm ncclBuffSize override is not supported with splitShare=1");
     return ncclInvalidArgument;
   }
   if (ncclxCfg->ibSplitDataOnQps.has_value()) {
-    ERR("Per-comm ibSplitDataOnQps override is not supported with splitShare=1");
+    ERR(ncclInvalidArgument,
+        "Per-comm ibSplitDataOnQps override is not supported with splitShare=1");
     return ncclInvalidArgument;
   }
   if (ncclxCfg->ibQpsPerConnection.has_value()) {
-    ERR("Per-comm ibQpsPerConnection override is not supported with splitShare=1");
+    ERR(ncclInvalidArgument,
+        "Per-comm ibQpsPerConnection override is not supported with splitShare=1");
     return ncclInvalidArgument;
   }
 

--- a/comms/ncclx/meta/collectives/AllReduceSparseBlock.cc
+++ b/comms/ncclx/meta/collectives/AllReduceSparseBlock.cc
@@ -12,7 +12,7 @@
 #define NCCLARGCHECK(statement, ...)                                        \
   do {                                                                      \
     if (!(statement)) {                                                     \
-      ERR_WITH_SCUBA(__VA_ARGS__);                                          \
+      ERR(ncclInvalidArgument, __VA_ARGS__);                                \
       return metaCommToNccl(ErrorStackTraceUtil::log(commInvalidArgument)); \
     }                                                                       \
   } while (0);

--- a/comms/ncclx/meta/comms-monitor/CommsMonitor.cc
+++ b/comms/ncclx/meta/comms-monitor/CommsMonitor.cc
@@ -54,7 +54,9 @@ folly::Singleton<CommsMonitor, CommsMonitorSingletonTag>
 bool CommsMonitor::deregisterCommImpl(ncclComm_t comm) {
   auto lockedMap = commsMap_.wlock();
   if (!lockedMap->contains(comm)) {
-    ERR("Deregistering comm %p that is not registered", comm);
+    ERR(ncclInternalError,
+        "Deregistering comm %p that is not registered",
+        comm);
     return false;
   }
   // Just mark the comm as dead. Since we have all the information, we can
@@ -176,7 +178,9 @@ CommDumpAllMap CommsMonitor::commDumpAllImpl(
   }
   auto commMonitorPtr = getInstance();
   if (commMonitorPtr == nullptr) {
-    ERR("Failed to get comms monitor instance to register comm %p", comm);
+    ERR(ncclInternalError,
+        "Failed to get comms monitor instance to register comm %p",
+        comm);
     return false;
   }
   return commMonitorPtr->deregisterCommImpl(comm);
@@ -188,7 +192,9 @@ CommDumpAllMap CommsMonitor::commDumpAllImpl(
   }
   auto commMonitorPtr = getInstance();
   if (commMonitorPtr == nullptr) {
-    ERR("Failed to get comms monitor instance to register comm %p", comm);
+    ERR(ncclInternalError,
+        "Failed to get comms monitor instance to register comm %p",
+        comm);
     return false;
   }
   return commMonitorPtr->registerCommImpl(comm);
@@ -201,7 +207,8 @@ CommDumpAllMap CommsMonitor::commDumpAllImpl(
   }
   auto lockedMap = commMonitorPtr->commsMap_.rlock();
   if (!lockedMap) {
-    ERR("Getting commsMap_ lock to get number of monitored comms timed out");
+    ERR(ncclInternalError,
+        "Getting commsMap_ lock to get number of monitored comms timed out");
     return -1;
   }
   return lockedMap->size();

--- a/comms/ncclx/meta/logger/DebugExt.cc
+++ b/comms/ncclx/meta/logger/DebugExt.cc
@@ -1,0 +1,63 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cstdarg>
+#include <cstdio>
+#include <vector>
+
+#include "core.h"
+#include "debug.h"
+
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/ErrorStackUtil.h"
+#include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/LoggingFormat.h"
+
+// These are Meta's logging implementations, kept out of the baseline debug.cc.
+// Guarded to v2_30+ since older versions keep their own copy in debug.cc.
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+
+void ncclMetaDebugLogError(
+    ncclResult_t code,
+    unsigned long flags,
+    const char* file,
+    const char* func,
+    int line,
+    const char* fmt,
+    ...) {
+  // Format the message once (same vsnprintf pattern as ncclMetaDebugLog).
+  size_t logLen = 0;
+  va_list vargs;
+  va_start(vargs, fmt);
+  logLen += std::vsnprintf(nullptr, 0, fmt, vargs);
+  va_end(vargs);
+
+  std::vector<char> buffer(logLen + 1); // +1 for null terminator
+  va_start(vargs, fmt);
+  // vsnprintf copy at most buf_size - 1 characters
+  std::vsnprintf(buffer.data(), buffer.size(), fmt, vargs);
+  va_end(vargs);
+
+  // Emit the folly ERR log via the common path so glog still shows 'E' and
+  // honors level/subsys filtering. Delegating also preserves the
+  // ncclDebugNoWarn downgrade and the ncclLastError save consistently with
+  // every other logging macro.
+  ncclMetaDebugLog(
+      NCCL_LOG_ERROR, flags, file, func, line, "%s", buffer.data());
+
+  const std::string message{buffer.data()};
+  // Capture the expensive native stack once and share it across all reporters.
+  std::vector<std::string> stack;
+  if (NCCL_SCUBA_STACK_TRACE_ON_ERROR_ENABLED) {
+    stack = ::meta::comms::logger::captureNativeErrorStack();
+  }
+  // ncclGetLastError state is independent of Scuba error logging.
+  ::meta::comms::logger::setLastError(message, stack);
+  // Scuba error record: hidden, env-gated; skip when downgraded via
+  // ncclDebugNoWarn.
+  if (ncclDebugNoWarn == 0 && NCCL_SCUBA_LOG_ERROR_ENABLED) {
+    ::meta::comms::logger::logErrorToScuba(
+        message, static_cast<int>(code), ncclCodeToString(code), stack);
+  }
+}
+
+#endif

--- a/comms/ncclx/meta/logger/tests/LoggingUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggingUT.cc
@@ -4,6 +4,7 @@
 
 #include <fmt/format.h>
 #include <folly/FileUtil.h>
+#include <folly/ScopeGuard.h>
 #include <folly/logging/LogMessage.h>
 #include <folly/testing/TestUtil.h>
 #include <gmock/gmock.h>
@@ -87,7 +88,7 @@ TEST_F(NcclLoggerTest, LogDisplay) {
 
   INFO(NCCL_ALL, "%s", TestStr.c_str());
   WARN("%s", TestStr.c_str());
-  ERR("%s", TestStr.c_str());
+  ERR(ncclInternalError, "%s", TestStr.c_str());
 
   finishLogging();
 }
@@ -119,7 +120,7 @@ TEST_F(NcclLoggerTest, GetLastCommsErrorTest) {
 
   // Log an error message - should update last error
   std::string errorMsg = "ERROR MESSAGE";
-  ERR("%s", errorMsg.c_str());
+  ERR(ncclInternalError, "%s", errorMsg.c_str());
   sleep(1);
   lastError = meta::comms::logger::getLastCommsError();
   EXPECT_THAT(lastError, ::testing::HasSubstr(errorMsg));
@@ -127,7 +128,7 @@ TEST_F(NcclLoggerTest, GetLastCommsErrorTest) {
 
   // Log another error message - should update to the new error
   std::string errorMsg2 = "SECOND ERROR MESSAGE";
-  ERR("%s", errorMsg2.c_str());
+  ERR(ncclInternalError, "%s", errorMsg2.c_str());
   sleep(1);
   lastError = meta::comms::logger::getLastCommsError();
   EXPECT_THAT(lastError, ::testing::HasSubstr(errorMsg2));
@@ -152,7 +153,7 @@ TEST_F(NcclLoggerTest, GetLastCommsErrorMultilineTest) {
 
   // Log a multiline error message
   std::string multilineError = "First line\nSecond line\nThird line";
-  ERR("%s", multilineError.c_str());
+  ERR(ncclInternalError, "%s", multilineError.c_str());
   sleep(1);
 
   auto lastError = meta::comms::logger::getLastCommsError();
@@ -170,7 +171,7 @@ TEST_F(NcclLoggerTest, GetLastCommsErrorLongMessageTest) {
 
   // Create a long error message (but within the 1024 char buffer)
   std::string longError(500, 'X');
-  ERR("%s", longError.c_str());
+  ERR(ncclInternalError, "%s", longError.c_str());
   sleep(1);
 
   auto lastError = meta::comms::logger::getLastCommsError();
@@ -205,7 +206,7 @@ TEST_F(NcclLoggerTest, WarnLogTest) {
   std::string TestStr = "TESTING";
 
   testing::internal::CaptureStdout();
-  ERR("%s", TestStr.c_str());
+  ERR(ncclInternalError, "%s", TestStr.c_str());
   sleep(1);
   std::string output = testing::internal::GetCapturedStdout();
   checkStringHasLogging(output, TestStr, "ERROR");
@@ -234,7 +235,7 @@ TEST_F(NcclLoggerTest, InfoLogTest) {
   std::string TestStr = "TESTING";
 
   testing::internal::CaptureStdout();
-  ERR("%s", TestStr.c_str());
+  ERR(ncclInternalError, "%s", TestStr.c_str());
   sleep(1);
   std::string output = testing::internal::GetCapturedStdout();
   checkStringHasLogging(output, TestStr, "ERROR");
@@ -325,6 +326,13 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
   setenv("NCCL_DEBUG", "INFO", 1);
   auto debugFileGuard = EnvRAII(NCCL_DEBUG_FILE, tempFile.string());
   setenv("NCCL_DEBUG_FILE", tempFile.c_str(), 1);
+  // EnvRAII only restores the NCCL_DEBUG_FILE cvar, not the raw OS env var. The
+  // tempFile lives in a TemporaryDirectory that is deleted at test end, so the
+  // OS env var must be unset on scope exit (even on the ASSERT_TRUE
+  // early-return below) or a later test's ncclCvarInit() would reload this
+  // stale path and NcclLogger would fail to open the deleted file.
+  auto debugFileEnvGuard =
+      folly::makeGuard([]() { unsetenv("NCCL_DEBUG_FILE"); });
   ncclResetDebugInit();
   initLogging();
 
@@ -341,7 +349,7 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
 
   INFO(NCCL_ALL, "%s", TestStr2.data());
   WARN("%s", TestStr2.data());
-  ERR("%s", TestStr2.data());
+  ERR(ncclInternalError, "%s", TestStr2.data());
 
   auto stderrOutput = testing::internal::GetCapturedStderr();
 
@@ -376,7 +384,7 @@ TEST_F(NcclLoggerTest, AppendErrorToStackTest) {
 
   // Log an error message first
   std::string errorMsg = "Base error message";
-  ERR("%s", errorMsg.c_str());
+  ERR(ncclInternalError, "%s", errorMsg.c_str());
   sleep(1);
 
   // Append stack frames
@@ -403,7 +411,7 @@ TEST_F(NcclLoggerTest, AppendErrorToStackOrderTest) {
 
   // Log an error message first
   std::string errorMsg = "Error for stack order test";
-  ERR("%s", errorMsg.c_str());
+  ERR(ncclInternalError, "%s", errorMsg.c_str());
   sleep(1);
 
   // Append stack frames in specific order
@@ -437,7 +445,7 @@ TEST_F(NcclLoggerTest, GetLastCommsErrorWithMultipleStackFrames) {
 
   // Log an error
   std::string errorMsg = "Critical error occurred";
-  ERR("%s", errorMsg.c_str());
+  ERR(ncclInternalError, "%s", errorMsg.c_str());
   sleep(1);
 
   // Add detailed stack trace
@@ -478,7 +486,7 @@ TEST_F(NcclLoggerTest, GetLastCommsErrorEmptyStackTrace) {
 
   // Log an error without adding any stack frames
   std::string errorMsg = "Simple error without stack";
-  ERR("%s", errorMsg.c_str());
+  ERR(ncclInternalError, "%s", errorMsg.c_str());
   sleep(1);
 
   auto lastError = meta::comms::logger::getLastCommsError();
@@ -490,176 +498,107 @@ TEST_F(NcclLoggerTest, GetLastCommsErrorEmptyStackTrace) {
   finishLogging();
 }
 
-TEST_F(NcclLoggerTest, WarnWithScubaAppendsToStackTrace) {
+// The following tests assert v2_30-only error behavior: plain ERR routes to the
+// Scuba error record, and WARN no longer contributes to the error stack. Older
+// ncclx versions keep the legacy behavior, so gate these tests to v2_30+.
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+
+TEST_F(NcclLoggerTest, WarnDoesNotContributeToErrorStack) {
   auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"INFO"});
   setenv("NCCL_DEBUG", "INFO", 1);
   ncclResetDebugInit();
 
   initLogging();
 
-  // Log an error first to set the error message
-  std::string errorMsg = "Initial error";
-  ERR("%s", errorMsg.c_str());
+  // An ERR sets the last error message.
+  const std::string errorMsg = "Initial error";
+  ERR(ncclInternalError, "%s", errorMsg.c_str());
   sleep(1);
 
-  // Use WARN_WITH_SCUBA to append to stack trace
-  WARN_WITH_SCUBA("Stack trace entry 1 from WARN_WITH_SCUBA");
-  WARN_WITH_SCUBA("Stack trace entry 2 from WARN_WITH_SCUBA");
+  // WARN is a propagator and must no longer append to the error stack.
+  const std::string warnMsg = "Propagator WARN should not be recorded";
+  WARN("%s", warnMsg.c_str());
+  sleep(1);
 
-  auto lastError = meta::comms::logger::getLastCommsError();
-  std::string errorStr(lastError);
-
+  const std::string errorStr(meta::comms::logger::getLastCommsError());
   EXPECT_THAT(errorStr, ::testing::HasSubstr(errorMsg));
   EXPECT_THAT(errorStr, ::testing::HasSubstr("NCCL Stack trace:"));
-  EXPECT_THAT(
-      errorStr,
-      ::testing::HasSubstr("Stack trace entry 1 from WARN_WITH_SCUBA"));
-  EXPECT_THAT(
-      errorStr,
-      ::testing::HasSubstr("Stack trace entry 2 from WARN_WITH_SCUBA"));
+  EXPECT_THAT(errorStr, ::testing::Not(::testing::HasSubstr(warnMsg)));
 
   finishLogging();
 }
 
-TEST_F(NcclLoggerTest, ErrWithScubaAppendsToStackTrace) {
+TEST_F(NcclLoggerTest, SecondErrorUpdatesLastError) {
   auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"INFO"});
   setenv("NCCL_DEBUG", "INFO", 1);
   ncclResetDebugInit();
 
   initLogging();
 
-  // Use ERR_WITH_SCUBA which should both log error and append to stack
-  ERR_WITH_SCUBA("Primary error from ERR_WITH_SCUBA");
+  ERR(ncclInternalError, "Base error message");
+  sleep(1);
+  ERR(ncclInternalError, "Newer error message");
   sleep(1);
 
-  // Add more stack frames
-  WARN_WITH_SCUBA("Additional context from WARN_WITH_SCUBA");
-  WARN_WITH_SCUBA("More context details");
-
-  auto lastError = meta::comms::logger::getLastCommsError();
-  std::string errorStr(lastError);
-
-  EXPECT_THAT(
-      errorStr, ::testing::HasSubstr("Primary error from ERR_WITH_SCUBA"));
-  EXPECT_THAT(errorStr, ::testing::HasSubstr("NCCL Stack trace:"));
-  EXPECT_THAT(
-      errorStr,
-      ::testing::HasSubstr("Additional context from WARN_WITH_SCUBA"));
-  EXPECT_THAT(errorStr, ::testing::HasSubstr("More context details"));
+  const std::string errorStr(meta::comms::logger::getLastCommsError());
+  EXPECT_THAT(errorStr, ::testing::HasSubstr("Newer error message"));
 
   finishLogging();
 }
 
-TEST_F(NcclLoggerTest, ScubaStackTraceOrder) {
+TEST_F(NcclLoggerTest, WarnNotAppendedButDirectAppendIs) {
   auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"INFO"});
   setenv("NCCL_DEBUG", "INFO", 1);
   ncclResetDebugInit();
 
   initLogging();
 
-  // Log an error
-  ERR("Base error message");
+  ERR(ncclInternalError, "Error occurred in operation");
   sleep(1);
 
-  // Use WARN_WITH_SCUBA in sequence
-  WARN_WITH_SCUBA("Frame A");
-  WARN_WITH_SCUBA("Frame B");
-  WARN_WITH_SCUBA("Frame C");
-
-  auto lastError = meta::comms::logger::getLastCommsError();
-  std::string errorStr(lastError);
-
-  // Verify the frames appear in order
-  size_t posA = errorStr.find("Frame A");
-  size_t posB = errorStr.find("Frame B");
-  size_t posC = errorStr.find("Frame C");
-
-  EXPECT_NE(posA, std::string::npos);
-  EXPECT_NE(posB, std::string::npos);
-  EXPECT_NE(posC, std::string::npos);
-  EXPECT_LT(posA, posB);
-  EXPECT_LT(posB, posC);
-
-  finishLogging();
-}
-
-TEST_F(NcclLoggerTest, MixedScubaAndDirectStackAppend) {
-  auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"INFO"});
-  setenv("NCCL_DEBUG", "INFO", 1);
-  ncclResetDebugInit();
-
-  initLogging();
-
-  // Log an error
-  ERR("Error occurred in operation");
+  // WARN must not appear in the error stack; direct appends still do.
+  WARN("This WARN must not appear in the error stack");
+  meta::comms::logger::appendErrorToStack("Direct append frame");
   sleep(1);
 
-  // Mix WARN_WITH_SCUBA and direct appendErrorToStack calls
-  WARN_WITH_SCUBA("From WARN_WITH_SCUBA 1");
-  meta::comms::logger::appendErrorToStack("From appendErrorToStack 1");
-  WARN_WITH_SCUBA("From WARN_WITH_SCUBA 2");
-  meta::comms::logger::appendErrorToStack("From appendErrorToStack 2");
-
-  auto lastError = meta::comms::logger::getLastCommsError();
-  std::string errorStr(lastError);
-
+  const std::string errorStr(meta::comms::logger::getLastCommsError());
   EXPECT_THAT(errorStr, ::testing::HasSubstr("Error occurred in operation"));
-  EXPECT_THAT(errorStr, ::testing::HasSubstr("From WARN_WITH_SCUBA 1"));
-  EXPECT_THAT(errorStr, ::testing::HasSubstr("From appendErrorToStack 1"));
-  EXPECT_THAT(errorStr, ::testing::HasSubstr("From WARN_WITH_SCUBA 2"));
-  EXPECT_THAT(errorStr, ::testing::HasSubstr("From appendErrorToStack 2"));
-
-  // Verify order is maintained
-  size_t pos1 = errorStr.find("From WARN_WITH_SCUBA 1");
-  size_t pos2 = errorStr.find("From appendErrorToStack 1");
-  size_t pos3 = errorStr.find("From WARN_WITH_SCUBA 2");
-  size_t pos4 = errorStr.find("From appendErrorToStack 2");
-
-  EXPECT_LT(pos1, pos2);
-  EXPECT_LT(pos2, pos3);
-  EXPECT_LT(pos3, pos4);
+  EXPECT_THAT(errorStr, ::testing::HasSubstr("Direct append frame"));
+  EXPECT_THAT(
+      errorStr,
+      ::testing::Not(::testing::HasSubstr("This WARN must not appear")));
 
   finishLogging();
 }
 
-TEST_F(NcclLoggerTest, ScubaStackTraceWithMultipleErrors) {
+TEST_F(NcclLoggerTest, SecondErrorUpdatesMessageKeepsAppendedStack) {
   auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"INFO"});
   setenv("NCCL_DEBUG", "INFO", 1);
   ncclResetDebugInit();
 
   initLogging();
 
-  // First error with stack
-  ERR("First error");
+  // First error with an appended stack frame.
+  ERR(ncclInternalError, "First error");
   sleep(1);
-  WARN_WITH_SCUBA("Stack for first error");
+  meta::comms::logger::appendErrorToStack("Stack for first error");
 
-  auto lastError1 = meta::comms::logger::getLastCommsError();
-  std::string errorStr1(lastError1);
+  const std::string errorStr1(meta::comms::logger::getLastCommsError());
   EXPECT_THAT(errorStr1, ::testing::HasSubstr("First error"));
   EXPECT_THAT(errorStr1, ::testing::HasSubstr("Stack for first error"));
 
-  // Second error should update the message but stack remains
-  ERR("Second error");
+  // A newer error updates the message; the appended stack remains.
+  ERR(ncclInternalError, "Second error");
   sleep(1);
 
-  auto lastError2 = meta::comms::logger::getLastCommsError();
-  std::string errorStr2(lastError2);
+  const std::string errorStr2(meta::comms::logger::getLastCommsError());
   EXPECT_THAT(errorStr2, ::testing::HasSubstr("Second error"));
-  // The old stack should still be there
   EXPECT_THAT(errorStr2, ::testing::HasSubstr("Stack for first error"));
-
-  // Add more stack for second error
-  WARN_WITH_SCUBA("Stack for second error");
-
-  auto lastError3 = meta::comms::logger::getLastCommsError();
-  std::string errorStr3(lastError3);
-  EXPECT_THAT(errorStr3, ::testing::HasSubstr("Second error"));
-  EXPECT_THAT(errorStr3, ::testing::HasSubstr("Stack for first error"));
-  EXPECT_THAT(errorStr3, ::testing::HasSubstr("Stack for second error"));
 
   finishLogging();
 }
+
+#endif // NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
 
 TEST_F(NcclLoggerTest, TestUtilsLogHandler) {
   ncclResetDebugInit();
@@ -710,7 +649,7 @@ TEST_F(NcclLoggerTest, TestUtilsLogHandler) {
 
   INFO(NCCL_ALL, "%s", TestStr.c_str());
   WARN("%s", TestStr.c_str());
-  ERR("%s", TestStr.c_str());
+  ERR(ncclInternalError, "%s", TestStr.c_str());
 
   finishLogging();
 }

--- a/comms/ncclx/meta/tcpstore/TCPSocket.cc
+++ b/comms/ncclx/meta/tcpstore/TCPSocket.cc
@@ -259,7 +259,7 @@ std::unique_ptr<SocketImpl> SocketConnectOp::run() {
       host_,
       port_);
 
-  ERR("%s", msg.c_str());
+  ERR(ncclInternalError, "%s", msg.c_str());
   throw std::runtime_error(msg);
 }
 
@@ -458,7 +458,7 @@ void SocketConnectOp::throwTimeoutError() const {
       host_,
       port_);
 
-  ERR("%s", msg.c_str());
+  ERR(ncclInternalError, "%s", msg.c_str());
   throw std::runtime_error(msg);
 }
 

--- a/comms/ncclx/meta/transport/transportProxy.cc
+++ b/comms/ncclx/meta/transport/transportProxy.cc
@@ -65,7 +65,7 @@ TransportProxy::TransportProxy(struct ncclComm* comm) : parentComm_(comm) {
   ncclResult_t allocRes =
       ncclCuMemHostAlloc((void**)&syncPoolPtr_, nullptr, kDefaultSyncPoolSize);
   if (allocRes != ncclSuccess && allocRes != ncclInProgress) {
-    WARN_WITH_SCUBA(
+    WARN(
         "%s:%s:%d -> %d (%s)",
         __FILE__,
         __func__,
@@ -112,7 +112,7 @@ void TransportProxy::shutdown() {
     syncFlagPool_.clear();
     ncclResult_t freeRes = ncclCuMemHostFree((void*)syncPoolPtr_);
     if (freeRes != ncclSuccess && freeRes != ncclInProgress) {
-      WARN_WITH_SCUBA(
+      WARN(
           "%s:%s:%d -> %d (%s)",
           __FILE__,
           __func__,

--- a/comms/ncclx/v2_29/src/include/debug.h
+++ b/comms/ncclx/v2_29/src/include/debug.h
@@ -33,7 +33,7 @@ extern char ncclLastError[];
 
 #define VERSION(...) ncclMetaDebugLog(NCCL_LOG_VERSION, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
 #define WARN(...) ncclMetaDebugLog(NCCL_LOG_WARN, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
-#define ERR(...) ncclMetaDebugLog(NCCL_LOG_ERROR, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define ERR(code, ...) ncclMetaDebugLog(NCCL_LOG_ERROR, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
 
 #define WARN_WITH_SCUBA(...) ncclMetaDebugLogWithScuba(NCCL_LOG_WARN, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
 #define ERR_WITH_SCUBA(...) ncclMetaDebugLogWithScuba(NCCL_LOG_ERROR, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)

--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -2610,7 +2610,7 @@ ncclResult_t ncclCommInitRankConfig(ncclComm_t *newcomm, int nranks, ncclUniqueI
     // memset to 0 as it will be used to generate hostHash
     memset(&commId, 0, sizeof(commId));
   } else if (!uniqueIdIsInitialized && NCCL_COMM_ID.empty()) {
-    ERR("No ncclUniqueId provided in nccl baseline init mode, please set TORCH_NCCL_BCAST_UNIQUEID=1 or set NCCL_COMM_ID env variable");
+    ERR(ncclInvalidUsage, "No ncclUniqueId provided in nccl baseline init mode, please set TORCH_NCCL_BCAST_UNIQUEID=1 or set NCCL_COMM_ID env variable");
     return ncclInvalidUsage;
   }
 

--- a/comms/ncclx/v2_29/src/register/register.cc
+++ b/comms/ncclx/v2_29/src/register/register.cc
@@ -126,7 +126,7 @@ ncclResult_t ncclCommRegister(const ncclComm_t comm, void* buff, size_t size, vo
   // FIXME: we should eventually support hybrid registration.
   // Disable it for now to avoid undefined behavior due to handle conflict.
   if (NCCL_CTRAN_REGISTER != NCCL_CTRAN_REGISTER::none && ncclParamLocalRegister()) {
-    ERR("Invalid usage to turn on NCCL_CTRAN_REGISTER and NCCL_LOCAL_REGISTER at the same time.");
+    ERR(ncclInvalidUsage, "Invalid usage to turn on NCCL_CTRAN_REGISTER and NCCL_LOCAL_REGISTER at the same time.");
     return metaCommToNccl(ErrorStackTraceUtil::log(commInvalidUsage));
   }
 
@@ -207,7 +207,7 @@ ncclResult_t ncclCommDeregister(const ncclComm_t comm, void *handle) {
   // FIXME: we should eventually support hybrid registration.
   // Disable it for now to avoid undefined behavior due to handle conflict.
   if (NCCL_CTRAN_REGISTER != NCCL_CTRAN_REGISTER::none && ncclParamLocalRegister()) {
-    ERR("Invalid usage to turn on NCCL_CTRAN_REGISTER and NCCL_LOCAL_REGISTER at the same time.");
+    ERR(ncclInvalidUsage, "Invalid usage to turn on NCCL_CTRAN_REGISTER and NCCL_LOCAL_REGISTER at the same time.");
     return metaCommToNccl(ErrorStackTraceUtil::log(commInvalidUsage));
   }
 

--- a/comms/ncclx/v2_30/src/allocator.cc
+++ b/comms/ncclx/v2_30/src/allocator.cc
@@ -227,13 +227,13 @@ ncclResult_t ncclSpaceAlloc(
     }
     i += 2; // Next empty segment
   }
-  WARN("Allocation failed. No suitable space found to accommodate size=0x%lx within limit=0x%lx", (long)size, (long)limit);
+  ERR(ncclInternalError, "Allocation failed. No suitable space found to accommodate size=0x%lx within limit=0x%lx", (long)size, (long)limit);
   return ncclInternalError;
 }
 
 ncclResult_t ncclSpaceFree(struct ncclSpace* a, int64_t offset, int64_t size) {
   if (a->count == 0 || a->cuts[a->count-1] <= offset) {
-    WARN("No allocation found at offset=0x%lx", (long)offset);
+    ERR(ncclInternalError, "No allocation found at offset=0x%lx", (long)offset);
     return ncclInternalError;
   }
 
@@ -245,7 +245,7 @@ ncclResult_t ncclSpaceFree(struct ncclSpace* a, int64_t offset, int64_t size) {
   int64_t hi = a->cuts[i];
 
   if (offset < lo || hi < offset + size) {
-    WARN("Given size=0x%lx extends beyond allocation.", (long)size);
+    ERR(ncclInternalError, "Given size=0x%lx extends beyond allocation.", (long)size);
     return ncclInternalError;
   }
 
@@ -427,7 +427,7 @@ ncclResult_t ncclShadowPoolFree(struct ncclShadowPool* pool, void* devObj, cudaS
   struct ncclShadowObject** pobj = &pool->table[b];
   while (true) {
     if (*pobj == nullptr) {
-      WARN("Device object does not exist in shadow pool.");
+      ERR(ncclInternalError, "Device object does not exist in shadow pool.");
       return ncclInternalError;
     }
     if ((*pobj)->devObj == devObj) break;
@@ -460,7 +460,7 @@ ncclResult_t ncclShadowPoolToHost(struct ncclShadowPool* pool, void* devObj, voi
   struct ncclShadowObject* obj = pool->table[b];
   while (true) {
     if (obj == nullptr) {
-      WARN("Device object does not exist in shadow pool.");
+      ERR(ncclInternalError, "Device object does not exist in shadow pool.");
       return ncclInternalError;
     }
     if (obj->devObj == devObj) break;

--- a/comms/ncclx/v2_30/src/bootstrap.cc
+++ b/comms/ncclx/v2_30/src/bootstrap.cc
@@ -122,19 +122,19 @@ ncclResult_t bootstrapNetInit() {
       if (env) {
         union ncclSocketAddress remoteAddr;
         if (ncclSocketGetAddrFromString(&remoteAddr, env) != ncclSuccess) {
-          WARN("Invalid NCCL_COMM_ID, please use format: <ipv4>:<port> or [<ipv6>]:<port> or <hostname>:<port>");
+          ERR(ncclInvalidArgument, "Invalid NCCL_COMM_ID, please use format: <ipv4>:<port> or [<ipv6>]:<port> or <hostname>:<port>");
           return ncclInvalidArgument;
         }
         NCCLCHECK(ncclFindInterfaceMatchSubnet(bootstrapNetIfName, &bootstrapNetIfAddr, &remoteAddr, MAX_IF_NAME_SIZE,
                                                &nIfs));
         if (nIfs <= 0) {
-          WARN("NET/Socket : No usable listening interface found");
+          ERR(ncclSystemError, "NET/Socket : No usable listening interface found");
           return ncclSystemError;
         }
       } else {
         NCCLCHECK(ncclFindInterfaces(bootstrapNetIfName, &bootstrapNetIfAddr, MAX_IF_NAME_SIZE, 1, &nIfs));
         if (nIfs <= 0) {
-          WARN("Bootstrap : no socket interface found");
+          ERR(ncclInvalidUsage, "Bootstrap : no socket interface found");
           return ncclInvalidUsage;
         }
       }
@@ -229,7 +229,7 @@ static ncclResult_t socketRecv(struct ncclSocket* sock, void* data, int size) {
   int recvSize;
   NCCLCHECK(ncclSocketRecv(sock, &recvSize, sizeof(int)));
   if (recvSize > size) {
-    WARN("Message truncated : received %d bytes instead of %d", recvSize, size);
+    ERR(ncclInternalError, "Message truncated : received %d bytes instead of %d", recvSize, size);
     return ncclInternalError;
   }
   int actualSize = std::min(recvSize, size);
@@ -242,7 +242,7 @@ static ncclResult_t socketSendRecv(struct ncclSocket* sendSock, void* sendData, 
   int senderRecvSize;
   NCCLCHECK(ncclSocketSendRecv(sendSock, &sendSize, sizeof(int), recvSock, &senderRecvSize, sizeof(int)));
   if (senderRecvSize > recvSize) {
-    WARN("Message truncated : received %d bytes instead of %d", senderRecvSize, recvSize);
+    ERR(ncclInternalError, "Message truncated : received %d bytes instead of %d", senderRecvSize, recvSize);
     return ncclInternalError;
   }
   NCCLCHECK(ncclSocketSendRecv(sendSock, sendData, sendSize, recvSock, recvData, std::min(recvSize, senderRecvSize)));
@@ -255,7 +255,7 @@ static ncclResult_t socketDoubleSendRecv(struct ncclSocketOp ops[4]) {
   NCCLCHECK(ncclSocketSendRecv(ops[0].sock, &ops[0].size, sizeof(int), ops[1].sock, &senderRecvSize1, sizeof(int)));
   NCCLCHECK(ncclSocketSendRecv(ops[2].sock, &ops[2].size, sizeof(int), ops[3].sock, &senderRecvSize2, sizeof(int)));
   if (senderRecvSize1 > ops[1].size || senderRecvSize2 > ops[3].size) {
-    WARN("Message truncated : received %d,%d bytes instead of %d,%d", senderRecvSize1, senderRecvSize2, ops[1].size, ops[3].size);
+    ERR(ncclInternalError, "Message truncated : received %d,%d bytes instead of %d,%d", senderRecvSize1, senderRecvSize2, ops[1].size, ops[3].size);
     return ncclInternalError;
   }
   ops[1].size = std::min(ops[1].size, senderRecvSize1);
@@ -340,19 +340,19 @@ static void* bootstrapRoot(void* rargs) {
     }
 
     if (nranks != info.nranks || nroots != info.nroots || iroot != info.iroot || offset != info.offset) {
-      WARN("Bootstrap Root : mismatch in info from procs, nranks %d vs %d, nroots %d vs %d, iroot %d vs %d, offset %d vs %d",
+      ERR(ncclInternalError, "Bootstrap Root : mismatch in info from procs, nranks %d vs %d, nroots %d vs %d, iroot %d vs %d, offset %d vs %d",
         nranks, info.nranks, nroots, info.nroots, iroot, info.iroot, offset, info.offset);
         goto out;
     }
 
     localId = localIdFromRoot(info.rank, iroot, nranks, nroots, offset);
     if (localId < 0 || localId >= nrecv) {
-      WARN("Bootstrap Root : localId %d is out of range", localId);
+      ERR(ncclInternalError, "Bootstrap Root : localId %d is out of range", localId);
       goto out;
     }
     if (memcmp(&zeroAddress, &rankAddressesRoot[localId], sizeof(union ncclSocketAddress)) != 0 ||
         memcmp(&zeroInfo, &rankInfo[localId], sizeof(union ringConnectInfo)) != 0) {
-      WARN("Bootstrap Root : rank %d of %d ranks has already checked in", info.rank, nranks);
+      ERR(ncclInternalError, "Bootstrap Root : rank %d of %d ranks has already checked in", info.rank, nranks);
       goto out;
     }
     // if the previous has already checked in, send the newly received handle, if not save the handle for later
@@ -439,13 +439,13 @@ ncclResult_t bootstrapGetUniqueId(struct ncclBootstrapHandle* handle, struct ncc
   if (env) {
     // If comm is provided (grow operation), NCCL_COMM_ID should not be set
     if (comm) {
-      WARN("ncclCommGetUniqueId should not be called when NCCL_COMM_ID is set");
+      ERR(ncclInvalidUsage, "ncclCommGetUniqueId should not be called when NCCL_COMM_ID is set");
       return ncclInvalidUsage;
     }
     // Normal init: use NCCL_COMM_ID from environment
     INFO(NCCL_ENV, "NCCL_COMM_ID set by environment to %s", env);
     if (ncclSocketGetAddrFromString(&handle->addr, env) != ncclSuccess) {
-      WARN("Invalid NCCL_COMM_ID, please use format: <ipv4>:<port> or [<ipv6>]:<port> or <hostname>:<port>");
+      ERR(ncclInvalidArgument, "Invalid NCCL_COMM_ID, please use format: <ipv4>:<port> or [<ipv6>]:<port> or <hostname>:<port>");
       return ncclInvalidArgument;
     }
     handle->magic = NCCL_MAGIC;
@@ -466,7 +466,7 @@ ncclResult_t bootstrapGetUniqueId(struct ncclBootstrapHandle* handle, struct ncc
 
 ncclResult_t bcastGrowHandle(struct ncclBootstrapHandle* handle, struct ncclComm* parent, bool isRoot) {
   if (!parent || !handle) {
-    WARN("bcastGrowHandle: parent comm and handle must be provided");
+    ERR(ncclInvalidArgument, "bcastGrowHandle: parent comm and handle must be provided");
     return ncclInvalidArgument;
   }
 
@@ -531,9 +531,9 @@ static ncclResult_t netGetDevice(int rank, struct ncclComm* comm, int* dev) {
         }
         if (devOOB == -1) {
           if (!searchNot)
-            WARN("no device found matching %s%s, verify NCCL_OOB_NET_IFNAME", searchExact ? "exactly " : "", userIfEnv);
+            ERR(ncclInvalidArgument, "no device found matching %s%s, verify NCCL_OOB_NET_IFNAME", searchExact ? "exactly " : "", userIfEnv);
           else
-            WARN("no device found after excluding %s%s, verify NCCL_OOB_NET_IFNAME", searchExact ? "exactly " : "", userIfEnv);
+            ERR(ncclInvalidArgument, "no device found after excluding %s%s, verify NCCL_OOB_NET_IFNAME", searchExact ? "exactly " : "", userIfEnv);
           return ncclInvalidArgument;
         }
       } else {
@@ -738,7 +738,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
   } else if (parent != NULL) {
     comm->magic = state->magic = hashCombine(parent->magic, parent->childCount);
   } else {
-    WARN("bootstrapInit: handles and parent are NULL");
+    ERR(ncclSystemError, "bootstrapInit: handles and parent are NULL");
     return ncclSystemError;
   }
 
@@ -778,7 +778,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
       if(handles != NULL) {
         offset = BOOTSTRAP_HANDLE(handles, 0)->nRanks - 1;
       } else {
-        WARN("bootstrapInit: handles and parent are NULL");
+        ERR(ncclSystemError, "bootstrapInit: handles and parent are NULL");
         return ncclSystemError;
       }
     }
@@ -1306,7 +1306,7 @@ ncclResult_t bootstrapClose(void* commState) {
   if (state->unexpectedConnections != NULL) {
     unexpectedFree(state);
     if (COMPILER_ATOMIC_LOAD(state->abortFlag, std::memory_order_acquire) == 0) {
-      WARN("Unexpected connections are not empty");
+      ERR(ncclInternalError, "Unexpected connections are not empty");
       return ncclInternalError;
     }
   }

--- a/comms/ncclx/v2_30/src/debug.cc
+++ b/comms/ncclx/v2_30/src/debug.cc
@@ -27,10 +27,8 @@
 #include <folly/logging/LogStreamProcessor.h>
 #include <folly/logging/xlog.h>
 
-#include "comms/utils/logger/ErrorStackUtil.h"
 #include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/LoggingFormat.h"
-#include "comms/utils/cvars/nccl_cvars.h"
 
 #define NCCL_DEBUG_RESET_TRIGGERED (-2)
 
@@ -467,41 +465,6 @@ void ncclSetThreadName(std::thread& thread, const char *fmt, ...) {
 
 void ncclSetMyThreadLoggingName(std::string_view name) {
   meta::comms::logger::initThreadMetaData(name);
-}
-
-void ncclMetaDebugLogError(ncclResult_t code, unsigned long flags, const char *file, const char *func, int line, const char *fmt, ...) {
-  // Format the message once (same vsnprintf pattern as ncclMetaDebugLog).
-  size_t logLen = 0;
-  va_list vargs;
-  va_start(vargs, fmt);
-  logLen += std::vsnprintf(nullptr, 0, fmt, vargs);
-  va_end(vargs);
-
-  std::vector<char> buffer(logLen + 1); // +1 for null terminator
-  va_start(vargs, fmt);
-  // vsnprintf copy at most buf_size - 1 characters
-  std::vsnprintf(buffer.data(), buffer.size(), fmt, vargs);
-  va_end(vargs);
-
-  // Emit the folly ERR log via the common path so glog still shows 'E' and
-  // honors level/subsys filtering. Delegating also preserves the
-  // ncclDebugNoWarn downgrade and the ncclLastError save consistently with
-  // every other logging macro.
-  ncclMetaDebugLog(NCCL_LOG_ERROR, flags, file, func, line, "%s", buffer.data());
-
-  const std::string message{buffer.data()};
-  // Capture the expensive native stack once and share it across all reporters.
-  std::vector<std::string> stack;
-  if (NCCL_SCUBA_STACK_TRACE_ON_ERROR_ENABLED) {
-    stack = ::meta::comms::logger::captureNativeErrorStack();
-  }
-  // ncclGetLastError state is independent of Scuba error logging.
-  ::meta::comms::logger::setLastError(message, stack);
-  // Scuba error record: hidden, env-gated; skip when downgraded via ncclDebugNoWarn.
-  if (ncclDebugNoWarn == 0 && NCCL_SCUBA_LOG_ERROR_ENABLED) {
-    ::meta::comms::logger::logErrorToScuba(
-        message, static_cast<int>(code), ncclCodeToString(code), stack);
-  }
 }
 
 /* Meta's logging function with separate file and func parameters.

--- a/comms/ncclx/v2_30/src/debug.cc
+++ b/comms/ncclx/v2_30/src/debug.cc
@@ -27,9 +27,10 @@
 #include <folly/logging/LogStreamProcessor.h>
 #include <folly/logging/xlog.h>
 
+#include "comms/utils/logger/ErrorStackUtil.h"
 #include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/LoggingFormat.h"
-#include "comms/ctran/utils/ErrorStackTraceUtil.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 
 #define NCCL_DEBUG_RESET_TRIGGERED (-2)
 
@@ -468,15 +469,39 @@ void ncclSetMyThreadLoggingName(std::string_view name) {
   meta::comms::logger::initThreadMetaData(name);
 }
 
-void ncclMetaDebugLogWithScuba(ncclDebugLogLevel level, unsigned long flags, const char *file, const char *func, int line, const char *fmt, ...) {
-  char buffer[256];
+void ncclMetaDebugLogError(ncclResult_t code, unsigned long flags, const char *file, const char *func, int line, const char *fmt, ...) {
+  // Format the message once (same vsnprintf pattern as ncclMetaDebugLog).
+  size_t logLen = 0;
   va_list vargs;
   va_start(vargs, fmt);
-  (void) vsnprintf(buffer, sizeof(buffer), fmt, vargs);
+  logLen += std::vsnprintf(nullptr, 0, fmt, vargs);
   va_end(vargs);
-  ::meta::comms::logger::appendErrorToStack(std::string{buffer});
-  ErrorStackTraceUtil::logErrorMessage(std::string{buffer});
-  ncclMetaDebugLog(level, flags, file, func, line, "%s", buffer);
+
+  std::vector<char> buffer(logLen + 1); // +1 for null terminator
+  va_start(vargs, fmt);
+  // vsnprintf copy at most buf_size - 1 characters
+  std::vsnprintf(buffer.data(), buffer.size(), fmt, vargs);
+  va_end(vargs);
+
+  // Emit the folly ERR log via the common path so glog still shows 'E' and
+  // honors level/subsys filtering. Delegating also preserves the
+  // ncclDebugNoWarn downgrade and the ncclLastError save consistently with
+  // every other logging macro.
+  ncclMetaDebugLog(NCCL_LOG_ERROR, flags, file, func, line, "%s", buffer.data());
+
+  const std::string message{buffer.data()};
+  // Capture the expensive native stack once and share it across all reporters.
+  std::vector<std::string> stack;
+  if (NCCL_SCUBA_STACK_TRACE_ON_ERROR_ENABLED) {
+    stack = ::meta::comms::logger::captureNativeErrorStack();
+  }
+  // ncclGetLastError state is independent of Scuba error logging.
+  ::meta::comms::logger::setLastError(message, stack);
+  // Scuba error record: hidden, env-gated; skip when downgraded via ncclDebugNoWarn.
+  if (ncclDebugNoWarn == 0 && NCCL_SCUBA_LOG_ERROR_ENABLED) {
+    ::meta::comms::logger::logErrorToScuba(
+        message, static_cast<int>(code), ncclCodeToString(code), stack);
+  }
 }
 
 /* Meta's logging function with separate file and func parameters.

--- a/comms/ncclx/v2_30/src/dev_runtime.cc
+++ b/comms/ncclx/v2_30/src/dev_runtime.cc
@@ -419,7 +419,7 @@ static ncclResult_t symTeamObtain(
 
   if (multimem) {
     if (!comm->nvlsSupport) {
-      WARN("Multicast support requested for team but none available on system.");
+      ERR(ncclInvalidArgument, "Multicast support requested for team but none available on system.");
       ret = ncclInvalidArgument;
       goto fail;
     } else {
@@ -512,7 +512,7 @@ static void symTeamDestroyAll(struct ncclComm* comm) {
 
 static ncclResult_t symMemoryRegisterGin(struct ncclComm* comm, struct ncclDevrMemory* mem) {
   if (mem->hasSysmemSegment) {
-    WARN("Window registration of addresses that contain CPU-backed physical segments is currently not supported with GIN.");
+    ERR(ncclInvalidArgument, "Window registration of addresses that contain CPU-backed physical segments is currently not supported with GIN.");
     return ncclInvalidArgument;
   }
   NCCLCHECK(ncclGinRegister(comm, mem->primaryAddr, mem->size, mem->ginHostWins, mem->ginDevWins, mem->winFlags,
@@ -993,7 +993,7 @@ ncclResult_t ncclDevrWindowRegisterInGroup(
 
     // GIN must already be connected via a prior collective window registration.
     if (!devr->ginEnabled) {
-      WARN("NCCL_WIN_LOCAL_ONLY requires GIN to be enabled. Register a collective window first.");
+      ERR(ncclInvalidUsage, "NCCL_WIN_LOCAL_ONLY requires GIN to be enabled. Register a collective window first.");
       ret = ncclInvalidUsage;
       goto fail_locReg;
     }
@@ -1026,7 +1026,7 @@ ncclResult_t ncclDevrWindowRegisterInGroup(
 
   if (hasSysmemSegment) {
     if (!ncclParamElasticBufferRegister()) {
-      WARN("VA represented by {userPtr = %p, size = %zu} contains CPU-backed physical segments, but NCCL_ELASTIC_BUFFER_REGISTER is set to 0. Please set NCCL_ELASTIC_BUFFER_REGISTER=1 and retry window registration", userPtr, userSize);
+      ERR(ncclInvalidArgument, "VA represented by {userPtr = %p, size = %zu} contains CPU-backed physical segments, but NCCL_ELASTIC_BUFFER_REGISTER is set to 0. Please set NCCL_ELASTIC_BUFFER_REGISTER=1 and retry window registration", userPtr, userSize);
       ret = ncclInvalidArgument;
       goto fail_locReg;
     }
@@ -1035,7 +1035,7 @@ ncclResult_t ncclDevrWindowRegisterInGroup(
         int multiNodeLsaSupported = 0;
         CUCHECKGOTO(cuDeviceGetAttribute(&multiNodeLsaSupported, CU_DEVICE_ATTRIBUTE_HOST_NUMA_MULTINODE_IPC_SUPPORTED, comm->cudaDev), ret, fail_locReg);
         if (!multiNodeLsaSupported) {
-          WARN("VA represented by {userPtr = %p, size = %zu} contains CPU-backed physical segments, but the LSA team does not support multi-node IPC on CPU-backed buffers. Please retry by setting NCCL_MNNVL_ENABLE=0", userPtr, userSize);
+          ERR(ncclInvalidArgument, "VA represented by {userPtr = %p, size = %zu} contains CPU-backed physical segments, but the LSA team does not support multi-node IPC on CPU-backed buffers. Please retry by setting NCCL_MNNVL_ENABLE=0", userPtr, userSize);
           ret = ncclInvalidArgument;
           goto fail_locReg;
         }
@@ -1045,7 +1045,7 @@ ncclResult_t ncclDevrWindowRegisterInGroup(
 
   memOffset = reinterpret_cast<CUdeviceptr>(userPtr) - memAddr;
   if (memOffset%NCCL_WIN_REQUIRED_ALIGNMENT != 0) {
-    WARN("Window address must be suitably aligned.");
+    ERR(ncclInvalidArgument, "Window address must be suitably aligned.");
     ret = ncclInvalidArgument;
     goto fail_locReg;
   }
@@ -1282,18 +1282,18 @@ ncclResult_t ncclDevrCommCreateInternal(
 
   bool requestedGinResources = ncclGinResourcesRequested(reqs);
   if (requestedGinResources && requestedConnectionType == NCCL_GIN_CONNECTION_NONE) {
-    WARN("User requested GIN resources but did not request GIN to be enabled!");
+    ERR(ncclInvalidArgument, "User requested GIN resources but did not request GIN to be enabled!");
     return ncclInvalidArgument;
   }
 
   if (requestedConnectionType != NCCL_GIN_CONNECTION_NONE) {
     if (comm->globalGinSupport == NCCL_GIN_CONNECTION_NONE) {
-      WARN("User requested GIN but not all ranks in the communicator support GIN");
+      ERR(ncclInvalidArgument, "User requested GIN but not all ranks in the communicator support GIN");
       return ncclInvalidArgument;
     }
     if (requestedConnectionType == NCCL_GIN_CONNECTION_FULL) {
       if (comm->globalGinSupport == NCCL_GIN_CONNECTION_RAIL) {
-        WARN("User requested GIN connection type NCCL_GIN_CONNECTION_FULL but the communicator supports only NCCL_GIN_CONNECTION_RAIL");
+        ERR(ncclInvalidArgument, "User requested GIN connection type NCCL_GIN_CONNECTION_FULL but the communicator supports only NCCL_GIN_CONNECTION_RAIL");
         return ncclInvalidArgument;
       }
     }
@@ -1516,7 +1516,7 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
   NCCLCHECK(PtrCheck(win, __func__, "win"));
   *win = nullptr;
   if (buff == nullptr || size <= 0) {
-    WARN("%s: invalid pointer %p / size %zu", __func__, buff, size);
+    ERR(ncclInvalidArgument, "%s: invalid pointer %p / size %zu", __func__, buff, size);
     return ncclInvalidArgument;
   }
 
@@ -1646,7 +1646,7 @@ static ncclResult_t getNcclVersionCompat(int compiledVersion, struct ncclDevComm
 
   if (compiledVersion > NCCL_VERSION_CODE && ncclParamEnableVersionCheck()) {
     char compiledBuf[16], runtimeBuf[16];
-    WARN("NCCL library is too old. This application was compiled with NCCL version %s, but is running with NCCL library version %s.",
+    ERR(ncclInvalidUsage, "NCCL library is too old. This application was compiled with NCCL version %s, but is running with NCCL library version %s.",
          ncclVersionToString(compiledVersion, compiledBuf, sizeof(compiledBuf)),
          ncclVersionToString(NCCL_VERSION_CODE, runtimeBuf, sizeof(runtimeBuf)));
     return ncclInvalidUsage;
@@ -1661,7 +1661,7 @@ static ncclResult_t getNcclVersionCompat(int compiledVersion, struct ncclDevComm
   }
   if (devCompat == nullptr) {
     char compiledBuf[16], runtimeBuf[16];
-    WARN("NCCL library is not backwards compatible. This application was compiled with NCCL version %s, but is running with NCCL library version %s.",
+    ERR(ncclInvalidUsage, "NCCL library is not backwards compatible. This application was compiled with NCCL version %s, but is running with NCCL library version %s.",
          ncclVersionToString(compiledVersion, compiledBuf, sizeof(compiledBuf)),
          ncclVersionToString(NCCL_VERSION_CODE, runtimeBuf, sizeof(runtimeBuf)));
     return ncclInvalidUsage;
@@ -1683,7 +1683,7 @@ ncclResult_t ncclCommQueryProperties(ncclComm_t comm, ncclCommProperties_t* prop
   NCCLCHECK(ncclCommEnsureReady(comm));
 
   if (props->magic != NCCL_API_MAGIC) {
-    WARN("Cannot get communicator properties: ncclCommProperties_t argument must be initialized via NCCL_COMM_PROPERTIES_INITIALIZER");
+    ERR(ncclInvalidUsage, "Cannot get communicator properties: ncclCommProperties_t argument must be initialized via NCCL_COMM_PROPERTIES_INITIALIZER");
     return ncclInvalidUsage;
   }
 
@@ -1723,7 +1723,7 @@ ncclResult_t ncclDevCommCreate(
   NCCLCHECK(CommCheck(comm, __func__, "comm"));
   NCCLCHECK(PtrCheck(reqs, __func__, "reqs"));
   if (reqs->magic != NCCL_API_MAGIC) {
-    WARN("Cannot create device communicator: ncclDevCommRequirements_t argument must be initialized via NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER");
+    ERR(ncclInvalidUsage, "Cannot create device communicator: ncclDevCommRequirements_t argument must be initialized via NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER");
     return ncclInvalidUsage;
   }
 
@@ -1738,7 +1738,7 @@ ncclResult_t ncclDevCommCreate(
   NCCLCHECK(ncclGroupStartInternal());
 
   if (!comm->symmetricSupport) {
-    WARN("Communicator does not support symmetric memory!");
+    ERR(ncclInvalidUsage, "Communicator does not support symmetric memory!");
     ret = ncclInvalidUsage;
     goto fail;
   }
@@ -1828,7 +1828,7 @@ ncclResult_t ncclWinGetUserPtr(struct ncclComm* comm, struct ncclWindow_vidmem* 
 
   winHost = (struct ncclDevrWindow*)winDevHost->winHost;
   if (winHost == nullptr) {
-    WARN("window has a NULL user pointer");
+    ERR(ncclInternalError, "window has a NULL user pointer");
     return ncclInternalError;
   }
 
@@ -1840,7 +1840,7 @@ ncclResult_t ncclDevrWorldToLsaRank(struct ncclComm* comm, int peerWorldRank, in
   ncclTeam_t worldTeam = ncclTeamWorld(comm);
   ncclTeam_t lsaTeam = ncclTeamLsa(comm);
   if (!ncclTeamRankIsMember(lsaTeam, worldTeam, peerWorldRank)) {
-    WARN("ncclDevrWorldToLsaRank: world rank %d is not a member of the LSA team", peerWorldRank);
+    ERR(ncclInternalError, "ncclDevrWorldToLsaRank: world rank %d is not a member of the LSA team", peerWorldRank);
     return ncclInternalError;
   }
   *peerLsaRank = ncclTeamRankToTeam(lsaTeam, worldTeam, peerWorldRank);
@@ -1885,7 +1885,7 @@ ncclResult_t ncclDevrGetLsaTeamPtrMC(struct ncclComm* comm, struct ncclDevrWindo
   if (winHost == nullptr || outPtr == nullptr) return ncclInternalError;
 
   if (!comm->nvlsSupport) {
-    WARN("Multimem pointer requested but system does not support multimem.");
+    ERR(ncclInvalidUsage, "Multimem pointer requested but system does not support multimem.");
     return ncclInvalidUsage;
   }
 
@@ -1903,7 +1903,7 @@ static ncclResult_t findCommAndHostWindowFromDeviceWindow(ncclWindow_t devWindow
   std::lock_guard<std::mutex> lock(ncclWindowMapMutex);
   NCCLCHECK(ncclIntruAddressMapFind(&ncclWindowMap, devWindow, &winHost));
   if (winHost == nullptr) {
-    WARN("Could not find communicator matching window %p (map hbits=%d count=%d)",
+    ERR(ncclInvalidArgument, "Could not find communicator matching window %p (map hbits=%d count=%d)",
          devWindow, ncclWindowMap.base.hbits, ncclWindowMap.base.count);
     return ncclInvalidArgument;
   }
@@ -1919,7 +1919,7 @@ ncclResult_t ncclGetMultimemDevicePointer (ncclWindow_t window, size_t offset, n
   NCCLCHECK(PtrCheck(window, __func__, "window"));
   NCCLCHECK(PtrCheck(outPtr, __func__, "outPtr"));
   if (multimem.mcBasePtr == nullptr) {
-    WARN("MCBasePtr %p needs to be valid.", multimem.mcBasePtr);
+    ERR(ncclInvalidArgument, "MCBasePtr %p needs to be valid.", multimem.mcBasePtr);
     return ncclInvalidArgument;
   }
 
@@ -1970,7 +1970,7 @@ ncclResult_t ncclGetLsaDevicePointer(ncclWindow_t window, size_t offset, int lsa
 
   devr = &comm->devrState;
   if (lsaRank < 0 || lsaRank >= devr->lsaSize) {
-    WARN("The provided lsaRank %d is not in the valid lsaSize of [0,%d] for the provided window %p.",
+    ERR(ncclInvalidArgument, "The provided lsaRank %d is not in the valid lsaSize of [0,%d] for the provided window %p.",
          lsaRank, devr->lsaSize, window);
     return ncclInvalidArgument; // In this case the user should know what the lsa size is.
   }
@@ -1996,7 +1996,7 @@ ncclResult_t ncclGetPeerDevicePointer(ncclWindow_t window, size_t offset, int pe
   NCCLCHECK(findCommAndHostWindowFromDeviceWindow(window, &comm, &winHost));
   // Validate peer rank is within bounds
   if (peer < 0 || peer >= comm->nRanks) {
-    WARN("peer %d is not within valid range of ranks %d.", peer, comm->nRanks);
+    ERR(ncclInvalidArgument, "peer %d is not within valid range of ranks %d.", peer, comm->nRanks);
     return ncclInvalidArgument;
   }
 

--- a/comms/ncclx/v2_30/src/enqueue.cc
+++ b/comms/ncclx/v2_30/src/enqueue.cc
@@ -89,7 +89,7 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
   }
 
   if (ncclShmemDynamicSize(cudaArch) > maxDynamicSmem) {
-    WARN("cudaArch %d dynamic smem %d exceeds device/fn maxSharedMem %d",
+    ERR(ncclSystemError, "cudaArch %d dynamic smem %d exceeds device/fn maxSharedMem %d",
          cudaArch, ncclShmemDynamicSize(cudaArch), maxDynamicSmem);
     return ncclSystemError;
   }
@@ -1164,11 +1164,11 @@ static ncclResult_t scheduleP2pTasksToPlan(struct ncclComm* comm, int* p2pEpoch,
 
       if (sendRank == comm->rank) {
         if (send != nullptr && recv == nullptr) {
-          WARN("Trying to send to self without a matching recv");
+          ERR(ncclInvalidUsage, "Trying to send to self without a matching recv");
           return ncclInvalidUsage;
         }
         if (send == nullptr && recv != nullptr) {
-          WARN("Trying to recv to self without a matching send");
+          ERR(ncclInvalidUsage, "Trying to recv to self without a matching send");
           return ncclInvalidUsage;
         }
       }
@@ -2028,7 +2028,7 @@ static ncclResult_t topoGetAlgoInfo(
     if (protoEnv) {
       snprintf(ncclProtoEnvStr, 1023, " NCCL_PROTO was set to %s.", protoEnv);
     }
-    WARN("No algorithm/protocol available for function %s with datatype %s.%s%s", ncclFuncToString(info->func), ncclDatatypeToString(info->datatype), ncclAlgoEnvStr, ncclProtoEnvStr);
+    ERR((algoEnv || protoEnv) ? ncclInvalidUsage : ncclInternalError, "No algorithm/protocol available for function %s with datatype %s.%s%s", ncclFuncToString(info->func), ncclDatatypeToString(info->datatype), ncclAlgoEnvStr, ncclProtoEnvStr);
     return (algoEnv || protoEnv) ? ncclInvalidUsage : ncclInternalError;
   }
   if (simInfo) simInfo->estimatedTime = time;
@@ -2184,7 +2184,7 @@ static ncclResult_t calcCollChunking(
       ncclPatternRingTwice;
     break;
   default:
-    WARN("Unknown pattern for collective %d algorithm %d", info->func, info->algorithm);
+    ERR(ncclInternalError, "Unknown pattern for collective %d algorithm %d", info->func, info->algorithm);
     return ncclInternalError;
   }
 
@@ -2309,7 +2309,7 @@ static ncclResult_t calcCollChunking(
     nstepsPerLoop = 1; nchunksPerLoop = comm->channels[0].nvls.nHeads;
     break;
   default:
-    WARN("Unknown pattern %d", pattern);
+    ERR(ncclInternalError, "Unknown pattern %d", pattern);
     return ncclInternalError;
   }
 
@@ -2375,7 +2375,7 @@ static ncclResult_t calcCollChunking(
         proxyOp->loopOffset = 0;
       }
     } else {
-      WARN("Net registration invalid algorithm %s", ncclAlgoToString(info->algorithm));
+      ERR(ncclInternalError, "Net registration invalid algorithm %s", ncclAlgoToString(info->algorithm));
       return ncclInternalError;
     }
 
@@ -2423,7 +2423,7 @@ static ncclResult_t calcCollChunking(
   case ncclPatternSend:
   case ncclPatternRecv:
   default:
-    WARN("Unknown pattern %d", pattern);
+    ERR(ncclInternalError, "Unknown pattern %d", pattern);
     return ncclInternalError;
   }
 
@@ -2516,7 +2516,7 @@ static ncclResult_t hostToDevRedOp(
     int ix = int(ncclUserRedOpMangle(comm, op)) - int(ncclNumOps);
     ncclUserRedOp *user = &comm->userRedOps[ix];
     if (datatype != user->datatype) {
-      WARN("Data type supplied to user-created ncclRedOp_t does not match type "
+      ERR(ncclInvalidArgument, "Data type supplied to user-created ncclRedOp_t does not match type "
            "given to reduction operation");
       return ncclInvalidArgument;
     }
@@ -2536,7 +2536,7 @@ static ncclResult_t ncclPlannerSetCapturingGraph(struct ncclComm* comm, struct n
         struct ncclCudaGraph graph;
         NCCLCHECK(ncclCudaGetCapturingGraph(&graph, info->stream, comm->config.graphUsageMode));
         if (planner->streams != nullptr && !ncclCudaGraphSame(planner->capturingGraph, graph)) {
-          WARN("Streams given to a communicator within a NCCL group must either be all uncaptured or all captured by the same graph.");
+          ERR(ncclInvalidUsage, "Streams given to a communicator within a NCCL group must either be all uncaptured or all captured by the same graph.");
           return ncclInvalidUsage;
         }
         planner->capturingGraph = graph; // C++ struct assignment
@@ -2780,33 +2780,33 @@ static ncclResult_t rmaTaskAppend(
   void const* srcBuff = info->sendbuff;
 
   if (!comm->hostRmaSupport) {
-    WARN("One sided RMA: host RMA is not supported in this communicator.");
+    ERR(ncclInvalidArgument, "One sided RMA: host RMA is not supported in this communicator.");
     return ncclInvalidArgument;
   }
 
   int driverVersion;
   NCCLCHECK(ncclCudaDriverVersion(&driverVersion));
   if (driverVersion < 12050) {
-    WARN("One-sided RMA requires CUDA driver 12.5 or later (found %d.%d).",
+    ERR(ncclInvalidUsage, "One-sided RMA requires CUDA driver 12.5 or later (found %d.%d).",
       driverVersion / 1000, (driverVersion % 1000) / 10);
     return ncclInvalidUsage;
   }
 
   // Check if context is valid (must be 0 for now)
   if (info->ctx != 0) {
-    WARN("Context %d is invalid (must be 0)", info->ctx);
+    ERR(ncclInvalidArgument, "Context %d is invalid (must be 0)", info->ctx);
     return ncclInvalidArgument;
   }
 
   // Check if signal index is valid (must be 0 for now)
   if (info->sigIdx != 0) {
-    WARN("Signal index %d is invalid (must be 0)", info->sigIdx);
+    ERR(ncclInvalidArgument, "Signal index %d is invalid (must be 0)", info->sigIdx);
     return ncclInvalidArgument;
   }
 
   // Check if flags is valid
   if (info->flags != 0) {
-    WARN("Flags %u is invalid (must be 0)", info->flags);
+    ERR(ncclInvalidArgument, "Flags %u is invalid (must be 0)", info->flags);
     return ncclInvalidArgument;
   }
 
@@ -2818,7 +2818,7 @@ static ncclResult_t rmaTaskAppend(
   if (info->coll == ncclFuncPutSignal) {
     // Validate peer window with detailed debugging
     if (info->peerWin == NULL) {
-      WARN("ncclPutSignal: peerWin is NULL");
+      ERR(ncclInvalidArgument, "ncclPutSignal: peerWin is NULL");
       return ncclInvalidArgument;
     }
 
@@ -2828,12 +2828,12 @@ static ncclResult_t rmaTaskAppend(
 
     // Validate source buffer and window
     if (srcBuff == NULL) {
-      WARN("ncclPutSignal: srcBuff is NULL");
+      ERR(ncclInvalidArgument, "ncclPutSignal: srcBuff is NULL");
       return ncclInvalidArgument;
     }
     NCCLCHECK(ncclDevrFindWindow(comm, srcBuff, &srcWinHost));
     if (srcWinHost == NULL || !(srcWinHost->winFlags & NCCL_WIN_COLL_SYMMETRIC)) {
-      WARN("ncclPutSignal: srcWinHost is not in a valid symmetric window");
+      ERR(ncclInvalidArgument, "ncclPutSignal: srcWinHost is not in a valid symmetric window");
       return ncclInvalidArgument;
     }
     srcWinOffset = (char*)srcBuff - (char*)srcWinHost->userPtr;
@@ -2842,39 +2842,39 @@ static ncclResult_t rmaTaskAppend(
     bool hasSysmemSegment = ncclDevrWindowHasSysmemSegment(srcWinHost) || ncclDevrWindowHasSysmemSegment(peerWinHost);
 
     if (isMultiSegment) {
-      WARN("ncclPutSignal currently does not support VAs backed by multiple physical cuMem segments");
+      ERR(ncclInvalidArgument, "ncclPutSignal currently does not support VAs backed by multiple physical cuMem segments");
       return ncclInvalidArgument;
     }
     if (hasSysmemSegment) {
-      WARN("ncclPutSignal currently does not support VAs with host-backed cuMem segments");
+      ERR(ncclInvalidArgument, "ncclPutSignal currently does not support VAs with host-backed cuMem segments");
       return ncclInvalidArgument;
     }
   }
   else if (info->coll == ncclFuncSignal) {
     // Check if count is valid
     if (info->count != 0) {
-      WARN("ncclSignal: count must be 0");
+      ERR(ncclInvalidArgument, "ncclSignal: count must be 0");
       return ncclInvalidArgument;
     }
   }
   else if (info->coll == ncclFuncWaitSignal) {
     // Check if signalDescs is valid
     if (info->signalDescs == NULL || info->nDesc == 0) {
-      WARN("ncclWaitSignal: invalid arguments");
+      ERR(ncclInvalidArgument, "ncclWaitSignal: invalid arguments");
       return ncclInvalidArgument;
     }
     // Validate each descriptor
     for (int i = 0; i < info->nDesc; i++) {
       if (info->signalDescs[i].opCnt <= 0) {
-        WARN("ncclWaitSignal: descriptor %d has invalid opCnt %d", i, info->signalDescs[i].opCnt);
+        ERR(ncclInvalidArgument, "ncclWaitSignal: descriptor %d has invalid opCnt %d", i, info->signalDescs[i].opCnt);
         return ncclInvalidArgument;
       }
       if (info->signalDescs[i].sigIdx != 0) {
-        WARN("ncclWaitSignal: descriptor %d has invalid sigIdx %d (must be 0)", i, info->signalDescs[i].sigIdx);
+        ERR(ncclInvalidArgument, "ncclWaitSignal: descriptor %d has invalid sigIdx %d (must be 0)", i, info->signalDescs[i].sigIdx);
         return ncclInvalidArgument;
       }
       if (info->signalDescs[i].ctx != 0) {
-        WARN("ncclWaitSignal: descriptor %d has invalid context %d (must be 0)",
+        ERR(ncclInvalidArgument, "ncclWaitSignal: descriptor %d has invalid context %d (must be 0)",
              i, info->signalDescs[i].ctx);
         return ncclInvalidArgument;
       }
@@ -3001,7 +3001,7 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
 
     if (info->datatype == ncclFloat8e4m3 || info->datatype == ncclFloat8e5m2) {
       if (comm->minCompCap < 90 && info->coll != ncclFuncAllGather && info->coll != ncclFuncBroadcast && info->coll != ncclFuncAlltoAll && info->coll != ncclFuncScatter && info->coll != ncclFuncGather) {
-        WARN("FP8 reduction support begins with sm90 capable devices.");
+        ERR(ncclInvalidArgument, "FP8 reduction support begins with sm90 capable devices.");
         return ncclInvalidArgument;
       }
     }
@@ -3089,7 +3089,7 @@ ncclResult_t ncclEnqueueCheck(struct ncclInfo* info) {
   ncclResult_t ret = CommCheck(info->comm, info->opName, "comm");
   if (ret != ncclSuccess) return ncclGroupErrCheck(ret);
   if (info->comm->revokedFlag) {
-    WARN("%s: communicator was revoked", info->opName);
+    ERR(ncclInvalidUsage, "%s: communicator was revoked", info->opName);
     return ncclGroupErrCheck(ncclInvalidUsage);
   }
   // Profiler - If a group API event has already started, update the profilerGroupDepth so that the depth
@@ -3176,7 +3176,7 @@ ncclResult_t ncclRedOpCreatePreMulSum(ncclRedOp_t *op, void *scalar, ncclDataTyp
 NCCL_API(ncclResult_t, ncclRedOpDestroy, ncclRedOp_t op, ncclComm_t comm);
 ncclResult_t ncclRedOpDestroy(ncclRedOp_t op, ncclComm_t comm) {
   if (0 <= int(op) && int(op) < int(ncclNumOps)) {
-    WARN("ncclRedOpDestroy : operator is a NCCL builtin.");
+    ERR(ncclInvalidArgument, "ncclRedOpDestroy : operator is a NCCL builtin.");
     return ncclInvalidArgument;
   }
   // int(ncclMaxRedOp) < int(op) will always be false due to the sizes of
@@ -3184,17 +3184,17 @@ ncclResult_t ncclRedOpDestroy(ncclRedOp_t op, ncclComm_t comm) {
   // just as a reminder.
   // coverity[result_independent_of_operands]
   if (int(op) < 0 || int(ncclMaxRedOp) < int(op)) {
-    WARN("ncclRedOpDestroy :  operator is garbage.");
+    ERR(ncclInvalidArgument, "ncclRedOpDestroy :  operator is garbage.");
     return ncclInvalidArgument;
   }
   if (comm == NULL) {
-    WARN("ncclRedOpDestroy : invalid communicator passed.");
+    ERR(ncclInvalidArgument, "ncclRedOpDestroy : invalid communicator passed.");
     return ncclInvalidArgument;
   }
 
   int ix = int(ncclUserRedOpMangle(comm, op)) - int(ncclNumOps);
   if (comm->userRedOpCapacity <= ix || comm->userRedOps[ix].freeNext != -1) {
-    WARN("ncclRedOpDestroy : operator unknown to this communicator.");
+    ERR(ncclInvalidArgument, "ncclRedOpDestroy : operator unknown to this communicator.");
     return ncclInvalidArgument;
   }
   // push to free list

--- a/comms/ncclx/v2_30/src/graph/connect.cc
+++ b/comms/ncclx/v2_30/src/graph/connect.cc
@@ -130,7 +130,7 @@ static ncclResult_t setTreeDown(struct ncclTree* tree, int* indexes, int d) {
   int x = 0;
   while (x < NCCL_MAX_TREE_ARITY && tree->down[x] >= 0) x++;
   if (x == NCCL_MAX_TREE_ARITY) {
-    WARN("Internal error : tree already has %d children (%d %d %d)", x, tree->down[0], tree->down[1], tree->down[2]);
+    ERR(ncclInternalError, "Internal error : tree already has %d children (%d %d %d)", x, tree->down[0], tree->down[1], tree->down[2]);
     return ncclInternalError;
   }
   tree->down[x] = indexes[d];

--- a/comms/ncclx/v2_30/src/graph/paths.cc
+++ b/comms/ncclx/v2_30/src/graph/paths.cc
@@ -31,7 +31,7 @@ static ncclResult_t getPath(struct ncclTopoSystem* system, struct ncclTopoNode* 
       return ncclSuccess;
     }
   }
-  WARN("Could not find node of type %d id %lx", t, id);
+  ERR(ncclInternalError, "Could not find node of type %d id %lx", t, id);
   return ncclInternalError;
 }
 
@@ -89,7 +89,7 @@ static ncclResult_t ncclTopoSetPaths(struct ncclTopoNode* baseNode, struct ncclT
             }
           }
           if (remPath->list[0] == NULL) {
-            WARN("Failed to find reverse path from remNode %d/%lx nlinks %d to node %d/%lx",
+            ERR(ncclInternalError, "Failed to find reverse path from remNode %d/%lx nlinks %d to node %d/%lx",
                  remNode->type, remNode->id, remNode->nlinks, node->type, node->id);
             return ncclInternalError;
           }
@@ -181,7 +181,7 @@ ncclResult_t ncclGetLocalCpu(struct ncclTopoSystem* system, int gpu, int* retCpu
     }
   }
   if (localCpu == -1) {
-    WARN("Error : could not find CPU close to GPU %d", gpu);
+    ERR(ncclInternalError, "Error : could not find CPU close to GPU %d", gpu);
     return ncclInternalError;
   }
   *retCpu = localCpu;
@@ -427,7 +427,7 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
         if (!good) {
           if (!ncclParamIgnoreDisabledP2p()) {
             if (path->type <= PATH_NVB) {
-              WARN("P2P is disabled between NVLINK connected GPUs %d and %d. This should not be the case given their connectivity, and is probably due to a hardware issue. If you still want to proceed, you can set NCCL_IGNORE_DISABLED_P2P=1.", indexes[i-1], indexes[i-0]);
+              ERR(ncclUnhandledCudaError, "P2P is disabled between NVLINK connected GPUs %d and %d. This should not be the case given their connectivity, and is probably due to a hardware issue. If you still want to proceed, you can set NCCL_IGNORE_DISABLED_P2P=1.", indexes[i-1], indexes[i-0]);
               return ncclUnhandledCudaError;
             } else if (path->type < PATH_SYS) {
               INFO(NCCL_INIT, "P2P is disabled between connected GPUs %d and %d. You can repress this message with NCCL_IGNORE_DISABLED_P2P=1.", indexes[i-1], indexes[i-0]);
@@ -672,7 +672,7 @@ ncclResult_t ncclTopoGetIntermediateRank(struct ncclTopoSystem* system, int rank
       }
     }
     if (node->type != GPU) {
-      WARN("Could not find intermediate GPU between GPU rank %d and NIC %lx", rank, netId);
+      ERR(ncclInternalError, "Could not find intermediate GPU between GPU rank %d and NIC %lx", rank, netId);
       return ncclInternalError;
     }
     NCCLCHECK(ncclTopoDevToRank(system, NCCL_TOPO_ID_SYSTEM_ID(node->id), node->gpu.dev, /*warn=*/true, intermediateRank));
@@ -904,7 +904,7 @@ ncclResult_t ncclTopoTrimSystem(struct ncclTopoSystem* system, struct ncclComm* 
       if (gpu->id == ids[i]) break; else gpu=NULL;
     }
     if (gpu == NULL) {
-      WARN("Could not find id %lx", ids[i]);
+      ERR(ncclInternalError, "Could not find id %lx", ids[i]);
       ret = ncclInternalError;
       goto fail;
     }

--- a/comms/ncclx/v2_30/src/graph/rings.cc
+++ b/comms/ncclx/v2_30/src/graph/rings.cc
@@ -50,7 +50,7 @@ ncclResult_t ncclBuildRings(int nrings, int* rings, int rank, int nranks, int* p
     snprintf(prefix, sizeof(prefix), "Channel %02d/%02d :", r, nrings);
     if (rank == 0) dumpLine(rings+r*nranks, nranks, prefix);
     if (current != rank) {
-      WARN("Error : ring %d does not loop back to start (%d != %d)", r, current, rank);
+      ERR(ncclInternalError, "Error : ring %d does not loop back to start (%d != %d)", r, current, rank);
       ret = ncclInternalError;
       goto end;
     }
@@ -60,7 +60,7 @@ ncclResult_t ncclBuildRings(int nrings, int* rings, int rank, int nranks, int* p
       // Fast check 64 ranks at a time
       if (mask == 1 && bits == 0xffffffffffffffff) { i += 63; continue; }
       if ((bits & mask) == 0) {
-        WARN("Error : ring %d does not contain rank %d", r, i);
+        ERR(ncclInternalError, "Error : ring %d does not contain rank %d", r, i);
         ret = ncclInternalError;
         goto end;
       }

--- a/comms/ncclx/v2_30/src/graph/search.cc
+++ b/comms/ncclx/v2_30/src/graph/search.cc
@@ -70,7 +70,7 @@ static ncclResult_t findRevLink(struct ncclTopoNode* node1, struct ncclTopoNode*
       return ncclSuccess;
     }
   }
-  WARN("Could not find rev link for %d/%ld -> %d/%ld", node1->type, node1->id, node2->type, node2->id);
+  ERR(ncclInternalError, "Could not find rev link for %d/%ld -> %d/%ld", node1->type, node1->id, node2->type, node2->id);
   return ncclInternalError;
 }
 
@@ -128,7 +128,7 @@ static ncclResult_t ncclTopoFollowPath(struct ncclTopoSystem* system, struct ncc
   struct ncclTopoLinkList* revPath = node2->paths[type1]+index1;
 
   if (path == NULL) {
-    WARN("No path computed to go from %s/%d to %s/%d", topoNodeTypeStr[type1], index1, topoNodeTypeStr[type2], index2);
+    ERR(ncclInternalError, "No path computed to go from %s/%d to %s/%d", topoNodeTypeStr[type1], index1, topoNodeTypeStr[type2], index2);
     return ncclInternalError;
   }
 
@@ -218,7 +218,7 @@ static ncclResult_t getGpuIndex(struct ncclTopoSystem* system, int rank, int* in
       return ncclSuccess;
     }
   }
-  WARN("Could not find gpu rank %d", rank);
+  ERR(ncclInternalError, "Could not find gpu rank %d", rank);
   return ncclInternalError;
 }
 
@@ -229,7 +229,7 @@ static ncclResult_t getNetIndex(struct ncclTopoSystem* system, int64_t id, int* 
       return ncclSuccess;
     }
   }
-  WARN("Could not find net id %lx", id);
+  ERR(ncclInternalError, "Could not find net id %lx", id);
   return ncclInternalError;
 }
 
@@ -855,7 +855,7 @@ ncclResult_t ncclTopoGetChannelFromXml(struct ncclXmlNode *xmlChannel, int c, st
           if (NCCL_TOPO_ID(systemId, system->nodes[GPU].nodes[g].gpu.dev) == dev) rank = system->nodes[GPU].nodes[g].gpu.rank;
         }
         if (rank == -1) {
-          WARN("XML Import Channel : dev %ld not found.", dev);
+          ERR(ncclSystemError, "XML Import Channel : dev %ld not found.", dev);
           return ncclSystemError;
         }
       }
@@ -922,7 +922,7 @@ ncclResult_t ncclTopoGetXmlFromChannel(struct ncclTopoGraph* graph, int c, struc
       }
     }
     if (dev == -1) {
-      WARN("XML Export Channel : rank %d not found.", intra[g]);
+      ERR(ncclInternalError, "XML Export Channel : rank %d not found.", intra[g]);
       return ncclInternalError;
     }
     NCCLCHECK(xmlSetAttrLong(node, "dev", dev));
@@ -1330,7 +1330,7 @@ ncclResult_t getNvlsNetDev(struct ncclComm* comm, struct ncclTopoGraph* graph, i
 exit:
   return ret;
 fail:
-  WARN("Could not find NIC for rank %d in NVLS graph", comm->rank);
+  ERR(ret, "Could not find NIC for rank %d in NVLS graph", comm->rank);
   goto exit;
 }
 

--- a/comms/ncclx/v2_30/src/graph/topo.cc
+++ b/comms/ncclx/v2_30/src/graph/topo.cc
@@ -103,7 +103,7 @@ ncclResult_t ncclTopoGetNode(struct ncclTopoSystem* system, struct ncclTopoNode*
 
 ncclResult_t ncclTopoCreateNode(struct ncclTopoSystem* system, struct ncclTopoNode** node, int type, uint64_t id) {
   if (system->nodes[type].count == NCCL_TOPO_MAX_NODES) {
-    WARN("Error : tried to create too many nodes of type %d", type);
+    ERR(ncclInternalError, "Error : tried to create too many nodes of type %d", type);
     return ncclInternalError;
   }
   struct ncclTopoNode* n = system->nodes[type].nodes+system->nodes[type].count;
@@ -171,7 +171,7 @@ ncclResult_t ncclTopoConnectNodes(struct ncclTopoNode* node, struct ncclTopoNode
     if (link->remNode == remNode && link->type == type) break;
   }
   if (link - node->links == NCCL_TOPO_MAX_LINKS) {
-    WARN("Error : too many Topo links (max %d)", NCCL_TOPO_MAX_LINKS);
+    ERR(ncclInternalError, "Error : too many Topo links (max %d)", NCCL_TOPO_MAX_LINKS);
     return ncclInternalError;
   }
   if (link->remNode == NULL) node->nlinks++;
@@ -235,7 +235,7 @@ ncclResult_t ncclTopoFlattenBcmSwitches(struct ncclTopoSystem* system) {
           if (remNode == pciSwitch) continue;
           // Add link from parent PCI switch -> PCI device
           if (pciSwitch->nlinks == NCCL_TOPO_MAX_LINKS) {
-            WARN("Error : too many Topo links (max %d)", NCCL_TOPO_MAX_LINKS);
+            ERR(ncclInternalError, "Error : too many Topo links (max %d)", NCCL_TOPO_MAX_LINKS);
             ret = ncclInternalError;
             goto fail;
           }
@@ -669,7 +669,7 @@ ncclResult_t ncclTopoAddNvLinks(struct ncclXmlNode* node, struct ncclTopoSystem*
     pBusId = NCCL_TOPO_ID(systemId, pBusId);
     NCCLCHECK(ncclTopoGetNode(system, &devNode, DEV, pBusId));
     if (devNode == NULL) {
-      WARN("Add NVLink error : could not find DEV for GPU %lx", pBusId);
+      ERR(ncclInternalError, "Add NVLink error : could not find DEV for GPU %lx", pBusId);
       return ncclInternalError;
     }
     int count;
@@ -724,7 +724,7 @@ ncclResult_t ncclTopoAddPciLinks(struct ncclXmlNode* node, struct ncclTopoSystem
     pBusId = NCCL_TOPO_ID(systemId, pBusId);
     NCCLCHECK(ncclTopoGetNode(system, &pci, PCI, pBusId));
     if (pci == NULL) {
-      WARN("Add PCI Link error : could not find PCI SW %lx", pBusId);
+      ERR(ncclInternalError, "Add PCI Link error : could not find PCI SW %lx", pBusId);
       return ncclInternalError;
     }
     struct ncclTopoNode* remote = NULL;
@@ -757,7 +757,7 @@ ncclResult_t ncclTopoAddC2c(struct ncclXmlNode* node, struct ncclTopoSystem* sys
     pBusId = NCCL_TOPO_ID(systemId, pBusId);
     NCCLCHECK(ncclTopoGetNode(system, &gpu, DEV, pBusId));
     if (gpu == NULL) {
-      WARN("Add NVLink error : could not find GPU %lx", pBusId);
+      ERR(ncclInternalError, "Add NVLink error : could not find GPU %lx", pBusId);
       return ncclInternalError;
     }
     int count = 0;
@@ -797,7 +797,7 @@ ncclResult_t ncclTopoGetSystemFromXml(struct ncclXml* xml, struct ncclTopoSystem
   while (systemId < system->nHosts && system->hostHashes[systemId] != localHostHash) systemId++;
   system->systemId = systemId;
   if(systemId == system->nHosts){
-    WARN("localHostHash = 0x%lx not found in the list of system hostHashes",localHostHash);
+    ERR(ncclInvalidArgument, "localHostHash = 0x%lx not found in the list of system hostHashes",localHostHash);
     return ncclInvalidArgument;
   }
 
@@ -1060,7 +1060,7 @@ ncclResult_t ncclTopoMakeUniqueBusId(struct ncclXml* xml, char* busId, struct nc
     i++;
   }
 
-  WARN("TOPO/NET : Couldn't generate unique busId after %d tries", i);
+  ERR(ncclInternalError, "TOPO/NET : Couldn't generate unique busId after %d tries", i);
   return ncclInternalError;
 }
 
@@ -1090,7 +1090,7 @@ ncclResult_t ncclTopoMakePciParent(struct ncclXml* xml, struct ncclXmlNode** par
   if (newBusId == NULL) {
     const char* name;
     NCCLCHECK(xmlGetAttr(physNetNode, "name", &name));
-    WARN("TOPO/NET : Can't find busId of child 0 %s", name);
+    ERR(ncclInternalError, "TOPO/NET : Can't find busId of child 0 %s", name);
     return ncclInternalError;
   }
 
@@ -1099,7 +1099,7 @@ ncclResult_t ncclTopoMakePciParent(struct ncclXml* xml, struct ncclXmlNode** par
 
 ncclResult_t ncclTopoMakeVnic(struct ncclXml* xml, struct ncclTopoNetInfo* netInfo, ncclNetVDeviceProps_t* vProps, struct ncclXmlNode** physNetNodes) {
   if (vProps->ndevs > netInfo->maxDevsPerNic) {
-    WARN("TOPO/NET : Tried to merge too many NICs. %d > %d", vProps->ndevs, netInfo->maxDevsPerNic);
+    ERR(ncclInternalError, "TOPO/NET : Tried to merge too many NICs. %d > %d", vProps->ndevs, netInfo->maxDevsPerNic);
     return ncclInternalError;
   }
 
@@ -1150,14 +1150,14 @@ ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* net
     }
 
     if (vProps.ndevs != nUserIfs) {
-      WARN("TOPO/NET : Only matched %d devices, %d requested from %s",
+      ERR(ncclInvalidUsage, "TOPO/NET : Only matched %d devices, %d requested from %s",
         vProps.ndevs, nUserIfs, semi);
       ret = ncclInvalidUsage;
       goto fail;
     }
 
     if (vProps.ndevs > netInfo->maxDevsPerNic) {
-      WARN("Specified fused NIC %s which has too many devices (%d). Max %d", semi, vProps.ndevs, netInfo->maxDevsPerNic);
+      ERR(ncclInvalidUsage, "Specified fused NIC %s which has too many devices (%d). Max %d", semi, vProps.ndevs, netInfo->maxDevsPerNic);
       ret = ncclInvalidUsage;
       goto fail;
     }
@@ -1169,7 +1169,7 @@ ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* net
         placedDevs[vProps.devs[i]] = 1;
       }
     } else {
-      WARN("TOPO/NET : Could not force merge NICs %s. Please specify a valid NCCL_NET_FORCE_MERGE string.", semi);
+      ERR(ncclInvalidUsage, "TOPO/NET : Could not force merge NICs %s. Please specify a valid NCCL_NET_FORCE_MERGE string.", semi);
       ret = ncclInvalidUsage;
       goto fail;
     }
@@ -1224,7 +1224,7 @@ ncclResult_t ncclTopoAutoMerge(struct ncclXml* xml, struct ncclTopoNetInfo* netI
       }
 
       if (vProps.ndevs > netInfo->maxDevsPerNic) {
-        WARN("TOPO/NET : Tried to merge too many NICs. %d > %d", vProps.ndevs, netInfo->maxDevsPerNic);
+        ERR(ncclInternalError, "TOPO/NET : Tried to merge too many NICs. %d > %d", vProps.ndevs, netInfo->maxDevsPerNic);
         return ncclInternalError;
       }
 
@@ -1707,7 +1707,7 @@ ncclResult_t ncclTopoGetLocal(struct ncclTopoSystem* system, int type, int index
     }
     if (paths[i].bw == maxBw && paths[i].type == minType) {
       if (count == NCCL_TOPO_MAX_NODES) {
-        WARN("Error : ran out of room to store found nodes in ncclTopoGetLocal."
+        ERR(ncclInternalError, "Error : ran out of room to store found nodes in ncclTopoGetLocal."
              " Filled %d of type %d, starting from index %d of type %d.",
              NCCL_TOPO_MAX_NODES, resultType, index, type);
         return ncclInternalError;
@@ -1775,7 +1775,7 @@ ncclResult_t ncclTopoGetNetDevsPolicy(enum netDevsPolicy* policy, int* policyNum
   static std::once_flag onceFlag;
   std::call_once(onceFlag, getNetDevsPolicyOnce);
   if (netDevsPolicy == NETDEVS_POLICY_MAX && netDevsPolicyNum <= 0) {
-    WARN("Invalid number of network devices = %d for policy MAX", netDevsPolicyNum);
+    ERR(ncclInternalError, "Invalid number of network devices = %d for policy MAX", netDevsPolicyNum);
     return ncclInternalError;
   }
   if (policy) *policy = netDevsPolicy;
@@ -1791,7 +1791,7 @@ ncclResult_t ncclTopoGetLocalNetType(struct ncclTopoSystem* system, int type, in
   int localNetCount;
   NCCLCHECK(ncclTopoGetLocal(system, GPU, gpu, type, localNets, &localNetCount, NULL));
   if (localNetCount==0) {
-    WARN("Could not find any local path from gpu %d to net.", gpu);
+    ERR(ncclInternalError, "Could not find any local path from gpu %d to net.", gpu);
     return ncclInternalError;
   }
 
@@ -1981,7 +1981,7 @@ ncclResult_t ncclCheckMultiRank(struct ncclComm* comm) {
       }
       if (numRanksFound == MAX_RANKS_ON_HOST) {
         if (firstRankOnHost == rank) {
-          WARN("ncclCheckMultiRank exceeded number of local ranks %d", MAX_RANKS_ON_HOST);
+          ERR(ncclInternalError, "ncclCheckMultiRank exceeded number of local ranks %d", MAX_RANKS_ON_HOST);
         }
         return ncclInternalError;
       }
@@ -1991,7 +1991,7 @@ ncclResult_t ncclCheckMultiRank(struct ncclComm* comm) {
   }
 
   if ((firstRankOnHost == -1 || firstRankOnHost == rank) && comm->isMultiRankGpu && ncclParamMultiRankGpuEnable() == 0) {
-    WARN("Multiple ranks detected using the same GPU on this node."
+    ERR(ncclInvalidUsage, "Multiple ranks detected using the same GPU on this node."
          " Set NCCL_MULTI_RANK_GPU_ENABLE=1 to enable this"
          " configuration.");
     return ncclInvalidUsage;

--- a/comms/ncclx/v2_30/src/graph/tuning.cc
+++ b/comms/ncclx/v2_30/src/graph/tuning.cc
@@ -70,7 +70,7 @@ ncclResult_t parseList(const char* str, const char* prefixElems[], int nprefixes
         // It makes no sense for any entry other than the first to not have a prefix,
         // because then all the prefixes before the prefix-less entry would be
         // overwritten.
-        WARN("All entries except the first must have a prefix: \"%s\"", str);
+        ERR(ncclInvalidUsage, "All entries except the first must have a prefix: \"%s\"", str);
         ret = ncclInvalidUsage;
         goto fail;
       }
@@ -103,7 +103,7 @@ ncclResult_t parseList(const char* str, const char* prefixElems[], int nprefixes
           }
         }
         if (e==nelems) {
-          WARN("Unrecognized element token \"%s\" when parsing \"%s\"", elem, str);
+          ERR(ncclInvalidUsage, "Unrecognized element token \"%s\" when parsing \"%s\"", elem, str);
           ret = ncclInvalidUsage;
           goto fail;
         }
@@ -113,7 +113,7 @@ ncclResult_t parseList(const char* str, const char* prefixElems[], int nprefixes
       tokStr = nullptr;
     }
     if (!foundPrefix) {
-      WARN("Unrecognized prefix token \"%s\" when parsing \"%s\"", prefix, str);
+      ERR(ncclInvalidUsage, "Unrecognized prefix token \"%s\" when parsing \"%s\"", prefix, str);
       ret = ncclInvalidUsage;
       goto fail;
     }

--- a/comms/ncclx/v2_30/src/graph/xml.cc
+++ b/comms/ncclx/v2_30/src/graph/xml.cc
@@ -37,7 +37,7 @@ struct xmlHandler {
 
 ncclResult_t xmlGetChar(FILE* file, char* c) {
   if (fread(c, 1, 1, file) == 0) {
-    WARN("XML Parse : Unexpected EOF");
+    ERR(ncclInternalError, "XML Parse : Unexpected EOF");
     return ncclInternalError;
   }
   return ncclSuccess;
@@ -53,7 +53,7 @@ ncclResult_t xmlGetValue(FILE* file, char* value, char* last) {
       value[o] = c;
       if (o == MAX_STR_LEN-1) {
         value[o] = '\0';
-        WARN("Error : value %s too long (max %d)", value, MAX_STR_LEN);
+        ERR(ncclInternalError, "Error : value %s too long (max %d)", value, MAX_STR_LEN);
         return ncclInternalError;
       }
       o++;
@@ -63,7 +63,7 @@ ncclResult_t xmlGetValue(FILE* file, char* value, char* last) {
     *last = c;
     return ncclSuccess;
 #else
-    WARN("XML Parse : Expected (double) quote.");
+    ERR(ncclInternalError, "XML Parse : Expected (double) quote.");
     return ncclInternalError;
 #endif
   }
@@ -74,7 +74,7 @@ ncclResult_t xmlGetValue(FILE* file, char* value, char* last) {
     value[o] = c;
     if (o == MAX_STR_LEN-1) {
       value[o] = '\0';
-      WARN("Error : value %s too long (max %d)", value, MAX_STR_LEN);
+      ERR(ncclInternalError, "Error : value %s too long (max %d)", value, MAX_STR_LEN);
       return ncclInternalError;
     }
     o++;
@@ -93,7 +93,7 @@ ncclResult_t xmlGetToken(FILE* file, char* name, char* value, char* last) {
     if (c == '=') {
       ptr[o] = '\0';
       if (value == NULL) {
-        WARN("XML Parse : Unexpected value with name %s", ptr);
+        ERR(ncclInternalError, "XML Parse : Unexpected value with name %s", ptr);
         return ncclInternalError;
       }
       return xmlGetValue(file, value, last);
@@ -101,7 +101,7 @@ ncclResult_t xmlGetToken(FILE* file, char* name, char* value, char* last) {
     ptr[o] = c;
     if (o == MAX_STR_LEN-1) {
       ptr[o] = '\0';
-      WARN("Error : name %s too long (max %d)", ptr, MAX_STR_LEN);
+      ERR(ncclInternalError, "Error : name %s too long (max %d)", ptr, MAX_STR_LEN);
       return ncclInternalError;
     }
     o++;
@@ -126,7 +126,7 @@ ncclResult_t xmlSkipComment(FILE* file, char* start, char next) {
   while (strcmp(end, "-->") != 0) {
     int c;
     if (fread(&c, 1, 1, file) != 1) {
-      WARN("XML Parse error : unterminated comment");
+      ERR(ncclInternalError, "XML Parse error : unterminated comment");
       return ncclInternalError;
     }
     SHIFT_APPEND(end, c);
@@ -141,7 +141,7 @@ ncclResult_t xmlGetNode(FILE* file, struct ncclXmlNode* node) {
     if (fread(&c, 1, 1, file) == 0) return ncclSuccess;
   }
   if (c != '<') {
-    WARN("XML Parse error : expecting '<', got '%c'", c);
+    ERR(ncclInternalError, "XML Parse error : expecting '<', got '%c'", c);
     return ncclInternalError;
   }
   // Read XML element name
@@ -159,7 +159,7 @@ ncclResult_t xmlGetNode(FILE* file, struct ncclXmlNode* node) {
     // Re-read the name, we got '/' in the first call
     NCCLCHECK(xmlGetToken(file, node->name, NULL, &c));
     if (c != '>') {
-      WARN("XML Parse error : unexpected trailing %c in closing tag %s", c, node->name);
+      ERR(ncclInternalError, "XML Parse error : unexpected trailing %c in closing tag %s", c, node->name);
       return ncclInternalError;
     }
     return ncclSuccess;
@@ -183,7 +183,7 @@ ncclResult_t xmlGetNode(FILE* file, struct ncclXmlNode* node) {
     NCCLCHECK(xmlGetToken(file, str, NULL, &c));
   }
   if (c != '>') {
-    WARN("XML Parse : expected >, got '%c'", c);
+    ERR(ncclInternalError, "XML Parse : expected >, got '%c'", c);
     return ncclInternalError;
   }
   return ncclSuccess;
@@ -193,7 +193,7 @@ ncclResult_t xmlLoadSub(FILE* file, struct ncclXml* xml, struct ncclXmlNode* hea
   if (head && head->type == NODE_TYPE_SINGLE) return ncclSuccess;
   while (1) {
     if (xml->maxIndex == xml->maxNodes) {
-      WARN("Error : XML parser is limited to %d nodes", xml->maxNodes);
+      ERR(ncclInternalError, "Error : XML parser is limited to %d nodes", xml->maxNodes);
       return ncclInternalError;
     }
     struct ncclXmlNode* node = xml->nodes+xml->maxIndex;
@@ -201,7 +201,7 @@ ncclResult_t xmlLoadSub(FILE* file, struct ncclXml* xml, struct ncclXmlNode* hea
     NCCLCHECK(xmlGetNode(file, node));
     if (node->type == NODE_TYPE_NONE) {
       if (head) {
-        WARN("XML Parse : unterminated %s", head->name);
+        ERR(ncclInternalError, "XML Parse : unterminated %s", head->name);
         return ncclInternalError;
       } else {
         // All done
@@ -210,7 +210,7 @@ ncclResult_t xmlLoadSub(FILE* file, struct ncclXml* xml, struct ncclXmlNode* hea
     }
     if (head && node->type == NODE_TYPE_CLOSE) {
       if (strcmp(node->name, head->name) != 0) {
-        WARN("XML Mismatch : %s / %s", head->name, node->name);
+        ERR(ncclInternalError, "XML Mismatch : %s / %s", head->name, node->name);
         return ncclInternalError;
       }
       return ncclSuccess;
@@ -220,7 +220,7 @@ ncclResult_t xmlLoadSub(FILE* file, struct ncclXml* xml, struct ncclXmlNode* hea
       if (strcmp(node->name, handlers[h].name) == 0) {
         if (head) {
           if (head->nSubs == MAX_SUBS) {
-            WARN("Error : XML parser is limited to %d subnodes", MAX_SUBS);
+            ERR(ncclInternalError, "Error : XML parser is limited to %d subnodes", MAX_SUBS);
             return ncclInternalError;
           }
           head->subs[head->nSubs++] = node;
@@ -375,7 +375,7 @@ ncclResult_t ncclTopoXmlLoadSystem(FILE* file, struct ncclXml* xml, struct ncclX
   int version;
   NCCLCHECK(xmlGetAttrInt(head, "version", &version));
   if (version != NCCL_TOPO_XML_VERSION) {
-    WARN("XML Topology has wrong version %d, %d needed", version, NCCL_TOPO_XML_VERSION);
+    ERR(ncclInvalidUsage, "XML Topology has wrong version %d, %d needed", version, NCCL_TOPO_XML_VERSION);
     return ncclInvalidUsage;
   }
   const char* name;
@@ -420,7 +420,7 @@ static ncclResult_t getPciPath(const char* busId, char** path) {
   memcpylower(busPath+sizeof("/sys/class/pci_bus/0000:00/../../")-1, busId, BUSID_SIZE-1);
   *path = ncclOsRealpath(busPath, NULL);
   if (*path == NULL) {
-    WARN("Could not find real path of %s", busPath);
+    ERR(ncclSystemError, "Could not find real path of %s", busPath);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -483,7 +483,7 @@ ncclResult_t ncclTopoGetXmlFromCpu(struct ncclXmlNode* cpuNode, struct ncclXml* 
     const char* numaId;
     NCCLCHECK(xmlGetAttr(cpuNode, "numaid", &numaId));
     if (numaId == NULL) {
-      WARN("GetXmlFromCpu : could not find CPU numa ID.");
+      ERR(ncclInternalError, "GetXmlFromCpu : could not find CPU numa ID.");
       return ncclInternalError;
     }
     // Set affinity
@@ -724,7 +724,7 @@ ncclResult_t ncclTopoGetXmlFromSys(struct ncclXmlNode* pciNode, struct ncclXml* 
       if (busId != NULL && strcmp(newBusId, busId) < 0) { subIndex = s; break; }
     }
     if (parent->nSubs == MAX_SUBS) {
-      WARN("Error : XML parser is limited to %d subnodes", MAX_SUBS);
+      ERR(ncclInternalError, "Error : XML parser is limited to %d subnodes", MAX_SUBS);
       ret = ncclInternalError;
       goto exit;
     }
@@ -1043,7 +1043,7 @@ ncclResult_t ncclTopoXmlGraphLoadGraphs(FILE* file, struct ncclXml* xmlGraph, st
   int version;
   NCCLCHECK(xmlGetAttrInt(head, "version", &version));
   if (version != NCCL_GRAPH_XML_VERSION) {
-    WARN("XML Graph has wrong version %d, %d needed", version, NCCL_GRAPH_XML_VERSION);
+    ERR(ncclInvalidUsage, "XML Graph has wrong version %d, %d needed", version, NCCL_GRAPH_XML_VERSION);
     return ncclInvalidUsage;
   }
   const char* name;
@@ -1059,7 +1059,7 @@ ncclResult_t ncclTopoXmlGraphLoadGraphs(FILE* file, struct ncclXml* xmlGraph, st
 ncclResult_t ncclTopoGetXmlGraphFromFile(const char* xmlGraphFile, struct ncclXml* xml) {
   FILE* file = fopen(xmlGraphFile, "r");
   if (file == NULL) {
-    WARN("Could not open XML graph file %s : %s", xmlGraphFile, strerror(errno));
+    ERR(ncclSystemError, "Could not open XML graph file %s : %s", xmlGraphFile, strerror(errno));
     return ncclSystemError;
   }
   struct xmlHandler handlers[] = { { "graphs", ncclTopoXmlGraphLoadGraphs } };

--- a/comms/ncclx/v2_30/src/group.cc
+++ b/comms/ncclx/v2_30/src/group.cc
@@ -68,7 +68,7 @@ ncclResult_t ncclAsyncLaunch(
       /* first met communicator */
       ncclGroupBlocking = comm->config.blocking;
     } else if (ncclGroupBlocking != comm->config.blocking) {
-      WARN("Blocking and nonblocking communicators are not allowed in the same group.");
+      ERR(ncclInvalidArgument, "Blocking and nonblocking communicators are not allowed in the same group.");
       ret = ncclInvalidArgument;
     }
     if (ret == ncclSuccess) {
@@ -344,7 +344,7 @@ static ncclResult_t doLaunches(struct ncclComm* head) {
       // We have entered barriers but are aborting without leaving them. Thus
       // these comms are permanently trashed. We need a good mechanism for
       // tracking and reporting that.
-      WARN("Either none or all communicators in a ncclGroup() can be CUDA graph captured.");
+      ERR(ncclInvalidUsage, "Either none or all communicators in a ncclGroup() can be CUDA graph captured.");
       result = ncclInvalidUsage;
       goto failure;
     }
@@ -779,7 +779,7 @@ ncclResult_t ncclGroupEndInternal(ncclSimInfo_t* simInfo) {
   internalSimInfo.magic = 0;
 
   if (ncclGroupDepth == 0) {
-    WARN("ncclGroupEnd: not in a group call.");
+    ERR(ncclInvalidUsage, "ncclGroupEnd: not in a group call.");
     ret = ncclInvalidUsage;
     goto exit;
   }
@@ -802,7 +802,7 @@ ncclResult_t ncclGroupEndInternal(ncclSimInfo_t* simInfo) {
     realSize = realSize > sizeof(ncclSimInfo_t) ? sizeof(ncclSimInfo_t) : realSize;
     memcpy((void*)&internalSimInfo, (void*)simInfo, realSize);
     if (internalSimInfo.magic != 0x74685283) {
-      WARN("ncclSimInfo_t argument not initialized via NCCL_SIM_INFO_INITIALIZER");
+      ERR(ncclInvalidArgument, "ncclSimInfo_t argument not initialized via NCCL_SIM_INFO_INITIALIZER");
       ret = ncclInvalidArgument;
       goto fail;
     }

--- a/comms/ncclx/v2_30/src/include/checks.h
+++ b/comms/ncclx/v2_30/src/include/checks.h
@@ -30,7 +30,7 @@ constexpr const char* ncclCodeToString(ncclResult_t code) {
   do {                                                                         \
     cudaError_t err = cmd;                                                     \
     if (err != cudaSuccess) {                                                  \
-      WARN_WITH_SCUBA("Cuda failure '%s'", cudaGetErrorString(err));                      \
+      ERR(ncclUnhandledCudaError, "Cuda failure '%s'", cudaGetErrorString(err));                      \
       (void)cudaGetLastError();                                                \
       return ncclUnhandledCudaError;                                           \
     }                                                                          \
@@ -40,7 +40,7 @@ constexpr const char* ncclCodeToString(ncclResult_t code) {
   do {                                                                         \
     cudaError_t err = cmd;                                                     \
     if (err != cudaSuccess) {                                                  \
-      WARN_WITH_SCUBA("Cuda failure '%s'", cudaGetErrorString(err));                      \
+      ERR(ncclUnhandledCudaError, "Cuda failure '%s'", cudaGetErrorString(err));                      \
       (void)cudaGetLastError();                                                \
       RES = ncclUnhandledCudaError;                                            \
       goto label;                                                              \
@@ -76,7 +76,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   int retval; \
   SYSCHECKSYNC((statement), name, retval); \
   if (retval == -1) { \
-    WARN_WITH_SCUBA("Call to " name " failed: %s", strerror(errno)); \
+    ERR(ncclSystemError, "Call to " name " failed: %s", strerror(errno)); \
     return ncclSystemError; \
   } \
 } while (false)
@@ -94,7 +94,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   int retval; \
   SYSCHECKSYNC((statement), name, retval); \
   if (retval == -1) { \
-    WARN_WITH_SCUBA("Call to " name " failed: %s", strerror(errno)); \
+    ERR(ncclSystemError, "Call to " name " failed: %s", strerror(errno)); \
     RES = ncclSystemError; \
     goto label; \
   } \
@@ -104,7 +104,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
 #define PTHREADCHECK(statement, name) do { \
   int retval = (statement); \
   if (retval != 0) { \
-    WARN_WITH_SCUBA("Call to " name " failed: %s", strerror(retval)); \
+    ERR(ncclSystemError, "Call to " name " failed: %s", strerror(retval)); \
     return ncclSystemError; \
   } \
 } while (0)
@@ -112,7 +112,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
 #define PTHREADCHECKGOTO(statement, name, RES, label) do { \
   int retval = (statement); \
   if (retval != 0) { \
-    WARN_WITH_SCUBA("Call to " name " failed: %s", strerror(retval)); \
+    ERR(ncclSystemError, "Call to " name " failed: %s", strerror(retval)); \
     RES = ncclSystemError; \
     goto label; \
   } \
@@ -121,7 +121,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
 #define NEQCHECK(statement, value) do {   \
   if ((statement) != value) {             \
     /* Print the back trace*/             \
-    WARN_WITH_SCUBA("%s:%d -> %d (%s)", __FILE__, __LINE__, ncclSystemError, strerror(errno));    \
+    ERR(ncclSystemError, "%s:%d -> %d (%s)", __FILE__, __LINE__, ncclSystemError, strerror(errno));    \
     return ncclSystemError;     \
   }                             \
 } while (0)
@@ -130,7 +130,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   if ((statement) != value) { \
     /* Print the back trace*/ \
     RES = ncclSystemError;    \
-    WARN_WITH_SCUBA("%s:%d -> %d (%s)", __FILE__, __LINE__, RES, strerror(errno));    \
+    ERR(ncclSystemError, "%s:%d -> %d (%s)", __FILE__, __LINE__, RES, strerror(errno));    \
     goto label; \
   } \
 } while (0)
@@ -138,7 +138,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
 #define EQCHECK(statement, value) do {    \
   if ((statement) == value) {             \
     /* Print the back trace*/             \
-    WARN_WITH_SCUBA("%s:%d -> %d (%s)", __FILE__, __LINE__, ncclSystemError, strerror(errno));    \
+    ERR(ncclSystemError, "%s:%d -> %d (%s)", __FILE__, __LINE__, ncclSystemError, strerror(errno));    \
     return ncclSystemError;     \
   }                             \
 } while (0)
@@ -147,7 +147,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   if ((statement) == value) { \
     /* Print the back trace*/ \
     RES = ncclSystemError;    \
-    WARN_WITH_SCUBA("%s:%d -> %d (%s)", __FILE__, __LINE__, RES, strerror(errno));    \
+    ERR(ncclSystemError, "%s:%d -> %d (%s)", __FILE__, __LINE__, RES, strerror(errno));    \
     goto label; \
   } \
 } while (0)
@@ -157,7 +157,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   ncclResult_t RES = call; \
   if (RES != ncclSuccess && RES != ncclInProgress) { \
     /* Print the back trace*/ \
-    if (ncclDebugNoWarn == 0) WARN_WITH_SCUBA("%s:%d -> %d", __FILE__, __LINE__, RES);    \
+    if (ncclDebugNoWarn == 0) WARN("%s:%d -> %d", __FILE__, __LINE__, RES);    \
     return RES; \
   } \
 } while (0)
@@ -166,7 +166,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   RES = call; \
   if (RES != ncclSuccess && RES != ncclInProgress) { \
     /* Print the back trace*/ \
-    if (ncclDebugNoWarn == 0) WARN_WITH_SCUBA("%s:%d -> %d", __FILE__, __LINE__, RES);    \
+    if (ncclDebugNoWarn == 0) WARN("%s:%d -> %d", __FILE__, __LINE__, RES);    \
     goto label; \
   } \
 } while (0)
@@ -190,7 +190,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   uint32_t* tmpAbortFlag = (abortFlagPtr);     \
   ncclResult_t RES = call;                \
   if (RES != ncclSuccess && RES != ncclInProgress) {               \
-    if (ncclDebugNoWarn == 0) WARN_WITH_SCUBA(NCCL_ALL,"%s:%d -> %d", __FILE__, __LINE__, RES);    \
+    if (ncclDebugNoWarn == 0) WARN("%s:%d -> %d", __FILE__, __LINE__, RES);    \
     return ncclInternalError;             \
   }                                       \
   if (COMPILER_ATOMIC_LOAD(tmpAbortFlag, std::memory_order_acquire)) NEQCHECK(*tmpAbortFlag, 0); \
@@ -200,7 +200,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   uint32_t* tmpAbortFlag = (abortFlagPtr);             \
   RES = call;                             \
   if (RES != ncclSuccess && RES != ncclInProgress) {               \
-    if (ncclDebugNoWarn == 0) WARN_WITH_SCUBA(NCCL_ALL,"%s:%d -> %d", __FILE__, __LINE__, RES);    \
+    if (ncclDebugNoWarn == 0) WARN("%s:%d -> %d", __FILE__, __LINE__, RES);    \
     goto label;                           \
   }                                       \
   if (COMPILER_ATOMIC_LOAD(tmpAbortFlag, std::memory_order_acquire)) NEQCHECKGOTO(*tmpAbortFlag, 0, RES, label); \
@@ -208,7 +208,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
 
 #define NCCLCHECKTHREAD(a, args) do { \
   if (((args)->ret = (a)) != ncclSuccess && (args)->ret != ncclInProgress) { \
-    WARN_WITH_SCUBA("%s:%d -> %d [Async thread]", __FILE__, __LINE__, (args)->ret); \
+    WARN("%s:%d -> %d [Async thread]", __FILE__, __LINE__, (args)->ret); \
     return args; \
   } \
 } while(0)
@@ -216,7 +216,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
 #define CUDACHECKTHREAD(a) do { \
   cudaError_t err = (a);        \
   if (err != cudaSuccess) {     \
-    WARN_WITH_SCUBA("%s:%d -> %d [Async thread]", __FILE__, __LINE__, (int)err); \
+    ERR(ncclUnhandledCudaError, "%s:%d -> %d [Async thread]", __FILE__, __LINE__, (int)err); \
     args->ret = ncclUnhandledCudaError; \
     return args; \
   } \
@@ -237,7 +237,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   do {                                                   \
     cudaError_t err = cmd;                               \
     if (err != cudaSuccess) {                            \
-      ERR_WITH_SCUBA("Cuda failure '%s'", cudaGetErrorString(err)); \
+      ERR(ncclUnhandledCudaError, "Cuda failure '%s'", cudaGetErrorString(err)); \
       abort();                                           \
     }                                                    \
   } while (false)
@@ -246,7 +246,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   do {                                                      \
     SYSCHECKSYNC(call, name, retval);                       \
     if (retval == -1) {                                     \
-      ERR_WITH_SCUBA("Call to " name " failed : %s", strerror(errno)); \
+      ERR(ncclSystemError, "Call to " name " failed : %s", strerror(errno)); \
     return ncclSystemError; \
   } \
 } while (false)
@@ -256,7 +256,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
 #define NCCLCHECKIGNORE(call, RES) do {                \
   ncclResult_t TMPRES = call;                          \
   if (TMPRES != ncclSuccess && TMPRES != ncclInProgress) { \
-    WARN_WITH_SCUBA(                                   \
+    WARN(                                              \
         "%s:%s:%d -> %d (%s)",                         \
         __FILE__,                                      \
         __func__,                                      \

--- a/comms/ncclx/v2_30/src/include/debug.h
+++ b/comms/ncclx/v2_30/src/include/debug.h
@@ -32,7 +32,7 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
 
 void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file, const char *func, int line, const char *fmt, ...) __attribute__ ((format (printf, 6, 7)));
 
-void ncclMetaDebugLogWithScuba(ncclDebugLogLevel level, unsigned long flags, const char *file, const char *func, int line, const char *fmt, ...) __attribute__ ((format (printf, 6, 7)));
+void ncclMetaDebugLogError(ncclResult_t code, unsigned long flags, const char *file, const char *func, int line, const char *fmt, ...) __attribute__ ((format (printf, 6, 7)));
 
 // Let code temporarily downgrade WARN into INFO
 extern thread_local int ncclDebugNoWarn;
@@ -40,11 +40,7 @@ extern char ncclLastError[];
 
 #define VERSION(...) ncclMetaDebugLog(NCCL_LOG_VERSION, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
 #define WARN(...) ncclMetaDebugLog(NCCL_LOG_WARN, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
-#define ERR(...) ncclMetaDebugLog(NCCL_LOG_ERROR, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
-
-#define WARN_WITH_SCUBA(...) ncclMetaDebugLogWithScuba(NCCL_LOG_WARN, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
-#define ERR_WITH_SCUBA(...) ncclMetaDebugLogWithScuba(NCCL_LOG_ERROR, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
-
+#define ERR(code, ...) ncclMetaDebugLogError((code), NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
 
 #define NOWARN(EXPR, FLAGS) \
   do { \

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -469,7 +469,7 @@ ncclResult_t ncclCommEnsureReady(ncclComm_t comm) {
   } else {
     NCCLCHECK(ncclCommGetAsyncError(comm, &ret));
     if (ret == ncclInProgress) {
-      WARN("Attempt to use communicator before the previous operation returned ncclSuccess");
+      ERR(ncclInvalidArgument, "Attempt to use communicator before the previous operation returned ncclSuccess");
       ret = ncclInvalidArgument;
       goto exit;
     }
@@ -483,11 +483,11 @@ exit:
 static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, int ndev, int rank) {
   auto sampleGuardBegin = EVENTS_SCUBA_UTIL_SAMPLE_GUARD("INIT");
   if (ndev < 1) {
-    WARN("invalid device count (%d) requested", ndev);
+    ERR(ncclInvalidArgument, "invalid device count (%d) requested", ndev);
     return ncclInvalidArgument;
   }
   if (rank >= ndev || rank < 0) {
-    WARN("rank %d exceeds ndev=%d", rank, ndev);
+    ERR(ncclInvalidArgument, "rank %d exceeds ndev=%d", rank, ndev);
     return ncclInvalidArgument;
   }
 
@@ -528,7 +528,7 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
 
   if (parent && parent->shareResources) {
     if (parent->ncclNet != comm->ncclNet) {
-      WARN("Split shares resources, but parent comm netName %s is different from child comm netName %s", parent->ncclNet->name, comm->ncclNet->name);
+      ERR(ncclInvalidUsage, "Split shares resources, but parent comm netName %s is different from child comm netName %s", parent->ncclNet->name, comm->ncclNet->name);
       return ncclInvalidUsage;
     }
   }
@@ -965,7 +965,7 @@ static ncclResult_t ncclP2pSchedule(struct ncclComm* comm) {
   int groupCount = 0;
   for (int n = 0; n < comm->nNodes; ++n) {
     if (0 != comm->nodeRanks[n].localRanks % groupSize) {
-      WARN("nLocals = %d should be a diviser of the number of ranks in node %d = %d", groupSize, n, comm->nodeRanks[n].localRanks);
+      ERR(ncclInternalError, "nLocals = %d should be a diviser of the number of ranks in node %d = %d", groupSize, n, comm->nodeRanks[n].localRanks);
       return ncclInternalError;
     }
     int nGroupsInNode = comm->nodeRanks[n].localRanks / groupSize;
@@ -977,7 +977,7 @@ static ncclResult_t ncclP2pSchedule(struct ncclComm* comm) {
     if (n < comm->node) group += nGroupsInNode;
   }
   if (groupCount != nGroups) {
-    WARN("Group creation failed: %d vs %d", groupCount, nGroups);
+    ERR(ncclInternalError, "Group creation failed: %d vs %d", groupCount, nGroups);
     return ncclInternalError;
   }
   INFO(NCCL_GRAPH,"%s: group size used is %d",__func__,groupSize);
@@ -1010,7 +1010,7 @@ static ncclResult_t ncclP2pSchedule(struct ncclComm* comm) {
   free(groupToLocal);
 
   if (round != comm->nRanks) {
-    WARN("P2p schedule creation has bugs.");
+    ERR(ncclInternalError, "P2p schedule creation has bugs.");
     return ncclInternalError;
   }
   return ncclSuccess;
@@ -1096,7 +1096,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   comm->cuMemSupport = 1;
   for (int i = 0; i < nranks; i++) {
     if (comm->peerInfo[i].version != comm->peerInfo[rank].version) {
-      WARN("Mismatched NCCL version detected : rank %d version %d rank %d version %d",
+      ERR(ncclInvalidUsage, "Mismatched NCCL version detected : rank %d version %d rank %d version %d",
            i, comm->peerInfo[i].version, rank, comm->peerInfo[rank].version);
       ret = ncclInvalidUsage;
       goto fail;
@@ -1158,7 +1158,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     TRACE(NCCL_INIT,"pidHash[%d] %lx intraProcRank %d intraProcRanks %d intraProcRank0 %d",
         rank, comm->peerInfo[rank].pidHash, intraProcRank, intraProcRanks, intraProcRank0);
     if (intraProcRank == -1 || intraProcRank0 == -1 || comm->peerInfo[intraProcRank0].comm == NULL) {
-      WARN("Failed to determine intra proc ranks rank %d hostHash %lx pidHash %lx intraProcRank %d intraProcRanks %d intraProcRank0 %d",
+      ERR(ncclInternalError, "Failed to determine intra proc ranks rank %d hostHash %lx pidHash %lx intraProcRank %d intraProcRanks %d intraProcRank0 %d",
           rank, comm->peerInfo[rank].hostHash, comm->peerInfo[rank].pidHash,
           intraProcRank, intraProcRanks, intraProcRank0);
       ret = ncclInternalError;
@@ -1215,7 +1215,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   NCCLCHECK(ncclCheckMultiRank(comm));
   if (comm->isMultiRankGpu) {
     if (ncclParamNvlsEnable() == 1) {
-      WARN("Multiple ranks detected using the same GPU on this node"
+      ERR(ncclInvalidUsage, "Multiple ranks detected using the same GPU on this node"
            " and NCCL_NVLS_ENABLE has been set to \"1\"."
            " At this time multiple ranks per gpu is incompatible with"
            " NVLS.");
@@ -1389,7 +1389,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
         INFO(NCCL_INIT, "Detected mixed local Net device counts across ranks (min %d, max %d). Ignoring due to NCCL_IGNORE_NET_MISMATCH.",
              minLocalNetCount, maxLocalNetCount);
       } else {
-        WARN("Detected mixed local Net device counts across ranks (min %d, max %d). Set NCCL_IGNORE_NET_MISMATCH=1 to continue.",
+        ERR(ncclSystemError, "Detected mixed local Net device counts across ranks (min %d, max %d). Set NCCL_IGNORE_NET_MISMATCH=1 to continue.",
              minLocalNetCount, maxLocalNetCount);
         ret = ncclSystemError;
       }
@@ -1408,7 +1408,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
         INFO(NCCL_INIT, "Detected mixed local CollNet device counts across ranks (min %d, max %d). Ignoring due to NCCL_IGNORE_COLLNET_MISMATCH.",
              minLocalCollNetCount, maxLocalCollNetCount);
       } else {
-        WARN("Detected mixed local CollNet device counts across ranks (min %d, max %d). Set NCCL_IGNORE_COLLNET_MISMATCH=1 to continue.",
+        ERR(ncclSystemError, "Detected mixed local CollNet device counts across ranks (min %d, max %d). Set NCCL_IGNORE_COLLNET_MISMATCH=1 to continue.",
              minLocalCollNetCount, maxLocalCollNetCount);
         ret = ncclSystemError;
       }
@@ -1460,7 +1460,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   TRACE(NCCL_INIT,"hostHash[%d] %lx localRank %d localRanks %d localRank0 %d",
         rank, comm->peerInfo[rank].hostHash, comm->localRank, comm->localRanks, comm->localRankToRank[0]);
   if (comm->localRank == -1 || comm->localRankToRank[0] == -1 || comm->localRanks == 0) {
-    WARN("Failed to determine local ranks rank %d hostHash %lx pidHash %lx localRank %d localRanks %d localRank0 %d",
+    ERR(ncclInternalError, "Failed to determine local ranks rank %d hostHash %lx pidHash %lx localRank %d localRanks %d localRank0 %d",
          rank, comm->peerInfo[rank].hostHash, comm->peerInfo[rank].pidHash,
          comm->localRank, comm->localRanks, comm->localRankToRank[0]);
     ret = ncclInternalError;
@@ -2346,7 +2346,7 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
     realSize = realSize > sizeof(ncclConfig_t) ? sizeof(ncclConfig_t) : realSize;
     memcpy((void*)internalConfigPtr, (void*)config, realSize);
     if (internalConfigPtr->magic != NCCL_API_MAGIC) {
-      WARN("ncclConfig_t argument not initialized via NCCL_CONFIG_INITIALIZER");
+      ERR(ncclInvalidArgument, "ncclConfig_t argument not initialized via NCCL_CONFIG_INITIALIZER");
       ret = ncclInvalidArgument;
       goto fail;
     }
@@ -2390,13 +2390,13 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
 
   /* check input config attributes, -1 means user-undefined and we should use default value from NCCL. */
   if (internalConfigPtr->blocking != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->blocking != 0 && internalConfigPtr->blocking != 1) {
-    WARN("Invalid config blocking attribute value %d", internalConfigPtr->blocking);
+    ERR(ncclInvalidArgument, "Invalid config blocking attribute value %d", internalConfigPtr->blocking);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->cgaClusterSize != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->cgaClusterSize < 0) {
-    WARN("Invalid config cgaClusterSize attribute value %d", internalConfigPtr->cgaClusterSize);
+    ERR(ncclInvalidArgument, "Invalid config cgaClusterSize attribute value %d", internalConfigPtr->cgaClusterSize);
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -2406,69 +2406,69 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
     (internalConfigPtr->maxCTAs != NCCL_CONFIG_UNDEF_INT &&
       internalConfigPtr->maxCTAs <= 0) ||
     (internalConfigPtr->minCTAs > internalConfigPtr->maxCTAs)) {
-    WARN("Invalid config min/max channels attribute value %d/%d", internalConfigPtr->minCTAs, internalConfigPtr->maxCTAs);
+    ERR(ncclInvalidArgument, "Invalid config min/max channels attribute value %d/%d", internalConfigPtr->minCTAs, internalConfigPtr->maxCTAs);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->splitShare != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->splitShare != 0 && internalConfigPtr->splitShare != 1) {
-    WARN("Invalid config splitShare attribute value %d", internalConfigPtr->splitShare);
+    ERR(ncclInvalidArgument, "Invalid config splitShare attribute value %d", internalConfigPtr->splitShare);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->collnetEnable != NCCL_CONFIG_UNDEF_INT && (internalConfigPtr->collnetEnable < 0 || internalConfigPtr->collnetEnable > 1)) {
-    WARN("Invalid config collnetEnable attribute value %d", internalConfigPtr->collnetEnable);
+    ERR(ncclInvalidArgument, "Invalid config collnetEnable attribute value %d", internalConfigPtr->collnetEnable);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->CTAPolicy != NCCL_CONFIG_UNDEF_INT) {
     if (!ctaPolicyIsValid(internalConfigPtr->CTAPolicy)) {
-      WARN("Invalid config policy attribute value %d", internalConfigPtr->CTAPolicy);
+      ERR(ncclInvalidArgument, "Invalid config policy attribute value %d", internalConfigPtr->CTAPolicy);
       ret = ncclInvalidArgument;
       goto fail;
     }
   }
 
   if (internalConfigPtr->shrinkShare != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->shrinkShare != 0 && internalConfigPtr->shrinkShare != 1) {
-    WARN("Invalid config shrinkShare attribute value %d", internalConfigPtr->shrinkShare);
+    ERR(ncclInvalidArgument, "Invalid config shrinkShare attribute value %d", internalConfigPtr->shrinkShare);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->nvlsCTAs != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->nvlsCTAs <= 0) {
-    WARN("Invalid config nvlsCTAs attribute value %d", internalConfigPtr->nvlsCTAs);
+    ERR(ncclInvalidArgument, "Invalid config nvlsCTAs attribute value %d", internalConfigPtr->nvlsCTAs);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->nChannelsPerNetPeer != NCCL_CONFIG_UNDEF_INT && (internalConfigPtr->nChannelsPerNetPeer <= 0 || internalConfigPtr->nChannelsPerNetPeer > MAXCHANNELS)) {
-    WARN("Invalid config nChannelsPerNetPeer attribute value %d", internalConfigPtr->nChannelsPerNetPeer);
+    ERR(ncclInvalidArgument, "Invalid config nChannelsPerNetPeer attribute value %d", internalConfigPtr->nChannelsPerNetPeer);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->nvlinkCentricSched != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->nvlinkCentricSched != 0 && internalConfigPtr->nvlinkCentricSched != 1) {
-    WARN("Invalid config nvlinkCentricSched attribute value %d", internalConfigPtr->nvlinkCentricSched);
+    ERR(ncclInvalidArgument, "Invalid config nvlinkCentricSched attribute value %d", internalConfigPtr->nvlinkCentricSched);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->graphUsageMode != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->graphUsageMode != 0 && internalConfigPtr->graphUsageMode != 1 && internalConfigPtr->graphUsageMode != 2) {
-    WARN("Invalig config graphUsageMode attribute value %d", internalConfigPtr->graphUsageMode);
+    ERR(ncclInvalidArgument, "Invalig config graphUsageMode attribute value %d", internalConfigPtr->graphUsageMode);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->numRmaCtx != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->numRmaCtx <= 0) {
-    WARN("Invalid config numRmaCtx attribute value %d", internalConfigPtr->numRmaCtx);
+    ERR(ncclInvalidArgument, "Invalid config numRmaCtx attribute value %d", internalConfigPtr->numRmaCtx);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->maxP2pPeers != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->maxP2pPeers <= 0) {
-    WARN("Invalid config maxP2pPeers attribute value %d", internalConfigPtr->maxP2pPeers);
+    ERR(ncclInvalidArgument, "Invalid config maxP2pPeers attribute value %d", internalConfigPtr->maxP2pPeers);
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -2545,7 +2545,7 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   auto sampleGuardBegin = EVENTS_SCUBA_UTIL_SAMPLE_GUARD("INIT");
 
   if (nId <= 0 || nId > nranks) {
-    WARN("improper usage of ncclCommInitRank: nId = %d, nranks=%d", nId, nranks);
+    ERR(ncclInvalidArgument, "improper usage of ncclCommInitRank: nId = %d, nranks=%d", nId, nranks);
     return ncclInvalidArgument;
   }
   ncclResult_t res = ncclSuccess;
@@ -2575,7 +2575,7 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   commLogData.commDesc = commDescForLog;
   sampleGuardBegin.sample().setCommunicatorMetadata(&commLogData);
   if (nranks < 1 || myrank < 0 || myrank >= nranks) {
-    WARN("Invalid rank requested : %d/%d", myrank, nranks);
+    ERR(ncclInvalidArgument, "Invalid rank requested : %d/%d", myrank, nranks);
     res = ncclInvalidArgument;
     goto fail;
   }
@@ -2684,7 +2684,7 @@ ncclResult_t ncclCommInitAll(ncclComm_t* comms, int ndev, const int* devlist) {
   CUDACHECK(cudaGetDevice(&oldDev));
   NCCLCHECKGOTO(PtrCheck(comms, "CommInitAll", "comms"), ret, fail);
   if (ndev < 0) {
-    WARN("Invalid device count requested : %d", ndev);
+    ERR(ncclInvalidArgument, "Invalid device count requested : %d", ndev);
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -2695,7 +2695,7 @@ ncclResult_t ncclCommInitAll(ncclComm_t* comms, int ndev, const int* devlist) {
     for (int i = 0; i < ndev; ++i) {
       /* invalid device check. */
       if (devlist[i] < 0 || devlist[i] >= totalnDev) {
-        WARN("Invalid device %d (totalnDev=%d)", devlist[i], totalnDev);
+        ERR(ncclInvalidArgument, "Invalid device %d (totalnDev=%d)", devlist[i], totalnDev);
         ret = ncclInvalidArgument;
         goto fail;
       }
@@ -2735,7 +2735,7 @@ fail:
 
 ncclResult_t ncclCommSetAsyncError(ncclComm_t comm, ncclResult_t nextState) {
   if (nextState < 0 || nextState >= ncclNumResults || comm == NULL) {
-    WARN("ncclCommSetAsyncError: error comm %p sets state %d", comm, nextState);
+    ERR(ncclInvalidArgument, "ncclCommSetAsyncError: error comm %p sets state %d", comm, nextState);
     return ncclInvalidArgument;
   }
 
@@ -3035,7 +3035,7 @@ ncclResult_t ncclCommDestroy(ncclComm_t comm) {
   NCCLCHECK(ncclGroupStartInternal());
   // Try and prevent a double free of the comm struct (user error)
   if (comm->rank == -1 || comm->nRanks == -1 || comm->cudaDev == -1 || comm->busId == -1) {
-    WARN("comm %p has already been destroyed", comm);
+    ERR(ncclInvalidArgument, "comm %p has already been destroyed", comm);
     return ncclInvalidArgument;
   }
 
@@ -3412,11 +3412,11 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
 
   if (newcomm == NULL) return ncclInvalidArgument;
   if (nRanks <= 0) {
-    WARN("ncclCommGrow: total ranks must be positive, got %d", nRanks);
+    ERR(ncclInvalidArgument, "ncclCommGrow: total ranks must be positive, got %d", nRanks);
     return ncclInvalidArgument;
   }
   if (comm && nRanks <= comm->nRanks) {
-    WARN("ncclCommGrow: total ranks %d is less than current ranks %d", nRanks, comm->nRanks);
+    ERR(ncclInvalidArgument, "ncclCommGrow: total ranks %d is less than current ranks %d", nRanks, comm->nRanks);
     return ncclInvalidArgument;
   }
 
@@ -3449,7 +3449,7 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
     NCCLCHECKGOTO(CommCheck(comm, __func__, "comm"), res, exit);
     NCCLCHECKGOTO(ncclCommEnsureReady(comm), res, exit);
     if (rank != -1) {
-      WARN("ncclCommGrow: existing ranks must pass rank=-1, got %d", rank);
+      ERR(ncclInvalidArgument, "ncclCommGrow: existing ranks must pass rank=-1, got %d", rank);
       res = ncclInvalidArgument;
       goto exit;
     }
@@ -3462,7 +3462,7 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
       NCCLCHECKGOTO(bcastGrowHandle(&recvHandle, comm, /*isRoot=*/false), res, exit);
       // verify the magic is the same as the one computed by the root
       if (recvHandle.magic != hashCombine(comm->magic, comm->childCount)) {
-        WARN("ncclCommGrow: magic mismatch computed by the root, got %lx expected %lx",
+        ERR(ncclInvalidArgument, "ncclCommGrow: magic mismatch computed by the root, got %lx expected %lx",
           recvHandle.magic, hashCombine(comm->magic, comm->childCount));
         res = ncclInvalidArgument;
         goto exit;
@@ -3472,17 +3472,17 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
   } else {
     // New ranks: validate parameters
     if (rank < 0) {
-      WARN("ncclCommGrow: new ranks must pass valid rank >= 0, got %d", rank);
+      ERR(ncclInvalidArgument, "ncclCommGrow: new ranks must pass valid rank >= 0, got %d", rank);
       res = ncclInvalidArgument;
       goto exit;
     }
     if (uniqueId == NULL) {
-      WARN("ncclCommGrow: new ranks must pass non-NULL uniqueId");
+      ERR(ncclInvalidArgument, "ncclCommGrow: new ranks must pass non-NULL uniqueId");
       res = ncclInvalidArgument;
       goto exit;
     }
     if (rank >= nRanks) {
-      WARN("ncclCommGrow: new rank %d exceeds total ranks %d", rank, nRanks);
+      ERR(ncclInvalidArgument, "ncclCommGrow: new rank %d exceeds total ranks %d", rank, nRanks);
       res = ncclInvalidArgument;
       goto exit;
     }

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -2770,7 +2770,7 @@ ncclResult_t ncclCommInitRankConfig(ncclComm_t *newcomm, int nranks, ncclUniqueI
     // memset to 0 as it will be used to generate hostHash
     memset(&commId, 0, sizeof(commId));
   } else if (!uniqueIdIsInitialized && NCCL_COMM_ID.empty()) {
-    ERR("No ncclUniqueId provided in nccl baseline init mode, please set TORCH_NCCL_BCAST_UNIQUEID=1 or set NCCL_COMM_ID env variable");
+    ERR(ncclInvalidUsage, "No ncclUniqueId provided in nccl baseline init mode, please set TORCH_NCCL_BCAST_UNIQUEID=1 or set NCCL_COMM_ID env variable");
     return ncclInvalidUsage;
   }
 

--- a/comms/ncclx/v2_30/src/mem_manager.cc
+++ b/comms/ncclx/v2_30/src/mem_manager.cc
@@ -143,7 +143,7 @@ static ncclResult_t ncclMemTrackInternal(
   if (ncclParamMemManagerDisable()) return ncclSuccess;
   if (manager == nullptr || ptr == nullptr) return ncclInternalError;
   if (!COMPILER_ATOMIC_LOAD(&manager->initialized, std::memory_order_acquire)) {
-    WARN("MemManager: Cannot track allocation ptr=%p, manager not initialized", ptr);
+    ERR(ncclInternalError, "MemManager: Cannot track allocation ptr=%p, manager not initialized", ptr);
     return ncclInternalError;
   }
 
@@ -164,7 +164,7 @@ static ncclResult_t ncclMemTrackInternal(
   // Scratch/Offload: create linked list entry
   ncclDynMemEntry* entry = (ncclDynMemEntry*)malloc(sizeof(ncclDynMemEntry));
   if (entry == nullptr) {
-    WARN("MemManager: Failed to allocate memory entry");
+    ERR(ncclSystemError, "MemManager: Failed to allocate memory entry");
     return ncclSystemError;
   }
 
@@ -261,7 +261,7 @@ ncclResult_t ncclMemUntrack(struct ncclMemManager* manager, void* ptr, size_t si
 
   // Atomic check to avoid locking destroyed mutex
   if (!COMPILER_ATOMIC_LOAD(&manager->initialized, std::memory_order_acquire)) {
-    WARN("MemManager: Cannot untrack allocation ptr=%p, manager not initialized", ptr);
+    ERR(ncclInternalError, "MemManager: Cannot untrack allocation ptr=%p, manager not initialized", ptr);
     return ncclInternalError;
   }
 
@@ -363,7 +363,7 @@ ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* pt
   if (ncclParamMemManagerDisable()) return ncclSuccess;
   if (manager == nullptr || ptr == nullptr) return ncclInternalError;
   if (!COMPILER_ATOMIC_LOAD(&manager->initialized, std::memory_order_acquire)) {
-    WARN("MemManager: Cannot mark export for ptr=%p, manager not initialized", ptr);
+    ERR(ncclInternalError, "MemManager: Cannot mark export for ptr=%p, manager not initialized", ptr);
     return ncclInternalError;
   }
   std::lock_guard<std::mutex> lock(manager->lock);
@@ -375,21 +375,21 @@ ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* pt
   }
 
   if (entry == nullptr) {
-    WARN("MemManager: Cannot mark export for ptr=%p - not found in tracked entries. "
+    ERR(ncclInternalError, "MemManager: Cannot mark export for ptr=%p - not found in tracked entries. "
          "Only dynamic memory (scratch/offload) needs export tracking for suspend/resume.", ptr);
     return ncclInternalError;
   }
 
   // Verify this is a local entry, not an imported one
   if (entry->isImportedFromPeer) {
-    WARN("MemManager: Cannot mark export for ptr=%p - this is an imported buffer, not a local one", ptr);
+    ERR(ncclInternalError, "MemManager: Cannot mark export for ptr=%p - this is an imported buffer, not a local one", ptr);
     return ncclInternalError;
   }
 
   // Check if peer already exists
   for (int i = 0; i < entry->desc.local.numExportedPeers; i++) {
     if (entry->desc.local.exportedPeerRanks[i] == peerRank) {
-      WARN("MemManager: Buffer ptr=%p already exported to peer rank %d", ptr, peerRank);
+      ERR(ncclInternalError, "MemManager: Buffer ptr=%p already exported to peer rank %d", ptr, peerRank);
       return ncclInternalError;
     }
   }
@@ -401,7 +401,7 @@ ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* pt
                                    entry->desc.local.exportedPeersCapacity,
                                    newCapacity);
     if (ret != ncclSuccess) {
-      WARN("MemManager: Failed to grow exportedPeerRanks array for ptr=%p", ptr);
+      ERR(ret, "MemManager: Failed to grow exportedPeerRanks array for ptr=%p", ptr);
       return ret;
     }
     entry->desc.local.exportedPeersCapacity = newCapacity;
@@ -425,7 +425,7 @@ ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* pt
 ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
   if (ncclParamMemManagerDisable())
   {
-    WARN("MemManager: Suspend failed, memory manager is disabled");
+    ERR(ncclInvalidUsage, "MemManager: Suspend failed, memory manager is disabled");
     return ncclInvalidUsage;
   }
   if (comm == nullptr) return ncclInvalidArgument;
@@ -433,7 +433,7 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
   ncclMemManager* manager = comm->memManager;
 
   if (manager->released) {
-    WARN("MemManager: Already suspended");
+    ERR(ncclInvalidUsage, "MemManager: Already suspended");
     return ncclInvalidUsage;
   }
 
@@ -491,7 +491,7 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
     if (entry->memType == ncclMemOffload) {
       NCCLCHECKGOTO(ncclCudaHostCalloc((char**)&entry->cpuBackup, entry->size), ret, fail);
       if (entry->cpuBackup == nullptr) {
-        WARN("MemManager: Failed to allocate CPU backup for offload");
+        ERR(ncclSystemError, "MemManager: Failed to allocate CPU backup for offload");
         ret = ncclSystemError;
         goto fail;
       }
@@ -501,7 +501,7 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
       if (err != cudaSuccess) {
         ncclCudaHostFree(entry->cpuBackup);
         entry->cpuBackup = nullptr;
-        WARN("MemManager: Failed to copy to CPU backup: %s", cudaGetErrorString(err));
+        ERR(ncclUnhandledCudaError, "MemManager: Failed to copy to CPU backup: %s", cudaGetErrorString(err));
         ret = ncclUnhandledCudaError;
         goto fail;
       }
@@ -556,7 +556,7 @@ fail:
 ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
   if (ncclParamMemManagerDisable())
   {
-    WARN("MemManager: Resume failed, memory manager is disabled");
+    ERR(ncclInvalidUsage, "MemManager: Resume failed, memory manager is disabled");
     return ncclInvalidUsage;
   }
   if (comm == nullptr) return ncclInvalidArgument;
@@ -564,7 +564,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
   ncclMemManager* manager = comm->memManager;
 
   if (!manager->released) {
-    WARN("MemManager: Not in suspended state");
+    ERR(ncclInvalidUsage, "MemManager: Not in suspended state");
     return ncclInvalidUsage;
   }
 
@@ -638,7 +638,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
     if (entry->memType == ncclMemOffload && entry->cpuBackup != NULL) {
       cudaError_t err = cudaMemcpy(entry->ptr, entry->cpuBackup, entry->size, cudaMemcpyHostToDevice);
       if (err != cudaSuccess) {
-        WARN("MemManager: Failed to restore from CPU backup: %s (backup preserved)", cudaGetErrorString(err));
+        ERR(ncclUnhandledCudaError, "MemManager: Failed to restore from CPU backup: %s (backup preserved)", cudaGetErrorString(err));
         ret = ncclUnhandledCudaError;
         goto fail;
       }
@@ -653,7 +653,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
       CUresult exportRet = CUPFN(cuMemExportToShareableHandle(&entry->desc.local.shareableHandle.fabricHandle, newHandle,
                                                                CU_MEM_HANDLE_TYPE_FABRIC, 0));
       if (exportRet != CUDA_SUCCESS) {
-        WARN("MemManager: cuMemExportToShareableHandle (FABRIC) failed for ptr=%p", entry->ptr);
+        ERR(ncclUnhandledCudaError, "MemManager: cuMemExportToShareableHandle (FABRIC) failed for ptr=%p", entry->ptr);
         CUCHECKIGNORE(cuMemUnmap((CUdeviceptr)entry->ptr, entry->size));
         CUCHECKIGNORE(cuMemRelease(newHandle));
         entry->handle = 0;
@@ -679,7 +679,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
          comm->rank, restoredLocalCount);
     ret = bootstrapBarrier(comm->bootstrap, comm->rank, comm->nRanks, 0xBEEF);
     if (ret != ncclSuccess) {
-      WARN("MemManager: Barrier failed during resume");
+      ERR(ret, "MemManager: Barrier failed during resume");
       return ret;
     }
   }
@@ -706,7 +706,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
     // Allocate buffer for all counts
     allCounts = (int*)malloc(comm->nRanks * sizeof(int));
     if (allCounts == nullptr) {
-      WARN("MemManager: Failed to allocate allCounts");
+      ERR(ncclSystemError, "MemManager: Failed to allocate allCounts");
       return ncclSystemError;
     }
     memset(allCounts, 0, comm->nRanks * sizeof(int));
@@ -716,7 +716,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
     ret = bootstrapAllGather(comm->bootstrap, allCounts, sizeof(int));
     if (ret != ncclSuccess) {
       free(allCounts);
-      WARN("MemManager: AllGather counts failed");
+      ERR(ret, "MemManager: AllGather counts failed");
       return ret;
     }
 
@@ -792,7 +792,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
                               localInfos,
                               localBroadcastCount * sizeof(ncclDynMemP2pHandleInfo));
           if (ret != ncclSuccess) {
-            WARN("MemManager: Send to rank %d failed - handle exchange incomplete", r);
+            ERR(ret, "MemManager: Send to rank %d failed - handle exchange incomplete", r);
             free(offsets);
             free(allCounts);
             free(localInfos);
@@ -808,7 +808,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
                               allInfos + offsets[r],
                               allCounts[r] * sizeof(ncclDynMemP2pHandleInfo));
           if (ret != ncclSuccess) {
-            WARN("MemManager: Recv from rank %d failed - handle exchange incomplete", r);
+            ERR(ret, "MemManager: Recv from rank %d failed - handle exchange incomplete", r);
             free(offsets);
             free(allCounts);
             free(localInfos);
@@ -933,7 +933,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
       if (allCounts) free(allCounts);
       if (localInfos) free(localInfos);
       if (allInfos) free(allInfos);
-      WARN("MemManager: Final barrier failed during resume");
+      ERR(ret, "MemManager: Final barrier failed during resume");
       return ret;
     }
   }
@@ -972,13 +972,13 @@ ncclResult_t ncclCommSuspend(ncclComm_t comm, int flags) {
   if (flags & NCCL_SUSPEND_MEM) {
     if (ncclParamMemManagerDisable())
     {
-      WARN("MemManager: Suspend not supported, memory manager is disabled");
+      ERR(ncclInvalidUsage, "MemManager: Suspend not supported, memory manager is disabled");
       ret = ncclInvalidUsage;
       goto fail;
     }
     // Check if manager is shared
     if (comm->memManager && comm->memManager->refCount > 1) {
-      WARN("Memory suspend not supported with split_share communicators (refCount=%d)",
+      ERR(ncclInvalidUsage, "Memory suspend not supported with split_share communicators (refCount=%d)",
            comm->memManager->refCount);
       ret = ncclInvalidUsage;
       goto fail;
@@ -1016,13 +1016,13 @@ ncclResult_t ncclCommResume(ncclComm_t comm) {
 
   if (ncclParamMemManagerDisable())
   {
-    WARN("MemManager: Resume not supported, memory manager is disabled");
+    ERR(ncclInvalidUsage, "MemManager: Resume not supported, memory manager is disabled");
     ret = ncclInvalidUsage;
     goto fail;
   }
   // Check if manager is shared
   if (comm->memManager && comm->memManager->refCount > 1) {
-    WARN("Memory resume not supported with split_share communicators (refCount=%d)",
+    ERR(ncclInvalidUsage, "Memory resume not supported with split_share communicators (refCount=%d)",
          comm->memManager->refCount);
     ret = ncclInvalidUsage;
     goto fail;
@@ -1053,7 +1053,7 @@ ncclResult_t ncclCommMemStats(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t*
   if (value == nullptr) return ncclInvalidArgument;
 
   if (ncclParamMemManagerDisable()) {
-    WARN("MemManager: MemStats not supported, memory manager is disabled");
+    ERR(ncclInvalidUsage, "MemManager: MemStats not supported, memory manager is disabled");
     return ncclInvalidUsage;
   }
 

--- a/comms/ncclx/v2_30/src/misc/argcheck.cc
+++ b/comms/ncclx/v2_30/src/misc/argcheck.cc
@@ -13,7 +13,7 @@ ncclResult_t CudaPtrCheck(const void* pointer, struct ncclComm* comm, const char
   cudaPointerAttributes attr;
   cudaError_t err = cudaPointerGetAttributes(&attr, pointer);
   if (err != cudaSuccess || attr.devicePointer == NULL) {
-    WARN("%s : %s %p is not a valid pointer", opname, ptrname, pointer);
+    ERR(ncclInvalidArgument, "%s : %s %p is not a valid pointer", opname, ptrname, pointer);
     return ncclInvalidArgument;
   }
 #if CUDART_VERSION >= 10000
@@ -25,7 +25,7 @@ ncclResult_t CudaPtrCheck(const void* pointer, struct ncclComm* comm, const char
 #else
   if (attr.memoryType == cudaMemoryTypeDevice && attr.device != comm->cudaDev) {
 #endif
-    WARN("%s : %s allocated on device %d mismatchs with NCCL device %d", opname, ptrname, attr.device, comm->cudaDev);
+    ERR(ncclInvalidArgument, "%s : %s allocated on device %d mismatchs with NCCL device %d", opname, ptrname, attr.device, comm->cudaDev);
     return ncclInvalidArgument;
   }
   return ncclSuccess;
@@ -33,7 +33,7 @@ ncclResult_t CudaPtrCheck(const void* pointer, struct ncclComm* comm, const char
 
 ncclResult_t PtrCheck(const void* ptr, const char* opname, const char* ptrname) {
   if (ptr == NULL) {
-    WARN("%s : %s argument is NULL", opname, ptrname);
+    ERR(ncclInvalidArgument, "%s : %s argument is NULL", opname, ptrname);
     return ncclInvalidArgument;
   }
   return ncclSuccess;
@@ -42,7 +42,7 @@ ncclResult_t PtrCheck(const void* ptr, const char* opname, const char* ptrname) 
 ncclResult_t CommCheck(struct ncclComm* comm, const char* opname, const char* ptrname) {
   NCCLCHECK(PtrCheck(comm, opname, ptrname));
   if (comm->startMagic != NCCL_MAGIC || comm->endMagic != NCCL_MAGIC) {
-    WARN("Error: corrupted comm object detected");
+    ERR(ncclInvalidArgument, "Error: corrupted comm object detected");
     return ncclInvalidArgument;
   }
   return ncclSuccess;
@@ -97,7 +97,7 @@ static ncclResult_t registrationCheck(struct ncclInfo* info) {
   for (int r = 1; r < comm->nRanks; r++) {
     int infoIdx = r * 2;
     if (cmpBufInfo[0].isSymRegistered != bufInfo[infoIdx].isSymRegistered || cmpBufInfo[1].isSymRegistered != bufInfo[infoIdx + 1].isSymRegistered) {
-      if (comm->rank == 0) WARN("Coll %s size %ld symmetric registration check failed on rank %d: sendReg %d recvReg %d mismatch with rank 0 sendReg %d recvReg %d", info->opName, size, r, bufInfo[infoIdx].isSymRegistered, bufInfo[infoIdx + 1].isSymRegistered, cmpBufInfo[0].isSymRegistered, cmpBufInfo[1].isSymRegistered);
+      if (comm->rank == 0) ERR(ncclInvalidArgument, "Coll %s size %ld symmetric registration check failed on rank %d: sendReg %d recvReg %d mismatch with rank 0 sendReg %d recvReg %d", info->opName, size, r, bufInfo[infoIdx].isSymRegistered, bufInfo[infoIdx + 1].isSymRegistered, cmpBufInfo[0].isSymRegistered, cmpBufInfo[1].isSymRegistered);
       ret = ncclInvalidArgument;
       goto fail;
     }
@@ -111,12 +111,12 @@ static ncclResult_t registrationCheck(struct ncclInfo* info) {
   if (info->coll == ncclFuncAllReduce || info->coll == ncclFuncReduceScatter || info->coll == ncclFuncAlltoAll || info->coll == ncclFuncGather) {
     if (cmpBufInfo[0].isSymRegistered) {
       if (sendWinMismatch) {
-        if (comm->rank == 0) WARN("Coll %s size %ld symmetric registration check failed on rank %d: send buffer window (0x%lx) mismatch with rank 0 (0x%lx)", info->opName, size, sendWinMismatchRank, bufInfo[sendWinMismatchRank * 2].bigOffset, cmpBufInfo[0].bigOffset);
+        if (comm->rank == 0) ERR(ncclInvalidArgument, "Coll %s size %ld symmetric registration check failed on rank %d: send buffer window (0x%lx) mismatch with rank 0 (0x%lx)", info->opName, size, sendWinMismatchRank, bufInfo[sendWinMismatchRank * 2].bigOffset, cmpBufInfo[0].bigOffset);
         ret = ncclInvalidArgument;
         goto fail;
       }
       if (sendUserMismatch) {
-        if (comm->rank == 0) WARN("Coll %s size %ld symmetric registration check failed on rank %d: send buffer user offset (0x%lx) mismatch with rank 0 (0x%lx)", info->opName, size, sendUserMismatchRank, bufInfo[sendUserMismatchRank * 2].userOffset, cmpBufInfo[0].userOffset);
+        if (comm->rank == 0) ERR(ncclInvalidArgument, "Coll %s size %ld symmetric registration check failed on rank %d: send buffer user offset (0x%lx) mismatch with rank 0 (0x%lx)", info->opName, size, sendUserMismatchRank, bufInfo[sendUserMismatchRank * 2].userOffset, cmpBufInfo[0].userOffset);
         ret = ncclInvalidArgument;
         goto fail;
       }
@@ -126,12 +126,12 @@ static ncclResult_t registrationCheck(struct ncclInfo* info) {
   if (info->coll == ncclFuncAllGather || info->coll == ncclFuncAllReduce || info->coll == ncclFuncAlltoAll || info->coll == ncclFuncScatter) {
     if (cmpBufInfo[1].isSymRegistered) {
       if (recvWinMismatch) {
-        if (comm->rank == 0) WARN("Coll %s size %ld symmetric registration check failed on rank %d: recv buffer window (0x%lx) mismatch with rank 0 (0x%lx)", info->opName, size, recvWinMismatchRank, bufInfo[recvWinMismatchRank * 2 + 1].bigOffset, cmpBufInfo[1].bigOffset);
+        if (comm->rank == 0) ERR(ncclInvalidArgument, "Coll %s size %ld symmetric registration check failed on rank %d: recv buffer window (0x%lx) mismatch with rank 0 (0x%lx)", info->opName, size, recvWinMismatchRank, bufInfo[recvWinMismatchRank * 2 + 1].bigOffset, cmpBufInfo[1].bigOffset);
         ret = ncclInvalidArgument;
         goto fail;
       }
       if (recvUserMismatch) {
-        if (comm->rank == 0) WARN("Coll %s size %ld symmetric registration check failed on rank %d: recv buffer user offset (0x%lx) mismatch with rank 0 (0x%lx)", info->opName, size, recvUserMismatchRank, bufInfo[recvUserMismatchRank * 2 + 1].userOffset, cmpBufInfo[1].userOffset);
+        if (comm->rank == 0) ERR(ncclInvalidArgument, "Coll %s size %ld symmetric registration check failed on rank %d: recv buffer user offset (0x%lx) mismatch with rank 0 (0x%lx)", info->opName, size, recvUserMismatchRank, bufInfo[recvUserMismatchRank * 2 + 1].userOffset, cmpBufInfo[1].userOffset);
         ret = ncclInvalidArgument;
         goto fail;
       }
@@ -157,11 +157,11 @@ ncclResult_t ncclArgsGlobalCheck(struct ncclArgsInfo* argsInfo) {
 ncclResult_t ArgsCheck(struct ncclInfo* info) {
   // First, the easy ones
   if (info->root < 0 || info->root >= info->comm->nRanks) {
-    WARN("%s : invalid root %d (root should be in the 0..%d range)", info->opName, info->root, info->comm->nRanks);
+    ERR(ncclInvalidArgument, "%s : invalid root %d (root should be in the 0..%d range)", info->opName, info->root, info->comm->nRanks);
     return ncclInvalidArgument;
   }
   if (info->datatype < 0 || info->datatype >= ncclNumTypes) {
-    WARN("%s : invalid type %d", info->opName, info->datatype);
+    ERR(ncclInvalidArgument, "%s : invalid type %d", info->opName, info->datatype);
     return ncclInvalidArgument;
   }
 
@@ -170,13 +170,13 @@ ncclResult_t ArgsCheck(struct ncclInfo* info) {
   // just as a reminder.
   // coverity[result_independent_of_operands]
   if (info->op < 0 || ncclMaxRedOp < info->op) {
-    WARN("%s : invalid reduction operation %d", info->opName, info->op);
+    ERR(ncclInvalidArgument, "%s : invalid reduction operation %d", info->opName, info->op);
     return ncclInvalidArgument;
   }
   int opIx = int(ncclUserRedOpMangle(info->comm, info->op)) - int(ncclNumOps);
   if (ncclNumOps <= info->op &&
       (info->comm->userRedOpCapacity <= opIx || info->comm->userRedOps[opIx].freeNext != -1)) {
-    WARN("%s : reduction operation %d unknown to this communicator", info->opName, info->op);
+    ERR(ncclInvalidArgument, "%s : reduction operation %d unknown to this communicator", info->opName, info->op);
     return ncclInvalidArgument;
   }
 

--- a/comms/ncclx/v2_30/src/misc/cudawrap.cc
+++ b/comms/ncclx/v2_30/src/misc/cudawrap.cc
@@ -182,7 +182,7 @@ bool ncclCudaLaunchBlocking = false;
     res = CUDACLEARERROR(cudaGetDriverEntryPointByVersion(#symbol, (void **) (&pfn_##symbol), version, cudaEnableDefault, &driverStatus)); \
     if (res != cudaSuccess || driverStatus != cudaDriverEntryPointSuccess) { \
       if (!ignore) {                                                    \
-        WARN("Retrieve %s version %d failed with %d status %d", #symbol, version, res, driverStatus); \
+        ERR(ncclSystemError, "Retrieve %s version %d failed with %d status %d", #symbol, version, res, driverStatus); \
         return ncclSystemError; }                                       \
     } } while(0)
 #elif CUDART_VERSION >= 12000
@@ -191,7 +191,7 @@ bool ncclCudaLaunchBlocking = false;
     res = CUDACLEARERROR(cudaGetDriverEntryPoint(#symbol, (void **) (&pfn_##symbol), cudaEnableDefault, &driverStatus)); \
     if (res != cudaSuccess || driverStatus != cudaDriverEntryPointSuccess) { \
       if (!ignore) {                                                    \
-        WARN("Retrieve %s failed with %d status %d", #symbol, res, driverStatus); \
+        ERR(ncclSystemError, "Retrieve %s failed with %d status %d", #symbol, res, driverStatus); \
         return ncclSystemError; }                                       \
     } } while(0)
 #else
@@ -199,7 +199,7 @@ bool ncclCudaLaunchBlocking = false;
     res = CUDACLEARERROR(cudaGetDriverEntryPoint(#symbol, (void **) (&pfn_##symbol), cudaEnableDefault)); \
     if (res != cudaSuccess) { \
       if (!ignore) {                                                    \
-        WARN("Retrieve %s failed with %d", #symbol, res);               \
+        ERR(ncclSystemError, "Retrieve %s failed with %d", #symbol, res);               \
         return ncclSystemError; }                                       \
     } } while(0)
 #endif
@@ -287,7 +287,7 @@ static void initOnceFunc() {
 
   #if CUDART_VERSION >= 11030
   if (cudaPfnFuncLoader()) {
-    WARN("CUDA some PFN functions not found in the library");
+    ERR(ncclSystemError, "CUDA some PFN functions not found in the library");
     goto error;
   }
   #endif

--- a/comms/ncclx/v2_30/src/misc/gdrwrap.cc
+++ b/comms/ncclx/v2_30/src/misc/gdrwrap.cc
@@ -43,7 +43,7 @@ std::mutex& getGdrMutex() {
     cast = (void**)&funcptr;                             \
     tmp = ncclOsDlsym(handle, symbol);                   \
     if (tmp == NULL) {                                   \
-      WARN("ncclOsDlsym failed on %s - %s", symbol, ncclOsDlerror()); \
+      ERR(ncclSystemError, "ncclOsDlsym failed on %s - %s", symbol, ncclOsDlerror()); \
       goto teardown;                                     \
     }                                                    \
     *cast = tmp;                                         \
@@ -68,7 +68,7 @@ static void initOnceFunc(void) {
 
   gdrhandle = ncclOsDlopen(GDRAPI_LIBNAME, NCCL_OS_DL_NOW);
   if (!gdrhandle) {
-    WARN("Failed to open %s - %s", GDRAPI_LIBNAME, ncclOsDlerror());
+    ERR(ncclSystemError, "Failed to open %s - %s", GDRAPI_LIBNAME, ncclOsDlerror());
     goto teardown;
   }
 
@@ -124,12 +124,12 @@ gdr_t wrap_gdr_open(void) {
 
 ncclResult_t wrap_gdr_close(gdr_t g) {
   if (gdr_internal_close == NULL) {
-    WARN("GDRCOPY lib wrapper not initialized.");
+    ERR(ncclInternalError, "GDRCOPY lib wrapper not initialized.");
     return ncclInternalError;
   }
   int ret = gdr_internal_close(g);
   if (ret != 0) {
-    WARN("gdr_close() failed: %d", ret);
+    ERR(ncclSystemError, "gdr_close() failed: %d", ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -137,13 +137,13 @@ ncclResult_t wrap_gdr_close(gdr_t g) {
 
 ncclResult_t wrap_gdr_pin_buffer(gdr_t g, unsigned long addr, size_t size, uint64_t p2p_token, uint32_t va_space, gdr_mh_t *handle) {
   if (gdr_internal_pin_buffer == NULL) {
-    WARN("GDRCOPY lib wrapper not initialized.");
+    ERR(ncclInternalError, "GDRCOPY lib wrapper not initialized.");
     return ncclInternalError;
   }
   int ret;
   GDRLOCKCALL(gdr_internal_pin_buffer(g, addr, size, p2p_token, va_space, handle), ret);
   if (ret != 0) {
-    WARN("gdr_pin_buffer(addr %lx, size %zu) failed: %d", addr, size, ret);
+    ERR(ncclSystemError, "gdr_pin_buffer(addr %lx, size %zu) failed: %d", addr, size, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -164,13 +164,13 @@ bool ncclGdrPinV2Available(void) {
 
 ncclResult_t wrap_gdr_pin_buffer_v2(gdr_t g, unsigned long addr, size_t size, uint32_t flags, gdr_mh_t *handle) {
   if (!ncclGdrPinV2Available()) {
-    WARN("gdr_pin_buffer_v2 not available; GDRCopy >= 2.5 required");
+    ERR(ncclInternalError, "gdr_pin_buffer_v2 not available; GDRCopy >= 2.5 required");
     return ncclInternalError;
   }
   int ret;
   GDRLOCKCALL(gdr_internal_pin_buffer_v2(g, addr, size, flags, handle), ret);
   if (ret != 0) {
-    WARN("gdr_pin_buffer_v2(addr %lx, size %zu, flags %u) failed: %d", addr, size, flags, ret);
+    ERR(ncclSystemError, "gdr_pin_buffer_v2(addr %lx, size %zu, flags %u) failed: %d", addr, size, flags, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -178,13 +178,13 @@ ncclResult_t wrap_gdr_pin_buffer_v2(gdr_t g, unsigned long addr, size_t size, ui
 
 ncclResult_t wrap_gdr_unpin_buffer(gdr_t g, gdr_mh_t handle) {
   if (gdr_internal_unpin_buffer == NULL) {
-    WARN("GDRCOPY lib wrapper not initialized.");
+    ERR(ncclInternalError, "GDRCOPY lib wrapper not initialized.");
     return ncclInternalError;
   }
   int ret;
   GDRLOCKCALL(gdr_internal_unpin_buffer(g, handle), ret);
   if (ret != 0) {
-    WARN("gdr_unpin_buffer(handle %lx) failed: %d", handle.h, ret);
+    ERR(ncclSystemError, "gdr_unpin_buffer(handle %lx) failed: %d", handle.h, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -192,13 +192,13 @@ ncclResult_t wrap_gdr_unpin_buffer(gdr_t g, gdr_mh_t handle) {
 
 ncclResult_t wrap_gdr_get_info(gdr_t g, gdr_mh_t handle, gdr_info_t *info) {
   if (gdr_internal_get_info == NULL) {
-    WARN("GDRCOPY lib wrapper not initialized.");
+    ERR(ncclInternalError, "GDRCOPY lib wrapper not initialized.");
     return ncclInternalError;
   }
   int ret;
   GDRLOCKCALL(gdr_internal_get_info(g, handle, info), ret);
   if (ret != 0) {
-    WARN("gdr_get_info(handle %lx) failed: %d", handle.h, ret);
+    ERR(ncclSystemError, "gdr_get_info(handle %lx) failed: %d", handle.h, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -206,13 +206,13 @@ ncclResult_t wrap_gdr_get_info(gdr_t g, gdr_mh_t handle, gdr_info_t *info) {
 
 ncclResult_t wrap_gdr_map(gdr_t g, gdr_mh_t handle, void **va, size_t size) {
   if (gdr_internal_map == NULL) {
-    WARN("GDRCOPY lib wrapper not initialized.");
+    ERR(ncclInternalError, "GDRCOPY lib wrapper not initialized.");
     return ncclInternalError;
   }
   int ret;
   GDRLOCKCALL(gdr_internal_map(g, handle, va, size), ret);
   if (ret != 0) {
-    WARN("gdr_map(handle %lx, size %zu) failed: %d", handle.h, size, ret);
+    ERR(ncclSystemError, "gdr_map(handle %lx, size %zu) failed: %d", handle.h, size, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -220,13 +220,13 @@ ncclResult_t wrap_gdr_map(gdr_t g, gdr_mh_t handle, void **va, size_t size) {
 
 ncclResult_t wrap_gdr_unmap(gdr_t g, gdr_mh_t handle, void *va, size_t size) {
   if (gdr_internal_unmap == NULL) {
-    WARN("GDRCOPY lib wrapper not initialized.");
+    ERR(ncclInternalError, "GDRCOPY lib wrapper not initialized.");
     return ncclInternalError;
   }
   int ret;
   GDRLOCKCALL(gdr_internal_unmap(g, handle, va, size), ret);
   if (ret != 0) {
-    WARN("gdr_unmap(handle %lx, va %p, size %zu) failed: %d", handle.h, va, size, ret);
+    ERR(ncclSystemError, "gdr_unmap(handle %lx, va %p, size %zu) failed: %d", handle.h, va, size, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -234,7 +234,7 @@ ncclResult_t wrap_gdr_unmap(gdr_t g, gdr_mh_t handle, void *va, size_t size) {
 
 ncclResult_t wrap_gdr_runtime_get_version(int *major, int *minor) {
   if (gdr_internal_runtime_get_version == NULL) {
-    WARN("GDRCOPY lib wrapper not initialized.");
+    ERR(ncclInternalError, "GDRCOPY lib wrapper not initialized.");
     return ncclInternalError;
   }
   gdr_internal_runtime_get_version(major, minor);
@@ -243,7 +243,7 @@ ncclResult_t wrap_gdr_runtime_get_version(int *major, int *minor) {
 
 ncclResult_t wrap_gdr_driver_get_version(gdr_t g, int *major, int *minor) {
   if (gdr_internal_driver_get_version == NULL) {
-    WARN("GDRCOPY lib wrapper not initialized.");
+    ERR(ncclInternalError, "GDRCOPY lib wrapper not initialized.");
     return ncclInternalError;
   }
   gdr_internal_driver_get_version(g, major, minor);
@@ -252,13 +252,13 @@ ncclResult_t wrap_gdr_driver_get_version(gdr_t g, int *major, int *minor) {
 
 ncclResult_t wrap_gdr_copy_to_mapping(gdr_mh_t handle, void *map_d_ptr, const void *h_ptr, size_t size) {
   if (gdr_internal_copy_to_mapping == NULL) {
-    WARN("GDRCOPY lib wrapper not initialized.");
+    ERR(ncclInternalError, "GDRCOPY lib wrapper not initialized.");
     return ncclInternalError;
   }
   int ret;
   GDRLOCKCALL(gdr_internal_copy_to_mapping(handle, map_d_ptr, h_ptr, size), ret);
   if (ret != 0) {
-    WARN("gdr_copy_to_mapping(handle %lx, map_d_ptr %p, h_ptr %p, size %zu) failed: %d", handle.h, map_d_ptr, h_ptr, size, ret);
+    ERR(ncclSystemError, "gdr_copy_to_mapping(handle %lx, map_d_ptr %p, h_ptr %p, size %zu) failed: %d", handle.h, map_d_ptr, h_ptr, size, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -266,13 +266,13 @@ ncclResult_t wrap_gdr_copy_to_mapping(gdr_mh_t handle, void *map_d_ptr, const vo
 
 ncclResult_t wrap_gdr_copy_from_mapping(gdr_mh_t handle, void *h_ptr, const void *map_d_ptr, size_t size) {
   if (gdr_internal_copy_from_mapping == NULL) {
-    WARN("GDRCOPY lib wrapper not initialized.");
+    ERR(ncclInternalError, "GDRCOPY lib wrapper not initialized.");
     return ncclInternalError;
   }
   int ret;
   GDRLOCKCALL(gdr_internal_copy_from_mapping(handle, h_ptr, map_d_ptr, size), ret);
   if (ret != 0) {
-    WARN("gdr_copy_from_mapping(handle %lx, h_ptr %p, map_d_ptr %p, size %zu) failed: %d", handle.h, h_ptr, map_d_ptr, size, ret);
+    ERR(ncclSystemError, "gdr_copy_from_mapping(handle %lx, h_ptr %p, map_d_ptr %p, size %zu) failed: %d", handle.h, h_ptr, map_d_ptr, size, ret);
     return ncclSystemError;
   }
   return ncclSuccess;

--- a/comms/ncclx/v2_30/src/misc/ibvsymbols.cc
+++ b/comms/ncclx/v2_30/src/misc/ibvsymbols.cc
@@ -97,7 +97,7 @@ ncclResult_t buildIbvSymbols(struct ncclIbvSymbols* ibvSymbols) {
     cast = (void**)&funcptr;                             \
     tmp = dlvsym(handle, symbol, IBVERBS_VERSION);       \
     if (tmp == NULL) {                                   \
-      WARN("dlvsym failed on %s - %s version %s", symbol, dlerror(), IBVERBS_VERSION);  \
+      ERR(ncclSystemError, "dlvsym failed on %s - %s version %s", symbol, dlerror(), IBVERBS_VERSION);  \
       goto teardown;                                     \
     }                                                    \
     *cast = tmp;                                         \

--- a/comms/ncclx/v2_30/src/misc/ibvwrap.cc
+++ b/comms/ncclx/v2_30/src/misc/ibvwrap.cc
@@ -32,7 +32,7 @@ ncclResult_t wrap_ibv_symbols(void) {
 /* CHECK_NOT_NULL: helper macro to check for NULL symbol */
 #define CHECK_NOT_NULL(container, internal_name) \
   if (container.internal_name == NULL) { \
-     WARN("lib wrapper not initialized."); \
+     ERR(ncclInternalError, "lib wrapper not initialized."); \
      return ncclInternalError; \
   }
 
@@ -40,7 +40,7 @@ ncclResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name); \
   retval = container.call; \
   if (retval == error_retval) { \
-    WARN("Call to " name " failed with error %s", strerror(errno)); \
+    ERR(ncclSystemError, "Call to " name " failed with error %s", strerror(errno)); \
     return ncclSystemError; \
   } \
   return ncclSuccess;
@@ -49,7 +49,7 @@ ncclResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name); \
   retval = container.call; \
   if (retval == error_retval) { \
-    WARN("Call to " name " failed"); \
+    ERR(ncclSystemError, "Call to " name " failed"); \
     return ncclSystemError; \
   } \
   return ncclSuccess;
@@ -66,7 +66,7 @@ ncclResult_t wrap_ibv_symbols(void) {
     *supported = 0; \
     return ncclSuccess; \
   } else if (ret != success_retval) { \
-    WARN("Call to " name " failed with error %s errno %d", strerror(ret), ret); \
+    ERR(ncclSystemError, "Call to " name " failed with error %s errno %d", strerror(ret), ret); \
     *supported = 1; \
     return ncclSystemError; \
   } \
@@ -77,7 +77,7 @@ ncclResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name); \
   int ret = container.call; \
   if (ret != success_retval) { \
-    WARN("Call to " name " failed with error %s errno %d", strerror(ret), ret); \
+    ERR(ncclSystemError, "Call to " name " failed with error %s errno %d", strerror(ret), ret); \
     return ncclSystemError; \
   } \
   return ncclSuccess;
@@ -86,7 +86,7 @@ ncclResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name); \
   int ret = container.call; \
   if (ret == error_retval) { \
-    WARN("Call to " name " failed"); \
+    ERR(ncclSystemError, "Call to " name " failed"); \
     return ncclSystemError; \
   } \
   return ncclSuccess;
@@ -306,7 +306,7 @@ ncclResult_t wrap_ibv_modify_qp(struct ibv_qp* qp, struct ibv_qp_attr* attr, int
   } while (IBV_MQP_RETRY_ERRNO_ALL(ret) && attempts < maxCnt);
   if (ret != 0) {
     ibvModifyQpLog(qp, attr->qp_state, attr, attr_mask, qpMsg, sizeof(qpMsg));
-    WARN("Call to ibv_modify_qp failed with %d %s, %s", ret, strerror(ret), qpMsg);
+    ERR(ncclSystemError, "Call to ibv_modify_qp failed with %d %s, %s", ret, strerror(ret), qpMsg);
     return ncclSystemError;
   }
   return ncclSuccess;

--- a/comms/ncclx/v2_30/src/misc/mlx5dvsymbols.cc
+++ b/comms/ncclx/v2_30/src/misc/mlx5dvsymbols.cc
@@ -51,7 +51,7 @@ ncclResult_t buildMlx5dvSymbols(struct ncclMlx5dvSymbols* mlx5dvSymbols) {
     cast = (void**)&funcptr;                             \
     tmp = dlvsym(handle, symbol, MLX5DV_VERSION);       \
     if (tmp == NULL) {                                   \
-      WARN("dlvsym failed on %s - %s version %s", symbol, dlerror(), MLX5DV_VERSION);  \
+      ERR(ncclSystemError, "dlvsym failed on %s - %s version %s", symbol, dlerror(), MLX5DV_VERSION);  \
       goto teardown;                                     \
     }                                                    \
     *cast = tmp;                                         \

--- a/comms/ncclx/v2_30/src/misc/mlx5dvwrap.cc
+++ b/comms/ncclx/v2_30/src/misc/mlx5dvwrap.cc
@@ -30,7 +30,7 @@ ncclResult_t wrap_mlx5dv_symbols(void) {
 /* CHECK_NOT_NULL: helper macro to check for NULL symbol */
 #define CHECK_NOT_NULL(container, internal_name) \
   if (container.internal_name == NULL) { \
-     WARN("NET/MLX5: lib wrapper not initialized."); \
+     ERR(ncclInternalError, "NET/MLX5: lib wrapper not initialized."); \
      return ncclInternalError; \
   }
 
@@ -38,7 +38,7 @@ ncclResult_t wrap_mlx5dv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name); \
   retval = container.call; \
   if (retval == error_retval) { \
-    WARN("NET/MLX5: Call to " name " failed with error %s", strerror(errno)); \
+    ERR(ncclSystemError, "NET/MLX5: Call to " name " failed with error %s", strerror(errno)); \
     return ncclSystemError; \
   } \
   return ncclSuccess;
@@ -47,7 +47,7 @@ ncclResult_t wrap_mlx5dv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name); \
   int ret = container.call; \
   if (ret != success_retval) { \
-    WARN("NET/MLX5: Call to " name " failed with error %s", strerror(errno)); \
+    ERR(ncclSystemError, "NET/MLX5: Call to " name " failed with error %s", strerror(errno)); \
     return ncclSystemError; \
   } \
   return ncclSuccess;

--- a/comms/ncclx/v2_30/src/misc/nvmlwrap.cc
+++ b/comms/ncclx/v2_30/src/misc/nvmlwrap.cc
@@ -120,7 +120,7 @@ ncclResult_t ncclNvmlEnsureInitialized() {
   #endif
   nvmlReturn_t res1 = (have_v2 ? pfn_nvmlInit_v2 : pfn_nvmlInit)();
   if (res1 != NVML_SUCCESS) {
-    WARN("nvmlInit%s() failed: %s", have_v2 ? "_v2" : "", pfn_nvmlErrorString(res1));
+    ERR(ncclSystemError, "nvmlInit%s() failed: %s", have_v2 ? "_v2" : "", pfn_nvmlErrorString(res1));
     initResult = ncclSystemError;
     return initResult;
   }
@@ -128,14 +128,14 @@ ncclResult_t ncclNvmlEnsureInitialized() {
   unsigned int ndev;
   res1 = (have_v2 ? pfn_nvmlDeviceGetCount_v2 : pfn_nvmlDeviceGetCount)(&ndev);
   if (res1 != NVML_SUCCESS) {
-    WARN("nvmlDeviceGetCount%s() failed: %s", have_v2 ? "_v2" :"", pfn_nvmlErrorString(res1));
+    ERR(ncclSystemError, "nvmlDeviceGetCount%s() failed: %s", have_v2 ? "_v2" :"", pfn_nvmlErrorString(res1));
     initResult = ncclSystemError;
     return initResult;
   }
 
   ncclNvmlDeviceCount = int(ndev);
   if (ncclNvmlMaxDevices < ncclNvmlDeviceCount) {
-    WARN("nvmlDeviceGetCount() reported more devices (%d) than the internal maximum (ncclNvmlMaxDevices=%d)", ncclNvmlDeviceCount, ncclNvmlMaxDevices);
+    ERR(ncclInternalError, "nvmlDeviceGetCount() reported more devices (%d) than the internal maximum (ncclNvmlMaxDevices=%d)", ncclNvmlDeviceCount, ncclNvmlMaxDevices);
     initResult = ncclInternalError;
     return initResult;
   }
@@ -143,14 +143,14 @@ ncclResult_t ncclNvmlEnsureInitialized() {
   for(int a=0; a < ncclNvmlDeviceCount; a++) {
     res1 = pfn_nvmlDeviceGetHandleByIndex(a, &ncclNvmlDevices[a].handle);
     if (res1 != NVML_SUCCESS) {
-      WARN("nvmlDeviceGetHandleByIndex(%d) failed: %s", int(a), pfn_nvmlErrorString(res1));
+      ERR(ncclSystemError, "nvmlDeviceGetHandleByIndex(%d) failed: %s", int(a), pfn_nvmlErrorString(res1));
       initResult = ncclSystemError;
       return initResult;
     }
 
     res1 = pfn_nvmlDeviceGetCudaComputeCapability(ncclNvmlDevices[a].handle, &ncclNvmlDevices[a].computeCapabilityMajor, &ncclNvmlDevices[a].computeCapabilityMinor);
     if (res1 != NVML_SUCCESS) {
-      WARN("nvmlDeviceGetCudaComputeCapability(%d) failed: %s", int(a), pfn_nvmlErrorString(res1));
+      ERR(ncclSystemError, "nvmlDeviceGetCudaComputeCapability(%d) failed: %s", int(a), pfn_nvmlErrorString(res1));
       initResult = ncclSystemError;
       return initResult;
     }
@@ -163,14 +163,14 @@ ncclResult_t ncclNvmlEnsureInitialized() {
 
       res1 = pfn_nvmlDeviceGetP2PStatus(da, db, NVML_P2P_CAPS_INDEX_READ, &ncclNvmlDevicePairs[a][b].p2pStatusRead);
       if (res1 != NVML_SUCCESS) {
-        WARN("nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_READ) failed: %s", a, b, pfn_nvmlErrorString(res1));
+        ERR(ncclSystemError, "nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_READ) failed: %s", a, b, pfn_nvmlErrorString(res1));
         initResult = ncclSystemError;
         return initResult;
       }
 
       res1 = pfn_nvmlDeviceGetP2PStatus(da, db, NVML_P2P_CAPS_INDEX_WRITE, &ncclNvmlDevicePairs[a][b].p2pStatusWrite);
       if (res1 != NVML_SUCCESS) {
-        WARN("nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_READ) failed: %s", a, b, pfn_nvmlErrorString(res1));
+        ERR(ncclSystemError, "nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_READ) failed: %s", a, b, pfn_nvmlErrorString(res1));
         initResult = ncclSystemError;
         return initResult;
       }
@@ -184,7 +184,7 @@ ncclResult_t ncclNvmlEnsureInitialized() {
 #define NVMLCHECK(name, ...) do { \
   nvmlReturn_t e44241808 = pfn_##name(__VA_ARGS__); \
   if (e44241808 != NVML_SUCCESS) { \
-    WARN(#name "() failed: %s", pfn_nvmlErrorString(e44241808)); \
+    ERR(ncclSystemError, #name "() failed: %s", pfn_nvmlErrorString(e44241808)); \
     return ncclSystemError; \
   } \
 } while(0)

--- a/comms/ncclx/v2_30/src/misc/socket.cc
+++ b/comms/ncclx/v2_30/src/misc/socket.cc
@@ -31,7 +31,7 @@ static ncclResult_t socketProgress(int op, struct ncclSocket* sock, void* ptr, i
       return ncclSuccess;
     } else {
       char line[SOCKET_NAME_MAXLEN+1];
-      WARN("socketProgress: Connection closed by remote peer %s",
+      ERR(ncclRemoteError, "socketProgress: Connection closed by remote peer %s",
            ncclSocketToString(&sock->addr, line, /*numericHostForm*/0));
       return ncclRemoteError;
     }
@@ -69,7 +69,7 @@ ncclResult_t ncclSocketShutdown(struct ncclSocket* sock, int how) {
 
 ncclResult_t ncclSocketGetFd(struct ncclSocket* sock, ncclSocketDescriptor* socketDescriptor) {
   if (sock == NULL) {
-    WARN("ncclSocketGetFd: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketGetFd: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (socketDescriptor) *socketDescriptor = sock->socketDescriptor;
@@ -78,7 +78,7 @@ ncclResult_t ncclSocketGetFd(struct ncclSocket* sock, ncclSocketDescriptor* sock
 
 ncclResult_t ncclSocketSetFd(ncclSocketDescriptor socketDescriptor, struct ncclSocket* sock) {
   if (sock == NULL) {
-    WARN("ncclSocketSetFd: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketSetFd: pass NULL socket");
     return ncclInvalidArgument;
   }
   sock->socketDescriptor = socketDescriptor;
@@ -88,11 +88,11 @@ ncclResult_t ncclSocketSetFd(ncclSocketDescriptor socketDescriptor, struct ncclS
 
 ncclResult_t ncclSocketListen(struct ncclSocket* sock) {
   if (sock == NULL) {
-    WARN("ncclSocketListen: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketListen: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (!ncclOsSocketIsValid(sock)) {
-    WARN("ncclSocketListen: socket is invalid");
+    ERR(ncclInvalidArgument, "ncclSocketListen: socket is invalid");
     return ncclInvalidArgument;
   }
 
@@ -210,7 +210,7 @@ ncclResult_t ncclFindInterfaces(char* ifNames, union ncclSocketAddress *ifAddrs,
 
 ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char* ip_port_pair) {
   if (!(ip_port_pair && strlen(ip_port_pair) > 1)) {
-    WARN("Net : string is null");
+    ERR(ncclInvalidArgument, "Net : string is null");
     return ncclInvalidArgument;
   }
 
@@ -220,7 +220,7 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
     struct netIf ni;
     // parse <ip_or_hostname>:<port> string, expect one pair
     if (parseStringList(ip_port_pair, &ni, 1) != 1) {
-      WARN("Net : No valid <IPv4_or_hostname>:<port> pair found");
+      ERR(ncclInvalidArgument, "Net : No valid <IPv4_or_hostname>:<port> pair found");
       return ncclInvalidArgument;
     }
 
@@ -231,7 +231,7 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
     hints.ai_socktype = SOCK_STREAM;
 
     if ( (rv = getaddrinfo(ni.prefix, NULL, &hints, &p)) != 0) {
-      WARN("Net : error encountered when getting address info : %s", gai_strerror(rv));
+      ERR(ncclInvalidArgument, "Net : error encountered when getting address info : %s", gai_strerror(rv));
       return ncclInvalidArgument;
     }
 
@@ -250,7 +250,7 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
       sin6.sin6_flowinfo = 0;                          // needed by IPv6, but possibly obsolete
       sin6.sin6_scope_id = 0;                          // should be global scope, set to 0
     } else {
-      WARN("Net : unsupported IP family");
+      ERR(ncclInvalidArgument, "Net : unsupported IP family");
       freeaddrinfo(p);
       return ncclInvalidArgument;
     }
@@ -264,7 +264,7 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
       if (ip_port_pair[i] == ']') break;
     }
     if (i == len) {
-      WARN("Net : No valid [IPv6]:port pair found");
+      ERR(ncclInvalidArgument, "Net : No valid [IPv6]:port pair found");
       return ncclInvalidArgument;
     }
     bool global_scope = (j == -1 ? true : false);     // If no % found, global scope; otherwise, link scope
@@ -282,7 +282,7 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
     sin6.sin6_family = AF_INET6;                       // IPv6
 
     if (inet_pton(AF_INET6, ip_str, &(sin6.sin6_addr)) != 1) {     // IP address
-      WARN("Net : error encountered when converting IPv6 address");
+      ERR(ncclInvalidArgument, "Net : error encountered when converting IPv6 address");
       return ncclInvalidArgument;
     }
 
@@ -295,7 +295,7 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
 
 ncclResult_t ncclSocketGetAddr(struct ncclSocket* sock, union ncclSocketAddress* addr) {
   if (sock == NULL) {
-    WARN("ncclSocketGetAddr: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketGetAddr: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (sock->state != ncclSocketStateReady) return ncclInternalError;
@@ -347,7 +347,7 @@ static ncclResult_t socketFinalizeAccept(struct ncclSocket* sock) {
     memcpy(&type, sock->finalizeBuffer, sizeof(type));
   }
   if (type != sock->type) {
-    WARN("socketFinalizeAccept from %s: wrong type %d != %d", ncclSocketToString(&sock->addr, line), type, sock->type);
+    ERR(ncclInternalError, "socketFinalizeAccept from %s: wrong type %d != %d", ncclSocketToString(&sock->addr, line), type, sock->type);
     (void) ncclSocketClose(sock);
     sock->state = ncclSocketStateError;
     return ncclInternalError;
@@ -359,7 +359,7 @@ static ncclResult_t socketFinalizeAccept(struct ncclSocket* sock) {
 
 ncclResult_t ncclSocketPollConnect(struct ncclSocket* sock) {
   if (sock == NULL) {
-    WARN("ncclSocketPollConnect: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketPollConnect: pass NULL socket");
     return ncclInvalidArgument;
   }
   NCCLCHECK(ncclOsSocketPollConnect(sock));
@@ -414,7 +414,7 @@ ncclResult_t ncclSocketReady(struct ncclSocket* sock, int *running) {
     return ncclSuccess;
   }
   if (sock->state == ncclSocketStateError || sock->state == ncclSocketStateClosed) {
-    WARN("ncclSocketReady: unexpected socket state %d", sock->state);
+    ERR(ncclRemoteError, "ncclSocketReady: unexpected socket state %d", sock->state);
     return ncclRemoteError;
   }
   *running = (sock->state == ncclSocketStateReady) ? 1 : 0;
@@ -431,18 +431,18 @@ ncclResult_t ncclSocketConnect(struct ncclSocket* sock, const char* localIfName)
 #endif
 
   if (sock == NULL) {
-    WARN("ncclSocketConnect: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketConnect: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (!ncclOsSocketIsValid(sock)) {
-    WARN("ncclSocketConnect: socket is invalid");
+    ERR(ncclInvalidArgument, "ncclSocketConnect: socket is invalid");
     return ncclInvalidArgument;
   }
 
   if (sock->state != ncclSocketStateInitialized) {
-    WARN("ncclSocketConnect: wrong socket state %d", sock->state);
-    if (sock->state == ncclSocketStateError) return ncclRemoteError;
-    return ncclInternalError;
+    ncclResult_t stateErr = (sock->state == ncclSocketStateError) ? ncclRemoteError : ncclInternalError;
+    ERR(stateErr, "ncclSocketConnect: wrong socket state %d", sock->state);
+    return stateErr;
   }
   TRACE(NCCL_INIT|NCCL_NET,"Connecting to socket %s", ncclSocketToString(&sock->addr, line));
 
@@ -478,7 +478,7 @@ ncclResult_t ncclSocketConnect(struct ncclSocket* sock, const char* localIfName)
     case ncclSocketStateError:
       return ncclSystemError;
     default:
-      WARN("ncclSocketConnect: wrong socket state %d", sock->state);
+      ERR(ncclInternalError, "ncclSocketConnect: wrong socket state %d", sock->state);
       return ncclInternalError;
   }
 }
@@ -487,16 +487,13 @@ ncclResult_t ncclSocketAccept(struct ncclSocket* sock, struct ncclSocket* listen
   ncclResult_t ret = ncclSuccess;
 
   if (listenSock == NULL || sock == NULL) {
-    WARN("ncclSocketAccept: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketAccept: pass NULL socket");
     ret = ncclInvalidArgument;
     goto exit;
   }
   if (listenSock->state != ncclSocketStateReady) {
-    WARN("ncclSocketAccept: wrong socket state %d", listenSock->state);
-    if (listenSock->state == ncclSocketStateError)
-      ret = ncclSystemError;
-    else
-      ret = ncclInternalError;
+    ret = (listenSock->state == ncclSocketStateError) ? ncclSystemError : ncclInternalError;
+    ERR(ret, "ncclSocketAccept: wrong socket state %d", listenSock->state);
     goto exit;
   }
 
@@ -526,7 +523,7 @@ ncclResult_t ncclSocketAccept(struct ncclSocket* sock, struct ncclSocket* listen
       ret = ncclSystemError;
       break;
     default:
-      WARN("ncclSocketAccept: wrong socket state %d", sock->state);
+      ERR(ncclInternalError, "ncclSocketAccept: wrong socket state %d", sock->state);
       ret = ncclInternalError;
       break;
   }
@@ -559,7 +556,7 @@ ncclResult_t ncclSocketInit(struct ncclSocket* sock, const union ncclSocketAddre
     family = sock->addr.sa.sa_family;
     if (family != AF_INET && family != AF_INET6) {
       char line[SOCKET_NAME_MAXLEN+1];
-      WARN("ncclSocketInit: connecting to address %s with family %d is neither AF_INET(%d) nor AF_INET6(%d)",
+      ERR(ncclInternalError, "ncclSocketInit: connecting to address %s with family %d is neither AF_INET(%d) nor AF_INET6(%d)",
           ncclSocketToString(&sock->addr, line), family, AF_INET, AF_INET6);
 
       WARN("You might set TORCH_NCCL_BCAST_UNIQUEID=0 to enable fast init feature, in ncclx 2.30 you will have ncclSocketInit errors. "
@@ -592,7 +589,7 @@ fail:
 
 ncclResult_t ncclSocketProgress(int op, struct ncclSocket* sock, void* ptr, int size, int* offset, int* closed) {
   if (sock == NULL) {
-    WARN("ncclSocketProgress: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketProgress: pass NULL socket");
     return ncclInvalidArgument;
   }
   NCCLCHECK(socketProgress(op, sock, ptr, size, offset, closed));
@@ -601,7 +598,7 @@ ncclResult_t ncclSocketProgress(int op, struct ncclSocket* sock, void* ptr, int 
 
 ncclResult_t ncclSocketWait(int op, struct ncclSocket* sock, void* ptr, int size, int* offset) {
   if (sock == NULL) {
-    WARN("ncclSocketWait: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketWait: pass NULL socket");
     return ncclInvalidArgument;
   }
   NCCLCHECK(socketWait(op, sock, ptr, size, offset));
@@ -611,11 +608,11 @@ ncclResult_t ncclSocketWait(int op, struct ncclSocket* sock, void* ptr, int size
 ncclResult_t ncclSocketSend(struct ncclSocket* sock, void* ptr, int size) {
   int offset = 0;
   if (sock == NULL) {
-    WARN("ncclSocketSend: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketSend: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (sock->state != ncclSocketStateReady) {
-    WARN("ncclSocketSend: socket state (%d) is not ready", sock->state);
+    ERR(ncclInternalError, "ncclSocketSend: socket state (%d) is not ready", sock->state);
     return ncclInternalError;
   }
   NCCLCHECK(socketWait(NCCL_SOCKET_SEND, sock, ptr, size, &offset));
@@ -625,11 +622,11 @@ ncclResult_t ncclSocketSend(struct ncclSocket* sock, void* ptr, int size) {
 ncclResult_t ncclSocketRecv(struct ncclSocket* sock, void* ptr, int size) {
   int offset = 0;
   if (sock == NULL) {
-    WARN("ncclSocketRecv: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketRecv: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (sock->state != ncclSocketStateReady && sock->state != ncclSocketStateTerminating) {
-    WARN("ncclSocketRecv: socket state (%d) is not ready", sock->state);
+    ERR(ncclInternalError, "ncclSocketRecv: socket state (%d) is not ready", sock->state);
     return ncclInternalError;
   }
   NCCLCHECK(socketWait(NCCL_SOCKET_RECV, sock, ptr, size, &offset));
@@ -639,12 +636,12 @@ ncclResult_t ncclSocketRecv(struct ncclSocket* sock, void* ptr, int size) {
 ncclResult_t ncclSocketSendRecv(struct ncclSocket* sendSock, void* sendPtr, int sendSize, struct ncclSocket* recvSock, void* recvPtr, int recvSize) {
   int sendOffset = 0, recvOffset = 0;
   if (sendSock == NULL || recvSock == NULL) {
-    WARN("ncclSocketSendRecv: invalid socket %p/%p", sendSock, recvSock);
+    ERR(ncclInternalError, "ncclSocketSendRecv: invalid socket %p/%p", sendSock, recvSock);
     return ncclInternalError;
   }
   if (sendSock->state != ncclSocketStateReady ||
       (recvSock->state != ncclSocketStateReady && recvSock->state != ncclSocketStateTerminating)) {
-    WARN("ncclSocketSendRecv: socket state (%d/%d) is not ready", sendSock->state, recvSock->state);
+    ERR(ncclInternalError, "ncclSocketSendRecv: socket state (%d/%d) is not ready", sendSock->state, recvSock->state);
     return ncclInternalError;
   }
   while (sendOffset < sendSize || recvOffset < recvSize) {
@@ -657,13 +654,13 @@ ncclResult_t ncclSocketSendRecv(struct ncclSocket* sendSock, void* sendPtr, int 
 
 ncclResult_t ncclSocketMultiOp(struct ncclSocketOp* ops, int numOps) {
   if (ops == NULL || numOps <= 0) {
-    WARN("ncclSocketMultiOp: invalid arguments ops=%p numOps=%d", ops, numOps);
+    ERR(ncclInvalidArgument, "ncclSocketMultiOp: invalid arguments ops=%p numOps=%d", ops, numOps);
     return ncclInvalidArgument;
   }
 
   for (int i = 0; i < numOps; i++) {
     if (ops[i].sock == NULL) {
-      WARN("ncclSocketMultiOp: invalid socket at index %d", i);
+      ERR(ncclInvalidArgument, "ncclSocketMultiOp: invalid socket at index %d", i);
       return ncclInvalidArgument;
     }
     ops[i].offset = 0;
@@ -682,7 +679,7 @@ ncclResult_t ncclSocketMultiOp(struct ncclSocketOp* ops, int numOps) {
 ncclResult_t ncclSocketTryRecv(struct ncclSocket* sock, void* ptr, int size, int* closed, bool blocking) {
   int offset = 0;
   if (sock == NULL) {
-    WARN("ncclSocketTryRecv: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketTryRecv: pass NULL socket");
     return ncclInvalidArgument;
   }
   *closed = 0;

--- a/comms/ncclx/v2_30/src/misc/strongstream.cc
+++ b/comms/ncclx/v2_30/src/misc/strongstream.cc
@@ -90,7 +90,7 @@ ncclResult_t ncclCudaGetCapturingGraph(
         graph->graphUsageMode = graphUsageMode;
       #endif
       if (status != cudaStreamCaptureStatusNone) {
-        WARN("NCCL cannot be captured in a graph if either it wasn't built with CUDA runtime >= 11.3 or if the installed CUDA driver < R465.");
+        ERR(ncclInvalidUsage, "NCCL cannot be captured in a graph if either it wasn't built with CUDA runtime >= 11.3 or if the installed CUDA driver < R465.");
         return ncclInvalidUsage;
       }
     } else {
@@ -281,7 +281,7 @@ ncclResult_t ncclStrongStreamRelease(
           CUDACHECK(cudaEventRecord(ss->serialEvent, ss->liveStream));
         }
         if (ss->liveAcquiredBy != localThreadId() && ncclParamLaunchRaceFatal()) {
-          WARN("%s", launchRaceFatalMsg);
+          ERR(ncclInvalidUsage, "%s", launchRaceFatalMsg);
           return ncclInvalidUsage;
         }
       } else {
@@ -344,7 +344,7 @@ ncclResult_t ncclStrongStreamRelease(
         #endif
 
         if (cap->acquiredBy != localThreadId() && ncclParamLaunchRaceFatal()) {
-          WARN("%s", launchRaceFatalMsg);
+          ERR(ncclInvalidUsage, "%s", launchRaceFatalMsg);
           return ncclInvalidUsage;
         }
       }

--- a/comms/ncclx/v2_30/src/misc/utils.cc
+++ b/comms/ncclx/v2_30/src/misc/utils.cc
@@ -427,15 +427,15 @@ ncclResult_t ncclIntruAddressMapInsert_untyped(
     uintptr_t key, void* object) {
   // Runtime validation
   if (map == nullptr) {
-    WARN("Intrusive address map pointer is NULL");
+    ERR(ncclInvalidUsage, "Intrusive address map pointer is NULL");
     return ncclInvalidUsage;
   }
   if (object == nullptr) {
-    WARN("Object pointer is NULL");
+    ERR(ncclInvalidUsage, "Object pointer is NULL");
     return ncclInvalidUsage;
   }
   if (keySize <= 0 || keySize > (int)sizeof(uintptr_t)) {
-    WARN("Invalid key size %d (must be 0 < keySize <= %zu)", keySize, sizeof(uintptr_t));
+    ERR(ncclInvalidUsage, "Invalid key size %d (must be 0 < keySize <= %zu)", keySize, sizeof(uintptr_t));
     return ncclInvalidUsage;
   }
 
@@ -445,7 +445,7 @@ ncclResult_t ncclIntruAddressMapInsert_untyped(
     map->table = (void**)calloc((size_t)1<<map->hbits, sizeof(void*));
     if (map->table == nullptr) {
       map->hbits = 0; // Reset on failure
-      WARN("Intrusive address map initialization failed: calloc(%zu entries) returned null", (size_t)1<<map->hbits);
+      ERR(ncclSystemError, "Intrusive address map initialization failed: calloc(%zu entries) returned null", (size_t)1<<map->hbits);
       return ncclSystemError;
     }
   }
@@ -462,7 +462,7 @@ ncclResult_t ncclIntruAddressMapInsert_untyped(
     // Allocate a new table (don't use realloc to avoid data corruption during rehashing)
     void** newTable = (void**)malloc(newSize * sizeof(void*));
     if (newTable == nullptr) {
-      WARN("Intrusive address map resize failed: malloc(%d entries) returned null", newSize);
+      ERR(ncclSystemError, "Intrusive address map resize failed: malloc(%d entries) returned null", newSize);
       return ncclSystemError;
     }
 
@@ -515,15 +515,15 @@ ncclResult_t ncclIntruAddressMapFind_untyped(
     uintptr_t key, void** object) {
   // Runtime validation
   if (map == nullptr) {
-    WARN("Intrusive address map pointer is NULL");
+    ERR(ncclInvalidUsage, "Intrusive address map pointer is NULL");
     return ncclInvalidUsage;
   }
   if (object == nullptr) {
-    WARN("Output object pointer is NULL");
+    ERR(ncclInvalidUsage, "Output object pointer is NULL");
     return ncclInvalidUsage;
   }
   if (keySize <= 0 || keySize > (int)sizeof(uintptr_t)) {
-    WARN("Invalid key size %d (must be 0 < keySize <= %zu)", keySize, sizeof(uintptr_t));
+    ERR(ncclInvalidUsage, "Invalid key size %d (must be 0 < keySize <= %zu)", keySize, sizeof(uintptr_t));
     return ncclInvalidUsage;
   }
 
@@ -556,11 +556,11 @@ ncclResult_t ncclIntruAddressMapRemove_untyped(
     uintptr_t key) {
   // Runtime validation
   if (map == nullptr) {
-    WARN("Intrusive address map pointer is NULL");
+    ERR(ncclInvalidUsage, "Intrusive address map pointer is NULL");
     return ncclInvalidUsage;
   }
   if (keySize <= 0 || keySize > (int)sizeof(uintptr_t)) {
-    WARN("Invalid key size %d (must be 0 < keySize <= %zu)", keySize, sizeof(uintptr_t));
+    ERR(ncclInvalidUsage, "Invalid key size %d (must be 0 < keySize <= %zu)", keySize, sizeof(uintptr_t));
     return ncclInvalidUsage;
   }
 

--- a/comms/ncclx/v2_30/src/mnnvl.cc
+++ b/comms/ncclx/v2_30/src/mnnvl.cc
@@ -72,7 +72,7 @@ ncclResult_t ncclMnnvlCheck(struct ncclComm* comm) {
                                       comm->memManager, "ncclMnnvlCheck", ncclMemOffload);
     if (ret != ncclSuccess) {
       // Return an error if this is a MNNVL capable system but FABRIC handles are not supported
-      WARN("MNNVL (cliqueSize %d) is available but not working on this system. Check the IMEX channel configuration (/dev/nvidia-caps-imex-channels). Set NCCL_MNNVL_ENABLE=0 to ignore this issue.",
+      ERR(ncclSystemError, "MNNVL (cliqueSize %d) is available but not working on this system. Check the IMEX channel configuration (/dev/nvidia-caps-imex-channels). Set NCCL_MNNVL_ENABLE=0 to ignore this issue.",
            comm->clique.size);
       return ncclSystemError;
     }
@@ -83,7 +83,7 @@ ncclResult_t ncclMnnvlCheck(struct ncclComm* comm) {
       (void) pfn_cuGetErrorString(err, &errStr);
       NCCLCHECK(ncclCuMemFree(ptr, comm->memManager));
       // Return an error if this is a MNNVL capable system but it's not working
-      WARN("MNNVL (cliqueSize %d) is available but not working on this system. Check the IMEX configuration (nvidia-imex-ctl -N). Set NCCL_MNNVL_ENABLE=0 to ignore this issue.",
+      ERR(ncclSystemError, "MNNVL (cliqueSize %d) is available but not working on this system. Check the IMEX configuration (nvidia-imex-ctl -N). Set NCCL_MNNVL_ENABLE=0 to ignore this issue.",
           comm->clique.size);
       return ncclSystemError;
     }

--- a/comms/ncclx/v2_30/src/os/linux.cc
+++ b/comms/ncclx/v2_30/src/os/linux.cc
@@ -187,12 +187,12 @@ ncclResult_t ncclOsSocketTryAccept(struct ncclSocket* sock) {
     /* per accept's man page, for linux sockets, the following errors might be already pending errors
      * and should be considered as EAGAIN. To avoid infinite loop in case of errors, we use the retry count*/
     if (++sock->errorRetries == ncclParamRetryCnt()) {
-      WARN("ncclOsSocketTryAccept: exceeded error retry count after %d attempts, %s", sock->errorRetries, strerror(errno));
+      ERR(ncclSystemError, "ncclOsSocketTryAccept: exceeded error retry count after %d attempts, %s", sock->errorRetries, strerror(errno));
       return ncclSystemError;
     }
     INFO(NCCL_NET|NCCL_INIT, "Call to accept returned %s, retrying", strerror(errno));
   } else if (errno != EINTR && errno != EAGAIN && errno != EWOULDBLOCK) {
-    WARN("ncclOsSocketTryAccept: Accept failed: %s", strerror(errno));
+    ERR(ncclSystemError, "ncclOsSocketTryAccept: Accept failed: %s", strerror(errno));
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -207,7 +207,7 @@ ncclResult_t ncclOsSocketSetFlags(struct ncclSocket* sock) {
   int flags;
   int rcvBuf, sndBuf;
   if (!ncclOsSocketIsValid(sock)) {
-    WARN("ncclOsSocketSetFlags: invalid socket");
+    ERR(ncclInvalidArgument, "ncclOsSocketSetFlags: invalid socket");
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -272,7 +272,7 @@ static ncclResult_t socketConnectCheck(struct ncclSocket* sock, int errCode, con
     if (sock->customRetry == 0) {
       if (sock->errorRetries++ == ncclParamRetryCnt()) {
         sock->state = ncclSocketStateError;
-        WARN("%s: connect to %s returned %s, exceeded error retry count after %d attempts",
+        ERR(ncclRemoteError, "%s: connect to %s returned %s, exceeded error retry count after %d attempts",
              funcName, ncclSocketToString(&sock->addr, line), strerror(errCode), sock->errorRetries);
         return ncclRemoteError;
       }
@@ -286,7 +286,7 @@ static ncclResult_t socketConnectCheck(struct ncclSocket* sock, int errCode, con
     sock->state = ncclSocketStateConnecting;
   } else {
     sock->state = ncclSocketStateError;
-    WARN("%s: connect to %s failed : %s", funcName, ncclSocketToString(&sock->addr, line), strerror(errCode));
+    ERR(ncclSystemError, "%s: connect to %s failed : %s", funcName, ncclSocketToString(&sock->addr, line), strerror(errCode));
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -312,7 +312,7 @@ ncclResult_t ncclOsSocketPollConnect(struct ncclSocket* sock) {
   if (ret == 0 || (ret < 0 && errno == EINTR)) {
     return ncclSuccess;
   } else if (ret < 0) {
-    WARN("ncclOsSocketPollConnect to %s failed with error %s", ncclSocketToString(&sock->addr, line), strerror(errno));
+    ERR(ncclSystemError, "ncclOsSocketPollConnect to %s failed with error %s", ncclSocketToString(&sock->addr, line), strerror(errno));
     return ncclSystemError;
   }
 
@@ -340,7 +340,7 @@ ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr,
         return ncclSuccess;
       }
       if (errno != EINTR && errno != EWOULDBLOCK && errno != EAGAIN) {
-        WARN("ncclOsSocketProgressOpt: Call to %s %s failed : %s", (op == NCCL_SOCKET_RECV ? "recv from" : "send to"),
+        ERR(ncclRemoteError, "ncclOsSocketProgressOpt: Call to %s %s failed : %s", (op == NCCL_SOCKET_RECV ? "recv from" : "send to"),
               ncclSocketToString(&sock->addr, line), strerror(errno));
         return ncclRemoteError;
       } else {
@@ -573,7 +573,7 @@ ncclAffinity ncclOsCpuAnd(const ncclAffinity& a, const ncclAffinity& b) {
 ncclResult_t ncclOsGetAffinity(ncclAffinity* affinity) {
   int result = sched_getaffinity(0, sizeof(ncclAffinity), affinity);
   if (result == -1) {
-    WARN("sched_getaffinity failed with error: %s", strerror(errno));
+    ERR(ncclSystemError, "sched_getaffinity failed with error: %s", strerror(errno));
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -582,7 +582,7 @@ ncclResult_t ncclOsGetAffinity(ncclAffinity* affinity) {
 ncclResult_t ncclOsSetAffinity(const ncclAffinity& affinity) {
   int result = sched_setaffinity(0, sizeof(ncclAffinity), &affinity);
   if (result == -1) {
-    WARN("sched_setaffinity failed with error: %s", strerror(errno));
+    ERR(ncclSystemError, "sched_setaffinity failed with error: %s", strerror(errno));
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -597,7 +597,7 @@ ncclResult_t ncclOsNvmlOpen(ncclOsLibraryHandle* handle) {
 
   *handle = ncclOsDlopen("libnvidia-ml.so.1");
   if (*handle == nullptr) {
-    WARN("Failed to open libnvidia-ml.so.1: %s", ncclOsDlerror());
+    ERR(ncclSystemError, "Failed to open libnvidia-ml.so.1: %s", ncclOsDlerror());
     return ncclSystemError;
   }
 
@@ -660,7 +660,7 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize,
           INFO(NCCL_ALL, "mkstemp: Failed to create %s, error: %s (%d) - retrying", shmPath, strerror(errno), errno);
           goto retry_mkstemp;
         }
-        WARN("Error: failed to create shared memory file %s, error %s (%d)", shmPath, strerror(errno), errno);
+        ERR(ncclSystemError, "Error: failed to create shared memory file %s, error %s (%d)", shmPath, strerror(errno), errno);
         ret = ncclSystemError;
         goto fail;
       }
@@ -674,7 +674,7 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize,
         INFO(NCCL_ALL, "fallocate: Failed to extend %s to %ld bytes, error: %s (%d) - retrying", shmPath, realShmSize, strerror(errno), errno);
         goto retry_fallocate;
       }
-      WARN("Error: failed to extend %s to %ld bytes, error: %s (%d)", shmPath, realShmSize, strerror(errno), errno);
+      ERR(ncclSystemError, "Error: failed to extend %s to %ld bytes, error: %s (%d)", shmPath, realShmSize, strerror(errno), errno);
       ret = ncclSystemError;
       goto fail;
     }
@@ -685,7 +685,7 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize,
 
   hptr = (char*)mmap(NULL, realShmSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
   if (hptr == MAP_FAILED) {
-    WARN("Error: Could not map %s size %zu, error: %s (%d)", shmPath, realShmSize, strerror(errno), errno);
+    ERR(ncclSystemError, "Error: Could not map %s size %zu, error: %s (%d)", shmPath, realShmSize, strerror(errno), errno);
     ret = ncclSystemError;
     hptr = NULL;
     goto fail;

--- a/comms/ncclx/v2_30/src/os/linux_ipcsocket.cc
+++ b/comms/ncclx/v2_30/src/os/linux_ipcsocket.cc
@@ -37,7 +37,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket *handle, int rank, uint64_t hash, v
   handle->fd = NCCL_INVALID_SOCKET;
   handle->socketName[0] = '\0';
   if ((fd = socket(AF_UNIX, SOCK_DGRAM, 0)) < 0) {
-    WARN("UDS: Socket creation error : %s (%d)", strerror(errno), errno);
+    ERR(ncclSystemError, "UDS: Socket creation error : %s (%d)", strerror(errno), errno);
     return ncclSystemError;
   }
 
@@ -47,7 +47,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket *handle, int rank, uint64_t hash, v
   // Create unique name for the socket.
   int len = snprintf(temp, NCCL_IPC_SOCKNAME_LEN, NCCL_IPC_SOCKNAME_STR, rank, hash);
   if (len > (int)(sizeof(cliaddr.sun_path) - 1)) {
-    WARN("UDS: Cannot bind provided name to socket. Name too large");
+    ERR(ncclInternalError, "UDS: Cannot bind provided name to socket. Name too large");
     close(fd);
     return ncclInternalError;
   }
@@ -65,7 +65,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket *handle, int rank, uint64_t hash, v
     cliaddr.sun_path[0] = '\0'; // Linux abstract socket trick
   }
   if (bind(fd, (struct sockaddr *)&cliaddr, sizeof(cliaddr)) < 0) {
-    WARN("UDS: Binding to socket %s failed : %s (%d)", temp, strerror(errno), errno);
+    ERR(ncclSystemError, "UDS: Binding to socket %s failed : %s (%d)", temp, strerror(errno), errno);
     close(fd);
     return ncclSystemError;
   }
@@ -86,7 +86,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket *handle, int rank, uint64_t hash, v
 
 ncclResult_t ncclIpcSocketGetFd(struct ncclIpcSocket* handle, int* fd) {
   if (handle == NULL) {
-    WARN("ncclIpcSocketGetFd: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclIpcSocketGetFd: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (fd) *fd = handle->fd;
@@ -139,7 +139,7 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
 
   while ((ret = recvmsg(handle->fd, &msg, 0)) <= 0) {
     if (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
-      WARN("UDS: Receiving data over socket failed : %d", errno);
+      ERR(ncclSystemError, "UDS: Receiving data over socket failed : %d", errno);
       return ncclSystemError;
     }
     if (handle->abortFlag && COMPILER_ATOMIC_LOAD(handle->abortFlag, std::memory_order_acquire)) return ncclInternalError;
@@ -148,13 +148,13 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
   if (recvFd != NULL) {
     if (((cmptr = CMSG_FIRSTHDR(&msg)) != NULL) && (cmptr->cmsg_len == CMSG_LEN(sizeof(int)))) {
       if ((cmptr->cmsg_level != SOL_SOCKET) || (cmptr->cmsg_type != SCM_RIGHTS)) {
-        WARN("UDS: Receiving data over socket failed");
+        ERR(ncclSystemError, "UDS: Receiving data over socket failed");
       return ncclSystemError;
       }
 
       memmove(recvFd, CMSG_DATA(cmptr), sizeof(*recvFd));
     } else {
-      WARN("UDS: Receiving data over socket %s failed", handle->socketName);
+      ERR(ncclSystemError, "UDS: Receiving data over socket %s failed", handle->socketName);
       return ncclSystemError;
     }
     TRACE(NCCL_INIT|NCCL_P2P, "UDS: Got recvFd %d from socket %s", *recvFd, handle->socketName);
@@ -187,7 +187,7 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
 
   int len = snprintf(temp, NCCL_IPC_SOCKNAME_LEN, NCCL_IPC_SOCKNAME_STR, rank, hash);
   if (len > (sizeof(cliaddr.sun_path) - 1)) {
-    WARN("UDS: Cannot connect to provided name for socket. Name too large");
+    ERR(ncclInternalError, "UDS: Cannot connect to provided name for socket. Name too large");
     return ncclInternalError;
   }
   strcpy(cliaddr.sun_path, temp);
@@ -228,7 +228,7 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
   ssize_t sendResult;
   while ((sendResult = sendmsg(handle->fd, &msg, 0)) < 0) {
     if (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
-      WARN("UDS: Sending data over socket %s failed : %s (%d)", temp, strerror(errno), errno);
+      ERR(ncclSystemError, "UDS: Sending data over socket %s failed : %s (%d)", temp, strerror(errno), errno);
       return ncclSystemError;
     }
     if (handle->abortFlag && COMPILER_ATOMIC_LOAD(handle->abortFlag, std::memory_order_acquire)) return ncclInternalError;

--- a/comms/ncclx/v2_30/src/os/windows.cc
+++ b/comms/ncclx/v2_30/src/os/windows.cc
@@ -136,7 +136,7 @@ ncclResult_t ncclOsInitialize() {
   WSADATA wsaData;
   int result = WSAStartup(MAKEWORD(2, 2), &wsaData);
   if (result != 0) {
-    WARN("WSAStartup failed with error: %d", result);
+    ERR(ncclSystemError, "WSAStartup failed with error: %d", result);
     return ncclSystemError;
   }
   INFO(NCCL_INIT|NCCL_NET, "WSAStartup succeeded, Winsock version %d.%d",
@@ -187,14 +187,14 @@ ncclResult_t ncclOsSocketTryAccept(struct ncclSocket* sock) {
     if (wsaError == WSAEINPROGRESS) {
       // Connection in progress, retry with backoff
       if (++sock->errorRetries == ncclParamRetryCnt()) {
-        WARN("ncclOsSocketTryAccept: exceeded error retry count after %d attempts, %s", sock->errorRetries, getWSAErrorMessage(wsaError));
+        ERR(ncclSystemError, "ncclOsSocketTryAccept: exceeded error retry count after %d attempts, %s", sock->errorRetries, getWSAErrorMessage(wsaError));
         return ncclSystemError;
       }
       INFO(NCCL_NET|NCCL_INIT, "Call to accept returned %s, retrying", getWSAErrorMessage(wsaError));
     } else if (wsaError != WSAEINTR && wsaError != WSAEWOULDBLOCK) {
       // WSAEWOULDBLOCK (10035) is expected for non-blocking accept - means no pending connection yet
       // WSAEINTR means interrupted, both are normal and we just return success to try again later
-      WARN("ncclOsSocketTryAccept: Accept failed: %s", getWSAErrorMessage(wsaError));
+      ERR(ncclSystemError, "ncclOsSocketTryAccept: Accept failed: %s", getWSAErrorMessage(wsaError));
       return ncclSystemError;
     }
   }
@@ -210,7 +210,7 @@ ncclResult_t ncclOsSocketSetFlags(struct ncclSocket* sock) {
   int sndBuf, rcvBuf;
   /* Set socket as non-blocking if async or if we need to be able to abort */
   if (!ncclOsSocketIsValid(sock)) {
-    WARN("ncclOsSocketSetFlags: invalid socket");
+    ERR(ncclInvalidArgument, "ncclOsSocketSetFlags: invalid socket");
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -218,7 +218,7 @@ ncclResult_t ncclOsSocketSetFlags(struct ncclSocket* sock) {
     u_long mode = 1;
     int iResult = ioctlsocket(sock->socketDescriptor, FIONBIO, &mode);
     if (iResult != NO_ERROR) {
-      WARN("ncclOsSocketSetFlags: ioctlsocket failed with error: %ld", iResult);
+      ERR(ncclSystemError, "ncclOsSocketSetFlags: ioctlsocket failed with error: %ld", iResult);
       ret = ncclSystemError;
       goto fail;
     }
@@ -254,7 +254,7 @@ ncclResult_t ncclOsSocketResetFd(struct ncclSocket* sock) {
   newSocket = socket(sock->addr.sa.sa_family, SOCK_STREAM, 0);
   if (newSocket == INVALID_SOCKET) {
       int wsaError = WSAGetLastError();
-      WARN("ncclOsSocketResetFd: socket() failed with error %d: %s", wsaError, getWSAErrorMessage(wsaError));
+      ERR(ncclSystemError, "ncclOsSocketResetFd: socket() failed with error %d: %s", wsaError, getWSAErrorMessage(wsaError));
       ret = ncclSystemError;
       goto cleanup;
   }
@@ -288,7 +288,7 @@ static ncclResult_t socketConnectCheck(struct ncclSocket* sock, int errCode, con
     if (sock->customRetry == 0) {
       if (sock->errorRetries++ == ncclParamRetryCnt()) {
         sock->state = ncclSocketStateError;
-        WARN("%s: connect to %s returned %s, exceeded error retry count after %d attempts",
+        ERR(ncclRemoteError, "%s: connect to %s returned %s, exceeded error retry count after %d attempts",
              funcName, ncclSocketToString(&sock->addr, line), getWSAErrorMessage(errCode), sock->errorRetries);
         return ncclRemoteError;
       }
@@ -302,7 +302,7 @@ static ncclResult_t socketConnectCheck(struct ncclSocket* sock, int errCode, con
     sock->state = ncclSocketStateConnecting;
   } else {
     sock->state = ncclSocketStateError;
-    WARN("%s: connect to %s failed : %s", funcName, ncclSocketToString(&sock->addr, line), getWSAErrorMessage(errCode));
+    ERR(ncclSystemError, "%s: connect to %s failed : %s", funcName, ncclSocketToString(&sock->addr, line), getWSAErrorMessage(errCode));
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -329,7 +329,7 @@ ncclResult_t ncclOsSocketPollConnect(struct ncclSocket* sock) {
     return ncclSuccess;
   } else if (ret < 0) {
     int wsaError = WSAGetLastError();
-    WARN("ncclOsSocketPollConnect to %s failed with error %s", ncclSocketToString(&sock->addr, line), getWSAErrorMessage(wsaError));
+    ERR(ncclSystemError, "ncclOsSocketPollConnect to %s failed with error %s", ncclSocketToString(&sock->addr, line), getWSAErrorMessage(wsaError));
     return ncclSystemError;
   }
 
@@ -348,7 +348,7 @@ ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr,
     u_long mode = !block;
     int iResult = ioctlsocket(sock->socketDescriptor, FIONBIO, &mode);
     if (iResult != NO_ERROR) {
-      WARN("ncclOsSocketProgressOpt: ioctlsocket failed with error: %ld", iResult);
+      ERR(ncclSystemError, "ncclOsSocketProgressOpt: ioctlsocket failed with error: %ld", iResult);
       return ncclSystemError;
     }
     sock->socketBlockingMode = block;
@@ -370,7 +370,7 @@ ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr,
       // WSAEINPROGRESS (10036) means operation is in progress
       // WSAEINTR means interrupted by signal
       if (wsaError != WSAEWOULDBLOCK && wsaError != WSAEINPROGRESS && wsaError != WSAEINTR) {
-        WARN("ncclOsSocketProgressOpt: Call to %s %s failed : %d (%s)", (op == NCCL_SOCKET_RECV ? "recv from" : "send to"),
+        ERR(ncclRemoteError, "ncclOsSocketProgressOpt: Call to %s %s failed : %d (%s)", (op == NCCL_SOCKET_RECV ? "recv from" : "send to"),
               ncclSocketToString(&sock->addr, line), wsaError, getWSAErrorMessage(wsaError));
         return ncclRemoteError;
       } else {
@@ -404,21 +404,21 @@ ncclResult_t ncclOsFindInterfaces(const char* prefixList, char* names, union ncc
   ULONG bufferSize = 0;
   DWORD result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL, NULL, &bufferSize);
   if (result != ERROR_BUFFER_OVERFLOW) {
-    WARN("GetAdaptersAddresses failed with error: %ld", result);
+    ERR(ncclSystemError, "GetAdaptersAddresses failed with error: %ld", result);
     ret = ncclSystemError;
     goto exit;
   }
 
   IP_ADAPTER_ADDRESSES* adapterAddresses = (IP_ADAPTER_ADDRESSES*)malloc(bufferSize);
   if (adapterAddresses == NULL) {
-    WARN("Failed to allocate memory for adapter addresses");
+    ERR(ncclSystemError, "Failed to allocate memory for adapter addresses");
     ret = ncclSystemError;
     goto exit;
   }
 
   result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL, adapterAddresses, &bufferSize);
   if (result != NO_ERROR) {
-    WARN("GetAdaptersAddresses failed with error: %ld", result);
+    ERR(ncclSystemError, "GetAdaptersAddresses failed with error: %ld", result);
     ret = ncclSystemError;
     goto exit;
   }
@@ -567,21 +567,21 @@ ncclResult_t ncclFindInterfaceMatchSubnet(char* ifName, union ncclSocketAddress*
   ULONG bufferSize = 0;
   DWORD result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL, NULL, &bufferSize);
   if (result != ERROR_BUFFER_OVERFLOW) {
-    WARN("GetAdaptersAddresses failed with error: %ld", result);
+    ERR(ncclSystemError, "GetAdaptersAddresses failed with error: %ld", result);
     ret = ncclSystemError;
     goto exit;
   }
 
   IP_ADAPTER_ADDRESSES* adapterAddresses = (IP_ADAPTER_ADDRESSES*)malloc(bufferSize);
   if (adapterAddresses == NULL) {
-    WARN("Failed to allocate memory for adapter addresses");
+    ERR(ncclSystemError, "Failed to allocate memory for adapter addresses");
     ret = ncclSystemError;
     goto exit;
   }
 
   result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL, adapterAddresses, &bufferSize);
   if (result != NO_ERROR) {
-    WARN("GetAdaptersAddresses failed with error: %ld", result);
+    ERR(ncclSystemError, "GetAdaptersAddresses failed with error: %ld", result);
     free(adapterAddresses);
     ret = ncclSystemError;
     goto exit;
@@ -685,7 +685,7 @@ ncclResult_t ncclOsGetAffinity(ncclAffinity* affinity) {
   DWORD_PTR processAffinityMask, systemAffinityMask;
   BOOL result = GetProcessAffinityMask(GetCurrentProcess(), &processAffinityMask, &systemAffinityMask);
   if (result == FALSE) {
-    WARN("GetProcessAffinityMask failed with error: %ld", GetLastError());
+    ERR(ncclSystemError, "GetProcessAffinityMask failed with error: %ld", GetLastError());
     return ncclSystemError;
   }
   *affinity = processAffinityMask;
@@ -695,7 +695,7 @@ ncclResult_t ncclOsGetAffinity(ncclAffinity* affinity) {
 ncclResult_t ncclOsSetAffinity(const ncclAffinity& affinity) {
   BOOL result = SetProcessAffinityMask(GetCurrentProcess(), affinity);
   if (result == FALSE) {
-    WARN("SetProcessAffinityMask failed with error: %ld", GetLastError());
+    ERR(ncclSystemError, "SetProcessAffinityMask failed with error: %ld", GetLastError());
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -724,7 +724,7 @@ ncclResult_t ncclOsNvmlOpen(ncclOsLibraryHandle* handle) {
 
   if (*handle == nullptr) {
     DWORD err = GetLastError();
-    WARN("Failed to load nvml.dll, error code: %lu", err);
+    ERR(ncclSystemError, "Failed to load nvml.dll, error code: %lu", err);
     return ncclSystemError;
   }
 
@@ -821,7 +821,7 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize,
       shmPath);                // name of mapping object
 
     if (hMapFile == NULL) {
-      WARN("Error: failed to create shared memory mapping %s, error code: %lu", shmPath, GetLastError());
+      ERR(ncclSystemError, "Error: failed to create shared memory mapping %s, error code: %lu", shmPath, GetLastError());
       ret = ncclSystemError;
       goto fail;
     }
@@ -835,7 +835,7 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize,
       shmPath);              // name of mapping object
 
     if (hMapFile == NULL) {
-      WARN("Error: failed to open shared memory mapping %s, error code: %lu", shmPath, GetLastError());
+      ERR(ncclSystemError, "Error: failed to open shared memory mapping %s, error code: %lu", shmPath, GetLastError());
       ret = ncclSystemError;
       goto fail;
     }
@@ -850,7 +850,7 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize,
     realShmSize);        // number of bytes to map
 
   if (hptr == NULL) {
-    WARN("Error: Could not map view of file %s size %zu, error code: %lu", shmPath, realShmSize, GetLastError());
+    ERR(ncclSystemError, "Error: Could not map view of file %s size %zu, error code: %lu", shmPath, realShmSize, GetLastError());
     ret = ncclSystemError;
     goto fail;
   }

--- a/comms/ncclx/v2_30/src/os/windows_ipcsocket.cc
+++ b/comms/ncclx/v2_30/src/os/windows_ipcsocket.cc
@@ -43,7 +43,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket *handle, int rank, uint64_t hash, v
   char pipeName[NCCL_IPC_SOCKNAME_LEN];
   int len = snprintf(pipeName, NCCL_IPC_SOCKNAME_LEN, NCCL_IPC_PIPENAME_STR, rank, hash);
   if (len >= NCCL_IPC_SOCKNAME_LEN) {
-    WARN("IPC: Pipe name too long");
+    ERR(ncclInternalError, "IPC: Pipe name too long");
     return ncclInternalError;
   }
 
@@ -64,7 +64,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket *handle, int rank, uint64_t hash, v
   );
 
   if (hPipe == INVALID_HANDLE_VALUE) {
-    WARN("IPC: Failed to create named pipe %s: error %d", pipeName, GetLastError());
+    ERR(ncclSystemError, "IPC: Failed to create named pipe %s: error %d", pipeName, GetLastError());
     return ncclSystemError;
   }
 
@@ -79,7 +79,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket *handle, int rank, uint64_t hash, v
 
 ncclResult_t ncclIpcSocketGetFd(struct ncclIpcSocket* handle, int* fd) {
   if (handle == NULL) {
-    WARN("ncclIpcSocketGetFd: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclIpcSocketGetFd: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (fd) *fd = (int)handle->fd;
@@ -101,7 +101,7 @@ ncclResult_t ncclIpcSocketClose(ncclIpcSocket *handle) {
 
 ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, int *recvFd) {
   if (handle == NULL || handle->fd == NCCL_INVALID_SOCKET) {
-    WARN("IPC: Invalid socket handle");
+    ERR(ncclInvalidArgument, "IPC: Invalid socket handle");
     return ncclInvalidArgument;
   }
 
@@ -115,7 +115,7 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
   // Wait for client to connect
   BOOL connected = ConnectNamedPipe(hPipe, NULL);
   if (!connected && GetLastError() != ERROR_PIPE_CONNECTED) {
-    WARN("IPC: Failed to connect named pipe: error %d", GetLastError());
+    ERR(ncclSystemError, "IPC: Failed to connect named pipe: error %d", GetLastError());
     return ncclSystemError;
   }
 
@@ -133,13 +133,13 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
     if (error == ERROR_NO_DATA || error == ERROR_BROKEN_PIPE) {
       // Check abort flag
       if (handle->abortFlag && COMPILER_ATOMIC_LOAD(handle->abortFlag, std::memory_order_acquire)) {
-        WARN("IPC: Operation aborted");
+        ERR(ncclInternalError, "IPC: Operation aborted");
         return ncclInternalError;
       }
       continue;
     }
 
-    WARN("IPC: ReadFile failed: error %d", error);
+    ERR(ncclSystemError, "IPC: ReadFile failed: error %d", error);
     return ncclSystemError;
   }
 
@@ -164,7 +164,7 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
     );
 
     if (!dupSuccess) {
-      WARN("IPC: DuplicateHandle failed: error %d", GetLastError());
+      ERR(ncclSystemError, "IPC: DuplicateHandle failed: error %d", GetLastError());
       return ncclSystemError;
     }
 
@@ -184,7 +184,7 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
   char pipeName[NCCL_IPC_SOCKNAME_LEN];
   int len = snprintf(pipeName, NCCL_IPC_SOCKNAME_LEN, NCCL_IPC_PIPENAME_STR, rank, hash);
   if (len >= NCCL_IPC_SOCKNAME_LEN) {
-    WARN("IPC: Pipe name too long");
+    ERR(ncclInternalError, "IPC: Pipe name too long");
     return ncclInternalError;
   }
 
@@ -210,13 +210,13 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
 
     DWORD error = GetLastError();
     if (error != ERROR_PIPE_BUSY && error != ERROR_FILE_NOT_FOUND) {
-      WARN("IPC: Failed to connect to pipe %s: error %d", pipeName, error);
+      ERR(ncclSystemError, "IPC: Failed to connect to pipe %s: error %d", pipeName, error);
       return ncclSystemError;
     }
 
     // Check abort flag
     if (handle && handle->abortFlag && COMPILER_ATOMIC_LOAD(handle->abortFlag, std::memory_order_acquire)) {
-      WARN("IPC: Operation aborted");
+      ERR(ncclInternalError, "IPC: Operation aborted");
       return ncclInternalError;
     }
   }
@@ -226,7 +226,7 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
   // Set pipe to message mode
   DWORD mode = PIPE_READMODE_MESSAGE;
   if (!SetNamedPipeHandleState(hPipe, &mode, NULL, NULL)) {
-    WARN("IPC: SetNamedPipeHandleState failed: error %d", GetLastError());
+    ERR(ncclSystemError, "IPC: SetNamedPipeHandleState failed: error %d", GetLastError());
     CloseHandle(hPipe);
     return ncclSystemError;
   }
@@ -250,7 +250,7 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
   BOOL success = WriteFile(hPipe, &msg, sizeof(msg), &bytesWritten, NULL);
 
   if (!success || bytesWritten != sizeof(msg)) {
-    WARN("IPC: WriteFile failed: error %d, wrote %d of %zu bytes", GetLastError(), bytesWritten, sizeof(msg));
+    ERR(ncclSystemError, "IPC: WriteFile failed: error %d, wrote %d of %zu bytes", GetLastError(), bytesWritten, sizeof(msg));
     CloseHandle(hPipe);
     return ncclSystemError;
   }

--- a/comms/ncclx/v2_30/src/param/param_registry.cc
+++ b/comms/ncclx/v2_30/src/param/param_registry.cc
@@ -18,7 +18,7 @@ ncclResult_t ncclParamRegistry::add(std::string key, ncclParamInfo_t info,
   auto& reg = state();
   std::lock_guard<std::mutex> lock(reg.mtx);
   if (reg.map.find(key) != reg.map.end()) {
-    WARN("PARAM: Duplicate registration for key \"%s\", ignoring.", key.c_str());
+    ERR(ncclInternalError, "PARAM: Duplicate registration for key \"%s\", ignoring.", key.c_str());
     return ncclInternalError;
   }
   reg.map[key] = {info, param};

--- a/comms/ncclx/v2_30/src/plugin/net.cc
+++ b/comms/ncclx/v2_30/src/plugin/net.cc
@@ -151,12 +151,12 @@ ncclResult_t ncclNetCheckDeviceVersion(struct ncclComm* comm, ncclNet_t* net, in
           props.netDeviceVersion);
         return ncclSuccess;
       } else {
-        WARN("NCCL_DEVICE_UNPACK plugin has incompatible version %d, this NCCL build is compatible with %d, not using it",
+        ERR(ncclInternalError, "NCCL_DEVICE_UNPACK plugin has incompatible version %d, this NCCL build is compatible with %d, not using it",
           props.netDeviceVersion, NCCL_NET_DEVICE_UNPACK_VERSION);
         return ncclInternalError;
       }
     default:
-      WARN("Unknown device code index %d", type);
+      ERR(ncclInternalError, "Unknown device code index %d", type);
       return ncclInternalError;
   }
 
@@ -338,7 +338,7 @@ ncclResult_t ncclNetInit(struct ncclComm* comm) {
     }
   }
   if (ncclNetPluginInitialized) return ncclSuccess;
-  WARN("Failed to initialize any NET plugin");
+  ERR(ncclInvalidUsage, "Failed to initialize any NET plugin");
   return ncclInvalidUsage;
 }
 
@@ -374,7 +374,7 @@ ncclResult_t ncclNetGetDevCount(int netPluginIndex, int* nPhysDevs, int* nVirtDe
   *nVirtDevs = netPluginLibs[netPluginIndex].netVirtDevs;
   return ncclSuccess;
 fail:
-  WARN("%s: trying to access the number of devices of an uninitialized netPlugin[%d]", __func__, netPluginIndex);
+  ERR(ncclInternalError, "%s: trying to access the number of devices of an uninitialized netPlugin[%d]", __func__, netPluginIndex);
   return ncclInternalError;
 }
 
@@ -386,7 +386,7 @@ ncclResult_t ncclCollNetGetDevCount(int netPluginIndex, int* nPhysDevs, int* nVi
   *nVirtDevs = netPluginLibs[netPluginIndex].collNetVirtDevs;
   return ncclSuccess;
 fail:
-  WARN("%s: trying to access the number of devices of an uninitialized netPlugin[%d]", __func__, netPluginIndex);
+  ERR(ncclInternalError, "%s: trying to access the number of devices of an uninitialized netPlugin[%d]", __func__, netPluginIndex);
   return ncclInternalError;
 }
 
@@ -396,7 +396,7 @@ ncclResult_t ncclNetSetVirtDevCount(int netPluginIndex, int nVirtDevs) {
   netPluginLibs[netPluginIndex].netVirtDevs = nVirtDevs;
   return ncclSuccess;
 fail:
-  WARN("%s: failed to set the number of devices for netPlugin[%d] to %d", __func__, netPluginIndex,nVirtDevs);
+  ERR(ncclInternalError, "%s: failed to set the number of devices for netPlugin[%d] to %d", __func__, netPluginIndex,nVirtDevs);
   return ncclInternalError;
 }
 
@@ -406,7 +406,7 @@ ncclResult_t ncclCollNetSetVirtDevCount(int netPluginIndex, int nVirtDevs) {
   netPluginLibs[netPluginIndex].collNetVirtDevs = nVirtDevs;
   return ncclSuccess;
 fail:
-  WARN("%s: failed to set the number of devices for netPlugin[%d] to %d", __func__, netPluginIndex,nVirtDevs);
+  ERR(ncclInternalError, "%s: failed to set the number of devices for netPlugin[%d] to %d", __func__, netPluginIndex,nVirtDevs);
   return ncclInternalError;
 }
 

--- a/comms/ncclx/v2_30/src/proxy.cc
+++ b/comms/ncclx/v2_30/src/proxy.cc
@@ -69,12 +69,12 @@ static ncclResult_t expectedProxyResponseStore(struct ncclProxyState* state, voi
   while (elem) {
     if (elem->opId == opId) {
       if (respSize != elem->respSize) {
-        WARN("Mismatched response size for opId=%p", opId);
+        ERR(ncclInternalError, "Mismatched response size for opId=%p", opId);
         return ncclInternalError;
       }
 
       if (elem->done) {
-        WARN("Storing response for already completed opId=%p", opId);
+        ERR(ncclInternalError, "Storing response for already completed opId=%p", opId);
         return ncclInternalError;
       }
 
@@ -89,7 +89,7 @@ static ncclResult_t expectedProxyResponseStore(struct ncclProxyState* state, voi
     elem = elem->next;
   }
 
-  WARN("Proxy response for opId=%p doesn't match any expected response", opId);
+  ERR(ncclInternalError, "Proxy response for opId=%p doesn't match any expected response", opId);
   return ncclInternalError;
 }
 
@@ -156,7 +156,7 @@ static ncclResult_t expectedProxyResponseRemove(struct ncclProxyState* state, vo
     prev = elem;
     elem = elem->next;
   }
-  WARN("Couldn't find opId=%p", opId);
+  ERR(ncclInternalError, "Couldn't find opId=%p", opId);
   return ncclInternalError;
 }
 
@@ -196,9 +196,9 @@ static ncclResult_t asyncProxyOpDequeue(struct ncclProxyLocalPeer* peer, ncclPro
     elem = elem->next;
   }
   if (op) {
-    WARN("Attempting to dequeue nonexistent async opId=%p", op->opId);
+    ERR(ncclInternalError, "Attempting to dequeue nonexistent async opId=%p", op->opId);
   } else {
-    WARN("Attempting to dequeue null operation");
+    ERR(ncclInternalError, "Attempting to dequeue null operation");
   }
   return ncclInternalError;
 }
@@ -252,7 +252,7 @@ ncclResult_t getOpIndex(struct ncclProxyArgs* op, struct ncclProxyProgressState*
     pool = pool->next;
     p++;
   }
-  WARN("Could not find pool of op %p", op);
+  ERR(ncclInternalError, "Could not find pool of op %p", op);
   return ncclInternalError;
 }
 
@@ -364,7 +364,7 @@ ncclResult_t dumpProxyState(struct ncclProxyProgressState* state) {
 static ncclResult_t ncclProxyOpToArgs(struct ncclProxyOp* op, struct ncclProxyArgs* args, int subIndex) {
   struct ncclProxySubArgs* sub = args->subs+subIndex;
   if (subIndex >= NCCL_PROXY_MAX_SUBS) {
-    WARN("Proxy append out of bounds");
+    ERR(ncclInternalError, "Proxy append out of bounds");
     return ncclInternalError;
   }
   PROXY_TRACE_OP_TO_SUBARGS(sub, op);
@@ -402,11 +402,11 @@ static ncclResult_t ncclProxyOpToArgs(struct ncclProxyOp* op, struct ncclProxyAr
         (args->dtype != op->dtype) ||
         (args->redOp != op->redOp) ||
         (args->coll != op->coll)) {
-      WARN("Proxy append mismatch");
+      ERR(ncclInternalError, "Proxy append mismatch");
       return ncclInternalError;
     }
     if (args->state != ncclProxyOpReady) {
-      WARN("Proxy append on running operation");
+      ERR(ncclInternalError, "Proxy append on running operation");
       return ncclInternalError;
     }
     goto exit;
@@ -535,7 +535,7 @@ static ncclResult_t ncclLocalOpAppend(struct ncclComm* comm, struct ncclProxyCon
       }
     }
     if (lastOp == -1) {
-      WARN("Unable to post incomplete proxy op chain %d..%d (opCount %ld)", proxyOps->nextOps, proxyOps->nextOpsEnd, lastOpCount);
+      ERR(ncclInternalError, "Unable to post incomplete proxy op chain %d..%d (opCount %ld)", proxyOps->nextOps, proxyOps->nextOpsEnd, lastOpCount);
       return ncclInternalError;
     }
     // Cut chain at lastOp
@@ -574,7 +574,7 @@ static ncclResult_t SaveProxy(struct ncclComm* comm, struct ncclChannel* channel
   struct ncclChannelPeer* peerComm = channel->peers[peer];
   struct ncclConnector* connector = type == proxyRecv ? peerComm->recv+connIndex : peerComm->send+connIndex;
   if (connector->transportComm == NULL) {
-    WARN("Rank %d has no transport for %s peer %d on channel %d/%d", comm->rank,
+    ERR(ncclInternalError, "Rank %d has no transport for %s peer %d on channel %d/%d", comm->rank,
         type == proxyRecv ? "recv" : "send", peer, channel->id, connIndex);
     return ncclInternalError;
   }
@@ -1243,7 +1243,7 @@ ncclResult_t ncclProxyCallBlockingUDS(struct ncclComm* comm, struct ncclProxyCon
 
 error:
   NCCLCHECK(ncclIpcSocketClose(&ipcSock));
-  WARN("ncclProxyCallBlockingUDS call to tpRank %d(%lx) failed : %d", proxyConn->tpRank, pidHash, res);
+  ERR(res, "ncclProxyCallBlockingUDS call to tpRank %d(%lx) failed : %d", proxyConn->tpRank, pidHash, res);
   return res;
 }
 
@@ -1264,7 +1264,7 @@ ncclResult_t ncclProxyClientGetFdBlocking(struct ncclComm* comm, int proxyRank, 
   return ret;
 
 error:
-  WARN("ncclProxyClientGetFd call to tpRank %d handle 0x%lx failed : %d", comm->topParentRanks[proxyRank], *(uint64_t*)handle, ret);
+  ERR(ret, "ncclProxyClientGetFd call to tpRank %d handle 0x%lx failed : %d", comm->topParentRanks[proxyRank], *(uint64_t*)handle, ret);
   return ret;
 }
 
@@ -1289,7 +1289,7 @@ exit:
   INFO(NCCL_PROXY, "UDS: ClientQueryFd localFd %d tpRank %d remote fd %d sameProcess %d", localFd, proxyConn->tpRank, *rmtFd, proxyConn->sameProcess);
   return ret;
 fail:
-  WARN("ncclProxyClientQueryFdBlocking call to tpRank %d localFd %d failed : %d", proxyConn->tpRank, localFd, ret);
+  ERR(ret, "ncclProxyClientQueryFdBlocking call to tpRank %d localFd %d failed : %d", proxyConn->tpRank, localFd, ret);
   goto exit;
 }
 
@@ -1324,7 +1324,7 @@ ncclResult_t ncclPollProxyResponse(struct ncclComm* comm, struct ncclProxyConnec
   struct ncclProxyState* sharedProxyState = comm->proxyState;
   // Receive the connection pointer from the Proxy
   if (COMPILER_ATOMIC_LOAD(comm->abortFlag, std::memory_order_acquire)) {
-    WARN("Comm %p is in abort state", comm);
+    ERR(ncclInternalError, "Comm %p is in abort state", comm);
     return ncclInternalError;
   }
   if (sharedProxyState->peerSocks == NULL) return ncclInternalError;
@@ -1338,7 +1338,7 @@ ncclResult_t ncclPollProxyResponse(struct ncclComm* comm, struct ncclProxyConnec
     ncclProxyRpcResponseHeader resp = {0};
     int offset = 0;
     if (ncclSuccess != ncclSocketProgress(NCCL_SOCKET_RECV, sock, &resp, sizeof(resp), &offset)) {
-      WARN("Socket recv failed while polling for opId=%p", opId);
+      ERR(ncclInternalError, "Socket recv failed while polling for opId=%p", opId);
       return ncclInternalError;
     }
 

--- a/comms/ncclx/v2_30/src/ras/client_support.cc
+++ b/comms/ncclx/v2_30/src/ras/client_support.cc
@@ -552,7 +552,7 @@ static ncclResult_t rasClientRun(struct rasClient* client) {
       client->status = RAS_CLIENT_FINISHED;
       break;
     default:
-      WARN("Invalid client status %d", client->status);
+      ERR(ncclInternalError, "Invalid client status %d", client->status);
       ret = ncclInternalError;
       goto exit;
   }

--- a/comms/ncclx/v2_30/src/ras/ras.cc
+++ b/comms/ncclx/v2_30/src/ras/ras.cc
@@ -230,7 +230,7 @@ static ncclResult_t rasLocalHandle(bool* terminate) {
     INFO(NCCL_RAS, "RAS handling local termination request");
     *terminate = true;
   } else {
-    WARN("RAS received unknown notification type %d", msg.type);
+    ERR(ncclInternalError, "RAS received unknown notification type %d", msg.type);
     return ncclInternalError;
   }
 
@@ -405,7 +405,7 @@ ncclResult_t rasMsgHandle(struct rasMsg* msg, struct rasSocket* sock) {
   } else if (msg->type == RAS_MSG_COLLRESP) {
     NCCLCHECK(rasMsgHandleCollResp(msg, sock));
   } else {
-    WARN("RAS received unknown message type (%d) from %s", msg->type, ncclSocketToString(&sock->sock.addr, rasLine));
+    ERR(ncclInternalError, "RAS received unknown message type (%d) from %s", msg->type, ncclSocketToString(&sock->sock.addr, rasLine));
     return ncclInternalError;
   }
 
@@ -429,7 +429,7 @@ static ncclResult_t rasMsgHandleConnInit(const struct rasMsg* msg, struct rasSoc
 
   if (msg->connInit.ncclVersion != NCCL_VERSION_CODE) {
     // Close any such sockets immediately!  This is basically unrecoverable...
-    WARN("NCCL version mismatch with remote peer %s (local: %s, remote %s)",
+    ERR(ncclInvalidUsage, "NCCL version mismatch with remote peer %s (local: %s, remote %s)",
          ncclSocketToString(&sock->sock.addr, rasLine),
          ncclVersionToString(NCCL_VERSION_CODE, versionLocal, sizeof(versionLocal)),
          ncclVersionToString(msg->connInit.ncclVersion, versionRemote, sizeof(versionRemote)));

--- a/comms/ncclx/v2_30/src/register/register.cc
+++ b/comms/ncclx/v2_30/src/register/register.cc
@@ -152,7 +152,7 @@ ncclResult_t ncclCommRegister(const ncclComm_t comm, void* buff, size_t size, vo
   // FIXME: we should eventually support hybrid registration.
   // Disable it for now to avoid undefined behavior due to handle conflict.
   if (NCCL_CTRAN_REGISTER != NCCL_CTRAN_REGISTER::none && ncclParamLocalRegister()) {
-    ERR("Invalid usage to turn on NCCL_CTRAN_REGISTER and NCCL_LOCAL_REGISTER at the same time.");
+    ERR(ncclInvalidUsage, "Invalid usage to turn on NCCL_CTRAN_REGISTER and NCCL_LOCAL_REGISTER at the same time.");
     return metaCommToNccl(ErrorStackTraceUtil::log(commInvalidUsage));
   }
 
@@ -233,7 +233,7 @@ ncclResult_t ncclCommDeregister(const ncclComm_t comm, void *handle) {
   // FIXME: we should eventually support hybrid registration.
   // Disable it for now to avoid undefined behavior due to handle conflict.
   if (NCCL_CTRAN_REGISTER != NCCL_CTRAN_REGISTER::none && ncclParamLocalRegister()) {
-    ERR("Invalid usage to turn on NCCL_CTRAN_REGISTER and NCCL_LOCAL_REGISTER at the same time.");
+    ERR(ncclInvalidUsage, "Invalid usage to turn on NCCL_CTRAN_REGISTER and NCCL_LOCAL_REGISTER at the same time.");
     return metaCommToNccl(ErrorStackTraceUtil::log(commInvalidUsage));
   }
 

--- a/comms/ncclx/v2_30/src/register/register.cc
+++ b/comms/ncclx/v2_30/src/register/register.cc
@@ -211,7 +211,7 @@ static ncclResult_t commDeregister(struct ncclComm *comm, bool isGraph, struct n
   CUDACHECK(cudaSetDevice(comm->cudaDev));
   for (slot = 0; slot < cache->population && cache->slots[slot] != reg; slot++);
   if (slot == cache->population) {
-    WARN("Deregister: Could not find handle");
+    ERR(ncclInvalidUsage, "Deregister: Could not find handle");
     return ncclInvalidUsage;
   }
   if (isGraph) --reg->graphRefs;

--- a/comms/ncclx/v2_30/src/rma/rma_ce.cc
+++ b/comms/ncclx/v2_30/src/rma/rma_ce.cc
@@ -158,7 +158,7 @@ ncclResult_t ncclRmaCePutLaunch(struct ncclComm* comm, struct ncclKernelPlan* pl
 
   // Make sure the RMA CE is initialized
   if (!comm->rmaState.rmaCeState.initialized) {
-    WARN("RMA CE is not initialized");
+    ERR(ncclInternalError, "RMA CE is not initialized");
     return ncclInternalError;
   }
 
@@ -198,7 +198,7 @@ ncclResult_t ncclRmaCePutLaunch(struct ncclComm* comm, struct ncclKernelPlan* pl
 
       // Validate peer buffer
       if (peerBuff == NULL) {
-        WARN("RMA CE: peerBuff is NULL after ncclDevrGetLsaRankPtr");
+        ERR(ncclInvalidArgument, "RMA CE: peerBuff is NULL after ncclDevrGetLsaRankPtr");
         ret = ncclInvalidArgument;
         goto fail;
       }
@@ -244,7 +244,7 @@ ncclResult_t ncclRmaCeWaitLaunch(struct ncclComm* comm, struct ncclKernelPlan* p
 
   // Make sure the RMA CE is initialized
   if (!comm->rmaState.rmaCeState.initialized) {
-    WARN("RMA CE is not initialized");
+    ERR(ncclInternalError, "RMA CE is not initialized");
     return ncclInternalError;
   }
 

--- a/comms/ncclx/v2_30/src/rma/rma_proxy.cc
+++ b/comms/ncclx/v2_30/src/rma/rma_proxy.cc
@@ -331,7 +331,7 @@ ncclResult_t ncclRmaProxyRegister(struct ncclComm* comm, void* address, size_t s
           NCCLCHECK(ncclRmaProxyRegMrSym(rmaProxyState->ncclGin, rmaProxyState->ginComms[n], rmaProxyState->props[n], address, size,
                                          NCCL_PTR_CUDA, 0, &rmaHostWins[n], &rmaDevWins[n]));
         if (rmaHostWins[n] == NULL) {
-          WARN("rank %d - GIN Symmetric register failed: buff %p, size %ld", comm->rank, address, size);
+          ERR(ncclSystemError, "rank %d - GIN Symmetric register failed: buff %p, size %ld", comm->rank, address, size);
           return ncclSystemError;
         }
       }
@@ -390,11 +390,11 @@ ncclResult_t ncclRmaProxyConnectOnce(struct ncclComm* comm) {
   struct ncclRmaProxyState *rmaProxyState = &comm->rmaState.rmaProxyState;
   rmaProxyState->comm = comm;
   if (rmaProxyState->ncclGin == NULL) {
-    WARN("GIN not supported.");
+    ERR(ncclInvalidUsage, "GIN not supported.");
     return ncclInvalidUsage;
   }
   if (ncclParamGinEnable() == 0) {
-    WARN("GIN is disabled.");
+    ERR(ncclInternalError, "GIN is disabled.");
     return ncclInternalError;
   }
   if (rmaProxyState->connected) return ncclSuccess;
@@ -404,7 +404,7 @@ ncclResult_t ncclRmaProxyConnectOnce(struct ncclComm* comm) {
   int ndev = 0;
   NCCLCHECK(rmaProxyState->ncclGin->devices(&ndev));
   if (ndev <= 0) {
-    WARN("No GIN-capable devices found.");
+    ERR(ncclInternalError, "No GIN-capable devices found.");
     return ncclInternalError;
   }
 
@@ -412,7 +412,7 @@ ncclResult_t ncclRmaProxyConnectOnce(struct ncclComm* comm) {
   NCCLCHECK(rmaProxyState->ncclGin->getProperties(0, &props));
   rmaProxyState->ginType = props.netDeviceType;
   if (rmaProxyState->ginType != NCCL_NET_DEVICE_GIN_PROXY) {
-    WARN("RMA proxy backend type mismatch.");
+    ERR(ncclInternalError, "RMA proxy backend type mismatch.");
     return ncclInternalError;
   }
 
@@ -437,7 +437,7 @@ ncclResult_t ncclRmaProxyConnectOnce(struct ncclComm* comm) {
   allCommCounts = NULL;
 
   if (ginCommCount == 0) {
-    WARN("Gin connect : min local net count is zero");
+    ERR(ncclSystemError, "Gin connect : min local net count is zero");
     ret = ncclSystemError;
     goto fail;
   }

--- a/comms/ncclx/v2_30/src/rma/rma_proxy_launch.cc
+++ b/comms/ncclx/v2_30/src/rma/rma_proxy_launch.cc
@@ -163,7 +163,7 @@ ncclResult_t ncclRmaProxyPutLaunch(struct ncclComm* comm, struct ncclKernelPlan*
   ncclResult_t ret = ncclSuccess;
 
   if (!comm->rmaState.rmaProxyState.connected) {
-    WARN("RMA proxy is not connected");
+    ERR(ncclInternalError, "RMA proxy is not connected");
     return ncclInternalError;
   }
 
@@ -259,7 +259,7 @@ ncclResult_t ncclRmaProxyWaitLaunch(struct ncclComm* comm, struct ncclKernelPlan
   ncclResult_t ret = ncclSuccess;
 
   if (!comm->rmaState.rmaProxyState.connected) {
-    WARN("RMA proxy is not connected");
+    ERR(ncclInternalError, "RMA proxy is not connected");
     return ncclInternalError;
   }
 

--- a/comms/ncclx/v2_30/src/transport.cc
+++ b/comms/ncclx/v2_30/src/transport.cc
@@ -38,7 +38,7 @@ static ncclResult_t selectTransport(struct ncclComm* comm, struct ncclTopoGraph*
       return ncclSuccess;
     }
   }
-  WARN("No transport found for rank %d[%lx] -> rank %d[%lx]", myInfo->rank, myInfo->busId, peerInfo->rank, peerInfo->busId);
+  ERR(ncclSystemError, "No transport found for rank %d[%lx] -> rank %d[%lx]", myInfo->rank, myInfo->busId, peerInfo->rank, peerInfo->busId);
   return ncclSystemError;
 }
 

--- a/comms/ncclx/v2_30/src/transport/coll_net.cc
+++ b/comms/ncclx/v2_30/src/transport/coll_net.cc
@@ -337,7 +337,7 @@ static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struc
   /* collective size limits*/
   resources->maxCollBytes = props.maxCollBytes;
   if((resources->maxCollBytes <= 0) || (resources->maxCollBytes > NCCL_MAX_NET_SIZE_BYTES)) {
-    WARN("sendProxySetup: collnet plugin returned invalid value for maxCollBytes %ld \
+    ERR(ncclInternalError, "sendProxySetup: collnet plugin returned invalid value for maxCollBytes %ld \
       [allowed range: %ld - %ld] \n", resources->maxCollBytes, 0L, NCCL_MAX_NET_SIZE_BYTES);
     return ncclInternalError;
   }
@@ -450,7 +450,7 @@ static ncclResult_t recvProxySetup(struct ncclProxyConnection* connection, struc
   resources->useDmaBuf = resources->useGdr && proxyState->dmaBufSupport && (props.ptrSupport & NCCL_PTR_DMABUF);
   resources->maxCollBytes = props.maxCollBytes;
   if((resources->maxCollBytes <= 0) || (resources->maxCollBytes > NCCL_MAX_NET_SIZE_BYTES)) {
-    WARN("sendProxySetup: collnet plugin returned invalid value for maxCollBytes %ld \
+    ERR(ncclInternalError, "sendProxySetup: collnet plugin returned invalid value for maxCollBytes %ld \
       [allowed range: %ld - %ld] \n", resources->maxCollBytes, 0L, NCCL_MAX_NET_SIZE_BYTES);
     return ncclInternalError;
   }
@@ -464,7 +464,7 @@ static ncclResult_t recvProxySetup(struct ncclProxyConnection* connection, struc
 
 static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   ncclResult_t ret = ncclSuccess;
-  if (reqSize != sizeof(struct collNetConnectArgs)) { WARN("sendProxyConnect: reqSize is %d != %ld", reqSize, sizeof(struct collNetConnectArgs)); return ncclInternalError; }
+  if (reqSize != sizeof(struct collNetConnectArgs)) { ERR(ncclInternalError, "sendProxyConnect: reqSize is %d != %ld", reqSize, sizeof(struct collNetConnectArgs)); return ncclInternalError; }
   struct collNetConnectArgs* args = (struct collNetConnectArgs*)reqBuff;
   static_assert(sizeof(collNetSendConnectInfo) <= sizeof(struct ncclConnect), "Collnet Send Connect info is too big");
   struct collNetSendConnectInfo* info = (struct collNetSendConnectInfo*)(args->connectInfos+args->rank);
@@ -481,7 +481,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   NCCLCHECK(sharedConnect(proxyState, resources->netDev, args->connectInfos, args->nranks, args->rank, connection->collNet, &resources->collNetComm));
 
   // Collnet connect is allowed to fail. Gracefully handle that case by returning NULL to the caller.
-  if (respSize != sizeof(struct connectMap*)) { WARN("sendProxyConnect: respSize is %d != %ld", respSize, sizeof(void*)); return ncclInternalError; }
+  if (respSize != sizeof(struct connectMap*)) { ERR(ncclInternalError, "sendProxyConnect: respSize is %d != %ld", respSize, sizeof(void*)); return ncclInternalError; }
   if (resources->collNetComm == NULL) {
     *((struct connectMap**)respBuff) = NULL;
     return ncclSuccess;
@@ -550,7 +550,7 @@ fail:
 
 static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   ncclResult_t ret = ncclSuccess;
-  if (reqSize != sizeof(struct collNetConnectArgs)) { WARN("recvProxyConnect: reqSize is %d != %ld", reqSize, sizeof(struct collNetConnectArgs)); return ncclInternalError; }
+  if (reqSize != sizeof(struct collNetConnectArgs)) { ERR(ncclInternalError, "recvProxyConnect: reqSize is %d != %ld", reqSize, sizeof(struct collNetConnectArgs)); return ncclInternalError; }
   struct collNetConnectArgs* args = (struct collNetConnectArgs*)reqBuff;
 
   struct recvResources* resources = (struct recvResources*)(connection->transportResources);
@@ -560,7 +560,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   NCCLCHECK(sharedConnect(proxyState, resources->netDev, args->connectInfos, args->nranks, args->rank, connection->collNet, &resources->collNetComm));
 
   // Collnet connect is allowed to fail. Gracefully handle that case by returning NULL to the caller.
-  if (respSize != sizeof(struct connectMap*)) { WARN("sendProxyConnect: respSize is %d != %ld", respSize, sizeof(void*)); return ncclInternalError; }
+  if (respSize != sizeof(struct connectMap*)) { ERR(ncclInternalError, "sendProxyConnect: respSize is %d != %ld", respSize, sizeof(void*)); return ncclInternalError; }
   if (resources->collNetComm == NULL) {
     *((struct connectMap**)respBuff) = NULL;
     return ncclSuccess;
@@ -625,7 +625,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   for (int p=0; p<NCCL_NUM_PROTOCOLS; p++)
     info->mhandles[p] = resources->mhandles[p];
 
-  if (respSize != sizeof(struct connectMap*)) { WARN("recvProxyConnect: respSize is %d != %ld", respSize, sizeof(void*)); return ncclInternalError; }
+  if (respSize != sizeof(struct connectMap*)) { ERR(ncclInternalError, "recvProxyConnect: respSize is %d != %ld", respSize, sizeof(void*)); return ncclInternalError; }
   *((struct connectMap**)respBuff) = &resources->map;
 
 exit:
@@ -945,7 +945,7 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
             int sendBeg = calcRegionOffset(args, 0, s, sub->received, 0);
             int sendEnd = calcRegionOffset(args, 0, s, sub->received, 1);
             if (sendEnd-sendBeg != connFifo[buffSlot].size) {
-              WARN("CollNet sizes: want=%d got=%ld", sendEnd-sendBeg, connFifo[buffSlot].size);
+              ERR(ncclInternalError, "CollNet sizes: want=%d got=%ld", sendEnd-sendBeg, connFifo[buffSlot].size);
               return ncclInternalError;
             }
           }
@@ -1126,7 +1126,7 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
               // Force a PCI-E read from GPU memory
               asm volatile ("mov (%0), %%eax" :: "l"(resources->gdcFlush) : "%eax", "memory");
 #else
-              WARN("NET: GDR Flush only supported on x86_64");
+              ERR(ncclInternalError, "NET: GDR Flush only supported on x86_64");
               return ncclInternalError;
 #endif
             } else {

--- a/comms/ncclx/v2_30/src/transport/net.cc
+++ b/comms/ncclx/v2_30/src/transport/net.cc
@@ -474,7 +474,7 @@ static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* conne
       if (err == cudaErrorPeerAccessAlreadyEnabled) {
         cudaGetLastError();
       } else if (err != cudaSuccess) {
-        WARN("failed to peer with device %d: %d %s", map->cudaDev, err, cudaGetErrorString(err));
+        ERR(ncclInternalError, "failed to peer with device %d: %d %s", map->cudaDev, err, cudaGetErrorString(err));
         return ncclInternalError;
       }
     }
@@ -654,7 +654,7 @@ static ncclResult_t recvFree(struct ncclComm* comm, struct ncclConnector* recv) 
 static ncclResult_t sharedNetBuffersInit(struct ncclProxyState* proxyState, int cuda, int tpLocalRank, int type, int sameProcess,
     int nChannels, char** gpuPtr, char** cpuPtr, int* size, ncclIpcDesc *ipcDesc) {
   if (cuda == 0 && sameProcess == 0) {
-      WARN("PXN should not use host buffers for data");
+      ERR(ncclInternalError, "PXN should not use host buffers for data");
       return ncclInternalError;
   }
   struct ncclProxyProgressState* progressState = &proxyState->progressState;
@@ -762,7 +762,7 @@ static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struc
   /* point-to-point size limits*/
   resources->maxP2pBytes = props.maxP2pBytes;
   if((resources->maxP2pBytes <= 0) || (resources->maxP2pBytes > NCCL_MAX_NET_SIZE_BYTES)) {
-    WARN("sendProxySetup: net plugin returned invalid value for maxP2pBytes %ld \
+    ERR(ncclInternalError, "sendProxySetup: net plugin returned invalid value for maxP2pBytes %ld \
       [allowed range: %ld - %ld] \n", resources->maxP2pBytes, 0L, NCCL_MAX_NET_SIZE_BYTES);
     return ncclInternalError;
   }
@@ -801,7 +801,7 @@ static ncclResult_t recvProxySetup(struct ncclProxyConnection* connection, struc
   /* point-to-point size limits*/
   resources->maxP2pBytes = props.maxP2pBytes;
   if((resources->maxP2pBytes <= 0) || (resources->maxP2pBytes > NCCL_MAX_NET_SIZE_BYTES)) {
-    WARN("recvProxySetup: net plugin returned invalid value for maxP2pBytes %ld \
+    ERR(ncclInternalError, "recvProxySetup: net plugin returned invalid value for maxP2pBytes %ld \
       [allowed range: %ld - %ld] \n", resources->maxP2pBytes, 0L, NCCL_MAX_NET_SIZE_BYTES);
     return ncclInternalError;
   }
@@ -1608,7 +1608,7 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
               // Force a PCI-E read from GPU memory
               asm volatile ("mov (%0), %%eax" :: "l"(resources->gdcFlush) : "%eax", "memory");
 #else
-              WARN("NET: GDR Flush only supported on x86_64");
+              ERR(ncclInternalError, "NET: GDR Flush only supported on x86_64");
               return ncclInternalError;
 #endif
             } else {

--- a/comms/ncclx/v2_30/src/transport/net_ib/common.cc
+++ b/comms/ncclx/v2_30/src/transport/net_ib/common.cc
@@ -29,7 +29,7 @@ extern int ncclParamIbResiliencyPortFailover();
 
 ncclResult_t ncclIbStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName) {
   if (ncclParamIbAsyncEvents() && COMPILER_ATOMIC_LOAD(&stat->fatalErrorCount, std::memory_order_relaxed)) {
-    WARN("communicator encountered a fatal error (detected in %s)", funcName);
+    ERR(ncclSystemError, "communicator encountered a fatal error (detected in %s)", funcName);
     return ncclSystemError;
   }
   return ncclSuccess;

--- a/comms/ncclx/v2_30/src/transport/net_ib/connect.cc
+++ b/comms/ncclx/v2_30/src/transport/net_ib/connect.cc
@@ -233,7 +233,7 @@ static ncclResult_t ncclIbRoceGetVersionNum(const char* deviceName, int portNum,
 
   int fd = open(roceTypePath, O_RDONLY);
   if (fd == -1) {
-    WARN("NET/IB: open failed in ncclIbRoceGetVersionNum: %s", strerror(errno));
+    ERR(ncclSystemError, "NET/IB: open failed in ncclIbRoceGetVersionNum: %s", strerror(errno));
     return ncclSystemError;
   }
   int ret = read(fd, gidRoceVerStr, 15);
@@ -243,7 +243,7 @@ static ncclResult_t ncclIbRoceGetVersionNum(const char* deviceName, int portNum,
     // In containerized environments, read could return EINVAL if the GID index is not mapped to the
     // container sysfs. In this case return ncclSuccess and let the caller move to next GID index.
     if (errno == EINVAL) return ncclSuccess;
-    WARN("NET/IB: read failed in ncclIbRoceGetVersionNum: %s", strerror(errno));
+    ERR(ncclSystemError, "NET/IB: read failed in ncclIbRoceGetVersionNum: %s", strerror(errno));
     return ncclSystemError;
   }
 
@@ -358,7 +358,7 @@ static ncclResult_t ncclIbCreateQpMlx5(struct ncclIbQpCreateAttr* createQpAttrs,
     dvAttr.comp_mask |= MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS;
   }
   qp->qp = wrap_mlx5dv_create_qp(createQpAttrs->pd->context, &qpInitAttr, &dvAttr);
-  if (qp->qp == NULL) { WARN("NET/IB: %s: mlx5dv_create_qp failed to create QP: %m", __func__);  return ncclInternalError; }
+  if (qp->qp == NULL) { ERR(ncclInternalError, "NET/IB: %s: mlx5dv_create_qp failed to create QP: %m", __func__);  return ncclInternalError; }
   return ncclSuccess;
 }
 
@@ -525,12 +525,12 @@ static ncclResult_t ncclIbSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
 
     if (ibDev->ibProvider == IB_PROVIDER_MLX5 && ncclParamIbOooRq()) {
       if (ibDev->ar == 0) {
-        WARN("NET/IB: %s: OOO RQ is force enabled but AR is not enabled, which is required for OOO RQ (device=%s)", __func__, ibDev->devName);
+        ERR(ncclInternalError, "NET/IB: %s: OOO RQ is force enabled but AR is not enabled, which is required for OOO RQ (device=%s)", __func__, ibDev->devName);
         return ncclInternalError;
       }
       qpCreateAttrs.oooRq = (comm->base.remOooRq && comm->base.localOooRq);
       if (!qpCreateAttrs.oooRq) {
-        WARN("NET/IB: %s: OOO RQ is force enabled but not supported on both sides of the connection (device=%s, localOooRq=%d, remOooRq=%d)",
+        ERR(ncclInternalError, "NET/IB: %s: OOO RQ is force enabled but not supported on both sides of the connection (device=%s, localOooRq=%d, remOooRq=%d)",
           __func__, ibDev->devName, comm->base.localOooRq, comm->base.remOooRq);
         return ncclInternalError;
       }
@@ -671,7 +671,7 @@ ncclResult_t ncclIbConnect(void* ctx, int dev, void* opaqueHandle, void** sendCo
   if (stage->state == ncclIbCommStateConnecting)   goto ib_connect;
   if (stage->state == ncclIbCommStateConnected)    goto ib_send_ready;
   if (stage->state != ncclIbCommStateStart) {
-    WARN("Error: trying to connect already connected sendComm");
+    ERR(ncclInternalError, "Error: trying to connect already connected sendComm");
     return ncclInternalError;
   }
   stage->buffer = NULL;
@@ -694,7 +694,7 @@ ib_connect_check:
   // IB Setup
   struct ncclIbMergedDev* mergedDev;
   if (dev >= ncclNMergedIbDevs) {
-    WARN("NET/IB : Trying to use non-existent virtual device %d", dev);
+    ERR(ncclInternalError, "NET/IB : Trying to use non-existent virtual device %d", dev);
     return ncclInternalError;
   }
 
@@ -822,7 +822,7 @@ ib_recv_dev_list:
     if (link_layer == IBV_LINK_LAYER_UNSPECIFIED) link_layer = devInfo->link_layer;
     if (link_layer != devInfo->link_layer) {
       int ibDev0 = comm->devs[0].base.ibDevN;
-      WARN("NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
+      ERR(ncclInternalError, "NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
            commDev->base.ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
       return ncclInternalError;
     }
@@ -860,7 +860,7 @@ ib_connect:
     link_layer = ncclIbDevs[ibDev0].portAttr.link_layer;
     for (int i = 0; i < remMeta.ndevs; i++) {
       if (remMeta.devs[i].link_layer != link_layer) {
-        WARN("NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
+        ERR(ncclInternalError, "NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
              NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
         return ncclInternalError;
       }
@@ -999,19 +999,19 @@ static ncclResult_t ncclIbReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
     }
     if (ibDev->ibProvider == IB_PROVIDER_MLX5 && ncclParamIbOooRq()) {
       if (ibDev->ar == 0) {
-        WARN("NET/IB: %s: OOO RQ is force enabled but AR is not enabled, which is required for OOO RQ (device=%s)", __func__, ibDev->devName);
+        ERR(ncclInternalError, "NET/IB: %s: OOO RQ is force enabled but AR is not enabled, which is required for OOO RQ (device=%s)", __func__, ibDev->devName);
         return ncclInternalError;
       }
       qpCreateAttrs.oooRq = (rComm->base.remOooRq && rComm->base.localOooRq);
       // out-of-order recv prerequisite: oooRq is supported on both sides
       if (!qpCreateAttrs.oooRq) {
-        WARN("NET/IB: %s: OOO RQ is force enabled but not supported on both sides of the connection (device=%s, localOooRq=%d, remOooRq=%d)",
+        ERR(ncclInternalError, "NET/IB: %s: OOO RQ is force enabled but not supported on both sides of the connection (device=%s, localOooRq=%d, remOooRq=%d)",
           __func__, ibDev->devName, rComm->base.localOooRq, rComm->base.remOooRq);
         return ncclInternalError;
       }
       // out-of-order recv prerequisite: oooRq size requirements are met
       if (ibDev->oooRqSize < qpCreateAttrs.maxRecvWorkRequest) {
-        WARN("NET/IB: %s: OOO RQ is force enabled but size %u is less than the required recv work request size %u on device:%s",
+        ERR(ncclInternalError, "NET/IB: %s: OOO RQ is force enabled but size %u is less than the required recv work request size %u on device:%s",
           __func__, ibDev->oooRqSize, qpCreateAttrs.maxRecvWorkRequest, ibDev->devName);
         return ncclInternalError;
       }
@@ -1194,7 +1194,7 @@ ncclResult_t ncclIbAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle
   if (stage->state == ncclIbCommStateSend) goto ib_send;
   if (stage->state == ncclIbCommStatePendingReady) goto ib_recv_ready;
   if (stage->state != ncclIbCommStateStart) {
-    WARN("Listencomm in unknown state %d", stage->state);
+    ERR(ncclInternalError, "Listencomm in unknown state %d", stage->state);
     return ncclInternalError;
   }
 
@@ -1227,7 +1227,7 @@ ib_recv_dev_list:
   ncclNetVDeviceProps_t remoteVProps;
   memcpy(&remoteVProps, stage->buffer, sizeof(ncclNetVDeviceProps_t));
   if (lComm->dev >= ncclNMergedIbDevs) {
-    WARN("NET/IB : Trying to use non-existent virtual device %d", lComm->dev);
+    ERR(ncclInternalError, "NET/IB : Trying to use non-existent virtual device %d", lComm->dev);
     return ncclInternalError;
   }
 
@@ -1313,7 +1313,7 @@ ib_recv:
     if (link_layer == IBV_LINK_LAYER_UNSPECIFIED) link_layer = ibDev->portAttr.link_layer;
     if (link_layer != ibDev->portAttr.link_layer) {
       int ibDev0 = rComm->devs[0].base.ibDevN;
-      WARN("NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
+      ERR(ncclInternalError, "NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
            ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
       return ncclInternalError;
     }
@@ -1324,7 +1324,7 @@ ib_recv:
   for (int i = 0; i < remMeta.ndevs; i++) {
     if (remMeta.devs[i].link_layer != link_layer) {
       int ibDev0 = rComm->devs[0].base.ibDevN;
-      WARN("NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
+      ERR(ncclInternalError, "NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
            NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
       return ncclInternalError;
     }

--- a/comms/ncclx/v2_30/src/transport/net_ib/gdaki/gin_host_gdaki.cc
+++ b/comms/ncclx/v2_30/src/transport/net_ib/gdaki/gin_host_gdaki.cc
@@ -32,7 +32,7 @@
     doca_error_t err = call;            \
     if (err != DOCA_SUCCESS) {          \
       /* Print the back trace*/         \
-      WARN("DOCA failure %d", err);     \
+      ERR(ncclSystemError, "DOCA failure %d", err);     \
       return ncclSystemError;           \
     }                                   \
   } while (0)
@@ -42,7 +42,7 @@
     doca_error_t err = call;            \
     if (err != DOCA_SUCCESS) {          \
       /* Print the back trace*/         \
-      WARN("DOCA failure %d", err);     \
+      ERR(ncclSystemError, "DOCA failure %d", err);     \
       RES = ncclSystemError;            \
       goto label;                       \
     }                                   \
@@ -275,7 +275,7 @@ class GdakiGlobalGPUBufferTable {
 
   ncclResult_t allocate_elements(unsigned int num_elements, unsigned int *out_start_idx) {
     if (this->next_unused_idx + num_elements > this->num_elements) {
-      WARN("Not enough space to get elements");
+      ERR(ncclInvalidUsage, "Not enough space to get elements");
       return ncclInvalidUsage;
     }
 
@@ -617,7 +617,7 @@ retry_create_qp_group_hl:
         goto retry_create_qp_group_hl;
       }
 
-      WARN("DOCA Error %d", docaStatus);
+      ERR(ncclSystemError, "DOCA Error %d", docaStatus);
       status = ncclSystemError;
       goto out;
     }

--- a/comms/ncclx/v2_30/src/transport/net_ib/gin.cc
+++ b/comms/ncclx/v2_30/src/transport/net_ib/gin.cc
@@ -44,7 +44,7 @@ static ncclResult_t ncclGinIbGdrGpuSupport(bool gdaki) {
   CUCHECK(cuDeviceGetAttribute(&dmaBufSupportOnDevice, CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED, cudaDev));
   if (dmaBufSupportOnDevice == 1) return ncclSuccess;
 
-  WARN("Unable to use GIN: Peermem is not supported, and device %d does not support DMA-BUF.", cudaDev);
+  ERR(ncclInvalidUsage, "Unable to use GIN: Peermem is not supported, and device %d does not support DMA-BUF.", cudaDev);
   return ncclInvalidUsage;
 }
 
@@ -291,7 +291,7 @@ ncclResult_t ncclGinIbGdakiDevices(int* ndev) {
 ncclResult_t ncclGinIbGdakiGetProperties(int dev, ncclNetProperties_t* props) {
   std::lock_guard<std::mutex> lock(ncclGinIbGdakiLockMutex);
   if (dev >= ncclGinIbGdakiNDevs) {
-    WARN("NET/IB : Requested properties for GIN GDAKI NIC %d, only %d GIN GDAKI NICs have been created", dev, ncclGinIbGdakiNDevs);
+    ERR(ncclInvalidUsage, "NET/IB : Requested properties for GIN GDAKI NIC %d, only %d GIN GDAKI NICs have been created", dev, ncclGinIbGdakiNDevs);
     return ncclInvalidUsage;
   }
   NCCLCHECK(ncclIbGetPhysProperties(ncclGinIbGdakiDevIndexes[dev], props));
@@ -426,7 +426,7 @@ ncclResult_t ncclGinIbProxyCreateContext(void* collComm, ncclGinConfig_v13_t* co
   ncclIbSetTrafficClass(cComm->ctx, config->trafficClass);
 
   if (config->queueDepth != 0) {
-    WARN("GIN_IB_PROXY does not support specifying qp depth");
+    ERR(ncclInvalidUsage, "GIN_IB_PROXY does not support specifying qp depth");
     return ncclInvalidUsage;
   }
 
@@ -645,7 +645,7 @@ ncclResult_t ncclGinIbProxyIPutSignal(void *ginCtx, int context, uint64_t srcOff
                                       uint64_t signalOff, void *signalMhandle, uint64_t signalValue,
                                       uint32_t signalOp, void **request) {
   if (signalOp != NCCL_NET_SIGNAL_OP_INC && signalOp != NCCL_NET_SIGNAL_OP_ADD) {
-    WARN("ncclGinIbProxyIPutSignal: Unsupported signalOp %u", signalOp);
+    ERR(ncclInvalidArgument, "ncclGinIbProxyIPutSignal: Unsupported signalOp %u", signalOp);
     return ncclInvalidArgument;
   }
 

--- a/comms/ncclx/v2_30/src/transport/net_ib/init.cc
+++ b/comms/ncclx/v2_30/src/transport/net_ib/init.cc
@@ -182,12 +182,12 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   }
 
   if (props->ndevs == 0) {
-      WARN("NET/IB : Can't make virtual NIC with 0 devices");
+      ERR(ncclInvalidUsage, "NET/IB : Can't make virtual NIC with 0 devices");
       return ncclInvalidUsage;
   }
 
   if (ncclNMergedIbDevs == MAX_IB_VDEVS) {
-    WARN("NET/IB : Cannot allocate any more virtual devices (%d)", MAX_IB_VDEVS);
+    ERR(ncclInvalidUsage, "NET/IB : Cannot allocate any more virtual devices (%d)", MAX_IB_VDEVS);
     return ncclInvalidUsage;
   }
 
@@ -214,12 +214,12 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   ncclIbDev* dev0 = ncclIbDevs + props->devs[0];
   for (int i = 1; i < props->ndevs; i++) {
     if (props->devs[i] >= ncclNIbDevs) {
-      WARN("NET/IB : Cannot use physical device %d, max %d", props->devs[i], ncclNIbDevs);
+      ERR(ncclInvalidUsage, "NET/IB : Cannot use physical device %d, max %d", props->devs[i], ncclNIbDevs);
       return ncclInvalidUsage;
     }
     ncclIbDev* dev = ncclIbDevs + props->devs[i];
     if (dev->link != dev0->link) {
-      WARN("NET/IB : Attempted to merge incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
+      ERR(ncclInvalidUsage, "NET/IB : Attempted to merge incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
         props->devs[0], dev0->devName, dev0->portNum, NCCL_IB_LLSTR(dev0->link), props->devs[i], dev->devName, dev->portNum, NCCL_IB_LLSTR(dev->link));
       return ncclInvalidUsage;
     }
@@ -272,7 +272,7 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       ncclNMergedIbDevs = 0;
       NCCLCHECK(ncclFindInterfaces(ncclIbIfName, &ncclIbIfAddr, MAX_IF_NAME_SIZE, 1, &nIpIfs));
       if (nIpIfs != 1) {
-        WARN("NET/IB : No IP interface found.");
+        ERR(ncclInternalError, "NET/IB : No IP interface found.");
         ret = ncclInternalError;
         goto fail;
       }
@@ -346,7 +346,7 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
                 } else if (res == ncclInvalidArgument) {
                   TRACE(NCCL_NET, "NET/IB: Device %s does not support Data Direct DMA.", devices[d]->name);
                 } else {
-                  WARN("NET/IB: Error in mlx5dv_get_data_direct_sysfs_path with device %s", devices[d]->name);
+                  ERR(res, "NET/IB: Error in mlx5dv_get_data_direct_sysfs_path with device %s", devices[d]->name);
                   return res;
                 }
               }
@@ -509,7 +509,7 @@ ncclResult_t ncclIbGetPhysProperties(int dev, ncclNetProperties_t* props) {
 
 ncclResult_t ncclIbGetProperties(int dev, ncclNetProperties_t* props) {
   if (dev >= ncclNMergedIbDevs) {
-    WARN("NET/IB : Requested properties for vNic %d, only %d vNics have been created", dev, ncclNMergedIbDevs);
+    ERR(ncclInvalidUsage, "NET/IB : Requested properties for vNic %d, only %d vNics have been created", dev, ncclNMergedIbDevs);
     return ncclInvalidUsage;
   }
   struct ncclIbMergedDev* mergedDev = ncclIbMergedDevs + dev;

--- a/comms/ncclx/v2_30/src/transport/net_ib/p2p.cc
+++ b/comms/ncclx/v2_30/src/transport/net_ib/p2p.cc
@@ -647,7 +647,7 @@ static ncclResult_t ncclIbLogCompletionWithError(struct ncclIbNetCommBase* commB
   ncclSocketGetAddr(&commBase->sock, &addr);
   ncclSocketToString(&addr, sockStr);
   char *hcaName = devBase->pd->context->device->name;
-  WARN_WITH_SCUBA("NET/IB: Got completion from peer %s with status=%s(%d) opcode=%s(%d) vendor_err=%u %s%s%s%s hca %s",
+  ERR(ncclRemoteError, "NET/IB: Got completion from peer %s with status=%s(%d) opcode=%s(%d) vendor_err=%u %s%s%s%s hca %s",
       sockStr, ibvWcStatusStr(wc->status), wc->status,
       ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->vendor_err,
       localGidStr ?  " localGid ":"", localGidString, remoteGidStr ? " remoteGids":"", remoteGidString, hcaName);

--- a/comms/ncclx/v2_30/src/transport/net_ib/p2p.cc
+++ b/comms/ncclx/v2_30/src/transport/net_ib/p2p.cc
@@ -32,7 +32,7 @@ ncclResult_t ncclIbGetRequest(struct ncclIbNetCommBase* base, struct ncclIbReque
       return ncclSuccess;
     }
   }
-  WARN("NET/IB : unable to allocate requests");
+  ERR(ncclInternalError, "NET/IB : unable to allocate requests");
   *req = NULL;
   return ncclInternalError;
 }
@@ -81,7 +81,7 @@ static ncclResult_t ncclIbPrintWr(struct ibv_send_wr* wr, char* wrStr) {
         wr->imm_data);
       break;
     default:
-      WARN("NET/IB: %s: No format specified for opcode=%d", __func__, wr->opcode);
+      ERR(ncclInternalError, "NET/IB: %s: No format specified for opcode=%d", __func__, wr->opcode);
       return ncclInternalError;
   }
   return ncclSuccess;
@@ -258,7 +258,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
 ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request) {
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
   if (comm->base.ready == 0) {
-    WARN("NET/IB: ncclIbIsend() called when comm->base.ready == 0");
+    ERR(ncclInternalError, "NET/IB: ncclIbIsend() called when comm->base.ready == 0");
     *request = NULL;
     return ncclInternalError;
   }
@@ -288,7 +288,7 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
       char line[SOCKET_NAME_MAXLEN + 1];
       union ncclSocketAddress addr;
       ncclSocketGetAddr(&comm->base.sock, &addr);
-      WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x",
+      ERR(ncclInternalError, "NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x",
         r, nreqs, tag, ncclSocketToString(&addr, line), slots[r].size, slots[r].addr, slots[r].rkeys[0]);
       return ncclInternalError;
     }
@@ -411,7 +411,7 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
 ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request) {
   struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
   if (comm->base.ready == 0) {
-    WARN("NET/IB: ncclIbIrecv() called when comm->base.ready == 0");
+    ERR(ncclInternalError, "NET/IB: ncclIbIrecv() called when comm->base.ready == 0");
     *request = NULL;
     return ncclInternalError;
   }
@@ -661,7 +661,7 @@ static inline ncclResult_t ncclIbCompletionEventProcess(struct ncclIbNetCommBase
   struct ncclIbRequest* req = NULL;
   NCCLCHECK(ncclIbRequestRetrieveFromCompletion(commBase, wc, &req));
   if (req == NULL) {
-    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=%ld, opcode=%d, qp_num=%u)", __func__, commBase->isSend ? "Send" : "Recv", commBase, wc->wr_id, wc->opcode, wc->qp_num);
+    ERR(ncclInternalError, "NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=%ld, opcode=%d, qp_num=%u)", __func__, commBase->isSend ? "Send" : "Recv", commBase, wc->wr_id, wc->opcode, wc->qp_num);
     return ncclInternalError;
   }
 
@@ -673,7 +673,7 @@ static inline ncclResult_t ncclIbCompletionEventProcess(struct ncclIbNetCommBase
 
   if (commBase->isSend) {
     if (req->type != NCCL_NET_IB_REQ_SEND) {
-      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, wc.opcode=%s(%d), wc.qp_num=%u)", __func__, ncclIbReqTypeStr[req->type], req, commBase, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
+      ERR(ncclInternalError, "NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, wc.opcode=%s(%d), wc.qp_num=%u)", __func__, ncclIbReqTypeStr[req->type], req, commBase, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
       return ncclInternalError;
     }
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)commBase;
@@ -682,7 +682,7 @@ static inline ncclResult_t ncclIbCompletionEventProcess(struct ncclIbNetCommBase
     for (int j = 0; j < req->nreqs; j++) {
       sendReq = sendComm->sendReqs[slot][j];
       if (!commBase->resiliency && (sendReq->events[devIndex] <= 0)) {
-        WARN("NET/IB: sendReq(%p)->events={%d,%d,%d,%d}, devIndex=%d, reqIdx=%d <= 0", sendReq, sendReq->events[0], sendReq->events[1], sendReq->events[2], sendReq->events[3], devIndex, j);
+        ERR(ncclInternalError, "NET/IB: sendReq(%p)->events={%d,%d,%d,%d}, devIndex=%d, reqIdx=%d <= 0", sendReq, sendReq->events[0], sendReq->events[1], sendReq->events[2], sendReq->events[3], devIndex, j);
         return ncclInternalError;
       }
       sendReq->events[devIndex]--;
@@ -700,7 +700,7 @@ static inline ncclResult_t ncclIbCompletionEventProcess(struct ncclIbNetCommBase
         return ncclSuccess;
       }
       if (req->type != NCCL_NET_IB_REQ_RECV && !commBase->resiliency) {
-        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, wc.status=%s(%d) wc.opcode=%s(%d), wc.qp_num=%u)", __func__, ncclIbReqTypeStr[req->type], req, req->base, req->id, wc->wr_id, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
+        ERR(ncclInternalError, "NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, wc.status=%s(%d) wc.opcode=%s(%d), wc.qp_num=%u)", __func__, ncclIbReqTypeStr[req->type], req, req->base, req->id, wc->wr_id, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
         return ncclInternalError;
       }
       if (req->nreqs == 1) {
@@ -732,7 +732,7 @@ static inline ncclResult_t ncclIbCompletionEventProcess(struct ncclIbNetCommBase
         return ncclSuccess;
       }
     } else {
-      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=%ld, wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)", __func__, req, commBase, req ? req->id : -1, devIndex, ncclIbReqTypeStr[req->type], wc->wr_id, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num, be32toh(wc->imm_data));
+      ERR(ncclInternalError, "NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=%ld, wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)", __func__, req, commBase, req ? req->id : -1, devIndex, ncclIbReqTypeStr[req->type], wc->wr_id, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num, be32toh(wc->imm_data));
       return ncclInternalError;
     }
 #ifdef NCCL_ENABLE_NET_PROFILING

--- a/comms/ncclx/v2_30/src/transport/net_ib/p2p.h
+++ b/comms/ncclx/v2_30/src/transport/net_ib/p2p.h
@@ -28,7 +28,7 @@ static inline ncclResult_t ncclIbRecvCommGetQpForCts(struct ncclIbRecvComm* recv
 
 static inline ncclResult_t ncclIbRequestRetrieveAsIndex(ncclIbRequest* reqs, uint32_t reqIndex, ncclIbRequest** req) {
   if (reqIndex < 0 || reqIndex >= NET_IB_MAX_REQUESTS) {
-    WARN("NET/IB: %s: Invalid request index %d. Not in the range [%d, %d). Cannot retrieve request.", __func__, reqIndex, 0, NET_IB_MAX_REQUESTS);
+    ERR(ncclInternalError, "NET/IB: %s: Invalid request index %d. Not in the range [%d, %d). Cannot retrieve request.", __func__, reqIndex, 0, NET_IB_MAX_REQUESTS);
     return ncclInternalError;
   }
   *req = &reqs[reqIndex];

--- a/comms/ncclx/v2_30/src/transport/net_ib/p2p_resiliency.cc
+++ b/comms/ncclx/v2_30/src/transport/net_ib/p2p_resiliency.cc
@@ -43,7 +43,7 @@ static ncclResult_t ncclIbResiliencyCheckErrorNotFatal(struct ncclIbResiliency* 
   }
 
   if (nFailedDevices > 1) {
-    WARN("NET/IB: %s: Fatal error. Detected %d failed devices out of %d devices on the %s communicator (comm=%p). No support for more than a single failed device.", __func__, nFailedDevices, resCtx->ndevs, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+    ERR(ncclRemoteError, "NET/IB: %s: Fatal error. Detected %d failed devices out of %d devices on the %s communicator (comm=%p). No support for more than a single failed device.", __func__, nFailedDevices, resCtx->ndevs, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
     return ncclRemoteError;
   }
 
@@ -58,7 +58,7 @@ static ncclResult_t ncclIbResiliencyCheckErrorNotFatal(struct ncclIbResiliency* 
     failureReason = "Fatal error status in work completion";
   }
 
-  WARN("NET/IB: %s: The error is fatal (%s). Cannot continue.", __func__, failureReason);
+  ERR(ncclRemoteError, "NET/IB: %s: The error is fatal (%s). Cannot continue.", __func__, failureReason);
   return ncclRemoteError;
 }
 
@@ -103,7 +103,7 @@ static ncclResult_t ncclIbResiliencyReplaceQps(struct ncclIbResiliency* resCtx, 
     } while (replaced == false && newQpIndex != failedQpIndex);
 
     if (!replaced) {
-      WARN("NET/IB: %s: Could not find a replacement QP for the failed QP with qpIndex=%d (devIndex=%d)", __func__, failedQpIndex, failedQp->devIndex);
+      ERR(ncclInternalError, "NET/IB: %s: Could not find a replacement QP for the failed QP with qpIndex=%d (devIndex=%d)", __func__, failedQpIndex, failedQp->devIndex);
       return ncclInternalError;
     }
 
@@ -131,12 +131,12 @@ static ncclResult_t ncclIbResiliencySendRequestInit(struct ncclIbResiliencySend*
   }
 
   if (request->id + 1 <= failedSendRequest->id) {
-    WARN("NET/IB: %s: Attempting to initiate a replay using an old request (req=%p, comm=%p, id=%ld, slot=%d, failedSendRequest.id=%ld).", __func__, request, request->base, request->id, slot, failedSendRequest->id);
+    ERR(ncclInternalError, "NET/IB: %s: Attempting to initiate a replay using an old request (req=%p, comm=%p, id=%ld, slot=%d, failedSendRequest.id=%ld).", __func__, request, request->base, request->id, slot, failedSendRequest->id);
     return ncclInternalError;
   }
 
   if (request->type != NCCL_NET_IB_REQ_SEND) {
-    WARN("NET/IB: %s: Attempting to initiate a failed request using a '%s' request while expecting a 'send' request (req=%p, comm=%p, id=%ld, slot=%d, failedSendRequest.id=%ld).", __func__, ncclIbReqTypeStr[request->type], request, request->base, request->id, slot, failedSendRequest->id);
+    ERR(ncclInternalError, "NET/IB: %s: Attempting to initiate a failed request using a '%s' request while expecting a 'send' request (req=%p, comm=%p, id=%ld, slot=%d, failedSendRequest.id=%ld).", __func__, ncclIbReqTypeStr[request->type], request, request->base, request->id, slot, failedSendRequest->id);
     return ncclInternalError;
   }
 
@@ -156,7 +156,7 @@ static ncclResult_t ncclIbResiliencySendRequestFree(struct ncclIbResiliencySend*
   assert(failedSendRequest != NULL);
   if (failedSendRequest->request == NULL) {
     int slot = failedSendRequest - sendResCtx->failedRequests;
-    WARN("NET/IB: %s: Attempting to free a non-existent failed request (slot=%d).", __func__, slot);
+    ERR(ncclInternalError, "NET/IB: %s: Attempting to free a non-existent failed request (slot=%d).", __func__, slot);
     return ncclInternalError;
   }
   INFO(NCCL_NET, "NET/IB: %s: Done handling failed send request (req=%p, comm=%p, id=%ld, slot=%ld).", __func__, failedSendRequest->request, failedSendRequest->request->base, failedSendRequest->request->id, failedSendRequest->request->id % NET_IB_MAX_REQUESTS);
@@ -176,7 +176,7 @@ static ncclResult_t ncclIbResiliencySendRequestFree(struct ncclIbResiliencySend*
 // Function to repost a given request.
 static ncclResult_t ncclIbResiliencyRepostRequest(struct ncclIbRequest* request) {
   if (request->type == NCCL_NET_IB_REQ_UNUSED) {
-    WARN("NET/IB: %s: Attempting to repost an unused request (id=%ld).", __func__, request->id);
+    ERR(ncclInternalError, "NET/IB: %s: Attempting to repost an unused request (id=%ld).", __func__, request->id);
     return ncclInternalError;
   }
   int slot = request->id % NET_IB_MAX_REQUESTS;
@@ -222,7 +222,7 @@ static ncclResult_t ncclIbResiliencyRepostRequest(struct ncclIbRequest* request)
     INFO(NCCL_NET, "NET/IB: %s: Reposting CTS (request=%p, comm=%p, id=%ld, slot=%ld)", __func__, request, request->base, request->id, request->id % NET_IB_MAX_REQUESTS);
     NCCLCHECK(ncclIbPostFifo((struct ncclIbRecvComm*)request->base, request, slot));
   } else {
-    WARN("NET/IB: %s: Unsupported type of request reposting (type=%d, id=%ld).", __func__, request->type, request->id);
+    ERR(ncclInternalError, "NET/IB: %s: Unsupported type of request reposting (type=%d, id=%ld).", __func__, request->type, request->id);
     return ncclInternalError;
   }
   return ncclSuccess;
@@ -233,7 +233,7 @@ static ncclResult_t ncclIbResiliencyHandleCompletionErrorReceiver(struct ncclIbR
   bool inRecvRange = (wc->wr_id >= 0 && wc->wr_id <= NET_IB_MAX_REQUESTS);
   bool inFlushRange = (wc->wr_id >= NCCL_IB_FLUSH_REQ_WR_ID_OFFSET && wc->wr_id < (NCCL_IB_FLUSH_REQ_WR_ID_OFFSET + NET_IB_MAX_REQUESTS));
   if (!inRecvRange && !inFlushRange && (wc->wr_id != NCCL_IB_RECV_WR_ID_DUMMY)) {
-    WARN("NET/IB: %s: Invalid wr_id (%ld). Unable to retrieve a request on the receiver side (comm=%p)", __func__, wc->wr_id, resCtx->baseComm);
+    ERR(ncclInternalError, "NET/IB: %s: Invalid wr_id (%ld). Unable to retrieve a request on the receiver side (comm=%p)", __func__, wc->wr_id, resCtx->baseComm);
     return ncclInternalError;
   }
   if (wc->wr_id == NCCL_IB_RECV_WR_ID_DUMMY) {
@@ -287,7 +287,7 @@ static ncclResult_t ncclIbResiliencyHandleCompletionErrorReceiver(struct ncclIbR
       WARN("NET/IB: %s: Unrecognized request. It might be a CTS message for which the request was already completed. Continue.", __func__);
       break;
     default:
-      WARN("NET/IB: %s: Unrecognized request type. request->type=%d", __func__, request->type);
+      ERR(ncclInternalError, "NET/IB: %s: Unrecognized request type. request->type=%d", __func__, request->type);
       return ncclInternalError;
   }
   return ncclSuccess;
@@ -395,7 +395,7 @@ static ncclResult_t ncclIbResiliencyProbePost(struct ncclIbResiliencySend* sendR
   assert(failedSendRequest->state == ncclIbResiliencyRequestStatePending);
 
   if (failedSendRequest->failedAttempts > ncclParamIbResiliencyPortFailoverMaxAttempts()) {
-    WARN("NET/IB: %s: Maximum number of probing attempts (%ld) reached for request %p (id=%ld). Cannot post another probe.", __func__, ncclParamIbResiliencyPortFailoverMaxAttempts(), failedSendRequest->request, failedSendRequest->request->id);
+    ERR(ncclRemoteError, "NET/IB: %s: Maximum number of probing attempts (%ld) reached for request %p (id=%ld). Cannot post another probe.", __func__, ncclParamIbResiliencyPortFailoverMaxAttempts(), failedSendRequest->request, failedSendRequest->request->id);
     return ncclRemoteError;
   }
 
@@ -421,7 +421,7 @@ static ncclResult_t ncclIbResiliencyProbePost(struct ncclIbResiliencySend* sendR
   }
 
   if (devIndex == sendResCtx->base.ndevs) {
-    WARN("NET/IB: %s: Could not find a functional device to post the probe for request %p (id=%ld)", __func__, failedSendRequest->request, failedSendRequest->request->id);
+    ERR(ncclInternalError, "NET/IB: %s: Could not find a functional device to post the probe for request %p (id=%ld)", __func__, failedSendRequest->request, failedSendRequest->request->id);
     return ncclInternalError;
   }
 

--- a/comms/ncclx/v2_30/src/transport/net_ib/p2p_resiliency_recovery.cc
+++ b/comms/ncclx/v2_30/src/transport/net_ib/p2p_resiliency_recovery.cc
@@ -216,7 +216,7 @@ static inline ncclResult_t ncclIbPortRecoveryContextInit(struct ncclIbResiliency
   if (!outRecoveryCtx) return ncclInternalError;
   ncclIbPortRecoveryContext* recoveryCtx = (ncclIbPortRecoveryContext*)malloc(sizeof(ncclIbPortRecoveryContext));
   if (!recoveryCtx) {
-    WARN("NET/IB: %s: Failed to allocate failure queue node (comm=%p)", __func__, resCtx->baseComm);
+    ERR(ncclInternalError, "NET/IB: %s: Failed to allocate failure queue node (comm=%p)", __func__, resCtx->baseComm);
     *outRecoveryCtx = NULL;
     return ncclInternalError;
   }
@@ -678,7 +678,7 @@ static inline ncclResult_t ncclIbPortRecoveryPostAliveMessages(struct ncclIbPort
   struct ibv_send_wr wr[NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX];
   int nMsgsToPost = ncclParamIbResiliencyPortRecoveryAliveMsgSequenceSize();
   if (nMsgsToPost > NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX) {
-    WARN("NET/IB: %s: Requested alive message batch size %d exceeds maximum supported %d", __func__, nMsgsToPost, NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX);
+    ERR(ncclInternalError, "NET/IB: %s: Requested alive message batch size %d exceeds maximum supported %d", __func__, nMsgsToPost, NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX);
     return ncclInternalError;
   }
   for (int i = 0; i < nMsgsToPost; i++) {
@@ -877,7 +877,7 @@ static inline ncclResult_t ncclIbPortRecoveryProgressAliveMessages(ncclIbPortRec
   }
   switch (progressResult) {
     case ncclIbPortRecoveryStateProgressResultGoToPrevState:
-      WARN("NET/IB: %s: Unexpected GoToPrevState result in AliveMessages state for device %d (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+      ERR(ncclInternalError, "NET/IB: %s: Unexpected GoToPrevState result in AliveMessages state for device %d (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
       return ncclInternalError;
     case ncclIbPortRecoveryStateProgressResultGoToNextState:
       INFO(NCCL_NET, "NET/IB: %s: Alive messages phase completed for device %d. Moving to next phase (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);

--- a/comms/ncclx/v2_30/src/transport/net_ib/reg.cc
+++ b/comms/ncclx/v2_30/src/transport/net_ib/reg.cc
@@ -104,7 +104,7 @@ ncclResult_t ncclIbDeregMrInternal(ncclIbNetCommDevBase* base, ibv_mr* mhandle) 
       return ncclSuccess;
     }
   }
-  WARN("NET/IB: could not find mr %p inside cache of %d entries", mhandle, cache->population);
+  ERR(ncclInternalError, "NET/IB: could not find mr %p inside cache of %d entries", mhandle, cache->population);
   return ncclInternalError;
 }
 

--- a/comms/ncclx/v2_30/src/transport/net_socket.cc
+++ b/comms/ncclx/v2_30/src/transport/net_socket.cc
@@ -57,7 +57,7 @@ ncclResult_t ncclNetSocketInit(void** ctx, uint64_t commId, ncclNetCommConfig_t*
       union ncclSocketAddress addrs[MAX_IFS];
       NCCLCHECK(ncclFindInterfaces(names, addrs, MAX_IF_NAME_SIZE, MAX_IFS, &ncclNetIfs));
       if (ncclNetIfs <= 0) {
-        WARN("NET/Socket : no interface found");
+        ERR(ncclInternalError, "NET/Socket : no interface found");
         return ncclInternalError;
       } else {
         #define MAX_LINE_LEN (2047)
@@ -401,7 +401,7 @@ fail:
 
 ncclResult_t ncclNetSocketListen(void* ctx, int dev, void* opaqueHandle, void** listenComm) {
   if (dev < 0 || dev >= ncclNetIfs) { // data transfer socket is based on specified dev
-    WARN("NET/Socket : ncclNetSocketListen dev=%d ncclNetIfs=%d", dev, ncclNetIfs);
+    ERR(ncclInternalError, "NET/Socket : ncclNetSocketListen dev=%d ncclNetIfs=%d", dev, ncclNetIfs);
     return ncclInternalError;
   }
   ncclResult_t ret = ncclSuccess;
@@ -545,7 +545,7 @@ ncclResult_t ncclNetSocketGetRequest(struct ncclNetSocketComm* comm, int op, voi
       return ncclSuccess;
     }
   }
-  WARN("NET/Socket : unable to allocate requests");
+  ERR(ncclInternalError, "NET/Socket : unable to allocate requests");
   return ncclInternalError;
 }
 
@@ -584,7 +584,7 @@ ncclResult_t ncclNetSocketGetTask(struct ncclNetSocketComm* comm, struct ncclPro
     res->threadCond.notify_one();
     return ncclSuccess;
   }
-  WARN("NET/Socket : unable to allocate subtasks");
+  ERR(ncclInternalError, "NET/Socket : unable to allocate subtasks");
   return ncclInternalError;
 }
 
@@ -595,7 +595,7 @@ ncclResult_t ncclNetSocketTest(void* request, int* done, int* size) {
   *done = 0;
   struct ncclNetSocketRequest *r = (struct ncclNetSocketRequest*)request;
   if (r == NULL) {
-    WARN("NET/Socket : test called with NULL request");
+    ERR(ncclInternalError, "NET/Socket : test called with NULL request");
     return ncclInternalError;
   }
   if (r->used == 1) { /* try to send/recv size (+ inline data if any) */
@@ -619,7 +619,7 @@ ncclResult_t ncclNetSocketTest(void* request, int* done, int* size) {
         char line[SOCKET_NAME_MAXLEN + 1];
         union ncclSocketAddress addr;
         NCCLCHECK(ncclSocketGetAddr(r->ctrlSock, &addr));
-        WARN("NET/Socket : peer %s message truncated : receiving %d bytes instead of %d. If you believe your socket network is in a healthy state, "
+        ERR(ncclInvalidUsage, "NET/Socket : peer %s message truncated : receiving %d bytes instead of %d. If you believe your socket network is in a healthy state, "
              "there may be a mismatch in collective sizes or environment settings (e.g. NCCL_PROTO, NCCL_ALGO) between ranks",
              ncclSocketToString(&addr, line), senderSize, r->size);
         return ncclInvalidUsage;

--- a/comms/ncclx/v2_30/src/transport/nvls.cc
+++ b/comms/ncclx/v2_30/src/transport/nvls.cc
@@ -355,7 +355,7 @@ static ncclResult_t nvlsAllocateMem(struct ncclComm* comm, const CUmemAccessDesc
     const char *errStr;                                                 \
     (void) pfn_cuGetErrorString(err, &errStr);                          \
     // Fail the job as NVLS support is not functional
-    WARN("Failed to bind NVLink SHARP (NVLS) Multicast memory of size %ld : CUDA error %d '%s'.\nThis is usually caused by a system or configuration error in the Fabric Manager or NVSwitches.\nDisable NVLS (NCCL_NVLS_ENABLE=0) if you wish to avoid this error in the future.", ucsize, err, errStr );
+    ERR(ncclUnhandledCudaError, "Failed to bind NVLink SHARP (NVLS) Multicast memory of size %ld : CUDA error %d '%s'.\nThis is usually caused by a system or configuration error in the Fabric Manager or NVSwitches.\nDisable NVLS (NCCL_NVLS_ENABLE=0) if you wish to avoid this error in the future.", ucsize, err, errStr );
     ret = ncclUnhandledCudaError;
     goto fail3;
   }

--- a/comms/ncclx/v2_30/src/transport/p2p.cc
+++ b/comms/ncclx/v2_30/src/transport/p2p.cc
@@ -365,7 +365,7 @@ static ncclResult_t p2pMap(struct ncclComm *comm, struct ncclProxyConnector* pro
       if (err == cudaErrorPeerAccessAlreadyEnabled) {
         cudaGetLastError();
       } else if (err != cudaSuccess) {
-        WARN("failed to peer with device %d(=%lx): %d %s",
+        ERR(ncclInternalError, "failed to peer with device %d(=%lx): %d %s",
             peerInfo->cudaDev, peerInfo->busId, err, cudaGetErrorString(err));
         return ncclInternalError;
       }

--- a/comms/ncclx/v2_30/src/transport/shm.cc
+++ b/comms/ncclx/v2_30/src/transport/shm.cc
@@ -526,7 +526,7 @@ static void initCeOperation() {
 
 ncclResult_t ncclShmAllocateShareableBuffer(size_t size, bool legacy, ncclShmIpcDesc_t *desc, void **hptr, void **dptr) {
   if (desc == NULL || hptr == NULL) {
-    WARN("Invalid argument desc %p, hptr %p", desc, hptr);
+    ERR(ncclInvalidArgument, "Invalid argument desc %p, hptr %p", desc, hptr);
     return ncclInvalidArgument;
   }
 #if CUDART_VERSION >= 12020
@@ -578,7 +578,7 @@ ncclResult_t ncclShmAllocateShareableBuffer(size_t size, bool legacy, ncclShmIpc
 
 ncclResult_t ncclShmImportShareableBuffer(struct ncclComm *comm, int proxyRank, ncclShmIpcDesc_t *desc, void **hptr, void **dptr, ncclShmIpcDesc_t *descOut) {
   if (comm == NULL || desc == NULL || hptr == NULL || descOut == NULL) {
-    WARN("Invalid argument comm %p, desc %p, hptr %p, descOut %p", comm, desc, hptr, descOut);
+    ERR(ncclInvalidArgument, "Invalid argument comm %p, desc %p, hptr %p, descOut %p", comm, desc, hptr, descOut);
     return ncclInvalidArgument;
   }
 #if CUDART_VERSION >= 12020

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -260,6 +260,12 @@ cvars:
    default     : False
    description : |-
      Enable logging of backend topology information to scuba.
+ - name        : NCCL_SCUBA_LOG_ERROR_ENABLED
+   type        : bool
+   default     : True
+   description : |-
+     Enable recording ERROR-level logs to the nccl_structured_logging Scuba
+     table.
 
 
  - name        : NCCL_SET_THREAD_NAME

--- a/comms/utils/logger/ErrorStackUtil.cc
+++ b/comms/utils/logger/ErrorStackUtil.cc
@@ -1,0 +1,80 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/ErrorStackUtil.h"
+
+#include <array>
+#include <sstream>
+#include <string_view>
+
+#if __has_include(<dwarf.h>)
+#include <folly/debugging/symbolizer/Symbolizer.h>
+#endif
+#include <folly/String.h>
+
+namespace {
+// Leading native-stack frames that belong to the logging / Scuba plumbing
+// rather than the real error site. We drop frames from the top of the captured
+// stack until the first frame that does NOT match any of these markers, so the
+// recorded stack starts near where the error was actually reported. A
+// name-based filter is used (instead of a fixed skip count) because setError()
+// is reached through several different call chains (direct CTRAN
+// ErrorStackTraceUtil, the NcclLogFormatter CTRAN hook, and the NCCL debug
+// path), each with a different amount of plumbing on top.
+constexpr std::array<std::string_view, 12> kInternalFrameMarkers = {
+    "folly::symbolizer",
+    "getStackTraceStr",
+    "NcclScubaSample",
+    "EventsScubaUtil",
+    "logErrorToScuba",
+    "ErrorStackTraceUtil",
+    "NcclLogFormatter",
+    "folly::LogStreamProcessor",
+    "folly::LogStreamVoidify",
+    "folly::LogStream",
+    "folly::XlogCategoryInfo",
+    "folly::LogCategory",
+};
+
+bool isInternalFrame(const std::string& frame) {
+  for (const auto& marker : kInternalFrameMarkers) {
+    if (frame.find(marker) != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Erase the leading plumbing frames (see kInternalFrameMarkers).
+void skipInternalFrames(std::vector<std::string>& frames) {
+  auto firstReal = frames.begin();
+  while (firstReal != frames.end() && isInternalFrame(*firstReal)) {
+    ++firstReal;
+  }
+  frames.erase(frames.begin(), firstReal);
+}
+} // namespace
+
+namespace meta::comms::logger {
+
+std::vector<std::string> captureNativeErrorStack() {
+  std::vector<std::string> stackTraceDemangled;
+
+  // Get stack trace (requires elfutils/libdwarf for folly Symbolizer)
+#if __has_include(<dwarf.h>)
+  std::stringstream ss;
+  ss << folly::symbolizer::getStackTraceStr();
+  // @lint-ignore CLANGTIDY
+  folly::split('\n', ss.str(), stackTraceDemangled);
+  for (auto& line : stackTraceDemangled) {
+    auto demangledLine = folly::demangle(line.c_str()).toStdString();
+    line.swap(demangledLine);
+  }
+  // Drop the leading logging / Scuba plumbing frames so the recorded stack
+  // starts near the real error site.
+  skipInternalFrames(stackTraceDemangled);
+#endif
+
+  return stackTraceDemangled;
+}
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/ErrorStackUtil.h
+++ b/comms/utils/logger/ErrorStackUtil.h
@@ -1,0 +1,17 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace meta::comms::logger {
+
+// Capture the native symbolized error stack once, dropping the leading logging
+// / Scuba plumbing frames. Returns the symbolized stack when symbolizer support
+// is available, and an empty vector when it is unavailable (no dwarf.h). The
+// result can be shared across all error reporters so the expensive capture runs
+// only once per error.
+std::vector<std::string> captureNativeErrorStack();
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/LoggingFormat.cc
+++ b/comms/utils/logger/LoggingFormat.cc
@@ -10,9 +10,14 @@
 #include <fmt/format.h>
 #include <folly/String.h>
 #include <folly/Synchronized.h>
+#include <folly/logging/LogCategory.h>
 #include <folly/logging/LogMessage.h>
 #include <folly/logging/LogName.h>
 #include <folly/synchronization/CallOnce.h>
+
+#include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
+#include "comms/utils/logger/EventsScubaUtil.h"
+#include "comms/utils/logger/NcclScubaSample.h"
 
 namespace {
 std::string getHostName(const char delim) {
@@ -38,14 +43,15 @@ static thread_local std::string myThreadName = "main";
 
 struct LastErrorInfo {
   std::string lastErrorMessage;
+  // Legacy per-frame error chain, still appended by v2_27/v2_29's debug.cc via
+  // appendErrorToStack(). Kept for backward compatibility.
   std::vector<std::string> lastErrorStack;
+  // Native symbolized stack captured at the error site by logErrorToScuba().
+  // Preferred by getLastCommsError() when present.
+  std::vector<std::string> lastErrorNativeStack;
 };
 
 static folly::Synchronized<LastErrorInfo> lastCommsError{};
-
-void logLastError(std::string_view message) {
-  lastCommsError.wlock()->lastErrorMessage = message;
-}
 } // Anonymous namespace
 
 namespace meta::comms::logger {
@@ -244,7 +250,16 @@ std::string NcclLogFormatter::formatMessage(
 
   bool isErrorMessage = message.getLevel() >= folly::LogLevel::ERR;
   if (isErrorMessage) {
-    logLastError(message.getMessage());
+    // Errors are recorded to Scuba at their call sites (ncclMetaDebugLogError
+    // for NCCL, CERR for CTRAN), each of which captures a fresh native stack
+    // via logErrorToScuba(). Clear any stale cached native stack here so
+    // getLastCommsError() does not pair this message with an unrelated stack;
+    // the call site's logErrorToScuba(), which runs after this formatter,
+    // re-sets it when present, and a bare XLOG(ERR) correctly falls back to the
+    // legacy per-frame chain.
+    auto lockedError = lastCommsError.wlock();
+    lockedError->lastErrorMessage = message.getMessage();
+    lockedError->lastErrorNativeStack.clear();
   }
 
   auto timeSinceEpoch = message.getTimestamp().time_since_epoch();
@@ -289,7 +304,7 @@ std::string NcclLogFormatter::formatMessage(
   // If this still isn't long enough the string will grow as necessary, so the
   // code will still be correct, but just slightly less efficient than if we
   // had allocated a large enough buffer the first time around.
-  size_t headerLengthGuess = 90 + basename.size();
+  std::size_t headerLengthGuess = 90 + basename.size();
 
   // Format the data into a buffer.
   std::string buffer;
@@ -301,7 +316,7 @@ std::string NcclLogFormatter::formatMessage(
     buffer.reserve(
         ((header.size() + 1) * message.getNumNewlines()) + msgData.size());
 
-    size_t idx = 0;
+    std::size_t idx = 0;
     while (true) {
       auto end = msgData.find('\n', idx);
       if (end == std::string_view::npos) {
@@ -328,12 +343,39 @@ std::string NcclLogFormatter::formatMessage(
   return buffer;
 }
 
+void logErrorToScuba(
+    const std::string& message,
+    const int code,
+    const std::string& errorName,
+    const std::vector<std::string>& stack) {
+  // Build one Scuba record for the whole error; the guard flushes it to
+  // nccl_structured_logging on scope exit and keeps the sticky-context columns.
+  auto sampleGuard = EVENTS_SCUBA_UTIL_SAMPLE_GUARD("ERROR");
+  auto& sample = sampleGuard.sample();
+  sample.setError(message, stack);
+  if (code != 0) {
+    sample.addNormal("error_code", fmt::format("{}:{}", code, errorName));
+  }
+}
+
+void setLastError(const std::string& message, std::vector<std::string> stack) {
+  auto w = lastCommsError.wlock();
+  w->lastErrorMessage = message;
+  w->lastErrorNativeStack = std::move(stack);
+}
+
 std::string getLastCommsError() {
   std::ostringstream ss;
   {
     auto lastCommsErrorRLocked = lastCommsError.rlock();
     ss << lastCommsErrorRLocked->lastErrorMessage << "\nNCCL Stack trace:";
-    for (const auto& stack : lastCommsErrorRLocked->lastErrorStack) {
+    // Prefer the native captured stack; fall back to the legacy per-frame
+    // chain (still populated by v2_27/v2_29) when no native stack is present.
+    const auto& stackTrace =
+        !lastCommsErrorRLocked->lastErrorNativeStack.empty()
+        ? lastCommsErrorRLocked->lastErrorNativeStack
+        : lastCommsErrorRLocked->lastErrorStack;
+    for (const auto& stack : stackTrace) {
       ss << '\n' << stack;
     }
   }

--- a/comms/utils/logger/LoggingFormat.h
+++ b/comms/utils/logger/LoggingFormat.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <vector>
 
 #include <fmt/format.h>
 #include <folly/Range.h>
@@ -72,6 +73,21 @@ fmt::memory_buffer getLogPrefix(LogLevel level);
 std::string getLastCommsError();
 
 void appendErrorToStack(std::string error);
+
+// Record an ERROR-level log to the nccl_structured_logging Scuba table as a
+// single error record (top-level message in the exception_message column,
+// native stack in the stack_trace column). The caller is responsible for gating
+// this on NCCL_SCUBA_LOG_ERROR_ENABLED and for capturing the native `stack`
+// once (via captureNativeErrorStack()) so it can be shared across reporters.
+void logErrorToScuba(
+    const std::string& message,
+    int code,
+    const std::string& errorName,
+    const std::vector<std::string>& stack);
+
+// Update the ncclGetLastError() state with the latest error message and its
+// pre-captured native stack. Unconditional; independent of Scuba error logging.
+void setLastError(const std::string& message, std::vector<std::string> stack);
 
 class NcclLogFormatter : public folly::LogFormatter {
  public:

--- a/comms/utils/logger/NcclScubaSample.cc
+++ b/comms/utils/logger/NcclScubaSample.cc
@@ -2,14 +2,11 @@
 
 #include "comms/utils/logger/NcclScubaSample.h"
 
-#include <sstream>
-
-#if __has_include(<dwarf.h>)
-#include <folly/debugging/symbolizer/Symbolizer.h>
-#endif
+#include <folly/String.h>
 #include <folly/json/json.h>
 
 #include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
+#include "comms/utils/logger/ErrorStackUtil.h"
 
 // Format uses these keys:
 // fbcode/rfe/scubadata/ScubaDataSample.cpp
@@ -61,22 +58,18 @@ void NcclScubaSample::setExceptionInfo(const std::exception& ex) {
 }
 
 void NcclScubaSample::setError(const std::string& error) {
-  // Get stack trace (requires elfutils/libdwarf for folly Symbolizer)
-#if __has_include(<dwarf.h>)
+  std::vector<std::string> stack;
   if (NCCL_SCUBA_STACK_TRACE_ON_ERROR_ENABLED) {
-    std::stringstream ss;
-    ss << folly::symbolizer::getStackTraceStr();
-    std::vector<std::string> stackTraceMangled;
-    // @lint-ignore CLANGTIDY
-    folly::split('\n', ss.str(), stackTraceMangled);
-    for (auto& line : stackTraceMangled) {
-      auto demangledLine = folly::demangle(line.c_str()).toStdString();
-      line.swap(demangledLine);
-    }
-    this->stackTrace = stackTraceMangled;
-    addNormVector("stack_trace", std::move(stackTraceMangled));
+    stack = ::meta::comms::logger::captureNativeErrorStack();
   }
-#endif
+  setError(error, stack);
+}
+
+void NcclScubaSample::setError(
+    const std::string& error,
+    const std::vector<std::string>& stack) {
+  this->stackTrace = stack;
+  addNormVector("stack_trace", stack);
 
   // Set attributes locally
   this->hasException = true;

--- a/comms/utils/logger/NcclScubaSample.h
+++ b/comms/utils/logger/NcclScubaSample.h
@@ -45,6 +45,13 @@ class NcclScubaSample {
   // Helper to include a custom error and collect stack trace
   void setError(const std::string& error);
 
+  // Helper to include a custom error using a pre-captured native stack instead
+  // of capturing one, so an expensive stack capture can be shared across
+  // multiple error reporters.
+  void setError(
+      const std::string& error,
+      const std::vector<std::string>& stack);
+
   // Set custom data attribute
   void setData(std::string data);
 

--- a/comms/utils/logger/tests/FormatterUT.cc
+++ b/comms/utils/logger/tests/FormatterUT.cc
@@ -302,6 +302,26 @@ TEST(LoggingFormat, getLastCommsErrorEmptyStack) {
   EXPECT_TRUE(errorStr.find("NCCL Stack trace:") != std::string::npos);
 }
 
+TEST(LoggingFormat, setLastErrorPrefersNativeStack) {
+  meta::comms::logger::setLastError(
+      "net timeout", {"stackFrame1", "stackFrame2"});
+
+  auto lastError = meta::comms::logger::getLastCommsError();
+  const auto messagePos = lastError.find("net timeout");
+  const auto headerPos = lastError.find("NCCL Stack trace:");
+  const auto frame1Pos = lastError.find("stackFrame1");
+  const auto frame2Pos = lastError.find("stackFrame2");
+
+  EXPECT_NE(messagePos, std::string::npos);
+  EXPECT_NE(headerPos, std::string::npos);
+  EXPECT_NE(frame1Pos, std::string::npos);
+  EXPECT_NE(frame2Pos, std::string::npos);
+
+  // The native stack is recorded after the message, in order.
+  EXPECT_LT(messagePos, frame1Pos);
+  EXPECT_LT(frame1Pos, frame2Pos);
+}
+
 TEST(LoggingFormat, nonErrorMessageDoesNotUpdateLastError) {
   LoggerDB db{LoggerDB::TESTING};
   auto* category = db.getCategory("test.info");

--- a/comms/utils/logger/tests/LogErrorToScubaTest.cc
+++ b/comms/utils/logger/tests/LogErrorToScubaTest.cc
@@ -1,0 +1,107 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/LoggingFormat.h"
+
+#include <sstream>
+#include <string>
+
+#include <folly/Singleton.h>
+#include <folly/init/Init.h>
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+#include <folly/portability/GTest.h>
+#include <folly/testing/TestUtil.h>
+
+#include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
+#include "comms/utils/logger/DataTableWrapper.h"
+#include "comms/utils/logger/EventMgr.h"
+#include "comms/utils/logger/tests/MockScubaTable.h"
+
+using meta::comms::logger::logErrorToScuba;
+
+namespace {
+
+// Drives logErrorToScuba() end-to-end into a mocked nccl_structured_logging
+// table so the flushed sample JSON can be inspected. The DataTableAllTables
+// singleton is replaced with MockScubaTable instances that capture the
+// serialized sample instead of writing it to a pipe/scuba sink.
+class LogErrorToScubaTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    savedLogFilePrefix_ = NCCL_SCUBA_LOG_FILE_PREFIX;
+    savedCommEventLogging_ = NCCL_COMM_EVENT_LOGGING;
+
+    // The nccl_structured_logging table is created only when its cvar names a
+    // "type:name" sink; point it at a pipe backed by a throwaway temp dir so
+    // the DataTable is constructed (and its writer thread runs) while the mock
+    // still captures every sample.
+    NCCL_SCUBA_LOG_FILE_PREFIX = tmpDir_.path().string();
+    NCCL_COMM_EVENT_LOGGING = "pipe:nccl_structured_logging";
+
+    folly::Singleton<const DataTableAllTables, DataTableAllTablesTag>::
+        make_mock([]() {
+          return new DataTableAllTables(
+              createAllMockTables(/*callParent=*/false));
+        });
+    DataTableWrapper::init();
+  }
+
+  void TearDown() override {
+    DataTableWrapper::shutdown();
+    NCCL_SCUBA_LOG_FILE_PREFIX = savedLogFilePrefix_;
+    NCCL_COMM_EVENT_LOGGING = savedCommEventLogging_;
+  }
+
+  // Flush the async writer thread and return the parsed JSON of the single
+  // sample logErrorToScuba() emitted.
+  folly::dynamic getLoggedSample() {
+    DataTableWrapper::shutdown();
+    std::istringstream iss(getMessages(LoggerEventType::CommEventType));
+    std::string line;
+    std::getline(iss, line);
+    return folly::parseJson(line);
+  }
+
+ private:
+  folly::test::TemporaryDirectory tmpDir_;
+  std::string savedLogFilePrefix_;
+  std::string savedCommEventLogging_;
+};
+
+// A non-zero code is recorded as "code:name", alongside the message and stack.
+TEST_F(LogErrorToScubaTest, RecordsErrorCodeMessageAndStack) {
+  logErrorToScuba("msg", 5, "ncclSystemError", {"f1", "f2"});
+
+  const auto json = getLoggedSample();
+
+  EXPECT_EQ(json["normal"]["error_code"].asString(), "5:ncclSystemError");
+  EXPECT_EQ(json["normal"]["exception_message"].asString(), "msg");
+  const auto expectedStack = folly::dynamic::array("f1", "f2");
+  EXPECT_EQ(json["normvector"]["stack_trace"], expectedStack);
+}
+
+// An empty error name still records the code with a trailing colon.
+TEST_F(LogErrorToScubaTest, ErrorCodeWithEmptyName) {
+  logErrorToScuba("msg", 5, "", {});
+
+  const auto json = getLoggedSample();
+
+  EXPECT_EQ(json["normal"]["error_code"].asString(), "5:");
+}
+
+// A zero code omits the error_code column entirely.
+TEST_F(LogErrorToScubaTest, NoErrorCodeWhenCodeIsZero) {
+  logErrorToScuba("msg", 0, "ncclSuccess", {});
+
+  const auto json = getLoggedSample();
+
+  EXPECT_EQ(json["normal"].count("error_code"), 0);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/utils/logger/tests/NcclScubaSampleTest.cc
+++ b/comms/utils/logger/tests/NcclScubaSampleTest.cc
@@ -1,0 +1,49 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/NcclScubaSample.h"
+
+#include <string>
+#include <vector>
+
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+#include <folly/portability/GTest.h>
+
+namespace {
+
+// setError() with a native stack records the frames in the stack_trace
+// normvector column and the plain top-level message in exception_message,
+// without duplicating the stack into the message.
+TEST(NcclScubaSampleTest, SetErrorRecordsStackAndMessage) {
+  const std::vector<std::string> stack{"frameA", "frameB"};
+  NcclScubaSample sample("ERROR");
+  sample.setError("boom", stack);
+
+  const auto json = folly::parseJson(sample.toJson());
+
+  const auto expectedStack = folly::dynamic::array("frameA", "frameB");
+  EXPECT_EQ(json["normvector"]["stack_trace"], expectedStack);
+
+  // The message column carries only the top-level message, not the stack.
+  const auto& message = json["normal"]["exception_message"].asString();
+  EXPECT_EQ(message, "boom");
+  EXPECT_EQ(message.find("frameA"), std::string::npos);
+  EXPECT_EQ(message.find("frameB"), std::string::npos);
+
+  EXPECT_EQ(json["int"]["exception_set"].asInt(), 1);
+}
+
+// setError() with an empty stack leaves stack_trace an empty normvector and
+// still records the message verbatim.
+TEST(NcclScubaSampleTest, SetErrorEmptyStack) {
+  NcclScubaSample sample("ERROR");
+  sample.setError("lonely error", {});
+
+  const auto json = folly::parseJson(sample.toJson());
+
+  EXPECT_TRUE(json["normvector"]["stack_trace"].empty());
+  EXPECT_EQ(json["normal"]["exception_message"].asString(), "lonely error");
+  EXPECT_EQ(json["int"]["exception_set"].asInt(), 1);
+}
+
+} // namespace


### PR DESCRIPTION
Summary:

Final subsystem pass of the NCCLX v2_30 error-logging cleanup: convert fatal, bail-out WARN() sites across the remaining v2_30/src subdirectories (graph/, misc/, os/, plugin/, gin/, ras/, rma/, devcomm/, param/, register/) to ERR(code, ...), so unrecoverable errors log at ERROR (glog 'E') and record exactly one Scuba error record carrying the concrete ncclResult_t. Recoverable/propagator/informational logs stay WARN. This completes the WARN->ERR audit begun in the top-level src and transport/ commits.
- 37 files converted. Each ERR carries the exact ncclResult_t the site returns / that its goto-target label returns - a literal code, or (only where the propagated value is already assigned before the log) the res/ret variable. Wrapper CHECK-style macros (gdrwrap, ibvwrap, mlx5dvwrap, nvmlwrap, ibvsymbols/mlx5dvsymbols LOAD_SYM, cudawrap) convert the WARN inside the macro definition to match the ncclResult_t the macro returns/gotos.
- Catch-all `fail:`/`error:` labels that only re-log an error already reported at its origin are kept as WARN (they are propagators; converting them would double-write the Scuba record) - e.g. the ncclOsShmOpen fail: label. Labels that are the sole logger for a bare `goto fail` (net/gin plugin device-count guards, search.cc NVLS-NIC lookup) are converted.
- socket.cc's two runtime-conditional sites (wrong-socket-state in ncclSocketConnect/ncclSocketAccept) compute the actual returned code (ncclRemoteError/ncclSystemError vs ncclInternalError) into a variable and pass it to ERR, so the Scuba code matches what the caller receives.
- KEEP-WARN categories are NOT converted: informational notices, best-effort teardown that continues, and recoverable paths. AMBIGUOUS sites with no ncclResult_t (abort()/exit()/return-NULL: misc/utils.cc, gdrwrap/ibvwrap open/reg wrappers) and other AMBIGUOUS cases (plugin/net.cc netName-mismatch, scheduler/symmetric_sched.cc "ran out of channel space" whose goto target currently returns ncclSuccess - a latent bug to resolve separately) are left as WARN. gin_v13.cc/devcomm_v23000.cc have no fatal-bail WARN sites.

Reviewed By: YulunW

Differential Revision: D112642438
