### PR TITLE
Wait for all GPE kernel blocks before termination

### DIFF
--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -846,9 +846,8 @@ void CtranGpe::Impl::gpeThreadFn() {
             kernelFlag->reset();
           }
         } else {
-          // In case of aborted comm, wait for kernel to start
-          while (comm->testAbort() &&
-                 !kernelFlag->testFlagAllGroups(KERNEL_STARTED)) {
+          // A late block must not overwrite the terminal state with STARTED.
+          while (!kernelFlag->testFlagAllGroups(KERNEL_STARTED)) {
             std::this_thread::yield();
           }
           // Stop kernel and kernel will free up the flag after confirmed the


### PR DESCRIPTION
Summary:
The GPE worker can observe block 0 in `KERNEL_STARTED` and complete the host algorithm before the remaining per-block kernel blocks run. It then publishes `KERNEL_TERMINATE` to every flag, allowing a late block to overwrite its terminal state with `KERNEL_STARTED` and wait forever. This causes the intermittent 600-second timeout tracked by T282958818.

Wait for every flag group to reach `KERNEL_STARTED` before publishing `KERNEL_TERMINATE` or `KERNEL_HOST_ABORT`. One-flag kernels continue through the same path with a single group.

Differential Revision: D114540026


