### PR TITLE
Add OOO_RQ integration + cvar-gated BusCard wire format (#3332)

### DIFF
--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -20,6 +20,7 @@
 #include "comms/ctran/backends/ib/CtranIbVc.h"
 #include "comms/ctran/backends/ib/ibutils.h"
 #include "comms/ctran/bootstrap/Socket.h"
+#include "comms/ctran/ibverbx/Mlx5dv.h"
 #include "comms/ctran/interfaces/ICtran.h"
 #include "comms/ctran/utils/ArgCheck.h"
 #include "comms/ctran/utils/Checks.h"
@@ -528,6 +529,44 @@ void CtranIb::init(
     }
 
     if (foundPort) {
+      // Probe OOO_DP per device. Default oooRqSize=0 (unsupported); only
+      // overwritten on a successful cap query. Any failure path — cvar off,
+      // libmlx5 symbol null, or driver too old to populate the mask bit —
+      // leaves it at 0, and this device silently drops out of localOooRq_
+      // downstream.
+      devices[device].oooRqSize = 0;
+      if (NCCL_CTRAN_IB_ENABLE_OOO_RQ) {
+        auto maybeCtx = ibverbx::Mlx5dv::queryDevice(
+            s->ibvDevices[singletonDevIdx].context(),
+            ibverbx::MLX5DV_CONTEXT_MASK_OOO_RECV_WRS);
+        if (maybeCtx.hasError()) {
+          // Covers: libmlx5 dlopen failed (EOPNOTSUPP from null symbol);
+          // driver didn't populate the requested caps (EOPNOTSUPP from
+          // firmware/kernel too old); any other errno from the driver.
+          CLOGF(
+              WARN,
+              "CTRAN-IB: OOO_RQ detection FAILED on {}: {} (errno {}).",
+              devices[device].devName,
+              maybeCtx.error().errStr,
+              maybeCtx.error().errNum);
+        } else if (maybeCtx->ooo_recv_wrs_caps.max_rc == 0) {
+          // Driver populated the caps struct but HW/firmware reports zero
+          // capability — the query API works; the feature is just absent.
+          CLOGF(
+              WARN,
+              "CTRAN-IB: OOO_RQ not supported by HW on {}: "
+              "ooo_recv_wrs_caps.max_rc == 0.",
+              devices[device].devName);
+        } else {
+          devices[device].oooRqSize = maybeCtx->ooo_recv_wrs_caps.max_rc;
+          CLOGF(
+              INFO,
+              "CTRAN-IB: OOO_RQ detected on {}: max_rc={}.",
+              devices[device].devName,
+              devices[device].oooRqSize);
+        }
+      }
+
       CLOGF_SUBSYS(
           INFO,
           INIT,

--- a/comms/ctran/backends/ib/CtranIbBase.h
+++ b/comms/ctran/backends/ib/CtranIbBase.h
@@ -41,6 +41,12 @@ struct CtranIbDevice {
   ibverbx::IbvCq* ibvCq;
   uint8_t port{0};
   std::string devName;
+
+  // Max recv WRs the mlx5 provider will place out-of-order per RC QP when
+  // MLX5DV_QP_CREATE_OOO_DP is set. Populated from mlx5dv_query_device's
+  // ooo_recv_wrs_caps.max_rc when NCCL_CTRAN_IB_ENABLE_OOO_RQ is true; 0
+  // means the device does not advertise OOO recv-wrs capability.
+  uint32_t oooRqSize{0};
 };
 
 /**

--- a/comms/ctran/backends/ib/CtranIbVc.cc
+++ b/comms/ctran/backends/ib/CtranIbVc.cc
@@ -38,6 +38,12 @@ struct BusCard {
       uint16_t lids[CTRAN_MAX_IB_DEVICES_PER_RANK];
     } ib;
   } u;
+  // OOO_RQ capability advertised to the peer during bootstrap. 1 iff the local
+  // peer set NCCL_CTRAN_IB_ENABLE_OOO_RQ=true AND every active device
+  // exposes ooo_recv_wrs_caps.max_rc >= MAX_RECV_WR. setupVc() cross-checks
+  // both sides and fail-closes if the local peer requested OOO_RQ but the
+  // negotiation doesn't yield mutual support.
+  uint8_t oooRq;
 };
 
 // Apply the per-VC QP configuration. MAX_QPS is supplied by the caller
@@ -431,6 +437,31 @@ std::size_t CtranIbVirtualConn::getBusCardSize() {
 
 commResult_t CtranIbVirtualConn::getLocalBusCard(void* localBusCard) {
   BusCard* busCard = reinterpret_cast<BusCard*>(localBusCard);
+
+  // Compute local OOO_RQ support from per-device caps probed at init.
+  // Require every active device's HW to accept at least MAX_RECV_WR OOO
+  // placements — matches the per-QP pre-post depth we run with.
+  localOooRq_ = NCCL_CTRAN_IB_ENABLE_OOO_RQ;
+  for (int device : activeDevices_) {
+    if (devices_[device].oooRqSize < static_cast<uint32_t>(MAX_RECV_WR)) {
+      localOooRq_ = false;
+      break;
+    }
+  }
+
+  // Data QPs get MLX5DV_QP_CREATE_OOO_DP when local support is confirmed
+  // (localOooRq_). If the user requested OOO_RQ but local caps are missing,
+  // we still create plain QPs and advertise oooRq=0; setupVc() on both peers
+  // evaluates the negotiation symmetrically and fail-closes (WARN +
+  // commSystemError) if the request can't be honored.
+  if (localOooRq_) {
+    CLOGF(
+        INFO,
+        "CTRAN-IB-VC: OOO_RQ ENABLED — data QPs created with "
+        "MLX5DV_QP_CREATE_OOO_DP (per-device oooRqSize >= MAX_RECV_WR={}).",
+        MAX_RECV_WR);
+  }
+
   // assuming all devices portAttr
   ibverbx::ibv_port_attr portAttr;
   const int ctrlDevice = ctrlDevice_;
@@ -491,13 +522,17 @@ commResult_t CtranIbVirtualConn::getLocalBusCard(void* localBusCard) {
           devices_[device].port,
           qpAccessFlags | ibverbx::IBV_ACCESS_REMOTE_ATOMIC));
     }
-    // maxNumQps_ is always a multiple of activeDevices_.size()
+    // Data QPs may opt into OOO_DP when local caps confirm it (localOooRq_).
+    // Control / notify / atomic QPs stay on the plain createRcQp path — their
+    // CQE handler (processCqeImpl) matches by FIFO deque order and would
+    // break under reordering.
     for (int i = 0; i < numQpsPerDevice_; i++) {
-      auto maybeQp = createRcQp(
+      auto maybeQp = createRcQpWithOooDp(
           devices_[device].ibvPd,
           devices_[device].ibvCq->cq(),
           MAX_SEND_WR,
-          MAX_RECV_WR);
+          MAX_RECV_WR,
+          localOooRq_);
       FOLLY_EXPECTED_CHECK(maybeQp);
       FOLLY_EXPECTED_CHECK(
           initQp(*maybeQp, devices_[device].port, qpAccessFlags));
@@ -531,11 +566,42 @@ commResult_t CtranIbVirtualConn::getLocalBusCard(void* localBusCard) {
   mtu_ = 128 * (1 << static_cast<int>(portAttr.active_mtu));
   maxMsgSize_ = portAttr.max_msg_sz;
 
+  busCard->oooRq = localOooRq_ ? 1 : 0;
+
   return commSuccess;
 }
 
 commResult_t CtranIbVirtualConn::setupVc(void* remoteBusCard) {
   BusCard* remoteBusCardStruct = reinterpret_cast<BusCard*>(remoteBusCard);
+
+  // OOO_RQ negotiation: fail-closed at the receive side so both peers
+  // evaluate symmetrically and abort together. Only fires when the local
+  // user explicitly requested OOO_RQ; peers with the cvar off ignore the
+  // remote's advertisement.
+  if (NCCL_CTRAN_IB_ENABLE_OOO_RQ) {
+    const bool remoteOooRq = (remoteBusCardStruct->oooRq != 0);
+    if (!localOooRq_ || !remoteOooRq) {
+      std::string perDevice;
+      for (int device : activeDevices_) {
+        perDevice += fmt::format(
+            " [dev={} name={} oooRqSize={}]",
+            device,
+            devices_[device].devName,
+            devices_[device].oooRqSize);
+      }
+      CLOGF(
+          WARN,
+          "CTRAN-IB-VC: NCCL_CTRAN_IB_ENABLE_OOO_RQ=true requested but "
+          "negotiation failed with peer {}: localOooRq={}, remoteOooRq={} "
+          "(need both sides supported). Local per-device state:{}. Aborting "
+          "connection (no silent fallback).",
+          peerRank,
+          localOooRq_,
+          remoteOooRq,
+          perDevice);
+      return commSystemError;
+    }
+  }
 
   // Validate that QPs have been initialized via getLocalBusCard()
   if (!areQpsInitialized()) {

--- a/comms/ctran/backends/ib/CtranIbVc.h
+++ b/comms/ctran/backends/ib/CtranIbVc.h
@@ -1908,6 +1908,10 @@ class CtranIbVirtualConn {
   const int igetFastQpIdx_{0};
 
   bool isReady_{false};
+  // Local OOO_RQ eligibility: user set NCCL_CTRAN_IB_ENABLE_OOO_RQ=true AND
+  // every active device exposes ooo_recv_wrs_caps.max_rc >= MAX_RECV_WR.
+  // Advertised to the peer via BusCard::oooRq and cross-checked in setupVc.
+  bool localOooRq_{false};
   std::vector<CtranIbDevice> devices_;
   // Set of IB device indices this VC owns QPs on (precomputed by
   // ctran::ib::VcLayout and supplied by CtranIb). For legacy

--- a/comms/ctran/backends/ib/VcState.cc
+++ b/comms/ctran/backends/ib/VcState.cc
@@ -57,10 +57,12 @@ commResult_t VcState::setupAndPublishVc(
 
   // Setup each VC under its own per-VC lock. The VC is not yet exposed
   // to local rank; the lock is taken to follow VC thread-safety semantics.
+  // Use return-style propagation (not throw) so that failures such as
+  // NCCL_CTRAN_IB_ENABLE_OOO_RQ fail-closed surface as commSystemError to
+  // the caller
   for (size_t i = 0; i < vcs.size(); ++i) {
     const std::lock_guard<std::mutex> lock(vcs[i]->mutex);
-    FB_COMMCHECKTHROW_EX(
-        vcs[i]->setupVc((void*)remoteVcIdentifiers[i].data()), *logData_);
+    FB_COMMCHECK(vcs[i]->setupVc((void*)remoteVcIdentifiers[i].data()));
   }
 
   {

--- a/comms/ctran/backends/ib/docs/ooo_rq_design.md
+++ b/comms/ctran/backends/ib/docs/ooo_rq_design.md
@@ -1,0 +1,155 @@
+# NCCL_CTRAN_IB_ENABLE_OOO_RQ — Design
+
+Short design doc for the ctran-scoped out-of-order receive-queue opt-in.
+For implementation details and file references, see `ooo_rq.md`.
+
+## Purpose
+
+Enable ctran data QPs to accept out-of-order packet arrival on the receiver
+side, so `WRITE_WITH_IMM` traffic can be spread across multiple fabric paths
+by adaptive-routing switches on CX8 NICs.
+
+## Contract
+
+```
+NCCL_CTRAN_IB_ENABLE_OOO_RQ = false (default) → OOO_RQ off; ctran behaves exactly as before
+NCCL_CTRAN_IB_ENABLE_OOO_RQ = true            → ctran negotiates OOO_RQ per connection;
+                                                 fail-closed if any prereq is missing
+```
+
+Fail-closed means: if the user asks for OOO_RQ but the local NIC or the peer
+can't support it, the connection is aborted with a WARN at BusCard receive
+time. There is no silent fallback to non-OOO mode.
+
+## Prerequisites checked per active device at init
+
+1. **Provider is mlx5** (implicit — checked via `mlx5dv_query_device` succeeding)
+2. **`ooo_recv_wrs_caps.max_rc >= 128`** — HCA firmware must expose enough
+   per-QP OOO recv-WR capacity to cover ctran's `MAX_RECV_WR`
+
+If any device fails either check, the local peer sets `localOooRq_ = false`
+and advertises `oooRq = 0` in the BusCard. The remote peer will then observe
+the mismatch on the receive side and abort with a WARN.
+
+**`MLX5DV_QP_CREATE_OOO_DP` must be set on both sender and receiver.**
+Per the man page: *"The flag [MLX5DV_QP_CREATE_OOO_DP], when set, must be set
+both on the sender and receiver side of a QP."* Ctran naturally satisfies this
+since both peers create their data QPs from the same code path with the same
+cvar-driven decision.
+
+## Design
+
+### Where the mechanism lives
+
+Ctran's IB backend already uses N data QPs per VC (`maxNumQps_`, default 16)
+and sends each fragment as `WRITE_WITH_IMM` when in DQPLB mode. OOO_RQ integrates
+by flipping a single flag on those data QPs at creation time — `MLX5DV_QP_CREATE_OOO_DP`.
+
+Everything else about the send/receive pattern is unchanged:
+- **Data QPs get OOO_DP.** N per VC.
+- **Control / notify / atomic QPs do NOT get OOO_DP.** Their CQE handlers
+  rely on FIFO order and would break under packet reordering.
+- **DqplbSeqTracker still runs.** OOO_RQ handles within-QP packet reorder;
+  cross-QP reassembly is still ctran's job via the seq numbers in IMM.
+
+### Peer negotiation
+
+Ctran's `BusCard` carries a single `oooRq` byte (0 or 1) advertising local
+OOO_RQ eligibility. The field is always present on the wire — no
+versioning.
+
+Both peers exchange their advertisement. On the receive side, if
+`NCCL_CTRAN_IB_ENABLE_OOO_RQ = true` locally and either side reports
+`oooRq = 0`, the connection is aborted with a WARN — evaluated symmetrically
+so both peers fail together and neither hangs waiting on a peer that already
+gave up. Peers with the cvar off ignore the remote's advertisement (they
+never asked for OOO_RQ).
+
+### Data flow when OOO_RQ is enabled
+
+```
+Sender (ctran DQPLB):
+  For each of 16 data QPs:
+    post 1 WRITE_WITH_IMM(seq, notify_bit_on_last) per fragment
+    ↓ (chunk = put_size / 16)
+Fabric:
+  Switch AR policy may spray packets across paths       ← depends on switch config,
+                                                          out of ctran's scope
+Receiver NIC (CX8 + OOO_RQ flag set on the RC QP):
+  Buffers out-of-order packets                          ← what OOO_RQ enables
+  Fires IMM CQE only after all packets of a WQE land
+Receiver software (ctran):
+  DqplbSeqTracker reassembles per-fragment order across the 16 QPs
+  Fires application waitNotify() when notify_bit seq arrives in-order
+```
+
+The OOO_RQ change is purely a receiver-side NIC behavior toggle: absorb
+per-QP in-fragment packet reordering. Nothing else in ctran changes.
+
+## What the user sees
+
+At init (per device):
+```
+CTRAN-IB: OOO_RQ detected on mlx5_2: max_rc=16384.
+```
+
+At each peer VC connection (when OOO_RQ negotiated successfully):
+```
+CTRAN-IB-VC: OOO_RQ ENABLED — creating 16 data QP(s) with MLX5DV_QP_CREATE_OOO_DP for peer 4
+  (per-device oooRqSize checked >= MAX_RECV_WR=128). Control/notify/atomic QPs stay on the plain path.
+```
+
+When negotiation fails (fail-closed, at receive side on both peers):
+```
+CTRAN-IB-VC: NCCL_CTRAN_IB_ENABLE_OOO_RQ=true requested but negotiation failed
+  with peer 4: localOooRq=0, remoteOooRq=0 (need both sides supported).
+  Local per-device state: [dev=0 name=mlx5_2 oooRqSize=0] [dev=1 name=mlx5_3 oooRqSize=0].
+  Aborting connection (no silent fallback).
+```
+
+## Failure modes and diagnostics
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| `OOO_RQ detection FAILED ... symbol unavailable` | libmlx5 not loaded or dlvsym version-tag mismatch | Check `ldconfig -p \| grep mlx5`; confirm ibverbx loaded the symbol via unversioned dlsym |
+| `did not populate OOO_RECV_WRS_CAPS mask bit` | Driver/firmware too old to expose caps | Check FW version on the CX8 NIC; upgrade if below 1.26-era |
+| `oooRqSize=0` in fail-closed WARN | Hardware doesn't expose caps for that device | Confirm mlx5 provider and firmware version |
+| Connection succeeds but no perf gain | Fabric switch not spraying WRITE_WITH_IMM on this TC | Escalate to network team for TC AR policy on the traffic class in use |
+
+## Scope boundary
+
+**In scope for this cvar:**
+- QP-creation flag on ctran data QPs
+- Bilateral peer negotiation via extended BusCard
+- Fail-closed contract when requested-but-unsupported
+
+**Out of scope (handled elsewhere or unchanged):**
+- Stock NCCL net_ib OOO_RQ — separate cvar `NCCL_IB_OOO_RQ`
+- Fabric switch AR policy — network-team owned
+- CX8 NIC firmware behavior — NVIDIA owned
+- Ctran spray mode — unaffected; OOO_RQ delivers no benefit to spray's
+  plain-WRITE data path (separate notify QP has no fence pattern to eliminate)
+
+## Interaction with other cvars
+
+| Cvar | Interaction |
+|---|---|
+| `NCCL_CTRAN_IB_VC_MODE` | Recommended: `dqplb`. Spray mode gets no OOO_RQ benefit. |
+| `NCCL_CTRAN_BACKENDS` | Must include `ib` for ctran to be the IB path |
+| `NCCL_IB_OOO_RQ` | Independent — stock NCCL's opt-in, unaffected by this cvar |
+| `NCCL_IB_ADAPTIVE_ROUTING` | Not read by ctran. Users still need fabric AR for the perf gain, but that's controlled by fabric config, not this cvar. |
+
+## Verification
+
+Four progressive signals, from weakest to strongest:
+
+1. Init log shows `OOO_RQ detected on mlx5_X: max_rc=...` on every device
+2. No `negotiation failed` WARN at connection time
+3. Per-VC `OOO_RQ ENABLED — data QPs created with MLX5DV_QP_CREATE_OOO_DP` log
+4. A/B perf comparison of `NCCL_CTRAN_IB_ENABLE_OOO_RQ=false` vs `=true` on
+   identical workload shows measurable busbw delta at mid/large sizes
+
+Signals 1-3 confirm the code path is exercised end-to-end (the QP flag reaches
+the driver). Signal 4 confirms it delivers value on the specific fabric —
+if it doesn't, the code is still correct but the fabric-team config is the
+remaining lever.

--- a/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
@@ -556,6 +556,8 @@ std::string createValidRemoteBusCard() {
         uint16_t lids[CTRAN_MAX_IB_DEVICES_PER_RANK];
       } ib;
     } u;
+    // OOO_RQ capability advertised to peer; must match CtranIbVc.cc BusCard.
+    uint8_t oooRq;
   };
 
   BusCard busCard{};
@@ -576,6 +578,8 @@ std::string createValidRemoteBusCard() {
     busCard.u.eth.spns[i] = 0xfe80000000000000ULL; // Link-local subnet prefix
     busCard.u.eth.iids[i] = 0x0000000000000001ULL + i; // Interface ID
   }
+
+  busCard.oooRq = 0;
 
   return std::string(reinterpret_cast<const char*>(&busCard), sizeof(BusCard));
 }
@@ -854,6 +858,40 @@ TEST_P(CtranIbAbortCtrlMsgTest, NoAbortNoError) {
       });
 
   testAbortedCtrlMsg(std::move(mockSocket), false);
+  EXPECT_FALSE(abortCtrl_->isAborted());
+}
+
+// Fail-closed contract: with NCCL_CTRAN_IB_ENABLE_OOO_RQ=true, if either side
+// cannot support OOO_RQ, setupVc must return commSystemError instead of
+// silently degrading. createValidRemoteBusCard() advertises oooRq=0, and on
+// any host without OOO_RQ HW localOooRq_ is also false, so the negotiation
+// must fail.
+TEST_P(CtranIbAbortCtrlMsgTest, EnableOooRqRemoteMismatchFailsCleanly) {
+  EnvRAII<bool> enableOooRq(NCCL_CTRAN_IB_ENABLE_OOO_RQ, /*newValue=*/true);
+
+  auto mockSocket =
+      std::make_unique<StrictMock<ctran::bootstrap::testing::MockISocket>>();
+
+  std::string remoteBusCard = createValidRemoteBusCard();
+
+  EXPECT_CALL(*mockSocket, connect(_, _, _, _, _))
+      .WillOnce([&](const folly::SocketAddress& addr,
+                    const std::string& ifName,
+                    const std::chrono::milliseconds timeout,
+                    size_t numRetries,
+                    bool async) { return 0; });
+
+  EXPECT_CALL(*mockSocket, send(_, _))
+      .WillRepeatedly([&](const void* buf, const size_t len) { return 0; });
+
+  EXPECT_CALL(*mockSocket, recv(_, _))
+      .WillRepeatedly([&](void* buf, const size_t len) {
+        std::memcpy(
+            buf, remoteBusCard.data(), std::min(len, remoteBusCard.size()));
+        return 0;
+      });
+
+  testAbortedCtrlMsg(std::move(mockSocket), /*shouldFail=*/true);
   EXPECT_FALSE(abortCtrl_->isAborted());
 }
 

--- a/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
@@ -18,6 +18,8 @@
 #include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/backends/ib/CtranIbBase.h"
 #include "comms/ctran/bootstrap/Socket.h"
+#include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/ibverbx/Mlx5dv.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
 #include "comms/ctran/tests/CtranTestUtils.h"
@@ -1281,6 +1283,47 @@ TEST_P(CtranIbTestParam, GpuMemPutNotify) {
   runPutNotify(
       /* bufCount */ 8192,
       /* numPuts*/ 1000,
+      /*localSignal*/ true,
+      NotifyMode::notifyAll,
+      /*isGpuMem*/ true);
+}
+
+// End-to-end put+notify with NCCL_CTRAN_IB_ENABLE_OOO_RQ=true. Verifies the
+// full OOO_RQ path on real HW: cap detection populates devices[i].oooRqSize,
+// getLocalBusCard advertises OOO_RQ via BusCard.oooRq, setupVc symmetrically
+// checks the negotiation and either accepts or fail-closes, data QPs are
+// created with MLX5DV_QP_CREATE_OOO_DP, and RDMA put+notify completes
+// correctly.
+//
+// Skips when the local device doesn't advertise OOO_RECV_WRS caps
+// (max_rc >= 128), avoiding false failures on hosts without CX8 hardware.
+TEST_F(CtranIbTest, GpuMemPutNotifyWithOooRq) {
+  // Cap probe on device 0 as a proxy for what CtranIbSingleton will see.
+  ASSERT_TRUE(ibverbx::ibvInit());
+  auto devices = ibverbx::IbvDevice::ibvGetDeviceList({std::string("mlx5_")});
+  if (!devices || devices->empty()) {
+    GTEST_SKIP() << "No mlx5 devices present; OOO_RQ not applicable";
+  }
+  auto maybeCtx = ibverbx::Mlx5dv::queryDevice(
+      devices->at(0).context(), ibverbx::MLX5DV_CONTEXT_MASK_OOO_RECV_WRS);
+  if (maybeCtx.hasError()) {
+    GTEST_SKIP() << "mlx5dv_query_device unavailable: "
+                 << maybeCtx.error().errStr;
+  }
+  if (!(maybeCtx->comp_mask & ibverbx::MLX5DV_CONTEXT_MASK_OOO_RECV_WRS) ||
+      maybeCtx->ooo_recv_wrs_caps.max_rc < 128) {
+    GTEST_SKIP() << "Device does not advertise sufficient OOO recv-wrs "
+                    "capability (need max_rc >= 128)";
+  }
+
+  EnvRAII<bool> enableOooRq(NCCL_CTRAN_IB_ENABLE_OOO_RQ, /*newValue=*/true);
+  this->printTestDesc(
+      "GpuMemPutNotifyWithOooRq",
+      "Verify OOO_RQ end-to-end: OOO_DP data QPs, BusCard negotiation, "
+      "and put+notify semantics all work correctly with real CX8 hardware.");
+  runPutNotify(
+      /* bufCount */ 8192,
+      /* numPuts*/ 100,
       /*localSignal*/ true,
       NotifyMode::notifyAll,
       /*isGpuMem*/ true);

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1977,6 +1977,17 @@ cvars:
      Number of main IB QPs owned by each physical CUDA block on each NIC.
      Puts from a block round-robin across its NIC-first QP lanes.
 
+ - name        : NCCL_CTRAN_IB_ENABLE_OOO_RQ
+   type        : bool
+   default     : false
+   description : |-
+     Enable out-of-order receive queue for ctran IB backend. When true,
+     ctran data QPs are created with MLX5DV_QP_CREATE_OOO_DP so
+     WRITE_WITH_IMM traffic can benefit from fabric packet spraying on CX8+
+     adaptive-routing fabrics. Fail-closed: if the local NIC doesn't
+     expose ooo_recv_wrs_caps.max_rc >= 128 or the peer doesn't advertise
+     support, the connection is aborted.
+
  - name        : NCCL_CTRAN_IBGDA_SIGNAL_COUNT
    type        : uint64_t
    default     : 1


### PR DESCRIPTION
Summary:

Integrates the ibverbx OOO_RQ surface (parent diff) into ctran's IB
backend and adds peer negotiation.

- `CtranIb.cc` / `CtranIbBase.h` — per-device caps detection at init
  via `Mlx5dv::queryDevice()`. Populates `devices[i].oooRqSize` from
  reported `ooo_recv_wrs_caps.max_rc`.
- `CtranIbVc.cc` — VC-level OOO_RQ negotiation:
  - `localOooRq_`: true iff every active device has
    `oooRqSize >= MAX_RECV_WR`.
  - Data QPs created with `MLX5DV_QP_CREATE_OOO_DP` when
    `NCCL_CTRAN_IB_OOO_RQ=1 && localOooRq_`.
  - `setupVc()` cross-checks the peer's advertisement and refuses
    the connection (fail-closed) if local requested OOO_RQ but peer
    doesn't support it.
- BusCard wire format is versioned (v1 → v2 adds
  `{version, oooRq, reserved[6]}` tail) and **gated on the cvar** so
  the on-wire layout only changes when a peer explicitly opts in.
  Backward-compat with pre-OOO_RQ ctran peers is preserved when the
  cvar is off. Size constants asserted at compile time
  (`v2 > v1`, `v1 == offsetof(version)`).
- `NCCL_CTRAN_IB_OOO_RQ` cvar declared in `nccl_cvars.yaml`.
- `ooo_rq_design.md` — initial design doc (consolidated later in stack).

Differential Revision: D113578039


