### PR TITLE
Prepost IB receives before QP connect

### DIFF
--- a/comms/ctran/backends/ib/CtranIbVc.cc
+++ b/comms/ctran/backends/ib/CtranIbVc.cc
@@ -572,6 +572,20 @@ commResult_t CtranIbVirtualConn::setupVc(void* remoteBusCard) {
     qpNumToIdx_.emplace(qpId, i);
   }
 
+  /* Post receive WQEs before making the QPs reachable. */
+  for (int i = 0; i < MAX_RECV_WR; i++) {
+    FB_COMMCHECK(this->postRecvCtrlMsg(this->recvCtrl_.packets_.at(i)));
+    this->recvCtrl_.postedPkts_.push_back(this->recvCtrl_.packets_.at(i));
+
+    // Pre populate recv on notifyQp
+    this->postRecvNotifyMsg(kNotifyQpIdx);
+
+    // In case dqplb is used, pre populate recv on dataQps
+    for (int j = 0; j < maxNumQps_; j++) {
+      FB_COMMCHECK(this->postRecvNotifyMsg(j));
+    }
+  }
+
   /* set QP to RTR state for control and notify QP first*/
   const int ctrlDevice = ctrlDevice_;
   RemoteQpInfo remoteQpInfo = {
@@ -641,20 +655,6 @@ commResult_t CtranIbVirtualConn::setupVc(void* remoteBusCard) {
   for (int i = 0; i < maxNumQps_; i++) {
     FOLLY_EXPECTED_CHECK(
         rtsQp(ibvDataQps_.at(i), NCCL_IB_TIMEOUT, NCCL_IB_RETRY_CNT));
-  }
-
-  /* post control WQEs */
-  for (int i = 0; i < MAX_RECV_WR; i++) {
-    FB_COMMCHECK(this->postRecvCtrlMsg(this->recvCtrl_.packets_.at(i)));
-    this->recvCtrl_.postedPkts_.push_back(this->recvCtrl_.packets_.at(i));
-
-    // Pre populate recv on notifyQp
-    this->postRecvNotifyMsg(kNotifyQpIdx);
-
-    // In case dqplb is used, pre populate recv on dataQps
-    for (int j = 0; j < maxNumQps_; j++) {
-      FB_COMMCHECK(this->postRecvNotifyMsg(j));
-    }
   }
 
   isReady_ = true;


### PR DESCRIPTION
Summary:
1KB MCCL ctring AllReduce runs were intermittently incrementing `rnr_nak_retry_err` during startup. The issue reproduced in the local 8-rank, IB-only, 1KB-only benchmark before the fix:
- DQPLB: RNR deltas `+2`, `+0`, `+4` across three 2000-iteration runs.
- SPRAY: RNR deltas `+3`, `+1`, `+5` across three 2000-iteration runs.
- All reproductions exited 0 with wrong count 0.

Temporary timestamp instrumentation around `CtranIbVirtualConn::setupVc()`, `postRecvNotifyMsg()`, receive-with-immediate completions, and spray notify sends showed this was not steady-state receive queue depletion. Once receive completions started, notify/data receive credits stayed at `127/128` and were reposted immediately. RNR counter jumps instead correlated with the setup/prepost window, where QPs were already reachable before receive WQEs were populated.

Move control, notify, and data receive preposting before the QPs are moved to RTR/RTS. This keeps receive queues populated before the peer can legally send traffic to the QP.

After the fix, the same 1KB validation matrix produced RNR delta `0` for all six runs:
- DQPLB: `0`, `0`, `0`.
- SPRAY: `0`, `0`, `0`.
- All final runs exited 0 with wrong count 0.

Differential Revision: D114139030


