### PR TITLE
Add BF16 transport quantization to direct IB (#3320)

### DIFF
--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -109,6 +109,18 @@ commResult_t ctranReduceScatter(
     cudaStream_t stream,
     enum NCCL_REDUCESCATTER_ALGO algo);
 
+commResult_t ctranReduceScatterQuantize(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t recvcount,
+    commDataType_t inputType,
+    commDataType_t transportType,
+    commRedOp_t redOp,
+    const uint64_t* seedPtr,
+    CtranComm* comm,
+    cudaStream_t stream,
+    enum NCCL_REDUCESCATTER_ALGO algo);
+
 bool ctranAllReduceSupport(CtranComm* comm, enum NCCL_ALLREDUCE_ALGO algo);
 commResult_t ctranAllReduce(
     const void* sendbuff,

--- a/comms/ctran/algos/ReduceScatter/ReduceScatter.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatter.cc
@@ -82,7 +82,11 @@ bool ctranReduceScatterSupport(
       }
       break;
     case NCCL_REDUCESCATTER_ALGO::ctdirect_ib:
-      return true;
+#if defined(ENABLE_PRIMS)
+      return ctranReduceScatterDirectIbSupport(comm);
+#else
+      return false;
+#endif
     case NCCL_REDUCESCATTER_ALGO::ctring_ib:
       // Hosted by MCCL; CTRAN reports unsupported so non-MCCL callers fall
       // back.
@@ -149,4 +153,30 @@ commResult_t ctranReduceScatter(
           nNodes);
       return commInternalError;
   }
+}
+
+commResult_t ctranReduceScatterQuantize(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t recvcount,
+    commDataType_t inputType,
+    commDataType_t transportType,
+    commRedOp_t redOp,
+    const uint64_t* seedPtr,
+    CtranComm* comm,
+    cudaStream_t stream,
+    enum NCCL_REDUCESCATTER_ALGO algo) {
+  if (algo != NCCL_REDUCESCATTER_ALGO::ctdirect_ib) {
+    return commInvalidArgument;
+  }
+  return ctranReduceScatterQuantizeDirectIb(
+      sendbuff,
+      recvbuff,
+      recvcount,
+      inputType,
+      transportType,
+      redOp,
+      seedPtr,
+      comm,
+      stream);
 }

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterDirectIb.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterDirectIb.cc
@@ -22,6 +22,30 @@
 
 static const auto myAlgo = NCCL_REDUCESCATTER_ALGO::ctdirect_ib;
 
+bool ctranReduceScatterDirectIbSupport(CtranComm* comm, int* unsupportedPeer) {
+  if (unsupportedPeer != nullptr) {
+    *unsupportedPeer = -1;
+  }
+  if (comm == nullptr || comm->statex_ == nullptr ||
+      comm->statex_->nRanks() <= 1 ||
+      comm->statex_->nNodes() != comm->statex_->nRanks() ||
+      comm->statex_->nRanks() > comms::prims::kDirectReduceScatterIbMaxRanks ||
+      comm->multiPeerTransport_ == nullptr) {
+    return false;
+  }
+
+  const auto* mpt = comm->multiPeerTransport_.get();
+  for (int peer = 0; peer < comm->statex_->nRanks(); ++peer) {
+    if (peer != comm->statex_->rank() && !mpt->has_ibgda(peer)) {
+      if (unsupportedPeer != nullptr) {
+        *unsupportedPeer = peer;
+      }
+      return false;
+    }
+  }
+  return true;
+}
+
 namespace {
 
 bool checkedMultiply(size_t lhs, size_t rhs, size_t& result) {
@@ -161,21 +185,23 @@ commResult_t validateDirectIbReduceScatter(
     return commInvalidArgument;
   }
 
-  auto* mpt = comm->multiPeerTransport_.get();
-  for (int peer = 0; peer < nRanks; ++peer) {
-    if (peer == statex->rank()) {
-      continue;
-    }
-    if (!mpt->has_ibgda(peer) || !mpt->prefers_ibgda(peer)) {
+  int unsupportedPeer = -1;
+  if (!ctranReduceScatterDirectIbSupport(comm, &unsupportedPeer)) {
+    if (unsupportedPeer >= 0) {
+      const auto* mpt = comm->multiPeerTransport_.get();
       CERR(
           commInvalidArgument,
-          "ReduceScatter {} requires preferred IBGDA transport for peer {}, has_ibgda={} prefers_ibgda={}",
+          "ReduceScatter {} requires IBGDA transport for peer {}, has_ibgda={}",
           reduceScatterAlgoName(myAlgo),
-          peer,
-          mpt->has_ibgda(peer),
-          mpt->prefers_ibgda(peer));
-      return commInvalidArgument;
+          unsupportedPeer,
+          mpt->has_ibgda(unsupportedPeer));
+    } else {
+      CLOGF(
+          ERR,
+          "ReduceScatter {} is unsupported for this communicator",
+          reduceScatterAlgoName(myAlgo));
     }
+    return commInvalidArgument;
   }
 
   return commSuccess;
@@ -183,12 +209,14 @@ commResult_t validateDirectIbReduceScatter(
 
 } // namespace
 
-commResult_t ctranReduceScatterDirectIb(
+static commResult_t ctranReduceScatterDirectIbImpl(
     const void* sendbuff,
     void* recvbuff,
     size_t recvcount,
     commDataType_t datatype,
     commRedOp_t redOp,
+    const uint64_t* seedPtr,
+    bool quantized,
     CtranComm* comm,
     cudaStream_t stream) {
   CTRAN_COLL_INFO(
@@ -236,9 +264,19 @@ commResult_t ctranReduceScatterDirectIb(
   try {
     mpt->materializePeers(peers);
 
+    size_t wireRecvBytes = recvBytes;
+    size_t wireTotalBytes = totalBytes;
+    if (quantized &&
+        (!checkedMultiply(
+             recvcount, commTypeSize(commBfloat16), wireRecvBytes) ||
+         !checkedMultiply(
+             wireRecvBytes, static_cast<size_t>(nRanks), wireTotalBytes))) {
+      return commInvalidArgument;
+    }
+
     const int numBlocks =
         ctran::reducescatter::direct_ib::numBlocksForTotalBytes(
-            totalBytes, MCCL_MAX_NCHANNELS);
+            wireTotalBytes, MCCL_MAX_NCHANNELS);
 
     comms::prims::DirectReduceScatterIbLaunchParams params{};
     params.my_rank = statex->rank();
@@ -248,6 +286,8 @@ commResult_t ctranReduceScatterDirectIb(
         ctran::reducescatter::direct_ib::signalingDataSize(recvBytes);
     params.input = static_cast<const float*>(sendbuff);
     params.output = static_cast<float*>(recvbuff);
+    params.seed_ptr = seedPtr;
+    params.quantized = quantized;
     params.in_place = isExactReduceScatterInPlace(
         reinterpret_cast<uintptr_t>(sendbuff),
         reinterpret_cast<uintptr_t>(recvbuff),
@@ -279,6 +319,51 @@ commResult_t ctranReduceScatterDirectIb(
   return commSuccess;
 }
 
+commResult_t ctranReduceScatterDirectIb(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t recvcount,
+    commDataType_t datatype,
+    commRedOp_t redOp,
+    CtranComm* comm,
+    cudaStream_t stream) {
+  return ctranReduceScatterDirectIbImpl(
+      sendbuff,
+      recvbuff,
+      recvcount,
+      datatype,
+      redOp,
+      nullptr,
+      false,
+      comm,
+      stream);
+}
+
+commResult_t ctranReduceScatterQuantizeDirectIb(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t recvcount,
+    commDataType_t inputType,
+    commDataType_t transportType,
+    commRedOp_t redOp,
+    const uint64_t* seedPtr,
+    CtranComm* comm,
+    cudaStream_t stream) {
+  if (transportType != commBfloat16 || redOp != commSum || seedPtr == nullptr) {
+    return commInvalidArgument;
+  }
+  return ctranReduceScatterDirectIbImpl(
+      sendbuff,
+      recvbuff,
+      recvcount,
+      inputType,
+      redOp,
+      seedPtr,
+      true,
+      comm,
+      stream);
+}
+
 #else // !ENABLE_PRIMS
 
 #include "comms/ctran/algos/ReduceScatter/ReduceScatterImpl.h"
@@ -295,6 +380,22 @@ commResult_t ctranReduceScatterDirectIb(
   CERR(
       commInvalidArgument,
       "ReduceScatter CtranReduceScatterDirectIb requires ENABLE_PRIMS");
+  return commInvalidArgument;
+}
+
+commResult_t ctranReduceScatterQuantizeDirectIb(
+    const void* /*sendbuff*/,
+    void* /*recvbuff*/,
+    size_t /*recvcount*/,
+    commDataType_t /*inputType*/,
+    commDataType_t /*transportType*/,
+    commRedOp_t /*redOp*/,
+    const uint64_t* /*seedPtr*/,
+    CtranComm* /*comm*/,
+    cudaStream_t /*stream*/) {
+  CLOGF(
+      ERR,
+      "ReduceScatter CtranReduceScatterQuantizeDirectIb requires ENABLE_PRIMS");
   return commInvalidArgument;
 }
 

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterImpl.h
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterImpl.h
@@ -43,6 +43,23 @@ commResult_t ctranReduceScatterDirectIb(
     CtranComm* comm,
     cudaStream_t stream);
 
+#if defined(ENABLE_PRIMS)
+bool ctranReduceScatterDirectIbSupport(
+    CtranComm* comm,
+    int* unsupportedPeer = nullptr);
+#endif
+
+commResult_t ctranReduceScatterQuantizeDirectIb(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t recvcount,
+    commDataType_t inputType,
+    commDataType_t transportType,
+    commRedOp_t redOp,
+    const uint64_t* seedPtr,
+    CtranComm* comm,
+    cudaStream_t stream);
+
 static inline commResult_t reduceScatterSingleRankImpl(
     const void* sendbuff,
     void* recvbuff,

--- a/comms/ncclx/meta/collectives/quantCollectives.cc
+++ b/comms/ncclx/meta/collectives/quantCollectives.cc
@@ -6,7 +6,9 @@
 #include "nccl.h"
 
 #include "meta/wrapper/DataTypeStrUtils.h"
+#include "meta/wrapper/MetaFactory.h"
 
+#include "comms/ctran/Ctran.h"
 #include "comms/ctran/utils/ExtUtils.h"
 #include "folly/logging/xlog.h"
 
@@ -82,6 +84,24 @@ static ncclResult_t ncclReduceScatterQuantizeInfoExt(
     cudaStream_t stream) {
   NCCLCHECK(
       validateReduceScatterQuantizeArgs(inputType, transportType, op, seedPtr));
+
+  constexpr auto kDirectIbAlgo = NCCL_REDUCESCATTER_ALGO::ctdirect_ib;
+  if (NCCL_REDUCESCATTER_QUANTIZED_ALGO ==
+          NCCL_REDUCESCATTER_QUANTIZED_ALGO::ctdirect_ib &&
+      comm->useCtran_ && op == ncclSum &&
+      ctranReduceScatterSupport(comm->ctranComm_.get(), kDirectIbAlgo)) {
+    return metaCommToNccl(ctranReduceScatterQuantize(
+        sendbuff,
+        recvbuff,
+        recvcount,
+        ncclToMetaComm(inputType),
+        ncclToMetaComm(transportType),
+        ncclToMetaComm(op),
+        seedPtr,
+        comm->ctranComm_.get(),
+        stream,
+        kDirectIbAlgo));
+  }
 
   auto info = ncclInfo{
       .coll = ncclFuncReduceScatter,

--- a/comms/ncclx/meta/collectives/tests/ReduceScatterQuantizeDirectIbTest.cc
+++ b/comms/ncclx/meta/collectives/tests/ReduceScatterQuantizeDirectIbTest.cc
@@ -1,0 +1,158 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <comm.h>
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <nccl.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/ncclx/meta/tests/VerifyAlgoStatsUtil.h"
+
+class ReduceScatterQuantizeDirectIbTest : public NcclxBaseTestFixture {
+ protected:
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp({
+        {"NCCL_CTRAN_ENABLE", "1"},
+        {"NCCL_CTRAN_USE_PIPES", "1"},
+        {"NCCL_COMM_STATE_DEBUG_TOPO", "nolocal"},
+        {"NCCL_MNNVL_ENABLE", "0"},
+        {"NCCL_P2P_DISABLE", "1"},
+        {"NCCL_REDUCESCATTER_QUANTIZED_ALGO", "ctdirect_ib"},
+    });
+    algoStats_.enable();
+    ncclx::Hints hints{{"useCtran", "1"}};
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    config.hints = &hints;
+    comm_.emplace(
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+    CUDACHECK_TEST(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaStreamDestroy(stream_));
+    comm_.reset();
+    NcclxBaseTestFixture::TearDown();
+  }
+
+  void run(ncclRedOp_t op, std::size_t count) {
+    const std::size_t sendCount = count * static_cast<std::size_t>(numRanks);
+    std::vector<float> input(sendCount, 1.0f);
+    std::vector<float> output(count);
+
+    float* send = nullptr;
+    float* recv = nullptr;
+    std::uint64_t* seed = nullptr;
+    if (count != 0) {
+      CUDACHECK_TEST(cudaMalloc(&send, sendCount * sizeof(float)));
+      CUDACHECK_TEST(cudaMalloc(&recv, count * sizeof(float)));
+      CUDACHECK_TEST(cudaMemcpy(
+          send,
+          input.data(),
+          sendCount * sizeof(float),
+          cudaMemcpyHostToDevice));
+    }
+    CUDACHECK_TEST(cudaMalloc(&seed, sizeof(*seed)));
+    constexpr std::uint64_t kSeed = 0x123456789abcdef0ULL;
+    CUDACHECK_TEST(
+        cudaMemcpy(seed, &kSeed, sizeof(kSeed), cudaMemcpyHostToDevice));
+
+    ASSERT_EQ(
+        ncclReduceScatterQuantize(
+            send,
+            recv,
+            count,
+            ncclFloat32,
+            ncclBfloat16,
+            op,
+            seed,
+            comm_->get(),
+            stream_),
+        ncclSuccess);
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+
+    if (count != 0) {
+      CUDACHECK_TEST(cudaMemcpy(
+          output.data(), recv, count * sizeof(float), cudaMemcpyDeviceToHost));
+      const float expected =
+          op == ncclSum ? static_cast<float>(numRanks) : 1.0f;
+      for (float value : output) {
+        EXPECT_EQ(value, expected);
+      }
+      CUDACHECK_TEST(cudaFree(send));
+      CUDACHECK_TEST(cudaFree(recv));
+    }
+    CUDACHECK_TEST(cudaFree(seed));
+  }
+
+  std::optional<ncclx::test::NcclCommRAII> comm_;
+  cudaStream_t stream_{nullptr};
+  ncclx::test::VerifyAlgoStatsHelper algoStats_;
+};
+
+class ReduceScatterQuantizePatTest : public ReduceScatterQuantizeDirectIbTest {
+ protected:
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp({{"NCCL_CTRAN_ENABLE", "0"}});
+    algoStats_.enable();
+    comm_.emplace(globalRank, numRanks, localRank, bootstrap_.get());
+    CUDACHECK_TEST(cudaStreamCreate(&stream_));
+  }
+};
+
+class ReduceScatterQuantizeDefaultPatTest
+    : public ReduceScatterQuantizeDirectIbTest {
+ protected:
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp({
+        {"NCCL_CTRAN_ENABLE", "1"},
+        {"NCCL_CTRAN_USE_PIPES", "1"},
+        {"NCCL_COMM_STATE_DEBUG_TOPO", "nolocal"},
+        {"NCCL_MNNVL_ENABLE", "0"},
+        {"NCCL_P2P_DISABLE", "1"},
+    });
+    algoStats_.enable();
+    ncclx::Hints hints{{"useCtran", "1"}};
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    config.hints = &hints;
+    comm_.emplace(
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+    CUDACHECK_TEST(cudaStreamCreate(&stream_));
+  }
+};
+
+TEST_F(ReduceScatterQuantizeDirectIbTest, SumUsesDirectIbForOddTail) {
+  run(ncclSum, 1025);
+  algoStats_.verify(
+      comm_->get(), "ReduceScatter", "CtranReduceScatterDirectIb");
+}
+
+TEST_F(ReduceScatterQuantizeDirectIbTest, ZeroCountSucceeds) {
+  run(ncclSum, 0);
+}
+
+TEST_F(ReduceScatterQuantizePatTest, CtranDisabledUsesPat) {
+  run(ncclSum, 1025);
+  algoStats_.verify(comm_->get(), "ReduceScatter", "PAT");
+  algoStats_.verifyNot(
+      comm_->get(), "ReduceScatter", "CtranReduceScatterDirectIb");
+}
+
+TEST_F(ReduceScatterQuantizeDefaultPatTest, DefaultUsesPat) {
+  run(ncclSum, 1025);
+  algoStats_.verify(comm_->get(), "ReduceScatter", "PAT");
+  algoStats_.verifyNot(
+      comm_->get(), "ReduceScatter", "CtranReduceScatterDirectIb");
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/v2_29/src/nccl.h.in
+++ b/comms/ncclx/v2_29/src/nccl.h.in
@@ -654,7 +654,7 @@ ncclResult_t pncclReduceScatter(const void* sendbuff, void* recvbuff,
  * Input   SR     Transport    Reduce            SR? + Output
  *
  * Notes:
- * Due to how PAT algorithm works, We will do multiple rounds of rounding. The
+ * The PAT algorithm may do multiple rounds of rounding. The
  * random number used for the rounding of each element would be
  * Philox(seed, element_id + num_elements * current_round_number), so we will
  * not be reusing the same random numbers.
@@ -664,7 +664,8 @@ ncclResult_t pncclReduceScatter(const void* sendbuff, void* recvbuff,
  * transportType: must be BF16, provided to make extension easier.
  * op: Only supports ncclSum and ncclAvg operations.
  * seedPtr: must be a GPU MEMORY pointer. The pointer must outlive the collective.
- * algo: Uses PAT algorithm exclusively via InfoExt override.
+ * algo: Set NCCL_REDUCESCATTER_QUANTIZED_ALGO=ctdirect_ib to use DirectIB
+ *       for ncclSum when supported. The default and fallback algorithm is PAT.
  */
 ncclResult_t  ncclReduceScatterQuantize(const void* sendbuff, void* recvbuff,
     size_t recvcount, ncclDataType_t inputType, ncclDataType_t transportType,

--- a/comms/ncclx/v2_30/src/nccl.h.in
+++ b/comms/ncclx/v2_30/src/nccl.h.in
@@ -662,7 +662,7 @@ ncclResult_t pncclReduceScatter(const void* sendbuff, void* recvbuff,
  * Input   SR     Transport    Reduce            SR? + Output
  *
  * Notes:
- * Due to how PAT algorithm works, We will do multiple rounds of rounding. The
+ * The PAT algorithm may do multiple rounds of rounding. The
  * random number used for the rounding of each element would be
  * Philox(seed, element_id + num_elements * current_round_number), so we will
  * not be reusing the same random numbers.
@@ -672,7 +672,8 @@ ncclResult_t pncclReduceScatter(const void* sendbuff, void* recvbuff,
  * transportType: must be BF16, provided to make extension easier.
  * op: Only supports ncclSum and ncclAvg operations.
  * seedPtr: must be a GPU MEMORY pointer. The pointer must outlive the collective.
- * algo: Uses PAT algorithm exclusively via InfoExt override.
+ * algo: Set NCCL_REDUCESCATTER_QUANTIZED_ALGO=ctdirect_ib to use DirectIB
+ *       for ncclSum when supported. The default and fallback algorithm is PAT.
  */
 ncclResult_t  ncclReduceScatterQuantize(const void* sendbuff, void* recvbuff,
     size_t recvcount, ncclDataType_t inputType, ncclDataType_t transportType,

--- a/comms/prims/collectives/ReduceScatterDirectIb.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIb.cu
@@ -5,6 +5,7 @@
 #include "comms/prims/core/Checks.h"
 #include "comms/prims/core/CopyOp.cuh"
 #include "comms/prims/core/CopyUtils.cuh"
+#include "comms/prims/core/QuantCopyOp.cuh"
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/TiledBuffer.cuh"
 #include "comms/prims/transport/P2pIbTransportDevice.cuh"
@@ -12,6 +13,7 @@
 namespace comms::prims {
 
 template <
+    bool kQuantized,
     bool kStaggerChannels,
     typename T,
     typename AccumOp,
@@ -39,14 +41,16 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
             .group_id = block.group_id,
             .block_id = block.block_id,
             .total_groups = block.total_groups,
-            .scope = SyncScope::MULTIWARP}
+            .scope = SyncScope::MULTIWARP,
+            .barrier_id = kQuantized ? 1 : ThreadGroup::kAutoBarrierId}
       : ThreadGroup{
             .thread_id_in_group = block.thread_id_in_group - kRecvThreads,
             .group_size = kSendThreads,
             .group_id = block.group_id,
             .block_id = block.block_id,
             .total_groups = block.total_groups,
-            .scope = SyncScope::MULTIWARP};
+            .scope = SyncScope::MULTIWARP,
+            .barrier_id = kQuantized ? 2 : ThreadGroup::kAutoBarrierId};
 
   const int channels = static_cast<int>(group.total_groups);
   const int channel = static_cast<int>(group.group_id);
@@ -89,8 +93,22 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
           ? reinterpret_cast<const char*>(own_src)
           : output_bytes;
       auto transport = args.peers[peer];
-      transport.template recv<ReduceOp>(
-          group, output_bytes, tile_bytes, max_sig, timeout, local_input);
+      if constexpr (kQuantized) {
+        const std::size_t wire_bytes =
+            output_tile.tile_size(channel) * sizeof(__nv_bfloat16);
+        QuantizedReduceScatterCopyOp::Args copy_args{
+            .sender_input_base = nullptr,
+            .receiver_input_base = reinterpret_cast<const T*>(local_input),
+            .receiver_output_base = output,
+            .seed = *args.seed_ptr,
+            .logical_element_base = 0,
+        };
+        transport.template recv<QuantizedReduceScatterCopyOp>(
+            group, output_bytes, wire_bytes, max_sig, timeout, copy_args);
+      } else {
+        transport.template recv<ReduceOp>(
+            group, output_bytes, tile_bytes, max_sig, timeout, local_input);
+      }
     }
   } else {
     if (W <= 1) {
@@ -106,18 +124,45 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
           args.chunk_elements,
           group);
       auto transport = args.peers[peer];
-      transport.send(
-          group,
-          reinterpret_cast<const char*>(send_tile.data()),
-          send_tile.bytes(),
-          max_sig,
-          timeout);
+      if constexpr (kQuantized) {
+        const std::size_t wire_bytes =
+            send_tile.tile_size(channel) * sizeof(__nv_bfloat16);
+        const std::uint64_t total_elements =
+            static_cast<std::uint64_t>(args.chunk_elements) *
+            static_cast<std::uint64_t>(W);
+        const std::uint64_t logical_element_base =
+            static_cast<std::uint64_t>(my_rank) * total_elements +
+            static_cast<std::uint64_t>(peer) * args.chunk_elements +
+            static_cast<std::uint64_t>(channel) * send_tile.tile_elements;
+        QuantizedReduceScatterCopyOp::Args copy_args{
+            .sender_input_base = send_tile.data(),
+            .receiver_input_base = nullptr,
+            .receiver_output_base = nullptr,
+            .seed = *args.seed_ptr,
+            .logical_element_base = logical_element_base,
+        };
+        transport.template send<QuantizedReduceScatterCopyOp>(
+            group,
+            reinterpret_cast<const char*>(send_tile.data()),
+            wire_bytes,
+            max_sig,
+            timeout,
+            copy_args);
+      } else {
+        transport.send(
+            group,
+            reinterpret_cast<const char*>(send_tile.data()),
+            send_tile.bytes(),
+            max_sig,
+            timeout);
+      }
     }
   }
 #endif
 }
 
 template __global__ void direct_reduce_scatter_ib_kernel<
+    false,
     true,
     float,
     SumOp,
@@ -134,6 +179,7 @@ void launch_direct_reduce_scatter_ib_impl(
     cudaStream_t stream,
     Timeout timeout) {
   auto* kernel = direct_reduce_scatter_ib_kernel<
+      false,
       true,
       float,
       SumOp,
@@ -172,6 +218,24 @@ void launch_direct_reduce_scatter_ib_impl(
         static_cast<int>(dynamic_smem)));
   }
   kernel<<<num_blocks, 512, dynamic_smem, stream>>>(args, timeout);
+  PIPES_CUDA_CHECK(cudaGetLastError());
+}
+
+void launch_direct_reduce_scatter_ib_quantized_impl(
+    const DirectReduceScatterIbArgs<float>& args,
+    int num_blocks,
+    cudaStream_t stream,
+    Timeout timeout) {
+  auto* kernel = direct_reduce_scatter_ib_kernel<
+      true,
+      true,
+      float,
+      SumOp,
+      352,
+      288,
+      640,
+      CpAsyncSmemReduce<float, SumOp, 8192, 384, 2>>;
+  kernel<<<num_blocks, 640, 0, stream>>>(args, timeout);
   PIPES_CUDA_CHECK(cudaGetLastError());
 }
 

--- a/comms/prims/collectives/ReduceScatterDirectIb.cuh
+++ b/comms/prims/collectives/ReduceScatterDirectIb.cuh
@@ -5,6 +5,7 @@
 #include <cuda_runtime_api.h>
 
 #include <cstddef>
+#include <cstdint>
 
 #include "comms/prims/core/Timeout.cuh"
 #include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
@@ -22,10 +23,17 @@ struct DirectReduceScatterIbArgs {
   P2pIbTransportDevice peers[kDirectIbDeviceMaxRanks]{};
   const T* input{nullptr};
   T* output{nullptr};
+  const uint64_t* seed_ptr{nullptr};
   bool in_place{false};
 };
 
 void launch_direct_reduce_scatter_ib_impl(
+    const DirectReduceScatterIbArgs<float>& args,
+    int num_blocks,
+    cudaStream_t stream,
+    Timeout timeout);
+
+void launch_direct_reduce_scatter_ib_quantized_impl(
     const DirectReduceScatterIbArgs<float>& args,
     int num_blocks,
     cudaStream_t stream,

--- a/comms/prims/collectives/ReduceScatterDirectIbLauncher.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIbLauncher.cu
@@ -28,6 +28,10 @@ void validate_direct_ib(const DirectReduceScatterIbLaunchParams& params) {
         "direct IB reduce-scatter requires num_blocks >= 1, got " +
         std::to_string(params.num_blocks));
   }
+  if (params.quantized && params.seed_ptr == nullptr) {
+    throw std::runtime_error(
+        "quantized direct IB reduce-scatter requires a device seed pointer");
+  }
 }
 
 Timeout make_launch_timeout(float timeout_ms) {
@@ -51,6 +55,7 @@ DirectReduceScatterIbArgs<float> make_args(
   args.signaling_data_size = params.signaling_data_size;
   args.input = params.input;
   args.output = params.output;
+  args.seed_ptr = params.seed_ptr;
   args.in_place = params.in_place;
 
   for (int peer = 0; peer < params.num_ranks; ++peer) {
@@ -67,11 +72,15 @@ DirectReduceScatterIbArgs<float> make_args(
 
 void launch_direct_reduce_scatter_ib(
     const DirectReduceScatterIbLaunchParams& params) {
-  launch_direct_reduce_scatter_ib_impl(
-      make_args(params),
-      params.num_blocks,
-      params.stream,
-      make_launch_timeout(params.timeout_ms));
+  const auto args = make_args(params);
+  const auto timeout = make_launch_timeout(params.timeout_ms);
+  if (params.quantized) {
+    launch_direct_reduce_scatter_ib_quantized_impl(
+        args, params.num_blocks, params.stream, timeout);
+  } else {
+    launch_direct_reduce_scatter_ib_impl(
+        args, params.num_blocks, params.stream, timeout);
+  }
 }
 
 } // namespace comms::prims

--- a/comms/prims/collectives/ReduceScatterDirectIbLauncher.h
+++ b/comms/prims/collectives/ReduceScatterDirectIbLauncher.h
@@ -5,6 +5,7 @@
 #include <cuda_runtime_api.h>
 
 #include <cstddef>
+#include <cstdint>
 
 #include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 
@@ -19,6 +20,8 @@ struct DirectReduceScatterIbLaunchParams {
   std::size_t signaling_data_size{0};
   const float* input{nullptr};
   float* output{nullptr};
+  const uint64_t* seed_ptr{nullptr};
+  bool quantized{false};
   bool in_place{false};
   int num_blocks{16};
   float timeout_ms{0.0f};

--- a/comms/prims/collectives/tests/DirectIbReduceScatterTest.cc
+++ b/comms/prims/collectives/tests/DirectIbReduceScatterTest.cc
@@ -19,6 +19,7 @@ namespace {
 
 struct DirectIbReduceScatterTestParams {
   std::size_t chunk_elements;
+  bool quantized;
   std::string name;
 };
 
@@ -65,10 +66,15 @@ TEST_P(DirectIbReduceScatterTest, Correctness) {
   const std::size_t total_elements = params.chunk_elements * worldSize;
   DeviceBuffer inputBuf(total_elements * sizeof(float));
   DeviceBuffer outputBuf(params.chunk_elements * sizeof(float));
+  DeviceBuffer repeatOutputBuf(params.chunk_elements * sizeof(float));
+  DeviceBuffer seedBuf(sizeof(std::uint64_t));
   CUDACHECK_TEST(
       cudaMemset(outputBuf.get(), 0, params.chunk_elements * sizeof(float)));
 
   fill_input(static_cast<float*>(inputBuf.get()), total_elements);
+  const std::uint64_t seed = 0x123456789abcdef0ULL;
+  CUDACHECK_TEST(
+      cudaMemcpy(seedBuf.get(), &seed, sizeof(seed), cudaMemcpyHostToDevice));
 
   DirectReduceScatterIbLaunchParams launchParams{};
   launchParams.my_rank = globalRank;
@@ -77,6 +83,10 @@ TEST_P(DirectIbReduceScatterTest, Correctness) {
   launchParams.signaling_data_size = 0;
   launchParams.input = static_cast<const float*>(inputBuf.get());
   launchParams.output = static_cast<float*>(outputBuf.get());
+  launchParams.quantized = params.quantized;
+  launchParams.seed_ptr = params.quantized
+      ? static_cast<const std::uint64_t*>(seedBuf.get())
+      : nullptr;
   launchParams.num_blocks = num_blocks;
   launchParams.timeout_ms = 30000.0f;
   for (int peer = 0; peer < worldSize; ++peer) {
@@ -92,8 +102,32 @@ TEST_P(DirectIbReduceScatterTest, Correctness) {
   CUDACHECK_TEST(cudaDeviceSynchronize());
   bootstrap->barrierAll();
 
+  if (params.quantized) {
+    launchParams.output = static_cast<float*>(repeatOutputBuf.get());
+    bootstrap->barrierAll();
+    launch_direct_reduce_scatter_ib(launchParams);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    bootstrap->barrierAll();
+
+    std::vector<float> output(params.chunk_elements);
+    std::vector<float> repeatOutput(params.chunk_elements);
+    CUDACHECK_TEST(cudaMemcpy(
+        output.data(),
+        outputBuf.get(),
+        params.chunk_elements * sizeof(float),
+        cudaMemcpyDeviceToHost));
+    CUDACHECK_TEST(cudaMemcpy(
+        repeatOutput.data(),
+        repeatOutputBuf.get(),
+        params.chunk_elements * sizeof(float),
+        cudaMemcpyDeviceToHost));
+    EXPECT_EQ(output, repeatOutput);
+  }
+
   verify_reduce_scatter(
-      static_cast<const float*>(outputBuf.get()), params.chunk_elements);
+      static_cast<const float*>(outputBuf.get()),
+      params.chunk_elements,
+      params.quantized ? 5e-2f : 1e-2f);
 }
 
 std::vector<DirectIbReduceScatterTestParams> all_test_params() {
@@ -110,8 +144,17 @@ std::vector<DirectIbReduceScatterTestParams> all_test_params() {
   for (const auto& [size_label, total_bytes] : sizes) {
     const std::size_t chunk_elements =
         total_bytes / sizeof(float) / kExpectedRanks;
-    out.push_back({.chunk_elements = chunk_elements, .name = size_label});
+    out.push_back(
+        {.chunk_elements = chunk_elements,
+         .quantized = false,
+         .name = size_label + "Fp32"});
+    out.push_back(
+        {.chunk_elements = chunk_elements,
+         .quantized = true,
+         .name = size_label + "Quantized"});
   }
+  out.push_back(
+      {.chunk_elements = 1025, .quantized = true, .name = "OddTailQuantized"});
   return out;
 }
 

--- a/comms/prims/collectives/tests/ReduceScatterTestHarness.h
+++ b/comms/prims/collectives/tests/ReduceScatterTestHarness.h
@@ -43,7 +43,8 @@ class ReduceScatterTestBase : public meta::comms::BenchmarkTestFixture {
 
   void verify_reduce_scatter(
       const float* output_d,
-      std::size_t chunk_elements) {
+      std::size_t chunk_elements,
+      float tolerance = 1e-2f) {
     std::vector<float> h_output(chunk_elements);
     CUDACHECK_TEST(cudaMemcpy(
         h_output.data(),
@@ -59,9 +60,9 @@ class ReduceScatterTestBase : public meta::comms::BenchmarkTestFixture {
         expected += static_cast<float>((rank * 7 + global_idx) % 100) * 0.01f;
       }
       float actual = h_output[i];
-      if (std::abs(actual - expected) > 1e-2f) {
+      if (std::abs(actual - expected) > tolerance) {
         if (errors < 10) {
-          EXPECT_NEAR(actual, expected, 1e-2f)
+          EXPECT_NEAR(actual, expected, tolerance)
               << "Mismatch at offset=" << i << " (my_rank=" << globalRank
               << ")";
         }

--- a/comms/prims/core/QuantCopyOp.cuh
+++ b/comms/prims/core/QuantCopyOp.cuh
@@ -1,0 +1,243 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_bf16.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/prims/core/DeviceCheck.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/utils/kernels/rng/philox_rng.cuh"
+#include "comms/utils/kernels/stochastic_rounding/stochastic_rounding.cuh"
+
+namespace comms::prims {
+
+struct QuantizedReduceScatterCopyOp {
+  struct Args {
+    const float* sender_input_base;
+    const float* receiver_input_base;
+    float* receiver_output_base;
+    std::uint64_t seed;
+    std::uint64_t logical_element_base;
+  };
+
+  static constexpr bool kVariableSize = false;
+  static constexpr std::size_t kActivationThreshold = 0;
+
+  __host__ __device__ __forceinline__ static constexpr std::size_t
+  worst_case_chunk_stride(std::size_t chunkSize) {
+    return chunkSize;
+  }
+
+  __device__ __forceinline__ static std::size_t send(
+      char* staging,
+      const char* /*src*/,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t byte_offset,
+      Args args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    PIPES_DEVICE_CHECK(byte_offset % sizeof(__nv_bfloat16) == 0);
+    PIPES_DEVICE_CHECK(nbytes % sizeof(__nv_bfloat16) == 0);
+    auto* stagingBf16 = reinterpret_cast<__nv_bfloat16*>(staging);
+    const std::size_t elementOffset = byte_offset / sizeof(__nv_bfloat16);
+    const std::size_t elementCount = nbytes / sizeof(__nv_bfloat16);
+    const std::uint64_t logicalBegin =
+        args.logical_element_base + elementOffset;
+    const std::size_t elementsToAlignment =
+        static_cast<std::size_t>((8 - logicalBegin % 8) % 8);
+    const std::size_t prefixCount =
+        elementsToAlignment < elementCount ? elementsToAlignment : elementCount;
+
+    for (std::size_t i = group.thread_id_in_group; i < prefixCount;
+         i += group.group_size) {
+      const std::uint64_t logicalElement = logicalBegin + i;
+      const PhiloxResult random =
+          philox_randint4x(args.seed, logicalElement / 8);
+      stagingBf16[i] = stochastic_round_bf16<kHasHardwareSR>(
+          args.sender_input_base[elementOffset + i],
+          random.u16[logicalElement % 8]);
+    }
+
+    const std::size_t packetCount = (elementCount - prefixCount) / 8;
+    const bool vectorAligned =
+        (reinterpret_cast<std::uintptr_t>(
+             args.sender_input_base + elementOffset + prefixCount) %
+         alignof(float4)) == 0 &&
+        (reinterpret_cast<std::uintptr_t>(stagingBf16 + prefixCount) %
+         alignof(uint2)) == 0;
+    const bool sendQuadAligned =
+        (reinterpret_cast<std::uintptr_t>(stagingBf16 + prefixCount) %
+         alignof(uint4)) == 0;
+#if defined(__CUDA_ARCH__)
+    // A Philox result supplies the entropy for one complete 8-element packet.
+    for (std::size_t packet = group.thread_id_in_group; packet < packetCount;
+         packet += group.group_size) {
+      const std::size_t base = prefixCount + packet * 8;
+      const PhiloxResult random = philox_randint4x(
+          args.seed, (logicalBegin + prefixCount + packet * 8) / 8);
+      const float* src = args.sender_input_base + elementOffset + base;
+      const float4 v0 = vectorAligned
+          ? reinterpret_cast<const float4*>(src)[0]
+          : make_float4(src[0], src[1], src[2], src[3]);
+      const float4 v1 = vectorAligned
+          ? reinterpret_cast<const float4*>(src + 4)[0]
+          : make_float4(src[4], src[5], src[6], src[7]);
+      const __nv_bfloat162 r0 = stochastic_round_bf16x2<kHasHardwareSR>(
+          make_float2(v0.x, v0.y), random.u32[0]);
+      const __nv_bfloat162 r1 = stochastic_round_bf16x2<kHasHardwareSR>(
+          make_float2(v0.z, v0.w), random.u32[1]);
+      const __nv_bfloat162 r2 = stochastic_round_bf16x2<kHasHardwareSR>(
+          make_float2(v1.x, v1.y), random.u32[2]);
+      const __nv_bfloat162 r3 = stochastic_round_bf16x2<kHasHardwareSR>(
+          make_float2(v1.z, v1.w), random.u32[3]);
+      if (sendQuadAligned) {
+        reinterpret_cast<uint4*>(stagingBf16 + base)[0] = make_uint4(
+            *reinterpret_cast<const std::uint32_t*>(&r0),
+            *reinterpret_cast<const std::uint32_t*>(&r1),
+            *reinterpret_cast<const std::uint32_t*>(&r2),
+            *reinterpret_cast<const std::uint32_t*>(&r3));
+      } else if (vectorAligned) {
+        reinterpret_cast<uint2*>(stagingBf16 + base)[0] = make_uint2(
+            *reinterpret_cast<const std::uint32_t*>(&r0),
+            *reinterpret_cast<const std::uint32_t*>(&r1));
+        reinterpret_cast<uint2*>(stagingBf16 + base + 4)[0] = make_uint2(
+            *reinterpret_cast<const std::uint32_t*>(&r2),
+            *reinterpret_cast<const std::uint32_t*>(&r3));
+      } else {
+        stagingBf16[base] = __low2bfloat16(r0);
+        stagingBf16[base + 1] = __high2bfloat16(r0);
+        stagingBf16[base + 2] = __low2bfloat16(r1);
+        stagingBf16[base + 3] = __high2bfloat16(r1);
+        stagingBf16[base + 4] = __low2bfloat16(r2);
+        stagingBf16[base + 5] = __high2bfloat16(r2);
+        stagingBf16[base + 6] = __low2bfloat16(r3);
+        stagingBf16[base + 7] = __high2bfloat16(r3);
+      }
+    }
+#else
+    for (std::size_t packet = group.thread_id_in_group; packet < packetCount;
+         packet += group.group_size) {
+      const std::size_t i = prefixCount + packet * 8;
+      const PhiloxResult random =
+          philox_randint4x(args.seed, (logicalBegin + i) / 8);
+#pragma unroll
+      for (std::size_t pair = 0; pair < 4; ++pair) {
+        const std::size_t pairIndex = i + pair * 2;
+        const float2 values = make_float2(
+            args.sender_input_base[elementOffset + pairIndex],
+            args.sender_input_base[elementOffset + pairIndex + 1]);
+        const __nv_bfloat162 rounded =
+            stochastic_round_bf16x2<false>(values, random.u32[pair]);
+        stagingBf16[pairIndex] = __low2bfloat16(rounded);
+        stagingBf16[pairIndex + 1] = __high2bfloat16(rounded);
+      }
+    }
+#endif
+
+    const std::size_t tailBegin = prefixCount + packetCount * 8;
+    for (std::size_t i = tailBegin + group.thread_id_in_group; i < elementCount;
+         i += group.group_size) {
+      const std::uint64_t logicalElement = logicalBegin + i;
+      const PhiloxResult random =
+          philox_randint4x(args.seed, logicalElement / 8);
+      stagingBf16[i] = stochastic_round_bf16<kHasHardwareSR>(
+          args.sender_input_base[elementOffset + i],
+          random.u16[logicalElement % 8]);
+    }
+#endif
+    return nbytes;
+  }
+
+  __device__ __forceinline__ static std::size_t recv(
+      char* /*dst*/,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t byte_offset,
+      Args args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    PIPES_DEVICE_CHECK(byte_offset % sizeof(__nv_bfloat16) == 0);
+    PIPES_DEVICE_CHECK(nbytes % sizeof(__nv_bfloat16) == 0);
+    const auto* stagingBf16 = reinterpret_cast<const __nv_bfloat16*>(staging);
+    const std::size_t elementOffset = byte_offset / sizeof(__nv_bfloat16);
+    const std::size_t elementCount = nbytes / sizeof(__nv_bfloat16);
+
+    const bool vectorAligned =
+        (reinterpret_cast<std::uintptr_t>(stagingBf16) % alignof(uint2)) == 0 &&
+        (reinterpret_cast<std::uintptr_t>(
+             args.receiver_input_base + elementOffset) %
+         alignof(float4)) == 0 &&
+        (reinterpret_cast<std::uintptr_t>(
+             args.receiver_output_base + elementOffset) %
+         alignof(float4)) == 0;
+    const std::uint32_t rpackCount =
+        vectorAligned ? static_cast<std::uint32_t>(elementCount / 4) : 0u;
+    const uint2* stagingPacks = reinterpret_cast<const uint2*>(stagingBf16);
+    const uint4* stagingQuads = reinterpret_cast<const uint4*>(stagingBf16);
+    const float4* localPacks = reinterpret_cast<const float4*>(
+        args.receiver_input_base + elementOffset);
+    float4* outPacks =
+        reinterpret_cast<float4*>(args.receiver_output_base + elementOffset);
+    const std::uint32_t rtid =
+        static_cast<std::uint32_t>(group.thread_id_in_group);
+    const std::uint32_t rstride = static_cast<std::uint32_t>(group.group_size);
+    // Load both adjacent packs before either store because input may alias
+    // output after the first peer step.
+    const bool quadAligned =
+        (reinterpret_cast<std::uintptr_t>(stagingBf16) % alignof(uint4)) == 0 &&
+        (reinterpret_cast<std::uintptr_t>(
+             args.receiver_input_base + elementOffset) %
+         alignof(uint4)) == 0 &&
+        (reinterpret_cast<std::uintptr_t>(
+             args.receiver_output_base + elementOffset) %
+         alignof(uint4)) == 0;
+    const std::uint32_t pairCount = quadAligned ? rpackCount / 2u : 0u;
+    for (std::uint32_t pr = rtid; pr < pairCount; pr += rstride) {
+      const std::uint32_t p0 = pr * 2u;
+      const std::uint32_t p1 = p0 + 1u;
+      const uint4 sq = stagingQuads[pr];
+      const float4 l0 = localPacks[p0];
+      const float4 l1 = localPacks[p1];
+      const float2 rL0 =
+          __bfloat1622float2(*reinterpret_cast<const __nv_bfloat162*>(&sq.x));
+      const float2 rH0 =
+          __bfloat1622float2(*reinterpret_cast<const __nv_bfloat162*>(&sq.y));
+      const float2 rL1 =
+          __bfloat1622float2(*reinterpret_cast<const __nv_bfloat162*>(&sq.z));
+      const float2 rH1 =
+          __bfloat1622float2(*reinterpret_cast<const __nv_bfloat162*>(&sq.w));
+      outPacks[p0] =
+          make_float4(rL0.x + l0.x, rL0.y + l0.y, rH0.x + l0.z, rH0.y + l0.w);
+      outPacks[p1] =
+          make_float4(rL1.x + l1.x, rL1.y + l1.y, rH1.x + l1.z, rH1.y + l1.w);
+    }
+    for (std::uint32_t pack = pairCount * 2u + rtid; pack < rpackCount;
+         pack += rstride) {
+      const uint2 s0 = stagingPacks[pack];
+      const float4 l0 = localPacks[pack];
+      const float2 rL0 =
+          __bfloat1622float2(*reinterpret_cast<const __nv_bfloat162*>(&s0.x));
+      const float2 rH0 =
+          __bfloat1622float2(*reinterpret_cast<const __nv_bfloat162*>(&s0.y));
+      outPacks[pack] =
+          make_float4(rL0.x + l0.x, rL0.y + l0.y, rH0.x + l0.z, rH0.y + l0.w);
+    }
+    const std::size_t packCount = rpackCount;
+
+    const std::size_t scalarBegin = packCount * 4;
+    for (std::size_t i = scalarBegin + group.thread_id_in_group;
+         i < elementCount;
+         i += group.group_size) {
+      const std::size_t element = elementOffset + i;
+      args.receiver_output_base[element] =
+          __bfloat162float(stagingBf16[i]) + args.receiver_input_base[element];
+    }
+#endif
+    return nbytes;
+  }
+};
+
+} // namespace comms::prims

--- a/comms/prims/core/ThreadGroup.cuh
+++ b/comms/prims/core/ThreadGroup.cuh
@@ -66,6 +66,7 @@ enum class SyncScope { THREAD, WARP, MULTIWARP, BLOCK, CLUSTER };
  *   - thread_id_in_group = 2 (position within warp: 34 % 32 = 2)
  */
 struct ThreadGroup {
+  static constexpr uint32_t kAutoBarrierId = UINT32_MAX;
   // LOCAL IDENTITY (within group):
   // ===============================
 
@@ -102,6 +103,8 @@ struct ThreadGroup {
   // CLUSTER: uses cluster.sync().
   SyncScope scope;
 
+  uint32_t barrier_id = kAutoBarrierId;
+
   __device__ inline void sync() {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     switch (scope) {
@@ -128,7 +131,8 @@ struct ThreadGroup {
         // group. `group_size` is configurable for make_multiwarp_group().
         uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
             threadIdx.z * blockDim.x * blockDim.y;
-        uint32_t barrierId = tid / group_size;
+        uint32_t barrierId =
+            barrier_id == kAutoBarrierId ? tid / group_size : barrier_id;
         // Keep compiler memory operations on their respective sides of the
         // hardware barrier.
         asm volatile("bar.sync %0, %1;"
@@ -275,7 +279,8 @@ struct ThreadGroup {
         __shared__ uint64_t __tg_broadcast_scratch[kMaxMultiwarpsPerBlock];
         uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
             threadIdx.z * blockDim.x * blockDim.y;
-        uint32_t scratch_idx = tid / group_size;
+        uint32_t scratch_idx =
+            barrier_id == kAutoBarrierId ? tid / group_size : barrier_id;
         if (is_leader()) {
           __tg_broadcast_scratch[scratch_idx] = static_cast<uint64_t>(val);
         }
@@ -477,7 +482,7 @@ struct ThreadGroup {
  * PartitionResult - Result of partitioning a ThreadGroup
  */
 struct PartitionResult {
-  uint32_t partition_id;
+  uint32_t partition_id{};
   ThreadGroup subgroup;
 };
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2231,6 +2231,15 @@ cvars:
      ctring_ib - Prims-native IBGDA ring algorithm
      ctrhd - Ctran-based recursive vector-halving distance-doubling algorithm
 
+ - name        : NCCL_REDUCESCATTER_QUANTIZED_ALGO
+   type        : enum
+   default     : pat
+   choices     : pat, ctdirect_ib
+   description : |-
+     The algorithm to use for quantized ReduceScatter communication
+     pat - Parallel Aggregation Tree algorithm
+     ctdirect_ib - Ctran-based direct IB algorithm
+
  - name        : NCCL_REDUCESCATTER_PAT_AVG_ENABLE
    type        : bool
    default     : false

--- a/comms/utils/kernels/stochastic_rounding/stochastic_rounding.cuh
+++ b/comms/utils/kernels/stochastic_rounding/stochastic_rounding.cuh
@@ -13,7 +13,8 @@
 #include <cuda_bf16.h>
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000) && \
-    defined(__CUDA_ARCH_FEAT_SM100_ALL)
+    (defined(__CUDA_ARCH_FEAT_SM100_ALL) ||              \
+     defined(__CUDA_ARCH_FEAT_SM103_ALL))
 constexpr bool kHasHardwareSR = true;
 #else
 constexpr bool kHasHardwareSR = false;
@@ -42,7 +43,8 @@ __device__ __forceinline__ bool isFinite(float val) {
 __device__ __forceinline__ __nv_bfloat162
 stochastic_round_bf16x2_blackwell(float2 vals, uint32_t rand_bits) {
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000) && \
-    defined(__CUDA_ARCH_FEAT_SM100_ALL)
+    (defined(__CUDA_ARCH_FEAT_SM100_ALL) ||              \
+     defined(__CUDA_ARCH_FEAT_SM103_ALL))
   // Use cvt.rs.bf16x2.f32 for vectorized stochastic rounding
   // PTX instruction: cvt.rs.bf16x2.f32 dst, src_hi, src_lo, rand;
   // - dst: 32-bit register containing 2 packed BF16 values


### PR DESCRIPTION
Summary:

Route quantized FP32 ReduceScatter SUM calls to `ctdirect_ib`, stochastically round remote FP32 contributions into BF16 transport staging with deterministic Philox element IDs, widen and accumulate in FP32 at the receiver, and preserve the owner contribution as FP32. Optimize the quantized-only path with an 8-block, 640-thread `352 send / 288 receive` launch while leaving the nonquantized kernel unchanged at 512 threads and `128 send / 384 receive`. Process complete 8-element send packets so one Philox result serves all eight values, issue two independent `float4` loads, and write the packed BF16 packet with one aligned `uint4` store. On receive, process adjacent packs with one aligned `uint4` staging load and issue both aliased FP32 input loads before either output store, preserving read-modify-write ordering while exposing memory-level parallelism. Add explicit MULTIWARP barrier and broadcast-slot IDs for unequal contiguous thread partitions while retaining automatic IDs for existing groups. Keep AVG on the existing PAT path and retain deterministic-seed, odd-tail, fallback, and zero-count coverage.

Reviewed By: snarayankh

Differential Revision: D113354513


