### PR TITLE
in-kernel colltrace emit for baseline NCCL collectives (#3406)

### DIFF
--- a/comms/ncclx/meta/baseline_modification_docs/inkernel_colltrace_baseline.md
+++ b/comms/ncclx/meta/baseline_modification_docs/inkernel_colltrace_baseline.md
@@ -1,0 +1,155 @@
+# In-kernel colltrace emit for baseline collectives: Baseline Modifications
+
+## Background
+
+The colltrace graph watchdog (and graph-mode colltrace tracing generally) times
+graph-captured collectives by reading per-collective `kStart`/`kEnd` timestamps
+that the collective **kernel** publishes into a shared HRDW ring at replay. Only
+ctran GPE kernels emitted these timestamps (via
+`ctran::device::ColltraceEventScope`); baseline NCCL collectives (the `orig`
+algorithm path) did not, so a graph-captured baseline collective registered a
+`collId` on the host (`recordGraphCollectiveImpl`) but the ring stayed empty and
+the watchdog had nothing to observe.
+
+The host-side colltrace machinery is already backend-agnostic:
+
+- Registration + `collId` assignment for a graph-captured collective happens in
+  `collTraceBaselineGetHandle` → `getHandleFromNcclKernelPlan` →
+  `CollTrace::recordGraphCollectiveImpl` — shared with ctran.
+- `CollTrace::pollGraphEvents` reads `kStart`/`kEnd` from the ring keyed on
+  `collId`, agnostic to which kernel wrote them.
+- `ICollTraceHandle::getColltraceDeviceHandle()` already returns the armed,
+  ring-backed `ColltraceDeviceHandle` (ring + `collId`) on the graph path and an
+  unarmed `{}` otherwise.
+
+So the only missing piece for baseline was the **device-side write** plus arming
+the per-launch handle onto the kernel args. The device writer itself is shared:
+the generic `meta::comms::colltrace::ColltraceEventScope` lives in
+`comms/utils/colltrace/ColltraceEventScope.cuh` (ctran's
+`ctran::device::ColltraceEventScope` is a thin subclass adding a `KernelFlagDev`
+overload).
+
+## Versions Affected
+
+v2.29, v2.30
+
+## Baseline Files Modified
+
+Three baseline files per version, each a tagged, minimal hook. All logic lives in
+the Meta helper `ncclx::colltrace::armNcclInKernelColltrace`
+(`meta/colltrace/CollTraceWrapper.{h,cc}`), which is version-agnostic.
+
+1. `src/include/device.h` — one field on the per-launch arg struct plus its
+   include:
+   ```cpp
+   // [META] In-kernel colltrace gate, defined here and used by every
+   // colltraceHdr reference so the struct has one layout across all TUs.
+   #if !defined(NCCLX_NO_INKERNEL_COLLTRACE) && \
+       !(CUDART_VERSION >= 13000 && CUDART_VERSION < 13030)
+   #define NCCLX_INKERNEL_COLLTRACE 1
+   #endif
+
+   #ifdef NCCLX_INKERNEL_COLLTRACE
+   #include "comms/utils/colltrace/ColltraceDeviceHandle.h"
+   #endif
+   ...
+   struct alignas(16) ncclDevKernelArgs {
+     ...
+     void* workBuf;
+     // [META] ... armed host-side in armNcclInKernelColltrace() ...
+   #ifdef NCCLX_INKERNEL_COLLTRACE
+     meta::comms::colltrace::ColltraceDeviceHandle colltraceHdr;
+   #endif
+     // struct ncclDevWorkBatch batches[];  // trailing inline region
+   };
+   ```
+   The handle is the **last fixed field**, so the trailing inline work-batch /
+   work region (located at `kernelArgs+1` and via `batch.offsetBase`, both
+   `sizeof(ncclDevKernelArgs)`-relative on host and device) stays consistent.
+   `ColltraceDeviceHandle` is a trivially-copyable aggregate, so the word-by-word
+   arg→shmem copy in `ncclKernelMain` carries it correctly.
+
+2. `src/device/common.h` — one RAII scope in the single generic kernel
+   `ncclKernelMain`, right after the prologue publishes `ncclShmem`:
+   ```cpp
+   // [META] in-kernel colltrace ...
+   #ifdef NCCLX_INKERNEL_COLLTRACE
+   meta::comms::colltrace::ColltraceDeviceEventScope colltraceScope(
+       ncclShmem.args.colltraceHdr);
+   #endif
+   ```
+   ctor emits `kStart`; dtor emits `kEnd` at kernel exit. One scope covers
+   **every** baseline collective, since they all funnel through `ncclKernelMain`.
+   An unarmed handle makes it a no-op (single-writer election is block0/thread0).
+
+3. `src/enqueue.cc` — one tagged call in `ncclLaunchKernel`, next to the existing
+   `collTraceBaselineGetHandle` injection:
+   ```cpp
+   ncclx::colltrace::armNcclInKernelColltrace(
+       plan, colltraceHandle.get(), comm->compCap);
+   ```
+   This writes the ring/`collId` into `plan->kernelArgs->colltraceHdr` just
+   before `cuLaunchKernelEx`, so the `collId` assigned at capture is baked into
+   the graph node and re-emitted on every replay. The helper is a no-op unless a
+   graph is being captured (`getColltraceDeviceHandle().valid()`) on an sm_90+
+   device (the ring's 128b atomic requirement); symmetric-memory kernels use a
+   different arg layout and are skipped.
+
+## Platform gating: CUDA only
+
+`device.h` defines a single gate macro, `NCCLX_INKERNEL_COLLTRACE`, and all
+three touch points test it with `#ifdef`. It is left undefined when
+`NCCLX_NO_INKERNEL_COLLTRACE` is set, which `device_object`'s
+`propagated_pp_flags` does on `ovr_config//gpu:amd`
+(`comms/ncclx/nccl_build_config.bzl`). The same `select` also drops
+`colltrace_device_handle` from that target's `exported_deps`, so on AMD the
+header is neither included nor on the include path.
+
+It is also left undefined on CUDA 13.0-13.2, where an nvcc
+`[[no_unique_address]]` device-layout bug (fixed in 13.3) misaligns the
+`args->__shared__` copy of `ncclDevKernelArgs`; any kernel launch carrying those
+args then faults with `cudaErrorMisalignedAddress` (seen as "Failed to allocate
+barrier buffer: misaligned address" in the torchcomms integration tests). The
+guard lives in the same commit that adds the field, so no point in the stack
+builds a `colltraceHdr` that the toolchain will mislay.
+
+Two reasons for the AMD case:
+
+- **It cannot work on AMD.** The ring publishes a slot with `atom.exch.b128`
+  inline PTX, which has no HIP equivalent —
+  `HrdwRingBufferWriter::write` compiles to a trap under `__HIPCC__`, and
+  `comms/utils/hrdw_ring_buffer/BUCK` already states AMD "will fail at
+  compile/link time when actually exercised".
+- **It breaks the AMD build if left in.** `colltrace_device_handle` reaches
+  `//comms/utils:hrdw_ring_buffer`, a `gpu_cpp_library`, so on AMD hipify
+  rewrites that target's `<cuda_runtime.h>` into `<hip/hip_runtime.h>`. ncclx is
+  never hipified — under `mode/*-amd-gpu` it still compiles with `nvcc` — so its
+  `nccl.h` keeps the real CUDA runtime. Any consumer including `collectives.h`
+  then gets CUDA's and HIP's vector types in one TU and fails with ~20 `typedef
+  redefinition` errors (first seen in `comms/utils/tests:comm_specs_test`).
+  Before this change ncclx's public headers never reached a hipified header: the
+  handle was only ever a `shared_ptr<ICollTraceHandle>` used inside `.cc` files,
+  and a pointer to an abstract type needs no layout. Embedding the handle
+  by value is what put it on the exported header path.
+
+The flag is propagated from the same target and the same `select` as the dep so
+no consumer can disagree about whether `colltraceHdr` exists — a mismatch would
+silently change `ncclDevKernelArgs`'s layout between TUs.
+
+## Why in baseline
+
+The three touch points are structurally forced:
+
+- The `collId` is per-collective and must be baked into each graph node's arg
+  bytes at capture, so it must live in the per-launch `ncclDevKernelArgs` (a
+  comm-level slot would be overwritten by the next captured collective) — hence
+  the `device.h` field.
+- The emit must run inside the collective kernel, and `ncclKernelMain` is the one
+  generic entry every baseline collective shares — hence the `common.h` line.
+- The arm must happen at the launch site where `plan->kernelArgs` is baked into
+  the graph node — hence the `enqueue.cc` call, placed beside the existing
+  colltrace injection.
+
+All heavy logic is in the Meta helper; the baseline edits are a field, a scope,
+and a call, each `[META]`-tagged. No `CollTrace.cc` / `CollTraceWrapper` handle
+or poll changes were needed — baseline reuses the ctran path end to end.

--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
@@ -402,6 +402,16 @@ getMetadataFromNcclKernelPlan(ncclKernelPlan& plan, cudaStream_t stream) {
       planInfo.p2pType == KernelPlanType::none) {
     XLOG_FIRST_N(
         ERR, 3, "CollTrace: No coll or p2p task in the NCCL Kenrel Plan!");
+    if (isCapturingStream(stream)) {
+      // Deadlock safety: a graph-captured plan with no coll/p2p task has no
+      // kernel that will publish a start/end timestamp into the graph ring, so
+      // registering a graph colltrace record for it would never complete and
+      // would hang the poll thread on drain. Skip it --
+      // getHandleFromNcclKernelPlan falls back to a DummyCollTraceHandle.
+      // (Eager empty-task tracing, which completes normally on the stream, is
+      // unaffected.)
+      return nullptr;
+    }
     return getEmptyKernelTaskMetadata(plan, planInfo, stream);
   }
 
@@ -445,7 +455,7 @@ getHandleFromNcclKernelPlan(ncclKernelPlan& plan, cudaStream_t stream) {
 
   if (res.hasError()) {
     XLOG_FIRST_N(
-        ERR, 5, "Failed to get colltrace handle due to: ", res.error().message);
+        ERR, 1, "Failed to get colltrace handle due to: ", res.error().message);
     return std::make_unique<meta::comms::colltrace::DummyCollTraceHandle>();
   }
   return res.value();
@@ -551,10 +561,47 @@ std::optional<AlgoInfo> parseAlgoInfoFromNcclKernelPlan(ncclKernelPlan& plan) {
   };
 }
 
+void armNcclInKernelColltrace(
+    [[maybe_unused]] ncclKernelPlan& plan,
+    [[maybe_unused]] const std::shared_ptr<
+        meta::comms::colltrace::ICollTraceHandle>& handle,
+    [[maybe_unused]] int compCap) {
+  // `colltraceHdr` only exists when the in-kernel colltrace gate in device.h
+  // is on; arming is a no-op otherwise.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+  // Symmetric-memory kernels use a different arg layout; skip them.
+  if (plan.isSymColl || plan.kernelArgs == nullptr || handle == nullptr) {
+    return;
+  }
+  // Default to unarmed so the in-kernel scope is a no-op off the graph path.
+  plan.kernelArgs->colltraceHdr = {};
+  // The ring's 128b atomic write requires sm_90+; getColltraceDeviceHandle()
+  // returns a ring-backed handle only while capturing a CUDA graph.
+  if (compCap < 90) {
+    return;
+  }
+  auto devHandle = handle->getColltraceDeviceHandle();
+  if (!devHandle.valid()) {
+    return;
+  }
+  // Single-kernel baseline collective: emit both boundaries on this kernel.
+  devHandle.emitStart = true;
+  devHandle.emitEnd = true;
+  plan.kernelArgs->colltraceHdr = devHandle;
+  // Tell the graph wait event this collective self-emits so it skips the
+  // host-launched timestamp path (they must never both write the ring).
+  // TEMPORARY: the host path is deleted at the in-kernel cutover.
+  handle->markInKernelEmit();
+#endif
+}
+
 } // namespace
 
 std::shared_ptr<meta::comms::colltrace::ICollTraceHandle>
-collTraceBaselineGetHandle(ncclKernelPlan* plan, cudaStream_t stream) {
+prepareNcclKernelColltrace(
+    ncclKernelPlan* plan,
+    cudaStream_t stream,
+    int compCap) {
   if (plan->comm->algoStats) {
     auto algoInfo = parseAlgoInfoFromNcclKernelPlan(*plan);
     if (algoInfo.has_value()) {
@@ -563,9 +610,12 @@ collTraceBaselineGetHandle(ncclKernelPlan* plan, cudaStream_t stream) {
     }
   }
 
-  if (NCCL_COLLTRACE.empty()) {
-    return std::make_unique<meta::comms::colltrace::DummyCollTraceHandle>();
-  }
-  return meta::comms::ncclx::getHandleFromNcclKernelPlan(*plan, stream);
+  auto handle = NCCL_COLLTRACE.empty()
+      ? std::shared_ptr<
+            meta::comms::colltrace::ICollTraceHandle>{std::make_unique<
+            meta::comms::colltrace::DummyCollTraceHandle>()}
+      : meta::comms::ncclx::getHandleFromNcclKernelPlan(*plan, stream);
+  armNcclInKernelColltrace(*plan, handle, compCap);
+  return handle;
 }
 } // namespace ncclx::colltrace

--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.h
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.h
@@ -28,6 +28,9 @@ std::unordered_map<std::string, std::string> collTraceGetInfo();
 namespace ncclx::colltrace {
 
 std::shared_ptr<meta::comms::colltrace::ICollTraceHandle>
-collTraceBaselineGetHandle(ncclKernelPlan* plan, cudaStream_t stream);
+prepareNcclKernelColltrace(
+    ncclKernelPlan* plan,
+    cudaStream_t stream,
+    int compCap);
 
 } // namespace ncclx::colltrace

--- a/comms/ncclx/meta/colltrace/tests/BaselineCudaGraphColltraceTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/BaselineCudaGraphColltraceTest.cc
@@ -1,0 +1,173 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <chrono>
+#include <functional>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+#include <folly/init/Init.h>
+#include <folly/json/json.h>
+#include <gtest/gtest.h>
+
+#include "comm.h" // @manual
+#include "nccl.h" // @manual
+
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/testinfra/TestUtils.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/commDump.h"
+
+namespace {
+
+// Baseline (orig NCCL, non-ctran) analog of CtranCudaGraphColltraceTest:
+// capture a real collective into a CUDA graph, replay it, and assert baseline
+// colltrace produced exactly one start/end pair per replay via the in-kernel
+// emit path. The synthetic graph_colltrace_ut drives the ring directly, so it
+// never catches a baseline kernel whose end event is not armed -- which would
+// leave the collective stuck mid-flight and hang the drain. In-kernel emit is
+// the only graph timestamp path and is gated on sm_90+; on older archs
+// graph-captured collectives are not colltrace-timestamped.
+class BaselineCudaGraphColltraceTest : public NcclxBaseTestFixture {
+ protected:
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp({
+        {"WORLD_SIZE", "4"},
+        {"NCCL_COLLTRACE", "trace"},
+        {"NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "true"},
+        // In-kernel device write is off by default until the cutover diff, so
+        // enable it explicitly to exercise the in-kernel colltrace path.
+        {"NCCLX_COLLTRACE_DEVICE_WRITE", "true"},
+    });
+    CUDACHECK_TEST(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaStreamDestroy(stream_));
+    if (sendBuf_ != nullptr) {
+      CUDACHECK_TEST(cudaFree(sendBuf_));
+    }
+    if (recvBuf_ != nullptr) {
+      CUDACHECK_TEST(cudaFree(recvBuf_));
+    }
+    NcclxBaseTestFixture::TearDown();
+  }
+
+  std::unordered_map<std::string, std::string> flushAndDump(ncclComm_t comm) {
+    EXPECT_NE(comm->newCollTrace, nullptr);
+    if (comm->newCollTrace == nullptr) {
+      return {};
+    }
+    comm->newCollTrace->waitFlush(comm->newCollTrace->requestFlush());
+    EXPECT_TRUE(meta::comms::ncclx::waitForCollTraceDrain(*comm->newCollTrace));
+    return meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
+  }
+
+  // Warms the collective eagerly (establishes transport connections and a
+  // stable colltrace baseline), captures it once, and replays it `numReplays`
+  // times under one CUDA graph on a single stream. Asserts colltrace fully
+  // drains (nothing left mid-flight) and produces exactly one past record per
+  // replay.
+  void runGraphColltraceCheck(
+      ncclComm_t comm,
+      int numReplays,
+      const std::string& expectedOpName,
+      const std::function<void(cudaStream_t)>& launch) {
+    // Eager warmup + baseline record count.
+    launch(stream_);
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+    auto baseline = flushAndDump(comm);
+    ASSERT_EQ(baseline["CT_currentColls"], "[]") << "warmup never drained";
+    const int baseCount =
+        static_cast<int>(folly::parseJson(baseline["CT_pastColls"]).size());
+
+    // Capture the collective once.
+    cudaGraph_t graph = nullptr;
+    cudaGraphExec_t graphExec = nullptr;
+    ASSERT_EQ(
+        cudaStreamBeginCapture(stream_, cudaStreamCaptureModeRelaxed),
+        cudaSuccess);
+    launch(stream_);
+    ASSERT_EQ(cudaStreamEndCapture(stream_, &graph), cudaSuccess);
+    ASSERT_NE(graph, nullptr);
+    ASSERT_EQ(
+        cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0),
+        cudaSuccess);
+
+    // Replay N times on one stream so completions are ordered.
+    for (int i = 0; i < numReplays; ++i) {
+      ASSERT_EQ(cudaGraphLaunch(graphExec, stream_), cudaSuccess);
+    }
+    ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+    auto dump = flushAndDump(comm);
+    EXPECT_EQ(dump["CT_currentColls"], "[]")
+        << "a replayed collective never completed -- missing colltrace end "
+           "event for "
+        << expectedOpName;
+    EXPECT_EQ(dump["CT_pendingColls"], "[]");
+
+    auto past = folly::parseJson(dump["CT_pastColls"]);
+    EXPECT_EQ(static_cast<int>(past.size()) - baseCount, numReplays)
+        << "expected exactly one colltrace record per graph replay for "
+        << expectedOpName;
+
+    CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+    CUDACHECK_TEST(cudaGraphDestroy(graph));
+  }
+
+  cudaStream_t stream_{};
+  int* sendBuf_{nullptr};
+  int* recvBuf_{nullptr};
+};
+
+constexpr int kNumReplays = 5;
+constexpr int kCount = 1024;
+
+TEST_F(BaselineCudaGraphColltraceTest, AllReduceOneRecordPerReplay) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  // Force the baseline (orig NCCL) AllReduce kernel path, not ctran.
+  auto algoGuard = EnvRAII(NCCL_ALLREDUCE_ALGO, NCCL_ALLREDUCE_ALGO::orig);
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
+  ASSERT_TRUE(comm->newCollTrace != nullptr);
+
+  CUDACHECK_TEST(cudaMalloc(&sendBuf_, kCount * sizeof(int)));
+  CUDACHECK_TEST(cudaMalloc(&recvBuf_, kCount * sizeof(int)));
+
+  runGraphColltraceCheck(comm, kNumReplays, "AllReduce", [&](cudaStream_t s) {
+    NCCLCHECK_TEST(
+        ncclAllReduce(sendBuf_, recvBuf_, kCount, ncclInt, ncclSum, comm, s));
+  });
+}
+
+TEST_F(BaselineCudaGraphColltraceTest, AllGatherOneRecordPerReplay) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  // Force the baseline (orig NCCL) AllGather kernel path, not ctran.
+  auto algoGuard = EnvRAII(NCCL_ALLGATHER_ALGO, NCCL_ALLGATHER_ALGO::orig);
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
+  ASSERT_TRUE(comm->newCollTrace != nullptr);
+
+  CUDACHECK_TEST(cudaMalloc(&sendBuf_, kCount * sizeof(int)));
+  CUDACHECK_TEST(cudaMalloc(&recvBuf_, kCount * numRanks * sizeof(int)));
+
+  runGraphColltraceCheck(comm, kNumReplays, "AllGather", [&](cudaStream_t s) {
+    NCCLCHECK_TEST(ncclAllGather(sendBuf_, recvBuf_, kCount, ncclInt, comm, s));
+  });
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/v2_29/src/device/common.h
+++ b/comms/ncclx/v2_29/src/device/common.h
@@ -13,6 +13,11 @@
 #include "op128.h"
 #include "reduce_kernel.h"
 #include "network/unpack/unpack_defs.h"
+// [META] in-kernel colltrace emit in ncclKernelMain below; gate defined in
+// device.h, included above.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+#include "comms/utils/colltrace/ColltraceDeviceEventScope.cuh"
+#endif
 
 #define COLL_UNROLL (ncclCollUnroll())
 
@@ -390,6 +395,15 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
     } break;
   }
   __syncthreads(); // publish ncclShmem
+
+  // [META] in-kernel colltrace: emit a graph-ring kStart now and a kEnd when
+  // this scope leaves at kernel exit. Unarmed (non-graph / pre-sm_90) handles
+  // make this a no-op. One scope here covers every baseline collective, since
+  // they all funnel through ncclKernelMain.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+  meta::comms::colltrace::ColltraceDeviceEventScope colltraceScope(
+      ncclShmem.args.colltraceHdr);
+#endif
 
   while (ncclShmem.aborted == 0) {
     profiler(START);

--- a/comms/ncclx/v2_29/src/enqueue.cc
+++ b/comms/ncclx/v2_29/src/enqueue.cc
@@ -1740,9 +1740,9 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
     CU_LAUNCH_PARAM_BUFFER_SIZE, &plan->kernelArgsSize,
     CU_LAUNCH_PARAM_END
   };
-  // CollTrace Injected code here
-  auto colltraceHandle = ncclx::colltrace::collTraceBaselineGetHandle(plan, launchStream);
-
+  // [META] Colltrace handle creation and in-kernel graph timestamp arming.
+  auto colltraceHandle = ncclx::colltrace::prepareNcclKernelColltrace(
+      plan, launchStream, comm->compCap);
 
   int driverVersion;
   NCCLCHECKGOTO(ncclCudaDriverVersion(&driverVersion), ret, do_return);

--- a/comms/ncclx/v2_29/src/include/device.h
+++ b/comms/ncclx/v2_29/src/include/device.h
@@ -12,6 +12,23 @@
 #include "nccl_device/core.h"
 #include "nccl_tuner.h"
 #include "bitops.h"
+// [META] In-kernel colltrace gate. Defined here, and used by every reference to
+// colltraceHdr (see common.h and CollTraceWrapper.cc), so ncclDevKernelArgs has
+// one layout across all TUs. Compiled out when either:
+//   - AMD: see the note on device_object's exported_deps in
+//     comms/ncclx/nccl_build_config.bzl.
+//   - CUDA 13.0-13.2: an nvcc [[no_unique_address]] device-layout bug (fixed in
+//     13.3) misaligns the args->__shared__ copy of ncclDevKernelArgs, so any
+//     kernel launch carrying these args faults with cudaErrorMisalignedAddress.
+//     CUDART_VERSION comes from nccl.h above.
+#if !defined(NCCLX_NO_INKERNEL_COLLTRACE) && \
+    !(CUDART_VERSION >= 13000 && CUDART_VERSION < 13030)
+#define NCCLX_INKERNEL_COLLTRACE 1
+#endif
+
+#ifdef NCCLX_INKERNEL_COLLTRACE
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
+#endif
 #include <algorithm>
 #include <stdint.h>
 #include <sys/types.h>
@@ -474,6 +491,14 @@ struct alignas(16) ncclDevKernelArgs {
   enum ncclDevWorkStorageType workStorageType;
   uint32_t workMask;
   void* workBuf;
+  // [META] in-kernel colltrace graph timestamp handle (ring + collId + emit
+  // flags), armed host-side in armNcclInKernelColltrace() only on the
+  // CUDA-graph path (unarmed = no-op). Kept as the last fixed field so the
+  // trailing inline work-batch region stays sizeof(ncclDevKernelArgs)-relative
+  // on both host and device.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+  meta::comms::colltrace::ColltraceDeviceHandle colltraceHdr;
+#endif
   // A channel's first batch is at `blockIdx.x`. Use `nextJump` to follow rest of list.
   // struct ncclDevWorkBatch batches[];
 };

--- a/comms/ncclx/v2_30/src/device/common.h
+++ b/comms/ncclx/v2_30/src/device/common.h
@@ -13,6 +13,11 @@
 #include "op128.h"
 #include "reduce_kernel.h"
 #include "network/unpack/unpack_defs.h"
+// [META] in-kernel colltrace emit in ncclKernelMain below; gate defined in
+// device.h, included above.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+#include "comms/utils/colltrace/ColltraceDeviceEventScope.cuh"
+#endif
 
 #define COLL_UNROLL (ncclCollUnroll())
 
@@ -395,6 +400,15 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
     } break;
   }
   __syncthreads(); // publish ncclShmem
+
+  // [META] in-kernel colltrace: emit a graph-ring kStart now and a kEnd when
+  // this scope leaves at kernel exit. Unarmed (non-graph / pre-sm_90) handles
+  // make this a no-op. One scope here covers every baseline collective, since
+  // they all funnel through ncclKernelMain.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+  meta::comms::colltrace::ColltraceDeviceEventScope colltraceScope(
+      ncclShmem.args.colltraceHdr);
+#endif
 
   while (ncclShmem.aborted == 0) {
     profiler(START);

--- a/comms/ncclx/v2_30/src/enqueue.cc
+++ b/comms/ncclx/v2_30/src/enqueue.cc
@@ -1744,9 +1744,9 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
     CU_LAUNCH_PARAM_BUFFER_SIZE, &plan->kernelArgsSize,
     CU_LAUNCH_PARAM_END
   };
-  // CollTrace Injected code here
-  auto colltraceHandle = ncclx::colltrace::collTraceBaselineGetHandle(plan, launchStream);
-
+  // [META] Colltrace handle creation and in-kernel graph timestamp arming.
+  auto colltraceHandle = ncclx::colltrace::prepareNcclKernelColltrace(
+      plan, launchStream, comm->compCap);
 
   int driverVersion;
   NCCLCHECKGOTO(ncclCudaDriverVersion(&driverVersion), ret, do_return);

--- a/comms/ncclx/v2_30/src/include/device.h
+++ b/comms/ncclx/v2_30/src/include/device.h
@@ -12,6 +12,23 @@
 #include "nccl_device/core.h"
 #include "nccl_tuner.h"
 #include "bitops.h"
+// [META] In-kernel colltrace gate. Defined here, and used by every reference to
+// colltraceHdr (see common.h and CollTraceWrapper.cc), so ncclDevKernelArgs has
+// one layout across all TUs. Compiled out when either:
+//   - AMD: see the note on device_object's exported_deps in
+//     comms/ncclx/nccl_build_config.bzl.
+//   - CUDA 13.0-13.2: an nvcc [[no_unique_address]] device-layout bug (fixed in
+//     13.3) misaligns the args->__shared__ copy of ncclDevKernelArgs, so any
+//     kernel launch carrying these args faults with cudaErrorMisalignedAddress.
+//     CUDART_VERSION comes from nccl.h above.
+#if !defined(NCCLX_NO_INKERNEL_COLLTRACE) && \
+    !(CUDART_VERSION >= 13000 && CUDART_VERSION < 13030)
+#define NCCLX_INKERNEL_COLLTRACE 1
+#endif
+
+#ifdef NCCLX_INKERNEL_COLLTRACE
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
+#endif
 #include <algorithm>
 #include <stdint.h>
 #include <sys/types.h>
@@ -477,6 +494,14 @@ struct alignas(16) ncclDevKernelArgs {
   enum ncclDevWorkStorageType workStorageType;
   uint32_t workMask;
   void* workBuf;
+  // [META] in-kernel colltrace graph timestamp handle (ring + collId + emit
+  // flags), armed host-side in armNcclInKernelColltrace() only on the
+  // CUDA-graph path (unarmed = no-op). Kept as the last fixed field so the
+  // trailing inline work-batch region stays sizeof(ncclDevKernelArgs)-relative
+  // on both host and device.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+  meta::comms::colltrace::ColltraceDeviceHandle colltraceHdr;
+#endif
   // A channel's first batch is at `blockIdx.x`. Use `nextJump` to follow rest of list.
   // struct ncclDevWorkBatch batches[];
 };


### PR DESCRIPTION
Summary:

Extend in-kernel colltrace graph-timestamp emit to the baseline (orig) NCCL
collective kernels, so CUDA-graph-captured baseline collectives publish their own
start/end timestamps into the shared colltrace ring at replay -- the same
mechanism ctran GPE kernels already use. Previously only ctran collectives
emitted, so the colltrace graph watchdog was blind to the common baseline path.

The host-side registration and the ring poll are already backend-agnostic; only
the device-side write plus a per-launch arm were missing. All logic lives in the
Meta helper `ncclx::colltrace::armBaselineInKernelColltrace`; the NCCL-core
footprint is three `[META]`-tagged hooks per version (v2.29, v2.30):

- `ncclDevKernelArgs` carries a `ColltraceDeviceHandle` (kept as the last fixed
  field so the trailing inline work-batch region stays offset-stable).
- `ncclKernelMain` constructs one `ColltraceEventScope` -- covers every baseline
  collective, since they all funnel through it.
- `ncclLaunchKernel` arms the handle on the CUDA-graph path (sm_90+); unarmed
  otherwise, so the kernel scope is a no-op.

See `meta/baseline_modification_docs/inkernel_colltrace_baseline.md`.

Reviewed By: minsii

Differential Revision: D113717553


