### PR TITLE
getChunkSize: match bytesPerRank against the per-rank shard, not total/nRanks^2

### DIFF
--- a/comms/ncclx/meta/tuner/MetaTuner.cc
+++ b/comms/ncclx/meta/tuner/MetaTuner.cc
@@ -456,6 +456,27 @@ ncclResult_t metaTunerGetChunkSize(
     return ncclInternalError;
   }
 
+  // getChunkSize's nBytes is the PER-RANK data size: enqueue.cc calls
+  // calcCollChunking with globalBytesPerElement*task->count, and for AllGather
+  // / ReduceScatter task->count is the per-rank send/recv count. getCollInfo,
+  // by contrast, receives the collective TOTAL. matchesCollective's
+  // bytesPerRank check assumes nBytes is the total and divides by nRanks, so we
+  // scale the per-rank nBytes back up to the total here -- otherwise
+  // bytesPerRank is compared against total/nRanks^2 and a size-scoped chunk
+  // rule only fires at tiny rank counts (silently no-ops at scale).
+  int64_t nRanksForChunk = static_cast<int64_t>(context->nNodes) *
+      static_cast<int64_t>(context->nLocalRanks);
+  if (nRanksForChunk <= 0) {
+    nRanksForChunk = 1;
+  }
+  // Saturate instead of letting size_t silently wrap: an overflowed product
+  // would shrink to a bogus small total, making matchesCollective derive a
+  // wrong (tiny) bytesPerRank and match an unintended rule. ranksForChunk is
+  // >= 1 (guarded above), so the division is safe.
+  const auto ranksForChunk = static_cast<size_t>(nRanksForChunk);
+  const size_t totalBytesForChunk =
+      nBytes > SIZE_MAX / ranksForChunk ? SIZE_MAX : nBytes * ranksForChunk;
+
   for (const auto& config : context->configs) {
     if (config.chunkSize == 0) {
       continue;
@@ -466,7 +487,7 @@ ncclResult_t metaTunerGetChunkSize(
     if (!matchesCollective(
             config,
             collType,
-            nBytes,
+            totalBytesForChunk,
             /* numPipeOps */ -1,
             context->nNodes,
             context->nLocalRanks,
@@ -477,13 +498,17 @@ ncclResult_t metaTunerGetChunkSize(
 
     // Core clamps the result to bufferMaxChunkSize; we do not clamp here.
     *chunkSize = config.chunkSize;
+    // Log the scaled total and derived per-rank shard that matching actually
+    // ran against (not the raw per-rank nBytes), so this line correlates with
+    // matchesCollective's mismatch log, which prints the same two values.
     NCCLX_TUNER_LOG(
         context->logFunction,
         NCCL_LOG_INFO,
         fmt::format(
-            "NCCLX TUNER: chunkSize override collType={} nBytes={} algo={} proto={} -> {} (clamped by core to bufferMaxChunkSize)",
+            "NCCLX TUNER: chunkSize override collType={} nBytes={} bytesPerRank={} algo={} proto={} -> {} (clamped by core to bufferMaxChunkSize)",
             static_cast<int>(collType),
-            nBytes,
+            totalBytesForChunk,
+            totalBytesForChunk / ranksForChunk,
             algo,
             proto,
             config.chunkSize));

--- a/comms/ncclx/meta/tuner/tests/MetaTunerTest.cpp
+++ b/comms/ncclx/meta/tuner/tests/MetaTunerTest.cpp
@@ -771,6 +771,35 @@ TEST_F(MetaTunerTest, ChunkSizeAlgoProtoKey) {
 
   kMetaTuner.finalize(context);
 }
+
+// Case 10b: getChunkSize's nBytes is the PER-RANK shard, so a size-scoped
+// bytesPerRank rule must be matched against the per-rank shard (nBytes scaled
+// back to the total), NOT nBytes/nRanks. Regression for the total/nRanks^2
+// double-divide that made nolocal AllGather/ReduceScatter chunk rules silently
+// no-op at scale.
+TEST_F(MetaTunerTest, ChunkSizePerRankShardScaling) {
+  // Rule fires only for a per-rank shard in [400K, 600K].
+  const TunerConfigFile config(
+      ".csv", "allgather,[409600,614400],pat,simple,-1,(7,),1,524288\n");
+  // 64 nolocal ranks: nNodes=64, nLocalRanks=64/64=1 (pure-IB PAT comm).
+  void* context = initTuner(/* nRanks */ 64, /* nNodes */ 64);
+
+  // getChunkSize receives the per-rank shard (512K). Under the old
+  // double-divide this resolved to 512K/64 = 8K and missed the [400K,600K]
+  // rule.
+  size_t chunk = 65536;
+  kMetaTuner.getChunkSize(
+      context,
+      ncclFuncAllGather,
+      /* nBytes (per-rank shard) */ 524288,
+      NCCL_ALGO_PAT,
+      NCCL_PROTO_SIMPLE,
+      8,
+      &chunk);
+  EXPECT_EQ(chunk, 524288);
+
+  kMetaTuner.finalize(context);
+}
 #endif // META_TUNER_UT_HAS_GETCHUNKSIZE
 
 // Case 1: CSV parsing with comments, blank lines and omitted optional columns.


### PR DESCRIPTION
Summary: metaTunerGetChunkSize is called (enqueue.cc calcCollChunking, nBytes = globalBytesPerElement*task->count) with the PER-RANK data size -- for AllGather/ReduceScatter task->count is the per-rank count -- while getCollInfo receives the collective TOTAL. matchesCollective's bytesPerRank check assumes nBytes is the total and divides by nRanks, so for the getChunkSize path bytesPerRank was compared against total/nRanks^2. A size-scoped chunkSize rule therefore only matched at tiny rank counts and silently no-op'd at scale (observed: a nolocal-PAT 512K chunk rule applied at 8 ranks but never at 64). Fix: scale the per-rank nBytes back to the total before matchesCollective in getChunkSize.

Reviewed By: minsii

Differential Revision: D113415310


