### PR TITLE
Fix the installed link_ep package's imports (OSS/conda egg) (#3425)

### DIFF
--- a/comms/prims/collectives/link_ep/link_ep/__init__.py
+++ b/comms/prims/collectives/link_ep/link_ep/__init__.py
@@ -12,10 +12,17 @@ Public Python surface for the prims-based dispatch / combine kernels under
 
 from __future__ import annotations
 
-# pyre-ignore[21]: cpp_python_extension at runtime
-from comms.prims.collectives.link_ep import _cpp  # @manual
-from comms.prims.collectives.link_ep.link_ep.buffer import Buffer
-from comms.prims.collectives.link_ep.link_ep.utils import EventOverlap
+try:
+    # Installed egg: this package is top-level, so `_cpp` sits beside it.
+    # pyre-ignore[21]: only resolvable in the installed-egg layout
+    from . import _cpp
+except ModuleNotFoundError:
+    # Buck: this package is nested one level deeper than the extension.
+    # pyre-ignore[21]: cpp_python_extension at runtime
+    from comms.prims.collectives.link_ep import _cpp  # @manual
+
+from .buffer import Buffer
+from .utils import EventOverlap
 
 # Tuning-knob struct re-exported from the C++ extension. Ctor:
 #   Config(num_sms,

--- a/comms/prims/collectives/link_ep/link_ep/buffer.py
+++ b/comms/prims/collectives/link_ep/link_ep/buffer.py
@@ -18,13 +18,16 @@ from typing import Any, Callable
 import torch
 import torch.distributed as dist
 
-# pyre-ignore[21]: cpp_python_extension at runtime
-from comms.prims.collectives.link_ep import _cpp  # @manual
-from comms.prims.collectives.link_ep.link_ep.utils import (
-    check_nvlink_connections,
-    EventHandle,
-    EventOverlap,
-)
+try:
+    # Installed egg: this package is top-level, so `_cpp` sits beside it.
+    # pyre-ignore[21]: only resolvable in the installed-egg layout
+    from . import _cpp
+except ModuleNotFoundError:
+    # Buck: this package is nested one level deeper than the extension.
+    # pyre-ignore[21]: cpp_python_extension at runtime
+    from comms.prims.collectives.link_ep import _cpp  # @manual
+
+from .utils import check_nvlink_connections, EventHandle, EventOverlap
 
 logger: logging.Logger = logging.getLogger(__name__)
 

--- a/comms/prims/collectives/link_ep/link_ep/utils.py
+++ b/comms/prims/collectives/link_ep/link_ep/utils.py
@@ -20,8 +20,14 @@ from typing import Any
 import torch
 import torch.distributed as dist
 
-# pyre-ignore[21]: cpp_python_extension at runtime; static analyzer doesn't see it
-from comms.prims.collectives.link_ep import _cpp  # @manual
+try:
+    # Installed egg: this package is top-level, so `_cpp` sits beside it.
+    # pyre-ignore[21]: only resolvable in the installed-egg layout
+    from . import _cpp
+except ModuleNotFoundError:
+    # Buck: this package is nested one level deeper than the extension.
+    # pyre-ignore[21]: cpp_python_extension at runtime; static analyzer doesn't see it
+    from comms.prims.collectives.link_ep import _cpp  # @manual
 
 logger: logging.Logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Summary:

The `link_ep` Python modules imported the C++ extension by its buck path
(`comms.prims.collectives.link_ep._cpp`), and imported each other the same way.
That resolves inside a buck binary, but the OSS `setup.py` installs the inner
package top-level as `link_ep`, so in the conda egg there is no `comms` package
and `import link_ep` dies with `ModuleNotFoundError: No module named 'comms'`.
Every conda/MAST consumer therefore fell into the dispatcher's "link_ep is not
installed" path -- the egg has never been importable.

Sibling imports become relative, which is correct in both layouts. The
extension import is the one that genuinely differs (beside the package in the
egg, one level up under buck), so it tries the relative form and falls back.
The fallback is keyed on `ModuleNotFoundError` rather than `ImportError`, so a
genuine load failure of the built `.so` propagates with its real message
instead of being masked as a missing module.

Reviewed By: srinathb-meta

Differential Revision: D114608219


