### PR TITLE
CERR conversion in CTRAN backends/ call sites

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -63,7 +63,9 @@ commResult_t Ctran::commRegister(void* buff, size_t size, void** handle) {
   commResult_t res = commSuccess;
 
   if (!this->mapper) {
-    CLOGF(ERR, "Ctran mapper is not initialized, skip commRegister");
+    CERR(
+        commInternalError,
+        "Ctran mapper is not initialized, skip commRegister");
     return commInternalError;
   } else if (NCCL_CTRAN_REGISTER != NCCL_CTRAN_REGISTER::none) {
     return this->mapper->regMem(buff, size, handle);
@@ -76,7 +78,9 @@ commResult_t Ctran::commDeregister(void* handle) {
   commResult_t res = commSuccess;
 
   if (!this->mapper) {
-    CLOGF(ERR, "Ctran mapper is not initialized, skip commDeregister");
+    CERR(
+        commInternalError,
+        "Ctran mapper is not initialized, skip commDeregister");
     return commInternalError;
   } else if (NCCL_CTRAN_REGISTER != NCCL_CTRAN_REGISTER::none) {
     return this->mapper->deregMem(handle);
@@ -283,7 +287,7 @@ commResult_t globalRegisterWithPtr(
 
   auto regCache = RegCache::getInstance();
   if (!regCache) {
-    CLOGF(ERR, "globalRegisterWithPtr: RegCache not available");
+    CERR(commInternalError, "globalRegisterWithPtr: RegCache not available");
     return commInternalError;
   }
 
@@ -299,7 +303,7 @@ globalDeregisterWithPtr(void* buff, size_t size, bool skipRemRelease) {
 
   auto regCache = RegCache::getInstance();
   if (!regCache) {
-    CLOGF(ERR, "globalDeregisterWithPtr: RegCache not available");
+    CERR(commInternalError, "globalDeregisterWithPtr: RegCache not available");
     return commInternalError;
   }
 

--- a/comms/ctran/algos/AllGather/AllGatherDirect.cc
+++ b/comms/ctran/algos/AllGather/AllGatherDirect.cc
@@ -110,8 +110,8 @@ static commResult_t impl(
       // Wait for receiving remote recv buffer from a local peer
       comm->ctran_->mapper->waitRequest(irecvReq[pRank].get());
       if (remoteAccessKeys[pRank].backend != CtranMapperBackend::NVL) {
-        CLOGF(
-            ERR,
+        CERR(
+            commInternalError,
             "NVLink backend not available between rank {} and {}",
             rank,
             pRank);

--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -95,6 +95,7 @@ commResult_t createPersistentRequest(
     CtranPersistentRequest** out,
     bool waitForInit) {
   if (out == nullptr) {
+    CERR(commInvalidArgument, "AllGatherP: output buffer must not be null");
     return commInvalidArgument;
   }
   *out = nullptr;

--- a/comms/ctran/algos/AllReduce/AllReduceDirect.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceDirect.cc
@@ -199,8 +199,8 @@ static commResult_t impl(
           intraNodeLocalRecvbuffReq[lr].get()));
       if (intraNodeRemoteRecvAccessKeys[lr].backend !=
           CtranMapperBackend::NVL) {
-        CLOGF(
-            ERR,
+        CERR(
+            commInternalError,
             "NVLink backend not available between rank {} and {}",
             rank,
             statex->localRankToRank(lr));
@@ -576,8 +576,8 @@ commResult_t ctranAllReduceDirect(
 
   // Prevent buffer overflow in localReduce.srcs array
   if (nLocalRanks > CTRAN_MAX_NVL_PEERS) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInvalidUsage,
         "nLocalRanks ({}) exceeds CTRAN_MAX_NVL_PEERS ({}). This will cause buffer overflow in localReduce.srcs array! ",
         nLocalRanks,
         CTRAN_MAX_NVL_PEERS);

--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -79,7 +79,7 @@ commResult_t getGpuArch(ctran::allreduce::ring::GpuArch* arch) {
   FB_CUDACHECK(cudaGetDevice(&cudaDev));
   auto cudaArch = ctran::utils::getCudaArch(cudaDev);
   if (!cudaArch.hasValue()) {
-    CLOGF(ERR, "{}", cudaArch.error());
+    CERR(commUnhandledCudaError, "{}", cudaArch.error());
     return commUnhandledCudaError;
   }
   if (cudaArch.value() < 1000) {
@@ -1319,7 +1319,7 @@ commResult_t ctranAllReduceRing(
         count,
         count * typeSize,
         typeSize);
-    CLOGF(ERR, "{}", errorMsg);
+    CERR(commInvalidArgument, "{}", errorMsg);
     throw ctran::utils::Exception(errorMsg, commInvalidArgument);
   }
 

--- a/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
@@ -410,6 +410,7 @@ commResult_t createPersistentRequest(
     bool waitForInit,
     bool skipCtrlMsg) {
   if (out == nullptr) {
+    CERR(commInvalidArgument, "AllToAllP: output buffer must not be null");
     return commInvalidArgument;
   }
   *out = nullptr;

--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.cc
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.cc
@@ -5,6 +5,7 @@
 #include "comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/LogUtils.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -145,6 +146,11 @@ commResult_t setupKernelConfig(
 
   // Build local rank -> global rank mapping
   if (kernArgs.nLocalRanks > CTRAN_MAX_NVL_PEERS) {
+    CERR(
+        commInternalError,
+        "DeviceAllToAllvPipes: nLocalRanks {} exceeds CTRAN_MAX_NVL_PEERS {}",
+        kernArgs.nLocalRanks,
+        CTRAN_MAX_NVL_PEERS);
     return commInternalError;
   }
   for (int lr = 0; lr < kernArgs.nLocalRanks; lr++) {

--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -189,8 +189,8 @@ commResult_t CtranAlgo::initKernelResources() {
   int rank = statex->rank();
 
   if (nLocalRanks > CTRAN_MAX_NVL_PEERS) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "CTRAN only supports NVL peers up to {}, but nLocalRanks is {}. "
         "This will likely cause seg fault or data corruption! "
         "Try set CTRAN_MAX_NVL_PEERS to be larger or equal to nLocalRanks via "
@@ -226,8 +226,8 @@ commResult_t CtranAlgo::initKernelResources() {
       statex->cudaDev()));
 
   if (maxSharedMemOptin < sizeof(CtranAlgoDeviceState)) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "CTRAN-ALGO: sharedMemPerBlockOptin {} on device {} is smaller than the size of CtranAlgoDeviceState {}",
         maxSharedMemOptin,
         statex->cudaDev(),
@@ -327,15 +327,17 @@ commResult_t CtranAlgo::initKernelResources() {
   const size_t nvlMaxNumChannels =
       static_cast<size_t>(std::max(1, CTRAN_ALGO_MAX_THREAD_BLOCKS));
   if (nvlPipelineDepth == 0) {
-    CLOGF(ERR, "CTRAN-ALGO: invalid NVL P2P config; pipelineDepth=0");
+    CERR(
+        commInvalidArgument,
+        "CTRAN-ALGO: invalid NVL P2P config; pipelineDepth=0");
     return commInvalidArgument;
   }
   const size_t nvlChannelAlign = 16ULL * nvlPipelineDepth;
   const size_t nvlPerChannelBuffer =
       alignDown(nvlSharedDevbufSize / nvlMaxNumChannels, nvlChannelAlign);
   if (nvlPerChannelBuffer == 0) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInvalidArgument,
         "CTRAN-ALGO: invalid NVL P2P config; sharedDevbufSize={} maxNumChannels={} pipelineDepth={} cannot produce aligned per-channel buffer",
         nvlSharedDevbufSize,
         nvlMaxNumChannels,
@@ -946,8 +948,8 @@ commResult_t CtranAlgo::initializeCommAttributesMap() {
     auto coll = getCollType(commAttrKeyValuePair.first);
     auto& statex = comm_->statex_;
     if (coll == CollType::UNKNOWN) {
-      CLOGF(
-          ERR,
+      CERR(
+          commInternalError,
           "CTRAN-ALGO: Unknown collective type {} in pimpl {} commHash {:x}, commDesc {}.",
           commAttrKeyValuePair.first,
           (void*)this,
@@ -972,8 +974,8 @@ commResult_t CtranAlgo::initializeCommAttributesMap() {
           commAttrKeyValuePair.second[qpConfigIndex::VC_MODE] == "dqplb") {
         config.vcMode = NCCL_CTRAN_IB_VC_MODE::dqplb;
       } else {
-        CLOGF(
-            ERR,
+        CERR(
+            commInternalError,
             "CTRAN-ALGO: Invalid VC mode {} in pimpl {} commHash {:x}, commDesc {}.",
             commAttrKeyValuePair.second[qpConfigIndex::VC_MODE],
             (void*)this,
@@ -983,8 +985,8 @@ commResult_t CtranAlgo::initializeCommAttributesMap() {
       }
       collToVcConfigMap_[coll] = config;
     } else {
-      CLOGF(
-          ERR,
+      CERR(
+          commInternalError,
           "CTRAN-ALGO: Invalid collective->vc config specified for {} in pimpl {} commHash {:x}, commDesc {}. Expected {} parameters but received only {}",
           commAttrKeyValuePair.first,
           (void*)this,

--- a/comms/ctran/algos/RMA/Get.cc
+++ b/comms/ctran/algos/RMA/Get.cc
@@ -30,7 +30,9 @@ static commResult_t getImpl(
 
   // IB backend must be available for current Get implementation
   if (!comm->ctran_->mapper->hasBackend(peerRank, CtranMapperBackend::IB)) {
-    CLOGF(ERR, "GET only support IB backend for now, and no IB backend found");
+    CERR(
+        commInternalError,
+        "GET only support IB backend for now, and no IB backend found");
     return commInternalError;
   }
 
@@ -109,8 +111,8 @@ commResult_t ctranGet(
   size_t countNbytes = count * commTypeSize(datatype);
   size_t peerWinSize = win->getDataSize(peer);
   if ((targetDispNbytes + countNbytes) > peerWinSize) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInvalidArgument,
         "Invalid target displacement from {} bytes to {} bytes exceeding peer {}'s window size {}",
         targetDispNbytes,
         targetDispNbytes + countNbytes,

--- a/comms/ctran/algos/RMA/PutSignal.cc
+++ b/comms/ctran/algos/RMA/PutSignal.cc
@@ -57,8 +57,8 @@ inline static commResult_t checkDisplacementBounds(
   size_t totalBytes = dispNbytes + (elemSize * elemCount);
 
   if (totalBytes > winSize) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInvalidArgument,
         "Invalid displacement from {} bytes to {} bytes exceeding the window size {}",
         dispNbytes,
         totalBytes,
@@ -72,8 +72,8 @@ inline static commResult_t checkSignalDisplacement(
     size_t disp,
     size_t signalSize) {
   if (disp > signalSize) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInvalidArgument,
         "Invalid displacement {} exceeding the signal buffer size {}",
         disp,
         signalSize);
@@ -409,8 +409,8 @@ waitSignalDriverApi(int peer, CtranWin* win, cudaStream_t stream) {
 
     // Propagate other errors - do not fallback as they may indicate
     // stream corruption from prior async operations
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "CTRAN RMA: Hardware wait failed with error ({}), not falling back",
         errStr ? errStr : "unknown error");
     return commInternalError;

--- a/comms/ctran/algos/RMA/PutSignal.cc
+++ b/comms/ctran/algos/RMA/PutSignal.cc
@@ -98,7 +98,7 @@ static commResult_t putSignalImpl(
 
   // The IB backend must be available
   if (!comm->ctran_->mapper->hasBackend(peerRank, CtranMapperBackend::IB)) {
-    CLOGF(ERR, "Put signal doesn't have IB backend");
+    CERR(commInternalError, "Put signal doesn't have IB backend");
     return commInternalError;
   }
 
@@ -173,7 +173,7 @@ static commResult_t signalImpl(
 
   // The IB backend must be available
   if (!comm->ctran_->mapper->hasBackend(peerRank, CtranMapperBackend::IB)) {
-    CLOGF(ERR, "Signal doesn't have IB backend");
+    CERR(commInternalError, "Signal doesn't have IB backend");
     return commInternalError;
   }
 

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterDirect.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterDirect.cc
@@ -184,8 +184,8 @@ commResult_t ctranReduceScatterDirect(
       stream);
 
   if (comm->statex_->nNodes() > 1) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "ctranReduceScatterDirect supports only single node, but nNodes={}",
         comm->statex_->nNodes());
     return commInternalError;

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterDirectIb.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterDirectIb.cc
@@ -86,32 +86,32 @@ commResult_t validateDirectIbReduceScatter(
   const int nRanks = statex->nRanks();
 
   if (datatype != commFloat32) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInvalidArgument,
         "ReduceScatter {} supports commFloat32 only; got {}",
         reduceScatterAlgoName(myAlgo),
         commDataTypeToString(datatype));
     return commInvalidArgument;
   }
   if (redOp != commSum) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInvalidArgument,
         "ReduceScatter {} supports commSum only; got {}",
         reduceScatterAlgoName(myAlgo),
         commOpToString(redOp));
     return commInvalidArgument;
   }
   if (nRanks <= 1) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInvalidArgument,
         "ReduceScatter {} requires multiple ranks, got nRanks={}",
         reduceScatterAlgoName(myAlgo),
         nRanks);
     return commInvalidArgument;
   }
   if (nRanks > comms::prims::kDirectReduceScatterIbMaxRanks) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInvalidArgument,
         "ReduceScatter {} nRanks={} exceeds max {}",
         reduceScatterAlgoName(myAlgo),
         nRanks,
@@ -119,8 +119,8 @@ commResult_t validateDirectIbReduceScatter(
     return commInvalidArgument;
   }
   if (!comm->multiPeerTransport_) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInvalidArgument,
         "ReduceScatter {} requires MultiPeerTransport (NCCL_CTRAN_USE_PIPES=1)",
         reduceScatterAlgoName(myAlgo));
     return commInvalidArgument;
@@ -130,8 +130,8 @@ commResult_t validateDirectIbReduceScatter(
   size_t totalBytes = 0;
   if (!reduceScatterByteSizes(
           recvcount, nRanks, datatype, recvBytes, totalBytes)) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInvalidArgument,
         "ReduceScatter {} byte size overflows size_t for recvcount={} nRanks={}",
         reduceScatterAlgoName(myAlgo),
         recvcount,
@@ -144,8 +144,8 @@ commResult_t validateDirectIbReduceScatter(
   uintptr_t recvEnd = 0;
   if (!checkedAdd(sendAddr, totalBytes, sendEnd) ||
       !checkedAdd(recvAddr, recvBytes, recvEnd)) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInvalidArgument,
         "ReduceScatter {} buffer range overflows address space",
         reduceScatterAlgoName(myAlgo));
     return commInvalidArgument;
@@ -153,8 +153,8 @@ commResult_t validateDirectIbReduceScatter(
   const bool inPlace = isExactReduceScatterInPlace(
       sendAddr, recvAddr, recvBytes, statex->rank());
   if (!inPlace && rangesOverlap(sendAddr, totalBytes, recvAddr, recvBytes)) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInvalidArgument,
         "ReduceScatter {} supports out-of-place buffers or exact ReduceScatter in-place aliasing only",
         reduceScatterAlgoName(myAlgo));
     return commInvalidArgument;
@@ -166,8 +166,8 @@ commResult_t validateDirectIbReduceScatter(
       continue;
     }
     if (!mpt->has_ibgda(peer) || !mpt->prefers_ibgda(peer)) {
-      CLOGF(
-          ERR,
+      CERR(
+          commInvalidArgument,
           "ReduceScatter {} requires preferred IBGDA transport for peer {}, has_ibgda={} prefers_ibgda={}",
           reduceScatterAlgoName(myAlgo),
           peer,
@@ -214,6 +214,12 @@ commResult_t ctranReduceScatterDirectIb(
   size_t totalBytes = 0;
   if (!reduceScatterByteSizes(
           recvcount, nRanks, datatype, recvBytes, totalBytes)) {
+    CERR(
+        commInvalidArgument,
+        "ReduceScatter {} byte size overflows size_t for recvcount={} nRanks={}",
+        reduceScatterAlgoName(myAlgo),
+        recvcount,
+        nRanks);
     return commInvalidArgument;
   }
 
@@ -284,7 +290,9 @@ commResult_t ctranReduceScatterDirectIb(
     commRedOp_t /*redOp*/,
     CtranComm* /*comm*/,
     cudaStream_t /*stream*/) {
-  CLOGF(ERR, "ReduceScatter CtranReduceScatterDirectIb requires ENABLE_PRIMS");
+  CERR(
+      commInvalidArgument,
+      "ReduceScatter CtranReduceScatterDirectIb requires ENABLE_PRIMS");
   return commInvalidArgument;
 }
 

--- a/comms/ctran/algos/SendRecv/SendRecvImpl.h
+++ b/comms/ctran/algos/SendRecv/SendRecvImpl.h
@@ -76,8 +76,8 @@ inline commResult_t selfSendRecvImpl(
     CtranComm* comm) {
   const auto statex = comm->statex_.get();
   if (selfSends.size() != selfRecvs.size()) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInvalidUsage,
         "Invalid usage: number of self ncclSend ({}) and ncclRecv ({}) does not match on rank {}",
         selfSends.size(),
         selfRecvs.size(),

--- a/comms/ctran/algos/common/AdaptiveTransfer.h
+++ b/comms/ctran/algos/common/AdaptiveTransfer.h
@@ -42,7 +42,8 @@ inline commResult_t checkAndSetTransferMode(
   if (backend == CtranMapperBackend::IB) {
     auto regCache = ctran::RegCache::getInstance();
     if (!regCache) {
-      CLOGF(ERR, "CTRAN-ADAPTIVE: Failed to get RegCache instance");
+      CERR(
+          commInternalError, "CTRAN-ADAPTIVE: Failed to get RegCache instance");
       return commInternalError;
     }
 

--- a/comms/ctran/backends/ib/BootstrapExternal.cc
+++ b/comms/ctran/backends/ib/BootstrapExternal.cc
@@ -82,8 +82,8 @@ commResult_t BootstrapExternal::connectVc(
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = pendingVcs_.find(peerRank);
     if (it == pendingVcs_.end()) {
-      CLOGF(
-          ERR,
+      CERR(
+          commInternalError,
           "CTRAN-IB: BootstrapExternal::connectVc called for peerRank {} before "
           "getLocalVcId. commHash {:x}, commDesc {}",
           peerRank,

--- a/comms/ctran/backends/ib/BootstrapInternal.cc
+++ b/comms/ctran/backends/ib/BootstrapInternal.cc
@@ -224,8 +224,8 @@ commResult_t Bootstrap::exchangeAndPublish(
     bool isServer,
     int peerRank) {
   if (peerRank < 0 || (comm_ && peerRank >= comm_->statex_->nRanks())) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "invalid peerRank ({}) < 0 or >= nRanks {}",
         peerRank,
         comm_ ? comm_->statex_->nRanks() : -1);

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -65,8 +65,8 @@ bool CtranIb::shouldEnableLocalFlushByDefault(int cudaArch) {
 commResult_t checkEpochLock(CtranIb* ctranIb) {
   if (NCCL_CTRAN_IB_EPOCH_LOCK_ENFORCE_CHECK &&
       NCCL_CTRAN_IB_EPOCH_LOCK_ENABLE && !epochLockedFlags[ctranIb].load()) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "NCCL_CTRAN_IB_EPOCH_LOCK_ENABLE is set to true, but the critical section is called "
         "without acquiring the epoch lock on the calling thread. It is likely a NCCL bug.");
     return commInternalError;
@@ -745,8 +745,8 @@ commResult_t CtranIb::epochLock() {
   }
 
   if (epochLockedFlags[this].load()) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "epochLock() already called on the same thread without epochUnlock(). It is likely a COMM bug.");
     return commInternalError;
   }
@@ -763,8 +763,8 @@ commResult_t CtranIb::epochTryLock() {
   }
 
   if (epochLockedFlags[this].load()) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "epochLock() already called on the same thread without epochUnlock(). It is likely a COMM bug.");
     return commInternalError;
   }
@@ -783,8 +783,8 @@ commResult_t CtranIb::epochUnlock() {
   }
 
   if (!epochLockedFlags[this].load()) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "epochUnlock() is called without an outstanding epochLock() on the thread. It is likely a COMM bug.");
     return commInternalError;
   }
@@ -801,8 +801,8 @@ commResult_t CtranIb::regMem(
     void** ibRegElem) {
   commResult_t res = commSuccess;
   if (len < CTRAN_MIN_REGISTRATION_SIZE && NCCL_CTRAN_REGISTRATION_SIZE_CHECK) {
-    CLOGF(
-        ERR,
+    CERR(
+        commSystemError,
         "CTRAN-IB: cannot register buffer, size ({}) < {}",
         len,
         CTRAN_MIN_REGISTRATION_SIZE);
@@ -862,8 +862,8 @@ commResult_t CtranIb::regMem(
       // fall back to ibv_reg_mr
       if (comms::utils::cumem::isBackedByMultipleCuMemAllocations(
               buf, cudaDev, len)) {
-        CLOGF(
-            ERR,
+        CERR(
+            commInvalidUsage,
             "CTRAN-IB: Memory region (buf {}, len {}) spans multiple cuMem allocations, ibv_reg_mr may fail!",
             buf,
             len);
@@ -1091,8 +1091,8 @@ commResult_t CtranIb::setPgToTrafficClassMap() {
     std::vector<std::string> pgTrafficClassPair;
     folly::split(":", pgTrafficClassPairStr, pgTrafficClassPair);
     if (pgTrafficClassPair.size() != 2) {
-      CLOGF(
-          ERR,
+      CERR(
+          commInternalError,
           "CTRAN-IB: Invalid PG->Traffic class pair {} in pimpl {} commHash {:x}, commDesc {}.",
           pgTrafficClassPairStr,
           (void*)this,
@@ -1103,8 +1103,8 @@ commResult_t CtranIb::setPgToTrafficClassMap() {
     std::string tcStr = pgTrafficClassPair[1];
     auto tc = folly::tryTo<uint32_t>(tcStr);
     if (!tc.hasValue()) {
-      CLOGF(
-          ERR,
+      CERR(
+          commInternalError,
           "CTRAN-IB: Invalid Traffic Class value provided {} in pimpl {} commHash {:x}, commDesc {}.",
           tcStr,
           (void*)this,

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -114,7 +114,7 @@ CtranIbSingleton::CtranIbSingleton() {
         "Set NCCL_CTRAN_BACKENDS=nvl,socket to use alternative backends.",
         ibvDevices.size(),
         NCCL_CTRAN_IB_DEVICES_PER_RANK);
-    CLOGF(ERR, msg);
+    CERR(commSystemError, "{}", msg);
     throw ctran::utils::Exception(msg, commSystemError);
   }
 
@@ -462,7 +462,7 @@ void CtranIb::init(
         std::to_string(NCCL_CTRAN_IB_DEVICES_PER_RANK) +
         ") exceeds CTRAN_MAX_IB_DEVICES_PER_RANK (" +
         std::to_string(CTRAN_MAX_IB_DEVICES_PER_RANK) + ")";
-    CLOGF(ERR, "CTRAN-IB: {}", msg);
+    CERR(commInvalidArgument, "CTRAN-IB: {}", msg);
     throw ::ctran::utils::Exception(
         msg.c_str(),
         commInvalidArgument,
@@ -477,7 +477,7 @@ void CtranIb::init(
     std::string msg = "cudaDev (" + std::to_string(cudaDev) +
         ") * NCCL_CTRAN_IB_DEVICES_PER_RANK * NCCL_CTRAN_IB_DEVICE_STRIDE exceeds the number of contexts (" +
         std::to_string(s->ibvDevices.size()) + ")";
-    CLOGF(ERR, "CTRAN-IB: {}", msg);
+    CERR(commSystemError, "CTRAN-IB: {}", msg);
     throw ::ctran::utils::Exception(
         msg.c_str(),
         commSystemError,
@@ -636,7 +636,7 @@ void CtranIb::init(
         "gets at least one data QP.",
         NCCL_CTRAN_IB_MAX_QPS,
         maxVcsPerPeer);
-    CLOGF(ERR, msg);
+    CERR(commInvalidArgument, "{}", msg);
     throw ctran::utils::Exception(msg, commInvalidArgument);
   }
   vcLayout_ = ctran::ib::VcLayout(numNics, maxVcsPerPeer);

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -599,8 +599,8 @@ class CtranIb {
 
   inline commResult_t checkValidPeer(int peerRank) {
     if (peerRank < 0 || (comm && peerRank >= comm->statex_->nRanks())) {
-      CLOGF(
-          ERR,
+      CERR(
+          commInternalError,
           "invalid peerRank ({}) < 0 or >= nRanks {}",
           peerRank,
           comm ? comm->statex_->nRanks() : -1);
@@ -613,8 +613,8 @@ class CtranIb {
       std::shared_ptr<CtranIbVirtualConn>& vc,
       int peerRank) {
     if (vc == nullptr) {
-      CLOGF(
-          ERR,
+      CERR(
+          commInternalError,
           "No valid VirtualConnection (VC) found for peerRank {}",
           peerRank);
       return commInternalError;
@@ -633,8 +633,11 @@ class CtranIb {
     deviceEnd = numNics;
     if (device.has_value()) {
       if (*device < 0 || *device >= numNics) {
-        CLOGF(
-            ERR, "CTRAN-IB: invalid device {} (numNics={})", *device, numNics);
+        CERR(
+            commInternalError,
+            "CTRAN-IB: invalid device {} (numNics={})",
+            *device,
+            numNics);
         return commInternalError;
       }
       deviceBegin = *device;
@@ -1080,8 +1083,8 @@ class CtranIb {
         std::shared_ptr<CtranIbVirtualConn> vc =
             vcState_.getVcByQp<PerfConfig>(std::make_pair(wc.qp_num, device));
         if (vc == nullptr) {
-          CLOGF(
-              ERR,
+          CERR(
+              commInternalError,
               "No valid VirtualConnection (VC) found for qpn {}",
               wc.qp_num);
           return commInternalError;

--- a/comms/ctran/backends/ib/CtranIbBase.h
+++ b/comms/ctran/backends/ib/CtranIbBase.h
@@ -62,7 +62,7 @@ class CtranIbRequest {
   inline commResult_t complete() {
     this->refCount_--;
     if (this->refCount_ < 0) {
-      CLOGF(ERR, "CTRAN-IB: req {} refCount_ < 0", (void*)this);
+      CERR(commInternalError, "CTRAN-IB: req {} refCount_ < 0", (void*)this);
       return commInternalError;
     }
     if (this->refCount_ == 0) {

--- a/comms/ctran/backends/ib/CtranIbImpl.h
+++ b/comms/ctran/backends/ib/CtranIbImpl.h
@@ -32,7 +32,7 @@
           wc.qp_num,                                                                                  \
           wc.status,                                                                                  \
           ibv_wc_status_str(wc.status));                                                              \
-      CLOGF(ERR, "{}", errMsg);                                                                       \
+      CERR(commRemoteError, "{}", errMsg);                                                            \
       return commRemoteError;                                                                         \
     }                                                                                                 \
   } while (0)

--- a/comms/ctran/backends/ib/CtranIbVc.cc
+++ b/comms/ctran/backends/ib/CtranIbVc.cc
@@ -539,8 +539,8 @@ commResult_t CtranIbVirtualConn::setupVc(void* remoteBusCard) {
 
   // Validate that QPs have been initialized via getLocalBusCard()
   if (!areQpsInitialized()) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "CTRAN-IB-VC: setupVc called before getLocalBusCard(). "
         "QPs not initialized: controlQp={}, notifyQp={}, atomicQp={}, dataQps={}. "
         "peerRank={}",
@@ -562,8 +562,8 @@ commResult_t CtranIbVirtualConn::setupVc(void* remoteBusCard) {
     QpUniqueId qpId =
         std::make_pair(this->ibvDataQps_.at(i).qp()->qp_num, ibDevice);
     if (qpNumToIdx_.find(qpId) != qpNumToIdx_.end()) {
-      CLOGF(
-          ERR,
+      CERR(
+          commInternalError,
           "CTRAN-IB-VC: QP {} on device {} already exists",
           this->ibvDataQps_.at(i).qp()->qp_num,
           ibDevice);

--- a/comms/ctran/backends/ib/CtranIbVc.h
+++ b/comms/ctran/backends/ib/CtranIbVc.h
@@ -726,8 +726,8 @@ class CtranIbVirtualConn {
       int device) {
     auto smrs = reinterpret_cast<std::vector<ibverbx::IbvMr>*>(put.ibRegElem);
     if (smrs == nullptr) {
-      CLOGF(
-          ERR,
+      CERR(
+          commSystemError,
           "CTRAN-IB: memory registration not found for addr {}",
           (void*)put.sbuf);
       return commSystemError;
@@ -854,8 +854,8 @@ class CtranIbVirtualConn {
 
     auto smrs = reinterpret_cast<std::vector<ibverbx::IbvMr>*>(ibRegElem);
     if (smrs == nullptr) {
-      CLOGF(
-          ERR,
+      CERR(
+          commSystemError,
           "CTRAN-IB: memory registration not found for addr {}",
           (void*)sbuf);
       return commSystemError;
@@ -960,8 +960,8 @@ class CtranIbVirtualConn {
 
     auto smrs = reinterpret_cast<std::vector<ibverbx::IbvMr>*>(ibRegElem);
     if (smrs == nullptr) {
-      CLOGF(
-          ERR,
+      CERR(
+          commSystemError,
           "CTRAN-IB: memory registration not found for addr {}",
           (void*)dbuf);
       return commSystemError;
@@ -992,8 +992,8 @@ class CtranIbVirtualConn {
       // sanity check
       // all previous spray messages should be completed
       if (outstandingGets_.size() > 0 || pendingGets_.size() > 0) {
-        CLOGF(
-            ERR,
+        CERR(
+            commSystemError,
             "igetFast issued when previous regular gets are still in progress: outstandingGets {}, pendingGets {}",
             outstandingGets_.size(),
             pendingGets_.size());
@@ -1003,8 +1003,8 @@ class CtranIbVirtualConn {
       uint64_t maxWqeSize = maxWqeSizeFor(config, len, /*qps=*/1);
 
       if (len > maxWqeSize) {
-        CLOGF(
-            ERR,
+        CERR(
+            commSystemError,
             "igetFast issued with len {} > maxWqeSize {}",
             len,
             maxWqeSize);
@@ -1012,8 +1012,8 @@ class CtranIbVirtualConn {
       }
 
       if (outstandingFastGets_.size() >= maxQpMsgs_) {
-        CLOGF(
-            ERR,
+        CERR(
+            commSystemError,
             "igetFast issued when outstanding fast gets {} > maxQpMsgs_ {}",
             outstandingFastGets_.size(),
             maxQpMsgs_);
@@ -1073,8 +1073,8 @@ class CtranIbVirtualConn {
       CtranIbRequest* req) {
     auto smrs = reinterpret_cast<std::vector<ibverbx::IbvMr>*>(ibRegElem);
     if (smrs == nullptr) {
-      CLOGF(
-          ERR,
+      CERR(
+          commSystemError,
           "CTRAN-IB: memory registration not found for addr {}",
           (void*)sbuf);
       return commSystemError;
@@ -1244,7 +1244,7 @@ class CtranIbVirtualConn {
       } break;
 
       default:
-        CLOGF(ERR, "CTRAN-IB: Found unknown opcode: {}", opcode);
+        CERR(commSystemError, "CTRAN-IB: Found unknown opcode: {}", opcode);
         return commSystemError;
     }
 
@@ -1690,8 +1690,8 @@ class CtranIbVirtualConn {
       }
       pendingAtomicReqs_.pop_front();
     } else {
-      CLOGF(
-          ERR,
+      CERR(
+          commInternalError,
           "CTRAN-IB-VC: Received completion for atomic Ops but no pending request");
       return commInternalError;
     }

--- a/comms/ctran/backends/ib/VcState.cc
+++ b/comms/ctran/backends/ib/VcState.cc
@@ -43,8 +43,8 @@ commResult_t VcState::setupAndPublishVc(
     const std::vector<std::string>& remoteVcIdentifiers,
     int peerRank) {
   if (vcs.empty() || vcs.size() != remoteVcIdentifiers.size()) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "CTRAN-IB: setupAndPublishVc called with vcs.size()={} remoteVcIdentifiers.size()={} for peerRank {} in pimpl {} commHash {:x} commDesc {}",
         vcs.size(),
         remoteVcIdentifiers.size(),
@@ -66,8 +66,8 @@ commResult_t VcState::setupAndPublishVc(
   {
     auto locked = vcStateMaps_.wlock();
     if (locked->rankToVcs.find(peerRank) != locked->rankToVcs.end()) {
-      CLOGF(
-          ERR,
+      CERR(
+          commInternalError,
           "CTRAN-IB: VirtualConnection (VC) already exists for peerRank {} in pimpl {} commHash {:x}, commDesc {}. It likely indicates a COMM bug.",
           peerRank,
           owner_,
@@ -150,8 +150,8 @@ commResult_t VcState::checkAndInsertQpToVcMap(
     QpUniqueId& qpId,
     std::shared_ptr<CtranIbVirtualConn>& vc) {
   if (map.find(qpId) != map.end()) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "CTRAN-IB: QP {} on device {} already exists in pimpl {} commHash {:x}, commDesc {}. It likely indicates a COMM bug.",
         qpId.first,
         qpId.second,

--- a/comms/ctran/backends/ib/ibutils.cc
+++ b/comms/ctran/backends/ib/ibutils.cc
@@ -20,12 +20,6 @@ using namespace ctran::ibvwrap;
 
 namespace {
 static folly::Singleton<VerbsUtils> kVerbsUtils;
-
-static inline commResult_t addToStackTrace(const std::string errorMessage) {
-  CLOGF(ERR, "{}", errorMessage.c_str());
-  ErrorStackTraceUtil::logErrorMessage(errorMessage);
-  return commSystemError;
-}
 } // namespace
 
 /* Set ibv_get_async_event to poll mode intead of default blocking mode.
@@ -43,11 +37,13 @@ commResult_t IbUtils::pollForAsyncEvent(
   int flags = fcntl(fdSet.fd, F_GETFL);
 
   if (flags == -1) {
-    return addToStackTrace("fcntl flags failure");
+    CERR(commSystemError, "fcntl flags failure");
+    return commSystemError;
   }
   auto ret = fcntl(fdSet.fd, F_SETFL, flags | O_NONBLOCK);
   if (ret == -1) {
-    return addToStackTrace("fcntl set NONBLOCK failure");
+    CERR(commSystemError, "fcntl set NONBLOCK failure");
+    return commSystemError;
   }
 
   bool stopRequested = false;
@@ -77,16 +73,18 @@ commResult_t IbUtils::pollForAsyncEvent(
     return commSystemError;
   }
   if (ret < 0) {
-    return addToStackTrace(
-        fmt::format(
-            "NET/IB : poll for IB async events failed with error code:{}",
-            ret));
+    CERR(
+        commSystemError,
+        "NET/IB : poll for IB async events failed with error code:{}",
+        ret);
+    return commSystemError;
   }
   if ((fdSet.revents & POLLIN) != POLLIN) {
-    return addToStackTrace(
-        fmt::format(
-            "NET/IB : poll returned unexpected POLLERR or POLLHUP for dev={} (probably a bad device)",
-            ibvContext->device->name));
+    CERR(
+        commSystemError,
+        "NET/IB : poll returned unexpected POLLERR or POLLHUP for dev={} (probably a bad device)",
+        ibvContext->device->name);
+    return commSystemError;
   }
   return commSuccess;
 }
@@ -112,7 +110,7 @@ void IbUtils::timeoutHandler(
           locked.as_lock(), duration, [&] { return *locked; })) {
     std::string errorMessage = fmt::format(
         "Link down timeout reached for {} ({} ms).", devName, duration.count());
-    addToStackTrace(errorMessage);
+    CERR(commSystemError, "{}", errorMessage);
     XLOGF(
         WARN,
         "ctranCommSetAsyncError: error comm NULL sets state %d",
@@ -215,7 +213,7 @@ commResult_t IbUtils::triageIbAsyncEvents(
       // a link down event is not considered an error unless it is down
       // for a period longer than the configured timeout
       // so do not return commSystemError here
-      addToStackTrace(msg);
+      CERR(commSystemError, "{}", msg);
       // for now, only ctran supports timer
       if (NCCL_IB_ASYNC_EVENT_LOOP == NCCL_IB_ASYNC_EVENT_LOOP::ctran) {
         // set timer; if timer expires it will trigger an error
@@ -233,7 +231,7 @@ commResult_t IbUtils::triageIbAsyncEvents(
     case ibverbx::IBV_EVENT_SRQ_ERR:
     case ibverbx::IBV_EVENT_DEVICE_FATAL:
       ret = commSystemError;
-      addToStackTrace(msg);
+      CERR(commSystemError, "{}", msg);
       // preserve baseline functionality by not sending async error
       if (NCCL_IB_ASYNC_EVENT_LOOP == NCCL_IB_ASYNC_EVENT_LOOP::ctran) {
         XLOGF(

--- a/comms/ctran/backends/socket/CtranSocket.cc
+++ b/comms/ctran/backends/socket/CtranSocket.cc
@@ -132,7 +132,7 @@ void CtranSocket::init(const SocketServerAddr& serverAddr) {
           "CTRAN-SOCKET: No socket interfaces found (NCCL_SOCKET_IFNAME={}, NCCL_SOCKET_IPADDR_PREFIX={})",
           NCCL_SOCKET_IFNAME,
           NCCL_SOCKET_IPADDR_PREFIX);
-      CLOGF(ERR, msg);
+      CERR(commSystemError, "{}", msg);
       throw ctran::utils::Exception(
           msg, commSystemError, rank_, commHash_, commDesc_);
     } else {

--- a/comms/ctran/backends/socket/CtranSocket.cc
+++ b/comms/ctran/backends/socket/CtranSocket.cc
@@ -304,8 +304,8 @@ commResult_t CtranSocket::updateSocket(
     int peerRank) {
   auto locked = socketMaps_.wlock();
   if (locked->rankToSocket.find(peerRank) != locked->rankToSocket.end()) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "CTRAN-SOCKET: socket already exists for peerRank {} in pimpl {} "
         "commHash {:x}, commDesc {}. It likely indicates a NCCL bug.",
         peerRank,
@@ -429,8 +429,10 @@ commResult_t CtranSocket::progressInternal() {
     continueWhileLoop = false;
     int count = poll(fds.data(), fds.size(), NCCL_CTRAN_SOCKET_POLL_TIMEOUT);
     if (count < 0) {
-      CLOGF_SUBSYS(
-          ERR, COLL, "CTRAN-SOCKET: polling error, errno {}", strerror(errno));
+      CERR(
+          commInternalError,
+          "CTRAN-SOCKET: polling error, errno {}",
+          strerror(errno));
       return commInternalError;
     } else if (count > 0) {
       CLOGF_TRACE(COLL, "CTRAN-SOCKET: polling returns {} events", count);
@@ -477,9 +479,8 @@ commResult_t CtranSocket::progressInternal() {
               bytes_read);
         }
       } else if (fds[fid].revents != 0) {
-        CLOGF_SUBSYS(
-            ERR,
-            COLL,
+        CERR(
+            commInternalError,
             "CTRAN-SOCKET: unexpected poll event {} rank {}",
             fds[fid].revents,
             peerRanks[fid]);

--- a/comms/ctran/backends/socket/CtranSocket.h
+++ b/comms/ctran/backends/socket/CtranSocket.h
@@ -111,8 +111,8 @@ class CtranSocket {
 
   inline commResult_t checkValidPeer(int peerRank) {
     if (peerRank < 0 || (comm && peerRank >= comm->statex_->nRanks())) {
-      CLOGF(
-          ERR,
+      CERR(
+          commInternalError,
           "invalid peerRank ({}) < 0 or >= nRanks {}",
           peerRank,
           comm ? comm->statex_->nRanks() : -1);

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -66,8 +66,8 @@ commResult_t mapBootstrapSocketError(
     return commRemoteError;
   }
 
-  CLOGF(
-      ERR,
+  CERR(
+      commInternalError,
       "CTRAN-TCPDM: bootstrap {} failed with peer {} on rank {} commHash {:x} commDesc {} errno={}",
       op,
       peerRank,

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -1219,8 +1219,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
           if (cudaErr == cudaSuccess) {
             *isComplete = true;
           } else if (cudaErr != cudaErrorNotReady) {
-            CLOGF(
-                ERR,
+            CERR(
+                commSystemError,
                 "CTRAN: cudaStreamQuery returned error '{}'",
                 cudaGetErrorString(cudaErr));
             return commSystemError;
@@ -1265,7 +1265,10 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         this->ctranTcpDm->cancelQueuedRecv(&notify->tcpDmReq);
       }
     } else {
-      CLOGF(ERR, "CTRAN-MAPPER: unexpected backend {}", notify->backend);
+      CERR(
+          commInternalError,
+          "CTRAN-MAPPER: unexpected backend {}",
+          notify->backend);
       return commInternalError;
     }
 
@@ -1367,8 +1370,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         FB_COMMCHECK(ipcRegCache->exportMem(
             buf, regElem->ipcRegElem, msg.ipcDesc, tmpExtraSegments));
         if (!tmpExtraSegments.empty()) {
-          CLOGF(
-              ERR,
+          CERR(
+              commInternalError,
               "CTRAN-MAPPER: exportMem to rank {} has overflow segments, which is "
               "not supported in this path.",
               rank);
@@ -1387,8 +1390,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       // No need to export the buffers, TCP device memory is steered by
       // the receiver.
     } else {
-      CLOGF(
-          ERR,
+      CERR(
+          commInvalidUsage,
           "CTRAN-MAPPER: Cannot export buffer {} to rank {}. The rank may not be "
           "reachable by any backend, or buffer type is not supported.",
           (void*)buf,
@@ -1417,8 +1420,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     switch (msg.type) {
       case ControlMsgType::IB_EXPORT_MEM:
         if (!this->ctranIb) {
-          CLOGF(
-              ERR,
+          CERR(
+              commInternalError,
               "CTRAN-MAPPER: IB backend is disabled but received unexpected internal control msg ({})",
               msg.toString());
           return commInternalError;
@@ -1428,8 +1431,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         break;
       case ControlMsgType::NVL_EXPORT_MEM: {
         if (!this->ctranNvl) {
-          CLOGF(
-              ERR,
+          CERR(
+              commInternalError,
               "CTRAN-MAPPER: NVL backend is disabled but received unexpected internal control msg ({})",
               msg.toString());
           return commInternalError;
@@ -1450,8 +1453,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         break;
       }
       default:
-        CLOGF(
-            ERR,
+        CERR(
+            commInternalError,
             "CTRAN-MAPPER: Received unexpected control message type {}",
             msg.type);
         return commInternalError;
@@ -1781,7 +1784,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       const std::vector<CtranMapperPutMsg>& puts,
       int peerRank) {
     if (this->ctranIb == nullptr) {
-      CLOGF(ERR, "CTRAN-MAPPER: ctranIB is null in batch put.");
+      CERR(commInternalError, "CTRAN-MAPPER: ctranIB is null in batch put.");
       return commInternalError;
     }
     std::vector<PutIbMsg> msgs;
@@ -1789,8 +1792,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     for (auto& put : puts) {
       const auto& remoteAccessKey = put.config.remoteAccessKey_;
       if (remoteAccessKey.backend != CtranMapperBackend::IB) {
-        CLOGF(
-            ERR,
+        CERR(
+            commInternalError,
             "CTRAN-MAPPER: Unsupported remote access key backend {}",
             backendToStr(remoteAccessKey.backend));
         return commInternalError;
@@ -1907,11 +1910,15 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
             config.ibFastPath_));
       } else {
         if (req == nullptr) {
-          CLOGF(ERR, "CTRAN-MAPPER: Unsupported TCPDM iput without request");
+          CERR(
+              commInternalError,
+              "CTRAN-MAPPER: Unsupported TCPDM iput without request");
           return commInternalError;
         }
         if (!notify) {
-          CLOGF(ERR, "CTRAN-MAPPER: Unsupported TCPDM iput without notify");
+          CERR(
+              commInternalError,
+              "CTRAN-MAPPER: Unsupported TCPDM iput without notify");
           return commInternalError;
         }
 
@@ -1941,8 +1948,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
           len);
 
       if (!kernElem) {
-        CLOGF(
-            ERR,
+        CERR(
+            commInternalError,
             "CTRAN-MAPPER: NVL PUT requires valid kernElem. It indicates a COMM internal bug");
         return commInternalError;
       }
@@ -1959,8 +1966,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       kernElem->post();
     } else {
       auto backendStr = backendToStr(remoteAccessKey.backend);
-      CLOGF(
-          ERR,
+      CERR(
+          commInternalError,
           "CTRAN-MAPPER: Unsupported remote access key backend {}",
           backendStr.c_str());
       return commInternalError;
@@ -1999,8 +2006,9 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
           req->backend = CtranMapperBackend::IB;
           req->setConfig(config);
         } else {
-          CLOGF(
-              ERR, "CTRAN-MAPPER: Unsupported backend iget without IB backend");
+          CERR(
+              commInternalError,
+              "CTRAN-MAPPER: Unsupported backend iget without IB backend");
           return commInternalError;
         }
       }
@@ -2031,16 +2039,16 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
             ibReqPtr,
             config.ibFastPath_));
       } else {
-        CLOGF(
-            ERR,
+        CERR(
+            commInternalError,
             "CTRAN-MAPPER: IB backend required for iget operation, but not available.");
 
         return commInternalError;
       }
     } else {
       auto backendStr = backendToStr(remoteAccessKey.backend);
-      CLOGF(
-          ERR,
+      CERR(
+          commInternalError,
           "CTRAN-MAPPER: Unsupported remote access key backend {}",
           backendStr.c_str());
       return commInternalError;
@@ -2058,7 +2066,9 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperRequest* req) {
     const auto& remoteAccessKey = config.remoteAccessKey_;
     if (remoteAccessKey.backend != CtranMapperBackend::IB) {
-      CLOGF(ERR, "CTRAN-MAPPER: atomicSet only supports IB backend");
+      CERR(
+          commInternalError,
+          "CTRAN-MAPPER: atomicSet only supports IB backend");
       return commInternalError;
     }
     if (req != nullptr) {
@@ -2110,14 +2120,16 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         rbuff = kernElem->waitNotify.recvbuff;
         len = kernElem->waitNotify.nbytes;
         if (rbuff == nullptr || len == 0) {
-          CLOGF(ERR, "TCP Device Memory requires recvbuff in the notifier");
+          CERR(
+              commInternalError,
+              "TCP Device Memory requires recvbuff in the notifier");
           return commInternalError;
         }
       } else {
         const DevMemType type = regElem->getType();
         if (type != kHostUnregistered && type != kHostPinned) {
-          CLOGF(
-              ERR,
+          CERR(
+              commInternalError,
               "TCP Device Memory requires kernElem in the notifier "
               "(memType {})",
               devMemTypeStr(type));
@@ -2170,7 +2182,10 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       FB_COMMCHECK(this->ctranTcpDm->progress());
       FB_COMMCHECK(this->ctranTcpDm->checkNotify(notify->peer, done));
     } else {
-      CLOGF(ERR, "CTRAN-MAPPER: unexpected backend {}", notify->backend);
+      CERR(
+          commInternalError,
+          "CTRAN-MAPPER: unexpected backend {}",
+          notify->backend);
       return commInternalError;
     }
 
@@ -2213,7 +2228,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         // Only icopy request doesn't have peer; expect it is not used in
         // testSomeRequests with timepoints.
         if (req->peer == -1) {
-          CLOGF(ERR, "Expect peer is specified in request.");
+          CERR(commInternalError, "Expect peer is specified in request.");
           return commInternalError;
         }
 
@@ -2245,7 +2260,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     for (auto it = reqs.begin(); it != reqs.end(); it++) {
       auto& req = *it;
       if (req.peer == -1) {
-        CLOGF(ERR, "Expect peer is specified in request.");
+        CERR(commInternalError, "Expect peer is specified in request.");
         return commInternalError;
       }
       FB_COMMCHECK(waitRequest<PerfConfig>(&req));
@@ -2263,8 +2278,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperRequest** req,
       const char* fnName) {
     if (req == nullptr) {
-      CLOGF(
-          ERR,
+      CERR(
+          commInternalError,
           "CTRAN-MAPPER: Invalid request pointer. Unexpected {} indicates a COMM internal bug",
           fnName);
       return commInternalError;
@@ -2279,8 +2294,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperRequest* req,
       const char* fnName) {
     if (req == nullptr) {
-      CLOGF(
-          ERR,
+      CERR(
+          commInternalError,
           "CTRAN-MAPPER: Invalid request pointer. Unexpected {} indicates a COMM internal bug",
           fnName);
       return commInternalError;

--- a/comms/ctran/regcache/IpcRegCache.cc
+++ b/comms/ctran/regcache/IpcRegCache.cc
@@ -280,8 +280,8 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
   auto peerIt = lockedMap->find(peerId);
   if (peerIt == lockedMap->end() ||
       peerIt->second.find(key) == peerIt->second.end()) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "CTRAN-REGCACHE: Unknown IPC remote memory registration from peer {} base {} uid {}",
         peerId,
         basePtr,

--- a/comms/ctran/regcache/IpcRegCache.cc
+++ b/comms/ctran/regcache/IpcRegCache.cc
@@ -492,7 +492,7 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
   // Initialize local peer ID (hostname:pid) for IPC communications
   char hostname[256];
   if (gethostname(hostname, sizeof(hostname)) != 0) {
-    CLOGF(ERR, "CTRAN-REGCACHE: Failed to get hostname");
+    CERR(commInternalError, "CTRAN-REGCACHE: Failed to get hostname");
     return commInternalError;
   }
   hostname[sizeof(hostname) - 1] = '\0';

--- a/comms/ctran/regcache/IpcRegCache.h
+++ b/comms/ctran/regcache/IpcRegCache.h
@@ -198,7 +198,9 @@ class IpcRegCache {
       ctran::regcache::IpcDesc& ipcDesc,
       std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments) {
     if (ipcRegElem == nullptr) {
-      CLOGF(ERR, "CTRAN-REGCACHE: ipcRegElem is nullptr in exportMem");
+      CERR(
+          commInvalidArgument,
+          "CTRAN-REGCACHE: ipcRegElem is nullptr in exportMem");
       return commInvalidArgument;
     }
     auto reg = reinterpret_cast<ctran::regcache::IpcRegElem*>(ipcRegElem);

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -1343,7 +1343,11 @@ commResult_t ctran::RegCache::acquireScopedRegister(
     const CommLogData& logMetaData,
     ctran::ScopedRegHdl& scopedRegHdl) {
   if (buf == nullptr || len == 0) {
-    CLOGF(ERR, "acquireScopedRegister: invalid buf {} len {}", (void*)buf, len);
+    CERR(
+        commInvalidUsage,
+        "acquireScopedRegister: invalid buf {} len {}",
+        (void*)buf,
+        len);
     return commInvalidUsage;
   }
 
@@ -1571,7 +1575,7 @@ commResult_t ctran::RegCache::deregRange(ctran::regcache::RegElem* regHdl) {
 
     auto it = regHdlToElemMap.find(regHdl);
     if (it == regHdlToElemMap.end()) {
-      CLOGF(ERR, "deregRange: regElem {} not found", (void*)regHdl);
+      CERR(commInvalidUsage, "deregRange: regElem {} not found", (void*)regHdl);
       return commInvalidUsage;
     }
 
@@ -1686,7 +1690,7 @@ std::vector<std::vector<ctran::regcache::Segment*>> getContiguousRegions(
 commResult_t ctran::RegCache::regAll() {
   auto regCache = ctran::RegCache::getInstance();
   if (!regCache) {
-    CLOGF(ERR, "regAll: RegCache instance not available");
+    CERR(commInternalError, "regAll: RegCache instance not available");
     return commInternalError;
   }
 
@@ -1730,7 +1734,9 @@ commResult_t ctran::RegCache::regAll() {
 
     int cudaDev = contiguousRegions[0].front()->cudaDev;
     if (cudaDev < 0) {
-      CLOGF(ERR, "regAll: could not determine cudaDev from cached segments");
+      CERR(
+          commInternalError,
+          "regAll: could not determine cudaDev from cached segments");
       return commInternalError;
     }
 
@@ -1819,7 +1825,7 @@ commResult_t ctran::RegCache::regAll() {
 commResult_t ctran::RegCache::deregAll() {
   auto regCache = ctran::RegCache::getInstance();
   if (!regCache) {
-    CLOGF(ERR, "deregAll: RegCache instance not available");
+    CERR(commInternalError, "deregAll: RegCache instance not available");
     return commInternalError;
   }
 

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -542,8 +542,8 @@ commResult_t ctran::RegCache::asyncRegRange(
     const struct CommLogData& logMetaData,
     const std::vector<bool>& backend) {
   if (!asyncRegThread_.joinable()) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInvalidUsage,
         "AsyncReg thread is not running. Check whether NCCL_CTRAN_REGISTER=async is set.");
     return commInvalidUsage;
   }
@@ -1368,8 +1368,8 @@ commResult_t ctran::RegCache::acquireScopedRegister(
       true /* acquireRef */);
 
   if (regResult != commSuccess || regHdl == nullptr) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInvalidUsage,
         "acquireScopedRegister: buffer [buf {} len {}] is not backed by a cached "
         "segment. Scoped registration requires the buffer's memory to be pre-registered "
         "by the allocator (globalRegister / CCA memory hook) before use. Ensure the "
@@ -1584,8 +1584,8 @@ commResult_t ctran::RegCache::deregRange(ctran::regcache::RegElem* regHdl) {
       // The caller may already have performed mapper-side remote release, so
       // this error is not a retry contract. Keep regcache state intact and let
       // higher-level failure cleanup or allocator force-free reclaim memory.
-      CLOGF(
-          ERR,
+      CERR(
+          commInvalidUsage,
           "deregRange: RegElem {} still has {} live use-side owner(s)",
           (void*)regHdl,
           inUseCnt);

--- a/comms/ctran/transport/ib/HostTransportImpl.h
+++ b/comms/ctran/transport/ib/HostTransportImpl.h
@@ -62,7 +62,7 @@ inline commResult_t importRemoteInfo(
     const ControlMsg& msg,
     RemotePeerInfo* out) {
   if (out == nullptr) {
-    CLOGF(ERR, "CTRAN-IB: importRemoteInfo: out is null");
+    CERR(commInvalidArgument, "CTRAN-IB: importRemoteInfo: out is null");
     return commInvalidArgument;
   }
   if (msg.type == ControlMsgType::IB_EXPORT_MEM) {
@@ -76,7 +76,10 @@ inline commResult_t importRemoteInfo(
     out->remoteKey = CtranIbRemoteAccessKey{};
     return commSuccess;
   }
-  CLOGF(ERR, "CTRAN-IB: importRemoteInfo unhandled msg type {}", msg.type);
+  CERR(
+      commInternalError,
+      "CTRAN-IB: importRemoteInfo unhandled msg type {}",
+      msg.type);
   return commInternalError;
 }
 

--- a/comms/ctran/utils/ArgCheck.cc
+++ b/comms/ctran/utils/ArgCheck.cc
@@ -8,7 +8,7 @@ namespace ctran {
 
 commResult_t PtrCheck(void* ptr, const char* opname, const char* ptrname) {
   if (ptr == nullptr) {
-    CLOGF(ERR, "{} : {} argument is NULL", opname, ptrname);
+    CERR(commInvalidArgument, "{} : {} argument is NULL", opname, ptrname);
     return commInvalidArgument;
   }
   return commSuccess;

--- a/comms/ctran/utils/Checks.h
+++ b/comms/ctran/utils/Checks.h
@@ -29,16 +29,20 @@
  *     macro that ignores
  */
 
-#define FB_CUDACHECK_RETURN(cmd, ret)                                    \
-  do {                                                                   \
-    cudaError_t err = cmd;                                               \
-    if (err != cudaSuccess) {                                            \
-      auto errStr = cudaGetErrorString(err);                             \
-      CLOGF(ERR, "Cuda failure {} '{}'", static_cast<int>(err), errStr); \
-      ErrorStackTraceUtil::logErrorMessage(                              \
-          "Cuda Error: " + std::string(errStr));                         \
-      return ret;                                                        \
-    }                                                                    \
+#define FB_CUDACHECK_RETURN(cmd, ret)            \
+  do {                                           \
+    cudaError_t err = cmd;                       \
+    if (err != cudaSuccess) {                    \
+      auto errStr = cudaGetErrorString(err);     \
+      CERR(                                      \
+          commUnhandledCudaError,                \
+          "Cuda failure {} '{}'",                \
+          static_cast<int>(err),                 \
+          errStr);                               \
+      ErrorStackTraceUtil::logErrorMessage(      \
+          "Cuda Error: " + std::string(errStr)); \
+      return ret;                                \
+    }                                            \
   } while (false)
 
 #define FB_CUDACHECK(cmd) FB_CUDACHECK_RETURN(cmd, commUnhandledCudaError)
@@ -47,8 +51,8 @@
   do {                                                             \
     cudaError_t err = cmd;                                         \
     if (err != cudaSuccess) {                                      \
-      CLOGF(                                                       \
-          ERR,                                                     \
+      CERR(                                                        \
+          commUnhandledCudaError,                                  \
           "{}:{} Cuda failure {}",                                 \
           __FILE__,                                                \
           __LINE__,                                                \
@@ -90,36 +94,38 @@
 #define FB_CUDACHECKTHROW_EX_NOCOMM(cmd) \
   FB_CUDACHECKTHROW_EX_DIRECT(cmd, std::nullopt, std::nullopt, std::nullopt)
 
-#define FB_CUDACHECKGOTO(cmd, RES, label)                     \
-  do {                                                        \
-    cudaError_t err = cmd;                                    \
-    if (err != cudaSuccess) {                                 \
-      CLOGF(ERR, "Cuda failure {}", cudaGetErrorString(err)); \
-      RES = commUnhandledCudaError;                           \
-      goto label;                                             \
-    }                                                         \
+#define FB_CUDACHECKGOTO(cmd, RES, label)                                      \
+  do {                                                                         \
+    cudaError_t err = cmd;                                                     \
+    if (err != cudaSuccess) {                                                  \
+      CERR(                                                                    \
+          commUnhandledCudaError, "Cuda failure {}", cudaGetErrorString(err)); \
+      RES = commUnhandledCudaError;                                            \
+      goto label;                                                              \
+    }                                                                          \
   } while (false)
 
-#define FB_CUCHECKGOTO(cmd, RES, label)                   \
-  do {                                                    \
-    CUresult err = cmd;                                   \
-    if (err != CUDA_SUCCESS) {                            \
-      const char* errStr;                                 \
-      cuGetErrorString(err, &errStr);                     \
-      CLOGF(ERR, "Cuda failure {}", std::string(errStr)); \
-      RES = commUnhandledCudaError;                       \
-      goto label;                                         \
-    }                                                     \
+#define FB_CUCHECKGOTO(cmd, RES, label)                                     \
+  do {                                                                      \
+    CUresult err = cmd;                                                     \
+    if (err != CUDA_SUCCESS) {                                              \
+      const char* errStr;                                                   \
+      cuGetErrorString(err, &errStr);                                       \
+      CERR(commUnhandledCudaError, "Cuda failure {}", std::string(errStr)); \
+      RES = commUnhandledCudaError;                                         \
+      goto label;                                                           \
+    }                                                                       \
   } while (false)
 
-#define FB_CUDACHECKGUARD(cmd, RES)                           \
-  do {                                                        \
-    cudaError_t err = cmd;                                    \
-    if (err != cudaSuccess) {                                 \
-      CLOGF(ERR, "Cuda failure {}", cudaGetErrorString(err)); \
-      RES = commUnhandledCudaError;                           \
-      return;                                                 \
-    }                                                         \
+#define FB_CUDACHECKGUARD(cmd, RES)                                            \
+  do {                                                                         \
+    cudaError_t err = cmd;                                                     \
+    if (err != cudaSuccess) {                                                  \
+      CERR(                                                                    \
+          commUnhandledCudaError, "Cuda failure {}", cudaGetErrorString(err)); \
+      RES = commUnhandledCudaError;                                            \
+      return;                                                                  \
+    }                                                                          \
   } while (false)
 
 // Report failure but clear error and continue
@@ -139,32 +145,33 @@
 
 // Use of abort should be aware of potential memory leak risk
 // and place a signal handler to catch it and trigger termination processing
-#define FB_CUDACHECKABORT(cmd)                                \
-  do {                                                        \
-    cudaError_t err = cmd;                                    \
-    if (err != cudaSuccess) {                                 \
-      CLOGF(ERR, "Cuda failure {}", cudaGetErrorString(err)); \
-      abort();                                                \
-    }                                                         \
+#define FB_CUDACHECKABORT(cmd)                                                 \
+  do {                                                                         \
+    cudaError_t err = cmd;                                                     \
+    if (err != cudaSuccess) {                                                  \
+      CERR(                                                                    \
+          commUnhandledCudaError, "Cuda failure {}", cudaGetErrorString(err)); \
+      abort();                                                                 \
+    }                                                                          \
   } while (false)
 
-#define FB_SYSCHECK(statement, name)                              \
-  do {                                                            \
-    int retval;                                                   \
-    FB_SYSCHECKSYNC((statement), name, retval);                   \
-    if (retval == -1) {                                           \
-      CLOGF(ERR, "Call to " name " failed: {}", strerror(errno)); \
-      return commSystemError;                                     \
-    }                                                             \
+#define FB_SYSCHECK(statement, name)                                         \
+  do {                                                                       \
+    int retval;                                                              \
+    FB_SYSCHECKSYNC((statement), name, retval);                              \
+    if (retval == -1) {                                                      \
+      CERR(commSystemError, "Call to " name " failed: {}", strerror(errno)); \
+      return commSystemError;                                                \
+    }                                                                        \
   } while (false)
 
-#define FB_SYSCHECKVAL(call, name, retval)                         \
-  do {                                                             \
-    FB_SYSCHECKSYNC(call, name, retval);                           \
-    if (retval == -1) {                                            \
-      CLOGF(ERR, "Call to " name " failed : {}", strerror(errno)); \
-      return commSystemError;                                      \
-    }                                                              \
+#define FB_SYSCHECKVAL(call, name, retval)                                    \
+  do {                                                                        \
+    FB_SYSCHECKSYNC(call, name, retval);                                      \
+    if (retval == -1) {                                                       \
+      CERR(commSystemError, "Call to " name " failed : {}", strerror(errno)); \
+      return commSystemError;                                                 \
+    }                                                                         \
   } while (false)
 
 #define FB_SYSCHECKSYNC(statement, name, retval)                             \
@@ -178,30 +185,36 @@
     }                                                                        \
   } while (true)
 
-#define FB_SYSCHECKGOTO(statement, name, RES, label)              \
-  do {                                                            \
-    int retval;                                                   \
-    FB_SYSCHECKSYNC((statement), name, retval);                   \
-    if (retval == -1) {                                           \
-      CLOGF(ERR, "Call to " name " failed: {}", strerror(errno)); \
-      RES = commSystemError;                                      \
-      goto label;                                                 \
-    }                                                             \
+#define FB_SYSCHECKGOTO(statement, name, RES, label)                         \
+  do {                                                                       \
+    int retval;                                                              \
+    FB_SYSCHECKSYNC((statement), name, retval);                              \
+    if (retval == -1) {                                                      \
+      CERR(commSystemError, "Call to " name " failed: {}", strerror(errno)); \
+      RES = commSystemError;                                                 \
+      goto label;                                                            \
+    }                                                                        \
   } while (0)
 
-#define FB_SYSCHECKTHROW_EX_DIRECT(cmd, rank, commHash, desc)                  \
-  do {                                                                         \
-    int err = cmd;                                                             \
-    if (err != 0) {                                                            \
-      auto errstr = folly::errnoStr(err);                                      \
-      CLOGF(ERR, "{}:{} -> {} ({})", __FILE__, __LINE__, err, errstr.c_str()); \
-      throw ctran::utils::Exception(                                           \
-          std::string("System error: ") + errstr,                              \
-          commSystemError,                                                     \
-          rank,                                                                \
-          commHash,                                                            \
-          desc);                                                               \
-    }                                                                          \
+#define FB_SYSCHECKTHROW_EX_DIRECT(cmd, rank, commHash, desc) \
+  do {                                                        \
+    int err = cmd;                                            \
+    if (err != 0) {                                           \
+      auto errstr = folly::errnoStr(err);                     \
+      CERR(                                                   \
+          commSystemError,                                    \
+          "{}:{} -> {} ({})",                                 \
+          __FILE__,                                           \
+          __LINE__,                                           \
+          err,                                                \
+          errstr.c_str());                                    \
+      throw ctran::utils::Exception(                          \
+          std::string("System error: ") + errstr,             \
+          commSystemError,                                    \
+          rank,                                               \
+          commHash,                                           \
+          desc);                                              \
+    }                                                         \
   } while (0)
 
 #define FB_SYSCHECKTHROW_EX_LOGDATA(cmd, logData) \
@@ -225,42 +238,48 @@
       FB_SYSCHECKTHROW_EX_LOGDATA, \
       UNUSED_PLACEHOLDER_1_ARG)(__VA_ARGS__)
 
-#define FB_SYSCHECKRETURN(cmd, retval)                                         \
-  do {                                                                         \
-    int err = cmd;                                                             \
-    if (err != 0) {                                                            \
-      auto errstr = folly::errnoStr(err);                                      \
-      CLOGF(ERR, "{}:{} -> {} ({})", __FILE__, __LINE__, err, errstr.c_str()); \
-      return retval;                                                           \
-    }                                                                          \
+#define FB_SYSCHECKRETURN(cmd, retval)    \
+  do {                                    \
+    int err = cmd;                        \
+    if (err != 0) {                       \
+      auto errstr = folly::errnoStr(err); \
+      CERR(                               \
+          commSystemError,                \
+          "{}:{} -> {} ({})",             \
+          __FILE__,                       \
+          __LINE__,                       \
+          err,                            \
+          errstr.c_str());                \
+      return retval;                      \
+    }                                     \
   } while (0)
 
 // Pthread calls don't set errno and never return EINTR.
-#define FB_PTHREADCHECK(statement, name)                           \
-  do {                                                             \
-    int retval = (statement);                                      \
-    if (retval != 0) {                                             \
-      CLOGF(ERR, "Call to " name " failed: {}", strerror(retval)); \
-      return commSystemError;                                      \
-    }                                                              \
+#define FB_PTHREADCHECK(statement, name)                                      \
+  do {                                                                        \
+    int retval = (statement);                                                 \
+    if (retval != 0) {                                                        \
+      CERR(commSystemError, "Call to " name " failed: {}", strerror(retval)); \
+      return commSystemError;                                                 \
+    }                                                                         \
   } while (0)
 
-#define FB_PTHREADCHECKGOTO(statement, name, RES, label)           \
-  do {                                                             \
-    int retval = (statement);                                      \
-    if (retval != 0) {                                             \
-      CLOGF(ERR, "Call to " name " failed: {}", strerror(retval)); \
-      RES = commSystemError;                                       \
-      goto label;                                                  \
-    }                                                              \
+#define FB_PTHREADCHECKGOTO(statement, name, RES, label)                      \
+  do {                                                                        \
+    int retval = (statement);                                                 \
+    if (retval != 0) {                                                        \
+      CERR(commSystemError, "Call to " name " failed: {}", strerror(retval)); \
+      RES = commSystemError;                                                  \
+      goto label;                                                             \
+    }                                                                         \
   } while (0)
 
 #define FB_NEQCHECK(statement, value) \
   do {                                \
     if ((statement) != value) {       \
       /* Print the back trace*/       \
-      CLOGF(                          \
-          ERR,                        \
+      CERR(                           \
+          commSystemError,            \
           "{}:{} -> {} ({})",         \
           __FILE__,                   \
           __LINE__,                   \
@@ -270,23 +289,28 @@
     }                                 \
   } while (0)
 
-#define FB_NEQCHECKGOTO(statement, value, RES, label)                         \
-  do {                                                                        \
-    if ((statement) != value) {                                               \
-      /* Print the back trace*/                                               \
-      RES = commSystemError;                                                  \
-      CLOGF(                                                                  \
-          ERR, "{}:{} -> {} ({})", __FILE__, __LINE__, RES, strerror(errno)); \
-      goto label;                                                             \
-    }                                                                         \
+#define FB_NEQCHECKGOTO(statement, value, RES, label) \
+  do {                                                \
+    if ((statement) != value) {                       \
+      /* Print the back trace*/                       \
+      RES = commSystemError;                          \
+      CERR(                                           \
+          commSystemError,                            \
+          "{}:{} -> {} ({})",                         \
+          __FILE__,                                   \
+          __LINE__,                                   \
+          RES,                                        \
+          strerror(errno));                           \
+      goto label;                                     \
+    }                                                 \
   } while (0)
 
 #define FB_EQCHECK(statement, value) \
   do {                               \
     if ((statement) == value) {      \
       /* Print the back trace*/      \
-      CLOGF(                         \
-          ERR,                       \
+      CERR(                          \
+          commSystemError,           \
           "{}:{} -> {} ({})",        \
           __FILE__,                  \
           __LINE__,                  \
@@ -296,15 +320,20 @@
     }                                \
   } while (0)
 
-#define FB_EQCHECKGOTO(statement, value, RES, label)                          \
-  do {                                                                        \
-    if ((statement) == value) {                                               \
-      /* Print the back trace*/                                               \
-      RES = commSystemError;                                                  \
-      CLOGF(                                                                  \
-          ERR, "{}:{} -> {} ({})", __FILE__, __LINE__, RES, strerror(errno)); \
-      goto label;                                                             \
-    }                                                                         \
+#define FB_EQCHECKGOTO(statement, value, RES, label) \
+  do {                                               \
+    if ((statement) == value) {                      \
+      /* Print the back trace*/                      \
+      RES = commSystemError;                         \
+      CERR(                                          \
+          commSystemError,                           \
+          "{}:{} -> {} ({})",                        \
+          __FILE__,                                  \
+          __LINE__,                                  \
+          RES,                                       \
+          strerror(errno));                          \
+      goto label;                                    \
+    }                                                \
   } while (0)
 
 // Propagate errors up
@@ -480,7 +509,7 @@
 #define FB_CHECKTHROW_EX_DIRECT(statement, rank, commHash, commDesc, msg) \
   do {                                                                    \
     if (!(statement)) {                                                   \
-      CLOGF(ERR, "Check failed: {} - {}", #statement, msg);               \
+      CERR(commInternalError, "Check failed: {} - {}", #statement, msg);  \
       throw ctran::utils::Exception(                                      \
           fmt::format("Check failed: {} - {}", #statement, msg),          \
           commInternalError,                                              \
@@ -490,17 +519,17 @@
     }                                                                     \
   } while (0)
 
-#define FB_CHECKTHROW_EX_LOGDATA(statement, commLogData, msg)    \
-  do {                                                           \
-    if (!(statement)) {                                          \
-      CLOGF(ERR, "Check failed: {} - {}", #statement, msg);      \
-      throw ctran::utils::Exception(                             \
-          fmt::format("Check failed: {} - {}", #statement, msg), \
-          commInternalError,                                     \
-          (commLogData).rank,                                    \
-          (commLogData).commHash,                                \
-          (commLogData).commDesc);                               \
-    }                                                            \
+#define FB_CHECKTHROW_EX_LOGDATA(statement, commLogData, msg)            \
+  do {                                                                   \
+    if (!(statement)) {                                                  \
+      CERR(commInternalError, "Check failed: {} - {}", #statement, msg); \
+      throw ctran::utils::Exception(                                     \
+          fmt::format("Check failed: {} - {}", #statement, msg),         \
+          commInternalError,                                             \
+          (commLogData).rank,                                            \
+          (commLogData).commHash,                                        \
+          (commLogData).commDesc);                                       \
+    }                                                                    \
   } while (0)
 
 // Selector macro, used with FB_CHECKTHROW_EX to delegate
@@ -527,7 +556,7 @@
     if (!(statement)) {                                                  \
       auto errorMsg =                                                    \
           fmt::format("Check failed: {} - {}", #statement, __VA_ARGS__); \
-      CLOGF(ERR, errorMsg);                                              \
+      CERR(commInternalError, "{}", errorMsg);                           \
       throw ctran::utils::Exception(errorMsg, commInternalError);        \
     }                                                                    \
   } while (0)
@@ -588,7 +617,7 @@
 #define FB_COMMARGCHECK(statement, ...)                     \
   do {                                                      \
     if (!(statement)) {                                     \
-      CLOGF(ERR, ##__VA_ARGS__);                            \
+      CERR(commInvalidArgument, ##__VA_ARGS__);             \
       return ErrorStackTraceUtil::log(commInvalidArgument); \
     }                                                       \
   } while (0);

--- a/comms/ctran/utils/CudaWrap.h
+++ b/comms/ctran/utils/CudaWrap.h
@@ -51,54 +51,66 @@ namespace ctran::utils {
 #define FB_CUPFN(symbol) symbol
 
 // Check CUDA PFN driver calls
-#define FB_CUCHECK(cmd)                                                  \
-  do {                                                                   \
-    CUresult err = cmd;                                                  \
-    if (err != CUDA_SUCCESS) {                                           \
-      const char* errStr;                                                \
-      (void)cuGetErrorString(err, &errStr);                              \
-      CLOGF(ERR, "Cuda failure {} '{}'", static_cast<int>(err), errStr); \
-      ErrorStackTraceUtil::logErrorMessage(                              \
-          "Cuda Error: " + std::string(errStr));                         \
-      return commUnhandledCudaError;                                     \
-    }                                                                    \
+#define FB_CUCHECK(cmd)                          \
+  do {                                           \
+    CUresult err = cmd;                          \
+    if (err != CUDA_SUCCESS) {                   \
+      const char* errStr;                        \
+      (void)cuGetErrorString(err, &errStr);      \
+      CERR(                                      \
+          commUnhandledCudaError,                \
+          "Cuda failure {} '{}'",                \
+          static_cast<int>(err),                 \
+          errStr);                               \
+      ErrorStackTraceUtil::logErrorMessage(      \
+          "Cuda Error: " + std::string(errStr)); \
+      return commUnhandledCudaError;             \
+    }                                            \
   } while (false)
 
-#define FB_CUCHECK_RETURN(cmd, ret)                                      \
-  do {                                                                   \
-    CUresult err = cmd;                                                  \
-    if (err != CUDA_SUCCESS) {                                           \
-      const char* errStr;                                                \
-      (void)cuGetErrorString(err, &errStr);                              \
-      CLOGF(ERR, "Cuda failure {} '{}'", static_cast<int>(err), errStr); \
-      ErrorStackTraceUtil::logErrorMessage(                              \
-          "Cuda Error: " + std::string(errStr));                         \
-      return ret;                                                        \
-    }                                                                    \
+#define FB_CUCHECK_RETURN(cmd, ret)              \
+  do {                                           \
+    CUresult err = cmd;                          \
+    if (err != CUDA_SUCCESS) {                   \
+      const char* errStr;                        \
+      (void)cuGetErrorString(err, &errStr);      \
+      CERR(                                      \
+          commUnhandledCudaError,                \
+          "Cuda failure {} '{}'",                \
+          static_cast<int>(err),                 \
+          errStr);                               \
+      ErrorStackTraceUtil::logErrorMessage(      \
+          "Cuda Error: " + std::string(errStr)); \
+      return ret;                                \
+    }                                            \
   } while (false)
 
-#define FB_CUCHECK_GOTO(cmd, ret, label)                                 \
-  do {                                                                   \
-    CUresult err = cmd;                                                  \
-    if (err != CUDA_SUCCESS) {                                           \
-      const char* errStr;                                                \
-      cuGetErrorString(err, &errStr);                                    \
-      CLOGF(ERR, "Cuda failure {} '{}'", static_cast<int>(err), errStr); \
-      ErrorStackTraceUtil::logErrorMessage(                              \
-          "Cuda Error: " + std::string(errStr));                         \
-      ret = commUnhandledCudaError;                                      \
-      goto label;                                                        \
-    }                                                                    \
+#define FB_CUCHECK_GOTO(cmd, ret, label)         \
+  do {                                           \
+    CUresult err = cmd;                          \
+    if (err != CUDA_SUCCESS) {                   \
+      const char* errStr;                        \
+      cuGetErrorString(err, &errStr);            \
+      CERR(                                      \
+          commUnhandledCudaError,                \
+          "Cuda failure {} '{}'",                \
+          static_cast<int>(err),                 \
+          errStr);                               \
+      ErrorStackTraceUtil::logErrorMessage(      \
+          "Cuda Error: " + std::string(errStr)); \
+      ret = commUnhandledCudaError;              \
+      goto label;                                \
+    }                                            \
   } while (false)
 
-#define FB_CUCHECKRES(res)                                     \
-  do {                                                         \
-    if (res != CUDA_SUCCESS) {                                 \
-      const char* errStr;                                      \
-      (void)cuGetErrorString(res, &errStr);                    \
-      CLOGF(ERR, "Cuda failure {} '{}'", res, errStr);         \
-      return ErrorStackTraceUtil::log(commUnhandledCudaError); \
-    }                                                          \
+#define FB_CUCHECKRES(res)                                               \
+  do {                                                                   \
+    if (res != CUDA_SUCCESS) {                                           \
+      const char* errStr;                                                \
+      (void)cuGetErrorString(res, &errStr);                              \
+      CERR(commUnhandledCudaError, "Cuda failure {} '{}'", res, errStr); \
+      return ErrorStackTraceUtil::log(commUnhandledCudaError);           \
+    }                                                                    \
   } while (false)
 
 // Report failure but clear error and continue
@@ -122,8 +134,8 @@ namespace ctran::utils {
   do {                                    \
     CUresult err = cmd;                   \
     if (err != CUDA_SUCCESS) {            \
-      CLOGF(                              \
-          ERR,                            \
+      CERR(                               \
+          commUnhandledCudaError,         \
           "{}:{} -> {} [Async thread]",   \
           __FILE__,                       \
           __LINE__,                       \
@@ -138,54 +150,66 @@ namespace ctran::utils {
 #define FB_CUPFN(symbol) ::ctran::utils::pfn_##symbol
 
 // Check CUDA PFN driver calls
-#define FB_CUCHECK(cmd)                                                  \
-  do {                                                                   \
-    CUresult err = ::ctran::utils::pfn_##cmd;                            \
-    if (err != CUDA_SUCCESS) {                                           \
-      const char* errStr;                                                \
-      (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr);          \
-      CLOGF(ERR, "Cuda failure {} '{}'", static_cast<int>(err), errStr); \
-      ErrorStackTraceUtil::logErrorMessage(                              \
-          "Cuda Error: " + std::string(errStr));                         \
-      return commUnhandledCudaError;                                     \
-    }                                                                    \
-  } while (false)
-
-#define FB_CUCHECK_RETURN(cmd, ret)                                      \
-  do {                                                                   \
-    CUresult err = ::ctran::utils::pfn_##cmd;                            \
-    if (err != CUDA_SUCCESS) {                                           \
-      const char* errStr;                                                \
-      (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr);          \
-      CLOGF(ERR, "Cuda failure {} '{}'", static_cast<int>(err), errStr); \
-      ErrorStackTraceUtil::logErrorMessage(                              \
-          "Cuda Error: " + std::string(errStr));                         \
-      return ret;                                                        \
-    }                                                                    \
-  } while (false)
-
-#define FB_CUCHECK_GOTO(cmd, ret, label)                                 \
-  do {                                                                   \
-    CUresult err = ::ctran::utils::pfn_##cmd;                            \
-    if (err != CUDA_SUCCESS) {                                           \
-      const char* errStr;                                                \
-      (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr);          \
-      CLOGF(ERR, "Cuda failure {} '{}'", static_cast<int>(err), errStr); \
-      ErrorStackTraceUtil::logErrorMessage(                              \
-          "Cuda Error: " + std::string(errStr));                         \
-      ret = commUnhandledCudaError;                                      \
-      goto label;                                                        \
-    }                                                                    \
-  } while (false)
-
-#define FB_CUCHECKRES(res)                                      \
+#define FB_CUCHECK(cmd)                                         \
   do {                                                          \
-    if (res != CUDA_SUCCESS) {                                  \
+    CUresult err = ::ctran::utils::pfn_##cmd;                   \
+    if (err != CUDA_SUCCESS) {                                  \
       const char* errStr;                                       \
-      (void)::ctran::utils::pfn_cuGetErrorString(res, &errStr); \
-      CLOGF(ERR, "Cuda failure {} '{}'", res, errStr);          \
-      return ErrorStackTraceUtil::log(commUnhandledCudaError);  \
+      (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr); \
+      CERR(                                                     \
+          commUnhandledCudaError,                               \
+          "Cuda failure {} '{}'",                               \
+          static_cast<int>(err),                                \
+          errStr);                                              \
+      ErrorStackTraceUtil::logErrorMessage(                     \
+          "Cuda Error: " + std::string(errStr));                \
+      return commUnhandledCudaError;                            \
     }                                                           \
+  } while (false)
+
+#define FB_CUCHECK_RETURN(cmd, ret)                             \
+  do {                                                          \
+    CUresult err = ::ctran::utils::pfn_##cmd;                   \
+    if (err != CUDA_SUCCESS) {                                  \
+      const char* errStr;                                       \
+      (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr); \
+      CERR(                                                     \
+          commUnhandledCudaError,                               \
+          "Cuda failure {} '{}'",                               \
+          static_cast<int>(err),                                \
+          errStr);                                              \
+      ErrorStackTraceUtil::logErrorMessage(                     \
+          "Cuda Error: " + std::string(errStr));                \
+      return ret;                                               \
+    }                                                           \
+  } while (false)
+
+#define FB_CUCHECK_GOTO(cmd, ret, label)                        \
+  do {                                                          \
+    CUresult err = ::ctran::utils::pfn_##cmd;                   \
+    if (err != CUDA_SUCCESS) {                                  \
+      const char* errStr;                                       \
+      (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr); \
+      CERR(                                                     \
+          commUnhandledCudaError,                               \
+          "Cuda failure {} '{}'",                               \
+          static_cast<int>(err),                                \
+          errStr);                                              \
+      ErrorStackTraceUtil::logErrorMessage(                     \
+          "Cuda Error: " + std::string(errStr));                \
+      ret = commUnhandledCudaError;                             \
+      goto label;                                               \
+    }                                                           \
+  } while (false)
+
+#define FB_CUCHECKRES(res)                                               \
+  do {                                                                   \
+    if (res != CUDA_SUCCESS) {                                           \
+      const char* errStr;                                                \
+      (void)::ctran::utils::pfn_cuGetErrorString(res, &errStr);          \
+      CERR(commUnhandledCudaError, "Cuda failure {} '{}'", res, errStr); \
+      return ErrorStackTraceUtil::log(commUnhandledCudaError);           \
+    }                                                                    \
   } while (false)
 
 // Report failure but clear error and continue
@@ -209,8 +233,8 @@ namespace ctran::utils {
   do {                                        \
     CUresult err = ::ctran::utils::pfn_##cmd; \
     if (err != CUDA_SUCCESS) {                \
-      CLOGF(                                  \
-          ERR,                                \
+      CERR(                                   \
+          commUnhandledCudaError,             \
           "{}:{} -> {} [Async thread]",       \
           __FILE__,                           \
           __LINE__,                           \

--- a/comms/ncclx/meta/collectives/pCollectives.cc
+++ b/comms/ncclx/meta/collectives/pCollectives.cc
@@ -43,28 +43,28 @@ __attribute__((visibility("default"))) ncclResult_t allGatherInit(
 
 #define CHECK_VALID_CTRAN(comm)                                             \
   if (!ctranInitialized(comm)) {                                            \
-    FB_ERRORRETURN(                                                         \
-        ncclInvalidUsage,                                                   \
+    ERR(ncclInvalidUsage,                                                   \
         "CTRAN must be enabled and initialized for persistent collective"); \
+    return ncclInvalidUsage;                                                \
   }
 
 #define CHECK_PREQ_TYPE(pReq, type)                                \
   if (pReq->type != type) {                                        \
-    FB_ERRORRETURN(                                                \
-        ncclInvalidArgument,                                       \
+    ERR(ncclInvalidArgument,                                       \
         "%s requires persistent request type %d, but received %d", \
         __func__,                                                  \
-        type,                                                      \
-        pReq->type);                                               \
+        static_cast<int>(type),                                    \
+        static_cast<int>(pReq->type));                             \
+    return ncclInvalidArgument;                                    \
   }
 
 #define GET_VALID_PREQ_OR_ERRRETURN(req, pReq)                    \
   do {                                                            \
     if (request == nullptr) {                                     \
-      FB_ERRORRETURN(                                             \
-          ncclInvalidArgument,                                    \
+      ERR(ncclInvalidArgument,                                    \
           "%s received invalid nullptr request",                  \
           __func__);                                              \
+      return ncclInvalidArgument;                                 \
     }                                                             \
     *(pReq) = reinterpret_cast<CtranPersistentRequest*>(request); \
   } while (0)
@@ -119,18 +119,18 @@ __attribute__((visibility("default"))) ncclResult_t pExec(void* request) {
       (void*)pReq->comm_);
 
   if (!ctranInitialized(pReq->comm_)) {
-    FB_ERRORRETURN(
-        ncclInvalidUsage,
+    ERR(ncclInvalidUsage,
         "CTRAN must be enabled and initialized for persistent collective");
+    return ncclInvalidUsage;
   }
 
   switch (pReq->type) {
     default:
-      FB_ERRORRETURN(
-          ncclInvalidArgument,
-          "Persistent request {} has unknown op type {}",
+      ERR(ncclInvalidArgument,
+          "Persistent request %p has unknown op type %d",
           (void*)pReq,
-          (void*)pReq->type);
+          static_cast<int>(pReq->type));
+      return ncclInvalidArgument;
   }
 }
 
@@ -143,9 +143,9 @@ __attribute__((visibility("default"))) ncclResult_t AllToAllInit(
     cudaStream_t stream,
     void*& request) {
   if (!ctran::AllToAllPSupport(comm->ctranComm_.get())) {
-    FB_ERRORRETURN(
-        ncclInvalidUsage,
+    ERR(ncclInvalidUsage,
         "Persistent AllToAll is not supported. Check whether CTRAN is enabled.");
+    return ncclInvalidUsage;
   }
 
   SetCudaDevRAII setCudaDev(comm->cudaDev);
@@ -167,24 +167,24 @@ __attribute__((visibility("default"))) ncclResult_t AllToAllInit(
 __attribute__((visibility("default"))) ncclResult_t
 AllToAllExec(const void* sendbuff, const size_t count, void* request) {
   if (request == nullptr) {
-    FB_ERRORRETURN(
-        ncclInvalidUsage,
+    ERR(ncclInvalidUsage,
         "request shouldn't be nullptr for persistent collective");
+    return ncclInvalidUsage;
   }
   CtranPersistentRequest* pReq =
       reinterpret_cast<CtranPersistentRequest*>(request);
 
   if (!ctranInitialized(pReq->comm_)) {
-    FB_ERRORRETURN(
-        ncclInvalidUsage,
+    ERR(ncclInvalidUsage,
         "CTRAN must be enabled and initialized for persistent collective");
+    return ncclInvalidUsage;
   }
 
   if (pReq->type != CtranPersistentRequest::Type::ALLTOALL_P) {
-    FB_ERRORRETURN(
-        ncclInvalidArgument,
+    ERR(ncclInvalidArgument,
         "Unexpected PersistentRequest type %d called into AllToAllExec",
-        pReq->type);
+        static_cast<int>(pReq->type));
+    return ncclInvalidArgument;
   }
 
   return metaCommToNccl(ctran::AllToAllPExec(sendbuff, count, pReq));
@@ -209,11 +209,11 @@ __attribute__((visibility("default"))) ncclResult_t pFree(void* request) {
           "allToAllvDedupDestroy: experimental API moved to comms/experiments/algos");
       return ncclInvalidUsage;
     default:
-      FB_ERRORRETURN(
-          ncclInvalidArgument,
-          "Persistent request {} has unknown op type {}",
+      ERR(ncclInvalidArgument,
+          "Persistent request %p has unknown op type %d",
           (void*)pReq,
-          pReq->type);
+          static_cast<int>(pReq->type));
+      return ncclInvalidArgument;
   }
 
   return ncclSuccess;

--- a/comms/ncclx/meta/colltrace/ProxyTrace.cc
+++ b/comms/ncclx/meta/colltrace/ProxyTrace.cc
@@ -152,13 +152,13 @@ inline ncclResult_t ProxyTrace::completeTraceEntries(
     auto opCount = sub->traceArgs.collInfo.opCount;
 
     if (!checkActiveOpExist(commHash, opCount, proxyOpId)) {
-      FB_ERRORRETURN(
-          ncclInternalError,
+      ERR(ncclInternalError,
           "PROXYTRACE: failed to complete %s entry of commHash %s opCount %lx proxyOpId %d, because no active entry exists",
           proxyOpTypetrMap[opType].c_str(),
           hashToHexStr(commHash).c_str(),
           opCount,
           proxyOpId);
+      return ncclInternalError;
     }
 
     auto& entry = activeOps_[commHash][opCount][proxyOpId];
@@ -235,13 +235,13 @@ inline ncclResult_t ProxyTrace::updateTraceEntryStep(
   auto opCount = sub->traceArgs.collInfo.opCount;
 
   if (!checkActiveOpExist(commHash, opCount, proxyOpId)) {
-    FB_ERRORRETURN(
-        ncclInternalError,
+    ERR(ncclInternalError,
         "PROXYTRACE: failed to update %s entry of commHash %s opCount %lx proxyOpId %d, because no active entry exists",
         proxyOpTypetrMap[opType].c_str(),
         hashToHexStr(commHash).c_str(),
         opCount,
         proxyOpId);
+    return ncclInternalError;
   }
 
   auto& entry = activeOps_[commHash][opCount][proxyOpId];

--- a/comms/ncclx/meta/rma/rma.cc
+++ b/comms/ncclx/meta/rma/rma.cc
@@ -16,11 +16,13 @@ ncclResult_t
 getValidatedNcclWin(ncclWindow_t win, ncclWin** outWin, const char* funcName) {
   ncclWin* ncclWinPtr = ncclWinMap().find(win);
   if (!ncclWinPtr) {
-    FB_ERRORRETURN(ncclInvalidUsage, "Invalid window handle in {}", funcName);
+    ERR(ncclInvalidUsage, "Invalid window handle in %s", funcName);
+    return ncclInvalidUsage;
   }
   auto comm = ncclWinPtr->comm->ctranComm_.get();
   if (!ctranInitialized(comm)) {
-    FB_ERRORRETURN(ncclInternalError, "{} requires Ctran support", funcName);
+    ERR(ncclInternalError, "%s requires Ctran support", funcName);
+    return ncclInternalError;
   }
   *outWin = ncclWinPtr;
   return ncclSuccess;

--- a/comms/ncclx/meta/rma/window.cc
+++ b/comms/ncclx/meta/rma/window.cc
@@ -16,17 +16,19 @@
 
 ncclResult_t CheckCommAndReturn(ncclComm_t comm) {
   if (!ncclGetCuMemSysSupported()) {
-    FB_ERRORRETURN(ncclInternalError, "ncclWin requires CUMEM support.");
+    ERR(ncclInternalError, "ncclWin requires CUMEM support.");
+    return ncclInternalError;
   }
 
   if (!ctranInitialized(comm->ctranComm_.get())) {
-    FB_ERRORRETURN(ncclInternalError, "ncclWin requires Ctran support.");
+    ERR(ncclInternalError, "ncclWin requires Ctran support.");
+    return ncclInternalError;
   }
 
   auto statex = comm->ctranComm_->statex_.get();
   if (statex == nullptr) {
-    FB_ERRORRETURN(
-        ncclInternalError, "Communicator does not have statex initialized.");
+    ERR(ncclInternalError, "Communicator does not have statex initialized.");
+    return ncclInternalError;
   }
   return ncclSuccess;
 }
@@ -81,9 +83,9 @@ ncclResult_t ncclWinRegister(
     const ncclx::Hints& hints) {
   NCCLCHECK(CheckCommAndReturn(comm));
   if (baseptr == nullptr) {
-    FB_ERRORRETURN(
-        ncclInvalidUsage,
+    ERR(ncclInvalidUsage,
         "Invalid baseptr to create shared buffer in ncclWinRegister.");
+    return ncclInvalidUsage;
   }
 
   ncclWin* win_ = new ncclWin();
@@ -116,16 +118,17 @@ ncclResult_t
 ncclWinSharedQuery(int rank, ncclComm_t comm, ncclWindow_t win, void** addr) {
   ncclWin* ncclWinPtr = ncclWinMap().find(win);
   if (!comm || !win || !ncclWinPtr || comm != ncclWinPtr->comm) {
-    FB_ERRORRETURN(
-        ncclInvalidUsage,
-        "Invalid parameter(s) to query shared buffer in ncclWinSharedQuery: comm {}, win {}",
+    ERR(ncclInvalidUsage,
+        "Invalid parameter(s) to query shared buffer in ncclWinSharedQuery: comm %p, win %p",
         (void*)comm,
         (void*)win);
+    return ncclInvalidUsage;
   }
 
   auto statex = comm->ctranComm_->statex_.get();
   if (statex == nullptr) {
-    FB_ERRORRETURN(ncclInternalError, "Empty communicator statex.");
+    ERR(ncclInternalError, "Empty communicator statex.");
+    return ncclInternalError;
   }
 
   NCCLCHECK(metaCommToNccl(
@@ -137,16 +140,17 @@ NCCL_API(ncclResult_t, ncclWinFree, ncclComm_t comm, ncclWindow_t win);
 ncclResult_t ncclWinFree(ncclComm_t comm, ncclWindow_t win) {
   ncclWin* ncclWinPtr = ncclWinMap().find(win);
   if (!comm || !win || !ncclWinPtr || comm != ncclWinPtr->comm) {
-    FB_ERRORRETURN(
-        ncclInvalidUsage,
-        "Invalid parameter(s) to free window: comm {}, win {}",
+    ERR(ncclInvalidUsage,
+        "Invalid parameter(s) to free window: comm %p, win %p",
         (void*)comm,
         (void*)win);
+    return ncclInvalidUsage;
   }
 
   auto statex = comm->ctranComm_->statex_.get();
   if (statex == nullptr) {
-    FB_ERRORRETURN(ncclInternalError, "Empty communicator statex.");
+    ERR(ncclInternalError, "Empty communicator statex.");
+    return ncclInternalError;
   }
 
   // Remove from map first, then cleanup resources
@@ -172,24 +176,25 @@ ncclResult_t
 ncclWinGetAttributes(int rank, ncclWindow_t win, ncclWinAttr_t* attr) {
   ncclWin* ncclWinPtr = ncclWinMap().find(win);
   if (!win || !ncclWinPtr || !attr) {
-    FB_ERRORRETURN(
-        ncclInvalidUsage,
-        "Invalid parameter(s) in ncclWinGetAttributes: win {}, attr {}",
+    ERR(ncclInvalidUsage,
+        "Invalid parameter(s) in ncclWinGetAttributes: win %p, attr %p",
         (void*)win,
         (void*)attr);
+    return ncclInvalidUsage;
   }
 
   auto statex = ncclWinPtr->comm->ctranComm_->statex_.get();
   if (statex == nullptr) {
-    FB_ERRORRETURN(ncclInternalError, "Empty communicator statex.");
+    ERR(ncclInternalError, "Empty communicator statex.");
+    return ncclInternalError;
   }
 
   if (rank < 0 || rank >= statex->nRanks()) {
-    FB_ERRORRETURN(
-        ncclInvalidUsage,
-        "Invalid rank {} in ncclWinGetAttributes: must be in range [0, {})",
+    ERR(ncclInvalidUsage,
+        "Invalid rank %d in ncclWinGetAttributes: must be in range [0, %d)",
         rank,
         statex->nRanks());
+    return ncclInvalidUsage;
   }
 
   auto newAttr = new ncclWinAttr();

--- a/comms/ncclx/meta/transport/transportProxy.cc
+++ b/comms/ncclx/meta/transport/transportProxy.cc
@@ -39,9 +39,9 @@ commResult_t tranportProxyInit(struct ncclComm* comm, struct ncclComm* parent) {
       mode != NCCL_USE_TRANSPORT_PROXY::none &&
       ncclx::getChannelMetadataLoc() ==
           NCCL_CHANNEL_METADATA_LOCATION::device) {
-    FB_ERRORRETURN(
-        commInternalError,
+    WARN(
         "NCCL_USE_TRANSPORT_PROXY is not supported with NCCL_CHANNEL_METADATA_LOCATION=device");
+    return commInternalError;
   }
 
   if (mode == NCCL_USE_TRANSPORT_PROXY::shared && parent != nullptr) {

--- a/comms/ncclx/v2_29/src/collectives.cc
+++ b/comms/ncclx/v2_29/src/collectives.cc
@@ -368,11 +368,12 @@ ncclResult_t ncclAllToAll(
   NCCLCHECK(CudaPtrCheck(sendbuff, comm, "sendbuff", "ncclAllToAll"));
   NCCLCHECK(CudaPtrCheck(recvbuff, comm, "recvbuff", "ncclAllToAll"));
   if (sendbuff == recvbuff) {
-    FB_ERRORRETURN(
+    ERR(
         ncclInvalidArgument,
         "Found sendbuff %p == recvbuff %p. In-place ncclAllToAll is not supported.",
         sendbuff,
         recvbuff);
+    return ncclInvalidArgument;
   }
 
   auto alltoallAlgo = NCCLX_CONFIG_FIELD(comm->config, alltoallAlgo);
@@ -449,11 +450,12 @@ ncclResult_t ncclAllToAllv(
   }
 
   if (totalSendCount && totalRecvCount && sendbuff == recvbuff) {
-    FB_ERRORRETURN(
+    ERR(
         ncclInvalidArgument,
         "Found sendbuff %p == recvbuff %p. In-place ncclAllToAllv is not supported.",
         sendbuff,
         recvbuff);
+    return ncclInvalidArgument;
   }
 
   if ((NCCLX_CONFIG_FIELD(comm->config, alltoallvAlgo) == NCCL_ALLTOALLV_ALGO::ctran) &&
@@ -506,9 +508,10 @@ ncclResult_t ncclx::deviceAllToAllv(
     int64_t recvcountsMultiplier,
     const std::unordered_map<std::string, std::string>& hints) {
   if (!ctranDeviceAllToAllvSupport(comm->ctranComm_.get())) {
-    FB_ERRORRETURN(
+    ERR(
         ncclInvalidUsage,
         "deviceAllToAllv requires ctran with pipes transport support");
+    return ncclInvalidUsage;
   }
   return metaCommToNccl(ctranDeviceAllToAllv(
       sendbuff,

--- a/comms/ncclx/v2_29/src/dev_runtime.cc
+++ b/comms/ncclx/v2_29/src/dev_runtime.cc
@@ -1236,12 +1236,14 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
     bool forceOrigPath = (winFlags & NCCL_WIN_DEVICE_API) != 0;
     if(!forceOrigPath && NCCLX_CONFIG_FIELD(comm->config, rmaAlgo) != NCCL_RMA_ALGO::orig && ctranInitialized(comm->ctranComm_.get())){
       if (!ncclGetCuMemSysSupported()) {
-        FB_ERRORRETURN(ncclInternalError, "ncclWin requires CUMEM support.");
+        ERR(ncclInternalError, "ncclWin requires CUMEM support.");
+        return ncclInternalError;
       }
       if (buff == nullptr) {
-        FB_ERRORRETURN(
+        ERR(
             ncclInvalidUsage,
             "Invalid baseptr to create shared buffer in ncclWinRegister.");
+        return ncclInvalidUsage;
       }
 
       ncclWin* win_ = new ncclWin();
@@ -1328,7 +1330,8 @@ ncclResult_t ncclCommWindowDeregister(struct ncclComm* comm, struct ncclWindow_v
     if (ncclWinPtr != nullptr && comm == ncclWinPtr->comm) {
       auto statex = comm->ctranComm_->statex_.get();
       if (statex == nullptr) {
-        FB_ERRORRETURN(ncclInternalError, "Empty communicator statex.");
+        ERR(ncclInternalError, "Empty communicator statex.");
+        return ncclInternalError;
       }
 
       // Remove from map first, then cleanup resources

--- a/comms/ncclx/v2_29/src/libnccl.map
+++ b/comms/ncclx/v2_29/src/libnccl.map
@@ -2,6 +2,8 @@
     global:
         nccl*;
         pnccl*;
+        /* Cross-.so error reporting symbols; keep in sync with version.script */
+        *ErrorToScuba*;
 
     local:
         *;

--- a/comms/ncclx/v2_29/src/version.script
+++ b/comms/ncclx/v2_29/src/version.script
@@ -12,6 +12,8 @@ cxa: Folly’s exception tracer intercepts all exceptions and uses
       *ctran*;
       *prims*;
       *cxa*;
+      /* Scuba error loggers called cross-.so from _comms_ncclx via CERR (CtranMapper.h) */
+      *ErrorToScuba*;
       *getDevMemType*;
       *getCudaDevFromPtr*;
       *StreamCaptureModeGuard*;

--- a/comms/ncclx/v2_30/src/collectives.cc
+++ b/comms/ncclx/v2_30/src/collectives.cc
@@ -368,11 +368,12 @@ ncclResult_t ncclAllToAll(
   NCCLCHECK(CudaPtrCheck(sendbuff, comm, "sendbuff", "ncclAllToAll"));
   NCCLCHECK(CudaPtrCheck(recvbuff, comm, "recvbuff", "ncclAllToAll"));
   if (sendbuff == recvbuff) {
-    FB_ERRORRETURN(
+    ERR(
         ncclInvalidArgument,
         "Found sendbuff %p == recvbuff %p. In-place ncclAllToAll is not supported.",
         sendbuff,
         recvbuff);
+    return ncclInvalidArgument;
   }
 
   auto alltoallAlgo = NCCLX_CONFIG_FIELD(comm->config, alltoallAlgo);
@@ -449,11 +450,12 @@ ncclResult_t ncclAllToAllv(
   }
 
   if (totalSendCount && totalRecvCount && sendbuff == recvbuff) {
-    FB_ERRORRETURN(
+    ERR(
         ncclInvalidArgument,
         "Found sendbuff %p == recvbuff %p. In-place ncclAllToAllv is not supported.",
         sendbuff,
         recvbuff);
+    return ncclInvalidArgument;
   }
 
   if ((NCCLX_CONFIG_FIELD(comm->config, alltoallvAlgo) == NCCL_ALLTOALLV_ALGO::ctran) &&
@@ -506,9 +508,10 @@ ncclResult_t ncclx::deviceAllToAllv(
     int64_t recvcountsMultiplier,
     const std::unordered_map<std::string, std::string>& hints) {
   if (!ctranDeviceAllToAllvSupport(comm->ctranComm_.get())) {
-    FB_ERRORRETURN(
+    ERR(
         ncclInvalidUsage,
         "deviceAllToAllv requires ctran with pipes transport support");
+    return ncclInvalidUsage;
   }
   return metaCommToNccl(ctranDeviceAllToAllv(
       sendbuff,

--- a/comms/ncclx/v2_30/src/dev_runtime.cc
+++ b/comms/ncclx/v2_30/src/dev_runtime.cc
@@ -1472,12 +1472,14 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
     bool forceOrigPath = (winFlags & NCCL_WIN_DEVICE_API) != 0;
     if(!forceOrigPath && NCCLX_CONFIG_FIELD(comm->config, rmaAlgo) != NCCL_RMA_ALGO::orig && ctranInitialized(comm->ctranComm_.get())){
       if (!ncclGetCuMemSysSupported()) {
-        FB_ERRORRETURN(ncclInternalError, "ncclWin requires CUMEM support.");
+        ERR(ncclInternalError, "ncclWin requires CUMEM support.");
+        return ncclInternalError;
       }
       if (buff == nullptr) {
-        FB_ERRORRETURN(
+        ERR(
             ncclInvalidUsage,
             "Invalid baseptr to create shared buffer in ncclWinRegister.");
+        return ncclInvalidUsage;
       }
 
       ncclWin* win_ = new ncclWin();
@@ -1564,7 +1566,8 @@ ncclResult_t ncclCommWindowDeregister(struct ncclComm* comm, struct ncclWindow_v
     if (ncclWinPtr != nullptr && comm == ncclWinPtr->comm) {
       auto statex = comm->ctranComm_->statex_.get();
       if (statex == nullptr) {
-        FB_ERRORRETURN(ncclInternalError, "Empty communicator statex.");
+        ERR(ncclInternalError, "Empty communicator statex.");
+        return ncclInternalError;
       }
 
       // Remove from map first, then cleanup resources

--- a/comms/ncclx/v2_30/src/devcomm/devcomm_v22902.cc
+++ b/comms/ncclx/v2_30/src/devcomm/devcomm_v22902.cc
@@ -107,7 +107,7 @@ static ncclResult_t ncclDevCommRequirementsFilter_v22902(ncclComm_t comm, ncclDe
   }
   if (userRequestedGin) {
     char compiledBuf[16], runtimeBuf[16];
-    WARN("The application was compiled with too old version of NCCL. It was compiled with NCCL version %s, but is running with NCCL library version %s. Because of its use of GIN device kernels, it needs to be recompiled, preferably with the same NCCL version that it will be running with.",
+    ERR(ncclInvalidUsage, "The application was compiled with too old version of NCCL. It was compiled with NCCL version %s, but is running with NCCL library version %s. Because of its use of GIN device kernels, it needs to be recompiled, preferably with the same NCCL version that it will be running with.",
          ncclVersionToString(reqs->version, compiledBuf, sizeof(compiledBuf)),
          ncclVersionToString(NCCL_VERSION_CODE, runtimeBuf, sizeof(runtimeBuf)));
     return ncclInvalidUsage;

--- a/comms/ncclx/v2_30/src/devcomm/devcomm_v22907.cc
+++ b/comms/ncclx/v2_30/src/devcomm/devcomm_v22907.cc
@@ -86,7 +86,7 @@ static ncclResult_t ncclDevCommRequirementsFilter_v22907(ncclComm_t comm, ncclDe
   }
   if (requestedGinResources && (reqs->ginConnectionType != NCCL_GIN_CONNECTION_NONE || reqs->ginForceEnable)) {
     char compiledBuf[16], runtimeBuf[16];
-    WARN("The application was compiled with too old version of NCCL. It was compiled with NCCL version %s, but is running with NCCL library version %s. Because of its use of GIN device kernels, it needs to be recompiled, preferably with the same NCCL version that it will be running with.",
+    ERR(ncclInvalidUsage, "The application was compiled with too old version of NCCL. It was compiled with NCCL version %s, but is running with NCCL library version %s. Because of its use of GIN device kernels, it needs to be recompiled, preferably with the same NCCL version that it will be running with.",
          ncclVersionToString(reqs->version, compiledBuf, sizeof(compiledBuf)),
          ncclVersionToString(NCCL_VERSION_CODE, runtimeBuf, sizeof(runtimeBuf)));
     return ncclInvalidUsage;

--- a/comms/ncclx/v2_30/src/gin/gin_host.cc
+++ b/comms/ncclx/v2_30/src/gin/gin_host.cc
@@ -77,7 +77,7 @@ ncclResult_t setLocalGinType(struct ncclComm* comm) {
     }
     return ncclSuccess;
   }
-  WARN("Cannot get gin type: ncclGin is not null but net device type (%d) is not a gin type",
+  ERR(ncclInternalError, "Cannot get gin type: ncclGin is not null but net device type (%d) is not a gin type",
        props.netDeviceType);
   return ncclInternalError;
 }
@@ -122,13 +122,13 @@ ncclResult_t ncclGinConnectOnce(struct ncclComm* comm) {
 
   ncclResult_t ret = ncclSuccess;
   if (ncclParamGinEnable() == 0) {
-    WARN("GIN is disabled.");
+    ERR(ncclInternalError, "GIN is disabled.");
     return ncclInternalError;
   }
 
   // Load plugin
   if (ginState->ncclGin == NULL) {
-    WARN("GIN not supported.");
+    ERR(ncclInvalidUsage, "GIN not supported.");
     return ncclInvalidUsage;
   }
 
@@ -138,12 +138,12 @@ ncclResult_t ncclGinConnectOnce(struct ncclComm* comm) {
   int ndev = 0;
   NCCLCHECK(ginState->ncclGin->devices(&ndev));
   if (ndev <= 0) {
-    WARN("No GIN-capable devices found.");
+    ERR(ncclInternalError, "No GIN-capable devices found.");
     return ncclInternalError;
   }
 
   if (!comm->symmetricSupport) {
-    WARN("Communicator does not support symmetric memory!");
+    ERR(ncclInternalError, "Communicator does not support symmetric memory!");
     return ncclInternalError;
   }
 
@@ -313,7 +313,7 @@ ncclResult_t ncclGinDevCommFree(struct ncclComm* comm, struct ncclDevComm const*
   struct ncclGinStateDevComm* dc = ginState->devComms, *prevDc = NULL;
   while (1) {
     if (dc == NULL) {
-      WARN("Dev comm not found\n");
+      ERR(ncclInternalError, "Dev comm not found\n");
       return ncclInternalError;
     }
     if (dc->devHandles[0]->handle == devComm->ginHandles[0]) break;
@@ -367,7 +367,7 @@ ncclResult_t ncclGinRegister(struct ncclComm* comm, void* address, size_t size,
     // Multi-segment GIN registration requires DMABUF support on all GIN connections
     for (int n = 0; n < ginState->ginCommCount; n++) {
       if (!(ginState->ginProps[n].ptrSupport & NCCL_PTR_DMABUF)) {
-        WARN("Window registration of addresses that span multiple physical segments requires DMABUF support with GIN.");
+        ERR(ncclInvalidArgument, "Window registration of addresses that span multiple physical segments requires DMABUF support with GIN.");
         return ncclInvalidArgument;
       }
     }
@@ -377,7 +377,7 @@ ncclResult_t ncclGinRegister(struct ncclComm* comm, void* address, size_t size,
     NCCLCHECK(ginState->ncclGin->regMrSym(ginState->ginComms[n], address, size, NCCL_PTR_CUDA, mrFlags,
                                           &ginHostWins[n], &ginDevWins[n]));
     if (ginHostWins[n] == NULL) {
-      WARN("rank %d - GIN Symmetric register failed: buff %p, size %ld", comm->rank, address, size);
+      ERR(ncclSystemError, "rank %d - GIN Symmetric register failed: buff %p, size %ld", comm->rank, address, size);
       return ncclSystemError;
     }
   }
@@ -394,21 +394,21 @@ ncclResult_t ncclGinRegisterLocal(struct ncclComm* comm, void* address, size_t s
 
   // GIN must already be connected
   if (!ginState->connected) {
-    WARN("ncclGinRegisterLocal: GIN not connected.");
+    ERR(ncclInvalidUsage, "ncclGinRegisterLocal: GIN not connected.");
     return ncclInvalidUsage;
   }
 
   for (int n = 0; n < ginState->ginCommCount; n++) {
     if (ginState->ginType == NCCL_GIN_TYPE_PROXY) {
       // Proxy path not yet supported for local-only registration
-      WARN("ncclGinRegisterLocal: Proxy path not yet supported");
+      ERR(ncclInvalidUsage, "ncclGinRegisterLocal: Proxy path not yet supported");
       return ncclInvalidUsage;
     } else {
       NCCLCHECK(ginState->ncclGin->regMrLocal(ginState->ginComms[n], address, size, NCCL_PTR_CUDA, 0,
                                               &ginHostWins[n], &ginDevWins[n]));
     }
     if (ginHostWins[n] == NULL) {
-      WARN("rank %d - GIN Local register failed: buff %p, size %ld", comm->rank, address, size);
+      ERR(ncclSystemError, "rank %d - GIN Local register failed: buff %p, size %ld", comm->rank, address, size);
       return ncclSystemError;
     }
   }
@@ -419,7 +419,7 @@ ncclResult_t ncclGinDeregisterLocal(struct ncclComm* comm, void* ginHostWins[NCC
   struct ncclGinState* ginState = &comm->sharedRes->ginState;
   for (int n = 0; n < ginState->ginCommCount; n++) {
     if (ginState->ginType == NCCL_GIN_TYPE_PROXY) {
-      WARN("ncclGinDeregisterLocal: Proxy path not yet supported");
+      ERR(ncclInvalidUsage, "ncclGinDeregisterLocal: Proxy path not yet supported");
       return ncclInvalidUsage;
     } else {
       NCCLCHECK(ginState->ncclGin->deregMrLocal(ginState->ginComms[n], ginHostWins[n]));

--- a/comms/ncclx/v2_30/src/gin/gin_host_proxy.cc
+++ b/comms/ncclx/v2_30/src/gin/gin_host_proxy.cc
@@ -115,7 +115,7 @@ static ncclResult_t proxyGinPollCompletions(void *collComm,
         ncclResult_t res = ginBackend->test(collComm, state->request, &state->done);
         if (res != ncclSuccess) {
             ctx->hasError = true;
-            WARN("Error on GFD test %d - stateIdx: %lu, request: %p", res, state - hostGpuCtx->states, state->request);
+            ERR(res, "Error on GFD test %d - stateIdx: %lu, request: %p", res, state - hostGpuCtx->states, state->request);
             return res;
         }
         if (state->done) {
@@ -249,7 +249,7 @@ static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx *ctx,
     void *dstHandle = (void *)(uint64_t)gfd->qword[ncclGinProxyGfdDstHandle].dstHandle.dstHandle;
     uint64_t size = gfd->qword[ncclGinProxyGfdHeader].header.size;
     if (!ginBackend->iget) {
-      WARN("GIN plugin does not support GET");
+      ERR(ncclInvalidUsage, "GIN plugin does not support GET");
       return ncclInvalidUsage;
     }
     NCCLCHECK(ginBackend->iget(ctx->ginCtx, hostGpuCtx->contextId, srcOff, srcHandle, size, dstOff, dstHandle,
@@ -259,7 +259,7 @@ static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx *ctx,
 
   if (extractOp(gfd) & ncclGinProxyOpFlush) {
     if (!ginBackend->iflush) {
-      WARN("GIN plugin does not support FLUSH");
+      ERR(ncclInvalidUsage, "GIN plugin does not support FLUSH");
       return ncclInvalidUsage;
     }
     NCCLCHECK(ginBackend->iflush(ctx->ginCtx, hostGpuCtx->contextId, ctx->signalsGinHandle, targetRank,&state->request));

--- a/comms/ncclx/v2_30/src/libnccl.map
+++ b/comms/ncclx/v2_30/src/libnccl.map
@@ -2,6 +2,8 @@
     global:
         nccl*;
         pnccl*;
+        /* Cross-.so error reporting symbols; keep in sync with version.script */
+        *ErrorToScuba*;
         extern "C++" {
             ncclParamNoCacheSet*;
         };

--- a/comms/ncclx/v2_30/src/plugin/gin.cc
+++ b/comms/ncclx/v2_30/src/plugin/gin.cc
@@ -296,6 +296,6 @@ ncclResult_t ncclGinGetDevCount(int ginPluginIndex, int* nPhysDevs, int* nVirtDe
   *nPhysDevs = ginPluginLibs[ginPluginIndex].ginPhysDevs;
   return ncclSuccess;
 fail:
-  WARN("%s: trying to access the number of devices of an uninitialized ginPlugin[%d]", __func__, ginPluginIndex);
+  ERR(ncclInternalError, "%s: trying to access the number of devices of an uninitialized ginPlugin[%d]", __func__, ginPluginIndex);
   return ncclInternalError;
 }

--- a/comms/ncclx/v2_30/src/plugin/gin/gin_v11.cc
+++ b/comms/ncclx/v2_30/src/plugin/gin/gin_v11.cc
@@ -15,7 +15,7 @@ static ncclGin_t ncclGin;
 static ncclResult_t ncclGin_createContext(void* collComm, ncclGinConfig_t* config,
     void** ginCtx, ncclNetDeviceHandle_t** devHandle) {
   if (config->nContexts > 1) {
-    WARN("GIN plugin v11 does not support multiple contexts");
+    ERR(ncclInvalidUsage, "GIN plugin v11 does not support multiple contexts");
     return ncclInvalidUsage;
   }
   if (ncclGin_v11->createContext == NULL) {
@@ -37,7 +37,7 @@ static ncclResult_t ncclGin_destroyContext(void* ginCtx) {
 static ncclResult_t ncclGin_iput(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
     uint64_t dstOff, void* dstMhandle, uint32_t rank, void** request) {
   if (context != 0) {
-    WARN("GIN plugin v11 does not support multiple contexts");
+    ERR(ncclInvalidUsage, "GIN plugin v11 does not support multiple contexts");
     return ncclInvalidUsage;
   }
   return ncclGin_v11->iput(ginCtx, srcOff, srcMhandle, size, dstOff, dstMhandle, rank, request);
@@ -54,7 +54,7 @@ static ncclResult_t ncclGin_iputSignal(void* ginCtx, int context, uint64_t srcOf
     size_t size, uint64_t dstOff, void* dstMhandle, uint32_t rank, uint64_t signalOff, void *signalMhandle,
     uint64_t signalValue, uint32_t signalOp, void** request) {
   if (context != 0) {
-    WARN("GIN plugin v11 does not support multiple connections");
+    ERR(ncclInvalidUsage, "GIN plugin v11 does not support multiple connections");
     return ncclInvalidUsage;
   }
   return ncclGin_v11->iputSignal(ginCtx, srcOff, srcMhandle, size, dstOff, dstMhandle, rank, signalOff, signalMhandle, signalValue, signalOp, request);

--- a/comms/ncclx/v2_30/src/plugin/gin/gin_v12.cc
+++ b/comms/ncclx/v2_30/src/plugin/gin/gin_v12.cc
@@ -21,7 +21,7 @@ static ncclResult_t ncclGin_createContext(void* collComm, ncclGinConfig_t* confi
     void** ginCtx, ncclNetDeviceHandle_t** devHandle) {
   if (ncclGin_v12->createContext == NULL) {
     if (config->nContexts > 1) {
-      WARN("GIN plugin v12 does not support multiple contexts");
+      ERR(ncclInvalidUsage, "GIN plugin v12 does not support multiple contexts");
       return ncclInvalidUsage;
     }
     *ginCtx = collComm;
@@ -49,7 +49,7 @@ static ncclResult_t ncclGin_iflush(void* ginCtx, int context, void* mhandle, uin
 static ncclResult_t ncclGin_iput(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
     uint64_t dstOff, void* dstMhandle, uint32_t rank, void** request) {
   if (context != 0) {
-    WARN("GIN plugin v12 does not support multiple contexts");
+    ERR(ncclInvalidUsage, "GIN plugin v12 does not support multiple contexts");
     return ncclInvalidUsage;
   }
   return ncclGin_v12->iput(ginCtx, srcOff, srcMhandle, size, dstOff, dstMhandle, rank, 0, request);
@@ -59,7 +59,7 @@ static ncclResult_t ncclGin_iputSignal(void* ginCtx, int context, uint64_t srcOf
     size_t size, uint64_t dstOff, void* dstMhandle, uint32_t rank, uint64_t signalOff, void *signalMhandle,
     uint64_t signalValue, uint32_t signalOp, void** request) {
   if (context != 0) {
-    WARN("GIN plugin v12 does not support multiple connections");
+    ERR(ncclInvalidUsage, "GIN plugin v12 does not support multiple connections");
     return ncclInvalidUsage;
   }
   return ncclGin_v12->iputSignal(ginCtx, srcOff, srcMhandle, size, dstOff, dstMhandle, rank, signalOff, signalMhandle, signalValue, signalOp, 0, request);

--- a/comms/ncclx/v2_30/src/version.script
+++ b/comms/ncclx/v2_30/src/version.script
@@ -12,6 +12,8 @@ cxa: Folly’s exception tracer intercepts all exceptions and uses
       *ctran*;
       *prims*;
       *cxa*;
+      /* Scuba error loggers called cross-.so from _comms_ncclx via CERR (CtranMapper.h) */
+      *ErrorToScuba*;
       *getDevMemType*;
       *getCudaDevFromPtr*;
       *StreamCaptureModeGuard*;

--- a/comms/utils/checks.h
+++ b/comms/utils/checks.h
@@ -73,7 +73,7 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
   {                                                                   \
     const auto err = cmd;                                             \
     if (err != cudaSuccess) {                                         \
-      XLOG(ERR) << fmt::format("Call for {} failed", #cmd);           \
+      CERR(commUnhandledCudaError, "Call for {} failed", #cmd);       \
       return folly::makeUnexpected(                                   \
           getCommsErrorFromCudaError(err, __FILE__, __LINE__, #cmd)); \
     }                                                                 \
@@ -101,8 +101,8 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
   do {                                                              \
     cudaError_t err = cmd;                                          \
     if (err != cudaSuccess) {                                       \
-      CLOGF(                                                        \
-          ERR,                                                      \
+      CERR(                                                         \
+          commUnhandledCudaError,                                   \
           "{}:{} Cuda failure {}",                                  \
           __FILE__,                                                 \
           __LINE__,                                                 \
@@ -170,7 +170,7 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
     if (!(statement)) {                                                        \
       auto errorMsg =                                                          \
           fmt::format("Check failed: {} - {}", #statement, __VA_ARGS__);       \
-      CLOGF(ERR, errorMsg);                                                    \
+      CERR(commInternalError, "{}", errorMsg);                                 \
       throw std::runtime_error(                                                \
           fmt::format(                                                         \
               "Check failed: {} - {}", #statement, fmt::format(__VA_ARGS__))); \

--- a/comms/utils/logger/LogUtils.h
+++ b/comms/utils/logger/LogUtils.h
@@ -52,6 +52,19 @@ void initCommLogging(bool alwaysInit = false);
 #define CLOGF(level, ...) XLOGF(level, ##__VA_ARGS__)
 
 /**
+ * CERR(code, fmt, ...) logs an ERR-level message (like CLOGF(ERR, ...)) AND
+ * records one Scuba error record carrying the commResult_t `code`. Use it at
+ * fatal/root-cause CTRAN error sites; keep plain CLOGF(ERR, ...) for
+ * recoverable/propagated logs that should not create an error record.
+ */
+#define CERR(code, ...)                         \
+  do {                                          \
+    XLOGF(ERR, ##__VA_ARGS__);                  \
+    ::meta::comms::logger::logCommErrorToScuba( \
+        (code), fmt::format(__VA_ARGS__));      \
+  } while (0)
+
+/**
  * Usage:
  *   CLOGF_IF(INFO, size > threshold, "Large data: {} bytes", size);
  *

--- a/comms/utils/logger/LoggingFormat.cc
+++ b/comms/utils/logger/LoggingFormat.cc
@@ -15,7 +15,9 @@
 #include <folly/logging/LogName.h>
 #include <folly/synchronization/CallOnce.h>
 
+#include "comms/utils/Conversion.h"
 #include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
+#include "comms/utils/logger/ErrorStackUtil.h"
 #include "comms/utils/logger/EventsScubaUtil.h"
 #include "comms/utils/logger/NcclScubaSample.h"
 
@@ -362,6 +364,21 @@ void setLastError(const std::string& message, std::vector<std::string> stack) {
   auto w = lastCommsError.wlock();
   w->lastErrorMessage = message;
   w->lastErrorNativeStack = std::move(stack);
+}
+
+void logCommErrorToScuba(commResult_t code, const std::string& message) {
+  if (!NCCL_SCUBA_LOG_ERROR_ENABLED) {
+    return;
+  }
+  std::vector<std::string> stack;
+  if (NCCL_SCUBA_STACK_TRACE_ON_ERROR_ENABLED) {
+    stack = captureNativeErrorStack();
+  }
+  logErrorToScuba(
+      message,
+      static_cast<int>(code),
+      ::meta::comms::commCodeToString(code),
+      stack);
 }
 
 std::string getLastCommsError() {

--- a/comms/utils/logger/LoggingFormat.h
+++ b/comms/utils/logger/LoggingFormat.h
@@ -12,6 +12,8 @@
 #include <folly/logging/LogFormatter.h>
 #include <folly/logging/LogLevel.h>
 
+#include "comms/utils/commSpecs.h"
+
 namespace meta::comms::logger {
 
 enum class LogLevel {
@@ -79,7 +81,7 @@ void appendErrorToStack(std::string error);
 // native stack in the stack_trace column). The caller is responsible for gating
 // this on NCCL_SCUBA_LOG_ERROR_ENABLED and for capturing the native `stack`
 // once (via captureNativeErrorStack()) so it can be shared across reporters.
-void logErrorToScuba(
+__attribute__((visibility("default"))) void logErrorToScuba(
     const std::string& message,
     int code,
     const std::string& errorName,
@@ -88,6 +90,12 @@ void logErrorToScuba(
 // Update the ncclGetLastError() state with the latest error message and its
 // pre-captured native stack. Unconditional; independent of Scuba error logging.
 void setLastError(const std::string& message, std::vector<std::string> stack);
+
+// Record a CTRAN ERR-level error to Scuba, carrying the commResult_t code.
+// Gated by NCCL_SCUBA_LOG_ERROR_ENABLED; a no-op when disabled.
+__attribute__((visibility("default"))) void logCommErrorToScuba(
+    commResult_t code,
+    const std::string& message);
 
 class NcclLogFormatter : public folly::LogFormatter {
  public:


### PR DESCRIPTION
Summary:
Continue the CERR-coverage campaign into `comms/ctran/backends/` so every root-cause error origination in the transport backends records exactly one Scuba error record carrying its `commResult_t`. `CERR(code, ...)` logs at ERR level (like `CLOGF(ERR, ...)`) and records the code; `FB_COMMCHECK` propagation only logs, so unrecorded originations were invisible to Scuba. Convert 25 existing `CLOGF(ERR, ...)` sites that log-then-return a fresh comm error to `CERR(code, ...)`:
- `ib/CtranIbVc.h` (9) and `ib/CtranIbVc.cc` (2): MR-not-found / QP / opcode / atomic-pending state errors -> commSystemError / commInternalError.
- `ib/CtranIb.h` (4) and `ib/CtranIbBase.h` (1): peer/VC/device validation -> commInternalError.
- `ib/VcState.cc` (3): QP-to-VC map state -> commInternalError (the propagating callers stay silent to avoid double-recording).
- `ib/BootstrapExternal.cc`, `ib/BootstrapInternal.cc`, `ib/ibutils.cc`, `ib/CtranIbImpl.h` (CQE_ERROR_CHECK macro -> commRemoteError): one each.
- `socket/CtranSocket.h` (1) and `tcpdevmem/CtranTcpDm.cc` (1, flag-gated, hand-verified).
Additionally, remove the now-redundant file-local `addToStackTrace` helper in `ib/ibutils.cc` and inline its 7 call sites as direct `CERR(commSystemError, ...)`. The helper was `CERR(commSystemError, ...)` + `ErrorStackTraceUtil::logErrorMessage(msg)` + `return commSystemError`; the middle step recorded to a separate process-global-errors / EventsScuba stack-trace sink and is intentionally dropped in favor of the single CERR comm-error Scuba record. The 4 `return addToStackTrace(...)` sites become `CERR(...); return commSystemError;` and the 3 standalone sites become `CERR(...);` with all surrounding logic (ProcessGlobalErrorsUtil::setNic, ret assignment, linkDownSetTimeout, XLOGF warnings) preserved. Since fatal/link IB events are now recorded only via `ProcessGlobalErrorsUtil::setNic` (badNics) rather than the dropped ErrorStackTraceUtil path (errorAndStackTraces), the `CtranIbTransportErrorsUT` AsyncEventFound and AsyncEventLinkFlap tests are updated to verify the fatal event and the link-down-timeout timing via `state.badNics` instead of `state.errorAndStackTraces`.
Each CERR code matches the error actually returned at the site. Propagators (e.g. VcState.cc callers of checkAndInsertQpToVcMap), catch blocks, destructors, log-and-continue (break/continue), non-comm returns (bool/nullptr), WARN-level logs, capability-probe fallbacks (IbvWrap), mock stubs, and the flag-gated tcpdevmem silent returns are intentionally left unchanged. CtranIb.cc and CtranSocket.cc were already converted in commit 1.

Reviewed By: YulunW

Differential Revision: D113325211
