### PR TITLE
ReduceScatter copy prereq: multimem load_reduce + stage layout

### DIFF
--- a/comms/prims/tests/MultiPeerNvlTransportDeviceFailureTest.cc
+++ b/comms/prims/tests/MultiPeerNvlTransportDeviceFailureTest.cc
@@ -1,0 +1,69 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <folly/futures/Future.h>
+
+#include <memory>
+#include <stdexcept>
+
+#include "comms/common/bootstrap/tests/MockBootstrap.h"
+#include "comms/prims/transport/nvl/MultiPeerNvlTransport.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+namespace comms::prims::tests {
+namespace {
+
+using StrictMockBootstrap =
+    ::testing::StrictMock<meta::comms::testing::MockBootstrap>;
+
+TEST(MultiPeerNvlTransportDeviceFailureTest, SelectionFailureRestoresDevice) {
+  using ::testing::_;
+
+  int deviceCount = 0;
+  CUDACHECK_TEST(cudaGetDeviceCount(&deviceCount));
+  if (deviceCount == 0) {
+    GTEST_SKIP() << "test requires a CUDA device";
+  }
+
+  int originalDevice = -1;
+  CUDACHECK_TEST(cudaGetDevice(&originalDevice));
+  auto mock = std::make_shared<StrictMockBootstrap>();
+  EXPECT_CALL(*mock, allGather(_, sizeof(int), 0, 3))
+      .WillOnce([](void* buf, int, int, int) {
+        auto* eligibility = static_cast<int*>(buf);
+        EXPECT_EQ(eligibility[0], -1);
+        eligibility[1] = 1;
+        eligibility[2] = 1;
+        return folly::makeSemiFuture(0);
+      });
+
+  MultiPeerNvlTransportConfig config{
+      .pipelineDepth = 0,
+      .p2pSignalCount = 1,
+      .maxNumChannels = 0,
+      .enableMultimem = true,
+  };
+  MultiPeerNvlTransport transport(
+      /*myRank=*/0,
+      /*nRanks=*/3,
+      /*multimemCudaDevice=*/deviceCount,
+      std::shared_ptr<meta::comms::IBootstrap>(mock),
+      config);
+
+  EXPECT_THROW(
+      static_cast<void>(transport.initializeMultimemNvlTransportIfEligible()),
+      std::runtime_error);
+  int currentDevice = -1;
+  CUDACHECK_TEST(cudaGetDevice(&currentDevice));
+  EXPECT_EQ(currentDevice, originalDevice);
+  EXPECT_THROW(
+      static_cast<void>(transport.initializeMultimemNvlTransportIfEligible()),
+      std::runtime_error);
+  CUDACHECK_TEST(cudaGetDevice(&currentDevice));
+  EXPECT_EQ(currentDevice, originalDevice);
+}
+
+} // namespace
+} // namespace comms::prims::tests

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -3,11 +3,15 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
 #include <folly/futures/Future.h>
 #include <folly/init/Init.h>
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -83,6 +87,21 @@ MultimemNvlTransportConfig makeConfig(
 using meta::comms::testing::MockBootstrap;
 using StrictMockBootstrap = ::testing::StrictMock<MockBootstrap>;
 
+class ScopedTestCudaDevice {
+ public:
+  explicit ScopedTestCudaDevice(int device) {
+    CUDACHECK_TEST(cudaGetDevice(&originalDevice_));
+    CUDACHECK_TEST(cudaSetDevice(device));
+  }
+
+  ~ScopedTestCudaDevice() {
+    EXPECT_EQ(cudaSetDevice(originalDevice_), cudaSuccess);
+  }
+
+ private:
+  int originalDevice_{-1};
+};
+
 // Builds a StrictMockBootstrap that, by default, forwards every IBootstrap
 // API to `real`. Individual tests override specific methods via EXPECT_CALL
 // to inject failures. StrictMock ensures that if MultimemNvlTransport (or
@@ -157,7 +176,7 @@ TEST_F(MultimemNvlTransportTestFixture, MultiPeerMultimemDisabled) {
   // exercises only the disabled-path API (hasMultimemNvlTransport() == false,
   // getMultimemNvlTransportDevice() throws) and never touches the multimem
   // setup, so it must run on non-NVLS hosts too (skipping would drop coverage).
-  auto bootstrap = makeBootstrap("multimem_nvl_transport_multi_peer_lazy_test");
+  auto bootstrap = makeBootstrap("multimem_nvl_transport_multi_peer_disabled");
 
   MultiPeerNvlTransportConfig config{
       .pipelineDepth = 0,
@@ -165,6 +184,7 @@ TEST_F(MultimemNvlTransportTestFixture, MultiPeerMultimemDisabled) {
       // Disable the tile P2P channels (a nonzero maxNumChannels requires
       // pipelineDepth >= 1); this test checks only the disabled-path API.
       .maxNumChannels = 0,
+      .memSharingMode = MemSharingMode::kCudaIpc,
       .enableMultimem = false,
   };
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
@@ -177,7 +197,361 @@ TEST_F(MultimemNvlTransportTestFixture, MultiPeerMultimemDisabled) {
 
 TEST_F(
     MultimemNvlTransportTestFixture,
-    MultiPeerLazilyInitializesMultimemTransport) {
+    MultiPeerCollectivelyRejectsAsymmetricEligibility) {
+  using ::testing::_;
+
+  auto mock = std::make_shared<StrictMockBootstrap>();
+  EXPECT_CALL(*mock, allGather(_, sizeof(int), 0, 2))
+      .WillOnce([](void* buf, int, int, int) {
+        auto* eligible = static_cast<int*>(buf);
+        eligible[0] = 0;
+        eligible[1] = 1;
+        return folly::makeSemiFuture(0);
+      });
+
+  MultiPeerNvlTransportConfig config{
+      .pipelineDepth = 0,
+      .p2pSignalCount = 1,
+      .maxNumChannels = 0,
+      .enableMultimem = true,
+  };
+  MultiPeerNvlTransport transport(
+      /*myRank=*/0,
+      /*nRanks=*/2,
+      std::shared_ptr<meta::comms::IBootstrap>(mock),
+      config);
+
+  EXPECT_FALSE(transport.hasMultimemNvlTransport());
+  EXPECT_FALSE(transport.initializeMultimemNvlTransportIfEligible());
+  EXPECT_FALSE(transport.hasMultimemNvlTransport());
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    MultiPeerRemoteEligibilityQueryErrorPoisonsRetry) {
+  using ::testing::_;
+
+  auto mock = std::make_shared<StrictMockBootstrap>();
+  EXPECT_CALL(*mock, allGather(_, sizeof(int), 0, 3))
+      .WillOnce([](void* buf, int, int, int) {
+        auto* eligibility = static_cast<int*>(buf);
+        EXPECT_GE(eligibility[0], 0);
+        eligibility[1] = -1;
+        eligibility[2] = 1;
+        return folly::makeSemiFuture(0);
+      });
+
+  MultiPeerNvlTransportConfig config{
+      .pipelineDepth = 0,
+      .p2pSignalCount = 1,
+      .maxNumChannels = 0,
+      .enableMultimem = true,
+  };
+  MultiPeerNvlTransport transport(
+      /*myRank=*/0,
+      /*nRanks=*/3,
+      /*multimemCudaDevice=*/localRank,
+      std::shared_ptr<meta::comms::IBootstrap>(mock),
+      config);
+
+  EXPECT_THROW(
+      static_cast<void>(transport.initializeMultimemNvlTransportIfEligible()),
+      std::runtime_error);
+  EXPECT_THROW(
+      static_cast<void>(transport.initializeMultimemNvlTransportIfEligible()),
+      std::runtime_error);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    MultiPeerGetterDoesNotInitializeOrTouchBootstrap) {
+  auto mock = std::make_shared<StrictMockBootstrap>();
+  MultiPeerNvlTransportConfig config{
+      .pipelineDepth = 0,
+      .p2pSignalCount = 1,
+      .maxNumChannels = 0,
+      .enableMultimem = true,
+  };
+  MultiPeerNvlTransport transport(
+      /*myRank=*/0,
+      /*nRanks=*/2,
+      std::shared_ptr<meta::comms::IBootstrap>(mock),
+      config);
+
+  EXPECT_THROW(
+      static_cast<void>(transport.getMultimemNvlTransportDevice()),
+      std::runtime_error);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    MultiPeerEligibilityAgreementFailurePoisonsRetry) {
+  using ::testing::_;
+
+  auto mock = std::make_shared<StrictMockBootstrap>();
+  EXPECT_CALL(*mock, allGather(_, sizeof(int), 0, 3))
+      .WillOnce([](void*, int, int, int) { return folly::makeSemiFuture(1); });
+
+  MultiPeerNvlTransportConfig config{
+      .pipelineDepth = 0,
+      .p2pSignalCount = 1,
+      .maxNumChannels = 0,
+      .enableMultimem = true,
+  };
+  MultiPeerNvlTransport transport(
+      /*myRank=*/0,
+      /*nRanks=*/3,
+      /*multimemCudaDevice=*/localRank,
+      std::shared_ptr<meta::comms::IBootstrap>(mock),
+      config);
+
+  EXPECT_THROW(
+      static_cast<void>(transport.initializeMultimemNvlTransportIfEligible()),
+      std::runtime_error);
+  EXPECT_THROW(
+      static_cast<void>(transport.initializeMultimemNvlTransportIfEligible()),
+      std::runtime_error);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    MultiPeerEligibilityAgreementExceptionPoisonsRetry) {
+  using ::testing::_;
+
+  auto mock = std::make_shared<StrictMockBootstrap>();
+  EXPECT_CALL(*mock, allGather(_, sizeof(int), 0, 3))
+      .WillOnce([](void*, int, int, int) {
+        return folly::makeSemiFuture<int>(std::runtime_error("injected"));
+      });
+
+  MultiPeerNvlTransportConfig config{
+      .pipelineDepth = 0,
+      .p2pSignalCount = 1,
+      .maxNumChannels = 0,
+      .enableMultimem = true,
+  };
+  MultiPeerNvlTransport transport(
+      /*myRank=*/0,
+      /*nRanks=*/3,
+      /*multimemCudaDevice=*/localRank,
+      std::shared_ptr<meta::comms::IBootstrap>(mock),
+      config);
+
+  EXPECT_THROW(
+      static_cast<void>(transport.initializeMultimemNvlTransportIfEligible()),
+      std::runtime_error);
+  EXPECT_THROW(
+      static_cast<void>(transport.initializeMultimemNvlTransportIfEligible()),
+      std::runtime_error);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    MultiPeerCollectivelyRejectsAsymmetricConstructionFailure) {
+  using ::testing::_;
+  using ::testing::InSequence;
+
+  auto mock = std::make_shared<StrictMockBootstrap>();
+  {
+    InSequence sequence;
+    EXPECT_CALL(*mock, allGather(_, sizeof(int), 0, 3))
+        .WillOnce([](void* buf, int, int, int) {
+          auto* eligible = static_cast<int*>(buf);
+          eligible[0] = 1;
+          eligible[1] = 1;
+          eligible[2] = 1;
+          return folly::makeSemiFuture(0);
+        });
+    EXPECT_CALL(*mock, allGather(_, sizeof(int), 0, 3))
+        .WillOnce([](void* buf, int, int, int) {
+          auto* ready = static_cast<int*>(buf);
+          EXPECT_EQ(ready[0], 0);
+          ready[1] = 1;
+          ready[2] = 1;
+          return folly::makeSemiFuture(0);
+        });
+  }
+
+  MultiPeerNvlTransportConfig config{
+      .pipelineDepth = 0,
+      .p2pSignalCount = 1,
+      .maxNumChannels = 0,
+      .enableMultimem = true,
+      .multimem =
+          MultimemNvlTransportConfig{
+              .dataBufferSize = 0,
+              .userSignalCount = 1,
+              .internalSignalCount = 1,
+          },
+  };
+  MultiPeerNvlTransport transport(
+      /*myRank=*/0,
+      /*nRanks=*/3,
+      /*multimemCudaDevice=*/localRank,
+      std::shared_ptr<meta::comms::IBootstrap>(mock),
+      config);
+
+  EXPECT_THROW(
+      static_cast<void>(transport.initializeMultimemNvlTransportIfEligible()),
+      std::runtime_error);
+  EXPECT_FALSE(transport.hasMultimemNvlTransport());
+  EXPECT_THROW(
+      static_cast<void>(transport.initializeMultimemNvlTransportIfEligible()),
+      std::runtime_error);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    MultiPeerMultimemUsesConfiguredDeviceAndRestoresCallerDevice) {
+  int deviceCount = 0;
+  CUDACHECK_TEST(cudaGetDeviceCount(&deviceCount));
+  if (deviceCount < 2 || numRanks < 3) {
+    GTEST_SKIP() << "test requires at least two GPUs and three ranks";
+  }
+
+  auto bootstrap = makeBootstrap("multimem_nvl_transport_owned_device");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  const int callerDevice = (localRank + 1) % deviceCount;
+  std::unique_ptr<ScopedTestCudaDevice> callerDeviceGuard;
+  {
+    MultiPeerNvlTransportConfig config{
+        .pipelineDepth = 0,
+        .p2pSignalCount = 1,
+        .maxNumChannels = 0,
+        .enableMultimem = true,
+        .multimem =
+            MultimemNvlTransportConfig{
+                .dataBufferSize = 4096,
+                .userSignalCount = 1,
+                .internalSignalCount = 1,
+            },
+    };
+    MultiPeerNvlTransport transport(
+        globalRank, numRanks, localRank, bootstrap, config);
+    ASSERT_NO_THROW(transport.exchange());
+
+    callerDeviceGuard = std::make_unique<ScopedTestCudaDevice>(callerDevice);
+    int currentDevice = -1;
+    CUDACHECK_TEST(cudaGetDevice(&currentDevice));
+    EXPECT_EQ(currentDevice, callerDevice);
+    ASSERT_TRUE(transport.initializeMultimemNvlTransportIfEligible());
+    CUDACHECK_TEST(cudaGetDevice(&currentDevice));
+    EXPECT_EQ(currentDevice, callerDevice);
+    EXPECT_NO_THROW(transport.getMultimemNvlTransportDevice());
+  }
+
+  int currentDevice = -1;
+  CUDACHECK_TEST(cudaGetDevice(&currentDevice));
+  EXPECT_EQ(currentDevice, callerDevice);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    MultiPeerConstructionAgreementFailurePoisonsRetry) {
+  using ::testing::_;
+  using ::testing::InSequence;
+
+  auto mock = std::make_shared<StrictMockBootstrap>();
+  {
+    InSequence sequence;
+    EXPECT_CALL(*mock, allGather(_, sizeof(int), 0, 3))
+        .WillOnce([](void* buf, int, int, int) {
+          auto* eligible = static_cast<int*>(buf);
+          eligible[0] = 1;
+          eligible[1] = 1;
+          eligible[2] = 1;
+          return folly::makeSemiFuture(0);
+        });
+    EXPECT_CALL(*mock, allGather(_, sizeof(int), 0, 3))
+        .WillOnce(
+            [](void*, int, int, int) { return folly::makeSemiFuture(1); });
+  }
+
+  MultiPeerNvlTransportConfig config{
+      .pipelineDepth = 0,
+      .p2pSignalCount = 1,
+      .maxNumChannels = 0,
+      .enableMultimem = true,
+      .multimem =
+          MultimemNvlTransportConfig{
+              .dataBufferSize = 4096,
+              .userSignalCount = 1,
+              .internalSignalCount = 1,
+          },
+  };
+  MultiPeerNvlTransport transport(
+      /*myRank=*/0,
+      /*nRanks=*/3,
+      /*multimemCudaDevice=*/localRank,
+      std::shared_ptr<meta::comms::IBootstrap>(mock),
+      config);
+
+  EXPECT_THROW(
+      static_cast<void>(transport.initializeMultimemNvlTransportIfEligible()),
+      std::runtime_error);
+  EXPECT_THROW(
+      static_cast<void>(transport.initializeMultimemNvlTransportIfEligible()),
+      std::runtime_error);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    MultiPeerConstructionAgreementExceptionPoisonsRetry) {
+  using ::testing::_;
+  using ::testing::InSequence;
+
+  auto mock = std::make_shared<StrictMockBootstrap>();
+  {
+    InSequence sequence;
+    EXPECT_CALL(*mock, allGather(_, sizeof(int), 0, 3))
+        .WillOnce([](void* buf, int, int, int) {
+          auto* eligible = static_cast<int*>(buf);
+          eligible[0] = 1;
+          eligible[1] = 1;
+          eligible[2] = 1;
+          return folly::makeSemiFuture(0);
+        });
+    EXPECT_CALL(*mock, allGather(_, sizeof(int), 0, 3))
+        .WillOnce([](void*, int, int, int) {
+          return folly::makeSemiFuture<int>(
+              folly::make_exception_wrapper<std::runtime_error>(
+                  "readiness agreement failed"));
+        });
+  }
+
+  MultiPeerNvlTransportConfig config{
+      .pipelineDepth = 0,
+      .p2pSignalCount = 1,
+      .maxNumChannels = 0,
+      .enableMultimem = true,
+      .multimem =
+          MultimemNvlTransportConfig{
+              .dataBufferSize = 4096,
+              .userSignalCount = 1,
+              .internalSignalCount = 1,
+          },
+  };
+  MultiPeerNvlTransport transport(
+      /*myRank=*/0,
+      /*nRanks=*/3,
+      /*multimemCudaDevice=*/localRank,
+      std::shared_ptr<meta::comms::IBootstrap>(mock),
+      config);
+
+  EXPECT_THROW(
+      static_cast<void>(transport.initializeMultimemNvlTransportIfEligible()),
+      std::runtime_error);
+  EXPECT_THROW(
+      static_cast<void>(transport.initializeMultimemNvlTransportIfEligible()),
+      std::runtime_error);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    MultiPeerCollectivelyInitializesMultimemTransport) {
   auto bootstrap = makeBootstrap("multimem_nvl_transport_multi_peer_test");
   if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
@@ -200,9 +574,46 @@ TEST_F(
           },
   };
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
-  EXPECT_TRUE(transport.hasMultimemNvlTransport());
+  EXPECT_FALSE(transport.hasMultimemNvlTransport());
   ASSERT_NO_THROW(transport.exchange());
+  ASSERT_TRUE(transport.initializeMultimemNvlTransportIfEligible());
+  EXPECT_TRUE(transport.hasMultimemNvlTransport());
   EXPECT_NO_THROW(transport.getMultimemNvlTransportDevice());
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    MultiPeerConstructionFailureDoesNotStrandPeers) {
+  auto bootstrap = makeBootstrap("multimem_nvl_transport_construction_failure");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  MultiPeerNvlTransportConfig config{
+      .pipelineDepth = 0,
+      .p2pSignalCount = 1,
+      .maxNumChannels = 0,
+      .enableMultimem = true,
+      .multimem =
+          MultimemNvlTransportConfig{
+              .dataBufferSize =
+                  globalRank == 0 ? std::size_t{0} : std::size_t{4096},
+              .userSignalCount = 1,
+              .internalSignalCount = 1,
+          },
+  };
+  MultiPeerNvlTransport transport(
+      globalRank, numRanks, localRank, bootstrap, config);
+  ASSERT_NO_THROW(transport.exchange());
+
+  EXPECT_THROW(
+      static_cast<void>(transport.initializeMultimemNvlTransportIfEligible()),
+      std::runtime_error);
+  EXPECT_FALSE(transport.hasMultimemNvlTransport());
+  EXPECT_THROW(
+      static_cast<void>(transport.initializeMultimemNvlTransportIfEligible()),
+      std::runtime_error);
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 }
 
 // getDeviceTransport() must refuse to vend a handle before exchange() has
@@ -258,6 +669,8 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
 
   EXPECT_NE(handle.localData, nullptr);
   EXPECT_NE(handle.multimemData, nullptr);
+  EXPECT_EQ(handle.nvlRank, globalRank);
+  EXPECT_EQ(handle.nvlRanks, numRanks);
   EXPECT_NE(handle.localData, handle.multimemData)
       << "unicast and multicast VAs should be distinct";
   EXPECT_EQ(handle.dataBufferSize, kDataBytes);
@@ -684,6 +1097,129 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceUserAndInternalSignalsIsolated) {
   CUDACHECK_TEST(cudaFree(pairOut));
 
   ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(MultimemNvlTransportTestFixture, DeviceLoadReduceCoversPublicTypes) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_device_load_reduce_types");
+  auto transport = makeExchangedTransport(
+      bootstrap,
+      globalRank,
+      numRanks,
+      localRank,
+      /*userSignalCount=*/1,
+      /*internalSignalCount=*/1);
+  if (!transport) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kElems = 9;
+  const float rankValue = static_cast<float>(globalRank + 1);
+  const float expected = static_cast<float>(numRanks * (numRanks + 1) / 2);
+  auto handle = transport->getDeviceTransport();
+
+  auto run = [&](test::MultimemReductionTestType type,
+                 bool accF32,
+                 std::size_t elementSize,
+                 std::size_t sourceOffsetElems,
+                 auto verify) {
+    void* output = nullptr;
+    CUDACHECK_TEST(cudaMalloc(&output, kElems * elementSize));
+    test::launchFillReductionInput(
+        handle, type, rankValue, kElems, sourceOffsetElems);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+    test::launchLoadReduce(
+        handle, type, accF32, output, kElems, sourceOffsetElems);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    verify(output, expected);
+    CUDACHECK_TEST(cudaFree(output));
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+  };
+
+  run(test::MultimemReductionTestType::Float,
+      /*accF32=*/true,
+      sizeof(float),
+      /*sourceOffsetElems=*/0,
+      [&](void* output, float expectedValue) {
+        std::vector<float> values(kElems);
+        CUDACHECK_TEST(cudaMemcpy(
+            values.data(),
+            output,
+            values.size() * sizeof(float),
+            cudaMemcpyDeviceToHost));
+        for (float value : values) {
+          EXPECT_EQ(value, expectedValue);
+        }
+      });
+  run(test::MultimemReductionTestType::Float,
+      /*accF32=*/true,
+      sizeof(float),
+      /*sourceOffsetElems=*/1,
+      [&](void* output, float expectedValue) {
+        std::vector<float> values(kElems);
+        CUDACHECK_TEST(cudaMemcpy(
+            values.data(),
+            output,
+            values.size() * sizeof(float),
+            cudaMemcpyDeviceToHost));
+        for (float value : values) {
+          EXPECT_EQ(value, expectedValue);
+        }
+      });
+  run(test::MultimemReductionTestType::Int32,
+      /*accF32=*/true,
+      sizeof(int32_t),
+      /*sourceOffsetElems=*/0,
+      [&](void* output, float expectedValue) {
+        std::vector<int32_t> values(kElems);
+        CUDACHECK_TEST(cudaMemcpy(
+            values.data(),
+            output,
+            values.size() * sizeof(int32_t),
+            cudaMemcpyDeviceToHost));
+        for (int32_t value : values) {
+          EXPECT_EQ(value, static_cast<int32_t>(expectedValue));
+        }
+      });
+
+  for (const auto type :
+       {test::MultimemReductionTestType::Float16,
+        test::MultimemReductionTestType::Bfloat16}) {
+    for (const bool accF32 : {false, true}) {
+      for (const std::size_t sourceOffsetElems : {0, 1}) {
+        run(type,
+            accF32,
+            sizeof(uint16_t),
+            sourceOffsetElems,
+            [&, type](void* output, float expectedValue) {
+              std::vector<uint16_t> values(kElems);
+              CUDACHECK_TEST(cudaMemcpy(
+                  values.data(),
+                  output,
+                  values.size() * sizeof(uint16_t),
+                  cudaMemcpyDeviceToHost));
+              for (uint16_t bits : values) {
+                float value = 0;
+                if (type == test::MultimemReductionTestType::Float16) {
+                  __half raw{};
+                  std::memcpy(&raw, &bits, sizeof(raw));
+                  value = __half2float(raw);
+                } else {
+                  __nv_bfloat16 raw{};
+                  std::memcpy(&raw, &bits, sizeof(raw));
+                  value = __bfloat162float(raw);
+                  expectedValue =
+                      __bfloat162float(__float2bfloat16(expectedValue));
+                }
+                EXPECT_EQ(value, expectedValue);
+              }
+            });
+      }
+    }
+  }
 }
 
 } // namespace comms::prims::tests

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -2,8 +2,11 @@
 
 #include "comms/prims/tests/MultimemNvlTransportTest.cuh"
 
+#include <type_traits>
+
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/tests/Checks.h"
+#include "comms/prims/transport/nvl/MultimemNvlReduce.cuh"
 
 namespace comms::prims::test {
 
@@ -78,6 +81,72 @@ __global__ void readUserAndInternalKernel(
   }
 }
 
+template <typename T>
+__device__ T reductionValue(float value) {
+  if constexpr (std::is_same_v<T, __half>) {
+    return __float2half(value);
+  } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    return __float2bfloat16_rn(value);
+  } else {
+    return static_cast<T>(value);
+  }
+}
+
+template <typename T>
+__global__ void fillReductionInputKernel(
+    MultimemNvlTransportDevice transport,
+    float value,
+    std::size_t elems,
+    std::size_t sourceOffsetElems) {
+  auto* source = reinterpret_cast<T*>(transport.localData) + sourceOffsetElems;
+  for (std::size_t i = threadIdx.x; i < elems; i += blockDim.x) {
+    source[i] = reductionValue<T>(value);
+  }
+}
+
+template <typename T, bool kAccF32>
+__global__ void loadReduceKernel(
+    MultimemNvlTransportDevice transport,
+    T* output,
+    std::size_t elems,
+    std::size_t sourceOffsetElems) {
+  auto group = make_warp_group();
+  const auto* source =
+      reinterpret_cast<const T*>(transport.multimemData) + sourceOffsetElems;
+  multimem::load_reduce_at<T, multimem::MultimemRedOp::Add, kAccF32>(
+      group, output, source, elems);
+}
+
+template <typename T>
+void launchFillReductionInputTyped(
+    MultimemNvlTransportDevice transport,
+    float value,
+    std::size_t elems,
+    std::size_t sourceOffsetElems,
+    cudaStream_t stream) {
+  fillReductionInputKernel<T>
+      <<<1, 32, 0, stream>>>(transport, value, elems, sourceOffsetElems);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+template <typename T>
+void launchLoadReduceTyped(
+    MultimemNvlTransportDevice transport,
+    bool accF32,
+    void* output,
+    std::size_t elems,
+    std::size_t sourceOffsetElems,
+    cudaStream_t stream) {
+  if (accF32) {
+    loadReduceKernel<T, true><<<1, 32, 0, stream>>>(
+        transport, static_cast<T*>(output), elems, sourceOffsetElems);
+  } else {
+    loadReduceKernel<T, false><<<1, 32, 0, stream>>>(
+        transport, static_cast<T*>(output), elems, sourceOffsetElems);
+  }
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
 } // namespace
 
 void launchSetUserSignal(
@@ -149,6 +218,53 @@ void launchReadUserAndInternal(
   readUserAndInternalKernel<<<1, 32, 0, stream>>>(
       transport, userId, internalId, out);
   PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchFillReductionInput(
+    MultimemNvlTransportDevice transport,
+    MultimemReductionTestType type,
+    float value,
+    std::size_t elems,
+    std::size_t sourceOffsetElems,
+    cudaStream_t stream) {
+  switch (type) {
+    case MultimemReductionTestType::Float:
+      return launchFillReductionInputTyped<float>(
+          transport, value, elems, sourceOffsetElems, stream);
+    case MultimemReductionTestType::Int32:
+      return launchFillReductionInputTyped<int32_t>(
+          transport, value, elems, sourceOffsetElems, stream);
+    case MultimemReductionTestType::Float16:
+      return launchFillReductionInputTyped<__half>(
+          transport, value, elems, sourceOffsetElems, stream);
+    case MultimemReductionTestType::Bfloat16:
+      return launchFillReductionInputTyped<__nv_bfloat16>(
+          transport, value, elems, sourceOffsetElems, stream);
+  }
+}
+
+void launchLoadReduce(
+    MultimemNvlTransportDevice transport,
+    MultimemReductionTestType type,
+    bool accF32,
+    void* output,
+    std::size_t elems,
+    std::size_t sourceOffsetElems,
+    cudaStream_t stream) {
+  switch (type) {
+    case MultimemReductionTestType::Float:
+      return launchLoadReduceTyped<float>(
+          transport, accF32, output, elems, sourceOffsetElems, stream);
+    case MultimemReductionTestType::Int32:
+      return launchLoadReduceTyped<int32_t>(
+          transport, accF32, output, elems, sourceOffsetElems, stream);
+    case MultimemReductionTestType::Float16:
+      return launchLoadReduceTyped<__half>(
+          transport, accF32, output, elems, sourceOffsetElems, stream);
+    case MultimemReductionTestType::Bfloat16:
+      return launchLoadReduceTyped<__nv_bfloat16>(
+          transport, accF32, output, elems, sourceOffsetElems, stream);
+  }
 }
 
 } // namespace comms::prims::test

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -12,6 +12,8 @@
 
 namespace comms::prims::test {
 
+enum class MultimemReductionTestType { Float, Int32, Float16, Bfloat16 };
+
 // Each launch is one warp -> one ThreadGroup. The leader performs the
 // multimem PTX store; the remaining lanes sync alongside it. Callers must
 // cudaStreamSynchronize (or cudaDeviceSynchronize) before observing effects
@@ -74,6 +76,23 @@ void launchReadUserAndInternal(
     uint64_t userId,
     uint64_t internalId,
     uint64_t* out,
+    cudaStream_t stream = nullptr);
+
+void launchFillReductionInput(
+    MultimemNvlTransportDevice transport,
+    MultimemReductionTestType type,
+    float value,
+    std::size_t elems,
+    std::size_t sourceOffsetElems,
+    cudaStream_t stream = nullptr);
+
+void launchLoadReduce(
+    MultimemNvlTransportDevice transport,
+    MultimemReductionTestType type,
+    bool accF32,
+    void* output,
+    std::size_t elems,
+    std::size_t sourceOffsetElems,
     cudaStream_t stream = nullptr);
 
 } // namespace comms::prims::test

--- a/comms/prims/tests/MultimemNvlTransportValidationTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportValidationTest.cc
@@ -150,4 +150,39 @@ TEST(
       "signalCount too large");
 }
 
+TEST(
+    MultimemNvlTransportValidationTest,
+    PrimaryCtorRejectsDataBufferAlignmentOverflow) {
+  MultimemNvlTransportConfig config{};
+  config.dataBufferSize = std::numeric_limits<std::size_t>::max();
+  config.userSignalCount = 1;
+  expectRuntimeErrorContains(
+      [&] {
+        MultimemNvlTransport(
+            /*bootstrap=*/nullptr,
+            /*commRank=*/0,
+            /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
+            config);
+      },
+      "dataBufferSize alignment overflows");
+}
+
+TEST(
+    MultimemNvlTransportValidationTest,
+    PrimaryCtorRejectsCombinedAllocationSizeOverflow) {
+  MultimemNvlTransportConfig config{};
+  config.dataBufferSize =
+      std::numeric_limits<std::size_t>::max() - (alignof(SignalState) - 1);
+  config.userSignalCount = 1;
+  expectRuntimeErrorContains(
+      [&] {
+        MultimemNvlTransport(
+            /*bootstrap=*/nullptr,
+            /*commRank=*/0,
+            /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
+            config);
+      },
+      "combined allocation size overflows");
+}
+
 } // namespace comms::prims::tests

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -160,7 +160,11 @@ void MultiPeerTransport::initFromTopology(
         bootstrap_, std::move(localRankToCommRank));
 
     nvlTransport_ = std::make_unique<MultiPeerNvlTransport>(
-        nvlLocalRank_, nvlNRanks_, nvlBootstrapAdapter_, config.nvlConfig);
+        nvlLocalRank_,
+        nvlNRanks_,
+        deviceId_,
+        nvlBootstrapAdapter_,
+        config.nvlConfig);
     VLOG(1) << "MultiPeerTransport: rank " << myRank_
             << " created NVL sub-transport, nvlNRanks=" << nvlNRanks_
             << " nvlLocalRank=" << nvlLocalRank_;
@@ -271,6 +275,28 @@ Transport* /*nullable*/ MultiPeerTransport::get_nvl_transports_array() const {
     return nullptr;
   }
   return nvlTransport_->getDeviceTransports().data();
+}
+
+bool MultiPeerTransport::has_multimem_nvl_transport() const {
+  // nvlTransport_ is legitimately null in normal builds without an NVL domain
+  // (e.g. nRanks == 1), same as get_nvl_transports_array() above; the null
+  // check is not masking an invariant.
+  return nvlTransport_ && nvlTransport_->hasMultimemNvlTransport();
+}
+
+bool MultiPeerTransport::initialize_multimem_nvl_transport() const {
+  return nvlTransport_ &&
+      nvlTransport_->initializeMultimemNvlTransportIfEligible();
+}
+
+MultimemNvlTransportDevice
+MultiPeerTransport::get_multimem_nvl_transport_device() const {
+  // The getter is local after collective initialization succeeds.
+  if (!has_multimem_nvl_transport()) {
+    throw std::runtime_error(
+        "MultiPeerTransport: multimem NVL transport is not initialized");
+  }
+  return nvlTransport_->getMultimemNvlTransportDevice();
 }
 
 P2pSelfTransportDevice MultiPeerTransport::get_p2p_self_transport_device()

--- a/comms/prims/transport/MultiPeerTransport.h
+++ b/comms/prims/transport/MultiPeerTransport.h
@@ -188,6 +188,39 @@ class MultiPeerTransport {
   Transport* /*nullable*/ get_nvl_transports_array() const;
 
   /**
+   * @return True after collective multimem initialization succeeds.
+   *
+   * This is a cached local query and never starts a collective operation.
+   */
+  bool has_multimem_nvl_transport() const;
+
+  /**
+   * Collectively initialize the multimem NVL transport when all ranks are
+   * eligible. Returns false for disabled/ineligible communicators so the
+   * dispatcher can select a fallback algorithm.
+   *
+   * PRECONDITION: all NVL ranks call this in lockstep.
+   * @throws std::runtime_error on bootstrap or multicast setup failure.
+   */
+  bool initialize_multimem_nvl_transport() const;
+
+  /**
+   * Return the device handle for the copy-based (staging) multimem NVL
+   * transport. Delegates to
+   * MultiPeerNvlTransport::getMultimemNvlTransportDevice(). Used by the cnvlmm
+   * staging path.
+   *
+   * Call initialize_multimem_nvl_transport() collectively before this cached
+   * getter. It throws when initialization has not succeeded.
+   *
+   * This getter is local and never touches bootstrap.
+   *
+   * @throws std::runtime_error if no NVL transport, multimem NVL is not
+   * initialized.
+   */
+  MultimemNvlTransportDevice get_multimem_nvl_transport_device() const;
+
+  /**
    * @param globalPeerRank Global rank of the IBGDA peer.
    * @return Non-owning pointer to GPU-allocated P2pIbgdaTransportDevice.
    */

--- a/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
@@ -3,6 +3,9 @@
 #include "comms/prims/transport/nvl/MultiPeerNvlTransport.h"
 
 #include <algorithm>
+#include <cstdio>
+#include <exception>
+#include <optional>
 #include <stdexcept>
 #include <vector>
 
@@ -16,6 +19,68 @@
 namespace comms::prims {
 
 namespace {
+
+constexpr int kMultimemEligibilityError = -1;
+constexpr int kMultimemIneligible = 0;
+constexpr int kMultimemEligible = 1;
+
+class ScopedCudaDevice {
+ public:
+  explicit ScopedCudaDevice(int device) {
+    auto status = cudaGetDevice(&previousDevice_);
+    if (status != cudaSuccess) {
+      throw std::runtime_error(
+          std::string("failed to query current CUDA device: ") +
+          cudaGetErrorString(status));
+    }
+    if (previousDevice_ != device) {
+      status = cudaSetDevice(device);
+      if (status != cudaSuccess) {
+        const auto selectionStatus = status;
+        const auto restoreStatus = cudaSetDevice(previousDevice_);
+        if (restoreStatus != cudaSuccess) {
+          throw std::runtime_error(
+              std::string("failed to select and restore CUDA device: ") +
+              cudaGetErrorString(selectionStatus) + "; " +
+              cudaGetErrorString(restoreStatus));
+        }
+        throw std::runtime_error(
+            std::string("failed to select CUDA device: ") +
+            cudaGetErrorString(selectionStatus));
+      }
+      restore_ = true;
+    }
+  }
+
+  ~ScopedCudaDevice() {
+    if (!restore_) {
+      return;
+    }
+    const auto status = cudaSetDevice(previousDevice_);
+    if (status != cudaSuccess) {
+      std::fprintf(
+          stderr,
+          "ScopedCudaDevice: failed to restore CUDA device %d: %s\n",
+          previousDevice_,
+          cudaGetErrorString(status));
+    }
+  }
+
+  ScopedCudaDevice(const ScopedCudaDevice&) = delete;
+  ScopedCudaDevice& operator=(const ScopedCudaDevice&) = delete;
+  ScopedCudaDevice(ScopedCudaDevice&&) = delete;
+  ScopedCudaDevice& operator=(ScopedCudaDevice&&) = delete;
+
+ private:
+  int previousDevice_{-1};
+  bool restore_{false};
+};
+
+int currentCudaDevice() {
+  int device = -1;
+  CUDA_CHECK(cudaGetDevice(&device));
+  return device;
+}
 
 std::size_t dataBufferSize(const MultiPeerNvlTransportConfig& config) {
   return static_cast<std::size_t>(config.maxNumChannels) *
@@ -70,8 +135,22 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
     int nRanks,
     std::shared_ptr<meta::comms::IBootstrap> bootstrap,
     const MultiPeerNvlTransportConfig& multiPeerNvlTransportConfig)
+    : MultiPeerNvlTransport(
+          myRank,
+          nRanks,
+          currentCudaDevice(),
+          std::move(bootstrap),
+          multiPeerNvlTransportConfig) {}
+
+MultiPeerNvlTransport::MultiPeerNvlTransport(
+    int myRank,
+    int nRanks,
+    int multimemCudaDevice,
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+    const MultiPeerNvlTransportConfig& multiPeerNvlTransportConfig)
     : myRank_(myRank),
       nRanks_(nRanks),
+      multimemCudaDevice_(multimemCudaDevice),
       bootstrap_(std::move(bootstrap)),
       config_(normalizeChannelConfig(multiPeerNvlTransportConfig)),
       memSharingMode_(
@@ -179,6 +258,24 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
   }
 }
 
+MultiPeerNvlTransport::~MultiPeerNvlTransport() {
+  if (!multimemNvlTransport_) {
+    return;
+  }
+  try {
+    ScopedCudaDevice guard(multimemCudaDevice_);
+    multimemNvlTransport_.reset();
+  } catch (const std::exception& error) {
+    std::fprintf(
+        stderr,
+        "MultiPeerNvlTransport: failed to select multimem CUDA device during "
+        "cleanup; leaking the multicast transport to avoid unsafe teardown: "
+        "%s\n",
+        error.what());
+    static_cast<void>(multimemNvlTransport_.release());
+  }
+}
+
 void MultiPeerNvlTransport::setExternalDataBuffers(
     ExternalStagingBuffers externalStagingBuffers) {
   // Validate that the vectors are large enough to index by rank.
@@ -248,8 +345,8 @@ void MultiPeerNvlTransport::exchange() {
   }
 
   // Multimem NVL is intentionally not initialized here. Most collectives only
-  // need the peer-to-peer NVLink transport; multicast setup is deferred until
-  // getMultimemNvlTransportDevice() is called by a multimem collective.
+  // need the peer-to-peer NVLink transport. Multimem collectives invoke the
+  // explicit collective initializer before reading the cached device handle.
 }
 
 P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
@@ -440,29 +537,43 @@ DeviceSpan<Transport> MultiPeerNvlTransport::getDeviceTransports() {
 }
 
 bool MultiPeerNvlTransport::hasMultimemNvlTransport() const {
+  std::lock_guard<std::mutex> lock(multimemInitMutex_);
+  return multimemNvlTransport_ != nullptr;
+}
+
+bool MultiPeerNvlTransport::initializeMultimemNvlTransportIfEligible() const {
   if (!config_.enableMultimem ||
-      multimemNvlUnavailable_.load(std::memory_order_acquire)) {
+      multimemNvlIneligible_.load(std::memory_order_acquire)) {
     return false;
   }
-
-  int cudaDevice = 0;
-  CUDA_CHECK(cudaGetDevice(&cudaDevice));
-  return MultimemNvlTransport::isEligible(nRanks_, cudaDevice);
+  try {
+    initializeMultimemNvlTransport();
+    return true;
+  } catch (...) {
+    if (multimemNvlIneligible_.load(std::memory_order_acquire)) {
+      return false;
+    }
+    throw;
+  }
 }
 
 MultimemNvlTransportDevice
 MultiPeerNvlTransport::getMultimemNvlTransportDevice() const {
-  initializeMultimemNvlTransport();
+  std::lock_guard<std::mutex> lock(multimemInitMutex_);
+  if (!multimemNvlTransport_) {
+    throw std::runtime_error(
+        "MultiPeerNvlTransport: multimem NVL transport is not initialized");
+  }
   return multimemNvlTransport_->getDeviceTransport();
 }
 
 void MultiPeerNvlTransport::initializeMultimemNvlTransport() const {
   // Serialize concurrent same-rank callers so at most one thread drives the
-  // collective (eligibility allGather + MultimemNvlTransport::exchange). If
-  // two threads on this rank both raced past the null-check, each would
-  // enter its own collective while other ranks only participate once,
-  // deadlocking the bootstrap. Second+ arrivals block here, then see the
-  // cached transport (or the poison bit) via the fast paths below.
+  // eligibility agreement, local construction, construction-readiness
+  // agreement, and multicast exchange. If two threads on this rank both raced
+  // past the null-check, each would enter its own collective while other ranks
+  // only participate once, deadlocking the bootstrap. Second+ arrivals block
+  // here, then see the cached transport or terminal state below.
   std::lock_guard<std::mutex> lock(multimemInitMutex_);
 
   if (multimemNvlTransport_) {
@@ -473,48 +584,115 @@ void MultiPeerNvlTransport::initializeMultimemNvlTransport() const {
         "MultiPeerNvlTransport: multimem NVL transport is not enabled "
         "(config.enableMultimem is false)");
   }
-  if (multimemNvlUnavailable_.load(std::memory_order_acquire)) {
+  if (multimemNvlUnavailable_) {
     throw std::runtime_error(
         "MultiPeerNvlTransport: multimem NVL transport is not available: " +
         multimemNvlErrorMessage_);
   }
 
-  int cudaDevice = 0;
-  CUDA_CHECK(cudaGetDevice(&cudaDevice));
   std::vector<int> multimemEligible(nRanks_, 0);
-  multimemEligible[myRank_] =
-      MultimemNvlTransport::isEligible(nRanks_, cudaDevice) ? 1 : 0;
-  auto eligibilityResult =
-      bootstrap_
-          ->allGather(multimemEligible.data(), sizeof(int), myRank_, nRanks_)
-          .get();
-  // Note: allGather-failure is intentionally NOT latched into
-  // multimemNvlUnavailable_. It can be transient (bootstrap glitch, peer
-  // slow-start) and the caller may legitimately want to retry -- the outer
-  // mutex serializes concurrent retries so cross-rank collectives stay
-  // aligned. Eligibility failure, in contrast, is terminal on this comm.
+  std::vector<int> multimemReady(nRanks_, 0);
+  std::optional<ScopedCudaDevice> deviceGuard;
+  // A local CUDA/driver query failure is an error vote, not an early return:
+  // every rank must still enter the allGather so peers cannot hang.
+  try {
+    deviceGuard.emplace(multimemCudaDevice_);
+    multimemEligible[myRank_] =
+        MultimemNvlTransport::isEligible(nRanks_, multimemCudaDevice_)
+        ? kMultimemEligible
+        : kMultimemIneligible;
+  } catch (...) {
+    multimemEligible[myRank_] = kMultimemEligibilityError;
+  }
+  int eligibilityResult = 0;
+  try {
+    eligibilityResult =
+        bootstrap_
+            ->allGather(multimemEligible.data(), sizeof(int), myRank_, nRanks_)
+            .get();
+  } catch (...) {
+    multimemNvlUnavailable_ = true;
+    multimemNvlErrorMessage_ =
+        "multimem NVL transport eligibility allGather threw";
+    throw;
+  }
   if (eligibilityResult != 0) {
+    multimemNvlUnavailable_ = true;
+    multimemNvlErrorMessage_ =
+        "multimem NVL transport eligibility allGather failed";
     throw std::runtime_error(
-        "MultiPeerNvlTransport: multimem eligibility allGather failed");
+        "MultiPeerNvlTransport: " + multimemNvlErrorMessage_);
+  }
+  if (std::any_of(
+          multimemEligible.begin(), multimemEligible.end(), [](int value) {
+            return value == kMultimemEligibilityError;
+          })) {
+    multimemNvlUnavailable_ = true;
+    multimemNvlErrorMessage_ =
+        "multimem NVL transport eligibility query failed on at least one rank";
+    throw std::runtime_error(
+        "MultiPeerNvlTransport: " + multimemNvlErrorMessage_);
   }
   if (!std::all_of(
           multimemEligible.begin(), multimemEligible.end(), [](int value) {
-            return value != 0;
+            return value == kMultimemEligible;
           })) {
+    multimemNvlIneligible_.store(true, std::memory_order_release);
+    multimemNvlUnavailable_ = true;
     multimemNvlErrorMessage_ =
         "multimem NVL transport is not eligible on all ranks";
-    multimemNvlUnavailable_.store(true, std::memory_order_release);
     throw std::runtime_error(
         "MultiPeerNvlTransport: " + multimemNvlErrorMessage_);
   }
 
-  auto multimemNvlTransport = std::make_unique<MultimemNvlTransport>(
-      myRank_, nRanks_, bootstrap_, config_.multimem);
+  std::unique_ptr<MultimemNvlTransport> multimemNvlTransport;
+  std::exception_ptr constructionError;
+  try {
+    multimemNvlTransport = std::make_unique<MultimemNvlTransport>(
+        myRank_, nRanks_, bootstrap_, config_.multimem);
+    multimemReady[myRank_] = 1;
+  } catch (...) {
+    constructionError = std::current_exception();
+  }
+
+  int readinessResult = 0;
+  try {
+    readinessResult =
+        bootstrap_
+            ->allGather(multimemReady.data(), sizeof(int), myRank_, nRanks_)
+            .get();
+  } catch (...) {
+    multimemNvlUnavailable_ = true;
+    multimemNvlErrorMessage_ =
+        "multimem NVL transport construction allGather threw";
+    throw;
+  }
+  if (readinessResult != 0) {
+    multimemNvlUnavailable_ = true;
+    multimemNvlErrorMessage_ =
+        "multimem NVL transport construction allGather failed";
+    throw std::runtime_error(
+        "MultiPeerNvlTransport: " + multimemNvlErrorMessage_);
+  }
+  if (!std::all_of(multimemReady.begin(), multimemReady.end(), [](int value) {
+        return value != 0;
+      })) {
+    multimemNvlUnavailable_ = true;
+    multimemNvlErrorMessage_ =
+        "multimem NVL transport construction failed on at least one rank";
+    if (constructionError) {
+      std::rethrow_exception(constructionError);
+    }
+    throw std::runtime_error(
+        "MultiPeerNvlTransport: " + multimemNvlErrorMessage_);
+  }
+
   // Unlike the eligibility allGather above, exchange() is a cross-rank
   // collective that can partially succeed on peers before it throws locally; a
   // retry would re-enter a collective the other ranks have already moved past,
   // risking desync/hang. So an exchange() failure is terminal: latch the poison
-  // bit before rethrowing so future callers fall back instead of retrying.
+  // bit before rethrowing so future callers throw the cached failure instead
+  // of retrying.
   try {
     multimemNvlTransport->exchange();
   } catch (const std::exception& e) {
@@ -522,9 +700,14 @@ void MultiPeerNvlTransport::initializeMultimemNvlTransport() const {
     // concatenation can throw (bad_alloc), and if the poison store were skipped
     // a later caller would retry the already-partially-run collective and risk
     // cross-rank desync.
-    multimemNvlUnavailable_.store(true, std::memory_order_release);
+    multimemNvlUnavailable_ = true;
     multimemNvlErrorMessage_ =
         std::string("multimem NVL transport exchange failed: ") + e.what();
+    throw;
+  } catch (...) {
+    multimemNvlUnavailable_ = true;
+    multimemNvlErrorMessage_ =
+        "multimem NVL transport exchange failed with a non-standard exception";
     throw;
   }
   multimemNvlTransport_ = std::move(multimemNvlTransport);

--- a/comms/prims/transport/nvl/MultiPeerNvlTransport.h
+++ b/comms/prims/transport/nvl/MultiPeerNvlTransport.h
@@ -87,11 +87,9 @@ struct MultiPeerNvlTransportConfig {
   std::optional<MemSharingMode> memSharingMode;
 
   // NVLS multicast: when true, the transport composes an internal
-  // MultimemNvlTransport (from `multimem` below) and reports it via
-  // hasMultimemNvlTransport(). The actual multicast setup runs lazily on the
-  // first getMultimemNvlTransportDevice() call, and only when the device
-  // supports multimem and the NVL team has more than two ranks. `multimem` is
-  // ignored unless `enableMultimem` is true.
+  // MultimemNvlTransport (from `multimem` below). Collective callers should
+  // use initializeMultimemNvlTransportIfEligible() before querying or fetching
+  // it. `multimem` is ignored unless `enableMultimem` is true.
   bool enableMultimem{false};
   MultimemNvlTransportConfig multimem;
 };
@@ -202,11 +200,36 @@ class MultiPeerNvlTransport {
       const MultiPeerNvlTransportConfig& multiPeerNvlTransportConfig);
 
   /**
+   * Constructor with an explicit device for lazy multicast initialization.
+   *
+   * `multimemCudaDevice` is used only for multicast eligibility checks,
+   * construction, and teardown. Base P2P resources retain the existing
+   * contract that the caller makes their owning device current before
+   * construction and destruction.
+   *
+   * @param myRank This rank's ID in the communicator (0 to nRanks-1)
+   * @param nRanks Total number of ranks in the communicator
+   * @param multimemCudaDevice Valid CUDA device ordinal for this rank's lazy
+   * multicast resources
+   * @param bootstrap Bootstrap interface for collective handle exchange
+   * @param multiPeerNvlTransportConfig Buffer configuration (must match across
+   * all ranks)
+   *
+   * @throws std::runtime_error if buffer allocation fails
+   */
+  MultiPeerNvlTransport(
+      int myRank,
+      int nRanks,
+      int multimemCudaDevice,
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+      const MultiPeerNvlTransportConfig& multiPeerNvlTransportConfig);
+
+  /**
    * Destructor - Clean up CUDA resources
    *
    * Frees device memory allocated for Transport array.
    */
-  ~MultiPeerNvlTransport() = default;
+  ~MultiPeerNvlTransport();
 
   /**
    * setExternalDataBuffers - Provide pre-exchanged data buffers
@@ -241,9 +264,9 @@ class MultiPeerNvlTransport {
    *    preallocated device array (allocated in constructor)
    * 3. Implicit barrier ensures all ranks complete before returning
    *
-   * Optional multimem NVL setup is not performed here; it is a separate
-   * collective operation triggered by getMultimemNvlTransportDevice() so
-   * non-multimem collectives do not pay the multicast allocation cost.
+   * Optional multimem NVL setup is not performed here. Multimem collectives
+   * call initializeMultimemNvlTransportIfEligible() in lockstep so other
+   * collectives do not pay the multicast allocation cost.
    *
    * The type of handle (fabric or cudaIpc) depends on the automatically
    * detected memory sharing mode.
@@ -323,18 +346,25 @@ class MultiPeerNvlTransport {
    */
   DeviceSpan<Transport> getDeviceTransports();
 
-  // Cheap local check for whether multimem NVL was configured and appears
-  // usable on this rank. This does not perform the collective multimem setup;
-  // the first getMultimemNvlTransportDevice() call initializes it lazily.
+  // Cheap local check for a successfully initialized multimem NVL transport.
+  // It is false until initializeMultimemNvlTransportIfEligible() collectively
+  // establishes communicator-wide eligibility and completes setup.
   bool hasMultimemNvlTransport() const;
 
   /**
-   * getMultimemNvlTransportDevice - Get the lazily initialized NVLS device
-   * transport.
+   * Collectively initialize multimem NVL when every rank is eligible.
    *
-   * PRECONDITION: All ranks that may use this multimem collective must call
-   * this method in the same order. The first call performs a collective
-   * eligibility check, multicast memory setup, and exchange.
+   * @return true after successful initialization, or false when multimem is
+   * disabled or any rank is ineligible. Setup failures throw and are cached as
+   * terminal errors. All ranks in the NVL team must call this in lockstep.
+   */
+  bool initializeMultimemNvlTransportIfEligible() const;
+
+  /**
+   * Get the cached NVLS device transport after successful initialization.
+   *
+   * This is a local operation and never touches bootstrap.
+   * PRECONDITION: initializeMultimemNvlTransportIfEligible() returned true.
    */
   MultimemNvlTransportDevice getMultimemNvlTransportDevice() const;
 
@@ -377,6 +407,7 @@ class MultiPeerNvlTransport {
 
   const int myRank_{-1};
   const int nRanks_{-1};
+  const int multimemCudaDevice_{-1};
   std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
   const MultiPeerNvlTransportConfig config_;
 
@@ -394,24 +425,26 @@ class MultiPeerNvlTransport {
       llBufferHandler_; // nullptr when llBufferSize == 0
   mutable std::unique_ptr<MultimemNvlTransport> multimemNvlTransport_;
   // Latched to true when we know multimem NVL cannot succeed on this comm:
-  // eligibility failed on some rank, or the multicast handle exchange() failed.
-  // Terminal -- subsequent calls throw the cached reason from
-  // `multimemNvlErrorMessage_` without re-attempting the collective. The
-  // eligibility allGather returning non-zero is intentionally NOT latched (it
-  // can be transient and is retry-safe) so callers can retry.
-  // `std::atomic` because `hasMultimemNvlTransport()` reads it on the fast path
-  // without holding `multimemInitMutex_`, while the init path stores under it.
-  mutable std::atomic<bool> multimemNvlUnavailable_{false};
-  // Preserved reason for the terminal-failure throw so debuggers see the
-  // original cause (e.g. "not eligible on all ranks") on every subsequent
-  // call, not a generic "not available".
+  // eligibility or local construction failed on some rank, the construction
+  // readiness agreement failed, or the multicast exchange failed.
+  // All listed outcomes prohibit retry. Eligibility rejection is a cached
+  // fallback that returns false; setup failures throw the cached reason from
+  // `multimemNvlErrorMessage_`.
+  // Protected by `multimemInitMutex_`.
+  mutable bool multimemNvlUnavailable_{false};
+  // Separates normal eligibility rejection (algorithm fallback) from a setup
+  // failure, which remains an error and must not be retried.
+  mutable std::atomic<bool> multimemNvlIneligible_{false};
+  // Preserved diagnostic for either terminal eligibility fallback or setup
+  // failure. Setup failures reuse it for subsequent throws instead of
+  // reporting a generic "not available" error.
   mutable std::string multimemNvlErrorMessage_;
   // Guards `initializeMultimemNvlTransport()` against concurrent callers on
-  // the same rank: only one thread performs the eligibility allGather +
-  // multimem exchange; other concurrent threads block and use the cached
-  // result. Without this, two same-rank threads could each drive an
-  // allGather while other ranks only participate once, deadlocking the
-  // collective.
+  // the same rank: only one thread performs the eligibility agreement, local
+  // construction, construction-readiness agreement, and multicast exchange.
+  // Other concurrent threads block and use the cached result. Without this,
+  // two same-rank threads could each drive an allGather while other ranks only
+  // participate once, deadlocking the collective.
   mutable std::mutex multimemInitMutex_;
 
   // External data buffer pointers (set via setExternalDataBuffers()).

--- a/comms/prims/transport/nvl/MultimemNvlReduce.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlReduce.cuh
@@ -1,0 +1,321 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// multimem.ld_reduce load-reduce primitives for single-NVL-domain collectives.
+//
+// Holds the reduce side of the NVLS staging model: the raw `multimem.ld_reduce`
+// PTX emitters (`comms::prims::detail`) and the public entry point
+// `multimem::load_reduce_at<>` that reads the cross-rank reduction of a
+// multicast VA into a local buffer. The store side (`multimem::store()`) and
+// the staging orchestration that composes both land later in the stack
+// (`MultimemNvlStore.cuh`, `MultimemNvlStaging.cuh`).
+
+// clang-tidy analyzes this .cuh as a standalone main file and misflags the
+// pragma; it is a genuine include-once header. False positive, so suppress it.
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#if defined(ENABLE_PRIMS)
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
+
+// PTX helpers extend the transport header's existing `comms::prims::detail`
+// namespace. The public free-function entry point (`load_reduce_at<>`) lives in
+// `comms::prims::multimem` further below and delegates into `detail::` for the
+// raw PTX.
+namespace comms::prims::detail {
+
+// ----------------------------------------------------------------------------
+// multimem.ld_reduce load-reduce helpers (relaxed.sys, data-path).
+// ----------------------------------------------------------------------------
+
+// Typed multimem load-reduce ops (relaxed.sys). These are the `.ld_reduce`
+// data peers of the `.st` store helpers alongside the signal-path emitters
+// (`multimem_store_release_sys_u64` / `multimem_red_release_sys_add_u64` in
+// MultimemNvlTransportDevice.cuh); those stay release.sys because they carry
+// the producer/consumer handshake, while these are relaxed.sys since for bulk
+// data the ordering is established by the signal that follows the data op.
+// Only the add reduction is implemented today; widen with a template/op
+// parameter later.
+
+__device__ __forceinline__ float multimem_ld_reduce_f32(const float* src) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  float v;
+  asm volatile("multimem.ld_reduce.relaxed.sys.global.add.f32 %0, [%1];"
+               : "=f"(v)
+               : "l"(__cvta_generic_to_global(src))
+               : "memory");
+  return v;
+#elif defined(__CUDA_ARCH__)
+  __trap();
+#endif
+  return {};
+}
+
+// Integer add reduction. NVLS has no 128-bit (v4) integer ld_reduce, so this is
+// scalar-only (one .add.s32 per element) -- there is no v4 int fast path.
+__device__ __forceinline__ int32_t multimem_ld_reduce_s32(const int32_t* src) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  int32_t v;
+  asm volatile("multimem.ld_reduce.relaxed.sys.global.add.s32 %0, [%1];"
+               : "=r"(v)
+               : "l"(__cvta_generic_to_global(src))
+               : "memory");
+  return v;
+#elif defined(__CUDA_ARCH__)
+  __trap();
+#endif
+  return {};
+}
+
+__device__ __forceinline__ float4 multimem_ld_reduce_v4_f32(const float4* src) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  float4 v;
+  asm volatile(
+      "multimem.ld_reduce.relaxed.sys.global.add.v4.f32 {%0,%1,%2,%3}, [%4];"
+      : "=f"(v.x), "=f"(v.y), "=f"(v.z), "=f"(v.w)
+      : "l"(__cvta_generic_to_global(src))
+      : "memory");
+  return v;
+#elif defined(__CUDA_ARCH__)
+  __trap();
+#endif
+  return {};
+}
+
+// 128-bit (v4) half reduction: one multimem.ld_reduce returns the cross-rank
+// sum of 8 halves (4 packed f16x2). 16 B/op vs the 4 B/op of the scalar-pair
+// f16x2 path, matching the float v4.f32 width. kAccF32 selects f32 accumulation
+// (`.acc::f32`, the default) vs native 2-byte accumulation.
+template <bool kAccF32 = true>
+__device__ __forceinline__ uint4 multimem_ld_reduce_v4_f16x2(const uint4* src) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900 && CUDART_VERSION >= 12020
+  uint4 v;
+  if constexpr (kAccF32) {
+    asm volatile(
+        "multimem.ld_reduce.relaxed.sys.global.add.acc::f32.v4.f16x2 "
+        "{%0,%1,%2,%3}, [%4];"
+        : "=r"(v.x), "=r"(v.y), "=r"(v.z), "=r"(v.w)
+        : "l"(__cvta_generic_to_global(src))
+        : "memory");
+  } else {
+    asm volatile(
+        "multimem.ld_reduce.relaxed.sys.global.add.v4.f16x2 "
+        "{%0,%1,%2,%3}, [%4];"
+        : "=r"(v.x), "=r"(v.y), "=r"(v.z), "=r"(v.w)
+        : "l"(__cvta_generic_to_global(src))
+        : "memory");
+  }
+  return v;
+#elif defined(__CUDA_ARCH__)
+  __trap();
+#endif
+  return {};
+}
+
+// Reduce-load a single half: `multimem.ld_reduce.f16x2` needs a 4-byte aligned
+// address, so read the aligned pair containing `src` and pick the requested
+// lane. Safe for any alignment of `src`.
+template <bool kAccF32 = true>
+__device__ __forceinline__ __half multimem_ld_reduce_f16(const __half* src) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900 && CUDART_VERSION >= 12020
+  const uintptr_t genericAddr = reinterpret_cast<uintptr_t>(src);
+  const uintptr_t globalAddr =
+      static_cast<uintptr_t>(__cvta_generic_to_global(src));
+  const uintptr_t alignedGlobalAddr = globalAddr & ~uintptr_t{0x3};
+  uint32_t raw;
+  if constexpr (kAccF32) {
+    asm volatile(
+        "multimem.ld_reduce.relaxed.sys.global.add.acc::f32.f16x2 %0, [%1];"
+        : "=r"(raw)
+        : "l"(alignedGlobalAddr)
+        : "memory");
+  } else {
+    asm volatile("multimem.ld_reduce.relaxed.sys.global.add.f16x2 %0, [%1];"
+                 : "=r"(raw)
+                 : "l"(alignedGlobalAddr)
+                 : "memory");
+  }
+  union {
+    uint32_t r;
+    __half h[2];
+  } u{raw};
+  return u.h[(genericAddr / sizeof(__half)) & 0x1];
+#elif defined(__CUDA_ARCH__)
+  __trap();
+#endif
+  return {};
+}
+
+// bf16 mirrors the f16 emitters above: same widths and .acc::f32 accumulation,
+// with the `.bf16x2` packed-type variant of each multimem verb. bf16 is the
+// dominant ML training dtype.
+
+// 128-bit (v4) bf16 reduction: one multimem.ld_reduce returns the cross-rank
+// sum of 8 bf16 (4 packed bf16x2) with f32 accumulation. 16 B/op, matching
+// v4.f16x2.
+template <bool kAccF32 = true>
+__device__ __forceinline__ uint4
+multimem_ld_reduce_v4_bf16x2(const uint4* src) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900 && CUDART_VERSION >= 12020
+  uint4 v;
+  if constexpr (kAccF32) {
+    asm volatile(
+        "multimem.ld_reduce.relaxed.sys.global.add.acc::f32.v4.bf16x2 "
+        "{%0,%1,%2,%3}, [%4];"
+        : "=r"(v.x), "=r"(v.y), "=r"(v.z), "=r"(v.w)
+        : "l"(__cvta_generic_to_global(src))
+        : "memory");
+  } else {
+    asm volatile(
+        "multimem.ld_reduce.relaxed.sys.global.add.v4.bf16x2 "
+        "{%0,%1,%2,%3}, [%4];"
+        : "=r"(v.x), "=r"(v.y), "=r"(v.z), "=r"(v.w)
+        : "l"(__cvta_generic_to_global(src))
+        : "memory");
+  }
+  return v;
+#elif defined(__CUDA_ARCH__)
+  __trap();
+#endif
+  return {};
+}
+
+// Reduce-load a single bf16: `multimem.ld_reduce.bf16x2` needs a 4-byte aligned
+// address, so read the aligned pair containing `src` and pick the requested
+// lane. Safe for any alignment of `src`.
+template <bool kAccF32 = true>
+__device__ __forceinline__ __nv_bfloat16
+multimem_ld_reduce_bf16(const __nv_bfloat16* src) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900 && CUDART_VERSION >= 12020
+  const uintptr_t genericAddr = reinterpret_cast<uintptr_t>(src);
+  const uintptr_t globalAddr =
+      static_cast<uintptr_t>(__cvta_generic_to_global(src));
+  const uintptr_t alignedGlobalAddr = globalAddr & ~uintptr_t{0x3};
+  uint32_t raw;
+  if constexpr (kAccF32) {
+    asm volatile(
+        "multimem.ld_reduce.relaxed.sys.global.add.acc::f32.bf16x2 %0, [%1];"
+        : "=r"(raw)
+        : "l"(alignedGlobalAddr)
+        : "memory");
+  } else {
+    asm volatile("multimem.ld_reduce.relaxed.sys.global.add.bf16x2 %0, [%1];"
+                 : "=r"(raw)
+                 : "l"(alignedGlobalAddr)
+                 : "memory");
+  }
+  union {
+    uint32_t r;
+    __nv_bfloat16 b[2];
+  } u{raw};
+  return u.b[(genericAddr / sizeof(__nv_bfloat16)) & 0x1];
+#elif defined(__CUDA_ARCH__)
+  __trap();
+#endif
+  return {};
+}
+
+} // namespace comms::prims::detail
+
+namespace comms::prims::multimem {
+
+/** Reduction operator for the multimem data reduce verbs. Only Add today. */
+enum class MultimemRedOp { Add };
+
+/**
+ * multimem.ld_reduce from an ARBITRARY multicast base pointer into `dst`.
+ *
+ * `mc` must point into a multicast VA; `dst` is local. Staging callers combine
+ * this with `transport.multimem_data_ptr(offset)`. Uses typed dispatch and a
+ * 16-byte fast path when the pointers are jointly aligned.
+ */
+template <
+    typename T,
+    MultimemRedOp Op = MultimemRedOp::Add,
+    bool kAccF32 = true>
+__device__ __forceinline__ void load_reduce_at(
+    comms::prims::ThreadGroup& group,
+    T* dst,
+    const T* mc,
+    std::size_t elems) {
+  static_assert(
+      Op == MultimemRedOp::Add,
+      "multimem load_reduce_at: only Add implemented");
+  const std::size_t stride = group.group_size;
+  const std::size_t t0 = group.thread_id_in_group;
+  const uintptr_t addrOr =
+      reinterpret_cast<uintptr_t>(mc) | reinterpret_cast<uintptr_t>(dst);
+  auto vec_loop = [&](auto* dstVec, std::size_t vecCount, auto load_pack) {
+    for (std::size_t i = t0; i < vecCount; i += stride) {
+      dstVec[i] = load_pack(i);
+    }
+  };
+
+  if constexpr (std::is_same_v<T, float>) {
+    if ((addrOr & 0xF) == 0) {
+      const std::size_t vec = elems / 4;
+      const auto* mcVec = reinterpret_cast<const float4*>(mc);
+      vec_loop(reinterpret_cast<float4*>(dst), vec, [&](std::size_t k) {
+        return comms::prims::detail::multimem_ld_reduce_v4_f32(mcVec + k);
+      });
+      for (std::size_t j = vec * 4 + t0; j < elems; j += stride) {
+        dst[j] = comms::prims::detail::multimem_ld_reduce_f32(mc + j);
+      }
+    } else {
+      for (std::size_t i = t0; i < elems; i += stride) {
+        dst[i] = comms::prims::detail::multimem_ld_reduce_f32(mc + i);
+      }
+    }
+  } else if constexpr (std::is_same_v<T, __half>) {
+    if ((addrOr & 0xF) == 0) {
+      const std::size_t vec = elems / 8;
+      const auto* mcVec = reinterpret_cast<const uint4*>(mc);
+      vec_loop(reinterpret_cast<uint4*>(dst), vec, [&](std::size_t k) {
+        return comms::prims::detail::multimem_ld_reduce_v4_f16x2<kAccF32>(
+            mcVec + k);
+      });
+      for (std::size_t j = vec * 8 + t0; j < elems; j += stride) {
+        dst[j] = comms::prims::detail::multimem_ld_reduce_f16<kAccF32>(mc + j);
+      }
+    } else {
+      for (std::size_t i = t0; i < elems; i += stride) {
+        dst[i] = comms::prims::detail::multimem_ld_reduce_f16<kAccF32>(mc + i);
+      }
+    }
+  } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    if ((addrOr & 0xF) == 0) {
+      const std::size_t vec = elems / 8;
+      const auto* mcVec = reinterpret_cast<const uint4*>(mc);
+      vec_loop(reinterpret_cast<uint4*>(dst), vec, [&](std::size_t k) {
+        return comms::prims::detail::multimem_ld_reduce_v4_bf16x2<kAccF32>(
+            mcVec + k);
+      });
+      for (std::size_t j = vec * 8 + t0; j < elems; j += stride) {
+        dst[j] = comms::prims::detail::multimem_ld_reduce_bf16<kAccF32>(mc + j);
+      }
+    } else {
+      for (std::size_t i = t0; i < elems; i += stride) {
+        dst[i] = comms::prims::detail::multimem_ld_reduce_bf16<kAccF32>(mc + i);
+      }
+    }
+  } else if constexpr (std::is_same_v<T, int32_t>) {
+    for (std::size_t i = t0; i < elems; i += stride) {
+      dst[i] = comms::prims::detail::multimem_ld_reduce_s32(mc + i);
+    }
+  } else {
+    static_assert(
+        sizeof(T) == 0, "multimem load_reduce_at: unsupported element type");
+  }
+}
+
+} // namespace comms::prims::multimem
+
+#endif // ENABLE_PRIMS

--- a/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
@@ -1,0 +1,206 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Staging-window layout + signal-slot addressing for single-NVL-domain
+// collectives.
+//
+// Shared infrastructure used by all three staging paths (ReduceScatter /
+// AllGather / AllReduce): the per-CTA staging-window geometry (`StageLayout` /
+// `make_stage_layout`) and the internal-signal slot-id helpers (ready/ack
+// per-peer SET slots and the staging ADD barrier slots). It depends only on the
+// transport struct in MultimemNvlTransportDevice.cuh, not on the reduce/store
+// PTX.
+
+// clang-tidy analyzes this .cuh as a standalone main file and misflags the
+// pragma; it is a genuine include-once header. False positive, so suppress it.
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#if defined(ENABLE_PRIMS)
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
+
+namespace comms::prims::multimem {
+
+namespace detail {
+
+__device__ __forceinline__ uint64_t
+checked_signal_product(uint64_t lhs, uint64_t rhs) {
+  if (lhs != 0 && rhs > ~uint64_t{0} / lhs) {
+#if defined(__CUDA_ARCH__)
+    printf(
+        "NvlMultimem signal layout overflow: %llu * %llu\n",
+        static_cast<unsigned long long>(lhs),
+        static_cast<unsigned long long>(rhs));
+    __trap();
+#endif
+    return 0;
+  }
+  return lhs * rhs;
+}
+
+} // namespace detail
+
+/**
+ * Layout of one CTA-group's slice of the shared staging window.
+ *
+ * The flat per-rank data buffer is split across CTAs (groups), and each group's
+ * slice is further split into `pipelineDepth` lanes. A round picks its lane
+ * round-robin so consecutive rounds use disjoint physical windows (pipelining).
+ */
+struct StageLayout {
+  std::size_t groupBeginBytes{0}; // this group's slice origin into the buffer
+  std::size_t stagingElems{0}; // one lane window, in elements
+  std::size_t stagingBytes{0}; // one lane window, in bytes
+  uint64_t signalBase{0}; // this group's base into the internal signals
+  uint64_t signalsPerLane{0}; // 2 * nvlRanks + 4
+  uint32_t pipelineDepth{1};
+};
+
+template <typename T>
+__device__ __forceinline__ StageLayout make_stage_layout(
+    const comms::prims::MultimemNvlTransportDevice& transport,
+    uint32_t pipelineDepth,
+    comms::prims::ThreadGroup& group) {
+  if (pipelineDepth == 0) {
+    pipelineDepth = 1;
+  }
+
+  // 16-byte (uint4) alignment for every staging-window slice, so the per-rank
+  // lane offsets are 128-bit aligned and the v4 multimem.ld_reduce / store fast
+  // paths engage for all element types (not just when offsets happen to land on
+  // 16B). The backing buffer base is already page-aligned.
+  const std::size_t alignBytes = sizeof(T) < 16 ? 16 : sizeof(T);
+  const std::size_t elemsPerAlign = alignBytes / sizeof(T);
+  const std::size_t totalUnits = transport.dataBufferSize / alignBytes;
+
+#if defined(__CUDA_ARCH__)
+  if (transport.localData == nullptr || transport.multimemData == nullptr) {
+    printf("NvlMultimem transport has null data pointers\n");
+    __trap();
+  }
+  // Trap before total_groups is used as a divisor below (division by zero is UB
+  // and would happen strictly before the stagingUnits guard could catch it).
+  if (group.total_groups == 0 || group.group_id >= group.total_groups) {
+    printf(
+        "NvlMultimem staging layout: invalid group_id=%u total_groups=%u\n",
+        static_cast<unsigned>(group.group_id),
+        static_cast<unsigned>(group.total_groups));
+    __trap();
+  }
+#endif
+
+  const std::size_t totalGroups = group.total_groups;
+  const std::size_t groupId = group.group_id;
+  const std::size_t unitsPerGroup = totalUnits / totalGroups;
+  const std::size_t extraUnits = totalUnits % totalGroups;
+  const std::size_t groupBeginUnit =
+      unitsPerGroup * groupId + (groupId < extraUnits ? groupId : extraUnits);
+  const std::size_t groupUnits =
+      unitsPerGroup + static_cast<std::size_t>(groupId < extraUnits);
+  const std::size_t stagingUnits =
+      groupUnits / static_cast<std::size_t>(pipelineDepth);
+
+#if defined(__CUDA_ARCH__)
+  if (stagingUnits == 0) {
+    printf(
+        "NvlMultimem staging window too small: dataBufferSize=%llu "
+        "groups=%u pipelineDepth=%u alignBytes=%llu\n",
+        static_cast<unsigned long long>(transport.dataBufferSize),
+        static_cast<unsigned>(group.total_groups),
+        static_cast<unsigned>(pipelineDepth),
+        static_cast<unsigned long long>(alignBytes));
+    __trap();
+  }
+#endif
+
+  // Layout per (group, lane):
+  //   [0, nvlRanks)             ready[rank]           (SET, per-peer)
+  //   [nvlRanks, 2*nvlRanks)    ack[rank]             (SET, per-peer)
+  //   2*nvlRanks + 0            staging_ready_counter (ADD, multicast)
+  //   2*nvlRanks + 1            staging_ready_epoch   (ADD, this rank baseline)
+  //   2*nvlRanks + 2            staging_ack_counter   (ADD, multicast)
+  //   2*nvlRanks + 3            staging_ack_epoch     (ADD, this rank baseline)
+  // The four ADD-mode barrier slots MUST live outside the SET-mode ready/ack
+  // region: without this separation, flipping stagingArrivalBarrier between ops
+  // in a single process leaves ADD counter residue in slots that a later
+  // SET-mode op reads with CMP_GE, and any past-op residue trivially satisfies
+  // the wait.
+#if defined(__CUDA_ARCH__)
+  if (transport.nvlRanks <= 0 ||
+      static_cast<uint64_t>(transport.nvlRanks) >
+          (static_cast<uint64_t>(~uint32_t{0}) - 4) / 2) {
+    printf(
+        "NvlMultimem staging layout: invalid nvlRanks=%d\n",
+        transport.nvlRanks);
+    __trap();
+  }
+#endif
+  const uint64_t signalsPerLane = multimem_staging_signals_per_lane(
+      static_cast<uint32_t>(transport.nvlRanks));
+  const uint64_t signalsPerGroup = detail::checked_signal_product(
+      static_cast<uint64_t>(pipelineDepth), signalsPerLane);
+  const uint64_t requiredSignals = detail::checked_signal_product(
+      static_cast<uint64_t>(group.total_groups), signalsPerGroup);
+#if defined(__CUDA_ARCH__)
+  if (requiredSignals > transport.internalLocalSignals.size()) {
+    printf(
+        "NvlMultimem requires %llu internal signals "
+        "(available=%u, groups=%u, pipelineDepth=%u, nvlRanks=%d)\n",
+        static_cast<unsigned long long>(requiredSignals),
+        static_cast<unsigned>(transport.internalLocalSignals.size()),
+        static_cast<unsigned>(group.total_groups),
+        static_cast<unsigned>(pipelineDepth),
+        transport.nvlRanks);
+    __trap();
+  }
+#endif
+
+  return StageLayout{
+      .groupBeginBytes = groupBeginUnit * alignBytes,
+      .stagingElems = stagingUnits * elemsPerAlign,
+      .stagingBytes = stagingUnits * alignBytes,
+      .signalBase = detail::checked_signal_product(
+          static_cast<uint64_t>(group.group_id), signalsPerGroup),
+      .signalsPerLane = signalsPerLane,
+      .pipelineDepth = pipelineDepth,
+  };
+}
+
+__device__ __forceinline__ uint64_t
+ready_signal_id(const StageLayout& layout, uint32_t lane, int rank) {
+  return layout.signalBase +
+      static_cast<uint64_t>(lane) * layout.signalsPerLane +
+      static_cast<uint64_t>(rank);
+}
+
+__device__ __forceinline__ uint64_t ack_signal_id(
+    const StageLayout& layout,
+    uint32_t lane,
+    int nvlRanks,
+    int rank) {
+  return layout.signalBase +
+      static_cast<uint64_t>(lane) * layout.signalsPerLane +
+      static_cast<uint64_t>(nvlRanks + rank);
+}
+
+__device__ __forceinline__ uint64_t
+round_id(uint64_t roundBase, uint64_t primitiveRound) {
+  return roundBase + primitiveRound + 1;
+}
+
+__device__ __forceinline__ std::size_t lane_begin(
+    const StageLayout& layout,
+    uint64_t primitiveRound) {
+  const uint32_t lane =
+      static_cast<uint32_t>(primitiveRound % layout.pipelineDepth);
+  return layout.groupBeginBytes +
+      static_cast<std::size_t>(lane) * layout.stagingBytes;
+}
+
+} // namespace comms::prims::multimem
+
+#endif // ENABLE_PRIMS

--- a/comms/prims/transport/nvl/MultimemNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.cc
@@ -107,14 +107,33 @@ MultimemNvlTransport::MultimemNvlTransport(
       break;
     }
   }
+  // Defensive backstop for the validateRankMap invariant: a -1 here would flow
+  // into device-side signal-slot indexing and produce out-of-bounds offsets, so
+  // fail loudly rather than corrupt memory if the map ever omits this rank.
+  if (nvlRank < 0) {
+    throw std::runtime_error(
+        "MultimemNvlTransport: commRank not found in nvlRankToCommRank_");
+  }
+  nvlRank_ = nvlRank;
 
-  cudaDevice_ = getCurrentCudaDevice();
-
+  constexpr std::size_t kSignalAlignment = alignof(SignalState);
+  if (config_.dataBufferSize >
+      std::numeric_limits<std::size_t>::max() - (kSignalAlignment - 1)) {
+    throw std::runtime_error(
+        "MultimemNvlTransport: dataBufferSize alignment overflows");
+  }
   signalRegionOffset_ =
-      comms::bitops::alignUp(config_.dataBufferSize, alignof(SignalState));
+      comms::bitops::alignUp(config_.dataBufferSize, kSignalAlignment);
   const std::size_t signalRegionBytes =
       getSignalBufferSize(static_cast<int>(totalSignalCount));
+  if (signalRegionOffset_ >
+      std::numeric_limits<std::size_t>::max() - signalRegionBytes) {
+    throw std::runtime_error(
+        "MultimemNvlTransport: combined allocation size overflows");
+  }
   const std::size_t combinedSize = signalRegionOffset_ + signalRegionBytes;
+
+  cudaDevice_ = getCurrentCudaDevice();
 
   // The GpuMemHandler owns the unicast backing; exchange() adds the multicast
   // overlay over it. Size the allocation to the multicast granularity
@@ -217,6 +236,8 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
       .internalMultimemSignals = DeviceSpan<SignalState>(
           multimemSignals + userSignalCount, internalSignalCount),
       .dataBufferSize = config_.dataBufferSize,
+      .nvlRank = nvlRank_,
+      .nvlRanks = nvlRanks_,
   };
 }
 

--- a/comms/prims/transport/nvl/MultimemNvlTransport.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.h
@@ -99,6 +99,10 @@ class MultimemNvlTransport {
  private:
   const int commRank_{-1};
   const int nvlRanks_{-1};
+  // This rank's index within the NVL team (its position in nvlRankToCommRank_).
+  // Retained so getDeviceTransport() can expose it to the device staging
+  // protocol, which keys its per-rank signal slots on the NVL-local rank.
+  int nvlRank_{-1};
   const std::vector<int> nvlRankToCommRank_;
   // Recorded after the rank-map validation in the constructor body so a bad
   // topology fails before cudaGetDevice is consulted (lets tests cover the

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -16,15 +16,15 @@
 namespace comms::prims {
 
 // Per-lane internal-signal count for the staging pipeline: the single source of
-// truth shared by the host-side signal-region sizing (CtranPipes) and the
+// truth shared by the host-side signal-region sizing (MCCL) and the
 // device-side `make_stage_layout` (MultimemNvlStageLayout.cuh) so the region is
 // sized identically on both sides. Layout per lane: `nvlRanks` per-peer ready[]
 // + `nvlRanks` per-peer ack[] + 4 staging arrival-barrier slots (ready/ack
 // counter+epoch, laid out past the SET-mode slots so ADD residue never
 // contaminates a later SET-mode CMP_GE wait) => 2 * nvlRanks + 4.
 __host__ __device__ constexpr uint32_t multimem_staging_signals_per_lane(
-    int nvlRanks) {
-  return static_cast<uint32_t>(2 * nvlRanks + 4);
+    uint32_t nvlRanks) {
+  return 2 * nvlRanks + 4;
 }
 
 namespace detail {
@@ -71,9 +71,10 @@ __device__ __forceinline__ void multimem_red_release_sys_add_u64(
  * `multimemData` and multimem signal spans are multicast VAs. Writes into the
  * multicast pointer preserve multicast semantics; `localData` and local signal
  * spans are this rank's backing memory after multicast replication. Callers
- * that want to broadcast into the multicast VA should obtain
- * `multimem_data_ptr()` and use PTX `multimem.st.*` intrinsics (or a helper
- * built on top, e.g. the one in `MultimemNvlStaging.cuh`).
+ * that want to reduce from the multicast VA should obtain
+ * `multimem_data_ptr()` and pass it to `multimem::load_reduce_at()`, defined
+ * in `MultimemNvlReduce.cuh`. Broadcast-store helpers are introduced by the
+ * later store-primitives diff.
  */
 struct MultimemNvlTransportDevice {
   char* localData{nullptr};
@@ -83,6 +84,8 @@ struct MultimemNvlTransportDevice {
   DeviceSpan<SignalState> internalLocalSignals{};
   DeviceSpan<SignalState> internalMultimemSignals{};
   std::size_t dataBufferSize{0};
+  int nvlRank{0};
+  int nvlRanks{1};
 
   __device__ __forceinline__ char* local_data_ptr(std::size_t offset) const {
     return localData + offset;


### PR DESCRIPTION
Summary:
Adds the baseline Prims support for MCCL CNVLMM staging ReduceScatter: typed multicast load-reduce operations, overflow-safe staging and signal layout, and host transport plumbing that exposes the multicast staging handle.

Multimem initialization has an explicit lifecycle through `initializeMultimemNvlTransportIfEligible()`.
Communicator-wide eligibility, eligibility-query errors, local construction readiness, and multicast exchange use explicit agreement and terminal-state handling so ranks cannot retry an asymmetric collective phase.
The configured CUDA device is selected and restored for lazy initialization and teardown, including rollback after a failed device-selection attempt.
Combined data and signal allocation arithmetic is checked before CUDA access so alignment or addition overflow cannot expose an undersized mapping.
Unsupported architectures compile a deterministic trap path instead of instantiating unsupported multimem PTX.

This prerequisite intentionally excludes no-copy alias fencing and later load-reduce unroll or batched-tail performance tuning.
Those remain owned by their no-copy and performance diffs.

#aup

Reviewed By: dboyda

Differential Revision: D110986508


