### PR TITLE
Set up NVL CE-multicast on the ctwin/window registration path (#3282)

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -7,8 +7,10 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <folly/Synchronized.h>

--- a/comms/ctran/algos/AllGather/AllGatherCtwin.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCtwin.cc
@@ -92,6 +92,13 @@ commResult_t createPersistentRequestFromWindow(
 
   pArgs.algo = agpVariant;
 
+  // NVL CE-multicast: if the window carries a standalone multicast object
+  // (set up in CtranWin::exchange when win_register_multicast is on and
+  // the NVL group supports it), cache recvbuff's multicast write base so
+  // nvlCeBcast fans out via a single NVSwitch write instead of N-1 per-peer
+  // unicast copies. std::nullopt (unicast) when there is no multicast object.
+  pArgs.mcWrite = win->multicastWriteBase(recvbuff);
+
   auto request = std::make_unique<CtranPersistentRequest>(
       CtranPersistentRequest::Type::ALLGATHER_P, comm, stream);
   request->algo = algo.release();

--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -11,10 +11,15 @@
 #include "comms/ctran/mapper/CtranMapperTypes.h"
 #include "comms/ctran/regcache/IpcRegCache.h"
 #include "comms/ctran/regcache/RegCache.h"
+#include "comms/ctran/utils/CudaWrap.h"
+#include "comms/ctran/utils/DevMemType.h"
 
 #include <folly/ScopeGuard.h>
 
+#include <algorithm>
+#include <exception>
 #include <memory>
+#include <vector>
 
 using ctran::algos::GpeKernelSync;
 using ctran::allgatherp::AlgoImpl;

--- a/comms/ctran/algos/AllGatherP/CommUtils.h
+++ b/comms/ctran/algos/AllGatherP/CommUtils.h
@@ -90,6 +90,9 @@ inline commResult_t exchangeIpcReg(CtranComm* comm, PersistArgs& pArgs) {
                            : pArgs.remoteIpcRegHdls_.at(i).toString());
   }
 
+  // NVL CE-multicast is set up on the window/ctwin registration path
+  // (CtranWin::exchange); the eager/graph AGP path here stays unicast, so
+  // pArgs.mcWrite is left std::nullopt.
   pArgs.initState = InitState::kInitialized;
   return commSuccess;
 }

--- a/comms/ctran/algos/AllGatherP/DirectImpl.cc
+++ b/comms/ctran/algos/AllGatherP/DirectImpl.cc
@@ -185,13 +185,18 @@ commResult_t AlgoImpl::execDirect(
 
   const auto sendSize = count * commTypeSize(datatype);
 
-  // Copy data to self for out-of-place allgather
-  FB_COMMCHECK(copyToSelf(
-      comm_,
-      sendbuff,
-      getPtr(pArgs.recvbuff, comm_->statex_->rank() * sendSize),
-      sendSize,
-      stream_));
+  // Copy data to self for out-of-place allgather. Skipped when multicast is
+  // engaged: the step-0 CE-multicast broadcast fans out to self too, so
+  // recvbuff[myRank] is already written (the GPE inter-node send sources its
+  // step-0 chunk from sendbuff, not recvbuff, so there is no early reader).
+  if (!pArgs.mcWrite) {
+    FB_COMMCHECK(copyToSelf(
+        comm_,
+        sendbuff,
+        getPtr(pArgs.recvbuff, comm_->statex_->rank() * sendSize),
+        sendSize,
+        stream_));
+  }
 
   // Wait till async init is done, so that we can schedule copy operations with
   // the remote address
@@ -213,7 +218,9 @@ commResult_t AlgoImpl::execDirect(
           myRank * sendSize,
           pArgs.remoteRecvBuffs,
           pArgs.remoteAccessKeys,
-          stream_));
+          stream_,
+          /*barrier=*/true,
+          pArgs.mcWrite));
     }
   }
 

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -282,13 +282,18 @@ commResult_t AlgoImpl::execPipeline(
     }
   }
 
-  // Copy data to self for out-of-place allgather
-  FB_COMMCHECK(copyToSelf(
-      comm_,
-      sendbuff,
-      getPtr(pArgs.recvbuff, comm_->statex_->rank() * sendSize),
-      sendSize,
-      stream_));
+  // Copy data to self for out-of-place allgather. Skipped when multicast is
+  // engaged: the step-0 CE-multicast broadcast fans out to self too, so
+  // recvbuff[myRank] is already written (the GPE inter-node ring sources its
+  // step-0 chunk from sendbuff, not recvbuff, so there is no early reader).
+  if (!pArgs.mcWrite) {
+    FB_COMMCHECK(copyToSelf(
+        comm_,
+        sendbuff,
+        getPtr(pArgs.recvbuff, comm_->statex_->rank() * sendSize),
+        sendSize,
+        stream_));
+  }
 
   // Submit intra-node copies in the pipeline
   if (nLocalRanks > 1) {
@@ -301,7 +306,9 @@ commResult_t AlgoImpl::execPipeline(
         myRank * sendSize,
         pArgs.remoteRecvBuffs,
         pArgs.remoteAccessKeys,
-        stream_));
+        stream_,
+        /*barrier=*/true,
+        pArgs.mcWrite));
 
     const int upPeer = (nRanks + myRank - nLocalRanks) % nRanks;
 
@@ -332,7 +339,9 @@ commResult_t AlgoImpl::execPipeline(
           offset,
           pArgs.remoteRecvBuffs,
           pArgs.remoteAccessKeys,
-          stream_));
+          stream_,
+          /*barrier=*/true,
+          pArgs.mcWrite));
     }
 
     PipeEndKernArgs kernArgs = {

--- a/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
@@ -289,7 +289,9 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
         myRank * sendSize,
         pArgs.remoteRecvBuffs,
         pArgs.remoteAccessKeys,
-        stream_));
+        stream_,
+        /*barrier=*/true,
+        pArgs.mcWrite));
 
     for (int step = 0; step < recvPlan.nSteps(); step++) {
       PipeSyncKernArgs syncArgs = {
@@ -316,7 +318,8 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
             pArgs.remoteRecvBuffs,
             pArgs.remoteAccessKeys,
             stream_,
-            chunkIndex++ == 0));
+            chunkIndex++ == 0,
+            pArgs.mcWrite));
       }
     }
 

--- a/comms/ctran/algos/AllGatherP/Types.h
+++ b/comms/ctran/algos/AllGatherP/Types.h
@@ -53,6 +53,18 @@ struct PersistArgs {
   // ctwin sets it per-comm by topology since a single cvar cannot express
   // multiple comms with different topologies.
   std::optional<enum NCCL_ALLGATHER_P_ALGO> algo;
+
+  // NVL CE-multicast broadcast state. Cache of the multicast write base: when
+  // engaged, mcWrite holds the multicast VA offset corresponding to recvbuff,
+  // and nvlCeBcast issues a single cudaMemcpyAsync to it instead of the N-1
+  // per-peer unicast fan-out. std::nullopt (unicast fallback) when multicast is
+  // disabled, unsupported, or the recvbuff is not a cuMem (VMM) allocation.
+  // Set at request creation on the user thread: the ctwin/window path fills it
+  // from CtranWin::multicastWriteBase(recvbuff) (see AllGatherCtwin.cc) before
+  // initState=kInitialized; the non-window AGP path leaves it std::nullopt.
+  // Consumed by nvlCeBcast during exec. Collapsing the enabled bit + pointer
+  // into one optional makes the (enabled, nullptr) state unrepresentable.
+  std::optional<void*> mcWrite;
 };
 
 struct Resource {

--- a/comms/ctran/algos/common/NvlUtils.h
+++ b/comms/ctran/algos/common/NvlUtils.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cuda_runtime.h>
+#include <optional>
 #include <vector>
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
@@ -133,7 +134,15 @@ inline commResult_t nvlCeBcast(
     const std::vector<void*>& remoteRecvBuffs,
     const std::vector<CtranMapperRemoteAccessKey>& remoteAccessKeys,
     cudaStream_t stream,
-    bool barrier = true) {
+    bool barrier = true,
+    // When mcWrite is engaged, broadcast via a single CE-multicast write to
+    // *mcWrite + recvOffset (NVSwitch fans it out to every NVL-domain peer,
+    // including self) instead of the N-1 per-peer unicast copies -- collapsing
+    // the per-peer Memcpy nodes into one CE node. *mcWrite already accounts for
+    // the recv buffer's offset within its multicast-bound allocation. Set up on
+    // the buffer's registration during the NVL rendezvous; std::nullopt on the
+    // unicast path (which makes the enabled-but-null state unrepresentable).
+    std::optional<void*> mcWrite = std::nullopt) {
   const auto statex = comm->statex_.get();
   const auto rank = statex->rank();
   const auto localRank = statex->localRank();
@@ -143,6 +152,24 @@ inline commResult_t nvlCeBcast(
   // avoid unwanted incast traffic congestion
   if (barrier) {
     nvlBarrier(comm, stream);
+  }
+
+  // CE-multicast fast path: one write fanned out by NVSwitch to all peers,
+  // captured as exactly one Memcpy node (vs numOps per-peer nodes below).
+  if (mcWrite) {
+    void* recvPtr = static_cast<char*>(*mcWrite) + recvOffset;
+    CLOGF_TRACE(
+        COLL,
+        "Rank {} CE multicast bcast, sendBuff {} -> mcRecvBuff {} (mcWrite {} + recvOffset {}), sendSize {}",
+        rank,
+        sendBuff,
+        recvPtr,
+        *mcWrite,
+        recvOffset,
+        sendSize);
+    FB_CUDACHECK(cudaMemcpyAsync(
+        recvPtr, sendBuff, sendSize, cudaMemcpyDeviceToDevice, stream));
+    return commSuccess;
   }
 
   const size_t numOps = nLocalRanks - 1;

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdio>
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -18,6 +19,7 @@
 #include "comms/ctran/transport/ib/HostCbTransport.h"
 #include "comms/ctran/transport/ib/HostZcTransport.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranIpc.h"
 #include "comms/utils/StrUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -1335,6 +1337,39 @@ commResult_t CtranMapper::allGatherCtrlImpl(
     FB_COMMCHECK(waitRequest(req.get()));
   }
 
+  return commSuccess;
+}
+
+commResult_t CtranMapper::intraNvlDomainAllGather(
+    const void* sendData,
+    void* recvData,
+    size_t elemSize) {
+  const auto& statex = comm->statex_;
+  const int nLocalRanks = statex->nLocalRanks();
+  const int selfIdx = statex->localRank(); // our own NVL-domain rank
+  auto* recvBytes = static_cast<char*>(recvData);
+  std::memcpy(recvBytes + selfIdx * elemSize, sendData, elemSize);
+
+  // One round: post an irecv from + isend to every other domain member, then
+  // wait all. recvData is indexed by domain rank (localRankToRank order), so it
+  // matches the exec/IPC layout. unique_ptr keeps request addresses stable
+  // across vector growth (the IB layer holds references into them).
+  std::vector<std::unique_ptr<CtranMapperRequest>> reqs;
+  for (int i = 0; i < nLocalRanks; i++) {
+    if (i == selfIdx) {
+      continue;
+    }
+    const int peer = statex->localRankToRank(i);
+    reqs.push_back(std::make_unique<CtranMapperRequest>());
+    FB_COMMCHECK(this->irecvCtrlMsg(
+        recvBytes + i * elemSize, elemSize, peer, reqs.back().get()));
+    reqs.push_back(std::make_unique<CtranMapperRequest>());
+    FB_COMMCHECK(
+        this->isendCtrlMsg(sendData, elemSize, peer, reqs.back().get()));
+  }
+  for (auto& req : reqs) {
+    FB_COMMCHECK(this->waitRequest(req.get()));
+  }
   return commSuccess;
 }
 

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -562,6 +563,18 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperBackend backend = CtranMapperBackend::UNSET,
       bool recordExport = true,
       std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls = nullptr);
+
+  // One-round all-gather of a fixed-size ctrl message over this comm's NVL
+  // domain (statex->localRankToRanks() -- the same membership
+  // intraAllGatherCtrl and the exec broadcast use): on return recvData[i *
+  // elemSize] holds domain rank i's sendData (self is at localRank()). The
+  // exchange mechanism itself is transport-generic (plain isend/irecv ctrl
+  // all-to-all that would work for any peer set); only the peer list is scoped
+  // to the NVL domain. Callers layer their own payload + decision on top.
+  commResult_t intraNvlDomainAllGather(
+      const void* sendData,
+      void* recvData,
+      size_t elemSize);
 
   /* Convenient wrapper of isendCtrl/irecvCtrl to post a blocking barrier among
    * all local ranks of the mapper associated communicator.

--- a/comms/ctran/tests/CtranDistAllgatherPTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherPTests.cc
@@ -460,6 +460,10 @@ TEST_F(CtranAllgatherPTestParam, DynamicSendRegPipeline) {
   }
 }
 
+// NVL CE-multicast is now set up on the window/ctwin registration path
+// (win_register_multicast); its coverage lives with the ctwin window tests, not
+// this eager/graph AGP suite.
+
 TEST_F(CtranAllgatherPTest, InvalidPreq) {
   auto request = std::make_unique<CtranPersistentRequest>(
       CtranPersistentRequest::Type::ALLTOALL_P, ctranComm.get(), stream);

--- a/comms/ctran/utils/CtranMulticast.cc
+++ b/comms/ctran/utils/CtranMulticast.cc
@@ -3,6 +3,7 @@
 
 #include "comms/ctran/utils/CtranMulticast.h"
 
+#include "comms/ctran/utils/Alloc.h" // isCuMemFabricEnabled
 #include "comms/ctran/utils/Checks.h" // FB_COMMCHECK
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/utils/logger/LogUtils.h"
@@ -74,8 +75,28 @@ bool CtranMulticast::isSupported(int cudaDev) {
           WARN,
           "CTRAN-MC: multicast disabled -- device {} reports no multicast support",
           cudaDev);
+      return false;
     }
-    return sup != 0;
+    // The MULTICAST_SUPPORTED attribute reports HW capability but NOT whether
+    // the env permits sharing a multicast object: it is shared across the NVL
+    // domain via a CU_MEM_HANDLE_TYPE_FABRIC handle, which needs the IMEX
+    // channel. On nodes without IMEX (e.g. RE/CI hosts) cuMulticastCreate
+    // returns CUDA_ERROR_NOT_PERMITTED even though the attribute is set. NVIDIA
+    // exposes no attribute for fabric/IMEX availability -- it can only be
+    // trialed -- so reuse ctran's existing memoized fabric probe:
+    // isCuMemFabricEnabled() sets the FABRIC bit iff a FABRIC cuMem
+    // alloc+export+import succeeds (the same signal regular cuMem IPC uses to
+    // choose fabric vs POSIX-fd handles). No fabric -> the multicast object
+    // cannot be shared across the domain -> declare unsupported so the group
+    // falls back to unicast.
+    if (!isCuMemFabricEnabled()) {
+      CLOGF(
+          WARN,
+          "CTRAN-MC: multicast disabled -- device {} reports multicast support but fabric memory handles are unavailable (IMEX channel not enabled?); the multicast object cannot be shared across the NVL domain",
+          cudaDev);
+      return false;
+    }
+    return true;
   }();
   return supported;
 }

--- a/comms/ctran/utils/CtranMulticast.h
+++ b/comms/ctran/utils/CtranMulticast.h
@@ -25,9 +25,10 @@ namespace ctran::utils {
 //
 // This class encapsulates ONLY the LOCAL (per-rank) CUDA operations + RAII
 // teardown; the collective exchange of the multicast object handle across the
-// NVL team is driven by the caller (e.g. CtranMapper::setupMulticast),
-// which uses the CtranIpc export/importShareableHandle helpers to move the
-// handle this class produces (createRoot) / consumes (adoptImported).
+// NVL team is driven by the caller (e.g. window::setupMulticast), which uses
+// the mapper's intraNvlDomainAllGather + the CtranIpc
+// export/importShareableHandle helpers to move the handle this class produces
+// (createRoot) / consumes (adoptImported).
 //
 // NOTE: not internally locked; the caller serializes access.
 class CtranMulticast {
@@ -40,10 +41,17 @@ class CtranMulticast {
   CtranMulticast(CtranMulticast&&) = delete;
   CtranMulticast& operator=(CtranMulticast&&) = delete;
 
-  // Runtime support gate (no arch/compute-capability conditional): the
-  // cuMulticast* driver entry points are present AND the device reports
-  // CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED. Mirrors PyTorch
-  // deviceSupportsMulticast and prims isMultimemSupported.
+  // Runtime support gate (no arch/compute-capability conditional), memoized
+  // process-wide: the cuMulticast* driver entry points are present, the device
+  // reports CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, AND fabric memory handles
+  // are usable (isCuMemFabricEnabled()). The fabric check is required because
+  // the attribute reports HW capability but not whether the env permits sharing
+  // the multicast object: it uses a CU_MEM_HANDLE_TYPE_FABRIC handle, and
+  // without the IMEX channel cuMulticastCreate returns
+  // CUDA_ERROR_NOT_PERMITTED. NVIDIA exposes no attribute for fabric/IMEX
+  // availability, so it is trialed once (the same alloc+export+import probe
+  // regular cuMem IPC uses to pick fabric vs fd; cf. PyTorch c10
+  // get_fabric_access).
   static bool isSupported(int cudaDev);
 
   // Multicast-object allocation granularity for the device+team; mcSize and

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -6,6 +6,8 @@
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <memory>
+#include <optional>
 #include <tuple>
 #include <unordered_map>
 #include <utility>
@@ -20,6 +22,7 @@
 #include "comms/ctran/regcache/RegCache.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/CtranIpc.h"
+#include "comms/ctran/utils/CtranMulticast.h"
 #include "comms/ctran/utils/DevMemType.h"
 #include "comms/ctran/window/Types.h"
 #if defined(ENABLE_PRIMS)
@@ -200,6 +203,14 @@ struct CtranWin {
     return symmetric_;
   }
 
+  // Multicast write base for a user pointer in this window's data buffer, or
+  // std::nullopt when there is no multicast object (unicast). Computed from the
+  // multicast object alone -- no CtranIpc involvement -- so ctwin AllGather
+  // fans out via a single NVSwitch write.
+  inline std::optional<void*> multicastWriteBase(const void* userPtr) const {
+    return mc_ ? mc_->writeBase(userPtr) : std::nullopt;
+  }
+
   inline uint64_t id() const {
     return id_;
   }
@@ -252,6 +263,10 @@ struct CtranWin {
   // peerBase + (buf - localBase). Records the upstream NCCL_WIN_COLL_SYMMETRIC
   // hint; consumed by a later window-based allgather. Cached only for now.
   bool symmetric_{false};
+  // The standalone NVL CE-multicast object for this window's data buffer, set
+  // in exchange() and read via multicastWriteBase(). Self-owning; released with
+  // the window. null unless multicast engaged.
+  std::unique_ptr<ctran::utils::CtranMulticast> mc_;
   // Per-comm unique id assigned at exchange() (see CtranComm::assignWindowId).
   uint64_t id_{0};
   // rank: window::OpCountType as key

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -11,6 +11,8 @@
 #include "comms/ctran/regcache/RegCache.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranIpc.h"
+#include "comms/ctran/utils/CtranMulticast.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/utils/DevMemType.h"
 #include "comms/ctran/window/CtranWin.h"
@@ -21,6 +23,7 @@
 #include "comms/prims/window/DeviceWindow.cuh"
 #include "comms/prims/window/HostWindow.h"
 #endif
+#include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/ScubaLogger.h"
 
@@ -148,6 +151,162 @@ commResult_t windowBarrier(CtranComm* comm, CtranMapper* mapper) {
     FB_COMMCHECK(mapper->waitRequest(&req));
   }
   return commSuccess;
+}
+
+// Set up a standalone NVL CE-multicast object over the caller's NVL domain for
+// the buffer registered under `dataRegHdl` (a RegElem*), returned via
+// `outMulticast`. The group is the comm's NVL domain
+// (statex->localRankToRanks()) -- the same membership the ipc_only handle
+// exchange (intraAllGatherCtrl) uses -- so the multicast group, the
+// IPC-exchange group, and the exec broadcast group all agree by construction.
+// The mapper supplies the generic intraNvlDomainAllGather ctrl exchange; the
+// multicast-specific logic lives here. Per-buffer eligibility (cuMem/fabric) is
+// decided by the unanimous retainSegments/isSupported vote, not by filtering
+// the group. No-op / unicast fallback (outMulticast stays null) if the group
+// declines, multicast is unsupported, or the buffer is not cuMem-backed.
+commResult_t setupMulticast(
+    CtranComm* comm,
+    CtranMapper* mapper,
+    void* dataRegHdl,
+    std::unique_ptr<ctran::utils::CtranMulticast>& outMulticast) {
+  outMulticast = nullptr;
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12040
+  // Multicast is fabric-only; fabric handles require CUDA 12.4+ and are not
+  // available on AMD.
+  (void)comm;
+  (void)mapper;
+  (void)dataRegHdl;
+  return commSuccess;
+#else
+  const auto& statex = comm->statex_;
+  const int rank = statex->rank();
+  const int cudaDev = statex->cudaDev();
+
+  // NVL rendezvous over the comm's NVL domain (spans hosts on MNNVL) -- exactly
+  // the membership intraAllGatherCtrl exchanges IPC handles over and that the
+  // exec broadcasts to, so all three agree by construction with no separate
+  // group derivation. Root is domain rank 0 (identical across all domain
+  // ranks); nvlLocalRank is our own domain rank. intraNvlDomainAllGather
+  // indexes recvData by domain rank, so allRzv[0] is the root's entry.
+  const int nLocalRanks = statex->nLocalRanks();
+  if (nLocalRanks <= 1) {
+    return commSuccess; // no NVL peers to multicast to (rank-uniform)
+  }
+  const int nvlLocalRank = statex->localRank();
+  const int rootRank = statex->localRankToRank(0);
+  const bool isRoot = (rank == rootRank);
+
+  auto mc = std::make_unique<ctran::utils::CtranMulticast>(
+      nvlLocalRank, nLocalRanks, cudaDev);
+
+  // Local eligibility, folded into localOk -- do NOT early-return past the
+  // rank-uniform nLocalRanks gate above. Whether the buffer carries an NVL/IPC
+  // registration (regElem/ipcRegElem) is LOCAL state that can differ across
+  // ranks in rare cases (e.g. IPC registration declined an unsupported memory
+  // type on one rank), so a rank that bailed here while its peers proceed to
+  // the all-gather would hang. A missing registration or any failed check just
+  // clears localOk; the group then falls back to unicast unanimously.
+  // retainSegments() also self-detects a non-cuMem/VMM buffer and declines.
+  auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(dataRegHdl);
+  const bool hasNvlReg = (regElem != nullptr && regElem->ipcRegElem != nullptr);
+  bool localOk = hasNvlReg &&
+      (mc->retainSegments(regElem->buf, regElem->len) == commSuccess);
+  const size_t mcSize = localOk ? mc->retainedSize() : 0;
+  size_t gran = 0;
+  localOk = localOk && ctran::utils::CtranMulticast::isSupported(cudaDev) &&
+      ctran::utils::CtranMulticast::granularity(cudaDev, nLocalRanks, gran) ==
+          commSuccess &&
+      gran != 0 && (mcSize % gran) == 0 && mc->segmentsAlignedTo(gran);
+
+  // Single-round rendezvous: the root creates + exports its fabric handle up
+  // front if its own validation passed; one all-gather of {ok, handle} then
+  // lets every rank decide unanimously (all must pass) and pick up the root's
+  // handle.
+  struct McRzv {
+    int ok{0};
+    ctran::utils::CtranIpcHandle handle{};
+  };
+  McRzv myRzv{}; // value-init: zeroes any padding, since the whole struct is
+                 // shipped over the wire by intraNvlDomainAllGather
+  myRzv.ok = localOk ? 1 : 0;
+  if (isRoot && localOk) {
+    CUmemGenericAllocationHandle mcHandle = 0;
+    if (mc->createRoot(mcSize, CU_MEM_HANDLE_TYPE_FABRIC, mcHandle) !=
+            commSuccess ||
+        ctran::utils::exportShareableHandle(
+            mcHandle, myRzv.handle, /*isFabric=*/true) != commSuccess) {
+      myRzv.ok = 0; // root couldn't create/export -> whole group -> unicast
+    }
+  }
+
+  std::vector<McRzv> allRzv(nLocalRanks);
+  FB_COMMCHECK(
+      mapper->intraNvlDomainAllGather(&myRzv, allRzv.data(), sizeof(McRzv)));
+
+  // Proceed only if every rank validated (root's handle is in allRzv[0]:
+  // intraNvlDomainAllGather indexes by domain rank, and root == domain rank 0).
+  bool allOk = true;
+  for (const auto& r : allRzv) {
+    allOk = allOk && (r.ok != 0);
+  }
+  if (!allOk) {
+    int declined = 0;
+    for (const auto& r : allRzv) {
+      if (r.ok == 0) {
+        declined++;
+      }
+    }
+    CLOGF(
+        WARN,
+        "CTRAN-MC: rank {} falling back to unicast -- {} of {} NVL-domain ranks declined multicast (unsupported HW/IMEX, or a non-cuMem / unregistered buffer)",
+        rank,
+        declined,
+        nLocalRanks);
+    // `mc` (incl. the root's just-created object, if any) is released by its
+    // dtor at scope exit; no leak.
+    return commSuccess;
+  }
+
+  // Non-root: import the root's fabric handle.
+  if (!isRoot) {
+    CUmemGenericAllocationHandle mcHandle = 0;
+    // Abort (not return) on failure: post-vote, every domain rank proceeds to
+    // the second windowBarrier below, so a one-rank error return here would
+    // hang its peers there. The regular NVL buffer import earlier in this same
+    // registration already proved fabric/IMEX works, so a failure now is a
+    // genuine anomaly -- fail loudly rather than deadlock.
+    FB_CHECKABORT(
+        ctran::utils::importShareableHandle(
+            allRzv[0].handle, mcHandle, /*isFabric=*/true) == commSuccess,
+        "CTRAN-MC: rank {} failed to import the root multicast handle post-vote",
+        rank);
+    mc->adoptImported(mcHandle);
+  }
+
+  // Every rank: add local device, bind each segment, map the multicast VA.
+  // Abort (not return) on failure for the same reason as the import above --
+  // these are post-vote local ops on the substrate the regular NVL import
+  // already exercised, and all ranks are past the vote heading to the second
+  // windowBarrier, so a one-rank error return would hang the peers (and a
+  // per-rank unicast fallback would leave divergent multicast membership).
+  FB_CHECKABORT(
+      mc->addDeviceAndBind() == commSuccess,
+      "CTRAN-MC: rank {} failed addDeviceAndBind post-vote",
+      rank);
+  FB_CHECKABORT(
+      mc->mapVA(mcSize, gran) == commSuccess,
+      "CTRAN-MC: rank {} failed mapVA post-vote",
+      rank);
+  outMulticast = std::move(mc);
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "CTRAN-MC: rank {} bound multicast over {} NVL ranks ({} bytes)",
+      rank,
+      nLocalRanks,
+      mcSize);
+  return commSuccess;
+#endif
 }
 
 } // namespace
@@ -390,6 +549,34 @@ commResult_t CtranWin::exchange() {
   FB_COMMCHECK(windowBarrier(comm, mapper));
   recordWinStage("WinExchange/Barrier", barrierTimer.durationUs());
 
+  // NVL CE-multicast setup (killswitch cvar NCCL_CTRAN_WIN_ENABLE_MULTICAST).
+  // Gated on ipc_only because that path exchanged handles over the whole NVL
+  // domain and is rejected on splitShare, so the domain equals the window's
+  // ranks -- the group setupMulticast builds the multicast over. Rank-uniform,
+  // so all ranks enter together and fall back to unicast unanimously.
+  if (NCCL_CTRAN_WIN_ENABLE_MULTICAST && ipcOnly_ && isSymmetric() &&
+      winDataPtr != nullptr) {
+    std::unique_ptr<ctran::utils::CtranMulticast> mc;
+    FB_COMMCHECK(setupMulticast(comm, mapper, dataRegHdl, mc));
+    const bool mcEngaged = (mc != nullptr);
+    if (mcEngaged) {
+      // exchange() is a CtranWin member; store the window's multicast object
+      // directly (the window owns its lifetime, torn down in free()).
+      mc_ = std::move(mc);
+    }
+    FB_COMMCHECK(windowBarrier(comm, mapper));
+    CLOGF_SUBSYS(
+        INFO,
+        INIT,
+        "CTRAN-WINDOW: Rank {} {} NVL CE-multicast on win {} comm {} commHash {:x} ({} bytes)",
+        myRank,
+        mcEngaged ? "engaged" : "did not engage (unicast fallback)",
+        (void*)this,
+        (void*)comm,
+        statex->commHash(),
+        dataBytes);
+  }
+
   // Cache only symmetric windows: ctwin collective algos needs all ranks
   // locally compute peerAddr = peerBase + offset, meaning same offset from base
   // on all ranks.
@@ -537,6 +724,11 @@ commResult_t CtranWin::free(bool skipBarrier) {
     }
     reqs->clear();
   }
+
+  // Release the multicast object after the persistent requests that cached its
+  // write base are gone. Self-owning (its own segment handles + VA), so this is
+  // independent of the data-registration teardown below.
+  mc_.reset();
 
   // Drop this window's entry from the comm cache before tearing down buffers so
   // a later lookup cannot resolve to a freed window.

--- a/comms/ncclx/meta/tests/AllGatherCtwinTest.cc
+++ b/comms/ncclx/meta/tests/AllGatherCtwinTest.cc
@@ -5,6 +5,9 @@
 #include <gtest/gtest.h>
 #include <nccl.h>
 #include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
 #include <vector>
 
 #include "comm.h"
@@ -85,7 +88,7 @@ TEST_F(AllGatherCtwinTest, AllGatherCtwinFallbackWhenNoWindow) {
 
   for (int r = 0; r < numRanks; r++) {
     int expectedVal = r + 1;
-    int errs = checkChunkValue(recvBuf + r * count, count, expectedVal);
+    const auto errs = checkChunkValue(recvBuf + r * count, count, expectedVal);
     EXPECT_EQ(errs, 0) << "rank " << globalRank << " checked chunk " << r
                        << " at " << recvBuf + r * count << " with " << errs
                        << " errors";
@@ -160,7 +163,7 @@ TEST_F(AllGatherCtwinTest, AllGatherCtwinUsedWhenWindowRegistered) {
 
   for (int r = 0; r < numRanks; r++) {
     int expectedVal = r + 1;
-    int errs = checkChunkValue(recvBuf + r * count, count, expectedVal);
+    const auto errs = checkChunkValue(recvBuf + r * count, count, expectedVal);
     EXPECT_EQ(errs, 0) << "rank " << globalRank << " checked chunk " << r
                        << " at " << recvBuf + r * count << " with " << errs
                        << " errors";
@@ -171,6 +174,203 @@ TEST_F(AllGatherCtwinTest, AllGatherCtwinUsedWhenWindowRegistered) {
   EXPECT_EQ(ncclCommWindowDeregister(comm, win), ncclSuccess);
   NCCLCHECK_TEST(ncclGlobalDeregisterWithPtr(winBase, totalBytes));
   testFreeBuf(winBase, totalBytes, kMemNcclMemAlloc);
+}
+
+// Same as above over a symmetric window, where multicast is on by default
+// (NCCL_CTRAN_WIN_ENABLE_MULTICAST): the window sets up an NVL CE-multicast
+// object in CtranWin::exchange, and ctwin's AllGatherP fans out through the
+// multicast VA (nvlCeBcast) instead of N-1 unicast copies. On HW without
+// multicast/fabric support the setup declines and the path falls back to
+// unicast, so the result must be correct either way; either way ctwin
+// (CtranAllGatherP) must run.
+TEST_F(AllGatherCtwinTest, AllGatherCtwinMulticastWhenWindowRegistered) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skip test";
+  }
+
+  constexpr size_t count = 1024;
+  const size_t totalBytes = count * numRanks * sizeof(int);
+
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints(
+      {{"allgatherAlgo",
+        ncclx::algoconf::algoValToStr(NCCL_ALLGATHER_ALGO::ctwin)},
+       {"win_register_symmetric", "1"},
+       {"win_register_ipc_only", "1"}});
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+  this->comm = commRaii.get();
+  ASSERT_NE(this->comm, nullptr);
+
+  if (comm->ctranComm_->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+
+  std::vector<TestMemSegment> winSegs;
+  void* winBase = testAllocBuf(totalBytes, kMemNcclMemAlloc, winSegs);
+  ASSERT_NE(winBase, nullptr);
+  // Mimic the CCA allocator hook so the window's acquireScopedRegister finds
+  // the buffer's segment cached.
+  NCCLCHECK_TEST(ncclGlobalRegisterWithPtr(winBase, totalBytes));
+  auto regGuard = folly::makeGuard([&]() {
+    NCCLCHECK_TEST(ncclGlobalDeregisterWithPtr(winBase, totalBytes));
+  });
+
+  ncclWindow_t win = nullptr;
+  ASSERT_EQ(
+      ncclCommWindowRegister(
+          comm, winBase, totalBytes, &win, NCCL_WIN_COLL_SYMMETRIC),
+      ncclSuccess);
+  ASSERT_NE(win, nullptr);
+  regGuard.dismiss();
+
+  // In-place layout required by ctwin: this rank's send chunk lives at its
+  // own offset within the recvbuf/window.
+  int* recvBuf = reinterpret_cast<int*>(winBase);
+  int* sendBuf = recvBuf + count * globalRank;
+
+  assignChunkValue(recvBuf, count * numRanks, -1);
+  assignChunkValue(sendBuf, count, globalRank + 1);
+
+  ASSERT_EQ(
+      ncclAllGather(sendBuf, recvBuf, count, ncclInt, comm, stream),
+      ncclSuccess);
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  for (int r = 0; r < numRanks; r++) {
+    int expectedVal = r + 1;
+    const auto errs = checkChunkValue(recvBuf + r * count, count, expectedVal);
+    EXPECT_EQ(errs, 0) << "rank " << globalRank << " checked chunk " << r
+                       << " at " << recvBuf + r * count << " with " << errs
+                       << " errors";
+  }
+
+  algoStats_.verify(comm, "AllGather", "CtranAllGatherP");
+
+  EXPECT_EQ(ncclCommWindowDeregister(comm, win), ncclSuccess);
+  NCCLCHECK_TEST(ncclGlobalDeregisterWithPtr(winBase, totalBytes));
+  testFreeBuf(winBase, totalBytes, kMemNcclMemAlloc);
+}
+
+// Standalone timed benchmark of ctwin AllGatherP over a symmetric window:
+// warmup, then a cudaEvent-timed loop of ncclAllGather, reporting busbw. Env
+// knobs (one binary covers the size sweep + MC-vs-unicast, no recompile):
+//   NCCLX_BENCH_BYTES     total recvbuf bytes (default 8 MiB)
+//   NCCLX_BENCH_ITERS     timed iterations (default 200)
+//   NCCLX_BENCH_WARMUP    warmup iterations (default 50)
+//   NCCLX_BENCH_MULTICAST "0" disables multicast via the
+//                         NCCL_CTRAN_WIN_ENABLE_MULTICAST cvar (ctwin-unicast
+//                         control); default on
+TEST_F(AllGatherCtwinTest, AllGatherCtwinPerf) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skip test";
+  }
+  auto envOr = [](const char* k, unsigned long long d) -> unsigned long long {
+    const char* v = getenv(k);
+    return (v != nullptr && *v != '\0') ? strtoull(v, nullptr, 10) : d;
+  };
+  const size_t totalBytes = envOr("NCCLX_BENCH_BYTES", 8ull << 20);
+  const int iters = static_cast<int>(envOr("NCCLX_BENCH_ITERS", 200));
+  const int warmup = static_cast<int>(envOr("NCCLX_BENCH_WARMUP", 50));
+  // Toggle multicast via the killswitch cvar (default on); "0" isolates the
+  // ctwin-unicast control. Restored after the test by the guard.
+  const char* mcEnv = getenv("NCCLX_BENCH_MULTICAST");
+  const bool mcOn = !(mcEnv != nullptr && std::string(mcEnv) == "0");
+  const auto mcCvarPrev = NCCL_CTRAN_WIN_ENABLE_MULTICAST;
+  NCCL_CTRAN_WIN_ENABLE_MULTICAST = mcOn;
+  auto mcCvarGuard =
+      folly::makeGuard([&]() { NCCL_CTRAN_WIN_ENABLE_MULTICAST = mcCvarPrev; });
+  const size_t count = totalBytes / (numRanks * sizeof(int)); // per-rank chunk
+  ASSERT_GT(count, 0u);
+  const size_t winBytes = count * numRanks * sizeof(int);
+
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints(
+      {{"allgatherAlgo",
+        ncclx::algoconf::algoValToStr(NCCL_ALLGATHER_ALGO::ctwin)},
+       {"win_register_symmetric", "1"},
+       {"win_register_ipc_only", "1"}});
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+  this->comm = commRaii.get();
+  ASSERT_NE(this->comm, nullptr);
+  if (comm->ctranComm_->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+
+  std::vector<TestMemSegment> winSegs;
+  void* winBase = testAllocBuf(winBytes, kMemNcclMemAlloc, winSegs);
+  ASSERT_NE(winBase, nullptr);
+  NCCLCHECK_TEST(ncclGlobalRegisterWithPtr(winBase, winBytes));
+  auto regGuard = folly::makeGuard([&]() {
+    NCCLCHECK_TEST(ncclGlobalDeregisterWithPtr(winBase, winBytes));
+  });
+  ncclWindow_t win = nullptr;
+  ASSERT_EQ(
+      ncclCommWindowRegister(
+          comm, winBase, winBytes, &win, NCCL_WIN_COLL_SYMMETRIC),
+      ncclSuccess);
+  ASSERT_NE(win, nullptr);
+  regGuard.dismiss();
+
+  int* recvBuf = reinterpret_cast<int*>(winBase);
+  int* sendBuf = recvBuf + count * globalRank; // in-place layout ctwin requires
+  assignChunkValue(recvBuf, count * numRanks, -1);
+  assignChunkValue(sendBuf, count, globalRank + 1);
+
+  for (int i = 0; i < warmup; i++) {
+    ASSERT_EQ(
+        ncclAllGather(sendBuf, recvBuf, count, ncclInt, comm, stream),
+        ncclSuccess);
+  }
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  cudaEvent_t start, stop;
+  CUDACHECK_TEST(cudaEventCreate(&start));
+  CUDACHECK_TEST(cudaEventCreate(&stop));
+  CUDACHECK_TEST(cudaEventRecord(start, stream));
+  for (int i = 0; i < iters; i++) {
+    ASSERT_EQ(
+        ncclAllGather(sendBuf, recvBuf, count, ncclInt, comm, stream),
+        ncclSuccess);
+  }
+  CUDACHECK_TEST(cudaEventRecord(stop, stream));
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+  float ms = 0.f;
+  CUDACHECK_TEST(cudaEventElapsedTime(&ms, start, stop));
+
+  const double secPerIter = (ms / 1e3) / iters;
+  const double algbw = (double)winBytes / 1e9 / secPerIter; // GB/s
+  const double busbw = algbw * (double)(numRanks - 1) / (double)numRanks;
+
+  int errs = 0;
+  for (int r = 0; r < numRanks; r++) {
+    errs += checkChunkValue(recvBuf + r * count, count, r + 1);
+  }
+  EXPECT_EQ(errs, 0);
+
+  if (globalRank == 0) {
+    printf(
+        "# AGCTWIN-BENCH multicast=%s ranks=%d bytes=%zu iters=%d  time=%.2f us/op  algbw=%.2f GB/s  busbw=%.2f GB/s  errs=%d\n",
+        mcOn ? "1" : "0",
+        numRanks,
+        winBytes,
+        iters,
+        secPerIter * 1e6,
+        algbw,
+        busbw,
+        errs);
+    fflush(stdout);
+  }
+  algoStats_.verify(comm, "AllGather", "CtranAllGatherP");
+
+  CUDACHECK_TEST(cudaEventDestroy(start));
+  CUDACHECK_TEST(cudaEventDestroy(stop));
+  EXPECT_EQ(ncclCommWindowDeregister(comm, win), ncclSuccess);
+  NCCLCHECK_TEST(ncclGlobalDeregisterWithPtr(winBase, winBytes));
+  testFreeBuf(winBase, winBytes, kMemNcclMemAlloc);
 }
 
 int main(int argc, char* argv[]) {

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2300,6 +2300,17 @@ cvars:
      Enable CTRAN backends to pre-connect to peers at
      the beginning of the collective call.
 
+ - name        : NCCL_CTRAN_WIN_ENABLE_MULTICAST
+   type        : bool
+   default     : true
+   description : |-
+     Enable NVL CE-multicast for window registration. When true (default), a
+     symmetric, ipc_only, cuMem-backed window on multicast-capable HW sets up an
+     NVL CE-multicast object at registration so window collectives (e.g. ctwin
+     AllGather) fan out via a single NVSwitch write; falls back to unicast
+     otherwise. Set false to disable multicast (killswitch) without a code/conda
+     change.
+
  - name        : NCCL_CTRAN_ENABLE_PUT_FAST_PATH_FOR_SMALL_MSGS
    type        : bool
    default     : false


### PR DESCRIPTION
Summary:

Sets up an NVL CE-multicast object for the ctwin window-based AllGather so the intra-NVL-domain broadcast fans out via a single NVSwitch write instead of N−1 per-peer unicast copies — collapsing the N−1 per-peer Memcpy graph nodes into one CE node (removes the cudaGraphLaunch lock-convoy).

  - CtranWin::exchange() (window.cc): when NCCL_CTRAN_CTWIN_ENABLE_MULTICAST (new bool cvar, default true, killswitch) and the window is ipc_only + symmetric, an anon-namespace setupMulticast() runs a 1-round NVL-domain rendezvous (local retainSegments/support vote → root createRoot+export → intraNvlDomainAllGather of {ok, handle} → adopt/bind/map) and builds a self-owning CtranMulticast, stored as CtranWin::mc_(released in free()).
  - Group = the comm's NVL domain (statex->localRankToRanks()) — the same membership intraAllGatherCtrl (IPC exchange) and the exec broadcast use, so they agree by construction.
  - Mapper gains a generic intraNvlDomainAllGather(send, recv, elemSize) (1-round ctrl all-to-all over the NVL domain).
  - Consumption: AllGatherCtwin.cc sets pArgs.mcWrite = win->multicastWriteBase(recvbuff); nvlCeBcast (NvlUtils.h) takes std::optional<void*> mcWrite and, when engaged, issues one cudaMemcpyAsync to the multicast VA. copyToSelf is skipped in Direct/Pipeline when engaged (the step-0 MC broadcast writes self).
  - Eligibility (CtranMulticast::isSupported): multicast driver entry points + CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED + isCuMemFabricEnabled() (the fabric/IMEX trial regular cuMem IPC uses). On non-fabric / no-IMEX hosts (e.g. RE/CI) it declines → unanimous unicast fallback, so the
collective is unaffected.
- Non-window eager/graph AGP path is untouched (mcWrite left std::nullopt).
  - Tests: AllGatherCtwinTest.AllGatherCtwinMulticastWhenWindowRegistered + env-parameterized AllGatherCtwinPerf busbw bench; adds a 1x2 config.

Reviewed By: minsii

Differential Revision: D112761232


