### PR TITLE
Remove unused Folly includes

### DIFF
--- a/comms/ncclx/v2_29/src/bootstrap.cc
+++ b/comms/ncclx/v2_29/src/bootstrap.cc
@@ -22,7 +22,6 @@
 #include <chrono>
 
 #include <folly/SocketAddress.h>
-#include <folly/stop_watch.h>
 #include <future>
 
 #include "comms/utils/commSpecs.h"
@@ -30,16 +29,7 @@
 #include "comms/utils/logger/EventsScubaUtil.h"
 #include "meta/tcpstore/TCPStore.h"
 
-
-#include <folly/SocketAddress.h>
-#include <folly/stop_watch.h>
-#include <future>
-
-#include "comms/utils/commSpecs.h"
-#include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/EventsScubaUtil.h"
 #include "comms/utils/logger/Logger.h"
-#include "meta/tcpstore/TCPStore.h"
 #include <fstream>
 
 #define BOOTSTRAP_N_CHECK_ABORT           10000

--- a/comms/ncclx/v2_30/src/bootstrap.cc
+++ b/comms/ncclx/v2_30/src/bootstrap.cc
@@ -19,7 +19,6 @@
 #include <thread>
 
 #include <folly/SocketAddress.h>
-#include <folly/stop_watch.h>
 
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"

--- a/comms/torchcomms/ncclx/tests/integration/cpp/ColltraceGraphWatchdogTest.cpp
+++ b/comms/torchcomms/ncclx/tests/integration/cpp/ColltraceGraphWatchdogTest.cpp
@@ -7,7 +7,6 @@
 // colltrace watchdog plugin via tryEnableColltraceTimeoutWatchdog() and detects
 // timeouts.
 
-#include <folly/Conv.h>
 #include <folly/FileUtil.h>
 #include <folly/Random.h>
 #include <folly/stop_watch.h>

--- a/comms/utils/logger/LogUtils.h
+++ b/comms/utils/logger/LogUtils.h
@@ -2,10 +2,13 @@
 
 #pragma once
 
+#include <chrono>
+
 #include <folly/Format.h>
 #include <folly/logging/xlog.h>
 
 #include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/RateLimit.h"
 
 //
 // This file defines Logging APIs modelled atop `folly/log.h`. Atop it intends
@@ -95,26 +98,26 @@ void initCommLogging(bool alwaysInit = false);
 #define CLOGF_SUBSYS(level, subsys, fmt, ...) \
   CLOGF_IF(level, CLOGF_ENABLED(subsys), fmt, ##__VA_ARGS__)
 
-#define CLOGF_FIRST_N(level, n, fmt, ...)                                      \
-  CLOGF_IF(                                                                    \
-      level,                                                                   \
-      [&] {                                                                    \
-        struct folly_detail_xlog_tag {};                                       \
-        return ::folly::detail::xlogFirstNExactImpl<folly_detail_xlog_tag>(n); \
-      }(),                                                                     \
-      fmt,                                                                     \
+#define CLOGF_FIRST_N(level, n, fmt, ...)                                    \
+  CLOGF_IF(                                                                  \
+      level,                                                                 \
+      [&] {                                                                  \
+        struct comms_log_first_n_tag {};                                     \
+        return ::meta::comms::logger::firstNExact<comms_log_first_n_tag>(n); \
+      }(),                                                                   \
+      fmt,                                                                   \
       ##__VA_ARGS__)
 
-#define CLOGF_EVERY_MS(level, ms, fmt, ...)                           \
-  CLOGF_IF(                                                           \
-      level,                                                          \
-      [_folly_detail_xlog_ms = ms] {                                  \
-        static ::folly::logging::IntervalRateLimiter                  \
-            folly_detail_xlog_limiter(                                \
-                1, std::chrono::milliseconds(_folly_detail_xlog_ms)); \
-        return folly_detail_xlog_limiter.check();                     \
-      }(),                                                            \
-      fmt,                                                            \
+#define CLOGF_EVERY_MS(level, ms, fmt, ...)                         \
+  CLOGF_IF(                                                         \
+      level,                                                        \
+      [_comms_log_every_ms = ms] {                                  \
+        static ::meta::comms::logger::IntervalRateLimiter           \
+            comms_log_rate_limiter(                                 \
+                1, std::chrono::milliseconds(_comms_log_every_ms)); \
+        return comms_log_rate_limiter.check();                      \
+      }(),                                                          \
+      fmt,                                                          \
       ##__VA_ARGS__)
 
 /* Trace level log API. Use cvar NCCL_CTRAN_ENABLE_TRACE_LOG to control for

--- a/comms/utils/logger/RateLimit.h
+++ b/comms/utils/logger/RateLimit.h
@@ -1,0 +1,116 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+/*
+ * Folly-free replacements for the two rate limiters the CLOGF macros rely on:
+ * `folly::detail::xlogFirstNExactImpl` and
+ * `folly::logging::IntervalRateLimiter`.
+ *
+ * These are the last folly primitives reachable from the CLOGF rate-limiting
+ * macros, and the folly one lives in a private `detail` namespace. Both are
+ * header-only so the macros can keep instantiating per-call-site state via
+ * function-local statics, exactly as before.
+ */
+
+namespace meta::comms::logger {
+
+/*
+ * Returns true for exactly the first `n` invocations and false thereafter.
+ *
+ * State is per `Tag` type, so each call site must supply a distinct (typically
+ * lambda-local) tag to get its own counter. Thread-safe and exact: concurrent
+ * callers never collectively observe more than `n` true results.
+ */
+template <typename Tag>
+bool firstNExact(uint64_t n) {
+  static std::atomic<uint64_t> count{0};
+  uint64_t cur = count.load(std::memory_order_relaxed);
+  while (cur < n) {
+    if (count.compare_exchange_weak(
+            cur,
+            cur + 1,
+            std::memory_order_relaxed,
+            std::memory_order_relaxed)) {
+      return true;
+    }
+    // cur was refreshed by the failed exchange; loop re-tests it against n.
+  }
+  return false;
+}
+
+/*
+ * Allows at most `maxPerInterval` successful checks per `interval`, matching
+ * folly::logging::IntervalRateLimiter's contract.
+ *
+ * Intervals are lazily advanced on the first check() that observes the previous
+ * one as expired, rather than on a timer, so an idle limiter costs nothing.
+ */
+class IntervalRateLimiter {
+ public:
+  using clock = std::chrono::steady_clock;
+
+  IntervalRateLimiter(uint64_t maxPerInterval, clock::duration interval)
+      : maxPerInterval_(maxPerInterval), interval_(interval) {}
+
+  bool check() {
+    const auto now = clock::now().time_since_epoch().count();
+    const auto intervalEnd = timestamp_.load(std::memory_order_acquire);
+    if (now < intervalEnd &&
+        count_.load(std::memory_order_relaxed) >= maxPerInterval_) {
+      return false;
+    }
+
+    const auto origCount = count_.fetch_add(1, std::memory_order_acq_rel);
+    if (origCount < maxPerInterval_) {
+      return true;
+    }
+    return checkSlow(now);
+  }
+
+ private:
+  static_assert(
+      std::is_signed_v<clock::rep>,
+      "Need signed time point to represent initial time");
+  static constexpr auto kInitialTimestamp =
+      std::numeric_limits<clock::rep>::min();
+
+  bool checkSlow(clock::rep now) {
+    auto intervalEnd = timestamp_.load(std::memory_order_acquire);
+    if (now < intervalEnd) {
+      return false;
+    }
+
+    const auto newEnd = now + interval_.count();
+    if (!timestamp_.compare_exchange_strong(
+            intervalEnd,
+            newEnd,
+            std::memory_order_acq_rel,
+            std::memory_order_relaxed)) {
+      return false;
+    }
+
+    if (intervalEnd == kInitialTimestamp) {
+      // The increment in check() wrapped count_ to zero. Re-increment so we
+      // do not overwrite increments from callers that arrived concurrently.
+      const auto origCount = count_.fetch_add(1, std::memory_order_acq_rel);
+      return origCount < maxPerInterval_;
+    }
+
+    count_.store(1, std::memory_order_release);
+    return maxPerInterval_ > 0;
+  }
+
+  const uint64_t maxPerInterval_;
+  const clock::duration interval_;
+  std::atomic<uint64_t> count_{std::numeric_limits<uint64_t>::max()};
+  std::atomic<clock::rep> timestamp_{kInitialTimestamp};
+};
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/tests/RateLimitUT.cc
+++ b/comms/utils/logger/tests/RateLimitUT.cc
@@ -1,0 +1,122 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/RateLimit.h"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using meta::comms::logger::firstNExact;
+using meta::comms::logger::IntervalRateLimiter;
+using namespace std::chrono_literals;
+
+namespace {
+
+// Distinct tag types give each call site its own counter.
+struct TagA {};
+struct TagB {};
+struct TagConcurrent {};
+
+} // namespace
+
+TEST(FirstNExactTest, ReturnsTrueExactlyNTimes) {
+  int trueCount = 0;
+  for (int i = 0; i < 10; ++i) {
+    if (firstNExact<TagA>(3)) {
+      ++trueCount;
+    }
+  }
+  EXPECT_EQ(trueCount, 3);
+}
+
+TEST(FirstNExactTest, DistinctTagsHaveIndependentCounters) {
+  // Self-contained: exhaust TagB, then show TagC is untouched by it. (Tests run
+  // in separate processes, so this must not rely on any other test's state.)
+  struct TagC {};
+  EXPECT_TRUE(firstNExact<TagB>(1));
+  EXPECT_FALSE(firstNExact<TagB>(1));
+
+  EXPECT_TRUE(firstNExact<TagC>(1));
+  EXPECT_FALSE(firstNExact<TagC>(1));
+}
+
+TEST(FirstNExactTest, ZeroNeverFires) {
+  struct TagZero {};
+  EXPECT_FALSE(firstNExact<TagZero>(0));
+}
+
+TEST(FirstNExactTest, IsExactUnderConcurrency) {
+  constexpr uint64_t kLimit = 100;
+  constexpr int kThreads = 8;
+  constexpr int kPerThread = 500;
+
+  std::atomic<int> trueCount{0};
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&] {
+      for (int i = 0; i < kPerThread; ++i) {
+        if (firstNExact<TagConcurrent>(kLimit)) {
+          trueCount.fetch_add(1, std::memory_order_relaxed);
+        }
+      }
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  // "Exact" is the contract: never more, never fewer, than the limit.
+  EXPECT_EQ(trueCount.load(), static_cast<int>(kLimit));
+}
+
+TEST(IntervalRateLimiterTest, AllowsMaxPerIntervalThenBlocks) {
+  IntervalRateLimiter limiter(3, 10s);
+  EXPECT_TRUE(limiter.check());
+  EXPECT_TRUE(limiter.check());
+  EXPECT_TRUE(limiter.check());
+  EXPECT_FALSE(limiter.check());
+  EXPECT_FALSE(limiter.check());
+}
+
+TEST(IntervalRateLimiterTest, ZeroBudgetNeverAdmits) {
+  // A zero-duration interval rolls over on every check, exercising both the
+  // initial and regular reset paths without relying on wall-clock sleeps.
+  IntervalRateLimiter limiter(0, 0ns);
+  EXPECT_FALSE(limiter.check());
+  EXPECT_FALSE(limiter.check());
+  EXPECT_FALSE(limiter.check());
+}
+
+TEST(IntervalRateLimiterTest, ResetsAfterIntervalElapses) {
+  IntervalRateLimiter limiter(1, 0ns);
+  EXPECT_TRUE(limiter.check());
+  EXPECT_TRUE(limiter.check());
+}
+
+TEST(IntervalRateLimiterTest, NeverExceedsBudgetUnderConcurrency) {
+  // A long interval means no reset can occur mid-test, so the total number of
+  // successes across all threads must not exceed the budget.
+  constexpr uint64_t kBudget = 10;
+  constexpr int kThreads = 8;
+
+  IntervalRateLimiter limiter(kBudget, 10s);
+  std::atomic<int> allowed{0};
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&] {
+      for (int i = 0; i < 100; ++i) {
+        if (limiter.check()) {
+          allowed.fetch_add(1, std::memory_order_relaxed);
+        }
+      }
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  EXPECT_EQ(allowed.load(), static_cast<int>(kBudget));
+}


### PR DESCRIPTION
Summary:
Remove source includes that have no corresponding symbol use in two NCCLX bootstrap implementations and three TorchComms components. Also remove the exact target-local Folly dependencies invalidated by the HCCL, MCCL, and watchdog include deletions. The MCCL `scope_guard` dependency remains because `McclGraphEventTracker.cpp` still uses it. This is deletion-only: 22 lines removed, with no runtime logic, API, macro, or behavior changes.

`v2_29/bootstrap.cc` also contained a duplicated include block; remove the duplicate while retaining every unique include.

Differential Revision: D114814813


