### PR TITLE
Re-clone incomplete /tmp/third-party caches in build_rcclx.sh

### DIFF
--- a/build_rcclx.sh
+++ b/build_rcclx.sh
@@ -40,6 +40,16 @@ function clean_third_party {
   fi
 }
 
+# The /tmp/third-party clones are cached across builds, but /tmp auto-cleanup
+# (tmpreaper/systemd-tmpfiles) can evict the less-recently-accessed source tree
+# while keeping frequently-touched build artifacts (e.g. boost's b2). A bare
+# existence check then skips re-cloning and the build fails on a missing entry
+# point (bootstrap.sh/configure/CMakeLists.txt). A valid git checkout always has
+# a .git dir, so treat its absence as "incomplete" and force a fresh clone.
+function needs_clone() {
+  [ ! -d "$1/.git" ]
+}
+
 function build_fb_oss_library() {
   local repo_url="$1"
   local repo_tag="$2"
@@ -48,7 +58,8 @@ function build_fb_oss_library() {
 
   clean_third_party "$library_name"
 
-  if [ ! -e "$library_name" ]; then
+  if needs_clone "$library_name"; then
+    rm -rf "$library_name"
     git clone --depth 1 -b "$repo_tag" "$repo_url" "$library_name"
   fi
 
@@ -79,7 +90,8 @@ function build_automake_library() {
 
   clean_third_party "$library_name"
 
-  if [ ! -e "$library_name" ]; then
+  if needs_clone "$library_name"; then
+    rm -rf "$library_name"
     git clone --depth 1 -b "$repo_tag" "$repo_url" "$library_name"
   fi
 
@@ -101,7 +113,8 @@ function build_boost() {
   # clean up existing boost
   clean_third_party "$library_name"
 
-  if [ ! -e "$library_name" ]; then
+  if needs_clone "$library_name"; then
+    rm -rf "$library_name"
     git clone -j 10 --recurse-submodules --depth 1 -b "$repo_tag" "$repo_url" "$library_name"
   fi
 
@@ -121,7 +134,8 @@ function build_openssl() {
   # clean up existing boost
   clean_third_party "$library_name"
 
-  if [ ! -e "$library_name" ]; then
+  if needs_clone "$library_name"; then
+    rm -rf "$library_name"
     git clone -j 10 --recurse-submodules --depth 1 -b "$repo_tag" "$repo_url" "$library_name"
   fi
 
@@ -210,7 +224,8 @@ function build_third_party {
   if [[ -z "${NCCL_FEEDSTOCK_BUILD}" ]]; then
     build_fb_oss_library "https://github.com/facebookincubator/fizz.git" "$third_party_tag" fizz "-DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF"
     # Clone mvfst and disable the xsk subdirectory (requires linux/if_xdp.h not available on all systems)
-    if [ ! -e "quic" ]; then
+    if needs_clone "quic"; then
+      rm -rf quic
       git clone --depth 1 -b "$third_party_tag" "https://github.com/facebook/mvfst" quic
     fi
     sed -i 's|^add_subdirectory(xsk)|# add_subdirectory(xsk) # disabled: requires linux/if_xdp.h|' quic/quic/CMakeLists.txt

--- a/build_rcclx.sh
+++ b/build_rcclx.sh
@@ -420,6 +420,7 @@ function build_rccl {
     --amdgpu_targets "$AMDGPU_TARGETS" \
     --disable-colltrace \
     --disable-msccl-kernel \
+    --disable-warp-speed \
     ${prims_flag}
 }
 

--- a/comms/rcclx/develop/projects/rccl/install.sh
+++ b/comms/rcclx/develop/projects/rccl/install.sh
@@ -86,6 +86,7 @@ function display_help()
     echo "    -q|--quiet-warnings        Suppress majority of compiler warnings (not recommended)"
     echo "       --rocshmem              Build with rocSHMEM support"
     echo "       --enable-prims          Compile comms/prims (pipes) into RCCLX (default: off)"
+    echo "       --disable-warp-speed    Build without WARP_SPEED kernels"
 }
 
 # #################################################


### PR DESCRIPTION
Summary:
The rcclx conda build (build_rcclx.sh) caches its OSS third-party source
clones under /tmp/third-party and reuses them across builds. Each clone
site guarded the download with a bare `[ ! -e "$dir" ]` existence check,
so any directory that merely exists is reused as-is.

That check is not enough: /tmp auto-cleanup (tmpreaper/systemd-tmpfiles)
evicts less-recently-accessed source files while leaving frequently-touched
build artifacts behind. The result is a half-deleted checkout -- e.g.
/tmp/third-party/boost with a stale `b2` and `project-config.jam` but no
`bootstrap.sh` and no `.git`. The build then skips re-cloning and dies with:

    comms/github/build_rcclx.sh: line 110: ./bootstrap.sh: No such file or directory

The same corruption was present in several other cached dirs (openssl,
sodium, event, quic); boost just failed first. Wiping the conda env
(WORKING_DIR=/data/users/$USER/l4x-rocm72) does not help because the stale
cache lives in /tmp/third-party, a separate location.

Fix: add a `needs_clone` helper that treats a checkout as valid only when
it contains a `.git` dir (always present after a real `git clone`, and only
removed by external /tmp cleanup). All five clone sites now `rm -rf` and
re-clone any checkout that is missing or incomplete, making the third-party
cache self-healing while preserving the intentional cross-build caching.

Reviewed By: JinghanHuang

Differential Revision: D114271032


