### PR TITLE
Add rank-consistent AllReduce zero-copy eligibility (#3415)

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1950,6 +1950,16 @@ cvars:
      shared IMEX domain fails communicator init outright. Set true on fleets
      known to share an IMEX domain.
 
+ - name        : MCCL_ALLREDUCE_ZERO_COPY_MODE
+   type        : enum
+   default     : "off"
+   choices     : off, force
+   description : |-
+     Select send-side zero-copy for MCCL-native AllReduce.
+     off - Preserve the existing copy-based registration and collective paths.
+     force - Require every rank and the exact Phase-2 source range to be
+             eligible for IBGDA zero-copy; never fall back to the copy path.
+
  - name        : NCCL_CTRAN_PIPES_TRACE_ENABLE
    type        : bool
    default     : false


### PR DESCRIPTION
Summary:

Add the minimal control plane required before MCCL-native Tree and Ring can consume registered send-side buffers.

- Add `MCCL_ALLREDUCE_ZERO_COPY_MODE=off|force`, defaulting to `off`.
- Preserve the existing CTRAN-only registration and copy collective paths when disabled.
- Track active MCCL composite registrations and resolve the exact Phase-2 source subrange to an IBGDA lease view.
- Carry algorithm, range, and lease generation in a reusable preflight token and reject stale tokens after deregistration.
- Agree on the mode during communicator initialization and gather per-rank eligibility before a forced launch.
- Return deterministic errors for mismatched modes, unsupported requests, missing registrations, invalid ranges, or unavailable IBGDA.
- Prevent `force` from silently falling back to the copy kernel.

This diff does not implement Tree or Ring zero-copy data movement. After successful eligibility preflight, force mode intentionally returns `commInvalidUsage` until the follow-up Tree and Ring integration diffs consume the token.

Reviewed By: rmahidhar

Differential Revision: D114571923


