### PR TITLE
Migrate fbcode/comms/ctran to Autodeps2 (#3365)

### DIFF
--- a/comms/ctran/algos/common/benchmarks/MultiTbSyncBench.cu
+++ b/comms/ctran/algos/common/benchmarks/MultiTbSyncBench.cu
@@ -1,6 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-#include <cooperative_groups.h>
+#include <cooperative_groups.h> // @manual
 #include "comms/ctran/algos/common/MultiTbSyncDev.cuh"
 
 namespace cg = cooperative_groups;

--- a/comms/ctran/backends/ib/BootstrapInternal.cc
+++ b/comms/ctran/backends/ib/BootstrapInternal.cc
@@ -15,7 +15,7 @@
 #include <folly/ScopeGuard.h>
 #include <folly/SocketAddress.h>
 
-#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/CtranComm.h" // @manual=//comms/ctran:ctran_comm
 #include "comms/ctran/backends/ib/CtranIbVc.h"
 #include "comms/ctran/backends/ib/VcState.h"
 #include "comms/ctran/bootstrap/Socket.h"

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include "comms/common/fault_tolerance/Abort.h"
-#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/CtranComm.h" // @manual=//comms/ctran:ctran_comm
 #include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/backends/ib/BootstrapInternal.h"
 #include "comms/ctran/backends/ib/CtranIbBase.h"

--- a/comms/ctran/backends/ib/CtranIbSingleton.h
+++ b/comms/ctran/backends/ib/CtranIbSingleton.h
@@ -8,7 +8,7 @@
 
 #include <folly/Singleton.h>
 
-#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/CtranComm.h" // @manual=//comms/ctran:ctran_comm
 #include "comms/ctran/backends/ib/ibutils.h"
 #include "comms/ctran/ibverbx/Ibverbx.h"
 #include "comms/ctran/utils/Checks.h"

--- a/comms/ctran/backends/ib/CtranIbVc.h
+++ b/comms/ctran/backends/ib/CtranIbVc.h
@@ -8,12 +8,12 @@
 #include <optional>
 #include <unordered_map>
 #include <vector>
-#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/CtranComm.h" // @manual=//comms/ctran:ctran_comm
 #include "comms/ctran/backends/ib/CtranIbBase.h"
 #include "comms/ctran/backends/ib/CtranIbSingleton.h"
 #include "comms/ctran/backends/ib/IbvWrap.h"
 #include "comms/ctran/ibverbx/IbvQpUtils.h"
-#include "comms/ctran/mapper/CtranMapperTypes.h"
+#include "comms/ctran/mapper/CtranMapperTypes.h" // @manual=//comms/ctran:mapper_types
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/CtranPerf.h"
 #include "comms/ctran/utils/Exception.h"

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
@@ -9,11 +9,11 @@
 #include <memory>
 #include <unordered_map>
 
-#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/CtranComm.h" // @manual=//comms/ctran:ctran_comm
 #include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDmBase.h"
 #include "comms/ctran/bootstrap/Socket.h"
-#include "comms/ctran/mapper/CtranMapperTypes.h"
+#include "comms/ctran/mapper/CtranMapperTypes.h" // @manual=//comms/ctran:mapper_types
 #include "comms/tcp_devmem/transport.h"
 #include "comms/utils/commSpecs.h"
 

--- a/comms/ctran/gpe/tests/CtranGpeUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeUT.cc
@@ -19,7 +19,7 @@
 #include "comms/ctran/tests/CtranTestUtils.h"
 #include "comms/testinfra/TestXPlatUtils.h"
 #if not defined(__HIP_PLATFORM_AMD__) and not defined(__HIP_PLATFORM_HCC__)
-#include <cupti.h>
+#include <cupti.h> // @manual
 #include "comms/utils/test_utils/CudaGraphTestUtils.h"
 #endif
 class CtranGpeTest : public ::testing::Test {

--- a/comms/ctran/hints/Hints.cc
+++ b/comms/ctran/hints/Hints.cc
@@ -2,9 +2,9 @@
 
 #include "comms/ctran/hints/Hints.h"
 
-#include "comms/ctran/algos/AllToAll/AllToAllPHintUtils.h"
+#include "comms/ctran/algos/AllToAll/AllToAllPHintUtils.h" // @manual=//comms/ctran:all_to_allp_hint_utils
 #include "comms/ctran/utils/Checks.h"
-#include "comms/ctran/window/WinHintUtils.h"
+#include "comms/ctran/window/WinHintUtils.h" // @manual=//comms/ctran:win_hint_utils
 #include "comms/utils/commSpecs.h"
 
 namespace meta::comms {

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -11,7 +11,7 @@
 #else
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDm.h"
 #endif
-#include "comms/ctran/mapper/CtranMapperTypes.h"
+#include "comms/ctran/mapper/CtranMapperTypes.h" // @manual=//comms/ctran:mapper_types
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/ctran/utils/ExtUtils.h"

--- a/comms/ctran/regcache/RegCache.h
+++ b/comms/ctran/regcache/RegCache.h
@@ -11,7 +11,7 @@
 #include <unordered_map>
 
 #include "comms/ctran/backends/ib/CtranIbSingleton.h"
-#include "comms/ctran/mapper/CtranMapperTypes.h"
+#include "comms/ctran/mapper/CtranMapperTypes.h" // @manual=//comms/ctran:mapper_types
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/CtranAvlTree.h"
 #include "comms/ctran/utils/CtranIpc.h"

--- a/comms/ctran/utils/CudaWrap.h
+++ b/comms/ctran/utils/CudaWrap.h
@@ -8,7 +8,7 @@
 #include "comms/utils/logger/LogUtils.h"
 
 #if CUDART_VERSION >= 11030
-#include <cudaTypedefs.h>
+#include <cudaTypedefs.h> // @manual
 
 #endif
 


### PR DESCRIPTION
Summary:

Autodeps1 is deprecated and will be deleted in August 2026 (see https://fb.workplace.com/groups/autodeps.users/permalink/3412393688929106/). This is a one-time automated migration to Autodeps2 C++ dependency resolution.

---
🛡️ code-knight prevention: reviewed `cpp_member_fn_const` in *11 files* — no changes applied

#buildmore #buildsonlynotests

Differential Revision: D113492185


