### PR TITLE
Migrate `-c fbcode.platform010_cuda_version` to the cuda constraint modifier (#3360)

### DIFF
--- a/comms/ctran/backends/ib/docs/ctranib_qp_interleave_devices_sweep_gb200.md
+++ b/comms/ctran/backends/ib/docs/ctranib_qp_interleave_devices_sweep_gb200.md
@@ -108,7 +108,7 @@ slightly negative at 2-put 64K) — the latency-bound region the gate excludes.
 NCCL_CTRAN_IB_DEVICES_PER_RANK=2 NCCL_CTRAN_IB_QP_INTERLEAVE_DEVICES_ENABLE=0 \
   buck2 run @fbcode//mode/opt -c fbcode.arch=aarch64 \
   -c fbcode.platform010-aarch64_clang=17 -c fbcode.nvcc_arch=b200 \
-  -c fbcode.platform010_cuda_version=12.8 \
+  -m ovr_config//third-party/cuda/constraints:12.8 \
   -m ovr_config//third-party/cuda/constraints:12.8 \
   fbcode//comms/ctran/backends/ib/benchmarks:ctranib_bench -- \
   --benchmark_filter=BM_CtranIb_MultiPut

--- a/comms/prims/benchmarks/results/IbgdaBenchmarkResults.md
+++ b/comms/prims/benchmarks/results/IbgdaBenchmarkResults.md
@@ -77,7 +77,7 @@ buck2 run @fbcode//mode/opt \
   -c fbcode.enable_gpu_sections=true \
   -c fbcode.nvcc_arch=b300 \
   -c fbcode.platform010-aarch64_clang=17 \
-  -c fbcode.platform010_cuda_version=13.0 \
+  -m ovr_config//third-party/cuda/constraints:13.0 \
   -m ovr_config//third-party/cuda/constraints:13.0 \
   -c comms.hosts=twshared0104.33.nlh2.facebook.com \
   -c comms.ifname=lo \

--- a/comms/uniflow/benchmarks/scripts/compare_rdma_bandwidth.py
+++ b/comms/uniflow/benchmarks/scripts/compare_rdma_bandwidth.py
@@ -73,13 +73,13 @@ _B200_FLAGS = (
     " -c fbcode.arch=aarch64"
     " -c fbcode.enable_gpu_sections=true"
     " -c fbcode.nvcc_arch=b200"
-    " -c fbcode.platform010_cuda_version=12.8"
+    " -m ovr_config//third-party/cuda/constraints:12.8"
 )
 _B300_FLAGS = (
     " -c fbcode.arch=aarch64"
     " -c fbcode.enable_gpu_sections=true"
     " -c fbcode.nvcc_arch=b200a"
-    " -c fbcode.platform010_cuda_version=13.0"
+    " -m ovr_config//third-party/cuda/constraints:13.0"
 )
 
 BUILD_SPECS = {

--- a/comms/uniflow/benchmarks/scripts/run_nvlink_benchmark.sh
+++ b/comms/uniflow/benchmarks/scripts/run_nvlink_benchmark.sh
@@ -114,13 +114,13 @@ if [[ -n "${HOSTS}" ]]; then
       -c fbcode.arch=aarch64 \
       -c fbcode.enable_gpu_sections=true \
       -c fbcode.nvcc_arch=b200 \
-      -c fbcode.platform010_cuda_version=12.8 \
+      -m ovr_config//third-party/cuda/constraints:12.8 \
       fbcode//comms/uniflow/benchmarks:uniflow_bench \
       --show-full-output 2>/dev/null | awk '{print $2}')
   elif [[ "${GPU_LOWER}" == "h100" ]]; then
     echo "Building uniflow_bench for x86_64 (H100)..."
     BENCH_BIN=$(buck2 build @fbcode//mode/opt \
-      -c fbcode.platform010_cuda_version=12.8 \
+      -m ovr_config//third-party/cuda/constraints:12.8 \
       fbcode//comms/uniflow/benchmarks:uniflow_bench \
       --show-full-output 2>/dev/null | awk '{print $2}')
   else


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/6100


X-link: https://github.com/facebookresearch/FBGEMM/pull/3005

This is the mechanical half of that migration (misc-1): every
`-c fbcode.platform010_cuda_version=<V>` invocation becomes
`-m ovr_config//third-party/cuda/constraints:<V>`.

Differential Revision: D114299816


