### PR TITLE
SendRecvTile prereqs: kMaxIbGroups 64->256 + expose AnsCompress::kMaxUncompBytes (#3454)

### DIFF
--- a/comms/prims/core/CopyOp.cuh
+++ b/comms/prims/core/CopyOp.cuh
@@ -368,6 +368,13 @@ struct AnsCompress {
   // shmem / aux-buf overhead.
   static constexpr std::size_t kActivationThreshold = 4ULL * 1024 * 1024;
 
+  // Maximum uncompressed sub-chunk size this CopyOp operates on (the
+  // `MaxUncompBytes` template arg). Consumers that stage a full uncompressed
+  // chunk (e.g. the per-block realign aux buffer in SendRecvTileCommon) size
+  // that scratch off this so the geometry tracks the CopyOp instead of a
+  // hard-coded per-algorithm constant.
+  static constexpr std::size_t kMaxUncompBytes = MaxUncompBytes;
+
  private:
   // ===========================================================================
   // Compile-time SM picker. nvCOMPDx instantiates a fully-typed

--- a/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
+++ b/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
@@ -131,5 +131,32 @@ TEST(MultiPeerIbTransportConfigTest, PeerMaterializationDefaultsOnDemand) {
   EXPECT_TRUE(config.ibLazyConnect);
 }
 
+// PeerQpPayload is the lazy (ibLazyConnect) bilateral wire format: one is sent
+// and one received per peer on every materializePeer(), and both live on the
+// stack while in flight. Its qpns[] array is dimensioned by
+// kMaxIbQpsPerPeerPerNic, so that constant must stay a QP budget in its own
+// right rather than being derived from the kMaxIbGroups index space -- growing
+// the group index space must not grow what every lazy peer exchange costs. The
+// footprint bound is kMaxNicsPerGpu * 8192 QPNs, ~64KB.
+TEST(MultiPeerIbTransportConfigTest, LazyQpPayloadDoesNotScaleWithGroupLimit) {
+  EXPECT_LT(kMaxIbQpsPerPeerPerNic, kMaxIbGroups * kMaxIbQpsPerBlockPerNic);
+  EXPECT_LE(sizeof(PeerQpPayload), 72u * 1024u);
+}
+
+// The shape this limit exists for -- SendRecvTile's 256 channels, both
+// directions -- must fit the QP budget while landing above the eager exchange
+// cap, i.e. it is reachable only with ibLazyConnect=true.
+TEST(MultiPeerIbTransportConfigTest, MaxGroupShapeFitsBudgetAndRequiresLazy) {
+  MultipeerIbTransportConfig config;
+  config.perChannelSize = 64 * 1024; // > 0 selects the two-direction shape
+  config.max_num_channels = kMaxIbGroups;
+  config.qpsPerConnection = 1;
+
+  const int mainQps = config.fixedChannelMainQpsPerPeerPerNic();
+  EXPECT_EQ(mainQps, kMaxIbGroups * kIbDirections);
+  EXPECT_LE(mainQps, kMaxIbQpsPerPeerPerNic);
+  EXPECT_GT(mainQps, kMaxEagerExchangeQpsPerPeerPerNic);
+}
+
 } // namespace
 } // namespace comms::prims

--- a/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
+++ b/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
@@ -593,5 +593,61 @@ TEST(MultiPeerIbTransportConfigTest, QpOrderingWireDefaultMatchesIbta) {
       payload.qpOrderingSemantic, static_cast<int>(IbQpOrderingSemantic::Ibta));
 }
 
+// PeerQpPayload is the lazy (ibLazyConnect) bilateral wire format: one is sent
+// and one received per peer on every materializePeer(), and both live on the
+// stack while in flight. Its qpns[] array is dimensioned by
+// kMaxIbQpsPerPeerPerNic, so that constant must stay a QP budget in its own
+// right rather than being derived from the kMaxIbGroups index space -- growing
+// the group index space must not grow what every lazy peer exchange costs. The
+// footprint bound is kMaxNicsPerGpu * 8192 QPNs, ~64KB.
+TEST(MultiPeerIbTransportConfigTest, LazyQpPayloadDoesNotScaleWithGroupLimit) {
+  // What actually matters to a lazy caller is the observable property: the
+  // bilateral exchange payload stays small no matter how wide the group index
+  // space gets. Assert that directly, against the same named bound the header
+  // static_asserts on, so there is no second copy of the number to drift.
+  //
+  // Deliberately NOT `kMaxIbQpsPerPeerPerNic < kMaxIbGroups *
+  // kMaxIbQpsPerBlockPerNic`: that only holds because kMaxIbGroups is 256
+  // today. Returning it to 64 would make the product exactly 8192 and turn the
+  // check red even though the constant would still be independent -- it
+  // expresses the decoupling only by accident.
+  //
+  // Nor `sizeof(PeerQpPayload) <= kMaxPeerQpPayloadBytes`: that is the header's
+  // static_assert, so a violation fails to compile and this test could never go
+  // red. Assert instead what only a runtime check can see -- that the WIDEST
+  // shape the index space admits still fits the exchanged array. That is the
+  // property a future kMaxIbGroups bump can actually break.
+  MultipeerIbTransportConfig narrow;
+  narrow.perChannelSize = 64 * 1024; // > 0 selects the two-direction shape
+  narrow.max_num_channels = 1;
+  narrow.qpsPerConnection = 1;
+
+  MultipeerIbTransportConfig widest = narrow;
+  widest.max_num_channels = kMaxIbGroups;
+
+  ASSERT_LT(
+      narrow.fixedChannelMainQpsPerPeerPerNic(),
+      widest.fixedChannelMainQpsPerPeerPerNic())
+      << "the two shapes must differ for this to prove anything";
+  EXPECT_LE(widest.fixedChannelMainQpsPerPeerPerNic(), kMaxIbQpsPerPeerPerNic)
+      << "the widest configurable shape must fit the exchanged qpns[] array; "
+         "raising kMaxIbGroups past the QP budget needs a wire-format change";
+}
+
+// The shape this limit exists for -- SendRecvTile's 256 channels, both
+// directions -- must fit the QP budget while landing above the eager exchange
+// cap, i.e. it is reachable only with ibLazyConnect=true.
+TEST(MultiPeerIbTransportConfigTest, MaxGroupShapeFitsBudgetAndRequiresLazy) {
+  MultipeerIbTransportConfig config;
+  config.perChannelSize = 64 * 1024; // > 0 selects the two-direction shape
+  config.max_num_channels = kMaxIbGroups;
+  config.qpsPerConnection = 1;
+
+  const int mainQps = config.fixedChannelMainQpsPerPeerPerNic();
+  EXPECT_EQ(mainQps, kMaxIbGroups * kIbDirections);
+  EXPECT_LE(mainQps, kMaxIbQpsPerPeerPerNic);
+  EXPECT_GT(mainQps, kMaxEagerExchangeQpsPerPeerPerNic);
+}
+
 } // namespace
 } // namespace comms::prims

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -2867,9 +2867,13 @@ class LazyModeTestFixture
     return GetParam();
   }
 
-  std::unique_ptr<TestIbTransport> createLazyTransport() {
+  std::unique_ptr<TestIbTransport> createLazyTransport(
+      int maxChannels = 64,
+      std::size_t perChannelSize = 0) {
     MultipeerIbTransportConfig config{
         .cudaDevice = localRank,
+        .perChannelSize = perChannelSize,
+        .max_num_channels = maxChannels,
         .numSignalSlots = 1,
         .numCounterSlots = 1,
         .ibLazyConnect = true,
@@ -2918,6 +2922,93 @@ TEST_P(LazyModeTestFixture, QueueThenConnect) {
 
     transport->connectPeers();
     EXPECT_TRUE(transport->isPeerMaterialized(peerRank));
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << backendName(backend()) << " not available: " << e.what();
+  }
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+// A full kMaxIbGroups channel count is reachable only through lazy peer
+// materialization: kMaxIbGroups channels x kIbDirections is far past
+// kMaxEagerExchangeQpsPerPeerPerNic. Materializes that shape for real and moves
+// data over it, so the bilateral PeerQpPayload exchange is exercised at the
+// widest group count the index space allows.
+TEST_P(LazyModeTestFixture, MaterializeAndTransferAboveEagerQpLimit) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+  }
+  ASSERT_GT(kMaxIbGroups * kIbDirections, kMaxEagerExchangeQpsPerPeerPerNic);
+
+  constexpr std::size_t perChannelSize = 4 * 1024;
+  constexpr std::size_t nbytes = 64 * 1024;
+  constexpr int numBlocks = 1;
+  constexpr int blockSize = 32;
+  constexpr uint8_t testPattern = 0x5a;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+
+  try {
+    auto transport = createLazyTransport(kMaxIbGroups, perChannelSize);
+    EXPECT_FALSE(transport->isPeerMaterialized(peerRank));
+
+    DeviceBuffer dataBuffer(nbytes);
+    auto localDataBuf = transport->registerBuffer(dataBuffer.get(), nbytes);
+    auto remoteDataBufs = transport->exchangeBuffer(localDataBuf);
+    const int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
+    auto remoteDataBuf = remoteDataBufs[peerIndex];
+
+    auto peerTransport = transport->getP2pTransportDevice(peerRank);
+    EXPECT_TRUE(transport->isPeerMaterialized(peerRank));
+
+    if (globalRank == 0) {
+      test::fillBufferWithPattern(
+          localDataBuf.ptr, nbytes, testPattern, numBlocks, blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      test::testPutAndSignal(
+          peerTransport,
+          localDataBuf,
+          remoteDataBuf,
+          nbytes,
+          /*signalId=*/0,
+          /*signalVal=*/1,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    } else {
+      CUDACHECK_TEST(cudaMemset(localDataBuf.ptr, 0, nbytes));
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      test::testWaitSignal(
+          peerTransport,
+          /*signalId=*/0,
+          /*expected=*/1,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      DeviceBuffer errorCountBuf(sizeof(int));
+      auto* dErrorCount = static_cast<int*>(errorCountBuf.get());
+      CUDACHECK_TEST(cudaMemset(dErrorCount, 0, sizeof(int)));
+      test::verifyBufferPattern(
+          localDataBuf.ptr,
+          nbytes,
+          testPattern,
+          dErrorCount,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      int hErrorCount = 0;
+      CUDACHECK_TEST(cudaMemcpy(
+          &hErrorCount, dErrorCount, sizeof(int), cudaMemcpyDeviceToHost));
+      EXPECT_EQ(hErrorCount, 0)
+          << "Rank " << globalRank << ": " << hErrorCount
+          << " byte mismatches over a " << kMaxIbGroups << "-group lazy peer";
+    }
   } catch (const std::exception& e) {
     GTEST_SKIP() << backendName(backend()) << " not available: " << e.what();
   }

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -7,6 +7,7 @@
 #include <chrono>
 #include "comms/utils/logger/SpdlogLogger.h"
 
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -3941,9 +3942,16 @@ class LazyModeTestFixture
     return GetParam();
   }
 
-  std::unique_ptr<TestIbTransport> createLazyTransport() {
+  // Default taken from the config struct rather than restated, so a change to
+  // MultipeerIbTransportConfig::max_num_channels keeps applying to the callers
+  // that do not pass one.
+  std::unique_ptr<TestIbTransport> createLazyTransport(
+      int maxChannels = MultipeerIbTransportConfig{}.max_num_channels,
+      std::size_t perChannelSize = 0) {
     MultipeerIbTransportConfig config{
         .cudaDevice = localRank,
+        .perChannelSize = perChannelSize,
+        .max_num_channels = maxChannels,
         .numSignalSlots = 1,
         .numCounterSlots = 1,
         .ibLazyConnect = true,
@@ -3994,6 +4002,254 @@ TEST_P(LazyModeTestFixture, QueueThenConnect) {
     EXPECT_TRUE(transport->isPeerMaterialized(peerRank));
   } catch (const std::exception& e) {
     GTEST_SKIP() << backendName(backend()) << " not available: " << e.what();
+  }
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+// A full kMaxIbGroups channel count is reachable only through lazy peer
+// materialization: kMaxIbGroups channels x kIbDirections is far past
+// kMaxEagerExchangeQpsPerPeerPerNic. Materializes that shape for real and moves
+// data over it, so the bilateral PeerQpPayload exchange is exercised at the
+// widest group count the index space allows.
+TEST_P(LazyModeTestFixture, MaterializeAndTransferAboveEagerQpLimit) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+  }
+  ASSERT_GT(kMaxIbGroups * kIbDirections, kMaxEagerExchangeQpsPerPeerPerNic);
+
+  constexpr std::size_t perChannelSize = 4 * 1024;
+  constexpr std::size_t nbytes = 64 * 1024;
+  constexpr int numBlocks = 1;
+  constexpr int blockSize = 32;
+  constexpr uint8_t testPattern = 0x5a;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+
+  // Try only around construction, with the skip decision reduced across ranks
+  // -- same shape as FixedChannelSendRecvSpansGroupsAboveLegacyLimit below, and
+  // for the same two reasons: a genuine failure at the 256-group shape is what
+  // this test exists to catch and must not be reported as "backend not
+  // available", and a rank that bailed out mid-body would leave its peer
+  // blocked in an inner barrier.
+  std::unique_ptr<TestIbTransport> transport;
+  std::string setupError;
+  try {
+    transport = createLazyTransport(kMaxIbGroups, perChannelSize);
+  } catch (const std::exception& e) {
+    setupError = e.what();
+  }
+  int localSetupOk = setupError.empty() ? 1 : 0;
+  int globalSetupOk = 0;
+  MPI_CHECK(MPI_Allreduce(
+      &localSetupOk, &globalSetupOk, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD));
+  if (globalSetupOk == 0) {
+    if (setupError.empty()) {
+      GTEST_SKIP() << backendName(backend())
+                   << " not available: peer rank could not construct";
+    }
+    GTEST_SKIP() << backendName(backend()) << " not available: " << setupError;
+  }
+
+  {
+    EXPECT_FALSE(transport->isPeerMaterialized(peerRank));
+
+    DeviceBuffer dataBuffer(nbytes);
+    auto localDataBuf = transport->registerBuffer(dataBuffer.get(), nbytes);
+    auto remoteDataBufs = transport->exchangeBuffer(localDataBuf);
+    const int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
+    auto remoteDataBuf = remoteDataBufs[peerIndex];
+
+    auto peerTransport = transport->getP2pTransportDevice(peerRank);
+    EXPECT_TRUE(transport->isPeerMaterialized(peerRank));
+
+    if (globalRank == 0) {
+      test::fillBufferWithPattern(
+          localDataBuf.ptr, nbytes, testPattern, numBlocks, blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      test::testPutAndSignal(
+          peerTransport,
+          localDataBuf,
+          remoteDataBuf,
+          nbytes,
+          /*signalId=*/0,
+          /*signalVal=*/1,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    } else {
+      CUDACHECK_TEST(cudaMemset(localDataBuf.ptr, 0, nbytes));
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      test::testWaitSignal(
+          peerTransport,
+          /*signalId=*/0,
+          /*expectedSignal=*/1,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      DeviceBuffer errorCountBuf(sizeof(int));
+      auto* dErrorCount = static_cast<int*>(errorCountBuf.get());
+      CUDACHECK_TEST(cudaMemset(dErrorCount, 0, sizeof(int)));
+      test::verifyBufferPattern(
+          localDataBuf.ptr,
+          nbytes,
+          testPattern,
+          dErrorCount,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      int hErrorCount = 0;
+      CUDACHECK_TEST(cudaMemcpy(
+          &hErrorCount, dErrorCount, sizeof(int), cudaMemcpyDeviceToHost));
+      EXPECT_EQ(hErrorCount, 0)
+          << "Rank " << globalRank << ": " << hErrorCount
+          << " byte mismatches over a " << kMaxIbGroups << "-group lazy peer";
+    }
+  }
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+// The group ceiling this diff replaces. Named so the test below cannot
+// quietly become vacuous if kMaxIbGroups is ever lowered back toward it.
+constexpr int kLegacyMaxIbGroups = 64;
+
+// MaterializeAndTransferAboveEagerQpLimit proves the lazy peer EXCHANGE
+// survives 512 QPs. It does not prove send/recv can SELECT a channel above the
+// old ceiling: it moves its bytes with a single-block put/signal, so it only
+// ever touches channel 0. Channel selection indexes a different set of
+// structures per block -- the per-(channel, protocol) resource slot, its
+// staging window, its progress cursor and its QP lane -- and none of those
+// above index 63 were reached.
+//
+// So drive the real fixed-channel send/recv path with one block per channel
+// across the whole 0..kMaxIbGroups-1 range. Two properties make the coverage
+// real rather than nominal:
+//   - each block owns its own slice, so a channel that moves nothing leaves
+//     its slice zeroed instead of being covered by a sibling block writing the
+//     same bytes;
+//   - bytesPerBlock stays inside one pipeline window, so a sender never waits
+//     on a peer's SLOT_FREE. With 256 blocks per rank and far fewer resident,
+//     a sender that could block on a not-yet-scheduled receiver would deadlock
+//     the test rather than fail it.
+TEST_P(LazyModeTestFixture, FixedChannelSendRecvSpansGroupsAboveLegacyLimit) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+  }
+  ASSERT_GT(kMaxIbGroups, kLegacyMaxIbGroups)
+      << "vacuous unless the group limit is above the legacy ceiling";
+
+  constexpr int numBlocks = kMaxIbGroups;
+  constexpr int blockSize = 256;
+  // Inside one pipeline window (perChannelSize) -- see the deadlock note above.
+  constexpr std::size_t bytesPerBlock = 4 * 1024;
+  constexpr std::size_t perChannelSize = 16 * 1024;
+  constexpr std::size_t maxSignalBytes = 0;
+  constexpr uint8_t basePattern = 0x11;
+  constexpr std::size_t totalBytes = bytesPerBlock * numBlocks;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+
+  // Only the transport construction is allowed to turn into a skip, and the
+  // skip decision is reduced across ranks before it is acted on. Wrapping the
+  // whole body instead would (a) report a genuine failure at the 256-group
+  // shape -- exactly what this test targets -- as "backend not available", and
+  // (b) let one rank bail out mid-test while its peer is still blocked on an
+  // inner barrier, hanging the run instead of failing it.
+  std::unique_ptr<TestIbTransport> transport;
+  std::string setupError;
+  try {
+    // perChannelSize > 0 selects the fixed-channel shape, which is also what
+    // makes the transport derive maxGroups from max_num_channels -- device-side
+    // QP selection needs block_id < maxGroups, so a 64-group transport would
+    // fault on block 64 rather than merely mis-route it.
+    transport = createLazyTransport(kMaxIbGroups, perChannelSize);
+  } catch (const std::exception& e) {
+    setupError = e.what();
+  }
+  int localSetupOk = setupError.empty() ? 1 : 0;
+  int globalSetupOk = 0;
+  MPI_CHECK(MPI_Allreduce(
+      &localSetupOk, &globalSetupOk, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD));
+  if (globalSetupOk == 0) {
+    // Two statements rather than a ternary: mixing a string literal with
+    // `setupError` in one conditional forces both arms to std::string, which
+    // copies the error on the branch that already owns it.
+    if (setupError.empty()) {
+      GTEST_SKIP() << backendName(backend())
+                   << " not available: peer rank could not construct";
+    }
+    GTEST_SKIP() << backendName(backend()) << " not available: " << setupError;
+  }
+
+  {
+    auto peerTransport = transport->getP2pTransportDevice(peerRank);
+    // EXPECT, not ASSERT: an ASSERT returns from the test body, so a rank that
+    // failed here would skip the trailing barrier while its peer stays blocked
+    // in it -- turning a failure into a distributed hang, and desyncing the
+    // barrier sequence for every later test in the binary.
+    EXPECT_TRUE(transport->isPeerMaterialized(peerRank));
+
+    DeviceBuffer buffer(totalBytes);
+    if (globalRank == 0) {
+      test::fillShardedPattern(
+          buffer.get(), bytesPerBlock, basePattern, numBlocks, blockSize);
+    } else {
+      CUDACHECK_TEST(cudaMemset(buffer.get(), 0, totalBytes));
+    }
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    test::testShardedSendRecvIb(
+        peerTransport,
+        buffer.get(),
+        bytesPerBlock,
+        maxSignalBytes,
+        /*send=*/globalRank == 0,
+        numBlocks,
+        blockSize);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    if (globalRank == 1) {
+      DeviceBuffer errorCountBuf(sizeof(int));
+      DeviceBuffer firstBadSliceBuf(sizeof(int));
+      auto* dErrorCount = static_cast<int*>(errorCountBuf.get());
+      auto* dFirstBadSlice = static_cast<int*>(firstBadSliceBuf.get());
+      CUDACHECK_TEST(cudaMemset(dErrorCount, 0, sizeof(int)));
+      const int sentinel = std::numeric_limits<int>::max();
+      CUDACHECK_TEST(cudaMemcpy(
+          dFirstBadSlice, &sentinel, sizeof(int), cudaMemcpyHostToDevice));
+
+      test::verifyShardedPattern(
+          buffer.get(),
+          bytesPerBlock,
+          basePattern,
+          dErrorCount,
+          dFirstBadSlice,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      int hErrorCount = 0;
+      int hFirstBadSlice = 0;
+      CUDACHECK_TEST(cudaMemcpy(
+          &hErrorCount, dErrorCount, sizeof(int), cudaMemcpyDeviceToHost));
+      CUDACHECK_TEST(cudaMemcpy(
+          &hFirstBadSlice,
+          dFirstBadSlice,
+          sizeof(int),
+          cudaMemcpyDeviceToHost));
+      EXPECT_EQ(hErrorCount, 0)
+          << hErrorCount << " byte mismatches across " << numBlocks
+          << " fixed channels; first bad channel "
+          << (hFirstBadSlice == sentinel ? -1 : hFirstBadSlice)
+          << " (legacy ceiling was " << kLegacyMaxIbGroups << ")";
+    }
   }
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 }

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -410,6 +410,66 @@ __global__ void sendRecvKernel(
   }
 }
 
+__global__ void shardedSendRecvIbKernel(
+    P2pIbTransportDevice transport,
+    void* buffer,
+    std::size_t bytesPerBlock,
+    std::size_t maxSignalBytes,
+    bool send,
+    AbortDevice abortDevice) {
+  auto group = make_block_group();
+  abortDevice.start();
+  // make_block_group() sets group_id = blockIdx.x, and the fixed-channel
+  // send/recv path keys its channel off group_id, so block b drives channel b.
+  // Giving each block its own slice makes that mapping observable end to end.
+  auto* slice = static_cast<char*>(buffer) +
+      static_cast<std::size_t>(blockIdx.x) * bytesPerBlock;
+  if (send) {
+    transport.send(group, slice, bytesPerBlock, maxSignalBytes, abortDevice);
+  } else {
+    transport.recv(group, slice, bytesPerBlock, maxSignalBytes, abortDevice);
+  }
+}
+
+// Single definition of the sharded pattern, shared by the producer and the
+// checker below. Restating the formula in both is how a test ends up passing
+// or failing for the wrong reason after one side is edited.
+__device__ __forceinline__ uint8_t
+shardedExpectedByte(uint8_t baseValue, unsigned slice, std::size_t i) {
+  return static_cast<uint8_t>(baseValue + slice + (i % 256));
+}
+
+__global__ void fillShardedPatternKernel(
+    uint8_t* buffer,
+    std::size_t bytesPerBlock,
+    uint8_t baseValue) {
+  uint8_t* slice =
+      buffer + static_cast<std::size_t>(blockIdx.x) * bytesPerBlock;
+  for (std::size_t i = threadIdx.x; i < bytesPerBlock; i += blockDim.x) {
+    slice[i] = shardedExpectedByte(baseValue, blockIdx.x, i);
+  }
+}
+
+__global__ void verifyShardedPatternKernel(
+    const uint8_t* buffer,
+    std::size_t bytesPerBlock,
+    uint8_t expectedBaseValue,
+    int* errorCount,
+    int* firstBadSlice) {
+  const uint8_t* slice =
+      buffer + static_cast<std::size_t>(blockIdx.x) * bytesPerBlock;
+  int local = 0;
+  for (std::size_t i = threadIdx.x; i < bytesPerBlock; i += blockDim.x) {
+    if (slice[i] != shardedExpectedByte(expectedBaseValue, blockIdx.x, i)) {
+      ++local;
+    }
+  }
+  if (local > 0) {
+    atomicAdd(errorCount, local);
+    atomicMin(firstBadSlice, static_cast<int>(blockIdx.x));
+  }
+}
+
 __global__ void twoCallSendThenRecvKernel(
     P2pIbTransportDevice transport,
     const void* sendBuffer,
@@ -441,6 +501,64 @@ void testSendRecv(
     int blockSize) {
   sendRecvKernel<<<numBlocks, blockSize>>>(
       transport, buffer, nbytes, maxSignalBytes, send, testAbortDevice());
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
+void testShardedSendRecvIb(
+    P2pIbTransportDevice transport,
+    void* buffer,
+    std::size_t bytesPerBlock,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize) {
+  shardedSendRecvIbKernel<<<numBlocks, blockSize>>>(
+      transport,
+      buffer,
+      bytesPerBlock,
+      maxSignalBytes,
+      send,
+      testAbortDevice());
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
+void fillShardedPattern(
+    void* buffer,
+    std::size_t bytesPerBlock,
+    uint8_t baseValue,
+    int numBlocks,
+    int blockSize) {
+  fillShardedPatternKernel<<<numBlocks, blockSize>>>(
+      static_cast<uint8_t*>(buffer), bytesPerBlock, baseValue);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
+void verifyShardedPattern(
+    const void* buffer,
+    std::size_t bytesPerBlock,
+    uint8_t expectedBaseValue,
+    int* errorCount,
+    int* firstBadSlice,
+    int numBlocks,
+    int blockSize) {
+  verifyShardedPatternKernel<<<numBlocks, blockSize>>>(
+      static_cast<const uint8_t*>(buffer),
+      bytesPerBlock,
+      expectedBaseValue,
+      errorCount,
+      firstBadSlice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -179,6 +179,60 @@ void testPipelineGeometry(
     int blockSize);
 
 /**
+ * Test kernel: blocking pipelined send or recv over the backend-DISPATCHING
+ * `P2pIbTransportDevice`, one fixed channel per block. Block `b` drives
+ * channel `b` over the `bytesPerBlock`-sized slice of `buffer` at
+ * `b * bytesPerBlock`.
+ *
+ * The per-block slice is what makes channel coverage observable. Handing
+ * every block the same buffer (what the single-buffer `testSendRecv` does)
+ * means a channel that silently moves nothing is masked by a sibling block
+ * writing the same bytes, so the verify passes with most channels dead.
+ *
+ * Caller must keep `bytesPerBlock` within one pipeline window: senders then
+ * never block on a peer's SLOT_FREE, so the test cannot deadlock when it runs
+ * more blocks than the GPU can hold resident.
+ */
+void testShardedSendRecvIb(
+    P2pIbTransportDevice transport,
+    void* buffer,
+    std::size_t bytesPerBlock,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize);
+
+/**
+ * Fill `numBlocks` consecutive `bytesPerBlock` slices, keying slice `b` on
+ * `baseValue + b` so every slice is byte-distinguishable from its neighbours.
+ */
+void fillShardedPattern(
+    void* buffer,
+    std::size_t bytesPerBlock,
+    uint8_t baseValue,
+    int numBlocks,
+    int blockSize);
+
+/**
+ * Verify the layout `fillShardedPattern` writes. `errorCount` accumulates
+ * mismatched bytes; `firstBadSlice` is `atomicMin`-reduced to the lowest slice
+ * index that had any mismatch, which is what tells a failure whether the
+ * channels above the legacy limit were the ones that dropped data.
+ *
+ * The caller must pre-seed `firstBadSlice` with a sentinel above every valid
+ * slice index (`std::numeric_limits<int>::max()`); a clean run leaves it
+ * untouched rather than writing a "no failure" value of its own.
+ */
+void verifyShardedPattern(
+    const void* buffer,
+    std::size_t bytesPerBlock,
+    uint8_t expectedBaseValue,
+    int* errorCount,
+    int* firstBadSlice,
+    int numBlocks,
+    int blockSize);
+
+/**
  * Test kernel: Blocking pipelined send or recv.
  */
 void testSendRecv(

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -281,9 +281,28 @@ constexpr int kMaxRanksForAllGather = 128;
 // block-owned QP shapes must use lazy peer materialization.
 constexpr int kMaxEagerExchangeQpsPerPeerPerNic = 128;
 
-constexpr int kMaxIbGroups = 64;
+// Group (channel) index space: device-side IB QP selection uses
+// ThreadGroup::block_id and requires block_id < maxGroups. This is an index
+// space only — per-group QP state is materialized lazily per group actually
+// used. Groups beyond kMaxEagerExchangeQpsPerPeerPerNic are NOT eligible for
+// the compact eager QPN-exchange wire format and therefore require lazy peer
+// materialization (ibLazyConnect=true); collectives that stay within that cap
+// pay no extra QP registration cost.
+constexpr int kMaxIbGroups = 256;
 constexpr int kMaxIbQpsPerBlockPerNic = 128;
-constexpr int kMaxIbQpsPerPeerPerNic = kMaxIbGroups * kMaxIbQpsPerBlockPerNic;
+
+// Budget for QPs actually created per (peer, NIC): max_num_channels *
+// direction_count * qpsPerConnection. Must stay independent of kMaxIbGroups:
+// it dimensions the PeerQpPayload::NicQpInfo::qpns wire array below, so
+// deriving it from the group index space would grow every lazy peer exchange
+// whenever that space grows. kMaxIbGroups * kMaxIbQpsPerBlockPerNic is also
+// not a meaningful bound — it multiplies two limits no configuration reaches
+// simultaneously.
+constexpr int kMaxIbQpsPerPeerPerNic = 8192;
+
+static_assert(
+    kMaxIbQpsPerPeerPerNic >= kMaxEagerExchangeQpsPerPeerPerNic,
+    "the eager-exchange QP cap must fit inside the created-QP budget");
 
 /**
  * Transport exchange info for allGather-based exchange.
@@ -344,6 +363,17 @@ struct PeerQpPayload {
   int maxGroups{0};
   int qpsPerBlockPerNic{0};
 };
+
+// This payload is sent and received once per peer on every materializePeer(),
+// and both copies are stack-resident while in flight, so its size is a
+// bootstrap cost every lazy collective pays per peer -- not only the ones that
+// ask for a large group count. It must stay within kMaxNicsPerGpu * 8192 QPNs
+// (~64KB) however large the group index space becomes; widening a QP-shape
+// limit past this has to revisit the wire format rather than silently scale
+// it.
+static_assert(
+    sizeof(PeerQpPayload) <= 72 * 1024,
+    "PeerQpPayload is exchanged and stack-allocated per peer; keep it small");
 
 struct PeerBufferPayload {
   IbgdaBufferExchInfo recvStaging;

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -698,9 +698,34 @@ constexpr int kMaxRanksForAllGather = 128;
 // block-owned QP shapes must use lazy peer materialization.
 constexpr int kMaxEagerExchangeQpsPerPeerPerNic = 128;
 
-constexpr int kMaxIbGroups = 64;
+// Group (channel) index space: device-side IB QP selection uses
+// ThreadGroup::block_id and requires block_id < maxGroups.
+//
+// This is an index space only: raising it creates no QP by itself, and a group
+// index costs nothing until a configuration actually asks for that many
+// channels. What it does NOT mean is that QPs appear per group on first use.
+// Materialization is lazy per PEER, not per group: the first touch of a peer
+// runs materializePeer() -> createPeerQps(), which builds that peer's ENTIRE
+// configured shape up front — `fixedChannelCompanionQpsPerPeerPerNic()` slots,
+// each a QP group plus a loopback companion — even if a single group ever runs
+// on it. So the QP cost of a transport is set by `max_num_channels` (times
+// directions, times qpsPerConnection) and the number of peers touched, and the
+// knob for reducing it is `max_num_channels`, not this limit.
+constexpr int kMaxIbGroups = 256;
 constexpr int kMaxIbQpsPerBlockPerNic = 128;
-constexpr int kMaxIbQpsPerPeerPerNic = kMaxIbGroups * kMaxIbQpsPerBlockPerNic;
+
+// Budget for QPs actually created per (peer, NIC): max_num_channels *
+// direction_count * qpsPerConnection. Must stay independent of kMaxIbGroups:
+// it dimensions the PeerQpPayload::NicQpInfo::qpns wire array below, so
+// deriving it from the group index space would grow every lazy peer exchange
+// whenever that space grows. kMaxIbGroups * kMaxIbQpsPerBlockPerNic is also
+// not a meaningful bound — it multiplies two limits no configuration reaches
+// simultaneously.
+constexpr int kMaxIbQpsPerPeerPerNic = 8192;
+
+static_assert(
+    kMaxIbQpsPerPeerPerNic >= kMaxEagerExchangeQpsPerPeerPerNic,
+    "the eager-exchange QP cap must fit inside the created-QP budget");
 
 /**
  * Transport exchange info for allGather-based exchange.
@@ -778,6 +803,29 @@ struct PeerQpPayload {
   // Defaults to the same 1 the transport resolves when nobody raises the depth.
   int maxRdAtomic{1};
 };
+
+// This payload is sent and received once per peer on every materializePeer(),
+// and both copies are stack-resident while in flight, so its size is a
+// bootstrap cost every lazy collective pays per peer -- not only the ones that
+// ask for a large group count. It must stay within kMaxNicsPerGpu * 8192 QPNs
+// (~64KB) however large the group index space becomes; widening a QP-shape
+// limit past this has to revisit the wire format rather than silently scale
+// it.
+//
+// Derived from the documented shape rather than rounded up to a convenient
+// number: a round bound leaves kilobytes of headroom for a new fixed array to
+// be added without the static_assert ever firing, which is exactly the drift
+// this constant exists to catch. The only slack is the scalar header.
+//
+// Named so the bound has one definition: MultiPeerIbTransportConfigTest checks
+// the same constant rather than restating the number.
+inline constexpr std::size_t kMaxPeerQpPayloadBytes =
+    kMaxNicsPerGpu * sizeof(PeerQpPayload::NicQpInfo) +
+    /*scalar header allowance=*/256;
+
+static_assert(
+    sizeof(PeerQpPayload) <= kMaxPeerQpPayloadBytes,
+    "PeerQpPayload is exchanged and stack-allocated per peer; keep it small");
 
 struct PeerBufferPayload {
   IbgdaBufferExchInfo recvStaging;

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -1457,6 +1457,39 @@ void MultipeerIbrcTransport::connectPeerQps(
 void MultipeerIbrcTransport::exchangeAndConnectQps() {
   const int numPeers = nRanks_ - 1;
   const int numQps = config_.fixedChannelMainQpsPerPeerPerNic();
+  // PRECONDITION OF THIS FUNCTION, not of the transport. Nothing calls
+  // exchangeAndConnectQps() today -- exchange() defers everything to
+  // materializePeer(), and IBGDA never used the eager allGather at all -- so
+  // this is unreachable as written. It is kept rather than deleted because it
+  // is the invariant that makes reviving the eager path safe, and that
+  // invariant stopped holding in this diff: the allGather wire format
+  // dimensions IbTransportExchInfoAll::NicWireInfo::qpnForRank[][] at
+  // kMaxEagerExchangeQpsPerPeerPerNic, and the loop below writes `numQps` slots
+  // into it. That used to be bounded by coincidence -- with kMaxIbGroups at 64,
+  // 64 channels x kIbDirections filled the array exactly -- but the group index
+  // space is now wider than the eager wire format, so a revived eager path
+  // would write off the end of the exchanged struct.
+  //
+  // Deliberately NOT hoisted into config validation: every live path is lazy,
+  // and a shape wider than the eager cap is legal there -- the SendRecvTile
+  // collective this stack adds runs at 512 QPs/(peer, NIC). Rejecting it at
+  // construction would break the supported configuration to guard a dead one.
+  if (numQps > kMaxEagerExchangeQpsPerPeerPerNic) {
+    throw std::invalid_argument(
+        fmt::format(
+            "MultipeerIbrcTransport: eager QP exchange needs {} QPs per "
+            "(peer, NIC) but the allGather wire format holds only {}. Reduce "
+            "max_num_channels to at most {} for eager exchange, or keep using "
+            "the (default) lazy per-peer materialization path, which has no "
+            "such limit",
+            numQps,
+            kMaxEagerExchangeQpsPerPeerPerNic,
+            kMaxEagerExchangeQpsPerPeerPerNic /
+                std::max(
+                    1,
+                    config_.fixedChannelDirectionCount() *
+                        config_.qpsPerConnection)));
+  }
 
   for (int peerIndex = 0; peerIndex < numPeers; ++peerIndex) {
     createPeerQps(peerIndex);


### PR DESCRIPTION
Summary:

First diff of a 5-way decomposition of D108504937 (the SendRecvTile / SendRecvTileCompressed point-to-point collective + benchmark). This diff contains only the small, cross-cutting primitive changes the collective depends on, isolated from the collective code so their (different) risk surfaces can be reviewed on their own.

1. `transport/MultiPeerIbTransport.h`: raise `kMaxIbGroups` 64 -> 256, and decouple the QP budget from it.
   - `kMaxIbGroups` is the group (channel) *index space*: device-side IB QP selection uses `ThreadGroup::block_id` and requires `block_id < maxGroups`. The SendRecvTile compressed path (later in this stack) can request up to 256 groups.
   - **Raising this limit creates no QP by itself.** A group index costs nothing until a configuration actually asks for that many channels.
   - **Correction to earlier versions of this summary:** they claimed per-group QP state is "materialized lazily per group actually used". That is wrong, and dboyda was right to challenge it. Materialization is lazy per **peer**, not per group: the first touch of a peer runs `materializePeer()` -> `createPeerQps()`, which builds that peer's ENTIRE configured shape up front -- `fixedChannelCompanionQpsPerPeerPerNic()` slots, each a QP group plus a loopback companion -- even if one group ever runs on it. The header comment has been rewritten to say so; see the resource note below. Making *creation* group-lazy is a real transport redesign (device-side QP selection indexes a dense per-channel array), so it is a follow-up rather than something to pile onto a prereq diff.
   - **`kMaxIbQpsPerPeerPerNic` is now an independent constant instead of `kMaxIbGroups * kMaxIbQpsPerBlockPerNic`** -- see below.

2. `transport/MultiPeerIbTransport.h`: `kMaxIbQpsPerPeerPerNic` no longer derives from `kMaxIbGroups`.
   - Addresses dboyda's review comment (and the `ai_diff_reviewer` note) that `kMaxIbGroups` also sizes `PeerQpPayload::NicQpInfo::qpns[kMaxIbQpsPerPeerPerNic]`, the fixed-size bilateral wire format exchanged by `exchangeWithPeer<PeerQpPayload>()` on every `materializePeer()`. Under the old derivation a 64 -> 256 index-space bump would have grown that payload ~4x (8192 -> 32768 QPNs per NIC, ~64KB -> ~256KB per peer) for every lazy caller, including ones using a handful of groups.
   - Fix: `kMaxIbQpsPerPeerPerNic` becomes its own budget for QPs *actually created* per (peer, NIC), i.e. `max_num_channels * direction_count * qpsPerConnection`. The old product multiplied two limits no configuration reaches simultaneously, and tying it to the index space meant every future group bump silently taxed the peer exchange.
   - The value is pinned at **8192** -- exactly what the old product yielded at `kMaxIbGroups=64`. So relative to the pre-diff code this changes **nothing**: the same QP shapes are accepted, and `PeerQpPayload` stays byte-identical at ~64KB. Net wire/stack growth from this diff is **zero**, not 4x.
   - A `static_assert` pins `sizeof(PeerQpPayload)` under that footprint. Per `ai_diff_reviewer`, the bound is now **derived from the documented shape** (`kMaxNicsPerGpu * sizeof(NicQpInfo)` plus a 256-byte scalar-header allowance) rather than rounded to 72KB: a round number left ~6KB of slack in which a new fixed array could hide without the assert ever firing, which is exactly the drift the constant exists to catch.
   - Note this is a decoupling, not a variable-length wire format. Making `qpns[]` variable-length needs a second bootstrap round-trip (or a self-describing header) per peer to keep the current clean topology-mismatch diagnostic -- more surgery than a prereq diff should carry. Happy to file a follow-up.

3. `core/CopyOp.cuh`: expose `AnsCompress::kMaxUncompBytes`.
   - Adds `static constexpr std::size_t kMaxUncompBytes = MaxUncompBytes;` -- a public, additive metadata member echoing the policy's `MaxUncompBytes` template argument.
   - Pure metadata, zero runtime/behavior change. Lets consumers that stage a full uncompressed chunk (e.g. the per-block realign aux buffer in `SendRecvTileCommon`, later in this stack) size that scratch off the CopyOp instead of a hard-coded per-algorithm constant.
   - Deliberately NOT added to the fixed-size sibling policies (`Memcpy`, `TileReduceStaged`), contra one `ai_diff_reviewer` note: "max uncompressed chunk" has no meaning for a policy that does not compress, and every consumer already reaches it only inside `if constexpr (CopyOp::kVariableSize)`. Adding a placeholder `0` to the fixed-size policies would make a real misuse compile silently instead of failing.

## QP resource cost at 256 channels (the eager-vs-lazy note)

Since materialization is per peer and builds the full configured shape, the cost is set by `max_num_channels`, not by how many groups run. Per materialized peer, per NIC: `max_num_channels * directions` slots, each a QP group (main + device companion) plus a loopback companion.

Measured on rtptest001.dkl2, 2 ranks, from the `LazyModeTestFixture` runs below -- materialization dominates these wall times:

| configured channels | test | IBGDA | IBRC |
|---|---|---|---|
| 64 (default) | `MaterializeOnAccess` | 1766 ms | 265 ms |
| 256 | `MaterializeAndTransferAboveEagerQpLimit` | 28199 ms | 4323 ms |
| 256 | `FixedChannelSendRecvSpansGroupsAboveLegacyLimit` | 27722 ms | 4328 ms |

So a 4x channel count costs roughly 16x IBGDA setup time for a 2-rank pair. That is a real cost and the reason the knob to turn is `max_num_channels`, sized to what the collective actually launches. `ibLazyConnect` is NOT that knob -- it is a deprecated no-op (`MultiPeerIbTransport.h:513`: "Per-peer state is always materialized on demand"), so the IBRC eager-exchange diagnostic no longer points at it.

Reviewed By: dboyda

Differential Revision: D112007058
