### PR TITLE
Change default A2A IB config

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1781,7 +1781,7 @@ cvars:
 
  - name        : NCCL_CTRAN_IB_QP_CONFIG_ALGO
    type        : dictlist
-   default     : alltoall:1048576,16,dqplb,128,224
+   default     : alltoall:1048576,4,spray,128,224
    description : |-
      Specify the vc config for each collective. The format is
      <ALGO0: VAL0>,<ALGO1: VAL1>,<ALGO2: VAL2>,<ALGO3: VAL3>


### PR DESCRIPTION
Summary:
From the prior experiment, we found when running multiple A2A the perf gets bad when using DQPLB on GB300. Changing to use spray helped resolve the issue. Thus changing the default.

For more info:
https://docs.google.com/document/d/1WtyTzp00NCAPaO2387LSq3s5fb6CsOBb_pmwcTZmNdA/edit?tab=t.j2fx0or9crzz#heading=h.gtsuti96hw4l

Differential Revision: D114269681


