### PR TITLE
runtime intra-node transport selection (default NVLink/P2P, flip to RDMA)

### DIFF
--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -144,6 +144,10 @@ MultiTransportFactory::MultiTransportFactory(
       deviceId_ >= -1 && deviceId_ < static_cast<int>(topo.gpuCount()),
       std::runtime_error);
 
+  // Register the intra-node interconnect tier whenever the hardware is present
+  // (NVLink on NVIDIA, P2P/XGMI on AMD). This tier and RDMA are both registered
+  // when available; selectTransport chooses per transfer (intraNodeTransport
+  // can flip the intra-node default -- see selectTransport).
 #ifndef __HIP_PLATFORM_AMD__
   if (deviceId_ >= 0 && isNvlinkAvailable()) {
     auto nvlink = std::make_shared<NVLinkTransportFactory>(
@@ -305,9 +309,24 @@ Result<Transport*> MultiTransport::selectTransport(
     return true;
   };
 
-  // VRAM→VRAM on matching device: prefer NVLink if ALL requests have it.
+  // Intra-node (VRAM<->VRAM on this device): default to the interconnect tier
+  // (NVLink/P2P). intraNodeTransport flips that choice (e.g. to RDMA) -- both
+  // tiers are registered, so this is a per-transfer selection override, not a
+  // kill-switch. Falls through to the inter-node fallback if the chosen tier is
+  // not present on all requests.
   if (localMemType == MemoryType::VRAM && remoteMemType == MemoryType::VRAM &&
       localDeviceId == deviceId_) {
+    // Try the intra-node override first (only if set and distinct from the
+    // NVLink/P2P default), then the default. Two explicit checks -> no
+    // per-transfer heap allocation, and no redundant re-check when the override
+    // is itself NVLink/P2P.
+    if (intraNodeTransport_.has_value() &&
+        *intraNodeTransport_ != TransportType::NVLink &&
+        allHaveTransport(*intraNodeTransport_)) {
+      if (auto* t = findTransport(*intraNodeTransport_)) {
+        return t;
+      }
+    }
     if (allHaveTransport(TransportType::NVLink)) {
       if (auto* t = findTransport(TransportType::NVLink)) {
         return t;
@@ -479,7 +498,8 @@ Result<std::unique_ptr<MultiTransport>> MultiTransportFactory::createTransport(
         entries.size());
   }
 
-  auto mt = std::make_unique<MultiTransport>(deviceId_, eventBaseThread_);
+  auto mt = std::make_unique<MultiTransport>(
+      deviceId_, eventBaseThread_, options_.intraNodeTransport);
   for (size_t i = 0, j = 0; i < entries.size() && j < factories_.size();) {
     if (entries[i].type < factories_[j]->transportType()) {
       ++i;

--- a/comms/uniflow/MultiTransport.h
+++ b/comms/uniflow/MultiTransport.h
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <cstddef>
+#include <optional>
 
 namespace uniflow {
 
@@ -24,14 +25,24 @@ struct MultiTransportFactoryOptions {
   CpuNicSelectionPolicy cpuNicSelectionPolicy{
       CpuNicSelectionPolicy::kNumaLocalBounded};
   size_t maxCpuNics{2};
+  // Runtime intra-node transport selection. Intra-node VRAM<->VRAM defaults to
+  // the on-host interconnect tier (NVLink on NVIDIA, P2P/XGMI on AMD). Set this
+  // to flip that choice -- e.g. TransportType::RDMA to route intra-node traffic
+  // over RDMA instead. Both tiers stay registered, so this is a selection
+  // override, not a kill-switch; inter-node stays RDMA. Caller-owned (no
+  // transport-internal config-system dependency).
+  std::optional<TransportType> intraNodeTransport;
 };
 
 class MultiTransport {
  public:
   explicit MultiTransport(
       int deviceId,
-      std::shared_ptr<ScopedEventBaseThread> evbThread = nullptr)
-      : deviceId_(deviceId), evbThread_(std::move(evbThread)) {
+      std::shared_ptr<ScopedEventBaseThread> evbThread = nullptr,
+      std::optional<TransportType> intraNodeTransport = std::nullopt)
+      : deviceId_(deviceId),
+        intraNodeTransport_(intraNodeTransport),
+        evbThread_(std::move(evbThread)) {
     if (!evbThread_) {
       evbThread_ = std::make_shared<ScopedEventBaseThread>();
     }
@@ -97,6 +108,7 @@ class MultiTransport {
   Transport* findTransport(TransportType type) const;
 
   const int deviceId_;
+  std::optional<TransportType> intraNodeTransport_;
   // Prevents destruction of the shared EventBase while transports are live.
   // Transports hold raw EventBase* borrowed from the ScopedEventBaseThread
   // owned by MultiTransportFactory; this shared_ptr ensures the thread (and

--- a/comms/uniflow/tests/unit/MultiTransportTest.cpp
+++ b/comms/uniflow/tests/unit/MultiTransportTest.cpp
@@ -1080,4 +1080,25 @@ TEST_F(MultiTransportTest, AsymmetricHandlesFallBackToRdma) {
   EXPECT_EQ(nvlink->putCount, 0);
 }
 
+TEST_F(MultiTransportTest, IntraNodeTransportFlipsToRdma) {
+  // intraNodeTransport=RDMA flips the intra-node default (NVLink) to RDMA; both
+  // tiers stay registered, so this is a per-transfer selection override.
+  MultiTransport mt(0, nullptr, TransportType::RDMA);
+  auto* nvlink = addMock(mt, TransportType::NVLink);
+  auto* rdma = addMock(mt, TransportType::RDMA);
+
+  TestSegments local(
+      MemoryType::VRAM, 0, {TransportType::NVLink, TransportType::RDMA});
+  TestSegments remote(
+      MemoryType::VRAM, 0, {TransportType::NVLink, TransportType::RDMA});
+  std::vector<TransferRequest> reqs = {
+      {local.regSeg.span(size_t{0}, size_t{32}),
+       remote.remoteSeg.span(size_t{0}, size_t{32})}};
+
+  auto future = mt.put(reqs);
+  EXPECT_TRUE(future.get().hasValue());
+  EXPECT_EQ(rdma->putCount, 1);
+  EXPECT_EQ(nvlink->putCount, 0);
+}
+
 } // namespace uniflow


### PR DESCRIPTION
Summary:
Follows the "register all available transports at construction, select per
transfer" model for the intra-node interconnect tier. Both the interconnect tier
(NVLink on NVIDIA, P2P/XGMI on AMD) and RDMA register whenever the hardware is
available -- there is no registration kill-switch.

selectTransport keeps NVLink/P2P as the intra-node default (VRAM<->VRAM on this
device) and RDMA as the inter-node default. New
MultiTransportFactoryOptions::intraNodeTransport changes the intra-node
preference -- e.g. set it to TransportType::RDMA to prefer RDMA for intra-node
traffic over NVLink/P2P. Because both tiers stay registered, this is a
per-transfer selection preference, not a kill-switch.

Contract: it is a preference, not a guarantee. If the preferred tier is not
available on all requests of a transfer, selection falls back to the NVLink/P2P
default (and then the inter-node RDMA->TCP fallback) -- NVLink/P2P remains an
acceptable path. Addresses the D110133969 request for a knob to prefer a
non-interconnect tier for intra-node transfers.

Caller-owned, so the transport takes no runtime-config-system dependency; the
rollout owner maps it to its preferred flag source at its own layer (mirroring
netdevPrefix).

TCP is intentionally out of scope here.

Reviewed By: rmahidhar

Differential Revision: D114457575


