### PR TITLE
Migrate fbcode/comms/uniflow to Autodeps2

### DIFF
--- a/comms/uniflow/benchmarks/bench/NcclSendRecvBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/NcclSendRecvBenchmark.cpp
@@ -7,7 +7,7 @@
 #include <cstring>
 
 #include <cuda_runtime_api.h> // @manual=third-party//cuda:cuda-lazy
-#include "nccl.h" // @manual
+#include "nccl.h" // @manual=//comms/ncclx:nccl
 
 #include "comms/uniflow/benchmarks/Rendezvous.h"
 #include "comms/uniflow/logging/Logger.h"


### PR DESCRIPTION
Summary:
Autodeps1 is deprecated and will be deleted in August 2026 (see https://fb.workplace.com/groups/autodeps.users/permalink/3412393688929106/). This is a one-time automated migration to Autodeps2 C++ dependency resolution.

#buildmore #buildsonlynotests

Differential Revision: D111234189


