### PR TITLE
Extract shared log formatting (#3448)

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -215,6 +215,11 @@ function build_third_party {
     fi
   fi
 
+  if [[ ! -f "${CMAKE_PREFIX_PATH}/include/spdlog/spdlog.h" ]]; then
+    build_fb_oss_library "https://github.com/gabime/spdlog.git" "v1.16.0" spdlog \
+      "-DSPDLOG_BUILD_SHARED=OFF -DSPDLOG_FMT_EXTERNAL=ON -DSPDLOG_BUILD_EXAMPLE=OFF -DSPDLOG_BUILD_TESTS=OFF"
+  fi
+
   popd
 }
 
@@ -377,7 +382,7 @@ fi
 pushd "${NCCL_HOME}"
 
 function build_nccl {
-  make VERBOSE=1 -j$(nproc) \
+  make VERBOSE=1 -j"${NCCL_BUILD_JOBS:-$(nproc)}" \
     src.build \
     BUILDDIR="$BUILDDIR" \
     NVCC_GENCODE="$NVCC_GENCODE" \
@@ -394,7 +399,7 @@ function build_nccl {
 }
 
 function build_and_install_nccl {
-make VERBOSE=1 -j$(nproc) \
+make VERBOSE=1 -j"${NCCL_BUILD_JOBS:-$(nproc)}" \
     src.install \
     BUILDDIR="$BUILDDIR" \
     NVCC_GENCODE="$NVCC_GENCODE" \

--- a/comms/ctran/CMakeLists.txt
+++ b/comms/ctran/CMakeLists.txt
@@ -36,6 +36,10 @@ add_library(ctran OBJECT
 )
 
 target_compile_features(ctran PRIVATE cxx_std_20)
+target_compile_definitions(ctran PRIVATE
+    SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO
+    SPDLOG_FMT_EXTERNAL
+)
 
 target_compile_options(ctran PRIVATE
     -fPIC

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -23,6 +23,8 @@ include ../makefiles/version.mk
 CXXFLAGS += -DMOCK_SCUBA_DATA -DFOLLY_XLOG_STRIP_PREFIXES=\"${BASE_DIR}\"
 # Use header-only fmt to avoid runtime dependency on libfmt.so
 CXXFLAGS += -DFMT_HEADER_ONLY=1
+CXXFLAGS += -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DSPDLOG_FMT_EXTERNAL
+NVCUFLAGS += -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DSPDLOG_FMT_EXTERNAL
 
 # Enable JSON parsing in the NCCLX built-in CSV/JSON tuner (meta/tuner) when
 # folly is available. The conda feedstock build sets NCCLX_TUNER_WITH_FOLLY_JSON=1

--- a/comms/utils/CMakeLists.txt
+++ b/comms/utils/CMakeLists.txt
@@ -1,6 +1,21 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 find_package(CUDA REQUIRED)
+find_package(spdlog 1.16.0 CONFIG QUIET)
+if(NOT spdlog_FOUND)
+    include(FetchContent)
+    set(SPDLOG_BUILD_SHARED OFF CACHE BOOL "" FORCE)
+    set(SPDLOG_BUILD_PIC ON CACHE BOOL "" FORCE)
+    set(SPDLOG_FMT_EXTERNAL ON CACHE BOOL "" FORCE)
+    set(SPDLOG_BUILD_EXAMPLE OFF CACHE BOOL "" FORCE)
+    set(SPDLOG_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    FetchContent_Declare(
+        spdlog
+        GIT_REPOSITORY https://github.com/gabime/spdlog.git
+        GIT_TAG v1.16.0
+    )
+    FetchContent_MakeAvailable(spdlog)
+endif()
 
 file(GLOB_RECURSE UTILS_SOURCES
     "*.cc"
@@ -23,6 +38,10 @@ target_compile_features(utils PRIVATE cxx_std_20)
 target_compile_options(utils PRIVATE
     -fPIC
 )
+target_compile_definitions(utils PRIVATE
+    SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO
+    SPDLOG_FMT_EXTERNAL
+)
 set_target_properties(utils PROPERTIES
     CUDA_SEPARABLE_COMPILATION ON
     CUDA_RESOLVE_DEVICE_SYMBOLS ON
@@ -33,3 +52,4 @@ target_include_directories(utils PUBLIC
     ${CONDA_INCLUDE}
     ${CUDA_INCLUDE_DIRS}
 )
+target_link_libraries(utils PUBLIC spdlog::spdlog)

--- a/comms/utils/logger/CommsLogFormatter.cc
+++ b/comms/utils/logger/CommsLogFormatter.cc
@@ -1,0 +1,69 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/CommsLogFormatter.h"
+
+#include <algorithm>
+
+#include <fmt/chrono.h>
+#include <fmt/format.h>
+
+namespace meta::comms::logger {
+
+std::string formatCommsLogMessage(
+    std::string_view levelName,
+    std::string_view message,
+    const CommsLogMetadata& metadata) {
+  const auto timeSinceEpoch = metadata.timestamp.time_since_epoch();
+  const auto epochSeconds =
+      std::chrono::duration_cast<std::chrono::seconds>(timeSinceEpoch);
+  const auto usecs =
+      std::chrono::duration_cast<std::chrono::microseconds>(timeSinceEpoch) -
+      epochSeconds;
+  const auto levelInitial = levelName.empty() ? '?' : levelName.front();
+
+  const auto header = fmt::format(
+      "{}{:%m%d %H:%M:%S}.{:06d} {:5d} {}:{}] {}:{}:{} [{}][{}] {} {} ",
+      levelInitial,
+      metadata.timestamp,
+      usecs.count(),
+      metadata.threadId,
+      metadata.filename,
+      metadata.lineNumber,
+      metadata.hostname,
+      metadata.processId,
+      metadata.threadId,
+      metadata.threadContext,
+      metadata.threadName,
+      metadata.prefix,
+      levelName);
+
+  std::string output;
+  if (message.find('\n') == std::string_view::npos) {
+    output.reserve(header.size() + message.size() + 1);
+    output.append(header);
+    output.append(message);
+    output.push_back('\n');
+    return output;
+  }
+
+  output.reserve(
+      ((header.size() + 1) * std::count(message.begin(), message.end(), '\n')) +
+      message.size());
+  std::size_t begin = 0;
+  while (true) {
+    auto end = message.find('\n', begin);
+    if (end == std::string_view::npos) {
+      end = message.size();
+    }
+    output.append(header);
+    output.append(message.substr(begin, end - begin));
+    output.push_back('\n');
+    if (end == message.size()) {
+      break;
+    }
+    begin = end + 1;
+  }
+  return output;
+}
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/CommsLogFormatter.h
+++ b/comms/utils/logger/CommsLogFormatter.h
@@ -1,0 +1,29 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace meta::comms::logger {
+
+struct CommsLogMetadata {
+  std::chrono::system_clock::time_point timestamp;
+  uint64_t threadId;
+  std::string_view filename;
+  unsigned int lineNumber;
+  std::string_view hostname;
+  int processId;
+  int threadContext;
+  std::string_view threadName;
+  std::string_view prefix;
+};
+
+std::string formatCommsLogMessage(
+    std::string_view levelName,
+    std::string_view message,
+    const CommsLogMetadata& metadata);
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/LoggingFormat.cc
+++ b/comms/utils/logger/LoggingFormat.cc
@@ -6,7 +6,6 @@
 #include <cstring>
 #include <sstream>
 
-#include <fmt/chrono.h>
 #include <fmt/format.h>
 #include <folly/String.h>
 #include <folly/Synchronized.h>
@@ -17,6 +16,7 @@
 
 #include "comms/utils/Conversion.h"
 #include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
+#include "comms/utils/logger/CommsLogFormatter.h"
 #include "comms/utils/logger/ErrorStackUtil.h"
 #include "comms/utils/logger/EventsScubaUtil.h"
 #include "comms/utils/logger/NcclScubaSample.h"
@@ -267,85 +267,24 @@ std::string NcclLogFormatter::formatMessage(
     lockedError->lastErrorNativeStack.clear();
   }
 
-  auto timeSinceEpoch = message.getTimestamp().time_since_epoch();
-  auto epochSeconds =
-      std::chrono::duration_cast<std::chrono::seconds>(timeSinceEpoch);
-  std::chrono::microseconds usecs =
-      std::chrono::duration_cast<std::chrono::microseconds>(timeSinceEpoch) -
-      epochSeconds;
-
   // At least for now, formatter is called in the same thread as the logging
   // thread. So we don't need to worry about getting the information of another
   // thread here.
   int cudaDev = threadContextFn_();
 
-  auto basename = message.getFileBaseName();
-  // Format: <Glog format> <hostname>:<pid>:<tid> [<threadCtx>][<threadName>]
-  // <prefix> <logLevel>
-  // Example: W0414 11:46:56.369712 4115466 Logger.cc:25]
-  // devvm2605:4115466:4115466 [-1][main] NCCL WARN
-  auto header = fmt::format(
-      "{}{:%m%d %H:%M:%S}.{:06d} {:5d} {}:{}] {}:{}:{} [{}][{}] {} {} ",
-      getGlogLevelName(message.getLevel())[0],
-      message.getTimestamp(),
-      usecs.count(),
-      message.getThreadID(),
-      basename,
-      message.getLineNumber(),
-      procMetaData.hostname,
-      procMetaData.pid,
-      message.getThreadID(),
-      cudaDev,
-      myThreadName,
-      prefix_,
-      getGlogLevelName(message.getLevel()));
-
-  // The fixed portion of the header takes up 31 bytes.
-  //
-  // The variable portions that we can't account for here include the line
-  // number and the thread ID (just in case it is larger than 6 digits long).
-  // Here we guess that 40 bytes will be long enough to include room for this.
-  //
-  // If this still isn't long enough the string will grow as necessary, so the
-  // code will still be correct, but just slightly less efficient than if we
-  // had allocated a large enough buffer the first time around.
-  std::size_t headerLengthGuess = 90 + basename.size();
-
-  // Format the data into a buffer.
-  std::string buffer;
-  std::string_view msgData{message.getMessage()};
-  if (message.containsNewlines()) {
-    // If there are multiple lines in the log message, add a header
-    // before each one.
-
-    buffer.reserve(
-        ((header.size() + 1) * message.getNumNewlines()) + msgData.size());
-
-    std::size_t idx = 0;
-    while (true) {
-      auto end = msgData.find('\n', idx);
-      if (end == std::string_view::npos) {
-        end = msgData.size();
-      }
-
-      buffer.append(header);
-      auto line = msgData.substr(idx, end - idx);
-      buffer.append(line.data(), line.size());
-      buffer.push_back('\n');
-
-      if (end == msgData.size()) {
-        break;
-      }
-      idx = end + 1;
-    }
-  } else {
-    buffer.reserve(headerLengthGuess + msgData.size());
-    buffer.append(header);
-    buffer.append(msgData.data(), msgData.size());
-    buffer.push_back('\n');
-  }
-
-  return buffer;
+  const auto basename = message.getFileBaseName();
+  return formatCommsLogMessage(
+      getGlogLevelName(message.getLevel()),
+      message.getMessage(),
+      {.timestamp = message.getTimestamp(),
+       .threadId = message.getThreadID(),
+       .filename = std::string_view{basename.data(), basename.size()},
+       .lineNumber = message.getLineNumber(),
+       .hostname = procMetaData.hostname,
+       .processId = procMetaData.pid,
+       .threadContext = cudaDev,
+       .threadName = myThreadName,
+       .prefix = prefix_});
 }
 
 void logErrorToScuba(

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -1,0 +1,37 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/SpdlogLogger.h"
+
+#include <cstddef>
+#include <memory>
+
+#include <spdlog/async.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+
+namespace meta::comms::logger {
+namespace {
+
+constexpr auto kLoggerName = "comms";
+constexpr auto kLogPattern = "%L%m%d %H:%M:%S.%f %t %s:%#] %v";
+constexpr size_t kAsyncQueueSize = 8192;
+constexpr size_t kAsyncThreadCount = 1;
+
+std::shared_ptr<spdlog::logger> createLogger() {
+  if (!spdlog::thread_pool()) {
+    spdlog::init_thread_pool(kAsyncQueueSize, kAsyncThreadCount);
+  }
+
+  auto logger =
+      spdlog::create_async_nb<spdlog::sinks::stderr_color_sink_mt>(kLoggerName);
+  logger->set_pattern(kLogPattern);
+  return logger;
+}
+
+} // namespace
+
+spdlog::logger& getSpdlogLogger() {
+  static auto logger = createLogger();
+  return *logger;
+}
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -1,0 +1,44 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstdlib>
+
+#ifndef SPDLOG_FMT_EXTERNAL
+#error "SpdlogLogger requires SPDLOG_FMT_EXTERNAL from the build target"
+#endif
+
+#ifndef SPDLOG_ACTIVE_LEVEL
+#error "SpdlogLogger requires SPDLOG_ACTIVE_LEVEL from the build target"
+#endif
+
+#include <spdlog/spdlog.h>
+
+namespace meta::comms::logger {
+
+// Returns the lazily initialized, non-blocking logger for the comms facade.
+spdlog::logger& getSpdlogLogger();
+
+} // namespace meta::comms::logger
+
+#define COMMS_LOG_DBG(...) \
+  SPDLOG_LOGGER_DEBUG(&::meta::comms::logger::getSpdlogLogger(), __VA_ARGS__)
+#define COMMS_LOG_INFO(...) \
+  SPDLOG_LOGGER_INFO(&::meta::comms::logger::getSpdlogLogger(), __VA_ARGS__)
+#define COMMS_LOG_WARN(...) \
+  SPDLOG_LOGGER_WARN(&::meta::comms::logger::getSpdlogLogger(), __VA_ARGS__)
+#define COMMS_LOG_ERR(...) \
+  SPDLOG_LOGGER_ERROR(&::meta::comms::logger::getSpdlogLogger(), __VA_ARGS__)
+#define COMMS_LOG_FATAL(...)                                        \
+  do {                                                              \
+    auto& _comms_logger = ::meta::comms::logger::getSpdlogLogger(); \
+    _comms_logger.log(                                              \
+        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION},  \
+        ::spdlog::level::critical,                                  \
+        __VA_ARGS__);                                               \
+    _comms_logger.flush();                                          \
+    ::spdlog::shutdown();                                           \
+    std::abort();                                                   \
+  } while (false)
+
+#define COMMS_LOG(level, ...) COMMS_LOG_##level(__VA_ARGS__)

--- a/comms/utils/logger/tests/FormatterUT.cc
+++ b/comms/utils/logger/tests/FormatterUT.cc
@@ -27,6 +27,7 @@
 #include <folly/portability/Stdlib.h>
 #include <folly/system/ThreadName.h>
 
+#include "comms/utils/logger/CommsLogFormatter.h"
 #include "comms/utils/logger/LoggingFormat.h"
 
 FOLLY_GNU_DISABLE_WARNING("-Wdeprecated-declarations")
@@ -53,11 +54,12 @@ std::string formatMsg(
     StringPiece functionName,
     // Default timestamp: 2017-04-17 13:45:56.123456 UTC
     uint64_t timestampNS = 1492436756123456789ULL,
-    StringPiece prefix = "NCCL") {
+    StringPiece prefix = "NCCL",
+    int threadContext = 0) {
   LoggerDB db{LoggerDB::TESTING};
   auto* category = db.getCategory("test");
   meta::comms::logger::NcclLogFormatter formatter(
-      prefix.str(), []() { return 0; });
+      prefix.str(), [threadContext]() { return threadContext; });
 
   std::chrono::system_clock::time_point logTimePoint{
       std::chrono::duration_cast<std::chrono::system_clock::duration>(
@@ -111,6 +113,39 @@ TEST(GlogFormatter, log) {
       expected,
       formatMsg(
           LogLevel::WARN, "hello world", "myfile.cpp", 1234, "testFunction"));
+}
+
+TEST(GlogFormatter, logCustomPrefixAndThreadContext) {
+  const auto formatted = formatMsg(
+      LogLevel::WARN,
+      "hello world",
+      "myfile.cpp",
+      1234,
+      "testFunction",
+      1492436756123456789ULL,
+      "CTRAN",
+      7);
+  EXPECT_NE(
+      formatted.find(" [7][main] CTRAN WARN hello world\n"), std::string::npos);
+}
+
+TEST(CommsLogFormatter, emptyLevelUsesPlaceholder) {
+  const meta::comms::logger::CommsLogMetadata metadata{
+      .timestamp = std::chrono::system_clock::time_point{},
+      .threadId = 1,
+      .filename = "test.cpp",
+      .lineNumber = 2,
+      .hostname = "host",
+      .processId = 3,
+      .threadContext = 4,
+      .threadName = "thread",
+      .prefix = "NCCL",
+  };
+
+  const auto formatted =
+      meta::comms::logger::formatCommsLogMessage("", "message", metadata);
+  EXPECT_EQ(formatted.front(), '?');
+  EXPECT_NE(formatted.find(" NCCL  message\n"), std::string::npos);
 }
 
 TEST(GlogFormatter, logThreadName) {

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -1,0 +1,38 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// Verify that build-wide spdlog configuration is independent of include order.
+#include <spdlog/spdlog.h>
+
+#include "comms/utils/logger/SpdlogLogger.h"
+
+#include <gtest/gtest.h>
+
+using meta::comms::logger::getSpdlogLogger;
+
+TEST(SpdlogLoggerTest, ReturnsStableNamedLogger) {
+  EXPECT_EQ(&getSpdlogLogger(), &getSpdlogLogger());
+  EXPECT_EQ(getSpdlogLogger().name(), "comms");
+}
+
+TEST(SpdlogLoggerTest, MapsFollyLevelNames) {
+  EXPECT_NO_THROW({
+    COMMS_LOG(DBG, "debug message: {}", 1);
+    COMMS_LOG(INFO, "info message: {}", 2);
+    COMMS_LOG(WARN, "warning message: {}", 3);
+    COMMS_LOG(ERR, "error message: {}", 4);
+  });
+}
+
+TEST(SpdlogLoggerTest, FatalTerminatesProcess) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_DEATH(COMMS_LOG(FATAL, "fatal message: {}", 5), "fatal message: 5");
+}
+
+TEST(SpdlogLoggerTest, CompileTimeGateSkipsArguments) {
+  int evaluationCount = 0;
+  COMMS_LOG(DBG, "compiled out: {}", ++evaluationCount);
+  EXPECT_EQ(evaluationCount, 0);
+
+  COMMS_LOG(INFO, "compiled in: {}", ++evaluationCount);
+  EXPECT_EQ(evaluationCount, 1);
+}

--- a/scripts/_build_wheel.sh
+++ b/scripts/_build_wheel.sh
@@ -30,5 +30,7 @@ pip install pyyaml
 
 export NCCL_SKIP_CONDA_INSTALL=1
 export CLEAN_BUILD=1
+# NCCLX device compilation can exhaust memory at full host parallelism.
+export NCCL_BUILD_JOBS=16
 
 python setup.py bdist_wheel


### PR DESCRIPTION
Summary:

Extract the established comms log wire format into an OSS-clean helper so the Folly and spdlog backends can share one implementation during migration.

Keep Folly responsible for category routing and last-error state. The existing formatter now supplies its producer-thread metadata to the shared helper, preserving timestamps, source locations, host/process/thread identifiers, GPU context, thread names, prefixes, severity names, and multiline handling.

Add a characterization test for the CTRAN prefix and nonzero GPU context before connecting production callers to spdlog.

Reviewed By: shr

Differential Revision: D114825986


