### PR TITLE
Store Abort reason in pinned memory

### DIFF
--- a/comms/common/fault_tolerance/Abort.cc
+++ b/comms/common/fault_tolerance/Abort.cc
@@ -2,9 +2,188 @@
 
 #include "comms/common/fault_tolerance/Abort.h"
 
+#ifdef COMMS_FAULT_TOLERANCE_WITH_CUDA
+#include <cuda_runtime.h>
+#endif
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
 #include <memory>
+#include <stdexcept>
+#include <string>
 
 namespace comms::fault_tolerance {
+
+Abort::Abort(bool enabled) : enabled_(enabled) {
+  if (!enabled_) {
+    return;
+  }
+
+#ifdef COMMS_FAULT_TOLERANCE_WITH_CUDA
+  const auto status = cudaHostAlloc(
+      reinterpret_cast<void**>(&state_),
+      sizeof(AbortState),
+      cudaHostAllocMapped);
+  if (status != cudaSuccess) {
+    state_ = nullptr;
+    if (status == cudaErrorInsufficientDriver || status == cudaErrorNoDevice ||
+        status == cudaErrorInitializationError ||
+        status == cudaErrorMemoryAllocation) {
+      state_ = new AbortState;
+    } else {
+      throw std::runtime_error(
+          "cudaHostAlloc failed for Abort state: " +
+          std::string(cudaGetErrorString(status)));
+    }
+  } else {
+    stateMapped_ = true;
+  }
+#else
+  state_ = new AbortState;
+#endif
+  state_->abort = encode(AbortReason::NONE);
+  state_->timeoutMs = -1;
+}
+
+Abort::~Abort() {
+  if (state_ == nullptr) {
+    return;
+  }
+#ifdef COMMS_FAULT_TOLERANCE_WITH_CUDA
+  if (stateMapped_) {
+    (void)cudaFreeHost(state_);
+  } else {
+    delete state_;
+  }
+#else
+  delete state_;
+#endif
+}
+
+void Abort::setAbort(AbortReason reason) {
+  if (!enabled_) {
+    return;
+  }
+
+  markAbort(reason);
+}
+
+bool Abort::isAborted() {
+  if (!enabled_) {
+    return false;
+  }
+
+  if (loadAbortReason() != encode(AbortReason::NONE)) {
+    return true;
+  }
+
+  if (isTimedOut()) {
+    return true;
+  }
+
+  return loadAbortReason() != encode(AbortReason::NONE);
+}
+
+bool Abort::isTimeoutActive() const {
+  return enabled_ && hasTimeout_.load(std::memory_order_acquire);
+}
+
+bool Abort::isTimedOut() {
+  if (!enabled_) {
+    return false;
+  }
+
+  if (loadAbortReason() == encode(AbortReason::TIMED_OUT)) {
+    return true;
+  }
+
+  if (!hasTimeout_.load(std::memory_order_acquire)) {
+    return false;
+  }
+
+  auto now = std::chrono::steady_clock::now();
+  if (now >= deadline_.load(std::memory_order_acquire)) {
+    markAbort(AbortReason::TIMED_OUT);
+    return loadAbortReason() == encode(AbortReason::TIMED_OUT);
+  }
+
+  return false;
+}
+
+std::chrono::milliseconds Abort::getTimeRemaining() {
+  if (!enabled_) {
+    return std::chrono::milliseconds{-1};
+  }
+
+  if (!hasTimeout_.load(std::memory_order_acquire)) {
+    return std::chrono::milliseconds{-1};
+  }
+
+  auto now = std::chrono::steady_clock::now();
+  auto deadline = deadline_.load(std::memory_order_acquire);
+  if (now >= deadline) {
+    return std::chrono::milliseconds{0};
+  }
+
+  return std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now);
+}
+
+void Abort::startTimeout(std::chrono::milliseconds duration) {
+  if (!enabled_) {
+    return;
+  }
+
+  auto deadline = std::chrono::steady_clock::now() + duration;
+  deadline_.store(deadline, std::memory_order_release);
+  hasTimeout_.store(true, std::memory_order_release);
+}
+
+void Abort::cancelTimeout() {
+  if (!enabled_) {
+    return;
+  }
+
+  hasTimeout_.store(false, std::memory_order_release);
+}
+
+void Abort::setDefaultTimeout(std::chrono::milliseconds duration) {
+  if (!enabled_) {
+    return;
+  }
+
+  std::atomic_ref<int64_t>{state_->timeoutMs}.store(
+      duration.count(), std::memory_order_release);
+}
+
+std::optional<std::chrono::milliseconds> Abort::getDefaultTimeout() const {
+  if (!enabled_) {
+    return std::nullopt;
+  }
+
+  const auto v = std::atomic_ref<int64_t>{state_->timeoutMs}.load(
+      std::memory_order_acquire);
+  if (v < 0) {
+    return std::nullopt;
+  }
+  return std::chrono::milliseconds{v};
+}
+
+int Abort::loadAbortReason() const {
+  return std::atomic_ref<int>{state_->abort}.load(std::memory_order_acquire);
+}
+
+void Abort::markAbort(AbortReason reason) {
+  if (!isValidTerminalReason(reason)) {
+    throw std::invalid_argument("Abort reason must be ABORTED or TIMED_OUT");
+  }
+  int expected = encode(AbortReason::NONE);
+  std::atomic_ref<int>{state_->abort}.compare_exchange_strong(
+      expected,
+      encode(reason),
+      std::memory_order_acq_rel,
+      std::memory_order_acquire);
+}
 
 std::shared_ptr<Abort> createAbort(bool enabled) {
   if (enabled) {

--- a/comms/common/fault_tolerance/Abort.h
+++ b/comms/common/fault_tolerance/Abort.h
@@ -4,9 +4,10 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
-#include <stdexcept>
 
 namespace comms::fault_tolerance {
 
@@ -16,26 +17,40 @@ enum class AbortReason : int {
   TIMED_OUT = 2,
 };
 
+struct AbortState {
+  int abort;
+  int64_t timeoutMs;
+};
+
+// Atomic operations require naturally aligned fields. Cacheline padding is a
+// performance choice, not a correctness requirement for this shared state.
+static_assert(offsetof(AbortState, abort) % alignof(int) == 0);
+static_assert(offsetof(AbortState, timeoutMs) % alignof(int64_t) == 0);
+
 class Abort final {
  public:
-  static constexpr int encode(AbortReason reason) {
-    return static_cast<int>(reason);
-  }
-
   /**
    * Constructs an abort controller.
    *
-   * Enabled controllers honor abort and timeout operations. Disabled
-   * controllers are no-op placeholders for callers that must pass an abort
-   * object while fault tolerance is disabled.
+   * Enabled controllers use a single `AbortState`. CUDA-capable environments
+   * allocate it as host-mapped pinned memory so host and device code can
+   * observe the same abort reason. Host-only or non-mappable runtime
+   * environments fall back to ordinary host memory while preserving the same
+   * host-side state semantics. Disabled controllers are no-op placeholders for
+   * callers that must pass an `Abort` object while fault tolerance is disabled.
    */
-  explicit Abort(bool enabled) : enabled_(enabled) {}
-  ~Abort() = default;
+  explicit Abort(bool enabled);
+  ~Abort();
+  Abort(const Abort&) = delete;
+  Abort& operator=(const Abort&) = delete;
+  Abort(Abort&&) = delete;
+  Abort& operator=(Abort&&) = delete;
 
   /**
    * Returns whether this controller is enabled.
    *
-   * Disabled controllers never report an abort or active timeout.
+   * Disabled controllers never report an abort, active timeout, or default
+   * timeout duration.
    */
   inline bool isEnabled() const {
     return enabled_;
@@ -47,56 +62,28 @@ class Abort final {
    * The abort state starts as `AbortReason::NONE` and can transition exactly
    * once to one valid terminal reason. The first writer wins. Later calls with
    * a different reason do not override the reason already visible to other host
-   * threads. Valid terminal reasons are `AbortReason::ABORTED` and
-   * `AbortReason::TIMED_OUT`; `AbortReason::NONE` and unknown enum values are
-   * invalid input and are rejected before attempting to update shared state.
+   * threads and device consumers. Valid terminal reasons are
+   * `AbortReason::ABORTED` and `AbortReason::TIMED_OUT`; `AbortReason::NONE`
+   * and unknown enum values are invalid input and are rejected before
+   * attempting to update shared state.
    */
-  inline void setAbort(AbortReason reason = AbortReason::ABORTED) {
-    if (!enabled_) {
-      return;
-    }
-    if (!isValidTerminalReason(reason)) {
-      throw std::invalid_argument("Abort reason must be ABORTED or TIMED_OUT");
-    }
-    int expected = encode(AbortReason::NONE);
-    abort_.compare_exchange_strong(
-        expected,
-        encode(reason),
-        std::memory_order_acq_rel,
-        std::memory_order_acquire);
-  }
+  void setAbort(AbortReason reason = AbortReason::ABORTED);
 
   /**
    * Returns true when an explicit abort or expired active timeout has aborted
    * this controller.
    *
    * This also checks the active deadline and records `AbortReason::TIMED_OUT`
-   * if the timeout is the first abort reason.
+   * when the timeout is the first abort reason.
    */
-  inline bool isAborted() {
-    if (!enabled_) {
-      return false;
-    }
-
-    if (abort_.load(std::memory_order_acquire) != encode(AbortReason::NONE)) {
-      return true;
-    }
-
-    if (!hasTimeout_.load(std::memory_order_acquire)) {
-      return false;
-    }
-
-    return isTimedOut();
-  }
+  bool isAborted();
 
   /**
    * Returns whether a per-operation timeout deadline is currently active.
    *
    * This does not imply that the deadline has expired.
    */
-  inline bool isTimeoutActive() const {
-    return hasTimeout_.load(std::memory_order_acquire);
-  }
+  bool isTimeoutActive() const;
 
   /**
    * Returns true only when the recorded abort reason is timeout.
@@ -105,32 +92,7 @@ class Abort final {
    * `AbortReason::TIMED_OUT`. If an explicit abort already won the race, this
    * returns false.
    */
-  inline bool isTimedOut() {
-    if (abort_.load(std::memory_order_acquire) ==
-        encode(AbortReason::TIMED_OUT)) {
-      return true;
-    }
-
-    if (!hasTimeout_.load(std::memory_order_acquire)) {
-      return false;
-    }
-
-    // Check for timeout if timeout is set
-    auto now = std::chrono::steady_clock::now();
-    if (now >= deadline_.load(std::memory_order_acquire)) {
-      int expected = encode(AbortReason::NONE);
-      if (abort_.compare_exchange_strong(
-              expected,
-              encode(AbortReason::TIMED_OUT),
-              std::memory_order_acq_rel,
-              std::memory_order_acquire)) {
-        return true;
-      }
-      return expected == encode(AbortReason::TIMED_OUT);
-    }
-
-    return false;
-  }
+  bool isTimedOut();
 
   /**
    * Returns the time remaining before the active timeout deadline.
@@ -138,24 +100,7 @@ class Abort final {
    * Returns `-1ms` when no timeout is active and `0ms` after the active
    * deadline has expired.
    */
-  inline std::chrono::milliseconds getTimeRemaining() {
-    if (!enabled_) {
-      return std::chrono::milliseconds{-1};
-    }
-
-    if (!hasTimeout_.load(std::memory_order_acquire)) {
-      return std::chrono::milliseconds{-1};
-    }
-
-    auto now = std::chrono::steady_clock::now();
-    auto deadline = deadline_.load(std::memory_order_acquire);
-    if (now >= deadline) {
-      return std::chrono::milliseconds{0};
-    }
-
-    return std::chrono::duration_cast<std::chrono::milliseconds>(
-        deadline - now);
-  }
+  std::chrono::milliseconds getTimeRemaining();
 
   /**
    * Starts or replaces the active per-operation timeout deadline.
@@ -163,28 +108,14 @@ class Abort final {
    * The deadline is computed from the current steady-clock time plus
    * `duration`.
    */
-  inline void startTimeout(std::chrono::milliseconds duration) {
-    if (!enabled_) {
-      return;
-    }
-
-    auto deadline = std::chrono::steady_clock::now() + duration;
-    deadline_.store(deadline, std::memory_order_release);
-    hasTimeout_.store(true, std::memory_order_release);
-  }
+  void startTimeout(std::chrono::milliseconds duration);
 
   /**
    * Cancels the active per-operation timeout deadline.
    *
    * This does not clear an abort reason that has already been recorded.
    */
-  inline void cancelTimeout() {
-    if (!enabled_) {
-      return;
-    }
-
-    hasTimeout_.store(false, std::memory_order_release);
-  }
+  void cancelTimeout();
 
   /**
    * Stores the default timeout duration.
@@ -192,13 +123,7 @@ class Abort final {
    * GPE applies this as a per-iteration deadline when no per-operation timeout
    * is supplied. This is only a stored duration; it does not start a deadline.
    */
-  inline void setDefaultTimeout(std::chrono::milliseconds duration) {
-    if (!enabled_) {
-      return;
-    }
-
-    timeoutMs_.store(duration.count(), std::memory_order_release);
-  }
+  void setDefaultTimeout(std::chrono::milliseconds duration);
 
   /**
    * Returns the default timeout duration when one has been configured.
@@ -206,19 +131,13 @@ class Abort final {
    * Returns `std::nullopt` for disabled controllers or before a default
    * timeout has been set.
    */
-  inline std::optional<std::chrono::milliseconds> getDefaultTimeout() const {
-    if (!enabled_) {
-      return std::nullopt;
-    }
-
-    auto v = timeoutMs_.load(std::memory_order_acquire);
-    if (v < 0) {
-      return std::nullopt;
-    }
-    return std::chrono::milliseconds{v};
-  }
+  std::optional<std::chrono::milliseconds> getDefaultTimeout() const;
 
  private:
+  static constexpr int encode(AbortReason reason) {
+    return static_cast<int>(reason);
+  }
+
   static constexpr bool isValidTerminalReason(AbortReason reason) {
     switch (reason) {
       case AbortReason::ABORTED:
@@ -230,20 +149,20 @@ class Abort final {
     return false;
   }
 
+  int loadAbortReason() const;
+  void markAbort(AbortReason reason);
+
   const bool enabled_;
 
-  std::atomic<int> abort_{encode(AbortReason::NONE)};
+  AbortState* state_{nullptr};
+  bool stateMapped_{false};
   std::atomic<bool> hasTimeout_{false};
   std::atomic<std::chrono::steady_clock::time_point> deadline_{
       std::chrono::steady_clock::time_point{}};
-  // -1 = unset.
-  std::atomic<int64_t> timeoutMs_{-1};
 
   static_assert(std::atomic<bool>::is_always_lock_free);
-  static_assert(std::atomic<int>::is_always_lock_free);
   static_assert(
       std::atomic<std::chrono::steady_clock::time_point>::is_always_lock_free);
-  static_assert(std::atomic<int64_t>::is_always_lock_free);
 };
 
 /**

--- a/comms/common/fault_tolerance/CMakeLists.txt
+++ b/comms/common/fault_tolerance/CMakeLists.txt
@@ -4,6 +4,11 @@ add_library(fault_tolerance OBJECT
     Abort.cc
 )
 
+option(COMMS_FAULT_TOLERANCE_ENABLE_CUDA "Enable CUDA-mapped Abort state" ON)
+if (COMMS_FAULT_TOLERANCE_ENABLE_CUDA)
+    find_package(CUDAToolkit)
+endif()
+
 target_compile_features(fault_tolerance PRIVATE cxx_std_20)
 target_compile_options(fault_tolerance PRIVATE -fPIC)
 set_target_properties(fault_tolerance PROPERTIES
@@ -13,3 +18,9 @@ target_include_directories(fault_tolerance PRIVATE
     ${ROOT}
     ${CONDA_INCLUDE}
 )
+if (COMMS_FAULT_TOLERANCE_ENABLE_CUDA AND CUDAToolkit_FOUND)
+    target_compile_definitions(fault_tolerance PRIVATE
+        COMMS_FAULT_TOLERANCE_WITH_CUDA=1
+    )
+    target_link_libraries(fault_tolerance PRIVATE CUDA::cudart)
+endif()

--- a/comms/common/fault_tolerance/tests/AbortUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortUT.cc
@@ -16,6 +16,31 @@ namespace comms::fault_tolerance::testing {
 using ::comms::fault_tolerance::Abort;
 using ::comms::fault_tolerance::AbortReason;
 
+namespace {
+
+template <typename Predicate>
+bool eventually(
+    Predicate&& predicate,
+    std::chrono::milliseconds timeout = std::chrono::seconds{1}) {
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (!predicate()) {
+    if (std::chrono::steady_clock::now() >= deadline) {
+      return false;
+    }
+    std::this_thread::yield();
+  }
+  return true;
+}
+
+void waitFor(std::chrono::milliseconds duration) {
+  const auto deadline = std::chrono::steady_clock::now() + duration;
+  while (std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::yield();
+  }
+}
+
+} // namespace
+
 TEST(AbortTest, enabledDefaultNotAbort) {
   Abort abort{/*enabled=*/true};
   EXPECT_FALSE(abort.isAborted());
@@ -68,8 +93,7 @@ TEST(AbortTest, MultipleAbortTest) {
           << "producer: test case did not start";
     }
 
-    // delay a bit to allow consumer start working first
-    std::this_thread::sleep_for(std::chrono::microseconds(20));
+    std::this_thread::yield();
 
     ASSERT_FALSE(abort.isAborted());
     abort.setAbort();
@@ -131,18 +155,14 @@ TEST(AbortTest, timeoutExpired) {
 
   abort.startTimeout(std::chrono::milliseconds(1));
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
   // Test should return true as timeout has expired
-  EXPECT_TRUE(abort.isAborted());
+  EXPECT_TRUE(eventually([&]() { return abort.isAborted(); }));
 }
 
 TEST(AbortTest, timeoutDisabledNoop) {
   Abort abort{/*enabled=*/false};
 
   abort.startTimeout(std::chrono::milliseconds(1));
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
   // Test should return false as abort is disabled:w
   EXPECT_FALSE(abort.isAborted());
@@ -165,8 +185,6 @@ TEST(AbortTest, timeoutAndExplicitSetBothTrue) {
   abort.startTimeout(std::chrono::milliseconds(1));
   abort.setAbort();
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
   // Test should return true (both conditions are true)
   EXPECT_TRUE(abort.isAborted());
 }
@@ -175,7 +193,9 @@ TEST(AbortTest, explicitAbortWinsOverExpiredTimeout) {
   Abort abort{/*enabled=*/true};
 
   abort.startTimeout(std::chrono::milliseconds(1));
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  EXPECT_TRUE(eventually([&]() {
+    return abort.getTimeRemaining() == std::chrono::milliseconds{0};
+  }));
   abort.setAbort();
 
   EXPECT_TRUE(abort.isAborted());
@@ -186,9 +206,8 @@ TEST(AbortTest, timeoutWinsBeforeExplicitAbort) {
   Abort abort{/*enabled=*/true};
 
   abort.startTimeout(std::chrono::milliseconds(1));
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
-  EXPECT_TRUE(abort.isTimedOut());
+  EXPECT_TRUE(eventually([&]() { return abort.isTimedOut(); }));
 
   abort.setAbort();
 
@@ -205,10 +224,8 @@ TEST(AbortTest, multipleTimeoutCalls) {
 
   abort.startTimeout(std::chrono::milliseconds(1));
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
   // Test should return true as the shorter timeout has expired
-  EXPECT_TRUE(abort.isAborted());
+  EXPECT_TRUE(eventually([&]() { return abort.isAborted(); }));
 }
 
 TEST(AbortTest, timeoutThreadSafety) {
@@ -227,7 +244,7 @@ TEST(AbortTest, timeoutThreadSafety) {
   // Thread 2: Continuously tests for abort
   std::thread tester([&]() {
     while (!timeoutSet.load()) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      std::this_thread::yield();
     }
 
     auto start = std::chrono::steady_clock::now();
@@ -238,7 +255,7 @@ TEST(AbortTest, timeoutThreadSafety) {
         timeoutDetected.store(true);
         break;
       }
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      std::this_thread::yield();
     }
   });
 
@@ -256,7 +273,7 @@ TEST(AbortTest, cancelTimeoutBeforeExpiry) {
   abort.startTimeout(std::chrono::milliseconds(100));
   abort.cancelTimeout();
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+  waitFor(std::chrono::milliseconds(150));
 
   // Test should return false as timeout was cancelled
   EXPECT_FALSE(abort.isAborted());
@@ -267,10 +284,8 @@ TEST(AbortTest, cancelTimeoutAfterExpiry) {
 
   abort.startTimeout(std::chrono::milliseconds(1));
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
   // Verify timeout has expired
-  EXPECT_TRUE(abort.isAborted());
+  EXPECT_TRUE(eventually([&]() { return abort.isAborted(); }));
 
   abort.cancelTimeout();
 
@@ -283,8 +298,6 @@ TEST(AbortTest, cancelTimeoutDisabledNoop) {
 
   abort.startTimeout(std::chrono::milliseconds(1));
   abort.cancelTimeout();
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
   // Test should return false as abort is disabled
   EXPECT_FALSE(abort.isAborted());
@@ -315,10 +328,8 @@ TEST(AbortTest, setTimeoutAfterCancel) {
 
   abort.startTimeout(std::chrono::milliseconds(1));
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
   // Test should return true as new timeout has expired
-  EXPECT_TRUE(abort.isAborted());
+  EXPECT_TRUE(eventually([&]() { return abort.isAborted(); }));
 }
 
 TEST(AbortTest, multipleCancelTimeoutCalls) {
@@ -329,7 +340,7 @@ TEST(AbortTest, multipleCancelTimeoutCalls) {
   abort.cancelTimeout();
   abort.cancelTimeout();
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+  waitFor(std::chrono::milliseconds(150));
 
   // Test should return false as timeout was cancelled
   EXPECT_FALSE(abort.isAborted());
@@ -352,11 +363,11 @@ TEST(AbortTest, cancelTimeoutThreadSafety) {
   // Thread 2: Cancels timeout after a brief delay
   std::thread timeoutCanceller([&]() {
     while (!timeoutSet.load()) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      std::this_thread::yield();
     }
 
     // Wait a bit then cancel
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waitFor(std::chrono::milliseconds(10));
     abort.cancelTimeout();
     timeoutCancelled.store(true);
   });
@@ -364,7 +375,7 @@ TEST(AbortTest, cancelTimeoutThreadSafety) {
   // Thread 3: Continuously tests for abort
   std::thread tester([&]() {
     while (!timeoutSet.load()) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      std::this_thread::yield();
     }
 
     // Test for timeout for a reasonable duration
@@ -377,7 +388,7 @@ TEST(AbortTest, cancelTimeoutThreadSafety) {
         timeoutDetected.store(true);
         break;
       }
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      std::this_thread::yield();
     }
   });
 
@@ -433,8 +444,7 @@ TEST(AbortTest, timedOutTrueAfterExpiry) {
   Abort abort{/*enabled=*/true};
   abort.startTimeout(std::chrono::milliseconds(1));
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  EXPECT_TRUE(abort.isTimedOut());
+  EXPECT_TRUE(eventually([&]() { return abort.isTimedOut(); }));
 }
 
 TEST(AbortTest, timedOutFalseForExplicitSet) {
@@ -508,7 +518,8 @@ TEST(AbortTest, timeRemainingDecreases) {
   abort.startTimeout(std::chrono::milliseconds(100));
 
   auto remaining1 = abort.getTimeRemaining();
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  EXPECT_TRUE(
+      eventually([&]() { return abort.getTimeRemaining() < remaining1; }));
   auto remaining2 = abort.getTimeRemaining();
 
   EXPECT_LT(remaining2, remaining1);
@@ -518,9 +529,9 @@ TEST(AbortTest, timeRemainingZeroAfterExpiry) {
   Abort abort{/*enabled=*/true};
   abort.startTimeout(std::chrono::milliseconds(1));
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
-  EXPECT_EQ(abort.getTimeRemaining(), std::chrono::milliseconds{0});
+  EXPECT_TRUE(eventually([&]() {
+    return abort.getTimeRemaining() == std::chrono::milliseconds{0};
+  }));
 }
 
 TEST(AbortTest, timeRemainingAfterCancel) {

--- a/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
@@ -595,12 +595,13 @@ class CtranIbAbortCtrlMsgTest
   }
 
   void TearDown() override {
-    CtranIbBootstrapTestBase::TearDown();
-
     acceptSocketBaton_.post();
+    ctranIb_.reset();
     mockServerSockets_.clear();
     mockSockets_.clear();
-    ctranIb_.reset();
+    abortCtrl_.reset();
+
+    CtranIbBootstrapTestBase::TearDown();
   }
 
   std::unique_ptr<StrictMock<ctran::bootstrap::testing::MockIServerSocket>>


### PR DESCRIPTION
Summary:
Move the unified `Abort` reason and default timeout duration storage into host-owned state that is allocated as CUDA-mapped pinned memory when the runtime can provide a mapped allocation.

Host code observes and updates shared fields through `std::atomic_ref`; device-side use in the child diff observes the same state through `cuda::atomic_ref`. `hasTimeout_` and `deadline_` remain host-only because active deadline tracking is CPU-owned.

Host-only or non-mappable CUDA runtime environments fall back to ordinary host memory for host API compatibility. Device handles still require mapped pinned state and fail explicitly when that state is unavailable. `AbortState` only requires natural field alignment for atomic refs; 128-byte cacheline padding is not a correctness requirement.

This update also fixes the CTRAN IB abort-control-message unit test teardown: the fixture now stops `CtranIb` and joins its listen thread before the base fixture calls `cudaDeviceReset()`, so the thread cannot touch mapped pinned abort state after CUDA reset.

Reviewed By: arttianezhu

Differential Revision: D113372517


