### PR TITLE
Migrate RCCL ROCm CI to the new MI350x meta-pytorch runner

### DIFF
--- a/.github/workflows/build_test_rccl.yaml
+++ b/.github/workflows/build_test_rccl.yaml
@@ -16,7 +16,8 @@ jobs:
       matrix:
         include:
           - name: RCCL
-            runs-on: amd-mi350-runner
+            # Migrated to the new MI350x meta-pytorch runner fleet.
+            runs-on: linux.rocm.gpu.meta-pytorch.mi350.1
             gpu-arch-type: "rocm"
             gpu-arch-version: "7.0"
             torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/rocm7.0'


### PR DESCRIPTION
## Summary

- Points the RCCL build job in `build_test_rccl.yaml` at the new MI350x meta-pytorch runner fleet: `linux.rocm.gpu.meta-pytorch.mi350.1` (was `amd-mi350-runner`).
- Part of migrating the meta-pytorch ecosystem ROCm CI onto the new MI350x cluster. The runner scale sets for these labels are provisioned by our infra.

**Draft** because the MI350x runners for the `meta-pytorch` org are not fully registered yet (pending the GitHub App / secret provisioning). Merging before the runners are online would strand this job with no runner to pick it up.

Note: single-GPU (`.mi350.1`) mirrors the prior single `amd-mi350-runner`. The fleet also exposes `.mi350.{2,4,8}` if the RCCL integration tests (currently commented out) are re-enabled and need multiple GPUs.

## Test plan

- [ ] After the new MI350x meta-pytorch runners are online, trigger the Build RCCL workflow and confirm the job lands on `linux.rocm.gpu.meta-pytorch.mi350.1` and builds green.

Made with Cursor