### PR TITLE
AllToAllv: run 1-SM stub when no local NVL peer has data (#3294)

### DIFF
--- a/comms/ctran/algos/AllToAll/AllToAllv.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllv.cc
@@ -70,12 +70,22 @@ static inline commResult_t setupKernelConfig(
   config.args.collective.alltoallv.selfSendDispl = sdispls[statex->rank()];
   config.args.collective.alltoallv.selfRecvDispl = rdispls[statex->rank()];
 
-  // When no local NVL peers (ppn=1, pure IB path), the alltoallv kernel's
-  // send/recv loops are empty — only self-copy and GPE sync remain. Issue
-  // the self D2D copy via cudaMemcpyAsync and signal the kernel to skip
-  // its body by setting sendElemsList to nullptr. The kernel then runs as
-  // a 1-block/1-thread stub for GPE sync, freeing SMs for overlapping compute.
-  if (statex->nLocalRanks() <= 1) {
+  // Run the 1-block/1-thread stub not only at ppn=1 but whenever no same-node
+  // NVL peer carries data (e.g. a2a_hier's rail leg): the kernel's send/recv
+  // loops are empty, so the self copy goes through icopy and the IB peers run
+  // on the GPE thread, avoiding the static grid of no-op CTAs.
+  bool hasLocalPeerWork = false;
+  for (int lr = 0; lr < statex->nLocalRanks(); ++lr) {
+    if (lr == statex->localRank()) {
+      continue;
+    }
+    const int g = statex->localRankToRank(lr);
+    if (sendcounts[g] != 0 || recvcounts[g] != 0) {
+      hasLocalPeerWork = true;
+      break;
+    }
+  }
+  if (!hasLocalPeerWork) {
     size_t selfBytes = sendcounts[statex->rank()] * commTypeSize(datatype);
     if (selfBytes > 0) {
       FB_COMMCHECK(comm->ctran_->mapper->icopy(

--- a/comms/ctran/tests/CtranDistAlltoAllvTest.cc
+++ b/comms/ctran/tests/CtranDistAlltoAllvTest.cc
@@ -41,6 +41,26 @@ class ctranAllToAllvTest : public ctran::CtranDistTestFixture,
     }
   }
 
+  void generateInterNodeOnlyCountsDisps(size_t count) {
+    // Only self and inter-node (IB) peers carry data; every same-node (NVL)
+    // peer is zero-size (a2a_hier's rail-leg shape), so the AllToAllv kernel
+    // runs the 1-block stub while the GPE thread drives the IB peers. On a
+    // single-node build this degenerates to a self-only copy, which still
+    // exercises the same stub path.
+    const int myNode = ctranComm->statex_->node();
+    const int stride = count * 2;
+    sendTotalCount = stride * numRanks;
+    recvTotalCount = stride * numRanks;
+    for (int i = 0; i < numRanks; ++i) {
+      const bool carriesData =
+          (i == globalRank) || (ctranComm->statex_->node(i) != myNode);
+      sendCounts[i] = carriesData ? count : 0;
+      sendDisps[i] = stride * i;
+      recvCounts[i] = carriesData ? count : 0;
+      recvDisps[i] = stride * i;
+    }
+  }
+
   void generateDistRandomCountsDisps() {
     // assign random send count for each peer
     srand(time(NULL) + globalRank);
@@ -254,6 +274,25 @@ TEST_P(ctranAllToAllvTestParam, ZeroByteAllToAllv) {
   EXPECT_EQ(errs, 0) << "rank " << globalRank
                      << " checked receive buffer (expect no update) with "
                      << errs << " errors";
+
+  releaseDataBuf(sendBuf, sendTotalCount * sizeof(int), true);
+  releaseDataBuf(recvBuf, recvTotalCount * sizeof(int), true);
+}
+
+// Exercises the low-SM stub path: data only for self and inter-node (IB)
+// peers, so no same-node NVL peer has work and AllToAllv launches 1 block.
+TEST_P(ctranAllToAllvTestParam, AllToAllvIbPeersOnly) {
+  const bool enable_lowlatency_config = GetParam();
+  EnvRAII env1(NCCL_CTRAN_NO_ERROR_CHECK, enable_lowlatency_config);
+  EnvRAII env2(NCCL_CTRAN_ENABLE_PRECONNECT, enable_lowlatency_config);
+
+  generateInterNodeOnlyCountsDisps(4096);
+  generateDistRandomExpValue();
+
+  sendBuf = (int*)createDataBuf(sendTotalCount * sizeof(int), true);
+  recvBuf = (int*)createDataBuf(recvTotalCount * sizeof(int), true);
+
+  run();
 
   releaseDataBuf(sendBuf, sendTotalCount * sizeof(int), true);
   releaseDataBuf(recvBuf, recvTotalCount * sizeof(int), true);


### PR DESCRIPTION
Summary:

`alltoallv="ctran"` splits into a GPU kernel (`ncclKernelAllToAllv`: self-copy +
intra-node NVLink copies) and a CPU GPE thread (`ctranAllToAllvIbImpl`: all IB
transfers, 0 GPU SMs). At ppn>1, `setupKernelConfig` always launched the static
`NCCL_CTRAN_ALLTOALLV_NUM_THREAD_BLOCKS` (64) grid, even when the call carries
data only for inter-node (IB) peers and every same-node (NVLink) peer is
zero-size -- the shape of `a2a_hier`'s (D113556114) rail leg. Those 64 CTAs then
do 0-byte NVLink work every step (self-copy + `nLocalRanks-1` zero copies),
captured in the graph -- the opposite of the intended "1SM A2AV".

This broadens the existing ppn=1 fast path: when no same-node peer other than
self carries data, the kernel's send/recv loops are empty, so we take the proven
ppn=1 stub -- self D2D copy via `icopy`, null `sendElemsList`/`recvElemsList`,
1 block / 1 thread -- and let the GPE thread drive the IB peers. The kernel's
no-work guard then fires and only GPE sync remains, freeing SMs for overlapping
compute. Strict improvement for the sparse (rail) case; no-op for the dense case
(a local peer has data -> `hasLocalPeerWork` -> unchanged static grid).

The stub + "IB handled by GPE" combination is exactly the ppn=1 path that
already ships and is exercised whenever ppn=1, so this reuses a tested code path.
The grid is chosen at CUDA-graph capture time; `a2a_hier`'s FSDP sharding is
fixed across replays, so the per-peer zero/nonzero pattern is stable (consistent
with the existing `selfBytes > 0` self-copy gate, which is also decided at
capture).

Reviewed By: minsii

Differential Revision: D113686405


