### PR TITLE
Stage quantized RS DirectIB receive operands with Blackwell TMA (#3441)

### DIFF
--- a/comms/ctran/algos/ReduceScatter/ReduceScatterDirectIb.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterDirectIb.cc
@@ -303,6 +303,7 @@ static commResult_t ctranReduceScatterDirectIbImpl(
         recvBytes,
         statex->rank());
     params.num_blocks = numBlocks;
+    params.use_tma = MCCL_PRIMS_TMA;
     params.timeout_ms = MCCL_ABORT_TIMEOUT_MS;
     params.stream = stream;
 

--- a/comms/prims/collectives/ReduceScatterDirectIb.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIb.cu
@@ -1,5 +1,7 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <atomic>
+
 #include "comms/prims/collectives/ReduceScatterDirectIb.cuh"
 
 #include "comms/prims/core/Checks.h"
@@ -14,6 +16,7 @@ namespace comms::prims {
 
 template <
     bool kQuantized,
+    bool kTmaRecv,
     bool kStaggerChannels,
     typename T,
     typename AccumOp,
@@ -31,6 +34,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
   static_assert(kSendThreads % comms::device::kWarpSize == 0);
   static_assert(kRecvThreads % comms::device::kWarpSize == 0);
   static_assert(kSendThreads + kRecvThreads == kBlockSize);
+
+  using QuantOp = QuantizedReduceScatterCopyOpT<kTmaRecv>;
 
   const ThreadGroup block = make_block_group();
   const bool is_recv = block.thread_id_in_group < kRecvThreads;
@@ -96,14 +101,14 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
       if constexpr (kQuantized) {
         const std::size_t wire_bytes =
             output_tile.tile_size(channel) * sizeof(__nv_bfloat16);
-        QuantizedReduceScatterCopyOp::Args copy_args{
+        typename QuantOp::Args copy_args{
             .sender_input_base = nullptr,
             .receiver_input_base = reinterpret_cast<const T*>(local_input),
             .receiver_output_base = output,
             .seed = *args.seed_ptr,
             .logical_element_base = 0,
         };
-        transport.template recv<QuantizedReduceScatterCopyOp>(
+        transport.template recv<QuantOp>(
             group, output_bytes, wire_bytes, max_sig, timeout, copy_args);
       } else {
         transport.template recv<ReduceOp>(
@@ -134,14 +139,14 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
             static_cast<std::uint64_t>(my_rank) * total_elements +
             static_cast<std::uint64_t>(peer) * args.chunk_elements +
             static_cast<std::uint64_t>(channel) * send_tile.tile_elements;
-        QuantizedReduceScatterCopyOp::Args copy_args{
+        typename QuantOp::Args copy_args{
             .sender_input_base = send_tile.data(),
             .receiver_input_base = nullptr,
             .receiver_output_base = nullptr,
             .seed = *args.seed_ptr,
             .logical_element_base = logical_element_base,
         };
-        transport.template send<QuantizedReduceScatterCopyOp>(
+        transport.template send<QuantOp>(
             group,
             reinterpret_cast<const char*>(send_tile.data()),
             wire_bytes,
@@ -163,6 +168,7 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
 
 template __global__ void direct_reduce_scatter_ib_kernel<
     false,
+    false,
     true,
     float,
     SumOp,
@@ -179,6 +185,7 @@ void launch_direct_reduce_scatter_ib_impl(
     cudaStream_t stream,
     Timeout timeout) {
   auto* kernel = direct_reduce_scatter_ib_kernel<
+      false,
       false,
       true,
       float,
@@ -221,22 +228,102 @@ void launch_direct_reduce_scatter_ib_impl(
   PIPES_CUDA_CHECK(cudaGetLastError());
 }
 
-void launch_direct_reduce_scatter_ib_quantized_impl(
+namespace {
+
+// Instantiated once per (TMA, geometry) pair. The TMA receive path stages both
+// operands through shared memory, which frees the receive group from issuing
+// per-thread loads, so it needs far fewer threads than the register path.
+template <bool kTmaRecv, int kSend, int kRecv, int kBlock>
+void launch_quantized(
     const DirectReduceScatterIbArgs<float>& args,
     int num_blocks,
     cudaStream_t stream,
     Timeout timeout) {
   auto* kernel = direct_reduce_scatter_ib_kernel<
       true,
+      kTmaRecv,
       true,
       float,
       SumOp,
-      480,
-      160,
-      640,
+      kSend,
+      kRecv,
+      kBlock,
       CpAsyncSmemReduce<float, SumOp, 8192, 384, 2>>;
-  kernel<<<num_blocks, 640, 0, stream>>>(args, timeout);
+  constexpr std::size_t dynamic_smem =
+      QuantizedReduceScatterCopyOpT<kTmaRecv>::smem_bytes();
+  if constexpr (dynamic_smem > 0) {
+    // The device's opt-in limit was already checked by
+    // tma_supported_on_device() before this specialization was selected.
+    PIPES_CUDA_CHECK(cudaFuncSetAttribute(
+        kernel,
+        cudaFuncAttributeMaxDynamicSharedMemorySize,
+        static_cast<int>(dynamic_smem)));
+  }
+  kernel<<<num_blocks, kBlock, dynamic_smem, stream>>>(args, timeout);
   PIPES_CUDA_CHECK(cudaGetLastError());
+}
+
+} // namespace
+
+namespace {
+
+// The TMA receive path is only validated on Blackwell (sm_100+) and its shared
+// memory footprint exceeds what earlier architectures can opt into, so it is
+// gated on the device rather than on the compile target. Anything else silently
+// takes the register path, which is functionally identical.
+//
+// Cached per device ordinal, not once per process: a process can bind several
+// GPUs, and a single cached answer would route a device of a different
+// capability onto the wrong geometry. Racing writers compute the same value.
+bool tma_supported_on_device() {
+  int device = 0;
+  PIPES_CUDA_CHECK(cudaGetDevice(&device));
+
+  constexpr int kMaxCachedDevices = 16;
+  constexpr signed char kUnknown = 0;
+  constexpr signed char kSupported = 1;
+  constexpr signed char kUnsupported = 2;
+  static std::atomic<signed char> cache[kMaxCachedDevices];
+
+  const bool cacheable = device >= 0 && device < kMaxCachedDevices;
+  if (cacheable) {
+    const signed char cached = cache[device].load(std::memory_order_relaxed);
+    if (cached != kUnknown) {
+      return cached == kSupported;
+    }
+  }
+
+  int cc_major = 0;
+  PIPES_CUDA_CHECK(cudaDeviceGetAttribute(
+      &cc_major, cudaDevAttrComputeCapabilityMajor, device));
+  bool supported = cc_major >= 10;
+  if (supported) {
+    int max_dynamic_smem = 0;
+    PIPES_CUDA_CHECK(cudaDeviceGetAttribute(
+        &max_dynamic_smem, cudaDevAttrMaxSharedMemoryPerBlockOptin, device));
+    supported = QuantizedReduceScatterCopyOpT<true>::smem_bytes() <=
+        static_cast<std::size_t>(max_dynamic_smem);
+  }
+  if (cacheable) {
+    cache[device].store(
+        supported ? kSupported : kUnsupported, std::memory_order_relaxed);
+  }
+  return supported;
+}
+
+} // namespace
+
+void launch_direct_reduce_scatter_ib_quantized_impl(
+    const DirectReduceScatterIbArgs<float>& args,
+    int num_blocks,
+    bool use_tma,
+    cudaStream_t stream,
+    Timeout timeout) {
+  if (use_tma && tma_supported_on_device()) {
+    launch_quantized<true, 640, 128, 768>(args, num_blocks, stream, timeout);
+  } else {
+    launch_quantized<false, 480, 160, 640>(args, num_blocks, stream, timeout);
+  }
 }
 
 } // namespace comms::prims

--- a/comms/prims/collectives/ReduceScatterDirectIb.cuh
+++ b/comms/prims/collectives/ReduceScatterDirectIb.cuh
@@ -36,6 +36,7 @@ void launch_direct_reduce_scatter_ib_impl(
 void launch_direct_reduce_scatter_ib_quantized_impl(
     const DirectReduceScatterIbArgs<float>& args,
     int num_blocks,
+    bool use_tma,
     cudaStream_t stream,
     Timeout timeout);
 

--- a/comms/prims/collectives/ReduceScatterDirectIbLauncher.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIbLauncher.cu
@@ -76,7 +76,7 @@ void launch_direct_reduce_scatter_ib(
   const auto timeout = make_launch_timeout(params.timeout_ms);
   if (params.quantized) {
     launch_direct_reduce_scatter_ib_quantized_impl(
-        args, params.num_blocks, params.stream, timeout);
+        args, params.num_blocks, params.use_tma, params.stream, timeout);
   } else {
     launch_direct_reduce_scatter_ib_impl(
         args, params.num_blocks, params.stream, timeout);

--- a/comms/prims/collectives/ReduceScatterDirectIbLauncher.h
+++ b/comms/prims/collectives/ReduceScatterDirectIbLauncher.h
@@ -24,6 +24,7 @@ struct DirectReduceScatterIbLaunchParams {
   bool quantized{false};
   bool in_place{false};
   int num_blocks{16};
+  bool use_tma{true};
   float timeout_ms{0.0f};
   cudaStream_t stream{nullptr};
   P2pIbTransportDevice peers[kDirectReduceScatterIbMaxRanks]{};

--- a/comms/prims/collectives/tests/DirectIbReduceScatterTest.cc
+++ b/comms/prims/collectives/tests/DirectIbReduceScatterTest.cc
@@ -20,6 +20,7 @@ namespace {
 struct DirectIbReduceScatterTestParams {
   std::size_t chunk_elements;
   bool quantized;
+  bool use_tma{true};
   std::string name;
 };
 
@@ -88,6 +89,7 @@ TEST_P(DirectIbReduceScatterTest, Correctness) {
       ? static_cast<const std::uint64_t*>(seedBuf.get())
       : nullptr;
   launchParams.num_blocks = num_blocks;
+  launchParams.use_tma = params.use_tma;
   launchParams.timeout_ms = 30000.0f;
   for (int peer = 0; peer < worldSize; ++peer) {
     if (peer == globalRank) {
@@ -152,9 +154,28 @@ std::vector<DirectIbReduceScatterTestParams> all_test_params() {
         {.chunk_elements = chunk_elements,
          .quantized = true,
          .name = size_label + "Quantized"});
+    // MCCL_PRIMS_TMA=0. Exercises launch_quantized<false, ...>, which is the
+    // production kill switch and is otherwise never instantiated by a test.
+    out.push_back(
+        {.chunk_elements = chunk_elements,
+         .quantized = true,
+         .use_tma = false,
+         .name = size_label + "QuantizedNoTma"});
   }
   out.push_back(
       {.chunk_elements = 1025, .quantized = true, .name = "OddTailQuantized"});
+  out.push_back(
+      {.chunk_elements = 1025,
+       .quantized = true,
+       .use_tma = false,
+       .name = "OddTailQuantizedNoTma"});
+  // A tile is 16384 bf16 elements per channel; this size leaves a partial final
+  // tile so the TMA path's ragged-tail handling is covered rather than only
+  // whole-tile chunks.
+  out.push_back(
+      {.chunk_elements = 16384 * 8 + 4096,
+       .quantized = true,
+       .name = "RaggedTileQuantized"});
   return out;
 }
 

--- a/comms/prims/core/QuantCopyOp.cuh
+++ b/comms/prims/core/QuantCopyOp.cuh
@@ -14,7 +14,169 @@
 
 namespace comms::prims {
 
-struct QuantizedReduceScatterCopyOp {
+// Raw-PTX TMA / mbarrier wrappers. Deliberately not <cuda/ptx>: CCCL's
+// `cuda/ptx` header is not on the fbcode CUDA include path for every target
+// that pulls this header in, and the inline asm below is byte-identical to
+// what `cuda::ptx::cp_async_bulk(space_shared, space_global, ...)` expands to.
+// All of these are PTX ISA 8.6 / SM_90 family-agnostic; they assemble for the
+// generic `sm_103` target that the b300 build uses (verified with
+// `nvcc -arch=sm_103` + `cuobjdump -sass`: UBLKCP.S.G, SYNCS.ARRIVE.TRANS64,
+// SYNCS.PHASECHK.TRANS64.TRYWAIT, FENCE.VIEW.ASYNC.{G,S}).
+namespace quant_tma {
+
+// Blackwell and newer only. On sm_90 the bulk global->shared destination must
+// be .shared::cluster; ptxas rejects the .shared::cta form used here with
+// "State space incorrect for instruction 'cp.async.bulk'". This must stay in
+// step with the compute-capability gate in
+// launch_direct_reduce_scatter_ib_quantized_impl.
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+#define COMMS_PRIMS_QUANT_TMA_AVAILABLE 1
+#else
+#define COMMS_PRIMS_QUANT_TMA_AVAILABLE 0
+#endif
+
+#if COMMS_PRIMS_QUANT_TMA_AVAILABLE
+
+__device__ __forceinline__ std::uint32_t smem_addr(const void* p) {
+  return static_cast<std::uint32_t>(__cvta_generic_to_shared(p));
+}
+
+__device__ __forceinline__ void mbarrier_init(
+    std::uint64_t* bar,
+    std::uint32_t arrive_count) {
+  asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;"
+               :
+               : "r"(smem_addr(bar)), "r"(arrive_count)
+               : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_inval(std::uint64_t* bar) {
+  asm volatile("mbarrier.inval.shared::cta.b64 [%0];"
+               :
+               : "r"(smem_addr(bar))
+               : "memory");
+}
+
+// Orders this thread's prior generic-proxy shared accesses ahead of async-proxy
+// (TMA) shared writes. Its load-bearing use is stage reuse: every consumer
+// publishes its reads of a stage before the group barrier that releases that
+// stage to the next tile's TMA. (It is NOT required after mbarrier.init:
+// cp.async.bulk reaches its mbarrier operand through the generic proxy.)
+__device__ __forceinline__ void fence_proxy_async_shared() {
+  asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+}
+
+// Orders this thread's prior generic-proxy global accesses (the DATA_READY flag
+// acquire that the transport leader performed) ahead of async-proxy global
+// reads issued by the same thread.
+__device__ __forceinline__ void fence_proxy_async_global() {
+  asm volatile("fence.proxy.async.global;" ::: "memory");
+}
+
+// cp.async.bulk.shared::cta.global — 1-D descriptorless TMA. Requires
+// 16B-aligned src, 16B-aligned dst and a size that is a multiple of 16.
+__device__ __forceinline__ void bulk_load(
+    void* dst_smem,
+    const void* src_gmem,
+    std::uint32_t nbytes,
+    std::uint64_t* bar) {
+  asm volatile(
+      "cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes"
+      " [%0], [%1], %2, [%3];"
+      :
+      : "r"(smem_addr(dst_smem)),
+        "l"(src_gmem),
+        "r"(nbytes),
+        "r"(smem_addr(bar))
+      : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_arrive_expect_tx(
+    std::uint64_t* bar,
+    std::uint32_t tx_bytes) {
+  asm volatile(
+      "mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 _, [%0], %1;"
+      :
+      : "r"(smem_addr(bar)), "r"(tx_bytes)
+      : "memory");
+}
+
+__device__ __forceinline__ bool mbarrier_try_wait_parity(
+    std::uint64_t* bar,
+    std::uint32_t parity) {
+  std::uint32_t done;
+  asm volatile(
+      "{\n\t.reg .pred P;\n\t"
+      "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64 P, [%1], %2;\n\t"
+      "selp.b32 %0, 1, 0, P;\n\t}"
+      : "=r"(done)
+      : "r"(smem_addr(bar)), "r"(parity)
+      : "memory");
+  return done != 0u;
+}
+
+#endif // COMMS_PRIMS_QUANT_TMA_AVAILABLE
+
+} // namespace quant_tma
+
+template <bool kUseTma>
+struct QuantizedReduceScatterCopyOpT {
+  // Whether the receive path stages its operands through shared memory with
+  // bulk TMA. Selected at launch through MCCL_PRIMS_TMA.
+  //
+  // This must NOT depend on COMMS_PRIMS_QUANT_TMA_AVAILABLE: that macro keys
+  // off
+  // __CUDA_ARCH__, which is undefined on the host pass, so folding it in here
+  // would make the launcher reserve zero dynamic shared memory for a kernel
+  // whose device code uses it. __HIP_PLATFORM_AMD__ is safe to fold in because
+  // it is defined identically on both passes, and ROCm has neither TMA nor
+  // enough LDS (64 KB/workgroup) for the staging region.
+#if defined(__HIP_PLATFORM_AMD__)
+  static constexpr bool kTmaRecv = false;
+#else
+  static constexpr bool kTmaRecv = kUseTma;
+#endif
+
+  // ---------------------------------------------------------------------
+  // Dynamic shared memory. The send and receive warp groups are inlined into
+  // the SAME CTA and run concurrently, so the region is statically partitioned
+  // and each group only ever touches its own half. This variant gives the send
+  // group nothing.
+  //
+  //   [0, kRecvHeaderBytes)                mbarrier array + 128B align slack
+  //   [.. + s*kRecvStageBytes ..)          stage s: bf16 wire tile | fp32 local
+  // ---------------------------------------------------------------------
+  static constexpr std::size_t kSendSmemBytes = 0;
+  static constexpr std::uint32_t kRecvStages = 2;
+  static constexpr std::uint32_t kRecvTileElems = 16384;
+  // Independent float4 outputs each recv thread keeps in flight while draining
+  // a staged tile. Covers LDS latency now that the loads are off the LSU.
+  static constexpr std::uint32_t kRecvSmemUnroll = 8;
+
+  static constexpr std::size_t kWireTileBytes =
+      static_cast<std::size_t>(kRecvTileElems) * sizeof(__nv_bfloat16);
+  static constexpr std::size_t kLocalTileBytes =
+      static_cast<std::size_t>(kRecvTileElems) * sizeof(float);
+  static constexpr std::size_t kRecvStageBytes =
+      kWireTileBytes + kLocalTileBytes;
+  static constexpr std::size_t kRecvHeaderBytes = 256;
+  static constexpr std::size_t kRecvSmemBytes =
+      kRecvHeaderBytes + kRecvStages * kRecvStageBytes;
+  __host__ __device__ static constexpr std::size_t smem_bytes() {
+    return kTmaRecv ? (kSendSmemBytes + kRecvSmemBytes) : 0;
+  }
+
+  static_assert(
+      kRecvTileElems % 8u == 0u,
+      "tile must keep both the bf16 (2B) and fp32 (4B) sub-tiles a multiple of "
+      "16 bytes for cp.async.bulk");
+  static_assert(
+      kRecvStageBytes % 128u == 0u,
+      "stage stride must preserve 128B alignment of every tile");
+  static_assert(
+      kRecvStageBytes < (1u << 20),
+      "per-stage expect_tx must stay inside the mbarrier tx-count range");
+
   struct Args {
     const float* sender_input_base;
     const float* receiver_input_base;
@@ -255,8 +417,8 @@ struct QuantizedReduceScatterCopyOp {
     const std::uint32_t rtid =
         static_cast<std::uint32_t>(group.thread_id_in_group);
     const std::uint32_t rstride = static_cast<std::uint32_t>(group.group_size);
-    // Load both adjacent packs before either store because input may alias
-    // output after the first peer step.
+    // cp.async.bulk needs 16B-aligned global src/dst and 16B-multiple sizes;
+    // this is exactly the existing quad-aligned predicate.
     const bool quadAligned =
         (reinterpret_cast<std::uintptr_t>(stagingBf16) % alignof(uint4)) == 0 &&
         (reinterpret_cast<std::uintptr_t>(
@@ -265,10 +427,194 @@ struct QuantizedReduceScatterCopyOp {
         (reinterpret_cast<std::uintptr_t>(
              args.receiver_output_base + elementOffset) %
          alignof(uint4)) == 0;
+
+#if COMMS_PRIMS_QUANT_TMA_AVAILABLE
+    if constexpr (kTmaRecv) {
+      // Every tile boundary lands on a multiple of 8 elements, which keeps the
+      // bf16 sub-tile a multiple of 16B and the fp32 sub-tile a multiple of
+      // 32B.
+      const std::size_t alignedElems = (elementCount / 8u) * 8u;
+      if (quadAligned && alignedElems >= kRecvTileElems) {
+        extern __shared__ __align__(128) char quant_dyn_smem[];
+        char* recvBase = quant_dyn_smem + kSendSmemBytes;
+        auto* bar = reinterpret_cast<std::uint64_t*>(recvBase);
+        char* tileBase = recvBase + kRecvStages * sizeof(std::uint64_t);
+        // Dynamic smem is only guaranteed 16B-aligned; TMA destinations want
+        // 128.
+        tileBase +=
+            (128u -
+             (static_cast<std::uintptr_t>(__cvta_generic_to_shared(tileBase)) %
+              128u)) %
+            128u;
+
+        // Only the recv group participates. An mbarrier's arrive-count is a
+        // property of the object, not of the CTA, so a proper subset of threads
+        // may own it: the leader is the sole arriver (count 1) and every other
+        // recv thread is a pure waiter (try_wait is not an arrival).
+        if (group.is_leader()) {
+#pragma unroll
+          for (std::uint32_t s = 0; s < kRecvStages; ++s) {
+            quant_tma::mbarrier_init(&bar[s], 1u);
+          }
+          quant_tma::fence_proxy_async_shared();
+        }
+        group.sync(); // named barrier for THIS group; never __syncthreads()
+
+        const std::uint32_t tiles = static_cast<std::uint32_t>(
+            (alignedElems + kRecvTileElems - 1u) / kRecvTileElems);
+
+        auto tile_elems = [&](std::uint32_t t) -> std::uint32_t {
+          const std::size_t off = static_cast<std::size_t>(t) * kRecvTileElems;
+          return static_cast<std::uint32_t>(
+              (off + kRecvTileElems <= alignedElems) ? kRecvTileElems
+                                                     : (alignedElems - off));
+        };
+
+        // Leader-only. The leader is also the thread that acquired DATA_READY
+        // in the transport, so fence.proxy.async.global here orders that
+        // generic acquire ahead of the async-proxy reads of the same bytes.
+        auto issue = [&](std::uint32_t t) {
+          if (!group.is_leader()) {
+            return;
+          }
+          const std::size_t off = static_cast<std::size_t>(t) * kRecvTileElems;
+          const std::uint32_t elems = tile_elems(t);
+          const std::uint32_t wireBytes =
+              elems * static_cast<std::uint32_t>(sizeof(__nv_bfloat16));
+          const std::uint32_t localBytes =
+              elems * static_cast<std::uint32_t>(sizeof(float));
+          char* dst = tileBase + (t % kRecvStages) * kRecvStageBytes;
+          // The sole arrival is fused into expect_tx, so the phase cannot flip
+          // before the transaction count is registered; either order is
+          // correct. Kept ahead of the copies to match CUTLASS and FA3.
+          quant_tma::mbarrier_arrive_expect_tx(
+              &bar[t % kRecvStages], wireBytes + localBytes);
+          quant_tma::bulk_load(
+              dst, stagingBf16 + off, wireBytes, &bar[t % kRecvStages]);
+          quant_tma::bulk_load(
+              dst + kWireTileBytes,
+              args.receiver_input_base + elementOffset + off,
+              localBytes,
+              &bar[t % kRecvStages]);
+        };
+
+        // Orders the leader's generic-proxy DATA_READY acquire, performed once
+        // in the transport before this call, ahead of every async-proxy read it
+        // issues below. One fence per call is sufficient: no further
+        // generic-proxy read of the staged bytes happens in between.
+        if (group.is_leader()) {
+          quant_tma::fence_proxy_async_global();
+        }
+
+        constexpr std::uint32_t kPrefetch = kRecvStages - 1u;
+        for (std::uint32_t u = 0; u < kPrefetch && u < tiles; ++u) {
+          issue(u);
+        }
+        for (std::uint32_t t = 0; t < tiles; ++t) {
+          // Refills stage (t + kRecvStages - 1) % kRecvStages == (t-1) %
+          // kRecvStages, which was last read in iteration t-1 and released by
+          // that iteration's trailing group.sync().
+          if (t + kPrefetch < tiles) {
+            issue(t + kPrefetch);
+          }
+          const std::uint32_t s = t % kRecvStages;
+          const std::uint32_t phase = (t / kRecvStages) & 1u;
+          // Every other wait in this transport is bounded. Without this a stuck
+          // TMA hangs the CTA with no rank/channel/tile diagnostic and the job
+          // only dies to an external watchdog.
+          std::uint64_t spins = 0;
+          while (!quant_tma::mbarrier_try_wait_parity(&bar[s], phase)) {
+            if ((++spins & 0xFFFFFFULL) == 0) {
+              printf(
+                  "[PIPES] FATAL: quant TMA recv stalled: tile=%u/%u stage=%u "
+                  "parity=%u\n",
+                  t,
+                  tiles,
+                  s,
+                  phase);
+              PIPES_DEVICE_TRAP();
+            }
+          }
+
+          const char* src = tileBase + s * kRecvStageBytes;
+          const uint2* wireS = reinterpret_cast<const uint2*>(src);
+          const float4* localS =
+              reinterpret_cast<const float4*>(src + kWireTileBytes);
+          const std::size_t off = static_cast<std::size_t>(t) * kRecvTileElems;
+          float4* outT = outPacks + (off / 4u);
+          const std::uint32_t vecs = tile_elems(t) / 4u;
+
+          std::uint32_t j = rtid;
+          for (; j + (kRecvSmemUnroll - 1u) * rstride < vecs;
+               j += kRecvSmemUnroll * rstride) {
+            uint2 sv[kRecvSmemUnroll];
+            float4 lv[kRecvSmemUnroll];
+#pragma unroll
+            for (std::uint32_t u = 0; u < kRecvSmemUnroll; ++u) {
+              sv[u] = wireS[j + u * rstride];
+              lv[u] = localS[j + u * rstride];
+            }
+#pragma unroll
+            for (std::uint32_t u = 0; u < kRecvSmemUnroll; ++u) {
+              const float2 lo = __bfloat1622float2(
+                  *reinterpret_cast<const __nv_bfloat162*>(&sv[u].x));
+              const float2 hi = __bfloat1622float2(
+                  *reinterpret_cast<const __nv_bfloat162*>(&sv[u].y));
+              outT[j + u * rstride] = make_float4(
+                  lo.x + lv[u].x,
+                  lo.y + lv[u].y,
+                  hi.x + lv[u].z,
+                  hi.y + lv[u].w);
+            }
+          }
+          for (; j < vecs; j += rstride) {
+            const uint2 s0 = wireS[j];
+            const float4 l0 = localS[j];
+            const float2 lo = __bfloat1622float2(
+                *reinterpret_cast<const __nv_bfloat162*>(&s0.x));
+            const float2 hi = __bfloat1622float2(
+                *reinterpret_cast<const __nv_bfloat162*>(&s0.y));
+            outT[j] =
+                make_float4(lo.x + l0.x, lo.y + l0.y, hi.x + l0.z, hi.y + l0.w);
+          }
+          // Fence first (per-thread: publishes THIS thread's reads of stage s),
+          // sync second (cross-thread edge). The reverse order does not order
+          // the other threads' reads against the TMA that overwrites this stage
+          // on tile t+kRecvStages, and is a real bug.
+          quant_tma::fence_proxy_async_shared();
+          group.sync(); // releases stage s for reuse by tile t+kRecvStages
+        }
+
+        if (group.is_leader()) {
+#pragma unroll
+          for (std::uint32_t s = 0; s < kRecvStages; ++s) {
+            quant_tma::mbarrier_inval(&bar[s]);
+          }
+        }
+
+        for (std::size_t i = alignedElems + group.thread_id_in_group;
+             i < elementCount;
+             i += group.group_size) {
+          const std::size_t element = elementOffset + i;
+          args.receiver_output_base[element] =
+              __bfloat162float(stagingBf16[i]) +
+              args.receiver_input_base[element];
+        }
+        // receiver_input_base aliases receiver_output_base from peer step 1 on,
+        // so every thread must publish its output stores to the async proxy
+        // before the next step's TMA reads them back as the accumulator. Once
+        // per call: within a call, tile t's stores and tile t+1's TMA reads
+        // cover disjoint bytes.
+        quant_tma::fence_proxy_async_global();
+        return nbytes;
+      }
+    }
+#endif // COMMS_PRIMS_QUANT_TMA_AVAILABLE
+
+    // ---- fallback: v9_s2_r5 register path (unaligned or sub-tile chunks) ----
+    // Load both adjacent packs before either store because input may alias
+    // output after the first peer step.
     const std::uint32_t pairCount = quadAligned ? rpackCount / 2u : 0u;
-    // Independent pairs kept in flight per thread. All loads of the group are
-    // issued before any store because receiver_input_base aliases
-    // receiver_output_base once accumulation is in place.
     constexpr std::uint32_t kRecvUnroll = 5;
     const std::uint32_t unrollSpan = rstride * kRecvUnroll;
     std::uint32_t pr = rtid;
@@ -341,9 +687,23 @@ struct QuantizedReduceScatterCopyOp {
       args.receiver_output_base[element] =
           __bfloat162float(stagingBf16[i]) + args.receiver_input_base[element];
     }
+#if COMMS_PRIMS_QUANT_TMA_AVAILABLE
+    // A chunk that fell back to the register path still writes the accumulator
+    // that a later, TMA-eligible chunk reads back through the async proxy.
+    if constexpr (kTmaRecv) {
+      quant_tma::fence_proxy_async_global();
+    }
+#endif
 #endif
     return nbytes;
   }
 };
 
+using QuantizedReduceScatterCopyOp = QuantizedReduceScatterCopyOpT<true>;
+using QuantizedReduceScatterCopyOpNoTma = QuantizedReduceScatterCopyOpT<false>;
+
 } // namespace comms::prims
+
+// File-scoped by definition; do not leak it to translation units that include
+// this header.
+#undef COMMS_PRIMS_QUANT_TMA_AVAILABLE

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3235,6 +3235,17 @@ cvars:
      Maximum number of logical CUDA blocks used by MCCL collectives that
      support message-size-based block tuning.
 
+ - name        : MCCL_PRIMS_TMA
+   type        : bool
+   default     : true
+   description : |-
+     Use Blackwell bulk TMA (cp.async.bulk) to stage the receive operands of the
+     quantized prims ReduceScatter through shared memory. Ignored on devices
+     below compute capability 10.0 and on any device that cannot opt into the
+     required dynamic shared memory; those fall back to the register load path,
+     which is functionally identical but slower. This is a kill switch for the
+     TMA path.
+
  - name        : MCCL_ABORT_TIMEOUT_MS
    type        : float
    default     : 30000.0


### PR DESCRIPTION
Summary:

Builds on the previous commit. Stages both receive operands - the BF16 wire
staging buffer and the FP32 accumulator - into shared memory with descriptorless
1-D bulk TMA (`cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes`)
instead of per-thread global loads, and grows the block to 768 threads with a
640 send / 128 receive split.

Why this helps: the receive path was limited by memory-level parallelism, and
every in-flight load needed a register to land in. Measured unconstrained
register demand is 159/thread against a ptxas cap of 96 at 640 threads, so
receive parallelism was capped by the register file. A bulk copy needs one
thread to issue a descriptor and no registers for the payload, which both
removes that cap and shrinks the receive group from 160 threads to 128, freeing
the rest for the send side.

Arithmetic is untouched: per element the receive still computes
`out[e] = bf16_to_float(wire[e]) + local[e]` once per peer step, in the existing
`(step + channel) % (W - 1)` peer order. TMA only changes how the operands reach
registers, so the output is bit-identical to the previous commit and reproducible
run to run - which quantized reduction requires, since it is not associative.

Async-proxy ordering, per tile, issued entirely by the receive-group leader
(the same thread that performs the system-scope DATA_READY acquire, since proxy
fences are per-thread):

  fence.proxy.async.shared::cta
  fence.proxy.async.global
  mbarrier.arrive.expect_tx(wireBytes + localBytes)
  cp.async.bulk(wire)  +  cp.async.bulk(local)

with all receive threads doing `mbarrier.try_wait.parity.acquire`, reading shared
memory, then `group.sync()`. The acquire on barrier completion is what makes the
async-proxy writes visible to generic-proxy reads. Stage reuse is released by the
trailing `group.sync()`. `group.sync()` is a named barrier - `__syncthreads()`
would hang, because the send and receive warp groups run concurrently and only a
subset of the block reaches any given barrier. The barrier is arrived at by a
single thread, so the arrive count is independent of the receive thread count.

`cp.async.bulk` and the mbarrier ops assemble for the generic `sm_103` target we
build with; no `sm_103a` target is required. Verified by disassembly (`UBLKCP.S.G`,
`SYNCS.ARRIVE.TRANS64`, `SYNCS.PHASECHK.TRANS64.TRYWAIT`, `FENCE.VIEW.ASYNC.*`).

Non-16-byte-aligned or short chunks fall back to the existing register path.

busbw is BF16 wire GB/s at 2 GiB. Cumulative over both commits:

| ranks | blocks | baseline | prev commit | this commit |
|-------|--------|----------|-------------|-------------|
| 4     | 8      | 55.39    | 72.85       | 81.64       |
| 4     | 12     | 76.34    | 89.76       | 90.48       |
| 4     | 16     | 89.11    | 90.92       | 91.20       |
| 8     | 8      | 55.87    | 73.35       | 80.82       |
| 8     | 12     | 76.84    | 86.50       | 88.18       |
| 8     | 16     | -        | 89.27       | 90.39       |

At 8 blocks this is 99% of an ablation ceiling measured by stripping both CopyOps
to minimal work (82.44), so little headroom remains without changing the memory
shapes themselves.

DRAFT - not for review yet. An async-proxy correctness audit against internal
prior art is still outstanding.

Differential Revision: D114676079


