### PR TITLE
Use leader-only system fence for puts

### DIFF
--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -291,12 +291,14 @@ class P2pIbrcTransportDevice {
       if (localBuf.ptr == nullptr || remoteBuf.ptr == nullptr) {
         trap("P2pIbrcTransportDevice: put data buffer is null");
       }
-      threadfence_system();
     }
     group.sync();
 
     IbLocalCompletionTicket completion;
     if (group.is_leader()) {
+      if (hasData) {
+        threadfence_system();
+      }
       validate_group_scope(group);
       const uint32_t queueId = select_put_queue_id(group, IbDirection::Send);
       // queue_for_lane encodes the lane ordinal modulo the total lane count.


### PR DESCRIPTION
Summary:
Move the system fence in `P2pIbrcTransportDevice::put` after the cooperative-group barrier and execute it only on the descriptor-enqueuing leader. The barrier hands cooperative writers stores to the leader; the portable system fence orders them before the release publication of `ready_seq`, which the CPU proxy acquire-loads before posting the RDMA work request.

This child diff relies on the cumulative `ThreadGroup` barrier semantics introduced by D113954274. Keep the internal fence for raw single-thread puts; shared send/progress paths retain their existing outer leader fence.

Differential Revision: D114103576


