### PR TITLE
Link fault_tolerance/Abort.cc into librccl.so to fix undefined createAbort symbol (#3355)

### DIFF
--- a/build_rcclx.sh
+++ b/build_rcclx.sh
@@ -40,6 +40,16 @@ function clean_third_party {
   fi
 }
 
+# The /tmp/third-party clones are cached across builds, but /tmp auto-cleanup
+# (tmpreaper/systemd-tmpfiles) can evict the less-recently-accessed source tree
+# while keeping frequently-touched build artifacts (e.g. boost's b2). A bare
+# existence check then skips re-cloning and the build fails on a missing entry
+# point (bootstrap.sh/configure/CMakeLists.txt). A valid git checkout always has
+# a .git dir, so treat its absence as "incomplete" and force a fresh clone.
+function needs_clone() {
+  [ ! -d "$1/.git" ]
+}
+
 function build_fb_oss_library() {
   local repo_url="$1"
   local repo_tag="$2"
@@ -48,7 +58,8 @@ function build_fb_oss_library() {
 
   clean_third_party "$library_name"
 
-  if [ ! -e "$library_name" ]; then
+  if needs_clone "$library_name"; then
+    rm -rf "$library_name"
     git clone --depth 1 -b "$repo_tag" "$repo_url" "$library_name"
   fi
 
@@ -79,7 +90,8 @@ function build_automake_library() {
 
   clean_third_party "$library_name"
 
-  if [ ! -e "$library_name" ]; then
+  if needs_clone "$library_name"; then
+    rm -rf "$library_name"
     git clone --depth 1 -b "$repo_tag" "$repo_url" "$library_name"
   fi
 
@@ -101,7 +113,8 @@ function build_boost() {
   # clean up existing boost
   clean_third_party "$library_name"
 
-  if [ ! -e "$library_name" ]; then
+  if needs_clone "$library_name"; then
+    rm -rf "$library_name"
     git clone -j 10 --recurse-submodules --depth 1 -b "$repo_tag" "$repo_url" "$library_name"
   fi
 
@@ -121,7 +134,8 @@ function build_openssl() {
   # clean up existing boost
   clean_third_party "$library_name"
 
-  if [ ! -e "$library_name" ]; then
+  if needs_clone "$library_name"; then
+    rm -rf "$library_name"
     git clone -j 10 --recurse-submodules --depth 1 -b "$repo_tag" "$repo_url" "$library_name"
   fi
 
@@ -210,7 +224,8 @@ function build_third_party {
   if [[ -z "${NCCL_FEEDSTOCK_BUILD}" ]]; then
     build_fb_oss_library "https://github.com/facebookincubator/fizz.git" "$third_party_tag" fizz "-DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF"
     # Clone mvfst and disable the xsk subdirectory (requires linux/if_xdp.h not available on all systems)
-    if [ ! -e "quic" ]; then
+    if needs_clone "quic"; then
+      rm -rf quic
       git clone --depth 1 -b "$third_party_tag" "https://github.com/facebook/mvfst" quic
     fi
     sed -i 's|^add_subdirectory(xsk)|# add_subdirectory(xsk) # disabled: requires linux/if_xdp.h|' quic/quic/CMakeLists.txt

--- a/build_rcclx.sh
+++ b/build_rcclx.sh
@@ -420,6 +420,7 @@ function build_rccl {
     --amdgpu_targets "$AMDGPU_TARGETS" \
     --disable-colltrace \
     --disable-msccl-kernel \
+    --disable-warp-speed \
     ${prims_flag}
 }
 

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -1012,6 +1012,8 @@ set(COMMON_FILES
   comms/common/IpcMemHandler.cc
   comms/common/IpcMemHandler.h
   comms/common/bootstrap/IBootstrap.h
+  comms/common/fault_tolerance/Abort.cc
+  comms/common/fault_tolerance/Abort.h
   comms/utils/checks.h
   comms/utils/colltrace/AlgoStats.cc
   comms/utils/colltrace/AlgoStats.h

--- a/comms/rcclx/develop/projects/rccl/install.sh
+++ b/comms/rcclx/develop/projects/rccl/install.sh
@@ -86,6 +86,7 @@ function display_help()
     echo "    -q|--quiet-warnings        Suppress majority of compiler warnings (not recommended)"
     echo "       --rocshmem              Build with rocSHMEM support"
     echo "       --enable-prims          Compile comms/prims (pipes) into RCCLX (default: off)"
+    echo "       --disable-warp-speed    Build without WARP_SPEED kernels"
 }
 
 # #################################################


### PR DESCRIPTION
Summary:

The RCCLX conda/CMake build (comms/rcclx/develop/projects/rccl/CMakeLists.txt)
compiles the comms/ctran sources into librccl.so. Those sources reference
comms::fault_tolerance::createAbort(bool) -- mostly via default arguments in
headers like CtranComm.h, mccl/bootstrap/Bootstrap.h, and CtranIb.cc -- so the
symbol gets instantiated into librccl's objects.

However, comms/common/fault_tolerance/Abort.cc (which defines createAbort) was
never listed in COMMON_FILES, so it was never compiled into librccl.so. The
result was an unresolved dynamic symbol:

  ImportError: .../torch/lib/../../../../librccl.so.1: undefined symbol:
  _ZN5comms15fault_tolerance11createAbortEb

which broke `import torch` (and therefore torchaudio's setup.py) in the
redacted/flagship_rocm (redacted.sh) conda build.

Add Abort.cc/Abort.h to COMMON_FILES so createAbort is compiled and linked into
librccl.so. Abort.cc is self-contained (includes only Abort.h and <memory>), so
this is a minimal, low-risk addition.

Reviewed By: JinghanHuang

Differential Revision: D114271030


