### PR TITLE
Order DirectIB reduce-scatter launches across streams (#3367)

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -25,6 +25,7 @@
 #include "comms/ctran/utils/CommGroupUtils.h"
 
 #if defined(ENABLE_PRIMS)
+#include "comms/ctran/algos/common/OrderedWorkStreamGuard.h"
 #include "comms/prims/trace/PipesTrace.h"
 #include "comms/prims/transport/MultiPeerDeviceHandle.cuh"
 #include "comms/prims/transport/MultiPeerTransport.h"
@@ -238,6 +239,7 @@ void CtranComm::destroy() {
   // ensure they do so in a specific order. Therefore, we manually handle
   // their de-initialization here.
 #if defined(ENABLE_PRIMS)
+  primsOrderedWorkStreamGuard_.reset();
   pipesTrace_.reset();
   // Must be destroyed before ctran_ (which owns SharedResource staging
   // buffers used as external data buffers) and before bootstrap_ (since

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -79,7 +79,10 @@ class MultiPeerTransport;
 }
 namespace ctran {
 struct CtranWin;
+namespace algos {
+class OrderedWorkStreamGuard;
 }
+} // namespace ctran
 
 using comms::fault_tolerance::Abort;
 using ctran::utils::AsyncError;
@@ -258,6 +261,8 @@ class CtranComm {
 #if defined(ENABLE_PRIMS)
   std::unique_ptr<comms::prims::MultiPeerTransport> multiPeerTransport_;
   std::unique_ptr<comms::prims::PipesTrace> pipesTrace_;
+  std::unique_ptr<ctran::algos::OrderedWorkStreamGuard>
+      primsOrderedWorkStreamGuard_;
 #endif // defined(ENABLE_PRIMS)
 
   // Deferred cleanup for CUDA graph resources. CUDA user-object destructor

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -10,6 +10,7 @@
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/algos/common/OrderedWorkStreamGuard.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -385,6 +386,11 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
             comm->statex_->cudaDev(),
             bootstrapPtr,
             config);
+    auto primsOrderedWorkStreamGuard =
+        std::make_unique<ctran::algos::OrderedWorkStreamGuard>();
+    primsOrderedWorkStreamGuard->init(
+        comm->logMetaData_, false /* synchronizeEagerAfterCapturedWork */);
+    comm->primsOrderedWorkStreamGuard_ = std::move(primsOrderedWorkStreamGuard);
     CLOGF(
         INFO,
         "Prims MultiPeerTransport initialized: nvlPeers={}, ibPeers={}, p2pDisable={}",

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterDirectIb.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterDirectIb.cc
@@ -13,6 +13,8 @@
 #include "comms/ctran/algos/CollUtils.h"
 #include "comms/ctran/algos/ReduceScatter/ReduceScatterDirectIbConfig.h"
 #include "comms/ctran/algos/ReduceScatter/ReduceScatterImpl.h"
+#include "comms/ctran/algos/common/OrderedWorkStreamGuard.h"
+#include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/prims/collectives/ReduceScatterDirectIbLauncher.h"
 #include "comms/prims/transport/MultiPeerTransport.h"
 #include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
@@ -149,6 +151,13 @@ commResult_t validateDirectIbReduceScatter(
         "ReduceScatter {} requires MultiPeerTransport (NCCL_CTRAN_USE_PIPES=1)",
         reduceScatterAlgoName(myAlgo));
     return commInvalidArgument;
+  }
+  if (!comm->primsOrderedWorkStreamGuard_) {
+    CLOGF(
+        ERR,
+        "ReduceScatter {} requires the PRIMS ordered work stream guard",
+        reduceScatterAlgoName(myAlgo));
+    return commInternalError;
   }
 
   size_t recvBytes = 0;
@@ -304,14 +313,42 @@ static commResult_t ctranReduceScatterDirectIbImpl(
 
     comm->recordAlgoStats(
         "ReduceScatter", reduceScatterAlgoName(myAlgo), recvBytes);
-    comms::prims::launch_direct_reduce_scatter_ib(params);
-    FB_CUDACHECK(cudaGetLastError());
+
+    ctran::utils::cudagraph::StreamCaptureInfo captureInfo;
+    FB_CUDACHECK(
+        ctran::utils::cudagraph::getStreamCaptureInfo(stream, captureInfo));
+    auto orderedScope =
+        comm->primsOrderedWorkStreamGuard_->acquire(stream, captureInfo);
+    FB_COMMCHECK(orderedScope.status());
+
+    try {
+      comms::prims::launch_direct_reduce_scatter_ib(params);
+    } catch (...) {
+      const auto releaseResult = orderedScope.release();
+      if (releaseResult != commSuccess) {
+        CLOGF(
+            ERR,
+            "ReduceScatter {} ordering release also failed: {}",
+            reduceScatterAlgoName(myAlgo),
+            releaseResult);
+      }
+      throw;
+    }
+    const auto launchError = cudaGetLastError();
+    FB_COMMCHECK(orderedScope.release());
+    FB_CUDACHECK(launchError);
   } catch (const std::exception& e) {
     CLOGF(
         ERR,
         "ReduceScatter {} failed: {}",
         reduceScatterAlgoName(myAlgo),
         e.what());
+    return commInternalError;
+  } catch (...) {
+    CLOGF(
+        ERR,
+        "ReduceScatter {} failed with an unknown exception",
+        reduceScatterAlgoName(myAlgo));
     return commInternalError;
   }
 

--- a/comms/ctran/algos/common/OrderedWorkStreamGuard.cc
+++ b/comms/ctran/algos/common/OrderedWorkStreamGuard.cc
@@ -23,18 +23,17 @@ void OrderedWorkStreamGuard::init(
       logMetaData);
 
   // Publish the initialized state only after every resource is ready.
-  logMetaData_ = &logMetaData;
   synchronizeEagerAfterCapturedWork_ = synchronizeEagerAfterCapturedWork;
   execModeSyncEvent_ = execModeSyncEvent;
   sideStream_ = std::move(sideStream);
   initialized_ = true;
 }
 
-OrderedWorkStreamGuard::~OrderedWorkStreamGuard() {
+OrderedWorkStreamGuard::~OrderedWorkStreamGuard() noexcept {
   if (!initialized_) {
     return;
   }
-  FB_CUDACHECKTHROW_EX(cudaEventDestroy(execModeSyncEvent_), *logMetaData_);
+  FB_CUDACHECKIGNORE(cudaEventDestroy(execModeSyncEvent_));
 }
 
 OrderedWorkStreamGuard::Scope::Scope(

--- a/comms/ctran/algos/common/OrderedWorkStreamGuard.h
+++ b/comms/ctran/algos/common/OrderedWorkStreamGuard.h
@@ -17,7 +17,7 @@ namespace ctran::algos {
 
 class OrderedWorkStreamGuard {
  public:
-  ~OrderedWorkStreamGuard();
+  ~OrderedWorkStreamGuard() noexcept;
 
   // Captured graphs that reference this guard must be destroyed first.
   void init(
@@ -75,7 +75,6 @@ class OrderedWorkStreamGuard {
   cudaStream_t lastUserStream_{nullptr};
   cudaGraphNode_t lastRecordNode_{};
   std::unique_ptr<meta::comms::GraphSideStream> sideStream_;
-  const CommLogData* logMetaData_{nullptr};
 };
 
 } // namespace ctran::algos

--- a/comms/ctran/algos/common/tests/OrderedWorkStreamGuardTest.cc
+++ b/comms/ctran/algos/common/tests/OrderedWorkStreamGuardTest.cc
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include <thread>
+#include <type_traits>
 
 #include <gtest/gtest.h>
 
@@ -16,6 +17,8 @@ namespace {
 
 using ctran::algos::OrderedWorkStreamGuard;
 using ctran::utils::cudagraph::StreamCaptureInfo;
+
+static_assert(std::is_nothrow_destructible_v<OrderedWorkStreamGuard>);
 
 void delayCallback(void* data) {
   const auto delay = *static_cast<const std::chrono::milliseconds*>(data);

--- a/comms/ncclx/meta/collectives/tests/ReduceScatterQuantizeDirectIbTest.cc
+++ b/comms/ncclx/meta/collectives/tests/ReduceScatterQuantizeDirectIbTest.cc
@@ -21,8 +21,10 @@ class ReduceScatterQuantizeDirectIbTest : public NcclxBaseTestFixture {
         {"NCCL_CTRAN_ENABLE", "1"},
         {"NCCL_CTRAN_USE_PIPES", "1"},
         {"NCCL_COMM_STATE_DEBUG_TOPO", "nolocal"},
+        {"MCCL_CHANNEL_BUFFER_SIZE", "4194304"},
         {"NCCL_MNNVL_ENABLE", "0"},
         {"NCCL_P2P_DISABLE", "1"},
+        {"NCCL_REDUCESCATTER_ALGO", "ctdirect_ib"},
         {"NCCL_REDUCESCATTER_QUANTIZED_ALGO", "ctdirect_ib"},
     });
     algoStats_.enable();
@@ -90,6 +92,214 @@ class ReduceScatterQuantizeDirectIbTest : public NcclxBaseTestFixture {
     CUDACHECK_TEST(cudaFree(seed));
   }
 
+  void runOnTwoStreams(bool quantized) {
+    constexpr std::size_t kCount = 1 << 20;
+    constexpr int kIterations = 4;
+    const std::size_t sendCount = kCount * static_cast<std::size_t>(numRanks);
+
+    cudaStream_t streams[2]{};
+    float* send[2]{};
+    float* recv[2][kIterations]{};
+    std::uint64_t* seed[2]{};
+    std::vector<float> output(kCount);
+    float expected[2]{};
+
+    for (int lane = 0; lane < 2; ++lane) {
+      CUDACHECK_TEST(
+          cudaStreamCreateWithFlags(&streams[lane], cudaStreamNonBlocking));
+      CUDACHECK_TEST(cudaMalloc(&send[lane], sendCount * sizeof(float)));
+      CUDACHECK_TEST(cudaMalloc(&seed[lane], sizeof(*seed[lane])));
+      for (int iteration = 0; iteration < kIterations; ++iteration) {
+        CUDACHECK_TEST(
+            cudaMalloc(&recv[lane][iteration], kCount * sizeof(float)));
+      }
+
+      const float rankValue = static_cast<float>((lane + 1) * 16 + globalRank);
+      std::vector<float> input(sendCount, rankValue);
+      CUDACHECK_TEST(cudaMemcpy(
+          send[lane],
+          input.data(),
+          sendCount * sizeof(float),
+          cudaMemcpyHostToDevice));
+      const std::uint64_t hostSeed =
+          0x123456789abcdef0ULL + static_cast<std::uint64_t>(lane);
+      CUDACHECK_TEST(cudaMemcpy(
+          seed[lane], &hostSeed, sizeof(hostSeed), cudaMemcpyHostToDevice));
+      expected[lane] = static_cast<float>(
+          numRanks * (lane + 1) * 16 + numRanks * (numRanks - 1) / 2);
+    }
+
+    for (int iteration = 0; iteration < kIterations; ++iteration) {
+      for (int lane = 0; lane < 2; ++lane) {
+        const ncclResult_t result = quantized ? ncclReduceScatterQuantize(
+                                                    send[lane],
+                                                    recv[lane][iteration],
+                                                    kCount,
+                                                    ncclFloat32,
+                                                    ncclBfloat16,
+                                                    ncclSum,
+                                                    seed[lane],
+                                                    comm_->get(),
+                                                    streams[lane])
+                                              : ncclReduceScatter(
+                                                    send[lane],
+                                                    recv[lane][iteration],
+                                                    kCount,
+                                                    ncclFloat32,
+                                                    ncclSum,
+                                                    comm_->get(),
+                                                    streams[lane]);
+        ASSERT_EQ(result, ncclSuccess);
+      }
+    }
+
+    for (int lane = 0; lane < 2; ++lane) {
+      CUDACHECK_TEST(cudaStreamSynchronize(streams[lane]));
+      for (int iteration = 0; iteration < kIterations; ++iteration) {
+        CUDACHECK_TEST(cudaMemcpy(
+            output.data(),
+            recv[lane][iteration],
+            kCount * sizeof(float),
+            cudaMemcpyDeviceToHost));
+        for (float value : output) {
+          EXPECT_EQ(value, expected[lane]);
+        }
+        CUDACHECK_TEST(cudaFree(recv[lane][iteration]));
+      }
+      CUDACHECK_TEST(cudaFree(send[lane]));
+      CUDACHECK_TEST(cudaFree(seed[lane]));
+      CUDACHECK_TEST(cudaStreamDestroy(streams[lane]));
+    }
+  }
+
+  void runCapturedOnTwoStreams() {
+    constexpr std::size_t kCount = 1 << 20;
+    const std::size_t sendCount = kCount * static_cast<std::size_t>(numRanks);
+
+    cudaStream_t primary{};
+    cudaStream_t streams[2]{};
+    cudaEvent_t forkEvent{};
+    cudaEvent_t joinEvents[2]{};
+    cudaGraph_t graph{};
+    cudaGraphExec_t graphExec{};
+    float* send[2]{};
+    float* recv[3]{};
+    std::uint64_t* seed[2]{};
+    float expected[2]{};
+
+    CUDACHECK_TEST(cudaStreamCreateWithFlags(&primary, cudaStreamNonBlocking));
+    CUDACHECK_TEST(
+        cudaEventCreateWithFlags(&forkEvent, cudaEventDisableTiming));
+    for (int lane = 0; lane < 2; ++lane) {
+      CUDACHECK_TEST(
+          cudaStreamCreateWithFlags(&streams[lane], cudaStreamNonBlocking));
+      CUDACHECK_TEST(
+          cudaEventCreateWithFlags(&joinEvents[lane], cudaEventDisableTiming));
+      CUDACHECK_TEST(cudaMalloc(&send[lane], sendCount * sizeof(float)));
+      CUDACHECK_TEST(cudaMalloc(&recv[lane], kCount * sizeof(float)));
+      CUDACHECK_TEST(cudaMalloc(&seed[lane], sizeof(*seed[lane])));
+
+      const float rankValue = static_cast<float>((lane + 1) * 32 + globalRank);
+      std::vector<float> input(sendCount, rankValue);
+      CUDACHECK_TEST(cudaMemcpy(
+          send[lane],
+          input.data(),
+          sendCount * sizeof(float),
+          cudaMemcpyHostToDevice));
+      const std::uint64_t hostSeed =
+          0x23456789abcdef01ULL + static_cast<std::uint64_t>(lane);
+      CUDACHECK_TEST(cudaMemcpy(
+          seed[lane], &hostSeed, sizeof(hostSeed), cudaMemcpyHostToDevice));
+      expected[lane] = static_cast<float>(
+          numRanks * (lane + 1) * 32 + numRanks * (numRanks - 1) / 2);
+
+      ASSERT_EQ(
+          ncclReduceScatterQuantize(
+              send[lane],
+              recv[lane],
+              kCount,
+              ncclFloat32,
+              ncclBfloat16,
+              ncclSum,
+              seed[lane],
+              comm_->get(),
+              streams[lane]),
+          ncclSuccess);
+    }
+    CUDACHECK_TEST(cudaStreamSynchronize(streams[0]));
+    CUDACHECK_TEST(cudaStreamSynchronize(streams[1]));
+    CUDACHECK_TEST(cudaMalloc(&recv[2], kCount * sizeof(float)));
+
+    CUDACHECK_TEST(
+        cudaStreamBeginCapture(primary, cudaStreamCaptureModeRelaxed));
+    CUDACHECK_TEST(cudaEventRecord(forkEvent, primary));
+    for (int lane = 0; lane < 2; ++lane) {
+      CUDACHECK_TEST(cudaStreamWaitEvent(streams[lane], forkEvent, 0));
+      ASSERT_EQ(
+          ncclReduceScatterQuantize(
+              send[lane],
+              recv[lane],
+              kCount,
+              ncclFloat32,
+              ncclBfloat16,
+              ncclSum,
+              seed[lane],
+              comm_->get(),
+              streams[lane]),
+          ncclSuccess);
+      CUDACHECK_TEST(cudaEventRecord(joinEvents[lane], streams[lane]));
+      CUDACHECK_TEST(cudaStreamWaitEvent(primary, joinEvents[lane], 0));
+    }
+    CUDACHECK_TEST(cudaStreamEndCapture(primary, &graph));
+    ASSERT_NE(graph, nullptr);
+    CUDACHECK_TEST(
+        cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+    CUDACHECK_TEST(cudaGraphLaunch(graphExec, primary));
+    CUDACHECK_TEST(cudaGraphLaunch(graphExec, primary));
+
+    ASSERT_EQ(
+        ncclReduceScatterQuantize(
+            send[0],
+            recv[2],
+            kCount,
+            ncclFloat32,
+            ncclBfloat16,
+            ncclSum,
+            seed[0],
+            comm_->get(),
+            streams[0]),
+        ncclSuccess);
+    CUDACHECK_TEST(cudaStreamSynchronize(primary));
+    CUDACHECK_TEST(cudaStreamSynchronize(streams[0]));
+
+    std::vector<float> output(kCount);
+    for (int outputIndex = 0; outputIndex < 3; ++outputIndex) {
+      CUDACHECK_TEST(cudaMemcpy(
+          output.data(),
+          recv[outputIndex],
+          kCount * sizeof(float),
+          cudaMemcpyDeviceToHost));
+      const float expectedValue = expected[outputIndex == 1 ? 1 : 0];
+      for (float value : output) {
+        EXPECT_EQ(value, expectedValue);
+      }
+    }
+
+    CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+    CUDACHECK_TEST(cudaGraphDestroy(graph));
+    CUDACHECK_TEST(cudaEventDestroy(forkEvent));
+    CUDACHECK_TEST(cudaStreamDestroy(primary));
+    for (int lane = 0; lane < 2; ++lane) {
+      CUDACHECK_TEST(cudaEventDestroy(joinEvents[lane]));
+      CUDACHECK_TEST(cudaStreamDestroy(streams[lane]));
+      CUDACHECK_TEST(cudaFree(send[lane]));
+      CUDACHECK_TEST(cudaFree(seed[lane]));
+    }
+    for (float* outputBuffer : recv) {
+      CUDACHECK_TEST(cudaFree(outputBuffer));
+    }
+  }
+
   std::optional<ncclx::test::NcclCommRAII> comm_;
   cudaStream_t stream_{nullptr};
   ncclx::test::VerifyAlgoStatsHelper algoStats_;
@@ -147,6 +357,30 @@ TEST_F(ReduceScatterQuantizeDefaultPatTest, DefaultUsesPat) {
   run(ncclSum, 1025);
   algoStats_.verify(comm_->get(), "ReduceScatter", "PAT");
   algoStats_.verifyNot(
+      comm_->get(), "ReduceScatter", "CtranReduceScatterDirectIb");
+}
+
+TEST_F(
+    ReduceScatterQuantizeDirectIbTest,
+    QuantizedCallsAreOrderedAcrossStreams) {
+  runOnTwoStreams(true);
+  algoStats_.verify(
+      comm_->get(), "ReduceScatter", "CtranReduceScatterDirectIb");
+}
+
+TEST_F(
+    ReduceScatterQuantizeDirectIbTest,
+    UnquantizedCallsAreOrderedAcrossStreams) {
+  runOnTwoStreams(false);
+  algoStats_.verify(
+      comm_->get(), "ReduceScatter", "CtranReduceScatterDirectIb");
+}
+
+TEST_F(
+    ReduceScatterQuantizeDirectIbTest,
+    CapturedCallsAreOrderedAcrossStreamsAndEagerWork) {
+  runCapturedOnTwoStreams();
+  algoStats_.verify(
       comm_->get(), "ReduceScatter", "CtranReduceScatterDirectIb");
 }
 


### PR DESCRIPTION
Summary:

Add a communicator-owned PRIMS work-stream guard and use it only around the shared quantized and unquantized DirectIB reduce-scatter launch. Preserve CUDA graph ordering while serializing the communicator-owned DirectIB progress state across model layer streams.

Add eager and captured two-stream distributed regressions with independent buffers and algorithm-stat verification.

Reviewed By: saifhhasan

Differential Revision: D113859424


