### PR TITLE
Fix eager-after-capture failure under NCCL_CTRAN_GRAPH_MIXING_SUPPORT=0

### DIFF
--- a/comms/ctran/algos/common/OrderedWorkStreamGuard.cc
+++ b/comms/ctran/algos/common/OrderedWorkStreamGuard.cc
@@ -22,11 +22,16 @@ void OrderedWorkStreamGuard::init(
   FB_CUDACHECKTHROW_EX(
       cudaEventCreateWithFlags(&execModeSyncEvent, cudaEventDisableTiming),
       logMetaData);
+  cudaEvent_t captureFenceEvent{};
+  FB_CUDACHECKTHROW_EX(
+      cudaEventCreateWithFlags(&captureFenceEvent, cudaEventDisableTiming),
+      logMetaData);
 
   // Publish the initialized state only after every resource is ready.
   graphMixingSupport_ = (NCCL_CTRAN_GRAPH_MIXING_SUPPORT != 0);
   synchronizeEagerAfterCapturedWork_ = synchronizeEagerAfterCapturedWork;
   execModeSyncEvent_ = execModeSyncEvent;
+  captureFenceEvent_ = captureFenceEvent;
   sideStream_ = std::move(sideStream);
   initialized_ = true;
 }
@@ -36,6 +41,7 @@ OrderedWorkStreamGuard::~OrderedWorkStreamGuard() noexcept {
     return;
   }
   FB_CUDACHECKIGNORE(cudaEventDestroy(execModeSyncEvent_));
+  FB_CUDACHECKIGNORE(cudaEventDestroy(captureFenceEvent_));
 }
 
 OrderedWorkStreamGuard::Scope::Scope(
@@ -106,10 +112,15 @@ commResult_t OrderedWorkStreamGuard::doAcquire(
     everCaptured_ = true;
   }
 
+  // Only an in-capture wait at mixing=0 targets the captured fence; every other
+  // path waits on the event the eager side records. The two are never both
+  // meaningful at once, so the choice follows from the capture state and mode
+  // rather than needing a per-call-site argument.
   auto doWait = [&]() -> commResult_t {
+    const bool inCaptureWithoutMixing = isCapturing && !graphMixingSupport_;
     FB_CUDACHECK(cudaStreamWaitEvent(
         userStream,
-        execModeSyncEvent_,
+        inCaptureWithoutMixing ? captureFenceEvent_ : execModeSyncEvent_,
         (isCapturing && graphMixingSupport_) ? cudaEventWaitExternal
                                              : cudaEventWaitDefault));
     return commSuccess;
@@ -136,10 +147,13 @@ commResult_t OrderedWorkStreamGuard::doAcquire(
 
   if (!isNewCapture) {
     if (!graphMixingSupport_) {
+      // The fence is a captured plain record, so capture folds this wait into
+      // the graph as a dependency edge; there is no node to re-link.
       return doWait();
     }
     // A later operation captured into the same graph must depend on the
-    // prior record node even if CUDA cannot infer a dependency across streams.
+    // prior record node even if CUDA cannot infer a dependency across streams:
+    // cudaStreamWaitEvent cannot observe an EVENT_RECORD node.
 #if defined(__HIP_PLATFORM_AMD__)
     FB_CUDACHECK(cudaStreamUpdateCaptureDependencies(
         userStream, &lastRecordNode_, 1, hipStreamAddCaptureDependencies));
@@ -157,6 +171,10 @@ commResult_t OrderedWorkStreamGuard::doAcquire(
   }
 
   if (!graphMixingSupport_) {
+    // New capture: the previous fence, if any, belongs to a different graph.
+    // captureFenceEvent_ cannot order across graphs (a captured record is only
+    // meaningful within its own capture) and execModeSyncEvent_ carries no
+    // replay record in this mode, so there is nothing to wait on.
     return commSuccess;
   }
 
@@ -168,8 +186,23 @@ commResult_t OrderedWorkStreamGuard::doRelease(
     const ctran::utils::cudagraph::StreamCaptureInfo& captureInfo) {
   const bool isCapturing = captureInfo.status == cudaStreamCaptureStatusActive;
 
-  if (!isCapturing || !graphMixingSupport_) {
+  if (!isCapturing) {
     FB_CUDACHECK(cudaEventRecord(execModeSyncEvent_, userStream));
+  } else if (!graphMixingSupport_) {
+    // Capture absorbs this record rather than executing it, so no standalone
+    // EVENT_RECORD node exists for cudaGraphInstantiate to place onto a busy
+    // hardware channel, and the next doAcquire's wait folds into the graph as a
+    // dependency edge.
+    //
+    // Use a dedicated event so that capture-bound state never lands on
+    // execModeSyncEvent_, which the eager path consumes live
+    // (cudaEventSynchronize / cudaStreamWaitEvent) and which a captured record
+    // would leave unusable. The cost is that nothing records
+    // execModeSyncEvent_ during capture, so the eager-after-capture GPE host
+    // barrier has no replay completion to order against; mixing=0 therefore
+    // does not support eager submissions after a capture. See
+    // NCCL_CTRAN_GRAPH_MIXING_SUPPORT in nccl_cvars.yaml.
+    FB_CUDACHECK(cudaEventRecord(captureFenceEvent_, userStream));
   } else {
     // Record from a forked capture stream so the external event can order
     // later eager work and operations captured by a different graph.

--- a/comms/ctran/algos/common/OrderedWorkStreamGuard.h
+++ b/comms/ctran/algos/common/OrderedWorkStreamGuard.h
@@ -67,6 +67,10 @@ class OrderedWorkStreamGuard {
 
   std::mutex submissionMutex_;
   cudaEvent_t execModeSyncEvent_{};
+  // Fence recorded during capture. Separate from execModeSyncEvent_ so a
+  // capture-absorbed record never taints the event the eager path consumes
+  // live. Only ever waited on from within the same capture.
+  cudaEvent_t captureFenceEvent_{};
   unsigned long long lastCaptureId_{0};
   bool everCaptured_{false};
   bool graphMixingSupport_{true};

--- a/comms/ctran/algos/common/tests/OrderedWorkStreamGuardTest.cc
+++ b/comms/ctran/algos/common/tests/OrderedWorkStreamGuardTest.cc
@@ -3,7 +3,9 @@
 #include <cuda_runtime.h>
 
 #include <chrono>
+#include <string>
 #include <thread>
+#include <tuple>
 #include <type_traits>
 
 #include <gtest/gtest.h>
@@ -12,6 +14,7 @@
 #include "comms/ctran/algos/common/OrderedWorkStreamGuard.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 
 namespace {
 
@@ -31,17 +34,42 @@ StreamCaptureInfo captureInfo(cudaStream_t stream) {
   return info;
 }
 
-class OrderedWorkStreamGuardTest : public ::testing::TestWithParam<bool> {
+// Parameterized over (synchronizeEagerAfterCapturedWork,
+// NCCL_CTRAN_GRAPH_MIXING_SUPPORT). The first is a per-consumer construction
+// argument (GPE passes true, Prims false); the second is a global perf cvar.
+// Both are covered explicitly because their interaction determines whether the
+// captured-to-eager barrier is effective.
+class OrderedWorkStreamGuardTest
+    : public ::testing::TestWithParam<std::tuple<bool, int>> {
  protected:
+  bool syncEagerAfterCaptured() const {
+    return std::get<0>(GetParam());
+  }
+  int mixingSupport() const {
+    return std::get<1>(GetParam());
+  }
+
   void SetUp() override {
+    // Without ncclCvarInit() the cvar globals keep their zero-initialized
+    // values, so NCCL_CTRAN_GRAPH_MIXING_SUPPORT would read 0 regardless of its
+    // documented default of 1 (the default is the env2num fallback applied
+    // during init, not a static initializer). Set it explicitly: the guard
+    // latches it in init() below, so this must happen first.
+    setenv(
+        "NCCL_CTRAN_GRAPH_MIXING_SUPPORT",
+        std::to_string(mixingSupport()).c_str(),
+        1);
+    ncclCvarInit();
     CUDACHECK_TEST(cudaStreamCreateWithFlags(&streamA_, cudaStreamNonBlocking));
     CUDACHECK_TEST(cudaStreamCreateWithFlags(&streamB_, cudaStreamNonBlocking));
-    guard_.init(logMetaData_, GetParam());
+    guard_.init(logMetaData_, syncEagerAfterCaptured());
   }
 
   void TearDown() override {
     CUDACHECK_TEST(cudaStreamDestroy(streamA_));
     CUDACHECK_TEST(cudaStreamDestroy(streamB_));
+    unsetenv("NCCL_CTRAN_GRAPH_MIXING_SUPPORT");
+    ncclCvarInit();
   }
 
   CommLogData logMetaData_{};
@@ -74,6 +102,15 @@ TEST_P(OrderedWorkStreamGuardTest, OrdersEagerWorkAcrossStreams) {
   CUDACHECK_TEST(cudaFree(value));
 }
 
+// The guard's captured-to-eager policy, across both dimensions.
+//
+// synchronizeEagerAfterCapturedWork=true asks for a host barrier after captured
+// work; false asks only for GPU-side ordering. The barrier is effective only at
+// mixing=1, where a graph EVENT_RECORD node records execModeSyncEvent_ at
+// replay. At mixing=0 the captured fence is an absorbed plain record on a
+// separate event, so no node records execModeSyncEvent_ and the barrier has
+// nothing to wait on -- the documented mixing=0 caveat. Either way the eager
+// acquire must succeed rather than fail on a capture-bound event.
 TEST_P(OrderedWorkStreamGuardTest, AppliesCapturedToEagerPolicy) {
   cudaGraph_t graph{};
   cudaGraphExec_t graphExec{};
@@ -88,13 +125,17 @@ TEST_P(OrderedWorkStreamGuardTest, AppliesCapturedToEagerPolicy) {
   CUDACHECK_TEST(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
   CUDACHECK_TEST(cudaGraphLaunch(graphExec, streamA_));
 
+  // The eager acquire must not fail on a capture-bound event, whichever policy
+  // is in force.
   auto eager = guard_.acquire(streamB_, captureInfo(streamB_));
   ASSERT_EQ(eager.status(), commSuccess);
   const cudaError_t replayStatus = cudaStreamQuery(streamA_);
-  if (GetParam()) {
-    EXPECT_EQ(replayStatus, cudaSuccess);
+  if (syncEagerAfterCaptured() && mixingSupport() != 0) {
+    EXPECT_EQ(replayStatus, cudaSuccess)
+        << "host sync must have waited for the replay to complete";
   } else {
-    EXPECT_EQ(replayStatus, cudaErrorNotReady);
+    EXPECT_EQ(replayStatus, cudaErrorNotReady)
+        << "without an effective host barrier the replay stays in flight";
   }
   ASSERT_EQ(eager.release(), commSuccess);
 
@@ -124,12 +165,18 @@ TEST_P(OrderedWorkStreamGuardTest, PropagatesPoisonedError) {
 
 TEST_P(OrderedWorkStreamGuardTest, DoubleInitAborts) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-  EXPECT_DEATH(guard_.init(logMetaData_, GetParam()), "initialized twice");
+  EXPECT_DEATH(
+      guard_.init(logMetaData_, syncEagerAfterCaptured()), "initialized twice");
 }
 
 INSTANTIATE_TEST_SUITE_P(
     CapturedToEagerPolicy,
     OrderedWorkStreamGuardTest,
-    ::testing::Bool());
+    ::testing::Combine(::testing::Bool(), ::testing::Values(0, 1)),
+    [](const ::testing::TestParamInfo<std::tuple<bool, int>>& info) {
+      return std::string(
+                 std::get<0>(info.param) ? "SyncEager" : "NoSyncEager") +
+          "Mixing" + std::to_string(std::get<1>(info.param));
+    });
 
 } // namespace

--- a/comms/ctran/gpe/tests/CtranGpeUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeUT.cc
@@ -707,13 +707,14 @@ struct ReleaseFencePlacement {
 // Capture: submit(kernelA) -> cudaMemsetAsync (non-GPE work) ->
 // submit(kernelB), all on one user stream, with
 // NCCL_CTRAN_GRAPH_MIXING_SUPPORT=`mixingMode`. With mixing on (=1) the guard
-// emits one explicit EVENT_RECORD node per submit (on the side stream); with
-// mixing off (=0) the ordering fence is a plain captured event that folds into
-// the graph as an edge, so no EVENT_RECORD node appears. Either way the two GPE
-// kernels must stay ordered. The graph is also instantiated and launched to
-// confirm correctness in both modes. The cvar is latched in
-// OrderedWorkStreamGuard::init() at CtranGpe construction, so it must be set
-// before `new CtranGpe`.
+// emits one explicit EVENT_RECORD node per submit, hung off a forked side
+// stream so the fence can order across graphs; with mixing off (=0) the fence
+// is a plain captured record on the user stream that folds into the graph as a
+// dependency edge, so no EVENT_RECORD node appears for cudaGraphInstantiate to
+// place onto a busy channel. Either way the two GPE kernels must stay ordered.
+// The graph is also instantiated and launched to confirm correctness in both
+// modes. The cvar is latched in OrderedWorkStreamGuard::init() at CtranGpe
+// construction, so it must be set before `new CtranGpe`.
 static ReleaseFencePlacement captureReleaseFencePlacement(
     int cudaDev,
     CtranComm* dummyComm,
@@ -841,10 +842,15 @@ TEST_F(CtranGpeTest, GraphCaptureGraphMixingSupportSideStream) {
 }
 
 // NCCL_CTRAN_GRAPH_MIXING_SUPPORT=0: the ordering fence is a plain captured
-// event that folds into the graph as a dependency edge, so no standalone
-// EVENT_RECORD node is emitted — cudaGraphInstantiate has no floating fence to
-// mis-place onto a busy channel. Cross-submit ordering is still preserved via
-// the edge.
+// event recorded on the user stream, which capture folds into the graph as a
+// dependency edge, so no standalone EVENT_RECORD node is emitted --
+// cudaGraphInstantiate has no floating fence to mis-place onto a busy channel.
+// Cross-submit ordering is still preserved via the edge.
+//
+// The fence uses captureFenceEvent_, not execModeSyncEvent_, so the absorbed
+// record cannot leave the eager path's event capture-bound. The cost is that
+// nothing records execModeSyncEvent_ during capture; see
+// EagerAfterCaptureGraphMixingSupportOffIsUnordered.
 TEST_F(CtranGpeTest, GraphCaptureGraphMixingSupportEdge) {
   auto placement =
       captureReleaseFencePlacement(cudaDev, dummyComm, dummyDevState_d, "0");
@@ -853,6 +859,81 @@ TEST_F(CtranGpeTest, GraphCaptureGraphMixingSupportEdge) {
          "a dependency edge";
   EXPECT_TRUE(placement.kernelsOrdered)
       << "cross-submit ordering must be preserved";
+}
+
+// NCCL_CTRAN_GRAPH_MIXING_SUPPORT=0 does not support eager submissions after a
+// capture, and must degrade cleanly rather than erroring.
+//
+// The captured fence is a plain cudaEventRecord that capture absorbs, so no
+// graph node ever records it. Keeping that absorbed record on a dedicated
+// captureFenceEvent_ leaves execModeSyncEvent_ untainted, so doAcquire()'s
+// eager cudaEventSynchronize(execModeSyncEvent_) still succeeds -- recording it
+// on execModeSyncEvent_ instead would leave the event capture-bound and fail
+// with cudaErrorInvalidValue, which the guard then latches permanently
+// (doAcquire() returns error_ on every later submit).
+//
+// What this does NOT assert is ordering: because no node records
+// execModeSyncEvent_ during capture, the host barrier has no replay completion
+// to wait on, so a replay's host node may still race the eager cmdEnqueue.
+// Callers at mixing=0 must host-synchronize between a replay and an eager
+// CTRAN submission. Only mixing=1 orders this transition in the guard.
+TEST_F(CtranGpeTest, EagerAfterCaptureGraphMixingSupportOffIsUnordered) {
+  setenv("NCCL_CTRAN_GRAPH_MIXING_SUPPORT", "0", 1);
+  ncclCvarInit();
+  auto gpe = std::unique_ptr<CtranGpe>(new CtranGpe(cudaDev, dummyComm));
+
+  cudaStream_t stream;
+  CUDACHECK_TEST(cudaStreamCreate(&stream));
+
+  int* buf = nullptr;
+  int* valPtr = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMemset(buf, 0, sizeof(int) * count));
+  CUDACHECK_TEST(cudaMallocHost(&valPtr, sizeof(int)));
+  *valPtr = 42;
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  auto submit = [&]() {
+    std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+    auto config = KernelConfig(
+        KernelConfig::KernelType::ALLGATHER, stream, "dummyAlgo", 0);
+    ctranKernelSetAllGatherArgs(
+        buf, valPtr, commInt8, count, dummyDevState_d, &config.args);
+    return gpe->submit(
+        std::move(emptyOps),
+        nullptr,
+        config,
+        reinterpret_cast<void*>(CtranGpeTestKernel));
+  };
+
+  cudaGraph_t graph;
+  CUDACHECK_TEST(cudaStreamBeginCapture(stream, cudaStreamCaptureModeRelaxed));
+  ASSERT_EQ(submit(), commSuccess);
+  CUDACHECK_TEST(cudaStreamEndCapture(stream, &graph));
+  ASSERT_NE(graph, nullptr);
+
+  cudaGraphExec_t graphExec;
+  CUDACHECK_TEST(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+  CUDACHECK_TEST(cudaGraphLaunch(graphExec, stream));
+  // The host sync callers must perform at mixing=0: it is what actually orders
+  // the replay's host node ahead of the eager cmdEnqueue below.
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  EXPECT_EQ(submit(), commSuccess)
+      << "eager submit after capture must not fail on a capture-bound event";
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  // The guard latches errors, so a second eager submit proves it stayed clean.
+  EXPECT_EQ(submit(), commSuccess) << "guard must not have latched an error";
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  CUDACHECK_TEST(cudaFree(buf));
+  CUDACHECK_TEST(cudaFreeHost(valPtr));
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+  unsetenv("NCCL_CTRAN_GRAPH_MIXING_SUPPORT");
+  ncclCvarInit();
 }
 
 // Verify that consecutive same-stream submits followed by a cross-stream

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -112,9 +112,22 @@ cvars:
      cudaStreamWaitEvent: under capture it folds into the graph as a dependency
      edge rather than a standalone EVENT_RECORD node, so cudaGraphInstantiate
      has no floating fence to mis-place onto a busy hardware channel — the cause
-     of an observed multi-ms collective park. The trade-off is no cross-graph
-     ordering. The eager (non-capture) path is unchanged regardless of this
-     setting.
+     of an observed multi-ms collective park.
+
+     CAVEAT — 0 does not order a graph replay ahead of a following eager CTRAN
+     submission, and does not order across graphs. The captured record is
+     absorbed by capture rather than executed, so no graph node records the
+     fence at replay and the guard's eager-path host barrier has nothing to wait
+     on. GPE enqueues its command from the graph's host node on a driver
+     callback thread, so that command can race an eager submission's enqueue
+     into GPE's single-threaded queue and deadlock. Callers that mix replay and
+     eager CTRAN operations must host-synchronize (cudaStreamSynchronize,
+     cudaDeviceSynchronize, or cudaEventSynchronize on their own event) between
+     the two; a cudaStreamWaitEvent is not sufficient, since it orders GPU work
+     while leaving the host free to enqueue ahead. Use 1 for eager-dispatching
+     paths such as ctwin AllGatherP; 0 suits capture-only paths such as ctgraph.
+     A separate internal event carries the captured fence, so the unsupported
+     mixed case degrades to unordered rather than failing.
 
  - name        : NCCL_CTRAN_GPE_DEVICE_RING
    type        : bool


### PR DESCRIPTION
Summary:
Under NCCL_CTRAN_GRAPH_MIXING_SUPPORT=0, an eager CTRAN GPE submission
following a CUDA graph capture failed with:

  OrderedWorkStreamGuard.cc:131 CTRAN ERROR Cuda failure 1 'invalid argument'
  CtranGpeImpl.cc:215 -> commUnhandledCudaError

Root cause: `execModeSyncEvent_` had two consumers with incompatible
requirements. At mixing=0, `doRelease()` recorded it with a plain
`cudaEventRecord()` on the capturing stream. Under capture that call is not
executed -- it is absorbed as a graph-construction directive, which serves an
intra-capture dependency edge but leaves the event capture-bound, so host-side
use returns `cudaErrorInvalidValue`. `doAcquire()`'s eager branch then
host-synchronizes on that same event (`cudaEventSynchronize`, deliberately not
gated on the mixing mode) to give GPE its ordering barrier, and failed.
`Scope`'s ctor latched the error into `error_`, so every later GPE submission
returned it too. The taint happens at capture time; a replay is not required to
trigger it.

Fix: split the event. `captureFenceEvent_` carries the captured fence;
`execModeSyncEvent_` is reserved for the eager path, which consumes it live.
mixing=0 still records with a plain `cudaEventRecord`, so capture still folds
the fence into the graph as a dependency edge and emits no standalone
EVENT_RECORD node for `cudaGraphInstantiate` to mis-place onto a busy hardware
channel -- the perf property the cvar exists for. Because the absorbed record
now lands on a dedicated event, `execModeSyncEvent_` stays usable and the eager
path no longer errors or latches. `doWait()` takes the event as a parameter so
each call site names which one it means.

Behavior at mixing=0: intra-graph submit-to-submit ordering via the dependency
edge (unchanged), no cross-graph ordering (unchanged), and eager-after-capture
degrades to unordered instead of failing. That last case is a documented
caveat, not a guarantee -- nothing records `execModeSyncEvent_` during capture,
so the host barrier has no replay completion to wait on and a replay's host
node can still race an eager `cmdEnqueue` into GPE's single-threaded queue.
Callers mixing replay and eager CTRAN operations at mixing=0 must
host-synchronize between them (`cudaStreamSynchronize`,
`cudaDeviceSynchronize`, or `cudaEventSynchronize` on their own event); a
`cudaStreamWaitEvent` is not sufficient, since it orders GPU work while leaving
the host free to enqueue ahead. Use mixing=1 for eager-dispatching paths such
as ctwin AllGatherP; 0 suits capture-only paths such as ctgraph.

Reachable from the ctwin AllGatherP path, which dispatches eagerly as well as
under capture; not from ctgraph, whose submissions stay inside capture. It was
masked before D114255856 landed on top of the OrderedWorkStreamGuard
extraction: the two `maybeAcquireWorkStreamScope()` call sites in
CtranGpeImpl.cc previously discarded their return value, so the same CUDA
failure was silently swallowed -- along with the host-node ordering it was
meant to enforce, making the deadlock a latent race rather than an error.

Reviewed By: dolpm

Differential Revision: D114664357


