### PR TITLE
Use leader-only system fences for send/recv puts

### DIFF
--- a/comms/prims/core/CopyOp.cuh
+++ b/comms/prims/core/CopyOp.cuh
@@ -842,11 +842,8 @@ struct AnsCompress {
     }
 #endif
 
-    // No per-thread release fence here: the transport
-    // (`P2pIbgdaTransportDevice::send`) already calls
-    // `__threadfence_system()` from every cooperating thread
-    // immediately after `CopyOp::send` returns and before the
-    // leader-issued RDMA put.
+    // The transport synchronizes all cooperating writers before the leader's
+    // system fence and RDMA put.
     return writeOffset;
   }
 

--- a/comms/prims/core/ThreadGroup.cuh
+++ b/comms/prims/core/ThreadGroup.cuh
@@ -129,7 +129,12 @@ struct ThreadGroup {
         uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
             threadIdx.z * blockDim.x * blockDim.y;
         uint32_t barrierId = tid / group_size;
-        asm volatile("bar.sync %0, %1;" : : "r"(barrierId), "r"(group_size));
+        // Keep compiler memory operations on their respective sides of the
+        // hardware barrier.
+        asm volatile("bar.sync %0, %1;"
+                     :
+                     : "r"(barrierId), "r"(group_size)
+                     : "memory");
 #else
         // AMD: no named barriers, fall back to block-level sync
         __syncthreads();

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -509,9 +509,9 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
       }
     }
 
-    __threadfence_system();
     group.sync();
     if (group.is_leader()) {
+      __threadfence_system();
       ThreadGroup solo{
           0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
       const std::size_t protocolBytesThis =
@@ -1027,11 +1027,10 @@ __device__ __forceinline__ void send(
           group, localSlotFree, protocolStreamEnd - pipelineBytesWire, timeout);
     }
 
-    // (4) threadfence_system + leader-only RDMA put with fused signal.
-    //     stores are visible to the NIC before the leader posts the WQE.
-    __threadfence_system();
+    // (4) Leader-only single-WQE RDMA put with fused signal.
     group.sync();
     if (group.is_leader()) {
+      __threadfence_system();
       ThreadGroup solo{
           0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
       const auto completion = transport.put(
@@ -1443,10 +1442,10 @@ __device__ __forceinline__ void forward(
           timeout);
     }
 
-    // (6) threadfence_system + RDMA put via fwd transport.
-    __threadfence_system();
+    // (6) Leader-only RDMA put via the forwarding transport.
     group.sync();
     if (group.is_leader()) {
+      __threadfence_system();
       ThreadGroup solo{
           0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
       const auto completion = fwdTransport.put(


### PR DESCRIPTION
Summary:
Move `__threadfence_system()` after the group barrier and execute it only on the thread that posts the RDMA WQE at all three send-side sites: blocking send, progress send, and forward.

This is safe because matching group barriers place the pre-barrier staging stores from every cooperative writer in the causal order of the leader. PTX synchronization is cumulative, so the system fence executed by the leader orders those stores before the WQE even though the leader did not issue them. Add a `"memory"` clobber to the MULTIWARP `bar.sync` so the compiler cannot move staging accesses across that handoff, and update the `CopyOp` contract.

This removes one `MEMBAR.SYS` per participating warp while retaining one fence on the WQE-posting thread. On the GB200 two-host IB duplex sweep, latency improved by about 0.7-1 us across all nine measured sizes; the 1-byte case improved from 36.4 us to 35.7 us.

Differential Revision: D113954274


