### PR TITLE
Move per-comm noLocal flag onto the opaque ncclxExt handle (#3278)

### DIFF
--- a/comms/ncclx/meta/collectives/quantCollectives.cc
+++ b/comms/ncclx/meta/collectives/quantCollectives.cc
@@ -7,6 +7,7 @@
 
 #include "meta/wrapper/DataTypeStrUtils.h"
 #include "meta/wrapper/MetaFactory.h"
+#include "meta/wrapper/NcclCommUseCtran.h"
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/utils/ExtUtils.h"
@@ -88,7 +89,7 @@ static ncclResult_t ncclReduceScatterQuantizeInfoExt(
   constexpr auto kDirectIbAlgo = NCCL_REDUCESCATTER_ALGO::ctdirect_ib;
   if (NCCL_REDUCESCATTER_QUANTIZED_ALGO ==
           NCCL_REDUCESCATTER_QUANTIZED_ALGO::ctdirect_ib &&
-      comm->useCtran_ && op == ncclSum &&
+      meta::comms::ncclx::ncclCommUseCtran(comm) && op == ncclSum &&
       ctranReduceScatterSupport(comm->ctranComm_.get(), kDirectIbAlgo)) {
     return metaCommToNccl(ctranReduceScatterQuantize(
         sendbuff,

--- a/comms/ncclx/meta/collectives/quantCollectives.cc
+++ b/comms/ncclx/meta/collectives/quantCollectives.cc
@@ -8,6 +8,7 @@
 #include "meta/NcclxLogger.h"
 #include "meta/wrapper/DataTypeStrUtils.h"
 #include "meta/wrapper/MetaFactory.h"
+#include "meta/wrapper/NcclCommUseCtran.h"
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/utils/ExtUtils.h"
@@ -89,7 +90,7 @@ static ncclResult_t ncclReduceScatterQuantizeInfoExt(
   constexpr auto kDirectIbAlgo = NCCL_REDUCESCATTER_ALGO::ctdirect_ib;
   if (NCCL_REDUCESCATTER_QUANTIZED_ALGO ==
           NCCL_REDUCESCATTER_QUANTIZED_ALGO::ctdirect_ib &&
-      comm->useCtran_ && op == ncclSum &&
+      meta::comms::ncclx::ncclCommUseCtran(comm) && op == ncclSum &&
       ctranReduceScatterSupport(comm->ctranComm_.get(), kDirectIbAlgo)) {
     return metaCommToNccl(ctranReduceScatterQuantize(
         sendbuff,

--- a/comms/ncclx/meta/comm/NcclxCommExt.h
+++ b/comms/ncclx/meta/comm/NcclxCommExt.h
@@ -1,0 +1,21 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+// Opaque per-communicator NCCLX state.
+//
+// This handle collects NCCLX-only members that would otherwise be woven
+// directly into the forked upstream `ncclComm` struct, keeping that struct
+// close to pristine NCCL. NCCLX code reaches the state through the single
+// `ncclComm::ncclxExt` pointer (including this header and dereferencing
+// `comm->ncclxExt`), while the forked `comm.h` only forward-declares the type.
+//
+// `ncclComm` is raw-allocated (calloc) and raw-freed, so no constructor or
+// destructor runs on it; this handle is instead created explicitly right after
+// the comm is allocated and destroyed in the NCCLX comm-free hook, giving it a
+// lifetime that exactly matches the communicator.
+struct ncclxCommExt {
+  // Ctran per-communicator control; populated from the parsed ncclx::Config at
+  // communicator init and gates creation of the per-comm CtranComm.
+  bool useCtran{false};
+};

--- a/comms/ncclx/meta/comm/NcclxCommExt.h
+++ b/comms/ncclx/meta/comm/NcclxCommExt.h
@@ -18,4 +18,8 @@ struct ncclxCommExt {
   // Ctran per-communicator control; populated from the parsed ncclx::Config at
   // communicator init and gates creation of the per-comm CtranComm.
   bool useCtran{false};
+
+  // Disable local transports (P2P and SHM); forces NET for all connections.
+  // Populated from the parsed ncclx::Config at communicator init.
+  bool noLocal{false};
 };

--- a/comms/ncclx/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/meta/commstate/FactoryCommStateX.cc
@@ -4,6 +4,7 @@
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/commstate/CommStateX.h"
 #include "meta/NcclxConfig.h" // @manual
+#include "meta/wrapper/NcclCommNoLocal.h"
 
 #include "nvmlwrap.h"
 #include "transport.h"
@@ -87,6 +88,8 @@ ncclResult_t initCommStateXFromNcclComm(void* _comm, CtranComm* ctranComm) {
   CHECKABORT(comm->rankToNode, "rankToNode is nullptr");
   CHECKABORT(comm->localRankToRank, "localRankToRank is nullptr");
 
+  const bool noLocal = meta::comms::ncclx::ncclCommNoLocal(comm);
+
   auto* bootstrap = ctranComm->bootstrap_.get();
 
   const int vCliqueSize = NCCLX_CONFIG_FIELD(comm->config, vCliqueSize);
@@ -101,7 +104,7 @@ ncclResult_t initCommStateXFromNcclComm(void* _comm, CtranComm* ctranComm) {
       std::vector<RankTopology>(), /* rankTopologies */
       std::vector<int>(), /* commRanksToWorldRanks */
       NCCLX_CONFIG_FIELD(comm->config, commDesc),
-      comm->noLocal_,
+      noLocal,
       vCliqueSize);
 
   try {
@@ -116,7 +119,7 @@ ncclResult_t initCommStateXFromNcclComm(void* _comm, CtranComm* ctranComm) {
   INFO(
       NCCL_INIT | NCCL_GRAPH,
       "CommStateX: set rankTopology with noLocal=%d, vCliqueSize=%d, commDesc=%s, commHash=0x%lx, rank=%d, nRanks=%d, nLocalRanks=%d",
-      comm->noLocal_,
+      noLocal,
       vCliqueSize,
       NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str(),
       comm->commHash,

--- a/comms/ncclx/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/meta/commstate/FactoryCommStateX.cc
@@ -6,6 +6,7 @@
 #include "comms/ctran/commstate/CommStateX.h"
 #include "meta/NcclxConfig.h" // @manual
 #include "meta/NcclxLogger.h"
+#include "meta/wrapper/NcclCommNoLocal.h"
 
 #include "nvmlwrap.h"
 #include "transport.h"
@@ -89,6 +90,8 @@ ncclResult_t initCommStateXFromNcclComm(void* _comm, CtranComm* ctranComm) {
   CHECKABORT(comm->rankToNode, "rankToNode is nullptr");
   CHECKABORT(comm->localRankToRank, "localRankToRank is nullptr");
 
+  const bool noLocal = meta::comms::ncclx::ncclCommNoLocal(comm);
+
   auto* bootstrap = ctranComm->bootstrap_.get();
 
   const int vCliqueSize = NCCLX_CONFIG_FIELD(comm->config, vCliqueSize);
@@ -103,7 +106,7 @@ ncclResult_t initCommStateXFromNcclComm(void* _comm, CtranComm* ctranComm) {
       std::vector<RankTopology>(), /* rankTopologies */
       std::vector<int>(), /* commRanksToWorldRanks */
       NCCLX_CONFIG_FIELD(comm->config, commDesc),
-      comm->noLocal_,
+      noLocal,
       vCliqueSize);
 
   try {
@@ -118,7 +121,7 @@ ncclResult_t initCommStateXFromNcclComm(void* _comm, CtranComm* ctranComm) {
   INFO(
       NCCL_INIT | NCCL_GRAPH,
       "CommStateX: set rankTopology with noLocal=%d, vCliqueSize=%d, commDesc=%s, commHash=0x%lx, rank=%d, nRanks=%d, nLocalRanks=%d",
-      comm->noLocal_,
+      noLocal,
       vCliqueSize,
       NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str(),
       comm->commHash,

--- a/comms/ncclx/meta/tests/CommWithNoLocalTest.cc
+++ b/comms/ncclx/meta/tests/CommWithNoLocalTest.cc
@@ -21,6 +21,7 @@
 #include "VerifyAlgoStatsUtil.h"
 
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "meta/wrapper/NcclCommNoLocal.h"
 
 // Hint lifecycle tests
 
@@ -41,7 +42,7 @@ TEST_F(CommWithNoLocalTest, NoLocalDisabledByDefault) {
   ncclx::test::NcclCommRAII comm{
       globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_NE(comm.get(), nullptr);
-  EXPECT_FALSE(comm->noLocal_);
+  EXPECT_FALSE(meta::comms::ncclx::ncclCommNoLocal(comm.get()));
 }
 
 namespace {
@@ -60,7 +61,7 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
   ncclx::test::NcclCommRAII comm1{
       globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_NE(comm1.get(), nullptr);
-  EXPECT_FALSE(comm1->noLocal_);
+  EXPECT_FALSE(meta::comms::ncclx::ncclCommNoLocal(comm1.get()));
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
@@ -93,14 +94,14 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
     } while (commStatus == ncclInProgress);
   }
 
-  EXPECT_TRUE(comm2->noLocal_);
+  EXPECT_TRUE(meta::comms::ncclx::ncclCommNoLocal(comm2));
 
   // Now disabled again
   {
     ncclx::test::NcclCommRAII comm3{
         globalRank, numRanks, localRank, bootstrap_.get()};
     ASSERT_NE(comm3.get(), nullptr);
-    EXPECT_FALSE(comm3->noLocal_);
+    EXPECT_FALSE(meta::comms::ncclx::ncclCommNoLocal(comm3.get()));
   }
 }
 
@@ -326,7 +327,7 @@ TEST_P(CommWithNoLocalCollTest, BaselineRun) {
   ncclx::test::NcclCommRAII comm{
       globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ASSERT_NE(comm.get(), nullptr);
-  EXPECT_EQ(comm->noLocal_, noLocal);
+  EXPECT_EQ(meta::comms::ncclx::ncclCommNoLocal(comm.get()), noLocal);
 
   run(comm.get(), collectiveOp);
   const char* collectiveName = (collectiveOp == CollectiveOp::kAllGather)
@@ -349,7 +350,7 @@ TEST_P(CommWithNoLocalCollTest, CtranRun) {
   ncclx::test::NcclCommRAII comm{
       globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ASSERT_NE(comm.get(), nullptr);
-  EXPECT_TRUE(comm->noLocal_);
+  EXPECT_TRUE(meta::comms::ncclx::ncclCommNoLocal(comm.get()));
 
   if (collectiveOp == CollectiveOp::kAllGather) {
     auto algoGuard = EnvRAII(NCCL_ALLGATHER_ALGO, NCCL_ALLGATHER_ALGO::ctran);

--- a/comms/ncclx/meta/tests/SendRecvTest.cc
+++ b/comms/ncclx/meta/tests/SendRecvTest.cc
@@ -15,6 +15,7 @@
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/algoconf/AlgoStrConv.h"
+#include "meta/wrapper/NcclCommNoLocal.h"
 
 static bool VERBOSE = true;
 
@@ -397,7 +398,7 @@ TEST_F(SendRecvTest, CtgraphGroupedSendRecv) {
 
   checkResults(recvPeer, commCount);
 
-  if (comm->noLocal_) {
+  if (meta::comms::ncclx::ncclCommNoLocal(comm)) {
     // nolocal: IB backend → ctgraph routes to ctran
     ctranAlgoStats_.verify(comm->ctranComm_.get(), "SendRecv", "Ctran");
   } else {

--- a/comms/ncclx/meta/wrapper/NcclCommNoLocal.h
+++ b/comms/ncclx/meta/wrapper/NcclCommNoLocal.h
@@ -1,0 +1,32 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comm.h"
+#include "nccl.h"
+
+// TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+#include "meta/comm/NcclxCommExt.h"
+#endif
+
+namespace meta::comms::ncclx {
+
+// Version-gated accessor for the per-communicator `noLocal` flag (disable local
+// P2P/SHM transports, forcing NET for all connections).
+//
+// In NCCL 2.30+ the flag lives on the opaque `comm->ncclxExt` handle, keeping
+// the forked upstream `ncclComm` struct closer to pristine NCCL. In older forks
+// (< 2.30, still the stable version) it remains a direct `ncclComm` member.
+// Routing shared NCCLX code and tests through this accessor lets them compile
+// against both layouts without touching the older fork.
+inline bool& ncclCommNoLocal(ncclComm* comm) {
+  // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+  return comm->ncclxExt->noLocal;
+#else
+  return comm->noLocal_;
+#endif
+}
+
+} // namespace meta::comms::ncclx

--- a/comms/ncclx/meta/wrapper/NcclCommUseCtran.h
+++ b/comms/ncclx/meta/wrapper/NcclCommUseCtran.h
@@ -1,0 +1,32 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comm.h"
+#include "nccl.h"
+
+// TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+#include "meta/comm/NcclxCommExt.h"
+#endif
+
+namespace meta::comms::ncclx {
+
+// Version-gated accessor for the per-communicator `useCtran` flag (route
+// supported collectives through CTRAN instead of the baseline path).
+//
+// In NCCL 2.30+ the flag lives on the opaque `comm->ncclxExt` handle, keeping
+// the forked upstream `ncclComm` struct closer to pristine NCCL. In older forks
+// (< 2.30, still the stable version) it remains a direct `ncclComm` member.
+// Routing shared NCCLX code and tests through this accessor lets them compile
+// against both layouts without touching the older fork.
+inline bool& ncclCommUseCtran(ncclComm* comm) {
+  // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+  return comm->ncclxExt->useCtran;
+#else
+  return comm->useCtran_;
+#endif
+}
+
+} // namespace meta::comms::ncclx

--- a/comms/ncclx/v2_30/src/include/comm.h
+++ b/comms/ncclx/v2_30/src/include/comm.h
@@ -42,6 +42,7 @@
 
 // Forward declarations of ncclx classes to avoid circular dependencies
 class ICtran;
+struct ncclxCommExt;
 namespace meta::comms {
 class IBootstrap;
 } // namespace meta::comms
@@ -838,6 +839,8 @@ struct ncclComm {
   /**
    * NCCLX specific state
    */
+  // Opaque NCCLX-only per-comm state; see meta/comm/NcclxCommExt.h.
+  ncclxCommExt* ncclxExt{nullptr};
   struct CommLogData logMetaData;
   std::shared_ptr<meta::comms::colltrace::ICollTrace> newCollTrace;
   std::shared_ptr<meta::comms::colltrace::AlgoStats> algoStats;
@@ -847,7 +850,6 @@ struct ncclComm {
   std::shared_ptr<ncclx::transport::TransportProxy> transportProxy_;
 
   // This is the only bridge between ctran and baseline code
-  bool useCtran_{false}; // Ctran per-communicator control; set at init entry functions
   std::unique_ptr<CtranComm> ctranComm_;
 
   // [META:PAT_AVG] per-communicator control; set at init entry functions

--- a/comms/ncclx/v2_30/src/include/comm.h
+++ b/comms/ncclx/v2_30/src/include/comm.h
@@ -856,9 +856,6 @@ struct ncclComm {
   // When enabled, forces PAT algorithm with ncclDevPatSumPostDiv for ReduceScatter with ncclAvg
   bool usePatAvg_{false};
 
-  // Disable local transports (P2P and SHM); forces NET for all connections
-  bool noLocal_{false};
-
   struct ncclMemManager* memManager;  // Memory manager
   struct ncclIntruQueue<struct ncclMemManagerTask, &ncclMemManagerTask::next> suspendTaskQueue;
   struct ncclIntruQueue<struct ncclMemManagerTask, &ncclMemManagerTask::next> resumeTaskQueue;

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -63,6 +63,7 @@
 #include "comms/utils/logger/LoggingFormat.h"
 #include "comms/ctran/memory/SlabAllocator.h"
 #include "comms/ctran/memory/Utils.h"
+#include "meta/comm/NcclxCommExt.h"
 #include "meta/wrapper/MetaFactory.h"
 #include "meta/transport/transportExt.h"
 
@@ -299,6 +300,8 @@ static void ncclxCommFree(ncclComm_t comm) {
     delete static_cast<ncclx::Config*>(comm->config.ncclxConfig);
     comm->config.ncclxConfig = nullptr;
   }
+  delete comm->ncclxExt;
+  comm->ncclxExt = nullptr;
 }
 
 static ncclResult_t commFree(ncclComm_t comm) {
@@ -2027,7 +2030,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   NCCLCHECKGOTO(meta::comms::ncclx::newCollTraceInit(comm), res, fail);
 
 
-  if (comm->useCtran_) {
+  if (comm->ncclxExt->useCtran) {
     NCCLCHECKGOTO(createCtranComm(comm), res, fail);
   }
   // --------------------- done
@@ -2585,14 +2588,15 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   NCCLCHECKGOTO(ncclCudaHostCalloc(&comm->abortFlagDev, 1), res, fail);
   NCCLCHECKGOTO(ncclCalloc(&comm->abortFlagRefCount, 1), res, fail);
   comm->startMagic = comm->endMagic = NCCL_MAGIC; // Used to detect comm corruption.
+  NEW_NOTHROW_GOTO(comm->ncclxExt, ncclxCommExt, res, fail);
   // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
-  comm->useCtran_ = NCCLX_CONFIG_FIELD(*config, useCtran);
+  comm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(*config, useCtran);
   comm->usePatAvg_ = NCCLX_CONFIG_FIELD(*config, usePatAvg);
   comm->noLocal_ = NCCLX_CONFIG_FIELD(*config, noLocal);
   INFO(NCCL_INIT, "CommInit comm %p commHash 0x%lx commDesc %s useCtran %d usePatAvg %d noLocal %d",
        comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES),
        NCCLX_CONFIG_FIELD(*config, commDesc).c_str(),
-       comm->useCtran_, comm->usePatAvg_, comm->noLocal_);
+       comm->ncclxExt->useCtran, comm->usePatAvg_, comm->noLocal_);
   *comm->abortFlagRefCount = 1;
   NCCLCHECKGOTO(parseCommConfig(comm, config), res, fail);
   /* start with ncclInProgress and will be changed to ncclSuccess if init succeeds. */
@@ -3280,6 +3284,7 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
   } else {
     NCCLCHECKGOTO(ncclCalloc(&childComm, 1), res, fail);
     childComm->startMagic = childComm->endMagic = NCCL_MAGIC;
+    NEW_NOTHROW_GOTO(childComm->ncclxExt, ncclxCommExt, res, fail);
 
     // Set the shareResource field, this is used throughout the init and must be reset every time.
     // Never share resources if the parent communicator has been revoked.
@@ -3309,12 +3314,12 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
     /* start with ncclInternalError and will be changed to ncclSuccess if init succeeds. */
     childComm->initState = ncclInternalError;
     // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
-    childComm->useCtran_ = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
+    childComm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
     childComm->usePatAvg_ = NCCLX_CONFIG_FIELD(childComm->config, usePatAvg);
     childComm->noLocal_ = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
     INFO(NCCL_INIT, "CommSplit comm %p commDesc %s useCtran %d usePatAvg %d noLocal %d",
         childComm, NCCLX_CONFIG_FIELD(childComm->config, commDesc).c_str(),
-        childComm->useCtran_, childComm->usePatAvg_, childComm->noLocal_);
+        childComm->ncclxExt->useCtran, childComm->usePatAvg_, childComm->noLocal_);
   }
 
   NEW_NOTHROW_GOTO(job, ncclCommInitRankAsyncJob, res, fail);
@@ -3504,6 +3509,7 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
   // All ranks allocate a NEW comm structure for the grown communicator
   NCCLCHECKGOTO(ncclCalloc(&newComm, 1), res, fail);
   newComm->startMagic = newComm->endMagic = NCCL_MAGIC;
+  NEW_NOTHROW_GOTO(newComm->ncclxExt, ncclxCommExt, res, fail);
 
   // All ranks allocate fresh resources for grown communicator
   NCCLCHECKGOTO(ncclCalloc(&newComm->abortFlag, 1), res, fail);

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -2592,11 +2592,11 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
   comm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(*config, useCtran);
   comm->usePatAvg_ = NCCLX_CONFIG_FIELD(*config, usePatAvg);
-  comm->noLocal_ = NCCLX_CONFIG_FIELD(*config, noLocal);
+  comm->ncclxExt->noLocal = NCCLX_CONFIG_FIELD(*config, noLocal);
   INFO(NCCL_INIT, "CommInit comm %p commHash 0x%lx commDesc %s useCtran %d usePatAvg %d noLocal %d",
        comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES),
        NCCLX_CONFIG_FIELD(*config, commDesc).c_str(),
-       comm->ncclxExt->useCtran, comm->usePatAvg_, comm->noLocal_);
+       comm->ncclxExt->useCtran, comm->usePatAvg_, comm->ncclxExt->noLocal);
   *comm->abortFlagRefCount = 1;
   NCCLCHECKGOTO(parseCommConfig(comm, config), res, fail);
   /* start with ncclInProgress and will be changed to ncclSuccess if init succeeds. */
@@ -3316,10 +3316,10 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
     // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
     childComm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
     childComm->usePatAvg_ = NCCLX_CONFIG_FIELD(childComm->config, usePatAvg);
-    childComm->noLocal_ = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
+    childComm->ncclxExt->noLocal = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
     INFO(NCCL_INIT, "CommSplit comm %p commDesc %s useCtran %d usePatAvg %d noLocal %d",
         childComm, NCCLX_CONFIG_FIELD(childComm->config, commDesc).c_str(),
-        childComm->ncclxExt->useCtran, childComm->usePatAvg_, childComm->noLocal_);
+        childComm->ncclxExt->useCtran, childComm->usePatAvg_, childComm->ncclxExt->noLocal);
   }
 
   NEW_NOTHROW_GOTO(job, ncclCommInitRankAsyncJob, res, fail);

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -2594,11 +2594,11 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
   comm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(*config, useCtran);
   comm->usePatAvg_ = NCCLX_CONFIG_FIELD(*config, usePatAvg);
-  comm->noLocal_ = NCCLX_CONFIG_FIELD(*config, noLocal);
+  comm->ncclxExt->noLocal = NCCLX_CONFIG_FIELD(*config, noLocal);
   INFO(NCCL_INIT, "CommInit comm %p commHash 0x%lx commDesc %s useCtran %d usePatAvg %d noLocal %d",
        comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES),
        NCCLX_CONFIG_FIELD(*config, commDesc).c_str(),
-       comm->ncclxExt->useCtran, comm->usePatAvg_, comm->noLocal_);
+       comm->ncclxExt->useCtran, comm->usePatAvg_, comm->ncclxExt->noLocal);
   *comm->abortFlagRefCount = 1;
   NCCLCHECKGOTO(parseCommConfig(comm, config), res, fail);
   /* start with ncclInProgress and will be changed to ncclSuccess if init succeeds. */
@@ -3318,10 +3318,10 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
     // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
     childComm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
     childComm->usePatAvg_ = NCCLX_CONFIG_FIELD(childComm->config, usePatAvg);
-    childComm->noLocal_ = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
+    childComm->ncclxExt->noLocal = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
     INFO(NCCL_INIT, "CommSplit comm %p commDesc %s useCtran %d usePatAvg %d noLocal %d",
         childComm, NCCLX_CONFIG_FIELD(childComm->config, commDesc).c_str(),
-        childComm->ncclxExt->useCtran, childComm->usePatAvg_, childComm->noLocal_);
+        childComm->ncclxExt->useCtran, childComm->usePatAvg_, childComm->ncclxExt->noLocal);
   }
 
   NEW_NOTHROW_GOTO(job, ncclCommInitRankAsyncJob, res, fail);

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -63,6 +63,7 @@
 #include "comms/utils/logger/LoggingFormat.h"
 #include "comms/ctran/memory/SlabAllocator.h"
 #include "comms/ctran/memory/Utils.h"
+#include "meta/comm/NcclxCommExt.h"
 #include "meta/wrapper/MetaFactory.h"
 #include "meta/transport/transportExt.h"
 
@@ -299,6 +300,8 @@ static void ncclxCommFree(ncclComm_t comm) {
     delete static_cast<ncclx::Config*>(comm->config.ncclxConfig);
     comm->config.ncclxConfig = nullptr;
   }
+  delete comm->ncclxExt;
+  comm->ncclxExt = nullptr;
 }
 
 static ncclResult_t commFree(ncclComm_t comm) {
@@ -2029,7 +2032,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   NCCLCHECKGOTO(meta::comms::ncclx::newCollTraceInit(comm), res, fail);
 
 
-  if (comm->useCtran_) {
+  if (comm->ncclxExt->useCtran) {
     NCCLCHECKGOTO(createCtranComm(comm), res, fail);
   }
   // --------------------- done
@@ -2587,14 +2590,15 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   NCCLCHECKGOTO(ncclCudaHostCalloc(&comm->abortFlagDev, 1), res, fail);
   NCCLCHECKGOTO(ncclCalloc(&comm->abortFlagRefCount, 1), res, fail);
   comm->startMagic = comm->endMagic = NCCL_MAGIC; // Used to detect comm corruption.
+  NEW_NOTHROW_GOTO(comm->ncclxExt, ncclxCommExt, res, fail);
   // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
-  comm->useCtran_ = NCCLX_CONFIG_FIELD(*config, useCtran);
+  comm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(*config, useCtran);
   comm->usePatAvg_ = NCCLX_CONFIG_FIELD(*config, usePatAvg);
   comm->noLocal_ = NCCLX_CONFIG_FIELD(*config, noLocal);
   INFO(NCCL_INIT, "CommInit comm %p commHash 0x%lx commDesc %s useCtran %d usePatAvg %d noLocal %d",
        comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES),
        NCCLX_CONFIG_FIELD(*config, commDesc).c_str(),
-       comm->useCtran_, comm->usePatAvg_, comm->noLocal_);
+       comm->ncclxExt->useCtran, comm->usePatAvg_, comm->noLocal_);
   *comm->abortFlagRefCount = 1;
   NCCLCHECKGOTO(parseCommConfig(comm, config), res, fail);
   /* start with ncclInProgress and will be changed to ncclSuccess if init succeeds. */
@@ -3282,6 +3286,7 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
   } else {
     NCCLCHECKGOTO(ncclCalloc(&childComm, 1), res, fail);
     childComm->startMagic = childComm->endMagic = NCCL_MAGIC;
+    NEW_NOTHROW_GOTO(childComm->ncclxExt, ncclxCommExt, res, fail);
 
     // Set the shareResource field, this is used throughout the init and must be reset every time.
     // Never share resources if the parent communicator has been revoked.
@@ -3311,12 +3316,12 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
     /* start with ncclInternalError and will be changed to ncclSuccess if init succeeds. */
     childComm->initState = ncclInternalError;
     // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
-    childComm->useCtran_ = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
+    childComm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
     childComm->usePatAvg_ = NCCLX_CONFIG_FIELD(childComm->config, usePatAvg);
     childComm->noLocal_ = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
     INFO(NCCL_INIT, "CommSplit comm %p commDesc %s useCtran %d usePatAvg %d noLocal %d",
         childComm, NCCLX_CONFIG_FIELD(childComm->config, commDesc).c_str(),
-        childComm->useCtran_, childComm->usePatAvg_, childComm->noLocal_);
+        childComm->ncclxExt->useCtran, childComm->usePatAvg_, childComm->noLocal_);
   }
 
   NEW_NOTHROW_GOTO(job, ncclCommInitRankAsyncJob, res, fail);
@@ -3506,6 +3511,7 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
   // All ranks allocate a NEW comm structure for the grown communicator
   NCCLCHECKGOTO(ncclCalloc(&newComm, 1), res, fail);
   newComm->startMagic = newComm->endMagic = NCCL_MAGIC;
+  NEW_NOTHROW_GOTO(newComm->ncclxExt, ncclxCommExt, res, fail);
 
   // All ranks allocate fresh resources for grown communicator
   NCCLCHECKGOTO(ncclCalloc(&newComm->abortFlag, 1), res, fail);

--- a/comms/ncclx/v2_30/src/transport/p2p.cc
+++ b/comms/ncclx/v2_30/src/transport/p2p.cc
@@ -7,6 +7,7 @@
 
 #include "checks.h"
 #include "comm.h"
+#include "meta/comm/NcclxCommExt.h"
 #include "meta/NcclxConfig.h" // @manual
 #include "graph.h"
 #include "utils.h"
@@ -137,7 +138,7 @@ extern int64_t ncclParamMNNVLEnable();
 ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2) {
   initCeOperation();
 
-  if (comm->noLocal_) {
+  if (comm->ncclxExt->noLocal) {
     *ret = 0;
     return ncclSuccess;
   }

--- a/comms/ncclx/v2_30/src/transport/shm.cc
+++ b/comms/ncclx/v2_30/src/transport/shm.cc
@@ -6,6 +6,7 @@
  *************************************************************************/
 
 #include "comm.h"
+#include "meta/comm/NcclxCommExt.h"
 #include "shmutils.h"
 #include "shm.h"
 #include "transport.h"
@@ -78,7 +79,7 @@ static ncclResult_t shmCanConnect(int* ret, struct ncclComm* comm, struct ncclTo
   *ret = 0;
   initCeOperation();
 
-  if (ncclParamShmDisable() == 1 || comm->noLocal_) return ncclSuccess;
+  if (ncclParamShmDisable() == 1 || comm->ncclxExt->noLocal) return ncclSuccess;
 
   int useNet = 0;
   NCCLCHECK(ncclTopoCheckNet(comm->topo, info1->rank, info2->rank, &useNet));


### PR DESCRIPTION
Summary:

Continue collapsing NCCLX-only members off the forked upstream `ncclComm`
struct behind the opaque `ncclxExt` handle. The per-communicator `noLocal`
flag (disables local P2P/SHM transports, forcing NET for all connections)
moves from a direct `ncclComm::noLocal_` member into `ncclxCommExt::noLocal`,
shrinking the forked v2_30 `comm.h` one member closer to pristine NCCL. This
mirrors the earlier `useCtran` relocation onto the same handle.

The change is v2_30 only; the stable v2_29 tree keeps `noLocal_` as a direct
member and its behavior is untouched. Shared `meta/` code and tests that
compile against both versions reach the flag through a version-gated accessor,
`meta::comms::ncclx::ncclCommNoLocal()` in `meta/wrapper/NcclCommNoLocal.h`
(the same pattern as the CollTrace/AlgoStats and logMetaData accessors): on
NCCL 2.30+ it resolves to `comm->ncclxExt->noLocal`; on older forks (2.29,
still the stable version) it resolves to `comm->noLocal_`. The forked v2_30
readers in `transport/shm.cc` and `transport/p2p.cc`, and the setters/logs in
`init.cc`, are version-locked and reach the handle directly. Removing the
pre-2.30 branch of the accessor once older forks retire is tracked in
T279903668. Behavior is identical -- this is a pure member relocation.

Reviewed By: shr

Differential Revision: D113491538


