### PR TITLE
Disable WARP_SPEED in conda build to match Buck (#3353)

### DIFF
--- a/build_rcclx.sh
+++ b/build_rcclx.sh
@@ -420,6 +420,7 @@ function build_rccl {
     --amdgpu_targets "$AMDGPU_TARGETS" \
     --disable-colltrace \
     --disable-msccl-kernel \
+    --disable-warp-speed \
     ${prims_flag}
 }
 

--- a/comms/rcclx/develop/projects/rccl/install.sh
+++ b/comms/rcclx/develop/projects/rccl/install.sh
@@ -86,6 +86,7 @@ function display_help()
     echo "    -q|--quiet-warnings        Suppress majority of compiler warnings (not recommended)"
     echo "       --rocshmem              Build with rocSHMEM support"
     echo "       --enable-prims          Compile comms/prims (pipes) into RCCLX (default: off)"
+    echo "       --disable-warp-speed    Build without WARP_SPEED kernels"
 }
 
 # #################################################


### PR DESCRIPTION
Summary:

The conda rcclx package is produced by the CMake path (comms/github/build_rcclx.sh -> RCCL install.sh), while fbcode consumers use the Buck build (comms/rcclx/rccl_build_config.bzl). Comparing the two revealed that WARP_SPEED is a feature that AMD's install.sh/CMakeLists leaves ON by default (when gfx950 is in the target list) but the Buck config never defines, and which build_rcclx.sh never disabled. This makes the conda librccl.so diverge from the Buck build, contributing to the observed collective perf gap.

- WARP_SPEED (default ON in CMake when gfx950 is in the target list): applies ENABLE_WARP_SPEED as a whole-target define. Buck never defines it.

Changes:
- build_rcclx.sh: pass --disable-warp-speed to install.sh alongside the existing --disable-colltrace --disable-msccl-kernel.
- install.sh: add a --help entry documenting --disable-warp-speed (the flag itself already worked -- it simply skips -DENABLE_WARP_SPEED=ON; there is no option() default forcing it on).

Reviewed By: JinghanHuang

Differential Revision: D114271031


