### PR TITLE
Migrate RCCL ROCm CI to MI350x meta-pytorch runner

### DIFF
--- a/.github/workflows/build_test_rccl.yaml
+++ b/.github/workflows/build_test_rccl.yaml
@@ -16,7 +16,8 @@ jobs:
       matrix:
         include:
           - name: RCCL
-            runs-on: amd-mi350-runner
+            # Migrated to the DigitalOcean MI350x meta-pytorch runner fleet.
+            runs-on: linux.rocm.gpu.meta-pytorch.mi350.1
             gpu-arch-type: "rocm"
             gpu-arch-version: "7.0"
             torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/rocm7.0'

--- a/.github/workflows/build_test_rccl.yaml
+++ b/.github/workflows/build_test_rccl.yaml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - main
-
+    tags:
+      - ciflow/rocm
 permissions:
       id-token: write
       contents: read

--- a/.github/workflows/build_test_rccl.yaml
+++ b/.github/workflows/build_test_rccl.yaml
@@ -17,7 +17,7 @@ jobs:
         include:
           - name: RCCL
             # Migrated to the DigitalOcean MI350x meta-pytorch runner fleet.
-            runs-on: linux.rocm.gpu.meta-pytorch.mi350.1
+            runs-on: linux.rocm.gpu.meta-pytorch.mi350.4
             gpu-arch-type: "rocm"
             gpu-arch-version: "7.0"
             torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/rocm7.0'


### PR DESCRIPTION
## Summary

Migrate the RCCL ROCm CI job to the new MI350x meta-pytorch runner fleet.

- `.github/workflows/build_test_rccl.yaml`: change the RCCL matrix entry `runs-on` from `amd-mi350-runner` to `linux.rocm.gpu.meta-pytorch.mi350.4`.

Draft until the MI350x runners are confirmed online and picking up jobs.

## Test plan

- [ ] Confirm the MI350x meta-pytorch runners are online and registered with the label `linux.rocm.gpu.meta-pytorch.mi350.1`.
- [ ] Trigger the RCCL build/test workflow and confirm jobs schedule onto the new runner and pass.

Made with Cursor