### PR TITLE
Extract prepareSendBuf/consumeRecvBuf from send/recv

### DIFF
--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -62,6 +62,12 @@ __device__ __forceinline__ void trace_ibgda_event(
 }
 #endif
 
+// Protocol-policy tags live in `protocol` to avoid collisions with the very
+// generic name `Simple` at comms::prims scope. LL is added alongside here.
+namespace protocol {
+struct Simple {};
+} // namespace protocol
+
 namespace detail {
 
 /**
@@ -817,7 +823,68 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
  *                        perBlockSlot. 0 means one signal per perBlockSlot.
  * @param timeout         Optional timeout for wait operations.
  */
-template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+// Per-call geometry for the blocking send()/recv() loops. One definition serves
+// both directions -- send and recv share the same layout, so the caller
+// resolves its own progress slot separately. Tag-dispatched on the protocol
+// `P`, but `P` is an unused tag today (single-space, 16B); per-protocol packet
+// geometry is added in a later diff. Blocking-path analog of
+// make_progress_geometry().
+struct SendRecvGeometry {
+  int groupId;
+  std::size_t perBlockSlot; // physical bytes per (slot, group)
+  std::size_t chunkSize; // max bytes per signaled chunk
+  std::size_t payloadProtocolBytes; // nbytes rounded up to 16; loop bound
+};
+
+template <typename P>
+__device__ __forceinline__ SendRecvGeometry calcGeometry(
+    P,
+    const IbChannelLayout& channelLayout,
+    ThreadGroup& group,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes) {
+  const int groupId = group.group_id;
+  const int maxGroups = channelLayout.maxChannels;
+  if (groupId >= maxGroups) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: send/recv group_id=%u >= maxGroups=%d\n",
+          groupId,
+          maxGroups);
+    }
+    PIPES_DEVICE_TRAP();
+  }
+  const std::size_t perBlockSlot = pipeline_chunk(channelLayout);
+  if (perBlockSlot == 0) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: send/recv perBlockSlot=0 "
+          "(perChannelBufferSize=%llu, pipelineDepth=%d)\n",
+          (unsigned long long)pipeline_window(channelLayout),
+          channelLayout.pipelineDepth);
+    }
+    PIPES_DEVICE_TRAP();
+  }
+  std::size_t chunkSize =
+      (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
+      ? (max_signal_bytes & ~15ULL)
+      : perBlockSlot;
+  if (chunkSize == 0) {
+    chunkSize = perBlockSlot;
+  }
+  return SendRecvGeometry{
+      .groupId = groupId,
+      .perBlockSlot = perBlockSlot,
+      .chunkSize = chunkSize,
+      .payloadProtocolBytes = align_protocol_bytes(nbytes),
+  };
+}
+
+template <
+    typename Transport,
+    typename CopyOp = Memcpy,
+    typename Proto = protocol::Simple,
+    typename... Args>
 __device__ __forceinline__ void send(
     Transport& transport,
     ThreadGroup& group,
@@ -838,39 +905,12 @@ __device__ __forceinline__ void send(
     return;
   }
   auto& channelLayout = transport.channel_layout();
-  const std::size_t payloadProtocolBytes = align_protocol_bytes(nbytes);
-
-  const int groupId = group.group_id;
-  const int maxGroups = channelLayout.maxChannels;
-  if (groupId >= maxGroups) {
-    if (group.is_leader()) {
-      printf(
-          "[PIPES] FATAL: send group_id=%u >= maxGroups=%d\n",
-          groupId,
-          maxGroups);
-    }
-    PIPES_DEVICE_TRAP();
-  }
-
-  const std::size_t perBlockSlot = pipeline_chunk(channelLayout);
-  if (perBlockSlot == 0) {
-    if (group.is_leader()) {
-      printf(
-          "[PIPES] FATAL: send perBlockSlot=0 "
-          "(perChannelBufferSize=%llu, pipelineDepth=%d)\n",
-          (unsigned long long)pipeline_window(channelLayout),
-          channelLayout.pipelineDepth);
-    }
-    PIPES_DEVICE_TRAP();
-  }
-
-  std::size_t chunkSize =
-      (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
-      ? (max_signal_bytes & ~15ULL)
-      : perBlockSlot;
-  if (chunkSize == 0) {
-    chunkSize = perBlockSlot;
-  }
+  const SendRecvGeometry geometry =
+      calcGeometry(Proto{}, channelLayout, group, nbytes, max_signal_bytes);
+  const int groupId = geometry.groupId;
+  const std::size_t perBlockSlot = geometry.perBlockSlot;
+  const std::size_t chunkSize = geometry.chunkSize;
+  const std::size_t payloadProtocolBytes = geometry.payloadProtocolBytes;
 
   auto& state = progress_send_slot(transport, group);
   IbLocalChannel& localChannel =
@@ -1002,7 +1042,11 @@ __device__ __forceinline__ void send(
  *                        Must match the sender's value.
  * @param timeout         Optional timeout for wait operations.
  */
-template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+template <
+    typename Transport,
+    typename CopyOp = Memcpy,
+    typename Proto = protocol::Simple,
+    typename... Args>
 __device__ __forceinline__ void recv(
     Transport& transport,
     ThreadGroup& group,
@@ -1023,39 +1067,12 @@ __device__ __forceinline__ void recv(
     return;
   }
   auto& channelLayout = transport.channel_layout();
-  const std::size_t payloadProtocolBytes = align_protocol_bytes(nbytes);
-
-  const int groupId = group.group_id;
-  const int maxGroups = channelLayout.maxChannels;
-  if (groupId >= maxGroups) {
-    if (group.is_leader()) {
-      printf(
-          "[PIPES] FATAL: recv group_id=%u >= maxGroups=%d\n",
-          groupId,
-          maxGroups);
-    }
-    PIPES_DEVICE_TRAP();
-  }
-
-  const std::size_t perBlockSlot = pipeline_chunk(channelLayout);
-  if (perBlockSlot == 0) {
-    if (group.is_leader()) {
-      printf(
-          "[PIPES] FATAL: recv perBlockSlot=0 "
-          "(perChannelBufferSize=%llu, pipelineDepth=%d)\n",
-          (unsigned long long)pipeline_window(channelLayout),
-          channelLayout.pipelineDepth);
-    }
-    PIPES_DEVICE_TRAP();
-  }
-
-  std::size_t chunkSize =
-      (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
-      ? (max_signal_bytes & ~15ULL)
-      : perBlockSlot;
-  if (chunkSize == 0) {
-    chunkSize = perBlockSlot;
-  }
+  const SendRecvGeometry geometry =
+      calcGeometry(Proto{}, channelLayout, group, nbytes, max_signal_bytes);
+  const int groupId = geometry.groupId;
+  const std::size_t perBlockSlot = geometry.perBlockSlot;
+  const std::size_t chunkSize = geometry.chunkSize;
+  const std::size_t payloadProtocolBytes = geometry.payloadProtocolBytes;
 
   auto& state = progress_recv_slot(transport, group);
   IbLocalChannel& localChannel =
@@ -1187,7 +1204,11 @@ __device__ __forceinline__ void recv(
  * @param timeout         Optional timeout for wait operations.
  * @param args            Extra args forwarded to CopyOp::forward.
  */
-template <typename CopyOp = Memcpy, typename Transport, typename... Args>
+template <
+    typename CopyOp = Memcpy,
+    typename Transport,
+    typename Proto = protocol::Simple,
+    typename... Args>
 __device__ __forceinline__ void forward(
     Transport& transport,
     ThreadGroup& group,
@@ -1208,65 +1229,21 @@ __device__ __forceinline__ void forward(
   }
   auto& channelLayout = transport.channel_layout();
   auto& fwdChannelLayout = fwdTransport.channel_layout();
-  const std::size_t payloadProtocolBytes = align_protocol_bytes(nbytes);
-
   const int groupId = group.group_id;
 
-  // --- recv side (this transport) ---
-  const int recvMaxGroups = channelLayout.maxChannels;
-  if (groupId >= recvMaxGroups) {
-    if (group.is_leader()) {
-      printf(
-          "[PIPES] FATAL: forward recv maxGroups=%d groupId=%u\n",
-          recvMaxGroups,
-          groupId);
-    }
-    PIPES_DEVICE_TRAP();
-  }
-
-  const std::size_t recvPerBlockSlot = pipeline_chunk(channelLayout);
-  if (recvPerBlockSlot == 0) {
-    if (group.is_leader()) {
-      printf("[PIPES] FATAL: forward recvPerBlockSlot=0\n");
-    }
-    PIPES_DEVICE_TRAP();
-  }
-
-  // --- fwd side (fwd transport) ---
-  const int fwdMaxGroups = fwdChannelLayout.maxChannels;
-  if (groupId >= fwdMaxGroups) {
-    if (group.is_leader()) {
-      printf(
-          "[PIPES] FATAL: forward fwd maxGroups=%d groupId=%u\n",
-          fwdMaxGroups,
-          groupId);
-    }
-    PIPES_DEVICE_TRAP();
-  }
-
-  const std::size_t fwdPerBlockSlot = pipeline_chunk(fwdChannelLayout);
-  if (fwdPerBlockSlot == 0) {
-    if (group.is_leader()) {
-      printf("[PIPES] FATAL: forward fwdPerBlockSlot=0\n");
-    }
-    PIPES_DEVICE_TRAP();
-  }
-
-  // Chunk sizes for recv and fwd sides
-  std::size_t recvChunkSize =
-      (max_signal_bytes > 0 && max_signal_bytes < recvPerBlockSlot)
-      ? (max_signal_bytes & ~15ULL)
-      : recvPerBlockSlot;
-  if (recvChunkSize == 0) {
-    recvChunkSize = recvPerBlockSlot;
-  }
-  std::size_t fwdChunkSize =
-      (max_signal_bytes > 0 && max_signal_bytes < fwdPerBlockSlot)
-      ? (max_signal_bytes & ~15ULL)
-      : fwdPerBlockSlot;
-  if (fwdChunkSize == 0) {
-    fwdChunkSize = fwdPerBlockSlot;
-  }
+  // Per-side geometry via the shared calcGeometry() helper. Single-space today
+  // (perBlockSlot / chunkSize); the payload/wire split is added in a follow-up.
+  // calcGeometry validates groupId < maxChannels and perBlockSlot != 0 for each
+  // channel.
+  const SendRecvGeometry recvGeo =
+      calcGeometry(Proto{}, channelLayout, group, nbytes, max_signal_bytes);
+  const SendRecvGeometry fwdGeo =
+      calcGeometry(Proto{}, fwdChannelLayout, group, nbytes, max_signal_bytes);
+  const std::size_t payloadProtocolBytes = recvGeo.payloadProtocolBytes;
+  const std::size_t recvPerBlockSlot = recvGeo.perBlockSlot;
+  const std::size_t recvChunkSize = recvGeo.chunkSize;
+  const std::size_t fwdPerBlockSlot = fwdGeo.perBlockSlot;
+  const std::size_t fwdChunkSize = fwdGeo.chunkSize;
 
   auto& recvSlotState = progress_recv_slot(transport, group);
   IbLocalChannel& recvLocalChannel =

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -62,10 +62,33 @@ __device__ __forceinline__ void trace_ibgda_event(
 }
 #endif
 
-// Protocol-policy tags live in `protocol` to avoid collisions with the very
-// generic name `Simple` at comms::prims scope. LL is added alongside here.
+/**
+ * Protocol policy selecting the send/recv wire format AND its packet geometry.
+ * The shared send/recv loop iterates in PAYLOAD bytes and derives physical
+ * staging offsets, RDMA lengths, and signal/counter thresholds in WIRE bytes
+ * via wire_bytes():
+ *   kData        payload bytes per packet / alignment quantum
+ *   kPacketBytes wire bytes per packet (== kData for Simple: no flag)
+ *   max_payload  wire-bytes -> payload capacity
+ *   wire_bytes   payload-bytes -> wire bytes (round up to a whole packet)
+ * `Simple` is nccl-"simple" put(data)+explicit-signal: a degenerate packet of
+ * 16 contiguous data bytes, no flag, so wire == payload. Low-latency (LL)
+ * policies are added in later diffs. Tags live in `protocol` to avoid
+ * collisions with the generic name `Simple` at comms::prims scope.
+ */
 namespace protocol {
-struct Simple {};
+struct Simple {
+  static constexpr std::size_t kData = 16; // protocol alignment quantum
+  static constexpr std::size_t kPacketBytes = 16; // wire == payload
+  __host__ __device__ static constexpr std::size_t max_payload(
+      std::size_t wireBytes) {
+    return wireBytes;
+  }
+  __host__ __device__ static constexpr std::size_t wire_bytes(
+      std::size_t payloadBytes) {
+    return (payloadBytes + kData - 1) / kData * kPacketBytes;
+  }
+};
 } // namespace protocol
 
 namespace detail {
@@ -831,9 +854,13 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
 // make_progress_geometry().
 struct SendRecvGeometry {
   int groupId;
-  std::size_t perBlockSlot; // physical bytes per (slot, group)
-  std::size_t chunkSize; // max bytes per signaled chunk
-  std::size_t payloadProtocolBytes; // nbytes rounded up to 16; loop bound
+  std::size_t perBlockSlotWire; // physical (wire) bytes per (slot, group)
+  std::size_t perBlockSlotPayload; // payload capacity of that region
+  std::size_t chunkPayload; // max payload per signaled chunk (>= 1 packet)
+  std::size_t pipelineBytesPayload; // ring window in payload bytes
+  std::size_t pipelineBytesWire; // ring window in wire bytes
+  std::size_t
+      payloadProtocolBytes; // payload bytes rounded up to kData; loop bound
 };
 
 template <typename P>
@@ -854,8 +881,8 @@ __device__ __forceinline__ SendRecvGeometry calcGeometry(
     }
     PIPES_DEVICE_TRAP();
   }
-  const std::size_t perBlockSlot = pipeline_chunk(channelLayout);
-  if (perBlockSlot == 0) {
+  const std::size_t perBlockSlotWire = pipeline_chunk(channelLayout);
+  if (perBlockSlotWire == 0) {
     if (group.is_leader()) {
       printf(
           "[PIPES] FATAL: send/recv perBlockSlot=0 "
@@ -865,18 +892,27 @@ __device__ __forceinline__ SendRecvGeometry calcGeometry(
     }
     PIPES_DEVICE_TRAP();
   }
-  std::size_t chunkSize =
-      (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
-      ? (max_signal_bytes & ~15ULL)
-      : perBlockSlot;
-  if (chunkSize == 0) {
-    chunkSize = perBlockSlot;
+  const std::size_t perBlockSlotPayload = P::max_payload(perBlockSlotWire);
+  // Chunk size in PAYLOAD bytes, aligned down to whole packets (kData).
+  std::size_t chunkPayload =
+      (max_signal_bytes > 0 && max_signal_bytes < perBlockSlotPayload)
+      ? (max_signal_bytes / P::kData * P::kData)
+      : perBlockSlotPayload;
+  if (chunkPayload == 0) {
+    chunkPayload = perBlockSlotPayload;
   }
+  const std::size_t pipelineBytesWire = pipeline_window(channelLayout);
+  // Payload bytes rounded up to a whole packet (kData). For Simple == round-16.
+  const std::size_t payloadProtocolBytes =
+      (nbytes + P::kData - 1) / P::kData * P::kData;
   return SendRecvGeometry{
       .groupId = groupId,
-      .perBlockSlot = perBlockSlot,
-      .chunkSize = chunkSize,
-      .payloadProtocolBytes = align_protocol_bytes(nbytes),
+      .perBlockSlotWire = perBlockSlotWire,
+      .perBlockSlotPayload = perBlockSlotPayload,
+      .chunkPayload = chunkPayload,
+      .pipelineBytesPayload = P::max_payload(pipelineBytesWire),
+      .pipelineBytesWire = pipelineBytesWire,
+      .payloadProtocolBytes = payloadProtocolBytes,
   };
 }
 
@@ -908,8 +944,11 @@ __device__ __forceinline__ void send(
   const SendRecvGeometry geometry =
       calcGeometry(Proto{}, channelLayout, group, nbytes, max_signal_bytes);
   const int groupId = geometry.groupId;
-  const std::size_t perBlockSlot = geometry.perBlockSlot;
-  const std::size_t chunkSize = geometry.chunkSize;
+  const std::size_t perBlockSlotWire = geometry.perBlockSlotWire;
+  const std::size_t perBlockSlotPayload = geometry.perBlockSlotPayload;
+  const std::size_t chunkPayload = geometry.chunkPayload;
+  const std::size_t pipelineBytesPayload = geometry.pipelineBytesPayload;
+  const std::size_t pipelineBytesWire = geometry.pipelineBytesWire;
   const std::size_t payloadProtocolBytes = geometry.payloadProtocolBytes;
 
   auto& state = progress_send_slot(transport, group);
@@ -921,10 +960,9 @@ __device__ __forceinline__ void send(
   assert_progress_slot_idle(group, state, "send");
   const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
   const std::size_t protocolTailPadding = tail_padding_for_signal_granularity(
-      baseByte, max_signal_bytes, perBlockSlot, nbytes);
+      baseByte, max_signal_bytes, perBlockSlotPayload, nbytes);
   const uint64_t payloadBaseByte = baseByte;
   const std::size_t protocolBytes = payloadProtocolBytes + protocolTailPadding;
-  const std::size_t pipelineBytes = pipeline_window(channelLayout);
   if (group.is_leader()) {
     state.activeStage = detail::IbSendRecvProgressStage::Busy;
     state.activeBaseStep = static_cast<int64_t>(baseByte);
@@ -932,32 +970,45 @@ __device__ __forceinline__ void send(
     state.activeTailPadding = protocolTailPadding;
   }
 
+  // The loop iterates in PAYLOAD bytes; physical staging offsets, RDMA lengths,
+  // and signal/counter thresholds are derived in WIRE bytes via
+  // Proto::wire_bytes() (1:1 for Simple, kPacketBytes:kData for LL). Tail
+  // padding rides the final signal/counter credit only -- the RDMA write covers
+  // valid payload/wire bytes.
   for (std::size_t dataOff = 0; dataOff < payloadProtocolBytes;) {
-    const uint64_t streamStart = payloadBaseByte + dataOff;
+    const uint64_t streamPayload = payloadBaseByte + dataOff;
     const std::size_t pipelineOff =
-        static_cast<std::size_t>(streamStart % pipelineBytes);
-    const int slot = static_cast<int>(pipelineOff / perBlockSlot);
-    const std::size_t slotOff = static_cast<std::size_t>(slot) * perBlockSlot;
-    const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
-    const std::size_t slotRemaining = perBlockSlot - chunkOff;
+        static_cast<std::size_t>(streamPayload % pipelineBytesPayload);
+    const int slot = static_cast<int>(pipelineOff / perBlockSlotPayload);
+    const std::size_t chunkOff = pipelineOff - slot * perBlockSlotPayload;
+    const std::size_t slotRemaining = perBlockSlotPayload - chunkOff;
     const std::size_t dataRemaining = payloadProtocolBytes - dataOff;
-    std::size_t bytesThis =
-        chunkSize < dataRemaining ? chunkSize : dataRemaining;
-    bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
-    const bool isFinalChunk = dataOff + bytesThis >= payloadProtocolBytes;
+    std::size_t payloadBytes =
+        chunkPayload < dataRemaining ? chunkPayload : dataRemaining;
+    payloadBytes = payloadBytes < slotRemaining ? payloadBytes : slotRemaining;
+    const bool isFinalChunk = dataOff + payloadBytes >= payloadProtocolBytes;
+
+    // Wire-space derivations (== payload for Simple: wire_bytes is identity).
+    const std::size_t bytesThis = Proto::wire_bytes(payloadBytes);
+    // Tail padding is a payload-space alignment credit; convert it to wire so
+    // it matches the wire flow-control stream (streamWire =
+    // wire_bytes(cursor)). Identity for Simple; kPacketBytes:kData for LL.
     const std::size_t protocolBytesThis =
-        bytesThis + (isFinalChunk ? protocolTailPadding : 0);
+        bytesThis + (isFinalChunk ? Proto::wire_bytes(protocolTailPadding) : 0);
     const std::size_t stagingOff =
-        static_cast<std::size_t>(groupId) * pipelineBytes + slotOff + chunkOff;
-    const uint64_t protocolStreamEnd = streamStart + protocolBytesThis;
-    const uint64_t pipelineCycle = streamStart / pipelineBytes;
+        static_cast<std::size_t>(groupId) * pipelineBytesWire +
+        static_cast<std::size_t>(slot) * perBlockSlotWire +
+        Proto::wire_bytes(chunkOff);
+    const uint64_t streamWire = Proto::wire_bytes(streamPayload);
+    const uint64_t protocolStreamEnd = streamWire + protocolBytesThis;
+    const uint64_t pipelineCycle = streamPayload / pipelineBytesPayload;
 
     // (1) Wait for NIC to finish with this slot's local sendStaging.
     prepare_send_slot(transport, group, slot, pipelineCycle, timeout);
 
     // (2) Cooperative copy: src -> local sendStaging via CopyOp.
     const std::size_t validBytes =
-        valid_payload_bytes(dataOff, bytesThis, nbytes);
+        valid_payload_bytes(dataOff, payloadBytes, nbytes);
     if (validBytes > 0) {
       CopyOp::send(
           channelLayout.sendStagingPtr + stagingOff,
@@ -971,9 +1022,9 @@ __device__ __forceinline__ void send(
 
     // (3) Backpressure: wait for receiver to free this byte range's
     //     recvStaging offset. Symmetric with DATA_READY.
-    if (protocolStreamEnd > pipelineBytes) {
+    if (protocolStreamEnd > pipelineBytesWire) {
       transport.wait_signal(
-          group, localSlotFree, protocolStreamEnd - pipelineBytes, timeout);
+          group, localSlotFree, protocolStreamEnd - pipelineBytesWire, timeout);
     }
 
     // (4) threadfence_system + leader-only RDMA put with fused signal.
@@ -1001,7 +1052,7 @@ __device__ __forceinline__ void send(
           completion);
     }
     group.sync();
-    dataOff += bytesThis;
+    dataOff += payloadBytes;
   }
 
   if (group.is_leader()) {
@@ -1070,8 +1121,11 @@ __device__ __forceinline__ void recv(
   const SendRecvGeometry geometry =
       calcGeometry(Proto{}, channelLayout, group, nbytes, max_signal_bytes);
   const int groupId = geometry.groupId;
-  const std::size_t perBlockSlot = geometry.perBlockSlot;
-  const std::size_t chunkSize = geometry.chunkSize;
+  const std::size_t perBlockSlotWire = geometry.perBlockSlotWire;
+  const std::size_t perBlockSlotPayload = geometry.perBlockSlotPayload;
+  const std::size_t chunkPayload = geometry.chunkPayload;
+  const std::size_t pipelineBytesPayload = geometry.pipelineBytesPayload;
+  const std::size_t pipelineBytesWire = geometry.pipelineBytesWire;
   const std::size_t payloadProtocolBytes = geometry.payloadProtocolBytes;
 
   auto& state = progress_recv_slot(transport, group);
@@ -1083,10 +1137,9 @@ __device__ __forceinline__ void recv(
   assert_progress_slot_idle(group, state, "recv");
   const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
   const std::size_t protocolTailPadding = tail_padding_for_signal_granularity(
-      baseByte, max_signal_bytes, perBlockSlot, nbytes);
+      baseByte, max_signal_bytes, perBlockSlotPayload, nbytes);
   const uint64_t payloadBaseByte = baseByte;
   const std::size_t protocolBytes = payloadProtocolBytes + protocolTailPadding;
-  const std::size_t pipelineBytes = pipeline_window(channelLayout);
   if (group.is_leader()) {
     state.activeStage = detail::IbSendRecvProgressStage::Busy;
     state.activeBaseStep = static_cast<int64_t>(baseByte);
@@ -1094,23 +1147,32 @@ __device__ __forceinline__ void recv(
     state.activeTailPadding = protocolTailPadding;
   }
 
+  // Payload-space iteration; wire-space staging/threshold derivations via
+  // Proto::wire_bytes() (identity for Simple). Tail padding rides the final
+  // SLOT_FREE credit only; the recv copies valid payload bytes.
   for (std::size_t dataOff = 0; dataOff < payloadProtocolBytes;) {
-    const uint64_t streamStart = payloadBaseByte + dataOff;
+    const uint64_t streamPayload = payloadBaseByte + dataOff;
     const std::size_t pipelineOff =
-        static_cast<std::size_t>(streamStart % pipelineBytes);
-    const int slot = static_cast<int>(pipelineOff / perBlockSlot);
-    const std::size_t slotOff = static_cast<std::size_t>(slot) * perBlockSlot;
-    const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
-    const std::size_t slotRemaining = perBlockSlot - chunkOff;
+        static_cast<std::size_t>(streamPayload % pipelineBytesPayload);
+    const int slot = static_cast<int>(pipelineOff / perBlockSlotPayload);
+    const std::size_t chunkOff = pipelineOff - slot * perBlockSlotPayload;
+    const std::size_t slotRemaining = perBlockSlotPayload - chunkOff;
     const std::size_t dataRemaining = payloadProtocolBytes - dataOff;
-    std::size_t bytesThis =
-        chunkSize < dataRemaining ? chunkSize : dataRemaining;
-    bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
-    const bool isFinalChunk = dataOff + bytesThis >= payloadProtocolBytes;
+    std::size_t payloadBytes =
+        chunkPayload < dataRemaining ? chunkPayload : dataRemaining;
+    payloadBytes = payloadBytes < slotRemaining ? payloadBytes : slotRemaining;
+    const bool isFinalChunk = dataOff + payloadBytes >= payloadProtocolBytes;
+
+    const std::size_t bytesThis = Proto::wire_bytes(payloadBytes);
+    // Tail padding is a payload-space alignment credit; convert it to wire so
+    // it matches the wire flow-control stream (streamWire =
+    // wire_bytes(cursor)). Identity for Simple; kPacketBytes:kData for LL.
     const std::size_t protocolBytesThis =
-        bytesThis + (isFinalChunk ? protocolTailPadding : 0);
+        bytesThis + (isFinalChunk ? Proto::wire_bytes(protocolTailPadding) : 0);
     const std::size_t stagingOff =
-        static_cast<std::size_t>(groupId) * pipelineBytes + slotOff + chunkOff;
+        static_cast<std::size_t>(groupId) * pipelineBytesWire +
+        static_cast<std::size_t>(slot) * perBlockSlotWire +
+        Proto::wire_bytes(chunkOff);
 
     // (1) Wait for sender's DATA_READY on the specific round-robin lane that
     //     carried this chunk (mirrors the sender's per-channel Send cursor).
@@ -1124,7 +1186,7 @@ __device__ __forceinline__ void recv(
 
     // (2) Cooperative copy: local recvStaging -> dst via CopyOp.
     const std::size_t validBytes =
-        valid_payload_bytes(dataOff, bytesThis, nbytes);
+        valid_payload_bytes(dataOff, payloadBytes, nbytes);
     if (validBytes > 0) {
       CopyOp::recv(
           static_cast<char*>(dst) + dataOff,
@@ -1138,7 +1200,7 @@ __device__ __forceinline__ void recv(
 
     transport.signal(
         group, remoteChannel.slotFree, protocolBytesThis, IbDirection::Recv);
-    dataOff += bytesThis;
+    dataOff += payloadBytes;
   }
 
   if (group.is_leader()) {
@@ -1231,20 +1293,18 @@ __device__ __forceinline__ void forward(
   auto& fwdChannelLayout = fwdTransport.channel_layout();
   const int groupId = group.group_id;
 
-  // Per-side geometry via the shared calcGeometry() helper. Single-space today
-  // (perBlockSlot / chunkSize); the payload/wire split is added in a follow-up.
-  // calcGeometry validates groupId < maxChannels and perBlockSlot != 0 for each
-  // channel.
+  // Per-side payload/wire geometry (Proto-tagged). calcGeometry validates
+  // groupId < maxChannels and perBlockSlot != 0 for each channel. The loop
+  // iterates in PAYLOAD bytes; staging offsets, RDMA lengths, and
+  // signal/counter thresholds are derived in WIRE bytes via Proto::wire_bytes()
+  // (identity for Simple; kPacketBytes:kData for LL).
   const SendRecvGeometry recvGeo =
       calcGeometry(Proto{}, channelLayout, group, nbytes, max_signal_bytes);
   const SendRecvGeometry fwdGeo =
       calcGeometry(Proto{}, fwdChannelLayout, group, nbytes, max_signal_bytes);
   const std::size_t payloadProtocolBytes = recvGeo.payloadProtocolBytes;
-  const std::size_t recvPerBlockSlot = recvGeo.perBlockSlot;
-  const std::size_t recvChunkSize = recvGeo.chunkSize;
-  const std::size_t fwdPerBlockSlot = fwdGeo.perBlockSlot;
-  const std::size_t fwdChunkSize = fwdGeo.chunkSize;
 
+  // --- recv side (this transport) ---
   auto& recvSlotState = progress_recv_slot(transport, group);
   IbLocalChannel& recvLocalChannel =
       transport.local_channel(static_cast<uint32_t>(groupId));
@@ -1255,12 +1315,12 @@ __device__ __forceinline__ void forward(
   const uint64_t recvBaseByte = static_cast<uint64_t>(recvSlotState.nextStep);
   const std::size_t recvProtocolTailPadding =
       tail_padding_for_signal_granularity(
-          recvBaseByte, max_signal_bytes, recvPerBlockSlot, nbytes);
+          recvBaseByte, max_signal_bytes, recvGeo.perBlockSlotPayload, nbytes);
   const uint64_t recvPayloadBaseByte = recvBaseByte;
   const std::size_t recvProtocolBytes =
       payloadProtocolBytes + recvProtocolTailPadding;
-  const std::size_t recvPipelineBytes = pipeline_window(channelLayout);
 
+  // --- fwd side (fwd transport) ---
   auto& fwdSlotState = progress_send_slot(fwdTransport, group);
   IbLocalChannel& fwdLocalChannel =
       fwdTransport.local_channel(static_cast<uint32_t>(groupId));
@@ -1271,11 +1331,10 @@ __device__ __forceinline__ void forward(
   const uint64_t fwdBaseByte = static_cast<uint64_t>(fwdSlotState.nextStep);
   const std::size_t fwdProtocolTailPadding =
       tail_padding_for_signal_granularity(
-          fwdBaseByte, max_signal_bytes, fwdPerBlockSlot, nbytes);
+          fwdBaseByte, max_signal_bytes, fwdGeo.perBlockSlotPayload, nbytes);
   const uint64_t fwdPayloadBaseByte = fwdBaseByte;
   const std::size_t fwdProtocolBytes =
       payloadProtocolBytes + fwdProtocolTailPadding;
-  const std::size_t fwdPipelineBytes = pipeline_window(fwdChannelLayout);
   if (group.is_leader()) {
     recvSlotState.activeStage = detail::IbSendRecvProgressStage::Busy;
     recvSlotState.activeBaseStep = static_cast<int64_t>(recvBaseByte);
@@ -1288,45 +1347,56 @@ __device__ __forceinline__ void forward(
   }
 
   for (std::size_t dataOff = 0; dataOff < payloadProtocolBytes;) {
-    // --- Recv side offsets ---
-    const uint64_t recvStreamStart = recvPayloadBaseByte + dataOff;
-    const std::size_t recvPipelineOff =
-        static_cast<std::size_t>(recvStreamStart % recvPipelineBytes);
-    const int recvSlot = static_cast<int>(recvPipelineOff / recvPerBlockSlot);
-    const std::size_t recvSlotOff =
-        static_cast<std::size_t>(recvSlot) * recvPerBlockSlot;
+    // --- Recv side offsets (ring math in PAYLOAD, physical offset in WIRE) ---
+    const uint64_t recvStreamPayload = recvPayloadBaseByte + dataOff;
+    const std::size_t recvPipelineOff = static_cast<std::size_t>(
+        recvStreamPayload % recvGeo.pipelineBytesPayload);
+    const int recvSlot =
+        static_cast<int>(recvPipelineOff / recvGeo.perBlockSlotPayload);
     const std::size_t recvChunkOff =
-        recvPipelineOff - recvSlot * recvPerBlockSlot;
+        recvPipelineOff - recvSlot * recvGeo.perBlockSlotPayload;
     const std::size_t recvStagingOff =
-        static_cast<std::size_t>(groupId) * recvPipelineBytes + recvSlotOff +
-        recvChunkOff;
+        static_cast<std::size_t>(groupId) * recvGeo.pipelineBytesWire +
+        static_cast<std::size_t>(recvSlot) * recvGeo.perBlockSlotWire +
+        Proto::wire_bytes(recvChunkOff);
+    const std::size_t recvSlotRemaining =
+        recvGeo.perBlockSlotPayload - recvChunkOff;
 
     // --- Fwd side offsets ---
-    const uint64_t fwdStreamStart = fwdPayloadBaseByte + dataOff;
-    const std::size_t fwdPipelineOff =
-        static_cast<std::size_t>(fwdStreamStart % fwdPipelineBytes);
-    const int fwdSlot = static_cast<int>(fwdPipelineOff / fwdPerBlockSlot);
-    const std::size_t fwdSlotOff =
-        static_cast<std::size_t>(fwdSlot) * fwdPerBlockSlot;
-    const std::size_t fwdChunkOff = fwdPipelineOff - fwdSlot * fwdPerBlockSlot;
+    const uint64_t fwdStreamPayload = fwdPayloadBaseByte + dataOff;
+    const std::size_t fwdPipelineOff = static_cast<std::size_t>(
+        fwdStreamPayload % fwdGeo.pipelineBytesPayload);
+    const int fwdSlot =
+        static_cast<int>(fwdPipelineOff / fwdGeo.perBlockSlotPayload);
+    const std::size_t fwdChunkOff =
+        fwdPipelineOff - fwdSlot * fwdGeo.perBlockSlotPayload;
     const std::size_t fwdStagingOff =
-        static_cast<std::size_t>(groupId) * fwdPipelineBytes + fwdSlotOff +
-        fwdChunkOff;
-    const std::size_t recvSlotRemaining = recvPerBlockSlot - recvChunkOff;
-    const std::size_t fwdSlotRemaining = fwdPerBlockSlot - fwdChunkOff;
+        static_cast<std::size_t>(groupId) * fwdGeo.pipelineBytesWire +
+        static_cast<std::size_t>(fwdSlot) * fwdGeo.perBlockSlotWire +
+        Proto::wire_bytes(fwdChunkOff);
+    const std::size_t fwdSlotRemaining =
+        fwdGeo.perBlockSlotPayload - fwdChunkOff;
+
+    // --- Chunk sizing in PAYLOAD; wire lengths via Proto::wire_bytes() ---
     const std::size_t dataRemaining = payloadProtocolBytes - dataOff;
-    std::size_t bytesThis =
-        recvChunkSize < fwdChunkSize ? recvChunkSize : fwdChunkSize;
-    bytesThis = bytesThis < dataRemaining ? bytesThis : dataRemaining;
-    bytesThis = bytesThis < recvSlotRemaining ? bytesThis : recvSlotRemaining;
-    bytesThis = bytesThis < fwdSlotRemaining ? bytesThis : fwdSlotRemaining;
-    const bool isFinalChunk = dataOff + bytesThis >= payloadProtocolBytes;
-    const std::size_t recvProtocolBytesThis =
-        bytesThis + (isFinalChunk ? recvProtocolTailPadding : 0);
-    const std::size_t fwdProtocolBytesThis =
-        bytesThis + (isFinalChunk ? fwdProtocolTailPadding : 0);
-    const uint64_t fwdProtocolStreamEnd = fwdStreamStart + fwdProtocolBytesThis;
-    const uint64_t fwdPipelineCycle = fwdStreamStart / fwdPipelineBytes;
+    std::size_t payloadBytes = recvGeo.chunkPayload < fwdGeo.chunkPayload
+        ? recvGeo.chunkPayload
+        : fwdGeo.chunkPayload;
+    payloadBytes = payloadBytes < dataRemaining ? payloadBytes : dataRemaining;
+    payloadBytes =
+        payloadBytes < recvSlotRemaining ? payloadBytes : recvSlotRemaining;
+    payloadBytes =
+        payloadBytes < fwdSlotRemaining ? payloadBytes : fwdSlotRemaining;
+    const bool isFinalChunk = dataOff + payloadBytes >= payloadProtocolBytes;
+    const std::size_t bytesThis = Proto::wire_bytes(payloadBytes);
+    const std::size_t recvProtocolBytesThis = bytesThis +
+        (isFinalChunk ? Proto::wire_bytes(recvProtocolTailPadding) : 0);
+    const std::size_t fwdProtocolBytesThis = bytesThis +
+        (isFinalChunk ? Proto::wire_bytes(fwdProtocolTailPadding) : 0);
+    const uint64_t fwdStreamWire = Proto::wire_bytes(fwdStreamPayload);
+    const uint64_t fwdProtocolStreamEnd = fwdStreamWire + fwdProtocolBytesThis;
+    const uint64_t fwdPipelineCycle =
+        fwdStreamPayload / fwdGeo.pipelineBytesPayload;
 
     // (1) Wait for the upstream sender's DATA_READY on the specific round-robin
     //     lane that carried this chunk (mirrors the upstream sender's Send
@@ -1344,7 +1414,7 @@ __device__ __forceinline__ void forward(
 
     // (3) CopyOp::forward — transform recv staging -> dst + fwd staging.
     const std::size_t validBytes =
-        valid_payload_bytes(dataOff, bytesThis, nbytes);
+        valid_payload_bytes(dataOff, payloadBytes, nbytes);
     if (validBytes > 0) {
       CopyOp::forward(
           dst ? static_cast<char*>(dst) + dataOff : nullptr,
@@ -1365,9 +1435,12 @@ __device__ __forceinline__ void forward(
 
     // (5) Wait for fwd receiver's SLOT_FREE (backpressure on fwd's
     //     recvStaging).
-    if (fwdProtocolStreamEnd > fwdPipelineBytes) {
+    if (fwdProtocolStreamEnd > fwdGeo.pipelineBytesWire) {
       fwdTransport.wait_signal(
-          group, fwdSlotFree, fwdProtocolStreamEnd - fwdPipelineBytes, timeout);
+          group,
+          fwdSlotFree,
+          fwdProtocolStreamEnd - fwdGeo.pipelineBytesWire,
+          timeout);
     }
 
     // (6) threadfence_system + RDMA put via fwd transport.
@@ -1394,7 +1467,7 @@ __device__ __forceinline__ void forward(
           completion);
     }
     group.sync();
-    dataOff += bytesThis;
+    dataOff += payloadBytes;
   }
 
   // Update shared byte cursors for both recv and fwd sides.

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -916,6 +916,147 @@ __device__ __forceinline__ SendRecvGeometry calcGeometry(
   };
 }
 
+struct SendSignal {
+  IbgdaRemoteBuffer buf;
+  uint64_t val;
+};
+
+template <typename CopyOp = Memcpy, typename... Args>
+__device__ __forceinline__ SendSignal prepareSendBuf(
+    protocol::Simple,
+    ThreadGroup& group,
+    char* staging,
+    const char* src,
+    std::size_t payloadBytes,
+    std::size_t nbytes,
+    std::size_t dataOff,
+    const IbRemoteChannel& remoteChannel,
+    uint64_t signalVal,
+    Args... args) {
+#if PIPES_IS_DEVICE_COMPILE
+  const std::size_t validBytes =
+      valid_payload_bytes(dataOff, payloadBytes, nbytes);
+  if (validBytes > 0) {
+    CopyOp::send(staging, src, validBytes, group, dataOff, args...);
+  }
+  group.sync();
+  return SendSignal{remoteChannel.dataReady, signalVal};
+#else
+  (void)group;
+  (void)staging;
+  (void)src;
+  (void)payloadBytes;
+  (void)nbytes;
+  (void)dataOff;
+  (void)remoteChannel;
+  (void)signalVal;
+  ((void)args, ...);
+  return SendSignal{};
+#endif
+}
+
+// Simple decode: wait for the sender's DATA_READY on this chunk's lane, then
+// cooperative CopyOp::recv from contiguous staging.
+template <typename CopyOp = Memcpy, typename Transport, typename... Args>
+__device__ __forceinline__ void consumeRecvBuf(
+    protocol::Simple,
+    Transport& transport,
+    ThreadGroup& group,
+    IbLocalChannel& localChannel,
+    const IbgdaLocalBuffer& localDataReady,
+    char* dst,
+    const char* staging,
+    std::size_t payloadBytes,
+    std::size_t nbytes,
+    std::size_t dataOff,
+    uint64_t waitCredit,
+    const Timeout& timeout,
+    Args... args) {
+#if PIPES_IS_DEVICE_COMPILE
+  wait_recv_data_ready(
+      transport, group, localChannel, localDataReady, waitCredit, timeout);
+  const std::size_t validBytes =
+      valid_payload_bytes(dataOff, payloadBytes, nbytes);
+  if (validBytes > 0) {
+    CopyOp::recv(dst, staging, validBytes, group, dataOff, args...);
+  }
+  group.sync();
+#else
+  (void)transport;
+  (void)group;
+  (void)localChannel;
+  (void)localDataReady;
+  (void)dst;
+  (void)staging;
+  (void)payloadBytes;
+  (void)nbytes;
+  (void)dataOff;
+  (void)waitCredit;
+  (void)timeout;
+  ((void)args, ...);
+#endif
+}
+
+// Simple forward: wait for the upstream chunk's DATA_READY, then a single fused
+// CopyOp::forward transforms recvStaging -> dst + fwdStaging, and return the
+// DATA_READY SendSignal that the relay put piggybacks. This is the forward
+// analog of consumeRecvBuf (recv-side readiness) fused with prepareSendBuf
+// (relay signal); LL later overrides it to poll inline flags, repack the fwd
+// staging, and return an empty signal.
+template <typename CopyOp = Memcpy, typename Transport, typename... Args>
+__device__ __forceinline__ SendSignal prepareForwardBuf(
+    protocol::Simple,
+    Transport& transport,
+    ThreadGroup& group,
+    IbLocalChannel& recvLocalChannel,
+    const IbgdaLocalBuffer& recvDataReady,
+    char* dst,
+    char* fwdStaging,
+    const char* recvStaging,
+    std::size_t payloadBytes,
+    std::size_t nbytes,
+    std::size_t dataOff,
+    uint64_t recvWaitCredit,
+    const IbRemoteChannel& fwdRemoteChannel,
+    uint64_t fwdSignalVal,
+    const Timeout& timeout,
+    Args... args) {
+#if PIPES_IS_DEVICE_COMPILE
+  wait_recv_data_ready(
+      transport,
+      group,
+      recvLocalChannel,
+      recvDataReady,
+      recvWaitCredit,
+      timeout);
+  const std::size_t validBytes =
+      valid_payload_bytes(dataOff, payloadBytes, nbytes);
+  if (validBytes > 0) {
+    CopyOp::forward(
+        dst, fwdStaging, recvStaging, validBytes, group, dataOff, args...);
+  }
+  group.sync();
+  return SendSignal{fwdRemoteChannel.dataReady, fwdSignalVal};
+#else
+  (void)transport;
+  (void)group;
+  (void)recvLocalChannel;
+  (void)recvDataReady;
+  (void)dst;
+  (void)fwdStaging;
+  (void)recvStaging;
+  (void)payloadBytes;
+  (void)nbytes;
+  (void)dataOff;
+  (void)recvWaitCredit;
+  (void)fwdRemoteChannel;
+  (void)fwdSignalVal;
+  (void)timeout;
+  ((void)args, ...);
+  return SendSignal{};
+#endif
+}
+
 template <
     typename Transport,
     typename CopyOp = Memcpy,
@@ -1007,18 +1148,17 @@ __device__ __forceinline__ void send(
     prepare_send_slot(transport, group, slot, pipelineCycle, timeout);
 
     // (2) Cooperative copy: src -> local sendStaging via CopyOp.
-    const std::size_t validBytes =
-        valid_payload_bytes(dataOff, payloadBytes, nbytes);
-    if (validBytes > 0) {
-      CopyOp::send(
-          channelLayout.sendStagingPtr + stagingOff,
-          static_cast<const char*>(src) + dataOff,
-          validBytes,
-          group,
-          dataOff,
-          args...);
-    }
-    group.sync();
+    const SendSignal sig = prepareSendBuf<CopyOp>(
+        Proto{},
+        group,
+        channelLayout.sendStagingPtr + stagingOff,
+        static_cast<const char*>(src) + dataOff,
+        payloadBytes,
+        nbytes,
+        dataOff,
+        remoteChannel,
+        protocolBytesThis,
+        args...);
 
     // (3) Backpressure: wait for receiver to free this byte range's
     //     recvStaging offset. Symmetric with DATA_READY.
@@ -1039,8 +1179,8 @@ __device__ __forceinline__ void send(
           channelLayout.sendStagingBuf.subBuffer(stagingOff),
           remoteChannel.recvStaging.subBuffer(stagingOff),
           bytesThis,
-          remoteChannel.dataReady,
-          protocolBytesThis,
+          sig.buf,
+          sig.val,
           /*counterBuf=*/{},
           /*counterVal=*/0,
           /*signalPerLane=*/true);
@@ -1174,29 +1314,22 @@ __device__ __forceinline__ void recv(
         static_cast<std::size_t>(slot) * perBlockSlotWire +
         Proto::wire_bytes(chunkOff);
 
-    // (1) Wait for sender's DATA_READY on the specific round-robin lane that
-    //     carried this chunk (mirrors the sender's per-channel Send cursor).
-    wait_recv_data_ready(
+    // (1)+(2) Wait for the chunk to be ready (DATA_READY signal or, for LL, the
+    //         inline flag) and cooperatively copy recvStaging -> dst (decode).
+    consumeRecvBuf<CopyOp>(
+        Proto{},
         transport,
         group,
         localChannel,
         localDataReady,
+        static_cast<char*>(dst) + dataOff,
+        channelLayout.recvStagingPtr + stagingOff,
+        payloadBytes,
+        nbytes,
+        dataOff,
         protocolBytesThis,
-        timeout);
-
-    // (2) Cooperative copy: local recvStaging -> dst via CopyOp.
-    const std::size_t validBytes =
-        valid_payload_bytes(dataOff, payloadBytes, nbytes);
-    if (validBytes > 0) {
-      CopyOp::recv(
-          static_cast<char*>(dst) + dataOff,
-          channelLayout.recvStagingPtr + stagingOff,
-          validBytes,
-          group,
-          dataOff,
-          args...);
-    }
-    group.sync();
+        timeout,
+        args...);
 
     transport.signal(
         group, remoteChannel.slotFree, protocolBytesThis, IbDirection::Recv);
@@ -1398,34 +1531,29 @@ __device__ __forceinline__ void forward(
     const uint64_t fwdPipelineCycle =
         fwdStreamPayload / fwdGeo.pipelineBytesPayload;
 
-    // (1) Wait for the upstream sender's DATA_READY on the specific round-robin
-    //     lane that carried this chunk (mirrors the upstream sender's Send
-    //     cursor via recvLocalChannel.recvDataReadyLaneCursor).
-    wait_recv_data_ready(
+    // (1) Wait for local completion on fwd's sendStaging.
+    prepare_send_slot(fwdTransport, group, fwdSlot, fwdPipelineCycle, timeout);
+
+    // (2) prepareForwardBuf: recv-side readiness + fused transform recvStaging
+    //     -> dst + fwdStaging, returning the relay SendSignal for the put.
+    //     Tag-dispatched on Proto (Simple = DATA_READY wait + contiguous copy).
+    const SendSignal sig = prepareForwardBuf<CopyOp>(
+        Proto{},
         transport,
         group,
         recvLocalChannel,
         recvDataReady,
+        dst ? static_cast<char*>(dst) + dataOff : nullptr,
+        fwdChannelLayout.sendStagingPtr + fwdStagingOff,
+        channelLayout.recvStagingPtr + recvStagingOff,
+        payloadBytes,
+        nbytes,
+        dataOff,
         recvProtocolBytesThis,
-        timeout);
-
-    // (2) Wait for local completion on fwd's sendStaging.
-    prepare_send_slot(fwdTransport, group, fwdSlot, fwdPipelineCycle, timeout);
-
-    // (3) CopyOp::forward — transform recv staging -> dst + fwd staging.
-    const std::size_t validBytes =
-        valid_payload_bytes(dataOff, payloadBytes, nbytes);
-    if (validBytes > 0) {
-      CopyOp::forward(
-          dst ? static_cast<char*>(dst) + dataOff : nullptr,
-          fwdChannelLayout.sendStagingPtr + fwdStagingOff,
-          channelLayout.recvStagingPtr + recvStagingOff,
-          validBytes,
-          group,
-          dataOff,
-          args...);
-    }
-    group.sync();
+        fwdRemoteChannel,
+        fwdProtocolBytesThis,
+        timeout,
+        args...);
 
     transport.signal(
         group,
@@ -1454,8 +1582,8 @@ __device__ __forceinline__ void forward(
           fwdChannelLayout.sendStagingBuf.subBuffer(fwdStagingOff),
           fwdRemoteChannel.recvStaging.subBuffer(fwdStagingOff),
           bytesThis,
-          fwdRemoteChannel.dataReady,
-          fwdProtocolBytesThis,
+          sig.buf,
+          sig.val,
           /*counterBuf=*/{},
           /*counterVal=*/0,
           /*signalPerLane=*/true);


### PR DESCRIPTION
Summary:
Move the inline encode + signal out of the shared send/recv body into
tag-dispatched helpers: prepareSendBuf<Proto>() (fills staging + returns the
SendSignal for the put) and consumeRecvBuf<Proto>() (waits/polls + decodes).
Simple returns the DATA_READY slot and waits the signal; this is the seam the
LL protocol overrides. Simple behavior is unchanged.

Differential Revision: D111048042


