### PR TITLE
Fold own-chunk NVL barrier into PipeStart

### DIFF
--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -310,6 +310,11 @@ commResult_t AlgoImpl::execPipeline(
   if (nLocalRanks > 1) {
     // - Step 0: Broadcast local chunk to intra-node peers
     // Copy data to other local ranks
+    //
+    // The own-chunk barrier (cross-iteration WAR guard) is folded into
+    // ncclKernelAllGatherPPipeStart, saving a separate ncclKernelNvlBarrier
+    // launch. PipeStart is only submitted when nNodes > 1, so the single-node
+    // case must still emit the standalone barrier here.
     FB_COMMCHECK(nvlCeBcast(
         comm_,
         sendbuff,
@@ -318,7 +323,7 @@ commResult_t AlgoImpl::execPipeline(
         pArgs.remoteRecvBuffs,
         pArgs.remoteAccessKeys,
         stream_,
-        /*barrier=*/true,
+        /*barrier=*/nNodes == 1,
         pArgs.mcWrite));
 
     const int upPeer = (nRanks + myRank - nLocalRanks) % nRanks;

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cu
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cu
@@ -16,14 +16,29 @@ namespace ctran::allgatherp {
 // transfer.
 // Used when nLocalRanks > 1 in allgatherP pipeline algorithm. It is called once
 // to start the algorithm
+//
+// Also carries the own-chunk intra-node barrier that the following nvlCeBcast
+// would otherwise launch as a separate ncclKernelNvlBarrier, saving one kernel
+// (one graph node under capture). Folding it in is free: that standalone kernel
+// does the same devStateLoadToShm + barrier, so the ~67KB shared-memory load
+// moves rather than being added.
 __global__ void ncclKernelAllGatherPPipeStart(
     ctran::gpe::KernelFlagDev* f,
     CtranAlgoDeviceState* devState) {
   ctran::device::ColltraceEventScope colltraceScope(f);
   int* flag = f ? const_cast<int*>(f->flag_) : nullptr;
   if (flag) {
+    // Kick GPE first: barriering before this would let a rank that is late to
+    // the barrier delay every peer's inter-node start, which is exactly the
+    // overlap this kernel exists to preserve.
     ctran::device::KernelStartGpeAndExit(f);
   }
+  if (flag) {
+    devStateLoadToShm(flag, devState);
+  } else {
+    devStateLoadToShm(devState);
+  }
+  barrier(statex->localRank(), statex->nLocalRanks());
 }
 
 // Kernel to block intranode CE copies on the stream till GPE thread has
@@ -103,6 +118,12 @@ __global__ void ncclKernelAllGatherPSrdPipeStart(
   if (flag) {
     ctran::device::KernelStartGpeAndExit(f);
   }
+  if (flag) {
+    devStateLoadToShm(flag, devState);
+  } else {
+    devStateLoadToShm(devState);
+  }
+  barrier(statex->localRank(), statex->nLocalRanks());
 }
 
 __global__ void ncclKernelAllGatherPSrdPipeSync(

--- a/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
@@ -314,6 +314,11 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
   }
 
   if (nLocalRanks > 1) {
+    // The own-chunk barrier (cross-iteration WAR guard) is folded into
+    // ncclKernelAllGatherPSrdPipeStart, saving a separate ncclKernelNvlBarrier
+    // launch. PipeStart is only submitted when nNodes > 1, so the single-node
+    // case must still emit the standalone barrier here: exactly one of the two
+    // must emit it.
     FB_COMMCHECK(nvlCeBcast(
         comm_,
         sendbuff,
@@ -322,7 +327,7 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
         pArgs.remoteRecvBuffs,
         pArgs.remoteAccessKeys,
         stream_,
-        /*barrier=*/true,
+        /*barrier=*/nNodes == 1,
         pArgs.mcWrite));
 
     for (int step = 0; step < recvPlan.nSteps(); step++) {


### PR DESCRIPTION
Summary:
AllGatherP's own-chunk intra-node barrier is launched as a standalone
ncclKernelNvlBarrier before the first nvlCeBcast. Fold it into the PipeStart GPE
kernel instead, saving one kernel launch (one node under CUDA graph capture) per
collective. Unconditional: the fold is a pure kernel-launch saving with
identical semantics, so there is no cvar to gate it.

Free to fold: ncclKernelNvlBarrier is just devStateLoadToShm + barrier, so the
~67KB shared-memory load moves into PipeStart rather than being added. PipeStart
already gets sizeof(CtranAlgoDeviceState) of dynamic shmem -- CtranGpeImpl.cc
sets it for every GPE kernel.

The barrier runs after KernelStartGpeAndExit, so the inter-node pipeline still
starts before any rank can be held at the barrier -- that overlap is why
PipeStart exists. It also passes the real kernel flag to devStateLoadToShm, so
the fused barrier is host-abortable (PipeEnd's uses placeHolderKernelFlag and is
not).

PipeStart is only submitted for nNodes > 1, so nNodes == 1 keeps the standalone
barrier -- hence the /*barrier=*/nNodes == 1 on the nvlCeBcast call: exactly one
of the two sites must emit it. Live only for nLocalRanks > 1 && nNodes > 1 on the
pipeline and SRD variants, reachable from ctwin or ctgraph; no effect on ctdirect
or the nLocalRanks == 1 variants.

Differential Revision: D114769368


