### PR TITLE
Make multi-peer IB transport always on demand (#3335)

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -118,12 +118,6 @@ uint64_t Ctran::getCtranOpCount() const {
 }
 
 #if defined(ENABLE_PRIMS)
-comms::prims::Transport* CtranComm::getMultiPeerTransportsPtr() const {
-  if (!multiPeerTransport_) {
-    return nullptr;
-  }
-  return multiPeerTransport_->get_device_handle().transports.data();
-}
 comms::prims::Transport* CtranComm::getMultiPeerTransportsPtr(
     const std::vector<int>& peers) {
   if (!multiPeerTransport_) {
@@ -132,9 +126,6 @@ comms::prims::Transport* CtranComm::getMultiPeerTransportsPtr(
   return multiPeerTransport_->get_device_handle(peers).transports.data();
 }
 #else
-comms::prims::Transport* CtranComm::getMultiPeerTransportsPtr() const {
-  return nullptr;
-}
 comms::prims::Transport* CtranComm::getMultiPeerTransportsPtr(
     const std::vector<int>& /*peers*/) {
   return nullptr;

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -38,12 +38,16 @@ using meta::comms::CommBackend;
 // Per-communicator Prims transport overrides.
 // -1 means use CVAR default.
 struct ctranPipesConfig {
+  // -1 uses NCCL_CTRAN_USE_PIPES. MCCL sets this explicitly so its Prims
+  // policy does not affect NCCLX or standalone Ctran communicators.
+  int64_t enablePrims{-1};
   int64_t nvlChunkSize{-1};
-  bool ibLazyConnect{false};
+  bool ibLazyConnect{true};
   int64_t ibgdaDataBufferSize{-1};
 
   bool operator==(const ctranPipesConfig& other) const {
-    return nvlChunkSize == other.nvlChunkSize &&
+    return enablePrims == other.enablePrims &&
+        nvlChunkSize == other.nvlChunkSize &&
         ibLazyConnect == other.ibLazyConnect &&
         ibgdaDataBufferSize == other.ibgdaDataBufferSize;
   }
@@ -182,16 +186,8 @@ class CtranComm {
     return parentRanks_;
   }
 
-  // Get a pointer to the Transport array from MultiPeerTransport,
-  // indexed by global rank. Returns nullptr if MultiPeerTransport is not
-  // initialized.
-  comms::prims::Transport* getMultiPeerTransportsPtr() const;
-
-  // Lazy-safe overload: materializes `peers` (via get_device_handle(peers))
-  // and returns the Transport array pointer. Required in lazy-connect mode,
-  // where the no-arg overload throws. Non-const because materialization
-  // mutates transport state. An empty `peers` list materializes nothing and
-  // still returns a valid pointer (for ranks that use no IB slots).
+  // Materializes `peers` and returns the Transport array indexed by global
+  // rank. An empty peer list initializes no IB transport slots.
   comms::prims::Transport* getMultiPeerTransportsPtr(
       const std::vector<int>& peers);
 

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -260,8 +260,6 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
           static_cast<uint8_t>(NCCL_CTRAN_IBGDA_RNR_RETRY);
     }
     config.ibConfig.ibLazyConnect = pc.ibLazyConnect;
-    config.ibConfig.materializePeerTimeoutMs =
-        NCCL_CTRAN_IBGDA_MATERIALIZE_PEER_TIMEOUT_MS;
     if (NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC <= 0) {
       CLOGF(
           ERR,
@@ -328,7 +326,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
 
     CLOGF(
         INFO,
-        "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} enableMultimem={} multimemSignals={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={} materializePeerTimeoutMs={}",
+        "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} enableMultimem={} multimemSignals={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={}",
         comm->statex_->rank(),
         config.nvlConfig.pipelineDepth,
         nvlSharedDevbufSize,
@@ -345,8 +343,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         static_cast<int>(config.topoConfig.mnnvlMode),
         config.ibConfig.dataBufferSize,
         config.ibConfig.qpDepth,
-        config.ibConfig.ibLazyConnect,
-        config.ibConfig.materializePeerTimeoutMs);
+        config.ibConfig.ibLazyConnect);
 
     CLOGF(
         INFO,

--- a/comms/ctran/algos/AllToAll/AllToAll.cc
+++ b/comms/ctran/algos/AllToAll/AllToAll.cc
@@ -256,6 +256,8 @@ bool ctranAllToAllSupport(
 // IB support will be added in a follow-up via IBGDA (not CPU proxy).
 // ============================================================================
 
+bool ctranDeviceAllToAllvSupport(CtranComm* comm);
+
 commResult_t ctranDeviceAllToAllv(
     const void* sendbuff,
     void* recvbuff,
@@ -267,6 +269,13 @@ commResult_t ctranDeviceAllToAllv(
     int64_t sendcountsMultiplier,
     int64_t recvcountsMultiplier,
     const std::unordered_map<std::string, std::string>& hints) {
+  if (!ctranDeviceAllToAllvSupport(comm)) {
+    CERR(
+        commInvalidArgument,
+        "DeviceAllToAllvPipes requires an initialized NVLink-only communicator");
+    return commInvalidArgument;
+  }
+
   auto opCount = comm->ctran_->getOpCount();
 
   KernelConfig config = KernelConfig(
@@ -333,8 +342,8 @@ bool ctranDeviceAllToAllvSupport(CtranComm* comm) {
 
   // NVLink domain only: verify ALL peers are reachable via NVLink (or self).
   // Reject communicators with any IB-only peers to prevent silent data loss.
-  // Use host-side API — getMultiPeerTransportsPtr() returns a device pointer
-  // that cannot be dereferenced on the host.
+  // Use host-side API — getMultiPeerTransportsPtr(peers) returns a device
+  // pointer that cannot be dereferenced on the host.
   const auto statex = comm->statex_.get();
   for (int rank = 0; rank < statex->nRanks(); rank++) {
     auto type = comm->multiPeerTransport_->get_transport_type(rank);

--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.cc
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.cc
@@ -158,7 +158,7 @@ commResult_t setupKernelConfig(
   }
 
   // Set transport array from MultiPeerTransport
-  kernArgs.transports = comm->getMultiPeerTransportsPtr();
+  kernArgs.transports = comm->getMultiPeerTransportsPtr({});
 
   // LL128 threshold from pre-resolved config
   kernArgs.ll128ThresholdBytes = collConfig.ll128ThresholdBytes;

--- a/comms/ctran/tests/CtranDistTestUtils.cc
+++ b/comms/ctran/tests/CtranDistTestUtils.cc
@@ -164,10 +164,8 @@ std::unique_ptr<CtranComm> CtranDistTestFixture::makeCtranComm(
       std::move(commBootstrap));
 
   comm->config_.commDesc = comm->statex_->commDesc().c_str();
-  // Set lazy IB connect on the per-comm config BEFORE ctranInit, which builds
-  // the Pipes transport from pipesConfig. The NCCL_CTRAN_IBGDA_LAZY_CONNECT env
-  // only feeds lazy via NcclxConfig, which this default-ctranConfig path does
-  // not go through, so tests must set it here explicitly.
+  // Preserve the compatibility setting through the standalone Ctran path.
+  // Peer materialization remains on demand for either value.
   comm->config_.pipesConfig.ibLazyConnect = ibLazyConnect;
 
   COMMCHECK_TEST(ctranInit(comm.get()));

--- a/comms/ctran/tests/CtranDistTestUtils.h
+++ b/comms/ctran/tests/CtranDistTestUtils.h
@@ -68,13 +68,11 @@ class CtranDistTestFixture : public CtranTestFixtureBase,
 
   void TearDown() override;
 
-  // When ibLazyConnect is true, the communicator is built with
-  // pipesConfig.ibLazyConnect set so IBGDA peers are materialized on-demand
-  // (the NCCL_CTRAN_IBGDA_LAZY_CONNECT env does NOT reach this default-config
-  // path -- see comment in makeCtranComm).
+  // ibLazyConnect is retained for compatibility; peers are always materialized
+  // on demand regardless of its value.
   std::unique_ptr<CtranComm> makeCtranComm(
       bool noLocal = false,
-      bool ibLazyConnect = false);
+      bool ibLazyConnect = true);
 
   // Asserts the comm's runtime topology matches the NCCL_COMM_STATE_DEBUG_TOPO
   // env override (nolocal/vnode). Early-returns when the env is unset, so

--- a/comms/ctran/tests/MultiPeerTransportTest.cc
+++ b/comms/ctran/tests/MultiPeerTransportTest.cc
@@ -3,6 +3,8 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
+#include <algorithm>
+
 #include <folly/init/Init.h>
 
 #include "comms/ctran/Ctran.h"
@@ -96,10 +98,32 @@ TEST_F(MultiPeerTransportTest, DeviceHandle) {
 
   ASSERT_NE(comm->multiPeerTransport_, nullptr);
 
-  // Get device handle - this should work after exchange()
-  auto deviceHandle = comm->multiPeerTransport_->get_device_handle();
+  const auto& ibPeers = comm->multiPeerTransport_->ib_peer_ranks();
+  auto addIbPeer = [&ibPeers](std::vector<int>& peers, int peer) {
+    if (std::find(ibPeers.begin(), ibPeers.end(), peer) != ibPeers.end() &&
+        std::find(peers.begin(), peers.end(), peer) == peers.end()) {
+      peers.push_back(peer);
+    }
+  };
+
+  std::vector<int> ringPeers;
+  if (numRanks > 1) {
+    addIbPeer(ringPeers, (globalRank + numRanks - 1) % numRanks);
+    addIbPeer(ringPeers, (globalRank + 1) % numRanks);
+  }
+  auto ringHandle = comm->multiPeerTransport_->get_device_handle(ringPeers);
+
+  std::vector<int> treePeers;
+  if (globalRank > 0) {
+    addIbPeer(treePeers, (globalRank - 1) / 2);
+  }
+  addIbPeer(treePeers, globalRank * 2 + 1);
+  addIbPeer(treePeers, globalRank * 2 + 2);
+  std::reverse(treePeers.begin(), treePeers.end());
+  auto deviceHandle = comm->multiPeerTransport_->get_device_handle(treePeers);
 
   // Verify device handle has valid data
+  EXPECT_EQ(ringHandle.transports.data(), deviceHandle.transports.data());
   EXPECT_EQ(deviceHandle.myRank, globalRank);
   EXPECT_EQ(deviceHandle.nRanks, numRanks);
   EXPECT_NE(deviceHandle.transports.data(), nullptr)

--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -197,7 +197,8 @@ Config::Config(const ncclConfig_t* config) {
     }
   }
 
-  ibLazyConnect = parseHintBool("ibLazyConnect", NCCL_CTRAN_IBGDA_LAZY_CONNECT);
+  deviceIbLazyConnect =
+      parseHintBool("deviceIbLazyConnect", NCCL_CTRAN_IBGDA_LAZY_CONNECT);
 
   // vCliqueSize: hint only (no flat ncclConfig_t field)
   {
@@ -400,7 +401,7 @@ void ncclxLogCommConfig(ncclComm_t comm) {
         fmt::format(
             "winRegisterEnableSignal={}", xCfg->winRegisterEnableSignal));
     append(fmt::format("winRegisterSymmetric={}", xCfg->winRegisterSymmetric));
-    append(fmt::format("ibLazyConnect={}", xCfg->ibLazyConnect));
+    append(fmt::format("deviceIbLazyConnect={}", xCfg->deviceIbLazyConnect));
     appendAlgo("sendrecvAlgo", xCfg->sendrecvAlgo);
     appendAlgo("allgatherAlgo", xCfg->allgatherAlgo);
     appendAlgo("allreduceAlgo", xCfg->allreduceAlgo);

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -70,8 +70,9 @@ class Config {
   std::optional<int> ibSplitDataOnQps;
   std::optional<int> ibQpsPerConnection;
 
-  // Defer per-peer IBGDA state to first use (hint > CVAR).
-  bool ibLazyConnect = false;
+  // Deprecated compatibility hint. Peer IB state is always initialized on
+  // demand; false no longer restores eager initialization.
+  bool deviceIbLazyConnect = true;
   // Update mutable hint fields (algo config only).  Rejects immutable keys.
   ncclResult_t update(const ncclx::Hints* hints);
 };
@@ -98,7 +99,7 @@ inline const std::vector<std::string>& knownHintKeys() {
       "ncclBuffSize",
       "ibSplitDataOnQps",
       "ibQpsPerConnection",
-      "ibLazyConnect",
+      "deviceIbLazyConnect",
       "win_register_ipc_only",
       "win_register_enable_signal",
       "win_register_symmetric",

--- a/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
+++ b/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
@@ -345,24 +345,24 @@ TEST(ConfigHintsUT, IbQpsPerConnectionDefaultUnset) {
   delete ncclxCfg;
 }
 
-// ----- ibLazyConnect tests -----
+// ----- deviceIbLazyConnect tests -----
 
-TEST(ConfigHintsUT, LazyPeerInit_DefaultIsFalse) {
+TEST(ConfigHintsUT, LazyPeerInit_DefaultIsTrue) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
   ASSERT_NE(config.ncclxConfig, nullptr);
-  EXPECT_FALSE(NCCLX_CONFIG_FIELD(config, ibLazyConnect));
+  EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, deviceIbLazyConnect));
   delete static_cast<ncclx::Config*>(config.ncclxConfig);
 }
 
 TEST(ConfigHintsUT, LazyPeerInit_HintOverrides) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   ncclx::Hints hints;
-  hints.set("ibLazyConnect", "true");
+  hints.set("deviceIbLazyConnect", "true");
   config.hints = &hints;
   EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
   ASSERT_NE(config.ncclxConfig, nullptr);
-  EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, ibLazyConnect));
+  EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, deviceIbLazyConnect));
   delete static_cast<ncclx::Config*>(config.ncclxConfig);
 }
 

--- a/comms/ncclx/meta/rma/transport.cc
+++ b/comms/ncclx/meta/rma/transport.cc
@@ -46,7 +46,7 @@ ncclResult_t ncclGetMultiPeerDeviceHandle(
     return ncclInternalError;
   }
 
-  auto handle = mpt->get_device_handle();
+  auto handle = mpt->get_device_handle(mpt->ib_peer_ranks());
   *outTransportsPtr = handle.transports.data();
   *outMyRank = handle.myRank;
   *outNRanks = handle.nRanks;

--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -46,7 +46,7 @@ ctranConfig makeCtranConfigFrom(ncclComm* comm) {
       tconfig.pipesConfig.nvlChunkSize =
           static_cast<int64_t>(ncclxCfg->pipesNvlChunkSize.value());
     }
-    tconfig.pipesConfig.ibLazyConnect = ncclxCfg->ibLazyConnect;
+    tconfig.pipesConfig.ibLazyConnect = ncclxCfg->deviceIbLazyConnect;
     if (ncclxCfg->pipesIbgdaDataBufferSize.has_value()) {
       tconfig.pipesConfig.ibgdaDataBufferSize =
           static_cast<int64_t>(ncclxCfg->pipesIbgdaDataBufferSize.value());

--- a/comms/prims/collectives/tests/RingAllGatherTest.cc
+++ b/comms/prims/collectives/tests/RingAllGatherTest.cc
@@ -19,7 +19,7 @@ struct RingAllGatherTestParams {
   int num_rings;
   std::size_t data_buffer_size;
   int pipeline_depth;
-  bool ibLazyConnect{false};
+  bool ibLazyConnect{true};
 };
 
 std::string param_name(

--- a/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
+++ b/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
@@ -126,5 +126,10 @@ TEST(MultiPeerIbTransportConfigTest, RelaxedOrderingDisabledNeverActive) {
       relaxedOrderingActiveForNic(config, /*nicRelaxedOrderingCapable=*/false));
 }
 
+TEST(MultiPeerIbTransportConfigTest, PeerMaterializationDefaultsOnDemand) {
+  const MultipeerIbTransportConfig config;
+  EXPECT_TRUE(config.ibLazyConnect);
+}
+
 } // namespace
 } // namespace comms::prims

--- a/comms/prims/tests/MultiPeerTransportIntegrationTest.cc
+++ b/comms/prims/tests/MultiPeerTransportIntegrationTest.cc
@@ -63,7 +63,7 @@ TEST_F(MultiPeerIntegrationTestFixture, DeviceHandleTypeMap) {
   }
 
   auto states = create_and_exchange();
-  auto handle = states->get_device_handle();
+  auto handle = states->get_device_handle(states->ib_peer_ranks());
 
   // Allocate output array on GPU
   int* output_d = nullptr;
@@ -102,7 +102,7 @@ TEST_F(MultiPeerIntegrationTestFixture, SelfTransportPut) {
 
   ASSERT_EQ(states->get_transport_type(globalRank), TransportType::SELF);
 
-  auto handle = states->get_device_handle();
+  auto handle = states->get_device_handle(states->ib_peer_ranks());
 
   const size_t nbytes = 4096;
   void* src_d = nullptr;

--- a/comms/prims/tests/MultiPeerTransportMultiNodeTest.cc
+++ b/comms/prims/tests/MultiPeerTransportMultiNodeTest.cc
@@ -1,5 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <algorithm>
 #include <cstring>
 #include <vector>
 
@@ -104,7 +105,8 @@ class MultiPeerTransportMultiNodeFixture : public MpiBaseTestFixture {
         localSize_);
   }
 
-  std::unique_ptr<MultiPeerTransport> create_transport_states() {
+  std::unique_ptr<MultiPeerTransport> create_transport_states(
+      bool p2pDisable = false) {
     MultiPeerTransportConfig config{
         .nvlConfig =
             {
@@ -116,6 +118,10 @@ class MultiPeerTransportMultiNodeFixture : public MpiBaseTestFixture {
         .ibConfig =
             {
                 .cudaDevice = localRank,
+            },
+        .topoConfig =
+            {
+                .p2pDisable = p2pDisable,
             },
     };
     auto bootstrap = std::make_shared<MpiBootstrap>();
@@ -197,7 +203,7 @@ TEST_F(MultiPeerTransportMultiNodeFixture, DeviceHandleMultiNode) {
   auto states = create_transport_states();
   states->exchange();
 
-  auto handle = states->get_device_handle();
+  auto handle = states->get_device_handle(states->ib_peer_ranks());
   EXPECT_EQ(handle.myRank, globalRank);
   EXPECT_EQ(handle.nRanks, numRanks);
   EXPECT_EQ(handle.transports.size(), static_cast<uint32_t>(numRanks));
@@ -214,6 +220,47 @@ TEST_F(MultiPeerTransportMultiNodeFixture, DeviceHandleMultiNode) {
   }
 
   // IBGDA is universal — all non-self peers.
+  EXPECT_EQ(handle.numIbPeers, numRanks - 1)
+      << "IBGDA transports should cover all peers";
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_F(MultiPeerTransportMultiNodeFixture, DeviceHandleAcrossPeerRounds) {
+  if (numRanks < 4) {
+    GTEST_SKIP() << "Requires >= 4 ranks (nnodes=2, ppn=2)";
+  }
+
+  auto states = create_transport_states(/*p2pDisable=*/true);
+  states->exchange();
+
+  const auto& ibPeers = states->ib_peer_ranks();
+  ASSERT_EQ(ibPeers.size(), numRanks - 1);
+  auto addIbPeer = [&ibPeers](std::vector<int>& peers, int peer) {
+    if (std::find(ibPeers.begin(), ibPeers.end(), peer) != ibPeers.end() &&
+        std::find(peers.begin(), peers.end(), peer) == peers.end()) {
+      peers.push_back(peer);
+    }
+  };
+
+  std::vector<int> ringPeers;
+  addIbPeer(ringPeers, (globalRank + numRanks - 1) % numRanks);
+  addIbPeer(ringPeers, (globalRank + 1) % numRanks);
+  auto ringHandle = states->get_device_handle(ringPeers);
+
+  std::vector<int> treePeers;
+  if (globalRank > 0) {
+    addIbPeer(treePeers, (globalRank - 1) / 2);
+  }
+  addIbPeer(treePeers, globalRank * 2 + 1);
+  addIbPeer(treePeers, globalRank * 2 + 2);
+  std::reverse(treePeers.begin(), treePeers.end());
+  auto handle = states->get_device_handle(treePeers);
+
+  EXPECT_EQ(ringHandle.transports.data(), handle.transports.data());
+  EXPECT_EQ(handle.myRank, globalRank);
+  EXPECT_EQ(handle.nRanks, numRanks);
+  EXPECT_EQ(handle.transports.size(), static_cast<uint32_t>(numRanks));
   EXPECT_EQ(handle.numIbPeers, numRanks - 1)
       << "IBGDA transports should cover all peers";
 

--- a/comms/prims/tests/MultiPeerTransportTest.cc
+++ b/comms/prims/tests/MultiPeerTransportTest.cc
@@ -219,7 +219,7 @@ TEST_F(MultiPeerTransportTestFixture, DeviceHandleMetadata) {
   auto transport = createTransport();
   transport->exchange();
 
-  auto handle = transport->get_device_handle();
+  auto handle = transport->get_device_handle(transport->ib_peer_ranks());
   EXPECT_EQ(handle.myRank, globalRank);
   EXPECT_EQ(handle.nRanks, numRanks);
   EXPECT_EQ(handle.transports.size(), static_cast<uint32_t>(numRanks));
@@ -234,7 +234,7 @@ TEST_F(MultiPeerTransportTestFixture, DeviceHandleMetadata) {
 
 TEST_F(MultiPeerTransportTestFixture, DeviceHandleBeforeExchange) {
   auto transport = createTransport();
-  EXPECT_THROW(transport->get_device_handle(), std::runtime_error);
+  EXPECT_THROW(transport->get_device_handle({}), std::runtime_error);
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -696,7 +696,7 @@ TEST_F(MultiPeerTransportTestFixture, DisableIb_DeviceHandleZeroIbPeers) {
   auto transport = createDisableIbTransport();
 
   transport->exchange();
-  auto handle = transport->get_device_handle();
+  auto handle = transport->get_device_handle({});
 
   EXPECT_EQ(handle.myRank, globalRank);
   EXPECT_EQ(handle.nRanks, numRanks);

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -127,7 +127,7 @@ class TestIbTransport {
     if (ibgda_) {
       return P2pIbTransportDevice(ibgda_->getP2pTransportDevice(peerRank));
     }
-    if (config_.ibLazyConnect && !ibrc_->isPeerMaterialized(peerRank)) {
+    if (!ibrc_->isPeerMaterialized(peerRank)) {
       ibrc_->materializePeer(peerRank);
     }
     return P2pIbTransportDevice(ibrc_->getP2pTransportDeviceSlot(peerRank));
@@ -2748,7 +2748,6 @@ class LazyModeTestFixture
         .numSignalSlots = 1,
         .numCounterSlots = 1,
         .ibLazyConnect = true,
-        .materializePeerTimeoutMs = 10000,
     };
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     return std::make_unique<TestIbTransport>(
@@ -2800,7 +2799,7 @@ TEST_P(LazyModeTestFixture, QueueThenConnect) {
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 }
 
-TEST_P(LazyModeTestFixture, EagerModeAllPeersMaterialized) {
+TEST_P(LazyModeTestFixture, DefaultModeDefersAllPeers) {
   if (numRanks < 2) {
     GTEST_SKIP() << "Requires at least 2 ranks";
   }
@@ -2812,7 +2811,7 @@ TEST_P(LazyModeTestFixture, EagerModeAllPeersMaterialized) {
       if (peer == globalRank) {
         continue;
       }
-      EXPECT_TRUE(transport->isPeerMaterialized(peer));
+      EXPECT_FALSE(transport->isPeerMaterialized(peer));
     }
   } catch (const std::exception& e) {
     GTEST_SKIP() << backendName(backend()) << " not available: " << e.what();

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -3,7 +3,6 @@
 #include "comms/prims/transport/MultiPeerIbTransport.h"
 
 #include <cerrno>
-#include <chrono>
 #include <cstring>
 #include <stdexcept>
 #include <string>
@@ -281,6 +280,10 @@ MultiPeerIbTransportBase::MultiPeerIbTransportBase(
   }
   if (nRanks_ < 2) {
     throw std::invalid_argument("Need at least 2 ranks");
+  }
+  if (auto isolatedBootstrap = bootstrap_->duplicate()) {
+    bootstrap_ =
+        std::shared_ptr<meta::comms::IBootstrap>(std::move(isolatedBootstrap));
   }
   // RoCE GID index: config override, else the RoCEv2 default. Read by
   // openNics() (query_gid) and by backends when building address handles.
@@ -1855,16 +1858,12 @@ bool MultiPeerIbTransportBase::isPeerMaterialized(int peerRank) const {
             myRank_,
             nRanks_));
   }
-  if (!config_.ibLazyConnect) {
-    return true;
-  }
+  const std::lock_guard<std::mutex> lock(materializationMutex_);
   return peerMaterialized_[rankToPeerIndex(peerRank)];
 }
 
 void MultiPeerIbTransportBase::queuePeerForMaterialization(int peerRank) {
-  if (!config_.ibLazyConnect) {
-    return;
-  }
+  const std::lock_guard<std::mutex> lock(materializationMutex_);
   if (materializationFailed_) {
     throw std::runtime_error(
         "MultiPeerIbTransport: lazy peer materialization previously failed; "
@@ -1879,7 +1878,7 @@ void MultiPeerIbTransportBase::queuePeerForMaterialization(int peerRank) {
             myRank_,
             nRanks_));
   }
-  if (isPeerMaterialized(peerRank)) {
+  if (peerMaterialized_[rankToPeerIndex(peerRank)]) {
     return;
   }
   for (int p : pendingPeers_) {
@@ -1961,29 +1960,22 @@ void MultiPeerIbTransportBase::exchangeRawWithPeer(
     const void* localPayload,
     void* remotePayload,
     std::size_t bytes,
-    int tag) {
-  auto timeoutUs = std::chrono::duration_cast<std::chrono::microseconds>(
-      std::chrono::milliseconds(config_.materializePeerTimeoutMs));
-  auto waitFuture = [&](auto&& future, const char* op) -> int {
-    try {
-      return std::move(future).get(timeoutUs);
-    } catch (const std::exception&) {
-      throw std::runtime_error(
-          fmt::format(
-              "materializePeer: rank {} {} with peer {} timed out ({}ms)",
-              myRank_,
-              op,
-              peerRank,
-              config_.materializePeerTimeoutMs));
-    }
-  };
-
+    int phase) {
+  constexpr int64_t kPrimsPeerTagBase = 1 << 16;
+  const int lowRank = std::min(myRank_, peerRank);
+  const int highRank = std::max(myRank_, peerRank);
+  const int64_t pairIndex = static_cast<int64_t>(lowRank) * nRanks_ + highRank;
+  const int64_t tagValue = kPrimsPeerTagBase + pairIndex * 2 + phase;
+  if (tagValue > std::numeric_limits<int>::max()) {
+    throw std::runtime_error("materializePeer: bootstrap tag overflow");
+  }
+  const int tag = static_cast<int>(tagValue);
   // Lower rank recvs first to avoid deadlock with blocking bootstrap
   // implementations (e.g. MpiBootstrap uses blocking MPI_Send/MPI_Recv).
   if (myRank_ < peerRank) {
     auto recvFuture =
         bootstrap_->recv(remotePayload, bytes, peerRank, /*tag=*/tag);
-    int recvResult = waitFuture(std::move(recvFuture), "recv");
+    int recvResult = std::move(recvFuture).get();
     if (recvResult != 0) {
       throw std::runtime_error(
           fmt::format(
@@ -1994,7 +1986,7 @@ void MultiPeerIbTransportBase::exchangeRawWithPeer(
     }
     auto sendFuture = bootstrap_->send(
         const_cast<void*>(localPayload), bytes, peerRank, /*tag=*/tag);
-    int sendResult = waitFuture(std::move(sendFuture), "send");
+    int sendResult = std::move(sendFuture).get();
     if (sendResult != 0) {
       throw std::runtime_error(
           fmt::format(
@@ -2006,7 +1998,7 @@ void MultiPeerIbTransportBase::exchangeRawWithPeer(
   } else {
     auto sendFuture = bootstrap_->send(
         const_cast<void*>(localPayload), bytes, peerRank, /*tag=*/tag);
-    int sendResult = waitFuture(std::move(sendFuture), "send");
+    int sendResult = std::move(sendFuture).get();
     if (sendResult != 0) {
       throw std::runtime_error(
           fmt::format(
@@ -2017,7 +2009,7 @@ void MultiPeerIbTransportBase::exchangeRawWithPeer(
     }
     auto recvFuture =
         bootstrap_->recv(remotePayload, bytes, peerRank, /*tag=*/tag);
-    int recvResult = waitFuture(std::move(recvFuture), "recv");
+    int recvResult = std::move(recvFuture).get();
     if (recvResult != 0) {
       throw std::runtime_error(
           fmt::format(

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -9,6 +9,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -216,13 +217,9 @@ struct MultipeerIbTransportConfig {
   // RNR retry count (ibv_qp_attr.rnr_retry); 7 means infinite.
   uint8_t rnrRetry{7};
 
-  // When true, defer per-peer state (QPs, staging, signal buffers) to first
-  // use via materializePeer(). When false (default), allocate eagerly at
-  // exchange() time.
-  bool ibLazyConnect{false};
-
-  // Timeout (ms) for the bilateral exchange in materializePeer().
-  uint32_t materializePeerTimeoutMs{30000};
+  // Deprecated compatibility setting. Per-peer state is always materialized
+  // on demand; false no longer enables eager all-peer allocation.
+  bool ibLazyConnect{true};
 };
 
 // Whether Data-Direct MR registration applies for a NIC: Data-Direct is
@@ -326,7 +323,8 @@ struct IbTransportExchInfoAll {
   int qpsPerBlockPerNic{1};
 };
 
-// Bootstrap tags for the two-phase bilateral exchange in lazy materialization.
+// Phases within the peer-pair-specific bootstrap tag computed by
+// exchangeRawWithPeer().
 constexpr int kIbPeerQpExchangeTag = 0;
 constexpr int kIbPeerBufferExchangeTag = 1;
 
@@ -449,7 +447,7 @@ class MultiPeerIbTransportBase {
   /** Queue a peer for lazy materialization (no network I/O). */
   void queuePeerForMaterialization(int peerRank);
 
-  /** @return true if the peer is ready for kernel use (always true eager). */
+  /** @return true if the peer is materialized and ready for kernel use. */
   bool isPeerMaterialized(int peerRank) const;
 
  protected:
@@ -498,8 +496,10 @@ class MultiPeerIbTransportBase {
 
   // Bilateral bootstrap exchange of a fixed-size payload with one peer. The
   // typed wrapper is header-only (so it can instantiate with backend-private
-  // payload types); the heavy logic (lower-rank-recvs-first to avoid deadlock,
-  // honoring materializePeerTimeoutMs) lives in exchangeRawWithPeer in the .cc.
+  // payload types); the heavy logic (lower-rank-recvs-first to avoid deadlock)
+  // lives in exchangeRawWithPeer in the .cc. The bootstrap implementation owns
+  // timeout and cancellation so caller-owned payloads remain live until the
+  // exchange completes.
   template <typename T>
   T exchangeWithPeer(int peerRank, const T& localPayload, int tag) {
     T remotePayload{};
@@ -655,6 +655,9 @@ class MultiPeerIbTransportBase {
   IbCounterStorage sendRecvCounterStorage_{IbCounterStorage::Device};
 
   // Lazy materialization state machine.
+  // connectPeers() holds this lock through the backend/bootstrap exchange so
+  // fixed bootstrap tags cannot be reused concurrently on one communicator.
+  mutable std::mutex materializationMutex_;
   std::vector<int> pendingPeers_;
   std::vector<bool> peerMaterialized_;
   bool materializationFailed_{false};
@@ -763,7 +766,7 @@ class MultiPeerIbTransportBase {
 template <typename Backend>
 class MultiPeerIbTransport : public MultiPeerIbTransportBase {
  public:
-  /** Materialize one peer (queue + connect). No-op in eager mode. */
+  /** Materialize one peer (queue + connect). */
   void materializePeer(int peerRank) {
     queuePeerForMaterialization(peerRank);
     connectPeers();
@@ -797,6 +800,9 @@ class MultiPeerIbTransport : public MultiPeerIbTransportBase {
 
 template <typename Backend>
 void MultiPeerIbTransport<Backend>::connectPeers() {
+  // queuePeerForMaterialization() releases this mutex before entering here;
+  // backend hooks must not recursively call materializePeer()/connectPeers().
+  const std::lock_guard<std::mutex> lock(materializationMutex_);
   if (materializationFailed_) {
     pendingPeers_.clear();
     throw std::runtime_error(
@@ -806,8 +812,8 @@ void MultiPeerIbTransport<Backend>::connectPeers() {
   if (pendingPeers_.empty()) {
     return;
   }
-  // Sorted order avoids deadlock for >2 ranks (both sides connect in the same
-  // global order).
+  // For a symmetric request graph, ascending local order is deadlock-free: the
+  // lowest remaining rank and its lowest pending neighbor select each other.
   std::sort(pendingPeers_.begin(), pendingPeers_.end());
 
   std::vector<int> peers;
@@ -817,7 +823,7 @@ void MultiPeerIbTransport<Backend>::connectPeers() {
 
   try {
     for (int peerRank : peers) {
-      if (isPeerMaterialized(peerRank)) {
+      if (peerMaterialized_[rankToPeerIndex(peerRank)]) {
         continue;
       }
       touchedPeerIndexes.push_back(rankToPeerIndex(peerRank));

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -63,7 +63,6 @@ MultiPeerTransport::MultiPeerTransport(
     : myRank_(myRank),
       nRanks_(nRanks),
       deviceId_(deviceId),
-      ibLazyConnect_(config.ibConfig.ibLazyConnect),
       bootstrap_(std::move(bootstrap)) {
   if (!topo.has_value()) {
     TopologyDiscovery topoDiscovery;
@@ -272,33 +271,15 @@ P2pSelfTransportDevice MultiPeerTransport::get_p2p_self_transport_device()
   return P2pSelfTransportDevice{};
 }
 
-MultiPeerDeviceHandle MultiPeerTransport::get_device_handle() const {
-  if (!deviceHandleBuilt_) {
-    throw std::runtime_error(
-        "MultiPeerTransport::get_device_handle() called before exchange()");
-  }
-  if (ibLazyConnect_) {
-    throw std::runtime_error(
-        "get_device_handle() cannot be used with lazy mode (ibLazyConnect=true). "
-        "Use get_device_handle(peers) or getP2pTransportDevice(peerRank).");
-  }
-
-  return MultiPeerDeviceHandle{
-      myRank_,
-      nRanks_,
-      {transportsGpu_, static_cast<uint32_t>(nRanks_)},
-      static_cast<int>(nvlPeerRanks_.size()),
-      static_cast<int>(ibPeerRanks_.size()),
-  };
-}
-
 MultiPeerDeviceHandle MultiPeerTransport::get_device_handle(
     const std::vector<int>& peers) {
   if (!deviceHandleBuilt_) {
     throw std::runtime_error(
         "MultiPeerTransport::get_device_handle(peers) called before exchange()");
   }
-  materializePeers(peers);
+  if (!peers.empty()) {
+    materializePeers(peers);
+  }
   return MultiPeerDeviceHandle{
       myRank_,
       nRanks_,
@@ -309,7 +290,7 @@ MultiPeerDeviceHandle MultiPeerTransport::get_device_handle(
 }
 
 bool MultiPeerTransport::is_lazy_mode() const {
-  return ibLazyConnect_;
+  return true;
 }
 
 void MultiPeerTransport::materializePeers(const std::vector<int>& peers) {

--- a/comms/prims/transport/MultiPeerTransport.h
+++ b/comms/prims/transport/MultiPeerTransport.h
@@ -32,7 +32,7 @@
 namespace comms::prims {
 
 // Forward declaration — include MultiPeerDeviceHandle.cuh to use
-// get_device_handle()
+// get_device_handle(peers).
 struct MultiPeerDeviceHandle;
 
 struct MultiPeerTransportConfig {
@@ -70,7 +70,7 @@ struct MultiPeerTransportConfig {
  * Usage:
  *   auto transport = MultiPeerTransport(myRank, nRanks, deviceId, bootstrap,
  * config); transport.exchange();                            // COLLECTIVE auto
- * handle = transport.get_device_handle();     // For kernels
+ * handle = transport.get_device_handle(peers); // For kernels
  */
 class MultiPeerTransport {
  public:
@@ -200,13 +200,6 @@ class MultiPeerTransport {
   // --- Device handle (for passing to kernels) ---
 
   /**
-   * @return MultiPeerDeviceHandle suitable for passing to CUDA kernels.
-   * @throws std::runtime_error if lazy mode is enabled or exchange() not
-   * called.
-   */
-  MultiPeerDeviceHandle get_device_handle() const;
-
-  /**
    * Materialize the specified IBGDA peers, then return the device handle.
    * Use with lazy mode for DeviceWindow or direct Transport[] access.
    *
@@ -216,6 +209,8 @@ class MultiPeerTransport {
 
   bool is_lazy_mode() const;
 
+  // Every requested edge must be requested by both endpoint ranks in the same
+  // connect round. Peer-vector order may differ between ranks.
   void materializePeers(const std::vector<int>& peers);
 
   void connectPeers();
@@ -289,7 +284,6 @@ class MultiPeerTransport {
   const int myRank_;
   const int nRanks_;
   const int deviceId_;
-  const bool ibLazyConnect_{false};
   std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
 
   // --- Topology (populated in constructor) ---

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -657,16 +657,6 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
             config_.qpsPerConnection,
             mainQpsPerPeerPerNic));
   }
-  if (!config_.ibLazyConnect &&
-      mainQpsPerPeerPerNic > kMaxEagerExchangeQpsPerPeerPerNic) {
-    throw std::invalid_argument(
-        fmt::format(
-            "eager IBGDA allGather exchange supports at most {} QPs per "
-            "(peer,NIC); got {}. Enable ibLazyConnect for larger "
-            "max_num_channels * direction_count * qpsPerConnection shapes.",
-            kMaxEagerExchangeQpsPerPeerPerNic,
-            mainQpsPerPeerPerNic));
-  }
   if (numNics_ * config_.qpsPerConnection > kIbMaxQpLanesPerChannelDirection) {
     throw std::invalid_argument(
         fmt::format(
@@ -697,38 +687,24 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
     // Open IB device and create PD
     openIbDevice();
 
-    if (!config_.ibLazyConnect) {
-      // Create QP groups (main + loopback) for all peers
-      createQpGroups();
-    } else {
-      const int numPeers = nRanks - 1;
-      const int companionSlots =
-          config_.fixedChannelCompanionQpsPerPeerPerNic();
-      for (auto& nic : nicDoca_) {
-        nic.blockQpGroups.resize(
-            static_cast<size_t>(numPeers) * companionSlots);
-        nic.extraMainQps.clear();
-        nic.loopbackCompanionQps.resize(
-            static_cast<size_t>(numPeers) * companionSlots);
-      }
-      peerMaterialized_.resize(numPeers, false);
+    const int numPeers = nRanks - 1;
+    const int companionSlots = config_.fixedChannelCompanionQpsPerPeerPerNic();
+    for (auto& nic : nicDoca_) {
+      nic.blockQpGroups.resize(static_cast<size_t>(numPeers) * companionSlots);
+      nic.extraMainQps.clear();
+      nic.loopbackCompanionQps.resize(
+          static_cast<size_t>(numPeers) * companionSlots);
     }
+    peerMaterialized_.resize(numPeers, false);
 
     // Allocate and register sink buffer for atomic return values
     allocateResources();
     registerMemory();
 
     // Allocate send/recv staging buffers when fixed channels are configured.
-    // Eager mode delegates to the shared base (Device counter: NIC loopback
-    // atomic); lazy mode only sizes the inherited per-peer view vector — the
-    // shared base allocateSendRecvBufferForPeer() fills it per peer at
-    // materialization.
+    // The shared base fills each entry when that peer is materialized.
     if (sendRecvBuffersEnabled()) {
-      if (!config_.ibLazyConnect) {
-        allocateSendRecvBuffersEager(IbCounterStorage::Device);
-      } else {
-        sendRecvPeerBuffers_.resize(nRanks_ - 1);
-      }
+      sendRecvPeerBuffers_.resize(nRanks_ - 1);
     }
   } catch (const std::exception&) {
     // Destructor won't run for a partially-constructed object, so clean up
@@ -867,154 +843,21 @@ void MultipeerIbgdaTransport::cleanup() {
 
 void MultipeerIbgdaTransport::exchange() {
   const int numPeers = nRanks_ - 1;
-  const int mainQpsPerPeerPerNic = config_.fixedChannelMainQpsPerPeerPerNic();
-  const int companionSlots = config_.fixedChannelCompanionQpsPerPeerPerNic();
-  auto& symbols = ibverbx::ibvSymbols;
-
-  if (config_.ibLazyConnect) {
-    peerTransportSize_ = getP2pIbgdaTransportDeviceSize();
-    std::size_t totalBytes = numPeers * peerTransportSize_;
-    cudaError_t err = cudaMalloc(&peerTransportsGpu_, totalBytes);
-    if (err != cudaSuccess) {
-      throw std::runtime_error(
-          "Failed to allocate lazy device transport array: " +
-          std::string(cudaGetErrorString(err)));
-    }
-    gpuAllocations_.push_back(peerTransportsGpu_);
-    err = cudaMemset(peerTransportsGpu_, 0, totalBytes);
-    if (err != cudaSuccess) {
-      throw std::runtime_error("Failed to zero lazy device transport array");
-    }
-    VLOG(1)
-        << "MultipeerIbgdaTransport: rank " << myRank_
-        << " lazy exchange complete (per-peer state deferred to materializePeer)";
-    return;
-  }
-
-  // Build this rank's exchange info. Per-NIC GID/LID land in nicInfo[n];
-  // gidIndex + MTU are common across NICs (same fabric/HCA generation in
-  // multi-NIC platforms). The rank-count guard, allGather, and per-peer
-  // topology validation are owned by the base (MultiPeerIbTransport).
-  IbgdaTransportExchInfoAll myInfo{};
-  myInfo.gidIndex = gidIndex_;
-  myInfo.mtu = localMtu_;
-  myInfo.numNics = numNics_;
-  myInfo.numQpsPerPeerPerNic = mainQpsPerPeerPerNic;
-  myInfo.maxGroups = config_.max_num_channels;
-  myInfo.qpsPerBlockPerNic = config_.qpsPerConnection;
-  for (int n = 0; n < numNics_; ++n) {
-    memcpy(
-        myInfo.nicInfo[n].gid,
-        nics_[n].localGid.raw,
-        sizeof(myInfo.nicInfo[n].gid));
-    // Query NIC n's port for LID (IB only — RoCE leaves LID as 0).
-    ibverbx::ibv_port_attr exchPortAttr{};
-    if (symbols.ibv_internal_query_port(nics_[n].ibvCtx, 1, &exchPortAttr) !=
-        0) {
-      LOG(WARNING) << "Failed to query port for LID on NIC " << n;
-    } else {
-      myInfo.nicInfo[n].lid = exchPortAttr.lid;
-    }
-  }
-
-  const int totalQpsPerPeer = numNics_ * mainQpsPerPeerPerNic;
-  for (int peerIndex = 0; peerIndex < numPeers; peerIndex++) {
-    const int peerRank = peerIndexToRank(peerIndex);
-    for (int nic = 0; nic < numNics_; nic++) {
-      const auto& nicQps = nicDoca_[nic].blockQpGroups;
-      for (int slot = 0; slot < companionSlots; slot++) {
-        const int slotIdx = peerIndex * companionSlots + slot;
-        myInfo.nicInfo[nic].qpnForRank[peerRank][slot] =
-            doca_verbs_qp_get_qpn(nicQps[slotIdx]->qp_main.qp);
-      }
-    }
-  }
-
-  VLOG(1) << "MultipeerIbgdaTransport: rank " << myRank_
-          << " performing allGather exchange (" << totalQpsPerPeer
-          << " main QPs/peer = " << numNics_ << " NICs × "
-          << mainQpsPerPeerPerNic << " main QPs)";
-
-  // allGather (rank-count guarded) + per-peer topology validation (numNics +
-  // numQpsPerPeerPerNic) are owned by the base.
-  std::vector<IbgdaTransportExchInfoAll> allInfo = allGatherExchInfo(myInfo);
-  validatePeerTopology(allInfo);
-
-  // Stash per-peer summary info (slot 0 / NIC 0) for retrospect/debug.
-  // Per-slot connection info is computed inline in the connect loop below.
-  peerExchInfo_.resize(numPeers);
-  for (int peerIndex = 0; peerIndex < numPeers; peerIndex++) {
-    int peerRank = peerIndexToRank(peerIndex);
-    const IbgdaTransportExchInfoAll& peerInfo = allInfo[peerRank];
-
-    CHECK_EQ(peerInfo.maxGroups, config_.max_num_channels)
-        << "Rank " << peerRank << " has maxGroups=" << peerInfo.maxGroups
-        << " but local rank " << myRank_ << " has " << config_.max_num_channels
-        << ". All ranks must use the same maxGroups.";
-    CHECK_EQ(peerInfo.qpsPerBlockPerNic, config_.qpsPerConnection)
-        << "Rank " << peerRank
-        << " has qpsPerBlockPerNic=" << peerInfo.qpsPerBlockPerNic
-        << " but local rank " << myRank_ << " has " << config_.qpsPerConnection
-        << ". All ranks must use the same qpsPerBlockPerNic.";
-
-    // Store common connection info (from QP 0 — same GID/LID for all QPs)
-    peerExchInfo_[peerIndex].qpn = peerInfo.nicInfo[0].qpnForRank[myRank_][0];
-    memcpy(
-        peerExchInfo_[peerIndex].gid,
-        peerInfo.nicInfo[0].gid,
-        sizeof(peerInfo.nicInfo[0].gid));
-    peerExchInfo_[peerIndex].gidIndex = peerInfo.gidIndex;
-    peerExchInfo_[peerIndex].lid = peerInfo.nicInfo[0].lid;
-    peerExchInfo_[peerIndex].mtu = peerInfo.mtu;
-
-    VLOG(1) << "MultipeerIbgdaTransport: received from peer " << peerRank
-            << " numNics=" << peerInfo.numNics
-            << " maxGroups=" << peerInfo.maxGroups
-            << " qpsPerBlockPerNic=" << peerInfo.qpsPerBlockPerNic
-            << " slot0_qpn=" << peerExchInfo_[peerIndex].qpn;
-  }
-
-  // Connect main QPs + loopback companions for all peers
-  for (int peerIndex = 0; peerIndex < numPeers; peerIndex++) {
-    const IbgdaTransportExchInfoAll& peerInfo =
-        allInfo[peerIndexToRank(peerIndex)];
-
-    for (int nic = 0; nic < numNics_; nic++) {
-      auto& nicQps = nicDoca_[nic].blockQpGroups;
-      for (int slot = 0; slot < companionSlots; slot++) {
-        const int slotIdx = peerIndex * companionSlots + slot;
-        IbgdaTransportExchInfo qpPeerInfo;
-        qpPeerInfo.qpn = peerInfo.nicInfo[nic].qpnForRank[myRank_][slot];
-        memcpy(
-            qpPeerInfo.gid, peerInfo.nicInfo[nic].gid, sizeof(qpPeerInfo.gid));
-        qpPeerInfo.gidIndex = peerInfo.gidIndex;
-        qpPeerInfo.lid = peerInfo.nicInfo[nic].lid;
-        qpPeerInfo.mtu = peerInfo.mtu;
-        connectQp(&nicQps[slotIdx]->qp_main, qpPeerInfo, nic);
-      }
-    }
-    connectPeerLoopback(peerIndex);
-  }
-  allocateSignalCounterResources(
-      IbCounterStorage::Device, /*allocateDiscardSignal=*/true);
-
-  exchangeSendRecvBuffersEager();
-
-  // Build device transports on GPU
-  std::vector<P2pIbgdaTransportBuildParams> buildParams;
-  buildParams.reserve(numPeers);
-  for (int peer = 0; peer < numPeers; peer++) {
-    buildParams.emplace_back(buildPeerTransportParams(peer));
-  }
-
-  peerTransportsGpu_ =
-      buildDeviceTransportsOnGpu(buildParams, numPeers, gpuAllocations_);
   peerTransportSize_ = getP2pIbgdaTransportDeviceSize();
-
+  const std::size_t totalBytes = numPeers * peerTransportSize_;
+  cudaError_t err = cudaMalloc(&peerTransportsGpu_, totalBytes);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        "Failed to allocate on-demand device transport array: " +
+        std::string(cudaGetErrorString(err)));
+  }
+  gpuAllocations_.push_back(peerTransportsGpu_);
+  err = cudaMemset(peerTransportsGpu_, 0, totalBytes);
+  if (err != cudaSuccess) {
+    throw std::runtime_error("Failed to zero on-demand device transport array");
+  }
   VLOG(1) << "MultipeerIbgdaTransport: rank " << myRank_
-          << " exchange complete, connected to " << numPeers << " peers"
-          << " (" << mainQpsPerPeerPerNic << " main QPs/(peer,NIC) × "
-          << numNics_ << " NICs)";
+          << " exchange complete (per-peer state deferred to materializePeer)";
 }
 
 MultipeerIbgdaDeviceTransport MultipeerIbgdaTransport::getDeviceTransport()
@@ -1027,7 +870,7 @@ MultipeerIbgdaDeviceTransport MultipeerIbgdaTransport::getDeviceTransport()
 
 P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getP2pTransportDevice(
     int peerRank) {
-  if (config_.ibLazyConnect && !isPeerMaterialized(peerRank)) {
+  if (!isPeerMaterialized(peerRank)) {
     materializePeer(peerRank);
   }
   int peerIndex = rankToPeerIndex(peerRank);
@@ -1043,15 +886,10 @@ P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getDeviceTransportPtr()
 
 P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getP2pTransportDeviceSlot(
     int peerRank) const {
-  if (config_.ibLazyConnect) {
-    LOG_FIRST_N(WARNING, 1)
-        << "MultipeerIbgdaTransport: lazy mode is enabled but "
-        << "Transport[] array is being built with unmaterialized IBGDA "
-        << "slots. Algorithms using Transport[] directly (DeviceWindow, "
-        << "AllToAllv) should disable lazy mode (ibLazyConnect=false). "
-        << "Algorithms using getP2pTransportDevice() per peer (Ring, "
-        << "SendRecv) are unaffected.";
-  }
+  LOG_FIRST_N(WARNING, 1)
+      << "MultipeerIbgdaTransport: Transport[] array is being built with "
+      << "possibly unmaterialized IBGDA slots. Call get_device_handle(peers) "
+      << "before kernels access those peers.";
   int peerIndex = rankToPeerIndex(peerRank);
   return reinterpret_cast<P2pIbgdaTransportDevice*>(
       reinterpret_cast<char*>(peerTransportsGpu_) +

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -303,17 +303,6 @@ MultipeerIbrcTransport::MultipeerIbrcTransport(
             config_.qpsPerConnection,
             numQpsPerPeerPerNic));
   }
-  if (!config.ibLazyConnect &&
-      numQpsPerPeerPerNic > kMaxEagerExchangeQpsPerPeerPerNic) {
-    throw std::invalid_argument(
-        fmt::format(
-            "eager IBRC allGather exchange supports at most {} QPs per "
-            "(peer,NIC); got {}. Enable ibLazyConnect for larger "
-            "max_num_channels * 2 * qpsPerConnection shapes.",
-            kMaxEagerExchangeQpsPerPeerPerNic,
-            numQpsPerPeerPerNic));
-  }
-
   peerResources_.resize(nRanks_ - 1);
   peerQueuesPublished_ = std::make_unique<std::atomic<bool>[]>(nRanks_ - 1);
 
@@ -335,9 +324,7 @@ MultipeerIbrcTransport::MultipeerIbrcTransport(
     progressCpus_ = selectProgressCpus();
     initializeControlResources();
     initializeDeviceTransportSlots();
-    if (config_.ibLazyConnect) {
-      peerMaterialized_.resize(nRanks_ - 1, false);
-    }
+    peerMaterialized_.resize(nRanks_ - 1, false);
   } catch (const std::exception&) {
     cleanup();
     throw;
@@ -349,27 +336,9 @@ MultipeerIbrcTransport::~MultipeerIbrcTransport() {
 }
 
 void MultipeerIbrcTransport::exchange() {
-  if (!config_.ibLazyConnect) {
-    exchangeAndConnectQps();
-    allocateSignalCounterResources(
-        IbCounterStorage::HostPinned, /*allocateDiscardSignal=*/false);
-    // Allocate + collectively exchange send/recv staging before building the
-    // device transports, so updatePeerDeviceTransport can embed the resulting
-    // IbChannelLayout. Delegated to the shared base; IBRC uses a host-mapped
-    // NIC_DONE counter (CPU proxy writes it) via the HostPinned counter
-    // storage.
-    allocateSendRecvBuffersEager(IbCounterStorage::HostPinned);
-    exchangeSendRecvBuffersEager();
-    allocateCmdQueuesForAllPeers();
-    VLOG(1) << "MultipeerIbrcTransport: rank " << myRank_ << " allocated "
-            << allocatedCmdQueueCount() << " command queues";
-    startProgressThread();
-  } else {
-    VLOG(1)
-        << "MultipeerIbrcTransport: rank " << myRank_
-        << " lazy exchange complete (per-peer QPs and command queues deferred "
-           "to materializePeer)";
-  }
+  VLOG(1) << "MultipeerIbrcTransport: rank " << myRank_
+          << " exchange complete (per-peer QPs and command queues deferred "
+             "to materializePeer)";
 }
 
 void MultipeerIbrcTransport::cleanup() {
@@ -1547,12 +1516,10 @@ void MultipeerIbrcTransport::exchangeAndConnectQps() {
 
 P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDeviceSlot(
     int peerRank) const {
-  if (config_.ibLazyConnect) {
-    LOG_FIRST_N(WARNING, 1)
-        << "MultipeerIbrcTransport: lazy mode is enabled but Transport[] "
-        << "array is being built with possibly unmaterialized IBRC slots. "
-        << "Call get_device_handle(peers) before kernels access lazy peers.";
-  }
+  LOG_FIRST_N(WARNING, 1)
+      << "MultipeerIbrcTransport: Transport[] array is being built with "
+      << "possibly unmaterialized IBRC slots. Call get_device_handle(peers) "
+      << "before kernels access those peers.";
   if (p2pTransportDevices_.device == nullptr) {
     throw std::runtime_error(
         "getP2pTransportDeviceSlot: IBRC device transport slots are not initialized");
@@ -1564,10 +1531,10 @@ P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDeviceSlot(
 }
 
 P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDevice(
-    int peerRank) const {
-  // IBRC builds every peer slot eagerly in initializeDeviceTransportSlots(), so
-  // the per-peer accessor is just slot pointer arithmetic (no materialization,
-  // hence no lazy warning unlike getP2pTransportDeviceSlot()).
+    int peerRank) {
+  if (!isPeerMaterialized(peerRank)) {
+    materializePeer(peerRank);
+  }
   if (p2pTransportDevices_.device == nullptr) {
     throw std::runtime_error(
         "getP2pTransportDevice: IBRC device transport slots are not initialized");
@@ -1609,7 +1576,7 @@ void MultipeerIbrcTransport::doMaterializePeer(int peerRank) {
 }
 
 void MultipeerIbrcTransport::cleanupPeerOnFailure(int peerIndex) {
-  // Quiesce progress before teardown; next doMaterializePeer restarts it.
+  publishTransportError(EIO, "peer materialization failed");
   stopProgressThread();
   cleanupPeerCmdQueues(peerIndex);
   cleanupPeerQps(peerIndex);

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
@@ -77,10 +77,9 @@ class MultipeerIbrcTransport
 
   P2pIbrcTransportDevice* getP2pTransportDeviceSlot(int peerRank) const;
 
-  // Per-peer device handle accessor used by Ring/SendRecv algorithms (the
-  // counterpart of IBGDA's getP2pTransportDevice). IBRC builds all slots
-  // eagerly, so this returns the slot pointer directly.
-  P2pIbrcTransportDevice* getP2pTransportDevice(int peerRank) const;
+  // Per-peer device handle accessor used by Ring/SendRecv algorithms. The
+  // requested peer is materialized before its device slot is returned.
+  P2pIbrcTransportDevice* getP2pTransportDevice(int peerRank);
 
  private:
   // Lazy per-peer materialization hook. The shared base owns queueing,

--- a/comms/prims/window/HostWindow.cc
+++ b/comms/prims/window/HostWindow.cc
@@ -488,7 +488,7 @@ DeviceWindow HostWindow::buildDeviceWindowImpl(
 }
 
 DeviceWindow HostWindow::getDeviceWindow() const {
-  return buildDeviceWindowImpl(transport_.get_device_handle());
+  return buildDeviceWindowImpl(transport_.get_device_handle(ibgdaPeerRanks_));
 }
 
 DeviceWindow HostWindow::getDeviceWindow(const std::vector<int>& peers) {

--- a/comms/prims/window/HostWindow.h
+++ b/comms/prims/window/HostWindow.h
@@ -122,22 +122,21 @@ class HostWindow {
    * Must be called after exchange() and after all registerLocalBuffer()
    * and registerAndExchangeBuffer() calls.
    *
-   * @throws std::runtime_error if lazy mode is enabled (ibLazyConnect=true).
-   *   Use getDeviceWindow(peers) instead.
+   * Materializes every IB peer for compatibility. Prefer
+   * getDeviceWindow(peers) when the operation uses a bounded peer set.
    */
   DeviceWindow getDeviceWindow() const;
 
   /**
-   * getDeviceWindow (lazy mode) - Materialize specific IBGDA peers,
+   * getDeviceWindow - Materialize specific on-demand IB peers,
    * then return the DeviceWindow.
    *
-   * Call this instead of getDeviceWindow() when lazy mode is enabled.
    * Materializes the listed peers (QPs, buffers, bilateral exchange)
    * before building the DeviceWindow. Unmaterialized peers remain as
    * zeroed transport slots — the kernel must only access materialized
    * peers.
    *
-   * No-op for non-IBGDA peers or in eager mode.
+   * Non-IB peers require no transport materialization.
    *
    * @param peers List of global peer ranks to materialize
    */

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1962,20 +1962,11 @@ cvars:
 
  - name        : NCCL_CTRAN_IBGDA_LAZY_CONNECT
    type        : bool
-   default     : false
+   default     : true
    description : |-
-     When true, MultipeerIbgdaTransport defers per-peer state allocation to
-     first use (lazy mode). When false (default), all per-peer state is
-     allocated eagerly at construction. Per-comm override via
-     CommOptions.hints["ncclx::ibLazyConnect"].
-
- - name        : NCCL_CTRAN_IBGDA_MATERIALIZE_PEER_TIMEOUT_MS
-   type        : uint32_t
-   default     : 30000
-   description : |-
-     Timeout (in milliseconds) for materializePeer bilateral exchange.
-     On timeout, materializePeer throws rather than hanging.
-     No per-comm override.
+     Deprecated compatibility knob. Per-peer transport state is always
+     initialized on demand; setting this false no longer enables eager
+     all-peer allocation.
 
  - name        : NCCL_CTRAN_BACKENDS
    type        : enumlist


### PR DESCRIPTION
Summary:

Remove eager all-peer IBGDA/IBRC initialization. Transport exchange now leaves peer state deferred; callers must provide explicit peers, and each requested peer still initializes the full configured `max_num_channels` QP shape. Materialization is serialized per communicator, bootstrap traffic uses isolated peer-specific tags, and IBRC publishes failures to device waiters. Legacy lazy settings remain compatibility-only and cannot restore eager behavior.

The bootstrap implementation owns exchange timeout and cancellation. A local future timeout was removed because MCCL bootstrap retains caller buffers asynchronously and NCCLX/MPI bootstrap calls can block before returning a future; returning locally on timeout would permit use-after-return and stale-tag traffic. The dead per-materialization timeout CVAR and config field are removed.

Reviewed By: saifhhasan, minsii

Differential Revision: D114108202


