### PR TITLE
Add net flush after recv in AllToAll IB algos

### DIFF
--- a/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
@@ -235,6 +235,13 @@ commResult_t ctranAllToAllPIbImpl(
       ibPutReqs, useProfiler ? (&timestamp->putComplete) : nullptr));
   // Wait for all receives (i.e., remote IB puts) to complete
   FB_COMMCHECK(comm->ctran_->mapper->waitAllNotifies<PerfConfig>(notifyVec));
+  // Flush received RDMA writes into recvbuff once all peers' data has arrived,
+  // so GPU copy engines/kernels observe it. No-op unless local flush is enabled
+  // (e.g. GB300, pre-H100 arch, or NCCL_CTRAN_NET_FORCE_FLUSH).
+  if (!ibRecvPeers.empty()) {
+    FB_COMMCHECK(
+        comm->ctran_->mapper->flush<PerfConfig>(recvbuff, pArgs->recvHdl));
+  }
 
   if (useProfiler) {
     comm->ctran_->mapper->timestamps.emplace_back(std::move(timestamp));

--- a/comms/ctran/algos/AllToAll/AllToAllvImpl.h
+++ b/comms/ctran/algos/AllToAll/AllToAllvImpl.h
@@ -83,7 +83,7 @@ commResult_t ctranAllToAllvIbImpl(
   std::vector<struct CtranMapperRemoteAccessKey> remoteAccessKeys(nRanks);
 
   std::vector<void*> sendMemHdl(nRanks);
-  std::vector<void*> recvMemHdl(nRanks);
+  void* recvMemHdl = nullptr;
   std::vector<void*> tmpRegHdls;
 
   std::vector<int> ibRecvPeers, ibSendPeers;
@@ -162,7 +162,7 @@ commResult_t ctranAllToAllvIbImpl(
         comm,
         recvbuff,
         contigRecvBufSize * commTypeSize(datatype),
-        tmpHdl,
+        recvMemHdl,
         tmpRegHdls));
 
     CTRAN_PROFILER_IF(
@@ -173,7 +173,11 @@ commResult_t ctranAllToAllvIbImpl(
       profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
 
   FB_COMMCHECK(comm->ctran_->mapper->isendCtrlBatch<PerfConfig>(
-      recvBuffs, tmpHdl, ibRecvPeers, ibSendCtrlReqs, CtranMapperBackend::IB));
+      recvBuffs,
+      recvMemHdl,
+      ibRecvPeers,
+      ibSendCtrlReqs,
+      CtranMapperBackend::IB));
   FB_COMMCHECK(comm->ctran_->mapper->initNotifyBatchIB(ibRecvPeers, notifyVec));
 
   tmpHdl = nullptr;
@@ -261,6 +265,12 @@ commResult_t ctranAllToAllvIbImpl(
       ibPutReqs, useProfiler ? (&timestamp->putComplete) : nullptr));
   // Wait for all receives (i.e., remote IB puts) to complete
   FB_COMMCHECK(comm->ctran_->mapper->waitAllNotifies<PerfConfig>(notifyVec));
+  // Flush received RDMA writes into recvbuff once all peers' data has arrived,
+  // so GPU copy engines/kernels observe it. No-op unless local flush is enabled
+  // (e.g. GB300, pre-H100 arch, or NCCL_CTRAN_NET_FORCE_FLUSH).
+  if (!ibRecvPeers.empty()) {
+    FB_COMMCHECK(comm->ctran_->mapper->flush<PerfConfig>(recvbuff, recvMemHdl));
+  }
 
   CTRAN_PROFILER_IF(
       profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));

--- a/comms/ctran/backends/ib/CtranIbLocalVc.cc
+++ b/comms/ctran/backends/ib/CtranIbLocalVc.cc
@@ -123,8 +123,7 @@ commResult_t LocalVirtualConn::iflush(
     ibverbx::ibv_send_wr* bad_wr{nullptr};
     auto maybeSend = ibvQps_[device].postSend(&wr, &bad_wr);
     FOLLY_EXPECTED_CHECK(maybeSend);
-    CLOGF_SUBSYS(
-        DBG,
+    CLOGF_TRACE(
         COLL,
         "CTRAN-IB: posted flush on qpn {}, req {}",
         ibvQps_[device].qp()->qp_num,


### PR DESCRIPTION
Summary:
Add a network flush of the receive buffer after the GPE host thread has received data from all peers in the CTRAN AllToAll IB host paths, so pending RDMA writes are drained into the recv buffer before GPU copy engines/kernels read it. This mirrors the existing pattern in `AllGatherP/PipelineImpl.cc` and `AllReduce/AllReduceDirect.cc`:
- `ctranAllToAllvIbImpl` (`AllToAllvImpl.h`): covers both AllToAll and AllToAllv; issue `flush<PerfConfig>(recvbuff, recvMemHdl)` right after `waitAllNotifies`, guarded by `!ibRecvPeers.empty()`. Repurpose the previously-unused `recvMemHdl` local to hold the recv-buffer registration handle (the recv `searchRegHandle` and `isendCtrlBatch` now write/read it) instead of letting the recv handle be clobbered when `tmpHdl` is reused for the send buffer.
- `ctranAllToAllPIbImpl` (`AllToAllPImpl.cc`): covers AllToAllP and AllToAllCtwin (which dispatches through `AllToAllPExec`); issue `flush<PerfConfig>(recvbuff, pArgs->recvHdl)` after `waitAllNotifies`, guarded by `!ibRecvPeers.empty()`.
- No call-site gating is needed: the flush is a no-op unless local flush is enabled inside `CtranIb::iflush` (GB300, pre-H100 arch, or `NCCL_CTRAN_NET_FORCE_FLUSH`).

Differential Revision: D113722298


