### PR TITLE
AllGatherP: profiler covers the NVL broadcast tail

### DIFF
--- a/comms/ctran/algos/AllGather/StreamedRd/Common.h
+++ b/comms/ctran/algos/AllGather/StreamedRd/Common.h
@@ -306,26 +306,4 @@ inline commResult_t progressSteps(AlgoContext& ctx, int localChunk) {
   return commSuccess;
 }
 
-template <typename AlgoContext>
-inline commResult_t runExchangeAndProgress(
-    AlgoContext& ctx,
-    int localChunk,
-    ctran::Profiler* profiler) {
-  CTRAN_PROFILER_IF(
-      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
-  FB_COMMCHECK(exchangeCtrl(ctx));
-  CTRAN_PROFILER_IF(
-      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
-
-  // Data transfer: step-ordered event loop.
-  CTRAN_PROFILER_IF(
-      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
-  FB_COMMCHECK(progressSteps(ctx, localChunk));
-  CTRAN_PROFILER_IF(
-      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
-
-  FB_COMMCHECK(waitCtrl(ctx));
-  return commSuccess;
-}
-
 } // namespace ctran::allgather::ctsrd::common

--- a/comms/ctran/algos/AllGather/StreamedRd/Impl.cc
+++ b/comms/ctran/algos/AllGather/StreamedRd/Impl.cc
@@ -21,8 +21,10 @@ namespace {
 using ctran::algos::PersistPlanKey;
 using ctran::allgather::ctsrd::createPersistPlan;
 using ctran::allgather::ctsrd::PersistPlan;
+using ctran::allgather::ctsrd::common::exchangeCtrl;
+using ctran::allgather::ctsrd::common::progressSteps;
 using ctran::allgather::ctsrd::common::resolveFwdPeers;
-using ctran::allgather::ctsrd::common::runExchangeAndProgress;
+using ctran::allgather::ctsrd::common::waitCtrl;
 
 const auto myAlgo = NCCL_ALLGATHER_ALGO::ctsrd;
 using CtsrdAlgoContext = ctran::allgather::ctsrd::AlgoContext;
@@ -129,7 +131,19 @@ commResult_t impl(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   CTRAN_PROFILER_IF(
       profiler, profiler->endEvent(ctran::ProfilerEvent::BUF_REG));
 
-  FB_COMMCHECK(runExchangeAndProgress(ctx, rank, profiler));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
+  FB_COMMCHECK(exchangeCtrl(ctx));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
+  FB_COMMCHECK(progressSteps(ctx, rank));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
+
+  FB_COMMCHECK(waitCtrl(ctx));
 
   return commSuccess;
 }

--- a/comms/ctran/algos/AllGatherP/CommUtils.h
+++ b/comms/ctran/algos/AllGatherP/CommUtils.h
@@ -24,6 +24,24 @@ using ctran::algos::copyToSelf;
 using ctran::algos::nvlBarrier;
 using ctran::algos::nvlCeBcast;
 
+// Clear the previous op's completion before this one posts any step, so
+// waitPipeEnd cannot latch a stale done. Must run before the first post().
+inline void resetPipeEnd(const Resource& resource, CtranComm* comm) {
+  if (resource.pipeSync != nullptr && comm->statex_->nLocalRanks() > 1) {
+    resource.pipeSync->resetStatus();
+  }
+}
+
+// Block until the end kernel signals completion. The NVL bcast + end barrier
+// run on the stream after the inter-node exchange, so ALGO_DATA needs this.
+inline void waitPipeEnd(const Resource& resource, CtranComm* comm) {
+  if (resource.pipeSync == nullptr || comm->statex_->nLocalRanks() <= 1) {
+    return;
+  }
+  while (!resource.pipeSync->isComplete(kPipeEndDone) && !comm->testAbort()) {
+  }
+}
+
 // Exchange intra-node NVL IPC handles into pArgs and mark initialized. Owns
 // the remote-buffer resize, the intraAllGatherCtrl + intraBarrier, per-peer
 // IPC logging, and setting initState. Logs its timing breakdown on the GPE

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -78,6 +78,8 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
 
   CtranMapperRequest syncSreq, syncRreq;
 
+  resetPipeEnd(*resource, comm);
+
   CTRAN_PROFILER_IF(
       profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
   // Ready-to-receive handshake with the rail neighbors. On the first replay it
@@ -148,6 +150,7 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   for (auto& putReq : putReqs) {
     FB_COMMCHECK(mapper->waitRequest(&putReq));
   }
+  waitPipeEnd(*resource, comm);
   CTRAN_PROFILER_IF(
       profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
 

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cu
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cu
@@ -87,6 +87,9 @@ __global__ void ncclKernelAllGatherPPipeEnd(
   const auto localRank = statex->localRank();
   const auto nLocalRanks = statex->nLocalRanks();
   barrier(localRank, nLocalRanks);
+
+  // Signal the GPE thread that the intra-node bcast + barrier finished
+  GpeKernelSyncDev::complete(args.pipeSync, 0, kPipeEndDone);
 }
 
 // The ctsrdpipeline (streamed recursive-doubling) variant's nLocalRanks > 1
@@ -126,6 +129,9 @@ __global__ void ncclKernelAllGatherPSrdPipeEnd(
   const auto localRank = statex->localRank();
   const auto nLocalRanks = statex->nLocalRanks();
   barrier(localRank, nLocalRanks);
+
+  // Signal the GPE thread that the intra-node bcast + barrier finished
+  GpeKernelSyncDev::complete(args.pipeSync, 0, kPipeEndDone);
 }
 
 } // namespace ctran::allgatherp

--- a/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
@@ -161,6 +161,8 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
       recvPlan,
       sendPlan);
 
+  resetPipeEnd(*resource, comm);
+
   CTRAN_PROFILER_IF(
       profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
   FB_COMMCHECK(exchangeCtrl(ctx));
@@ -170,6 +172,7 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   CTRAN_PROFILER_IF(
       profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
   FB_COMMCHECK(progressSteps(ctx, nodeId));
+  waitPipeEnd(*resource, comm);
   CTRAN_PROFILER_IF(
       profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
 

--- a/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
@@ -24,8 +24,10 @@ using ctran::algos::PersistPlanKey;
 using ctran::allgather::ctsrd::createPersistPlan;
 using ctran::allgather::ctsrd::PersistPlan;
 using ctran::allgather::ctsrd::Plan;
+using ctran::allgather::ctsrd::common::exchangeCtrl;
+using ctran::allgather::ctsrd::common::progressSteps;
 using ctran::allgather::ctsrd::common::resolveFwdPeers;
-using ctran::allgather::ctsrd::common::runExchangeAndProgress;
+using ctran::allgather::ctsrd::common::waitCtrl;
 using ctran::allgatherp::AlgoImpl;
 using ctran::allgatherp::PersistArgs;
 using ctran::allgatherp::Resource;
@@ -159,7 +161,19 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
       recvPlan,
       sendPlan);
 
-  FB_COMMCHECK(runExchangeAndProgress(ctx, nodeId, profiler));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
+  FB_COMMCHECK(exchangeCtrl(ctx));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
+  FB_COMMCHECK(progressSteps(ctx, nodeId));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
+
+  FB_COMMCHECK(waitCtrl(ctx));
 
   return commSuccess;
 }

--- a/comms/ctran/algos/AllGatherP/Types.h
+++ b/comms/ctran/algos/AllGatherP/Types.h
@@ -74,6 +74,9 @@ struct Resource {
   GpeKernelSync* pipeSync{nullptr};
 };
 
+// Fixed completion step; resetPipeEnd clears the flag each op.
+constexpr int kPipeEndDone = 0;
+
 struct PipeEndKernArgs {
   GpeKernelSync* pipeSync;
 };


### PR DESCRIPTION
Summary:
The AllGatherP `PipeEnd` kernels run the intra-node NVL broadcast and end barrier on the stream after the inter-node exchange returns, but `gpeFn` closed the `ALGO_DATA` profiler window as soon as that exchange completed. `dataTransferTimeUs` / `collectiveDurationUs` therefore covered only the inter-node phase and the derived busbw was inflated.

Both `PipeEnd` kernels now signal completion on `pipeSync->completeFlag`, and both `gpeFn`s wait for that signal before closing `ALGO_DATA`. The wait and its companion reset live in `CommUtils.h` as `waitPipeEnd` / `resetPipeEnd` so `ctpipeline` and `ctsrdpipeline` share one implementation.

`resetPipeEnd` clears the flag on the GPE thread before the op posts any step, so a fixed `kPipeEndDone` is enough to distinguish this collective's completion from the previous one's and nothing needs to be plumbed through `PipeEndKernArgs`.

Differential Revision: D114126087


