### PR TITLE
Package the c10d backend for out-of-tree use (#3296)

### DIFF
--- a/comms/torchcomms/cmake/third_party/glog.cmake
+++ b/comms/torchcomms/cmake/third_party/glog.cmake
@@ -26,16 +26,45 @@ if(EXISTS "${CONDA_INCLUDE}/glog/logging.h")
     set_target_properties(glog::glog_headers PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES "${CONDA_INCLUDE}"
     )
+    set(_glog_defs)
+    if(EXISTS "${CONDA_INCLUDE}/glog/export.h")
+        list(APPEND _glog_defs GLOG_USE_GLOG_EXPORT)
+    endif()
+    file(STRINGS "${CONDA_INCLUDE}/glog/logging.h" _glog_public_init
+        REGEX "bool[ \t]+IsGoogleLoggingInitialized\\(\\)")
+    if(_glog_public_init)
+        list(APPEND _glog_defs TORCHCOMMS_GLOG_HAS_PUBLIC_INIT_CHECK)
+    endif()
+    if(_glog_defs)
+        set_target_properties(glog::glog PROPERTIES
+            INTERFACE_COMPILE_DEFINITIONS "${_glog_defs}")
+        set_target_properties(glog::glog_headers PROPERTIES
+            INTERFACE_COMPILE_DEFINITIONS "${_glog_defs}")
+    endif()
     message(STATUS "Using glog: ${_GLOG_LIB}")
 else()
     find_package(glog 0.4.0 QUIET CONFIG NO_CMAKE_PACKAGE_REGISTRY)
     if(glog_FOUND)
         message(STATUS "Found system glog: ${glog_VERSION}")
         get_target_property(_glog_inc glog::glog INTERFACE_INCLUDE_DIRECTORIES)
+        get_target_property(_glog_defs glog::glog INTERFACE_COMPILE_DEFINITIONS)
+        if(NOT _glog_defs OR _glog_defs MATCHES "-NOTFOUND$")
+            set(_glog_defs)
+        endif()
+        if(glog_VERSION VERSION_GREATER_EQUAL "0.6.0")
+            set_property(TARGET glog::glog APPEND PROPERTY
+                INTERFACE_COMPILE_DEFINITIONS
+                TORCHCOMMS_GLOG_HAS_PUBLIC_INIT_CHECK)
+            list(APPEND _glog_defs TORCHCOMMS_GLOG_HAS_PUBLIC_INIT_CHECK)
+        endif()
         add_library(glog::glog_headers INTERFACE IMPORTED GLOBAL)
         set_target_properties(glog::glog_headers PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES "${_glog_inc}"
         )
+        if(_glog_defs AND NOT _glog_defs MATCHES "-NOTFOUND$")
+            set_target_properties(glog::glog_headers PROPERTIES
+                INTERFACE_COMPILE_DEFINITIONS "${_glog_defs}")
+        endif()
     else()
         message(STATUS "System glog not found, fetching v0.4.0 via FetchContent")
         include(FetchContent)

--- a/comms/torchcomms/utils/Logging.hpp
+++ b/comms/torchcomms/utils/Logging.hpp
@@ -33,20 +33,24 @@ inline std::string getRankPrefix(torch::comms::TorchCommBackend* comm) {
       TC_LOG_WITH_PREFIX_BUILDER(__VA_ARGS__), \
       TC_LOG_WITH_PREFIX_BUILDER(__VA_ARGS__, getDefaultCommunicator()))
 
-// Google glog's api does not have an external function that allows one to check
-// if glog is initialized or not. It does have an internal function - so we are
-// declaring it here. This is a hack but has been used by a bunch of others too
-// (e.g. Torch).
-// Copied from https://fburl.com/code/tu9hg6gf
+#if !defined(TORCHCOMMS_GLOG_HAS_PUBLIC_INIT_CHECK)
+// Older glog releases expose the initialization check only through this
+// internal symbol.
 namespace google::glog_internal_namespace_ {
 bool IsGoogleLoggingInitialized();
 } // namespace google::glog_internal_namespace_
+#endif
 
 namespace {
 
 [[maybe_unused]] void tryTorchCommLoggingInit(std::string_view name) {
-  // This trick can only be used on UNIX platforms
-  if (!::google::glog_internal_namespace_::IsGoogleLoggingInitialized()) {
+#if defined(TORCHCOMMS_GLOG_HAS_PUBLIC_INIT_CHECK)
+  const bool initialized = ::google::IsGoogleLoggingInitialized();
+#else
+  const bool initialized =
+      ::google::glog_internal_namespace_::IsGoogleLoggingInitialized();
+#endif
+  if (!initialized) {
     ::google::InitGoogleLogging(name.data());
     // This will trigger a kernel panic on GB200 NVIDIA driver
     // temporarily disable signal handler until NVIDIA releases the new driver


### PR DESCRIPTION
Summary:

## Context

- The world-group c10d adapter exists in the internal source layout, but the standalone MCCL artifact does not install its registrar or publish c10d discovery metadata.
- Existing staging and projection place native bindings differently from CMake, can collect unrelated Python packages, and can retain the obsolete binding location in a reused OSS tree.
- Source-present prims and TCP device-memory support are auto-enabled even though the initial package only requires classic CTRAN all-reduce, pulling advanced transport dependencies into the minimal artifact.
- Supported package environments carry different Boost and glog configurations, so relying on a removed Boost library or one glog initialization API breaks otherwise compatible builds.

## Solution

- Package one flat registrar and its type stub, declare direct PyTorch and TorchComms dependencies, and publish distinct TorchComms and c10d entry points. Validate the installed artifact with the installation interpreter, using explicit discovery on PyTorch 2.13 and automatic discovery on PyTorch 2.14 and newer.
- Project native binding sources at the CMake-consumed path, place the registrar at the package root, and remove the obsolete projection destination. This keeps the Python package narrow while making repeated source projection deterministic.
- Default wheel builds to generic OSS mode with prims and TCP device memory disabled, while preserving standard CMake boolean opt-ins. These are wheel-specific defaults; direct CMake builds retain their existing feature defaults.
- Make explicit TCP device-memory configuration authoritative, request only the Boost components that are linked, and select the public or legacy glog initialization check from the header actually used by the compiler.
- Keep runtime requirements broad in this packaging slice. Exact ABI binding, reproducibility, and native dependency bundling remain separate prerequisites before publishing portable wheels.

Differential Revision: D113593444


