### PR TITLE
Inline runExchangeAndProgress into AG/AGP gpeFn (#3359)

### DIFF
--- a/comms/ctran/algos/AllGather/StreamedRd/Common.h
+++ b/comms/ctran/algos/AllGather/StreamedRd/Common.h
@@ -306,26 +306,4 @@ inline commResult_t progressSteps(AlgoContext& ctx, int localChunk) {
   return commSuccess;
 }
 
-template <typename AlgoContext>
-inline commResult_t runExchangeAndProgress(
-    AlgoContext& ctx,
-    int localChunk,
-    ctran::Profiler* profiler) {
-  CTRAN_PROFILER_IF(
-      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
-  FB_COMMCHECK(exchangeCtrl(ctx));
-  CTRAN_PROFILER_IF(
-      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
-
-  // Data transfer: step-ordered event loop.
-  CTRAN_PROFILER_IF(
-      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
-  FB_COMMCHECK(progressSteps(ctx, localChunk));
-  CTRAN_PROFILER_IF(
-      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
-
-  FB_COMMCHECK(waitCtrl(ctx));
-  return commSuccess;
-}
-
 } // namespace ctran::allgather::ctsrd::common

--- a/comms/ctran/algos/AllGather/StreamedRd/Impl.cc
+++ b/comms/ctran/algos/AllGather/StreamedRd/Impl.cc
@@ -21,8 +21,10 @@ namespace {
 using ctran::algos::PersistPlanKey;
 using ctran::allgather::ctsrd::createPersistPlan;
 using ctran::allgather::ctsrd::PersistPlan;
+using ctran::allgather::ctsrd::common::exchangeCtrl;
+using ctran::allgather::ctsrd::common::progressSteps;
 using ctran::allgather::ctsrd::common::resolveFwdPeers;
-using ctran::allgather::ctsrd::common::runExchangeAndProgress;
+using ctran::allgather::ctsrd::common::waitCtrl;
 
 const auto myAlgo = NCCL_ALLGATHER_ALGO::ctsrd;
 using CtsrdAlgoContext = ctran::allgather::ctsrd::AlgoContext;
@@ -129,7 +131,19 @@ commResult_t impl(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   CTRAN_PROFILER_IF(
       profiler, profiler->endEvent(ctran::ProfilerEvent::BUF_REG));
 
-  FB_COMMCHECK(runExchangeAndProgress(ctx, rank, profiler));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
+  FB_COMMCHECK(exchangeCtrl(ctx));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
+  FB_COMMCHECK(progressSteps(ctx, rank));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
+
+  FB_COMMCHECK(waitCtrl(ctx));
 
   return commSuccess;
 }

--- a/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
@@ -24,8 +24,10 @@ using ctran::algos::PersistPlanKey;
 using ctran::allgather::ctsrd::createPersistPlan;
 using ctran::allgather::ctsrd::PersistPlan;
 using ctran::allgather::ctsrd::Plan;
+using ctran::allgather::ctsrd::common::exchangeCtrl;
+using ctran::allgather::ctsrd::common::progressSteps;
 using ctran::allgather::ctsrd::common::resolveFwdPeers;
-using ctran::allgather::ctsrd::common::runExchangeAndProgress;
+using ctran::allgather::ctsrd::common::waitCtrl;
 using ctran::allgatherp::AlgoImpl;
 using ctran::allgatherp::PersistArgs;
 using ctran::allgatherp::Resource;
@@ -159,7 +161,19 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
       recvPlan,
       sendPlan);
 
-  FB_COMMCHECK(runExchangeAndProgress(ctx, nodeId, profiler));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
+  FB_COMMCHECK(exchangeCtrl(ctx));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
+  FB_COMMCHECK(progressSteps(ctx, nodeId));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
+
+  FB_COMMCHECK(waitCtrl(ctx));
 
   return commSuccess;
 }


### PR DESCRIPTION
Summary:

Pure refactor, no behavior change. `runExchangeAndProgress` in `AllGather/StreamedRd/Common.h` wrapped `exchangeCtrl | progressSteps | waitCtrl` plus the `ALGO_CTRL`/`ALGO_DATA` profiler events, and was shared by the two GPE callbacks: AllGatherP `gpeFn` (`StreamedRecursiveDoublingImpl.cc`) and AllGather srd `impl` (`StreamedRd/Impl.cc`). This inlines that body directly into each caller and drops the wrapper, so each algorithm owns its own profiler-event placement. The `exchangeCtrl` / `progressSteps` / `waitCtrl` helpers stay shared in `Common.h`.

This unblocks a follow-up that extends AGP's `ALGO_DATA` window to cover the intra-node NVL broadcast tail, without touching the AllGather srd path.

Differential Revision: D114133270


