### PR TITLE
cut graph timing over to in-kernel emit; remove host timestamp kernels (#3409)

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherBrucksFF.cu
+++ b/comms/ctran/algos/AllGather/AllGatherBrucksFF.cu
@@ -9,6 +9,7 @@ __global__ void ncclKernelAllGatherCtranBrucks(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {

--- a/comms/ctran/algos/AllGather/AllGatherDirect.cuh
+++ b/comms/ctran/algos/AllGather/AllGatherDirect.cuh
@@ -51,6 +51,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelAllGatherCtranDirect(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/comms/ctran/algos/AllGather/AllGatherRing.cu
+++ b/comms/ctran/algos/AllGather/AllGatherRing.cu
@@ -9,6 +9,7 @@ __global__ void ncclKernelAllGatherCtranRing(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {

--- a/comms/ctran/algos/AllGather/StreamedRd/Impl.cu
+++ b/comms/ctran/algos/AllGather/StreamedRd/Impl.cu
@@ -9,6 +9,7 @@ __global__ void ncclKernelAllGatherCtranStreamedRd(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {

--- a/comms/ctran/algos/AllGatherP/DirectImpl.cu
+++ b/comms/ctran/algos/AllGatherP/DirectImpl.cu
@@ -9,6 +9,7 @@ namespace ctran::allgatherp {
 __global__ void ncclKernelAllGatherPDirect(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
     ctran::device::devLoadAbortFlags(flag, devState);

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -244,8 +244,7 @@ commResult_t AlgoImpl::execPipeline(
   config.numThreads = 1;
   config.args.devState_d = ctran->algo->getDevState();
 
-  // TODO: ensure colltrace can capture the group of operations as single
-  // allgather
+  bool colltraceGroupOpen = false;
 
   if (nNodes > 1) {
     // Submit inter-node Ring pipeline for GPE thread to execute. Skip if single
@@ -266,6 +265,11 @@ commResult_t AlgoImpl::execPipeline(
       //   GPE thread till allgather starts. ncclKernelAllGatherPPipeStart
       //   returns immediately after started GPE, thus the inter-node pipeline
       //   can be overlapped with the following intra-node copies.
+      // Multi-kernel begin: emit the start boundary and open the group; the
+      // PipeEnd kernel below reuses this record and emits the end.
+      config.colltraceEmitStart = true;
+      config.colltraceEmitEnd = false;
+      colltraceGroupOpen = true;
       FB_COMMCHECK(ctran->gpe->submit(
           std::move(opGroup),
           gpeFn,
@@ -274,6 +278,10 @@ commResult_t AlgoImpl::execPipeline(
     } else {
       // - For nLocalRanks == 1 case, ncclKernelAllGatherPRing holds the stream
       //   till GPE thread finishes entire transfer.
+      // Single-kernel collective: emit both boundaries explicitly rather than
+      // relying on the reused `config`'s KernelConfig defaults.
+      config.colltraceEmitStart = true;
+      config.colltraceEmitEnd = true;
       FB_COMMCHECK(ctran->gpe->submit(
           std::move(opGroup),
           gpeFn,
@@ -321,6 +329,11 @@ commResult_t AlgoImpl::execPipeline(
           .pipeSync = resource_.pipeSync,
       };
       config.algoArgs = reinterpret_cast<void*>(&kernArgs);
+      // Interior kernel: emits neither boundary and reuses the begin kernel's
+      // record. Overwrite the values leaked from the reused `config` (set on
+      // the PipeStart submit above).
+      config.colltraceEmitStart = false;
+      config.colltraceEmitEnd = false;
       FB_COMMCHECK(ctran->gpe->submit(
           {},
           nullptr,
@@ -349,6 +362,15 @@ commResult_t AlgoImpl::execPipeline(
         .pipeSync = resource_.pipeSync,
     };
     config.algoArgs = reinterpret_cast<void*>(&kernArgs);
+    if (colltraceGroupOpen) {
+      // Close the record opened by PipeStart.
+      config.colltraceEmitStart = false;
+      config.colltraceEmitEnd = true;
+    } else {
+      // With no PipeStart, PipeEnd bounds the whole collective.
+      config.colltraceEmitStart = true;
+      config.colltraceEmitEnd = true;
+    }
     FB_COMMCHECK(ctran->gpe->submit(
         {},
         nullptr,

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cu
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cu
@@ -19,6 +19,7 @@ namespace ctran::allgatherp {
 __global__ void ncclKernelAllGatherPPipeStart(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
     ctran::device::KernelStartGpeAndExit(f);
@@ -33,6 +34,7 @@ __global__ void ncclKernelAllGatherPPipeSync(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     PipeSyncKernArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   ctran::device::devLoadAbortFlags(flag, devState);
   // wait till GPE thread post the current stepId
@@ -45,6 +47,7 @@ __global__ void ncclKernelAllGatherPPipeSync(
 __global__ void ncclKernelAllGatherPRing(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
     ctran::device::devLoadAbortFlags(flag, devState);
@@ -58,6 +61,7 @@ __global__ void ncclKernelAllGatherPRing(
 __global__ void ncclKernelAllGatherPStreamedRd(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
     ctran::device::devLoadAbortFlags(flag, devState);
@@ -70,9 +74,11 @@ __global__ void ncclKernelAllGatherPStreamedRd(
 // broadcast. Used when nLocalRanks > 1 in allgatherP pipeline algorithm. It is
 // called once at the end.
 __global__ void ncclKernelAllGatherPPipeEnd(
-    ctran::gpe::KernelFlagDev* flag,
+    ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     PipeEndKernArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
+
   // Reset sync flag for next GPE->kernel pipeline sync to use
   GpeKernelSyncDev::reset(args.pipeSync, 0);
 
@@ -89,6 +95,7 @@ __global__ void ncclKernelAllGatherPPipeEnd(
 __global__ void ncclKernelAllGatherPSrdPipeStart(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
     ctran::device::KernelStartGpeAndExit(f);
@@ -99,6 +106,7 @@ __global__ void ncclKernelAllGatherPSrdPipeSync(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     PipeSyncKernArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   ctran::device::devLoadAbortFlags(flag, devState);
   // wait till GPE thread post the current stepId
@@ -109,6 +117,7 @@ __global__ void ncclKernelAllGatherPSrdPipeEnd(
     ctran::gpe::KernelFlagDev* flag,
     CtranAlgoDeviceState* devState,
     PipeEndKernArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(flag);
   // Reset sync flag for next GPE->kernel pipeline sync to use
   GpeKernelSyncDev::reset(args.pipeSync, 0);
 

--- a/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
@@ -245,6 +245,12 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
   config.numThreads = 1;
   config.args.devState_d = ctran->algo->getDevState();
 
+  // In-kernel colltrace grouping across the Srd multi-kernel collective
+  // (SrdPipeStart..SrdPipeSync..SrdPipeEnd): the begin kernel emits the start
+  // boundary and opens the group; the end kernel emits the end. Set explicitly
+  // per submit because the reused KernelConfig defaults its emit flags to true.
+  bool colltraceGroupOpen = false;
+
   // The streamed GPE path sources every outgoing chunk from recvbuff, including
   // the local rank's own chunk. Keep the copy stream-ordered before PipeStart.
   FB_COMMCHECK(copyToSelf(
@@ -267,12 +273,21 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
     opGroup.push_back(std::move(op));
 
     if (nLocalRanks > 1) {
+      // Multi-kernel begin: emit the start boundary and open the group; the
+      // SrdPipeEnd kernel below reuses this record and emits the end.
+      config.colltraceEmitStart = true;
+      config.colltraceEmitEnd = false;
+      colltraceGroupOpen = true;
       FB_COMMCHECK(ctran->gpe->submit(
           std::move(opGroup),
           gpeFn,
           config,
           reinterpret_cast<void*>(ncclKernelAllGatherPSrdPipeStart)));
     } else {
+      // Single-kernel collective: emit both boundaries explicitly rather than
+      // relying on the reused config's KernelConfig defaults.
+      config.colltraceEmitStart = true;
+      config.colltraceEmitEnd = true;
       FB_COMMCHECK(ctran->gpe->submit(
           std::move(opGroup),
           gpeFn,
@@ -299,6 +314,10 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
           .pipeSync = resource_.pipeSync,
       };
       config.algoArgs = reinterpret_cast<void*>(&syncArgs);
+      // Interior kernel: emits neither boundary and reuses the begin kernel's
+      // record. Overwrite the values leaked from the reused `config`.
+      config.colltraceEmitStart = false;
+      config.colltraceEmitEnd = false;
       FB_COMMCHECK(ctran->gpe->submit(
           {},
           nullptr,
@@ -327,6 +346,17 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
         .pipeSync = resource_.pipeSync,
     };
     config.algoArgs = reinterpret_cast<void*>(&endArgs);
+    if (colltraceGroupOpen) {
+      // Multi-kernel end: close the group opened by SrdPipeStart and emit only
+      // the end boundary.
+      config.colltraceEmitStart = false;
+      config.colltraceEmitEnd = true;
+    } else {
+      // No inter-node begin ran (nNodes == 1), so this end kernel represents
+      // the whole intra-node collective: emit both boundaries.
+      config.colltraceEmitStart = true;
+      config.colltraceEmitEnd = true;
+    }
     FB_COMMCHECK(ctran->gpe->submit(
         {},
         nullptr,

--- a/comms/ctran/algos/AllReduce/AllReduceDirect.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceDirect.cuh
@@ -159,6 +159,7 @@ __global__ void ncclKernelAllReduceCtranDirect(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allreduce::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;

--- a/comms/ctran/algos/AllReduce/AllReduceRing.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cuh
@@ -396,6 +396,7 @@ __global__ void ncclKernelAllReduceCtranRing(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::allreduce::ring::KernArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;

--- a/comms/ctran/algos/AllToAll/AllToAll.cc
+++ b/comms/ctran/algos/AllToAll/AllToAll.cc
@@ -324,6 +324,12 @@ commResult_t ctranDeviceAllToAllv(
       ? ncclKernelDeviceAllToAllvPipes<PipeProtocol::LL128>
       : ncclKernelDeviceAllToAllvPipes<PipeProtocol::Simple>;
 
+  // This NVLink-only device kernel does not use the GPE flag mechanism and does
+  // not construct a ColltraceEventScope, so do not arm an in-kernel colltrace
+  // record for it — otherwise the reused config's default emit flags would
+  // create a record that never receives its start/end and stays in-flight.
+  config.colltraceEmitStart = false;
+  config.colltraceEmitEnd = false;
   FB_COMMCHECK(comm->ctran_->gpe->submit(
       std::move(opGroup), nullptr, config, reinterpret_cast<void*>(kernel)));
 

--- a/comms/ctran/algos/AllToAll/AllToAll.cuh
+++ b/comms/ctran/algos/AllToAll/AllToAll.cuh
@@ -109,6 +109,7 @@ __global__ void ncclKernelAllToAll(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::alltoall::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/comms/ctran/algos/AllToAll/AllToAllPImpl.cu
+++ b/comms/ctran/algos/AllToAll/AllToAllPImpl.cu
@@ -17,6 +17,7 @@ namespace ctran::alltoallp {
 __global__ void ncclKernelAllToAllPDirect(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
     ctran::device::devLoadAbortFlags(flag, devState);

--- a/comms/ctran/algos/AllToAll/AllToAllv.cuh
+++ b/comms/ctran/algos/AllToAll/AllToAllv.cuh
@@ -139,6 +139,7 @@ __global__ void ncclKernelAllToAllv(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::alltoallv::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/comms/ctran/algos/Broadcast/Broadcast.cu
+++ b/comms/ctran/algos/Broadcast/Broadcast.cu
@@ -20,6 +20,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelBroadcast(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::broadcast::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/comms/ctran/algos/RMA/Get.cu
+++ b/comms/ctran/algos/RMA/Get.cu
@@ -8,6 +8,7 @@
 __global__ void ncclKernelGet(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {

--- a/comms/ctran/algos/RMA/PutSignal.cu
+++ b/comms/ctran/algos/RMA/PutSignal.cu
@@ -80,6 +80,7 @@ __global__ void ncclKernelPutSignal(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     CtranKernelPutSignalArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
@@ -106,6 +107,7 @@ __global__ void ncclKernelPutSignal(
 __global__ void ncclKernelPut(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
@@ -119,6 +121,7 @@ __global__ void ncclKernelWaitSignal(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     CtranKernelWaitSignalArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {
@@ -147,6 +150,7 @@ __global__ void ncclKernelSignal(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     CtranKernelSignalArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
   if (flag && gtIdx == 0) {

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterDirect.cuh
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterDirect.cuh
@@ -131,6 +131,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelReduceScatterDirect(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::reducescatter::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   // TODO(T243528798): remove this preload of devstate by splitting h2d/d2h
   // channels.

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterRHD.cuh
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterRHD.cuh
@@ -18,6 +18,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelReduceScatterRHD(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::reducescatter::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterRing.cuh
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterRing.cuh
@@ -18,6 +18,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelReduceScatterRing(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::reducescatter::KernelArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/comms/ctran/algos/SendRecv/SendRecv.cu
+++ b/comms/ctran/algos/SendRecv/SendRecv.cu
@@ -19,6 +19,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelSend(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::sendrecv::KernelSendArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
@@ -50,6 +51,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelRecv(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::sendrecv::KernelRecvArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;
@@ -91,6 +93,7 @@ __global__ void __launch_bounds__(1024, 1) ncclKernelSendRecv(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState,
     ctran::sendrecv::KernelSendRecvArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto tId = threadIdx.x;
   const auto bId = blockIdx.x;

--- a/comms/ctran/algos/SendRecv/SendRecvP2p.cu
+++ b/comms/ctran/algos/SendRecv/SendRecvP2p.cu
@@ -78,6 +78,7 @@ __global__ __launch_bounds__(512, 1) void ncclKernelSendRecvP2p(
     CtranAlgoDeviceState* devState, // TODO: this is not needed for now, but
                                     // maybe needed for fault-tolerance
     ctran::sendrecv::KernArgs args) {
+  ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 

--- a/comms/ctran/algos/common/ColltraceEventScope.cuh
+++ b/comms/ctran/algos/common/ColltraceEventScope.cuh
@@ -1,0 +1,46 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comms/ctran/algos/common/GpeRing.h" // ctran::gpe::KernelFlagDev
+#include "comms/utils/colltrace/ColltraceDeviceEventScope.cuh"
+
+// In-kernel colltrace timestamp emission for ctran GPE kernels. The generic
+// device writer (single-writer election + RAII start/end) is shared with the
+// baseline ncclx kernels in ColltraceDeviceEventScope.cuh; this
+// header only adds the ctran-specific convenience of arming directly from a
+// KernelFlagDev so call sites don't repeat the null-check ternary.
+
+namespace ctran::device {
+
+// Re-expose the shared emitter under the ctran::device namespace that existing
+// ctran call sites use.
+using meta::comms::colltrace::ColltraceEmitEvent;
+
+struct ColltraceEventScope : meta::comms::colltrace::ColltraceDeviceEventScope {
+  __forceinline__ __device__ explicit ColltraceEventScope(
+      meta::comms::colltrace::ColltraceDeviceHandle handle,
+      unsigned int startWriterThreadIdxX = 0,
+      unsigned int endWriterThreadIdxX = 0)
+      : meta::comms::colltrace::ColltraceDeviceEventScope(
+            handle,
+            startWriterThreadIdxX,
+            endWriterThreadIdxX) {}
+
+  // Convenience overload: take the kernel flag directly. A null flag yields an
+  // unarmed (no-op) scope. startWriterThreadIdxX / endWriterThreadIdxX pick the
+  // elected writer lane for the start (ctor) and end (dtor) emits; both default
+  // to thread 0. Keep the end lane at 0 in GPE kernels where only thread 0
+  // waits for completion (see the base ColltraceEventScope note).
+  __forceinline__ __device__ explicit ColltraceEventScope(
+      const ctran::gpe::KernelFlagDev* f,
+      unsigned int startWriterThreadIdxX = 0,
+      unsigned int endWriterThreadIdxX = 0)
+      : meta::comms::colltrace::ColltraceDeviceEventScope(
+            f ? f->colltraceHdr
+              : meta::comms::colltrace::ColltraceDeviceHandle{},
+            startWriterThreadIdxX,
+            endWriterThreadIdxX) {}
+};
+
+} // namespace ctran::device

--- a/comms/ctran/algos/common/GpeKernelDev.cuh
+++ b/comms/ctran/algos/common/GpeKernelDev.cuh
@@ -5,6 +5,7 @@
 #include "comms/common/AtomicUtils.cuh"
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/ctran/algos/DevShmState.cuh"
+#include "comms/ctran/algos/common/ColltraceEventScope.cuh"
 #include "comms/ctran/algos/common/GpeKernel.h"
 #include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/utils/DevUtils.cuh"
@@ -28,15 +29,22 @@ static inline __device__ void devLoadAbortFlags(
 }
 
 // Publish this launch's cmd id to the device ring in GPU execution order.
-// Single-writer election (block 0, thread 0); no-op when not armed
-// (hdr.enabled == 0). The GPE worker consumes the ring to order started cmds.
-// The ring write is the HRDWRingBuffer System-scope 128b atomic path.
+// Single-writer election (the one thread with all block and thread indices zero
+// across x/y/z, so a 2D/3D launch still elects exactly one writer); no-op when
+// not armed (hdr.enabled == 0). The GPE worker consumes the ring to order
+// started cmds. The ring write is the HRDWRingBuffer System-scope 128b atomic
+// path.
 static __forceinline__ __device__ void KernelPublishGpeRing(
     ctran::gpe::GpeKernelFlagHeader hdr) {
-  if (blockIdx.x == 0 && threadIdx.x == 0 && hdr.enabled) {
+  if (blockIdx.x == 0 && blockIdx.y == 0 && blockIdx.z == 0 &&
+      threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0 && hdr.enabled) {
     hdr.ring.write(hdr.cmdId);
   }
 }
+
+// ColltraceEmitEvent / ColltraceEventScope moved to ColltraceEventScope.cuh
+// (included above); kept accessible here since kernels include
+// GpeKernelDev.cuh.
 
 // Kernel start prologue: publish this cmd's id to the ring (block 0 only, no-op
 // when not armed), then signal the GPE worker that block `bId` has started. The

--- a/comms/ctran/algos/common/GpeRing.h
+++ b/comms/ctran/algos/common/GpeRing.h
@@ -3,9 +3,11 @@
 #ifndef CTRAN_GPE_RING_H_
 #define CTRAN_GPE_RING_H_
 
+#include <cstddef>
 #include <cstdint>
 
 #include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
 #include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
 namespace ctran::gpe {
@@ -41,19 +43,39 @@ using GpeRingHandle = hrdw_ring_buffer::
 // KernelStartGpe prologue reads it via KernelFlagDev::gpeHdr and publishes
 // cmdId to the ring.
 struct GpeKernelFlagHeader {
-  GpeRingHandle ring{};
+  // NOTE: the scalar fields are intentionally placed BEFORE the embedded ring
+  // handle. That handle uses [[no_unique_address]] empty members; when it is
+  // the first member, nvcc computes a different device offset for a following
+  // scalar than the host does (placing it past the end of the object), so a
+  // kernel reads cmdId/enabled back as garbage -- e.g. a nonzero `enabled` on
+  // an unarmed header, which drives KernelPublishGpeRing to write to a null
+  // ring and hang/crash the kernel. Keeping the scalars in the head bytes keeps
+  // the host and device offsets in agreement. Same workaround as
+  // meta::comms::colltrace::ColltraceDeviceHandle.
   GpeCmdId cmdId{0};
   uint32_t enabled{0};
+  GpeRingHandle ring{};
 };
+static_assert(
+    offsetof(GpeKernelFlagHeader, cmdId) <
+            offsetof(GpeKernelFlagHeader, ring) &&
+        offsetof(GpeKernelFlagHeader, enabled) <
+            offsetof(GpeKernelFlagHeader, ring),
+    "GpeKernelFlagHeader scalars (cmdId/enabled) must precede the ring handle "
+    "to keep host/device offsetof in agreement; see the note above.");
 
 // Device-facing view of a per-cmd kernel flag object: the per-block start/stop
-// flags plus the ring header, laid out in pinned host memory. Every GPE kernel
-// takes a KernelFlagDev* as its first argument and reads gpeHdr directly — no
-// pointer-offset recovery. KernelFlagItem (host) embeds this as its first
-// member, so &kernelFlag->dev is the pointer handed to the kernel.
+// flags plus the ring headers, laid out in pinned host memory. Every GPE kernel
+// takes a KernelFlagDev* as its first argument and reads gpeHdr/colltraceHdr
+// directly — no pointer-offset recovery. KernelFlagItem (host) embeds this as
+// its first member, so &kernelFlag->dev is the pointer handed to the kernel.
+// colltraceHdr is armed host-side at submit() for the kernels that bound a
+// logical collective; a default (null-ring) handle means unarmed, so the
+// in-kernel emit no-ops. See meta::comms::colltrace::ColltraceDeviceHandle.
 struct KernelFlagDev {
   volatile int flag_[CTRAN_ALGO_MAX_THREAD_BLOCKS];
   GpeKernelFlagHeader gpeHdr{};
+  meta::comms::colltrace::ColltraceDeviceHandle colltraceHdr{};
 };
 
 } // namespace ctran::gpe

--- a/comms/ctran/algos/common/tests/ColltraceEventScopeTest.cc
+++ b/comms/ctran/algos/common/tests/ColltraceEventScopeTest.cc
@@ -1,0 +1,96 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Unit test for ColltraceEventScope: the RAII scope must emit exactly the armed
+// start/end colltrace events into the HRDW ring, elected to a single writer
+// regardless of block/thread count, and be a no-op when unarmed.
+
+#include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
+#include "comms/utils/colltrace/GraphCollTraceEvent.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
+
+using meta::comms::colltrace::ColltraceDeviceHandle;
+using meta::comms::colltrace::GraphCollTraceEvent;
+using meta::comms::colltrace::GraphCollTracePhase;
+
+// Defined in ColltraceEventScopeTest.cu.
+void launchColltraceScopeKernel(
+    const ColltraceDeviceHandle& handle,
+    int blocks,
+    int threads,
+    cudaStream_t stream);
+
+namespace {
+
+// Runs one ColltraceEventScope with the given emit flags across blocks*threads
+// threads, then returns the events written to the ring in write order.
+std::vector<GraphCollTraceEvent> runScope(
+    bool emitStart,
+    bool emitEnd,
+    uint32_t collId,
+    int blocks,
+    int threads) {
+  hrdw_ring_buffer::HRDWRingBuffer<GraphCollTraceEvent> buf(/*capacity=*/64);
+  EXPECT_TRUE(buf.valid());
+
+  ColltraceDeviceHandle handle{};
+  handle.collId = collId;
+  handle.emitStart = emitStart;
+  handle.emitEnd = emitEnd;
+  handle.ring = buf.deviceHandle();
+
+  cudaStream_t stream = nullptr;
+  EXPECT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+  launchColltraceScopeKernel(handle, blocks, threads, stream);
+  EXPECT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  EXPECT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+
+  std::vector<GraphCollTraceEvent> events;
+  hrdw_ring_buffer::HRDWRingBufferReader<GraphCollTraceEvent> reader(buf);
+  reader.poll([&](const auto& entry, uint64_t /*slot*/) {
+    events.push_back(entry.data);
+  });
+  return events;
+}
+
+TEST(ColltraceEventScopeTest, EmitsStartThenEndSingleWriter) {
+  // 64 threads all construct the scope, but the emit is elected to one writer,
+  // so exactly one start and one end land in the ring.
+  auto events =
+      runScope(/*emitStart=*/true, /*emitEnd=*/true, /*collId=*/42, 2, 32);
+  ASSERT_EQ(events.size(), 2u);
+  EXPECT_EQ(events[0].phase, GraphCollTracePhase::kStart);
+  EXPECT_EQ(events[0].collId, 42u);
+  EXPECT_EQ(events[1].phase, GraphCollTracePhase::kEnd);
+  EXPECT_EQ(events[1].collId, 42u);
+}
+
+TEST(ColltraceEventScopeTest, StartOnly) {
+  auto events =
+      runScope(/*emitStart=*/true, /*emitEnd=*/false, /*collId=*/7, 1, 1);
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].phase, GraphCollTracePhase::kStart);
+  EXPECT_EQ(events[0].collId, 7u);
+}
+
+TEST(ColltraceEventScopeTest, EndOnly) {
+  auto events =
+      runScope(/*emitStart=*/false, /*emitEnd=*/true, /*collId=*/8, 1, 1);
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].phase, GraphCollTracePhase::kEnd);
+  EXPECT_EQ(events[0].collId, 8u);
+}
+
+TEST(ColltraceEventScopeTest, UnarmedIsNoOp) {
+  auto events =
+      runScope(/*emitStart=*/false, /*emitEnd=*/false, /*collId=*/9, 4, 64);
+  EXPECT_TRUE(events.empty());
+}
+
+} // namespace

--- a/comms/ctran/algos/common/tests/ColltraceEventScopeTest.cu
+++ b/comms/ctran/algos/common/tests/ColltraceEventScopeTest.cu
@@ -1,0 +1,22 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda_runtime.h>
+
+#include "comms/ctran/algos/common/ColltraceEventScope.cuh"
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
+
+// Every thread constructs the scope; ColltraceEventScope elects a single writer
+// (block 0, thread 0) internally, emitting the start on construction and the
+// end on destruction into the armed handle's ring.
+__global__ void colltraceScopeKernel(
+    meta::comms::colltrace::ColltraceDeviceHandle handle) {
+  ctran::device::ColltraceEventScope scope(handle);
+}
+
+void launchColltraceScopeKernel(
+    const meta::comms::colltrace::ColltraceDeviceHandle& handle,
+    int blocks,
+    int threads,
+    cudaStream_t stream) {
+  colltraceScopeKernel<<<blocks, threads, 0, stream>>>(handle);
+}

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -315,6 +315,18 @@ struct KernelConfig {
   // launched on a single GPE thread.
   bool canConcurrent{false};
 
+  // In-kernel colltrace: on the graph-capture path (sm_90+), the collective
+  // kernel writes its own start/end timestamps into the colltrace ring so one
+  // logical collective maps to one CollTrace record. A single-kernel collective
+  // emits both boundaries (the defaults). A multi-kernel collective (e.g. the
+  // AllGatherP pipeline) sets these per kernel: the begin kernel emits the
+  // start and opens the record, interior kernels emit neither (and reuse the
+  // record), and the end kernel emits the end. A kernel owns the record iff it
+  // emits the start; interior/end kernels reuse the begin kernel's. Off the
+  // in-kernel path (eager, pre-sm_90, HIP) these are ignored.
+  bool colltraceEmitStart{true};
+  bool colltraceEmitEnd{true};
+
  public:
   KernelConfig(
       enum KernelType type,

--- a/comms/ctran/gpe/CtranGpeColltrace.h
+++ b/comms/ctran/gpe/CtranGpeColltrace.h
@@ -72,10 +72,6 @@ inline void armInKernelColltrace(
       devHandle.emitStart = true;
       devHandle.emitEnd = emitEnd;
       flagDev.colltraceHdr = devHandle;
-      // Tell this collective's graph wait event it self-emits, so it skips the
-      // host-launched timestamp path (the two must never both write the ring).
-      // TEMPORARY: the host path is deleted at the in-kernel cutover.
-      colltraceHandle->markInKernelEmit();
       if (!emitEnd) {
         // Multi-kernel begin: the End kernel reuses the same ring/collId.
         pendingGroup = devHandle;
@@ -88,11 +84,6 @@ inline void armInKernelColltrace(
     // the Begin and emit only the end.
     if (pendingGroup.valid()) {
       flagDev.colltraceHdr = pendingGroup;
-      // TEMPORARY (removed at the in-kernel cutover): keep the host path off
-      // for the End kernel's wait event too, if it has one.
-      if (colltraceHandle) {
-        colltraceHandle->markInKernelEmit();
-      }
     }
     // The group is closed once its End is armed; clear it so a later unrelated
     // End (a Begin whose End was dropped, then this collective's End) can never

--- a/comms/ctran/gpe/CtranGpeColltrace.h
+++ b/comms/ctran/gpe/CtranGpeColltrace.h
@@ -1,0 +1,105 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <mutex>
+
+#include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
+
+#include "comms/ctran/algos/common/GpeRing.h" // ctran::gpe::KernelFlagDev
+#include "comms/utils/colltrace/CollTraceHandle.h" // ICollTraceHandle
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h" // ColltraceDeviceHandle
+
+namespace ctran::gpe {
+
+// In-kernel colltrace (the collective kernel publishing its own start/end
+// timestamps into the colltrace ring) requires sm_90+ for the ring's 128b
+// atomic device write — the same hardware requirement as the GPE device ring,
+// but determined independently of it. The compute capability is queried once
+// per process (call_once); NCCL pins one device per process, so a single cached
+// value is correct.
+inline bool inKernelColltraceSupported() {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_HCC__)
+  return false;
+#else
+  static std::once_flag onceFlag;
+  static int ccMajor = -1; // -1 = unknown/query failed
+  std::call_once(onceFlag, [] {
+    int dev = 0;
+    int major = 0;
+    if (cudaGetDevice(&dev) == cudaSuccess &&
+        cudaDeviceGetAttribute(
+            &major, cudaDevAttrComputeCapabilityMajor, dev) == cudaSuccess) {
+      ccMajor = major;
+    }
+  });
+  return ccMajor >= 9;
+#endif
+}
+
+// Arm a kernel flag for in-kernel colltrace start/end emission and maintain the
+// cross-submit grouping state (`pendingGroup`) for multi-kernel collectives.
+//
+// A multi-kernel collective (e.g. AllGatherP's PipeStart..PipeSync..PipeEnd)
+// records one CollTrace event: its Begin kernel writes the start and stashes
+// the device handle (ring + collId) in `pendingGroup`, and its End kernel
+// reuses that handle to write the end. A single-kernel collective arms both
+// boundaries on the same kernel; interior kernels emit neither and leave
+// `pendingGroup` untouched.
+//
+// Precondition: the caller has already gated on inKernelColltraceSupported()
+// and a live kernel flag. `colltraceHandle` may be null (no record was
+// created).
+inline void armInKernelColltrace(
+    meta::comms::colltrace::ColltraceDeviceHandle& pendingGroup,
+    KernelFlagDev& flagDev,
+    meta::comms::colltrace::ICollTraceHandle* colltraceHandle,
+    bool emitStart,
+    bool emitEnd) {
+  if (emitStart) {
+    // Begin (or single-kernel) collective: this kernel opens the record and
+    // writes the start. Drop any pending group left behind by a Begin whose End
+    // was never submitted (early-return, exception, or a future non-contiguous
+    // algo path), so a stale collId can never be consumed by a later unrelated
+    // End.
+    pendingGroup = {};
+    auto devHandle = colltraceHandle
+        ? colltraceHandle->getColltraceDeviceHandle()
+        : meta::comms::colltrace::ColltraceDeviceHandle{};
+    if (devHandle.valid()) {
+      // A single-kernel collective also emits the end here (emitEnd == true); a
+      // multi-kernel begin hands the end to the group's End kernel below.
+      devHandle.emitStart = true;
+      devHandle.emitEnd = emitEnd;
+      flagDev.colltraceHdr = devHandle;
+      // Tell this collective's graph wait event it self-emits, so it skips the
+      // host-launched timestamp path (the two must never both write the ring).
+      // TEMPORARY: the host path is deleted at the in-kernel cutover.
+      colltraceHandle->markInKernelEmit();
+      if (!emitEnd) {
+        // Multi-kernel begin: the End kernel reuses the same ring/collId.
+        pendingGroup = devHandle;
+        pendingGroup.emitStart = false;
+        pendingGroup.emitEnd = true;
+      }
+    }
+  } else if (emitEnd) {
+    // End kernel of a multi-kernel collective: reuse the ring/collId stashed by
+    // the Begin and emit only the end.
+    if (pendingGroup.valid()) {
+      flagDev.colltraceHdr = pendingGroup;
+      // TEMPORARY (removed at the in-kernel cutover): keep the host path off
+      // for the End kernel's wait event too, if it has one.
+      if (colltraceHandle) {
+        colltraceHandle->markInKernelEmit();
+      }
+    }
+    // The group is closed once its End is armed; clear it so a later unrelated
+    // End (a Begin whose End was dropped, then this collective's End) can never
+    // consume this collective's stale collId.
+    pendingGroup = {};
+  }
+  // Otherwise (interior kernel: no emit) there is nothing to arm.
+}
+
+} // namespace ctran::gpe

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <atomic>
 #include <chrono>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 
@@ -12,6 +14,7 @@
 #include "comms/ctran/colltrace/MapperTrace.h"
 #include "comms/ctran/gpe/CtranChecksum.h"
 #include "comms/ctran/gpe/CtranGpe.h"
+#include "comms/ctran/gpe/CtranGpeColltrace.h"
 #include "comms/ctran/gpe/CtranGpeDev.h"
 #include "comms/ctran/gpe/CtranGpeImpl.h"
 #include "comms/ctran/mapper/CtranMapper.h"
@@ -22,6 +25,7 @@
 #include "comms/ctran/utils/ExtUtils.h"
 
 #include "comms/utils/colltrace/CollRecord.h"
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 
@@ -146,6 +150,20 @@ commResult_t CtranGpe::Impl::submit(
           kernelConfig.stream, streamCaptureInfo));
   bool isCapturing = streamCaptureInfo.status == cudaStreamCaptureStatusActive;
 
+  // Only graph tracing on sm_90+ creates the ring consumed by the kernel.
+  const bool useInKernelColltrace = ctran::gpe::inKernelColltraceSupported() &&
+      isCapturing && NCCL_COLLTRACE_TRACE_CUDA_GRAPH;
+  // Single-kernel collectives emit both boundaries (the KernelConfig defaults);
+  // multi-kernel collectives (the AllGatherP pipeline) set these per kernel.
+  const bool colltraceEmitStart =
+      useInKernelColltrace && kernelConfig.colltraceEmitStart;
+  const bool colltraceEmitEnd =
+      useInKernelColltrace && kernelConfig.colltraceEmitEnd;
+  // Multi-kernel graph collectives create one record at their start boundary.
+  const bool colltraceCreatesRecord = !isCapturing || colltraceEmitStart;
+  // Boundary-only kernels still need a flag to carry colltraceHdr.
+  const bool colltraceNeedsFlag = colltraceEmitStart || colltraceEmitEnd;
+
   // For eager (non-capture) submits with empty opGroup but a
   // postKernelCleanup, we still need a cmd + kernelFlag so the GPE thread
   // can synchronize with the kernel before running cleanup. During graph
@@ -153,7 +171,13 @@ commResult_t CtranGpe::Impl::submit(
   // retainUserObject, avoiding host-node overhead.
   bool needsKernelFlag = !opGroup.empty() ||
       kernelConfig.unpackPool != nullptr ||
-      (kernelConfig.postKernelCleanup && !isCapturing);
+      (kernelConfig.postKernelCleanup && !isCapturing) || colltraceNeedsFlag;
+
+  // A boundary-only kernel never signals KERNEL_STARTED; retain its flag on
+  // the graph instead of routing it through the GPE worker.
+  const bool colltraceOnlyFlag = isCapturing && needsKernelFlag &&
+      opGroup.empty() && func == nullptr &&
+      kernelConfig.unpackPool == nullptr && !kernelConfig.postKernelCleanup;
 
   auto kernelFlag = needsKernelFlag ? this->kernelFlagPool->pop() : nullptr;
   ctran::gpe::KernelFlagDev* flagDev = nullptr;
@@ -196,8 +220,23 @@ commResult_t CtranGpe::Impl::submit(
   }
 
   // Record CollTrace event. Must be called before moving opGroup to cmd
-  auto colltraceHandle = meta::comms::colltrace::getCollTraceHandle(
-      comm, opGroup, kernelConfig, ifchecksum);
+  std::shared_ptr<meta::comms::colltrace::ICollTraceHandle> colltraceHandle =
+      colltraceCreatesRecord ? meta::comms::colltrace::getCollTraceHandle(
+                                   comm, opGroup, kernelConfig, ifchecksum)
+                             : nullptr;
+
+  // Arm the collective kernel to publish its own start/end timestamps into the
+  // colltrace ring, replacing the host-launched timestamp kernels for the
+  // grouped/self-timing pipeline collective. The header defaults to disabled
+  // (cleared on flag recycle), so kernels that emit nothing fall through.
+  if (useInKernelColltrace && kernelFlag != nullptr) {
+    ctran::gpe::armInKernelColltrace(
+        pendingColltraceGroup_,
+        kernelFlag->dev,
+        colltraceHandle.get(),
+        colltraceEmitStart,
+        colltraceEmitEnd);
+  }
 
   cudaStream_t launchStream = kernelConfig.stream;
   std::optional<ctran::algos::OrderedWorkStreamGuard::Scope> wsScope;
@@ -221,7 +260,7 @@ commResult_t CtranGpe::Impl::submit(
   size_t opGroupSize = 0;
   // Enqueue op to gpeThread if any op is appended, or if there is a
   // postKernelCleanup that needs to run after the kernel completes.
-  if (needsKernelFlag) {
+  if (needsKernelFlag && !colltraceOnlyFlag) {
     // record opGroup size before moving the object
     opGroupSize = opGroup.size();
     class CtranGpeCmd* cmd = new class CtranGpeCmd;
@@ -286,6 +325,26 @@ commResult_t CtranGpe::Impl::submit(
     }
   } else {
     FB_COMMCHECK(maybeAcquireWorkStreamScope());
+  }
+
+  // Colltrace-only graph flag: no GPE cmd is created (the kernel does no GPE
+  // work and never signals the flag), so retain the armed flag on the graph and
+  // reclaim it on destroy — clearPersistent()+reset() makes it reclaimable by
+  // the pool, mirroring what ~CtranGpeCmd does for the cmd path.
+  if (colltraceOnlyFlag) {
+    kernelFlag->setPersistent();
+    FB_COMMCHECKGOTO(
+        utils::cudagraph::retainUserObject(
+            /*obj=*/kernelFlag,
+            /*destroyCallback=*/
+            [](void* p) {
+              auto* f = static_cast<KernelFlagItem*>(p);
+              f->clearPersistent();
+              f->reset();
+            },
+            streamCaptureInfo),
+        res,
+        fail);
   }
 
   // For the no-cmd path during graph capture, retain cleanup on the graph.
@@ -474,6 +533,10 @@ fail:
   if (kernelFlag != nullptr) {
     kernelFlag->reset();
   }
+  // A failure after arming a Begin would leave an open colltrace group whose
+  // End never submits; clear it so a later collective's End can't consume this
+  // collective's stale collId.
+  pendingColltraceGroup_ = {};
   return res;
 }
 
@@ -574,6 +637,9 @@ void CtranGpe::Impl::start() {
 }
 
 void CtranGpe::Impl::terminate() {
+  // Let the worker's kernel-start waits (gpeThreadFn) bail out so a cmd whose
+  // kernel never launches cannot block join() forever.
+  terminating_.store(true, std::memory_order_relaxed);
   class CtranGpeCmd* cmd = new class CtranGpeCmd;
   cmd->type = CtranGpeCmd::TypeEnum::TERMINATE;
 
@@ -733,9 +799,11 @@ void CtranGpe::Impl::gpeThreadFn() {
         volatile int* flag_d = kernelFlag->dev.flag_;
         // Here we check just flag_d[0]. This is ok because Kernel Start signal
         // is only used for tracing purposes. Before the flags are freed below
-        // with reset, all block flags are checked.
+        // with reset, all block flags are checked. Bail out on terminate() so a
+        // cmd whose kernel never launches cannot wedge teardown.
         while (flag_d[0] != KERNEL_STARTED &&
-               flag_d[0] != KERNEL_STARTED_AND_EXIT) {
+               flag_d[0] != KERNEL_STARTED_AND_EXIT &&
+               !terminating_.load(std::memory_order_relaxed)) {
           std::this_thread::yield();
         }
       }

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -3,6 +3,7 @@
 #ifndef CTRAN_GPE_IMPL_H_
 #define CTRAN_GPE_IMPL_H_
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstddef>
@@ -41,9 +42,10 @@ struct alignas(128) KernelFlagItem {
     for (int i = 0; i < numGroups_; i++) {
       dev.flag_[i] = KERNEL_UNSET;
     }
-    // Clear the full ring header so enabled==1 always implies ring/cmdId are
-    // current; submit() re-arms it per-cmd on the ring path.
+    // Clear the full ring + colltrace headers (not just enabled) so a stale
+    // ring/cmdId/collId can never be published; submit() re-arms them per-cmd.
     dev.gpeHdr = {};
+    dev.colltraceHdr = {};
   }
 
   bool inUse() {
@@ -63,9 +65,10 @@ struct alignas(128) KernelFlagItem {
       dev.flag_[i] = KERNEL_SCHEDULED;
     }
     numGroups_ = 1;
-    // Clear the full ring header (not just enabled) so a stale ring/cmdId can
-    // never be published; submit() re-arms it per-cmd on the ring path.
+    // Clear the full ring + colltrace headers (not just enabled) so a stale
+    // ring/cmdId/collId can never be published; submit() re-arms them per-cmd.
     dev.gpeHdr = {};
+    dev.colltraceHdr = {};
   }
 
   bool testFlagAllGroups(int flag) {
@@ -282,6 +285,9 @@ class CtranGpe::Impl {
   folly::Synchronized<CmdQueue, std::mutex> cmdQueue_;
   std::condition_variable cmdQueueCv_;
   std::thread thread_;
+  // Set by terminate() so the worker's kernel-start waits bail out during
+  // teardown instead of blocking forever on a cmd whose kernel never launches.
+  std::atomic<bool> terminating_{false};
   ctran::algos::OrderedWorkStreamGuard ws_;
 
   // Device-ring dispatch state (NCCL_CTRAN_GPE_DEVICE_RING). Ring + reader are
@@ -291,6 +297,16 @@ class CtranGpe::Impl {
   std::unique_ptr<ctran::gpe::GpeRingReader> deviceRingReader_;
   std::queue<CtranGpeCmd*> ringPending_;
   GpeDeviceRingCmdRegistry deviceRingCmdRegistry_;
+
+  // In-kernel colltrace grouping: a multi-submit collective (e.g. AllGatherP's
+  // PipeStart..PipeSync..PipeEnd) records one CollTrace event whose start is
+  // written by the group's Begin kernel and end by its End kernel. Begin
+  // stashes the device handle (ring + collId) here so the following End submit
+  // arms its kernel with the same collId. A default (null-ring, !valid())
+  // handle means no group is open. Written and read only on the submit
+  // (capture) thread, and a group's submits are always contiguous, so a single
+  // pending slot suffices.
+  meta::comms::colltrace::ColltraceDeviceHandle pendingColltraceGroup_{};
 
   // Main function called by the GPE thread. It waits and handles any  commands
   // submitted to cmdQueue until the TERMINATE command is received.

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphColltraceTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphColltraceTest.cc
@@ -11,6 +11,7 @@
 #include "comms/ctran/regcache/RegCache.h"
 #include "comms/ctran/tests/cudagraph/CtranCudaGraphTestBase.h"
 #include "comms/utils/CudaRAII.h"
+#include "comms/utils/colltrace/CollTrace.h"
 
 namespace {
 
@@ -30,10 +31,12 @@ class CtranCudaGraphColltraceTest : public CtranCudaGraphTestBase {
         ctran::CtranEnvs{
             {"NCCL_COLLTRACE", "trace"},
             {"NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "true"},
-            // In-kernel device write is off by default until the cutover diff,
-            // so enable it explicitly to exercise the in-kernel colltrace path.
-            {"NCCLX_COLLTRACE_DEVICE_WRITE", "true"},
         });
+    if (!meta::comms::colltrace::graphColltraceSupported(
+            "CtranCudaGraphColltraceTest")) {
+      GTEST_SKIP() << "graph colltrace unsupported on this device/driver "
+                      "(needs sm_90+ and a CUDA driver outside 13.0-13.2)";
+    }
   }
 
   // Warms the collective eagerly (establishes transport connections and gives a

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphColltraceTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphColltraceTest.cc
@@ -1,0 +1,290 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <functional>
+#include <string>
+
+#include <folly/json.h>
+
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
+#include "comms/ctran/algos/ReduceScatter/ReduceScatterImpl.h"
+#include "comms/ctran/regcache/RegCache.h"
+#include "comms/ctran/tests/cudagraph/CtranCudaGraphTestBase.h"
+#include "comms/utils/CudaRAII.h"
+
+namespace {
+
+// Exercises the in-kernel colltrace emit path end-to-end: a real collective is
+// captured into a CUDA graph and replayed, and we assert colltrace produced
+// exactly one start/end pair per replay. This is the coverage the synthetic
+// graph_colltrace_ut misses -- that unit test drives the ring directly, so it
+// never catches an algo whose end event is not armed (which leaves the
+// collective stuck mid-flight and hangs the drain).
+class CtranCudaGraphColltraceTest : public CtranCudaGraphTestBase {
+ protected:
+  void SetUp() override {
+    // Enable graph-mode colltrace tracing. In-kernel emit is the only graph
+    // timestamp path and is gated on sm_90+ in the GPE; on older archs
+    // graph-captured collectives are not colltrace-timestamped.
+    CtranDistTestFixture::SetUp(
+        ctran::CtranEnvs{
+            {"NCCL_COLLTRACE", "trace"},
+            {"NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "true"},
+            // In-kernel device write is off by default until the cutover diff,
+            // so enable it explicitly to exercise the in-kernel colltrace path.
+            {"NCCLX_COLLTRACE_DEVICE_WRITE", "true"},
+        });
+  }
+
+  // Warms the collective eagerly (establishes transport connections and gives a
+  // stable colltrace baseline), then captures it once and replays it
+  // `numReplays` times under one CUDA graph on a single stream. Asserts that:
+  //   - colltrace fully drains (nothing left in CT_currentColls) -- a missing
+  //     end event would leave a collective mid-flight and time out the drain;
+  //   - exactly one past record is produced per replay;
+  //   - every new record names the expected collective.
+  void runGraphColltraceCheck(
+      CtranComm* comm,
+      int numReplays,
+      const std::string& expectedOpName,
+      const std::function<void(cudaStream_t)>& launch) {
+    meta::comms::CudaStream stream(cudaStreamNonBlocking);
+
+    auto flushAndDump = [&]() {
+      if (comm->colltraceNew_ != nullptr) {
+        comm->colltraceNew_->waitFlush(comm->colltraceNew_->requestFlush());
+      }
+      return ctran::waitForCollTraceDrain(comm);
+    };
+
+    // Eager warmup + baseline.
+    launch(stream.get());
+    CUDACHECK_TEST(cudaStreamSynchronize(stream.get()));
+    auto baseline = flushAndDump();
+    ASSERT_EQ(baseline["CT_currentColls"], "[]") << "warmup collective never "
+                                                    "drained";
+    const int baseCount = folly::parseJson(baseline["CT_pastColls"]).size();
+
+    // Capture the collective once.
+    cudaGraph_t graph = nullptr;
+    cudaGraphExec_t graphExec = nullptr;
+    ASSERT_EQ(
+        cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeRelaxed),
+        cudaSuccess);
+    launch(stream.get());
+    ASSERT_EQ(cudaStreamEndCapture(stream.get(), &graph), cudaSuccess);
+    ASSERT_NE(graph, nullptr);
+    ASSERT_EQ(
+        cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0),
+        cudaSuccess);
+
+    // Replay N times on one stream so completions are ordered.
+    for (int i = 0; i < numReplays; ++i) {
+      ASSERT_EQ(cudaGraphLaunch(graphExec, stream.get()), cudaSuccess);
+    }
+    ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+    auto dump = flushAndDump();
+    EXPECT_EQ(dump["CT_currentColls"], "[]")
+        << "a replayed collective never completed -- missing colltrace end "
+           "event for "
+        << expectedOpName;
+    EXPECT_EQ(dump["CT_pendingColls"], "[]");
+
+    auto past = folly::parseJson(dump["CT_pastColls"]);
+    EXPECT_EQ(static_cast<int>(past.size()) - baseCount, numReplays)
+        << "expected exactly one colltrace record per graph replay";
+    for (int i = baseCount; i < static_cast<int>(past.size()); ++i) {
+      EXPECT_EQ(past[i]["opName"].asString(), expectedOpName);
+    }
+
+    CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+    CUDACHECK_TEST(cudaGraphDestroy(graph));
+    waitAndVerifyGpeClean(comm);
+  }
+};
+
+constexpr int kNumReplays = 5;
+constexpr size_t kCount = 1024;
+
+TEST_F(CtranCudaGraphColltraceTest, AllGatherOneRecordPerReplay) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+  const auto algo = NCCL_ALLGATHER_ALGO::ctran;
+  if (!ctranAllGatherSupport(comm.get(), algo)) {
+    GTEST_SKIP() << "AllGather not supported on this topology";
+  }
+
+  ctran::TestDeviceBuffer send(kCount * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(kCount * numRanks * sizeof(int32_t));
+  fillSendBuf(send.get(), kCount, globalRank);
+
+  runGraphColltraceCheck(
+      comm.get(), kNumReplays, "AllGather", [&](cudaStream_t s) {
+        ASSERT_EQ(
+            ctranAllGather(
+                send.get(), recv.get(), kCount, commInt32, comm.get(), s, algo),
+            commSuccess);
+      });
+}
+
+TEST_F(CtranCudaGraphColltraceTest, AllReduceOneRecordPerReplay) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+  const auto algo = NCCL_ALLREDUCE_ALGO::ctran;
+  if (!ctranAllReduceSupport(comm.get(), algo)) {
+    GTEST_SKIP() << "AllReduce not supported on this topology";
+  }
+
+  ctran::TestDeviceBuffer send(kCount * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(kCount * sizeof(int32_t));
+  fillSendBuf(send.get(), kCount, globalRank);
+
+  runGraphColltraceCheck(
+      comm.get(), kNumReplays, "AllReduce", [&](cudaStream_t s) {
+        ASSERT_EQ(
+            ctranAllReduce(
+                send.get(),
+                recv.get(),
+                kCount,
+                commInt32,
+                commSum,
+                comm.get(),
+                s,
+                algo),
+            commSuccess);
+      });
+}
+
+TEST_F(CtranCudaGraphColltraceTest, ReduceScatterOneRecordPerReplay) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+  const auto algo = NCCL_REDUCESCATTER_ALGO::ctran;
+  if (!ctranReduceScatterSupport(comm.get(), algo)) {
+    GTEST_SKIP() << "ReduceScatter not supported on this topology";
+  }
+
+  ctran::TestDeviceBuffer send(kCount * numRanks * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(kCount * sizeof(int32_t));
+  fillSendBuf(send.get(), kCount * numRanks, globalRank);
+
+  runGraphColltraceCheck(
+      comm.get(), kNumReplays, "ReduceScatter", [&](cudaStream_t s) {
+        ASSERT_EQ(
+            ctranReduceScatter(
+                send.get(),
+                recv.get(),
+                kCount,
+                commInt32,
+                commSum,
+                comm.get(),
+                s,
+                algo),
+            commSuccess);
+      });
+}
+
+// AllGatherP `ctpipeline` is the only path that uses the multi-kernel colltrace
+// grouping (PipeStart=kBegin, PipeSync=kInner, PipeEnd=kEnd); every other
+// collective is a single kSolo kernel. This asserts the grouping collapses the
+// whole pipeline to exactly ONE colltrace record per graph replay (not one per
+// pipe stage, and not zero from a dropped end). ctgraph_pipeline requires an
+// intra-node NVL domain (nLocalRanks > 1) and a registered recvbuf, and is only
+// used during capture (eager warmup uses the direct ctran algo).
+TEST_F(CtranCudaGraphColltraceTest, AllGatherPPipelineOneRecordPerReplay) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+  if (!ctran::allGatherPSupport(comm.get()) ||
+      comm->statex_.get()->nLocalRanks() <= 1) {
+    GTEST_SKIP() << "AllGatherP ctpipeline requires nLocalRanks > 1";
+  }
+
+  ctran::TestDeviceBuffer send(kCount * sizeof(int32_t));
+  ctran::TestDeviceBuffer recv(kCount * numRanks * sizeof(int32_t));
+  fillSendBuf(send.get(), kCount, globalRank);
+
+  // The graph AGP path requires the recvbuf segment cached in the regcache;
+  // keep it registered until after the graph is destroyed below.
+  const size_t recvBytes = kCount * numRanks * sizeof(int32_t);
+  ctran::RegCache::getInstance()->globalRegister(
+      recv.get(), recvBytes, /*forceReg=*/true);
+
+  meta::comms::CudaStream stream(cudaStreamNonBlocking);
+  auto launch = [&](cudaStream_t s, enum NCCL_ALLGATHER_ALGO algo) {
+    ASSERT_EQ(
+        ctranAllGather(
+            send.get(), recv.get(), kCount, commInt32, comm.get(), s, algo),
+        commSuccess);
+  };
+  // Count only "AllGatherP" records (ignoring the one-time "AllGatherP_Init"
+  // and the direct-warmup "AllGather"), after draining colltrace.
+  auto countAllGatherP = [&]() -> int {
+    if (comm->colltraceNew_ != nullptr) {
+      comm->colltraceNew_->waitFlush(comm->colltraceNew_->requestFlush());
+    }
+    auto d = ctran::waitForCollTraceDrain(comm.get());
+    EXPECT_EQ(d["CT_currentColls"], "[]");
+    int n = 0;
+    for (const auto& rec : folly::parseJson(d["CT_pastColls"])) {
+      if (rec["opName"].asString() == "AllGatherP") {
+        ++n;
+      }
+    }
+    return n;
+  };
+
+  // Eager warmup on the direct algo, then capture the pipeline algo once.
+  launch(stream.get(), NCCL_ALLGATHER_ALGO::ctran);
+  CUDACHECK_TEST(cudaStreamSynchronize(stream.get()));
+
+  cudaGraph_t graph = nullptr;
+  cudaGraphExec_t graphExec = nullptr;
+  ASSERT_EQ(
+      cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeRelaxed),
+      cudaSuccess);
+  launch(stream.get(), NCCL_ALLGATHER_ALGO::ctgraph_pipeline);
+  ASSERT_EQ(cudaStreamEndCapture(stream.get(), &graph), cudaSuccess);
+  ASSERT_NE(graph, nullptr);
+  ASSERT_EQ(
+      cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0),
+      cudaSuccess);
+
+  const int before = countAllGatherP();
+  for (int i = 0; i < kNumReplays; ++i) {
+    ASSERT_EQ(cudaGraphLaunch(graphExec, stream.get()), cudaSuccess);
+  }
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+  const int after = countAllGatherP();
+
+  EXPECT_EQ(after - before, kNumReplays)
+      << "AllGatherP ctpipeline should emit exactly one colltrace record per "
+         "replay (one logical collective via kBegin/kInner/kEnd grouping, not "
+         "one per pipe stage): before="
+      << before << " after=" << after;
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  waitAndVerifyGpeClean(comm.get());
+  ctran::RegCache::getInstance()->globalDeregister(recv.get(), recvBytes);
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new CtranCudaGraphEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/baseline_modification_docs/inkernel_colltrace_baseline.md
+++ b/comms/ncclx/meta/baseline_modification_docs/inkernel_colltrace_baseline.md
@@ -1,0 +1,155 @@
+# In-kernel colltrace emit for baseline collectives: Baseline Modifications
+
+## Background
+
+The colltrace graph watchdog (and graph-mode colltrace tracing generally) times
+graph-captured collectives by reading per-collective `kStart`/`kEnd` timestamps
+that the collective **kernel** publishes into a shared HRDW ring at replay. Only
+ctran GPE kernels emitted these timestamps (via
+`ctran::device::ColltraceEventScope`); baseline NCCL collectives (the `orig`
+algorithm path) did not, so a graph-captured baseline collective registered a
+`collId` on the host (`recordGraphCollectiveImpl`) but the ring stayed empty and
+the watchdog had nothing to observe.
+
+The host-side colltrace machinery is already backend-agnostic:
+
+- Registration + `collId` assignment for a graph-captured collective happens in
+  `collTraceBaselineGetHandle` → `getHandleFromNcclKernelPlan` →
+  `CollTrace::recordGraphCollectiveImpl` — shared with ctran.
+- `CollTrace::pollGraphEvents` reads `kStart`/`kEnd` from the ring keyed on
+  `collId`, agnostic to which kernel wrote them.
+- `ICollTraceHandle::getColltraceDeviceHandle()` already returns the armed,
+  ring-backed `ColltraceDeviceHandle` (ring + `collId`) on the graph path and an
+  unarmed `{}` otherwise.
+
+So the only missing piece for baseline was the **device-side write** plus arming
+the per-launch handle onto the kernel args. The device writer itself is shared:
+the generic `meta::comms::colltrace::ColltraceEventScope` lives in
+`comms/utils/colltrace/ColltraceEventScope.cuh` (ctran's
+`ctran::device::ColltraceEventScope` is a thin subclass adding a `KernelFlagDev`
+overload).
+
+## Versions Affected
+
+v2.29, v2.30
+
+## Baseline Files Modified
+
+Three baseline files per version, each a tagged, minimal hook. All logic lives in
+the Meta helper `ncclx::colltrace::armNcclInKernelColltrace`
+(`meta/colltrace/CollTraceWrapper.{h,cc}`), which is version-agnostic.
+
+1. `src/include/device.h` — one field on the per-launch arg struct plus its
+   include:
+   ```cpp
+   // [META] In-kernel colltrace gate, defined here and used by every
+   // colltraceHdr reference so the struct has one layout across all TUs.
+   #if !defined(NCCLX_NO_INKERNEL_COLLTRACE) && \
+       !(CUDART_VERSION >= 13000 && CUDART_VERSION < 13030)
+   #define NCCLX_INKERNEL_COLLTRACE 1
+   #endif
+
+   #ifdef NCCLX_INKERNEL_COLLTRACE
+   #include "comms/utils/colltrace/ColltraceDeviceHandle.h"
+   #endif
+   ...
+   struct alignas(16) ncclDevKernelArgs {
+     ...
+     void* workBuf;
+     // [META] ... armed host-side in armNcclInKernelColltrace() ...
+   #ifdef NCCLX_INKERNEL_COLLTRACE
+     meta::comms::colltrace::ColltraceDeviceHandle colltraceHdr;
+   #endif
+     // struct ncclDevWorkBatch batches[];  // trailing inline region
+   };
+   ```
+   The handle is the **last fixed field**, so the trailing inline work-batch /
+   work region (located at `kernelArgs+1` and via `batch.offsetBase`, both
+   `sizeof(ncclDevKernelArgs)`-relative on host and device) stays consistent.
+   `ColltraceDeviceHandle` is a trivially-copyable aggregate, so the word-by-word
+   arg→shmem copy in `ncclKernelMain` carries it correctly.
+
+2. `src/device/common.h` — one RAII scope in the single generic kernel
+   `ncclKernelMain`, right after the prologue publishes `ncclShmem`:
+   ```cpp
+   // [META] in-kernel colltrace ...
+   #ifdef NCCLX_INKERNEL_COLLTRACE
+   meta::comms::colltrace::ColltraceDeviceEventScope colltraceScope(
+       ncclShmem.args.colltraceHdr);
+   #endif
+   ```
+   ctor emits `kStart`; dtor emits `kEnd` at kernel exit. One scope covers
+   **every** baseline collective, since they all funnel through `ncclKernelMain`.
+   An unarmed handle makes it a no-op (single-writer election is block0/thread0).
+
+3. `src/enqueue.cc` — one tagged call in `ncclLaunchKernel`, next to the existing
+   `collTraceBaselineGetHandle` injection:
+   ```cpp
+   ncclx::colltrace::armNcclInKernelColltrace(
+       plan, colltraceHandle.get(), comm->compCap);
+   ```
+   This writes the ring/`collId` into `plan->kernelArgs->colltraceHdr` just
+   before `cuLaunchKernelEx`, so the `collId` assigned at capture is baked into
+   the graph node and re-emitted on every replay. The helper is a no-op unless a
+   graph is being captured (`getColltraceDeviceHandle().valid()`) on an sm_90+
+   device (the ring's 128b atomic requirement); symmetric-memory kernels use a
+   different arg layout and are skipped.
+
+## Platform gating: CUDA only
+
+`device.h` defines a single gate macro, `NCCLX_INKERNEL_COLLTRACE`, and all
+three touch points test it with `#ifdef`. It is left undefined when
+`NCCLX_NO_INKERNEL_COLLTRACE` is set, which `device_object`'s
+`propagated_pp_flags` does on `ovr_config//gpu:amd`
+(`comms/ncclx/nccl_build_config.bzl`). The same `select` also drops
+`colltrace_device_handle` from that target's `exported_deps`, so on AMD the
+header is neither included nor on the include path.
+
+It is also left undefined on CUDA 13.0-13.2, where an nvcc
+`[[no_unique_address]]` device-layout bug (fixed in 13.3) misaligns the
+`args->__shared__` copy of `ncclDevKernelArgs`; any kernel launch carrying those
+args then faults with `cudaErrorMisalignedAddress` (seen as "Failed to allocate
+barrier buffer: misaligned address" in the torchcomms integration tests). The
+guard lives in the same commit that adds the field, so no point in the stack
+builds a `colltraceHdr` that the toolchain will mislay.
+
+Two reasons for the AMD case:
+
+- **It cannot work on AMD.** The ring publishes a slot with `atom.exch.b128`
+  inline PTX, which has no HIP equivalent —
+  `HrdwRingBufferWriter::write` compiles to a trap under `__HIPCC__`, and
+  `comms/utils/hrdw_ring_buffer/BUCK` already states AMD "will fail at
+  compile/link time when actually exercised".
+- **It breaks the AMD build if left in.** `colltrace_device_handle` reaches
+  `//comms/utils:hrdw_ring_buffer`, a `gpu_cpp_library`, so on AMD hipify
+  rewrites that target's `<cuda_runtime.h>` into `<hip/hip_runtime.h>`. ncclx is
+  never hipified — under `mode/*-amd-gpu` it still compiles with `nvcc` — so its
+  `nccl.h` keeps the real CUDA runtime. Any consumer including `collectives.h`
+  then gets CUDA's and HIP's vector types in one TU and fails with ~20 `typedef
+  redefinition` errors (first seen in `comms/utils/tests:comm_specs_test`).
+  Before this change ncclx's public headers never reached a hipified header: the
+  handle was only ever a `shared_ptr<ICollTraceHandle>` used inside `.cc` files,
+  and a pointer to an abstract type needs no layout. Embedding the handle
+  by value is what put it on the exported header path.
+
+The flag is propagated from the same target and the same `select` as the dep so
+no consumer can disagree about whether `colltraceHdr` exists — a mismatch would
+silently change `ncclDevKernelArgs`'s layout between TUs.
+
+## Why in baseline
+
+The three touch points are structurally forced:
+
+- The `collId` is per-collective and must be baked into each graph node's arg
+  bytes at capture, so it must live in the per-launch `ncclDevKernelArgs` (a
+  comm-level slot would be overwritten by the next captured collective) — hence
+  the `device.h` field.
+- The emit must run inside the collective kernel, and `ncclKernelMain` is the one
+  generic entry every baseline collective shares — hence the `common.h` line.
+- The arm must happen at the launch site where `plan->kernelArgs` is baked into
+  the graph node — hence the `enqueue.cc` call, placed beside the existing
+  colltrace injection.
+
+All heavy logic is in the Meta helper; the baseline edits are a field, a scope,
+and a call, each `[META]`-tagged. No `CollTrace.cc` / `CollTraceWrapper` handle
+or poll changes were needed — baseline reuses the ctran path end to end.

--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
@@ -402,6 +402,16 @@ getMetadataFromNcclKernelPlan(ncclKernelPlan& plan, cudaStream_t stream) {
       planInfo.p2pType == KernelPlanType::none) {
     XLOG_FIRST_N(
         ERR, 3, "CollTrace: No coll or p2p task in the NCCL Kenrel Plan!");
+    if (isCapturingStream(stream)) {
+      // Deadlock safety: a graph-captured plan with no coll/p2p task has no
+      // kernel that will publish a start/end timestamp into the graph ring, so
+      // registering a graph colltrace record for it would never complete and
+      // would hang the poll thread on drain. Skip it --
+      // getHandleFromNcclKernelPlan falls back to a DummyCollTraceHandle.
+      // (Eager empty-task tracing, which completes normally on the stream, is
+      // unaffected.)
+      return nullptr;
+    }
     return getEmptyKernelTaskMetadata(plan, planInfo, stream);
   }
 
@@ -445,7 +455,7 @@ getHandleFromNcclKernelPlan(ncclKernelPlan& plan, cudaStream_t stream) {
 
   if (res.hasError()) {
     XLOG_FIRST_N(
-        ERR, 5, "Failed to get colltrace handle due to: ", res.error().message);
+        ERR, 1, "Failed to get colltrace handle due to: ", res.error().message);
     return std::make_unique<meta::comms::colltrace::DummyCollTraceHandle>();
   }
   return res.value();
@@ -551,10 +561,47 @@ std::optional<AlgoInfo> parseAlgoInfoFromNcclKernelPlan(ncclKernelPlan& plan) {
   };
 }
 
+void armNcclInKernelColltrace(
+    [[maybe_unused]] ncclKernelPlan& plan,
+    [[maybe_unused]] const std::shared_ptr<
+        meta::comms::colltrace::ICollTraceHandle>& handle,
+    [[maybe_unused]] int compCap) {
+  // `colltraceHdr` only exists when the in-kernel colltrace gate in device.h
+  // is on; arming is a no-op otherwise.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+  // Symmetric-memory kernels use a different arg layout; skip them.
+  if (plan.isSymColl || plan.kernelArgs == nullptr || handle == nullptr) {
+    return;
+  }
+  // Default to unarmed so the in-kernel scope is a no-op off the graph path.
+  plan.kernelArgs->colltraceHdr = {};
+  // The ring's 128b atomic write requires sm_90+; getColltraceDeviceHandle()
+  // returns a ring-backed handle only while capturing a CUDA graph.
+  if (compCap < 90) {
+    return;
+  }
+  auto devHandle = handle->getColltraceDeviceHandle();
+  if (!devHandle.valid()) {
+    return;
+  }
+  // Single-kernel baseline collective: emit both boundaries on this kernel.
+  devHandle.emitStart = true;
+  devHandle.emitEnd = true;
+  plan.kernelArgs->colltraceHdr = devHandle;
+  // Tell the graph wait event this collective self-emits so it skips the
+  // host-launched timestamp path (they must never both write the ring).
+  // TEMPORARY: the host path is deleted at the in-kernel cutover.
+  handle->markInKernelEmit();
+#endif
+}
+
 } // namespace
 
 std::shared_ptr<meta::comms::colltrace::ICollTraceHandle>
-collTraceBaselineGetHandle(ncclKernelPlan* plan, cudaStream_t stream) {
+prepareNcclKernelColltrace(
+    ncclKernelPlan* plan,
+    cudaStream_t stream,
+    int compCap) {
   if (plan->comm->algoStats) {
     auto algoInfo = parseAlgoInfoFromNcclKernelPlan(*plan);
     if (algoInfo.has_value()) {
@@ -563,9 +610,12 @@ collTraceBaselineGetHandle(ncclKernelPlan* plan, cudaStream_t stream) {
     }
   }
 
-  if (NCCL_COLLTRACE.empty()) {
-    return std::make_unique<meta::comms::colltrace::DummyCollTraceHandle>();
-  }
-  return meta::comms::ncclx::getHandleFromNcclKernelPlan(*plan, stream);
+  auto handle = NCCL_COLLTRACE.empty()
+      ? std::shared_ptr<
+            meta::comms::colltrace::ICollTraceHandle>{std::make_unique<
+            meta::comms::colltrace::DummyCollTraceHandle>()}
+      : meta::comms::ncclx::getHandleFromNcclKernelPlan(*plan, stream);
+  armNcclInKernelColltrace(*plan, handle, compCap);
+  return handle;
 }
 } // namespace ncclx::colltrace

--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
@@ -588,10 +588,6 @@ void armNcclInKernelColltrace(
   devHandle.emitStart = true;
   devHandle.emitEnd = true;
   plan.kernelArgs->colltraceHdr = devHandle;
-  // Tell the graph wait event this collective self-emits so it skips the
-  // host-launched timestamp path (they must never both write the ring).
-  // TEMPORARY: the host path is deleted at the in-kernel cutover.
-  handle->markInKernelEmit();
 #endif
 }
 

--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.h
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.h
@@ -28,6 +28,9 @@ std::unordered_map<std::string, std::string> collTraceGetInfo();
 namespace ncclx::colltrace {
 
 std::shared_ptr<meta::comms::colltrace::ICollTraceHandle>
-collTraceBaselineGetHandle(ncclKernelPlan* plan, cudaStream_t stream);
+prepareNcclKernelColltrace(
+    ncclKernelPlan* plan,
+    cudaStream_t stream,
+    int compCap);
 
 } // namespace ncclx::colltrace

--- a/comms/ncclx/meta/colltrace/tests/BaselineCudaGraphColltraceTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/BaselineCudaGraphColltraceTest.cc
@@ -1,0 +1,173 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <chrono>
+#include <functional>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+#include <folly/init/Init.h>
+#include <folly/json/json.h>
+#include <gtest/gtest.h>
+
+#include "comm.h" // @manual
+#include "nccl.h" // @manual
+
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/testinfra/TestUtils.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/commDump.h"
+
+namespace {
+
+// Baseline (orig NCCL, non-ctran) analog of CtranCudaGraphColltraceTest:
+// capture a real collective into a CUDA graph, replay it, and assert baseline
+// colltrace produced exactly one start/end pair per replay via the in-kernel
+// emit path. The synthetic graph_colltrace_ut drives the ring directly, so it
+// never catches a baseline kernel whose end event is not armed -- which would
+// leave the collective stuck mid-flight and hang the drain. In-kernel emit is
+// the only graph timestamp path and is gated on sm_90+; on older archs
+// graph-captured collectives are not colltrace-timestamped.
+class BaselineCudaGraphColltraceTest : public NcclxBaseTestFixture {
+ protected:
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp({
+        {"WORLD_SIZE", "4"},
+        {"NCCL_COLLTRACE", "trace"},
+        {"NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "true"},
+        // In-kernel device write is off by default until the cutover diff, so
+        // enable it explicitly to exercise the in-kernel colltrace path.
+        {"NCCLX_COLLTRACE_DEVICE_WRITE", "true"},
+    });
+    CUDACHECK_TEST(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaStreamDestroy(stream_));
+    if (sendBuf_ != nullptr) {
+      CUDACHECK_TEST(cudaFree(sendBuf_));
+    }
+    if (recvBuf_ != nullptr) {
+      CUDACHECK_TEST(cudaFree(recvBuf_));
+    }
+    NcclxBaseTestFixture::TearDown();
+  }
+
+  std::unordered_map<std::string, std::string> flushAndDump(ncclComm_t comm) {
+    EXPECT_NE(comm->newCollTrace, nullptr);
+    if (comm->newCollTrace == nullptr) {
+      return {};
+    }
+    comm->newCollTrace->waitFlush(comm->newCollTrace->requestFlush());
+    EXPECT_TRUE(meta::comms::ncclx::waitForCollTraceDrain(*comm->newCollTrace));
+    return meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
+  }
+
+  // Warms the collective eagerly (establishes transport connections and a
+  // stable colltrace baseline), captures it once, and replays it `numReplays`
+  // times under one CUDA graph on a single stream. Asserts colltrace fully
+  // drains (nothing left mid-flight) and produces exactly one past record per
+  // replay.
+  void runGraphColltraceCheck(
+      ncclComm_t comm,
+      int numReplays,
+      const std::string& expectedOpName,
+      const std::function<void(cudaStream_t)>& launch) {
+    // Eager warmup + baseline record count.
+    launch(stream_);
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+    auto baseline = flushAndDump(comm);
+    ASSERT_EQ(baseline["CT_currentColls"], "[]") << "warmup never drained";
+    const int baseCount =
+        static_cast<int>(folly::parseJson(baseline["CT_pastColls"]).size());
+
+    // Capture the collective once.
+    cudaGraph_t graph = nullptr;
+    cudaGraphExec_t graphExec = nullptr;
+    ASSERT_EQ(
+        cudaStreamBeginCapture(stream_, cudaStreamCaptureModeRelaxed),
+        cudaSuccess);
+    launch(stream_);
+    ASSERT_EQ(cudaStreamEndCapture(stream_, &graph), cudaSuccess);
+    ASSERT_NE(graph, nullptr);
+    ASSERT_EQ(
+        cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0),
+        cudaSuccess);
+
+    // Replay N times on one stream so completions are ordered.
+    for (int i = 0; i < numReplays; ++i) {
+      ASSERT_EQ(cudaGraphLaunch(graphExec, stream_), cudaSuccess);
+    }
+    ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+    auto dump = flushAndDump(comm);
+    EXPECT_EQ(dump["CT_currentColls"], "[]")
+        << "a replayed collective never completed -- missing colltrace end "
+           "event for "
+        << expectedOpName;
+    EXPECT_EQ(dump["CT_pendingColls"], "[]");
+
+    auto past = folly::parseJson(dump["CT_pastColls"]);
+    EXPECT_EQ(static_cast<int>(past.size()) - baseCount, numReplays)
+        << "expected exactly one colltrace record per graph replay for "
+        << expectedOpName;
+
+    CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+    CUDACHECK_TEST(cudaGraphDestroy(graph));
+  }
+
+  cudaStream_t stream_{};
+  int* sendBuf_{nullptr};
+  int* recvBuf_{nullptr};
+};
+
+constexpr int kNumReplays = 5;
+constexpr int kCount = 1024;
+
+TEST_F(BaselineCudaGraphColltraceTest, AllReduceOneRecordPerReplay) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  // Force the baseline (orig NCCL) AllReduce kernel path, not ctran.
+  auto algoGuard = EnvRAII(NCCL_ALLREDUCE_ALGO, NCCL_ALLREDUCE_ALGO::orig);
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
+  ASSERT_TRUE(comm->newCollTrace != nullptr);
+
+  CUDACHECK_TEST(cudaMalloc(&sendBuf_, kCount * sizeof(int)));
+  CUDACHECK_TEST(cudaMalloc(&recvBuf_, kCount * sizeof(int)));
+
+  runGraphColltraceCheck(comm, kNumReplays, "AllReduce", [&](cudaStream_t s) {
+    NCCLCHECK_TEST(
+        ncclAllReduce(sendBuf_, recvBuf_, kCount, ncclInt, ncclSum, comm, s));
+  });
+}
+
+TEST_F(BaselineCudaGraphColltraceTest, AllGatherOneRecordPerReplay) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "needs >= 2 ranks";
+  }
+  // Force the baseline (orig NCCL) AllGather kernel path, not ctran.
+  auto algoGuard = EnvRAII(NCCL_ALLGATHER_ALGO, NCCL_ALLGATHER_ALGO::orig);
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
+  ASSERT_TRUE(comm->newCollTrace != nullptr);
+
+  CUDACHECK_TEST(cudaMalloc(&sendBuf_, kCount * sizeof(int)));
+  CUDACHECK_TEST(cudaMalloc(&recvBuf_, kCount * numRanks * sizeof(int)));
+
+  runGraphColltraceCheck(comm, kNumReplays, "AllGather", [&](cudaStream_t s) {
+    NCCLCHECK_TEST(ncclAllGather(sendBuf_, recvBuf_, kCount, ncclInt, comm, s));
+  });
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/colltrace/tests/BaselineCudaGraphColltraceTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/BaselineCudaGraphColltraceTest.cc
@@ -17,6 +17,7 @@
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/colltrace/CollTrace.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/commDump.h"
 
@@ -37,11 +38,15 @@ class BaselineCudaGraphColltraceTest : public NcclxBaseTestFixture {
         {"WORLD_SIZE", "4"},
         {"NCCL_COLLTRACE", "trace"},
         {"NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "true"},
-        // In-kernel device write is off by default until the cutover diff, so
-        // enable it explicitly to exercise the in-kernel colltrace path.
-        {"NCCLX_COLLTRACE_DEVICE_WRITE", "true"},
     });
+    // Create the stream before any skip: TearDown() destroys stream_
+    // unconditionally, and GTEST_SKIP() in SetUp() still runs TearDown().
     CUDACHECK_TEST(cudaStreamCreate(&stream_));
+    if (!meta::comms::colltrace::graphColltraceSupported(
+            "BaselineCudaGraphColltraceTest")) {
+      GTEST_SKIP() << "graph colltrace unsupported on this device/driver "
+                      "(needs sm_90+ and a CUDA driver outside 13.0-13.2)";
+    }
   }
 
   void TearDown() override {

--- a/comms/ncclx/v2_29/src/device/common.h
+++ b/comms/ncclx/v2_29/src/device/common.h
@@ -13,6 +13,11 @@
 #include "op128.h"
 #include "reduce_kernel.h"
 #include "network/unpack/unpack_defs.h"
+// [META] in-kernel colltrace emit in ncclKernelMain below; gate defined in
+// device.h, included above.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+#include "comms/utils/colltrace/ColltraceDeviceEventScope.cuh"
+#endif
 
 #define COLL_UNROLL (ncclCollUnroll())
 
@@ -390,6 +395,15 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
     } break;
   }
   __syncthreads(); // publish ncclShmem
+
+  // [META] in-kernel colltrace: emit a graph-ring kStart now and a kEnd when
+  // this scope leaves at kernel exit. Unarmed (non-graph / pre-sm_90) handles
+  // make this a no-op. One scope here covers every baseline collective, since
+  // they all funnel through ncclKernelMain.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+  meta::comms::colltrace::ColltraceDeviceEventScope colltraceScope(
+      ncclShmem.args.colltraceHdr);
+#endif
 
   while (ncclShmem.aborted == 0) {
     profiler(START);

--- a/comms/ncclx/v2_29/src/enqueue.cc
+++ b/comms/ncclx/v2_29/src/enqueue.cc
@@ -1740,9 +1740,9 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
     CU_LAUNCH_PARAM_BUFFER_SIZE, &plan->kernelArgsSize,
     CU_LAUNCH_PARAM_END
   };
-  // CollTrace Injected code here
-  auto colltraceHandle = ncclx::colltrace::collTraceBaselineGetHandle(plan, launchStream);
-
+  // [META] Colltrace handle creation and in-kernel graph timestamp arming.
+  auto colltraceHandle = ncclx::colltrace::prepareNcclKernelColltrace(
+      plan, launchStream, comm->compCap);
 
   int driverVersion;
   NCCLCHECKGOTO(ncclCudaDriverVersion(&driverVersion), ret, do_return);

--- a/comms/ncclx/v2_29/src/include/device.h
+++ b/comms/ncclx/v2_29/src/include/device.h
@@ -12,6 +12,23 @@
 #include "nccl_device/core.h"
 #include "nccl_tuner.h"
 #include "bitops.h"
+// [META] In-kernel colltrace gate. Defined here, and used by every reference to
+// colltraceHdr (see common.h and CollTraceWrapper.cc), so ncclDevKernelArgs has
+// one layout across all TUs. Compiled out when either:
+//   - AMD: see the note on device_object's exported_deps in
+//     comms/ncclx/nccl_build_config.bzl.
+//   - CUDA 13.0-13.2: an nvcc [[no_unique_address]] device-layout bug (fixed in
+//     13.3) misaligns the args->__shared__ copy of ncclDevKernelArgs, so any
+//     kernel launch carrying these args faults with cudaErrorMisalignedAddress.
+//     CUDART_VERSION comes from nccl.h above.
+#if !defined(NCCLX_NO_INKERNEL_COLLTRACE) && \
+    !(CUDART_VERSION >= 13000 && CUDART_VERSION < 13030)
+#define NCCLX_INKERNEL_COLLTRACE 1
+#endif
+
+#ifdef NCCLX_INKERNEL_COLLTRACE
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
+#endif
 #include <algorithm>
 #include <stdint.h>
 #include <sys/types.h>
@@ -474,6 +491,14 @@ struct alignas(16) ncclDevKernelArgs {
   enum ncclDevWorkStorageType workStorageType;
   uint32_t workMask;
   void* workBuf;
+  // [META] in-kernel colltrace graph timestamp handle (ring + collId + emit
+  // flags), armed host-side in armNcclInKernelColltrace() only on the
+  // CUDA-graph path (unarmed = no-op). Kept as the last fixed field so the
+  // trailing inline work-batch region stays sizeof(ncclDevKernelArgs)-relative
+  // on both host and device.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+  meta::comms::colltrace::ColltraceDeviceHandle colltraceHdr;
+#endif
   // A channel's first batch is at `blockIdx.x`. Use `nextJump` to follow rest of list.
   // struct ncclDevWorkBatch batches[];
 };

--- a/comms/ncclx/v2_30/src/device/common.h
+++ b/comms/ncclx/v2_30/src/device/common.h
@@ -13,6 +13,11 @@
 #include "op128.h"
 #include "reduce_kernel.h"
 #include "network/unpack/unpack_defs.h"
+// [META] in-kernel colltrace emit in ncclKernelMain below; gate defined in
+// device.h, included above.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+#include "comms/utils/colltrace/ColltraceDeviceEventScope.cuh"
+#endif
 
 #define COLL_UNROLL (ncclCollUnroll())
 
@@ -395,6 +400,15 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
     } break;
   }
   __syncthreads(); // publish ncclShmem
+
+  // [META] in-kernel colltrace: emit a graph-ring kStart now and a kEnd when
+  // this scope leaves at kernel exit. Unarmed (non-graph / pre-sm_90) handles
+  // make this a no-op. One scope here covers every baseline collective, since
+  // they all funnel through ncclKernelMain.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+  meta::comms::colltrace::ColltraceDeviceEventScope colltraceScope(
+      ncclShmem.args.colltraceHdr);
+#endif
 
   while (ncclShmem.aborted == 0) {
     profiler(START);

--- a/comms/ncclx/v2_30/src/enqueue.cc
+++ b/comms/ncclx/v2_30/src/enqueue.cc
@@ -1744,9 +1744,9 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
     CU_LAUNCH_PARAM_BUFFER_SIZE, &plan->kernelArgsSize,
     CU_LAUNCH_PARAM_END
   };
-  // CollTrace Injected code here
-  auto colltraceHandle = ncclx::colltrace::collTraceBaselineGetHandle(plan, launchStream);
-
+  // [META] Colltrace handle creation and in-kernel graph timestamp arming.
+  auto colltraceHandle = ncclx::colltrace::prepareNcclKernelColltrace(
+      plan, launchStream, comm->compCap);
 
   int driverVersion;
   NCCLCHECKGOTO(ncclCudaDriverVersion(&driverVersion), ret, do_return);

--- a/comms/ncclx/v2_30/src/include/device.h
+++ b/comms/ncclx/v2_30/src/include/device.h
@@ -12,6 +12,23 @@
 #include "nccl_device/core.h"
 #include "nccl_tuner.h"
 #include "bitops.h"
+// [META] In-kernel colltrace gate. Defined here, and used by every reference to
+// colltraceHdr (see common.h and CollTraceWrapper.cc), so ncclDevKernelArgs has
+// one layout across all TUs. Compiled out when either:
+//   - AMD: see the note on device_object's exported_deps in
+//     comms/ncclx/nccl_build_config.bzl.
+//   - CUDA 13.0-13.2: an nvcc [[no_unique_address]] device-layout bug (fixed in
+//     13.3) misaligns the args->__shared__ copy of ncclDevKernelArgs, so any
+//     kernel launch carrying these args faults with cudaErrorMisalignedAddress.
+//     CUDART_VERSION comes from nccl.h above.
+#if !defined(NCCLX_NO_INKERNEL_COLLTRACE) && \
+    !(CUDART_VERSION >= 13000 && CUDART_VERSION < 13030)
+#define NCCLX_INKERNEL_COLLTRACE 1
+#endif
+
+#ifdef NCCLX_INKERNEL_COLLTRACE
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
+#endif
 #include <algorithm>
 #include <stdint.h>
 #include <sys/types.h>
@@ -477,6 +494,14 @@ struct alignas(16) ncclDevKernelArgs {
   enum ncclDevWorkStorageType workStorageType;
   uint32_t workMask;
   void* workBuf;
+  // [META] in-kernel colltrace graph timestamp handle (ring + collId + emit
+  // flags), armed host-side in armNcclInKernelColltrace() only on the
+  // CUDA-graph path (unarmed = no-op). Kept as the last fixed field so the
+  // trailing inline work-batch region stays sizeof(ncclDevKernelArgs)-relative
+  // on both host and device.
+#ifdef NCCLX_INKERNEL_COLLTRACE
+  meta::comms::colltrace::ColltraceDeviceHandle colltraceHdr;
+#endif
   // A channel's first batch is at `blockIdx.x`. Use `nextJump` to follow rest of list.
   // struct ncclDevWorkBatch batches[];
 };

--- a/comms/torchcomms/ncclx/tests/integration/cpp/ColltraceGraphWatchdogTest.cpp
+++ b/comms/torchcomms/ncclx/tests/integration/cpp/ColltraceGraphWatchdogTest.cpp
@@ -25,6 +25,7 @@
 #include "comms/torchcomms/TorchComm.hpp"
 #include "comms/torchcomms/TorchCommOptions.hpp"
 #include "comms/torchcomms/ncclx/TorchCommNCCLX.hpp"
+#include "comms/utils/colltrace/CollTrace.h"
 
 class ColltraceGraphWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
                                    public ::testing::Test {
@@ -56,6 +57,14 @@ class ColltraceGraphWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
                         (tmpDir_.path() / "logfile%p").string()),
                 },
         });
+    // The watchdog observes graph-captured collectives through colltrace's
+    // in-kernel timestamps. Where that is unavailable no graph record is ever
+    // created, so no replay can time out and there is nothing to assert.
+    if (!meta::comms::colltrace::graphColltraceSupported(
+            "ColltraceGraphWatchdogTest")) {
+      GTEST_SKIP() << "graph colltrace unsupported on this device/driver "
+                      "(needs sm_90+ and a CUDA driver outside 13.0-13.2)";
+    }
   }
 
   folly::test::TemporaryDirectory tmpDir_{

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -37,7 +37,60 @@ void
   delete sp;
 }
 
+// Why graph colltrace cannot run here, or empty if it can. Both inputs are
+// fixed for the process -- the driver version is per-process, and the compute
+// capability is read from the current device, which assumes a homogeneous-GPU
+// host (true across the fleet; a mixed sm_80/sm_90 host would get whichever
+// device was current on the first call). So this is computed exactly once.
+// The lambda captures nothing on purpose: a static whose initializer reads a
+// function argument would bind the first caller's value forever, which is both
+// a dangling-reference hazard and a clang-tidy
+// facebook-hte-ContextDependentStaticInit violation. The caller's log prefix is
+// applied at log time instead.
+const std::string& graphColltraceUnsupportedReason() {
+  static const std::string reason = [] {
+    int device = 0;
+    int ccMajor = 0;
+    if (cudaGetDevice(&device) != cudaSuccess ||
+        cudaDeviceGetAttribute(
+            &ccMajor, cudaDevAttrComputeCapabilityMajor, device) !=
+            cudaSuccess) {
+      return std::string{
+          "could not query device compute capability; graph collectives will "
+          "be untimed."};
+    }
+    if (ccMajor < 9) {
+      return fmt::format(
+          "device {} compute capability major {} < 9 (in-kernel ring write "
+          "requires sm_90); graph collectives will be untimed.",
+          device,
+          ccMajor);
+    }
+    int driverVersion = 0;
+    if (cudaDriverGetVersion(&driverVersion) == cudaSuccess &&
+        driverVersion >= 13000 && driverVersion < 13030) {
+      return fmt::format(
+          "CUDA driver {} is in 13.0-13.2, which miscompiles the device "
+          "ring-write handle; graph collectives will be untimed. Please use a "
+          "compatible version if you want colltrace graph support.",
+          driverVersion);
+    }
+    return std::string{};
+  }();
+  return reason;
+}
+
 } // namespace
+
+bool graphColltraceSupported(std::string_view logPrefix) {
+  const auto& reason = graphColltraceUnsupportedReason();
+  if (reason.empty()) {
+    return true;
+  }
+  XLOG_FIRST_N(WARNING, 1) << logPrefix << ": graph colltrace disabled -- "
+                           << reason;
+  return false;
+}
 
 template <auto Method>
 void triggerPlugins(
@@ -74,7 +127,7 @@ CollTrace::CollTrace(
           folly::MPMCQueue<std::unique_ptr<CollTraceEvent>>{
               config_.maxPendingQueueSize}),
       plugins_(std::move(plugins)) {
-  if (NCCL_COLLTRACE_TRACE_CUDA_GRAPH) {
+  if (NCCL_COLLTRACE_TRACE_CUDA_GRAPH && graphColltraceSupported(logPrefix_)) {
     // Eagerly initialize the globaltimer calibration singleton now (outside
     // graph capture) so it is ready when GraphCudaWaitEvent is constructed
     // during capture.

--- a/comms/utils/colltrace/CollTrace.h
+++ b/comms/utils/colltrace/CollTrace.h
@@ -6,6 +6,7 @@
 #include <latch>
 #include <mutex>
 #include <set>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
@@ -30,6 +31,20 @@ namespace meta::comms::colltrace {
 struct GraphCollTraceState;
 struct GraphCollectiveEntry;
 class GraphCudaWaitEvent;
+
+// Whether graph-captured collectives can be timed on the *current* device.
+// Requires both a compute capability of sm_90+ (the ring's 128b System-scope
+// atomic) and a CUDA driver outside [13.0, 13.2] (that range miscompiles the
+// device-side ColltraceDeviceHandle layout -- a [[no_unique_address]] bug fixed
+// in 13.3; cuda-compat's 13.3 driver on a 13.1 build is fine). When false the
+// collective kernel never publishes start/end timestamps, so graph colltrace is
+// disabled outright and the ring is never allocated -- that preserves the
+// deadlock-safety invariant that a graph colltrace record only exists when its
+// kernel will emit, since an unemitted record can never complete and would hang
+// the poll thread on drain. Both inputs are fixed for the process, so the
+// verdict is computed once and cached (this assumes a homogeneous-GPU host).
+// Exposed so tests can skip on hosts where graph timing cannot work.
+bool graphColltraceSupported(std::string_view logPrefix);
 
 struct CollTraceConfig {
   static constexpr ::size_t kDefaultMaxPendingQueueSize{1024};

--- a/comms/utils/colltrace/CollTraceHandle.h
+++ b/comms/utils/colltrace/CollTraceHandle.h
@@ -46,14 +46,6 @@ class ICollTraceHandle {
   virtual ColltraceDeviceHandle getColltraceDeviceHandle() noexcept {
     return {};
   }
-
-  // Mark that this collective's kernel is armed to publish its own start/end
-  // timestamps from inside the kernel, so the host-launched timestamp path is
-  // skipped (they must never both write the ring). No-op except on the graph
-  // handle. Called by the GPE / baseline arming code during submit, before the
-  // launch triggers beforeCollKernelScheduled(). TEMPORARY: removed together
-  // with the host-launched path at the in-kernel cutover.
-  virtual void markInKernelEmit() noexcept {}
 };
 
 // Handle to be returned to the user for triggering stages for the collective.

--- a/comms/utils/colltrace/GraphCollTraceHandle.h
+++ b/comms/utils/colltrace/GraphCollTraceHandle.h
@@ -60,13 +60,6 @@ class GraphCollTraceHandle : public ICollTraceHandle {
   }
 
   ColltraceDeviceHandle getColltraceDeviceHandle() noexcept override {
-    // Killswitch: when NCCLX_COLLTRACE_DEVICE_WRITE is off, hand out no device
-    // ring handle, so neither the ctran nor the baseline arming path arms the
-    // kernel (both gate on valid()). This is the single gate for the in-kernel
-    // device-write across all backends.
-    if (!colltraceDeviceWriteEnabled()) {
-      return {};
-    }
     auto* graphWaitEvent = graphWaitEvent_();
     if (graphWaitEvent == nullptr || !graphWaitEvent->hasRingBuffer()) {
       return {};
@@ -80,24 +73,6 @@ class GraphCollTraceHandle : public ICollTraceHandle {
         .emitStart = false,
         .emitEnd = false,
         .ring = graphWaitEvent->deviceHandle()};
-  }
-
-  // TEMPORARY (removed at the in-kernel cutover): forward the "kernel
-  // self-emits" signal to the wait event so it skips the host-launched
-  // timestamp path.
-  void markInKernelEmit() noexcept override {
-    // Gate identically to getColltraceDeviceHandle(): only mark the wait event
-    // as self-emitting when the killswitch is on and a ring is attached, so we
-    // never skip the host-launched fallback for a kernel that isn't actually
-    // armed to self-emit.
-    if (!colltraceDeviceWriteEnabled()) {
-      return;
-    }
-    auto* graphWaitEvent = graphWaitEvent_();
-    if (graphWaitEvent == nullptr || !graphWaitEvent->hasRingBuffer()) {
-      return;
-    }
-    graphWaitEvent->markInKernelEmit();
   }
 
  private:

--- a/comms/utils/colltrace/GraphCudaWaitEvent.cc
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.cc
@@ -2,50 +2,21 @@
 
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 
-#include <cstring>
-
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
 
 #include <folly/Unit.h>
 #include <folly/logging/xlog.h>
 
-#include "comms/utils/CudaRAII.h"
 #include "comms/utils/PrecisionClock.h"
 #include "comms/utils/checks.h"
-#include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
 namespace meta::comms::colltrace {
 
-bool colltraceDeviceWriteEnabled() noexcept {
-  return NCCLX_COLLTRACE_DEVICE_WRITE;
-}
-
 GraphCudaWaitEvent::GraphCudaWaitEvent(cudaStream_t stream, uint32_t collId)
-    : stream_(stream), collId_(collId), enqueueTime_(precisionNow()) {
-  // Per-collective CUDA resources for the host-launched timestamp fallback,
-  // created in relaxed capture mode so they don't disturb the in-progress graph
-  // capture. TEMPORARY: removed together with the host path at the in-kernel
-  // cutover.
-  StreamCaptureModeGuard guard{cudaStreamCaptureModeRelaxed};
-  CUDA_CHECK(cudaStreamCreate(&timestampStream_));
-  CUDA_CHECK(cudaEventCreateWithFlags(&depEvent_, cudaEventDisableTiming));
-}
+    : stream_(stream), collId_(collId), enqueueTime_(precisionNow()) {}
 
-GraphCudaWaitEvent::~GraphCudaWaitEvent() {
-  if (timestampStream_) {
-    CUDA_CHECK_WITH_IGNORE(
-        cudaStreamDestroy(timestampStream_),
-        cudaErrorCudartUnloading,
-        cudaErrorContextIsDestroyed);
-  }
-  if (depEvent_) {
-    CUDA_CHECK_WITH_IGNORE(
-        cudaEventDestroy(depEvent_),
-        cudaErrorCudartUnloading,
-        cudaErrorContextIsDestroyed);
-  }
-}
+GraphCudaWaitEvent::~GraphCudaWaitEvent() = default;
 
 void GraphCudaWaitEvent::attachRingBuffer(
     ::hrdw_ring_buffer::HRDWRingBuffer<GraphCollTraceEvent>*
@@ -54,91 +25,24 @@ void GraphCudaWaitEvent::attachRingBuffer(
 }
 
 CommsMaybeVoid GraphCudaWaitEvent::beforeCollKernelScheduled() noexcept {
-  if (inKernelEmit_) {
-    // The collective kernel publishes its own start timestamp into the ring
-    // from inside the kernel, so there is nothing to schedule on the host.
-    return folly::unit;
+  // The collective kernel publishes its own start timestamp into the ring from
+  // inside the kernel, so there is nothing to schedule on the host. If no ring
+  // was attached, the kernel emits nothing and there is no host-launched
+  // fallback (removed at the in-kernel cutover), so this graph-captured
+  // collective goes untimed. Warn a few times so that silent timing loss is
+  // detectable rather than invisible, without spamming the log per collective.
+  if (ringBuffer_ == nullptr) {
+    XLOG_FIRST_N(WARNING, 8)
+        << "GraphCudaWaitEvent: no in-kernel colltrace ring attached (collId="
+        << collId_
+        << "); graph-captured collective timing is unavailable on this device.";
   }
-  // Host-launched fallback (kernel not armed to self-emit, e.g. pre-sm90 or a
-  // not-yet-migrated collective). Fork: collective stream -> timestamp stream
-  // so the start kernel is captured into the graph, with a dependency on the
-  // main stream's current position (right before the collective launches).
-  CUDA_CHECK_EXPECTED(cudaEventRecord(depEvent_, stream_));
-  CUDA_CHECK_EXPECTED(cudaStreamWaitEvent(timestampStream_, depEvent_));
-
-  // Launch the start timestamp kernel on this collective's timestamp stream.
-  CUDA_CHECK_EXPECTED(ringBuffer_->write(
-      timestampStream_,
-      GraphCollTraceEvent{collId_, GraphCollTracePhase::kStart}));
-
   return folly::unit;
 }
 
 CommsMaybeVoid GraphCudaWaitEvent::afterCollKernelScheduled() noexcept {
-  if (inKernelEmit_) {
-    // The collective kernel publishes its own end timestamp into the ring from
-    // inside the kernel, so there is nothing to schedule on the host.
-    return folly::unit;
-  }
-  // Host-launched fallback. Fork: collective stream -> timestamp stream. This
-  // DAG edge ensures the end timestamp kernel fires only after the collective
-  // completes.
-  CUDA_CHECK_EXPECTED(cudaEventRecord(depEvent_, stream_));
-  CUDA_CHECK_EXPECTED(cudaStreamWaitEvent(timestampStream_, depEvent_));
-
-  // Launch the end timestamp kernel on this collective's timestamp stream.
-  CUDA_CHECK_EXPECTED(ringBuffer_->write(
-      timestampStream_,
-      GraphCollTraceEvent{collId_, GraphCollTracePhase::kEnd}));
-
-  // Save the collective stream's capture deps before the rejoin.
-  cudaStreamCaptureStatus status;
-  const cudaGraphNode_t* preRejoinDeps = nullptr;
-  const cudaGraphEdgeData* preRejoinEdgeData = nullptr;
-  size_t numPreRejoinDeps = 0;
-#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-  CUDA_CHECK_EXPECTED(hipStreamGetCaptureInfo_v2(
-      stream_, &status, nullptr, nullptr, &preRejoinDeps, &numPreRejoinDeps));
-#elif CUDART_VERSION >= 13000
-  CUDA_CHECK_EXPECTED(cudaStreamGetCaptureInfo(
-      stream_,
-      &status,
-      nullptr,
-      nullptr,
-      &preRejoinDeps,
-      &preRejoinEdgeData,
-      &numPreRejoinDeps));
-#else
-  CUDA_CHECK_EXPECTED(cudaStreamGetCaptureInfo_v2(
-      stream_, &status, nullptr, nullptr, &preRejoinDeps, &numPreRejoinDeps));
-#endif
-  std::vector<cudaGraphNode_t> savedDeps(
-      preRejoinDeps, preRejoinDeps + numPreRejoinDeps);
-  std::vector<cudaGraphEdgeData> savedEdgeData(
-      preRejoinEdgeData,
-      preRejoinEdgeData ? preRejoinEdgeData + numPreRejoinDeps
-                        : preRejoinEdgeData);
-
-  // Rejoin: timestamp stream -> collective stream. Required by
-  // cudaStreamEndCapture (all forked streams must rejoin). We immediately
-  // restore the pre-rejoin deps afterward so the rejoin node exists in
-  // the graph DAG but is NOT a dependency of subsequent ops on the
-  // collective stream. This means non-traced ops between collectives
-  // won't be serialized behind the end kernel.
-  CUDA_CHECK_EXPECTED(cudaEventRecord(depEvent_, timestampStream_));
-  CUDA_CHECK_EXPECTED(cudaStreamWaitEvent(stream_, depEvent_));
-
-  // Immediately undo: restore pre-rejoin deps so the main stream
-  // doesn't carry the endK dependency forward.
-  CUDA_CHECK_EXPECTED(cudaStreamUpdateCaptureDependencies(
-      stream_,
-      savedDeps.data(),
-#if CUDART_VERSION >= 13000
-      savedEdgeData.empty() ? nullptr : savedEdgeData.data(),
-#endif
-      savedDeps.size(),
-      cudaStreamSetCaptureDependencies));
-
+  // The collective kernel publishes its own end timestamp into the ring from
+  // inside the kernel, so there is nothing to schedule on the host.
   return folly::unit;
 }
 

--- a/comms/utils/colltrace/GraphCudaWaitEvent.h
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.h
@@ -16,13 +16,6 @@ namespace meta::comms::colltrace {
 inline constexpr uint32_t kDefaultRingSize =
     65536; // NOLINT(misc-unused-using-decls)
 
-// Reads the NCCLX_COLLTRACE_DEVICE_WRITE cvar (off by default until the
-// in-kernel cutover diff lands): whether collective kernels should publish
-// their own timestamps into the graph ring (in-kernel "device write"). Defined
-// out-of-line so this header (and the exported GraphCollTraceHandle.h that
-// gates on it) doesn't pull in nccl_cvars.h.
-bool colltraceDeviceWriteEnabled() noexcept;
-
 // Graph-aware wait event that uses device-side globaltimer reads and a
 // shared ring buffer for precise per-replay timing. All collectives across
 // ALL CUDA graphs share a single ring buffer (owned by CollTrace) and
@@ -80,15 +73,6 @@ class GraphCudaWaitEvent : public ICollWaitEvent {
     return ringBuffer_ != nullptr;
   }
 
-  // Mark that this collective's kernel is armed to publish its own start/end
-  // timestamps from inside the kernel, so the host-launched timestamp path is
-  // skipped. Called by the GPE / baseline arming code during submit, before the
-  // launch triggers beforeCollKernelScheduled(). TEMPORARY: removed together
-  // with the host-launched path at the in-kernel cutover.
-  void markInKernelEmit() noexcept {
-    inKernelEmit_ = true;
-  }
-
   // Device-side write handle for the shared ring, handed to a collective kernel
   // so it can publish its own start/end timestamps from inside the kernel.
   // Returns a default (null-ring, invalid) handle if no ring is attached, so
@@ -105,17 +89,6 @@ class GraphCudaWaitEvent : public ICollWaitEvent {
   cudaStream_t stream_;
   uint32_t collId_;
   system_clock_time_point enqueueTime_;
-
-  // Set by markInKernelEmit() when the collective kernel is armed to self-emit;
-  // when true the host-launched timestamp path is skipped so the two never
-  // double-write the ring. TEMPORARY: removed at the in-kernel cutover.
-  bool inKernelEmit_{false};
-
-  // Per-collective timestamp stream + dependency event for the host-launched
-  // fork/join timestamp path, used until the kernel self-emits (pre-sm90, or a
-  // not-yet-migrated collective). TEMPORARY: removed at the in-kernel cutover.
-  cudaStream_t timestampStream_{nullptr};
-  cudaEvent_t depEvent_{nullptr};
 
   // owned by CollTrace, shared across ALL graphs. set via attachRingBuffer().
   ::hrdw_ring_buffer::HRDWRingBuffer<GraphCollTraceEvent>* ringBuffer_{nullptr};

--- a/comms/utils/colltrace/tests/GraphCollTraceUT.cc
+++ b/comms/utils/colltrace/tests/GraphCollTraceUT.cc
@@ -22,15 +22,21 @@
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/utils/colltrace/CollTrace.h"
 #include "comms/utils/colltrace/CollTraceHandle.h"
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
 #include "comms/utils/colltrace/CudaWaitEvent.h"
+#include "comms/utils/colltrace/GraphCollTraceEvent.h"
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
 using meta::comms::colltrace::CollTrace;
 using meta::comms::colltrace::CollTraceConfig;
+using meta::comms::colltrace::ColltraceDeviceHandle;
 using meta::comms::colltrace::CollTraceEvent;
 using meta::comms::colltrace::CollTraceHandleTriggerState;
+using meta::comms::colltrace::GraphCollTraceEvent;
+using meta::comms::colltrace::GraphCollTracePhase;
 using meta::comms::colltrace::GraphCudaWaitEvent;
 using meta::comms::colltrace::ICollMetadata;
 using meta::comms::colltrace::ICollTracePlugin;
@@ -153,6 +159,11 @@ class GraphColltraceProgressingTest : public ::testing::Test {
     }
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
     cudaSetDevice(0);
+    if (!meta::comms::colltrace::graphColltraceSupported(
+            "GraphColltraceProgressingTest")) {
+      GTEST_SKIP() << "graph colltrace unsupported on this device/driver "
+                      "(needs sm_90+ and a CUDA driver outside 13.0-13.2)";
+    }
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
     cudaStreamCreate(&stream_);
 
@@ -240,8 +251,13 @@ class GraphColltraceProgressingTest : public ::testing::Test {
       if (collRecord.hasValue() && collRecord.value() != nullptr) {
         cg.collIds.push_back(collRecord.value()->getCollId());
       }
+      auto devHandle = handle->getColltraceDeviceHandle();
       handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+      // The collective kernel emits its own start/end in-kernel; mirror that
+      // with ring writes bracketing the host-sleep "work".
+      writeColltraceRing(devHandle, GraphCollTracePhase::kStart);
       launchHostSleep(sleepMs);
+      writeColltraceRing(devHandle, GraphCollTracePhase::kEnd);
       handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
     }
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
@@ -250,6 +266,25 @@ class GraphColltraceProgressingTest : public ::testing::Test {
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
     cudaGraphInstantiate(&cg.instance, cg.graph, nullptr, nullptr, 0);
     return cg;
+  }
+
+  // Write a colltrace event into the ring via the device handle colltrace hands
+  // to a kernel — the same write a collective kernel does in-kernel (e.g.
+  // AllGatherP PipeStart/PipeEnd). Enqueued on `stream` (defaulting to the
+  // capture stream) so it is captured/replayed like the real kernel write;
+  // concurrent-collective tests pass a per-collective stream.
+  void writeColltraceRing(
+      const ColltraceDeviceHandle& devHandle,
+      GraphCollTracePhase phase,
+      cudaStream_t stream = nullptr) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    hrdw_ring_buffer::launchRingBufferWrite<GraphCollTraceEvent>(
+        stream ? stream : stream_,
+        devHandle.ring.ring,
+        devHandle.ring.writeIndex,
+        devHandle.ring.mask,
+        devHandle.ring.shift,
+        GraphCollTraceEvent{devHandle.collId, phase});
   }
 
   cudaStream_t stream_{nullptr};
@@ -338,13 +373,18 @@ TEST_F(GraphColltraceProgressingTest, DetectsMultipleInFlightCollectives) {
     if (collRecord.hasValue() && collRecord.value() != nullptr) {
       cg.collIds.push_back(collRecord.value()->getCollId());
     }
+    auto devHandle = handle->getColltraceDeviceHandle();
     handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+    // Emit the in-kernel start/end on the collective's own stream so all
+    // starts fire (concurrently) before any end.
+    writeColltraceRing(devHandle, GraphCollTracePhase::kStart, collStreams[c]);
     // Host sleep on the collective's stream — all sleeps run concurrently.
     cudaLaunchHostFunc(
         collStreams[c],
         hostSleepCallback,
         // NOLINTNEXTLINE(performance-no-int-to-ptr)
         reinterpret_cast<void*>(static_cast<uintptr_t>(kSleepMs)));
+    writeColltraceRing(devHandle, GraphCollTracePhase::kEnd, collStreams[c]);
     handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
     handles.push_back(std::move(handle));
   }
@@ -421,7 +461,10 @@ TEST_F(GraphColltraceProgressingTest, EagerAndGraphMergedByTimestamp) {
           ->recordCollective(
               std::move(graphMetadata), std::move(graphWaitEvent))
           .value();
+  auto graphDevHandle = graphHandle->getColltraceDeviceHandle();
   graphHandle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+  // The kernel emits its own start/end in-kernel; mirror that here.
+  writeColltraceRing(graphDevHandle, GraphCollTracePhase::kStart);
   // Short host sleep as the "work".
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
   cudaLaunchHostFunc(
@@ -429,6 +472,7 @@ TEST_F(GraphColltraceProgressingTest, EagerAndGraphMergedByTimestamp) {
       hostSleepCallback,
       // NOLINTNEXTLINE(performance-no-int-to-ptr)
       reinterpret_cast<void*>(static_cast<uintptr_t>(10)));
+  writeColltraceRing(graphDevHandle, GraphCollTracePhase::kEnd);
   graphHandle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
   cudaStreamEndCapture(stream_, &graph);
@@ -484,4 +528,137 @@ TEST_F(GraphColltraceProgressingTest, EagerAndGraphMergedByTimestamp) {
   cudaGraphExecDestroy(instance);
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
   cudaGraphDestroy(graph);
+}
+
+// ---------------------------------------------------------------------------
+// In-kernel colltrace: the collective kernel writes its own start/end into the
+// ring via the ColltraceDeviceHandle colltrace exposes, replacing the separate
+// inter-kernel timestamp kernels. These validate the colltrace-layer contract
+// the GPE relies on when arming AllGatherP's PipeStart/PipeEnd (and Solo)
+// kernels. The AllGatherP grouping/arming itself is covered at the ctran layer.
+// ---------------------------------------------------------------------------
+
+// getColltraceDeviceHandle() is capable only for the graph path; eager wait
+// events (no ring) report not-capable so the GPE keeps the host path.
+TEST_F(GraphColltraceProgressingTest, DeviceHandleCapableOnlyForGraphPath) {
+  // A graph collective must be recorded while the stream is capturing —
+  // recordCollective binds it to the capturing stream's graph state.
+  cudaGraph_t graph = nullptr;
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
+  auto graphWaitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
+  auto graphHandle =
+      colltrace_
+          ->recordCollective(
+              std::make_unique<SimpleMetadata>(), std::move(graphWaitEvent))
+          .value();
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamEndCapture(stream_, &graph);
+  if (graph != nullptr) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaGraphDestroy(graph);
+  }
+
+  auto devHandle = graphHandle->getColltraceDeviceHandle();
+  EXPECT_TRUE(devHandle.valid())
+      << "graph wait event with an attached ring must be in-kernel capable";
+  auto record = graphHandle->getCollRecord();
+  ASSERT_TRUE(record.hasValue() && record.value() != nullptr);
+  EXPECT_EQ(devHandle.collId, record.value()->getCollId())
+      << "device handle collId must match the record's collId";
+
+  // An eager wait event (recorded outside capture) has no ring and must not be
+  // in-kernel capable, so the GPE keeps the host-launched timestamp path.
+  auto eagerHandle =
+      colltrace_
+          ->recordCollective(
+              std::make_unique<SimpleMetadata>(),
+              std::make_unique<meta::comms::colltrace::CudaWaitEvent>(stream_))
+          .value();
+  EXPECT_FALSE(eagerHandle->getColltraceDeviceHandle().valid())
+      << "eager wait event has no ring and must not be in-kernel capable";
+}
+
+// The kernel-style writes through the ColltraceDeviceHandle drive the
+// poll-thread pairing: one start, one completion for the logical collective.
+TEST_F(GraphColltraceProgressingTest, InKernelWritesPairStartAndEnd) {
+  CapturedGraph cg;
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
+  auto metadata = std::make_unique<SimpleMetadata>();
+  auto waitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
+  auto handle =
+      colltrace_->recordCollective(std::move(metadata), std::move(waitEvent))
+          .value();
+  auto devHandle = handle->getColltraceDeviceHandle();
+  ASSERT_TRUE(devHandle.valid());
+
+  // The kernel writes its own start/end into the ring.
+  handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+  writeColltraceRing(devHandle, GraphCollTracePhase::kStart);
+  launchHostSleep(10);
+  writeColltraceRing(devHandle, GraphCollTracePhase::kEnd);
+  handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamEndCapture(stream_, &cg.graph);
+  ASSERT_NE(cg.graph, nullptr);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphInstantiate(&cg.instance, cg.graph, nullptr, nullptr, 0);
+
+  ASSERT_EQ(cudaGraphLaunch(cg.instance, stream_), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+  // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  EXPECT_EQ(progressPlugin_->getStartedCollIds().size(), 1u)
+      << "in-kernel start write should be observed for the collective";
+  EXPECT_EQ(progressPlugin_->getCompletedCollIds().size(), 1u)
+      << "in-kernel start+end writes should pair into one completion";
+}
+
+// Timeout/hang detection must survive the grouped in-kernel path: a collective
+// that wrote its in-kernel start (PipeStart ran) but never its end (stalled
+// before PipeEnd) must still be flagged in-flight so the watchdog — which
+// consumes collEventProgressing — can time it out. Writes only kStart via the
+// device handle, then stalls with no kEnd, and asserts progressing fires while
+// completion never does.
+TEST_F(GraphColltraceProgressingTest, InKernelStartWithoutEndDetectedInFlight) {
+  constexpr uint64_t kStallMs = 100;
+  CapturedGraph cg;
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
+  auto metadata = std::make_unique<SimpleMetadata>();
+  auto waitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
+  auto handle =
+      colltrace_->recordCollective(std::move(metadata), std::move(waitEvent))
+          .value();
+  auto devHandle = handle->getColltraceDeviceHandle();
+  ASSERT_TRUE(devHandle.valid());
+
+  // PipeStart wrote the start; the pipeline then stalls (host sleep) and the
+  // end is never written — the collect stays in-flight the whole time.
+  handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+  writeColltraceRing(devHandle, GraphCollTracePhase::kStart);
+  launchHostSleep(kStallMs);
+  // No kEnd — simulates a hang between PipeStart and PipeEnd.
+  handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamEndCapture(stream_, &cg.graph);
+  ASSERT_NE(cg.graph, nullptr);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphInstantiate(&cg.instance, cg.graph, nullptr, nullptr, 0);
+
+  // While the start sits in the ring with no end for ~kStallMs, the 1ms poll
+  // thread must observe the collective as in-flight and fire progressing.
+  ASSERT_EQ(cudaGraphLaunch(cg.instance, stream_), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+  // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+  EXPECT_FALSE(progressPlugin_->getProgressedCollIds().empty())
+      << "a started-but-not-ended collective must be detected in-flight so the "
+         "watchdog can time it out";
+  EXPECT_GT(progressPlugin_->progressCount(), 0);
+  EXPECT_TRUE(progressPlugin_->getCompletedCollIds().empty())
+      << "a collective whose end never fired must never be marked completed";
 }

--- a/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
+++ b/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
@@ -1,6 +1,10 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 //
-// Validates the CUDA graph DAG topology produced by graph colltrace capture.
+// Validates graph colltrace replay behavior: per-replay record accounting via
+// the flush path, replay timing consistency, and that no telemetry is produced
+// when cudagraph tracing is disabled. Collectives publish their start/end into
+// the shared ring in-kernel; these tests drive that ring via the device handle
+// (the same write a collective kernel does) so the captured graph replays it.
 
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
 
@@ -13,16 +17,22 @@
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/utils/colltrace/CollTrace.h"
 #include "comms/utils/colltrace/CollTraceHandle.h"
+#include "comms/utils/colltrace/ColltraceDeviceHandle.h"
+#include "comms/utils/colltrace/GraphCollTraceEvent.h"
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/colltrace/plugins/CommDumpPlugin.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 #include "comms/utils/test_utils/CudaGraphTestUtils.h"
 
 using meta::comms::colltrace::CollTrace;
 using meta::comms::colltrace::CollTraceConfig;
+using meta::comms::colltrace::ColltraceDeviceHandle;
 using meta::comms::colltrace::CollTraceHandleTriggerState;
 using meta::comms::colltrace::CommDumpPlugin;
+using meta::comms::colltrace::GraphCollTraceEvent;
+using meta::comms::colltrace::GraphCollTracePhase;
 using meta::comms::colltrace::GraphCudaWaitEvent;
 using meta::comms::colltrace::ICollMetadata;
 using meta::comms::colltrace::ICollTracePlugin;
@@ -48,7 +58,7 @@ class BenchMetadata : public ICollMetadata {
 
 } // namespace
 
-class GraphColltraceTopologyTest : public ::testing::Test {
+class GraphColltraceReplayTest : public ::testing::Test {
  protected:
   void SetUp() override {
     int deviceCount = 0;
@@ -58,12 +68,15 @@ class GraphColltraceTopologyTest : public ::testing::Test {
     }
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
     cudaSetDevice(0);
+    if (!meta::comms::colltrace::graphColltraceSupported(
+            "GraphColltraceReplayTest")) {
+      GTEST_SKIP() << "graph colltrace unsupported on this device/driver "
+                      "(needs sm_90+ and a CUDA driver outside 13.0-13.2)";
+    }
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
     cudaStreamCreate(&stream_);
 
-    // Enable cudagraph tracing for these tests.
     cvarGuard_.emplace(NCCL_COLLTRACE_TRACE_CUDA_GRAPH, true);
-
     hrdw_ring_buffer::GlobaltimerCalibration::get();
 
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
@@ -71,14 +84,20 @@ class GraphColltraceTopologyTest : public ::testing::Test {
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
     cudaMalloc(&buf2_, kWorkBytes);
 
+    auto dumpPlugin = std::make_unique<CommDumpPlugin>(
+        meta::comms::colltrace::CommDumpConfig{.pastCollSize = 100});
+    dumpPlugin_ = dumpPlugin.get();
+
     auto plugins = std::vector<std::unique_ptr<ICollTracePlugin>>{};
-    plugins.push_back(std::make_unique<CommDumpPlugin>());
+    plugins.push_back(std::move(dumpPlugin));
     CommLogData logData{};
     colltrace_ = std::make_shared<CollTrace>(
         CollTraceConfig{
-            .maxCheckCancelInterval = std::chrono::milliseconds{10}},
+            // Long interval so the poll thread sleeps between cycles; ring
+            // entries sit unread until an explicit flush wakes the thread.
+            .maxCheckCancelInterval = std::chrono::milliseconds{100000}},
         logData,
-        [this]() -> meta::comms::CommsMaybeVoid {
+        []() -> meta::comms::CommsMaybeVoid {
           // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
           cudaSetDevice(0);
           auto mode = cudaStreamCaptureModeThreadLocal;
@@ -110,19 +129,25 @@ class GraphColltraceTopologyTest : public ::testing::Test {
         buf2_, buf1_, kWorkBytes, cudaMemcpyDeviceToDevice, stream_);
   }
 
-  // If COLLTRACE_GRAPH_DUMP_DIR is set, dump the graph as a DOT file.
-  // Filename includes the current test name and a suffix for context.
-  void maybeDumpGraph(cudaGraph_t graph, const std::string& suffix) {
-    const char* dir = std::getenv("COLLTRACE_GRAPH_DUMP_DIR");
-    if (dir != nullptr) {
-      auto testName = std::string(
-          ::testing::UnitTest::GetInstance()->current_test_info()->name());
-      auto path = std::string(dir) + "/" + testName + "_" + suffix + ".dot";
-      cudaGraphDebugDotPrint(graph, path.c_str(), 0);
-    }
+  // Write a colltrace event into the ring via the device handle colltrace hands
+  // to a kernel — the same write a collective kernel does in-kernel. Enqueued
+  // on stream_ so it is captured/replayed like the real kernel write.
+  void writeColltraceRing(
+      const ColltraceDeviceHandle& devHandle,
+      GraphCollTracePhase phase) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    hrdw_ring_buffer::launchRingBufferWrite<GraphCollTraceEvent>(
+        stream_,
+        devHandle.ring.ring,
+        devHandle.ring.writeIndex,
+        devHandle.ring.mask,
+        devHandle.ring.shift,
+        GraphCollTraceEvent{devHandle.collId, phase});
   }
 
-  // Capture N serial collectives with colltrace instrumentation.
+  // Capture N serial collectives, each emitting its start/end into the ring
+  // in-kernel (via the device handle) around the work — the graph replay then
+  // reproduces those writes exactly as a real collective kernel would.
   cudaGraph_t captureSerial(uint32_t numColls) {
     cudaGraph_t graph;
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
@@ -134,190 +159,15 @@ class GraphColltraceTopologyTest : public ::testing::Test {
           colltrace_
               ->recordCollective(std::move(metadata), std::move(waitEvent))
               .value();
+      auto devHandle = handle->getColltraceDeviceHandle();
       handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+      writeColltraceRing(devHandle, GraphCollTracePhase::kStart);
       launchWork();
+      writeColltraceRing(devHandle, GraphCollTracePhase::kEnd);
       handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
     }
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
     cudaStreamEndCapture(stream_, &graph);
-    maybeDumpGraph(graph, std::to_string(numColls));
-    return graph;
-  }
-
-  // Capture N concurrent collectives on separate streams, simulating
-  // the signal/wait RMA pattern where canConcurrent=true.
-  cudaGraph_t captureConcurrent(uint32_t numColls) {
-    cudaGraph_t graph;
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
-
-    // Create per-collective streams forked from the main capture stream.
-    std::vector<cudaStream_t> collStreams(numColls);
-    cudaEvent_t forkEvent;
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaEventCreateWithFlags(&forkEvent, cudaEventDisableTiming);
-
-    // Fork: main stream → each collective stream.
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaEventRecord(forkEvent, stream_);
-    for (uint32_t c = 0; c < numColls; ++c) {
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      cudaStreamCreate(&collStreams[c]);
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      cudaStreamWaitEvent(collStreams[c], forkEvent);
-    }
-
-    // Launch work + colltrace on each concurrent stream.
-    for (uint32_t c = 0; c < numColls; ++c) {
-      auto metadata = std::make_unique<BenchMetadata>();
-      auto waitEvent = std::make_unique<GraphCudaWaitEvent>(collStreams[c]);
-      auto handle =
-          colltrace_
-              ->recordCollective(std::move(metadata), std::move(waitEvent))
-              .value();
-      handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
-      // Work on the collective's own stream.
-      cudaMemcpyAsync(
-          buf2_, buf1_, kWorkBytes, cudaMemcpyDeviceToDevice, collStreams[c]);
-      handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
-    }
-
-    // Join: all collective streams → main stream.
-    for (uint32_t c = 0; c < numColls; ++c) {
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      cudaEventRecord(forkEvent, collStreams[c]);
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      cudaStreamWaitEvent(stream_, forkEvent);
-    }
-
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaStreamEndCapture(stream_, &graph);
-    maybeDumpGraph(graph, std::to_string(numColls));
-
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaEventDestroy(forkEvent);
-    for (auto& s : collStreams) {
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      cudaStreamDestroy(s);
-    }
-
-    return graph;
-  }
-
-  // Capture a mixed pattern: serial → concurrent → serial.
-  // Models a realistic workload like: allreduce, then concurrent
-  // signal/wait RMA ops, then another allreduce.
-  cudaGraph_t captureMixed(uint32_t numConcurrent) {
-    cudaGraph_t graph;
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
-
-    // Serial collective 1 (e.g., allreduce)
-    {
-      auto metadata = std::make_unique<BenchMetadata>();
-      auto waitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
-      auto handle =
-          colltrace_
-              ->recordCollective(std::move(metadata), std::move(waitEvent))
-              .value();
-      handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
-      launchWork();
-      handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
-    }
-
-    // Concurrent collectives (e.g., signal/wait RMA ops)
-    {
-      std::vector<cudaStream_t> concStreams(numConcurrent);
-      cudaEvent_t forkEvent;
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      cudaEventCreateWithFlags(&forkEvent, cudaEventDisableTiming);
-
-      // Fork main → concurrent streams
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      cudaEventRecord(forkEvent, stream_);
-      for (uint32_t c = 0; c < numConcurrent; ++c) {
-        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-        cudaStreamCreate(&concStreams[c]);
-        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-        cudaStreamWaitEvent(concStreams[c], forkEvent);
-      }
-
-      // Launch concurrent work + colltrace
-      for (uint32_t c = 0; c < numConcurrent; ++c) {
-        auto metadata = std::make_unique<BenchMetadata>();
-        auto waitEvent = std::make_unique<GraphCudaWaitEvent>(concStreams[c]);
-        auto handle =
-            colltrace_
-                ->recordCollective(std::move(metadata), std::move(waitEvent))
-                .value();
-        handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
-        cudaMemcpyAsync(
-            buf2_, buf1_, kWorkBytes, cudaMemcpyDeviceToDevice, concStreams[c]);
-        handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
-      }
-
-      // Join concurrent streams → main
-      for (uint32_t c = 0; c < numConcurrent; ++c) {
-        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-        cudaEventRecord(forkEvent, concStreams[c]);
-        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-        cudaStreamWaitEvent(stream_, forkEvent);
-      }
-
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      cudaEventDestroy(forkEvent);
-      for (auto& s : concStreams) {
-        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-        cudaStreamDestroy(s);
-      }
-    }
-
-    // Serial collective 2 (e.g., another allreduce)
-    {
-      auto metadata = std::make_unique<BenchMetadata>();
-      auto waitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
-      auto handle =
-          colltrace_
-              ->recordCollective(std::move(metadata), std::move(waitEvent))
-              .value();
-      handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
-      launchWork();
-      handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
-    }
-
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaStreamEndCapture(stream_, &graph);
-    maybeDumpGraph(graph, std::to_string(numConcurrent));
-    return graph;
-  }
-
-  // Capture with non-traced ops interleaved between traced collectives.
-  // This tests that the deferred rejoin doesn't drop dependencies from
-  // non-traced operations.
-  cudaGraph_t captureWithInterleavedOps(uint32_t numColls) {
-    cudaGraph_t graph;
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
-    for (uint32_t c = 0; c < numColls; ++c) {
-      auto metadata = std::make_unique<BenchMetadata>();
-      auto waitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
-      auto handle =
-          colltrace_
-              ->recordCollective(std::move(metadata), std::move(waitEvent))
-              .value();
-      handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
-      launchWork();
-      handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
-
-      // Non-traced op between collectives (e.g., a memset).
-      if (c < numColls - 1) {
-        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-        cudaMemsetAsync(buf1_, 0, kWorkBytes, stream_);
-      }
-    }
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaStreamEndCapture(stream_, &graph);
-    maybeDumpGraph(graph, "interleaved_" + std::to_string(numColls));
     return graph;
   }
 
@@ -327,132 +177,14 @@ class GraphColltraceTopologyTest : public ::testing::Test {
   float* buf2_{nullptr};
   std::optional<EnvRAII<bool>> cvarGuard_;
   std::shared_ptr<CollTrace> colltrace_;
+  CommDumpPlugin* dumpPlugin_{nullptr};
 };
 
-// Graph capture succeeds for various configurations.
-TEST_F(GraphColltraceTopologyTest, CaptureSucceeds) {
-  for (uint32_t n : {1u, 3u, 10u}) {
-    auto graph = captureSerial(n);
-    ASSERT_NE(graph, nullptr) << "Serial capture failed for N=" << n;
-    auto topo = getGraphTopology(graph);
-    EXPECT_GT(topo.allNodes.size(), 0u);
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaGraphDestroy(graph);
-  }
-}
-
-// Serial collectives have the expected node types.
-TEST_F(GraphColltraceTopologyTest, SerialNodeTypes) {
-  constexpr uint32_t kNumColls = 3;
+// Without an explicit flush, ring buffer entries written during replay sit
+// unread (the poll thread sleeps on the long interval), so the dump is empty.
+TEST_F(GraphColltraceReplayTest, DumpWithoutFlushMissesEvents) {
+  constexpr uint32_t kNumColls = 5;
   auto graph = captureSerial(kNumColls);
-  auto topo = getGraphTopology(graph);
-
-  auto& memcpyNodes = topo.nodesOfType(cudaGraphNodeTypeMemcpy);
-  auto& kernelNodes = topo.nodesOfType(cudaGraphNodeTypeKernel);
-
-  EXPECT_EQ(memcpyNodes.size(), kNumColls);
-  EXPECT_GE(kernelNodes.size(), kNumColls)
-      << "Expected at least " << kNumColls << " kernel nodes";
-
-  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-  cudaGraphDestroy(graph);
-}
-
-// Each collective has at least one kernel reachable from it (end kernel).
-TEST_F(GraphColltraceTopologyTest, EndKernelsDependOnCollectives) {
-  constexpr uint32_t kNumColls = 3;
-  auto graph = captureSerial(kNumColls);
-  auto topo = getGraphTopology(graph);
-
-  auto& memcpyNodes = topo.nodesOfType(cudaGraphNodeTypeMemcpy);
-  auto& kernelNodes = topo.nodesOfType(cudaGraphNodeTypeKernel);
-
-  for (size_t i = 0; i < memcpyNodes.size(); ++i) {
-    bool hasReachableKernel = false;
-    for (auto& kn : kernelNodes) {
-      if (topo.hasEdge(memcpyNodes[i], kn) ||
-          topo.hasPath(memcpyNodes[i], kn)) {
-        hasReachableKernel = true;
-        break;
-      }
-    }
-    EXPECT_TRUE(hasReachableKernel)
-        << "Collective " << i << " has no reachable end kernel";
-  }
-
-  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-  cudaGraphDestroy(graph);
-}
-
-// Verify deferred rejoin: for serial collectives, no kernel node (start or
-// end timestamp kernel) should be a direct predecessor of any memcpy node
-// (collective). This proves that intermediate rejoins have been undone —
-// the next collective doesn't wait for the previous end kernel.
-TEST_F(GraphColltraceTopologyTest, DeferredRejoinRemovesIntermediateEdges) {
-  constexpr uint32_t kNumColls = 3;
-  auto graph = captureSerial(kNumColls);
-  auto topo = getGraphTopology(graph);
-
-  auto& memcpyNodes = topo.nodesOfType(cudaGraphNodeTypeMemcpy);
-  auto& kernelNodes = topo.nodesOfType(cudaGraphNodeTypeKernel);
-
-  ASSERT_EQ(memcpyNodes.size(), kNumColls);
-
-  // For each memcpy (collective), check that no kernel node has a direct
-  // edge to it. If the deferred rejoin is working, the main stream's
-  // capture dependencies were restored to exclude the end kernel before
-  // the next collective was captured.
-  for (size_t i = 0; i < memcpyNodes.size(); ++i) {
-    for (auto& kn : kernelNodes) {
-      // Direct edge means the end kernel's rejoin was NOT undone.
-      // hasPath would also catch indirect edges through event nodes,
-      // which is too strict — we only care about direct edges that
-      // indicate a pending rejoin.
-
-      // Check: is there a direct edge from any kernel to this memcpy?
-      // We look for edges kernel → X → memcpy where X is an event wait
-      // node (which is how rejoins manifest in the graph). A direct
-      // kernel → memcpy edge or kernel → eventWait → memcpy means the
-      // rejoin was not undone.
-
-      // Simpler: just check no kernel is a direct predecessor.
-      EXPECT_FALSE(topo.hasEdge(kn, memcpyNodes[i]))
-          << "Kernel node has a direct edge to collective " << i
-          << " — deferred rejoin not working (intermediate end kernel "
-             "is blocking the next collective)";
-    }
-  }
-
-  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-  cudaGraphDestroy(graph);
-}
-
-// Concurrent capture succeeds and produces a valid graph.
-TEST_F(GraphColltraceTopologyTest, ConcurrentCaptureSucceeds) {
-  for (uint32_t n : {2u, 3u, 5u}) {
-    auto graph = captureConcurrent(n);
-    ASSERT_NE(graph, nullptr) << "Concurrent capture failed for N=" << n;
-    auto topo = getGraphTopology(graph);
-    EXPECT_GT(topo.allNodes.size(), 0u);
-
-    // Should have N memcpy nodes (one per concurrent collective).
-    auto& memcpyNodes = topo.nodesOfType(cudaGraphNodeTypeMemcpy);
-    EXPECT_EQ(memcpyNodes.size(), n);
-
-    // Should have kernel nodes (start + end per collective).
-    auto& kernelNodes = topo.nodesOfType(cudaGraphNodeTypeKernel);
-    EXPECT_GE(kernelNodes.size(), n);
-
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaGraphDestroy(graph);
-  }
-}
-
-// Concurrent collectives: verify that the graph can be instantiated and
-// replayed, producing correct timestamps for each collective.
-TEST_F(GraphColltraceTopologyTest, ConcurrentReplayProducesTimestamps) {
-  constexpr uint32_t kNumColls = 3;
-  auto graph = captureConcurrent(kNumColls);
   ASSERT_NE(graph, nullptr);
 
   cudaGraphExec_t instance;
@@ -461,11 +193,13 @@ TEST_F(GraphColltraceTopologyTest, ConcurrentReplayProducesTimestamps) {
       cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0),
       cudaSuccess);
 
-  // Replay a few times.
-  for (int i = 0; i < 5; ++i) {
-    ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
-  }
+  ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
   ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  auto dumpResult = dumpPlugin_->dump();
+  ASSERT_TRUE(dumpResult.hasValue());
+  EXPECT_EQ(static_cast<int>(dumpResult.value().pastColls.size()), 0)
+      << "Without flush, ring buffer entries should not be processed yet";
 
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
   cudaGraphExecDestroy(instance);
@@ -473,32 +207,28 @@ TEST_F(GraphColltraceTopologyTest, ConcurrentReplayProducesTimestamps) {
   cudaGraphDestroy(graph);
 }
 
-// Mixed pattern: serial → concurrent → serial. Models a realistic workload.
-TEST_F(GraphColltraceTopologyTest, MixedSerialConcurrentSerial) {
-  constexpr uint32_t kNumConcurrent = 2;
-  auto graph = captureMixed(kNumConcurrent);
+// Flush wakes the poll thread, which drains the ring and processes every graph
+// replay event through the plugin pipeline.
+TEST_F(GraphColltraceReplayTest, FlushDrainsRingBuffer) {
+  constexpr uint32_t kNumColls = 5;
+  auto graph = captureSerial(kNumColls);
   ASSERT_NE(graph, nullptr);
 
-  auto topo = getGraphTopology(graph);
-
-  // Total: 1 serial + 2 concurrent + 1 serial = 4 memcpy nodes.
-  auto& memcpyNodes = topo.nodesOfType(cudaGraphNodeTypeMemcpy);
-  EXPECT_EQ(memcpyNodes.size(), 2 + kNumConcurrent);
-
-  // Should have kernel nodes for all collectives.
-  auto& kernelNodes = topo.nodesOfType(cudaGraphNodeTypeKernel);
-  EXPECT_GE(kernelNodes.size(), 2 + kNumConcurrent);
-
-  // Verify the graph can be instantiated and replayed.
   cudaGraphExec_t instance;
   ASSERT_EQ(
       // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
       cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0),
       cudaSuccess);
-  for (int i = 0; i < 5; ++i) {
-    ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
-  }
+
+  ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
   ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  colltrace_->waitFlush(colltrace_->requestFlush());
+
+  auto dumpResult = dumpPlugin_->dump();
+  ASSERT_TRUE(dumpResult.hasValue());
+  EXPECT_EQ(static_cast<int>(dumpResult.value().pastColls.size()), kNumColls)
+      << "After flush, all graph replay events should appear in pastColls";
 
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
   cudaGraphExecDestroy(instance);
@@ -506,87 +236,108 @@ TEST_F(GraphColltraceTopologyTest, MixedSerialConcurrentSerial) {
   cudaGraphDestroy(graph);
 }
 
-// Concurrent collectives: verify no kernel node serialization.
-// With per-collective timestamp streams, concurrent collectives' memcpy
-// nodes should NOT have a path between them (they're on parallel streams).
-TEST_F(GraphColltraceTopologyTest, ConcurrentCollectivesAreParallel) {
-  constexpr uint32_t kNumColls = 3;
-  auto graph = captureConcurrent(kNumColls);
-  auto topo = getGraphTopology(graph);
+// Replay a graph multiple times and verify each replay produces valid timing
+// (non-zero duration, enqueueTs == startTs for graph clones).
+TEST_F(GraphColltraceReplayTest, ReplayTimingValid) {
+  constexpr uint32_t kNumColls = 2;
+  constexpr int kNumReplays = 3;
 
-  auto& memcpyNodes = topo.nodesOfType(cudaGraphNodeTypeMemcpy);
-  ASSERT_EQ(memcpyNodes.size(), kNumColls);
-
-  // For concurrent collectives, no memcpy should be reachable from another
-  // memcpy (they're on independent streams).
-  for (size_t i = 0; i < memcpyNodes.size(); ++i) {
-    for (size_t j = 0; j < memcpyNodes.size(); ++j) {
-      if (i == j) {
-        continue;
-      }
-      EXPECT_FALSE(topo.hasPath(memcpyNodes[i], memcpyNodes[j]))
-          << "Concurrent collective " << i << " should not be reachable from "
-          << j << " — they should be parallel";
-    }
-  }
-
-  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-  cudaGraphDestroy(graph);
-}
-
-// Verify that non-traced operations between traced collectives preserve
-// their ordering. The deferred rejoin restores capture deps, which must
-// include any non-traced ops that were added after the previous rejoin.
-TEST_F(GraphColltraceTopologyTest, InterleavedNonTracedOpsPreserveOrder) {
-  constexpr uint32_t kNumColls = 3;
-  auto graph = captureWithInterleavedOps(kNumColls);
+  auto graph = captureSerial(kNumColls);
   ASSERT_NE(graph, nullptr);
 
-  auto topo = getGraphTopology(graph);
-
-  // With 3 collectives and memsets between them:
-  // 3 memcpy nodes (collectives) + 2 memset nodes.
-  auto& memcpyNodes = topo.nodesOfType(cudaGraphNodeTypeMemcpy);
-  auto& memsetNodes = topo.nodesOfType(cudaGraphNodeTypeMemset);
-
-  EXPECT_EQ(memcpyNodes.size(), kNumColls);
-  EXPECT_EQ(memsetNodes.size(), kNumColls - 1);
-
-  // Each memset should be reachable from at least one memcpy (the
-  // collective before it) and should have at least one memcpy reachable
-  // from it (the collective after it). If the deferred rejoin broke the
-  // dependency chain, a memset would be disconnected.
-  for (size_t i = 0; i < memsetNodes.size(); ++i) {
-    bool hasPredMemcpy = false;
-    bool hasSuccMemcpy = false;
-    for (auto& mc : memcpyNodes) {
-      if (topo.hasPath(mc, memsetNodes[i])) {
-        hasPredMemcpy = true;
-      }
-      if (topo.hasPath(memsetNodes[i], mc)) {
-        hasSuccMemcpy = true;
-      }
-    }
-    EXPECT_TRUE(hasPredMemcpy)
-        << "Memset " << i
-        << " has no predecessor collective — "
-           "deferred rejoin may have dropped dependencies";
-    EXPECT_TRUE(hasSuccMemcpy)
-        << "Memset " << i
-        << " has no successor collective — "
-           "deferred rejoin may have dropped dependencies";
-  }
-
-  // Verify it can instantiate and replay correctly.
   cudaGraphExec_t instance;
   ASSERT_EQ(
       // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
       cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0),
       cudaSuccess);
-  for (int i = 0; i < 5; ++i) {
+
+  for (int r = 0; r < kNumReplays; ++r) {
     ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
   }
   ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  colltrace_->waitFlush(colltrace_->requestFlush());
+
+  auto dump = dumpPlugin_->dump();
+  ASSERT_TRUE(dump.hasValue());
+  EXPECT_GE(
+      static_cast<int>(dump.value().pastColls.size()),
+      static_cast<int>(kNumColls * kNumReplays));
+
+  for (const auto& coll : dump.value().pastColls) {
+    auto startTs = coll->getTimingInfo().getCollStartTs();
+    auto endTs = coll->getTimingInfo().getCollEndTs();
+    auto enqueueTs = coll->getTimingInfo().getCollEnqueueTs();
+    auto dur =
+        std::chrono::duration_cast<std::chrono::microseconds>(endTs - startTs)
+            .count();
+    EXPECT_GT(dur, 0) << "collId=" << coll->getCollId()
+                      << " has non-positive duration";
+    EXPECT_GE(endTs, startTs);
+    EXPECT_EQ(enqueueTs, startTs)
+        << "Graph clone enqueueTs should equal startTs";
+  }
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphExecDestroy(instance);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+}
+
+// Reproduces the production bug where pastColls entries had corrupted timing
+// because the clone was shared between pastColls and the next replay's
+// collEntry. Run multiple replays without flushing between them (the production
+// pattern), then flush once and verify that all retained pastColls entries have
+// enqueueTs == startTs. With the old shared-record approach, the next replay's
+// start event would overwrite startTs while leaving enqueueTs stale.
+TEST_F(GraphColltraceReplayTest, ReplayTimingConsistency) {
+  constexpr uint32_t kNumColls = 5;
+  constexpr int kNumReplays = 10;
+
+  auto graph = captureSerial(kNumColls);
+  ASSERT_NE(graph, nullptr);
+
+  cudaGraphExec_t instance;
+  ASSERT_EQ(
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0),
+      cudaSuccess);
+
+  // Run all replays back-to-back WITHOUT flushing — this is the production
+  // pattern where comm_dump_all is called once per step but collectives from
+  // the previous step are still in pastColls.
+  for (int step = 0; step < kNumReplays; ++step) {
+    ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
+  }
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  colltrace_->waitFlush(colltrace_->requestFlush());
+
+  auto dump = dumpPlugin_->dump();
+  ASSERT_TRUE(dump.hasValue());
+
+  int checked = 0;
+  for (const auto& coll : dump.value().pastColls) {
+    auto startTs = coll->getTimingInfo().getCollStartTs();
+    auto endTs = coll->getTimingInfo().getCollEndTs();
+    auto enqueueTs = coll->getTimingInfo().getCollEnqueueTs();
+    auto dur =
+        std::chrono::duration_cast<std::chrono::microseconds>(endTs - startTs)
+            .count();
+    EXPECT_GT(dur, 0) << "collId=" << coll->getCollId()
+                      << " has non-positive duration " << dur << "us";
+    EXPECT_GE(endTs, startTs)
+        << "collId=" << coll->getCollId() << ": endTs < startTs";
+    EXPECT_EQ(enqueueTs, startTs)
+        << "collId=" << coll->getCollId()
+        << ": enqueueTs != startTs — pastColls entry was mutated"
+           " by a subsequent replay's start event";
+
+    checked++;
+  }
+
+  EXPECT_GT(checked, 0) << "pastColls should not be empty after " << kNumReplays
+                        << " replays";
 
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
   cudaGraphExecDestroy(instance);
@@ -595,9 +346,9 @@ TEST_F(GraphColltraceTopologyTest, InterleavedNonTracedOpsPreserveOrder) {
 }
 
 // When NCCL_COLLTRACE_TRACE_CUDA_GRAPH is disabled, recordCollective should
-// fail for graph-captured collectives and the resulting graph should contain
-// no telemetry kernel nodes.
-TEST(GraphColltraceTopologyDisabledTest, NoTelemetryNodesWhenDisabled) {
+// fail for graph-captured collectives and the resulting graph should contain no
+// telemetry kernel nodes.
+TEST(GraphColltraceDisabledTest, NoTelemetryNodesWhenDisabled) {
   int deviceCount = 0;
   auto err = cudaGetDeviceCount(&deviceCount);
   if (err != cudaSuccess || deviceCount == 0) {
@@ -683,276 +434,4 @@ TEST(GraphColltraceTopologyDisabledTest, NoTelemetryNodesWhenDisabled) {
   cudaFree(buf1);
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
   cudaStreamDestroy(stream);
-}
-
-// ---------------------------------------------------------------------------
-// Flush tests — verify that requestFlush/waitFlush forces the poll thread
-// to read the ring buffer, processing graph replay events that would
-// otherwise sit unread until the next poll interval.
-// ---------------------------------------------------------------------------
-
-class GraphColltraceFlushTest : public ::testing::Test {
- protected:
-  void SetUp() override {
-    int deviceCount = 0;
-    auto err = cudaGetDeviceCount(&deviceCount);
-    if (err != cudaSuccess || deviceCount == 0) {
-      GTEST_SKIP() << "No CUDA device available";
-    }
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaSetDevice(0);
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaStreamCreate(&stream_);
-
-    cvarGuard_.emplace(NCCL_COLLTRACE_TRACE_CUDA_GRAPH, true);
-    hrdw_ring_buffer::GlobaltimerCalibration::get();
-
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaMalloc(&buf1_, kWorkBytes);
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaMalloc(&buf2_, kWorkBytes);
-
-    auto dumpPlugin = std::make_unique<CommDumpPlugin>(
-        meta::comms::colltrace::CommDumpConfig{.pastCollSize = 100});
-    dumpPlugin_ = dumpPlugin.get();
-
-    auto plugins = std::vector<std::unique_ptr<ICollTracePlugin>>{};
-    plugins.push_back(std::move(dumpPlugin));
-    CommLogData logData{};
-    colltrace_ = std::make_shared<CollTrace>(
-        CollTraceConfig{
-            // Long interval so the poll thread sleeps between cycles.
-            // Ring buffer entries sit unread until flush wakes the thread.
-            .maxCheckCancelInterval = std::chrono::milliseconds{100000}},
-        logData,
-        []() -> meta::comms::CommsMaybeVoid {
-          // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-          cudaSetDevice(0);
-          auto mode = cudaStreamCaptureModeThreadLocal;
-          // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-          cudaThreadExchangeStreamCaptureMode(&mode);
-          return folly::unit;
-        },
-        std::move(plugins));
-  }
-
-  void TearDown() override {
-    colltrace_.reset();
-    if (buf2_) {
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      cudaFree(buf2_);
-    }
-    if (buf1_) {
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      cudaFree(buf1_);
-    }
-    if (stream_) {
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      cudaStreamDestroy(stream_);
-    }
-  }
-
-  cudaGraph_t captureSerial(uint32_t numColls) {
-    cudaGraph_t graph;
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
-    for (uint32_t c = 0; c < numColls; ++c) {
-      auto metadata = std::make_unique<BenchMetadata>();
-      auto waitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
-      auto handle =
-          colltrace_
-              ->recordCollective(std::move(metadata), std::move(waitEvent))
-              .value();
-      handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
-      cudaMemcpyAsync(
-          buf2_, buf1_, kWorkBytes, cudaMemcpyDeviceToDevice, stream_);
-      handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
-    }
-    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-    cudaStreamEndCapture(stream_, &graph);
-    return graph;
-  }
-
-  static constexpr size_t kWorkBytes = 64 * 1024;
-  cudaStream_t stream_{nullptr};
-  float* buf1_{nullptr};
-  float* buf2_{nullptr};
-  std::optional<EnvRAII<bool>> cvarGuard_;
-  std::shared_ptr<CollTrace> colltrace_;
-  CommDumpPlugin* dumpPlugin_{nullptr};
-};
-
-TEST_F(GraphColltraceFlushTest, DumpWithoutFlushMissesEvents) {
-  constexpr uint32_t kNumColls = 5;
-  auto graph = captureSerial(kNumColls);
-  ASSERT_NE(graph, nullptr);
-
-  cudaGraphExec_t instance;
-  ASSERT_EQ(
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0),
-      cudaSuccess);
-
-  ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
-  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
-
-  // GPU has written ring buffer entries, but the poll thread is sleeping
-  // (10s interval). Dump without flush should show no completed events.
-  auto dumpResult = dumpPlugin_->dump();
-  ASSERT_TRUE(dumpResult.hasValue());
-  EXPECT_EQ(static_cast<int>(dumpResult.value().pastColls.size()), 0)
-      << "Without flush, ring buffer entries should not be processed yet";
-
-  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-  cudaGraphExecDestroy(instance);
-  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-  cudaGraphDestroy(graph);
-}
-
-TEST_F(GraphColltraceFlushTest, FlushDrainsRingBuffer) {
-  constexpr uint32_t kNumColls = 5;
-  auto graph = captureSerial(kNumColls);
-  ASSERT_NE(graph, nullptr);
-
-  cudaGraphExec_t instance;
-  ASSERT_EQ(
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0),
-      cudaSuccess);
-
-  ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
-  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
-
-  // Flush wakes the poll thread, which reads the ring buffer and
-  // processes all graph replay events through the plugin pipeline.
-  colltrace_->waitFlush(colltrace_->requestFlush());
-
-  auto dumpResult = dumpPlugin_->dump();
-  ASSERT_TRUE(dumpResult.hasValue());
-  EXPECT_EQ(static_cast<int>(dumpResult.value().pastColls.size()), kNumColls)
-      << "After flush, all graph replay events should appear in pastColls";
-
-  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-  cudaGraphExecDestroy(instance);
-  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-  cudaGraphDestroy(graph);
-}
-
-// Replay a graph multiple times and verify each replay produces valid
-// timing (non-zero duration, enqueueTs == startTs for graph clones).
-TEST_F(GraphColltraceTopologyTest, ReplayTimingValid) {
-  constexpr uint32_t kNumColls = 2;
-  constexpr int kNumReplays = 3;
-
-  auto graph = captureSerial(kNumColls);
-  ASSERT_NE(graph, nullptr);
-
-  cudaGraphExec_t instance;
-  ASSERT_EQ(
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0),
-      cudaSuccess);
-
-  auto* plugin = dynamic_cast<CommDumpPlugin*>(colltrace_->getPluginByName(
-      std::string{CommDumpPlugin::kCommDumpPluginName}));
-  ASSERT_NE(plugin, nullptr);
-
-  for (int r = 0; r < kNumReplays; ++r) {
-    ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
-  }
-  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
-
-  colltrace_->waitFlush(colltrace_->requestFlush());
-
-  auto dump = plugin->dump();
-  ASSERT_TRUE(dump.hasValue());
-  EXPECT_GE(
-      static_cast<int>(dump.value().pastColls.size()),
-      static_cast<int>(kNumColls * kNumReplays));
-
-  for (const auto& coll : dump.value().pastColls) {
-    auto startTs = coll->getTimingInfo().getCollStartTs();
-    auto endTs = coll->getTimingInfo().getCollEndTs();
-    auto enqueueTs = coll->getTimingInfo().getCollEnqueueTs();
-    auto dur =
-        std::chrono::duration_cast<std::chrono::microseconds>(endTs - startTs)
-            .count();
-    EXPECT_GT(dur, 0) << "collId=" << coll->getCollId()
-                      << " has non-positive duration";
-    EXPECT_GE(endTs, startTs);
-    EXPECT_EQ(enqueueTs, startTs)
-        << "Graph clone enqueueTs should equal startTs";
-  }
-
-  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-  cudaGraphExecDestroy(instance);
-  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-  cudaGraphDestroy(graph);
-}
-
-// Reproduces the production bug where pastColls entries had corrupted
-// timing because the clone was shared between pastColls and the next
-// replay's collEntry. Run multiple replays without flushing between
-// them (the production pattern), then flush once and verify that all
-// retained pastColls entries have enqueueTs == startTs. With the old
-// shared-record approach, the next replay's start event would overwrite
-// startTs while leaving enqueueTs stale.
-TEST_F(GraphColltraceTopologyTest, ReplayTimingConsistency) {
-  constexpr uint32_t kNumColls = 5;
-  constexpr int kNumReplays = 10;
-
-  auto graph = captureSerial(kNumColls);
-  ASSERT_NE(graph, nullptr);
-
-  cudaGraphExec_t instance;
-  ASSERT_EQ(
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0),
-      cudaSuccess);
-
-  auto* plugin = dynamic_cast<CommDumpPlugin*>(colltrace_->getPluginByName(
-      std::string{CommDumpPlugin::kCommDumpPluginName}));
-  ASSERT_NE(plugin, nullptr);
-
-  // Run all replays back-to-back WITHOUT flushing — this is the
-  // production pattern where comm_dump_all is called once per step
-  // but collectives from the previous step are still in pastColls.
-  for (int step = 0; step < kNumReplays; ++step) {
-    ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
-  }
-  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
-
-  auto gen = colltrace_->requestFlush();
-  colltrace_->waitFlush(gen);
-
-  auto dump = plugin->dump();
-  ASSERT_TRUE(dump.hasValue());
-
-  int checked = 0;
-  for (const auto& coll : dump.value().pastColls) {
-    auto startTs = coll->getTimingInfo().getCollStartTs();
-    auto endTs = coll->getTimingInfo().getCollEndTs();
-    auto enqueueTs = coll->getTimingInfo().getCollEnqueueTs();
-    auto dur =
-        std::chrono::duration_cast<std::chrono::microseconds>(endTs - startTs)
-            .count();
-    EXPECT_GT(dur, 0) << "collId=" << coll->getCollId()
-                      << " has non-positive duration " << dur << "us";
-    EXPECT_GE(endTs, startTs)
-        << "collId=" << coll->getCollId() << ": endTs < startTs";
-    EXPECT_EQ(enqueueTs, startTs)
-        << "collId=" << coll->getCollId()
-        << ": enqueueTs != startTs — pastColls entry was mutated"
-           " by a subsequent replay's start event";
-
-    checked++;
-  }
-
-  EXPECT_GT(checked, 0) << "pastColls should not be empty after " << kNumReplays
-                        << " replays";
-
-  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-  cudaGraphExecDestroy(instance);
-  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-  cudaGraphDestroy(graph);
 }

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2481,16 +2481,6 @@ cvars:
      still haven't fully tested the performance impact of this feature. So
      it is disabled by default. In the future, we will enable it by default.
 
- - name        : NCCLX_COLLTRACE_DEVICE_WRITE
-   type        : bool
-   default     : false
-   description : |-
-     When graph colltrace tracing is enabled (NCCL_COLLTRACE_TRACE_CUDA_GRAPH),
-     have collective kernels publish their own start/end timestamps into the
-     graph ring from inside the kernel (in-kernel "device write"). Off by
-     default until the in-kernel cutover diff lands; set true to hand collective
-     kernels the device ring handle and enable in-kernel emission.
-
  - name        : NCCL_COLLTRACE_CTRAN_USE_CPU_RECORD
    type        : bool
    default     : true


### PR DESCRIPTION
Summary:

Final cutover of the graph-path colltrace timing migration. Now that the shared
in-kernel emit primitives, the baseline NCCL integration, and the ctran
integration are all in place (the commits below this one), delete the old
host-launched timestamp-kernel path and the temporary gate that let the two
coexist during the transition.

- `GraphCudaWaitEvent`: remove the fork-a-side-stream / write / rejoin
  timestamp-kernel scheduling; `beforeCollKernelScheduled` / `afterCollKernelScheduled`
  become no-ops (the collective kernel self-emits into the ring). Drop the
  temporary `timestampStream_` / `depEvent_` members and the `inKernelEmit_` gate.
- Remove the temporary `ICollTraceHandle::markInKernelEmit()` hook (and the
  `GraphCollTraceHandle` override) and its callers in the ctran
  (`armInKernelColltrace`) and baseline (`armBaselineInKernelColltrace`) arming
  paths.
- Drop the now-unused `cuda_raii` dep from the `graph_cuda_wait_event` target.

After this commit, in-kernel emit is the only graph-timing path (requires sm_90+;
pre-sm90 graph collectives are untimed, warned once). The whole feature stays
gated behind `NCCL_COLLTRACE_TRACE_CUDA_GRAPH` (default off), so there is no
default-path behavior change.

Reviewed By: minsii

Differential Revision: D113718490
