### PR TITLE
Honor NCCL_IB_USE_INLINE for AINIC instead of force-enabling it

### DIFF
--- a/comms/rcclx/develop/projects/rccl/ext-src/rocm_netib.patch
+++ b/comms/rcclx/develop/projects/rccl/ext-src/rocm_netib.patch
@@ -74,7 +74,7 @@ index 9bfd8dcf..4d3f0a08 100644
  
    // Detect IB cards
    int nIbDevs = 0;
-@@ -944,6 +978,23 @@ ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
+@@ -944,6 +978,29 @@ ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
      INFO(NCCL_INIT|NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, ncclIbRelaxedOrderingEnabled ? "[RO]" : "",
            ncclIbIfName, ncclSocketToString(&ncclIbIfAddr, addrline));
  
@@ -86,14 +86,20 @@ index 9bfd8dcf..4d3f0a08 100644
 +      // for AINIC, these params are defaulted to enabled unless user forces it to disable(0).
 +      rcclCtsInlineData = ((rcclParamCtsInlineData() == 0) ? false : true);
 +      rcclCtsOffloadEnabled = ((rcclParamCtsOffloadEnabled() == 0) ? false : true);
-+      // for AINIC IbUseInline is enabled by default always
-+      ncclIbUseInline = true;
++      // Honor NCCL_IB_USE_INLINE for AINIC (already read into ncclIbUseInline above).
++      // The CTS Offload and CTS Inline Data paths both rely on inline sends, so
++      // auto-enable inline whenever either is on (this restores 2.27's offload->inline
++      // coupling, extended to the 2.28 CTS-inline-data feature). Otherwise leave the
++      // decision to NCCL_IB_USE_INLINE (default off) so it can be A/B tested.
++      if ((rcclCtsOffloadEnabled || rcclCtsInlineData) && !ncclIbUseInline) {
++        ncclIbUseInline = true;
++      }
 +      // for AINIC GDR flush is disabled by default
 +      // ncclIbGdrFlushDisable = 1;
 +
 +      INFO(NCCL_INIT|NCCL_NET, "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
-+           "IB Use Inline: enabled; GDR Flush: disabled", rcclCtsInlineData ? "Enabled": "Disabled",
-+           rcclCtsOffloadEnabled ? "Enabled": "Disabled");
++           "IB Use Inline: %s; GDR Flush: disabled", rcclCtsInlineData ? "Enabled": "Disabled",
++           rcclCtsOffloadEnabled ? "Enabled": "Disabled", ncclIbUseInline ? "Enabled": "Disabled");
 +    }
    }
  exit:

--- a/comms/rcclx/develop/projects/rccl/src/transport/net_ib_rocm.cc
+++ b/comms/rcclx/develop/projects/rccl/src/transport/net_ib_rocm.cc
@@ -986,14 +986,20 @@ ncclResult_t rocmIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
       // for AINIC, these params are defaulted to enabled unless user forces it to disable(0).
       rcclCtsInlineData = ((rcclParamCtsInlineData() == 0) ? false : true);
       rcclCtsOffloadEnabled = ((rcclParamCtsOffloadEnabled() == 0) ? false : true);
-      // for AINIC IbUseInline is enabled by default always
-      ncclIbUseInline = true;
+      // Honor NCCL_IB_USE_INLINE for AINIC (already read into ncclIbUseInline above).
+      // The CTS Offload and CTS Inline Data paths both rely on inline sends, so
+      // auto-enable inline whenever either is on (this restores 2.27's offload->inline
+      // coupling, extended to the 2.28 CTS-inline-data feature). Otherwise leave the
+      // decision to NCCL_IB_USE_INLINE (default off) so it can be A/B tested.
+      if ((rcclCtsOffloadEnabled || rcclCtsInlineData) && !ncclIbUseInline) {
+        ncclIbUseInline = true;
+      }
       // for AINIC GDR flush is disabled by default
       // ncclIbGdrFlushDisable = 1;
 
       INFO(NCCL_INIT|NCCL_NET, "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
-           "IB Use Inline: enabled; GDR Flush: disabled", rcclCtsInlineData ? "Enabled": "Disabled",
-           rcclCtsOffloadEnabled ? "Enabled": "Disabled");
+           "IB Use Inline: %s; GDR Flush: disabled", rcclCtsInlineData ? "Enabled": "Disabled",
+           rcclCtsOffloadEnabled ? "Enabled": "Disabled", ncclIbUseInline ? "Enabled": "Disabled");
     }
   }
 exit:


### PR DESCRIPTION
Summary:
On the AINIC RoCEv2 path, rcclx 2.28 unconditionally forces
`ncclIbUseInline = true` (net_ib_rocm.cc), overriding the
`NCCL_IB_USE_INLINE` env (RCCL_PARAM RocmIbUseInline, default 0). This is
the one behavioral difference in the P2P/IB hot path vs the ainic 2.27.7
branch, which leaves inline off unless CTS-offload requires it. With
inline forced on, every network send applies IBV_SEND_INLINE to the
per-op CTS/rendezvous FIFO handshake (remFifo.flags, QP max_inline_data),
which adds a small per-op latency on the latency-bound rendezvous path.

Trace analysis of the tier2 (v5f_tpp_800 TIER2_2p3B, 736 ranks / 92
nodes) training shows the MoE Expert-Parallel all_to_allv (grouped
ncclSend/ncclRecv over INTER_NODE_EP) is ~+8 us/op (p50 49->57 us,
+16%) slower on rcclx vs ainic; the same collective is only ~+4 us/op on
tier1 (176 ranks / 22 nodes). Because all_to_allv is many small P2P ops,
this per-op delta accumulates and scales with the inter-node peer count,
so it surfaces in the comm-bound tier2 (~45% compute/comms overlap)
while tier1's ~61% overlap hides it. All other P2P-path code (host
scheduling, channel assignment/count, device sendrecv kernel, the
P2P-batching gate which is inert with RCCL_P2P_BATCH_ENABLE=0) is
functionally identical between 2.27 and 2.28, leaving the forced inline
as the only active delta.

This change makes AINIC honor NCCL_IB_USE_INLINE (default off) so the
setting can be A/B tested and controlled per job, while preserving the
inline->CTS coupling: inline is still auto-enabled whenever CTS Offload
or CTS Inline Data is on (both require inline sends). This restores the
2.27 behavior (offload-gated) and extends the coupling to the 2.28
CTS-inline-data feature. The startup INFO line now reports the actual
IB-Use-Inline state instead of a hardcoded "enabled".

Note: ncclIbUseInline gates the CTS/rendezvous handshake for ALL
inter-node network communication, so this changes the AINIC default from
inline-on to inline-off for every collective's network path (allreduce /
reduce_scatter / all_gather / all_to_allv), not just all_to_allv. The
proven-good ainic 2.27 baseline already runs inline-off, and an earlier
inline on/off A/B showed no change to overall wps, so this is expected to
be net-neutral-to-positive; validate across collectives before shipping.

Reviewed By: JinghanHuang

Differential Revision: D114909189


