### PR TITLE
IBGDA transport: variable-size CopyOp send/recv support (#3346)

### DIFF
--- a/comms/prims/benchmarks/IbgdaSendRecvAns.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecvAns.cu
@@ -1,0 +1,128 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// ANS (variable-size CopyOp) send/recv benchmark kernels for the IBGDA
+// transport. Built with `--device-c` + `PIPES_ENABLE_ANS_COMPRESSION` and
+// device-linked against the nvcompdx fatbin (see `:ibgda_sendrecv_ans_kernels`
+// in BUCK) so `AnsCompress<...>::send/recv` resolve. This TU is the transport
+// benchmark's first client of the variable-size compressed send/recv path
+// added in D111967119; it lives in its own translation unit + device-link
+// target (mirroring `:ans_copy_op_bench`) so the plain `Memcpy` kernels in
+// IbgdaSendRecv.cu stay nvcompdx-free and pay no device-link cost.
+
+#include "comms/prims/benchmarks/IbgdaSendRecvAns.h"
+
+#include "comms/prims/core/CopyOp.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/core/TiledBuffer.cuh"
+#include "comms/prims/core/Timeout.cuh"
+#include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
+
+namespace comms::prims::benchmark {
+
+namespace {
+
+// Each block is one cooperative compress/decompress group. AnsCompress is
+// instantiated for 8 warps (256 threads): the warp count drives the per-block
+// nvcompdx scratch + register footprint, so raising it too far trips
+// cudaErrorLaunchOutOfResources for the combined ANS + transport kernel. The
+// grid launches one such block per channel (numBlocks), matching the plain
+// Memcpy launchers.
+constexpr int kAnsNumWarps = 8;
+// Both kernels ask ptxas for 8 resident blocks/SM (8 * 256 == 2048 threads ==
+// a fully occupied SM). That caps the compiler at 65536/2048 == 32 registers
+// per thread, which is well under what the ANS codec wants: send() drops from
+// ~195 registers / 256 B of stack to 32 / 800 B, i.e. the codec's live state
+// moves into local memory. Occupancy is being bought with spills here.
+constexpr int kAnsMinBlocksPerSm = 8;
+using BenchAnsCompress =
+    AnsCompress<kAnsNumWarps, PIPES_ANS_DEFAULT_MAX_UNCOMP_BYTES>;
+
+__device__ __forceinline__ std::size_t ans_section_bytes(
+    P2pIbgdaTransportDevice* transport,
+    std::size_t totalBytes) {
+  return min(transport->channel_layout().data_buffer_size(), totalBytes);
+}
+
+} // namespace
+
+__global__ void __launch_bounds__(kAnsNumWarps * 32, kAnsMinBlocksPerSm)
+    ibgda_send_ans_kernel(
+        P2pIbgdaTransportDevice* transport,
+        char* src,
+        std::size_t totalBytes,
+        Timeout timeout) {
+  auto group = make_block_group();
+
+  const std::size_t sectionBytes = ans_section_bytes(transport, totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    TiledBuffer<char> tiles(src + s * sectionBytes, sectionBytes, group);
+    // max_signal_bytes = 0 exercises the transport's 0-sentinel, which derives
+    // the trap-safe chunk size via CopyOp::max_safe_chunk_size_for_slot().
+    // Trailing nullptr is AnsCompress::send()'s alignedAuxBuf (src is a
+    // cudaMalloc base stepped by 512-byte-aligned chunk offsets => 16B
+    // aligned).
+    transport->send<BenchAnsCompress>(
+        group,
+        tiles.data(),
+        tiles.bytes(),
+        /*max_signal_bytes=*/0,
+        timeout,
+        /*alignedAuxBuf=*/static_cast<char*>(nullptr));
+  }
+}
+
+__global__ void __launch_bounds__(kAnsNumWarps * 32, kAnsMinBlocksPerSm)
+    ibgda_recv_ans_kernel(
+        P2pIbgdaTransportDevice* transport,
+        char* dst,
+        std::size_t totalBytes,
+        Timeout timeout) {
+  auto group = make_block_group();
+
+  const std::size_t sectionBytes = ans_section_bytes(transport, totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    TiledBuffer<char> tiles(dst + s * sectionBytes, sectionBytes, group);
+    // max_signal_bytes = 0: exercise the transport's 0-sentinel (derives the
+    // trap-safe chunk size via CopyOp::max_safe_chunk_size_for_slot()).
+    transport->recv<BenchAnsCompress>(
+        group, tiles.data(), tiles.bytes(), /*max_signal_bytes=*/0, timeout);
+  }
+}
+
+void launch_ibgda_send_ans(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    Timeout timeout) {
+  ibgda_send_ans_kernel<<<numBlocks, kAnsNumWarps * 32, 0, stream>>>(
+      transport, src, nbytes, timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] ANS send kernel launch failed: %s\n", cudaGetErrorString(err));
+  }
+}
+
+void launch_ibgda_recv_ans(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    Timeout timeout) {
+  ibgda_recv_ans_kernel<<<numBlocks, kAnsNumWarps * 32, 0, stream>>>(
+      transport, dst, nbytes, timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] ANS recv kernel launch failed: %s\n", cudaGetErrorString(err));
+  }
+}
+
+} // namespace comms::prims::benchmark

--- a/comms/prims/benchmarks/IbgdaSendRecvAns.h
+++ b/comms/prims/benchmarks/IbgdaSendRecvAns.h
@@ -1,0 +1,50 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstddef>
+
+#include "comms/prims/core/Timeout.cuh"
+
+namespace comms::prims {
+class P2pIbgdaTransportDevice;
+} // namespace comms::prims
+
+namespace comms::prims::benchmark {
+
+// Unidirectional ANS send/recv launchers for the IBGDA transport.
+//
+// These drive a VARIABLE-SIZE CopyOp (`AnsCompress`) over the transport's
+// blocking send()/recv(), which is what exercises the
+// `if constexpr (detail::copyop_variable_size_v<CopyOp>)` compressed path
+// added in D111967119 (the plain `Memcpy` launchers only ever compile/run
+// the fixed-size branch). The compressed on-wire size is data-dependent, so
+// the transport reserves a worst-case staging stride per sub-chunk and the
+// RDMA put is sized from `AnsCompress::send()`'s returned byte count.
+
+/**
+ * Launch unidirectional ANS (compressed) tile send. All blocks send.
+ * Grid: numBlocks. Block: 256 threads (8 warps == AnsCompress NumWarps).
+ */
+void launch_ibgda_send_ans(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    Timeout timeout = Timeout());
+
+/**
+ * Launch unidirectional ANS (compressed) tile recv. All blocks receive.
+ * Grid: numBlocks. Block: 256 threads (8 warps == AnsCompress NumWarps).
+ */
+void launch_ibgda_recv_ans(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    Timeout timeout = Timeout());
+
+} // namespace comms::prims::benchmark

--- a/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -17,6 +17,7 @@
 #include <utility>
 
 #include "comms/prims/benchmarks/IbgdaSendRecv.h"
+#include "comms/prims/benchmarks/IbgdaSendRecvAns.h"
 #include "comms/prims/transport/ibgda/MultipeerIbgdaTransport.h"
 #include "comms/testinfra/ITestBootstrap.h"
 #include "comms/testinfra/TcpStoreBootstrap.h"
@@ -47,6 +48,14 @@ enum class SendRecvApi {
 enum class SendRecvDirection {
   Bidirectional,
   Unidirectional,
+};
+
+// CopyOp policy driven through the transport. `Memcpy` is the fixed-size path;
+// `Ans` drives the variable-size (compressed) `AnsCompress` CopyOp, exercising
+// the compressed send/recv branch added in D111967119.
+enum class SendRecvCopyOp {
+  Memcpy,
+  Ans,
 };
 
 bool isTcpEnvironment() {
@@ -203,6 +212,13 @@ constexpr std::array<BenchmarkSize, 33> kBenchmarkSizes{{
 
 constexpr std::size_t kMaxBenchmarkBytes = 4ULL << 30;
 
+// ANS (variable-size) benchmarks run only over this size window. Below 1MB the
+// per-chunk compress/decompress cost dominates (see AnsCompress
+// kActivationThreshold), and the window is capped so the compressed sweep
+// stays bounded in wall-clock time.
+constexpr std::size_t kAnsMinBytes = 1ULL << 20;
+constexpr std::size_t kAnsMaxBytes = 256ULL << 20;
+
 const char* apiName(SendRecvApi api) {
   switch (api) {
     case SendRecvApi::Blocking:
@@ -223,14 +239,27 @@ const char* directionName(SendRecvDirection direction) {
   return "unknown";
 }
 
+const char* copyOpName(SendRecvCopyOp copyOp) {
+  switch (copyOp) {
+    case SendRecvCopyOp::Memcpy:
+      return "memcpy";
+    case SendRecvCopyOp::Ans:
+      return "ans";
+  }
+  return "unknown";
+}
+
 std::string benchmarkName(
     SendRecvApi api,
     SendRecvDirection direction,
+    SendRecvCopyOp copyOp,
     const char* sizeName) {
   std::string name = "ibgdaSendRecv(";
   name += apiName(api);
   name += "_";
   name += directionName(direction);
+  name += "_";
+  name += copyOpName(copyOp);
   name += "_";
   name += sizeName;
   name += ")";
@@ -303,12 +332,15 @@ class IbgdaSendRecvBenchmarkContext {
   IbgdaSendRecvBenchmarkContext& operator=(IbgdaSendRecvBenchmarkContext&&) =
       delete;
 
-  void
-  warmup(std::size_t nbytes, SendRecvApi api, SendRecvDirection direction) {
+  void warmup(
+      std::size_t nbytes,
+      SendRecvApi api,
+      SendRecvDirection direction,
+      SendRecvCopyOp copyOp) {
     CHECK_LE(nbytes, maxBytes_);
     bootstrap_->barrierAll();
     for (int i = 0; i < kWarmupIters; ++i) {
-      launchOperation(nbytes, api, direction);
+      launchOperation(nbytes, api, direction, copyOp);
       CHECK_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
     }
   }
@@ -317,7 +349,8 @@ class IbgdaSendRecvBenchmarkContext {
       uint32_t iters,
       std::size_t nbytes,
       SendRecvApi api,
-      SendRecvDirection direction) {
+      SendRecvDirection direction,
+      SendRecvCopyOp copyOp) {
     CHECK_LE(nbytes, maxBytes_);
 
     cudaEvent_t start{};
@@ -327,7 +360,7 @@ class IbgdaSendRecvBenchmarkContext {
 
     CHECK_EQ(cudaEventRecord(start, stream_), cudaSuccess);
     for (uint32_t i = 0; i < iters; ++i) {
-      launchOperation(nbytes, api, direction);
+      launchOperation(nbytes, api, direction, copyOp);
     }
     CHECK_EQ(cudaEventRecord(stop, stream_), cudaSuccess);
     CHECK_EQ(cudaEventSynchronize(stop), cudaSuccess);
@@ -344,9 +377,24 @@ class IbgdaSendRecvBenchmarkContext {
   void launchOperation(
       std::size_t nbytes,
       SendRecvApi api,
-      SendRecvDirection direction) {
+      SendRecvDirection direction,
+      SendRecvCopyOp copyOp) {
     auto* sendBuf = static_cast<char*>(sendBuf_->get());
     auto* recvBuf = static_cast<char*>(recvBuf_->get());
+
+    if (copyOp == SendRecvCopyOp::Ans) {
+      // ANS is a variable-size CopyOp: only the blocking, unidirectional path
+      // is wired here (the resumable progress API static_asserts against
+      // variable-size CopyOps). rank 0 compresses+sends, rank 1 recvs+decomp.
+      if (globalRank_ == 0) {
+        launch_ibgda_send_ans(
+            deviceTransport_, sendBuf, nbytes, kNumBlocks, stream_);
+      } else {
+        launch_ibgda_recv_ans(
+            deviceTransport_, recvBuf, nbytes, kNumBlocks, stream_);
+      }
+      return;
+    }
 
     if (direction == SendRecvDirection::Bidirectional) {
       if (api == SendRecvApi::Blocking) {
@@ -396,15 +444,16 @@ static unsigned int ibgdaSendRecv(
     std::size_t nbytes,
     SendRecvApi api,
     SendRecvDirection direction,
+    SendRecvCopyOp copyOp,
     folly::UserCounters& counters) {
   CHECK_GT(iters, 0);
 
   BENCHMARK_SUSPEND {
-    context.warmup(nbytes, api, direction);
+    context.warmup(nbytes, api, direction, copyOp);
   }
 
   const float elapsedMs =
-      context.runLocalElapsed(iters, nbytes, api, direction);
+      context.runLocalElapsed(iters, nbytes, api, direction, copyOp);
   folly::doNotOptimizeAway(elapsedMs);
 
   BENCHMARK_SUSPEND {
@@ -427,32 +476,55 @@ void registerBenchmark(
     IbgdaSendRecvBenchmarkContext& context,
     const BenchmarkSize& size,
     SendRecvApi api,
-    SendRecvDirection direction) {
+    SendRecvDirection direction,
+    SendRecvCopyOp copyOp) {
   folly::addBenchmark(
       __FILE__,
-      benchmarkName(api, direction, size.name),
-      [&context, nbytes = size.nbytes, api, direction](
+      benchmarkName(api, direction, copyOp, size.name),
+      [&context, nbytes = size.nbytes, api, direction, copyOp](
           folly::UserCounters& counters, unsigned int iters) -> unsigned int {
-        return ibgdaSendRecv(context, iters, nbytes, api, direction, counters);
+        return ibgdaSendRecv(
+            context, iters, nbytes, api, direction, copyOp, counters);
       });
 }
 
 void registerBenchmarks(IbgdaSendRecvBenchmarkContext& context) {
   for (const auto& size : kBenchmarkSizes) {
     registerBenchmark(
-        context, size, SendRecvApi::Blocking, SendRecvDirection::Bidirectional);
-    registerBenchmark(
-        context, size, SendRecvApi::Progress, SendRecvDirection::Bidirectional);
-    registerBenchmark(
         context,
         size,
         SendRecvApi::Blocking,
-        SendRecvDirection::Unidirectional);
+        SendRecvDirection::Bidirectional,
+        SendRecvCopyOp::Memcpy);
     registerBenchmark(
         context,
         size,
         SendRecvApi::Progress,
-        SendRecvDirection::Unidirectional);
+        SendRecvDirection::Bidirectional,
+        SendRecvCopyOp::Memcpy);
+    registerBenchmark(
+        context,
+        size,
+        SendRecvApi::Blocking,
+        SendRecvDirection::Unidirectional,
+        SendRecvCopyOp::Memcpy);
+    registerBenchmark(
+        context,
+        size,
+        SendRecvApi::Progress,
+        SendRecvDirection::Unidirectional,
+        SendRecvCopyOp::Memcpy);
+    // ANS (variable-size CopyOp): blocking + unidirectional only, over a
+    // bounded size window. This is the transport benchmark's coverage of the
+    // compressed send/recv path from D111967119.
+    if (size.nbytes >= kAnsMinBytes && size.nbytes <= kAnsMaxBytes) {
+      registerBenchmark(
+          context,
+          size,
+          SendRecvApi::Blocking,
+          SendRecvDirection::Unidirectional,
+          SendRecvCopyOp::Ans);
+    }
   }
 }
 

--- a/comms/prims/collectives/benchmarks/AnsCopyOpBench.cc
+++ b/comms/prims/collectives/benchmarks/AnsCopyOpBench.cc
@@ -1,0 +1,528 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Standalone single-GPU microbenchmark for the raw ANS CopyOp APIs
+// (`AnsCompress::send()` / `AnsCompress::recv()` in
+// `comms/prims/core/CopyOp.cuh`) — no transport, no inter-rank
+// communication. Extracted from AllToAllvTileBenchmark.cc so the ANS
+// CopyOp primitive can be enabled and benchmarked independently of the
+// AllToAllv-tile collective.
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <cuda.h> // driver API: green contexts for SM partitioning
+
+#include "comms/common/CudaWrap.h"
+#include "comms/prims/collectives/benchmarks/AnsCopyOpBench.cuh"
+#include "comms/prims/core/Checks.h"
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::CudaEvent;
+using meta::comms::DeviceBuffer;
+
+namespace comms::prims::benchmark {
+namespace {
+
+// Local placeholder for the ANS stats struct. The standalone microbench
+// measures the produced compressed size directly per iteration rather than
+// via the device-global stat counters, so this stays {0, 0} (the ratio
+// branch guarded by `compressed_bytes > 0` is intentionally inert here).
+struct LocalCompStats {
+  uint64_t uncompressed_bytes = 0;
+  uint64_t compressed_bytes = 0;
+};
+
+// Driver-API error check (runtime calls use PIPES_CUDA_CHECK).
+#define PIPES_CU_CHECK(expr)                                           \
+  do {                                                                 \
+    CUresult _res = (expr);                                            \
+    if (_res != CUDA_SUCCESS) {                                        \
+      const char* _msg = nullptr;                                      \
+      cuGetErrorString(_res, &_msg);                                   \
+      XLOG(FATAL) << "[AnsCopyOpStandalone] CUDA driver error: " #expr \
+                  << " -> " << (_msg ? _msg : "unknown");              \
+    }                                                                  \
+  } while (0)
+
+// A stream confined to a green context spanning >= `numSms` SMs of the
+// current device. Launching the bench kernels on this stream restricts
+// them to that SM partition, so a fixed grid runs at a controlled
+// blocks/SM ratio (e.g. 512 blocks on 32 SMs => 16 blocks/SM). `numSms
+// <= 0` returns an empty handle (stream == nullptr) = the default stream
+// over the whole GPU. The realized SM count may round up to the hardware
+// split granularity.
+struct GreenCtxStream {
+  CUgreenCtx ctx = nullptr;
+  cudaStream_t stream = nullptr;
+};
+
+GreenCtxStream makeGreenCtxStream(int numSms) {
+  GreenCtxStream out;
+  if (numSms <= 0) {
+    return out;
+  }
+  int ordinal = 0;
+  PIPES_CUDA_CHECK(cudaGetDevice(&ordinal));
+  CUdevice dev = 0;
+  PIPES_CU_CHECK(cuDeviceGet(&dev, ordinal));
+
+  CUdevResource sm{};
+  const CUresult smRes =
+      cuDeviceGetDevResource(dev, &sm, CU_DEV_RESOURCE_TYPE_SM);
+  if (smRes != CUDA_SUCCESS) {
+    const char* nm = nullptr;
+    cuGetErrorName(smRes, &nm);
+    XLOG(FATAL)
+        << "[AnsCopyOpStandalone] green-context SM partitioning unavailable "
+        << "(cuDeviceGetDevResource -> " << (nm ? nm : "?") << "). "
+        << "PIPES_COPYOP_BENCH_NUM_SMS requires CUDA driver >= 12.4 (R550); "
+        << "this host's driver is older. Re-run without "
+        << "PIPES_COPYOP_BENCH_NUM_SMS (whole GPU) or use a newer-driver host.";
+  }
+  CUdevResource group{};
+  CUdevResource remaining{};
+  unsigned int nGroups = 1;
+  PIPES_CU_CHECK(cuDevSmResourceSplitByCount(
+      &group,
+      &nGroups,
+      &sm,
+      &remaining,
+      /*useFlags=*/0,
+      /*minCount=*/static_cast<unsigned int>(numSms)));
+
+  CUdevResourceDesc desc{};
+  PIPES_CU_CHECK(cuDevResourceGenerateDesc(&desc, &group, 1));
+  PIPES_CU_CHECK(
+      cuGreenCtxCreate(&out.ctx, desc, dev, CU_GREEN_CTX_DEFAULT_STREAM));
+
+  CUstream cuStream = nullptr;
+  PIPES_CU_CHECK(cuGreenCtxStreamCreate(
+      &cuStream, out.ctx, CU_STREAM_NON_BLOCKING, /*priority=*/0));
+  out.stream = reinterpret_cast<cudaStream_t>(cuStream);
+  return out;
+}
+
+std::string format_bytes(std::size_t bytes) {
+  if (bytes >= 1024UL * 1024 * 1024) {
+    return std::to_string(bytes / (1024UL * 1024 * 1024)) + "GB";
+  }
+  if (bytes >= 1024 * 1024) {
+    return std::to_string(bytes / (1024 * 1024)) + "MB";
+  }
+  if (bytes >= 1024) {
+    return std::to_string(bytes / 1024) + "KB";
+  }
+  return std::to_string(bytes) + "B";
+}
+
+class AnsCopyOpBenchFixture : public meta::comms::BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    const char* localRankEnv = std::getenv("OMPI_COMM_WORLD_LOCAL_RANK");
+    if (localRankEnv) {
+      localRank = std::atoi(localRankEnv);
+    }
+    PIPES_CUDA_CHECK(cudaSetDevice(localRank));
+  }
+};
+
+TEST_F(AnsCopyOpBenchFixture, AnsCopyOpStandalone) {
+  // Single-GPU microbenchmark for the raw `AnsCompress::send()` /
+  // `AnsCompress::recv()` APIs in `CopyOp.cuh` — no transport, no
+  // inter-rank communication. Only rank 0 drives the launches; the
+  // other ranks return immediately so the run wall-time isn't
+  // dominated by per-rank serialisation. There are no in-test
+  // `bootstrap->barrierAll()` calls because each rank's behaviour is
+  // independent.
+  if (globalRank != 0) {
+    return;
+  }
+
+  // Defaults requested by the bench owner: 20 warmup + 200 timed
+  // iterations per (sparsity, size) cell, driven from inside the
+  // kernel so we measure pure ANS (de)compression time and amortise
+  // the per-launch overhead.
+  constexpr int kCopyOpWarmupIter = 20;
+  constexpr int kCopyOpMeasureIter = 200;
+  // Launch geometry. Both overridable at runtime via env vars (no
+  // rebuild) for quick sweeps:
+  //
+  //   PIPES_COPYOP_BENCH_BLOCKS=128 PIPES_COPYOP_BENCH_THREADS=512 \
+  //       buck2 run ... -- --gtest_filter='*AnsCopyOpStandalone*'
+  //
+  // `threads` must be one of {32, 64, 128, 256, 512} (the NumWarps
+  // ∈ {1, 2, 4, 8, 16} values explicitly instantiated in
+  // `AnsCopyOpBench.cu`); `min_blocks_per_sm` must be one of {1, 2,
+  // 3, 4}, plus the two 100%-occupancy points {256 threads → 8,
+  // 128 threads → 16} (the second `__launch_bounds__` argument).
+  // Other values are rejected at launch.
+  //
+  // Defaults target 100% occupancy on H100-class SMs: 512 blocks ×
+  // 256 threads confined to 64 SMs = 8 blocks/SM = 64 warps/SM, with
+  // `min_blocks_per_sm=8` capping registers at 65536/(256*8)=32/thread
+  // so all 8 blocks stay resident.
+  auto env_int = [](const char* name, int fallback) {
+    const char* v = std::getenv(name);
+    return (v != nullptr && *v != '\0') ? std::atoi(v) : fallback;
+  };
+  const int kCopyOpBlocks = env_int("PIPES_COPYOP_BENCH_BLOCKS", 512);
+  const int kCopyOpThreads = env_int("PIPES_COPYOP_BENCH_THREADS", 256);
+  const int kCopyOpMinBlocksPerSM =
+      env_int("PIPES_COPYOP_BENCH_MIN_BLOCKS_PER_SM", 8);
+  // >0 = confine the kernel to a green context of this many SMs (rounds
+  // up to the hw split granularity); 0 = whole GPU. Default 64 pairs
+  // with 512 blocks to give 8 blocks/SM.
+  const int kCopyOpNumSms = env_int("PIPES_COPYOP_BENCH_NUM_SMS", 64);
+  const AnsCopyOpBenchKernels bench_kernels =
+      pick_ans_copy_op_bench_kernels(kCopyOpThreads, kCopyOpMinBlocksPerSM);
+  if (kCopyOpBlocks <= 0 || bench_kernels.compress_kernel == nullptr) {
+    GTEST_FAIL() << "Invalid PIPES_COPYOP_BENCH_BLOCKS=" << kCopyOpBlocks
+                 << " / PIPES_COPYOP_BENCH_THREADS=" << kCopyOpThreads
+                 << " / PIPES_COPYOP_BENCH_MIN_BLOCKS_PER_SM="
+                 << kCopyOpMinBlocksPerSM
+                 << " (threads must be one of 32, 64, 128, 256, 512; "
+                 << "min_blocks_per_sm must be one of 1, 2, 3, 4, or the "
+                 << "100%-occupancy points 8 (256 threads) / 16 (128 "
+                 << "threads); blocks must be positive)";
+  }
+
+  const std::vector<std::size_t> sizes = {
+      256ULL * 1024,
+      512ULL * 1024,
+      1024ULL * 1024,
+      2ULL * 1024 * 1024,
+      4ULL * 1024 * 1024,
+  };
+
+  // Allocate buffers once at the largest size and reuse them across
+  // the sparsity × size sweep. Layout: [block 0 region | block 1
+  // region | ...]. The compress kernel writes into `d_staging` and
+  // the decompress kernel reads from the same buffer, so the
+  // decompress measurement always sees a freshly-produced layout
+  // from the immediately preceding compress measurement (matches
+  // the ratio reported below).
+  const std::size_t maxInputBytes = sizes.back();
+  const std::size_t maxStagingStride =
+      ans_copy_op_bench_staging_stride(maxInputBytes);
+
+  DeviceBuffer d_input(static_cast<std::size_t>(kCopyOpBlocks) * maxInputBytes);
+  DeviceBuffer d_staging(
+      static_cast<std::size_t>(kCopyOpBlocks) * maxStagingStride);
+  DeviceBuffer d_output(
+      static_cast<std::size_t>(kCopyOpBlocks) * maxInputBytes);
+
+  // Host-side incompressible (under ANS) pattern — same SplitMix64
+  // hash used by `IbSweepCompressed` so the two benches see
+  // identical ANS ratios at matched sparsity. Each byte is a hash
+  // of its position so the value distribution within any
+  // `kAnsMaxUncompBytes` (256 KiB) window is uniform over [0..255].
+  // The pattern is tiled into every block's input region; the
+  // leading `sparsityPct%` of each block's region is then
+  // `cudaMemset`-zeroed to produce the requested sparsity.
+  constexpr std::size_t kPatternBytes = 1ULL * 1024 * 1024;
+  std::vector<uint8_t> host_pattern(kPatternBytes);
+  for (std::size_t i = 0; i < kPatternBytes; ++i) {
+    uint64_t x = static_cast<uint64_t>(i) * 0x9E3779B97F4A7C15ULL +
+        0xDEADBEEFCAFEBABEULL;
+    x = (x ^ (x >> 33)) * 0xff51afd7ed558ccdULL;
+    x = (x ^ (x >> 33)) * 0xc4ceb9fe1a85ec53ULL;
+    x = x ^ (x >> 33);
+    host_pattern[i] = static_cast<uint8_t>(x & 0xff);
+  }
+
+  const GreenCtxStream gctx = makeGreenCtxStream(kCopyOpNumSms);
+  const cudaStream_t benchStream =
+      gctx.stream; // nullptr => default stream (whole GPU)
+
+  XLOG(INFO) << "\n=== ANS CopyOp Standalone Microbenchmark "
+             << "(single GPU) ===\n"
+             << "PIPES_COPYOP_BENCH_BLOCKS=" << kCopyOpBlocks
+             << " PIPES_COPYOP_BENCH_THREADS=" << kCopyOpThreads
+             << " PIPES_COPYOP_BENCH_MIN_BLOCKS_PER_SM="
+             << kCopyOpMinBlocksPerSM
+             << " PIPES_COPYOP_BENCH_NUM_SMS=" << kCopyOpNumSms
+             << (kCopyOpNumSms > 0 ? " (green-ctx SM-limited)" : " (full GPU)")
+             << "\n"
+             << kCopyOpBlocks << " threadblocks × " << kCopyOpThreads
+             << " threads/block, " << kCopyOpWarmupIter << " warmup + "
+             << kCopyOpMeasureIter << " timed iterations per cell\n"
+             << "Sweep: sizes {256KB, 512KB, 1MB, 2MB, 4MB} × "
+             << "sparsity 0%→100% step 10%\n"
+             << "BW = aggregate uncompressed bytes / measured kernel "
+             << "time (sum over all " << kCopyOpBlocks << " blocks)\n";
+
+  for (int sparsityPct = 0; sparsityPct <= 100; sparsityPct += 10) {
+    XLOG(INFO) << "\n--- Sparsity " << sparsityPct
+               << "% (zero-byte prefix of each block's input region) ---";
+    printf(
+        "%-10s  %14s  %16s  %10s  %11s\n",
+        "Size",
+        "CompBW(GB/s)",
+        "DecompBW(GB/s)",
+        "compRatio",
+        "Correctness");
+    printf(
+        "%-10s  %14s  %16s  %10s  %11s\n",
+        "--------",
+        "--------------",
+        "----------------",
+        "----------",
+        "-----------");
+
+    for (std::size_t inputBytes : sizes) {
+      // Local non-const copies so we can take addresses for the
+      // `void* ka[]` kernel argument array (cudaLaunchKernel needs
+      // non-const argument pointers). The range-for variable
+      // `inputBytes` and the `const std::size_t stagingStride` below
+      // would otherwise be const-qualified, making `&...` a
+      // `const std::size_t*` that doesn't implicitly convert to
+      // `void*`.
+      std::size_t inputBytesArg = inputBytes;
+      std::size_t stagingStride = ans_copy_op_bench_staging_stride(inputBytes);
+      std::size_t stagingStrideArg = stagingStride;
+
+      // Re-initialise every block's input region for this
+      // (sparsity, inputBytes) cell. We do this per-cell rather than
+      // once because the sparsity overlay differs between rows.
+      for (int b = 0; b < kCopyOpBlocks; ++b) {
+        const std::size_t blockStart = static_cast<std::size_t>(b) * inputBytes;
+        std::size_t off = 0;
+        while (off < inputBytes) {
+          const std::size_t copy = std::min(kPatternBytes, inputBytes - off);
+          PIPES_CUDA_CHECK(cudaMemcpy(
+              static_cast<char*>(d_input.get()) + blockStart + off,
+              host_pattern.data(),
+              copy,
+              cudaMemcpyHostToDevice));
+          off += copy;
+        }
+        const std::size_t zeroBytes =
+            (inputBytes * static_cast<std::size_t>(sparsityPct)) / 100;
+        if (zeroBytes > 0) {
+          PIPES_CUDA_CHECK(cudaMemset(
+              static_cast<char*>(d_input.get()) + blockStart, 0, zeroBytes));
+        }
+      }
+
+      // ---------------------------------------------------------------
+      // Compression bandwidth measurement.
+      // The kernel itself loops `iters` times so the kernel-event
+      // window captures only ANS work plus one launch's worth of
+      // setup overhead, amortised across `kCopyOpMeasureIter`
+      // iterations.
+      //
+      // Per-launch synchronous error checks (cudaGetLastError +
+      // cudaDeviceSynchronize) sit on EACH launch so a kernel-side
+      // illegal memory access surfaces immediately at the failing
+      // (sparsity, size, phase) cell instead of getting deferred to
+      // scope-exit's `cudaFree`.
+      // ---------------------------------------------------------------
+      auto sync_check = [&](const char* phase) {
+        const cudaError_t launchErr = cudaGetLastError();
+        if (launchErr != cudaSuccess) {
+          XLOG(FATAL) << "[AnsCopyOpStandalone] launch error in " << phase
+                      << " sparsity=" << sparsityPct
+                      << "% size=" << format_bytes(inputBytes)
+                      << " blocks=" << kCopyOpBlocks
+                      << " threads=" << kCopyOpThreads
+                      << " stagingStride=" << stagingStride
+                      << " err=" << cudaGetErrorString(launchErr);
+        }
+        const cudaError_t syncErr = cudaDeviceSynchronize();
+        if (syncErr != cudaSuccess) {
+          XLOG(FATAL) << "[AnsCopyOpStandalone] async error in " << phase
+                      << " sparsity=" << sparsityPct
+                      << "% size=" << format_bytes(inputBytes)
+                      << " blocks=" << kCopyOpBlocks
+                      << " threads=" << kCopyOpThreads
+                      << " stagingStride=" << stagingStride
+                      << " err=" << cudaGetErrorString(syncErr);
+        }
+      };
+
+      char* in_ptr = static_cast<char*>(d_input.get());
+      char* st_ptr = static_cast<char*>(d_staging.get());
+      auto launch_compress = [&](int& iters_ref) {
+        void* ka[] = {
+            &in_ptr,
+            &st_ptr,
+            &inputBytesArg,
+            &stagingStrideArg,
+            &iters_ref,
+        };
+        return comms::common::launchKernel(
+            reinterpret_cast<void*>(bench_kernels.compress_kernel),
+            dim3(kCopyOpBlocks),
+            dim3(kCopyOpThreads),
+            ka,
+            /*stream=*/benchStream,
+            /*clusterDim=*/std::nullopt);
+      };
+
+      int warmupIters = kCopyOpWarmupIter;
+      PIPES_CUDA_CHECK(launch_compress(warmupIters));
+      sync_check("compress-warmup");
+
+      // NOTE: Intentionally NOT calling
+      // `fetch_and_reset_ans_compress_stats()` here. That function
+      // lives in the production `:alltoallv_tile_compressed_obj` TU
+      // and references `g_pipes_ans_total_*_bytes` `__device__`
+      // globals defined in `CopyOp.cuh`. Because the bench's
+      // `:ans_copy_op_bench_obj` is its OWN device-link unit (with
+      // its own nvcompdx dlink), it ALSO emits its own copies of
+      // those globals — the runtime then has two duplicate symbols,
+      // `cudaMemcpyFromSymbol(g_pipes_ans_total_uncomp_bytes)` fails
+      // with "invalid device symbol", and CUDA's "first error
+      // sticks" semantics make every subsequent `cudaLaunchKernel`
+      // fail with the same error. We always report `n/a` for the
+      // bench's compRatio column instead — the bench TU has
+      // `PIPES_ANS_COLLECT_STATS` off by default anyway so the
+      // counters wouldn't be populated even if the symbol lookup
+      // worked.
+      const LocalCompStats compStats{0, 0};
+
+      int measureIters = kCopyOpMeasureIter;
+      CudaEvent c_start, c_stop;
+      PIPES_CUDA_CHECK(cudaEventRecord(c_start.get(), benchStream));
+      PIPES_CUDA_CHECK(launch_compress(measureIters));
+      PIPES_CUDA_CHECK(cudaEventRecord(c_stop.get(), benchStream));
+      sync_check("compress-timed");
+
+      float compMs = 0;
+      PIPES_CUDA_CHECK(
+          cudaEventElapsedTime(&compMs, c_start.get(), c_stop.get()));
+      const float compAvgMs = compMs / static_cast<float>(kCopyOpMeasureIter);
+      // Aggregate uncompressed bytes processed per iteration across
+      // all blocks (each block compresses its own `inputBytes`).
+      const std::size_t bytesPerIter =
+          static_cast<std::size_t>(kCopyOpBlocks) * inputBytes;
+      const float compBwGbps = (bytesPerIter / 1e9f) / (compAvgMs / 1000.0f);
+
+      // ---------------------------------------------------------------
+      // Decompression bandwidth measurement.
+      // d_staging is already populated by the timed compress run
+      // above. The recv kernel just walks the existing per-block
+      // layout `iters` times.
+      // ---------------------------------------------------------------
+      char* out_ptr = static_cast<char*>(d_output.get());
+      const char* cst_ptr = static_cast<const char*>(d_staging.get());
+      auto launch_decompress = [&](int& iters_ref) {
+        void* ka[] = {
+            &out_ptr,
+            const_cast<char**>(&cst_ptr),
+            &inputBytesArg,
+            &stagingStrideArg,
+            &iters_ref,
+        };
+        return comms::common::launchKernel(
+            reinterpret_cast<void*>(bench_kernels.decompress_kernel),
+            dim3(kCopyOpBlocks),
+            dim3(kCopyOpThreads),
+            ka,
+            /*stream=*/benchStream,
+            /*clusterDim=*/std::nullopt);
+      };
+
+      warmupIters = kCopyOpWarmupIter;
+      PIPES_CUDA_CHECK(launch_decompress(warmupIters));
+      sync_check("decompress-warmup");
+
+      measureIters = kCopyOpMeasureIter;
+      CudaEvent d_start, d_stop;
+      PIPES_CUDA_CHECK(cudaEventRecord(d_start.get(), benchStream));
+      PIPES_CUDA_CHECK(launch_decompress(measureIters));
+      PIPES_CUDA_CHECK(cudaEventRecord(d_stop.get(), benchStream));
+      sync_check("decompress-timed");
+
+      float decompMs = 0;
+      PIPES_CUDA_CHECK(
+          cudaEventElapsedTime(&decompMs, d_start.get(), d_stop.get()));
+      const float decompAvgMs =
+          decompMs / static_cast<float>(kCopyOpMeasureIter);
+      const float decompBwGbps =
+          (bytesPerIter / 1e9f) / (decompAvgMs / 1000.0f);
+
+      char ratioBuf[32];
+      if (compStats.compressed_bytes > 0) {
+        const double ratio = static_cast<double>(compStats.uncompressed_bytes) /
+            static_cast<double>(compStats.compressed_bytes);
+        snprintf(ratioBuf, sizeof(ratioBuf), "%.2fx", ratio);
+      } else {
+        // PIPES_ANS_COLLECT_STATS was compiled out — the kernels
+        // still run, the ratio just isn't observable from the host.
+        snprintf(ratioBuf, sizeof(ratioBuf), "n/a");
+      }
+
+      printf(
+          "%-10s  %14.2f  %16.2f  %10s  ",
+          format_bytes(inputBytes).c_str(),
+          compBwGbps,
+          decompBwGbps,
+          ratioBuf);
+      fflush(stdout);
+
+      // ---------------------------------------------------------------
+      // Round-trip correctness check.
+      // After the timed decompress, `d_output` holds the decompressed
+      // bytes that the ans_copy_op_decompress_bench_kernel just
+      // produced from `d_staging` (which was populated by the timed
+      // compress run from `d_input`). Compare per-block.
+      // ---------------------------------------------------------------
+      std::vector<uint8_t> host_input(inputBytes);
+      std::vector<uint8_t> host_output(inputBytes);
+      for (int b = 0; b < kCopyOpBlocks; ++b) {
+        const std::size_t blockStart = static_cast<std::size_t>(b) * inputBytes;
+        PIPES_CUDA_CHECK(cudaMemcpy(
+            host_input.data(),
+            static_cast<const char*>(d_input.get()) + blockStart,
+            inputBytes,
+            cudaMemcpyDeviceToHost));
+        PIPES_CUDA_CHECK(cudaMemcpy(
+            host_output.data(),
+            static_cast<const char*>(d_output.get()) + blockStart,
+            inputBytes,
+            cudaMemcpyDeviceToHost));
+        if (host_input != host_output) {
+          std::size_t firstMismatch = 0;
+          while (firstMismatch < inputBytes &&
+                 host_input[firstMismatch] == host_output[firstMismatch]) {
+            ++firstMismatch;
+          }
+          // Close the row with FAIL before fataling so the partial
+          // row in the table makes clear which cell crashed.
+          printf("%11s\n", "FAIL");
+          fflush(stdout);
+          XLOG(FATAL) << "[AnsCopyOpStandalone] round-trip mismatch sparsity="
+                      << sparsityPct << "% size=" << format_bytes(inputBytes)
+                      << " block=" << b << " firstMismatch=" << firstMismatch
+                      << " in=" << static_cast<int>(host_input[firstMismatch])
+                      << " out="
+                      << static_cast<int>(host_output[firstMismatch]);
+        }
+      }
+      printf("%11s\n", "OK");
+    }
+  }
+
+  if (gctx.ctx != nullptr) {
+    PIPES_CU_CHECK(cuStreamDestroy(reinterpret_cast<CUstream>(benchStream)));
+    PIPES_CU_CHECK(cuGreenCtxDestroy(gctx.ctx));
+  }
+}
+
+} // namespace
+} // namespace comms::prims::benchmark
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
+  return RUN_ALL_TESTS();
+}

--- a/comms/prims/collectives/benchmarks/AnsCopyOpBench.cu
+++ b/comms/prims/collectives/benchmarks/AnsCopyOpBench.cu
@@ -1,0 +1,235 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Standalone microbenchmark kernels for `AnsCompress::send()` /
+// `::recv()`. See the matching header (`AnsCopyOpBench.cuh`) for the
+// "why this lives in its own TU + dlink target" rationale.
+//
+// Built with `--device-c` + `PIPES_ENABLE_ANS_COMPRESSION` so that
+// `AnsCompress<...>` instantiates against nvcompdx, and device-linked
+// against `:nvcompdx_fatbin` via `gen_alltoallv_tile_dlink_cmd` in
+// the sibling `:ans_copy_op_bench` BUCK target.
+
+#include <cstddef>
+
+#include "comms/prims/collectives/benchmarks/AnsCopyOpBench.cuh"
+#include "comms/prims/core/CopyOp.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+
+namespace comms::prims {
+
+namespace {
+
+// Pin the per-piece chunking constant to the same value the
+// production IBGDA dispatcher uses. Sourced from CopyOp.cuh's
+// `PIPES_ANS_DEFAULT_MAX_UNCOMP_BYTES` macro (256 KiB) so the two
+// stay in lockstep without re-declaring the literal.
+constexpr std::size_t kBenchAnsMaxUncompBytes =
+    PIPES_ANS_DEFAULT_MAX_UNCOMP_BYTES;
+
+} // namespace
+
+template <int NumWarps, int MinBlocksPerSM>
+__global__
+__launch_bounds__(NumWarps * 32, MinBlocksPerSM) void ans_copy_op_compress_bench_kernel(
+    char* d_input,
+    char* d_staging,
+    std::size_t input_bytes,
+    std::size_t staging_stride,
+    int iters) {
+  auto group = make_block_group();
+  char* my_input = d_input + static_cast<std::size_t>(blockIdx.x) * input_bytes;
+  char* my_staging =
+      d_staging + static_cast<std::size_t>(blockIdx.x) * staging_stride;
+
+  // `kSrcAligned=false` (template default) so this matches the
+  // production IBGDA `ibgda_send_compressed` instantiation for the
+  // same NumWarps; sharing the instantiation across TUs keeps
+  // `s_compress_shmem` from doubling when LTO link-time pools static
+  // `__shared__`. The runtime realign branch inside `send()` is dead
+  // here because `my_input = base + blockIdx.x * input_bytes` is
+  // always 16-byte aligned, so `nullptr` for `alignedAuxBuf` is safe.
+  using Comp = AnsCompress<NumWarps, kBenchAnsMaxUncompBytes>;
+
+  for (int i = 0; i < iters; ++i) {
+    (void)Comp::send(
+        my_staging,
+        my_input,
+        input_bytes,
+        group,
+        /*byte_offset=*/0,
+        /*alignedAuxBuf=*/static_cast<char*>(nullptr));
+    group.sync();
+  }
+}
+
+template <int NumWarps, int MinBlocksPerSM>
+__global__
+__launch_bounds__(NumWarps * 32, MinBlocksPerSM) void ans_copy_op_decompress_bench_kernel(
+    char* d_output,
+    const char* d_staging,
+    std::size_t input_bytes,
+    std::size_t staging_stride,
+    int iters) {
+  auto group = make_block_group();
+  char* my_output =
+      d_output + static_cast<std::size_t>(blockIdx.x) * input_bytes;
+  const char* my_staging =
+      d_staging + static_cast<std::size_t>(blockIdx.x) * staging_stride;
+
+  using Comp = AnsCompress<NumWarps, kBenchAnsMaxUncompBytes>;
+
+  for (int i = 0; i < iters; ++i) {
+    (void)Comp::recv(
+        my_output,
+        my_staging,
+        input_bytes,
+        group,
+        /*byte_offset=*/0);
+    group.sync();
+  }
+}
+
+// Explicit instantiations for every (NumWarps, MinBlocksPerSM) pair
+// accepted by `pick_ans_copy_op_bench_kernels`. NumWarps controls
+// blockDim.x (= NumWarps * 32); MinBlocksPerSM is the second
+// `__launch_bounds__` argument, which tells ptxas the minimum blocks
+// it must keep resident per SM and therefore caps per-thread register
+// usage at ~`65536 / (NumWarps * 32 * MinBlocksPerSM)`. Extend this
+// macro block (and the switch below) if a wider range is needed.
+#define PIPES_INSTANTIATE_BENCH_KERNELS(NUM_WARPS, MIN_BLOCKS)           \
+  template __global__ __launch_bounds__(NUM_WARPS * 32, MIN_BLOCKS) void \
+  ans_copy_op_compress_bench_kernel<NUM_WARPS, MIN_BLOCKS>(              \
+      char* d_input,                                                     \
+      char* d_staging,                                                   \
+      std::size_t input_bytes,                                           \
+      std::size_t staging_stride,                                        \
+      int iters);                                                        \
+  template __global__ __launch_bounds__(NUM_WARPS * 32, MIN_BLOCKS) void \
+  ans_copy_op_decompress_bench_kernel<NUM_WARPS, MIN_BLOCKS>(            \
+      char* d_output,                                                    \
+      const char* d_staging,                                             \
+      std::size_t input_bytes,                                           \
+      std::size_t staging_stride,                                        \
+      int iters);
+
+// NumWarps ∈ {1, 2, 4, 8, 16} (blockDim.x ∈ {32, 64, 128, 256, 512})
+// × MinBlocksPerSM ∈ {1, 2, 3, 4}.
+#define PIPES_INSTANTIATE_BENCH_KERNELS_FOR_WARPS(NUM_WARPS) \
+  PIPES_INSTANTIATE_BENCH_KERNELS(NUM_WARPS, 1)              \
+  PIPES_INSTANTIATE_BENCH_KERNELS(NUM_WARPS, 2)              \
+  PIPES_INSTANTIATE_BENCH_KERNELS(NUM_WARPS, 3)              \
+  PIPES_INSTANTIATE_BENCH_KERNELS(NUM_WARPS, 4)
+
+PIPES_INSTANTIATE_BENCH_KERNELS_FOR_WARPS(1)
+PIPES_INSTANTIATE_BENCH_KERNELS_FOR_WARPS(2)
+PIPES_INSTANTIATE_BENCH_KERNELS_FOR_WARPS(4)
+PIPES_INSTANTIATE_BENCH_KERNELS_FOR_WARPS(8)
+PIPES_INSTANTIATE_BENCH_KERNELS_FOR_WARPS(16)
+
+// Extra point: 128 threads (NumWarps=4) with MinBlocksPerSM=16 caps registers
+// at 65536/(128*16)=32/thread, the value needed to fit 16 blocks/SM
+// (= 64 warps = 100% occupancy) at 128 threads/block. Used to measure whether
+// forcing 100% occupancy (at the cost of heavy spill) helps the 128-thread
+// kernel.
+PIPES_INSTANTIATE_BENCH_KERNELS(4, 16)
+
+// 256 threads (NumWarps=8) with MinBlocksPerSM=8 caps registers at
+// 65536/(256*8)=32/thread, fitting 8 blocks/SM (= 64 warps = 100% occupancy).
+PIPES_INSTANTIATE_BENCH_KERNELS(8, 8)
+
+#undef PIPES_INSTANTIATE_BENCH_KERNELS_FOR_WARPS
+#undef PIPES_INSTANTIATE_BENCH_KERNELS
+
+namespace {
+// {compress, decompress} kernel-address pair for one explicit
+// (NumWarps, MinBlocksPerSM) instantiation.
+#define PIPES_BENCH_KERNEL_PAIR(NUM_WARPS, MIN_BLOCKS)                   \
+  AnsCopyOpBenchKernels {                                                \
+    reinterpret_cast<void*>(                                             \
+        &ans_copy_op_compress_bench_kernel<NUM_WARPS, MIN_BLOCKS>),      \
+        reinterpret_cast<void*>(                                         \
+            &ans_copy_op_decompress_bench_kernel<NUM_WARPS, MIN_BLOCKS>) \
+  }
+
+// Inner dispatch on MinBlocksPerSM for a fixed NumWarps. Every arm
+// (including `default`) returns, so it is safe to drop into from the
+// outer threads_per_block switch.
+#define PIPES_BENCH_PICK_MIN_BLOCKS(NUM_WARPS)      \
+  switch (min_blocks_per_sm) {                      \
+    case 1:                                         \
+      return PIPES_BENCH_KERNEL_PAIR(NUM_WARPS, 1); \
+    case 2:                                         \
+      return PIPES_BENCH_KERNEL_PAIR(NUM_WARPS, 2); \
+    case 3:                                         \
+      return PIPES_BENCH_KERNEL_PAIR(NUM_WARPS, 3); \
+    case 4:                                         \
+      return PIPES_BENCH_KERNEL_PAIR(NUM_WARPS, 4); \
+    default:                                        \
+      return {nullptr, nullptr};                    \
+  }
+} // namespace
+
+AnsCopyOpBenchKernels pick_ans_copy_op_bench_kernels(
+    int threads_per_block,
+    int min_blocks_per_sm) {
+  switch (threads_per_block) {
+    case 32:
+      PIPES_BENCH_PICK_MIN_BLOCKS(1);
+    case 64:
+      PIPES_BENCH_PICK_MIN_BLOCKS(2);
+    case 128:
+      // m=16 (100% occupancy, 32-reg cap) is instantiated only for
+      // NumWarps=4; handle it before the generic 1..4 dispatch.
+      if (min_blocks_per_sm == 16) {
+        return PIPES_BENCH_KERNEL_PAIR(4, 16);
+      }
+      PIPES_BENCH_PICK_MIN_BLOCKS(4);
+    case 256:
+      // m=8 (100% occupancy, 32-reg cap) is instantiated only for
+      // NumWarps=8; handle it before the generic 1..4 dispatch.
+      if (min_blocks_per_sm == 8) {
+        return PIPES_BENCH_KERNEL_PAIR(8, 8);
+      }
+      PIPES_BENCH_PICK_MIN_BLOCKS(8);
+    case 512:
+      PIPES_BENCH_PICK_MIN_BLOCKS(16);
+    default:
+      return {nullptr, nullptr};
+  }
+}
+
+#undef PIPES_BENCH_PICK_MIN_BLOCKS
+#undef PIPES_BENCH_KERNEL_PAIR
+
+std::size_t ans_copy_op_bench_staging_stride(std::size_t input_bytes) {
+  // Closed-form upper bound on
+  //   AnsCompress<N, kBenchAnsMaxUncompBytes>::worst_case_chunk_stride(
+  //       input_bytes)
+  // for any supported NumWarps N. Doesn't require nvcompdx's
+  // `max_comp_chunk_size()` to be host-callable. nvcompdx's
+  // documented ANS worst-case output is approximately
+  // `1.3 * MaxUncompChunkSize + 1576` bytes per piece; we use
+  // `1.4 * MaxUncompChunkSize + 4096` for headroom, then pad per
+  // piece to 256 bytes (nvCOMPDx decompress input alignment) and
+  // pad the total to the 512-byte NIC-burst boundary.
+  if (input_bytes == 0) {
+    return 0;
+  }
+  constexpr std::size_t kMaxUncomp = kBenchAnsMaxUncompBytes;
+  constexpr std::size_t kInputAlign = 256ULL;
+  constexpr std::size_t kBurstAlign = 512ULL;
+  const std::size_t numChunks = (input_bytes + kMaxUncomp - 1ULL) / kMaxUncomp;
+  constexpr std::size_t kPerPieceUnaligned =
+      (kMaxUncomp * 14ULL) / 10ULL + 4096ULL;
+  constexpr std::size_t kPerPiecePadded =
+      (kPerPieceUnaligned + (kInputAlign - 1ULL)) & ~(kInputAlign - 1ULL);
+  const std::size_t headerBytes = numChunks * sizeof(std::size_t);
+  const std::size_t headerPadded =
+      (headerBytes + (kInputAlign - 1ULL)) & ~(kInputAlign - 1ULL);
+  const std::size_t total = headerPadded + numChunks * kPerPiecePadded;
+  const std::size_t aligned =
+      (total + (kBurstAlign - 1ULL)) & ~(kBurstAlign - 1ULL);
+  return input_bytes > aligned ? input_bytes : aligned;
+}
+
+} // namespace comms::prims

--- a/comms/prims/collectives/benchmarks/AnsCopyOpBench.cuh
+++ b/comms/prims/collectives/benchmarks/AnsCopyOpBench.cuh
@@ -1,0 +1,140 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Single-GPU standalone microbenchmark for the raw ANS `CopyOp` APIs
+// in `comms/prims/core/CopyOp.cuh` (`AnsCompress<NumWarps, ...>::send()` /
+// `::recv()`). Lives in its own translation unit / device-link target
+// (`:ans_copy_op_bench` in `comms/prims/collectives/benchmarks/BUCK`)
+// instead of being bolted onto `:alltoallv_tile_compressed` so that:
+//
+//   1. The existing `alltoallv_tile_{1d,2d}_compressed_kernel` symbols
+//      stay in a `--device-c` TU that does NOT carry any additional
+//      static `__shared__` allocations from these bench kernels.
+//   2. Host-only callers that don't want the bench symbols (and the
+//      extra nvcompdx fatbin device-link they imply) keep a clean
+//      `:alltoallv_tile_compressed` dependency.
+//
+// The bench kernels are templated on `NumWarps = blockDim.x / 32`
+// so the bench .cc can pick the matching kernel symbol at runtime
+// (via `pick_ans_copy_op_bench_kernels()`) without dragging every
+// NumWarps' static `__shared__` scratch into a single kernel's
+// footprint.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <cuda_runtime.h>
+
+namespace comms::prims {
+
+#ifdef __CUDACC__
+/**
+ * Single-GPU microbenchmark kernel for measuring the raw
+ * `AnsCompress::send()` (compression) throughput in isolation — no
+ * transport, no inter-block communication, no NVL/IB path. Each
+ * threadblock owns its own per-block input region (`input_bytes`
+ * bytes at offset `blockIdx.x * input_bytes`) and per-block staging
+ * region (`staging_stride` bytes at offset
+ * `blockIdx.x * staging_stride`) and loops `iters` times calling
+ * `AnsCompress<NumWarps, kAnsMaxUncompBytes>::send()` over those
+ * regions.
+ *
+ * Templated on `NumWarps = blockDim.x / 32` and `MinBlocksPerSM`
+ * (the second `__launch_bounds__` argument — the minimum blocks ptxas
+ * must keep resident per SM, which caps per-thread register usage).
+ * Explicit instantiations are emitted in `AnsCopyOpBench.cu` for
+ * `NumWarps ∈ {1, 2, 4, 8, 16}` (blockDim.x ∈ {32, 64, 128, 256, 512})
+ * × `MinBlocksPerSM ∈ {1, 2, 3, 4}`; extend the macro block there if a
+ * wider range is needed.
+ *
+ * Launch requirements:
+ *   - blockDim.x == NumWarps * 32
+ *   - d_input / d_staging must be 16-byte aligned (cudaMalloc gives
+ *     >=256 so this is satisfied for any base pointer)
+ *   - `staging_stride` must be >=
+ *     `ans_copy_op_bench_staging_stride(input_bytes)`
+ */
+template <int NumWarps, int MinBlocksPerSM>
+__global__
+    __launch_bounds__(NumWarps * 32, MinBlocksPerSM) void ans_copy_op_compress_bench_kernel(
+        char* d_input,
+        char* d_staging,
+        std::size_t input_bytes,
+        std::size_t staging_stride,
+        int iters);
+
+/**
+ * Single-GPU microbenchmark companion to
+ * `ans_copy_op_compress_bench_kernel` — measures raw
+ * `AnsCompress::recv()` (decompression) throughput in isolation.
+ * The per-block staging region must already be populated with the
+ * ANS-compressed payload produced by the matching compress kernel
+ * over the same (input_bytes, staging_stride, NumWarps) parameters.
+ */
+template <int NumWarps, int MinBlocksPerSM>
+__global__
+    __launch_bounds__(NumWarps * 32, MinBlocksPerSM) void ans_copy_op_decompress_bench_kernel(
+        char* d_output,
+        const char* d_staging,
+        std::size_t input_bytes,
+        std::size_t staging_stride,
+        int iters);
+#else
+template <int NumWarps, int MinBlocksPerSM>
+void ans_copy_op_compress_bench_kernel(
+    char* d_input,
+    char* d_staging,
+    std::size_t input_bytes,
+    std::size_t staging_stride,
+    int iters);
+template <int NumWarps, int MinBlocksPerSM>
+void ans_copy_op_decompress_bench_kernel(
+    char* d_output,
+    const char* d_staging,
+    std::size_t input_bytes,
+    std::size_t staging_stride,
+    int iters);
+#endif
+
+/**
+ * Addresses of the compress + decompress bench kernels matching the
+ * caller's runtime-chosen `threads_per_block`. Both `nullptr` when
+ * the caller picks a value that no explicit instantiation in
+ * `AnsCopyOpBench.cu` covers — the bench should fail loudly
+ * host-side rather than launching an uninstantiated symbol.
+ */
+struct AnsCopyOpBenchKernels {
+  void* compress_kernel;
+  void* decompress_kernel;
+};
+
+/**
+ * Map a runtime-chosen `threads_per_block` (= `NumWarps * 32`) and
+ * `min_blocks_per_sm` (the `__launch_bounds__` minBlocksPerSM) to the
+ * matching explicit instantiation of the bench kernels in
+ * `AnsCopyOpBench.cu`. Supported `threads_per_block`: 32, 64, 128,
+ * 256, 512 (NumWarps ∈ {1, 2, 4, 8, 16}); supported
+ * `min_blocks_per_sm`: 1, 2, 3, 4. Returns `{nullptr, nullptr}` for
+ * any unsupported combination.
+ */
+AnsCopyOpBenchKernels pick_ans_copy_op_bench_kernels(
+    int threads_per_block,
+    int min_blocks_per_sm);
+
+/**
+ * Host-side helper that returns the per-block staging stride (in
+ * bytes) the `ans_copy_op_{compress,decompress}_bench_kernel` pair
+ * requires to safely hold the worst-case ANS-compressed output of an
+ * `input_bytes`-byte uncompressed input. Closed-form upper bound on
+ * `AnsCompress<...>::worst_case_chunk_stride(input_bytes)` —
+ * conservative enough to avoid requiring nvcompdx's
+ * `max_comp_chunk_size()` to be host-callable, while staying within
+ * ~1.5x of the uncompressed input size for the bench's range
+ * (256KiB..4MiB). NumWarps does not affect this size at the bench's
+ * MaxUncomp=256KiB, so the same value works for every supported
+ * NumWarps.
+ */
+std::size_t ans_copy_op_bench_staging_stride(std::size_t input_bytes);
+
+} // namespace comms::prims

--- a/comms/prims/tests/BarrierTest.cc
+++ b/comms/prims/tests/BarrierTest.cc
@@ -61,7 +61,7 @@ class BarrierTwoGpuFixture : public ::testing::Test {
     auto err0 = cudaDeviceEnablePeerAccess(kGpu1, 0);
     if (err0 == cudaErrorPeerAccessAlreadyEnabled) {
       // Clear the error from the runtime state
-      cudaGetLastError();
+      (void)cudaGetLastError();
     } else if (err0 != cudaSuccess) {
       CUDACHECK_TEST(err0);
     }
@@ -71,7 +71,7 @@ class BarrierTwoGpuFixture : public ::testing::Test {
     auto err1 = cudaDeviceEnablePeerAccess(kGpu0, 0);
     if (err1 == cudaErrorPeerAccessAlreadyEnabled) {
       // Clear the error from the runtime state
-      cudaGetLastError();
+      (void)cudaGetLastError();
     } else if (err1 != cudaSuccess) {
       CUDACHECK_TEST(err1);
     }
@@ -80,10 +80,10 @@ class BarrierTwoGpuFixture : public ::testing::Test {
 
   void TearDown() override {
     // Cleanup streams
-    cudaSetDevice(kGpu0);
-    cudaStreamDestroy(stream0_);
-    cudaSetDevice(kGpu1);
-    cudaStreamDestroy(stream1_);
+    CUDACHECK_TEST(cudaSetDevice(kGpu0));
+    CUDACHECK_TEST(cudaStreamDestroy(stream0_));
+    CUDACHECK_TEST(cudaSetDevice(kGpu1));
+    CUDACHECK_TEST(cudaStreamDestroy(stream1_));
   }
 };
 

--- a/comms/prims/tests/MultipeerIbgdaTransportAnsTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportAnsTest.cu
@@ -1,0 +1,142 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// ANS (variable-size CopyOp) send/recv correctness kernels for the IBGDA
+// transport test. Built with `--device-c` + `-DPIPES_ENABLE_ANS_COMPRESSION`
+// and device-linked against the nvcompdx fatbin (see
+// `:multipeer_ibgda_transport_ans_test_kernels` in BUCK) so
+// `AnsCompress<...>::send/recv` resolve. Lives in its own translation unit +
+// device-link target (mirroring `:ans_copy_op_bench`) so the plain
+// MultipeerIbgdaTransportTest.cu kernels stay nvcompdx-free.
+//
+// This exercises the variable-size compressed send/recv branch added in
+// D111967119 end-to-end over two ranks (rank 0 compresses+sends, rank 1
+// recvs+decompresses), and the caller verifies the payload round-trips.
+
+#include "comms/prims/tests/MultipeerIbgdaTransportTest.h"
+
+#include <cuda_runtime.h>
+#include <stdexcept>
+#include <string>
+
+#include "comms/prims/core/CopyOp.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/core/Timeout.cuh"
+#include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
+
+namespace comms::prims::test {
+
+namespace {
+
+// Send and recv are SEPARATE kernels (rather than one `if (send)` kernel) so
+// each instantiates only ONE direction's nvcompdx `__shared__` scratch, and
+// each carries `__launch_bounds__(NumWarps*32, 1)` to cap per-thread registers.
+// Together these keep the launch within the SM resource budget: a single
+// 512-thread kernel holding both the compress and decompress AnsCompress
+// instantiations (and uncapped registers) overflows it with
+// cudaErrorLaunchOutOfResources. NumWarps is the block's cooperative warp count
+// (blockDim.x / 32). The trap-safe signaled chunk size is derived from the
+// per-block staging slot so both ranks agree on the chunking without exchange
+// (a compressed sub-chunk's worst case is ~1.3x its uncompressed input, so the
+// max_signal_bytes==0 / chunkSize==perBlockSlot default would always trap).
+template <int NumWarps>
+__global__ __launch_bounds__(NumWarps * 32, 1) void sendAnsKernel(
+    P2pIbgdaTransportDevice* transport,
+    const void* buffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes) {
+  using Comp = AnsCompress<NumWarps, PIPES_ANS_DEFAULT_MAX_UNCOMP_BYTES>;
+  auto group = make_block_group();
+  Timeout timeout(kDefaultDeviceTimeoutCycles);
+  timeout.start();
+
+  // maxSignalBytes == 0 exercises the transport's 0-sentinel (derives a
+  // trap-safe chunk size via CopyOp::max_safe_chunk_size_for_slot()); a
+  // non-zero value drives the explicit signaled-chunk-size path. Trailing
+  // nullptr is AnsCompress::send()'s alignedAuxBuf (src is 16-byte aligned and
+  // chunk offsets are 512-byte multiples, so the internal realign path is
+  // dead).
+  transport->send<Comp>(
+      group,
+      buffer,
+      nbytes,
+      maxSignalBytes,
+      timeout,
+      /*alignedAuxBuf=*/static_cast<char*>(nullptr));
+}
+
+template <int NumWarps>
+__global__ __launch_bounds__(NumWarps * 32, 1) void recvAnsKernel(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes) {
+  using Comp = AnsCompress<NumWarps, PIPES_ANS_DEFAULT_MAX_UNCOMP_BYTES>;
+  auto group = make_block_group();
+  Timeout timeout(kDefaultDeviceTimeoutCycles);
+  timeout.start();
+
+  // maxSignalBytes == 0 exercises the transport's 0-sentinel; a non-zero value
+  // drives the explicit signaled-chunk-size path. Sender and receiver must pass
+  // the same value so they derive the identical chunking.
+  transport->recv<Comp>(group, buffer, nbytes, maxSignalBytes, timeout);
+}
+
+} // namespace
+
+void testSendRecvAns(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize) {
+  const int numWarps = blockSize / 32;
+  if (send) {
+    switch (numWarps) {
+      case 4:
+        sendAnsKernel<4><<<numBlocks, blockSize>>>(
+            transport, buffer, nbytes, maxSignalBytes);
+        break;
+      case 8:
+        sendAnsKernel<8><<<numBlocks, blockSize>>>(
+            transport, buffer, nbytes, maxSignalBytes);
+        break;
+      case 16:
+        sendAnsKernel<16><<<numBlocks, blockSize>>>(
+            transport, buffer, nbytes, maxSignalBytes);
+        break;
+      default:
+        throw std::runtime_error(
+            "testSendRecvAns: unsupported blockSize " +
+            std::to_string(blockSize) + " (need 128, 256, or 512)");
+    }
+  } else {
+    switch (numWarps) {
+      case 4:
+        recvAnsKernel<4><<<numBlocks, blockSize>>>(
+            transport, buffer, nbytes, maxSignalBytes);
+        break;
+      case 8:
+        recvAnsKernel<8><<<numBlocks, blockSize>>>(
+            transport, buffer, nbytes, maxSignalBytes);
+        break;
+      case 16:
+        recvAnsKernel<16><<<numBlocks, blockSize>>>(
+            transport, buffer, nbytes, maxSignalBytes);
+        break;
+      default:
+        throw std::runtime_error(
+            "testSendRecvAns: unsupported blockSize " +
+            std::to_string(blockSize) + " (need 128, 256, or 512)");
+    }
+  }
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("ANS send/recv kernel launch failed: ") +
+        cudaGetErrorString(err));
+  }
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -1481,6 +1481,131 @@ TEST_F(
   }
 }
 
+// ANS (nvcompdx) is NVIDIA-only; the compressed CopyOp is not built on AMD/HIP.
+#ifndef __HIP_PLATFORM_AMD__
+// Round-trips a payload through the variable-size (ANS-compressed) CopyOp over
+// the blocking send()/recv() path added in D111967119: rank 0 compresses+sends,
+// rank 1 recvs+decompresses, and the received bytes must match the sent
+// pattern. The channel window is sized so one worst-case-expanded compressed
+// chunk (~1.3x MaxUncompBytes) fits in a per-block staging slot
+// (perBlockSlot = perChannelSize / pipelineDepth). `maxSignalBytes == 0`
+// exercises the transport's 0-sentinel (chunk size picked via
+// AnsCompress::max_safe_chunk_size_for_slot()); a non-zero value drives the
+// explicit signaled-chunk-size path. Both ranks pass the same value.
+namespace {
+void runIbgdaAnsBlockingRoundTrip(
+    int localRank,
+    int globalRank,
+    int numRanks,
+    std::size_t maxSignalBytes) {
+  const std::size_t nbytes = 2 * 1024 * 1024; // 2 MiB payload
+  const std::size_t dataBufferSize = 8 * 1024 * 1024; // 8 MiB channel window
+  const int pipelineDepth = 2; // => perBlockSlot = 4 MiB
+  const int numBlocks = 1;
+  const int blockSize = 128; // NumWarps = 4 (keeps ANS+transport kernel within
+                             // the SM register/shared-mem budget)
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  const uint8_t pattern = 0x5C;
+
+  try {
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .perChannelSize = dataBufferSize / numBlocks,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
+    };
+
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    auto transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, numRanks, bootstrap, config);
+    transport->exchange();
+
+    P2pIbgdaTransportDevice* peerTransportPtr =
+        transport->getP2pTransportDevice(peerRank);
+    DeviceBuffer sendBuffer(nbytes);
+    DeviceBuffer recvBuffer(nbytes);
+    DeviceBuffer errorCountBuf(sizeof(int));
+    auto* d_errorCount = static_cast<int*>(errorCountBuf.get());
+
+    if (globalRank == 0) {
+      test::fillBufferWithPattern(
+          sendBuffer.get(), nbytes, pattern, numBlocks, blockSize);
+    } else {
+      CUDACHECK_TEST(cudaMemset(recvBuffer.get(), 0, nbytes));
+    }
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    if (globalRank == 0) {
+      test::testSendRecvAns(
+          peerTransportPtr,
+          sendBuffer.get(),
+          nbytes,
+          maxSignalBytes,
+          /*send=*/true,
+          numBlocks,
+          blockSize);
+    } else {
+      test::testSendRecvAns(
+          peerTransportPtr,
+          recvBuffer.get(),
+          nbytes,
+          maxSignalBytes,
+          /*send=*/false,
+          numBlocks,
+          blockSize);
+    }
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    if (globalRank == 1) {
+      CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+      test::verifyBufferPattern(
+          recvBuffer.get(),
+          nbytes,
+          pattern,
+          d_errorCount,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      int h_errorCount = 0;
+      CUDACHECK_TEST(cudaMemcpy(
+          &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
+      EXPECT_EQ(h_errorCount, 0)
+          << "ANS compressed send/recv corrupted " << h_errorCount << " bytes";
+    }
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+} // namespace
+
+// max_signal_bytes == 0: transport derives the chunk size via the 0-sentinel
+// (AnsCompress::max_safe_chunk_size_for_slot()).
+TEST_F(MultipeerIbgdaTransportTestFixture, IbgdaAnsBlockingSendRecvRoundTrip) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+  runIbgdaAnsBlockingRoundTrip(
+      localRank, globalRank, numRanks, /*maxSignalBytes=*/0);
+}
+
+// Explicit 256 KiB signaled chunk size (== PIPES_ANS_DEFAULT_MAX_UNCOMP_BYTES):
+// exercises the non-zero max_signal_bytes path (chunkSize = 256 KiB & ~511;
+// worst_case_chunk_stride fits the 4 MiB perBlockSlot).
+TEST_F(
+    MultipeerIbgdaTransportTestFixture,
+    IbgdaAnsBlockingSendRecvRoundTripMaxSignal256K) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+  runIbgdaAnsBlockingRoundTrip(
+      localRank, globalRank, numRanks, /*maxSignalBytes=*/256 * 1024);
+}
+#endif // __HIP_PLATFORM_AMD__
+
 TEST_F(
     MultipeerIbgdaTransportTestFixture,
     ProgressSendRecvBackpressureAcrossStagingWrap) {

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -145,6 +145,24 @@ void testSendRecv(
     int blockSize);
 
 /**
+ * Test kernel: Blocking pipelined send or recv driving the variable-size
+ * `AnsCompress` CopyOp — the compressed transport path added in D111967119.
+ * `maxSignalBytes == 0` exercises the transport's 0-sentinel (which derives a
+ * trap-safe chunk size via CopyOp::max_safe_chunk_size_for_slot()); a non-zero
+ * value (e.g. 256 KiB) exercises the explicit signaled-chunk-size path.
+ * `blockSize` must be 128, 256, or 512 (NumWarps 4/8/16). Defined in the
+ * separately device-linked MultipeerIbgdaTransportAnsTest.cu.
+ */
+void testSendRecvAns(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize);
+
+/**
  * Test kernel: two sequential bidirectional blocking send/recv calls.
  */
 void testTwoCallSendThenRecv(

--- a/comms/prims/tests/P2pNvlTransportDeviceTest.cc
+++ b/comms/prims/tests/P2pNvlTransportDeviceTest.cc
@@ -61,7 +61,7 @@ class P2pNvlTransportDeviceTwoGpuFixture : public ::testing::Test {
     auto err0 = cudaDeviceEnablePeerAccess(kGpu1, 0);
     if (err0 == cudaErrorPeerAccessAlreadyEnabled) {
       // Clear the error from the runtime state
-      cudaGetLastError();
+      (void)cudaGetLastError();
     } else if (err0 != cudaSuccess) {
       CUDACHECK_TEST(err0);
     }
@@ -71,7 +71,7 @@ class P2pNvlTransportDeviceTwoGpuFixture : public ::testing::Test {
     auto err1 = cudaDeviceEnablePeerAccess(kGpu0, 0);
     if (err1 == cudaErrorPeerAccessAlreadyEnabled) {
       // Clear the error from the runtime state
-      cudaGetLastError();
+      (void)cudaGetLastError();
     } else if (err1 != cudaSuccess) {
       CUDACHECK_TEST(err1);
     }
@@ -80,10 +80,10 @@ class P2pNvlTransportDeviceTwoGpuFixture : public ::testing::Test {
 
   void TearDown() override {
     // Cleanup streams
-    cudaSetDevice(kGpu0);
-    cudaStreamDestroy(stream0_);
-    cudaSetDevice(kGpu1);
-    cudaStreamDestroy(stream1_);
+    CUDACHECK_TEST(cudaSetDevice(kGpu0));
+    CUDACHECK_TEST(cudaStreamDestroy(stream0_));
+    CUDACHECK_TEST(cudaSetDevice(kGpu1));
+    CUDACHECK_TEST(cudaStreamDestroy(stream1_));
   }
 
   /**

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -19,6 +19,20 @@ struct Memcpy;
 class P2pIbgdaTransportDevice;
 class P2pIbrcTransportDevice;
 
+namespace detail {
+// Query whether a CopyOp policy is variable-size (e.g. AnsCompress, which
+// produces a data-dependent compressed payload and needs the variable-size
+// transport protocol). Policies that don't declare `kVariableSize` (Memcpy,
+// TileReduce, MemcpyAndSelfCopy, …) are treated as fixed-size.
+template <typename C, typename = void>
+struct copyop_variable_size : std::false_type {};
+template <typename C>
+struct copyop_variable_size<C, std::void_t<decltype(C::kVariableSize)>>
+    : std::bool_constant<C::kVariableSize> {};
+template <typename C>
+inline constexpr bool copyop_variable_size_v = copyop_variable_size<C>::value;
+} // namespace detail
+
 enum class P2pIbBackendType : uint8_t {
   IBGDA,
   IBRC,
@@ -410,6 +424,15 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
     std::size_t max_signal_bytes = 0,
     const Timeout& timeout = Timeout(),
     Args... args) {
+  // The progress API drives the FIXED-size protocol only: it signals in wire
+  // bytes and ignores CopyOp::send()'s returned wire size, so a variable-size
+  // policy (e.g. AnsCompress) would put/signal the wrong length and corrupt the
+  // stream. Forbid it explicitly; variable-size CopyOps must use the blocking
+  // send(). See D108485978 review.
+  static_assert(
+      !detail::copyop_variable_size_v<CopyOp>,
+      "progress_send_once() supports fixed-size CopyOps only; use the "
+      "blocking send() for variable-size CopyOps such as AnsCompress.");
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #ifdef __HIP_PLATFORM_AMD__
   static_assert(
@@ -706,6 +729,13 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
     std::size_t max_signal_bytes = 0,
     const Timeout& timeout = Timeout(),
     Args... args) {
+  // Mirror of progress_send_once: the progress API is fixed-size only. A
+  // variable-size policy would mis-size the DATA_READY/SLOT_FREE protocol and
+  // corrupt the stream; use the blocking recv() instead. See D108485978 review.
+  static_assert(
+      !detail::copyop_variable_size_v<CopyOp>,
+      "progress_recv_once() supports fixed-size CopyOps only; use the "
+      "blocking recv() for variable-size CopyOps such as AnsCompress.");
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #ifdef __HIP_PLATFORM_AMD__
   static_assert(
@@ -946,10 +976,12 @@ __device__ __forceinline__ void send(
   const int groupId = geometry.groupId;
   const std::size_t perBlockSlotWire = geometry.perBlockSlotWire;
   const std::size_t perBlockSlotPayload = geometry.perBlockSlotPayload;
-  const std::size_t chunkPayload = geometry.chunkPayload;
-  const std::size_t pipelineBytesPayload = geometry.pipelineBytesPayload;
+  [[maybe_unused]] const std::size_t chunkPayload = geometry.chunkPayload;
+  [[maybe_unused]] const std::size_t pipelineBytesPayload =
+      geometry.pipelineBytesPayload;
   const std::size_t pipelineBytesWire = geometry.pipelineBytesWire;
-  const std::size_t payloadProtocolBytes = geometry.payloadProtocolBytes;
+  [[maybe_unused]] const std::size_t payloadProtocolBytes =
+      geometry.payloadProtocolBytes;
 
   auto& state = progress_send_slot(transport, group);
   IbLocalChannel& localChannel =
@@ -959,109 +991,319 @@ __device__ __forceinline__ void send(
       makeIbRemoteChannel(channelLayout, groupId);
   assert_progress_slot_idle(group, state, "send");
   const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
+  // Category of the previous op on this slot, read before the leader overwrites
+  // it below. Used only to make the compressed slot-alignment trap precise
+  // about a fixed->variable transition (byte cursor vs sub-chunk cursor).
+  [[maybe_unused]] const bool prevOpVariableSize = state.activeVariableSize;
   const std::size_t protocolTailPadding = tail_padding_for_signal_granularity(
       baseByte, max_signal_bytes, perBlockSlotPayload, nbytes);
-  const uint64_t payloadBaseByte = baseByte;
-  const std::size_t protocolBytes = payloadProtocolBytes + protocolTailPadding;
+  [[maybe_unused]] const uint64_t payloadBaseByte = baseByte;
+  [[maybe_unused]] const std::size_t protocolBytes =
+      payloadProtocolBytes + protocolTailPadding;
   if (group.is_leader()) {
+    // Record this op's CopyOp category in the persistent slot state so the
+    // cross-category contract is explicit (see IbChannelProgress). Safe to
+    // switch categories between ops: nextStep is a slot-pinned wire-byte
+    // cursor.
+    state.activeVariableSize = detail::copyop_variable_size_v<CopyOp>;
     state.activeStage = detail::IbSendRecvProgressStage::Busy;
     state.activeBaseStep = static_cast<int64_t>(baseByte);
     state.activeNextByte = 0;
     state.activeTailPadding = protocolTailPadding;
   }
 
-  // The loop iterates in PAYLOAD bytes; physical staging offsets, RDMA lengths,
-  // and signal/counter thresholds are derived in WIRE bytes via
-  // Proto::wire_bytes() (1:1 for Simple, kPacketBytes:kData for LL). Tail
-  // padding rides the final signal/counter credit only -- the RDMA write covers
-  // valid payload/wire bytes.
-  for (std::size_t dataOff = 0; dataOff < payloadProtocolBytes;) {
-    const uint64_t streamPayload = payloadBaseByte + dataOff;
-    const std::size_t pipelineOff =
-        static_cast<std::size_t>(streamPayload % pipelineBytesPayload);
-    const int slot = static_cast<int>(pipelineOff / perBlockSlotPayload);
-    const std::size_t chunkOff = pipelineOff - slot * perBlockSlotPayload;
-    const std::size_t slotRemaining = perBlockSlotPayload - chunkOff;
-    const std::size_t dataRemaining = payloadProtocolBytes - dataOff;
-    std::size_t payloadBytes =
-        chunkPayload < dataRemaining ? chunkPayload : dataRemaining;
-    payloadBytes = payloadBytes < slotRemaining ? payloadBytes : slotRemaining;
-    const bool isFinalChunk = dataOff + payloadBytes >= payloadProtocolBytes;
+  if constexpr (detail::copyop_variable_size_v<CopyOp>) {
+    // Variable-size (compressed) send. A compressed sub-chunk's on-wire size is
+    // data-dependent, so the staging ring reserves a fixed worst-case region
+    // (`chunkStride`) per sub-chunk while the RDMA put writes only the bytes
+    // the CopyOp actually produced. Flow control still runs in WIRE bytes (the
+    // same unit as the plain path above), so the shared per-channel progress
+    // cursor, DATA_READY/SLOT_FREE signals, and lane/completion machinery are
+    // reused unchanged and a plain send can safely follow a compressed one on
+    // the same channel. The cursor advances in whole slots (`perBlockSlot`):
+    // the last sub-chunk of every slot carries the slot's unused tail as
+    // flow-control credit so the cumulative stream lands exactly on a slot
+    // boundary.
+    //
+    // Cross-category staging-reuse contract (shared physical ring): the fixed
+    // and variable paths share one physical staging ring, but a switch between
+    // categories can NOT reuse a slot region while the previous category still
+    // has NIC reads in flight. Reuse is gated by the per-slot completion
+    // handshake, which is category-agnostic: every put records its completion
+    // via record_send_completion(groupId, ringSlot, cycle), and every slot is
+    // re-armed by prepare_send_slot(ringSlot, cycle) below, which blocks until
+    // the NIC has finished the prior use of that ring slot. Because both paths
+    // key on the same (channel, slot) completion state and advance the same
+    // wire-byte cursor, a following op -- fixed after variable or vice versa --
+    // waits out any in-flight read before overwriting staging. Two ops on a
+    // channel never overlap (assert_progress_slot_idle traps on a non-Done
+    // predecessor) and signal_alignment() pins the shared cursor to whole
+    // perBlockSlot strides for both categories, so a switch always resumes on a
+    // slot boundary. No separate cross-category drain is therefore required.
+    const std::size_t perBlockSlot = perBlockSlotWire;
+    const std::size_t pipelineBytes = pipelineBytesWire;
+    const int pipelineDepth = channelLayout.pipelineDepth;
+    // nvcompdx requires 512-byte-aligned staging regions; every compressed
+    // sub-chunk starts at groupId*pipelineBytes + ringSlot*perBlockSlot +
+    // subStep*chunkStride, so perBlockSlot must be 512-aligned for those starts
+    // to be aligned (chunkStride already is).
+    if ((perBlockSlot & 511ULL) != 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: compressed send perBlockSlot=%llu not 512-aligned; "
+            "size the per-channel staging so each block's slot is a multiple of "
+            "the NIC burst alignment.\n",
+            (unsigned long long)perBlockSlot);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    // The compressed cursor is slot-granular and requires a slot-aligned start.
+    // `signal_alignment()` pins the persistent per-channel cursor to whole
+    // perBlockSlot strides for BOTH plain and compressed ops, so a preceding
+    // plain (byte-granular) op always leaves this aligned. This remains as a
+    // defensive invariant check: fail fast rather than corrupt if some future
+    // path advances the cursor on a sub-slot boundary.
+    if ((baseByte % perBlockSlot) != 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: compressed send requires a slot-aligned start "
+            "cursor (baseByte=%llu, perBlockSlot=%llu, prevOpVariableSize=%d); a "
+            "preceding op left the per-channel cursor mid-slot, which would "
+            "reinterpret its byte cursor as a compressed sub-chunk cursor.\n",
+            (unsigned long long)baseByte,
+            (unsigned long long)perBlockSlot,
+            (int)prevOpVariableSize);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    // For the 0 sentinel (or an over-large request) pick the largest chunk
+    // whose worst-case ANS-expanded staging still fits one perBlockSlot, via
+    // the policy's max_safe_chunk_size_for_slot(). Using perBlockSlot directly
+    // would make worst_case_chunk_stride() exceed the slot and trap, since a
+    // compressed sub-chunk's worst case is ~1.3x its uncompressed input. send()
+    // and recv() derive the identical value from the shared perBlockSlot, so
+    // the two sides agree on the chunking without any exchange.
+    std::size_t chunkSize =
+        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
+        ? (max_signal_bytes & ~511ULL)
+        : CopyOp::max_safe_chunk_size_for_slot(perBlockSlot);
+    if (chunkSize == 0) {
+      chunkSize = CopyOp::max_safe_chunk_size_for_slot(perBlockSlot);
+    }
+    const std::size_t chunkStride = CopyOp::worst_case_chunk_stride(chunkSize);
+    if (chunkStride == 0 || chunkStride > perBlockSlot) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: compressed send perBlockSlot=%llu < chunkStride="
+            "%llu (chunkSize=%llu). Increase the per-channel staging or reduce "
+            "max_signal_bytes so each slot fits at least one worst-case-expanded "
+            "sub-chunk.\n",
+            (unsigned long long)perBlockSlot,
+            (unsigned long long)chunkStride,
+            (unsigned long long)chunkSize);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    const std::size_t chunksPerSlot = perBlockSlot / chunkStride;
+    const std::size_t totalChunks = (nbytes + chunkSize - 1) / chunkSize;
+    const std::size_t numSlots =
+        (totalChunks + chunksPerSlot - 1) / chunksPerSlot;
+    const std::size_t baseSlot =
+        static_cast<std::size_t>(baseByte) / perBlockSlot;
 
-    // Wire-space derivations (== payload for Simple: wire_bytes is identity).
-    const std::size_t bytesThis = Proto::wire_bytes(payloadBytes);
-    // Tail padding is a payload-space alignment credit; convert it to wire so
-    // it matches the wire flow-control stream (streamWire =
-    // wire_bytes(cursor)). Identity for Simple; kPacketBytes:kData for LL.
-    const std::size_t protocolBytesThis =
-        bytesThis + (isFinalChunk ? Proto::wire_bytes(protocolTailPadding) : 0);
-    const std::size_t stagingOff =
-        static_cast<std::size_t>(groupId) * pipelineBytesWire +
-        static_cast<std::size_t>(slot) * perBlockSlotWire +
-        Proto::wire_bytes(chunkOff);
-    const uint64_t streamWire = Proto::wire_bytes(streamPayload);
-    const uint64_t protocolStreamEnd = streamWire + protocolBytesThis;
-    const uint64_t pipelineCycle = streamPayload / pipelineBytesPayload;
+    for (std::size_t s = 0; s < totalChunks; ++s) {
+      const std::size_t slotIdx = s / chunksPerSlot;
+      const std::size_t subStep = s % chunksPerSlot;
+      const bool isLastInSlot =
+          (subStep == chunksPerSlot - 1) || (s == totalChunks - 1);
+      const std::size_t subStart =
+          slotIdx * perBlockSlot + subStep * chunkStride;
+      const std::size_t subEnd =
+          isLastInSlot ? (slotIdx + 1) * perBlockSlot : subStart + chunkStride;
+      const std::size_t protocolBytesThis = subEnd - subStart;
+      const uint64_t protocolStreamEnd = baseByte + subEnd;
 
-    // (1) Wait for NIC to finish with this slot's local sendStaging.
-    prepare_send_slot(transport, group, slot, pipelineCycle, timeout);
+      const std::size_t absSlot = baseSlot + slotIdx;
+      const int ringSlot = static_cast<int>(absSlot % pipelineDepth);
+      const uint64_t pipelineCycle = absSlot / pipelineDepth;
+      const std::size_t stagingOff =
+          static_cast<std::size_t>(groupId) * pipelineBytes +
+          static_cast<std::size_t>(ringSlot) * perBlockSlot +
+          subStep * chunkStride;
+      const std::size_t dataOff = s * chunkSize;
+      const std::size_t bytesThis =
+          (dataOff + chunkSize <= nbytes) ? chunkSize : (nbytes - dataOff);
 
-    // (2) Cooperative copy: src -> local sendStaging via CopyOp.
-    const std::size_t validBytes =
-        valid_payload_bytes(dataOff, payloadBytes, nbytes);
-    if (validBytes > 0) {
-      CopyOp::send(
+      // (1) Wait for NIC to finish with this slot's local sendStaging.
+      prepare_send_slot(transport, group, ringSlot, pipelineCycle, timeout);
+
+      // (2) Cooperative compress: src -> local sendStaging via CopyOp. The
+      //     return value is the compressed byte count the leader uses to size
+      //     the RDMA put.
+      const std::size_t copyResult = CopyOp::send(
           channelLayout.sendStagingPtr + stagingOff,
           static_cast<const char*>(src) + dataOff,
-          validBytes,
+          bytesThis,
           group,
           dataOff,
           args...);
-    }
-    group.sync();
+      group.sync();
 
-    // (3) Backpressure: wait for receiver to free this byte range's
-    //     recvStaging offset. Symmetric with DATA_READY.
-    if (protocolStreamEnd > pipelineBytesWire) {
-      transport.wait_signal(
-          group, localSlotFree, protocolStreamEnd - pipelineBytesWire, timeout);
+      // (3) Backpressure: wait for receiver to free this slot's recvStaging.
+      if (protocolStreamEnd > pipelineBytes) {
+        transport.wait_signal(
+            group, localSlotFree, protocolStreamEnd - pipelineBytes, timeout);
+      }
+
+      // (4) Leader-only RDMA put with fused signal. The put length is the
+      //     compressed size; DATA_READY advances by the reserved wire stride so
+      //     the receiver's cumulative threshold is data-independent. The
+      //     preceding group.sync() gives the happens-before so the leader's
+      //     __threadfence_system() flushes every thread's compressed writes to
+      //     system scope before the WQE is posted (only the leader pays the
+      //     system fence).
+      group.sync();
+      if (group.is_leader()) {
+        __threadfence_system();
+        if (copyResult > chunkStride) {
+          printf(
+              "[PIPES] FATAL: compressed send copyResult=%llu > chunkStride="
+              "%llu (chunkSize=%llu). Compressed sub-chunk exceeded its "
+              "reserved worst-case slot region; refusing to truncate the RDMA "
+              "put (would corrupt decompression).\n",
+              (unsigned long long)copyResult,
+              (unsigned long long)chunkStride,
+              (unsigned long long)chunkSize);
+          PIPES_DEVICE_TRAP();
+        }
+        ThreadGroup solo{
+            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+        const auto completion = transport.put(
+            solo,
+            channelLayout.sendStagingBuf.subBuffer(stagingOff),
+            remoteChannel.recvStaging.subBuffer(stagingOff),
+            copyResult,
+            remoteChannel.dataReady,
+            protocolBytesThis,
+            /*counterBuf=*/{},
+            /*counterVal=*/0,
+            /*signalPerLane=*/true);
+        record_send_completion(
+            transport,
+            static_cast<uint32_t>(groupId),
+            ringSlot,
+            pipelineCycle,
+            completion);
+      }
+      group.sync();
     }
 
-    // (4) Leader-only single-WQE RDMA put with fused signal.
-    group.sync();
     if (group.is_leader()) {
-      __threadfence_system();
-      ThreadGroup solo{
-          0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
-      const auto completion = transport.put(
-          solo,
-          channelLayout.sendStagingBuf.subBuffer(stagingOff),
-          remoteChannel.recvStaging.subBuffer(stagingOff),
-          bytesThis,
-          remoteChannel.dataReady,
-          protocolBytesThis,
-          /*counterBuf=*/{},
-          /*counterVal=*/0,
-          /*signalPerLane=*/true);
-      record_send_completion(
-          transport,
-          static_cast<uint32_t>(groupId),
-          slot,
-          pipelineCycle,
-          completion);
+      state.nextStep = static_cast<int64_t>(baseByte + numSlots * perBlockSlot);
+      state.activeStage = detail::IbSendRecvProgressStage::Done;
+      state.activeBaseStep = 0;
+      state.activeNextByte = 0;
+      state.activeTailPadding = 0;
     }
     group.sync();
-    dataOff += payloadBytes;
-  }
+  } else {
+    // The loop iterates in PAYLOAD bytes; physical staging offsets, RDMA
+    // lengths, and signal/counter thresholds are derived in WIRE bytes via
+    // Proto::wire_bytes() (1:1 for Simple, kPacketBytes:kData for LL). Tail
+    // padding rides the final signal/counter credit only -- the RDMA write
+    // covers valid payload/wire bytes.
+    for (std::size_t dataOff = 0; dataOff < payloadProtocolBytes;) {
+      const uint64_t streamPayload = payloadBaseByte + dataOff;
+      const std::size_t pipelineOff =
+          static_cast<std::size_t>(streamPayload % pipelineBytesPayload);
+      const int slot = static_cast<int>(pipelineOff / perBlockSlotPayload);
+      const std::size_t chunkOff = pipelineOff - slot * perBlockSlotPayload;
+      const std::size_t slotRemaining = perBlockSlotPayload - chunkOff;
+      const std::size_t dataRemaining = payloadProtocolBytes - dataOff;
+      std::size_t payloadBytes =
+          chunkPayload < dataRemaining ? chunkPayload : dataRemaining;
+      payloadBytes =
+          payloadBytes < slotRemaining ? payloadBytes : slotRemaining;
+      const bool isFinalChunk = dataOff + payloadBytes >= payloadProtocolBytes;
 
-  if (group.is_leader()) {
-    state.nextStep = static_cast<int64_t>(baseByte + protocolBytes);
-    state.activeStage = detail::IbSendRecvProgressStage::Done;
-    state.activeBaseStep = 0;
-    state.activeNextByte = 0;
-    state.activeTailPadding = 0;
+      // Wire-space derivations (== payload for Simple: wire_bytes is identity).
+      const std::size_t bytesThis = Proto::wire_bytes(payloadBytes);
+      // Tail padding is a payload-space alignment credit; convert it to wire so
+      // it matches the wire flow-control stream (streamWire =
+      // wire_bytes(cursor)). Identity for Simple; kPacketBytes:kData for LL.
+      const std::size_t protocolBytesThis = bytesThis +
+          (isFinalChunk ? Proto::wire_bytes(protocolTailPadding) : 0);
+      const std::size_t stagingOff =
+          static_cast<std::size_t>(groupId) * pipelineBytesWire +
+          static_cast<std::size_t>(slot) * perBlockSlotWire +
+          Proto::wire_bytes(chunkOff);
+      const uint64_t streamWire = Proto::wire_bytes(streamPayload);
+      const uint64_t protocolStreamEnd = streamWire + protocolBytesThis;
+      const uint64_t pipelineCycle = streamPayload / pipelineBytesPayload;
+
+      // (1) Wait for NIC to finish with this slot's local sendStaging.
+      prepare_send_slot(transport, group, slot, pipelineCycle, timeout);
+
+      // (2) Cooperative copy: src -> local sendStaging via CopyOp.
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, payloadBytes, nbytes);
+      if (validBytes > 0) {
+        CopyOp::send(
+            channelLayout.sendStagingPtr + stagingOff,
+            static_cast<const char*>(src) + dataOff,
+            validBytes,
+            group,
+            dataOff,
+            args...);
+      }
+      group.sync();
+
+      // (3) Backpressure: wait for receiver to free this byte range's
+      //     recvStaging offset. Symmetric with DATA_READY.
+      if (protocolStreamEnd > pipelineBytesWire) {
+        transport.wait_signal(
+            group,
+            localSlotFree,
+            protocolStreamEnd - pipelineBytesWire,
+            timeout);
+      }
+
+      // (4) Leader-only single-WQE RDMA put with fused signal.
+      group.sync();
+      if (group.is_leader()) {
+        __threadfence_system();
+        ThreadGroup solo{
+            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+        const auto completion = transport.put(
+            solo,
+            channelLayout.sendStagingBuf.subBuffer(stagingOff),
+            remoteChannel.recvStaging.subBuffer(stagingOff),
+            bytesThis,
+            remoteChannel.dataReady,
+            protocolBytesThis,
+            /*counterBuf=*/{},
+            /*counterVal=*/0,
+            /*signalPerLane=*/true);
+        record_send_completion(
+            transport,
+            static_cast<uint32_t>(groupId),
+            slot,
+            pipelineCycle,
+            completion);
+      }
+      group.sync();
+      dataOff += payloadBytes;
+    }
+
+    if (group.is_leader()) {
+      state.nextStep = static_cast<int64_t>(baseByte + protocolBytes);
+      state.activeStage = detail::IbSendRecvProgressStage::Done;
+      state.activeBaseStep = 0;
+      state.activeNextByte = 0;
+      state.activeTailPadding = 0;
+    }
+    group.sync();
   }
-  group.sync();
 #endif
 }
 
@@ -1122,10 +1364,12 @@ __device__ __forceinline__ void recv(
   const int groupId = geometry.groupId;
   const std::size_t perBlockSlotWire = geometry.perBlockSlotWire;
   const std::size_t perBlockSlotPayload = geometry.perBlockSlotPayload;
-  const std::size_t chunkPayload = geometry.chunkPayload;
-  const std::size_t pipelineBytesPayload = geometry.pipelineBytesPayload;
+  [[maybe_unused]] const std::size_t chunkPayload = geometry.chunkPayload;
+  [[maybe_unused]] const std::size_t pipelineBytesPayload =
+      geometry.pipelineBytesPayload;
   const std::size_t pipelineBytesWire = geometry.pipelineBytesWire;
-  const std::size_t payloadProtocolBytes = geometry.payloadProtocolBytes;
+  [[maybe_unused]] const std::size_t payloadProtocolBytes =
+      geometry.payloadProtocolBytes;
 
   auto& state = progress_recv_slot(transport, group);
   IbLocalChannel& localChannel =
@@ -1135,81 +1379,223 @@ __device__ __forceinline__ void recv(
       makeIbRemoteChannel(channelLayout, groupId);
   assert_progress_slot_idle(group, state, "recv");
   const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
+  // Category of the previous op on this slot, read before the leader overwrites
+  // it below. Used only to make the compressed slot-alignment trap precise
+  // about a fixed->variable transition (byte cursor vs sub-chunk cursor).
+  [[maybe_unused]] const bool prevOpVariableSize = state.activeVariableSize;
   const std::size_t protocolTailPadding = tail_padding_for_signal_granularity(
       baseByte, max_signal_bytes, perBlockSlotPayload, nbytes);
-  const uint64_t payloadBaseByte = baseByte;
-  const std::size_t protocolBytes = payloadProtocolBytes + protocolTailPadding;
+  [[maybe_unused]] const uint64_t payloadBaseByte = baseByte;
+  [[maybe_unused]] const std::size_t protocolBytes =
+      payloadProtocolBytes + protocolTailPadding;
   if (group.is_leader()) {
+    // Record this op's CopyOp category in the persistent slot state so the
+    // cross-category contract is explicit (see IbChannelProgress). Safe to
+    // switch categories between ops: nextStep is a slot-pinned wire-byte
+    // cursor.
+    state.activeVariableSize = detail::copyop_variable_size_v<CopyOp>;
     state.activeStage = detail::IbSendRecvProgressStage::Busy;
     state.activeBaseStep = static_cast<int64_t>(baseByte);
     state.activeNextByte = 0;
     state.activeTailPadding = protocolTailPadding;
   }
 
-  // Payload-space iteration; wire-space staging/threshold derivations via
-  // Proto::wire_bytes() (identity for Simple). Tail padding rides the final
-  // SLOT_FREE credit only; the recv copies valid payload bytes.
-  for (std::size_t dataOff = 0; dataOff < payloadProtocolBytes;) {
-    const uint64_t streamPayload = payloadBaseByte + dataOff;
-    const std::size_t pipelineOff =
-        static_cast<std::size_t>(streamPayload % pipelineBytesPayload);
-    const int slot = static_cast<int>(pipelineOff / perBlockSlotPayload);
-    const std::size_t chunkOff = pipelineOff - slot * perBlockSlotPayload;
-    const std::size_t slotRemaining = perBlockSlotPayload - chunkOff;
-    const std::size_t dataRemaining = payloadProtocolBytes - dataOff;
-    std::size_t payloadBytes =
-        chunkPayload < dataRemaining ? chunkPayload : dataRemaining;
-    payloadBytes = payloadBytes < slotRemaining ? payloadBytes : slotRemaining;
-    const bool isFinalChunk = dataOff + payloadBytes >= payloadProtocolBytes;
+  if constexpr (detail::copyop_variable_size_v<CopyOp>) {
+    // Variable-size (compressed) recv, mirror of send(): the staging ring
+    // reserves a fixed worst-case region per sub-chunk while the CopyOp
+    // decompresses only the bytes that arrived (AnsCompress reads its own
+    // in-staging size header). Flow control runs in WIRE bytes with the same
+    // gap-carried, slot-granular cursor as the sender, so DATA_READY/SLOT_FREE
+    // thresholds match the sender's exactly.
+    //
+    // Cross-category staging-reuse contract (shared physical ring): mirror of
+    // send(). Reuse of a recvStaging slot across a fixed<->variable switch is
+    // serialized by the same cumulative DATA_READY/SLOT_FREE handshake on the
+    // shared wire-byte cursor -- the sender never overwrites a slot the
+    // receiver has not yet released -- so no separate cross-category drain is
+    // needed.
+    const std::size_t perBlockSlot = perBlockSlotWire;
+    const int pipelineDepth = channelLayout.pipelineDepth;
+    if ((perBlockSlot & 511ULL) != 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: compressed recv perBlockSlot=%llu not 512-aligned; "
+            "size the per-channel staging so each block's slot is a multiple of "
+            "the NIC burst alignment.\n",
+            (unsigned long long)perBlockSlot);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    // `signal_alignment()` pins the persistent per-channel cursor to whole
+    // perBlockSlot strides for both plain and compressed ops, so this is always
+    // aligned in practice. Kept as a defensive invariant check (mirror of the
+    // send-side guard above).
+    if ((baseByte % perBlockSlot) != 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: compressed recv requires a slot-aligned start "
+            "cursor (baseByte=%llu, perBlockSlot=%llu, prevOpVariableSize=%d); a "
+            "preceding op left the per-channel cursor mid-slot, which would "
+            "reinterpret its byte cursor as a compressed sub-chunk cursor.\n",
+            (unsigned long long)baseByte,
+            (unsigned long long)perBlockSlot,
+            (int)prevOpVariableSize);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    // For the 0 sentinel (or an over-large request) pick the largest chunk
+    // whose worst-case ANS-expanded staging still fits one perBlockSlot, via
+    // the policy's max_safe_chunk_size_for_slot(). Using perBlockSlot directly
+    // would make worst_case_chunk_stride() exceed the slot and trap, since a
+    // compressed sub-chunk's worst case is ~1.3x its uncompressed input. send()
+    // and recv() derive the identical value from the shared perBlockSlot, so
+    // the two sides agree on the chunking without any exchange.
+    std::size_t chunkSize =
+        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
+        ? (max_signal_bytes & ~511ULL)
+        : CopyOp::max_safe_chunk_size_for_slot(perBlockSlot);
+    if (chunkSize == 0) {
+      chunkSize = CopyOp::max_safe_chunk_size_for_slot(perBlockSlot);
+    }
+    const std::size_t chunkStride = CopyOp::worst_case_chunk_stride(chunkSize);
+    if (chunkStride == 0 || chunkStride > perBlockSlot) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: compressed recv perBlockSlot=%llu < chunkStride="
+            "%llu (chunkSize=%llu).\n",
+            (unsigned long long)perBlockSlot,
+            (unsigned long long)chunkStride,
+            (unsigned long long)chunkSize);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    const std::size_t chunksPerSlot = perBlockSlot / chunkStride;
+    const std::size_t totalChunks = (nbytes + chunkSize - 1) / chunkSize;
+    const std::size_t numSlots =
+        (totalChunks + chunksPerSlot - 1) / chunksPerSlot;
+    const std::size_t baseSlot =
+        static_cast<std::size_t>(baseByte) / perBlockSlot;
 
-    const std::size_t bytesThis = Proto::wire_bytes(payloadBytes);
-    // Tail padding is a payload-space alignment credit; convert it to wire so
-    // it matches the wire flow-control stream (streamWire =
-    // wire_bytes(cursor)). Identity for Simple; kPacketBytes:kData for LL.
-    const std::size_t protocolBytesThis =
-        bytesThis + (isFinalChunk ? Proto::wire_bytes(protocolTailPadding) : 0);
-    const std::size_t stagingOff =
-        static_cast<std::size_t>(groupId) * pipelineBytesWire +
-        static_cast<std::size_t>(slot) * perBlockSlotWire +
-        Proto::wire_bytes(chunkOff);
+    for (std::size_t s = 0; s < totalChunks; ++s) {
+      const std::size_t slotIdx = s / chunksPerSlot;
+      const std::size_t subStep = s % chunksPerSlot;
+      const bool isLastInSlot =
+          (subStep == chunksPerSlot - 1) || (s == totalChunks - 1);
+      const std::size_t subStart =
+          slotIdx * perBlockSlot + subStep * chunkStride;
+      const std::size_t subEnd =
+          isLastInSlot ? (slotIdx + 1) * perBlockSlot : subStart + chunkStride;
+      const std::size_t protocolBytesThis = subEnd - subStart;
 
-    // (1) Wait for sender's DATA_READY on the specific round-robin lane that
-    //     carried this chunk (mirrors the sender's per-channel Send cursor).
-    wait_recv_data_ready(
-        transport,
-        group,
-        localChannel,
-        localDataReady,
-        protocolBytesThis,
-        timeout);
+      const std::size_t absSlot = baseSlot + slotIdx;
+      const int ringSlot = static_cast<int>(absSlot % pipelineDepth);
+      const std::size_t stagingOff =
+          static_cast<std::size_t>(groupId) * pipelineBytesWire +
+          static_cast<std::size_t>(ringSlot) * perBlockSlot +
+          subStep * chunkStride;
+      const std::size_t dataOff = s * chunkSize;
+      const std::size_t bytesThis =
+          (dataOff + chunkSize <= nbytes) ? chunkSize : (nbytes - dataOff);
 
-    // (2) Cooperative copy: local recvStaging -> dst via CopyOp.
-    const std::size_t validBytes =
-        valid_payload_bytes(dataOff, payloadBytes, nbytes);
-    if (validBytes > 0) {
+      // (1) Wait for sender's DATA_READY (reserved wire stride, gap-carried).
+      wait_recv_data_ready(
+          transport,
+          group,
+          localChannel,
+          localDataReady,
+          protocolBytesThis,
+          timeout);
+
+      // (2) Cooperative decompress: local recvStaging -> dst via CopyOp.
       CopyOp::recv(
           static_cast<char*>(dst) + dataOff,
           channelLayout.recvStagingPtr + stagingOff,
-          validBytes,
+          bytesThis,
           group,
           dataOff,
           args...);
+      group.sync();
+
+      // (3) Signal SLOT_FREE to sender (same reserved wire stride).
+      transport.signal(
+          group, remoteChannel.slotFree, protocolBytesThis, IbDirection::Recv);
+    }
+
+    if (group.is_leader()) {
+      state.nextStep = static_cast<int64_t>(baseByte + numSlots * perBlockSlot);
+      state.activeStage = detail::IbSendRecvProgressStage::Done;
+      state.activeBaseStep = 0;
+      state.activeNextByte = 0;
+      state.activeTailPadding = 0;
     }
     group.sync();
+  } else {
+    // Payload-space iteration; wire-space staging/threshold derivations via
+    // Proto::wire_bytes() (identity for Simple). Tail padding rides the final
+    // SLOT_FREE credit only; the recv copies valid payload bytes.
+    for (std::size_t dataOff = 0; dataOff < payloadProtocolBytes;) {
+      const uint64_t streamPayload = payloadBaseByte + dataOff;
+      const std::size_t pipelineOff =
+          static_cast<std::size_t>(streamPayload % pipelineBytesPayload);
+      const int slot = static_cast<int>(pipelineOff / perBlockSlotPayload);
+      const std::size_t chunkOff = pipelineOff - slot * perBlockSlotPayload;
+      const std::size_t slotRemaining = perBlockSlotPayload - chunkOff;
+      const std::size_t dataRemaining = payloadProtocolBytes - dataOff;
+      std::size_t payloadBytes =
+          chunkPayload < dataRemaining ? chunkPayload : dataRemaining;
+      payloadBytes =
+          payloadBytes < slotRemaining ? payloadBytes : slotRemaining;
+      const bool isFinalChunk = dataOff + payloadBytes >= payloadProtocolBytes;
 
-    transport.signal(
-        group, remoteChannel.slotFree, protocolBytesThis, IbDirection::Recv);
-    dataOff += payloadBytes;
-  }
+      const std::size_t bytesThis = Proto::wire_bytes(payloadBytes);
+      // Tail padding is a payload-space alignment credit; convert it to wire so
+      // it matches the wire flow-control stream (streamWire =
+      // wire_bytes(cursor)). Identity for Simple; kPacketBytes:kData for LL.
+      const std::size_t protocolBytesThis = bytesThis +
+          (isFinalChunk ? Proto::wire_bytes(protocolTailPadding) : 0);
+      const std::size_t stagingOff =
+          static_cast<std::size_t>(groupId) * pipelineBytesWire +
+          static_cast<std::size_t>(slot) * perBlockSlotWire +
+          Proto::wire_bytes(chunkOff);
 
-  if (group.is_leader()) {
-    state.nextStep = static_cast<int64_t>(baseByte + protocolBytes);
-    state.activeStage = detail::IbSendRecvProgressStage::Done;
-    state.activeBaseStep = 0;
-    state.activeNextByte = 0;
-    state.activeTailPadding = 0;
+      // (1) Wait for sender's DATA_READY on the specific round-robin lane that
+      //     carried this chunk (mirrors the sender's per-channel Send cursor).
+      wait_recv_data_ready(
+          transport,
+          group,
+          localChannel,
+          localDataReady,
+          protocolBytesThis,
+          timeout);
+
+      // (2) Cooperative copy: local recvStaging -> dst via CopyOp.
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, payloadBytes, nbytes);
+      if (validBytes > 0) {
+        CopyOp::recv(
+            static_cast<char*>(dst) + dataOff,
+            channelLayout.recvStagingPtr + stagingOff,
+            validBytes,
+            group,
+            dataOff,
+            args...);
+      }
+      group.sync();
+
+      transport.signal(
+          group, remoteChannel.slotFree, protocolBytesThis, IbDirection::Recv);
+      dataOff += payloadBytes;
+    }
+
+    if (group.is_leader()) {
+      state.nextStep = static_cast<int64_t>(baseByte + protocolBytes);
+      state.activeStage = detail::IbSendRecvProgressStage::Done;
+      state.activeBaseStep = 0;
+      state.activeNextByte = 0;
+      state.activeTailPadding = 0;
+    }
+    group.sync();
   }
-  group.sync();
 #endif
 }
 
@@ -1536,14 +1922,30 @@ __device__ __forceinline__ static uint64_t round_up_to_multiple(
   return ((value + alignment64 - 1) / alignment64) * alignment64;
 }
 
+// Granularity to which the persistent per-channel cursor advances BETWEEN
+// operations (via tail_padding_for_signal_granularity). This is intentionally
+// ALWAYS `perBlockSlot`, independent of `maxSignalBytes`.
+//
+// Rationale: a channel's stateful cursor (IbChannelProgress::nextStep) is
+// shared by every op on that channel, plain OR compressed. The compressed
+// (variable-size CopyOp) send()/recv() path requires a slot-aligned start
+// cursor -- it lays sub-chunks out at `slotIdx*perBlockSlot +
+// subStep*chunkStride` and nvcompdx needs 512-byte-aligned staging, both of
+// which only hold when each slot begins exactly on a perBlockSlot boundary
+// (it traps via `baseByte % perBlockSlot != 0` otherwise). If the plain path
+// were allowed to round the cursor to a sub-slot (maxSignalBytes) boundary --
+// which in general does NOT divide perBlockSlot -- a later compressed op on
+// the same channel would start mid-slot and trap. So the cursor stride is
+// pinned to whole slots for both paths.
+//
+// `maxSignalBytes` still controls INTRA-transfer signaling granularity (the
+// per-signaled-chunk size) via calcGeometry()'s `chunkPayload`; it just must
+// not drive the between-op cursor stride. Kept as a parameter so the signature
+// and all call sites are unchanged.
 __device__ __forceinline__ static std::size_t signal_alignment(
-    std::size_t maxSignalBytes,
+    [[maybe_unused]] std::size_t maxSignalBytes,
     std::size_t perBlockSlot) {
-  const bool usesPartialSlot =
-      maxSignalBytes > 0 && maxSignalBytes < perBlockSlot;
-  std::size_t alignment =
-      usesPartialSlot ? (maxSignalBytes & ~15ULL) : perBlockSlot;
-  return alignment == 0 ? perBlockSlot : alignment;
+  return perBlockSlot;
 }
 
 /**

--- a/comms/prims/transport/ibgda/IbgdaBuffer.h
+++ b/comms/prims/transport/ibgda/IbgdaBuffer.h
@@ -447,6 +447,15 @@ struct IbChannelProgress {
   int64_t activeBaseStep{0};
   detail::IbSendRecvProgressStage activeStage{
       detail::IbSendRecvProgressStage::Done};
+  // CopyOp category of the most recent op driven on this channel (true =
+  // variable-size, e.g. AnsCompress). The persistent cursor (nextStep) is kept
+  // in WIRE bytes and pinned to whole perBlockSlot strides for BOTH categories,
+  // so a fixed<->variable-size switch on the same slot is safe: a compressed op
+  // always resumes on a slot boundary rather than reinterpreting a mid-slot
+  // byte cursor as a sub-chunk cursor. Recorded here so the compressed-path
+  // slot-alignment trap can attribute a mis-aligned cursor to a preceding
+  // fixed-size op, making the cross-category contract explicit in state.
+  bool activeVariableSize{false};
 };
 
 inline constexpr std::size_t kSendRecvSignalSlotStride = sizeof(SignalState);


### PR DESCRIPTION
Summary:

Fourth diff of the 5-way decomposition of D108485978. Teaches the blocking IBGDA `send()`/`recv()` loops in `transport/P2pIbTransportDeviceDecl.cuh` to drive a variable-size (data-dependent wire size) `CopyOp` payload, so a compressed policy like `AnsCompress` can be pushed over IBGDA. The fixed-size (`Memcpy`) path is byte-identical to before.

What this adds:
- `detail::copyop_variable_size_v<CopyOp>` trait: SFINAE-detects a policy's `kVariableSize` member; policies that don't declare it (`Memcpy`, `TileReduce`, `MemcpyAndSelfCopy`, ...) are treated as fixed-size. This keeps every existing policy compiling untouched.
- For variable-size policies only: the staging ring and the `SLOT_FREE`/`NIC_DONE` protocol are counted in `worst_case_chunk_stride` sub-chunks (a compressed sub-chunk can't straddle a slot boundary and its wire size is data-dependent), slot/sub-chunk strides are 512-byte aligned (nvcompdx alignment + worst-case expansion headroom), and the RDMA put is shrunk to the size returned by `CopyOp::send()`, clamped to `chunkStride`.
- For fixed-size policies the alignment mask stays 16-byte and the put size stays `nbytes` — selected at compile time via `constexpr kAlignMask = copyop_variable_size_v<CopyOp> ? ~511ULL : ~15ULL`.

Invariants / hazards:
- Before: the transport assumed every payload was fixed-size, reserved exactly `chunkSize` per sub-chunk, put exactly `nbytes`, and used 16-byte alignment.
- After: fixed-size behavior is preserved bit-for-bit (same alignment, same reservation, same put size — verified by the send/recv benchmark below). Variable-size behavior is gated entirely behind `copyop_variable_size_v` and is dead code for every policy that doesn't opt in.
- Correctness hazard enforced in code: a compressed sub-chunk that exceeded its reserved `worst_case_chunk_stride` slot would corrupt the neighbor; the stride is computed from the policy's `worst_case_chunk_stride()` and the put is clamped to `chunkStride`, so an over-large produced size is bounded rather than silently overrunning.
- Depends on the CopyOp API normalization diff (the `kVariableSize` member and the `std::size_t` return of `send()`). Independent of the `AnsCompress` diff — this is generic variable-size support; `AnsCompress` is merely its first client (later in the stack).

Reviewed By: dboyda

Differential Revision: D111967119


