### PR TITLE
comms/dsl: DSL-agnostic tuning spine + a2a adapter base (P0 geometry guard) (#3462)

### DIFF
--- a/comms/dsl/README.md
+++ b/comms/dsl/README.md
@@ -1,10 +1,10 @@
 # comms/dsl: customized collectives without the plumbing - a hook in, an autotuned kernel out
 
-`comms/dsl` framework lets a kernel developer (user) build a customized, autotunable collective in DSLs (Triton or CuTe) by writing only the small part that differentiates their kernel: per-tile hooks and optionally transports, while the framework owns the generic ~95% (schedule, multi-peer addressing, signal/wait protocol) and automates the performance tuning.
+`comms/dsl` framework lets a kernel developer (user) build a customized, autotunable collective in a DSL (CuTe today; the façade is backend-parametrized so Triton can be re-added) by writing only the small part that differentiates their kernel: per-tile hooks and optionally transports, while the framework owns the generic ~95% (schedule, multi-peer addressing, signal/wait protocol) and automates the performance tuning.
 
 ## Why
 
-Researchers prototype new ideas as kernels in DSLs like Triton/CuTe instead of CUDA/C++ for the fast iteration loop. Scaling the idea needs communication, and that usually leads to repetitive work: days-to-weeks of race-prone stage/signal/wait/fence logic, re-derived per kernel, with bugs that could pass tests and fail at scale. Notably, the part that differentiates the kernel is typically small: a transpose, a quantize, or an accumulate, while a lot around it is plumbing.
+Researchers prototype new ideas as kernels in DSLs like CuTe/Triton instead of CUDA/C++ for the fast iteration loop. Scaling the idea needs communication, and that usually leads to repetitive work: days-to-weeks of race-prone stage/signal/wait/fence logic, re-derived per kernel, with bugs that could pass tests and fail at scale. Notably, the part that differentiates the kernel is typically small: a transpose, a quantize, or an accumulate, while a lot around it is plumbing.
 
 For instance, the `all_to_all_single_non_contig` kernel is ~800 lines, of which roughly 95% is generic machinery, including the signaling protocol, the pipeline, symmetric-memory staging, multi-peer addressing, and tile-size math. The remaining ~5% is layout transform, which is what really makes this kernel unique.
 
@@ -17,9 +17,9 @@ comms/dsl breaks both loops. It provides the customizable boilerplate, and it tu
 | Piece | What it is |
 |---|---|
 | **Transport** | A fabric binding (NVLink today, IB later): cross-GPU memory + signaling state, created once via a `rendezvous` over PyTorch symmetric memory. The framework ships defaults and the user either sets one up or could provide their own. |
-| **Endpoint (`PeerEndpoint`)** | How the transport hands a schedule per-peer addresses - `send_dst` (where to write into a peer), `recv_src` (where to read its data), and the signal slots - so no schedule touches raw pointers. Two forms: a host-resolved `PeerEndpoint` for a single peer (used by `send_tile`/`recv_tile`), and a device-side table of all peers that a fused collective indexes by peer in-kernel (e.g. `all_to_all`). |
+| **Endpoint (`PeerEndpoint`)** | How the transport hands a schedule per-peer addresses - `send_dst` (where to write into a peer), `recv_src` (where to read its data), and the signal slots - so no schedule touches raw pointers. Two forms: a host-resolved `PeerEndpoint` for a single peer (used by `send_tiles`/`recv_tiles`), and a device-side table of all peers that a fused collective indexes by peer in-kernel (e.g. `all_to_all`). |
 | **Ops** | The transport's four device functions that act on those addresses: `put` (remote write), `get` (local read), `signal`/`wait` (the data-ready handshake). The only fabric-specific (NVLink vs IB) device code; hooks and schedules call them and stay transport-agnostic. |
-| **Hook + `Ctx`** | The 5% the user writes: `produce(ctx) -> tile` and `consume(ctx, tile)`. `Ctx` is the per-tile view the framework hands the hook - input/output pointer, flat index, mask, and within-chunk position. This is where a transpose / gather / quantize / accumulate goes. |
+| **Hook + `Ctx`** | The 5% the user writes, in **two tiers**. *Per-element / value* — `produce(ctx) -> tile` / `consume(ctx, tile)`: a per-thread transform on the tile *value* (scale / quantize / accumulate), over the per-tile `Ctx` (CuTe exposes `part`/`atom` + read-only facts `coord`/`peer`). *Block-tile / layout* — `layout_hook(bctx)`: a CTA-cooperative transform over a SMEM-staged 2D tile (`BlockCtx` exposes the loaded tile `sA` + tile coords), for coalescing-critical layout changes (transpose / permute / reshape) where a per-element gather would go uncoalesced. The framework owns the coalesced SMEM load + barriers; the hook does the in-SMEM transform. The portable contract is the hook *role*; the field set is per-DSL, so a hook body is written against its backend's `Ctx`. |
 | **Collective** | The shipped schedule (e.g. `all_to_all`) that runs the hook over the fused `peer x block` transfer, owning all addressing and signal/wait. |
 | **`Config` + `Key`** | `Config` = the launch tunables the autotuner sweeps; `Key` = how a tuned config is looked up at runtime. Both are defined by the user (see principles). |
 | **Adapter** | A thin class that plugs a collective into the comms-owned tuner engine (`comm_tuning`). |
@@ -28,10 +28,10 @@ Flow: a `Transport` gives the kernel per-peer addresses; the `Collective` loops 
 
 ## Design principles
 
-- Own the 95%, expose the 5%. The framework owns the schedule and the race-prone protocol; the user writes a per-tile `produce`/`consume` hook (transpose, gather, quantize, accumulate) and supplies a transport. No fences, no wait loops, no deadlock reasoning in user code.
+- Own the 95%, expose the 5%. The framework owns the schedule and the race-prone protocol; the user writes a hook — a per-element `produce`/`consume` value transform (quantize, scale, accumulate) or a block-tile `layout_hook` (transpose, permute, reshape) — and supplies a transport. No fences, no wait loops, no deadlock reasoning in user code.
 - Performance is autotuned, and the tuner is generic. The user declares two things: a `Key` (which input properties should map to one tuned config - size, dtype, world size, layout, whatever matters for that kernel) and a `Config` (the launch knobs to sweep). A shared engine sweeps configs offline and emits a `{Key: Config}` map; at runtime the collective rebuilds the same key and looks it up (safe default if absent). Changing shapes means re-running the tuner, not rewriting the kernel.
-- Spectrum of control. Plug-and-play collective (write a hook) -> `send_tile`/`recv_tile` (keep your own schedule) -> raw `put`/`get`/`signal`/`wait` ops (full control). Climb only as high as you need.
-- Contracts shared, code per-DSL. Triton and CuTe share the same op names, hook roles, and Config/Key shapes; the device kernels are written per DSL (flat pointers vs partitions), since device code is not portable across DSLs.
+- Spectrum of control. Plug-and-play collective (write a hook) -> `send_tiles`/`recv_tiles` (keep your own schedule) -> raw `put`/`get`/`signal`/`wait` ops (full control). Climb only as high as you need.
+- Backend-parametrized, code per-DSL. The transport contract, hook roles, lookup `Key` shape, and the `comms.dsl.collectives` façade are DSL-agnostic; the `Config` launch knobs and the device kernels are per-DSL (partitions, DSL-specific tunables), since device code is not portable across DSLs. CuTe is the shipped backend; the façade keeps a `backend=` seam so a second DSL (Triton) re-registers without touching callers.
 
 ## Example: a custom collective (a2a non-contig), end to end
 
@@ -43,60 +43,63 @@ A transport, one hook, one call:
 
 ```python
 from comms.dsl import nvl_rendezvous
-from comms.dsl.triton import all_to_all
-from comms.dsl.triton.hooks import transpose_produce   # the 5%: the layout transform
+from comms.dsl.cute import all_to_all
 
 t = nvl_rendezvous(group, dev, per_peer_bytes=chunk_bytes)   # transport (staging + signaling)
-all_to_all(t, out, inp, produce=transpose_produce, rows=R)   # config=None -> tuned lookup
+all_to_all(t, out, inp, rows=R)                              # config=None -> tuned lookup
 ```
 
-`nvl_rendezvous` allocates the per-peer staging buffer + signal pad once; `rows` describes the 2D tile layout the hook reads; with no `produce` hook this is a plain all-to-all.
+`nvl_rendezvous` allocates the per-peer staging buffer + signal pad once; `rows` describes the 2D tile layout the hook reads; with the default identity copy hook this is a plain all-to-all.
 
-The hook is the 5%. `ctx` is the per-tile view (input pointer, flat index, mask, within-chunk position `pos` with `rows`/`cols`); it returns the tile to send - here, the transposed source position, fused into the transfer leg with no extra HBM pass:
+The hook is the 5%, in two tiers. A **per-element** `produce`/`consume` transforms the tile *value* (scale / quantize / accumulate). The `rows > 0` transpose is the flagship **block-tile** hook (`transpose_tile`): the framework coalesced-loads each `[tile, tile]` chunk into padded SMEM and barriers (via the shared substrate leaf `_block_tile_u`, the block-tile twin of the value leaf `_send_u`), and the hook coalesced-stores it transposed — both gmem legs stay coalesced, unlike a per-element gather (the CuTe twin of genai's on-chip `tl.trans`). The transpose SMEM tile is `32x32`, so `rows > 0` has a `2KB` floor (a sub-tile transpose is degenerate); plain (`rows=0`) a2a still goes down to `32B`.
 
-```python
-@triton.jit
-def transpose_produce(ctx):
-    r = ctx.pos % ctx.rows           # position in the transposed [cols, rows] layout
-    c = ctx.pos // ctx.rows
-    src = r * ctx.cols + c           # source position in the [rows, cols] layout
-    base = ctx.idx - ctx.pos         # chunk base in the input
-    return tl.load(ctx.ptr + base + src, mask=ctx.mask)
-```
+The framework runs the fused `peer x block` schedule (multi-peer addressing, signal/wait) in one launch, validated bit-exact against `dist.all_to_all_single`.
 
-The framework runs the fused `peer x block` schedule (multi-peer addressing, signal/wait) in one launch, validated bit-exact against `dist.all_to_all_single` on 4 ranks.
+> **Backend note (honest scope).** The per-element `produce`/`consume` value hooks (scale / quantize / accumulate) run on the CuTe copy-staging schedule, and are **proven reusable across collectives** — the same value leaf (`_send_u`/`_send_slot`) is composed by both `all_to_all` and the standalone `send_tiles`/`recv_tiles`. The block-tile `rows > 0` transpose (the non-contiguous headline) ships on the **zero-copy transfer** (`all_to_all(rows=R)` auto-selects an orchestrated mid-band / fused large-band kernel, both composing the shared `_block_tile_u` leaf), on-par-or-exceeding genai across `0.5MB–128MB` on 8×GB300 (bit-exact, SM-matched). The block-tile tier ships today as the `BlockCtx` contract + `_block_tile_u` leaf + this **a2a reference**; reuse across other collectives is a documented backlog item (unlike the value tier). A fused copy-staged block-tile variant was evaluated and removed as send-leg-bound at the mid band (archived; see the CuTe backend notes). The TMA bulk-copy and raw zero-copy (`direct`/`ce`) paths move raw bytes and apply no hook.
 
 ### 2. Autotune it
 
-Write one thin adapter - the engine is generic, so you only declare your `Key` and the `Config`s to sweep:
+No adapter to write - declare the hook on a collective *object* and call `.autotune()`. The object is both the callable collective and the thing that tunes itself, because it already knows its hook, `variant`, candidate search, and correctness reference:
 
 ```python
-class A2ATuningAdapter(CommKernelTuningAdapter):
-    def enumerate_input_specs(self, world_size): ...      # the shapes to tune
-    def make_key(self, spec, world_size): ...             # YOUR key (must match runtime)
-    def enumerate_candidate_configs(self, spec, key): ... # YOUR configs to sweep
-    def make_inputs(self, spec, *, rank, world_size, device): ...   # tensors + nvl_rendezvous
-    def run_candidate(self, inputs, config, group):       # the collective with the tuned config
-        all_to_all(inputs.transport, inputs.output, inputs.input, rows=inputs.rows, config=config)
-        return inputs.output
-    def run_baseline(self, inputs, baseline, group): ...  # e.g. NCCL, the speed baseline
-    def check_correctness(self, candidate, reference): ...
+from comms.dsl.collectives import A2A
+
+# The non-contig transpose: rows>0 selects the block-tile transpose hook, and its own tuned
+# table falls out of the `rows` field in the lookup key (no produce= -- the transpose is a
+# block-tile LAYOUT hook, not a per-element value hook).
+a2a = A2A(
+    backend="cute",
+    reference=transpose_ref,           # (inputs, group)->Tensor; default = nccl identity
+    # candidates=<dict | callable>     # optional; default = shipped expert size-banded grid
+)
+
+a2a(t, out, inp, rows=R)               # callable: config=None -> per-shape tuned lookup
+a2a.autotune(shapes=PROD_SHAPES)       # sweep -> select -> generate (one tuning job)
+
+# A per-element VALUE hook (quantize / scale / accumulate) instead plugs in as produce=/consume=
+# and MUST carry an explicit `variant` so its tuned configs don't collide with the default copy:
+#   A2A(backend="cute", produce=quantize_produce, consume=dequant_consume, variant="fp8")
 ```
 
-Parent mode sweeps every candidate, benchmarks it against your baseline, and checks correctness; select mode picks the winner per key and writes a generated table:
+`.autotune()` drives the comms-owned `comm_tuning` engine and writes the generated table; `__call__` rebuilds the **same** key (including `rows` and `variant`, so the transpose / a custom value hook never reuses the default copy hook's config) and looks it up. The candidate search is pluggable: omit it for the expert default grid, pass a flat `{CuteA2AConfig_field: [values]}` dict (cartesian), or a `(spec, key) -> [CuteA2AConfig]` callable.
 
 ```python
-# comms/dsl/triton/generated/a2a_tuned_configs.py  (generated; do not hand-edit)
-from comms.dsl.triton.collectives_tuning import A2AConfig, A2AKey
+# comms/dsl/cute/a2a/generated/a2a_tuned_configs.py  (generated; do not hand-edit)
+from comms.dsl.cute.a2a.tuning import CuteA2AConfig, CuteA2AKey
 
 TUNED_A2A_CONFIGS = {
-    A2AKey(world_size=8, dtype="bfloat16", numel=8192, rows=0, transport_kind="NvlTransport"):
-        A2AConfig(num_blocks=16, block=2048, num_warps=8),
-    # ... one row per tuned key ...
+    CuteA2AKey(world_size=8, dtype="bfloat16", numel=8192, rows=0,
+               transport_kind="NvlTransport", device="GB300", backend="cute", variant=""):
+        CuteA2AConfig(num_blocks=8, num_threads=512, primitive="copy"),
+    # ... one row per tuned key (per shape x hardware x hook) ...
 }
 ```
 
-Then nothing else changes: the Step 1 call `all_to_all(..., config=None)` rebuilds the key and looks it up, so it now runs the tuned config automatically. When shapes change, re-run the tuner and regenerate the table - no kernel edits.
+Re-tune = re-run `.autotune()`, regenerate the table - no kernel edits.
+
+**Where it runs.** Perf tuning runs on **MAST/conda**, not a local buck par: the DSL JIT-compiles in a conda env, and production shapes (GB300, multi-node, TP=8) only exist on cluster GPUs. So `.autotune()` is the *body of the tuning-job entrypoint*; you launch it with the MAST launcher (`buck2 run //comms/dsl/tests:mast_launch -- --tune ...` -- buck only builds/launches the launcher; MAST runs the sweep). The framework stays buck-importable for single-host correctness tests / CI.
+
+**Reuse contract (M1).** Each `(shape)` should get its own transport; reusing one transport across configs of differing *geometry* (`num_blocks`/`primitive`) is unsafe without a drain, which is not implemented here yet. A runtime guard raises on a geometry switch on a reused transport (no runtime drain, so reinterpreting in-flight bytes would corrupt staging); `COMMS_DSL_ALLOW_GEOMETRY_SWITCH=1` downgrades it to a silent advance for callers whose successive launches are device-sync-separated (a benchmark / tuner sweeping configs at one size). A fully user-declared `Key` (arbitrary fields) and a numel shape-bucket are planned extensions. See `USER_GUIDE.md` for runnable, task-oriented examples of all three usage layers + the autotuner workflow.
 
 ## What the same pattern enables next
 

--- a/comms/dsl/USER_GUIDE.md
+++ b/comms/dsl/USER_GUIDE.md
@@ -1,0 +1,319 @@
+# comms/dsl — User Guide
+
+Build a **customized, autotunable collective** by writing only the part that differs from a plain
+transfer (a per-tile hook), while the framework owns the ~95% plumbing (schedule, multi-peer
+addressing, staging, signal/wait) and turns performance into an autotuner run.
+
+This guide is task-oriented and runnable. It covers the **three layers of control** (call a
+collective → add your hooks → compose your own collective from send/recv primitives) and the
+**auto-tuning** workflow end to end.
+
+---
+
+## 0. Mental model (30 seconds)
+
+| Piece | What it is | You touch it? |
+|---|---|---|
+| **Transport** | Cross-GPU staging + signaling, created once via `nvl_rendezvous` over PyTorch symmetric memory. | Create it (one line). |
+| **Hook + `Ctx`** | The 5% you write: a per-tile transform. Two tiers — **value** (`produce`/`consume`, per-thread) and **block-tile / layout** (`layout_hook`, CTA-cooperative over a SMEM tile). | Write it (optional). |
+| **Collective** | A shipped schedule (`all_to_all`) that runs your hook over the fused `peer × block` transfer. | Call it. |
+| **`Config` + `Key`** | `Config` = launch knobs the tuner sweeps; `Key` = how a tuned config is looked up at runtime. | Autotuner fills these. |
+| **Adapter** | Plugs a collective into the comms-owned tuner (`comm_tuning`). | Not needed for a2a (shipped). |
+
+Import surface:
+
+```python
+from comms.dsl import nvl_rendezvous                      # transport
+from comms.dsl.cute import all_to_all, all_to_all_zc      # collectives
+from comms.dsl.collectives import A2A                     # collective object (callable + .autotune)
+from comms.dsl.cute.send_recv import pipelined_sendrecv   # send/recv primitive (Layer 3)
+import cutlass.cute as cute                               # only if you WRITE a hook
+```
+
+### Shared test harness (used by every example below)
+
+Every example is a `run(rank, ws, group, device)` function. Drive it locally on an 8-GPU host with:
+
+```python
+import os, torch, torch.distributed as dist, torch.multiprocessing as mp
+
+def _spawn(run):
+    def _worker(rank, ws, port):
+        os.environ["MASTER_ADDR"] = "127.0.0.1"; os.environ["MASTER_PORT"] = str(port)
+        torch.cuda.set_device(rank)
+        dist.init_process_group("nccl", rank=rank, world_size=ws)
+        run(rank, ws, dist.group.WORLD, torch.device(f"cuda:{rank}"))
+        dist.barrier(); dist.destroy_process_group()
+    ws = min(torch.cuda.device_count(), 8)
+    mp.spawn(_worker, args=(ws, 29500), nprocs=ws, join=True)
+```
+
+Run a file with `buck2 run @fbcode//mode/opt //your/target -- ...` (single-host correctness/CI).
+Production shapes (GB300, multi-node) run on MAST — see §5.
+
+---
+
+## Layer 1 — Call a shipped collective (simplest)
+
+Plain all-to-all. No hook, no tuning needed: `config=None` looks up the tuned table for this
+(shape, hardware) and falls back to a safe analytic default on a miss.
+
+```python
+from comms.dsl import nvl_rendezvous
+from comms.dsl.cute import all_to_all
+
+def run(rank, ws, group, device):
+    CHUNK = 1 << 20                                  # per-peer elements; numel = ws * CHUNK
+    inp = torch.randn(ws * CHUNK, dtype=torch.bfloat16, device=device)
+    out = torch.empty_like(inp)
+    t = nvl_rendezvous(group, device, per_peer_bytes=CHUNK * inp.element_size())
+    all_to_all(t, out, inp)                          # config=None -> tuned lookup / analytic default
+    # `out` now holds the equal-split all-to-all result (bit-exact vs dist.all_to_all_single).
+```
+
+The built-in **non-contiguous transpose** all-to-all is one argument away — `rows=R` makes each
+received `[rows, cols]` chunk arrive transposed to `[cols, rows]` (this selects the block-tile
+transpose hook under the hood; see Layer 2b):
+
+```python
+    all_to_all(t, out, inp, rows=R)                  # R must divide the per-peer chunk; R, cols multiples of 32
+```
+
+---
+
+## Layer 2 — Add your own hooks
+
+Write the 5% (the transform); the framework runs it inside the fused schedule.
+
+### 2a. Value hook (`produce` / `consume`) — per-thread, e.g. scale / quantize / accumulate
+
+A value hook works in registers on a per-thread tile fragment. `produce` runs on the **send** leg
+(input → fragment), `consume` on the **recv** leg (fragment → output). Bodies are constexpr-traced,
+so constants are baked in.
+
+```python
+import cutlass.cute as cute
+from comms.dsl import nvl_rendezvous
+from comms.dsl.cute import all_to_all
+
+def scale_produce(ctx):                       # send: load input tile, multiply by 2
+    frag = cute.make_fragment_like(ctx.part)  # ctx.part = this thread's tile; ctx.atom = copy atom
+    cute.copy(ctx.atom, ctx.part, frag)
+    frag.store(frag.load() * 2.0)             # <-- your transform (register-only)
+    return frag
+
+def bias_consume(ctx, frag):                  # recv: add 1, store to output tile
+    frag.store(frag.load() + 1.0)
+    cute.copy(ctx.atom, frag, ctx.part)
+
+def run(rank, ws, group, device):
+    CHUNK = 1 << 20
+    inp = torch.randn(ws * CHUNK, dtype=torch.bfloat16, device=device)
+    out = torch.empty_like(inp)
+    t = nvl_rendezvous(group, device, per_peer_bytes=CHUNK * inp.element_size())
+    all_to_all(t, out, inp, produce=scale_produce, consume=bias_consume, variant="scalebias")
+    # out == (all_to_all(inp * 2)) + 1, fused into the transfer leg (no extra HBM pass).
+```
+
+`Ctx` also exposes read-only **facts** for position/peer-dependent transforms: `ctx.coord` (tile
+index), `ctx.peer` (dest/source rank), `ctx.rank` / `ctx.world_size`, `ctx.rows` / `ctx.cols` /
+`ctx.chunk`. A per-peer dequant scale, positional mask, etc. read these without touching machinery.
+
+> Pass `variant="..."` whenever you use a non-default hook — it tags this hook's tuned configs so
+> they don't collide with the default copy hook's (required by `A2A`; see §4).
+
+### 2b. Block-tile / layout hook (`layout_hook`) — CTA-cooperative, e.g. transpose / permute
+
+Coalescing-critical layout changes need the whole CTA to cooperate on a 2D SMEM tile (a per-thread
+gather would be uncoalesced). The framework coalesced-loads a `[tile, tile]` input tile into padded
+SMEM and barriers; **your hook does the in-SMEM transform + coalesced store**. Contract (`BlockCtx`):
+`bctx.sA` (loaded SMEM tile), `bctx.dst` (destination tensor), `bctx.tile`, `bctx.block_rows`,
+`bctx.tx`/`bctx.ty` (this thread's lane/row), `bctx.br`/`bctx.bc` (2D tile coords).
+
+The **shipped block-tile hook is the transpose**, reached via `rows=R` (Layer 1). Its hook body is
+the template for writing your own:
+
+```python
+def transpose_tile(bctx):                     # the shipped reference (comms.dsl.cute.hooks)
+    tile = bctx.tile
+    for r in range(0, tile, bctx.block_rows):
+        bctx.dst[(bctx.bc * tile + bctx.ty + r, bctx.br * tile + bctx.tx)] = \
+            bctx.sA[(bctx.tx, bctx.ty + r)]   # swapped indices = transpose; +1 SMEM pad => no bank conflict
+```
+
+Runnable today (transpose is wired into the public entry):
+
+```python
+def run(rank, ws, group, device):
+    R, COLS = 512, 512                        # per-peer chunk = R*COLS; both multiples of 32
+    inp = torch.randn(ws * R * COLS, dtype=torch.bfloat16, device=device)
+    out = torch.empty_like(inp)
+    t = nvl_rendezvous(group, device, per_peer_bytes=R * COLS * inp.element_size())
+    all_to_all(t, out, inp, rows=R)           # each [R,COLS] chunk arrives transposed to [COLS,R]
+```
+
+> **Scope note (be honest with users):** the block-tile **contract** (`BlockCtx` + `layout_hook`)
+> is general, but the public `all_to_all(rows=R)` currently wires the shipped `transpose_tile`
+> reference. Plumbing an *arbitrary* user block-tile hook (e.g. a permute) through the public entry
+> is a near-term extension; the value-hook tier (2a) is the fully general path today.
+
+---
+
+## Layer 3 — Compose your own collective from send/recv primitives
+
+When you need a schedule the framework doesn't ship (a ring, a custom pattern), drop to the
+**send/recv primitive** and keep the framework's staging + signal/wait + slot pipeline. Your hooks
+still apply.
+
+`pipelined_sendrecv(transport, send_buf, recv_buf, send_peer, recv_peer, *, num_blocks,
+mode="bidir"|"send"|"recv", produce=copy_produce, consume=copy_consume)` — a graph-safe, slot-
+pipelined whole-buffer transfer for one peer pair. Size the transport `per_peer_bytes >= numel*elem`.
+
+Minimal: a neighbor exchange (send to `rank+1`, recv from `rank-1`), optionally with a value hook.
+
+```python
+from comms.dsl import nvl_rendezvous
+from comms.dsl.cute.send_recv import pipelined_sendrecv
+
+def run(rank, ws, group, device):
+    N = 1 << 20
+    send_buf = torch.full((N,), float(rank), dtype=torch.bfloat16, device=device)
+    recv_buf = torch.empty_like(send_buf)
+    t = nvl_rendezvous(group, device, per_peer_bytes=N * send_buf.element_size())
+    pipelined_sendrecv(
+        t, send_buf, recv_buf,
+        send_peer=(rank + 1) % ws, recv_peer=(rank - 1) % ws,
+        num_blocks=8, mode="bidir",
+        # produce=my_produce, consume=my_consume,   # optional: transform in-flight
+    )
+    # recv_buf now holds the previous rank's shard (== (rank-1) % ws).
+```
+
+Compose a **ring all-gather** by looping it `ws-1` steps, rotating the chunk each step (each step is
+one `pipelined_sendrecv`; the framework owns the per-step staging/signal). For the lowest level of
+control, the transport's device ops — `put` / `get` / `signal` / `wait` (`comms.dsl.cute.nvl_ops`) —
+are callable directly inside your own `@cute.kernel`, but that is rarely needed.
+
+---
+
+## 4. Auto-tuning — how it works, and how to run it
+
+The launch parameters that win on one shape/hardware lose on others, so performance is an
+**autotuner run**, not hand-tuning. You do not write a tuner; you drive the comms-owned
+`comm_tuning` engine through a one-line entry.
+
+### What happens under the hood
+
+1. **`A2A(...).autotune()`** hands the engine an adapter that knows your hook, `variant`, candidate
+   search, and a correctness `reference`.
+2. The engine, **per input shape** (a size ladder or your `shapes=`):
+   - builds a **`Key`** = `(world_size, dtype, numel, rows, transport_kind, device, backend, variant)`
+     — the *same* key the runtime rebuilds, so lookups match (no drift);
+   - enumerates **candidate `Config`s** — the shipped expert size-banded grid by default, or your
+     `{field: [values]}` dict (cartesian) or `(spec, key) -> [Config]` callable;
+   - runs each candidate, times it, and **correctness-gates it bit-exact** (`assert_close(atol=0,
+     rtol=0)`) against the `reference` (default = `dist.all_to_all_single`; a transforming hook needs
+     its own reference);
+   - keeps the lowest-latency **correct** candidate for that key.
+3. It writes a generated `{Key: Config}` table (`cute/a2a/generated/a2a_tuned_configs.py`). Commit it.
+4. At runtime, `all_to_all(..., config=None)` rebuilds the key and looks it up; a miss falls back to
+   the safe analytic default. **User code never changes between tuned and untuned.**
+
+The **Config knobs** the tuner sweeps (each defaults to `0` = "use the analytic pick", so the default
+config reproduces the analytic defaults): `num_blocks` (grid = `ws × num_blocks`), `num_threads`,
+`num_slots`, `unroll`, `cluster` / `cluster_y` (CGA), `tma_drain_warps`, and `primitive`
+(`copy` staging / `tma` / `direct` zero-copy / `ce` copy-engine).
+
+### Tuning a shipped collective (no code)
+
+```python
+# tune_my_a2a.py  — the body of the tuning-job entrypoint
+from comms.dsl.collectives import A2A
+A2A(backend="cute").autotune()          # default copy hook = plain a2a
+```
+
+### Tuning YOUR hook (no adapter file)
+
+```python
+from comms.dsl.collectives import A2A
+A2A(backend="cute",
+    produce=scale_produce, consume=bias_consume, variant="scalebias",
+    reference=my_reference,             # (inputs, group)->Tensor capturing your hook's semantics
+    # candidates=<dict | callable>,     # optional; default = expert size-banded grid
+).autotune(shapes=PROD_SHAPES)          # PROD_SHAPES = list of per-rank byte sizes or specs
+```
+
+`my_reference` for the scale/bias hook above:
+
+```python
+def my_reference(inputs, group):
+    ref = torch.empty_like(inputs.input)
+    dist.all_to_all_single(ref, inputs.input * 2.0, group=group)
+    return ref + 1.0
+```
+
+### Where and how to launch it (MAST — concrete)
+
+Tuning runs on **MAST with conda delivery** (the DSL JIT-compiles in a conda env; production shapes
+only exist on cluster GPUs). `buck` only builds/launches the launcher; MAST runs the sweep.
+
+**As a master user, you provide your own tenant via `--entitlement`** (the `rmAttribution` leaf that
+holds your GB300 quota). Full command (quota path):
+
+```bash
+buck2 run @fbcode//mode/opt //comms/dsl/tests:mast_launch -- \
+    --tune \                                  # run parent -> select -> emit-table in one job
+    --delivery conda \                        # required for tuning (JIT + source overlay)
+    --nnode 2 --ppn 4 --nvl-hosts 2 \         # 2 GB300 hosts x 4 GPU = world_size 8, one NVL72 domain
+    --hw gb300_dsf \                          # the registered MastProdCluster sub-type (quota path)
+    --cluster MastProdCluster \
+    --region uco \                            # locality (ignored if --flex-pool-id is set)
+    --entitlement <YOUR_TENANT_LEAF> \        # rmAttribution: YOUR tenant with GB300 quota  <-- master user sets this
+    --identity <YOUR_DATA_PROJECT_ACL> \      # hpcIdentity / data-project ACL (default: networkai_comms_tools)
+    --oncall <YOUR_ONCALL> \                  # default: hpc_comms_lib
+    --flex-pool-id '' \                       # '' = use the quota path; omit to use the default NetAI burn-in pool
+    --tune-output-dir /tmp/a2a_tune \         # remote dir: parent results + selected table
+    --submit                                  # ACTUALLY schedule (default is dry-run — no capacity used)
+```
+
+Notes for the runner:
+- **`--entitlement` / `--rm-attribution`** is the tenant hook. Point it at your team's leaf that has
+  GB300 quota. `--identity` (hpcIdentity) is the data-project/ACL your job runs under.
+- **`--flex-pool-id ''`** selects the quota path. Leaving it default routes to a dedicated NetAI
+  burn-in pool (no quota / no preempt) if you have access; the quota path is the portable choice.
+- **`--hw gb300_dsf`** is the sub-type MastProdCluster registers; a bare `gb300` is rejected.
+- Omit `--submit` first to **dry-run** (validates the request, uses no capacity).
+- Smoke a tiny sweep before a full run: add `--bench-args "--max-sizes 2 --max-candidates 2"`.
+- The job runs parent → select → prints the generated `TUNED_A2A_CONFIGS` table; copy it into
+  `comms/dsl/cute/a2a/generated/a2a_tuned_configs.py` and commit. **Re-tune = re-run this; no kernel
+  edits.**
+
+### Consuming the tuned table (runtime)
+
+Nothing to change — the same call now hits the tuned config:
+
+```python
+all_to_all(t, out, inp, rows=R)             # config=None -> get_a2a_config(key) -> tuned or default
+```
+
+---
+
+## 5. Gotchas
+
+- **Custom hook ⇒ `variant=` + `reference=`.** `variant` keeps your tuned entries from colliding
+  with the default copy hook (`A2A` raises without it). `reference` is required for a *transforming*
+  hook — the default bit-exact gate compares against a plain `all_to_all_single`, which won't match a
+  transformed output.
+- **Hooks are constexpr-traced.** Bake constants into the body (or use module constants / distinct
+  variants); they are not runtime parameters.
+- **Zero-copy returns a view.** `all_to_all_zc` (and the internal transpose zero-copy path) returns a
+  view into the transport's symmetric-memory output buffer. Consume or `.clone()` it **before**
+  reusing/freeing the transport, or before a graph replay overwrites it. The staging `all_to_all`
+  writes your owned `output`, so it has no such caveat.
+- **Transport reuse across geometries.** Switching `num_blocks` / `primitive` on a *reused* transport
+  is unsafe without a drain (not implemented); a runtime guard raises. Use a fresh transport per
+  geometry, or set `COMMS_DSL_ALLOW_GEOMETRY_SWITCH=1` if your calls are device-sync-separated.
+- **Transpose floor.** `rows>0` uses a 32×32 SMEM tile, so its practical floor is 2KB/peer; plain
+  (`rows=0`) a2a goes down to 32B.
+- **Sizing.** `all_to_all`: `per_peer_bytes = (numel // ws) * elem`. `pipelined_sendrecv` (whole
+  buffer): `per_peer_bytes >= numel * elem`. `numel % world_size == 0`.

--- a/comms/dsl/__init__.py
+++ b/comms/dsl/__init__.py
@@ -1,0 +1,34 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Composable send/recv framework — DSL-agnostic contract.
+
+This package exposes the stable, backend-independent transport contract: the
+user-owned p2p transport objects (:class:`NvlTransport` now; IB / Mesh
+transports reserved as future intent, not implemented here) and
+:func:`nvl_rendezvous`. A device schedule binds to a transport's per-peer
+:class:`PeerEndpoint` and stays fabric-agnostic.
+"""
+
+from __future__ import annotations
+
+from .transport import (
+    check_transfer,
+    LinkKind,
+    nvl_rendezvous,
+    NvlTransport,
+    P2pTransport,
+    PeerEndpoint,
+    PeerTable,
+)
+
+__all__ = [
+    "LinkKind",
+    "P2pTransport",
+    "PeerEndpoint",
+    "PeerTable",
+    "NvlTransport",
+    "nvl_rendezvous",
+    "check_transfer",
+]

--- a/comms/dsl/a2a_base.py
+++ b/comms/dsl/a2a_base.py
@@ -1,0 +1,324 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""DSL-agnostic a2a tuning base: the shared all_to_all adapter lifecycle.
+
+Split out of :mod:`comms.dsl.tuning_base` so that module stays collective-agnostic
+(Config / Key / Spec / grid / geometry guard) while this module owns the pieces that
+are specific to the all_to_all collective but identical across the Triton and CuTe
+backends: the materialized rank-local inputs and the ``BaseA2AAdapter`` lifecycle
+(CLI args, shape enumeration, key building, input materialization, candidate
+dispatch, NCCL reference / correctness gate, and serialization). A per-backend
+subclass supplies only what genuinely differs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+from .transport import nvl_rendezvous
+from .tuning_base import (
+    _CommTunerBase,
+    _device_tag,
+    BaseAdapterMixin,
+    import_obj,
+    resolve_variant,
+    SIZE_LADDER,
+)
+
+
+@dataclass
+class A2AInputs:
+    """Materialized rank-local state for one a2a tuning run (shared by both backends)."""
+
+    transport: Any
+    input: torch.Tensor
+    output: torch.Tensor
+    rows: int
+
+
+# pyre-ignore[11]: _CommTunerBase is `object` or the optional CommKernelTuningAdapter.
+class BaseA2AAdapter(BaseAdapterMixin, _CommTunerBase):
+    """DSL-agnostic adapter lifecycle for the all_to_all schedule, shared by both backends.
+
+    The comms-owned tuner engine (``comm_tuning``) drives this; the generic engine owns
+    orchestration / timing / selection, and this base owns everything identical across the
+    Triton and CuTe backends: CLI args, shape enumeration, key building, input
+    materialization (equal-split a2a), candidate dispatch, the NCCL baseline / reference /
+    correctness gate, and serialization. A per-backend subclass supplies only what genuinely
+    differs: its config/key/spec classes + core fields + identity-copy hooks + generated
+    artifact names (class attributes), and the expert candidate grid, the static feasibility
+    filter, the config render template, and the collective launch (methods).
+
+    Key sharing: ``make_key`` here MUST match the runtime key builder so the tuned map looks
+    up. Each backend pins its default (copy) hook; a transformed variant is a separate tuned
+    map keyed by ``variant``.
+    """
+
+    # Per-backend class attributes the subclass sets (config_cls / key_cls / spec_cls /
+    # core_config_fields / backend_name come from BaseAdapterMixin).
+    transport_kind: str = "NvlTransport"
+    default_produce: Any = None
+    default_consume: Any = None
+    spec_tag: str = ""
+    generated_table: str = ""
+    generated_file: str = ""
+    generated_import: str = ""
+    # The backend's host-side ``all_to_all`` entry, bound by the subclass as a
+    # ``staticmethod`` so the shared ``run_collective`` below is backend-agnostic.
+    host_all_to_all: Any = None
+
+    # Per-call state (set in __init__).
+    _max_sizes: int = 0
+    _max_candidates: int = 0
+    _variant: str = ""
+    # None (expert default) | dict grid | (spec, key) -> list[config] callable.
+    _candidates: Any = None
+    _feasible: Any = None
+
+    def __init__(
+        self,
+        *,
+        produce=None,
+        consume=None,
+        variant: str = "",
+        reference=None,
+        candidates=None,
+        feasible=None,
+        shapes=None,
+    ) -> None:
+        # Parametrized by the A2A object (or constructed bare for the CLI path). Hooks default
+        # to the backend's identity copy hooks; the variant is validated once here
+        # (explicit-required for a non-default hook).
+        self._produce = produce if produce is not None else self.default_produce
+        self._consume = consume if consume is not None else self.default_consume
+        self._variant = resolve_variant(
+            self._produce,
+            self._consume,
+            variant,
+            default_produce=self.default_produce,
+            default_consume=self.default_consume,
+        )
+        self._reference = reference
+        self._candidates = candidates
+        self._feasible = feasible
+        self._shapes = shapes
+        self._max_sizes = 0
+        self._max_candidates = 0
+
+    # --- tuner CLI knobs (engine calls add_cli_args/configure) -------------
+    def add_cli_args(self, parser: Any) -> None:
+        parser.add_argument(
+            "--max-sizes",
+            type=int,
+            default=0,
+            help="smoke: tune only the first N size bands (0 = all)",
+        )
+        parser.add_argument(
+            "--max-candidates",
+            type=int,
+            default=0,
+            help="smoke: sweep only the first M candidate configs per band (0 = all)",
+        )
+        # Tune a custom hook with NO adapter file: point at import paths + a variant.
+        parser.add_argument(
+            "--produce", default=None, help="custom produce hook as 'module:attr'"
+        )
+        parser.add_argument(
+            "--consume", default=None, help="custom consume hook as 'module:attr'"
+        )
+        parser.add_argument(
+            "--variant", default=None, help="tuned-table variant tag for a custom hook"
+        )
+        parser.add_argument(
+            "--reference",
+            default=None,
+            help="correctness reference '(inputs, group)->Tensor' as 'module:attr' "
+            "(default: identity all_to_all_single)",
+        )
+
+    def configure(self, args: Any) -> None:
+        self._max_sizes = int(getattr(args, "max_sizes", 0) or 0)
+        self._max_candidates = int(getattr(args, "max_candidates", 0) or 0)
+        # CLI overrides (used by the generic tune entrypoint; absent in the A2A-object path).
+        produce = getattr(args, "produce", None)
+        consume = getattr(args, "consume", None)
+        variant = getattr(args, "variant", None)
+        reference = getattr(args, "reference", None)
+        if produce:
+            self._produce = import_obj(produce)
+        if consume:
+            self._consume = import_obj(consume)
+        if produce or consume or variant:
+            self._variant = resolve_variant(
+                self._produce,
+                self._consume,
+                variant or self._variant,
+                default_produce=self.default_produce,
+                default_consume=self.default_consume,
+            )
+        if reference:
+            self._reference = import_obj(reference)
+
+    # --- what to tune -----------------------------------------------------
+    def _spec_from_bytes(self, nbytes: int, world_size: int):
+        elem = torch.bfloat16.itemsize
+        numel = nbytes // elem
+        numel -= numel % world_size
+        return self.spec_cls(numel=numel, dtype=torch.bfloat16) if numel > 0 else None
+
+    def enumerate_input_specs(self, world_size: int) -> list:
+        # The user's production shapes (`shapes=` on the object, or the default ladder). Each
+        # entry may be a spec (full control incl. dtype/rows) or an int = per-rank bytes
+        # (bf16, 1D). The best launch config shifts across sizes, so each is tuned separately.
+        if self._shapes is not None:
+            specs = []
+            for s in self._shapes:
+                if isinstance(s, self.spec_cls):
+                    specs.append(s)
+                elif isinstance(s, int):
+                    spec = self._spec_from_bytes(s, world_size)
+                    if spec is not None:
+                        specs.append(spec)
+                else:
+                    raise TypeError(
+                        f"shapes entry must be {self.spec_cls.__name__} or "
+                        f"int (per-rank bytes), got {type(s).__name__}"
+                    )
+        else:
+            specs = [
+                s
+                for s in (self._spec_from_bytes(n, world_size) for n in SIZE_LADDER)
+                if s is not None
+            ]
+        if self._max_sizes:
+            specs = specs[: self._max_sizes]
+        return specs
+
+    def make_key(self, spec, world_size: int):
+        # MUST match the runtime key builder so the tuned map looks up. Tuned on the target
+        # GPU, so _device_tag() tags the entry with this host's hardware; _variant is "" for
+        # the default copy hook and set by the A2A object for a custom hook.
+        return self.make_key_from_spec(
+            spec=spec,
+            world_size=world_size,
+            transport_kind=self.transport_kind,
+            device=_device_tag(),
+            variant=self._variant,
+        )
+
+    def enumerate_candidate_configs(self, spec, key) -> list:
+        # Dispatch the candidate source: default expert banded grid / flat declarative grid
+        # (dict) / callable (full control); then static-feasibility filter + size-cap.
+        cand = self._candidates
+        if cand is None:
+            out = self.default_candidate_configs(spec, key)
+        elif callable(cand):
+            # pyre-ignore[6]: a callable candidate source returns the backend's config list.
+            out = list(cand(spec, key))
+        elif isinstance(cand, dict):
+            out = self.expand_candidate_grid(cand)
+        else:
+            raise TypeError(
+                "candidates must be None (expert default), a dict grid, or a callable "
+                f"(spec, key) -> list[{self.config_cls.__name__}]; got {type(cand)!r}"
+            )
+        feasible = self._feasible or self.default_feasible
+        out = [c for c in out if feasible(c, spec)]
+        if self._max_candidates:
+            out = out[: self._max_candidates]
+        return out
+
+    def enumerate_baselines(self, spec, key) -> list[str]:
+        return ["nccl"]
+
+    # --- materialize + run ------------------------------------------------
+    def make_inputs(self, spec, *, rank: int, world_size: int, device: torch.device):
+        assert spec.numel % world_size == 0
+        chunk = spec.numel // world_size
+        inp = torch.randn(spec.numel, dtype=spec.dtype, device=device)
+        out = torch.empty_like(inp)
+        group = dist.group.WORLD
+        assert group is not None, "default process group not initialized"
+        transport = nvl_rendezvous(
+            group, device, per_peer_bytes=chunk * inp.element_size()
+        )
+        return A2AInputs(transport=transport, input=inp, output=out, rows=spec.rows)
+
+    def run_candidate(self, inputs, config, group) -> torch.Tensor:
+        self.run_collective(inputs, config)
+        return inputs.output
+
+    def run_baseline(self, inputs, baseline: str, group) -> torch.Tensor:
+        if baseline != "nccl":
+            raise ValueError(f"unknown baseline {baseline}")
+        return self.run_reference(inputs, group)
+
+    def run_reference(self, inputs, group) -> torch.Tensor:
+        # Custom hooks (transpose/quantize/...) change the expected output, so the user
+        # supplies a reference `(inputs, group) -> Tensor` capturing their semantics; the
+        # default (identity copy hook) is a plain all_to_all_single.
+        if self._reference is not None:
+            return self._reference(inputs, group)
+        ref = torch.empty_like(inputs.input)
+        dist.all_to_all_single(ref, inputs.input, group=group)
+        return ref
+
+    def check_correctness(self, candidate_output, reference_output) -> dict[str, Any]:
+        torch.testing.assert_close(candidate_output, reference_output, atol=0, rtol=0)
+        # The engine records this dict verbatim and the selector keeps a candidate only when
+        # correctness["status"] == "pass"; assert_close(atol=0, rtol=0) raises on any mismatch,
+        # so reaching here means bit-exact -- the error is provably 0.0. Computing it via
+        # .abs().max().item() would only force a needless GPU sync.
+        return {
+            "status": "pass",
+            "max_abs_err": 0.0,
+        }
+
+    # --- serialization (parent -> child) ----------------------------------
+    def spec_to_json(self, spec) -> tuple[str, dict[str, Any]]:
+        return (self.spec_tag, spec.to_json_dict())
+
+    def spec_from_json(self, spec_type: str, data: dict[str, Any]):
+        if spec_type != self.spec_tag:
+            raise ValueError(f"unknown spec type {spec_type}")
+        return super().spec_from_json(spec_type, data)
+
+    # --- generated artifact names -----------------------------------------
+    def generated_table_name(self) -> str:
+        return self.generated_table
+
+    def generated_filename(self) -> str:
+        return self.generated_file
+
+    def generated_imports(self) -> str:
+        return self.generated_import
+
+    # --- per-backend hooks (subclass supplies these) ----------------------
+    def default_candidate_configs(self, spec, key) -> list:
+        """The shipped expert, size-banded candidate grid (the zero-effort default)."""
+        raise NotImplementedError
+
+    def default_feasible(self, config, spec) -> bool:
+        """Cheap, shape-independent static feasibility pre-filter for user grids."""
+        raise NotImplementedError
+
+    def run_collective(self, inputs, config) -> None:
+        """Launch this backend's all_to_all writing ``inputs.output`` (used by run_candidate).
+
+        Backend-agnostic: dispatches to the subclass-bound ``host_all_to_all`` with the
+        adapter's hooks; identical across Triton and CuTe, so it lives here."""
+        self.host_all_to_all(
+            inputs.transport,
+            inputs.output,
+            inputs.input,
+            produce=self._produce,
+            consume=self._consume,
+            rows=inputs.rows,
+            config=config,
+        )

--- a/comms/dsl/tests/_dist_harness.py
+++ b/comms/dsl/tests/_dist_harness.py
@@ -1,0 +1,60 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Shared multi-rank scaffolding for the distributed correctness suites.
+
+The small helpers every distributed test repeats: a free-port picker, the bit-exact
+input builder, the ``dist.all_to_all_single`` golden, the cross-rank PASS/FAIL
+min-reduce + reporter, and the transport rendezvous. Kept here so the scaffolding
+lives in one place; a test with a special need (e.g. multi-dtype bit-exact-per-dtype
+inputs) keeps its own local variant.
+"""
+
+import socket
+
+import torch
+import torch.distributed as dist
+
+_FP32_BYTES = 4
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _make_input(rank: int, numel: int, device: torch.device) -> torch.Tensor:
+    idx = torch.arange(numel, device=device, dtype=torch.int64)
+    return ((rank + 1) * 1_000_000 + idx).to(torch.float32)
+
+
+def _golden(group: dist.ProcessGroup, inp: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(inp)
+    dist.all_to_all_single(out, inp, group=group)
+    return out
+
+
+def _all_ok(local_ok: bool, device: torch.device, group: dist.ProcessGroup) -> bool:
+    status = torch.tensor([1 if local_ok else 0], dtype=torch.int32, device=device)
+    dist.all_reduce(status, op=dist.ReduceOp.MIN, group=group)
+    return bool(status.item())
+
+
+def _report(name: str, local_ok: bool, device, group, rank: int) -> bool:
+    ok = _all_ok(local_ok, device, group)
+    if rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: {name}", flush=True)
+    return ok
+
+
+def _rendezvous(group, device, max_chunk_numel: int, *, max_blocks_per_peer: int = 32):
+    from comms.dsl import nvl_rendezvous
+
+    return nvl_rendezvous(
+        group,
+        device,
+        per_peer_bytes=max_chunk_numel * _FP32_BYTES,
+        max_blocks_per_peer=max_blocks_per_peer,
+    )

--- a/comms/dsl/tests/test_a2a_base.py
+++ b/comms/dsl/tests/test_a2a_base.py
@@ -1,0 +1,31 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+import unittest
+
+from comms.dsl.a2a_base import BaseA2AAdapter
+from comms.dsl.tuning_base import BaseInputSpec
+
+
+class TestA2ABase(unittest.TestCase):
+    def test_run_baseline_rejects_unknown_baseline(self):
+        adapter = object.__new__(BaseA2AAdapter)
+        with self.assertRaises(ValueError):
+            adapter.run_baseline(inputs=None, baseline="gloo", group=None)
+
+    def test_spec_from_json_rejects_unknown_spec_type(self):
+        adapter = object.__new__(BaseA2AAdapter)
+        adapter.spec_tag = "A2AInputSpec"
+        with self.assertRaises(ValueError):
+            adapter.spec_from_json("WrongSpec", {})
+
+    def test_enumerate_input_specs_rejects_non_int_non_spec_shape(self):
+        # A shapes entry that is neither a spec nor an int (per-rank bytes) must raise a
+        # clear TypeError, not an opaque `nbytes // elem` failure deep in _spec_from_bytes.
+        adapter = object.__new__(BaseA2AAdapter)
+        adapter.spec_cls = BaseInputSpec
+        adapter._shapes = [object()]
+        adapter._max_sizes = 0
+        with self.assertRaises(TypeError):
+            adapter.enumerate_input_specs(world_size=8)

--- a/comms/dsl/tests/test_transport.py
+++ b/comms/dsl/tests/test_transport.py
@@ -1,0 +1,71 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Host-side (CPU, no device) coverage for transport.check_transfer.
+
+check_transfer is pure host validation -- it only reads per_peer_bytes /
+max_blocks_per_peer off the transport and dtype.itemsize -- so all three ValueError
+invariants (dtype divisibility, per-peer capacity, and signal-pad slot range) are
+exercisable without a symmetric-memory PG. The device rendezvous path (nvl_rendezvous)
+still needs a real symm-mem-capable group and is covered by the next-layer send/recv tests.
+"""
+
+import unittest
+from dataclasses import dataclass
+from typing import cast
+
+import torch
+from comms.dsl import check_transfer, P2pTransport
+
+
+@dataclass
+class _StubTransport:
+    """Minimal P2pTransport-shaped stub: just the fields check_transfer reads."""
+
+    world_size: int
+    per_peer_bytes: int
+    max_blocks_per_peer: int
+
+
+class TransportCheckTransferTest(unittest.TestCase):
+    def test_dtype_not_divisible_raises(self) -> None:
+        # per_peer_bytes must be a whole multiple of the dtype itemsize (mirrors endpoint()):
+        # 65 bytes is not divisible by bfloat16's 2-byte itemsize.
+        t = cast(
+            P2pTransport,
+            _StubTransport(world_size=2, per_peer_bytes=65, max_blocks_per_peer=8),
+        )
+        with self.assertRaises(ValueError):
+            check_transfer(t, numel=1, dtype=torch.bfloat16, num_blocks=1)
+
+    def test_numel_overrun_raises(self) -> None:
+        # per_peer_bytes=64 holds 64 uint8 / 32 bf16 elems; one past capacity raises.
+        for dtype, cap in ((torch.uint8, 64), (torch.bfloat16, 32)):
+            t = cast(
+                P2pTransport,
+                _StubTransport(world_size=2, per_peer_bytes=64, max_blocks_per_peer=8),
+            )
+            with self.assertRaises(ValueError):
+                check_transfer(t, numel=cap + 1, dtype=dtype, num_blocks=1)
+
+    def test_num_blocks_out_of_range_raises(self) -> None:
+        t = cast(
+            P2pTransport,
+            _StubTransport(world_size=2, per_peer_bytes=64, max_blocks_per_peer=8),
+        )
+        with self.assertRaises(ValueError):
+            check_transfer(t, numel=1, dtype=torch.uint8, num_blocks=0)
+        with self.assertRaises(ValueError):
+            check_transfer(
+                t, numel=1, dtype=torch.uint8, num_blocks=t.max_blocks_per_peer + 1
+            )
+
+    def test_valid_transfer_passes(self) -> None:
+        t = cast(
+            P2pTransport,
+            _StubTransport(world_size=2, per_peer_bytes=64, max_blocks_per_peer=8),
+        )
+        for dtype, cap in ((torch.uint8, 64), (torch.bfloat16, 32)):
+            check_transfer(t, numel=cap, dtype=dtype, num_blocks=1)
+            check_transfer(t, numel=cap, dtype=dtype, num_blocks=t.max_blocks_per_peer)

--- a/comms/dsl/tests/test_tuning_base.py
+++ b/comms/dsl/tests/test_tuning_base.py
@@ -1,0 +1,78 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+import unittest
+from unittest import mock
+
+import torch
+from comms.dsl.tuning_base import (
+    _device_tag,
+    BaseInputSpec,
+    BaseTunableConfig,
+    BaseTuningKey,
+)
+
+
+class TestTuningBase(unittest.TestCase):
+    def test_key_no_backend_default_in_base(self):
+        # The agnostic base stays backend-neutral: an empty backend is left as-is. A backend
+        # default belongs on a per-backend key subclass; a missing backend is attributed to the
+        # loading adapter only on the deserialization path (BaseAdapterMixin.key_from_json).
+        k = BaseTuningKey(
+            world_size=8,
+            dtype="bfloat16",
+            numel=1024,
+            rows=0,
+            transport_kind="NvlTransport",
+            device="H100",
+            backend="",
+            variant="",
+        )
+        self.assertEqual(k.backend, "")
+
+    def test_spec_json_roundtrip(self):
+        spec = BaseInputSpec(numel=8, dtype=torch.bfloat16, rows=0)
+        d = spec.to_json_dict()
+        self.assertEqual(d["dtype"], "bfloat16")
+        spec2 = BaseInputSpec.from_json_dict(d)
+        self.assertEqual(spec, spec2)
+
+    def test_config_hashable_as_dict_key(self):
+        cfg1 = BaseTunableConfig()
+        cfg2 = BaseTunableConfig()
+        d = {cfg1: "v"}
+        self.assertEqual(d[cfg2], "v")
+
+    def test_device_tag_cuda_absent_returns_unknown(self):
+        # CUDA unavailable raises RuntimeError -> the intended "unknown" fallback, no raise.
+        with mock.patch(
+            "torch.cuda.get_device_name", side_effect=RuntimeError("no CUDA")
+        ):
+            tag = _device_tag()
+        self.assertEqual(tag, "unknown")
+
+    def test_device_tag_cpu_device_returns_unknown(self):
+        # A CPU device (e.g. a CPU input tensor's .device) makes torch raise ValueError;
+        # the tag falls back to "unknown" rather than propagating (real make_a2a_key path).
+        self.assertEqual(_device_tag(torch.device("cpu")), "unknown")
+
+    def test_device_tag_known_models_match_exactly(self):
+        cases = {
+            "NVIDIA H100": "H100",
+            "NVIDIA GB300": "GB300",
+            "NVIDIA A100": "A100",
+            "NVIDIA B200": "B200",
+            "NVIDIA H200": "H200",
+            # GH (Grace+Hopper) must tag distinctly, not collide with the inner H200.
+            "NVIDIA GH200": "GH200",
+        }
+        for name, expected in cases.items():
+            with mock.patch("torch.cuda.get_device_name", return_value=name):
+                self.assertEqual(_device_tag(), expected)
+
+    def test_device_tag_four_digit_model_not_truncated(self):
+        # Regression: "RTX A6000" must NOT partial-match to "A600"; it falls through to the
+        # readable cleaned-name path.
+        with mock.patch("torch.cuda.get_device_name", return_value="NVIDIA RTX A6000"):
+            self.assertEqual(_device_tag(), "NVIDIA_RTX_A6000")

--- a/comms/dsl/transport.py
+++ b/comms/dsl/transport.py
@@ -1,0 +1,371 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""User-owned p2p transport objects for the composable send/recv framework.
+
+A transport owns all transport state (staging buffer + signal pads for the
+symmetric-memory case) behind an abstraction. A device schedule consumes a
+per-peer :class:`PeerEndpoint` resolved from a transport and never sees whether
+it is NVLink or IB.
+
+Design points realized here:
+
+* **User-owned, one rendezvous.** :func:`nvl_rendezvous` does a single collective
+  rendezvous for the whole group and returns an object the user holds (reused
+  across CUDA-graph replays). There is no hidden module-level cache.
+* **Mixed transport (future).** A ``MeshTransport`` would compose an intra-domain NVLink
+  transport with a (future) inter-domain IB transport and route per peer via
+  :meth:`P2pTransport.link_kind`, so a single collective could mix transports. Reserved
+  intent only -- not implemented here (see the future-note at the end of this module).
+
+Device transport-ops seam: a transport's only transport-specific device code is four
+primitives -- ``put`` (produced tile -> peer region), ``get`` (received tile <- region),
+``signal`` (publish "data ready"), ``wait`` (await a peer's data). A device schedule is
+written once against this seam and treats the per-peer buffers as opaque, so one schedule
+serves NVLink today and IB later, and a mixed-transport kernel can bind different ops per
+call site. There is no runtime dispatch -- the concrete ops are passed as compile-time
+constants; implementations live per transport + DSL.
+
+NVLink is implemented for real (minimal) here; IB and the mixed-transport mesh are reserved
+seams (the future-fabric interface contract, raising until their stack lands).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from torch._C._distributed_c10d import _SymmetricMemory
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+_SR_DEBUG: bool | None = None
+
+
+def _sr_debug() -> bool:
+    global _SR_DEBUG
+    if _SR_DEBUG is None:
+        _SR_DEBUG = os.environ.get("SENDRECV_DEBUG", "0") == "1"
+    return _SR_DEBUG
+
+
+def _rdv_dbg(group: dist.ProcessGroup, msg: str) -> None:
+    if _sr_debug():
+        logger.debug("[r%d] rdv: %s", dist.get_rank(group), msg)
+
+
+# Shape-independent default; the staging region per peer must hold the message.
+_DEFAULT_MAX_BLOCKS_PER_PEER: int = 32
+
+# Floor for the total symmetric-memory allocation (see nvl_rendezvous): GB300's NVL72
+# fabric rendezvous deadlocks on sub-MB allocations, so always allocate at least this much.
+_MIN_SYMM_TOTAL_BYTES: int = 4 * 1024 * 1024
+
+
+class LinkKind(Enum):
+    """How a given peer is reached. NVLINK is the only implemented kind today; IB is reserved
+    for the future IB (torchcomms window) transport and has no backing implementation yet."""
+
+    NVLINK = "nvlink"
+    IB = "ib"
+
+
+@dataclass(frozen=True)
+class PeerEndpoint:
+    """Host-resolved per-peer device state for one peer.
+
+    The four handles are passed directly to a device schedule (typed tensors, not
+    pointer-of-pointer indirection). Today each is a ``torch.Tensor`` (NVLink:
+    symm-mem-mapped); an IB transport will carry a ``(remote_addr, rkey)``
+    descriptor instead — a field-type change behind this same struct. The
+    ``send_dst``/``signal_dst`` pair drives this rank's writes to ``peer``; the
+    ``recv_src``/``signal_src`` pair drives this rank's reads of what ``peer`` wrote.
+    """
+
+    send_dst: torch.Tensor  # WHERE this rank writes for the peer (remote)
+    recv_src: torch.Tensor  # WHERE this rank reads what the peer wrote (local)
+    signal_dst: torch.Tensor  # signal this rank raises at the peer
+    signal_src: torch.Tensor  # signal this rank waits on (the peer raises it)
+
+
+@dataclass(frozen=True)
+class PeerTable:
+    """Device-side addressing for fused multi-peer schedules.
+
+    The multi-peer analogue of :class:`PeerEndpoint` (host-resolved, single
+    peer): every peer's staging-buffer and signal-pad base pointer as an int64
+    device tensor, indexed by peer id (cast int->ptr) inside the kernel. Used by
+    a fused multi-peer schedule that picks the peer on device via ``program_id``
+    instead of pre-slicing one ``PeerEndpoint`` per peer on the host.
+    """
+
+    buffer_ptrs: torch.Tensor  # int64[world_size]: peer -> staging-buffer base
+    signal_pad_ptrs: torch.Tensor  # int64[world_size]: peer -> signal-pad base
+
+
+@runtime_checkable
+class P2pTransport(Protocol):
+    """The transport abstraction a device schedule depends on (NVLink now, IB later)."""
+
+    world_size: int
+    per_peer_bytes: int
+    max_blocks_per_peer: int
+
+    def link_kind(self, peer: int) -> LinkKind: ...
+
+    def endpoint(self, peer: int, *, dtype: torch.dtype) -> PeerEndpoint: ...
+
+    def endpoints_device(self) -> PeerTable: ...
+
+
+@dataclass
+class NvlTransport:
+    """Symmetric-memory NVLink transport (real, minimal).
+
+    Owns the ``_SymmetricMemory`` handle. The buffer is ``per_peer_bytes`` per
+    peer (``per_peer_bytes * world_size`` total); the signal pad holds two int64
+    regions of ``world_size * max_blocks_per_peer`` entries each (tail then head),
+    laid out by ``[sender_rank * max_blocks_per_peer + block]``. Tail = sender
+    "data ready"; head = receiver "slot consumed" (so a sender never overwrites a
+    slot a receiver has not drained).
+    """
+
+    handle: _SymmetricMemory
+    world_size: int
+    # Rank within the NVLink rendezvous group (``dist.get_rank(group)``), i.e. the
+    # index used to address this rank's slot in the symmetric-memory buffer. This is
+    # NOT the node-local rank (``LOCAL_RANK`` env / ``get_node_local_rank``): on an
+    # NVL fabric the rendezvous group may span trays, so it is a group-relative rank.
+    local_rank: int
+    per_peer_bytes: int
+    max_blocks_per_peer: int = _DEFAULT_MAX_BLOCKS_PER_PEER
+    _endpoints_device_cache: PeerTable | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+    _step_state_cache: tuple[torch.Tensor, torch.Tensor] | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+
+    def link_kind(self, peer: int) -> LinkKind:
+        return LinkKind.NVLINK
+
+    def endpoint(self, peer: int, *, dtype: torch.dtype) -> PeerEndpoint:
+        if not (0 <= peer < self.world_size) or peer == self.local_rank:
+            raise ValueError(
+                f"peer={peer} must be in [0, {self.world_size}) and "
+                f"!= local_rank={self.local_rank}"
+            )
+        elem = dtype.itemsize
+        if self.per_peer_bytes % elem != 0:
+            raise ValueError(
+                f"per_peer_bytes={self.per_peer_bytes} not a multiple of {elem} "
+                f"(dtype={dtype})"
+            )
+        cap_elems = self.per_peer_bytes // elem
+        mbp = self.max_blocks_per_peer
+
+        # Staging regions are indexed by SENDER rank within each rank's buffer.
+        send_dst = self.handle.get_buffer(
+            peer,
+            sizes=[cap_elems],
+            dtype=dtype,
+            storage_offset=self.local_rank * cap_elems,
+        )
+        recv_src = self.handle.get_buffer(
+            self.local_rank,
+            sizes=[cap_elems],
+            dtype=dtype,
+            storage_offset=peer * cap_elems,
+        )
+        peer_sig = self.handle.get_signal_pad(peer).view(torch.int64)
+        local_sig = self.handle.get_signal_pad(self.local_rank).view(torch.int64)
+        signal_dst = peer_sig[self.local_rank * mbp : self.local_rank * mbp + mbp]
+        signal_src = local_sig[peer * mbp : peer * mbp + mbp]
+        return PeerEndpoint(send_dst, recv_src, signal_dst, signal_src)
+
+    def endpoints_device(self) -> PeerTable:
+        """All peers' buffer + signal-pad base pointers as a device :class:`PeerTable`.
+
+        The device-side counterpart of :meth:`endpoint` for a single fused
+        multi-peer kernel: index by peer on device (cast int->ptr) instead of
+        pre-slicing one :class:`PeerEndpoint` per peer. The per-peer staging
+        region for sender ``s`` inside a rank's buffer is at
+        ``s * (per_peer_bytes // elem)`` (same convention as :meth:`endpoint`),
+        and signal-pad slots for sender ``s`` start at ``s * max_blocks_per_peer``.
+        """
+        if self._endpoints_device_cache is None:
+            # Symm-mem base addresses are fixed after rendezvous, so build once and
+            # cache: repeated fused-schedule calls and CUDA-graph capture must not
+            # re-allocate / re-copy. Device is the transport's own symm-mem device,
+            # not the caller's current device.
+            dev = self.handle.get_buffer(
+                self.local_rank, sizes=[1], dtype=torch.uint8
+            ).device
+            self._endpoints_device_cache = PeerTable(
+                buffer_ptrs=torch.tensor(
+                    self.handle.buffer_ptrs, dtype=torch.int64, device=dev
+                ),
+                signal_pad_ptrs=torch.tensor(
+                    self.handle.signal_pad_ptrs, dtype=torch.int64, device=dev
+                ),
+            )
+        return self._endpoints_device_cache
+
+    def step_state(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """Persistent monotonic step counters for graph-safe signalling.
+
+        Returns ``(sender_step, recver_step)``, each an int64 device tensor of
+        ``world_size * max_blocks_per_peer`` entries indexed by
+        ``peer * max_blocks_per_peer + block``. Each slot has exactly one writer
+        (the local send leg writes ``sender_step``; the local recv leg writes
+        ``recver_step``), so no atomics are needed.
+
+        The schedule signals an absolute, monotonically increasing sequence
+        number per call and the kernel advances these counters itself, so a
+        reused transport / CUDA-graph replay never reads a stale signal slot.
+        Allocated once and cached (zero-initialized; the signal pad is zeroed at
+        rendezvous, so the first ``wait_ge(_, 1)`` is race-free).
+        """
+        if self._step_state_cache is None:
+            dev = self.handle.get_buffer(
+                self.local_rank, sizes=[1], dtype=torch.uint8
+            ).device
+            n = self.world_size * self.max_blocks_per_peer
+            self._step_state_cache = (
+                torch.zeros(n, dtype=torch.int64, device=dev),
+                torch.zeros(n, dtype=torch.int64, device=dev),
+            )
+        return self._step_state_cache
+
+
+def nvl_rendezvous(
+    group: dist.ProcessGroup,
+    device: torch.device,
+    per_peer_bytes: int,
+    max_blocks_per_peer: int = _DEFAULT_MAX_BLOCKS_PER_PEER,
+) -> NvlTransport:
+    """One collective rendezvous; returns a user-owned :class:`NvlTransport`.
+
+    Allocates ``per_peer_bytes * world_size`` of symmetric memory (one per-peer
+    staging region per peer), floored at ``_MIN_SYMM_TOTAL_BYTES`` (4 MiB) because
+    the GB300 NVL72 fabric rendezvous deadlocks on sub-MB allocations -- so a small
+    transfer allocates more than the raw product. Zeroes the signal pad so the first
+    ``wait(_, 1)`` is race-free after the barrier.
+    """
+    world_size = dist.get_world_size(group)
+    local_rank = dist.get_rank(group)
+    total = per_peer_bytes * world_size
+    # GB300 NVL72 symm-mem fabric rendezvous DEADLOCKS on a tiny allocation: a 32B-per-peer
+    # (64B total) transfer wedges the receiver inside symm_mem.rendezvous() while the sender
+    # returns (pinpointed via SENDRECV_DEBUG -- rank1 freezes at symm_mem.rendezvous start).
+    # Floor the symm-mem allocation to a fabric-safe size. The per-peer staging math
+    # (cap_elems = per_peer_bytes // elem) is unchanged, so the extra bytes are unused
+    # headroom and the measured transfer size is unaffected; the signal pad is sized
+    # separately. H100 does not need this (it handles tiny allocations fine).
+    total = max(total, _MIN_SYMM_TOTAL_BYTES)
+    logger.info(
+        "nvl_rendezvous on PG %s: allocating %d bytes (%d peers x %d)",
+        group.group_desc,
+        total,
+        world_size,
+        per_peer_bytes,
+    )
+    _rdv_dbg(group, f"symm_mem.empty({total}B) start")
+    raw = symm_mem.empty(total, dtype=torch.uint8, device=device)
+    _rdv_dbg(group, "symm_mem.empty done; symm_mem.rendezvous start")
+    handle = symm_mem.rendezvous(raw, group=group)
+    _rdv_dbg(group, "symm_mem.rendezvous done")
+
+    # Signal pad holds two int64 regions per (sender, block) slot:
+    #   tail [0 .. ws*MBP): sender publishes "data ready" (polled by receiver)
+    #   head [ws*MBP .. 2*ws*MBP): receiver publishes "slot consumed" (polled by
+    #       sender, so a sender never overwrites a slot the receiver has not yet
+    #       drained -> back-to-back / reuse is race-free).
+    need = 2 * world_size * max_blocks_per_peer
+    sig = handle.get_signal_pad(handle.rank).view(torch.int64)
+    if sig.numel() < need:
+        raise RuntimeError(
+            f"signal pad too small: {sig.numel()} int64 < required {need} "
+            f"(2 x world_size={world_size} x max_blocks_per_peer={max_blocks_per_peer})"
+        )
+    sig.zero_()
+    _rdv_dbg(group, "sig.zero_ done; barrier start")
+    dist.barrier(group)
+    _rdv_dbg(group, "barrier done")
+    transport = NvlTransport(
+        handle=handle,
+        world_size=world_size,
+        local_rank=local_rank,
+        per_peer_bytes=per_peer_bytes,
+        max_blocks_per_peer=max_blocks_per_peer,
+    )
+    # Eagerly materialize the device-side caches (peer table + step counters) now,
+    # so the first collective can be issued inside a CUDA-graph capture without the
+    # lazy allocation happening during capture.
+    transport.endpoints_device()
+    _rdv_dbg(group, "endpoints_device done")
+    transport.step_state()
+    _rdv_dbg(group, "step_state done")
+    return transport
+
+
+def check_transfer(
+    transport: P2pTransport,
+    numel: int,
+    dtype: torch.dtype,
+    num_blocks: int,
+) -> None:
+    """Validate a transfer against the transport before launch (fail loud).
+
+    Three invariants whose violation would otherwise cause **silent remote
+    corruption** (a kernel writing past a per-peer region overruns the next
+    peer's staging or signal-pad region on the remote rank):
+
+    * ``per_peer_bytes`` must be a whole multiple of the dtype itemsize (mirrors
+      ``endpoint()``), so the per-peer region holds whole elements.
+    * ``numel`` must fit the per-peer staging region (``per_peer_bytes``).
+    * ``num_blocks`` must fit the per-peer signal-pad slots
+      (``max_blocks_per_peer``), since each block signals slot ``block_id``.
+    """
+    elem = dtype.itemsize
+    # Mirror endpoint()'s divisibility guard so pre-launch validation is complete: a per-peer
+    # region that is not a whole number of elements would otherwise pass here and fail later
+    # inside endpoint() (or silently mis-slice the symm-mem buffer).
+    if transport.per_peer_bytes % elem != 0:
+        raise ValueError(
+            f"per_peer_bytes={transport.per_peer_bytes} not a multiple of dtype itemsize "
+            f"{elem} ({dtype}); the per-peer region cannot hold whole elements"
+        )
+    cap_elems = transport.per_peer_bytes // elem
+    if numel > cap_elems:
+        raise ValueError(
+            f"transfer numel={numel} exceeds per-peer capacity={cap_elems} elems "
+            f"(per_peer_bytes={transport.per_peer_bytes}, dtype={dtype}); "
+            f"increase per_peer_bytes at rendezvous"
+        )
+    mbp = transport.max_blocks_per_peer
+    if not (1 <= num_blocks <= mbp):
+        raise ValueError(
+            f"num_blocks={num_blocks} must be in [1, {mbp}] "
+            f"(one signal-pad slot per block per peer)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Future: IB / Mesh transports.
+#
+# The intent is retained but not implemented here: an IB (torchcomms window)
+# transport and a mixed-transport ``MeshTransport`` (intra-domain NVLink composed
+# with inter-domain IB, routed per peer via ``P2pTransport.link_kind``) would slot
+# onto the same ``P2pTransport`` protocol + four-op device seam above, so device
+# schedules stay fabric-agnostic. Not shipped in this framework (no kernel uses it);
+# ``LinkKind.IB`` is the reserved kind for the IB transport, and a mesh kind would be
+# added to ``LinkKind`` when ``MeshTransport`` lands (only NVLINK/IB exist today).
+# ---------------------------------------------------------------------------

--- a/comms/dsl/tuning_base.py
+++ b/comms/dsl/tuning_base.py
@@ -1,0 +1,390 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""DSL-agnostic tuning base: shared Config / Key / Spec / Adapter mixin for backends.
+
+This layer owns everything the backends share: the tunable Config / lookup Key /
+input Spec dataclasses, their JSON roundtrip, rendering, and the dict-grid candidate
+expansion. Backends inherit and add their core fields. A generated-table entry that
+does not name a backend is attributed to the loading adapter's backend.
+"""
+
+from __future__ import annotations
+
+import importlib
+import itertools
+import logging
+import os
+import re
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import torch
+
+try:  # optional dep: the comms-owned tuner engine; absent until comm_tuning lands.
+    # pyre-ignore[21]: optional dependency, resolved at runtime when the tuner is present.
+    from comm_tuning.adapter import CommKernelTuningAdapter as _CommTunerBase
+except ImportError:  # the adapter base is still importable/testable without the engine
+    _CommTunerBase = object
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _device_tag(device: torch.device | int | str | None = None) -> str:
+    """Short, stable hardware tag for the tuning key (e.g. ``H100``, ``GB300``,
+    ``B200``, ``A100``). Tuned configs are hardware-specific -- the best launch config
+    differs by GPU/NVLink generation -- so the key includes the device so an H100-tuned
+    table and a GB300-tuned table coexist in one map instead of colliding on identical
+    (world_size, dtype, numel, rows, transport) keys. Backend-agnostic, so both DSLs build
+    an identical tag; MUST be computed identically offline (tuner) and at runtime (lookup).
+    """
+    try:
+        name = torch.cuda.get_device_name(device)  # e.g. "NVIDIA H100", "NVIDIA GB300"
+    except (RuntimeError, ValueError, AssertionError):
+        # torch raises RuntimeError when CUDA is unavailable / the index is out of range,
+        # ValueError for a non-CUDA device (e.g. a CPU tensor's device), and AssertionError
+        # on a bad device arg; "unknown" is the intended fallback only for those. Anything
+        # else is a real bug and must not be folded into a tuning key.
+        return "unknown"
+    # The (?!\d) lookahead stops a 4-digit model (e.g. "RTX A6000") from partial-matching
+    # to "A600"; such names fall through to the readable cleaned-name path instead.
+    m = re.search(r"(GB\d{3}|GH\d{3}|B\d{3}|H\d{3}|A\d{3})(?!\d)", name.upper())
+    return m.group(1) if m else name.replace(" ", "_")
+
+
+# Default per-rank message-size ladder for the autotuner: the 32 B .. 2 GB 2x ladder (27 sizes)
+# plus 48 MB / 96 MB for mid-band resolution where the launch-config dip lives = 29 sizes. The
+# best launch config shifts across sizes, so each is tuned independently; mirrors the benchmark
+# size sweep. Used by the adapter's enumerate_input_specs when no explicit shapes are given.
+SIZE_LADDER: tuple[int, ...] = (
+    32,
+    64,
+    128,
+    256,
+    512,
+    1024,
+    2 * 1024,
+    4 * 1024,
+    8 * 1024,
+    16 * 1024,
+    32 * 1024,
+    64 * 1024,
+    128 * 1024,
+    256 * 1024,
+    512 * 1024,
+    1 * 1024 * 1024,
+    2 * 1024 * 1024,
+    4 * 1024 * 1024,
+    8 * 1024 * 1024,
+    16 * 1024 * 1024,
+    32 * 1024 * 1024,
+    48 * 1024 * 1024,
+    64 * 1024 * 1024,
+    96 * 1024 * 1024,
+    128 * 1024 * 1024,
+    256 * 1024 * 1024,
+    512 * 1024 * 1024,
+    1024 * 1024 * 1024,
+    2 * 1024 * 1024 * 1024,
+)
+
+
+def import_obj(path: str):
+    """Resolve a ``module:attr`` import path to the object, for CLI ``--produce`` /
+    ``--reference`` so a user can tune a custom hook with no adapter file."""
+    mod, _, name = path.partition(":")
+    if not mod or not name:
+        raise ValueError(f"expected 'module:attr', got {path!r}")
+    return getattr(importlib.import_module(mod), name)
+
+
+def resolve_variant(
+    produce, consume, variant: str, *, default_produce, default_consume
+) -> str:
+    """Single chokepoint for the tuned-table hook discriminator. The default identity copy
+    hooks map to ``""`` (back-compat). Any *non-default* hook MUST carry an explicit
+    ``variant`` -- else its tuned configs would silently collide with the default copy
+    hook's, for a kernel with a different access pattern."""
+    if produce is default_produce and consume is default_consume:
+        return variant
+    if not variant:
+        raise ValueError(
+            "a non-default produce/consume hook needs an explicit variant tag so its tuned "
+            "configs don't collide with the default copy hook; pass variant=... "
+            "(e.g. A2A(produce=my_op, variant='myq'))."
+        )
+    return variant
+
+
+def geometry_signature(config: Any, fields: frozenset[str]) -> tuple:
+    """Geometry-defining field values: two configs with the same signature can reuse one
+    transport back-to-back; a different signature on a reused transport is the documented
+    hazard the runtime geometry guard catches. ``fields`` is the per-collective set of
+    knobs that change the physical staging geometry."""
+    return tuple(getattr(config, f) for f in sorted(fields))
+
+
+def nondefault_inapplicable_fields(
+    config: Any,
+    *,
+    core_fields: frozenset[str],
+    primitive_applies: dict[str, frozenset[str]],
+    default: Any,
+) -> set[str]:
+    """Names of fields ``config`` sets to a NON-default value that its ``primitive`` does not
+    consume at launch (empty == honest). Shared skeleton for the per-backend feasibility
+    filter; the backend passes its ``core_fields`` / ``primitive_applies`` map / ``default``
+    config. ``num_blocks`` and ``primitive`` are always excluded (grid axes, not knobs)."""
+    applies = primitive_applies.get(config.primitive, frozenset())
+    checked = core_fields - {"num_blocks", "primitive"}
+    return {
+        name
+        for name in checked
+        if name not in applies and getattr(config, name) != getattr(default, name)
+    }
+
+
+def check_geometry(
+    transport: Any, config: Any, fields: frozenset[str], *, collective: str
+) -> None:
+    """Guard against an unsafe staging-geometry switch on a reused transport (both backends).
+
+    The kernel's persistent step counters + shared staging buffer make back-to-back launches
+    safe only when the geometry-defining ``fields`` are unchanged (see ``geometry_signature``).
+    Switching geometry on the same transport without a drain reinterprets in-flight bytes; the
+    framework has no runtime drain, so this guard surfaces the hazard.
+
+    A geometry switch on a reused transport is a hard error by default: there is no runtime
+    drain, so reinterpreting in-flight bytes silently corrupts staging data and a warn-and-
+    proceed default would let that corruption through unnoticed. ``COMMS_DSL_ALLOW_GEOMETRY_SWITCH=1``
+    downgrades it to a silent advance for callers whose successive launches are device-sync-
+    separated (a benchmark / tuner sweeping configs at one size) -- they know no bytes are in
+    flight across the switch. The transport is a non-frozen dataclass, so we stash the last
+    accepted geometry on it directly (private attr).
+
+    ``collective`` names the calling collective (e.g. ``"all_to_all"``) purely to attribute the
+    hazard in the error message; this module is collective-agnostic, so it is required rather
+    than defaulted -- a baked-in default would misattribute a different collective's hazard.
+    """
+    sig = geometry_signature(config, fields)
+    prev = getattr(transport, "_last_geometry_signature", None)
+    # The cache advances only on an accepted switch: reseeding the baseline before the raise
+    # would let the next (still hazardous) switch slip through unflagged.
+    if prev is None or prev == sig:
+        transport._last_geometry_signature = (
+            sig  # pyre-ignore[16]: runtime cache on the transport
+        )
+        return
+    if os.environ.get("COMMS_DSL_ALLOW_GEOMETRY_SWITCH") == "1":
+        transport._last_geometry_signature = sig  # pyre-ignore[16]: runtime cache
+        return
+    names = sorted(fields)
+    raise ValueError(
+        f"{collective}: staging geometry changed on a reused transport "
+        f"({dict(zip(names, prev))} -> {dict(zip(names, sig))}). There is no runtime drain yet, "
+        "so back-to-back calls of differing geometry on one transport (without an intervening "
+        "device sync) would corrupt in-flight staging data. Use a fresh transport per "
+        "geometry/shape, or set COMMS_DSL_ALLOW_GEOMETRY_SWITCH=1 if your calls are sync-separated."
+    )
+
+
+@dataclass(frozen=True)
+class BaseTunableConfig:
+    """Base tunable config shared across backends.
+
+    Subclasses add backend-specific core fields.
+    """
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "BaseTunableConfig":
+        # Subclasses override to construct their core fields.
+        return cls(**data)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True)
+class BaseTuningKey:
+    """Base lookup key shared across backends.
+
+    The base stays backend-neutral: subclasses set the ``backend`` field (e.g. the Triton
+    ``A2AKey`` defaults it to ``"triton"``). A table entry that does not name a backend is
+    attributed to the loading adapter's backend on the deserialization path (see
+    ``BaseAdapterMixin.key_from_json``), not here -- a default baked into the agnostic base
+    would silently mislabel a different backend's key.
+    """
+
+    world_size: int
+    dtype: str
+    numel: int
+    rows: int
+    transport_kind: str
+    device: str = ""
+    backend: str = ""
+    variant: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "BaseTuningKey":
+        return cls(**data)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True)
+class BaseInputSpec:
+    """Serializable input spec shared across backends."""
+
+    numel: int
+    dtype: torch.dtype
+    rows: int = 0
+
+    def to_json_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        # torch.dtype -> string for JSON
+        d["dtype"] = str(self.dtype).removeprefix("torch.")
+        return d
+
+    @classmethod
+    def from_json_dict(cls, data: dict[str, Any]) -> "BaseInputSpec":
+        dtype_str = data["dtype"]
+        dtype = getattr(torch, dtype_str) if isinstance(dtype_str, str) else dtype_str
+        return cls(
+            numel=int(data["numel"]),
+            dtype=dtype,
+            rows=int(data.get("rows", 0)),
+        )
+
+
+def expand_config_grid(
+    grid: dict[str, list[Any]],
+    config_cls: type,
+    core_fields: frozenset[str],
+) -> list[Any]:
+    """Expand a flat ``{field: [values]}`` grid into the cartesian product of config objects.
+
+    Every grid key must name a declared core config field; an unknown name is rejected.
+    The single grid-expansion implementation, shared by
+    ``BaseAdapterMixin.expand_candidate_grid`` and the per-backend grid helpers.
+    """
+    unknown = [k for k in grid if k not in core_fields]
+    if unknown:
+        raise ValueError(
+            f"unknown grid field(s) {unknown}; allowed: {sorted(core_fields)}"
+        )
+    keys = list(grid)
+    values = [grid[k] for k in keys]
+    return [
+        config_cls(**dict(zip(keys, combo))) for combo in itertools.product(*values)
+    ]
+
+
+class BaseAdapterMixin:
+    """Shared adapter helpers for tuner adapters across backends.
+
+    Subclasses must define:
+      - core_config_fields: frozenset of core tunable field names
+      - config_cls
+      - key_cls
+      - spec_cls
+      - backend_name: str e.g. "triton" or "cute"
+    and implement backend-specific abstract methods: enumerate_candidate_configs core logic,
+    run_candidate, make_inputs, etc. This mixin provides shared JSON, render, expand, and key building.
+    """
+
+    # To be overridden by subclasses
+    core_config_fields: frozenset[str] = frozenset()
+    config_cls: type = BaseTunableConfig
+    key_cls: type = BaseTuningKey
+    spec_cls: type = BaseInputSpec
+    backend_name: str = ""
+
+    # Shared helpers below – subclasses may override for customization
+
+    def expand_candidate_grid(self, grid: dict[str, list[Any]]) -> list[Any]:
+        """Expand declarative grid into list of config objects."""
+        return expand_config_grid(grid, self.config_cls, self.core_config_fields)
+
+    def make_key_from_spec(
+        self,
+        spec: BaseInputSpec,
+        world_size: int,
+        transport_kind: str,
+        device: str,
+        variant: str,
+    ) -> BaseTuningKey:
+        # dtype string normalization
+        dtype_str = (
+            spec.dtype
+            if isinstance(spec.dtype, str)
+            else str(spec.dtype).removeprefix("torch.")
+        )
+        return self.key_cls(
+            world_size=world_size,
+            dtype=dtype_str,
+            numel=spec.numel,
+            rows=spec.rows,
+            transport_kind=transport_kind,
+            device=device,
+            backend=self.backend_name,
+            variant=variant,
+        )
+
+    def key_to_json(self, key: BaseTuningKey) -> tuple[str, dict[str, Any]]:
+        return (type(key).__name__, asdict(key))
+
+    def key_from_json(self, key_type: str, data: dict[str, Any]) -> BaseTuningKey:
+        # key_type ignored, we trust subclass key_cls.
+        data = dict(data)
+        # A table entry that does not name a backend is attributed to this adapter's backend
+        # (set by the subclass) and flagged, rather than assuming a backend in the base.
+        if not data.get("backend") and self.backend_name:
+            logger.warning(
+                "tuned-table key missing 'backend'; backfilling %r", self.backend_name
+            )
+            data["backend"] = self.backend_name
+        return self.key_cls(**data)
+
+    def config_to_json(self, config: BaseTunableConfig) -> tuple[str, dict[str, Any]]:
+        return (type(config).__name__, asdict(config))
+
+    def config_from_json(
+        self, config_type: str, data: dict[str, Any]
+    ) -> BaseTunableConfig:
+        return self.config_cls(**data)
+
+    def spec_to_json(self, spec: BaseInputSpec) -> tuple[str, dict[str, Any]]:
+        return ("BaseInputSpec", spec.to_json_dict())
+
+    def spec_from_json(self, spec_type: str, data: dict[str, Any]) -> BaseInputSpec:
+        # Subclass may override to return its specific spec subclass; base returns BaseInputSpec
+        return self.spec_cls.from_json_dict(data)
+
+    def render_key(self, key_type: str, key_dict: dict[str, Any]) -> str:
+        # Build dynamic string template preserving core order for readability.
+        base_order = [
+            "world_size",
+            "dtype",
+            "numel",
+            "rows",
+            "transport_kind",
+            "device",
+            "backend",
+            "variant",
+        ]
+        parts = []
+        for f in base_order:
+            if f in key_dict:
+                v = key_dict[f]
+                parts.append(f"{f}={v!r}" if isinstance(v, str) else f"{f}={v}")
+        return f"{key_type}({', '.join(parts)})"
+
+    def render_config(self, config_type: str, config_dict: dict[str, Any]) -> str:
+        # Subclass should override core order; base does generic sorted keys.
+        items = sorted(
+            config_dict.items()
+        )  # subclasses likely override for pretty order
+        parts = [f"{k}={v!r}" if isinstance(v, str) else f"{k}={v}" for k, v in items]
+        return f"{config_type}({', '.join(parts)})"

--- a/comms/dsl/tuning_base.py
+++ b/comms/dsl/tuning_base.py
@@ -1,0 +1,384 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""DSL-agnostic tuning base: shared Config / Key / Spec / Adapter mixin for backends.
+
+This layer owns everything the backends share: the tunable Config / lookup Key /
+input Spec dataclasses, their JSON roundtrip, rendering, and the dict-grid candidate
+expansion. Backends inherit and add their core fields. A generated-table entry that
+does not name a backend is attributed to the loading adapter's backend.
+"""
+
+from __future__ import annotations
+
+import importlib
+import itertools
+import logging
+import os
+import re
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import torch
+
+try:  # optional dep: the comms-owned tuner engine; absent until comm_tuning lands.
+    # pyre-ignore[21]: optional dependency, resolved at runtime when the tuner is present.
+    from comm_tuning.adapter import CommKernelTuningAdapter as _CommTunerBase
+except ImportError:  # the adapter base is still importable/testable without the engine
+    _CommTunerBase = object
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _device_tag(device: torch.device | int | str | None = None) -> str:
+    """Short, stable hardware tag for the tuning key (e.g. ``H100``, ``GB300``,
+    ``B200``, ``A100``). Tuned configs are hardware-specific -- the best launch config
+    differs by GPU/NVLink generation -- so the key includes the device so an H100-tuned
+    table and a GB300-tuned table coexist in one map instead of colliding on identical
+    (world_size, dtype, numel, rows, transport) keys. Backend-agnostic, so both DSLs build
+    an identical tag; MUST be computed identically offline (tuner) and at runtime (lookup).
+    """
+    try:
+        name = torch.cuda.get_device_name(device)  # e.g. "NVIDIA H100", "NVIDIA GB300"
+    except (RuntimeError, ValueError, AssertionError):
+        # torch raises RuntimeError when CUDA is unavailable / the index is out of range,
+        # ValueError for a non-CUDA device (e.g. a CPU tensor's device), and AssertionError
+        # on a bad device arg; "unknown" is the intended fallback only for those. Anything
+        # else is a real bug and must not be folded into a tuning key.
+        return "unknown"
+    # The (?!\d) lookahead stops a 4-digit model (e.g. "RTX A6000") from partial-matching
+    # to "A600"; such names fall through to the readable cleaned-name path instead.
+    m = re.search(r"(GB\d{3}|GH\d{3}|B\d{3}|H\d{3}|A\d{3})(?!\d)", name.upper())
+    return m.group(1) if m else name.replace(" ", "_")
+
+
+# Default per-rank message-size ladder for the autotuner: the 32 B .. 2 GB 2x ladder (27 sizes)
+# plus 48 MB / 96 MB for mid-band resolution where the launch-config dip lives = 29 sizes. The
+# best launch config shifts across sizes, so each is tuned independently; mirrors the benchmark
+# size sweep. Used by the adapter's enumerate_input_specs when no explicit shapes are given.
+SIZE_LADDER: tuple[int, ...] = (
+    32,
+    64,
+    128,
+    256,
+    512,
+    1024,
+    2 * 1024,
+    4 * 1024,
+    8 * 1024,
+    16 * 1024,
+    32 * 1024,
+    64 * 1024,
+    128 * 1024,
+    256 * 1024,
+    512 * 1024,
+    1 * 1024 * 1024,
+    2 * 1024 * 1024,
+    4 * 1024 * 1024,
+    8 * 1024 * 1024,
+    16 * 1024 * 1024,
+    32 * 1024 * 1024,
+    48 * 1024 * 1024,
+    64 * 1024 * 1024,
+    96 * 1024 * 1024,
+    128 * 1024 * 1024,
+    256 * 1024 * 1024,
+    512 * 1024 * 1024,
+    1024 * 1024 * 1024,
+    2 * 1024 * 1024 * 1024,
+)
+
+
+def import_obj(path: str):
+    """Resolve a ``module:attr`` import path to the object, for CLI ``--produce`` /
+    ``--reference`` so a user can tune a custom hook with no adapter file."""
+    mod, _, name = path.partition(":")
+    if not mod or not name:
+        raise ValueError(f"expected 'module:attr', got {path!r}")
+    return getattr(importlib.import_module(mod), name)
+
+
+def resolve_variant(
+    produce, consume, variant: str, *, default_produce, default_consume
+) -> str:
+    """Single chokepoint for the tuned-table hook discriminator. The default identity copy
+    hooks map to ``""`` (back-compat). Any *non-default* hook MUST carry an explicit
+    ``variant`` -- else its tuned configs would silently collide with the default copy
+    hook's, for a kernel with a different access pattern."""
+    if produce is default_produce and consume is default_consume:
+        return variant
+    if not variant:
+        raise ValueError(
+            "a non-default produce/consume hook needs an explicit variant tag so its tuned "
+            "configs don't collide with the default copy hook; pass variant=... "
+            "(e.g. A2A(produce=my_op, variant='myq'))."
+        )
+    return variant
+
+
+def geometry_signature(config: Any, fields: frozenset[str]) -> tuple:
+    """Geometry-defining field values: two configs with the same signature can reuse one
+    transport back-to-back; a different signature on a reused transport is the documented
+    hazard the runtime geometry guard catches. ``fields`` is the per-collective set of
+    knobs that change the physical staging geometry."""
+    return tuple(getattr(config, f) for f in sorted(fields))
+
+
+def nondefault_inapplicable_fields(
+    config: Any,
+    *,
+    core_fields: frozenset[str],
+    primitive_applies: dict[str, frozenset[str]],
+    default: Any,
+) -> set[str]:
+    """Names of fields ``config`` sets to a NON-default value that its ``primitive`` does not
+    consume at launch (empty == honest). Shared skeleton for the per-backend feasibility
+    filter; the backend passes its ``core_fields`` / ``primitive_applies`` map / ``default``
+    config. ``num_blocks`` and ``primitive`` are always excluded (grid axes, not knobs)."""
+    applies = primitive_applies.get(config.primitive, frozenset())
+    checked = core_fields - {"num_blocks", "primitive"}
+    return {
+        name
+        for name in checked
+        if name not in applies and getattr(config, name) != getattr(default, name)
+    }
+
+
+def check_geometry(transport: Any, config: Any, fields: frozenset[str]) -> None:
+    """Guard against an unsafe staging-geometry switch on a reused transport (both backends).
+
+    The kernel's persistent step counters + shared staging buffer make back-to-back launches
+    safe only when the geometry-defining ``fields`` are unchanged (see ``geometry_signature``).
+    Switching geometry on the same transport without a drain reinterprets in-flight bytes; the
+    framework has no runtime drain, so this guard surfaces the hazard.
+
+    A geometry switch on a reused transport is a hard error by default: there is no runtime
+    drain, so reinterpreting in-flight bytes silently corrupts staging data and a warn-and-
+    proceed default would let that corruption through unnoticed. ``COMMS_DSL_ALLOW_GEOMETRY_SWITCH=1``
+    downgrades it to a silent advance for callers whose successive launches are device-sync-
+    separated (a benchmark / tuner sweeping configs at one size) -- they know no bytes are in
+    flight across the switch. The transport is a non-frozen dataclass, so we stash the last
+    accepted geometry on it directly (private attr).
+    """
+    sig = geometry_signature(config, fields)
+    prev = getattr(transport, "_last_geometry_signature", None)
+    # The cache advances only on an accepted switch: reseeding the baseline before the raise
+    # would let the next (still hazardous) switch slip through unflagged.
+    if prev is None or prev == sig:
+        transport._last_geometry_signature = (
+            sig  # pyre-ignore[16]: runtime cache on the transport
+        )
+        return
+    if os.environ.get("COMMS_DSL_ALLOW_GEOMETRY_SWITCH") == "1":
+        transport._last_geometry_signature = sig  # pyre-ignore[16]: runtime cache
+        return
+    names = sorted(fields)
+    raise ValueError(
+        "all_to_all: staging geometry changed on a reused transport "
+        f"({dict(zip(names, prev))} -> {dict(zip(names, sig))}). There is no runtime drain yet, "
+        "so back-to-back calls of differing geometry on one transport (without an intervening "
+        "device sync) would corrupt in-flight staging data. Use a fresh transport per "
+        "geometry/shape, or set COMMS_DSL_ALLOW_GEOMETRY_SWITCH=1 if your calls are sync-separated."
+    )
+
+
+@dataclass(frozen=True)
+class BaseTunableConfig:
+    """Base tunable config shared across backends.
+
+    Subclasses add backend-specific core fields.
+    """
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "BaseTunableConfig":
+        # Subclasses override to construct their core fields.
+        return cls(**data)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True)
+class BaseTuningKey:
+    """Base lookup key shared across backends.
+
+    The base stays backend-neutral: subclasses set the ``backend`` field (e.g. the Triton
+    ``A2AKey`` defaults it to ``"triton"``). A table entry that does not name a backend is
+    attributed to the loading adapter's backend on the deserialization path (see
+    ``BaseAdapterMixin.key_from_json``), not here -- a default baked into the agnostic base
+    would silently mislabel a different backend's key.
+    """
+
+    world_size: int
+    dtype: str
+    numel: int
+    rows: int
+    transport_kind: str
+    device: str = ""
+    backend: str = ""
+    variant: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "BaseTuningKey":
+        return cls(**data)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True)
+class BaseInputSpec:
+    """Serializable input spec shared across backends."""
+
+    numel: int
+    dtype: torch.dtype
+    rows: int = 0
+
+    def to_json_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        # torch.dtype -> string for JSON
+        d["dtype"] = str(self.dtype).removeprefix("torch.")
+        return d
+
+    @classmethod
+    def from_json_dict(cls, data: dict[str, Any]) -> "BaseInputSpec":
+        dtype_str = data["dtype"]
+        dtype = getattr(torch, dtype_str) if isinstance(dtype_str, str) else dtype_str
+        return cls(
+            numel=int(data["numel"]),
+            dtype=dtype,
+            rows=int(data.get("rows", 0)),
+        )
+
+
+def expand_config_grid(
+    grid: dict[str, list[Any]],
+    config_cls: type,
+    core_fields: frozenset[str],
+) -> list[Any]:
+    """Expand a flat ``{field: [values]}`` grid into the cartesian product of config objects.
+
+    Every grid key must name a declared core config field; an unknown name is rejected.
+    The single grid-expansion implementation, shared by
+    ``BaseAdapterMixin.expand_candidate_grid`` and the per-backend grid helpers.
+    """
+    unknown = [k for k in grid if k not in core_fields]
+    if unknown:
+        raise ValueError(
+            f"unknown grid field(s) {unknown}; allowed: {sorted(core_fields)}"
+        )
+    keys = list(grid)
+    values = [grid[k] for k in keys]
+    return [
+        config_cls(**dict(zip(keys, combo))) for combo in itertools.product(*values)
+    ]
+
+
+class BaseAdapterMixin:
+    """Shared adapter helpers for tuner adapters across backends.
+
+    Subclasses must define:
+      - core_config_fields: frozenset of core tunable field names
+      - config_cls
+      - key_cls
+      - spec_cls
+      - backend_name: str e.g. "triton" or "cute"
+    and implement backend-specific abstract methods: enumerate_candidate_configs core logic,
+    run_candidate, make_inputs, etc. This mixin provides shared JSON, render, expand, and key building.
+    """
+
+    # To be overridden by subclasses
+    core_config_fields: frozenset[str] = frozenset()
+    config_cls: type = BaseTunableConfig
+    key_cls: type = BaseTuningKey
+    spec_cls: type = BaseInputSpec
+    backend_name: str = ""
+
+    # Shared helpers below – subclasses may override for customization
+
+    def expand_candidate_grid(self, grid: dict[str, list[Any]]) -> list[Any]:
+        """Expand declarative grid into list of config objects."""
+        return expand_config_grid(grid, self.config_cls, self.core_config_fields)
+
+    def make_key_from_spec(
+        self,
+        spec: BaseInputSpec,
+        world_size: int,
+        transport_kind: str,
+        device: str,
+        variant: str,
+    ) -> BaseTuningKey:
+        # dtype string normalization
+        dtype_str = (
+            spec.dtype
+            if isinstance(spec.dtype, str)
+            else str(spec.dtype).removeprefix("torch.")
+        )
+        return self.key_cls(
+            world_size=world_size,
+            dtype=dtype_str,
+            numel=spec.numel,
+            rows=spec.rows,
+            transport_kind=transport_kind,
+            device=device,
+            backend=self.backend_name,
+            variant=variant,
+        )
+
+    def key_to_json(self, key: BaseTuningKey) -> tuple[str, dict[str, Any]]:
+        return (type(key).__name__, asdict(key))
+
+    def key_from_json(self, key_type: str, data: dict[str, Any]) -> BaseTuningKey:
+        # key_type ignored, we trust subclass key_cls.
+        data = dict(data)
+        # A table entry that does not name a backend is attributed to this adapter's backend
+        # (set by the subclass) and flagged, rather than assuming a backend in the base.
+        if not data.get("backend") and self.backend_name:
+            logger.warning(
+                "tuned-table key missing 'backend'; backfilling %r", self.backend_name
+            )
+            data["backend"] = self.backend_name
+        return self.key_cls(**data)
+
+    def config_to_json(self, config: BaseTunableConfig) -> tuple[str, dict[str, Any]]:
+        return (type(config).__name__, asdict(config))
+
+    def config_from_json(
+        self, config_type: str, data: dict[str, Any]
+    ) -> BaseTunableConfig:
+        return self.config_cls(**data)
+
+    def spec_to_json(self, spec: BaseInputSpec) -> tuple[str, dict[str, Any]]:
+        return ("BaseInputSpec", spec.to_json_dict())
+
+    def spec_from_json(self, spec_type: str, data: dict[str, Any]) -> BaseInputSpec:
+        # Subclass may override to return its specific spec subclass; base returns BaseInputSpec
+        return self.spec_cls.from_json_dict(data)
+
+    def render_key(self, key_type: str, key_dict: dict[str, Any]) -> str:
+        # Build dynamic string template preserving core order for readability.
+        base_order = [
+            "world_size",
+            "dtype",
+            "numel",
+            "rows",
+            "transport_kind",
+            "device",
+            "backend",
+            "variant",
+        ]
+        parts = []
+        for f in base_order:
+            if f in key_dict:
+                v = key_dict[f]
+                parts.append(f"{f}={v!r}" if isinstance(v, str) else f"{f}={v}")
+        return f"{key_type}({', '.join(parts)})"
+
+    def render_config(self, config_type: str, config_dict: dict[str, Any]) -> str:
+        # Subclass should override core order; base does generic sorted keys.
+        items = sorted(
+            config_dict.items()
+        )  # subclasses likely override for pretty order
+        parts = [f"{k}={v!r}" if isinstance(v, str) else f"{k}={v}" for k, v in items]
+        return f"{config_type}({', '.join(parts)})"


### PR DESCRIPTION
Summary:

Second layer of the lean CuTe-only comms/dsl stack. Adds the backend-neutral autotuning spine `tuning_base` (`BaseTunableConfig` / `BaseTuningKey` / grid expansion / `geometry_signature` + the P0 staging-geometry guard `check_geometry`) and the collective-specific-but-DSL-agnostic `a2a_base.BaseA2AAdapter` — the shared all_to_all adapter lifecycle (CLI args, shape/key/input enumeration, NCCL reference + bit-exact correctness gate, serialization) that both DSL backends subclass. Kept strictly backend-neutral so a second DSL reuses it unchanged.

Reviewed By: Scusemua

Differential Revision: D110302961


