### PR TITLE
Add OSS-clean spdlog logging facade (#3447)

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -215,6 +215,11 @@ function build_third_party {
     fi
   fi
 
+  if [[ ! -f "${CMAKE_PREFIX_PATH}/include/spdlog/spdlog.h" ]]; then
+    build_fb_oss_library "https://github.com/gabime/spdlog.git" "v1.16.0" spdlog \
+      "-DSPDLOG_BUILD_SHARED=OFF -DSPDLOG_FMT_EXTERNAL=ON -DSPDLOG_BUILD_EXAMPLE=OFF -DSPDLOG_BUILD_TESTS=OFF"
+  fi
+
   popd
 }
 
@@ -377,7 +382,7 @@ fi
 pushd "${NCCL_HOME}"
 
 function build_nccl {
-  make VERBOSE=1 -j$(nproc) \
+  make VERBOSE=1 -j"${NCCL_BUILD_JOBS:-$(nproc)}" \
     src.build \
     BUILDDIR="$BUILDDIR" \
     NVCC_GENCODE="$NVCC_GENCODE" \
@@ -394,7 +399,7 @@ function build_nccl {
 }
 
 function build_and_install_nccl {
-make VERBOSE=1 -j$(nproc) \
+make VERBOSE=1 -j"${NCCL_BUILD_JOBS:-$(nproc)}" \
     src.install \
     BUILDDIR="$BUILDDIR" \
     NVCC_GENCODE="$NVCC_GENCODE" \

--- a/comms/ctran/CMakeLists.txt
+++ b/comms/ctran/CMakeLists.txt
@@ -36,6 +36,10 @@ add_library(ctran OBJECT
 )
 
 target_compile_features(ctran PRIVATE cxx_std_20)
+target_compile_definitions(ctran PRIVATE
+    SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO
+    SPDLOG_FMT_EXTERNAL
+)
 
 target_compile_options(ctran PRIVATE
     -fPIC

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -23,6 +23,8 @@ include ../makefiles/version.mk
 CXXFLAGS += -DMOCK_SCUBA_DATA -DFOLLY_XLOG_STRIP_PREFIXES=\"${BASE_DIR}\"
 # Use header-only fmt to avoid runtime dependency on libfmt.so
 CXXFLAGS += -DFMT_HEADER_ONLY=1
+CXXFLAGS += -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DSPDLOG_FMT_EXTERNAL
+NVCUFLAGS += -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DSPDLOG_FMT_EXTERNAL
 
 # Enable JSON parsing in the NCCLX built-in CSV/JSON tuner (meta/tuner) when
 # folly is available. The conda feedstock build sets NCCLX_TUNER_WITH_FOLLY_JSON=1

--- a/comms/utils/CMakeLists.txt
+++ b/comms/utils/CMakeLists.txt
@@ -1,6 +1,21 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 find_package(CUDA REQUIRED)
+find_package(spdlog 1.16.0 CONFIG QUIET)
+if(NOT spdlog_FOUND)
+    include(FetchContent)
+    set(SPDLOG_BUILD_SHARED OFF CACHE BOOL "" FORCE)
+    set(SPDLOG_BUILD_PIC ON CACHE BOOL "" FORCE)
+    set(SPDLOG_FMT_EXTERNAL ON CACHE BOOL "" FORCE)
+    set(SPDLOG_BUILD_EXAMPLE OFF CACHE BOOL "" FORCE)
+    set(SPDLOG_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    FetchContent_Declare(
+        spdlog
+        GIT_REPOSITORY https://github.com/gabime/spdlog.git
+        GIT_TAG v1.16.0
+    )
+    FetchContent_MakeAvailable(spdlog)
+endif()
 
 file(GLOB_RECURSE UTILS_SOURCES
     "*.cc"
@@ -23,6 +38,10 @@ target_compile_features(utils PRIVATE cxx_std_20)
 target_compile_options(utils PRIVATE
     -fPIC
 )
+target_compile_definitions(utils PRIVATE
+    SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO
+    SPDLOG_FMT_EXTERNAL
+)
 set_target_properties(utils PROPERTIES
     CUDA_SEPARABLE_COMPILATION ON
     CUDA_RESOLVE_DEVICE_SYMBOLS ON
@@ -33,3 +52,4 @@ target_include_directories(utils PUBLIC
     ${CONDA_INCLUDE}
     ${CUDA_INCLUDE_DIRS}
 )
+target_link_libraries(utils PUBLIC spdlog::spdlog)

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -1,0 +1,37 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/SpdlogLogger.h"
+
+#include <cstddef>
+#include <memory>
+
+#include <spdlog/async.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+
+namespace meta::comms::logger {
+namespace {
+
+constexpr auto kLoggerName = "comms";
+constexpr auto kLogPattern = "%L%m%d %H:%M:%S.%f %t %s:%#] %v";
+constexpr size_t kAsyncQueueSize = 8192;
+constexpr size_t kAsyncThreadCount = 1;
+
+std::shared_ptr<spdlog::logger> createLogger() {
+  if (!spdlog::thread_pool()) {
+    spdlog::init_thread_pool(kAsyncQueueSize, kAsyncThreadCount);
+  }
+
+  auto logger =
+      spdlog::create_async_nb<spdlog::sinks::stderr_color_sink_mt>(kLoggerName);
+  logger->set_pattern(kLogPattern);
+  return logger;
+}
+
+} // namespace
+
+spdlog::logger& getSpdlogLogger() {
+  static auto logger = createLogger();
+  return *logger;
+}
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -1,0 +1,44 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstdlib>
+
+#ifndef SPDLOG_FMT_EXTERNAL
+#error "SpdlogLogger requires SPDLOG_FMT_EXTERNAL from the build target"
+#endif
+
+#ifndef SPDLOG_ACTIVE_LEVEL
+#error "SpdlogLogger requires SPDLOG_ACTIVE_LEVEL from the build target"
+#endif
+
+#include <spdlog/spdlog.h>
+
+namespace meta::comms::logger {
+
+// Returns the lazily initialized, non-blocking logger for the comms facade.
+spdlog::logger& getSpdlogLogger();
+
+} // namespace meta::comms::logger
+
+#define COMMS_LOG_DBG(...) \
+  SPDLOG_LOGGER_DEBUG(&::meta::comms::logger::getSpdlogLogger(), __VA_ARGS__)
+#define COMMS_LOG_INFO(...) \
+  SPDLOG_LOGGER_INFO(&::meta::comms::logger::getSpdlogLogger(), __VA_ARGS__)
+#define COMMS_LOG_WARN(...) \
+  SPDLOG_LOGGER_WARN(&::meta::comms::logger::getSpdlogLogger(), __VA_ARGS__)
+#define COMMS_LOG_ERR(...) \
+  SPDLOG_LOGGER_ERROR(&::meta::comms::logger::getSpdlogLogger(), __VA_ARGS__)
+#define COMMS_LOG_FATAL(...)                                        \
+  do {                                                              \
+    auto& _comms_logger = ::meta::comms::logger::getSpdlogLogger(); \
+    _comms_logger.log(                                              \
+        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION},  \
+        ::spdlog::level::critical,                                  \
+        __VA_ARGS__);                                               \
+    _comms_logger.flush();                                          \
+    ::spdlog::shutdown();                                           \
+    std::abort();                                                   \
+  } while (false)
+
+#define COMMS_LOG(level, ...) COMMS_LOG_##level(__VA_ARGS__)

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -1,0 +1,38 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// Verify that build-wide spdlog configuration is independent of include order.
+#include <spdlog/spdlog.h>
+
+#include "comms/utils/logger/SpdlogLogger.h"
+
+#include <gtest/gtest.h>
+
+using meta::comms::logger::getSpdlogLogger;
+
+TEST(SpdlogLoggerTest, ReturnsStableNamedLogger) {
+  EXPECT_EQ(&getSpdlogLogger(), &getSpdlogLogger());
+  EXPECT_EQ(getSpdlogLogger().name(), "comms");
+}
+
+TEST(SpdlogLoggerTest, MapsFollyLevelNames) {
+  EXPECT_NO_THROW({
+    COMMS_LOG(DBG, "debug message: {}", 1);
+    COMMS_LOG(INFO, "info message: {}", 2);
+    COMMS_LOG(WARN, "warning message: {}", 3);
+    COMMS_LOG(ERR, "error message: {}", 4);
+  });
+}
+
+TEST(SpdlogLoggerTest, FatalTerminatesProcess) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_DEATH(COMMS_LOG(FATAL, "fatal message: {}", 5), "fatal message: 5");
+}
+
+TEST(SpdlogLoggerTest, CompileTimeGateSkipsArguments) {
+  int evaluationCount = 0;
+  COMMS_LOG(DBG, "compiled out: {}", ++evaluationCount);
+  EXPECT_EQ(evaluationCount, 0);
+
+  COMMS_LOG(INFO, "compiled in: {}", ++evaluationCount);
+  EXPECT_EQ(evaluationCount, 1);
+}

--- a/scripts/_build_wheel.sh
+++ b/scripts/_build_wheel.sh
@@ -30,5 +30,7 @@ pip install pyyaml
 
 export NCCL_SKIP_CONDA_INSTALL=1
 export CLEAN_BUILD=1
+# NCCLX device compilation can exhaust memory at full host parallelism.
+export NCCL_BUILD_JOBS=16
 
 python setup.py bdist_wheel


### PR DESCRIPTION
Summary:

Establish an additive spdlog-backed logging facade alongside the existing Folly logger. The new `oss_cpp_library` follows the UniFlow design: a lazily initialized named logger, an 8192-entry queue, one background worker, and non-blocking `overrun_oldest` behavior.

Expose `COMMS_LOG` dispatch for the existing `DBG`, `INFO`, `WARN`, `ERR`, and `FATAL` level tokens. Each mapping uses the named `SPDLOG_LOGGER_*` macro so `SPDLOG_ACTIVE_LEVEL` performs compile-time gating without evaluating disabled arguments. The logger API returns a non-null reference; `create_async_nb` construction failures propagate as `spdlog_ex`, so there is no impossible null-return branch.

Before aborting, `FATAL` calls `spdlog::shutdown()`; the thread-pool destructor drains queued messages and joins the worker, preserving the fatal line. The death test requires the formatted fatal text on stderr, not only process termination.

Make the OSS CMake path self-contained by bootstrapping spdlog v1.16.0 when its headers are absent and propagating `spdlog::spdlog` from the `utils` object library. This fixes the missing `spdlog/spdlog.h` failure in TorchComms wheel and C++ builds while matching the internal and MCCL spdlog version.

This increment does not redirect production `CLOGF` or remove the Folly backend. That switch remains gated on preserving GPU/thread-context prefixes, category filtering, sinks, and fatal behavior.

Reviewed By: shr

Differential Revision: D114807334


