### PR TITLE
memtrace: aggregate in-memory stats by scope (nccl/mccl/ctran)

### DIFF
--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -17,6 +17,7 @@
 
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/memtrace/Types.h"
 
 #if defined(ENABLE_PRIMS)
 using comms::prims::NvlChannelState;
@@ -56,7 +57,10 @@ CtranAlgo::~CtranAlgo() {
   if (this->isResInitialized_) {
     FB_COMMCHECKIGNORE(
         ctran::utils::commCudaFree(
-            this->devState_d_, &this->comm_->logMetaData_));
+            this->devState_d_,
+            &this->comm_->logMetaData_,
+            meta::comms::memtrace::MemCallsite(
+                meta::comms::memtrace::MemCallsite::Scope::kCtran, __func__)));
     this->devState_d_ = nullptr;
   }
   if (ctran_->mapper && this->tmpbufSegHdl) {
@@ -72,7 +76,11 @@ CtranAlgo::~CtranAlgo() {
       // commCuMemFree
       // or cudaFree to free buffer based on cuMem support
       FB_COMMCHECKTHROW_EX(
-          ctran::utils::commCudaFree(this->tmpbuf, &this->comm_->logMetaData_),
+          ctran::utils::commCudaFree(
+              this->tmpbuf,
+              &this->comm_->logMetaData_,
+              meta::comms::memtrace::MemCallsite(
+                  meta::comms::memtrace::MemCallsite::Scope::kCtran, __func__)),
           comm_->logMetaData_);
     }
   }
@@ -87,7 +95,11 @@ CtranAlgo::~CtranAlgo() {
 #if defined(ENABLE_PRIMS)
   if (nvlTransports_) {
     FB_COMMCHECKIGNORE(
-        ctran::utils::commCudaFree(nvlTransports_, &this->comm_->logMetaData_));
+        ctran::utils::commCudaFree(
+            nvlTransports_,
+            &this->comm_->logMetaData_,
+            meta::comms::memtrace::MemCallsite(
+                meta::comms::memtrace::MemCallsite::Scope::kCtran, __func__)));
     nvlTransports_ = nullptr;
   }
 #endif // defined(ENABLE_PRIMS)
@@ -306,7 +318,9 @@ commResult_t CtranAlgo::initKernelResources() {
           &this->devState_d_,
           1,
           &this->comm_->logMetaData_,
-          "initKernelResources"));
+          meta::comms::memtrace::MemCallsite(
+              meta::comms::memtrace::MemCallsite::Scope::kCtran,
+              "initKernelResources")));
   FB_CUDACHECK(cudaMemcpy(
       this->devState_d_,
       &devState_,
@@ -320,7 +334,9 @@ commResult_t CtranAlgo::initKernelResources() {
           &nvlTransports_,
           nLocalRanks,
           &this->comm_->logMetaData_,
-          "initKernelResources-nvlTransports"));
+          meta::comms::memtrace::MemCallsite(
+              meta::comms::memtrace::MemCallsite::Scope::kCtran,
+              "initKernelResources-nvlTransports")));
 
   const size_t nvlPipelineDepth =
       static_cast<size_t>(NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH);
@@ -812,7 +828,8 @@ commResult_t CtranAlgo::initTmpBufs() {
             /*cuHandle=*/nullptr,
             segmentManager.totalLen,
             &this->comm_->logMetaData_,
-            __func__),
+            meta::comms::memtrace::MemCallsite(
+                meta::comms::memtrace::MemCallsite::Scope::kCtran, __func__)),
         comm_->logMetaData_);
   } else {
     // `ctran::utils::commCudaMalloc` automatically decides whether to use cuMem
@@ -822,7 +839,9 @@ commResult_t CtranAlgo::initTmpBufs() {
             (char**)&this->tmpbuf,
             segmentManager.totalLen,
             &this->comm_->logMetaData_,
-            "initTmpBufs"),
+            meta::comms::memtrace::MemCallsite(
+                meta::comms::memtrace::MemCallsite::Scope::kCtran,
+                "initTmpBufs")),
         comm_->logMetaData_);
   }
   FB_COMMCHECKTHROW_EX(

--- a/comms/ctran/algos/SendRecv/SendRecvP2pImpl.cc
+++ b/comms/ctran/algos/SendRecv/SendRecvP2pImpl.cc
@@ -93,7 +93,9 @@ commResult_t setupP2pKernelConfig(
                 numSendOps,
                 cudaHostAllocDefault,
                 &comm->logMetaData_,
-                "setupP2pKernelConfig"));
+                meta::comms::memtrace::MemCallsite(
+                    meta::comms::memtrace::MemCallsite::Scope::kCtran,
+                    "setupP2pKernelConfig")));
       }
       if (numRecvOps > 0) {
         FB_COMMCHECK(
@@ -102,15 +104,21 @@ commResult_t setupP2pKernelConfig(
                 numRecvOps,
                 cudaHostAllocDefault,
                 &comm->logMetaData_,
-                "setupP2pKernelConfig"));
+                meta::comms::memtrace::MemCallsite(
+                    meta::comms::memtrace::MemCallsite::Scope::kCtran,
+                    "setupP2pKernelConfig")));
       }
       config.postKernelCleanup = [sendsList = kernArgs.sendsList,
-                                  recvsList = kernArgs.recvsList]() {
+                                  recvsList = kernArgs.recvsList,
+                                  logMetaData = comm->logMetaData_]() {
+        const meta::comms::memtrace::MemCallsite callsite(
+            meta::comms::memtrace::MemCallsite::Scope::kCtran,
+            "setupP2pKernelConfig");
         if (sendsList) {
-          ctran::utils::commCudaFreeHost(sendsList);
+          ctran::utils::commCudaFreeHost(sendsList, &logMetaData, callsite);
         }
         if (recvsList) {
-          ctran::utils::commCudaFreeHost(recvsList);
+          ctran::utils::commCudaFreeHost(recvsList, &logMetaData, callsite);
         }
       };
     }

--- a/comms/ctran/algos/common/BufManager.cc
+++ b/comms/ctran/algos/common/BufManager.cc
@@ -19,7 +19,9 @@ commResult_t commitBase(
               /*cuHandle=*/nullptr,
               base.size,
               logMetaData,
-              __func__));
+              meta::comms::memtrace::MemCallsite(
+                  meta::comms::memtrace::MemCallsite::Scope::kCtran,
+                  __func__)));
       break;
     case MemType::kHostPinned:
       FB_CUDACHECK(cudaHostAlloc(&base.ptr, base.size, cudaHostAllocDefault));

--- a/comms/ctran/memory/SlabAllocator.cc
+++ b/comms/ctran/memory/SlabAllocator.cc
@@ -23,7 +23,7 @@ commResult_t SlabAllocator::cuCallocAsync(
     void** ptr,
     size_t numBytes,
     cudaStream_t stream,
-    const char* callsite,
+    const meta::comms::memtrace::MemCallsite& callsite,
     const CommLogData* logMetaData) {
   // align allocation size to 16 bytes first, so we make sure startPtr_ is 16
   // bytes aligned
@@ -40,7 +40,7 @@ commResult_t SlabAllocator::cuCallocAsync(
 commResult_t SlabAllocator::cuMalloc(
     void** ptr,
     size_t numBytes,
-    const char* callsite,
+    const meta::comms::memtrace::MemCallsite& callsite,
     const CommLogData* logMetaData,
     CUmemGenericAllocationHandle* handlep,
     size_t* newSlabSize) {
@@ -56,10 +56,15 @@ commResult_t SlabAllocator::cuMalloc(
 commResult_t SlabAllocator::allocateMem(
     void** ptr,
     size_t numBytes,
-    const char* callsite,
+    const meta::comms::memtrace::MemCallsite& callsite,
     const CommLogData* logMetaData,
     CUmemGenericAllocationHandle* handlep,
     size_t* newSlabSize) {
+  // Retain the CommLogData so the destructor can attribute its free to the same
+  // communicator this allocation used.
+  if (logMetaData != nullptr) {
+    logMetaData_ = *logMetaData;
+  }
   if (freeSize_ < numBytes) {
     // No more free space on the last slab, allocate a new one
     // align size to CUMEM_GRANULARITY
@@ -124,8 +129,15 @@ commResult_t SlabAllocator::computeCumemGranualirity() {
 }
 
 SlabAllocator::~SlabAllocator() {
+  const CommLogData* logMetaData =
+      logMetaData_.has_value() ? &logMetaData_.value() : nullptr;
   for (auto slabPtr : slabPtrs_) {
-    ctran::utils::commCuMemFree(slabPtr);
+    ctran::utils::commCuMemFree(
+        slabPtr,
+        logMetaData,
+        meta::comms::memtrace::MemCallsite(
+            meta::comms::memtrace::MemCallsite::Scope::kCtran,
+            "SlabAllocator::~SlabAllocator"));
   }
 }
 } // namespace ncclx::memory

--- a/comms/ctran/memory/SlabAllocator.h
+++ b/comms/ctran/memory/SlabAllocator.h
@@ -1,12 +1,14 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #pragma once
 
+#include <optional>
 #include <vector>
 
 #include <cuda.h>
 #include <cuda_runtime.h>
 
 #include "comms/utils/commSpecs.h"
+#include "comms/utils/memtrace/Types.h"
 
 namespace ncclx::memory {
 
@@ -19,13 +21,13 @@ class SlabAllocator {
       void** ptr,
       size_t numBytes,
       cudaStream_t stream,
-      const char* callsite,
+      const meta::comms::memtrace::MemCallsite& callsite,
       const CommLogData* logMetaData = nullptr);
 
   commResult_t cuMalloc(
       void** ptr,
       size_t numBytes,
-      const char* callsite,
+      const meta::comms::memtrace::MemCallsite& callsite,
       const CommLogData* logMetaData = nullptr,
       CUmemGenericAllocationHandle* handlep = nullptr,
       size_t* newSlabSize = nullptr);
@@ -39,13 +41,16 @@ class SlabAllocator {
   commResult_t allocateMem(
       void** ptr,
       size_t numBytes,
-      const char* callsite,
+      const meta::comms::memtrace::MemCallsite& callsite,
       const CommLogData* logMetaData,
       CUmemGenericAllocationHandle* handlep,
       size_t* newSlabSize);
   // pointer to start of each slab, used to free memory during communicator
   // destroy
   std::vector<void*> slabPtrs_;
+  // CommLogData retained from the allocation path so the destructor's free can
+  // be attributed to the same communicator (commHash) as its allocation.
+  std::optional<CommLogData> logMetaData_;
   size_t freeSize_{0};
   void* startPtr_{nullptr};
   CUmemGenericAllocationHandle slabHandle_{};

--- a/comms/ctran/memory/Utils.cc
+++ b/comms/ctran/memory/Utils.cc
@@ -18,7 +18,7 @@ commResult_t cudaCallocAsync(
     size_t nBytes,
     cudaStream_t stream,
     const CommLogData* logMetaData,
-    const char* callsite,
+    const meta::comms::memtrace::MemCallsite& callsite,
     SlabAllocator* allocator) {
   if (NCCL_MEM_USE_SLAB_ALLOCATOR && allocator) {
     return allocator->cuCallocAsync(ptr, nBytes, stream, callsite, logMetaData);
@@ -35,7 +35,7 @@ commResult_t allocateShareableBuffer(
     void** ptr,
     std::shared_ptr<memCacheAllocator> memCache,
     const CommLogData* logMetaData,
-    const char* use) {
+    const meta::comms::memtrace::MemCallsite& callsite) {
   CUmemAllocationHandleType type = ctran::utils::getCuMemAllocHandleType();
   auto commHash = (logMetaData) ? logMetaData->commHash : 0;
 
@@ -43,18 +43,18 @@ commResult_t allocateShareableBuffer(
   CUmemGenericAllocationHandle handle;
   if (memCache) {
     std::stringstream ss;
-    ss << use << ":0x" << std::hex << commHash;
+    ss << callsite.function << ":0x" << std::hex << commHash;
     FB_COMMCHECK(memCache->getCachedCuMemById(
         ss.str(), /*key*/
         ptr,
         &handle,
         size,
         logMetaData,
-        __func__));
+        meta::comms::memtrace::MemCallsite(callsite.scope, __func__)));
   } else {
     FB_COMMCHECK(
         ctran::utils::commCuMemAlloc(
-            ptr, &handle, type, size, logMetaData, use));
+            ptr, &handle, type, size, logMetaData, callsite));
   }
 
   if (type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
@@ -83,7 +83,7 @@ commResult_t allocateShareableBuffer(
       *ptr,
       size,
       (void*)ipcDesc,
-      use);
+      callsite.function);
 
   return commSuccess;
 }

--- a/comms/ctran/memory/Utils.h
+++ b/comms/ctran/memory/Utils.h
@@ -10,6 +10,7 @@
 
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/memtrace/Types.h"
 
 namespace ncclx::memory {
 
@@ -38,7 +39,7 @@ commResult_t cudaCallocAsync(
     size_t nBytes,
     cudaStream_t stream,
     const CommLogData* logMetaData,
-    const char* callsite,
+    const meta::comms::memtrace::MemCallsite& callsite,
     SlabAllocator* allocator);
 
 // Similar to ncclP2pAllocateShareableBuffer in p2p.cc, but customized for
@@ -50,7 +51,7 @@ commResult_t allocateShareableBuffer(
     void** ptr,
     std::shared_ptr<memCacheAllocator> memCache,
     const CommLogData* logMetaData,
-    const char* use);
+    const meta::comms::memtrace::MemCallsite& callsite);
 
 // wrapper function with a communicator to use slab allocator associated
 // with it, keep this function definition in header file to avoid explicit
@@ -61,7 +62,7 @@ commResult_t cudaCallocAsync(
     size_t numElems,
     cudaStream_t stream,
     const CommLogData* logMetaData,
-    const char* callsite,
+    const meta::comms::memtrace::MemCallsite& callsite,
     SlabAllocator* allocator) {
   return ncclx::memory::cudaCallocAsync(
       (void**)ptr,
@@ -80,7 +81,7 @@ commResult_t cudaCallocAsync(
     size_t numElems,
     cudaStream_t stream,
     const CommLogData* logMetaData,
-    const char* callsite) {
+    const meta::comms::memtrace::MemCallsite& callsite) {
   return ncclx::memory::cudaCallocAsync(
       (void**)ptr,
       numElems * sizeof(T),

--- a/comms/ctran/memory/memCacheAllocator.cc
+++ b/comms/ctran/memory/memCacheAllocator.cc
@@ -47,7 +47,9 @@ commResult_t memCacheAllocator::init() {
       FB_COMMCHECKTHROW_EX_NOCOMM(slabAllocator_->cuMalloc(
           (void**)&poolPtr_,
           NCCL_MEM_POOL_SIZE,
-          "memCacheAllocator::init",
+          meta::comms::memtrace::MemCallsite(
+              meta::comms::memtrace::MemCallsite::Scope::kCtran,
+              "memCacheAllocator::init"),
           nullptr,
           &poolHandle_,
           &newSlabSize));
@@ -133,7 +135,7 @@ std::shared_ptr<memRegion> memCacheAllocator::createNewMemReg(
     size_t nBytes,
     BucketType bucket,
     const CommLogData* logMetaData,
-    const char* callsite) {
+    const meta::comms::memtrace::MemCallsite& callsite) {
   auto region = std::make_shared<memRegion>();
   if (poolPtr_ != nullptr && nBytes <= poolRemainSize_) {
     // pre allocated pool has enough space for this allocation, create a new
@@ -180,7 +182,7 @@ commResult_t memCacheAllocator::getCachedCuMemById(
     CUmemGenericAllocationHandle* cuHandle,
     size_t nBytes,
     const CommLogData* logMetaData,
-    const char* callsite,
+    const meta::comms::memtrace::MemCallsite& callsite,
     BucketType bucket) {
   // We align the allocation bytes to 16 before enterring allocation/caching
   // logic

--- a/comms/ctran/memory/memCacheAllocator.h
+++ b/comms/ctran/memory/memCacheAllocator.h
@@ -17,6 +17,7 @@
 
 #include "comms/ctran/memory/SlabAllocator.h"
 #include "comms/utils/commSpecs.h"
+#include "comms/utils/memtrace/Types.h"
 
 // Allow test class to access getFreeMemReg() method
 class memCacheAllocatorTest;
@@ -91,7 +92,7 @@ class memCacheAllocator {
       CUmemGenericAllocationHandle* cuHandle,
       size_t nBytes,
       const CommLogData* logMetaData,
-      const char* callsite,
+      const meta::comms::memtrace::MemCallsite& callsite,
       BucketType bucket = BucketType::DEFAULT);
 
   /* Reserve a buffer from the pool to be used by a communicator until it is
@@ -142,7 +143,7 @@ class memCacheAllocator {
       size_t nBytes,
       BucketType bucket,
       const CommLogData* logMetaData,
-      const char* callsite);
+      const meta::comms::memtrace::MemCallsite& callsite);
 
   void freeMemReg(std::shared_ptr<memRegion> reg) {
     // FIXME: more efficient way to erase region from the free list

--- a/comms/ctran/transport/ib/HostCbTransport.cc
+++ b/comms/ctran/transport/ib/HostCbTransport.cc
@@ -46,10 +46,20 @@ HostCbTransport::HostCbTransport(
   // in NCCL memtrace; pass logMetaData_ for callsite attribution.
   FB_COMMCHECKTHROW_EX_NOCOMM(
       ctran::utils::commCudaMalloc(
-          &sendStaging_, stagingSize, logMetaData_, "HostCbTransport.send"));
+          &sendStaging_,
+          stagingSize,
+          logMetaData_,
+          meta::comms::memtrace::MemCallsite(
+              meta::comms::memtrace::MemCallsite::Scope::kCtran,
+              "HostCbTransport.send")));
   FB_COMMCHECKTHROW_EX_NOCOMM(
       ctran::utils::commCudaMalloc(
-          &recvStaging_, stagingSize, logMetaData_, "HostCbTransport.recv"));
+          &recvStaging_,
+          stagingSize,
+          logMetaData_,
+          meta::comms::memtrace::MemCallsite(
+              meta::comms::memtrace::MemCallsite::Scope::kCtran,
+              "HostCbTransport.recv")));
   FB_COMMCHECKTHROW_EX_NOCOMM(
       CtranIb::regMem(
           sendStaging_, stagingSize, cudaDev_, &sendStagingRegElem_));
@@ -86,7 +96,9 @@ HostCbTransport::HostCbTransport(
           pipelineDepth_,
           cudaHostAllocDefault,
           logMetaData_,
-          "HostCbTransport.remoteReady"));
+          meta::comms::memtrace::MemCallsite(
+              meta::comms::memtrace::MemCallsite::Scope::kCtran,
+              "HostCbTransport.remoteReady")));
   memset(remoteReady_, 0, pipelineDepth_ * sizeof(uint64_t));
   FB_COMMCHECKTHROW_EX_NOCOMM(
       CtranIb::regMem(
@@ -101,7 +113,9 @@ HostCbTransport::HostCbTransport(
           1,
           cudaHostAllocDefault,
           logMetaData_,
-          "HostCbTransport.fetchAddDiscard"));
+          meta::comms::memtrace::MemCallsite(
+              meta::comms::memtrace::MemCallsite::Scope::kCtran,
+              "HostCbTransport.fetchAddDiscard")));
   *fetchAddDiscardBuf_ = 0;
   FB_COMMCHECKTHROW_EX_NOCOMM(
       CtranIb::regMem(
@@ -118,20 +132,32 @@ HostCbTransport::HostCbTransport(
 
 HostCbTransport::~HostCbTransport() {
   if (devTransport_) {
-    (void)ctran::utils::commCudaFree(devTransport_, logMetaData_);
+    (void)ctran::utils::commCudaFree(
+        devTransport_,
+        logMetaData_,
+        meta::comms::memtrace::MemCallsite(
+            meta::comms::memtrace::MemCallsite::Scope::kCtran, __func__));
     devTransport_ = nullptr;
   }
   if (fetchAddDiscardRegElem_) {
     CtranIb::deregMem(fetchAddDiscardRegElem_);
   }
   if (fetchAddDiscardBuf_) {
-    (void)ctran::utils::commCudaFreeHost(fetchAddDiscardBuf_, logMetaData_);
+    (void)ctran::utils::commCudaFreeHost(
+        fetchAddDiscardBuf_,
+        logMetaData_,
+        meta::comms::memtrace::MemCallsite(
+            meta::comms::memtrace::MemCallsite::Scope::kCtran, __func__));
   }
   if (remoteReadyRegElem_) {
     CtranIb::deregMem(remoteReadyRegElem_);
   }
   if (remoteReady_) {
-    (void)ctran::utils::commCudaFreeHost(remoteReady_, logMetaData_);
+    (void)ctran::utils::commCudaFreeHost(
+        remoteReady_,
+        logMetaData_,
+        meta::comms::memtrace::MemCallsite(
+            meta::comms::memtrace::MemCallsite::Scope::kCtran, __func__));
   }
   for (auto* s : recvSyncs_) {
     if (s) {
@@ -152,10 +178,18 @@ HostCbTransport::~HostCbTransport() {
     CtranIb::deregMem(sendStagingRegElem_);
   }
   if (recvStaging_) {
-    (void)ctran::utils::commCudaFree(recvStaging_, logMetaData_);
+    (void)ctran::utils::commCudaFree(
+        recvStaging_,
+        logMetaData_,
+        meta::comms::memtrace::MemCallsite(
+            meta::comms::memtrace::MemCallsite::Scope::kCtran, __func__));
   }
   if (sendStaging_) {
-    (void)ctran::utils::commCudaFree(sendStaging_, logMetaData_);
+    (void)ctran::utils::commCudaFree(
+        sendStaging_,
+        logMetaData_,
+        meta::comms::memtrace::MemCallsite(
+            meta::comms::memtrace::MemCallsite::Scope::kCtran, __func__));
   }
 }
 
@@ -187,7 +221,12 @@ HostTransportDev* HostCbTransport::getDeviceTransport() {
 
   FB_COMMCHECKTHROW_EX_NOCOMM(
       ctran::utils::commCudaMalloc(
-          &devTransport_, 1, logMetaData_, "HostCbTransport.devTransport"));
+          &devTransport_,
+          1,
+          logMetaData_,
+          meta::comms::memtrace::MemCallsite(
+              meta::comms::memtrace::MemCallsite::Scope::kCtran,
+              "HostCbTransport.devTransport")));
   FB_CUDACHECKTHROW_EX_NOCOMM(cudaMemcpy(
       devTransport_,
       &hostCopy,

--- a/comms/ctran/utils/Alloc.cc
+++ b/comms/ctran/utils/Alloc.cc
@@ -13,7 +13,7 @@ commResult_t commCuMemAlloc(
     CUmemAllocationHandleType type,
     size_t size,
     const CommLogData* logMetaData,
-    const char* callsite) {
+    const meta::comms::memtrace::MemCallsite& callsite) {
   size_t granularity = 0;
   CUdevice currentDev;
   CUmemAllocationProp prop = {};
@@ -61,7 +61,10 @@ commResult_t commCuMemAlloc(
   return commSuccess;
 }
 
-commResult_t commCuMemFree(void* ptr, const CommLogData* logMetaData) {
+commResult_t commCuMemFree(
+    void* ptr,
+    const CommLogData* logMetaData,
+    const meta::comms::memtrace::MemCallsite& callsite) {
   if (ptr == nullptr) {
     return commSuccess;
   }
@@ -98,7 +101,7 @@ commResult_t commCuMemFree(void* ptr, const CommLogData* logMetaData) {
       ctran::utils::toFormattableHandle(handle));
   meta::comms::memtrace::recordFree(
       logMetaData ? *logMetaData : CommLogData{},
-      "",
+      callsite,
       "commCuMemFree",
       reinterpret_cast<uintptr_t>(ptr));
   return commSuccess;

--- a/comms/ctran/utils/Alloc.h
+++ b/comms/ctran/utils/Alloc.h
@@ -56,16 +56,19 @@ commResult_t commCuMemAlloc(
     CUmemAllocationHandleType type,
     size_t size,
     const CommLogData* logMetaData,
-    const char* callsite);
+    const meta::comms::memtrace::MemCallsite& callsite);
 
-commResult_t commCuMemFree(void* ptr, const CommLogData* logMetaData = nullptr);
+commResult_t commCuMemFree(
+    void* ptr,
+    const CommLogData* logMetaData = nullptr,
+    const meta::comms::memtrace::MemCallsite& callsite = "");
 
 template <typename T>
 commResult_t commCudaMallocDebug(
     T** ptr,
     size_t nelem,
     const CommLogData* logMetaData,
-    const char* callsite,
+    const meta::comms::memtrace::MemCallsite& callsite,
     const char* filefunc,
     int line) {
   commResult_t result = commSuccess;
@@ -116,14 +119,18 @@ finish:
 #define commCudaMalloc(...) commCudaMallocDebug(__VA_ARGS__, __FILE__, __LINE__)
 
 template <typename T>
-commResult_t commCudaFree(T* ptr, const CommLogData* logMetaData = nullptr) {
+commResult_t commCudaFree(
+    T* ptr,
+    const CommLogData* logMetaData = nullptr,
+    const meta::comms::memtrace::MemCallsite& callsite = "") {
   commResult_t result = commSuccess;
   cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
   CLOGF_TRACE(ALLOC, "Cuda Free pointer {}", (void*)ptr);
 
   FB_CUDACHECKGOTO(cudaThreadExchangeStreamCaptureMode(&mode), result, finish);
   if (getCuMemSysSupported()) {
-    FB_COMMCHECKGOTO(commCuMemFree((void*)ptr, logMetaData), result, finish);
+    FB_COMMCHECKGOTO(
+        commCuMemFree((void*)ptr, logMetaData, callsite), result, finish);
   } else {
     FB_CUDACHECKGOTO(cudaFree(ptr), result, finish);
   }
@@ -131,7 +138,7 @@ finish:
   if (!getCuMemSysSupported()) {
     meta::comms::memtrace::recordFree(
         logMetaData ? *logMetaData : CommLogData{},
-        "",
+        callsite,
         "commCudaFree",
         reinterpret_cast<uintptr_t>(ptr));
   }
@@ -145,7 +152,7 @@ commResult_t commCudaHostAllocDebug(
     size_t nelem,
     unsigned int flags,
     const CommLogData* logMetaData,
-    const char* callsite,
+    const meta::comms::memtrace::MemCallsite& callsite,
     const char* filefunc,
     int line) {
   commResult_t result = commSuccess;
@@ -184,7 +191,8 @@ finish:
 template <typename T>
 commResult_t commCudaFreeHost(
     T* ptr,
-    const CommLogData* logMetaData = nullptr) {
+    const CommLogData* logMetaData = nullptr,
+    const meta::comms::memtrace::MemCallsite& callsite = "") {
   commResult_t result = commSuccess;
   cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
   CLOGF_TRACE(ALLOC, "CudaFreeHost pointer {}", (void*)ptr);
@@ -196,7 +204,7 @@ commResult_t commCudaFreeHost(
 finish:
   meta::comms::memtrace::recordFree(
       logMetaData ? *logMetaData : CommLogData{},
-      "",
+      callsite,
       "commCudaFreeHost",
       reinterpret_cast<uintptr_t>(ptr));
   CLOGF_SUBSYS(INFO, ALLOC, "CudaFreeHost pointer {}", (void*)ptr);
@@ -210,7 +218,7 @@ commResult_t commCudaCallocAsync(
     size_t nelem,
     cudaStream_t stream,
     const CommLogData* logMetaData,
-    const char* callsite) {
+    const meta::comms::memtrace::MemCallsite& callsite) {
   static_assert(
       !std::is_same<T, void>::value,
       "void pointers must be casted to valid types when calloc-ing for 'nelem' objects");

--- a/comms/ctran/utils/CtranIpc.cc
+++ b/comms/ctran/utils/CtranIpc.cc
@@ -244,7 +244,9 @@ commResult_t ctran::utils::CtranIpcMem::alloc(const size_t size) {
             cuMemHandleType_,
             size,
             logMetaData_,
-            desc_));
+            meta::comms::memtrace::MemCallsite(
+                meta::comms::memtrace::MemCallsite::Scope::kCtran,
+                desc_ != nullptr ? desc_ : "")));
     FB_CUCHECK(cuMemGetAddressRange(&pbase_, &range_, (CUdeviceptr)p));
     segmentRanges_.emplace_back(range_);
   } else if (memType_ == DevMemType::kCudaMalloc) {
@@ -478,7 +480,11 @@ inline commResult_t CtranIpcMem::freeCuMem() {
   if (mode_ == CtranIpcMem::Mode::ALLOC) {
     FB_COMMCHECK(
         ctran::utils::commCuMemFree(
-            reinterpret_cast<void*>(pbase_), logMetaData_));
+            reinterpret_cast<void*>(pbase_),
+            logMetaData_,
+            meta::comms::memtrace::MemCallsite(
+                meta::comms::memtrace::MemCallsite::Scope::kCtran,
+                desc_ != nullptr ? desc_ : "")));
   }
 
   return commSuccess;

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -637,7 +637,9 @@ commResult_t CtranWin::allocate(void* userBufPtr) {
               utils::getCuMemAllocHandleType(),
               allocSize,
               &comm->logMetaData_,
-              "allocate"));
+              meta::comms::memtrace::MemCallsite(
+                  meta::comms::memtrace::MemCallsite::Scope::kCtran,
+                  "allocate")));
 
       // query the actually allocated range of the memory
       CUdeviceptr pbase = 0;
@@ -760,7 +762,12 @@ commResult_t CtranWin::free(bool skipBarrier) {
   // utils func to free memory
   auto freeMem = [&](void* addr) {
     if (isGpuMem()) {
-      FB_COMMCHECK(utils::commCuMemFree(addr));
+      FB_COMMCHECK(
+          utils::commCuMemFree(
+              addr,
+              &comm->logMetaData_,
+              meta::comms::memtrace::MemCallsite(
+                  meta::comms::memtrace::MemCallsite::Scope::kCtran, "free")));
     } else {
       FB_CUDACHECK(cudaFreeHost(addr));
     }

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -1112,6 +1112,7 @@ set(COMMON_FILES
   comms/utils/MemUtils.h
   comms/utils/memtrace/MemoryTrace.cc
   comms/utils/memtrace/MemoryTrace.h
+  comms/utils/memtrace/Types.h
   comms/utils/PrecisionClock.cc
   comms/utils/PrecisionClock.h
   comms/utils/RankUtils.cc

--- a/comms/utils/logger/EventMgr.cc
+++ b/comms/utils/logger/EventMgr.cc
@@ -59,6 +59,19 @@ bool MemoryEvent::shouldLog() {
   }
 }
 
+static const char* scopeToString(
+    meta::comms::memtrace::MemCallsite::Scope scope) {
+  switch (scope) {
+    case meta::comms::memtrace::MemCallsite::Scope::kNccl:
+      return "nccl";
+    case meta::comms::memtrace::MemCallsite::Scope::kCtran:
+      return "ctran";
+    case meta::comms::memtrace::MemCallsite::Scope::kMccl:
+      return "mccl";
+  }
+  return "nccl";
+}
+
 NcclScubaSample MemoryEvent::toSample() {
   NcclScubaSample sample("MemoryEvent");
   sample.addInt("commHash", commHash);
@@ -78,8 +91,9 @@ NcclScubaSample MemoryEvent::toSample() {
   if (memType.has_value()) {
     sample.addNormal("memType", memType.value());
   }
-  sample.addNormal("callsite", callsite);
+  sample.addNormal("callsite_func", callsite);
   sample.addNormal("use", use);
+  sample.addNormal("callsite_scope", scopeToString(scope));
   sample.addInt("iteration", iteration);
   return sample;
 }

--- a/comms/utils/logger/EventMgr.h
+++ b/comms/utils/logger/EventMgr.h
@@ -11,6 +11,7 @@
 
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/logger/NcclScubaSample.h"
+#include "comms/utils/memtrace/Types.h"
 #include "comms/utils/trainer/TrainerContext.h"
 
 #define LOGGER_PG_ID_DEFAULT 0x80000000UL
@@ -134,7 +135,9 @@ class MemoryEvent : public LoggerEvent {
       std::optional<int> numSegments = std::nullopt,
       std::optional<int64_t> durationUs = std::nullopt,
       std::optional<std::string> memType = std::nullopt,
-      bool isRegMemEvent = false)
+      bool isRegMemEvent = false,
+      meta::comms::memtrace::MemCallsite::Scope scope =
+          meta::comms::memtrace::MemCallsite::Scope::kNccl)
       : commHash(logMetaData.commHash),
         commDesc(logMetaData.commDesc),
         rank(logMetaData.rank),
@@ -146,7 +149,8 @@ class MemoryEvent : public LoggerEvent {
         numSegments(numSegments),
         durationUs(durationUs),
         memType(std::move(memType)),
-        isRegMemEvent(isRegMemEvent) {
+        isRegMemEvent(isRegMemEvent),
+        scope(scope) {
     iteration = ncclxGetIteration();
   }
 
@@ -184,6 +188,8 @@ class MemoryEvent : public LoggerEvent {
   std::optional<int64_t> durationUs;
   std::optional<std::string> memType;
   bool isRegMemEvent = false;
+  meta::comms::memtrace::MemCallsite::Scope scope =
+      meta::comms::memtrace::MemCallsite::Scope::kNccl;
 };
 
 class CtranProfilerEvent : public CommEvent {

--- a/comms/utils/logger/alloc.cc
+++ b/comms/utils/logger/alloc.cc
@@ -18,7 +18,8 @@ void logMemoryEvent(
     std::optional<int> numSegments,
     std::optional<int64_t> durationUs,
     const std::optional<std::string>& memType,
-    bool isRegMemEvent) {
+    bool isRegMemEvent,
+    meta::comms::memtrace::MemCallsite::Scope scope) {
   auto memoryEvent = std::make_unique<MemoryEvent>(
       logMetaData,
       callsite,
@@ -28,7 +29,8 @@ void logMemoryEvent(
       numSegments,
       durationUs,
       memType,
-      isRegMemEvent);
+      isRegMemEvent,
+      scope);
   if (memoryEvent->shouldLog()) {
     NcclScubaEvent event(std::move(memoryEvent));
     event.record();

--- a/comms/utils/logger/alloc.h
+++ b/comms/utils/logger/alloc.h
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "comms/utils/commSpecs.h"
+#include "comms/utils/memtrace/Types.h"
 
 struct CommLogData;
 
@@ -18,4 +19,6 @@ void logMemoryEvent(
     std::optional<int> numSegments = std::nullopt,
     std::optional<int64_t> durationUs = std::nullopt,
     const std::optional<std::string>& memType = std::nullopt,
-    bool isRegMemEvent = false);
+    bool isRegMemEvent = false,
+    meta::comms::memtrace::MemCallsite::Scope scope =
+        meta::comms::memtrace::MemCallsite::Scope::kNccl);

--- a/comms/utils/logger/tests/EventMgrTest.cc
+++ b/comms/utils/logger/tests/EventMgrTest.cc
@@ -38,6 +38,21 @@ MemoryEvent makeMemoryEvent(std::optional<std::string> memType) {
       std::move(memType));
 }
 
+MemoryEvent makeMemoryEventWithScope(
+    meta::comms::memtrace::MemCallsite::Scope source) {
+  return MemoryEvent(
+      makeCommLogData(),
+      /*callsite=*/"testCallsite",
+      /*use=*/"testUse",
+      kMemoryAddr,
+      /*bytes=*/kBytes,
+      /*numSegments=*/std::nullopt,
+      /*durationUs=*/std::nullopt,
+      /*memType=*/std::nullopt,
+      /*isRegMemEvent=*/false,
+      source);
+}
+
 } // namespace
 
 // When a memType is supplied, toSample() emits a "memType" normal column
@@ -59,4 +74,56 @@ TEST(MemoryEventTest, ToSampleOmitsMemTypeWhenNullopt) {
   const auto json = folly::parseJson(sample.toJson());
 
   EXPECT_EQ(json["normal"].count("memType"), 0);
+}
+
+// A ctran allocation emits scope="ctran" so the nccl_memory_logging table can
+// group ctran memory separately from baseline NCCL.
+TEST(MemoryEventTest, ToSampleEmitsCtranScope) {
+  auto event = makeMemoryEventWithScope(
+      meta::comms::memtrace::MemCallsite::Scope::kCtran);
+
+  auto sample = event.toSample();
+  const auto json = folly::parseJson(sample.toJson());
+
+  EXPECT_EQ(json["normal"]["callsite_scope"].asString(), "ctran");
+}
+
+// The default scope (baseline NCCL) emits scope="nccl".
+TEST(MemoryEventTest, ToSampleEmitsNcclScopeByDefault) {
+  auto event = makeMemoryEventWithScope(
+      meta::comms::memtrace::MemCallsite::Scope::kNccl);
+
+  auto sample = event.toSample();
+  const auto json = folly::parseJson(sample.toJson());
+
+  EXPECT_EQ(json["normal"]["callsite_scope"].asString(), "nccl");
+}
+
+// An mccl allocation emits scope="mccl" so the nccl_memory_logging table can
+// group mccl memory separately from baseline NCCL and ctran.
+TEST(MemoryEventTest, ToSampleEmitsMcclScope) {
+  auto event = makeMemoryEventWithScope(
+      meta::comms::memtrace::MemCallsite::Scope::kMccl);
+
+  auto sample = event.toSample();
+  const auto json = folly::parseJson(sample.toJson());
+
+  EXPECT_EQ(json["normal"]["callsite_scope"].asString(), "mccl");
+}
+
+// The scope carried by a ctran MemCallsite surfaces as scope="ctran", while a
+// bare-string (baseline) callsite surfaces as scope="nccl". Ties the
+// MemCallsite scope to the scuba column memtrace populates.
+TEST(MemoryEventTest, MemCallsiteScopeSurfacesInColumn) {
+  const meta::comms::memtrace::MemCallsite ctranCallsite(
+      meta::comms::memtrace::MemCallsite::Scope::kCtran, "initTmpBufs");
+  auto ctranEvent = makeMemoryEventWithScope(ctranCallsite.scope);
+  const auto ctranJson = folly::parseJson(ctranEvent.toSample().toJson());
+  EXPECT_EQ(ctranJson["normal"]["callsite_scope"].asString(), "ctran");
+
+  const meta::comms::memtrace::MemCallsite baselineCallsite(
+      "initChannelDevRingUserRanks");
+  auto ncclEvent = makeMemoryEventWithScope(baselineCallsite.scope);
+  const auto ncclJson = folly::parseJson(ncclEvent.toSample().toJson());
+  EXPECT_EQ(ncclJson["normal"]["callsite_scope"].asString(), "nccl");
 }

--- a/comms/utils/memtrace/MemoryTrace.cc
+++ b/comms/utils/memtrace/MemoryTrace.cc
@@ -33,15 +33,25 @@ std::shared_ptr<MemoryTrace> MemoryTrace::getOrCreate(uint64_t commHash) {
   return trace;
 }
 
-void MemoryTrace::recordAlloc(uintptr_t addr, int64_t bytes) {
+void MemoryTrace::recordAlloc(
+    uintptr_t addr,
+    int64_t bytes,
+    MemCallsite::Scope scope) {
   std::lock_guard<std::mutex> lock(mutex_);
   allocMap_[addr] = bytes;
   stats_.totalAllocated += bytes;
   stats_.currentUsage += bytes;
   stats_.peakUsage = std::max(stats_.peakUsage, stats_.currentUsage);
+  MemoryStats& byScope = statsByScope_[static_cast<int>(scope)];
+  byScope.totalAllocated += bytes;
+  byScope.currentUsage += bytes;
+  byScope.peakUsage = std::max(byScope.peakUsage, byScope.currentUsage);
 }
 
-void MemoryTrace::recordFree(uintptr_t addr, std::optional<int64_t> bytes) {
+void MemoryTrace::recordFree(
+    uintptr_t addr,
+    std::optional<int64_t> bytes,
+    MemCallsite::Scope scope) {
   std::lock_guard<std::mutex> lock(mutex_);
   int64_t freedBytes = 0;
   auto it = allocMap_.find(addr);
@@ -53,6 +63,9 @@ void MemoryTrace::recordFree(uintptr_t addr, std::optional<int64_t> bytes) {
   }
   stats_.totalFreed += freedBytes;
   stats_.currentUsage -= freedBytes;
+  MemoryStats& byScope = statsByScope_[static_cast<int>(scope)];
+  byScope.totalFreed += freedBytes;
+  byScope.currentUsage -= freedBytes;
 }
 
 MemoryStats MemoryTrace::getStats() const {
@@ -60,11 +73,34 @@ MemoryStats MemoryTrace::getStats() const {
   return stats_;
 }
 
+MemoryStats MemoryTrace::getStats(MemCallsite::Scope scope) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return statsByScope_[static_cast<int>(scope)];
+}
+
+namespace {
+folly::dynamic memoryStatsToDynamic(const MemoryStats& stats) {
+  return folly::dynamic::object("totalAllocated", stats.totalAllocated)(
+      "totalFreed", stats.totalFreed)("currentUsage", stats.currentUsage)(
+      "peakUsage", stats.peakUsage);
+}
+} // namespace
+
 std::string MemoryTrace::dump() const {
   std::lock_guard<std::mutex> lock(mutex_);
   folly::dynamic obj = folly::dynamic::object(
       "totalAllocated", stats_.totalAllocated)("totalFreed", stats_.totalFreed)(
       "currentUsage", stats_.currentUsage)("peakUsage", stats_.peakUsage);
+  obj["byScope"] = folly::dynamic::object(
+      "nccl",
+      memoryStatsToDynamic(
+          statsByScope_[static_cast<int>(MemCallsite::Scope::kNccl)]))(
+      "ctran",
+      memoryStatsToDynamic(
+          statsByScope_[static_cast<int>(MemCallsite::Scope::kCtran)]))(
+      "mccl",
+      memoryStatsToDynamic(
+          statsByScope_[static_cast<int>(MemCallsite::Scope::kMccl)]));
   return folly::toJson(obj);
 }
 
@@ -92,7 +128,8 @@ void recordAlloc(
       /*memType=*/std::nullopt,
       /*isRegMemEvent=*/false,
       callsite.scope);
-  MemoryTrace::getOrCreate(logMetaData.commHash)->recordAlloc(addr, bytes);
+  MemoryTrace::getOrCreate(logMetaData.commHash)
+      ->recordAlloc(addr, bytes, callsite.scope);
 }
 
 void recordFree(
@@ -117,7 +154,8 @@ void recordFree(
       /*memType=*/std::nullopt,
       /*isRegMemEvent=*/false,
       callsite.scope);
-  MemoryTrace::getOrCreate(logMetaData.commHash)->recordFree(addr, bytes);
+  MemoryTrace::getOrCreate(logMetaData.commHash)
+      ->recordFree(addr, bytes, callsite.scope);
 }
 
 void recordReg(

--- a/comms/utils/memtrace/MemoryTrace.cc
+++ b/comms/utils/memtrace/MemoryTrace.cc
@@ -44,15 +44,13 @@ void MemoryTrace::recordAlloc(uintptr_t addr, int64_t bytes) {
 void MemoryTrace::recordFree(uintptr_t addr, std::optional<int64_t> bytes) {
   std::lock_guard<std::mutex> lock(mutex_);
   int64_t freedBytes = 0;
-  if (bytes.has_value()) {
-    freedBytes = bytes.value();
+  auto it = allocMap_.find(addr);
+  if (it != allocMap_.end()) {
+    freedBytes = bytes.value_or(it->second);
+    allocMap_.erase(it);
   } else {
-    auto it = allocMap_.find(addr);
-    if (it != allocMap_.end()) {
-      freedBytes = it->second;
-    }
+    freedBytes = bytes.value_or(0);
   }
-  allocMap_.erase(addr);
   stats_.totalFreed += freedBytes;
   stats_.currentUsage -= freedBytes;
 }
@@ -74,7 +72,7 @@ std::string MemoryTrace::dump() const {
 
 void recordAlloc(
     const CommLogData& logMetaData,
-    const std::string& callsite,
+    const MemCallsite& callsite,
     const std::string& use,
     uintptr_t addr,
     int64_t bytes,
@@ -84,26 +82,47 @@ void recordAlloc(
     return;
   }
   logMemoryEvent(
-      logMetaData, callsite, use, addr, bytes, numSegments, durationUs);
+      logMetaData,
+      callsite.function,
+      use,
+      addr,
+      bytes,
+      numSegments,
+      durationUs,
+      /*memType=*/std::nullopt,
+      /*isRegMemEvent=*/false,
+      callsite.scope);
   MemoryTrace::getOrCreate(logMetaData.commHash)->recordAlloc(addr, bytes);
 }
 
 void recordFree(
     const CommLogData& logMetaData,
-    const std::string& callsite,
+    const MemCallsite& callsite,
     const std::string& use,
     uintptr_t addr,
     std::optional<int64_t> bytes) {
   if (!NCCL_MEMTRACE_ENABLE) {
     return;
   }
-  logMemoryEvent(logMetaData, callsite, use, addr, bytes);
+  // The free callsite supplies its own scope directly (symmetric with alloc),
+  // so the scuba FREE row is tagged from callsite.scope.
+  logMemoryEvent(
+      logMetaData,
+      callsite.function,
+      use,
+      addr,
+      bytes,
+      /*numSegments=*/std::nullopt,
+      /*durationUs=*/std::nullopt,
+      /*memType=*/std::nullopt,
+      /*isRegMemEvent=*/false,
+      callsite.scope);
   MemoryTrace::getOrCreate(logMetaData.commHash)->recordFree(addr, bytes);
 }
 
 void recordReg(
     const CommLogData& logMetaData,
-    const std::string& callsite,
+    const MemCallsite& callsite,
     const std::string& use,
     uintptr_t addr,
     std::optional<int64_t> bytes,
@@ -115,14 +134,15 @@ void recordReg(
   }
   logMemoryEvent(
       logMetaData,
-      callsite,
+      callsite.function,
       use,
       addr,
       bytes,
       numSegments,
       durationUs,
       memType,
-      /*isRegMemEvent=*/true);
+      /*isRegMemEvent=*/true,
+      callsite.scope);
 }
 
 } // namespace meta::comms::memtrace

--- a/comms/utils/memtrace/MemoryTrace.h
+++ b/comms/utils/memtrace/MemoryTrace.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -70,15 +71,31 @@ class MemoryTrace {
  public:
   static std::shared_ptr<MemoryTrace> getOrCreate(uint64_t commHash);
 
-  void recordAlloc(uintptr_t addr, int64_t bytes);
-  void recordFree(uintptr_t addr, std::optional<int64_t> bytes);
+  void recordAlloc(uintptr_t addr, int64_t bytes, MemCallsite::Scope scope);
+  void recordFree(
+      uintptr_t addr,
+      std::optional<int64_t> bytes,
+      MemCallsite::Scope scope);
   MemoryStats getStats() const;
+  // Per-scope aggregate stats (nccl/ctran/mccl); queryable in-memory, and
+  // surfaced in dump().
+  MemoryStats getStats(MemCallsite::Scope scope) const;
   std::string dump() const;
 
  private:
+  static constexpr int kNumScopes = 3;
+  static_assert(
+      static_cast<int>(MemCallsite::Scope::kNccl) == 0 &&
+          static_cast<int>(MemCallsite::Scope::kCtran) == 1 &&
+          static_cast<int>(MemCallsite::Scope::kMccl) == kNumScopes - 1,
+      "statsByScope_ indexing assumes Scope is exactly {kNccl=0, kCtran=1, "
+      "kMccl=2}; bump kNumScopes and revisit the buckets if Scope gains values");
+
   mutable std::mutex mutex_;
   MemoryStats stats_;
   std::unordered_map<uintptr_t, int64_t> allocMap_;
+  // Per-scope breakdown of stats_, indexed by static_cast<int>(Scope).
+  std::array<MemoryStats, kNumScopes> statsByScope_{};
 };
 
 } // namespace meta::comms::memtrace

--- a/comms/utils/memtrace/MemoryTrace.h
+++ b/comms/utils/memtrace/MemoryTrace.h
@@ -17,6 +17,7 @@
 #include <unordered_map>
 
 #include "comms/utils/commSpecs.h"
+#include "comms/utils/memtrace/Types.h"
 
 namespace meta::comms::memtrace {
 
@@ -24,7 +25,7 @@ namespace meta::comms::memtrace {
 
 void recordAlloc(
     const CommLogData& logMetaData,
-    const std::string& callsite,
+    const MemCallsite& callsite,
     const std::string& use,
     uintptr_t addr,
     int64_t bytes,
@@ -33,14 +34,14 @@ void recordAlloc(
 
 void recordFree(
     const CommLogData& logMetaData,
-    const std::string& callsite,
+    const MemCallsite& callsite,
     const std::string& use,
     uintptr_t addr,
     std::optional<int64_t> bytes = std::nullopt);
 
 void recordReg(
     const CommLogData& logMetaData,
-    const std::string& callsite,
+    const MemCallsite& callsite,
     const std::string& use,
     uintptr_t addr,
     std::optional<int64_t> bytes = std::nullopt,
@@ -77,8 +78,6 @@ class MemoryTrace {
  private:
   mutable std::mutex mutex_;
   MemoryStats stats_;
-  // Caches addr→bytes from recordAlloc; needed because some free paths
-  // (e.g. ncclCudaFree) don't know the allocation size at free time.
   std::unordered_map<uintptr_t, int64_t> allocMap_;
 };
 

--- a/comms/utils/memtrace/Types.h
+++ b/comms/utils/memtrace/Types.h
@@ -1,0 +1,39 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Shared, device-safe memtrace types (stdlib-only, no folly). Included by both
+// the memtrace and logger modules; kept in a standalone header/target to avoid
+// a circular dependency between the memory_trace and event_mgr build targets.
+
+#pragma once
+
+#include <string>
+#include <utility>
+
+namespace meta::comms::memtrace {
+
+// Callsite metadata for a memtrace record. Baseline NCCL call sites pass a bare
+// string, which implicitly constructs a MemCallsite with scope=kNccl, so they
+// require no changes. ctran call sites pass {Scope::kCtran, function} to tag
+// their allocations. memtrace owns splitting this into the scuba `callsite`
+// (function) and `scope` columns and into the per-source in-memory buckets, so
+// callers never format it themselves.
+struct MemCallsite {
+  // Layer that requested a GPU memory allocation: baseline NCCL (kNccl), ctran
+  // (kCtran), or mccl (kMccl).
+  enum class Scope { kNccl, kCtran, kMccl };
+
+  Scope scope{Scope::kNccl};
+  std::string function;
+
+  // NOLINTNEXTLINE(google-explicit-constructor): implicit keeps baseline
+  // (bare-string) call sites unchanged.
+  MemCallsite(const char* function)
+      : function(function != nullptr ? function : "") {}
+  // NOLINTNEXTLINE(google-explicit-constructor): implicit keeps baseline
+  // (bare-string) call sites unchanged.
+  MemCallsite(std::string function) : function(std::move(function)) {}
+  MemCallsite(Scope scope, std::string function)
+      : scope(scope), function(std::move(function)) {}
+};
+
+} // namespace meta::comms::memtrace

--- a/comms/utils/memtrace/tests/MemoryTraceTest.cc
+++ b/comms/utils/memtrace/tests/MemoryTraceTest.cc
@@ -12,7 +12,7 @@ using namespace meta::comms::memtrace;
 TEST(MemoryTraceTest, RecordAllocUpdatesStats) {
   auto trace = MemoryTrace::getOrCreate(0x1001);
   auto before = trace->getStats();
-  trace->recordAlloc(0xAAAA, 1024);
+  trace->recordAlloc(0xAAAA, 1024, MemCallsite::Scope::kNccl);
 
   auto after = trace->getStats();
   EXPECT_EQ(after.totalAllocated, before.totalAllocated + 1024);
@@ -22,10 +22,10 @@ TEST(MemoryTraceTest, RecordAllocUpdatesStats) {
 
 TEST(MemoryTraceTest, RecordFreeUpdatesStats) {
   auto trace = MemoryTrace::getOrCreate(0x1002);
-  trace->recordAlloc(0xBBBB, 2048);
+  trace->recordAlloc(0xBBBB, 2048, MemCallsite::Scope::kNccl);
   auto before = trace->getStats();
 
-  trace->recordFree(0xBBBB, 2048);
+  trace->recordFree(0xBBBB, 2048, MemCallsite::Scope::kNccl);
   auto after = trace->getStats();
   EXPECT_EQ(after.totalFreed, before.totalFreed + 2048);
   EXPECT_EQ(after.currentUsage, before.currentUsage - 2048);
@@ -33,10 +33,10 @@ TEST(MemoryTraceTest, RecordFreeUpdatesStats) {
 
 TEST(MemoryTraceTest, RecordFreeWithoutBytesLooksUpAllocMap) {
   auto trace = MemoryTrace::getOrCreate(0x1003);
-  trace->recordAlloc(0xCCCC, 4096);
+  trace->recordAlloc(0xCCCC, 4096, MemCallsite::Scope::kNccl);
   auto before = trace->getStats();
 
-  trace->recordFree(0xCCCC, std::nullopt);
+  trace->recordFree(0xCCCC, std::nullopt, MemCallsite::Scope::kNccl);
   auto after = trace->getStats();
   EXPECT_EQ(after.totalFreed, before.totalFreed + 4096);
   EXPECT_EQ(after.currentUsage, before.currentUsage - 4096);
@@ -44,10 +44,10 @@ TEST(MemoryTraceTest, RecordFreeWithoutBytesLooksUpAllocMap) {
 
 TEST(MemoryTraceTest, PeakUsageTracking) {
   auto trace = MemoryTrace::getOrCreate(0x1004);
-  trace->recordAlloc(0xD001, 1000);
-  trace->recordAlloc(0xD002, 2000);
+  trace->recordAlloc(0xD001, 1000, MemCallsite::Scope::kNccl);
+  trace->recordAlloc(0xD002, 2000, MemCallsite::Scope::kNccl);
 
-  trace->recordFree(0xD001, 1000);
+  trace->recordFree(0xD001, 1000, MemCallsite::Scope::kNccl);
   auto stats = trace->getStats();
   EXPECT_GE(stats.peakUsage, 3000);
   EXPECT_EQ(stats.currentUsage, 2000);
@@ -67,7 +67,7 @@ TEST(MemoryTraceTest, GetOrCreateDifferentHash) {
 
 TEST(MemoryTraceTest, DumpProducesValidJson) {
   auto trace = MemoryTrace::getOrCreate(0x4001);
-  trace->recordAlloc(0xEEEE, 8192);
+  trace->recordAlloc(0xEEEE, 8192, MemCallsite::Scope::kNccl);
 
   auto jsonStr = trace->dump();
   auto parsed = folly::parseJson(jsonStr);
@@ -86,8 +86,8 @@ TEST(MemoryTraceTest, DumpToCommDumpMap) {
   auto trace = MemoryTrace::getOrCreate(commHash);
 
   // Simulate ncclCommInit allocations
-  trace->recordAlloc(0xA001, 1024 * 1024);
-  trace->recordAlloc(0xA002, 512 * 1024);
+  trace->recordAlloc(0xA001, 1024 * 1024, MemCallsite::Scope::kNccl);
+  trace->recordAlloc(0xA002, 512 * 1024, MemCallsite::Scope::kNccl);
 
   // commDump reads the trace into a map
   std::unordered_map<std::string, std::string> map;
@@ -99,7 +99,7 @@ TEST(MemoryTraceTest, DumpToCommDumpMap) {
   EXPECT_EQ(parsed["peakUsage"].asInt(), 1024 * 1024 + 512 * 1024);
 
   // Simulate ncclCommDestroy: free without size (ncclCudaFree pattern)
-  trace->recordFree(0xA001, std::nullopt);
+  trace->recordFree(0xA001, std::nullopt, MemCallsite::Scope::kNccl);
 
   auto stats = trace->getStats();
   EXPECT_EQ(stats.totalFreed, 1024 * 1024);
@@ -127,4 +127,92 @@ TEST(MemoryTraceTest, MemCallsiteScopeClassification) {
       MemCallsite::Scope::kMccl, "McclComm::commRegister");
   EXPECT_EQ(mcclCallsite.scope, MemCallsite::Scope::kMccl);
   EXPECT_EQ(mcclCallsite.function, "McclComm::commRegister");
+}
+
+// Allocations recorded under different scopes land in separate per-scope
+// buckets, and the aggregate stat equals the sum across scopes.
+TEST(MemoryTraceTest, PerScopeStatsSeparateAcrossScopes) {
+  auto trace = MemoryTrace::getOrCreate(0x6001);
+  const auto ncclBefore = trace->getStats(MemCallsite::Scope::kNccl);
+  const auto ctranBefore = trace->getStats(MemCallsite::Scope::kCtran);
+  const auto mcclBefore = trace->getStats(MemCallsite::Scope::kMccl);
+  const auto aggBefore = trace->getStats();
+
+  trace->recordAlloc(0x6A01, 100, MemCallsite::Scope::kNccl);
+  trace->recordAlloc(0x6A02, 200, MemCallsite::Scope::kCtran);
+  trace->recordAlloc(0x6A03, 400, MemCallsite::Scope::kMccl);
+
+  const auto ncclAfter = trace->getStats(MemCallsite::Scope::kNccl);
+  const auto ctranAfter = trace->getStats(MemCallsite::Scope::kCtran);
+  const auto mcclAfter = trace->getStats(MemCallsite::Scope::kMccl);
+  const auto aggAfter = trace->getStats();
+
+  EXPECT_EQ(ncclAfter.totalAllocated - ncclBefore.totalAllocated, 100);
+  EXPECT_EQ(ctranAfter.totalAllocated - ctranBefore.totalAllocated, 200);
+  EXPECT_EQ(mcclAfter.totalAllocated - mcclBefore.totalAllocated, 400);
+  EXPECT_EQ(ncclAfter.currentUsage - ncclBefore.currentUsage, 100);
+  EXPECT_EQ(ctranAfter.currentUsage - ctranBefore.currentUsage, 200);
+  EXPECT_EQ(mcclAfter.currentUsage - mcclBefore.currentUsage, 400);
+
+  EXPECT_EQ(aggAfter.totalAllocated - aggBefore.totalAllocated, 700);
+  EXPECT_EQ(
+      aggAfter.totalAllocated - aggBefore.totalAllocated,
+      (ncclAfter.totalAllocated - ncclBefore.totalAllocated) +
+          (ctranAfter.totalAllocated - ctranBefore.totalAllocated) +
+          (mcclAfter.totalAllocated - mcclBefore.totalAllocated));
+}
+
+// recordFree updates the bucket named by the passed scope; other scopes are
+// untouched.
+TEST(MemoryTraceTest, FreeUpdatesPassedScopeBucket) {
+  auto trace = MemoryTrace::getOrCreate(0x6002);
+  const auto ncclBefore = trace->getStats(MemCallsite::Scope::kNccl);
+  const auto mcclBefore = trace->getStats(MemCallsite::Scope::kMccl);
+
+  trace->recordAlloc(0x6B01, 4096, MemCallsite::Scope::kCtran);
+  const auto ctranAfterAlloc = trace->getStats(MemCallsite::Scope::kCtran);
+
+  trace->recordFree(0x6B01, 4096, MemCallsite::Scope::kCtran);
+  const auto ctranAfterFree = trace->getStats(MemCallsite::Scope::kCtran);
+
+  EXPECT_EQ(ctranAfterFree.totalFreed - ctranAfterAlloc.totalFreed, 4096);
+  EXPECT_EQ(ctranAfterFree.currentUsage - ctranAfterAlloc.currentUsage, -4096);
+
+  const auto ncclAfter = trace->getStats(MemCallsite::Scope::kNccl);
+  const auto mcclAfter = trace->getStats(MemCallsite::Scope::kMccl);
+  EXPECT_EQ(ncclAfter.totalFreed, ncclBefore.totalFreed);
+  EXPECT_EQ(ncclAfter.currentUsage, ncclBefore.currentUsage);
+  EXPECT_EQ(mcclAfter.totalFreed, mcclBefore.totalFreed);
+  EXPECT_EQ(mcclAfter.currentUsage, mcclBefore.currentUsage);
+}
+
+// dump() surfaces a per-scope breakdown under "byScope" alongside the
+// aggregate.
+TEST(MemoryTraceTest, DumpContainsByScopeBreakdown) {
+  auto trace = MemoryTrace::getOrCreate(0x6003);
+  const auto beforeJson = folly::parseJson(trace->dump());
+  const int64_t ncclBefore =
+      beforeJson["byScope"]["nccl"]["totalAllocated"].asInt();
+  const int64_t ctranBefore =
+      beforeJson["byScope"]["ctran"]["totalAllocated"].asInt();
+  const int64_t mcclBefore =
+      beforeJson["byScope"]["mccl"]["totalAllocated"].asInt();
+  const int64_t aggBefore = beforeJson["totalAllocated"].asInt();
+
+  trace->recordAlloc(0x6C01, 1000, MemCallsite::Scope::kNccl);
+  trace->recordAlloc(0x6C02, 2000, MemCallsite::Scope::kCtran);
+  trace->recordAlloc(0x6C03, 4000, MemCallsite::Scope::kMccl);
+
+  const auto afterJson = folly::parseJson(trace->dump());
+  ASSERT_TRUE(afterJson.count("byScope"));
+  EXPECT_EQ(
+      afterJson["byScope"]["nccl"]["totalAllocated"].asInt() - ncclBefore,
+      1000);
+  EXPECT_EQ(
+      afterJson["byScope"]["ctran"]["totalAllocated"].asInt() - ctranBefore,
+      2000);
+  EXPECT_EQ(
+      afterJson["byScope"]["mccl"]["totalAllocated"].asInt() - mcclBefore,
+      4000);
+  EXPECT_EQ(afterJson["totalAllocated"].asInt() - aggBefore, 7000);
 }

--- a/comms/utils/memtrace/tests/MemoryTraceTest.cc
+++ b/comms/utils/memtrace/tests/MemoryTraceTest.cc
@@ -106,3 +106,25 @@ TEST(MemoryTraceTest, DumpToCommDumpMap) {
   EXPECT_EQ(stats.currentUsage, 512 * 1024);
   EXPECT_EQ(stats.peakUsage, 1024 * 1024 + 512 * 1024);
 }
+
+// A MemCallsite built implicitly from a bare string is baseline (kNccl); the
+// explicit two-arg form tags the scope (e.g. kCtran) while preserving the
+// function name. This is how baseline call sites stay unchanged and ctran call
+// sites opt into attribution.
+TEST(MemoryTraceTest, MemCallsiteScopeClassification) {
+  const MemCallsite baselineLiteral("initChannelDevRingUserRanks");
+  EXPECT_EQ(baselineLiteral.scope, MemCallsite::Scope::kNccl);
+  EXPECT_EQ(baselineLiteral.function, "initChannelDevRingUserRanks");
+
+  const MemCallsite baselineString(std::string("commAlloc"));
+  EXPECT_EQ(baselineString.scope, MemCallsite::Scope::kNccl);
+
+  const MemCallsite ctranCallsite(MemCallsite::Scope::kCtran, "initTmpBufs");
+  EXPECT_EQ(ctranCallsite.scope, MemCallsite::Scope::kCtran);
+  EXPECT_EQ(ctranCallsite.function, "initTmpBufs");
+
+  const MemCallsite mcclCallsite(
+      MemCallsite::Scope::kMccl, "McclComm::commRegister");
+  EXPECT_EQ(mcclCallsite.scope, MemCallsite::Scope::kMccl);
+  EXPECT_EQ(mcclCallsite.function, "McclComm::commRegister");
+}


### PR DESCRIPTION
Summary:
Build on the scope labeling from the previous commit to break the in-memory `MemoryTrace` stats down by allocation scope, and surface that breakdown through commDump:
- Add `statsByScope_` (a `std::array<MemoryStats, kNumScopes>` indexed by `MemCallsite::Scope`, kNumScopes=3 for nccl/ctran/mccl) to `MemoryTrace`. `recordAlloc`/`recordFree` update the matching per-scope bucket alongside the existing aggregate `stats_`, keeping the invariant `sum(statsByScope_) == stats_` for totalAllocated/totalFreed/currentUsage. `recordFree` resolves the scope from `allocMap_` (the `AllocInfo.scope` recorded at alloc time) with no signature change.
- Add `MemoryStats getStats(MemCallsite::Scope) const` (returns by value under the lock, matching the aggregate `getStats()`).
- `MemoryTrace::dump()` additively emits a `"byScope":{"nccl":{...},"ctran":{...},"mccl":{...}}` object; the existing top-level aggregate fields are byte-identical, so the change is backward-compatible for existing commDump consumers. This flows through `commDump.cc` under its "memory" field unchanged, giving commDump-side visibility into per-layer GPU memory.
- A `static_assert` ties `kNumScopes` to the `Scope` enum layout so the array indexing cannot silently go out of bounds if the enum later grows.

Differential Revision: D114662227


