### PR TITLE
Add mlx5 direct-verbs surface for OOO_RQ (#3306)

### DIFF
--- a/comms/ctran/ibverbx/IbvPd.cc
+++ b/comms/ctran/ibverbx/IbvPd.cc
@@ -208,4 +208,47 @@ folly::Expected<IbvQp, Error> IbvPd::createDcQp(
   return IbvQp(qp, deviceId_);
 }
 
+folly::Expected<IbvQp, Error> IbvPd::createExtRcQpMlx5(
+    ibv_qp_init_attr_ex* initAttrEx,
+    mlx5dv_qp_init_attr* mlx5InitAttr) const {
+  if (initAttrEx == nullptr || mlx5InitAttr == nullptr) {
+    return folly::makeUnexpected(
+        Error(EINVAL, "createExtRcQpMlx5: null init attrs"));
+  }
+  if (initAttrEx->qp_type != IBV_QPT_RC) {
+    return folly::makeUnexpected(
+        Error(EINVAL, "createExtRcQpMlx5: only IBV_QPT_RC supported"));
+  }
+  if ((mlx5InitAttr->comp_mask & MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS) ==
+      0) {
+    return folly::makeUnexpected(Error(
+        EINVAL,
+        "createExtRcQpMlx5: MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS bit not "
+        "set in comp_mask — caller must advertise create_flags via comp_mask"));
+  }
+  if (mlx5InitAttr->create_flags == 0) {
+    return folly::makeUnexpected(Error(
+        EINVAL,
+        "createExtRcQpMlx5: create_flags is 0 — use plain createRcQp instead "
+        "of the mlx5dv path when no mlx5-specific flags are needed"));
+  }
+  if (!ibvSymbols.mlx5dv_internal_create_qp) {
+    return folly::makeUnexpected(
+        Error(ENOTSUP, "mlx5dv_create_qp not available"));
+  }
+
+  // mlx5dv_create_qp only honors initAttrEx->pd when IBV_QP_INIT_ATTR_PD is
+  // set in comp_mask. Set both together to avoid asymmetry that would let a
+  // caller who forgot the bit silently get a QP with an unexpected PD.
+  initAttrEx->pd = pd_;
+  initAttrEx->comp_mask |= IBV_QP_INIT_ATTR_PD;
+
+  ibv_qp* qp = ibvSymbols.mlx5dv_internal_create_qp(
+      pd_->context, initAttrEx, mlx5InitAttr);
+  if (!qp) {
+    return folly::makeUnexpected(Error(errno));
+  }
+  return IbvQp(qp, deviceId_);
+}
+
 } // namespace ibverbx

--- a/comms/ctran/ibverbx/IbvPd.h
+++ b/comms/ctran/ibverbx/IbvPd.h
@@ -73,6 +73,14 @@ class IbvPd {
       ibv_qp_init_attr_ex* initAttrEx,
       mlx5dv_qp_init_attr* mlx5InitAttr) const;
 
+  // Create an RC QP via mlx5dv_create_qp so mlx5 direct-verbs create-flags
+  // (e.g. MLX5DV_QP_CREATE_OOO_DP for out-of-order data placement) can be
+  // applied. Caller is responsible for building initAttrEx (IBV_QPT_RC, caps,
+  // etc.) and mlx5InitAttr (comp_mask, create_flags). See NCCL_IB_OOO_RQ.
+  folly::Expected<IbvQp, Error> createExtRcQpMlx5(
+      ibv_qp_init_attr_ex* initAttrEx,
+      mlx5dv_qp_init_attr* mlx5InitAttr) const;
+
  private:
   friend class IbvDevice;
 

--- a/comms/ctran/ibverbx/IbvQpUtils.cc
+++ b/comms/ctran/ibverbx/IbvQpUtils.cc
@@ -25,6 +25,42 @@ createRcQp(const IbvPd* ibvPd, ibv_cq* cq, int maxSendWr, int maxRecvWr) {
   return ibvPd->createQp(&initAttr);
 }
 
+folly::Expected<IbvQp, Error> createRcQpWithOooDp(
+    const IbvPd* ibvPd,
+    ibv_cq* cq,
+    int maxSendWr,
+    int maxRecvWr,
+    bool oooDp) {
+  // Fast path: when OOO_DP isn't needed, use the plain libibverbs create-QP
+  // path. Some deployments dynamically load libmlx5 (dlopen); if that failed
+  // silently the mlx5dv symbols are null, and forcing them through the
+  // mlx5dv_create_qp path would break every data-QP creation. Only opt in
+  // to the mlx5dv path when the caller actually needs OOO_DP.
+  if (!oooDp) {
+    return createRcQp(ibvPd, cq, maxSendWr, maxRecvWr);
+  }
+
+  ibv_qp_init_attr_ex initAttrEx;
+  memset(&initAttrEx, 0, sizeof(initAttrEx));
+  initAttrEx.send_cq = cq;
+  initAttrEx.recv_cq = cq;
+  initAttrEx.qp_type = IBV_QPT_RC;
+  initAttrEx.sq_sig_all = 0;
+  initAttrEx.cap.max_send_wr = maxSendWr;
+  initAttrEx.cap.max_recv_wr = maxRecvWr;
+  initAttrEx.cap.max_send_sge = 1;
+  initAttrEx.cap.max_recv_sge = 1;
+  initAttrEx.cap.max_inline_data = 16;
+  initAttrEx.comp_mask = IBV_QP_INIT_ATTR_PD;
+
+  mlx5dv_qp_init_attr mlx5InitAttr;
+  memset(&mlx5InitAttr, 0, sizeof(mlx5InitAttr));
+  mlx5InitAttr.comp_mask |= MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS;
+  mlx5InitAttr.create_flags |= MLX5DV_QP_CREATE_OOO_DP;
+
+  return ibvPd->createExtRcQpMlx5(&initAttrEx, &mlx5InitAttr);
+}
+
 folly::Expected<folly::Unit, Error>
 initQp(IbvQp& ibvQp, int port, int qp_access_flags) {
   ibv_qp_attr qpAttr;

--- a/comms/ctran/ibverbx/IbvQpUtils.h
+++ b/comms/ctran/ibverbx/IbvQpUtils.h
@@ -35,6 +35,22 @@ struct RemoteQpInfo {
 folly::Expected<IbvQp, Error>
 createRcQp(const IbvPd* ibvPd, ibv_cq* cq, int maxSendWr, int maxRecvWr);
 
+// createRcQpWithOooDp - Creates an RC QP with the option to enable mlx5
+// out-of-order data placement (OOO_DP). When oooDp=true, goes through
+// mlx5dv_create_qp with MLX5DV_QP_CREATE_OOO_DP so packet-sprayed data
+// (adaptive routing) may arrive out of order on the RQ. When oooDp=false,
+// bypasses mlx5dv entirely and delegates to the standard createRcQp() path
+// — so deployments without libmlx5 loaded still create QPs normally.
+// Caller must ensure the underlying device supports OOO DP when oooDp=true
+// (mlx5 provider, adaptive routing enabled, ooo_recv_wrs_caps.max_rc >=
+// maxRecvWr) — this helper does not gate.
+folly::Expected<IbvQp, Error> createRcQpWithOooDp(
+    const IbvPd* ibvPd,
+    ibv_cq* cq,
+    int maxSendWr,
+    int maxRecvWr,
+    bool oooDp);
+
 // initQp - Transitions QP to INIT state with port and access
 // configuration
 folly::Expected<folly::Unit, Error>

--- a/comms/ctran/ibverbx/IbverbxSymbols.cc
+++ b/comms/ctran/ibverbx/IbverbxSymbols.cc
@@ -280,6 +280,14 @@ struct ibv_qp* linked_mlx5dv_create_qp(
       reinterpret_cast<::mlx5dv_qp_init_attr*>(mlx5_qp_attr)));
 }
 
+int linked_mlx5dv_query_device(
+    struct ibv_context* ctx_in,
+    struct mlx5dv_context* attrs_out) {
+  return mlx5dv_query_device(
+      reinterpret_cast<::ibv_context*>(ctx_in),
+      reinterpret_cast<::mlx5dv_context*>(attrs_out));
+}
+
 struct mlx5dv_qp_ex* linked_mlx5dv_qp_ex_from_ibv_qp_ex(struct ibv_qp_ex* qp) {
   return reinterpret_cast<struct mlx5dv_qp_ex*>(
       mlx5dv_qp_ex_from_ibv_qp_ex(reinterpret_cast<::ibv_qp_ex*>(qp)));
@@ -501,6 +509,7 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
   symbols.mlx5dv_internal_create_qp = &linked_mlx5dv_create_qp;
   symbols.mlx5dv_internal_qp_ex_from_ibv_qp_ex =
       &linked_mlx5dv_qp_ex_from_ibv_qp_ex;
+  symbols.mlx5dv_internal_query_device = &linked_mlx5dv_query_device;
 
   // SRQ symbols
   symbols.ibv_internal_create_srq = &linked_create_srq;
@@ -594,6 +603,26 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
     *cast = tmp;                                             \
   }
 
+// dlsym-based (unversioned) loader. Use when the vendored libmlx5's actual
+// symbol version tag differs from any known upstream MLX5_X.Y label — dlsym
+// picks whatever version the library exports without a strict version match.
+// Necessary for some fbcode-vendored libmlx5 builds that repackage symbol
+// versions (empirically observed on GB300 fleet hosts).
+#define LOAD_SYM_UNVERSIONED_WARN(handle, symbol, funcptr) \
+  {                                                        \
+    cast = (void**)&funcptr;                               \
+    (void)dlerror(); /* clear any stale error state */     \
+    tmp = dlsym(handle, symbol);                           \
+    if (tmp == nullptr) {                                  \
+      const char* dlErr = dlerror();                       \
+      XLOG(WARN) << fmt::format(                           \
+          "dlsym failed on {} - {}, set null",             \
+          symbol,                                          \
+          dlErr ? dlErr : "unknown");                      \
+    }                                                      \
+    *cast = tmp;                                           \
+  }
+
 #define LOAD_IBVERBS_SYM(symbol, funcptr) \
   LOAD_SYM(ibvhandle, symbol, funcptr, IBVERBS_VERSION)
 
@@ -607,6 +636,11 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
 #define LOAD_MLX5DV_SYM(symbol, funcptr)                              \
   if (mlx5dvhandle != nullptr) {                                      \
     LOAD_SYM_WARN_ONLY(mlx5dvhandle, symbol, funcptr, MLX5DV_VERSION) \
+  }
+
+#define LOAD_MLX5DV_SYM_UNVERSIONED(symbol, funcptr)         \
+  if (mlx5dvhandle != nullptr) {                             \
+    LOAD_SYM_UNVERSIONED_WARN(mlx5dvhandle, symbol, funcptr) \
   }
 
 #define LOAD_MLX5DV_SYM_VERSION(symbol, funcptr, version)      \
@@ -671,6 +705,11 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
   // Cherry-pick the mlx5dv_get_data_direct_sysfs_path API from MLX5 1.2
   LOAD_MLX5DV_SYM_VERSION(
       "mlx5dv_init_obj", symbols.mlx5dv_internal_init_obj, "MLX5_1.2");
+  // mlx5dv_query_device — fbcode-vendored libmlx5 exports this at a
+  // non-upstream version tag on the fleet, so dlvsym on MLX5_1.X fails.
+  // Use unversioned dlsym; callers must null-guard.
+  LOAD_MLX5DV_SYM_UNVERSIONED(
+      "mlx5dv_query_device", symbols.mlx5dv_internal_query_device);
   // Cherry-pick the mlx5dv_get_data_direct_sysfs_path API from MLX5 1.25
   LOAD_MLX5DV_SYM_VERSION(
       "mlx5dv_get_data_direct_sysfs_path",
@@ -686,6 +725,11 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
       "mlx5dv_dci_stream_id_reset",
       symbols.mlx5dv_internal_dci_stream_id_reset,
       "MLX5_1.21");
+  // mlx5dv_create_qp — needed for MLX5DV_QP_CREATE_OOO_DP and DC QP creation.
+  // Same fbcode-vendored version-tag mismatch as mlx5dv_query_device — use
+  // unversioned dlsym; callers must null-guard.
+  LOAD_MLX5DV_SYM_UNVERSIONED(
+      "mlx5dv_create_qp", symbols.mlx5dv_internal_create_qp);
 
   // all symbols were loaded successfully, dismiss guard
   guard.dismiss();

--- a/comms/ctran/ibverbx/IbverbxSymbols.h
+++ b/comms/ctran/ibverbx/IbverbxSymbols.h
@@ -110,6 +110,9 @@ struct IbvSymbols {
       struct ibv_context* context,
       char* buf,
       size_t buf_len) = nullptr;
+  int (*mlx5dv_internal_query_device)(
+      struct ibv_context* ctx_in,
+      struct mlx5dv_context* attrs_out) = nullptr;
   /* DMA-BUF support */
   struct ibv_mr* (*mlx5dv_internal_reg_dmabuf_mr)(
       struct ibv_pd* pd,

--- a/comms/ctran/ibverbx/Mlx5core.h
+++ b/comms/ctran/ibverbx/Mlx5core.h
@@ -220,6 +220,106 @@ enum mlx5dv_obj_type {
 };
 
 //------------------------------------------------------------------------------
+// MLX5 Device Query (mlx5dv_query_device)
+//------------------------------------------------------------------------------
+
+enum mlx5dv_context_comp_mask {
+  MLX5DV_CONTEXT_MASK_CQE_COMPRESION = 1 << 0,
+  MLX5DV_CONTEXT_MASK_SWP = 1 << 1,
+  MLX5DV_CONTEXT_MASK_STRIDING_RQ = 1 << 2,
+  MLX5DV_CONTEXT_MASK_TUNNEL_OFFLOADS = 1 << 3,
+  MLX5DV_CONTEXT_MASK_DYN_BFREGS = 1 << 4,
+  MLX5DV_CONTEXT_MASK_CLOCK_INFO_UPDATE = 1 << 5,
+  MLX5DV_CONTEXT_MASK_FLOW_ACTION_FLAGS = 1 << 6,
+  MLX5DV_CONTEXT_MASK_DC_ODP_CAPS = 1 << 7,
+  MLX5DV_CONTEXT_MASK_HCA_CORE_CLOCK = 1 << 8,
+  MLX5DV_CONTEXT_MASK_NUM_LAG_PORTS = 1 << 9,
+  MLX5DV_CONTEXT_MASK_SIGNATURE_OFFLOAD = 1 << 10,
+  MLX5DV_CONTEXT_MASK_DCI_STREAMS = 1 << 11,
+  MLX5DV_CONTEXT_MASK_WR_MEMCPY_LENGTH = 1 << 12,
+  MLX5DV_CONTEXT_MASK_CRYPTO_OFFLOAD = 1 << 13,
+  MLX5DV_CONTEXT_MASK_MAX_DC_RD_ATOM = 1 << 14,
+  MLX5DV_CONTEXT_MASK_REG_C0 = 1 << 15,
+  MLX5DV_CONTEXT_MASK_OOO_RECV_WRS = 1 << 16,
+};
+
+struct mlx5dv_cqe_comp_caps {
+  uint32_t max_num;
+  uint32_t supported_format;
+};
+
+struct mlx5dv_sw_parsing_caps {
+  uint32_t sw_parsing_offloads;
+  uint32_t supported_qpts;
+};
+
+struct mlx5dv_striding_rq_caps {
+  uint32_t min_single_stride_log_num_of_bytes;
+  uint32_t max_single_stride_log_num_of_bytes;
+  uint32_t min_single_wqe_log_num_of_strides;
+  uint32_t max_single_wqe_log_num_of_strides;
+  uint32_t supported_qpts;
+};
+
+struct mlx5dv_dci_streams_caps {
+  uint8_t max_log_num_concurent;
+  uint8_t max_log_num_errored;
+};
+
+struct mlx5dv_sig_caps {
+  uint64_t block_size;
+  uint32_t block_prot;
+  uint16_t t10dif_bg;
+  uint16_t crc_type;
+};
+
+struct mlx5dv_crypto_caps {
+  uint16_t failed_selftests;
+  uint8_t crypto_engines;
+  uint8_t wrapped_import_method;
+  uint8_t log_max_num_deks;
+  uint32_t flags;
+};
+
+struct mlx5dv_ooo_recv_wrs_caps {
+  uint32_t max_rc;
+  uint32_t max_xrc;
+  uint32_t max_dct;
+  uint32_t max_ud;
+  uint32_t max_uc;
+};
+
+struct mlx5dv_reg {
+  uint32_t value;
+  uint32_t mask;
+};
+
+// Verbatim mirror of rdma-core's mlx5dv_context — layout must match exactly.
+struct mlx5dv_context {
+  uint8_t version;
+  uint64_t flags;
+  uint64_t comp_mask; // Use enum mlx5dv_context_comp_mask
+  struct mlx5dv_cqe_comp_caps cqe_comp_caps;
+  struct mlx5dv_sw_parsing_caps sw_parsing_caps;
+  struct mlx5dv_striding_rq_caps striding_rq_caps;
+  uint32_t tunnel_offloads_caps;
+  uint32_t max_dynamic_bfregs;
+  uint64_t max_clock_info_update_nsec;
+  uint32_t flow_action_flags;
+  uint32_t dc_odp_caps;
+  void* hca_core_clock;
+  uint8_t num_lag_ports;
+  struct mlx5dv_sig_caps sig_caps;
+  struct mlx5dv_dci_streams_caps dci_streams_caps;
+  size_t max_wr_memcpy_length;
+  struct mlx5dv_crypto_caps crypto_caps;
+  uint64_t max_dc_rd_atom;
+  uint64_t max_dc_init_rd_atom;
+  struct mlx5dv_reg reg_c0;
+  struct mlx5dv_ooo_recv_wrs_caps ooo_recv_wrs_caps;
+};
+
+//------------------------------------------------------------------------------
 // DC (Dynamically Connected) Transport Structures
 //------------------------------------------------------------------------------
 
@@ -228,6 +328,17 @@ enum mlx5dv_qp_init_attr_mask {
   MLX5DV_QP_INIT_ATTR_MASK_DC = 1 << 1,
   MLX5DV_QP_INIT_ATTR_MASK_SEND_OPS_FLAGS = 1 << 2,
   MLX5DV_QP_INIT_ATTR_MASK_DCI_STREAMS = 1 << 3,
+};
+
+enum mlx5dv_qp_create_flags {
+  MLX5DV_QP_CREATE_TUNNEL_OFFLOADS = 1 << 0,
+  MLX5DV_QP_CREATE_TIR_ALLOW_SELF_LOOPBACK_UC = 1 << 1,
+  MLX5DV_QP_CREATE_TIR_ALLOW_SELF_LOOPBACK_MC = 1 << 2,
+  MLX5DV_QP_CREATE_DISABLE_SCATTER_TO_CQE = 1 << 3,
+  MLX5DV_QP_CREATE_ALLOW_SCATTER_TO_CQE = 1 << 4,
+  MLX5DV_QP_CREATE_PACKET_BASED_CREDIT_MODE = 1 << 5,
+  MLX5DV_QP_CREATE_SIG_PIPELINING = 1 << 6,
+  MLX5DV_QP_CREATE_OOO_DP = 1 << 7,
 };
 
 enum mlx5dv_dc_type {

--- a/comms/ctran/ibverbx/Mlx5dv.cc
+++ b/comms/ctran/ibverbx/Mlx5dv.cc
@@ -1,6 +1,9 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include "comms/ctran/ibverbx/Mlx5dv.h"
+
+#include <fmt/core.h>
+
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
 
 namespace ibverbx {
@@ -15,6 +18,40 @@ folly::Expected<folly::Unit, Error> Mlx5dv::initObj(
     return folly::makeUnexpected(Error(rc));
   }
   return folly::unit;
+}
+
+folly::Expected<mlx5dv_context, Error> Mlx5dv::queryDevice(
+    ibv_context* ctx,
+    uint64_t compMask) {
+  if (ctx == nullptr) {
+    return folly::makeUnexpected(
+        Error(EINVAL, "mlx5dv_query_device: null ibv_context"));
+  }
+  if (ibvSymbols.mlx5dv_internal_query_device == nullptr) {
+    return folly::makeUnexpected(
+        Error(EOPNOTSUPP, "mlx5dv_query_device symbol unavailable"));
+  }
+  mlx5dv_context dvCtx{};
+  dvCtx.comp_mask = compMask;
+  // mlx5dv_query_device returns errno-style values on failure (positive
+  // errno directly, per rdma-core convention for this symbol) — pass rc
+  // through unchanged rather than reading errno separately.
+  const int rc = ibvSymbols.mlx5dv_internal_query_device(ctx, &dvCtx);
+  if (rc != 0) {
+    return folly::makeUnexpected(Error(rc, "mlx5dv_query_device failed"));
+  }
+  // Driver silently omits caps if firmware/kernel is too old — a partial
+  // response looks successful but leaves requested fields unpopulated.
+  if ((dvCtx.comp_mask & compMask) != compMask) {
+    return folly::makeUnexpected(Error(
+        EOPNOTSUPP,
+        fmt::format(
+            "mlx5dv_query_device: driver did not populate requested caps "
+            "(requested=0x{:x} got=0x{:x})",
+            compMask,
+            dvCtx.comp_mask)));
+  }
+  return dvCtx;
 }
 
 } // namespace ibverbx

--- a/comms/ctran/ibverbx/Mlx5dv.h
+++ b/comms/ctran/ibverbx/Mlx5dv.h
@@ -6,6 +6,7 @@
 
 #include "comms/ctran/ibverbx/IbvCommon.h"
 #include "comms/ctran/ibverbx/Ibvcore.h"
+#include "comms/ctran/ibverbx/Mlx5core.h"
 
 namespace ibverbx {
 
@@ -14,6 +15,15 @@ class Mlx5dv {
   static folly::Expected<folly::Unit, Error> initObj(
       mlx5dv_obj* obj,
       uint64_t obj_type);
+
+  // Query mlx5-specific device attributes via mlx5dv_query_device.
+  // Caller sets the requested caps via compMask (enum
+  // mlx5dv_context_comp_mask). Returns EOPNOTSUPP if libmlx5 is unavailable
+  // (dynamic-loading path failed to resolve the symbol); other errors from
+  // mlx5dv_query_device pass through.
+  static folly::Expected<mlx5dv_context, Error> queryDevice(
+      ibv_context* ctx,
+      uint64_t compMask);
 };
 
 } // namespace ibverbx

--- a/comms/ctran/ibverbx/tests/IbverbxOooRqSupportTest.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxOooRqSupportTest.cc
@@ -1,0 +1,140 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/ibverbx/IbvQpUtils.h"
+#include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/ibverbx/IbverbxSymbols.h"
+#include "comms/ctran/ibverbx/Mlx5dv.h"
+
+namespace ibverbx {
+
+extern IbvSymbols ibvSymbols;
+
+// OOO_RQ (MLX5DV_QP_CREATE_OOO_DP) is mlx5-only.
+const std::string kNicPrefix("mlx5_");
+
+class IbverbxOooRqTestFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+#if defined(__HIP_PLATFORM_AMD__)
+    GTEST_SKIP()
+        << "Skipping OOO_RQ test on AMD platform: mlx5dv not supported";
+#else
+    ASSERT_TRUE(ibvInit());
+    // Filter to mlx5-family NICs — OOO_RQ is mlx5-only. Skips on hosts where
+    // the first device would otherwise be e.g. bnxt_re, which would exercise
+    // the mlx5dv APIs against a non-mlx5 provider (returns ENOTSUP but
+    // defeats the intent of validating the mlx5 path).
+    auto devices = IbvDevice::ibvGetDeviceList({kNicPrefix});
+    ASSERT_TRUE(devices);
+    if (devices->empty()) {
+      GTEST_SKIP() << "No mlx5 devices found on host";
+    }
+    devicesHolder_ = std::move(*devices);
+    device_ = &devicesHolder_[0];
+
+    // With an mlx5 device present, these symbols MUST resolve — production
+    // wraps null-symbol into EOPNOTSUPP, silently disabling OOO_RQ fleet-wide.
+    ASSERT_NE(ibvSymbols.mlx5dv_internal_query_device, nullptr)
+        << "mlx5dv_query_device symbol failed to resolve on host with mlx5 "
+           "device present — production dlopen/dlsym path is broken. Every "
+           "OOO_RQ deployment silently disables the feature.";
+    ASSERT_NE(ibvSymbols.mlx5dv_internal_create_qp, nullptr)
+        << "mlx5dv_create_qp symbol failed to resolve on host with mlx5 "
+           "device present — production dlopen/dlsym path is broken. Every "
+           "OOO_RQ deployment silently disables the feature.";
+#endif
+  }
+
+  // Held to keep device_ pointing at a live object across the test body.
+  std::vector<IbvDevice> devicesHolder_;
+  IbvDevice* device_{nullptr};
+};
+
+// Basic query: mlx5dv_query_device with MLX5DV_CONTEXT_MASK_OOO_RECV_WRS.
+// Three outcomes:
+//   1. Query API unsupported (older libmlx5 / no cap category)
+//       → returns ENOTSUP / EOPNOTSUPP → skip.
+//   2. Query works, HW doesn't support the feature (max_rc == 0)
+//       → skip (caps struct legitimately populated with zeros).
+//   3. Query works, HW supports the feature (max_rc > 0)
+//       → pass.
+TEST_F(IbverbxOooRqTestFixture, QueryOooRecvWrsCaps) {
+  auto maybeCtx =
+      Mlx5dv::queryDevice(device_->context(), MLX5DV_CONTEXT_MASK_OOO_RECV_WRS);
+  if (maybeCtx.hasError() &&
+      (maybeCtx.error().errNum == ENOTSUP ||
+       maybeCtx.error().errNum == EOPNOTSUPP)) {
+    GTEST_SKIP() << "mlx5dv_query_device not available: "
+                 << maybeCtx.error().errStr;
+  }
+  ASSERT_TRUE(maybeCtx) << "queryDevice failed: " << maybeCtx.error().errStr;
+
+  // Driver populated the caps struct but HW/firmware reports max_rc == 0.
+  // The query API works; the underlying feature is just absent on this host.
+  if (maybeCtx->ooo_recv_wrs_caps.max_rc == 0) {
+    GTEST_SKIP() << "OOO_RECV_WRS caps struct populated but HW reports "
+                    "max_rc == 0 (feature not supported on this host)";
+  }
+}
+
+// Create an RC QP with MLX5DV_QP_CREATE_OOO_DP.
+//
+// Precheck the HW/firmware capability via mlx5dv_query_device and skip only
+// when OOO_RQ is genuinely unsupported (query API absent, or reported max_rc
+// below what we run with).
+TEST_F(IbverbxOooRqTestFixture, CreateRcQpWithOooDp) {
+  constexpr uint32_t kRequiredOooMaxRc = 128;
+
+  auto maybeCtx =
+      Mlx5dv::queryDevice(device_->context(), MLX5DV_CONTEXT_MASK_OOO_RECV_WRS);
+  if (maybeCtx.hasError() &&
+      (maybeCtx.error().errNum == ENOTSUP ||
+       maybeCtx.error().errNum == EOPNOTSUPP)) {
+    GTEST_SKIP() << "mlx5dv_query_device not available: "
+                 << maybeCtx.error().errStr;
+  }
+  ASSERT_TRUE(maybeCtx) << "queryDevice failed: " << maybeCtx.error().errStr;
+  if (maybeCtx->ooo_recv_wrs_caps.max_rc < kRequiredOooMaxRc) {
+    GTEST_SKIP() << "OOO_RECV_WRS not supported on this host (max_rc="
+                 << maybeCtx->ooo_recv_wrs_caps.max_rc << " < "
+                 << kRequiredOooMaxRc << ")";
+  }
+
+  auto pd = device_->allocPd();
+  ASSERT_TRUE(pd);
+
+  auto cq = device_->createCq(1024, nullptr, nullptr, 0);
+  ASSERT_TRUE(cq);
+
+  auto qp = createRcQpWithOooDp(
+      &(*pd),
+      cq->cq(),
+      /*maxSendWr=*/256,
+      /*maxRecvWr=*/128,
+      /*oooDp=*/true);
+  ASSERT_TRUE(qp)
+      << "createRcQpWithOooDp(oooDp=true) failed on OOO-capable device "
+      << "(errno=" << qp.error().errNum << " " << qp.error().errStr
+      << "). Likely a bug in this diff's QP init attrs / comp_mask / "
+      << "create_flags wiring rather than a hardware-support issue.";
+  ASSERT_NE(qp->qp(), nullptr);
+}
+
+// Sanity: the same helper with oooDp=false still yields a valid RC QP via the
+// standard createRcQp fallback (mlx5dv is not exercised on this path).
+TEST_F(IbverbxOooRqTestFixture, CreateRcQpWithoutOooDp) {
+  auto pd = device_->allocPd();
+  ASSERT_TRUE(pd);
+
+  auto cq = device_->createCq(1024, nullptr, nullptr, 0);
+  ASSERT_TRUE(cq);
+
+  auto qp = createRcQpWithOooDp(&(*pd), cq->cq(), 256, 128, /*oooDp=*/false);
+  ASSERT_TRUE(qp) << "createRcQpWithOooDp(oooDp=false) failed: "
+                  << qp.error().errStr;
+  ASSERT_NE(qp->qp(), nullptr);
+}
+
+} // namespace ibverbx


### PR DESCRIPTION
Summary:

Adds the ibverbx-layer plumbing required to create QPs with the mlx5
direct-verbs create-flag `MLX5DV_QP_CREATE_OOO_DP` (out-of-order data
placement). This flag lives outside the standard libibverbs surface, so
ctran needs a new call path through `mlx5dv_create_qp`.

Layers added:
- `Mlx5core.h` — mlx5-specific structs/enums (`mlx5dv_context`,
  `comp_mask`, `ooo_recv_wrs_caps`).
- `IbverbxSymbols.{cc,h}` — dlsym'd function pointer for
  `mlx5dv_query_device` plus `LOAD_SYM_UNVERSIONED_WARN` macro for
  vendored-libmlx5 symbol tags that differ from upstream MLX5_X.Y.
- `Mlx5dv::queryDevice()` — `folly::Expected` wrapper. Validates the
  driver populated the requested caps (guards firmware/kernel-too-old).
- `IbvPd::createExtRcQpMlx5()` — PD factory method for RC QPs via
  `mlx5dv_create_qp`. Validates inputs (non-null attrs, `IBV_QPT_RC`,
  non-zero `create_flags`).
- `IbvQpUtils::createRcQpMlx5(oooDp)` — top-level helper. When
  `oooDp=false`, bypasses `mlx5dv` entirely and calls the standard
  `createRcQp()` path — so deployments without libmlx5 loaded still
  create QPs normally.

No behavior change on the fast path: existing QP creation paths that
don't request OOO_DP go through the unchanged `createRcQp()`.

Reviewed By: snarayankh

Differential Revision: D113578037


