### PR TITLE
Hoist NCCLX runtime bootstrap out of forked param.cc into a meta seam (#3339)

### DIFF
--- a/comms/ctran/memory/tests/memoryUtilsTests.cc
+++ b/comms/ctran/memory/tests/memoryUtilsTests.cc
@@ -9,6 +9,13 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/Logger.h"
 
+// ncclxInitLogger() is defined in the shared ncclx runtime seam
+// (comms/ncclx/meta/wrapper/NcclxRuntime.cc) that this test already links, but
+// that header is not on this target's include path; forward-declare the symbol.
+namespace meta::comms::ncclx {
+void ncclxInitLogger();
+} // namespace meta::comms::ncclx
+
 class memoryUtilsTest : public ::testing::Test {
  public:
   int cudaDev = 0;
@@ -24,7 +31,12 @@ class memoryUtilsTest : public ::testing::Test {
     setenv("NCCL_DEBUG_SUBSYS", "ALLOC", 0);
     ncclCvarInit();
     ncclCudaLibraryInit();
+    // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+    meta::comms::ncclx::ncclxInitLogger();
+#else
     initNcclLogger();
+#endif
 
     dummyLogData = CommLogData{
         .commId = 0,

--- a/comms/ncclx/meta/collectives/quantCollectives.cc
+++ b/comms/ncclx/meta/collectives/quantCollectives.cc
@@ -7,6 +7,7 @@
 
 #include "meta/wrapper/DataTypeStrUtils.h"
 #include "meta/wrapper/MetaFactory.h"
+#include "meta/wrapper/NcclCommUseCtran.h"
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/utils/ExtUtils.h"
@@ -88,7 +89,7 @@ static ncclResult_t ncclReduceScatterQuantizeInfoExt(
   constexpr auto kDirectIbAlgo = NCCL_REDUCESCATTER_ALGO::ctdirect_ib;
   if (NCCL_REDUCESCATTER_QUANTIZED_ALGO ==
           NCCL_REDUCESCATTER_QUANTIZED_ALGO::ctdirect_ib &&
-      comm->useCtran_ && op == ncclSum &&
+      meta::comms::ncclx::ncclCommUseCtran(comm) && op == ncclSum &&
       ctranReduceScatterSupport(comm->ctranComm_.get(), kDirectIbAlgo)) {
     return metaCommToNccl(ctranReduceScatterQuantize(
         sendbuff,

--- a/comms/ncclx/meta/collectives/quantCollectives.cc
+++ b/comms/ncclx/meta/collectives/quantCollectives.cc
@@ -8,6 +8,7 @@
 #include "meta/NcclxLogger.h"
 #include "meta/wrapper/DataTypeStrUtils.h"
 #include "meta/wrapper/MetaFactory.h"
+#include "meta/wrapper/NcclCommUseCtran.h"
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/utils/ExtUtils.h"
@@ -89,7 +90,7 @@ static ncclResult_t ncclReduceScatterQuantizeInfoExt(
   constexpr auto kDirectIbAlgo = NCCL_REDUCESCATTER_ALGO::ctdirect_ib;
   if (NCCL_REDUCESCATTER_QUANTIZED_ALGO ==
           NCCL_REDUCESCATTER_QUANTIZED_ALGO::ctdirect_ib &&
-      comm->useCtran_ && op == ncclSum &&
+      meta::comms::ncclx::ncclCommUseCtran(comm) && op == ncclSum &&
       ctranReduceScatterSupport(comm->ctranComm_.get(), kDirectIbAlgo)) {
     return metaCommToNccl(ctranReduceScatterQuantize(
         sendbuff,

--- a/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -26,6 +26,7 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/Logger.h"
 #include "meta/commDump.h"
+#include "meta/wrapper/NcclxRuntime.h"
 
 using ::meta::comms::colltrace::CollTraceConfig;
 
@@ -112,7 +113,12 @@ class CollTraceTest : public NcclxBaseTestFixture {
         NCCL_DEBUG_SUBSYS.empty() ? "INIT,BOOTSTRAP,ENV" : NCCL_DEBUG_SUBSYS;
     NCCL_DEBUG = "INFO";
     NCCL_DEBUG_SUBSYS = "INIT,COLL";
+    // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+    meta::comms::ncclx::ncclxInitLogger();
+#else
     initNcclLogger();
+#endif
   }
 
   void endVerboseLogging() {
@@ -120,7 +126,12 @@ class CollTraceTest : public NcclxBaseTestFixture {
     NcclLogger::close();
     NCCL_DEBUG = prevDebug;
     NCCL_DEBUG_SUBSYS = prevDebugSubsys;
+    // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+    meta::comms::ncclx::ncclxInitLogger();
+#else
     initNcclLogger();
+#endif
   }
 
   void barrier() {

--- a/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -25,6 +25,7 @@
 #include "comms/utils/colltrace/tests/nvidia-only/CPUControlledKernel.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/commDump.h"
+#include "meta/wrapper/NcclxRuntime.h"
 
 using ::meta::comms::colltrace::CollTraceConfig;
 
@@ -111,7 +112,12 @@ class CollTraceTest : public NcclxBaseTestFixture {
         NCCL_DEBUG_SUBSYS.empty() ? "INIT,BOOTSTRAP,ENV" : NCCL_DEBUG_SUBSYS;
     NCCL_DEBUG = "INFO";
     NCCL_DEBUG_SUBSYS = "INIT,COLL";
+    // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+    meta::comms::ncclx::ncclxInitLogger();
+#else
     initNcclLogger();
+#endif
   }
 
   void endVerboseLogging() {
@@ -119,7 +125,12 @@ class CollTraceTest : public NcclxBaseTestFixture {
     NcclLogger::close();
     NCCL_DEBUG = prevDebug;
     NCCL_DEBUG_SUBSYS = prevDebugSubsys;
+    // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+    meta::comms::ncclx::ncclxInitLogger();
+#else
     initNcclLogger();
+#endif
   }
 
   void barrier() {

--- a/comms/ncclx/meta/comm/NcclxCommExt.h
+++ b/comms/ncclx/meta/comm/NcclxCommExt.h
@@ -1,0 +1,21 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+// Opaque per-communicator NCCLX state.
+//
+// This handle collects NCCLX-only members that would otherwise be woven
+// directly into the forked upstream `ncclComm` struct, keeping that struct
+// close to pristine NCCL. NCCLX code reaches the state through the single
+// `ncclComm::ncclxExt` pointer (including this header and dereferencing
+// `comm->ncclxExt`), while the forked `comm.h` only forward-declares the type.
+//
+// `ncclComm` is raw-allocated (calloc) and raw-freed, so no constructor or
+// destructor runs on it; this handle is instead created explicitly right after
+// the comm is allocated and destroyed in the NCCLX comm-free hook, giving it a
+// lifetime that exactly matches the communicator.
+struct ncclxCommExt {
+  // Ctran per-communicator control; populated from the parsed ncclx::Config at
+  // communicator init and gates creation of the per-comm CtranComm.
+  bool useCtran{false};
+};

--- a/comms/ncclx/meta/comm/NcclxCommExt.h
+++ b/comms/ncclx/meta/comm/NcclxCommExt.h
@@ -18,4 +18,8 @@ struct ncclxCommExt {
   // Ctran per-communicator control; populated from the parsed ncclx::Config at
   // communicator init and gates creation of the per-comm CtranComm.
   bool useCtran{false};
+
+  // Disable local transports (P2P and SHM); forces NET for all connections.
+  // Populated from the parsed ncclx::Config at communicator init.
+  bool noLocal{false};
 };

--- a/comms/ncclx/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/meta/commstate/FactoryCommStateX.cc
@@ -4,6 +4,7 @@
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/commstate/CommStateX.h"
 #include "meta/NcclxConfig.h" // @manual
+#include "meta/wrapper/NcclCommNoLocal.h"
 
 #include "nvmlwrap.h"
 #include "transport.h"
@@ -87,6 +88,8 @@ ncclResult_t initCommStateXFromNcclComm(void* _comm, CtranComm* ctranComm) {
   CHECKABORT(comm->rankToNode, "rankToNode is nullptr");
   CHECKABORT(comm->localRankToRank, "localRankToRank is nullptr");
 
+  const bool noLocal = meta::comms::ncclx::ncclCommNoLocal(comm);
+
   auto* bootstrap = ctranComm->bootstrap_.get();
 
   const int vCliqueSize = NCCLX_CONFIG_FIELD(comm->config, vCliqueSize);
@@ -101,7 +104,7 @@ ncclResult_t initCommStateXFromNcclComm(void* _comm, CtranComm* ctranComm) {
       std::vector<RankTopology>(), /* rankTopologies */
       std::vector<int>(), /* commRanksToWorldRanks */
       NCCLX_CONFIG_FIELD(comm->config, commDesc),
-      comm->noLocal_,
+      noLocal,
       vCliqueSize);
 
   try {
@@ -116,7 +119,7 @@ ncclResult_t initCommStateXFromNcclComm(void* _comm, CtranComm* ctranComm) {
   INFO(
       NCCL_INIT | NCCL_GRAPH,
       "CommStateX: set rankTopology with noLocal=%d, vCliqueSize=%d, commDesc=%s, commHash=0x%lx, rank=%d, nRanks=%d, nLocalRanks=%d",
-      comm->noLocal_,
+      noLocal,
       vCliqueSize,
       NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str(),
       comm->commHash,

--- a/comms/ncclx/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/meta/commstate/FactoryCommStateX.cc
@@ -6,6 +6,7 @@
 #include "comms/ctran/commstate/CommStateX.h"
 #include "meta/NcclxConfig.h" // @manual
 #include "meta/NcclxLogger.h"
+#include "meta/wrapper/NcclCommNoLocal.h"
 
 #include "nvmlwrap.h"
 #include "transport.h"
@@ -89,6 +90,8 @@ ncclResult_t initCommStateXFromNcclComm(void* _comm, CtranComm* ctranComm) {
   CHECKABORT(comm->rankToNode, "rankToNode is nullptr");
   CHECKABORT(comm->localRankToRank, "localRankToRank is nullptr");
 
+  const bool noLocal = meta::comms::ncclx::ncclCommNoLocal(comm);
+
   auto* bootstrap = ctranComm->bootstrap_.get();
 
   const int vCliqueSize = NCCLX_CONFIG_FIELD(comm->config, vCliqueSize);
@@ -103,7 +106,7 @@ ncclResult_t initCommStateXFromNcclComm(void* _comm, CtranComm* ctranComm) {
       std::vector<RankTopology>(), /* rankTopologies */
       std::vector<int>(), /* commRanksToWorldRanks */
       NCCLX_CONFIG_FIELD(comm->config, commDesc),
-      comm->noLocal_,
+      noLocal,
       vCliqueSize);
 
   try {
@@ -118,7 +121,7 @@ ncclResult_t initCommStateXFromNcclComm(void* _comm, CtranComm* ctranComm) {
   INFO(
       NCCL_INIT | NCCL_GRAPH,
       "CommStateX: set rankTopology with noLocal=%d, vCliqueSize=%d, commDesc=%s, commHash=0x%lx, rank=%d, nRanks=%d, nLocalRanks=%d",
-      comm->noLocal_,
+      noLocal,
       vCliqueSize,
       NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str(),
       comm->commHash,

--- a/comms/ncclx/meta/logger/tests/DebugExtentionUT.cc
+++ b/comms/ncclx/meta/logger/tests/DebugExtentionUT.cc
@@ -10,6 +10,7 @@
 #include "comms/utils/logger/Logger.h"
 
 #include "meta/logger/DebugExt.h"
+#include "meta/wrapper/NcclxRuntime.h"
 
 #include "debug.h" // @manual
 #include "param.h" // @manual
@@ -45,7 +46,12 @@ class DebugExtTest : public ::testing::Test {
 
   void initLogging() {
     ncclDebugLevel = -1;
+    // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+    meta::comms::ncclx::ncclxInitLogger();
+#else
     initNcclLogger();
+#endif
   }
 };
 

--- a/comms/ncclx/meta/logger/tests/LoggerUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggerUT.cc
@@ -16,6 +16,9 @@
 #include "LoggerUtil.h"
 #include "ScubaLoggerTestMixin.h"
 #include "debug.h" // @manual
+#include "nccl.h" // @manual
+
+#include "meta/wrapper/NcclxRuntime.h"
 
 #include "comms/testinfra/TestUtils.h"
 #include "comms/utils/commSpecs.h"
@@ -96,7 +99,12 @@ class NcclLoggerTest : public ::testing::Test, public ScubaLoggerTestMixin {
           return new DataTableAllTables(createAllMockTables(mockPassthru));
         });
     ncclDebugLevel = -1;
+    // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+    meta::comms::ncclx::ncclxInitLogger();
+#else
     initNcclLogger();
+#endif
   }
 
   void CommEventWriteLog() {

--- a/comms/ncclx/meta/logger/tests/LoggerUTBench.cc
+++ b/comms/ncclx/meta/logger/tests/LoggerUTBench.cc
@@ -9,6 +9,9 @@
 #include "LoggerUtil.h"
 #include "ScubaLoggerTestMixin.h"
 #include "debug.h" // @manual
+#include "nccl.h" // @manual
+
+#include "meta/wrapper/NcclxRuntime.h"
 
 #include "comms/testinfra/TestUtils.h"
 #include "comms/utils/commSpecs.h"
@@ -175,14 +178,24 @@ class NcclLoggerBenchTest : public ::testing::Test {
 
 TEST_F(NcclLoggerBenchTest, CommBenchScubaLog) {
   setLogType(LogType::SCUBA);
+  // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+  meta::comms::ncclx::ncclxInitLogger();
+#else
   initNcclLogger();
+#endif
   ncclLoggerBenchTest();
   finishLogging();
 }
 
 TEST_F(NcclLoggerBenchTest, CommBenchScubaLogWithEventApi) {
   setLogType(LogType::SCUBA);
+  // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+  meta::comms::ncclx::ncclxInitLogger();
+#else
   initNcclLogger();
+#endif
   ncclLoggerBenchTest(true);
   finishLogging();
 }
@@ -193,7 +206,12 @@ TEST_F(NcclLoggerBenchTest, CommBenchDebugLog) {
   EnvRAII env(NCCL_DEBUG_FILE, getTmpLogFile());
   // Reset ncclDebugLevel to force debug sub-system to be re-initialized
   ncclDebugLevel = -1;
+  // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+  meta::comms::ncclx::ncclxInitLogger();
+#else
   initNcclLogger();
+#endif
   ncclLoggerBenchTest();
   finishLogging();
 }

--- a/comms/ncclx/meta/logger/tests/LoggingUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggingUT.cc
@@ -16,6 +16,8 @@
 #include "comms/utils/logger/LoggingFormat.h"
 #include "meta/NcclxChecks.h"
 
+#include "meta/wrapper/NcclxRuntime.h"
+
 #include "debug.h" // @manual
 #include "param.h" // @manual
 
@@ -53,7 +55,12 @@ class NcclLoggerTest : public ::testing::Test {
 
   void initLogging() {
     ncclDebugLevel = -1;
+    // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+    meta::comms::ncclx::ncclxInitLogger();
+#else
     initNcclLogger();
+#endif
   }
 
   void initLegacyLogging() {

--- a/comms/ncclx/meta/logger/tests/LoggingUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggingUT.cc
@@ -15,6 +15,8 @@
 #include "comms/utils/logger/Logger.h"
 #include "comms/utils/logger/LoggingFormat.h"
 
+#include "meta/wrapper/NcclxRuntime.h"
+
 #include "debug.h" // @manual
 #include "param.h" // @manual
 
@@ -50,7 +52,12 @@ class NcclLoggerTest : public ::testing::Test {
 
   void initLogging() {
     ncclDebugLevel = -1;
+    // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+    meta::comms::ncclx::ncclxInitLogger();
+#else
     initNcclLogger();
+#endif
   }
 };
 

--- a/comms/ncclx/meta/tests/CommWithNoLocalTest.cc
+++ b/comms/ncclx/meta/tests/CommWithNoLocalTest.cc
@@ -21,6 +21,7 @@
 #include "VerifyAlgoStatsUtil.h"
 
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "meta/wrapper/NcclCommNoLocal.h"
 
 // Hint lifecycle tests
 
@@ -41,7 +42,7 @@ TEST_F(CommWithNoLocalTest, NoLocalDisabledByDefault) {
   ncclx::test::NcclCommRAII comm{
       globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_NE(comm.get(), nullptr);
-  EXPECT_FALSE(comm->noLocal_);
+  EXPECT_FALSE(meta::comms::ncclx::ncclCommNoLocal(comm.get()));
 }
 
 namespace {
@@ -60,7 +61,7 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
   ncclx::test::NcclCommRAII comm1{
       globalRank, numRanks, localRank, bootstrap_.get()};
   ASSERT_NE(comm1.get(), nullptr);
-  EXPECT_FALSE(comm1->noLocal_);
+  EXPECT_FALSE(meta::comms::ncclx::ncclCommNoLocal(comm1.get()));
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
@@ -93,14 +94,14 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
     } while (commStatus == ncclInProgress);
   }
 
-  EXPECT_TRUE(comm2->noLocal_);
+  EXPECT_TRUE(meta::comms::ncclx::ncclCommNoLocal(comm2));
 
   // Now disabled again
   {
     ncclx::test::NcclCommRAII comm3{
         globalRank, numRanks, localRank, bootstrap_.get()};
     ASSERT_NE(comm3.get(), nullptr);
-    EXPECT_FALSE(comm3->noLocal_);
+    EXPECT_FALSE(meta::comms::ncclx::ncclCommNoLocal(comm3.get()));
   }
 }
 
@@ -326,7 +327,7 @@ TEST_P(CommWithNoLocalCollTest, BaselineRun) {
   ncclx::test::NcclCommRAII comm{
       globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ASSERT_NE(comm.get(), nullptr);
-  EXPECT_EQ(comm->noLocal_, noLocal);
+  EXPECT_EQ(meta::comms::ncclx::ncclCommNoLocal(comm.get()), noLocal);
 
   run(comm.get(), collectiveOp);
   const char* collectiveName = (collectiveOp == CollectiveOp::kAllGather)
@@ -349,7 +350,7 @@ TEST_P(CommWithNoLocalCollTest, CtranRun) {
   ncclx::test::NcclCommRAII comm{
       globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ASSERT_NE(comm.get(), nullptr);
-  EXPECT_TRUE(comm->noLocal_);
+  EXPECT_TRUE(meta::comms::ncclx::ncclCommNoLocal(comm.get()));
 
   if (collectiveOp == CollectiveOp::kAllGather) {
     auto algoGuard = EnvRAII(NCCL_ALLGATHER_ALGO, NCCL_ALLGATHER_ALGO::ctran);

--- a/comms/ncclx/meta/tests/LogTest.cc
+++ b/comms/ncclx/meta/tests/LogTest.cc
@@ -11,6 +11,8 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/Logger.h"
 #include "debug.h"
+#include "meta/wrapper/NcclxRuntime.h"
+#include "nccl.h" // @manual
 
 class LogTest : public ::testing::Test {
  public:
@@ -24,7 +26,12 @@ class LogTest : public ::testing::Test {
   void initLogging() {
     ncclDebugLevel = -1;
     ncclDebugFile = nullptr;
+    // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+    meta::comms::ncclx::ncclxInitLogger();
+#else
     initNcclLogger();
+#endif
   }
 };
 

--- a/comms/ncclx/meta/tests/MemoryTraceDistTest.cc
+++ b/comms/ncclx/meta/tests/MemoryTraceDistTest.cc
@@ -25,6 +25,7 @@
 #include "comm.h" // @manual
 #include "comms/ncclx/meta/logger/tests/LoggerUtil.h"
 #include "debug.h" // @manual
+#include "meta/wrapper/NcclxRuntime.h"
 #include "nccl.h" // @manual
 
 class MemoryTraceTestFixture : public NcclxBaseTestFixture,
@@ -67,7 +68,12 @@ class MemoryTraceTestFixture : public NcclxBaseTestFixture,
     // force singleton init
     folly::Singleton<const DataTableAllTables, DataTableAllTablesTag>::
         try_get();
+    // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+    meta::comms::ncclx::ncclxInitLogger();
+#else
     initNcclLogger();
+#endif
     auto logFileName = getMemoryEventScubaFile();
     std::cout << "Rank " << this->globalRank
               << " reading from memory logging file " << logFileName

--- a/comms/ncclx/meta/tests/SendRecvTest.cc
+++ b/comms/ncclx/meta/tests/SendRecvTest.cc
@@ -15,6 +15,7 @@
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/algoconf/AlgoStrConv.h"
+#include "meta/wrapper/NcclCommNoLocal.h"
 
 static bool VERBOSE = true;
 
@@ -397,7 +398,7 @@ TEST_F(SendRecvTest, CtgraphGroupedSendRecv) {
 
   checkResults(recvPeer, commCount);
 
-  if (comm->noLocal_) {
+  if (meta::comms::ncclx::ncclCommNoLocal(comm)) {
     // nolocal: IB backend → ctgraph routes to ctran
     ctranAlgoStats_.verify(comm->ctranComm_.get(), "SendRecv", "Ctran");
   } else {

--- a/comms/ncclx/meta/wrapper/NcclCommNoLocal.h
+++ b/comms/ncclx/meta/wrapper/NcclCommNoLocal.h
@@ -1,0 +1,32 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comm.h"
+#include "nccl.h"
+
+// TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+#include "meta/comm/NcclxCommExt.h"
+#endif
+
+namespace meta::comms::ncclx {
+
+// Version-gated accessor for the per-communicator `noLocal` flag (disable local
+// P2P/SHM transports, forcing NET for all connections).
+//
+// In NCCL 2.30+ the flag lives on the opaque `comm->ncclxExt` handle, keeping
+// the forked upstream `ncclComm` struct closer to pristine NCCL. In older forks
+// (< 2.30, still the stable version) it remains a direct `ncclComm` member.
+// Routing shared NCCLX code and tests through this accessor lets them compile
+// against both layouts without touching the older fork.
+inline bool& ncclCommNoLocal(ncclComm* comm) {
+  // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+  return comm->ncclxExt->noLocal;
+#else
+  return comm->noLocal_;
+#endif
+}
+
+} // namespace meta::comms::ncclx

--- a/comms/ncclx/meta/wrapper/NcclCommUseCtran.h
+++ b/comms/ncclx/meta/wrapper/NcclCommUseCtran.h
@@ -1,0 +1,32 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comm.h"
+#include "nccl.h"
+
+// TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+#include "meta/comm/NcclxCommExt.h"
+#endif
+
+namespace meta::comms::ncclx {
+
+// Version-gated accessor for the per-communicator `useCtran` flag (route
+// supported collectives through CTRAN instead of the baseline path).
+//
+// In NCCL 2.30+ the flag lives on the opaque `comm->ncclxExt` handle, keeping
+// the forked upstream `ncclComm` struct closer to pristine NCCL. In older forks
+// (< 2.30, still the stable version) it remains a direct `ncclComm` member.
+// Routing shared NCCLX code and tests through this accessor lets them compile
+// against both layouts without touching the older fork.
+inline bool& ncclCommUseCtran(ncclComm* comm) {
+  // TODO T279903668: Cleanup version check after v2_29 removal
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+  return comm->ncclxExt->useCtran;
+#else
+  return comm->useCtran_;
+#endif
+}
+
+} // namespace meta::comms::ncclx

--- a/comms/ncclx/meta/wrapper/NcclxRuntime.cc
+++ b/comms/ncclx/meta/wrapper/NcclxRuntime.cc
@@ -1,0 +1,52 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "meta/wrapper/NcclxRuntime.h"
+
+#include <mutex>
+#include <string>
+#include <string_view>
+
+#include "comms/utils/InitFolly.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/SpdlogLogger.h"
+#include "meta/NcclxLogger.h"
+
+#include "cuda_runtime_api.h"
+
+namespace meta::comms::ncclx {
+
+void ncclxInitLogger() {
+  // Shared CollTrace code still emits raw XLOG under comms.utils.
+  meta::comms::logger::initCommLogging();
+  meta::comms::logger::configureSpdlogLogger(
+      ::ncclx::logging::kNcclxLoggerName,
+      "NCCL",
+      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
+      []() {
+        int cudaDev = -1;
+        (void)cudaGetDevice(&cudaDev);
+        return cudaDev;
+      },
+      [](std::string_view message) {
+        meta::comms::logger::setLastError(std::string{message}, {});
+      },
+      NCCL_DEBUG_LOGGING_ASYNC);
+  meta::comms::logger::getSpdlogLogger(::ncclx::logging::kNcclxLoggerName)
+      .set_level(
+          meta::comms::logger::loggerLevelToSpdlogLevel(
+              meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
+}
+
+void ncclxInitRuntime(void (*loadEnvFiles)()) {
+  static std::once_flag once;
+  std::call_once(once, [loadEnvFiles] {
+    meta::comms::initFolly();
+    ncclCvarInit();
+    loadEnvFiles();
+    ncclxInitLogger();
+  });
+}
+
+} // namespace meta::comms::ncclx

--- a/comms/ncclx/meta/wrapper/NcclxRuntime.cc
+++ b/comms/ncclx/meta/wrapper/NcclxRuntime.cc
@@ -1,0 +1,60 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "meta/wrapper/NcclxRuntime.h"
+
+#include <mutex>
+
+#include "comms/utils/InitFolly.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/Logger.h"
+#include "comms/utils/logger/LoggingFormat.h"
+
+#include "cuda_runtime_api.h"
+
+namespace meta::comms::ncclx {
+
+void ncclxInitLogger() {
+  NcclLogger::init(
+      NcclLoggerInitConfig{
+          .contextName = "comms.ncclx",
+          .logPrefix = "NCCL",
+          .logFilePath =
+              meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
+          .logLevel = meta::comms::logger::loggerLevelToFollyLogLevel(
+              meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
+          .threadContextFn = []() {
+            int cudaDev = -1;
+            cudaGetDevice(&cudaDev);
+            return cudaDev;
+          }});
+  // Init logging for NCCL header inside meta directory.
+  // This is due to the buck2 behavior of copying the header files to the
+  // buck-out directory.
+  // For logging in src/include headers, they are using NCCL logging
+  // (INFO/WARN/ERROR) which will inherit the logging category from debug.cc
+  NcclLogger::init(
+      NcclLoggerInitConfig{
+          .contextName = "meta",
+          .logPrefix = "NCCL",
+          .logFilePath =
+              meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
+          .logLevel = meta::comms::logger::loggerLevelToFollyLogLevel(
+              meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
+          .threadContextFn = []() {
+            int cudaDev = -1;
+            cudaGetDevice(&cudaDev);
+            return cudaDev;
+          }});
+}
+
+void ncclxInitRuntime(void (*loadEnvFiles)()) {
+  static std::once_flag once;
+  std::call_once(once, [loadEnvFiles] {
+    meta::comms::initFolly();
+    ncclCvarInit();
+    loadEnvFiles();
+    ncclxInitLogger();
+  });
+}
+
+} // namespace meta::comms::ncclx

--- a/comms/ncclx/meta/wrapper/NcclxRuntime.h
+++ b/comms/ncclx/meta/wrapper/NcclxRuntime.h
@@ -1,0 +1,28 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+namespace meta::comms::ncclx {
+
+// Initialize the NCCLX loggers for the "comms.ncclx" and "meta" logging
+// contexts. Unlike `ncclxInitRuntime`, this is NOT once-guarded, so callers
+// that reset logging state (e.g. tests that null the debug file and re-init)
+// can call it repeatedly. Also invoked by `ncclxInitRuntime` as the final
+// step of the one-time bootstrap.
+void ncclxInitLogger();
+
+// One-time NCCLX runtime bootstrap, hoisted out of the forked upstream
+// `param.cc` so that file stays close to pristine NCCL. Runs exactly once per
+// process, in this fixed order:
+//   1. Folly runtime init
+//   2. NCCLX CVAR init
+//   3. `loadEnvFiles` -- the upstream `.nccl.conf` / `/etc/nccl.conf` loader.
+//      It is kept in the forked file (it is pristine NCCL behavior) and passed
+//      in so only the NCCLX-only bootstrap lives here.
+//   4. NCCLX logger init
+//
+// `loadEnvFiles` must be non-null. Subsequent calls are no-ops (the bootstrap
+// is guarded by an internal `std::once_flag`).
+void ncclxInitRuntime(void (*loadEnvFiles)());
+
+} // namespace meta::comms::ncclx

--- a/comms/ncclx/v2_30/src/include/comm.h
+++ b/comms/ncclx/v2_30/src/include/comm.h
@@ -42,6 +42,7 @@
 
 // Forward declarations of ncclx classes to avoid circular dependencies
 class ICtran;
+struct ncclxCommExt;
 namespace meta::comms {
 class IBootstrap;
 } // namespace meta::comms
@@ -838,6 +839,8 @@ struct ncclComm {
   /**
    * NCCLX specific state
    */
+  // Opaque NCCLX-only per-comm state; see meta/comm/NcclxCommExt.h.
+  ncclxCommExt* ncclxExt{nullptr};
   struct CommLogData logMetaData;
   std::shared_ptr<meta::comms::colltrace::ICollTrace> newCollTrace;
   std::shared_ptr<meta::comms::colltrace::AlgoStats> algoStats;
@@ -847,7 +850,6 @@ struct ncclComm {
   std::shared_ptr<ncclx::transport::TransportProxy> transportProxy_;
 
   // This is the only bridge between ctran and baseline code
-  bool useCtran_{false}; // Ctran per-communicator control; set at init entry functions
   std::unique_ptr<CtranComm> ctranComm_;
 
   // [META:PAT_AVG] per-communicator control; set at init entry functions

--- a/comms/ncclx/v2_30/src/include/comm.h
+++ b/comms/ncclx/v2_30/src/include/comm.h
@@ -856,9 +856,6 @@ struct ncclComm {
   // When enabled, forces PAT algorithm with ncclDevPatSumPostDiv for ReduceScatter with ncclAvg
   bool usePatAvg_{false};
 
-  // Disable local transports (P2P and SHM); forces NET for all connections
-  bool noLocal_{false};
-
   struct ncclMemManager* memManager;  // Memory manager
   struct ncclIntruQueue<struct ncclMemManagerTask, &ncclMemManagerTask::next> suspendTaskQueue;
   struct ncclIntruQueue<struct ncclMemManagerTask, &ncclMemManagerTask::next> resumeTaskQueue;

--- a/comms/ncclx/v2_30/src/include/param.h
+++ b/comms/ncclx/v2_30/src/include/param.h
@@ -31,6 +31,4 @@ int64_t ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, i
     return cache; \
   }
 
-void initNcclLogger();
-
 #endif

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -63,6 +63,7 @@
 #include "comms/utils/logger/LoggingFormat.h"
 #include "comms/ctran/memory/SlabAllocator.h"
 #include "comms/ctran/memory/Utils.h"
+#include "meta/comm/NcclxCommExt.h"
 #include "meta/wrapper/MetaFactory.h"
 #include "meta/transport/transportExt.h"
 
@@ -299,6 +300,8 @@ static void ncclxCommFree(ncclComm_t comm) {
     delete static_cast<ncclx::Config*>(comm->config.ncclxConfig);
     comm->config.ncclxConfig = nullptr;
   }
+  delete comm->ncclxExt;
+  comm->ncclxExt = nullptr;
 }
 
 static ncclResult_t commFree(ncclComm_t comm) {
@@ -2027,7 +2030,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   NCCLCHECKGOTO(meta::comms::ncclx::newCollTraceInit(comm), res, fail);
 
 
-  if (comm->useCtran_) {
+  if (comm->ncclxExt->useCtran) {
     NCCLCHECKGOTO(createCtranComm(comm), res, fail);
   }
   // --------------------- done
@@ -2585,14 +2588,15 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   NCCLCHECKGOTO(ncclCudaHostCalloc(&comm->abortFlagDev, 1), res, fail);
   NCCLCHECKGOTO(ncclCalloc(&comm->abortFlagRefCount, 1), res, fail);
   comm->startMagic = comm->endMagic = NCCL_MAGIC; // Used to detect comm corruption.
+  NEW_NOTHROW_GOTO(comm->ncclxExt, ncclxCommExt, res, fail);
   // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
-  comm->useCtran_ = NCCLX_CONFIG_FIELD(*config, useCtran);
+  comm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(*config, useCtran);
   comm->usePatAvg_ = NCCLX_CONFIG_FIELD(*config, usePatAvg);
   comm->noLocal_ = NCCLX_CONFIG_FIELD(*config, noLocal);
   INFO(NCCL_INIT, "CommInit comm %p commHash 0x%lx commDesc %s useCtran %d usePatAvg %d noLocal %d",
        comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES),
        NCCLX_CONFIG_FIELD(*config, commDesc).c_str(),
-       comm->useCtran_, comm->usePatAvg_, comm->noLocal_);
+       comm->ncclxExt->useCtran, comm->usePatAvg_, comm->noLocal_);
   *comm->abortFlagRefCount = 1;
   NCCLCHECKGOTO(parseCommConfig(comm, config), res, fail);
   /* start with ncclInProgress and will be changed to ncclSuccess if init succeeds. */
@@ -3280,6 +3284,7 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
   } else {
     NCCLCHECKGOTO(ncclCalloc(&childComm, 1), res, fail);
     childComm->startMagic = childComm->endMagic = NCCL_MAGIC;
+    NEW_NOTHROW_GOTO(childComm->ncclxExt, ncclxCommExt, res, fail);
 
     // Set the shareResource field, this is used throughout the init and must be reset every time.
     // Never share resources if the parent communicator has been revoked.
@@ -3309,12 +3314,12 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
     /* start with ncclInternalError and will be changed to ncclSuccess if init succeeds. */
     childComm->initState = ncclInternalError;
     // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
-    childComm->useCtran_ = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
+    childComm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
     childComm->usePatAvg_ = NCCLX_CONFIG_FIELD(childComm->config, usePatAvg);
     childComm->noLocal_ = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
     INFO(NCCL_INIT, "CommSplit comm %p commDesc %s useCtran %d usePatAvg %d noLocal %d",
         childComm, NCCLX_CONFIG_FIELD(childComm->config, commDesc).c_str(),
-        childComm->useCtran_, childComm->usePatAvg_, childComm->noLocal_);
+        childComm->ncclxExt->useCtran, childComm->usePatAvg_, childComm->noLocal_);
   }
 
   NEW_NOTHROW_GOTO(job, ncclCommInitRankAsyncJob, res, fail);
@@ -3504,6 +3509,7 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
   // All ranks allocate a NEW comm structure for the grown communicator
   NCCLCHECKGOTO(ncclCalloc(&newComm, 1), res, fail);
   newComm->startMagic = newComm->endMagic = NCCL_MAGIC;
+  NEW_NOTHROW_GOTO(newComm->ncclxExt, ncclxCommExt, res, fail);
 
   // All ranks allocate fresh resources for grown communicator
   NCCLCHECKGOTO(ncclCalloc(&newComm->abortFlag, 1), res, fail);

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -2592,11 +2592,11 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
   comm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(*config, useCtran);
   comm->usePatAvg_ = NCCLX_CONFIG_FIELD(*config, usePatAvg);
-  comm->noLocal_ = NCCLX_CONFIG_FIELD(*config, noLocal);
+  comm->ncclxExt->noLocal = NCCLX_CONFIG_FIELD(*config, noLocal);
   INFO(NCCL_INIT, "CommInit comm %p commHash 0x%lx commDesc %s useCtran %d usePatAvg %d noLocal %d",
        comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES),
        NCCLX_CONFIG_FIELD(*config, commDesc).c_str(),
-       comm->ncclxExt->useCtran, comm->usePatAvg_, comm->noLocal_);
+       comm->ncclxExt->useCtran, comm->usePatAvg_, comm->ncclxExt->noLocal);
   *comm->abortFlagRefCount = 1;
   NCCLCHECKGOTO(parseCommConfig(comm, config), res, fail);
   /* start with ncclInProgress and will be changed to ncclSuccess if init succeeds. */
@@ -3316,10 +3316,10 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
     // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
     childComm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
     childComm->usePatAvg_ = NCCLX_CONFIG_FIELD(childComm->config, usePatAvg);
-    childComm->noLocal_ = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
+    childComm->ncclxExt->noLocal = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
     INFO(NCCL_INIT, "CommSplit comm %p commDesc %s useCtran %d usePatAvg %d noLocal %d",
         childComm, NCCLX_CONFIG_FIELD(childComm->config, commDesc).c_str(),
-        childComm->ncclxExt->useCtran, childComm->usePatAvg_, childComm->noLocal_);
+        childComm->ncclxExt->useCtran, childComm->usePatAvg_, childComm->ncclxExt->noLocal);
   }
 
   NEW_NOTHROW_GOTO(job, ncclCommInitRankAsyncJob, res, fail);

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -2594,11 +2594,11 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
   comm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(*config, useCtran);
   comm->usePatAvg_ = NCCLX_CONFIG_FIELD(*config, usePatAvg);
-  comm->noLocal_ = NCCLX_CONFIG_FIELD(*config, noLocal);
+  comm->ncclxExt->noLocal = NCCLX_CONFIG_FIELD(*config, noLocal);
   INFO(NCCL_INIT, "CommInit comm %p commHash 0x%lx commDesc %s useCtran %d usePatAvg %d noLocal %d",
        comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES),
        NCCLX_CONFIG_FIELD(*config, commDesc).c_str(),
-       comm->ncclxExt->useCtran, comm->usePatAvg_, comm->noLocal_);
+       comm->ncclxExt->useCtran, comm->usePatAvg_, comm->ncclxExt->noLocal);
   *comm->abortFlagRefCount = 1;
   NCCLCHECKGOTO(parseCommConfig(comm, config), res, fail);
   /* start with ncclInProgress and will be changed to ncclSuccess if init succeeds. */
@@ -3318,10 +3318,10 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
     // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
     childComm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
     childComm->usePatAvg_ = NCCLX_CONFIG_FIELD(childComm->config, usePatAvg);
-    childComm->noLocal_ = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
+    childComm->ncclxExt->noLocal = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
     INFO(NCCL_INIT, "CommSplit comm %p commDesc %s useCtran %d usePatAvg %d noLocal %d",
         childComm, NCCLX_CONFIG_FIELD(childComm->config, commDesc).c_str(),
-        childComm->ncclxExt->useCtran, childComm->usePatAvg_, childComm->noLocal_);
+        childComm->ncclxExt->useCtran, childComm->usePatAvg_, childComm->ncclxExt->noLocal);
   }
 
   NEW_NOTHROW_GOTO(job, ncclCommInitRankAsyncJob, res, fail);

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -63,6 +63,7 @@
 #include "comms/utils/logger/LoggingFormat.h"
 #include "comms/ctran/memory/SlabAllocator.h"
 #include "comms/ctran/memory/Utils.h"
+#include "meta/comm/NcclxCommExt.h"
 #include "meta/wrapper/MetaFactory.h"
 #include "meta/transport/transportExt.h"
 
@@ -299,6 +300,8 @@ static void ncclxCommFree(ncclComm_t comm) {
     delete static_cast<ncclx::Config*>(comm->config.ncclxConfig);
     comm->config.ncclxConfig = nullptr;
   }
+  delete comm->ncclxExt;
+  comm->ncclxExt = nullptr;
 }
 
 static ncclResult_t commFree(ncclComm_t comm) {
@@ -2029,7 +2032,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   NCCLCHECKGOTO(meta::comms::ncclx::newCollTraceInit(comm), res, fail);
 
 
-  if (comm->useCtran_) {
+  if (comm->ncclxExt->useCtran) {
     NCCLCHECKGOTO(createCtranComm(comm), res, fail);
   }
   // --------------------- done
@@ -2587,14 +2590,15 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   NCCLCHECKGOTO(ncclCudaHostCalloc(&comm->abortFlagDev, 1), res, fail);
   NCCLCHECKGOTO(ncclCalloc(&comm->abortFlagRefCount, 1), res, fail);
   comm->startMagic = comm->endMagic = NCCL_MAGIC; // Used to detect comm corruption.
+  NEW_NOTHROW_GOTO(comm->ncclxExt, ncclxCommExt, res, fail);
   // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
-  comm->useCtran_ = NCCLX_CONFIG_FIELD(*config, useCtran);
+  comm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(*config, useCtran);
   comm->usePatAvg_ = NCCLX_CONFIG_FIELD(*config, usePatAvg);
   comm->noLocal_ = NCCLX_CONFIG_FIELD(*config, noLocal);
   INFO(NCCL_INIT, "CommInit comm %p commHash 0x%lx commDesc %s useCtran %d usePatAvg %d noLocal %d",
        comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES),
        NCCLX_CONFIG_FIELD(*config, commDesc).c_str(),
-       comm->useCtran_, comm->usePatAvg_, comm->noLocal_);
+       comm->ncclxExt->useCtran, comm->usePatAvg_, comm->noLocal_);
   *comm->abortFlagRefCount = 1;
   NCCLCHECKGOTO(parseCommConfig(comm, config), res, fail);
   /* start with ncclInProgress and will be changed to ncclSuccess if init succeeds. */
@@ -3282,6 +3286,7 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
   } else {
     NCCLCHECKGOTO(ncclCalloc(&childComm, 1), res, fail);
     childComm->startMagic = childComm->endMagic = NCCL_MAGIC;
+    NEW_NOTHROW_GOTO(childComm->ncclxExt, ncclxCommExt, res, fail);
 
     // Set the shareResource field, this is used throughout the init and must be reset every time.
     // Never share resources if the parent communicator has been revoked.
@@ -3311,12 +3316,12 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
     /* start with ncclInternalError and will be changed to ncclSuccess if init succeeds. */
     childComm->initState = ncclInternalError;
     // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
-    childComm->useCtran_ = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
+    childComm->ncclxExt->useCtran = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
     childComm->usePatAvg_ = NCCLX_CONFIG_FIELD(childComm->config, usePatAvg);
     childComm->noLocal_ = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
     INFO(NCCL_INIT, "CommSplit comm %p commDesc %s useCtran %d usePatAvg %d noLocal %d",
         childComm, NCCLX_CONFIG_FIELD(childComm->config, commDesc).c_str(),
-        childComm->useCtran_, childComm->usePatAvg_, childComm->noLocal_);
+        childComm->ncclxExt->useCtran, childComm->usePatAvg_, childComm->noLocal_);
   }
 
   NEW_NOTHROW_GOTO(job, ncclCommInitRankAsyncJob, res, fail);
@@ -3506,6 +3511,7 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
   // All ranks allocate a NEW comm structure for the grown communicator
   NCCLCHECKGOTO(ncclCalloc(&newComm, 1), res, fail);
   newComm->startMagic = newComm->endMagic = NCCL_MAGIC;
+  NEW_NOTHROW_GOTO(newComm->ncclxExt, ncclxCommExt, res, fail);
 
   // All ranks allocate fresh resources for grown communicator
   NCCLCHECKGOTO(ncclCalloc(&newComm->abortFlag, 1), res, fail);

--- a/comms/ncclx/v2_30/src/misc/param.cc
+++ b/comms/ncclx/v2_30/src/misc/param.cc
@@ -15,17 +15,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <string>
 #include <mutex>
-#include <unordered_set>
 #include "os.h"
 
-#include "comms/utils/logger/Logger.h"
-#include "comms/utils/logger/LoggingFormat.h"
-#include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/InitFolly.h"
-
-#include "cuda_runtime_api.h"
+#include "meta/wrapper/NcclxRuntime.h"
 
 const char* userHomeDir() {
   return getenv("HOME");
@@ -74,13 +67,7 @@ static void initEnvFunc() {
 }
 
 void initEnv() {
-  static std::once_flag once;
-  std::call_once(once, [] {
-    meta::comms::initFolly();
-    ncclCvarInit();
-    initEnvFunc();
-    initNcclLogger();
-  });
+  meta::comms::ncclx::ncclxInitRuntime(initEnvFunc);
 }
 
 static void ncclGetCachePolicy(char const* env, int8_t* noCache) {
@@ -118,34 +105,4 @@ int64_t ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, i
 const char* ncclGetEnv(const char* name) {
   ncclInitEnv();
   return ncclEnvPluginGetEnv(name);
-}
-
-void initNcclLogger() {
-  NcclLogger::init(NcclLoggerInitConfig{
-    .contextName = "comms.ncclx",
-    .logPrefix = "NCCL",
-    .logFilePath = meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
-    .logLevel = meta::comms::logger::loggerLevelToFollyLogLevel(
-        meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
-    .threadContextFn = []() {
-      int cudaDev = -1;
-      cudaGetDevice(&cudaDev);
-      return cudaDev;
-    }});
-    // Init logging for NCCL header inside meta directory.
-    // This is due to the buck2 behavior of copying the header files to the
-    // buck-out directory.
-    // For logging in src/include headers, they are using NCCL logging
-    // (INFO/WARN/ERROR) which will inherit the loggging category from debug.cc
-    NcclLogger::init(NcclLoggerInitConfig{
-      .contextName = "meta",
-      .logPrefix = "NCCL",
-      .logFilePath = meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
-      .logLevel = meta::comms::logger::loggerLevelToFollyLogLevel(
-          meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
-      .threadContextFn = []() {
-        int cudaDev = -1;
-        cudaGetDevice(&cudaDev);
-        return cudaDev;
-      }});
 }

--- a/comms/ncclx/v2_30/src/misc/param.cc
+++ b/comms/ncclx/v2_30/src/misc/param.cc
@@ -20,13 +20,7 @@
 #include <unordered_set>
 #include "os.h"
 
-#include "comms/utils/logger/LogUtils.h"
-#include "comms/utils/logger/LoggingFormat.h"
-#include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/InitFolly.h"
-#include "meta/NcclxLogger.h"
-
-#include "cuda_runtime_api.h"
+#include "meta/wrapper/NcclxRuntime.h"
 
 const char* userHomeDir() {
   return getenv("HOME");
@@ -75,13 +69,7 @@ static void initEnvFunc() {
 }
 
 void initEnv() {
-  static std::once_flag once;
-  std::call_once(once, [] {
-    meta::comms::initFolly();
-    ncclCvarInit();
-    initEnvFunc();
-    initNcclLogger();
-  });
+  meta::comms::ncclx::ncclxInitRuntime(initEnvFunc);
 }
 
 static void ncclGetCachePolicy(char const* env, int8_t* noCache) {
@@ -119,25 +107,4 @@ int64_t ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, i
 const char* ncclGetEnv(const char* name) {
   ncclInitEnv();
   return ncclEnvPluginGetEnv(name);
-}
-
-void initNcclLogger() {
-  // Shared CollTrace code still emits raw XLOG under comms.utils.
-  meta::comms::logger::initCommLogging();
-  meta::comms::logger::configureSpdlogLogger(
-      ncclx::logging::kNcclxLoggerName,
-      "NCCL",
-      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
-      []() {
-        int cudaDev = -1;
-        (void)cudaGetDevice(&cudaDev);
-        return cudaDev;
-      },
-      [](std::string_view message) {
-        meta::comms::logger::setLastError(std::string{message}, {});
-      },
-      NCCL_DEBUG_LOGGING_ASYNC);
-  meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName)
-      .set_level(meta::comms::logger::loggerLevelToSpdlogLevel(
-          meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
 }

--- a/comms/ncclx/v2_30/src/transport/p2p.cc
+++ b/comms/ncclx/v2_30/src/transport/p2p.cc
@@ -7,6 +7,7 @@
 
 #include "checks.h"
 #include "comm.h"
+#include "meta/comm/NcclxCommExt.h"
 #include "meta/NcclxConfig.h" // @manual
 #include "graph.h"
 #include "utils.h"
@@ -137,7 +138,7 @@ extern int64_t ncclParamMNNVLEnable();
 ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2) {
   initCeOperation();
 
-  if (comm->noLocal_) {
+  if (comm->ncclxExt->noLocal) {
     *ret = 0;
     return ncclSuccess;
   }

--- a/comms/ncclx/v2_30/src/transport/shm.cc
+++ b/comms/ncclx/v2_30/src/transport/shm.cc
@@ -6,6 +6,7 @@
  *************************************************************************/
 
 #include "comm.h"
+#include "meta/comm/NcclxCommExt.h"
 #include "shmutils.h"
 #include "shm.h"
 #include "transport.h"
@@ -78,7 +79,7 @@ static ncclResult_t shmCanConnect(int* ret, struct ncclComm* comm, struct ncclTo
   *ret = 0;
   initCeOperation();
 
-  if (ncclParamShmDisable() == 1 || comm->noLocal_) return ncclSuccess;
+  if (ncclParamShmDisable() == 1 || comm->ncclxExt->noLocal) return ncclSuccess;
 
   int useNet = 0;
   NCCLCHECK(ncclTopoCheckNet(comm->topo, info1->rank, info2->rank, &useNet));


### PR DESCRIPTION
Summary:

The forked upstream `param.cc::initEnv()` wove the NCCLX-only runtime bootstrap
straight into the fork: a `std::once_flag`, the `initFolly` -> `ncclCvarInit` ->
env-file load -> `initNcclLogger` chain, and the entire `initNcclLogger()`
definition (with its folly-logger / CVAR / CUDA includes). All of that is NCCLX
addition sitting on top of pristine NCCL.

Move the NCCLX-only bootstrap into a new shared seam
`meta::comms::ncclx::ncclxInitRuntime()` (`meta/wrapper/NcclxRuntime.{h,cc}`).
The seam owns the once-guard and runs the bootstrap in the exact same order; the
pristine `.nccl.conf` / `/etc/nccl.conf` loader stays in the fork and is passed
in as a callback, so only NCCLX code moves out. `initEnv()` collapses to a
one-line delegation, and the forked `param.cc` / `param.h` shed the
`initNcclLogger()` definition + declaration and the folly-logger / `InitFolly` /
CVAR / CUDA includes.

This is a pure, behavior-preserving refactor: same calls, same order, same
run-exactly-once semantics; no init-flow change.

The relocated logger init is a file-local (anonymous-namespace) function and the
seam entry point is namespaced, so the shared `meta/` translation unit -- which
is compiled into both the v2.29 and v2.30 libraries -- does not collide with
v2.29's own external-linkage `initNcclLogger()` / `initEnv()`.

Footprint: the forked upstream files drop 43 net lines of fork-local NCCLX
additions (`param.cc` -41, `param.h` -2); the +85 lines added under
`meta/wrapper/` are NCCLX-only and do not count against the upstream fork
surface. No upstream NCCL API, type, enum, or macro is dropped.

Reviewed By: zhiyongww

Differential Revision: D113610740


