### PR TITLE
CERR conversion for WARN-level root-cause errors in CTRAN (#3324)

### DIFF
--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -669,7 +669,7 @@ enum NCCL_ALLREDUCE_ALGO CtranAlgo::getAllReduceAlgo() {
 commResult_t CtranAlgo::exchangePeerTmpbuf(int peer) {
   // if peer is out of range, we report an error
   if (comm_->statex_->nRanks() < peer) {
-    CLOGF(WARN, "Invalid value for peer: {}", peer);
+    CERR(commInvalidArgument, "Invalid value for peer: {}", peer);
     return commInvalidArgument;
   }
   // if tmpbuffs are already exchanged, we don't need to do anything

--- a/comms/ctran/algos/ReduceScatter/ReduceScatter.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatter.cc
@@ -142,8 +142,8 @@ commResult_t ctranReduceScatter(
       return ctranReduceScatterDirectIb(
           sendbuff, recvbuff, recvcount, datatype, redOp, comm, stream);
     default:
-      CLOGF(
-          WARN,
+      CERR(
+          commInternalError,
           "ctranReduceScatter: no valid algorithm to support nLocalRanks {} nNodes {}",
           nLocalRanks,
           nNodes);

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterRHD.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterRHD.cc
@@ -336,15 +336,15 @@ commResult_t ctranReduceScatterRHD(
       stream);
   const size_t totalBufSize = recvcount * typeSize * statex->nRanks();
   if (NCCL_CTRAN_INTERNODE_TMPBUF_SIZE < totalBufSize) {
-    CLOGF(
-        WARN,
+    CERR(
+        commInternalError,
         "ctranReduceScatterRHD: data buffer of size {} bytes "
         "is too large to fit in tmpBuf",
         totalBufSize);
     return commInternalError;
   } else if ((statex->nRanks() & (statex->nRanks() - 1)) != 0) {
-    CLOGF(
-        WARN,
+    CERR(
+        commInternalError,
         "ctranReduceScatterRHD: current implementation requires"
         "number of ranks to be a power of 2, nRanks: {}",
         statex->nRanks());

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -1046,8 +1046,8 @@ class CtranIb {
         CTRAN_IB_PER_OBJ_LOCK_GUARD(cqMutex, {
           auto maybeWcsVector = devices[device].ibvCq->pollCq(1);
           if (maybeWcsVector.hasError()) {
-            CLOGF(
-                WARN,
+            CERR(
+                commSystemError,
                 "Call to pollCq() on device {} failed with error {}",
                 device,
                 maybeWcsVector.error().errStr);

--- a/comms/ctran/backends/ib/IbvWrap.cc
+++ b/comms/ctran/backends/ib/IbvWrap.cc
@@ -29,20 +29,24 @@ commResult_t wrap_ibv_symbols(void) {
 }
 
 /* CHECK_NOT_NULL: helper macro to check for NULL symbol */
-#define CHECK_NOT_NULL(container, internal_name) \
-  if (container.internal_name == nullptr) {      \
-    CLOGF(WARN, "lib wrapper not initialized."); \
-    return commInternalError;                    \
+#define CHECK_NOT_NULL(container, internal_name)             \
+  if (container.internal_name == nullptr) {                  \
+    CERR(commInternalError, "lib wrapper not initialized."); \
+    return commInternalError;                                \
   }
 
-#define IBV_PTR_CHECK_ERRNO(                                               \
-    container, internal_name, call, retval, error_retval, name)            \
-  CHECK_NOT_NULL(container, internal_name);                                \
-  retval = container.call;                                                 \
-  if (retval == error_retval) {                                            \
-    CLOGF(WARN, "Call to {} failed with error {}", name, strerror(errno)); \
-    return commSystemError;                                                \
-  }                                                                        \
+#define IBV_PTR_CHECK_ERRNO(                                    \
+    container, internal_name, call, retval, error_retval, name) \
+  CHECK_NOT_NULL(container, internal_name);                     \
+  retval = container.call;                                      \
+  if (retval == error_retval) {                                 \
+    CERR(                                                       \
+        commSystemError,                                        \
+        "Call to {} failed with error {}",                      \
+        name,                                                   \
+        strerror(errno));                                       \
+    return commSystemError;                                     \
+  }                                                             \
   return commSuccess;
 
 #define IBV_PTR_CHECK(                                          \
@@ -50,7 +54,7 @@ commResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name);                     \
   retval = container.call;                                      \
   if (retval == error_retval) {                                 \
-    CLOGF(WARN, "Call to {} failed", name);                     \
+    CERR(commSystemError, "Call to {} failed", name);           \
     return commSystemError;                                     \
   }                                                             \
   return commSuccess;
@@ -86,8 +90,8 @@ commResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name);               \
   int ret = container.call;                               \
   if (ret != success_retval) {                            \
-    CLOGF(                                                \
-        WARN,                                             \
+    CERR(                                                 \
+        commSystemError,                                  \
         "Call to {} failed with error {} errno {}",       \
         name,                                             \
         strerror(ret),                                    \
@@ -100,7 +104,7 @@ commResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name);                               \
   int ret = container.call;                                               \
   if (ret == error_retval) {                                              \
-    CLOGF(WARN, "Call to failed", name);                                  \
+    CERR(commSystemError, "Call to failed", name);                        \
     return commSystemError;                                               \
   }                                                                       \
   return commSuccess;
@@ -541,8 +545,8 @@ wrap_ibv_modify_qp(struct ibv_qp* qp, struct ibv_qp_attr* attr, int attr_mask) {
   } while (IBV_MQP_RETRY_ERRNO_ALL(ret) && attempts < maxCnt);
   if (ret != 0) {
     ibvModifyQpLog(qp, attr->qp_state, attr, attr_mask, qpMsg, sizeof(qpMsg));
-    CLOGF(
-        WARN,
+    CERR(
+        commSystemError,
         "Call to ibv_modify_qp failed with {} {}, {}",
         ret,
         strerror(ret),

--- a/comms/ctran/backends/ib/IbvWrap.h
+++ b/comms/ctran/backends/ib/IbvWrap.h
@@ -117,7 +117,7 @@ static inline commResult_t wrap_ibv_poll_cq(
       cq, num_entries, wc); /*returns the number of wcs or 0 on success, a
                                negative number otherwise*/
   if (done < 0) {
-    CLOGF(WARN, "Call to ibv_poll_cq() returned {}", done);
+    CERR(commSystemError, "Call to ibv_poll_cq() returned {}", done);
     return commSystemError;
   }
   *num_done = done;
@@ -145,8 +145,8 @@ static inline commResult_t wrap_ibv_post_send(
       qp, wr, bad_wr); /*returns 0 on success, or the value of errno on failure
                           (which indicates the failure reason)*/
   if (ret != IBV_SUCCESS) {
-    CLOGF(
-        WARN,
+    CERR(
+        commSystemError,
         "ibv_post_send() failed with error {}, Bad WR {}, First WR {}",
         strerror(ret),
         (void*)wr,
@@ -164,7 +164,8 @@ static inline commResult_t wrap_ibv_post_recv(
       qp, wr, bad_wr); /*returns 0 on success, or the value of errno on failure
                           (which indicates the failure reason)*/
   if (ret != IBV_SUCCESS) {
-    CLOGF(WARN, "ibv_post_recv() failed with error {}", strerror(ret));
+    CERR(
+        commSystemError, "ibv_post_recv() failed with error {}", strerror(ret));
     return commSystemError;
   }
   return commSuccess;

--- a/comms/ctran/gpe/CtranGpe.cc
+++ b/comms/ctran/gpe/CtranGpe.cc
@@ -383,8 +383,8 @@ commResult_t CtranGpe::allocKernelElems(
     this->pimpl->kernelElemPool->reclaim();
 
     if (numElems > this->pimpl->kernelElemPool->size()) {
-      CLOGF(
-          WARN,
+      CERR(
+          commInternalError,
           "CTRAN-GPE: Internal KernelElem pool has unexpected high usage (capacity: {}, available: {}, current request: {}). "
           "It is likely that some COMM kernels are not released properly",
           this->pimpl->kernelElemPool->capacity(),

--- a/comms/ctran/regcache/IpcRegCache.cc
+++ b/comms/ctran/regcache/IpcRegCache.cc
@@ -392,8 +392,8 @@ commResult_t ctran::IpcRegCache::notifyRemoteIpcRelease(
     int32_t exportCount) {
   // Check if AsyncSocket is initialized
   if (!asyncSocketEvbThread_ || !asyncServerSocket_) {
-    CLOGF(
-        WARN,
+    CERR(
+        commInternalError,
         "CTRAN-REGCACHE: AsyncSocket not initialized, skipping remote release");
     return commInternalError;
   }
@@ -441,8 +441,8 @@ commResult_t ctran::IpcRegCache::notifyRemoteIpcExport(
     ctran::regcache::IpcReqCb* reqCb) {
   // Check if AsyncSocket is initialized
   if (!asyncSocketEvbThread_ || !asyncServerSocket_) {
-    CLOGF(
-        WARN,
+    CERR(
+        commInternalError,
         "CTRAN-REGCACHE: AsyncSocket not initialized, skipping remote export");
     return commInternalError;
   }

--- a/comms/ctran/utils/Checks.h
+++ b/comms/ctran/utils/Checks.h
@@ -350,8 +350,8 @@
 #define FOLLY_EXPECTED_CHECK(RES) \
   do {                            \
     if (RES.hasError()) {         \
-      CLOGF(                      \
-          ERR,                    \
+      CERR(                       \
+          commSystemError,        \
           "{}:{} -> {}, {}",      \
           __FILE__,               \
           __LINE__,               \
@@ -602,14 +602,13 @@
 #define FB_CUDACHECKTHREAD(a)             \
   do {                                    \
     if ((a) != cudaSuccess) {             \
-      CLOGF_SUBSYS(                       \
-          ERR,                            \
-          INIT,                           \
-          "{}:{}} -> {}} [Async thread]", \
+      args->ret = commUnhandledCudaError; \
+      CERR(                               \
+          commUnhandledCudaError,         \
+          "{}:{} -> {} [Async thread]",   \
           __FILE__,                       \
           __LINE__,                       \
           args->ret);                     \
-      args->ret = commUnhandledCudaError; \
       return args;                        \
     }                                     \
   } while (0)
@@ -624,7 +623,7 @@
 
 #define FB_ERRORRETURN(error, ...)                                  \
   do {                                                              \
-    CLOGF(ERR, ##__VA_ARGS__);                                      \
+    CERR(error, ##__VA_ARGS__);                                     \
     ErrorStackTraceUtil::logErrorMessage(fmt::format(__VA_ARGS__)); \
     return error;                                                   \
   } while (0)

--- a/comms/rcclx/develop/meta/ctran/PersistentCollectives.cc
+++ b/comms/rcclx/develop/meta/ctran/PersistentCollectives.cc
@@ -41,30 +41,30 @@ __attribute__((visibility("default"))) ncclResult_t allGatherInit(
 
 #define CHECK_VALID_CTRAN(comm)                                             \
   if (!ctranInitialized(comm)) {                                            \
-    FB_ERRORRETURN(                                                         \
-        ncclInvalidUsage,                                                   \
+    CLOGF(                                                                  \
+        ERR,                                                                \
         "CTRAN must be enabled and initialized for persistent collective"); \
+    return ncclInvalidUsage;                                                \
   }
 
 #define CHECK_PREQ_TYPE(pReq, type)                                \
   if (pReq->type != type) {                                        \
-    FB_ERRORRETURN(                                                \
-        ncclInvalidArgument,                                       \
+    CLOGF(                                                         \
+        ERR,                                                       \
         "%s requires persistent request type %d, but received %d", \
         __func__,                                                  \
         type,                                                      \
         pReq->type);                                               \
+    return ncclInvalidArgument;                                    \
   }
 
-#define GET_VALID_PREQ_OR_ERRRETURN(req, pReq)                    \
-  do {                                                            \
-    if (request == nullptr) {                                     \
-      FB_ERRORRETURN(                                             \
-          ncclInvalidArgument,                                    \
-          "%s received invalid nullptr request",                  \
-          __func__);                                              \
-    }                                                             \
-    *(pReq) = reinterpret_cast<CtranPersistentRequest*>(request); \
+#define GET_VALID_PREQ_OR_ERRRETURN(req, pReq)                     \
+  do {                                                             \
+    if (request == nullptr) {                                      \
+      CLOGF(ERR, "%s received invalid nullptr request", __func__); \
+      return ncclInvalidArgument;                                  \
+    }                                                              \
+    *(pReq) = reinterpret_cast<CtranPersistentRequest*>(request);  \
   } while (0)
 
 __attribute__((visibility("default"))) ncclResult_t allGatherExec(
@@ -91,18 +91,19 @@ __attribute__((visibility("default"))) ncclResult_t pExec(void* request) {
       (void*)pReq->comm_);
 
   if (!ctranInitialized(pReq->comm_)) {
-    FB_ERRORRETURN(
-        ncclInvalidUsage,
-        "CTRAN must be enabled and initialized for persistent collective");
+    CLOGF(
+        ERR, "CTRAN must be enabled and initialized for persistent collective");
+    return ncclInvalidUsage;
   }
 
   switch (pReq->type) {
     default:
-      FB_ERRORRETURN(
-          ncclInvalidArgument,
+      CLOGF(
+          ERR,
           "Persistent request {} has unknown op type {}",
           (void*)pReq,
           (void*)pReq->type);
+      return ncclInvalidArgument;
   }
 }
 
@@ -115,11 +116,12 @@ __attribute__((visibility("default"))) ncclResult_t pFree(void* request) {
       NCCLCHECK(metaCommToNccl(ctran::allGatherPDestroy(pReq)));
       break;
     default:
-      FB_ERRORRETURN(
-          ncclInvalidArgument,
+      CLOGF(
+          ERR,
           "Persistent request {} has unknown op type {}",
           (void*)pReq,
           pReq->type);
+      return ncclInvalidArgument;
   }
   delete pReq;
 


### PR DESCRIPTION
Summary:

Final commit of the CERR-coverage campaign, handling the severity-changing cases. Some CTRAN root-cause error paths logged at WARN level then returned a fresh comm error, so they neither surfaced at ERR nor recorded to Scuba. Promote the 19 genuine root-cause WARN sites to `CERR(code, ...)` (logs at ERR level and records one Scuba error record with the `commResult_t`). This changes both severity (WARN -> ERR) and observability (adds the Scuba record); it is intentional and reviewed separately from the mechanical ERR->CERR commits. Sites:
- `backends/ib/IbvWrap.cc` (6 macros) + `IbvWrap.h` (3): ibv symbol-null / poll_cq / post_send / post_recv / modify_qp failures -> commInternalError / commSystemError.
- `backends/ib/CtranIb.h` (1): pollCq error -> commSystemError.
- `algos/CtranAlgo.cc` (1, peer out of range -> commInvalidArgument), `algos/ReduceScatter/ReduceScatterRHD.cc` (2) and `ReduceScatter.cc` (1) -> commInternalError.
- `algos/AllToAll/fb/compressed/CompressedAllToAllvImpl.h` (2, flag-gated, hand-verified) -> commSystemError.
- `regcache/IpcRegCache.cc` (2, AsyncSocket not initialized) and `gpe/CtranGpe.cc` (1, KernelElem pool exhausted) -> commInternalError.
Each CERR code matches the fresh error returned at the site. Log-and-continue WARNs, capability-probe/fallback signals (IBV_INT_CHECK_RET_ERRNO_OPTIONAL, PutSignal.cc HW-wait fallback, tcpdevmem peer-disconnect), callee wrappers (CompressedAllToAllvImpl.h:154/353), propagators, catch blocks, and non-comm returns are intentionally left as WARN.

Reviewed By: YulunW

Differential Revision: D113325208


