### PR TITLE
Plumb per-algo IB config into AllToAllP (ctgraph)

### DIFF
--- a/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
@@ -200,6 +200,15 @@ commResult_t ctranAllToAllPIbImpl(
         tmpRegHdls));
   }
 
+  // Per-collective IB QP config override from NCCL_CTRAN_IB_QP_CONFIG_ALGO;
+  // cached once per thread since the parsed map lives on CtranAlgo for the
+  // comm's lifetime. Nullptr means fall back to the VC's default config.
+  static thread_local auto alltoallpIbConfig =
+      comm->ctran_->algo->getCollToVcConfig(CollType::ALLTOALL);
+  const size_t qpScalingTh = alltoallpIbConfig
+      ? alltoallpIbConfig->qpScalingTh
+      : NCCL_CTRAN_IB_QP_SCALING_THRESHOLD;
+
   std::vector<CtranMapperRequest> ibPutReqs(ibSendPeers.size());
   int idx = 0;
   // Issue network puts using provided remote recvbuff handles
@@ -208,12 +217,8 @@ commResult_t ctranAllToAllPIbImpl(
       timestamp->recvCtrl.push_back(CtranMapperTimestampPoint(peer));
     }
     auto sendSize = sendCounts[peer] * commTypeSize(datatype);
-    // FIXME: we should compare sendSize with real maxWqeSize:
-    // NCCL_CTRAN_IB_QP_SCALING_THRESHOLD may not be maxWqeSize if user
-    // specified NCCL_CTRAN_IB_QP_CONFIG_ALGO to overwrite qp_scaling_threshold
-    // for certain algo.
     bool enableFastPath = NCCL_CTRAN_ENABLE_PUT_FAST_PATH_FOR_SMALL_MSGS &&
-        (sendSize <= NCCL_CTRAN_IB_QP_SCALING_THRESHOLD);
+        (sendSize <= qpScalingTh);
     FB_COMMCHECK(comm->ctran_->mapper->iput<PerfConfig>(
         sendBuffs[peer],
         remoteRecvBuffs[peer],
@@ -223,6 +228,7 @@ commResult_t ctranAllToAllPIbImpl(
             .memHdl_ = sendMemHdl,
             .remoteAccessKey_ = pArgs->remoteAccessKeys[peer],
             .notify_ = true /*notify*/,
+            .ibConfig_ = alltoallpIbConfig,
             .ibFastPath_ = enableFastPath},
         &ibPutReqs[idx++]));
     if (useProfiler) {

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphAllToAllPCtgraphTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphAllToAllPCtgraphTest.cc
@@ -304,6 +304,96 @@ TEST_F(CtranCudaGraphTestBase, CtgraphUncachedRecvbufFailsCleanly) {
   ASSERT_EQ(cudaFree(recvbuf), cudaSuccess);
 }
 
+// Regression coverage for the per-collective IB QP config plumbing on the
+// ctgraph AllToAll path. Before the fix, ctranAllToAllPIbImpl silently dropped
+// NCCL_CTRAN_IB_QP_CONFIG_ALGO="alltoall:..." and fell back to the process
+// global CVAR defaults; the plain-map assertion in ctranAllToAllvIbTest cannot
+// catch that. This test seeds the override before comm construction so the
+// config lives on the freshly-built CtranAlgo, then runs a full
+// capture/instantiate/launch of the ctgraph AllToAll end-to-end and verifies
+// (a) the graph produces the correct transpose and (b) the per-collective
+// config was actually parsed onto the comm.
+class CudaGraphAllToAllPCtgraphIbConfig : public CtranCudaGraphTestBase {
+ protected:
+  void SetUp() override {
+    // Route env-var setup through the fixture helper so TearDown restores the
+    // original value; ncclCvarInit() runs before the base SetUp, so the fresh
+    // CtranAlgo constructed inside makeCtranComm() sees the override.
+    CtranDistTestFixture::SetUp(
+        ctran::CtranEnvs{
+            {"NCCL_CTRAN_IB_QP_CONFIG_ALGO", "alltoall:131072,1,dqplb,8,192"},
+        });
+  }
+};
+
+TEST_F(CudaGraphAllToAllPCtgraphIbConfig, CtgraphHonorsAllToAllIbConfig) {
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  const size_t count = kDefaultCount;
+  const int nRanks = numRanks;
+
+  meta::comms::CudaStream stream(cudaStreamNonBlocking);
+  ctran::TestDeviceBuffer send(count * nRanks * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(count * nRanks * sizeof(int32_t));
+  fillAllToAllSendBuf(send.get(), count, globalRank, nRanks);
+
+  ScopedRecvBufReg recvReg(recv.get(), count * nRanks * sizeof(int32_t));
+
+  cudaGraph_t graph;
+  cudaGraphExec_t exec;
+  ASSERT_EQ(
+      cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  if (!ctranAllToAllSupport(
+          count,
+          commInt32,
+          comm.get(),
+          NCCL_ALLTOALL_ALGO::ctgraph,
+          stream.get())) {
+    cudaGraph_t skipped = nullptr;
+    cudaStreamEndCapture(stream.get(), &skipped);
+    if (skipped != nullptr) {
+      cudaGraphDestroy(skipped);
+    }
+    GTEST_SKIP() << "AllToAllP ctgraph not supported";
+  }
+  ASSERT_EQ(
+      ctranAllToAll(
+          send.get(),
+          recv.get(),
+          count,
+          commInt32,
+          comm.get(),
+          stream.get(),
+          NCCL_ALLTOALL_ALGO::ctgraph),
+      commSuccess);
+  ASSERT_EQ(cudaStreamEndCapture(stream.get(), &graph), cudaSuccess);
+  ASSERT_EQ(cudaGraphInstantiate(&exec, graph, 0), cudaSuccess);
+
+  ASSERT_EQ(cudaGraphLaunch(exec, stream.get()), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  verifyAllToAllTranspose(recv.get(), count, globalRank, nRanks);
+
+  // Confirm the override reached CtranAlgo. Values must match the seeded env
+  // string "alltoall:131072,1,dqplb,8,192".
+  ASSERT_NE(comm->ctran_, nullptr);
+  ASSERT_NE(comm->ctran_->algo, nullptr);
+  const CtranIbConfig* ibConfig =
+      comm->ctran_->algo->getCollToVcConfig(CollType::ALLTOALL);
+  ASSERT_NE(ibConfig, nullptr)
+      << "NCCL_CTRAN_IB_QP_CONFIG_ALGO override did not land on CtranAlgo";
+  EXPECT_EQ(ibConfig->qpScalingTh, 131072u);
+  EXPECT_EQ(ibConfig->numQps, 1);
+  EXPECT_EQ(ibConfig->vcMode, NCCL_CTRAN_IB_VC_MODE::dqplb);
+  EXPECT_EQ(ibConfig->qpMsgs, 8);
+
+  ASSERT_EQ(cudaGraphExecDestroy(exec), cudaSuccess);
+  ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new CtranCudaGraphEnvironment);


### PR DESCRIPTION
Summary:
`NCCL_CTRAN_IB_QP_CONFIG_ALGO="alltoall:..."` was silently dropped on the
ctgraph AllToAll path. The plain `ctran` variant (via `AllToAllvImpl.h`)
caches `CtranAlgo::getCollToVcConfig(CollType::ALLTOALL)` and plants it in
`CtranMapperConfig::ibConfig_` on every `iput`, so the IB backend honors
the per-collective QP/VC override via `getOpQps` / `getOpVcMode` /
`getOpMaxQpMsgs` / `getOpScalingTh` (`CtranIbVc.h:657-676`). The ctgraph
path routes through `AllToAllPImpl.cc::ctranAllToAllPIbImpl`, which built
a `CtranMapperConfig{}` without setting `ibConfig_` — so the override
never reached the wire and the process-global CVAR defaults were used
instead.

This diff mirrors the `AllToAllvImpl.h:206-207,247-252` idiom in
`ctranAllToAllPIbImpl`: cache the config in a `static thread_local`,
plumb `.ibConfig_ = alltoallpIbConfig` into the mapper config, and drive
`enableFastPath` off the resolved `qpScalingTh` (which resolves the FIXME
on the old lines 211-214 — the fast-path threshold check now honors the
per-collective override).

`ctwin` also runs through `ctranAllToAllPIbImpl` (via `AlgoImpl::exec` ->
`gpeFn` -> `RETURN_ALLTOALLP_IB_IMPL`), so the same edit closes the
identical gap there — intentional and desirable.

Differential Revision: D113720128


