### PR TITLE
Drop the CUDA 13.0-13.2 carve-out from the in-kernel colltrace gate (#3444)

### DIFF
--- a/comms/ctran/tests/cudagraph/CtranCudaGraphColltraceTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphColltraceTest.cc
@@ -34,8 +34,8 @@ class CtranCudaGraphColltraceTest : public CtranCudaGraphTestBase {
         });
     if (!meta::comms::colltrace::graphColltraceSupported(
             "CtranCudaGraphColltraceTest")) {
-      GTEST_SKIP() << "graph colltrace unsupported on this device/driver "
-                      "(needs sm_90+ and a CUDA driver outside 13.0-13.2)";
+      GTEST_SKIP()
+          << "graph colltrace unsupported on this device (needs sm_90+)";
     }
   }
 

--- a/comms/ncclx/meta/colltrace/tests/BaselineCudaGraphColltraceTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/BaselineCudaGraphColltraceTest.cc
@@ -44,8 +44,8 @@ class BaselineCudaGraphColltraceTest : public NcclxBaseTestFixture {
     CUDACHECK_TEST(cudaStreamCreate(&stream_));
     if (!meta::comms::colltrace::graphColltraceSupported(
             "BaselineCudaGraphColltraceTest")) {
-      GTEST_SKIP() << "graph colltrace unsupported on this device/driver "
-                      "(needs sm_90+ and a CUDA driver outside 13.0-13.2)";
+      GTEST_SKIP()
+          << "graph colltrace unsupported on this device (needs sm_90+)";
     }
   }
 

--- a/comms/ncclx/v2_29/src/include/device.h
+++ b/comms/ncclx/v2_29/src/include/device.h
@@ -14,15 +14,11 @@
 #include "bitops.h"
 // [META] In-kernel colltrace gate. Defined here, and used by every reference to
 // colltraceHdr (see common.h and CollTraceWrapper.cc), so ncclDevKernelArgs has
-// one layout across all TUs. Compiled out when either:
-//   - AMD: see the note on device_object's exported_deps in
-//     comms/ncclx/nccl_build_config.bzl.
-//   - CUDA 13.0-13.2: an nvcc [[no_unique_address]] device-layout bug (fixed in
-//     13.3) misaligns the args->__shared__ copy of ncclDevKernelArgs, so any
-//     kernel launch carrying these args faults with cudaErrorMisalignedAddress.
-//     CUDART_VERSION comes from nccl.h above.
-#if !defined(NCCLX_NO_INKERNEL_COLLTRACE) && \
-    !(CUDART_VERSION >= 13000 && CUDART_VERSION < 13030)
+// one layout across all TUs. Compiled out only on AMD: see the note on
+// device_object's exported_deps in comms/ncclx/nccl_build_config.bzl.
+// (A CUDA 13.0-13.2 carve-out used to live here; the layout bug behind it is
+// fixed in HRDWRingBufferDeviceHandle.)
+#if !defined(NCCLX_NO_INKERNEL_COLLTRACE)
 #define NCCLX_INKERNEL_COLLTRACE 1
 #endif
 

--- a/comms/ncclx/v2_30/src/include/device.h
+++ b/comms/ncclx/v2_30/src/include/device.h
@@ -14,15 +14,11 @@
 #include "bitops.h"
 // [META] In-kernel colltrace gate. Defined here, and used by every reference to
 // colltraceHdr (see common.h and CollTraceWrapper.cc), so ncclDevKernelArgs has
-// one layout across all TUs. Compiled out when either:
-//   - AMD: see the note on device_object's exported_deps in
-//     comms/ncclx/nccl_build_config.bzl.
-//   - CUDA 13.0-13.2: an nvcc [[no_unique_address]] device-layout bug (fixed in
-//     13.3) misaligns the args->__shared__ copy of ncclDevKernelArgs, so any
-//     kernel launch carrying these args faults with cudaErrorMisalignedAddress.
-//     CUDART_VERSION comes from nccl.h above.
-#if !defined(NCCLX_NO_INKERNEL_COLLTRACE) && \
-    !(CUDART_VERSION >= 13000 && CUDART_VERSION < 13030)
+// one layout across all TUs. Compiled out only on AMD: see the note on
+// device_object's exported_deps in comms/ncclx/nccl_build_config.bzl.
+// (A CUDA 13.0-13.2 carve-out used to live here; the layout bug behind it is
+// fixed in HRDWRingBufferDeviceHandle.)
+#if !defined(NCCLX_NO_INKERNEL_COLLTRACE)
 #define NCCLX_INKERNEL_COLLTRACE 1
 #endif
 

--- a/comms/torchcomms/ncclx/tests/integration/cpp/ColltraceGraphWatchdogTest.cpp
+++ b/comms/torchcomms/ncclx/tests/integration/cpp/ColltraceGraphWatchdogTest.cpp
@@ -66,8 +66,8 @@ class ColltraceGraphWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
     // created, so no replay can time out and there is nothing to assert.
     if (!meta::comms::colltrace::graphColltraceSupported(
             "ColltraceGraphWatchdogTest")) {
-      GTEST_SKIP() << "graph colltrace unsupported on this device/driver "
-                      "(needs sm_90+ and a CUDA driver outside 13.0-13.2)";
+      GTEST_SKIP()
+          << "graph colltrace unsupported on this device (needs sm_90+)";
     }
   }
 
@@ -187,14 +187,6 @@ TEST_F(ColltraceGraphWatchdogTest, TestTimeoutViaTorchCommsInit) {
 // Captures an AllReduce into a CUDA graph via TorchComms, replays it, and
 // verifies the colltrace watchdog detects a timeout during graph replay.
 TEST_F(ColltraceGraphWatchdogTest, TestGraphReplayTimeout) {
-#if CUDART_VERSION >= 13000 && CUDART_VERSION < 13030
-  // The in-kernel colltrace graph path this exercises is compiled out on CUDA
-  // 13.0-13.2 (nvcc [[no_unique_address]] layout bug, fixed in 13.3; see the
-  // colltraceHdr gate in comms/ncclx/v2_30/src/include/device.h). With the
-  // primary GraphEventTracker also disabled in SetUp, there is no graph-replay
-  // timeout detector left to test here.
-  GTEST_SKIP() << "in-kernel colltrace graph path disabled on CUDA 13.0-13.2";
-#endif
   if (isTestDriverProcess()) {
     testDriverCheckCrashedWithWatchdog();
     return;
@@ -266,12 +258,6 @@ TEST_F(ColltraceGraphWatchdogTest, TestGraphReplayTimeout) {
 TEST_F(
     ColltraceGraphWatchdogTest,
     TestGraphReplayTimeoutAfterSuccessfulReplays) {
-#if CUDART_VERSION >= 13000 && CUDART_VERSION < 13030
-  // In-kernel colltrace graph path is compiled out on CUDA 13.0-13.2 (nvcc
-  // [[no_unique_address]] layout bug, fixed in 13.3); nothing to test here with
-  // GraphEventTracker also disabled in SetUp. See device.h colltraceHdr gate.
-  GTEST_SKIP() << "in-kernel colltrace graph path disabled on CUDA 13.0-13.2";
-#endif
   if (isTestDriverProcess()) {
     testDriverCheckCrashedWithWatchdog();
     return;

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -37,11 +37,11 @@ void
   delete sp;
 }
 
-// Why graph colltrace cannot run here, or empty if it can. Both inputs are
-// fixed for the process -- the driver version is per-process, and the compute
-// capability is read from the current device, which assumes a homogeneous-GPU
-// host (true across the fleet; a mixed sm_80/sm_90 host would get whichever
-// device was current on the first call). So this is computed exactly once.
+// Why graph colltrace cannot run here, or empty if it can. The input is fixed
+// for the process: the compute capability is read from the current device,
+// which assumes a homogeneous-GPU host (true across the fleet; a mixed
+// sm_80/sm_90 host would get whichever device was current on the first call).
+// So this is computed exactly once.
 // The lambda captures nothing on purpose: a static whose initializer reads a
 // function argument would bind the first caller's value forever, which is both
 // a dangling-reference hazard and a clang-tidy
@@ -66,15 +66,9 @@ const std::string& graphColltraceUnsupportedReason() {
           device,
           ccMajor);
     }
-    int driverVersion = 0;
-    if (cudaDriverGetVersion(&driverVersion) == cudaSuccess &&
-        driverVersion >= 13000 && driverVersion < 13030) {
-      return fmt::format(
-          "CUDA driver {} is in 13.0-13.2, which miscompiles the device "
-          "ring-write handle; graph collectives will be untimed. Please use a "
-          "compatible version if you want colltrace graph support.",
-          driverVersion);
-    }
+    // No driver-version check: the 13.0-13.2 rejection that used to live here
+    // guarded the [[no_unique_address]] layout bug now fixed in
+    // HRDWRingBufferDeviceHandle.
     return std::string{};
   }();
   return reason;

--- a/comms/utils/colltrace/tests/GraphCollTraceUT.cc
+++ b/comms/utils/colltrace/tests/GraphCollTraceUT.cc
@@ -161,8 +161,8 @@ class GraphColltraceProgressingTest : public ::testing::Test {
     cudaSetDevice(0);
     if (!meta::comms::colltrace::graphColltraceSupported(
             "GraphColltraceProgressingTest")) {
-      GTEST_SKIP() << "graph colltrace unsupported on this device/driver "
-                      "(needs sm_90+ and a CUDA driver outside 13.0-13.2)";
+      GTEST_SKIP()
+          << "graph colltrace unsupported on this device (needs sm_90+)";
     }
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
     cudaStreamCreate(&stream_);

--- a/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
+++ b/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
@@ -70,8 +70,8 @@ class GraphColltraceReplayTest : public ::testing::Test {
     cudaSetDevice(0);
     if (!meta::comms::colltrace::graphColltraceSupported(
             "GraphColltraceReplayTest")) {
-      GTEST_SKIP() << "graph colltrace unsupported on this device/driver "
-                      "(needs sm_90+ and a CUDA driver outside 13.0-13.2)";
+      GTEST_SKIP()
+          << "graph colltrace unsupported on this device (needs sm_90+)";
     }
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
     cudaStreamCreate(&stream_);

--- a/comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h
+++ b/comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h
@@ -73,6 +73,7 @@ struct Nothing {
 
 // define_if<Cond, T> is T when Cond, otherwise an empty Nothing<T>.
 // Pair with [[no_unique_address]] so the absent member costs zero bytes.
+// Host-only: nvcc 13.0-13.2 mis-offsets device-side fields that follow one.
 template <bool Cond, typename T>
 using define_if = std::conditional_t<Cond, T, Nothing<T>>;
 
@@ -430,12 +431,13 @@ struct HRDWRingBufferDeviceHandle {
   uint64_t* writeIndex;
   uint32_t mask;
   uint32_t shift;
-  [[no_unique_address]] detail::
-      define_if<W == WritePolicy::Blocking, const uint64_t*> readIndex;
-  [[no_unique_address]] detail::
-      define_if<W == WritePolicy::Blocking, const uint32_t*> abort;
-  [[no_unique_address]] detail::define_if<W == WritePolicy::Blocking, uint32_t>
-      spinBackoffNanos;
+  // Blocking-only, but declared unconditionally and without
+  // [[no_unique_address]]: nvcc 13.0-13.2 mis-offsets fields following such a
+  // member on device. One layout for both policies, 24 bytes wasted on
+  // Overwrite. The host-side ring below is unaffected and keeps the attribute.
+  const uint64_t* readIndex;
+  const uint32_t* abort;
+  uint32_t spinBackoffNanos;
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
   __device__ __forceinline__ void write(DataT data) {
@@ -471,11 +473,12 @@ static_assert(
         std::is_trivially_copyable_v<BlockingHandleProbe>,
     "device handle must stay trivially copyable - it is passed by value to kernels");
 static_assert(
-    sizeof(OverwriteHandleProbe) == 24,
-    "Overwrite device handle regressed: expected 2 pointers + 2 uint32s = 24 bytes");
+    sizeof(OverwriteHandleProbe) == sizeof(BlockingHandleProbe),
+    "device handle layout must not depend on WritePolicy; see the note on "
+    "HRDWRingBufferDeviceHandle");
 static_assert(
     sizeof(BlockingHandleProbe) == 48,
-    "Blocking device handle regressed: expected Overwrite + readIndex + abort + spin = 48 bytes");
+    "device handle regressed: expected 2 pointers + 2 uint32s + readIndex + abort + spin = 48 bytes");
 } // namespace detail
 
 // Templated kernel launch for host-side write(). The template definition


### PR DESCRIPTION
Summary:

`NCCLX_INKERNEL_COLLTRACE` was compiled out on CUDA 13.0-13.2 because an nvcc
`[[no_unique_address]]` device-layout bug misaligned the `args->__shared__` copy
of `ncclDevKernelArgs`, faulting any kernel launch carrying those args with
`cudaErrorMisalignedAddress`. The trigger was the conditionally-present members
of the embedded `HRDWRingBufferDeviceHandle`; the parent commit declares those
unconditionally and without the attribute, so host and device now agree on the
layout for every toolkit.

With the trigger gone the carve-out has no purpose, and keeping it leaves graph
colltrace dead on 13.0-13.2 — which is what ships in the current flagship and
gbunified condas (`cuda-nvcc 13.1.115` / `cuda-cudart 13.1.80`). The gate is now
AMD-only, matching how CTran already handles this: `ctran/algos/common/GpeRing.h`
carries `colltraceHdr` in `KernelFlagDev` unconditionally and gates arming at
runtime on sm_90+ alone.

Reviewed By: pavanbalaji

Differential Revision: D114821756


