### PR TITLE
Add registered-send protocol regression coverage (#3412)

### DIFF
--- a/comms/prims/P2pIbTransportBuildContractTest.py
+++ b/comms/prims/P2pIbTransportBuildContractTest.py
@@ -7,10 +7,14 @@ from pathlib import Path
 
 _PROGRESS_ONLY_FUNCTIONS = (
     "init_send_progress",
+    "init_registered_send_progress",
     "init_recv_progress",
     "progress_send_once",
+    "progress_registered_send_once",
+    "progress_registered_send_drain_once",
     "poll_recv_data_ready",
     "progress_recv_once",
+    "send_registered",
     "store_progress_state",
     "make_progress_geometry",
     "active_payload_offset",

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -1964,6 +1964,205 @@ TEST_F(
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 }
 
+TEST_F(
+    MultipeerIbgdaTransportTestFixture,
+    RegisteredAndStagedSendShareProtocolCursor) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+  if (!test::supportsProgressSendRecv()) {
+    GTEST_SKIP() << "registered-source send is not supported for this build";
+  }
+
+  constexpr std::size_t perChannelSize = 64 * 1024;
+  constexpr int pipelineDepth = 2;
+  constexpr std::size_t firstBytes = 17 * 1024 + 1;
+  constexpr std::size_t secondBytes = 9 * 1024 + 7;
+  constexpr std::size_t thirdBytes = 40 * 1024 + 17;
+  constexpr std::size_t totalBytes = firstBytes + secondBytes + thirdBytes;
+  constexpr std::size_t maxSignalBytes = 4 * 1024;
+  constexpr int numBlocks = 1;
+  constexpr int blockSize = 128;
+  const int peerRank = globalRank == 0 ? 1 : 0;
+
+  std::unique_ptr<MultipeerIbgdaTransport> transport;
+  try {
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .perChannelSize = perChannelSize,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
+    };
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, numRanks, bootstrap, config);
+    transport->exchange();
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+
+  auto* peerTransport = transport->getP2pTransportDevice(peerRank);
+  DeviceBuffer sendBuffer(totalBytes);
+  DeviceBuffer recvBuffer(totalBytes);
+  DeviceBuffer errorCountBuffer(sizeof(int));
+  auto* errorCount = static_cast<int*>(errorCountBuffer.get());
+  IbgdaLocalBuffer registeredSource{};
+  if (globalRank == 0) {
+    registeredSource = transport->registerBuffer(sendBuffer.get(), totalBytes);
+    test::fillBufferWithPattern(
+        sendBuffer.get(), firstBytes, 0x31, numBlocks, blockSize);
+    test::fillBufferWithPattern(
+        static_cast<char*>(sendBuffer.get()) + firstBytes,
+        secondBytes,
+        0x72,
+        numBlocks,
+        blockSize);
+    test::fillBufferWithPattern(
+        static_cast<char*>(sendBuffer.get()) + firstBytes + secondBytes,
+        thirdBytes,
+        0xB4,
+        numBlocks,
+        blockSize);
+  } else {
+    CUDACHECK_TEST(cudaMemset(recvBuffer.get(), 0, totalBytes));
+  }
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  test::testMixedRegisteredAndStagedSendRecv(
+      peerTransport,
+      registeredSource,
+      recvBuffer.get(),
+      firstBytes,
+      secondBytes,
+      thirdBytes,
+      maxSignalBytes,
+      globalRank == 0,
+      numBlocks,
+      blockSize);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  if (globalRank == 1) {
+    const std::array<std::tuple<std::size_t, std::size_t, uint8_t>, 3> ranges{{
+        {0, firstBytes, 0x31},
+        {firstBytes, secondBytes, 0x72},
+        {firstBytes + secondBytes, thirdBytes, 0xB4},
+    }};
+    for (const auto& [offset, nbytes, pattern] : ranges) {
+      CUDACHECK_TEST(cudaMemset(errorCount, 0, sizeof(int)));
+      test::verifyBufferPattern(
+          static_cast<char*>(recvBuffer.get()) + offset,
+          nbytes,
+          pattern,
+          errorCount,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      int hostErrors = 0;
+      CUDACHECK_TEST(cudaMemcpy(
+          &hostErrors, errorCount, sizeof(hostErrors), cudaMemcpyDeviceToHost));
+      EXPECT_EQ(hostErrors, 0)
+          << "mixed registered/staged send corrupted range at " << offset;
+    }
+  } else {
+    transport->deregisterBuffer(sendBuffer.get());
+  }
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+TEST_F(
+    MultipeerIbgdaTransportTestFixture,
+    RegisteredSendBackpressureAcrossStagingWrap) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+  if (!test::supportsProgressSendRecv()) {
+    GTEST_SKIP() << "registered-source send is not supported for this build";
+  }
+
+  constexpr std::size_t perChannelSize = 64 * 1024;
+  constexpr int pipelineDepth = 2;
+  constexpr std::size_t nbytes = 8 * 1024 * 1024 + 17;
+  constexpr std::size_t maxSignalBytes = 4 * 1024;
+  constexpr int numBlocks = 1;
+  constexpr int blockSize = 128;
+  const int peerRank = globalRank == 0 ? 1 : 0;
+  std::vector<uint8_t> expected(nbytes);
+  for (std::size_t i = 0; i < nbytes; ++i) {
+    const std::size_t generation = i / perChannelSize;
+    expected[i] = static_cast<uint8_t>(generation * 37 + (i % 251));
+  }
+
+  std::unique_ptr<MultipeerIbgdaTransport> transport;
+  try {
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .perChannelSize = perChannelSize,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
+    };
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, numRanks, bootstrap, config);
+    transport->exchange();
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+
+  auto* peerTransport = transport->getP2pTransportDevice(peerRank);
+  DeviceBuffer sendBuffer(nbytes);
+  DeviceBuffer recvBuffer(nbytes);
+  DeviceBuffer observationBuffer(sizeof(test::RegisteredSendObservation));
+  auto* observation =
+      static_cast<test::RegisteredSendObservation*>(observationBuffer.get());
+  IbgdaLocalBuffer registeredSource{};
+  if (globalRank == 0) {
+    registeredSource = transport->registerBuffer(sendBuffer.get(), nbytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        sendBuffer.get(), expected.data(), nbytes, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(
+        cudaMemset(observation, 0, sizeof(test::RegisteredSendObservation)));
+  } else {
+    CUDACHECK_TEST(cudaMemset(recvBuffer.get(), 0, nbytes));
+  }
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  test::testRegisteredSendRecv(
+      peerTransport,
+      registeredSource,
+      recvBuffer.get(),
+      nbytes,
+      maxSignalBytes,
+      globalRank == 0,
+      numBlocks,
+      blockSize,
+      globalRank == 0 ? observation : nullptr);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  if (globalRank == 0) {
+    test::RegisteredSendObservation hostObservation{};
+    CUDACHECK_TEST(cudaMemcpy(
+        &hostObservation,
+        observation,
+        sizeof(hostObservation),
+        cudaMemcpyDeviceToHost));
+    EXPECT_GT(hostObservation.waitingCount, 0);
+    EXPECT_EQ(hostObservation.postedCount, 1);
+    EXPECT_EQ(hostObservation.drainedCount, 1);
+    transport->deregisterBuffer(sendBuffer.get());
+  } else {
+    std::vector<uint8_t> received(nbytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        received.data(), recvBuffer.get(), nbytes, cudaMemcpyDeviceToHost));
+    EXPECT_EQ(received, expected)
+        << "registered send corrupted data across slot wrap";
+  }
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
 // =============================================================================
 // Sustained chunked send/recv - repro for the GB200 per-channel DATA_READY
 // deadlock (two NICs atomic-FA the same flag at maxGroups>=8). Streams a large

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -6,9 +6,9 @@
 #include <folly/logging/xlog.h>
 #include <array>
 
-#include <chrono>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #ifdef __HIP_PLATFORM_AMD__
@@ -1789,6 +1789,179 @@ TEST_P(
     GTEST_SKIP() << backendName(backend())
                  << " transport not available: " << e.what();
   }
+}
+
+TEST_F(
+    MultipeerIbgdaTransportTestFixture,
+    RegisteredSendTailsDrainAndStagingIsolation) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+  if (!test::supportsProgressSendRecv()) {
+    GTEST_SKIP() << "registered-source send is not supported for this build";
+  }
+
+  constexpr std::size_t perChannelSize = 64 * 1024;
+  constexpr int pipelineDepth = 2;
+  constexpr std::size_t pipelineChunk = perChannelSize / pipelineDepth;
+  constexpr std::size_t maxSignalBytes = 4 * 1024;
+  constexpr std::size_t simpleProtocolDataBytes = 16;
+  constexpr int numBlocks = 1;
+  constexpr int blockSize = 128;
+  constexpr uint8_t stagingPoison = 0xA5;
+  constexpr std::size_t zeroByteAfterPostedIndex = 2;
+  const int peerRank = globalRank == 0 ? 1 : 0;
+  const std::array<std::size_t, 8> sizes{
+      0,
+      1,
+      7,
+      simpleProtocolDataBytes - 1,
+      simpleProtocolDataBytes,
+      simpleProtocolDataBytes + 1,
+      pipelineChunk - 1,
+      pipelineChunk + 1,
+  };
+
+  std::unique_ptr<MultipeerIbgdaTransport> transport;
+  try {
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .perChannelSize = perChannelSize,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
+    };
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, numRanks, bootstrap, config);
+    transport->exchange();
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+
+  auto* peerTransport = transport->getP2pTransportDevice(peerRank);
+  DeviceBuffer errorCountBuffer(sizeof(int));
+  DeviceBuffer observationBuffer(sizeof(test::RegisteredSendObservation));
+  auto* errorCount = static_cast<int*>(errorCountBuffer.get());
+  auto* observation =
+      static_cast<test::RegisteredSendObservation*>(observationBuffer.get());
+
+  test::testFillTransportStaging(
+      peerTransport,
+      globalRank == 0,
+      0,
+      perChannelSize,
+      stagingPoison,
+      numBlocks,
+      blockSize);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  for (std::size_t index = 0; index < sizes.size(); ++index) {
+    const std::size_t nbytes = sizes[index];
+    const std::size_t allocationBytes = nbytes == 0 ? 1 : nbytes;
+    const uint8_t pattern = static_cast<uint8_t>(0x20 + index * 13);
+    DeviceBuffer sendBuffer(allocationBytes);
+    DeviceBuffer recvBuffer(allocationBytes);
+    IbgdaLocalBuffer registeredSource{};
+    if (globalRank == 0) {
+      if (nbytes > 0) {
+        registeredSource = transport->registerBuffer(sendBuffer.get(), nbytes);
+      }
+      test::fillBufferWithPattern(
+          sendBuffer.get(), nbytes, pattern, numBlocks, blockSize);
+      CUDACHECK_TEST(
+          cudaMemset(observation, 0, sizeof(test::RegisteredSendObservation)));
+    } else {
+      CUDACHECK_TEST(cudaMemset(recvBuffer.get(), 0, allocationBytes));
+    }
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    test::testRegisteredSendRecv(
+        peerTransport,
+        registeredSource,
+        recvBuffer.get(),
+        nbytes,
+        maxSignalBytes,
+        globalRank == 0,
+        numBlocks,
+        blockSize,
+        globalRank == 0 ? observation : nullptr,
+        index == 4,
+        globalRank == 0 && nbytes > 0,
+        static_cast<uint8_t>(pattern ^ 0xFF),
+        index == zeroByteAfterPostedIndex);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    if (globalRank == 0) {
+      test::RegisteredSendObservation hostObservation{};
+      CUDACHECK_TEST(cudaMemcpy(
+          &hostObservation,
+          observation,
+          sizeof(hostObservation),
+          cudaMemcpyDeviceToHost));
+      if (index == 4) {
+        EXPECT_EQ(hostObservation.postedCount, 0);
+      } else if (index == zeroByteAfterPostedIndex) {
+        EXPECT_EQ(hostObservation.postedCount, 2);
+      } else {
+        EXPECT_EQ(hostObservation.postedCount, 1);
+      }
+      EXPECT_EQ(hostObservation.drainedCount, 1);
+    } else {
+      CUDACHECK_TEST(cudaMemset(errorCount, 0, sizeof(int)));
+      test::verifyBufferPattern(
+          recvBuffer.get(), nbytes, pattern, errorCount, numBlocks, blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      int hostErrors = 0;
+      CUDACHECK_TEST(cudaMemcpy(
+          &hostErrors, errorCount, sizeof(hostErrors), cudaMemcpyDeviceToHost));
+      EXPECT_EQ(hostErrors, 0) << "registered send corrupted size " << nbytes;
+    }
+
+    if (index == 1 && globalRank == 1) {
+      CUDACHECK_TEST(cudaMemset(errorCount, 0, sizeof(int)));
+      test::testVerifyTransportStaging(
+          peerTransport,
+          false,
+          1,
+          simpleProtocolDataBytes - 1,
+          stagingPoison,
+          errorCount,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      int hostErrors = 0;
+      CUDACHECK_TEST(cudaMemcpy(
+          &hostErrors, errorCount, sizeof(hostErrors), cudaMemcpyDeviceToHost));
+      EXPECT_EQ(hostErrors, 0)
+          << "registered send wrote rounded tail bytes into recv staging";
+    }
+    if (globalRank == 0 && nbytes > 0) {
+      transport->deregisterBuffer(sendBuffer.get());
+    }
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  }
+
+  if (globalRank == 0) {
+    CUDACHECK_TEST(cudaMemset(errorCount, 0, sizeof(int)));
+    test::testVerifyTransportStaging(
+        peerTransport,
+        true,
+        0,
+        perChannelSize,
+        stagingPoison,
+        errorCount,
+        numBlocks,
+        blockSize);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    int hostErrors = 0;
+    CUDACHECK_TEST(cudaMemcpy(
+        &hostErrors, errorCount, sizeof(hostErrors), cudaMemcpyDeviceToHost));
+    EXPECT_EQ(hostErrors, 0)
+        << "registered send modified transport send staging";
+  }
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 }
 
 // =============================================================================

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -479,6 +479,138 @@ __global__ void progressReservationKernel(
   }
 }
 
+template <typename Transport>
+__device__ IbgdaRegisteredSendProgressStatus postRegisteredSend(
+    Transport& transport,
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& source,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    const Timeout& timeout,
+    RegisteredSendObservation* observation) {
+  transport.init_registered_send_progress(group, nbytes, maxSignalBytes);
+  IbgdaRegisteredSendProgressStatus status;
+  do {
+    status = transport.progress_registered_send_once(
+        group, source, nbytes, maxSignalBytes, timeout);
+    if (group.is_leader() && observation != nullptr) {
+      observation->record(status);
+    }
+  } while (status != IbgdaRegisteredSendProgressStatus::Posted &&
+           status != IbgdaRegisteredSendProgressStatus::Drained);
+  return status;
+}
+
+template <typename Transport>
+__device__ void drainRegisteredSends(
+    Transport& transport,
+    ThreadGroup& group,
+    const Timeout& timeout,
+    RegisteredSendObservation* observation) {
+  IbgdaRegisteredSendProgressStatus status;
+  do {
+    status = transport.progress_registered_send_drain_once(group, timeout);
+    if (group.is_leader() && observation != nullptr) {
+      observation->record(status);
+    }
+  } while (status != IbgdaRegisteredSendProgressStatus::Drained);
+}
+
+__global__ void registeredSendRecvKernel(
+    P2pIbTransportDevice transport,
+    IbgdaLocalBuffer source,
+    void* recvBuffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    bool send,
+    RegisteredSendObservation* observation,
+    bool blocking,
+    bool overwriteAfterDrain,
+    uint8_t overwriteValue,
+    bool zeroByteAfterPosted) {
+  auto group = make_block_group();
+  Timeout timeout(kDefaultDeviceTimeoutCycles);
+  timeout.start();
+  if (send) {
+    if (blocking) {
+      transport.send_registered(group, source, nbytes, maxSignalBytes, timeout);
+      if (group.is_leader() && observation != nullptr) {
+        ++observation->drainedCount;
+      }
+    } else {
+      const auto status = postRegisteredSend(
+          transport,
+          group,
+          source,
+          nbytes,
+          maxSignalBytes,
+          timeout,
+          observation);
+      if (zeroByteAfterPosted) {
+        transport.init_registered_send_progress(group, 0, maxSignalBytes);
+        const auto zeroByteStatus = transport.progress_registered_send_once(
+            group, IbgdaLocalBuffer{}, 0, maxSignalBytes, timeout);
+        if (group.is_leader() && observation != nullptr) {
+          observation->record(zeroByteStatus);
+        }
+      }
+      if (status != IbgdaRegisteredSendProgressStatus::Drained) {
+        drainRegisteredSends(transport, group, timeout, observation);
+      }
+    }
+    if (overwriteAfterDrain) {
+      auto* bytes = static_cast<uint8_t*>(source.ptr);
+      for (std::size_t i = group.thread_id_in_group; i < nbytes;
+           i += group.group_size) {
+        bytes[i] = overwriteValue;
+      }
+      group.sync();
+    }
+  } else {
+    transport.recv(group, recvBuffer, nbytes, maxSignalBytes, timeout);
+  }
+}
+
+__global__ void fillTransportStagingKernel(
+    P2pIbgdaTransportDevice* transport,
+    bool sendStaging,
+    std::size_t offset,
+    std::size_t nbytes,
+    uint8_t value) {
+  auto group = make_block_group();
+  auto& layout = transport->channel_layout();
+  char* staging = sendStaging ? layout.sendStagingPtr : layout.recvStagingPtr;
+  staging +=
+      static_cast<std::size_t>(group.group_id) * layout.perChannelBufferSize +
+      offset;
+  for (std::size_t i = group.thread_id_in_group; i < nbytes;
+       i += group.group_size) {
+    staging[i] = static_cast<char>(value);
+  }
+}
+
+__global__ void verifyTransportStagingKernel(
+    P2pIbgdaTransportDevice* transport,
+    bool sendStaging,
+    std::size_t offset,
+    std::size_t nbytes,
+    uint8_t expected,
+    int* errorCount) {
+  auto group = make_block_group();
+  const auto& layout = transport->channel_layout();
+  const char* staging =
+      sendStaging ? layout.sendStagingPtr : layout.recvStagingPtr;
+  staging +=
+      static_cast<std::size_t>(group.group_id) * layout.perChannelBufferSize +
+      offset;
+  for (std::size_t i = group.thread_id_in_group; i < nbytes;
+       i += group.group_size) {
+    if (static_cast<uint8_t>(staging[i]) != expected) {
+      atomicAdd(errorCount, 1);
+    }
+  }
+}
+
 #endif
 
 void testProgressSendRecv(
@@ -532,6 +664,115 @@ void testProgressReservations(
   progressReservationKernel<<<numBlocks, blockSize>>>(
       transport, output, sendBytes, recvBytes);
   cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+#endif
+}
+
+void testRegisteredSendRecv(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& source,
+    void* recvBuffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize,
+    RegisteredSendObservation* observation,
+    bool blocking,
+    bool overwriteAfterDrain,
+    uint8_t overwriteValue,
+    bool zeroByteAfterPosted) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)source;
+  (void)recvBuffer;
+  (void)nbytes;
+  (void)maxSignalBytes;
+  (void)send;
+  (void)numBlocks;
+  (void)blockSize;
+  (void)observation;
+  (void)blocking;
+  (void)overwriteAfterDrain;
+  (void)overwriteValue;
+  (void)zeroByteAfterPosted;
+  throw std::runtime_error("registered-source send is NVIDIA-only");
+#else
+  P2pIbTransportDevice unifiedTransport(transport);
+  registeredSendRecvKernel<<<numBlocks, blockSize>>>(
+      unifiedTransport,
+      source,
+      recvBuffer,
+      nbytes,
+      maxSignalBytes,
+      send,
+      observation,
+      blocking,
+      overwriteAfterDrain,
+      overwriteValue,
+      zeroByteAfterPosted);
+  const cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+#endif
+}
+
+void testFillTransportStaging(
+    P2pIbgdaTransportDevice* transport,
+    bool sendStaging,
+    std::size_t offset,
+    std::size_t nbytes,
+    uint8_t value,
+    int numBlocks,
+    int blockSize) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)sendStaging;
+  (void)offset;
+  (void)nbytes;
+  (void)value;
+  (void)numBlocks;
+  (void)blockSize;
+  throw std::runtime_error("registered-source send is NVIDIA-only");
+#else
+  fillTransportStagingKernel<<<numBlocks, blockSize>>>(
+      transport, sendStaging, offset, nbytes, value);
+  const cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+#endif
+}
+
+void testVerifyTransportStaging(
+    P2pIbgdaTransportDevice* transport,
+    bool sendStaging,
+    std::size_t offset,
+    std::size_t nbytes,
+    uint8_t expected,
+    int* errorCount,
+    int numBlocks,
+    int blockSize) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)sendStaging;
+  (void)offset;
+  (void)nbytes;
+  (void)expected;
+  (void)errorCount;
+  (void)numBlocks;
+  (void)blockSize;
+  throw std::runtime_error("registered-source send is NVIDIA-only");
+#else
+  verifyTransportStagingKernel<<<numBlocks, blockSize>>>(
+      transport, sendStaging, offset, nbytes, expected, errorCount);
+  const cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(
         std::string("Kernel launch failed: ") + cudaGetErrorString(err));

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -571,6 +571,57 @@ __global__ void registeredSendRecvKernel(
   }
 }
 
+__global__ void mixedRegisteredAndStagedSendRecvKernel(
+    P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t thirdBytes,
+    std::size_t maxSignalBytes,
+    bool send) {
+  auto group = make_block_group();
+  Timeout timeout(kDefaultDeviceTimeoutCycles);
+  timeout.start();
+  if (send) {
+    (void)postRegisteredSend(
+        *transport,
+        group,
+        sendBuffer,
+        firstBytes,
+        maxSignalBytes,
+        timeout,
+        nullptr);
+    transport->send(
+        group,
+        static_cast<const char*>(sendBuffer.ptr) + firstBytes,
+        secondBytes,
+        maxSignalBytes,
+        timeout);
+    (void)postRegisteredSend(
+        *transport,
+        group,
+        sendBuffer.subBuffer(firstBytes + secondBytes),
+        thirdBytes,
+        maxSignalBytes,
+        timeout,
+        nullptr);
+    drainRegisteredSends(*transport, group, timeout, nullptr);
+    return;
+  }
+
+  auto* output = static_cast<char*>(recvBuffer);
+  transport->recv(group, output, firstBytes, maxSignalBytes, timeout);
+  transport->recv(
+      group, output + firstBytes, secondBytes, maxSignalBytes, timeout);
+  transport->recv(
+      group,
+      output + firstBytes + secondBytes,
+      thirdBytes,
+      maxSignalBytes,
+      timeout);
+}
+
 __global__ void fillTransportStagingKernel(
     P2pIbgdaTransportDevice* transport,
     bool sendStaging,
@@ -714,6 +765,47 @@ void testRegisteredSendRecv(
       overwriteAfterDrain,
       overwriteValue,
       zeroByteAfterPosted);
+  const cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+#endif
+}
+
+void testMixedRegisteredAndStagedSendRecv(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t thirdBytes,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)sendBuffer;
+  (void)recvBuffer;
+  (void)firstBytes;
+  (void)secondBytes;
+  (void)thirdBytes;
+  (void)maxSignalBytes;
+  (void)send;
+  (void)numBlocks;
+  (void)blockSize;
+  throw std::runtime_error("registered-source send is NVIDIA-only");
+#else
+  mixedRegisteredAndStagedSendRecvKernel<<<numBlocks, blockSize>>>(
+      transport,
+      sendBuffer,
+      recvBuffer,
+      firstBytes,
+      secondBytes,
+      thirdBytes,
+      maxSignalBytes,
+      send);
   const cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
@@ -104,6 +104,34 @@ __global__ void progressReservationKernel(
     int64_t* output,
     std::size_t sendBytes,
     std::size_t recvBytes);
+
+__global__ void registeredSendRecvKernel(
+    P2pIbTransportDevice transport,
+    IbgdaLocalBuffer source,
+    void* recvBuffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    bool send,
+    RegisteredSendObservation* observation,
+    bool blocking,
+    bool overwriteAfterDrain,
+    uint8_t overwriteValue,
+    bool zeroByteAfterPosted);
+
+__global__ void fillTransportStagingKernel(
+    P2pIbgdaTransportDevice* transport,
+    bool sendStaging,
+    std::size_t offset,
+    std::size_t nbytes,
+    uint8_t value);
+
+__global__ void verifyTransportStagingKernel(
+    P2pIbgdaTransportDevice* transport,
+    bool sendStaging,
+    std::size_t offset,
+    std::size_t nbytes,
+    uint8_t expected,
+    int* errorCount);
 #endif
 
 __global__ void

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
@@ -118,6 +118,16 @@ __global__ void registeredSendRecvKernel(
     uint8_t overwriteValue,
     bool zeroByteAfterPosted);
 
+__global__ void mixedRegisteredAndStagedSendRecvKernel(
+    P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t thirdBytes,
+    std::size_t maxSignalBytes,
+    bool send);
+
 __global__ void fillTransportStagingKernel(
     P2pIbgdaTransportDevice* transport,
     bool sendStaging,

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -122,6 +122,31 @@ void testPutOnly(
  */
 bool supportsProgressSendRecv();
 
+struct RegisteredSendObservation {
+  uint64_t waitingCount{0};
+  uint64_t progressedCount{0};
+  uint64_t postedCount{0};
+  uint64_t drainedCount{0};
+
+  template <typename Status>
+  IBGDA_HOST_DEVICE void record(Status status) {
+    switch (status) {
+      case Status::Waiting:
+        ++waitingCount;
+        break;
+      case Status::Progressed:
+        ++progressedCount;
+        break;
+      case Status::Posted:
+        ++postedCount;
+        break;
+      case Status::Drained:
+        ++drainedCount;
+        break;
+    }
+  }
+};
+
 /**
  * Test kernel: snapshot send/recv pipeline geometry through the unified IB
  * transport wrapper. Output: pipelineDepth, pipelineWindow, pipelineChunk.
@@ -197,6 +222,44 @@ void testProgressReservations(
     int64_t* output,
     std::size_t sendBytes,
     std::size_t recvBytes,
+    int numBlocks,
+    int blockSize);
+
+/**
+ * Test kernel: registered-source send progress or the matching staged recv.
+ */
+void testRegisteredSendRecv(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& source,
+    void* recvBuffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize,
+    RegisteredSendObservation* observation = nullptr,
+    bool blocking = false,
+    bool overwriteAfterDrain = false,
+    uint8_t overwriteValue = 0,
+    bool zeroByteAfterPosted = false);
+
+/** Fill or verify a byte range in this channel's transport staging. */
+void testFillTransportStaging(
+    P2pIbgdaTransportDevice* transport,
+    bool sendStaging,
+    std::size_t offset,
+    std::size_t nbytes,
+    uint8_t value,
+    int numBlocks,
+    int blockSize);
+
+void testVerifyTransportStaging(
+    P2pIbgdaTransportDevice* transport,
+    bool sendStaging,
+    std::size_t offset,
+    std::size_t nbytes,
+    uint8_t expected,
+    int* errorCount,
     int numBlocks,
     int blockSize);
 

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -243,6 +243,21 @@ void testRegisteredSendRecv(
     uint8_t overwriteValue = 0,
     bool zeroByteAfterPosted = false);
 
+/**
+ * Test kernel: registered A, staged B, registered C on one send cursor.
+ */
+void testMixedRegisteredAndStagedSendRecv(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t thirdBytes,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize);
+
 /** Fill or verify a byte range in this channel's transport staging. */
 void testFillTransportStaging(
     P2pIbgdaTransportDevice* transport,

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -505,6 +505,17 @@ __device__ __forceinline__ void P2pIbTransportDevice::fence() {
 // Pipelined send/recv — forwarded to the active backend.
 // ===========================================================================
 
+__device__ __forceinline__ void P2pIbTransportDevice::require_ibgda(
+    ThreadGroup& group,
+    const char* operation) const {
+  if (type == P2pIbBackendType::IBRC) {
+    if (group.is_leader()) {
+      printf("[PIPES] FATAL: %s requires IBGDA\n", operation);
+    }
+    PIPES_DEVICE_TRAP();
+  }
+}
+
 template <typename CopyOp, typename... Args>
 __device__ __forceinline__ void P2pIbTransportDevice::send(
     ThreadGroup& group,
@@ -518,6 +529,17 @@ __device__ __forceinline__ void P2pIbTransportDevice::send(
   } else {
     ibgda->send<CopyOp>(group, src, nbytes, max_signal_bytes, timeout, args...);
   }
+}
+
+template <typename>
+__device__ __forceinline__ void P2pIbTransportDevice::send_registered(
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout) {
+  require_ibgda(group, "registered-source send");
+  ibgda->send_registered(group, src, nbytes, max_signal_bytes, timeout);
 }
 
 template <typename CopyOp, typename... Args>
@@ -596,6 +618,16 @@ __device__ __forceinline__ void P2pIbTransportDevice::init_send_progress(
 }
 
 template <typename>
+__device__ __forceinline__ void
+P2pIbTransportDevice::init_registered_send_progress(
+    ThreadGroup& group,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes) {
+  require_ibgda(group, "registered-source send progress");
+  ibgda->init_registered_send_progress(group, nbytes, max_signal_bytes);
+}
+
+template <typename>
 __device__ __forceinline__ void P2pIbTransportDevice::init_recv_progress(
     ThreadGroup& group,
     std::size_t nbytes,
@@ -622,6 +654,28 @@ P2pIbTransportDevice::progress_send_once(
   }
   return ibgda->progress_send_once<CopyOp>(
       group, src, nbytes, max_signal_bytes, timeout, args...);
+}
+
+template <typename>
+__device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+P2pIbTransportDevice::progress_registered_send_once(
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout) {
+  require_ibgda(group, "registered-source send progress");
+  return ibgda->progress_registered_send_once(
+      group, src, nbytes, max_signal_bytes, timeout);
+}
+
+template <typename>
+__device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+P2pIbTransportDevice::progress_registered_send_drain_once(
+    ThreadGroup& group,
+    const Timeout& timeout) {
+  require_ibgda(group, "registered-source send drain");
+  return ibgda->progress_registered_send_drain_once(group, timeout);
 }
 
 template <typename CopyOp, typename... Args>

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -29,6 +29,50 @@ enum class IbgdaSendRecvProgressStatus : uint8_t {
   Done,
 };
 
+enum class IbgdaRegisteredSendProgressStatus : uint8_t {
+  Waiting,
+  Progressed,
+  Posted,
+  Drained,
+};
+
+namespace detail {
+
+template <typename Transport>
+__device__ __forceinline__ void init_registered_send_progress(
+    Transport& transport,
+    ThreadGroup& group,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0);
+
+template <typename Transport>
+__device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+progress_registered_send_once(
+    Transport& transport,
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0,
+    const Timeout& timeout = Timeout());
+
+template <typename Transport>
+__device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+progress_registered_send_drain_once(
+    Transport& transport,
+    ThreadGroup& group,
+    const Timeout& timeout = Timeout());
+
+template <typename Transport>
+__device__ __forceinline__ void send_registered(
+    Transport& transport,
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0,
+    const Timeout& timeout = Timeout());
+
+} // namespace detail
+
 struct P2pIbTransportDevice {
   P2pIbBackendType type{P2pIbBackendType::IBGDA};
   union {
@@ -213,6 +257,10 @@ struct P2pIbTransportDevice {
 
   __device__ void fence();
 
+  __device__ __forceinline__ void require_ibgda(
+      ThreadGroup& group,
+      const char* operation) const;
+
   template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void send(
       ThreadGroup& group,
@@ -221,6 +269,14 @@ struct P2pIbTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args);
+
+  template <typename = void>
+  __device__ __forceinline__ void send_registered(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& src,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout());
 
   template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void recv(
@@ -254,6 +310,12 @@ struct P2pIbTransportDevice {
       std::size_t max_signal_bytes = 0);
 
   template <typename = void>
+  __device__ __forceinline__ void init_registered_send_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0);
+
+  template <typename = void>
   __device__ __forceinline__ void init_recv_progress(
       ThreadGroup& group,
       std::size_t nbytes,
@@ -267,6 +329,21 @@ struct P2pIbTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args);
+
+  template <typename = void>
+  __device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+  progress_registered_send_once(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& src,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout());
+
+  template <typename = void>
+  __device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+  progress_registered_send_drain_once(
+      ThreadGroup& group,
+      const Timeout& timeout = Timeout());
 
   template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -162,6 +162,26 @@ __device__ __forceinline__ void init_send_progress(
 #endif
 }
 
+template <typename Transport>
+__device__ __forceinline__ void init_registered_send_progress(
+    Transport& transport,
+    ThreadGroup& group,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  if (nbytes > 0) {
+    __threadfence_system();
+    group.sync();
+  }
+  init_send_progress(transport, group, nbytes, max_signal_bytes);
+#else
+  (void)transport;
+  (void)group;
+  (void)nbytes;
+  (void)max_signal_bytes;
+#endif
+}
+
 /**
  * Initialize transport-owned state for one pipelined recv operation.
  *
@@ -468,6 +488,249 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
   (void)max_signal_bytes;
   (void)timeout;
   return IbgdaSendRecvProgressStatus::Done;
+#endif
+}
+
+template <typename Transport>
+__device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+progress_registered_send_once(
+    Transport& transport,
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  auto& channelLayout = transport.channel_layout();
+  auto& progressSlot = progress_send_slot<protocol::Simple>(transport, group);
+  IbChannelProgress state = progressSlot;
+  if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
+    return IbgdaRegisteredSendProgressStatus::Posted;
+  }
+
+  const ProgressGeometry geometry = make_progress_geometry<protocol::Simple>(
+      channelLayout,
+      group,
+      nbytes,
+      max_signal_bytes,
+      "progress_registered_send_once");
+  if (active_payload_offset(state) >= geometry.protocolBytes) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: progress_registered_send_once payloadOffset=%llu "
+          ">= protocolBytes=%llu without Done stage\n",
+          static_cast<unsigned long long>(active_payload_offset(state)),
+          static_cast<unsigned long long>(geometry.protocolBytes));
+    }
+    PIPES_DEVICE_TRAP();
+  }
+  validate_send_progress_stage(group, state);
+
+  const detail::IbSendRecvProgressStage initialStage = state.activeStage;
+  const std::size_t initialNextByte = state.activeNextByte;
+  const std::size_t pipelineBytesWire = geometry.perBlockSlotWire *
+      static_cast<std::size_t>(channelLayout.pipelineDepth);
+  const ChannelSlotView ch =
+      acquire_channel<protocol::Simple>(transport, channelLayout, group);
+  const IbgdaLocalBuffer localSlotFree = ch.local.slotFree;
+  const IbRemoteChannel remoteChannel = ch.remote;
+
+  if (state.activeStage ==
+      detail::IbSendRecvProgressStage::WaitLocalCompletion) {
+    const ProgressChunk chunk =
+        next_chunk<protocol::Simple>(channelLayout, state, geometry);
+    if (!try_prepare_send_slot<protocol::Simple>(
+            transport,
+            group,
+            chunk.slotId,
+            chunk.pipelineGeneration,
+            timeout)) {
+      return IbgdaRegisteredSendProgressStatus::Waiting;
+    }
+    transition_progress_stage(
+        group, state, detail::IbSendRecvProgressStage::WaitSlotFree);
+  }
+
+  if (state.activeStage == detail::IbSendRecvProgressStage::WaitSlotFree) {
+    const ProgressChunk chunk =
+        next_chunk<protocol::Simple>(channelLayout, state, geometry);
+    const bool isFinalChunk =
+        chunk.dataOff + chunk.payloadBytes >= geometry.protocolBytes;
+    const uint64_t protocolStreamEnd = chunk.streamEndWire +
+        (isFinalChunk ? protocol::Simple::wire_bytes(state.activeTailPadding)
+                      : 0);
+    if (protocolStreamEnd > pipelineBytesWire) {
+      const uint64_t expected = protocolStreamEnd - pipelineBytesWire;
+      uint32_t ready = 1;
+      unsigned long long current = 0;
+      if (group.is_leader()) {
+        current = static_cast<unsigned long long>(
+            transport.read_signal(localSlotFree));
+        ready = current >= expected ? 1U : 0U;
+        if (!ready) {
+          TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+              timeout,
+              "progress_registered_send_once waiting for SLOT_FREE "
+              "expected>=%llu, current=%llu",
+              static_cast<unsigned long long>(expected),
+              current);
+        }
+      }
+      ready = group.broadcast<uint32_t>(ready);
+      if (!ready) {
+        if (state.activeStage != initialStage ||
+            state.activeNextByte != initialNextByte) {
+          store_progress_state(group, progressSlot, state);
+          return IbgdaRegisteredSendProgressStatus::Progressed;
+        }
+        return IbgdaRegisteredSendProgressStatus::Waiting;
+      }
+    }
+
+    const std::size_t validBytes = valid_payload_bytes(
+        chunk.dataOff, chunk.payloadBytes, geometry.payloadBytes);
+    const std::size_t protocolBytesThis = chunk.wireBytes +
+        (isFinalChunk ? protocol::Simple::wire_bytes(state.activeTailPadding)
+                      : 0);
+
+    group.sync();
+    if (group.is_leader()) {
+      __threadfence_system();
+      ThreadGroup solo{
+          0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+      const auto completion = transport.put(
+          solo,
+          src.subBuffer(chunk.dataOff),
+          remoteChannel.recvStaging.subBuffer(chunk.stagingOff),
+          validBytes,
+          remoteChannel.dataReady,
+          protocolBytesThis,
+          {},
+          0,
+          true);
+      record_send_completion<protocol::Simple>(
+          transport,
+          static_cast<uint32_t>(geometry.groupId),
+          chunk.slotId,
+          chunk.pipelineGeneration,
+          completion);
+    }
+    group.sync();
+
+    state.activeNextByte += chunk.payloadBytes;
+    if (active_payload_offset(state) >= geometry.protocolBytes) {
+      transition_progress_stage(
+          group, state, detail::IbSendRecvProgressStage::Done);
+      store_progress_state(group, progressSlot, state);
+      return IbgdaRegisteredSendProgressStatus::Posted;
+    }
+    transition_progress_stage(
+        group, state, detail::IbSendRecvProgressStage::WaitLocalCompletion);
+  }
+
+  if (state.activeStage != initialStage ||
+      state.activeNextByte != initialNextByte) {
+    store_progress_state(group, progressSlot, state);
+    return IbgdaRegisteredSendProgressStatus::Progressed;
+  }
+  return IbgdaRegisteredSendProgressStatus::Waiting;
+#else
+  (void)transport;
+  (void)group;
+  (void)src;
+  (void)nbytes;
+  (void)max_signal_bytes;
+  (void)timeout;
+  return IbgdaRegisteredSendProgressStatus::Drained;
+#endif
+}
+
+template <typename Transport>
+__device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+progress_registered_send_drain_once(
+    Transport& transport,
+    ThreadGroup& group,
+    const Timeout& timeout) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  uint32_t result =
+      static_cast<uint32_t>(IbgdaRegisteredSendProgressStatus::Drained);
+  if (group.is_leader()) {
+    bool foundPending = false;
+    bool madeProgress = false;
+    auto& channel =
+        transport.template local_channel_slot<protocol::Simple>(group.group_id);
+    const uint32_t numLanes = transport.send_completion_lane_count();
+    const int pipelineDepth = transport.channel_layout().pipelineDepth;
+
+    for (int slotId = 0; slotId < pipelineDepth; ++slotId) {
+      auto& slot = channel.sendCompletionSlots[slotId];
+      uint64_t pending = slot.laneMask;
+      for (uint32_t laneId = 0; laneId < numLanes; ++laneId) {
+        const uint64_t laneBit = 1ULL << laneId;
+        if ((pending & laneBit) == 0) {
+          continue;
+        }
+        const IbLocalCompletionTicket ticket{
+            .completionId = laneId,
+            .value = slot.values[laneId],
+        };
+        if (transport.is_local_completion_ready(group.group_id, ticket)) {
+          pending &= ~laneBit;
+          madeProgress = true;
+          continue;
+        }
+        foundPending = true;
+        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+            timeout,
+            "registered send local completion timed out slot=%d lane=%u",
+            slotId,
+            laneId);
+      }
+      slot.laneMask = pending;
+    }
+
+    if (foundPending) {
+      result = static_cast<uint32_t>(
+          madeProgress ? IbgdaRegisteredSendProgressStatus::Progressed
+                       : IbgdaRegisteredSendProgressStatus::Waiting);
+    }
+  }
+  result = group.broadcast<uint32_t>(result);
+  return static_cast<IbgdaRegisteredSendProgressStatus>(result);
+#else
+  (void)transport;
+  (void)group;
+  (void)timeout;
+  return IbgdaRegisteredSendProgressStatus::Drained;
+#endif
+}
+
+template <typename Transport>
+__device__ __forceinline__ void send_registered(
+    Transport& transport,
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  init_registered_send_progress(transport, group, nbytes, max_signal_bytes);
+  IbgdaRegisteredSendProgressStatus status;
+  do {
+    status = progress_registered_send_once(
+        transport, group, src, nbytes, max_signal_bytes, timeout);
+  } while (status != IbgdaRegisteredSendProgressStatus::Posted &&
+           status != IbgdaRegisteredSendProgressStatus::Drained);
+  while (status != IbgdaRegisteredSendProgressStatus::Drained) {
+    status = progress_registered_send_drain_once(transport, group, timeout);
+  }
+#else
+  (void)transport;
+  (void)group;
+  (void)src;
+  (void)nbytes;
+  (void)max_signal_bytes;
+  (void)timeout;
 #endif
 }
 

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -2081,6 +2081,19 @@ class P2pIbgdaTransportDevice {
   }
 
   /**
+   * Initialize a registered-source send that shares the normal send protocol
+   * cursor but bypasses local send staging.
+   */
+  template <typename = void>
+  __device__ __forceinline__ void init_registered_send_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0) {
+    detail::init_registered_send_progress(
+        *this, group, nbytes, max_signal_bytes);
+  }
+
+  /**
    * Initialize transport-owned state for one pipelined recv operation.
    *
    * The transport reserves the receiver-side protocol byte stream for
@@ -2156,6 +2169,34 @@ class P2pIbgdaTransportDevice {
       Args... args) {
     return detail::progress_send_once<P2pIbgdaTransportDevice, CopyOp>(
         *this, group, src, nbytes, max_signal_bytes, timeout, args...);
+  }
+
+  /**
+   * Post registered-source send chunks without copying through send staging.
+   * `Posted` does not release the source; callers must later drain.
+   */
+  template <typename = void>
+  __device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+  progress_registered_send_once(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& src,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout()) {
+    return detail::progress_registered_send_once(
+        *this, group, src, nbytes, max_signal_bytes, timeout);
+  }
+
+  /**
+   * Poll all outstanding send completion tickets for this channel. `Drained`
+   * means registered source ranges posted before the call are reusable.
+   */
+  template <typename = void>
+  __device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+  progress_registered_send_drain_once(
+      ThreadGroup& group,
+      const Timeout& timeout = Timeout()) {
+    return detail::progress_registered_send_drain_once(*this, group, timeout);
   }
 
   /**
@@ -2248,6 +2289,20 @@ class P2pIbgdaTransportDevice {
       Args... args) {
     sendWithTrace<CopyOp>(
         group, src, nbytes, max_signal_bytes, timeout, {}, 0, args...);
+  }
+
+  /**
+   * Blocking registered-source send. Returns only after local NIC completion.
+   */
+  template <typename = void>
+  __device__ __forceinline__ void send_registered(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& src,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout()) {
+    detail::send_registered(
+        *this, group, src, nbytes, max_signal_bytes, timeout);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>


### PR DESCRIPTION
Summary:

Cover two protocol interactions for registered-source IBGDA sends: sharing the normal send cursor with staged sends, and maintaining backpressure and data integrity across repeated staging-slot wrap.

This is test-only hardening for the registered-source transport primitive.

Reviewed By: rmahidhar

Differential Revision: D114552006


