### PR TITLE
MCCL AllReduce: add multi-node direct rail phase (#3330)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceImpl.h
+++ b/comms/ctran/algos/AllReduce/AllReduceImpl.h
@@ -65,6 +65,8 @@ static inline const std::string allReduceAlgoName(
       return "CtranAllReduceTreeDirect";
     case NCCL_ALLREDUCE_ALGO::cthierarchical_ring:
       return "CtranAllReduceHierarchicalRingDirect";
+    case NCCL_ALLREDUCE_ALGO::ctmdirect:
+      return "McclAllReduceDirect";
     default:
       return "Unknown";
   }

--- a/comms/ncclx/meta/algoconf/AlgoStrConv.h
+++ b/comms/ncclx/meta/algoconf/AlgoStrConv.h
@@ -75,6 +75,8 @@ inline void algoStrToVal(
     val = NCCL_ALLREDUCE_ALGO::ctree;
   } else if (str == "cthierarchical_ring") {
     val = NCCL_ALLREDUCE_ALGO::cthierarchical_ring;
+  } else if (str == "ctmdirect") {
+    val = NCCL_ALLREDUCE_ALGO::ctmdirect;
   } else {
     val = NCCL_ALLREDUCE_ALGO::orig;
   }
@@ -184,6 +186,8 @@ inline std::string algoValToStr(enum NCCL_ALLREDUCE_ALGO val) {
       return "ctree";
     case NCCL_ALLREDUCE_ALGO::cthierarchical_ring:
       return "cthierarchical_ring";
+    case NCCL_ALLREDUCE_ALGO::ctmdirect:
+      return "ctmdirect";
   }
   return "unknown";
 }

--- a/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
+++ b/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
@@ -116,6 +116,9 @@ void checkAlgoStrToVal(enum NCCL_ALLREDUCE_ALGO algo) {
     case NCCL_ALLREDUCE_ALGO::cthierarchical_ring:
       str = "cthierarchical_ring";
       break;
+    case NCCL_ALLREDUCE_ALGO::ctmdirect:
+      str = "ctmdirect";
+      break;
   }
   enum NCCL_ALLREDUCE_ALGO result;
   algoStrToVal(str, result);
@@ -222,6 +225,7 @@ TEST(AlgoStrConvTest, AllReduceCompleteness) {
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctring);
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctree);
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::cthierarchical_ring);
+  checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctmdirect);
 }
 
 TEST(AlgoStrConvTest, AllToAllVCompleteness) {

--- a/comms/prims/tests/MultiPeerTransportMultiNodeTest.cc
+++ b/comms/prims/tests/MultiPeerTransportMultiNodeTest.cc
@@ -37,6 +37,8 @@ namespace comms::prims::tests {
  */
 class MultiPeerTransportMultiNodeFixture : public MpiBaseTestFixture {
  protected:
+  static constexpr int kIbgdaMaxGroups = 17;
+
   void SetUp() override {
     MpiBaseTestFixture::SetUp();
     CUDACHECK_TEST(cudaSetDevice(localRank));
@@ -118,6 +120,7 @@ class MultiPeerTransportMultiNodeFixture : public MpiBaseTestFixture {
         .ibConfig =
             {
                 .cudaDevice = localRank,
+                .max_num_channels = kIbgdaMaxGroups,
             },
         .topoConfig =
             {
@@ -274,6 +277,7 @@ TEST_F(MultiPeerTransportMultiNodeFixture, HostAccessorsMultiNode) {
   }
 
   auto states = create_transport_states();
+  EXPECT_EQ(states->ibgda_max_groups(), kIbgdaMaxGroups);
   states->exchange();
 
   // NVL peer accessor — always has at least same-node peers.

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -192,6 +192,13 @@ MultiPeerTransport::~MultiPeerTransport() {
   free_device_handle();
 }
 
+std::optional<int> MultiPeerTransport::ibgda_max_groups() const {
+  if (!ibgdaTransport_) {
+    return std::nullopt;
+  }
+  return ibgdaTransport_->maxGroups();
+}
+
 void MultiPeerTransport::setExternalNvlDataBuffers(
     ExternalStagingBuffers externalStagingBuffers) {
   if (nvlTransport_) {

--- a/comms/prims/transport/MultiPeerTransport.h
+++ b/comms/prims/transport/MultiPeerTransport.h
@@ -209,8 +209,15 @@ class MultiPeerTransport {
 
   bool is_lazy_mode() const;
 
-  // Every requested edge must be requested by both endpoint ranks in the same
-  // connect round. Peer-vector order may differ between ranks.
+  /*
+   * Actual channel capacity of the configured IBGDA transport.
+   */
+  std::optional<int> ibgda_max_groups() const;
+
+  /*
+   * Every requested edge must be requested by both endpoint ranks in the same
+   * connect round. Peer-vector order may differ between ranks.
+   */
   void materializePeers(const std::vector<int>& peers);
 
   void connectPeers();

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2709,7 +2709,7 @@ cvars:
  - name        : NCCL_ALLREDUCE_ALGO
    type        : enum
    default     : orig
-   choices     : orig, ctran, ctdirect, ctring, ctree, cthierarchical_ring
+   choices     : orig, ctran, ctdirect, ctring, ctree, cthierarchical_ring, ctmdirect
    description : |-
      The algorithm to use for Allreduce communication
      orig - Copy-based algorithm
@@ -2718,6 +2718,7 @@ cvars:
      ctring - ctran-based ring algorithm
      ctree - Ctran-based tree algorithm (Pipes-native)
      cthierarchical_ring - Ctran-based hierarchical ring algorithm (Prims-native): NVL ReduceScatter + inter-node IBGDA ring + NVL AllGather
+     ctmdirect - MCCL-native direct algorithm (Prims-native): NVL ReduceScatter + flat rail-based inter-node IB + NVL AllGather
 
  - name        : NCCL_ALLREDUCE_TYPE
    type        : enum


### PR DESCRIPTION
Summary:

Add the native PIPES-backed inter-node phase for MCCL `direct`, selected temporarily through the legacy `NCCL_ALLREDUCE_ALGO=ctmdirect` compatibility value. Build same-local-rank rails from MCCL topology, validate IBGDA peers and actual transport group bounds on the host, then run a fused rail reduce-scatter and all-gather between the shared NVL phases. The device schedule uses concurrent blocking receive/send subgroups, reserved full-block phase-barrier synchronization between and after the rail phases, and a receive-copy policy whose cooperative tile width matches the receive subgroup. The effective collective timeout is resolved once and propagated through NVL and IB phases.

Reviewed By: snarayankh

Differential Revision: D113184607


