### PR TITLE
Add opaque ncclxExt handle for NCCLX per-communicator state (#3261)

### DIFF
--- a/comms/ncclx/meta/collectives/quantCollectives.cc
+++ b/comms/ncclx/meta/collectives/quantCollectives.cc
@@ -7,6 +7,7 @@
 
 #include "meta/wrapper/DataTypeStrUtils.h"
 #include "meta/wrapper/MetaFactory.h"
+#include "meta/wrapper/NcclCommUseCtran.h"
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/utils/ExtUtils.h"
@@ -88,7 +89,7 @@ static ncclResult_t ncclReduceScatterQuantizeInfoExt(
   constexpr auto kDirectIbAlgo = NCCL_REDUCESCATTER_ALGO::ctdirect_ib;
   if (NCCL_REDUCESCATTER_QUANTIZED_ALGO ==
           NCCL_REDUCESCATTER_QUANTIZED_ALGO::ctdirect_ib &&
-      comm->useCtran_ && op == ncclSum &&
+      meta::comms::ncclx::ncclCommUseCtran(comm) && op == ncclSum &&
       ctranReduceScatterSupport(comm->ctranComm_.get(), kDirectIbAlgo)) {
     return metaCommToNccl(ctranReduceScatterQuantize(
         sendbuff,

--- a/comms/ncclx/meta/collectives/quantCollectives.cc
+++ b/comms/ncclx/meta/collectives/quantCollectives.cc
@@ -8,6 +8,7 @@
 #include "meta/NcclxLogger.h"
 #include "meta/wrapper/DataTypeStrUtils.h"
 #include "meta/wrapper/MetaFactory.h"
+#include "meta/wrapper/NcclCommUseCtran.h"
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/utils/ExtUtils.h"
@@ -89,7 +90,7 @@ static ncclResult_t ncclReduceScatterQuantizeInfoExt(
   constexpr auto kDirectIbAlgo = NCCL_REDUCESCATTER_ALGO::ctdirect_ib;
   if (NCCL_REDUCESCATTER_QUANTIZED_ALGO ==
           NCCL_REDUCESCATTER_QUANTIZED_ALGO::ctdirect_ib &&
-      comm->useCtran_ && op == ncclSum &&
+      meta::comms::ncclx::ncclCommUseCtran(comm) && op == ncclSum &&
       ctranReduceScatterSupport(comm->ctranComm_.get(), kDirectIbAlgo)) {
     return metaCommToNccl(ctranReduceScatterQuantize(
         sendbuff,

--- a/comms/ncclx/meta/comm/NcclxCommExt.h
+++ b/comms/ncclx/meta/comm/NcclxCommExt.h
@@ -1,0 +1,21 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+// Opaque per-communicator NCCLX state.
+//
+// This handle collects NCCLX-only members that would otherwise be woven
+// directly into the forked upstream `ncclComm` struct, keeping that struct
+// close to pristine NCCL. NCCLX code reaches the state through the single
+// `ncclComm::ncclxExt` pointer (including this header and dereferencing
+// `comm->ncclxExt`), while the forked `comm.h` only forward-declares the type.
+//
+// `ncclComm` is raw-allocated (calloc) and raw-freed, so no constructor or
+// destructor runs on it; this handle is instead created explicitly right after
+// the comm is allocated and destroyed in the NCCLX comm-free hook, giving it a
+// lifetime that exactly matches the communicator.
+struct ncclxCommExt {
+  // Ctran per-communicator control; populated from the parsed ncclx::Config at
+  // communicator init and gates creation of the per-comm CtranComm.
+  bool useCtran{false};
+};

--- a/comms/ncclx/meta/wrapper/NcclCommUseCtran.h
+++ b/comms/ncclx/meta/wrapper/NcclCommUseCtran.h
@@ -1,0 +1,32 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comm.h"
+#include "nccl.h"
+
+// TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+#include "meta/comm/NcclxCommExt.h"
+#endif
+
+namespace meta::comms::ncclx {
+
+// Version-gated accessor for the per-communicator `useCtran` flag (route
+// supported collectives through CTRAN instead of the baseline path).
+//
+// In NCCL 2.30+ the flag lives on the opaque `comm->ncclxExt` handle, keeping
+// the forked upstream `ncclComm` struct closer to pristine NCCL. In older forks
+// (< 2.30, still the stable version) it remains a direct `ncclComm` member.
+// Routing shared NCCLX code and tests through this accessor lets them compile
+// against both layouts without touching the older fork.
+inline bool& ncclCommUseCtran(ncclComm* comm) {
+  // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+  return comm->ncclxExt->useCtran;
+#else
+  return comm->useCtran_;
+#endif
+}
+
+} // namespace meta::comms::ncclx

--- a/comms/ncclx/v2_30/src/include/comm.h
+++ b/comms/ncclx/v2_30/src/include/comm.h
@@ -42,6 +42,7 @@
 
 // Forward declarations of ncclx classes to avoid circular dependencies
 class ICtran;
+struct ncclxCommExt;
 namespace meta::comms {
 class IBootstrap;
 } // namespace meta::comms
@@ -838,6 +839,8 @@ struct ncclComm {
   /**
    * NCCLX specific state
    */
+  // Opaque NCCLX-only per-comm state; see meta/comm/NcclxCommExt.h.
+  ncclxCommExt* ncclxExt{nullptr};
   struct CommLogData logMetaData;
   std::shared_ptr<meta::comms::colltrace::ICollTrace> newCollTrace;
   std::shared_ptr<meta::comms::colltrace::AlgoStats> algoStats;
@@ -847,7 +850,6 @@ struct ncclComm {
   std::shared_ptr<ncclx::transport::TransportProxy> transportProxy_;
 
   // This is the only bridge between ctran and baseline code
-  bool useCtran_{false}; // Ctran per-communicator control; set at init entry functions
   std::unique_ptr<CtranComm> ctranComm_;
 
   // [META:PAT_AVG] per-communicator control; set at init entry functions

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -63,6 +63,7 @@
 #include "comms/utils/logger/LoggingFormat.h"
 #include "comms/ctran/memory/SlabAllocator.h"
 #include "comms/ctran/memory/Utils.h"
+#include "meta/comm/NcclxCommExt.h"
 #include "meta/wrapper/MetaFactory.h"
 #include "meta/transport/transportExt.h"
 
@@ -299,6 +300,8 @@ static void ncclxCommFree(ncclComm_t comm) {
     delete static_cast<ncclx::Config*>(comm->config.ncclxConfig);
     comm->config.ncclxConfig = nullptr;
   }
+  delete comm->ncclxExt;
+  comm->ncclxExt = nullptr;
 }
 
 static ncclResult_t commFree(ncclComm_t comm) {
@@ -2027,7 +2030,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   NCCLCHECKGOTO(meta::comms::ncclx::newCollTraceInit(comm), res, fail);
 
 
-  if (comm->useCtran_) {
+  if (comm->ncclxExt->useCtran) {
     NCCLCHECKGOTO(createCtranComm(comm), res, fail);
   }
   // --------------------- done
@@ -2585,14 +2588,15 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   NCCLCHECKGOTO(ncclCudaHostCalloc(&comm->abortFlagDev, 1), res, fail);
   NCCLCHECKGOTO(ncclCalloc(&comm->abortFlagRefCount, 1), res, fail);
   comm->startMagic = comm->endMagic = NCCL_MAGIC; // Used to detect comm corruption.
+  NEW_NOTHROW_GOTO(comm->ncclxExt, ncclxCommExt, res, fail);
   // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
-  comm->useCtran_ = NCCLX_CONFIG_FIELD(*config, useCtran);
+  comm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(*config, useCtran);
   comm->usePatAvg_ = NCCLX_CONFIG_FIELD(*config, usePatAvg);
   comm->noLocal_ = NCCLX_CONFIG_FIELD(*config, noLocal);
   INFO(NCCL_INIT, "CommInit comm %p commHash 0x%lx commDesc %s useCtran %d usePatAvg %d noLocal %d",
        comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES),
        NCCLX_CONFIG_FIELD(*config, commDesc).c_str(),
-       comm->useCtran_, comm->usePatAvg_, comm->noLocal_);
+       comm->ncclxExt->useCtran, comm->usePatAvg_, comm->noLocal_);
   *comm->abortFlagRefCount = 1;
   NCCLCHECKGOTO(parseCommConfig(comm, config), res, fail);
   /* start with ncclInProgress and will be changed to ncclSuccess if init succeeds. */
@@ -3280,6 +3284,7 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
   } else {
     NCCLCHECKGOTO(ncclCalloc(&childComm, 1), res, fail);
     childComm->startMagic = childComm->endMagic = NCCL_MAGIC;
+    NEW_NOTHROW_GOTO(childComm->ncclxExt, ncclxCommExt, res, fail);
 
     // Set the shareResource field, this is used throughout the init and must be reset every time.
     // Never share resources if the parent communicator has been revoked.
@@ -3309,12 +3314,12 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
     /* start with ncclInternalError and will be changed to ncclSuccess if init succeeds. */
     childComm->initState = ncclInternalError;
     // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
-    childComm->useCtran_ = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
+    childComm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
     childComm->usePatAvg_ = NCCLX_CONFIG_FIELD(childComm->config, usePatAvg);
     childComm->noLocal_ = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
     INFO(NCCL_INIT, "CommSplit comm %p commDesc %s useCtran %d usePatAvg %d noLocal %d",
         childComm, NCCLX_CONFIG_FIELD(childComm->config, commDesc).c_str(),
-        childComm->useCtran_, childComm->usePatAvg_, childComm->noLocal_);
+        childComm->ncclxExt->useCtran, childComm->usePatAvg_, childComm->noLocal_);
   }
 
   NEW_NOTHROW_GOTO(job, ncclCommInitRankAsyncJob, res, fail);
@@ -3504,6 +3509,7 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
   // All ranks allocate a NEW comm structure for the grown communicator
   NCCLCHECKGOTO(ncclCalloc(&newComm, 1), res, fail);
   newComm->startMagic = newComm->endMagic = NCCL_MAGIC;
+  NEW_NOTHROW_GOTO(newComm->ncclxExt, ncclxCommExt, res, fail);
 
   // All ranks allocate fresh resources for grown communicator
   NCCLCHECKGOTO(ncclCalloc(&newComm->abortFlag, 1), res, fail);

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -63,6 +63,7 @@
 #include "comms/utils/logger/LoggingFormat.h"
 #include "comms/ctran/memory/SlabAllocator.h"
 #include "comms/ctran/memory/Utils.h"
+#include "meta/comm/NcclxCommExt.h"
 #include "meta/wrapper/MetaFactory.h"
 #include "meta/transport/transportExt.h"
 
@@ -299,6 +300,8 @@ static void ncclxCommFree(ncclComm_t comm) {
     delete static_cast<ncclx::Config*>(comm->config.ncclxConfig);
     comm->config.ncclxConfig = nullptr;
   }
+  delete comm->ncclxExt;
+  comm->ncclxExt = nullptr;
 }
 
 static ncclResult_t commFree(ncclComm_t comm) {
@@ -2029,7 +2032,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   NCCLCHECKGOTO(meta::comms::ncclx::newCollTraceInit(comm), res, fail);
 
 
-  if (comm->useCtran_) {
+  if (comm->ncclxExt->useCtran) {
     NCCLCHECKGOTO(createCtranComm(comm), res, fail);
   }
   // --------------------- done
@@ -2587,14 +2590,15 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   NCCLCHECKGOTO(ncclCudaHostCalloc(&comm->abortFlagDev, 1), res, fail);
   NCCLCHECKGOTO(ncclCalloc(&comm->abortFlagRefCount, 1), res, fail);
   comm->startMagic = comm->endMagic = NCCL_MAGIC; // Used to detect comm corruption.
+  NEW_NOTHROW_GOTO(comm->ncclxExt, ncclxCommExt, res, fail);
   // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
-  comm->useCtran_ = NCCLX_CONFIG_FIELD(*config, useCtran);
+  comm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(*config, useCtran);
   comm->usePatAvg_ = NCCLX_CONFIG_FIELD(*config, usePatAvg);
   comm->noLocal_ = NCCLX_CONFIG_FIELD(*config, noLocal);
   INFO(NCCL_INIT, "CommInit comm %p commHash 0x%lx commDesc %s useCtran %d usePatAvg %d noLocal %d",
        comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES),
        NCCLX_CONFIG_FIELD(*config, commDesc).c_str(),
-       comm->useCtran_, comm->usePatAvg_, comm->noLocal_);
+       comm->ncclxExt->useCtran, comm->usePatAvg_, comm->noLocal_);
   *comm->abortFlagRefCount = 1;
   NCCLCHECKGOTO(parseCommConfig(comm, config), res, fail);
   /* start with ncclInProgress and will be changed to ncclSuccess if init succeeds. */
@@ -3282,6 +3286,7 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
   } else {
     NCCLCHECKGOTO(ncclCalloc(&childComm, 1), res, fail);
     childComm->startMagic = childComm->endMagic = NCCL_MAGIC;
+    NEW_NOTHROW_GOTO(childComm->ncclxExt, ncclxCommExt, res, fail);
 
     // Set the shareResource field, this is used throughout the init and must be reset every time.
     // Never share resources if the parent communicator has been revoked.
@@ -3311,12 +3316,12 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
     /* start with ncclInternalError and will be changed to ncclSuccess if init succeeds. */
     childComm->initState = ncclInternalError;
     // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
-    childComm->useCtran_ = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
+    childComm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
     childComm->usePatAvg_ = NCCLX_CONFIG_FIELD(childComm->config, usePatAvg);
     childComm->noLocal_ = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
     INFO(NCCL_INIT, "CommSplit comm %p commDesc %s useCtran %d usePatAvg %d noLocal %d",
         childComm, NCCLX_CONFIG_FIELD(childComm->config, commDesc).c_str(),
-        childComm->useCtran_, childComm->usePatAvg_, childComm->noLocal_);
+        childComm->ncclxExt->useCtran, childComm->usePatAvg_, childComm->noLocal_);
   }
 
   NEW_NOTHROW_GOTO(job, ncclCommInitRankAsyncJob, res, fail);
@@ -3506,6 +3511,7 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
   // All ranks allocate a NEW comm structure for the grown communicator
   NCCLCHECKGOTO(ncclCalloc(&newComm, 1), res, fail);
   newComm->startMagic = newComm->endMagic = NCCL_MAGIC;
+  NEW_NOTHROW_GOTO(newComm->ncclxExt, ncclxCommExt, res, fail);
 
   // All ranks allocate fresh resources for grown communicator
   NCCLCHECKGOTO(ncclCalloc(&newComm->abortFlag, 1), res, fail);


### PR DESCRIPTION
Summary:

NCCLX weaves its per-communicator state directly into the forked upstream `ncclComm` struct in `v2_30/src/include/comm.h`. That grows the fork's footprint over pristine NCCL and has to be re-reconciled by hand on every rebase. This adds a single opaque handle, `ncclComm::ncclxExt` (type `ncclxCommExt`, defined in the shared `comms/ncclx/meta/comm/NcclxCommExt.h`), so NCCLX members can be relocated off the forked struct into an NCCLX-only home. `comm.h` only forward-declares the type, so relocating a member no longer touches the forked header's feature includes.

`ncclComm` is raw-allocated with `ncclCalloc` (malloc + memset) and raw-`free`d, so no constructor or destructor runs on it. The handle is therefore created explicitly with `NEW_NOTHROW_GOTO` immediately after each of the three `ncclComm` allocations — rank init (`ncclCommInitRankDev`), comm split (`ncclCommInitChildComm`), and comm grow (`ncclCommGrow`) — before any NCCLX member is populated, and destroyed in the existing `ncclxCommFree` hook. This gives it a lifetime that exactly matches the communicator and guarantees `comm->ncclxExt` is non-null on every comm that reaches `ncclCommInitRankFunc` (which reads it).

As the first resident of the handle, the per-communicator `useCtran` control flag is moved off `ncclComm` (`comm->useCtran_` becomes `comm->ncclxExt->useCtran`). This is a pure relocation with no behavior change. `useCtran` is referenced only within `v2_30/src` (`init.cc`), so the change is confined to v2_30.

This is a foundational enabler. It establishes the seam that lets subsequent NCCLX features relocate their own per-comm members off the forked `ncclComm` without editing the upstream header further.

Reviewed By: shr

Differential Revision: D112035822


