### PR TITLE
Configure direct IB pipeline geometry through transport CVARs

### DIFF
--- a/comms/ctran/algos/ReduceScatter/ReduceScatterDirectIb.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterDirectIb.cc
@@ -17,6 +17,7 @@
 #include "comms/prims/transport/MultiPeerTransport.h"
 #include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 #include "comms/utils/commSpecs.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 
 static const auto myAlgo = NCCL_REDUCESCATTER_ALGO::ctdirect_ib;
@@ -236,7 +237,8 @@ commResult_t ctranReduceScatterDirectIb(
     mpt->materializePeers(peers);
 
     const int numBlocks =
-        ctran::reducescatter::direct_ib::numBlocksForTotalBytes(totalBytes);
+        ctran::reducescatter::direct_ib::numBlocksForTotalBytes(
+            totalBytes, MCCL_MAX_NCHANNELS);
 
     comms::prims::DirectReduceScatterIbLaunchParams params{};
     params.my_rank = statex->rank();
@@ -252,7 +254,7 @@ commResult_t ctranReduceScatterDirectIb(
         recvBytes,
         statex->rank());
     params.num_blocks = numBlocks;
-    params.timeout_ms = ctran::reducescatter::direct_ib::kTimeoutMs;
+    params.timeout_ms = MCCL_ABORT_TIMEOUT_MS;
     params.stream = stream;
 
     for (int peer : peers) {

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterDirectIbConfig.h
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterDirectIbConfig.h
@@ -2,32 +2,29 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 
 namespace ctran::reducescatter::direct_ib {
 
-constexpr int kMaxNumBlocks = 8;
-constexpr std::size_t kPerChannelSize = 512ULL * 1024;
-constexpr int kPipelineDepth = 4;
-constexpr int kQpsPerConnection = 1;
-constexpr float kTimeoutMs = 30000.0f;
 constexpr std::size_t kSignalChunkThreshold = 4ULL * 1024 * 1024;
+constexpr std::size_t kSignalingDataSize = 256ULL * 1024;
 
-inline int numBlocksForTotalBytes(std::size_t totalBytes) {
+inline int numBlocksForTotalBytes(std::size_t totalBytes, int maxChannels) {
   if (totalBytes <= 32ULL * 1024) {
-    return 1;
+    return std::min(1, maxChannels);
   }
   if (totalBytes <= 64ULL * 1024) {
-    return 2;
+    return std::min(2, maxChannels);
   }
   if (totalBytes <= 128ULL * 1024) {
-    return 4;
+    return std::min(4, maxChannels);
   }
-  return kMaxNumBlocks;
+  return std::min(8, maxChannels);
 }
 
 inline std::size_t signalingDataSize(std::size_t chunkBytes) {
-  return chunkBytes <= kSignalChunkThreshold ? kPerChannelSize / 2 : 0;
+  return chunkBytes <= kSignalChunkThreshold ? kSignalingDataSize : 0;
 }
 
 } // namespace ctran::reducescatter::direct_ib

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3157,6 +3157,11 @@ cvars:
      Maximum number of logical CUDA blocks used by MCCL collectives that
      support message-size-based block tuning.
 
+ - name        : MCCL_ABORT_TIMEOUT_MS
+   type        : float
+   default     : 30000.0
+   description : Timeout in milliseconds for MCCL device-side abort polling.
+
  - name        : MCCL_TREE_FANOUT
    type        : int
    default     : 2


### PR DESCRIPTION
Summary: Reuse the landed MCCL fixed-channel IB geometry for DirectIB ReduceScatter instead of adding duplicate CTRAN CVARs. DirectIB now caps launch blocks with `MCCL_MAX_NCHANNELS` and uses the transport default signaling cadence, so per-communicator buffer hints cannot diverge from host-side geometry. Remove the old hard-coded per-channel size, pipeline depth, QP count, and block cap from `ReduceScatterDirectIbConfig.h`.

Reviewed By: saifhhasan

Differential Revision: D113055045


