### PR TITLE
comms/uniflow: native TCP transport (DRAM + VRAM host-staged) (#3371)

### DIFF
--- a/comms/uniflow/CMakeLists.txt
+++ b/comms/uniflow/CMakeLists.txt
@@ -102,6 +102,7 @@ add_library(uniflow ${UNIFLOW_LIB_TYPE}
     $<TARGET_OBJECTS:uniflow_transport>
     $<TARGET_OBJECTS:uniflow_nvlink_transport>
     $<TARGET_OBJECTS:uniflow_rdma_transport>
+    $<TARGET_OBJECTS:uniflow_tcp_transport>
     $<TARGET_OBJECTS:uniflow_cuda>
     $<TARGET_OBJECTS:uniflow_nvml>
     $<TARGET_OBJECTS:uniflow_ibv>

--- a/comms/uniflow/CMakeLists.txt
+++ b/comms/uniflow/CMakeLists.txt
@@ -62,6 +62,12 @@ if(spdlog_FOUND)
   endif()
 endif()
 
+if(CMAKE_HIP_COMPILER)
+  set(UNIFLOW_ENABLE_TCP_TRANSPORT ON)
+else()
+  set(UNIFLOW_ENABLE_TCP_TRANSPORT OFF)
+endif()
+
 # Sub-components
 add_subdirectory(executor)
 add_subdirectory(controller)
@@ -110,6 +116,12 @@ add_library(uniflow ${UNIFLOW_LIB_TYPE}
 )
 
 target_compile_features(uniflow PUBLIC cxx_std_20)
+
+if(UNIFLOW_ENABLE_TCP_TRANSPORT)
+  target_sources(uniflow PRIVATE $<TARGET_OBJECTS:uniflow_tcp_transport>)
+  target_compile_definitions(
+      uniflow PUBLIC UNIFLOW_ENABLE_TCP_TRANSPORT=1)
+endif()
 
 target_include_directories(uniflow PUBLIC
     ${ROOT}

--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -8,13 +8,24 @@
 // RDMA is the GPU transport on AMD as well as NVIDIA. NVLink is NVIDIA-only
 // (NVML-backed topology, fabric/FD IPC) and is compiled out on AMD/HIP.
 #include "comms/uniflow/transport/rdma/RdmaTransport.h"
+#ifdef UNIFLOW_ENABLE_TCP_TRANSPORT
+#include "comms/uniflow/transport/tcp/TcpTransport.h"
+#endif
 #ifndef __HIP_PLATFORM_AMD__
 #include "comms/uniflow/transport/nvlink/NVLinkTransport.h"
 #else
 #include "comms/uniflow/transport/p2p/P2pTransport.h"
 #endif
 
+#ifdef UNIFLOW_ENABLE_TCP_TRANSPORT
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#endif
+
 #include <cstring>
+#include <optional>
 
 namespace uniflow {
 
@@ -23,6 +34,93 @@ namespace {
 bool isCpu(int deviceId) {
   return deviceId == -1;
 }
+
+#ifdef UNIFLOW_ENABLE_TCP_TRANSPORT
+// Resolve a routable bind host for the TCP transport. Prefers an interface
+// whose name starts with netdevPrefix, else the first global (non-loopback,
+// non-link-local) address found, else falls back to loopback. Binding a
+// routable address (instead of 127.0.0.1) is what lets the TCP transport's
+// connect() succeed across hosts.
+std::string resolveTcpBindHost(const std::string& netdevPrefix) {
+  struct ifaddrs* ifaddr = nullptr;
+  if (getifaddrs(&ifaddr) != 0 || ifaddr == nullptr) {
+    return "127.0.0.1";
+  }
+  std::string prefixMatch;
+  std::string anyGlobal;
+  for (auto* ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr == nullptr) {
+      continue;
+    }
+    char buf[INET6_ADDRSTRLEN] = {};
+    std::string addr;
+    const int family = ifa->ifa_addr->sa_family;
+    if (family == AF_INET6) {
+      auto* sa = reinterpret_cast<sockaddr_in6*>(ifa->ifa_addr);
+      const auto* b = sa->sin6_addr.s6_addr;
+      const bool linkLocal = b[0] == 0xfe && (b[1] & 0xc0) == 0x80;
+      bool loopback = true;
+      for (int i = 0; i < 15; ++i) {
+        loopback = loopback && b[i] == 0;
+      }
+      loopback = loopback && b[15] == 1;
+      // Unspecified (::) and IPv4-mapped-IPv6 loopback (::ffff:127.0.0.0/8) are
+      // not routable; skip them so anyGlobal never holds a loopback-equivalent
+      // over a genuinely global address enumerated later on the same host.
+      bool unspecified = true;
+      for (int i = 0; i < 16; ++i) {
+        unspecified = unspecified && b[i] == 0;
+      }
+      bool v4Mapped = true;
+      for (int i = 0; i < 10; ++i) {
+        v4Mapped = v4Mapped && b[i] == 0;
+      }
+      const bool v4MappedLoopback =
+          v4Mapped && b[10] == 0xff && b[11] == 0xff && b[12] == 127;
+      if (linkLocal || loopback || unspecified || v4MappedLoopback ||
+          inet_ntop(AF_INET6, &sa->sin6_addr, buf, sizeof(buf)) == nullptr) {
+        continue;
+      }
+      addr = buf;
+    } else if (family == AF_INET) {
+      auto* sa = reinterpret_cast<sockaddr_in*>(ifa->ifa_addr);
+      if ((ntohl(sa->sin_addr.s_addr) >> 24) == 127 ||
+          inet_ntop(AF_INET, &sa->sin_addr, buf, sizeof(buf)) == nullptr) {
+        continue;
+      }
+      addr = buf;
+    } else {
+      continue;
+    }
+    const std::string name = ifa->ifa_name != nullptr ? ifa->ifa_name : "";
+    if (prefixMatch.empty() && !netdevPrefix.empty() &&
+        name.rfind(netdevPrefix, 0) == 0) {
+      prefixMatch = addr;
+    }
+    if (anyGlobal.empty()) {
+      anyGlobal = addr;
+    }
+  }
+  freeifaddrs(ifaddr);
+  std::string host = !prefixMatch.empty()
+      ? prefixMatch
+      : (!anyGlobal.empty() ? anyGlobal : std::string("127.0.0.1"));
+  UNIFLOW_LOG_INFO(
+      "TCP transport bind host resolved to {} (netdevPrefix={})",
+      host,
+      netdevPrefix);
+  return host;
+}
+
+// True if @p host is empty or loopback. Advertising a loopback bind address in
+// the connect handshake would break cross-host connections for all transports,
+// so TCP is not auto-registered in that case.
+bool isLoopbackHost(const std::string& host) {
+  return host.empty() || host == "::1" || host.rfind("127.", 0) == 0 ||
+      // IPv4-mapped-IPv6 loopback forms (dotted and pure-hex 127.0.0.0/8).
+      host.rfind("::ffff:127.", 0) == 0 || host.rfind("::ffff:7f", 0) == 0;
+}
+#endif
 
 } // namespace
 
@@ -83,7 +181,13 @@ Status MultiTransportFactory::supported(TransportType type) {
       return P2pTransportFactory::supported();
 #endif
     case TransportType::TCP:
-      return Err(ErrCode::NotImplemented, "tcp transport is not implemented");
+#ifdef UNIFLOW_ENABLE_TCP_TRANSPORT
+      return TcpTransportFactory::supported();
+#else
+      return Err(
+          ErrCode::NotImplemented,
+          "tcp transport is not enabled in this platform build");
+#endif
     case TransportType::Mock:
       return Ok();
     case TransportType::NumTransportType:
@@ -144,6 +248,22 @@ MultiTransportFactory::MultiTransportFactory(
       deviceId_ >= -1 && deviceId_ < static_cast<int>(topo.gpuCount()),
       std::runtime_error);
 
+#ifdef UNIFLOW_ENABLE_TCP_TRANSPORT
+  // An explicit TCP request (via preferred/intra/interNodeTransport) must carry
+  // a bind host AND enableTcp; otherwise TCP would not register (silently
+  // falling back to RDMA/NVLink) or would auto-resolve a non-front-end NIC.
+  // Fail fast at construction rather than mis-routing at transfer time.
+  const auto requestsTcp = [](const std::optional<TransportType>& t) {
+    return t.has_value() && *t == TransportType::TCP;
+  };
+  CHECK_THROW_EXCEPTION(
+      !((requestsTcp(options_.preferredTransport) ||
+         requestsTcp(options_.intraNodeTransport) ||
+         requestsTcp(options_.interNodeTransport)) &&
+        (options_.tcpBindHost.empty() || !options_.enableTcp)),
+      std::invalid_argument);
+#endif
+
   // Register the intra-node interconnect tier whenever the hardware is present
   // (NVLink on NVIDIA, P2P/XGMI on AMD). This tier and RDMA are both registered
   // when available; selectTransport chooses per transfer (intraNodeTransport
@@ -182,6 +302,32 @@ MultiTransportFactory::MultiTransportFactory(
         std::move(nics), eventBaseThread_->getEventBase(), config);
     factories_.emplace_back(std::move(rdma));
   }
+
+#ifdef UNIFLOW_ENABLE_TCP_TRANSPORT
+  // TCP joins the transport pool automatically whenever a routable bind address
+  // is available (selectTransport still prefers NVLink/P2P -> RDMA and uses TCP
+  // only as the common fallback or when explicitly selected). Registration is
+  // skipped when only a loopback address resolves, since advertising loopback
+  // in the connect handshake would break cross-host connections for all
+  // transports. enableTcp force-registers even on loopback (e.g. same-host
+  // testing).
+  std::string tcpHost = options_.tcpBindHost;
+  if (tcpHost.empty()) {
+    tcpHost = resolveTcpBindHost(options_.netdevPrefix);
+  }
+  if (!isLoopbackHost(tcpHost) || options_.enableTcp) {
+    auto tcp = std::make_shared<TcpTransportFactory>(
+        deviceId,
+        eventBaseThread_->getEventBase(),
+        controller::TcpSocketConfig{},
+        tcpHost);
+    factories_.emplace_back(std::move(tcp));
+  } else {
+    UNIFLOW_LOG_INFO(
+        "TCP transport not registered: only a loopback bind address is "
+        "available (set tcpBindHost or enableTcp to force)");
+  }
+#endif
 }
 
 void MultiTransport::addTransport(std::unique_ptr<Transport> transport) {
@@ -309,40 +455,74 @@ Result<Transport*> MultiTransport::selectTransport(
     return true;
   };
 
-  // Intra-node (VRAM<->VRAM on this device): default to the interconnect tier
-  // (NVLink/P2P). intraNodeTransport flips that choice (e.g. to RDMA) -- both
-  // tiers are registered, so this is a per-transfer selection override, not a
-  // kill-switch.
-  if (localMemType == MemoryType::VRAM && remoteMemType == MemoryType::VRAM &&
-      localDeviceId == deviceId_) {
-    // Try the intra-node override first (only if set and distinct from the
-    // NVLink/P2P default), then the default. Two explicit checks -> no
-    // per-transfer heap allocation, and no redundant re-check when the override
-    // is itself NVLink/P2P.
-    if (intraNodeTransport_.has_value() &&
-        *intraNodeTransport_ != TransportType::NVLink &&
-        allHaveTransport(*intraNodeTransport_)) {
-      if (auto* t = findTransport(*intraNodeTransport_)) {
-        return t;
-      }
-    }
-    if (allHaveTransport(TransportType::NVLink)) {
-      if (auto* t = findTransport(TransportType::NVLink)) {
-        return t;
-      }
+#ifndef UNIFLOW_ENABLE_TCP_TRANSPORT
+  const auto tcpUnavailable = [&]() -> Result<Transport*> {
+    return Err(
+        ErrCode::NotImplemented,
+        "tcp transport is not enabled in this platform build");
+  };
+  if (preferredTransport_ == TransportType::TCP) {
+    return tcpUnavailable();
+  }
+#endif
+
+  // preferredTransport: global force -- if set and available on all requests,
+  // it wins regardless of topology (both intra- and inter-node).
+  if (preferredTransport_.has_value() &&
+      allHaveTransport(*preferredTransport_)) {
+    if (auto* t = findTransport(*preferredTransport_)) {
+      return t;
     }
   }
 
-  // Fallback: RDMA → TCP, must be available in ALL requests.
-  static constexpr TransportType kFallback[] = {
-      TransportType::RDMA, TransportType::TCP};
-  for (auto type : kFallback) {
-    if (allHaveTransport(type)) {
-      if (auto* t = findTransport(type)) {
-        return t;
-      }
+  // Intra-node = VRAM<->VRAM on this device (reachable over the on-host
+  // interconnect tier); otherwise inter-node. One transport per batch.
+  const bool intraNode = localMemType == MemoryType::VRAM &&
+      remoteMemType == MemoryType::VRAM && localDeviceId == deviceId_;
+
+  // Per-case ordered preference, evaluated allocation-free with no transport
+  // checked twice: the case override first (if set), then the case defaults
+  // skipping whichever tier equals the override.
+  //   intra-node: [intraNodeTransport?] NVLink -> RDMA -> TCP
+  //   inter-node: [interNodeTransport?] RDMA -> TCP
+  const std::optional<TransportType>& caseOverride =
+      intraNode ? intraNodeTransport_ : interNodeTransport_;
+  auto tryTier = [&](TransportType type) -> Transport* {
+    return allHaveTransport(type) ? findTransport(type) : nullptr;
+  };
+
+#ifndef UNIFLOW_ENABLE_TCP_TRANSPORT
+  if (caseOverride == TransportType::TCP) {
+    return tcpUnavailable();
+  }
+#endif
+
+  if (caseOverride.has_value()) {
+    if (auto* t = tryTier(*caseOverride)) {
+      return t;
     }
   }
+  if (intraNode && caseOverride != TransportType::NVLink) {
+    if (auto* t = tryTier(TransportType::NVLink)) {
+      return t;
+    }
+  }
+  if (caseOverride != TransportType::RDMA) {
+    if (auto* t = tryTier(TransportType::RDMA)) {
+      return t;
+    }
+  }
+#ifdef UNIFLOW_ENABLE_TCP_TRANSPORT
+  if (caseOverride != TransportType::TCP) {
+    if (auto* t = tryTier(TransportType::TCP)) {
+      return t;
+    }
+  }
+#else
+  if (allHaveTransport(TransportType::TCP)) {
+    return tcpUnavailable();
+  }
+#endif
 
   return Err(
       ErrCode::NotConnected,
@@ -498,7 +678,11 @@ Result<std::unique_ptr<MultiTransport>> MultiTransportFactory::createTransport(
   }
 
   auto mt = std::make_unique<MultiTransport>(
-      deviceId_, eventBaseThread_, options_.intraNodeTransport);
+      deviceId_,
+      eventBaseThread_,
+      options_.intraNodeTransport,
+      options_.preferredTransport,
+      options_.interNodeTransport);
   for (size_t i = 0, j = 0; i < entries.size() && j < factories_.size();) {
     if (entries[i].type < factories_[j]->transportType()) {
       ++i;

--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -8,11 +8,17 @@
 // RDMA is the GPU transport on AMD as well as NVIDIA. NVLink is NVIDIA-only
 // (NVML-backed topology, fabric/FD IPC) and is compiled out on AMD/HIP.
 #include "comms/uniflow/transport/rdma/RdmaTransport.h"
+#include "comms/uniflow/transport/tcp/TcpTransport.h"
 #ifndef __HIP_PLATFORM_AMD__
 #include "comms/uniflow/transport/nvlink/NVLinkTransport.h"
 #else
 #include "comms/uniflow/transport/p2p/P2pTransport.h"
 #endif
+
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
 
 #include <cstring>
 
@@ -22,6 +28,91 @@ namespace {
 
 bool isCpu(int deviceId) {
   return deviceId == -1;
+}
+
+// Resolve a routable bind host for the TCP transport. Prefers an interface
+// whose name starts with netdevPrefix, else the first global (non-loopback,
+// non-link-local) address found, else falls back to loopback. Binding a
+// routable address (instead of 127.0.0.1) is what lets the TCP transport's
+// connect() succeed across hosts.
+std::string resolveTcpBindHost(const std::string& netdevPrefix) {
+  struct ifaddrs* ifaddr = nullptr;
+  if (getifaddrs(&ifaddr) != 0 || ifaddr == nullptr) {
+    return "127.0.0.1";
+  }
+  std::string prefixMatch;
+  std::string anyGlobal;
+  for (auto* ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr == nullptr) {
+      continue;
+    }
+    char buf[INET6_ADDRSTRLEN] = {};
+    std::string addr;
+    const int family = ifa->ifa_addr->sa_family;
+    if (family == AF_INET6) {
+      auto* sa = reinterpret_cast<sockaddr_in6*>(ifa->ifa_addr);
+      const auto* b = sa->sin6_addr.s6_addr;
+      const bool linkLocal = b[0] == 0xfe && (b[1] & 0xc0) == 0x80;
+      bool loopback = true;
+      for (int i = 0; i < 15; ++i) {
+        loopback = loopback && b[i] == 0;
+      }
+      loopback = loopback && b[15] == 1;
+      // Unspecified (::) and IPv4-mapped-IPv6 loopback (::ffff:127.0.0.0/8) are
+      // not routable; skip them so anyGlobal never holds a loopback-equivalent
+      // over a genuinely global address enumerated later on the same host.
+      bool unspecified = true;
+      for (int i = 0; i < 16; ++i) {
+        unspecified = unspecified && b[i] == 0;
+      }
+      bool v4Mapped = true;
+      for (int i = 0; i < 10; ++i) {
+        v4Mapped = v4Mapped && b[i] == 0;
+      }
+      const bool v4MappedLoopback =
+          v4Mapped && b[10] == 0xff && b[11] == 0xff && b[12] == 127;
+      if (linkLocal || loopback || unspecified || v4MappedLoopback ||
+          inet_ntop(AF_INET6, &sa->sin6_addr, buf, sizeof(buf)) == nullptr) {
+        continue;
+      }
+      addr = buf;
+    } else if (family == AF_INET) {
+      auto* sa = reinterpret_cast<sockaddr_in*>(ifa->ifa_addr);
+      if ((ntohl(sa->sin_addr.s_addr) >> 24) == 127 ||
+          inet_ntop(AF_INET, &sa->sin_addr, buf, sizeof(buf)) == nullptr) {
+        continue;
+      }
+      addr = buf;
+    } else {
+      continue;
+    }
+    const std::string name = ifa->ifa_name != nullptr ? ifa->ifa_name : "";
+    if (prefixMatch.empty() && !netdevPrefix.empty() &&
+        name.rfind(netdevPrefix, 0) == 0) {
+      prefixMatch = addr;
+    }
+    if (anyGlobal.empty()) {
+      anyGlobal = addr;
+    }
+  }
+  freeifaddrs(ifaddr);
+  std::string host = !prefixMatch.empty()
+      ? prefixMatch
+      : (!anyGlobal.empty() ? anyGlobal : std::string("127.0.0.1"));
+  UNIFLOW_LOG_INFO(
+      "TCP transport bind host resolved to {} (netdevPrefix={})",
+      host,
+      netdevPrefix);
+  return host;
+}
+
+// True if @p host is empty or loopback. Advertising a loopback bind address in
+// the connect handshake would break cross-host connections for all transports,
+// so TCP is not auto-registered in that case.
+bool isLoopbackHost(const std::string& host) {
+  return host.empty() || host == "::1" || host.rfind("127.", 0) == 0 ||
+      // IPv4-mapped-IPv6 loopback forms (dotted and pure-hex 127.0.0.0/8).
+      host.rfind("::ffff:127.", 0) == 0 || host.rfind("::ffff:7f", 0) == 0;
 }
 
 } // namespace
@@ -83,7 +174,7 @@ Status MultiTransportFactory::supported(TransportType type) {
       return P2pTransportFactory::supported();
 #endif
     case TransportType::TCP:
-      return Err(ErrCode::NotImplemented, "tcp transport is not implemented");
+      return TcpTransportFactory::supported();
     case TransportType::Mock:
       return Ok();
     case TransportType::NumTransportType:
@@ -144,6 +235,20 @@ MultiTransportFactory::MultiTransportFactory(
       deviceId_ >= -1 && deviceId_ < static_cast<int>(topo.gpuCount()),
       std::runtime_error);
 
+  // An explicit TCP request (via preferred/intra/interNodeTransport) must carry
+  // a bind host AND enableTcp; otherwise TCP would not register (silently
+  // falling back to RDMA/NVLink) or would auto-resolve a non-front-end NIC.
+  // Fail fast at construction rather than mis-routing at transfer time.
+  const auto requestsTcp = [](const std::optional<TransportType>& t) {
+    return t.has_value() && *t == TransportType::TCP;
+  };
+  CHECK_THROW_EXCEPTION(
+      !((requestsTcp(options_.preferredTransport) ||
+         requestsTcp(options_.intraNodeTransport) ||
+         requestsTcp(options_.interNodeTransport)) &&
+        (options_.tcpBindHost.empty() || !options_.enableTcp)),
+      std::invalid_argument);
+
   // Register the intra-node interconnect tier whenever the hardware is present
   // (NVLink on NVIDIA, P2P/XGMI on AMD). This tier and RDMA are both registered
   // when available; selectTransport chooses per transfer (intraNodeTransport
@@ -181,6 +286,30 @@ MultiTransportFactory::MultiTransportFactory(
     auto rdma = std::make_shared<RdmaTransportFactory>(
         std::move(nics), eventBaseThread_->getEventBase(), config);
     factories_.emplace_back(std::move(rdma));
+  }
+
+  // TCP joins the transport pool automatically whenever a routable bind address
+  // is available (selectTransport still prefers NVLink/P2P -> RDMA and uses TCP
+  // only as the common fallback or when explicitly selected). Registration is
+  // skipped when only a loopback address resolves, since advertising loopback
+  // in the connect handshake would break cross-host connections for all
+  // transports. enableTcp force-registers even on loopback (e.g. same-host
+  // testing).
+  std::string tcpHost = options_.tcpBindHost;
+  if (tcpHost.empty()) {
+    tcpHost = resolveTcpBindHost(options_.netdevPrefix);
+  }
+  if (!isLoopbackHost(tcpHost) || options_.enableTcp) {
+    auto tcp = std::make_shared<TcpTransportFactory>(
+        deviceId,
+        eventBaseThread_->getEventBase(),
+        controller::TcpSocketConfig{},
+        tcpHost);
+    factories_.emplace_back(std::move(tcp));
+  } else {
+    UNIFLOW_LOG_INFO(
+        "TCP transport not registered: only a loopback bind address is "
+        "available (set tcpBindHost or enableTcp to force)");
   }
 }
 
@@ -309,38 +438,49 @@ Result<Transport*> MultiTransport::selectTransport(
     return true;
   };
 
-  // Intra-node (VRAM<->VRAM on this device): default to the interconnect tier
-  // (NVLink/P2P). intraNodeTransport flips that choice (e.g. to RDMA) -- both
-  // tiers are registered, so this is a per-transfer selection override, not a
-  // kill-switch.
-  if (localMemType == MemoryType::VRAM && remoteMemType == MemoryType::VRAM &&
-      localDeviceId == deviceId_) {
-    // Try the intra-node override first (only if set and distinct from the
-    // NVLink/P2P default), then the default. Two explicit checks -> no
-    // per-transfer heap allocation, and no redundant re-check when the override
-    // is itself NVLink/P2P.
-    if (intraNodeTransport_.has_value() &&
-        *intraNodeTransport_ != TransportType::NVLink &&
-        allHaveTransport(*intraNodeTransport_)) {
-      if (auto* t = findTransport(*intraNodeTransport_)) {
-        return t;
-      }
-    }
-    if (allHaveTransport(TransportType::NVLink)) {
-      if (auto* t = findTransport(TransportType::NVLink)) {
-        return t;
-      }
+  // preferredTransport: global force -- if set and available on all requests,
+  // it wins regardless of topology (both intra- and inter-node).
+  if (preferredTransport_.has_value() &&
+      allHaveTransport(*preferredTransport_)) {
+    if (auto* t = findTransport(*preferredTransport_)) {
+      return t;
     }
   }
 
-  // Fallback: RDMA → TCP, must be available in ALL requests.
-  static constexpr TransportType kFallback[] = {
-      TransportType::RDMA, TransportType::TCP};
-  for (auto type : kFallback) {
-    if (allHaveTransport(type)) {
-      if (auto* t = findTransport(type)) {
-        return t;
-      }
+  // Intra-node = VRAM<->VRAM on this device (reachable over the on-host
+  // interconnect tier); otherwise inter-node. One transport per batch.
+  const bool intraNode = localMemType == MemoryType::VRAM &&
+      remoteMemType == MemoryType::VRAM && localDeviceId == deviceId_;
+
+  // Per-case ordered preference, evaluated allocation-free with no transport
+  // checked twice: the case override first (if set), then the case defaults
+  // skipping whichever tier equals the override.
+  //   intra-node: [intraNodeTransport?] NVLink -> RDMA -> TCP
+  //   inter-node: [interNodeTransport?] RDMA -> TCP
+  const std::optional<TransportType>& caseOverride =
+      intraNode ? intraNodeTransport_ : interNodeTransport_;
+  auto tryTier = [&](TransportType type) -> Transport* {
+    return allHaveTransport(type) ? findTransport(type) : nullptr;
+  };
+
+  if (caseOverride.has_value()) {
+    if (auto* t = tryTier(*caseOverride)) {
+      return t;
+    }
+  }
+  if (intraNode && caseOverride != TransportType::NVLink) {
+    if (auto* t = tryTier(TransportType::NVLink)) {
+      return t;
+    }
+  }
+  if (caseOverride != TransportType::RDMA) {
+    if (auto* t = tryTier(TransportType::RDMA)) {
+      return t;
+    }
+  }
+  if (caseOverride != TransportType::TCP) {
+    if (auto* t = tryTier(TransportType::TCP)) {
+      return t;
     }
   }
 
@@ -498,7 +638,11 @@ Result<std::unique_ptr<MultiTransport>> MultiTransportFactory::createTransport(
   }
 
   auto mt = std::make_unique<MultiTransport>(
-      deviceId_, eventBaseThread_, options_.intraNodeTransport);
+      deviceId_,
+      eventBaseThread_,
+      options_.intraNodeTransport,
+      options_.preferredTransport,
+      options_.interNodeTransport);
   for (size_t i = 0, j = 0; i < entries.size() && j < factories_.size();) {
     if (entries[i].type < factories_[j]->transportType()) {
       ++i;

--- a/comms/uniflow/MultiTransport.h
+++ b/comms/uniflow/MultiTransport.h
@@ -29,9 +29,23 @@ struct MultiTransportFactoryOptions {
   // the on-host interconnect tier (NVLink on NVIDIA, P2P/XGMI on AMD). Set this
   // to flip that choice -- e.g. TransportType::RDMA to route intra-node traffic
   // over RDMA instead. Both tiers stay registered, so this is a selection
-  // override, not a kill-switch; inter-node stays RDMA. Caller-owned (no
-  // transport-internal config-system dependency).
+  // override, not a kill-switch. Caller-owned (no transport-internal
+  // config-system dependency).
   std::optional<TransportType> intraNodeTransport;
+  // preferredTransport: global force, checked first in selectTransport --
+  // applies to both intra- and inter-node. interNodeTransport: inter-node
+  // override (default RDMA). Each falls through to the remaining tiers if the
+  // chosen transport is unavailable on all requests.
+  std::optional<TransportType> preferredTransport;
+  std::optional<TransportType> interNodeTransport;
+  // The TCP data transport auto-registers whenever a routable bind address is
+  // available (tcpBindHost if set, else resolveTcpBindHost: netdevPrefix match,
+  // else first global address). It is skipped when only loopback resolves,
+  // since advertising loopback in the connect handshake breaks cross-host
+  // connections for all transports. Set enableTcp to force-register even on
+  // loopback (e.g. same-host testing).
+  bool enableTcp{false};
+  std::string tcpBindHost{};
 };
 
 class MultiTransport {
@@ -39,9 +53,13 @@ class MultiTransport {
   explicit MultiTransport(
       int deviceId,
       std::shared_ptr<ScopedEventBaseThread> evbThread = nullptr,
-      std::optional<TransportType> intraNodeTransport = std::nullopt)
+      std::optional<TransportType> intraNodeTransport = std::nullopt,
+      std::optional<TransportType> preferredTransport = std::nullopt,
+      std::optional<TransportType> interNodeTransport = std::nullopt)
       : deviceId_(deviceId),
+        preferredTransport_(preferredTransport),
         intraNodeTransport_(intraNodeTransport),
+        interNodeTransport_(interNodeTransport),
         evbThread_(std::move(evbThread)) {
     if (!evbThread_) {
       evbThread_ = std::make_shared<ScopedEventBaseThread>();
@@ -108,7 +126,9 @@ class MultiTransport {
   Transport* findTransport(TransportType type) const;
 
   const int deviceId_;
+  std::optional<TransportType> preferredTransport_;
   std::optional<TransportType> intraNodeTransport_;
+  std::optional<TransportType> interNodeTransport_;
   // Prevents destruction of the shared EventBase while transports are live.
   // Transports hold raw EventBase* borrowed from the ScopedEventBaseThread
   // owned by MultiTransportFactory; this shared_ptr ensures the thread (and

--- a/comms/uniflow/Segment.h
+++ b/comms/uniflow/Segment.h
@@ -192,6 +192,7 @@ class RegisteredSegment : public SegmentBase<RegisteredSegment> {
         : TSpan(segment, offset, length), handles_(segment.handles_) {}
 
     friend class MultiTransport;
+    friend class TcpTransport;
     friend class NvLinkTransport;
     friend class RdmaTransport;
 
@@ -237,16 +238,20 @@ class RemoteRegisteredSegment : public SegmentBase<RemoteRegisteredSegment> {
     Span(RemoteRegisteredSegment& segment, size_t offset, size_t length)
         : TSpan(segment, offset, length),
           handles_(segment.handles_),
-          nvlinkOffset_(offset) {}
+          remoteOffset_(offset) {}
 
     friend class MultiTransport;
+    friend class TcpTransport;
     friend class NVLinkTransport;
     friend class RdmaTransport;
     friend class P2pTransport;
 
    private:
     std::span<const std::unique_ptr<RemoteRegistrationHandle>> handles_;
-    size_t nvlinkOffset_;
+    /// Byte offset of this span within the remote registered segment.
+    /// Transport-agnostic: NVLink and P2P add it to a mapped base pointer,
+    /// TCP sends it alongside the segId for the peer to resolve.
+    size_t remoteOffset_;
   };
 
   friend class SegmentTest;

--- a/comms/uniflow/Segment.h
+++ b/comms/uniflow/Segment.h
@@ -192,6 +192,7 @@ class RegisteredSegment : public SegmentBase<RegisteredSegment> {
         : TSpan(segment, offset, length), handles_(segment.handles_) {}
 
     friend class MultiTransport;
+    friend class TcpTransport;
     friend class NvLinkTransport;
     friend class RdmaTransport;
 
@@ -240,6 +241,7 @@ class RemoteRegisteredSegment : public SegmentBase<RemoteRegisteredSegment> {
           nvlinkOffset_(offset) {}
 
     friend class MultiTransport;
+    friend class TcpTransport;
     friend class NVLinkTransport;
     friend class RdmaTransport;
     friend class P2pTransport;

--- a/comms/uniflow/Uniflow.cpp
+++ b/comms/uniflow/Uniflow.cpp
@@ -7,12 +7,30 @@
 
 namespace uniflow {
 
+namespace {
+
+MultiTransportFactoryOptions makeFactoryOptions(
+    const UniflowAgentConfig& config) {
+  MultiTransportFactoryOptions options;
+  options.enableTcp = config.enableTcp;
+  options.tcpBindHost = config.tcpBindHost;
+  options.preferredTransport = config.preferredTransport;
+  options.intraNodeTransport = config.intraNodeTransport;
+  options.interNodeTransport = config.interNodeTransport;
+  return options;
+}
+
+} // namespace
+
 UniflowAgent::UniflowAgent(
     const UniflowAgentConfig& config,
     std::unique_ptr<controller::Client> client,
     std::unique_ptr<controller::Server> server)
     : config_(config),
-      factory_(std::make_shared<MultiTransportFactory>(config.deviceId)),
+      factory_(
+          std::make_shared<MultiTransportFactory>(
+              config.deviceId,
+              makeFactoryOptions(config))),
       client_(std::move(client)),
       server_(std::move(server)) {
   if (!client_) {

--- a/comms/uniflow/Uniflow.h
+++ b/comms/uniflow/Uniflow.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "comms/uniflow/Connection.h"
@@ -22,6 +23,18 @@ struct UniflowAgentConfig {
   std::string listenAddress{};
   int connectRetries{10};
   int connectTimeoutMs{1000};
+  // Transport selection for the underlying MultiTransportFactory. TCP is opt-in
+  // and must bind a routable address to work cross-host; leave tcpBindHost
+  // empty to auto-resolve one. Set preferredTransport to force a specific
+  // transport (e.g. TCP) even when RDMA is also available.
+  bool enableTcp{false};
+  std::string tcpBindHost{};
+  std::optional<TransportType> preferredTransport;
+  // Per-topology transport selection (see MultiTransport::selectTransport):
+  // intra-node defaults to NVLink/P2P, inter-node to RDMA. Set these to switch
+  // a case's first choice (intra-node -> RDMA/TCP; inter-node -> TCP).
+  std::optional<TransportType> intraNodeTransport;
+  std::optional<TransportType> interNodeTransport;
 };
 
 class UniflowAgent {

--- a/comms/uniflow/UniflowPy.cpp
+++ b/comms/uniflow/UniflowPy.cpp
@@ -429,26 +429,49 @@ PYBIND11_MODULE(_core, m) {
                       const std::string& name,
                       const std::string& listenAddress,
                       int connectRetries,
-                      int connectTimeoutMs) {
+                      int connectTimeoutMs,
+                      bool enableTcp,
+                      const std::string& tcpBindHost,
+                      std::optional<TransportType> preferredTransport,
+                      std::optional<TransportType> intraNodeTransport,
+                      std::optional<TransportType> interNodeTransport) {
             return UniflowAgentConfig{
                 .deviceId = deviceId,
                 .name = name,
                 .listenAddress = listenAddress,
                 .connectRetries = connectRetries,
                 .connectTimeoutMs = connectTimeoutMs,
+                .enableTcp = enableTcp,
+                .tcpBindHost = tcpBindHost,
+                .preferredTransport = preferredTransport,
+                .intraNodeTransport = intraNodeTransport,
+                .interNodeTransport = interNodeTransport,
             };
           }),
           py::arg("device_id") = -1,
           py::arg("name") = "",
           py::arg("listen_address") = "",
           py::arg("connect_retries") = 10,
-          py::arg("connect_timeout_ms") = 1000)
+          py::arg("connect_timeout_ms") = 1000,
+          py::arg("enable_tcp") = false,
+          py::arg("tcp_bind_host") = "",
+          py::arg("preferred_transport") = std::nullopt,
+          py::arg("intra_node_transport") = std::nullopt,
+          py::arg("inter_node_transport") = std::nullopt)
       .def_readwrite("device_id", &UniflowAgentConfig::deviceId)
       .def_readwrite("name", &UniflowAgentConfig::name)
       .def_readwrite("listen_address", &UniflowAgentConfig::listenAddress)
       .def_readwrite("connect_retries", &UniflowAgentConfig::connectRetries)
       .def_readwrite(
-          "connect_timeout_ms", &UniflowAgentConfig::connectTimeoutMs);
+          "connect_timeout_ms", &UniflowAgentConfig::connectTimeoutMs)
+      .def_readwrite("enable_tcp", &UniflowAgentConfig::enableTcp)
+      .def_readwrite("tcp_bind_host", &UniflowAgentConfig::tcpBindHost)
+      .def_readwrite(
+          "preferred_transport", &UniflowAgentConfig::preferredTransport)
+      .def_readwrite(
+          "intra_node_transport", &UniflowAgentConfig::intraNodeTransport)
+      .def_readwrite(
+          "inter_node_transport", &UniflowAgentConfig::interNodeTransport);
 
   // ---------------------------------------------------------------------------
   // MultiTransport
@@ -538,12 +561,16 @@ PYBIND11_MODULE(_core, m) {
           py::init([](int deviceId,
                       const std::string& nicFilter,
                       CpuNicSelectionPolicy cpuNicSelectionPolicy,
-                      size_t maxCpuNics) {
+                      size_t maxCpuNics,
+                      bool enableTcp,
+                      const std::string& tcpBindHost) {
             MultiTransportFactoryOptions options{
                 .nicFilter =
                     nicFilter.empty() ? NicFilter() : NicFilter(nicFilter),
                 .cpuNicSelectionPolicy = cpuNicSelectionPolicy,
                 .maxCpuNics = maxCpuNics,
+                .enableTcp = enableTcp,
+                .tcpBindHost = tcpBindHost,
             };
             return std::make_shared<MultiTransportFactory>(
                 deviceId, std::move(options));
@@ -553,7 +580,9 @@ PYBIND11_MODULE(_core, m) {
           py::arg("nic_filter") = "",
           py::arg("cpu_nic_selection_policy") =
               CpuNicSelectionPolicy::kNumaLocalBounded,
-          py::arg("max_cpu_nics") = 2)
+          py::arg("max_cpu_nics") = 2,
+          py::arg("enable_tcp") = false,
+          py::arg("tcp_bind_host") = "")
       .def(
           "register_segment",
           [](MultiTransportFactory& f, Segment& seg) {

--- a/comms/uniflow/tests/integration/MultiTransportSingleHostTest.cpp
+++ b/comms/uniflow/tests/integration/MultiTransportSingleHostTest.cpp
@@ -146,42 +146,87 @@ TEST_F(MultiTransportFactoryTest, SelectNicsGpuGB200) {
 }
 
 // --- Constructor integration tests ---
-TEST_F(MultiTransportFactoryTest, ConstructorCpuCreatesRdmaFactory) {
-  auto st = isPlatformSupported("");
-  if (!st) {
-    GTEST_SKIP() << st.error().message();
-  }
+#ifdef UNIFLOW_ENABLE_TCP_TRANSPORT
+TEST_F(MultiTransportFactoryTest, ConstructorCpuCreatesTcpAndOptionalRdma) {
+  const auto rdmaSupported = isPlatformSupported("").hasValue();
 
-  MultiTransportFactory factory(-1);
-  // CPU mode: no NVLink, only RDMA (if NICs available).
-  EXPECT_EQ(factoryCount(factory), 1u);
-  EXPECT_EQ(factoryTransportType(factory, 0), TransportType::RDMA);
+  // TCP is opt-in.
+  MultiTransportFactoryOptions opts;
+  opts.enableTcp = true;
+  MultiTransportFactory factory(-1, opts);
+  ASSERT_GE(factoryCount(factory), 1u);
+  EXPECT_EQ(
+      factoryTransportType(factory, factoryCount(factory) - 1),
+      TransportType::TCP);
+  if (rdmaSupported) {
+    EXPECT_EQ(factoryTransportType(factory, 0), TransportType::RDMA);
+    EXPECT_EQ(factoryCount(factory), 2u);
+  }
 }
 
-TEST_F(MultiTransportFactoryTest, ConstructorGpuCreatesNvlinkAndRdma) {
+// TCP is skipped when only a loopback bind address is available, so a loopback-
+// bound TCP transport cannot break cross-host connections.
+TEST_F(MultiTransportFactoryTest, ConstructorOmitsTcpOnLoopbackBindHost) {
+  MultiTransportFactoryOptions opts;
+  opts.tcpBindHost = "127.0.0.1";
+  MultiTransportFactory factory(-1, opts);
+  for (size_t i = 0; i < factoryCount(factory); ++i) {
+    EXPECT_NE(factoryTransportType(factory, i), TransportType::TCP);
+  }
+}
+
+// TCP auto-registers (without enableTcp) when a routable bind address resolves.
+TEST_F(MultiTransportFactoryTest, ConstructorRegistersTcpWhenRoutable) {
+  MultiTransportFactoryOptions opts;
+  opts.tcpBindHost =
+      "2401:db00:eef0:1120:3520:0:0:1"; // routable (non-loopback)
+  MultiTransportFactory factory(-1, opts);
+  bool hasTcp = false;
+  for (size_t i = 0; i < factoryCount(factory); ++i) {
+    if (factoryTransportType(factory, i) == TransportType::TCP) {
+      hasTcp = true;
+    }
+  }
+  EXPECT_TRUE(hasTcp);
+}
+
+TEST_F(MultiTransportFactoryTest, ConstructorGpuCreatesNvlinkAndOptionalRdma) {
   if (topo_->gpuCount() == 0) {
     GTEST_SKIP() << "No GPUs available";
   }
 
-  MultiTransportFactory factory(0);
+  MultiTransportFactoryOptions opts;
+  opts.enableTcp = true;
+  MultiTransportFactory factory(0, opts);
   ASSERT_GE(factoryCount(factory), 1u);
+  EXPECT_EQ(
+      factoryTransportType(factory, factoryCount(factory) - 1),
+      TransportType::TCP);
 #if defined(__HIP_PLATFORM_AMD__)
-  // On AMD the NVLink tier is served by the P2P (XGMI) transport, registered
-  // only on all-XGMI nodes (gfx942/gfx950/gfx1250); otherwise the GPU factory
-  // falls back to RDMA. Gate the expectation on the same condition the
-  // constructor uses (see MultiTransport.cpp).
-  if (!MultiTransportFactory::supported(TransportType::NVLink).hasError()) {
-    EXPECT_EQ(factoryTransportType(factory, 0), TransportType::NVLink);
-    if (factoryCount(factory) > 1) {
-      EXPECT_EQ(factoryTransportType(factory, 1), TransportType::RDMA);
-    }
-  } else {
-    EXPECT_EQ(factoryTransportType(factory, 0), TransportType::RDMA);
+  // Registration order is [interconnect tier?, RDMA?, TCP]; each earlier tier
+  // is present only if its hardware is. On AMD the interconnect tier is
+  // P2P/XGMI (advertised as TransportType::NVLink), registered only on all-XGMI
+  // nodes; RDMA is registered only when a NIC is present. TCP is last (asserted
+  // above). Walk the earlier tiers by index, gating each on availability -- a
+  // node may have P2P but no RDMA NIC (or vice versa), so don't assume a fixed
+  // RDMA index.
+  const bool nvlinkSupported =
+      !MultiTransportFactory::supported(TransportType::NVLink).hasError();
+  const bool rdmaSupported = isPlatformSupported("").hasValue();
+  size_t idx = 0;
+  if (nvlinkSupported) {
+    ASSERT_GT(factoryCount(factory), idx);
+    EXPECT_EQ(factoryTransportType(factory, idx++), TransportType::NVLink);
+  }
+  if (rdmaSupported) {
+    ASSERT_GT(factoryCount(factory), idx);
+    EXPECT_EQ(factoryTransportType(factory, idx++), TransportType::RDMA);
   }
 #else
-  // GPU mode: NVLink factory first, then RDMA if PIX NICs exist.
-  EXPECT_EQ(factoryTransportType(factory, 0), TransportType::NVLink);
   if (factoryCount(factory) > 1) {
+    EXPECT_EQ(factoryTransportType(factory, 0), TransportType::NVLink);
+  }
+  if (factoryCount(factory) > 2) {
     EXPECT_EQ(factoryTransportType(factory, 1), TransportType::RDMA);
   }
 #endif
@@ -192,5 +237,50 @@ TEST_F(MultiTransportFactoryTest, ConstructorRejectsInvalidDeviceId) {
   EXPECT_THROW(MultiTransportFactory factory(gpuCount), std::runtime_error);
   EXPECT_THROW(MultiTransportFactory factory(-2), std::runtime_error);
 }
+
+TEST_F(
+    MultiTransportFactoryTest,
+    ConstructorRejectsTcpRequestWithoutBindConfig) {
+  // Requesting TCP via preferred/intra/interNodeTransport requires enableTcp
+  // AND a bind host; otherwise TCP can't register and selection would silently
+  // fall back. Fail fast at construction.
+  MultiTransportFactoryOptions preferredNoConfig;
+  preferredNoConfig.preferredTransport = TransportType::TCP;
+  EXPECT_THROW(
+      MultiTransportFactory factory(-1, preferredNoConfig),
+      std::invalid_argument);
+
+  MultiTransportFactoryOptions interEnabledNoBind;
+  interEnabledNoBind.interNodeTransport = TransportType::TCP;
+  interEnabledNoBind.enableTcp = true; // bind host still empty
+  EXPECT_THROW(
+      MultiTransportFactory factory(-1, interEnabledNoBind),
+      std::invalid_argument);
+
+  // Fully configured TCP request (enableTcp + routable bind) does not throw.
+  MultiTransportFactoryOptions configured;
+  configured.preferredTransport = TransportType::TCP;
+  configured.enableTcp = true;
+  configured.tcpBindHost = "::1";
+  EXPECT_NO_THROW(MultiTransportFactory factory(-1, configured));
+}
+#else
+TEST_F(MultiTransportFactoryTest, TcpCapabilityIsNotImplemented) {
+  auto status = MultiTransportFactory::supported(TransportType::TCP);
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::NotImplemented);
+}
+
+TEST_F(MultiTransportFactoryTest, ConstructorNeverRegistersTcp) {
+  MultiTransportFactoryOptions opts;
+  opts.enableTcp = true;
+  opts.tcpBindHost = "127.0.0.1";
+  opts.preferredTransport = TransportType::TCP;
+  MultiTransportFactory factory(-1, opts);
+  for (size_t i = 0; i < factoryCount(factory); ++i) {
+    EXPECT_NE(factoryTransportType(factory, i), TransportType::TCP);
+  }
+}
+#endif
 
 } // namespace uniflow

--- a/comms/uniflow/tests/integration/MultiTransportSingleHostTest.cpp
+++ b/comms/uniflow/tests/integration/MultiTransportSingleHostTest.cpp
@@ -146,42 +146,86 @@ TEST_F(MultiTransportFactoryTest, SelectNicsGpuGB200) {
 }
 
 // --- Constructor integration tests ---
-TEST_F(MultiTransportFactoryTest, ConstructorCpuCreatesRdmaFactory) {
-  auto st = isPlatformSupported("");
-  if (!st) {
-    GTEST_SKIP() << st.error().message();
-  }
+TEST_F(MultiTransportFactoryTest, ConstructorCpuCreatesTcpAndOptionalRdma) {
+  const auto rdmaSupported = isPlatformSupported("").hasValue();
 
-  MultiTransportFactory factory(-1);
-  // CPU mode: no NVLink, only RDMA (if NICs available).
-  EXPECT_EQ(factoryCount(factory), 1u);
-  EXPECT_EQ(factoryTransportType(factory, 0), TransportType::RDMA);
+  // TCP is opt-in.
+  MultiTransportFactoryOptions opts;
+  opts.enableTcp = true;
+  MultiTransportFactory factory(-1, opts);
+  ASSERT_GE(factoryCount(factory), 1u);
+  EXPECT_EQ(
+      factoryTransportType(factory, factoryCount(factory) - 1),
+      TransportType::TCP);
+  if (rdmaSupported) {
+    EXPECT_EQ(factoryTransportType(factory, 0), TransportType::RDMA);
+    EXPECT_EQ(factoryCount(factory), 2u);
+  }
 }
 
-TEST_F(MultiTransportFactoryTest, ConstructorGpuCreatesNvlinkAndRdma) {
+// TCP is skipped when only a loopback bind address is available, so a loopback-
+// bound TCP transport cannot break cross-host connections.
+TEST_F(MultiTransportFactoryTest, ConstructorOmitsTcpOnLoopbackBindHost) {
+  MultiTransportFactoryOptions opts;
+  opts.tcpBindHost = "127.0.0.1";
+  MultiTransportFactory factory(-1, opts);
+  for (size_t i = 0; i < factoryCount(factory); ++i) {
+    EXPECT_NE(factoryTransportType(factory, i), TransportType::TCP);
+  }
+}
+
+// TCP auto-registers (without enableTcp) when a routable bind address resolves.
+TEST_F(MultiTransportFactoryTest, ConstructorRegistersTcpWhenRoutable) {
+  MultiTransportFactoryOptions opts;
+  opts.tcpBindHost =
+      "2401:db00:eef0:1120:3520:0:0:1"; // routable (non-loopback)
+  MultiTransportFactory factory(-1, opts);
+  bool hasTcp = false;
+  for (size_t i = 0; i < factoryCount(factory); ++i) {
+    if (factoryTransportType(factory, i) == TransportType::TCP) {
+      hasTcp = true;
+    }
+  }
+  EXPECT_TRUE(hasTcp);
+}
+
+TEST_F(MultiTransportFactoryTest, ConstructorGpuCreatesNvlinkAndOptionalRdma) {
   if (topo_->gpuCount() == 0) {
     GTEST_SKIP() << "No GPUs available";
   }
 
-  MultiTransportFactory factory(0);
+  MultiTransportFactoryOptions opts;
+  opts.enableTcp = true;
+  MultiTransportFactory factory(0, opts);
   ASSERT_GE(factoryCount(factory), 1u);
+  EXPECT_EQ(
+      factoryTransportType(factory, factoryCount(factory) - 1),
+      TransportType::TCP);
 #if defined(__HIP_PLATFORM_AMD__)
-  // On AMD the NVLink tier is served by the P2P (XGMI) transport, registered
-  // only on all-XGMI nodes (gfx942/gfx950/gfx1250); otherwise the GPU factory
-  // falls back to RDMA. Gate the expectation on the same condition the
-  // constructor uses (see MultiTransport.cpp).
-  if (!MultiTransportFactory::supported(TransportType::NVLink).hasError()) {
-    EXPECT_EQ(factoryTransportType(factory, 0), TransportType::NVLink);
-    if (factoryCount(factory) > 1) {
-      EXPECT_EQ(factoryTransportType(factory, 1), TransportType::RDMA);
-    }
-  } else {
-    EXPECT_EQ(factoryTransportType(factory, 0), TransportType::RDMA);
+  // Registration order is [interconnect tier?, RDMA?, TCP]; each earlier tier
+  // is present only if its hardware is. On AMD the interconnect tier is
+  // P2P/XGMI (advertised as TransportType::NVLink), registered only on all-XGMI
+  // nodes; RDMA is registered only when a NIC is present. TCP is last (asserted
+  // above). Walk the earlier tiers by index, gating each on availability -- a
+  // node may have P2P but no RDMA NIC (or vice versa), so don't assume a fixed
+  // RDMA index.
+  const bool nvlinkSupported =
+      !MultiTransportFactory::supported(TransportType::NVLink).hasError();
+  const bool rdmaSupported = isPlatformSupported("").hasValue();
+  size_t idx = 0;
+  if (nvlinkSupported) {
+    ASSERT_GT(factoryCount(factory), idx);
+    EXPECT_EQ(factoryTransportType(factory, idx++), TransportType::NVLink);
+  }
+  if (rdmaSupported) {
+    ASSERT_GT(factoryCount(factory), idx);
+    EXPECT_EQ(factoryTransportType(factory, idx++), TransportType::RDMA);
   }
 #else
-  // GPU mode: NVLink factory first, then RDMA if PIX NICs exist.
-  EXPECT_EQ(factoryTransportType(factory, 0), TransportType::NVLink);
   if (factoryCount(factory) > 1) {
+    EXPECT_EQ(factoryTransportType(factory, 0), TransportType::NVLink);
+  }
+  if (factoryCount(factory) > 2) {
     EXPECT_EQ(factoryTransportType(factory, 1), TransportType::RDMA);
   }
 #endif
@@ -191,6 +235,33 @@ TEST_F(MultiTransportFactoryTest, ConstructorRejectsInvalidDeviceId) {
   int gpuCount = static_cast<int>(topo_->gpuCount());
   EXPECT_THROW(MultiTransportFactory factory(gpuCount), std::runtime_error);
   EXPECT_THROW(MultiTransportFactory factory(-2), std::runtime_error);
+}
+
+TEST_F(
+    MultiTransportFactoryTest,
+    ConstructorRejectsTcpRequestWithoutBindConfig) {
+  // Requesting TCP via preferred/intra/interNodeTransport requires enableTcp
+  // AND a bind host; otherwise TCP can't register and selection would silently
+  // fall back. Fail fast at construction.
+  MultiTransportFactoryOptions preferredNoConfig;
+  preferredNoConfig.preferredTransport = TransportType::TCP;
+  EXPECT_THROW(
+      MultiTransportFactory factory(-1, preferredNoConfig),
+      std::invalid_argument);
+
+  MultiTransportFactoryOptions interEnabledNoBind;
+  interEnabledNoBind.interNodeTransport = TransportType::TCP;
+  interEnabledNoBind.enableTcp = true; // bind host still empty
+  EXPECT_THROW(
+      MultiTransportFactory factory(-1, interEnabledNoBind),
+      std::invalid_argument);
+
+  // Fully configured TCP request (enableTcp + routable bind) does not throw.
+  MultiTransportFactoryOptions configured;
+  configured.preferredTransport = TransportType::TCP;
+  configured.enableTcp = true;
+  configured.tcpBindHost = "::1";
+  EXPECT_NO_THROW(MultiTransportFactory factory(-1, configured));
 }
 
 } // namespace uniflow

--- a/comms/uniflow/tests/unit/MultiTransportTest.cpp
+++ b/comms/uniflow/tests/unit/MultiTransportTest.cpp
@@ -388,6 +388,7 @@ TEST_F(MultiTransportFactoryTest, DefaultOptionsUseBoundedNumaLocalCpuNics) {
   EXPECT_EQ(
       options.cpuNicSelectionPolicy, CpuNicSelectionPolicy::kNumaLocalBounded);
   EXPECT_EQ(options.maxCpuNics, 2u);
+  EXPECT_FALSE(options.preferredTransport.has_value());
 }
 
 TEST_F(MultiTransportFactoryTest, RegisterSegmentSingleFactory) {
@@ -840,6 +841,74 @@ TEST_F(MultiTransportTest, DramPutRoutesToRdma) {
   EXPECT_TRUE(future.get().hasValue());
   EXPECT_EQ(rdma->putCount, 1);
   EXPECT_EQ(nvlink->putCount, 0);
+}
+
+TEST_F(MultiTransportTest, PreferredTcpOverridesRdma) {
+  MultiTransport mt(
+      0,
+      nullptr,
+      /*intraNodeTransport=*/std::nullopt,
+      /*preferredTransport=*/TransportType::TCP);
+  auto* rdma = addMock(mt, TransportType::RDMA);
+  auto* tcp = addMock(mt, TransportType::TCP);
+
+  TestSegments local(
+      MemoryType::DRAM, -1, {TransportType::RDMA, TransportType::TCP});
+  TestSegments remote(
+      MemoryType::DRAM, -1, {TransportType::RDMA, TransportType::TCP});
+  std::vector<TransferRequest> reqs = {
+      {local.regSeg.span(size_t{0}, size_t{32}),
+       remote.remoteSeg.span(size_t{0}, size_t{32})}};
+
+  auto future = mt.put(reqs);
+  EXPECT_TRUE(future.get().hasValue());
+  EXPECT_EQ(tcp->putCount, 1);
+  EXPECT_EQ(rdma->putCount, 0);
+}
+
+TEST_F(MultiTransportTest, IntraNodeTransportOverrideRoutesVramToTcp) {
+  MultiTransport mt(0, nullptr, /*intraNodeTransport=*/TransportType::TCP);
+  auto* nvlink = addMock(mt, TransportType::NVLink);
+  auto* rdma = addMock(mt, TransportType::RDMA);
+  auto* tcp = addMock(mt, TransportType::TCP);
+
+  const std::vector<TransportType> h = {
+      TransportType::NVLink, TransportType::RDMA, TransportType::TCP};
+  TestSegments local(MemoryType::VRAM, 0, h);
+  TestSegments remote(MemoryType::VRAM, 0, h);
+  std::vector<TransferRequest> reqs = {
+      {local.regSeg.span(size_t{0}, size_t{32}),
+       remote.remoteSeg.span(size_t{0}, size_t{32})}};
+
+  EXPECT_TRUE(mt.put(reqs).get().hasValue());
+  EXPECT_EQ(tcp->putCount, 1);
+  EXPECT_EQ(nvlink->putCount, 0);
+  EXPECT_EQ(rdma->putCount, 0);
+}
+
+TEST_F(MultiTransportTest, InterNodeTransportOverrideRoutesToTcp) {
+  // Inter-node transfer (DRAM, not VRAM<->VRAM-same-device);
+  // interNodeTransport=TCP switches the inter-node default RDMA -> TCP.
+  MultiTransport mt(
+      0,
+      nullptr,
+      /*intraNodeTransport=*/std::nullopt,
+      /*preferredTransport=*/std::nullopt,
+      /*interNodeTransport=*/TransportType::TCP);
+  auto* rdma = addMock(mt, TransportType::RDMA);
+  auto* tcp = addMock(mt, TransportType::TCP);
+
+  const std::vector<TransportType> h = {
+      TransportType::RDMA, TransportType::TCP};
+  TestSegments local(MemoryType::DRAM, -1, h);
+  TestSegments remote(MemoryType::DRAM, -1, h);
+  std::vector<TransferRequest> reqs = {
+      {local.regSeg.span(size_t{0}, size_t{32}),
+       remote.remoteSeg.span(size_t{0}, size_t{32})}};
+
+  EXPECT_TRUE(mt.put(reqs).get().hasValue());
+  EXPECT_EQ(tcp->putCount, 1);
+  EXPECT_EQ(rdma->putCount, 0);
 }
 
 TEST_F(MultiTransportTest, VramGetRoutesToNvLink) {

--- a/comms/uniflow/tests/unit/MultiTransportTest.cpp
+++ b/comms/uniflow/tests/unit/MultiTransportTest.cpp
@@ -388,6 +388,7 @@ TEST_F(MultiTransportFactoryTest, DefaultOptionsUseBoundedNumaLocalCpuNics) {
   EXPECT_EQ(
       options.cpuNicSelectionPolicy, CpuNicSelectionPolicy::kNumaLocalBounded);
   EXPECT_EQ(options.maxCpuNics, 2u);
+  EXPECT_FALSE(options.preferredTransport.has_value());
 }
 
 TEST_F(MultiTransportFactoryTest, RegisterSegmentSingleFactory) {
@@ -841,6 +842,124 @@ TEST_F(MultiTransportTest, DramPutRoutesToRdma) {
   EXPECT_EQ(rdma->putCount, 1);
   EXPECT_EQ(nvlink->putCount, 0);
 }
+
+#ifdef UNIFLOW_ENABLE_TCP_TRANSPORT
+TEST_F(MultiTransportTest, PreferredTcpOverridesRdma) {
+  MultiTransport mt(
+      0,
+      nullptr,
+      /*intraNodeTransport=*/std::nullopt,
+      /*preferredTransport=*/TransportType::TCP);
+  auto* rdma = addMock(mt, TransportType::RDMA);
+  auto* tcp = addMock(mt, TransportType::TCP);
+
+  TestSegments local(
+      MemoryType::DRAM, -1, {TransportType::RDMA, TransportType::TCP});
+  TestSegments remote(
+      MemoryType::DRAM, -1, {TransportType::RDMA, TransportType::TCP});
+  std::vector<TransferRequest> reqs = {
+      {local.regSeg.span(size_t{0}, size_t{32}),
+       remote.remoteSeg.span(size_t{0}, size_t{32})}};
+
+  auto future = mt.put(reqs);
+  EXPECT_TRUE(future.get().hasValue());
+  EXPECT_EQ(tcp->putCount, 1);
+  EXPECT_EQ(rdma->putCount, 0);
+}
+
+TEST_F(MultiTransportTest, IntraNodeTransportOverrideRoutesVramToTcp) {
+  MultiTransport mt(0, nullptr, /*intraNodeTransport=*/TransportType::TCP);
+  auto* nvlink = addMock(mt, TransportType::NVLink);
+  auto* rdma = addMock(mt, TransportType::RDMA);
+  auto* tcp = addMock(mt, TransportType::TCP);
+
+  const std::vector<TransportType> h = {
+      TransportType::NVLink, TransportType::RDMA, TransportType::TCP};
+  TestSegments local(MemoryType::VRAM, 0, h);
+  TestSegments remote(MemoryType::VRAM, 0, h);
+  std::vector<TransferRequest> reqs = {
+      {local.regSeg.span(size_t{0}, size_t{32}),
+       remote.remoteSeg.span(size_t{0}, size_t{32})}};
+
+  EXPECT_TRUE(mt.put(reqs).get().hasValue());
+  EXPECT_EQ(tcp->putCount, 1);
+  EXPECT_EQ(nvlink->putCount, 0);
+  EXPECT_EQ(rdma->putCount, 0);
+}
+
+TEST_F(MultiTransportTest, InterNodeTransportOverrideRoutesToTcp) {
+  MultiTransport mt(
+      0,
+      nullptr,
+      /*intraNodeTransport=*/std::nullopt,
+      /*preferredTransport=*/std::nullopt,
+      /*interNodeTransport=*/TransportType::TCP);
+  auto* rdma = addMock(mt, TransportType::RDMA);
+  auto* tcp = addMock(mt, TransportType::TCP);
+
+  const std::vector<TransportType> h = {
+      TransportType::RDMA, TransportType::TCP};
+  TestSegments local(MemoryType::DRAM, -1, h);
+  TestSegments remote(MemoryType::DRAM, -1, h);
+  std::vector<TransferRequest> reqs = {
+      {local.regSeg.span(size_t{0}, size_t{32}),
+       remote.remoteSeg.span(size_t{0}, size_t{32})}};
+
+  EXPECT_TRUE(mt.put(reqs).get().hasValue());
+  EXPECT_EQ(tcp->putCount, 1);
+  EXPECT_EQ(rdma->putCount, 0);
+}
+#else
+TEST_F(MultiTransportTest, PreferredTcpReturnsNotImplemented) {
+  MultiTransport mt(
+      0,
+      nullptr,
+      /*intraNodeTransport=*/std::nullopt,
+      /*preferredTransport=*/TransportType::TCP);
+  auto* rdma = addMock(mt, TransportType::RDMA);
+
+  TestSegments local(MemoryType::DRAM, -1, {TransportType::RDMA});
+  TestSegments remote(MemoryType::DRAM, -1, {TransportType::RDMA});
+  std::vector<TransferRequest> reqs = {
+      {local.regSeg.span(size_t{0}, size_t{32}),
+       remote.remoteSeg.span(size_t{0}, size_t{32})}};
+
+  auto status = mt.put(reqs).get();
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::NotImplemented);
+  EXPECT_EQ(rdma->putCount, 0);
+}
+
+TEST_F(MultiTransportTest, CommonTcpOnlyReturnsNotImplemented) {
+  MultiTransport mt(0);
+  TestSegments local(MemoryType::DRAM, -1, {TransportType::TCP});
+  TestSegments remote(MemoryType::DRAM, -1, {TransportType::TCP});
+  std::vector<TransferRequest> reqs = {
+      {local.regSeg.span(size_t{0}, size_t{32}),
+       remote.remoteSeg.span(size_t{0}, size_t{32})}};
+
+  auto status = mt.put(reqs).get();
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::NotImplemented);
+}
+
+TEST_F(MultiTransportTest, DisjointTcpBatchReturnsNotConnected) {
+  MultiTransport mt(0);
+  TestSegments tcpLocal(MemoryType::DRAM, -1, {TransportType::TCP});
+  TestSegments tcpRemote(MemoryType::DRAM, -1, {TransportType::TCP});
+  TestSegments rdmaLocal(MemoryType::DRAM, -1, {TransportType::RDMA});
+  TestSegments rdmaRemote(MemoryType::DRAM, -1, {TransportType::RDMA});
+  std::vector<TransferRequest> reqs = {
+      {tcpLocal.regSeg.span(size_t{0}, size_t{32}),
+       tcpRemote.remoteSeg.span(size_t{0}, size_t{32})},
+      {rdmaLocal.regSeg.span(size_t{0}, size_t{32}),
+       rdmaRemote.remoteSeg.span(size_t{0}, size_t{32})}};
+
+  auto status = mt.put(reqs).get();
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::NotConnected);
+}
+#endif
 
 TEST_F(MultiTransportTest, VramGetRoutesToNvLink) {
   MultiTransport mt(0);

--- a/comms/uniflow/transport/CMakeLists.txt
+++ b/comms/uniflow/transport/CMakeLists.txt
@@ -26,3 +26,4 @@ target_include_directories(uniflow_transport PUBLIC
 # Sub-components
 add_subdirectory(nvlink)
 add_subdirectory(rdma)
+add_subdirectory(tcp)

--- a/comms/uniflow/transport/CMakeLists.txt
+++ b/comms/uniflow/transport/CMakeLists.txt
@@ -26,3 +26,6 @@ target_include_directories(uniflow_transport PUBLIC
 # Sub-components
 add_subdirectory(nvlink)
 add_subdirectory(rdma)
+if(UNIFLOW_ENABLE_TCP_TRANSPORT)
+  add_subdirectory(tcp)
+endif()

--- a/comms/uniflow/transport/nvlink/NVLinkTransport.cpp
+++ b/comms/uniflow/transport/nvlink/NVLinkTransport.cpp
@@ -210,7 +210,7 @@ std::future<Status> NVLinkTransport::put(
       return make_ready_future<Status>(std::move(remoteHandle).error());
     }
     auto* remoteDst = static_cast<uint8_t*>(remoteHandle.value()->mappedPtr()) +
-        req.remote.nvlinkOffset_;
+        req.remote.remoteOffset_;
     ops.emplace_back(remoteDst, req.local.data(), req.local.size());
   }
 
@@ -253,7 +253,7 @@ std::future<Status> NVLinkTransport::get(
       return make_ready_future<Status>(std::move(remoteHandle).error());
     }
     auto* remoteSrc = static_cast<uint8_t*>(remoteHandle.value()->mappedPtr()) +
-        req.remote.nvlinkOffset_;
+        req.remote.remoteOffset_;
     ops.emplace_back(req.local.mutable_data(), remoteSrc, req.remote.size());
   }
 

--- a/comms/uniflow/transport/p2p/P2pTransport.cpp
+++ b/comms/uniflow/transport/p2p/P2pTransport.cpp
@@ -282,7 +282,7 @@ Result<std::vector<P2pTransport::CopyOp>> P2pTransport::buildCopyOps(
     if (mappedBase == nullptr) {
       return Err(ErrCode::InvalidArgument, "P2P: null mapped pointer");
     }
-    auto* remotePtr = mappedBase + req.remote.nvlinkOffset_;
+    auto* remotePtr = mappedBase + req.remote.remoteOffset_;
 
     if (dir == Dir::Put) {
       ops.emplace_back(CopyOp{remotePtr, req.local.data(), req.local.size()});

--- a/comms/uniflow/transport/tcp/CMakeLists.txt
+++ b/comms/uniflow/transport/tcp/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+set(UNIFLOW_TCP_TRANSPORT_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/TcpRegistrationHandle.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/TcpTransport.cpp
+)
+
+set(UNIFLOW_TCP_TRANSPORT_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/TcpRegistrationHandle.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/TcpTransport.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/TcpWireProtocol.h
+)
+
+add_library(uniflow_tcp_transport OBJECT
+    ${UNIFLOW_TCP_TRANSPORT_SOURCES}
+    ${UNIFLOW_TCP_TRANSPORT_HEADERS}
+)
+
+target_compile_features(uniflow_tcp_transport PUBLIC cxx_std_20)
+
+target_compile_options(uniflow_tcp_transport PRIVATE -fPIC)
+
+target_include_directories(uniflow_tcp_transport PUBLIC
+    ${ROOT}
+)

--- a/comms/uniflow/transport/tcp/TcpRegistrationHandle.cpp
+++ b/comms/uniflow/transport/tcp/TcpRegistrationHandle.cpp
@@ -1,0 +1,62 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/transport/tcp/TcpRegistrationHandle.h"
+
+#include <cstring>
+
+namespace uniflow {
+
+TcpRegistrationHandle::TcpRegistrationHandle(
+    uint64_t segId,
+    uint64_t len,
+    std::function<void()> onDestroy)
+    : segId_(segId), len_(len), onDestroy_(std::move(onDestroy)) {}
+
+TcpRegistrationHandle::~TcpRegistrationHandle() {
+  if (onDestroy_) {
+    onDestroy_();
+  }
+}
+
+std::vector<uint8_t> TcpRegistrationHandle::serialize() const {
+  Header header{
+      .segId = segId_,
+      .len = len_,
+  };
+  std::vector<uint8_t> data(sizeof(Header));
+  std::memcpy(data.data(), &header, sizeof(header));
+  return data;
+}
+
+TcpRemoteRegistrationHandle::TcpRemoteRegistrationHandle(
+    uint64_t segId,
+    uint64_t len)
+    : segId_(segId), len_(len) {}
+
+Result<std::unique_ptr<TcpRemoteRegistrationHandle>>
+TcpRemoteRegistrationHandle::deserialize(
+    size_t segmentLength,
+    std::span<const uint8_t> payload) {
+  if (payload.size() < sizeof(TcpRegistrationHandle::Header)) {
+    return Err(
+        ErrCode::InvalidArgument,
+        "tcp registration payload is smaller than its header");
+  }
+
+  TcpRegistrationHandle::Header header;
+  std::memcpy(&header, payload.data(), sizeof(header));
+
+  if (payload.size() != sizeof(header)) {
+    return Err(
+        ErrCode::InvalidArgument, "tcp registration payload size mismatch");
+  }
+  if (header.len != segmentLength) {
+    return Err(
+        ErrCode::InvalidArgument,
+        "tcp registration length does not match segment length");
+  }
+  return std::make_unique<TcpRemoteRegistrationHandle>(
+      header.segId, header.len);
+}
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/TcpRegistrationHandle.cpp
+++ b/comms/uniflow/transport/tcp/TcpRegistrationHandle.cpp
@@ -1,0 +1,65 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/transport/tcp/TcpRegistrationHandle.h"
+
+#include <cstring>
+
+namespace uniflow {
+
+TcpRegistrationHandle::TcpRegistrationHandle(
+    uint64_t segId,
+    uint64_t base,
+    uint64_t len,
+    std::function<void()> onDestroy)
+    : segId_(segId), base_(base), len_(len), onDestroy_(std::move(onDestroy)) {}
+
+TcpRegistrationHandle::~TcpRegistrationHandle() {
+  if (onDestroy_) {
+    onDestroy_();
+  }
+}
+
+std::vector<uint8_t> TcpRegistrationHandle::serialize() const {
+  Header header{
+      .segId = segId_,
+      .base = base_,
+      .len = len_,
+  };
+  std::vector<uint8_t> data(sizeof(Header));
+  std::memcpy(data.data(), &header, sizeof(header));
+  return data;
+}
+
+TcpRemoteRegistrationHandle::TcpRemoteRegistrationHandle(
+    uint64_t segId,
+    uint64_t base,
+    uint64_t len)
+    : segId_(segId), base_(base), len_(len) {}
+
+Result<std::unique_ptr<TcpRemoteRegistrationHandle>>
+TcpRemoteRegistrationHandle::deserialize(
+    size_t segmentLength,
+    std::span<const uint8_t> payload) {
+  if (payload.size() < sizeof(TcpRegistrationHandle::Header)) {
+    return Err(
+        ErrCode::InvalidArgument,
+        "tcp registration payload is smaller than its header");
+  }
+
+  TcpRegistrationHandle::Header header;
+  std::memcpy(&header, payload.data(), sizeof(header));
+
+  if (payload.size() != sizeof(header)) {
+    return Err(
+        ErrCode::InvalidArgument, "tcp registration payload size mismatch");
+  }
+  if (header.len != segmentLength) {
+    return Err(
+        ErrCode::InvalidArgument,
+        "tcp registration length does not match segment length");
+  }
+  return std::make_unique<TcpRemoteRegistrationHandle>(
+      header.segId, header.base, header.len);
+}
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/TcpRegistrationHandle.h
+++ b/comms/uniflow/transport/tcp/TcpRegistrationHandle.h
@@ -1,0 +1,94 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <span>
+#include <vector>
+
+#include "comms/uniflow/Result.h"
+#include "comms/uniflow/Segment.h"
+#include "comms/uniflow/transport/TransportType.h"
+
+namespace uniflow {
+
+class TcpRegistrationHandle : public RegistrationHandle {
+ public:
+  struct __attribute__((packed)) Header {
+    uint64_t segId{0};
+    uint64_t base{0};
+    uint64_t len{0};
+  };
+
+  TcpRegistrationHandle(
+      uint64_t segId,
+      uint64_t base,
+      uint64_t len,
+      std::function<void()> onDestroy = {});
+
+  // Deregisters segId_ from the owning registry (RegistrationHandle contract).
+  ~TcpRegistrationHandle() override;
+
+  TcpRegistrationHandle(const TcpRegistrationHandle&) = delete;
+  TcpRegistrationHandle& operator=(const TcpRegistrationHandle&) = delete;
+  TcpRegistrationHandle(TcpRegistrationHandle&&) = delete;
+  TcpRegistrationHandle& operator=(TcpRegistrationHandle&&) = delete;
+
+  TransportType transportType() const noexcept override {
+    return TransportType::TCP;
+  }
+
+  std::vector<uint8_t> serialize() const override;
+
+  uint64_t segId() const noexcept {
+    return segId_;
+  }
+
+  uint64_t base() const noexcept {
+    return base_;
+  }
+
+  uint64_t len() const noexcept {
+    return len_;
+  }
+
+ private:
+  uint64_t segId_{0};
+  uint64_t base_{0};
+  uint64_t len_{0};
+  std::function<void()> onDestroy_;
+};
+
+class TcpRemoteRegistrationHandle : public RemoteRegistrationHandle {
+ public:
+  TcpRemoteRegistrationHandle(uint64_t segId, uint64_t base, uint64_t len);
+
+  static Result<std::unique_ptr<TcpRemoteRegistrationHandle>> deserialize(
+      size_t segmentLength,
+      std::span<const uint8_t> payload);
+
+  TransportType transportType() const noexcept override {
+    return TransportType::TCP;
+  }
+
+  uint64_t segId() const noexcept {
+    return segId_;
+  }
+
+  uint64_t base() const noexcept {
+    return base_;
+  }
+
+  uint64_t len() const noexcept {
+    return len_;
+  }
+
+ private:
+  uint64_t segId_{0};
+  uint64_t base_{0};
+  uint64_t len_{0};
+};
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/TcpRegistrationHandle.h
+++ b/comms/uniflow/transport/tcp/TcpRegistrationHandle.h
@@ -1,0 +1,85 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <span>
+#include <vector>
+
+#include "comms/uniflow/Result.h"
+#include "comms/uniflow/Segment.h"
+#include "comms/uniflow/transport/TransportType.h"
+
+namespace uniflow {
+
+class TcpRegistrationHandle : public RegistrationHandle {
+ public:
+  // Wire format. Deliberately carries no peer virtual address: the receiver
+  // resolves the destination from its own TcpSegmentRegistry by segId, so a
+  // sender-supplied address would be both unused and unsafe to trust.
+  struct __attribute__((packed)) Header {
+    uint64_t segId{0};
+    uint64_t len{0};
+  };
+
+  TcpRegistrationHandle(
+      uint64_t segId,
+      uint64_t len,
+      std::function<void()> onDestroy = {});
+
+  // Deregisters segId_ from the owning registry (RegistrationHandle contract).
+  ~TcpRegistrationHandle() override;
+
+  TcpRegistrationHandle(const TcpRegistrationHandle&) = delete;
+  TcpRegistrationHandle& operator=(const TcpRegistrationHandle&) = delete;
+  TcpRegistrationHandle(TcpRegistrationHandle&&) = delete;
+  TcpRegistrationHandle& operator=(TcpRegistrationHandle&&) = delete;
+
+  TransportType transportType() const noexcept override {
+    return TransportType::TCP;
+  }
+
+  std::vector<uint8_t> serialize() const override;
+
+  uint64_t segId() const noexcept {
+    return segId_;
+  }
+
+  uint64_t len() const noexcept {
+    return len_;
+  }
+
+ private:
+  uint64_t segId_{0};
+  uint64_t len_{0};
+  std::function<void()> onDestroy_;
+};
+
+class TcpRemoteRegistrationHandle : public RemoteRegistrationHandle {
+ public:
+  TcpRemoteRegistrationHandle(uint64_t segId, uint64_t len);
+
+  static Result<std::unique_ptr<TcpRemoteRegistrationHandle>> deserialize(
+      size_t segmentLength,
+      std::span<const uint8_t> payload);
+
+  TransportType transportType() const noexcept override {
+    return TransportType::TCP;
+  }
+
+  uint64_t segId() const noexcept {
+    return segId_;
+  }
+
+  uint64_t len() const noexcept {
+    return len_;
+  }
+
+ private:
+  uint64_t segId_{0};
+  uint64_t len_{0};
+};
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -1,0 +1,989 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/transport/tcp/TcpTransport.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "comms/uniflow/drivers/cuda/CudaApi.h"
+#include "comms/uniflow/logging/Logger.h"
+#include "comms/uniflow/transport/tcp/TcpRegistrationHandle.h"
+#include "comms/uniflow/transport/tcp/TcpWireProtocol.h"
+
+namespace uniflow {
+
+// Completion state shared by all requests in a single put()/get() call. The
+// call's promise is fulfilled once every request's reply has arrived (or on the
+// first error). Thread-safe: touched by the caller thread and the reader
+// thread.
+struct TcpOpState {
+  std::mutex mu;
+  size_t remaining{0};
+  bool done{false};
+  std::promise<Status> promise;
+
+  void completeOne() {
+    std::lock_guard<std::mutex> lk(mu);
+    if (done) {
+      return;
+    }
+    if (remaining > 0) {
+      --remaining;
+    }
+    if (remaining == 0) {
+      done = true;
+      promise.set_value(Ok());
+    }
+  }
+
+  void fail(Status status) {
+    std::lock_guard<std::mutex> lk(mu);
+    if (done) {
+      return;
+    }
+    done = true;
+    promise.set_value(std::move(status));
+  }
+
+  bool isDone() {
+    std::lock_guard<std::mutex> lk(mu);
+    return done;
+  }
+};
+
+namespace {
+
+// The controller frames each TcpConn message with a 4-byte length and caps it
+// at 64 MiB; keep each chunk (header + payload) safely under that so large
+// put/get transfers are split across multiple frames.
+constexpr size_t kMaxChunkSize = 4u << 20; // 4 MiB
+// Hard wire-frame cap from the controller's TcpConn framing (4-byte length,
+// 64 MiB max). send()/recv() are single-frame (no chunking), so a send payload
+// must fit within it; put()/get() chunk and are not bound by this.
+constexpr size_t kMaxFrameSize = 64u << 20; // 64 MiB
+
+std::vector<uint8_t> makeHeaderFrame(TcpOp op, uint64_t reqId) {
+  TcpMsgHeader header;
+  header.op = static_cast<uint8_t>(op);
+  header.reqId = reqId;
+  return serializeTcpHeader(header);
+}
+
+// Representation-independent ordering key for a bind host. Parses IPv6 then
+// IPv4 to raw address bytes so different textual forms of the same address
+// (e.g. 2001:db8::1 vs its fully-expanded form) order and compare equal on both
+// peers; falls back to the raw string for non-numeric hosts. Used only for
+// deterministic listener/dialer role assignment.
+std::string hostOrderKey(const std::string& host) {
+  in6_addr a6{};
+  if (::inet_pton(AF_INET6, host.c_str(), &a6) == 1) {
+    return "6:" + std::string(reinterpret_cast<const char*>(&a6), sizeof(a6));
+  }
+  in_addr a4{};
+  if (::inet_pton(AF_INET, host.c_str(), &a4) == 1) {
+    return "4:" + std::string(reinterpret_cast<const char*>(&a4), sizeof(a4));
+  }
+  return "s:" + host;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// TcpTransportInfo
+// ---------------------------------------------------------------------------
+
+TransportInfo TcpTransportInfo::serialize() const {
+  Header header{
+      .port = port,
+      .hostLen = static_cast<uint16_t>(host.size()),
+  };
+  TransportInfo data(sizeof(Header) + host.size());
+  std::memcpy(data.data(), &header, sizeof(header));
+  if (!host.empty()) {
+    std::memcpy(data.data() + sizeof(header), host.data(), host.size());
+  }
+  return data;
+}
+
+Result<TcpTransportInfo> TcpTransportInfo::deserialize(
+    std::span<const uint8_t> data) {
+  if (data.size() < sizeof(Header)) {
+    return Err(ErrCode::InvalidArgument, "tcp transport info is truncated");
+  }
+
+  Header header;
+  std::memcpy(&header, data.data(), sizeof(header));
+  if (data.size() != sizeof(header) + header.hostLen) {
+    return Err(ErrCode::InvalidArgument, "tcp transport info size mismatch");
+  }
+
+  TcpTransportInfo info;
+  info.port = header.port;
+  info.host.assign(
+      reinterpret_cast<const char*>(data.data() + sizeof(header)),
+      header.hostLen);
+  return info;
+}
+
+// ---------------------------------------------------------------------------
+// TcpTransport
+// ---------------------------------------------------------------------------
+
+TcpTransport::TcpTransport(
+    int deviceId,
+    EventBase* evb,
+    std::shared_ptr<TcpSegmentRegistry> registry,
+    controller::TcpSocketConfig config,
+    std::string host,
+    std::shared_ptr<CudaApi> cudaApi)
+    : deviceId_(deviceId),
+      evb_(evb),
+      registry_(std::move(registry)),
+      cudaApi_(std::move(cudaApi)),
+      config_(std::move(config)) {
+  if (!registry_) {
+    registry_ = std::make_shared<TcpSegmentRegistry>();
+  }
+  if (!cudaApi_) {
+    cudaApi_ = std::make_shared<CudaApi>();
+  }
+  if (!host.empty()) {
+    host_ = std::move(host);
+  }
+}
+
+Status TcpTransport::hostFromDevice(
+    void* hostDst,
+    const void* devSrc,
+    size_t len,
+    int deviceId,
+    void* stream) {
+  if (len == 0) {
+    return Ok();
+  }
+  auto s = static_cast<cudaStream_t>(stream);
+  CudaDeviceGuard guard(*cudaApi_, deviceId);
+  auto st =
+      cudaApi_->memcpyAsync(hostDst, devSrc, len, cudaMemcpyDeviceToHost, s);
+  if (!st) {
+    return st;
+  }
+  return cudaApi_->streamSynchronize(s);
+}
+
+Status TcpTransport::deviceFromHost(
+    void* devDst,
+    const void* hostSrc,
+    size_t len,
+    int deviceId,
+    void* stream) {
+  if (len == 0) {
+    return Ok();
+  }
+  auto s = static_cast<cudaStream_t>(stream);
+  CudaDeviceGuard guard(*cudaApi_, deviceId);
+  auto st =
+      cudaApi_->memcpyAsync(devDst, hostSrc, len, cudaMemcpyHostToDevice, s);
+  if (!st) {
+    return st;
+  }
+  return cudaApi_->streamSynchronize(s);
+}
+
+TcpTransport::~TcpTransport() {
+  shutdown();
+}
+
+TransportInfo TcpTransport::bind() {
+  server_ = std::make_unique<controller::AsyncTcpServer>(
+      host_ + ":0", config_, *evb_);
+  auto status = server_->init();
+  if (!status) {
+    UNIFLOW_LOG_ERROR(
+        "TcpTransport::bind: server init failed: {}", status.error().message());
+    state_ = TransportState::Error;
+    server_.reset();
+    return TransportInfo{};
+  }
+  port_ = static_cast<uint16_t>(server_->getPort());
+  state_ = TransportState::Initialized;
+
+  TcpTransportInfo info;
+  info.host = host_;
+  info.port = port_;
+  return info.serialize();
+}
+
+Status TcpTransport::connect(std::span<const uint8_t> remoteInfo) {
+  if (state_ != TransportState::Initialized) {
+    return Err(
+        ErrCode::InvalidArgument, "tcp connect: transport must be bound first");
+  }
+
+  auto peerResult = TcpTransportInfo::deserialize(remoteInfo);
+  if (!peerResult) {
+    state_ = TransportState::Error;
+    return std::move(peerResult).error();
+  }
+  const auto peer = std::move(peerResult).value();
+
+  // Deterministic role: the smaller (host, port) listens, the other dials.
+  // Compare by the parsed binary address (hostOrderKey), not the raw string, so
+  // different textual forms of the same IPv6 address can't make the two peers
+  // disagree on ordering. Reject the degenerate identical-endpoint case, which
+  // would otherwise leave both peers dialing and nobody accepting (silent
+  // hang).
+  const auto localKey = std::make_tuple(hostOrderKey(host_), port_);
+  const auto peerKey = std::make_tuple(hostOrderKey(peer.host), peer.port);
+  if (localKey == peerKey) {
+    state_ = TransportState::Error;
+    return Err(
+        ErrCode::ConnectionFailed,
+        "tcp connect: local and peer bind address are identical; cannot assign "
+        "distinct listener/dialer roles");
+  }
+  const bool listener = localKey < peerKey;
+
+  std::unique_ptr<controller::Conn> conn;
+  if (listener) {
+    if (!server_) {
+      state_ = TransportState::Error;
+      return Err(ErrCode::ConnectionFailed, "tcp connect: no server bound");
+    }
+    conn = server_->accept().get();
+  } else {
+    controller::AsyncTcpClient client(config_, *evb_);
+    conn = client.connect(peer.host + ":" + std::to_string(peer.port)).get();
+  }
+
+  if (!conn) {
+    state_ = TransportState::Error;
+    return Err(
+        ErrCode::ConnectionFailed, "tcp connect: data connection failed");
+  }
+
+  dataConn_ = std::move(conn);
+  running_.store(true, std::memory_order_release);
+  reader_ = std::thread([this]() { readerLoop(); });
+  sender_ = std::thread([this]() { senderLoop(); });
+  state_ = TransportState::Connected;
+  UNIFLOW_LOG_INFO(
+      "TcpTransport: connected (listener={}) {}:{} <-> {}:{}",
+      listener,
+      host_,
+      port_,
+      peer.host,
+      peer.port);
+  return Ok();
+}
+
+Result<const TcpRemoteRegistrationHandle*> TcpTransport::findRemoteHandle(
+    const RemoteRegisteredSegment::Span& span) const {
+  for (const auto& handle : span.handles_) {
+    if (auto* tcp =
+            dynamic_cast<const TcpRemoteRegistrationHandle*>(handle.get())) {
+      return tcp;
+    }
+  }
+  return Err(
+      ErrCode::InvalidArgument, "tcp: no TCP remote registration handle found");
+}
+
+std::future<Status> TcpTransport::put(
+    std::span<const TransferRequest> requests,
+    const RequestOptions& options) {
+  if (state_ != TransportState::Connected ||
+      connBroken_.load(std::memory_order_acquire)) {
+    return make_ready_future<Status>(
+        Err(ErrCode::NotConnected, "tcp put: not connected"));
+  }
+  if (requests.empty()) {
+    return make_ready_future<Status>(Ok());
+  }
+
+  auto state = std::make_shared<TcpOpState>();
+  auto future = state->promise.get_future();
+
+  // Validate and count chunks up front so the completion counter is exact.
+  size_t totalChunks = 0;
+  for (const auto& req : requests) {
+    if (req.local.size() != req.remote.size()) {
+      state->fail(
+          Err(ErrCode::InvalidArgument,
+              "tcp put: local and remote buffer sizes must match"));
+      return future;
+    }
+    const size_t len = req.local.size();
+    totalChunks += (len == 0) ? 1 : (len + kMaxChunkSize - 1) / kMaxChunkSize;
+  }
+  state->remaining = totalChunks;
+
+  for (const auto& req : requests) {
+    auto remoteHandle = findRemoteHandle(req.remote);
+    if (!remoteHandle) {
+      state->fail(std::move(remoteHandle).error());
+      return future;
+    }
+    const uint64_t segId = remoteHandle.value()->segId();
+    const uint64_t baseOffset = static_cast<uint64_t>(req.remote.nvlinkOffset_);
+    const size_t len = req.local.size();
+    const bool vram = req.local.memType() == MemoryType::VRAM;
+    const int deviceId = req.local.deviceId();
+    const auto* src = static_cast<const uint8_t*>(req.local.data());
+
+    size_t off = 0;
+    do {
+      const size_t chunk = std::min(kMaxChunkSize, len - off);
+      const uint64_t reqId = nextReqId_.fetch_add(1, std::memory_order_relaxed);
+      {
+        std::lock_guard<std::mutex> lk(inflightMu_);
+        inflight_[reqId] = TcpInflight{state, nullptr, chunk, false};
+      }
+      std::vector<uint8_t> frame(sizeof(TcpMsgHeader) + chunk);
+      TcpMsgHeader header;
+      header.op = static_cast<uint8_t>(TcpOp::Write);
+      header.reqId = reqId;
+      header.segId = segId;
+      header.offset = baseOffset + off;
+      header.len = static_cast<uint64_t>(chunk);
+      std::memcpy(frame.data(), &header, sizeof(header));
+      if (chunk > 0) {
+        Status st = Ok();
+        if (vram) {
+          st = hostFromDevice(
+              frame.data() + sizeof(header),
+              src + off,
+              chunk,
+              deviceId,
+              options.stream.has_value()
+                  ? static_cast<void*>(options.stream.value())
+                  : nullptr);
+        } else {
+          std::memcpy(frame.data() + sizeof(header), src + off, chunk);
+        }
+        if (!st) {
+          {
+            std::lock_guard<std::mutex> lk(inflightMu_);
+            inflight_.erase(reqId);
+          }
+          state->fail(std::move(st));
+          return future;
+        }
+      }
+      enqueueFrame(std::move(frame));
+      off += chunk;
+    } while (off < len);
+  }
+
+  return future;
+}
+
+std::future<Status> TcpTransport::get(
+    std::span<const TransferRequest> requests,
+    const RequestOptions& options) {
+  if (state_ != TransportState::Connected ||
+      connBroken_.load(std::memory_order_acquire)) {
+    return make_ready_future<Status>(
+        Err(ErrCode::NotConnected, "tcp get: not connected"));
+  }
+  if (requests.empty()) {
+    return make_ready_future<Status>(Ok());
+  }
+
+  auto state = std::make_shared<TcpOpState>();
+  auto future = state->promise.get_future();
+
+  size_t totalChunks = 0;
+  for (const auto& req : requests) {
+    if (req.local.size() != req.remote.size()) {
+      state->fail(
+          Err(ErrCode::InvalidArgument,
+              "tcp get: local and remote buffer sizes must match"));
+      return future;
+    }
+    const size_t len = req.local.size();
+    totalChunks += (len == 0) ? 1 : (len + kMaxChunkSize - 1) / kMaxChunkSize;
+  }
+  state->remaining = totalChunks;
+
+  for (const auto& req : requests) {
+    auto remoteHandle = findRemoteHandle(req.remote);
+    if (!remoteHandle) {
+      state->fail(std::move(remoteHandle).error());
+      return future;
+    }
+    const uint64_t segId = remoteHandle.value()->segId();
+    const uint64_t baseOffset = static_cast<uint64_t>(req.remote.nvlinkOffset_);
+    const size_t len = req.local.size();
+    const MemoryType memType = req.local.memType();
+    const int deviceId = req.local.deviceId();
+    auto* dst = static_cast<uint8_t*>(req.local.mutable_data());
+
+    size_t off = 0;
+    do {
+      const size_t chunk = std::min(kMaxChunkSize, len - off);
+      const uint64_t reqId = nextReqId_.fetch_add(1, std::memory_order_relaxed);
+      {
+        std::lock_guard<std::mutex> lk(inflightMu_);
+        inflight_[reqId] = TcpInflight{
+            state,
+            dst + off,
+            chunk,
+            true,
+            memType,
+            deviceId,
+            options.stream.has_value()
+                ? static_cast<void*>(options.stream.value())
+                : nullptr};
+      }
+      TcpMsgHeader header;
+      header.op = static_cast<uint8_t>(TcpOp::ReadRequest);
+      header.reqId = reqId;
+      header.segId = segId;
+      header.offset = baseOffset + off;
+      header.len = static_cast<uint64_t>(chunk);
+      enqueueFrame(serializeTcpHeader(header));
+      off += chunk;
+    } while (off < len);
+  }
+
+  return future;
+}
+
+void TcpTransport::enqueueFrame(std::vector<uint8_t> frame) {
+  {
+    std::lock_guard<std::mutex> lk(outMu_);
+    if (outClosed_) {
+      return;
+    }
+    outQueue_.push_back(TcpOutItem{std::move(frame), nullptr});
+  }
+  outCv_.notify_one();
+}
+
+void TcpTransport::enqueueSendFrame(
+    std::vector<uint8_t> frame,
+    std::shared_ptr<TcpOpState> onSent) {
+  {
+    std::lock_guard<std::mutex> lk(outMu_);
+    if (outClosed_) {
+      if (onSent) {
+        onSent->fail(Err(ErrCode::NotConnected, "tcp send: transport closing"));
+      }
+      return;
+    }
+    outQueue_.push_back(TcpOutItem{std::move(frame), std::move(onSent)});
+  }
+  outCv_.notify_one();
+}
+
+void TcpTransport::senderLoop() noexcept {
+  for (;;) {
+    TcpOutItem item;
+    {
+      std::unique_lock<std::mutex> lk(outMu_);
+      outCv_.wait(lk, [this]() { return outClosed_ || !outQueue_.empty(); });
+      if (outClosed_) {
+        return;
+      }
+      item = std::move(outQueue_.front());
+      outQueue_.pop_front();
+    }
+
+    auto result = dataConn_->send(item.bytes).get();
+    if (!result) {
+      UNIFLOW_LOG_ERROR(
+          "tcp sender: send failed: {}", result.error().message());
+      if (item.onSent) {
+        item.onSent->fail(Err(ErrCode::ConnectionFailed, "tcp: send failed"));
+      }
+      failAllPending("tcp: send failed");
+      return;
+    }
+    if (item.onSent) {
+      item.onSent->completeOne();
+    }
+  }
+}
+
+void TcpTransport::readerLoop() noexcept {
+  while (running_.load(std::memory_order_acquire)) {
+    std::vector<uint8_t> msg;
+    auto result = dataConn_->recv(msg).get();
+    if (!result) {
+      // Connection closed, errored, or idle-timed-out; stop reading.
+      break;
+    }
+    handleFrame(msg);
+  }
+  // The reader is the only place that resolves in-flight put/get/recv replies.
+  // If it exits on a recv error (peer disconnect) while requests are still
+  // outstanding and the sender is idle, nothing else would fulfill their
+  // promises and callers would block forever on future.get(). Fail them here.
+  // Idempotent with shutdown()'s own failAllPending().
+  failAllPending("tcp: reader stopped (connection closed or read error)");
+}
+
+void TcpTransport::handleFrame(std::span<const uint8_t> frame) noexcept {
+  auto headerResult = deserializeTcpHeader(frame);
+  if (!headerResult) {
+    UNIFLOW_LOG_ERROR(
+        "tcp: dropping malformed frame: {}", headerResult.error().message());
+    return;
+  }
+  const TcpMsgHeader header = headerResult.value();
+  const auto op = static_cast<TcpOp>(header.op);
+  const std::span<const uint8_t> payload = frame.subspan(sizeof(TcpMsgHeader));
+
+  switch (op) {
+    case TcpOp::Write: {
+      bool ok = false;
+      auto entry = registry_->find(header.segId);
+      if (entry && header.len <= entry->len &&
+          header.offset <= entry->len - header.len &&
+          payload.size() == header.len) {
+        Status st = Ok();
+        if (header.len > 0) {
+          void* dst = static_cast<uint8_t*>(entry->ptr) + header.offset;
+          if (entry->memType == MemoryType::VRAM) {
+            st = deviceFromHost(
+                dst, payload.data(), header.len, entry->deviceId);
+          } else {
+            std::memcpy(dst, payload.data(), header.len);
+          }
+        }
+        ok = !st.hasError();
+      }
+      enqueueFrame(
+          makeHeaderFrame(ok ? TcpOp::Ack : TcpOp::Error, header.reqId));
+      break;
+    }
+
+    case TcpOp::ReadRequest: {
+      auto entry = registry_->find(header.segId);
+      Status readStatus = Ok();
+      if (entry && header.len <= entry->len &&
+          header.offset <= entry->len - header.len) {
+        std::vector<uint8_t> reply(sizeof(TcpMsgHeader) + header.len);
+        TcpMsgHeader replyHeader;
+        replyHeader.op = static_cast<uint8_t>(TcpOp::ReadReply);
+        replyHeader.reqId = header.reqId;
+        replyHeader.segId = header.segId;
+        replyHeader.offset = header.offset;
+        replyHeader.len = header.len;
+        std::memcpy(reply.data(), &replyHeader, sizeof(replyHeader));
+        if (header.len > 0) {
+          const void* src =
+              static_cast<const uint8_t*>(entry->ptr) + header.offset;
+          if (entry->memType == MemoryType::VRAM) {
+            readStatus = hostFromDevice(
+                reply.data() + sizeof(replyHeader),
+                src,
+                header.len,
+                entry->deviceId);
+          } else {
+            std::memcpy(reply.data() + sizeof(replyHeader), src, header.len);
+          }
+        }
+        if (!readStatus.hasError()) {
+          enqueueFrame(std::move(reply));
+        }
+      } else {
+        readStatus = Err(ErrCode::InvalidArgument, "tcp read: bad segment");
+      }
+      if (readStatus.hasError()) {
+        enqueueFrame(makeHeaderFrame(TcpOp::Error, header.reqId));
+      }
+      break;
+    }
+
+    case TcpOp::Send: {
+      if (payload.size() != header.len) {
+        UNIFLOW_LOG_ERROR("tcp send: inbound payload size mismatch");
+        break;
+      }
+      std::shared_ptr<TcpOpState> state;
+      void* dst = nullptr;
+      size_t cap = 0;
+      MemoryType memType = MemoryType::DRAM;
+      int deviceId = -1;
+      bool matched = false;
+      {
+        std::lock_guard<std::mutex> lk(recvMu_);
+        if (!pendingRecvs_.empty()) {
+          auto pr = std::move(pendingRecvs_.front());
+          pendingRecvs_.pop_front();
+          state = std::move(pr.state);
+          dst = pr.dst;
+          cap = pr.cap;
+          memType = pr.memType;
+          deviceId = pr.deviceId;
+          matched = true;
+        } else {
+          unmatchedSends_.emplace_back(payload.begin(), payload.end());
+        }
+      }
+      if (matched && state) {
+        if (payload.size() > cap) {
+          state->fail(
+              Err(ErrCode::InvalidArgument,
+                  "tcp recv: buffer too small for incoming send"));
+        } else {
+          Status st = Ok();
+          if (!payload.empty() && dst != nullptr) {
+            if (memType == MemoryType::VRAM) {
+              st =
+                  deviceFromHost(dst, payload.data(), payload.size(), deviceId);
+            } else {
+              std::memcpy(dst, payload.data(), payload.size());
+            }
+          }
+          if (st.hasError()) {
+            state->fail(std::move(st));
+          } else {
+            state->completeOne();
+          }
+        }
+      }
+      break;
+    }
+
+    case TcpOp::Ack:
+    case TcpOp::ReadReply:
+    case TcpOp::Error: {
+      TcpInflight entry;
+      bool found = false;
+      {
+        std::lock_guard<std::mutex> lk(inflightMu_);
+        auto it = inflight_.find(header.reqId);
+        if (it != inflight_.end()) {
+          entry = std::move(it->second);
+          inflight_.erase(it);
+          found = true;
+        }
+      }
+      if (!found || !entry.state) {
+        break;
+      }
+      if (op == TcpOp::Error) {
+        entry.state->fail(
+            Err(ErrCode::TransportError, "tcp: peer reported an error"));
+      } else if (op == TcpOp::ReadReply) {
+        if (entry.state->isDone()) {
+          // A sibling chunk of this multi-chunk op already resolved the
+          // caller's future (e.g. a prior chunk failed); the caller's local
+          // buffer may be gone. Drop this late reply without touching
+          // entry.dst.
+          break;
+        }
+        if (payload.size() != header.len || header.len != entry.len) {
+          entry.state->fail(Err(
+              ErrCode::TransportError, "tcp get: read reply size mismatch"));
+        } else {
+          Status st = Ok();
+          if (header.len > 0 && entry.dst != nullptr) {
+            if (entry.memType == MemoryType::VRAM) {
+              st = deviceFromHost(
+                  entry.dst,
+                  payload.data(),
+                  header.len,
+                  entry.deviceId,
+                  entry.stream);
+            } else {
+              std::memcpy(entry.dst, payload.data(), header.len);
+            }
+          }
+          if (st.hasError()) {
+            entry.state->fail(std::move(st));
+          } else {
+            entry.state->completeOne();
+          }
+        }
+      } else { // Ack
+        entry.state->completeOne();
+      }
+      break;
+    }
+
+    case TcpOp::Notification:
+      UNIFLOW_LOG_WARN("tcp: unexpected inbound Notification frame");
+      break;
+
+    default:
+      UNIFLOW_LOG_WARN(
+          "tcp: unexpected opcode {}", static_cast<int>(header.op));
+      break;
+  }
+}
+
+void TcpTransport::failAllPending(const char* message) {
+  connBroken_.store(true, std::memory_order_release);
+  {
+    std::lock_guard<std::mutex> lk(inflightMu_);
+    for (auto& [reqId, entry] : inflight_) {
+      if (entry.state) {
+        entry.state->fail(Err(ErrCode::ConnectionFailed, message));
+      }
+    }
+    inflight_.clear();
+  }
+  {
+    std::lock_guard<std::mutex> lk(recvMu_);
+    for (auto& pr : pendingRecvs_) {
+      if (pr.state) {
+        pr.state->fail(Err(ErrCode::ConnectionFailed, message));
+      }
+    }
+    pendingRecvs_.clear();
+    unmatchedSends_.clear();
+  }
+  {
+    std::lock_guard<std::mutex> lk(outMu_);
+    for (auto& item : outQueue_) {
+      if (item.onSent) {
+        item.onSent->fail(Err(ErrCode::ConnectionFailed, message));
+      }
+    }
+    outQueue_.clear();
+  }
+}
+
+std::future<Status> TcpTransport::sendImpl(
+    const void* data,
+    size_t len,
+    MemoryType memType,
+    int deviceId) {
+  if (state_ != TransportState::Connected ||
+      connBroken_.load(std::memory_order_acquire)) {
+    return make_ready_future<Status>(
+        Err(ErrCode::NotConnected, "tcp send: not connected"));
+  }
+  // send() is single-frame (no chunking); reject payloads that would exceed the
+  // wire-frame cap so callers get a diagnostic instead of a silent drop/hang.
+  if (len > kMaxFrameSize - sizeof(TcpMsgHeader)) {
+    return make_ready_future<Status>(
+        Err(ErrCode::InvalidArgument,
+            "tcp send: payload exceeds the 64 MiB wire-frame cap; use put/get "
+            "(which chunk) for large transfers"));
+  }
+  auto state = std::make_shared<TcpOpState>();
+  state->remaining = 1;
+  auto future = state->promise.get_future();
+
+  std::vector<uint8_t> frame(sizeof(TcpMsgHeader) + len);
+  TcpMsgHeader header;
+  header.op = static_cast<uint8_t>(TcpOp::Send);
+  header.len = static_cast<uint64_t>(len);
+  std::memcpy(frame.data(), &header, sizeof(header));
+  if (len > 0 && data != nullptr) {
+    Status st = Ok();
+    if (memType == MemoryType::VRAM) {
+      st = hostFromDevice(frame.data() + sizeof(header), data, len, deviceId);
+    } else {
+      std::memcpy(frame.data() + sizeof(header), data, len);
+    }
+    if (!st) {
+      state->fail(std::move(st));
+      return future;
+    }
+  }
+  enqueueSendFrame(std::move(frame), std::move(state));
+  return future;
+}
+
+std::future<Status> TcpTransport::recvImpl(
+    void* dst,
+    size_t cap,
+    MemoryType memType,
+    int deviceId) {
+  if (state_ != TransportState::Connected ||
+      connBroken_.load(std::memory_order_acquire)) {
+    return make_ready_future<Status>(
+        Err(ErrCode::NotConnected, "tcp recv: not connected"));
+  }
+  auto state = std::make_shared<TcpOpState>();
+  state->remaining = 1;
+  auto future = state->promise.get_future();
+
+  std::vector<uint8_t> payload;
+  bool matched = false;
+  {
+    std::lock_guard<std::mutex> lk(recvMu_);
+    if (!unmatchedSends_.empty()) {
+      payload = std::move(unmatchedSends_.front());
+      unmatchedSends_.pop_front();
+      matched = true;
+    } else {
+      pendingRecvs_.push_back(
+          TcpPendingRecv{dst, cap, state, memType, deviceId});
+    }
+  }
+  if (matched) {
+    if (payload.size() > cap) {
+      state->fail(
+          Err(ErrCode::InvalidArgument,
+              "tcp recv: buffer too small for buffered send"));
+    } else {
+      Status st = Ok();
+      if (!payload.empty() && dst != nullptr) {
+        if (memType == MemoryType::VRAM) {
+          st = deviceFromHost(dst, payload.data(), payload.size(), deviceId);
+        } else {
+          std::memcpy(dst, payload.data(), payload.size());
+        }
+      }
+      if (st.hasError()) {
+        state->fail(std::move(st));
+      } else {
+        state->completeOne();
+      }
+    }
+  }
+  return future;
+}
+
+std::future<Status> TcpTransport::send(
+    RegisteredSegment::Span src,
+    const RequestOptions& /*options*/) {
+  return sendImpl(src.data(), src.size(), src.memType(), src.deviceId());
+}
+
+std::future<Status> TcpTransport::recv(
+    RegisteredSegment::Span dst,
+    const RequestOptions& /*options*/) {
+  return recvImpl(
+      dst.mutable_data(), dst.size(), dst.memType(), dst.deviceId());
+}
+
+std::future<Status> TcpTransport::send(
+    Segment::Span src,
+    const RequestOptions& /*options*/) {
+  return sendImpl(src.data(), src.size(), src.memType(), src.deviceId());
+}
+
+std::future<Status> TcpTransport::recv(
+    Segment::Span dst,
+    const RequestOptions& /*options*/) {
+  return recvImpl(
+      dst.mutable_data(), dst.size(), dst.memType(), dst.deviceId());
+}
+
+void TcpTransport::shutdown() {
+  running_.store(false, std::memory_order_release);
+
+  {
+    std::lock_guard<std::mutex> lk(outMu_);
+    outClosed_ = true;
+  }
+  outCv_.notify_all();
+
+  // Closing the data connection unblocks the reader's blocking recv and any
+  // in-progress send on the sender thread.
+  if (dataConn_) {
+    dataConn_->close();
+  }
+  if (reader_.joinable()) {
+    reader_.join();
+  }
+  if (sender_.joinable()) {
+    sender_.join();
+  }
+
+  failAllPending("tcp transport shut down");
+
+  if (state_ != TransportState::Error) {
+    state_ = TransportState::Disconnected;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// TcpTransportFactory
+// ---------------------------------------------------------------------------
+
+Status TcpTransportFactory::supported() {
+  return Ok();
+}
+
+TcpTransportFactory::TcpTransportFactory(
+    int deviceId,
+    EventBase* evb,
+    controller::TcpSocketConfig config,
+    std::string host,
+    std::shared_ptr<CudaApi> cudaApi)
+    : TransportFactory(TransportType::TCP),
+      deviceId_(deviceId),
+      evb_(evb),
+      config_(std::move(config)),
+      host_(host.empty() ? std::string("127.0.0.1") : std::move(host)),
+      cudaApi_(cudaApi ? std::move(cudaApi) : std::make_shared<CudaApi>()) {}
+
+Result<std::unique_ptr<RegistrationHandle>>
+TcpTransportFactory::registerSegment(Segment& segment) {
+  if (segment.memType() != MemoryType::DRAM &&
+      segment.memType() != MemoryType::VRAM) {
+    return Err(
+        ErrCode::MemoryRegistrationError,
+        "tcp transport supports only DRAM and VRAM segments");
+  }
+
+  const auto segId = nextSegId_.fetch_add(1, std::memory_order_relaxed);
+  registry_->add(
+      segId,
+      segment.mutable_data(),
+      segment.len(),
+      segment.memType(),
+      segment.deviceId());
+  return std::make_unique<TcpRegistrationHandle>(
+      segId,
+      reinterpret_cast<uint64_t>(segment.data()),
+      static_cast<uint64_t>(segment.len()),
+      [weakRegistry = std::weak_ptr<TcpSegmentRegistry>(registry_), segId]() {
+        if (auto registry = weakRegistry.lock()) {
+          registry->erase(segId);
+        }
+      });
+}
+
+Result<std::unique_ptr<RemoteRegistrationHandle>>
+TcpTransportFactory::importSegment(
+    size_t segmentLength,
+    std::span<const uint8_t> payload) {
+  auto handle =
+      TcpRemoteRegistrationHandle::deserialize(segmentLength, payload);
+  if (!handle) {
+    return std::move(handle).error();
+  }
+  return std::move(handle).value();
+}
+
+Result<std::unique_ptr<Transport>> TcpTransportFactory::createTransport(
+    std::span<const uint8_t> peerTopology) {
+  auto info = TcpTransportInfo::deserialize(peerTopology);
+  if (!info) {
+    return std::move(info).error();
+  }
+  return std::make_unique<TcpTransport>(
+      deviceId_, evb_, registry_, config_, host_, cudaApi_);
+}
+
+std::vector<uint8_t> TcpTransportFactory::getTopology() {
+  return TcpTransportInfo{}.serialize();
+}
+
+Status TcpTransportFactory::canConnect(std::span<const uint8_t> peerTopology) {
+  auto info = TcpTransportInfo::deserialize(peerTopology);
+  if (!info) {
+    return std::move(info).error();
+  }
+  return Ok();
+}
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -1,0 +1,1244 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/transport/tcp/TcpTransport.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "comms/uniflow/drivers/cuda/CudaApi.h"
+#include "comms/uniflow/logging/Logger.h"
+#include "comms/uniflow/transport/tcp/TcpRegistrationHandle.h"
+#include "comms/uniflow/transport/tcp/TcpWireProtocol.h"
+
+namespace uniflow {
+
+namespace {
+// Fallback when TcpSocketConfig::connTimeout is unset.
+constexpr int kDefaultHandshakeTimeoutSeconds = 30;
+} // namespace
+
+namespace {
+
+// The controller frames each TcpConn message with a 4-byte length and caps it
+// at 64 MiB; keep each chunk (header + payload) safely under that so large
+// put/get transfers are split across multiple frames.
+constexpr size_t kMaxChunkSize = 4u << 20; // 4 MiB
+std::vector<uint8_t> makeHeaderFrame(TcpOp op, uint64_t reqId) {
+  TcpMsgHeader header;
+  header.op = static_cast<uint8_t>(op);
+  header.reqId = reqId;
+  return serializeTcpHeader(header);
+}
+
+// Representation-independent ordering key for a bind host. Parses IPv6 then
+// IPv4 to raw address bytes so different textual forms of the same address
+// (e.g. 2001:db8::1 vs its fully-expanded form) order and compare equal on both
+// peers; falls back to the raw string for non-numeric hosts. Used only for
+// deterministic listener/dialer role assignment.
+std::string hostOrderKey(const std::string& host) {
+  in6_addr a6{};
+  if (::inet_pton(AF_INET6, host.c_str(), &a6) == 1) {
+    return "6:" + std::string(reinterpret_cast<const char*>(&a6), sizeof(a6));
+  }
+  in_addr a4{};
+  if (::inet_pton(AF_INET, host.c_str(), &a4) == 1) {
+    return "4:" + std::string(reinterpret_cast<const char*>(&a4), sizeof(a4));
+  }
+  return "s:" + host;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// TcpTransportInfo
+// ---------------------------------------------------------------------------
+
+TransportInfo TcpTransportInfo::serialize() const {
+  Header header{
+      .port = port,
+      .hostLen = static_cast<uint16_t>(host.size()),
+  };
+  TransportInfo data(sizeof(Header) + host.size());
+  std::memcpy(data.data(), &header, sizeof(header));
+  if (!host.empty()) {
+    std::memcpy(data.data() + sizeof(header), host.data(), host.size());
+  }
+  return data;
+}
+
+Result<TcpTransportInfo> TcpTransportInfo::deserialize(
+    std::span<const uint8_t> data) {
+  if (data.size() < sizeof(Header)) {
+    return Err(ErrCode::InvalidArgument, "tcp transport info is truncated");
+  }
+
+  Header header;
+  std::memcpy(&header, data.data(), sizeof(header));
+  if (data.size() != sizeof(header) + header.hostLen) {
+    return Err(ErrCode::InvalidArgument, "tcp transport info size mismatch");
+  }
+
+  TcpTransportInfo info;
+  info.port = header.port;
+  info.host.assign(
+      reinterpret_cast<const char*>(data.data() + sizeof(header)),
+      header.hostLen);
+  return info;
+}
+
+// ---------------------------------------------------------------------------
+// TcpTransport
+// ---------------------------------------------------------------------------
+
+TcpTransport::TcpTransport(
+    int deviceId,
+    EventBase* evb,
+    std::shared_ptr<TcpSegmentRegistry> registry,
+    controller::TcpSocketConfig config,
+    std::string host,
+    std::shared_ptr<CudaApi> cudaApi)
+    : deviceId_(deviceId),
+      evb_(evb),
+      registry_(std::move(registry)),
+      cudaApi_(std::move(cudaApi)),
+      config_(std::move(config)) {
+  if (!registry_) {
+    registry_ = std::make_shared<TcpSegmentRegistry>();
+  }
+  if (!cudaApi_) {
+    cudaApi_ = std::make_shared<CudaApi>();
+  }
+  if (!host.empty()) {
+    host_ = std::move(host);
+  }
+}
+
+Status TcpTransport::hostFromDevice(
+    void* hostDst,
+    const void* devSrc,
+    size_t len,
+    int deviceId,
+    void* stream) {
+  if (len == 0) {
+    return Ok();
+  }
+  auto s = static_cast<cudaStream_t>(stream);
+  CudaDeviceGuard guard(*cudaApi_, deviceId);
+  auto st =
+      cudaApi_->memcpyAsync(hostDst, devSrc, len, cudaMemcpyDeviceToHost, s);
+  if (!st) {
+    return st;
+  }
+  return cudaApi_->streamSynchronize(s);
+}
+
+Status TcpTransport::deviceFromHost(
+    void* devDst,
+    const void* hostSrc,
+    size_t len,
+    int deviceId,
+    void* stream) {
+  if (len == 0) {
+    return Ok();
+  }
+  auto s = static_cast<cudaStream_t>(stream);
+  CudaDeviceGuard guard(*cudaApi_, deviceId);
+  auto st =
+      cudaApi_->memcpyAsync(devDst, hostSrc, len, cudaMemcpyHostToDevice, s);
+  if (!st) {
+    return st;
+  }
+  return cudaApi_->streamSynchronize(s);
+}
+
+TcpTransport::~TcpTransport() {
+  shutdown();
+}
+
+TransportInfo TcpTransport::bind() {
+  std::lock_guard<std::mutex> lk(lifecycleMu_);
+  if (shutdown_.load(std::memory_order_acquire)) {
+    UNIFLOW_LOG_ERROR("TcpTransport::bind: transport is already shut down");
+    return TransportInfo{};
+  }
+  server_ = std::make_unique<controller::AsyncTcpServer>(
+      host_ + ":0", config_, *evb_);
+  auto status = server_->init();
+  if (!status) {
+    UNIFLOW_LOG_ERROR(
+        "TcpTransport::bind: server init failed: {}", status.error().message());
+    state_ = TransportState::Error;
+    server_.reset();
+    return TransportInfo{};
+  }
+  port_ = static_cast<uint16_t>(server_->getPort());
+  state_ = TransportState::Initialized;
+
+  TcpTransportInfo info;
+  info.host = host_;
+  info.port = port_;
+  return info.serialize();
+}
+
+Status TcpTransport::connect(std::span<const uint8_t> remoteInfo) {
+  // Held across the handshake wait below, so a concurrent shutdown() cannot
+  // interleave with the installation of dataConn_/reader_/sender_ at the end of
+  // this function. The flag check is what stops a connect() queued behind a
+  // completed shutdown() from bringing the transport back to life.
+  std::lock_guard<std::mutex> lk(lifecycleMu_);
+  if (shutdown_.load(std::memory_order_acquire)) {
+    return Err(
+        ErrCode::NotConnected, "tcp connect: transport is already shut down");
+  }
+  if (state_ != TransportState::Initialized) {
+    return Err(
+        ErrCode::InvalidArgument, "tcp connect: transport must be bound first");
+  }
+
+  auto peerResult = TcpTransportInfo::deserialize(remoteInfo);
+  if (!peerResult) {
+    state_ = TransportState::Error;
+    return std::move(peerResult).error();
+  }
+  const auto peer = std::move(peerResult).value();
+
+  // Deterministic role: the smaller (host, port) listens, the other dials.
+  // Compare by the parsed binary address (hostOrderKey), not the raw string, so
+  // different textual forms of the same IPv6 address can't make the two peers
+  // disagree on ordering. Reject the degenerate identical-endpoint case, which
+  // would otherwise leave both peers dialing and nobody accepting (silent
+  // hang).
+  const auto localKey = std::make_tuple(hostOrderKey(host_), port_);
+  const auto peerKey = std::make_tuple(hostOrderKey(peer.host), peer.port);
+  if (localKey == peerKey) {
+    state_ = TransportState::Error;
+    return Err(
+        ErrCode::ConnectionFailed,
+        "tcp connect: local and peer bind address are identical; cannot assign "
+        "distinct listener/dialer roles");
+  }
+  const bool listener = localKey < peerKey;
+
+  std::unique_ptr<controller::Conn> conn;
+  // Both handshake waits are bounded. AsyncAccept::accept() queues a promise
+  // that is resolved only by an inbound connection or by teardown, so an
+  // unbounded get() here wedges this thread forever if the dialing peer dies
+  // between the bind-info exchange and its own connect(). Nothing would rescue
+  // it: server_ is owned by this transport, whose connect() is the thing
+  // parked. AsyncAccept also ignores acceptRetryCnt and AsyncConnect ignores
+  // connectRetries, so no configured bound applies on its own.
+  //
+  // This matters beyond TCP: MultiTransport::connect() connects every
+  // registered transport, so on AMD a wedged TCP handshake would stall
+  // connection setup even for jobs whose data path is RDMA.
+  const auto handshakeTimeout = config_.connTimeout.value_or(
+      std::chrono::seconds{kDefaultHandshakeTimeoutSeconds});
+
+  if (listener) {
+    if (!server_) {
+      state_ = TransportState::Error;
+      return Err(ErrCode::ConnectionFailed, "tcp connect: no server bound");
+    }
+    auto future = server_->accept();
+    if (future.wait_for(handshakeTimeout) != std::future_status::ready) {
+      // shutdown() resolves the queued promise with nullptr (via teardown), so
+      // the get() below returns immediately instead of blocking. Safe from this
+      // thread: AsyncAccept::shutdown marshals teardown onto the EventBase
+      // thread and waits when called from outside the loop.
+      UNIFLOW_LOG_ERROR(
+          "TcpTransport::connect: no peer dialed in within {}s; tearing down "
+          "listener {}:{}",
+          handshakeTimeout.count(),
+          host_,
+          port_);
+      server_->shutdown();
+    }
+    conn = future.get();
+  } else {
+    controller::AsyncTcpClient client(config_, *evb_);
+    auto future = client.connect(peer.host + ":" + std::to_string(peer.port));
+    if (future.wait_for(handshakeTimeout) != std::future_status::ready) {
+      UNIFLOW_LOG_ERROR(
+          "TcpTransport::connect: dial to {}:{} did not complete within {}s",
+          peer.host,
+          peer.port,
+          handshakeTimeout.count());
+      // No teardown hook on the client side; abandon the attempt. The future
+      // owns its own state, so letting it go out of scope is safe.
+      state_ = TransportState::Error;
+      return Err(ErrCode::ConnectionFailed, "tcp connect: dial timed out");
+    }
+    conn = future.get();
+  }
+
+  if (!conn) {
+    state_ = TransportState::Error;
+    return Err(
+        ErrCode::ConnectionFailed, "tcp connect: data connection failed");
+  }
+
+  dataConn_ = std::move(conn);
+  running_.store(true, std::memory_order_release);
+  reader_ = std::thread([this]() { readerLoop(); });
+  sender_ = std::thread([this]() { senderLoop(); });
+  state_ = TransportState::Connected;
+  UNIFLOW_LOG_INFO(
+      "TcpTransport: connected (listener={}) {}:{} <-> {}:{}",
+      listener,
+      host_,
+      port_,
+      peer.host,
+      peer.port);
+  return Ok();
+}
+
+Result<const TcpRemoteRegistrationHandle*> TcpTransport::findRemoteHandle(
+    const RemoteRegisteredSegment::Span& span) const {
+  for (const auto& handle : span.handles_) {
+    if (auto* tcp =
+            dynamic_cast<const TcpRemoteRegistrationHandle*>(handle.get())) {
+      return tcp;
+    }
+  }
+  return Err(
+      ErrCode::InvalidArgument, "tcp: no TCP remote registration handle found");
+}
+
+std::future<Status> TcpTransport::put(
+    std::span<const TransferRequest> requests,
+    const RequestOptions& options) {
+  if (state_ != TransportState::Connected ||
+      connBroken_.load(std::memory_order_acquire)) {
+    return make_ready_future<Status>(
+        Err(ErrCode::NotConnected, "tcp put: not connected"));
+  }
+  if (requests.empty()) {
+    return make_ready_future<Status>(Ok());
+  }
+
+  auto state = std::make_shared<TcpOpState>();
+  auto future = state->promise.get_future();
+
+  // Validate and count chunks up front so the completion counter is exact.
+  size_t totalChunks = 0;
+  for (const auto& req : requests) {
+    if (req.local.size() != req.remote.size()) {
+      state->fail(
+          Err(ErrCode::InvalidArgument,
+              "tcp put: local and remote buffer sizes must match"));
+      return future;
+    }
+    const size_t len = req.local.size();
+    totalChunks += (len == 0) ? 1 : (len + kMaxChunkSize - 1) / kMaxChunkSize;
+  }
+  state->remaining = totalChunks;
+
+  for (const auto& req : requests) {
+    auto remoteHandle = findRemoteHandle(req.remote);
+    if (!remoteHandle) {
+      state->fail(std::move(remoteHandle).error());
+      return future;
+    }
+    const uint64_t segId = remoteHandle.value()->segId();
+    const uint64_t baseOffset = static_cast<uint64_t>(req.remote.remoteOffset_);
+    const size_t len = req.local.size();
+    const bool vram = req.local.memType() == MemoryType::VRAM;
+    const int deviceId = req.local.deviceId();
+    const auto* src = static_cast<const uint8_t*>(req.local.data());
+
+    size_t off = 0;
+    do {
+      const size_t chunk = std::min(kMaxChunkSize, len - off);
+      const uint64_t reqId = nextReqId_.fetch_add(1, std::memory_order_relaxed);
+      if (auto admitted =
+              admitInflight(reqId, TcpInflight{state, nullptr, chunk, false});
+          admitted.hasError()) {
+        state->fail(std::move(admitted));
+        return future;
+      }
+      std::vector<uint8_t> frame(sizeof(TcpMsgHeader) + chunk);
+      TcpMsgHeader header;
+      header.op = static_cast<uint8_t>(TcpOp::Write);
+      header.reqId = reqId;
+      header.segId = segId;
+      header.offset = baseOffset + off;
+      header.len = static_cast<uint64_t>(chunk);
+      std::memcpy(frame.data(), &header, sizeof(header));
+      if (chunk > 0) {
+        Status st = Ok();
+        if (vram) {
+          st = hostFromDevice(
+              frame.data() + sizeof(header),
+              src + off,
+              chunk,
+              deviceId,
+              options.stream.has_value()
+                  ? static_cast<void*>(options.stream.value())
+                  : nullptr);
+        } else {
+          std::memcpy(frame.data() + sizeof(header), src + off, chunk);
+        }
+        if (!st) {
+          {
+            std::lock_guard<std::mutex> lk(inflightMu_);
+            inflight_.erase(reqId);
+          }
+          state->fail(std::move(st));
+          return future;
+        }
+      }
+      if (!enqueueFrame(std::move(frame), /*mayBlock=*/true)) {
+        state->fail(
+            Err(ErrCode::NotConnected,
+                "tcp put: transport closed before the write was queued"));
+        return future;
+      }
+      off += chunk;
+    } while (off < len);
+  }
+
+  return future;
+}
+
+std::future<Status> TcpTransport::get(
+    std::span<const TransferRequest> requests,
+    const RequestOptions& options) {
+  if (state_ != TransportState::Connected ||
+      connBroken_.load(std::memory_order_acquire)) {
+    return make_ready_future<Status>(
+        Err(ErrCode::NotConnected, "tcp get: not connected"));
+  }
+  if (requests.empty()) {
+    return make_ready_future<Status>(Ok());
+  }
+
+  auto state = std::make_shared<TcpOpState>();
+  auto future = state->promise.get_future();
+
+  size_t totalChunks = 0;
+  for (const auto& req : requests) {
+    if (req.local.size() != req.remote.size()) {
+      state->fail(
+          Err(ErrCode::InvalidArgument,
+              "tcp get: local and remote buffer sizes must match"));
+      return future;
+    }
+    const size_t len = req.local.size();
+    totalChunks += (len == 0) ? 1 : (len + kMaxChunkSize - 1) / kMaxChunkSize;
+  }
+  state->remaining = totalChunks;
+
+  for (const auto& req : requests) {
+    auto remoteHandle = findRemoteHandle(req.remote);
+    if (!remoteHandle) {
+      state->fail(std::move(remoteHandle).error());
+      return future;
+    }
+    const uint64_t segId = remoteHandle.value()->segId();
+    const uint64_t baseOffset = static_cast<uint64_t>(req.remote.remoteOffset_);
+    const size_t len = req.local.size();
+    const MemoryType memType = req.local.memType();
+    const int deviceId = req.local.deviceId();
+    auto* dst = static_cast<uint8_t*>(req.local.mutable_data());
+
+    size_t off = 0;
+    do {
+      const size_t chunk = std::min(kMaxChunkSize, len - off);
+      const uint64_t reqId = nextReqId_.fetch_add(1, std::memory_order_relaxed);
+      if (auto admitted = admitInflight(
+              reqId,
+              TcpInflight{
+                  state,
+                  dst + off,
+                  chunk,
+                  true,
+                  memType,
+                  deviceId,
+                  options.stream.has_value()
+                      ? static_cast<void*>(options.stream.value())
+                      : nullptr});
+          admitted.hasError()) {
+        state->fail(std::move(admitted));
+        return future;
+      }
+      TcpMsgHeader header;
+      header.op = static_cast<uint8_t>(TcpOp::ReadRequest);
+      header.reqId = reqId;
+      header.segId = segId;
+      header.offset = baseOffset + off;
+      header.len = static_cast<uint64_t>(chunk);
+      if (!enqueueFrame(serializeTcpHeader(header), /*mayBlock=*/true)) {
+        state->fail(
+            Err(ErrCode::NotConnected,
+                "tcp get: transport closed before the read was queued"));
+        return future;
+      }
+      off += chunk;
+    } while (off < len);
+  }
+
+  return future;
+}
+
+Status TcpTransport::admitInflight(uint64_t reqId, TcpInflight entry) {
+  std::lock_guard<std::mutex> lk(inflightMu_);
+  if (connBroken_.load(std::memory_order_acquire)) {
+    return Err(
+        ErrCode::NotConnected, "tcp: transport closed while admitting request");
+  }
+  if (inflight_.size() >= kMaxInflightRequests) {
+    return Err(
+        ErrCode::ResourceExhausted,
+        "tcp: too many outstanding requests (" +
+            std::to_string(kMaxInflightRequests) + ")");
+  }
+  inflight_[reqId] = std::move(entry);
+  return Ok();
+}
+
+bool TcpTransport::enqueueFrame(std::vector<uint8_t> frame, bool mayBlock) {
+  const size_t bytes = frame.size();
+  {
+    std::unique_lock<std::mutex> lk(outMu_);
+    if (mayBlock) {
+      // Caller threads absorb backpressure by waiting, which is real
+      // backpressure: an application issuing put/get faster than the link
+      // drains slows down instead of growing the queue. An empty queue always
+      // admits, however large the frame, or a payload bigger than the cap could
+      // never drain and would wedge here forever.
+      outCv_.wait(lk, [this, bytes]() {
+        return outClosed_ || connBroken_.load(std::memory_order_acquire) ||
+            outQueue_.empty() || outBytes_ + bytes <= kMaxOutQueueBytes;
+      });
+    }
+    // The reader thread deliberately gets no cap. It is producing replies the
+    // peer is already blocked on, and a get of N bytes legitimately needs up to
+    // N bytes of replies queued -- N is bounded only by the segment size, so no
+    // fixed cap can tell a large honest get apart from abuse; they are the same
+    // traffic. Refusing here would fail every unrelated in-flight transfer on
+    // the connection. It cannot wait either: that stops it draining the socket
+    // and reintroduces the mutual-READ deadlock the reader/sender split exists
+    // to avoid. What bounds this queue is the drain rate, not a byte cap.
+    if (outClosed_) {
+      return false;
+    }
+    outQueue_.push_back(TcpOutItem{std::move(frame), nullptr});
+    outBytes_ += bytes;
+  }
+  outCv_.notify_all();
+  return true;
+}
+
+void TcpTransport::enqueueSendFrame(
+    std::vector<uint8_t> frame,
+    std::shared_ptr<TcpOpState> onSent) {
+  bool closed = false;
+  std::shared_ptr<TcpOpState> toFail;
+  const size_t bytes = frame.size();
+  {
+    std::unique_lock<std::mutex> lk(outMu_);
+    // send() runs on a caller thread, so it can wait for room.
+    outCv_.wait(lk, [this, bytes]() {
+      return outClosed_ || connBroken_.load(std::memory_order_acquire) ||
+          outQueue_.empty() || outBytes_ + bytes <= kMaxOutQueueBytes;
+    });
+    if (outClosed_) {
+      closed = true;
+      // Taken over here so each path has exactly one owner: the queue takes it
+      // when the frame is enqueued, this does when it cannot be.
+      toFail = std::move(onSent);
+    } else {
+      outQueue_.push_back(TcpOutItem{std::move(frame), std::move(onSent)});
+      outBytes_ += bytes;
+    }
+  }
+  // Settled outside outMu_ so TcpOpState::mu stays a leaf lock: a caller woken
+  // by this promise may re-enter the transport from its error path, and it must
+  // not find a container mutex still held by the thread that woke it.
+  if (closed) {
+    if (toFail) {
+      toFail->fail(Err(ErrCode::NotConnected, "tcp send: transport closing"));
+    }
+    return;
+  }
+  outCv_.notify_all();
+}
+
+void TcpTransport::senderLoop() noexcept {
+  for (;;) {
+    TcpOutItem item;
+    {
+      std::unique_lock<std::mutex> lk(outMu_);
+      outCv_.wait(lk, [this]() { return outClosed_ || !outQueue_.empty(); });
+      if (outClosed_) {
+        return;
+      }
+      item = std::move(outQueue_.front());
+      outQueue_.pop_front();
+      outBytes_ -= std::min(outBytes_, item.bytes.size());
+    }
+    outCv_.notify_all(); // room freed; wake any producer waiting for space
+
+    auto result = dataConn_->send(item.bytes).get();
+    if (!result) {
+      UNIFLOW_LOG_ERROR(
+          "tcp sender: send failed: {}", result.error().message());
+      // Close the out queue before unwinding. Nothing drains outQueue_ once
+      // this thread returns, and enqueueFrame() gates only on outClosed_, so
+      // the still-running reader thread would keep appending
+      // Ack/Error/ReadReply frames -- the last up to kMaxChunkSize each -- to a
+      // queue with no consumer. failAllPending() clears it exactly once, so
+      // without this the growth is unbounded and driven by whatever the peer
+      // keeps requesting.
+      {
+        std::lock_guard<std::mutex> lk(outMu_);
+        outClosed_ = true;
+      }
+      outCv_.notify_all();
+      if (item.onSent) {
+        item.onSent->fail(Err(ErrCode::ConnectionFailed, "tcp: send failed"));
+      }
+      failAllPending("tcp: send failed");
+      return;
+    }
+    if (item.onSent) {
+      item.onSent->completeOne();
+    }
+  }
+}
+
+void TcpTransport::readerLoop() noexcept {
+  while (running_.load(std::memory_order_acquire)) {
+    std::vector<uint8_t> msg;
+    auto result = dataConn_->recv(msg).get();
+    if (!result) {
+      // Connection closed, errored, or idle-timed-out; stop reading.
+      break;
+    }
+    handleFrame(msg);
+  }
+  // The reader is the only place that resolves in-flight put/get/recv replies.
+  // If it exits on a recv error (peer disconnect) while requests are still
+  // outstanding and the sender is idle, nothing else would fulfill their
+  // promises and callers would block forever on future.get(). Fail them here.
+  // Idempotent with shutdown()'s own failAllPending().
+  failAllPending("tcp: reader stopped (connection closed or read error)");
+}
+
+void TcpTransport::handleFrame(std::span<const uint8_t> frame) noexcept {
+  // An exception leaving a noexcept function is std::terminate, and the throw
+  // sites in here are reachable from the wire: a ReadRequest's length sizes an
+  // allocation, and the VRAM staging path throws if the segment was registered
+  // with an invalid deviceId. Neither may let a peer abort the process.
+  //
+  // The connection is failed rather than the frame dropped, because an
+  // exception can land midway through a staging copy or a completion, leaving
+  // protocol state that cannot be reasoned about. Stopping the reader also
+  // resolves outstanding ops, so no caller is left blocked in future.get().
+  try {
+    handleFrameImpl(frame);
+  } catch (const std::exception& e) {
+    UNIFLOW_LOG_ERROR(
+        "tcp: frame handling raised '{}'; failing the connection", e.what());
+    running_.store(false, std::memory_order_release);
+    failAllPending("tcp: frame handling raised an exception");
+  } catch (...) {
+    UNIFLOW_LOG_ERROR(
+        "tcp: frame handling raised a non-standard exception; failing the "
+        "connection");
+    running_.store(false, std::memory_order_release);
+    failAllPending("tcp: frame handling raised an exception");
+  }
+}
+
+void TcpTransport::handleFrameImpl(std::span<const uint8_t> frame) {
+  auto headerResult = deserializeTcpHeader(frame);
+  if (!headerResult) {
+    UNIFLOW_LOG_ERROR(
+        "tcp: dropping malformed frame: {}", headerResult.error().message());
+    return;
+  }
+  const TcpMsgHeader header = headerResult.value();
+  const auto op = static_cast<TcpOp>(header.op);
+  const std::span<const uint8_t> payload = frame.subspan(sizeof(TcpMsgHeader));
+
+  switch (op) {
+    case TcpOp::Write: {
+      bool ok = false;
+      // Lease, not a plain lookup: it must outlive the copy below, because it
+      // is what stops the owner deregistering and freeing the buffer underneath
+      // us.
+      auto entry = registry_->find(header.segId);
+      if (entry && header.len <= entry->len &&
+          header.offset <= entry->len - header.len &&
+          payload.size() == header.len) {
+        Status st = Ok();
+        if (header.len > 0) {
+          void* dst = static_cast<uint8_t*>(entry->ptr) + header.offset;
+          if (entry->memType == MemoryType::VRAM) {
+            st = deviceFromHost(
+                dst, payload.data(), header.len, entry->deviceId);
+          } else {
+            std::memcpy(dst, payload.data(), header.len);
+          }
+        }
+        ok = !st.hasError();
+      }
+      (void)enqueueFrame(
+          makeHeaderFrame(ok ? TcpOp::Ack : TcpOp::Error, header.reqId),
+          /*mayBlock=*/false);
+      break;
+    }
+
+    case TcpOp::ReadRequest: {
+      // Held across the read below for the same reason as the Write path.
+      auto entry = registry_->find(header.segId);
+      Status readStatus = Ok();
+      // Bound the reply by the wire-frame cap, not just by the segment length.
+      // A peer that registered a segment larger than the cap can request a read
+      // whose reply exceeds kMaxMessageSize; the controller then refuses the
+      // send, and senderLoop treats that as fatal -- killing the sender and
+      // failing every unrelated in-flight transfer. Our own get() chunks at
+      // kMaxChunkSize so a same-version peer never asks for this, which is
+      // exactly the version-skew case the header version byte guards: a peer
+      // built with a larger chunk size would otherwise turn a recoverable
+      // per-request error into a permanently dead connection.
+      if (header.len > kMaxFrameSize - sizeof(TcpMsgHeader)) {
+        readStatus =
+            Err(ErrCode::InvalidArgument,
+                "tcp read: requested length would exceed the wire-frame cap");
+      } else if (
+          entry && header.len <= entry->len &&
+          header.offset <= entry->len - header.len) {
+        std::vector<uint8_t> reply(sizeof(TcpMsgHeader) + header.len);
+        TcpMsgHeader replyHeader;
+        replyHeader.op = static_cast<uint8_t>(TcpOp::ReadReply);
+        replyHeader.reqId = header.reqId;
+        replyHeader.segId = header.segId;
+        replyHeader.offset = header.offset;
+        replyHeader.len = header.len;
+        std::memcpy(reply.data(), &replyHeader, sizeof(replyHeader));
+        if (header.len > 0) {
+          const void* src =
+              static_cast<const uint8_t*>(entry->ptr) + header.offset;
+          if (entry->memType == MemoryType::VRAM) {
+            readStatus = hostFromDevice(
+                reply.data() + sizeof(replyHeader),
+                src,
+                header.len,
+                entry->deviceId);
+          } else {
+            std::memcpy(reply.data() + sizeof(replyHeader), src, header.len);
+          }
+        }
+        if (!readStatus.hasError()) {
+          (void)enqueueFrame(std::move(reply), /*mayBlock=*/false);
+        }
+      } else {
+        readStatus = Err(ErrCode::InvalidArgument, "tcp read: bad segment");
+      }
+      if (readStatus.hasError()) {
+        (void)enqueueFrame(
+            makeHeaderFrame(TcpOp::Error, header.reqId), /*mayBlock=*/false);
+      }
+      break;
+    }
+
+    case TcpOp::Send: {
+      if (payload.size() != header.len) {
+        UNIFLOW_LOG_ERROR("tcp send: inbound payload size mismatch");
+        break;
+      }
+      std::shared_ptr<TcpOpState> state;
+      void* dst = nullptr;
+      size_t cap = 0;
+      MemoryType memType = MemoryType::DRAM;
+      int deviceId = -1;
+      void* stream = nullptr;
+      bool matched = false;
+      bool overflow = false;
+      {
+        std::lock_guard<std::mutex> lk(recvMu_);
+        if (!pendingRecvs_.empty()) {
+          auto pr = std::move(pendingRecvs_.front());
+          pendingRecvs_.pop_front();
+          state = std::move(pr.state);
+          dst = pr.dst;
+          cap = pr.cap;
+          memType = pr.memType;
+          deviceId = pr.deviceId;
+          stream = pr.stream;
+          matched = true;
+        } else if (unmatchedBytes_ + payload.size() > kMaxUnmatchedSendBytes) {
+          overflow = true;
+        } else {
+          unmatchedSends_.emplace_back(payload.begin(), payload.end());
+          unmatchedBytes_ += payload.size();
+        }
+      }
+      if (overflow) {
+        // No backpressure is available on this path, so absorbing more would be
+        // unbounded host-memory growth driven by the peer. Refuse the
+        // connection instead: closing it makes the reader's next recv() fail,
+        // and the reader's own failAllPending() then resolves outstanding ops.
+        UNIFLOW_LOG_ERROR(
+            "tcp recv: unmatched inbound sends exceed {} bytes; closing the "
+            "connection",
+            kMaxUnmatchedSendBytes);
+        closeDataConnOnce();
+        break;
+      }
+      if (matched && state) {
+        if (payload.size() > cap) {
+          state->fail(
+              Err(ErrCode::InvalidArgument,
+                  "tcp recv: buffer too small for incoming send"));
+        } else {
+          Status st = Ok();
+          if (!payload.empty() && dst != nullptr) {
+            if (memType == MemoryType::VRAM) {
+              st = deviceFromHost(
+                  dst, payload.data(), payload.size(), deviceId, stream);
+            } else {
+              std::memcpy(dst, payload.data(), payload.size());
+            }
+          }
+          if (st.hasError()) {
+            state->fail(std::move(st));
+          } else {
+            state->completeOne();
+          }
+        }
+      }
+      break;
+    }
+
+    case TcpOp::Ack:
+    case TcpOp::ReadReply:
+    case TcpOp::Error: {
+      TcpInflight entry;
+      bool found = false;
+      {
+        std::lock_guard<std::mutex> lk(inflightMu_);
+        auto it = inflight_.find(header.reqId);
+        if (it != inflight_.end()) {
+          entry = std::move(it->second);
+          inflight_.erase(it);
+          found = true;
+        }
+      }
+      if (!found || !entry.state) {
+        break;
+      }
+      if (op == TcpOp::Error) {
+        entry.state->fail(
+            Err(ErrCode::TransportError, "tcp: peer reported an error"));
+      } else if (op == TcpOp::ReadReply) {
+        if (payload.size() != header.len || header.len != entry.len) {
+          entry.state->fail(Err(
+              ErrCode::TransportError, "tcp get: read reply size mismatch"));
+          break;
+        }
+        // The copy into the caller's get() destination and this chunk's
+        // completion must be one step: a concurrent failAllPending() resolving
+        // the op (via a sibling chunk of the same multi-chunk get()) releases
+        // the caller to free entry.dst, so writing it either side of that
+        // resolution is a write-after-free. writeAndComplete() drops the copy
+        // if the op is already resolved.
+        entry.state->writeAndComplete([&]() -> Status {
+          if (header.len == 0 || entry.dst == nullptr) {
+            return Ok();
+          }
+          if (entry.memType == MemoryType::VRAM) {
+            return deviceFromHost(
+                entry.dst,
+                payload.data(),
+                header.len,
+                entry.deviceId,
+                entry.stream);
+          }
+          std::memcpy(entry.dst, payload.data(), header.len);
+          return Ok();
+        });
+      } else { // Ack
+        entry.state->completeOne();
+      }
+      break;
+    }
+
+    case TcpOp::Notification:
+      UNIFLOW_LOG_WARN("tcp: unexpected inbound Notification frame");
+      break;
+
+    default:
+      UNIFLOW_LOG_WARN(
+          "tcp: unexpected opcode {}", static_cast<int>(header.op));
+      break;
+  }
+}
+
+void TcpTransport::closeDataConnOnce() {
+  // Conn::close() tests the fd, closes it, then clears it, with no
+  // synchronisation. The reader refuses the connection on unmatched-send
+  // overflow while an application thread can be in shutdown() doing the same,
+  // and neither holds lifecycleMu_ (the reader must not, since shutdown() holds
+  // it across reader_.join()). Both callers can therefore observe the fd open
+  // and both ::close() it, and the second reaps a descriptor that another
+  // thread in the process may already have been handed by open/socket/accept.
+  // Winning this exchange is what earns the right to close.
+  if (dataConn_ != nullptr &&
+      !dataConnClosed_.exchange(true, std::memory_order_acq_rel)) {
+    dataConn_->close();
+  }
+}
+
+void TcpTransport::failAllPending(const char* message) {
+  connBroken_.store(true, std::memory_order_release);
+  // Collect first, settle after every mutex is released. Fulfilling a promise
+  // under a container mutex hands control to the waiting caller while this
+  // thread still holds it; a caller that tears the transport down from its
+  // error path would then destroy the mutex and the containers underneath this
+  // function. Settling afterwards also keeps TcpOpState::mu a leaf lock.
+  std::vector<std::shared_ptr<TcpOpState>> toFail;
+  {
+    std::lock_guard<std::mutex> lk(inflightMu_);
+    for (auto& [reqId, entry] : inflight_) {
+      if (entry.state) {
+        toFail.push_back(std::move(entry.state));
+      }
+    }
+    inflight_.clear();
+  }
+  {
+    std::lock_guard<std::mutex> lk(recvMu_);
+    for (auto& pr : pendingRecvs_) {
+      if (pr.state) {
+        toFail.push_back(std::move(pr.state));
+      }
+    }
+    pendingRecvs_.clear();
+    unmatchedSends_.clear();
+    unmatchedBytes_ = 0;
+  }
+  {
+    std::lock_guard<std::mutex> lk(outMu_);
+    for (auto& item : outQueue_) {
+      if (item.onSent) {
+        toFail.push_back(std::move(item.onSent));
+      }
+    }
+    outQueue_.clear();
+    outBytes_ = 0;
+  }
+  outCv_.notify_all(); // wake producers blocked for space so they see the break
+  for (auto& state : toFail) {
+    state->fail(Err(ErrCode::ConnectionFailed, message));
+  }
+}
+
+std::future<Status> TcpTransport::sendImpl(
+    const void* data,
+    size_t len,
+    MemoryType memType,
+    int deviceId,
+    const RequestOptions& options) {
+  if (state_ != TransportState::Connected ||
+      connBroken_.load(std::memory_order_acquire)) {
+    return make_ready_future<Status>(
+        Err(ErrCode::NotConnected, "tcp send: not connected"));
+  }
+  // Staging VRAM on the null stream is the one outcome that can silently
+  // transmit stale device data, so require the caller to say which stream the
+  // D2H must be ordered against. Matches RdmaTransport::rdmaSendRecvTransfer.
+  if (memType == MemoryType::VRAM && !options.stream.has_value()) {
+    return make_ready_future<Status>(
+        Err(ErrCode::InvalidArgument,
+            "VRAM transfer requires an explicit CUDA stream"));
+  }
+  // send() is single-frame (no chunking); reject payloads that would exceed the
+  // wire-frame cap so callers get a diagnostic instead of a silent drop/hang.
+  if (len > kMaxFrameSize - sizeof(TcpMsgHeader)) {
+    return make_ready_future<Status>(
+        Err(ErrCode::InvalidArgument,
+            "tcp send: payload exceeds the 64 MiB wire-frame cap; use put/get "
+            "(which chunk) for large transfers"));
+  }
+  auto state = std::make_shared<TcpOpState>();
+  state->remaining = 1;
+  auto future = state->promise.get_future();
+
+  std::vector<uint8_t> frame(sizeof(TcpMsgHeader) + len);
+  TcpMsgHeader header;
+  header.op = static_cast<uint8_t>(TcpOp::Send);
+  header.len = static_cast<uint64_t>(len);
+  std::memcpy(frame.data(), &header, sizeof(header));
+  if (len > 0 && data != nullptr) {
+    Status st = Ok();
+    if (memType == MemoryType::VRAM) {
+      st = hostFromDevice(
+          frame.data() + sizeof(header),
+          data,
+          len,
+          deviceId,
+          static_cast<void*>(options.stream.value()));
+    } else {
+      std::memcpy(frame.data() + sizeof(header), data, len);
+    }
+    if (!st) {
+      state->fail(std::move(st));
+      return future;
+    }
+  }
+  enqueueSendFrame(std::move(frame), std::move(state));
+  return future;
+}
+
+std::future<Status> TcpTransport::recvImpl(
+    void* dst,
+    size_t cap,
+    MemoryType memType,
+    int deviceId,
+    const RequestOptions& options) {
+  if (state_ != TransportState::Connected ||
+      connBroken_.load(std::memory_order_acquire)) {
+    return make_ready_future<Status>(
+        Err(ErrCode::NotConnected, "tcp recv: not connected"));
+  }
+  // Without an explicit stream the H2D would land on the null stream, letting
+  // the caller launch kernels against a buffer the payload has not reached yet.
+  // Matches RdmaTransport::rdmaSendRecvTransfer.
+  if (memType == MemoryType::VRAM && !options.stream.has_value()) {
+    return make_ready_future<Status>(
+        Err(ErrCode::InvalidArgument,
+            "VRAM transfer requires an explicit CUDA stream"));
+  }
+  void* const stream = options.stream.has_value()
+      ? static_cast<void*>(options.stream.value())
+      : nullptr;
+  auto state = std::make_shared<TcpOpState>();
+  state->remaining = 1;
+  auto future = state->promise.get_future();
+
+  std::vector<uint8_t> payload;
+  bool matched = false;
+  bool closed = false;
+  {
+    std::lock_guard<std::mutex> lk(recvMu_);
+    // Same admission race as the inflight_ path: a failAllPending() landing
+    // between the entry check above and this push_back would leave a posted
+    // recv no sweep will ever see, blocking the caller forever. Checked under
+    // recvMu_ so the two orderings are exclusive.
+    if (connBroken_.load(std::memory_order_acquire)) {
+      closed = true;
+    } else if (!unmatchedSends_.empty()) {
+      payload = std::move(unmatchedSends_.front());
+      unmatchedSends_.pop_front();
+      unmatchedBytes_ -= std::min(unmatchedBytes_, payload.size());
+      matched = true;
+    } else {
+      pendingRecvs_.push_back(
+          TcpPendingRecv{dst, cap, state, memType, deviceId, stream});
+    }
+  }
+  if (closed) {
+    state->fail(
+        Err(ErrCode::NotConnected,
+            "tcp recv: transport closed while posting receive"));
+    return future;
+  }
+  if (matched) {
+    if (payload.size() > cap) {
+      state->fail(
+          Err(ErrCode::InvalidArgument,
+              "tcp recv: buffer too small for buffered send"));
+    } else {
+      Status st = Ok();
+      if (!payload.empty() && dst != nullptr) {
+        if (memType == MemoryType::VRAM) {
+          st = deviceFromHost(
+              dst, payload.data(), payload.size(), deviceId, stream);
+        } else {
+          std::memcpy(dst, payload.data(), payload.size());
+        }
+      }
+      if (st.hasError()) {
+        state->fail(std::move(st));
+      } else {
+        state->completeOne();
+      }
+    }
+  }
+  return future;
+}
+
+std::future<Status> TcpTransport::send(
+    RegisteredSegment::Span src,
+    const RequestOptions& options) {
+  return sendImpl(
+      src.data(), src.size(), src.memType(), src.deviceId(), options);
+}
+
+std::future<Status> TcpTransport::recv(
+    RegisteredSegment::Span dst,
+    const RequestOptions& options) {
+  return recvImpl(
+      dst.mutable_data(), dst.size(), dst.memType(), dst.deviceId(), options);
+}
+
+std::future<Status> TcpTransport::send(
+    Segment::Span src,
+    const RequestOptions& options) {
+  return sendImpl(
+      src.data(), src.size(), src.memType(), src.deviceId(), options);
+}
+
+std::future<Status> TcpTransport::recv(
+    Segment::Span dst,
+    const RequestOptions& options) {
+  return recvImpl(
+      dst.mutable_data(), dst.size(), dst.memType(), dst.deviceId(), options);
+}
+
+void TcpTransport::shutdown() {
+  std::lock_guard<std::mutex> lk(lifecycleMu_);
+  // One-shot, but checked under the mutex rather than before taking it:
+  // shutdown() is called twice in the normal flow (MultiTransport::shutdown()
+  // then ~TcpTransport), and the second caller must not return while the first
+  // is still tearing down -- the destructor would otherwise race it.
+  if (shutdown_.exchange(true)) {
+    return;
+  }
+  running_.store(false, std::memory_order_release);
+
+  {
+    std::lock_guard<std::mutex> lk(outMu_);
+    outClosed_ = true;
+  }
+  outCv_.notify_all();
+
+  // Closing the data connection unblocks the reader's blocking recv and any
+  // in-progress send on the sender thread. A no-op if the reader already
+  // refused the connection, in which case it is on its way out anyway.
+  closeDataConnOnce();
+  if (reader_.joinable()) {
+    reader_.join();
+  }
+  if (sender_.joinable()) {
+    sender_.join();
+  }
+
+  failAllPending("tcp transport shut down");
+
+  // Compare-exchange, not load-then-store: a concurrent bind() failure setting
+  // Error in the gap between a load and a store would be clobbered back to
+  // Disconnected, so a transport that failed to bind would report as cleanly
+  // closed.
+  auto expected = state_.load(std::memory_order_acquire);
+  while (
+      expected != TransportState::Error &&
+      !state_.compare_exchange_weak(expected, TransportState::Disconnected)) {
+  }
+}
+
+// ---------------------------------------------------------------------------
+// TcpTransportFactory
+// ---------------------------------------------------------------------------
+
+Status TcpTransportFactory::supported() {
+  return Ok();
+}
+
+TcpTransportFactory::TcpTransportFactory(
+    int deviceId,
+    EventBase* evb,
+    controller::TcpSocketConfig config,
+    std::string host,
+    std::shared_ptr<CudaApi> cudaApi)
+    : TransportFactory(TransportType::TCP),
+      deviceId_(deviceId),
+      evb_(evb),
+      config_(std::move(config)),
+      host_(host.empty() ? std::string("127.0.0.1") : std::move(host)),
+      cudaApi_(cudaApi ? std::move(cudaApi) : std::make_shared<CudaApi>()) {}
+
+Result<std::unique_ptr<RegistrationHandle>>
+TcpTransportFactory::registerSegment(Segment& segment) {
+  if (segment.memType() != MemoryType::DRAM &&
+      segment.memType() != MemoryType::VRAM) {
+    return Err(
+        ErrCode::MemoryRegistrationError,
+        "tcp transport supports only DRAM and VRAM segments");
+  }
+
+  const auto segId = nextSegId_.fetch_add(1, std::memory_order_relaxed);
+  registry_->add(
+      segId,
+      segment.mutable_data(),
+      segment.len(),
+      segment.memType(),
+      segment.deviceId());
+  return std::make_unique<TcpRegistrationHandle>(
+      segId,
+      static_cast<uint64_t>(segment.len()),
+      [weakRegistry = std::weak_ptr<TcpSegmentRegistry>(registry_), segId]() {
+        if (auto registry = weakRegistry.lock()) {
+          // Blocks until no reader is mid-copy on this segment, so that when
+          // the handle finishes destructing the owner can free the buffer.
+          registry->erase(segId);
+        }
+      });
+}
+
+Result<std::unique_ptr<RemoteRegistrationHandle>>
+TcpTransportFactory::importSegment(
+    size_t segmentLength,
+    std::span<const uint8_t> payload) {
+  auto handle =
+      TcpRemoteRegistrationHandle::deserialize(segmentLength, payload);
+  if (!handle) {
+    return std::move(handle).error();
+  }
+  return std::move(handle).value();
+}
+
+Result<std::unique_ptr<Transport>> TcpTransportFactory::createTransport(
+    std::span<const uint8_t> peerTopology) {
+  // Validate the peer's capability blob before building anything, the way
+  // RdmaTransportFactory::createTransport does. The peer's *address* is not
+  // here; it arrives later through bind()/connect().
+  auto status = canConnect(peerTopology);
+  if (!status) {
+    return std::move(status).error();
+  }
+  return std::make_unique<TcpTransport>(
+      deviceId_, evb_, registry_, config_, host_, cudaApi_);
+}
+
+std::vector<uint8_t> TcpTransportFactory::getTopology() {
+  return TcpTopologyInfo{}.serialize();
+}
+
+Status TcpTransportFactory::canConnect(std::span<const uint8_t> peerTopology) {
+  auto info = TcpTopologyInfo::deserialize(peerTopology);
+  if (!info) {
+    return std::move(info).error();
+  }
+  if (info->version != kTcpWireVersion) {
+    return Err(
+        ErrCode::TopologyDisconnect,
+        "tcp: unsupported peer wire version " + std::to_string(info->version) +
+            ", local is " + std::to_string(kTcpWireVersion));
+  }
+  return Ok();
+}
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -1,0 +1,613 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <span>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "comms/uniflow/controller/TcpController.h"
+#include "comms/uniflow/executor/EventBase.h"
+#include "comms/uniflow/transport/Transport.h"
+
+namespace uniflow {
+
+class TcpRemoteRegistrationHandle;
+
+/// Completion state shared by all requests in a single put()/get()/send()/
+/// recv() call. The call's promise is fulfilled once every request's reply has
+/// arrived, or on the first error. Thread-safe: touched by the caller thread,
+/// the reader thread and the sender thread.
+struct TcpOpState {
+  std::mutex mu;
+  size_t remaining{0};
+  bool done{false};
+  std::promise<Status> promise;
+
+  void completeOne() {
+    std::lock_guard<std::mutex> lk(mu);
+    completeOneLocked();
+  }
+
+  void fail(Status status) {
+    std::lock_guard<std::mutex> lk(mu);
+    failLocked(std::move(status));
+  }
+
+  /// Copies a reply payload into the caller's destination buffer (`write`) and
+  /// records that chunk's completion as one atomic step.
+  ///
+  /// Resolving this op's promise is what releases the caller to free or reuse
+  /// the destination, so a write into it may only start while the promise is
+  /// unresolved and must keep it unresolved until the write finishes. Holding
+  /// `mu` across `write` gives both: a concurrent fail() (send error, peer
+  /// disconnect, shutdown) either resolves the op first, in which case `write`
+  /// is skipped because the destination may already be gone, or it blocks
+  /// until the write is done.
+  ///
+  /// `mu` is a leaf lock: nothing in this struct acquires another mutex while
+  /// holding it, and no caller may hold one of the transport's container
+  /// mutexes (`inflightMu_`, `recvMu_`, `outMu_`) when calling in. `write`
+  /// therefore must only touch the destination buffer -- a memcpy or a device
+  /// copy -- and never reach back into the transport's queues.
+  template <typename Fn>
+  void writeAndComplete(Fn&& write) {
+    std::lock_guard<std::mutex> lk(mu);
+    if (done) {
+      return;
+    }
+    Status status = write();
+    if (status.hasError()) {
+      failLocked(std::move(status));
+    } else {
+      completeOneLocked();
+    }
+  }
+
+ private:
+  void completeOneLocked() {
+    if (done) {
+      return;
+    }
+    if (remaining > 0) {
+      --remaining;
+    }
+    if (remaining == 0) {
+      done = true;
+      promise.set_value(Ok());
+    }
+  }
+
+  void failLocked(Status status) {
+    if (done) {
+      return;
+    }
+    done = true;
+    promise.set_value(std::move(status));
+  }
+};
+
+struct TcpTransportInfo {
+  struct __attribute__((packed)) Header {
+    uint16_t port{0};
+    uint16_t hostLen{0};
+  };
+
+  std::string host{"127.0.0.1"};
+  uint16_t port{0};
+
+  TransportInfo serialize() const;
+  static Result<TcpTransportInfo> deserialize(std::span<const uint8_t> data);
+};
+
+class CudaApi;
+
+/// Factory-shared registry mapping a locally-assigned segment id to the
+/// registered host buffer. registerSegment() (on the factory) populates it;
+/// every TcpTransport created by that factory shares it so an inbound WRITE or
+/// READ_REQUEST naming a segId can be resolved to the local buffer.
+/// Thread-safe.
+///
+/// The registry hands out leases rather than bare entries because the mutex
+/// protects the map, not the lifetime of the memory the map points at. `ptr` is
+/// the application's buffer, borrowed at registerSegment() time; the registry
+/// never owns it and so cannot extend its life. Without a lease the reader
+/// thread could copy an entry out, the owner could deregister and free the
+/// buffer, and the reader would then write into freed memory. erase() therefore
+/// waits for outstanding leases to drain, which is the barrier ibv_dereg_mr
+/// gives the RDMA path for free.
+class TcpSegmentRegistry {
+ public:
+  struct Entry {
+    void* ptr{nullptr};
+    size_t len{0};
+    MemoryType memType{MemoryType::DRAM};
+    int deviceId{-1};
+  };
+
+  /// A borrow of a registered segment that blocks its deregistration. While a
+  /// lease is alive, erase() for that segId waits, so `ptr` stays valid for as
+  /// long as the holder keeps the lease in scope. Hold one across every access
+  /// to `ptr` -- a memcpy or a device copy -- and let it go as soon as the copy
+  /// is done, because a lease held longer stalls any thread deregistering that
+  /// segment. Empty (`!lease`) means the segment is unregistered or already
+  /// being torn down.
+  class Lease {
+   public:
+    Lease() = default;
+    Lease(TcpSegmentRegistry* registry, uint64_t segId, Entry entry)
+        : registry_(registry), segId_(segId), entry_(entry) {}
+
+    ~Lease() {
+      reset();
+    }
+
+    Lease(Lease&& other) noexcept
+        : registry_(other.registry_),
+          segId_(other.segId_),
+          entry_(other.entry_) {
+      other.registry_ = nullptr;
+    }
+
+    Lease& operator=(Lease&& other) noexcept {
+      if (this != &other) {
+        reset();
+        registry_ = other.registry_;
+        segId_ = other.segId_;
+        entry_ = other.entry_;
+        other.registry_ = nullptr;
+      }
+      return *this;
+    }
+
+    Lease(const Lease&) = delete;
+    Lease& operator=(const Lease&) = delete;
+
+    explicit operator bool() const {
+      return registry_ != nullptr;
+    }
+    const Entry* operator->() const {
+      return &entry_;
+    }
+    const Entry& operator*() const {
+      return entry_;
+    }
+
+    void reset() {
+      if (registry_ != nullptr) {
+        registry_->releaseLease(segId_);
+        registry_ = nullptr;
+      }
+    }
+
+   private:
+    TcpSegmentRegistry* registry_{nullptr};
+    uint64_t segId_{0};
+    Entry entry_{};
+  };
+
+  void
+  add(uint64_t segId, void* ptr, size_t len, MemoryType memType, int deviceId) {
+    std::lock_guard<std::mutex> lk(mu_);
+    segs_[segId] = Slot{Entry{ptr, len, memType, deviceId}, 0, false};
+  }
+
+  /// Never blocks: a segment being torn down yields an empty lease rather than
+  /// waiting, so the reader thread is never parked behind a deregistration.
+  Lease find(uint64_t segId) {
+    std::lock_guard<std::mutex> lk(mu_);
+    auto it = segs_.find(segId);
+    if (it == segs_.end() || it->second.dying) {
+      return Lease{};
+    }
+    ++it->second.leases;
+    return Lease{this, segId, it->second.entry};
+  }
+
+  /// Blocks until every outstanding lease on `segId` is released, so that when
+  /// this returns no thread is still reading from or writing to the segment and
+  /// the owner may free it.
+  ///
+  /// Callers must hold no other transport lock: this waits on another thread
+  /// making progress. No lock cycle is possible -- find() and releaseLease()
+  /// are the only other acquirers of mu_ and neither waits, and nothing
+  /// acquires mu_ while holding another transport mutex.
+  ///
+  /// How long this can block is bounded by the slowest lease holder, and on the
+  /// VRAM path that is not bounded by the transport. The reader queues its Ack
+  /// and reply frames without blocking, but it holds its lease across the whole
+  /// host-staging copy, and that copy ends in a synchronize on the null stream
+  /// (handleFrame passes no stream), which waits on every blocking stream on
+  /// the device -- i.e. on unrelated application GPU work. So a caller here can
+  /// wait for an application step, and deadlocks outright if that GPU work is
+  /// itself gated on a later inbound frame, since the parked reader is the
+  /// thread that would deliver it. Giving the staging copies a dedicated
+  /// non-blocking stream removes both; until then a DRAM-only deployment is the
+  /// safe case, because there the copy under lease is a plain memcpy.
+  void erase(uint64_t segId) {
+    std::unique_lock<std::mutex> lk(mu_);
+    auto it = segs_.find(segId);
+    if (it == segs_.end()) {
+      return;
+    }
+    // Stop handing out leases first, or a steady stream of inbound frames for
+    // this segment could keep the count above zero and starve the wait.
+    it->second.dying = true;
+    drained_.wait(lk, [this, segId]() {
+      auto slot = segs_.find(segId);
+      return slot == segs_.end() || slot->second.leases == 0;
+    });
+    segs_.erase(segId);
+  }
+
+ private:
+  struct Slot {
+    Entry entry;
+    int leases{0};
+    // Set by erase() so find() stops issuing leases while it drains.
+    bool dying{false};
+  };
+
+  void releaseLease(uint64_t segId) {
+    bool notify = false;
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      auto it = segs_.find(segId);
+      if (it == segs_.end()) {
+        return;
+      }
+      if (it->second.leases > 0) {
+        --it->second.leases;
+      }
+      // Only an erase() is ever waiting, so skip the notify on the hot path.
+      notify = it->second.dying && it->second.leases == 0;
+    }
+    if (notify) {
+      drained_.notify_all();
+    }
+  }
+
+  mutable std::mutex mu_;
+  std::condition_variable drained_;
+  std::unordered_map<uint64_t, Slot> segs_;
+};
+
+/// Tracks a single in-flight request awaiting its reply. Shared completion
+/// state is aggregated per put()/get() call in TcpOpState.
+struct TcpInflight {
+  std::shared_ptr<TcpOpState> state;
+  void* dst{nullptr}; // READ destination; nullptr for WRITE.
+  size_t len{0};
+  bool isRead{false};
+  MemoryType memType{MemoryType::DRAM};
+  int deviceId{-1};
+  // Caller's CUDA stream (as void*) for VRAM staging on the get() consumer
+  // path, so the H2D is ordered against the framework's stream (not the null
+  // stream). nullptr => null stream.
+  void* stream{nullptr};
+};
+
+/// One queued outbound frame. `onSent`, when set, is completed by the sender
+/// thread once the frame is flushed to the socket (two-sided send()).
+struct TcpOutItem {
+  std::vector<uint8_t> bytes;
+  std::shared_ptr<TcpOpState> onSent;
+};
+
+/// A posted recv() awaiting a matching inbound SEND frame.
+struct TcpPendingRecv {
+  void* dst{nullptr};
+  size_t cap{0};
+  std::shared_ptr<TcpOpState> state;
+  MemoryType memType{MemoryType::DRAM};
+  int deviceId{-1};
+  // Caller's CUDA stream (as void*) for the H2D that lands the payload, so the
+  // copy is ordered against the framework's stream rather than the null stream.
+  // Retained here because the matching SEND may not arrive until long after
+  // recv() returned, by which point the caller's RequestOptions is gone.
+  // Mirrors TcpInflight::stream on the get() path.
+  void* stream{nullptr};
+};
+
+/// Native, self-contained TCP data transport.
+///
+/// Establishes one full-duplex data connection per peer (deterministic
+/// listener/dialer role by host:port ordering). Three threads run per
+/// connection:
+///  - reader: blocking recv + demultiplex; never blocks on a send, so it always
+///    drains inbound (avoids the mutual-READ deadlock).
+///  - sender: drains an outbound frame queue and performs all socket sends
+///    (requests, ACKs, READ replies), serialized by construction.
+///
+/// put() copies a local buffer into a peer segment (WRITE + ACK). get() is
+/// emulated as a pull: READ_REQUEST -> peer replies READ_REPLY with the data.
+///
+/// Independent of NIXL/UCX/folly. send()/recv() implement a two-sided
+/// rendezvous (FIFO-matched via pendingRecvs_/unmatchedSends_).
+class TcpTransport : public Transport {
+ public:
+  TcpTransport(
+      int deviceId,
+      EventBase* evb,
+      std::shared_ptr<TcpSegmentRegistry> registry,
+      controller::TcpSocketConfig config = {},
+      std::string host = "127.0.0.1",
+      std::shared_ptr<CudaApi> cudaApi = nullptr);
+
+  ~TcpTransport() override;
+
+  TcpTransport(const TcpTransport&) = delete;
+  TcpTransport& operator=(const TcpTransport&) = delete;
+  TcpTransport(TcpTransport&&) = delete;
+  TcpTransport& operator=(TcpTransport&&) = delete;
+
+  const std::string& name() const noexcept override {
+    return name_;
+  }
+
+  TransportType transportType() const noexcept override {
+    return TransportType::TCP;
+  }
+
+  TransportState state() const noexcept override {
+    return state_;
+  }
+
+  TransportInfo bind() override;
+  Status connect(std::span<const uint8_t> remoteInfo) override;
+
+  std::future<Status> put(
+      std::span<const TransferRequest> requests,
+      const RequestOptions& options = {}) override;
+
+  std::future<Status> get(
+      std::span<const TransferRequest> requests,
+      const RequestOptions& options = {}) override;
+
+  std::future<Status> send(
+      RegisteredSegment::Span src,
+      const RequestOptions& options = {}) override;
+
+  std::future<Status> recv(
+      RegisteredSegment::Span dst,
+      const RequestOptions& options = {}) override;
+
+  std::future<Status> send(
+      Segment::Span src,
+      const RequestOptions& options = {}) override;
+
+  std::future<Status> recv(
+      Segment::Span dst,
+      const RequestOptions& options = {}) override;
+
+  void shutdown() override;
+
+ private:
+  // Needs handleFrame() plus the outbound queue to drive peer-supplied frames
+  // directly and assert the bounds checks reject them. Those checks are the
+  // memory-safety boundary of this transport, so they are worth pinning.
+  friend class TcpTransportFrameTest;
+
+  Result<const TcpRemoteRegistrationHandle*> findRemoteHandle(
+      const RemoteRegisteredSegment::Span& span) const;
+
+  // Reader thread: blocking recv + demultiplex until the connection closes.
+  void readerLoop() noexcept;
+  // Sender thread: drains outQueue_ and performs all socket sends.
+  void senderLoop() noexcept;
+  // Handles one fully-received inbound frame (reader thread).
+  void handleFrame(std::span<const uint8_t> frame) noexcept;
+  // The body of handleFrame(), allowed to throw. Peer-supplied lengths size
+  // allocations in here and the VRAM staging path throws on an invalid
+  // deviceId, so handleFrame() is the boundary that stops either reaching the
+  // top of the reader thread.
+  void handleFrameImpl(std::span<const uint8_t> frame);
+  // Queues one fire-and-forget framed message for the sender thread.
+  // `mayBlock` must be true only for caller threads. Returns false if the frame
+  // was not queued (transport closing, or the reader hit the cap and refused
+  // the connection).
+  [[nodiscard]] bool enqueueFrame(std::vector<uint8_t> frame, bool mayBlock);
+  // Queues a framed message whose completion is reported via `onSent` once the
+  // frame is flushed (two-sided send()).
+  void enqueueSendFrame(
+      std::vector<uint8_t> frame,
+      std::shared_ptr<TcpOpState> onSent);
+  // Registers an in-flight request, but only if teardown has not already swept
+  // the map. Returns false if the transport broke first, in which case the
+  // caller must fail the op: nothing else will ever resolve it.
+  //
+  // The entry-time state_/connBroken_ checks in put()/get() are not enough on
+  // their own -- a failAllPending() can land between that check and this
+  // insert, leaving an entry no sweep will ever see and a caller blocked in
+  // future.get() forever. Checking connBroken_ *under* inflightMu_ makes the
+  // two outcomes exclusive: either the insert precedes the sweep and the sweep
+  // fails it, or the sweep precedes the insert and this returns false.
+  Status admitInflight(uint64_t reqId, TcpInflight entry);
+
+  // Shared bodies for the zero-copy and copy-based send/recv overloads.
+  // `options` is threaded through rather than dropped so a VRAM caller's stream
+  // reaches the host-staging copy, as put()/get() already do.
+  std::future<Status> sendImpl(
+      const void* data,
+      size_t len,
+      MemoryType memType,
+      int deviceId,
+      const RequestOptions& options);
+  std::future<Status> recvImpl(
+      void* dst,
+      size_t cap,
+      MemoryType memType,
+      int deviceId,
+      const RequestOptions& options);
+  // Host-staging copies used for VRAM segments (plain memcpy for DRAM):
+  // hostFromDevice = D2H, deviceFromHost = H2D. Synchronous. `stream` (a
+  // cudaStream_t as void*, nullptr => null stream) orders the copy against the
+  // caller's framework stream, matching the RDMA CopyEngine.
+  Status hostFromDevice(
+      void* hostDst,
+      const void* devSrc,
+      size_t len,
+      int deviceId,
+      void* stream = nullptr);
+  Status deviceFromHost(
+      void* devDst,
+      const void* hostSrc,
+      size_t len,
+      int deviceId,
+      void* stream = nullptr);
+  // Fails every pending put/get/recv/queued-send; marks the conn broken.
+  void failAllPending(const char* message);
+  // Closes the data connection, at most once for the lifetime of the transport.
+  // Both the reader thread and shutdown() refuse the connection, so this has
+  // two concurrent callers.
+  void closeDataConnOnce();
+
+  [[maybe_unused]] int deviceId_{-1};
+  EventBase* evb_{nullptr};
+  std::shared_ptr<TcpSegmentRegistry> registry_;
+  std::shared_ptr<CudaApi> cudaApi_;
+  controller::TcpSocketConfig config_;
+  std::string name_{"tcp"};
+  // Atomic: written by bind()/connect()/shutdown() and read by the
+  // put/get/send/recv guards and state(), which callers may invoke from any
+  // thread (e.g. a shutdown racing an in-flight transfer). A plain member here
+  // is a data race, matching why running_/connBroken_ below are atomic too.
+  std::atomic<TransportState> state_{TransportState::Disconnected};
+
+  std::string host_{"127.0.0.1"};
+  uint16_t port_{0};
+
+  std::unique_ptr<controller::AsyncTcpServer> server_;
+  std::unique_ptr<controller::Conn> dataConn_;
+
+  // Serialises bind()/connect()/shutdown(), which together own server_,
+  // dataConn_, reader_ and sender_. Without it a shutdown() concurrent with an
+  // in-progress connect() races a unique_ptr and two std::thread objects, and
+  // -- because connect() parks for the whole handshake -- can let connect()
+  // install a live connection and both threads *after* shutdown() has already
+  // torn down and returned.
+  //
+  // Held for the entire body of each of the three, including connect()'s
+  // handshake wait, so a concurrent shutdown() waits out the handshake (bounded
+  // by config_.connTimeout) instead of interleaving with it. Deliberately NOT
+  // taken by put/get/send/recv, which keep reading state_/connBroken_
+  // atomically so a transfer is never serialised against a connect. Safe to
+  // hold across the reader_/sender_ joins in shutdown(): neither loop, nor
+  // failAllPending(), ever acquires it.
+  // Bounds on the outbound queue and the in-flight map, for work this side
+  // originates: outQueue_ holds whole payloads, and inflight_ one entry per
+  // outstanding chunk, so an application issuing put/get faster than the link
+  // drains would otherwise grow both without limit. Caller threads wait for
+  // room, which is real backpressure -- the application slows down and nothing
+  // breaks.
+  //
+  // kMaxOutQueueBytes deliberately does NOT apply to the reader thread's
+  // replies. A get of N bytes legitimately requires up to N bytes of ReadReply
+  // queued, and N is bounded only by the segment size, so no fixed cap can
+  // distinguish a large honest get from abuse. The reader also cannot wait
+  // without ceasing to drain the socket, which is the mutual-READ deadlock the
+  // reader/sender split exists to avoid. Bounding the reply side properly needs
+  // credit-based flow control in the wire protocol; until then the drain rate
+  // is what bounds it.
+  static constexpr size_t kMaxOutQueueBytes = 64UL * 1024 * 1024;
+  static constexpr size_t kMaxInflightRequests = 4096;
+  // Bytes currently queued in outQueue_. Guarded by outMu_.
+  size_t outBytes_{0};
+
+  // Cap on bytes buffered in unmatchedSends_. The reader thread never stops
+  // draining the socket -- that is what avoids the mutual-READ deadlock -- so
+  // the socket buffer applies no backpressure and a peer sending faster than
+  // the local side posts recvs would grow this deque without limit, each entry
+  // up to the wire-frame cap. One max-size frame may sit buffered; beyond that
+  // the connection is refused rather than absorbed.
+  static constexpr size_t kMaxUnmatchedSendBytes = 64UL * 1024 * 1024;
+  // Total bytes currently held in unmatchedSends_. Guarded by recvMu_.
+  size_t unmatchedBytes_{0};
+
+  std::mutex lifecycleMu_;
+  // Set once by shutdown() under lifecycleMu_. Makes teardown one-shot and
+  // stops a later bind()/connect() from resurrecting a shut-down transport.
+  // Checked under the mutex rather than short-circuiting before it, so a second
+  // shutdown() (the normal MultiTransport-then-destructor path) waits for the
+  // first to finish rather than returning while teardown is still running.
+  std::atomic<bool> shutdown_{false};
+
+  std::thread reader_;
+  std::thread sender_;
+  std::atomic<bool> running_{false};
+  std::atomic<bool> connBroken_{false};
+  // Gates closeDataConnOnce(). Conn::close() is a check-then-act on a bare fd,
+  // so two callers seeing it open both close it; the second reaps a descriptor
+  // some unrelated thread has since been handed.
+  std::atomic<bool> dataConnClosed_{false};
+
+  // Outbound frame queue drained by the sender thread. Decoupling all sends
+  // from the reader thread is what prevents a mutual-READ deadlock (two peers'
+  // readers both blocked mid-send while neither drains its recv).
+  std::mutex outMu_;
+  std::condition_variable outCv_;
+  std::deque<TcpOutItem> outQueue_;
+  bool outClosed_{false};
+
+  std::mutex inflightMu_;
+  std::unordered_map<uint64_t, TcpInflight> inflight_;
+  std::atomic<uint64_t> nextReqId_{1};
+
+  // Two-sided send/recv rendezvous (FIFO-matched on the single stream):
+  // inbound SEND frames waiting for a posted recv, and posted recvs waiting
+  // for an inbound SEND frame.
+  std::mutex recvMu_;
+  std::deque<TcpPendingRecv> pendingRecvs_;
+  std::deque<std::vector<uint8_t>> unmatchedSends_;
+};
+
+class TcpTransportFactory : public TransportFactory {
+ public:
+  static Status supported();
+
+  // @param host  Local IP the transport binds to and advertises to peers.
+  //              Defaults to loopback; pass a routable IP (e.g. an eth2 IPv6)
+  //              for cross-host transfers.
+  explicit TcpTransportFactory(
+      int deviceId,
+      EventBase* evb,
+      controller::TcpSocketConfig config = {},
+      std::string host = "127.0.0.1",
+      std::shared_ptr<CudaApi> cudaApi = nullptr);
+
+  Result<std::unique_ptr<RegistrationHandle>> registerSegment(
+      Segment& segment) override;
+
+  Result<std::unique_ptr<RemoteRegistrationHandle>> importSegment(
+      size_t segmentLength,
+      std::span<const uint8_t> payload) override;
+
+  Result<std::unique_ptr<Transport>> createTransport(
+      std::span<const uint8_t> peerTopology) override;
+
+  std::vector<uint8_t> getTopology() override;
+
+  Status canConnect(std::span<const uint8_t> peerTopology) override;
+
+ private:
+  int deviceId_{-1};
+  EventBase* evb_{nullptr};
+  controller::TcpSocketConfig config_;
+  std::string host_{"127.0.0.1"};
+  std::shared_ptr<CudaApi> cudaApi_;
+  std::shared_ptr<TcpSegmentRegistry> registry_{
+      std::make_shared<TcpSegmentRegistry>()};
+  std::atomic<uint64_t> nextSegId_{1};
+};
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -1,0 +1,306 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <span>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "comms/uniflow/controller/TcpController.h"
+#include "comms/uniflow/executor/EventBase.h"
+#include "comms/uniflow/transport/Transport.h"
+
+namespace uniflow {
+
+// Defined in TcpTransport.cpp.
+struct TcpOpState;
+
+class TcpRemoteRegistrationHandle;
+
+struct TcpTransportInfo {
+  struct __attribute__((packed)) Header {
+    uint16_t port{0};
+    uint16_t hostLen{0};
+  };
+
+  std::string host{"127.0.0.1"};
+  uint16_t port{0};
+
+  TransportInfo serialize() const;
+  static Result<TcpTransportInfo> deserialize(std::span<const uint8_t> data);
+};
+
+class CudaApi;
+
+/// Factory-shared registry mapping a locally-assigned segment id to the
+/// registered host buffer. registerSegment() (on the factory) populates it;
+/// every TcpTransport created by that factory shares it so an inbound WRITE or
+/// READ_REQUEST naming a segId can be resolved to the local buffer.
+/// Thread-safe.
+class TcpSegmentRegistry {
+ public:
+  struct Entry {
+    void* ptr{nullptr};
+    size_t len{0};
+    MemoryType memType{MemoryType::DRAM};
+    int deviceId{-1};
+  };
+
+  void
+  add(uint64_t segId, void* ptr, size_t len, MemoryType memType, int deviceId) {
+    std::lock_guard<std::mutex> lk(mu_);
+    segs_[segId] = Entry{ptr, len, memType, deviceId};
+  }
+
+  std::optional<Entry> find(uint64_t segId) const {
+    std::lock_guard<std::mutex> lk(mu_);
+    auto it = segs_.find(segId);
+    if (it == segs_.end()) {
+      return std::nullopt;
+    }
+    return it->second;
+  }
+
+  void erase(uint64_t segId) {
+    std::lock_guard<std::mutex> lk(mu_);
+    segs_.erase(segId);
+  }
+
+ private:
+  mutable std::mutex mu_;
+  std::unordered_map<uint64_t, Entry> segs_;
+};
+
+/// Tracks a single in-flight request awaiting its reply. Shared completion
+/// state is aggregated per put()/get() call in TcpOpState.
+struct TcpInflight {
+  std::shared_ptr<TcpOpState> state;
+  void* dst{nullptr}; // READ destination; nullptr for WRITE.
+  size_t len{0};
+  bool isRead{false};
+  MemoryType memType{MemoryType::DRAM};
+  int deviceId{-1};
+  // Caller's CUDA stream (as void*) for VRAM staging on the get() consumer
+  // path, so the H2D is ordered against the framework's stream (not the null
+  // stream). nullptr => null stream.
+  void* stream{nullptr};
+};
+
+/// One queued outbound frame. `onSent`, when set, is completed by the sender
+/// thread once the frame is flushed to the socket (two-sided send()).
+struct TcpOutItem {
+  std::vector<uint8_t> bytes;
+  std::shared_ptr<TcpOpState> onSent;
+};
+
+/// A posted recv() awaiting a matching inbound SEND frame.
+struct TcpPendingRecv {
+  void* dst{nullptr};
+  size_t cap{0};
+  std::shared_ptr<TcpOpState> state;
+  MemoryType memType{MemoryType::DRAM};
+  int deviceId{-1};
+};
+
+/// Native, self-contained TCP data transport.
+///
+/// Establishes one full-duplex data connection per peer (deterministic
+/// listener/dialer role by host:port ordering). Three threads run per
+/// connection:
+///  - reader: blocking recv + demultiplex; never blocks on a send, so it always
+///    drains inbound (avoids the mutual-READ deadlock).
+///  - sender: drains an outbound frame queue and performs all socket sends
+///    (requests, ACKs, READ replies), serialized by construction.
+///
+/// put() copies a local buffer into a peer segment (WRITE + ACK). get() is
+/// emulated as a pull: READ_REQUEST -> peer replies READ_REPLY with the data.
+///
+/// Independent of NIXL/UCX/folly. send()/recv() implement a two-sided
+/// rendezvous (FIFO-matched via pendingRecvs_/unmatchedSends_).
+class TcpTransport : public Transport {
+ public:
+  TcpTransport(
+      int deviceId,
+      EventBase* evb,
+      std::shared_ptr<TcpSegmentRegistry> registry,
+      controller::TcpSocketConfig config = {},
+      std::string host = "127.0.0.1",
+      std::shared_ptr<CudaApi> cudaApi = nullptr);
+
+  ~TcpTransport() override;
+
+  TcpTransport(const TcpTransport&) = delete;
+  TcpTransport& operator=(const TcpTransport&) = delete;
+  TcpTransport(TcpTransport&&) = delete;
+  TcpTransport& operator=(TcpTransport&&) = delete;
+
+  const std::string& name() const noexcept override {
+    return name_;
+  }
+
+  TransportType transportType() const noexcept override {
+    return TransportType::TCP;
+  }
+
+  TransportState state() const noexcept override {
+    return state_;
+  }
+
+  TransportInfo bind() override;
+  Status connect(std::span<const uint8_t> remoteInfo) override;
+
+  std::future<Status> put(
+      std::span<const TransferRequest> requests,
+      const RequestOptions& options = {}) override;
+
+  std::future<Status> get(
+      std::span<const TransferRequest> requests,
+      const RequestOptions& options = {}) override;
+
+  std::future<Status> send(
+      RegisteredSegment::Span src,
+      const RequestOptions& options = {}) override;
+
+  std::future<Status> recv(
+      RegisteredSegment::Span dst,
+      const RequestOptions& options = {}) override;
+
+  std::future<Status> send(
+      Segment::Span src,
+      const RequestOptions& options = {}) override;
+
+  std::future<Status> recv(
+      Segment::Span dst,
+      const RequestOptions& options = {}) override;
+
+  void shutdown() override;
+
+ private:
+  Result<const TcpRemoteRegistrationHandle*> findRemoteHandle(
+      const RemoteRegisteredSegment::Span& span) const;
+
+  // Reader thread: blocking recv + demultiplex until the connection closes.
+  void readerLoop() noexcept;
+  // Sender thread: drains outQueue_ and performs all socket sends.
+  void senderLoop() noexcept;
+  // Handles one fully-received inbound frame (reader thread).
+  void handleFrame(std::span<const uint8_t> frame) noexcept;
+  // Queues one fire-and-forget framed message for the sender thread.
+  void enqueueFrame(std::vector<uint8_t> frame);
+  // Queues a framed message whose completion is reported via `onSent` once the
+  // frame is flushed (two-sided send()).
+  void enqueueSendFrame(
+      std::vector<uint8_t> frame,
+      std::shared_ptr<TcpOpState> onSent);
+  // Shared bodies for the zero-copy and copy-based send/recv overloads.
+  std::future<Status>
+  sendImpl(const void* data, size_t len, MemoryType memType, int deviceId);
+  std::future<Status>
+  recvImpl(void* dst, size_t cap, MemoryType memType, int deviceId);
+  // Host-staging copies used for VRAM segments (plain memcpy for DRAM):
+  // hostFromDevice = D2H, deviceFromHost = H2D. Synchronous. `stream` (a
+  // cudaStream_t as void*, nullptr => null stream) orders the copy against the
+  // caller's framework stream, matching the RDMA CopyEngine.
+  Status hostFromDevice(
+      void* hostDst,
+      const void* devSrc,
+      size_t len,
+      int deviceId,
+      void* stream = nullptr);
+  Status deviceFromHost(
+      void* devDst,
+      const void* hostSrc,
+      size_t len,
+      int deviceId,
+      void* stream = nullptr);
+  // Fails every pending put/get/recv/queued-send; marks the conn broken.
+  void failAllPending(const char* message);
+
+  [[maybe_unused]] int deviceId_{-1};
+  EventBase* evb_{nullptr};
+  std::shared_ptr<TcpSegmentRegistry> registry_;
+  std::shared_ptr<CudaApi> cudaApi_;
+  controller::TcpSocketConfig config_;
+  std::string name_{"tcp"};
+  TransportState state_{TransportState::Disconnected};
+
+  std::string host_{"127.0.0.1"};
+  uint16_t port_{0};
+
+  std::unique_ptr<controller::AsyncTcpServer> server_;
+  std::unique_ptr<controller::Conn> dataConn_;
+
+  std::thread reader_;
+  std::thread sender_;
+  std::atomic<bool> running_{false};
+  std::atomic<bool> connBroken_{false};
+
+  // Outbound frame queue drained by the sender thread. Decoupling all sends
+  // from the reader thread is what prevents a mutual-READ deadlock (two peers'
+  // readers both blocked mid-send while neither drains its recv).
+  std::mutex outMu_;
+  std::condition_variable outCv_;
+  std::deque<TcpOutItem> outQueue_;
+  bool outClosed_{false};
+
+  std::mutex inflightMu_;
+  std::unordered_map<uint64_t, TcpInflight> inflight_;
+  std::atomic<uint64_t> nextReqId_{1};
+
+  // Two-sided send/recv rendezvous (FIFO-matched on the single stream):
+  // inbound SEND frames waiting for a posted recv, and posted recvs waiting
+  // for an inbound SEND frame.
+  std::mutex recvMu_;
+  std::deque<TcpPendingRecv> pendingRecvs_;
+  std::deque<std::vector<uint8_t>> unmatchedSends_;
+};
+
+class TcpTransportFactory : public TransportFactory {
+ public:
+  static Status supported();
+
+  // @param host  Local IP the transport binds to and advertises to peers.
+  //              Defaults to loopback; pass a routable IP (e.g. an eth2 IPv6)
+  //              for cross-host transfers.
+  explicit TcpTransportFactory(
+      int deviceId,
+      EventBase* evb,
+      controller::TcpSocketConfig config = {},
+      std::string host = "127.0.0.1",
+      std::shared_ptr<CudaApi> cudaApi = nullptr);
+
+  Result<std::unique_ptr<RegistrationHandle>> registerSegment(
+      Segment& segment) override;
+
+  Result<std::unique_ptr<RemoteRegistrationHandle>> importSegment(
+      size_t segmentLength,
+      std::span<const uint8_t> payload) override;
+
+  Result<std::unique_ptr<Transport>> createTransport(
+      std::span<const uint8_t> peerTopology) override;
+
+  std::vector<uint8_t> getTopology() override;
+
+  Status canConnect(std::span<const uint8_t> peerTopology) override;
+
+ private:
+  int deviceId_{-1};
+  EventBase* evb_{nullptr};
+  controller::TcpSocketConfig config_;
+  std::string host_{"127.0.0.1"};
+  std::shared_ptr<CudaApi> cudaApi_;
+  std::shared_ptr<TcpSegmentRegistry> registry_{
+      std::make_shared<TcpSegmentRegistry>()};
+  std::atomic<uint64_t> nextSegId_{1};
+};
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/TcpWireProtocol.h
+++ b/comms/uniflow/transport/tcp/TcpWireProtocol.h
@@ -1,0 +1,68 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <vector>
+
+#include "comms/uniflow/Result.h"
+
+namespace uniflow {
+
+constexpr uint8_t kTcpWireVersion{1};
+
+enum class TcpOp : uint8_t {
+  Write = 1,
+  ReadRequest = 2,
+  ReadReply = 3,
+  Notification = 4,
+  Ack = 5,
+  Error = 6,
+  Send = 7,
+};
+
+struct __attribute__((packed)) TcpMsgHeader {
+  uint8_t version{kTcpWireVersion};
+  uint8_t op{0};
+  uint8_t flags{0};
+  uint8_t rsvd{0};
+  uint64_t reqId{0};
+  uint64_t segId{0};
+  uint64_t offset{0};
+  uint64_t len{0};
+};
+
+static_assert(sizeof(TcpMsgHeader) == 36);
+
+inline std::vector<uint8_t> serializeTcpHeader(const TcpMsgHeader& header) {
+  std::vector<uint8_t> data(sizeof(TcpMsgHeader));
+  std::memcpy(data.data(), &header, sizeof(header));
+  return data;
+}
+
+inline Result<TcpMsgHeader> deserializeTcpHeader(
+    std::span<const uint8_t> data) {
+  if (data.size() < sizeof(TcpMsgHeader)) {
+    return Err(
+        ErrCode::InvalidArgument,
+        "tcp header truncated: need " + std::to_string(sizeof(TcpMsgHeader)) +
+            " bytes, got " + std::to_string(data.size()));
+  }
+
+  TcpMsgHeader header;
+  std::memcpy(&header, data.data(), sizeof(header));
+  if (header.version != kTcpWireVersion) {
+    return Err(
+        ErrCode::InvalidArgument,
+        "unsupported tcp wire version " + std::to_string(header.version));
+  }
+  return header;
+}
+
+inline bool tcpOpHasPayload(TcpOp op) {
+  return op == TcpOp::Write || op == TcpOp::ReadReply || op == TcpOp::Send;
+}
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/TcpWireProtocol.h
+++ b/comms/uniflow/transport/tcp/TcpWireProtocol.h
@@ -1,0 +1,109 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <vector>
+
+#include "comms/uniflow/Result.h"
+
+namespace uniflow {
+
+constexpr uint8_t kTcpWireVersion{1};
+
+// Hard wire-frame cap from the controller's TcpConn framing (4-byte length
+// prefix, 64 MiB max message). Any frame this transport emits -- including a
+// ReadReply it builds on a peer's behalf -- must fit within it, because the
+// controller refuses an oversized send and the sender thread treats that
+// refusal as fatal.
+constexpr size_t kMaxFrameSize = 64u << 20; // 64 MiB
+
+enum class TcpOp : uint8_t {
+  Write = 1,
+  ReadRequest = 2,
+  ReadReply = 3,
+  Notification = 4,
+  Ack = 5,
+  Error = 6,
+  Send = 7,
+};
+
+struct __attribute__((packed)) TcpMsgHeader {
+  uint8_t version{kTcpWireVersion};
+  uint8_t op{0};
+  uint8_t flags{0};
+  uint8_t rsvd{0};
+  uint64_t reqId{0};
+  uint64_t segId{0};
+  uint64_t offset{0};
+  uint64_t len{0};
+};
+
+static_assert(sizeof(TcpMsgHeader) == 36);
+
+inline std::vector<uint8_t> serializeTcpHeader(const TcpMsgHeader& header) {
+  std::vector<uint8_t> data(sizeof(TcpMsgHeader));
+  std::memcpy(data.data(), &header, sizeof(header));
+  return data;
+}
+
+inline Result<TcpMsgHeader> deserializeTcpHeader(
+    std::span<const uint8_t> data) {
+  if (data.size() < sizeof(TcpMsgHeader)) {
+    return Err(
+        ErrCode::InvalidArgument,
+        "tcp header truncated: need " + std::to_string(sizeof(TcpMsgHeader)) +
+            " bytes, got " + std::to_string(data.size()));
+  }
+
+  TcpMsgHeader header;
+  std::memcpy(&header, data.data(), sizeof(header));
+  if (header.version != kTcpWireVersion) {
+    return Err(
+        ErrCode::InvalidArgument,
+        "unsupported tcp wire version " + std::to_string(header.version));
+  }
+  return header;
+}
+
+inline bool tcpOpHasPayload(TcpOp op) {
+  return op == TcpOp::Write || op == TcpOp::ReadReply || op == TcpOp::Send;
+}
+
+/// Capability blob exchanged through TransportFactory::getTopology() /
+/// canConnect(), before any connection is attempted. Deliberately separate from
+/// TcpTransportInfo, which is *addressing* and is exchanged later via
+/// bind()/connect(): reusing the addressing struct as the capability blob left
+/// canConnect() with nothing meaningful to validate, so a wire-format mismatch
+/// could only be discovered mid-transfer as a dropped frame.
+///
+/// Versioned so that mismatch is rejected at handshake time instead. Mirrors
+/// RdmaTopologyInfo (transport/rdma/RdmaTransport.cpp). Shares kTcpWireVersion
+/// with the frame header so a single bump covers both; the size check is exact,
+/// so adding a capability field here requires bumping that version.
+struct __attribute__((packed)) TcpTopologyInfo {
+  uint8_t version{kTcpWireVersion};
+
+  std::vector<uint8_t> serialize() const {
+    std::vector<uint8_t> data(sizeof(TcpTopologyInfo));
+    std::memcpy(data.data(), this, sizeof(TcpTopologyInfo));
+    return data;
+  }
+
+  static Result<TcpTopologyInfo> deserialize(std::span<const uint8_t> data) {
+    if (data.size() != sizeof(TcpTopologyInfo)) {
+      return Err(
+          ErrCode::InvalidArgument,
+          "tcp topology payload size mismatch: expected " +
+              std::to_string(sizeof(TcpTopologyInfo)) + " bytes, got " +
+              std::to_string(data.size()));
+    }
+    TcpTopologyInfo info;
+    std::memcpy(&info, data.data(), sizeof(TcpTopologyInfo));
+    return info;
+  }
+};
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/tests/integration/CrossHostGpuTests.cpp
+++ b/comms/uniflow/transport/tcp/tests/integration/CrossHostGpuTests.cpp
@@ -1,0 +1,391 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/// Cross-host GPU (VRAM) integration test for the TCP transport.
+/// Requires MPI with 2 ranks on 2 different hosts (nnodes=2, ppn=1), each with
+/// at least one GPU. VRAM segments are transferred via host-staging inside the
+/// transport (D2H on the source, H2D on the destination); TCP never touches
+/// device memory directly. Front-end NIC (eth2) is auto-detected per host.
+///
+/// Running it for real (2 ranks): standard single-process CI can't form a
+/// 2-rank MPI world, so those lanes skip (see SetUp). Exercise it on two GPU
+/// hosts with the mpirun harness, pointing it at the GPU binary (set env vars):
+///
+///   BUILD_MODE=@mode/opt-amd-gpu
+///   ROCM_MODIFIER=rocm70
+///   BUILD_TARGET=fbcode//comms/uniflow/transport/tcp/tests/integration:cross_host_gpu_test_binary
+///   fbcode/scripts/cppc/run_uniflow_cross_host_tcp.sh rtptest521.maz5
+///   rtptest522.maz5
+
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <mpi.h>
+
+#include <cuda_runtime_api.h> // @manual=third-party//cuda:cuda-lazy
+
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/uniflow/Segment.h"
+#include "comms/uniflow/executor/ScopedEventBaseThread.h"
+#include "comms/uniflow/transport/tcp/TcpTransport.h"
+
+using meta::comms::MpiBaseTestFixture;
+using meta::comms::MPIEnvironmentBase;
+
+namespace uniflow {
+
+/// Friend-class wrapper (name must be exactly "SegmentTest").
+class SegmentTest {
+ public:
+  static RegisteredSegment makeRegistered(
+      Segment& segment,
+      std::unique_ptr<RegistrationHandle> handle) {
+    RegisteredSegment reg(segment);
+    reg.handles_.push_back(std::move(handle));
+    return reg;
+  }
+
+  static RemoteRegisteredSegment makeRemote(
+      void* buf,
+      size_t len,
+      std::unique_ptr<RemoteRegistrationHandle> handle) {
+    RemoteRegisteredSegment remote(buf, len);
+    remote.handles_.push_back(std::move(handle));
+    return remote;
+  }
+};
+
+namespace {
+
+std::string getInterfaceIpv6(const std::string& iface) {
+  struct ifaddrs* ifaddr = nullptr;
+  if (getifaddrs(&ifaddr) != 0) {
+    return "";
+  }
+  std::string result;
+  for (auto* ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr == nullptr || ifa->ifa_addr->sa_family != AF_INET6 ||
+        iface != ifa->ifa_name) {
+      continue;
+    }
+    auto* sa = reinterpret_cast<sockaddr_in6*>(ifa->ifa_addr);
+    if (sa->sin6_addr.s6_addr[0] == 0xfe &&
+        (sa->sin6_addr.s6_addr[1] & 0xc0) == 0x80) {
+      continue; // link-local
+    }
+    char buf[INET6_ADDRSTRLEN] = {};
+    if (inet_ntop(AF_INET6, &sa->sin6_addr, buf, sizeof(buf)) != nullptr) {
+      result = buf;
+      break;
+    }
+  }
+  freeifaddrs(ifaddr);
+  return result;
+}
+
+std::vector<uint8_t> mpiExchange(
+    const std::vector<uint8_t>& localData,
+    int rank) {
+  int peerRank = 1 - rank;
+  int localSize = static_cast<int>(localData.size());
+  int remoteSize = 0;
+  MPI_Sendrecv(
+      &localSize,
+      1,
+      MPI_INT,
+      peerRank,
+      0,
+      &remoteSize,
+      1,
+      MPI_INT,
+      peerRank,
+      0,
+      MPI_COMM_WORLD,
+      MPI_STATUS_IGNORE);
+  std::vector<uint8_t> remoteData(remoteSize);
+  MPI_Sendrecv(
+      localData.data(),
+      localSize,
+      MPI_BYTE,
+      peerRank,
+      1,
+      remoteData.data(),
+      remoteSize,
+      MPI_BYTE,
+      peerRank,
+      1,
+      MPI_COMM_WORLD,
+      MPI_STATUS_IGNORE);
+  return remoteData;
+}
+
+uint64_t mpiExchangeAddr(uint64_t localVal, int rank) {
+  int peerRank = 1 - rank;
+  uint64_t remoteVal = 0;
+  MPI_Sendrecv(
+      &localVal,
+      1,
+      MPI_UINT64_T,
+      peerRank,
+      2,
+      &remoteVal,
+      1,
+      MPI_UINT64_T,
+      peerRank,
+      2,
+      MPI_COMM_WORLD,
+      MPI_STATUS_IGNORE);
+  return remoteVal;
+}
+
+bool anyRankWantsToSkip(bool localSkip) {
+  int localVal = localSkip ? 1 : 0;
+  int globalVal = 0;
+  MPI_Allreduce(&localVal, &globalVal, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+  return globalVal != 0;
+}
+
+/// RAII device buffer.
+struct CudaBuffer {
+  void* ptr{nullptr};
+  size_t size{0};
+  int device{0};
+
+  CudaBuffer(size_t n, int dev) : size(n), device(dev) {
+    (void)cudaSetDevice(dev);
+    if (cudaMalloc(&ptr, n) != cudaSuccess) {
+      ptr = nullptr;
+    }
+  }
+  ~CudaBuffer() {
+    if (ptr) {
+      (void)cudaSetDevice(device);
+      (void)cudaFree(ptr);
+    }
+  }
+  CudaBuffer(const CudaBuffer&) = delete;
+  CudaBuffer& operator=(const CudaBuffer&) = delete;
+};
+
+} // namespace
+
+class TcpGpuCrossHostTest : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    // See CrossHostTests.cpp: skip on single-process CI lanes; real 2-rank
+    // coverage is the mpirun 2-host harness.
+    if (numRanks != 2) {
+      GTEST_SKIP() << "requires exactly 2 MPI ranks (run under mpirun -n 2)";
+    }
+    eth2Host_ = getInterfaceIpv6("eth2");
+    ASSERT_FALSE(eth2Host_.empty()) << "no global IPv6 on eth2";
+    evbThread_ = std::make_unique<ScopedEventBaseThread>();
+  }
+
+  void TearDown() override {
+    evbThread_.reset();
+    MpiBaseTestFixture::TearDown();
+  }
+
+  struct ConnectedPair {
+    std::unique_ptr<TcpTransportFactory> factory;
+    std::unique_ptr<Transport> transport;
+  };
+
+  struct SegmentRegistration {
+    RegisteredSegment local;
+    RemoteRegisteredSegment remote;
+  };
+
+  ConnectedPair connectCrossHost() {
+    ConnectedPair pair;
+    auto* evb = evbThread_->getEventBase();
+    pair.factory = std::make_unique<TcpTransportFactory>(
+        /*deviceId=*/-1, evb, controller::TcpSocketConfig{}, eth2Host_);
+
+    auto localTopo = pair.factory->getTopology();
+    auto remoteTopo = mpiExchange(localTopo, globalRank);
+    auto transportResult = pair.factory->createTransport(remoteTopo);
+    EXPECT_TRUE(transportResult.hasValue())
+        << transportResult.error().message();
+    pair.transport = std::move(transportResult.value());
+
+    auto localInfo = pair.transport->bind();
+    auto remoteInfo = mpiExchange(localInfo, globalRank);
+    auto connectStatus = pair.transport->connect(remoteInfo);
+    EXPECT_FALSE(connectStatus.hasError()) << connectStatus.error().message();
+    return pair;
+  }
+
+  std::optional<SegmentRegistration> registerAndExchangeSegments(
+      TcpTransportFactory& factory,
+      void* buf,
+      size_t totalSize,
+      MemoryType memType,
+      int deviceId) {
+    Segment seg(buf, totalSize, memType, deviceId);
+    auto regResult = factory.registerSegment(seg);
+    EXPECT_TRUE(regResult.hasValue()) << regResult.error().message();
+    if (regResult.hasError()) {
+      return std::nullopt;
+    }
+    auto localPayload = regResult.value()->serialize();
+    auto remotePayload = mpiExchange(localPayload, globalRank);
+
+    auto remoteHandle = factory.importSegment(totalSize, remotePayload);
+    EXPECT_TRUE(remoteHandle.hasValue()) << remoteHandle.error().message();
+    if (remoteHandle.hasError()) {
+      return std::nullopt;
+    }
+
+    auto localReg =
+        SegmentTest::makeRegistered(seg, std::move(regResult.value()));
+    uint64_t remoteAddr =
+        mpiExchangeAddr(reinterpret_cast<uint64_t>(buf), globalRank);
+    auto remoteReg = SegmentTest::makeRemote(
+        // NOLINTNEXTLINE(performance-no-int-to-ptr)
+        reinterpret_cast<void*>(remoteAddr),
+        totalSize,
+        std::move(remoteHandle.value()));
+    return SegmentRegistration{std::move(localReg), std::move(remoteReg)};
+  }
+
+  std::string eth2Host_;
+  std::unique_ptr<ScopedEventBaseThread> evbThread_;
+};
+
+// rank 0 puts a VRAM buffer into rank 1's VRAM segment (host-staged over TCP).
+TEST_F(TcpGpuCrossHostTest, VramPut) {
+  int deviceCount = 0;
+  bool noCuda =
+      cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount < 1;
+  if (anyRankWantsToSkip(noCuda)) {
+    GTEST_SKIP() << "some rank lacks a GPU";
+  }
+
+  constexpr int kDev = 0;
+  constexpr size_t kLen = 4 * 1024 * 1024; // 4 MiB
+  auto pair = connectCrossHost();
+
+  CudaBuffer gpuBuf(kLen, kDev);
+  ASSERT_NE(gpuBuf.ptr, nullptr) << "cudaMalloc failed";
+  ASSERT_EQ(cudaSetDevice(kDev), cudaSuccess);
+
+  std::vector<uint8_t> host(kLen);
+  if (globalRank == 0) {
+    for (size_t i = 0; i < kLen; ++i) {
+      host[i] = static_cast<uint8_t>((i * 131 + 7) & 0xFF);
+    }
+    ASSERT_EQ(
+        cudaMemcpy(gpuBuf.ptr, host.data(), kLen, cudaMemcpyHostToDevice),
+        cudaSuccess);
+  } else {
+    ASSERT_EQ(cudaMemset(gpuBuf.ptr, 0, kLen), cudaSuccess);
+  }
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  auto segments = registerAndExchangeSegments(
+      *pair.factory, gpuBuf.ptr, kLen, MemoryType::VRAM, kDev);
+  ASSERT_TRUE(segments.has_value());
+
+  if (globalRank == 0) {
+    std::vector<TransferRequest> reqs;
+    reqs.push_back(
+        TransferRequest{
+            .local = segments->local.span(size_t{0}, kLen),
+            .remote = segments->remote.span(size_t{0}, kLen)});
+    auto st = pair.transport->put(reqs, {}).get();
+    ASSERT_FALSE(st.hasError()) << "put failed: " << st.error().message();
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  if (globalRank == 1) {
+    std::vector<uint8_t> verify(kLen, 0);
+    ASSERT_EQ(cudaSetDevice(kDev), cudaSuccess);
+    ASSERT_EQ(
+        cudaMemcpy(verify.data(), gpuBuf.ptr, kLen, cudaMemcpyDeviceToHost),
+        cudaSuccess);
+    for (size_t i = 0; i < kLen; ++i) {
+      ASSERT_EQ(verify[i], static_cast<uint8_t>((i * 131 + 7) & 0xFF))
+          << "VRAM put mismatch at byte " << i;
+    }
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// rank 0 pulls (get) rank 1's VRAM segment into its own VRAM buffer.
+TEST_F(TcpGpuCrossHostTest, VramGet) {
+  int deviceCount = 0;
+  bool noCuda =
+      cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount < 1;
+  if (anyRankWantsToSkip(noCuda)) {
+    GTEST_SKIP() << "some rank lacks a GPU";
+  }
+
+  constexpr int kDev = 0;
+  constexpr size_t kLen = 4 * 1024 * 1024; // 4 MiB
+  auto pair = connectCrossHost();
+
+  CudaBuffer gpuBuf(kLen, kDev);
+  ASSERT_NE(gpuBuf.ptr, nullptr) << "cudaMalloc failed";
+  ASSERT_EQ(cudaSetDevice(kDev), cudaSuccess);
+
+  if (globalRank == 0) {
+    ASSERT_EQ(cudaMemset(gpuBuf.ptr, 0, kLen), cudaSuccess);
+  } else {
+    std::vector<uint8_t> host(kLen);
+    for (size_t i = 0; i < kLen; ++i) {
+      host[i] = static_cast<uint8_t>((i * 17 + 3) & 0xFF);
+    }
+    ASSERT_EQ(
+        cudaMemcpy(gpuBuf.ptr, host.data(), kLen, cudaMemcpyHostToDevice),
+        cudaSuccess);
+  }
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  auto segments = registerAndExchangeSegments(
+      *pair.factory, gpuBuf.ptr, kLen, MemoryType::VRAM, kDev);
+  ASSERT_TRUE(segments.has_value());
+
+  if (globalRank == 0) {
+    std::vector<TransferRequest> reqs;
+    reqs.push_back(
+        TransferRequest{
+            .local = segments->local.span(size_t{0}, kLen),
+            .remote = segments->remote.span(size_t{0}, kLen)});
+    auto st = pair.transport->get(reqs, {}).get();
+    ASSERT_FALSE(st.hasError()) << "get failed: " << st.error().message();
+
+    std::vector<uint8_t> verify(kLen, 0);
+    ASSERT_EQ(cudaSetDevice(kDev), cudaSuccess);
+    ASSERT_EQ(
+        cudaMemcpy(verify.data(), gpuBuf.ptr, kLen, cudaMemcpyDeviceToHost),
+        cudaSuccess);
+    for (size_t i = 0; i < kLen; ++i) {
+      ASSERT_EQ(verify[i], static_cast<uint8_t>((i * 17 + 3) & 0xFF))
+          << "VRAM get mismatch at byte " << i;
+    }
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+} // namespace uniflow
+
+int main(int argc, char** argv) {
+  // Force MPI to bootstrap over the TCP BTL (see CrossHostTests.cpp): the CI
+  // RDMA NIC can fail openib init, preventing the 2-rank world from forming.
+  setenv("OMPI_MCA_btl", "tcp,self", 0);
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase());
+  return RUN_ALL_TESTS();
+}

--- a/comms/uniflow/transport/tcp/tests/integration/CrossHostTests.cpp
+++ b/comms/uniflow/transport/tcp/tests/integration/CrossHostTests.cpp
@@ -1,0 +1,429 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/// Cross-host integration test for the TCP transport.
+/// Requires MPI with 2 ranks on 2 different hosts (nnodes=2, ppn=1).
+/// Each rank auto-detects its own eth2 (front-end) IPv6 address, stands up a
+/// TcpTransport bound to it, and connects to the peer via MPI-exchanged bind
+/// info. DRAM only (TCP does not touch device memory).
+///
+/// Running it for real (2 ranks): standard single-process CI can't form a
+/// 2-rank MPI world, so those lanes skip (see SetUp). Exercise it on two hosts
+/// with the mpirun harness (forms MPI_COMM_WORLD size 2 over eth2):
+///
+///   fbcode/scripts/cppc/run_uniflow_cross_host_tcp.sh rtptest521.maz5
+///   rtptest522.maz5
+///
+/// Verified: 8/8 pass 2-rank on rtptest521<->522 over eth2.
+
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <mpi.h>
+
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/uniflow/Segment.h"
+#include "comms/uniflow/executor/ScopedEventBaseThread.h"
+#include "comms/uniflow/transport/tcp/TcpTransport.h"
+
+using meta::comms::MpiBaseTestFixture;
+using meta::comms::MPIEnvironmentBase;
+
+namespace uniflow {
+
+/// Friend-class wrapper to construct RegisteredSegment /
+/// RemoteRegisteredSegment with handles for testing. The name must be exactly
+/// "SegmentTest" to match the friend declaration in Segment.h.
+class SegmentTest {
+ public:
+  static RegisteredSegment makeRegistered(
+      Segment& segment,
+      std::unique_ptr<RegistrationHandle> handle) {
+    RegisteredSegment reg(segment);
+    reg.handles_.push_back(std::move(handle));
+    return reg;
+  }
+
+  static RemoteRegisteredSegment makeRemote(
+      void* buf,
+      size_t len,
+      std::unique_ptr<RemoteRegistrationHandle> handle) {
+    RemoteRegisteredSegment remote(buf, len);
+    remote.handles_.push_back(std::move(handle));
+    return remote;
+  }
+};
+
+namespace {
+
+/// Return the first global (non-link-local) IPv6 address on interface `iface`,
+/// or empty if none. Front-end NIC on these hosts is eth2 (IPv6-only).
+std::string getInterfaceIpv6(const std::string& iface) {
+  struct ifaddrs* ifaddr = nullptr;
+  if (getifaddrs(&ifaddr) != 0) {
+    return "";
+  }
+  std::string result;
+  for (auto* ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr == nullptr || ifa->ifa_addr->sa_family != AF_INET6 ||
+        iface != ifa->ifa_name) {
+      continue;
+    }
+    auto* sa = reinterpret_cast<sockaddr_in6*>(ifa->ifa_addr);
+    // Skip link-local (fe80::/10).
+    if (sa->sin6_addr.s6_addr[0] == 0xfe &&
+        (sa->sin6_addr.s6_addr[1] & 0xc0) == 0x80) {
+      continue;
+    }
+    char buf[INET6_ADDRSTRLEN] = {};
+    if (inet_ntop(AF_INET6, &sa->sin6_addr, buf, sizeof(buf)) != nullptr) {
+      result = buf;
+      break;
+    }
+  }
+  freeifaddrs(ifaddr);
+  return result;
+}
+
+/// Exchange a variable-length byte vector between rank 0 and rank 1 via MPI.
+std::vector<uint8_t> mpiExchange(
+    const std::vector<uint8_t>& localData,
+    int rank) {
+  int peerRank = 1 - rank;
+  int localSize = static_cast<int>(localData.size());
+  int remoteSize = 0;
+  MPI_Sendrecv(
+      &localSize,
+      1,
+      MPI_INT,
+      peerRank,
+      0,
+      &remoteSize,
+      1,
+      MPI_INT,
+      peerRank,
+      0,
+      MPI_COMM_WORLD,
+      MPI_STATUS_IGNORE);
+  std::vector<uint8_t> remoteData(remoteSize);
+  MPI_Sendrecv(
+      localData.data(),
+      localSize,
+      MPI_BYTE,
+      peerRank,
+      1,
+      remoteData.data(),
+      remoteSize,
+      MPI_BYTE,
+      peerRank,
+      1,
+      MPI_COMM_WORLD,
+      MPI_STATUS_IGNORE);
+  return remoteData;
+}
+
+uint64_t mpiExchangeAddr(uint64_t localVal, int rank) {
+  int peerRank = 1 - rank;
+  uint64_t remoteVal = 0;
+  MPI_Sendrecv(
+      &localVal,
+      1,
+      MPI_UINT64_T,
+      peerRank,
+      2,
+      &remoteVal,
+      1,
+      MPI_UINT64_T,
+      peerRank,
+      2,
+      MPI_COMM_WORLD,
+      MPI_STATUS_IGNORE);
+  return remoteVal;
+}
+
+} // namespace
+
+class TcpCrossHostTest : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    // Single-process CI lanes (e.g. linux/dev `buck test`) can't form a 2-rank
+    // MPI world, so skip rather than fail. Real 2-rank coverage comes from the
+    // mpirun 2-host harness. The RDMA/multi_transport cross-host tests are
+    // excluded from that lane via ci.remove(ci.linux(ci.dev())); the CPU test
+    // macro doesn't expose that label, so we skip in-test instead.
+    if (numRanks != 2) {
+      GTEST_SKIP() << "TcpCrossHostTest requires exactly 2 MPI ranks "
+                      "(run under mpirun -n 2)";
+    }
+    eth2Host_ = getInterfaceIpv6("eth2");
+    ASSERT_FALSE(eth2Host_.empty())
+        << "no global IPv6 address found on eth2 (front-end NIC)";
+    evbThread_ = std::make_unique<ScopedEventBaseThread>();
+  }
+
+  void TearDown() override {
+    evbThread_.reset();
+    MpiBaseTestFixture::TearDown();
+  }
+
+  struct ConnectedPair {
+    std::unique_ptr<TcpTransportFactory> factory;
+    std::unique_ptr<Transport> transport;
+  };
+
+  struct SegmentRegistration {
+    RegisteredSegment local;
+    RemoteRegisteredSegment remote;
+  };
+
+  ConnectedPair connectCrossHost() {
+    ConnectedPair pair;
+    auto* evb = evbThread_->getEventBase();
+    pair.factory = std::make_unique<TcpTransportFactory>(
+        /*deviceId=*/-1, evb, controller::TcpSocketConfig{}, eth2Host_);
+
+    auto localTopo = pair.factory->getTopology();
+    auto remoteTopo = mpiExchange(localTopo, globalRank);
+    auto transportResult = pair.factory->createTransport(remoteTopo);
+    EXPECT_TRUE(transportResult.hasValue())
+        << "createTransport failed: " << transportResult.error().message();
+    pair.transport = std::move(transportResult.value());
+
+    auto localInfo = pair.transport->bind();
+    auto remoteInfo = mpiExchange(localInfo, globalRank);
+    auto connectStatus = pair.transport->connect(remoteInfo);
+    EXPECT_FALSE(connectStatus.hasError())
+        << "connect failed: " << connectStatus.error().message();
+    return pair;
+  }
+
+  std::optional<SegmentRegistration> registerAndExchangeSegments(
+      TcpTransportFactory& factory,
+      void* buf,
+      size_t totalSize) {
+    Segment seg(buf, totalSize, MemoryType::DRAM);
+    auto regResult = factory.registerSegment(seg);
+    EXPECT_TRUE(regResult.hasValue()) << regResult.error().message();
+    if (regResult.hasError()) {
+      return std::nullopt;
+    }
+    auto localPayload = regResult.value()->serialize();
+    auto remotePayload = mpiExchange(localPayload, globalRank);
+
+    auto remoteHandle = factory.importSegment(totalSize, remotePayload);
+    EXPECT_TRUE(remoteHandle.hasValue()) << remoteHandle.error().message();
+    if (remoteHandle.hasError()) {
+      return std::nullopt;
+    }
+
+    auto localReg =
+        SegmentTest::makeRegistered(seg, std::move(regResult.value()));
+    uint64_t remoteAddr =
+        mpiExchangeAddr(reinterpret_cast<uint64_t>(buf), globalRank);
+    auto remoteReg = SegmentTest::makeRemote(
+        // NOLINTNEXTLINE(performance-no-int-to-ptr)
+        reinterpret_cast<void*>(remoteAddr),
+        totalSize,
+        std::move(remoteHandle.value()));
+    return SegmentRegistration{std::move(localReg), std::move(remoteReg)};
+  }
+
+  static std::vector<TransferRequest> buildTransferRequests(
+      RegisteredSegment& local,
+      RemoteRegisteredSegment& remote,
+      size_t bufSize,
+      size_t numRequests) {
+    std::vector<TransferRequest> reqs;
+    reqs.reserve(numRequests);
+    for (size_t r = 0; r < numRequests; ++r) {
+      reqs.push_back(
+          TransferRequest{
+              .local = local.span(r * bufSize, bufSize),
+              .remote = remote.span(r * bufSize, bufSize),
+          });
+    }
+    return reqs;
+  }
+
+  std::string eth2Host_;
+  std::unique_ptr<ScopedEventBaseThread> evbThread_;
+};
+
+TEST_F(TcpCrossHostTest, TransportsConnectAcrossHosts) {
+  auto pair = connectCrossHost();
+  EXPECT_EQ(pair.transport->state(), TransportState::Connected);
+  pair.transport->shutdown();
+  EXPECT_EQ(pair.transport->state(), TransportState::Disconnected);
+}
+
+struct CrossHostTransferParam {
+  size_t bufSize;
+  size_t numRequests;
+  std::string name;
+};
+
+std::string crossHostParamName(
+    const ::testing::TestParamInfo<CrossHostTransferParam>& info) {
+  return info.param.name;
+}
+
+class DramTcpCrossHostTest
+    : public TcpCrossHostTest,
+      public ::testing::WithParamInterface<CrossHostTransferParam> {};
+
+TEST_P(DramTcpCrossHostTest, Put) {
+  const auto& param = GetParam();
+  const size_t totalSize = param.bufSize * param.numRequests;
+  auto pair = connectCrossHost();
+
+  // Rank 0 is sender, rank 1 is receiver.
+  std::vector<char> localBuf(totalSize);
+  if (globalRank == 0) {
+    for (size_t r = 0; r < param.numRequests; ++r) {
+      std::memset(
+          localBuf.data() + r * param.bufSize,
+          static_cast<int>(0xA0 + r),
+          param.bufSize);
+    }
+  } else {
+    std::memset(localBuf.data(), 0, totalSize);
+  }
+
+  auto segments =
+      registerAndExchangeSegments(*pair.factory, localBuf.data(), totalSize);
+  ASSERT_TRUE(segments.has_value());
+
+  if (globalRank == 0) {
+    auto reqs = buildTransferRequests(
+        segments->local, segments->remote, param.bufSize, param.numRequests);
+    auto putStatus = pair.transport->put(reqs, {}).get();
+    ASSERT_FALSE(putStatus.hasError())
+        << "put failed: " << putStatus.error().message();
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  if (globalRank == 1) {
+    for (size_t r = 0; r < param.numRequests; ++r) {
+      auto expected = static_cast<uint8_t>(0xA0 + r);
+      for (size_t i = 0; i < param.bufSize; ++i) {
+        ASSERT_EQ(
+            static_cast<uint8_t>(localBuf[r * param.bufSize + i]), expected)
+            << "mismatch at request " << r << " byte " << i;
+      }
+    }
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_P(DramTcpCrossHostTest, Get) {
+  const auto& param = GetParam();
+  const size_t totalSize = param.bufSize * param.numRequests;
+  auto pair = connectCrossHost();
+
+  // Rank 0 is reader (zeroed), rank 1 is source (filled).
+  std::vector<char> localBuf(totalSize);
+  if (globalRank == 0) {
+    std::memset(localBuf.data(), 0, totalSize);
+  } else {
+    for (size_t r = 0; r < param.numRequests; ++r) {
+      std::memset(
+          localBuf.data() + r * param.bufSize,
+          static_cast<int>(0xB0 + r),
+          param.bufSize);
+    }
+  }
+
+  auto segments =
+      registerAndExchangeSegments(*pair.factory, localBuf.data(), totalSize);
+  ASSERT_TRUE(segments.has_value());
+
+  if (globalRank == 0) {
+    auto reqs = buildTransferRequests(
+        segments->local, segments->remote, param.bufSize, param.numRequests);
+    auto getStatus = pair.transport->get(reqs, {}).get();
+    ASSERT_FALSE(getStatus.hasError())
+        << "get failed: " << getStatus.error().message();
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  if (globalRank == 0) {
+    for (size_t r = 0; r < param.numRequests; ++r) {
+      auto expected = static_cast<uint8_t>(0xB0 + r);
+      for (size_t i = 0; i < param.bufSize; ++i) {
+        ASSERT_EQ(
+            static_cast<uint8_t>(localBuf[r * param.bufSize + i]), expected)
+            << "mismatch at request " << r << " byte " << i;
+      }
+    }
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DramTcpCrossHost,
+    DramTcpCrossHostTest,
+    ::testing::Values(
+        CrossHostTransferParam{4096, 1, "4KB_single"},
+        CrossHostTransferParam{1024 * 1024, 1, "1MB_single"},
+        CrossHostTransferParam{4 * 1024 * 1024, 4, "4MB_batch4"}),
+    crossHostParamName);
+
+// Two-sided send/recv across hosts: rank 0 sends, rank 1 posts a recv.
+TEST_F(TcpCrossHostTest, SendRecvAcrossHosts) {
+  constexpr size_t kLen = 1 << 20; // 1 MiB
+  auto pair = connectCrossHost();
+
+  std::vector<char> buf(kLen);
+  if (globalRank == 0) {
+    std::memset(buf.data(), 0x5C, kLen);
+  } else {
+    std::memset(buf.data(), 0, kLen);
+  }
+
+  // send/recv only need a RegisteredSegment::Span for the local buffer; TCP
+  // two-sided transfer does not use a segId, so no remote import is required.
+  Segment seg(buf.data(), kLen, MemoryType::DRAM);
+  auto reg = pair.factory->registerSegment(seg);
+  ASSERT_FALSE(reg.hasError()) << reg.error().message();
+  auto localReg = SegmentTest::makeRegistered(seg, std::move(reg.value()));
+
+  if (globalRank == 0) {
+    auto st = pair.transport->send(localReg.span(size_t{0}, kLen)).get();
+    ASSERT_FALSE(st.hasError()) << "send failed: " << st.error().message();
+  } else {
+    auto st = pair.transport->recv(localReg.span(size_t{0}, kLen)).get();
+    ASSERT_FALSE(st.hasError()) << "recv failed: " << st.error().message();
+    for (size_t i = 0; i < kLen; ++i) {
+      ASSERT_EQ(static_cast<uint8_t>(buf[i]), 0x5Cu)
+          << "recv data mismatch at byte " << i;
+    }
+  }
+
+  // Keep rank 0 alive until rank 1 has received before tearing down.
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+} // namespace uniflow
+
+int main(int argc, char** argv) {
+  // Force MPI to bootstrap over the TCP BTL. The CI sandbox's RDMA NIC (mlx5)
+  // can fail openib init ("No space left on device"), which prevents the 2-rank
+  // MPI world from forming (each rank falls back to a singleton, numRanks==1).
+  // TCP is reliable here and this is a front-end TCP test anyway. overwrite=0
+  // so an explicit env override still wins.
+  setenv("OMPI_MCA_btl", "tcp,self", 0);
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase());
+  return RUN_ALL_TESTS();
+}

--- a/comms/uniflow/transport/tcp/tests/integration/CrossHostTests.cpp
+++ b/comms/uniflow/transport/tcp/tests/integration/CrossHostTests.cpp
@@ -1,0 +1,475 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/// Cross-host integration test for the TCP transport.
+/// Requires MPI with 2 ranks on 2 different hosts (nnodes=2, ppn=1).
+/// Each rank auto-detects its own eth2 (front-end) IPv6 address, stands up a
+/// TcpTransport bound to it, and connects to the peer via MPI-exchanged bind
+/// info. DRAM only (TCP does not touch device memory).
+///
+/// Running it for real (2 ranks): standard single-process CI can't form a
+/// 2-rank MPI world, so those lanes skip (see SetUp). Exercise it on two hosts
+/// with the mpirun harness (forms MPI_COMM_WORLD size 2 over eth2):
+///
+///   fbcode/scripts/cppc/run_uniflow_cross_host_tcp.sh rtptest521.maz5
+///   rtptest522.maz5
+///
+/// Verified: 8/8 pass 2-rank on rtptest521<->522 over eth2.
+
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <chrono>
+
+#include <mpi.h>
+
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/uniflow/Segment.h"
+#include "comms/uniflow/executor/ScopedEventBaseThread.h"
+#include "comms/uniflow/transport/tcp/TcpTransport.h"
+
+using meta::comms::MpiBaseTestFixture;
+using meta::comms::MPIEnvironmentBase;
+
+namespace uniflow {
+
+/// Friend-class wrapper to construct RegisteredSegment /
+/// RemoteRegisteredSegment with handles for testing. The name must be exactly
+/// "SegmentTest" to match the friend declaration in Segment.h.
+class SegmentTest {
+ public:
+  static RegisteredSegment makeRegistered(
+      Segment& segment,
+      std::unique_ptr<RegistrationHandle> handle) {
+    RegisteredSegment reg(segment);
+    reg.handles_.push_back(std::move(handle));
+    return reg;
+  }
+
+  static RemoteRegisteredSegment makeRemote(
+      void* buf,
+      size_t len,
+      std::unique_ptr<RemoteRegistrationHandle> handle) {
+    RemoteRegisteredSegment remote(buf, len);
+    remote.handles_.push_back(std::move(handle));
+    return remote;
+  }
+};
+
+namespace {
+
+/// Return the first global (non-link-local) IPv6 address on interface `iface`,
+/// or empty if none. Front-end NIC on these hosts is eth2 (IPv6-only).
+std::string getInterfaceIpv6(const std::string& iface) {
+  struct ifaddrs* ifaddr = nullptr;
+  if (getifaddrs(&ifaddr) != 0) {
+    return "";
+  }
+  std::string result;
+  for (auto* ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr == nullptr || ifa->ifa_addr->sa_family != AF_INET6 ||
+        iface != ifa->ifa_name) {
+      continue;
+    }
+    auto* sa = reinterpret_cast<sockaddr_in6*>(ifa->ifa_addr);
+    // Skip link-local (fe80::/10).
+    if (sa->sin6_addr.s6_addr[0] == 0xfe &&
+        (sa->sin6_addr.s6_addr[1] & 0xc0) == 0x80) {
+      continue;
+    }
+    char buf[INET6_ADDRSTRLEN] = {};
+    if (inet_ntop(AF_INET6, &sa->sin6_addr, buf, sizeof(buf)) != nullptr) {
+      result = buf;
+      break;
+    }
+  }
+  freeifaddrs(ifaddr);
+  return result;
+}
+
+/// Exchange a variable-length byte vector between rank 0 and rank 1 via MPI.
+std::vector<uint8_t> mpiExchange(
+    const std::vector<uint8_t>& localData,
+    int rank) {
+  int peerRank = 1 - rank;
+  int localSize = static_cast<int>(localData.size());
+  int remoteSize = 0;
+  MPI_Sendrecv(
+      &localSize,
+      1,
+      MPI_INT,
+      peerRank,
+      0,
+      &remoteSize,
+      1,
+      MPI_INT,
+      peerRank,
+      0,
+      MPI_COMM_WORLD,
+      MPI_STATUS_IGNORE);
+  std::vector<uint8_t> remoteData(remoteSize);
+  MPI_Sendrecv(
+      localData.data(),
+      localSize,
+      MPI_BYTE,
+      peerRank,
+      1,
+      remoteData.data(),
+      remoteSize,
+      MPI_BYTE,
+      peerRank,
+      1,
+      MPI_COMM_WORLD,
+      MPI_STATUS_IGNORE);
+  return remoteData;
+}
+
+uint64_t mpiExchangeAddr(uint64_t localVal, int rank) {
+  int peerRank = 1 - rank;
+  uint64_t remoteVal = 0;
+  MPI_Sendrecv(
+      &localVal,
+      1,
+      MPI_UINT64_T,
+      peerRank,
+      2,
+      &remoteVal,
+      1,
+      MPI_UINT64_T,
+      peerRank,
+      2,
+      MPI_COMM_WORLD,
+      MPI_STATUS_IGNORE);
+  return remoteVal;
+}
+
+} // namespace
+
+class TcpCrossHostTest : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    // Single-process CI lanes (e.g. linux/dev `buck test`) can't form a 2-rank
+    // MPI world, so skip rather than fail. Real 2-rank coverage comes from the
+    // mpirun 2-host harness. The RDMA/multi_transport cross-host tests are
+    // excluded from that lane via ci.remove(ci.linux(ci.dev())); the CPU test
+    // macro doesn't expose that label, so we skip in-test instead.
+    if (numRanks != 2) {
+      GTEST_SKIP() << "TcpCrossHostTest requires exactly 2 MPI ranks "
+                      "(run under mpirun -n 2)";
+    }
+    eth2Host_ = getInterfaceIpv6("eth2");
+    ASSERT_FALSE(eth2Host_.empty())
+        << "no global IPv6 address found on eth2 (front-end NIC)";
+    evbThread_ = std::make_unique<ScopedEventBaseThread>();
+  }
+
+  void TearDown() override {
+    evbThread_.reset();
+    MpiBaseTestFixture::TearDown();
+  }
+
+  struct ConnectedPair {
+    std::unique_ptr<TcpTransportFactory> factory;
+    std::unique_ptr<Transport> transport;
+  };
+
+  struct SegmentRegistration {
+    RegisteredSegment local;
+    RemoteRegisteredSegment remote;
+  };
+
+  ConnectedPair connectCrossHost() {
+    ConnectedPair pair;
+    auto* evb = evbThread_->getEventBase();
+    pair.factory = std::make_unique<TcpTransportFactory>(
+        /*deviceId=*/-1, evb, controller::TcpSocketConfig{}, eth2Host_);
+
+    auto localTopo = pair.factory->getTopology();
+    auto remoteTopo = mpiExchange(localTopo, globalRank);
+    auto transportResult = pair.factory->createTransport(remoteTopo);
+    EXPECT_TRUE(transportResult.hasValue())
+        << "createTransport failed: " << transportResult.error().message();
+    pair.transport = std::move(transportResult.value());
+
+    auto localInfo = pair.transport->bind();
+    auto remoteInfo = mpiExchange(localInfo, globalRank);
+    auto connectStatus = pair.transport->connect(remoteInfo);
+    EXPECT_FALSE(connectStatus.hasError())
+        << "connect failed: " << connectStatus.error().message();
+    return pair;
+  }
+
+  std::optional<SegmentRegistration> registerAndExchangeSegments(
+      TcpTransportFactory& factory,
+      void* buf,
+      size_t totalSize) {
+    Segment seg(buf, totalSize, MemoryType::DRAM);
+    auto regResult = factory.registerSegment(seg);
+    EXPECT_TRUE(regResult.hasValue()) << regResult.error().message();
+    if (regResult.hasError()) {
+      return std::nullopt;
+    }
+    auto localPayload = regResult.value()->serialize();
+    auto remotePayload = mpiExchange(localPayload, globalRank);
+
+    auto remoteHandle = factory.importSegment(totalSize, remotePayload);
+    EXPECT_TRUE(remoteHandle.hasValue()) << remoteHandle.error().message();
+    if (remoteHandle.hasError()) {
+      return std::nullopt;
+    }
+
+    auto localReg =
+        SegmentTest::makeRegistered(seg, std::move(regResult.value()));
+    uint64_t remoteAddr =
+        mpiExchangeAddr(reinterpret_cast<uint64_t>(buf), globalRank);
+    auto remoteReg = SegmentTest::makeRemote(
+        // NOLINTNEXTLINE(performance-no-int-to-ptr)
+        reinterpret_cast<void*>(remoteAddr),
+        totalSize,
+        std::move(remoteHandle.value()));
+    return SegmentRegistration{std::move(localReg), std::move(remoteReg)};
+  }
+
+  static std::vector<TransferRequest> buildTransferRequests(
+      RegisteredSegment& local,
+      RemoteRegisteredSegment& remote,
+      size_t bufSize,
+      size_t numRequests) {
+    std::vector<TransferRequest> reqs;
+    reqs.reserve(numRequests);
+    for (size_t r = 0; r < numRequests; ++r) {
+      reqs.push_back(
+          TransferRequest{
+              .local = local.span(r * bufSize, bufSize),
+              .remote = remote.span(r * bufSize, bufSize),
+          });
+    }
+    return reqs;
+  }
+
+  std::string eth2Host_;
+  std::unique_ptr<ScopedEventBaseThread> evbThread_;
+};
+
+TEST_F(TcpCrossHostTest, TransportsConnectAcrossHosts) {
+  auto pair = connectCrossHost();
+  EXPECT_EQ(pair.transport->state(), TransportState::Connected);
+  pair.transport->shutdown();
+  EXPECT_EQ(pair.transport->state(), TransportState::Disconnected);
+}
+
+struct CrossHostTransferParam {
+  size_t bufSize;
+  size_t numRequests;
+  std::string name;
+};
+
+std::string crossHostParamName(
+    const ::testing::TestParamInfo<CrossHostTransferParam>& info) {
+  return info.param.name;
+}
+
+class DramTcpCrossHostTest
+    : public TcpCrossHostTest,
+      public ::testing::WithParamInterface<CrossHostTransferParam> {};
+
+TEST_P(DramTcpCrossHostTest, Put) {
+  const auto& param = GetParam();
+  const size_t totalSize = param.bufSize * param.numRequests;
+  auto pair = connectCrossHost();
+
+  // Rank 0 is sender, rank 1 is receiver.
+  std::vector<char> localBuf(totalSize);
+  if (globalRank == 0) {
+    for (size_t r = 0; r < param.numRequests; ++r) {
+      std::memset(
+          localBuf.data() + r * param.bufSize,
+          static_cast<int>(0xA0 + r),
+          param.bufSize);
+    }
+  } else {
+    std::memset(localBuf.data(), 0, totalSize);
+  }
+
+  auto segments =
+      registerAndExchangeSegments(*pair.factory, localBuf.data(), totalSize);
+  ASSERT_TRUE(segments.has_value());
+
+  if (globalRank == 0) {
+    auto reqs = buildTransferRequests(
+        segments->local, segments->remote, param.bufSize, param.numRequests);
+    auto putStatus = pair.transport->put(reqs, {}).get();
+    ASSERT_FALSE(putStatus.hasError())
+        << "put failed: " << putStatus.error().message();
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  if (globalRank == 1) {
+    for (size_t r = 0; r < param.numRequests; ++r) {
+      auto expected = static_cast<uint8_t>(0xA0 + r);
+      for (size_t i = 0; i < param.bufSize; ++i) {
+        ASSERT_EQ(
+            static_cast<uint8_t>(localBuf[r * param.bufSize + i]), expected)
+            << "mismatch at request " << r << " byte " << i;
+      }
+    }
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_P(DramTcpCrossHostTest, Get) {
+  const auto& param = GetParam();
+  const size_t totalSize = param.bufSize * param.numRequests;
+  auto pair = connectCrossHost();
+
+  // Rank 0 is reader (zeroed), rank 1 is source (filled).
+  std::vector<char> localBuf(totalSize);
+  if (globalRank == 0) {
+    std::memset(localBuf.data(), 0, totalSize);
+  } else {
+    for (size_t r = 0; r < param.numRequests; ++r) {
+      std::memset(
+          localBuf.data() + r * param.bufSize,
+          static_cast<int>(0xB0 + r),
+          param.bufSize);
+    }
+  }
+
+  auto segments =
+      registerAndExchangeSegments(*pair.factory, localBuf.data(), totalSize);
+  ASSERT_TRUE(segments.has_value());
+
+  if (globalRank == 0) {
+    auto reqs = buildTransferRequests(
+        segments->local, segments->remote, param.bufSize, param.numRequests);
+    auto getStatus = pair.transport->get(reqs, {}).get();
+    ASSERT_FALSE(getStatus.hasError())
+        << "get failed: " << getStatus.error().message();
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  if (globalRank == 0) {
+    for (size_t r = 0; r < param.numRequests; ++r) {
+      auto expected = static_cast<uint8_t>(0xB0 + r);
+      for (size_t i = 0; i < param.bufSize; ++i) {
+        ASSERT_EQ(
+            static_cast<uint8_t>(localBuf[r * param.bufSize + i]), expected)
+            << "mismatch at request " << r << " byte " << i;
+      }
+    }
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DramTcpCrossHost,
+    DramTcpCrossHostTest,
+    ::testing::Values(
+        CrossHostTransferParam{4096, 1, "4KB_single"},
+        CrossHostTransferParam{1024 * 1024, 1, "1MB_single"},
+        CrossHostTransferParam{4 * 1024 * 1024, 4, "4MB_batch4"}),
+    crossHostParamName);
+
+// Two-sided send/recv across hosts: rank 0 sends, rank 1 posts a recv.
+// The reader thread is the only place that resolves in-flight put/get/recv
+// replies. If it exits on a peer disconnect while requests are outstanding,
+// nothing else would fulfil their promises and callers would block on
+// future.get() forever -- so readerLoop() fails all pending work on exit
+// (TcpTransport.cpp, failAllPending on reader stop). That is the
+// fault-tolerance guarantee the reader/sender split rests on, and it needs two
+// real processes to exercise: rank 1 tears its transport down mid-flight while
+// rank 0 has a recv posted.
+TEST_F(TcpCrossHostTest, PeerDisconnectFailsInflightRatherThanHanging) {
+  constexpr size_t kLen = 1 << 20; // 1 MiB
+  auto pair = connectCrossHost();
+
+  std::vector<char> buf(kLen, 0);
+  Segment seg(buf.data(), kLen, MemoryType::DRAM);
+  auto reg = pair.factory->registerSegment(seg);
+  ASSERT_FALSE(reg.hasError()) << reg.error().message();
+  auto localReg = SegmentTest::makeRegistered(seg, std::move(reg.value()));
+
+  if (globalRank == 0) {
+    // Post a recv that the peer will never satisfy.
+    auto future = pair.transport->recv(localReg.span(size_t{0}, kLen));
+
+    // Let rank 1 disconnect.
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // The guarantee is "fails", not "blocks": bound the wait so a regression
+    // shows up as a timeout here instead of hanging the test binary.
+    ASSERT_EQ(
+        future.wait_for(std::chrono::seconds(30)), std::future_status::ready)
+        << "in-flight recv never completed after peer disconnect; readerLoop "
+           "must fail pending requests when it exits";
+
+    const Status status = future.get();
+    EXPECT_TRUE(status.hasError())
+        << "a recv interrupted by peer disconnect must fail, not succeed";
+  } else {
+    // Drop the connection while rank 0's recv is outstanding.
+    pair.transport->shutdown();
+    MPI_Barrier(MPI_COMM_WORLD);
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_F(TcpCrossHostTest, SendRecvAcrossHosts) {
+  constexpr size_t kLen = 1 << 20; // 1 MiB
+  auto pair = connectCrossHost();
+
+  std::vector<char> buf(kLen);
+  if (globalRank == 0) {
+    std::memset(buf.data(), 0x5C, kLen);
+  } else {
+    std::memset(buf.data(), 0, kLen);
+  }
+
+  // send/recv only need a RegisteredSegment::Span for the local buffer; TCP
+  // two-sided transfer does not use a segId, so no remote import is required.
+  Segment seg(buf.data(), kLen, MemoryType::DRAM);
+  auto reg = pair.factory->registerSegment(seg);
+  ASSERT_FALSE(reg.hasError()) << reg.error().message();
+  auto localReg = SegmentTest::makeRegistered(seg, std::move(reg.value()));
+
+  if (globalRank == 0) {
+    auto st = pair.transport->send(localReg.span(size_t{0}, kLen)).get();
+    ASSERT_FALSE(st.hasError()) << "send failed: " << st.error().message();
+  } else {
+    auto st = pair.transport->recv(localReg.span(size_t{0}, kLen)).get();
+    ASSERT_FALSE(st.hasError()) << "recv failed: " << st.error().message();
+    for (size_t i = 0; i < kLen; ++i) {
+      ASSERT_EQ(static_cast<uint8_t>(buf[i]), 0x5Cu)
+          << "recv data mismatch at byte " << i;
+    }
+  }
+
+  // Keep rank 0 alive until rank 1 has received before tearing down.
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+} // namespace uniflow
+
+int main(int argc, char** argv) {
+  // Force MPI to bootstrap over the TCP BTL. The CI sandbox's RDMA NIC (mlx5)
+  // can fail openib init ("No space left on device"), which prevents the 2-rank
+  // MPI world from forming (each rank falls back to a singleton, numRanks==1).
+  // TCP is reliable here and this is a front-end TCP test anyway. overwrite=0
+  // so an explicit env override still wins.
+  setenv("OMPI_MCA_btl", "tcp,self", 0);
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase());
+  return RUN_ALL_TESTS();
+}

--- a/comms/uniflow/transport/tcp/tests/integration/TcpTransportIntegrationTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/integration/TcpTransportIntegrationTest.cpp
@@ -1,0 +1,408 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/MultiTransport.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+#include "comms/uniflow/Segment.h"
+#include "comms/uniflow/executor/ScopedEventBaseThread.h"
+#include "comms/uniflow/transport/tcp/TcpRegistrationHandle.h"
+#include "comms/uniflow/transport/tcp/TcpTransport.h"
+
+namespace uniflow {
+
+// Friend wrapper (name must be exactly "SegmentTest") to build a
+// RegisteredSegment with a handle for the direct-transport send/recv test.
+class SegmentTest {
+ public:
+  static RegisteredSegment makeRegistered(
+      Segment& segment,
+      std::unique_ptr<RegistrationHandle> handle) {
+    RegisteredSegment reg(segment);
+    reg.handles_.push_back(std::move(handle));
+    return reg;
+  }
+};
+
+namespace {
+
+// TCP-only factory options: a non-matching netdev prefix excludes RDMA NIC
+// discovery and deviceId=-1 excludes NVLink, so only the TCP transport is
+// registered — making this test host-independent (no RDMA/GPU required).
+MultiTransportFactoryOptions tcpOnlyOptions() {
+  MultiTransportFactoryOptions opt;
+  opt.netdevPrefix = "uniflow_tcp_test_nonic";
+  opt.preferredTransport = TransportType::TCP;
+  opt.enableTcp = true;
+  opt.tcpBindHost = "127.0.0.1";
+  return opt;
+}
+
+// Same-host loopback: two in-process agents exchange bind info, connect over
+// TCP, and one puts a DRAM buffer into the other's registered segment.
+TEST(TcpTransportIntegration, DramPutRoundTrip) {
+  constexpr size_t kLen = 8192;
+  std::vector<uint8_t> src(kLen);
+  std::vector<uint8_t> dst(kLen, 0);
+  for (size_t i = 0; i < kLen; ++i) {
+    src[i] = static_cast<uint8_t>((i * 131 + 7) & 0xFF);
+  }
+
+  MultiTransportFactory factoryA(/*deviceId=*/-1, tcpOnlyOptions());
+  MultiTransportFactory factoryB(/*deviceId=*/-1, tcpOnlyOptions());
+
+  Segment srcSeg(src.data(), kLen, MemoryType::DRAM);
+  Segment dstSeg(dst.data(), kLen, MemoryType::DRAM);
+
+  auto regA = factoryA.registerSegment(srcSeg);
+  ASSERT_FALSE(regA.hasError()) << regA.error().message();
+  auto regB = factoryB.registerSegment(dstSeg);
+  ASSERT_FALSE(regB.hasError()) << regB.error().message();
+
+  auto exportB = regB.value().exportId();
+  ASSERT_FALSE(exportB.hasError()) << exportB.error().message();
+  auto remoteOnA = factoryA.importSegment(exportB.value());
+  ASSERT_FALSE(remoteOnA.hasError()) << remoteOnA.error().message();
+
+  auto mtAResult = factoryA.createTransport(factoryB.getTopology());
+  ASSERT_FALSE(mtAResult.hasError()) << mtAResult.error().message();
+  auto mtBResult = factoryB.createTransport(factoryA.getTopology());
+  ASSERT_FALSE(mtBResult.hasError()) << mtBResult.error().message();
+  auto& mtA = mtAResult.value();
+  auto& mtB = mtBResult.value();
+
+  auto bindA = mtA->bind();
+  ASSERT_FALSE(bindA.hasError()) << bindA.error().message();
+  auto bindB = mtB->bind();
+  ASSERT_FALSE(bindB.hasError()) << bindB.error().message();
+
+  // connect() blocks on the listener side, so run both peers concurrently.
+  Status ca = Ok();
+  Status cb = Ok();
+  std::thread tA([&]() { ca = mtA->connect(bindB.value()); });
+  std::thread tB([&]() { cb = mtB->connect(bindA.value()); });
+  tA.join();
+  tB.join();
+  ASSERT_FALSE(ca.hasError()) << ca.error().message();
+  ASSERT_FALSE(cb.hasError()) << cb.error().message();
+
+  std::vector<TransferRequest> requests;
+  requests.push_back(
+      TransferRequest{
+          regA.value().span(size_t{0}, kLen),
+          remoteOnA.value().span(size_t{0}, kLen)});
+
+  auto putStatus = mtA->put(requests).get();
+  ASSERT_FALSE(putStatus.hasError()) << putStatus.error().message();
+
+  EXPECT_EQ(dst, src);
+
+  mtA->shutdown();
+  mtB->shutdown();
+}
+
+// Same-host loopback: A pulls (get) a DRAM buffer from B's registered segment.
+TEST(TcpTransportIntegration, DramGetRoundTrip) {
+  constexpr size_t kLen = 8192;
+  std::vector<uint8_t> remoteSrc(kLen);
+  std::vector<uint8_t> localDst(kLen, 0);
+  for (size_t i = 0; i < kLen; ++i) {
+    remoteSrc[i] = static_cast<uint8_t>((i * 17 + 3) & 0xFF);
+  }
+
+  MultiTransportFactory factoryA(/*deviceId=*/-1, tcpOnlyOptions());
+  MultiTransportFactory factoryB(/*deviceId=*/-1, tcpOnlyOptions());
+
+  Segment srcSeg(remoteSrc.data(), kLen, MemoryType::DRAM);
+  Segment dstSeg(localDst.data(), kLen, MemoryType::DRAM);
+
+  auto regB = factoryB.registerSegment(srcSeg);
+  ASSERT_FALSE(regB.hasError()) << regB.error().message();
+  auto regA = factoryA.registerSegment(dstSeg);
+  ASSERT_FALSE(regA.hasError()) << regA.error().message();
+
+  auto exportB = regB.value().exportId();
+  ASSERT_FALSE(exportB.hasError()) << exportB.error().message();
+  auto remoteOnA = factoryA.importSegment(exportB.value());
+  ASSERT_FALSE(remoteOnA.hasError()) << remoteOnA.error().message();
+
+  auto mtAResult = factoryA.createTransport(factoryB.getTopology());
+  ASSERT_FALSE(mtAResult.hasError()) << mtAResult.error().message();
+  auto mtBResult = factoryB.createTransport(factoryA.getTopology());
+  ASSERT_FALSE(mtBResult.hasError()) << mtBResult.error().message();
+  auto& mtA = mtAResult.value();
+  auto& mtB = mtBResult.value();
+
+  auto bindA = mtA->bind();
+  ASSERT_FALSE(bindA.hasError()) << bindA.error().message();
+  auto bindB = mtB->bind();
+  ASSERT_FALSE(bindB.hasError()) << bindB.error().message();
+
+  Status ca = Ok();
+  Status cb = Ok();
+  std::thread tA([&]() { ca = mtA->connect(bindB.value()); });
+  std::thread tB([&]() { cb = mtB->connect(bindA.value()); });
+  tA.join();
+  tB.join();
+  ASSERT_FALSE(ca.hasError()) << ca.error().message();
+  ASSERT_FALSE(cb.hasError()) << cb.error().message();
+
+  std::vector<TransferRequest> requests;
+  requests.push_back(
+      TransferRequest{
+          regA.value().span(size_t{0}, kLen),
+          remoteOnA.value().span(size_t{0}, kLen)});
+
+  auto getStatus = mtA->get(requests).get();
+  ASSERT_FALSE(getStatus.hasError()) << getStatus.error().message();
+
+  EXPECT_EQ(localDst, remoteSrc);
+
+  mtA->shutdown();
+  mtB->shutdown();
+}
+
+// Both peers issue a concurrent get() to each other with large payloads. This
+// exercises the mutual-READ path that would deadlock if reply sends blocked the
+// reader; the dedicated sender thread must keep both readers draining.
+TEST(TcpTransportIntegration, MutualGetNoDeadlock) {
+  constexpr size_t kLen = 262144; // 256 KiB to stress socket buffers
+  std::vector<uint8_t> aSrc(kLen), aDst(kLen, 0);
+  std::vector<uint8_t> bSrc(kLen), bDst(kLen, 0);
+  for (size_t i = 0; i < kLen; ++i) {
+    aSrc[i] = static_cast<uint8_t>((i * 5 + 1) & 0xFF);
+    bSrc[i] = static_cast<uint8_t>((i * 9 + 2) & 0xFF);
+  }
+
+  MultiTransportFactory factoryA(/*deviceId=*/-1, tcpOnlyOptions());
+  MultiTransportFactory factoryB(/*deviceId=*/-1, tcpOnlyOptions());
+
+  Segment aSrcSeg(aSrc.data(), kLen, MemoryType::DRAM);
+  Segment aDstSeg(aDst.data(), kLen, MemoryType::DRAM);
+  Segment bSrcSeg(bSrc.data(), kLen, MemoryType::DRAM);
+  Segment bDstSeg(bDst.data(), kLen, MemoryType::DRAM);
+
+  auto regASrc = factoryA.registerSegment(aSrcSeg);
+  auto regADst = factoryA.registerSegment(aDstSeg);
+  auto regBSrc = factoryB.registerSegment(bSrcSeg);
+  auto regBDst = factoryB.registerSegment(bDstSeg);
+  ASSERT_FALSE(regASrc.hasError());
+  ASSERT_FALSE(regADst.hasError());
+  ASSERT_FALSE(regBSrc.hasError());
+  ASSERT_FALSE(regBDst.hasError());
+
+  auto exportASrc = regASrc.value().exportId();
+  auto exportBSrc = regBSrc.value().exportId();
+  ASSERT_FALSE(exportASrc.hasError());
+  ASSERT_FALSE(exportBSrc.hasError());
+  auto remoteBOnA = factoryA.importSegment(exportBSrc.value());
+  auto remoteAOnB = factoryB.importSegment(exportASrc.value());
+  ASSERT_FALSE(remoteBOnA.hasError());
+  ASSERT_FALSE(remoteAOnB.hasError());
+
+  auto mtAResult = factoryA.createTransport(factoryB.getTopology());
+  auto mtBResult = factoryB.createTransport(factoryA.getTopology());
+  ASSERT_FALSE(mtAResult.hasError());
+  ASSERT_FALSE(mtBResult.hasError());
+  auto& mtA = mtAResult.value();
+  auto& mtB = mtBResult.value();
+
+  auto bindA = mtA->bind();
+  auto bindB = mtB->bind();
+  ASSERT_FALSE(bindA.hasError());
+  ASSERT_FALSE(bindB.hasError());
+
+  Status ca = Ok();
+  Status cb = Ok();
+  std::thread tA([&]() { ca = mtA->connect(bindB.value()); });
+  std::thread tB([&]() { cb = mtB->connect(bindA.value()); });
+  tA.join();
+  tB.join();
+  ASSERT_FALSE(ca.hasError()) << ca.error().message();
+  ASSERT_FALSE(cb.hasError()) << cb.error().message();
+
+  std::vector<TransferRequest> reqA;
+  reqA.push_back(
+      TransferRequest{
+          regADst.value().span(size_t{0}, kLen),
+          remoteBOnA.value().span(size_t{0}, kLen)});
+  std::vector<TransferRequest> reqB;
+  reqB.push_back(
+      TransferRequest{
+          regBDst.value().span(size_t{0}, kLen),
+          remoteAOnB.value().span(size_t{0}, kLen)});
+
+  auto futA = mtA->get(reqA);
+  auto futB = mtB->get(reqB);
+  auto statusA = futA.get();
+  auto statusB = futB.get();
+  ASSERT_FALSE(statusA.hasError()) << statusA.error().message();
+  ASSERT_FALSE(statusB.hasError()) << statusB.error().message();
+
+  EXPECT_EQ(aDst, bSrc);
+  EXPECT_EQ(bDst, aSrc);
+
+  mtA->shutdown();
+  mtB->shutdown();
+}
+
+// Same-host loopback: two-sided send/recv between two direct TcpTransports.
+TEST(TcpTransportIntegration, SendRecvRoundTrip) {
+  constexpr size_t kLen = 4096;
+  std::vector<uint8_t> src(kLen);
+  std::vector<uint8_t> dst(kLen, 0);
+  for (size_t i = 0; i < kLen; ++i) {
+    src[i] = static_cast<uint8_t>((i * 37 + 5) & 0xFF);
+  }
+
+  ScopedEventBaseThread evbtA;
+  ScopedEventBaseThread evbtB;
+  TcpTransportFactory factoryA(/*deviceId=*/-1, evbtA.getEventBase());
+  TcpTransportFactory factoryB(/*deviceId=*/-1, evbtB.getEventBase());
+
+  Segment srcSeg(src.data(), kLen, MemoryType::DRAM);
+  Segment dstSeg(dst.data(), kLen, MemoryType::DRAM);
+  auto rA = factoryA.registerSegment(srcSeg);
+  auto rB = factoryB.registerSegment(dstSeg);
+  ASSERT_FALSE(rA.hasError()) << rA.error().message();
+  ASSERT_FALSE(rB.hasError()) << rB.error().message();
+  auto regA = SegmentTest::makeRegistered(srcSeg, std::move(rA.value()));
+  auto regB = SegmentTest::makeRegistered(dstSeg, std::move(rB.value()));
+
+  auto taResult = factoryA.createTransport(factoryB.getTopology());
+  auto tbResult = factoryB.createTransport(factoryA.getTopology());
+  ASSERT_FALSE(taResult.hasError()) << taResult.error().message();
+  ASSERT_FALSE(tbResult.hasError()) << tbResult.error().message();
+  auto& ta = taResult.value();
+  auto& tb = tbResult.value();
+
+  auto ia = ta->bind();
+  auto ib = tb->bind();
+  std::thread t1([&]() { (void)ta->connect(ib); });
+  (void)tb->connect(ia);
+  t1.join();
+
+  auto fRecv = tb->recv(regB.span(size_t{0}, kLen));
+  auto fSend = ta->send(regA.span(size_t{0}, kLen));
+  ASSERT_FALSE(fSend.get().hasError());
+  ASSERT_FALSE(fRecv.get().hasError());
+  EXPECT_EQ(dst, src);
+
+  ta->shutdown();
+  tb->shutdown();
+}
+
+// A send() payload exceeding the 64 MiB wire-frame cap is rejected with a clear
+// InvalidArgument. send() is single-frame (no chunking); large transfers should
+// use put/get, which chunk.
+TEST(TcpTransportIntegration, DramOversizeSendRejected) {
+  constexpr size_t kLen = (64u << 20) + 1; // just over the 64 MiB frame cap
+  std::vector<uint8_t> src(kLen);
+
+  ScopedEventBaseThread evbtA;
+  ScopedEventBaseThread evbtB;
+  TcpTransportFactory factoryA(/*deviceId=*/-1, evbtA.getEventBase());
+  TcpTransportFactory factoryB(/*deviceId=*/-1, evbtB.getEventBase());
+
+  Segment srcSeg(src.data(), kLen, MemoryType::DRAM);
+  auto rA = factoryA.registerSegment(srcSeg);
+  ASSERT_FALSE(rA.hasError()) << rA.error().message();
+  auto regA = SegmentTest::makeRegistered(srcSeg, std::move(rA.value()));
+
+  auto taResult = factoryA.createTransport(factoryB.getTopology());
+  auto tbResult = factoryB.createTransport(factoryA.getTopology());
+  ASSERT_FALSE(taResult.hasError()) << taResult.error().message();
+  ASSERT_FALSE(tbResult.hasError()) << tbResult.error().message();
+  auto& ta = taResult.value();
+  auto& tb = tbResult.value();
+
+  auto ia = ta->bind();
+  auto ib = tb->bind();
+  std::thread t1([&]() { (void)ta->connect(ib); });
+  (void)tb->connect(ia);
+  t1.join();
+
+  auto st = ta->send(regA.span(size_t{0}, kLen)).get();
+  EXPECT_TRUE(st.hasError());
+  EXPECT_EQ(st.error().code(), ErrCode::InvalidArgument);
+
+  ta->shutdown();
+  tb->shutdown();
+}
+
+// Exercises payload chunking: a >4 MiB transfer spans multiple wire frames.
+// Verifies both put (write) and get (pull) reassemble correctly.
+TEST(TcpTransportIntegration, DramLargeChunkedPutGet) {
+  constexpr size_t kLen = 10 * 1024 * 1024; // 10 MiB > 4 MiB chunk
+  std::vector<uint8_t> src(kLen);
+  std::vector<uint8_t> dst(kLen, 0);
+  std::vector<uint8_t> back(kLen, 0);
+  for (size_t i = 0; i < kLen; ++i) {
+    src[i] = static_cast<uint8_t>((i * 2654435761u) >> 24);
+  }
+
+  MultiTransportFactory factoryA(/*deviceId=*/-1, tcpOnlyOptions());
+  MultiTransportFactory factoryB(/*deviceId=*/-1, tcpOnlyOptions());
+
+  Segment srcSeg(src.data(), kLen, MemoryType::DRAM);
+  Segment backSeg(back.data(), kLen, MemoryType::DRAM);
+  Segment dstSeg(dst.data(), kLen, MemoryType::DRAM);
+
+  auto regASrc = factoryA.registerSegment(srcSeg);
+  auto regABack = factoryA.registerSegment(backSeg);
+  auto regBDst = factoryB.registerSegment(dstSeg);
+  ASSERT_FALSE(regASrc.hasError());
+  ASSERT_FALSE(regABack.hasError());
+  ASSERT_FALSE(regBDst.hasError());
+
+  auto exportB = regBDst.value().exportId();
+  ASSERT_FALSE(exportB.hasError());
+  auto remoteBOnA = factoryA.importSegment(exportB.value());
+  ASSERT_FALSE(remoteBOnA.hasError());
+
+  auto mtAResult = factoryA.createTransport(factoryB.getTopology());
+  auto mtBResult = factoryB.createTransport(factoryA.getTopology());
+  ASSERT_FALSE(mtAResult.hasError());
+  ASSERT_FALSE(mtBResult.hasError());
+  auto& mtA = mtAResult.value();
+  auto& mtB = mtBResult.value();
+
+  auto bindA = mtA->bind();
+  auto bindB = mtB->bind();
+  ASSERT_FALSE(bindA.hasError());
+  ASSERT_FALSE(bindB.hasError());
+  Status ca = Ok();
+  Status cb = Ok();
+  std::thread tA([&]() { ca = mtA->connect(bindB.value()); });
+  std::thread tB([&]() { cb = mtB->connect(bindA.value()); });
+  tA.join();
+  tB.join();
+  ASSERT_FALSE(ca.hasError()) << ca.error().message();
+  ASSERT_FALSE(cb.hasError()) << cb.error().message();
+
+  std::vector<TransferRequest> putReqs;
+  putReqs.push_back(
+      TransferRequest{
+          regASrc.value().span(size_t{0}, kLen),
+          remoteBOnA.value().span(size_t{0}, kLen)});
+  ASSERT_FALSE(mtA->put(putReqs).get().hasError());
+  EXPECT_EQ(dst, src);
+
+  std::vector<TransferRequest> getReqs;
+  getReqs.push_back(
+      TransferRequest{
+          regABack.value().span(size_t{0}, kLen),
+          remoteBOnA.value().span(size_t{0}, kLen)});
+  ASSERT_FALSE(mtA->get(getReqs).get().hasError());
+  EXPECT_EQ(back, src);
+
+  mtA->shutdown();
+  mtB->shutdown();
+}
+
+} // namespace
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/tests/integration/TcpTransportIntegrationTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/integration/TcpTransportIntegrationTest.cpp
@@ -1,0 +1,571 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/MultiTransport.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstdint>
+#include <random>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "comms/uniflow/Segment.h"
+#include "comms/uniflow/executor/ScopedEventBaseThread.h"
+#include "comms/uniflow/transport/tcp/TcpRegistrationHandle.h"
+#include "comms/uniflow/transport/tcp/TcpTransport.h"
+#include "comms/uniflow/transport/tcp/TcpWireProtocol.h"
+
+namespace uniflow {
+
+// Friend wrapper (name must be exactly "SegmentTest") to build a
+// RegisteredSegment with a handle for the direct-transport send/recv test.
+class SegmentTest {
+ public:
+  static RegisteredSegment makeRegistered(
+      Segment& segment,
+      std::unique_ptr<RegistrationHandle> handle) {
+    RegisteredSegment reg(segment);
+    reg.handles_.push_back(std::move(handle));
+    return reg;
+  }
+};
+
+namespace {
+
+// TCP-only factory options: a non-matching netdev prefix excludes RDMA NIC
+// discovery and deviceId=-1 excludes NVLink, so only the TCP transport is
+// registered — making this test host-independent (no RDMA/GPU required).
+MultiTransportFactoryOptions tcpOnlyOptions() {
+  MultiTransportFactoryOptions opt;
+  opt.netdevPrefix = "uniflow_tcp_test_nonic";
+  opt.preferredTransport = TransportType::TCP;
+  opt.enableTcp = true;
+  opt.tcpBindHost = "127.0.0.1";
+  return opt;
+}
+
+// Same-host loopback: two in-process agents exchange bind info, connect over
+// TCP, and one puts a DRAM buffer into the other's registered segment.
+TEST(TcpTransportIntegration, DramPutRoundTrip) {
+  constexpr size_t kLen = 8192;
+  std::vector<uint8_t> src(kLen);
+  std::vector<uint8_t> dst(kLen, 0);
+  for (size_t i = 0; i < kLen; ++i) {
+    src[i] = static_cast<uint8_t>((i * 131 + 7) & 0xFF);
+  }
+
+  MultiTransportFactory factoryA(/*deviceId=*/-1, tcpOnlyOptions());
+  MultiTransportFactory factoryB(/*deviceId=*/-1, tcpOnlyOptions());
+
+  Segment srcSeg(src.data(), kLen, MemoryType::DRAM);
+  Segment dstSeg(dst.data(), kLen, MemoryType::DRAM);
+
+  auto regA = factoryA.registerSegment(srcSeg);
+  ASSERT_FALSE(regA.hasError()) << regA.error().message();
+  auto regB = factoryB.registerSegment(dstSeg);
+  ASSERT_FALSE(regB.hasError()) << regB.error().message();
+
+  auto exportB = regB.value().exportId();
+  ASSERT_FALSE(exportB.hasError()) << exportB.error().message();
+  auto remoteOnA = factoryA.importSegment(exportB.value());
+  ASSERT_FALSE(remoteOnA.hasError()) << remoteOnA.error().message();
+
+  auto mtAResult = factoryA.createTransport(factoryB.getTopology());
+  ASSERT_FALSE(mtAResult.hasError()) << mtAResult.error().message();
+  auto mtBResult = factoryB.createTransport(factoryA.getTopology());
+  ASSERT_FALSE(mtBResult.hasError()) << mtBResult.error().message();
+  auto& mtA = mtAResult.value();
+  auto& mtB = mtBResult.value();
+
+  auto bindA = mtA->bind();
+  ASSERT_FALSE(bindA.hasError()) << bindA.error().message();
+  auto bindB = mtB->bind();
+  ASSERT_FALSE(bindB.hasError()) << bindB.error().message();
+
+  // connect() blocks on the listener side, so run both peers concurrently.
+  Status ca = Ok();
+  Status cb = Ok();
+  std::thread tA([&]() { ca = mtA->connect(bindB.value()); });
+  std::thread tB([&]() { cb = mtB->connect(bindA.value()); });
+  tA.join();
+  tB.join();
+  ASSERT_FALSE(ca.hasError()) << ca.error().message();
+  ASSERT_FALSE(cb.hasError()) << cb.error().message();
+
+  std::vector<TransferRequest> requests;
+  requests.push_back(
+      TransferRequest{
+          regA.value().span(size_t{0}, kLen),
+          remoteOnA.value().span(size_t{0}, kLen)});
+
+  auto putStatus = mtA->put(requests).get();
+  ASSERT_FALSE(putStatus.hasError()) << putStatus.error().message();
+
+  EXPECT_EQ(dst, src);
+
+  mtA->shutdown();
+  mtB->shutdown();
+}
+
+// Same-host loopback: A pulls (get) a DRAM buffer from B's registered segment.
+TEST(TcpTransportIntegration, DramGetRoundTrip) {
+  constexpr size_t kLen = 8192;
+  std::vector<uint8_t> remoteSrc(kLen);
+  std::vector<uint8_t> localDst(kLen, 0);
+  for (size_t i = 0; i < kLen; ++i) {
+    remoteSrc[i] = static_cast<uint8_t>((i * 17 + 3) & 0xFF);
+  }
+
+  MultiTransportFactory factoryA(/*deviceId=*/-1, tcpOnlyOptions());
+  MultiTransportFactory factoryB(/*deviceId=*/-1, tcpOnlyOptions());
+
+  Segment srcSeg(remoteSrc.data(), kLen, MemoryType::DRAM);
+  Segment dstSeg(localDst.data(), kLen, MemoryType::DRAM);
+
+  auto regB = factoryB.registerSegment(srcSeg);
+  ASSERT_FALSE(regB.hasError()) << regB.error().message();
+  auto regA = factoryA.registerSegment(dstSeg);
+  ASSERT_FALSE(regA.hasError()) << regA.error().message();
+
+  auto exportB = regB.value().exportId();
+  ASSERT_FALSE(exportB.hasError()) << exportB.error().message();
+  auto remoteOnA = factoryA.importSegment(exportB.value());
+  ASSERT_FALSE(remoteOnA.hasError()) << remoteOnA.error().message();
+
+  auto mtAResult = factoryA.createTransport(factoryB.getTopology());
+  ASSERT_FALSE(mtAResult.hasError()) << mtAResult.error().message();
+  auto mtBResult = factoryB.createTransport(factoryA.getTopology());
+  ASSERT_FALSE(mtBResult.hasError()) << mtBResult.error().message();
+  auto& mtA = mtAResult.value();
+  auto& mtB = mtBResult.value();
+
+  auto bindA = mtA->bind();
+  ASSERT_FALSE(bindA.hasError()) << bindA.error().message();
+  auto bindB = mtB->bind();
+  ASSERT_FALSE(bindB.hasError()) << bindB.error().message();
+
+  Status ca = Ok();
+  Status cb = Ok();
+  std::thread tA([&]() { ca = mtA->connect(bindB.value()); });
+  std::thread tB([&]() { cb = mtB->connect(bindA.value()); });
+  tA.join();
+  tB.join();
+  ASSERT_FALSE(ca.hasError()) << ca.error().message();
+  ASSERT_FALSE(cb.hasError()) << cb.error().message();
+
+  std::vector<TransferRequest> requests;
+  requests.push_back(
+      TransferRequest{
+          regA.value().span(size_t{0}, kLen),
+          remoteOnA.value().span(size_t{0}, kLen)});
+
+  auto getStatus = mtA->get(requests).get();
+  ASSERT_FALSE(getStatus.hasError()) << getStatus.error().message();
+
+  EXPECT_EQ(localDst, remoteSrc);
+
+  mtA->shutdown();
+  mtB->shutdown();
+}
+
+// Both peers issue a concurrent get() to each other with large payloads. This
+// exercises the mutual-READ path that would deadlock if reply sends blocked the
+// reader; the dedicated sender thread must keep both readers draining.
+TEST(TcpTransportIntegration, MutualGetNoDeadlock) {
+  constexpr size_t kLen = 262144; // 256 KiB to stress socket buffers
+  std::vector<uint8_t> aSrc(kLen), aDst(kLen, 0);
+  std::vector<uint8_t> bSrc(kLen), bDst(kLen, 0);
+  for (size_t i = 0; i < kLen; ++i) {
+    aSrc[i] = static_cast<uint8_t>((i * 5 + 1) & 0xFF);
+    bSrc[i] = static_cast<uint8_t>((i * 9 + 2) & 0xFF);
+  }
+
+  MultiTransportFactory factoryA(/*deviceId=*/-1, tcpOnlyOptions());
+  MultiTransportFactory factoryB(/*deviceId=*/-1, tcpOnlyOptions());
+
+  Segment aSrcSeg(aSrc.data(), kLen, MemoryType::DRAM);
+  Segment aDstSeg(aDst.data(), kLen, MemoryType::DRAM);
+  Segment bSrcSeg(bSrc.data(), kLen, MemoryType::DRAM);
+  Segment bDstSeg(bDst.data(), kLen, MemoryType::DRAM);
+
+  auto regASrc = factoryA.registerSegment(aSrcSeg);
+  auto regADst = factoryA.registerSegment(aDstSeg);
+  auto regBSrc = factoryB.registerSegment(bSrcSeg);
+  auto regBDst = factoryB.registerSegment(bDstSeg);
+  ASSERT_FALSE(regASrc.hasError());
+  ASSERT_FALSE(regADst.hasError());
+  ASSERT_FALSE(regBSrc.hasError());
+  ASSERT_FALSE(regBDst.hasError());
+
+  auto exportASrc = regASrc.value().exportId();
+  auto exportBSrc = regBSrc.value().exportId();
+  ASSERT_FALSE(exportASrc.hasError());
+  ASSERT_FALSE(exportBSrc.hasError());
+  auto remoteBOnA = factoryA.importSegment(exportBSrc.value());
+  auto remoteAOnB = factoryB.importSegment(exportASrc.value());
+  ASSERT_FALSE(remoteBOnA.hasError());
+  ASSERT_FALSE(remoteAOnB.hasError());
+
+  auto mtAResult = factoryA.createTransport(factoryB.getTopology());
+  auto mtBResult = factoryB.createTransport(factoryA.getTopology());
+  ASSERT_FALSE(mtAResult.hasError());
+  ASSERT_FALSE(mtBResult.hasError());
+  auto& mtA = mtAResult.value();
+  auto& mtB = mtBResult.value();
+
+  auto bindA = mtA->bind();
+  auto bindB = mtB->bind();
+  ASSERT_FALSE(bindA.hasError());
+  ASSERT_FALSE(bindB.hasError());
+
+  Status ca = Ok();
+  Status cb = Ok();
+  std::thread tA([&]() { ca = mtA->connect(bindB.value()); });
+  std::thread tB([&]() { cb = mtB->connect(bindA.value()); });
+  tA.join();
+  tB.join();
+  ASSERT_FALSE(ca.hasError()) << ca.error().message();
+  ASSERT_FALSE(cb.hasError()) << cb.error().message();
+
+  std::vector<TransferRequest> reqA;
+  reqA.push_back(
+      TransferRequest{
+          regADst.value().span(size_t{0}, kLen),
+          remoteBOnA.value().span(size_t{0}, kLen)});
+  std::vector<TransferRequest> reqB;
+  reqB.push_back(
+      TransferRequest{
+          regBDst.value().span(size_t{0}, kLen),
+          remoteAOnB.value().span(size_t{0}, kLen)});
+
+  auto futA = mtA->get(reqA);
+  auto futB = mtB->get(reqB);
+  auto statusA = futA.get();
+  auto statusB = futB.get();
+  ASSERT_FALSE(statusA.hasError()) << statusA.error().message();
+  ASSERT_FALSE(statusB.hasError()) << statusB.error().message();
+
+  EXPECT_EQ(aDst, bSrc);
+  EXPECT_EQ(bDst, aSrc);
+
+  mtA->shutdown();
+  mtB->shutdown();
+}
+
+// Same-host loopback: two-sided send/recv between two direct TcpTransports.
+TEST(TcpTransportIntegration, SendRecvRoundTrip) {
+  constexpr size_t kLen = 4096;
+  std::vector<uint8_t> src(kLen);
+  std::vector<uint8_t> dst(kLen, 0);
+  for (size_t i = 0; i < kLen; ++i) {
+    src[i] = static_cast<uint8_t>((i * 37 + 5) & 0xFF);
+  }
+
+  ScopedEventBaseThread evbtA;
+  ScopedEventBaseThread evbtB;
+  TcpTransportFactory factoryA(/*deviceId=*/-1, evbtA.getEventBase());
+  TcpTransportFactory factoryB(/*deviceId=*/-1, evbtB.getEventBase());
+
+  Segment srcSeg(src.data(), kLen, MemoryType::DRAM);
+  Segment dstSeg(dst.data(), kLen, MemoryType::DRAM);
+  auto rA = factoryA.registerSegment(srcSeg);
+  auto rB = factoryB.registerSegment(dstSeg);
+  ASSERT_FALSE(rA.hasError()) << rA.error().message();
+  ASSERT_FALSE(rB.hasError()) << rB.error().message();
+  auto regA = SegmentTest::makeRegistered(srcSeg, std::move(rA.value()));
+  auto regB = SegmentTest::makeRegistered(dstSeg, std::move(rB.value()));
+
+  auto taResult = factoryA.createTransport(factoryB.getTopology());
+  auto tbResult = factoryB.createTransport(factoryA.getTopology());
+  ASSERT_FALSE(taResult.hasError()) << taResult.error().message();
+  ASSERT_FALSE(tbResult.hasError()) << tbResult.error().message();
+  auto& ta = taResult.value();
+  auto& tb = tbResult.value();
+
+  auto ia = ta->bind();
+  auto ib = tb->bind();
+  std::thread t1([&]() { (void)ta->connect(ib); });
+  (void)tb->connect(ia);
+  t1.join();
+
+  auto fRecv = tb->recv(regB.span(size_t{0}, kLen));
+  auto fSend = ta->send(regA.span(size_t{0}, kLen));
+  ASSERT_FALSE(fSend.get().hasError());
+  ASSERT_FALSE(fRecv.get().hasError());
+  EXPECT_EQ(dst, src);
+
+  ta->shutdown();
+  tb->shutdown();
+}
+
+// A send() payload exceeding the 64 MiB wire-frame cap is rejected with a clear
+// InvalidArgument. send() is single-frame (no chunking); large transfers should
+// use put/get, which chunk.
+TEST(TcpTransportIntegration, DramOversizeSendRejected) {
+  constexpr size_t kLen = (64u << 20) + 1; // just over the 64 MiB frame cap
+  std::vector<uint8_t> src(kLen);
+
+  ScopedEventBaseThread evbtA;
+  ScopedEventBaseThread evbtB;
+  TcpTransportFactory factoryA(/*deviceId=*/-1, evbtA.getEventBase());
+  TcpTransportFactory factoryB(/*deviceId=*/-1, evbtB.getEventBase());
+
+  Segment srcSeg(src.data(), kLen, MemoryType::DRAM);
+  auto rA = factoryA.registerSegment(srcSeg);
+  ASSERT_FALSE(rA.hasError()) << rA.error().message();
+  auto regA = SegmentTest::makeRegistered(srcSeg, std::move(rA.value()));
+
+  auto taResult = factoryA.createTransport(factoryB.getTopology());
+  auto tbResult = factoryB.createTransport(factoryA.getTopology());
+  ASSERT_FALSE(taResult.hasError()) << taResult.error().message();
+  ASSERT_FALSE(tbResult.hasError()) << tbResult.error().message();
+  auto& ta = taResult.value();
+  auto& tb = tbResult.value();
+
+  auto ia = ta->bind();
+  auto ib = tb->bind();
+  std::thread t1([&]() { (void)ta->connect(ib); });
+  (void)tb->connect(ia);
+  t1.join();
+
+  auto st = ta->send(regA.span(size_t{0}, kLen)).get();
+  EXPECT_TRUE(st.hasError());
+  EXPECT_EQ(st.error().code(), ErrCode::InvalidArgument);
+
+  ta->shutdown();
+  tb->shutdown();
+}
+
+// Exercises payload chunking: a >4 MiB transfer spans multiple wire frames.
+// Verifies both put (write) and get (pull) reassemble correctly.
+TEST(TcpTransportIntegration, DramLargeChunkedPutGet) {
+  constexpr size_t kLen = 10 * 1024 * 1024; // 10 MiB > 4 MiB chunk
+  std::vector<uint8_t> src(kLen);
+  std::vector<uint8_t> dst(kLen, 0);
+  std::vector<uint8_t> back(kLen, 0);
+  for (size_t i = 0; i < kLen; ++i) {
+    src[i] = static_cast<uint8_t>((i * 2654435761u) >> 24);
+  }
+
+  MultiTransportFactory factoryA(/*deviceId=*/-1, tcpOnlyOptions());
+  MultiTransportFactory factoryB(/*deviceId=*/-1, tcpOnlyOptions());
+
+  Segment srcSeg(src.data(), kLen, MemoryType::DRAM);
+  Segment backSeg(back.data(), kLen, MemoryType::DRAM);
+  Segment dstSeg(dst.data(), kLen, MemoryType::DRAM);
+
+  auto regASrc = factoryA.registerSegment(srcSeg);
+  auto regABack = factoryA.registerSegment(backSeg);
+  auto regBDst = factoryB.registerSegment(dstSeg);
+  ASSERT_FALSE(regASrc.hasError());
+  ASSERT_FALSE(regABack.hasError());
+  ASSERT_FALSE(regBDst.hasError());
+
+  auto exportB = regBDst.value().exportId();
+  ASSERT_FALSE(exportB.hasError());
+  auto remoteBOnA = factoryA.importSegment(exportB.value());
+  ASSERT_FALSE(remoteBOnA.hasError());
+
+  auto mtAResult = factoryA.createTransport(factoryB.getTopology());
+  auto mtBResult = factoryB.createTransport(factoryA.getTopology());
+  ASSERT_FALSE(mtAResult.hasError());
+  ASSERT_FALSE(mtBResult.hasError());
+  auto& mtA = mtAResult.value();
+  auto& mtB = mtBResult.value();
+
+  auto bindA = mtA->bind();
+  auto bindB = mtB->bind();
+  ASSERT_FALSE(bindA.hasError());
+  ASSERT_FALSE(bindB.hasError());
+  Status ca = Ok();
+  Status cb = Ok();
+  std::thread tA([&]() { ca = mtA->connect(bindB.value()); });
+  std::thread tB([&]() { cb = mtB->connect(bindA.value()); });
+  tA.join();
+  tB.join();
+  ASSERT_FALSE(ca.hasError()) << ca.error().message();
+  ASSERT_FALSE(cb.hasError()) << cb.error().message();
+
+  std::vector<TransferRequest> putReqs;
+  putReqs.push_back(
+      TransferRequest{
+          regASrc.value().span(size_t{0}, kLen),
+          remoteBOnA.value().span(size_t{0}, kLen)});
+  ASSERT_FALSE(mtA->put(putReqs).get().hasError());
+  EXPECT_EQ(dst, src);
+
+  std::vector<TransferRequest> getReqs;
+  getReqs.push_back(
+      TransferRequest{
+          regABack.value().span(size_t{0}, kLen),
+          remoteBOnA.value().span(size_t{0}, kLen)});
+  ASSERT_FALSE(mtA->get(getReqs).get().hasError());
+  EXPECT_EQ(back, src);
+
+  mtA->shutdown();
+  mtB->shutdown();
+}
+
+// Byte value at an absolute offset, from a hash with a period far longer than
+// any transfer here. This matters: a pattern that repeats every 256 bytes (say
+// `offset & 0xFF`) is invisible to a whole-chunk misplacement, because chunk
+// boundaries are multiples of 256. With this, a chunk landing at the wrong
+// offset -- or duplicated, dropped, or reordered -- changes the bytes.
+uint8_t patternAt(uint64_t offset, uint64_t round) {
+  uint64_t x = offset + 0x9E3779B97F4A7C15ULL * (round + 1);
+  x ^= x >> 33;
+  x *= 0xFF51AFD7ED558CCDULL;
+  x ^= x >> 33;
+  x *= 0xC4CEB9FE1A85EC53ULL;
+  x ^= x >> 33;
+  return static_cast<uint8_t>(x);
+}
+
+// Transfer sizes for the correctness sweep. Random sizes alone are weak here:
+// every failure this transport can have lives on a boundary, and a uniform draw
+// almost never lands on one. So the boundaries are enumerated explicitly and
+// the random sizes only add coverage between them.
+std::vector<size_t> sweepSizes(size_t maxLen) {
+  constexpr size_t kChunk = 4UL * 1024 * 1024; // kMaxChunkSize in TcpTransport
+  std::vector<size_t> sizes{
+      0, // the (len == 0) ? 1 : ... chunk-count special case
+      1,
+      3,
+      4095, // unaligned tails
+      4096,
+      4097,
+      kChunk - 1, // chunk boundary: +1 leaves a 1-byte final chunk
+      kChunk,
+      kChunk + 1,
+      2 * kChunk, // exact multiple: no remainder chunk at all
+      2 * kChunk + 1,
+      kMaxFrameSize - 1, // wire-frame cap / ReadRequest rejection edge
+      kMaxFrameSize,
+      kMaxFrameSize + 1,
+      kMaxFrameSize + kChunk, // just over the outbound queue cap
+      2 * kMaxFrameSize, // 128 MiB: the size that used to kill the connection
+  };
+
+  // Log-uniform, not uniform: a uniform draw over [1, maxLen] puts ~99% of
+  // samples above 2 MiB and would essentially never exercise small transfers.
+  // Fixed seed so a failure reproduces exactly.
+  constexpr uint64_t kSeed = 0x5EED1234;
+  std::mt19937_64 rng(kSeed);
+  std::uniform_real_distribution<double> logDist(
+      0.0, std::log(static_cast<double>(maxLen)));
+  for (int i = 0; i < 12; ++i) {
+    sizes.push_back(static_cast<size_t>(std::exp(logDist(rng))));
+  }
+
+  std::erase_if(sizes, [maxLen](size_t s) { return s > maxLen; });
+  return sizes;
+}
+
+// Boundary + randomized size/offset sweep with content verification, over one
+// connection. Two gaps this closes: nothing exercised a transfer larger than
+// kMaxOutQueueBytes (which is how a 128 MiB get killing the connection reached
+// a published diff), and nothing used a non-zero remote offset, so the
+// `offset <= entry->len - len` bounds check and the `baseOffset + off` chunk
+// arithmetic were only ever tested at offset 0.
+TEST(TcpTransportIntegration, DramSizeAndOffsetSweepPutGet) {
+  // Segment must exceed the largest transfer so a non-zero offset still fits.
+  constexpr size_t kMaxLen = 2 * kMaxFrameSize; // 128 MiB
+  constexpr size_t kSegLen = kMaxLen + 4UL * 1024 * 1024;
+  std::vector<uint8_t> src(kSegLen, 0);
+  std::vector<uint8_t> dst(kSegLen, 0);
+  std::vector<uint8_t> back(kSegLen, 0);
+
+  MultiTransportFactory factoryA(/*deviceId=*/-1, tcpOnlyOptions());
+  MultiTransportFactory factoryB(/*deviceId=*/-1, tcpOnlyOptions());
+
+  Segment srcSeg(src.data(), kSegLen, MemoryType::DRAM);
+  Segment backSeg(back.data(), kSegLen, MemoryType::DRAM);
+  Segment dstSeg(dst.data(), kSegLen, MemoryType::DRAM);
+
+  auto regASrc = factoryA.registerSegment(srcSeg);
+  auto regABack = factoryA.registerSegment(backSeg);
+  auto regBDst = factoryB.registerSegment(dstSeg);
+  ASSERT_FALSE(regASrc.hasError()) << regASrc.error().message();
+  ASSERT_FALSE(regABack.hasError()) << regABack.error().message();
+  ASSERT_FALSE(regBDst.hasError()) << regBDst.error().message();
+
+  auto exportB = regBDst.value().exportId();
+  ASSERT_FALSE(exportB.hasError()) << exportB.error().message();
+  auto remoteBOnA = factoryA.importSegment(exportB.value());
+  ASSERT_FALSE(remoteBOnA.hasError()) << remoteBOnA.error().message();
+
+  auto mtAResult = factoryA.createTransport(factoryB.getTopology());
+  auto mtBResult = factoryB.createTransport(factoryA.getTopology());
+  ASSERT_FALSE(mtAResult.hasError()) << mtAResult.error().message();
+  ASSERT_FALSE(mtBResult.hasError()) << mtBResult.error().message();
+  auto& mtA = mtAResult.value();
+  auto& mtB = mtBResult.value();
+
+  auto bindA = mtA->bind();
+  auto bindB = mtB->bind();
+  ASSERT_FALSE(bindA.hasError()) << bindA.error().message();
+  ASSERT_FALSE(bindB.hasError()) << bindB.error().message();
+  Status ca = Ok();
+  Status cb = Ok();
+  std::thread tA([&]() { ca = mtA->connect(bindB.value()); });
+  std::thread tB([&]() { cb = mtB->connect(bindA.value()); });
+  tA.join();
+  tB.join();
+  ASSERT_FALSE(ca.hasError()) << ca.error().message();
+  ASSERT_FALSE(cb.hasError()) << cb.error().message();
+
+  const std::vector<size_t> sizes = sweepSizes(kMaxLen);
+  std::mt19937_64 offsetRng(0xA5A5A5A5);
+  uint64_t round = 0;
+
+  for (size_t len : sizes) {
+    // Offset 0 always, plus one unaligned offset that still fits the segment.
+    std::vector<size_t> offsets{0};
+    if (kSegLen > len) {
+      offsets.push_back(
+          std::uniform_int_distribution<size_t>(1, kSegLen - len)(offsetRng));
+    }
+
+    for (size_t offset : offsets) {
+      SCOPED_TRACE(
+          "len=" + std::to_string(len) + " offset=" + std::to_string(offset));
+      // Re-seed every round. A transfer that silently moved nothing therefore
+      // fails, because the destination still holds the previous round's
+      // pattern rather than this round's.
+      ++round;
+      for (size_t i = 0; i < len; ++i) {
+        src[offset + i] = patternAt(offset + i, round);
+        dst[offset + i] = 0;
+        back[offset + i] = 0;
+      }
+
+      std::vector<TransferRequest> putReqs{TransferRequest{
+          regASrc.value().span(offset, len),
+          remoteBOnA.value().span(offset, len)}};
+      auto putStatus = mtA->put(putReqs).get();
+      ASSERT_FALSE(putStatus.hasError()) << putStatus.error().message();
+      for (size_t i = 0; i < len; ++i) {
+        ASSERT_EQ(dst[offset + i], patternAt(offset + i, round))
+            << "put mismatch at byte " << i;
+      }
+
+      std::vector<TransferRequest> getReqs{TransferRequest{
+          regABack.value().span(offset, len),
+          remoteBOnA.value().span(offset, len)}};
+      auto getStatus = mtA->get(getReqs).get();
+      ASSERT_FALSE(getStatus.hasError()) << getStatus.error().message();
+      for (size_t i = 0; i < len; ++i) {
+        ASSERT_EQ(back[offset + i], patternAt(offset + i, round))
+            << "get mismatch at byte " << i;
+      }
+    }
+  }
+
+  mtA->shutdown();
+  mtB->shutdown();
+}
+
+} // namespace
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/tests/unit/TcpRegistrationHandleTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpRegistrationHandleTest.cpp
@@ -1,0 +1,31 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/transport/tcp/TcpRegistrationHandle.h"
+
+#include <gtest/gtest.h>
+
+namespace uniflow {
+
+TEST(TcpRegistrationHandleTest, SerializeDeserializeRoundTrip) {
+  TcpRegistrationHandle local(7, 4096);
+
+  auto remote =
+      TcpRemoteRegistrationHandle::deserialize(4096, local.serialize());
+
+  ASSERT_TRUE(remote.hasValue()) << remote.error().message();
+  EXPECT_EQ(remote.value()->transportType(), TransportType::TCP);
+  EXPECT_EQ(remote.value()->segId(), 7);
+  EXPECT_EQ(remote.value()->len(), 4096);
+}
+
+TEST(TcpRegistrationHandleTest, DeserializeRejectsLengthMismatch) {
+  TcpRegistrationHandle local(7, 4096);
+
+  auto remote =
+      TcpRemoteRegistrationHandle::deserialize(2048, local.serialize());
+
+  ASSERT_TRUE(remote.hasError());
+  EXPECT_EQ(remote.error().code(), ErrCode::InvalidArgument);
+}
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/tests/unit/TcpRegistrationHandleTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpRegistrationHandleTest.cpp
@@ -1,0 +1,32 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/transport/tcp/TcpRegistrationHandle.h"
+
+#include <gtest/gtest.h>
+
+namespace uniflow {
+
+TEST(TcpRegistrationHandleTest, SerializeDeserializeRoundTrip) {
+  TcpRegistrationHandle local(7, 0x1000, 4096);
+
+  auto remote =
+      TcpRemoteRegistrationHandle::deserialize(4096, local.serialize());
+
+  ASSERT_TRUE(remote.hasValue()) << remote.error().message();
+  EXPECT_EQ(remote.value()->transportType(), TransportType::TCP);
+  EXPECT_EQ(remote.value()->segId(), 7);
+  EXPECT_EQ(remote.value()->base(), 0x1000);
+  EXPECT_EQ(remote.value()->len(), 4096);
+}
+
+TEST(TcpRegistrationHandleTest, DeserializeRejectsLengthMismatch) {
+  TcpRegistrationHandle local(7, 0x1000, 4096);
+
+  auto remote =
+      TcpRemoteRegistrationHandle::deserialize(2048, local.serialize());
+
+  ASSERT_TRUE(remote.hasError());
+  EXPECT_EQ(remote.error().code(), ErrCode::InvalidArgument);
+}
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportConnectTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportConnectTest.cpp
@@ -1,0 +1,261 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/transport/tcp/TcpTransport.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <vector>
+
+#include "comms/uniflow/executor/ScopedEventBaseThread.h"
+#include "comms/uniflow/transport/tcp/TcpWireProtocol.h"
+
+namespace uniflow {
+
+// connect() decides who listens and who dials by comparing the two endpoints'
+// order keys. Identical endpoints have no valid assignment: both peers would
+// dial and nobody would accept, so connect() must reject rather than hang.
+class TcpTransportConnectTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    evbThread_ = std::make_unique<ScopedEventBaseThread>("tcp-connect-test");
+    registry_ = std::make_shared<TcpSegmentRegistry>();
+    transport_ = std::make_unique<TcpTransport>(
+        /*deviceId=*/-1,
+        evbThread_->getEventBase(),
+        registry_,
+        controller::TcpSocketConfig{},
+        /*host=*/"127.0.0.1");
+  }
+
+  /// A transport whose handshake wait is short, so timeout paths finish fast.
+  std::unique_ptr<TcpTransport> makeShortTimeoutTransport() {
+    controller::TcpSocketConfig config;
+    config.connTimeout = std::chrono::seconds{2};
+    return std::make_unique<TcpTransport>(
+        /*deviceId=*/-1,
+        evbThread_->getEventBase(),
+        registry_,
+        config,
+        /*host=*/"127.0.0.1");
+  }
+
+  void TearDown() override {
+    if (transport_) {
+      transport_->shutdown();
+      transport_.reset();
+    }
+    evbThread_.reset();
+  }
+
+  std::unique_ptr<ScopedEventBaseThread> evbThread_;
+  std::shared_ptr<TcpSegmentRegistry> registry_;
+  std::unique_ptr<TcpTransport> transport_;
+};
+
+TEST_F(TcpTransportConnectTest, RejectsIdenticalEndpoint) {
+  // bind() publishes this transport's own host:port. Feeding that straight back
+  // into connect() is exactly the degenerate case.
+  const TransportInfo self = transport_->bind();
+  ASSERT_FALSE(self.empty()) << "bind() must publish a routable endpoint";
+  ASSERT_EQ(transport_->state(), TransportState::Initialized);
+
+  const Status status = transport_->connect(self);
+
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::ConnectionFailed);
+  // The code alone does not pin this guard: with the guard removed, dialing our
+  // own listener also fails with ConnectionFailed ("tcp connect: data
+  // connection failed"). Assert on the message so this test goes red if the
+  // identical-endpoint check is ever dropped.
+  EXPECT_NE(status.error().message().find("identical"), std::string::npos)
+      << "expected the identical-endpoint guard to fire, got: "
+      << status.error().message();
+  // Fenced, so a caller cannot then drive transfers over a transport that never
+  // established a connection.
+  EXPECT_EQ(transport_->state(), TransportState::Error);
+}
+
+// The listener branch of connect() waits on AsyncAccept, whose promise is
+// resolved only by an inbound connection or by teardown. If the dialing peer
+// never arrives, an unbounded wait would wedge this thread forever -- and
+// nothing could rescue it, because server_ belongs to the transport whose
+// connect() is parked. Assert the wait is bounded and reports failure.
+TEST_F(TcpTransportConnectTest, ListenerTimesOutWhenNoPeerDials) {
+  auto listener = makeShortTimeoutTransport();
+  const TransportInfo self = listener->bind();
+  ASSERT_FALSE(self.empty());
+
+  // Choose a peer endpoint that orders ABOVE ours so connect() takes the
+  // listener branch, then never dial it.
+  auto peer = TcpTransportInfo::deserialize(self);
+  ASSERT_TRUE(peer.hasValue()) << peer.error().message();
+  TcpTransportInfo absent = peer.value();
+  absent.port = static_cast<uint16_t>(absent.port + 1);
+
+  const auto start = std::chrono::steady_clock::now();
+  const Status status = listener->connect(absent.serialize());
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+
+  ASSERT_TRUE(status.hasError())
+      << "connect() must fail rather than block when no peer dials in";
+  EXPECT_EQ(status.error().code(), ErrCode::ConnectionFailed);
+  // Bounded: comfortably under the 30s default, proving the configured
+  // timeout is what released it rather than some unrelated failure.
+  EXPECT_LT(elapsed, std::chrono::seconds{20})
+      << "connect() took "
+      << std::chrono::duration_cast<std::chrono::seconds>(elapsed).count()
+      << "s; the handshake wait is not bounded by connTimeout";
+
+  listener->shutdown();
+}
+
+TEST_F(TcpTransportConnectTest, RejectsMalformedPeerInfo) {
+  ASSERT_FALSE(transport_->bind().empty());
+
+  // A truncated payload cannot name an endpoint; connect() must reject it
+  // rather than proceed with a partially parsed peer.
+  const std::vector<uint8_t> truncated(2, 0);
+  const Status status = transport_->connect(truncated);
+
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::InvalidArgument);
+}
+
+// shutdown() used to load state_ and then store Disconnected as two separate
+// steps, so a bind() failure landing in the gap was clobbered and a transport
+// that never came up reported as cleanly closed. Error must survive teardown.
+TEST_F(TcpTransportConnectTest, ShutdownPreservesTheErrorState) {
+  // TEST-NET-1 (RFC 5737): never assigned to a local interface, so the listen
+  // socket genuinely fails to bind rather than the failure being simulated.
+  auto unbindable = std::make_unique<TcpTransport>(
+      /*deviceId=*/-1,
+      evbThread_->getEventBase(),
+      registry_,
+      controller::TcpSocketConfig{},
+      /*host=*/"192.0.2.1");
+
+  EXPECT_TRUE(unbindable->bind().empty()) << "bind() was expected to fail";
+  ASSERT_EQ(unbindable->state(), TransportState::Error);
+
+  unbindable->shutdown();
+
+  EXPECT_EQ(unbindable->state(), TransportState::Error)
+      << "shutdown() must not report a failed transport as cleanly closed";
+}
+
+// shutdown() is called twice in the normal flow (MultiTransport::shutdown()
+// then ~TcpTransport), and may be called on a transport that never connected.
+TEST_F(TcpTransportConnectTest, ShutdownIsIdempotent) {
+  ASSERT_FALSE(transport_->bind().empty());
+
+  transport_->shutdown();
+  transport_->shutdown();
+
+  EXPECT_EQ(transport_->state(), TransportState::Disconnected);
+}
+
+TEST_F(TcpTransportConnectTest, ShutdownWithoutBindOrConnectIsSafe) {
+  transport_->shutdown();
+
+  EXPECT_EQ(transport_->state(), TransportState::Disconnected);
+}
+
+// Teardown is one-shot. connect() parks for the whole handshake, so without a
+// terminal check it could install a data connection and both worker threads
+// after shutdown() had already returned, leaving state() reporting Connected on
+// a torn-down transport.
+TEST_F(TcpTransportConnectTest, ConnectAfterShutdownIsRefused) {
+  const TransportInfo self = transport_->bind();
+  ASSERT_FALSE(self.empty());
+  auto peer = TcpTransportInfo::deserialize(self);
+  ASSERT_TRUE(peer.hasValue()) << peer.error().message();
+  TcpTransportInfo other = peer.value();
+  other.port = static_cast<uint16_t>(other.port + 1);
+
+  transport_->shutdown();
+  const Status status = transport_->connect(other.serialize());
+
+  ASSERT_TRUE(status.hasError())
+      << "connect() must not revive a shut-down transport";
+  EXPECT_EQ(status.error().code(), ErrCode::NotConnected);
+  EXPECT_NE(transport_->state(), TransportState::Connected);
+}
+
+TEST_F(TcpTransportConnectTest, BindAfterShutdownIsRefused) {
+  transport_->shutdown();
+
+  EXPECT_TRUE(transport_->bind().empty())
+      << "bind() must not re-open a shut-down transport";
+}
+
+// The factory's topology blob used to be a default-constructed *addressing*
+// struct, so it advertised 127.0.0.1:0 rather than a real endpoint and carried
+// no version. canConnect() therefore validated nothing, and a wire-format
+// mismatch could only surface later as a dropped frame mid-transfer.
+class TcpTransportTopologyTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    evbThread_ = std::make_unique<ScopedEventBaseThread>("tcp-topology-test");
+    factory_ = std::make_unique<TcpTransportFactory>(
+        /*deviceId=*/-1,
+        evbThread_->getEventBase(),
+        controller::TcpSocketConfig{},
+        /*host=*/"127.0.0.1");
+  }
+
+  void TearDown() override {
+    factory_.reset();
+    evbThread_.reset();
+  }
+
+  std::unique_ptr<ScopedEventBaseThread> evbThread_;
+  std::unique_ptr<TcpTransportFactory> factory_;
+};
+
+TEST_F(TcpTransportTopologyTest, TopologyIsAVersionedCapabilityBlob) {
+  const std::vector<uint8_t> topology = factory_->getTopology();
+
+  // Capability, not addressing: it is exactly the topology struct, so there is
+  // no host or port in it to be mistaken for a real endpoint.
+  ASSERT_EQ(topology.size(), sizeof(TcpTopologyInfo));
+  auto info = TcpTopologyInfo::deserialize(topology);
+  ASSERT_TRUE(info.hasValue()) << info.error().message();
+  EXPECT_EQ(info->version, kTcpWireVersion);
+  EXPECT_FALSE(factory_->canConnect(topology).hasError())
+      << "a peer running this build must be accepted";
+}
+
+TEST_F(TcpTransportTopologyTest, RejectsMismatchedTopologyVersion) {
+  TcpTopologyInfo future;
+  future.version = static_cast<uint8_t>(kTcpWireVersion + 1);
+
+  const Status status = factory_->canConnect(future.serialize());
+
+  ASSERT_TRUE(status.hasError())
+      << "a peer on a different wire version must be rejected at handshake";
+  EXPECT_EQ(status.error().code(), ErrCode::TopologyDisconnect);
+}
+
+TEST_F(TcpTransportTopologyTest, RejectsWrongSizedTopology) {
+  const std::vector<uint8_t> oversized(sizeof(TcpTopologyInfo) + 4, 0);
+
+  const Status status = factory_->canConnect(oversized);
+
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::InvalidArgument);
+}
+
+TEST_F(TcpTransportTopologyTest, CreateTransportValidatesPeerTopology) {
+  TcpTopologyInfo future;
+  future.version = static_cast<uint8_t>(kTcpWireVersion + 1);
+
+  auto result = factory_->createTransport(future.serialize());
+
+  ASSERT_TRUE(result.hasError())
+      << "createTransport must not build against an incompatible peer";
+  EXPECT_EQ(result.error().code(), ErrCode::TopologyDisconnect);
+}
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
@@ -1,0 +1,829 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/transport/tcp/TcpTransport.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <future>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "comms/uniflow/drivers/cuda/mock/MockCudaApi.h"
+#include "comms/uniflow/executor/ScopedEventBaseThread.h"
+#include "comms/uniflow/transport/tcp/TcpWireProtocol.h"
+
+namespace uniflow {
+
+// handleFrame() acts on peer-supplied segId/offset/len before touching a
+// registered buffer, so its bounds checks are this transport's memory-safety
+// boundary. They are correct as written but nothing exercised them, meaning a
+// refactor could drop a clause silently. These tests drive frames straight into
+// handleFrame() and assert two things per case: the registered buffer is left
+// untouched, and an Error frame is queued back to the peer.
+//
+// The last test covers the other buffer handleFrame() writes into: a READ_REPLY
+// targets a *caller-owned* get() destination, which the caller may free as soon
+// as the op's future resolves.
+/// A connection whose send() always fails; recv() is never used by these tests.
+class FailingConn : public controller::Conn {
+ public:
+  std::future<Result<size_t>> send(std::span<const uint8_t>) override {
+    return make_ready_future<Result<size_t>>(
+        Err(ErrCode::ConnectionFailed, "test: send failed"));
+  }
+  std::future<Result<size_t>> recv(std::vector<uint8_t>&) override {
+    return make_ready_future<Result<size_t>>(
+        Err(ErrCode::ConnectionFailed, "test: recv failed"));
+  }
+  std::future<Result<size_t>> recv(std::span<uint8_t>) override {
+    return make_ready_future<Result<size_t>>(
+        Err(ErrCode::ConnectionFailed, "test: recv failed"));
+  }
+  void close() override {
+    closed = true;
+    ++closeCount;
+  }
+  bool closed{false};
+  int closeCount{0};
+};
+
+class TcpTransportFrameTest : public ::testing::Test {
+ protected:
+  static constexpr uint64_t kSegId = 42;
+  static constexpr size_t kSegLen = 256;
+
+  void SetUp() override {
+    evbThread_ = std::make_unique<ScopedEventBaseThread>("tcp-frame-test");
+    registry_ = std::make_shared<TcpSegmentRegistry>();
+    cudaApi_ = std::make_shared<::testing::NiceMock<MockCudaApi>>();
+    // Enough for CudaDeviceGuard; the VRAM copies themselves are stubbed
+    // per-test.
+    ON_CALL(*cudaApi_, getDevice())
+        .WillByDefault(::testing::Return(Result<int>(0)));
+    ON_CALL(*cudaApi_, setDevice(::testing::_))
+        .WillByDefault(::testing::Return(Ok()));
+    ON_CALL(*cudaApi_, streamSynchronize(::testing::_))
+        .WillByDefault(::testing::Return(Ok()));
+
+    transport_ = std::make_unique<TcpTransport>(
+        /*deviceId=*/-1,
+        evbThread_->getEventBase(),
+        registry_,
+        controller::TcpSocketConfig{},
+        /*host=*/"127.0.0.1",
+        cudaApi_);
+
+    // A registered DRAM segment filled with a known pattern, so any
+    // out-of-contract write is detectable.
+    segment_.assign(kSegLen, std::byte{0xAB});
+    registry_->add(
+        kSegId, segment_.data(), kSegLen, MemoryType::DRAM, /*deviceId=*/-1);
+    pristine_ = segment_;
+  }
+
+  void TearDown() override {
+    if (transport_) {
+      transport_->shutdown();
+      transport_.reset();
+    }
+    evbThread_.reset();
+  }
+
+  /// Build one framed message: header followed by `payload` bytes.
+  static std::vector<uint8_t> makeFrame(
+      TcpOp op,
+      uint64_t segId,
+      uint64_t offset,
+      uint64_t len,
+      size_t payloadBytes) {
+    TcpMsgHeader header;
+    header.op = static_cast<uint8_t>(op);
+    header.reqId = 1;
+    header.segId = segId;
+    header.offset = offset;
+    header.len = len;
+
+    std::vector<uint8_t> frame(sizeof(TcpMsgHeader) + payloadBytes);
+    std::memcpy(frame.data(), &header, sizeof(header));
+    // Distinct from the segment pattern so a stray write is unmistakable.
+    std::fill(frame.begin() + sizeof(TcpMsgHeader), frame.end(), uint8_t{0xCD});
+    return frame;
+  }
+
+  void feed(const std::vector<uint8_t>& frame) {
+    transport_->handleFrame(frame);
+  }
+
+  /// True if the transport queued at least one Error frame back to the peer.
+  bool queuedErrorFrame() const {
+    std::lock_guard<std::mutex> lk(transport_->outMu_);
+    for (const auto& item : transport_->outQueue_) {
+      auto header = deserializeTcpHeader(item.bytes);
+      if (header.hasValue() &&
+          static_cast<TcpOp>(header.value().op) == TcpOp::Error) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool segmentUntouched() const {
+    return segment_ == pristine_;
+  }
+
+  bool connBroken() const {
+    return transport_->connBroken_.load(std::memory_order_acquire);
+  }
+
+  bool readerRunning() const {
+    return transport_->running_.load(std::memory_order_acquire);
+  }
+
+  /// Registers `chunks` in-flight READ chunks sharing one op state, the way a
+  /// multi-chunk get() does. Chunk reqId 1 targets `dst`; the rest stand in for
+  /// siblings whose replies have not arrived yet. VRAM so the copy runs through
+  /// the mocked CudaApi. Returns the caller's future.
+  std::future<Status> postReadChunks(void* dst, size_t len, size_t chunks) {
+    auto state = std::make_shared<TcpOpState>();
+    state->remaining = chunks;
+    auto future = state->promise.get_future();
+    std::lock_guard<std::mutex> lk(transport_->inflightMu_);
+    for (size_t i = 0; i < chunks; ++i) {
+      transport_->inflight_[i + 1] = TcpInflight{
+          state,
+          i == 0 ? dst : nullptr,
+          len,
+          /*isRead=*/true,
+          MemoryType::VRAM,
+          /*deviceId=*/0,
+          /*stream=*/nullptr};
+    }
+    return future;
+  }
+
+  void failAllPending() {
+    transport_->failAllPending("test: connection failed");
+  }
+
+  size_t inflightCount() {
+    std::lock_guard<std::mutex> lk(transport_->inflightMu_);
+    return transport_->inflight_.size();
+  }
+
+  Status admitInflight(uint64_t reqId, TcpInflight entry) {
+    return transport_->admitInflight(reqId, std::move(entry));
+  }
+
+  bool enqueueReaderFrame(size_t bytes) {
+    return transport_->enqueueFrame(
+        std::vector<uint8_t>(bytes, 0), /*mayBlock=*/false);
+  }
+
+  size_t outQueueBytes() {
+    std::lock_guard<std::mutex> lk(transport_->outMu_);
+    return transport_->outBytes_;
+  }
+
+  static constexpr size_t outQueueCap() {
+    return TcpTransport::kMaxOutQueueBytes;
+  }
+
+  static constexpr size_t inflightCap() {
+    return TcpTransport::kMaxInflightRequests;
+  }
+
+  /// Installs a connection whose send() always fails, so senderLoop() can be
+  /// driven down its error path without a peer.
+  void installFailingConn() {
+    auto conn = std::make_unique<FailingConn>();
+    failingConn_ = conn.get();
+    transport_->dataConn_ = std::move(conn);
+  }
+
+  bool connClosed() const {
+    return failingConn_ != nullptr && failingConn_->closed;
+  }
+
+  int connCloseCount() const {
+    return failingConn_ == nullptr ? 0 : failingConn_->closeCount;
+  }
+
+  size_t unmatchedBytes() {
+    std::lock_guard<std::mutex> lk(transport_->recvMu_);
+    return transport_->unmatchedBytes_;
+  }
+
+  static constexpr size_t unmatchedCap() {
+    return TcpTransport::kMaxUnmatchedSendBytes;
+  }
+
+  void runSenderLoop() {
+    transport_->senderLoop();
+  }
+
+  bool enqueueFrame(std::vector<uint8_t> frame) {
+    return transport_->enqueueFrame(std::move(frame), /*mayBlock=*/false);
+  }
+
+  void enqueueSendFrame(
+      std::vector<uint8_t> frame,
+      std::shared_ptr<TcpOpState> onSent) {
+    transport_->enqueueSendFrame(std::move(frame), std::move(onSent));
+  }
+
+  size_t outQueueDepth() {
+    std::lock_guard<std::mutex> lk(transport_->outMu_);
+    return transport_->outQueue_.size();
+  }
+
+  /// send()/recv() are gated on the Connected state; these tests drive the
+  /// staging path directly rather than standing up a real peer.
+  void setConnected() {
+    transport_->state_ = TransportState::Connected;
+  }
+
+  /// Buffers an inbound SEND payload so the next recv() takes its
+  /// already-matched fast path instead of posting a pending recv.
+  void bufferInboundSend(size_t len) {
+    std::lock_guard<std::mutex> lk(transport_->recvMu_);
+    transport_->unmatchedSends_.emplace_back(len, uint8_t{0xCD});
+  }
+
+  std::unique_ptr<ScopedEventBaseThread> evbThread_;
+  std::shared_ptr<TcpSegmentRegistry> registry_;
+  std::shared_ptr<::testing::NiceMock<MockCudaApi>> cudaApi_;
+  std::unique_ptr<TcpTransport> transport_;
+  std::vector<std::byte> segment_;
+  std::vector<std::byte> pristine_;
+  FailingConn* failingConn_{nullptr};
+};
+
+TEST_F(TcpTransportFrameTest, WriteToUnknownSegIdIsRejected) {
+  feed(makeFrame(TcpOp::Write, kSegId + 1, /*offset=*/0, /*len=*/8, 8));
+
+  EXPECT_TRUE(segmentUntouched()) << "an unknown segId must touch no buffer";
+  EXPECT_TRUE(queuedErrorFrame());
+}
+
+TEST_F(TcpTransportFrameTest, WritePastSegmentEndIsRejected) {
+  // offset is inside the segment but offset + len runs past the end.
+  feed(makeFrame(TcpOp::Write, kSegId, /*offset=*/kSegLen - 4, /*len=*/8, 8));
+
+  EXPECT_TRUE(segmentUntouched()) << "a write past the end must be rejected";
+  EXPECT_TRUE(queuedErrorFrame());
+}
+
+TEST_F(TcpTransportFrameTest, WriteWithLenExceedingSegmentIsRejected) {
+  feed(makeFrame(
+      TcpOp::Write, kSegId, /*offset=*/0, /*len=*/kSegLen + 1, kSegLen + 1));
+
+  EXPECT_TRUE(segmentUntouched());
+  EXPECT_TRUE(queuedErrorFrame());
+}
+
+TEST_F(TcpTransportFrameTest, WriteWithPayloadLengthMismatchIsRejected) {
+  // header.len says 32 but only 8 payload bytes arrived. Without the
+  // payload.size() == header.len clause this would read past the frame.
+  feed(makeFrame(TcpOp::Write, kSegId, /*offset=*/0, /*len=*/32, 8));
+
+  EXPECT_TRUE(segmentUntouched())
+      << "a header.len/payload.size() mismatch must be rejected";
+  EXPECT_TRUE(queuedErrorFrame());
+}
+
+TEST_F(TcpTransportFrameTest, ReadRequestPastSegmentEndIsRejected) {
+  feed(makeFrame(
+      TcpOp::ReadRequest, kSegId, /*offset=*/kSegLen - 4, /*len=*/64, 0));
+
+  EXPECT_TRUE(queuedErrorFrame())
+      << "an out-of-range ReadRequest must not return segment contents";
+}
+
+TEST_F(TcpTransportFrameTest, InBoundsWriteIsApplied) {
+  // Control: the checks must not reject a legitimate frame.
+  feed(makeFrame(TcpOp::Write, kSegId, /*offset=*/0, /*len=*/8, 8));
+
+  EXPECT_FALSE(segmentUntouched()) << "an in-bounds write must be applied";
+  EXPECT_FALSE(queuedErrorFrame());
+}
+
+// A READ_REPLY copies its payload into the caller's get() destination after
+// dropping inflightMu_. Resolving the op's future is what releases the caller
+// to free that destination, so the copy and the resolution must be one atomic
+// step. failAllPending() (send error, peer disconnect, shutdown) can resolve
+// the op mid-copy via a *sibling* chunk of the same multi-chunk get(), which
+// shares the op state -- a silent write-after-free.
+TEST_F(TcpTransportFrameTest, ReadReplyCopyKeepsTheGetUnresolvedWhileItRuns) {
+  constexpr size_t kLen = 64;
+  std::vector<uint8_t> dst(kLen, 0);
+  // Chunk 2 never replies, so failAllPending() has a sibling to fail.
+  auto future = postReadChunks(dst.data(), kLen, /*chunks=*/2);
+
+  // Park the H2D mid-copy so the fail is guaranteed to land while the copy into
+  // dst is in flight.
+  std::promise<void> copyStarted;
+  std::promise<void> releaseCopy;
+  auto copyStartedFuture = copyStarted.get_future();
+  auto releaseCopyFuture = releaseCopy.get_future();
+  EXPECT_CALL(
+      *cudaApi_,
+      memcpyAsync(
+          ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+      .WillOnce([&](void* d, const void* s, size_t n, auto, auto) -> Status {
+        copyStarted.set_value();
+        releaseCopyFuture.wait();
+        std::memcpy(d, s, n);
+        return Ok();
+      });
+
+  std::thread reader([&]() {
+    feed(makeFrame(TcpOp::ReadReply, kSegId, /*offset=*/0, kLen, kLen));
+  });
+  copyStartedFuture.wait();
+  std::thread failer([&]() { failAllPending(); });
+
+  // Generous: a resolution here would be immediate, so the full window is only
+  // ever waited out when the op is correctly held open.
+  const bool resolvedDuringCopy =
+      future.wait_for(std::chrono::milliseconds(500)) ==
+      std::future_status::ready;
+
+  releaseCopy.set_value();
+  reader.join();
+  failer.join();
+
+  EXPECT_FALSE(resolvedDuringCopy)
+      << "the get() future resolved while a READ_REPLY copy into the caller's "
+         "destination was still running; the caller may free it there";
+
+  const std::vector<uint8_t> expected(kLen, 0xCD);
+  EXPECT_EQ(dst, expected) << "the in-flight copy must still complete";
+  EXPECT_TRUE(future.get().hasError())
+      << "failAllPending() must still fail the op";
+}
+
+// put()/get() forward options.stream into their VRAM host-staging copies, but
+// all four send()/recv() overloads used to discard RequestOptions, so the
+// D2H/H2D ran on the null stream whatever the caller passed. That can transmit
+// stale device data on send, and let the caller launch kernels against an
+// unfilled buffer on recv, with no diagnostic. These tests pin both halves of
+// the fix: the stream now reaches every staging site, and a VRAM transfer with
+// no stream is refused rather than guessed at (matching RdmaTransport).
+
+TEST_F(TcpTransportFrameTest, VramSendWithoutAnExplicitStreamIsRejected) {
+  setConnected();
+  std::vector<uint8_t> buf(64, 0xEE);
+  Segment seg(buf.data(), buf.size(), MemoryType::VRAM, /*deviceId=*/0);
+  // It must refuse before staging anything, not stage on the null stream.
+  EXPECT_CALL(
+      *cudaApi_,
+      memcpyAsync(
+          ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+      .Times(0);
+
+  // Bounded: with the guard removed this queues a frame no sender drains, so an
+  // unbounded get() would hang instead of failing.
+  auto future = transport_->send(seg.span(size_t{0}, buf.size()));
+  ASSERT_EQ(future.wait_for(std::chrono::seconds{5}), std::future_status::ready)
+      << "a rejected VRAM transfer must fail immediately, not queue work";
+  const auto status = future.get();
+
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::InvalidArgument);
+}
+
+TEST_F(TcpTransportFrameTest, VramRecvWithoutAnExplicitStreamIsRejected) {
+  setConnected();
+  std::vector<uint8_t> buf(64, 0);
+  Segment seg(buf.data(), buf.size(), MemoryType::VRAM, /*deviceId=*/0);
+  EXPECT_CALL(
+      *cudaApi_,
+      memcpyAsync(
+          ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+      .Times(0);
+
+  // Bounded: with the guard removed this queues a frame no sender drains, so an
+  // unbounded get() would hang instead of failing.
+  auto future = transport_->recv(seg.span(size_t{0}, buf.size()));
+  ASSERT_EQ(future.wait_for(std::chrono::seconds{5}), std::future_status::ready)
+      << "a rejected VRAM transfer must fail immediately, not queue work";
+  const auto status = future.get();
+
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::InvalidArgument);
+}
+
+TEST_F(TcpTransportFrameTest, VramSendStagesOnTheCallersStream) {
+  setConnected();
+  std::vector<uint8_t> buf(64, 0xEE);
+  Segment seg(buf.data(), buf.size(), MemoryType::VRAM, /*deviceId=*/0);
+  auto* const callerStream = reinterpret_cast<void*>(0xF00D);
+  RequestOptions options;
+  options.stream = callerStream;
+
+  void* staged = nullptr;
+  EXPECT_CALL(
+      *cudaApi_,
+      memcpyAsync(
+          ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+      .WillOnce([&](void*, const void*, size_t, auto, auto s) -> Status {
+        staged = static_cast<void*>(s);
+        return Ok();
+      });
+
+  (void)transport_->send(seg.span(size_t{0}, buf.size()), options);
+
+  EXPECT_EQ(staged, callerStream) << "the D2H must run on the caller's stream";
+}
+
+TEST_F(
+    TcpTransportFrameTest,
+    VramRecvMatchedImmediatelyStagesOnTheCallersStream) {
+  setConnected();
+  constexpr size_t kLen = 64;
+  bufferInboundSend(kLen);
+  std::vector<uint8_t> buf(kLen, 0);
+  Segment seg(buf.data(), kLen, MemoryType::VRAM, /*deviceId=*/0);
+  auto* const callerStream = reinterpret_cast<void*>(0xBEEF);
+  RequestOptions options;
+  options.stream = callerStream;
+
+  void* staged = nullptr;
+  EXPECT_CALL(
+      *cudaApi_,
+      memcpyAsync(
+          ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+      .WillOnce([&](void*, const void*, size_t, auto, auto s) -> Status {
+        staged = static_cast<void*>(s);
+        return Ok();
+      });
+
+  (void)transport_->recv(seg.span(size_t{0}, kLen), options);
+
+  EXPECT_EQ(staged, callerStream);
+}
+
+// The case that needs TcpPendingRecv to carry the stream: a posted recv is
+// completed by the reader thread when the SEND eventually arrives, long after
+// the caller's RequestOptions is gone. Without the retained field this stages
+// on the null stream.
+TEST_F(TcpTransportFrameTest, PostedVramRecvRetainsTheStreamForALaterSend) {
+  setConnected();
+  constexpr size_t kLen = 64;
+  std::vector<uint8_t> buf(kLen, 0);
+  Segment seg(buf.data(), kLen, MemoryType::VRAM, /*deviceId=*/0);
+  auto* const callerStream = reinterpret_cast<void*>(0xCAFE);
+  RequestOptions options;
+  options.stream = callerStream;
+
+  // No buffered send, so this posts a pending recv and returns unresolved.
+  auto future = transport_->recv(seg.span(size_t{0}, kLen), options);
+
+  void* staged = nullptr;
+  EXPECT_CALL(
+      *cudaApi_,
+      memcpyAsync(
+          ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+      .WillOnce([&](void*, const void*, size_t, auto, auto s) -> Status {
+        staged = static_cast<void*>(s);
+        return Ok();
+      });
+
+  feed(makeFrame(TcpOp::Send, kSegId, /*offset=*/0, kLen, kLen));
+
+  EXPECT_EQ(staged, callerStream)
+      << "a posted recv must remember the stream it was given";
+  EXPECT_FALSE(future.get().hasError());
+}
+
+// The admission race mahi flagged: a put()/get() that passes the entry check,
+// then has failAllPending() sweep inflight_ before its own insert lands, used
+// to leave an entry nothing would ever resolve -- enqueueFrame() drops the
+// frame silently once the out queue is closed, and no later sweep runs, so the
+// caller blocked in future.get() forever. This diff previously made that worse:
+// the one-shot shutdown_ guard removed the accidental second failAllPending()
+// that the MultiTransport-then-destructor double shutdown used to provide.
+//
+// Tested at the admission primitive rather than end-to-end: the window is
+// between the entry check and the insert, and there is no hook in put()/get()
+// to park a thread inside it, so an end-to-end test would either pass for the
+// wrong reason (the entry check rejects first) or be a flaky thread race.
+TEST_F(TcpTransportFrameTest, AdmissionIsRefusedOnceTeardownHasSwept) {
+  setConnected();
+  // Teardown has run: the sweep is done and the transport is marked broken.
+  failAllPending();
+
+  auto state = std::make_shared<TcpOpState>();
+  state->remaining = 1;
+  auto future = state->promise.get_future();
+
+  const Status admitted = admitInflight(
+      /*reqId=*/99, TcpInflight{state, nullptr, /*len=*/64, /*isRead=*/false});
+
+  EXPECT_TRUE(admitted.hasError())
+      << "admitting after the sweep orphans the entry and hangs the caller";
+  EXPECT_EQ(inflightCount(), 0u) << "no orphaned inflight entry may remain";
+  // The caller is expected to fail the op on refusal; nothing else can.
+  EXPECT_NE(future.wait_for(std::chrono::seconds{0}), std::future_status::ready)
+      << "admitInflight must not resolve the promise itself";
+}
+
+TEST_F(TcpTransportFrameTest, AdmissionSucceedsOnAHealthyTransport) {
+  setConnected();
+
+  auto state = std::make_shared<TcpOpState>();
+  state->remaining = 1;
+
+  EXPECT_FALSE(admitInflight(
+                   /*reqId=*/7,
+                   TcpInflight{state, nullptr, /*len=*/64, /*isRead=*/false})
+                   .hasError());
+  EXPECT_EQ(inflightCount(), 1u);
+}
+
+// A dead sender used to leave the out queue open: enqueueFrame() gates only on
+// outClosed_, so the still-running reader thread kept appending Ack/Error/
+// ReadReply frames (up to 4 MiB each) to a queue nothing drained, and
+// failAllPending() clears it exactly once. Unbounded, peer-driven growth.
+TEST_F(TcpTransportFrameTest, DeadSenderClosesTheOutQueue) {
+  setConnected();
+  installFailingConn();
+
+  // One item for the sender to pick up and fail on.
+  auto state = std::make_shared<TcpOpState>();
+  state->remaining = 1;
+  auto future = state->promise.get_future();
+  enqueueSendFrame(std::vector<uint8_t>(16, 0), state);
+  ASSERT_EQ(outQueueDepth(), 1u);
+
+  runSenderLoop(); // returns once send() fails
+
+  EXPECT_TRUE(future.get().hasError()) << "the in-flight op must be failed";
+  // The reader thread would keep producing replies after the sender is gone.
+  enqueueFrame(std::vector<uint8_t>(4096, 0));
+  enqueueFrame(std::vector<uint8_t>(4096, 0));
+  EXPECT_EQ(outQueueDepth(), 0u)
+      << "a dead sender must close the out queue, not let it grow unbounded";
+}
+
+// A ReadRequest whose reply would exceed the wire-frame cap must be refused per
+// request. The controller refuses an oversized send and senderLoop treats that
+// as fatal, so without this bound one oversized request from a version-skewed
+// peer (built with a larger chunk size) kills the sender and fails every
+// unrelated in-flight transfer. The segment here is deliberately large enough
+// that the offset/len bounds check passes, so only the cap can reject it.
+TEST_F(TcpTransportFrameTest, OversizedReadRequestIsRefusedPerRequest) {
+  constexpr uint64_t kBigSegId = kSegId + 100;
+  const size_t kBigLen = kMaxFrameSize;
+  std::vector<std::byte> big(kBigLen, std::byte{0x11});
+  registry_->add(
+      kBigSegId, big.data(), kBigLen, MemoryType::DRAM, /*deviceId=*/-1);
+
+  feed(makeFrame(
+      TcpOp::ReadRequest,
+      kBigSegId,
+      /*offset=*/0,
+      kBigLen,
+      /*payloadBytes=*/0));
+
+  EXPECT_TRUE(queuedErrorFrame())
+      << "an oversized read must get a per-request Error rather than a "
+         "ReadReply the controller will refuse and the sender will treat as "
+         "fatal";
+}
+
+// unmatchedSends_ buffers every inbound Send that finds no posted recv. The
+// reader never stops draining the socket -- that is what avoids the mutual-READ
+// deadlock -- so nothing upstream slows the peer down and the deque would
+// otherwise grow without limit.
+TEST_F(TcpTransportFrameTest, UnmatchedSendsOverflowRefusesTheConnection) {
+  setConnected();
+  installFailingConn();
+
+  constexpr size_t kChunk = 4UL * 1024 * 1024;
+  const size_t maxFrames = (unmatchedCap() / kChunk) + 4;
+  size_t frames = 0;
+  while (!connClosed() && frames < maxFrames) {
+    feed(makeFrame(TcpOp::Send, kSegId, /*offset=*/0, kChunk, kChunk));
+    ++frames;
+  }
+
+  EXPECT_TRUE(connClosed())
+      << "unmatched sends past the cap must refuse the connection instead of "
+         "buffering without bound";
+  EXPECT_LE(unmatchedBytes(), unmatchedCap());
+}
+
+// The reader refuses the connection on unmatched-send overflow, and shutdown()
+// closes it too, from an application thread. Conn::close() tests the fd, closes
+// it, then clears it with no synchronisation, so two callers that both see it
+// open both ::close() it -- and the second reaps whatever descriptor another
+// thread in the process has since been handed. Only one close may reach the
+// connection for the lifetime of the transport.
+TEST_F(TcpTransportFrameTest, TheDataConnectionIsClosedAtMostOnce) {
+  setConnected();
+  installFailingConn();
+
+  constexpr size_t kChunk = 4UL * 1024 * 1024;
+  const size_t maxFrames = (unmatchedCap() / kChunk) + 4;
+  size_t frames = 0;
+  while (!connClosed() && frames < maxFrames) {
+    feed(makeFrame(TcpOp::Send, kSegId, /*offset=*/0, kChunk, kChunk));
+    ++frames;
+  }
+  ASSERT_EQ(connCloseCount(), 1) << "the reader must refuse the connection";
+
+  // The path that races the reader in production. Sequential here because the
+  // race is a lost check-then-act, so a second close arriving at any time is
+  // the defect; running them concurrently would only make the test flaky about
+  // observing it.
+  transport_->shutdown();
+
+  EXPECT_EQ(connCloseCount(), 1)
+      << "shutdown() must not close a connection the reader already closed";
+}
+
+// A get of N bytes arrives at the responder as N/kMaxChunkSize ReadRequests and
+// legitimately needs up to N bytes of ReadReply queued, with N bounded only by
+// the segment size. Capping the reader path therefore rejects honest traffic:
+// applying kMaxOutQueueBytes here made every get >= 128 MiB kill the
+// connection, failing all unrelated in-flight transfers with it. The reader
+// must accept past the cap -- it also cannot wait, since ceasing to drain the
+// socket is the mutual-READ deadlock the reader/sender split exists to avoid.
+TEST_F(
+    TcpTransportFrameTest,
+    ReaderRepliesAreNotCappedAndDoNotKillTheConnection) {
+  setConnected();
+  installFailingConn();
+
+  // Mimic serving a 128 MiB get: 32 x 4 MiB replies, i.e. 2x the queue cap.
+  constexpr size_t kChunk = 4UL * 1024 * 1024;
+  const size_t frames = (2 * outQueueCap()) / kChunk;
+  for (size_t i = 0; i < frames; ++i) {
+    ASSERT_TRUE(enqueueReaderFrame(kChunk))
+        << "the reader path must keep accepting replies past the queue cap, "
+        << "refused at frame " << i;
+  }
+
+  EXPECT_GT(outQueueBytes(), outQueueCap())
+      << "the reply path is deliberately uncapped";
+  EXPECT_FALSE(connClosed())
+      << "serving a large get must not refuse the connection";
+}
+
+TEST_F(TcpTransportFrameTest, InflightAdmissionIsCappedNotUnbounded) {
+  setConnected();
+  auto state = std::make_shared<TcpOpState>();
+  state->remaining = 1;
+
+  for (size_t i = 0; i < inflightCap(); ++i) {
+    ASSERT_FALSE(
+        admitInflight(
+            i + 1, TcpInflight{state, nullptr, /*len=*/8, /*isRead=*/false})
+            .hasError())
+        << "admission below the cap must succeed, failed at " << i;
+  }
+  ASSERT_EQ(inflightCount(), inflightCap());
+
+  const Status overflow = admitInflight(
+      inflightCap() + 1, TcpInflight{state, nullptr, /*len=*/8, false});
+
+  ASSERT_TRUE(overflow.hasError()) << "inflight_ must not grow past its cap";
+  EXPECT_EQ(overflow.error().code(), ErrCode::ResourceExhausted);
+  EXPECT_EQ(inflightCount(), inflightCap());
+}
+
+// handleFrame() is noexcept, so an exception escaping it is std::terminate --
+// i.e. a peer-triggerable process abort. The VRAM staging path runs
+// CudaDeviceGuard, which throws when setDevice fails, and the deviceId it uses
+// comes from whatever the application passed to registerSegment (Segment
+// defaults it to -1). So this is reachable without a hostile peer at all.
+TEST_F(TcpTransportFrameTest, VramStagingThrowDoesNotAbortTheReader) {
+  constexpr uint64_t kVramSegId = kSegId + 500;
+  std::vector<std::byte> vram(kSegLen, std::byte{0});
+  registry_->add(
+      kVramSegId, vram.data(), kSegLen, MemoryType::VRAM, /*deviceId=*/-1);
+  EXPECT_CALL(*cudaApi_, setDevice(-1))
+      .WillRepeatedly(
+          ::testing::Return(
+              Err(ErrCode::InvalidArgument, "test: no such device")));
+
+  // Without the try/catch boundary in handleFrame this call terminates the
+  // process, so the failure mode of this test is an abort, not an assertion.
+  feed(makeFrame(TcpOp::Write, kVramSegId, /*offset=*/0, /*len=*/8, 8));
+
+  // Failed rather than silently dropped: an exception can land midway through a
+  // staging copy, so protocol state is no longer known to be sound.
+  EXPECT_TRUE(connBroken())
+      << "a throw inside handleFrame must fail the connection";
+  EXPECT_FALSE(readerRunning())
+      << "the reader must stop rather than keep serving frames";
+}
+
+// The registry's mutex protects the map, not the lifetime of the application
+// buffer an entry points at. Nothing stopped the reader thread from copying an
+// entry out, the owner deregistering and freeing the buffer, and the reader
+// then writing into freed memory. erase() now drains outstanding leases first.
+//
+// These exercise the registry directly rather than through handleFrame(): the
+// race needs the reader parked between the lookup and the copy, and there is no
+// hook to park it there, so an end-to-end version would be a flaky thread race
+// that passes for the wrong reason most runs.
+class TcpSegmentRegistryTest : public ::testing::Test {
+ protected:
+  static constexpr uint64_t kSegId = 7;
+
+  void SetUp() override {
+    buf_.assign(64, std::byte{0});
+    registry_.add(kSegId, buf_.data(), buf_.size(), MemoryType::DRAM, -1);
+  }
+
+  TcpSegmentRegistry registry_;
+  std::vector<std::byte> buf_;
+};
+
+TEST_F(TcpSegmentRegistryTest, EraseWaitsForAnOutstandingLease) {
+  auto lease = registry_.find(kSegId);
+  ASSERT_TRUE(lease) << "a registered segment must yield a lease";
+  EXPECT_EQ(lease->ptr, buf_.data());
+  EXPECT_EQ(lease->len, buf_.size());
+
+  std::atomic<bool> erased{false};
+  std::thread eraser([this, &erased]() {
+    registry_.erase(kSegId);
+    erased.store(true);
+  });
+
+  // Deregistration must not complete while a reader could still be mid-copy.
+  // Without the drain this flips to true almost immediately.
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  EXPECT_FALSE(erased.load())
+      << "erase() returned while a lease was outstanding: the owner is now free "
+         "to release memory the reader may still write into";
+
+  lease.reset();
+  eraser
+      .join(); // Hangs here if releasing the last lease fails to wake erase().
+  EXPECT_TRUE(erased.load());
+}
+
+TEST_F(TcpSegmentRegistryTest, DrainingSegmentHandsOutNoNewLeases) {
+  auto lease = registry_.find(kSegId);
+  ASSERT_TRUE(lease);
+
+  std::atomic<bool> erased{false};
+  std::thread eraser([this, &erased]() {
+    registry_.erase(kSegId);
+    erased.store(true);
+  });
+
+  // Let erase() mark the segment dying and start waiting. If find() kept
+  // issuing leases here, a steady stream of inbound frames for this segment
+  // could hold the count above zero and starve the drain indefinitely.
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Both halves matter: the segment must still be mid-drain (not already gone)
+  // AND refusing leases. Checking only the refusal would also pass against an
+  // erase() that removed the entry outright, which is the bug.
+  ASSERT_FALSE(erased.load()) << "erase() completed before the drain finished";
+  EXPECT_FALSE(registry_.find(kSegId))
+      << "a segment being torn down must not yield further leases";
+
+  lease.reset();
+  eraser.join();
+  EXPECT_FALSE(registry_.find(kSegId));
+}
+
+TEST_F(TcpSegmentRegistryTest, FindNeverBlocksBehindADrain) {
+  // The reader thread calls find() and must never be parked behind a
+  // deregistration: it is the thread that releases leases, and blocking it
+  // behind an app thread waiting on it would deadlock both.
+  auto lease = registry_.find(kSegId);
+  ASSERT_TRUE(lease);
+  std::thread eraser([this]() { registry_.erase(kSegId); });
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  auto refused = std::async(std::launch::async, [this]() {
+    return static_cast<bool>(registry_.find(kSegId));
+  });
+  ASSERT_EQ(
+      refused.wait_for(std::chrono::seconds(5)), std::future_status::ready)
+      << "find() blocked while a drain was in progress";
+  EXPECT_FALSE(refused.get());
+
+  lease.reset();
+  eraser.join();
+}
+
+TEST_F(TcpSegmentRegistryTest, EraseWithNoLeasesOrUnknownSegmentReturns) {
+  registry_.erase(kSegId); // No leases outstanding: must not wait.
+  EXPECT_FALSE(registry_.find(kSegId));
+  registry_.erase(kSegId); // Already gone.
+  registry_.erase(kSegId + 1000); // Never registered.
+}
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/tests/unit/TcpWireProtocolTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpWireProtocolTest.cpp
@@ -1,0 +1,49 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/transport/tcp/TcpWireProtocol.h"
+
+#include <gtest/gtest.h>
+
+namespace uniflow {
+
+TEST(TcpWireProtocolTest, HeaderRoundTrip) {
+  TcpMsgHeader header{
+      .version = kTcpWireVersion,
+      .op = static_cast<uint8_t>(TcpOp::Write),
+      .flags = 3,
+      .rsvd = 0,
+      .reqId = 11,
+      .segId = 22,
+      .offset = 33,
+      .len = 44,
+  };
+
+  auto parsed = deserializeTcpHeader(serializeTcpHeader(header));
+
+  ASSERT_TRUE(parsed.hasValue()) << parsed.error().message();
+  EXPECT_EQ(parsed.value().version, kTcpWireVersion);
+  EXPECT_EQ(parsed.value().op, static_cast<uint8_t>(TcpOp::Write));
+  EXPECT_EQ(parsed.value().flags, 3);
+  EXPECT_EQ(parsed.value().reqId, 11);
+  EXPECT_EQ(parsed.value().segId, 22);
+  EXPECT_EQ(parsed.value().offset, 33);
+  EXPECT_EQ(parsed.value().len, 44);
+}
+
+TEST(TcpWireProtocolTest, RejectsTruncatedHeader) {
+  std::vector<uint8_t> data(sizeof(TcpMsgHeader) - 1);
+
+  auto parsed = deserializeTcpHeader(data);
+
+  ASSERT_TRUE(parsed.hasError());
+  EXPECT_EQ(parsed.error().code(), ErrCode::InvalidArgument);
+}
+
+TEST(TcpWireProtocolTest, PayloadClassification) {
+  EXPECT_TRUE(tcpOpHasPayload(TcpOp::Write));
+  EXPECT_TRUE(tcpOpHasPayload(TcpOp::ReadReply));
+  EXPECT_FALSE(tcpOpHasPayload(TcpOp::Ack));
+  EXPECT_FALSE(tcpOpHasPayload(TcpOp::Notification));
+}
+
+} // namespace uniflow


### PR DESCRIPTION
Summary:

PG Inference runs on AMD platforms without RDMA backend NICs. This requires a TCP transport. Enable this only on AMD.

Adds a self-contained TCP data transport implementing the full Transport interface (bind/connect/put/get/send/recv/shutdown), independent of NIXL/UCX/folly. A reader/sender thread split keeps the reader always draining the socket, which is what avoids a mutual-READ deadlock between peers. Payloads are chunked under the controller's 64MiB frame cap. VRAM is supported via host-staging (D2H/H2D through CudaApi; hipified for AMD).

Buffer lifetime and completion:
- A READ_REPLY copy into a caller-owned get() destination is atomic with that chunk's completion (TcpOpState::writeAndComplete). Resolving an op's promise is what releases the caller to free or reuse the destination, so the copy starts while the promise is unresolved and keeps it unresolved until it finishes, including when a sibling chunk of the same multi-chunk get() is resolved concurrently.
- TcpSegmentRegistry::find() returns an RAII lease, and a live lease blocks deregistration of that segment. erase() marks the entry dying so no new leases are issued, waits for outstanding leases to drain, then removes it; ~TcpRegistrationHandle therefore returns only once in-flight copies against the segment have finished. find() never waits, so the reader is never parked behind a deregistration. The wait is bounded by the slowest lease holder: the reader queues its Ack and reply frames without blocking, but it holds its lease across the whole host-staging copy, and on the VRAM path that copy ends in a synchronize on the null stream, which waits on every blocking stream on the device. Deregistration can therefore block for the duration of unrelated application GPU work; giving the staging copies a dedicated non-blocking stream removes that, tracked with the null-stream ordering gap below.
- Pending promises are settled after every container mutex is released, in failAllPending() and enqueueSendFrame() alike. TcpOpState::mu is a leaf lock: no path holds a container mutex while touching op state, so a caller woken by a promise can re-enter the transport from its error path without meeting a held lock.
- enqueueSendFrame() gives onSent exactly one owner per path: the out queue takes it when the frame is enqueued, a local takes it when the transport is closing.

Lifecycle:
- bind(), connect() and shutdown() are serialised by a lifecycle mutex, and teardown is one-shot. connect() parks for the whole handshake under that mutex and bounds the wait, so a transport cannot acquire a live connection or worker threads after shutdown() has returned.
- The terminal state transition is a compare-exchange rather than a load followed by a store, so a concurrent bind() failure setting Error is preserved rather than clobbered back to Disconnected.
- handleFrame() contains exceptions rather than propagating them out of the reader thread. Peer-supplied lengths size allocations there and the VRAM staging path throws on an invalid deviceId, so it catches, fails the connection and stops the reader. The frame is not merely dropped, because a throw can land midway through a staging copy or a completion, leaving protocol state that cannot be reasoned about.
- put(), get() and recv() admit their requests under the same mutex the teardown sweep uses, so a request that races failAllPending() is refused rather than orphaned: both the check and the insert sit inside one critical section.

Bounds and backpressure:
- outQueue_ and inflight_ are bounded during normal operation for work this side originates, not only at teardown. outQueue_ holds whole payloads and inflight_ one entry per outstanding chunk, so caller threads (put/get/send) wait for room. That is real backpressure, and what the socket would provide if a queue were not sitting in front of it. An empty queue always admits regardless of frame size, so a payload larger than the cap can still drain.
- The reader thread is deliberately exempt from the byte cap. It produces replies the peer is already blocked on, and a get of N bytes legitimately needs up to N bytes of ReadReply queued, with N bounded only by the segment size, so no fixed cap distinguishes a large honest get from abuse and refusing would fail every unrelated in-flight transfer on the connection. It cannot wait either, since ceasing to drain the socket is the mutual-READ deadlock the reader/sender split exists to avoid. Its drain rate is what bounds it; bounding the reply side by size needs credit-based flow control in the wire protocol, tracked separately.
- enqueueFrame() reports refusal rather than dropping a frame silently, so put()/get() fail the op instead of leaving the caller blocked on a frame that was never queued.
- An inbound ReadRequest is bounded by the wire-frame cap as well as by the segment length, and an oversized request gets a per-request TcpOp::Error like the bad-segment case. Our own get() chunks at kMaxChunkSize, so this is the version-skew case the header version byte exists for. kMaxFrameSize lives in TcpWireProtocol.h with the rest of the wire contract.
- unmatchedSends_ is capped by total buffered bytes. The reader never stops draining the socket, so the socket buffer will not slow a peer down on that path; past the cap the connection is refused, which makes the reader's next recv() fail and its own failAllPending() resolve outstanding ops. A Send completes locally when it is written, so an Error reply would have nothing for the peer to correlate, making refusal the actionable option.
- A sender thread that dies on a send error closes the out queue before unwinding, so the still-running reader cannot append to a queue nothing drains.
- The data connection is closed at most once for the lifetime of the transport. Both the reader, refusing the connection on unmatched-send overflow, and shutdown() on an application thread close it, and neither can hold the lifecycle mutex for it -- shutdown() holds that across reader_.join(). Conn::close() tests the fd, closes it, then clears it without synchronisation, so an atomic exchange decides which caller performs the close.

CUDA streams:
- send()/recv() forward the caller's stream into their VRAM host-staging copies, retained on the pending-recv entry since a matching SEND may arrive long after recv() returned, and reject a VRAM transfer that supplies no stream rather than silently staging on the null stream. put()/get() forward the stream as well.
- The null-stream fallback provides no ordering against PyTorch streams, since c10 creates every stream cudaStreamNonBlocking, and for a one-sided read the peer-side staging copy has no caller stream in scope at all. Closing that needs a registration-time stream or a quiescence contract rather than an initiator-side check. Tracked separately.

Topology and integration:
- Factory topology is a versioned capability blob (TcpTopologyInfo), distinct from the addressing struct returned by bind(). canConnect() rejects a version mismatch with TopologyDisconnect, so a wire-format change is caught at handshake time rather than surfacing later as a dropped frame; createTransport() validates through it.
- MultiTransport integrates TCP only in AMD/HIP builds. NVIDIA/default builds neither compile nor link TCP into MultiTransport; TCP capability and explicit/common TCP selection return NotImplemented, while batches with no common transport remain NotConnected. Standalone TCP targets remain portable on both platforms. Buck selects the branch through ovr_config//gpu:amd and CMake through CMAKE_HIP_COMPILER.
- Transport selection on AMD is: preferredTransport globally; intra-node [intraNodeTransport] NVLink/P2P -> RDMA -> TCP; inter-node [interNodeTransport] RDMA -> TCP. TCP auto-registers when a routable bind address resolves, and enableTcp can force loopback registration. Explicit TCP selection requires enableTcp plus tcpBindHost and fails fast when misconfigured.
- enableTcp, tcpBindHost, preferredTransport, intraNodeTransport, and interNodeTransport are exposed through UniflowAgentConfig and the Python binding.

Reviewed By: rmahidhar

Differential Revision: D114431544


