### PR TITLE
Add NCCL_CTRAN_GRAPH_MIXING_SUPPORT to fold GPE ordering fence into a graph edge (#3358)

### DIFF
--- a/comms/ctran/algos/common/OrderedWorkStreamGuard.cc
+++ b/comms/ctran/algos/common/OrderedWorkStreamGuard.cc
@@ -6,6 +6,7 @@
 
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/CudaWrap.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 
 namespace ctran::algos {
@@ -23,6 +24,7 @@ void OrderedWorkStreamGuard::init(
       logMetaData);
 
   // Publish the initialized state only after every resource is ready.
+  graphMixingSupport_ = (NCCL_CTRAN_GRAPH_MIXING_SUPPORT != 0);
   synchronizeEagerAfterCapturedWork_ = synchronizeEagerAfterCapturedWork;
   execModeSyncEvent_ = execModeSyncEvent;
   sideStream_ = std::move(sideStream);
@@ -108,12 +110,13 @@ commResult_t OrderedWorkStreamGuard::doAcquire(
     FB_CUDACHECK(cudaStreamWaitEvent(
         userStream,
         execModeSyncEvent_,
-        isCapturing ? cudaEventWaitExternal : cudaEventWaitDefault));
+        (isCapturing && graphMixingSupport_) ? cudaEventWaitExternal
+                                             : cudaEventWaitDefault));
     return commSuccess;
   };
 
   if (lastUserStream_ == nullptr) {
-    if (isCapturing) {
+    if (isCapturing && graphMixingSupport_) {
       return doWait();
     }
     return commSuccess;
@@ -132,6 +135,9 @@ commResult_t OrderedWorkStreamGuard::doAcquire(
   }
 
   if (!isNewCapture) {
+    if (!graphMixingSupport_) {
+      return doWait();
+    }
     // A later operation captured into the same graph must depend on the
     // prior record node even if CUDA cannot infer a dependency across streams.
 #if defined(__HIP_PLATFORM_AMD__)
@@ -150,6 +156,10 @@ commResult_t OrderedWorkStreamGuard::doAcquire(
 #endif
   }
 
+  if (!graphMixingSupport_) {
+    return commSuccess;
+  }
+
   return doWait();
 }
 
@@ -158,7 +168,7 @@ commResult_t OrderedWorkStreamGuard::doRelease(
     const ctran::utils::cudagraph::StreamCaptureInfo& captureInfo) {
   const bool isCapturing = captureInfo.status == cudaStreamCaptureStatusActive;
 
-  if (!isCapturing) {
+  if (!isCapturing || !graphMixingSupport_) {
     FB_CUDACHECK(cudaEventRecord(execModeSyncEvent_, userStream));
   } else {
     // Record from a forked capture stream so the external event can order

--- a/comms/ctran/algos/common/OrderedWorkStreamGuard.h
+++ b/comms/ctran/algos/common/OrderedWorkStreamGuard.h
@@ -69,6 +69,7 @@ class OrderedWorkStreamGuard {
   cudaEvent_t execModeSyncEvent_{};
   unsigned long long lastCaptureId_{0};
   bool everCaptured_{false};
+  bool graphMixingSupport_{true};
   bool synchronizeEagerAfterCapturedWork_{false};
   bool initialized_{false};
   commResult_t error_{commSuccess};

--- a/comms/ctran/gpe/tests/CtranGpeUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeUT.cc
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 #include <atomic>
 #include <chrono>
+#include <cstdlib>
 #include <future>
 #include <iostream>
 #include <thread>
@@ -693,6 +694,165 @@ TEST_F(CtranGpeTest, GraphCaptureGuardWaitRecordPerKernel) {
   CUDACHECK_TEST(cudaFree(buf));
   CUDACHECK_TEST(cudaFreeHost(valPtr));
   CUDACHECK_TEST(cudaStreamDestroy(stream));
+}
+
+// Result of capturing a single-user-stream graph with a non-GPE memset
+// interposed between two GPE submits, under a given
+// NCCL_CTRAN_GRAPH_MIXING_SUPPORT setting.
+struct ReleaseFencePlacement {
+  size_t recordNodeCount{0};
+  bool kernelsOrdered{false};
+};
+
+// Capture: submit(kernelA) -> cudaMemsetAsync (non-GPE work) ->
+// submit(kernelB), all on one user stream, with
+// NCCL_CTRAN_GRAPH_MIXING_SUPPORT=`mixingMode`. With mixing on (=1) the guard
+// emits one explicit EVENT_RECORD node per submit (on the side stream); with
+// mixing off (=0) the ordering fence is a plain captured event that folds into
+// the graph as an edge, so no EVENT_RECORD node appears. Either way the two GPE
+// kernels must stay ordered. The graph is also instantiated and launched to
+// confirm correctness in both modes. The cvar is latched in
+// OrderedWorkStreamGuard::init() at CtranGpe construction, so it must be set
+// before `new CtranGpe`.
+static ReleaseFencePlacement captureReleaseFencePlacement(
+    int cudaDev,
+    CtranComm* dummyComm,
+    CtranAlgoDeviceState* dummyDevState_d,
+    const char* mixingMode) {
+  setenv("NCCL_CTRAN_GRAPH_MIXING_SUPPORT", mixingMode, 1);
+  ncclCvarInit();
+  auto gpe = std::unique_ptr<CtranGpe>(new CtranGpe(cudaDev, dummyComm));
+
+  cudaStream_t stream;
+  CUDACHECK_TEST(cudaStreamCreate(&stream));
+
+  int* bufA = nullptr;
+  int* bufB = nullptr;
+  int* nonGpeBuf = nullptr;
+  int* valPtr = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&bufA, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMalloc(&bufB, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMalloc(&nonGpeBuf, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(bufA, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(bufB, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(nonGpeBuf, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr, sizeof(int)));
+  *valPtr = 42;
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  CUDACHECK_TEST(cudaStreamBeginCapture(stream, cudaStreamCaptureModeRelaxed));
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER, stream, "dummyAlgo", 0);
+    ctranKernelSetAllGatherArgs(
+        bufA, valPtr, commInt8, count, dummyDevState_d, &config.args);
+    EXPECT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+
+  // Non-GPE work on the user stream between the two submits. It inherits the
+  // release fence as a dependency only when that fence is anchored inline.
+  CUDACHECK_TEST(cudaMemsetAsync(nonGpeBuf, 0xFF, sizeof(int) * count, stream));
+
+  {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER, stream, "dummyAlgo", 0);
+    ctranKernelSetAllGatherArgs(
+        bufB, valPtr, commInt8, count, dummyDevState_d, &config.args);
+    EXPECT_EQ(
+        gpe->submit(
+            std::move(emptyOps),
+            nullptr,
+            config,
+            reinterpret_cast<void*>(CtranGpeTestKernel)),
+        commSuccess);
+  }
+
+  cudaGraph_t graph;
+  CUDACHECK_TEST(cudaStreamEndCapture(stream, &graph));
+  EXPECT_NE(graph, nullptr);
+
+  ReleaseFencePlacement out;
+  {
+    auto topo = getGraphTopology(graph);
+    auto recordNodes = topo.nodesOfType(cudaGraphNodeTypeEventRecord);
+    auto memsetNodes = topo.nodesOfType(cudaGraphNodeTypeMemset);
+    auto kernelNodes = topo.nodesOfType(cudaGraphNodeTypeKernel);
+    out.recordNodeCount = recordNodes.size();
+    // The interposed cudaMemsetAsync is the only Memset node captured here
+    // (the setup cudaMemsets run before capture begins).
+    EXPECT_EQ(memsetNodes.size(), 1u);
+    EXPECT_EQ(kernelNodes.size(), 2u);
+    if (kernelNodes.size() == 2) {
+      // cudaGraphGetNodes order is unspecified, so check both directions: the
+      // two same-stream GPE submits must be ordered relative to each other.
+      out.kernelsOrdered = topo.hasPath(kernelNodes[0], kernelNodes[1]) ||
+          topo.hasPath(kernelNodes[1], kernelNodes[0]);
+    }
+  }
+
+  // Instantiate + launch: both placements must produce correct results.
+  cudaGraphExec_t graphExec;
+  CUDACHECK_TEST(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+  CUDACHECK_TEST(cudaGraphLaunch(graphExec, stream));
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+  std::vector<int> hostA(count, 0);
+  std::vector<int> hostB(count, 0);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostA.data(), bufA, sizeof(int) * count, cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaMemcpy(
+      hostB.data(), bufB, sizeof(int) * count, cudaMemcpyDeviceToHost));
+  EXPECT_THAT(hostA, testing::Each(42));
+  EXPECT_THAT(hostB, testing::Each(42));
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  CUDACHECK_TEST(cudaFree(bufA));
+  CUDACHECK_TEST(cudaFree(bufB));
+  CUDACHECK_TEST(cudaFree(nonGpeBuf));
+  CUDACHECK_TEST(cudaFreeHost(valPtr));
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+
+  // Restore the default so this cvar doesn't leak into other tests via the
+  // fixture's ncclCvarInit().
+  unsetenv("NCCL_CTRAN_GRAPH_MIXING_SUPPORT");
+  ncclCvarInit();
+  return out;
+}
+
+// NCCL_CTRAN_GRAPH_MIXING_SUPPORT=1 (default): the guard emits an explicit
+// EVENT_RECORD node per submit (on the side stream) so the fence can order
+// across graphs. Cross-submit ordering is still enforced (kernelB depends on
+// kernelA).
+TEST_F(CtranGpeTest, GraphCaptureGraphMixingSupportSideStream) {
+  auto placement =
+      captureReleaseFencePlacement(cudaDev, dummyComm, dummyDevState_d, "1");
+  EXPECT_EQ(placement.recordNodeCount, 2u)
+      << "one explicit release EVENT_RECORD node per submit";
+  EXPECT_TRUE(placement.kernelsOrdered)
+      << "cross-submit ordering must be preserved";
+}
+
+// NCCL_CTRAN_GRAPH_MIXING_SUPPORT=0: the ordering fence is a plain captured
+// event that folds into the graph as a dependency edge, so no standalone
+// EVENT_RECORD node is emitted — cudaGraphInstantiate has no floating fence to
+// mis-place onto a busy channel. Cross-submit ordering is still preserved via
+// the edge.
+TEST_F(CtranGpeTest, GraphCaptureGraphMixingSupportEdge) {
+  auto placement =
+      captureReleaseFencePlacement(cudaDev, dummyComm, dummyDevState_d, "0");
+  EXPECT_EQ(placement.recordNodeCount, 0u)
+      << "mixing off must not emit any explicit EVENT_RECORD node; the fence is "
+         "a dependency edge";
+  EXPECT_TRUE(placement.kernelsOrdered)
+      << "cross-submit ordering must be preserved";
 }
 
 // Verify that consecutive same-stream submits followed by a cross-stream

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -97,6 +97,25 @@ cvars:
      consolidated abort ERR line on stderr (gpeProfiler_->debugString())
      keeps producing per-phase latencies. Set true to enable Scuba flush.
 
+ - name        : NCCL_CTRAN_GRAPH_MIXING_SUPPORT
+   type        : int
+   default     : 1
+   description : |-
+     CTRAN GPE analog of NCCL_GRAPH_MIXING_SUPPORT, controlling the
+     OrderedWorkStreamGuard ordering fence inserted during CUDA graph capture.
+     When 1 (default), each captured CTRAN GPE submission records its ordering
+     event via cudaGraphAddEventRecordNode on a dedicated side stream and the
+     next submission waits on it with cudaEventWaitExternal, so the fence can
+     order across graphs (mixed capture/replay) without serializing unrelated
+     work on the user stream. When 0, the fence is instead a plain
+     cudaEventRecord on the user stream, awaited with a non-external
+     cudaStreamWaitEvent: under capture it folds into the graph as a dependency
+     edge rather than a standalone EVENT_RECORD node, so cudaGraphInstantiate
+     has no floating fence to mis-place onto a busy hardware channel — the cause
+     of an observed multi-ms collective park. The trade-off is no cross-graph
+     ordering. The eager (non-capture) path is unchanged regardless of this
+     setting.
+
  - name        : NCCL_CTRAN_GPE_DEVICE_RING
    type        : bool
    default     : false


### PR DESCRIPTION
Summary:

CTRAN's GPE `OrderedWorkStreamGuard` inserts a cross-graph ordering fence
during CUDA graph capture: `doRelease` records an ordering event via
`cudaGraphAddEventRecordNode` on a dedicated side stream, and the next
`doAcquire` re-links it as a capture dependency of the user stream and waits
on it with `cudaEventWaitExternal`. The external wait plus the explicit record
node give cross-graph (mixed capture/replay) ordering, but they leave the node
"floating" — `cudaGraphInstantiate` can place it onto a busy hardware channel,
parking an otherwise-independent collective (the CTRAN analog of the ncclx
StrongStream event-record-node stall that `NCCL_GRAPH_MIXING_SUPPORT=0`
addresses on the classic path). That path is unconditional today; nothing in
CTRAN reads `graphUsageMode`, so `NCCL_GRAPH_MIXING_SUPPORT` does not cover it.

Add a dedicated `NCCL_CTRAN_GRAPH_MIXING_SUPPORT` cvar (int, default 1):
- `1` (default): unchanged — `cudaGraphAddEventRecordNode` on `sideStream_`,
  re-linked and waited on with `cudaEventWaitExternal` for cross-graph ordering.
- `0`: `doRelease` records the fence with a plain `cudaEventRecord` on
  `userStream`, and `doAcquire` waits on it with the default (non-external)
  `cudaStreamWaitEvent`. Under capture this folds into the graph as a
  dependency edge, so there is no standalone EVENT_RECORD node for
  `cudaGraphInstantiate` to park on a busy channel. The trade-off is no
  cross-graph (mixed capture/replay) ordering — precisely what disabling
  graph-mixing support means. To avoid tripping capture isolation, the
  mixing-off path skips the wait on the first submit and on a new capture
  (nothing has been recorded inside the capture yet).

The eager (non-capture) path is unchanged — it always uses the default wait.

Reviewed By: ngimel

Differential Revision: D114255856


