### PR TITLE
Migrate CTRAN capability warnings (#3452)

### DIFF
--- a/comms/ctran/utils/CtranMulticast.cc
+++ b/comms/ctran/utils/CtranMulticast.cc
@@ -6,7 +6,9 @@
 #include "comms/ctran/utils/Alloc.h" // isCuMemFabricEnabled
 #include "comms/ctran/utils/Checks.h" // FB_COMMCHECK
 #include "comms/ctran/utils/CudaWrap.h"
+#include "comms/ctran/utils/LogInit.h"
 #include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace ctran::utils {
 
@@ -57,7 +59,8 @@ bool CtranMulticast::isSupported(int cudaDev) {
         FB_CUPFN(cuMulticastBindMem) == nullptr ||
         FB_CUPFN(cuMulticastGetGranularity) == nullptr ||
         FB_CUPFN(cuMulticastUnbind) == nullptr) {
-      CLOGF(
+      COMMS_LOG_CONTEXT(
+          ctran::logging::kCtranSpdlogContext,
           WARN,
           "CTRAN-MC: multicast disabled -- driver multicast entry points unavailable (needs a newer CUDA driver)");
       return false;
@@ -71,7 +74,8 @@ bool CtranMulticast::isSupported(int cudaDev) {
             &sup, CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, cuDev),
         false);
     if (sup == 0) {
-      CLOGF(
+      COMMS_LOG_CONTEXT(
+          ctran::logging::kCtranSpdlogContext,
           WARN,
           "CTRAN-MC: multicast disabled -- device {} reports no multicast support",
           cudaDev);
@@ -90,7 +94,8 @@ bool CtranMulticast::isSupported(int cudaDev) {
     // cannot be shared across the domain -> declare unsupported so the group
     // falls back to unicast.
     if (!isCuMemFabricEnabled()) {
-      CLOGF(
+      COMMS_LOG_CONTEXT(
+          ctran::logging::kCtranSpdlogContext,
           WARN,
           "CTRAN-MC: multicast disabled -- device {} reports multicast support but fabric memory handles are unavailable (IMEX channel not enabled?); the multicast object cannot be shared across the NVL domain",
           cudaDev);

--- a/comms/ctran/utils/LogInit.cc
+++ b/comms/ctran/utils/LogInit.cc
@@ -10,6 +10,7 @@
 #include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/Logger.h"
 #include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace ctran::logging {
 
@@ -28,6 +29,27 @@ std::string getHipCtranCategory() {
   auto ctranComponentIdx = fullFilePath.find(kCtranComponent);
   return fullFilePath.substr(0, ctranComponentIdx + kCtranComponent.size());
 };
+
+spdlog::level::level_enum loggerLevelToSpdlogLevel(
+    meta::comms::logger::LogLevel level) {
+  switch (level) {
+    case meta::comms::logger::LogLevel::NONE:
+    case meta::comms::logger::LogLevel::VERSION:
+      // COMMS_LOG_FATAL bypasses this threshold; off suppresses only
+      // non-fatal messages for these modes.
+      return spdlog::level::off;
+    case meta::comms::logger::LogLevel::ERROR:
+      return spdlog::level::err;
+    case meta::comms::logger::LogLevel::WARN:
+      return spdlog::level::warn;
+    case meta::comms::logger::LogLevel::INFO:
+      return spdlog::level::info;
+    case meta::comms::logger::LogLevel::ABORT:
+    case meta::comms::logger::LogLevel::TRACE:
+      return spdlog::level::debug;
+  }
+  return spdlog::level::off;
+}
 
 } // namespace
 
@@ -78,6 +100,21 @@ void initCtranLoggingImpl() {
             return cudaDev;
           }});
 #endif
+  meta::comms::logger::configureSpdlogLogger(
+      kCtranSpdlogContext,
+      "CTRAN",
+      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
+      []() {
+        int cudaDev = -1;
+        (void)cudaGetDevice(&cudaDev);
+        return cudaDev;
+      },
+      [](std::string_view message) {
+        meta::comms::logger::setLastError(std::string{message}, {});
+      });
+  meta::comms::logger::getSpdlogLogger(kCtranSpdlogContext)
+      .set_level(loggerLevelToSpdlogLevel(
+          meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
 }
 } // anonymous namespace
 

--- a/comms/ctran/utils/LogInit.h
+++ b/comms/ctran/utils/LogInit.h
@@ -15,6 +15,8 @@
 
 namespace ctran::logging {
 
+constexpr std::string_view kCtranSpdlogContext = "comms.ctran";
+
 // AKA Ctran file path. This needs to be changed in refactoring
 constexpr std::string_view kCtranCategory = "comms.ncclx.v2_25.comms.ctran";
 /**

--- a/comms/ctran/utils/tests/LogUT.cc
+++ b/comms/ctran/utils/tests/LogUT.cc
@@ -17,6 +17,7 @@
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/Logger.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 class CtranUtilsLogTest : public ::testing::Test {
  public:
@@ -67,6 +68,20 @@ TEST_F(CtranUtilsLogTest, TestCLOGF) {
 
   std::string expectedContent = "Test message with value: 42";
   EXPECT_NE(messages[0].find(expectedContent), std::string::npos);
+}
+
+TEST_F(CtranUtilsLogTest, TestSpdlogContextPreservesLastError) {
+  auto& logger =
+      meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranSpdlogContext);
+  EXPECT_EQ(logger.name(), ctran::logging::kCtranSpdlogContext);
+  logger.set_level(spdlog::level::info);
+
+  COMMS_LOG_CONTEXT(
+      ctran::logging::kCtranSpdlogContext, ERR, "Spdlog CTRAN error {}", 42);
+
+  EXPECT_THAT(
+      meta::comms::logger::getLastCommsError(),
+      testing::HasSubstr("Spdlog CTRAN error 42"));
 }
 
 TEST_F(CtranUtilsLogTest, TestCLOGF_IF) {

--- a/comms/utils/logger/LoggingFormat.cc
+++ b/comms/utils/logger/LoggingFormat.cc
@@ -20,6 +20,7 @@
 #include "comms/utils/logger/ErrorStackUtil.h"
 #include "comms/utils/logger/EventsScubaUtil.h"
 #include "comms/utils/logger/NcclScubaSample.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace {
 std::string getHostName(const char delim) {
@@ -245,7 +246,10 @@ void initProcMetaData() {
 
 void initThreadMetaData(std::string_view threadName) {
   static thread_local folly::once_flag threadNameFlag;
-  folly::call_once(threadNameFlag, [&]() { myThreadName = threadName; });
+  folly::call_once(threadNameFlag, [&]() {
+    myThreadName = threadName;
+    setSpdlogThreadName(threadName);
+  });
 }
 
 std::string NcclLogFormatter::formatMessage(

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -2,19 +2,74 @@
 
 #include "comms/utils/logger/SpdlogLogger.h"
 
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <chrono>
 #include <cstddef>
+#include <cstring>
 #include <memory>
+#include <string>
+#include <string_view>
 
 #include <spdlog/async.h>
+#include <spdlog/pattern_formatter.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
+
+#include "comms/utils/logger/CommsLogFormatter.h"
 
 namespace meta::comms::logger {
 namespace {
 
 constexpr auto kLoggerName = "comms";
-constexpr auto kLogPattern = "%L%m%d %H:%M:%S.%f %t %s:%#] %v";
 constexpr size_t kAsyncQueueSize = 8192;
 constexpr size_t kAsyncThreadCount = 1;
+thread_local std::string threadName = "main";
+
+std::string getHostName() {
+  char hostname[HOST_NAME_MAX + 1];
+  if (gethostname(hostname, sizeof(hostname)) != 0) {
+    return "unknown";
+  }
+  hostname[HOST_NAME_MAX] = '\0';
+  if (auto* domain = std::strchr(hostname, '.')) {
+    *domain = '\0';
+  }
+  return hostname;
+}
+
+std::string_view getSpdlogLevelName(spdlog::level::level_enum level) {
+  switch (level) {
+    case spdlog::level::trace:
+    case spdlog::level::debug:
+      return "VERBOSE";
+    case spdlog::level::info:
+      return "INFO";
+    case spdlog::level::warn:
+      return "WARN";
+    case spdlog::level::err:
+      return "ERROR";
+    case spdlog::level::critical:
+      return "CRITICAL";
+    case spdlog::level::off:
+    case spdlog::level::n_levels:
+      return "UNKNOWN";
+  }
+  return "UNKNOWN";
+}
+
+std::string_view getBaseName(const char* filename) {
+  if (filename == nullptr) {
+    return {};
+  }
+  const auto* slash = std::strrchr(filename, '/');
+  return slash == nullptr ? filename : slash + 1;
+}
+
+uint64_t getCurrentThreadId() {
+  static thread_local const auto threadId =
+      static_cast<uint64_t>(::syscall(SYS_gettid));
+  return threadId;
+}
 
 std::shared_ptr<spdlog::logger> createLogger() {
   if (!spdlog::thread_pool()) {
@@ -23,15 +78,131 @@ std::shared_ptr<spdlog::logger> createLogger() {
 
   auto logger =
       spdlog::create_async_nb<spdlog::sinks::stderr_color_sink_mt>(kLoggerName);
-  logger->set_pattern(kLogPattern);
+  logger->set_formatter(
+      std::make_unique<spdlog::pattern_formatter>(
+          "%v", spdlog::pattern_time_type::local, ""));
   return logger;
 }
 
 } // namespace
 
-spdlog::logger& getSpdlogLogger() {
-  static auto logger = createLogger();
-  return *logger;
+CommsSpdlogLogger::CommsSpdlogLogger() : logger_(createLogger()) {
+  storeConfiguration(std::make_shared<const Configuration>());
+}
+
+std::string_view CommsSpdlogLogger::getLevelName(
+    spdlog::level::level_enum level) {
+  return getSpdlogLevelName(level);
+}
+
+bool CommsSpdlogLogger::should_log(spdlog::level::level_enum level) const {
+  return logger_->should_log(level);
+}
+
+const std::string& CommsSpdlogLogger::name() const {
+  return logger_->name();
+}
+
+void CommsSpdlogLogger::set_level(spdlog::level::level_enum level) {
+  logger_->set_level(level);
+}
+
+void CommsSpdlogLogger::flush() {
+  logger_->flush();
+}
+
+void CommsSpdlogLogger::log(
+    spdlog::source_loc location,
+    spdlog::level::level_enum level,
+    std::string_view message) {
+  if (should_log(level)) {
+    logFormatted(location, level, getLevelName(level), message, false);
+  }
+}
+
+void CommsSpdlogLogger::logFatal(
+    spdlog::source_loc location,
+    std::string_view message) {
+  logFormatted(location, spdlog::level::critical, "FATAL", message, true);
+}
+
+void CommsSpdlogLogger::configure(
+    std::string prefix,
+    std::function<int(void)> threadContextFn) {
+  if (!threadContextFn) {
+    threadContextFn = []() { return 0; };
+  }
+  std::shared_ptr<const Configuration> configuration =
+      std::make_shared<const Configuration>(
+          Configuration{std::move(prefix), std::move(threadContextFn)});
+  storeConfiguration(std::move(configuration));
+}
+
+std::shared_ptr<const CommsSpdlogLogger::Configuration>
+CommsSpdlogLogger::loadConfiguration() const {
+#if defined(__cpp_lib_atomic_shared_ptr) && \
+    __cpp_lib_atomic_shared_ptr >= 201711L
+  return configuration_.load(std::memory_order_acquire);
+#else
+  return std::atomic_load_explicit(&configuration_, std::memory_order_acquire);
+#endif
+}
+
+void CommsSpdlogLogger::storeConfiguration(
+    std::shared_ptr<const Configuration> configuration) {
+#if defined(__cpp_lib_atomic_shared_ptr) && \
+    __cpp_lib_atomic_shared_ptr >= 201711L
+  configuration_.store(std::move(configuration), std::memory_order_release);
+#else
+  std::atomic_store_explicit(
+      &configuration_, std::move(configuration), std::memory_order_release);
+#endif
+}
+
+void CommsSpdlogLogger::logFormatted(
+    spdlog::source_loc location,
+    spdlog::level::level_enum level,
+    std::string_view levelName,
+    std::string_view message,
+    bool bypassLevelGate) {
+  static const auto hostname = getHostName();
+  static const auto processId = getpid();
+  const auto configuration = loadConfiguration();
+  const auto formatted = formatCommsLogMessage(
+      levelName,
+      message,
+      {std::chrono::system_clock::now(),
+       getCurrentThreadId(),
+       getBaseName(location.filename),
+       static_cast<unsigned int>(location.line),
+       hostname,
+       processId,
+       configuration->threadContextFn(),
+       threadName,
+       configuration->prefix});
+  if (bypassLevelGate) {
+    spdlog::logger fatalLogger{
+        logger_->name(), logger_->sinks().begin(), logger_->sinks().end()};
+    fatalLogger.log(location, level, formatted);
+    fatalLogger.flush();
+  } else {
+    logger_->log(location, level, formatted);
+  }
+}
+
+CommsSpdlogLogger& getSpdlogLogger() {
+  static CommsSpdlogLogger logger;
+  return logger;
+}
+
+void configureSpdlogLogger(
+    std::string prefix,
+    std::function<int(void)> threadContextFn) {
+  getSpdlogLogger().configure(std::move(prefix), std::move(threadContextFn));
+}
+
+void setSpdlogThreadName(std::string_view name) {
+  threadName = name;
 }
 
 } // namespace meta::comms::logger

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -7,12 +7,19 @@
 #include <chrono>
 #include <cstddef>
 #include <cstring>
+#include <map>
 #include <memory>
+#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 #include <spdlog/async.h>
 #include <spdlog/pattern_formatter.h>
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 
 #include "comms/utils/logger/CommsLogFormatter.h"
@@ -20,10 +27,61 @@
 namespace meta::comms::logger {
 namespace {
 
-constexpr auto kLoggerName = "comms";
+constexpr std::string_view kLoggerName = "comms";
 constexpr size_t kAsyncQueueSize = 8192;
 constexpr size_t kAsyncThreadCount = 1;
 thread_local std::string threadName = "main";
+// Guard the full callback chain so it cannot recurse through another context
+// logger and eventually re-enter the originating callback.
+thread_local bool errorCallbackInProgress = false;
+
+class ErrorCallbackGuard {
+ public:
+  ErrorCallbackGuard() {
+    errorCallbackInProgress = true;
+  }
+  ~ErrorCallbackGuard() {
+    errorCallbackInProgress = false;
+  }
+
+  ErrorCallbackGuard(const ErrorCallbackGuard&) = delete;
+  ErrorCallbackGuard& operator=(const ErrorCallbackGuard&) = delete;
+  ErrorCallbackGuard(ErrorCallbackGuard&&) = delete;
+  ErrorCallbackGuard& operator=(ErrorCallbackGuard&&) = delete;
+};
+
+class StderrRoutingSink final : public spdlog::sinks::sink {
+ public:
+  StderrRoutingSink()
+      : sink_(std::make_shared<spdlog::sinks::stderr_color_sink_mt>()) {}
+
+  void log(const spdlog::details::log_msg& message) override {
+    if (should_log(message.level) &&
+        shouldWriteCommsLogToStderr(message.level)) {
+      sink_->log(message);
+    }
+  }
+
+  void flush() override {
+    sink_->flush();
+  }
+
+  void set_pattern(const std::string& pattern) override {
+    sink_->set_pattern(pattern);
+  }
+
+  void set_formatter(std::unique_ptr<spdlog::formatter> formatter) override {
+    sink_->set_formatter(std::move(formatter));
+  }
+
+ private:
+  std::shared_ptr<spdlog::sinks::sink> sink_;
+};
+
+std::unique_ptr<spdlog::formatter> makeFormatter() {
+  return std::make_unique<spdlog::pattern_formatter>(
+      "%v", spdlog::pattern_time_type::local, "");
+}
 
 std::string getHostName() {
   char hostname[HOST_NAME_MAX + 1];
@@ -71,22 +129,31 @@ uint64_t getCurrentThreadId() {
   return threadId;
 }
 
-std::shared_ptr<spdlog::logger> createLogger() {
+std::shared_ptr<spdlog::logger> createLogger(std::string name) {
   if (!spdlog::thread_pool()) {
     spdlog::init_thread_pool(kAsyncQueueSize, kAsyncThreadCount);
   }
 
-  auto logger =
-      spdlog::create_async_nb<spdlog::sinks::stderr_color_sink_mt>(kLoggerName);
-  logger->set_formatter(
-      std::make_unique<spdlog::pattern_formatter>(
-          "%v", spdlog::pattern_time_type::local, ""));
+  auto logger = spdlog::create_async_nb<spdlog::sinks::stderr_color_sink_mt>(
+      std::move(name));
+  logger->set_formatter(makeFormatter());
   return logger;
 }
 
 } // namespace
 
-CommsSpdlogLogger::CommsSpdlogLogger() : logger_(createLogger()) {
+bool shouldWriteCommsLogToStderr(spdlog::level::level_enum level) {
+  return level >= spdlog::level::warn && level < spdlog::level::off;
+}
+
+CommsSpdlogLogger::CommsSpdlogLogger()
+    : CommsSpdlogLogger(std::string{kLoggerName}) {}
+
+CommsSpdlogLogger::CommsSpdlogLogger(std::string name)
+    : logger_(createLogger(std::move(name))),
+      outputSink_(
+          std::make_shared<spdlog::sinks::dist_sink_mt>(logger_->sinks())) {
+  logger_->sinks() = {outputSink_};
   storeConfiguration(std::make_shared<const Configuration>());
 }
 
@@ -128,13 +195,16 @@ void CommsSpdlogLogger::logFatal(
 
 void CommsSpdlogLogger::configure(
     std::string prefix,
-    std::function<int(void)> threadContextFn) {
+    std::function<int(void)> threadContextFn,
+    std::function<void(std::string_view)> errorCallback) {
   if (!threadContextFn) {
     threadContextFn = []() { return 0; };
   }
   std::shared_ptr<const Configuration> configuration =
-      std::make_shared<const Configuration>(
-          Configuration{std::move(prefix), std::move(threadContextFn)});
+      std::make_shared<const Configuration>(Configuration{
+          std::move(prefix),
+          std::move(threadContextFn),
+          std::move(errorCallback)});
   storeConfiguration(std::move(configuration));
 }
 
@@ -159,6 +229,27 @@ void CommsSpdlogLogger::storeConfiguration(
 #endif
 }
 
+void CommsSpdlogLogger::configureOutput(std::string_view logFilePath) {
+  std::vector<std::shared_ptr<spdlog::sinks::sink>> sinks;
+  if (logFilePath.empty()) {
+    sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
+  } else {
+    const auto path = std::string{logFilePath};
+    try {
+      sinks.push_back(
+          std::make_shared<spdlog::sinks::basic_file_sink_mt>(path, false));
+    } catch (const spdlog::spdlog_ex& error) {
+      throw spdlog::spdlog_ex(
+          "Failed to open comms log file '" + path + "': " + error.what());
+    }
+    sinks.push_back(std::make_shared<StderrRoutingSink>());
+  }
+  for (auto& sink : sinks) {
+    sink->set_formatter(makeFormatter());
+  }
+  outputSink_->set_sinks(std::move(sinks));
+}
+
 void CommsSpdlogLogger::logFormatted(
     spdlog::source_loc location,
     spdlog::level::level_enum level,
@@ -168,6 +259,14 @@ void CommsSpdlogLogger::logFormatted(
   static const auto hostname = getHostName();
   static const auto processId = getpid();
   const auto configuration = loadConfiguration();
+  if (level >= spdlog::level::err && configuration->errorCallback &&
+      !errorCallbackInProgress) {
+    ErrorCallbackGuard guard;
+    try {
+      configuration->errorCallback(message);
+    } catch (...) {
+    }
+  }
   const auto formatted = formatCommsLogMessage(
       levelName,
       message,
@@ -195,10 +294,45 @@ CommsSpdlogLogger& getSpdlogLogger() {
   return logger;
 }
 
+CommsSpdlogLogger& getSpdlogLogger(std::string_view contextName) {
+  if (contextName == kLoggerName) {
+    return getSpdlogLogger();
+  }
+  static std::shared_mutex mutex;
+  static std::map<std::string, std::unique_ptr<CommsSpdlogLogger>, std::less<>>
+      loggers;
+  {
+    std::shared_lock lock{mutex};
+    if (const auto it = loggers.find(contextName); it != loggers.end()) {
+      return *it->second;
+    }
+  }
+  std::unique_lock lock{mutex};
+  if (const auto it = loggers.find(contextName); it != loggers.end()) {
+    return *it->second;
+  }
+  auto name = std::string{contextName};
+  auto logger = std::make_unique<CommsSpdlogLogger>(name);
+  const auto it = loggers.emplace(std::move(name), std::move(logger)).first;
+  return *it->second;
+}
+
 void configureSpdlogLogger(
     std::string prefix,
     std::function<int(void)> threadContextFn) {
   getSpdlogLogger().configure(std::move(prefix), std::move(threadContextFn));
+}
+
+void configureSpdlogLogger(
+    std::string_view contextName,
+    std::string prefix,
+    std::string_view logFilePath,
+    std::function<int(void)> threadContextFn,
+    std::function<void(std::string_view)> errorCallback) {
+  auto& logger = getSpdlogLogger(contextName);
+  logger.configure(
+      std::move(prefix), std::move(threadContextFn), std::move(errorCallback));
+  logger.configureOutput(logFilePath);
 }
 
 void setSpdlogThreadName(std::string_view name) {

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -2,7 +2,13 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdlib>
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
 
 #ifndef SPDLOG_FMT_EXTERNAL
 #error "SpdlogLogger requires SPDLOG_FMT_EXTERNAL from the build target"
@@ -16,28 +22,121 @@
 
 namespace meta::comms::logger {
 
-// Returns the lazily initialized, non-blocking logger for the comms facade.
-spdlog::logger& getSpdlogLogger();
+class CommsSpdlogLogger {
+ public:
+  CommsSpdlogLogger();
+
+  template <typename... Args>
+  void log(
+      spdlog::source_loc location,
+      spdlog::level::level_enum level,
+      spdlog::format_string_t<Args...> format,
+      Args&&... args) {
+    if (!should_log(level)) {
+      return;
+    }
+    logFormatted(
+        location,
+        level,
+        getLevelName(level),
+        fmt::format(format, std::forward<Args>(args)...),
+        false);
+  }
+
+  void log(
+      spdlog::source_loc location,
+      spdlog::level::level_enum level,
+      std::string_view message);
+
+  template <typename... Args>
+  void logFatal(
+      spdlog::source_loc location,
+      spdlog::format_string_t<Args...> format,
+      Args&&... args) {
+    logFormatted(
+        location,
+        spdlog::level::critical,
+        "FATAL",
+        fmt::format(format, std::forward<Args>(args)...),
+        true);
+  }
+
+  void logFatal(spdlog::source_loc location, std::string_view message);
+
+  bool should_log(spdlog::level::level_enum level) const;
+  const std::string& name() const;
+  void set_level(spdlog::level::level_enum level);
+  void flush();
+
+  void configure(std::string prefix, std::function<int(void)> threadContextFn);
+
+ private:
+  struct Configuration {
+    std::string prefix{"COMMS"};
+    std::function<int(void)> threadContextFn{[]() { return 0; }};
+  };
+
+#if defined(__cpp_lib_atomic_shared_ptr) && \
+    __cpp_lib_atomic_shared_ptr >= 201711L
+  using ConfigurationStorage =
+      std::atomic<std::shared_ptr<const Configuration>>;
+#else
+  // NCCLX also builds this target as C++17, before atomic<shared_ptr> exists.
+  using ConfigurationStorage = std::shared_ptr<const Configuration>;
+#endif
+
+  static std::string_view getLevelName(spdlog::level::level_enum level);
+
+  std::shared_ptr<const Configuration> loadConfiguration() const;
+  void storeConfiguration(std::shared_ptr<const Configuration> configuration);
+
+  void logFormatted(
+      spdlog::source_loc location,
+      spdlog::level::level_enum level,
+      std::string_view levelName,
+      std::string_view message,
+      bool bypassLevelGate);
+
+  std::shared_ptr<spdlog::logger> logger_;
+  ConfigurationStorage configuration_;
+};
+
+CommsSpdlogLogger& getSpdlogLogger();
+
+void configureSpdlogLogger(
+    std::string prefix,
+    std::function<int(void)> threadContextFn);
+
+void setSpdlogThreadName(std::string_view threadName);
 
 } // namespace meta::comms::logger
 
+#define COMMS_LOG_IMPL(spdlog_level, spdlog_macro, ...)             \
+  do {                                                              \
+    auto& _comms_logger = ::meta::comms::logger::getSpdlogLogger(); \
+    if (_comms_logger.should_log(spdlog_level)) {                   \
+      spdlog_macro(&_comms_logger, __VA_ARGS__);                    \
+    }                                                               \
+  } while (false)
+
 #define COMMS_LOG_DBG(...) \
-  SPDLOG_LOGGER_DEBUG(&::meta::comms::logger::getSpdlogLogger(), __VA_ARGS__)
+  COMMS_LOG_IMPL(::spdlog::level::debug, SPDLOG_LOGGER_DEBUG, __VA_ARGS__)
 #define COMMS_LOG_INFO(...) \
-  SPDLOG_LOGGER_INFO(&::meta::comms::logger::getSpdlogLogger(), __VA_ARGS__)
+  COMMS_LOG_IMPL(::spdlog::level::info, SPDLOG_LOGGER_INFO, __VA_ARGS__)
 #define COMMS_LOG_WARN(...) \
-  SPDLOG_LOGGER_WARN(&::meta::comms::logger::getSpdlogLogger(), __VA_ARGS__)
+  COMMS_LOG_IMPL(::spdlog::level::warn, SPDLOG_LOGGER_WARN, __VA_ARGS__)
 #define COMMS_LOG_ERR(...) \
-  SPDLOG_LOGGER_ERROR(&::meta::comms::logger::getSpdlogLogger(), __VA_ARGS__)
+  COMMS_LOG_IMPL(::spdlog::level::err, SPDLOG_LOGGER_ERROR, __VA_ARGS__)
+#define COMMS_LOG_CRITICAL(...) \
+  COMMS_LOG_IMPL(::spdlog::level::critical, SPDLOG_LOGGER_CRITICAL, __VA_ARGS__)
 #define COMMS_LOG_FATAL(...)                                        \
   do {                                                              \
     auto& _comms_logger = ::meta::comms::logger::getSpdlogLogger(); \
-    _comms_logger.log(                                              \
-        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION},  \
-        ::spdlog::level::critical,                                  \
-        __VA_ARGS__);                                               \
     _comms_logger.flush();                                          \
     ::spdlog::shutdown();                                           \
+    _comms_logger.logFatal(                                         \
+        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION},  \
+        __VA_ARGS__);                                               \
     std::abort();                                                   \
   } while (false)
 

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -18,6 +18,7 @@
 #error "SpdlogLogger requires SPDLOG_ACTIVE_LEVEL from the build target"
 #endif
 
+#include <spdlog/sinks/dist_sink.h>
 #include <spdlog/spdlog.h>
 
 namespace meta::comms::logger {
@@ -25,6 +26,7 @@ namespace meta::comms::logger {
 class CommsSpdlogLogger {
  public:
   CommsSpdlogLogger();
+  explicit CommsSpdlogLogger(std::string name);
 
   template <typename... Args>
   void log(
@@ -68,12 +70,17 @@ class CommsSpdlogLogger {
   void set_level(spdlog::level::level_enum level);
   void flush();
 
-  void configure(std::string prefix, std::function<int(void)> threadContextFn);
+  void configure(
+      std::string prefix,
+      std::function<int(void)> threadContextFn,
+      std::function<void(std::string_view)> errorCallback = {});
+  void configureOutput(std::string_view logFilePath);
 
  private:
   struct Configuration {
     std::string prefix{"COMMS"};
     std::function<int(void)> threadContextFn{[]() { return 0; }};
+    std::function<void(std::string_view)> errorCallback;
   };
 
 #if defined(__cpp_lib_atomic_shared_ptr) && \
@@ -98,46 +105,117 @@ class CommsSpdlogLogger {
       bool bypassLevelGate);
 
   std::shared_ptr<spdlog::logger> logger_;
+  std::shared_ptr<spdlog::sinks::dist_sink_mt> outputSink_;
   ConfigurationStorage configuration_;
 };
 
 CommsSpdlogLogger& getSpdlogLogger();
+CommsSpdlogLogger& getSpdlogLogger(std::string_view contextName);
 
 void configureSpdlogLogger(
     std::string prefix,
     std::function<int(void)> threadContextFn);
 
+void configureSpdlogLogger(
+    std::string_view contextName,
+    std::string prefix,
+    std::string_view logFilePath,
+    std::function<int(void)> threadContextFn,
+    std::function<void(std::string_view)> errorCallback);
+
 void setSpdlogThreadName(std::string_view threadName);
+
+bool shouldWriteCommsLogToStderr(spdlog::level::level_enum level);
 
 } // namespace meta::comms::logger
 
-#define COMMS_LOG_IMPL(spdlog_level, spdlog_macro, ...)             \
-  do {                                                              \
-    auto& _comms_logger = ::meta::comms::logger::getSpdlogLogger(); \
-    if (_comms_logger.should_log(spdlog_level)) {                   \
-      spdlog_macro(&_comms_logger, __VA_ARGS__);                    \
-    }                                                               \
+#define COMMS_LOG_IMPL(logger_expression, spdlog_level, spdlog_macro, ...) \
+  do {                                                                     \
+    auto& _comms_logger = (logger_expression);                             \
+    if (_comms_logger.should_log(spdlog_level)) {                          \
+      spdlog_macro(&_comms_logger, __VA_ARGS__);                           \
+    }                                                                      \
   } while (false)
 
-#define COMMS_LOG_DBG(...) \
-  COMMS_LOG_IMPL(::spdlog::level::debug, SPDLOG_LOGGER_DEBUG, __VA_ARGS__)
-#define COMMS_LOG_INFO(...) \
-  COMMS_LOG_IMPL(::spdlog::level::info, SPDLOG_LOGGER_INFO, __VA_ARGS__)
-#define COMMS_LOG_WARN(...) \
-  COMMS_LOG_IMPL(::spdlog::level::warn, SPDLOG_LOGGER_WARN, __VA_ARGS__)
-#define COMMS_LOG_ERR(...) \
-  COMMS_LOG_IMPL(::spdlog::level::err, SPDLOG_LOGGER_ERROR, __VA_ARGS__)
-#define COMMS_LOG_CRITICAL(...) \
-  COMMS_LOG_IMPL(::spdlog::level::critical, SPDLOG_LOGGER_CRITICAL, __VA_ARGS__)
-#define COMMS_LOG_FATAL(...)                                        \
-  do {                                                              \
-    auto& _comms_logger = ::meta::comms::logger::getSpdlogLogger(); \
-    _comms_logger.flush();                                          \
-    ::spdlog::shutdown();                                           \
-    _comms_logger.logFatal(                                         \
-        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION},  \
-        __VA_ARGS__);                                               \
-    std::abort();                                                   \
+#define COMMS_LOG_FATAL_IMPL(logger_expression, ...)               \
+  do {                                                             \
+    auto& _comms_logger = (logger_expression);                     \
+    _comms_logger.flush();                                         \
+    ::spdlog::shutdown();                                          \
+    _comms_logger.logFatal(                                        \
+        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, \
+        __VA_ARGS__);                                              \
+    std::abort();                                                  \
   } while (false)
+
+#define COMMS_LOG_DBG(...)                      \
+  COMMS_LOG_IMPL(                               \
+      ::meta::comms::logger::getSpdlogLogger(), \
+      ::spdlog::level::debug,                   \
+      SPDLOG_LOGGER_DEBUG,                      \
+      __VA_ARGS__)
+#define COMMS_LOG_CONTEXT_DBG(context, ...)            \
+  COMMS_LOG_IMPL(                                      \
+      ::meta::comms::logger::getSpdlogLogger(context), \
+      ::spdlog::level::debug,                          \
+      SPDLOG_LOGGER_DEBUG,                             \
+      __VA_ARGS__)
+
+#define COMMS_LOG_INFO(...)                     \
+  COMMS_LOG_IMPL(                               \
+      ::meta::comms::logger::getSpdlogLogger(), \
+      ::spdlog::level::info,                    \
+      SPDLOG_LOGGER_INFO,                       \
+      __VA_ARGS__)
+#define COMMS_LOG_WARN(...)                     \
+  COMMS_LOG_IMPL(                               \
+      ::meta::comms::logger::getSpdlogLogger(), \
+      ::spdlog::level::warn,                    \
+      SPDLOG_LOGGER_WARN,                       \
+      __VA_ARGS__)
+#define COMMS_LOG_ERR(...)                      \
+  COMMS_LOG_IMPL(                               \
+      ::meta::comms::logger::getSpdlogLogger(), \
+      ::spdlog::level::err,                     \
+      SPDLOG_LOGGER_ERROR,                      \
+      __VA_ARGS__)
+#define COMMS_LOG_CRITICAL(...)                 \
+  COMMS_LOG_IMPL(                               \
+      ::meta::comms::logger::getSpdlogLogger(), \
+      ::spdlog::level::critical,                \
+      SPDLOG_LOGGER_CRITICAL,                   \
+      __VA_ARGS__)
+#define COMMS_LOG_FATAL(...) \
+  COMMS_LOG_FATAL_IMPL(::meta::comms::logger::getSpdlogLogger(), __VA_ARGS__)
+
+#define COMMS_LOG_CONTEXT_INFO(context, ...)           \
+  COMMS_LOG_IMPL(                                      \
+      ::meta::comms::logger::getSpdlogLogger(context), \
+      ::spdlog::level::info,                           \
+      SPDLOG_LOGGER_INFO,                              \
+      __VA_ARGS__)
+#define COMMS_LOG_CONTEXT_WARN(context, ...)           \
+  COMMS_LOG_IMPL(                                      \
+      ::meta::comms::logger::getSpdlogLogger(context), \
+      ::spdlog::level::warn,                           \
+      SPDLOG_LOGGER_WARN,                              \
+      __VA_ARGS__)
+#define COMMS_LOG_CONTEXT_ERR(context, ...)            \
+  COMMS_LOG_IMPL(                                      \
+      ::meta::comms::logger::getSpdlogLogger(context), \
+      ::spdlog::level::err,                            \
+      SPDLOG_LOGGER_ERROR,                             \
+      __VA_ARGS__)
+#define COMMS_LOG_CONTEXT_CRITICAL(context, ...)       \
+  COMMS_LOG_IMPL(                                      \
+      ::meta::comms::logger::getSpdlogLogger(context), \
+      ::spdlog::level::critical,                       \
+      SPDLOG_LOGGER_CRITICAL,                          \
+      __VA_ARGS__)
+#define COMMS_LOG_CONTEXT_FATAL(context, ...) \
+  COMMS_LOG_FATAL_IMPL(                       \
+      ::meta::comms::logger::getSpdlogLogger(context), __VA_ARGS__)
 
 #define COMMS_LOG(level, ...) COMMS_LOG_##level(__VA_ARGS__)
+#define COMMS_LOG_CONTEXT(context, level, ...) \
+  COMMS_LOG_CONTEXT_##level(context, __VA_ARGS__)

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -5,6 +5,7 @@
 
 #include "comms/utils/logger/SpdlogLogger.h"
 
+#include <stdexcept>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -21,6 +22,27 @@ class LogLevelRestoringTest : public testing::Test {
 TEST(SpdlogLoggerTest, ReturnsStableNamedLogger) {
   EXPECT_EQ(&getSpdlogLogger(), &getSpdlogLogger());
   EXPECT_EQ(getSpdlogLogger().name(), "comms");
+}
+
+TEST(SpdlogLoggerTest, ReturnsStableLoggerPerContext) {
+  auto& ctranLogger = getSpdlogLogger("comms.ctran");
+  EXPECT_EQ(&ctranLogger, &getSpdlogLogger("comms.ctran"));
+  EXPECT_NE(&ctranLogger, &getSpdlogLogger("comms.ncclx"));
+  EXPECT_EQ(ctranLogger.name(), "comms.ctran");
+}
+
+TEST(SpdlogLoggerTest, MatchesLegacyStderrRouting) {
+  EXPECT_TRUE(
+      meta::comms::logger::shouldWriteCommsLogToStderr(spdlog::level::warn));
+  EXPECT_TRUE(
+      meta::comms::logger::shouldWriteCommsLogToStderr(spdlog::level::err));
+  EXPECT_TRUE(
+      meta::comms::logger::shouldWriteCommsLogToStderr(
+          spdlog::level::critical));
+  EXPECT_FALSE(
+      meta::comms::logger::shouldWriteCommsLogToStderr(spdlog::level::info));
+  EXPECT_FALSE(
+      meta::comms::logger::shouldWriteCommsLogToStderr(spdlog::level::off));
 }
 
 TEST(SpdlogLoggerTest, MapsFollyLevelNames) {
@@ -84,4 +106,89 @@ TEST_F(LogLevelRestoringTest, EmptyThreadContextUsesDefault) {
   EXPECT_NO_THROW(COMMS_LOG(INFO, "empty callback"));
 
   meta::comms::logger::configureSpdlogLogger("COMMS", []() { return 0; });
+}
+
+TEST(SpdlogLoggerTest, ErrorCallbackReceivesFormattedUserMessage) {
+  std::string errorMessage;
+  auto& logger = getSpdlogLogger("comms.callback_test");
+  logger.configure(
+      "TEST",
+      []() { return 0; },
+      [&](std::string_view message) { errorMessage = message; });
+
+  COMMS_LOG_CONTEXT("comms.callback_test", ERR, "error message: {}", 9);
+  EXPECT_EQ(errorMessage, "error message: 9");
+  logger.configure("TEST", []() { return 0; }, {});
+}
+
+TEST(SpdlogLoggerTest, ErrorCallbackDoesNotReenter) {
+  constexpr std::string_view kContext = "comms.reentrant_callback_test";
+  int callbackCount = 0;
+  auto& logger = getSpdlogLogger(kContext);
+  logger.configure(
+      "TEST",
+      []() { return 0; },
+      [&](std::string_view) {
+        ++callbackCount;
+        COMMS_LOG_CONTEXT(kContext, ERR, "nested error");
+      });
+
+  COMMS_LOG_CONTEXT(kContext, ERR, "outer error");
+  EXPECT_EQ(callbackCount, 1);
+  logger.configure("TEST", []() { return 0; }, {});
+}
+
+TEST(SpdlogLoggerTest, ErrorCallbackGuardSpansContexts) {
+  constexpr std::string_view kOuterContext = "comms.outer_callback_test";
+  constexpr std::string_view kInnerContext = "comms.inner_callback_test";
+  int outerCallbackCount = 0;
+  int innerCallbackCount = 0;
+  auto& outerLogger = getSpdlogLogger(kOuterContext);
+  auto& innerLogger = getSpdlogLogger(kInnerContext);
+  innerLogger.configure(
+      "TEST",
+      []() { return 0; },
+      [&](std::string_view) { ++innerCallbackCount; });
+  outerLogger.configure(
+      "TEST",
+      []() { return 0; },
+      [&](std::string_view) {
+        ++outerCallbackCount;
+        COMMS_LOG_CONTEXT(kInnerContext, ERR, "nested error");
+      });
+
+  COMMS_LOG_CONTEXT(kOuterContext, ERR, "outer error");
+  EXPECT_EQ(outerCallbackCount, 1);
+  EXPECT_EQ(innerCallbackCount, 0);
+  outerLogger.configure("TEST", []() { return 0; }, {});
+  innerLogger.configure("TEST", []() { return 0; }, {});
+}
+
+TEST(SpdlogLoggerTest, ErrorCallbackExceptionDoesNotEscapeLogCall) {
+  constexpr std::string_view kContext = "comms.throwing_callback_test";
+  int callbackCount = 0;
+  auto& logger = getSpdlogLogger(kContext);
+  logger.configure(
+      "TEST",
+      []() { return 0; },
+      [&](std::string_view) {
+        ++callbackCount;
+        throw std::runtime_error{"callback failure"};
+      });
+
+  EXPECT_NO_THROW(COMMS_LOG_CONTEXT(kContext, ERR, "first error"));
+  EXPECT_NO_THROW(COMMS_LOG_CONTEXT(kContext, ERR, "second error"));
+  EXPECT_EQ(callbackCount, 2);
+  logger.configure("TEST", []() { return 0; }, {});
+}
+
+TEST(SpdlogLoggerTest, FileOpenFailureIncludesPath) {
+  constexpr std::string_view kLogPath = "/proc/comms_spdlog_missing/logger.log";
+
+  try {
+    getSpdlogLogger("comms.file_failure_test").configureOutput(kLogPath);
+    FAIL() << "Expected configureOutput to reject an invalid path";
+  } catch (const spdlog::spdlog_ex& error) {
+    EXPECT_NE(std::string{error.what()}.find(kLogPath), std::string::npos);
+  }
 }

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -5,9 +5,18 @@
 
 #include "comms/utils/logger/SpdlogLogger.h"
 
+#include <string>
+
 #include <gtest/gtest.h>
 
 using meta::comms::logger::getSpdlogLogger;
+
+class LogLevelRestoringTest : public testing::Test {
+ protected:
+  void TearDown() override {
+    getSpdlogLogger().set_level(spdlog::level::info);
+  }
+};
 
 TEST(SpdlogLoggerTest, ReturnsStableNamedLogger) {
   EXPECT_EQ(&getSpdlogLogger(), &getSpdlogLogger());
@@ -20,12 +29,32 @@ TEST(SpdlogLoggerTest, MapsFollyLevelNames) {
     COMMS_LOG(INFO, "info message: {}", 2);
     COMMS_LOG(WARN, "warning message: {}", 3);
     COMMS_LOG(ERR, "error message: {}", 4);
+    COMMS_LOG(CRITICAL, std::string{"critical message"});
   });
 }
 
 TEST(SpdlogLoggerTest, FatalTerminatesProcess) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-  EXPECT_DEATH(COMMS_LOG(FATAL, "fatal message: {}", 5), "fatal message: 5");
+  EXPECT_DEATH(
+      {
+        thread_local int threadContext = 7;
+        meta::comms::logger::configureSpdlogLogger(
+            "CTRAN", [&]() { return threadContext; });
+        meta::comms::logger::setSpdlogThreadName("caller");
+        COMMS_LOG(INFO, "message before fatal");
+        COMMS_LOG(FATAL, "fatal message: {}", 5);
+      },
+      "message before fatal(.|\\n)*\\[7\\]\\[caller\\] CTRAN FATAL fatal message: 5");
+}
+
+TEST_F(LogLevelRestoringTest, FatalIsNotSuppressedByRuntimeLevel) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_DEATH(
+      {
+        getSpdlogLogger().set_level(spdlog::level::off);
+        COMMS_LOG(FATAL, "fatal while logging is disabled");
+      },
+      "FATAL fatal while logging is disabled");
 }
 
 TEST(SpdlogLoggerTest, CompileTimeGateSkipsArguments) {
@@ -35,4 +64,24 @@ TEST(SpdlogLoggerTest, CompileTimeGateSkipsArguments) {
 
   COMMS_LOG(INFO, "compiled in: {}", ++evaluationCount);
   EXPECT_EQ(evaluationCount, 1);
+}
+
+TEST_F(LogLevelRestoringTest, RuntimeGateSkipsArguments) {
+  int evaluationCount = 0;
+  getSpdlogLogger().set_level(spdlog::level::warn);
+
+  COMMS_LOG(INFO, "filtered at runtime: {}", ++evaluationCount);
+  EXPECT_EQ(evaluationCount, 0);
+
+  COMMS_LOG(WARN, "enabled at runtime: {}", ++evaluationCount);
+  EXPECT_EQ(evaluationCount, 1);
+}
+
+TEST_F(LogLevelRestoringTest, EmptyThreadContextUsesDefault) {
+  getSpdlogLogger().set_level(spdlog::level::info);
+  meta::comms::logger::configureSpdlogLogger("TEST", {});
+
+  EXPECT_NO_THROW(COMMS_LOG(INFO, "empty callback"));
+
+  meta::comms::logger::configureSpdlogLogger("COMMS", []() { return 0; });
 }


### PR DESCRIPTION
Summary:

Configure a named CTRAN spdlog context alongside the existing Folly logger during the transition. Derive its output path and runtime level from the same `NCCL_DEBUG_FILE` and `NCCL_DEBUG` settings, preserve producer-thread GPU metadata, and update last-error state synchronously for future ERR migrations.

Migrate only the three process-wide multicast capability warnings. Leave the `retainSegments()` warnings on Folly because their existing test relies on synchronous stderr delivery; this keeps the first production caller batch bounded without weakening coverage.

Reviewed By: shr

Differential Revision: D114829369


