### PR TITLE
Use per-comm trafficClass hint in CTran IB (#3318)

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -88,6 +88,9 @@ inline int64_t ctranPrimsResolvedMaxBlocks(const ctranPrimsConfig& pc) {
 struct ctranConfig {
   int blocking{-1};
   std::string commDesc;
+  // Per-comm traffic class hint sourced from ncclConfig_t.trafficClass.
+  // Negative means "hint not set"; consumers fall back to env/default.
+  int trafficClass{-1};
   std::vector<enum CommBackend> backends = {};
   ctranPrimsConfig primsConfig;
   // The creator supplies this; ctran does not read the sampling cvar
@@ -98,6 +101,7 @@ struct ctranConfig {
     return (
         blocking == other.blocking && commDesc == other.commDesc &&
         backends == other.backends && primsConfig == other.primsConfig &&
+        trafficClass == other.trafficClass &&
         enableProfiler == other.enableProfiler);
   }
 };

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -4,6 +4,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <climits>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -56,6 +57,10 @@ struct ctranPipesConfig {
 struct ctranConfig {
   int blocking{-1};
   std::string commDesc;
+  // Per-comm traffic class hint sourced from ncclConfig_t.trafficClass.
+  // Default INT_MIN matches NCCL_CONFIG_UNDEF_INT (nccl.h). Consumers should
+  // treat any negative value as "hint not set" and fall back to env/default.
+  int trafficClass{INT_MIN};
   std::vector<enum CommBackend> backends = {};
   ctranPipesConfig pipesConfig;
   bool enableProfiler{NCCL_CTRAN_TRANSPORT_PROFILER};
@@ -63,7 +68,8 @@ struct ctranConfig {
   bool operator==(const ctranConfig& other) const {
     return (
         blocking == other.blocking && commDesc == other.commDesc &&
-        backends == other.backends && pipesConfig == other.pipesConfig &&
+        trafficClass == other.trafficClass && backends == other.backends &&
+        pipesConfig == other.pipesConfig &&
         enableProfiler == other.enableProfiler);
   }
 };

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -42,6 +42,7 @@ namespace {
 #define CTRAN_IB_ANY_PORT -1
 constexpr int kH100CudaArch = 900;
 constexpr int kGb300CudaArch = 1030;
+constexpr int kMaxTrafficClass = 255;
 }; // namespace
 
 thread_local std::unordered_map<void*, std::atomic_bool> epochLockedFlags;
@@ -431,7 +432,7 @@ void CtranIb::init(
   FB_CHECKTHROW_EX_LOGDATA(this->numNics > 0, ncclLogData, "numNics > 0");
   this->devices.resize(this->numNics);
   this->cqs.reserve(this->numNics);
-  FB_COMMCHECKTHROW_EX(this->setPgToTrafficClassMap(), this->ncclLogData);
+  FB_COMMCHECKTHROW_EX(this->resolveTrafficClass(), this->ncclLogData);
 
   auto s = CtranIbSingleton::getInstance();
   CHECK_VALID_IB_SINGLETON(s);
@@ -1086,7 +1087,36 @@ const char* CtranIb::ibv_wc_status_str(enum ibverbx::ibv_wc_status status) {
   }
 }
 
-commResult_t CtranIb::setPgToTrafficClassMap() {
+commResult_t CtranIb::resolveTrafficClass() {
+  // Precedence:
+  //   1. per-comm NcclConfig.traffic_class hint (int in [0, kMaxTrafficClass])
+  //   2. NCCL_CTRAN_IB_PG_TRAFFIC_CLASS env-map matched on commDesc prefix
+  //   3. NCCL_IB_TC global fallback
+  // Called once from CtranIb::init(); result stored in trafficClass_.
+
+  // 1. Per-comm hint. ncclConfig_t.trafficClass defaults to
+  // NCCL_CONFIG_UNDEF_INT (INT_MIN); reject any out-of-range value so we
+  // never program a bogus DSCP on the wire.
+  if (comm && comm->config_.trafficClass >= 0 &&
+      comm->config_.trafficClass <= kMaxTrafficClass) {
+    trafficClass_ = static_cast<uint32_t>(comm->config_.trafficClass);
+    CLOGF_SUBSYS(
+        INFO,
+        INIT,
+        "CTRAN-IB: commHash {:x}, commDesc {} trafficClass={} (from per-comm hint)",
+        commHash,
+        commDesc,
+        trafficClass_);
+    return commSuccess;
+  }
+
+  // 2. NCCL_CTRAN_IB_PG_TRAFFIC_CLASS env-map. Only the entry whose PG
+  // prefix matches this comm's commDesc applies; the map itself is a
+  // global cvar shared across all comms.
+  std::vector<std::string> pgCommDescPair;
+  folly::split(":", commDesc, pgCommDescPair);
+  const std::string& pgPrefix = pgCommDescPair[0];
+
   for (const auto& pgTrafficClassPairStr : NCCL_CTRAN_IB_PG_TRAFFIC_CLASS) {
     std::vector<std::string> pgTrafficClassPair;
     folly::split(":", pgTrafficClassPairStr, pgTrafficClassPair);
@@ -1100,38 +1130,41 @@ commResult_t CtranIb::setPgToTrafficClassMap() {
           commDesc);
       return commInternalError;
     }
-    std::string tcStr = pgTrafficClassPair[1];
-    auto tc = folly::tryTo<uint32_t>(tcStr);
+    if (pgTrafficClassPair[0] != pgPrefix) {
+      continue;
+    }
+    auto tc = folly::tryTo<uint32_t>(pgTrafficClassPair[1]);
     if (!tc.hasValue()) {
       CERR(
           commInternalError,
           "CTRAN-IB: Invalid Traffic Class value provided {} in pimpl {} commHash {:x}, commDesc {}.",
-          tcStr,
+          pgTrafficClassPair[1],
           (void*)this,
           commHash,
           commDesc);
       return commInternalError;
     }
+    trafficClass_ = tc.value();
     CLOGF_SUBSYS(
         INFO,
         INIT,
-        "CTRAN-IB: commHash {:x}, commDesc {} override traffic class to {}",
+        "CTRAN-IB: commHash {:x}, commDesc {} trafficClass={} (from NCCL_CTRAN_IB_PG_TRAFFIC_CLASS env-map)",
         commHash,
         commDesc,
-        tc.value());
-    pgToTrafficClassMap_[pgTrafficClassPair[0]] = tc.value();
+        trafficClass_);
+    return commSuccess;
   }
-  return commSuccess;
-}
 
-uint32_t CtranIb::getPgToTrafficClassValue() const {
-  std::vector<std::string> pgCommDescPair;
-  folly::split(":", commDesc, pgCommDescPair);
-  auto it = pgToTrafficClassMap_.find(pgCommDescPair[0]);
-  if (it != pgToTrafficClassMap_.end()) {
-    return it->second;
-  }
-  return NCCL_IB_TC;
+  // 3. Global fallback.
+  trafficClass_ = static_cast<uint32_t>(NCCL_IB_TC);
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "CTRAN-IB: commHash {:x}, commDesc {} trafficClass={} (from NCCL_IB_TC global fallback)",
+      commHash,
+      commDesc,
+      trafficClass_);
+  return commSuccess;
 }
 
 // ============================================================

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -43,6 +43,7 @@ namespace {
 #define CTRAN_IB_ANY_PORT -1
 constexpr int kH100CudaArch = 900;
 constexpr int kGb300CudaArch = 1030;
+constexpr int kMaxTrafficClass = 255;
 }; // namespace
 
 thread_local std::unordered_map<void*, std::atomic_bool> epochLockedFlags;
@@ -431,7 +432,7 @@ void CtranIb::init(
   FB_CHECKTHROW_EX_LOGDATA(this->numNics > 0, ncclLogData, "numNics > 0");
   this->devices.resize(this->numNics);
   this->cqs.reserve(this->numNics);
-  FB_COMMCHECKTHROW_EX(this->setPgToTrafficClassMap(), this->ncclLogData);
+  FB_COMMCHECKTHROW_EX(this->resolveTrafficClass(), this->ncclLogData);
 
   auto s = CtranIbSingleton::getInstance();
   CHECK_VALID_IB_SINGLETON(s);
@@ -699,7 +700,7 @@ void CtranIb::init(
         commHash,
         commDesc,
         ncclLogData,
-        getPgToTrafficClassValue());
+        getTrafficClass());
     CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
@@ -716,7 +717,7 @@ void CtranIb::init(
         ncclLogData,
         comm,
         devices,
-        getPgToTrafficClassValue(),
+        getTrafficClass(),
         cudaDev,
         rank,
         commHash,
@@ -1124,7 +1125,50 @@ const char* CtranIb::ibv_wc_status_str(enum ibverbx::ibv_wc_status status) {
   }
 }
 
-commResult_t CtranIb::setPgToTrafficClassMap() {
+commResult_t CtranIb::resolveTrafficClass() {
+  // Precedence:
+  //   1. per-comm NcclConfig.traffic_class hint (int in [0, kMaxTrafficClass])
+  //   2. NCCL_CTRAN_IB_PG_TRAFFIC_CLASS env-map matched on commDesc prefix
+  //   3. NCCL_IB_TC global fallback
+  // Called once from CtranIb::init(); result stored in trafficClass_.
+
+  // 1. Per-comm hint. A negative value means the hint was never set (the
+  // ctranConfig default, and NCCL_CONFIG_UNDEF_INT upstream). A value above
+  // the DSCP range is a misconfiguration: warn and fall back rather than
+  // program a bogus DSCP on the wire.
+  if (comm) {
+    const int hint = comm->config_.trafficClass;
+    if (hint >= 0 && hint <= kMaxTrafficClass) {
+      trafficClass_ = static_cast<uint32_t>(hint);
+      CLOGF_SUBSYS(
+          INFO,
+          INIT,
+          "CTRAN-IB: commHash {:x}, commDesc {} trafficClass={} (from per-comm hint)",
+          commHash,
+          commDesc,
+          trafficClass_);
+      return commSuccess;
+    }
+    if (hint > kMaxTrafficClass) {
+      CLOGF(
+          WARN,
+          "CTRAN-IB: commHash {:x}, commDesc {} ignoring out-of-range per-comm trafficClass hint {} (valid range [0, {}]); falling back to env settings.",
+          commHash,
+          commDesc,
+          hint,
+          kMaxTrafficClass);
+    }
+  }
+
+  // 2. NCCL_CTRAN_IB_PG_TRAFFIC_CLASS env-map. Every entry is validated so a
+  // malformed pair is reported regardless of where it sits in the list; only
+  // the first entry whose PG prefix matches this comm's commDesc is applied.
+  // The map itself is a global cvar shared across all comms.
+  std::vector<std::string> pgCommDescPair;
+  folly::split(":", commDesc, pgCommDescPair);
+  const std::string& pgPrefix = pgCommDescPair[0];
+
+  std::optional<uint32_t> matchedTc;
   for (const auto& pgTrafficClassPairStr : NCCL_CTRAN_IB_PG_TRAFFIC_CLASS) {
     std::vector<std::string> pgTrafficClassPair;
     folly::split(":", pgTrafficClassPairStr, pgTrafficClassPair);
@@ -1138,38 +1182,55 @@ commResult_t CtranIb::setPgToTrafficClassMap() {
           commDesc);
       return commInternalError;
     }
-    std::string tcStr = pgTrafficClassPair[1];
-    auto tc = folly::tryTo<uint32_t>(tcStr);
+    const auto tc = folly::tryTo<uint32_t>(pgTrafficClassPair[1]);
     if (!tc.hasValue()) {
       CTRAN_ERR(
           commInternalError,
           "CTRAN-IB: Invalid Traffic Class value provided {} in pimpl {} commHash {:x}, commDesc {}.",
-          tcStr,
+          pgTrafficClassPair[1],
           (void*)this,
           commHash,
           commDesc);
       return commInternalError;
     }
-    CTRAN_LOG_SUBSYS(
+    if (tc.value() > kMaxTrafficClass) {
+      CTRAN_ERR(
+          commInternalError,
+          "CTRAN-IB: Out-of-range Traffic Class value {} (valid range [0, {}]) in pimpl {} commHash {:x}, commDesc {}.",
+          tc.value(),
+          kMaxTrafficClass,
+          (void*)this,
+          commHash,
+          commDesc);
+      return commInternalError;
+    }
+    if (!matchedTc.has_value() && pgTrafficClassPair[0] == pgPrefix) {
+      matchedTc = tc.value();
+    }
+  }
+
+  if (matchedTc.has_value()) {
+    trafficClass_ = *matchedTc;
+    CLOGF_SUBSYS(
         INFO,
         INIT,
-        "CTRAN-IB: commHash {:x}, commDesc {} override traffic class to {}",
+        "CTRAN-IB: commHash {:x}, commDesc {} trafficClass={} (from NCCL_CTRAN_IB_PG_TRAFFIC_CLASS env-map)",
         commHash,
         commDesc,
-        tc.value());
-    pgToTrafficClassMap_[pgTrafficClassPair[0]] = tc.value();
+        trafficClass_);
+    return commSuccess;
   }
-  return commSuccess;
-}
 
-uint32_t CtranIb::getPgToTrafficClassValue() const {
-  std::vector<std::string> pgCommDescPair;
-  folly::split(":", commDesc, pgCommDescPair);
-  auto it = pgToTrafficClassMap_.find(pgCommDescPair[0]);
-  if (it != pgToTrafficClassMap_.end()) {
-    return it->second;
-  }
-  return NCCL_IB_TC;
+  // 3. Global fallback.
+  trafficClass_ = static_cast<uint32_t>(NCCL_IB_TC);
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "CTRAN-IB: commHash {:x}, commDesc {} trafficClass={} (from NCCL_IB_TC global fallback)",
+      commHash,
+      commDesc,
+      trafficClass_);
+  return commSuccess;
 }
 
 // ============================================================

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -571,6 +571,10 @@ class CtranIb {
     return numNics;
   }
 
+  uint32_t getTrafficClass() const {
+    return trafficClass_;
+  }
+
  private:
   friend class CtranIbRequest;
   void init(
@@ -588,9 +592,12 @@ class CtranIb {
       std::optional<int> maxNumCqe = std::nullopt,
       std::optional<int> maxNumNic = std::nullopt);
 
-  commResult_t setPgToTrafficClassMap();
-
-  uint32_t getPgToTrafficClassValue() const;
+  // Resolve the effective traffic class once from:
+  //   per-comm NcclConfig.traffic_class hint (0..255)
+  //   > NCCL_CTRAN_IB_PG_TRAFFIC_CLASS env-map (matched on commDesc prefix)
+  //   > NCCL_IB_TC global fallback
+  // Called once from init(); result stored in trafficClass_.
+  commResult_t resolveTrafficClass();
 
   const char* ibv_wc_status_str(enum ibverbx::ibv_wc_status status);
 
@@ -1165,7 +1172,9 @@ class CtranIb {
   folly::F14FastMap<int, PendingOpQueue> rankToPendingOpsMap;
   std::mutex pendingOpsMutex;
 
-  std::unordered_map<std::string, uint32_t> pgToTrafficClassMap_;
+  // Traffic class resolved once at init from hint > env-map > NCCL_IB_TC.
+  // Used for all QPs on this CtranIb / comm.
+  uint32_t trafficClass_{0};
 
   std::shared_ptr<::comms::fault_tolerance::Abort> abortCtrl_{nullptr};
 };

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -570,6 +570,10 @@ class CtranIb {
     return numNics;
   }
 
+  uint32_t getPgToTrafficClassValue() const {
+    return trafficClass_;
+  }
+
  private:
   friend class CtranIbRequest;
   void init(
@@ -587,9 +591,12 @@ class CtranIb {
       std::optional<int> maxNumCqe = std::nullopt,
       std::optional<int> maxNumNic = std::nullopt);
 
-  commResult_t setPgToTrafficClassMap();
-
-  uint32_t getPgToTrafficClassValue() const;
+  // Resolve the effective traffic class once from:
+  //   per-comm NcclConfig.traffic_class hint (0..255)
+  //   > NCCL_CTRAN_IB_PG_TRAFFIC_CLASS env-map (matched on commDesc prefix)
+  //   > NCCL_IB_TC global fallback
+  // Called once from init(); result stored in trafficClass_.
+  commResult_t resolveTrafficClass();
 
   const char* ibv_wc_status_str(enum ibverbx::ibv_wc_status status);
 
@@ -1164,7 +1171,9 @@ class CtranIb {
   folly::F14FastMap<int, PendingOpQueue> rankToPendingOpsMap;
   std::mutex pendingOpsMutex;
 
-  std::unordered_map<std::string, uint32_t> pgToTrafficClassMap_;
+  // Traffic class resolved once at init from hint > env-map > NCCL_IB_TC.
+  // Used for all QPs on this CtranIb / comm.
+  uint32_t trafficClass_{0};
 
   std::shared_ptr<::comms::fault_tolerance::Abort> abortCtrl_{nullptr};
 };

--- a/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
@@ -2026,6 +2026,46 @@ TEST_F(CtranIbTest, pgTrafficClassConfig) {
   }
 }
 
+// Precedence: comm hint > NCCL_CTRAN_IB_PG_TRAFFIC_CLASS env-map > NCCL_IB_TC.
+TEST_F(CtranIbTest, trafficClassHintOverridesEnvMap) {
+  // Env-map would otherwise set PP_P2P_0 -> 200. The hint (192) must win.
+  std::vector<std::string> pgTrafficClass = {"PP_P2P_0:200", "PP_P2P_1:208"};
+  EnvRAII env1(NCCL_CTRAN_IB_PG_TRAFFIC_CLASS, std::move(pgTrafficClass));
+  this->comm->config_.commDesc = "PP_P2P_0";
+  this->comm->config_.trafficClass = 192;
+  try {
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
+    EXPECT_EQ(ctranIb->getPgToTrafficClassValue(), 192u);
+  } catch (const std::bad_alloc&) {
+    GTEST_SKIP() << "IB backend not enabled. Skip test";
+  }
+}
+
+TEST_F(CtranIbTest, trafficClassFallsBackToNcclIbTc) {
+  EnvRAII env1(NCCL_IB_TC, int64_t{128});
+  // No PG env-map entry, no hint.
+  this->comm->config_.commDesc = "DP";
+  this->comm->config_.trafficClass = INT_MIN;
+  try {
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
+    EXPECT_EQ(ctranIb->getPgToTrafficClassValue(), 128u);
+  } catch (const std::bad_alloc&) {
+    GTEST_SKIP() << "IB backend not enabled. Skip test";
+  }
+}
+
+TEST_F(CtranIbTest, trafficClassOutOfRangeFallsBackToEnv) {
+  EnvRAII env1(NCCL_IB_TC, int64_t{64});
+  this->comm->config_.commDesc = "DP";
+  this->comm->config_.trafficClass = 1024; // > 255
+  try {
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
+    EXPECT_EQ(ctranIb->getPgToTrafficClassValue(), 64u);
+  } catch (const std::bad_alloc&) {
+    GTEST_SKIP() << "IB backend not enabled. Skip test";
+  }
+}
+
 TEST_F(CtranIbTest, pgTrafficClassConfigWithoutComm) {
   const std::string eth = "eth0";
   EnvRAII env1(NCCL_SOCKET_IFNAME, eth);

--- a/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
@@ -2116,6 +2116,88 @@ TEST_F(CtranIbTest, pgTrafficClassConfig) {
   }
 }
 
+// CtranIb resolves the env-map against comm->statex_->commDesc(), so an
+// env-map entry only matches when it is keyed on that value's prefix.
+namespace {
+std::string trafficClassPgPrefix(const CtranComm* comm) {
+  const std::string commDesc = comm->statex_->commDesc();
+  return commDesc.substr(0, commDesc.find(':'));
+}
+} // namespace
+
+// Precedence: comm hint > NCCL_CTRAN_IB_PG_TRAFFIC_CLASS env-map > NCCL_IB_TC.
+TEST_F(CtranIbTest, trafficClassHintOverridesEnvMap) {
+  // Env-map matches this comm and would set 200. The hint (192) must win.
+  std::vector<std::string> pgTrafficClass = {
+      trafficClassPgPrefix(this->comm) + ":200"};
+  EnvRAII env1(NCCL_CTRAN_IB_PG_TRAFFIC_CLASS, std::move(pgTrafficClass));
+  this->comm->config_.trafficClass = 192;
+  try {
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
+    EXPECT_EQ(ctranIb->getTrafficClass(), 192u);
+  } catch (const std::bad_alloc&) {
+    GTEST_SKIP() << "IB backend not enabled. Skip test";
+  }
+}
+
+TEST_F(CtranIbTest, trafficClassFallsBackToNcclIbTc) {
+  EnvRAII env1(NCCL_IB_TC, int64_t{128});
+  // No PG env-map entry, no hint.
+  this->comm->config_.trafficClass = INT_MIN;
+  try {
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
+    EXPECT_EQ(ctranIb->getTrafficClass(), 128u);
+  } catch (const std::bad_alloc&) {
+    GTEST_SKIP() << "IB backend not enabled. Skip test";
+  }
+}
+
+TEST_F(CtranIbTest, trafficClassOutOfRangeFallsBackToEnv) {
+  EnvRAII env1(NCCL_IB_TC, int64_t{64});
+  this->comm->config_.commDesc = "DP";
+  this->comm->config_.trafficClass = 1024; // > 255
+  try {
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
+    EXPECT_EQ(ctranIb->getTrafficClass(), 64u);
+  } catch (const std::bad_alloc&) {
+    GTEST_SKIP() << "IB backend not enabled. Skip test";
+  }
+}
+
+TEST_F(CtranIbTest, trafficClassEnvMapUsedWhenHintUnset) {
+  // No hint: the env-map entry matching this comm's PG prefix applies, and
+  // NCCL_IB_TC stays unused. The non-matching entry must be ignored.
+  EnvRAII env1(NCCL_IB_TC, int64_t{64});
+  std::vector<std::string> pgTrafficClass = {
+      "PP_P2P_0:200", trafficClassPgPrefix(this->comm) + ":208"};
+  EnvRAII env2(NCCL_CTRAN_IB_PG_TRAFFIC_CLASS, std::move(pgTrafficClass));
+  this->comm->config_.trafficClass = -1;
+  try {
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
+    EXPECT_EQ(ctranIb->getTrafficClass(), 208u);
+  } catch (const std::bad_alloc&) {
+    GTEST_SKIP() << "IB backend not enabled. Skip test";
+  }
+}
+
+TEST_F(CtranIbTest, trafficClassMalformedEnvEntryRejectedRegardlessOfOrder) {
+  // The malformed entry sits after the one that matches this comm; it must
+  // still be reported instead of being skipped by an early match.
+  std::vector<std::string> pgTrafficClass = {
+      trafficClassPgPrefix(this->comm) + ":200", "PP_P2P_1:xyz"};
+  EnvRAII env1(NCCL_CTRAN_IB_PG_TRAFFIC_CLASS, std::move(pgTrafficClass));
+  this->comm->config_.trafficClass = -1;
+  try {
+    auto ctranIb = std::make_unique<CtranIb>(this->comm);
+    ADD_FAILURE() << "Expected CtranIb construction to reject the malformed "
+                     "NCCL_CTRAN_IB_PG_TRAFFIC_CLASS entry";
+  } catch (const std::bad_alloc&) {
+    GTEST_SKIP() << "IB backend not enabled. Skip test";
+  } catch (const ctran::utils::Exception&) {
+    SUCCEED();
+  }
+}
+
 TEST_F(CtranIbTest, pgTrafficClassConfigWithoutComm) {
   const std::string eth = "eth0";
   EnvRAII env1(NCCL_SOCKET_IFNAME, eth);

--- a/comms/ncclx/meta/tests/TrafficClassTest.cc
+++ b/comms/ncclx/meta/tests/TrafficClassTest.cc
@@ -1,0 +1,77 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <climits>
+#include <cstdlib>
+
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+#include "comm.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/testinfra/TestUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "nccl.h"
+
+// End-to-end coverage for the per-comm trafficClass hint: creates a real
+// communicator via ncclCommInitRankConfig with config.trafficClass set,
+// then verifies the value propagates into both ncclComm->config and the
+// CtranComm mirror populated by MetaFactory.
+
+class trafficClassTest : public NcclxBaseTestFixture {
+ public:
+  trafficClassTest() = default;
+
+ protected:
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp();
+  }
+
+  void TearDown() override {
+    NcclxBaseTestFixture::TearDown();
+  }
+};
+
+// When the hint is set on ncclConfig_t.trafficClass at comm init, both the
+// NCCL comm and its CtranComm mirror should carry the value.
+TEST_F(trafficClassTest, hintPropagatesToCommAndCtran) {
+  EnvRAII ctranEnv(NCCL_CTRAN_ENABLE, true);
+  constexpr int kHintValue = 192;
+
+  ncclConfig_t inputConfig = NCCL_CONFIG_INITIALIZER;
+  inputConfig.trafficClass = kHintValue;
+
+  ncclx::test::NcclCommRAII comm(
+      globalRank,
+      numRanks,
+      localRank,
+      bootstrap_.get(),
+      /*isMock=*/false,
+      &inputConfig);
+  ASSERT_NE(nullptr, static_cast<ncclComm_t>(comm));
+
+  EXPECT_EQ(comm->config.trafficClass, kHintValue);
+  ASSERT_NE(nullptr, comm->ctranComm_);
+  EXPECT_EQ(comm->ctranComm_->config_.trafficClass, kHintValue);
+}
+
+// When the hint is not set, ncclConfig_t.trafficClass stays at the upstream
+// NCCL_CONFIG_UNDEF_INT sentinel (INT_MIN), and CtranComm mirrors that.
+TEST_F(trafficClassTest, hintUnsetLeavesUndefSentinel) {
+  EnvRAII ctranEnv(NCCL_CTRAN_ENABLE, true);
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, static_cast<ncclComm_t>(comm));
+
+  EXPECT_EQ(comm->config.trafficClass, NCCL_CONFIG_UNDEF_INT);
+  ASSERT_NE(nullptr, comm->ctranComm_);
+  EXPECT_EQ(comm->ctranComm_->config_.trafficClass, NCCL_CONFIG_UNDEF_INT);
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -38,6 +38,7 @@ ctranConfig makeCtranConfigFrom(ncclComm* comm) {
   struct ctranConfig tconfig = {
       .blocking = comm->config.blocking,
       .commDesc = NCCLX_CONFIG_FIELD(comm->config, commDesc),
+      .trafficClass = comm->config.trafficClass,
       .enableProfiler = NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT > 0,
   };
   if (comm->config.ncclxConfig != nullptr) {

--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -38,6 +38,7 @@ ctranConfig makeCtranConfigFrom(ncclComm* comm) {
   struct ctranConfig tconfig = {
       .blocking = comm->config.blocking,
       .commDesc = NCCLX_CONFIG_FIELD(comm->config, commDesc),
+      .trafficClass = comm->config.trafficClass,
   };
   if (comm->config.ncclxConfig != nullptr) {
     const auto* ncclxCfg =

--- a/comms/ncclx/v2_30/src/transport/net_ib/connect.cc
+++ b/comms/ncclx/v2_30/src/transport/net_ib/connect.cc
@@ -829,8 +829,11 @@ ib_recv_dev_list:
   }
   trafficClass = ncclIbGetTrafficClass(ctx);
   meta.addr = (uint64_t)comm->ctsFifo;
-  meta.sl = (ncclParamIbSl() != -1) ? ncclParamIbSl() : (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass : NCCL_IB_SL_DEFAULT;
-  meta.tc = (ncclParamIbTc() != -1) ? ncclParamIbTc() : (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass : NCCL_IB_TC_DEFAULT;
+  // Precedence: per-comm hint (ncclConfig_t.trafficClass) > env (NCCL_IB_SL/NCCL_IB_TC) > default.
+  meta.sl = (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass : (ncclParamIbSl() != -1) ? static_cast<int>(ncclParamIbSl()) : NCCL_IB_SL_DEFAULT;
+  meta.tc = (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass : (ncclParamIbTc() != -1) ? static_cast<int>(ncclParamIbTc()) : NCCL_IB_TC_DEFAULT;
+  INFO(NCCL_NET, "NET/IB : QP RTR meta.sl=%d meta.tc=%d", meta.sl, meta.tc);
+  
   strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
 
   stage->state = ncclIbCommStateSend;


### PR DESCRIPTION
Summary:

Plumbs `NcclConfig(traffic_class=X)` into the CTran IB backend so a single
per-comm hint sets the RoCE DSCP on CTran IB QPs, with hint-first precedence.

Split out of the original combined diff at reviewer request: this diff is
CTran-only. The baseline net_ib half is the child diff in this stack.

Changes:
- `ctranConfig` gains an `int trafficClass{-1}` field so it can carry the
  per-comm hint sourced from `ncclConfig_t.trafficClass`. Negative means
  "hint not set" (`fbcode/comms/ctran/CtranComm.h`).
- `makeCtranConfigFrom()` copies `comm->config.trafficClass` into the
  ctranConfig at CtranComm construction time
  (`fbcode/comms/ncclx/meta/wrapper/MetaFactory.cc`).
- `setPgToTrafficClassMap()` becomes `resolveTrafficClass()`, which resolves
  the effective TC once at init and stores it in `trafficClass_`. Precedence:
  `hint > NCCL_CTRAN_IB_PG_TRAFFIC_CLASS env-map > NCCL_IB_TC > 0`. The
  per-PG map is gone; the getter is now `getTrafficClass()` and is public
  (`fbcode/comms/ctran/backends/ib/CtranIb.{h,cc}`).
- Validation is uniform across sources: values outside [0, 255] are rejected
  whether they come from the hint (warn + fall back) or the env-map (error).
  Every env-map entry is validated regardless of ordering, so a malformed
  pair after the matching one is still reported.
- 5 unit tests in `CtranIbDistUT.cc` covering hint > env-map, env-map when
  the hint is unset, NCCL_IB_TC fallback, out-of-range hint fallback, and
  malformed-env-entry rejection independent of ordering.
- New `TrafficClassTest.cc` creating a real communicator via
  `ncclCommInitRankConfig` with `config.trafficClass` set, asserting the
  value reaches both `ncclComm->config` and the CtranComm mirror
  (`fbcode/comms/ncclx/meta/tests/{BUCK,TrafficClassTest.cc}`).

Motivation:
llama4x/GALA-family training runs currently rely on the env-var
`NCCL_CTRAN_IB_PG_TRAFFIC_CLASS="PP_P2P_0:200,PP_P2P_1:208"` to differentiate
DSCP per parallelism. This makes the per-comm hint the single source of truth
so callers can set `NcclConfig(traffic_class=X)` instead.

Behavior change: for comms that set the hint, `NCCL_CTRAN_IB_PG_TRAFFIC_CLASS`
and `NCCL_IB_TC` are no longer authoritative. Env vars remain the fallback
when the hint is unset, so existing env-only launchers behave identically.

Reviewed By: saifhhasan

Differential Revision: D113875097


