### PR TITLE
CERR conversion in CTRAN mapper/gpe/utils/window call sites

### DIFF
--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -288,8 +288,8 @@ commResult_t CtranGpe::Impl::submit(
 
   // Error checking before GPE cmd and kernel submission
   if (kernelConfig.args.devState_d == nullptr) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "COMM internally passed invalid devState_d (nullptr) to kernel {}",
         kernelTypeToName[kernelConfig.type]);
     return commInternalError;

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -824,8 +824,8 @@ commResult_t CtranMapper::searchRegHandle(
 
   if (!regHdl_) {
     if (!allowDynamic) {
-      CLOGF(
-          ERR,
+      CERR(
+          commInvalidUsage,
           "CTRAN-MAPPER: buffer {} len {} is not pre-registered by user. ",
           buf,
           len);

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -1630,6 +1630,10 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
           ControlMsgType::SYNC, payload, size, peerRank, req->ibReq);
     }
     // only support ib for now
+    CERR(
+        commInvalidArgument,
+        "CTRAN-MAPPER: isendCtrlMsg only supports the IB backend for peerRank {}",
+        peerRank);
     return commInvalidArgument;
   }
 
@@ -1664,6 +1668,10 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       return ctranIb->irecvCtrlMsg<PerfConfig>(
           payload, size, peerRank, req->ibReq);
     }
+    CERR(
+        commInvalidArgument,
+        "CTRAN-MAPPER: irecvCtrlMsg only supports the IB backend for peerRank {}",
+        peerRank);
     return commInvalidArgument;
   }
 
@@ -1742,6 +1750,10 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     } else if (ctranTcpDm) {
       return ctranTcpDm->isendCtrlMsg(msg, peerRank, req->tcpDmReq);
     }
+    CERR(
+        commInternalError,
+        "CTRAN-MAPPER: isendCtrl found no available backend for peerRank {}",
+        peerRank);
     return commInternalError;
   }
 
@@ -1775,6 +1787,10 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     } else if (ctranTcpDm) {
       return ctranTcpDm->irecvCtrlMsg(msg, peerRank, req->tcpDmReq);
     }
+    CERR(
+        commInternalError,
+        "CTRAN-MAPPER: irecvCtrl found no available backend for peerRank {}",
+        peerRank);
     return commInternalError;
   }
 

--- a/comms/ctran/utils/CtranAvlTree.cc
+++ b/comms/ctran/utils/CtranAvlTree.cc
@@ -48,8 +48,8 @@ commResult_t CtranAvlTree::remove(void* hdl) {
 
   auto it = handles_.find(hdl);
   if (it == handles_.end()) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInvalidUsage,
         "CTRAN-AVL-TREE: Trying to remove hdl {} while the handle is not in the cache, likely double freeing",
         (void*)hdl);
     return commInvalidUsage;

--- a/comms/ctran/utils/CtranIpc.cc
+++ b/comms/ctran/utils/CtranIpc.cc
@@ -138,8 +138,8 @@ commResult_t ctran::utils::CtranIpcMem::ipcExport(CtranIpcDesc& ipcDesc) {
   std::vector<CtranIpcSegDesc> extraSegments;
   FB_COMMCHECK(ipcExport(ipcDesc, extraSegments));
   if (!extraSegments.empty()) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "CTRAN-IPC: tried to export CtranIpcMem backed by too many physical memory allocations. [{}]",
         this->toString());
     return commInternalError;
@@ -276,16 +276,16 @@ commResult_t ctran::utils::CtranIpcMem::tryLoad(
     bool shouldSupportCudaMalloc) {
   // Should never call load from an instance with allocation mode
   if (this->mode_ != CtranIpcMem::Mode::LOAD) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "CTRAN-IPC: try to load a memory range to an instance with allocation mode. It indicates a COMM internal bug.");
     return commInternalError;
   }
 
   // A load instance should manage only one memory range at lifetime
   if (this->pbase_) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "CTRAN-IPC: CtranIpcMem already manages an existing memory range: {}. It indicates a COMM internal bug.",
         this->toString().c_str());
     return commInternalError;
@@ -378,13 +378,13 @@ inline commResult_t ctran::utils::CtranIpcMem::tryLoadCuMem(
         (segmentHandleType != cuMemHandleType_);
 
     if (isUnsupportedType) {
-      CLOGF(
-          ERR,
-          "CTRAN-IPC: [pbase {:x} range {}] associated with [ptr {} len {}] "
+      CERR(
+          commInvalidUsage,
+          "CTRAN-IPC: [pbase {} range {}] associated with [ptr {} len {}] "
           "has unsupported allocation properties for IPC export: "
           "handleType = {} ({}), supportedExportType = {} ({}), gpuDirectRDMACapable = {}, "
           "segmentHandleType = {} ({})",
-          segs[i].base,
+          reinterpret_cast<void*>(segs[i].base),
           segs[i].size,
           (void*)ptr,
           len,
@@ -622,8 +622,8 @@ commResult_t CtranIpcRemMem::importCuMem(const CtranIpcDesc& ipcDesc) {
 
 commResult_t CtranIpcRemMem::importCudaMallocMem(const CtranIpcDesc& ipcDesc) {
   if (ipcDesc.totalSegments != 1) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInternalError,
         "CTRAN-IPC: Number of segments is expected to be 1, but got {}",
         ipcDesc.totalSegments);
     return commInternalError;

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -941,8 +941,8 @@ commResult_t checkUserBufType(const DevMemType bufType) {
         devMemTypeStr(bufType));
     return commSuccess;
   }
-  CLOGF(
-      ERR,
+  CERR(
+      commInvalidUsage,
       "CTRAN-WINDOW: Unsupported buffer type {} provided when registering window. Supported buffer types are kCumem, kHostPinned, kHostUnregistered, kCudaMalloc",
       devMemTypeStr(bufType));
 
@@ -1014,8 +1014,8 @@ commResult_t ctranWinSharedQuery(int rank, CtranWin* win, void** addr) {
 
   // Validate rank is within valid bounds
   if (rank < 0 || rank >= comm->statex_->nRanks()) {
-    CLOGF(
-        ERR,
+    CERR(
+        commInvalidArgument,
         "CTRAN-WINDOW: Invalid rank {} for sharedQuery (valid range: [0, {}))",
         rank,
         comm->statex_->nRanks());


### PR DESCRIPTION
Summary:
Continue the CERR-coverage campaign into the remaining CTRAN support modules (mapper, gpe, utils, window) so every root-cause error origination records exactly one Scuba error record carrying its `commResult_t`. `CERR(code, ...)` logs at ERR level (like `CLOGF(ERR, ...)`) and records the code; `FB_COMMCHECK` propagation only logs. Two kinds of change:
- Convert 10 existing `CLOGF(ERR, ...)` sites that log-then-return a fresh comm error to `CERR(code, ...)`: CtranMapper.cc (1), utils/CtranAvlTree.cc (1), utils/CtranIpc.cc (5), gpe/CtranGpeImpl.cc (1), window/window.cc (2).
- Add CERR to 4 previously-silent root-cause returns in mapper/CtranMapper.h (isendCtrlMsgImpl / irecvCtrlMsgImp unsupported-backend -> commInvalidArgument; isendCtrlImpl / irecvCtrlImpl no-backend-set -> commInternalError).
Each CERR code matches the error actually returned at the site. Propagators, catch/throw sites, destructors, log-and-continue paths, non-comm returns (nullptr/enum), and WARN/INFO/TRACE logs are left unchanged. RegCache.cc/IpcRegCache.cc were converted in commit 1; utils/Checks.h header macros (FB_ERRORRETURN, FB_CUDACHECKTHREAD) are handled separately in the header-fix commit.

Reviewed By: YulunW

Differential Revision: D113325209


