### PR TITLE
Compile the v2_30 getChunkSize tuner hook into the conda libnccl

### DIFF
--- a/comms/ncclx/meta/tuner/MetaTuner.cc
+++ b/comms/ncclx/meta/tuner/MetaTuner.cc
@@ -456,6 +456,27 @@ ncclResult_t metaTunerGetChunkSize(
     return ncclInternalError;
   }
 
+  // getChunkSize's nBytes is the PER-RANK data size: enqueue.cc calls
+  // calcCollChunking with globalBytesPerElement*task->count, and for AllGather
+  // / ReduceScatter task->count is the per-rank send/recv count. getCollInfo,
+  // by contrast, receives the collective TOTAL. matchesCollective's
+  // bytesPerRank check assumes nBytes is the total and divides by nRanks, so we
+  // scale the per-rank nBytes back up to the total here -- otherwise
+  // bytesPerRank is compared against total/nRanks^2 and a size-scoped chunk
+  // rule only fires at tiny rank counts (silently no-ops at scale).
+  int64_t nRanksForChunk = static_cast<int64_t>(context->nNodes) *
+      static_cast<int64_t>(context->nLocalRanks);
+  if (nRanksForChunk <= 0) {
+    nRanksForChunk = 1;
+  }
+  // Saturate instead of letting size_t silently wrap: an overflowed product
+  // would shrink to a bogus small total, making matchesCollective derive a
+  // wrong (tiny) bytesPerRank and match an unintended rule. ranksForChunk is
+  // >= 1 (guarded above), so the division is safe.
+  const auto ranksForChunk = static_cast<size_t>(nRanksForChunk);
+  const size_t totalBytesForChunk =
+      nBytes > SIZE_MAX / ranksForChunk ? SIZE_MAX : nBytes * ranksForChunk;
+
   for (const auto& config : context->configs) {
     if (config.chunkSize == 0) {
       continue;
@@ -466,7 +487,7 @@ ncclResult_t metaTunerGetChunkSize(
     if (!matchesCollective(
             config,
             collType,
-            nBytes,
+            totalBytesForChunk,
             /* numPipeOps */ -1,
             context->nNodes,
             context->nLocalRanks,
@@ -477,13 +498,17 @@ ncclResult_t metaTunerGetChunkSize(
 
     // Core clamps the result to bufferMaxChunkSize; we do not clamp here.
     *chunkSize = config.chunkSize;
+    // Log the scaled total and derived per-rank shard that matching actually
+    // ran against (not the raw per-rank nBytes), so this line correlates with
+    // matchesCollective's mismatch log, which prints the same two values.
     NCCLX_TUNER_LOG(
         context->logFunction,
         NCCL_LOG_INFO,
         fmt::format(
-            "NCCLX TUNER: chunkSize override collType={} nBytes={} algo={} proto={} -> {} (clamped by core to bufferMaxChunkSize)",
+            "NCCLX TUNER: chunkSize override collType={} nBytes={} bytesPerRank={} algo={} proto={} -> {} (clamped by core to bufferMaxChunkSize)",
             static_cast<int>(collType),
-            nBytes,
+            totalBytesForChunk,
+            totalBytesForChunk / ranksForChunk,
             algo,
             proto,
             config.chunkSize));

--- a/comms/ncclx/meta/tuner/tests/MetaTunerTest.cpp
+++ b/comms/ncclx/meta/tuner/tests/MetaTunerTest.cpp
@@ -771,6 +771,35 @@ TEST_F(MetaTunerTest, ChunkSizeAlgoProtoKey) {
 
   kMetaTuner.finalize(context);
 }
+
+// Case 10b: getChunkSize's nBytes is the PER-RANK shard, so a size-scoped
+// bytesPerRank rule must be matched against the per-rank shard (nBytes scaled
+// back to the total), NOT nBytes/nRanks. Regression for the total/nRanks^2
+// double-divide that made nolocal AllGather/ReduceScatter chunk rules silently
+// no-op at scale.
+TEST_F(MetaTunerTest, ChunkSizePerRankShardScaling) {
+  // Rule fires only for a per-rank shard in [400K, 600K].
+  const TunerConfigFile config(
+      ".csv", "allgather,[409600,614400],pat,simple,-1,(7,),1,524288\n");
+  // 64 nolocal ranks: nNodes=64, nLocalRanks=64/64=1 (pure-IB PAT comm).
+  void* context = initTuner(/* nRanks */ 64, /* nNodes */ 64);
+
+  // getChunkSize receives the per-rank shard (512K). Under the old
+  // double-divide this resolved to 512K/64 = 8K and missed the [400K,600K]
+  // rule.
+  size_t chunk = 65536;
+  kMetaTuner.getChunkSize(
+      context,
+      ncclFuncAllGather,
+      /* nBytes (per-rank shard) */ 524288,
+      NCCL_ALGO_PAT,
+      NCCL_PROTO_SIMPLE,
+      8,
+      &chunk);
+  EXPECT_EQ(chunk, 524288);
+
+  kMetaTuner.finalize(context);
+}
 #endif // META_TUNER_UT_HAS_GETCHUNKSIZE
 
 // Case 1: CSV parsing with comments, blank lines and omitted optional columns.

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -33,6 +33,18 @@ ifeq ($(NCCLX_TUNER_WITH_FOLLY_JSON),1)
 CXXFLAGS += -DNCCLX_TUNER_WITH_FOLLY_JSON
 endif
 
+# NCCLX v2.30 uses tuner API v6, which adds the getChunkSize hook. Gate the
+# v6-only getChunkSize callback in meta/tuner on this flag -- matching
+# def_build.bzl. The conda feedstock build sets NCCLX_TUNER_HAS_GETCHUNKSIZE=1;
+# a bare OSS `make` leaves it off so chunkSize overrides compile out (proto/algo
+# and channel rules still work).
+# TODO: Remove this flag once v2.29 is deleted (all remaining versions use tuner
+# API v6+, so getChunkSize can be enabled unconditionally).
+NCCLX_TUNER_HAS_GETCHUNKSIZE ?= 0
+ifeq ($(NCCLX_TUNER_HAS_GETCHUNKSIZE),1)
+CXXFLAGS += -DNCCLX_TUNER_HAS_GETCHUNKSIZE
+endif
+
 ifeq ($(ENABLE_TCPDM),0)
 CXXFLAGS += -DCTRAN_DISABLE_TCPDM
 endif


### PR DESCRIPTION
Summary:
The NCCLX v2.30 built-in tuner's getChunkSize hook (tuner API v6) is gated in the
shared meta/tuner sources behind -DNCCLX_TUNER_HAS_GETCHUNKSIZE. The Buck build sets
it (comms/ncclx/v2_30/def_build.bzl), but the conda feedstock path never did: the
v2_30 src/Makefile only gated -DNCCLX_TUNER_WITH_FOLLY_JSON, and conda/feedstock/nccl/
build.sh only exported NCCLX_TUNER_WITH_FOLLY_JSON=1.

Consequence: the conda-built libnccl.so compiled metaTunerGetChunkSize (and the
.getChunkSize struct field) OUT, so a .json tuner's chunkSize-override rules loaded
but silently no-op'd at runtime -- proto/algo and channel-cap rules still fired, but
the nolocal-PAT chunkSize push-up never did. Observed on a v17_tpp_535 CAMILLE_BENCH_
NIGHTLY gb200 run: 51 rules loaded, 22 AllGather->PAT proto matches, but 0 'chunkSize
override' lines.

Fix (mirror the folly-JSON gate; both flags now handled the same way):
- comms/ncclx/v2_30/src/Makefile: add a NCCLX_TUNER_HAS_GETCHUNKSIZE ?= 0 gate that
  appends -DNCCLX_TUNER_HAS_GETCHUNKSIZE to CXXFLAGS when set to 1.
- conda/feedstock/nccl/build.sh: export NCCLX_TUNER_HAS_GETCHUNKSIZE=1. Safe for
  v2_29 (API v5) -- its Makefile has no such gate and ignores the env.

The macro only compiles in the getChunkSize callback; it does NOT change the
metaTunerInit ABI (in tuner_v6.h ncclTunerConstants_v6_t / ncclNvlDomainInfo_v6_t are
typedefs of the v5 types), so init behavior is unchanged.

Reviewed By: minsii

Differential Revision: D113792186


