### PR TITLE
folly::sformat -> fmt::format

### DIFF
--- a/comms/ncclx/meta/tests/SocketTosTest.cpp
+++ b/comms/ncclx/meta/tests/SocketTosTest.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 #include <thread>
 #include "comms/testinfra/TestUtils.h"
@@ -17,7 +18,7 @@ class SocketSetTosTest : public ::testing::Test {
     const ::testing::TestInfo* test_info =
         ::testing::UnitTest::GetInstance()->current_test_info();
     testName =
-        folly::sformat("{}.{}", test_info->test_case_name(), test_info->name());
+        fmt::format("{}.{}", test_info->test_case_name(), test_info->name());
   }
 };
 


### PR DESCRIPTION
Summary:
Part of the fbsource-wide `folly::sformat` -> `fmt::format` migration, done
with the clang `folly-to-fmt-format` codemod (not by hand). The codemod
rewrites the call, adds `#include <fmt/format.h>`, and wraps any non-literal
format string in `fmt::runtime(...)`; `arc lint -a` supplied clang-format and
buck deps.

Differential Revision: D114453575


