### PR TITLE
CtranMulticast teardown robustness: mapVA reserved size + createRoot handle clear

### DIFF
--- a/comms/ctran/utils/CtranMulticast.cc
+++ b/comms/ctran/utils/CtranMulticast.cc
@@ -128,6 +128,7 @@ commResult_t CtranMulticast::createRoot(
   // previously-held multicast object.
   if (mcHandle_ != 0) {
     FB_CUCHECKIGNORE(cuMemRelease(mcHandle_));
+    mcHandle_ = 0; // so a cuMulticastCreate failure below can't double-release
   }
   CUmulticastObjectProp prop = {};
   prop.numDevices = static_cast<unsigned int>(nLocalRanks_);
@@ -229,13 +230,16 @@ commResult_t CtranMulticast::addDeviceAndBind() {
 commResult_t CtranMulticast::mapVA(size_t mcSize, size_t gran) {
   FB_CUCHECK(cuMemAddressReserve(
       &mcVA_, mcSize, /*alignment=*/gran, /*addr=*/0, /*flags=*/0));
+  // Record the reserved size now so a failure in the map/setAccess below leaves
+  // the dtor unmapping/freeing exactly what was reserved (mcSize_ may otherwise
+  // still hold a different createRoot size).
+  mcSize_ = mcSize;
   FB_CUCHECK(cuMemMap(mcVA_, mcSize, /*offset=*/0, mcHandle_, /*flags=*/0));
   CUmemAccessDesc accessDesc = {};
   accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
   accessDesc.location.id = cudaDev_;
   accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
   FB_CUCHECK(cuMemSetAccess(mcVA_, mcSize, &accessDesc, /*count=*/1));
-  mcSize_ = mcSize;
   return commSuccess;
 }
 


### PR DESCRIPTION
Summary:
Two defensive fixes to CtranMulticast, split out of D112761231 so that diff
re-lands byte-identical to its reviewed version. Both are error-path only, no
happy-path behavior change (AI-reviewer nits):
- mapVA() records mcSize_ right after cuMemAddressReserve, so a failure in the
  subsequent cuMemMap/cuMemSetAccess leaves the dtor unmapping/freeing exactly
  the reserved size, not a stale createRoot size.
- createRoot() clears mcHandle_ after cuMemRelease in the re-invoke guard, so a
  cuMulticastCreate failure below cannot leave a stale handle for the dtor to
  double-release.

Reviewed By: minsii

Differential Revision: D113480939


