### PR TITLE
Batch SLOT_FREE credit at physical slot boundaries

### DIFF
--- a/comms/prims/benchmarks/IbgdaSendRecv.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cu
@@ -320,6 +320,22 @@ __global__ void __launch_bounds__(512, 1) ibgda_drain_send_recv_kernel(
     return;
   }
   auto& channel = transport->local_channel(static_cast<uint32_t>(groupId));
+  if (transport->batches_slot_free()) {
+    detail::assert_progress_slot_idle(
+        group, channel.recvProgress, "drain recv");
+    const IbRemoteChannel remoteChannel = makeIbRemoteChannel(layout, groupId);
+    const std::size_t slotPayload =
+        protocol::Simple::max_payload(detail::pipeline_chunk(layout));
+    const std::size_t trailingPayload =
+        static_cast<uint64_t>(channel.recvProgress.nextStep) % slotPayload;
+    if (trailingPayload != 0) {
+      transport->signal(
+          group,
+          remoteChannel.slotFree,
+          protocol::Simple::wire_bytes(trailingPayload),
+          IbDirection::Recv);
+    }
+  }
   transport->wait_counter(group, channel.nicDoneWait, expectedBytes, timeout);
   transport->wait_signal(group, channel.slotFree, expectedBytes, timeout);
 }

--- a/comms/prims/benchmarks/IbgdaSendRecv.h
+++ b/comms/prims/benchmarks/IbgdaSendRecv.h
@@ -97,7 +97,8 @@ void launch_ibgda_recv(
 
 /**
  * Drain outstanding bidirectional send/recv transport work for benchmark
- * measurement and safe teardown.
+ * measurement and safe teardown. Reset the benchmark transport state before
+ * launching more send/recv work.
  */
 void launch_ibgda_drain_send_recv(
     P2pIbgdaTransportDevice* transport,

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -100,11 +100,6 @@ class TestIbTransport {
     return ibgda_ ? ibgda_->qpsPerBlockPerNic() : config_.qpsPerBlockPerNic;
   }
 
-  std::size_t pipeline_window() const {
-    return config_.perChannelSize *
-        static_cast<std::size_t>(config_.pipelineDepth);
-  }
-
   int getGidIndex() const {
     return ibgda_ ? ibgda_->getGidIndex() : config_.gidIndex.value_or(-1);
   }
@@ -278,7 +273,7 @@ TEST_P(MultipeerIbTransportTestFixture, ConstructAndExchange) {
   XLOGF(INFO, "Rank {}: ConstructAndExchange test completed", globalRank);
 }
 
-TEST_P(MultipeerIbTransportTestFixture, PipelineGeometry) {
+TEST_P(MultipeerIbTransportTestFixture, PipelineLimits) {
   if (numRanks != 2) {
     GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
   }
@@ -307,7 +302,7 @@ TEST_P(MultipeerIbTransportTestFixture, PipelineGeometry) {
     auto* dOutput = static_cast<uint64_t*>(outputBuffer.get());
     CUDACHECK_TEST(cudaMemset(dOutput, 0, 3 * sizeof(uint64_t)));
 
-    test::testPipelineGeometry(
+    test::testPipelineLimits(
         transport.getP2pTransportDevice(peerRank),
         dOutput,
         numBlocks,
@@ -322,7 +317,10 @@ TEST_P(MultipeerIbTransportTestFixture, PipelineGeometry) {
         cudaMemcpyDeviceToHost));
 
     EXPECT_EQ(output[0], static_cast<uint64_t>(pipelineDepth));
-    EXPECT_EQ(output[1], static_cast<uint64_t>(perChannelBufferSize));
+    const std::size_t expectedPipelineWindow = backend() == IbTestBackend::Ibgda
+        ? perChannelBufferSize - pipelineChunk
+        : perChannelBufferSize;
+    EXPECT_EQ(output[1], static_cast<uint64_t>(expectedPipelineWindow));
     EXPECT_EQ(output[2], static_cast<uint64_t>(pipelineChunk));
   } catch (const std::exception& e) {
     GTEST_SKIP() << backendName(backend())
@@ -1328,10 +1326,8 @@ TEST_F(
         output.size() * sizeof(int64_t),
         cudaMemcpyDeviceToHost));
 
-    const int64_t expectedReservation =
-        static_cast<int64_t>(dataBufferSize / numBlocks / pipelineDepth);
-    EXPECT_EQ(output[0], expectedReservation);
-    EXPECT_EQ(output[1], expectedReservation);
+    EXPECT_EQ(output[0], static_cast<int64_t>(sendBytes));
+    EXPECT_EQ(output[1], static_cast<int64_t>(recvBytes));
   } catch (const std::exception& e) {
     GTEST_SKIP() << "IBGDA transport not available: " << e.what();
   }
@@ -1588,6 +1584,59 @@ TEST_F(
   }
 }
 
+void runSendThenRecvSequence(
+    P2pIbTransportDevice peerTransport,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    int repeatCount,
+    std::size_t maxSignalBytes,
+    uint8_t myPattern,
+    uint8_t peerPattern,
+    int numBlocks,
+    int blockSize) {
+  const std::size_t totalBytes = firstBytes + repeatCount * secondBytes;
+  DeviceBuffer sendBuffer(totalBytes);
+  DeviceBuffer recvBuffer(totalBytes);
+  DeviceBuffer errorCountBuf(sizeof(int));
+  auto* d_errorCount = static_cast<int*>(errorCountBuf.get());
+
+  test::fillBufferWithPattern(
+      sendBuffer.get(), totalBytes, myPattern, numBlocks, blockSize);
+  CUDACHECK_TEST(cudaMemset(recvBuffer.get(), 0, totalBytes));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  test::testSendThenRecvSequence(
+      peerTransport,
+      sendBuffer.get(),
+      recvBuffer.get(),
+      firstBytes,
+      secondBytes,
+      repeatCount,
+      maxSignalBytes,
+      numBlocks,
+      blockSize);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+  test::verifyBufferPattern(
+      recvBuffer.get(),
+      totalBytes,
+      peerPattern,
+      d_errorCount,
+      numBlocks,
+      blockSize);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  int h_errorCount = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(h_errorCount, 0)
+      << "send/recv sequence corrupted " << h_errorCount << " bytes";
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
 TEST_P(
     MultipeerIbTransportTestFixture,
     TwoCallSendThenRecvPaddingCreditNoDeadlock) {
@@ -1618,27 +1667,153 @@ TEST_P(
 
     P2pIbTransportDevice peerTransport =
         transport.getP2pTransportDevice(peerRank);
-    const std::size_t firstBytes = transport.pipeline_window() / 2;
-    const std::size_t secondBytes = transport.pipeline_window();
-    const std::size_t totalBytes = firstBytes + secondBytes;
-    DeviceBuffer sendBuffer(totalBytes);
-    DeviceBuffer recvBuffer(totalBytes);
+    const std::size_t firstBytes = dataBufferSize / 2;
+    const std::size_t secondBytes = dataBufferSize;
+    runSendThenRecvSequence(
+        peerTransport,
+        firstBytes,
+        secondBytes,
+        1,
+        maxSignalBytes,
+        myPattern,
+        peerPattern,
+        numBlocks,
+        blockSize);
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << backendName(backend())
+                 << " transport not available: " << e.what();
+  }
+}
+
+TEST_P(MultipeerIbTransportTestFixture, ResidualThenPipelineWindowNoDeadlock) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+
+  constexpr std::size_t physicalWindow = 64 * 1024;
+  constexpr int pipelineDepth = 4;
+  constexpr std::size_t pipelineChunk = physicalWindow / pipelineDepth;
+  constexpr std::size_t firstBytes = 16;
+  constexpr std::size_t maxSignalBytes = 0;
+  constexpr int numBlocks = 1;
+  constexpr int blockSize = 128;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  const uint8_t myPattern = static_cast<uint8_t>(0x50 + globalRank * 0x20);
+  const uint8_t peerPattern = static_cast<uint8_t>(0x50 + peerRank * 0x20);
+
+  try {
+    MultipeerIbTransportConfig config{
+        .cudaDevice = localRank,
+        .perChannelSize = physicalWindow,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
+    };
+
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    TestIbTransport transport(
+        backend(), globalRank, numRanks, std::move(bootstrap), config);
+    P2pIbTransportDevice peerTransport =
+        transport.getP2pTransportDevice(peerRank);
+    const std::size_t secondBytes = backend() == IbTestBackend::Ibgda
+        ? physicalWindow - pipelineChunk
+        : physicalWindow;
+    runSendThenRecvSequence(
+        peerTransport,
+        firstBytes,
+        secondBytes,
+        2,
+        maxSignalBytes,
+        myPattern,
+        peerPattern,
+        numBlocks,
+        blockSize);
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << backendName(backend())
+                 << " transport not available: " << e.what();
+  }
+}
+
+TEST_P(MultipeerIbTransportTestFixture, ForwardWithAsymmetricCursorOffsets) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+
+  constexpr std::size_t physicalWindow = 64 * 1024;
+  constexpr int pipelineDepth = 4;
+  constexpr std::size_t pipelineChunk = physicalWindow / pipelineDepth;
+  constexpr std::size_t primeBytes = 16;
+  constexpr std::size_t maxSignalBytes = 0;
+  constexpr uint8_t pattern = 0x71;
+  constexpr int numBlocks = 1;
+  constexpr int blockSize = 128;
+
+  try {
+    MultipeerIbTransportConfig config{
+        .cudaDevice = localRank,
+        .perChannelSize = physicalWindow,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
+        .qpsPerConnection = 2,
+    };
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    TestIbTransport transport(
+        backend(), globalRank, numRanks, std::move(bootstrap), config);
+    const int peerRank = globalRank == 0 ? 1 : 0;
+    P2pIbTransportDevice peer = transport.getP2pTransportDevice(peerRank);
+    P2pIbTransportDevice empty;
+
+    DeviceBuffer sendBuffer(pipelineChunk);
+    DeviceBuffer forwardBuffer(pipelineChunk);
+    DeviceBuffer recvBuffer(pipelineChunk);
+    DeviceBuffer primeRecvBuffer(primeBytes);
     DeviceBuffer errorCountBuf(sizeof(int));
     auto* d_errorCount = static_cast<int*>(errorCountBuf.get());
-
     test::fillBufferWithPattern(
-        sendBuffer.get(), totalBytes, myPattern, numBlocks, blockSize);
-    CUDACHECK_TEST(cudaMemset(recvBuffer.get(), 0, totalBytes));
+        sendBuffer.get(), pipelineChunk, pattern, numBlocks, blockSize);
+    CUDACHECK_TEST(cudaMemset(forwardBuffer.get(), 0, pipelineChunk));
+    CUDACHECK_TEST(cudaMemset(recvBuffer.get(), 0, pipelineChunk));
+    CUDACHECK_TEST(cudaMemset(primeRecvBuffer.get(), 0, primeBytes));
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
-    test::testTwoCallSendThenRecv(
-        peerTransport,
+    if (globalRank == 0) {
+      test::testSendForwardRecv(
+          empty,
+          peer,
+          sendBuffer.get(),
+          nullptr,
+          primeBytes,
+          maxSignalBytes,
+          test::SendForwardRecvRole::Send,
+          numBlocks,
+          blockSize);
+    } else {
+      test::testSendForwardRecv(
+          peer,
+          empty,
+          nullptr,
+          primeRecvBuffer.get(),
+          primeBytes,
+          maxSignalBytes,
+          test::SendForwardRecvRole::Recv,
+          numBlocks,
+          blockSize);
+    }
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    const test::SendForwardRecvRole role = globalRank == 0
+        ? test::SendForwardRecvRole::SendRecv
+        : test::SendForwardRecvRole::Forward;
+    void* output = globalRank == 0 ? recvBuffer.get() : forwardBuffer.get();
+    test::testSendForwardRecv(
+        peer,
+        peer,
         sendBuffer.get(),
-        recvBuffer.get(),
-        firstBytes,
-        secondBytes,
+        output,
+        pipelineChunk,
         maxSignalBytes,
+        role,
         numBlocks,
         blockSize);
     CUDACHECK_TEST(cudaDeviceSynchronize());
@@ -1646,19 +1821,13 @@ TEST_P(
 
     CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
     test::verifyBufferPattern(
-        recvBuffer.get(),
-        totalBytes,
-        peerPattern,
-        d_errorCount,
-        numBlocks,
-        blockSize);
+        output, pipelineChunk, pattern, d_errorCount, numBlocks, blockSize);
     CUDACHECK_TEST(cudaDeviceSynchronize());
-
     int h_errorCount = 0;
     CUDACHECK_TEST(cudaMemcpy(
         &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
-    EXPECT_EQ(h_errorCount, 0) << "two-call send-then-recv transfer corrupted "
-                               << h_errorCount << " bytes";
+    EXPECT_EQ(h_errorCount, 0)
+        << "send-forward-recv transfer corrupted " << h_errorCount << " bytes";
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
   } catch (const std::exception& e) {
     GTEST_SKIP() << backendName(backend())

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -311,10 +311,10 @@ void testPutOnly(
 }
 
 // =============================================================================
-// Kernel: Pipeline geometry snapshot
+// Kernel: Pipeline limits snapshot
 // =============================================================================
 
-__global__ void pipelineGeometryKernel(
+__global__ void pipelineLimitsKernel(
     P2pIbTransportDevice transport,
     uint64_t* output) {
   if (threadIdx.x == 0 && blockIdx.x == 0) {
@@ -324,12 +324,12 @@ __global__ void pipelineGeometryKernel(
   }
 }
 
-void testPipelineGeometry(
+void testPipelineLimits(
     P2pIbTransportDevice transport,
     uint64_t* output,
     int numBlocks,
     int blockSize) {
-  pipelineGeometryKernel<<<numBlocks, blockSize>>>(transport, output);
+  pipelineLimitsKernel<<<numBlocks, blockSize>>>(transport, output);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(
@@ -365,12 +365,13 @@ __global__ void sendRecvKernel(
   }
 }
 
-__global__ void twoCallSendThenRecvKernel(
+__global__ void sendThenRecvSequenceKernel(
     P2pIbTransportDevice transport,
     const void* sendBuffer,
     void* recvBuffer,
     std::size_t firstBytes,
     std::size_t secondBytes,
+    int repeatCount,
     std::size_t maxSignalBytes) {
   auto group = make_block_group();
   Timeout timeout(kDefaultDeviceTimeoutCycles);
@@ -380,10 +381,13 @@ __global__ void twoCallSendThenRecvKernel(
 
   transport.send(group, sendBytes, firstBytes, maxSignalBytes, timeout);
   transport.recv(group, recvBytes, firstBytes, maxSignalBytes, timeout);
-  transport.send(
-      group, sendBytes + firstBytes, secondBytes, maxSignalBytes, timeout);
-  transport.recv(
-      group, recvBytes + firstBytes, secondBytes, maxSignalBytes, timeout);
+  for (int call = 0; call < repeatCount; ++call) {
+    const std::size_t offset = firstBytes + call * secondBytes;
+    transport.send(
+        group, sendBytes + offset, secondBytes, maxSignalBytes, timeout);
+    transport.recv(
+        group, recvBytes + offset, secondBytes, maxSignalBytes, timeout);
+  }
 }
 
 void testSendRecv(
@@ -403,22 +407,71 @@ void testSendRecv(
   }
 }
 
-void testTwoCallSendThenRecv(
+void testSendThenRecvSequence(
     P2pIbTransportDevice transport,
     const void* sendBuffer,
     void* recvBuffer,
     std::size_t firstBytes,
     std::size_t secondBytes,
+    int repeatCount,
     std::size_t maxSignalBytes,
     int numBlocks,
     int blockSize) {
-  twoCallSendThenRecvKernel<<<numBlocks, blockSize>>>(
+  sendThenRecvSequenceKernel<<<numBlocks, blockSize>>>(
       transport,
       sendBuffer,
       recvBuffer,
       firstBytes,
       secondBytes,
+      repeatCount,
       maxSignalBytes);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
+__global__ void sendForwardRecvKernel(
+    P2pIbTransportDevice prev,
+    P2pIbTransportDevice next,
+    const void* sendBuffer,
+    void* recvBuffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    SendForwardRecvRole role) {
+  auto group = make_block_group();
+  Timeout timeout(kDefaultDeviceTimeoutCycles);
+  timeout.start();
+  switch (role) {
+    case SendForwardRecvRole::Send:
+      next.send(group, sendBuffer, nbytes, maxSignalBytes, timeout);
+      return;
+    case SendForwardRecvRole::Forward:
+      prev.forward(group, recvBuffer, next, nbytes, maxSignalBytes, timeout);
+      return;
+    case SendForwardRecvRole::Recv:
+      prev.recv(group, recvBuffer, nbytes, maxSignalBytes, timeout);
+      return;
+    case SendForwardRecvRole::SendRecv:
+      next.send(group, sendBuffer, nbytes, maxSignalBytes, timeout);
+      prev.recv(group, recvBuffer, nbytes, maxSignalBytes, timeout);
+      return;
+  }
+}
+
+void testSendForwardRecv(
+    P2pIbTransportDevice prev,
+    P2pIbTransportDevice next,
+    const void* sendBuffer,
+    void* recvBuffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    SendForwardRecvRole role,
+    int numBlocks,
+    int blockSize) {
+  sendForwardRecvKernel<<<numBlocks, blockSize>>>(
+      prev, next, sendBuffer, recvBuffer, nbytes, maxSignalBytes, role);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
@@ -71,7 +71,7 @@ __global__ void putOnlyKernel(
     IbgdaRemoteBuffer remoteBuf,
     std::size_t nbytes);
 
-__global__ void pipelineGeometryKernel(
+__global__ void pipelineLimitsKernel(
     P2pIbTransportDevice transport,
     uint64_t* output);
 

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -18,6 +18,13 @@ class P2pIbgdaTransportDevice;
 
 namespace comms::prims::test {
 
+enum class SendForwardRecvRole : uint8_t {
+  Send,
+  Forward,
+  Recv,
+  SendRecv,
+};
+
 /**
  * Test kernel: Put data + signal remote (thread-scope, slot-index)
  *
@@ -123,10 +130,10 @@ void testPutOnly(
 bool supportsProgressSendRecv();
 
 /**
- * Test kernel: snapshot send/recv pipeline geometry through the unified IB
+ * Test kernel: snapshot send/recv pipeline limits through the unified IB
  * transport wrapper. Output: pipelineDepth, pipelineWindow, pipelineChunk.
  */
-void testPipelineGeometry(
+void testPipelineLimits(
     P2pIbTransportDevice transport,
     uint64_t* output,
     int numBlocks,
@@ -145,15 +152,28 @@ void testSendRecv(
     int blockSize);
 
 /**
- * Test kernel: two sequential bidirectional blocking send/recv calls.
+ * Test kernel: one initial bidirectional call followed by repeated calls.
  */
-void testTwoCallSendThenRecv(
+void testSendThenRecvSequence(
     P2pIbTransportDevice transport,
     const void* sendBuffer,
     void* recvBuffer,
     std::size_t firstBytes,
     std::size_t secondBytes,
+    int repeatCount,
     std::size_t maxSignalBytes,
+    int numBlocks,
+    int blockSize);
+
+/** Test kernel: one role in a send -> forward -> recv chain. */
+void testSendForwardRecv(
+    P2pIbTransportDevice prev,
+    P2pIbTransportDevice next,
+    const void* sendBuffer,
+    void* recvBuffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    SendForwardRecvRole role,
     int numBlocks,
     int blockSize);
 

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -99,12 +99,11 @@ namespace detail {
  * `stagingOff` is an offset into the transport-owned send/recv staging
  * buffers. `dataOff` is the matching protocol offset into the caller's user
  * buffer. `bytes` never crosses a per-block staging partition or the
- * reserved protocol byte count. `streamEnd` is the absolute protocol byte
- * value after this chunk and is used as the DATA_READY and SLOT_FREE readiness
- * threshold. `slotId` and `pipelineGeneration` identify the local completion
- * frontier that protects this staging range. `dataOff` is a protocol offset;
- * callers mask it against the payload byte count before invoking user-buffer
- * copy callbacks.
+ * reserved protocol byte count. `streamEnd` is the absolute protocol cursor
+ * after this chunk; the send path derives its SLOT_FREE threshold from it.
+ * `completesPhysicalSlot` marks a boundary for deferred receive credit.
+ * `slotId` and `pipelineGeneration` identify the local completion frontier
+ * that protects this staging range.
  */
 struct ProgressChunk {
   std::size_t stagingOff;
@@ -112,6 +111,7 @@ struct ProgressChunk {
   std::size_t bytes;
   uint64_t streamEnd;
   uint32_t slotId;
+  bool completesPhysicalSlot;
   uint64_t pipelineGeneration;
 };
 
@@ -166,7 +166,7 @@ tail_padding_for_signal_granularity(
     std::size_t perBlockSlot,
     std::size_t payloadBytes);
 
-__device__ __forceinline__ std::size_t pipeline_window(
+__device__ __forceinline__ std::size_t physical_pipeline_window(
     const IbChannelLayout& channelLayout);
 
 __device__ __forceinline__ std::size_t pipeline_chunk(
@@ -192,11 +192,29 @@ __device__ __forceinline__ ProgressGeometry make_progress_geometry(
 __device__ __forceinline__ std::size_t active_payload_offset(
     const IbChannelProgress& state);
 
+template <typename Transport>
 __device__ __forceinline__ void reserve_progress_step(
+    const Transport& transport,
     ThreadGroup& group,
     IbChannelProgress& slot,
     IbChannelProgress& state,
     const ProgressGeometry& geometry);
+
+template <typename Transport>
+__device__ __forceinline__ std::size_t operation_tail_padding(
+    const Transport& transport,
+    uint64_t baseByte,
+    std::size_t maxSignalBytes,
+    std::size_t perBlockSlot,
+    std::size_t payloadBytes);
+
+template <typename Transport>
+__device__ __forceinline__ void release_recv_credit(
+    Transport& transport,
+    ThreadGroup& group,
+    const IbgdaRemoteBuffer& remoteSlotFree,
+    std::size_t immediateCredit,
+    bool completesPhysicalSlot);
 
 __device__ __forceinline__ void validate_send_progress_stage(
     ThreadGroup& group,
@@ -304,7 +322,7 @@ __device__ __forceinline__ void init_send_progress(
   // Validate the transfer before reserving the transport byte cursor.
   const ProgressGeometry geometry = make_progress_geometry(
       channelLayout, group, nbytes, max_signal_bytes, "init_send_progress");
-  reserve_progress_step(group, slot, state, geometry);
+  reserve_progress_step(transport, group, slot, state, geometry);
   store_progress_state(group, slot, state);
 #else
   (void)transport;
@@ -359,7 +377,7 @@ __device__ __forceinline__ void init_recv_progress(
   // Validate the transfer before reserving the transport byte cursor.
   const ProgressGeometry geometry = make_progress_geometry(
       channelLayout, group, nbytes, max_signal_bytes, "init_recv_progress");
-  reserve_progress_step(group, slot, state, geometry);
+  reserve_progress_step(transport, group, slot, state, geometry);
   store_progress_state(group, slot, state);
 #else
   (void)transport;
@@ -680,8 +698,8 @@ __device__ __forceinline__ bool poll_recv_data_ready(
  *
  * When DATA_READY reaches the chunk's `streamEnd`, the recv path copies from
  * transport-owned recv-staging into the caller's destination through
- * `CopyOp::recv`, then signals SLOT_FREE per chunk back to the
- * sender. Returning `Done` means the reserved byte range has completed.
+ * `CopyOp::recv`, then releases SLOT_FREE credit back to the sender.
+ * Returning `Done` means the reserved byte range has completed.
  *
  * `CopyOp` must expose `recv(dst, src, bytes, group, dataOffset, args...)`.
  * The default `Memcpy` copies bytes cooperatively across the supplied
@@ -783,8 +801,12 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
   }
   group.sync();
 
-  transport.signal(
-      group, remoteChannel.slotFree, protocolBytesThis, IbDirection::Recv);
+  release_recv_credit(
+      transport,
+      group,
+      remoteChannel.slotFree,
+      protocolBytesThis,
+      chunk.completesPhysicalSlot);
 
   state.activeNextByte += chunk.bytes;
   if (active_payload_offset(state) >= progress_params.protocolBytes) {
@@ -821,8 +843,9 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
  *   LOCAL_DONE — completion ticket returned by each RDMA put. Blocking send
  *                waits on the latest channel frontier before overwriting
  *                local sendStaging.
- *   SLOT_FREE  — receiver increments by bytesThis for each signaled byte
- *                range. send waits before overwriting recvStaging.
+ *   SLOT_FREE  — receiver publishes consumed staging credit. IBGDA with more
+ *                than one pipeline slot publishes at physical slot
+ *                boundaries; other modes publish each signaled range.
  *   DATA_READY — sender increments by bytesThis, piggybacked on put.
  *                recv waits on this before reading recvStaging.
  *
@@ -863,6 +886,16 @@ struct SendRecvGeometry {
       payloadProtocolBytes; // payload bytes rounded up to kData; loop bound
 };
 
+struct SendRecvChunkGeometry {
+  uint64_t streamPayload;
+  std::size_t stagingOff;
+  std::size_t dataOff;
+  std::size_t payloadBytes;
+  std::size_t slotRemaining;
+  int slot;
+  uint64_t pipelineCycle;
+};
+
 template <typename P>
 __device__ __forceinline__ SendRecvGeometry calcGeometry(
     P,
@@ -887,7 +920,7 @@ __device__ __forceinline__ SendRecvGeometry calcGeometry(
       printf(
           "[PIPES] FATAL: send/recv perBlockSlot=0 "
           "(perChannelBufferSize=%llu, pipelineDepth=%d)\n",
-          (unsigned long long)pipeline_window(channelLayout),
+          (unsigned long long)physical_pipeline_window(channelLayout),
           channelLayout.pipelineDepth);
     }
     PIPES_DEVICE_TRAP();
@@ -901,7 +934,7 @@ __device__ __forceinline__ SendRecvGeometry calcGeometry(
   if (chunkPayload == 0) {
     chunkPayload = perBlockSlotPayload;
   }
-  const std::size_t pipelineBytesWire = pipeline_window(channelLayout);
+  const std::size_t pipelineBytesWire = physical_pipeline_window(channelLayout);
   // Payload bytes rounded up to a whole packet (kData). For Simple == round-16.
   const std::size_t payloadProtocolBytes =
       (nbytes + P::kData - 1) / P::kData * P::kData;
@@ -914,6 +947,111 @@ __device__ __forceinline__ SendRecvGeometry calcGeometry(
       .pipelineBytesWire = pipelineBytesWire,
       .payloadProtocolBytes = payloadProtocolBytes,
   };
+}
+
+template <typename Proto>
+__device__ __forceinline__ SendRecvChunkGeometry calcChunkGeometry(
+    const SendRecvGeometry& geometry,
+    uint64_t baseByte,
+    std::size_t dataOff,
+    std::size_t protocolBytes) {
+  const uint64_t streamPayload = baseByte + dataOff;
+  const std::size_t pipelineOff =
+      static_cast<std::size_t>(streamPayload % geometry.pipelineBytesPayload);
+  const int slot = static_cast<int>(pipelineOff / geometry.perBlockSlotPayload);
+  const std::size_t chunkOff =
+      pipelineOff - slot * geometry.perBlockSlotPayload;
+  const std::size_t slotRemaining = geometry.perBlockSlotPayload - chunkOff;
+  const std::size_t dataRemaining = protocolBytes - dataOff;
+  std::size_t payloadBytes = geometry.chunkPayload < dataRemaining
+      ? geometry.chunkPayload
+      : dataRemaining;
+  if (slotRemaining < payloadBytes) {
+    payloadBytes = slotRemaining;
+  }
+  return SendRecvChunkGeometry{
+      .streamPayload = streamPayload,
+      .stagingOff = static_cast<std::size_t>(geometry.groupId) *
+              geometry.pipelineBytesWire +
+          static_cast<std::size_t>(slot) * geometry.perBlockSlotWire +
+          Proto::wire_bytes(chunkOff),
+      .dataOff = dataOff,
+      .payloadBytes = payloadBytes,
+      .slotRemaining = slotRemaining,
+      .slot = slot,
+      .pipelineCycle = streamPayload / geometry.pipelineBytesPayload,
+  };
+}
+
+template <typename Proto, typename Transport>
+__device__ __forceinline__ void post_forward_chunks(
+    Transport& transport,
+    ThreadGroup& group,
+    IbChannelLayout& channelLayout,
+    const SendRecvGeometry& geometry,
+    const IbgdaLocalBuffer& localSlotFree,
+    const IbRemoteChannel& remoteChannel,
+    uint64_t baseByte,
+    std::size_t protocolBytes,
+    std::size_t tailPadding,
+    std::size_t copiedBytes,
+    std::size_t& postedBytes,
+    bool waitForCredit,
+    const Timeout& timeout) {
+  while (postedBytes < copiedBytes) {
+    const SendRecvChunkGeometry chunk = calcChunkGeometry<Proto>(
+        geometry, baseByte, postedBytes, protocolBytes);
+    if (postedBytes + chunk.payloadBytes > copiedBytes) {
+      return;
+    }
+
+    const bool isFinalChunk = postedBytes + chunk.payloadBytes >= protocolBytes;
+    const std::size_t bytesThis = Proto::wire_bytes(chunk.payloadBytes);
+    const std::size_t protocolBytesThis =
+        bytesThis + (isFinalChunk ? Proto::wire_bytes(tailPadding) : 0);
+    const uint64_t protocolStreamEnd =
+        Proto::wire_bytes(chunk.streamPayload) + protocolBytesThis;
+    if (protocolStreamEnd > geometry.pipelineBytesWire) {
+      const uint64_t expected = protocolStreamEnd - geometry.pipelineBytesWire;
+      if (waitForCredit) {
+        transport.wait_signal(group, localSlotFree, expected, timeout);
+      } else {
+        uint32_t ready = 1;
+        if (group.is_leader()) {
+          ready = transport.read_signal(localSlotFree) >= expected ? 1U : 0U;
+        }
+        ready = group.broadcast<uint32_t>(ready);
+        if (!ready) {
+          return;
+        }
+      }
+    }
+
+    group.sync();
+    if (group.is_leader()) {
+      device::threadfence_system();
+      ThreadGroup solo{
+          0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+      const auto completion = transport.put(
+          solo,
+          channelLayout.sendStagingBuf.subBuffer(chunk.stagingOff),
+          remoteChannel.recvStaging.subBuffer(chunk.stagingOff),
+          bytesThis,
+          remoteChannel.dataReady,
+          protocolBytesThis,
+          /*counterBuf=*/{},
+          /*counterVal=*/0,
+          /*signalPerLane=*/true);
+      record_send_completion(
+          transport,
+          static_cast<uint32_t>(geometry.groupId),
+          chunk.slot,
+          chunk.pipelineCycle,
+          completion);
+    }
+    group.sync();
+    postedBytes += chunk.payloadBytes;
+  }
 }
 
 template <
@@ -959,8 +1097,8 @@ __device__ __forceinline__ void send(
       makeIbRemoteChannel(channelLayout, groupId);
   assert_progress_slot_idle(group, state, "send");
   const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
-  const std::size_t protocolTailPadding = tail_padding_for_signal_granularity(
-      baseByte, max_signal_bytes, perBlockSlotPayload, nbytes);
+  const std::size_t protocolTailPadding = operation_tail_padding(
+      transport, baseByte, max_signal_bytes, perBlockSlotPayload, nbytes);
   const uint64_t payloadBaseByte = baseByte;
   const std::size_t protocolBytes = payloadProtocolBytes + protocolTailPadding;
   if (group.is_leader()) {
@@ -1077,8 +1215,8 @@ __device__ __forceinline__ void send(
  * Signaling protocol (per group, symmetric with send):
  *   DATA_READY — sender increments by bytesThis after RDMA put completes.
  *                recv waits on this before copying from recvStaging.
- *   SLOT_FREE  — recv increments by bytesThis (symmetric with DATA_READY)
- *                to release backpressure on sender.
+ *   SLOT_FREE  — recv publishes consumed staging credit to release sender
+ *                backpressure.
  *
  * @param transport       Owning transport used for every transport op.
  * @param group           ThreadGroup (all threads participate in memcpy,
@@ -1135,8 +1273,8 @@ __device__ __forceinline__ void recv(
       makeIbRemoteChannel(channelLayout, groupId);
   assert_progress_slot_idle(group, state, "recv");
   const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
-  const std::size_t protocolTailPadding = tail_padding_for_signal_granularity(
-      baseByte, max_signal_bytes, perBlockSlotPayload, nbytes);
+  const std::size_t protocolTailPadding = operation_tail_padding(
+      transport, baseByte, max_signal_bytes, perBlockSlotPayload, nbytes);
   const uint64_t payloadBaseByte = baseByte;
   const std::size_t protocolBytes = payloadProtocolBytes + protocolTailPadding;
   if (group.is_leader()) {
@@ -1147,8 +1285,8 @@ __device__ __forceinline__ void recv(
   }
 
   // Payload-space iteration; wire-space staging/threshold derivations via
-  // Proto::wire_bytes() (identity for Simple). Tail padding rides the final
-  // SLOT_FREE credit only; the recv copies valid payload bytes.
+  // Proto::wire_bytes() (identity for Simple). When present, tail padding
+  // rides the final SLOT_FREE credit only; recv copies valid payload bytes.
   for (std::size_t dataOff = 0; dataOff < payloadProtocolBytes;) {
     const uint64_t streamPayload = payloadBaseByte + dataOff;
     const std::size_t pipelineOff =
@@ -1197,8 +1335,12 @@ __device__ __forceinline__ void recv(
     }
     group.sync();
 
-    transport.signal(
-        group, remoteChannel.slotFree, protocolBytesThis, IbDirection::Recv);
+    release_recv_credit(
+        transport,
+        group,
+        remoteChannel.slotFree,
+        protocolBytesThis,
+        payloadBytes == slotRemaining);
     dataOff += payloadBytes;
   }
 
@@ -1222,16 +1364,14 @@ __device__ __forceinline__ void recv(
  * and staging (this transport's recv staging). This enables fused
  * receive-reduce-forward patterns.
  *
- * Signal ordering invariant (critical for ring deadlock avoidance):
- *   1. Wait DATA_READY from sender (this transport)
- *   2. Wait for local completion on fwd transport's sendStaging
- *   3. CopyOp::forward(dst, fwd_staging, staging, ...)
- *   4. Signal SLOT_FREE to sender (this transport) — BEFORE step 5
- *   5. Wait SLOT_FREE from fwd transport's receiver
- *   6. threadfence_system + RDMA put via fwd transport
- *
- * Step 4 before step 5 breaks the circular dependency in rings: each rank
- * releases its predecessor's staging before waiting on its successor.
+ * Incoming and outgoing links may have different persistent cursor offsets,
+ * so their native DATA_READY chunks are tracked independently. Ready outgoing
+ * chunks post without blocking while an incoming credit epoch is filling. A
+ * potentially blocking post waits until the completed incoming slot has
+ * released predecessor credit. A final partial slot may also block. Ring
+ * callers avoid a ring-wide wait by limiting each step to
+ * `fwdTransport.pipeline_window()` after prior matched traffic has been
+ * consumed; this leaves one physical slot of outgoing headroom.
  *
  * Protocol compatibility with send() and recv():
  *
@@ -1241,14 +1381,14 @@ __device__ __forceinline__ void recv(
  *   Recv side (this transport):
  *     - Uses this channel's recv progress cursor.
  *     - Waits DATA_READY on this channel's local data-ready signal.
- *     - Signals SLOT_FREE on the remote channel's slot-free signal.
+ *     - Publishes SLOT_FREE on the remote channel's slot-free signal.
  *
  *   Fwd side (fwd transport):
  *     - Uses the forward channel's send progress cursor.
  *     - Waits on the forward channel's local-completion ticket.
  *     - Waits SLOT_FREE on the forward channel's local slot-free signal.
- *     - RDMA puts with DATA_READY on the forward remote channel and
- *       returns a ticket covering local completion of the data put.
+ *     - RDMA puts each native outgoing chunk with DATA_READY and returns a
+ *       ticket covering local completion of the data put.
  *
  * Any chain of send → forward* → recv is therefore valid: each
  * forward consumes exactly the signals its predecessor produces
@@ -1259,7 +1399,8 @@ __device__ __forceinline__ void recv(
  * @param dst             Application destination (may be nullptr if
  *                        CopyOp handles it, e.g. reduce-scatter).
  * @param fwdTransport    Forward transport (sends to next peer in ring).
- * @param nbytes          Bytes to receive and forward.
+ * @param nbytes          Bytes to receive and forward. Ring callers must
+ *                        bound this by `fwdTransport.pipeline_window()`.
  * @param max_signal_bytes Max bytes per signaled sub-chunk. 0 =
  * perBlockSlot.
  * @param timeout         Optional timeout for wait operations.
@@ -1302,6 +1443,7 @@ __device__ __forceinline__ void forward(
   const SendRecvGeometry fwdGeo =
       calcGeometry(Proto{}, fwdChannelLayout, group, nbytes, max_signal_bytes);
   const std::size_t payloadProtocolBytes = recvGeo.payloadProtocolBytes;
+  const bool batchesSlotFree = transport.batches_slot_free();
 
   // --- recv side (this transport) ---
   auto& recvSlotState = progress_recv_slot(transport, group);
@@ -1312,9 +1454,12 @@ __device__ __forceinline__ void forward(
       makeIbRemoteChannel(channelLayout, groupId);
   assert_progress_slot_idle(group, recvSlotState, "forward recv");
   const uint64_t recvBaseByte = static_cast<uint64_t>(recvSlotState.nextStep);
-  const std::size_t recvProtocolTailPadding =
-      tail_padding_for_signal_granularity(
-          recvBaseByte, max_signal_bytes, recvGeo.perBlockSlotPayload, nbytes);
+  const std::size_t recvProtocolTailPadding = operation_tail_padding(
+      transport,
+      recvBaseByte,
+      max_signal_bytes,
+      recvGeo.perBlockSlotPayload,
+      nbytes);
   const uint64_t recvPayloadBaseByte = recvBaseByte;
   const std::size_t recvProtocolBytes =
       payloadProtocolBytes + recvProtocolTailPadding;
@@ -1328,9 +1473,12 @@ __device__ __forceinline__ void forward(
       makeIbRemoteChannel(fwdChannelLayout, groupId);
   assert_progress_slot_idle(group, fwdSlotState, "forward send");
   const uint64_t fwdBaseByte = static_cast<uint64_t>(fwdSlotState.nextStep);
-  const std::size_t fwdProtocolTailPadding =
-      tail_padding_for_signal_granularity(
-          fwdBaseByte, max_signal_bytes, fwdGeo.perBlockSlotPayload, nbytes);
+  const std::size_t fwdProtocolTailPadding = operation_tail_padding(
+      fwdTransport,
+      fwdBaseByte,
+      max_signal_bytes,
+      fwdGeo.perBlockSlotPayload,
+      nbytes);
   const uint64_t fwdPayloadBaseByte = fwdBaseByte;
   const std::size_t fwdProtocolBytes =
       payloadProtocolBytes + fwdProtocolTailPadding;
@@ -1345,61 +1493,41 @@ __device__ __forceinline__ void forward(
     fwdSlotState.activeTailPadding = fwdProtocolTailPadding;
   }
 
-  for (std::size_t dataOff = 0; dataOff < payloadProtocolBytes;) {
-    // --- Recv side offsets (ring math in PAYLOAD, physical offset in WIRE) ---
-    const uint64_t recvStreamPayload = recvPayloadBaseByte + dataOff;
-    const std::size_t recvPipelineOff = static_cast<std::size_t>(
-        recvStreamPayload % recvGeo.pipelineBytesPayload);
-    const int recvSlot =
-        static_cast<int>(recvPipelineOff / recvGeo.perBlockSlotPayload);
-    const std::size_t recvChunkOff =
-        recvPipelineOff - recvSlot * recvGeo.perBlockSlotPayload;
-    const std::size_t recvStagingOff =
-        static_cast<std::size_t>(groupId) * recvGeo.pipelineBytesWire +
-        static_cast<std::size_t>(recvSlot) * recvGeo.perBlockSlotWire +
-        Proto::wire_bytes(recvChunkOff);
-    const std::size_t recvSlotRemaining =
-        recvGeo.perBlockSlotPayload - recvChunkOff;
+  std::size_t recvConsumed = 0;
+  std::size_t fwdCopied = 0;
+  std::size_t fwdPosted = 0;
+  SendRecvChunkGeometry fwdCopyChunk{};
 
-    // --- Fwd side offsets ---
-    const uint64_t fwdStreamPayload = fwdPayloadBaseByte + dataOff;
-    const std::size_t fwdPipelineOff = static_cast<std::size_t>(
-        fwdStreamPayload % fwdGeo.pipelineBytesPayload);
-    const int fwdSlot =
-        static_cast<int>(fwdPipelineOff / fwdGeo.perBlockSlotPayload);
-    const std::size_t fwdChunkOff =
-        fwdPipelineOff - fwdSlot * fwdGeo.perBlockSlotPayload;
-    const std::size_t fwdStagingOff =
-        static_cast<std::size_t>(groupId) * fwdGeo.pipelineBytesWire +
-        static_cast<std::size_t>(fwdSlot) * fwdGeo.perBlockSlotWire +
-        Proto::wire_bytes(fwdChunkOff);
-    const std::size_t fwdSlotRemaining =
-        fwdGeo.perBlockSlotPayload - fwdChunkOff;
+  while (recvConsumed < payloadProtocolBytes) {
+    const SendRecvChunkGeometry recvChunk = calcChunkGeometry<Proto>(
+        recvGeo, recvPayloadBaseByte, recvConsumed, payloadProtocolBytes);
+    const std::size_t recvChunkEnd = recvConsumed + recvChunk.payloadBytes;
+    const bool isFinalRecvChunk = recvChunkEnd >= payloadProtocolBytes;
 
-    // --- Chunk sizing in PAYLOAD; wire lengths via Proto::wire_bytes() ---
-    const std::size_t dataRemaining = payloadProtocolBytes - dataOff;
-    std::size_t payloadBytes = recvGeo.chunkPayload < fwdGeo.chunkPayload
-        ? recvGeo.chunkPayload
-        : fwdGeo.chunkPayload;
-    payloadBytes = payloadBytes < dataRemaining ? payloadBytes : dataRemaining;
-    payloadBytes =
-        payloadBytes < recvSlotRemaining ? payloadBytes : recvSlotRemaining;
-    payloadBytes =
-        payloadBytes < fwdSlotRemaining ? payloadBytes : fwdSlotRemaining;
-    const bool isFinalChunk = dataOff + payloadBytes >= payloadProtocolBytes;
-    const std::size_t bytesThis = Proto::wire_bytes(payloadBytes);
-    const std::size_t recvProtocolBytesThis = bytesThis +
-        (isFinalChunk ? Proto::wire_bytes(recvProtocolTailPadding) : 0);
-    const std::size_t fwdProtocolBytesThis = bytesThis +
-        (isFinalChunk ? Proto::wire_bytes(fwdProtocolTailPadding) : 0);
-    const uint64_t fwdStreamWire = Proto::wire_bytes(fwdStreamPayload);
-    const uint64_t fwdProtocolStreamEnd = fwdStreamWire + fwdProtocolBytesThis;
-    const uint64_t fwdPipelineCycle =
-        fwdStreamPayload / fwdGeo.pipelineBytesPayload;
+    std::size_t creditBoundaryRemaining =
+        batchesSlotFree ? recvChunk.slotRemaining : recvChunk.payloadBytes;
+    const std::size_t transferRemaining = payloadProtocolBytes - recvConsumed;
+    if (transferRemaining < creditBoundaryRemaining) {
+      creditBoundaryRemaining = transferRemaining;
+    }
+    const std::size_t pendingFwdBytes = fwdCopied - fwdPosted;
+    if (pendingFwdBytes > fwdGeo.pipelineBytesPayload ||
+        creditBoundaryRemaining >
+            fwdGeo.pipelineBytesPayload - pendingFwdBytes) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: forward staging capacity exceeded pending=%llu "
+            "to_boundary=%llu window=%llu\n",
+            static_cast<unsigned long long>(pendingFwdBytes),
+            static_cast<unsigned long long>(creditBoundaryRemaining),
+            static_cast<unsigned long long>(fwdGeo.pipelineBytesPayload));
+      }
+      PIPES_DEVICE_TRAP();
+    }
 
-    // (1) Wait for the upstream sender's DATA_READY on the specific round-robin
-    //     lane that carried this chunk (mirrors the upstream sender's Send
-    //     cursor via recvLocalChannel.recvDataReadyLaneCursor).
+    const std::size_t recvProtocolBytesThis =
+        Proto::wire_bytes(recvChunk.payloadBytes) +
+        (isFinalRecvChunk ? Proto::wire_bytes(recvProtocolTailPadding) : 0);
     wait_recv_data_ready(
         transport,
         group,
@@ -1408,65 +1536,81 @@ __device__ __forceinline__ void forward(
         recvProtocolBytesThis,
         timeout);
 
-    // (2) Wait for local completion on fwd's sendStaging.
-    prepare_send_slot(fwdTransport, group, fwdSlot, fwdPipelineCycle, timeout);
+    while (fwdCopied < recvChunkEnd) {
+      if (fwdCopied == fwdCopyChunk.dataOff + fwdCopyChunk.payloadBytes) {
+        fwdCopyChunk = calcChunkGeometry<Proto>(
+            fwdGeo, fwdPayloadBaseByte, fwdCopied, payloadProtocolBytes);
+        prepare_send_slot(
+            fwdTransport,
+            group,
+            fwdCopyChunk.slot,
+            fwdCopyChunk.pipelineCycle,
+            timeout);
+      }
 
-    // (3) CopyOp::forward — transform recv staging -> dst + fwd staging.
-    const std::size_t validBytes =
-        valid_payload_bytes(dataOff, payloadBytes, nbytes);
-    if (validBytes > 0) {
-      CopyOp::forward(
-          dst ? static_cast<char*>(dst) + dataOff : nullptr,
-          fwdChannelLayout.sendStagingPtr + fwdStagingOff,
-          channelLayout.recvStagingPtr + recvStagingOff,
-          validBytes,
-          group,
-          dataOff,
-          args...);
+      const std::size_t fwdCopyChunkEnd =
+          fwdCopyChunk.dataOff + fwdCopyChunk.payloadBytes;
+      const std::size_t copyEnd =
+          recvChunkEnd < fwdCopyChunkEnd ? recvChunkEnd : fwdCopyChunkEnd;
+      const std::size_t copyBytes = copyEnd - fwdCopied;
+      const std::size_t validBytes =
+          valid_payload_bytes(fwdCopied, copyBytes, nbytes);
+      if (validBytes > 0) {
+        CopyOp::forward(
+            dst ? static_cast<char*>(dst) + fwdCopied : nullptr,
+            fwdChannelLayout.sendStagingPtr + fwdCopyChunk.stagingOff +
+                Proto::wire_bytes(fwdCopied - fwdCopyChunk.dataOff),
+            channelLayout.recvStagingPtr + recvChunk.stagingOff +
+                Proto::wire_bytes(fwdCopied - recvConsumed),
+            validBytes,
+            group,
+            fwdCopied,
+            args...);
+      }
+      group.sync();
+      fwdCopied = copyEnd;
     }
-    group.sync();
 
-    transport.signal(
+    const bool completesPhysicalSlot =
+        recvChunk.payloadBytes == recvChunk.slotRemaining;
+    release_recv_credit(
+        transport,
         group,
         recvRemoteChannel.slotFree,
         recvProtocolBytesThis,
-        IbDirection::Recv);
+        completesPhysicalSlot);
+    recvConsumed = recvChunkEnd;
 
-    // (5) Wait for fwd receiver's SLOT_FREE (backpressure on fwd's
-    //     recvStaging).
-    if (fwdProtocolStreamEnd > fwdGeo.pipelineBytesWire) {
-      fwdTransport.wait_signal(
-          group,
-          fwdSlotFree,
-          fwdProtocolStreamEnd - fwdGeo.pipelineBytesWire,
-          timeout);
-    }
+    const bool mayWaitForCredit =
+        !batchesSlotFree || completesPhysicalSlot || isFinalRecvChunk;
+    post_forward_chunks<Proto>(
+        fwdTransport,
+        group,
+        fwdChannelLayout,
+        fwdGeo,
+        fwdSlotFree,
+        fwdRemoteChannel,
+        fwdPayloadBaseByte,
+        payloadProtocolBytes,
+        fwdProtocolTailPadding,
+        fwdCopied,
+        fwdPosted,
+        mayWaitForCredit,
+        timeout);
+  }
 
-    // (6) Leader-only RDMA put via the forwarding transport.
-    group.sync();
+  if (recvConsumed != payloadProtocolBytes ||
+      fwdCopied != payloadProtocolBytes || fwdPosted != payloadProtocolBytes) {
     if (group.is_leader()) {
-      __threadfence_system();
-      ThreadGroup solo{
-          0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
-      const auto completion = fwdTransport.put(
-          solo,
-          fwdChannelLayout.sendStagingBuf.subBuffer(fwdStagingOff),
-          fwdRemoteChannel.recvStaging.subBuffer(fwdStagingOff),
-          bytesThis,
-          fwdRemoteChannel.dataReady,
-          fwdProtocolBytesThis,
-          /*counterBuf=*/{},
-          /*counterVal=*/0,
-          /*signalPerLane=*/true);
-      record_send_completion(
-          fwdTransport,
-          static_cast<uint32_t>(groupId),
-          fwdSlot,
-          fwdPipelineCycle,
-          completion);
+      printf(
+          "[PIPES] FATAL: forward incomplete recv=%llu copied=%llu "
+          "posted=%llu expected=%llu\n",
+          static_cast<unsigned long long>(recvConsumed),
+          static_cast<unsigned long long>(fwdCopied),
+          static_cast<unsigned long long>(fwdPosted),
+          static_cast<unsigned long long>(payloadProtocolBytes));
     }
-    group.sync();
-    dataOff += payloadBytes;
+    PIPES_DEVICE_TRAP();
   }
 
   // Update shared byte cursors for both recv and fwd sides.
@@ -1497,9 +1641,9 @@ __device__ __forceinline__ void forward(
 }
 
 /**
- * Maximum bytes one channel can send without blocking on pipeline backpressure.
+ * Physical staging bytes owned by one channel.
  */
-__device__ __forceinline__ std::size_t pipeline_window(
+__device__ __forceinline__ std::size_t physical_pipeline_window(
     const IbChannelLayout& channelLayout) {
   return channelLayout.perChannelBufferSize != 0
       ? channelLayout.perChannelBufferSize
@@ -1511,7 +1655,7 @@ __device__ __forceinline__ std::size_t pipeline_chunk(
   if (channelLayout.pipelineDepth <= 0) {
     return 0;
   }
-  return pipeline_window(channelLayout) /
+  return physical_pipeline_window(channelLayout) /
       static_cast<std::size_t>(channelLayout.pipelineDepth);
 }
 
@@ -1567,6 +1711,37 @@ tail_padding_for_signal_granularity(
   const uint64_t payloadEnd = baseByte + align_protocol_bytes(payloadBytes);
   return static_cast<std::size_t>(
       round_up_to_multiple(payloadEnd, alignment) - payloadEnd);
+}
+
+template <typename Transport>
+__device__ __forceinline__ std::size_t operation_tail_padding(
+    const Transport& transport,
+    uint64_t baseByte,
+    std::size_t maxSignalBytes,
+    std::size_t perBlockSlot,
+    std::size_t payloadBytes) {
+  if (transport.batches_slot_free()) {
+    return 0;
+  }
+  return tail_padding_for_signal_granularity(
+      baseByte, maxSignalBytes, perBlockSlot, payloadBytes);
+}
+
+template <typename Transport>
+__device__ __forceinline__ void release_recv_credit(
+    Transport& transport,
+    ThreadGroup& group,
+    const IbgdaRemoteBuffer& remoteSlotFree,
+    std::size_t immediateCredit,
+    bool completesPhysicalSlot) {
+  if (transport.batches_slot_free()) {
+    if (completesPhysicalSlot) {
+      transport.signal(
+          group, remoteSlotFree, transport.pipeline_chunk(), IbDirection::Recv);
+    }
+    return;
+  }
+  transport.signal(group, remoteSlotFree, immediateCredit, IbDirection::Recv);
 }
 
 __device__ __forceinline__ static std::size_t valid_payload_bytes(
@@ -1739,12 +1914,13 @@ __device__ __forceinline__ ProgressGeometry make_progress_geometry(
           "[PIPES] FATAL: %s perBlockSlot=0 "
           "(perChannelBufferSize=%llu, pipelineDepth=%d)\n",
           opName,
-          (unsigned long long)pipeline_window(channelLayout),
+          (unsigned long long)physical_pipeline_window(channelLayout),
           channelLayout.pipelineDepth);
     }
     PIPES_DEVICE_TRAP();
   }
-  const std::size_t perChannelBufferSize = pipeline_window(channelLayout);
+  const std::size_t perChannelBufferSize =
+      physical_pipeline_window(channelLayout);
 
   const std::size_t protocolBytes = align_protocol_bytes(nbytes);
   std::size_t chunkSize =
@@ -1786,7 +1962,9 @@ __device__ __forceinline__ std::size_t active_payload_offset(
  * complete across many bounded calls. The active byte cursor tracks payload
  * protocol bytes; final signals/counters carry any tail padding reserved here.
  */
+template <typename Transport>
 __device__ __forceinline__ void reserve_progress_step(
+    const Transport& transport,
     ThreadGroup& group,
     IbChannelProgress& slot,
     IbChannelProgress& state,
@@ -1796,7 +1974,8 @@ __device__ __forceinline__ void reserve_progress_step(
   uint64_t protocolTailPadding = 0;
   if (group.is_leader()) {
     baseStep = static_cast<uint64_t>(slot.nextStep);
-    protocolTailPadding = tail_padding_for_signal_granularity(
+    protocolTailPadding = operation_tail_padding(
+        transport,
         baseStep,
         geometry.chunkSize,
         geometry.perBlockSlot,
@@ -1810,6 +1989,7 @@ __device__ __forceinline__ void reserve_progress_step(
   state.activeNextByte = 0;
   state.activeTailPadding = static_cast<std::size_t>(protocolTailPadding);
 #else
+  (void)transport;
   (void)group;
   (void)slot;
   (void)state;
@@ -1956,6 +2136,7 @@ __device__ __forceinline__ ProgressChunk next_chunk(
       .bytes = bytes,
       .streamEnd = streamStart + bytes,
       .slotId = static_cast<uint32_t>(slot),
+      .completesPhysicalSlot = bytes == slotRemaining,
       .pipelineGeneration = streamStart / pipelineBytes,
   };
 }
@@ -2284,13 +2465,14 @@ struct P2pIbTransportDevice {
       const Timeout& timeout = Timeout(),
       Args... args);
 
-  // Total staging bytes for one channel, forwarded to the active backend.
+  // Guaranteed byte window for a pipeline step after prior matched traffic
+  // has been consumed, forwarded to the active backend.
   __device__ __forceinline__ std::size_t pipeline_window() const;
 
   // Slots per channel, forwarded to the active backend.
   __device__ __forceinline__ int pipeline_depth() const;
 
-  // Slot/chunk bytes, forwarded to the active backend.
+  // Physical slot/chunk bytes, forwarded to the active backend.
   __device__ __forceinline__ std::size_t pipeline_chunk() const;
 
   __device__ __forceinline__ void init_send_progress(

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -1960,9 +1960,9 @@ class P2pIbgdaTransportDevice {
   //                        chunkSize = floor16(min(perBlockSlot,
   //                                             max_signal_bytes))
   //   channel progress   = persistent 16-byte-aligned protocol cursor.
-  //                        DATA_READY, SLOT_FREE, and NIC_DONE counters also
-  //                        advance by protocol bytes, which keeps cursor state
-  //                        independent of max_signal_bytes.
+  //                        DATA_READY advances per chunk; with pipeline depth
+  //                        greater than one, SLOT_FREE advances at physical
+  //                        slot boundaries.
   //
   // Typical usage:
   //   auto [role, sub] = group.partition(2);
@@ -2007,12 +2007,10 @@ class P2pIbgdaTransportDevice {
    *        |
    *        | DATA_READY reached streamEnd; copy recvStaging -> user dst
    *        v
-   *   Signal SLOT_FREE, then either WaitDataReady for next chunk or Done
+   *   Publish SLOT_FREE credit, then either WaitDataReady or Done
    *
-   * Compatibility follows from using the same cumulative byte counters:
-   * DATA_READY advances by bytesThis/chunk.bytes on each put, SLOT_FREE
-   * advances by the same amount after recv copies out of staging, and NIC_DONE
-   * advances by the same amount after the NIC completes the sender's WQE.
+   * DATA_READY advances per chunk. SLOT_FREE tracks the same consumed byte
+   * stream, but may defer publication to a physical slot boundary.
    * Blocking send()/recv() and async init share one transport-owned byte
    * cursor. Blocking calls advance it when the call completes; progress init
    * reserves that cursor range before returning so later blocking calls cannot
@@ -2166,7 +2164,7 @@ class P2pIbgdaTransportDevice {
    *
    * When DATA_READY reaches the chunk's `streamEnd`, the recv path copies from
    * transport-owned recv-staging into the caller's destination through
-   * `CopyOp::recv`, then signals SLOT_FREE back to the sender. Returning `Done`
+   * `CopyOp::recv`, then publishes SLOT_FREE credit. Returning `Done`
    * means the reserved protocol byte range has completed. For unaligned
    * payload sizes, the final WQE may include transport-private padding;
    * `CopyOp` is invoked only for valid payload bytes.
@@ -2209,8 +2207,8 @@ class P2pIbgdaTransportDevice {
    * Signaling protocol (per group):
    *   NIC_DONE   — loopback counter incremented by NIC after each RDMA put.
    *                send waits on this before overwriting local sendStaging.
-   *   SLOT_FREE  — receiver increments by bytesThis for each signaled byte
-   *                range. send waits before overwriting recvStaging.
+   *   SLOT_FREE  — receiver publishes consumed staging credit. With more than
+   *                one pipeline slot, publication occurs at slot boundaries.
    *   DATA_READY — sender increments by bytesThis, piggybacked on put.
    *                recv waits on this before reading recvStaging.
    *
@@ -2302,8 +2300,8 @@ class P2pIbgdaTransportDevice {
    * Signaling protocol (per group, symmetric with send):
    *   DATA_READY — sender increments by bytesThis after RDMA put completes.
    *                recv waits on this before copying from recvStaging.
-   *   SLOT_FREE  — recv increments by bytesThis (symmetric with DATA_READY)
-   *                to release backpressure on sender.
+   *   SLOT_FREE  — recv publishes consumed staging credit to release sender
+   *                backpressure.
    *
    * @param group           ThreadGroup (all threads participate in memcpy,
    *                        leader does signal ops).
@@ -2381,16 +2379,10 @@ class P2pIbgdaTransportDevice {
    * and staging (this transport's recv staging). This enables fused
    * receive-reduce-forward patterns.
    *
-   * Signal ordering invariant (critical for ring deadlock avoidance):
-   *   1. Wait DATA_READY from sender (this transport)
-   *   2. Wait NIC_DONE on fwd transport's sendStaging (backpressure)
-   *   3. CopyOp::forward(dst, fwd_staging, staging, ...)
-   *   4. Signal SLOT_FREE to sender (this transport) — BEFORE step 5
-   *   5. Wait SLOT_FREE from fwd transport's receiver
-   *   6. threadfence_system + RDMA put via fwd transport
-   *
-   * Step 4 before step 5 breaks the circular dependency in rings: each rank
-   * releases its predecessor's staging before waiting on its successor.
+   * Incoming and outgoing links track native DATA_READY chunks independently.
+   * Ready outgoing chunks may post while a receive-credit epoch is filling;
+   * an interior post that would wait is deferred until predecessor credit is
+   * published. A bounded final partial epoch may then block.
    *
    * Protocol compatibility with send() and recv():
    *
@@ -2400,14 +2392,14 @@ class P2pIbgdaTransportDevice {
    *   Recv side (this transport):
    *     - Uses this channel's recv progress cursor.
    *     - Waits DATA_READY on this channel's local data-ready signal.
-   *     - Signals SLOT_FREE on the remote channel's slot-free signal.
+   *     - Publishes SLOT_FREE on the remote channel's slot-free signal.
    *
    *   Fwd side (fwd transport):
    *     - Uses the forward channel's send progress cursor.
-   *     - Waits NIC_DONE on the forward channel's local completion counter.
+   *     - Waits on the forward channel's local-completion ticket.
    *     - Waits SLOT_FREE on the forward channel's local slot-free signal.
-   *     - RDMA puts with DATA_READY on the forward remote channel and
-   *       posts NIC_DONE credit per chunk to the local completion counter.
+   *     - RDMA puts each native outgoing chunk with DATA_READY and records a
+   *       ticket covering local completion.
    *
    * Any chain of send → forward* → recv is therefore valid: each
    * forward consumes exactly the signals its predecessor produces
@@ -2491,16 +2483,16 @@ class P2pIbgdaTransportDevice {
   }
 
   /**
-   * Total send/recv staging buffer bytes for one channel.
-   *
-   * The channel window is split into pipelineDepth fixed chunks. Public
-   * geometry follows:
-   *   pipeline_chunk() = pipeline_window() / pipeline_depth()
+   * Guaranteed bytes a pipeline step can send before receive progress after
+   * prior matched traffic has been consumed.
    */
   __device__ __forceinline__ std::size_t pipeline_window() const {
-    return channelLayout_.perChannelBufferSize != 0
-        ? channelLayout_.perChannelBufferSize
-        : channelLayout_.perChannelSize;
+    const std::size_t physicalWindow =
+        detail::physical_pipeline_window(channelLayout_);
+    if (!batches_slot_free()) {
+      return physicalWindow;
+    }
+    return physicalWindow - pipeline_chunk();
   }
 
   __device__ __forceinline__ std::size_t pipeline_window(
@@ -2517,8 +2509,12 @@ class P2pIbgdaTransportDevice {
     if (channelLayout_.pipelineDepth <= 0) {
       return 0;
     }
-    return pipeline_window() /
+    return detail::physical_pipeline_window(channelLayout_) /
         static_cast<std::size_t>(channelLayout_.pipelineDepth);
+  }
+
+  __device__ __forceinline__ bool batches_slot_free() const {
+    return channelLayout_.pipelineDepth > 1;
   }
 
  private:

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -580,9 +580,7 @@ class P2pIbrcTransportDevice {
   }
 
   __device__ __forceinline__ std::size_t pipeline_window() const {
-    return channelLayout_.perChannelBufferSize != 0
-        ? channelLayout_.perChannelBufferSize
-        : channelLayout_.perChannelSize;
+    return detail::physical_pipeline_window(channelLayout_);
   }
 
   __device__ __forceinline__ std::size_t pipeline_window(
@@ -599,8 +597,12 @@ class P2pIbrcTransportDevice {
     if (channelLayout_.pipelineDepth <= 0) {
       return 0;
     }
-    return pipeline_window() /
+    return detail::physical_pipeline_window(channelLayout_) /
         static_cast<std::size_t>(channelLayout_.pipelineDepth);
+  }
+
+  __device__ __forceinline__ bool batches_slot_free() const {
+    return false;
   }
 
   __device__ __forceinline__ void init_send_progress(


### PR DESCRIPTION
Summary:
IBGDA previously returned `SLOT_FREE` for every signaled range and padded each operation to its signaling boundary. For repeated sub-slot operations, that made a small payload reserve an entire physical staging slot and pay one reverse-direction atomic per call.

Keep the send/recv protocol as a continuous 16-byte-aligned byte stream. `DATA_READY` remains per transfer chunk, while IBGDA with pipeline depth greater than one now publishes `SLOT_FREE` only after the receiver has consumed a complete physical slot. Pipeline depth one and IBRC retain immediate credit publication.

Hide this credit policy behind the existing `pipeline_window()` transport API. Physical staging capacity remains internal, `pipeline_chunk()` remains one physical slot, and `pipeline_window()` returns the guaranteed scheduling window after prior matched traffic has been consumed. Batched IBGDA reserves one slot of headroom; immediate-credit transports return the full physical window. Collective kernels continue to schedule through `pipeline_window()` without encoding the credit formula.

Removing per-operation slot padding allows incoming and outgoing forwarding cursors to have different physical offsets. Update `forward()` to track receive, copied, and posted progress independently, release predecessor credit before a potentially blocking successor wait, and preserve local-completion protection for outgoing staging. Add residual-credit, wraparound, and asymmetric-cursor coverage.

On two GB300 hosts, 1 B bidirectional MCCL latency improved from 34.38 us to 27.17 us with batched `SLOT_FREE`, compared with 27.99 us for NCCL Simple. A 5,000-iteration reduced-window wrap run completed at 27.06 us with `0 OK`. The documented cross-collective GB300 sweeps also completed with `0 OK` for Send/Recv, AllGather, AllReduce, and ReduceScatter paths.

Differential Revision: D114422390


