### PR TITLE
Preserve log metadata in spdlog (#3449)

### DIFF
--- a/comms/utils/logger/LoggingFormat.cc
+++ b/comms/utils/logger/LoggingFormat.cc
@@ -20,6 +20,7 @@
 #include "comms/utils/logger/ErrorStackUtil.h"
 #include "comms/utils/logger/EventsScubaUtil.h"
 #include "comms/utils/logger/NcclScubaSample.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace {
 std::string getHostName(const char delim) {
@@ -245,7 +246,10 @@ void initProcMetaData() {
 
 void initThreadMetaData(std::string_view threadName) {
   static thread_local folly::once_flag threadNameFlag;
-  folly::call_once(threadNameFlag, [&]() { myThreadName = threadName; });
+  folly::call_once(threadNameFlag, [&]() {
+    myThreadName = threadName;
+    setSpdlogThreadName(threadName);
+  });
 }
 
 std::string NcclLogFormatter::formatMessage(

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -2,19 +2,74 @@
 
 #include "comms/utils/logger/SpdlogLogger.h"
 
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <chrono>
 #include <cstddef>
+#include <cstring>
 #include <memory>
+#include <string>
+#include <string_view>
 
 #include <spdlog/async.h>
+#include <spdlog/pattern_formatter.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
+
+#include "comms/utils/logger/CommsLogFormatter.h"
 
 namespace meta::comms::logger {
 namespace {
 
 constexpr auto kLoggerName = "comms";
-constexpr auto kLogPattern = "%L%m%d %H:%M:%S.%f %t %s:%#] %v";
 constexpr size_t kAsyncQueueSize = 8192;
 constexpr size_t kAsyncThreadCount = 1;
+thread_local std::string threadName = "main";
+
+std::string getHostName() {
+  char hostname[HOST_NAME_MAX + 1];
+  if (gethostname(hostname, sizeof(hostname)) != 0) {
+    return "unknown";
+  }
+  hostname[HOST_NAME_MAX] = '\0';
+  if (auto* domain = std::strchr(hostname, '.')) {
+    *domain = '\0';
+  }
+  return hostname;
+}
+
+std::string_view getSpdlogLevelName(spdlog::level::level_enum level) {
+  switch (level) {
+    case spdlog::level::trace:
+    case spdlog::level::debug:
+      return "VERBOSE";
+    case spdlog::level::info:
+      return "INFO";
+    case spdlog::level::warn:
+      return "WARN";
+    case spdlog::level::err:
+      return "ERROR";
+    case spdlog::level::critical:
+      return "CRITICAL";
+    case spdlog::level::off:
+    case spdlog::level::n_levels:
+      return "UNKNOWN";
+  }
+  return "UNKNOWN";
+}
+
+std::string_view getBaseName(const char* filename) {
+  if (filename == nullptr) {
+    return {};
+  }
+  const auto* slash = std::strrchr(filename, '/');
+  return slash == nullptr ? filename : slash + 1;
+}
+
+uint64_t getCurrentThreadId() {
+  static thread_local const auto threadId =
+      static_cast<uint64_t>(::syscall(SYS_gettid));
+  return threadId;
+}
 
 std::shared_ptr<spdlog::logger> createLogger() {
   if (!spdlog::thread_pool()) {
@@ -23,15 +78,131 @@ std::shared_ptr<spdlog::logger> createLogger() {
 
   auto logger =
       spdlog::create_async_nb<spdlog::sinks::stderr_color_sink_mt>(kLoggerName);
-  logger->set_pattern(kLogPattern);
+  logger->set_formatter(
+      std::make_unique<spdlog::pattern_formatter>(
+          "%v", spdlog::pattern_time_type::local, ""));
   return logger;
 }
 
 } // namespace
 
-spdlog::logger& getSpdlogLogger() {
-  static auto logger = createLogger();
-  return *logger;
+CommsSpdlogLogger::CommsSpdlogLogger() : logger_(createLogger()) {
+  storeConfiguration(std::make_shared<const Configuration>());
+}
+
+std::string_view CommsSpdlogLogger::getLevelName(
+    spdlog::level::level_enum level) {
+  return getSpdlogLevelName(level);
+}
+
+bool CommsSpdlogLogger::should_log(spdlog::level::level_enum level) const {
+  return logger_->should_log(level);
+}
+
+const std::string& CommsSpdlogLogger::name() const {
+  return logger_->name();
+}
+
+void CommsSpdlogLogger::set_level(spdlog::level::level_enum level) {
+  logger_->set_level(level);
+}
+
+void CommsSpdlogLogger::flush() {
+  logger_->flush();
+}
+
+void CommsSpdlogLogger::log(
+    spdlog::source_loc location,
+    spdlog::level::level_enum level,
+    std::string_view message) {
+  if (should_log(level)) {
+    logFormatted(location, level, getLevelName(level), message, false);
+  }
+}
+
+void CommsSpdlogLogger::logFatal(
+    spdlog::source_loc location,
+    std::string_view message) {
+  logFormatted(location, spdlog::level::critical, "FATAL", message, true);
+}
+
+void CommsSpdlogLogger::configure(
+    std::string prefix,
+    std::function<int(void)> threadContextFn) {
+  if (!threadContextFn) {
+    threadContextFn = []() { return 0; };
+  }
+  std::shared_ptr<const Configuration> configuration =
+      std::make_shared<const Configuration>(
+          Configuration{std::move(prefix), std::move(threadContextFn)});
+  storeConfiguration(std::move(configuration));
+}
+
+std::shared_ptr<const CommsSpdlogLogger::Configuration>
+CommsSpdlogLogger::loadConfiguration() const {
+#if defined(__cpp_lib_atomic_shared_ptr) && \
+    __cpp_lib_atomic_shared_ptr >= 201711L
+  return configuration_.load(std::memory_order_acquire);
+#else
+  return std::atomic_load_explicit(&configuration_, std::memory_order_acquire);
+#endif
+}
+
+void CommsSpdlogLogger::storeConfiguration(
+    std::shared_ptr<const Configuration> configuration) {
+#if defined(__cpp_lib_atomic_shared_ptr) && \
+    __cpp_lib_atomic_shared_ptr >= 201711L
+  configuration_.store(std::move(configuration), std::memory_order_release);
+#else
+  std::atomic_store_explicit(
+      &configuration_, std::move(configuration), std::memory_order_release);
+#endif
+}
+
+void CommsSpdlogLogger::logFormatted(
+    spdlog::source_loc location,
+    spdlog::level::level_enum level,
+    std::string_view levelName,
+    std::string_view message,
+    bool bypassLevelGate) {
+  static const auto hostname = getHostName();
+  static const auto processId = getpid();
+  const auto configuration = loadConfiguration();
+  const auto formatted = formatCommsLogMessage(
+      levelName,
+      message,
+      {std::chrono::system_clock::now(),
+       getCurrentThreadId(),
+       getBaseName(location.filename),
+       static_cast<unsigned int>(location.line),
+       hostname,
+       processId,
+       configuration->threadContextFn(),
+       threadName,
+       configuration->prefix});
+  if (bypassLevelGate) {
+    spdlog::logger fatalLogger{
+        logger_->name(), logger_->sinks().begin(), logger_->sinks().end()};
+    fatalLogger.log(location, level, formatted);
+    fatalLogger.flush();
+  } else {
+    logger_->log(location, level, formatted);
+  }
+}
+
+CommsSpdlogLogger& getSpdlogLogger() {
+  static CommsSpdlogLogger logger;
+  return logger;
+}
+
+void configureSpdlogLogger(
+    std::string prefix,
+    std::function<int(void)> threadContextFn) {
+  getSpdlogLogger().configure(std::move(prefix), std::move(threadContextFn));
+}
+
+void setSpdlogThreadName(std::string_view name) {
+  threadName = name;
 }
 
 } // namespace meta::comms::logger

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -2,7 +2,13 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdlib>
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
 
 #ifndef SPDLOG_FMT_EXTERNAL
 #error "SpdlogLogger requires SPDLOG_FMT_EXTERNAL from the build target"
@@ -16,28 +22,121 @@
 
 namespace meta::comms::logger {
 
-// Returns the lazily initialized, non-blocking logger for the comms facade.
-spdlog::logger& getSpdlogLogger();
+class CommsSpdlogLogger {
+ public:
+  CommsSpdlogLogger();
+
+  template <typename... Args>
+  void log(
+      spdlog::source_loc location,
+      spdlog::level::level_enum level,
+      spdlog::format_string_t<Args...> format,
+      Args&&... args) {
+    if (!should_log(level)) {
+      return;
+    }
+    logFormatted(
+        location,
+        level,
+        getLevelName(level),
+        fmt::format(format, std::forward<Args>(args)...),
+        false);
+  }
+
+  void log(
+      spdlog::source_loc location,
+      spdlog::level::level_enum level,
+      std::string_view message);
+
+  template <typename... Args>
+  void logFatal(
+      spdlog::source_loc location,
+      spdlog::format_string_t<Args...> format,
+      Args&&... args) {
+    logFormatted(
+        location,
+        spdlog::level::critical,
+        "FATAL",
+        fmt::format(format, std::forward<Args>(args)...),
+        true);
+  }
+
+  void logFatal(spdlog::source_loc location, std::string_view message);
+
+  bool should_log(spdlog::level::level_enum level) const;
+  const std::string& name() const;
+  void set_level(spdlog::level::level_enum level);
+  void flush();
+
+  void configure(std::string prefix, std::function<int(void)> threadContextFn);
+
+ private:
+  struct Configuration {
+    std::string prefix{"COMMS"};
+    std::function<int(void)> threadContextFn{[]() { return 0; }};
+  };
+
+#if defined(__cpp_lib_atomic_shared_ptr) && \
+    __cpp_lib_atomic_shared_ptr >= 201711L
+  using ConfigurationStorage =
+      std::atomic<std::shared_ptr<const Configuration>>;
+#else
+  // NCCLX also builds this target as C++17, before atomic<shared_ptr> exists.
+  using ConfigurationStorage = std::shared_ptr<const Configuration>;
+#endif
+
+  static std::string_view getLevelName(spdlog::level::level_enum level);
+
+  std::shared_ptr<const Configuration> loadConfiguration() const;
+  void storeConfiguration(std::shared_ptr<const Configuration> configuration);
+
+  void logFormatted(
+      spdlog::source_loc location,
+      spdlog::level::level_enum level,
+      std::string_view levelName,
+      std::string_view message,
+      bool bypassLevelGate);
+
+  std::shared_ptr<spdlog::logger> logger_;
+  ConfigurationStorage configuration_;
+};
+
+CommsSpdlogLogger& getSpdlogLogger();
+
+void configureSpdlogLogger(
+    std::string prefix,
+    std::function<int(void)> threadContextFn);
+
+void setSpdlogThreadName(std::string_view threadName);
 
 } // namespace meta::comms::logger
 
+#define COMMS_LOG_IMPL(spdlog_level, spdlog_macro, ...)             \
+  do {                                                              \
+    auto& _comms_logger = ::meta::comms::logger::getSpdlogLogger(); \
+    if (_comms_logger.should_log(spdlog_level)) {                   \
+      spdlog_macro(&_comms_logger, __VA_ARGS__);                    \
+    }                                                               \
+  } while (false)
+
 #define COMMS_LOG_DBG(...) \
-  SPDLOG_LOGGER_DEBUG(&::meta::comms::logger::getSpdlogLogger(), __VA_ARGS__)
+  COMMS_LOG_IMPL(::spdlog::level::debug, SPDLOG_LOGGER_DEBUG, __VA_ARGS__)
 #define COMMS_LOG_INFO(...) \
-  SPDLOG_LOGGER_INFO(&::meta::comms::logger::getSpdlogLogger(), __VA_ARGS__)
+  COMMS_LOG_IMPL(::spdlog::level::info, SPDLOG_LOGGER_INFO, __VA_ARGS__)
 #define COMMS_LOG_WARN(...) \
-  SPDLOG_LOGGER_WARN(&::meta::comms::logger::getSpdlogLogger(), __VA_ARGS__)
+  COMMS_LOG_IMPL(::spdlog::level::warn, SPDLOG_LOGGER_WARN, __VA_ARGS__)
 #define COMMS_LOG_ERR(...) \
-  SPDLOG_LOGGER_ERROR(&::meta::comms::logger::getSpdlogLogger(), __VA_ARGS__)
+  COMMS_LOG_IMPL(::spdlog::level::err, SPDLOG_LOGGER_ERROR, __VA_ARGS__)
+#define COMMS_LOG_CRITICAL(...) \
+  COMMS_LOG_IMPL(::spdlog::level::critical, SPDLOG_LOGGER_CRITICAL, __VA_ARGS__)
 #define COMMS_LOG_FATAL(...)                                        \
   do {                                                              \
     auto& _comms_logger = ::meta::comms::logger::getSpdlogLogger(); \
-    _comms_logger.log(                                              \
-        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION},  \
-        ::spdlog::level::critical,                                  \
-        __VA_ARGS__);                                               \
     _comms_logger.flush();                                          \
     ::spdlog::shutdown();                                           \
+    _comms_logger.logFatal(                                         \
+        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION},  \
+        __VA_ARGS__);                                               \
     std::abort();                                                   \
   } while (false)
 

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -5,9 +5,18 @@
 
 #include "comms/utils/logger/SpdlogLogger.h"
 
+#include <string>
+
 #include <gtest/gtest.h>
 
 using meta::comms::logger::getSpdlogLogger;
+
+class LogLevelRestoringTest : public testing::Test {
+ protected:
+  void TearDown() override {
+    getSpdlogLogger().set_level(spdlog::level::info);
+  }
+};
 
 TEST(SpdlogLoggerTest, ReturnsStableNamedLogger) {
   EXPECT_EQ(&getSpdlogLogger(), &getSpdlogLogger());
@@ -20,12 +29,32 @@ TEST(SpdlogLoggerTest, MapsFollyLevelNames) {
     COMMS_LOG(INFO, "info message: {}", 2);
     COMMS_LOG(WARN, "warning message: {}", 3);
     COMMS_LOG(ERR, "error message: {}", 4);
+    COMMS_LOG(CRITICAL, std::string{"critical message"});
   });
 }
 
 TEST(SpdlogLoggerTest, FatalTerminatesProcess) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-  EXPECT_DEATH(COMMS_LOG(FATAL, "fatal message: {}", 5), "fatal message: 5");
+  EXPECT_DEATH(
+      {
+        thread_local int threadContext = 7;
+        meta::comms::logger::configureSpdlogLogger(
+            "CTRAN", [&]() { return threadContext; });
+        meta::comms::logger::setSpdlogThreadName("caller");
+        COMMS_LOG(INFO, "message before fatal");
+        COMMS_LOG(FATAL, "fatal message: {}", 5);
+      },
+      "message before fatal(.|\\n)*\\[7\\]\\[caller\\] CTRAN FATAL fatal message: 5");
+}
+
+TEST_F(LogLevelRestoringTest, FatalIsNotSuppressedByRuntimeLevel) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_DEATH(
+      {
+        getSpdlogLogger().set_level(spdlog::level::off);
+        COMMS_LOG(FATAL, "fatal while logging is disabled");
+      },
+      "FATAL fatal while logging is disabled");
 }
 
 TEST(SpdlogLoggerTest, CompileTimeGateSkipsArguments) {
@@ -35,4 +64,24 @@ TEST(SpdlogLoggerTest, CompileTimeGateSkipsArguments) {
 
   COMMS_LOG(INFO, "compiled in: {}", ++evaluationCount);
   EXPECT_EQ(evaluationCount, 1);
+}
+
+TEST_F(LogLevelRestoringTest, RuntimeGateSkipsArguments) {
+  int evaluationCount = 0;
+  getSpdlogLogger().set_level(spdlog::level::warn);
+
+  COMMS_LOG(INFO, "filtered at runtime: {}", ++evaluationCount);
+  EXPECT_EQ(evaluationCount, 0);
+
+  COMMS_LOG(WARN, "enabled at runtime: {}", ++evaluationCount);
+  EXPECT_EQ(evaluationCount, 1);
+}
+
+TEST_F(LogLevelRestoringTest, EmptyThreadContextUsesDefault) {
+  getSpdlogLogger().set_level(spdlog::level::info);
+  meta::comms::logger::configureSpdlogLogger("TEST", {});
+
+  EXPECT_NO_THROW(COMMS_LOG(INFO, "empty callback"));
+
+  meta::comms::logger::configureSpdlogLogger("COMMS", []() { return 0; });
 }


### PR DESCRIPTION
Summary:

Format spdlog messages on the producer thread through the shared comms formatter before enqueueing them to the asynchronous sink. This preserves source location, host/process/thread identifiers, GPU context, thread name, prefix, severity name, and multiline behavior without invoking CUDA-backed context callbacks on the spdlog worker.

Retain named spdlog macro compile-time gating and add explicit runtime gating so disabled log arguments are not evaluated. Keep `CRITICAL` distinct from `FATAL`: both use spdlog's critical transport level, but only `FATAL` flushes and aborts.

Mirror existing `initThreadMetaData()` calls into the spdlog thread-local name. This increment remains additive and does not redirect production `CLOGF` callers.

Reviewed By: shr

Differential Revision: D114826772


