### PR TITLE
Add AbortDevice timeout transition APIs (#3459)

### DIFF
--- a/comms/common/fault_tolerance/AbortDevice.cuh
+++ b/comms/common/fault_tolerance/AbortDevice.cuh
@@ -120,12 +120,20 @@ deviceCompareExchangeSystem(int* value, int* expected, int desired) {
  */
 struct AbortDevice final {
   /**
+   * Creates a disabled no-op device handle.
+   *
+   * This makes `AbortDevice` usable in aggregate kernel arguments and as a
+   * temporary compatibility replacement for disabled Prims timeouts.
+   */
+  __host__ __device__ AbortDevice() = default;
+
+  /**
    * Returns whether this handle references enabled shared abort state.
    *
    * Disabled handles are valid kernel arguments. They have a null state pointer
    * and all mutating/query APIs behave like the host disabled `Abort` object.
    */
-  __device__ bool isEnabled() const {
+  __host__ __device__ bool isEnabled() const {
     return state_ != nullptr;
   }
 
@@ -157,6 +165,17 @@ struct AbortDevice final {
   }
 
   /**
+   * Transition alias for Prims `Timeout::start()`.
+   *
+   * New device code should prefer `startTimeout()`. This exists so timeout
+   * shaped Prims waits can migrate to `AbortDevice` without introducing a
+   * separate adapter type.
+   */
+  __device__ void start() {
+    startTimeout();
+  }
+
+  /**
    * Cancels this handle's active device-side timeout.
    *
    * The deadline is local to this copied handle. Canceling it does not clear a
@@ -175,15 +194,35 @@ struct AbortDevice final {
    * first-writer-wins.
    */
   __device__ bool isAborted() const {
+    return checkExpired();
+  }
+
+  /**
+   * Transition alias for Prims `Timeout::checkExpired()`.
+   *
+   * Returns true for either an explicit abort or an expired local device
+   * timeout. If this handle's local deadline has expired, this records
+   * `AbortReason::TIMED_OUT` in the shared state.
+   */
+  __device__ bool checkExpired() const {
     if (!isEnabled()) {
       return false;
     }
-    const auto observedReason = reason();
-    if (observedReason != AbortReason::NONE) {
+    if (reason() != AbortReason::NONE) {
       return true;
     }
-    (void)markTimedOutIfExpired();
-    return reason() != AbortReason::NONE;
+    return markTimedOutIfExpired() || reason() != AbortReason::NONE;
+  }
+
+  /**
+   * Group-scoped transition alias for Prims `Timeout::checkExpired(group)`.
+   *
+   * Only the group leader polls shared abort state, matching the current
+   * timeout check shape used by Prims wait loops.
+   */
+  template <typename ThreadGroup>
+  __device__ bool checkExpired(const ThreadGroup& group) const {
+    return group.is_leader() && checkExpired();
   }
 
   /**

--- a/comms/common/fault_tolerance/FAULT_TOLERANCE.md
+++ b/comms/common/fault_tolerance/FAULT_TOLERANCE.md
@@ -1,0 +1,140 @@
+# Fault Tolerance Abort Contract
+
+This document describes the shared abort contract used by MCCL, CTRAN, and
+Prims device code.
+
+## Host `Abort`
+
+`Abort` is a communicator-scoped controller. MCCL creates the host object and
+passes the same `std::shared_ptr<Abort>` to CTRAN, so host-side MCCL and CTRAN
+observe and update the same state.
+
+An enabled `Abort` owns one `AbortState`. CUDA-capable builds allocate that
+state as mapped pinned host memory so CPU and CUDA device code can access the
+same abort reason. Disabled abort objects do not allocate state and all query
+and mutation APIs behave as no-ops or non-aborted results.
+
+The abort reason is first-writer-wins:
+
+- `AbortReason::ABORTED` records an explicit user or transport abort.
+- `AbortReason::TIMED_OUT` records an expired timeout.
+- `AbortReason::NONE` means no terminal reason has been recorded.
+
+Host and device writers only transition from `NONE` to one terminal reason.
+Later writers cannot overwrite the recorded reason.
+
+## Device `AbortDevice`
+
+`AbortDevice` is a small, non-owning CUDA device view of the host-owned
+`AbortState`. It is safe to pass by value to kernels and device helper methods.
+It must not outlive the owning host `Abort` object.
+
+Create device handles through `Abort::getDeviceHandle()`. The returned handle
+captures the mapped device pointer and device clock conversion for the current
+CUDA device. Kernels that consume the handle must run on that same device, or
+the caller must create a new handle after switching devices.
+
+Disabled handles are valid kernel arguments. They have a null state pointer and
+all APIs behave as no-op or non-aborted.
+
+## Device Timeout Semantics
+
+`AbortDevice::startTimeout()` starts a timeout on the copied device handle. The
+deadline is local to that copy; it is not stored in shared `AbortState`.
+
+For Prims collectives and transports, timeout-bearing abort handles should be
+treated as per-operation and per-block state:
+
+1. The kernel receives an unstarted `AbortDevice`.
+2. Each block copies the handle locally.
+3. The block starts the local deadline once near kernel entry.
+4. Wait loops pass the local handle into transport or synchronization waits.
+
+If any block's local deadline expires, `AbortDevice::isAborted()` records
+`AbortReason::TIMED_OUT` in shared state. Other blocks and host code then see
+the same terminal abort reason on their next poll.
+
+Do not store started timeout state in persistent transport objects. Transport
+device handles may live across calls and may be reused by many blocks. Storing a
+started deadline there would make timeout state shared across unrelated blocks,
+kernels, or operations.
+
+## MPT And Prims Integration
+
+`MultiPeerTransport` is the device-handle propagation point for Prims
+collectives. It is created for the communicator, receives the same host `Abort`
+shared by MCCL and CTRAN, and includes a device abort handle in each
+`MultiPeerDeviceHandle` it returns.
+
+`MultiPeerDeviceHandle` exposes the abort handle as data. It should not wrap
+additional convenience methods such as `isAborted()`. Kernel code should copy
+the exposed `AbortDevice`, start a per-block timeout when needed, and pass that
+local copy to waits.
+
+Transport handles must not embed started abort timeout state. NVL, IBGDA, and
+IBRC waits consume the operation-local `AbortDevice` passed by the collective or
+kernel.
+
+## MCCL Collective Integration
+
+MCCL and CTRAN already share the same host `Abort`. MCCL collective code should
+not add a second host abort pointer to `CommContext`.
+
+For Prims-backed collectives:
+
+1. Host orchestration gets a `MultiPeerDeviceHandle` from MPT.
+2. Kernel arguments carry either the full handle or the exposed
+   `AbortDevice`.
+3. Kernel entry creates a local per-block copy and calls `startTimeout()`.
+4. Transport and synchronization waits poll that local abort handle.
+
+The long-term target is to remove the separate Prims `Timeout` type and use
+`AbortDevice` for both explicit abort and abort-based timeout checks.
+
+## Usage Examples
+
+Host explicit abort:
+
+```cpp
+auto abort = comm->getAbort();
+abort->setAbort(comms::fault_tolerance::AbortReason::ABORTED);
+```
+
+Host default timeout:
+
+```cpp
+auto abort = comm->getAbort();
+abort->setDefaultTimeout(std::chrono::milliseconds{5000});
+```
+
+Kernel wait:
+
+```cpp
+__global__ void kernel(KernArgs args) {
+  auto abort = args.handle.abort;
+  abort.startTimeout();
+
+  while (!ready()) {
+    if (abort.isAborted()) {
+      printf("CUDA ABORT ERROR: wait aborted\n");
+      __trap();
+    }
+  }
+}
+```
+Device explicit abort:
+
+```cpp
+abort.setAbort(comms::fault_tolerance::AbortReason::ABORTED);
+```
+
+Device timeout:
+
+```cpp
+abort.startTimeout();
+while (!ready()) {
+  if (abort.isAborted()) {
+    __trap();
+  }
+}
+```

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
@@ -65,6 +65,16 @@ __global__ void deviceReadAbortPredicateKernel(
   }
 }
 
+__global__ void deviceReadCheckExpiredKernel(
+    AbortDevice abort,
+    int* observedCheckExpired,
+    int* observedReason) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    *observedCheckExpired = abort.checkExpired() ? 1 : 0;
+    *observedReason = static_cast<int>(abort.reason());
+  }
+}
+
 __global__ void deviceWaitForTimeoutKernel(
     AbortDevice abort,
     int* observedMode,
@@ -86,6 +96,29 @@ __global__ void deviceWaitForTimeoutKernel(
 
   *observedMode = static_cast<int>(AbortReason::NONE);
   *observedIsAborted = 0;
+}
+
+__global__ void deviceWaitForTimeoutStartAliasKernel(
+    AbortDevice abort,
+    int* observedMode,
+    int* observedCheckExpired,
+    int maxIterations) {
+  if (blockIdx.x != 0 || threadIdx.x != 0) {
+    return;
+  }
+
+  abort.start();
+  for (int i = 0; i < maxIterations; ++i) {
+    if (abort.checkExpired()) {
+      *observedMode = static_cast<int>(abort.reason());
+      *observedCheckExpired = 1;
+      return;
+    }
+    __nanosleep(64);
+  }
+
+  *observedMode = static_cast<int>(AbortReason::NONE);
+  *observedCheckExpired = 0;
 }
 
 __global__ void deviceCancelAndRestartTimeoutKernel(
@@ -170,6 +203,16 @@ cudaError_t launchDeviceReadAbortPredicate(
   return cudaGetLastError();
 }
 
+cudaError_t launchDeviceReadCheckExpired(
+    AbortDevice abort,
+    int* observedCheckExpired,
+    int* observedReason,
+    cudaStream_t stream) {
+  deviceReadCheckExpiredKernel<<<1, 1, 0, stream>>>(
+      abort, observedCheckExpired, observedReason);
+  return cudaGetLastError();
+}
+
 cudaError_t launchDeviceWaitForTimeout(
     AbortDevice abort,
     int* observedMode,
@@ -178,6 +221,17 @@ cudaError_t launchDeviceWaitForTimeout(
     cudaStream_t stream) {
   deviceWaitForTimeoutKernel<<<1, 1, 0, stream>>>(
       abort, observedMode, observedIsAborted, maxIterations);
+  return cudaGetLastError();
+}
+
+cudaError_t launchDeviceWaitForTimeoutStartAlias(
+    AbortDevice abort,
+    int* observedMode,
+    int* observedCheckExpired,
+    int maxIterations,
+    cudaStream_t stream) {
+  deviceWaitForTimeoutStartAliasKernel<<<1, 1, 0, stream>>>(
+      abort, observedMode, observedCheckExpired, maxIterations);
   return cudaGetLastError();
 }
 

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
@@ -39,10 +39,23 @@ cudaError_t launchDeviceReadAbortPredicate(
     int* observedReason,
     cudaStream_t stream);
 
+cudaError_t launchDeviceReadCheckExpired(
+    AbortDevice abort,
+    int* observedCheckExpired,
+    int* observedReason,
+    cudaStream_t stream);
+
 cudaError_t launchDeviceWaitForTimeout(
     AbortDevice abort,
     int* observedMode,
     int* observedIsAborted,
+    int maxIterations,
+    cudaStream_t stream);
+
+cudaError_t launchDeviceWaitForTimeoutStartAlias(
+    AbortDevice abort,
+    int* observedMode,
+    int* observedCheckExpired,
     int maxIterations,
     cudaStream_t stream);
 

--- a/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
@@ -94,6 +94,29 @@ TEST(AbortDeviceTest, hostProducerDeviceConsumer) {
       readDeviceValue(observedMode), static_cast<int>(AbortReason::ABORTED));
 }
 
+TEST(AbortDeviceTest, checkExpiredSeesHostAbort) {
+  Abort abort{/*enabled=*/true};
+  auto observedCheckExpired = makeDeviceValue<int>();
+  auto observedReason = makeDeviceValue<int>();
+  ASSERT_NE(observedCheckExpired, nullptr);
+  ASSERT_NE(observedReason, nullptr);
+
+  abort.setAbort();
+
+  EXPECT_EQ(
+      launchDeviceReadCheckExpired(
+          abort.getDeviceHandle(),
+          observedCheckExpired.get(),
+          observedReason.get(),
+          /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(observedCheckExpired), 1);
+  EXPECT_EQ(
+      readDeviceValue(observedReason), static_cast<int>(AbortReason::ABORTED));
+}
+
 TEST(AbortDeviceTest, deviceProducerHostConsumer) {
   Abort abort{/*enabled=*/true};
 
@@ -303,6 +326,31 @@ TEST(AbortDeviceTest, deviceTimeoutWinsOverHostAbort) {
   EXPECT_TRUE(abort.isTimedOut());
 }
 
+TEST(AbortDeviceTest, startAliasAndCheckExpiredRecordTimeout) {
+  Abort abort{/*enabled=*/true};
+  auto observedMode = makeDeviceValue<int>();
+  auto observedCheckExpired = makeDeviceValue<int>();
+  ASSERT_NE(observedMode, nullptr);
+  ASSERT_NE(observedCheckExpired, nullptr);
+
+  abort.setDefaultTimeout(std::chrono::milliseconds{1});
+
+  EXPECT_EQ(
+      launchDeviceWaitForTimeoutStartAlias(
+          abort.getDeviceHandle(),
+          observedMode.get(),
+          observedCheckExpired.get(),
+          kDeviceTimeoutPollIterations,
+          /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(observedCheckExpired), 1);
+  EXPECT_EQ(
+      readDeviceValue(observedMode), static_cast<int>(AbortReason::TIMED_OUT));
+  EXPECT_TRUE(abort.isTimedOut());
+}
+
 TEST(AbortDeviceTest, deviceTimeoutCanBeCancelledAndRestarted) {
   Abort abort{/*enabled=*/true};
   auto observedAfterCancel = makeDeviceValue<int>();
@@ -400,6 +448,24 @@ TEST(AbortDeviceTest, disabledAbortDeviceHandleIsNoop) {
   EXPECT_EQ(readDeviceValue(observed), 0);
   EXPECT_EQ(readDeviceValue(observedMode), static_cast<int>(AbortReason::NONE));
   EXPECT_EQ(readDeviceValue(observedTimeoutMs), -1);
+}
+
+TEST(AbortDeviceTest, defaultConstructedHandleIsDisabledNoop) {
+  AbortDevice handle;
+  auto observed = makeDeviceValue<int>();
+  auto observedMode = makeDeviceValue<int>();
+  ASSERT_NE(observed, nullptr);
+  ASSERT_NE(observedMode, nullptr);
+
+  EXPECT_FALSE(handle.isEnabled());
+  EXPECT_EQ(
+      launchDeviceReadAbort(
+          handle, observed.get(), observedMode.get(), /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(observed), 0);
+  EXPECT_EQ(readDeviceValue(observedMode), static_cast<int>(AbortReason::NONE));
 }
 
 } // namespace comms::fault_tolerance::testing


### PR DESCRIPTION
Summary:

Add disabled default construction and timeout-shaped transition APIs to `AbortDevice` so Prims callsites can migrate from `Timeout` without introducing an adapter type. Cover `start()` and `checkExpired()` aliases in the device tests.

___

Differential Revision: D114901578


