### PR TITLE
Instrument AllToAllP with Scuba profiler events

### DIFF
--- a/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
@@ -200,6 +200,15 @@ commResult_t ctranAllToAllPIbImpl(
         tmpRegHdls));
   }
 
+  // Per-collective IB QP config override from NCCL_CTRAN_IB_QP_CONFIG_ALGO;
+  // cached once per thread since the parsed map lives on CtranAlgo for the
+  // comm's lifetime. Nullptr means fall back to the VC's default config.
+  static thread_local auto alltoallpIbConfig =
+      comm->ctran_->algo->getCollToVcConfig(CollType::ALLTOALL);
+  const size_t qpScalingTh = alltoallpIbConfig
+      ? alltoallpIbConfig->qpScalingTh
+      : NCCL_CTRAN_IB_QP_SCALING_THRESHOLD;
+
   std::vector<CtranMapperRequest> ibPutReqs(ibSendPeers.size());
   int idx = 0;
   // Issue network puts using provided remote recvbuff handles
@@ -208,12 +217,8 @@ commResult_t ctranAllToAllPIbImpl(
       timestamp->recvCtrl.push_back(CtranMapperTimestampPoint(peer));
     }
     auto sendSize = sendCounts[peer] * commTypeSize(datatype);
-    // FIXME: we should compare sendSize with real maxWqeSize:
-    // NCCL_CTRAN_IB_QP_SCALING_THRESHOLD may not be maxWqeSize if user
-    // specified NCCL_CTRAN_IB_QP_CONFIG_ALGO to overwrite qp_scaling_threshold
-    // for certain algo.
     bool enableFastPath = NCCL_CTRAN_ENABLE_PUT_FAST_PATH_FOR_SMALL_MSGS &&
-        (sendSize <= NCCL_CTRAN_IB_QP_SCALING_THRESHOLD);
+        (sendSize <= qpScalingTh);
     FB_COMMCHECK(comm->ctran_->mapper->iput<PerfConfig>(
         sendBuffs[peer],
         remoteRecvBuffs[peer],
@@ -223,6 +228,7 @@ commResult_t ctranAllToAllPIbImpl(
             .memHdl_ = sendMemHdl,
             .remoteAccessKey_ = pArgs->remoteAccessKeys[peer],
             .notify_ = true /*notify*/,
+            .ibConfig_ = alltoallpIbConfig,
             .ibFastPath_ = enableFastPath},
         &ibPutReqs[idx++]));
     if (useProfiler) {

--- a/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
@@ -8,6 +8,7 @@
 #include "comms/ctran/algos/PersistentCleanup.h"
 #include "comms/ctran/algos/common/NvlUtils.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/regcache/IpcRegCache.h"
 #include "comms/ctran/regcache/RegCache.h"
 #include "comms/ctran/utils/CtranPerf.h"
@@ -34,6 +35,7 @@ using ctran::alltoallp::PersistArgs;
       counts,                                \
       displs,                                \
       pArgs->datatype,                       \
+      op->opCount,                           \
       comm,                                  \
       std::move(timestamp),                  \
       pArgs);
@@ -104,6 +106,7 @@ commResult_t ctranAllToAllPIbImpl(
     std::vector<size_t>& recvCounts,
     std::vector<size_t>& rDispls,
     commDataType_t datatype,
+    uint64_t opCount,
     CtranComm* comm,
     std::unique_ptr<CtranMapperTimestamp> timestamp,
     ctran::alltoallp::PersistArgs* pArgs) {
@@ -113,6 +116,12 @@ commResult_t ctranAllToAllPIbImpl(
 
   const std::string algoName = AlgoImpl::algoName(myAlgo);
   const bool useProfiler = NCCL_CTRAN_PROFILING != NCCL_CTRAN_PROFILING::none;
+
+  ctran::Profiler* profiler = comm->ctran_->profiler.get();
+  if (profiler) {
+    profiler->initForEachColl(
+        opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+  }
 
   std::vector<const void*> sendBuffs(nRanks);
 
@@ -133,6 +142,13 @@ commResult_t ctranAllToAllPIbImpl(
     }
     CtranMapperContext context(algoName, sendSizes, recvSizes);
     comm->ctran_->mapper->setContext(std::move(context));
+
+    CTRAN_PROFILER_IF(profiler, {
+      auto& algoContext = profiler->algoContext;
+      algoContext.algorithmName = algoName;
+      algoContext.sendContext.messageSizes = folly::join(',', sendSizes);
+      algoContext.recvContext.messageSizes = folly::join(',', recvSizes);
+    });
   }
 
   // Prepare buffers shifted with displacement, and set ctrl/put/notify
@@ -169,11 +185,15 @@ commResult_t ctranAllToAllPIbImpl(
   //     ensure remote buffer is ready to be updated (e.g., double buffering).
   bool doHandshake = !pArgs->skipCtrlMsg || !pArgs->ibKeysExchanged;
   if (doHandshake) {
+    CTRAN_PROFILER_IF(
+        profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
     FB_COMMCHECK(ibHandshake(
         comm->ctran_->mapper.get(),
         statex.get(),
         pArgs,
         !pArgs->ibKeysExchanged));
+    CTRAN_PROFILER_IF(
+        profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
   }
   pArgs->ibKeysExchanged = true;
 
@@ -191,6 +211,8 @@ commResult_t ctranAllToAllPIbImpl(
   // Search for the handle only when there are SendPeers to avoid attempting to
   // search/register with a buffer size of 0.
   if (!ibSendPeers.empty()) {
+    CTRAN_PROFILER_IF(
+        profiler, profiler->startEvent(ctran::ProfilerEvent::BUF_REG));
     // TODO: move this to main thread before submitting to GPE
     FB_COMMCHECK(searchRegHandle(
         comm,
@@ -198,6 +220,8 @@ commResult_t ctranAllToAllPIbImpl(
         contigSendBufSize * commTypeSize(datatype),
         sendMemHdl,
         tmpRegHdls));
+    CTRAN_PROFILER_IF(
+        profiler, profiler->endEvent(ctran::ProfilerEvent::BUF_REG));
   }
 
   // Per-collective IB QP config override from NCCL_CTRAN_IB_QP_CONFIG_ALGO;
@@ -208,6 +232,9 @@ commResult_t ctranAllToAllPIbImpl(
   const size_t qpScalingTh = alltoallpIbConfig
       ? alltoallpIbConfig->qpScalingTh
       : NCCL_CTRAN_IB_QP_SCALING_THRESHOLD;
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
 
   std::vector<CtranMapperRequest> ibPutReqs(ibSendPeers.size());
   int idx = 0;
@@ -241,6 +268,11 @@ commResult_t ctranAllToAllPIbImpl(
       ibPutReqs, useProfiler ? (&timestamp->putComplete) : nullptr));
   // Wait for all receives (i.e., remote IB puts) to complete
   FB_COMMCHECK(comm->ctran_->mapper->waitAllNotifies<PerfConfig>(notifyVec));
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
+
+  CTRAN_PROFILER_IF(profiler, { profiler->reportToScuba(); });
 
   if (useProfiler) {
     comm->ctran_->mapper->timestamps.emplace_back(std::move(timestamp));

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphAllToAllPCtgraphTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphAllToAllPCtgraphTest.cc
@@ -304,6 +304,96 @@ TEST_F(CtranCudaGraphTestBase, CtgraphUncachedRecvbufFailsCleanly) {
   ASSERT_EQ(cudaFree(recvbuf), cudaSuccess);
 }
 
+// Regression coverage for the per-collective IB QP config plumbing on the
+// ctgraph AllToAll path. Before the fix, ctranAllToAllPIbImpl silently dropped
+// NCCL_CTRAN_IB_QP_CONFIG_ALGO="alltoall:..." and fell back to the process
+// global CVAR defaults; the plain-map assertion in ctranAllToAllvIbTest cannot
+// catch that. This test seeds the override before comm construction so the
+// config lives on the freshly-built CtranAlgo, then runs a full
+// capture/instantiate/launch of the ctgraph AllToAll end-to-end and verifies
+// (a) the graph produces the correct transpose and (b) the per-collective
+// config was actually parsed onto the comm.
+class CudaGraphAllToAllPCtgraphIbConfig : public CtranCudaGraphTestBase {
+ protected:
+  void SetUp() override {
+    // Route env-var setup through the fixture helper so TearDown restores the
+    // original value; ncclCvarInit() runs before the base SetUp, so the fresh
+    // CtranAlgo constructed inside makeCtranComm() sees the override.
+    CtranDistTestFixture::SetUp(
+        ctran::CtranEnvs{
+            {"NCCL_CTRAN_IB_QP_CONFIG_ALGO", "alltoall:131072,1,dqplb,8,192"},
+        });
+  }
+};
+
+TEST_F(CudaGraphAllToAllPCtgraphIbConfig, CtgraphHonorsAllToAllIbConfig) {
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  const size_t count = kDefaultCount;
+  const int nRanks = numRanks;
+
+  meta::comms::CudaStream stream(cudaStreamNonBlocking);
+  ctran::TestDeviceBuffer send(count * nRanks * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(count * nRanks * sizeof(int32_t));
+  fillAllToAllSendBuf(send.get(), count, globalRank, nRanks);
+
+  ScopedRecvBufReg recvReg(recv.get(), count * nRanks * sizeof(int32_t));
+
+  cudaGraph_t graph;
+  cudaGraphExec_t exec;
+  ASSERT_EQ(
+      cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  if (!ctranAllToAllSupport(
+          count,
+          commInt32,
+          comm.get(),
+          NCCL_ALLTOALL_ALGO::ctgraph,
+          stream.get())) {
+    cudaGraph_t skipped = nullptr;
+    cudaStreamEndCapture(stream.get(), &skipped);
+    if (skipped != nullptr) {
+      cudaGraphDestroy(skipped);
+    }
+    GTEST_SKIP() << "AllToAllP ctgraph not supported";
+  }
+  ASSERT_EQ(
+      ctranAllToAll(
+          send.get(),
+          recv.get(),
+          count,
+          commInt32,
+          comm.get(),
+          stream.get(),
+          NCCL_ALLTOALL_ALGO::ctgraph),
+      commSuccess);
+  ASSERT_EQ(cudaStreamEndCapture(stream.get(), &graph), cudaSuccess);
+  ASSERT_EQ(cudaGraphInstantiate(&exec, graph, 0), cudaSuccess);
+
+  ASSERT_EQ(cudaGraphLaunch(exec, stream.get()), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  verifyAllToAllTranspose(recv.get(), count, globalRank, nRanks);
+
+  // Confirm the override reached CtranAlgo. Values must match the seeded env
+  // string "alltoall:131072,1,dqplb,8,192".
+  ASSERT_NE(comm->ctran_, nullptr);
+  ASSERT_NE(comm->ctran_->algo, nullptr);
+  const CtranIbConfig* ibConfig =
+      comm->ctran_->algo->getCollToVcConfig(CollType::ALLTOALL);
+  ASSERT_NE(ibConfig, nullptr)
+      << "NCCL_CTRAN_IB_QP_CONFIG_ALGO override did not land on CtranAlgo";
+  EXPECT_EQ(ibConfig->qpScalingTh, 131072u);
+  EXPECT_EQ(ibConfig->numQps, 1);
+  EXPECT_EQ(ibConfig->vcMode, NCCL_CTRAN_IB_VC_MODE::dqplb);
+  EXPECT_EQ(ibConfig->qpMsgs, 8);
+
+  ASSERT_EQ(cudaGraphExecDestroy(exec), cudaSuccess);
+  ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new CtranCudaGraphEnvironment);

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphAllToAllPCtgraphTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphAllToAllPCtgraphTest.cc
@@ -10,6 +10,7 @@
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/algos/AllToAll/AllToAllImpl.h"
 #include "comms/ctran/algos/AllToAll/AllToAllvImpl.h"
+#include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/regcache/RegCache.h"
 #include "comms/ctran/tests/cudagraph/CtranCudaGraphParamTest.h"
 
@@ -388,6 +389,111 @@ TEST_F(CudaGraphAllToAllPCtgraphIbConfig, CtgraphHonorsAllToAllIbConfig) {
   EXPECT_EQ(ibConfig->numQps, 1);
   EXPECT_EQ(ibConfig->vcMode, NCCL_CTRAN_IB_VC_MODE::dqplb);
   EXPECT_EQ(ibConfig->qpMsgs, 8);
+
+  ASSERT_EQ(cudaGraphExecDestroy(exec), cudaSuccess);
+  ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+}
+
+// Verifies the ctgraph AllToAllP path actually feeds the ctran::Profiler
+// (whose reporter writes to the `nccl_profiler_algo` Scuba table). Without
+// this, the instrumentation added in `ctranAllToAllPIbImpl` would compile
+// but silently no-op — the default test env sets
+// NCCL_CTRAN_TRANSPORT_PROFILER=false, so `comm->ctran_->profiler` is
+// nullptr and every CTRAN_PROFILER_IF block skips. This fixture flips both
+// knobs so the profiler is constructed AND every collective is traced,
+// then reads the accumulated profiler state after the graph replays.
+class CudaGraphAllToAllPCtgraphProfilerScuba : public CtranCudaGraphTestBase {
+ protected:
+  void SetUp() override {
+    CtranDistTestFixture::SetUp(
+        ctran::CtranEnvs{
+            {"NCCL_CTRAN_TRANSPORT_PROFILER", "true"},
+            {"NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT", "1"},
+        });
+  }
+};
+
+TEST_F(
+    CudaGraphAllToAllPCtgraphProfilerScuba,
+    CtgraphInvokesAlgoProfilerReporter) {
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  const size_t count = kDefaultCount;
+  const int nRanks = numRanks;
+
+  meta::comms::CudaStream stream(cudaStreamNonBlocking);
+  ctran::TestDeviceBuffer send(count * nRanks * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(count * nRanks * sizeof(int32_t));
+  fillAllToAllSendBuf(send.get(), count, globalRank, nRanks);
+
+  ScopedRecvBufReg recvReg(recv.get(), count * nRanks * sizeof(int32_t));
+
+  cudaGraph_t graph;
+  cudaGraphExec_t exec;
+  ASSERT_EQ(
+      cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  if (!ctranAllToAllSupport(
+          count,
+          commInt32,
+          comm.get(),
+          NCCL_ALLTOALL_ALGO::ctgraph,
+          stream.get())) {
+    cudaGraph_t skipped = nullptr;
+    cudaStreamEndCapture(stream.get(), &skipped);
+    if (skipped != nullptr) {
+      cudaGraphDestroy(skipped);
+    }
+    GTEST_SKIP() << "AllToAllP ctgraph not supported";
+  }
+  ASSERT_EQ(
+      ctranAllToAll(
+          send.get(),
+          recv.get(),
+          count,
+          commInt32,
+          comm.get(),
+          stream.get(),
+          NCCL_ALLTOALL_ALGO::ctgraph),
+      commSuccess);
+  ASSERT_EQ(cudaStreamEndCapture(stream.get(), &graph), cudaSuccess);
+  ASSERT_EQ(cudaGraphInstantiate(&exec, graph, 0), cudaSuccess);
+
+  ASSERT_EQ(cudaGraphLaunch(exec, stream.get()), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  verifyAllToAllTranspose(recv.get(), count, globalRank, nRanks);
+
+  // `ctranAllToAllPIbImpl` (the file that holds the new instrumentation)
+  // only runs for inter-node peers. On single-node topologies the collective
+  // completes via the intra-node NVL path and never touches the profiler, so
+  // there's nothing to assert; skip on those configs and let the multi-node
+  // variants (e.g. `1x8_nolocal`) carry the coverage.
+  if (comm->statex_->nNodes() <= 1) {
+    GTEST_SKIP() << "Single-node topology skips ctranAllToAllPIbImpl";
+  }
+
+  ASSERT_NE(comm->ctran_, nullptr);
+  ASSERT_NE(comm->ctran_->profiler, nullptr)
+      << "Profiler must be constructed when NCCL_CTRAN_TRANSPORT_PROFILER=true";
+  auto* profiler = comm->ctran_->profiler.get();
+
+  // Post-condition set inside `ctranAllToAllPIbImpl`: on a traced collective
+  // the CTRAN_PROFILER_IF block populates the algo name. Distinguishes a real
+  // instrumented run from any incidental default state.
+  EXPECT_EQ(profiler->algoContext.algorithmName, "CtranAllToAllP")
+      << "Profiler algoContext must be populated by ctranAllToAllPIbImpl";
+
+  // `reportToScuba()` (called at the end of `ctranAllToAllPIbImpl`) ends the
+  // implicit ALGO_TOTAL event, so its duration is nonzero iff the reporter
+  // path actually ran end-to-end. This is the closest we can get in-test to
+  // "the report reached the Scuba pipeline" without mocking the reporter.
+  EXPECT_GT(profiler->getEventDurationUs(ctran::ProfilerEvent::ALGO_TOTAL), 0u)
+      << "reportToScuba must have run (ends ALGO_TOTAL event)";
+  EXPECT_GT(profiler->getEventDurationUs(ctran::ProfilerEvent::ALGO_DATA), 0u)
+      << "ALGO_DATA start/end must wrap the IB put loop";
 
   ASSERT_EQ(cudaGraphExecDestroy(exec), cudaSuccess);
   ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);


### PR DESCRIPTION
Summary:
`AllToAllP` collectives (ctgraph / ctwin / ctran-P) were not appearing in
the `nccl_profiler_algo` Scuba table because `ctranAllToAllPIbImpl` never
touched `ctran::Profiler` — only the plain `ctran` AllToAll (via
`AllToAllvImpl.h`) called `initForEachColl` / `startEvent` / `endEvent` /
`reportToScuba`. A2AP had a `useProfiler` flag but that only drove the
in-memory `CtranMapperTimestamp` (recvCtrl / putIssued / putComplete
points, distinct from the Scuba pipeline).

This diff ports the A2Av instrumentation pattern (`AllToAllvImpl.h:92-96,
110-115, 158-194, 172-234, 265-274`) to `AllToAllPImpl.cc`:

- Thread `op->opCount` from `gpeFn` down into `ctranAllToAllPIbImpl` via
  a new `uint64_t opCount` parameter and the `RETURN_ALLTOALLP_IB_IMPL`
  macro, so `initForEachColl` can key events on the right op.
- Grab `comm->ctran_->profiler` and call `initForEachColl(opCount,
  NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT)` at entry.
- Populate `profiler->algoContext` (algorithmName, sendContext /
  recvContext messageSizes) alongside the existing `CtranMapperContext`
  setup.
- Wrap the ctrl phase (`ibHandshake`) with `ALGO_CTRL` start / end.
- Wrap the sendbuf `searchRegHandle` with `BUF_REG` start / end.
- Wrap the put loop + `waitAllRequests` + `waitAllNotifies` with
  `ALGO_DATA` start / end.
- Call `profiler->reportToScuba()` after the data phase completes so the
  event lands in the `nccl_profiler_algo` Scuba table.

The existing `useProfiler` / `CtranMapperTimestamp` machinery is left
untouched — those two profilers cover different signals and coexist on
the A2Av path today.

Differential Revision: D113720306


