### PR TITLE
Set MCCL_CHANNEL_BUFFER_SIZE channel buffer size to be non-zero

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3200,7 +3200,7 @@ cvars:
 
  - name        : MCCL_CHANNEL_BUFFER_SIZE
    type        : uint64_t
-   default     : 0
+   default     : 524288
    description : |-
      Per-channel prims IB send/recv staging size in bytes, shared by the IBGDA
      and IBRC backends. Total staging per peer and direction is this value


### PR DESCRIPTION
Summary:
As title. Or it will fail with

```
E0724 18:33:38.929513 565767 CtranPipes.cc:239] rtptest548:565767:565767 [1][main] CTRAN ERROR send/recv requires a positive staging size via MCCL_CHANNEL_BUFFER_SIZE or pipesIbgdaDataBufferSize
E0724 18:33:38.929509 565766 CtranPipes.cc:239] rtptest548:565766:565766 [0][main] CTRAN ERROR send/recv requires a positive staging size via MCCL_CHANNEL_BUFFER_SIZE or pipesIbgdaDataBufferSize
E0724 18:33:38.929509 565766 CtranPipes.cc:239] rtptest548:565766:565766 [0][main] CTRAN ERROR send/recv requires a positive staging size via MCCL_CHANNEL_BUFFER_SIZE or pipesIbgdaDataBufferSize
E0724 18:33:38.929533 565766 McclComm.cpp:435] rtptest548:565766:565766 [0][main] MCCL ERROR fbcode/comms/mccl/McclComm.cpp:435 -> commInvalidArgument (invalid argument (run with NCCL_DEBUG=WARN for details))
E0724 18:33:38.929533 565766 McclComm.cpp:435] rtptest548:565766:565766 [0][main] MCCL ERROR fbcode/comms/mccl/McclComm.cpp:435 -> commInvalidArgument (invalid argument (run with NCCL_DEBUG=WARN for details))
E0724 18:33:38.929635 3021582 CtranPipes.cc:239] rtptest546:3021582:3021582 [1][main] CTRAN ERROR send/recv requires a positive staging size via MCCL_CHANNEL_BUFFER_SIZE or pipesIbgdaDataBufferSize
E0724 18:33:38.929635 3021582 CtranPipes.cc:239] rtptest546:3021582:3021582 [1][main] CTRAN ERROR send/recv requires a positive staging size via MCCL_CHANNEL_BUFFER_SIZE or pipesIbgdaDataBufferSize
E0724 18:33:38.929635 3021581 CtranPipes.cc:239] rtptest546:3021581:3021581 [0][main] CTRAN ERROR send/recv requires a positive staging size via MCCL_CHANNEL_BUFFER_
```

Differential Revision: D113625638


