### PR TITLE
Make the device handle layout independent of WritePolicy (#3443)

### DIFF
--- a/comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h
+++ b/comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h
@@ -73,6 +73,7 @@ struct Nothing {
 
 // define_if<Cond, T> is T when Cond, otherwise an empty Nothing<T>.
 // Pair with [[no_unique_address]] so the absent member costs zero bytes.
+// Host-only: nvcc 13.0-13.2 mis-offsets device-side fields that follow one.
 template <bool Cond, typename T>
 using define_if = std::conditional_t<Cond, T, Nothing<T>>;
 
@@ -430,12 +431,13 @@ struct HRDWRingBufferDeviceHandle {
   uint64_t* writeIndex;
   uint32_t mask;
   uint32_t shift;
-  [[no_unique_address]] detail::
-      define_if<W == WritePolicy::Blocking, const uint64_t*> readIndex;
-  [[no_unique_address]] detail::
-      define_if<W == WritePolicy::Blocking, const uint32_t*> abort;
-  [[no_unique_address]] detail::define_if<W == WritePolicy::Blocking, uint32_t>
-      spinBackoffNanos;
+  // Blocking-only, but declared unconditionally and without
+  // [[no_unique_address]]: nvcc 13.0-13.2 mis-offsets fields following such a
+  // member on device. One layout for both policies, 24 bytes wasted on
+  // Overwrite. The host-side ring below is unaffected and keeps the attribute.
+  const uint64_t* readIndex;
+  const uint32_t* abort;
+  uint32_t spinBackoffNanos;
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
   __device__ __forceinline__ void write(DataT data) {
@@ -471,11 +473,12 @@ static_assert(
         std::is_trivially_copyable_v<BlockingHandleProbe>,
     "device handle must stay trivially copyable - it is passed by value to kernels");
 static_assert(
-    sizeof(OverwriteHandleProbe) == 24,
-    "Overwrite device handle regressed: expected 2 pointers + 2 uint32s = 24 bytes");
+    sizeof(OverwriteHandleProbe) == sizeof(BlockingHandleProbe),
+    "device handle layout must not depend on WritePolicy; see the note on "
+    "HRDWRingBufferDeviceHandle");
 static_assert(
     sizeof(BlockingHandleProbe) == 48,
-    "Blocking device handle regressed: expected Overwrite + readIndex + abort + spin = 48 bytes");
+    "device handle regressed: expected 2 pointers + 2 uint32s + readIndex + abort + spin = 48 bytes");
 } // namespace detail
 
 // Templated kernel launch for host-side write(). The template definition


### PR DESCRIPTION
Summary:

`HRDWRingBufferDeviceHandle` declared its three Blocking-only members via
`detail::define_if` + `[[no_unique_address]]`, so on `WritePolicy::Overwrite`
they collapsed to zero bytes. That is exactly the construct nvcc 13.0-13.2
mishandles: it computes a different device-side offset than the host for any
field following a `[[no_unique_address]]` empty member. `ColltraceDeviceHandle`
already works around one instance of this by pinning its scalars ahead of the
embedded ring handle (see the layout note there), and
`comms/ncclx/v2_30/src/include/device.h` compiles `colltraceHdr` out of
`ncclDevKernelArgs` entirely on those toolkits for the same reason.

Declare the three members unconditionally and without the attribute. Both write
policies now have one layout that host and device compilers agree on for every
toolkit, and there is no conditionally-present member left for a future nvcc to
disagree about. Overwrite handles grow 24 -> 48 bytes; `ncclDevKernelArgs` has a
4 KiB budget (`ncclMaxKernelArgsSize`), so the trailing inline work-batch region
loses the difference. Overwrite kernels never read the added members.

The size assertion now pins the invariant that matters — that the layout does
not depend on `WritePolicy` — rather than a per-policy magic number.

The host-side `HRDWRingBuffer` class keeps its `[[no_unique_address]]` members:
that object never crosses to device code, so it is unaffected and the bytes are
worth saving. `detail::define_if`'s doc comment now says so explicitly.

This does not by itself re-enable in-kernel colltrace on CUDA 13.0-13.2; the
`device.h` gate is a separate change.

Reviewed By: pavanbalaji

Differential Revision: D114821473


