### PR TITLE
test: intra-node flip-target-unavailable fallback + drop stale comment

### DIFF
--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -312,8 +312,7 @@ Result<Transport*> MultiTransport::selectTransport(
   // Intra-node (VRAM<->VRAM on this device): default to the interconnect tier
   // (NVLink/P2P). intraNodeTransport flips that choice (e.g. to RDMA) -- both
   // tiers are registered, so this is a per-transfer selection override, not a
-  // kill-switch. Falls through to the inter-node fallback if the chosen tier is
-  // not present on all requests.
+  // kill-switch.
   if (localMemType == MemoryType::VRAM && remoteMemType == MemoryType::VRAM &&
       localDeviceId == deviceId_) {
     // Try the intra-node override first (only if set and distinct from the

--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -144,6 +144,10 @@ MultiTransportFactory::MultiTransportFactory(
       deviceId_ >= -1 && deviceId_ < static_cast<int>(topo.gpuCount()),
       std::runtime_error);
 
+  // Register the intra-node interconnect tier whenever the hardware is present
+  // (NVLink on NVIDIA, P2P/XGMI on AMD). This tier and RDMA are both registered
+  // when available; selectTransport chooses per transfer (intraNodeTransport
+  // can flip the intra-node default -- see selectTransport).
 #ifndef __HIP_PLATFORM_AMD__
   if (deviceId_ >= 0 && isNvlinkAvailable()) {
     auto nvlink = std::make_shared<NVLinkTransportFactory>(
@@ -305,9 +309,24 @@ Result<Transport*> MultiTransport::selectTransport(
     return true;
   };
 
-  // VRAM→VRAM on matching device: prefer NVLink if ALL requests have it.
+  // Intra-node (VRAM<->VRAM on this device): default to the interconnect tier
+  // (NVLink/P2P). intraNodeTransport flips that choice (e.g. to RDMA) -- both
+  // tiers are registered, so this is a per-transfer selection override, not a
+  // kill-switch. Falls through to the inter-node fallback if the chosen tier is
+  // not present on all requests.
   if (localMemType == MemoryType::VRAM && remoteMemType == MemoryType::VRAM &&
       localDeviceId == deviceId_) {
+    // Try the intra-node override first (only if set and distinct from the
+    // NVLink/P2P default), then the default. Two explicit checks -> no
+    // per-transfer heap allocation, and no redundant re-check when the override
+    // is itself NVLink/P2P.
+    if (intraNodeTransport_.has_value() &&
+        *intraNodeTransport_ != TransportType::NVLink &&
+        allHaveTransport(*intraNodeTransport_)) {
+      if (auto* t = findTransport(*intraNodeTransport_)) {
+        return t;
+      }
+    }
     if (allHaveTransport(TransportType::NVLink)) {
       if (auto* t = findTransport(TransportType::NVLink)) {
         return t;
@@ -479,7 +498,8 @@ Result<std::unique_ptr<MultiTransport>> MultiTransportFactory::createTransport(
         entries.size());
   }
 
-  auto mt = std::make_unique<MultiTransport>(deviceId_, eventBaseThread_);
+  auto mt = std::make_unique<MultiTransport>(
+      deviceId_, eventBaseThread_, options_.intraNodeTransport);
   for (size_t i = 0, j = 0; i < entries.size() && j < factories_.size();) {
     if (entries[i].type < factories_[j]->transportType()) {
       ++i;

--- a/comms/uniflow/MultiTransport.h
+++ b/comms/uniflow/MultiTransport.h
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <cstddef>
+#include <optional>
 
 namespace uniflow {
 
@@ -24,14 +25,24 @@ struct MultiTransportFactoryOptions {
   CpuNicSelectionPolicy cpuNicSelectionPolicy{
       CpuNicSelectionPolicy::kNumaLocalBounded};
   size_t maxCpuNics{2};
+  // Runtime intra-node transport selection. Intra-node VRAM<->VRAM defaults to
+  // the on-host interconnect tier (NVLink on NVIDIA, P2P/XGMI on AMD). Set this
+  // to flip that choice -- e.g. TransportType::RDMA to route intra-node traffic
+  // over RDMA instead. Both tiers stay registered, so this is a selection
+  // override, not a kill-switch; inter-node stays RDMA. Caller-owned (no
+  // transport-internal config-system dependency).
+  std::optional<TransportType> intraNodeTransport;
 };
 
 class MultiTransport {
  public:
   explicit MultiTransport(
       int deviceId,
-      std::shared_ptr<ScopedEventBaseThread> evbThread = nullptr)
-      : deviceId_(deviceId), evbThread_(std::move(evbThread)) {
+      std::shared_ptr<ScopedEventBaseThread> evbThread = nullptr,
+      std::optional<TransportType> intraNodeTransport = std::nullopt)
+      : deviceId_(deviceId),
+        intraNodeTransport_(intraNodeTransport),
+        evbThread_(std::move(evbThread)) {
     if (!evbThread_) {
       evbThread_ = std::make_shared<ScopedEventBaseThread>();
     }
@@ -97,6 +108,7 @@ class MultiTransport {
   Transport* findTransport(TransportType type) const;
 
   const int deviceId_;
+  std::optional<TransportType> intraNodeTransport_;
   // Prevents destruction of the shared EventBase while transports are live.
   // Transports hold raw EventBase* borrowed from the ScopedEventBaseThread
   // owned by MultiTransportFactory; this shared_ptr ensures the thread (and

--- a/comms/uniflow/tests/unit/MultiTransportTest.cpp
+++ b/comms/uniflow/tests/unit/MultiTransportTest.cpp
@@ -1101,4 +1101,28 @@ TEST_F(MultiTransportTest, IntraNodeTransportFlipsToRdma) {
   EXPECT_EQ(nvlink->putCount, 0);
 }
 
+TEST_F(MultiTransportTest, IntraNodeFlipToRdmaFallsBackToNvLinkWhenRdmaAbsent) {
+  // Flip-target-unavailable edge: intraNodeTransport=RDMA, but the intra-node
+  // VRAM<->VRAM segment has only an NVLink handle (no RDMA). This is the exact
+  // case that distinguishes the two possible contracts -- "prefer RDMA" vs
+  // "avoid the interconnect tier". Under the "prefer RDMA, NVLink is fine"
+  // contract the unsatisfiable RDMA preference falls back to the NVLink/P2P
+  // default (instead of skipping to the inter-node fallback), so NVLink gets
+  // the transfer and RDMA does not.
+  MultiTransport mt(0, nullptr, TransportType::RDMA);
+  auto* nvlink = addMock(mt, TransportType::NVLink);
+  auto* rdma = addMock(mt, TransportType::RDMA);
+
+  TestSegments local(MemoryType::VRAM, 0, {TransportType::NVLink});
+  TestSegments remote(MemoryType::VRAM, 0, {TransportType::NVLink});
+  std::vector<TransferRequest> reqs = {
+      {local.regSeg.span(size_t{0}, size_t{32}),
+       remote.remoteSeg.span(size_t{0}, size_t{32})}};
+
+  auto future = mt.put(reqs);
+  EXPECT_TRUE(future.get().hasValue());
+  EXPECT_EQ(nvlink->putCount, 1);
+  EXPECT_EQ(rdma->putCount, 0);
+}
+
 } // namespace uniflow

--- a/comms/uniflow/tests/unit/MultiTransportTest.cpp
+++ b/comms/uniflow/tests/unit/MultiTransportTest.cpp
@@ -1080,4 +1080,25 @@ TEST_F(MultiTransportTest, AsymmetricHandlesFallBackToRdma) {
   EXPECT_EQ(nvlink->putCount, 0);
 }
 
+TEST_F(MultiTransportTest, IntraNodeTransportFlipsToRdma) {
+  // intraNodeTransport=RDMA flips the intra-node default (NVLink) to RDMA; both
+  // tiers stay registered, so this is a per-transfer selection override.
+  MultiTransport mt(0, nullptr, TransportType::RDMA);
+  auto* nvlink = addMock(mt, TransportType::NVLink);
+  auto* rdma = addMock(mt, TransportType::RDMA);
+
+  TestSegments local(
+      MemoryType::VRAM, 0, {TransportType::NVLink, TransportType::RDMA});
+  TestSegments remote(
+      MemoryType::VRAM, 0, {TransportType::NVLink, TransportType::RDMA});
+  std::vector<TransferRequest> reqs = {
+      {local.regSeg.span(size_t{0}, size_t{32}),
+       remote.remoteSeg.span(size_t{0}, size_t{32})}};
+
+  auto future = mt.put(reqs);
+  EXPECT_TRUE(future.get().hasValue());
+  EXPECT_EQ(rdma->putCount, 1);
+  EXPECT_EQ(nvlink->putCount, 0);
+}
+
 } // namespace uniflow


### PR DESCRIPTION
Summary:
Adds the flip-target-unavailable test for intra-node transport selection and
drops a now-inaccurate comment.

New test IntraNodeFlipToRdmaFallsBackToNvLinkWhenRdmaAbsent covers the exact edge
that distinguishes the two possible contracts for intraNodeTransport=RDMA: a
VRAM<->VRAM segment that has an NVLink handle but NOT an RDMA handle. Under the
"prefer RDMA, NVLink is fine" contract the unsatisfiable RDMA preference falls
back to the NVLink/P2P default (asserted: NVLink gets the transfer, RDMA does
not), rather than skipping to the inter-node fallback. This closes the Arctic
test gap: without it, a future change to the fallback branch would go uncaught.

Also drops the outer selectTransport comment's stale "Falls through to the
inter-node fallback..." sentence, which disagreed with the code (selection falls
through to the NVLink/P2P default first). The accurate inner comment stays.

Differential Revision: D114688843


