### PR TITLE
Disable BackendWrapperShutdownTest.py::test_mixed_backend_destroy_ide…

### DIFF
--- a/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
+++ b/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
@@ -162,8 +162,8 @@ class TestBackendWrapperShutdown(unittest.TestCase):
         shuts down both sub-backends, which share one ``TorchComm``.
         Without idempotent ``shutdown``, the second call raises
         ``TorchCommNCCL already finalized``."""
-        if os.environ["TEST_BACKEND"] not in ["nccl", "xccl"]:
-            self.skipTest("mixed backend test is nccl/xccl-specific")
+        if os.environ["TEST_BACKEND"] not in ["nccl"]:
+            self.skipTest("mixed backend test is nccl-specific")
         if _torch_predates_pr_182057():
             self.skipTest(
                 f"torch {torch.__version__} predates pytorch/pytorch#182057 "


### PR DESCRIPTION
This test (Disable BackendWrapperShutdownTest.py::test_mixed_backend_destroy_idempotent) was enable for XCCL, which is not functional anymore for external changes. We are disabling the test for now for CI to pass while we investigate internally.

 