### PR TITLE
Fix SPSCQueue.h missing includes

### DIFF
--- a/comms/ctran/utils/SPSCQueue.h
+++ b/comms/ctran/utils/SPSCQueue.h
@@ -2,6 +2,8 @@
 
 #pragma once
 #include <folly/Synchronized.h>
+#include <condition_variable>
+#include <memory>
 #include <queue>
 
 namespace ctran::utils {


### PR DESCRIPTION
Summary: `SPSCQueue.h` uses `std::condition_variable` and `std::unique_ptr` but included neither `<condition_variable>` nor `<memory>`, relying on `<folly/Synchronized.h>` and `<queue>` to drag them in. Include them directly so the header is self-contained.

Differential Revision: D114751781


