### PR TITLE
SendRecvTile: plain point-to-point tile collective (#3455)

### DIFF
--- a/comms/prims/collectives/SendRecvTile.cu
+++ b/comms/prims/collectives/SendRecvTile.cu
@@ -1,0 +1,20 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Plain (no-compression) flavour of the sendrecv-tile kernel. Built
+// without PIPES_ENABLE_ANS_COMPRESSION; never sees nvcompdx symbols. The
+// compressed kernel symbols (`sendrecv_tile_compressed_kernel<Compressor,
+// NumWarps>`) and `fetch_and_reset_sendrecv_ans_compress_stats` live in the
+// sibling SendRecvTileCompressed.cu translation unit.
+
+#include "comms/prims/collectives/SendRecvTileCommon.cuh"
+
+namespace comms::prims {
+
+__global__ __launch_bounds__(512, 2) void sendrecv_tile_kernel(
+    const __grid_constant__ SendRecvTileArgs args,
+    Timeout timeout) {
+  timeout.start();
+  sendrecv_tile_impl<Memcpy>(args, timeout);
+}
+
+} // namespace comms::prims

--- a/comms/prims/collectives/SendRecvTile.cu
+++ b/comms/prims/collectives/SendRecvTile.cu
@@ -1,0 +1,20 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Plain (no-compression) flavour of the sendrecv-tile kernel. Built
+// without PIPES_ENABLE_ANS_COMPRESSION; never sees nvcompdx symbols. The
+// compressed kernel symbols (`sendrecv_tile_compressed_kernel<Compressor,
+// NumWarps>`) and `fetch_and_reset_sendrecv_ans_compress_stats` live in the
+// sibling SendRecvTileCompressed.cu translation unit.
+
+#include "comms/prims/collectives/SendRecvTileCommon.cuh"
+
+namespace comms::prims {
+
+__global__ __launch_bounds__(512, 2) void sendrecv_tile_kernel(
+    const __grid_constant__ SendRecvTileArgs args,
+    AbortDevice abortDevice) {
+  abortDevice.start();
+  sendrecv_tile_impl<Memcpy>(args, abortDevice);
+}
+
+} // namespace comms::prims

--- a/comms/prims/collectives/SendRecvTile.cuh
+++ b/comms/prims/collectives/SendRecvTile.cuh
@@ -1,0 +1,126 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Plain (no-compression) flavour of a tile-based pipelined point-to-point
+// send/recv with NVLink and IB support. Provided by the `:sendrecv_tile`
+// BUCK target.
+//
+// SendRecvTile is the point-to-point specialisation of AllToAllvTile. A
+// single launch can do any of:
+//   - send only:   send `send_count` bytes from `send_data` to `send_peer`
+//   - recv only:   recv `recv_count` bytes from `recv_peer` into `recv_data`
+//   - send + recv: do BOTH simultaneously, to/from (possibly different)
+//                  peers — half the grid's blocks drive the send, the
+//                  other half drive the recv.
+// selected by the `is_send` / `is_recv` flags. The per-tile send/recv
+// mechanism (NVL-vs-IB dispatch, sub-chunk pipelining, signalling) is
+// self-contained (see `SendRecvTileCommon.cuh`).
+//
+// For ANS-compressed IBGDA chunks, see the sibling
+// `SendRecvTileCompressed.cuh` (provided by `:sendrecv_tile_compressed`).
+//
+// Uses MultiPeerDeviceHandle for NVLink/IB transport dispatch. For each
+// direction, the two endpoints MUST agree on the per-direction active
+// block count so the per-block tiling lines up: a one-directional launch
+// uses all `gridDim.x` blocks; a bidirectional (send+recv) launch gives
+// each direction `gridDim.x / 2` blocks, so the matching peer's launch
+// must be bidirectional too (or a one-way launch of `gridDim.x / 2`).
+
+#pragma once
+
+#include <cstddef>
+
+#include <cuda_runtime.h>
+
+#include "comms/prims/core/Timeout.cuh"
+#include "comms/prims/transport/MultiPeerDeviceHandle.cuh"
+
+namespace comms::prims {
+
+/**
+ * SendRecvTileArgs — Kernel arguments for the tile-based point-to-point
+ * send/recv collective.
+ *
+ * The `is_send` / `is_recv` flags select the mode:
+ *   - is_send && !is_recv : send `send_count` bytes from `send_data` to
+ *                           `send_peer` (all blocks).
+ *   - !is_send && is_recv : recv `recv_count` bytes from `recv_peer` into
+ *                           `recv_data` (all blocks).
+ *   - is_send && is_recv  : do both at once — the first half of the grid's
+ *                           blocks send to `send_peer`, the second half
+ *                           recv from `recv_peer`. `send_peer` and
+ *                           `recv_peer` may differ.
+ * A direction with a zero count is skipped. The matching peer(s) must
+ * issue mirrored launches with the same per-direction active block count
+ * (see header comment).
+ *
+ * Shared by both the plain and ANS-compressed kernel symbols. The base
+ * compress-vs-plain choice is still selected by the kernel symbol the
+ * caller launches (`sendrecv_tile_kernel` vs
+ * `sendrecv_tile_compressed_kernel`). The one exception is
+ * `plain_block_fraction` below: on the ANS-compressed kernel it lets a
+ * runtime-chosen fraction of thread-blocks fall back to the plain
+ * `Memcpy` CopyOp per block (see field doc). It has no effect on the
+ * plain kernel (every block is already `Memcpy` there).
+ */
+struct SendRecvTileArgs {
+  MultiPeerDeviceHandle handle;
+
+  // Direction enables. When both are true the grid is split in half.
+  bool is_send;
+  bool is_recv;
+
+  // Peer ranks for each direction (may be equal for bidirectional pairs).
+  int send_peer;
+  int recv_peer;
+
+  // Send-side source buffer + byte count (consulted only when is_send).
+  char* send_data;
+  std::size_t send_count;
+
+  // Recv-side destination buffer + byte count (consulted only when
+  // is_recv).
+  char* recv_data;
+  std::size_t recv_count;
+
+  // Sub-chunk signaling hint (bytes). 0 = one signal per slot fill.
+  // Applies to both directions.
+  std::size_t max_signal_bytes;
+
+  // Per-block 16-byte-aligned auxiliary buffer used by compressed
+  // sends when the per-chunk source pointer is not 16-byte aligned.
+  // Defaults to nullptr; ignored by the plain (Memcpy) kernel and only
+  // consulted by the compressed send dispatcher when the per-chunk src
+  // is misaligned. Sized `gridDim.x * CopyOp::kMaxUncompBytes` (every
+  // block gets a slice keyed on its global `blockIdx.x`), where the
+  // per-block stride is the compiled compressor's max uncompressed chunk.
+  char* aligned_aux_buf;
+
+  // Fraction of each direction's active thread-blocks that use the plain
+  // `Memcpy` CopyOp instead of the kernel's compiled CopyOp; the rest use
+  // the compiled CopyOp (ANS for `sendrecv_tile_compressed_kernel`).
+  // Clamped to [0, 1]. Blocks are selected evenly interleaved (Bresenham
+  // over the per-direction subgroup id) so sender and receiver agree
+  // per block. Default `0.0f` -> every block uses the compiled CopyOp,
+  // byte-identical to a build without this field. Only consulted by the
+  // ANS-compressed kernel; on the plain kernel every block is already
+  // `Memcpy` so this is a no-op. Motivation: plain blocks are light and
+  // saturate spare NIC bandwidth that the compute-heavy ANS blocks leave
+  // idle, raising aggregate effective bandwidth.
+  float plain_block_fraction = 0.0f;
+};
+
+#ifdef __CUDACC__
+/**
+ * Plain (Memcpy) point-to-point tile send/recv. NVL and IB peers are
+ * both supported (dispatched per-peer by the transport handle). For a
+ * one-directional launch all `gridDim.x` blocks cooperate; for a
+ * bidirectional (send+recv) launch the grid is split in half.
+ */
+__global__ __launch_bounds__(512, 2) void sendrecv_tile_kernel(
+    const __grid_constant__ SendRecvTileArgs args,
+    Timeout timeout = Timeout());
+#else
+void sendrecv_tile_kernel(SendRecvTileArgs args, Timeout timeout);
+#endif
+
+} // namespace comms::prims

--- a/comms/prims/collectives/SendRecvTile.cuh
+++ b/comms/prims/collectives/SendRecvTile.cuh
@@ -1,0 +1,158 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Plain (no-compression) flavour of a tile-based pipelined point-to-point
+// send/recv with NVLink and IB support. Provided by the `:sendrecv_tile`
+// BUCK target.
+//
+// SendRecvTile is the point-to-point specialisation of AllToAllvTile. A
+// single launch can do any of:
+//   - send only:   send `send_count` bytes from `send_data` to `send_peer`
+//   - recv only:   recv `recv_count` bytes from `recv_peer` into `recv_data`
+//   - send + recv: do BOTH simultaneously, to/from (possibly different)
+//                  peers — half the grid's blocks drive the send, the
+//                  other half drive the recv.
+// selected by the `is_send` / `is_recv` flags. The per-tile send/recv
+// mechanism (NVL-vs-IB dispatch, sub-chunk pipelining, signalling) is
+// self-contained (see `SendRecvTileCommon.cuh`).
+//
+// For ANS-compressed IBGDA chunks, see the sibling
+// `SendRecvTileCompressed.cuh` (provided by `:sendrecv_tile_compressed`).
+//
+// Uses MultiPeerDeviceHandle for NVLink/IB transport dispatch.
+//
+// CROSS-RANK CONTRACT. Nothing below is negotiated at runtime -- both sides
+// derive tile boundaries, signalling and wire format independently -- so a
+// mismatch does not error, it silently drops data or waits forever. For a flow
+// A -> B, the two launches MUST agree on all of:
+//
+//   * byte count: A's `send_count` == B's `recv_count`. This is what both ends
+//     tile, so a mismatch mis-aligns every block's slice.
+//   * per-direction active block count, so the per-block tiling lines up: a
+//     one-directional launch uses all `gridDim.x` blocks; a bidirectional
+//     (send+recv) launch gives each direction `gridDim.x / 2` blocks, so the
+//     matching peer's launch must be bidirectional too (or a one-way launch of
+//     `gridDim.x / 2`).
+//   * `max_signal_bytes`, which sets the sub-chunk/signal granularity.
+//   * `plain_block_fraction`, which decides per block whether a tile ships
+//     plain or compressed.
+//   * the CopyOp the kernel was instantiated with, i.e. both ends must use the
+//     plain kernel or both the compressed one -- they are different wire
+//     formats.
+//
+// BUFFER ALIASING. `send_data` and `recv_data` must not overlap in a
+// bidirectional launch. The two directions run concurrently on disjoint halves
+// of the grid with no ordering between them, so a receiving block may land
+// peer bytes on a region a local sending block has not staged yet, corrupting
+// the outbound data. In-place send/recv is NOT supported; pass disjoint
+// ranges.
+
+#pragma once
+
+#include <cstddef>
+
+#include <cuda_runtime.h>
+
+#include "comms/prims/core/AbortCheck.cuh"
+#include "comms/prims/transport/MultiPeerDeviceHandle.cuh"
+
+namespace comms::prims {
+
+/**
+ * SendRecvTileArgs — Kernel arguments for the tile-based point-to-point
+ * send/recv collective.
+ *
+ * The `is_send` / `is_recv` flags select the mode:
+ *   - is_send && !is_recv : send `send_count` bytes from `send_data` to
+ *                           `send_peer` (all blocks).
+ *   - !is_send && is_recv : recv `recv_count` bytes from `recv_peer` into
+ *                           `recv_data` (all blocks).
+ *   - is_send && is_recv  : do both at once — the first half of the grid's
+ *                           blocks send to `send_peer`, the second half
+ *                           recv from `recv_peer`. `send_peer` and
+ *                           `recv_peer` may differ.
+ * A direction with a zero count is skipped. The matching peer(s) must
+ * issue mirrored launches with the same per-direction active block count
+ * (see header comment).
+ *
+ * Shared by both the plain and ANS-compressed kernel symbols. The base
+ * compress-vs-plain choice is still selected by the kernel symbol the
+ * caller launches (`sendrecv_tile_kernel` vs
+ * `sendrecv_tile_compressed_kernel`). The one exception is
+ * `plain_block_fraction` below: on the ANS-compressed kernel it lets a
+ * runtime-chosen fraction of thread-blocks fall back to the plain
+ * `Memcpy` CopyOp per block (see field doc). It has no effect on the
+ * plain kernel (every block is already `Memcpy` there).
+ */
+struct SendRecvTileArgs {
+  MultiPeerDeviceHandle handle;
+
+  // Direction enables. When both are true the grid is split in half.
+  bool is_send;
+  bool is_recv;
+
+  // Peer ranks for each direction (may be equal for bidirectional pairs).
+  int send_peer;
+  int recv_peer;
+
+  // Send-side source buffer + byte count (consulted only when is_send).
+  // `send_count` must equal the peer's `recv_count` for this flow.
+  char* send_data;
+  std::size_t send_count;
+
+  // Recv-side destination buffer + byte count (consulted only when
+  // is_recv). `recv_count` must equal the peer's `send_count` for this flow.
+  //
+  // Must not alias `send_data` when both directions are enabled: the two
+  // directions run concurrently and unordered, so an incoming write can clobber
+  // bytes the local sender has not staged yet. See the aliasing note at the top
+  // of this file.
+  char* recv_data;
+  std::size_t recv_count;
+
+  // Sub-chunk signaling hint (bytes). 0 = one signal per slot fill.
+  // Applies to both directions.
+  std::size_t max_signal_bytes;
+
+  // Per-block 16-byte-aligned auxiliary buffer used by compressed
+  // sends when the per-chunk source pointer is not 16-byte aligned.
+  // Defaults to nullptr; ignored by the plain (Memcpy) kernel and only
+  // consulted by the compressed send dispatcher when the per-chunk src
+  // is misaligned. Sized `gridDim.x * CopyOp::kMaxUncompBytes` (every
+  // block gets a slice keyed on its global `blockIdx.x`), where the
+  // per-block stride is the compiled compressor's max uncompressed chunk.
+  char* aligned_aux_buf;
+
+  // Fraction of each direction's active thread-blocks that use the plain
+  // `Memcpy` CopyOp instead of the kernel's compiled CopyOp; the rest use
+  // the compiled CopyOp (ANS for `sendrecv_tile_compressed_kernel`).
+  // Clamped to [0, 1]. Blocks are selected evenly interleaved (Bresenham
+  // over the per-direction subgroup id) so sender and receiver agree
+  // per block. Default `0.0f` -> every block uses the compiled CopyOp,
+  // byte-identical to a build without this field. Only consulted by the
+  // ANS-compressed kernel; on the plain kernel every block is already
+  // `Memcpy` so this is a no-op. Motivation: plain blocks are light and
+  // saturate spare NIC bandwidth that the compute-heavy ANS blocks leave
+  // idle, raising aggregate effective bandwidth.
+  float plain_block_fraction = 0.0f;
+};
+
+#ifdef __CUDACC__
+/**
+ * Plain (Memcpy) point-to-point tile send/recv. NVL and IB peers are
+ * both supported (dispatched per-peer by the transport handle). For a
+ * one-directional launch all `gridDim.x` blocks cooperate; for a
+ * bidirectional (send+recv) launch the grid is split in half.
+ */
+__global__ __launch_bounds__(512, 2) void sendrecv_tile_kernel(
+    const __grid_constant__ SendRecvTileArgs args,
+    AbortDevice abortDevice = AbortDevice());
+#else
+// Same defaulted trailing argument as the __CUDACC__ declaration above, so a
+// host-only TU that includes this header sees the same call signature a .cu
+// consumer does.
+void sendrecv_tile_kernel(
+    SendRecvTileArgs args,
+    AbortDevice abortDevice = AbortDevice());
+#endif
+
+} // namespace comms::prims

--- a/comms/prims/collectives/SendRecvTileCommon.cuh
+++ b/comms/prims/collectives/SendRecvTileCommon.cuh
@@ -1,0 +1,314 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Private (in-tree only) shared device helpers for the sendrecv-tile
+// kernels. Included by both SendRecvTile.cu (plain Memcpy path) and
+// SendRecvTileCompressed.cu (ANS-compressed path); each TU instantiates
+// the templates below with the CopyOp policy that matches its build
+// flavour.
+//
+// SendRecvTile is self-contained: it depends only on the core CopyOp /
+// transport primitives (the `:copy_op` / `:copy_op_compress` layer), NOT
+// on the AllToAllvTile collective. The compressed-specific dispatchers
+// (`ibgda_send_compressed`, `ibgda_recv_compressed`, `kAnsMaxUncompBytes`,
+// `AnsCopyOp`) live in the sibling SendRecvTileCompressed.cuh, which is
+// conditionally included below ONLY when PIPES_ENABLE_ANS_COMPRESSION is
+// defined — so the plain TU never sees any nvcompdx symbols.
+//
+// Do NOT include this header from public consumers — the only stable
+// contracts are `SendRecvTile.cuh` (plain kernel + `SendRecvTileArgs`)
+// and `SendRecvTileCompressed.cuh` (compressed kernels + stats).
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/prims/collectives/SendRecvTile.cuh"
+#include "comms/prims/core/CopyOp.cuh"
+#include "comms/prims/core/CopyUtils.cuh"
+#include "comms/prims/core/DeviceMacros.cuh"
+#include "comms/prims/core/TiledBuffer.cuh"
+
+#ifdef PIPES_ENABLE_ANS_COMPRESSION
+// Pulls in `kAnsMaxUncompBytes`, `ibgda_send_compressed`,
+// `ibgda_recv_compressed`, `AnsCopyOp`. Must be included BEFORE the
+// `send_to_peer` / `recv_from_peer` template definitions below so that
+// non-dependent name lookup of the dispatchers (inside the
+// `if constexpr (CopyOp::kVariableSize)` branch) succeeds at template
+// definition time.
+#include "comms/prims/collectives/SendRecvTileCompressed.cuh"
+#endif
+
+namespace comms::prims {
+
+namespace {
+
+// Send one tile to a single peer. CopyOp tags the build flavour:
+//   - Memcpy (kVariableSize == false)        -> plain transport-level send
+//   - AnsCopyOp (kVariableSize == true)      -> compressed dispatcher
+// NVL transport is bandwidth-bound on intra-node links, so it always
+// uses the plain `send()` regardless of CopyOp; only the IB path honours
+// the compression policy. The `if constexpr` branch on
+// `CopyOp::kVariableSize` resolves the discriminator at compile time and
+// drops dead code per TU; the branch is preprocessor-removed when
+// PIPES_ENABLE_ANS_COMPRESSION is undefined, so the plain TU never
+// references `ibgda_send_compressed`.
+template <typename CopyOp = Memcpy>
+__device__ __forceinline__ void send_to_peer(
+    MultiPeerDeviceHandle& handle,
+    int peer,
+    ThreadGroup& group,
+    void* src,
+    std::size_t nbytes,
+    std::size_t peer_total_bytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    char* aligned_aux_buf,
+    const Timeout& timeout) {
+  if (handle.get_type(peer) == TransportType::P2P_NVL) {
+    handle.get_nvl(peer).send(group, src, nbytes, max_signal_bytes, timeout);
+    return;
+  }
+#ifdef PIPES_ENABLE_ANS_COMPRESSION
+  if constexpr (CopyOp::kVariableSize) {
+    // Per-peer activation threshold: small tiles bypass the compressed
+    // CopyOp and fall back to the plain Memcpy IB path. The discriminator
+    // is the PER-PEER total byte count (`peer_total_bytes`), NOT this
+    // block's per-tile `nbytes`, so sender + receiver + every block agree
+    // on the same compress-vs-bypass decision per peer.
+    if (peer_total_bytes >= CopyOp::kActivationThreshold) {
+      // Per-block slice of the caller-provided 16-byte-aligned aux
+      // buffer (sized `CopyOp::kMaxUncompBytes` per block, derived from the
+      // compiled compressor rather than a hard-coded ANS constant). Only
+      // consumed inside the compressor's `send` when `src` is misaligned;
+      // null is fine for callers that always pass aligned `src`.
+      char* perBlockAux = aligned_aux_buf == nullptr
+          ? nullptr
+          : aligned_aux_buf + blockIdx.x * CopyOp::kMaxUncompBytes;
+      ibgda_send_compressed<CopyOp>(
+          handle.get_ibgda(peer),
+          group,
+          src,
+          nbytes,
+          active_blocks,
+          max_signal_bytes,
+          timeout,
+          perBlockAux);
+      return;
+    }
+    // Fall through to the plain IB Memcpy path below for sub-threshold
+    // peers.
+  }
+#endif
+  handle.get_ibgda(peer).send(group, src, nbytes, max_signal_bytes, timeout);
+}
+
+template <typename CopyOp = Memcpy>
+__device__ __forceinline__ void recv_from_peer(
+    MultiPeerDeviceHandle& handle,
+    int peer,
+    ThreadGroup& group,
+    void* dst,
+    std::size_t nbytes,
+    std::size_t peer_total_bytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout) {
+  if (handle.get_type(peer) == TransportType::P2P_NVL) {
+    handle.get_nvl(peer).recv(group, dst, nbytes, max_signal_bytes, timeout);
+    return;
+  }
+#ifdef PIPES_ENABLE_ANS_COMPRESSION
+  if constexpr (CopyOp::kVariableSize) {
+    // Mirror the sender-side `kActivationThreshold` gate. Sender and
+    // receiver MUST agree on this discriminator (both see the same
+    // `peer_total_bytes`), or the receiver would try to ANS-decompress
+    // raw payload.
+    if (peer_total_bytes >= CopyOp::kActivationThreshold) {
+      ibgda_recv_compressed<CopyOp>(
+          handle.get_ibgda(peer),
+          group,
+          dst,
+          nbytes,
+          active_blocks,
+          max_signal_bytes,
+          timeout);
+      return;
+    }
+    // Fall through to the plain IB Memcpy recv path below.
+  }
+#endif
+  handle.get_ibgda(peer).recv(group, dst, nbytes, max_signal_bytes, timeout);
+}
+
+// Per-block plain/compressed selector for the mixed-mode dispatch. When
+// `fraction` is in (0, 1), exactly `k = lround(fraction * activeBlocks)`
+// of the `activeBlocks` blocks are chosen to use the plain `Memcpy`
+// CopyOp, evenly interleaved across the block-id range via a
+// Bresenham-style test. The decision depends only on (`fraction`,
+// `blockId`, `activeBlocks`) — all identical on both peers for a given
+// per-direction subgroup id — so a plain-sending block is always matched
+// by a plain-receiving block on the peer. `fraction <= 0` -> never plain
+// (all compiled CopyOp); `fraction >= 1` -> always plain.
+__device__ __forceinline__ bool
+sendrecv_use_plain_block(float fraction, int blockId, int activeBlocks) {
+  if (fraction <= 0.0f || activeBlocks <= 0) {
+    return false;
+  }
+  if (fraction >= 1.0f) {
+    return true;
+  }
+  long k = lroundf(fraction * static_cast<float>(activeBlocks));
+  if (k <= 0) {
+    return false;
+  }
+  if (k >= activeBlocks) {
+    return true;
+  }
+  // floor((blockId+1)*k / activeBlocks) > floor(blockId*k / activeBlocks)
+  // selects exactly k evenly spread block ids.
+  const long lo = (static_cast<long>(blockId) * k) / activeBlocks;
+  const long hi = (static_cast<long>(blockId + 1) * k) / activeBlocks;
+  return hi > lo;
+}
+
+// Drive the send direction with `group`'s blocks: tile `send_data` across
+// the group and have each block ship its slice to `send_peer`.
+template <typename CopyOp = Memcpy>
+__device__ __forceinline__ void sendrecv_do_send(
+    MultiPeerDeviceHandle& handle,
+    const SendRecvTileArgs& args,
+    ThreadGroup& group,
+    const Timeout& timeout) {
+  const int activeBlocks = group.total_groups;
+  const int blockId = group.group_id;
+  TiledBuffer<char> tiles(args.send_data, args.send_count, activeBlocks);
+  // Mixed-mode: a fraction of blocks fall back to plain Memcpy so their
+  // light-weight sends fill NIC bandwidth the compute-heavy CopyOp
+  // blocks leave idle. Byte-identical to the all-CopyOp path when
+  // plain_block_fraction == 0 (the common case).
+  if (sendrecv_use_plain_block(
+          args.plain_block_fraction, blockId, activeBlocks)) {
+    send_to_peer<Memcpy>(
+        handle,
+        args.send_peer,
+        group,
+        tiles.tile_data(blockId),
+        tiles.tile_bytes(blockId),
+        args.send_count,
+        activeBlocks,
+        args.max_signal_bytes,
+        args.aligned_aux_buf,
+        timeout);
+    return;
+  }
+  send_to_peer<CopyOp>(
+      handle,
+      args.send_peer,
+      group,
+      tiles.tile_data(blockId),
+      tiles.tile_bytes(blockId),
+      args.send_count,
+      activeBlocks,
+      args.max_signal_bytes,
+      args.aligned_aux_buf,
+      timeout);
+}
+
+// Drive the recv direction with `group`'s blocks: tile `recv_data` across
+// the group and have each block pull its slice from `recv_peer`.
+template <typename CopyOp = Memcpy>
+__device__ __forceinline__ void sendrecv_do_recv(
+    MultiPeerDeviceHandle& handle,
+    const SendRecvTileArgs& args,
+    ThreadGroup& group,
+    const Timeout& timeout) {
+  const int activeBlocks = group.total_groups;
+  const int blockId = group.group_id;
+  TiledBuffer<char> tiles(args.recv_data, args.recv_count, activeBlocks);
+  // Mirror the send-side mixed-mode decision so a plain-sent tile is
+  // plain-received (same fraction/blockId/activeBlocks on both peers).
+  if (sendrecv_use_plain_block(
+          args.plain_block_fraction, blockId, activeBlocks)) {
+    recv_from_peer<Memcpy>(
+        handle,
+        args.recv_peer,
+        group,
+        tiles.tile_data(blockId),
+        tiles.tile_bytes(blockId),
+        args.recv_count,
+        activeBlocks,
+        args.max_signal_bytes,
+        timeout);
+    return;
+  }
+  recv_from_peer<CopyOp>(
+      handle,
+      args.recv_peer,
+      group,
+      tiles.tile_data(blockId),
+      tiles.tile_bytes(blockId),
+      args.recv_count,
+      activeBlocks,
+      args.max_signal_bytes,
+      timeout);
+}
+
+// Point-to-point driver. Modes (selected by is_send / is_recv):
+//   - send only:   all blocks send to send_peer.
+//   - recv only:   all blocks recv from recv_peer.
+//   - send + recv: split the grid — role 0 (first half) sends to
+//                  send_peer, role 1 (second half) recvs from recv_peer
+//                  (each direction gets gridDim.x / 2 blocks). The two
+//                  directions use independent transport staging/signal
+//                  state, so a bidirectional pair to the same peer is
+//                  safe.
+// `send_to_peer` / `recv_from_peer` dispatch to NVL or IB (and, for
+// variable-size CopyOps, to the ANS-compressed path).
+template <typename CopyOp = Memcpy>
+__device__ __forceinline__ void sendrecv_tile_impl(
+    const SendRecvTileArgs& args,
+    Timeout& timeout) {
+  auto handle = args.handle;
+  const bool doSend = args.is_send && args.send_count > 0;
+  const bool doRecv = args.is_recv && args.recv_count > 0;
+  if (!doSend && !doRecv) {
+    return;
+  }
+
+  auto group = make_block_group();
+
+  if (doSend && doRecv) {
+    // Bidirectional mode splits the grid in half via partition(2). An odd
+    // gridDim.x would hand the two directions unequal block counts, breaking
+    // the matching per-direction active-block invariant the peers rely on
+    // (peer A's role-0 sender count must equal peer B's role-1 receiver
+    // count). Require an even grid and fail loudly rather than hang.
+    if ((gridDim.x % 2u) != 0u) {
+      if (blockIdx.x == 0 && threadIdx.x == 0) {
+        printf(
+            "[PIPES] FATAL: SendRecvTile bidirectional mode requires an even "
+            "gridDim.x (got %u)\n",
+            gridDim.x);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    auto [role, sub] = group.partition(2);
+    if (role == 0) {
+      sendrecv_do_send<CopyOp>(handle, args, sub, timeout);
+    } else {
+      sendrecv_do_recv<CopyOp>(handle, args, sub, timeout);
+    }
+    return;
+  }
+
+  if (doSend) {
+    sendrecv_do_send<CopyOp>(handle, args, group, timeout);
+  } else {
+    sendrecv_do_recv<CopyOp>(handle, args, group, timeout);
+  }
+}
+
+} // namespace
+
+} // namespace comms::prims

--- a/comms/prims/collectives/SendRecvTileCommon.cuh
+++ b/comms/prims/collectives/SendRecvTileCommon.cuh
@@ -1,0 +1,453 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Private (in-tree only) shared device helpers for the sendrecv-tile
+// kernels. Included by both SendRecvTile.cu (plain Memcpy path) and
+// SendRecvTileCompressed.cu (ANS-compressed path); each TU instantiates
+// the templates below with the CopyOp policy that matches its build
+// flavour.
+//
+// SendRecvTile is self-contained: it depends only on the core CopyOp /
+// transport primitives (the `:copy_op` / `:copy_op_compress` layer), NOT
+// on the AllToAllvTile collective. The compressed-specific dispatchers
+// (`ibgda_send_compressed`, `ibgda_recv_compressed`, `kAnsMaxUncompBytes`,
+// `AnsCopyOp`) live in the sibling SendRecvTileCompressed.cuh, which is
+// conditionally included below ONLY when PIPES_ENABLE_ANS_COMPRESSION is
+// defined — so the plain TU never sees any nvcompdx symbols.
+//
+// Do NOT include this header from public consumers — the only stable
+// contracts are `SendRecvTile.cuh` (plain kernel + `SendRecvTileArgs`)
+// and `SendRecvTileCompressed.cuh` (compressed kernels + stats).
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include "comms/prims/collectives/SendRecvTile.cuh"
+#include "comms/prims/core/CopyOp.cuh"
+#include "comms/prims/core/CopyUtils.cuh"
+#include "comms/prims/core/DeviceMacros.cuh"
+#include "comms/prims/core/TiledBuffer.cuh"
+// Definitions (not just declarations) of P2pIbTransportDevice::send/recv.
+// MultiPeerDeviceHandle.cuh only pulls in the Decl header, which is enough to
+// name the type but leaves the dispatching send/recv as unresolved externs in
+// a whole-program (non `--device-c`) build like the plain SendRecvTile TU.
+#include "comms/prims/transport/P2pIbTransportDevice.cuh"
+
+#ifdef PIPES_ENABLE_ANS_COMPRESSION
+// Pulls in `kAnsMaxUncompBytes`, `ibgda_send_compressed`,
+// `ibgda_recv_compressed`, `AnsCopyOp`. Must be included BEFORE the
+// `send_to_peer` / `recv_from_peer` template definitions below so that
+// non-dependent name lookup of the dispatchers (inside the
+// `if constexpr (CopyOp::kVariableSize)` branch) succeeds at template
+// definition time.
+#include "comms/prims/collectives/SendRecvTileCompressed.cuh"
+#endif
+
+namespace comms::prims {
+
+namespace {
+
+// Validate a peer index BEFORE it is used to index the transport array, then
+// hand back that peer's transport type. `args.send_peer` / `args.recv_peer` are
+// plain host-supplied ints, so a defaulted or miscomputed field would otherwise
+// read off the end of `handle.transports` before any type check could fire.
+__device__ __forceinline__ TransportType sendrecv_peer_transport_type(
+    ThreadGroup& group,
+    const MultiPeerDeviceHandle& handle,
+    int peer,
+    const char* direction) {
+  if (peer < 0 || peer >= handle.nRanks) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: SendRecvTile %s peer %d is outside [0, %d)\n",
+          direction,
+          peer,
+          handle.nRanks);
+    }
+    PIPES_DEVICE_TRAP();
+  }
+  return handle.get_type(peer);
+}
+
+// Guard for the IB arm of the transport union. `Transport::p2p_ib` is a union
+// with no discriminator of its own, so reaching it for a peer that is neither
+// NVL nor IB (SELF, or a peer whose transport was never established)
+// reinterprets unrelated bytes as a transport pointer. Mirrors the
+// `require_ibgda` precondition the compressed path uses.
+__device__ __forceinline__ void sendrecv_require_ib_peer(
+    ThreadGroup& group,
+    TransportType type,
+    int peer,
+    const char* direction) {
+  if (type == TransportType::P2P_IBGDA || type == TransportType::P2P_IBRC) {
+    return;
+  }
+  if (group.is_leader()) {
+    printf(
+        "[PIPES] FATAL: SendRecvTile %s peer %d has transport type %d, which "
+        "is neither NVL nor IB (SELF, or never established)\n",
+        direction,
+        peer,
+        static_cast<int>(type));
+  }
+  PIPES_DEVICE_TRAP();
+}
+
+// Send one tile to a single peer. CopyOp tags the build flavour:
+//   - Memcpy (kVariableSize == false)        -> plain transport-level send
+//   - AnsCopyOp (kVariableSize == true)      -> compressed dispatcher
+// NVL transport is bandwidth-bound on intra-node links, so it always
+// uses the plain `send()` regardless of CopyOp; only the IB path honours
+// the compression policy. The `if constexpr` branch on
+// `CopyOp::kVariableSize` resolves the discriminator at compile time and
+// drops dead code per TU; the branch is preprocessor-removed when
+// PIPES_ENABLE_ANS_COMPRESSION is undefined, so the plain TU never
+// references `ibgda_send_compressed`.
+template <typename CopyOp = Memcpy>
+__device__ __forceinline__ void send_to_peer(
+    MultiPeerDeviceHandle& handle,
+    int peer,
+    ThreadGroup& group,
+    void* src,
+    std::size_t nbytes,
+    std::size_t peer_total_bytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    char* aligned_aux_buf,
+    const AbortDevice& abortDevice) {
+  const TransportType peerType =
+      sendrecv_peer_transport_type(group, handle, peer, "send to");
+  if (peerType == TransportType::P2P_NVL) {
+    handle.get_nvl(peer).send(
+        group, src, nbytes, max_signal_bytes, abortDevice);
+    return;
+  }
+  sendrecv_require_ib_peer(group, peerType, peer, "send to");
+#ifdef PIPES_ENABLE_ANS_COMPRESSION
+  if constexpr (CopyOp::kVariableSize) {
+    // Per-peer activation threshold: small tiles bypass the compressed
+    // CopyOp and fall back to the plain Memcpy IB path. The discriminator
+    // is the PER-PEER total byte count (`peer_total_bytes`), NOT this
+    // block's per-tile `nbytes`, so sender + receiver + every block agree
+    // on the same compress-vs-bypass decision per peer.
+    if (peer_total_bytes >= CopyOp::kActivationThreshold) {
+      // Per-block slice of the caller-provided 16-byte-aligned aux
+      // buffer (sized `CopyOp::kMaxUncompBytes` per block, derived from the
+      // compiled compressor rather than a hard-coded ANS constant). Only
+      // consumed inside the compressor's `send` when `src` is misaligned;
+      // null is fine for callers that always pass aligned `src`.
+      char* perBlockAux = aligned_aux_buf == nullptr
+          ? nullptr
+          : aligned_aux_buf + blockIdx.x * CopyOp::kMaxUncompBytes;
+      // Unlike the plain path below, this one really is IBGDA-bound (nvcompdx
+      // staging + the variable-size wire protocol). Make that a checked
+      // precondition rather than an unchecked read of the union's ibgda arm.
+      handle.get_ib(peer).require_ibgda(group, "sendrecv_tile compressed send");
+      ibgda_send_compressed<CopyOp>(
+          handle.get_ibgda(peer),
+          group,
+          src,
+          nbytes,
+          active_blocks,
+          max_signal_bytes,
+          abortDevice,
+          perBlockAux);
+      return;
+    }
+    // Fall through to the plain IB Memcpy path below for sub-threshold
+    // peers.
+  }
+#endif
+  // Backend-dispatching handle, not get_ibgda(): the plain path has no
+  // IBGDA-only dependency, and `Transport::p2p_ib` is a union — reading the
+  // ibgda arm on a transport built with the IBRC backend hands send() an
+  // IBRC pointer typed as IBGDA. Only the compressed branch above is
+  // IBGDA-bound (nvcompdx staging + the variable-size wire protocol).
+  // Explicitly <Memcpy>, not <CopyOp>. Reaching here with a variable-size
+  // CopyOp means the peer total was below kActivationThreshold, and BOTH sides
+  // took this branch and agreed to ship the tile uncompressed -- forwarding
+  // CopyOp would compress data the receiver is going to read as plain.
+  // Guard the third case. `if constexpr (CopyOp::kVariableSize)` above compiles
+  // out entirely for a fixed-size CopyOp, so a future non-Memcpy fixed-size
+  // policy (a quantizing op, say) routed through here would be silently
+  // downgraded to a byte copy with no diagnostic. The two paths that legally
+  // reach this line are plain Memcpy, and a variable-size op whose peer total
+  // fell below kActivationThreshold -- where shipping plain is the agreed
+  // behaviour on both ranks, not a downgrade.
+  static_assert(
+      std::is_same_v<CopyOp, Memcpy> || CopyOp::kVariableSize,
+      "the plain IB path ships bytes verbatim; a fixed-size non-Memcpy CopyOp "
+      "routed here would be silently downgraded to Memcpy");
+  handle.get_ib(peer).send<Memcpy>(
+      group, src, nbytes, max_signal_bytes, abortDevice);
+}
+
+template <typename CopyOp = Memcpy>
+__device__ __forceinline__ void recv_from_peer(
+    MultiPeerDeviceHandle& handle,
+    int peer,
+    ThreadGroup& group,
+    void* dst,
+    std::size_t nbytes,
+    std::size_t peer_total_bytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    const AbortDevice& abortDevice) {
+  const TransportType peerType =
+      sendrecv_peer_transport_type(group, handle, peer, "recv from");
+  if (peerType == TransportType::P2P_NVL) {
+    handle.get_nvl(peer).recv(
+        group, dst, nbytes, max_signal_bytes, abortDevice);
+    return;
+  }
+  sendrecv_require_ib_peer(group, peerType, peer, "recv from");
+#ifdef PIPES_ENABLE_ANS_COMPRESSION
+  if constexpr (CopyOp::kVariableSize) {
+    // Mirror the sender-side `kActivationThreshold` gate. Sender and
+    // receiver MUST agree on this discriminator (both see the same
+    // `peer_total_bytes`), or the receiver would try to ANS-decompress
+    // raw payload.
+    if (peer_total_bytes >= CopyOp::kActivationThreshold) {
+      handle.get_ib(peer).require_ibgda(group, "sendrecv_tile compressed recv");
+      ibgda_recv_compressed<CopyOp>(
+          handle.get_ibgda(peer),
+          group,
+          dst,
+          nbytes,
+          active_blocks,
+          max_signal_bytes,
+          abortDevice);
+      return;
+    }
+    // Fall through to the plain IB Memcpy recv path below.
+  }
+#endif
+  // Backend-dispatching handle — see the note on the send side.
+  // Explicitly <Memcpy> -- see the note on the send side.
+  static_assert(
+      std::is_same_v<CopyOp, Memcpy> || CopyOp::kVariableSize,
+      "the plain IB path ships bytes verbatim; a fixed-size non-Memcpy CopyOp "
+      "routed here would be silently downgraded to Memcpy");
+  handle.get_ib(peer).recv<Memcpy>(
+      group, dst, nbytes, max_signal_bytes, abortDevice);
+}
+
+// Per-block plain/compressed selector for the mixed-mode dispatch. When
+// `fraction` is in (0, 1), exactly `k = lround(fraction * activeBlocks)`
+// of the `activeBlocks` blocks are chosen to use the plain `Memcpy`
+// CopyOp, evenly interleaved across the block-id range via a
+// Bresenham-style test. The decision depends only on (`fraction`,
+// `blockId`, `activeBlocks`) — all identical on both peers for a given
+// per-direction subgroup id — so a plain-sending block is always matched
+// by a plain-receiving block on the peer. `fraction <= 0` -> never plain
+// (all compiled CopyOp); `fraction >= 1` -> always plain.
+__device__ __forceinline__ bool
+sendrecv_use_plain_block(float fraction, int blockId, int activeBlocks) {
+  // NaN fails every comparison, so without this it would slip past both the
+  // <= 0 and >= 1 guards and reach lroundf(NaN), whose result is unspecified --
+  // and an unspecified k makes the plain/compressed split arbitrary, which the
+  // peer would not reproduce. Treat any non-finite fraction as "never plain",
+  // matching the documented [0,1] contract.
+  if (!isfinite(fraction) || fraction <= 0.0f || activeBlocks <= 0) {
+    return false;
+  }
+  if (fraction >= 1.0f) {
+    return true;
+  }
+  const long k = lroundf(fraction * static_cast<float>(activeBlocks));
+  if (k <= 0) {
+    return false;
+  }
+  if (k >= activeBlocks) {
+    return true;
+  }
+  // floor((blockId+1)*k / activeBlocks) > floor(blockId*k / activeBlocks)
+  // selects exactly k evenly spread block ids.
+  const long lo = (static_cast<long>(blockId) * k) / activeBlocks;
+  const long hi = (static_cast<long>(blockId + 1) * k) / activeBlocks;
+  return hi > lo;
+}
+
+// Drive the send direction with `group`'s blocks: tile `send_data` across
+// the group and have each block ship its slice to `send_peer`.
+template <typename CopyOp = Memcpy>
+__device__ __forceinline__ void sendrecv_do_send(
+    MultiPeerDeviceHandle& handle,
+    const SendRecvTileArgs& args,
+    ThreadGroup& group,
+    const AbortDevice& abortDevice) {
+  const int activeBlocks = group.total_groups;
+  const int blockId = group.group_id;
+  TiledBuffer<char> tiles(args.send_data, args.send_count, activeBlocks);
+  // Mixed-mode: a fraction of blocks fall back to plain Memcpy so their
+  // light-weight sends fill NIC bandwidth the compute-heavy CopyOp
+  // blocks leave idle. Byte-identical to the all-CopyOp path when
+  // plain_block_fraction == 0 (the common case).
+  // `if constexpr`: in the plain (Memcpy) instantiation both arms below expand
+  // to the SAME call, so without this guard every block would still evaluate
+  // the selector -- isfinite, lroundf and the Bresenham divisions -- only to
+  // choose between two identical code paths. Compiled out entirely there;
+  // unchanged in the compressed TU.
+  if constexpr (!std::is_same_v<CopyOp, Memcpy>) {
+    if (sendrecv_use_plain_block(
+            args.plain_block_fraction, blockId, activeBlocks)) {
+      send_to_peer<Memcpy>(
+          handle,
+          args.send_peer,
+          group,
+          tiles.tile_data(blockId),
+          tiles.tile_bytes(blockId),
+          args.send_count,
+          activeBlocks,
+          args.max_signal_bytes,
+          args.aligned_aux_buf,
+          abortDevice);
+      return;
+    }
+  }
+  send_to_peer<CopyOp>(
+      handle,
+      args.send_peer,
+      group,
+      tiles.tile_data(blockId),
+      tiles.tile_bytes(blockId),
+      args.send_count,
+      activeBlocks,
+      args.max_signal_bytes,
+      args.aligned_aux_buf,
+      abortDevice);
+}
+
+// Drive the recv direction with `group`'s blocks: tile `recv_data` across
+// the group and have each block pull its slice from `recv_peer`.
+template <typename CopyOp = Memcpy>
+__device__ __forceinline__ void sendrecv_do_recv(
+    MultiPeerDeviceHandle& handle,
+    const SendRecvTileArgs& args,
+    ThreadGroup& group,
+    const AbortDevice& abortDevice) {
+  const int activeBlocks = group.total_groups;
+  const int blockId = group.group_id;
+  TiledBuffer<char> tiles(args.recv_data, args.recv_count, activeBlocks);
+  // Mirror the send-side mixed-mode decision so a plain-sent tile is
+  // plain-received (same fraction/blockId/activeBlocks on both peers).
+  // `if constexpr`: in the plain (Memcpy) instantiation both arms below expand
+  // to the SAME call, so without this guard every block would still evaluate
+  // the selector -- isfinite, lroundf and the Bresenham divisions -- only to
+  // choose between two identical code paths. Compiled out entirely there;
+  // unchanged in the compressed TU.
+  if constexpr (!std::is_same_v<CopyOp, Memcpy>) {
+    if (sendrecv_use_plain_block(
+            args.plain_block_fraction, blockId, activeBlocks)) {
+      recv_from_peer<Memcpy>(
+          handle,
+          args.recv_peer,
+          group,
+          tiles.tile_data(blockId),
+          tiles.tile_bytes(blockId),
+          args.recv_count,
+          activeBlocks,
+          args.max_signal_bytes,
+          abortDevice);
+      return;
+    }
+  }
+  recv_from_peer<CopyOp>(
+      handle,
+      args.recv_peer,
+      group,
+      tiles.tile_data(blockId),
+      tiles.tile_bytes(blockId),
+      args.recv_count,
+      activeBlocks,
+      args.max_signal_bytes,
+      abortDevice);
+}
+
+// Point-to-point driver. Modes (selected by is_send / is_recv):
+//   - send only:   all blocks send to send_peer.
+//   - recv only:   all blocks recv from recv_peer.
+//   - send + recv: split the grid — role 0 (first half) sends to
+//                  send_peer, role 1 (second half) recvs from recv_peer
+//                  (each direction gets gridDim.x / 2 blocks). The two
+//                  directions use independent transport staging/signal
+//                  state, so a bidirectional pair to the same peer is
+//                  safe.
+// `send_to_peer` / `recv_from_peer` dispatch to NVL or IB (and, for
+// variable-size CopyOps, to the ANS-compressed path).
+template <typename CopyOp = Memcpy>
+__device__ __forceinline__ void sendrecv_tile_impl(
+    const SendRecvTileArgs& args,
+    AbortDevice& abortDevice) {
+  auto handle = args.handle;
+  // The grid split is keyed on the direction ENABLES, never on the counts. The
+  // enables are launch configuration both peers agree on; the counts are data.
+  // Folding a zero count into the split would give a rank with
+  // is_send && is_recv but send_count == 0 all gridDim.x blocks for its recv,
+  // while the peer -- with both counts non-zero -- still uses gridDim.x / 2 per
+  // direction. That breaks the matching per-direction active-block invariant
+  // and shows up as a hang or mis-tiled data, with no diagnostic.
+  const bool bidirectional = args.is_send && args.is_recv;
+  const bool doSend = args.is_send && args.send_count > 0;
+  const bool doRecv = args.is_recv && args.recv_count > 0;
+  if (!doSend && !doRecv) {
+    return;
+  }
+
+  auto group = make_block_group();
+
+  if (bidirectional) {
+    // Bidirectional mode splits the grid in half via partition(2). An odd
+    // gridDim.x would hand the two directions unequal block counts, breaking
+    // the matching per-direction active-block invariant the peers rely on
+    // (peer A's role-0 sender count must equal peer B's role-1 receiver
+    // count). Require an even grid and fail loudly rather than hang.
+    if ((gridDim.x % 2u) != 0u) {
+      if (blockIdx.x == 0 && threadIdx.x == 0) {
+        printf(
+            "[PIPES] FATAL: SendRecvTile bidirectional mode requires an even "
+            "gridDim.x (got %u)\n",
+            gridDim.x);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    // INTERLEAVED, not contiguous. `partition(2)` puts every sender in the
+    // lower grid half, which is a liveness hazard once a tile exceeds
+    // `pipelineBytes` and the sender has to wait on the peer's SLOT_FREE:
+    // blocks become resident roughly in blockIdx order, so an oversubscribed
+    // grid can fill every resident CTA slot with senders on BOTH ranks and
+    // leave no receiver scheduled to drain them. That is a hang, not a slow
+    // path. Interleaving (even blocks send, odd blocks recv) makes any
+    // contiguous run of resident blocks contain both roles, so a sender always
+    // has a receiver co-resident to release its window.
+    //
+    // Both ranks derive the split the same way from blockIdx, so the
+    // per-direction block counts still match peer-to-peer.
+    auto [role, sub] = group.partition_interleaved(2);
+    // A direction whose count is zero still consumes its half of the grid; it
+    // simply does no work. That keeps this rank's per-direction block count
+    // equal to the peer's.
+    if (role == 0) {
+      if (doSend) {
+        sendrecv_do_send<CopyOp>(handle, args, sub, abortDevice);
+      }
+    } else {
+      if (doRecv) {
+        sendrecv_do_recv<CopyOp>(handle, args, sub, abortDevice);
+      }
+    }
+    return;
+  }
+
+  if (doSend) {
+    sendrecv_do_send<CopyOp>(handle, args, group, abortDevice);
+  } else {
+    sendrecv_do_recv<CopyOp>(handle, args, group, abortDevice);
+  }
+}
+
+} // namespace
+
+} // namespace comms::prims

--- a/comms/prims/core/CopyOp.cuh
+++ b/comms/prims/core/CopyOp.cuh
@@ -368,6 +368,13 @@ struct AnsCompress {
   // shmem / aux-buf overhead.
   static constexpr std::size_t kActivationThreshold = 4ULL * 1024 * 1024;
 
+  // Maximum uncompressed sub-chunk size this CopyOp operates on (the
+  // `MaxUncompBytes` template arg). Consumers that stage a full uncompressed
+  // chunk (e.g. the per-block realign aux buffer in SendRecvTileCommon) size
+  // that scratch off this so the geometry tracks the CopyOp instead of a
+  // hard-coded per-algorithm constant.
+  static constexpr std::size_t kMaxUncompBytes = MaxUncompBytes;
+
  private:
   // ===========================================================================
   // Compile-time SM picker. nvCOMPDx instantiates a fully-typed

--- a/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
+++ b/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
@@ -131,5 +131,32 @@ TEST(MultiPeerIbTransportConfigTest, PeerMaterializationDefaultsOnDemand) {
   EXPECT_TRUE(config.ibLazyConnect);
 }
 
+// PeerQpPayload is the lazy (ibLazyConnect) bilateral wire format: one is sent
+// and one received per peer on every materializePeer(), and both live on the
+// stack while in flight. Its qpns[] array is dimensioned by
+// kMaxIbQpsPerPeerPerNic, so that constant must stay a QP budget in its own
+// right rather than being derived from the kMaxIbGroups index space -- growing
+// the group index space must not grow what every lazy peer exchange costs. The
+// footprint bound is kMaxNicsPerGpu * 8192 QPNs, ~64KB.
+TEST(MultiPeerIbTransportConfigTest, LazyQpPayloadDoesNotScaleWithGroupLimit) {
+  EXPECT_LT(kMaxIbQpsPerPeerPerNic, kMaxIbGroups * kMaxIbQpsPerBlockPerNic);
+  EXPECT_LE(sizeof(PeerQpPayload), 72u * 1024u);
+}
+
+// The shape this limit exists for -- SendRecvTile's 256 channels, both
+// directions -- must fit the QP budget while landing above the eager exchange
+// cap, i.e. it is reachable only with ibLazyConnect=true.
+TEST(MultiPeerIbTransportConfigTest, MaxGroupShapeFitsBudgetAndRequiresLazy) {
+  MultipeerIbTransportConfig config;
+  config.perChannelSize = 64 * 1024; // > 0 selects the two-direction shape
+  config.max_num_channels = kMaxIbGroups;
+  config.qpsPerConnection = 1;
+
+  const int mainQps = config.fixedChannelMainQpsPerPeerPerNic();
+  EXPECT_EQ(mainQps, kMaxIbGroups * kIbDirections);
+  EXPECT_LE(mainQps, kMaxIbQpsPerPeerPerNic);
+  EXPECT_GT(mainQps, kMaxEagerExchangeQpsPerPeerPerNic);
+}
+
 } // namespace
 } // namespace comms::prims

--- a/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
+++ b/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
@@ -593,5 +593,61 @@ TEST(MultiPeerIbTransportConfigTest, QpOrderingWireDefaultMatchesIbta) {
       payload.qpOrderingSemantic, static_cast<int>(IbQpOrderingSemantic::Ibta));
 }
 
+// PeerQpPayload is the lazy (ibLazyConnect) bilateral wire format: one is sent
+// and one received per peer on every materializePeer(), and both live on the
+// stack while in flight. Its qpns[] array is dimensioned by
+// kMaxIbQpsPerPeerPerNic, so that constant must stay a QP budget in its own
+// right rather than being derived from the kMaxIbGroups index space -- growing
+// the group index space must not grow what every lazy peer exchange costs. The
+// footprint bound is kMaxNicsPerGpu * 8192 QPNs, ~64KB.
+TEST(MultiPeerIbTransportConfigTest, LazyQpPayloadDoesNotScaleWithGroupLimit) {
+  // What actually matters to a lazy caller is the observable property: the
+  // bilateral exchange payload stays small no matter how wide the group index
+  // space gets. Assert that directly, against the same named bound the header
+  // static_asserts on, so there is no second copy of the number to drift.
+  //
+  // Deliberately NOT `kMaxIbQpsPerPeerPerNic < kMaxIbGroups *
+  // kMaxIbQpsPerBlockPerNic`: that only holds because kMaxIbGroups is 256
+  // today. Returning it to 64 would make the product exactly 8192 and turn the
+  // check red even though the constant would still be independent -- it
+  // expresses the decoupling only by accident.
+  //
+  // Nor `sizeof(PeerQpPayload) <= kMaxPeerQpPayloadBytes`: that is the header's
+  // static_assert, so a violation fails to compile and this test could never go
+  // red. Assert instead what only a runtime check can see -- that the WIDEST
+  // shape the index space admits still fits the exchanged array. That is the
+  // property a future kMaxIbGroups bump can actually break.
+  MultipeerIbTransportConfig narrow;
+  narrow.perChannelSize = 64 * 1024; // > 0 selects the two-direction shape
+  narrow.max_num_channels = 1;
+  narrow.qpsPerConnection = 1;
+
+  MultipeerIbTransportConfig widest = narrow;
+  widest.max_num_channels = kMaxIbGroups;
+
+  ASSERT_LT(
+      narrow.fixedChannelMainQpsPerPeerPerNic(),
+      widest.fixedChannelMainQpsPerPeerPerNic())
+      << "the two shapes must differ for this to prove anything";
+  EXPECT_LE(widest.fixedChannelMainQpsPerPeerPerNic(), kMaxIbQpsPerPeerPerNic)
+      << "the widest configurable shape must fit the exchanged qpns[] array; "
+         "raising kMaxIbGroups past the QP budget needs a wire-format change";
+}
+
+// The shape this limit exists for -- SendRecvTile's 256 channels, both
+// directions -- must fit the QP budget while landing above the eager exchange
+// cap, i.e. it is reachable only with ibLazyConnect=true.
+TEST(MultiPeerIbTransportConfigTest, MaxGroupShapeFitsBudgetAndRequiresLazy) {
+  MultipeerIbTransportConfig config;
+  config.perChannelSize = 64 * 1024; // > 0 selects the two-direction shape
+  config.max_num_channels = kMaxIbGroups;
+  config.qpsPerConnection = 1;
+
+  const int mainQps = config.fixedChannelMainQpsPerPeerPerNic();
+  EXPECT_EQ(mainQps, kMaxIbGroups * kIbDirections);
+  EXPECT_LE(mainQps, kMaxIbQpsPerPeerPerNic);
+  EXPECT_GT(mainQps, kMaxEagerExchangeQpsPerPeerPerNic);
+}
+
 } // namespace
 } // namespace comms::prims

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -2867,9 +2867,13 @@ class LazyModeTestFixture
     return GetParam();
   }
 
-  std::unique_ptr<TestIbTransport> createLazyTransport() {
+  std::unique_ptr<TestIbTransport> createLazyTransport(
+      int maxChannels = 64,
+      std::size_t perChannelSize = 0) {
     MultipeerIbTransportConfig config{
         .cudaDevice = localRank,
+        .perChannelSize = perChannelSize,
+        .max_num_channels = maxChannels,
         .numSignalSlots = 1,
         .numCounterSlots = 1,
         .ibLazyConnect = true,
@@ -2918,6 +2922,93 @@ TEST_P(LazyModeTestFixture, QueueThenConnect) {
 
     transport->connectPeers();
     EXPECT_TRUE(transport->isPeerMaterialized(peerRank));
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << backendName(backend()) << " not available: " << e.what();
+  }
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+// A full kMaxIbGroups channel count is reachable only through lazy peer
+// materialization: kMaxIbGroups channels x kIbDirections is far past
+// kMaxEagerExchangeQpsPerPeerPerNic. Materializes that shape for real and moves
+// data over it, so the bilateral PeerQpPayload exchange is exercised at the
+// widest group count the index space allows.
+TEST_P(LazyModeTestFixture, MaterializeAndTransferAboveEagerQpLimit) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+  }
+  ASSERT_GT(kMaxIbGroups * kIbDirections, kMaxEagerExchangeQpsPerPeerPerNic);
+
+  constexpr std::size_t perChannelSize = 4 * 1024;
+  constexpr std::size_t nbytes = 64 * 1024;
+  constexpr int numBlocks = 1;
+  constexpr int blockSize = 32;
+  constexpr uint8_t testPattern = 0x5a;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+
+  try {
+    auto transport = createLazyTransport(kMaxIbGroups, perChannelSize);
+    EXPECT_FALSE(transport->isPeerMaterialized(peerRank));
+
+    DeviceBuffer dataBuffer(nbytes);
+    auto localDataBuf = transport->registerBuffer(dataBuffer.get(), nbytes);
+    auto remoteDataBufs = transport->exchangeBuffer(localDataBuf);
+    const int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
+    auto remoteDataBuf = remoteDataBufs[peerIndex];
+
+    auto peerTransport = transport->getP2pTransportDevice(peerRank);
+    EXPECT_TRUE(transport->isPeerMaterialized(peerRank));
+
+    if (globalRank == 0) {
+      test::fillBufferWithPattern(
+          localDataBuf.ptr, nbytes, testPattern, numBlocks, blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      test::testPutAndSignal(
+          peerTransport,
+          localDataBuf,
+          remoteDataBuf,
+          nbytes,
+          /*signalId=*/0,
+          /*signalVal=*/1,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    } else {
+      CUDACHECK_TEST(cudaMemset(localDataBuf.ptr, 0, nbytes));
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      test::testWaitSignal(
+          peerTransport,
+          /*signalId=*/0,
+          /*expected=*/1,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      DeviceBuffer errorCountBuf(sizeof(int));
+      auto* dErrorCount = static_cast<int*>(errorCountBuf.get());
+      CUDACHECK_TEST(cudaMemset(dErrorCount, 0, sizeof(int)));
+      test::verifyBufferPattern(
+          localDataBuf.ptr,
+          nbytes,
+          testPattern,
+          dErrorCount,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      int hErrorCount = 0;
+      CUDACHECK_TEST(cudaMemcpy(
+          &hErrorCount, dErrorCount, sizeof(int), cudaMemcpyDeviceToHost));
+      EXPECT_EQ(hErrorCount, 0)
+          << "Rank " << globalRank << ": " << hErrorCount
+          << " byte mismatches over a " << kMaxIbGroups << "-group lazy peer";
+    }
   } catch (const std::exception& e) {
     GTEST_SKIP() << backendName(backend()) << " not available: " << e.what();
   }

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -7,6 +7,7 @@
 #include <chrono>
 #include "comms/utils/logger/SpdlogLogger.h"
 
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -3941,9 +3942,16 @@ class LazyModeTestFixture
     return GetParam();
   }
 
-  std::unique_ptr<TestIbTransport> createLazyTransport() {
+  // Default taken from the config struct rather than restated, so a change to
+  // MultipeerIbTransportConfig::max_num_channels keeps applying to the callers
+  // that do not pass one.
+  std::unique_ptr<TestIbTransport> createLazyTransport(
+      int maxChannels = MultipeerIbTransportConfig{}.max_num_channels,
+      std::size_t perChannelSize = 0) {
     MultipeerIbTransportConfig config{
         .cudaDevice = localRank,
+        .perChannelSize = perChannelSize,
+        .max_num_channels = maxChannels,
         .numSignalSlots = 1,
         .numCounterSlots = 1,
         .ibLazyConnect = true,
@@ -3994,6 +4002,254 @@ TEST_P(LazyModeTestFixture, QueueThenConnect) {
     EXPECT_TRUE(transport->isPeerMaterialized(peerRank));
   } catch (const std::exception& e) {
     GTEST_SKIP() << backendName(backend()) << " not available: " << e.what();
+  }
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+// A full kMaxIbGroups channel count is reachable only through lazy peer
+// materialization: kMaxIbGroups channels x kIbDirections is far past
+// kMaxEagerExchangeQpsPerPeerPerNic. Materializes that shape for real and moves
+// data over it, so the bilateral PeerQpPayload exchange is exercised at the
+// widest group count the index space allows.
+TEST_P(LazyModeTestFixture, MaterializeAndTransferAboveEagerQpLimit) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+  }
+  ASSERT_GT(kMaxIbGroups * kIbDirections, kMaxEagerExchangeQpsPerPeerPerNic);
+
+  constexpr std::size_t perChannelSize = 4 * 1024;
+  constexpr std::size_t nbytes = 64 * 1024;
+  constexpr int numBlocks = 1;
+  constexpr int blockSize = 32;
+  constexpr uint8_t testPattern = 0x5a;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+
+  // Try only around construction, with the skip decision reduced across ranks
+  // -- same shape as FixedChannelSendRecvSpansGroupsAboveLegacyLimit below, and
+  // for the same two reasons: a genuine failure at the 256-group shape is what
+  // this test exists to catch and must not be reported as "backend not
+  // available", and a rank that bailed out mid-body would leave its peer
+  // blocked in an inner barrier.
+  std::unique_ptr<TestIbTransport> transport;
+  std::string setupError;
+  try {
+    transport = createLazyTransport(kMaxIbGroups, perChannelSize);
+  } catch (const std::exception& e) {
+    setupError = e.what();
+  }
+  int localSetupOk = setupError.empty() ? 1 : 0;
+  int globalSetupOk = 0;
+  MPI_CHECK(MPI_Allreduce(
+      &localSetupOk, &globalSetupOk, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD));
+  if (globalSetupOk == 0) {
+    if (setupError.empty()) {
+      GTEST_SKIP() << backendName(backend())
+                   << " not available: peer rank could not construct";
+    }
+    GTEST_SKIP() << backendName(backend()) << " not available: " << setupError;
+  }
+
+  {
+    EXPECT_FALSE(transport->isPeerMaterialized(peerRank));
+
+    DeviceBuffer dataBuffer(nbytes);
+    auto localDataBuf = transport->registerBuffer(dataBuffer.get(), nbytes);
+    auto remoteDataBufs = transport->exchangeBuffer(localDataBuf);
+    const int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
+    auto remoteDataBuf = remoteDataBufs[peerIndex];
+
+    auto peerTransport = transport->getP2pTransportDevice(peerRank);
+    EXPECT_TRUE(transport->isPeerMaterialized(peerRank));
+
+    if (globalRank == 0) {
+      test::fillBufferWithPattern(
+          localDataBuf.ptr, nbytes, testPattern, numBlocks, blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      test::testPutAndSignal(
+          peerTransport,
+          localDataBuf,
+          remoteDataBuf,
+          nbytes,
+          /*signalId=*/0,
+          /*signalVal=*/1,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    } else {
+      CUDACHECK_TEST(cudaMemset(localDataBuf.ptr, 0, nbytes));
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      test::testWaitSignal(
+          peerTransport,
+          /*signalId=*/0,
+          /*expectedSignal=*/1,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      DeviceBuffer errorCountBuf(sizeof(int));
+      auto* dErrorCount = static_cast<int*>(errorCountBuf.get());
+      CUDACHECK_TEST(cudaMemset(dErrorCount, 0, sizeof(int)));
+      test::verifyBufferPattern(
+          localDataBuf.ptr,
+          nbytes,
+          testPattern,
+          dErrorCount,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      int hErrorCount = 0;
+      CUDACHECK_TEST(cudaMemcpy(
+          &hErrorCount, dErrorCount, sizeof(int), cudaMemcpyDeviceToHost));
+      EXPECT_EQ(hErrorCount, 0)
+          << "Rank " << globalRank << ": " << hErrorCount
+          << " byte mismatches over a " << kMaxIbGroups << "-group lazy peer";
+    }
+  }
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+// The group ceiling this diff replaces. Named so the test below cannot
+// quietly become vacuous if kMaxIbGroups is ever lowered back toward it.
+constexpr int kLegacyMaxIbGroups = 64;
+
+// MaterializeAndTransferAboveEagerQpLimit proves the lazy peer EXCHANGE
+// survives 512 QPs. It does not prove send/recv can SELECT a channel above the
+// old ceiling: it moves its bytes with a single-block put/signal, so it only
+// ever touches channel 0. Channel selection indexes a different set of
+// structures per block -- the per-(channel, protocol) resource slot, its
+// staging window, its progress cursor and its QP lane -- and none of those
+// above index 63 were reached.
+//
+// So drive the real fixed-channel send/recv path with one block per channel
+// across the whole 0..kMaxIbGroups-1 range. Two properties make the coverage
+// real rather than nominal:
+//   - each block owns its own slice, so a channel that moves nothing leaves
+//     its slice zeroed instead of being covered by a sibling block writing the
+//     same bytes;
+//   - bytesPerBlock stays inside one pipeline window, so a sender never waits
+//     on a peer's SLOT_FREE. With 256 blocks per rank and far fewer resident,
+//     a sender that could block on a not-yet-scheduled receiver would deadlock
+//     the test rather than fail it.
+TEST_P(LazyModeTestFixture, FixedChannelSendRecvSpansGroupsAboveLegacyLimit) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+  }
+  ASSERT_GT(kMaxIbGroups, kLegacyMaxIbGroups)
+      << "vacuous unless the group limit is above the legacy ceiling";
+
+  constexpr int numBlocks = kMaxIbGroups;
+  constexpr int blockSize = 256;
+  // Inside one pipeline window (perChannelSize) -- see the deadlock note above.
+  constexpr std::size_t bytesPerBlock = 4 * 1024;
+  constexpr std::size_t perChannelSize = 16 * 1024;
+  constexpr std::size_t maxSignalBytes = 0;
+  constexpr uint8_t basePattern = 0x11;
+  constexpr std::size_t totalBytes = bytesPerBlock * numBlocks;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+
+  // Only the transport construction is allowed to turn into a skip, and the
+  // skip decision is reduced across ranks before it is acted on. Wrapping the
+  // whole body instead would (a) report a genuine failure at the 256-group
+  // shape -- exactly what this test targets -- as "backend not available", and
+  // (b) let one rank bail out mid-test while its peer is still blocked on an
+  // inner barrier, hanging the run instead of failing it.
+  std::unique_ptr<TestIbTransport> transport;
+  std::string setupError;
+  try {
+    // perChannelSize > 0 selects the fixed-channel shape, which is also what
+    // makes the transport derive maxGroups from max_num_channels -- device-side
+    // QP selection needs block_id < maxGroups, so a 64-group transport would
+    // fault on block 64 rather than merely mis-route it.
+    transport = createLazyTransport(kMaxIbGroups, perChannelSize);
+  } catch (const std::exception& e) {
+    setupError = e.what();
+  }
+  int localSetupOk = setupError.empty() ? 1 : 0;
+  int globalSetupOk = 0;
+  MPI_CHECK(MPI_Allreduce(
+      &localSetupOk, &globalSetupOk, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD));
+  if (globalSetupOk == 0) {
+    // Two statements rather than a ternary: mixing a string literal with
+    // `setupError` in one conditional forces both arms to std::string, which
+    // copies the error on the branch that already owns it.
+    if (setupError.empty()) {
+      GTEST_SKIP() << backendName(backend())
+                   << " not available: peer rank could not construct";
+    }
+    GTEST_SKIP() << backendName(backend()) << " not available: " << setupError;
+  }
+
+  {
+    auto peerTransport = transport->getP2pTransportDevice(peerRank);
+    // EXPECT, not ASSERT: an ASSERT returns from the test body, so a rank that
+    // failed here would skip the trailing barrier while its peer stays blocked
+    // in it -- turning a failure into a distributed hang, and desyncing the
+    // barrier sequence for every later test in the binary.
+    EXPECT_TRUE(transport->isPeerMaterialized(peerRank));
+
+    DeviceBuffer buffer(totalBytes);
+    if (globalRank == 0) {
+      test::fillShardedPattern(
+          buffer.get(), bytesPerBlock, basePattern, numBlocks, blockSize);
+    } else {
+      CUDACHECK_TEST(cudaMemset(buffer.get(), 0, totalBytes));
+    }
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    test::testShardedSendRecvIb(
+        peerTransport,
+        buffer.get(),
+        bytesPerBlock,
+        maxSignalBytes,
+        /*send=*/globalRank == 0,
+        numBlocks,
+        blockSize);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    if (globalRank == 1) {
+      DeviceBuffer errorCountBuf(sizeof(int));
+      DeviceBuffer firstBadSliceBuf(sizeof(int));
+      auto* dErrorCount = static_cast<int*>(errorCountBuf.get());
+      auto* dFirstBadSlice = static_cast<int*>(firstBadSliceBuf.get());
+      CUDACHECK_TEST(cudaMemset(dErrorCount, 0, sizeof(int)));
+      const int sentinel = std::numeric_limits<int>::max();
+      CUDACHECK_TEST(cudaMemcpy(
+          dFirstBadSlice, &sentinel, sizeof(int), cudaMemcpyHostToDevice));
+
+      test::verifyShardedPattern(
+          buffer.get(),
+          bytesPerBlock,
+          basePattern,
+          dErrorCount,
+          dFirstBadSlice,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      int hErrorCount = 0;
+      int hFirstBadSlice = 0;
+      CUDACHECK_TEST(cudaMemcpy(
+          &hErrorCount, dErrorCount, sizeof(int), cudaMemcpyDeviceToHost));
+      CUDACHECK_TEST(cudaMemcpy(
+          &hFirstBadSlice,
+          dFirstBadSlice,
+          sizeof(int),
+          cudaMemcpyDeviceToHost));
+      EXPECT_EQ(hErrorCount, 0)
+          << hErrorCount << " byte mismatches across " << numBlocks
+          << " fixed channels; first bad channel "
+          << (hFirstBadSlice == sentinel ? -1 : hFirstBadSlice)
+          << " (legacy ceiling was " << kLegacyMaxIbGroups << ")";
+    }
   }
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 }

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -410,6 +410,66 @@ __global__ void sendRecvKernel(
   }
 }
 
+__global__ void shardedSendRecvIbKernel(
+    P2pIbTransportDevice transport,
+    void* buffer,
+    std::size_t bytesPerBlock,
+    std::size_t maxSignalBytes,
+    bool send,
+    AbortDevice abortDevice) {
+  auto group = make_block_group();
+  abortDevice.start();
+  // make_block_group() sets group_id = blockIdx.x, and the fixed-channel
+  // send/recv path keys its channel off group_id, so block b drives channel b.
+  // Giving each block its own slice makes that mapping observable end to end.
+  auto* slice = static_cast<char*>(buffer) +
+      static_cast<std::size_t>(blockIdx.x) * bytesPerBlock;
+  if (send) {
+    transport.send(group, slice, bytesPerBlock, maxSignalBytes, abortDevice);
+  } else {
+    transport.recv(group, slice, bytesPerBlock, maxSignalBytes, abortDevice);
+  }
+}
+
+// Single definition of the sharded pattern, shared by the producer and the
+// checker below. Restating the formula in both is how a test ends up passing
+// or failing for the wrong reason after one side is edited.
+__device__ __forceinline__ uint8_t
+shardedExpectedByte(uint8_t baseValue, unsigned slice, std::size_t i) {
+  return static_cast<uint8_t>(baseValue + slice + (i % 256));
+}
+
+__global__ void fillShardedPatternKernel(
+    uint8_t* buffer,
+    std::size_t bytesPerBlock,
+    uint8_t baseValue) {
+  uint8_t* slice =
+      buffer + static_cast<std::size_t>(blockIdx.x) * bytesPerBlock;
+  for (std::size_t i = threadIdx.x; i < bytesPerBlock; i += blockDim.x) {
+    slice[i] = shardedExpectedByte(baseValue, blockIdx.x, i);
+  }
+}
+
+__global__ void verifyShardedPatternKernel(
+    const uint8_t* buffer,
+    std::size_t bytesPerBlock,
+    uint8_t expectedBaseValue,
+    int* errorCount,
+    int* firstBadSlice) {
+  const uint8_t* slice =
+      buffer + static_cast<std::size_t>(blockIdx.x) * bytesPerBlock;
+  int local = 0;
+  for (std::size_t i = threadIdx.x; i < bytesPerBlock; i += blockDim.x) {
+    if (slice[i] != shardedExpectedByte(expectedBaseValue, blockIdx.x, i)) {
+      ++local;
+    }
+  }
+  if (local > 0) {
+    atomicAdd(errorCount, local);
+    atomicMin(firstBadSlice, static_cast<int>(blockIdx.x));
+  }
+}
+
 __global__ void twoCallSendThenRecvKernel(
     P2pIbTransportDevice transport,
     const void* sendBuffer,
@@ -441,6 +501,64 @@ void testSendRecv(
     int blockSize) {
   sendRecvKernel<<<numBlocks, blockSize>>>(
       transport, buffer, nbytes, maxSignalBytes, send, testAbortDevice());
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
+void testShardedSendRecvIb(
+    P2pIbTransportDevice transport,
+    void* buffer,
+    std::size_t bytesPerBlock,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize) {
+  shardedSendRecvIbKernel<<<numBlocks, blockSize>>>(
+      transport,
+      buffer,
+      bytesPerBlock,
+      maxSignalBytes,
+      send,
+      testAbortDevice());
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
+void fillShardedPattern(
+    void* buffer,
+    std::size_t bytesPerBlock,
+    uint8_t baseValue,
+    int numBlocks,
+    int blockSize) {
+  fillShardedPatternKernel<<<numBlocks, blockSize>>>(
+      static_cast<uint8_t*>(buffer), bytesPerBlock, baseValue);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
+void verifyShardedPattern(
+    const void* buffer,
+    std::size_t bytesPerBlock,
+    uint8_t expectedBaseValue,
+    int* errorCount,
+    int* firstBadSlice,
+    int numBlocks,
+    int blockSize) {
+  verifyShardedPatternKernel<<<numBlocks, blockSize>>>(
+      static_cast<const uint8_t*>(buffer),
+      bytesPerBlock,
+      expectedBaseValue,
+      errorCount,
+      firstBadSlice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -179,6 +179,60 @@ void testPipelineGeometry(
     int blockSize);
 
 /**
+ * Test kernel: blocking pipelined send or recv over the backend-DISPATCHING
+ * `P2pIbTransportDevice`, one fixed channel per block. Block `b` drives
+ * channel `b` over the `bytesPerBlock`-sized slice of `buffer` at
+ * `b * bytesPerBlock`.
+ *
+ * The per-block slice is what makes channel coverage observable. Handing
+ * every block the same buffer (what the single-buffer `testSendRecv` does)
+ * means a channel that silently moves nothing is masked by a sibling block
+ * writing the same bytes, so the verify passes with most channels dead.
+ *
+ * Caller must keep `bytesPerBlock` within one pipeline window: senders then
+ * never block on a peer's SLOT_FREE, so the test cannot deadlock when it runs
+ * more blocks than the GPU can hold resident.
+ */
+void testShardedSendRecvIb(
+    P2pIbTransportDevice transport,
+    void* buffer,
+    std::size_t bytesPerBlock,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize);
+
+/**
+ * Fill `numBlocks` consecutive `bytesPerBlock` slices, keying slice `b` on
+ * `baseValue + b` so every slice is byte-distinguishable from its neighbours.
+ */
+void fillShardedPattern(
+    void* buffer,
+    std::size_t bytesPerBlock,
+    uint8_t baseValue,
+    int numBlocks,
+    int blockSize);
+
+/**
+ * Verify the layout `fillShardedPattern` writes. `errorCount` accumulates
+ * mismatched bytes; `firstBadSlice` is `atomicMin`-reduced to the lowest slice
+ * index that had any mismatch, which is what tells a failure whether the
+ * channels above the legacy limit were the ones that dropped data.
+ *
+ * The caller must pre-seed `firstBadSlice` with a sentinel above every valid
+ * slice index (`std::numeric_limits<int>::max()`); a clean run leaves it
+ * untouched rather than writing a "no failure" value of its own.
+ */
+void verifyShardedPattern(
+    const void* buffer,
+    std::size_t bytesPerBlock,
+    uint8_t expectedBaseValue,
+    int* errorCount,
+    int* firstBadSlice,
+    int numBlocks,
+    int blockSize);
+
+/**
  * Test kernel: Blocking pipelined send or recv.
  */
 void testSendRecv(

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -281,9 +281,28 @@ constexpr int kMaxRanksForAllGather = 128;
 // block-owned QP shapes must use lazy peer materialization.
 constexpr int kMaxEagerExchangeQpsPerPeerPerNic = 128;
 
-constexpr int kMaxIbGroups = 64;
+// Group (channel) index space: device-side IB QP selection uses
+// ThreadGroup::block_id and requires block_id < maxGroups. This is an index
+// space only — per-group QP state is materialized lazily per group actually
+// used. Groups beyond kMaxEagerExchangeQpsPerPeerPerNic are NOT eligible for
+// the compact eager QPN-exchange wire format and therefore require lazy peer
+// materialization (ibLazyConnect=true); collectives that stay within that cap
+// pay no extra QP registration cost.
+constexpr int kMaxIbGroups = 256;
 constexpr int kMaxIbQpsPerBlockPerNic = 128;
-constexpr int kMaxIbQpsPerPeerPerNic = kMaxIbGroups * kMaxIbQpsPerBlockPerNic;
+
+// Budget for QPs actually created per (peer, NIC): max_num_channels *
+// direction_count * qpsPerConnection. Must stay independent of kMaxIbGroups:
+// it dimensions the PeerQpPayload::NicQpInfo::qpns wire array below, so
+// deriving it from the group index space would grow every lazy peer exchange
+// whenever that space grows. kMaxIbGroups * kMaxIbQpsPerBlockPerNic is also
+// not a meaningful bound — it multiplies two limits no configuration reaches
+// simultaneously.
+constexpr int kMaxIbQpsPerPeerPerNic = 8192;
+
+static_assert(
+    kMaxIbQpsPerPeerPerNic >= kMaxEagerExchangeQpsPerPeerPerNic,
+    "the eager-exchange QP cap must fit inside the created-QP budget");
 
 /**
  * Transport exchange info for allGather-based exchange.
@@ -344,6 +363,17 @@ struct PeerQpPayload {
   int maxGroups{0};
   int qpsPerBlockPerNic{0};
 };
+
+// This payload is sent and received once per peer on every materializePeer(),
+// and both copies are stack-resident while in flight, so its size is a
+// bootstrap cost every lazy collective pays per peer -- not only the ones that
+// ask for a large group count. It must stay within kMaxNicsPerGpu * 8192 QPNs
+// (~64KB) however large the group index space becomes; widening a QP-shape
+// limit past this has to revisit the wire format rather than silently scale
+// it.
+static_assert(
+    sizeof(PeerQpPayload) <= 72 * 1024,
+    "PeerQpPayload is exchanged and stack-allocated per peer; keep it small");
 
 struct PeerBufferPayload {
   IbgdaBufferExchInfo recvStaging;

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -698,9 +698,34 @@ constexpr int kMaxRanksForAllGather = 128;
 // block-owned QP shapes must use lazy peer materialization.
 constexpr int kMaxEagerExchangeQpsPerPeerPerNic = 128;
 
-constexpr int kMaxIbGroups = 64;
+// Group (channel) index space: device-side IB QP selection uses
+// ThreadGroup::block_id and requires block_id < maxGroups.
+//
+// This is an index space only: raising it creates no QP by itself, and a group
+// index costs nothing until a configuration actually asks for that many
+// channels. What it does NOT mean is that QPs appear per group on first use.
+// Materialization is lazy per PEER, not per group: the first touch of a peer
+// runs materializePeer() -> createPeerQps(), which builds that peer's ENTIRE
+// configured shape up front — `fixedChannelCompanionQpsPerPeerPerNic()` slots,
+// each a QP group plus a loopback companion — even if a single group ever runs
+// on it. So the QP cost of a transport is set by `max_num_channels` (times
+// directions, times qpsPerConnection) and the number of peers touched, and the
+// knob for reducing it is `max_num_channels`, not this limit.
+constexpr int kMaxIbGroups = 256;
 constexpr int kMaxIbQpsPerBlockPerNic = 128;
-constexpr int kMaxIbQpsPerPeerPerNic = kMaxIbGroups * kMaxIbQpsPerBlockPerNic;
+
+// Budget for QPs actually created per (peer, NIC): max_num_channels *
+// direction_count * qpsPerConnection. Must stay independent of kMaxIbGroups:
+// it dimensions the PeerQpPayload::NicQpInfo::qpns wire array below, so
+// deriving it from the group index space would grow every lazy peer exchange
+// whenever that space grows. kMaxIbGroups * kMaxIbQpsPerBlockPerNic is also
+// not a meaningful bound — it multiplies two limits no configuration reaches
+// simultaneously.
+constexpr int kMaxIbQpsPerPeerPerNic = 8192;
+
+static_assert(
+    kMaxIbQpsPerPeerPerNic >= kMaxEagerExchangeQpsPerPeerPerNic,
+    "the eager-exchange QP cap must fit inside the created-QP budget");
 
 /**
  * Transport exchange info for allGather-based exchange.
@@ -778,6 +803,29 @@ struct PeerQpPayload {
   // Defaults to the same 1 the transport resolves when nobody raises the depth.
   int maxRdAtomic{1};
 };
+
+// This payload is sent and received once per peer on every materializePeer(),
+// and both copies are stack-resident while in flight, so its size is a
+// bootstrap cost every lazy collective pays per peer -- not only the ones that
+// ask for a large group count. It must stay within kMaxNicsPerGpu * 8192 QPNs
+// (~64KB) however large the group index space becomes; widening a QP-shape
+// limit past this has to revisit the wire format rather than silently scale
+// it.
+//
+// Derived from the documented shape rather than rounded up to a convenient
+// number: a round bound leaves kilobytes of headroom for a new fixed array to
+// be added without the static_assert ever firing, which is exactly the drift
+// this constant exists to catch. The only slack is the scalar header.
+//
+// Named so the bound has one definition: MultiPeerIbTransportConfigTest checks
+// the same constant rather than restating the number.
+inline constexpr std::size_t kMaxPeerQpPayloadBytes =
+    kMaxNicsPerGpu * sizeof(PeerQpPayload::NicQpInfo) +
+    /*scalar header allowance=*/256;
+
+static_assert(
+    sizeof(PeerQpPayload) <= kMaxPeerQpPayloadBytes,
+    "PeerQpPayload is exchanged and stack-allocated per peer; keep it small");
 
 struct PeerBufferPayload {
   IbgdaBufferExchInfo recvStaging;

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -1457,6 +1457,39 @@ void MultipeerIbrcTransport::connectPeerQps(
 void MultipeerIbrcTransport::exchangeAndConnectQps() {
   const int numPeers = nRanks_ - 1;
   const int numQps = config_.fixedChannelMainQpsPerPeerPerNic();
+  // PRECONDITION OF THIS FUNCTION, not of the transport. Nothing calls
+  // exchangeAndConnectQps() today -- exchange() defers everything to
+  // materializePeer(), and IBGDA never used the eager allGather at all -- so
+  // this is unreachable as written. It is kept rather than deleted because it
+  // is the invariant that makes reviving the eager path safe, and that
+  // invariant stopped holding in this diff: the allGather wire format
+  // dimensions IbTransportExchInfoAll::NicWireInfo::qpnForRank[][] at
+  // kMaxEagerExchangeQpsPerPeerPerNic, and the loop below writes `numQps` slots
+  // into it. That used to be bounded by coincidence -- with kMaxIbGroups at 64,
+  // 64 channels x kIbDirections filled the array exactly -- but the group index
+  // space is now wider than the eager wire format, so a revived eager path
+  // would write off the end of the exchanged struct.
+  //
+  // Deliberately NOT hoisted into config validation: every live path is lazy,
+  // and a shape wider than the eager cap is legal there -- the SendRecvTile
+  // collective this stack adds runs at 512 QPs/(peer, NIC). Rejecting it at
+  // construction would break the supported configuration to guard a dead one.
+  if (numQps > kMaxEagerExchangeQpsPerPeerPerNic) {
+    throw std::invalid_argument(
+        fmt::format(
+            "MultipeerIbrcTransport: eager QP exchange needs {} QPs per "
+            "(peer, NIC) but the allGather wire format holds only {}. Reduce "
+            "max_num_channels to at most {} for eager exchange, or keep using "
+            "the (default) lazy per-peer materialization path, which has no "
+            "such limit",
+            numQps,
+            kMaxEagerExchangeQpsPerPeerPerNic,
+            kMaxEagerExchangeQpsPerPeerPerNic /
+                std::max(
+                    1,
+                    config_.fixedChannelDirectionCount() *
+                        config_.qpsPerConnection)));
+  }
 
   for (int peerIndex = 0; peerIndex < numPeers; ++peerIndex) {
     createPeerQps(peerIndex);


### PR DESCRIPTION
Summary:

Second diff of the D108504937 decomposition. Adds the plain (no-compression) SendRecvTile collective — the two-peer point-to-point specialization of AllToAllvTile — plus the shared header both variants use. No nvcompdx anywhere in this diff's link tree; the ANS-compressed variant is a separate diff on top.

Files:
- `collectives/SendRecvTileCommon.cuh` (new): shared device/host code for both variants (geometry, staging layout, the send/recv driver). All nvcompdx/`AnsCompress`-specific code is guarded behind `#ifdef PIPES_ENABLE_ANS_COMPRESSION`, so the plain translation unit here never sees nvcompdx symbols.
- `collectives/SendRecvTile.cuh` (new): plain collective declarations + the public cross-rank contract.
- `collectives/SendRecvTile.cu` (new): plain `sendrecv_tile_kernel`.
- `collectives/BUCK`: new `:sendrecv_tile` target — a single-TU `comms_gpu_cpp_library` (no `--device-c`, no nvcompdx), depending only on the core CopyOp/transport primitives (`:abort_check`, `:copy_op`, `:copy_utils`, `:device_macros`, `:multi_peer_device_handle`, `:p2p_ib_transport_device`, `:tiled_buffer`), NOT on AllToAllvTile.

Invariants:
- Self-contained: `:sendrecv_tile` builds and links with zero nvcompdx cost. A consumer wanting ANS-compressed IBGDA chunks depends on the sibling `:sendrecv_tile_compressed` (next diff) instead.
- Independent of the prereq CopyOp change: the plain build defines no `PIPES_ENABLE_ANS_COMPRESSION`, so `CopyOp::kMaxUncompBytes` (added in the prereq diff) is referenced only in the compiled-out compressed path here.

## Review follow-ups in this version

- **Bidirectional grid split is now interleaved, not contiguous** (dboyda). `partition(2)` put every sender in the lower grid half, which is a liveness hazard once a tile exceeds `pipelineBytes` and the sender waits on the peer's `SLOT_FREE`: blocks become resident roughly in `blockIdx` order, so an oversubscribed grid can fill every resident CTA slot with senders on BOTH ranks and leave no receiver scheduled to drain them — a hang, not a slow path. `partition_interleaved(2)` makes even blocks send and odd blocks recv, so any contiguous run of resident blocks contains both roles. Both ranks still derive the split from `blockIdx` alone, so the per-direction block counts continue to match peer-to-peer.
- **Public cross-rank contract is now written down** (dboyda). `SendRecvTile.cuh` states that nothing is negotiated at runtime, so a mismatch silently drops data or waits forever, and enumerates what both ends must agree on: byte count (`send_count` == peer's `recv_count`), per-direction active block count, `max_signal_bytes`, `plain_block_fraction`, and the CopyOp the kernel was instantiated with.
- **Buffer aliasing is now rejected in the contract** (dboyda). `send_data` and `recv_data` must be disjoint in a bidirectional launch: the two directions run concurrently and unordered, so an incoming write can clobber bytes the local sender has not staged yet. In-place send/recv is not supported.
- **Dead per-block work removed from the plain TU** (`ai_diff_reviewer`). In the `Memcpy` instantiation both arms of the mixed-mode branch expanded to the same call, so every block still evaluated `sendrecv_use_plain_block` — `isfinite`, `lroundf`, two 64-bit divisions — to choose between identical paths. Now guarded by `if constexpr (!std::is_same_v<CopyOp, Memcpy>)`; compiled out entirely in the plain TU, unchanged in the compressed one.
- **Declaration signatures match** (`ai_diff_reviewer`). The non-`__CUDACC__` declaration of `sendrecv_tile_kernel` now carries the same defaulted `abortDevice` argument as the `__CUDACC__` one.
- **Single-use locals inlined** (`ai_diff_reviewer`): `handle.get_ib(peer).send<Memcpy>(...)` / `.recv<Memcpy>(...)` directly.

Not changed, with reasons: the helpers stay in an unnamed namespace — this header is compiled by two TUs with *different* macros (`PIPES_ENABLE_ANS_COMPRESSION` set in one, not the other), so internal linkage is what keeps it ODR-clean rather than an oversight. And behavioural coverage lives in `D112008483` directly above, not in this diff, so there is no launcher here to test.

Reviewed By: dboyda

Differential Revision: D112007061
