### PR TITLE
folly::format -> fmt::format in comms

### DIFF
--- a/comms/utils/logger/tests/FormatterUT.cc
+++ b/comms/utils/logger/tests/FormatterUT.cc
@@ -98,7 +98,7 @@ TEST(GlogFormatter, log) {
   constexpr std::string_view kPrefix = "NCCL";
 
   // Test a very simple single-line log message
-  auto expected = folly::sformat(
+  auto expected = fmt::format(
       "W0417 13:45:56.123456 {:5d} myfile.cpp:1234] {}:{}:{} [{}][{}] {} WARN hello world\n",
       tid,
       hostname,
@@ -122,7 +122,7 @@ TEST(GlogFormatter, logThreadName) {
 
   meta::comms::logger::initThreadMetaData(kThreadName);
   // Test a very simple single-line log message
-  auto expected = folly::sformat(
+  auto expected = fmt::format(
       "W0417 13:45:56.123456 {:5d} myfile.cpp:1234] {}:{}:{} [{}][{}] {} WARN hello world\n",
       tid,
       hostname,
@@ -165,7 +165,7 @@ TEST(GlogFormatter, logThreadNameChanged) {
     });
     thread.join();
     // Test a very simple single-line log message
-    auto expected = folly::sformat(
+    auto expected = fmt::format(
         "W0417 13:45:56.123456 {:5d} myfile.cpp:1234] {}:{}:{} [{}][{}] {} WARN hello world\n",
         otherThreadID,
         hostname,


### PR DESCRIPTION
Summary:
Mechanical migration of `folly::sformat(...)` call sites to `fmt::format(...)`
(adding `#include <fmt/format.h>` where needed) in `comms`.

`folly::sformat` and `fmt::format` share identical format-string syntax, so this
is a semantically-equivalent, token-level rewrite produced by the
`folly-to-fmt-format` clang codemod, run via the migration farm in
`fbcode/scripts/rbarnes/folly_to_fmt` (D112466250). Part of the fbcode-wide
`folly::format` -> `fmt::format` migration.

This diff covers 7 file(s).

Differential Revision: D113288039


