### PR TITLE
MCCL comm: init NVL fabric topology (MNNVL cross-host NVLink) (#3269)

### DIFF
--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -161,9 +161,9 @@ void CommStateX::initRankStatesTopology(meta::comms::IBootstrap* bootstrap) {
 
 void CommStateX::setNvlFabricTopos(
     std::vector<NvlFabricTopology> nvlFabricTopologies,
-    std::optional<bool> fabricHwSupportedForTest) {
-  bool fabricHwSupported =
-      fabricHwSupportedForTest.value_or(ctran::utils::isCuMemFabricEnabled());
+    std::optional<bool> fabricHwSupportedOverride) {
+  const bool fabricHwSupported =
+      fabricHwSupportedOverride.value_or(ctran::utils::isCuMemFabricEnabled());
   FB_CHECKABORT(
       nvlFabricTopologies.size() == nRanks_,
       "size of nvlFabricTopologies not equal to nRanks_: {}",
@@ -171,6 +171,9 @@ void CommStateX::setNvlFabricTopos(
   nvlFabricTopos_ = std::move(nvlFabricTopologies);
   nvlFabricRankStates_.clear();
   nvlDomainRanks_.clear();
+  cliqueRanks_.clear();
+  myNvlFabricRankState_ = {};
+  nvlFabricCliqueEnabled_ = false;
   nvlFabricEnabled_ =
       fabricHwSupported && nvlFabricTopos_.at(rank_).supportNvlFabric;
   if (!nvlFabricEnabled_) {

--- a/comms/ctran/commstate/CommStateX.h
+++ b/comms/ctran/commstate/CommStateX.h
@@ -87,11 +87,11 @@ class CommStateX {
 
   /* Setters */
   void setRankTopologies(std::vector<RankTopology> rankTopologies);
-  // fabricHwSupportedForTest: optional override for testing; when not provided,
-  // uses runtime detection via getCuMemAllocHandleType()
+  // A supplied fabricHwSupported value is the communicator-agreed result.
+  // When absent, use the legacy process-local runtime detection.
   void setNvlFabricTopos(
       std::vector<NvlFabricTopology> nvlFabricTopologies,
-      std::optional<bool> fabricHwSupportedForTest = std::nullopt);
+      std::optional<bool> fabricHwSupported = std::nullopt);
 
   /* Getters */
   const std::vector<ncclx::RankTopology>& rankTopologiesRef() const;

--- a/comms/ctran/commstate/tests/CommStateXTest.cc
+++ b/comms/ctran/commstate/tests/CommStateXTest.cc
@@ -335,6 +335,65 @@ TEST(CommStateXTest, nvlFabricTest) {
   }
 }
 
+// Regression for the MCCL fabric-init prep (mccl::utils::initRankTopology now
+// calls setNvlFabricTopos): a single NVL fabric clusterId spanning MULTIPLE
+// physical hosts must collapse into ONE cross-host NVL domain, so
+// localRankToRanks() returns the whole domain (all ranks) rather than the
+// per-host node group. This is what lets a single-NVL-domain algo (cnvlmm) span
+// an MNNVL clique; without the fabric topos, localRankToRanks() would return
+// only same-host ranks and cross-host peers would fall back to IB.
+TEST(CommStateXTest, nvlFabricCrossHostSingleDomain) {
+  const int rank = 0;
+  const int nRanks = 8;
+  const int cudaDev = 0;
+  const int cudaArch = 90;
+  const int64_t busId = 25;
+  const uint64_t commHash = 0;
+
+  // All 8 ranks share ONE NVL fabric (clusterId1 / cliqueId1) ...
+  std::vector<NvlFabricTopology> nvlFabricTopologies{};
+  for (int r = 0; r < nRanks; ++r) {
+    nvlFabricTopologies.emplace_back(
+        createNvlFabricTopology(r, kNvlFabricClusterId1, kNvlFabricCliqueId1));
+  }
+  // ... spread across 4 distinct physical hosts (2 ranks each).
+  std::vector<RankTopology> rankTopologies{};
+  rankTopologies.emplace_back(createRankTopology(0, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(1, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(2, kDc, kZone, kHost1));
+  rankTopologies.emplace_back(createRankTopology(3, kDc, kZone, kHost1));
+  rankTopologies.emplace_back(createRankTopology(4, kDc, kZone, kHost2));
+  rankTopologies.emplace_back(createRankTopology(5, kDc, kZone, kHost2));
+  rankTopologies.emplace_back(createRankTopology(6, kDc, kZone, kHost3));
+  rankTopologies.emplace_back(createRankTopology(7, kDc, kZone, kHost3));
+
+  auto commState = std::make_unique<CommStateX>(
+      rank,
+      nRanks,
+      cudaDev,
+      cudaArch,
+      busId,
+      commHash,
+      rankTopologies,
+      std::vector<int>{});
+
+  // With fabric HW supported, the single clusterId collapses all 8 cross-host
+  // ranks into one NVL domain.
+  commState->setNvlFabricTopos(nvlFabricTopologies, /*fabricHwSupported=*/true);
+  EXPECT_TRUE(commState->nvlFabricEnabled());
+  for (int i = 0; i < nRanks; ++i) {
+    EXPECT_TRUE(commState->isSameNvlFabric(0, i));
+  }
+  EXPECT_EQ(commState->localRankToRanks().size(), static_cast<size_t>(nRanks));
+
+  // Without fabric HW support (the pre-fix / no-IMEX case), it falls back to
+  // the per-host node group (2 ranks/host), NOT one cross-host domain.
+  commState->setNvlFabricTopos(
+      std::move(nvlFabricTopologies), /*fabricHwSupported=*/false);
+  EXPECT_FALSE(commState->nvlFabricEnabled());
+  EXPECT_LT(commState->localRankToRanks().size(), static_cast<size_t>(nRanks));
+}
+
 TEST(CommStateXTest, nvlFabricCliqueTest) {
   // enable clique and NVL software partioning mode
   EnvRAII env1(NCCL_MNNVL_DETERMINISTIC_COLLECTIVE_ENABLE, true);
@@ -403,6 +462,14 @@ TEST(CommStateXTest, nvlFabricCliqueTest) {
     EXPECT_EQ(commState->node(i), i / 2);
     EXPECT_EQ(commState->localRankToRanks().size(), 2);
   }
+
+  commState->setNvlFabricTopos(nvlFabricTopologies, true);
+  EXPECT_TRUE(commState->nvlFabricEnabled());
+  EXPECT_TRUE(commState->nvlFabricCliqueEnabled());
+
+  commState->setNvlFabricTopos(std::move(nvlFabricTopologies), false);
+  EXPECT_FALSE(commState->nvlFabricEnabled());
+  EXPECT_FALSE(commState->nvlFabricCliqueEnabled());
 }
 
 TEST(CommStateXTest, nvlFabricVCliqueSizeHint) {

--- a/comms/ctran/utils/tests/AllocUT.cc
+++ b/comms/ctran/utils/tests/AllocUT.cc
@@ -57,7 +57,7 @@ TEST_F(CommAllocTest, CuMemAllocation) {
   // trustable info about if fabric handle is supported, so we use this
   // hardcoded GPU name to test. See:
   // https://forums.developer.nvidia.com/t/cudevicegetattribute-shows-i-can-use-fabric-handle-but-actually-i-cannot/336426/10
-  if (gpuName_.find("GB") == std::string::npos) {
+  if (gpuName_.find("NVIDIA GB") == std::string::npos) {
     // on non-GB (Grace Blackwell) platforms, fabric is not supported, we use
     // posix file descriptor for cuda allocation
     ensureDeviceMemNoLeak([this]() {
@@ -109,7 +109,7 @@ TEST_F(CommAllocTest, isCuMemFabricHandleSupported) {
   // since the CUDA allocator may retain internal memory pools after the probe
   // even though all allocations are freed.
   bool fabricSupported = isCuMemFabricEnabled();
-  if (gpuName_.find("GB") == std::string::npos) {
+  if (gpuName_.find("NVIDIA GB") == std::string::npos) {
     // on non-GB (Grace Blackwell) platforms, fabric handle should not be
     // supported
     EXPECT_FALSE(fabricSupported);


### PR DESCRIPTION
Summary:

`mccl::utils::initRankTopology` now allGathers each rank's NVL fabric info and calls `CommStateX::setNvlFabricTopos`, mirroring the production NCCLX initialization path. Previously MCCL-native communicators never populated these topologies, so cross-host peers in one MNNVL fabric were classified as IB instead of NVL and CNVLMM could not span the clique.

The raw bootstrap wire has an explicit, size-pinned layout. Fabric topology is enabled only when every rank reports valid fabric information; mixed CUDA/NVML availability disables it communicator-wide so all ranks retain identical topology state. The conversion is kept behind an internal helper with deterministic coverage for available, unavailable, mixed, and distinct per-rank UUID/clique values.

On H100 and other hosts without NVL fabric information this remains a no-op. Software-defined clique partitioning remains guarded by the follow-up diffs and is not enabled here.

Reviewed By: dboyda

Differential Revision: D113320384


