### PR TITLE
shared in-kernel emit primitives

### DIFF
--- a/comms/utils/colltrace/CollTraceHandle.h
+++ b/comms/utils/colltrace/CollTraceHandle.h
@@ -9,6 +9,7 @@
 #include <folly/dynamic.h>
 
 #include "comms/utils/colltrace/CollTraceEvent.h"
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
 #include "comms/utils/commSpecs.h"
 
 namespace meta::comms::colltrace {
@@ -36,6 +37,23 @@ class ICollTraceHandle {
       folly::dynamic params) noexcept = 0;
   virtual CommsMaybe<std::shared_ptr<ICollRecord>> getCollRecord() noexcept = 0;
   virtual CommsMaybeVoid invalidate() noexcept = 0;
+
+  // In-kernel colltrace: expose the graph ring device handle + collId so the
+  // GPE can point the collective kernel at where to write its own start/end
+  // timestamps, instead of the host-launched timestamp kernels. Returns a
+  // non-capable handle for cases that don't support it (eager, dummy); only the
+  // graph handle overrides this.
+  virtual ColltraceDeviceHandle getColltraceDeviceHandle() noexcept {
+    return {};
+  }
+
+  // Mark that this collective's kernel is armed to publish its own start/end
+  // timestamps from inside the kernel, so the host-launched timestamp path is
+  // skipped (they must never both write the ring). No-op except on the graph
+  // handle. Called by the GPE / baseline arming code during submit, before the
+  // launch triggers beforeCollKernelScheduled(). TEMPORARY: removed together
+  // with the host-launched path at the in-kernel cutover.
+  virtual void markInKernelEmit() noexcept {}
 };
 
 // Handle to be returned to the user for triggering stages for the collective.

--- a/comms/utils/colltrace/ColltraceDeviceEventScope.cuh
+++ b/comms/utils/colltrace/ColltraceDeviceEventScope.cuh
@@ -1,0 +1,98 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
+
+// In-kernel colltrace timestamp emission: a collective kernel publishes its own
+// start/end timestamps into the graph colltrace ring, replacing the host-
+// launched <<<1,1>>> timestamp kernels on the CUDA-graph path. This header is
+// backend-agnostic (it depends only on the shared ColltraceDeviceHandle), so it
+// is used by both the ctran GPE kernels and the baseline ncclx kernels; the
+// ctran-specific KernelFlagDev convenience overload lives in ctran's own
+// ColltraceDeviceEventScope.cuh which wraps this.
+
+namespace meta::comms::colltrace {
+
+// Publish a colltrace start/end timestamp for this logical collective from
+// inside the kernel. Single-writer election: the elected writer is the one
+// thread in block 0 with threadIdx.y == threadIdx.z == 0 and threadIdx.x equal
+// to writerThreadIdxX, so a 2D/3D launch still elects exactly one writer and
+// never duplicates an event. writerThreadIdxX defaults to 0 (thread 0); a
+// caller may elect a different lane (e.g. thread 1) so this emit runs in
+// parallel with other thread-0 work such as the GPE-ring kick. If the requested
+// lane does not exist in this launch (writerThreadIdxX >= blockDim.x, e.g. a
+// single-thread kernel), it falls back to thread 0 so the event is still
+// emitted exactly once and never dropped. No-op on an unarmed handle (valid()
+// == false). The timestamp reflects when the elected writer crosses this scope
+// boundary, not a grid-wide barrier. The ring write is the HRDWRingBuffer
+// System-scope 128b atomic path, which requires sm_90+; the host therefore only
+// arms this when the device supports it, falling back to the host-launched
+// writer otherwise.
+static __forceinline__ __device__ void ColltraceEmitEvent(
+    ColltraceDeviceHandle hdr,
+    GraphCollTracePhase phase,
+    unsigned int writerThreadIdxX = 0) {
+  const unsigned int electedThreadIdxX =
+      (writerThreadIdxX < blockDim.x) ? writerThreadIdxX : 0u;
+  if (blockIdx.x == 0 && blockIdx.y == 0 && blockIdx.z == 0 &&
+      threadIdx.x == electedThreadIdxX && threadIdx.y == 0 &&
+      threadIdx.z == 0 && hdr.valid()) {
+    hdr.ring.write(GraphCollTraceEvent{hdr.collId, phase});
+  }
+}
+
+// One RAII colltrace timing scope for a collective kernel: emits the start
+// timestamp on construction when the armed handle enables start, and the end
+// timestamp on destruction when it enables end. The host arms the emitStart/
+// emitEnd flags per the kernel's role, so a single uniform line covers all
+// shapes: a single-kernel collective arms both; a multi-kernel one arms start
+// on its first kernel and end on its last; interior kernels arm neither.
+//
+// Threading: the start (ctor) and end (dtor) emits are each recorded by a
+// single elected writer in block 0 -- by default thread 0 for both, but the
+// start and end lanes are independently configurable via startWriterThreadIdxX
+// / endWriterThreadIdxX (see ColltraceEmitEvent). Every other block/thread
+// constructs the scope but its emits are no-ops. So it is safe (and required,
+// for a correct start boundary) to place at the very top of any kernel, before
+// any per-thread work. Both emits are also valid()-gated, so an unarmed handle
+// makes the whole scope a no-op.
+//
+// NOTE: the end lane must be a thread that stays alive until kernel exit. In
+// ctran GPE kernels only thread 0 waits for collective completion; every other
+// thread exits early, so endWriterThreadIdxX must stay 0 there or kEnd would
+// record a too-early timestamp.
+struct ColltraceDeviceEventScope {
+  ColltraceDeviceHandle hdr;
+  unsigned int startWriterThreadIdxX;
+  unsigned int endWriterThreadIdxX;
+
+  __forceinline__ __device__ explicit ColltraceDeviceEventScope(
+      ColltraceDeviceHandle handle,
+      unsigned int startWriterThreadIdxX = 0,
+      unsigned int endWriterThreadIdxX = 0)
+      : hdr(handle),
+        startWriterThreadIdxX(startWriterThreadIdxX),
+        endWriterThreadIdxX(endWriterThreadIdxX) {
+    if (hdr.emitStart) {
+      ColltraceEmitEvent(
+          hdr, GraphCollTracePhase::kStart, startWriterThreadIdxX);
+    }
+  }
+
+  __forceinline__ __device__ ~ColltraceDeviceEventScope() {
+    if (hdr.emitEnd) {
+      ColltraceEmitEvent(hdr, GraphCollTracePhase::kEnd, endWriterThreadIdxX);
+    }
+  }
+
+  // Non-copyable and non-movable: the scope's lifetime must match the enclosing
+  // kernel body so kEnd fires exactly once at kernel exit.
+  ColltraceDeviceEventScope(const ColltraceDeviceEventScope&) = delete;
+  ColltraceDeviceEventScope& operator=(const ColltraceDeviceEventScope&) =
+      delete;
+  ColltraceDeviceEventScope(ColltraceDeviceEventScope&&) = delete;
+  ColltraceDeviceEventScope& operator=(ColltraceDeviceEventScope&&) = delete;
+};
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/ColltraceDeviceHandle.h
+++ b/comms/utils/colltrace/ColltraceDeviceHandle.h
@@ -1,0 +1,76 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include "comms/utils/colltrace/GraphCollTraceEvent.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+
+namespace meta::comms::colltrace {
+
+// The device-side handle colltrace hands to a collective kernel so it can
+// publish its own start/end timestamps into the graph ring from inside the
+// kernel, replacing the host-launched timestamp kernels on the graph path.
+struct ColltraceDeviceHandle {
+  // NOTE: these scalar fields are intentionally placed BEFORE the embedded
+  // HRDWRingBufferDeviceHandle. That handle uses [[no_unique_address]] empty
+  // members in its Overwrite specialization; when it is the first member, nvcc
+  // computes a different offset for a following field on the device than on the
+  // host -- it places the field past the end of the object (observed: host
+  // offsetof(collId) == 24 but the device reads it at 32, with sizeof == 24 on
+  // both), so the kernel reads collId/emit flags back as 0. Keeping the scalars
+  // in the head bytes keeps the host and device offsets in agreement.
+  // No default member initializers: this keeps the handle trivially
+  // default-constructible so it can be embedded in ncclx's ncclDevKernelArgs,
+  // which is copied into __shared__ ncclShmem (dynamic init is illegal for
+  // __shared__ variables). Producers value-initialize (`{}`, which zeroes every
+  // member -> valid()==false) or assign an armed handle; there are no bare
+  // default-constructed-then-used handles.
+  uint32_t collId;
+  // Which boundaries this kernel emits, set host-side per the kernel's role in
+  // the collective: a single-kernel collective emits both; a multi-kernel one
+  // emits start on its first kernel and end on its last; interior kernels emit
+  // neither. Read by ColltraceEventScope (ctor→start, dtor→end).
+  bool emitStart;
+  bool emitEnd;
+  ::hrdw_ring_buffer::HRDWRingBufferDeviceHandle<GraphCollTraceEvent> ring;
+
+  // Usable only when a ring is attached (the graph in-kernel path). A default
+  // (null-ring) handle means "not armed": host callers keep the host-launched
+  // timestamps, and the in-kernel emit is a no-op. Callable from device code
+  // since the collective kernel gates its ring write on it.
+#if defined(__CUDACC__) || defined(__HIPCC__)
+  __host__ __device__
+#endif
+      bool valid() const {
+    return ring.ring != nullptr;
+  }
+};
+
+// Pin the scalar-before-ring layout the note above depends on. The host/device
+// offsetof agreement (and thus in-kernel emit working at all) requires collId
+// and the emit flags to stay ahead of the embedded ring handle; a future
+// reorder that moves a scalar past `ring` would silently make the kernel read
+// collId/emit flags back as 0. Fail the build instead of shipping that.
+static_assert(
+    offsetof(ColltraceDeviceHandle, collId) <
+            offsetof(ColltraceDeviceHandle, emitStart) &&
+        offsetof(ColltraceDeviceHandle, emitStart) <
+            offsetof(ColltraceDeviceHandle, emitEnd) &&
+        offsetof(ColltraceDeviceHandle, emitEnd) <
+            offsetof(ColltraceDeviceHandle, ring),
+    "ColltraceDeviceHandle scalars (collId/emitStart/emitEnd) must precede the "
+    "embedded ring handle; see the layout note on the struct.");
+
+// Must stay trivially default-constructible so it can be embedded in ncclx's
+// ncclDevKernelArgs, which lands in __shared__ memory (no dynamic init
+// allowed).
+static_assert(
+    std::is_trivially_default_constructible_v<ColltraceDeviceHandle>,
+    "ColltraceDeviceHandle must be trivially default-constructible (no default "
+    "member initializers) so it can live in __shared__ ncclShmem.");
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/GraphCollTraceHandle.h
+++ b/comms/utils/colltrace/GraphCollTraceHandle.h
@@ -2,9 +2,12 @@
 
 #pragma once
 
+#include <cassert>
+
 #include "comms/utils/colltrace/CollRecord.h"
 #include "comms/utils/colltrace/CollTraceHandle.h"
 #include "comms/utils/colltrace/CollWaitEvent.h"
+#include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/commSpecs.h"
 
 namespace meta::comms::colltrace {
@@ -56,7 +59,59 @@ class GraphCollTraceHandle : public ICollTraceHandle {
     return folly::Unit{};
   }
 
+  ColltraceDeviceHandle getColltraceDeviceHandle() noexcept override {
+    // Killswitch: when NCCLX_COLLTRACE_DEVICE_WRITE is off, hand out no device
+    // ring handle, so neither the ctran nor the baseline arming path arms the
+    // kernel (both gate on valid()). This is the single gate for the in-kernel
+    // device-write across all backends.
+    if (!colltraceDeviceWriteEnabled()) {
+      return {};
+    }
+    auto* graphWaitEvent = graphWaitEvent_();
+    if (graphWaitEvent == nullptr || !graphWaitEvent->hasRingBuffer()) {
+      return {};
+    }
+    // emitStart/emitEnd are set by the arming code (armInKernelColltrace /
+    // armBaselineInKernelColltrace) per the kernel's role; initialize them
+    // explicitly here since ColltraceDeviceHandle has no default member
+    // initializers (for __shared__ compatibility).
+    return {
+        .collId = graphWaitEvent->getCollId(),
+        .emitStart = false,
+        .emitEnd = false,
+        .ring = graphWaitEvent->deviceHandle()};
+  }
+
+  // TEMPORARY (removed at the in-kernel cutover): forward the "kernel
+  // self-emits" signal to the wait event so it skips the host-launched
+  // timestamp path.
+  void markInKernelEmit() noexcept override {
+    // Gate identically to getColltraceDeviceHandle(): only mark the wait event
+    // as self-emitting when the killswitch is on and a ring is attached, so we
+    // never skip the host-launched fallback for a kernel that isn't actually
+    // armed to self-emit.
+    if (!colltraceDeviceWriteEnabled()) {
+      return;
+    }
+    auto* graphWaitEvent = graphWaitEvent_();
+    if (graphWaitEvent == nullptr || !graphWaitEvent->hasRingBuffer()) {
+      return;
+    }
+    graphWaitEvent->markInKernelEmit();
+  }
+
  private:
+  // waitEvent_ is always a GraphCudaWaitEvent for this handle (constructed by
+  // CollTrace::recordGraphCollectiveImpl), or null after invalidate(). This is
+  // on the submit hot path, so static_cast avoids RTTI; the debug-only assert
+  // catches any future violation of that invariant.
+  GraphCudaWaitEvent* graphWaitEvent_() const {
+    assert(
+        waitEvent_ == nullptr ||
+        dynamic_cast<GraphCudaWaitEvent*>(waitEvent_) != nullptr);
+    return static_cast<GraphCudaWaitEvent*>(waitEvent_);
+  }
+
   ICollWaitEvent* waitEvent_;
   std::shared_ptr<ICollRecord> record_;
 };

--- a/comms/utils/colltrace/GraphCudaWaitEvent.cc
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.cc
@@ -12,14 +12,21 @@
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/PrecisionClock.h"
 #include "comms/utils/checks.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
 namespace meta::comms::colltrace {
 
+bool colltraceDeviceWriteEnabled() noexcept {
+  return NCCLX_COLLTRACE_DEVICE_WRITE;
+}
+
 GraphCudaWaitEvent::GraphCudaWaitEvent(cudaStream_t stream, uint32_t collId)
     : stream_(stream), collId_(collId), enqueueTime_(precisionNow()) {
-  // Create per-collective CUDA resources using relaxed capture mode so
-  // they don't interfere with the graph capture in progress.
+  // Per-collective CUDA resources for the host-launched timestamp fallback,
+  // created in relaxed capture mode so they don't disturb the in-progress graph
+  // capture. TEMPORARY: removed together with the host path at the in-kernel
+  // cutover.
   StreamCaptureModeGuard guard{cudaStreamCaptureModeRelaxed};
   CUDA_CHECK(cudaStreamCreate(&timestampStream_));
   CUDA_CHECK(cudaEventCreateWithFlags(&depEvent_, cudaEventDisableTiming));
@@ -47,10 +54,15 @@ void GraphCudaWaitEvent::attachRingBuffer(
 }
 
 CommsMaybeVoid GraphCudaWaitEvent::beforeCollKernelScheduled() noexcept {
-  // Fork: collective stream -> timestamp stream so the start kernel is
-  // captured into the graph. We use cudaStreamWaitEvent to bring the
-  // timestamp stream into the capture with a dependency on the main
-  // stream's current position (right before the collective launches).
+  if (inKernelEmit_) {
+    // The collective kernel publishes its own start timestamp into the ring
+    // from inside the kernel, so there is nothing to schedule on the host.
+    return folly::unit;
+  }
+  // Host-launched fallback (kernel not armed to self-emit, e.g. pre-sm90 or a
+  // not-yet-migrated collective). Fork: collective stream -> timestamp stream
+  // so the start kernel is captured into the graph, with a dependency on the
+  // main stream's current position (right before the collective launches).
   CUDA_CHECK_EXPECTED(cudaEventRecord(depEvent_, stream_));
   CUDA_CHECK_EXPECTED(cudaStreamWaitEvent(timestampStream_, depEvent_));
 
@@ -63,8 +75,14 @@ CommsMaybeVoid GraphCudaWaitEvent::beforeCollKernelScheduled() noexcept {
 }
 
 CommsMaybeVoid GraphCudaWaitEvent::afterCollKernelScheduled() noexcept {
-  // Fork: collective stream -> timestamp stream. This DAG edge ensures the
-  // end timestamp kernel fires only after the collective completes.
+  if (inKernelEmit_) {
+    // The collective kernel publishes its own end timestamp into the ring from
+    // inside the kernel, so there is nothing to schedule on the host.
+    return folly::unit;
+  }
+  // Host-launched fallback. Fork: collective stream -> timestamp stream. This
+  // DAG edge ensures the end timestamp kernel fires only after the collective
+  // completes.
   CUDA_CHECK_EXPECTED(cudaEventRecord(depEvent_, stream_));
   CUDA_CHECK_EXPECTED(cudaStreamWaitEvent(timestampStream_, depEvent_));
 

--- a/comms/utils/colltrace/GraphCudaWaitEvent.h
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.h
@@ -16,14 +16,21 @@ namespace meta::comms::colltrace {
 inline constexpr uint32_t kDefaultRingSize =
     65536; // NOLINT(misc-unused-using-decls)
 
+// Reads the NCCLX_COLLTRACE_DEVICE_WRITE cvar (off by default until the
+// in-kernel cutover diff lands): whether collective kernels should publish
+// their own timestamps into the graph ring (in-kernel "device write"). Defined
+// out-of-line so this header (and the exported GraphCollTraceHandle.h that
+// gates on it) doesn't pull in nccl_cvars.h.
+bool colltraceDeviceWriteEnabled() noexcept;
+
 // Graph-aware wait event that uses device-side globaltimer reads and a
 // shared ring buffer for precise per-replay timing. All collectives across
 // ALL CUDA graphs share a single ring buffer (owned by CollTrace) and
 // atomically claim slots via a shared write index.
 //
-// Each GraphCudaWaitEvent owns its own timestamp stream and dependency event.
-// Per-collective streams ensure that concurrent collectives (e.g.,
-// signal/wait RMA ops) don't serialize their timestamp kernels.
+// The collective kernel publishes its own start/end timestamps into the ring
+// from inside the kernel (see ColltraceEventScope + the GPE arming path); this
+// class holds the shared ring handle and per-collective identity used for that.
 //
 // No back-pressure — if the poll thread falls behind by more than ringSize
 // replays across all collectives, data loss is detected and logged.
@@ -69,16 +76,45 @@ class GraphCudaWaitEvent : public ICollWaitEvent {
     collId_ = collId;
   }
 
+  bool hasRingBuffer() const noexcept {
+    return ringBuffer_ != nullptr;
+  }
+
+  // Mark that this collective's kernel is armed to publish its own start/end
+  // timestamps from inside the kernel, so the host-launched timestamp path is
+  // skipped. Called by the GPE / baseline arming code during submit, before the
+  // launch triggers beforeCollKernelScheduled(). TEMPORARY: removed together
+  // with the host-launched path at the in-kernel cutover.
+  void markInKernelEmit() noexcept {
+    inKernelEmit_ = true;
+  }
+
+  // Device-side write handle for the shared ring, handed to a collective kernel
+  // so it can publish its own start/end timestamps from inside the kernel.
+  // Returns a default (null-ring, invalid) handle if no ring is attached, so
+  // callers that skip the hasRingBuffer() gate can't null-deref.
+  ::hrdw_ring_buffer::HRDWRingBufferDeviceHandle<GraphCollTraceEvent>
+  deviceHandle() const noexcept {
+    if (ringBuffer_ == nullptr) {
+      return {};
+    }
+    return ringBuffer_->deviceHandle();
+  }
+
  private:
   cudaStream_t stream_;
   uint32_t collId_;
   system_clock_time_point enqueueTime_;
 
-  // per-collective timestamp stream — runs in parallel with the collective
-  // stream. each collective gets its own stream so concurrent collectives
-  // (e.g., signal/wait) don't serialize their timestamp kernels.
+  // Set by markInKernelEmit() when the collective kernel is armed to self-emit;
+  // when true the host-launched timestamp path is skipped so the two never
+  // double-write the ring. TEMPORARY: removed at the in-kernel cutover.
+  bool inKernelEmit_{false};
+
+  // Per-collective timestamp stream + dependency event for the host-launched
+  // fork/join timestamp path, used until the kernel self-emits (pre-sm90, or a
+  // not-yet-migrated collective). TEMPORARY: removed at the in-kernel cutover.
   cudaStream_t timestampStream_{nullptr};
-  // per-collective dependency event for fork/join edges.
   cudaEvent_t depEvent_{nullptr};
 
   // owned by CollTrace, shared across ALL graphs. set via attachRingBuffer().

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2472,6 +2472,16 @@ cvars:
      still haven't fully tested the performance impact of this feature. So
      it is disabled by default. In the future, we will enable it by default.
 
+ - name        : NCCLX_COLLTRACE_DEVICE_WRITE
+   type        : bool
+   default     : false
+   description : |-
+     When graph colltrace tracing is enabled (NCCL_COLLTRACE_TRACE_CUDA_GRAPH),
+     have collective kernels publish their own start/end timestamps into the
+     graph ring from inside the kernel (in-kernel "device write"). Off by
+     default until the in-kernel cutover diff lands; set true to hand collective
+     kernels the device ring handle and enable in-kernel emission.
+
  - name        : NCCL_COLLTRACE_CTRAN_USE_CPU_RECORD
    type        : bool
    default     : true


### PR DESCRIPTION
Summary:
Factor out the backend-agnostic pieces of the in-kernel colltrace graph-timestamp
path so both ctran GPE kernels and baseline NCCL kernels can share them:

- `ColltraceDeviceHandle` (ring handle + `collId` + emitStart/emitEnd flags): the
  device-side handle a collective kernel reads to publish its own start/end
  timestamps into the graph colltrace HRDW ring. Trivially default-constructible
  so it can be embedded in kernel-arg aggregates (including `__shared__` memory).
- `ColltraceEventScope` (`comms/utils/colltrace/ColltraceEventScope.cuh`): the
  generic RAII writer, single-writer-elected to block0/thread0 and a no-op unless
  armed.
- Graph wait-event plumbing: `GraphCudaWaitEvent` holds the shared ring handle and
  exposes it via `getColltraceDeviceHandle()`. Armed collectives publish their own
  timestamps from the kernel; un-armed collectives keep the existing host-launched
  timestamp fallback (removed at the cutover, D113718490).

No behavior change on its own -- the ctran and baseline integrations stack on top.

Reviewed By: minsii

Differential Revision: D113717550


