### PR TITLE
Add perf knob for skipping per-step barrier in multicast path - 28% busbw gain in solo AGP, 49% gain when overlap with DistMOE using DORA config

### DIFF
--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -345,6 +345,15 @@ commResult_t AlgoImpl::execPipeline(
       const auto offset =
           getRecvChunkIdxInRail(upPeer, step, nLocalRanks, nRanks) * sendSize;
       const auto sendPtr = getPtr(pArgs.recvbuff, offset);
+      // The per-step barrier only paces the N-1 unicast writes' incast, so it
+      // is always kept on that path. The multicast write is a single
+      // switch-fanned store with no incast to pace, so
+      // NCCL_CTRAN_AGP_SKIP_MC_INTRA_BARRIER can drop it there as a perf A/B.
+      // Correctness holds either way via the step-0 barrier (cross-iteration
+      // WAR) + PipeEnd (completion), with disjoint per-rank rail columns in
+      // between.
+      const bool skipBarrier =
+          pArgs.mcWrite && NCCL_CTRAN_AGP_SKIP_MC_INTRA_BARRIER;
       FB_COMMCHECK(nvlCeBcast(
           comm_,
           sendPtr,
@@ -353,7 +362,7 @@ commResult_t AlgoImpl::execPipeline(
           pArgs.remoteRecvBuffs,
           pArgs.remoteAccessKeys,
           stream_,
-          /*barrier=*/true,
+          /*barrier=*/!skipBarrier,
           pArgs.mcWrite));
     }
 

--- a/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
@@ -329,6 +329,15 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
         const auto offset =
             (static_cast<size_t>(node) * nLocalRanks + localRank) * sendSize;
         auto srcPtr = ctran::allgatherp::getPtr(pArgs.recvbuff, offset);
+        // The per-step barrier fires once per step (first chunk) and only paces
+        // the N-1 unicast writes' incast, so it is always kept on that path.
+        // The multicast write is a single switch-fanned store with no incast to
+        // pace, so NCCL_CTRAN_AGP_SKIP_MC_INTRA_BARRIER can drop it there as a
+        // perf A/B. Correctness holds either way via the pre-loop own-chunk
+        // barrier (cross-iteration WAR) + PipeEnd, with disjoint per-rank rail
+        // columns.
+        const bool skipBarrier =
+            pArgs.mcWrite && NCCL_CTRAN_AGP_SKIP_MC_INTRA_BARRIER;
         FB_COMMCHECK(nvlCeBcast(
             comm_,
             srcPtr,
@@ -337,7 +346,7 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
             pArgs.remoteRecvBuffs,
             pArgs.remoteAccessKeys,
             stream_,
-            chunkIndex++ == 0,
+            chunkIndex++ == 0 && !skipBarrier,
             pArgs.mcWrite));
       }
     }

--- a/comms/ctran/tests/CtranDistAllgatherCtwinTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherCtwinTests.cc
@@ -15,6 +15,7 @@
 #include "comms/ctran/tests/VerifyAlgoStatsUtil.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/window/CtranWin.h"
+#include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
 
 using namespace ctran;
@@ -638,6 +639,85 @@ TEST_F(CtranAllgatherCtwinTest, ForceVariants) {
   oobBarrier();
   freeSymmetricWindow(win, winBase, windowBytes);
 }
+
+// A/B for NCCL_CTRAN_AGP_SKIP_MC_INTRA_BARRIER, both settings in one job so a
+// single launch covers the knob on and off.
+//
+// The knob gates only the per-step intra-node NVL broadcast barrier, and only
+// where the multicast write is engaged. Reaching that branch needs BOTH:
+//   - nLocalRanks > 1, else nvlCeBcast is never called at all; and
+//   - nNodes > 1, else the loops holding the gated call run zero iterations
+//     (ctpipeline is bounded by nNodes-1, ctsrdpipeline by log2(nNodes)).
+// A single-node config therefore cannot exercise it, so skip loudly rather than
+// pass vacuously. Reachable topologies include the vnode configs (which fake
+// nNodes>1 on one host) and real multinode runs.
+class CtranAllgatherCtwinMcBarrierTest
+    : public CtranAllgatherCtwinTest,
+      public ::testing::WithParamInterface<bool> {};
+
+TEST_P(CtranAllgatherCtwinMcBarrierTest, PerStepBarrierSkip) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skipping ctwin test";
+  }
+  if (ctranComm->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+  const auto nLocalRanks = ctranComm->statex_->nLocalRanks();
+  const auto nNodes = ctranComm->statex_->nNodes();
+  if (nLocalRanks < 2 || nNodes < 2) {
+    GTEST_SKIP() << "the gated per-step barrier needs nLocalRanks>1 and "
+                 << "nNodes>1 to be reached; got nLocalRanks=" << nLocalRanks
+                 << " nNodes=" << nNodes;
+  }
+
+  // Read fresh inside each exec, so flipping it here applies to the gathers
+  // below even though the window caches the AGP request across calls. Every
+  // rank runs the same parameterized case in the same order, so the local ranks
+  // agree on whether the device-side barrier is emitted -- they must, or a rank
+  // that still emits it would wait on peers that skipped it.
+  EnvRAII<bool> skipBarrier(NCCL_CTRAN_AGP_SKIP_MC_INTRA_BARRIER, GetParam());
+
+  const size_t typeSize = commTypeSize(dt);
+  const size_t sendCount = 8192;
+  const size_t regionBytes = sendCount * numRanks * typeSize;
+  const size_t windowBytes = 2 * regionBytes;
+
+  CtranWin* win = nullptr;
+  void* winBase = createSymmetricWindow(windowBytes, &win);
+  ASSERT_NE(win, nullptr);
+  EXPECT_TRUE(win->isSymmetric());
+
+  // Both variants that gate the barrier on this cvar, on disjoint sub-ranges so
+  // each gets its own cached persistent request.
+  runGatherOnStream(
+      win,
+      winBase,
+      /*byteOffset=*/0,
+      sendCount,
+      /*iter=*/0,
+      stream,
+      NCCL_ALLGATHER_ALGO::ctwin_pipeline);
+  runGatherOnStream(
+      win,
+      winBase,
+      /*byteOffset=*/regionBytes,
+      sendCount,
+      /*iter=*/1,
+      stream,
+      NCCL_ALLGATHER_ALGO::ctwin_rdpipeline);
+  EXPECT_EQ(win->numPersistentRequests(), 2u);
+
+  oobBarrier();
+  freeSymmetricWindow(win, winBase, windowBytes);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CtranTest,
+    CtranAllgatherCtwinMcBarrierTest,
+    ::testing::Bool(),
+    [](const ::testing::TestParamInfo<bool>& info) {
+      return info.param ? "SkipMcIntraBarrier" : "KeepMcIntraBarrier";
+    });
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2169,7 +2169,25 @@ cvars:
                   inter-node rail ring and intra-node CopyEngine based copy
      ctsrdpipeline - Ctran-based hybrid algorithm that streams recursive-doubling
                      forwards across rails while keeping NVLink-domain CopyEngine
-                     broadcast step-based. Requires nNodes to be a power of 2.
+                    broadcast step-based. Requires nNodes to be a power of 2.
+
+ - name        : NCCL_CTRAN_AGP_SKIP_MC_INTRA_BARRIER
+   type        : bool
+   default     : false
+   description : |-
+     Perf A/B knob for the per-step intra-node NVL broadcast barrier in the
+     AllGatherP pipeline / streamed-recursive-doubling algorithms, scoped to the
+     CE-multicast path only. When false (default) the per-step barrier is
+     emitted; when true it is skipped, but only where the multicast write is
+     engaged (pArgs.mcWrite). The barrier exists to pace the N-1 per-peer unicast
+     writes so they do not all-to-one incast a single peer, so it is always kept
+     on the unicast path regardless of this setting — including on ctwin runs
+     that fell back to unicast because multicast was unavailable, and on ctgraph,
+     which is always unicast. A multicast broadcast is one switch-fanned store
+     with no incast to pace, which is what makes it safe to drop there. Only the
+     optional per-step barrier is affected; the step-0/own-chunk barrier
+     (cross-iteration WAR guard) and the PipeEnd barrier (final completion) are
+     always kept for correctness.
 
  - name        : NCCL_ALLGATHER_ALGO
    type        : enum


### PR DESCRIPTION
Summary:
Adds `NCCL_CTRAN_AGP_SKIP_MC_INTRA_BARRIER` (bool, default false), a perf A/B knob
for the per-step intra-node NVL broadcast barrier in AllGatherP's pipeline / SRD
algorithms, scoped to the CE-multicast path only.

Why scoped and not global: the barrier is not dead weight on unicast. nvlCeBcast
issues N-1 per-peer copies starting at `(localRank + r) % nLocalRanks` so each
destination is targeted by one source at a time; that shift is only a permutation
if the ranks are in lockstep, so dropping the barrier there lets phases drift and
several ranks incast the same peer. A multicast broadcast is one switch-fanned
store with no per-peer incast to pace -- nvlCeBcast returns before the peer loop
entirely. So the barrier stays unconditional on unicast; only multicast is gated.

The predicate is `pArgs.mcWrite` (is the multicast write actually engaged), not
"is this ctwin". mcWrite is set only on the ctwin/window path, and even there only
if CtranMulticast::isSupported(): driver multicast entry points, plus
CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED (Hopper+, no arch conditional), plus
isCuMemFabricEnabled(). That last one is the practical discriminator -- the MC
object is shared over the NVL domain via a CU_MEM_HANDLE_TYPE_FABRIC handle, so
without an IMEX channel cuMulticastCreate returns CUDA_ERROR_NOT_PERMITTED and the
group falls back to unicast. A ctwin run may therefore be unicast or multicast
depending on the host, and ctgraph is always unicast; gating on the front-end
instead of mcWrite would drop the barrier on exactly the unicast runs needing it.

Correctness is unchanged either way. Only the optional per-step barrier is
affected -- the step-0 / own-chunk barrier (cross-iteration WAR guard) and the
PipeEnd device barrier (completion + release/acquire visibility) are always
emitted. Between them each rank writes only its own rail column
`(node * nLocalRanks + localRank) * sendSize`, the same formula the GPE side uses,
so write sets are disjoint, each offset is written once per collective, and no
rank reads a peer-written region before PipeEnd.

Live only for nLocalRanks > 1 and nNodes >= 2 on pipeline/SRD; a no-op for
ctdirect (no per-step barrier) and the nLocalRanks == 1 variants (never call
nvlCeBcast). Also reorders SRD's condition to `chunkIndex++ == 0 && !skipBarrier`
so the increment is no longer hidden behind a short-circuit.

Test infra, so the knob is covered rather than assumed:
- `CtranAllgatherCtwinMcBarrierTest.PerStepBarrierSkip` -- TEST_P over
  `::testing::Bool()` flipping the cvar via `EnvRAII<bool>` and running both gated
  variants (ctwin_pipeline, ctwin_rdpipeline). Both settings in ONE job. Works
  because the cvar is read fresh per exec even though the window caches the AGP
  request. All ranks run the same case in the same order, so local ranks agree on
  whether the device barrier is emitted -- they must, or a rank still emitting it
  would wait forever on peers that skipped. GTEST_SKIPs with a reason when
  nLocalRanks < 2 or nNodes < 2, where the gated call runs zero iterations and the
  test would pass vacuously.
- `2x2_init_ring_hybrid` config for ctran_dist_allgather_ctwin -- smallest
  topology reaching the branch (ctpipeline is bounded by nNodes-1, SRD by
  log2(nNodes), so single-node runs neither), and it fits 2-GPU hosts where ppn=8
  collides ranks onto one device and cuMulticastAddDevice fails on the duplicate.

Reviewed By: dolpm

Differential Revision: D114454470


