### PR TITLE
Add bulk-buffer registration leases for IBGDA (#3414)

### DIFF
--- a/comms/prims/P2pIbTransportBuildContractTest.py
+++ b/comms/prims/P2pIbTransportBuildContractTest.py
@@ -7,10 +7,14 @@ from pathlib import Path
 
 _PROGRESS_ONLY_FUNCTIONS = (
     "init_send_progress",
+    "init_registered_send_progress",
     "init_recv_progress",
     "progress_send_once",
+    "progress_registered_send_once",
+    "progress_registered_send_drain_once",
     "poll_recv_data_ready",
     "progress_recv_once",
+    "send_registered",
     "store_progress_state",
     "make_progress_geometry",
     "active_payload_offset",

--- a/comms/prims/benchmarks/IbgdaSendRecv.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cu
@@ -416,7 +416,8 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_send_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    Timeout timeout,
+    bool waitForSlotFree) {
   auto group = make_block_group();
 
   const std::size_t sectionBytes = section_bytes(transport, totalBytes);
@@ -430,6 +431,50 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_send_kernel(
            IbgdaSendRecvProgressStatus::Done) {
     }
   }
+
+  if (waitForSlotFree) {
+    auto& channel = transport->local_channel(group.group_id);
+    transport->wait_signal(
+        group,
+        channel.slotFree,
+        static_cast<uint64_t>(channel.sendProgress.nextStep),
+        timeout);
+  }
+}
+
+__global__ void __launch_bounds__(512, 1) ibgda_registered_progress_send_kernel(
+    P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer src,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  auto status = IbgdaRegisteredSendProgressStatus::Waiting;
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    const auto section = src.subBuffer(s * sectionBytes);
+    transport->init_registered_send_progress(
+        group, sectionBytes, maxSignalBytes);
+    status = IbgdaRegisteredSendProgressStatus::Waiting;
+    while (status != IbgdaRegisteredSendProgressStatus::Posted &&
+           status != IbgdaRegisteredSendProgressStatus::Drained) {
+      status = transport->progress_registered_send_once(
+          group, section, sectionBytes, maxSignalBytes, timeout);
+    }
+  }
+  while (status != IbgdaRegisteredSendProgressStatus::Drained) {
+    status = transport->progress_registered_send_drain_once(group, timeout);
+  }
+
+  auto& channel = transport->local_channel(group.group_id);
+  transport->wait_signal(
+      group,
+      channel.slotFree,
+      static_cast<uint64_t>(channel.sendProgress.nextStep),
+      timeout);
 }
 
 __global__ void __launch_bounds__(512, 1) ibgda_progress_recv_kernel(
@@ -474,11 +519,69 @@ void launch_ibgda_progress_send(
   printf("[PIPES] progress send benchmark is NVIDIA-only\n");
 #else
   ibgda_progress_send_kernel<<<numBlocks, 512, 0, stream>>>(
-      transport, src, nbytes, numBlocks, maxSignalBytes, timeout);
+      transport, src, nbytes, numBlocks, maxSignalBytes, timeout, false);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(
         "[PIPES] progress send kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+#endif
+}
+
+void launch_ibgda_progress_send_complete(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)src;
+  (void)nbytes;
+  (void)numBlocks;
+  (void)stream;
+  (void)maxSignalBytes;
+  (void)timeout;
+  printf("[PIPES] progress send benchmark is NVIDIA-only\n");
+#else
+  ibgda_progress_send_kernel<<<numBlocks, 512, 0, stream>>>(
+      transport, src, nbytes, numBlocks, maxSignalBytes, timeout, true);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] progress send kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+#endif
+}
+
+void launch_ibgda_registered_progress_send(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& src,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)src;
+  (void)nbytes;
+  (void)numBlocks;
+  (void)stream;
+  (void)maxSignalBytes;
+  (void)timeout;
+  printf("[PIPES] registered progress send benchmark is NVIDIA-only\n");
+#else
+  ibgda_registered_progress_send_kernel<<<numBlocks, 512, 0, stream>>>(
+      transport, src, nbytes, numBlocks, maxSignalBytes, timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] registered progress send kernel launch failed: %s\n",
         cudaGetErrorString(err));
   }
 #endif

--- a/comms/prims/benchmarks/IbgdaSendRecv.cuh
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cuh
@@ -86,6 +86,19 @@ __global__ void ibgda_progress_send_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
+    Timeout timeout,
+    bool waitForSlotFree);
+
+/**
+ * Unidirectional registered-source progress send kernel.
+ * Grid: numBlocks. Block: 512 threads.
+ */
+__global__ void ibgda_registered_progress_send_kernel(
+    P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer src,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
     Timeout timeout);
 
 /**

--- a/comms/prims/benchmarks/IbgdaSendRecv.h
+++ b/comms/prims/benchmarks/IbgdaSendRecv.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 
 #include "comms/prims/core/Timeout.cuh"
+#include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 
 namespace comms::prims {
 class P2pIbgdaTransportDevice;
@@ -122,6 +123,33 @@ void launch_ibgda_reset_send_recv(
 void launch_ibgda_progress_send(
     P2pIbgdaTransportDevice* transport,
     char* src,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
+    Timeout timeout = Timeout());
+
+/**
+ * Launch the staged progress sender and wait for the receiver's final credit.
+ */
+void launch_ibgda_progress_send_complete(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
+    Timeout timeout = Timeout());
+
+/**
+ * Launch a unidirectional registered-source progress send kernel.
+ *
+ * The source is read directly by the NIC. The kernel drains local NIC reads
+ * and waits for the receiver's final slot-free credit before returning.
+ */
+void launch_ibgda_registered_progress_send(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& src,
     std::size_t nbytes,
     int numBlocks,
     cudaStream_t stream,

--- a/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -8,6 +8,7 @@
 #include <folly/portability/GFlags.h>
 #include <glog/logging.h>
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstdlib>
@@ -28,14 +29,29 @@ using meta::comms::ITestBootstrap;
 using meta::comms::MpiBootstrap;
 using meta::comms::TcpStoreBootstrap;
 
+DEFINE_bool(
+    ibgda_sendrecv_enable_registered,
+    false,
+    "Enable the registered-source send comparison");
+DEFINE_int32(
+    ibgda_sendrecv_num_blocks,
+    2,
+    "Number of sender and receiver blocks");
+DEFINE_int64(
+    ibgda_sendrecv_per_channel_bytes,
+    4 * 1024 * 1024,
+    "Transport staging bytes per channel");
+DEFINE_int32(ibgda_sendrecv_pipeline_depth, 2, "Transport slots per channel");
+DEFINE_int32(
+    ibgda_sendrecv_qps_per_connection,
+    1,
+    "QPs per channel, direction, and NIC");
+DEFINE_int32(ibgda_sendrecv_warmup_iters, 5, "Warmup iterations");
+
 namespace comms::prims::benchmark {
 namespace {
 
 constexpr int kWorldSize = 2;
-constexpr int kNumBlocks = 2;
-constexpr std::size_t kSlotSize = 8 * 1024 * 1024;
-constexpr int kPipelineDepth = 2;
-constexpr int kWarmupIters = 5;
 constexpr const char* kDefaultBenchmarkIters = "20";
 constexpr const char* kDefaultBenchmarkMaxIters = "21";
 
@@ -51,6 +67,7 @@ constexpr uint32_t kSmallMessageIters = 2048;
 enum class SendRecvApi {
   Blocking,
   Progress,
+  RegisteredProgress,
 };
 
 enum class SendRecvDirection {
@@ -226,6 +243,8 @@ const char* apiName(SendRecvApi api) {
       return "blocking";
     case SendRecvApi::Progress:
       return "progress";
+    case SendRecvApi::RegisteredProgress:
+      return "registered_progress";
   }
   return "unknown";
 }
@@ -252,7 +271,8 @@ std::string benchmarkName(
     SendRecvApi api,
     SendRecvDirection direction,
     SendRecvCopyOp copyOp,
-    const char* sizeName) {
+    const char* sizeName,
+    int repeat = -1) {
   std::string name = "ibgdaSendRecv(";
   name += apiName(api);
   name += "_";
@@ -261,6 +281,10 @@ std::string benchmarkName(
   name += copyOpName(copyOp);
   name += "_";
   name += sizeName;
+  if (repeat >= 0) {
+    name += "_rep";
+    name += std::to_string(repeat);
+  }
   name += ")";
   return name;
 }
@@ -270,9 +294,27 @@ class IbgdaSendRecvBenchmarkContext {
   IbgdaSendRecvBenchmarkContext(
       std::shared_ptr<ITestBootstrap> bootstrap,
       std::size_t maxBytes)
-      : bootstrap_(std::move(bootstrap)), maxBytes_(maxBytes) {
+      : bootstrap_(std::move(bootstrap)),
+        maxBytes_(maxBytes),
+        perChannelSize_(
+            static_cast<std::size_t>(FLAGS_ibgda_sendrecv_per_channel_bytes)),
+        numBlocks_(FLAGS_ibgda_sendrecv_num_blocks),
+        pipelineDepth_(FLAGS_ibgda_sendrecv_pipeline_depth),
+        warmupIters_(FLAGS_ibgda_sendrecv_warmup_iters),
+        registeredEnabled_(FLAGS_ibgda_sendrecv_enable_registered) {
     CHECK(bootstrap_ != nullptr);
     CHECK_GT(maxBytes_, 0);
+    CHECK_GT(FLAGS_ibgda_sendrecv_per_channel_bytes, 0);
+    CHECK_GT(FLAGS_ibgda_sendrecv_qps_per_connection, 0);
+    CHECK_GT(perChannelSize_, 0);
+    CHECK_GT(numBlocks_, 0);
+    CHECK_GT(pipelineDepth_, 0);
+    CHECK_GT(warmupIters_, 0);
+    CHECK_EQ(perChannelSize_ % static_cast<std::size_t>(pipelineDepth_), 0);
+    if (registeredEnabled_) {
+      CHECK_EQ(numBlocks_, 1)
+          << "registered-source comparison requires one block";
+    }
     globalRank_ = bootstrap_->getGlobalRank();
     worldSize_ = bootstrap_->getWorldSize();
     localRank_ = bootstrap_->getLocalRank();
@@ -288,9 +330,10 @@ class IbgdaSendRecvBenchmarkContext {
 
     MultipeerIbgdaTransportConfig transportConfig{
         .cudaDevice = localRank_,
-        .perChannelSize = kSlotSize / kNumBlocks,
-        .max_num_channels = kNumBlocks,
-        .pipelineDepth = kPipelineDepth,
+        .perChannelSize = perChannelSize_,
+        .max_num_channels = numBlocks_,
+        .pipelineDepth = pipelineDepth_,
+        .qpsPerConnection = FLAGS_ibgda_sendrecv_qps_per_connection,
     };
     transportConfig.ibHca = benchIbHca();
     transport_ = std::make_unique<MultipeerIbgdaTransport>(
@@ -303,6 +346,11 @@ class IbgdaSendRecvBenchmarkContext {
     CHECK_EQ(cudaMemset(recvBuf_->get(), 0, maxBytes_), cudaSuccess);
     CHECK_EQ(cudaDeviceSynchronize(), cudaSuccess);
 
+    if (registeredEnabled_ && globalRank_ == 0) {
+      registeredSendBuf_ =
+          transport_->registerBuffer(sendBuf_->get(), maxBytes_, true);
+    }
+
     deviceTransport_ = transport_->getP2pTransportDevice(1 - globalRank_);
   }
 
@@ -313,6 +361,10 @@ class IbgdaSendRecvBenchmarkContext {
     }
     if (bootstrap_) {
       bootstrap_->barrierAll();
+    }
+    if (transport_ && registeredSendBuf_.ptr != nullptr) {
+      transport_->deregisterBuffer(sendBuf_->get());
+      registeredSendBuf_ = {};
     }
     if (stream_ != nullptr) {
       CHECK_EQ(cudaStreamDestroy(stream_), cudaSuccess);
@@ -331,6 +383,18 @@ class IbgdaSendRecvBenchmarkContext {
   IbgdaSendRecvBenchmarkContext& operator=(IbgdaSendRecvBenchmarkContext&&) =
       delete;
 
+  int numBlocks() const {
+    return numBlocks_;
+  }
+
+  std::size_t pipelineChunkBytes() const {
+    return perChannelSize_ / static_cast<std::size_t>(pipelineDepth_);
+  }
+
+  bool registeredEnabled() const {
+    return registeredEnabled_;
+  }
+
   void warmup(
       std::size_t nbytes,
       SendRecvApi api,
@@ -338,10 +402,11 @@ class IbgdaSendRecvBenchmarkContext {
       SendRecvCopyOp copyOp) {
     CHECK_LE(nbytes, maxBytes_);
     bootstrap_->barrierAll();
-    for (int i = 0; i < kWarmupIters; ++i) {
+    for (int i = 0; i < warmupIters_; ++i) {
       launchOperation(nbytes, api, direction, copyOp);
       CHECK_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
     }
+    bootstrap_->barrierAll();
   }
 
   float runLocalElapsed(
@@ -369,7 +434,15 @@ class IbgdaSendRecvBenchmarkContext {
     CHECK_EQ(cudaEventDestroy(start), cudaSuccess);
     CHECK_EQ(cudaEventDestroy(stop), cudaSuccess);
 
-    return elapsedMs;
+    std::array<float, kWorldSize> rankElapsed{};
+    rankElapsed[globalRank_] = elapsedMs;
+    CHECK_EQ(
+        bootstrap_
+            ->allGather(
+                rankElapsed.data(), sizeof(float), globalRank_, worldSize_)
+            .get(),
+        0);
+    return *std::max_element(rankElapsed.begin(), rankElapsed.end());
   }
 
  private:
@@ -384,10 +457,10 @@ class IbgdaSendRecvBenchmarkContext {
     if (direction == SendRecvDirection::Bidirectional) {
       if (api == SendRecvApi::Blocking) {
         launch_ibgda_send_recv(
-            deviceTransport_, sendBuf, recvBuf, nbytes, kNumBlocks, stream_);
+            deviceTransport_, sendBuf, recvBuf, nbytes, numBlocks_, stream_);
       } else {
         launch_ibgda_progress_send_recv(
-            deviceTransport_, sendBuf, recvBuf, nbytes, kNumBlocks, stream_);
+            deviceTransport_, sendBuf, recvBuf, nbytes, numBlocks_, stream_);
       }
       return;
     }
@@ -395,19 +468,28 @@ class IbgdaSendRecvBenchmarkContext {
     if (globalRank_ == 0) {
       if (api == SendRecvApi::Blocking) {
         launch_ibgda_send(
-            deviceTransport_, sendBuf, nbytes, kNumBlocks, stream_);
+            deviceTransport_, sendBuf, nbytes, numBlocks_, stream_);
+      } else if (api == SendRecvApi::RegisteredProgress) {
+        CHECK(registeredEnabled_);
+        launch_ibgda_registered_progress_send(
+            deviceTransport_, registeredSendBuf_, nbytes, numBlocks_, stream_);
       } else {
-        launch_ibgda_progress_send(
-            deviceTransport_, sendBuf, nbytes, kNumBlocks, stream_);
+        if (registeredEnabled_) {
+          launch_ibgda_progress_send_complete(
+              deviceTransport_, sendBuf, nbytes, numBlocks_, stream_);
+        } else {
+          launch_ibgda_progress_send(
+              deviceTransport_, sendBuf, nbytes, numBlocks_, stream_);
+        }
       }
       return;
     }
 
     if (api == SendRecvApi::Blocking) {
-      launch_ibgda_recv(deviceTransport_, recvBuf, nbytes, kNumBlocks, stream_);
+      launch_ibgda_recv(deviceTransport_, recvBuf, nbytes, numBlocks_, stream_);
     } else {
       launch_ibgda_progress_recv(
-          deviceTransport_, recvBuf, nbytes, kNumBlocks, stream_);
+          deviceTransport_, recvBuf, nbytes, numBlocks_, stream_);
     }
   }
 
@@ -415,12 +497,18 @@ class IbgdaSendRecvBenchmarkContext {
   std::unique_ptr<MultipeerIbgdaTransport> transport_;
   std::unique_ptr<DeviceBuffer> sendBuf_;
   std::unique_ptr<DeviceBuffer> recvBuf_;
+  IbgdaLocalBuffer registeredSendBuf_{};
   P2pIbgdaTransportDevice* deviceTransport_{nullptr};
   std::size_t maxBytes_{0};
+  std::size_t perChannelSize_{0};
   cudaStream_t stream_{};
+  int numBlocks_{0};
+  int pipelineDepth_{0};
+  int warmupIters_{0};
   int globalRank_{0};
   int worldSize_{0};
   int localRank_{0};
+  bool registeredEnabled_{false};
 };
 
 static unsigned int ibgdaSendRecv(
@@ -458,6 +546,12 @@ static unsigned int ibgdaSendRecv(
         (totalBytes / 1e9) / elapsedSec, folly::UserMetric::Type::METRIC);
     counters["message_size"] = folly::UserMetric(
         static_cast<double>(nbytes), folly::UserMetric::Type::METRIC);
+    counters["num_blocks"] = folly::UserMetric(
+        static_cast<double>(context.numBlocks()),
+        folly::UserMetric::Type::METRIC);
+    counters["pipeline_chunk_bytes"] = folly::UserMetric(
+        static_cast<double>(context.pipelineChunkBytes()),
+        folly::UserMetric::Type::METRIC);
   }
   return iters;
 }
@@ -467,10 +561,11 @@ void registerBenchmark(
     const BenchmarkSize& size,
     SendRecvApi api,
     SendRecvDirection direction,
-    SendRecvCopyOp copyOp) {
+    SendRecvCopyOp copyOp,
+    int repeat = -1) {
   folly::addBenchmark(
       __FILE__,
-      benchmarkName(api, direction, copyOp, size.name),
+      benchmarkName(api, direction, copyOp, size.name, repeat),
       [&context, nbytes = size.nbytes, api, direction, copyOp](
           folly::UserCounters& counters, unsigned int iters) -> unsigned int {
         return ibgdaSendRecv(
@@ -504,6 +599,35 @@ void registerBenchmarks(IbgdaSendRecvBenchmarkContext& context) {
         SendRecvApi::Progress,
         SendRecvDirection::Unidirectional,
         SendRecvCopyOp::Memcpy);
+    if (context.registeredEnabled()) {
+      registerBenchmark(
+          context,
+          size,
+          SendRecvApi::RegisteredProgress,
+          SendRecvDirection::Unidirectional,
+          SendRecvCopyOp::Memcpy);
+    }
+
+    if (context.registeredEnabled() &&
+        (size.nbytes == (64ULL << 20) || size.nbytes == (256ULL << 20) ||
+         size.nbytes == (1ULL << 30) || size.nbytes == (2ULL << 30))) {
+      for (int repeat = 0; repeat < 5; ++repeat) {
+        registerBenchmark(
+            context,
+            size,
+            SendRecvApi::Progress,
+            SendRecvDirection::Unidirectional,
+            SendRecvCopyOp::Memcpy,
+            repeat);
+        registerBenchmark(
+            context,
+            size,
+            SendRecvApi::RegisteredProgress,
+            SendRecvDirection::Unidirectional,
+            SendRecvCopyOp::Memcpy,
+            repeat);
+      }
+    }
   }
 }
 

--- a/comms/prims/tests/MultiSegmentRegistrationTest.cc
+++ b/comms/prims/tests/MultiSegmentRegistrationTest.cc
@@ -5,6 +5,7 @@
 
 #include <folly/init/Init.h>
 #include <cstddef>
+#include <limits>
 #include <memory>
 #include <vector>
 
@@ -151,12 +152,39 @@ struct TransportHandle {
       ibrc->deregisterBuffer(ptr);
     }
   }
+
+  IbBufferRegistrationLease registerIbBulkBuffer(void* ptr, std::size_t size) {
+    return ibgda ? ibgda->registerIbBulkBuffer(ptr, size)
+                 : ibrc->registerIbBulkBuffer(ptr, size);
+  }
+
+  std::optional<IbBufferRegistrationView> lookupIbBulkBuffer(
+      const IbBufferRegistrationLease& lease,
+      void* ptr,
+      std::size_t size) const {
+    return ibgda ? ibgda->lookupIbBulkBuffer(lease, ptr, size)
+                 : ibrc->lookupIbBulkBuffer(lease, ptr, size);
+  }
+
+  void deregisterIbBulkBuffer(IbBufferRegistrationLease& lease) {
+    if (ibgda) {
+      ibgda->deregisterIbBulkBuffer(lease);
+    } else {
+      ibrc->deregisterIbBulkBuffer(lease);
+    }
+  }
+
+  bool isIbBulkBufferViewActive(const IbBufferRegistrationView& view) const {
+    return ibgda ? ibgda->isIbBulkBufferViewActive(view)
+                 : ibrc->isIbBulkBufferViewActive(view);
+  }
 };
 
-TransportHandle createTransport(IbTestBackend backend) {
+TransportHandle createTransport(
+    IbTestBackend backend,
+    const MultipeerIbTransportConfig& config) {
   auto bootstrap = std::make_shared<
       testing::NiceMock<meta::comms::testing::MockBootstrap>>();
-  auto config = makeConfig();
   TransportHandle handle;
   if (backend == IbTestBackend::Ibgda) {
     handle.ibgda = std::make_unique<MultipeerIbgdaTransport>(
@@ -166,6 +194,10 @@ TransportHandle createTransport(IbTestBackend backend) {
         0, 2, std::move(bootstrap), config);
   }
   return handle;
+}
+
+TransportHandle createTransport(IbTestBackend backend) {
+  return createTransport(backend, makeConfig());
 }
 
 class MultiSegmentRegistrationTest
@@ -249,6 +281,161 @@ TEST_P(MultiSegmentRegistrationTest, ContiguousBufferRegistration) {
 
   transport.deregisterBuffer(devPtr);
   CUDACHECK_TEST(cudaFree(devPtr));
+}
+
+TEST_P(MultiSegmentRegistrationTest, BulkLeaseBoundsContainedViews) {
+  CUDACHECK_TEST(cudaSetDevice(0));
+
+  TransportHandle transport;
+  try {
+    transport = createTransport(GetParam());
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << backendName(GetParam())
+                 << " transport not available: " << e.what();
+  }
+
+  constexpr std::size_t kAllocationSize = 4 * 1024 * 1024;
+  constexpr std::size_t kLeaseOffset = 512 * 1024;
+  constexpr std::size_t kLeaseSize = 2 * 1024 * 1024;
+  constexpr std::size_t kViewOffset = 128 * 1024;
+  constexpr std::size_t kViewSize = 256 * 1024;
+  void* allocation = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&allocation, kAllocationSize));
+  auto* const leasePtr = static_cast<char*>(allocation) + kLeaseOffset;
+
+  EXPECT_THROW(
+      transport.registerIbBulkBuffer(leasePtr, 0), std::invalid_argument);
+  auto lease = transport.registerIbBulkBuffer(leasePtr, kLeaseSize);
+  EXPECT_THROW(
+      transport.lookupIbBulkBuffer(lease, leasePtr, 0), std::invalid_argument);
+  EXPECT_THROW(
+      transport.lookupIbBulkBuffer(
+          lease, leasePtr, std::numeric_limits<std::size_t>::max()),
+      std::invalid_argument);
+  auto exact = transport.lookupIbBulkBuffer(lease, leasePtr, kLeaseSize);
+  auto contained =
+      transport.lookupIbBulkBuffer(lease, leasePtr + kViewOffset, kViewSize);
+  auto tail = transport.lookupIbBulkBuffer(lease, leasePtr + kLeaseSize - 1, 1);
+  auto before = transport.lookupIbBulkBuffer(lease, leasePtr - 1, kViewSize);
+  auto after = transport.lookupIbBulkBuffer(
+      lease, leasePtr + kLeaseSize - kViewSize + 1, kViewSize);
+
+  ASSERT_TRUE(exact.has_value());
+  ASSERT_TRUE(contained.has_value());
+  ASSERT_TRUE(tail.has_value());
+  EXPECT_EQ(exact->localBuffer.ptr, leasePtr);
+  EXPECT_EQ(contained->localBuffer.ptr, leasePtr + kViewOffset);
+  EXPECT_EQ(contained->size, kViewSize);
+  EXPECT_EQ(contained->leaseGeneration, lease.generation());
+  EXPECT_FALSE(before.has_value());
+  EXPECT_FALSE(after.has_value());
+  EXPECT_TRUE(transport.isIbBulkBufferViewActive(*contained));
+
+  transport.deregisterIbBulkBuffer(lease);
+  EXPECT_FALSE(lease.valid());
+  EXPECT_FALSE(
+      transport.lookupIbBulkBuffer(lease, leasePtr, kViewSize).has_value());
+  EXPECT_FALSE(transport.isIbBulkBufferViewActive(*contained));
+  EXPECT_THROW(transport.deregisterIbBulkBuffer(lease), std::invalid_argument);
+  CUDACHECK_TEST(cudaFree(allocation));
+}
+
+TEST_P(MultiSegmentRegistrationTest, BulkLeaseReportsEffectiveStrictOrdering) {
+  CUDACHECK_TEST(cudaSetDevice(0));
+
+  auto config = makeConfig();
+  config.enablePciRelaxedOrdering =
+      MultipeerIbTransportConfig::PciRelaxedOrderingMode::Disabled;
+  TransportHandle transport;
+  try {
+    transport = createTransport(GetParam(), config);
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << backendName(GetParam())
+                 << " transport not available: " << e.what();
+  }
+
+  constexpr std::size_t kSize = 2 * 1024 * 1024;
+  void* allocation = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&allocation, kSize));
+
+  auto lease = transport.registerIbBulkBuffer(allocation, kSize);
+  auto view = transport.lookupIbBulkBuffer(lease, allocation, kSize);
+  ASSERT_TRUE(view.has_value());
+  EXPECT_FALSE(view->relaxedOrdering);
+
+  transport.deregisterIbBulkBuffer(lease);
+  CUDACHECK_TEST(cudaFree(allocation));
+}
+
+TEST_P(MultiSegmentRegistrationTest, OverlappingBulkLeasesRemainDistinct) {
+  CUDACHECK_TEST(cudaSetDevice(0));
+
+  TransportHandle transport;
+  try {
+    transport = createTransport(GetParam());
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << backendName(GetParam())
+                 << " transport not available: " << e.what();
+  }
+
+  constexpr std::size_t kAllocationSize = 4 * 1024 * 1024;
+  constexpr std::size_t kOuterSize = 3 * 1024 * 1024;
+  constexpr std::size_t kInnerOffset = 1024 * 1024;
+  constexpr std::size_t kInnerSize = 1024 * 1024;
+  void* allocation = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&allocation, kAllocationSize));
+  auto* const base = static_cast<char*>(allocation);
+
+  auto outer = transport.registerIbBulkBuffer(base, kOuterSize);
+  auto inner = transport.registerIbBulkBuffer(base + kInnerOffset, kInnerSize);
+  auto outerView =
+      transport.lookupIbBulkBuffer(outer, base + kInnerOffset, kInnerSize);
+  auto innerView =
+      transport.lookupIbBulkBuffer(inner, base + kInnerOffset, kInnerSize);
+
+  ASSERT_TRUE(outerView.has_value());
+  ASSERT_TRUE(innerView.has_value());
+  EXPECT_NE(outer.generation(), inner.generation());
+  EXPECT_EQ(outerView->leaseGeneration, outer.generation());
+  EXPECT_EQ(innerView->leaseGeneration, inner.generation());
+
+  transport.deregisterIbBulkBuffer(inner);
+  EXPECT_FALSE(transport.isIbBulkBufferViewActive(*innerView));
+  EXPECT_TRUE(transport.isIbBulkBufferViewActive(*outerView));
+  transport.deregisterIbBulkBuffer(outer);
+  CUDACHECK_TEST(cudaFree(allocation));
+}
+
+TEST_P(MultiSegmentRegistrationTest, ReregistrationChangesLeaseGeneration) {
+  CUDACHECK_TEST(cudaSetDevice(0));
+
+  TransportHandle transport;
+  try {
+    transport = createTransport(GetParam());
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << backendName(GetParam())
+                 << " transport not available: " << e.what();
+  }
+
+  constexpr std::size_t kSize = 2 * 1024 * 1024;
+  void* allocation = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&allocation, kSize));
+
+  auto first = transport.registerIbBulkBuffer(allocation, kSize);
+  auto firstView = transport.lookupIbBulkBuffer(first, allocation, kSize);
+  ASSERT_TRUE(firstView.has_value());
+  const uint64_t firstGeneration = first.generation();
+  transport.deregisterIbBulkBuffer(first);
+
+  auto second = transport.registerIbBulkBuffer(allocation, kSize);
+  auto secondView = transport.lookupIbBulkBuffer(second, allocation, kSize);
+  ASSERT_TRUE(secondView.has_value());
+  EXPECT_NE(firstGeneration, second.generation());
+  EXPECT_FALSE(transport.isIbBulkBufferViewActive(*firstView));
+  EXPECT_TRUE(transport.isIbBulkBufferViewActive(*secondView));
+
+  transport.deregisterIbBulkBuffer(second);
+  CUDACHECK_TEST(cudaFree(allocation));
 }
 
 } // namespace comms::prims::tests

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -1964,6 +1964,205 @@ TEST_F(
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 }
 
+TEST_F(
+    MultipeerIbgdaTransportTestFixture,
+    RegisteredAndStagedSendShareProtocolCursor) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+  if (!test::supportsProgressSendRecv()) {
+    GTEST_SKIP() << "registered-source send is not supported for this build";
+  }
+
+  constexpr std::size_t perChannelSize = 64 * 1024;
+  constexpr int pipelineDepth = 2;
+  constexpr std::size_t firstBytes = 17 * 1024 + 1;
+  constexpr std::size_t secondBytes = 9 * 1024 + 7;
+  constexpr std::size_t thirdBytes = 40 * 1024 + 17;
+  constexpr std::size_t totalBytes = firstBytes + secondBytes + thirdBytes;
+  constexpr std::size_t maxSignalBytes = 4 * 1024;
+  constexpr int numBlocks = 1;
+  constexpr int blockSize = 128;
+  const int peerRank = globalRank == 0 ? 1 : 0;
+
+  std::unique_ptr<MultipeerIbgdaTransport> transport;
+  try {
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .perChannelSize = perChannelSize,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
+    };
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, numRanks, bootstrap, config);
+    transport->exchange();
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+
+  auto* peerTransport = transport->getP2pTransportDevice(peerRank);
+  DeviceBuffer sendBuffer(totalBytes);
+  DeviceBuffer recvBuffer(totalBytes);
+  DeviceBuffer errorCountBuffer(sizeof(int));
+  auto* errorCount = static_cast<int*>(errorCountBuffer.get());
+  IbgdaLocalBuffer registeredSource{};
+  if (globalRank == 0) {
+    registeredSource = transport->registerBuffer(sendBuffer.get(), totalBytes);
+    test::fillBufferWithPattern(
+        sendBuffer.get(), firstBytes, 0x31, numBlocks, blockSize);
+    test::fillBufferWithPattern(
+        static_cast<char*>(sendBuffer.get()) + firstBytes,
+        secondBytes,
+        0x72,
+        numBlocks,
+        blockSize);
+    test::fillBufferWithPattern(
+        static_cast<char*>(sendBuffer.get()) + firstBytes + secondBytes,
+        thirdBytes,
+        0xB4,
+        numBlocks,
+        blockSize);
+  } else {
+    CUDACHECK_TEST(cudaMemset(recvBuffer.get(), 0, totalBytes));
+  }
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  test::testMixedRegisteredAndStagedSendRecv(
+      peerTransport,
+      registeredSource,
+      recvBuffer.get(),
+      firstBytes,
+      secondBytes,
+      thirdBytes,
+      maxSignalBytes,
+      globalRank == 0,
+      numBlocks,
+      blockSize);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  if (globalRank == 1) {
+    const std::array<std::tuple<std::size_t, std::size_t, uint8_t>, 3> ranges{{
+        {0, firstBytes, 0x31},
+        {firstBytes, secondBytes, 0x72},
+        {firstBytes + secondBytes, thirdBytes, 0xB4},
+    }};
+    for (const auto& [offset, nbytes, pattern] : ranges) {
+      CUDACHECK_TEST(cudaMemset(errorCount, 0, sizeof(int)));
+      test::verifyBufferPattern(
+          static_cast<char*>(recvBuffer.get()) + offset,
+          nbytes,
+          pattern,
+          errorCount,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      int hostErrors = 0;
+      CUDACHECK_TEST(cudaMemcpy(
+          &hostErrors, errorCount, sizeof(hostErrors), cudaMemcpyDeviceToHost));
+      EXPECT_EQ(hostErrors, 0)
+          << "mixed registered/staged send corrupted range at " << offset;
+    }
+  } else {
+    transport->deregisterBuffer(sendBuffer.get());
+  }
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+TEST_F(
+    MultipeerIbgdaTransportTestFixture,
+    RegisteredSendBackpressureAcrossStagingWrap) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+  if (!test::supportsProgressSendRecv()) {
+    GTEST_SKIP() << "registered-source send is not supported for this build";
+  }
+
+  constexpr std::size_t perChannelSize = 64 * 1024;
+  constexpr int pipelineDepth = 2;
+  constexpr std::size_t nbytes = 8 * 1024 * 1024 + 17;
+  constexpr std::size_t maxSignalBytes = 4 * 1024;
+  constexpr int numBlocks = 1;
+  constexpr int blockSize = 128;
+  const int peerRank = globalRank == 0 ? 1 : 0;
+  std::vector<uint8_t> expected(nbytes);
+  for (std::size_t i = 0; i < nbytes; ++i) {
+    const std::size_t generation = i / perChannelSize;
+    expected[i] = static_cast<uint8_t>(generation * 37 + (i % 251));
+  }
+
+  std::unique_ptr<MultipeerIbgdaTransport> transport;
+  try {
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .perChannelSize = perChannelSize,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
+    };
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, numRanks, bootstrap, config);
+    transport->exchange();
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+
+  auto* peerTransport = transport->getP2pTransportDevice(peerRank);
+  DeviceBuffer sendBuffer(nbytes);
+  DeviceBuffer recvBuffer(nbytes);
+  DeviceBuffer observationBuffer(sizeof(test::RegisteredSendObservation));
+  auto* observation =
+      static_cast<test::RegisteredSendObservation*>(observationBuffer.get());
+  IbgdaLocalBuffer registeredSource{};
+  if (globalRank == 0) {
+    registeredSource = transport->registerBuffer(sendBuffer.get(), nbytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        sendBuffer.get(), expected.data(), nbytes, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(
+        cudaMemset(observation, 0, sizeof(test::RegisteredSendObservation)));
+  } else {
+    CUDACHECK_TEST(cudaMemset(recvBuffer.get(), 0, nbytes));
+  }
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  test::testRegisteredSendRecv(
+      peerTransport,
+      registeredSource,
+      recvBuffer.get(),
+      nbytes,
+      maxSignalBytes,
+      globalRank == 0,
+      numBlocks,
+      blockSize,
+      globalRank == 0 ? observation : nullptr);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  if (globalRank == 0) {
+    test::RegisteredSendObservation hostObservation{};
+    CUDACHECK_TEST(cudaMemcpy(
+        &hostObservation,
+        observation,
+        sizeof(hostObservation),
+        cudaMemcpyDeviceToHost));
+    EXPECT_GT(hostObservation.waitingCount, 0);
+    EXPECT_EQ(hostObservation.postedCount, 1);
+    EXPECT_EQ(hostObservation.drainedCount, 1);
+    transport->deregisterBuffer(sendBuffer.get());
+  } else {
+    std::vector<uint8_t> received(nbytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        received.data(), recvBuffer.get(), nbytes, cudaMemcpyDeviceToHost));
+    EXPECT_EQ(received, expected)
+        << "registered send corrupted data across slot wrap";
+  }
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
 // =============================================================================
 // Sustained chunked send/recv - repro for the GB200 per-channel DATA_READY
 // deadlock (two NICs atomic-FA the same flag at maxGroups>=8). Streams a large

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -6,9 +6,9 @@
 #include <folly/logging/xlog.h>
 #include <array>
 
-#include <chrono>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #ifdef __HIP_PLATFORM_AMD__
@@ -1789,6 +1789,179 @@ TEST_P(
     GTEST_SKIP() << backendName(backend())
                  << " transport not available: " << e.what();
   }
+}
+
+TEST_F(
+    MultipeerIbgdaTransportTestFixture,
+    RegisteredSendTailsDrainAndStagingIsolation) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+  if (!test::supportsProgressSendRecv()) {
+    GTEST_SKIP() << "registered-source send is not supported for this build";
+  }
+
+  constexpr std::size_t perChannelSize = 64 * 1024;
+  constexpr int pipelineDepth = 2;
+  constexpr std::size_t pipelineChunk = perChannelSize / pipelineDepth;
+  constexpr std::size_t maxSignalBytes = 4 * 1024;
+  constexpr std::size_t simpleProtocolDataBytes = 16;
+  constexpr int numBlocks = 1;
+  constexpr int blockSize = 128;
+  constexpr uint8_t stagingPoison = 0xA5;
+  constexpr std::size_t zeroByteAfterPostedIndex = 2;
+  const int peerRank = globalRank == 0 ? 1 : 0;
+  const std::array<std::size_t, 8> sizes{
+      0,
+      1,
+      7,
+      simpleProtocolDataBytes - 1,
+      simpleProtocolDataBytes,
+      simpleProtocolDataBytes + 1,
+      pipelineChunk - 1,
+      pipelineChunk + 1,
+  };
+
+  std::unique_ptr<MultipeerIbgdaTransport> transport;
+  try {
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .perChannelSize = perChannelSize,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
+    };
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, numRanks, bootstrap, config);
+    transport->exchange();
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+
+  auto* peerTransport = transport->getP2pTransportDevice(peerRank);
+  DeviceBuffer errorCountBuffer(sizeof(int));
+  DeviceBuffer observationBuffer(sizeof(test::RegisteredSendObservation));
+  auto* errorCount = static_cast<int*>(errorCountBuffer.get());
+  auto* observation =
+      static_cast<test::RegisteredSendObservation*>(observationBuffer.get());
+
+  test::testFillTransportStaging(
+      peerTransport,
+      globalRank == 0,
+      0,
+      perChannelSize,
+      stagingPoison,
+      numBlocks,
+      blockSize);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  for (std::size_t index = 0; index < sizes.size(); ++index) {
+    const std::size_t nbytes = sizes[index];
+    const std::size_t allocationBytes = nbytes == 0 ? 1 : nbytes;
+    const uint8_t pattern = static_cast<uint8_t>(0x20 + index * 13);
+    DeviceBuffer sendBuffer(allocationBytes);
+    DeviceBuffer recvBuffer(allocationBytes);
+    IbgdaLocalBuffer registeredSource{};
+    if (globalRank == 0) {
+      if (nbytes > 0) {
+        registeredSource = transport->registerBuffer(sendBuffer.get(), nbytes);
+      }
+      test::fillBufferWithPattern(
+          sendBuffer.get(), nbytes, pattern, numBlocks, blockSize);
+      CUDACHECK_TEST(
+          cudaMemset(observation, 0, sizeof(test::RegisteredSendObservation)));
+    } else {
+      CUDACHECK_TEST(cudaMemset(recvBuffer.get(), 0, allocationBytes));
+    }
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    test::testRegisteredSendRecv(
+        peerTransport,
+        registeredSource,
+        recvBuffer.get(),
+        nbytes,
+        maxSignalBytes,
+        globalRank == 0,
+        numBlocks,
+        blockSize,
+        globalRank == 0 ? observation : nullptr,
+        index == 4,
+        globalRank == 0 && nbytes > 0,
+        static_cast<uint8_t>(pattern ^ 0xFF),
+        index == zeroByteAfterPostedIndex);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    if (globalRank == 0) {
+      test::RegisteredSendObservation hostObservation{};
+      CUDACHECK_TEST(cudaMemcpy(
+          &hostObservation,
+          observation,
+          sizeof(hostObservation),
+          cudaMemcpyDeviceToHost));
+      if (index == 4) {
+        EXPECT_EQ(hostObservation.postedCount, 0);
+      } else if (index == zeroByteAfterPostedIndex) {
+        EXPECT_EQ(hostObservation.postedCount, 2);
+      } else {
+        EXPECT_EQ(hostObservation.postedCount, 1);
+      }
+      EXPECT_EQ(hostObservation.drainedCount, 1);
+    } else {
+      CUDACHECK_TEST(cudaMemset(errorCount, 0, sizeof(int)));
+      test::verifyBufferPattern(
+          recvBuffer.get(), nbytes, pattern, errorCount, numBlocks, blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      int hostErrors = 0;
+      CUDACHECK_TEST(cudaMemcpy(
+          &hostErrors, errorCount, sizeof(hostErrors), cudaMemcpyDeviceToHost));
+      EXPECT_EQ(hostErrors, 0) << "registered send corrupted size " << nbytes;
+    }
+
+    if (index == 1 && globalRank == 1) {
+      CUDACHECK_TEST(cudaMemset(errorCount, 0, sizeof(int)));
+      test::testVerifyTransportStaging(
+          peerTransport,
+          false,
+          1,
+          simpleProtocolDataBytes - 1,
+          stagingPoison,
+          errorCount,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      int hostErrors = 0;
+      CUDACHECK_TEST(cudaMemcpy(
+          &hostErrors, errorCount, sizeof(hostErrors), cudaMemcpyDeviceToHost));
+      EXPECT_EQ(hostErrors, 0)
+          << "registered send wrote rounded tail bytes into recv staging";
+    }
+    if (globalRank == 0 && nbytes > 0) {
+      transport->deregisterBuffer(sendBuffer.get());
+    }
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  }
+
+  if (globalRank == 0) {
+    CUDACHECK_TEST(cudaMemset(errorCount, 0, sizeof(int)));
+    test::testVerifyTransportStaging(
+        peerTransport,
+        true,
+        0,
+        perChannelSize,
+        stagingPoison,
+        errorCount,
+        numBlocks,
+        blockSize);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    int hostErrors = 0;
+    CUDACHECK_TEST(cudaMemcpy(
+        &hostErrors, errorCount, sizeof(hostErrors), cudaMemcpyDeviceToHost));
+    EXPECT_EQ(hostErrors, 0)
+        << "registered send modified transport send staging";
+  }
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 }
 
 // =============================================================================

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -479,6 +479,138 @@ __global__ void progressReservationKernel(
   }
 }
 
+template <typename Transport>
+__device__ IbgdaRegisteredSendProgressStatus postRegisteredSend(
+    Transport& transport,
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& source,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    const Timeout& timeout,
+    RegisteredSendObservation* observation) {
+  transport.init_registered_send_progress(group, nbytes, maxSignalBytes);
+  IbgdaRegisteredSendProgressStatus status;
+  do {
+    status = transport.progress_registered_send_once(
+        group, source, nbytes, maxSignalBytes, timeout);
+    if (group.is_leader() && observation != nullptr) {
+      observation->record(status);
+    }
+  } while (status != IbgdaRegisteredSendProgressStatus::Posted &&
+           status != IbgdaRegisteredSendProgressStatus::Drained);
+  return status;
+}
+
+template <typename Transport>
+__device__ void drainRegisteredSends(
+    Transport& transport,
+    ThreadGroup& group,
+    const Timeout& timeout,
+    RegisteredSendObservation* observation) {
+  IbgdaRegisteredSendProgressStatus status;
+  do {
+    status = transport.progress_registered_send_drain_once(group, timeout);
+    if (group.is_leader() && observation != nullptr) {
+      observation->record(status);
+    }
+  } while (status != IbgdaRegisteredSendProgressStatus::Drained);
+}
+
+__global__ void registeredSendRecvKernel(
+    P2pIbTransportDevice transport,
+    IbgdaLocalBuffer source,
+    void* recvBuffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    bool send,
+    RegisteredSendObservation* observation,
+    bool blocking,
+    bool overwriteAfterDrain,
+    uint8_t overwriteValue,
+    bool zeroByteAfterPosted) {
+  auto group = make_block_group();
+  Timeout timeout(kDefaultDeviceTimeoutCycles);
+  timeout.start();
+  if (send) {
+    if (blocking) {
+      transport.send_registered(group, source, nbytes, maxSignalBytes, timeout);
+      if (group.is_leader() && observation != nullptr) {
+        ++observation->drainedCount;
+      }
+    } else {
+      const auto status = postRegisteredSend(
+          transport,
+          group,
+          source,
+          nbytes,
+          maxSignalBytes,
+          timeout,
+          observation);
+      if (zeroByteAfterPosted) {
+        transport.init_registered_send_progress(group, 0, maxSignalBytes);
+        const auto zeroByteStatus = transport.progress_registered_send_once(
+            group, IbgdaLocalBuffer{}, 0, maxSignalBytes, timeout);
+        if (group.is_leader() && observation != nullptr) {
+          observation->record(zeroByteStatus);
+        }
+      }
+      if (status != IbgdaRegisteredSendProgressStatus::Drained) {
+        drainRegisteredSends(transport, group, timeout, observation);
+      }
+    }
+    if (overwriteAfterDrain) {
+      auto* bytes = static_cast<uint8_t*>(source.ptr);
+      for (std::size_t i = group.thread_id_in_group; i < nbytes;
+           i += group.group_size) {
+        bytes[i] = overwriteValue;
+      }
+      group.sync();
+    }
+  } else {
+    transport.recv(group, recvBuffer, nbytes, maxSignalBytes, timeout);
+  }
+}
+
+__global__ void fillTransportStagingKernel(
+    P2pIbgdaTransportDevice* transport,
+    bool sendStaging,
+    std::size_t offset,
+    std::size_t nbytes,
+    uint8_t value) {
+  auto group = make_block_group();
+  auto& layout = transport->channel_layout();
+  char* staging = sendStaging ? layout.sendStagingPtr : layout.recvStagingPtr;
+  staging +=
+      static_cast<std::size_t>(group.group_id) * layout.perChannelBufferSize +
+      offset;
+  for (std::size_t i = group.thread_id_in_group; i < nbytes;
+       i += group.group_size) {
+    staging[i] = static_cast<char>(value);
+  }
+}
+
+__global__ void verifyTransportStagingKernel(
+    P2pIbgdaTransportDevice* transport,
+    bool sendStaging,
+    std::size_t offset,
+    std::size_t nbytes,
+    uint8_t expected,
+    int* errorCount) {
+  auto group = make_block_group();
+  const auto& layout = transport->channel_layout();
+  const char* staging =
+      sendStaging ? layout.sendStagingPtr : layout.recvStagingPtr;
+  staging +=
+      static_cast<std::size_t>(group.group_id) * layout.perChannelBufferSize +
+      offset;
+  for (std::size_t i = group.thread_id_in_group; i < nbytes;
+       i += group.group_size) {
+    if (static_cast<uint8_t>(staging[i]) != expected) {
+      atomicAdd(errorCount, 1);
+    }
+  }
+}
+
 #endif
 
 void testProgressSendRecv(
@@ -532,6 +664,115 @@ void testProgressReservations(
   progressReservationKernel<<<numBlocks, blockSize>>>(
       transport, output, sendBytes, recvBytes);
   cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+#endif
+}
+
+void testRegisteredSendRecv(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& source,
+    void* recvBuffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize,
+    RegisteredSendObservation* observation,
+    bool blocking,
+    bool overwriteAfterDrain,
+    uint8_t overwriteValue,
+    bool zeroByteAfterPosted) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)source;
+  (void)recvBuffer;
+  (void)nbytes;
+  (void)maxSignalBytes;
+  (void)send;
+  (void)numBlocks;
+  (void)blockSize;
+  (void)observation;
+  (void)blocking;
+  (void)overwriteAfterDrain;
+  (void)overwriteValue;
+  (void)zeroByteAfterPosted;
+  throw std::runtime_error("registered-source send is NVIDIA-only");
+#else
+  P2pIbTransportDevice unifiedTransport(transport);
+  registeredSendRecvKernel<<<numBlocks, blockSize>>>(
+      unifiedTransport,
+      source,
+      recvBuffer,
+      nbytes,
+      maxSignalBytes,
+      send,
+      observation,
+      blocking,
+      overwriteAfterDrain,
+      overwriteValue,
+      zeroByteAfterPosted);
+  const cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+#endif
+}
+
+void testFillTransportStaging(
+    P2pIbgdaTransportDevice* transport,
+    bool sendStaging,
+    std::size_t offset,
+    std::size_t nbytes,
+    uint8_t value,
+    int numBlocks,
+    int blockSize) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)sendStaging;
+  (void)offset;
+  (void)nbytes;
+  (void)value;
+  (void)numBlocks;
+  (void)blockSize;
+  throw std::runtime_error("registered-source send is NVIDIA-only");
+#else
+  fillTransportStagingKernel<<<numBlocks, blockSize>>>(
+      transport, sendStaging, offset, nbytes, value);
+  const cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+#endif
+}
+
+void testVerifyTransportStaging(
+    P2pIbgdaTransportDevice* transport,
+    bool sendStaging,
+    std::size_t offset,
+    std::size_t nbytes,
+    uint8_t expected,
+    int* errorCount,
+    int numBlocks,
+    int blockSize) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)sendStaging;
+  (void)offset;
+  (void)nbytes;
+  (void)expected;
+  (void)errorCount;
+  (void)numBlocks;
+  (void)blockSize;
+  throw std::runtime_error("registered-source send is NVIDIA-only");
+#else
+  verifyTransportStagingKernel<<<numBlocks, blockSize>>>(
+      transport, sendStaging, offset, nbytes, expected, errorCount);
+  const cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(
         std::string("Kernel launch failed: ") + cudaGetErrorString(err));

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -571,6 +571,57 @@ __global__ void registeredSendRecvKernel(
   }
 }
 
+__global__ void mixedRegisteredAndStagedSendRecvKernel(
+    P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t thirdBytes,
+    std::size_t maxSignalBytes,
+    bool send) {
+  auto group = make_block_group();
+  Timeout timeout(kDefaultDeviceTimeoutCycles);
+  timeout.start();
+  if (send) {
+    (void)postRegisteredSend(
+        *transport,
+        group,
+        sendBuffer,
+        firstBytes,
+        maxSignalBytes,
+        timeout,
+        nullptr);
+    transport->send(
+        group,
+        static_cast<const char*>(sendBuffer.ptr) + firstBytes,
+        secondBytes,
+        maxSignalBytes,
+        timeout);
+    (void)postRegisteredSend(
+        *transport,
+        group,
+        sendBuffer.subBuffer(firstBytes + secondBytes),
+        thirdBytes,
+        maxSignalBytes,
+        timeout,
+        nullptr);
+    drainRegisteredSends(*transport, group, timeout, nullptr);
+    return;
+  }
+
+  auto* output = static_cast<char*>(recvBuffer);
+  transport->recv(group, output, firstBytes, maxSignalBytes, timeout);
+  transport->recv(
+      group, output + firstBytes, secondBytes, maxSignalBytes, timeout);
+  transport->recv(
+      group,
+      output + firstBytes + secondBytes,
+      thirdBytes,
+      maxSignalBytes,
+      timeout);
+}
+
 __global__ void fillTransportStagingKernel(
     P2pIbgdaTransportDevice* transport,
     bool sendStaging,
@@ -714,6 +765,47 @@ void testRegisteredSendRecv(
       overwriteAfterDrain,
       overwriteValue,
       zeroByteAfterPosted);
+  const cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+#endif
+}
+
+void testMixedRegisteredAndStagedSendRecv(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t thirdBytes,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)sendBuffer;
+  (void)recvBuffer;
+  (void)firstBytes;
+  (void)secondBytes;
+  (void)thirdBytes;
+  (void)maxSignalBytes;
+  (void)send;
+  (void)numBlocks;
+  (void)blockSize;
+  throw std::runtime_error("registered-source send is NVIDIA-only");
+#else
+  mixedRegisteredAndStagedSendRecvKernel<<<numBlocks, blockSize>>>(
+      transport,
+      sendBuffer,
+      recvBuffer,
+      firstBytes,
+      secondBytes,
+      thirdBytes,
+      maxSignalBytes,
+      send);
   const cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
@@ -104,6 +104,34 @@ __global__ void progressReservationKernel(
     int64_t* output,
     std::size_t sendBytes,
     std::size_t recvBytes);
+
+__global__ void registeredSendRecvKernel(
+    P2pIbTransportDevice transport,
+    IbgdaLocalBuffer source,
+    void* recvBuffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    bool send,
+    RegisteredSendObservation* observation,
+    bool blocking,
+    bool overwriteAfterDrain,
+    uint8_t overwriteValue,
+    bool zeroByteAfterPosted);
+
+__global__ void fillTransportStagingKernel(
+    P2pIbgdaTransportDevice* transport,
+    bool sendStaging,
+    std::size_t offset,
+    std::size_t nbytes,
+    uint8_t value);
+
+__global__ void verifyTransportStagingKernel(
+    P2pIbgdaTransportDevice* transport,
+    bool sendStaging,
+    std::size_t offset,
+    std::size_t nbytes,
+    uint8_t expected,
+    int* errorCount);
 #endif
 
 __global__ void

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
@@ -118,6 +118,16 @@ __global__ void registeredSendRecvKernel(
     uint8_t overwriteValue,
     bool zeroByteAfterPosted);
 
+__global__ void mixedRegisteredAndStagedSendRecvKernel(
+    P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t thirdBytes,
+    std::size_t maxSignalBytes,
+    bool send);
+
 __global__ void fillTransportStagingKernel(
     P2pIbgdaTransportDevice* transport,
     bool sendStaging,

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -122,6 +122,31 @@ void testPutOnly(
  */
 bool supportsProgressSendRecv();
 
+struct RegisteredSendObservation {
+  uint64_t waitingCount{0};
+  uint64_t progressedCount{0};
+  uint64_t postedCount{0};
+  uint64_t drainedCount{0};
+
+  template <typename Status>
+  IBGDA_HOST_DEVICE void record(Status status) {
+    switch (status) {
+      case Status::Waiting:
+        ++waitingCount;
+        break;
+      case Status::Progressed:
+        ++progressedCount;
+        break;
+      case Status::Posted:
+        ++postedCount;
+        break;
+      case Status::Drained:
+        ++drainedCount;
+        break;
+    }
+  }
+};
+
 /**
  * Test kernel: snapshot send/recv pipeline geometry through the unified IB
  * transport wrapper. Output: pipelineDepth, pipelineWindow, pipelineChunk.
@@ -197,6 +222,44 @@ void testProgressReservations(
     int64_t* output,
     std::size_t sendBytes,
     std::size_t recvBytes,
+    int numBlocks,
+    int blockSize);
+
+/**
+ * Test kernel: registered-source send progress or the matching staged recv.
+ */
+void testRegisteredSendRecv(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& source,
+    void* recvBuffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize,
+    RegisteredSendObservation* observation = nullptr,
+    bool blocking = false,
+    bool overwriteAfterDrain = false,
+    uint8_t overwriteValue = 0,
+    bool zeroByteAfterPosted = false);
+
+/** Fill or verify a byte range in this channel's transport staging. */
+void testFillTransportStaging(
+    P2pIbgdaTransportDevice* transport,
+    bool sendStaging,
+    std::size_t offset,
+    std::size_t nbytes,
+    uint8_t value,
+    int numBlocks,
+    int blockSize);
+
+void testVerifyTransportStaging(
+    P2pIbgdaTransportDevice* transport,
+    bool sendStaging,
+    std::size_t offset,
+    std::size_t nbytes,
+    uint8_t expected,
+    int* errorCount,
     int numBlocks,
     int blockSize);
 

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -243,6 +243,21 @@ void testRegisteredSendRecv(
     uint8_t overwriteValue = 0,
     bool zeroByteAfterPosted = false);
 
+/**
+ * Test kernel: registered A, staged B, registered C on one send cursor.
+ */
+void testMixedRegisteredAndStagedSendRecv(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t thirdBytes,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize);
+
 /** Fill or verify a byte range in this channel's transport staging. */
 void testFillTransportStaging(
     P2pIbgdaTransportDevice* transport,

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -248,6 +248,27 @@ void checkSendRecvSignalAlignment(const void* ptr, const char* label) {
         fmt::format("{} must be {}-byte aligned", label, alignof(SignalState)));
   }
 }
+
+bool rangeContains(
+    uintptr_t outerBegin,
+    std::size_t outerSize,
+    uintptr_t innerBegin,
+    std::size_t innerSize) {
+  return innerSize != 0 && innerBegin >= outerBegin && innerSize <= outerSize &&
+      innerBegin - outerBegin <= outerSize - innerSize;
+}
+
+uintptr_t
+checkedRangeEnd(const void* ptr, std::size_t size, const char* operation) {
+  const auto begin = reinterpret_cast<uintptr_t>(ptr);
+  if (ptr == nullptr || size == 0 ||
+      size > std::numeric_limits<uintptr_t>::max() - begin) {
+    throw std::invalid_argument(
+        fmt::format(
+            "{}: invalid buffer range ptr={} size={}", operation, ptr, size));
+  }
+  return begin + size;
+}
 } // namespace
 
 MultiPeerIbTransportBase::MultiPeerIbTransportBase(
@@ -1081,6 +1102,10 @@ IbgdaLocalBuffer MultiPeerIbTransportBase::registerBuffer(
     throw std::invalid_argument("Invalid buffer pointer or size");
   }
 
+  const auto addr = reinterpret_cast<uintptr_t>(ptr);
+  [[maybe_unused]] const auto requestedEnd =
+      checkedRangeEnd(ptr, size, "registerBuffer");
+
   // Resolve the effective Relaxed Ordering once, up front: the caller's request
   // gated by config (NCCL_IB_PCI_RELAXED_ORDERING) AND by NIC capability probed
   // during openNics. Gating on capability means a NIC whose driver rejects
@@ -1094,11 +1119,10 @@ IbgdaLocalBuffer MultiPeerIbTransportBase::registerBuffer(
   // Fast path: containment lookup — if [ptr, ptr+size) falls entirely within an
   // existing registration with the same effective ordering, return the cached
   // per-NIC lkeys with no driver call.
-  const auto addr = reinterpret_cast<uintptr_t>(ptr);
   auto it = registeredBuffers_.upper_bound(addr);
   if (it != registeredBuffers_.begin()) {
     --it;
-    if (addr + size <= it->first + it->second.allocSize) {
+    if (rangeContains(it->first, it->second.allocSize, addr, size)) {
       // The cache holds one MR set per allocation; its access flags (including
       // Relaxed Ordering) are fixed at registration, so the effective ordering
       // is part of the cache key. A containment hit resolving to different
@@ -1155,7 +1179,6 @@ IbgdaLocalBuffer MultiPeerIbTransportBase::registerBuffer(
   // covers the full contiguous VA — ibv_reg_dmabuf_mr handles the underlying
   // physical discontinuity transparently.
   {
-    const auto requestedEnd = reinterpret_cast<uintptr_t>(ptr) + size;
     const auto allocEnd = static_cast<uintptr_t>(allocBase) + allocSize;
     if (requestedEnd > allocEnd) {
       allocBase = reinterpret_cast<CUdeviceptr>(ptr);
@@ -1317,6 +1340,113 @@ IbgdaLocalBuffer MultiPeerIbTransportBase::registerBuffer(
     keys[n] = NetworkLKey(HostLKey(cached.mrs[n]->lkey));
   }
   return IbgdaLocalBuffer(ptr, keys);
+}
+
+IbBufferRegistrationLease MultiPeerIbTransportBase::registerIbBulkBuffer(
+    void* ptr,
+    std::size_t size) {
+  checkedRangeEnd(ptr, size, "registerIbBulkBuffer");
+  const auto localBuffer = registerBuffer(ptr, size, /*relaxedOrdering=*/true);
+
+  try {
+    const auto addr = reinterpret_cast<uintptr_t>(ptr);
+    auto mrIt = registeredBuffers_.upper_bound(addr);
+    if (mrIt == registeredBuffers_.begin()) {
+      throw std::logic_error(
+          "registerIbBulkBuffer: MR missing after registration");
+    }
+    --mrIt;
+    if (!rangeContains(mrIt->first, mrIt->second.allocSize, addr, size)) {
+      throw std::logic_error(
+          "registerIbBulkBuffer: MR does not contain registered range");
+    }
+    if (nextBulkBufferGeneration_ == std::numeric_limits<uint64_t>::max()) {
+      throw std::overflow_error(
+          "registerIbBulkBuffer: lease generation exhausted");
+    }
+
+    const uint64_t generation = nextBulkBufferGeneration_++;
+    bulkBufferRegistrations_.emplace(
+        generation,
+        BulkBufferRegistration{
+            .ptr = ptr,
+            .size = size,
+            .localBuffer = localBuffer,
+            .relaxedOrdering = mrIt->second.relaxedOrdering,
+        });
+    return IbBufferRegistrationLease(generation);
+  } catch (...) {
+    deregisterBuffer(ptr);
+    throw;
+  }
+}
+
+std::optional<IbBufferRegistrationView>
+MultiPeerIbTransportBase::lookupIbBulkBuffer(
+    const IbBufferRegistrationLease& lease,
+    void* ptr,
+    std::size_t size) const {
+  checkedRangeEnd(ptr, size, "lookupIbBulkBuffer");
+  if (!lease.valid()) {
+    return std::nullopt;
+  }
+
+  const auto registration = bulkBufferRegistrations_.find(lease.generation());
+  if (registration == bulkBufferRegistrations_.end()) {
+    return std::nullopt;
+  }
+
+  const auto& active = registration->second;
+  const auto requestedBegin = reinterpret_cast<uintptr_t>(ptr);
+  const auto registeredBegin = reinterpret_cast<uintptr_t>(active.ptr);
+  if (!rangeContains(registeredBegin, active.size, requestedBegin, size)) {
+    return std::nullopt;
+  }
+
+  return IbBufferRegistrationView{
+      .leaseGeneration = lease.generation(),
+      .localBuffer =
+          active.localBuffer.subBuffer(requestedBegin - registeredBegin),
+      .size = size,
+      .relaxedOrdering = active.relaxedOrdering,
+  };
+}
+
+void MultiPeerIbTransportBase::deregisterIbBulkBuffer(
+    IbBufferRegistrationLease& lease) {
+  if (!lease.valid()) {
+    throw std::invalid_argument(
+        "deregisterIbBulkBuffer: invalid registration lease");
+  }
+
+  const auto registration = bulkBufferRegistrations_.find(lease.generation());
+  if (registration == bulkBufferRegistrations_.end()) {
+    throw std::runtime_error(
+        "deregisterIbBulkBuffer: stale registration lease");
+  }
+
+  void* const ptr = registration->second.ptr;
+  bulkBufferRegistrations_.erase(registration);
+  deregisterBuffer(ptr);
+  lease.reset();
+}
+
+bool MultiPeerIbTransportBase::isIbBulkBufferViewActive(
+    const IbBufferRegistrationView& view) const {
+  if (!view.valid()) {
+    return false;
+  }
+  const auto registration = bulkBufferRegistrations_.find(view.leaseGeneration);
+  if (registration == bulkBufferRegistrations_.end()) {
+    return false;
+  }
+
+  const auto& active = registration->second;
+  return rangeContains(
+      reinterpret_cast<uintptr_t>(active.ptr),
+      active.size,
+      reinterpret_cast<uintptr_t>(view.localBuffer.ptr),
+      view.size);
 }
 
 void MultiPeerIbTransportBase::deregisterBuffer(void* ptr) {

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -247,6 +247,54 @@ inline bool relaxedOrderingActiveForNic(
       nicRelaxedOrderingCapable;
 }
 
+// Explicit-release token for one transport-owned registration. Callers must
+// pass every valid lease to deregisterIbBulkBuffer() before destroying it; the
+// lease does not own the transport and therefore cannot release itself safely.
+class IbBufferRegistrationLease {
+ public:
+  IbBufferRegistrationLease() = default;
+  ~IbBufferRegistrationLease() = default;
+  IbBufferRegistrationLease(const IbBufferRegistrationLease&) = delete;
+  IbBufferRegistrationLease& operator=(const IbBufferRegistrationLease&) =
+      delete;
+  IbBufferRegistrationLease(IbBufferRegistrationLease&& other) noexcept
+      : generation_(std::exchange(other.generation_, 0)) {}
+  // Assignment could silently discard a registration that still requires an
+  // explicit release.
+  IbBufferRegistrationLease& operator=(IbBufferRegistrationLease&&) = delete;
+
+  bool valid() const {
+    return generation_ != 0;
+  }
+
+  uint64_t generation() const {
+    return generation_;
+  }
+
+ private:
+  friend class MultiPeerIbTransportBase;
+
+  explicit IbBufferRegistrationLease(uint64_t generation)
+      : generation_(generation) {}
+
+  void reset() {
+    generation_ = 0;
+  }
+
+  uint64_t generation_{0};
+};
+
+struct IbBufferRegistrationView {
+  uint64_t leaseGeneration{0};
+  IbgdaLocalBuffer localBuffer;
+  std::size_t size{0};
+  bool relaxedOrdering{false};
+
+  bool valid() const {
+    return leaseGeneration != 0 && localBuffer.ptr != nullptr && size != 0;
+  }
+};
+
 /**
  * Transport connection information for RDMA QP setup.
  *
@@ -438,6 +486,29 @@ class MultiPeerIbTransportBase {
   void deregisterBuffer(void* ptr);
 
   /**
+   * Register a logical bulk-data range and return its move-only ownership
+   * token. The underlying allocation MR is shared with other registrations,
+   * while the lease preserves the exact caller-visible range.
+   */
+  IbBufferRegistrationLease registerIbBulkBuffer(void* ptr, std::size_t size);
+
+  /**
+   * Return a non-owning RDMA view when the requested range is fully contained
+   * in the active lease. The view remains valid only while its lease is active.
+   */
+  std::optional<IbBufferRegistrationView> lookupIbBulkBuffer(
+      const IbBufferRegistrationLease& lease,
+      void* ptr,
+      std::size_t size) const;
+
+  /** Release one logical bulk registration and invalidate its ownership token.
+   */
+  void deregisterIbBulkBuffer(IbBufferRegistrationLease& lease);
+
+  /** Return whether a previously resolved view still names its active lease. */
+  bool isIbBulkBufferViewActive(const IbBufferRegistrationView& view) const;
+
+  /**
    * exchangeBuffer - COLLECTIVE. allGather a registered buffer's addr + per-NIC
    * rkeys; return one IbgdaRemoteBuffer per peer (indexed by peerIndexToRank).
    */
@@ -594,6 +665,13 @@ class MultiPeerIbTransportBase {
     bool relaxedOrdering{false};
   };
 
+  struct BulkBufferRegistration {
+    void* ptr{nullptr};
+    std::size_t size{0};
+    IbgdaLocalBuffer localBuffer;
+    bool relaxedOrdering{false};
+  };
+
   const int myRank_{-1};
   const int nRanks_{0};
   std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
@@ -638,6 +716,11 @@ class MultiPeerIbTransportBase {
   // Maps allocation base address -> cached MR covering the full allocation.
   // Ordered map enables O(log n) containment lookup via upper_bound.
   std::map<uintptr_t, CachedMr> registeredBuffers_;
+
+  // Logical bulk-data registrations are keyed by a monotonically increasing
+  // generation. Their underlying MRs remain owned by registeredBuffers_.
+  std::map<uint64_t, BulkBufferRegistration> bulkBufferRegistrations_;
+  uint64_t nextBulkBufferGeneration_{1};
 
   // Shared send/recv staging-ring state (eager mode). Owns the bulk
   // allocations; sendRecvPeerBuffers_ slices them per peer.

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -405,6 +405,56 @@ IbgdaLocalBuffer MultiPeerTransport::localRegisterIbgdaBuffer(
       "localRegisterIbgdaBuffer: IB transport not available");
 }
 
+IbBufferRegistrationLease MultiPeerTransport::registerIbBulkBuffer(
+    void* ptr,
+    std::size_t size) {
+  if (ibgdaTransport_) {
+    return ibgdaTransport_->registerIbBulkBuffer(ptr, size);
+  }
+  if (ibrcTransport_) {
+    return ibrcTransport_->registerIbBulkBuffer(ptr, size);
+  }
+  throw std::runtime_error("registerIbBulkBuffer: IB transport not available");
+}
+
+std::optional<IbBufferRegistrationView> MultiPeerTransport::lookupIbBulkBuffer(
+    const IbBufferRegistrationLease& lease,
+    void* ptr,
+    std::size_t size) const {
+  if (ibgdaTransport_) {
+    return ibgdaTransport_->lookupIbBulkBuffer(lease, ptr, size);
+  }
+  if (ibrcTransport_) {
+    return ibrcTransport_->lookupIbBulkBuffer(lease, ptr, size);
+  }
+  return std::nullopt;
+}
+
+void MultiPeerTransport::deregisterIbBulkBuffer(
+    IbBufferRegistrationLease& lease) {
+  if (ibgdaTransport_) {
+    ibgdaTransport_->deregisterIbBulkBuffer(lease);
+    return;
+  }
+  if (ibrcTransport_) {
+    ibrcTransport_->deregisterIbBulkBuffer(lease);
+    return;
+  }
+  throw std::runtime_error(
+      "deregisterIbBulkBuffer: IB transport not available");
+}
+
+bool MultiPeerTransport::isIbBulkBufferViewActive(
+    const IbBufferRegistrationView& view) const {
+  if (ibgdaTransport_) {
+    return ibgdaTransport_->isIbBulkBufferViewActive(view);
+  }
+  if (ibrcTransport_) {
+    return ibrcTransport_->isIbBulkBufferViewActive(view);
+  }
+  return false;
+}
+
 void MultiPeerTransport::localDeregisterIbgdaBuffer(void* ptr) {
   if (ibgdaTransport_) {
     ibgdaTransport_->deregisterBuffer(ptr);

--- a/comms/prims/transport/MultiPeerTransport.h
+++ b/comms/prims/transport/MultiPeerTransport.h
@@ -278,6 +278,17 @@ class MultiPeerTransport {
    */
   IbgdaLocalBuffer localRegisterIbgdaBuffer(void* ptr, size_t size);
 
+  IbBufferRegistrationLease registerIbBulkBuffer(void* ptr, std::size_t size);
+
+  std::optional<IbBufferRegistrationView> lookupIbBulkBuffer(
+      const IbBufferRegistrationLease& lease,
+      void* ptr,
+      std::size_t size) const;
+
+  void deregisterIbBulkBuffer(IbBufferRegistrationLease& lease);
+
+  bool isIbBulkBufferViewActive(const IbBufferRegistrationView& view) const;
+
   /**
    * Deregister a previously registered IBGDA buffer.
    *

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -505,6 +505,17 @@ __device__ __forceinline__ void P2pIbTransportDevice::fence() {
 // Pipelined send/recv — forwarded to the active backend.
 // ===========================================================================
 
+__device__ __forceinline__ void P2pIbTransportDevice::require_ibgda(
+    ThreadGroup& group,
+    const char* operation) const {
+  if (type == P2pIbBackendType::IBRC) {
+    if (group.is_leader()) {
+      printf("[PIPES] FATAL: %s requires IBGDA\n", operation);
+    }
+    PIPES_DEVICE_TRAP();
+  }
+}
+
 template <typename CopyOp, typename... Args>
 __device__ __forceinline__ void P2pIbTransportDevice::send(
     ThreadGroup& group,
@@ -518,6 +529,17 @@ __device__ __forceinline__ void P2pIbTransportDevice::send(
   } else {
     ibgda->send<CopyOp>(group, src, nbytes, max_signal_bytes, timeout, args...);
   }
+}
+
+template <typename>
+__device__ __forceinline__ void P2pIbTransportDevice::send_registered(
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout) {
+  require_ibgda(group, "registered-source send");
+  ibgda->send_registered(group, src, nbytes, max_signal_bytes, timeout);
 }
 
 template <typename CopyOp, typename... Args>
@@ -596,6 +618,16 @@ __device__ __forceinline__ void P2pIbTransportDevice::init_send_progress(
 }
 
 template <typename>
+__device__ __forceinline__ void
+P2pIbTransportDevice::init_registered_send_progress(
+    ThreadGroup& group,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes) {
+  require_ibgda(group, "registered-source send progress");
+  ibgda->init_registered_send_progress(group, nbytes, max_signal_bytes);
+}
+
+template <typename>
 __device__ __forceinline__ void P2pIbTransportDevice::init_recv_progress(
     ThreadGroup& group,
     std::size_t nbytes,
@@ -622,6 +654,28 @@ P2pIbTransportDevice::progress_send_once(
   }
   return ibgda->progress_send_once<CopyOp>(
       group, src, nbytes, max_signal_bytes, timeout, args...);
+}
+
+template <typename>
+__device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+P2pIbTransportDevice::progress_registered_send_once(
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout) {
+  require_ibgda(group, "registered-source send progress");
+  return ibgda->progress_registered_send_once(
+      group, src, nbytes, max_signal_bytes, timeout);
+}
+
+template <typename>
+__device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+P2pIbTransportDevice::progress_registered_send_drain_once(
+    ThreadGroup& group,
+    const Timeout& timeout) {
+  require_ibgda(group, "registered-source send drain");
+  return ibgda->progress_registered_send_drain_once(group, timeout);
 }
 
 template <typename CopyOp, typename... Args>

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -29,6 +29,50 @@ enum class IbgdaSendRecvProgressStatus : uint8_t {
   Done,
 };
 
+enum class IbgdaRegisteredSendProgressStatus : uint8_t {
+  Waiting,
+  Progressed,
+  Posted,
+  Drained,
+};
+
+namespace detail {
+
+template <typename Transport>
+__device__ __forceinline__ void init_registered_send_progress(
+    Transport& transport,
+    ThreadGroup& group,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0);
+
+template <typename Transport>
+__device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+progress_registered_send_once(
+    Transport& transport,
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0,
+    const Timeout& timeout = Timeout());
+
+template <typename Transport>
+__device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+progress_registered_send_drain_once(
+    Transport& transport,
+    ThreadGroup& group,
+    const Timeout& timeout = Timeout());
+
+template <typename Transport>
+__device__ __forceinline__ void send_registered(
+    Transport& transport,
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0,
+    const Timeout& timeout = Timeout());
+
+} // namespace detail
+
 struct P2pIbTransportDevice {
   P2pIbBackendType type{P2pIbBackendType::IBGDA};
   union {
@@ -213,6 +257,10 @@ struct P2pIbTransportDevice {
 
   __device__ void fence();
 
+  __device__ __forceinline__ void require_ibgda(
+      ThreadGroup& group,
+      const char* operation) const;
+
   template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void send(
       ThreadGroup& group,
@@ -221,6 +269,14 @@ struct P2pIbTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args);
+
+  template <typename = void>
+  __device__ __forceinline__ void send_registered(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& src,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout());
 
   template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void recv(
@@ -254,6 +310,12 @@ struct P2pIbTransportDevice {
       std::size_t max_signal_bytes = 0);
 
   template <typename = void>
+  __device__ __forceinline__ void init_registered_send_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0);
+
+  template <typename = void>
   __device__ __forceinline__ void init_recv_progress(
       ThreadGroup& group,
       std::size_t nbytes,
@@ -267,6 +329,21 @@ struct P2pIbTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args);
+
+  template <typename = void>
+  __device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+  progress_registered_send_once(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& src,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout());
+
+  template <typename = void>
+  __device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+  progress_registered_send_drain_once(
+      ThreadGroup& group,
+      const Timeout& timeout = Timeout());
 
   template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -162,6 +162,26 @@ __device__ __forceinline__ void init_send_progress(
 #endif
 }
 
+template <typename Transport>
+__device__ __forceinline__ void init_registered_send_progress(
+    Transport& transport,
+    ThreadGroup& group,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  if (nbytes > 0) {
+    __threadfence_system();
+    group.sync();
+  }
+  init_send_progress(transport, group, nbytes, max_signal_bytes);
+#else
+  (void)transport;
+  (void)group;
+  (void)nbytes;
+  (void)max_signal_bytes;
+#endif
+}
+
 /**
  * Initialize transport-owned state for one pipelined recv operation.
  *
@@ -468,6 +488,249 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
   (void)max_signal_bytes;
   (void)timeout;
   return IbgdaSendRecvProgressStatus::Done;
+#endif
+}
+
+template <typename Transport>
+__device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+progress_registered_send_once(
+    Transport& transport,
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  auto& channelLayout = transport.channel_layout();
+  auto& progressSlot = progress_send_slot<protocol::Simple>(transport, group);
+  IbChannelProgress state = progressSlot;
+  if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
+    return IbgdaRegisteredSendProgressStatus::Posted;
+  }
+
+  const ProgressGeometry geometry = make_progress_geometry<protocol::Simple>(
+      channelLayout,
+      group,
+      nbytes,
+      max_signal_bytes,
+      "progress_registered_send_once");
+  if (active_payload_offset(state) >= geometry.protocolBytes) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: progress_registered_send_once payloadOffset=%llu "
+          ">= protocolBytes=%llu without Done stage\n",
+          static_cast<unsigned long long>(active_payload_offset(state)),
+          static_cast<unsigned long long>(geometry.protocolBytes));
+    }
+    PIPES_DEVICE_TRAP();
+  }
+  validate_send_progress_stage(group, state);
+
+  const detail::IbSendRecvProgressStage initialStage = state.activeStage;
+  const std::size_t initialNextByte = state.activeNextByte;
+  const std::size_t pipelineBytesWire = geometry.perBlockSlotWire *
+      static_cast<std::size_t>(channelLayout.pipelineDepth);
+  const ChannelSlotView ch =
+      acquire_channel<protocol::Simple>(transport, channelLayout, group);
+  const IbgdaLocalBuffer localSlotFree = ch.local.slotFree;
+  const IbRemoteChannel remoteChannel = ch.remote;
+
+  if (state.activeStage ==
+      detail::IbSendRecvProgressStage::WaitLocalCompletion) {
+    const ProgressChunk chunk =
+        next_chunk<protocol::Simple>(channelLayout, state, geometry);
+    if (!try_prepare_send_slot<protocol::Simple>(
+            transport,
+            group,
+            chunk.slotId,
+            chunk.pipelineGeneration,
+            timeout)) {
+      return IbgdaRegisteredSendProgressStatus::Waiting;
+    }
+    transition_progress_stage(
+        group, state, detail::IbSendRecvProgressStage::WaitSlotFree);
+  }
+
+  if (state.activeStage == detail::IbSendRecvProgressStage::WaitSlotFree) {
+    const ProgressChunk chunk =
+        next_chunk<protocol::Simple>(channelLayout, state, geometry);
+    const bool isFinalChunk =
+        chunk.dataOff + chunk.payloadBytes >= geometry.protocolBytes;
+    const uint64_t protocolStreamEnd = chunk.streamEndWire +
+        (isFinalChunk ? protocol::Simple::wire_bytes(state.activeTailPadding)
+                      : 0);
+    if (protocolStreamEnd > pipelineBytesWire) {
+      const uint64_t expected = protocolStreamEnd - pipelineBytesWire;
+      uint32_t ready = 1;
+      unsigned long long current = 0;
+      if (group.is_leader()) {
+        current = static_cast<unsigned long long>(
+            transport.read_signal(localSlotFree));
+        ready = current >= expected ? 1U : 0U;
+        if (!ready) {
+          TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+              timeout,
+              "progress_registered_send_once waiting for SLOT_FREE "
+              "expected>=%llu, current=%llu",
+              static_cast<unsigned long long>(expected),
+              current);
+        }
+      }
+      ready = group.broadcast<uint32_t>(ready);
+      if (!ready) {
+        if (state.activeStage != initialStage ||
+            state.activeNextByte != initialNextByte) {
+          store_progress_state(group, progressSlot, state);
+          return IbgdaRegisteredSendProgressStatus::Progressed;
+        }
+        return IbgdaRegisteredSendProgressStatus::Waiting;
+      }
+    }
+
+    const std::size_t validBytes = valid_payload_bytes(
+        chunk.dataOff, chunk.payloadBytes, geometry.payloadBytes);
+    const std::size_t protocolBytesThis = chunk.wireBytes +
+        (isFinalChunk ? protocol::Simple::wire_bytes(state.activeTailPadding)
+                      : 0);
+
+    group.sync();
+    if (group.is_leader()) {
+      __threadfence_system();
+      ThreadGroup solo{
+          0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+      const auto completion = transport.put(
+          solo,
+          src.subBuffer(chunk.dataOff),
+          remoteChannel.recvStaging.subBuffer(chunk.stagingOff),
+          validBytes,
+          remoteChannel.dataReady,
+          protocolBytesThis,
+          {},
+          0,
+          true);
+      record_send_completion<protocol::Simple>(
+          transport,
+          static_cast<uint32_t>(geometry.groupId),
+          chunk.slotId,
+          chunk.pipelineGeneration,
+          completion);
+    }
+    group.sync();
+
+    state.activeNextByte += chunk.payloadBytes;
+    if (active_payload_offset(state) >= geometry.protocolBytes) {
+      transition_progress_stage(
+          group, state, detail::IbSendRecvProgressStage::Done);
+      store_progress_state(group, progressSlot, state);
+      return IbgdaRegisteredSendProgressStatus::Posted;
+    }
+    transition_progress_stage(
+        group, state, detail::IbSendRecvProgressStage::WaitLocalCompletion);
+  }
+
+  if (state.activeStage != initialStage ||
+      state.activeNextByte != initialNextByte) {
+    store_progress_state(group, progressSlot, state);
+    return IbgdaRegisteredSendProgressStatus::Progressed;
+  }
+  return IbgdaRegisteredSendProgressStatus::Waiting;
+#else
+  (void)transport;
+  (void)group;
+  (void)src;
+  (void)nbytes;
+  (void)max_signal_bytes;
+  (void)timeout;
+  return IbgdaRegisteredSendProgressStatus::Drained;
+#endif
+}
+
+template <typename Transport>
+__device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+progress_registered_send_drain_once(
+    Transport& transport,
+    ThreadGroup& group,
+    const Timeout& timeout) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  uint32_t result =
+      static_cast<uint32_t>(IbgdaRegisteredSendProgressStatus::Drained);
+  if (group.is_leader()) {
+    bool foundPending = false;
+    bool madeProgress = false;
+    auto& channel =
+        transport.template local_channel_slot<protocol::Simple>(group.group_id);
+    const uint32_t numLanes = transport.send_completion_lane_count();
+    const int pipelineDepth = transport.channel_layout().pipelineDepth;
+
+    for (int slotId = 0; slotId < pipelineDepth; ++slotId) {
+      auto& slot = channel.sendCompletionSlots[slotId];
+      uint64_t pending = slot.laneMask;
+      for (uint32_t laneId = 0; laneId < numLanes; ++laneId) {
+        const uint64_t laneBit = 1ULL << laneId;
+        if ((pending & laneBit) == 0) {
+          continue;
+        }
+        const IbLocalCompletionTicket ticket{
+            .completionId = laneId,
+            .value = slot.values[laneId],
+        };
+        if (transport.is_local_completion_ready(group.group_id, ticket)) {
+          pending &= ~laneBit;
+          madeProgress = true;
+          continue;
+        }
+        foundPending = true;
+        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+            timeout,
+            "registered send local completion timed out slot=%d lane=%u",
+            slotId,
+            laneId);
+      }
+      slot.laneMask = pending;
+    }
+
+    if (foundPending) {
+      result = static_cast<uint32_t>(
+          madeProgress ? IbgdaRegisteredSendProgressStatus::Progressed
+                       : IbgdaRegisteredSendProgressStatus::Waiting);
+    }
+  }
+  result = group.broadcast<uint32_t>(result);
+  return static_cast<IbgdaRegisteredSendProgressStatus>(result);
+#else
+  (void)transport;
+  (void)group;
+  (void)timeout;
+  return IbgdaRegisteredSendProgressStatus::Drained;
+#endif
+}
+
+template <typename Transport>
+__device__ __forceinline__ void send_registered(
+    Transport& transport,
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  init_registered_send_progress(transport, group, nbytes, max_signal_bytes);
+  IbgdaRegisteredSendProgressStatus status;
+  do {
+    status = progress_registered_send_once(
+        transport, group, src, nbytes, max_signal_bytes, timeout);
+  } while (status != IbgdaRegisteredSendProgressStatus::Posted &&
+           status != IbgdaRegisteredSendProgressStatus::Drained);
+  while (status != IbgdaRegisteredSendProgressStatus::Drained) {
+    status = progress_registered_send_drain_once(transport, group, timeout);
+  }
+#else
+  (void)transport;
+  (void)group;
+  (void)src;
+  (void)nbytes;
+  (void)max_signal_bytes;
+  (void)timeout;
 #endif
 }
 

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -2081,6 +2081,19 @@ class P2pIbgdaTransportDevice {
   }
 
   /**
+   * Initialize a registered-source send that shares the normal send protocol
+   * cursor but bypasses local send staging.
+   */
+  template <typename = void>
+  __device__ __forceinline__ void init_registered_send_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0) {
+    detail::init_registered_send_progress(
+        *this, group, nbytes, max_signal_bytes);
+  }
+
+  /**
    * Initialize transport-owned state for one pipelined recv operation.
    *
    * The transport reserves the receiver-side protocol byte stream for
@@ -2156,6 +2169,34 @@ class P2pIbgdaTransportDevice {
       Args... args) {
     return detail::progress_send_once<P2pIbgdaTransportDevice, CopyOp>(
         *this, group, src, nbytes, max_signal_bytes, timeout, args...);
+  }
+
+  /**
+   * Post registered-source send chunks without copying through send staging.
+   * `Posted` does not release the source; callers must later drain.
+   */
+  template <typename = void>
+  __device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+  progress_registered_send_once(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& src,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout()) {
+    return detail::progress_registered_send_once(
+        *this, group, src, nbytes, max_signal_bytes, timeout);
+  }
+
+  /**
+   * Poll all outstanding send completion tickets for this channel. `Drained`
+   * means registered source ranges posted before the call are reusable.
+   */
+  template <typename = void>
+  __device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+  progress_registered_send_drain_once(
+      ThreadGroup& group,
+      const Timeout& timeout = Timeout()) {
+    return detail::progress_registered_send_drain_once(*this, group, timeout);
   }
 
   /**
@@ -2248,6 +2289,20 @@ class P2pIbgdaTransportDevice {
       Args... args) {
     sendWithTrace<CopyOp>(
         group, src, nbytes, max_signal_bytes, timeout, {}, 0, args...);
+  }
+
+  /**
+   * Blocking registered-source send. Returns only after local NIC completion.
+   */
+  template <typename = void>
+  __device__ __forceinline__ void send_registered(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& src,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout()) {
+    detail::send_registered(
+        *this, group, src, nbytes, max_signal_bytes, timeout);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>


### PR DESCRIPTION
Summary:

Add move-only bulk-buffer registration leases with stable generations and non-owning contained-range views. Bulk registrations request PCIe Relaxed Ordering, share the existing per-allocation MR cache, and reject invalid, overflowing, stale, or released ranges.

Expose the lease operations through `MultiPeerTransport` for the IBGDA zero-copy AllReduce path. This change does not alter collective behavior or enable zero-copy Ring or Tree.

Add focused lifetime, containment, overlap, ordering, and re-registration coverage. IBRC exercises the shared transport-base implementation as regression coverage; IBGDA remains the product scope.

Reviewed By: rmahidhar

Differential Revision: D114554503


