### PR TITLE
Add per-comm tmpbufEagerAlloc flag to skip eager tmpbuf/NVL staging/bcast allocation (#3405)

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -228,6 +228,13 @@ class CtranComm {
   // Depending on this flag CtranAlgo initialized resources differently
   bool runtimeConn_{}; // if dynamic connection is supported
 
+  // FIXME: runtimeConn_ is NOT the proper flag to gate tmpbuf allocation;
+  // tmpbuf is unrelated to whether a peer connection is created.
+  // tmpbufEagerAlloc_ is the correct control. The eager tmpbuf-slab gate below
+  // still ANDs with !runtimeConn_ to preserve current behavior until MCCL
+  // updates the callsites of this config.
+  bool tmpbufEagerAlloc_{true};
+
   // TODO: change shared_prt to unique_ptr after refactor all ctran code using
   // CtranComm
   std::shared_ptr<ICtran> ctran_;

--- a/comms/ctran/CtranCommSplit.cc
+++ b/comms/ctran/CtranCommSplit.cc
@@ -156,6 +156,7 @@ commResult_t buildSplitShareChild(
   child->logMetaData_.nRanks = parentRanks.size();
   child->opCount_ = parent->opCount_;
   child->runtimeConn_ = parent->runtimeConn_;
+  child->tmpbufEagerAlloc_ = parent->tmpbufEagerAlloc_;
   child->colltraceNew_ = parent->colltraceNew_;
   child->memCache_ = parent->memCache_;
   child->isSplitShare_ = true;

--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -29,7 +29,11 @@ CtranAlgo::CtranAlgo(CtranComm* comm, ICtran* ctran)
   // getDevState() call.
   // TODO: Properly move some heavy allocation to on-demand.
   FB_COMMCHECKTHROW_EX(initKernelResources(), comm_->logMetaData_);
-  if (!comm->runtimeConn_) {
+  // FIXME: runtimeConn_ is not the proper flag to control tmpbuf allocation
+  // (tmpbuf is unrelated to peer connection). Kept ANDed here to preserve
+  // current behavior until the MCCL side updates the callsites of this config
+  // to use tmpbufEagerAlloc_.
+  if (!comm->runtimeConn_ && comm->tmpbufEagerAlloc_) {
     FB_COMMCHECKIGNORE(initTmpBufs());
   }
 
@@ -208,7 +212,13 @@ commResult_t CtranAlgo::initKernelResources() {
       ctranEffectiveP2pNvlSharedDevbufSize(nLocalRanks);
 
   // Initialize inter-process shared device buffer
-  if (!this->sharedRes_) {
+  // FIXME: (b) NVL per-peer staging + (c) bcast buffer have NO on-demand
+  // support yet. When tmpbufEagerAlloc_ is false we skip allocating them (and
+  // nvlTransports_) to save memory; devState_d_ is still allocated so kernels
+  // that don't touch NVL staging work. Collectives that DO need them will fail:
+  // SendRecv (nvlTransports_), AllToAll at ppn>1 (staging maps), ReduceScatter
+  // stage-copy (bcast). Making (b)/(c) on-demand is follow-up.
+  if (comm_->tmpbufEagerAlloc_ && !this->sharedRes_) {
     this->sharedRes_ = new SharedResource(comm_);
   }
 
@@ -314,82 +324,86 @@ commResult_t CtranAlgo::initKernelResources() {
       cudaMemcpyHostToDevice));
 
 #if defined(ENABLE_PRIMS)
-  // Pre-allocate P2pNvlTransportDevice array for all peers in device memory.
-  FB_COMMCHECK(
-      ctran::utils::commCudaMalloc(
-          &nvlTransports_,
-          nLocalRanks,
-          &this->comm_->logMetaData_,
-          "initKernelResources-nvlTransports"));
+  if (this->sharedRes_) {
+    // Pre-allocate P2pNvlTransportDevice array for all peers in device memory.
+    FB_COMMCHECK(
+        ctran::utils::commCudaMalloc(
+            &nvlTransports_,
+            nLocalRanks,
+            &this->comm_->logMetaData_,
+            "initKernelResources-nvlTransports"));
 
-  const size_t nvlPipelineDepth =
-      static_cast<size_t>(NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH);
-  const size_t nvlMaxNumChannels =
-      static_cast<size_t>(std::max(1, CTRAN_ALGO_MAX_THREAD_BLOCKS));
-  if (nvlPipelineDepth == 0) {
-    CERR(
-        commInvalidArgument,
-        "CTRAN-ALGO: invalid NVL P2P config; pipelineDepth=0");
-    return commInvalidArgument;
-  }
-  const size_t nvlChannelAlign = 16ULL * nvlPipelineDepth;
-  const size_t nvlPerChannelBuffer =
-      alignDown(nvlSharedDevbufSize / nvlMaxNumChannels, nvlChannelAlign);
-  if (nvlPerChannelBuffer == 0) {
-    CERR(
-        commInvalidArgument,
-        "CTRAN-ALGO: invalid NVL P2P config; sharedDevbufSize={} maxNumChannels={} pipelineDepth={} cannot produce aligned per-channel buffer",
-        nvlSharedDevbufSize,
-        nvlMaxNumChannels,
-        nvlPipelineDepth);
-    return commInvalidArgument;
-  }
-  comms::prims::P2pNvlTransportOptions options{
-      .dataBufferSize = nvlMaxNumChannels * nvlPerChannelBuffer,
-      .pipelineDepth = nvlPipelineDepth,
-      .per_channel_buffer = nvlPerChannelBuffer,
-      .per_channel_slot = nvlPerChannelBuffer / nvlPipelineDepth,
-      .max_num_channels = static_cast<int>(nvlMaxNumChannels)};
-
-  for (int peer = 0; peer < nLocalRanks; peer++) {
-    // Skip self - slot remains default-constructed (unused)
-    if (peer == localRank) {
-      continue;
+    const size_t nvlPipelineDepth =
+        static_cast<size_t>(NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH);
+    const size_t nvlMaxNumChannels =
+        static_cast<size_t>(std::max(1, CTRAN_ALGO_MAX_THREAD_BLOCKS));
+    if (nvlPipelineDepth == 0) {
+      CERR(
+          commInvalidArgument,
+          "CTRAN-ALGO: invalid NVL P2P config; pipelineDepth=0");
+      return commInvalidArgument;
     }
+    const size_t nvlChannelAlign = 16ULL * nvlPipelineDepth;
+    const size_t nvlPerChannelBuffer =
+        alignDown(nvlSharedDevbufSize / nvlMaxNumChannels, nvlChannelAlign);
+    if (nvlPerChannelBuffer == 0) {
+      CERR(
+          commInvalidArgument,
+          "CTRAN-ALGO: invalid NVL P2P config; sharedDevbufSize={} maxNumChannels={} pipelineDepth={} cannot produce aligned per-channel buffer",
+          nvlSharedDevbufSize,
+          nvlMaxNumChannels,
+          nvlPipelineDepth);
+      return commInvalidArgument;
+    }
+    comms::prims::P2pNvlTransportOptions options{
+        .dataBufferSize = nvlMaxNumChannels * nvlPerChannelBuffer,
+        .pipelineDepth = nvlPipelineDepth,
+        .per_channel_buffer = nvlPerChannelBuffer,
+        .per_channel_slot = nvlPerChannelBuffer / nvlPipelineDepth,
+        .max_num_channels = static_cast<int>(nvlMaxNumChannels)};
 
-    comms::prims::LocalState localState{
-        .dataBuffer = static_cast<char*>(devState_.localStagingBufsMap[peer])};
+    for (int peer = 0; peer < nLocalRanks; peer++) {
+      // Skip self - slot remains default-constructed (unused)
+      if (peer == localRank) {
+        continue;
+      }
 
-    comms::prims::RemoteState remoteState{
-        .dataBuffer = static_cast<char*>(devState_.remoteStagingBufsMap[peer])};
+      comms::prims::LocalState localState{
+          .dataBuffer =
+              static_cast<char*>(devState_.localStagingBufsMap[peer])};
 
-    int localPos = LOCAL_RANK_TO_DEV_REGION_POS(peer, localRank);
-    int remotePos = LOCAL_RANK_TO_DEV_REGION_POS(localRank, peer);
-    NvlChannelState* localChannelState = partitionChannelStates(
-        this->sharedRes_->mappedDevShmPtrs[localRank],
-        nLocalRanks,
-        localPos,
-        nvlSharedDevbufSize);
-    NvlChannelState* remoteChannelState = partitionChannelStates(
-        this->sharedRes_->mappedDevShmPtrs[peer],
-        nLocalRanks,
-        remotePos,
-        nvlSharedDevbufSize);
+      comms::prims::RemoteState remoteState{
+          .dataBuffer =
+              static_cast<char*>(devState_.remoteStagingBufsMap[peer])};
 
-    // Construct the object on CPU and copy to device memory
-    comms::prims::P2pNvlTransportDevice transport(
-        localRank,
-        peer,
-        options,
-        localState,
-        remoteState,
-        localChannelState,
-        remoteChannelState);
-    FB_CUDACHECK(cudaMemcpy(
-        &nvlTransports_[peer],
-        &transport,
-        sizeof(comms::prims::P2pNvlTransportDevice),
-        cudaMemcpyHostToDevice));
+      int localPos = LOCAL_RANK_TO_DEV_REGION_POS(peer, localRank);
+      int remotePos = LOCAL_RANK_TO_DEV_REGION_POS(localRank, peer);
+      NvlChannelState* localChannelState = partitionChannelStates(
+          this->sharedRes_->mappedDevShmPtrs[localRank],
+          nLocalRanks,
+          localPos,
+          nvlSharedDevbufSize);
+      NvlChannelState* remoteChannelState = partitionChannelStates(
+          this->sharedRes_->mappedDevShmPtrs[peer],
+          nLocalRanks,
+          remotePos,
+          nvlSharedDevbufSize);
+
+      // Construct the object on CPU and copy to device memory
+      comms::prims::P2pNvlTransportDevice transport(
+          localRank,
+          peer,
+          options,
+          localState,
+          remoteState,
+          localChannelState,
+          remoteChannelState);
+      FB_CUDACHECK(cudaMemcpy(
+          &nvlTransports_[peer],
+          &transport,
+          sizeof(comms::prims::P2pNvlTransportDevice),
+          cudaMemcpyHostToDevice));
+    }
   }
 #endif // defined(ENABLE_PRIMS)
 

--- a/comms/ctran/tests/CtranDistTestUtils.cc
+++ b/comms/ctran/tests/CtranDistTestUtils.cc
@@ -115,7 +115,8 @@ void CtranDistTestFixture::TearDown() {
 
 std::unique_ptr<CtranComm> CtranDistTestFixture::makeCtranComm(
     bool noLocal,
-    bool ibLazyConnect) {
+    bool ibLazyConnect,
+    bool tmpbufEagerAlloc) {
   const std::string uuid{"0"};
   uint64_t commHash =
       ctran::utils::getHash(uuid.data(), static_cast<int>(uuid.size()));
@@ -167,6 +168,9 @@ std::unique_ptr<CtranComm> CtranDistTestFixture::makeCtranComm(
   // Preserve the compatibility setting through the standalone Ctran path.
   // Peer materialization remains on demand for either value.
   comm->config_.pipesConfig.ibLazyConnect = ibLazyConnect;
+  // Consumed during ctranInit (inside CtranAlgo's ctor), so must be set on the
+  // comm before ctranInit runs.
+  comm->tmpbufEagerAlloc_ = tmpbufEagerAlloc;
 
   COMMCHECK_TEST(ctranInit(comm.get()));
   CHECK(ctranInitialized(comm.get())) << "Ctran not initialized";

--- a/comms/ctran/tests/CtranDistTestUtils.h
+++ b/comms/ctran/tests/CtranDistTestUtils.h
@@ -72,7 +72,8 @@ class CtranDistTestFixture : public CtranTestFixtureBase,
   // on demand regardless of its value.
   std::unique_ptr<CtranComm> makeCtranComm(
       bool noLocal = false,
-      bool ibLazyConnect = true);
+      bool ibLazyConnect = true,
+      bool tmpbufEagerAlloc = true);
 
   // Asserts the comm's runtime topology matches the NCCL_COMM_STATE_DEBUG_TOPO
   // env override (nolocal/vnode). Early-returns when the env is unset, so

--- a/comms/ctran/tests/CtranTmpbufEagerAllocDistTest.cc
+++ b/comms/ctran/tests/CtranTmpbufEagerAllocDistTest.cc
@@ -1,0 +1,414 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <vector>
+
+#include <folly/init/Init.h>
+#include <glog/logging.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "CtranUtUtils.h"
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/memory/memCacheAllocator.h"
+#include "comms/ctran/regcache/RegCache.h"
+#include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/tests/CtranTestUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+// Verifies that ctran collectives still initialize and run correctly when
+// CtranComm::tmpbufEagerAlloc_ is FALSE. With the flag false, the eager tmpbuf
+// slab is skipped during ctranInit: devState_d_ is still allocated
+// (getDevState() stays non-null), nvlTransports_ is skipped
+// (getNvlTransportsBase() returns null), and sharedRes_ stays null. At ppn1
+// (nLocalRanks==1, via nolocal) the covered collectives never touch sharedRes_,
+// so they must still succeed. At ppn>1 (plain 1x8 and vnode) the NVL-staging
+// collectives (AllGatherP/AllToAll/AllToAllP) are skipped because their sync/
+// staging maps are null when sharedRes_ is absent; only the init/memory
+// contract runs there. Each test logs ctran pool usage with the [CTRAN_MEM]
+// tag.
+class CtranTmpbufEagerAllocDistTest : public ctran::CtranDistTestFixture,
+                                      public CtranBaseTest {
+ public:
+  CtranTmpbufEagerAllocDistTest() = default;
+
+  void SetUp() override {
+    // Always run ctran alltoall regardless of message size.
+    setenv("NCCL_CTRAN_ALLTOALL_THRESHOLD", "0", 0);
+    ctran::CtranDistTestFixture::SetUp();
+  }
+
+  void TearDown() override {
+    ctran::CtranDistTestFixture::TearDown();
+  }
+
+  // Create a comm with eager tmpbuf allocation disabled. Topology (nLocalRanks)
+  // is driven by the per-config NCCL_COMM_STATE_DEBUG_TOPO env, not forced
+  // here.
+  std::unique_ptr<CtranComm> makeEagerAllocFalseComm() {
+    return makeCtranComm(
+        /*noLocal=*/false, /*ibLazyConnect=*/false, /*tmpbufEagerAlloc=*/false);
+  }
+
+  // Current ctran memory pool in-use bytes; null-safe.
+  static size_t ctranUsedMemBytes() {
+    const auto alloc = ncclx::memory::memCacheAllocator::getInstance();
+    return alloc ? alloc->getUsedMem() : 0;
+  }
+
+  // Free device memory (bytes) from cudaMemGetInfo; used-memory deltas are
+  // computed as (baseFree - currentFree). Captures allocations the memCache
+  // pool metric misses (e.g. the NVL SharedResource).
+  static size_t cudaFreeBytes() {
+    size_t freeBytes = 0;
+    size_t totalBytes = 0;
+    CUDACHECK_TEST(cudaMemGetInfo(&freeBytes, &totalBytes));
+    return freeBytes;
+  }
+
+  void* createDataBuf(size_t nbytes, bool doRegister) {
+    void* buf = nullptr;
+    CUDACHECK_TEST(cudaMalloc(&buf, nbytes));
+    if (buf && doRegister) {
+      COMMCHECK_TEST(ctran::globalRegisterWithPtr(buf, nbytes));
+    }
+    return buf;
+  }
+
+  void releaseDataBuf(void* buf, size_t nbytes, bool doDeregister) {
+    if (doDeregister) {
+      COMMCHECK_TEST(ctran::globalDeregisterWithPtr(buf, nbytes));
+    }
+    CUDACHECK_TEST(cudaFree(buf));
+  }
+
+  // Persistent-collective recv buffers must be CCA-cached (via the regcache
+  // globalRegister path) so the eager scoped registration can acquire them.
+  void* createDataBufCached(size_t nbytes) {
+    void* buf = nullptr;
+    CUDACHECK_TEST(cudaMalloc(&buf, nbytes));
+    if (buf) {
+      COMMCHECK_TEST(
+          ctran::RegCache::getInstance()->globalRegister(buf, nbytes));
+    }
+    return buf;
+  }
+
+  void releaseDataBufCached(void* buf, size_t nbytes) {
+    COMMCHECK_TEST(
+        ctran::RegCache::getInstance()->globalDeregister(buf, nbytes));
+    CUDACHECK_TEST(cudaFree(buf));
+  }
+
+  void runAllGather(CtranComm* comm, enum NCCL_ALLGATHER_ALGO algo) {
+    const size_t numElements = 8192;
+    const size_t sendBytes = numElements * sizeof(int32_t);
+    const size_t recvBytes = sendBytes * numRanks;
+
+    void* sendbuf = createDataBuf(sendBytes, /*doRegister=*/true);
+    void* recvbuf = createDataBuf(recvBytes, /*doRegister=*/true);
+
+    std::vector<int32_t> input_h(numElements, globalRank);
+    CUDACHECK_TEST(
+        cudaMemcpy(sendbuf, input_h.data(), sendBytes, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemset(recvbuf, 0, recvBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    const auto res = ctranAllGather(
+        sendbuf, recvbuf, numElements, commInt32, comm, testStream, algo);
+    ASSERT_EQ(res, commSuccess);
+    CUDACHECK_TEST(cudaStreamSynchronize(testStream));
+
+    std::vector<int32_t> output_h(numElements * numRanks);
+    CUDACHECK_TEST(cudaMemcpy(
+        output_h.data(), recvbuf, recvBytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < numElements * numRanks; i++) {
+      const int expected = i / numElements;
+      EXPECT_EQ(output_h[i], expected)
+          << "rank " << globalRank << " mismatch at index " << i;
+    }
+
+    verifyGpeLeak(comm->ctran_.get());
+
+    releaseDataBuf(sendbuf, sendBytes, /*doDeregister=*/true);
+    releaseDataBuf(recvbuf, recvBytes, /*doDeregister=*/true);
+  }
+
+  void runAllGatherP(CtranComm* comm) {
+    const size_t count = 8192;
+    const size_t maxRecvCount = count * numRanks;
+    // commInt8 keeps sendBytes/recvBytes == count/maxRecvCount (no conversion).
+    const size_t sendBytes = count;
+    const size_t recvBytes = maxRecvCount;
+
+    char* sendbuf = reinterpret_cast<char*>(createDataBufCached(sendBytes));
+    char* recvbuf = reinterpret_cast<char*>(createDataBufCached(recvBytes));
+
+    CUDACHECK_TEST(
+        cudaMemset(sendbuf, static_cast<char>(globalRank), sendBytes));
+    CUDACHECK_TEST(cudaMemset(recvbuf, 0, recvBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    meta::comms::Hints hints;
+    CtranPersistentRequest* request = nullptr;
+    COMMCHECK_TEST(
+        ctran::allGatherPInit(
+            recvbuf, maxRecvCount, hints, commInt8, comm, testStream, request));
+    ASSERT_EQ(cudaStreamSynchronize(testStream), cudaSuccess);
+
+    ASSERT_EQ(
+        ctran::allGatherPExec(sendbuf, count, commInt8, request), commSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(testStream), cudaSuccess);
+
+    std::vector<char> observed(recvBytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        observed.data(), recvbuf, recvBytes, cudaMemcpyDeviceToHost));
+    for (int i = 0; i < numRanks; i++) {
+      const std::vector<char> chunk(
+          observed.begin() + i * count, observed.begin() + (i + 1) * count);
+      EXPECT_THAT(chunk, testing::Each(static_cast<char>(i)))
+          << "rank " << globalRank << " chunk from peer " << i;
+    }
+
+    verifyGpeLeak(comm->ctran_.get());
+
+    ASSERT_EQ(ctran::allGatherPDestroy(request), commSuccess);
+    delete request;
+
+    releaseDataBufCached(sendbuf, sendBytes);
+    releaseDataBufCached(recvbuf, recvBytes);
+  }
+
+  void runAllToAll(CtranComm* comm) {
+    const size_t count = 8192;
+    const size_t bufCount = count * numRanks;
+    const size_t bufNbytes = bufCount * sizeof(int32_t);
+    // Fixed (rank-independent) base value so every rank derives the same
+    // expected chunk values without an out-of-band exchange.
+    const int expectedVal = 0;
+
+    int32_t* sendBuf = reinterpret_cast<int32_t*>(
+        createDataBuf(bufNbytes, /*doRegister=*/true));
+    int32_t* recvBuf = reinterpret_cast<int32_t*>(
+        createDataBuf(bufNbytes, /*doRegister=*/true));
+
+    for (int i = 0; i < numRanks; i++) {
+      assignChunkValue<int32_t>(
+          sendBuf + i * count, count, expectedVal + globalRank * 10 + i + 1);
+    }
+
+    const auto res = ctranAllToAll(
+        sendBuf,
+        recvBuf,
+        count,
+        commInt32,
+        comm,
+        testStream,
+        NCCL_ALLTOALL_ALGO::ctran);
+    ASSERT_EQ(res, commSuccess);
+    CUDACHECK_TEST(cudaStreamSynchronize(testStream));
+
+    for (int i = 0; i < numRanks; i++) {
+      const int errs = checkChunkValue<int32_t>(
+          recvBuf + i * count, count, expectedVal + i * 10 + globalRank + 1);
+      EXPECT_EQ(errs, 0) << "rank " << globalRank << " chunk from peer " << i;
+    }
+
+    verifyGpeLeak(comm->ctran_.get());
+
+    releaseDataBuf(sendBuf, bufNbytes, /*doDeregister=*/true);
+    releaseDataBuf(recvBuf, bufNbytes, /*doDeregister=*/true);
+  }
+
+  void runAllToAllP(CtranComm* comm) {
+    const size_t maxRecvCount = 1024 * 1024;
+    const size_t count = 8192;
+    const size_t bufNbytes = maxRecvCount * sizeof(int);
+    const int expectedVal = 0;
+
+    int* sendBuf =
+        reinterpret_cast<int*>(createDataBuf(bufNbytes, /*doRegister=*/true));
+    void* recvBuf = createDataBufCached(bufNbytes);
+
+    meta::comms::Hints hints;
+    CtranPersistentRequest* request = nullptr;
+    COMMCHECK_TEST(
+        ctran::AllToAllPInit(
+            recvBuf, maxRecvCount, hints, commInt, comm, testStream, request));
+
+    for (int i = 0; i < numRanks; i++) {
+      assignChunkValue<int>(
+          sendBuf + i * count, count, expectedVal + globalRank * 100 + i + 1);
+    }
+
+    ASSERT_EQ(ctran::AllToAllPExec(sendBuf, count, request), commSuccess);
+    CUDACHECK_TEST(cudaStreamSynchronize(testStream));
+
+    int* recvbuff = reinterpret_cast<int*>(recvBuf);
+    for (int i = 0; i < numRanks; i++) {
+      const int errs = checkChunkValue<int>(
+          recvbuff + i * count, count, expectedVal + i * 100 + globalRank + 1);
+      EXPECT_EQ(errs, 0) << "rank " << globalRank << " chunk from peer " << i;
+    }
+
+    ASSERT_EQ(ctran::AllToAllPDestroy(request), commSuccess);
+    delete request;
+
+    releaseDataBuf(sendBuf, bufNbytes, /*doDeregister=*/true);
+    releaseDataBufCached(recvBuf, bufNbytes);
+  }
+
+ protected:
+  cudaStream_t testStream{0};
+};
+
+TEST_F(CtranTmpbufEagerAllocDistTest, InitContractWithEagerAllocFalse) {
+  const size_t base = ctranUsedMemBytes();
+  const size_t baseFree = cudaFreeBytes();
+  auto comm = makeEagerAllocFalseComm();
+  const size_t initUsed = ctranUsedMemBytes() - base;
+  const size_t devInitUsed = baseFree - cudaFreeBytes();
+  LOG(INFO) << "[CTRAN_MEM] test=InitContract nLocalRanks="
+            << comm->statex_->nLocalRanks() << " rank=" << globalRank
+            << " initUsedMiB=" << (initUsed / 1024.0 / 1024.0)
+            << " devInitUsedMiB=" << (devInitUsed / 1024.0 / 1024.0);
+  auto* algo = comm->ctran_->algo.get();
+  // devState_d_ is always allocated; the eager slab / nvlTransports_ are not.
+  EXPECT_NE(algo->getDevState(), nullptr);
+  EXPECT_EQ(algo->getNvlTransportsBase(), nullptr);
+}
+
+TEST_F(CtranTmpbufEagerAllocDistTest, AllGatherRing) {
+  const size_t base = ctranUsedMemBytes();
+  const size_t baseFree = cudaFreeBytes();
+  auto comm = makeEagerAllocFalseComm();
+  const size_t initUsed = ctranUsedMemBytes() - base;
+  const size_t devInitUsed = baseFree - cudaFreeBytes();
+  LOG(INFO) << "[CTRAN_MEM] test=AllGatherRing nLocalRanks="
+            << comm->statex_->nLocalRanks() << " rank=" << globalRank
+            << " initUsedMiB=" << (initUsed / 1024.0 / 1024.0)
+            << " devInitUsedMiB=" << (devInitUsed / 1024.0 / 1024.0);
+  const auto algo = NCCL_ALLGATHER_ALGO::ctring;
+  if (!ctranAllGatherSupport(comm.get(), algo)) {
+    GTEST_SKIP() << "ctring AllGather not supported, skip test";
+  }
+  runAllGather(comm.get(), algo);
+  const size_t postUsed = ctranUsedMemBytes() - base;
+  const size_t devPostUsed = baseFree - cudaFreeBytes();
+  LOG(INFO) << "[CTRAN_MEM] test=AllGatherRing nLocalRanks="
+            << comm->statex_->nLocalRanks() << " rank=" << globalRank
+            << " postUsedMiB=" << (postUsed / 1024.0 / 1024.0)
+            << " devPostUsedMiB=" << (devPostUsed / 1024.0 / 1024.0);
+}
+
+TEST_F(CtranTmpbufEagerAllocDistTest, AllGatherCtsrd) {
+  const size_t base = ctranUsedMemBytes();
+  const size_t baseFree = cudaFreeBytes();
+  auto comm = makeEagerAllocFalseComm();
+  const size_t initUsed = ctranUsedMemBytes() - base;
+  const size_t devInitUsed = baseFree - cudaFreeBytes();
+  LOG(INFO) << "[CTRAN_MEM] test=AllGatherCtsrd nLocalRanks="
+            << comm->statex_->nLocalRanks() << " rank=" << globalRank
+            << " initUsedMiB=" << (initUsed / 1024.0 / 1024.0)
+            << " devInitUsedMiB=" << (devInitUsed / 1024.0 / 1024.0);
+  const auto algo = NCCL_ALLGATHER_ALGO::ctsrd;
+  if (!ctranAllGatherSupport(comm.get(), algo)) {
+    GTEST_SKIP() << "ctsrd AllGather requires nLocalRanks=1, skip test";
+  }
+  runAllGather(comm.get(), algo);
+  const size_t postUsed = ctranUsedMemBytes() - base;
+  const size_t devPostUsed = baseFree - cudaFreeBytes();
+  LOG(INFO) << "[CTRAN_MEM] test=AllGatherCtsrd nLocalRanks="
+            << comm->statex_->nLocalRanks() << " rank=" << globalRank
+            << " postUsedMiB=" << (postUsed / 1024.0 / 1024.0)
+            << " devPostUsedMiB=" << (devPostUsed / 1024.0 / 1024.0);
+}
+
+TEST_F(CtranTmpbufEagerAllocDistTest, AllGatherP) {
+  const size_t base = ctranUsedMemBytes();
+  const size_t baseFree = cudaFreeBytes();
+  auto comm = makeEagerAllocFalseComm();
+  const size_t initUsed = ctranUsedMemBytes() - base;
+  const size_t devInitUsed = baseFree - cudaFreeBytes();
+  LOG(INFO) << "[CTRAN_MEM] test=AllGatherP nLocalRanks="
+            << comm->statex_->nLocalRanks() << " rank=" << globalRank
+            << " initUsedMiB=" << (initUsed / 1024.0 / 1024.0)
+            << " devInitUsedMiB=" << (devInitUsed / 1024.0 / 1024.0);
+  if (comm->statex_->nLocalRanks() > 1) {
+    GTEST_SKIP() << "flag=false: NVL sync/staging maps are null at ppn>1";
+  }
+  if (!ctran::allGatherPSupport(comm.get())) {
+    GTEST_SKIP() << "AllGatherP not supported, skip test";
+  }
+  if (comm->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB backend found, skip test";
+  }
+  runAllGatherP(comm.get());
+  const size_t postUsed = ctranUsedMemBytes() - base;
+  const size_t devPostUsed = baseFree - cudaFreeBytes();
+  LOG(INFO) << "[CTRAN_MEM] test=AllGatherP nLocalRanks="
+            << comm->statex_->nLocalRanks() << " rank=" << globalRank
+            << " postUsedMiB=" << (postUsed / 1024.0 / 1024.0)
+            << " devPostUsedMiB=" << (devPostUsed / 1024.0 / 1024.0);
+}
+
+TEST_F(CtranTmpbufEagerAllocDistTest, AllToAll) {
+  const size_t base = ctranUsedMemBytes();
+  const size_t baseFree = cudaFreeBytes();
+  auto comm = makeEagerAllocFalseComm();
+  const size_t initUsed = ctranUsedMemBytes() - base;
+  const size_t devInitUsed = baseFree - cudaFreeBytes();
+  LOG(INFO) << "[CTRAN_MEM] test=AllToAll nLocalRanks="
+            << comm->statex_->nLocalRanks() << " rank=" << globalRank
+            << " initUsedMiB=" << (initUsed / 1024.0 / 1024.0)
+            << " devInitUsedMiB=" << (devInitUsed / 1024.0 / 1024.0);
+  if (comm->statex_->nLocalRanks() > 1) {
+    GTEST_SKIP() << "flag=false: NVL sync/staging maps are null at ppn>1";
+  }
+  if (!ctranAllToAllSupport(
+          8192, commInt32, comm.get(), NCCL_ALLTOALL_ALGO::ctran)) {
+    GTEST_SKIP() << "AllToAll not supported, skip test";
+  }
+  runAllToAll(comm.get());
+  const size_t postUsed = ctranUsedMemBytes() - base;
+  const size_t devPostUsed = baseFree - cudaFreeBytes();
+  LOG(INFO) << "[CTRAN_MEM] test=AllToAll nLocalRanks="
+            << comm->statex_->nLocalRanks() << " rank=" << globalRank
+            << " postUsedMiB=" << (postUsed / 1024.0 / 1024.0)
+            << " devPostUsedMiB=" << (devPostUsed / 1024.0 / 1024.0);
+}
+
+TEST_F(CtranTmpbufEagerAllocDistTest, AllToAllP) {
+  const size_t base = ctranUsedMemBytes();
+  const size_t baseFree = cudaFreeBytes();
+  auto comm = makeEagerAllocFalseComm();
+  const size_t initUsed = ctranUsedMemBytes() - base;
+  const size_t devInitUsed = baseFree - cudaFreeBytes();
+  LOG(INFO) << "[CTRAN_MEM] test=AllToAllP nLocalRanks="
+            << comm->statex_->nLocalRanks() << " rank=" << globalRank
+            << " initUsedMiB=" << (initUsed / 1024.0 / 1024.0)
+            << " devInitUsedMiB=" << (devInitUsed / 1024.0 / 1024.0);
+  if (comm->statex_->nLocalRanks() > 1) {
+    GTEST_SKIP() << "flag=false: NVL sync/staging maps are null at ppn>1";
+  }
+  if (!ctran::AllToAllPSupport(comm.get())) {
+    GTEST_SKIP() << "AllToAllP not supported, skip test";
+  }
+  runAllToAllP(comm.get());
+  const size_t postUsed = ctranUsedMemBytes() - base;
+  const size_t devPostUsed = baseFree - cudaFreeBytes();
+  LOG(INFO) << "[CTRAN_MEM] test=AllToAllP nLocalRanks="
+            << comm->statex_->nLocalRanks() << " rank=" << globalRank
+            << " postUsedMiB=" << (postUsed / 1024.0 / 1024.0)
+            << " devPostUsedMiB=" << (devPostUsed / 1024.0 / 1024.0);
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new ctran::CtranDistEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -200,6 +200,8 @@ Config::Config(const ncclConfig_t* config) {
   deviceIbLazyConnect =
       parseHintBool("deviceIbLazyConnect", NCCL_CTRAN_IBGDA_LAZY_CONNECT);
 
+  tmpbufEagerAlloc = parseHintBool("ctranTmpbufEagerAlloc", true);
+
   // vCliqueSize: hint only (no flat ncclConfig_t field)
   {
     auto val = getHintStr("vCliqueSize");

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -73,6 +73,9 @@ class Config {
   // Deprecated compatibility hint. Peer IB state is always initialized on
   // demand; false no longer restores eager initialization.
   bool deviceIbLazyConnect = true;
+  // Eagerly allocate ctran tmpbuf/NVL staging/bcast buffers at init.
+  // When false, ctran skips those allocations to save memory (per-comm only).
+  bool tmpbufEagerAlloc = true;
   // Update mutable hint fields (algo config only).  Rejects immutable keys.
   ncclResult_t update(const ncclx::Hints* hints);
 };
@@ -100,6 +103,7 @@ inline const std::vector<std::string>& knownHintKeys() {
       "ibSplitDataOnQps",
       "ibQpsPerConnection",
       "deviceIbLazyConnect",
+      "ctranTmpbufEagerAlloc",
       "win_register_ipc_only",
       "win_register_enable_signal",
       "win_register_symmetric",

--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -66,6 +66,11 @@ commResult_t setCtranCommBase(ncclComm* ncclCommVal) {
   ncclCommVal->ctranComm_->opCount_ = &ncclCommVal->opCount;
   ncclCommVal->ctranComm_->logMetaData_ = ncclCommVal->logMetaData;
   ncclCommVal->ctranComm_->runtimeConn_ = ncclCommVal->runtimeConn;
+  if (ncclCommVal->config.ncclxConfig != nullptr) {
+    const auto* ncclxCfg =
+        static_cast<ncclx::Config*>(ncclCommVal->config.ncclxConfig);
+    ncclCommVal->ctranComm_->tmpbufEagerAlloc_ = ncclxCfg->tmpbufEagerAlloc;
+  }
 
   return commSuccess;
 }


### PR DESCRIPTION
Summary:

Adds a per-comm boolean `CtranComm::tmpbufEagerAlloc_` (default true, preserving current behavior) so a communicator can opt out of eager device-buffer allocation to save memory:
- (a) tmpbuf slab: gates the constructor's eager `initTmpBufs()` call; when false, the slab (~160 MiB on an 8-GPU node) is left to the existing lazy on-demand path that the algorithms already use.
- (b) NVL `SharedResource` per-peer staging:  gates the `SharedResource` and `nvlTransports_` allocation inside `initKernelResources()`
- (c) bcast buffer (~88 MiB ppn8 / ~32 MiB ppn1): same as (b)
- `devState_d_` is still always allocated so kernels that do not touch NVL staging keep working.
- **FIXME (in code)**: (b)/(c) have no on-demand support yet, so with the flag false the collectives that need them (SendRecv, AllToAll at ppn>1, ReduceScatter stage-copy) will fail — making them on-demand is follow-up.
- **FIXME on the (a) gate**: `runtimeConn_` is not the proper flag to control tmpbuf allocation (tmpbuf is unrelated to whether a peer connection is created); it is kept ANDed with the new flag only to preserve current behavior until MCCL updates the callsites of this config.
- Wiring is per-comm only (no CVAR): ncclx hint `ctranTmpbufEagerAlloc` (default true, via `ncclx::Config`); mccl `McclCommCreateOpts::ctranTmpbufEagerAlloc` (default true); propagated to child comms on split.

Differential Revision: D114442203


