### PR TITLE
Propagate bootstrap ring all-gather errors (#3350)

### DIFF
--- a/comms/ncclx/meta/ctran-integration/BootstrapCleanup.h
+++ b/comms/ncclx/meta/ctran-integration/BootstrapCleanup.h
@@ -1,0 +1,86 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstdlib>
+
+#include "bootstrap.h"
+#include "debug.h"
+#include "socket.h"
+
+namespace ncclx {
+
+inline ncclResult_t abortBootstrapState(struct bootstrapState* state) {
+  if (state == nullptr) {
+    return ncclSuccess;
+  }
+
+  ncclResult_t result = ncclSuccess;
+  const auto recordCloseResult =
+      [&result](const char* endpoint, ncclResult_t closeResult) {
+        if (closeResult == ncclSuccess || closeResult == ncclInProgress) {
+          return;
+        }
+        WARN("Failed to close bootstrap %s: %d", endpoint, closeResult);
+        if (result == ncclSuccess) {
+          result = closeResult;
+        }
+      };
+
+  if (state->ringUsesOobNet) {
+    recordCloseResult(
+        "OOB-net send endpoint",
+        state->net->closeSend(state->ring.net.sendComm));
+    recordCloseResult(
+        "OOB-net receive endpoint",
+        state->net->closeRecv(state->ring.net.recvComm));
+    recordCloseResult(
+        "OOB-net listener", state->net->closeListen(state->listen.net.comm));
+  } else {
+    recordCloseResult(
+        "ring send socket", ncclSocketClose(&state->ring.socket.send));
+    recordCloseResult(
+        "ring receive socket", ncclSocketClose(&state->ring.socket.recv));
+    recordCloseResult("ring listener", ncclSocketClose(&state->listen.socket));
+  }
+  recordCloseResult(
+      "peer listener", ncclSocketClose(&state->listen.peerSocket));
+
+  while (state->unexpectedConnections != nullptr) {
+    struct unexConn* const connection = state->unexpectedConnections;
+    state->unexpectedConnections = connection->next;
+    std::free(connection);
+  }
+  std::free(state->peerProxyAddresses);
+  std::free(state->peerProxyAddressesUDS);
+  std::free(state->peerP2pAddresses);
+  std::free(state);
+  return result;
+}
+
+inline void abortBootstrapAfterRingAllInfoFailure(
+    struct ncclComm* comm,
+    struct ncclSocket*& proxySocket) {
+  if (proxySocket != nullptr) {
+    struct ncclSocket* const socket = proxySocket;
+    proxySocket = nullptr;
+    const ncclResult_t closeResult = ncclSocketClose(socket);
+    if (closeResult != ncclSuccess) {
+      WARN("Failed to close bootstrap proxy listener: %d", closeResult);
+    }
+    std::free(socket);
+  }
+
+  void* const bootstrap = comm->bootstrap;
+  comm->bootstrap = nullptr;
+  if (bootstrap == nullptr) {
+    return;
+  }
+
+  const ncclResult_t abortResult = bootstrapAbort(bootstrap);
+  if (abortResult != ncclSuccess) {
+    WARN("Failed to abort bootstrap state: %d", abortResult);
+  }
+}
+
+} // namespace ncclx

--- a/comms/ncclx/meta/tests/BootstrapTest.cc
+++ b/comms/ncclx/meta/tests/BootstrapTest.cc
@@ -8,12 +8,14 @@
 #include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <cstdlib>
 #include <future>
 
 #include <gtest/gtest.h>
 
 #include "bootstrap.h"
 #include "meta/NcclxConfig.h"
+#include "meta/ctran-integration/BootstrapCleanup.h"
 
 namespace {
 
@@ -85,6 +87,52 @@ thread_local RecvFaultState* activeRecvFault = nullptr;
 // NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
 std::atomic<int> injectedFaults{0};
 
+struct NetCloseState {
+  int sendCalls{0};
+  int receiveCalls{0};
+  int listenCalls{0};
+
+  bool operator==(const NetCloseState& other) const {
+    return sendCalls == other.sendCalls && receiveCalls == other.receiveCalls &&
+        listenCalls == other.listenCalls;
+  }
+};
+
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+NetCloseState netCloseState;
+
+ncclResult_t closeSend(void*) {
+  ++netCloseState.sendCalls;
+  return ncclSuccess;
+}
+
+ncclResult_t failCloseSend(void*) {
+  ++netCloseState.sendCalls;
+  return ncclSystemError;
+}
+
+ncclResult_t closeReceive(void*) {
+  ++netCloseState.receiveCalls;
+  return ncclSuccess;
+}
+
+ncclResult_t closeListen(void*) {
+  ++netCloseState.listenCalls;
+  return ncclSuccess;
+}
+
+bootstrapState*
+allocateBootstrapState(ncclNet_t* net, bool fastInitMode, bool ringUsesOobNet) {
+  auto* state =
+      static_cast<bootstrapState*>(std::calloc(1, sizeof(bootstrapState)));
+  if (state != nullptr) {
+    state->net = net;
+    state->fastInitMode = fastInitMode;
+    state->ringUsesOobNet = ringUsesOobNet;
+  }
+  return state;
+}
+
 class ScopedRecvFault {
  public:
   explicit ScopedRecvFault(RecvFaultState& state) {
@@ -119,7 +167,87 @@ recv(int socket, void* buffer, std::size_t length, int flags) {
 
 namespace {
 
-TEST(BootstrapInitTest, DISABLED_RingAllGatherFailureClosesPeerSockets) {
+TEST(BootstrapCleanupTest, OobNetFailureStillClosesRemainingEndpoints) {
+  netCloseState = {};
+  ncclNet_t net{};
+  net.closeSend = failCloseSend;
+  net.closeRecv = closeReceive;
+  net.closeListen = closeListen;
+
+  auto* state = allocateBootstrapState(&net, true, true);
+  if (state == nullptr) {
+    FAIL() << "Failed to allocate bootstrap state";
+  }
+
+  EXPECT_EQ(bootstrapAbort(state), ncclSystemError);
+  const NetCloseState expected{1, 1, 1};
+  EXPECT_EQ(netCloseState, expected);
+}
+
+TEST(BootstrapCleanupTest, NormalCloseUsesStoredOobNetTransport) {
+  netCloseState = {};
+  ncclNet_t net{};
+  net.closeSend = closeSend;
+  net.closeRecv = closeReceive;
+  net.closeListen = closeListen;
+
+  auto* state = allocateBootstrapState(&net, true, true);
+  if (state == nullptr) {
+    FAIL() << "Failed to allocate bootstrap state";
+  }
+
+  EXPECT_EQ(bootstrapClose(state), ncclSuccess);
+  const NetCloseState expected{1, 1, 1};
+  EXPECT_EQ(netCloseState, expected);
+}
+
+TEST(BootstrapCleanupTest, StoredSocketTransportDoesNotUseNetCleanup) {
+  netCloseState = {};
+  ncclNet_t net{};
+  net.closeSend = closeSend;
+  net.closeRecv = closeReceive;
+  net.closeListen = closeListen;
+
+  auto* state = allocateBootstrapState(&net, false, false);
+  if (state == nullptr) {
+    FAIL() << "Failed to allocate bootstrap state";
+  }
+
+  EXPECT_EQ(bootstrapAbort(state), ncclSuccess);
+  const NetCloseState expected{};
+  EXPECT_EQ(netCloseState, expected);
+}
+
+TEST(BootstrapCleanupTest, RingFailureCleanupIsIdempotent) {
+  netCloseState = {};
+  ncclNet_t net{};
+  net.closeSend = closeSend;
+  net.closeRecv = closeReceive;
+  net.closeListen = closeListen;
+
+  ncclComm comm{};
+  comm.bootstrap = allocateBootstrapState(&net, true, true);
+  if (comm.bootstrap == nullptr) {
+    FAIL() << "Failed to allocate bootstrap state";
+  }
+  auto* proxySocket =
+      static_cast<ncclSocket*>(std::calloc(1, sizeof(ncclSocket)));
+  if (proxySocket == nullptr) {
+    std::free(comm.bootstrap);
+    FAIL() << "Failed to allocate proxy socket";
+  }
+
+  ncclx::abortBootstrapAfterRingAllInfoFailure(&comm, proxySocket);
+  EXPECT_EQ(comm.bootstrap, nullptr);
+  EXPECT_EQ(proxySocket, nullptr);
+  const NetCloseState expected{1, 1, 1};
+  EXPECT_EQ(netCloseState, expected);
+
+  ncclx::abortBootstrapAfterRingAllInfoFailure(&comm, proxySocket);
+  EXPECT_EQ(netCloseState, expected);
+}
+
+TEST(BootstrapInitTest, RingAllGatherFailureClosesPeerSockets) {
   ASSERT_EQ(bootstrapNetInit(), ncclSuccess);
 
   ncclBootstrapHandle handle{};

--- a/comms/ncclx/v2_30/src/bootstrap.cc
+++ b/comms/ncclx/v2_30/src/bootstrap.cc
@@ -7,7 +7,7 @@
 
 #include "nccl.h"
 #include "meta/NcclxConfig.h" // @manual
-#include "core.h"
+#include "meta/ctran-integration/BootstrapCleanup.h" // @manual
 #include "utils.h"
 #include "bootstrap.h"
 #include "net.h"
@@ -613,7 +613,7 @@ static ncclResult_t ringAllInfo(struct ncclComm* comm, struct bootstrapState* st
 
 exit:
   free(ringData);
-  return ncclSuccess;
+  return res;
 }
 
 static ncclResult_t sendToRoot(struct ncclBootstrapHandle* handle, struct ncclComm* comm, struct extInfo* info) {
@@ -712,7 +712,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
   int nranks = comm->nRanks;
   // char nextPeerHandle[NCCL_NET_HANDLE_MAXSIZE];
   struct bootstrapState* state;
-  struct ncclSocket* proxySocket;
+  struct ncclSocket* proxySocket = nullptr;
   struct ncclSocket sock, listenSockRoot;
   struct extInfo info = {0};
   union ringConnectInfo nextPeer;
@@ -746,6 +746,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
   BOOTSTRAP_PROF_OPEN(timers[BOOTSTRAP_INIT_TIME_TOTAL]);
   bool skipFormRingViaTcpStore = (nHandles != 1) && NCCL_SKIP_TCPFORM_RING;
   if (isFastInitRingMode(state->fastInitMode) && !skipFormRingViaTcpStore) {
+    state->ringUsesOobNet = false;
     INFO(NCCL_INIT, "rank %d nHandles %d, fast-init mode: ring-hybrid, use formRingViaTcpStore to form boostrap ring", rank, nHandles);
     // (meta) fast path to form ring via tcpstore
     NCCLCHECK(formRingViaTcpStore(state, comm));
@@ -757,7 +758,8 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
   // get the ring connection info
   memset(&nextPeer, 0, sizeof(union ringConnectInfo));
   BOOTSTRAP_PROF_OPEN(timers[BOOTSTRAP_INIT_TIME_CREATE]);
-  if (ncclParamBootstrapNetEnable()) {
+  state->ringUsesOobNet = ncclParamBootstrapNetEnable() != 0;
+  if (state->ringUsesOobNet) {
     // Create net interface for other ranks to contact me (all gather)
     NCCLCHECK(netGetDevice(rank, comm, &STATE_LISTEN(state, net.dev)));
     NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev), STATE_LISTEN(state, net.handle), &STATE_LISTEN(state, net.comm)));
@@ -837,7 +839,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
   BOOTSTRAP_PROF_CLOSE(timers[BOOTSTRAP_INIT_TIME_RECV]);
 
   // accept and connect the ring network
-  if (ncclParamBootstrapNetEnable()) {
+  if (state->ringUsesOobNet) {
     NCCLCHECK(netRingConnect(comm->netContext, state->net, &state->listen, nextPeer.handle,
                              &STATE_RING(state, net.sendComm), &STATE_RING(state, net.sendDevHandle),
                              &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle), state->abortFlag));
@@ -881,7 +883,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
   }
 
   BOOTSTRAP_PROF_OPEN(timers[BOOTSTRAP_INIT_TIME_RING]);
-  NCCLCHECKGOTO(ringAllInfo(comm, state, state->peerP2pAddresses, state->peerProxyAddresses, state->peerProxyAddressesUDS, rasRanks), result, fail);
+  NCCLCHECKGOTO(ringAllInfo(comm, state, state->peerP2pAddresses, state->peerProxyAddresses, state->peerProxyAddressesUDS, rasRanks), result, ringInfoFail);
   BOOTSTRAP_PROF_CLOSE(timers[BOOTSTRAP_INIT_TIME_RING]);
 
   // Create the service proxy and get the UDS
@@ -902,6 +904,9 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
        timers[BOOTSTRAP_INIT_TIME_DELAY] / 1e9);
 exit:
   return result;
+ringInfoFail:
+  ncclx::abortBootstrapAfterRingAllInfoFailure(comm, proxySocket);
+  goto exit;
 fail:
   free(proxySocket);
   goto exit;
@@ -914,7 +919,7 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   int prev, next;
   union ringConnectInfo info;
   union ringConnectInfo nextPeer;
-  struct ncclSocket* proxySocket = NULL;
+  struct ncclSocket* proxySocket = nullptr;
   struct bootstrapState* state;
 
   NCCLCHECKGOTO(ncclCalloc(&state, 1), ret, fail);
@@ -926,12 +931,15 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   state->fastInitMode = NCCLX_CONFIG_FIELD(comm->config, fastInitMode);
   comm->bootstrap = state;
   comm->magic = state->magic = magic;
+  state->ringUsesOobNet =
+      !isFastInitRingMode(state->fastInitMode) &&
+      ncclParamBootstrapNetEnable() != 0;
 
   prev = parentRanks[(rank - 1 + nranks) % nranks];
   next = parentRanks[(rank + 1) % nranks];
 
   // create a handle for the others to reach out to me
-  if (!isFastInitRingMode(state->fastInitMode) && ncclParamBootstrapNetEnable()) {
+  if (state->ringUsesOobNet) {
     NCCLCHECKGOTO(netGetDevice(rank, comm, &STATE_LISTEN(state, net.dev)), ret, fail);
     NCCLCHECKGOTO(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev), STATE_LISTEN(state, net.handle), &STATE_LISTEN(state, net.comm)), ret, fail);
     memcpy(info.handle, STATE_LISTEN(state, net.handle), NCCL_NET_HANDLE_MAXSIZE);
@@ -951,7 +959,7 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   // Get addr from next rank using the parent's connections
   NCCLCHECKGOTO(bootstrapSend(parent->bootstrap, prev, BOOTSTRAP_TAG_COMMSPLIT, &info, sizeof(union ringConnectInfo)), ret, fail);
   NCCLCHECKGOTO(bootstrapRecv(parent->bootstrap, next, BOOTSTRAP_TAG_COMMSPLIT, &nextPeer, sizeof(union ringConnectInfo)), ret, fail);
-  if (!isFastInitRingMode(state->fastInitMode) && ncclParamBootstrapNetEnable()) {
+  if (state->ringUsesOobNet) {
     NCCLCHECKGOTO(netRingConnect(comm->netContext, state->net, &state->listen, nextPeer.handle,
                                  &STATE_RING(state, net.sendComm), &STATE_RING(state, net.sendDevHandle),
                                  &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle), state->abortFlag),
@@ -967,7 +975,7 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
     for (int i = 0; i < nranks; ++i) {
       comm->topParentRanks[i] = parent->topParentRanks[parentRanks[i]];
     }
-    NCCLCHECKGOTO(ringAllInfo(comm, state, state->peerP2pAddresses, NULL, NULL, NULL), ret, fail);
+    NCCLCHECKGOTO(ringAllInfo(comm, state, state->peerP2pAddresses, nullptr, nullptr, nullptr), ret, ringInfoFail);
   } else {
     NCCLCHECKGOTO(ncclCalloc(&state->peerProxyAddresses, nranks), ret, fail);
     NCCLCHECKGOTO(ncclCalloc(&state->peerProxyAddressesUDS, nranks), ret, fail);
@@ -975,7 +983,7 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
     NCCLCHECKGOTO(ncclCalloc(&proxySocket, 1), ret, fail);
     NCCLCHECKGOTO(getUDS(state->peerProxyAddressesUDS + rank), ret, fail);
     NCCLCHECKGOTO(createListenSocket(comm, comm->magic, proxySocket, state->peerProxyAddresses + rank, ncclSocketTypeProxy), ret, fail);
-    NCCLCHECKGOTO(ringAllInfo(comm, state, state->peerP2pAddresses, state->peerProxyAddresses, state->peerProxyAddressesUDS, NULL), ret, fail);
+    NCCLCHECKGOTO(ringAllInfo(comm, state, state->peerP2pAddresses, state->peerProxyAddresses, state->peerProxyAddressesUDS, nullptr), ret, ringInfoFail);
     NCCLCHECKGOTO(ncclProxyInit(comm, proxySocket, state->peerProxyAddresses, state->peerProxyAddressesUDS), ret, fail);
   }
 
@@ -984,6 +992,9 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
 
 exit:
   return ret;
+ringInfoFail:
+  ncclx::abortBootstrapAfterRingAllInfoFailure(comm, proxySocket);
+  goto exit;
 fail:
   free(proxySocket);
   goto exit;
@@ -1199,7 +1210,7 @@ ncclResult_t bootstrapAllGather(void* commState, void* allData, int size) {
 
   uint64_t time = 0;
   BOOTSTRAP_PROF_OPEN(time);
-  if (ncclParamBootstrapNetEnable()) {
+  if (state->ringUsesOobNet) {
     NCCLCHECKGOTO(netRingAllGather(state->net, STATE_RING(state, net.sendComm), STATE_RING(state, net.recvComm), rank, nranks, (char*)allData, size, state->abortFlag), res, exit);
   } else {
     NCCLCHECKGOTO(socketRingAllGather(&STATE_RING(state, socket.send), &STATE_RING(state, socket.recv), rank, nranks, (char*)allData, size), res, exit);
@@ -1309,7 +1320,7 @@ ncclResult_t bootstrapClose(void* commState) {
       return ncclInternalError;
     }
   }
-  if (!isFastInitRingMode(state->fastInitMode) && ncclParamBootstrapNetEnable()) {
+  if (state->ringUsesOobNet) {
     NCCLCHECK(state->net->closeSend(STATE_RING(state, net.sendComm)));
     NCCLCHECK(state->net->closeRecv(STATE_RING(state, net.recvComm)));
     NCCLCHECK(state->net->closeListen(STATE_LISTEN(state, net.comm)));
@@ -1331,9 +1342,5 @@ ncclResult_t bootstrapAbort(void* commState) {
   if (commState == NULL)
     return ncclSuccess;
   struct bootstrapState* state = (struct bootstrapState*)commState;
-  // when aborting we need to close the proxy here (maybe?)
-  free(state->peerProxyAddresses);
-  free(state->peerProxyAddressesUDS);
-  NCCLCHECK(bootstrapClose(commState));
-  return ncclSuccess;
+  return ncclx::abortBootstrapState(state);
 }

--- a/comms/ncclx/v2_30/src/include/bootstrap.h
+++ b/comms/ncclx/v2_30/src/include/bootstrap.h
@@ -68,6 +68,7 @@ struct bootstrapState {
   // Reference to CommLogData to object to facilicate logging
   struct CommLogData *logMetaDataPtr{nullptr};
   bool fastInitMode{false};
+  bool ringUsesOobNet{false};
 };
 
 ncclResult_t bootstrapNetInit();


### PR DESCRIPTION
Summary:

In NCCLX 2.30, return the error captured from bootstrapAllGather instead of unconditionally returning success. When that error reaches bootstrapInit or bootstrapSplit, close the standalone proxy listener and abort the initialized bootstrap state so peers do not remain blocked on open but unserviced endpoints.

Detach both the proxy socket and comm->bootstrap before destructive cleanup. Bootstrap abort attempts every OOB-net or socket endpoint close even when an earlier close fails, preserves the first cleanup error for reporting, and always releases the bootstrap-owned allocations. This makes the failure path idempotent without making later endpoints unreachable after a partial abort.

Record the ring transport selected during setup in bootstrapState and use that value for connection, metadata all-gather, normal close, and abort. This avoids inferring transport from fast-init configuration or re-reading the environment: multi-handle fast init with NCCL_SKIP_TCPFORM_RING=1 can construct an OOB-net ring even though fast-init remains enabled.

Keep ringAllInfo file-local with its original signature. Put the shared cleanup behavior under meta/, limit the v2.30 baseline changes to transport recording, bootstrapAbort delegation, and ownership-safe post-ring cleanup edges, and re-enable the regression added disabled by the parent diff. Per review direction, v2.29 is explicitly excluded and unchanged.

Reviewed By: snarayankh

Differential Revision: D114258249


