### PR TITLE
Update Intel DLE to 2026.1.2.25

### DIFF
--- a/.github/workflows/xpu_test.yml
+++ b/.github/workflows/xpu_test.yml
@@ -101,12 +101,12 @@ jobs:
         run: |
           set -x
           #Install Intel Deep Learning Essentials
-          DLE_VER=2026.0.0.624
+          DLE_VER=2026.1.2.25
           DLE_ROOT=/home/jenkins/${RUNNER_NAME}/dle-${DLE_VER}
           DLE_PATH=${DLE_ROOT}/dle
           if [[ ! -d ${DLE_ROOT} ]]; then
             mkdir -p ${DLE_ROOT}
-            DLE_URL="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/8170208e-86db-4faa-a0d6-1ecf62699574/intel-deep-learning-essentials-${DLE_VER}_offline.sh"
+            DLE_URL="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c109e1ae-e02c-48a6-917b-b03b90d33f77/intel-deep-learning-essentials-${DLE_VER}_offline.sh"
             wget -qO ${DLE_ROOT}/intel-deep-learning-essentials.sh ${DLE_URL}
             chmod +x ${DLE_ROOT}/intel-deep-learning-essentials.sh
             ${DLE_ROOT}/intel-deep-learning-essentials.sh -a --silent --eula accept --install-dir ${DLE_PATH} --instance=custom-id-${GITHUB_RUN_NUMBER}


### PR DESCRIPTION
Update to latest Intel Deep Learning Essentials/OneAPI https://www.intel.com/content/www/us/en/developer/tools/oneapi/oneapi-toolkit-download.html?packages=dl-essentials&dl-essentials-os=linux&dl-lin=offline