### PR TITLE
CERR conversion for remaining CTRAN Checks.h error macros (#3323)

### DIFF
--- a/comms/ctran/utils/Checks.h
+++ b/comms/ctran/utils/Checks.h
@@ -350,8 +350,8 @@
 #define FOLLY_EXPECTED_CHECK(RES) \
   do {                            \
     if (RES.hasError()) {         \
-      CLOGF(                      \
-          ERR,                    \
+      CERR(                       \
+          commSystemError,        \
           "{}:{} -> {}, {}",      \
           __FILE__,               \
           __LINE__,               \
@@ -602,14 +602,13 @@
 #define FB_CUDACHECKTHREAD(a)             \
   do {                                    \
     if ((a) != cudaSuccess) {             \
-      CLOGF_SUBSYS(                       \
-          ERR,                            \
-          INIT,                           \
-          "{}:{}} -> {}} [Async thread]", \
+      args->ret = commUnhandledCudaError; \
+      CERR(                               \
+          commUnhandledCudaError,         \
+          "{}:{} -> {} [Async thread]",   \
           __FILE__,                       \
           __LINE__,                       \
           args->ret);                     \
-      args->ret = commUnhandledCudaError; \
       return args;                        \
     }                                     \
   } while (0)
@@ -624,7 +623,7 @@
 
 #define FB_ERRORRETURN(error, ...)                                  \
   do {                                                              \
-    CLOGF(ERR, ##__VA_ARGS__);                                      \
+    CERR(error, ##__VA_ARGS__);                                     \
     ErrorStackTraceUtil::logErrorMessage(fmt::format(__VA_ARGS__)); \
     return error;                                                   \
   } while (0)

--- a/comms/rcclx/develop/meta/ctran/PersistentCollectives.cc
+++ b/comms/rcclx/develop/meta/ctran/PersistentCollectives.cc
@@ -41,30 +41,30 @@ __attribute__((visibility("default"))) ncclResult_t allGatherInit(
 
 #define CHECK_VALID_CTRAN(comm)                                             \
   if (!ctranInitialized(comm)) {                                            \
-    FB_ERRORRETURN(                                                         \
-        ncclInvalidUsage,                                                   \
+    CLOGF(                                                                  \
+        ERR,                                                                \
         "CTRAN must be enabled and initialized for persistent collective"); \
+    return ncclInvalidUsage;                                                \
   }
 
 #define CHECK_PREQ_TYPE(pReq, type)                                \
   if (pReq->type != type) {                                        \
-    FB_ERRORRETURN(                                                \
-        ncclInvalidArgument,                                       \
+    CLOGF(                                                         \
+        ERR,                                                       \
         "%s requires persistent request type %d, but received %d", \
         __func__,                                                  \
         type,                                                      \
         pReq->type);                                               \
+    return ncclInvalidArgument;                                    \
   }
 
-#define GET_VALID_PREQ_OR_ERRRETURN(req, pReq)                    \
-  do {                                                            \
-    if (request == nullptr) {                                     \
-      FB_ERRORRETURN(                                             \
-          ncclInvalidArgument,                                    \
-          "%s received invalid nullptr request",                  \
-          __func__);                                              \
-    }                                                             \
-    *(pReq) = reinterpret_cast<CtranPersistentRequest*>(request); \
+#define GET_VALID_PREQ_OR_ERRRETURN(req, pReq)                     \
+  do {                                                             \
+    if (request == nullptr) {                                      \
+      CLOGF(ERR, "%s received invalid nullptr request", __func__); \
+      return ncclInvalidArgument;                                  \
+    }                                                              \
+    *(pReq) = reinterpret_cast<CtranPersistentRequest*>(request);  \
   } while (0)
 
 __attribute__((visibility("default"))) ncclResult_t allGatherExec(
@@ -91,18 +91,19 @@ __attribute__((visibility("default"))) ncclResult_t pExec(void* request) {
       (void*)pReq->comm_);
 
   if (!ctranInitialized(pReq->comm_)) {
-    FB_ERRORRETURN(
-        ncclInvalidUsage,
-        "CTRAN must be enabled and initialized for persistent collective");
+    CLOGF(
+        ERR, "CTRAN must be enabled and initialized for persistent collective");
+    return ncclInvalidUsage;
   }
 
   switch (pReq->type) {
     default:
-      FB_ERRORRETURN(
-          ncclInvalidArgument,
+      CLOGF(
+          ERR,
           "Persistent request {} has unknown op type {}",
           (void*)pReq,
           (void*)pReq->type);
+      return ncclInvalidArgument;
   }
 }
 
@@ -115,11 +116,12 @@ __attribute__((visibility("default"))) ncclResult_t pFree(void* request) {
       NCCLCHECK(metaCommToNccl(ctran::allGatherPDestroy(pReq)));
       break;
     default:
-      FB_ERRORRETURN(
-          ncclInvalidArgument,
+      CLOGF(
+          ERR,
           "Persistent request {} has unknown op type {}",
           (void*)pReq,
           pReq->type);
+      return ncclInvalidArgument;
   }
   delete pReq;
 


### PR DESCRIPTION
Summary:

Finish the CERR-coverage campaign in the shared error-check header `comms/ctran/utils/Checks.h`. An earlier commit converted most of this header's check macros to `CERR`; three root-cause originations were still on `CLOGF(ERR, ...)` / `CLOGF_SUBSYS(ERR, ...)` and thus recorded nothing to Scuba when they fired. `CERR(code, ...)` logs at ERR level (like `CLOGF(ERR, ...)`) and records one Scuba error record carrying the `commResult_t`. Three edits:
- `FB_CUDACHECKTHREAD`: convert `CLOGF_SUBSYS(ERR, INIT, ...)` to `CERR(commUnhandledCudaError, ...)`, fix a format-string bug (`"{}:{}} -> {}}"` had doubled closing braces -> `"{}:{} -> {}"`), and move `args->ret = commUnhandledCudaError;` before the log so the logged value matches the recorded/returned code instead of a stale value.
- `FB_ERRORRETURN`: convert `CLOGF(ERR, ##__VA_ARGS__)` to `CERR(error, ##__VA_ARGS__)` (mirrors the sibling FB_COMMARGCHECK; keeps the ErrorStackTraceUtil::logErrorMessage stack-trace line and `return error`).
- `FOLLY_EXPECTED_CHECK`: convert `CLOGF(ERR, ...)` to `CERR(commSystemError, ...)`. This macro translates a foreign `folly::Expected` / ibverbx error into a fresh `commSystemError` (a genuine ctran-level origination); it has 33 call sites, all in backends/ib/, unchanged by this macro-internal edit.
Each CERR code matches the value returned at the site. Propagator, throw, abort, WARN, retry, and dead macros (e.g. FB_COMMCHECK, FB_COMMCHECKTHREAD, FB_ERRORTHROW_EX*, FOLLY_EXPECTED_CHECKTHROW_EX*, the unused FB_COMMWAIT) are intentionally left unchanged.

Reviewed By: YulunW

Differential Revision: D113325213


