### PR TITLE
clang21: (void)-cast discarded HIP status in Buffer.cc sync calls

### DIFF
--- a/comms/prims/collectives/moe_ep/cpp/Buffer.cc
+++ b/comms/prims/collectives/moe_ep/cpp/Buffer.cc
@@ -722,7 +722,7 @@ py::tuple Buffer::intranode_dispatch(
           topkIdx.has_value(), "num_worst_tokens > 0 requires topk_idx");
     } else {
       // Block until notify_dispatch flushes the per-rank/per-expert counters.
-      cudaStreamSynchronize(stream);
+      (void)cudaStreamSynchronize(stream);
       numRecvTokens = *intranode_->getMoeRecvCounterHost();
       TORCH_CHECK(
           numRecvTokens >= 0, "notify_dispatch did not publish counter");
@@ -1152,7 +1152,7 @@ py::tuple Buffer::low_latency_dispatch(
       stream);
 
   // Synchronize to get packed_recv_count values
-  cudaStreamSynchronize(stream);
+  (void)cudaStreamSynchronize(stream);
 
   // Build handle for combine: (src_info, layout_range, packed_recv_x_ref).
   // Test accesses handle[0], handle[1]; handle[2] is for
@@ -1272,7 +1272,7 @@ py::tuple Buffer::low_latency_combine(
       false, // zero_copy
       stream);
 
-  cudaStreamSynchronize(stream);
+  (void)cudaStreamSynchronize(stream);
 
   auto noopHook = py::cpp_function([]() {});
   return py::make_tuple(combinedX, EventHandle(), noopHook);


### PR DESCRIPTION
Summary:
clang21 marks `hipError_t` as `[[nodiscard]]` (HIPify rewrites `cudaError_t` ->
`hipError_t` on AMD), so `cpp/Buffer.cc` fails the `fbcode//mode/opt-amd-gpu`
clang21 build with `-Werror,-Wunused-value` on three `cudaStreamSynchronize(stream)`
calls whose status is intentionally dropped (a sync-before-read, not inline
actionable). clang19 (the default shard) does not mark the type nodiscard, so
this surfaces only on the clang21 AMD shard and blocks the `:buffer` / `:_cpp`
build signals on the moe_ep stack (e.g. D109955690). Pre-existing latent break
exposed by the toolchain bump, not a behavior change -- mirrors D113317697.

Make each intentional discard explicit with `(void)`: Buffer.cc:725
(intranode_dispatch), :1155 (low_latency_dispatch), :1275 (low_latency_combine).
Behavior unchanged.

Differential Revision: D113846407


