### PR TITLE
AllReduce copy (staging) kernel + ICollective + test (bit-exact fp16/bf16, both acc modes)

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -109,6 +109,61 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     const size_t nvlDataBufferSize =
         nvlMaxNumChannels * config.nvlConfig.perChannelSize;
 
+    // The multimem staging window is decoupled from the P2P shared devbuf: a
+    // larger window means fewer staging rounds, which is the dominant cnvlmm
+    // throughput lever at large sizes. Falls back to the P2P size when the
+    // dedicated cvar is 0. Computed before the enable guard so setting only the
+    // multimem cvar (with the P2P devbuf at 0) is sufficient to enable the
+    // path.
+    const size_t multimemDevbufSize = MCCL_NVL_MULTIMEM_BUFSIZE > 0
+        ? static_cast<size_t>(MCCL_NVL_MULTIMEM_BUFSIZE)
+        : nvlSharedDevbufSize;
+    if (comm->statex_->nLocalRanks() > 2 && multimemDevbufSize > 0) {
+      const uint32_t multimemPipelineDepth = static_cast<uint32_t>(
+          std::max<size_t>(1, config.nvlConfig.pipelineDepth));
+      // Reuse the already-computed channel count (== std::max(1,
+      // MCCL_MAX_NBLOCKS)) as the group count so the signal sizing cannot drift
+      // from the transport's actual channel count.
+      const uint32_t multimemMaxGroups =
+          static_cast<uint32_t>(config.nvlConfig.maxNumChannels);
+      // Per-lane signal region, sized from the shared source of truth
+      // `multimem_staging_signals_per_lane` (MultimemNvlTransportDevice.cuh).
+      // The device-side `make_stage_layout` (MultimemNvlStageLayout.cuh, added
+      // by the ReduceScatter copy prereq stacked on this diff) is updated to
+      // call the same helper, so the host sizing here and the device layout
+      // stay in lockstep off one definition rather than duplicated literals.
+      const uint32_t multimemSignalsPerLane =
+          comms::prims::multimem_staging_signals_per_lane(
+              comm->statex_->nLocalRanks());
+      // Evaluate the product in u64 (all three factors are hardware-bounded to
+      // small values, so it cannot realistically overflow u64) and bound it
+      // against the transport's signal-count limit (INT_MAX; see
+      // MultimemNvlTransport's ctor) before narrowing into the u32 field, so a
+      // future large maxGroups/pipelineDepth/nLocalRanks fails loudly here with
+      // context rather than silently wrapping or throwing deeper in the ctor.
+      const uint64_t multimemInternalSignalCount =
+          static_cast<uint64_t>(multimemMaxGroups) * multimemPipelineDepth *
+          multimemSignalsPerLane;
+      if (multimemInternalSignalCount >
+          static_cast<uint64_t>(std::numeric_limits<int>::max())) {
+        CLOGF(
+            ERR,
+            "CTRAN-PRIMS: multimem internalSignalCount {} exceeds the transport signal-count limit (INT_MAX); maxGroups={} pipelineDepth={} signalsPerLane={}",
+            multimemInternalSignalCount,
+            multimemMaxGroups,
+            multimemPipelineDepth,
+            multimemSignalsPerLane);
+        return commInvalidArgument;
+      }
+      config.nvlConfig.enableMultimem = true;
+      config.nvlConfig.multimem = comms::prims::MultimemNvlTransportConfig{
+          .dataBufferSize = multimemDevbufSize,
+          .userSignalCount = 1,
+          .internalSignalCount =
+              static_cast<uint32_t>(multimemInternalSignalCount),
+      };
+    }
+
     // LL128 buffer allocation for DeviceAllToAllv
     if (NCCL_CTRAN_DA2A_LL128_THRESHOLD > 0) {
       if (NCCL_CTRAN_DA2A_LL128_BUFFER_SIZE > 0) {
@@ -286,13 +341,17 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
 
     CLOGF(
         INFO,
-        "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={} materializePeerTimeoutMs={}",
+        "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} enableMultimem={} multimemSignals={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={} materializePeerTimeoutMs={}",
         comm->statex_->rank(),
         config.nvlConfig.pipelineDepth,
         nvlSharedDevbufSize,
         nvlDataBufferSize,
         config.nvlConfig.maxNumChannels,
         config.nvlConfig.perChannelSize,
+        config.nvlConfig.enableMultimem,
+        config.nvlConfig.enableMultimem
+            ? config.nvlConfig.multimem.internalSignalCount
+            : 0,
         hierAgOverlapEnabled,
         config.disableIb,
         config.topoConfig.p2pDisable,

--- a/comms/ctran/commstate/tests/CommStateXTest.cc
+++ b/comms/ctran/commstate/tests/CommStateXTest.cc
@@ -335,6 +335,66 @@ TEST(CommStateXTest, nvlFabricTest) {
   }
 }
 
+// Regression for the MCCL fabric-init prep (mccl::utils::initRankTopology now
+// calls setNvlFabricTopos): a single NVL fabric clusterId spanning MULTIPLE
+// physical hosts must collapse into ONE cross-host NVL domain, so
+// localRankToRanks() returns the whole domain (all ranks) rather than the
+// per-host node group. This is what lets a single-NVL-domain algo (cnvlmm) span
+// an MNNVL clique; without the fabric topos, localRankToRanks() would return
+// only same-host ranks and cross-host peers would fall back to IB.
+TEST(CommStateXTest, nvlFabricCrossHostSingleDomain) {
+  const int rank = 0;
+  const int nRanks = 8;
+  const int cudaDev = 0;
+  const int cudaArch = 90;
+  const int64_t busId = 25;
+  const uint64_t commHash = 0;
+
+  // All 8 ranks share ONE NVL fabric (clusterId1 / cliqueId1) ...
+  std::vector<NvlFabricTopology> nvlFabricTopologies{};
+  for (int r = 0; r < nRanks; ++r) {
+    nvlFabricTopologies.emplace_back(
+        createNvlFabricTopology(r, kNvlFabricClusterId1, kNvlFabricCliqueId1));
+  }
+  // ... spread across 4 distinct physical hosts (2 ranks each).
+  std::vector<RankTopology> rankTopologies{};
+  rankTopologies.emplace_back(createRankTopology(0, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(1, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(2, kDc, kZone, kHost1));
+  rankTopologies.emplace_back(createRankTopology(3, kDc, kZone, kHost1));
+  rankTopologies.emplace_back(createRankTopology(4, kDc, kZone, kHost2));
+  rankTopologies.emplace_back(createRankTopology(5, kDc, kZone, kHost2));
+  rankTopologies.emplace_back(createRankTopology(6, kDc, kZone, kHost3));
+  rankTopologies.emplace_back(createRankTopology(7, kDc, kZone, kHost3));
+
+  auto commState = std::make_unique<CommStateX>(
+      rank,
+      nRanks,
+      cudaDev,
+      cudaArch,
+      busId,
+      commHash,
+      rankTopologies,
+      std::vector<int>{});
+
+  // With fabric HW supported, the single clusterId collapses all 8 cross-host
+  // ranks into one NVL domain.
+  commState->setNvlFabricTopos(
+      nvlFabricTopologies, /*fabricHwSupportedForTest=*/true);
+  EXPECT_TRUE(commState->nvlFabricEnabled());
+  for (int i = 0; i < nRanks; ++i) {
+    EXPECT_TRUE(commState->isSameNvlFabric(0, i));
+  }
+  EXPECT_EQ(commState->localRankToRanks().size(), static_cast<size_t>(nRanks));
+
+  // Without fabric HW support (the pre-fix / no-IMEX case), it falls back to
+  // the per-host node group (2 ranks/host), NOT one cross-host domain.
+  commState->setNvlFabricTopos(
+      std::move(nvlFabricTopologies), /*fabricHwSupportedForTest=*/false);
+  EXPECT_FALSE(commState->nvlFabricEnabled());
+  EXPECT_LT(commState->localRankToRanks().size(), static_cast<size_t>(nRanks));
+}
+
 TEST(CommStateXTest, nvlFabricCliqueTest) {
   // enable clique and NVL software partioning mode
   EnvRAII env1(NCCL_MNNVL_DETERMINISTIC_COLLECTIVE_ENABLE, true);

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -267,6 +267,25 @@ Transport* /*nullable*/ MultiPeerTransport::get_nvl_transports_array() const {
   return nvlTransport_->getDeviceTransports().data();
 }
 
+bool MultiPeerTransport::has_multimem_nvl_transport() const {
+  // nvlTransport_ is legitimately null in normal builds without an NVL domain
+  // (e.g. nRanks == 1), same as get_nvl_transports_array() above; the null
+  // check is not masking an invariant.
+  return nvlTransport_ && nvlTransport_->hasMultimemNvlTransport();
+}
+
+MultimemNvlTransportDevice
+MultiPeerTransport::get_multimem_nvl_transport_device() const {
+  // Honor the header contract: throw when NVL transport is absent OR multimem
+  // is not configured / not eligible, rather than blindly delegating.
+  if (!has_multimem_nvl_transport()) {
+    throw std::runtime_error(
+        "MultiPeerTransport: multimem NVL transport is not configured or not "
+        "eligible");
+  }
+  return nvlTransport_->getMultimemNvlTransportDevice();
+}
+
 P2pSelfTransportDevice MultiPeerTransport::get_p2p_self_transport_device()
     const {
   return P2pSelfTransportDevice{};

--- a/comms/prims/transport/MultiPeerTransport.h
+++ b/comms/prims/transport/MultiPeerTransport.h
@@ -188,6 +188,43 @@ class MultiPeerTransport {
   Transport* /*nullable*/ get_nvl_transports_array() const;
 
   /**
+   * @return True when this rank has multimem (NVLS) NVL transport CONFIGURED
+   * and eligible.
+   *
+   * Cheap local check: it reflects configuration + hardware eligibility
+   * (`enableMultimem` set at transport construction && `isEligible`) and that
+   * no prior exchange/eligibility failure has latched the transport
+   * unavailable. It does NOT itself run the collective multicast exchange -
+   * that happens lazily on the first get_multimem_nvl_transport_device() call -
+   * but it does flip back to false if that exchange later fails. Used by cnvlmm
+   * collective support predicates to gate on multimem availability.
+   */
+  bool has_multimem_nvl_transport() const;
+
+  /**
+   * Return the device handle for the copy-based (staging) multimem NVL
+   * transport, lazily performing the collective multicast exchange on the first
+   * call for a configured transport. Delegates to
+   * MultiPeerNvlTransport::getMultimemNvlTransportDevice(). Used by the cnvlmm
+   * staging path (and the no-copy path's arrival-barrier signals).
+   *
+   * The eligibility guard and the lazy first-call exchange are consistent:
+   * has_multimem_nvl_transport() reflects configuration/eligibility (true
+   * BEFORE the exchange), so a configured, eligible transport passes the guard
+   * and its first call runs the exchange. It throws when there is no NVL
+   * transport, when multimem was never configured / not eligible, or when a
+   * prior exchange failed and latched the transport unavailable.
+   *
+   * PRECONDITION: COLLECTIVE - all NVL ranks that may use a multimem collective
+   * must call this in lockstep; the first call performs the multicast exchange.
+   *
+   * @throws std::runtime_error if no NVL transport, multimem NVL is not
+   * configured / not eligible on all ranks, or a prior exchange latched it
+   * unavailable.
+   */
+  MultimemNvlTransportDevice get_multimem_nvl_transport_device() const;
+
+  /**
    * @param globalPeerRank Global rank of the IBGDA peer.
    * @return Non-owning pointer to GPU-allocated P2pIbgdaTransportDevice.
    */

--- a/comms/prims/transport/nvl/MultimemNvlReduce.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlReduce.cuh
@@ -1,0 +1,443 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// multimem.ld_reduce load-reduce primitives for single-NVL-domain collectives.
+//
+// Holds the reduce side of the NVLS staging model: the raw `multimem.ld_reduce`
+// PTX emitters (`comms::prims::detail`) and the public entry point
+// `multimem::load_reduce_at<>` that reads the cross-rank reduction of a
+// multicast VA into a local buffer. The store side (`multimem::store()`) and
+// the staging orchestration that composes both land later in the stack
+// (`MultimemNvlStore.cuh`, `MultimemNvlStaging.cuh`).
+
+// clang-tidy analyzes this .cuh as a standalone main file and misflags the
+// pragma; it is a genuine include-once header. False positive, so suppress it.
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#if defined(ENABLE_PRIMS)
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
+
+// PTX helpers extend the transport header's existing `comms::prims::detail`
+// namespace. The public free-function entry point (`load_reduce_at<>`) lives in
+// `comms::prims::multimem` further below and delegates into `detail::` for the
+// raw PTX.
+namespace comms::prims::detail {
+
+// ----------------------------------------------------------------------------
+// multimem.ld_reduce load-reduce helpers (relaxed.sys, data-path).
+// ----------------------------------------------------------------------------
+
+// Typed multimem load-reduce ops (relaxed.sys). These are the `.ld_reduce`
+// data peers of the `.st` store helpers alongside the signal-path emitters
+// (`multimem_store_release_sys_u64` / `multimem_red_release_sys_add_u64` in
+// MultimemNvlTransportDevice.cuh); those stay release.sys because they carry
+// the producer/consumer handshake, while these are relaxed.sys since for bulk
+// data the ordering is established by the signal that follows the data op.
+// Only the add reduction is implemented today; widen with a template/op
+// parameter later.
+
+__device__ __forceinline__ float multimem_ld_reduce_f32(const float* src) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  float v;
+  asm volatile("multimem.ld_reduce.relaxed.sys.global.add.f32 %0, [%1];"
+               : "=f"(v)
+               : "l"(__cvta_generic_to_global(src))
+               : "memory");
+  return v;
+#else
+  return *src;
+#endif
+}
+
+// Integer add reduction. NVLS has no 128-bit (v4) integer ld_reduce, so this is
+// scalar-only (one .add.s32 per element) -- there is no v4 int fast path.
+__device__ __forceinline__ int32_t multimem_ld_reduce_s32(const int32_t* src) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  int32_t v;
+  asm volatile("multimem.ld_reduce.relaxed.sys.global.add.s32 %0, [%1];"
+               : "=r"(v)
+               : "l"(__cvta_generic_to_global(src))
+               : "memory");
+  return v;
+#else
+  return *src;
+#endif
+}
+
+__device__ __forceinline__ float4 multimem_ld_reduce_v4_f32(const float4* src) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  float4 v;
+  asm volatile(
+      "multimem.ld_reduce.relaxed.sys.global.add.v4.f32 {%0,%1,%2,%3}, [%4];"
+      : "=f"(v.x), "=f"(v.y), "=f"(v.z), "=f"(v.w)
+      : "l"(__cvta_generic_to_global(src))
+      : "memory");
+  return v;
+#else
+  return *src;
+#endif
+}
+
+// 128-bit (v4) half reduction: one multimem.ld_reduce returns the cross-rank
+// sum of 8 halves (4 packed f16x2). 16 B/op vs the 4 B/op of the scalar-pair
+// f16x2 path, matching the float v4.f32 width. kAccF32 selects f32 accumulation
+// (`.acc::f32`, the default) vs native 2-byte accumulation.
+template <bool kAccF32 = true>
+__device__ __forceinline__ uint4 multimem_ld_reduce_v4_f16x2(const uint4* src) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900 && CUDART_VERSION >= 12020
+  uint4 v;
+  if constexpr (kAccF32) {
+    asm volatile(
+        "multimem.ld_reduce.relaxed.sys.global.add.acc::f32.v4.f16x2 "
+        "{%0,%1,%2,%3}, [%4];"
+        : "=r"(v.x), "=r"(v.y), "=r"(v.z), "=r"(v.w)
+        : "l"(__cvta_generic_to_global(src))
+        : "memory");
+  } else {
+    asm volatile(
+        "multimem.ld_reduce.relaxed.sys.global.add.v4.f16x2 "
+        "{%0,%1,%2,%3}, [%4];"
+        : "=r"(v.x), "=r"(v.y), "=r"(v.z), "=r"(v.w)
+        : "l"(__cvta_generic_to_global(src))
+        : "memory");
+  }
+  return v;
+#else
+  return *src;
+#endif
+}
+
+// Reduce-load a single half: `multimem.ld_reduce.f16x2` needs a 4-byte aligned
+// address, so read the aligned pair containing `src` and pick the requested
+// lane. Safe for any alignment of `src`.
+template <bool kAccF32 = true>
+__device__ __forceinline__ __half multimem_ld_reduce_f16(const __half* src) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900 && CUDART_VERSION >= 12020
+  const uintptr_t genericAddr = reinterpret_cast<uintptr_t>(src);
+  const uintptr_t globalAddr =
+      static_cast<uintptr_t>(__cvta_generic_to_global(src));
+  const uintptr_t alignedGlobalAddr = globalAddr & ~uintptr_t{0x3};
+  uint32_t raw;
+  if constexpr (kAccF32) {
+    asm volatile(
+        "multimem.ld_reduce.relaxed.sys.global.add.acc::f32.f16x2 %0, [%1];"
+        : "=r"(raw)
+        : "l"(alignedGlobalAddr)
+        : "memory");
+  } else {
+    asm volatile("multimem.ld_reduce.relaxed.sys.global.add.f16x2 %0, [%1];"
+                 : "=r"(raw)
+                 : "l"(alignedGlobalAddr)
+                 : "memory");
+  }
+  union {
+    uint32_t r;
+    __half h[2];
+  } u{raw};
+  return u.h[(genericAddr / sizeof(__half)) & 0x1];
+#else
+  return *src;
+#endif
+}
+
+// bf16 mirrors the f16 emitters above: same widths and .acc::f32 accumulation,
+// with the `.bf16x2` packed-type variant of each multimem verb. bf16 is the
+// dominant ML training dtype.
+
+// 128-bit (v4) bf16 reduction: one multimem.ld_reduce returns the cross-rank
+// sum of 8 bf16 (4 packed bf16x2) with f32 accumulation. 16 B/op, matching
+// v4.f16x2.
+template <bool kAccF32 = true>
+__device__ __forceinline__ uint4
+multimem_ld_reduce_v4_bf16x2(const uint4* src) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900 && CUDART_VERSION >= 12020
+  uint4 v;
+  if constexpr (kAccF32) {
+    asm volatile(
+        "multimem.ld_reduce.relaxed.sys.global.add.acc::f32.v4.bf16x2 "
+        "{%0,%1,%2,%3}, [%4];"
+        : "=r"(v.x), "=r"(v.y), "=r"(v.z), "=r"(v.w)
+        : "l"(__cvta_generic_to_global(src))
+        : "memory");
+  } else {
+    asm volatile(
+        "multimem.ld_reduce.relaxed.sys.global.add.v4.bf16x2 "
+        "{%0,%1,%2,%3}, [%4];"
+        : "=r"(v.x), "=r"(v.y), "=r"(v.z), "=r"(v.w)
+        : "l"(__cvta_generic_to_global(src))
+        : "memory");
+  }
+  return v;
+#else
+  return *src;
+#endif
+}
+
+// Reduce-load a single bf16: `multimem.ld_reduce.bf16x2` needs a 4-byte aligned
+// address, so read the aligned pair containing `src` and pick the requested
+// lane. Safe for any alignment of `src`.
+template <bool kAccF32 = true>
+__device__ __forceinline__ __nv_bfloat16
+multimem_ld_reduce_bf16(const __nv_bfloat16* src) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900 && CUDART_VERSION >= 12020
+  const uintptr_t genericAddr = reinterpret_cast<uintptr_t>(src);
+  const uintptr_t globalAddr =
+      static_cast<uintptr_t>(__cvta_generic_to_global(src));
+  const uintptr_t alignedGlobalAddr = globalAddr & ~uintptr_t{0x3};
+  uint32_t raw;
+  if constexpr (kAccF32) {
+    asm volatile(
+        "multimem.ld_reduce.relaxed.sys.global.add.acc::f32.bf16x2 %0, [%1];"
+        : "=r"(raw)
+        : "l"(alignedGlobalAddr)
+        : "memory");
+  } else {
+    asm volatile("multimem.ld_reduce.relaxed.sys.global.add.bf16x2 %0, [%1];"
+                 : "=r"(raw)
+                 : "l"(alignedGlobalAddr)
+                 : "memory");
+  }
+  union {
+    uint32_t r;
+    __nv_bfloat16 b[2];
+  } u{raw};
+  return u.b[(genericAddr / sizeof(__nv_bfloat16)) & 0x1];
+#else
+  return *src;
+#endif
+}
+
+// Proxy fence between a multicast-alias read (multimem.ld_reduce) and a
+// unicast-alias store to the same physical memory (in-place no-copy reduce).
+// PTX ISA 8.6 requires a proxy fence to synchronize memory operations across
+// different proxies. No-op when kEnabled is false (out-of-place: the read and
+// store target distinct allocations, so there is no cross-proxy aliasing).
+template <bool kEnabled>
+__device__ __forceinline__ void proxy_alias_fence() {
+#if defined(__CUDA_ARCH__)
+  if constexpr (kEnabled) {
+    asm volatile("fence.proxy.alias;" ::: "memory");
+  }
+#endif
+}
+
+} // namespace comms::prims::detail
+
+namespace comms::prims::multimem {
+
+// Legacy alias for callers that historically reached the PTX helpers via
+// `comms::prims::detail`.
+namespace nocopy_detail = comms::prims::detail;
+
+// multimem.ld_reduce unroll depth on the bandwidth-critical reduce read: issue
+// this many switch-reduce loads into registers before storing, to overlap their
+// latencies (memory-level parallelism). It is the single knob for RS, direct
+// AR, and composed AR reads. 16 (not the NVLS symmetric kernels' 8) is the
+// measured sweet spot on GB300: a single CTA is memory-level-parallelism bound
+// at large sizes (one 640-thread CTA saturates the switch only at ~4 CTAs), and
+// doubling the in-flight loads lifts the low-CTA regime sharply -- 4GB no-copy
+// AllReduce goes 119->201 GB/s at 1 CTA and 230->390 GB/s at 2 CTAs, while the
+// multi-CTA plateau is unchanged (~458 GB/s at 4-8 CTAs). 32 regresses
+// everything: uint4 tmp[32] = 128 registers/thread spills for a 640-thread CTA.
+//
+// Passed as the `kUnroll` template argument of load_reduce_at (below).
+constexpr int kReduceUnroll = 16;
+
+/**
+ * multimem.ld_reduce from an ARBITRARY multicast base pointer into `dst`.
+ *
+ * `mc` must point into a multicast VA; `dst` is local. Callers that reduce
+ * relative to a transport's staging window should combine this with
+ * `transport.multimem_data_ptr(offset)`; callers that reduce the user's
+ * registered multicast send VA (a distinct multicast object) pass that
+ * pointer directly. Typed dispatch and 16-byte (v4) fast path when the
+ * pointers are jointly 16-byte aligned.
+ */
+template <
+    typename T,
+    comms::prims::MultimemRedOp Op = comms::prims::MultimemRedOp::Add,
+    // Unroll depth for the multimem-load reduce loop (see kReduceUnroll): batch
+    // this many switch-reduce loads into registers before storing, for
+    // memory-level parallelism.
+    int kUnroll = 1,
+    bool kAliased = false,
+    bool kAccF32 = true>
+__device__ __forceinline__ void load_reduce_at(
+    comms::prims::ThreadGroup& group,
+    T* dst,
+    const T* mc,
+    std::size_t elems) {
+  static_assert(
+      Op == comms::prims::MultimemRedOp::Add,
+      "multimem load_reduce_at: only Add implemented");
+  static_assert(kUnroll > 0);
+  const std::size_t stride = group.group_size;
+  const std::size_t t0 = group.thread_id_in_group;
+  const uintptr_t addrOr =
+      reinterpret_cast<uintptr_t>(mc) | reinterpret_cast<uintptr_t>(dst);
+  // When kAliased (in-place no-copy: dst aliases the multicast-read physical),
+  // the multicast read and unicast store cross proxies -> emit the PTX 8.6
+  // proxy fence between this thread's reads and its stores (no-op otherwise).
+
+  // kUnroll-wide grid-stride over 16B packs: issue kUnroll multimem.ld_reduce
+  // loads into registers before storing any, so the per-op switch-reduce
+  // latencies overlap (memory-level parallelism). Matches transport.load_reduce
+  // and reduce_broadcast_at; without it this path is latency-bound (it was the
+  // ~2-3x no-copy ReduceScatter slowdown vs AllReduce). dstVec/load_pack carry
+  // the typed 16B pack; the scalar tail stays per-element.
+  auto vec_loop = [&](auto* dstVec, std::size_t vecCount, auto load_pack) {
+    std::size_t i = t0;
+    for (; i + (kUnroll - 1) * stride < vecCount; i += kUnroll * stride) {
+      decltype(load_pack(i)) tmp[kUnroll];
+#pragma unroll
+      for (int u = 0; u < kUnroll; ++u) {
+        tmp[u] = load_pack(i + static_cast<std::size_t>(u) * stride);
+      }
+      nocopy_detail::proxy_alias_fence<kAliased>();
+#pragma unroll
+      for (int u = 0; u < kUnroll; ++u) {
+        dstVec[i + static_cast<std::size_t>(u) * stride] = tmp[u];
+      }
+    }
+    // Batched remainder: issue this thread's last (< kUnroll) packs all into
+    // registers before storing any, so a tile whose whole shard is below the
+    // kUnroll*stride threshold that engages the loop above still gets memory-
+    // level parallelism instead of collapsing to one in-flight switch-reduce
+    // per thread (the serialized single-issue tail was the ~128KiB-shard
+    // ReduceScatter/AllReduce small-message latency hump). The kAliased proxy
+    // fence between the batched load and store is preserved for in-place
+    // correctness (a no-op out-of-place).
+    {
+      decltype(load_pack(i)) tmp[kUnroll];
+#pragma unroll
+      for (int u = 0; u < kUnroll; ++u) {
+        const std::size_t idx = i + static_cast<std::size_t>(u) * stride;
+        if (idx < vecCount) {
+          tmp[u] = load_pack(idx);
+        }
+      }
+      nocopy_detail::proxy_alias_fence<kAliased>();
+#pragma unroll
+      for (int u = 0; u < kUnroll; ++u) {
+        const std::size_t idx = i + static_cast<std::size_t>(u) * stride;
+        if (idx < vecCount) {
+          dstVec[idx] = tmp[u];
+        }
+      }
+    }
+  };
+
+  if constexpr (std::is_same_v<T, float>) {
+    if ((addrOr & 0xF) == 0) {
+      const std::size_t vec = elems / 4;
+      const auto* mcVec = reinterpret_cast<const float4*>(mc);
+      vec_loop(reinterpret_cast<float4*>(dst), vec, [&](std::size_t k) {
+        return nocopy_detail::multimem_ld_reduce_v4_f32(mcVec + k);
+      });
+      for (std::size_t j = vec * 4 + t0; j < elems; j += stride) {
+        const float v = nocopy_detail::multimem_ld_reduce_f32(mc + j);
+        nocopy_detail::proxy_alias_fence<kAliased>();
+        dst[j] = v;
+      }
+    } else {
+      for (std::size_t i = t0; i < elems; i += stride) {
+        const float v = nocopy_detail::multimem_ld_reduce_f32(mc + i);
+        nocopy_detail::proxy_alias_fence<kAliased>();
+        dst[i] = v;
+      }
+    }
+  } else if constexpr (std::is_same_v<T, __half>) {
+    if ((addrOr & 0xF) == 0) {
+      const std::size_t vec = elems / 8;
+      const auto* mcVec = reinterpret_cast<const uint4*>(mc);
+      vec_loop(reinterpret_cast<uint4*>(dst), vec, [&](std::size_t k) {
+        return nocopy_detail::multimem_ld_reduce_v4_f16x2<kAccF32>(mcVec + k);
+      });
+      for (std::size_t j = vec * 8 + t0; j < elems; j += stride) {
+        const __half v = nocopy_detail::multimem_ld_reduce_f16<kAccF32>(mc + j);
+        nocopy_detail::proxy_alias_fence<kAliased>();
+        dst[j] = v;
+      }
+    } else {
+      for (std::size_t i = t0; i < elems; i += stride) {
+        const __half v = nocopy_detail::multimem_ld_reduce_f16<kAccF32>(mc + i);
+        nocopy_detail::proxy_alias_fence<kAliased>();
+        dst[i] = v;
+      }
+    }
+  } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    if ((addrOr & 0xF) == 0) {
+      const std::size_t vec = elems / 8;
+      const auto* mcVec = reinterpret_cast<const uint4*>(mc);
+      vec_loop(reinterpret_cast<uint4*>(dst), vec, [&](std::size_t k) {
+        return nocopy_detail::multimem_ld_reduce_v4_bf16x2<kAccF32>(mcVec + k);
+      });
+      for (std::size_t j = vec * 8 + t0; j < elems; j += stride) {
+        const __nv_bfloat16 v =
+            nocopy_detail::multimem_ld_reduce_bf16<kAccF32>(mc + j);
+        nocopy_detail::proxy_alias_fence<kAliased>();
+        dst[j] = v;
+      }
+    } else {
+      for (std::size_t i = t0; i < elems; i += stride) {
+        const __nv_bfloat16 v =
+            nocopy_detail::multimem_ld_reduce_bf16<kAccF32>(mc + i);
+        nocopy_detail::proxy_alias_fence<kAliased>();
+        dst[i] = v;
+      }
+    }
+  } else if constexpr (std::is_same_v<T, int32_t>) {
+    // No 128-bit integer multimem.ld_reduce -> scalar, but still unroll the
+    // issue for memory-level parallelism.
+    std::size_t i = t0;
+    for (; i + (kUnroll - 1) * stride < elems; i += kUnroll * stride) {
+      int32_t tmp[kUnroll];
+#pragma unroll
+      for (int u = 0; u < kUnroll; ++u) {
+        tmp[u] = nocopy_detail::multimem_ld_reduce_s32(
+            mc + (i + static_cast<std::size_t>(u) * stride));
+      }
+      nocopy_detail::proxy_alias_fence<kAliased>();
+#pragma unroll
+      for (int u = 0; u < kUnroll; ++u) {
+        dst[i + static_cast<std::size_t>(u) * stride] = tmp[u];
+      }
+    }
+    // Batched remainder (see vec_loop): keep MLP for small tiles; the kAliased
+    // proxy fence is preserved for in-place correctness.
+    {
+      int32_t tmp[kUnroll];
+#pragma unroll
+      for (int u = 0; u < kUnroll; ++u) {
+        const std::size_t idx = i + static_cast<std::size_t>(u) * stride;
+        if (idx < elems) {
+          tmp[u] = nocopy_detail::multimem_ld_reduce_s32(mc + idx);
+        }
+      }
+      nocopy_detail::proxy_alias_fence<kAliased>();
+#pragma unroll
+      for (int u = 0; u < kUnroll; ++u) {
+        const std::size_t idx = i + static_cast<std::size_t>(u) * stride;
+        if (idx < elems) {
+          dst[idx] = tmp[u];
+        }
+      }
+    }
+  } else {
+    static_assert(
+        sizeof(T) == 0, "multimem load_reduce_at: unsupported element type");
+  }
+}
+
+} // namespace comms::prims::multimem
+
+#endif // ENABLE_PRIMS

--- a/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
@@ -153,6 +153,38 @@ __device__ __forceinline__ uint64_t ack_signal_id(
       static_cast<uint64_t>(nvlRanks + rank);
 }
 
+// Arrival-counter barrier slots for the STAGING full barriers (input-ready in
+// stage_and_wait_all_inputs, ack in reduce_round_to_all_ranks). Live in four
+// dedicated slots past the SET-mode ready/ack region so they never alias the
+// per-peer SET slots. Counter slot is multicast-added +
+// locally read; epoch slot is a per-rank local-only baseline.
+__device__ __forceinline__ uint64_t staging_ready_counter_id(
+    const StageLayout& layout,
+    uint32_t lane,
+    int nvlRanks) {
+  return layout.signalBase +
+      static_cast<uint64_t>(lane) * layout.signalsPerLane +
+      static_cast<uint64_t>(2 * nvlRanks + 0);
+}
+__device__ __forceinline__ uint64_t
+staging_ready_epoch_id(const StageLayout& layout, uint32_t lane, int nvlRanks) {
+  return layout.signalBase +
+      static_cast<uint64_t>(lane) * layout.signalsPerLane +
+      static_cast<uint64_t>(2 * nvlRanks + 1);
+}
+__device__ __forceinline__ uint64_t
+staging_ack_counter_id(const StageLayout& layout, uint32_t lane, int nvlRanks) {
+  return layout.signalBase +
+      static_cast<uint64_t>(lane) * layout.signalsPerLane +
+      static_cast<uint64_t>(2 * nvlRanks + 2);
+}
+__device__ __forceinline__ uint64_t
+staging_ack_epoch_id(const StageLayout& layout, uint32_t lane, int nvlRanks) {
+  return layout.signalBase +
+      static_cast<uint64_t>(lane) * layout.signalsPerLane +
+      static_cast<uint64_t>(2 * nvlRanks + 3);
+}
+
 __device__ __forceinline__ uint64_t
 round_id(uint64_t roundBase, uint64_t primitiveRound) {
   return roundBase + primitiveRound + 1;

--- a/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
@@ -1,0 +1,172 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Staging-window layout + signal-slot addressing for single-NVL-domain
+// collectives.
+//
+// Shared infrastructure used by all three staging paths (ReduceScatter /
+// AllGather / AllReduce): the per-CTA staging-window geometry (`StageLayout` /
+// `make_stage_layout`) and the internal-signal slot-id helpers (ready/ack
+// per-peer SET slots and the staging ADD barrier slots). It depends only on the
+// transport struct in MultimemNvlTransportDevice.cuh, not on the reduce/store
+// PTX.
+
+// clang-tidy analyzes this .cuh as a standalone main file and misflags the
+// pragma; it is a genuine include-once header. False positive, so suppress it.
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#if defined(ENABLE_PRIMS)
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
+
+namespace comms::prims::multimem {
+
+/**
+ * Layout of one CTA-group's slice of the shared staging window.
+ *
+ * The flat per-rank data buffer is split across CTAs (groups), and each group's
+ * slice is further split into `pipelineDepth` lanes. A round picks its lane
+ * round-robin so consecutive rounds use disjoint physical windows (pipelining).
+ */
+struct StageLayout {
+  std::size_t groupBeginBytes{0}; // this group's slice origin into the buffer
+  std::size_t stagingElems{0}; // one lane window, in elements
+  std::size_t stagingBytes{0}; // one lane window, in bytes
+  uint64_t signalBase{0}; // this group's base into the internal signals
+  uint64_t signalsPerLane{0}; // 2 * nvlRanks + 4
+  uint32_t pipelineDepth{1};
+};
+
+template <typename T>
+__device__ __forceinline__ StageLayout make_stage_layout(
+    const comms::prims::MultimemNvlTransportDevice& transport,
+    uint32_t pipelineDepth,
+    comms::prims::ThreadGroup& group) {
+  if (pipelineDepth == 0) {
+    pipelineDepth = 1;
+  }
+
+  // 16-byte (uint4) alignment for every staging-window slice, so the per-rank
+  // lane offsets are 128-bit aligned and the v4 multimem.ld_reduce / store fast
+  // paths engage for all element types (not just when offsets happen to land on
+  // 16B). The backing buffer base is already page-aligned.
+  const std::size_t alignBytes = sizeof(T) < 16 ? 16 : sizeof(T);
+  const std::size_t elemsPerAlign = alignBytes / sizeof(T);
+  const std::size_t totalUnits = transport.dataBufferSize / alignBytes;
+
+#if defined(__CUDA_ARCH__)
+  if (transport.localData == nullptr || transport.multimemData == nullptr) {
+    printf("NvlMultimem transport has null data pointers\n");
+    __trap();
+  }
+  // Trap before total_groups is used as a divisor below (division by zero is UB
+  // and would happen strictly before the stagingUnits guard could catch it).
+  if (group.total_groups == 0) {
+    printf("NvlMultimem staging layout: total_groups == 0\n");
+    __trap();
+  }
+#endif
+
+  const std::size_t groupBeginUnit =
+      (totalUnits * static_cast<std::size_t>(group.group_id)) /
+      static_cast<std::size_t>(group.total_groups);
+  const std::size_t groupEndUnit =
+      (totalUnits * static_cast<std::size_t>(group.group_id + 1)) /
+      static_cast<std::size_t>(group.total_groups);
+  const std::size_t groupUnits = groupEndUnit - groupBeginUnit;
+  const std::size_t stagingUnits =
+      groupUnits / static_cast<std::size_t>(pipelineDepth);
+
+#if defined(__CUDA_ARCH__)
+  if (stagingUnits == 0) {
+    printf(
+        "NvlMultimem staging window too small: dataBufferSize=%llu "
+        "groups=%u pipelineDepth=%u alignBytes=%llu\n",
+        static_cast<unsigned long long>(transport.dataBufferSize),
+        static_cast<unsigned>(group.total_groups),
+        static_cast<unsigned>(pipelineDepth),
+        static_cast<unsigned long long>(alignBytes));
+    __trap();
+  }
+#endif
+
+  // Layout per (group, lane):
+  //   [0, nvlRanks)             ready[rank]           (SET, per-peer)
+  //   [nvlRanks, 2*nvlRanks)    ack[rank]             (SET, per-peer)
+  //   2*nvlRanks + 0            staging_ready_counter (ADD, multicast)
+  //   2*nvlRanks + 1            staging_ready_epoch   (ADD, this rank baseline)
+  //   2*nvlRanks + 2            staging_ack_counter   (ADD, multicast)
+  //   2*nvlRanks + 3            staging_ack_epoch     (ADD, this rank baseline)
+  // The four ADD-mode barrier slots MUST live outside the SET-mode ready/ack
+  // region: without this separation, flipping stagingArrivalBarrier between ops
+  // in a single process leaves ADD counter residue in slots that a later
+  // SET-mode op reads with CMP_GE, and any past-op residue trivially satisfies
+  // the wait.
+  const uint64_t signalsPerLane =
+      multimem_staging_signals_per_lane(transport.nvlRanks);
+  const uint64_t signalsPerGroup =
+      static_cast<uint64_t>(pipelineDepth) * signalsPerLane;
+  const uint64_t requiredSignals =
+      static_cast<uint64_t>(group.total_groups) * signalsPerGroup;
+#if defined(__CUDA_ARCH__)
+  if (requiredSignals > transport.internalLocalSignals.size()) {
+    printf(
+        "NvlMultimem requires %llu internal signals "
+        "(available=%u, groups=%u, pipelineDepth=%u, nvlRanks=%d)\n",
+        static_cast<unsigned long long>(requiredSignals),
+        static_cast<unsigned>(transport.internalLocalSignals.size()),
+        static_cast<unsigned>(group.total_groups),
+        static_cast<unsigned>(pipelineDepth),
+        transport.nvlRanks);
+    __trap();
+  }
+#endif
+
+  return StageLayout{
+      .groupBeginBytes = groupBeginUnit * alignBytes,
+      .stagingElems = stagingUnits * elemsPerAlign,
+      .stagingBytes = stagingUnits * alignBytes,
+      .signalBase = static_cast<uint64_t>(group.group_id) * signalsPerGroup,
+      .signalsPerLane = signalsPerLane,
+      .pipelineDepth = pipelineDepth,
+  };
+}
+
+__device__ __forceinline__ uint64_t
+ready_signal_id(const StageLayout& layout, uint32_t lane, int rank) {
+  return layout.signalBase +
+      static_cast<uint64_t>(lane) * layout.signalsPerLane +
+      static_cast<uint64_t>(rank);
+}
+
+__device__ __forceinline__ uint64_t ack_signal_id(
+    const StageLayout& layout,
+    uint32_t lane,
+    int nvlRanks,
+    int rank) {
+  return layout.signalBase +
+      static_cast<uint64_t>(lane) * layout.signalsPerLane +
+      static_cast<uint64_t>(nvlRanks + rank);
+}
+
+__device__ __forceinline__ uint64_t
+round_id(uint64_t roundBase, uint64_t primitiveRound) {
+  return roundBase + primitiveRound + 1;
+}
+
+__device__ __forceinline__ std::size_t lane_begin(
+    const StageLayout& layout,
+    uint64_t primitiveRound) {
+  const uint32_t lane =
+      static_cast<uint32_t>(primitiveRound % layout.pipelineDepth);
+  return layout.groupBeginBytes +
+      static_cast<std::size_t>(lane) * layout.stagingBytes;
+}
+
+} // namespace comms::prims::multimem
+
+#endif // ENABLE_PRIMS

--- a/comms/prims/transport/nvl/MultimemNvlStaging.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlStaging.cuh
@@ -1,0 +1,253 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Generic NVL multimem staging protocol for single-NVL-domain collectives.
+//
+// The reduction path follows the NVLS staging model: all local ranks write
+// their contribution to the same offset in their private unicast backing, then
+// the reducer reads that offset through the multicast VA with the
+// `load_reduce_at` free function (multimem.ld_reduce). Broadcast uses the
+// `store` free function (multimem.st). This header carries no collective- or
+// algorithm-specific state (no KernArgs, no IB, no segment math); it reads its
+// rank topology and buffers straight from MultimemNvlTransportDevice and is
+// driven by thin per-collective loops (ReduceScatter / AllGather / AllReduce).
+//
+// The building blocks are split across sibling headers, all pulled in here:
+//   - MultimemNvlStore.cuh       multimem.st store PTX + `store<>`
+//   - MultimemNvlReduce.cuh      multimem.ld_reduce PTX + `load_reduce_at<>`
+//   - MultimemNvlStageLayout.cuh staging-window layout + signal-slot addressing
+// This umbrella header adds the round-level staging orchestration that composes
+// them (`reduce_from_multimem`, `stage_and_wait_all_inputs`,
+// `reduce_round_to_all_ranks`, `reduce_scatter_allgather_round`).
+//
+// Namespace: comms::prims::multimem.
+
+#pragma once
+
+#if defined(ENABLE_PRIMS)
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/prims/core/CopyUtils.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlReduce.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlStageLayout.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlStore.cuh"
+
+namespace comms::prims::multimem {
+
+template <typename T, bool kAccF32 = true>
+__device__ __forceinline__ void reduce_from_multimem(
+    const comms::prims::MultimemNvlTransportDevice& transport,
+    const StageLayout& layout,
+    uint64_t primitiveRound,
+    T* dst,
+    std::size_t elems,
+    comms::prims::ThreadGroup& group) {
+  const T* mc = reinterpret_cast<const T*>(
+      transport.multimem_data_ptr(lane_begin(layout, primitiveRound)));
+  load_reduce_at<
+      T,
+      comms::prims::MultimemRedOp::Add,
+      kReduceUnroll,
+      /*kAliased=*/false,
+      kAccF32>(group, dst, mc, elems);
+}
+
+template <typename T>
+__device__ __forceinline__ void stage_and_wait_all_inputs(
+    const comms::prims::MultimemNvlTransportDevice& transport,
+    const StageLayout& layout,
+    uint64_t roundId,
+    uint64_t primitiveRound,
+    const T* src,
+    std::size_t elems,
+    comms::prims::ThreadGroup& group) {
+  const uint32_t lane =
+      static_cast<uint32_t>(primitiveRound % layout.pipelineDepth);
+  const std::size_t bytes = elems * sizeof(T);
+  // Stage this rank's input into the shared window with 8-deep vectorized copy
+  // (matches the broadcast path); 16B uint4 stores, 8 per thread per pass.
+  comms::prims::memcpy_vectorized<8>(
+      transport.local_data_ptr(lane_begin(layout, primitiveRound)),
+      reinterpret_cast<const char*>(src),
+      bytes,
+      group);
+  if (transport.stagingArrivalBarrier) {
+    // O(1) arrival-counter barrier: the +nvlRanks accumulation across rounds
+    // (lane reused every pipelineDepth rounds) and across ops is handled by the
+    // per-slot epoch, exactly like the no-copy path. `roundId` is unused here.
+    (void)roundId;
+    transport.arrival_barrier(
+        group,
+        staging_ready_counter_id(layout, lane, transport.nvlRanks),
+        staging_ready_epoch_id(layout, lane, transport.nvlRanks));
+    return;
+  }
+  transport.signal_internal(
+      group,
+      ready_signal_id(layout, lane, transport.nvlRank),
+      comms::prims::SignalOp::SIGNAL_SET,
+      roundId);
+
+  for (int rank = 0; rank < transport.nvlRanks; ++rank) {
+    transport.wait_internal_signal_until(
+        group,
+        ready_signal_id(layout, lane, rank),
+        comms::prims::CmpOp::CMP_GE,
+        roundId);
+  }
+}
+
+template <typename T, bool kAccF32 = true>
+__device__ __forceinline__ void reduce_round_to_all_ranks(
+    const comms::prims::MultimemNvlTransportDevice& transport,
+    const StageLayout& layout,
+    uint64_t roundId,
+    uint64_t primitiveRound,
+    T* dst,
+    std::size_t elems,
+    comms::prims::ThreadGroup& group) {
+  const uint32_t lane =
+      static_cast<uint32_t>(primitiveRound % layout.pipelineDepth);
+  reduce_from_multimem<T, kAccF32>(
+      transport, layout, primitiveRound, dst, elems, group);
+  if (transport.stagingArrivalBarrier) {
+    // O(1) arrival barrier replacing the per-peer ack full barrier. Only
+    // `direct` calls this; `direct_rsag` keeps its per-owner ack interleaving
+    // in reduce_scatter_allgather_round, so the ack[] SET slots stay live there
+    // and the arrival counter/epoch slots are chosen disjoint from them.
+    (void)roundId;
+    transport.arrival_barrier(
+        group,
+        staging_ack_counter_id(layout, lane, transport.nvlRanks),
+        staging_ack_epoch_id(layout, lane, transport.nvlRanks));
+    return;
+  }
+  transport.signal_internal(
+      group,
+      ack_signal_id(layout, lane, transport.nvlRanks, transport.nvlRank),
+      comms::prims::SignalOp::SIGNAL_SET,
+      roundId);
+  for (int rank = 0; rank < transport.nvlRanks; ++rank) {
+    transport.wait_internal_signal_until(
+        group,
+        ack_signal_id(layout, lane, transport.nvlRanks, rank),
+        comms::prims::CmpOp::CMP_GE,
+        roundId);
+  }
+}
+
+/**
+ * Fused reduce-scatter + all-gather for one staging round (the cnvlmm AllReduce
+ * `direct_rsag` large-message path). Requires `stage_and_wait_all_inputs` to
+ * have already staged every rank's input slice into the window for this round.
+ *
+ * Unlike `reduce_round_to_all_ranks` (where EVERY rank multimem.ld_reduces the
+ * FULL slice -> ~nvlRanks x switch egress, which plateaus at large sizes), each
+ * rank here reduces ONLY its own 1/nvlRanks shard (a disjoint sub-region) into
+ * its output, then broadcasts that reduced shard to all peers via
+ * multimem::store (multimem.st). Every rank ends with the full reduced slice.
+ * Switch traffic is ~1x reduce-read + ~1x broadcast (the NVLS
+ * reduce-scatter+all-gather shape).
+ *
+ * Shards use the ceil convention; idle/partial tail shards stay in lockstep
+ * (still signal/wait). The per-shard ack wait is a full barrier (each rank
+ * waits all other owners), bounding cross-rank drift to < 1 round so lane reuse
+ * under pipelining is safe.
+ */
+template <typename T, bool kAccF32 = true>
+__device__ __forceinline__ void reduce_scatter_allgather_round(
+    const comms::prims::MultimemNvlTransportDevice& transport,
+    const StageLayout& layout,
+    uint64_t roundId,
+    uint64_t primitiveRound,
+    T* dst,
+    std::size_t elems,
+    comms::prims::ThreadGroup& group) {
+  const uint32_t lane =
+      static_cast<uint32_t>(primitiveRound % layout.pipelineDepth);
+  const std::size_t laneBeginBytes = lane_begin(layout, primitiveRound);
+  const int nvlRanks = transport.nvlRanks;
+  const int self = transport.nvlRank;
+  // Round the per-rank shard up to the 16-byte vector width so every rank's
+  // shard base (self * shardElems) is 16-byte aligned in the multicast window.
+  // A non-16B-aligned multimem.ld_reduce base is run-to-run NON-deterministic
+  // for fp16/bf16 (the switch's cross-rank accumulation of a misaligned read
+  // varies by ~1 ULP); a 16B-aligned base uses the deterministic v4 read, so
+  // the 2-shot reduce-scatter matches the 1-shot (aligned base 0) path bit for
+  // bit. Coverage stays complete (shards over-cover; tail shards clamp/idle).
+  const std::size_t kVecElems = 16 / sizeof(T) > 0 ? 16 / sizeof(T) : 1;
+  const std::size_t rawShard =
+      (elems + static_cast<std::size_t>(nvlRanks) - 1) /
+      static_cast<std::size_t>(nvlRanks);
+  const std::size_t shardElems =
+      ((rawShard + kVecElems - 1) / kVecElems) * kVecElems;
+
+  // Reduce-scatter: reduce this rank's own shard from the multicast window into
+  // its output slot.
+  const std::size_t myBegin = static_cast<std::size_t>(self) * shardElems;
+  const std::size_t myElems = myBegin < elems
+      ? (elems - myBegin < shardElems ? elems - myBegin : shardElems)
+      : 0;
+  if (myElems > 0) {
+    const T* myMc = reinterpret_cast<const T*>(
+        transport.multimem_data_ptr(laneBeginBytes + myBegin * sizeof(T)));
+    load_reduce_at<
+        T,
+        comms::prims::MultimemRedOp::Add,
+        kReduceUnroll,
+        /*kAliased=*/false,
+        kAccF32>(group, dst + myBegin, myMc, myElems);
+  }
+  // load_reduce wrote dst[myBegin..]; the broadcast store reads it back, and
+  // the two map threads to elements differently, so order the write before the
+  // read.
+  group.sync();
+  // Broadcast the reduced shard to all backings' window slot (multimem.st).
+  // Each rank stores its OWN shard byte-count here (asymmetric across ranks -
+  // tail/idle shards differ), which is fine despite store()'s "same bytes"
+  // note: store() does no cross-rank coordination, and the all-gather readers
+  // below recompute each owner's shard size deterministically from the shared
+  // shardElems/elems, so the per-owner byte counts always match.
+  if (myElems > 0) {
+    store<8>(
+        group,
+        transport.multimem_data_ptr(laneBeginBytes + myBegin * sizeof(T)),
+        dst + myBegin,
+        myElems * sizeof(T));
+  }
+  transport.signal_internal(
+      group,
+      ack_signal_id(layout, lane, nvlRanks, self),
+      comms::prims::SignalOp::SIGNAL_SET,
+      roundId);
+
+  // All-gather: once each owner's broadcast is visible (the ack release/acquire
+  // pairs the multimem.st with these reads), copy its reduced shard into dst.
+  for (int s = 0; s < nvlRanks; ++s) {
+    if (s == self) {
+      continue;
+    }
+    transport.wait_internal_signal_until(
+        group,
+        ack_signal_id(layout, lane, nvlRanks, s),
+        comms::prims::CmpOp::CMP_GE,
+        roundId);
+    const std::size_t sBegin = static_cast<std::size_t>(s) * shardElems;
+    const std::size_t sElems = sBegin < elems
+        ? (elems - sBegin < shardElems ? elems - sBegin : shardElems)
+        : 0;
+    if (sElems > 0) {
+      comms::prims::memcpy_vectorized<8>(
+          reinterpret_cast<char*>(dst + sBegin),
+          transport.local_data_ptr(laneBeginBytes + sBegin * sizeof(T)),
+          sElems * sizeof(T),
+          group);
+    }
+  }
+}
+
+} // namespace comms::prims::multimem
+
+#endif // ENABLE_PRIMS

--- a/comms/prims/transport/nvl/MultimemNvlStore.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlStore.cuh
@@ -1,0 +1,273 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// multimem.st broadcast primitives for single-NVL-domain collectives.
+//
+// Holds the store side of the NVLS staging model: the raw `multimem.st` PTX
+// emitters (`comms::prims::detail`) and the public bulk-broadcast entry point
+// `multimem::store<>` that broadcasts a local buffer into a multicast VA (every
+// store through the VA is replicated by NVSwitch into all ranks' backings). The
+// reduce side lives in `MultimemNvlReduce.cuh`; the staging orchestration that
+// composes both lives in `MultimemNvlStaging.cuh`.
+
+// clang-tidy analyzes this .cuh as a standalone main file and misflags the
+// pragma; it is a genuine include-once header. False positive, so suppress it.
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#if defined(ENABLE_PRIMS)
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
+
+// PTX helpers extend the transport header's existing `comms::prims::detail`
+// namespace (which already holds the release.sys signal-path emitters). The
+// public free-function entry point (`store<>`) lives in
+// `comms::prims::multimem` further below and delegates into `detail::` for the
+// raw PTX.
+namespace comms::prims::detail {
+
+// ----------------------------------------------------------------------------
+// multimem.st store helpers (relaxed.sys, data-path).
+// Signal-path emitters live in MultimemNvlTransportDevice.cuh as
+// `detail::multimem_store_release_sys_u64` / `multimem_red_release_sys_add_u64`
+// (release.sys) and are separate from these because they carry the
+// producer/consumer handshake.
+// ----------------------------------------------------------------------------
+
+__device__ __forceinline__ uint8_t load_u8_unaligned(const char* src) {
+  return *reinterpret_cast<const uint8_t*>(src);
+}
+
+__device__ __forceinline__ uint16_t load_u16_unaligned(const char* src) {
+  const auto* bytes = reinterpret_cast<const uint8_t*>(src);
+  return static_cast<uint16_t>(bytes[0]) |
+      (static_cast<uint16_t>(bytes[1]) << 8);
+}
+
+__device__ __forceinline__ uint32_t load_u32_unaligned(const char* src) {
+  const auto* bytes = reinterpret_cast<const uint8_t*>(src);
+  return static_cast<uint32_t>(bytes[0]) |
+      (static_cast<uint32_t>(bytes[1]) << 8) |
+      (static_cast<uint32_t>(bytes[2]) << 16) |
+      (static_cast<uint32_t>(bytes[3]) << 24);
+}
+
+__device__ __forceinline__ uint64_t load_u64_unaligned(const char* src) {
+  return static_cast<uint64_t>(load_u32_unaligned(src)) |
+      (static_cast<uint64_t>(load_u32_unaligned(src + 4)) << 32);
+}
+
+__device__ __forceinline__ uint4 load_v4_u32_unaligned(const char* src) {
+  return uint4{
+      load_u32_unaligned(src),
+      load_u32_unaligned(src + 4),
+      load_u32_unaligned(src + 8),
+      load_u32_unaligned(src + 12)};
+}
+
+// NOTE: multimem_store_u8 and multimem_store_u16 emit regular `st.global.bN`
+// rather than `multimem.st.*`. PTX `multimem.st.*` only exists for 4/8/16-byte
+// widths; for 1- and 2-byte sub-tail stores the multicast semantics still
+// apply because `dst` is a multimem virtual address - every store through that
+// VA is replicated by NVSwitch regardless of the underlying PTX opcode. The
+// `multimem_` prefix here denotes "store into the multimem VA", not the
+// `multimem.*` PTX family.
+__device__ __forceinline__ void multimem_store_u8(uint8_t* dst, uint8_t v) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("st.global.b8 [%0], %1;"
+               :
+               : "l"(dst), "r"(static_cast<uint32_t>(v))
+               : "memory");
+#else
+  *dst = v;
+#endif
+}
+
+__device__ __forceinline__ void multimem_store_u16(uint16_t* dst, uint16_t v) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("st.global.b16 [%0], %1;" : : "l"(dst), "h"(v) : "memory");
+#else
+  *dst = v;
+#endif
+}
+
+__device__ __forceinline__ void multimem_store_u32(uint32_t* dst, uint32_t v) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("multimem.st.global.b32 [%0], %1;"
+               :
+               : "l"(dst), "r"(v)
+               : "memory");
+#else
+  *dst = v;
+#endif
+}
+
+__device__ __forceinline__ void multimem_store_u64(uint64_t* dst, uint64_t v) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("multimem.st.global.b64 [%0], %1;"
+               :
+               : "l"(dst), "l"(v)
+               : "memory");
+#else
+  *dst = v;
+#endif
+}
+
+__device__ __forceinline__ void multimem_store_v4_u32(uint4* dst, uint4 v) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("multimem.st.global.v4.f32 [%0], {%1,%2,%3,%4};"
+               :
+               : "l"(dst), "r"(v.x), "r"(v.y), "r"(v.z), "r"(v.w)
+               : "memory");
+#else
+  *dst = v;
+#endif
+}
+
+template <int kUnroll>
+__device__ __forceinline__ void strided_multimem_store_aligned(
+    comms::prims::ThreadGroup& group,
+    uint4* dstVec,
+    const uint4* srcVec,
+    std::size_t vecCount) {
+  static_assert(kUnroll > 0);
+  constexpr std::size_t unroll = static_cast<std::size_t>(kUnroll);
+  const std::size_t loopStride =
+      static_cast<std::size_t>(group.group_size) * unroll;
+  const std::size_t alignedVecCount = (vecCount / loopStride) * loopStride;
+
+  for (std::size_t i = group.thread_id_in_group; i < alignedVecCount;
+       i += loopStride) {
+    uint4 vals[kUnroll];
+#pragma unroll
+    for (int j = 0; j < kUnroll; ++j) {
+      vals[j] = srcVec[i + static_cast<std::size_t>(j) * group.group_size];
+    }
+#pragma unroll
+    for (int j = 0; j < kUnroll; ++j) {
+      const std::size_t offset =
+          i + static_cast<std::size_t>(j) * group.group_size;
+      multimem_store_v4_u32(dstVec + offset, vals[j]);
+    }
+  }
+
+  for (std::size_t i = alignedVecCount + group.thread_id_in_group; i < vecCount;
+       i += group.group_size) {
+    multimem_store_v4_u32(dstVec + i, srcVec[i]);
+  }
+}
+
+__device__ __forceinline__ void
+multimem_store_bytes(char* dst, const char* src, std::size_t bytes) {
+  while (bytes > 0) {
+    const auto dstAddr = reinterpret_cast<uintptr_t>(dst);
+    if (bytes >= sizeof(uint4) && (dstAddr & 0xF) == 0) {
+      multimem_store_v4_u32(
+          reinterpret_cast<uint4*>(dst), load_v4_u32_unaligned(src));
+      dst += sizeof(uint4);
+      src += sizeof(uint4);
+      bytes -= sizeof(uint4);
+    } else if (bytes >= sizeof(uint64_t) && (dstAddr & 0x7) == 0) {
+      multimem_store_u64(
+          reinterpret_cast<uint64_t*>(dst), load_u64_unaligned(src));
+      dst += sizeof(uint64_t);
+      src += sizeof(uint64_t);
+      bytes -= sizeof(uint64_t);
+    } else if (bytes >= sizeof(uint32_t) && (dstAddr & 0x3) == 0) {
+      multimem_store_u32(
+          reinterpret_cast<uint32_t*>(dst), load_u32_unaligned(src));
+      dst += sizeof(uint32_t);
+      src += sizeof(uint32_t);
+      bytes -= sizeof(uint32_t);
+    } else if (bytes >= sizeof(uint16_t) && (dstAddr & 0x1) == 0) {
+      multimem_store_u16(
+          reinterpret_cast<uint16_t*>(dst), load_u16_unaligned(src));
+      dst += sizeof(uint16_t);
+      src += sizeof(uint16_t);
+      bytes -= sizeof(uint16_t);
+    } else {
+      multimem_store_u8(
+          reinterpret_cast<uint8_t*>(dst), load_u8_unaligned(src));
+      ++dst;
+      ++src;
+      --bytes;
+    }
+  }
+}
+
+__device__ __forceinline__ void strided_multimem_store_unaligned(
+    comms::prims::ThreadGroup& group,
+    char* dst,
+    const char* src,
+    std::size_t bytes) {
+  constexpr std::size_t kChunkBytes = sizeof(uint4);
+  for (std::size_t offset =
+           static_cast<std::size_t>(group.thread_id_in_group) * kChunkBytes;
+       offset < bytes;
+       offset += static_cast<std::size_t>(group.group_size) * kChunkBytes) {
+    const std::size_t remaining = bytes - offset;
+    multimem_store_bytes(
+        dst + offset,
+        src + offset,
+        remaining < kChunkBytes ? remaining : kChunkBytes);
+  }
+}
+
+} // namespace comms::prims::detail
+
+namespace comms::prims::multimem {
+
+/**
+ * Bulk broadcast into a multimem VA. When both `src` and `dst` are 16-byte
+ * aligned, the bulk goes through the unrolled vectorized v4.f32 fast path
+ * (`detail::strided_multimem_store_aligned<kUnroll>`) plus a tail.
+ *
+ * Any other alignment (including 16B-aligned `dst` with unaligned `src`) uses
+ * `detail::strided_multimem_store_unaligned`, which still issues a v4
+ * `multimem.st` per 16-byte chunk whenever `dst` is 16B-aligned -- gathering
+ * the unaligned `src` via `load_v4_u32_unaligned` -- and only steps down to
+ * 8/4/2/1-byte multimem stores for sub-16B `dst` alignment or the final tail.
+ * It forgoes the fully-aligned path's `kUnroll` batching; a dedicated unrolled
+ * aligned-dst/unaligned-src path is intentionally omitted, since the staging
+ * buffers are 16B-aligned on both ends so that shape is not the hot path and
+ * the extra specialization is not worth the complexity.
+ *
+ * `dst` must point into a multimem VA (typically
+ * `transport.multimem_data_ptr(offset)`); `src` is a local buffer. All ranks
+ * in the NVL team must call with the same `bytes`.
+ */
+template <int kUnroll>
+__device__ __forceinline__ void store(
+    comms::prims::ThreadGroup& group,
+    char* dst,
+    const void* src,
+    std::size_t bytes) {
+  static_assert(kUnroll > 0);
+  const auto srcAddr = reinterpret_cast<uintptr_t>(src);
+  const auto dstAddr = reinterpret_cast<uintptr_t>(dst);
+  if (((srcAddr | dstAddr) & 0xF) == 0) {
+    const std::size_t alignedBytes = bytes & ~static_cast<std::size_t>(0xF);
+    auto* srcVec = reinterpret_cast<const uint4*>(src);
+    auto* dstVec = reinterpret_cast<uint4*>(dst);
+    const std::size_t vecCount = alignedBytes / sizeof(uint4);
+    comms::prims::detail::strided_multimem_store_aligned<kUnroll>(
+        group, dstVec, srcVec, vecCount);
+    if (alignedBytes != bytes) {
+      comms::prims::detail::strided_multimem_store_unaligned(
+          group,
+          dst + alignedBytes,
+          static_cast<const char*>(src) + alignedBytes,
+          bytes - alignedBytes);
+    }
+  } else {
+    comms::prims::detail::strided_multimem_store_unaligned(
+        group, dst, static_cast<const char*>(src), bytes);
+  }
+}
+
+} // namespace comms::prims::multimem
+
+#endif // ENABLE_PRIMS

--- a/comms/prims/transport/nvl/MultimemNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.cc
@@ -107,6 +107,14 @@ MultimemNvlTransport::MultimemNvlTransport(
       break;
     }
   }
+  // Defensive backstop for the validateRankMap invariant: a -1 here would flow
+  // into device-side signal-slot indexing and produce out-of-bounds offsets, so
+  // fail loudly rather than corrupt memory if the map ever omits this rank.
+  if (nvlRank < 0) {
+    throw std::runtime_error(
+        "MultimemNvlTransport: commRank not found in nvlRankToCommRank_");
+  }
+  nvlRank_ = nvlRank;
 
   cudaDevice_ = getCurrentCudaDevice();
 
@@ -217,6 +225,8 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
       .internalMultimemSignals = DeviceSpan<SignalState>(
           multimemSignals + userSignalCount, internalSignalCount),
       .dataBufferSize = config_.dataBufferSize,
+      .nvlRank = nvlRank_,
+      .nvlRanks = nvlRanks_,
   };
 }
 

--- a/comms/prims/transport/nvl/MultimemNvlTransport.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.h
@@ -99,6 +99,10 @@ class MultimemNvlTransport {
  private:
   const int commRank_{-1};
   const int nvlRanks_{-1};
+  // This rank's index within the NVL team (its position in nvlRankToCommRank_).
+  // Retained so getDeviceTransport() can expose it to the device staging
+  // protocol, which keys its per-rank signal slots on the NVL-local rank.
+  int nvlRank_{-1};
   const std::vector<int> nvlRankToCommRank_;
   // Recorded after the rank-map validation in the constructor body so a bad
   // topology fails before cudaGetDevice is consulted (lets tests cover the

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -15,6 +15,18 @@
 
 namespace comms::prims {
 
+// Per-lane internal-signal count for the staging pipeline: the single source of
+// truth shared by the host-side signal-region sizing (CtranPipes) and the
+// device-side `make_stage_layout` (MultimemNvlStageLayout.cuh) so the region is
+// sized identically on both sides. Layout per lane: `nvlRanks` per-peer ready[]
+// + `nvlRanks` per-peer ack[] + 4 staging arrival-barrier slots (ready/ack
+// counter+epoch, laid out past the SET-mode slots so ADD residue never
+// contaminates a later SET-mode CMP_GE wait) => 2 * nvlRanks + 4.
+__host__ __device__ constexpr uint32_t multimem_staging_signals_per_lane(
+    int nvlRanks) {
+  return static_cast<uint32_t>(2 * nvlRanks + 4);
+}
+
 namespace detail {
 
 __device__ __forceinline__ void multimem_store_release_sys_u64(

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -89,6 +89,14 @@ struct MultimemNvlTransportDevice {
   std::size_t dataBufferSize{0};
   int nvlRank{0};
   int nvlRanks{1};
+  // When true, the STAGING full barriers (input-ready in
+  // stage_and_wait_all_inputs, ack in reduce_round_to_all_ranks) use the O(1)
+  // arrival-counter barrier instead of the per-peer SIGNAL_SET loop. Plumbed
+  // from NCCL_CTRAN_ALLREDUCE_CNVLMM_STAGING_ARRIVAL_BARRIER. The arrival
+  // counter/epoch slots are repurposed from the per-(group,lane) staging signal
+  // region (disjoint from the rsag ack[] slots), so this needs no host sizing
+  // change. The device cannot read cvars, hence this bool field.
+  bool stagingArrivalBarrier{false};
 
   __device__ __forceinline__ char* local_data_ptr(std::size_t offset) const {
     return localData + offset;
@@ -140,6 +148,63 @@ struct MultimemNvlTransportDevice {
       const Timeout& timeout = Timeout()) const {
     internal_local_signal_ptr(signal_id)->wait_until(
         group, op, expected, timeout);
+  }
+
+  /**
+   * O(1) arrival-counter barrier over the NVL team (NVLS lsa_barrier-style),
+   * built from the existing SIGNAL_ADD / wait primitives.
+   *
+   * `counter_id` is a multicast-backed internal slot used ONLY by this barrier
+   * point (one per CTA group), and `epoch_id` is a separate internal slot used
+   * as this rank's PRIVATE (local-view-only) baseline. Each barrier: the group
+   * leader multimem.red.add's 1 into the counter (fanning +1 into every rank's
+   * backing), so after all `nvlRanks` arrive every rank's local copy of the
+   * counter has advanced by exactly `nvlRanks`. The group then waits its single
+   * local counter slot to reach `epoch + nvlRanks` and advances the epoch. The
+   * u64 counter is monotonic and never reset, so no wraparound handling is
+   * needed; the wait `Timeout` turns a mismatch into a clean abort, not a hang.
+   *
+   * Replaces the legacy O(nvlRanks) per-peer SIGNAL_SET barrier (every rank
+   * polls all N peer slots). Caller must use disjoint (counter_id, epoch_id)
+   * slots per barrier point and per CTA group; both must be zero-initialized
+   * (the internal signal region is) and persist across launches (it does).
+   *
+   * PRECONDITION: for a given communicator+signal-region, the (group_id, lane,
+   * barrier-point) -> physical slot mapping must be stable across every op that
+   * uses this barrier. The per-group base depends only on group_id, so varying
+   * numBlocks/total_groups across ops is safe; `nvlRanks` is fixed per comm.
+   * The one variable that would break the counter/epoch pairing is
+   * `pipelineDepth` (it scales the per-lane stride): all ops on a comm that use
+   * this barrier MUST use the same pipelineDepth, else a slot inherits residue
+   * from an op with a different geometry and `target` becomes unreachable
+   * (Timeout) or already-satisfied (premature release). Unlike the SET path
+   * (absolute monotonic roundId), the ADD counter has no self-correcting
+   * absolute value.
+   */
+  __device__ __forceinline__ void arrival_barrier(
+      ThreadGroup& group,
+      uint64_t counter_id,
+      uint64_t epoch_id,
+      const Timeout& timeout = Timeout()) const {
+    // The arrival target is this transport's multicast team size (`nvlRanks`);
+    // taken from the member so a caller cannot pass a mismatched count (which
+    // would skew the target: too large -> hang until Timeout, too small ->
+    // premature release).
+    const uint64_t target = internal_local_signal_ptr(epoch_id)->load() +
+        static_cast<uint64_t>(nvlRanks);
+    // Arrive: leader adds 1 to the shared multicast counter (fences +
+    // group.sync internally, then the multimem.red.add fans the increment to
+    // all backings).
+    signal_internal(group, counter_id, SignalOp::SIGNAL_ADD, 1);
+    // Wait: O(1) - spin this rank's single local counter slot until all
+    // arrived.
+    wait_internal_signal_until(
+        group, counter_id, CmpOp::CMP_GE, target, timeout);
+    // Advance this rank's private baseline for the next use of this slot.
+    if (group.is_leader()) {
+      internal_local_signal_ptr(epoch_id)->store(target);
+    }
+    group.sync();
   }
 
  private:

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -65,15 +65,19 @@ __device__ __forceinline__ void multimem_red_release_sys_add_u64(
 
 } // namespace detail
 
+/** Reduction operator for the multimem data reduce verbs. Only Add today. */
+enum class MultimemRedOp { Add };
+
 /**
  * Device-side handle for one multicast staging window.
  *
  * `multimemData` and multimem signal spans are multicast VAs. Writes into the
  * multicast pointer preserve multicast semantics; `localData` and local signal
  * spans are this rank's backing memory after multicast replication. Callers
- * that want to broadcast into the multicast VA should obtain
- * `multimem_data_ptr()` and use PTX `multimem.st.*` intrinsics (or a helper
- * built on top, e.g. the one in `MultimemNvlStaging.cuh`).
+ * that want to broadcast into or reduce from the multicast VA should obtain
+ * `multimem_data_ptr()` and pass it to the `multimem::store()` (multimem.st) /
+ * `multimem::load_reduce_at()` (multimem.ld_reduce) free functions, defined in
+ * `MultimemNvlStore.cuh` / `MultimemNvlReduce.cuh`.
  */
 struct MultimemNvlTransportDevice {
   char* localData{nullptr};
@@ -83,6 +87,8 @@ struct MultimemNvlTransportDevice {
   DeviceSpan<SignalState> internalLocalSignals{};
   DeviceSpan<SignalState> internalMultimemSignals{};
   std::size_t dataBufferSize{0};
+  int nvlRank{0};
+  int nvlRanks{1};
 
   __device__ __forceinline__ char* local_data_ptr(std::size_t offset) const {
     return localData + offset;

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1534,6 +1534,18 @@ cvars:
     each is used with a dedicated NVLink peer. It serves as a bi-directional
     point-to-point staged data copy channel between every two peers.
 
+ - name        : MCCL_NVL_MULTIMEM_BUFSIZE
+   type        : uint64_t
+   default     : 33554432
+   description : |-
+    Size in bytes of the cnvlmm (NVLink multimem) staging window, per rank.
+    Decoupled from NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE so the multimem path can
+    use a larger window without growing the P2P staging buffers. A larger window
+    means fewer staging rounds, which is the dominant cnvlmm throughput lever at
+    large message sizes. 0 falls back to the effective P2P NVL shared devbuf
+    size (the larger of the P2P and hier-AG NVL devbuf sizes when hier-AG
+    overlap is enabled). Default 32 MiB.
+
 
  - name        : CTRAN_P2P_NVL_DEVMEM_MAX_CHUNKS
    type        : uint64_t

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3251,6 +3251,22 @@ cvars:
    description : |-
      Use f32 accumulation for fp16/bf16 multimem reduce; false = native 2-byte accumulation.
 
+ - name        : MCCL_ALLGATHER_ALGO
+   type        : enum
+   default     : none
+   choices     : none, cnvlmm
+   description : |-
+     Selects the MCCL-hosted AllGather algorithm dispatched through the
+     ICollective interface (McclComm::allGather).
+     none - do not select an MCCL-hosted algorithm; fall through to the existing
+            ctran AllGather path (NCCL_ALLGATHER_ALGO).
+     cnvlmm - single-NVLink-domain AllGather over NVLink multimem (NVLS store).
+              Requires nNodes==1, >2 local ranks, and a Prims-backed multimem
+              NVL transport; store-only over fp32/fp16/bf16/int32 element
+              widths. Explicitly selecting cnvlmm is a hard requirement: if the
+              comm/opts are unsupported the request is rejected
+              (commInvalidArgument); it does not fall back to the baseline path.
+
  - name        : MCCL_BOOTSTRAP_SOCKET_HEALTH_POLL_ENABLED
    type        : bool
    default     : true

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1886,6 +1886,17 @@ cvars:
      initialize MultiPeerTransport which provides unified NVLink and IBGDA
      transport for P2P communication.
 
+ - name        : MCCL_ALLREDUCE_CNVLMM_ONESHOT_BYTES_THRESHOLD
+   type        : uint64_t
+   default     : 131072
+   description : |-
+     Total message size in bytes at or below which the cnvlmm (NVLink multimem)
+     staging AllReduce uses the 1-shot reduce-to-all path; larger messages use
+     the 2-shot reduce-scatter + all-gather path. 1-shot has every rank
+     reduce-read the full slice (lowest latency, ~nranks x switch egress);
+     2-shot reduces only each rank's shard then broadcasts it (~1x reduce + 1x
+     broadcast, saturates bandwidth at large sizes). Only affects the staging
+     (unregistered-buffer) path; the no-copy path is always 2-shot. Default 128 KiB.
  - name        : NCCL_CTRAN_PIPES_TRACE_ENABLE
    type        : bool
    default     : false
@@ -3264,6 +3275,23 @@ cvars:
               Requires nNodes==1, >2 local ranks, and a Prims-backed multimem
               NVL transport; store-only over fp32/fp16/bf16/int32 element
               widths. Explicitly selecting cnvlmm is a hard requirement: if the
+              comm/opts are unsupported the request is rejected
+              (commInvalidArgument); it does not fall back to the baseline path.
+
+ - name        : MCCL_ALLREDUCE_ALGO
+   type        : enum
+   default     : none
+   choices     : none, cnvlmm
+   description : |-
+     Selects the MCCL-hosted AllReduce algorithm dispatched through the
+     ICollective interface (McclComm::allReduce).
+     none - do not select an MCCL-hosted algorithm; fall through to the existing
+            AllReduce dispatch (NCCL_ALLREDUCE_ALGO, incl. the fused ctree/
+            cthierarchical_ring paths).
+     cnvlmm - single-NVLink-domain AllReduce over NVLink multimem (NVLS
+              in-switch reduce). Requires nNodes==1, >2 local ranks, a Prims-
+              backed multimem NVL transport, and commSum over fp32/fp16/bf16/
+              int32. Explicitly selecting cnvlmm is a hard requirement: if the
               comm/opts are unsupported the request is rejected
               (commInvalidArgument); it does not fall back to the baseline path.
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3229,6 +3229,28 @@ cvars:
      Usage: If the NCCL_CTRAN_BACKENS is set with certain values,
      this config will allow MCCL to override backends.
 
+ - name        : MCCL_REDUCESCATTER_ALGO
+   type        : enum
+   default     : none
+   choices     : none, cnvlmm
+   description : |-
+     Selects the MCCL-hosted ReduceScatter algorithm dispatched through the
+     ICollective interface (McclComm::reduceScatter).
+     none - do not select an MCCL-hosted algorithm; fall through to the existing
+            ctran ReduceScatter path (NCCL_REDUCESCATTER_ALGO).
+     cnvlmm - single-NVLink-domain ReduceScatter over NVLink multimem (NVLS
+              in-switch reduce). Requires nNodes==1, >2 local ranks, a Prims-
+              backed multimem NVL transport, and commSum over fp32/fp16/bf16/
+              int32; if those preconditions are not met the request is rejected
+              with commInvalidArgument (it does NOT fall through to the ctran
+              baseline - set this cvar to none for the baseline path).
+
+ - name        : MCCL_CNVLMM_REDUCE_ACC_F32
+   type        : bool
+   default     : true
+   description : |-
+     Use f32 accumulation for fp16/bf16 multimem reduce; false = native 2-byte accumulation.
+
  - name        : MCCL_BOOTSTRAP_SOCKET_HEALTH_POLL_ENABLED
    type        : bool
    default     : true


### PR DESCRIPTION
Summary: MCCL-hosted cnvlmm AllReduce copy (staging) path: device kernel(s) under `comms/mccl/collectives/allreduce/` + an `AllReduceCnvlmm` `ICollective` host impl (reads only `CommContext`, never `CtranComm`) dispatched from `McclComm::allReduce()` via the new `MCCL_ALLREDUCE_ALGO=cnvlmm` cvar (zero ctran dispatch edits). Test suite on the `CollectiveTestSuite` harness; `supported()` gates to a single NVLink domain with >2 local ranks (1x1/1x2 and all 2xN gracefully skip). All-mccl, zero `comms/ctran` changes. fp16/bf16 reduce is bit-exact deterministic under BOTH accumulation modes (`.acc::f32` and native 2-byte, cvar `NCCL_CTRAN_CNVLMM_REDUCE_ACC_F32`), enforced by a `_nativeacc` test-suite variant. 1-shot/2-shot staging split by `NCCL_CTRAN_ALLREDUCE_CNVLMM_ONESHOT_BYTES_THRESHOLD`.

Differential Revision: D110801598


