### PR TITLE
Give MCCL an independent default-on Prims policy (#3336)

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -15,6 +15,11 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 
+bool ctranPrimsEnabled(const CtranComm* comm) {
+  const auto enablePrims = comm->config_.pipesConfig.enablePrims;
+  return enablePrims < 0 ? NCCL_CTRAN_USE_PIPES : enablePrims != 0;
+}
+
 #if defined(ENABLE_PRIMS)
 
 #include "comms/prims/trace/PipesTrace.h"
@@ -61,7 +66,7 @@ commResult_t ctran::ctranPreparePipesTrace(
 }
 
 commResult_t ctranInitializePipes(CtranComm* comm) {
-  if (!NCCL_CTRAN_USE_PIPES) {
+  if (!ctranPrimsEnabled(comm)) {
     CLOGF(INFO, "CTRAN-PRIMS: initialization skipped; prims are disabled");
     return commSuccess;
   }
@@ -518,11 +523,12 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo) {
       nvlNRanks - 1,
       comm->multiPeerTransport_->ib_peer_ranks().size());
 
-  // Wire staging buffers only when there are NVL peers. When P2P is disabled
-  // (NCCL_P2P_DISABLE=1), nvlNRanks == 1 (self only) while nLocalRanks may
-  // be larger. No NVL peers means no staging buffers to wire; communication
-  // falls back to IBGDA for all peers including intra-node.
-  if (nvlNRanks > 1) {
+  // External staging buffers are indexed by Ctran's host-local rank. A
+  // physical NVLink clique can be smaller than that group, in which case the
+  // transport must retain its internally allocated buffers.
+  const bool canUseExternalNvlBuffers =
+      nvlNRanks > 1 && nvlNRanks == statex->nLocalRanks();
+  if (canUseExternalNvlBuffers) {
     CLOGF(
         INFO,
         "CTRAN-PRIMS: validating ctran/prims consistency rank={}",
@@ -585,10 +591,17 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo) {
         INFO,
         "CTRAN-PRIMS: external NVL data buffers set rank={}",
         statex->rank());
-  } else {
+  } else if (nvlNRanks <= 1) {
     CLOGF(
         INFO,
         "CTRAN-PRIMS: no NVL peers; skipping external staging buffer wiring rank={}",
+        statex->rank());
+  } else {
+    CLOGF(
+        INFO,
+        "CTRAN-PRIMS: physical NVLink group size {} differs from Ctran local group size {}; using internal staging buffers rank={}",
+        nvlNRanks,
+        statex->nLocalRanks(),
         statex->rank());
   }
 

--- a/comms/ctran/CtranPipes.h
+++ b/comms/ctran/CtranPipes.h
@@ -28,6 +28,10 @@ inline size_t ctranEffectiveP2pNvlSharedDevbufSize(int nLocalRanks) {
 // exchange() is deferred to ctranInitPipesResources().
 commResult_t ctranInitializePipes(CtranComm* comm);
 
+// Resolve the per-communicator override, falling back to the legacy CTRAN
+// CVAR for NCCLX and standalone Ctran callers.
+bool ctranPrimsEnabled(const CtranComm* comm);
+
 // Wire SharedResource staging buffers as external data buffers to
 // MultiPeerTransport and exchange handles. Must be called after both
 // CtranAlgo (SharedResource) and MultiPeerTransport have been created.

--- a/comms/ctran/tests/CtranCommTest.cc
+++ b/comms/ctran/tests/CtranCommTest.cc
@@ -1,9 +1,12 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <folly/ScopeGuard.h>
 #include <gtest/gtest.h>
 
 #include "comms/common/fault_tolerance/Abort.h"
 #include "comms/ctran/CtranComm.h"
+#include "comms/ctran/CtranPipes.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 
 namespace ctran::testing {
 
@@ -60,6 +63,34 @@ TEST(CtranCommTest, ctranCommConfigTest) {
   /// Explicitly create comm with false abort as first argument is unomittable
   CtranComm comm2(comms::fault_tolerance::createAbort(false));
   EXPECT_EQ(comm2.config_.backends.size(), 0);
+}
+
+TEST(CtranCommTest, PrimsPolicyIsPerCommunicator) {
+  auto abort = comms::fault_tolerance::createAbort(/*enabled=*/true);
+  const bool savedUsePipes = NCCL_CTRAN_USE_PIPES;
+  NCCL_CTRAN_USE_PIPES = false;
+  auto restoreUsePipes = folly::makeGuard(
+      [savedUsePipes] { NCCL_CTRAN_USE_PIPES = savedUsePipes; });
+
+  CtranComm mcclComm(abort, ctranConfig{.pipesConfig = {.enablePrims = 1}});
+  CtranComm ncclxComm(abort);
+
+  EXPECT_TRUE(ctranPrimsEnabled(&mcclComm));
+  EXPECT_FALSE(ctranPrimsEnabled(&ncclxComm));
+}
+
+TEST(CtranCommTest, ExplicitPrimsDisableDoesNotAffectLegacyPolicy) {
+  auto abort = comms::fault_tolerance::createAbort(/*enabled=*/true);
+  const bool savedUsePipes = NCCL_CTRAN_USE_PIPES;
+  NCCL_CTRAN_USE_PIPES = true;
+  auto restoreUsePipes = folly::makeGuard(
+      [savedUsePipes] { NCCL_CTRAN_USE_PIPES = savedUsePipes; });
+
+  CtranComm mcclComm(abort, ctranConfig{.pipesConfig = {.enablePrims = 0}});
+  CtranComm ncclxComm(abort);
+
+  EXPECT_FALSE(ctranPrimsEnabled(&mcclComm));
+  EXPECT_TRUE(ctranPrimsEnabled(&ncclxComm));
 }
 
 } // namespace ctran::testing

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1895,6 +1895,15 @@ cvars:
      initialize MultiPeerTransport which provides unified NVLink and IBGDA
      transport for P2P communication.
 
+ - name        : MCCL_PRIMS_ENABLE
+   type        : bool
+   default     : true
+   description : |-
+     Enable Prims transports for MCCL communicators. This is independent of
+     NCCL_CTRAN_USE_PIPES so enabling Prims in MCCL does not enable Pipes for
+     NCCLX or standalone Ctran users. Set false to roll MCCL communicators back
+     to the legacy transport policy.
+
  - name        : NCCL_CTRAN_PIPES_TRACE_ENABLE
    type        : bool
    default     : false


### PR DESCRIPTION
Summary:

Add `MCCL_PRIMS_ENABLE`, default it on for MCCL communicators, and pass the decision through a per-communicator Ctran override. NCCLX and standalone Ctran continue to resolve the legacy `NCCL_CTRAN_USE_PIPES` default, so enabling Prims for MCCL does not unexpectedly enable it elsewhere. `MCCL_PRIMS_ENABLE=0` is the documented MCCL rollback switch. MCCL tests and benchmarks use the MCCL-specific knob.

Reviewed By: saifhhasan

Differential Revision: D114108204


