### PR TITLE
test: intra-node kill-switch omits the interconnect tier

### DIFF
--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -144,16 +144,25 @@ MultiTransportFactory::MultiTransportFactory(
       deviceId_ >= -1 && deviceId_ < static_cast<int>(topo.gpuCount()),
       std::runtime_error);
 
+  // Kill-switch: when set, skip registering the intra-node interconnect tier so
+  // intra-node VRAM->VRAM falls back to RDMA. Caller-owned via
+  // MultiTransportFactoryOptions (no transport-internal config dependency),
+  // mirroring preferredTransport / netdevPrefix.
+  const bool intraNodeDisabled = options_.disableIntraNode;
 #ifndef __HIP_PLATFORM_AMD__
-  if (deviceId_ >= 0 && isNvlinkAvailable()) {
+  if (!intraNodeDisabled && deviceId_ >= 0 && isNvlinkAvailable()) {
     auto nvlink = std::make_shared<NVLinkTransportFactory>(
         deviceId, eventBaseThread_->getEventBase());
     factories_.emplace_back(std::move(nvlink));
+  } else if (intraNodeDisabled && deviceId_ >= 0) {
+    UNIFLOW_LOG_INFO(
+        "intra-node NVLink tier disabled via MultiTransportFactoryOptions; "
+        "falling back to RDMA");
   }
 #else
   // AMD: the NVLink tier is served by the P2P (XGMI) transport. Its supported()
   // owns the all-XGMI arch gate (selectTransport is presence-driven; see §5.6).
-  if (deviceId_ >= 0) {
+  if (!intraNodeDisabled && deviceId_ >= 0) {
     auto p2pSupported = P2pTransportFactory::supported();
     if (!p2pSupported.hasError()) {
       auto p2p = std::make_shared<P2pTransportFactory>(
@@ -165,6 +174,10 @@ MultiTransportFactory::MultiTransportFactory(
           deviceId_,
           p2pSupported.error().message());
     }
+  } else if (intraNodeDisabled && deviceId_ >= 0) {
+    UNIFLOW_LOG_INFO(
+        "intra-node P2P/XGMI tier disabled via MultiTransportFactoryOptions; "
+        "falling back to RDMA");
   }
 #endif
 

--- a/comms/uniflow/MultiTransport.h
+++ b/comms/uniflow/MultiTransport.h
@@ -24,6 +24,13 @@ struct MultiTransportFactoryOptions {
   CpuNicSelectionPolicy cpuNicSelectionPolicy{
       CpuNicSelectionPolicy::kNumaLocalBounded};
   size_t maxCpuNics{2};
+  // Kill-switch for the intra-node GPU interconnect tier (NVLink on NVIDIA,
+  // P2P/XGMI on AMD). Default false = tier enabled; set true to skip
+  // registering it so intra-node VRAM->VRAM falls back to RDMA without a code
+  // revert (selectTransport is presence-driven). Caller-owned so the transport
+  // takes no runtime-config-system dependency; the rollout owner may wire it to
+  // an env var / JustKnob / config at its own layer.
+  bool disableIntraNode{false};
 };
 
 class MultiTransport {

--- a/comms/uniflow/tests/integration/MultiTransportSingleHostTest.cpp
+++ b/comms/uniflow/tests/integration/MultiTransportSingleHostTest.cpp
@@ -187,6 +187,34 @@ TEST_F(MultiTransportFactoryTest, ConstructorGpuCreatesNvlinkAndRdma) {
 #endif
 }
 
+TEST_F(MultiTransportFactoryTest, ConstructorGpuOmitsIntraNodeWhenDisabled) {
+  if (topo_->gpuCount() == 0) {
+    GTEST_SKIP() << "No GPUs available";
+  }
+  // Only meaningful where the intra-node interconnect tier would normally be
+  // registered (NVLink on NVIDIA; P2P/XGMI on all-XGMI AMD nodes). Otherwise
+  // there is nothing to disable.
+  if (MultiTransportFactory::supported(TransportType::NVLink).hasError()) {
+    GTEST_SKIP() << "Intra-node interconnect tier not available on this host";
+  }
+
+  // Kill-switch (D114457575): with disableIntraNode, the intra-node
+  // interconnect factory is not registered. Since selectTransport is
+  // presence-driven, an intra-node VRAM->VRAM batch then has no NVLink-tier
+  // handle to match and falls back to RDMA. Assert the tier is absent from the
+  // registered factories (the observable cause of that fallback); the default
+  // case is covered by ConstructorGpuCreatesNvlinkAndRdma above.
+  MultiTransportFactoryOptions opts;
+  opts.disableIntraNode = true;
+  MultiTransportFactory factory(0, opts);
+
+  for (size_t i = 0; i < factoryCount(factory); ++i) {
+    EXPECT_NE(factoryTransportType(factory, i), TransportType::NVLink)
+        << "intra-node interconnect tier must be omitted when "
+           "disableIntraNode=true so intra-node traffic falls back to RDMA";
+  }
+}
+
 TEST_F(MultiTransportFactoryTest, ConstructorRejectsInvalidDeviceId) {
   int gpuCount = static_cast<int>(topo_->gpuCount());
   EXPECT_THROW(MultiTransportFactory factory(gpuCount), std::runtime_error);


### PR DESCRIPTION
Summary:
Unit test for the intra-node kill-switch (MultiTransportFactoryOptions::
disableIntraNode). On a GPU host where the interconnect tier is available
(NVLink on NVIDIA, P2P/XGMI on AMD), disableIntraNode=true registers NO
NVLink/P2P factory -- the presence-driven cause of the RDMA fallback for
intra-node VRAM->VRAM. The default case stays covered by
ConstructorGpuCreatesNvlinkAndRdma.

Stacked on the intra-node kill-switch change (adds disableIntraNode).

Differential Revision: D114485292


