### PR TITLE
GraphEventTracker primary graph watchdog; colltrace fallback (#3408)

### DIFF
--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
@@ -588,7 +588,7 @@ void armNcclInKernelColltrace(
   devHandle.emitStart = true;
   devHandle.emitEnd = true;
   plan.kernelArgs->colltraceHdr = devHandle;
-#endif
+#endif // in-kernel colltrace gate
 }
 
 } // namespace

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -88,8 +88,8 @@ bool colltraceCudaGraphTracingRequested() {
 // The colltrace cudagraph watchdog only fires when BOTH the cudagraph tracing
 // flag is set AND colltrace itself is in trace/verbose mode — otherwise
 // CollTraceWrapper::newCollTraceInit short-circuits before installing the
-// WatchdogPlugin. Both conditions must hold before we hand graph-timeout
-// monitoring over to colltrace and disable GraphEventTracker.
+// WatchdogPlugin. Both conditions must hold before the colltrace watchdog can
+// serve as the fallback when GraphEventTracker monitoring is disabled.
 bool isColltraceGraphTracingEnabled() {
   return colltraceCudaGraphTracingRequested() && colltraceTraceModeEnabled();
 }
@@ -105,32 +105,6 @@ bool isGraphTimeoutMonitoringEnabled() {
       std::string val(env);
       enabled = (val != "0" && val != "false");
     }
-    // Misconfiguration guard: the operator asked for colltrace cudagraph
-    // tracing, but colltrace is not in trace/verbose mode, so
-    // CollTraceWrapper::newCollTraceInit will never install the timeout
-    // WatchdogPlugin. Warn loudly — otherwise both watchdogs can end up
-    // silently disabled (the failure mode that let a hang go undetected).
-    if (colltraceCudaGraphTracingRequested() && !colltraceTraceModeEnabled()) {
-      const char* colltraceEnv = std::getenv("NCCL_COLLTRACE");
-      LOG(WARNING)
-          << "[TC] NCCL_COLLTRACE_TRACE_CUDA_GRAPH is enabled but NCCL_COLLTRACE='"
-          << (colltraceEnv != nullptr ? colltraceEnv : "<unset>")
-          << "' does not enable a 'trace'/'verbose' mode — the colltrace timeout "
-          << "watchdog will NOT be installed. "
-          << (enabled
-                  ? "Keeping GraphEventTracker as the graph-collective watchdog."
-                  : "TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING is also disabled, so "
-                    "NO graph-collective watchdog will be active.")
-          << " Set NCCL_COLLTRACE=trace to enable the colltrace watchdog.";
-    }
-
-    if (enabled && isColltraceGraphTracingEnabled()) {
-      LOG(WARNING)
-          << "[TC] NCCL_COLLTRACE_TRACE_CUDA_GRAPH is enabled — "
-          << "disabling GraphEventTracker timeout monitoring in favor of "
-          << "colltrace watchdog plugin";
-      enabled = false;
-    }
     state = enabled ? 1 : 0;
     g_graphTimeoutMonitoringState.store(state, std::memory_order_relaxed);
   }
@@ -142,14 +116,9 @@ void resetGraphTimeoutMonitoringCacheForTest() {
 }
 
 bool tryEnableColltraceTimeoutWatchdog(std::chrono::milliseconds timeout) {
-  const char* monitoringEnv =
-      std::getenv("TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING");
-  if (monitoringEnv != nullptr) {
-    std::string val(monitoringEnv);
-    if (val == "0" || val == "false") {
-      return false;
-    }
-  }
+  // Fallback watchdog (used when GraphEventTracker monitoring is disabled):
+  // only the colltrace WatchdogPlugin can be configured, and only when
+  // colltrace is actually tracing graph-captured collectives.
   if (!isColltraceGraphTracingEnabled()) {
     return false;
   }
@@ -261,12 +230,18 @@ void TorchCommNCCLX::init(
     return;
   }
 
-  // When TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING is enabled (default) and
-  // NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1, set colltrace watchdog hints before
-  // creating the NCCL communicator — the colltrace plugin is configured
-  // during ncclCommInitRank and must see the hints at that point.
-  if (!isGraphTimeoutMonitoringEnabled()) {
-    tryEnableColltraceTimeoutWatchdog(options_.timeout);
+  // GraphEventTracker is the default graph-collective watchdog (and feeds
+  // clog). When it is disabled (TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING=0),
+  // fall back to the colltrace watchdog so graph-captured hangs are still
+  // detected — its hints must be set before ncclCommInitRank, where the
+  // colltrace plugin is configured. Warn if neither watchdog ends up active.
+  if (!isGraphTimeoutMonitoringEnabled() &&
+      !tryEnableColltraceTimeoutWatchdog(options_.timeout)) {
+    LOG(WARNING)
+        << "[TC] GraphEventTracker timeout monitoring is disabled and the "
+        << "colltrace watchdog is unavailable (needs NCCL_COLLTRACE in a "
+        << "'trace'/'verbose' mode with NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1) — no "
+        << "graph-collective timeout watchdog will be active.";
   }
 
   if (device_.index() == -1 || nccl_comm_ == nullptr) {

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -65,22 +65,21 @@ constexpr size_t kDefaultGraphTimeoutCheckIntervalMs = 1000;
 // Global call-once check for graph timeout monitoring (env var gated).
 // Reads TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING on first call; caches result.
 // Default: enabled. Set to "0" or "false" to disable (for benchmarking).
-// Also returns false when the colltrace cudagraph watchdog will actually run —
-// i.e. NCCL_COLLTRACE_TRACE_CUDA_GRAPH is enabled AND NCCL_COLLTRACE selects a
-// "trace"/"verbose" mode — since the colltrace watchdog plugin then handles
-// graph timeout detection instead. If cudagraph tracing is requested but
-// colltrace is not in trace/verbose mode (so no watchdog plugin is installed),
-// GraphEventTracker is kept active and a warning is logged.
+// GraphEventTracker is the primary graph-collective timeout watchdog and also
+// feeds clog's per-replay logging, so this is independent of colltrace. When it
+// returns false, init() falls back to the colltrace watchdog (see
+// tryEnableColltraceTimeoutWatchdog).
 bool isGraphTimeoutMonitoringEnabled();
 
 // Test-only: reset the cached state so next call re-reads the env var.
 void resetGraphTimeoutMonitoringCacheForTest();
 
-// When NCCL_COLLTRACE_TRACE_CUDA_GRAPH is enabled, configures the colltrace
-// watchdog plugin to handle async error checking and timeout detection for
-// graph-captured collectives via ncclx global hints.
-// No-op when TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING is explicitly disabled.
-// Returns true if colltrace graph tracing is active and all hints succeeded.
+// Fallback watchdog used when GraphEventTracker monitoring is disabled:
+// configures the colltrace WatchdogPlugin to handle async error checking and
+// timeout detection for graph-captured collectives via ncclx global hints.
+// Requires colltrace to be tracing graph-captured collectives (NCCL_COLLTRACE
+// in a "trace"/"verbose" mode AND NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1); otherwise
+// there is no WatchdogPlugin to configure. Returns true if the hints succeeded.
 bool tryEnableColltraceTimeoutWatchdog(std::chrono::milliseconds timeout);
 
 class TorchCommNCCLX : public TorchCommBackend,

--- a/comms/torchcomms/ncclx/tests/integration/cpp/ColltraceGraphWatchdogTest.cpp
+++ b/comms/torchcomms/ncclx/tests/integration/cpp/ColltraceGraphWatchdogTest.cpp
@@ -1,9 +1,11 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 //
-// Integration tests for TorchComms colltrace-based timeout watchdog.
-// Validates that when NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1, TorchCommNCCLX::init()
-// automatically enables the colltrace watchdog plugin via
-// tryEnableColltraceTimeoutWatchdog(), and that it correctly detects timeouts.
+// Integration tests for the colltrace-based timeout watchdog fallback.
+// Validates that when GraphEventTracker monitoring is disabled
+// (TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING=0) and colltrace is tracing
+// graph-captured collectives, TorchCommNCCLX::init() falls back to the
+// colltrace watchdog plugin via tryEnableColltraceTimeoutWatchdog() and detects
+// timeouts.
 
 #include <folly/Conv.h>
 #include <folly/FileUtil.h>
@@ -47,7 +49,9 @@ class ColltraceGraphWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
                     "NCCL_COMMSMONITOR_ENABLE=1",
                     "NCCL_COLLTRACE=trace",
                     "NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1",
-                    "TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING=1",
+                    // Disable GraphEventTracker so init() falls back to the
+                    // colltrace watchdog — the path this test exercises.
+                    "TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING=0",
                     "NCCL_CTRAN_ENABLE=1",
                     "NCCL_CTRAN_REGISTRATION_SIZE_CHECK=1",
                     "NCCL_CTRAN_BACKENDS=ib,socket,nvl",
@@ -135,10 +139,9 @@ class ColltraceGraphWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
   }
 };
 
-// Creates a TorchComm via new_comm("ncclx", ...) with
-// NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1, verifying that init() automatically
-// enables the colltrace watchdog and it detects a timeout when a collective
-// hangs.
+// Creates a TorchComm via new_comm("ncclx", ...) with GraphEventTracker
+// monitoring disabled, verifying that init() falls back to the colltrace
+// watchdog and it detects a timeout when a collective hangs.
 TEST_F(ColltraceGraphWatchdogTest, TestTimeoutViaTorchCommsInit) {
   if (isTestDriverProcess()) {
     testDriverCheckCrashedWithWatchdog();
@@ -149,10 +152,10 @@ TEST_F(ColltraceGraphWatchdogTest, TestTimeoutViaTorchCommsInit) {
   int rank = getRank();
   int worldSize = getWorldSize();
 
-  // Create TorchComm via the full init path.
-  // NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1 is set in the env, so
-  // initNcclxResources() will call tryEnableColltraceTimeoutWatchdog(timeout)
-  // which sets crashOnAsyncError, crashOnTimeout, and timeoutMs hints.
+  // Create TorchComm via the full init path. GraphEventTracker monitoring is
+  // disabled and colltrace graph tracing is on, so init() falls back to
+  // tryEnableColltraceTimeoutWatchdog(timeout), which sets crashOnAsyncError,
+  // crashOnTimeout, and timeoutMs hints.
   auto torchcomm = createTorchComm(
       rank,
       worldSize,
@@ -184,6 +187,14 @@ TEST_F(ColltraceGraphWatchdogTest, TestTimeoutViaTorchCommsInit) {
 // Captures an AllReduce into a CUDA graph via TorchComms, replays it, and
 // verifies the colltrace watchdog detects a timeout during graph replay.
 TEST_F(ColltraceGraphWatchdogTest, TestGraphReplayTimeout) {
+#if CUDART_VERSION >= 13000 && CUDART_VERSION < 13030
+  // The in-kernel colltrace graph path this exercises is compiled out on CUDA
+  // 13.0-13.2 (nvcc [[no_unique_address]] layout bug, fixed in 13.3; see the
+  // colltraceHdr gate in comms/ncclx/v2_30/src/include/device.h). With the
+  // primary GraphEventTracker also disabled in SetUp, there is no graph-replay
+  // timeout detector left to test here.
+  GTEST_SKIP() << "in-kernel colltrace graph path disabled on CUDA 13.0-13.2";
+#endif
   if (isTestDriverProcess()) {
     testDriverCheckCrashedWithWatchdog();
     return;
@@ -255,6 +266,12 @@ TEST_F(ColltraceGraphWatchdogTest, TestGraphReplayTimeout) {
 TEST_F(
     ColltraceGraphWatchdogTest,
     TestGraphReplayTimeoutAfterSuccessfulReplays) {
+#if CUDART_VERSION >= 13000 && CUDART_VERSION < 13030
+  // In-kernel colltrace graph path is compiled out on CUDA 13.0-13.2 (nvcc
+  // [[no_unique_address]] layout bug, fixed in 13.3); nothing to test here with
+  // GraphEventTracker also disabled in SetUp. See device.h colltraceHdr gate.
+  GTEST_SKIP() << "in-kernel colltrace graph path disabled on CUDA 13.0-13.2";
+#endif
   if (isTestDriverProcess()) {
     testDriverCheckCrashedWithWatchdog();
     return;

--- a/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
@@ -1228,193 +1228,39 @@ TEST_F(
   resetGraphTimeoutMonitoringCacheForTest();
   setupFinalizeExpectations(*comm);
 }
-// --- Colltrace graph tracing disables GraphEventTracker monitoring ---
 
-TEST_F(
-    GraphEventTrackerTest,
-    ColltraceGraphTracing_DisablesGraphTimeoutMonitoring) {
+// --- Graph timeout monitoring gate + colltrace watchdog fallback ---
+
+// The gate is env-only; colltrace mode does not affect it.
+TEST_F(GraphEventTrackerTest, GraphTimeoutMonitoring_EnabledByDefault) {
   resetGraphTimeoutMonitoringCacheForTest();
-
-  ::setenv("NCCL_COLLTRACE", "trace", 1);
-  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
-  EXPECT_FALSE(isGraphTimeoutMonitoringEnabled());
-
-  ::unsetenv("NCCL_COLLTRACE");
-  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
-  resetGraphTimeoutMonitoringCacheForTest();
-}
-
-TEST_F(
-    GraphEventTrackerTest,
-    ColltraceGraphTracing_MonitoringEnabledWhenNotSet) {
-  resetGraphTimeoutMonitoringCacheForTest();
-
-  ::unsetenv("NCCL_COLLTRACE");
-  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
-  EXPECT_TRUE(isGraphTimeoutMonitoringEnabled());
-
-  resetGraphTimeoutMonitoringCacheForTest();
-}
-
-// NCCL_COLLTRACE_TRACE_CUDA_GRAPH only disables monitoring when colltrace is
-// actually active (NCCL_COLLTRACE=trace|verbose). With NCCL_COLLTRACE unset the
-// colltrace watchdog plugin is not running, so monitoring must stay enabled.
-TEST_F(
-    GraphEventTrackerTest,
-    ColltraceGraphTracing_MonitoringEnabledWhenColltraceUnset) {
-  resetGraphTimeoutMonitoringCacheForTest();
-
-  ::unsetenv("NCCL_COLLTRACE");
-  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
-  EXPECT_TRUE(isGraphTimeoutMonitoringEnabled());
-
-  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
-  resetGraphTimeoutMonitoringCacheForTest();
-}
-
-// NCCL_COLLTRACE set to a value other than trace/verbose does not activate the
-// colltrace watchdog plugin, so monitoring stays enabled.
-TEST_F(
-    GraphEventTrackerTest,
-    ColltraceGraphTracing_MonitoringEnabledWhenColltraceNotTraceOrVerbose) {
-  resetGraphTimeoutMonitoringCacheForTest();
-
-  ::setenv("NCCL_COLLTRACE", "1", 1);
-  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
-  EXPECT_TRUE(isGraphTimeoutMonitoringEnabled());
-
-  ::unsetenv("NCCL_COLLTRACE");
-  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
-  resetGraphTimeoutMonitoringCacheForTest();
-}
-
-// NCCL_COLLTRACE=verbose also activates the colltrace watchdog plugin, so
-// monitoring is disabled just like the trace case.
-TEST_F(
-    GraphEventTrackerTest,
-    ColltraceGraphTracing_VerboseDisablesGraphTimeoutMonitoring) {
-  resetGraphTimeoutMonitoringCacheForTest();
-
-  ::setenv("NCCL_COLLTRACE", "verbose", 1);
-  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
-  EXPECT_FALSE(isGraphTimeoutMonitoringEnabled());
-
-  ::unsetenv("NCCL_COLLTRACE");
-  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
-  resetGraphTimeoutMonitoringCacheForTest();
-}
-
-TEST_F(
-    GraphEventTrackerTest,
-    ColltraceGraphTracing_ExplicitDisableOverridesColltrace) {
-  resetGraphTimeoutMonitoringCacheForTest();
-
-  ::setenv("TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING", "0", 1);
-  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
-  EXPECT_FALSE(isGraphTimeoutMonitoringEnabled());
-
   ::unsetenv("TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING");
-  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
+  EXPECT_TRUE(isGraphTimeoutMonitoringEnabled());
   resetGraphTimeoutMonitoringCacheForTest();
 }
 
-TEST_F(
-    GraphEventTrackerTest,
-    ColltraceGraphTracing_NoStartEndEventsOrReplayCounter) {
+TEST_F(GraphEventTrackerTest, GraphTimeoutMonitoring_DisabledByEnv) {
   resetGraphTimeoutMonitoringCacheForTest();
+  ::setenv("TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING", "0", 1);
+  EXPECT_FALSE(isGraphTimeoutMonitoringEnabled());
+  ::unsetenv("TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING");
+  resetGraphTimeoutMonitoringCacheForTest();
+}
 
-  auto comm = createMockedTorchComm();
-  cuda_mock_->setupDefaultBehaviors();
-  nccl_mock_->setupDefaultBehaviors();
-
-  auto options = createAbortModeOptions();
+// Colltrace trace + cudagraph tracing must NOT disable GraphEventTracker — it
+// stays enabled so clog keeps its per-replay stream.
+TEST_F(GraphEventTrackerTest, GraphTimeoutMonitoring_NotAffectedByColltrace) {
+  resetGraphTimeoutMonitoringCacheForTest();
   ::setenv("NCCL_COLLTRACE", "trace", 1);
   ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
-  comm->init(*device_, "test_colltrace_graph_no_events", options);
-
-  setupGraphCaptureMocks();
-
-  // Only sync_event_ created — no start_event_ or end_event_
-  cudaEvent_t sync = reinterpret_cast<cudaEvent_t>(0xA003);
-  EXPECT_CALL(*cuda_mock_, eventCreateWithFlags(_, _))
-      .WillOnce(DoAll(SetArgPointee<0>(sync), Return(cudaSuccess)));
-
-  // No replay counter kernel
-  EXPECT_CALL(*cuda_mock_, launchHostFunc(_, _, _)).Times(0);
-
-  // Cleanup callback still installed
-  EXPECT_CALL(*cuda_mock_, userObjectCreate(_, _, _, _, _))
-      .WillOnce(DoAll(
-          SetArgPointee<0>(reinterpret_cast<cudaUserObject_t>(0x3000)),
-          Return(cudaSuccess)));
-  EXPECT_CALL(*cuda_mock_, graphRetainUserObject(_, _, _, _))
-      .WillOnce(Return(cudaSuccess));
-
-  setupEventRecordMocks();
-
-  auto tensor = createTestTensor({10, 10});
-
-  {
-    auto work = comm->send(tensor, 1, true);
-  }
-
-  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
-
-  switchToReplayMode();
+  EXPECT_TRUE(isGraphTimeoutMonitoringEnabled());
   ::unsetenv("NCCL_COLLTRACE");
   ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
   resetGraphTimeoutMonitoringCacheForTest();
-  setupFinalizeExpectations(*comm);
 }
 
-TEST_F(GraphEventTrackerTest, ColltraceGraphTracing_CheckGraphEventsReturnsOK) {
-  resetGraphTimeoutMonitoringCacheForTest();
-
-  auto comm = createMockedTorchComm();
-  cuda_mock_->setupDefaultBehaviors();
-  nccl_mock_->setupDefaultBehaviors();
-
-  auto options = createAbortModeOptions();
-  ::setenv("NCCL_COLLTRACE", "trace", 1);
-  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
-  comm->init(*device_, "test_colltrace_graph_check_ok", options);
-
-  setupGraphCaptureMocks();
-
-  cudaEvent_t sync = reinterpret_cast<cudaEvent_t>(0xA003);
-  EXPECT_CALL(*cuda_mock_, eventCreateWithFlags(_, _))
-      .WillOnce(DoAll(SetArgPointee<0>(sync), Return(cudaSuccess)))
-      .WillRepeatedly(DoAll(
-          SetArgPointee<0>(reinterpret_cast<cudaEvent_t>(0xA100)),
-          Return(cudaSuccess)));
-
-  setupEventRecordMocks();
-
-  auto tensor = createTestTensor({10, 10});
-
-  {
-    auto work = comm->send(tensor, 1, true);
-  }
-
-  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
-
-  switchToReplayMode();
-
-  // No event queries — checkAll() returns OK immediately
-  EXPECT_CALL(*cuda_mock_, eventQuery(_)).Times(0);
-
-  comm->checkGraphEvents();
-
-  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
-
-  ::unsetenv("NCCL_COLLTRACE");
-  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
-  resetGraphTimeoutMonitoringCacheForTest();
-  setupFinalizeExpectations(*comm);
-}
-
-// --- tryEnableColltraceTimeoutWatchdog env var gating ---
-
+// The colltrace watchdog fallback is only available when colltrace is actually
+// tracing graph-captured collectives.
 TEST_F(
     GraphEventTrackerTest,
     TryEnableColltraceWatchdog_ReturnsFalseWhenGraphTracingDisabled) {
@@ -1423,9 +1269,6 @@ TEST_F(
       tryEnableColltraceTimeoutWatchdog(std::chrono::milliseconds{5000}));
 }
 
-// Regression: with NCCL_COLLTRACE unset the colltrace watchdog is never created
-// (this path short-circuits), so it must not be relied on to replace the
-// GraphEventTracker timeout monitoring.
 TEST_F(
     GraphEventTrackerTest,
     TryEnableColltraceWatchdog_ReturnsFalseWhenColltraceUnset) {
@@ -1433,88 +1276,7 @@ TEST_F(
   ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
   EXPECT_FALSE(
       tryEnableColltraceTimeoutWatchdog(std::chrono::milliseconds{5000}));
-
   ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
-}
-
-TEST_F(
-    GraphEventTrackerTest,
-    TryEnableColltraceWatchdog_ReturnsFalseWhenMonitoringExplicitlyDisabled) {
-  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
-  ::setenv("TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING", "0", 1);
-  EXPECT_FALSE(
-      tryEnableColltraceTimeoutWatchdog(std::chrono::milliseconds{5000}));
-
-  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
-  ::unsetenv("TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING");
-}
-
-// --- NCCL_COLLTRACE stringlist parsing in isGraphTimeoutMonitoringEnabled ---
-// NCCL_COLLTRACE is a comma-separated stringlist. Graph-timeout monitoring is
-// handed to colltrace (GraphEventTracker disabled) iff a "trace"/"verbose"
-// token is present AND NCCL_COLLTRACE_TRACE_CUDA_GRAPH is set — consistent with
-// CollTraceWrapper::newCollTraceInit. Otherwise GraphEventTracker must remain
-// active so a watchdog always covers graph-captured collectives.
-
-TEST_F(
-    GraphEventTrackerTest,
-    GraphTimeoutMonitoring_DisabledForMultiTokenTrace) {
-  // "trace,algostat" starts the colltrace worker + watchdog, so colltrace owns
-  // graph-timeout detection and GraphEventTracker monitoring is disabled.
-  ::setenv("NCCL_COLLTRACE", "trace,algostat", 1);
-  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
-  resetGraphTimeoutMonitoringCacheForTest();
-
-  EXPECT_FALSE(isGraphTimeoutMonitoringEnabled());
-
-  ::unsetenv("NCCL_COLLTRACE");
-  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
-  resetGraphTimeoutMonitoringCacheForTest();
-}
-
-TEST_F(GraphEventTrackerTest, GraphTimeoutMonitoring_KeptForAlgostatOnly) {
-  // "algostat" alone does NOT start the colltrace worker/watchdog, so
-  // GraphEventTracker must stay active even though cudagraph tracing is asked.
-  ::setenv("NCCL_COLLTRACE", "algostat", 1);
-  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
-  resetGraphTimeoutMonitoringCacheForTest();
-
-  EXPECT_TRUE(isGraphTimeoutMonitoringEnabled());
-
-  ::unsetenv("NCCL_COLLTRACE");
-  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
-  resetGraphTimeoutMonitoringCacheForTest();
-}
-
-TEST_F(GraphEventTrackerTest, GraphTimeoutMonitoring_KeptForEmptyColltrace) {
-  // Regression for the observed MAST hang: NCCL_COLLTRACE blanked while
-  // cudagraph tracing is requested. No colltrace watchdog is installed, so
-  // GraphEventTracker must remain the graph-collective watchdog.
-  ::setenv("NCCL_COLLTRACE", "", 1);
-  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
-  resetGraphTimeoutMonitoringCacheForTest();
-
-  EXPECT_TRUE(isGraphTimeoutMonitoringEnabled());
-
-  ::unsetenv("NCCL_COLLTRACE");
-  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
-  resetGraphTimeoutMonitoringCacheForTest();
-}
-
-TEST_F(
-    GraphEventTrackerTest,
-    GraphTimeoutMonitoring_KeptForWrongCaseColltrace) {
-  // Token matching is case-sensitive (mirrors CollTraceWrapper); "Trace" does
-  // not enable colltrace, so GraphEventTracker must stay active.
-  ::setenv("NCCL_COLLTRACE", "Trace", 1);
-  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
-  resetGraphTimeoutMonitoringCacheForTest();
-
-  EXPECT_TRUE(isGraphTimeoutMonitoringEnabled());
-
-  ::unsetenv("NCCL_COLLTRACE");
-  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
-  resetGraphTimeoutMonitoringCacheForTest();
 }
 
 } // namespace torch::comms::test


### PR DESCRIPTION
Summary:

GraphEventTracker is the primary graph-collective timeout watchdog and also feeds clog per-replay logging, so it stays enabled by default independently of colltrace: isGraphTimeoutMonitoringEnabled() is gated only by TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING (default on).

When GraphEventTracker monitoring is explicitly disabled (TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING=0), init() falls back to the colltrace WatchdogPlugin via tryEnableColltraceTimeoutWatchdog() so graph-captured hangs are still detected, provided colltrace is tracing graph collectives (NCCL_COLLTRACE=trace|verbose + NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1). If neither watchdog is available, a warning is logged.

Reviewed By: minsii

Differential Revision: D113496433


