### PR TITLE
Derive CtranPipes channel geometry from CVARs

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -10,7 +10,6 @@
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/CtranAlgo.h"
-#include "comms/ctran/algos/ReduceScatter/ReduceScatterDirectIbConfig.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -207,23 +206,36 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
           MCCL_MAX_NCHANNELS);
       return commInvalidArgument;
     }
-    const auto numChannels = static_cast<size_t>(MCCL_MAX_NCHANNELS);
+    const int maxChannels = static_cast<int>(MCCL_MAX_NCHANNELS);
+    const int channelPipelineDepth =
+        static_cast<int>(MCCL_CHANNEL_PIPELINE_DEPTH);
+    if (channelPipelineDepth <= 0) {
+      CLOGF(
+          ERR,
+          "MCCL_CHANNEL_PIPELINE_DEPTH must be positive, got {}",
+          channelPipelineDepth);
+      return commInvalidArgument;
+    }
+
     size_t ibgdaDataBufferSize = 0;
     if (pc.ibgdaDataBufferSize > 0) {
       ibgdaDataBufferSize = static_cast<size_t>(pc.ibgdaDataBufferSize);
     } else {
-      const auto perChannelSize = static_cast<size_t>(MCCL_CHANNEL_BUFFER_SIZE);
-      if (perChannelSize > std::numeric_limits<size_t>::max() / numChannels) {
+      const auto perDirectionChannelBuffer =
+          static_cast<size_t>(MCCL_CHANNEL_BUFFER_SIZE);
+      if (perDirectionChannelBuffer > std::numeric_limits<size_t>::max() /
+              static_cast<size_t>(maxChannels)) {
         CLOGF(
             ERR,
             "MCCL_CHANNEL_BUFFER_SIZE={} overflows total size for {} channels",
-            perChannelSize,
-            numChannels);
+            perDirectionChannelBuffer,
+            maxChannels);
         return commInvalidArgument;
       }
-      ibgdaDataBufferSize = perChannelSize * numChannels;
+      ibgdaDataBufferSize =
+          perDirectionChannelBuffer * static_cast<size_t>(maxChannels);
     }
-    config.ibConfig.dataBufferSize = static_cast<size_t>(ibgdaDataBufferSize);
+    config.ibConfig.dataBufferSize = ibgdaDataBufferSize;
     config.ibConfig.qpDepth = MCCL_IB_QP_DEPTH;
     if (NCCL_IB_TIMEOUT != NCCL_IB_TIMEOUT_DEFAULTCVARVALUE) {
       config.ibConfig.timeout = static_cast<uint8_t>(NCCL_IB_TIMEOUT);
@@ -257,75 +269,50 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
           NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC);
       return commInvalidArgument;
     }
-    config.ibConfig.maxGroups = static_cast<int>(MCCL_MAX_NCHANNELS);
+    config.ibConfig.maxGroups = maxChannels;
     config.ibConfig.qpsPerConnection =
         static_cast<int>(NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC);
 
-    const bool directIbReduceScatter =
-        NCCL_REDUCESCATTER_ALGO == NCCL_REDUCESCATTER_ALGO::ctdirect_ib;
-    if (directIbReduceScatter) {
-      config.ibConfig.perChannelSize =
-          ctran::reducescatter::direct_ib::kPerChannelSize;
-      config.ibConfig.max_num_channels =
-          ctran::reducescatter::direct_ib::kMaxNumBlocks;
-      config.ibConfig.pipelineDepth =
-          ctran::reducescatter::direct_ib::kPipelineDepth;
-      config.ibConfig.qpsPerConnection =
-          ctran::reducescatter::direct_ib::kQpsPerConnection;
-      config.ibConfig.maxGroups =
-          ctran::reducescatter::direct_ib::kMaxNumBlocks;
-      config.ibConfig.dataBufferSize =
-          config.ibConfig.fixedChannelDataBufferSize();
+    if (config.ibConfig.dataBufferSize == 0) {
       CLOGF(
-          INFO,
-          "Direct IB ReduceScatter pins IB config: perChannelSize={}, maxNumChannels={}, pipelineDepth={}, qpsPerConnection={}, maxGroups={}, dataBufferSize={}",
-          config.ibConfig.perChannelSize,
-          config.ibConfig.max_num_channels,
-          config.ibConfig.pipelineDepth,
-          config.ibConfig.qpsPerConnection,
-          config.ibConfig.maxGroups,
-          config.ibConfig.dataBufferSize);
+          ERR,
+          "send/recv requires a positive staging size via MCCL_CHANNEL_BUFFER_SIZE or pipesIbgdaDataBufferSize");
+      return commInvalidArgument;
     }
-
-    if (NCCL_CTRAN_IBGDA_SENDRECV_ENABLE && !directIbReduceScatter) {
-      if (config.ibConfig.dataBufferSize == 0) {
-        CLOGF(
-            ERR,
-            "send/recv requires a positive staging size via MCCL_CHANNEL_BUFFER_SIZE or pipesIbgdaDataBufferSize");
-        return commInvalidArgument;
-      }
-      if (config.ibConfig.dataBufferSize % numChannels != 0) {
-        CLOGF(
-            ERR,
-            "IB data-buffer size {} must be divisible by channel count {}",
-            config.ibConfig.dataBufferSize,
-            numChannels);
-        return commInvalidArgument;
-      }
-      const int pipelineDepth = static_cast<int>(MCCL_CHANNEL_PIPELINE_DEPTH);
-      if (pipelineDepth <= 0) {
-        CLOGF(
-            ERR,
-            "MCCL_CHANNEL_PIPELINE_DEPTH must be positive, got {}",
-            pipelineDepth);
-        return commInvalidArgument;
-      }
-
-      config.ibConfig.perChannelSize =
-          config.ibConfig.dataBufferSize / numChannels;
-      config.ibConfig.max_num_channels = config.ibConfig.maxGroups;
-      config.ibConfig.pipelineDepth = pipelineDepth;
-    }
-    if (NCCL_CTRAN_IBGDA_SENDRECV_ENABLE || directIbReduceScatter) {
+    if (config.ibConfig.dataBufferSize % static_cast<size_t>(maxChannels) !=
+        0) {
       CLOGF(
-          INFO,
-          "Prims IBGDA sendRecv configured: perChannelSize={}, maxNumChannels={}, pipelineDepth={}, dataBufferSize={}, directIbReduceScatter={}",
-          config.ibConfig.perChannelSize,
-          config.ibConfig.max_num_channels,
-          config.ibConfig.pipelineDepth,
+          ERR,
+          "IB data-buffer size {} must be divisible by channel count {}",
           config.ibConfig.dataBufferSize,
-          directIbReduceScatter);
+          maxChannels);
+      return commInvalidArgument;
     }
+    const size_t perDirectionChannelBuffer =
+        config.ibConfig.dataBufferSize / static_cast<size_t>(maxChannels);
+    const auto pipelineDepth = static_cast<size_t>(channelPipelineDepth);
+    if (perDirectionChannelBuffer % pipelineDepth != 0) {
+      CLOGF(
+          ERR,
+          "IB per-direction channel buffer {} must be divisible by pipeline depth {}",
+          perDirectionChannelBuffer,
+          channelPipelineDepth);
+      return commInvalidArgument;
+    }
+
+    config.ibConfig.perChannelSize = perDirectionChannelBuffer;
+    config.ibConfig.max_num_channels = config.ibConfig.maxGroups;
+    config.ibConfig.pipelineDepth = channelPipelineDepth;
+    const size_t channelChunkSize = config.ibConfig.perChannelSize /
+        static_cast<size_t>(config.ibConfig.pipelineDepth);
+    CLOGF(
+        INFO,
+        "Prims IB sendRecv configured: perChannelSize={}, channelChunkSize={}, maxNumChannels={}, pipelineDepth={}, dataBufferSize={}",
+        config.ibConfig.perChannelSize,
+        channelChunkSize,
+        config.ibConfig.max_num_channels,
+        config.ibConfig.pipelineDepth,
+        config.ibConfig.dataBufferSize);
 
     if (MCCL_IB_MODE == MCCL_IB_MODE::ibrc) {
       config.ibMode = comms::prims::IbBackendMode::kIbrc;

--- a/comms/ctran/benchmarks/AllGatherBench.cc
+++ b/comms/ctran/benchmarks/AllGatherBench.cc
@@ -211,7 +211,6 @@ class CtranAllGatherBenchmark : public ctran::CtranDistTestFixture {
   void SetUp() override {
     setenv("NCCL_CTRAN_ENABLE", "1", 0);
     setenv("NCCL_CTRAN_USE_PIPES", "1", 0);
-    setenv("NCCL_CTRAN_IBGDA_SENDRECV_ENABLE", "1", 0);
     setenv("MCCL_CHANNEL_BUFFER_SIZE", "131072", 0);
     setenv("NCCL_DEBUG", "WARN", 0);
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1968,17 +1968,6 @@ cvars:
      On timeout, materializePeer throws rather than hanging.
      No per-comm override.
 
- - name        : NCCL_CTRAN_IBGDA_SENDRECV_ENABLE
-   type        : bool
-   default     : false
-   description : |-
-     Enable send/recv staging buffers for prims IB transports in
-     MultiPeerTransport. Required for cthierarchical_ring. When enabled,
-     allocates additional GPU memory for pipelined send/recv staging per IB
-     peer. The effective per-channel buffer must be positive via
-     MCCL_CHANNEL_BUFFER_SIZE or the per-communicator
-     pipesIbgdaDataBufferSize hint.
-
  - name        : NCCL_CTRAN_BACKENDS
    type        : enumlist
    default     : ib, nvl, socket
@@ -3182,9 +3171,17 @@ cvars:
      benchmarking. Valid values are 1 through the compile-time maximum tree
      children.
 
+ - name        : MCCL_ALLREDUCE_IB_SIGNAL_BYTES
+   type        : uint64_t
+   default     : 0
+   description : |-
+     Maximum bytes per signaled sub-chunk for MCCL fused AllReduce IB phases.
+     Applies to ctree and cthierarchical_ring. 0 preserves the transport
+     default signaling cadence.
+
  - name        : MCCL_MAX_NCHANNELS
    type        : int
-   default     : 64
+   default     : 32
    description : |-
      Maximum number of fixed prims IB channels per peer. Channels index
      staging, signal, and QP resources through ThreadGroup::group_id and do
@@ -3211,23 +3208,23 @@ cvars:
 
  - name        : MCCL_CHANNEL_BUFFER_SIZE
    type        : uint64_t
-   default     : 0
+   default     : 2097152
    description : |-
-     Per-channel prims IB send/recv staging size in bytes, shared by the IBGDA
-     and IBRC backends. Total staging per peer and direction is this value
-     multiplied by MCCL_MAX_NCHANNELS. Combined with
-     MCCL_CHANNEL_PIPELINE_DEPTH: chunk size = this / depth. A value of 0
-     provides no global staging size; a per-communicator
-     pipesIbgdaDataBufferSize total override may still provide an effective
-     total.
+     Per-channel, per-direction prims IB send/recv staging size in bytes,
+     shared by the IBGDA and IBRC backends. Total staging per peer and
+     direction is this value multiplied by MCCL_MAX_NCHANNELS. Combined with
+     MCCL_CHANNEL_PIPELINE_DEPTH: channel chunk size = this / depth.
+     The default is 2MiB per channel per direction; with the default pipeline
+     depth of 4 this yields 512KiB chunks, or 4MiB combined send+recv staging
+     per channel.
 
  - name        : MCCL_CHANNEL_PIPELINE_DEPTH
    type        : int
-   default     : 2
+   default     : 4
    description : |-
-     Number of staging ring slots (pipeline depth) per prims IB channel,
-     shared by the IBGDA and IBRC backends. Chunk size is the per-channel
-     buffer size divided by this depth.
+     Number of staging slots per prims IB channel, shared by the IBGDA and
+     IBRC backends. Each slot carries one channel chunk. Channel chunk size is
+     MCCL_CHANNEL_BUFFER_SIZE divided by this depth.
 
  - name        : MCCL_CTRAN_BACKENDS
    type        : enumlist


### PR DESCRIPTION
Summary:
Derive MCCL/CtranPipes channel geometry from CVARs instead of local constants.

This sets the runtime defaults to `MCCL_MAX_NCHANNELS=32`, `MCCL_CHANNEL_PIPELINE_DEPTH=4`, and `MCCL_CHANNEL_BUFFER_SIZE=2097152` bytes per channel per direction. That gives 4 x 512KiB chunks per direction, with 2MiB send plus 2MiB recv per channel.

The AllReduce benchmark helper sweeps MCCL variants and NCCL Simple baselines while applying PD/signal sweeps only to MCCL variants that consume those settings. Signal-byte tuning remains explicit via `MCCL_ALLREDUCE_IB_SIGNAL_BYTES`.

Follow-up in this version: raise the high-ppn `IB_ONLY_1x7`/`IB_ONLY_1x8` test timeouts to cover the measured communicator setup cost, and make the CTRAN Prims send/recv log backend-neutral for IBGDA/IBRC.

Reviewed By: function47

Differential Revision: D113609971


