### PR TITLE
Gate IB control-message issuing on peer readiness

### DIFF
--- a/comms/ctran/backends/ib/BootstrapExternal.cc
+++ b/comms/ctran/backends/ib/BootstrapExternal.cc
@@ -101,7 +101,18 @@ commResult_t BootstrapExternal::connectVc(
   std::vector<std::shared_ptr<CtranIbVirtualConn>> vcs;
   vcs.push_back(std::move(vc));
   std::vector<std::string> remoteIds{remoteVcIdentifier};
-  return vcState_.setupAndPublishVc(std::move(vcs), remoteIds, peerRank);
+  FB_COMMCHECK(vcState_.setupAndPublishVc(std::move(vcs), remoteIds, peerRank));
+  // STOPGAP: external bootstrap has no ack/handshake, so CtranIb cannot prove
+  // the remote peer finished setupVc (recv WQEs posted). We mark peer-ready
+  // here anyway, which assumes the external caller performed its own
+  // cross-rank barrier before issuing traffic. This preserves pre-existing
+  // external behavior (external mode never had a readiness barrier) and does
+  // not regress it; removing the call would deadlock external mode under the
+  // getVc peer-ready gate.
+  // TODO: add a proper external readiness handshake (deferred to a follow-up
+  // diff) so we no longer rely on the caller's barrier assumption.
+  vcState_.markPeerReady(peerRank);
+  return commSuccess;
 }
 
 } // namespace ctran::ib

--- a/comms/ctran/backends/ib/BootstrapInternal.cc
+++ b/comms/ctran/backends/ib/BootstrapInternal.cc
@@ -300,6 +300,12 @@ commResult_t Bootstrap::exchangeAndPublish(
     FB_SYSCHECKRETURN(sock->recv(&ack, sizeof(int)), commRemoteError);
     FB_SYSCHECKRETURN(sock->send(&ack, sizeof(int)), commRemoteError);
   }
+
+  // The ack above confirms the remote peer finished its own setupVc (recv
+  // WQEs posted, QPs in RTR/RTS). Only now is it safe for this rank to issue
+  // WQEs to the peer, so promote all its VCs to peer-ready.
+  vcState_.markPeerReady(peerRank);
+
   return commSuccess;
 }
 

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -1009,9 +1009,17 @@ commResult_t CtranIb::preConnect(const std::unordered_set<int>& peerRanks) {
   // check if all requested peers are connected
   for (int peerRank : peerRanks) {
     if (!vcState_.isPeerConnected(peerRank)) {
+      // getVc() returns non-null only once the VC is published AND the
+      // bootstrap ack confirmed the peer finished setupVc, so this also
+      // waits for peer-readiness. On abort we return commUserAbort (not
+      // success), leaving markPeerConnected() uncalled, so callers do not
+      // proceed to use an unpublished/unready peer (mirrors connectVcs()'s
+      // teardown unblock).
       while (vcState_.getVc(peerRank) == nullptr) {
-        // wait listening thread to establish connections with rest of peers
-        // with smaller rank number
+        if (abortCtrl_ && abortCtrl_->isAborted()) {
+          return commUserAbort;
+        }
+        std::this_thread::yield();
       }
       vcState_.markPeerConnected(peerRank);
       newConnection = true;

--- a/comms/ctran/backends/ib/CtranIbVc.cc
+++ b/comms/ctran/backends/ib/CtranIbVc.cc
@@ -415,7 +415,7 @@ CtranIbVirtualConn::CtranIbVirtualConn(
 
 CtranIbVirtualConn::~CtranIbVirtualConn() {
   // clean up control messages only if it gets initialized
-  if (isReady_) {
+  if (status_.load(std::memory_order_acquire) != Status::kNone) {
     recvCtrl_.packets_.clear();
     sendCtrl_.packets_.clear();
   }
@@ -657,7 +657,7 @@ commResult_t CtranIbVirtualConn::setupVc(void* remoteBusCard) {
         rtsQp(ibvDataQps_.at(i), NCCL_IB_TIMEOUT, NCCL_IB_RETRY_CNT));
   }
 
-  isReady_ = true;
+  markLocalReady();
 
   return commSuccess;
 }

--- a/comms/ctran/backends/ib/CtranIbVc.h
+++ b/comms/ctran/backends/ib/CtranIbVc.h
@@ -3,6 +3,7 @@
 #ifndef CTRAN_IB_VC_H_
 #define CTRAN_IB_VC_H_
 
+#include <atomic>
 #include <deque>
 #include <mutex>
 #include <optional>
@@ -238,6 +239,26 @@ class CtranIbVirtualConn {
   // Get the size of local business card so that socket knows the bytes sent
   // to the other rank.
   std::size_t getBusCardSize();
+
+  // Connection readiness. Transitions monotonically:
+  //   kNone -> kLocalReady : local setupVc() completed (recv WQEs posted,
+  //                          QPs moved to RTR/RTS).
+  //   kLocalReady -> kPeerReady : the bootstrap handshake confirmed the
+  //                          remote peer also finished its setupVc(), so it
+  //                          is safe to issue WQEs to it.
+  enum class Status : uint8_t { kNone = 0, kLocalReady = 1, kPeerReady = 2 };
+
+  void markLocalReady() {
+    status_.store(Status::kLocalReady, std::memory_order_release);
+  }
+
+  void markPeerReady() {
+    status_.store(Status::kPeerReady, std::memory_order_release);
+  }
+
+  bool isPeerReady() const {
+    return status_.load(std::memory_order_acquire) == Status::kPeerReady;
+  }
 
   // Create local IB connection resource (QPs) and get the local business card
   // that describes the local resource. It will be exchanged with the peer via
@@ -1907,7 +1928,7 @@ class CtranIbVirtualConn {
   const int iputFastQpIdx_{0};
   const int igetFastQpIdx_{0};
 
-  bool isReady_{false};
+  std::atomic<Status> status_{Status::kNone};
   std::vector<CtranIbDevice> devices_;
   // Set of IB device indices this VC owns QPs on (precomputed by
   // ctran::ib::VcLayout and supplied by CtranIb). For legacy

--- a/comms/ctran/backends/ib/VcState.cc
+++ b/comms/ctran/backends/ib/VcState.cc
@@ -133,12 +133,30 @@ commResult_t VcState::setupAndPublishVc(
   return commSuccess;
 }
 
+void VcState::markPeerReady(int peerRank) {
+  auto locked = vcStateMaps_.rlock();
+  auto it = locked->rankToVcs.find(peerRank);
+  if (it == locked->rankToVcs.end()) {
+    return;
+  }
+  for (auto& vc : it->second) {
+    vc->markPeerReady();
+  }
+}
+
 const std::vector<std::shared_ptr<CtranIbVirtualConn>>* VcState::tryGetVcs(
     int peerRank) {
   auto locked = vcStateMaps_.rlock();
   auto it = locked->rankToVcs.find(peerRank);
   if (it == locked->rankToVcs.end()) {
     return nullptr;
+  }
+  // Only expose the peer once every VC is peer-ready (safe to issue).
+  // markPeerReady() sets each VC individually, so check all of them.
+  for (const auto& vc : it->second) {
+    if (!vc->isPeerReady()) {
+      return nullptr;
+    }
   }
   // Value-reference stability via std::unordered_map: the pointer
   // remains valid until releaseAll() / rankToVcs.erase(peerRank).

--- a/comms/ctran/backends/ib/VcState.h
+++ b/comms/ctran/backends/ib/VcState.h
@@ -86,10 +86,14 @@ class VcState {
 
   // ---- connectVcs() helpers used by CtranIb::connectVcs() ----
   //
-  // Read-only lookup of the per-peer VC vector. Returns nullptr when the
-  // peer has not yet been published.
+  // Read-only lookup of the per-peer VC vector. Returns nullptr until every
+  // VC of the peer is peer-ready.
   const std::vector<std::shared_ptr<CtranIbVirtualConn>>* tryGetVcs(
       int peerRank);
+
+  // Promote every VC of `peerRank` to peer-ready (safe to issue WQEs). Called
+  // once the bootstrap handshake confirms the remote peer finished setupVc.
+  void markPeerReady(int peerRank);
 
   // Returns true if the peer has been pre-connected (preConnect path).
   inline bool isPeerConnected(int peerRank) const {
@@ -110,9 +114,7 @@ class VcState {
   }
 
   // Get a virtual connection for a given peer (legacy single-VC view).
-  // Reads rankToVcs[peer].front(). If the peer is not yet connected,
-  // returns nullptr. For a returned VC, it is guaranteed to be ready
-  // to use.
+  // Reads rankToVcs[peer].front(). Returns nullptr until the VC is peer-ready.
   template <typename PerfConfig = DefaultPerfCollConfig>
   inline std::shared_ptr<CtranIbVirtualConn> getVc(int peerRank) {
     if (PerfConfig::skipVcConnectionCheck ||
@@ -124,7 +126,14 @@ class VcState {
       if (it == locked->rankToVcs.end() || it->second.empty()) {
         return nullptr;
       }
-      return it->second.front();
+      auto& vc = it->second.front();
+      // Two-layer readiness: the VC is published (routable for incoming CQEs
+      // via getVcByQp) at setupVc time, but only safe to ISSUE on once the
+      // bootstrap handshake confirmed the peer finished setupVc. Gate here.
+      if (!vc->isPeerReady()) {
+        return nullptr;
+      }
+      return vc;
     }
   }
 

--- a/comms/ctran/backends/ib/docs/ctranib_external_bootstrap.md
+++ b/comms/ctran/backends/ib/docs/ctranib_external_bootstrap.md
@@ -1,0 +1,196 @@
+# CtranIb External Bootstrap — Design & Readiness Analysis
+
+## 1. Overview
+
+`CtranIb` supports two ways to establish per-peer virtual connections
+(VCs):
+
+- **Internal bootstrap** (`BootstrapMode::kDefaultServer` /
+  `kSpecifiedServer`): `CtranIb` owns a TCP listen thread and drives the
+  full rendezvous itself (bus-card swap **plus an ack round-trip**). See
+  `ctranib_multi_channel_vc_management.md` §4 and the "VC readiness"
+  section there.
+- **External bootstrap** (`BootstrapMode::kExternal`): the *caller*
+  drives the rendezvous. `CtranIb` only exposes two primitives —
+  `getLocalVcId()` and `connectVc()` — and the caller is responsible for
+  carrying the bus cards between peers and for any cross-rank ordering.
+
+This document describes the external path and analyzes why it is safe
+for its current sole consumer even though it has **no ack / readiness
+handshake** of its own.
+
+**Who uses it.** The only production consumer today is
+`comms/torchcomms/transport/RdmaTransport`, which is in turn driven by
+the tensor-shard Thrift service in `msl/rl/tensor_transfer`:
+
+```
+msl/rl/tensor_transfer  (Thrift shard service, client-pull data plane)
+        │
+        ▼
+comms/torchcomms/transport/RdmaTransport   (kExternal CtranIb)
+        │
+        ▼
+comms/ctran/backends/ib  BootstrapExternal  (getLocalVcId / connectVc)
+```
+
+## 2. Control flow — no listen thread, no ack, synchronous on the caller
+
+In `kExternal` mode `CtranIb` **never constructs the internal
+`Bootstrap`** and **never starts the listen thread**
+(`CtranIb.cc:655-687`): only `BootstrapExternal` is created, and it owns
+no thread, no listen socket, and no accept loop. (Contrast: the internal
+`Bootstrap::start()` launches `listenThread_ = std::thread{acceptLoop}`,
+the `"CTranIbListen"` thread — `BootstrapInternal.cc:107,165,312,320`.)
+
+Consequently both external primitives run **synchronously on the
+caller's own thread**:
+
+- `getLocalVcId(peerRank)` (`BootstrapExternal.cc:37-75`) creates the
+  VC's QPs (INIT state) and returns the serialized local bus card.
+- `connectVc(remoteVcId, peerRank)` (`BootstrapExternal.cc:77-116`) runs
+  `setupVc` (prepost recv WQEs → QPs RTR → RTS → publish) via
+  `setupAndPublishVc`, then marks the VC peer-ready.
+
+Because there is no listen thread, external mode has **none** of the
+internal-mode "listen thread publishes/acks while the user thread spins
+on `getVc`" split. Structurally it behaves like the internal
+*smaller-rank* path: a synchronous local setup on the calling thread.
+
+## 3. Readiness in external mode
+
+`CtranIb` uses a monotonic per-VC status `kNone → kLocalReady →
+kPeerReady` (see `CtranIbVc.h`), and the issue path (`getVc` /
+`tryGetVcs`) returns `nullptr` until a VC is `kPeerReady`.
+
+- **Internal** bootstrap sets `kPeerReady` only *after* the ack
+  round-trip, which proves the remote finished `setupVc` (recv WQEs
+  posted) — a real cross-rank happens-before.
+- **External** bootstrap has **no ack**, so `CtranIb` cannot prove the
+  remote is ready. `connectVc` marks the VC `kPeerReady` right after the
+  local `setupVc`/publish anyway (`BootstrapExternal.cc:114`). This is a
+  **STOPGAP**: it makes the VC locally issuable and assumes the external
+  caller established its own cross-rank barrier before issuing traffic.
+  Removing the call would deadlock external mode under the `getVc`
+  peer-ready gate.
+
+So in external mode, `connectVc` returning (and `getVc()!=nullptr` /
+`RdmaTransport::connected()`) proves only **local** readiness. The
+cross-rank guarantee must come from the caller.
+
+## 4. How the caller provides the cross-rank barrier
+
+The caller stack supplies the missing barrier implicitly, through the
+Thrift request/response ordering plus a **strictly one-directional,
+client-pull data plane**.
+
+Roles on a connection (`msl/rl/tensor_transfer/shard_service_thrift.cpp`):
+
+- **server** = the *only* rank that issues RDMA writes
+  (`transport->write()` → `ib_->iput`, `:541`), and only *inside* the
+  `co_fetchSliceRdma` handler.
+- **client** = the RDMA-write *target*; it sends its destination
+  pointers + rkey in the fetch request and **never issues RDMA to the
+  server**. Completion is delivered by the Thrift response, not by RDMA
+  notify.
+
+### Sequence
+
+```
+ role: SERVER = only issuer of RDMA writes (iput)
+       CLIENT = RDMA-write target (its recv WQEs must be posted first)
+
+===== PHASE 1: setup — co_connectRdmaTransport (no RDMA traffic) =====
+
+ CLIENT (write target)                          SERVER (write issuer)
+ ---------------------                          ---------------------
+ bind() = getLocalVcId
+   (QPs created, INIT)
+ clientUrl ──── co_connectRdmaTransport(clientUrl) ────►
+                                                bind() = getLocalVcId (QPs INIT)
+                                                connect(clientUrl) = connectVc:
+                                                  prepost recvs → RTR → RTS → publish
+                                                  ★ SERVER VC ready
+                       ◄──────── reply: serverUrl ────────
+ connect(serverUrl) = connectVc:
+   prepost recvs → RTR → RTS → publish
+   ★ CLIENT VC ready  (recv WQEs POSTED, QP RTR/RTS)
+ connect() == commSuccess  (checked)
+ └─ getOrCreateConnection() returns ONLY now ─┘
+
+===== PHASE 2: first transfer — co_fetchSliceRdma (only first-traffic RDMA) =====
+
+ build fetch req (dst ptrs + rkey)
+ ──────── co_fetchSliceRdma(dstPtrs, rkey) ────────►
+                                                handler: write() = ib_->iput
+                                                  ═══════ RDMA WRITE ═══════╗
+ client QP already RTR/RTS,                                                 ║
+ recv WQEs already posted   ◄══════════════════════════════════════════════╝
+ → target provably ready: no unready-target write, no RNR
+                       ◄──────── reply: done ────────
+```
+
+### Happens-before chain
+
+```
+ CLIENT connect(serverUrl) completes          (shard_service_thrift.cpp:1886, checks commSuccess)
+        │  (getOrCreateConnection does not return until this completes, :1451)
+        ▼
+ CLIENT builds + sends co_fetchSliceRdma       (:1513-1527)
+        │
+        ▼
+ SERVER issues iput to CLIENT                  (inside the fetch handler, :541)
+```
+
+Therefore, at the moment the server issues its first write, the target
+(client) has provably finished `connectVc` — recv WQEs posted, QP in
+RTR/RTS. The server likewise finished its own `connect(clientUrl)` back
+in Phase 1. **A single Thrift request/response round-trip is the
+cross-rank barrier** that `BootstrapExternal`'s STOPGAP assumes.
+
+Key call sites:
+- `RdmaTransport.cpp:206-217` (kExternal ctor), `:296-307`
+  (`bind`/`connect`/`connected`), `:346` (`iput` in `write`).
+- `shard_service_thrift.cpp:345-392` (server connect handler),
+  `:541-550` (server write), `:1828-1905` (client connect handler),
+  `:1451` / `:1513-1527` (client fetch path).
+
+## 5. Why it is always safe — and the three preconditions
+
+The barrier holds **only** because of three properties of the caller's
+protocol. If any is violated, the RPC no longer orders the write after
+the target's `connectVc`, and a proper external readiness handshake
+would be required.
+
+| # | Precondition | What breaks if violated |
+|---|---|---|
+| (a) | Data plane is **one-directional, server → client** | If the client also issues `iput`/`iget` to the server, the client's write is not ordered after any "server connected" RPC. |
+| (b) | The server issues writes **only inside the fetch handler** | If the server pushes before receiving a client fetch, the write can precede the client's `connectVc`. |
+| (c) | The client **never** issues RDMA to the server | Same as (a). |
+
+Note the base "prepost before RTR" fix (D114139030) already guarantees
+that any RC QP in RTR has recv WQEs, and a peer still in INIT cannot
+raise RNR (an inbound write just triggers ordinary transport
+retransmit). But relying on that alone would make first-transfer
+correctness depend on the target reaching RTR within the RC retry
+window; if it did not, the RC write would exhaust the retry counter and
+surface as a **fatal** completion error (→ `broken_` + reconnect), not a
+benign retry (`RdmaTransport.cpp:357-370,463-473`). The caller's barrier
+(§4) is what keeps this from arising.
+
+## 6. Conclusion & guidance
+
+- **No external readiness handshake is needed for the current caller.**
+  The tensor_transfer / RdmaTransport protocol provides the cross-rank
+  barrier the STOPGAP assumes, so no rank ever issues an RDMA WQE to a
+  peer that has not finished `connectVc`.
+- **This safety is a property of the caller's protocol, not of the
+  transport.** It is not enforced by `CtranIb`. If a future consumer
+  makes the data plane bidirectional, has the server push before a
+  client fetch, or has the client issue RDMA to the server, then
+  external bootstrap must gain a real readiness handshake (an ack
+  round-trip over the caller's channel, or promotion to `kPeerReady`
+  only after an explicit post-barrier signal) before that consumer can
+  be safe.
+- The STOPGAP and this reasoning live at `BootstrapExternal.cc:105-114`;
+  the internal-bootstrap ack contrast is at `BootstrapInternal.cc` and
+  in `ctranib_multi_channel_vc_management.md`.

--- a/comms/ctran/backends/ib/docs/ctranib_multi_channel_vc_management.md
+++ b/comms/ctran/backends/ib/docs/ctranib_multi_channel_vc_management.md
@@ -346,12 +346,13 @@ const std::vector<std::shared_ptr<CtranIbVirtualConn>>&
 **`connectVcs` is a blocking, init-once-per-peer API:**
 
 - **Blocking on first call.** The call returns only after the per-peer
-  rendezvous (TCP connect → bus-card swap loop → publish) has
+  rendezvous (TCP connect → bus-card swap loop → publish → ack) has
   completed on both sides. The smaller-rank side does the work
   synchronously inside the call; the larger-rank side spins on
   `vcState_.tryGetVcs(peer)` (with `std::this_thread::yield()` and
   an `abortCtrl_->Test()` check) until the CtranIb listen thread
-  publishes the vector. There is no async / future-returning variant.
+  publishes the vector *and marks it peer-ready* (see "VC readiness"
+  below). There is no async / future-returning variant.
 - **Single-thread-per-peer contract.** `connectVcs(peer, ...)` is NOT
   safe to call concurrently from multiple threads for the same
   `peer`. Callers (algos / RMA / `p2pHostIbTransport`) must serialize
@@ -384,7 +385,8 @@ const std::vector<std::shared_ptr<CtranIbVirtualConn>>&
 - **Single source of truth — fully backward compatible with
   `getVc`.** `vcStateMaps.rankToVcs[peer]` is the only per-peer VC
   storage. The legacy `getVc(peer)` is now a thin accessor that
-  returns `rankToVcs[peer].front()` (i.e. `vcs[0]`); it does not
+  returns `rankToVcs[peer].front()` (i.e. `vcs[0]`), and only once
+  that VC is peer-ready (see "VC readiness" below); it does not
   maintain a separate map and does not own a separate VC. The
   bootstrap path is unified too: `Bootstrap::connect` (and the
   accept-side handshake) always loops over
@@ -419,19 +421,81 @@ derived from cvars at init time):
   `Bootstrap` computes once per peer via
   `CtranIbVirtualConn::computeMaxQpsPerVc(comm, peer, numVcs)`),
   inserts the QPs into `qpToVcMap`, and publishes the vector into
-  `vcStateMaps.rankToVcs[B]`.
+  `vcStateMaps.rankToVcs[B]`. A then completes a one-int **ack
+  round-trip** with B over the same socket and calls `markPeerReady(B)`
+  to promote every VC to `kPeerReady`.
 - **Larger rank B**: the CtranIb listen thread accepts the TCP
   connection from A, matches the magic + rank, runs the matching
-  accept side of the bus-card swap loop, then publishes the resulting
-  VC vector into `vcStateMaps.rankToVcs[A]`. The application thread
+  accept side of the bus-card swap loop, publishes the resulting
+  VC vector into `vcStateMaps.rankToVcs[A]`, then runs the ack
+  round-trip and calls `markPeerReady(A)`. The application thread
   that called `connectVcs(A)` is spinning on `tryGetVcs(A)` (with a
   yield and an abort check) and returns the cached vector as soon
-  as the listen thread publishes.
+  as it is **peer-ready** — after the listen thread's ack, not merely
+  after publish.
 
 The larger-rank spin is intentionally simple — the same pattern as
 `preConnect` — and avoids per-peer waiter bookkeeping. `releaseAll()`
 clears `rankToVcs` and the spin loop's `abortCtrl_->Test()` check is
 what lets in-flight spinners exit cleanly during teardown.
+
+### VC readiness — the two-layer publish / peer-ready gate
+
+A VC carries a monotonic readiness status that separates *routable*
+from *issuable*, so a rank never issues traffic to a peer that has not
+yet finished its own `setupVc()`:
+
+`kNone → kLocalReady → kPeerReady`
+
+- **kLocalReady** — set at the end of `setupVc()` (local recv WQEs
+  posted, QPs in RTR/RTS). The VC is published into `vcStateMaps` at
+  this point, so incoming completions can already be routed.
+- **kPeerReady** — set by `VcState::markPeerReady(peer)` *after* the
+  bootstrap ack round-trip (internal bootstrap), or right after
+  `setupAndPublishVc` in the external bootstrap (no ack — the caller
+  owns the cross-rank barrier).
+
+The two lookup surfaces gate on different levels:
+
+| Lookup | Used for | Gated on |
+|---|---|---|
+| `getVcByQp((qpn, dev))` | incoming-CQE routing (`progressInternal`) | publish (kLocalReady) |
+| `getVc(peer)` / `tryGetVcs(peer)` | the **issue** path (ctrl/data ops, `connectVcs`, `preConnect`) | kPeerReady |
+
+`getVcByQp` resolves at publish so a completion for a QP that just
+reached RTR can always be dispatched. `getVc` / `tryGetVcs` return
+`nullptr` until the VC is peer-ready, so every issue path waits for the
+ack with no scattered per-call checks. The lock-free fast path in
+`getVc` (eager / `skipVcConnectionCheck`) is exempt: `preConnect`
+latches `connectedPeerMap_` only after a peer is peer-ready, so
+`isPeerConnected ⇒ kPeerReady`.
+
+**Why the gate exists.** The VC is published *before* the bootstrap
+ack. On the larger-rank side `setupVc()` and the ack both run on the
+**IB listen thread**, while the **user thread** reaches the data path
+by spinning on `getVc` / `tryGetVcs`. If those returned at publish, the
+user thread could issue a WQE after publish but before the ack — i.e.
+before the peer finished `setupVc()` and posted its recv WQEs. The
+smaller rank was already safe because its user thread drives
+`connect()` synchronously, which does not return until the ack
+completes. Gating `getVc` / `tryGetVcs` on `kPeerReady` extends that
+happens-before to the larger-rank user thread:
+
+```
+  LARGER RANK (issues the WQE)                    SMALLER RANK
+  user thread        IB listen thread             connect() thread (user)
+  -------------      ----------------------       -----------------------
+                     setupVc: RTR/RTS             setupVc: prepost + RTR/RTS
+                     publish VC (kLocalReady)
+  getVc()==null <--- published, NOT peer-ready
+   (keep spinning)   ack round-trip  <==socket==>  ack (sent after prepost)
+                     markPeerReady (kPeerReady)
+  getVc()!=null ───► issue WQE ═══════════════════► RQ has recvs, no RNR
+```
+
+Destructor cleanup keys on "past kNone" (`>= kLocalReady`), so a VC
+that completed `setupVc` but died before the ack still releases its
+control-message buffers.
 
 After `connectVcs` returns, the consumer holds `shared_ptr`s to every VC and
 calls `vc->iput(...)`, `vc->isendCtrlMsg(...)`, etc. directly **under

--- a/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
@@ -1149,6 +1149,184 @@ TEST_F(CtranIbBootstrapCommonTest, AbortDuringBusCardExchange) {
                             "bus card exchange";
 }
 
+// Verifies the two-layer readiness invariant that guards against the
+// server-side RNR race: a VC that has completed setupVc/publish
+// (markLocalReady) is routable for incoming CQEs, but is NOT yet safe to
+// issue on. getVc() must return nullptr until the bootstrap ack confirms the
+// remote peer also finished its setupVc (markPeerReady). Otherwise this rank
+// could issue a WQE before the peer preposted its recv WQEs, causing an IB
+// RNR NAK.
+//
+// The client (rank 0 -> peerRank 1) drives bootstrap connect() synchronously
+// inside isendCtrlMsg. We block the mock socket inside the ack recv, which is
+// the exact window after publish but before peer-ready, and assert getVc()
+// gates the VC there; then we release the ack and assert getVc() exposes it.
+TEST_F(CtranIbBootstrapCommonTest, GetVcGatedOnPeerReadyUntilAck) {
+  auto abortCtrl = comms::fault_tolerance::createAbort(/*enabled=*/true);
+  folly::Baton<> acceptSocketBaton;
+  // Posted when the sender enters the bootstrap ack recv (publish has run by
+  // then); released by the main thread once it has verified the gate.
+  folly::Baton<> ackEntered;
+  folly::Baton<> ackRelease;
+
+  std::string remoteBusCard = createValidRemoteBusCard();
+
+  auto mockSocket =
+      std::make_unique<StrictMock<ctran::bootstrap::testing::MockISocket>>();
+
+  EXPECT_CALL(*mockSocket, connect(_, _, _, _, _))
+      .WillRepeatedly([](const folly::SocketAddress& addr,
+                         const std::string& ifName,
+                         const std::chrono::milliseconds timeout,
+                         size_t numRetries,
+                         bool async) { return 0; });
+
+  EXPECT_CALL(*mockSocket, send(_, _))
+      .WillRepeatedly([](const void* buf, const size_t len) { return 0; });
+
+  // The client recvs the remote bus card first (large), then the ack
+  // (sizeof(int)). Block inside the ack recv so the main thread observes the
+  // window where the VC is published (markLocalReady) but not yet peer-ready.
+  EXPECT_CALL(*mockSocket, recv(_, _))
+      .WillRepeatedly([&](void* buf, const size_t len) {
+        if (len == sizeof(int)) {
+          ackEntered.post();
+          ackRelease.wait();
+          return 0;
+        }
+        std::memcpy(
+            buf, remoteBusCard.data(), std::min(len, remoteBusCard.size()));
+        return 0;
+      });
+
+  auto mockServerSocket = std::make_unique<
+      StrictMock<ctran::bootstrap::testing::MockIServerSocket>>();
+
+  EXPECT_CALL(*mockServerSocket, bindAndListen(_, _))
+      .WillOnce([](const folly::SocketAddress& addr,
+                   const std::string& ifName) { return 0; });
+
+  EXPECT_CALL(*mockServerSocket, hasShutDown()).WillOnce([]() {
+    return false;
+  });
+
+  EXPECT_CALL(*mockServerSocket, acceptSocket()).WillOnce([&]() {
+    acceptSocketBaton.wait();
+    return folly::makeUnexpected(ECONNABORTED);
+  });
+
+  EXPECT_CALL(*mockServerSocket, shutdown()).WillOnce([&]() {
+    acceptSocketBaton.post();
+    return 0;
+  });
+
+  std::vector<std::unique_ptr<ctran::bootstrap::testing::MockISocket>>
+      mockSockets;
+  mockSockets.push_back(std::move(mockSocket));
+
+  std::vector<std::unique_ptr<ctran::bootstrap::testing::MockIServerSocket>>
+      mockServerSockets;
+  mockServerSockets.push_back(std::move(mockServerSocket));
+
+  auto socketFactory =
+      std::make_shared<ctran::bootstrap::testing::MockInjectorSocketFactory>(
+          std::move(mockSockets), std::move(mockServerSockets));
+
+  SocketServerAddr serverAddr = getSocketServerAddress();
+  auto ctranIb = createCtranIb(
+      /*rank=*/0,
+      CtranIb::BootstrapMode::kSpecifiedServer,
+      abortCtrl,
+      &serverAddr,
+      socketFactory);
+
+  // isendCtrlMsg to a larger rank drives bootstrap connect() synchronously, so
+  // run it on a separate thread; it blocks inside the ack recv. There is no
+  // real remote QP, so the ctrl WQE never completes: drive progress until abort
+  // and swallow the resulting error instead of waiting for completion. The
+  // epoch lock is thread-local, so it must be acquired on this thread.
+  std::thread sender([&]() {
+    try {
+      CtranIbEpochRAII epochRAII(ctranIb.get());
+      SocketServerAddr peerServerAddr =
+          getSocketServerAddress(12348, "127.0.0.1", "lo");
+      ControlMsg msg;
+      CtranIbRequest req;
+      ctranIb->isendCtrlMsg(
+          msg.type, &msg, sizeof(msg), 1, req, &peerServerAddr);
+      while (!abortCtrl->isAborted()) {
+        ctranIb->progress();
+      }
+    } catch (const std::exception&) {
+      // Expected: issuing to a fake remote QP eventually errors during
+      // progress/teardown. The gate assertions below are what matter.
+    }
+  });
+
+  // Wait until we're blocked in the ack recv: publish/markLocalReady has run,
+  // but markPeerReady has NOT. getVc() must still gate the VC.
+  ackEntered.wait();
+  EXPECT_EQ(ctranIb->getVc(1), nullptr)
+      << "getVc must return nullptr while the VC is only published "
+         "(markLocalReady) but the bootstrap ack has not made it peer-ready";
+
+  // Let the ack complete; markPeerReady runs and getVc must expose the VC.
+  ackRelease.post();
+  EXPECT_TRUE(waitForVcEstablished(ctranIb.get(), 1, 5s));
+  EXPECT_NE(ctranIb->getVc(1), nullptr)
+      << "getVc must return the VC once the bootstrap ack confirmed peer-ready";
+
+  // Cleanup: unblock the sender's progress loop and join before teardown.
+  abortCtrl->setAbort();
+  sender.join();
+}
+
+// Verifies the larger-rank peer-ready wait unblocks on abort instead of
+// looping forever. rank 1 calls connectVcs(peerRank=0); since rank > peerRank
+// it skips the initiator and enters the spin waiting for the listen thread to
+// publish the peer's VCs. With no smaller-rank initiator, tryGetVcs() stays
+// empty, so the loop must exit via the abort check and return the empty vector.
+//
+// NOTE: this exercises the abort-during-peer-ready-wait contract on
+// connectVcs() rather than preConnect(). preConnect()'s wait loop only runs
+// once connectedPeerMap_ is sized, which requires nRanks > 0, and that in turn
+// requires a full CtranComm built via cross-rank bootstrap URL exchange --
+// not constructible in this single-process harness (the comm-less CtranIb
+// ctor used here always passes nRanks 0 to VcState::init). connectVcs()'s
+// spin shares the same abort-unblock contract and needs no connectedPeerMap_.
+TEST_F(CtranIbBootstrapCommonTest, AbortDuringConnectVcsPeerReadyWait) {
+  auto abortCtrl = comms::fault_tolerance::createAbort(/*enabled=*/true);
+  SocketServerAddr serverAddr = getSocketServerAddress();
+  auto ctranIb = createCtranIb(
+      /*rank=*/1,
+      CtranIb::BootstrapMode::kSpecifiedServer,
+      abortCtrl,
+      &serverAddr);
+
+  constexpr int kPeerRank = 0;
+
+  folly::Baton<> connectStarted;
+  bool returnedEmpty = false;
+  std::thread connectThread([&]() {
+    connectStarted.post();
+    const auto& vcs = ctranIb->connectVcs(kPeerRank);
+    returnedEmpty = vcs.empty();
+  });
+
+  // Ensure the spinner is running, then abort to unblock it.
+  connectStarted.wait();
+  std::this_thread::sleep_for(100ms);
+  auto start = std::chrono::steady_clock::now();
+  abortCtrl->setAbort();
+  connectThread.join();
+  auto elapsed = std::chrono::steady_clock::now() - start;
+
+  EXPECT_LT(elapsed, 5s) << "connectVcs() should unblock quickly after abort";
+  EXPECT_TRUE(returnedEmpty)
+      << "connectVcs() must return an empty vector on abort, not hang";
+  EXPECT_TRUE(abortCtrl->isAborted());
+}
+
 // Test aborting waitNotify operation
 TEST_F(CtranIbBootstrapCommonTest, AbortWaitNotify) {
   auto rank0Action = [this](


### PR DESCRIPTION
Summary:
The two ends of a CTran-IB virtual connection run setupVc() concurrently and independently after the out-of-band bus-card swap. On the larger-rank side, setupVc() runs on the IB listen (bootstrap) thread, not the user thread: that listen thread publishes the VC into VcState and only THEN performs the ack round-trip. The user thread reaches the data path by spinning on getVc(), which returned as soon as the VC was published -- i.e. before the listen thread's ack completes. So the user thread could issue WQEs having waited only on publish, never on the ack, to a peer that had not yet finished setupVc() (not yet posted its receive WQEs). The ack was the intended "peer is ready" barrier, but only the smaller rank was protected by it: its user thread drives connect() synchronously, which does not return until the ack completes.

BUG (larger-rank user thread issues between publish and ack):

  LARGER RANK (issues the WQE)                     SMALLER RANK
  user thread        IB listen thread              connect() thread (user)
  -------------      -----------------------       -----------------------
                     exchangeAndPublish():
                       swap bus cards  <===socket===>  swap bus cards
                       setupVc: RTR/RTS                setupVc:
                       publish VC                        prepost recv WQEs
  spin getVc() ...                                       RTR/RTS
  getVc()!=null <--- published (pre-ack!)              (still running...)
  issue WQE ==========================================>  RQ empty  X  RNR
       |             send ack   <=======socket======>  recv ack
       |             recv ack   <=======socket======>  send ack (after prepost)
       |             markPeerReady
       +-- user thread issued after PUBLISH but before the ACK; only the
           listen thread saw the ack, and the user thread never waited on it

In practice this did not corrupt data: the base "prepost before RTR" fix (D114139030) guarantees an RC QP in RTR always has recv WQEs, and a peer still in INIT cannot raise RNR (it only triggers ordinary transport retransmit). But it left correctness resting on hardware retransmit instead of a real happens-before, surfacing as spurious rnr_nak_retry_err during startup.

FIX (getVc returns non-null only at kPeerReady, so the user thread's spin waits for the ack):

  LARGER RANK (issues the WQE)                     SMALLER RANK
  user thread        IB listen thread              connect() thread (user)
  -------------      -----------------------       -----------------------
                     exchangeAndPublish():
                       swap bus cards  <===socket===>  swap bus cards
                       setupVc: RTR/RTS                setupVc:
                       publish VC  (kLocalReady)         prepost recv WQEs
  spin getVc()                                           RTR/RTS
  getVc()==null <--- published, NOT peer-ready         recv ack
   (keep spinning)   send ack  <========socket======>  (received)
                     recv ack  <========socket======>  send ack (after prepost)
                     markPeerReady (kPeerReady) <-- gate opens
  getVc()!=null <--- peer-ready now
  issue WQE =========================================>  RQ has recvs  no RNR

Fix -- upgrade per-VC readiness from a bool into a monotonic status and centralize the issue gate in the VC lookup APIs:
- Replace CtranIbVirtualConn::isReady_ with std::atomic<Status>; Status transitions kNone -> kLocalReady (local setupVc done: recv WQEs posted, QPs RTR/RTS) -> kPeerReady (bootstrap handshake confirmed the remote finished setupVc).
- Set kLocalReady at the end of setupVc; set kPeerReady via VcState::markPeerReady after the ack (internal bootstrap) and right after setupAndPublishVc (external bootstrap has no ack; the caller owns the cross-rank barrier).
- Centralize the gate: VcState::getVc (slow path) and VcState::tryGetVcs return nullptr until the VC(s) are peer-ready, so every issue path (isendCtrlMsg/irecvCtrlMsg pending, connectVcs, preConnect) waits with no scattered checks. The lock-free fast path is unchanged: preConnect latches connectedPeerMap_ only after peer-ready, so isPeerConnected implies peer-ready.
- Keep receive / CQE routing (getVcByQp) gated on publish (pre-ack): a two-layer model -- receivable at publish, issuable at peer-ready. Destructor cleanup triggers for any VC past kNone, matching the former isReady_ semantics.
- The data path (iput/iget/notify/atomic) hard-errors via checkValidVc if issued before peer-ready; this is correct ctran usage (control handshake always precedes data), so it surfaces misuse rather than masking it.

Add edge-case tests:
- CtranIbBootstrapTest.GetVcGatedOnPeerReadyUntilAck: a mock bootstrap stalls the ack recv so the VC is published but not peer-ready; asserts getVc() returns nullptr in that window and non-null once the ack completes. A deterministic regression guard for the two-layer gate.
- CtranIbConnectionTest: assert external connectVc promotes the VC to peer-ready (getVc non-null immediately after connectVc, since external has no ack).

Also update docs/ctranib_multi_channel_vc_management.md: document the ack step in the connectVcs rendezvous and add a "VC readiness" section describing the two-layer publish/peer-ready gate for VC connection and state publish.

Differential Revision: D114653450


