### PR TITLE
Add DeviceAbort handle for Abort (#3291)

### DIFF
--- a/comms/common/fault_tolerance/Abort.cc
+++ b/comms/common/fault_tolerance/Abort.cc
@@ -2,9 +2,188 @@
 
 #include "comms/common/fault_tolerance/Abort.h"
 
+#ifdef COMMS_FAULT_TOLERANCE_WITH_CUDA
+#include <cuda_runtime.h>
+#endif
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
 #include <memory>
+#include <stdexcept>
+#include <string>
 
 namespace comms::fault_tolerance {
+
+Abort::Abort(bool enabled) : enabled_(enabled) {
+  if (!enabled_) {
+    return;
+  }
+
+#ifdef COMMS_FAULT_TOLERANCE_WITH_CUDA
+  const auto status = cudaHostAlloc(
+      reinterpret_cast<void**>(&state_),
+      sizeof(AbortState),
+      cudaHostAllocMapped);
+  if (status != cudaSuccess) {
+    state_ = nullptr;
+    if (status == cudaErrorInsufficientDriver || status == cudaErrorNoDevice ||
+        status == cudaErrorInitializationError ||
+        status == cudaErrorMemoryAllocation) {
+      state_ = new AbortState;
+    } else {
+      throw std::runtime_error(
+          "cudaHostAlloc failed for Abort state: " +
+          std::string(cudaGetErrorString(status)));
+    }
+  } else {
+    stateMapped_ = true;
+  }
+#else
+  state_ = new AbortState;
+#endif
+  state_->abort = encode(AbortReason::NONE);
+  state_->timeoutMs = -1;
+}
+
+Abort::~Abort() {
+  if (state_ == nullptr) {
+    return;
+  }
+#ifdef COMMS_FAULT_TOLERANCE_WITH_CUDA
+  if (stateMapped_) {
+    (void)cudaFreeHost(state_);
+  } else {
+    delete state_;
+  }
+#else
+  delete state_;
+#endif
+}
+
+void Abort::setAbort(AbortReason reason) {
+  if (!enabled_) {
+    return;
+  }
+
+  markAbort(reason);
+}
+
+bool Abort::isAborted() {
+  if (!enabled_) {
+    return false;
+  }
+
+  if (loadAbortReason() != encode(AbortReason::NONE)) {
+    return true;
+  }
+
+  if (isTimedOut()) {
+    return true;
+  }
+
+  return loadAbortReason() != encode(AbortReason::NONE);
+}
+
+bool Abort::isTimeoutActive() const {
+  return enabled_ && hasTimeout_.load(std::memory_order_acquire);
+}
+
+bool Abort::isTimedOut() {
+  if (!enabled_) {
+    return false;
+  }
+
+  if (loadAbortReason() == encode(AbortReason::TIMED_OUT)) {
+    return true;
+  }
+
+  if (!hasTimeout_.load(std::memory_order_acquire)) {
+    return false;
+  }
+
+  auto now = std::chrono::steady_clock::now();
+  if (now >= deadline_.load(std::memory_order_acquire)) {
+    markAbort(AbortReason::TIMED_OUT);
+    return loadAbortReason() == encode(AbortReason::TIMED_OUT);
+  }
+
+  return false;
+}
+
+std::chrono::milliseconds Abort::getTimeRemaining() {
+  if (!enabled_) {
+    return std::chrono::milliseconds{-1};
+  }
+
+  if (!hasTimeout_.load(std::memory_order_acquire)) {
+    return std::chrono::milliseconds{-1};
+  }
+
+  auto now = std::chrono::steady_clock::now();
+  auto deadline = deadline_.load(std::memory_order_acquire);
+  if (now >= deadline) {
+    return std::chrono::milliseconds{0};
+  }
+
+  return std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now);
+}
+
+void Abort::startTimeout(std::chrono::milliseconds duration) {
+  if (!enabled_) {
+    return;
+  }
+
+  auto deadline = std::chrono::steady_clock::now() + duration;
+  deadline_.store(deadline, std::memory_order_release);
+  hasTimeout_.store(true, std::memory_order_release);
+}
+
+void Abort::cancelTimeout() {
+  if (!enabled_) {
+    return;
+  }
+
+  hasTimeout_.store(false, std::memory_order_release);
+}
+
+void Abort::setDefaultTimeout(std::chrono::milliseconds duration) {
+  if (!enabled_) {
+    return;
+  }
+
+  std::atomic_ref<int64_t>{state_->timeoutMs}.store(
+      duration.count(), std::memory_order_release);
+}
+
+std::optional<std::chrono::milliseconds> Abort::getDefaultTimeout() const {
+  if (!enabled_) {
+    return std::nullopt;
+  }
+
+  const auto v = std::atomic_ref<int64_t>{state_->timeoutMs}.load(
+      std::memory_order_acquire);
+  if (v < 0) {
+    return std::nullopt;
+  }
+  return std::chrono::milliseconds{v};
+}
+
+int Abort::loadAbortReason() const {
+  return std::atomic_ref<int>{state_->abort}.load(std::memory_order_acquire);
+}
+
+void Abort::markAbort(AbortReason reason) {
+  if (!isValidTerminalReason(reason)) {
+    throw std::invalid_argument("Abort reason must be ABORTED or TIMED_OUT");
+  }
+  int expected = encode(AbortReason::NONE);
+  std::atomic_ref<int>{state_->abort}.compare_exchange_strong(
+      expected,
+      encode(reason),
+      std::memory_order_acq_rel,
+      std::memory_order_acquire);
+}
 
 std::shared_ptr<Abort> createAbort(bool enabled) {
   if (enabled) {

--- a/comms/common/fault_tolerance/Abort.cc
+++ b/comms/common/fault_tolerance/Abort.cc
@@ -61,12 +61,12 @@ Abort::~Abort() {
 #endif
 }
 
-void Abort::setAbort(AbortReason reason) {
+void Abort::setAbort(AbortReason newReason) {
   if (!enabled_) {
     return;
   }
 
-  markAbort(reason);
+  markAbort(newReason);
 }
 
 bool Abort::isAborted() {
@@ -173,14 +173,14 @@ int Abort::loadAbortReason() const {
   return std::atomic_ref<int>{state_->abort}.load(std::memory_order_acquire);
 }
 
-void Abort::markAbort(AbortReason reason) {
-  if (!isValidTerminalReason(reason)) {
+void Abort::markAbort(AbortReason newReason) {
+  if (!isValidTerminalReason(newReason)) {
     throw std::invalid_argument("Abort reason must be ABORTED or TIMED_OUT");
   }
   int expected = encode(AbortReason::NONE);
   std::atomic_ref<int>{state_->abort}.compare_exchange_strong(
       expected,
-      encode(reason),
+      encode(newReason),
       std::memory_order_acq_rel,
       std::memory_order_acquire);
 }

--- a/comms/common/fault_tolerance/Abort.h
+++ b/comms/common/fault_tolerance/Abort.h
@@ -4,9 +4,10 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
-#include <stdexcept>
 
 namespace comms::fault_tolerance {
 
@@ -16,26 +17,40 @@ enum class AbortReason : int {
   TIMED_OUT = 2,
 };
 
+struct AbortState {
+  int abort;
+  int64_t timeoutMs;
+};
+
+// Atomic operations require naturally aligned fields. Cacheline padding is a
+// performance choice, not a correctness requirement for this shared state.
+static_assert(offsetof(AbortState, abort) % alignof(int) == 0);
+static_assert(offsetof(AbortState, timeoutMs) % alignof(int64_t) == 0);
+
 class Abort final {
  public:
-  static constexpr int encode(AbortReason reason) {
-    return static_cast<int>(reason);
-  }
-
   /**
    * Constructs an abort controller.
    *
-   * Enabled controllers honor abort and timeout operations. Disabled
-   * controllers are no-op placeholders for callers that must pass an abort
-   * object while fault tolerance is disabled.
+   * Enabled controllers use a single `AbortState`. CUDA-capable environments
+   * allocate it as host-mapped pinned memory so host and device code can
+   * observe the same abort reason. Host-only or non-mappable runtime
+   * environments fall back to ordinary host memory while preserving the same
+   * host-side state semantics. Disabled controllers are no-op placeholders for
+   * callers that must pass an `Abort` object while fault tolerance is disabled.
    */
-  explicit Abort(bool enabled) : enabled_(enabled) {}
-  ~Abort() = default;
+  explicit Abort(bool enabled);
+  ~Abort();
+  Abort(const Abort&) = delete;
+  Abort& operator=(const Abort&) = delete;
+  Abort(Abort&&) = delete;
+  Abort& operator=(Abort&&) = delete;
 
   /**
    * Returns whether this controller is enabled.
    *
-   * Disabled controllers never report an abort or active timeout.
+   * Disabled controllers never report an abort, active timeout, or default
+   * timeout duration.
    */
   inline bool isEnabled() const {
     return enabled_;
@@ -47,56 +62,28 @@ class Abort final {
    * The abort state starts as `AbortReason::NONE` and can transition exactly
    * once to one valid terminal reason. The first writer wins. Later calls with
    * a different reason do not override the reason already visible to other host
-   * threads. Valid terminal reasons are `AbortReason::ABORTED` and
-   * `AbortReason::TIMED_OUT`; `AbortReason::NONE` and unknown enum values are
-   * invalid input and are rejected before attempting to update shared state.
+   * threads and device consumers. Valid terminal reasons are
+   * `AbortReason::ABORTED` and `AbortReason::TIMED_OUT`; `AbortReason::NONE`
+   * and unknown enum values are invalid input and are rejected before
+   * attempting to update shared state.
    */
-  inline void setAbort(AbortReason reason = AbortReason::ABORTED) {
-    if (!enabled_) {
-      return;
-    }
-    if (!isValidTerminalReason(reason)) {
-      throw std::invalid_argument("Abort reason must be ABORTED or TIMED_OUT");
-    }
-    int expected = encode(AbortReason::NONE);
-    abort_.compare_exchange_strong(
-        expected,
-        encode(reason),
-        std::memory_order_acq_rel,
-        std::memory_order_acquire);
-  }
+  void setAbort(AbortReason reason = AbortReason::ABORTED);
 
   /**
    * Returns true when an explicit abort or expired active timeout has aborted
    * this controller.
    *
    * This also checks the active deadline and records `AbortReason::TIMED_OUT`
-   * if the timeout is the first abort reason.
+   * when the timeout is the first abort reason.
    */
-  inline bool isAborted() {
-    if (!enabled_) {
-      return false;
-    }
-
-    if (abort_.load(std::memory_order_acquire) != encode(AbortReason::NONE)) {
-      return true;
-    }
-
-    if (!hasTimeout_.load(std::memory_order_acquire)) {
-      return false;
-    }
-
-    return isTimedOut();
-  }
+  bool isAborted();
 
   /**
    * Returns whether a per-operation timeout deadline is currently active.
    *
    * This does not imply that the deadline has expired.
    */
-  inline bool isTimeoutActive() const {
-    return hasTimeout_.load(std::memory_order_acquire);
-  }
+  bool isTimeoutActive() const;
 
   /**
    * Returns true only when the recorded abort reason is timeout.
@@ -105,32 +92,7 @@ class Abort final {
    * `AbortReason::TIMED_OUT`. If an explicit abort already won the race, this
    * returns false.
    */
-  inline bool isTimedOut() {
-    if (abort_.load(std::memory_order_acquire) ==
-        encode(AbortReason::TIMED_OUT)) {
-      return true;
-    }
-
-    if (!hasTimeout_.load(std::memory_order_acquire)) {
-      return false;
-    }
-
-    // Check for timeout if timeout is set
-    auto now = std::chrono::steady_clock::now();
-    if (now >= deadline_.load(std::memory_order_acquire)) {
-      int expected = encode(AbortReason::NONE);
-      if (abort_.compare_exchange_strong(
-              expected,
-              encode(AbortReason::TIMED_OUT),
-              std::memory_order_acq_rel,
-              std::memory_order_acquire)) {
-        return true;
-      }
-      return expected == encode(AbortReason::TIMED_OUT);
-    }
-
-    return false;
-  }
+  bool isTimedOut();
 
   /**
    * Returns the time remaining before the active timeout deadline.
@@ -138,24 +100,7 @@ class Abort final {
    * Returns `-1ms` when no timeout is active and `0ms` after the active
    * deadline has expired.
    */
-  inline std::chrono::milliseconds getTimeRemaining() {
-    if (!enabled_) {
-      return std::chrono::milliseconds{-1};
-    }
-
-    if (!hasTimeout_.load(std::memory_order_acquire)) {
-      return std::chrono::milliseconds{-1};
-    }
-
-    auto now = std::chrono::steady_clock::now();
-    auto deadline = deadline_.load(std::memory_order_acquire);
-    if (now >= deadline) {
-      return std::chrono::milliseconds{0};
-    }
-
-    return std::chrono::duration_cast<std::chrono::milliseconds>(
-        deadline - now);
-  }
+  std::chrono::milliseconds getTimeRemaining();
 
   /**
    * Starts or replaces the active per-operation timeout deadline.
@@ -163,28 +108,14 @@ class Abort final {
    * The deadline is computed from the current steady-clock time plus
    * `duration`.
    */
-  inline void startTimeout(std::chrono::milliseconds duration) {
-    if (!enabled_) {
-      return;
-    }
-
-    auto deadline = std::chrono::steady_clock::now() + duration;
-    deadline_.store(deadline, std::memory_order_release);
-    hasTimeout_.store(true, std::memory_order_release);
-  }
+  void startTimeout(std::chrono::milliseconds duration);
 
   /**
    * Cancels the active per-operation timeout deadline.
    *
    * This does not clear an abort reason that has already been recorded.
    */
-  inline void cancelTimeout() {
-    if (!enabled_) {
-      return;
-    }
-
-    hasTimeout_.store(false, std::memory_order_release);
-  }
+  void cancelTimeout();
 
   /**
    * Stores the default timeout duration.
@@ -192,13 +123,7 @@ class Abort final {
    * GPE applies this as a per-iteration deadline when no per-operation timeout
    * is supplied. This is only a stored duration; it does not start a deadline.
    */
-  inline void setDefaultTimeout(std::chrono::milliseconds duration) {
-    if (!enabled_) {
-      return;
-    }
-
-    timeoutMs_.store(duration.count(), std::memory_order_release);
-  }
+  void setDefaultTimeout(std::chrono::milliseconds duration);
 
   /**
    * Returns the default timeout duration when one has been configured.
@@ -206,19 +131,13 @@ class Abort final {
    * Returns `std::nullopt` for disabled controllers or before a default
    * timeout has been set.
    */
-  inline std::optional<std::chrono::milliseconds> getDefaultTimeout() const {
-    if (!enabled_) {
-      return std::nullopt;
-    }
-
-    auto v = timeoutMs_.load(std::memory_order_acquire);
-    if (v < 0) {
-      return std::nullopt;
-    }
-    return std::chrono::milliseconds{v};
-  }
+  std::optional<std::chrono::milliseconds> getDefaultTimeout() const;
 
  private:
+  static constexpr int encode(AbortReason reason) {
+    return static_cast<int>(reason);
+  }
+
   static constexpr bool isValidTerminalReason(AbortReason reason) {
     switch (reason) {
       case AbortReason::ABORTED:
@@ -230,20 +149,20 @@ class Abort final {
     return false;
   }
 
+  int loadAbortReason() const;
+  void markAbort(AbortReason reason);
+
   const bool enabled_;
 
-  std::atomic<int> abort_{encode(AbortReason::NONE)};
+  AbortState* state_{nullptr};
+  bool stateMapped_{false};
   std::atomic<bool> hasTimeout_{false};
   std::atomic<std::chrono::steady_clock::time_point> deadline_{
       std::chrono::steady_clock::time_point{}};
-  // -1 = unset.
-  std::atomic<int64_t> timeoutMs_{-1};
 
   static_assert(std::atomic<bool>::is_always_lock_free);
-  static_assert(std::atomic<int>::is_always_lock_free);
   static_assert(
       std::atomic<std::chrono::steady_clock::time_point>::is_always_lock_free);
-  static_assert(std::atomic<int64_t>::is_always_lock_free);
 };
 
 /**

--- a/comms/common/fault_tolerance/Abort.h
+++ b/comms/common/fault_tolerance/Abort.h
@@ -17,8 +17,29 @@ enum class AbortReason : int {
   TIMED_OUT = 2,
 };
 
+/**
+ * Host-owned state shared with CUDA device code through mapped pinned memory.
+ *
+ * Both fields are read and written with system-scope atomic operations. The
+ * allocation is owned by `Abort`; `AbortDevice` stores only a non-owning mapped
+ * pointer to this same state.
+ */
 struct AbortState {
+  /**
+   * Encoded `AbortReason`.
+   *
+   * Starts as `AbortReason::NONE` and may transition once to a valid terminal
+   * reason. Host and device writers use compare-exchange from `NONE`, so the
+   * first valid terminal reason wins.
+   */
   int abort;
+
+  /**
+   * Shared default timeout duration in milliseconds.
+   *
+   * `-1` means unset. Host code may update this value, and device handles read
+   * the latest value when starting a device-side timeout.
+   */
   int64_t timeoutMs;
 };
 
@@ -27,6 +48,33 @@ struct AbortState {
 static_assert(offsetof(AbortState, abort) % alignof(int) == 0);
 static_assert(offsetof(AbortState, timeoutMs) % alignof(int64_t) == 0);
 
+struct AbortDevice;
+
+/**
+ * Shared abort state for communicator-scoped fault tolerance.
+ *
+ * `Abort` owns a single host-allocated, CUDA-mapped pinned state object that is
+ * visible to both CPU threads and CUDA device code. The host object owns that
+ * storage for its full lifetime; device handles returned by `getDeviceHandle()`
+ * are non-owning views and must not outlive the `Abort` object.
+ *
+ * Enabled `Abort` instances use shared state when CUDA pinned allocation and
+ * device mapping are available. Host-only environments fall back to ordinary
+ * host memory for the same `AbortState` fields so CPU callers can keep using
+ * the same API. Disabled instances do not allocate state and every
+ * mutating/query operation is a no-op or a non-aborted result. The disabled
+ * singleton returned by `createAbort(false)` is intended for code paths that
+ * must accept an abort object without enabling fault tolerance.
+ *
+ * `AbortState::abort` and `AbortState::timeoutMs` are mutable shared fields.
+ * Host code and device code access them with system-scope atomic operations so
+ * updates from either side become visible to the other side. The abort reason
+ * is first-writer-wins: an explicit abort records `AbortReason::ABORTED`; an
+ * expired timeout records `AbortReason::TIMED_OUT` only if no earlier valid
+ * terminal reason has been recorded. The default timeout duration is also
+ * stored in shared state for graph-mode device code; host active-deadline
+ * tracking remains host-only.
+ */
 class Abort final {
  public:
   /**
@@ -67,7 +115,7 @@ class Abort final {
    * and unknown enum values are invalid input and are rejected before
    * attempting to update shared state.
    */
-  void setAbort(AbortReason reason = AbortReason::ABORTED);
+  void setAbort(AbortReason newReason = AbortReason::ABORTED);
 
   /**
    * Returns true when an explicit abort or expired active timeout has aborted
@@ -133,6 +181,20 @@ class Abort final {
    */
   std::optional<std::chrono::milliseconds> getDefaultTimeout() const;
 
+  /**
+   * Returns a non-owning device view over the shared abort state.
+   *
+   * The returned handle is valid only while this `Abort` instance remains
+   * alive. Disabled abort objects return a disabled no-op device handle.
+   * Enabled abort objects must be backed by CUDA-mapped pinned state; this
+   * throws `std::runtime_error` when the shared state is host-only or when CUDA
+   * cannot map the host state for the current device. The handle captures the
+   * current device mapping and clock rate, so kernels must consume it on the
+   * same CUDA device that was current when the handle was created. Create a new
+   * handle after switching devices.
+   */
+  AbortDevice getDeviceHandle() const;
+
  private:
   static constexpr int encode(AbortReason reason) {
     return static_cast<int>(reason);
@@ -150,7 +212,7 @@ class Abort final {
   }
 
   int loadAbortReason() const;
-  void markAbort(AbortReason reason);
+  void markAbort(AbortReason newReason);
 
   const bool enabled_;
 

--- a/comms/common/fault_tolerance/AbortDevice.cuh
+++ b/comms/common/fault_tolerance/AbortDevice.cuh
@@ -1,0 +1,330 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#ifndef __HIP_PLATFORM_AMD__
+#include <cuda/atomic>
+#endif
+
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include "comms/common/fault_tolerance/Abort.h"
+
+namespace comms::fault_tolerance {
+
+namespace detail {
+
+inline int hostCurrentDevice() {
+  int device = 0;
+  auto status = cudaGetDevice(&device);
+  if (status != cudaSuccess) {
+    throw std::runtime_error(
+        "cudaGetDevice failed for Abort::getDeviceHandle(): " +
+        std::string(cudaGetErrorString(status)));
+  }
+  return device;
+}
+
+__device__ __forceinline__ uint64_t deviceClock() {
+#if defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+  return wall_clock64();
+#elif defined(__CUDA_ARCH__)
+  return clock64();
+#else
+  return 0;
+#endif
+}
+
+inline uint64_t hostDeviceCyclesPerMs(int device) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)device;
+  // TODO: Revisit this when AMD device-side abort timeout support is added.
+  return 100000;
+#else
+  constexpr int kMaxCachedDevices = 64;
+  thread_local std::array<uint64_t, kMaxCachedDevices> cachedCyclesPerMs{};
+  const bool cacheableDevice = device >= 0 && device < kMaxCachedDevices;
+  if (cacheableDevice && cachedCyclesPerMs[device] != 0) {
+    return cachedCyclesPerMs[device];
+  }
+
+  int clockRateKHz = 0;
+  auto status =
+      cudaDeviceGetAttribute(&clockRateKHz, cudaDevAttrClockRate, device);
+  if (status != cudaSuccess) {
+    throw std::runtime_error(
+        "cudaDeviceGetAttribute(cudaDevAttrClockRate) failed for Abort::getDeviceHandle(): " +
+        std::string(cudaGetErrorString(status)));
+  }
+  const auto cyclesPerMs = static_cast<uint64_t>(clockRateKHz);
+  if (cacheableDevice) {
+    cachedCyclesPerMs[device] = cyclesPerMs;
+  }
+  return cyclesPerMs;
+#endif
+}
+
+__device__ __forceinline__ bool deviceIsValidTerminalReason(
+    AbortReason reason) {
+  switch (reason) {
+    case AbortReason::ABORTED:
+    case AbortReason::TIMED_OUT:
+      return true;
+    case AbortReason::NONE:
+      return false;
+  }
+  return false;
+}
+
+template <typename T>
+__device__ __forceinline__ T deviceLoadAcquireSystem(T* value) {
+#ifdef __HIP_PLATFORM_AMD__
+  return __atomic_load_n(value, __ATOMIC_ACQUIRE);
+#else
+  return cuda::atomic_ref<T, cuda::thread_scope_system>{*value}.load(
+      cuda::memory_order_acquire);
+#endif
+}
+
+__device__ __forceinline__ bool
+deviceCompareExchangeSystem(int* value, int* expected, int desired) {
+#ifdef __HIP_PLATFORM_AMD__
+  return __atomic_compare_exchange_n(
+      value, expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+#else
+  return cuda::atomic_ref<int, cuda::thread_scope_system>{*value}
+      .compare_exchange_strong(
+          *expected,
+          desired,
+          cuda::memory_order_acq_rel,
+          cuda::memory_order_acquire);
+#endif
+}
+
+} // namespace detail
+
+/**
+ * Non-owning CUDA device view of an `Abort` object's shared state.
+ *
+ * The owning `Abort` object allocates and frees the mapped pinned `AbortState`.
+ * Kernels may copy this handle by value, but the handle must not be used after
+ * the owning `Abort` is destroyed. All reads and writes of shared state use
+ * system-scope atomics so CPU and device updates are mutually visible. Create
+ * handles through `Abort::getDeviceHandle()` so the mapped device pointer and
+ * timeout clock-rate conversion are initialized together.
+ */
+struct AbortDevice final {
+  /**
+   * Returns whether this handle references enabled shared abort state.
+   *
+   * Disabled handles are valid kernel arguments. They have a null state pointer
+   * and all mutating/query APIs behave like the host disabled `Abort` object.
+   */
+  __device__ bool isEnabled() const {
+    return state_ != nullptr;
+  }
+
+  /**
+   * Starts this handle's device-side timeout from the shared default duration.
+   *
+   * Non-positive or unset default timeouts leave the device deadline inactive.
+   * If converting the timeout to device cycles would overflow, the deadline is
+   * set to the current device clock so the next timeout check fails fast rather
+   * than silently creating an effectively infinite deadline.
+   */
+  __device__ void startTimeout() {
+    if (!isEnabled()) {
+      deadlineCycles_ = 0;
+      return;
+    }
+    const auto timeoutMs = getTimeoutMs();
+    if (timeoutMs <= 0 || cyclesPerMs_ == 0) {
+      deadlineCycles_ = 0;
+      return;
+    }
+    const auto now = detail::deviceClock();
+    const auto timeoutMsU = static_cast<uint64_t>(timeoutMs);
+    if (timeoutMsU > (UINT64_MAX - now) / cyclesPerMs_) {
+      deadlineCycles_ = now;
+      return;
+    }
+    deadlineCycles_ = now + timeoutMsU * cyclesPerMs_;
+  }
+
+  /**
+   * Cancels this handle's active device-side timeout.
+   *
+   * The deadline is local to this copied handle. Canceling it does not clear a
+   * shared abort reason that has already been recorded.
+   */
+  __device__ void cancelTimeout() {
+    deadlineCycles_ = 0;
+  }
+
+  /**
+   * Returns true when an explicit abort or this handle's expired timeout has
+   * recorded a terminal abort reason.
+   *
+   * If the local deadline has expired, this attempts to record
+   * `AbortReason::TIMED_OUT` as the shared reason. The shared reason remains
+   * first-writer-wins.
+   */
+  __device__ bool isAborted() const {
+    if (!isEnabled()) {
+      return false;
+    }
+    const auto observedReason = reason();
+    if (observedReason != AbortReason::NONE) {
+      return true;
+    }
+    (void)markTimedOutIfExpired();
+    return reason() != AbortReason::NONE;
+  }
+
+  /**
+   * Returns the shared abort reason currently visible to device code.
+   *
+   * Disabled handles always report `AbortReason::NONE`.
+   */
+  __device__ AbortReason reason() const {
+    if (!isEnabled()) {
+      return AbortReason::NONE;
+    }
+    return static_cast<AbortReason>(
+        detail::deviceLoadAcquireSystem(&state_->abort));
+  }
+
+  /**
+   * Returns the shared default timeout duration in milliseconds.
+   *
+   * A negative value means no default timeout has been configured.
+   */
+  __device__ int64_t getTimeoutMs() const {
+    if (!isEnabled()) {
+      return -1;
+    }
+    return detail::deviceLoadAcquireSystem(&state_->timeoutMs);
+  }
+
+  /**
+   * Records the first shared abort reason from device code.
+   *
+   * Valid terminal reasons are `AbortReason::ABORTED` and
+   * `AbortReason::TIMED_OUT`. `AbortReason::NONE` and unknown enum values are
+   * invalid; debug/device assert builds catch them, and release-compatible
+   * builds return before touching shared state. The CAS only transitions the
+   * shared state from `NONE`, so later writers cannot overwrite the first
+   * terminal reason.
+   */
+  __device__ void setAbort(AbortReason newReason = AbortReason::ABORTED) const {
+    if (!isEnabled()) {
+      return;
+    }
+    const bool validReason = detail::deviceIsValidTerminalReason(newReason);
+    assert(validReason);
+    if (!validReason) {
+      return;
+    }
+
+    int expected = static_cast<int>(AbortReason::NONE);
+    detail::deviceCompareExchangeSystem(
+        &state_->abort, &expected, static_cast<int>(newReason));
+  }
+
+ private:
+  friend class Abort;
+
+  /**
+   * Creates a device handle for mapped pinned state owned by `Abort`.
+   *
+   * Passing this handle by value to a kernel passes only this small non-owning
+   * view. The shared abort state remains in mapped pinned memory; device code
+   * does not receive a private copy of the state. Disabled handles use
+   * `state == nullptr`, which makes all public device APIs no-op/non-aborted.
+   *
+   * `cyclesPerMs` is sampled on the host while creating the handle. CUDA device
+   * clocks can change dynamically, so long-running timeouts may be approximate.
+   * AMD uses `wall_clock64()`, whose frequency is fixed at 100 MHz; NVIDIA uses
+   * `clock64()` and `cudaDevAttrClockRate`.
+   *
+   * The mapped device pointer and clock conversion are for the CUDA device that
+   * was current when `Abort::getDeviceHandle()` created this handle. Launch
+   * kernels that consume the handle on that same device, or create a new handle
+   * after switching devices.
+   *
+   * TODO: Evaluate CUPTI APIs for a more accurate timeout conversion source.
+   */
+  explicit AbortDevice(AbortState* state, uint64_t cyclesPerMs)
+      : state_{state}, cyclesPerMs_{cyclesPerMs} {}
+
+  __device__ bool deadlineExpired() const {
+    return deadlineCycles_ != 0 && detail::deviceClock() >= deadlineCycles_;
+  }
+
+  __device__ bool markTimedOutIfExpired() const {
+    if (!isEnabled() || !deadlineExpired()) {
+      return false;
+    }
+
+    int expected = static_cast<int>(AbortReason::NONE);
+    if (detail::deviceCompareExchangeSystem(
+            &state_->abort,
+            &expected,
+            static_cast<int>(AbortReason::TIMED_OUT))) {
+      return true;
+    }
+    return expected == static_cast<int>(AbortReason::TIMED_OUT);
+  }
+
+  /**
+   * Device pointer to the same mapped pinned state owned by the host `Abort`.
+   *
+   * This pointer is non-owning and is expected to be non-null for handles
+   * returned by `Abort::getDeviceHandle()`.
+   */
+  AbortState* state_{nullptr};
+
+  /**
+   * Device clock cycles per millisecond captured when the handle is created.
+   *
+   * Device timeout setup uses this to convert the shared default timeout from
+   * milliseconds into device clock cycles.
+   */
+  uint64_t cyclesPerMs_{0};
+
+  /**
+   * Per-handle device deadline in `detail::deviceClock()` cycles.
+   *
+   * A value of zero means no device-side timeout is active. This is local to
+   * the copied handle and is not part of the host-owned shared state.
+   */
+  uint64_t deadlineCycles_{0};
+};
+
+inline AbortDevice Abort::getDeviceHandle() const {
+  if (!enabled_) {
+    return AbortDevice{/*state=*/nullptr, /*cyclesPerMs=*/0};
+  }
+  if (state_ == nullptr || !stateMapped_) {
+    throw std::runtime_error(
+        "Abort::getDeviceHandle() requires CUDA host-mapped Abort state");
+  }
+  const auto device = detail::hostCurrentDevice();
+  void* deviceState = nullptr;
+  auto status = cudaHostGetDevicePointer(&deviceState, state_, 0);
+  if (status != cudaSuccess) {
+    throw std::runtime_error(
+        "cudaHostGetDevicePointer failed for Abort::getDeviceHandle(): " +
+        std::string(cudaGetErrorString(status)));
+  }
+  return AbortDevice{
+      static_cast<AbortState*>(deviceState),
+      detail::hostDeviceCyclesPerMs(device)};
+}
+
+} // namespace comms::fault_tolerance

--- a/comms/common/fault_tolerance/CMakeLists.txt
+++ b/comms/common/fault_tolerance/CMakeLists.txt
@@ -4,6 +4,11 @@ add_library(fault_tolerance OBJECT
     Abort.cc
 )
 
+option(COMMS_FAULT_TOLERANCE_ENABLE_CUDA "Enable CUDA-mapped Abort state" ON)
+if (COMMS_FAULT_TOLERANCE_ENABLE_CUDA)
+    find_package(CUDAToolkit)
+endif()
+
 target_compile_features(fault_tolerance PRIVATE cxx_std_20)
 target_compile_options(fault_tolerance PRIVATE -fPIC)
 set_target_properties(fault_tolerance PROPERTIES
@@ -13,3 +18,9 @@ target_include_directories(fault_tolerance PRIVATE
     ${ROOT}
     ${CONDA_INCLUDE}
 )
+if (COMMS_FAULT_TOLERANCE_ENABLE_CUDA AND CUDAToolkit_FOUND)
+    target_compile_definitions(fault_tolerance PRIVATE
+        COMMS_FAULT_TOLERANCE_WITH_CUDA=1
+    )
+    target_link_libraries(fault_tolerance PRIVATE CUDA::cudart)
+endif()

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
@@ -1,0 +1,195 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/common/fault_tolerance/tests/AbortDeviceTest.cuh"
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+
+namespace comms::fault_tolerance::testing {
+namespace {
+
+__global__ void deviceSetAbortKernel(AbortDevice abort, AbortReason reason) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    abort.setAbort(reason);
+  }
+}
+
+__global__ void
+deviceReadAbortKernel(AbortDevice abort, int* observed, int* observedMode) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    auto reason = abort.reason();
+    *observedMode = static_cast<int>(reason);
+    *observed = reason != AbortReason::NONE ? 1 : 0;
+  }
+}
+
+__global__ void deviceWaitForAbortKernel(
+    AbortDevice abort,
+    int* observed,
+    int* observedMode,
+    int maxIterations) {
+  if (blockIdx.x != 0 || threadIdx.x != 0) {
+    return;
+  }
+
+  for (int i = 0; i < maxIterations; ++i) {
+    auto reason = abort.reason();
+    if (reason != AbortReason::NONE) {
+      *observedMode = static_cast<int>(reason);
+      *observed = 1;
+      return;
+    }
+    __nanosleep(64);
+  }
+
+  *observedMode = static_cast<int>(AbortReason::NONE);
+  *observed = 0;
+}
+
+__global__ void deviceReadDefaultTimeoutMsKernel(
+    AbortDevice abort,
+    int64_t* observedTimeoutMs) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    *observedTimeoutMs = abort.getTimeoutMs();
+  }
+}
+
+__global__ void deviceReadAbortPredicateKernel(
+    AbortDevice abort,
+    int* observedIsAborted,
+    int* observedReason) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    *observedIsAborted = abort.isAborted() ? 1 : 0;
+    *observedReason = static_cast<int>(abort.reason());
+  }
+}
+
+__global__ void deviceWaitForTimeoutKernel(
+    AbortDevice abort,
+    int* observedMode,
+    int* observedIsAborted,
+    int maxIterations) {
+  if (blockIdx.x != 0 || threadIdx.x != 0) {
+    return;
+  }
+
+  abort.startTimeout();
+  for (int i = 0; i < maxIterations; ++i) {
+    if (abort.isAborted()) {
+      *observedMode = static_cast<int>(abort.reason());
+      *observedIsAborted = 1;
+      return;
+    }
+    __nanosleep(64);
+  }
+
+  *observedMode = static_cast<int>(AbortReason::NONE);
+  *observedIsAborted = 0;
+}
+
+__global__ void deviceCancelAndRestartTimeoutKernel(
+    AbortDevice abort,
+    int* observedAfterCancel,
+    int* observedMode,
+    int maxIterations) {
+  if (blockIdx.x != 0 || threadIdx.x != 0) {
+    return;
+  }
+
+  abort.startTimeout();
+  abort.cancelTimeout();
+  for (int i = 0; i < maxIterations; ++i) {
+    if (abort.isAborted()) {
+      *observedAfterCancel = 1;
+      *observedMode = static_cast<int>(abort.reason());
+      return;
+    }
+    __nanosleep(64);
+  }
+
+  *observedAfterCancel = 0;
+  abort.startTimeout();
+  for (int i = 0; i < maxIterations; ++i) {
+    if (abort.isAborted()) {
+      *observedMode = static_cast<int>(abort.reason());
+      return;
+    }
+    __nanosleep(64);
+  }
+
+  *observedMode = static_cast<int>(AbortReason::NONE);
+}
+
+} // namespace
+
+cudaError_t launchDeviceSetAbort(
+    AbortDevice abort,
+    AbortReason reason,
+    cudaStream_t stream) {
+  deviceSetAbortKernel<<<1, 1, 0, stream>>>(abort, reason);
+  return cudaGetLastError();
+}
+
+cudaError_t launchDeviceReadAbort(
+    AbortDevice abort,
+    int* observed,
+    int* observedMode,
+    cudaStream_t stream) {
+  deviceReadAbortKernel<<<1, 1, 0, stream>>>(abort, observed, observedMode);
+  return cudaGetLastError();
+}
+
+cudaError_t launchDeviceWaitForAbort(
+    AbortDevice abort,
+    int* observed,
+    int* observedMode,
+    int maxIterations,
+    cudaStream_t stream) {
+  deviceWaitForAbortKernel<<<1, 1, 0, stream>>>(
+      abort, observed, observedMode, maxIterations);
+  return cudaGetLastError();
+}
+
+cudaError_t launchDeviceReadDefaultTimeoutMs(
+    AbortDevice abort,
+    int64_t* observedTimeoutMs,
+    cudaStream_t stream) {
+  deviceReadDefaultTimeoutMsKernel<<<1, 1, 0, stream>>>(
+      abort, observedTimeoutMs);
+  return cudaGetLastError();
+}
+
+cudaError_t launchDeviceReadAbortPredicate(
+    AbortDevice abort,
+    int* observedIsAborted,
+    int* observedReason,
+    cudaStream_t stream) {
+  deviceReadAbortPredicateKernel<<<1, 1, 0, stream>>>(
+      abort, observedIsAborted, observedReason);
+  return cudaGetLastError();
+}
+
+cudaError_t launchDeviceWaitForTimeout(
+    AbortDevice abort,
+    int* observedMode,
+    int* observedIsAborted,
+    int maxIterations,
+    cudaStream_t stream) {
+  deviceWaitForTimeoutKernel<<<1, 1, 0, stream>>>(
+      abort, observedMode, observedIsAborted, maxIterations);
+  return cudaGetLastError();
+}
+
+cudaError_t launchDeviceCancelAndRestartTimeout(
+    AbortDevice abort,
+    int* observedAfterCancel,
+    int* observedMode,
+    int maxIterations,
+    cudaStream_t stream) {
+  deviceCancelAndRestartTimeoutKernel<<<1, 1, 0, stream>>>(
+      abort, observedAfterCancel, observedMode, maxIterations);
+  return cudaGetLastError();
+}
+
+} // namespace comms::fault_tolerance::testing

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
@@ -1,0 +1,56 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+
+#include "comms/common/fault_tolerance/AbortDevice.cuh"
+
+namespace comms::fault_tolerance::testing {
+
+cudaError_t launchDeviceSetAbort(
+    AbortDevice abort,
+    AbortReason reason,
+    cudaStream_t stream);
+
+cudaError_t launchDeviceReadAbort(
+    AbortDevice abort,
+    int* observed,
+    int* observedMode,
+    cudaStream_t stream);
+
+cudaError_t launchDeviceWaitForAbort(
+    AbortDevice abort,
+    int* observed,
+    int* observedMode,
+    int maxIterations,
+    cudaStream_t stream);
+
+cudaError_t launchDeviceReadDefaultTimeoutMs(
+    AbortDevice abort,
+    int64_t* observedTimeoutMs,
+    cudaStream_t stream);
+
+cudaError_t launchDeviceReadAbortPredicate(
+    AbortDevice abort,
+    int* observedIsAborted,
+    int* observedReason,
+    cudaStream_t stream);
+
+cudaError_t launchDeviceWaitForTimeout(
+    AbortDevice abort,
+    int* observedMode,
+    int* observedIsAborted,
+    int maxIterations,
+    cudaStream_t stream);
+
+cudaError_t launchDeviceCancelAndRestartTimeout(
+    AbortDevice abort,
+    int* observedAfterCancel,
+    int* observedMode,
+    int maxIterations,
+    cudaStream_t stream);
+
+} // namespace comms::fault_tolerance::testing

--- a/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
@@ -1,0 +1,405 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda_runtime.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "comms/common/fault_tolerance/Abort.h"
+#include "comms/common/fault_tolerance/tests/AbortDeviceTest.cuh"
+
+namespace comms::fault_tolerance::testing {
+namespace {
+
+constexpr int kDeviceTimeoutPollIterations = 10000000;
+constexpr int kDeviceTimeoutExpectedMs = 1000;
+constexpr float kDeviceTimeoutAccuracyMs = 100.0F;
+
+struct CudaFreeDeleter {
+  template <typename T>
+  void operator()(T* ptr) const {
+    if (ptr != nullptr) {
+      (void)cudaFree(ptr);
+    }
+  }
+};
+
+template <typename T>
+using DeviceValue = std::unique_ptr<T, CudaFreeDeleter>;
+
+template <typename T>
+DeviceValue<T> makeDeviceValue(T value = 0) {
+  T* ptr = nullptr;
+  EXPECT_EQ(cudaMalloc(&ptr, sizeof(T)), cudaSuccess);
+  if (ptr == nullptr) {
+    return nullptr;
+  }
+
+  EXPECT_EQ(
+      cudaMemcpy(ptr, &value, sizeof(T), cudaMemcpyHostToDevice), cudaSuccess);
+  return DeviceValue<T>{ptr};
+}
+
+template <typename T>
+T readDeviceValue(const DeviceValue<T>& ptr) {
+  T value = 0;
+  EXPECT_EQ(
+      cudaMemcpy(&value, ptr.get(), sizeof(T), cudaMemcpyDeviceToHost),
+      cudaSuccess);
+  return value;
+}
+
+void destroyEvent(cudaEvent_t event) {
+  if (event != nullptr) {
+    EXPECT_EQ(cudaEventDestroy(event), cudaSuccess);
+  }
+}
+
+} // namespace
+
+TEST(AbortDeviceTest, hostProducerHostConsumer) {
+  Abort abort{/*enabled=*/true};
+
+  EXPECT_FALSE(abort.isAborted());
+
+  abort.setAbort();
+
+  EXPECT_TRUE(abort.isAborted());
+}
+
+TEST(AbortDeviceTest, hostProducerDeviceConsumer) {
+  Abort abort{/*enabled=*/true};
+  auto observed = makeDeviceValue<int>();
+  auto observedMode = makeDeviceValue<int>();
+  ASSERT_NE(observed, nullptr);
+  ASSERT_NE(observedMode, nullptr);
+
+  abort.setAbort();
+
+  EXPECT_EQ(
+      launchDeviceReadAbort(
+          abort.getDeviceHandle(),
+          observed.get(),
+          observedMode.get(),
+          /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  EXPECT_EQ(readDeviceValue(observed), 1);
+  EXPECT_EQ(
+      readDeviceValue(observedMode), static_cast<int>(AbortReason::ABORTED));
+}
+
+TEST(AbortDeviceTest, deviceProducerHostConsumer) {
+  Abort abort{/*enabled=*/true};
+
+  EXPECT_EQ(
+      launchDeviceSetAbort(
+          abort.getDeviceHandle(), AbortReason::ABORTED, /*stream=*/nullptr),
+      cudaSuccess);
+
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (!abort.isAborted() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::yield();
+  }
+
+  EXPECT_TRUE(abort.isAborted());
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+}
+
+TEST(AbortDeviceTest, deviceProducerDeviceConsumer) {
+  Abort abort{/*enabled=*/true};
+  auto observed = makeDeviceValue<int>();
+  auto observedMode = makeDeviceValue<int>();
+  ASSERT_NE(observed, nullptr);
+  ASSERT_NE(observedMode, nullptr);
+
+  EXPECT_EQ(
+      launchDeviceSetAbort(
+          abort.getDeviceHandle(), AbortReason::ABORTED, /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(
+      launchDeviceReadAbort(
+          abort.getDeviceHandle(),
+          observed.get(),
+          observedMode.get(),
+          /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(observed), 1);
+  EXPECT_EQ(
+      readDeviceValue(observedMode), static_cast<int>(AbortReason::ABORTED));
+}
+
+TEST(AbortDeviceTest, hostDefaultTimeoutDeviceConsumer) {
+  Abort abort{/*enabled=*/true};
+  auto observedTimeoutMs = makeDeviceValue<int64_t>();
+  ASSERT_NE(observedTimeoutMs, nullptr);
+
+  abort.setDefaultTimeout(std::chrono::milliseconds{1234});
+
+  EXPECT_EQ(
+      launchDeviceReadDefaultTimeoutMs(
+          abort.getDeviceHandle(), observedTimeoutMs.get(), /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  EXPECT_EQ(readDeviceValue(observedTimeoutMs), 1234);
+}
+
+TEST(AbortDeviceTest, deviceHandleSeesHostDefaultTimeoutUpdates) {
+  Abort abort{/*enabled=*/true};
+  auto handle = abort.getDeviceHandle();
+  auto observedTimeoutMs = makeDeviceValue<int64_t>();
+  ASSERT_NE(observedTimeoutMs, nullptr);
+
+  abort.setDefaultTimeout(std::chrono::milliseconds{4321});
+
+  EXPECT_EQ(
+      launchDeviceReadDefaultTimeoutMs(
+          handle, observedTimeoutMs.get(), /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  EXPECT_EQ(readDeviceValue(observedTimeoutMs), 4321);
+}
+
+TEST(AbortDeviceTest, timedOutModeIsAbortedOnDevice) {
+  Abort abort{/*enabled=*/true};
+  auto observedIsAborted = makeDeviceValue<int>();
+  auto observedReason = makeDeviceValue<int>();
+  ASSERT_NE(observedIsAborted, nullptr);
+  ASSERT_NE(observedReason, nullptr);
+
+  abort.startTimeout(std::chrono::milliseconds{0});
+  ASSERT_TRUE(abort.isAborted());
+
+  EXPECT_EQ(
+      launchDeviceReadAbortPredicate(
+          abort.getDeviceHandle(),
+          observedIsAborted.get(),
+          observedReason.get(),
+          /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  EXPECT_EQ(readDeviceValue(observedIsAborted), 1);
+  EXPECT_EQ(
+      readDeviceValue(observedReason),
+      static_cast<int>(AbortReason::TIMED_OUT));
+}
+
+TEST(AbortDeviceTest, deviceTimeoutProducerHostAndDeviceConsumer) {
+  Abort abort{/*enabled=*/true};
+  auto observedMode = makeDeviceValue<int>();
+  auto observedIsAborted = makeDeviceValue<int>();
+  ASSERT_NE(observedMode, nullptr);
+  ASSERT_NE(observedIsAborted, nullptr);
+
+  abort.setDefaultTimeout(std::chrono::milliseconds{1});
+
+  EXPECT_EQ(
+      launchDeviceWaitForTimeout(
+          abort.getDeviceHandle(),
+          observedMode.get(),
+          observedIsAborted.get(),
+          kDeviceTimeoutPollIterations,
+          /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  EXPECT_EQ(
+      readDeviceValue(observedMode), static_cast<int>(AbortReason::TIMED_OUT));
+  EXPECT_EQ(readDeviceValue(observedIsAborted), 1);
+  EXPECT_TRUE(abort.isAborted());
+  EXPECT_TRUE(abort.isTimedOut());
+}
+
+TEST(AbortDeviceTest, hostAbortWinsOverDeviceTimeout) {
+  Abort abort{/*enabled=*/true};
+  auto observedMode = makeDeviceValue<int>();
+  auto observedIsAborted = makeDeviceValue<int>();
+  ASSERT_NE(observedMode, nullptr);
+  ASSERT_NE(observedIsAborted, nullptr);
+
+  abort.setAbort(AbortReason::ABORTED);
+  abort.setDefaultTimeout(std::chrono::milliseconds{1});
+
+  EXPECT_EQ(
+      launchDeviceWaitForTimeout(
+          abort.getDeviceHandle(),
+          observedMode.get(),
+          observedIsAborted.get(),
+          kDeviceTimeoutPollIterations,
+          /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  EXPECT_EQ(
+      readDeviceValue(observedMode), static_cast<int>(AbortReason::ABORTED));
+  EXPECT_EQ(readDeviceValue(observedIsAborted), 1);
+  EXPECT_TRUE(abort.isAborted());
+  EXPECT_FALSE(abort.isTimedOut());
+}
+
+TEST(AbortDeviceTest, deviceAbortWinsOverHostTimeout) {
+  Abort abort{/*enabled=*/true};
+
+  EXPECT_EQ(
+      launchDeviceSetAbort(
+          abort.getDeviceHandle(), AbortReason::ABORTED, /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  abort.startTimeout(std::chrono::milliseconds{0});
+
+  EXPECT_TRUE(abort.isAborted());
+  EXPECT_FALSE(abort.isTimedOut());
+}
+
+TEST(AbortDeviceTest, hostTimeoutWinsOverDeviceAbort) {
+  Abort abort{/*enabled=*/true};
+
+  abort.startTimeout(std::chrono::milliseconds{0});
+  ASSERT_TRUE(abort.isTimedOut());
+
+  EXPECT_EQ(
+      launchDeviceSetAbort(
+          abort.getDeviceHandle(), AbortReason::ABORTED, /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_TRUE(abort.isAborted());
+  EXPECT_TRUE(abort.isTimedOut());
+}
+
+TEST(AbortDeviceTest, deviceTimeoutWinsOverHostAbort) {
+  Abort abort{/*enabled=*/true};
+  auto observedMode = makeDeviceValue<int>();
+  auto observedIsAborted = makeDeviceValue<int>();
+  ASSERT_NE(observedMode, nullptr);
+  ASSERT_NE(observedIsAborted, nullptr);
+
+  abort.setDefaultTimeout(std::chrono::milliseconds{1});
+
+  EXPECT_EQ(
+      launchDeviceWaitForTimeout(
+          abort.getDeviceHandle(),
+          observedMode.get(),
+          observedIsAborted.get(),
+          kDeviceTimeoutPollIterations,
+          /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  abort.setAbort(AbortReason::ABORTED);
+
+  EXPECT_EQ(
+      readDeviceValue(observedMode), static_cast<int>(AbortReason::TIMED_OUT));
+  EXPECT_EQ(readDeviceValue(observedIsAborted), 1);
+  EXPECT_TRUE(abort.isAborted());
+  EXPECT_TRUE(abort.isTimedOut());
+}
+
+TEST(AbortDeviceTest, deviceTimeoutCanBeCancelledAndRestarted) {
+  Abort abort{/*enabled=*/true};
+  auto observedAfterCancel = makeDeviceValue<int>();
+  auto observedMode = makeDeviceValue<int>();
+  ASSERT_NE(observedAfterCancel, nullptr);
+  ASSERT_NE(observedMode, nullptr);
+
+  abort.setDefaultTimeout(std::chrono::milliseconds{1});
+
+  EXPECT_EQ(
+      launchDeviceCancelAndRestartTimeout(
+          abort.getDeviceHandle(),
+          observedAfterCancel.get(),
+          observedMode.get(),
+          kDeviceTimeoutPollIterations,
+          /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  EXPECT_EQ(readDeviceValue(observedAfterCancel), 0);
+  EXPECT_EQ(
+      readDeviceValue(observedMode), static_cast<int>(AbortReason::TIMED_OUT));
+  EXPECT_TRUE(abort.isAborted());
+  EXPECT_TRUE(abort.isTimedOut());
+}
+
+TEST(AbortDeviceTest, deviceTimeoutAccuracyMeasuredWithCudaEvents) {
+  Abort abort{/*enabled=*/true};
+  auto observedMode = makeDeviceValue<int>();
+  auto observedIsAborted = makeDeviceValue<int>();
+  ASSERT_NE(observedMode, nullptr);
+  ASSERT_NE(observedIsAborted, nullptr);
+
+  abort.setDefaultTimeout(std::chrono::milliseconds{kDeviceTimeoutExpectedMs});
+
+  cudaEvent_t start = nullptr;
+  cudaEvent_t end = nullptr;
+  ASSERT_EQ(cudaEventCreate(&start), cudaSuccess);
+  ASSERT_EQ(cudaEventCreate(&end), cudaSuccess);
+
+  ASSERT_EQ(cudaEventRecord(start, /*stream=*/nullptr), cudaSuccess);
+  EXPECT_EQ(
+      launchDeviceWaitForTimeout(
+          abort.getDeviceHandle(),
+          observedMode.get(),
+          observedIsAborted.get(),
+          kDeviceTimeoutPollIterations,
+          /*stream=*/nullptr),
+      cudaSuccess);
+  ASSERT_EQ(cudaEventRecord(end, /*stream=*/nullptr), cudaSuccess);
+  ASSERT_EQ(cudaEventSynchronize(end), cudaSuccess);
+
+  float elapsedMs = 0.0F;
+  ASSERT_EQ(cudaEventElapsedTime(&elapsedMs, start, end), cudaSuccess);
+  destroyEvent(end);
+  destroyEvent(start);
+
+  std::fprintf(
+      stderr,
+      "AbortDevice timeout accuracy expected_ms=%d observed_ms=%.3f tolerance_ms=%.3f\n",
+      kDeviceTimeoutExpectedMs,
+      elapsedMs,
+      kDeviceTimeoutAccuracyMs);
+  EXPECT_EQ(
+      readDeviceValue(observedMode), static_cast<int>(AbortReason::TIMED_OUT));
+  EXPECT_EQ(readDeviceValue(observedIsAborted), 1);
+  EXPECT_GE(
+      elapsedMs,
+      static_cast<float>(kDeviceTimeoutExpectedMs) - kDeviceTimeoutAccuracyMs);
+  EXPECT_LE(
+      elapsedMs,
+      static_cast<float>(kDeviceTimeoutExpectedMs) + kDeviceTimeoutAccuracyMs);
+}
+
+TEST(AbortDeviceTest, disabledAbortDeviceHandleIsNoop) {
+  auto abort = createAbort(/*enabled=*/false);
+  auto observed = makeDeviceValue<int>();
+  auto observedMode = makeDeviceValue<int>();
+  auto observedTimeoutMs = makeDeviceValue<int64_t>();
+  ASSERT_NE(observed, nullptr);
+  ASSERT_NE(observedMode, nullptr);
+  ASSERT_NE(observedTimeoutMs, nullptr);
+
+  auto handle = abort->getDeviceHandle();
+
+  EXPECT_EQ(
+      launchDeviceReadAbort(
+          handle, observed.get(), observedMode.get(), /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(
+      launchDeviceReadDefaultTimeoutMs(
+          handle, observedTimeoutMs.get(), /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(observed), 0);
+  EXPECT_EQ(readDeviceValue(observedMode), static_cast<int>(AbortReason::NONE));
+  EXPECT_EQ(readDeviceValue(observedTimeoutMs), -1);
+}
+
+} // namespace comms::fault_tolerance::testing

--- a/comms/common/fault_tolerance/tests/AbortUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortUT.cc
@@ -16,6 +16,31 @@ namespace comms::fault_tolerance::testing {
 using ::comms::fault_tolerance::Abort;
 using ::comms::fault_tolerance::AbortReason;
 
+namespace {
+
+template <typename Predicate>
+bool eventually(
+    Predicate&& predicate,
+    std::chrono::milliseconds timeout = std::chrono::seconds{1}) {
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (!predicate()) {
+    if (std::chrono::steady_clock::now() >= deadline) {
+      return false;
+    }
+    std::this_thread::yield();
+  }
+  return true;
+}
+
+void waitFor(std::chrono::milliseconds duration) {
+  const auto deadline = std::chrono::steady_clock::now() + duration;
+  while (std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::yield();
+  }
+}
+
+} // namespace
+
 TEST(AbortTest, enabledDefaultNotAbort) {
   Abort abort{/*enabled=*/true};
   EXPECT_FALSE(abort.isAborted());
@@ -68,8 +93,7 @@ TEST(AbortTest, MultipleAbortTest) {
           << "producer: test case did not start";
     }
 
-    // delay a bit to allow consumer start working first
-    std::this_thread::sleep_for(std::chrono::microseconds(20));
+    std::this_thread::yield();
 
     ASSERT_FALSE(abort.isAborted());
     abort.setAbort();
@@ -131,18 +155,14 @@ TEST(AbortTest, timeoutExpired) {
 
   abort.startTimeout(std::chrono::milliseconds(1));
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
   // Test should return true as timeout has expired
-  EXPECT_TRUE(abort.isAborted());
+  EXPECT_TRUE(eventually([&]() { return abort.isAborted(); }));
 }
 
 TEST(AbortTest, timeoutDisabledNoop) {
   Abort abort{/*enabled=*/false};
 
   abort.startTimeout(std::chrono::milliseconds(1));
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
   // Test should return false as abort is disabled:w
   EXPECT_FALSE(abort.isAborted());
@@ -165,8 +185,6 @@ TEST(AbortTest, timeoutAndExplicitSetBothTrue) {
   abort.startTimeout(std::chrono::milliseconds(1));
   abort.setAbort();
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
   // Test should return true (both conditions are true)
   EXPECT_TRUE(abort.isAborted());
 }
@@ -175,7 +193,9 @@ TEST(AbortTest, explicitAbortWinsOverExpiredTimeout) {
   Abort abort{/*enabled=*/true};
 
   abort.startTimeout(std::chrono::milliseconds(1));
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  EXPECT_TRUE(eventually([&]() {
+    return abort.getTimeRemaining() == std::chrono::milliseconds{0};
+  }));
   abort.setAbort();
 
   EXPECT_TRUE(abort.isAborted());
@@ -186,9 +206,8 @@ TEST(AbortTest, timeoutWinsBeforeExplicitAbort) {
   Abort abort{/*enabled=*/true};
 
   abort.startTimeout(std::chrono::milliseconds(1));
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
-  EXPECT_TRUE(abort.isTimedOut());
+  EXPECT_TRUE(eventually([&]() { return abort.isTimedOut(); }));
 
   abort.setAbort();
 
@@ -205,10 +224,8 @@ TEST(AbortTest, multipleTimeoutCalls) {
 
   abort.startTimeout(std::chrono::milliseconds(1));
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
   // Test should return true as the shorter timeout has expired
-  EXPECT_TRUE(abort.isAborted());
+  EXPECT_TRUE(eventually([&]() { return abort.isAborted(); }));
 }
 
 TEST(AbortTest, timeoutThreadSafety) {
@@ -227,7 +244,7 @@ TEST(AbortTest, timeoutThreadSafety) {
   // Thread 2: Continuously tests for abort
   std::thread tester([&]() {
     while (!timeoutSet.load()) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      std::this_thread::yield();
     }
 
     auto start = std::chrono::steady_clock::now();
@@ -238,7 +255,7 @@ TEST(AbortTest, timeoutThreadSafety) {
         timeoutDetected.store(true);
         break;
       }
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      std::this_thread::yield();
     }
   });
 
@@ -256,7 +273,7 @@ TEST(AbortTest, cancelTimeoutBeforeExpiry) {
   abort.startTimeout(std::chrono::milliseconds(100));
   abort.cancelTimeout();
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+  waitFor(std::chrono::milliseconds(150));
 
   // Test should return false as timeout was cancelled
   EXPECT_FALSE(abort.isAborted());
@@ -267,10 +284,8 @@ TEST(AbortTest, cancelTimeoutAfterExpiry) {
 
   abort.startTimeout(std::chrono::milliseconds(1));
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
   // Verify timeout has expired
-  EXPECT_TRUE(abort.isAborted());
+  EXPECT_TRUE(eventually([&]() { return abort.isAborted(); }));
 
   abort.cancelTimeout();
 
@@ -283,8 +298,6 @@ TEST(AbortTest, cancelTimeoutDisabledNoop) {
 
   abort.startTimeout(std::chrono::milliseconds(1));
   abort.cancelTimeout();
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
   // Test should return false as abort is disabled
   EXPECT_FALSE(abort.isAborted());
@@ -315,10 +328,8 @@ TEST(AbortTest, setTimeoutAfterCancel) {
 
   abort.startTimeout(std::chrono::milliseconds(1));
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
   // Test should return true as new timeout has expired
-  EXPECT_TRUE(abort.isAborted());
+  EXPECT_TRUE(eventually([&]() { return abort.isAborted(); }));
 }
 
 TEST(AbortTest, multipleCancelTimeoutCalls) {
@@ -329,7 +340,7 @@ TEST(AbortTest, multipleCancelTimeoutCalls) {
   abort.cancelTimeout();
   abort.cancelTimeout();
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+  waitFor(std::chrono::milliseconds(150));
 
   // Test should return false as timeout was cancelled
   EXPECT_FALSE(abort.isAborted());
@@ -352,11 +363,11 @@ TEST(AbortTest, cancelTimeoutThreadSafety) {
   // Thread 2: Cancels timeout after a brief delay
   std::thread timeoutCanceller([&]() {
     while (!timeoutSet.load()) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      std::this_thread::yield();
     }
 
     // Wait a bit then cancel
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waitFor(std::chrono::milliseconds(10));
     abort.cancelTimeout();
     timeoutCancelled.store(true);
   });
@@ -364,7 +375,7 @@ TEST(AbortTest, cancelTimeoutThreadSafety) {
   // Thread 3: Continuously tests for abort
   std::thread tester([&]() {
     while (!timeoutSet.load()) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      std::this_thread::yield();
     }
 
     // Test for timeout for a reasonable duration
@@ -377,7 +388,7 @@ TEST(AbortTest, cancelTimeoutThreadSafety) {
         timeoutDetected.store(true);
         break;
       }
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      std::this_thread::yield();
     }
   });
 
@@ -433,8 +444,7 @@ TEST(AbortTest, timedOutTrueAfterExpiry) {
   Abort abort{/*enabled=*/true};
   abort.startTimeout(std::chrono::milliseconds(1));
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  EXPECT_TRUE(abort.isTimedOut());
+  EXPECT_TRUE(eventually([&]() { return abort.isTimedOut(); }));
 }
 
 TEST(AbortTest, timedOutFalseForExplicitSet) {
@@ -508,7 +518,8 @@ TEST(AbortTest, timeRemainingDecreases) {
   abort.startTimeout(std::chrono::milliseconds(100));
 
   auto remaining1 = abort.getTimeRemaining();
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  EXPECT_TRUE(
+      eventually([&]() { return abort.getTimeRemaining() < remaining1; }));
   auto remaining2 = abort.getTimeRemaining();
 
   EXPECT_LT(remaining2, remaining1);
@@ -518,9 +529,9 @@ TEST(AbortTest, timeRemainingZeroAfterExpiry) {
   Abort abort{/*enabled=*/true};
   abort.startTimeout(std::chrono::milliseconds(1));
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
-  EXPECT_EQ(abort.getTimeRemaining(), std::chrono::milliseconds{0});
+  EXPECT_TRUE(eventually([&]() {
+    return abort.getTimeRemaining() == std::chrono::milliseconds{0};
+  }));
 }
 
 TEST(AbortTest, timeRemainingAfterCancel) {

--- a/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
@@ -595,12 +595,13 @@ class CtranIbAbortCtrlMsgTest
   }
 
   void TearDown() override {
-    CtranIbBootstrapTestBase::TearDown();
-
     acceptSocketBaton_.post();
+    ctranIb_.reset();
     mockServerSockets_.clear();
     mockSockets_.clear();
-    ctranIb_.reset();
+    abortCtrl_.reset();
+
+    CtranIbBootstrapTestBase::TearDown();
   }
 
   std::unique_ptr<StrictMock<ctran::bootstrap::testing::MockIServerSocket>>


### PR DESCRIPTION
Summary:

Introduce a non-owning `AbortDevice` handle over the mapped pinned `Abort` state. `Abort::getDeviceHandle()` returns a device-usable view while ownership stays with the host `Abort` object, and device code can signal/read explicit aborts and deadline-derived timeout state through the shared reason enum.

Disabled device handles are valid no-op handles. Device-side timeout cancellation is supported. The handle contract now explicitly states that the mapped device pointer and clock conversion are bound to the CUDA device current when the handle is created; callers should create a new handle after switching devices.

`cudaDevAttrHostNativeAtomicSupported` is not used as a hard gate: the H100 DevGPU used for validation reports that attribute as unsupported, while the mapped pinned state behavior is covered directly by host/device producer-consumer tests. Host-only fallback remains internal to `Abort`; requesting an enabled device handle still requires mapped pinned state and the caller must keep the owning `Abort` alive.

Reviewed By: arttianezhu

Differential Revision: D113372516


