### PR TITLE
comms/dsl: CuTe a2a benchmark (SM-matched, CUDA-graph) + MAST launcher + UniBench sink (#3466)

### DIFF
--- a/comms/dsl/README.md
+++ b/comms/dsl/README.md
@@ -1,10 +1,10 @@
 # comms/dsl: customized collectives without the plumbing - a hook in, an autotuned kernel out
 
-`comms/dsl` framework lets a kernel developer (user) build a customized, autotunable collective in DSLs (Triton or CuTe) by writing only the small part that differentiates their kernel: per-tile hooks and optionally transports, while the framework owns the generic ~95% (schedule, multi-peer addressing, signal/wait protocol) and automates the performance tuning.
+`comms/dsl` framework lets a kernel developer (user) build a customized, autotunable collective in a DSL (CuTe today; the façade is backend-parametrized so Triton can be re-added) by writing only the small part that differentiates their kernel: per-tile hooks and optionally transports, while the framework owns the generic ~95% (schedule, multi-peer addressing, signal/wait protocol) and automates the performance tuning.
 
 ## Why
 
-Researchers prototype new ideas as kernels in DSLs like Triton/CuTe instead of CUDA/C++ for the fast iteration loop. Scaling the idea needs communication, and that usually leads to repetitive work: days-to-weeks of race-prone stage/signal/wait/fence logic, re-derived per kernel, with bugs that could pass tests and fail at scale. Notably, the part that differentiates the kernel is typically small: a transpose, a quantize, or an accumulate, while a lot around it is plumbing.
+Researchers prototype new ideas as kernels in DSLs like CuTe/Triton instead of CUDA/C++ for the fast iteration loop. Scaling the idea needs communication, and that usually leads to repetitive work: days-to-weeks of race-prone stage/signal/wait/fence logic, re-derived per kernel, with bugs that could pass tests and fail at scale. Notably, the part that differentiates the kernel is typically small: a transpose, a quantize, or an accumulate, while a lot around it is plumbing.
 
 For instance, the `all_to_all_single_non_contig` kernel is ~800 lines, of which roughly 95% is generic machinery, including the signaling protocol, the pipeline, symmetric-memory staging, multi-peer addressing, and tile-size math. The remaining ~5% is layout transform, which is what really makes this kernel unique.
 
@@ -17,9 +17,9 @@ comms/dsl breaks both loops. It provides the customizable boilerplate, and it tu
 | Piece | What it is |
 |---|---|
 | **Transport** | A fabric binding (NVLink today, IB later): cross-GPU memory + signaling state, created once via a `rendezvous` over PyTorch symmetric memory. The framework ships defaults and the user either sets one up or could provide their own. |
-| **Endpoint (`PeerEndpoint`)** | How the transport hands a schedule per-peer addresses - `send_dst` (where to write into a peer), `recv_src` (where to read its data), and the signal slots - so no schedule touches raw pointers. Two forms: a host-resolved `PeerEndpoint` for a single peer (used by `send_tile`/`recv_tile`), and a device-side table of all peers that a fused collective indexes by peer in-kernel (e.g. `all_to_all`). |
+| **Endpoint (`PeerEndpoint`)** | How the transport hands a schedule per-peer addresses - `send_dst` (where to write into a peer), `recv_src` (where to read its data), and the signal slots - so no schedule touches raw pointers. Two forms: a host-resolved `PeerEndpoint` for a single peer (used by `send_tiles`/`recv_tiles`), and a device-side table of all peers that a fused collective indexes by peer in-kernel (e.g. `all_to_all`). |
 | **Ops** | The transport's four device functions that act on those addresses: `put` (remote write), `get` (local read), `signal`/`wait` (the data-ready handshake). The only fabric-specific (NVLink vs IB) device code; hooks and schedules call them and stay transport-agnostic. |
-| **Hook + `Ctx`** | The 5% the user writes: `produce(ctx) -> tile` and `consume(ctx, tile)`. `Ctx` is the per-tile view the framework hands the hook - input/output pointer, flat index, mask, and within-chunk position. This is where a transpose / gather / quantize / accumulate goes. |
+| **Hook + `Ctx`** | The 5% the user writes, in **two tiers**. *Per-element / value* — `produce(ctx) -> tile` / `consume(ctx, tile)`: a per-thread transform on the tile *value* (scale / quantize / accumulate), over the per-tile `Ctx` (CuTe exposes `part`/`atom` + read-only facts `coord`/`peer`). *Block-tile / layout* — `layout_hook(bctx)`: a CTA-cooperative transform over a SMEM-staged 2D tile (`BlockCtx` exposes the loaded tile `sA` + tile coords), for coalescing-critical layout changes (transpose / permute / reshape) where a per-element gather would go uncoalesced. The framework owns the coalesced SMEM load + barriers; the hook does the in-SMEM transform. The portable contract is the hook *role*; the field set is per-DSL, so a hook body is written against its backend's `Ctx`. |
 | **Collective** | The shipped schedule (e.g. `all_to_all`) that runs the hook over the fused `peer x block` transfer, owning all addressing and signal/wait. |
 | **`Config` + `Key`** | `Config` = the launch tunables the autotuner sweeps; `Key` = how a tuned config is looked up at runtime. Both are defined by the user (see principles). |
 | **Adapter** | A thin class that plugs a collective into the comms-owned tuner engine (`comm_tuning`). |
@@ -28,10 +28,10 @@ Flow: a `Transport` gives the kernel per-peer addresses; the `Collective` loops 
 
 ## Design principles
 
-- Own the 95%, expose the 5%. The framework owns the schedule and the race-prone protocol; the user writes a per-tile `produce`/`consume` hook (transpose, gather, quantize, accumulate) and supplies a transport. No fences, no wait loops, no deadlock reasoning in user code.
+- Own the 95%, expose the 5%. The framework owns the schedule and the race-prone protocol; the user writes a hook — a per-element `produce`/`consume` value transform (quantize, scale, accumulate) or a block-tile `layout_hook` (transpose, permute, reshape) — and supplies a transport. No fences, no wait loops, no deadlock reasoning in user code.
 - Performance is autotuned, and the tuner is generic. The user declares two things: a `Key` (which input properties should map to one tuned config - size, dtype, world size, layout, whatever matters for that kernel) and a `Config` (the launch knobs to sweep). A shared engine sweeps configs offline and emits a `{Key: Config}` map; at runtime the collective rebuilds the same key and looks it up (safe default if absent). Changing shapes means re-running the tuner, not rewriting the kernel.
-- Spectrum of control. Plug-and-play collective (write a hook) -> `send_tile`/`recv_tile` (keep your own schedule) -> raw `put`/`get`/`signal`/`wait` ops (full control). Climb only as high as you need.
-- Contracts shared, code per-DSL. Triton and CuTe share the same op names, hook roles, and Config/Key shapes; the device kernels are written per DSL (flat pointers vs partitions), since device code is not portable across DSLs.
+- Spectrum of control. Plug-and-play collective (write a hook) -> `send_tiles`/`recv_tiles` (keep your own schedule) -> raw `put`/`get`/`signal`/`wait` ops (full control). Climb only as high as you need.
+- Backend-parametrized, code per-DSL. The transport contract, hook roles, lookup `Key` shape, and the `comms.dsl.collectives` façade are DSL-agnostic; the `Config` launch knobs and the device kernels are per-DSL (partitions, DSL-specific tunables), since device code is not portable across DSLs. CuTe is the shipped backend; the façade keeps a `backend=` seam so a second DSL (Triton) re-registers without touching callers.
 
 ## Example: a custom collective (a2a non-contig), end to end
 
@@ -43,60 +43,63 @@ A transport, one hook, one call:
 
 ```python
 from comms.dsl import nvl_rendezvous
-from comms.dsl.triton import all_to_all
-from comms.dsl.triton.hooks import transpose_produce   # the 5%: the layout transform
+from comms.dsl.cute import all_to_all
 
 t = nvl_rendezvous(group, dev, per_peer_bytes=chunk_bytes)   # transport (staging + signaling)
-all_to_all(t, out, inp, produce=transpose_produce, rows=R)   # config=None -> tuned lookup
+all_to_all(t, out, inp, rows=R)                              # config=None -> tuned lookup
 ```
 
-`nvl_rendezvous` allocates the per-peer staging buffer + signal pad once; `rows` describes the 2D tile layout the hook reads; with no `produce` hook this is a plain all-to-all.
+`nvl_rendezvous` allocates the per-peer staging buffer + signal pad once; `rows` describes the 2D tile layout the hook reads; with the default identity copy hook this is a plain all-to-all.
 
-The hook is the 5%. `ctx` is the per-tile view (input pointer, flat index, mask, within-chunk position `pos` with `rows`/`cols`); it returns the tile to send - here, the transposed source position, fused into the transfer leg with no extra HBM pass:
+The hook is the 5%, in two tiers. A **per-element** `produce`/`consume` transforms the tile *value* (scale / quantize / accumulate). The `rows > 0` transpose is the flagship **block-tile** hook (`transpose_tile`): the framework coalesced-loads each `[tile, tile]` chunk into padded SMEM and barriers (via the shared substrate leaf `_block_tile_u`, the block-tile twin of the value leaf `_send_u`), and the hook coalesced-stores it transposed — both gmem legs stay coalesced, unlike a per-element gather (the CuTe twin of genai's on-chip `tl.trans`). The transpose SMEM tile is `32x32`, so `rows > 0` has a `2KB` floor (a sub-tile transpose is degenerate); plain (`rows=0`) a2a still goes down to `32B`.
 
-```python
-@triton.jit
-def transpose_produce(ctx):
-    r = ctx.pos % ctx.rows           # position in the transposed [cols, rows] layout
-    c = ctx.pos // ctx.rows
-    src = r * ctx.cols + c           # source position in the [rows, cols] layout
-    base = ctx.idx - ctx.pos         # chunk base in the input
-    return tl.load(ctx.ptr + base + src, mask=ctx.mask)
-```
+The framework runs the fused `peer x block` schedule (multi-peer addressing, signal/wait) in one launch, validated bit-exact against `dist.all_to_all_single`.
 
-The framework runs the fused `peer x block` schedule (multi-peer addressing, signal/wait) in one launch, validated bit-exact against `dist.all_to_all_single` on 4 ranks.
+> **Backend note (honest scope).** The per-element `produce`/`consume` value hooks (scale / quantize / accumulate) run on the CuTe copy-staging schedule, and are **proven reusable across collectives** — the same value leaf (`_send_u`/`_send_slot`) is composed by both `all_to_all` and the standalone `send_tiles`/`recv_tiles`. The block-tile `rows > 0` transpose (the non-contiguous headline) ships on the **zero-copy transfer** (`all_to_all(rows=R)` auto-selects an orchestrated mid-band / fused large-band kernel, both composing the shared `_block_tile_u` leaf), on-par-or-exceeding genai across `0.5MB–128MB` on 8×GB300 (bit-exact, SM-matched). The block-tile tier ships today as the `BlockCtx` contract + `_block_tile_u` leaf + this **a2a reference**; reuse across other collectives is a documented backlog item (unlike the value tier). A fused copy-staged block-tile variant was evaluated and removed as send-leg-bound at the mid band (archived; see the CuTe backend notes). The TMA bulk-copy and raw zero-copy (`direct`/`ce`) paths move raw bytes and apply no hook.
 
 ### 2. Autotune it
 
-Write one thin adapter - the engine is generic, so you only declare your `Key` and the `Config`s to sweep:
+No adapter to write - declare the hook on a collective *object* and call `.autotune()`. The object is both the callable collective and the thing that tunes itself, because it already knows its hook, `variant`, candidate search, and correctness reference:
 
 ```python
-class A2ATuningAdapter(CommKernelTuningAdapter):
-    def enumerate_input_specs(self, world_size): ...      # the shapes to tune
-    def make_key(self, spec, world_size): ...             # YOUR key (must match runtime)
-    def enumerate_candidate_configs(self, spec, key): ... # YOUR configs to sweep
-    def make_inputs(self, spec, *, rank, world_size, device): ...   # tensors + nvl_rendezvous
-    def run_candidate(self, inputs, config, group):       # the collective with the tuned config
-        all_to_all(inputs.transport, inputs.output, inputs.input, rows=inputs.rows, config=config)
-        return inputs.output
-    def run_baseline(self, inputs, baseline, group): ...  # e.g. NCCL, the speed baseline
-    def check_correctness(self, candidate, reference): ...
+from comms.dsl.collectives import A2A
+
+# The non-contig transpose: rows>0 selects the block-tile transpose hook, and its own tuned
+# table falls out of the `rows` field in the lookup key (no produce= -- the transpose is a
+# block-tile LAYOUT hook, not a per-element value hook).
+a2a = A2A(
+    backend="cute",
+    reference=transpose_ref,           # (inputs, group)->Tensor; default = nccl identity
+    # candidates=<dict | callable>     # optional; default = shipped expert size-banded grid
+)
+
+a2a(t, out, inp, rows=R)               # callable: config=None -> per-shape tuned lookup
+a2a.autotune(shapes=PROD_SHAPES)       # sweep -> select -> generate (one tuning job)
+
+# A per-element VALUE hook (quantize / scale / accumulate) instead plugs in as produce=/consume=
+# and MUST carry an explicit `variant` so its tuned configs don't collide with the default copy:
+#   A2A(backend="cute", produce=quantize_produce, consume=dequant_consume, variant="fp8")
 ```
 
-Parent mode sweeps every candidate, benchmarks it against your baseline, and checks correctness; select mode picks the winner per key and writes a generated table:
+`.autotune()` drives the comms-owned `comm_tuning` engine and writes the generated table; `__call__` rebuilds the **same** key (including `rows` and `variant`, so the transpose / a custom value hook never reuses the default copy hook's config) and looks it up. The candidate search is pluggable: omit it for the expert default grid, pass a flat `{CuteA2AConfig_field: [values]}` dict (cartesian), or a `(spec, key) -> [CuteA2AConfig]` callable.
 
 ```python
-# comms/dsl/triton/generated/a2a_tuned_configs.py  (generated; do not hand-edit)
-from comms.dsl.triton.collectives_tuning import A2AConfig, A2AKey
+# comms/dsl/cute/a2a/generated/a2a_tuned_configs.py  (generated; do not hand-edit)
+from comms.dsl.cute.a2a.tuning import CuteA2AConfig, CuteA2AKey
 
 TUNED_A2A_CONFIGS = {
-    A2AKey(world_size=8, dtype="bfloat16", numel=8192, rows=0, transport_kind="NvlTransport"):
-        A2AConfig(num_blocks=16, block=2048, num_warps=8),
-    # ... one row per tuned key ...
+    CuteA2AKey(world_size=8, dtype="bfloat16", numel=8192, rows=0,
+               transport_kind="NvlTransport", device="GB300", backend="cute", variant=""):
+        CuteA2AConfig(num_blocks=8, num_threads=512, primitive="copy"),
+    # ... one row per tuned key (per shape x hardware x hook) ...
 }
 ```
 
-Then nothing else changes: the Step 1 call `all_to_all(..., config=None)` rebuilds the key and looks it up, so it now runs the tuned config automatically. When shapes change, re-run the tuner and regenerate the table - no kernel edits.
+Re-tune = re-run `.autotune()`, regenerate the table - no kernel edits.
+
+**Where it runs.** Perf tuning runs on **MAST/conda**, not a local buck par: the DSL JIT-compiles in a conda env, and production shapes (GB300, multi-node, TP=8) only exist on cluster GPUs. So `.autotune()` is the *body of the tuning-job entrypoint*; you launch it with the MAST launcher (`buck2 run //comms/dsl/tests:mast_launch -- --tune ...` -- buck only builds/launches the launcher; MAST runs the sweep). The framework stays buck-importable for single-host correctness tests / CI.
+
+**Reuse contract (M1).** Each `(shape)` should get its own transport; reusing one transport across configs of differing *geometry* (`num_blocks`/`primitive`) is unsafe without a drain, which is not implemented here yet. A runtime guard raises on a geometry switch on a reused transport (no runtime drain, so reinterpreting in-flight bytes would corrupt staging); `COMMS_DSL_ALLOW_GEOMETRY_SWITCH=1` downgrades it to a silent advance for callers whose successive launches are device-sync-separated (a benchmark / tuner sweeping configs at one size). A fully user-declared `Key` (arbitrary fields) and a numel shape-bucket are planned extensions. See `USER_GUIDE.md` for runnable, task-oriented examples of all three usage layers + the autotuner workflow.
 
 ## What the same pattern enables next
 

--- a/comms/dsl/USER_GUIDE.md
+++ b/comms/dsl/USER_GUIDE.md
@@ -1,0 +1,319 @@
+# comms/dsl — User Guide
+
+Build a **customized, autotunable collective** by writing only the part that differs from a plain
+transfer (a per-tile hook), while the framework owns the ~95% plumbing (schedule, multi-peer
+addressing, staging, signal/wait) and turns performance into an autotuner run.
+
+This guide is task-oriented and runnable. It covers the **three layers of control** (call a
+collective → add your hooks → compose your own collective from send/recv primitives) and the
+**auto-tuning** workflow end to end.
+
+---
+
+## 0. Mental model (30 seconds)
+
+| Piece | What it is | You touch it? |
+|---|---|---|
+| **Transport** | Cross-GPU staging + signaling, created once via `nvl_rendezvous` over PyTorch symmetric memory. | Create it (one line). |
+| **Hook + `Ctx`** | The 5% you write: a per-tile transform. Two tiers — **value** (`produce`/`consume`, per-thread) and **block-tile / layout** (`layout_hook`, CTA-cooperative over a SMEM tile). | Write it (optional). |
+| **Collective** | A shipped schedule (`all_to_all`) that runs your hook over the fused `peer × block` transfer. | Call it. |
+| **`Config` + `Key`** | `Config` = launch knobs the tuner sweeps; `Key` = how a tuned config is looked up at runtime. | Autotuner fills these. |
+| **Adapter** | Plugs a collective into the comms-owned tuner (`comm_tuning`). | Not needed for a2a (shipped). |
+
+Import surface:
+
+```python
+from comms.dsl import nvl_rendezvous                      # transport
+from comms.dsl.cute import all_to_all, all_to_all_zc      # collectives
+from comms.dsl.collectives import A2A                     # collective object (callable + .autotune)
+from comms.dsl.cute.send_recv import pipelined_sendrecv   # send/recv primitive (Layer 3)
+import cutlass.cute as cute                               # only if you WRITE a hook
+```
+
+### Shared test harness (used by every example below)
+
+Every example is a `run(rank, ws, group, device)` function. Drive it locally on an 8-GPU host with:
+
+```python
+import os, torch, torch.distributed as dist, torch.multiprocessing as mp
+
+def _spawn(run):
+    def _worker(rank, ws, port):
+        os.environ["MASTER_ADDR"] = "127.0.0.1"; os.environ["MASTER_PORT"] = str(port)
+        torch.cuda.set_device(rank)
+        dist.init_process_group("nccl", rank=rank, world_size=ws)
+        run(rank, ws, dist.group.WORLD, torch.device(f"cuda:{rank}"))
+        dist.barrier(); dist.destroy_process_group()
+    ws = min(torch.cuda.device_count(), 8)
+    mp.spawn(_worker, args=(ws, 29500), nprocs=ws, join=True)
+```
+
+Run a file with `buck2 run @fbcode//mode/opt //your/target -- ...` (single-host correctness/CI).
+Production shapes (GB300, multi-node) run on MAST — see §5.
+
+---
+
+## Layer 1 — Call a shipped collective (simplest)
+
+Plain all-to-all. No hook, no tuning needed: `config=None` looks up the tuned table for this
+(shape, hardware) and falls back to a safe analytic default on a miss.
+
+```python
+from comms.dsl import nvl_rendezvous
+from comms.dsl.cute import all_to_all
+
+def run(rank, ws, group, device):
+    CHUNK = 1 << 20                                  # per-peer elements; numel = ws * CHUNK
+    inp = torch.randn(ws * CHUNK, dtype=torch.bfloat16, device=device)
+    out = torch.empty_like(inp)
+    t = nvl_rendezvous(group, device, per_peer_bytes=CHUNK * inp.element_size())
+    all_to_all(t, out, inp)                          # config=None -> tuned lookup / analytic default
+    # `out` now holds the equal-split all-to-all result (bit-exact vs dist.all_to_all_single).
+```
+
+The built-in **non-contiguous transpose** all-to-all is one argument away — `rows=R` makes each
+received `[rows, cols]` chunk arrive transposed to `[cols, rows]` (this selects the block-tile
+transpose hook under the hood; see Layer 2b):
+
+```python
+    all_to_all(t, out, inp, rows=R)                  # R must divide the per-peer chunk; R, cols multiples of 32
+```
+
+---
+
+## Layer 2 — Add your own hooks
+
+Write the 5% (the transform); the framework runs it inside the fused schedule.
+
+### 2a. Value hook (`produce` / `consume`) — per-thread, e.g. scale / quantize / accumulate
+
+A value hook works in registers on a per-thread tile fragment. `produce` runs on the **send** leg
+(input → fragment), `consume` on the **recv** leg (fragment → output). Bodies are constexpr-traced,
+so constants are baked in.
+
+```python
+import cutlass.cute as cute
+from comms.dsl import nvl_rendezvous
+from comms.dsl.cute import all_to_all
+
+def scale_produce(ctx):                       # send: load input tile, multiply by 2
+    frag = cute.make_fragment_like(ctx.part)  # ctx.part = this thread's tile; ctx.atom = copy atom
+    cute.copy(ctx.atom, ctx.part, frag)
+    frag.store(frag.load() * 2.0)             # <-- your transform (register-only)
+    return frag
+
+def bias_consume(ctx, frag):                  # recv: add 1, store to output tile
+    frag.store(frag.load() + 1.0)
+    cute.copy(ctx.atom, frag, ctx.part)
+
+def run(rank, ws, group, device):
+    CHUNK = 1 << 20
+    inp = torch.randn(ws * CHUNK, dtype=torch.bfloat16, device=device)
+    out = torch.empty_like(inp)
+    t = nvl_rendezvous(group, device, per_peer_bytes=CHUNK * inp.element_size())
+    all_to_all(t, out, inp, produce=scale_produce, consume=bias_consume, variant="scalebias")
+    # out == (all_to_all(inp * 2)) + 1, fused into the transfer leg (no extra HBM pass).
+```
+
+`Ctx` also exposes read-only **facts** for position/peer-dependent transforms: `ctx.coord` (tile
+index), `ctx.peer` (dest/source rank), `ctx.rank` / `ctx.world_size`, `ctx.rows` / `ctx.cols` /
+`ctx.chunk`. A per-peer dequant scale, positional mask, etc. read these without touching machinery.
+
+> Pass `variant="..."` whenever you use a non-default hook — it tags this hook's tuned configs so
+> they don't collide with the default copy hook's (required by `A2A`; see §4).
+
+### 2b. Block-tile / layout hook (`layout_hook`) — CTA-cooperative, e.g. transpose / permute
+
+Coalescing-critical layout changes need the whole CTA to cooperate on a 2D SMEM tile (a per-thread
+gather would be uncoalesced). The framework coalesced-loads a `[tile, tile]` input tile into padded
+SMEM and barriers; **your hook does the in-SMEM transform + coalesced store**. Contract (`BlockCtx`):
+`bctx.sA` (loaded SMEM tile), `bctx.dst` (destination tensor), `bctx.tile`, `bctx.block_rows`,
+`bctx.tx`/`bctx.ty` (this thread's lane/row), `bctx.br`/`bctx.bc` (2D tile coords).
+
+The **shipped block-tile hook is the transpose**, reached via `rows=R` (Layer 1). Its hook body is
+the template for writing your own:
+
+```python
+def transpose_tile(bctx):                     # the shipped reference (comms.dsl.cute.hooks)
+    tile = bctx.tile
+    for r in range(0, tile, bctx.block_rows):
+        bctx.dst[(bctx.bc * tile + bctx.ty + r, bctx.br * tile + bctx.tx)] = \
+            bctx.sA[(bctx.tx, bctx.ty + r)]   # swapped indices = transpose; +1 SMEM pad => no bank conflict
+```
+
+Runnable today (transpose is wired into the public entry):
+
+```python
+def run(rank, ws, group, device):
+    R, COLS = 512, 512                        # per-peer chunk = R*COLS; both multiples of 32
+    inp = torch.randn(ws * R * COLS, dtype=torch.bfloat16, device=device)
+    out = torch.empty_like(inp)
+    t = nvl_rendezvous(group, device, per_peer_bytes=R * COLS * inp.element_size())
+    all_to_all(t, out, inp, rows=R)           # each [R,COLS] chunk arrives transposed to [COLS,R]
+```
+
+> **Scope note (be honest with users):** the block-tile **contract** (`BlockCtx` + `layout_hook`)
+> is general, but the public `all_to_all(rows=R)` currently wires the shipped `transpose_tile`
+> reference. Plumbing an *arbitrary* user block-tile hook (e.g. a permute) through the public entry
+> is a near-term extension; the value-hook tier (2a) is the fully general path today.
+
+---
+
+## Layer 3 — Compose your own collective from send/recv primitives
+
+When you need a schedule the framework doesn't ship (a ring, a custom pattern), drop to the
+**send/recv primitive** and keep the framework's staging + signal/wait + slot pipeline. Your hooks
+still apply.
+
+`pipelined_sendrecv(transport, send_buf, recv_buf, send_peer, recv_peer, *, num_blocks,
+mode="bidir"|"send"|"recv", produce=copy_produce, consume=copy_consume)` — a graph-safe, slot-
+pipelined whole-buffer transfer for one peer pair. Size the transport `per_peer_bytes >= numel*elem`.
+
+Minimal: a neighbor exchange (send to `rank+1`, recv from `rank-1`), optionally with a value hook.
+
+```python
+from comms.dsl import nvl_rendezvous
+from comms.dsl.cute.send_recv import pipelined_sendrecv
+
+def run(rank, ws, group, device):
+    N = 1 << 20
+    send_buf = torch.full((N,), float(rank), dtype=torch.bfloat16, device=device)
+    recv_buf = torch.empty_like(send_buf)
+    t = nvl_rendezvous(group, device, per_peer_bytes=N * send_buf.element_size())
+    pipelined_sendrecv(
+        t, send_buf, recv_buf,
+        send_peer=(rank + 1) % ws, recv_peer=(rank - 1) % ws,
+        num_blocks=8, mode="bidir",
+        # produce=my_produce, consume=my_consume,   # optional: transform in-flight
+    )
+    # recv_buf now holds the previous rank's shard (== (rank-1) % ws).
+```
+
+Compose a **ring all-gather** by looping it `ws-1` steps, rotating the chunk each step (each step is
+one `pipelined_sendrecv`; the framework owns the per-step staging/signal). For the lowest level of
+control, the transport's device ops — `put` / `get` / `signal` / `wait` (`comms.dsl.cute.nvl_ops`) —
+are callable directly inside your own `@cute.kernel`, but that is rarely needed.
+
+---
+
+## 4. Auto-tuning — how it works, and how to run it
+
+The launch parameters that win on one shape/hardware lose on others, so performance is an
+**autotuner run**, not hand-tuning. You do not write a tuner; you drive the comms-owned
+`comm_tuning` engine through a one-line entry.
+
+### What happens under the hood
+
+1. **`A2A(...).autotune()`** hands the engine an adapter that knows your hook, `variant`, candidate
+   search, and a correctness `reference`.
+2. The engine, **per input shape** (a size ladder or your `shapes=`):
+   - builds a **`Key`** = `(world_size, dtype, numel, rows, transport_kind, device, backend, variant)`
+     — the *same* key the runtime rebuilds, so lookups match (no drift);
+   - enumerates **candidate `Config`s** — the shipped expert size-banded grid by default, or your
+     `{field: [values]}` dict (cartesian) or `(spec, key) -> [Config]` callable;
+   - runs each candidate, times it, and **correctness-gates it bit-exact** (`assert_close(atol=0,
+     rtol=0)`) against the `reference` (default = `dist.all_to_all_single`; a transforming hook needs
+     its own reference);
+   - keeps the lowest-latency **correct** candidate for that key.
+3. It writes a generated `{Key: Config}` table (`cute/a2a/generated/a2a_tuned_configs.py`). Commit it.
+4. At runtime, `all_to_all(..., config=None)` rebuilds the key and looks it up; a miss falls back to
+   the safe analytic default. **User code never changes between tuned and untuned.**
+
+The **Config knobs** the tuner sweeps (each defaults to `0` = "use the analytic pick", so the default
+config reproduces the analytic defaults): `num_blocks` (grid = `ws × num_blocks`), `num_threads`,
+`num_slots`, `unroll`, `cluster` / `cluster_y` (CGA), `tma_drain_warps`, and `primitive`
+(`copy` staging / `tma` / `direct` zero-copy / `ce` copy-engine).
+
+### Tuning a shipped collective (no code)
+
+```python
+# tune_my_a2a.py  — the body of the tuning-job entrypoint
+from comms.dsl.collectives import A2A
+A2A(backend="cute").autotune()          # default copy hook = plain a2a
+```
+
+### Tuning YOUR hook (no adapter file)
+
+```python
+from comms.dsl.collectives import A2A
+A2A(backend="cute",
+    produce=scale_produce, consume=bias_consume, variant="scalebias",
+    reference=my_reference,             # (inputs, group)->Tensor capturing your hook's semantics
+    # candidates=<dict | callable>,     # optional; default = expert size-banded grid
+).autotune(shapes=PROD_SHAPES)          # PROD_SHAPES = list of per-rank byte sizes or specs
+```
+
+`my_reference` for the scale/bias hook above:
+
+```python
+def my_reference(inputs, group):
+    ref = torch.empty_like(inputs.input)
+    dist.all_to_all_single(ref, inputs.input * 2.0, group=group)
+    return ref + 1.0
+```
+
+### Where and how to launch it (MAST — concrete)
+
+Tuning runs on **MAST with conda delivery** (the DSL JIT-compiles in a conda env; production shapes
+only exist on cluster GPUs). `buck` only builds/launches the launcher; MAST runs the sweep.
+
+**As a master user, you provide your own tenant via `--entitlement`** (the `rmAttribution` leaf that
+holds your GB300 quota). Full command (quota path):
+
+```bash
+buck2 run @fbcode//mode/opt //comms/dsl/tests:mast_launch -- \
+    --tune \                                  # run parent -> select -> emit-table in one job
+    --delivery conda \                        # required for tuning (JIT + source overlay)
+    --nnode 2 --ppn 4 --nvl-hosts 2 \         # 2 GB300 hosts x 4 GPU = world_size 8, one NVL72 domain
+    --hw gb300_dsf \                          # the registered MastProdCluster sub-type (quota path)
+    --cluster MastProdCluster \
+    --region uco \                            # locality (ignored if --flex-pool-id is set)
+    --entitlement <YOUR_TENANT_LEAF> \        # rmAttribution: YOUR tenant with GB300 quota  <-- master user sets this
+    --identity <YOUR_DATA_PROJECT_ACL> \      # hpcIdentity / data-project ACL (default: networkai_comms_tools)
+    --oncall <YOUR_ONCALL> \                  # default: hpc_comms_lib
+    --flex-pool-id '' \                       # '' = use the quota path; omit to use the default NetAI burn-in pool
+    --tune-output-dir /tmp/a2a_tune \         # remote dir: parent results + selected table
+    --submit                                  # ACTUALLY schedule (default is dry-run — no capacity used)
+```
+
+Notes for the runner:
+- **`--entitlement` / `--rm-attribution`** is the tenant hook. Point it at your team's leaf that has
+  GB300 quota. `--identity` (hpcIdentity) is the data-project/ACL your job runs under.
+- **`--flex-pool-id ''`** selects the quota path. Leaving it default routes to a dedicated NetAI
+  burn-in pool (no quota / no preempt) if you have access; the quota path is the portable choice.
+- **`--hw gb300_dsf`** is the sub-type MastProdCluster registers; a bare `gb300` is rejected.
+- Omit `--submit` first to **dry-run** (validates the request, uses no capacity).
+- Smoke a tiny sweep before a full run: add `--bench-args "--max-sizes 2 --max-candidates 2"`.
+- The job runs parent → select → prints the generated `TUNED_A2A_CONFIGS` table; copy it into
+  `comms/dsl/cute/a2a/generated/a2a_tuned_configs.py` and commit. **Re-tune = re-run this; no kernel
+  edits.**
+
+### Consuming the tuned table (runtime)
+
+Nothing to change — the same call now hits the tuned config:
+
+```python
+all_to_all(t, out, inp, rows=R)             # config=None -> get_a2a_config(key) -> tuned or default
+```
+
+---
+
+## 5. Gotchas
+
+- **Custom hook ⇒ `variant=` + `reference=`.** `variant` keeps your tuned entries from colliding
+  with the default copy hook (`A2A` raises without it). `reference` is required for a *transforming*
+  hook — the default bit-exact gate compares against a plain `all_to_all_single`, which won't match a
+  transformed output.
+- **Hooks are constexpr-traced.** Bake constants into the body (or use module constants / distinct
+  variants); they are not runtime parameters.
+- **Zero-copy returns a view.** `all_to_all_zc` (and the internal transpose zero-copy path) returns a
+  view into the transport's symmetric-memory output buffer. Consume or `.clone()` it **before**
+  reusing/freeing the transport, or before a graph replay overwrites it. The staging `all_to_all`
+  writes your owned `output`, so it has no such caveat.
+- **Transport reuse across geometries.** Switching `num_blocks` / `primitive` on a *reused* transport
+  is unsafe without a drain (not implemented); a runtime guard raises. Use a fresh transport per
+  geometry, or set `COMMS_DSL_ALLOW_GEOMETRY_SWITCH=1` if your calls are device-sync-separated.
+- **Transpose floor.** `rows>0` uses a 32×32 SMEM tile, so its practical floor is 2KB/peer; plain
+  (`rows=0`) a2a goes down to 32B.
+- **Sizing.** `all_to_all`: `per_peer_bytes = (numel // ws) * elem`. `pipelined_sendrecv` (whole
+  buffer): `per_peer_bytes >= numel * elem`. `numel % world_size == 0`.

--- a/comms/dsl/__init__.py
+++ b/comms/dsl/__init__.py
@@ -1,0 +1,34 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Composable send/recv framework — DSL-agnostic contract.
+
+This package exposes the stable, backend-independent transport contract: the
+user-owned p2p transport objects (:class:`NvlTransport` now; IB / Mesh
+transports reserved as future intent, not implemented here) and
+:func:`nvl_rendezvous`. A device schedule binds to a transport's per-peer
+:class:`PeerEndpoint` and stays fabric-agnostic.
+"""
+
+from __future__ import annotations
+
+from .transport import (
+    check_transfer,
+    LinkKind,
+    nvl_rendezvous,
+    NvlTransport,
+    P2pTransport,
+    PeerEndpoint,
+    PeerTable,
+)
+
+__all__ = [
+    "LinkKind",
+    "P2pTransport",
+    "PeerEndpoint",
+    "PeerTable",
+    "NvlTransport",
+    "nvl_rendezvous",
+    "check_transfer",
+]

--- a/comms/dsl/a2a_base.py
+++ b/comms/dsl/a2a_base.py
@@ -1,0 +1,324 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""DSL-agnostic a2a tuning base: the shared all_to_all adapter lifecycle.
+
+Split out of :mod:`comms.dsl.tuning_base` so that module stays collective-agnostic
+(Config / Key / Spec / grid / geometry guard) while this module owns the pieces that
+are specific to the all_to_all collective but identical across the Triton and CuTe
+backends: the materialized rank-local inputs and the ``BaseA2AAdapter`` lifecycle
+(CLI args, shape enumeration, key building, input materialization, candidate
+dispatch, NCCL reference / correctness gate, and serialization). A per-backend
+subclass supplies only what genuinely differs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+from .transport import nvl_rendezvous
+from .tuning_base import (
+    _CommTunerBase,
+    _device_tag,
+    BaseAdapterMixin,
+    import_obj,
+    resolve_variant,
+    SIZE_LADDER,
+)
+
+
+@dataclass
+class A2AInputs:
+    """Materialized rank-local state for one a2a tuning run (shared by both backends)."""
+
+    transport: Any
+    input: torch.Tensor
+    output: torch.Tensor
+    rows: int
+
+
+# pyre-ignore[11]: _CommTunerBase is `object` or the optional CommKernelTuningAdapter.
+class BaseA2AAdapter(BaseAdapterMixin, _CommTunerBase):
+    """DSL-agnostic adapter lifecycle for the all_to_all schedule, shared by both backends.
+
+    The comms-owned tuner engine (``comm_tuning``) drives this; the generic engine owns
+    orchestration / timing / selection, and this base owns everything identical across the
+    Triton and CuTe backends: CLI args, shape enumeration, key building, input
+    materialization (equal-split a2a), candidate dispatch, the NCCL baseline / reference /
+    correctness gate, and serialization. A per-backend subclass supplies only what genuinely
+    differs: its config/key/spec classes + core fields + identity-copy hooks + generated
+    artifact names (class attributes), and the expert candidate grid, the static feasibility
+    filter, the config render template, and the collective launch (methods).
+
+    Key sharing: ``make_key`` here MUST match the runtime key builder so the tuned map looks
+    up. Each backend pins its default (copy) hook; a transformed variant is a separate tuned
+    map keyed by ``variant``.
+    """
+
+    # Per-backend class attributes the subclass sets (config_cls / key_cls / spec_cls /
+    # core_config_fields / backend_name come from BaseAdapterMixin).
+    transport_kind: str = "NvlTransport"
+    default_produce: Any = None
+    default_consume: Any = None
+    spec_tag: str = ""
+    generated_table: str = ""
+    generated_file: str = ""
+    generated_import: str = ""
+    # The backend's host-side ``all_to_all`` entry, bound by the subclass as a
+    # ``staticmethod`` so the shared ``run_collective`` below is backend-agnostic.
+    host_all_to_all: Any = None
+
+    # Per-call state (set in __init__).
+    _max_sizes: int = 0
+    _max_candidates: int = 0
+    _variant: str = ""
+    # None (expert default) | dict grid | (spec, key) -> list[config] callable.
+    _candidates: Any = None
+    _feasible: Any = None
+
+    def __init__(
+        self,
+        *,
+        produce=None,
+        consume=None,
+        variant: str = "",
+        reference=None,
+        candidates=None,
+        feasible=None,
+        shapes=None,
+    ) -> None:
+        # Parametrized by the A2A object (or constructed bare for the CLI path). Hooks default
+        # to the backend's identity copy hooks; the variant is validated once here
+        # (explicit-required for a non-default hook).
+        self._produce = produce if produce is not None else self.default_produce
+        self._consume = consume if consume is not None else self.default_consume
+        self._variant = resolve_variant(
+            self._produce,
+            self._consume,
+            variant,
+            default_produce=self.default_produce,
+            default_consume=self.default_consume,
+        )
+        self._reference = reference
+        self._candidates = candidates
+        self._feasible = feasible
+        self._shapes = shapes
+        self._max_sizes = 0
+        self._max_candidates = 0
+
+    # --- tuner CLI knobs (engine calls add_cli_args/configure) -------------
+    def add_cli_args(self, parser: Any) -> None:
+        parser.add_argument(
+            "--max-sizes",
+            type=int,
+            default=0,
+            help="smoke: tune only the first N size bands (0 = all)",
+        )
+        parser.add_argument(
+            "--max-candidates",
+            type=int,
+            default=0,
+            help="smoke: sweep only the first M candidate configs per band (0 = all)",
+        )
+        # Tune a custom hook with NO adapter file: point at import paths + a variant.
+        parser.add_argument(
+            "--produce", default=None, help="custom produce hook as 'module:attr'"
+        )
+        parser.add_argument(
+            "--consume", default=None, help="custom consume hook as 'module:attr'"
+        )
+        parser.add_argument(
+            "--variant", default=None, help="tuned-table variant tag for a custom hook"
+        )
+        parser.add_argument(
+            "--reference",
+            default=None,
+            help="correctness reference '(inputs, group)->Tensor' as 'module:attr' "
+            "(default: identity all_to_all_single)",
+        )
+
+    def configure(self, args: Any) -> None:
+        self._max_sizes = int(getattr(args, "max_sizes", 0) or 0)
+        self._max_candidates = int(getattr(args, "max_candidates", 0) or 0)
+        # CLI overrides (used by the generic tune entrypoint; absent in the A2A-object path).
+        produce = getattr(args, "produce", None)
+        consume = getattr(args, "consume", None)
+        variant = getattr(args, "variant", None)
+        reference = getattr(args, "reference", None)
+        if produce:
+            self._produce = import_obj(produce)
+        if consume:
+            self._consume = import_obj(consume)
+        if produce or consume or variant:
+            self._variant = resolve_variant(
+                self._produce,
+                self._consume,
+                variant or self._variant,
+                default_produce=self.default_produce,
+                default_consume=self.default_consume,
+            )
+        if reference:
+            self._reference = import_obj(reference)
+
+    # --- what to tune -----------------------------------------------------
+    def _spec_from_bytes(self, nbytes: int, world_size: int):
+        elem = torch.bfloat16.itemsize
+        numel = nbytes // elem
+        numel -= numel % world_size
+        return self.spec_cls(numel=numel, dtype=torch.bfloat16) if numel > 0 else None
+
+    def enumerate_input_specs(self, world_size: int) -> list:
+        # The user's production shapes (`shapes=` on the object, or the default ladder). Each
+        # entry may be a spec (full control incl. dtype/rows) or an int = per-rank bytes
+        # (bf16, 1D). The best launch config shifts across sizes, so each is tuned separately.
+        if self._shapes is not None:
+            specs = []
+            for s in self._shapes:
+                if isinstance(s, self.spec_cls):
+                    specs.append(s)
+                elif isinstance(s, int):
+                    spec = self._spec_from_bytes(s, world_size)
+                    if spec is not None:
+                        specs.append(spec)
+                else:
+                    raise TypeError(
+                        f"shapes entry must be {self.spec_cls.__name__} or "
+                        f"int (per-rank bytes), got {type(s).__name__}"
+                    )
+        else:
+            specs = [
+                s
+                for s in (self._spec_from_bytes(n, world_size) for n in SIZE_LADDER)
+                if s is not None
+            ]
+        if self._max_sizes:
+            specs = specs[: self._max_sizes]
+        return specs
+
+    def make_key(self, spec, world_size: int):
+        # MUST match the runtime key builder so the tuned map looks up. Tuned on the target
+        # GPU, so _device_tag() tags the entry with this host's hardware; _variant is "" for
+        # the default copy hook and set by the A2A object for a custom hook.
+        return self.make_key_from_spec(
+            spec=spec,
+            world_size=world_size,
+            transport_kind=self.transport_kind,
+            device=_device_tag(),
+            variant=self._variant,
+        )
+
+    def enumerate_candidate_configs(self, spec, key) -> list:
+        # Dispatch the candidate source: default expert banded grid / flat declarative grid
+        # (dict) / callable (full control); then static-feasibility filter + size-cap.
+        cand = self._candidates
+        if cand is None:
+            out = self.default_candidate_configs(spec, key)
+        elif callable(cand):
+            # pyre-ignore[6]: a callable candidate source returns the backend's config list.
+            out = list(cand(spec, key))
+        elif isinstance(cand, dict):
+            out = self.expand_candidate_grid(cand)
+        else:
+            raise TypeError(
+                "candidates must be None (expert default), a dict grid, or a callable "
+                f"(spec, key) -> list[{self.config_cls.__name__}]; got {type(cand)!r}"
+            )
+        feasible = self._feasible or self.default_feasible
+        out = [c for c in out if feasible(c, spec)]
+        if self._max_candidates:
+            out = out[: self._max_candidates]
+        return out
+
+    def enumerate_baselines(self, spec, key) -> list[str]:
+        return ["nccl"]
+
+    # --- materialize + run ------------------------------------------------
+    def make_inputs(self, spec, *, rank: int, world_size: int, device: torch.device):
+        assert spec.numel % world_size == 0
+        chunk = spec.numel // world_size
+        inp = torch.randn(spec.numel, dtype=spec.dtype, device=device)
+        out = torch.empty_like(inp)
+        group = dist.group.WORLD
+        assert group is not None, "default process group not initialized"
+        transport = nvl_rendezvous(
+            group, device, per_peer_bytes=chunk * inp.element_size()
+        )
+        return A2AInputs(transport=transport, input=inp, output=out, rows=spec.rows)
+
+    def run_candidate(self, inputs, config, group) -> torch.Tensor:
+        self.run_collective(inputs, config)
+        return inputs.output
+
+    def run_baseline(self, inputs, baseline: str, group) -> torch.Tensor:
+        if baseline != "nccl":
+            raise ValueError(f"unknown baseline {baseline}")
+        return self.run_reference(inputs, group)
+
+    def run_reference(self, inputs, group) -> torch.Tensor:
+        # Custom hooks (transpose/quantize/...) change the expected output, so the user
+        # supplies a reference `(inputs, group) -> Tensor` capturing their semantics; the
+        # default (identity copy hook) is a plain all_to_all_single.
+        if self._reference is not None:
+            return self._reference(inputs, group)
+        ref = torch.empty_like(inputs.input)
+        dist.all_to_all_single(ref, inputs.input, group=group)
+        return ref
+
+    def check_correctness(self, candidate_output, reference_output) -> dict[str, Any]:
+        torch.testing.assert_close(candidate_output, reference_output, atol=0, rtol=0)
+        # The engine records this dict verbatim and the selector keeps a candidate only when
+        # correctness["status"] == "pass"; assert_close(atol=0, rtol=0) raises on any mismatch,
+        # so reaching here means bit-exact -- the error is provably 0.0. Computing it via
+        # .abs().max().item() would only force a needless GPU sync.
+        return {
+            "status": "pass",
+            "max_abs_err": 0.0,
+        }
+
+    # --- serialization (parent -> child) ----------------------------------
+    def spec_to_json(self, spec) -> tuple[str, dict[str, Any]]:
+        return (self.spec_tag, spec.to_json_dict())
+
+    def spec_from_json(self, spec_type: str, data: dict[str, Any]):
+        if spec_type != self.spec_tag:
+            raise ValueError(f"unknown spec type {spec_type}")
+        return super().spec_from_json(spec_type, data)
+
+    # --- generated artifact names -----------------------------------------
+    def generated_table_name(self) -> str:
+        return self.generated_table
+
+    def generated_filename(self) -> str:
+        return self.generated_file
+
+    def generated_imports(self) -> str:
+        return self.generated_import
+
+    # --- per-backend hooks (subclass supplies these) ----------------------
+    def default_candidate_configs(self, spec, key) -> list:
+        """The shipped expert, size-banded candidate grid (the zero-effort default)."""
+        raise NotImplementedError
+
+    def default_feasible(self, config, spec) -> bool:
+        """Cheap, shape-independent static feasibility pre-filter for user grids."""
+        raise NotImplementedError
+
+    def run_collective(self, inputs, config) -> None:
+        """Launch this backend's all_to_all writing ``inputs.output`` (used by run_candidate).
+
+        Backend-agnostic: dispatches to the subclass-bound ``host_all_to_all`` with the
+        adapter's hooks; identical across Triton and CuTe, so it lives here."""
+        self.host_all_to_all(
+            inputs.transport,
+            inputs.output,
+            inputs.input,
+            produce=self._produce,
+            consume=self._consume,
+            rows=inputs.rows,
+            config=config,
+        )

--- a/comms/dsl/collectives.py
+++ b/comms/dsl/collectives.py
@@ -1,0 +1,166 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""DSL-agnostic all_to_all entry: dispatch to the CuTe device backend.
+
+A thin façade over the device backend so a caller selects the DSL with a
+``backend=`` argument instead of importing a backend package directly. The backend
+module is imported lazily, so a caller never pays the import cost of the DSL's
+compiler stack until first use.
+
+The backend exposes a stable surface -- staging ``all_to_all`` (caller output) and
+zero-copy ``all_to_all_zc`` (returns the transport's output view) plus a tunable ``Config`` /
+lookup ``Key`` / ``CommTuner`` adapter. The façade stays backend-parametrized so a second
+DSL (Triton) can be re-registered later by adding it to ``_BACKENDS`` / ``_ADAPTER_CLS``
+without touching callers; CuTe is the only shipped backend today.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any, Callable
+
+_BACKENDS: tuple[str, ...] = ("cute",)
+
+# Backend -> the CommTuner adapter class the autotuner drives.
+_ADAPTER_CLS: dict[str, str] = {
+    "cute": "CuteA2ATuningAdapter",
+}
+
+
+def _check_backend(backend: str) -> None:
+    if backend not in _BACKENDS:
+        raise ValueError(f"unknown backend {backend!r}; choose from {_BACKENDS}")
+
+
+def _backend_collectives(backend: str):
+    _check_backend(backend)
+    return import_module(f"comms.dsl.{backend}.a2a.host")
+
+
+def all_to_all(
+    transport,
+    output,
+    input,
+    *,
+    backend: str = "cute",
+    **kwargs,
+) -> None:
+    """Equal-split all_to_all_single on the selected DSL backend.
+
+    ``backend`` selects the DSL (``"cute"`` today); the remaining keyword arguments
+    (``produce`` / ``consume`` / ``rows`` / ``config`` / ``variant``)
+    forward to that backend's ``all_to_all``.
+
+    Hook support: a non-identity ``produce`` / ``consume`` (elementwise) and the ``rows > 0``
+    layout transpose both run on the fused CuTe copy staging schedule. The TMA and zero-copy
+    (``direct`` / ``ce``) paths move raw bytes and apply neither."""
+    _backend_collectives(backend).all_to_all(transport, output, input, **kwargs)
+
+
+def all_to_all_zc(
+    transport,
+    input,
+    *,
+    backend: str = "cute",
+    primitive: str = "direct",
+    config: Any = None,
+) -> Any:
+    """Zero-copy all_to_all on the selected DSL backend: returns this rank's symmetric-memory
+    output view (slot ``s`` = the chunk from sender ``s``), so the transport must be sized
+    ``per_peer_bytes >= chunk * elem``. ``primitive`` picks ``"direct"`` (DirectWrite) or
+    ``"ce"`` (copy-engine)."""
+    return _backend_collectives(backend).all_to_all_zc(
+        transport, input, primitive=primitive, config=config
+    )
+
+
+class A2A:
+    """Backend-dispatching all_to_all collective object (callable + ``autotune``).
+
+    ``backend=`` selects the DSL; the object then behaves like the per-backend collective
+    -- ``__call__`` runs a tuned-table-looked-up all_to_all, and ``autotune`` drives the
+    ``comm_tuning`` engine through the backend's adapter (the body of the tuning-job
+    entrypoint). ``produce`` / ``consume`` default to ``None`` = the backend's identity
+    copy hooks; a non-default hook MUST carry an explicit ``variant`` so its tuned configs
+    do not collide with the default copy hook's."""
+
+    def __init__(
+        self,
+        *,
+        backend: str = "cute",
+        produce: Callable[..., Any] | None = None,
+        consume: Callable[..., Any] | None = None,
+        variant: str = "",
+        reference: Callable[..., Any] | None = None,
+        candidates: Any = None,
+        feasible: Any = None,
+    ) -> None:
+        _check_backend(backend)
+        self.backend = backend
+        self.produce = produce
+        self.consume = consume
+        self.variant = variant
+        self.reference = reference
+        self.candidates = candidates
+        self.feasible = feasible
+        # A non-default hook changes the access pattern, so it must carry an explicit variant
+        # tag (else its tuned configs would silently reuse the default copy hook's entries).
+        if (produce is not None or consume is not None) and not variant:
+            raise ValueError(
+                "a non-default produce/consume hook needs an explicit variant tag so its "
+                "tuned configs don't collide with the default copy hook; pass variant=... "
+                "(e.g. A2A(produce=my_op, variant='myq'))."
+            )
+
+    def _hook_kwargs(self) -> dict[str, Any]:
+        # Forward a hook only when set, so the backend's own default identity hook applies.
+        kw: dict[str, Any] = {}
+        if self.produce is not None:
+            kw["produce"] = self.produce
+        if self.consume is not None:
+            kw["consume"] = self.consume
+        return kw
+
+    def __call__(
+        self,
+        transport,
+        output,
+        input,
+        *,
+        rows: int = 0,
+        config: Any = None,
+    ) -> None:
+        all_to_all(
+            transport,
+            output,
+            input,
+            backend=self.backend,
+            rows=rows,
+            config=config,
+            variant=self.variant,
+            **self._hook_kwargs(),
+        )
+
+    def autotune(self, *, shapes: Any = None) -> None:
+        """Drive the ``comm_tuning`` engine through this backend's adapter (parent/child/
+        select modes + ``--max-sizes`` etc. parsed from argv by ``run_tuning_cli``).
+
+        The per-backend tuning adapter module (``comms.dsl.<backend>.a2a.adapter`` /
+        :class:`A2ATuningAdapter`) ships in the tuning-adapter sub-diff layered on top of
+        this one, so ``autotune`` is not callable until that module is present (a
+        :exc:`ModuleNotFoundError` from the import below is expected before then)."""
+        from comm_tuning.cli import run_tuning_cli  # pyre-ignore[21]
+
+        adapter_mod = import_module(f"comms.dsl.{self.backend}.a2a.adapter")
+        adapter_cls = getattr(adapter_mod, _ADAPTER_CLS[self.backend])
+        kwargs: dict[str, Any] = {
+            "variant": self.variant,
+            "reference": self.reference,
+            "candidates": self.candidates,
+            "feasible": self.feasible,
+            "shapes": shapes,
+        }
+        kwargs.update(self._hook_kwargs())
+        run_tuning_cli(adapter_cls(**kwargs))

--- a/comms/dsl/cute/__init__.py
+++ b/comms/dsl/cute/__init__.py
@@ -1,0 +1,49 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""CuTe backend: send/recv tile primitives + hooks over the shared transport.
+
+Symbols are exposed lazily (PEP 562 ``__getattr__``) so that merely importing
+this package does not eagerly pull the cutlass DSL. The cutlass-backed
+primitives (``send_tiles``/``recv_tiles``/``nvl_ops``/``copy_*``) load only on
+first access, while the pure-Python submodules (``ctx``, ``ib_ops``) stay
+importable in a GPU-less sandbox. The fused ``all_to_all`` collective is layered
+on top of these primitives and registers its own exports in a later diff.
+"""
+
+from importlib import import_module
+from typing import Any
+
+__all__ = [
+    "send_tiles",
+    "recv_tiles",
+    "nvl_ops",
+    "ib_ops",
+    "copy_produce",
+    "copy_consume",
+]
+
+# Exported name -> (submodule, attribute). ``attr is None`` exports the submodule
+# itself (e.g. ``nvl_ops`` / ``ib_ops``).
+_LAZY: dict[str, tuple[str, str | None]] = {
+    "send_tiles": ("send_recv", "send_tiles"),
+    "recv_tiles": ("send_recv", "recv_tiles"),
+    "copy_produce": ("hooks", "copy_produce"),
+    "copy_consume": ("hooks", "copy_consume"),
+    "nvl_ops": ("nvl_ops", None),
+    "ib_ops": ("ib_ops", None),
+}
+
+
+def __getattr__(name: str) -> Any:
+    entry = _LAZY.get(name)
+    if entry is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    mod_name, attr = entry
+    mod = import_module(f".{mod_name}", __name__)
+    return mod if attr is None else getattr(mod, attr)
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/comms/dsl/cute/__init__.py
+++ b/comms/dsl/cute/__init__.py
@@ -2,20 +2,23 @@
 
 # pyre-strict
 
-"""CuTe backend: send/recv tile primitives + hooks over the shared transport.
+"""CuTe backend: send/recv tile primitives + the fused all_to_all over the shared transport.
 
 Symbols are exposed lazily (PEP 562 ``__getattr__``) so that merely importing
 this package does not eagerly pull the cutlass DSL. The cutlass-backed
-primitives (``send_tiles``/``recv_tiles``/``nvl_ops``/``copy_*``) load only on
-first access, while the pure-Python submodules (``ctx``, ``ib_ops``) stay
-importable in a GPU-less sandbox. The fused ``all_to_all`` collective is layered
-on top of these primitives and registers its own exports in a later diff.
+kernels (``send_tiles``/``recv_tiles``/``all_to_all``/``nvl_ops``/``copy_*``) load
+only on first access, while the pure-Python submodules (``ctx``, ``ib_ops``) stay
+importable in a GPU-less sandbox.
 """
 
 from importlib import import_module
 from typing import Any
 
 __all__ = [
+    "all_to_all",
+    "all_to_all_zc",
+    "all_to_all_transpose",
+    "CuteA2AConfig",
     "send_tiles",
     "recv_tiles",
     "nvl_ops",
@@ -27,6 +30,10 @@ __all__ = [
 # Exported name -> (submodule, attribute). ``attr is None`` exports the submodule
 # itself (e.g. ``nvl_ops`` / ``ib_ops``).
 _LAZY: dict[str, tuple[str, str | None]] = {
+    "all_to_all": ("a2a.host", "all_to_all"),
+    "all_to_all_zc": ("a2a.host", "all_to_all_zc"),
+    "all_to_all_transpose": ("a2a.host", "all_to_all_transpose"),
+    "CuteA2AConfig": ("a2a.tuning", "CuteA2AConfig"),
     "send_tiles": ("send_recv", "send_tiles"),
     "recv_tiles": ("send_recv", "recv_tiles"),
     "copy_produce": ("hooks", "copy_produce"),

--- a/comms/dsl/cute/a2a/__init__.py
+++ b/comms/dsl/cute/a2a/__init__.py
@@ -1,0 +1,5 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""CuTe all_to_all collective: device kernels (``schedules``) + host entries (``host``)."""

--- a/comms/dsl/cute/a2a/adapter.py
+++ b/comms/dsl/cute/a2a/adapter.py
@@ -1,0 +1,145 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# pyre-ignore-all-errors[6, 7, 14, 29, 35]: the adapter intentionally narrows BaseA2AAdapter's
+# generic overrides to its declared config_cls/key_cls/spec_cls (the comm_tuning engine always
+# passes the concrete subtype), and the declarative candidate source is `object`.
+
+"""CuteCommTuner adapter for the comms/dsl CuTe all_to_all schedule.
+
+The CuTe twin of ``triton/a2a/adapter.py``: binds the CuTe all_to_all into the comms-owned
+tuner (``comm_tuning``) by supplying the backend-specific pieces to
+:class:`~comms.dsl.a2a_base.BaseA2AAdapter` -- the ``CuteA2AConfig`` / ``CuteA2AKey`` /
+``CuteA2AInputSpec`` classes and identity-copy hooks, the expert size-banded candidate grid,
+the static feasibility filter, the generated-table render template, and the collective
+launch. The shared adapter lifecycle (CLI, shape/key/input enumeration, NCCL baseline +
+correctness, serialization) lives in the base.
+
+Key sharing: the base ``make_key`` matches runtime ``make_a2a_key`` (a2a.tuning)
+so the tuned map looks up. This adapter pins the default (copy) hook; a transformed variant
+is a separate adapter instance with its own tuned map (keyed by ``variant``).
+"""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from comms.dsl.a2a_base import BaseA2AAdapter
+from comms.dsl.tuning_base import BaseInputSpec
+
+from ..hooks import copy_consume, copy_produce
+from .host import all_to_all
+from .tuning import (
+    CUTE_A2A_CORE_FIELDS,
+    CuteA2AConfig,
+    CuteA2AKey,
+    nondefault_inapplicable_fields,
+)
+
+
+@dataclass(frozen=True)
+class CuteA2AInputSpec(BaseInputSpec):
+    """Serializable recipe for one input case to tune (numel/dtype/rows)."""
+
+
+def _default_candidate_configs(
+    spec: CuteA2AInputSpec, key: CuteA2AKey
+) -> list[CuteA2AConfig]:
+    """The shipped expert, size-banded candidate grid (the zero-effort default).
+
+    Size-aware launch grid over the CuTe launch knobs. ``num_blocks`` is bounded by the
+    SM-budget guard, so oversized candidates fail run_candidate and are skipped. The
+    analytic defaults (``num_threads``/``num_slots``/``unroll``/``cluster`` = 0) already
+    approximate the optimum; the sweep confirms/locks them per size. A user can override
+    with a flat ``candidates`` grid or a callable; this banded logic is the default that
+    preserves the expert pruning."""
+    per_rank = spec.numel * torch.tensor([], dtype=spec.dtype).element_size()
+    if per_rank <= 256 * 1024:
+        # Latency-bound: few CTAs, narrow tile, single shot.
+        threads, slots, unrolls = [256, 512], [1], [1]
+        num_blocks_grid, clusters, primitives = [1, 2], [0], ["copy"]
+    elif per_rank <= 16 * 1024 * 1024:
+        # SM-scaling band: scale CTAs to the SM budget; single-shot still wins.
+        threads, slots, unrolls = [512, 1024], [1, 8], [1, 8]
+        num_blocks_grid, clusters, primitives = [1, 2, 4, 8], [0], ["copy"]
+    else:
+        # Large band: deep run-ahead pipeline + register-blocked stores + the CGA cluster
+        # all maximize the NVLink send/drain overlap.
+        threads, slots, unrolls = [512, 1024], [8], [8]
+        num_blocks_grid, clusters, primitives = [4, 8, 16], [0, -1], ["copy"]
+
+    # itertools.product advances the rightmost (primitives) fastest, so the emitted order
+    # is identical to the equivalent nested num_blocks/threads/slots/unrolls/clusters/
+    # primitives loops; flattened per python.md's max-3-indent-levels.
+    return [
+        CuteA2AConfig(
+            num_blocks=nb,
+            num_threads=nt,
+            num_slots=s,
+            unroll=u,
+            cluster=cl,
+            primitive=p,
+        )
+        for nb, nt, s, u, cl, p in itertools.product(
+            num_blocks_grid, threads, slots, unrolls, clusters, primitives
+        )
+    ]
+
+
+def _default_feasible(config: CuteA2AConfig, spec: CuteA2AInputSpec) -> bool:
+    """Cheap, shape-independent static feasibility pre-filter for user grids.
+    world_size-dependent / SM-budget invalids still drop at run time. Override via
+    ``feasible=``.
+
+    Also enforces the apply-path honesty invariant: a candidate must not set a knob its
+    ``primitive`` does not consume at launch (e.g. ``num_slots`` on the single-shot
+    ``direct`` path), so the emitted tuned table never carries a silently-ignored field."""
+    if config.num_blocks < 1:
+        return False
+    if nondefault_inapplicable_fields(config):
+        return False
+    return True
+
+
+class CuteA2ATuningAdapter(BaseA2AAdapter):
+    """Tune the comms/dsl CuTe all_to_all (default copy hook) against dist.all_to_all_single."""
+
+    name = "comms_dsl_a2a_cute"
+
+    # BaseA2AAdapter bindings: the CuTe config/key/spec classes + identity-copy hooks +
+    # generated-artifact names. The shared lifecycle lives in the base.
+    config_cls = CuteA2AConfig
+    key_cls = CuteA2AKey
+    spec_cls = CuteA2AInputSpec
+    core_config_fields = CUTE_A2A_CORE_FIELDS
+    backend_name = "cute"
+    # staticmethod so instance access yields the bare hook function: a plain-function hook
+    # would otherwise bind to the adapter instance and fail the identity check that maps the
+    # default hooks to the empty variant.
+    default_produce = staticmethod(copy_produce)
+    default_consume = staticmethod(copy_consume)
+    spec_tag = "cute_a2a_input_spec"
+    generated_table = "TUNED_A2A_CONFIGS"
+    generated_file = "a2a_tuned_configs.py"
+    generated_import = "from comms.dsl.cute.a2a.tuning import CuteA2AConfig, CuteA2AKey"
+    host_all_to_all = staticmethod(all_to_all)
+
+    def default_candidate_configs(
+        self, spec: CuteA2AInputSpec, key: CuteA2AKey
+    ) -> list[CuteA2AConfig]:
+        return _default_candidate_configs(spec, key)
+
+    def default_feasible(self, config: CuteA2AConfig, spec: CuteA2AInputSpec) -> bool:
+        return _default_feasible(config, spec)
+
+    def render_config(self, config_type: str, config: dict[str, Any]) -> str:
+        base = (
+            "CuteA2AConfig(num_blocks={num_blocks}, num_threads={num_threads}, "
+            "num_slots={num_slots}, unroll={unroll}, primitive={primitive!r}, "
+            "cluster={cluster}, cluster_y={cluster_y}, "
+            "tma_drain_warps={tma_drain_warps})"
+        )
+        return base.format(**config)

--- a/comms/dsl/cute/a2a/generated/__init__.py
+++ b/comms/dsl/cute/a2a/generated/__init__.py
@@ -1,0 +1,5 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Tuner-emitted artifacts for the CuTe collectives (generated; do not hand-edit)."""

--- a/comms/dsl/cute/a2a/generated/a2a_tuned_configs.py
+++ b/comms/dsl/cute/a2a/generated/a2a_tuned_configs.py
@@ -1,0 +1,15 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""CuTe A2A tuned configs emitted by the comm_tuning select step (generated; do not hand-edit).
+
+Placeholder: empty until an autotuner sweep emits the table, so ``get_a2a_config`` falls back
+to ``DEFAULT_A2A_CONFIG`` (the analytic adaptive pick) for every key. The GB300 table is
+populated in a later layer of this stack; refresh via ``mast_launch --delivery conda --tune``
+and overwrite this file with the emitted table.
+"""
+
+from comms.dsl.cute.a2a.tuning import CuteA2AConfig, CuteA2AKey  # noqa: F401
+
+TUNED_A2A_CONFIGS: dict[CuteA2AKey, CuteA2AConfig] = {}

--- a/comms/dsl/cute/a2a/host.py
+++ b/comms/dsl/cute/a2a/host.py
@@ -1,0 +1,850 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Public host entries for the fused all_to_all in the CuTe DSL (symmetric-memory NVLink).
+
+The host half of the CuTe all_to_all: :func:`all_to_all` (staging, writes the
+caller's output) and :func:`all_to_all_zc` (zero-copy DirectWrite / copy-engine,
+returns the transport's symmetric-memory output view, dispatching to
+``_all_to_all_direct`` / ``_all_to_all_ce``). Each resolves a tuned
+``CuteA2AConfig``, picks the analytic launch shape, and ``cute.compile``/launches
+the device kernels in :mod:`comms.dsl.cute.a2a.schedules`.
+
+Mirrors :mod:`comms.dsl.triton.a2a.host`: launch tunables come from ``config``;
+when ``config is None`` it is looked up from the tuned table by the runtime key,
+falling back to the analytic adaptive defaults. The per-element staging schedules
+(copy) apply a non-default ``produce``/``consume`` value hook; ``rows>0`` (the
+block-tile layout transpose) delegates to :func:`all_to_all_transpose` (zero-copy).
+The TMA bulk-copy and zero-copy direct/ce paths move raw bytes and reject a hook.
+"""
+
+import logging
+import os
+from importlib import import_module
+from typing import Any
+
+import torch
+from comms.dsl.transport import check_transfer, NvlTransport
+from comms.dsl.tuning_base import check_geometry
+
+# Importing schedules runs the one-time CuTe setup (CUTE_DSL_ARCH detection +
+# cuda-bindings shim) AND imports cutlass; the os.environ statement below is a
+# barrier so the formatter cannot hoist the cutlass imports above this setup.
+from ..send_recv import (
+    _ensure_cuda_rt_compat,
+    _pick_slots,
+    _pick_tile,
+    _resolve_cute_dsl_arch,
+)
+
+os.environ.setdefault("CUTE_DSL_ARCH", _resolve_cute_dsl_arch())
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.runtime import from_dlpack
+
+from ..hooks import copy_consume, copy_produce, transpose_tile
+from .schedules import (
+    _A2ACfg,
+    _CeSignalKernel,
+    _launch_a2a,
+    _launch_a2a_tma,
+    _launch_a2a_transpose,
+    _MAX_PORTABLE_CLUSTER,
+    _pick_cluster,
+)
+from .tuning import (
+    CUTE_A2A_GEOMETRY_FIELDS,
+    CuteA2AConfig,
+    get_a2a_config,
+    make_a2a_key,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+_cuda_driver: Any = import_module("cuda.bindings.driver")
+
+
+# Minimal dtype support: (cutlass dtype, bits-per-element).
+_CUTLASS_DTYPE: dict[torch.dtype, tuple[Any, int]] = {
+    torch.float32: (cutlass.Float32, 32),
+    torch.bfloat16: (cutlass.BFloat16, 16),
+}
+
+_COMPILED: dict[tuple[Any, ...], Any] = {}
+
+
+def all_to_all(  # noqa: C901
+    transport: NvlTransport,
+    output: torch.Tensor,
+    input: torch.Tensor,
+    *,
+    produce=copy_produce,
+    consume=copy_consume,
+    rows: int = 0,
+    config: CuteA2AConfig | None = None,
+    variant: str = "",
+) -> None:
+    """Equal-split all_to_all_single via the fused CuTe kernel.
+
+    Mirrors ``triton.all_to_all``: launch tunables come from ``config`` (a
+    ``CuteA2AConfig``); when ``config is None`` it is looked up from the tuned table by
+    the runtime key, falling back to the analytic adaptive defaults. The per-element staging
+    schedules (copy) apply a non-default ``produce``/``consume`` value hook; ``rows > 0`` (the
+    per-chunk ``[rows, cols] -> [cols, rows]`` block-tile transpose) delegates to
+    :func:`all_to_all_transpose` (zero-copy) and writes the result into ``output``. A value hook
+    combined with ``rows > 0`` is rejected (a value hook cannot compose with the layout hook); the
+    TMA path moves raw bytes and rejects a hook."""
+    if not (input.is_cuda and output.is_cuda):
+        raise ValueError("cute a2a requires CUDA input/output tensors")
+    if not (input.is_contiguous() and output.is_contiguous()):
+        raise ValueError("cute a2a requires contiguous input/output tensors")
+    if input.dtype != output.dtype:
+        raise ValueError("cute a2a requires matching input/output dtype")
+    # A non-identity produce/consume runs on the per-element staging schedule (copy); the TMA
+    # bulk-copy and the zero-copy direct/ce paths move raw bytes and cannot apply a per-tile
+    # hook, so a hook on those raises (TMA below; direct/ce rejected after the config is
+    # resolved -- those must route to all_to_all_zc).
+    hooked = produce is not copy_produce or consume is not copy_consume
+    # rows>0 = the per-chunk [rows, cols] -> [cols, rows] transpose: the fast BLOCK-TILE HOOK
+    # path (all_to_all_transpose), a fused block-cooperative SMEM transpose written zero-copy
+    # into peers' buffers and returned like all_to_all_zc. It is a LAYOUT hook, not a per-element
+    # value hook, so a produce/consume value transform cannot compose with it here -- reject that
+    # combination rather than silently dropping the hook. (The old per-element gather hook is
+    # superseded -- it could not coalesce the strided access, ~0.26x; the block-tile tier fixes it.)
+    if rows > 0:
+        if hooked:
+            raise ValueError(
+                "cute a2a: rows>0 selects the block-tile transpose (a LAYOUT hook) and cannot be "
+                "combined with a per-element produce/consume value hook; drop rows= or the hook"
+            )
+        # all_to_all_transpose is zero-copy (returns the transport's symm-mem buffer); the
+        # all_to_all facade contract is to WRITE `output`, so copy the result in. Perf callers
+        # (benchmark) call all_to_all_transpose directly to skip this copy.
+        output.copy_(all_to_all_transpose(transport, input, rows, config=config))
+        return
+    if input.dtype not in _CUTLASS_DTYPE:
+        raise ValueError(f"cute a2a supports {list(_CUTLASS_DTYPE)}, got {input.dtype}")
+    ws = transport.world_size
+    numel = input.numel()
+    if numel != output.numel():
+        raise ValueError("cute a2a requires input.numel() == output.numel()")
+    if numel % ws != 0:
+        raise ValueError("equal-split requires numel % world_size == 0")
+    chunk = numel // ws
+    cdtype, dbits = _CUTLASS_DTYPE[input.dtype]
+    if config is None:
+        config = get_a2a_config(
+            make_a2a_key(
+                input,
+                transport,
+                rows=rows,
+                produce=produce,
+                consume=consume,
+                variant=variant,
+            )
+        )
+    check_geometry(transport, config, CUTE_A2A_GEOMETRY_FIELDS)
+    if config.primitive in ("direct", "ce"):
+        raise ValueError(
+            f"primitive {config.primitive!r} is zero-copy (symm-mem output); call "
+            f"all_to_all_zc(primitive={config.primitive!r}) instead of all_to_all"
+        )
+    nb = config.num_blocks
+    num_threads, vec = _pick_tile(chunk, dbits, nb * ws)
+    # Variant selection: config.primitive picks the staging schedule; an env flag still
+    # overrides for A-B (so a default config + env sweep keeps working).
+    tma_variant = os.environ.get("A2A_CUTE_TMA") == "1" or config.primitive == "tma"
+    send_only = os.environ.get("A2A_CUTE_SENDONLY") == "1"
+    if hooked and tma_variant:
+        raise NotImplementedError(
+            "cute fused hooks are wired into the per-element schedules (copy); the TMA "
+            "bulk-copy path moves raw bytes and cannot apply a per-tile transform"
+        )
+    # TMA-drain adds D drain warps on top of the send threads, so the TMA send width clamps
+    # to 512 (the largest power-of-2 with +32 <= the 1024-thread block cap). D=1 is the
+    # validated single-warp drain (~305 GB/s on GB300); D>1 parallelises it but is WIP.
+    tma_dwarps = max(
+        1, int(os.environ.get("A2A_CUTE_TMA_DWARPS", str(config.tma_drain_warps)))
+    )
+    if tma_variant and num_threads > 1024 - tma_dwarps * 32:
+        num_threads = 512
+    # num_threads: analytic _pick_tile, overridden by a tuned/explicit config (0 = analytic),
+    # an env knob winning over the config; the override cascades into num_tiles / num_slots.
+    if "A2A_CUTE_NT" not in os.environ and config.num_threads:
+        units = chunk // vec
+        nt = min(config.num_threads, units)
+        while nt > 1 and units % nt:
+            nt -= 1
+        num_threads = nt
+    # Re-apply the TMA block-thread budget AFTER the config.num_threads override: that override
+    # is NOT gated on `not tma_variant` (num_threads IS a tuned knob for the tma primitive), so a
+    # tuned value (e.g. 1024) could make the block dim num_threads + tma_dwarps*32 exceed the
+    # 1024-thread cap and fail the launch. Re-clamp keeps a fitting tuned value and only clamps
+    # when it would overflow.
+    if tma_variant and num_threads > 1024 - tma_dwarps * 32:
+        num_threads = 512
+    num_tiles = chunk // (num_threads * vec)
+    num_slots, tiles_per_slot = _pick_slots(num_tiles, chunk * input.element_size())
+    if "A2A_CUTE_SLOTS" not in os.environ and config.num_slots:
+        want = max(1, min(config.num_slots, num_tiles))
+        tiles_per_slot = (num_tiles + want - 1) // want
+        num_slots = (num_tiles + tiles_per_slot - 1) // tiles_per_slot
+    check_transfer(transport, chunk, input.dtype, nb)
+    cap_elems = transport.per_peer_bytes // input.element_size()
+    mbp = transport.max_blocks_per_peer
+
+    table = transport.endpoints_device()
+    send_ctr, recv_ctr = transport.step_state()
+
+    in2d = from_dlpack(input.view(ws, chunk), assumed_align=16)
+    out2d = from_dlpack(output.view(ws, chunk), assumed_align=16)
+    # TMA-drain reads MY local staging buffer (where peers wrote) as [ws, chunk] (row
+    # stride cap_elems) -- the descriptor source for the drain bounce. Built only for
+    # the TMA variant; other variants pass out2d as an unused placeholder so the
+    # compiled signature stays uniform.
+    if tma_variant:
+        stg_full = transport.handle.get_buffer(
+            transport.local_rank, sizes=[ws, cap_elems], dtype=input.dtype
+        )
+        stg_arg = from_dlpack(stg_full[:, :chunk], assumed_align=16)
+    else:
+        stg_arg = out2d
+    buf_c = from_dlpack(table.buffer_ptrs, assumed_align=8)
+    sig_c = from_dlpack(table.signal_pad_ptrs, assumed_align=8)
+    send_c = from_dlpack(send_ctr, assumed_align=8)
+    recv_c = from_dlpack(recv_ctr, assumed_align=8)
+    stream = _cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    # Register-blocking unroll for the NVLink store loop (in-flight stores/thread): the
+    # per-SM injection lever (GB300 ncu: unroll 1->8 cut the 64MB send leg ~1.55x and
+    # lifted the large band ~0.62->~0.90x NCCL; 16 spills the register file). Default to 8
+    # once the per-peer chunk is large enough for the unrolled body to engage (tiny sizes
+    # keep 1); a tuned/explicit config (0 = analytic) overrides, an env knob winning over it.
+    _u_default = 8 if chunk * input.element_size() >= 64 * 1024 else 1
+    unroll = max(1, int(os.environ.get("A2A_CUTE_UNROLL", str(_u_default))))
+    if "A2A_CUTE_UNROLL" not in os.environ and config.unroll:
+        unroll = max(1, config.unroll)
+    # CGA cluster size along the block axis (co-locate the blocks targeting one peer on one
+    # GPC): raises the per-SM NVLink send rate at the >=256MB band but regresses the mid
+    # band, so 0 = analytic default (cluster the large band, else off), -1 = max, >0 =
+    # explicit. Capped at the portable cluster size and collapsed to 1 unless it divides
+    # num_blocks (so a large SM-budget nb, e.g. 19, runs cluster-off instead of tripping
+    # CUDA_ERROR_INVALID_CLUSTER_SIZE). An env knob wins over the config.
+    _cl_default = 0 if chunk * input.element_size() >= 64 * 1024 * 1024 else 1
+    _cl_env = os.environ.get("A2A_CUTE_CLUSTER")
+    _cl = int(_cl_env) if _cl_env is not None else (config.cluster or _cl_default)
+    cluster = min(nb if _cl <= 0 else _cl, _MAX_PORTABLE_CLUSTER)
+    cluster_y = max(1, int(os.environ.get("A2A_CUTE_CLUSTER_Y", str(config.cluster_y))))
+    if nb % cluster:
+        cluster = 1
+    if ws % cluster_y:
+        cluster_y = 1
+
+    key = (
+        "a2a",
+        nb,
+        num_threads,
+        vec,
+        input.dtype,
+        ws,
+        chunk,
+        cap_elems,
+        mbp,
+        num_slots,
+        tiles_per_slot,
+        unroll,
+        send_only,
+        cluster,
+        cluster_y,
+        tma_variant,
+        tma_dwarps,
+        produce,
+        consume,
+        rows,
+    )
+    compiled = _COMPILED.get(key)
+    if compiled is None:
+        _ensure_cuda_rt_compat()  # lazy: shim cuda-bindings before this cute.compile path
+        logger.info(
+            "compiling cute a2a: ws=%s chunk=%s nb=%s nt=%s vec=%s",
+            ws,
+            chunk,
+            nb,
+            num_threads,
+            vec,
+        )
+        cfg = _A2ACfg(
+            num_blocks=nb,
+            num_threads=num_threads,
+            vec=vec,
+            dtype=cdtype,
+            dbits=dbits,
+            world_size=ws,
+            local_rank=transport.local_rank,
+            chunk=chunk,
+            cap_elems=cap_elems,
+            mbp=mbp,
+            num_slots=num_slots,
+            tiles_per_slot=tiles_per_slot,
+            unroll=unroll,
+            send_only=send_only,
+            cluster=cluster,
+            cluster_y=cluster_y,
+            tma=tma_variant,
+            tma_drain_warps=tma_dwarps,
+        )
+        # Pick the @cute.jit entry at the host level (real Python branch): the TMA
+        # variant routes through _launch_a2a_tma (extra stg_arg + smem), everything
+        # else through _launch_a2a. This keeps the dead variant's body out of the
+        # trace. The cfg is UNPACKED into individual constexpr args at the
+        # cute.compile boundary -- never passed as a single Constexpr object.
+        if tma_variant:
+            compiled = cute.compile(
+                _launch_a2a_tma,
+                in2d,
+                out2d,
+                stg_arg,
+                buf_c,
+                sig_c,
+                send_c,
+                recv_c,
+                cfg.num_blocks,
+                cfg.num_threads,
+                cfg.vec,
+                cfg.dtype,
+                cfg.dbits,
+                cfg.world_size,
+                cfg.local_rank,
+                cfg.chunk,
+                cfg.cap_elems,
+                cfg.mbp,
+                cfg.num_slots,
+                cfg.tiles_per_slot,
+                cfg.unroll,
+                cfg.tma_stages,
+                cfg.tma_drain_warps,
+                cfg.cluster,
+                cfg.cluster_y,
+                stream,
+            )
+        else:
+            compiled = cute.compile(
+                _launch_a2a,
+                in2d,
+                out2d,
+                buf_c,
+                sig_c,
+                send_c,
+                recv_c,
+                cfg.num_blocks,
+                cfg.num_threads,
+                cfg.vec,
+                cfg.dtype,
+                cfg.dbits,
+                cfg.world_size,
+                cfg.local_rank,
+                cfg.chunk,
+                cfg.cap_elems,
+                cfg.mbp,
+                cfg.num_slots,
+                cfg.tiles_per_slot,
+                cfg.unroll,
+                cfg.send_only,
+                cfg.direct,
+                cfg.cluster,
+                cfg.cluster_y,
+                produce,
+                consume,
+                rows,
+                stream,
+            )
+        _COMPILED[key] = compiled
+    if tma_variant:
+        compiled(in2d, out2d, stg_arg, buf_c, sig_c, send_c, recv_c, stream)
+    else:
+        compiled(in2d, out2d, buf_c, sig_c, send_c, recv_c, stream)
+
+
+def _check_zc_input(input: torch.Tensor, transport: NvlTransport) -> None:
+    """Shared zero-copy (direct/ce) input preconditions -- raise (not ``assert``, so they still
+    guard under ``python -O``)."""
+    if not (input.is_cuda and input.is_contiguous()):
+        raise ValueError("all_to_all_zc requires a contiguous CUDA input")
+    if input.dtype not in _CUTLASS_DTYPE:
+        raise ValueError(f"cute a2a supports {list(_CUTLASS_DTYPE)}, got {input.dtype}")
+    if input.numel() % transport.world_size != 0:
+        raise ValueError("equal-split requires numel % world_size == 0")
+
+
+def _all_to_all_direct(
+    transport: NvlTransport,
+    input: torch.Tensor,
+    *,
+    config: CuteA2AConfig,
+) -> torch.Tensor:
+    """Zero-copy DirectWrite all_to_all: each rank writes its chunks STRAIGHT into
+    peers' symmetric-memory output buffers (no staging, no drain), then reads the
+    result from its own symm-mem buffer. Returns that buffer view as the output, so
+    the transport must be sized ``per_peer_bytes == chunk * elem``. This is the
+    theoretical-minimum-work kernel (one NVLink store/elem + one fence); its busbw
+    is the per-SM send-rate ceiling that bounds every staging variant from above.
+
+    Honors the same tuned ``CuteA2AConfig`` knobs the staging path does -- a field
+    left at its sentinel (``0``) takes the analytic adaptive pick (``_pick_tile`` /
+    ``_pick_cluster``), an explicit value (from a tuned direct entry) overrides, and
+    an env knob wins over both -- so a tuned direct config drives ``num_threads`` /
+    ``unroll`` / ``cluster`` / ``cluster_y`` at launch, not just ``num_blocks``."""
+    _check_zc_input(input, transport)
+    ws = transport.world_size
+    numel = input.numel()
+    chunk = numel // ws
+    num_blocks = config.num_blocks
+    cdtype, dbits = _CUTLASS_DTYPE[input.dtype]
+    num_threads, vec = _pick_tile(chunk, dbits, num_blocks * ws)
+    # num_threads: analytic _pick_tile, overridden by a tuned config (0 = analytic),
+    # an env knob still winning over the config -- mirrors the staging path.
+    if "A2A_CUTE_NT" not in os.environ and config.num_threads:
+        units = chunk // vec
+        nt = min(config.num_threads, units)
+        while nt > 1 and units % nt:
+            nt -= 1
+        num_threads = nt
+    num_tiles = chunk // (num_threads * vec)
+    check_transfer(transport, chunk, input.dtype, num_blocks)
+    cap_elems = transport.per_peer_bytes // input.element_size()
+    # The flat get_buffer([numel]) return assumes slot s starts at s*chunk, but slots live at
+    # s*cap_elems; equality is the only sizing where the flat view IS the contiguous a2a result
+    # while keeping the true zero-copy return (a strided [:,:chunk].reshape would force a copy).
+    if cap_elems != chunk:
+        raise ValueError("direct needs per_peer_bytes == chunk * elem")
+    mbp = transport.max_blocks_per_peer
+    # Register-block N independent 16B loads then N stores (NCCL COLL_UNROLL) so N
+    # NVLink stores stay in flight per thread -- the dominant per-SM send-rate lever.
+    # Mirror the staging path's size-aware default: a hardcoded unroll of 1 leaves
+    # ~12-18% busbw on the table (GB300 measured 0.98->1.09x NCCL at 96 MiB/peer,
+    # 1.04->1.16x at 48 MiB/peer going unroll 1->8). A tuned config (0 = analytic)
+    # overrides; an env knob wins over it.
+    _u_default = 8 if chunk * input.element_size() >= 64 * 1024 else 1
+    unroll = max(1, int(os.environ.get("A2A_CUTE_UNROLL", str(_u_default))))
+    if "A2A_CUTE_UNROLL" not in os.environ and config.unroll:
+        unroll = max(1, config.unroll)
+    # Direct is the pure-send path -> CGA cluster raises its send-rate ceiling; pick the adaptive
+    # default (cluster every block per peer at the large band). Precedence: an A2A_CUTE_CLUSTER env
+    # value wins (routed through _pick_cluster, which parses int(env): <=0 = max = num_blocks
+    # sentinel, >0 = explicit count, both capped at the portable cap and dropped to 1 if they don't
+    # divide num_blocks), else a tuned config.cluster (0 = analytic, -1 = max, >0 = explicit), else
+    # the analytic _pick_cluster. The env value IS parsed here (same as staging) -- it just goes
+    # through _pick_cluster rather than being read inline.
+    _cl_env = os.environ.get("A2A_CUTE_CLUSTER")
+    if _cl_env is not None:
+        cluster = _pick_cluster(num_blocks, chunk * input.element_size())
+    elif config.cluster:
+        _cl = num_blocks if config.cluster < 0 else config.cluster
+        cluster = min(_cl, _MAX_PORTABLE_CLUSTER)
+        if num_blocks % cluster:
+            cluster = 1
+    else:
+        cluster = _pick_cluster(num_blocks, chunk * input.element_size())
+    cluster_y = max(1, int(os.environ.get("A2A_CUTE_CLUSTER_Y", str(config.cluster_y))))
+    if ws % cluster_y:
+        cluster_y = 1
+
+    table = transport.endpoints_device()
+    send_ctr, recv_ctr = transport.step_state()
+    # The output IS this rank's symm-mem buffer: after the kernel, slot s holds the
+    # chunk sender s wrote, i.e. the a2a output. A fresh per-call view (graph-safe).
+    output = transport.handle.get_buffer(
+        transport.local_rank, sizes=[numel], dtype=input.dtype, storage_offset=0
+    )
+
+    in2d = from_dlpack(input.view(ws, chunk), assumed_align=16)
+    buf_c = from_dlpack(table.buffer_ptrs, assumed_align=8)
+    sig_c = from_dlpack(table.signal_pad_ptrs, assumed_align=8)
+    send_c = from_dlpack(send_ctr, assumed_align=8)
+    recv_c = from_dlpack(recv_ctr, assumed_align=8)
+    stream = _cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    key = (
+        "a2a_direct",
+        num_blocks,
+        num_threads,
+        vec,
+        input.dtype,
+        ws,
+        chunk,
+        cap_elems,
+        mbp,
+        unroll,
+        cluster,
+        cluster_y,
+    )
+    compiled = _COMPILED.get(key)
+    if compiled is None:
+        _ensure_cuda_rt_compat()  # lazy: shim cuda-bindings before this cute.compile path
+        cfg = _A2ACfg(
+            num_blocks=num_blocks,
+            num_threads=num_threads,
+            vec=vec,
+            dtype=cdtype,
+            dbits=dbits,
+            world_size=ws,
+            local_rank=transport.local_rank,
+            chunk=chunk,
+            cap_elems=cap_elems,
+            mbp=mbp,
+            # direct is drain-free (no slot pipeline): the direct kernel never reads
+            # num_slots/tiles_per_slot, so these are unused placeholders that only satisfy
+            # the (required) _A2ACfg fields. They are deliberately out of the compile key.
+            num_slots=1,
+            tiles_per_slot=num_tiles,
+            unroll=unroll,
+            direct=True,
+            cluster=cluster,
+            cluster_y=cluster_y,
+        )
+        # Unpack cfg into individual constexpr args at the cute.compile boundary
+        # (in2d passed twice: out2d is unused on the direct path).
+        compiled = cute.compile(
+            _launch_a2a,
+            in2d,
+            in2d,
+            buf_c,
+            sig_c,
+            send_c,
+            recv_c,
+            cfg.num_blocks,
+            cfg.num_threads,
+            cfg.vec,
+            cfg.dtype,
+            cfg.dbits,
+            cfg.world_size,
+            cfg.local_rank,
+            cfg.chunk,
+            cfg.cap_elems,
+            cfg.mbp,
+            cfg.num_slots,
+            cfg.tiles_per_slot,
+            cfg.unroll,
+            cfg.send_only,
+            cfg.direct,
+            cfg.cluster,
+            cfg.cluster_y,
+            copy_produce,
+            copy_consume,
+            0,
+            stream,
+        )
+        _COMPILED[key] = compiled
+    compiled(in2d, in2d, buf_c, sig_c, send_c, recv_c, stream)  # out2d unused
+    return output
+
+
+# Block-cooperative SMEM transpose tile (bank-conflict-free classic transpose): 32x32 tile,
+# 8 thread-rows -> 256 threads/CTA, each thread streams 4 rows. rows/cols must be tile-multiples.
+_TR_TILE: int = 32
+_TR_BLOCK_ROWS: int = 8
+
+# Per-peer byte crossover for the transpose variant auto-select. GB300 8xGB300 A/B (bit-exact,
+# vs the production reference): the STAGED orchestrated variant wins/on-par small+mid
+# (2MB 1.47x, 8MB 0.97x, 32MB 1.06x) but its ``empty_like`` scratch crashes above (2GB CUDA
+# illegal access); the scratch-free FUSED kernel wins the large band (128MB-2GB, 1.3-11.8x) and
+# is OOM-safe. So route <=32MB/peer -> orchestrated, above -> fused.
+_TR_ORCH_MAX_BYTES: int = 32 * 1024 * 1024
+
+
+def all_to_all_transpose(
+    transport: NvlTransport,
+    input: torch.Tensor,
+    rows: int,
+    *,
+    config: CuteA2AConfig | None = None,
+) -> torch.Tensor:
+    """Non-contiguous all_to_all: each received ``[rows, cols]`` chunk arrives TRANSPOSED to
+    ``[cols, rows]``, via the block-tile ``transpose_tile`` HOOK. Auto-selects the best variant
+    per size from the GB300 A/B: the STAGED :func:`all_to_all_transpose_orchestrated` (block-hook
+    transpose -> tuned zero-copy a2a) for <=32MB/peer (small+mid, where it wins/on-par vs the
+    production reference:
+    2MB 1.47x, 8MB 0.97x, 32MB 1.06x), and the mem-efficient single-fused
+    :func:`all_to_all_transpose_fused` above (the large band 128MB-2GB, where it wins 1.3-11.8x
+    and is scratch-free/OOM-safe -- orchestrated's ``empty_like`` scratch crashes at 2GB).
+    ``A2A_TR_ORCH`` forces one path (``1`` = orchestrated, ``0`` = fused). ``rows`` and
+    ``chunk // rows`` (= cols) must be multiples of 32."""
+    _orch = os.environ.get("A2A_TR_ORCH")
+    if _orch == "1":
+        return all_to_all_transpose_orchestrated(transport, input, rows, config=config)
+    if _orch != "0":
+        per_peer_bytes = (input.numel() // transport.world_size) * input.element_size()
+        if per_peer_bytes <= _TR_ORCH_MAX_BYTES:
+            return all_to_all_transpose_orchestrated(
+                transport, input, rows, config=config
+            )
+    return all_to_all_transpose_fused(transport, input, rows, config=config)
+
+
+def all_to_all_transpose_orchestrated(
+    transport: NvlTransport,
+    input: torch.Tensor,
+    rows: int,
+    *,
+    config: CuteA2AConfig | None = None,
+) -> torch.Tensor:
+    """Block-hook SMEM transpose into a scratch, then the tuned zero-copy a2a (each leg at its
+    peak). Wins the mid band on GB300, but the scratch OOM/crashes at the top of the ladder
+    (2GB) -- use :func:`all_to_all_transpose` (fused, mem-efficient) for the full range. Kept as
+    an autotuner-selectable mid-band variant (pending the top-of-ladder memory hardening)."""
+    from ..transpose import transpose_chunks
+
+    _check_zc_input(input, transport)
+    ws = transport.world_size
+    chunk = input.numel() // ws
+    if rows <= 0 or chunk % rows:
+        raise ValueError(f"rows={rows} must divide the per-peer chunk={chunk}")
+    cols = chunk // rows
+    if rows % _TR_TILE or cols % _TR_TILE:
+        raise ValueError(
+            f"transpose needs rows/cols % {_TR_TILE} == 0, got {rows}x{cols}"
+        )
+    scratch = torch.empty_like(input)
+    transpose_chunks(scratch, input, ws, rows, cols)
+    return all_to_all_zc(transport, scratch, primitive="direct", config=config)
+
+
+def all_to_all_transpose_fused(
+    transport: NvlTransport,
+    input: torch.Tensor,
+    rows: int,
+    *,
+    config: CuteA2AConfig | None = None,
+) -> torch.Tensor:
+    """Single-fused-kernel variant: the block-cooperative SMEM transpose (``transpose_tile``
+    block-hook) is written zero-copy STRAIGHT into peers' symm-mem output buffers in ONE kernel
+    (no scratch). Fastest at the small/large bands; the default single-buffer store leg is
+    barrier-per-tile, so it loses the mid band on GB300 (8MB 0.75x vs the orchestrated 0.99x).
+    ``A2A_TR_PIPELINE=2`` selects the depth-2 load/store software pipeline (overlaps each tile's
+    NVLink stores with the next tile's HBM load, one barrier/tile) to close that gap. The fused-vs-
+    orchestrated *variant* is size-selected by :func:`all_to_all_transpose`, but this kernel's
+    ``num_blocks`` is analytic (occupancy ramp below) -- it does NOT consume a tuned ``config``.
+    ``rows``/``cols`` must be multiples of 32."""
+    _check_zc_input(input, transport)
+    ws = transport.world_size
+    numel = input.numel()
+    chunk = numel // ws
+    if rows <= 0 or chunk % rows:
+        raise ValueError(f"rows={rows} must divide the per-peer chunk={chunk}")
+    cols = chunk // rows
+    if rows % _TR_TILE or cols % _TR_TILE:
+        raise ValueError(
+            f"transpose needs rows/cols % {_TR_TILE} == 0, got {rows}x{cols}"
+        )
+    cdtype, dbits = _CUTLASS_DTYPE[input.dtype]
+    # No tuned-config lookup here: num_blocks is analytic (occupancy ramp below) and the geometry
+    # guard is built from a synthetic config reflecting the real launch, so a lookup would be dead.
+    # `config` stays in the signature only for symmetry with the orchestrated variant.
+    mbp = transport.max_blocks_per_peer
+    # The fused SMEM transpose is occupancy-bound: each tile does load->barrier->store, so it
+    # needs many CTA waves to hide the barrier stalls (measured 8xH100 8MB: 4 blocks/peer =
+    # 0.33x reference, 32 blocks/peer = 0.99x). UNLIKE the plain a2a's small SM-matched grid, so
+    # default to a full blocks/peer grid -- but cap at the actual per-peer 2D-tile count so a
+    # tiny chunk (e.g. 64x64 = 4 tiles) does not over-launch idle CTAs (which cost 0.39x at 8KB).
+    # num_blocks*ws is a full-SM grid at scale, keeping a fair full-device budget.
+    # Size ramp: signal/sync overhead scales with block count, so small chunks want few blocks
+    # (8xH100 64KB: 4 blocks = 1.88x reference, 32 = 0.54x) while large chunks want a full grid for
+    # occupancy (8MB: 32 = 1.00x). Ramp ~1 block per 256KB, floored at 4, capped by mbp and the
+    # actual per-peer tile count. The autotuner refines this per size (transpose tuned entries).
+    ntiles_pp = (rows // _TR_TILE) * (cols // _TR_TILE)
+    chunk_bytes = chunk * input.element_size()
+    num_blocks = min(ntiles_pp, max(4, min(mbp, chunk_bytes // (256 * 1024))))
+    num_blocks = max(1, num_blocks)
+    _tr_blk = os.environ.get("A2A_TR_BLOCKS")
+    if _tr_blk:
+        num_blocks = max(1, min(int(_tr_blk), mbp, ntiles_pp))
+    # Opt-in depth-2 load/store software pipeline: overlaps each tile's NVLink stores with the
+    # next tile's coalesced HBM load (one barrier/tile, not two) to close the mid-band gap.
+    # Default 1 = the GB300-validated single-buffer path; flip the default once depth-2 is
+    # A/B-validated on GB300 (bit-exact is verified on H100 for both depths).
+    # Store-unroll factor U (A2A_TR_PIPELINE): batch U 2D-tiles per barrier group so U*(tile/
+    # block_rows) NVLink stores are in flight and barriers drop to 2/U-per-tile (vs 2 for U=1),
+    # closing the mid-band gap. Default 1 = the GB300-validated single-buffer path; flip the
+    # default once a U is A/B-validated on GB300 (bit-exact is verified on H100 for U>1).
+    pipeline_depth = max(1, min(8, int(os.environ.get("A2A_TR_PIPELINE", "1"))))
+    check_transfer(transport, chunk, input.dtype, num_blocks)
+    cap_elems = transport.per_peer_bytes // input.element_size()
+    if cap_elems != chunk:
+        raise ValueError("transpose (zero-copy) needs per_peer_bytes == chunk * elem")
+    # Guard on the ACTUAL launch geometry, not the resolved `config`: this path computes
+    # num_blocks analytically (the occupancy ramp above, independent of config.num_blocks) and
+    # always transfers zero-copy DirectWrite. Validating with `config` (which may carry a copy
+    # primitive / a different num_blocks) would let a real geometry switch slip past the guard on
+    # a reused transport, since the stashed signature would not reflect the real per-(peer,block)
+    # step-counter shape. Build the signature from the values actually used at launch (mirrors the
+    # ce path's synthetic CuteA2AConfig(primitive="ce")).
+    check_geometry(
+        transport,
+        CuteA2AConfig(num_blocks=num_blocks, primitive="direct"),
+        CUTE_A2A_GEOMETRY_FIELDS,
+    )
+
+    table = transport.endpoints_device()
+    send_ctr, recv_ctr = transport.step_state()
+    output = transport.handle.get_buffer(
+        transport.local_rank, sizes=[numel], dtype=input.dtype, storage_offset=0
+    )
+    in2d = from_dlpack(input.view(ws, chunk), assumed_align=16)
+    buf_c = from_dlpack(table.buffer_ptrs, assumed_align=8)
+    sig_c = from_dlpack(table.signal_pad_ptrs, assumed_align=8)
+    send_c = from_dlpack(send_ctr, assumed_align=8)
+    recv_c = from_dlpack(recv_ctr, assumed_align=8)
+    stream = _cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    key = (
+        "a2a_transpose",
+        num_blocks,
+        input.dtype,
+        ws,
+        rows,
+        cols,
+        cap_elems,
+        mbp,
+        pipeline_depth,
+    )
+    compiled = _COMPILED.get(key)
+    if compiled is None:
+        _ensure_cuda_rt_compat()
+        compiled = cute.compile(
+            _launch_a2a_transpose,
+            in2d,
+            in2d,  # out2d unused (zero-copy)
+            buf_c,
+            sig_c,
+            send_c,
+            recv_c,
+            cdtype,
+            dbits,
+            num_blocks,
+            transport.local_rank,
+            chunk,
+            cap_elems,
+            mbp,
+            ws,
+            rows,
+            cols,
+            _TR_TILE,
+            _TR_BLOCK_ROWS,
+            pipeline_depth,
+            transpose_tile,
+            stream,
+        )
+        _COMPILED[key] = compiled
+    compiled(in2d, in2d, buf_c, sig_c, send_c, recv_c, stream)
+    return output
+
+
+def _ce_buf_host(transport: NvlTransport, table) -> list[int]:
+    """Host-side peer symm-mem buffer base addresses (cached on the transport).
+
+    Read once (a device->host copy) and reused, so the timed/CUDA-graph-captured
+    region issues only ``cuMemcpyAsync`` + the signal kernel (no host sync)."""
+    cached = getattr(transport, "_a2a_ce_buf_host", None)
+    if cached is None:
+        cached = table.buffer_ptrs.cpu().tolist()
+        transport._a2a_ce_buf_host = cached  # pyre-ignore[16]: runtime cache
+    return cached
+
+
+def _all_to_all_ce(transport: NvlTransport, input: torch.Tensor) -> torch.Tensor:
+    """Copy-engine zero-copy all_to_all: move data with ``cuMemcpyAsync`` (the GB300
+    copy engines, zero SM occupancy) straight into peers' symmetric-memory output
+    buffers, then a 1-CTA kernel does the cross-rank completion handshake. Frees all
+    SMs for compute overlap; wins the very-large band where the copy engines sustain
+    more BW than per-SM NVLink stores (ported from Cen's ``ce_a2a_zc``, D108841080).
+    Returns this rank's symm-mem buffer view (slot s = chunk from sender s)."""
+    _check_zc_input(input, transport)
+    ws = transport.world_size
+    numel = input.numel()
+    chunk = numel // ws
+    elem = input.element_size()
+    per_peer_bytes = chunk * elem
+    cap_elems = transport.per_peer_bytes // elem
+    # The final get_buffer([numel]) is a contiguous view that equals the a2a output only when
+    # cap_elems == chunk (cuMemcpyAsync writes slot s at s*cap_bytes); == keeps the flat
+    # zero-copy return correct without a strided reshape/copy.
+    if cap_elems != chunk:
+        raise ValueError("ce needs per_peer_bytes == chunk * elem")
+    cap_bytes = cap_elems * elem
+    rank = transport.local_rank
+    mbp = transport.max_blocks_per_peer
+    table = transport.endpoints_device()
+    buf_host = _ce_buf_host(transport, table)
+    src_base = input.data_ptr()
+    raw_stream = torch.cuda.current_stream().cuda_stream
+
+    # Round-robin peer order: every rank starts at a different peer so the N remote
+    # writes do not all incast onto one destination at once.
+    for step in range(ws):
+        peer = (rank + step) % ws
+        src = src_base + peer * per_peer_bytes
+        dst = buf_host[peer] + rank * cap_bytes
+        (err,) = _cuda_driver.cuMemcpyAsync(dst, src, per_peer_bytes, raw_stream)
+        # External driver return code must survive -O (an assert can be stripped, turning a
+        # failed copy into a silent read of undefined peer data).
+        if err != _cuda_driver.CUresult.CUDA_SUCCESS:
+            raise RuntimeError(f"cuMemcpyAsync failed: {err}")
+
+    send_ctr, recv_ctr = transport.step_state()
+    sig_c = from_dlpack(table.signal_pad_ptrs, assumed_align=8)
+    send_c = from_dlpack(send_ctr, assumed_align=8)
+    recv_c = from_dlpack(recv_ctr, assumed_align=8)
+    stream = _cuda_driver.CUstream(raw_stream)
+    key = ("a2a_ce", ws, rank, mbp)
+    compiled = _COMPILED.get(key)
+    if compiled is None:
+        _ensure_cuda_rt_compat()  # lazy: shim cuda-bindings before this cute.compile path
+        k = _CeSignalKernel(world_size=ws, local_rank=rank, mbp=mbp)
+        compiled = cute.compile(k, sig_c, send_c, recv_c, stream)
+        _COMPILED[key] = compiled
+    compiled(sig_c, send_c, recv_c, stream)
+    return transport.handle.get_buffer(
+        rank, sizes=[numel], dtype=input.dtype, storage_offset=0
+    )
+
+
+def all_to_all_zc(
+    transport: NvlTransport,
+    input: torch.Tensor,
+    *,
+    primitive: str = "direct",
+    config: CuteA2AConfig | None = None,
+) -> torch.Tensor:
+    """Zero-copy all_to_all: write each chunk straight into peers' symmetric-memory buffers
+    and return this rank's buffer view (slot ``s`` = the chunk from sender ``s``); the buffer
+    is read back in place, so the transport must be sized ``per_peer_bytes == chunk * elem``.
+    ``primitive='direct'`` is the DirectWrite NVLink-store path; ``'ce'`` is the copy-engine
+    path (``cuMemcpyAsync`` on the GB300 copy engines, zero SM occupancy). For ``'direct'``,
+    ``config`` supplies the tuned launch knobs (``num_blocks`` plus ``num_threads`` / ``unroll``
+    / ``cluster`` / ``cluster_y``; a sentinel ``0`` takes the analytic pick); the copy-engine
+    path has no grid and ignores ``config``."""
+    if primitive == "direct":
+        if config is None:
+            # Mirror the staging path + the Triton twin: a None config looks up the
+            # tuned table by the runtime key so a tuned direct entry's knobs apply,
+            # falling back to the analytic default.
+            config = get_a2a_config(make_a2a_key(input, transport))
+        # Same geometry guard as the staging all_to_all: the zero-copy paths drive the
+        # transport's persistent step counters too, so switching num_blocks/primitive on a
+        # reused transport without a drain is the identical hazard. Guard AFTER the config is
+        # resolved, BEFORE dispatch.
+        check_geometry(transport, config, CUTE_A2A_GEOMETRY_FIELDS)
+        return _all_to_all_direct(transport, input, config=config)
+    if primitive == "ce":
+        # ce has no grid (1-CTA signal kernel) so no num_blocks knob; check the geometry
+        # signature against a config that names this primitive so a copy/direct -> ce switch
+        # on a reused transport is still flagged.
+        check_geometry(
+            transport, CuteA2AConfig(primitive="ce"), CUTE_A2A_GEOMETRY_FIELDS
+        )
+        return _all_to_all_ce(transport, input)
+    raise ValueError(
+        f"all_to_all_zc supports primitive 'direct' or 'ce'; got {primitive!r}"
+    )

--- a/comms/dsl/cute/a2a/schedules.py
+++ b/comms/dsl/cute/a2a/schedules.py
@@ -1,0 +1,1028 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# pyre-ignore-all-errors[6, 29, 35, 58]: @cute.kernel / @cute.jit constexpr params are
+# annotated cutlass.Constexpr; pyre models that as Constexpr[Any] and rejects the
+# arithmetic / range() / dataclass-field uses the kernel bodies do on them, and the calls
+# to the produce/consume hook constexprs ([29]) -- the values are real compile-time ints /
+# callables at trace time. The identical Triton/tuning twins are accepted under the same
+# file-level idiom.
+
+"""Device kernels for the fused all_to_all in the CuTe DSL (symmetric-memory NVLink).
+
+The on-device half of the CuTe all_to_all: the free ``@cute.kernel`` schedules, the
+``@cute.jit`` launchers (``_launch_a2a`` / ``_launch_a2a_tma``), the shared copy
+atoms, the CGA-cluster sizing helper ``_pick_cluster`` (the tile/slot sizing
+``_pick_tile`` / ``_pick_slots`` are shared from ``cute/send_recv.py``), the
+host-side launch-constant bundle ``_A2ACfg``, and the copy-engine signal kernel
+``_CeSignalKernel``. The public host entries that look up a config and
+``cute.compile``/launch these kernels live in :mod:`comms.dsl.cute.a2a.host`.
+
+Each ``(peer, block)`` program streams its sub-chunk to the peer's staging over
+NVLink, publishes a data-ready signal, then drains the peer's matching staging slot
+into the output. Device-side peer addressing uses ``cute.make_ptr`` over the
+transport's int64 peer table (the same symmetric-memory base pointers the Triton
+kernel casts), so a single fused launch selects the peer on device via ``block_idx``
+instead of one launch per peer.
+
+Graph-safe: signalling uses the transport's persistent monotonic per-(peer, block)
+step counters + a TAIL (data-ready) / HEAD (slot-free) signal pair, exactly like the
+Triton path, so a transport is reusable across calls / CUDA-graph replays. The base
+kernel is single-shot per chunk (stage whole sub-chunk, then drain); the slot
+pipeline overlaps send/drain on top. The zero-copy ``direct`` path additionally
+launches with a CGA thread-block cluster (co-locating every block that targets one
+peer on a single GPC) -- on the pure-send path this raises the per-SM NVLink
+injection rate and lets direct beat NCCL at the large band (see ``_pick_cluster``).
+
+Scope: equal-split ``all_to_all_single``, identity copy (bf16/fp32), ``numel``
+divisible by ``world_size`` and the per-(peer,block) tile by the thread count.
+"""
+
+# Annotations are evaluated eagerly (no ``from __future__ import annotations``): the
+# @cute.kernel / @cute.jit launchers classify their compile-time params via the real
+# ``cutlass.Constexpr`` annotation object, which inspect.getfullargspec only exposes when
+# annotations are NOT stringized -- stringized annotations leave cute unable to tell a
+# constexpr from a dynamic arg and it mis-marshals the dtype.
+import os
+from dataclasses import dataclass
+from typing import Any
+
+# Importing send_recv runs its one-time setup (CUTE_DSL_ARCH detection +
+# cuda-bindings shim) AND imports cutlass; the os.environ statement below is a
+# barrier so the formatter cannot hoist the cutlass imports above this setup.
+from ..send_recv import _resolve_cute_dsl_arch
+
+os.environ.setdefault("CUTE_DSL_ARCH", _resolve_cute_dsl_arch())
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.cute.nvgpu.cpasync as cpasync
+import cutlass.utils as cutlass_utils
+
+from .. import nvl_ops
+from ..tma_smem import make_tma_smem
+
+
+@dataclass
+class _A2ACfg:
+    """Host-side bundle of the fused all_to_all launch constants, for readability at the
+    call site. It is NEVER passed as a single ``cutlass.Constexpr`` -- cute's tree-walk
+    would call ``__extract_mlir_values__`` on the ``dtype`` (a cutlass NumericMeta) and
+    crash on the tiny/odd-chunk paths. Always UNPACK it into individual positional args at
+    the ``cute.compile`` / ``.launch`` boundary."""
+
+    num_blocks: int
+    num_threads: int
+    vec: int
+    dtype: Any
+    dbits: int
+    world_size: int
+    local_rank: int
+    chunk: int
+    cap_elems: int
+    mbp: int
+    num_slots: int
+    tiles_per_slot: int
+    unroll: int = 1
+    direct: bool = False
+    send_only: bool = False
+    cluster: int = 1
+    cluster_y: int = 1
+    tma: bool = False
+    tma_stages: int = 4
+    tma_drain_warps: int = 1
+
+
+# Shared CuTe send/recv substrate (the copy leaves + the per-slot credit-ring
+# primitives) lives in ``cute/send_recv.py`` -- the backend substrate home, symmetric
+# with the Triton ``triton/send_recv.py`` holding ``send_step``/``recv_step``. a2a and
+# the standalone send/recv collective both compose the SAME ``_send_slot``/``_recv_slot``
+# (the C2 symmetric-substrate contract).
+from ..send_recv import (  # noqa: E402
+    _block_tile_u,
+    _copy_atom,
+    _copy_u,
+    _local_u,
+    _recv_slot,
+    _send_slot,
+)
+
+
+@cute.jit
+def _launch_a2a(
+    in2d,
+    out2d,
+    buf_ptrs,
+    sig_ptrs,
+    send_ctr,
+    recv_ctr,
+    num_blocks: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    vec: cutlass.Constexpr,
+    dtype: cutlass.Constexpr,
+    dbits: cutlass.Constexpr,
+    world_size: cutlass.Constexpr,
+    local_rank: cutlass.Constexpr,
+    chunk: cutlass.Constexpr,
+    cap_elems: cutlass.Constexpr,
+    mbp: cutlass.Constexpr,
+    num_slots: cutlass.Constexpr,
+    tiles_per_slot: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+    send_only: cutlass.Constexpr,
+    direct: cutlass.Constexpr,
+    cluster: cutlass.Constexpr,
+    cluster_y: cutlass.Constexpr,
+    produce: cutlass.Constexpr,
+    consume: cutlass.Constexpr,
+    rows: cutlass.Constexpr,
+    stream,
+) -> None:
+    # in2d / out2d are [world_size, chunk] views; per-peer chunk = row peer.
+    # The `direct` flag is constexpr, so the dispatch test is wrapped in
+    # cutlass.const_expr -- this folds the branch at trace time (only the selected
+    # schedule is traced). A bare `if flag:` on a constexpr would emit a traced
+    # scf.if and walk BOTH arms, instantiating the unselected kernel (e.g. the
+    # zero-copy `direct` kernel, whose symm-mem output addressing differs from the
+    # staging path -> a mistraced launch).
+    # CGA cluster dims (None == off); host guarantees the grid is divisible.
+    cl = (
+        [cluster, cluster_y, 1]
+        if cutlass.const_expr(cluster > 1 or cluster_y > 1)
+        else None
+    )
+    if cutlass.const_expr(direct):
+        # zero-copy: writes the peer's symm-mem output buffer; out2d unused.
+        _a2a_kernel_direct(
+            in2d,
+            out2d,
+            buf_ptrs,
+            sig_ptrs,
+            send_ctr,
+            recv_ctr,
+            dtype,
+            vec,
+            dbits,
+            num_blocks,
+            num_threads,
+            local_rank,
+            chunk,
+            cap_elems,
+            mbp,
+            unroll,
+        ).launch(
+            grid=(num_blocks, world_size, 1),
+            block=(num_threads, 1, 1),
+            cluster=cl,
+            stream=stream,
+        )
+    else:
+        _a2a_kernel(
+            in2d,
+            out2d,
+            buf_ptrs,
+            sig_ptrs,
+            send_ctr,
+            recv_ctr,
+            dtype,
+            vec,
+            dbits,
+            num_blocks,
+            num_threads,
+            local_rank,
+            chunk,
+            cap_elems,
+            mbp,
+            num_slots,
+            tiles_per_slot,
+            unroll,
+            send_only,
+            produce,
+            consume,
+            rows,
+        ).launch(
+            grid=(num_blocks, world_size, 1),
+            block=(num_threads, 1, 1),
+            cluster=cl,
+            stream=stream,
+        )
+
+
+@cute.jit
+def _launch_a2a_tma(
+    in2d,
+    out2d,
+    stg2d,
+    buf_ptrs,
+    sig_ptrs,
+    send_ctr,
+    recv_ctr,
+    num_blocks: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    vec: cutlass.Constexpr,
+    dtype: cutlass.Constexpr,
+    dbits: cutlass.Constexpr,
+    world_size: cutlass.Constexpr,
+    local_rank: cutlass.Constexpr,
+    chunk: cutlass.Constexpr,
+    cap_elems: cutlass.Constexpr,
+    mbp: cutlass.Constexpr,
+    num_slots: cutlass.Constexpr,
+    tiles_per_slot: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+    tma_stages: cutlass.Constexpr,
+    tma_drain_warps: cutlass.Constexpr,
+    cluster: cutlass.Constexpr,
+    cluster_y: cutlass.Constexpr,
+    stream,
+) -> None:
+    # Separate @cute.jit entry for the TMA-drain variant. It is selected at the
+    # HOST level (a real Python branch in ``all_to_all``) rather than via a
+    # ``if tma`` inside ``_launch_a2a`` -- CuTe traces BOTH arms of an in-kernel
+    # ``if`` on a host bool, so a dead TMA arm would still touch the TMA-only
+    # state and crash the non-TMA compile. stg2d is my local staging buffer
+    # as [ws, chunk] (row = sender): the descriptor source for the drain bounce.
+    tile_elems = num_threads * vec
+    total_bufs = tma_drain_warps * tma_stages
+    tma_smem = make_tma_smem(dtype, tile_elems, total_bufs)
+    tma_bytes = (dbits // 8) * tile_elems
+    cl = (
+        [cluster, cluster_y, 1]
+        if cutlass.const_expr(cluster > 1 or cluster_y > 1)
+        else None
+    )
+    # Build the TMA descriptors host-side (cutlass cpasync API): one bulk-tensor-
+    # tile G2S load over my staging [ws, chunk] and one S2G store over the output
+    # [ws, chunk], tiled (1, tile_elems) so a (peer, tile) coord selects each tile.
+    smem_layout = cute.make_layout((1, tile_elems))
+    cta_tiler = (1, tile_elems)
+    load_atom, load_tns = cpasync.make_tiled_tma_atom(
+        cpasync.CopyBulkTensorTileG2SOp(), stg2d, smem_layout, cta_tiler
+    )
+    store_atom, store_tns = cpasync.make_tiled_tma_atom(
+        cpasync.CopyBulkTensorTileS2GOp(), out2d, smem_layout, cta_tiler
+    )
+    _a2a_kernel_tma(
+        in2d,
+        out2d,
+        buf_ptrs,
+        sig_ptrs,
+        send_ctr,
+        recv_ctr,
+        load_atom,
+        load_tns,
+        store_atom,
+        store_tns,
+        dtype,
+        vec,
+        dbits,
+        num_blocks,
+        num_threads,
+        local_rank,
+        chunk,
+        cap_elems,
+        mbp,
+        num_slots,
+        tiles_per_slot,
+        unroll,
+        tma_stages,
+        tma_drain_warps,
+        tma_smem,
+        tile_elems,
+        tma_bytes,
+    ).launch(
+        grid=(num_blocks, world_size, 1),
+        block=(num_threads + tma_drain_warps * 32, 1, 1),
+        cluster=cl,
+        smem=tma_smem.size_in_bytes(),
+        stream=stream,
+    )
+
+
+@cute.kernel
+def _a2a_kernel(  # noqa: C901
+    in2d,
+    out2d,
+    buf_ptrs,
+    sig_ptrs,
+    send_ctr,
+    recv_ctr,
+    dtype: cutlass.Constexpr,
+    vec: cutlass.Constexpr,
+    dbits: cutlass.Constexpr,
+    num_blocks: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    local_rank: cutlass.Constexpr,
+    chunk: cutlass.Constexpr,
+    cap_elems: cutlass.Constexpr,
+    mbp: cutlass.Constexpr,
+    num_slots: cutlass.Constexpr,
+    tiles_per_slot: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+    send_only: cutlass.Constexpr,
+    produce: cutlass.Constexpr,
+    consume: cutlass.Constexpr,
+    rows: cutlass.Constexpr,
+) -> None:
+    tidx = cute.arch.thread_idx()[0]
+    b = cute.arch.block_idx()[0]
+    peer = cute.arch.block_idx()[1]
+    u = unroll
+    nb = num_blocks
+
+    # Vectorized copy: each thread moves VEC contiguous elements per copy, so
+    # the NVLink store is a vectorized st.global (up to 128-bit) instead of a
+    # scalar 16-bit store -- the single biggest copy-bandwidth lever (mirrors
+    # the Triton 128-bit-store fix). (num_threads, VEC) are chosen per chunk by
+    # the host (`_pick_tile`) so any size tiles exactly -- VEC drops to keep
+    # small/odd chunks correct (down to scalar), covering the whole 32B-2GB
+    # ladder with no tail. The tiler is num_threads*VEC elems/tile.
+    copy_atom = _copy_atom(dtype, vec, dbits)
+    tiled_copy = cute.make_tiled_copy_tv(
+        copy_atom, cute.make_layout(num_threads), cute.make_layout(vec)
+    )
+    thr_copy = tiled_copy.get_slice(tidx)
+
+    # This peer's contiguous input/output chunk (row `peer` of the [ws, chunk] views). Layout
+    # changes (rows>0 transpose) are NOT done here -- they run on the block-tile `transpose_tile`
+    # hook over a SMEM-staged 2D tile (see `host.all_to_all_transpose`); this schedule handles
+    # the contiguous copy + the per-element value hooks (produce/consume).
+    in_chunk = in2d[(peer, None)]
+    raw_chunk = in_chunk  # source handed to a gather hook via Ctx.src
+    out_chunk = out2d[(peer, None)]
+    tiler = cute.make_layout(num_threads * vec)
+    g_in = cute.zipped_divide(in_chunk, tiler)
+    g_out = cute.zipped_divide(out_chunk, tiler)
+    # Tile count from the actual divided layout (the authoritative value): the host
+    # also derives it for _pick_slots, but recomputing here keeps the kernel's tile
+    # bound tied to its own zipped_divide and never out of step with a host value.
+    num_tiles = cute.size(g_in, mode=[1])
+
+    # CuTe forbids early `return` in a kernel, so the diagonal (local) and the
+    # comm path are an if/else (peer is a runtime block index, not constexpr).
+    if peer == local_rank:
+        # Diagonal: local copy in_chunk -> out_chunk (no comm). Grid-stride
+        # `while` stays inline (CuTe captures control flow only here); the
+        # unrolled body is the straight-line `_copy_u`.
+        t = b
+        while t + (u - 1) * nb < num_tiles:
+            _local_u(
+                thr_copy,
+                copy_atom,
+                g_in,
+                g_out,
+                t,
+                u,
+                num_blocks,
+                produce,
+                consume,
+                src=raw_chunk,
+                tiler=tiler,
+                rows=rows,
+                chunk=chunk,
+                peer=peer,
+            )
+            t += u * nb
+        while t < num_tiles:
+            _local_u(
+                thr_copy,
+                copy_atom,
+                g_in,
+                g_out,
+                t,
+                1,
+                num_blocks,
+                produce,
+                consume,
+                src=raw_chunk,
+                tiler=tiler,
+                rows=rows,
+                chunk=chunk,
+                peer=peer,
+            )
+            t += nb
+    else:
+        # --- device-side symm-mem addressing for this peer ---
+        peer_buf_addr = buf_ptrs[peer]
+        my_buf_addr = buf_ptrs[local_rank]
+        peer_sig_addr = sig_ptrs[peer]
+        my_sig_addr = sig_ptrs[local_rank]
+
+        # Staging regions (elem layout [chunk]); sender `s` occupies the byte
+        # slot `s * cap_elems * elem_bytes` in a rank's buffer (Triton-path
+        # convention). SEND -> my sender slot inside peer's buffer; RECV ->
+        # peer's sender slot inside my buffer (byte addresses, int64).
+        elem_bytes = dbits // 8
+        cap_bytes = cap_elems * elem_bytes
+        send_addr = peer_buf_addr + local_rank * cap_bytes
+        recv_addr = my_buf_addr + peer * cap_bytes
+        send_ptr = cute.make_ptr(
+            dtype, send_addr, cute.AddressSpace.gmem, assumed_align=16
+        )
+        recv_ptr = cute.make_ptr(
+            dtype, recv_addr, cute.AddressSpace.gmem, assumed_align=16
+        )
+        send_region = cute.make_tensor(send_ptr, cute.make_layout(chunk))
+        recv_region = cute.make_tensor(recv_ptr, cute.make_layout(chunk))
+        g_send = cute.zipped_divide(send_region, tiler)
+        g_recv = cute.zipped_divide(recv_region, tiler)
+
+        step_idx = peer * mbp + b
+        start_send = send_ctr[step_idx]
+        start_recv = recv_ctr[step_idx]
+        # This (peer, block)'s own signal counters: block b sends ITS tile
+        # subset to the peer and signals its own counter; the peer's block b
+        # waits the matching counter and drains the SAME subset -- so the
+        # pipeline is fully independent across blocks (no cross-block sync).
+        tail_remote = peer_sig_addr + (local_rank * mbp + b) * 8
+        tail_local = my_sig_addr + (peer * mbp + b) * 8
+
+        # Slot pipeline, composed from the shared per-slot primitives: send slot s
+        # (NVLink store + TAIL) then drain slot s-1 (local HBM) so the still-in-flight
+        # stores of slot s overlap the drain. Disjoint regions (my-staging drain vs
+        # peer-staging store) -> no false dependency. num_slots is constexpr so this
+        # loop unrolls at trace time. _send_slot / _recv_slot are the CuTe twins of the
+        # Triton send_step / recv_step: a2a and the standalone send/recv compose the
+        # SAME primitives (the symmetric-substrate contract).
+        for s in range(num_slots):
+            _send_slot(
+                thr_copy,
+                copy_atom,
+                g_in,
+                g_send,
+                tail_remote,
+                start_send,
+                b,
+                tidx,
+                s,
+                tiles_per_slot,
+                num_tiles,
+                num_blocks,
+                unroll,
+                produce,
+                src=raw_chunk,
+                tiler=tiler,
+                rows=rows,
+                chunk=chunk,
+                peer=peer,
+            )
+            if not send_only:
+                if s >= 1:
+                    _recv_slot(
+                        thr_copy,
+                        copy_atom,
+                        g_recv,
+                        g_out,
+                        tail_local,
+                        start_recv,
+                        b,
+                        tidx,
+                        s - 1,
+                        tiles_per_slot,
+                        num_tiles,
+                        num_blocks,
+                        unroll,
+                        consume,
+                        peer=peer,
+                    )
+        # Drain the final slot (no later send to overlap it).
+        if not send_only:
+            _recv_slot(
+                thr_copy,
+                copy_atom,
+                g_recv,
+                g_out,
+                tail_local,
+                start_recv,
+                b,
+                tidx,
+                num_slots - 1,
+                tiles_per_slot,
+                num_tiles,
+                num_blocks,
+                unroll,
+                consume,
+                peer=peer,
+            )
+        if tidx == 0:
+            send_ctr[step_idx] = start_send + num_slots
+            recv_ctr[step_idx] = start_recv + num_slots
+
+
+@cute.kernel
+def _a2a_kernel_tma(  # noqa: C901
+    in2d,
+    out2d,
+    buf_ptrs,
+    sig_ptrs,
+    send_ctr,
+    recv_ctr,
+    load_atom,
+    load_tns,
+    store_atom,
+    store_tns,
+    dtype: cutlass.Constexpr,
+    vec: cutlass.Constexpr,
+    dbits: cutlass.Constexpr,
+    num_blocks: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    local_rank: cutlass.Constexpr,
+    chunk: cutlass.Constexpr,
+    cap_elems: cutlass.Constexpr,
+    mbp: cutlass.Constexpr,
+    num_slots: cutlass.Constexpr,
+    tiles_per_slot: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+    tma_stages: cutlass.Constexpr,
+    tma_drain_warps: cutlass.Constexpr,
+    tma_smem: cutlass.Constexpr,
+    tma_tile_elems: cutlass.Constexpr,
+    tma_bytes: cutlass.Constexpr,
+) -> None:
+    # TMA-drain: warps 1..N SEND (LSU NVLink stores, num_threads wide), warp 0
+    # DRAINS by bouncing my-staging -> smem -> out through the TMA/bulk-copy
+    # engine. The two legs touch disjoint memory and are coupled only by the
+    # cross-GPU signal pad, so they need NO intra-CTA barrier: warp 0 drains
+    # slot s (after the peer signals it) while the send warps fill slot s+1.
+    tidx = cute.arch.thread_idx()[0]
+    b = cute.arch.block_idx()[0]
+    peer = cute.arch.block_idx()[1]
+    u = unroll
+    nb = num_blocks
+    nt = num_threads
+    d_warps = tma_drain_warps
+    d_threads = d_warps * 32
+    warp = tidx // 32
+
+    copy_atom = _copy_atom(dtype, vec, dbits)
+    tiled_copy = cute.make_tiled_copy_tv(
+        copy_atom, cute.make_layout(nt), cute.make_layout(vec)
+    )
+    in_chunk = in2d[(peer, None)]
+    out_chunk = out2d[(peer, None)]
+    tiler = cute.make_layout(nt * vec)
+    g_in = cute.zipped_divide(in_chunk, tiler)
+    num_tiles = cute.size(g_in, mode=[1])
+
+    if peer == local_rank:
+        # Diagonal: the send warps copy the local chunk straight to out (no comm,
+        # no drain); the drain warps are idle.
+        if warp >= d_warps:
+            g_out = cute.zipped_divide(out_chunk, tiler)
+            thr = tiled_copy.get_slice(tidx - d_threads)
+            t = b
+            while t + (u - 1) * nb < num_tiles:
+                _copy_u(thr, copy_atom, g_in, g_out, t, u, num_blocks)
+                t += u * nb
+            while t < num_tiles:
+                _copy_u(thr, copy_atom, g_in, g_out, t, 1, num_blocks)
+                t += nb
+    else:
+        peer_buf_addr = buf_ptrs[peer]
+        peer_sig_addr = sig_ptrs[peer]
+        my_sig_addr = sig_ptrs[local_rank]
+        elem_bytes = dbits // 8
+        cap_bytes = cap_elems * elem_bytes
+        send_ptr = cute.make_ptr(
+            dtype,
+            peer_buf_addr + local_rank * cap_bytes,
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        )
+        g_send = cute.zipped_divide(
+            cute.make_tensor(send_ptr, cute.make_layout(chunk)), tiler
+        )
+        step_idx = peer * mbp + b
+        start_send = send_ctr[step_idx]
+        start_recv = recv_ctr[step_idx]
+        tail_remote = peer_sig_addr + (local_rank * mbp + b) * 8
+        tail_local = my_sig_addr + (peer * mbp + b) * 8
+
+        if warp >= d_warps:
+            # SEND warps: stage each slot to the peer, then publish data-ready.
+            thr = tiled_copy.get_slice(tidx - d_threads)
+            for s in range(num_slots):
+                s_lo = s * tiles_per_slot
+                s_hi = min((s + 1) * tiles_per_slot, num_tiles)
+                t = s_lo + b
+                while t + (u - 1) * nb < s_hi:
+                    _copy_u(thr, copy_atom, g_in, g_send, t, u, num_blocks)
+                    t += u * nb
+                while t < s_hi:
+                    _copy_u(thr, copy_atom, g_in, g_send, t, 1, num_blocks)
+                    t += nb
+                cute.arch.barrier(barrier_id=1, number_of_threads=nt)
+                if tidx == d_threads:
+                    nvl_ops.signal(tail_remote, start_send + s + 1)
+            if tidx == d_threads:
+                send_ctr[step_idx] = start_send + num_slots
+        else:
+            # DRAIN warps (warps 0..D-1): wait the peer's slot, then TMA-bounce its
+            # tiles my-staging[peer, t] -> smem -> out[peer, t] on the TMA engine,
+            # concurrently with the send warps' LSU stores. Each drain warp d owns a
+            # STRIDED tile subset (every D-th tile, offset d) + its own smem stages
+            # + its own mbarriers, so D warps issue TMA in parallel -- scaling the
+            # drain past the single-warp throughput ceiling. Within a warp the
+            # subset is drained in groups of ``tma_stages`` bounces in flight.
+            d = warp
+            stg = tma_stages
+            smem = cutlass_utils.SmemAllocator()
+            storage = smem.allocate(tma_smem)
+            mbar_ptr = storage.mbar.data_ptr()
+            staged = storage.buf.get_tensor(
+                cute.make_layout((1, tma_tile_elems, d_warps * stg))
+            )
+            load_tiled = cute.zipped_divide(load_tns, (1, tma_tile_elems))
+            store_tiled = cute.zipped_divide(store_tns, (1, tma_tile_elems))
+            wstride = d_warps * nb  # tile stride between this warp's tiles
+            for s in range(num_slots):
+                if tidx == 0:
+                    nvl_ops.wait(tail_local, start_recv + s + 1)
+                    for j in range(d_warps * stg):
+                        cute.arch.mbarrier_init(mbar_ptr + j, 1)
+                cute.arch.mbarrier_init_fence()
+                cute.arch.barrier(barrier_id=2, number_of_threads=d_threads)
+                s_hi = min((s + 1) * tiles_per_slot, num_tiles)
+                base = s * tiles_per_slot + b + d * nb
+                gphase = 0
+                while base < s_hi:
+                    for j in range(stg):
+                        tj = base + j * wstride
+                        if tj < s_hi:
+                            buf = d * stg + j
+                            smt = cute.group_modes(
+                                cute.slice_(staged, (None, None, buf)), 0, 2
+                            )
+                            g_l = cute.group_modes(
+                                load_tiled[(None, None), (peer, tj)], 0, 2
+                            )
+                            sp, gp = cpasync.tma_partition(
+                                load_atom, 0, cute.make_layout(1), smt, g_l
+                            )
+                            if tidx == d * 32:
+                                cute.arch.mbarrier_arrive_and_expect_tx(
+                                    mbar_ptr + buf, tma_bytes
+                                )
+                            cute.copy(load_atom, gp, sp, tma_bar_ptr=mbar_ptr + buf)
+                    for j in range(stg):
+                        if base + j * wstride < s_hi:
+                            cute.arch.mbarrier_wait(mbar_ptr + d * stg + j, gphase)
+                    cute.arch.fence_proxy(
+                        cute.arch.ProxyKind.async_shared,
+                        space=cute.arch.SharedSpace.shared_cta,
+                    )
+                    for j in range(stg):
+                        tj = base + j * wstride
+                        if tj < s_hi:
+                            buf = d * stg + j
+                            smt = cute.group_modes(
+                                cute.slice_(staged, (None, None, buf)), 0, 2
+                            )
+                            g_s = cute.group_modes(
+                                store_tiled[(None, None), (peer, tj)], 0, 2
+                            )
+                            sps, gps = cpasync.tma_partition(
+                                store_atom, 0, cute.make_layout(1), smt, g_s
+                            )
+                            cute.copy(store_atom, sps, gps)
+                    cute.arch.cp_async_bulk_commit_group()
+                    cute.arch.cp_async_bulk_wait_group(0)
+                    gphase = 1 - gphase
+                    base += stg * wstride
+                # Slot-end sync: every drain warp must finish slot s's bounces
+                # before thread 0 re-arms the mbarriers for slot s+1 (else a slow
+                # warp's in-flight wait races the re-init -> deadlock).
+                cute.arch.barrier(barrier_id=2, number_of_threads=d_threads)
+            if tidx == 0:
+                recv_ctr[step_idx] = start_recv + num_slots
+
+
+@cute.kernel
+def _a2a_kernel_direct(  # noqa: C901
+    in2d,
+    out2d,
+    buf_ptrs,
+    sig_ptrs,
+    send_ctr,
+    recv_ctr,
+    dtype: cutlass.Constexpr,
+    vec: cutlass.Constexpr,
+    dbits: cutlass.Constexpr,
+    num_blocks: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    local_rank: cutlass.Constexpr,
+    chunk: cutlass.Constexpr,
+    cap_elems: cutlass.Constexpr,
+    mbp: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+) -> None:
+    # Zero-copy DirectWrite: each (peer, block) writes this rank's chunk for
+    # `peer` STRAIGHT into peer's symmetric-memory OUTPUT buffer at this rank's
+    # slot (no staging, no drain), publishes data-ready, and waits for `peer`'s
+    # write into MY output slot. After all blocks, this rank's symm-mem buffer is
+    # the complete a2a output (slot s = chunk from sender s) -- the caller reads
+    # it via handle.get_buffer (out2d is unused). The theoretical-minimum work:
+    # one NVLink store/elem + one fence; its busbw is the per-SM send-rate
+    # ceiling (== the SEND-ONLY diagnostic), the upper bound every staging
+    # variant is bounded by (see a2a_cute_perf_and_exhaustion.md).
+    tidx = cute.arch.thread_idx()[0]
+    b = cute.arch.block_idx()[0]
+    peer = cute.arch.block_idx()[1]
+    u = unroll
+    nb = num_blocks
+    copy_atom = _copy_atom(dtype, vec, dbits)
+    thr_copy = cute.make_tiled_copy_tv(
+        copy_atom, cute.make_layout(num_threads), cute.make_layout(vec)
+    ).get_slice(tidx)
+    tiler = cute.make_layout(num_threads * vec)
+    g_in = cute.zipped_divide(in2d[(peer, None)], tiler)
+    num_tiles = cute.size(g_in, mode=[1])
+    elem_bytes = dbits // 8
+    cap_bytes = cap_elems * elem_bytes
+    # Destination = peer's output buffer at THIS rank's slot (peer==self -> my
+    # own buffer, the local diagonal). Same slot convention as staging.
+    dst_ptr = cute.make_ptr(
+        dtype,
+        buf_ptrs[peer] + local_rank * cap_bytes,
+        cute.AddressSpace.gmem,
+        assumed_align=16,
+    )
+    g_dst = cute.zipped_divide(
+        cute.make_tensor(dst_ptr, cute.make_layout(chunk)), tiler
+    )
+    t = b
+    while t + (u - 1) * nb < num_tiles:
+        _copy_u(thr_copy, copy_atom, g_in, g_dst, t, u, num_blocks)
+        t += u * nb
+    while t < num_tiles:
+        _copy_u(thr_copy, copy_atom, g_in, g_dst, t, 1, num_blocks)
+        t += nb
+    if peer != local_rank:
+        cute.arch.barrier()
+        step_idx = peer * mbp + b
+        start_send = send_ctr[step_idx]
+        start_recv = recv_ctr[step_idx]
+        if tidx == 0:
+            tail_remote = sig_ptrs[peer] + (local_rank * mbp + b) * 8
+            nvl_ops.signal(tail_remote, start_send + 1)
+            tail_local = sig_ptrs[local_rank] + (peer * mbp + b) * 8
+            nvl_ops.wait(tail_local, start_recv + 1)
+            send_ctr[step_idx] = start_send + 1
+            recv_ctr[step_idx] = start_recv + 1
+
+
+def _make_transpose_smem(dtype, tile: int, depth: int = 1):
+    """Per-CTA SMEM for the block-cooperative transpose: ``depth`` stacked ``(tile, tile+1)``
+    tiles (the +1 pad makes the transposed read bank-conflict-free). ``depth>1`` is the store-
+    unroll: the kernel loads ``depth`` tiles, barriers once, then stores all ``depth`` (so
+    ``depth * tile/block_rows`` NVLink stores are in flight before the next barrier)."""
+
+    @cute.struct
+    class _TrSmem:
+        buf: cute.struct.MemRange[dtype, depth * tile * (tile + 1)]
+
+    return _TrSmem
+
+
+@cute.kernel
+def _a2a_kernel_transpose_direct(  # noqa: C901
+    in2d,
+    out2d,
+    buf_ptrs,
+    sig_ptrs,
+    send_ctr,
+    recv_ctr,
+    dtype: cutlass.Constexpr,
+    dbits: cutlass.Constexpr,
+    num_blocks: cutlass.Constexpr,
+    local_rank: cutlass.Constexpr,
+    chunk: cutlass.Constexpr,
+    cap_elems: cutlass.Constexpr,
+    mbp: cutlass.Constexpr,
+    rows: cutlass.Constexpr,
+    cols: cutlass.Constexpr,
+    tile: cutlass.Constexpr,
+    block_rows: cutlass.Constexpr,
+    pipeline_depth: cutlass.Constexpr,
+    smem_struct: cutlass.Constexpr,
+    layout_hook: cutlass.Constexpr,
+) -> None:
+    # Zero-copy DirectWrite + FUSED block-cooperative SMEM transform (block-tile HOOK). Each
+    # (peer, block)
+    # transposes this rank's [rows, cols] chunk-for-peer into [cols, rows] and writes it
+    # STRAIGHT into peer's symm-mem OUTPUT buffer at this rank's slot -- one kernel, no
+    # staging, no scratch. The transpose is done in SMEM (coalesced load -> padded smem ->
+    # coalesced transposed store), so BOTH the local HBM read and the NVLink store are
+    # coalesced (unlike the per-element gather hook's uncoalesced vec=1). This is the CuTe
+    # twin of the reference sender-side tl.trans, but zero-copy instead of staged.
+    tidx = cute.arch.thread_idx()[0]
+    b = cute.arch.block_idx()[0]
+    peer = cute.arch.block_idx()[1]
+    tx = (
+        tidx % tile
+    )  # lane -> contiguous gmem dim on BOTH legs (coalesced load AND store)
+    ty = tidx // tile
+    elem_bytes = dbits // 8
+    cap_bytes = cap_elems * elem_bytes
+    # src = my input chunk for peer, as [rows, cols]; dst = peer's output buffer at my slot,
+    # as [cols, rows] (the transposed output layout).
+    src = cute.make_tensor(
+        in2d[(peer, None)].iterator, cute.make_layout((rows, cols), stride=(cols, 1))
+    )
+    dst_ptr = cute.make_ptr(
+        dtype,
+        buf_ptrs[peer] + local_rank * cap_bytes,
+        cute.AddressSpace.gmem,
+        assumed_align=16,
+    )
+    dst = cute.make_tensor(dst_ptr, cute.make_layout((cols, rows), stride=(rows, 1)))
+    smem = cutlass_utils.SmemAllocator()
+    storage = smem.allocate(smem_struct)
+    tlayout = cute.make_layout((tile, tile + 1), stride=(tile + 1, 1))
+    ntiles_r = rows // tile
+    ntiles_c = cols // tile
+    total = ntiles_r * ntiles_c
+    if cutlass.const_expr(pipeline_depth > 1):
+        # Store-unroll via a ROTATING SMEM buffer (depth-``pipeline_depth`` software pipeline):
+        # each tile lands in buffer ``(seq % depth)``, so consecutive tiles use different buffers
+        # and the post-store WAR barrier is dropped (a buffer is reused ``depth`` tiles later,
+        # covered by the intervening load barriers). One barrier per tile (not two) AND each
+        # tile's NVLink store overlaps the next tile's coalesced HBM load -> more stores in
+        # flight, closing the mid-band stall. The buffer index is a runtime slice (same as the
+        # per-peer ``in2d`` slice), so there is no Python-state toggle across the traced loop.
+        sAbuf = storage.buf.get_tensor(
+            cute.make_layout(
+                (pipeline_depth, tile, tile + 1),
+                stride=(tile * (tile + 1), tile + 1, 1),
+            )
+        )
+        gt = b
+        while gt < total:
+            br = gt // ntiles_c
+            bc = gt % ntiles_c
+            bidx = (gt // num_blocks) % pipeline_depth
+            # Shared block-tile leaf; rotating buffer -> war_barrier=False (WAR covered by the
+            # intervening RAW barriers of the next `depth` tiles).
+            _block_tile_u(
+                sAbuf[(bidx, None, None)],
+                src,
+                dst,
+                br,
+                bc,
+                tile,
+                block_rows,
+                tx,
+                ty,
+                layout_hook,
+                war_barrier=False,
+            )
+            gt += num_blocks
+        cute.arch.barrier()  # last tiles' stores done reading SMEM before the signal
+    else:
+        sA = storage.buf.get_tensor(tlayout)
+        gt = b
+        while gt < total:
+            br = gt // ntiles_c
+            bc = gt % ntiles_c
+            _block_tile_u(sA, src, dst, br, bc, tile, block_rows, tx, ty, layout_hook)
+            gt += num_blocks
+    if peer != local_rank:
+        cute.arch.barrier()
+        step_idx = peer * mbp + b
+        start_send = send_ctr[step_idx]
+        start_recv = recv_ctr[step_idx]
+        if tidx == 0:
+            tail_remote = sig_ptrs[peer] + (local_rank * mbp + b) * 8
+            nvl_ops.signal(tail_remote, start_send + 1)
+            tail_local = sig_ptrs[local_rank] + (peer * mbp + b) * 8
+            nvl_ops.wait(tail_local, start_recv + 1)
+            send_ctr[step_idx] = start_send + 1
+            recv_ctr[step_idx] = start_recv + 1
+
+
+@cute.jit
+def _launch_a2a_transpose(
+    in2d,
+    out2d,
+    buf_ptrs,
+    sig_ptrs,
+    send_ctr,
+    recv_ctr,
+    dtype: cutlass.Constexpr,
+    dbits: cutlass.Constexpr,
+    num_blocks: cutlass.Constexpr,
+    local_rank: cutlass.Constexpr,
+    chunk: cutlass.Constexpr,
+    cap_elems: cutlass.Constexpr,
+    mbp: cutlass.Constexpr,
+    world_size: cutlass.Constexpr,
+    rows: cutlass.Constexpr,
+    cols: cutlass.Constexpr,
+    tile: cutlass.Constexpr,
+    block_rows: cutlass.Constexpr,
+    pipeline_depth: cutlass.Constexpr,
+    layout_hook: cutlass.Constexpr,
+    stream,
+) -> None:
+    smem_struct = _make_transpose_smem(dtype, tile, pipeline_depth)
+    _a2a_kernel_transpose_direct(
+        in2d,
+        out2d,
+        buf_ptrs,
+        sig_ptrs,
+        send_ctr,
+        recv_ctr,
+        dtype,
+        dbits,
+        num_blocks,
+        local_rank,
+        chunk,
+        cap_elems,
+        mbp,
+        rows,
+        cols,
+        tile,
+        block_rows,
+        pipeline_depth,
+        smem_struct,
+        layout_hook,
+    ).launch(
+        grid=(num_blocks, world_size, 1),
+        block=(tile * block_rows, 1, 1),
+        stream=stream,
+        smem=smem_struct.size_in_bytes(),
+    )
+
+
+# CGA cluster co-locates all CTAs targeting one peer on a single GPC, so their
+# NVLink stores inject through the shared GPC->NVLink path with less contention --
+# this RAISES the per-SM send-rate ceiling on the pure-send (direct) path. Measured
+# 8xH100 (apple-to-apple, num_blocks=4): direct large-band 0.74-0.94x -> 1.01-1.15x
+# (beats NCCL at 64MB-1GB). Only at the few-CTA / large-chunk band: with many CTAs
+# (mid sizes) the GPU is already saturated and a wide cluster over-constrains
+# placement (regresses). Staging gains little (it is drain/sync-bound, not send-
+# bound), so this is a direct-path default; an explicit A2A_CUTE_CLUSTER still wins.
+_MIN_CLUSTER_CHUNK_BYTES: int = 1024 * 1024  # 1 MiB per-peer chunk
+_MAX_PORTABLE_CLUSTER: int = 8  # Hopper/Blackwell portable cluster cap
+
+
+def _pick_cluster(num_blocks: int, chunk_bytes: int) -> int:
+    """Default CGA cluster size along the block axis for the direct path: cluster
+    every block targeting one peer (``num_blocks``) when in the few-CTA / large-
+    chunk band, else 1 (off). Capped at the portable cluster size; an explicit
+    ``A2A_CUTE_CLUSTER`` env overrides (``<=0`` is the "max" = num_blocks sentinel).
+    """
+    env = os.environ.get("A2A_CUTE_CLUSTER")
+    if env is not None:
+        v = int(env)
+        # Cap the env-derived cluster at the portable cap (matches the staging path), so
+        # A2A_CUTE_CLUSTER=0 with num_blocks>cap can't request an invalid cluster size on
+        # Hopper (CUDA_ERROR_INVALID_CLUSTER_SIZE).
+        c = min(num_blocks if v <= 0 else v, _MAX_PORTABLE_CLUSTER)
+        return c if num_blocks % c == 0 else 1
+    if num_blocks <= _MAX_PORTABLE_CLUSTER and chunk_bytes >= _MIN_CLUSTER_CHUNK_BYTES:
+        return num_blocks
+    return 1
+
+
+class _CeSignalKernel:
+    """1-CTA signal/recv companion for the copy-engine (CE) all_to_all.
+
+    The data movement is done host-side by ``cuMemcpyAsync`` on the copy engines
+    (zero SM); this tiny kernel does only the cross-rank completion handshake on
+    the symmetric-memory signal pad, stream-ordered AFTER the memcpys. Thread
+    ``peer`` (one per peer, peer != self) publishes a data-ready signal into peer's
+    pad and waits for peer's signal into mine, using the transport's persistent
+    monotonic counters (graph-safe; no reset needed)."""
+
+    def __init__(self, *, world_size: int, local_rank: int, mbp: int) -> None:
+        self.world_size = world_size
+        self.local_rank = local_rank
+        self.mbp = mbp
+
+    @cute.jit
+    def __call__(self, sig_ptrs, send_ctr, recv_ctr, stream) -> None:
+        # One thread per peer (kernel indexes peer = thread_idx). Size the block (warp-
+        # rounded) to world_size so peers >=32 (e.g. GB200 NVL72) still get a thread; the
+        # `peer < world_size` guard makes the rounding-up extras no-ops.
+        block_threads = max(32, (self.world_size + 31) // 32 * 32)
+        self.kernel(sig_ptrs, send_ctr, recv_ctr).launch(
+            grid=(1, 1, 1), block=(block_threads, 1, 1), stream=stream
+        )
+
+    @cute.kernel
+    def kernel(self, sig_ptrs, send_ctr, recv_ctr) -> None:
+        peer = cute.arch.thread_idx()[0]
+        if peer < self.world_size:
+            if peer != self.local_rank:
+                step_idx = peer * self.mbp
+                start_send = send_ctr[step_idx]
+                start_recv = recv_ctr[step_idx]
+                # Publish "my chunk for `peer` has landed in peer's buffer" into
+                # peer's pad slot for me; wait for peer's matching signal into mine.
+                tail_remote = sig_ptrs[peer] + (self.local_rank * self.mbp) * 8
+                nvl_ops.signal(tail_remote, start_send + 1)
+                tail_local = sig_ptrs[self.local_rank] + (peer * self.mbp) * 8
+                nvl_ops.wait(tail_local, start_recv + 1)
+                send_ctr[step_idx] = start_send + 1
+                recv_ctr[step_idx] = start_recv + 1

--- a/comms/dsl/cute/a2a/tune.py
+++ b/comms/dsl/cute/a2a/tune.py
@@ -1,0 +1,25 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""CLI entrypoint: tune the comms/dsl CuTe all_to_all via the comm tuner.
+
+The CuTe twin of ``triton/a2a/tune.py`` -- the body of the tuning-job entrypoint that the
+MAST/conda launcher submits and the ``comm_tuning`` engine re-execs per candidate. The
+default ``A2A(backend="cute")`` (identity copy hook) tunes the plain CuTe all_to_all:
+
+    buck2 run @fbcode//mode/opt //comms/dsl:tune_a2a_cute -- --mode parent --output-dir /tmp/t ...
+
+Run modes (parent/child/select) and ``--max-sizes`` / ``--max-candidates`` are parsed by
+``run_tuning_cli`` via the adapter.
+"""
+
+from comms.dsl.collectives import A2A
+
+
+def main() -> None:
+    A2A(backend="cute").autotune()
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/dsl/cute/a2a/tuning.py
+++ b/comms/dsl/cute/a2a/tuning.py
@@ -1,0 +1,207 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# pyre-ignore-all-errors[35]: pyre mis-flags this frozen-dataclass-subclass's fields as
+# illegal annotation targets (the identical Triton A2AConfig/A2AKey twin is accepted); the
+# dataclasses are correct and runtime-validated.
+
+"""Tunable Config + lookup Key for the CuTe all_to_all schedule.
+
+The CuTe twin of ``triton/a2a/tuning.py``: same autotuner-shaped surface
+(see ``CuteCommTuner`` / ``comm_tuning``) -- a frozen ``CuteA2AConfig`` of launch
+tunables, a ``CuteA2AKey`` rebuilt identically offline (tuning) and at runtime
+(lookup), a safe ``DEFAULT_A2A_CONFIG``, and ``get_a2a_config(key)`` that
+reads the tuner-emitted map and falls back to the default. The kernel takes
+``config=None`` and looks it up; a tuning adapter passes an explicit config.
+
+Tier note: only LAUNCH tunables live here. A field left at its sentinel (``0``)
+means "use the analytic adaptive pick" (``_pick_tile`` / ``_pick_slots`` /
+``_pick_cluster`` in ``a2a.schedules``), so the default config reproduces the
+analytic defaults exactly; a tuned table overrides per (size, ws, device).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+
+from ...tuning_base import (
+    _device_tag,
+    BaseTunableConfig as _BaseConfig,
+    BaseTuningKey as _BaseKey,
+    geometry_signature as _geometry_signature,
+    nondefault_inapplicable_fields as _nondefault_inapplicable_fields,
+    resolve_variant as _resolve_variant_impl,
+)
+from ..hooks import copy_consume, copy_produce
+
+
+@dataclass(frozen=True)
+class CuteA2AConfig(_BaseConfig):
+    """Launch tunables swept by the autotuner (perf axis only).
+
+    ``num_blocks`` is the block count per peer (device grid = ``world_size *
+    num_blocks``; one CTA per ``(peer, block)`` streams its sub-chunk). The remaining
+    knobs default to ``0`` = "use the analytic adaptive pick", so the default config
+    reproduces the size-aware analytic defaults exactly:
+
+    * ``num_threads`` -- threads/CTA (``0`` -> ``_pick_tile``); the per-thread vector
+      width ``vec`` is always the widest the chunk allows and is not independently
+      tuned.
+    * ``num_slots`` -- send/drain pipeline slots (``0`` -> ``_pick_slots``);
+      ``tiles_per_slot`` is derived from it.
+    * ``unroll`` -- register-blocking unroll of the NVLink store loop (``0`` ->
+      size-aware default, 8 once the per-peer chunk is large enough else 1).
+    * ``cluster`` -- CGA thread-block cluster size along the block axis (``0`` ->
+      ``_pick_cluster``; ``-1`` = max = ``num_blocks``; ``>0`` = explicit).
+
+    ``primitive`` selects the transfer schedule (one enum, the CuTe twin of the
+    Triton ``primitive``):
+
+    * ``"copy"`` (default) -- slot-pipelined per-thread staging copy.
+    * ``"tma"`` -- TMA-drain bounce variant (the TMA engine drains staging while warps
+      issue the NVLink send); launched via :func:`all_to_all` with ``primitive="tma"``.
+    * ``"direct"`` -- drain-free DirectWrite into the peer's symm-mem output;
+      launched via :func:`all_to_all_zc`, not :func:`all_to_all`.
+    * ``"ce"`` -- copy-engine zero-copy (``cuMemcpyAsync`` + a 1-CTA signal kernel);
+      launched via :func:`all_to_all_zc` with ``primitive="ce"``.
+    """
+
+    num_blocks: int = 8
+    num_threads: int = 0
+    num_slots: int = 0
+    unroll: int = 0
+    primitive: str = "copy"
+    cluster: int = 0
+    cluster_y: int = 1
+    tma_drain_warps: int = 1
+
+
+# Fields whose value changes the physical staging geometry (grid partition / output
+# semantics) rather than launch-only packing; switching one on a reused transport is
+# the documented hazard the runtime geometry guard catches. The tile/slot/unroll/
+# cluster knobs are launch-only and free to sweep. Mirrors A2A_GEOMETRY_FIELDS.
+CUTE_A2A_GEOMETRY_FIELDS: frozenset[str] = frozenset({"num_blocks", "primitive"})
+
+# Core tunable field names, for the adapter's candidate-grid validation. Derived from the
+# dataclass so it can never drift from CuteA2AConfig; mirrors A2A_CORE_FIELDS.
+CUTE_A2A_CORE_FIELDS: frozenset[str] = frozenset(f.name for f in fields(CuteA2AConfig))
+
+# Launch knobs each primitive actually consumes at launch (the apply-path audit, made
+# structural so the candidate grid can never emit a field that does nothing for its
+# primitive -- the WS5 honesty invariant). A field NOT listed for a primitive must be left
+# at its dataclass default when that primitive is swept, so a tuned entry never carries a
+# silently-ignored value. ``num_blocks``/``primitive`` are always meaningful and excluded
+# from the non-default check (``num_blocks`` shapes the grid for every path; ``primitive`` is
+# the selector). ``copy`` is the staging schedule (all knobs apply); ``direct`` is the
+# drain-free single-shot DirectWrite (no slot pipeline, so ``num_slots`` does NOT apply);
+# ``ce`` is the host copy-engine path (no device grid -> no launch knobs).
+CUTE_PRIMITIVE_APPLIES: dict[str, frozenset[str]] = {
+    "copy": frozenset(
+        {
+            "num_threads",
+            "num_slots",
+            "unroll",
+            "cluster",
+            "cluster_y",
+            "tma_drain_warps",
+        }
+    ),
+    "tma": frozenset(
+        {
+            "num_threads",
+            "num_slots",
+            "unroll",
+            "cluster",
+            "cluster_y",
+            "tma_drain_warps",
+        }
+    ),
+    "direct": frozenset({"num_threads", "unroll", "cluster", "cluster_y"}),
+    "ce": frozenset(),
+}
+
+
+def geometry_signature(config: "CuteA2AConfig") -> tuple:
+    """Geometry-defining field values for the CuTe a2a config (the
+    ``CUTE_A2A_GEOMETRY_FIELDS`` subset; see ``tuning_base.geometry_signature``)."""
+    return _geometry_signature(config, CUTE_A2A_GEOMETRY_FIELDS)
+
+
+def _resolve_variant(produce, consume, variant: str = "") -> str:
+    """CuTe a2a hook discriminator: the default identity copy hooks map to ``""``; a
+    non-default hook needs an explicit ``variant`` (see ``tuning_base.resolve_variant``).
+    """
+    return _resolve_variant_impl(
+        produce,
+        consume,
+        variant,
+        default_produce=copy_produce,
+        default_consume=copy_consume,
+    )
+
+
+@dataclass(frozen=True)
+class CuteA2AKey(_BaseKey):
+    """Runtime lookup key; must be rebuilt identically offline and at runtime."""
+
+    # Inherits world_size, dtype, numel, rows, transport_kind, device, backend, variant
+    # from BaseTuningKey. The agnostic base stays backend-neutral; the CuTe default
+    # lives here on the subclass (the twin of A2AKey.backend = "triton").
+    backend: str = "cute"
+
+
+DEFAULT_A2A_CONFIG = CuteA2AConfig()
+
+
+def nondefault_inapplicable_fields(config: "CuteA2AConfig") -> set[str]:
+    """Names of fields this config sets to a NON-default value that its ``primitive`` does
+    not consume at launch (empty == honest). The candidate grid's feasibility filter uses
+    this so a swept config can never carry a silently-ignored knob for its primitive."""
+    return _nondefault_inapplicable_fields(
+        config,
+        core_fields=CUTE_A2A_CORE_FIELDS,
+        primitive_applies=CUTE_PRIMITIVE_APPLIES,
+        default=DEFAULT_A2A_CONFIG,
+    )
+
+
+# Emitted by the tuner; absent until a tuning run has produced it.
+try:
+    # pyre-ignore[21]: generated by the tuner; absent until a tuning run exists.
+    from comms.dsl.cute.a2a.generated.a2a_tuned_configs import (  # noqa: F401
+        TUNED_A2A_CONFIGS,
+    )
+except ImportError:
+    TUNED_A2A_CONFIGS = {}
+
+
+def make_a2a_key(
+    input,
+    transport,
+    *,
+    rows: int = 0,
+    produce=copy_produce,
+    consume=copy_consume,
+    variant: str = "",
+    backend: str = "cute",
+) -> CuteA2AKey:
+    """Build the lookup key from runtime args (same fields the tuner keys on).
+
+    The hooks + ``variant`` resolve the tuned-table hook discriminator through the single
+    ``_resolve_variant`` chokepoint, so the runtime lookup and the offline tuner derive an
+    identical key for the same logical inputs + hook (no dual-key drift)."""
+    return CuteA2AKey(
+        world_size=transport.world_size,
+        dtype=str(input.dtype).removeprefix("torch."),
+        numel=int(input.numel()),
+        rows=rows,
+        transport_kind=type(transport).__name__,
+        device=_device_tag(input.device),
+        backend=backend,
+        variant=_resolve_variant(produce, consume, variant),
+    )
+
+
+def get_a2a_config(key: CuteA2AKey) -> CuteA2AConfig:
+    """Tuned config for this key, falling back to the safe default."""
+    return TUNED_A2A_CONFIGS.get(key, DEFAULT_A2A_CONFIG)

--- a/comms/dsl/cute/ctx.py
+++ b/comms/dsl/cute/ctx.py
@@ -1,0 +1,100 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""CuTe hook-contract views. Two tiers, matching what the transform needs:
+
+* :class:`Ctx` -- the **per-element / value** tier. ``part`` is this tile's partitioned tensor
+  (input for ``produce``, output for ``consume``), ``atom`` the gmem<->rmem copy atom; a value
+  hook (scale / quantize / accumulate) loads ``part``, transforms in registers, returns the
+  fragment. Plus stable read-only FACTS -- ``coord`` (tile index), ``peer`` (dest/source rank),
+  ``rank`` / ``world_size``, and shape ``rows`` / ``cols`` / ``chunk`` -- for position/peer/
+  rank-dependent value transforms (masking, positional encoding, per-peer scale) without touching
+  any machinery. This tier is per-thread-per-tile: it CANNOT do a block-cooperative transform.
+
+* :class:`BlockCtx` -- the **block-tile / layout** tier. A coalescing-critical layout change
+  (transpose, permute, block-reshape) needs the whole CTA to cooperate on a 2D SMEM tile, which
+  the per-element tier cannot express. The framework does the coalescing 95% -- coalesced-load a
+  ``[tile, tile]`` input tile into padded SMEM (``sA``) + ``barrier`` -- and the block hook does
+  the 5%: the in-SMEM transform / transposed store into ``dst``. See ``hooks.transpose_tile``.
+  The framework side is the shared substrate leaf ``send_recv._block_tile_u`` (the block-tile twin
+  of the value leaf ``_send_u``), which the a2a transpose schedules compose in the next layer.
+
+The CuTe twin of ``triton/ctx.py``. Kept importable GPU-free (no module-scope cutlass); both
+classes are plain field holders, constructed by the schedule inside the kernel (GPU present).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class Ctx:
+    """Per-element (value) hook view: ``part`` + ``atom`` + read-only facts."""
+
+    __slots__ = (
+        "part",
+        "atom",
+        "coord",
+        "peer",
+        "rank",
+        "world_size",
+        "rows",
+        "cols",
+        "chunk",
+    )
+
+    def __init__(
+        self,
+        part: Any,
+        atom: Any,
+        coord: Any = None,
+        peer: Any = None,
+        rank: Any = None,
+        world_size: Any = None,
+        rows: Any = 0,
+        chunk: Any = 0,
+    ) -> None:
+        self.part = part
+        self.atom = atom
+        # Position / identity / shape facts -- stable read-only scalars a value hook may use.
+        self.coord = coord
+        self.peer = peer
+        self.rank = rank
+        self.world_size = world_size
+        self.rows = rows
+        self.chunk = chunk
+        self.cols = (chunk // rows) if rows else chunk
+
+
+class BlockCtx:
+    """Block-tile (layout) hook view: a CTA-cooperative 2D SMEM tile transform.
+
+    ``sA`` is the coalesced-loaded, padded ``[tile, tile+1]`` SMEM input tile (framework-loaded,
+    post-barrier). ``dst`` is this peer's destination tensor (``[cols, rows]`` for a transpose),
+    into which the hook coalesced-stores the transformed tile. ``(br, bc)`` is the 2D tile coord
+    (units of ``tile``); ``(tx, ty)`` this thread's lane/row within the tile; ``block_rows`` the
+    row-stride each thread streams. A hook loops ``r in range(0, tile, block_rows)`` and writes
+    ``dst`` from ``sA`` under its own mapping (transpose = swapped indices)."""
+
+    __slots__ = ("sA", "dst", "tile", "block_rows", "tx", "ty", "br", "bc")
+
+    def __init__(
+        self,
+        sA: Any,
+        dst: Any,
+        tile: Any,
+        block_rows: Any,
+        tx: Any,
+        ty: Any,
+        br: Any,
+        bc: Any,
+    ) -> None:
+        self.sA = sA
+        self.dst = dst
+        self.tile = tile
+        self.block_rows = block_rows
+        self.tx = tx
+        self.ty = ty
+        self.br = br
+        self.bc = bc

--- a/comms/dsl/cute/device_utils.py
+++ b/comms/dsl/cute/device_utils.py
@@ -1,0 +1,116 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Inline-PTX signaling primitives for the CuTe backend.
+
+The CuTe twin of ``triton/device_utils.py``: the cross-rank acquire/release
+signaling, emitting the **same on-wire protocol** so the two DSLs interoperate.
+Each op is a single PTX snippet via ``@dsl_user_op`` + ``llvm.inline_asm``.
+
+Minimal scope: only the two ops the no-pipeline send/recv needs —
+``wait_ge`` (receiver acquire-poll) and ``fence_and_remote_store_i64`` (sender
+release + remote store).
+"""
+
+from __future__ import annotations
+
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.typing import Int64
+from cutlass.cutlass_dsl import dsl_user_op
+
+
+@dsl_user_op
+def wait_ge(addr: Int64, target: Int64, *, loc=None, ip=None) -> None:
+    """Acquire-poll int64 until ``*addr >= target`` (local read)."""
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int64(target).ir_value(loc=loc, ip=ip)],
+        """{
+            .reg .u64   %tmp64;
+            .reg .pred  %p;
+            _fw_wait_ge:
+                ld.global.acquire.sys.b64 %tmp64, [$0];
+                setp.lt.u64 %p, %tmp64, $1;
+                @%p bra _fw_wait_ge;
+        }""",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def fence_and_remote_store_i64(addr: Int64, val: Int64, *, loc=None, ip=None) -> None:
+    """System release fence + remote relaxed int64 store (publish data)."""
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int64(val).ir_value(loc=loc, ip=ip)],
+        """{
+            fence.acq_rel.sys;
+            st.global.relaxed.sys.b64 [$0], $1;
+        }""",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def wait_ge_volatile(addr: Int64, target: Int64, *, loc=None, ip=None) -> None:
+    """Volatile-poll int64 until ``*addr >= target`` (local read, no acquire).
+
+    The cheaper twin of :func:`wait_ge` for the HEAD (slot-free) credit: the
+    producer of a HEAD signal only transfers staging-slot ownership and never
+    publishes payload the poller reads, so no acquire ordering is needed. Pairs
+    with :func:`remote_store_i64_relaxed`.
+    """
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int64(target).ir_value(loc=loc, ip=ip)],
+        """{
+            .reg .u64   %tmp64;
+            .reg .pred  %p;
+            _fw_wait_ge_vol:
+                ld.volatile.global.u64 %tmp64, [$0];
+                setp.lt.u64 %p, %tmp64, $1;
+                @%p bra _fw_wait_ge_vol;
+        }""",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def remote_store_i64_relaxed(addr: Int64, val: Int64, *, loc=None, ip=None) -> None:
+    """Remote relaxed int64 store WITHOUT a preceding system fence (HEAD credit).
+
+    For the slot-free (HEAD) credit that only transfers staging-slot ownership:
+    the sender reads no payload the receiver wrote, so the release fence in
+    :func:`fence_and_remote_store_i64` is unnecessary. A block-scope barrier
+    before this store ensures all prior staging reads completed. Do NOT use for
+    data-ready (TAIL) signals.
+    """
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int64(val).ir_value(loc=loc, ip=ip)],
+        """{
+            st.global.relaxed.sys.b64 [$0], $1;
+        }""",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )

--- a/comms/dsl/cute/hooks.py
+++ b/comms/dsl/cute/hooks.py
@@ -1,0 +1,64 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""CuTe hooks -- two tiers (see ``ctx.py`` for the ``Ctx`` / ``BlockCtx`` contracts).
+
+* **Per-element / value** (``produce(ctx)`` / ``consume(ctx, frag)``): the default identity
+  ``copy_*`` hooks and example value-transforms (``scale2`` / ``addone``, register-only math on
+  ``ctx.part``). ``produce`` loads the input tile into a register fragment and returns it;
+  ``consume`` writes a fragment to the output tile. This tier is per-thread-per-tile.
+* **Block-tile / layout** (``layout_hook(bctx)``): a CTA-cooperative 2D SMEM-tile transform for
+  coalescing-critical layout changes. ``transpose_tile`` is the flagship (coalesced-store the
+  SMEM tile transposed); permute/reshape reuse the same path. The framework does the coalesced
+  SMEM load + barriers (the shared substrate leaf ``send_recv._block_tile_u``, the block-tile twin
+  of the value leaf ``_send_u``); the hook does the in-SMEM transform. The CuTe twin of genai's
+  ``tl.trans``. The a2a transpose schedules compose this leaf in the next layer.
+"""
+
+from __future__ import annotations
+
+import cutlass.cute as cute
+
+
+def copy_produce(ctx):
+    """produce: load the input tile into a register fragment (no transform)."""
+    frag = cute.make_fragment_like(ctx.part)
+    cute.copy(ctx.atom, ctx.part, frag)
+    return frag
+
+
+def copy_consume(ctx, frag):
+    """consume: store a received fragment to the output tile (overwrite)."""
+    cute.copy(ctx.atom, frag, ctx.part)
+
+
+def scale2_produce(ctx):
+    """Send-side: load the input tile, multiply by 2, return the fragment."""
+    frag = cute.make_fragment_like(ctx.part)
+    cute.copy(ctx.atom, ctx.part, frag)
+    frag.store(frag.load() * 2.0)
+    return frag
+
+
+def addone_consume(ctx, frag):
+    """Recv-side: add 1 to the received fragment, store to the output tile."""
+    frag.store(frag.load() + 1.0)
+    cute.copy(ctx.atom, frag, ctx.part)
+
+
+def transpose_tile(bctx):
+    """Block-tile (layout) hook: coalesced-store the SMEM tile TRANSPOSED into ``dst``.
+
+    The flagship block-tile hook and the CuTe twin of genai's on-chip ``tl.trans``. The framework
+    has already coalesced-loaded the ``[tile, tile]`` input tile into the padded SMEM ``bctx.sA``
+    and barriered; this hook reads ``sA`` with swapped indices (bank-conflict-free thanks to the
+    +1 pad) and coalesced-stores it into ``dst`` at the transposed position. Both gmem legs stay
+    coalesced (``tx`` = lane is the contiguous dim on load AND store) -- the whole point of the
+    block-tile tier vs the per-element gather. A permute/reshape hook reuses the same path with a
+    different index mapping. ``all_to_all(..., rows=R)`` selects this hook by default."""
+    tile = bctx.tile
+    for r in range(0, tile, bctx.block_rows):
+        bctx.dst[(bctx.bc * tile + bctx.ty + r, bctx.br * tile + bctx.tx)] = bctx.sA[
+            (bctx.tx, bctx.ty + r)
+        ]

--- a/comms/dsl/cute/ib_ops.py
+++ b/comms/dsl/cute/ib_ops.py
@@ -1,0 +1,31 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Reserved IB device transport-ops (CuTe).
+
+CuTe twin of ``triton/ib_ops.py``: documents the same four-op seam
+(``transport.py``) the IB (RDMA) backend must implement. Bodies raise so any
+attempt to trace/compile a kernel with them fails loudly until the IB stack wires
+them; they remain importable so the interface is visible now.
+"""
+
+from __future__ import annotations
+
+_RESERVED = "framework IB ops (CuTe) are reserved; implemented in the IB stack"
+
+
+def put(atom, frag, dst_part):
+    raise NotImplementedError(_RESERVED)
+
+
+def get(atom, src_part):
+    raise NotImplementedError(_RESERVED)
+
+
+def signal(addr, seq):
+    raise NotImplementedError(_RESERVED)
+
+
+def wait(addr, seq):
+    raise NotImplementedError(_RESERVED)

--- a/comms/dsl/cute/nvl_ops.py
+++ b/comms/dsl/cute/nvl_ops.py
@@ -1,0 +1,62 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""NVLink device transport-ops (real, minimal) for the CuTe send/recv seam.
+
+CuTe twin of ``triton/nvl_ops.py``: the concrete four-op seam
+(``transport.py``) for the symmetric-memory transport, in **cute-native**
+signatures. ``put``/``get`` are ``cute.copy`` over the tile's copy atom;
+``signal``/``wait`` wrap the ``device_utils`` PTX. Passed as ``constexpr`` to
+``send_tiles``/``recv_tiles`` so the kernel is transport-agnostic and the
+transport binds per call-site (same intent as the Triton seam).
+"""
+
+from __future__ import annotations
+
+import cutlass.cute as cute
+
+from .device_utils import (
+    fence_and_remote_store_i64,
+    remote_store_i64_relaxed,
+    wait_ge,
+    wait_ge_volatile,
+)
+
+
+def put(atom, frag, dst_part):
+    """Write a produced fragment into the peer's staging partition (remote store)."""
+    cute.copy(atom, frag, dst_part)
+
+
+def get(atom, src_part):
+    """Read a received tile from the local staging partition into a fragment."""
+    frag = cute.make_fragment_like(src_part)
+    cute.copy(atom, src_part, frag)
+    return frag
+
+
+def signal(addr, seq):
+    """Publish "data ready" to the peer (fence + remote int64 store)."""
+    fence_and_remote_store_i64(addr, seq)
+
+
+def wait(addr, seq):
+    """Wait until the peer published ``seq`` (acquire-poll local int64)."""
+    wait_ge(addr, seq)
+
+
+def signal_free(addr, seq):
+    """Publish "slot free" (HEAD credit) to the peer (relaxed store, no fence).
+
+    The cheaper twin of :func:`signal` for the slot-free credit: the peer polling
+    it only reuses the staging slot and never reads payload published by this
+    store, so the release fence is unnecessary. The caller must barrier first so
+    all of this block's staging reads completed before the slot is handed back.
+    """
+    remote_store_i64_relaxed(addr, seq)
+
+
+def wait_free(addr, seq):
+    """Wait until the peer freed the slot (HEAD credit ``seq``; volatile poll)."""
+    wait_ge_volatile(addr, seq)

--- a/comms/dsl/cute/send_recv.py
+++ b/comms/dsl/cute/send_recv.py
@@ -1,0 +1,1051 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# pyre-ignore-all-errors[6, 29, 35, 58, 61]: @cute.kernel / @cute.jit constexpr params are
+# annotated cutlass.Constexpr; pyre models that as Constexpr[Any] and rejects the
+# arithmetic / range() / dataclass-field uses the kernel bodies do on them, and the calls
+# to the produce/consume hook constexprs ([29]) -- the values are real compile-time ints /
+# callables at trace time. [61]: locals set under a ``do_send``/``do_recv`` constexpr guard
+# and used under the same guard are always defined at runtime. Same idiom as the schedules twin.
+
+"""Minimal CuTe DSL send/recv kernel for the composable framework.
+
+The CuTe realization of the device send/recv primitive. It is the DSL twin of
+``framework/triton/send_recv.py``: same contract (consumes a `PeerEndpoint` from
+the shared `NvlTransport`), same minimal semantics (no pipeline, single-shot,
+per-block chunk + one data-ready signal), just written in CuTe instead of Triton.
+Its existence validates that the host layer (transport, ctx, signal protocol) is
+genuinely DSL-agnostic.
+
+Minimal scope (correctness only; performance is not a goal): no slots /
+double-buffer / credit; ``seq = 1`` single-shot; requires ``numel`` divisible by
+the CTA thread count (no tail handling); fixed 1-element-per-thread copy.
+"""
+
+# NOTE: do NOT add ``from __future__ import annotations`` here. The @cute.jit /
+# @cute.kernel launchers below (``_send_slot`` / ``_recv_slot`` / ``_sendrecv_kernel`` /
+# ``_launch_sendrecv``) classify their compile-time params via the REAL
+# ``cutlass.Constexpr`` annotation object, which ``inspect.getfullargspec`` only exposes
+# when annotations are NOT stringized -- stringizing makes cute marshal a constexpr dtype
+# as a dynamic arg and crash (Float32.__c_pointers__ TypeError).
+import logging
+import os
+from importlib import import_module
+from typing import Any
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _resolve_cute_dsl_arch() -> str:
+    """``sm_<major><minor>[a]`` for the local device; honors CUTE_DSL_ARCH."""
+    explicit = os.environ.get("CUTE_DSL_ARCH")
+    if explicit:
+        return explicit
+    try:
+        import torch as _torch
+
+        major, minor = _torch.cuda.get_device_capability(0)
+    except (ImportError, RuntimeError, AssertionError) as e:
+        logger.warning(
+            "could not detect CUDA device capability (%s); "
+            "defaulting CUTE_DSL_ARCH to sm_90a",
+            e,
+        )
+        return "sm_90a"
+    if (major, minor) == (9, 0):
+        return "sm_90a"
+    if (major, minor) in {(10, 0), (10, 1)}:
+        return "sm_100a"
+    if (major, minor) == (8, 0):
+        return "sm_80"
+    return f"sm_{major}{minor}"
+
+
+# Must be set before importing cutlass.cute.
+os.environ.setdefault("CUTE_DSL_ARCH", _resolve_cute_dsl_arch())
+
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass.cute.runtime import from_dlpack
+
+from ..transport import check_transfer, NvlTransport
+from . import nvl_ops
+from .ctx import BlockCtx, Ctx
+from .hooks import copy_consume, copy_produce
+
+_cuda_driver: Any = import_module("cuda.bindings.driver")
+_cuda_rt: Any = import_module("cuda.bindings.runtime")
+
+
+def _ensure_cuda_rt_compat() -> None:
+    """Idempotently shim cuda-bindings symbols the cutlass DSL JIT executor expects.
+
+    Some cuda-bindings versions lack ``cudaLibrary_t`` / ``cudaLibraryUnload``, so kernel
+    compilation cannot load the cuda library. This patches them in on first use (NOT at
+    import scope, per python.md's don't-mutate-imported-module-attributes-at-import rule).
+    The installed ``cudaLibraryUnload`` is a process-wide no-op, so it can leak library
+    handles for OTHER callers of cuda.bindings.runtime -- we log a warning when installing
+    it so that side effect is visible rather than silent. Invoked lazily from the JIT paths
+    (just before cute.compile)."""
+    if hasattr(_cuda_rt, "cudaLibrary_t"):
+        return
+
+    class _cudaLibrary_t:
+        __slots__ = ("value",)
+
+        def __init__(self, value: int = 0) -> None:
+            self.value = value
+
+    logger.warning(
+        "installing process-wide cuda.bindings.runtime shim (cudaLibrary_t + "
+        "no-op cudaLibraryUnload); cudaLibraryUnload becomes a no-op for ALL callers"
+    )
+    _cuda_rt.cudaLibrary_t = _cudaLibrary_t
+    _cuda_rt.cudaLibraryUnload = lambda lib: (_cuda_rt.cudaError_t(0),)
+
+
+_NUM_THREADS: int = 128
+
+# Minimal dtype support: (cutlass dtype, bits-per-element).
+_CUTLASS_DTYPE: dict[torch.dtype, tuple[Any, int]] = {
+    torch.float32: (cutlass.Float32, 32),
+    torch.bfloat16: (cutlass.BFloat16, 16),
+}
+
+_COMPILED: dict[tuple[Any, ...], object] = {}
+
+
+# ---------------------------------------------------------------------------
+# Shared CuTe send/recv substrate: the vectorized copy leaves + the per-slot
+# credit-ring primitives (``_send_slot`` / ``_recv_slot``). This is the backend
+# substrate home -- symmetric with the Triton ``triton/send_recv.py`` holding
+# ``send_step`` / ``recv_step``. A schedule composes these primitives by supplying its
+# own per-peer region/offset math, so a perf/codegen change here lands once and every
+# composer inherits it. The dependency is one-way: a composer imports these from here;
+# nothing here imports a schedule.
+# ---------------------------------------------------------------------------
+
+
+def _copy_atom(dtype: Any, vec: int, dbits: int):
+    """The vectorized gmem copy atom every schedule shares: VEC contiguous elems per
+    thread per copy, so the NVLink store is a vectorized st.global (up to 128-bit)
+    instead of a scalar store -- the single biggest copy-bandwidth lever (mirrors the
+    Triton 128-bit-store fix). The TV-tiled copy is built per schedule on top of it."""
+    return cute.make_copy_atom(
+        cute.nvgpu.CopyUniversalOp(),
+        dtype,
+        num_bits_per_copy=vec * dbits,
+    )
+
+
+def _copy_u(thr_copy, copy_atom, g_src, g_dst, t, n, num_blocks):
+    """Copy ``n`` consecutive (stride ``num_blocks``) tiles starting at ``t``:
+    issue all ``n`` loads, then all ``n`` stores, so ``n`` NVLink stores are in
+    flight per thread (mirrors NCCL's ``COLL_UNROLL`` -- the per-SM-extraction
+    lever Triton/TLX could not use because the wider per-thread footprint
+    spilled). STRAIGHT-LINE only (``n`` is constexpr; no control flow) so it is
+    safe to call from the kernel body -- CuTe only rewrites control flow in the
+    ``@cute.kernel`` function itself, so the grid-stride ``while`` stays inline
+    there. Correctness is unroll-independent: src and dst share one ``thr_copy``
+    partition, so any order copies the same elements."""
+    nb = num_blocks
+    frags = [
+        nvl_ops.get(copy_atom, thr_copy.partition_S(g_src[(None, t + i * nb)]))
+        for i in range(n)
+    ]
+    for i in range(n):
+        nvl_ops.put(
+            copy_atom, frags[i], thr_copy.partition_D(g_dst[(None, t + i * nb)])
+        )
+
+
+# Hook-aware twins of _copy_u, one per leg. The default copy hooks make them identical to
+# _copy_u (nvl_ops.get IS copy_produce, nvl_ops.put IS copy_consume -- both cute.copy over
+# the atom), so the identity path is bit-for-bit unchanged; a non-default hook transforms
+# the tile on its owning leg. Same unroll shape (issue all n loads, then all n stores) so n
+# NVLink transfers stay in flight, and the same straight-line (n constexpr) contract so they
+# are safe to call from the kernel body.
+def _send_u(
+    thr_copy,
+    copy_atom,
+    g_in,
+    g_send,
+    t,
+    n,
+    num_blocks,
+    produce,
+    src=None,
+    tiler=None,
+    rows=0,
+    chunk=0,
+    peer=None,
+):
+    """Send leg: produce n input tiles (HBM -> frag, transform) then NVLink-store to staging.
+
+    ``src``/``tiler``/``rows``/``chunk`` are the gather-hook context (this peer's raw chunk +
+    tile shape); a value-transform hook ignores them, a gather hook (transpose) uses them to
+    re-index ``src`` itself. ``peer`` is the position/identity fact for per-peer transforms.
+    Defaults keep the identity/value path unchanged."""
+    nb = num_blocks
+    frags = [
+        produce(
+            Ctx(
+                part=thr_copy.partition_S(g_in[(None, t + i * nb)]),
+                atom=copy_atom,
+                coord=t + i * nb,
+                rows=rows,
+                chunk=chunk,
+                peer=peer,
+            )
+        )
+        for i in range(n)
+    ]
+    for i in range(n):
+        nvl_ops.put(
+            copy_atom, frags[i], thr_copy.partition_D(g_send[(None, t + i * nb)])
+        )
+
+
+def _recv_u(thr_copy, copy_atom, g_recv, g_out, t, n, num_blocks, consume, peer=None):
+    """Recv leg: NVLink-load n staging tiles then consume them (frag -> HBM, transform).
+
+    ``coord``/``peer`` are the position/identity facts a consume hook may use (masking,
+    per-peer dequant scale); a value/identity consume ignores them."""
+    nb = num_blocks
+    frags = [
+        nvl_ops.get(copy_atom, thr_copy.partition_S(g_recv[(None, t + i * nb)]))
+        for i in range(n)
+    ]
+    for i in range(n):
+        consume(
+            Ctx(
+                part=thr_copy.partition_D(g_out[(None, t + i * nb)]),
+                atom=copy_atom,
+                coord=t + i * nb,
+                peer=peer,
+            ),
+            frags[i],
+        )
+
+
+def _local_u(
+    thr_copy,
+    copy_atom,
+    g_in,
+    g_out,
+    t,
+    n,
+    num_blocks,
+    produce,
+    consume,
+    src=None,
+    tiler=None,
+    rows=0,
+    chunk=0,
+    peer=None,
+):
+    """Diagonal (local) leg: produce from input then consume to output (no NVLink hop).
+
+    ``src``/``tiler``/``rows``/``chunk`` carry the gather-hook context (see ``_send_u``);
+    ``coord``/``peer`` are the position/identity facts for both legs."""
+    nb = num_blocks
+    frags = [
+        produce(
+            Ctx(
+                part=thr_copy.partition_S(g_in[(None, t + i * nb)]),
+                atom=copy_atom,
+                coord=t + i * nb,
+                rows=rows,
+                chunk=chunk,
+                peer=peer,
+            )
+        )
+        for i in range(n)
+    ]
+    for i in range(n):
+        consume(
+            Ctx(
+                part=thr_copy.partition_D(g_out[(None, t + i * nb)]),
+                atom=copy_atom,
+                coord=t + i * nb,
+                peer=peer,
+            ),
+            frags[i],
+        )
+
+
+def _block_tile_u(
+    sA, src, dst, br, bc, tile, block_rows, tx, ty, hook, war_barrier=True
+):
+    """Block-tile (layout) hook leaf: the CTA-cooperative twin of :func:`_send_u`/:func:`_copy_u`.
+
+    Coalesced-loads the ``[tile, tile]`` tile at 2D coord ``(br, bc)`` from ``src`` (a per-peer
+    ``[rows, cols]`` view) into the padded SMEM tile ``sA``, barriers (RAW), then the block-tile
+    ``hook`` (a :class:`BlockCtx` consumer such as ``transpose_tile``) transforms it in SMEM and
+    coalesced-stores it into ``dst`` at the transformed position. Both gmem legs stay coalesced
+    (``tx`` = lane is the contiguous dim on load AND store) -- the whole point of the block-tile
+    tier vs the per-element value hook.
+
+    ``war_barrier=False`` drops the trailing WAR barrier for a ROTATING-buffer (store-unroll)
+    caller: a buffer is reused ``depth`` tiles later, covered by the intervening RAW load-barriers,
+    so one barrier per tile suffices and each store overlaps the next load. Straight-line (only
+    barriers + a constexpr ``r``-loop, no control flow) so it composes into any schedule's
+    grid-stride loop -- exactly the contract of the value leaf ``_send_u``. This is the SHARED
+    substrate leaf for the block-tile hook tier, composed by the a2a transpose schedules in the
+    next layer (symmetric with how the value leaves ``_send_u``/``_send_slot`` are composed)."""
+    for r in range(0, tile, block_rows):
+        sA[(ty + r, tx)] = src[(br * tile + ty + r, bc * tile + tx)]
+    cute.arch.barrier()
+    hook(BlockCtx(sA, dst, tile, block_rows, tx, ty, br, bc))
+    if war_barrier:
+        cute.arch.barrier()
+
+
+@cute.jit
+def _send_slot(
+    thr_copy,
+    copy_atom,
+    g_in,
+    g_send,
+    tail_remote,
+    start_send,
+    b,
+    tidx,
+    s: cutlass.Constexpr,
+    tiles_per_slot: cutlass.Constexpr,
+    num_tiles: cutlass.Constexpr,
+    num_blocks: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+    produce: cutlass.Constexpr,
+    src=None,
+    tiler=None,
+    rows=0,
+    chunk=0,
+    peer=None,
+) -> None:
+    """One credit-ring SEND slot (CuTe twin of the Triton ``send_step``): stage slot
+    ``s`` into the peer's staging over NVLink, then publish its data-ready TAIL.
+
+    Extracted as a ``@cute.jit`` device sub-function so every schedule composes the SAME
+    slot primitive (symmetric with how the Triton ``send_step`` is shared). It carries the
+    runtime grid-stride ``while`` + barrier + leader signal, so it MUST be ``@cute.jit`` --
+    a plain helper would not get CuTe's control-flow rewrite (see ``_copy_u``).
+    ``src``/``tiler``/``rows``/``chunk`` are the gather-hook context forwarded to ``_send_u``."""
+    u = unroll
+    nb = num_blocks
+    s_lo = s * tiles_per_slot
+    s_hi = min((s + 1) * tiles_per_slot, num_tiles)
+    t = s_lo + b
+    while t + (u - 1) * nb < s_hi:
+        _send_u(
+            thr_copy,
+            copy_atom,
+            g_in,
+            g_send,
+            t,
+            u,
+            num_blocks,
+            produce,
+            src=src,
+            tiler=tiler,
+            rows=rows,
+            chunk=chunk,
+            peer=peer,
+        )
+        t += u * nb
+    while t < s_hi:
+        _send_u(
+            thr_copy,
+            copy_atom,
+            g_in,
+            g_send,
+            t,
+            1,
+            num_blocks,
+            produce,
+            src=src,
+            tiler=tiler,
+            rows=rows,
+            chunk=chunk,
+            peer=peer,
+        )
+        t += nb
+    cute.arch.barrier()
+    if tidx == 0:
+        # data-ready for slots 0..s (monotonic counter).
+        nvl_ops.signal(tail_remote, start_send + s + 1)
+
+
+@cute.jit
+def _recv_slot(
+    thr_copy,
+    copy_atom,
+    g_recv,
+    g_out,
+    tail_local,
+    start_recv,
+    b,
+    tidx,
+    s: cutlass.Constexpr,
+    tiles_per_slot: cutlass.Constexpr,
+    num_tiles: cutlass.Constexpr,
+    num_blocks: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+    consume: cutlass.Constexpr,
+    peer=None,
+) -> None:
+    """One credit-ring RECV slot (CuTe twin of the Triton ``recv_step``): wait the
+    peer's data-ready TAIL for slot ``s``, then drain its matching staging slot into
+    the output. Symmetric twin of :func:`_send_slot`; same ``@cute.jit`` rationale."""
+    u = unroll
+    nb = num_blocks
+    p_lo = s * tiles_per_slot
+    p_hi = min((s + 1) * tiles_per_slot, num_tiles)
+    if tidx == 0:
+        nvl_ops.wait(tail_local, start_recv + s + 1)
+    cute.arch.barrier()
+    t = p_lo + b
+    while t + (u - 1) * nb < p_hi:
+        _recv_u(
+            thr_copy, copy_atom, g_recv, g_out, t, u, num_blocks, consume, peer=peer
+        )
+        t += u * nb
+    while t < p_hi:
+        _recv_u(
+            thr_copy, copy_atom, g_recv, g_out, t, 1, num_blocks, consume, peer=peer
+        )
+        t += nb
+
+
+class _SendTilesKernel:
+    """Send direction: produce hook (HBM -> frag), write frag to staging, signal."""
+
+    def __init__(
+        self, *, num_blocks, num_threads, dtype, dbits, hook, put, signal
+    ) -> None:
+        self.num_blocks = num_blocks
+        self.num_threads = num_threads
+        self.dtype = dtype
+        self.dbits = dbits
+        self.hook = hook  # produce hook; called per tile with a Ctx
+        self.put = put  # transport op: write produced frag to staging
+        self.signal = signal  # transport op: publish data-ready
+
+    @cute.jit
+    def __call__(self, data, staging, sig_addr, stream) -> None:
+        tiler = cute.make_layout(self.num_threads)
+        g_data = cute.zipped_divide(data, tiler)
+        g_staging = cute.zipped_divide(staging, tiler)
+        num_tiles = cute.size(g_data, mode=[1])
+        self.kernel(g_data, g_staging, sig_addr, num_tiles).launch(
+            grid=(self.num_blocks, 1, 1),
+            block=(self.num_threads, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(self, g_data, g_staging, sig_addr, num_tiles: cutlass.Int32) -> None:
+        tidx = cute.arch.thread_idx()[0]
+        bid = cute.arch.block_idx()[0]
+        copy_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), self.dtype, num_bits_per_copy=self.dbits
+        )
+        tiled_copy = cute.make_tiled_copy_tv(
+            copy_atom, cute.make_layout(self.num_threads), cute.make_layout(1)
+        )
+        thr_copy = tiled_copy.get_slice(tidx)
+        addr = sig_addr[0] + bid * 8  # per-block signal slot (slot == block id)
+
+        tile_idx = bid
+        while tile_idx < num_tiles:
+            # produce hook owns the input leg (HBM -> frag); the primitive writes
+            # the returned fragment to staging.
+            in_part = thr_copy.partition_S(g_data[(None, tile_idx)])
+            stg_part = thr_copy.partition_D(g_staging[(None, tile_idx)])
+            frag = self.hook(Ctx(part=in_part, atom=copy_atom))
+            self.put(copy_atom, frag, stg_part)
+            tile_idx += self.num_blocks
+
+        cute.arch.barrier()  # all staging writes visible before the data-ready signal
+        if tidx == 0:
+            self.signal(addr, 1)
+
+
+class _RecvTilesKernel:
+    """Recv direction: wait, load staging -> frag, consume hook (frag -> HBM)."""
+
+    def __init__(
+        self, *, num_blocks, num_threads, dtype, dbits, hook, get, wait
+    ) -> None:
+        self.num_blocks = num_blocks
+        self.num_threads = num_threads
+        self.dtype = dtype
+        self.dbits = dbits
+        self.hook = hook  # consume hook; called per tile with (Ctx, frag)
+        self.get = get  # transport op: read staging into frag
+        self.wait = wait  # transport op: wait for data-ready
+
+    @cute.jit
+    def __call__(self, data, staging, sig_addr, stream) -> None:
+        tiler = cute.make_layout(self.num_threads)
+        g_data = cute.zipped_divide(data, tiler)
+        g_staging = cute.zipped_divide(staging, tiler)
+        num_tiles = cute.size(g_data, mode=[1])
+        self.kernel(g_data, g_staging, sig_addr, num_tiles).launch(
+            grid=(self.num_blocks, 1, 1),
+            block=(self.num_threads, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(self, g_data, g_staging, sig_addr, num_tiles: cutlass.Int32) -> None:
+        tidx = cute.arch.thread_idx()[0]
+        bid = cute.arch.block_idx()[0]
+        copy_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), self.dtype, num_bits_per_copy=self.dbits
+        )
+        tiled_copy = cute.make_tiled_copy_tv(
+            copy_atom, cute.make_layout(self.num_threads), cute.make_layout(1)
+        )
+        thr_copy = tiled_copy.get_slice(tidx)
+        addr = sig_addr[0] + bid * 8  # per-block signal slot (slot == block id)
+
+        if tidx == 0:
+            self.wait(addr, 1)
+        cute.arch.barrier()  # data-ready before any thread reads staging
+
+        tile_idx = bid
+        while tile_idx < num_tiles:
+            # primitive loads staging -> frag; consume hook owns the output leg
+            # (frag -> HBM).
+            stg_part = thr_copy.partition_S(g_staging[(None, tile_idx)])
+            out_part = thr_copy.partition_D(g_data[(None, tile_idx)])
+            frag = self.get(copy_atom, stg_part)
+            self.hook(Ctx(part=out_part, atom=copy_atom), frag)
+            tile_idx += self.num_blocks
+
+
+def _launch(data_buf, staging, sig_slice, *, kernel_cls, num_blocks, hook, ops) -> None:
+    dtype = data_buf.dtype
+    if dtype not in _CUTLASS_DTYPE:
+        raise ValueError(
+            f"cute minimal backend supports {list(_CUTLASS_DTYPE)}, got {dtype}"
+        )
+    cdtype, dbits = _CUTLASS_DTYPE[dtype]
+
+    # Signal-slot base address passed as data (read on device); sig_slice is the
+    # (remote for send, local for recv) address of this peer's slot region.
+    #
+    # NOTE (CUDA graph): this per-call allocation is NOT graph-capture-safe — the
+    # tensor's lifetime ends with this call, so a captured graph would reference
+    # freed memory on replay. A persistent, transport-owned sig-addr buffer is the
+    # follow-up fix (lands with the pipelined/graph work).
+    sig_addr = torch.tensor(
+        [sig_slice.data_ptr()], dtype=torch.int64, device=data_buf.device
+    )
+    _ensure_cuda_rt_compat()  # lazy: shim cuda-bindings before the cute.compile JIT path
+    data_c = from_dlpack(data_buf, assumed_align=16)
+    staging_c = from_dlpack(staging, assumed_align=16)
+    sig_c = from_dlpack(sig_addr, assumed_align=8)
+    stream = _cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    key = (
+        kernel_cls.__name__,
+        num_blocks,
+        _NUM_THREADS,
+        dtype,
+        data_buf.numel(),
+        hook,
+        *(ops[k] for k in sorted(ops)),
+    )
+    compiled = _COMPILED.get(key)
+    if compiled is None:
+        logger.info(
+            "compiling cute %s: blocks=%s numel=%s hook=%s",
+            kernel_cls.__name__,
+            num_blocks,
+            data_buf.numel(),
+            getattr(hook, "__name__", None),
+        )
+        kernel = kernel_cls(
+            num_blocks=num_blocks,
+            num_threads=_NUM_THREADS,
+            dtype=cdtype,
+            dbits=dbits,
+            hook=hook,
+            **ops,
+        )
+        compiled = cute.compile(kernel, data_c, staging_c, sig_c, stream)
+        _COMPILED[key] = compiled
+    compiled(data_c, staging_c, sig_c, stream)
+
+
+def send_tiles(data_buf, staging, sig_slice, *, num_blocks, hook, put, signal) -> None:
+    """Send-direction device transfer (impl behind the ``send`` launcher)."""
+    _launch(
+        data_buf,
+        staging,
+        sig_slice,
+        kernel_cls=_SendTilesKernel,
+        num_blocks=num_blocks,
+        hook=hook,
+        ops={"put": put, "signal": signal},
+    )
+
+
+def recv_tiles(data_buf, staging, sig_slice, *, num_blocks, hook, get, wait) -> None:
+    """Recv-direction device transfer (impl behind the ``recv`` launcher)."""
+    _launch(
+        data_buf,
+        staging,
+        sig_slice,
+        kernel_cls=_RecvTilesKernel,
+        num_blocks=num_blocks,
+        hook=hook,
+        ops={"get": get, "wait": wait},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pipelined credit-ring send/recv collective (graph-safe), composed from the shared
+# _send_slot / _recv_slot substrate above -- the standalone CuTe twin of the Triton
+# pipelined send/recv. Single-peer-pair whole-buffer transfer, keeping the slot
+# send/drain overlap. uni (send-only / recv-only) and bidir are selected by the
+# do_send / do_recv constexprs. Graph-safe via the transport's persistent monotonic
+# counters + the symmetric-memory signal pad (NOT the per-call sig tensor the minimal
+# send_tiles uses).
+# ---------------------------------------------------------------------------
+
+
+# Analytic tile / slot sizing for the pipelined send/recv geometry. Owned here so the
+# send/recv collective is self-contained; a fused multi-peer schedule reuses these.
+_SATURATION_THREADS: int = 32768
+_MIN_TILES: int = 32  # keep at least this many tiles so the pipeline has slots
+# Target number of pipeline slots per (peer, block) once pipelining is on. The
+# send/drain overlap approaches the send-only NVLink ceiling as slots grow (the
+# un-overlapped tail is one slot's drain), with diminishing returns vs per-slot
+# signal overhead; ~8 is the measured knee on H100. Overridable for the autotuner.
+_NUM_SLOTS: int = 8
+# Only pipeline when the per-peer chunk is large enough that the bandwidth-bound
+# send/drain overlap win beats the per-slot sync overhead. Below this the message
+# is latency-bound and a single shot (no extra barriers/signals/waits) is faster.
+# Measured on 8xH100: chunks <4MB regress under pipelining, >=8MB chunks gain
+# ~15-25%. Gated on bytes, not tiles -- 16MB and 64MB land at the same tile count
+# but opposite optima, so absolute size is the right signal.
+_MIN_PIPELINE_CHUNK_BYTES: int = 4 * 1024 * 1024
+# Per-peer chunk at/above which the deep (8-slot) run-ahead beats the shallow
+# (4-slot) one -- below it the deeper pipeline's per-slot sub-chunk is too small and
+# the sync overhead dominates (GB300, unroll=8). 64 MiB chunk.
+_DEEP_PIPELINE_CHUNK_BYTES: int = 64 * 1024 * 1024
+
+
+def _pick_tile(chunk: int, dbits: int, total_ctas: int) -> tuple[int, int]:
+    """Pick (num_threads, vec) so the per-(peer,block) chunk tiles EXACTLY.
+
+    Vec is the widest 128-bit-down-to-scalar copy the chunk allows (vec drops to 1
+    for tiny/odd chunks, so the whole 32B-2GB ladder tiles with no tail). Threads
+    are chosen CTA-aware: ``_SATURATION_THREADS / total_ctas`` (more warps per CTA
+    when few CTAs are in the SM budget), bounded so a small chunk keeps
+    ``_MIN_TILES`` tiles, floored so a chunk with real work is not under-threaded,
+    and capped at the 1024 hardware limit. An explicit ``A2A_CUTE_NT`` env overrides
+    the analytic pick (for sweeps / the autotuner).
+    """
+    env_nt = os.environ.get("A2A_CUTE_NT")
+    for vbits in (128, 64, 32, 16):
+        if vbits < dbits:
+            continue
+        vec = vbits // dbits
+        if chunk % vec:
+            continue
+        units = chunk // vec  # number of vectors to copy across the whole chunk
+        if env_nt is not None:
+            # Floor at 1 and cap at 1024 (mirrors the analytic branch): A2A_CUTE_NT="0" would
+            # otherwise return nt=0 and divide-by-zero in the caller's num_tiles math, and
+            # A2A_CUTE_NT>1024 would exceed the CUDA per-block thread cap and fail the launch.
+            nt = max(1, min(int(env_nt), units, 1024))
+        else:
+            nt = max(1, _SATURATION_THREADS // max(1, total_ctas))
+            nt = min(nt, max(1, units // _MIN_TILES))  # leave enough tiles
+            nt = min(nt, 1024)  # hardware cap
+            nt = max(nt, min(256, units))  # don't under-thread a chunk with work
+        nt = min(nt, units)
+        while nt > 1 and units % nt:
+            nt -= 1
+        # Final floor: the `min(nt, units)` above re-introduces nt=0 when units==0
+        # (chunk==0), which would divide-by-zero in the caller's num_tiles math.
+        return max(1, nt), vec
+    return 1, 1  # scalar fallback (chunk not a multiple of any vec width)
+
+
+def _pick_slots(num_tiles: int, chunk_bytes: int) -> tuple[int, int]:
+    """Split ``num_tiles`` into (num_slots, tiles_per_slot) for the send/drain
+    pipeline. Returns ``(1, num_tiles)`` (single shot, no pipeline) for per-peer
+    chunks below ``_MIN_PIPELINE_CHUNK_BYTES`` -- latency-bound sizes are faster
+    without the per-slot sync. An explicit ``A2A_CUTE_SLOTS`` env forces the slot
+    count (for sweeps / the autotuner)."""
+    if num_tiles <= 1:
+        return 1, 1
+    env_slots = os.environ.get("A2A_CUTE_SLOTS")
+    if env_slots is not None:
+        want = max(1, min(int(env_slots), num_tiles))
+    elif chunk_bytes < _MIN_PIPELINE_CHUNK_BYTES:
+        return 1, num_tiles  # single shot: latency-bound band
+    else:
+        # The mid-large band over-pipelines at 8 slots -- each slot's sub-chunk gets
+        # too small and the per-slot sync dominates, so 4 slots is the knee there; the
+        # >=64MB chunk band keeps 8 (the deeper run-ahead still wins).
+        want = min(
+            4 if chunk_bytes < _DEEP_PIPELINE_CHUNK_BYTES else _NUM_SLOTS, num_tiles
+        )
+    tps = (num_tiles + want - 1) // want
+    slots = (num_tiles + tps - 1) // tps  # re-derive exact slot count for this tps
+    return slots, tps
+
+
+@cute.kernel
+def _sendrecv_kernel(  # noqa: C901
+    in_t,
+    out_t,
+    buf_ptrs,
+    sig_ptrs,
+    send_ctr,
+    recv_ctr,
+    dtype: cutlass.Constexpr,
+    vec: cutlass.Constexpr,
+    dbits: cutlass.Constexpr,
+    num_blocks: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    local_rank: cutlass.Constexpr,
+    send_peer: cutlass.Constexpr,
+    recv_peer: cutlass.Constexpr,
+    numel: cutlass.Constexpr,
+    cap_elems: cutlass.Constexpr,
+    mbp: cutlass.Constexpr,
+    num_slots: cutlass.Constexpr,
+    tiles_per_slot: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+    do_send: cutlass.Constexpr,
+    do_recv: cutlass.Constexpr,
+    produce: cutlass.Constexpr,
+    consume: cutlass.Constexpr,
+) -> None:
+    tidx = cute.arch.thread_idx()[0]
+    b = cute.arch.block_idx()[0]
+    copy_atom = _copy_atom(dtype, vec, dbits)
+    tiled_copy = cute.make_tiled_copy_tv(
+        copy_atom, cute.make_layout(num_threads), cute.make_layout(vec)
+    )
+    thr_copy = tiled_copy.get_slice(tidx)
+    tiler = cute.make_layout(num_threads * vec)
+    g_in = cute.zipped_divide(in_t, tiler)
+    g_out = cute.zipped_divide(out_t, tiler)
+    num_tiles = cute.size(g_in, mode=[1])
+    elem_bytes = dbits // 8
+    cap_bytes = cap_elems * elem_bytes
+
+    # SEND: stream the whole buffer into send_peer's staging at MY slot, signal TAIL.
+    # const_expr so the branch folds at trace time -- a bare `if` on a constexpr makes
+    # CuTe emit a dynamic scf.if whose nested scope hides g_send from the slot loop below.
+    if cutlass.const_expr(do_send):
+        send_ptr = cute.make_ptr(
+            dtype,
+            buf_ptrs[send_peer] + local_rank * cap_bytes,
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        )
+        g_send = cute.zipped_divide(
+            cute.make_tensor(send_ptr, cute.make_layout(numel)), tiler
+        )
+        tail_remote = sig_ptrs[send_peer] + (local_rank * mbp + b) * 8
+        start_send = send_ctr[send_peer * mbp + b]
+    # RECV: wait recv_peer's TAIL, drain recv_peer's slot in MY staging into the output.
+    if cutlass.const_expr(do_recv):
+        recv_ptr = cute.make_ptr(
+            dtype,
+            buf_ptrs[local_rank] + recv_peer * cap_bytes,
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        )
+        g_recv = cute.zipped_divide(
+            cute.make_tensor(recv_ptr, cute.make_layout(numel)), tiler
+        )
+        tail_local = sig_ptrs[local_rank] + (recv_peer * mbp + b) * 8
+        start_recv = recv_ctr[recv_peer * mbp + b]
+
+    if cutlass.const_expr(do_send and do_recv):
+        # bidir: send slot s then drain slot s-1 so the in-flight stores overlap the
+        # drain (disjoint regions: my-staging drain vs peer-staging store).
+        for s in range(num_slots):
+            _send_slot(
+                thr_copy,
+                copy_atom,
+                g_in,
+                g_send,
+                tail_remote,
+                start_send,
+                b,
+                tidx,
+                s,
+                tiles_per_slot,
+                num_tiles,
+                num_blocks,
+                unroll,
+                produce,
+            )
+            if s >= 1:
+                _recv_slot(
+                    thr_copy,
+                    copy_atom,
+                    g_recv,
+                    g_out,
+                    tail_local,
+                    start_recv,
+                    b,
+                    tidx,
+                    s - 1,
+                    tiles_per_slot,
+                    num_tiles,
+                    num_blocks,
+                    unroll,
+                    consume,
+                )
+        _recv_slot(
+            thr_copy,
+            copy_atom,
+            g_recv,
+            g_out,
+            tail_local,
+            start_recv,
+            b,
+            tidx,
+            num_slots - 1,
+            tiles_per_slot,
+            num_tiles,
+            num_blocks,
+            unroll,
+            consume,
+        )
+    elif cutlass.const_expr(do_send):
+        for s in range(num_slots):
+            _send_slot(
+                thr_copy,
+                copy_atom,
+                g_in,
+                g_send,
+                tail_remote,
+                start_send,
+                b,
+                tidx,
+                s,
+                tiles_per_slot,
+                num_tiles,
+                num_blocks,
+                unroll,
+                produce,
+            )
+    elif cutlass.const_expr(do_recv):
+        for s in range(num_slots):
+            _recv_slot(
+                thr_copy,
+                copy_atom,
+                g_recv,
+                g_out,
+                tail_local,
+                start_recv,
+                b,
+                tidx,
+                s,
+                tiles_per_slot,
+                num_tiles,
+                num_blocks,
+                unroll,
+                consume,
+            )
+
+    if cutlass.const_expr(do_send):
+        if tidx == 0:
+            send_ctr[send_peer * mbp + b] = start_send + num_slots
+    if cutlass.const_expr(do_recv):
+        if tidx == 0:
+            recv_ctr[recv_peer * mbp + b] = start_recv + num_slots
+
+
+@cute.jit
+def _launch_sendrecv(
+    in_t,
+    out_t,
+    buf_ptrs,
+    sig_ptrs,
+    send_ctr,
+    recv_ctr,
+    num_blocks: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    vec: cutlass.Constexpr,
+    dtype: cutlass.Constexpr,
+    dbits: cutlass.Constexpr,
+    local_rank: cutlass.Constexpr,
+    send_peer: cutlass.Constexpr,
+    recv_peer: cutlass.Constexpr,
+    numel: cutlass.Constexpr,
+    cap_elems: cutlass.Constexpr,
+    mbp: cutlass.Constexpr,
+    num_slots: cutlass.Constexpr,
+    tiles_per_slot: cutlass.Constexpr,
+    unroll: cutlass.Constexpr,
+    do_send: cutlass.Constexpr,
+    do_recv: cutlass.Constexpr,
+    produce: cutlass.Constexpr,
+    consume: cutlass.Constexpr,
+    stream,
+) -> None:
+    _sendrecv_kernel(
+        in_t,
+        out_t,
+        buf_ptrs,
+        sig_ptrs,
+        send_ctr,
+        recv_ctr,
+        dtype,
+        vec,
+        dbits,
+        num_blocks,
+        num_threads,
+        local_rank,
+        send_peer,
+        recv_peer,
+        numel,
+        cap_elems,
+        mbp,
+        num_slots,
+        tiles_per_slot,
+        unroll,
+        do_send,
+        do_recv,
+        produce,
+        consume,
+    ).launch(grid=(num_blocks, 1, 1), block=(num_threads, 1, 1), stream=stream)
+
+
+def pipelined_sendrecv(
+    transport: NvlTransport,
+    send_buf,
+    recv_buf,
+    send_peer: int,
+    recv_peer: int,
+    *,
+    num_blocks: int,
+    mode: str = "bidir",
+    produce=copy_produce,
+    consume=copy_consume,
+) -> None:
+    """Graph-safe pipelined CuTe send/recv over the shared NvlTransport.
+
+    ``mode``: ``"bidir"`` (send to send_peer + recv from recv_peer), ``"send"`` (send
+    only), or ``"recv"`` (recv only). Whole-buffer transfer (single peer pair), so the
+    transport must be sized ``per_peer_bytes >= numel * elem``. Composes the shared
+    ``_send_slot``/``_recv_slot`` substrate over the analytic tile/slot sizing above.
+    """
+    if mode not in ("bidir", "send", "recv"):
+        raise ValueError(f"mode must be one of bidir/send/recv, got {mode!r}")
+    do_send = mode != "recv"
+    do_recv = mode != "send"
+    # Validate each leg that actually reaches from_dlpack (send_buf on the send leg, recv_buf
+    # on the recv leg) so an invalid buffer fails at this guard, not deep inside from_dlpack.
+    for nm, t, used in (
+        ("send_buf", send_buf, do_send),
+        ("recv_buf", recv_buf, do_recv),
+    ):
+        if used:
+            assert t.is_cuda and t.is_contiguous(), f"{nm} must be CUDA+contiguous"
+    # bidir bakes numel/dtype from the active leg into the compiled kernel for BOTH in_t and
+    # out_t, so a recv_buf that disagrees with send_buf would OOB-write g_out / mismatch the
+    # constexpr dtype. Require the two legs to agree before any device work.
+    if do_send and do_recv:
+        assert (
+            recv_buf.numel() == send_buf.numel() and recv_buf.dtype == send_buf.dtype
+        ), "bidir requires recv_buf.numel()/dtype == send_buf.numel()/dtype"
+    buf = send_buf if do_send else recv_buf  # dtype/numel source for the active leg
+    dtype = buf.dtype
+    if dtype not in _CUTLASS_DTYPE:
+        raise ValueError(f"cute sendrecv supports {list(_CUTLASS_DTYPE)}, got {dtype}")
+    cdtype, dbits = _CUTLASS_DTYPE[dtype]
+    numel = buf.numel()
+    elem = buf.element_size()
+    num_threads, vec = _pick_tile(numel, dbits, num_blocks)
+    num_tiles = numel // (num_threads * vec)
+    num_slots, tiles_per_slot = _pick_slots(num_tiles, numel * elem)
+    check_transfer(transport, numel, dtype, num_blocks)
+    cap_elems = transport.per_peer_bytes // elem
+    mbp = transport.max_blocks_per_peer
+    local_rank = transport.local_rank
+    # Register-blocking unroll for the NVLink store loop (the per-SM injection lever):
+    # default 8 once the buffer is large enough for the unrolled body to engage.
+    unroll = 8 if numel * elem >= 64 * 1024 else 1
+
+    table = transport.endpoints_device()
+    send_ctr, recv_ctr = transport.step_state()
+    _ensure_cuda_rt_compat()  # lazy: shim cuda-bindings before the cute.compile JIT path
+    in_t = from_dlpack(send_buf if do_send else recv_buf, assumed_align=16)
+    # out_t is only read on device under do_recv (g_out is consumed inside do_recv-guarded
+    # slot loops); on send-only recv_buf is unvalidated and may be None, so source it from
+    # send_buf to keep from_dlpack and the unconditional g_out=zipped_divide(out_t) valid.
+    out_t = from_dlpack(recv_buf if do_recv else send_buf, assumed_align=16)
+    buf_c = from_dlpack(table.buffer_ptrs, assumed_align=8)
+    sig_c = from_dlpack(table.signal_pad_ptrs, assumed_align=8)
+    send_c = from_dlpack(send_ctr, assumed_align=8)
+    recv_c = from_dlpack(recv_ctr, assumed_align=8)
+    stream = _cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    key = (
+        "sendrecv",
+        num_blocks,
+        num_threads,
+        vec,
+        dtype,
+        numel,
+        cap_elems,
+        mbp,
+        num_slots,
+        tiles_per_slot,
+        unroll,
+        local_rank,
+        send_peer,
+        recv_peer,
+        do_send,
+        do_recv,
+        produce,
+        consume,
+    )
+    compiled = _COMPILED.get(key)
+    if compiled is None:
+        compiled = cute.compile(
+            _launch_sendrecv,
+            in_t,
+            out_t,
+            buf_c,
+            sig_c,
+            send_c,
+            recv_c,
+            num_blocks,
+            num_threads,
+            vec,
+            cdtype,
+            dbits,
+            local_rank,
+            send_peer,
+            recv_peer,
+            numel,
+            cap_elems,
+            mbp,
+            num_slots,
+            tiles_per_slot,
+            unroll,
+            do_send,
+            do_recv,
+            produce,
+            consume,
+            stream,
+        )
+        _COMPILED[key] = compiled
+    compiled(in_t, out_t, buf_c, sig_c, send_c, recv_c, stream)

--- a/comms/dsl/cute/tma_smem.py
+++ b/comms/dsl/cute/tma_smem.py
@@ -1,0 +1,32 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Shared-memory layout factory for the TMA-drain a2a variant.
+
+This module intentionally does NOT use ``from __future__ import annotations``:
+``@cute.struct`` reads the REAL type objects off a class's annotations to build the
+smem layout, and PEP 563 stringized annotations (which ``collectives.py`` enables)
+turn ``cute.struct.MemRange[...]`` into a plain string that ``@cute.struct`` rejects
+("Struct element only support struct/array/base_dsl scalar"). Keeping the struct
+definition here, annotation-eager, sidesteps that.
+"""
+
+import cutlass
+import cutlass.cute as cute
+
+
+def make_tma_smem(dtype, tile_elems: int, stages: int):
+    """Build the per-CTA shared-memory struct for the TMA-drain bounce: ``stages``
+    mbarriers (two int64 slots each -- full + empty) plus a ``tile_elems * stages``
+    element bounce buffer, 128B-aligned for TMA."""
+
+    @cute.struct
+    class _TmaSmem:
+        mbar: cute.struct.MemRange[cutlass.Int64, stages * 2]
+        buf: cute.struct.Align[
+            cute.struct.MemRange[dtype, tile_elems * stages],
+            128,
+        ]
+
+    return _TmaSmem

--- a/comms/dsl/cute/transpose.py
+++ b/comms/dsl/cute/transpose.py
@@ -1,0 +1,185 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# pyre-ignore-all-errors[6, 29, 35, 58]: @cute.jit/@cute.kernel constexpr params are annotated
+# cutlass.Constexpr; pyre models that as Constexpr[Any]. Same idiom as schedules/send_recv.
+
+"""Batched SMEM-staged transpose: each of ``ws`` contiguous ``[rows, cols]`` chunks -> ``[cols,
+rows]``, bit-exact, at ~coalesced HBM bandwidth.
+
+The fast realization of the a2a transpose. A naive per-element gather hook reads through a
+strided ``(rows, cols):(cols, 1)`` view (uncoalesced vec=1 gather -> ~0.26x of coalesced BW);
+this does the classic bank-conflict-free SMEM transpose instead -- coalesced load into a padded
+``[TILE, TILE+1]`` smem tile, then coalesced store of the transposed tile -- reaching ~plain
+copy bandwidth (H100 microbench: 48MB 1.01x, 128MB 0.97x of a plain contiguous copy). It shares
+the block-tile ``transpose_tile`` hook with the fused schedule (see ``hooks.transpose_tile``).
+
+Because the per-(sender,receiver)-chunk transpose COMMUTES with the equal-split all_to_all
+(transpose-input-then-a2a == a2a-then-transpose-output), this powers the ORCHESTRATED transpose
+variant (``host.all_to_all_transpose_orchestrated``): transpose the local input chunks with this
+kernel, then a plain best-variant a2a (incl. the zero-copy direct/ce paths) -- each leg at its
+own peak. The DEFAULT (``all_to_all_transpose``) is instead a single fused SMEM-staging kernel
+that stores transposed straight into the peer output buffer (one launch, no scratch).
+"""
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as cutlass_utils
+import torch
+from cutlass.cute.runtime import from_dlpack
+
+# Reuse the backend's one-time CUTE_DSL_ARCH detection + cuda-bindings shim + dtype table.
+from .hooks import transpose_tile
+from .send_recv import _block_tile_u, _CUTLASS_DTYPE, _ensure_cuda_rt_compat
+
+_TILE: int = 32
+_BLOCK_ROWS: int = 8
+_COMPILED: dict = {}
+
+
+def _make_smem_t(dtype, tile: int):
+    @cute.struct
+    class _SmemT:
+        buf: cute.struct.MemRange[dtype, tile * (tile + 1)]
+
+    return _SmemT
+
+
+@cute.kernel
+def _transpose_kernel(
+    src,  # [ws, rows, cols] contiguous
+    dst,  # [ws, cols, rows] contiguous
+    ntiles_r: cutlass.Constexpr,  # rows // TILE
+    ntiles_c: cutlass.Constexpr,  # cols // TILE
+    ws: cutlass.Constexpr,
+    smem_struct: cutlass.Constexpr,
+    tile: cutlass.Constexpr,
+    block_rows: cutlass.Constexpr,
+    num_blocks: cutlass.Constexpr,
+    layout_hook: cutlass.Constexpr,
+) -> None:
+    tidx = cute.arch.thread_idx()[0]
+    bid = cute.arch.block_idx()[0]
+    tx = (
+        tidx % tile
+    )  # lane -> contiguous gmem dim on BOTH legs (coalesced load AND store)
+    ty = tidx // tile
+    smem = cutlass_utils.SmemAllocator()
+    storage = smem.allocate(smem_struct)
+    # (tile, tile+1) padded so the transposed smem read hits distinct banks (no conflict).
+    sA = storage.buf.get_tensor(
+        cute.make_layout((tile, tile + 1), stride=(tile + 1, 1))
+    )
+    tiles_per_chunk = ntiles_r * ntiles_c
+    total = ws * tiles_per_chunk
+    gt = bid
+    while gt < total:
+        peer = gt // tiles_per_chunk
+        tb = gt % tiles_per_chunk
+        br = tb // ntiles_c  # tile-row into rows
+        bc = tb % ntiles_c  # tile-col into cols
+        # Shared block-tile leaf: coalesced-load src[peer] tile -> padded SMEM, barrier, then the
+        # HOOK does the in-SMEM transform + coalesced store into dst[peer] (transpose_tile default).
+        _block_tile_u(
+            sA,
+            src[(peer, None, None)],
+            dst[(peer, None, None)],
+            br,
+            bc,
+            tile,
+            block_rows,
+            tx,
+            ty,
+            layout_hook,
+        )
+        gt += num_blocks
+
+
+@cute.jit
+def _transpose_launch(
+    src,
+    dst,
+    rows: cutlass.Constexpr,
+    cols: cutlass.Constexpr,
+    ws: cutlass.Constexpr,
+    tile: cutlass.Constexpr,
+    block_rows: cutlass.Constexpr,
+    dtype: cutlass.Constexpr,
+    num_blocks: cutlass.Constexpr,
+    stream,
+) -> None:
+    src3d = cute.make_tensor(
+        src.iterator, cute.make_layout((ws, rows, cols), stride=(rows * cols, cols, 1))
+    )
+    dst3d = cute.make_tensor(
+        dst.iterator, cute.make_layout((ws, cols, rows), stride=(cols * rows, rows, 1))
+    )
+    smem_struct = _make_smem_t(dtype, tile)
+    _transpose_kernel(
+        src3d,
+        dst3d,
+        rows // tile,
+        cols // tile,
+        ws,
+        smem_struct,
+        tile,
+        block_rows,
+        num_blocks,
+        transpose_tile,
+    ).launch(
+        grid=(num_blocks, 1, 1),
+        block=(tile * block_rows, 1, 1),
+        stream=stream,
+        smem=smem_struct.size_in_bytes(),
+    )
+
+
+def _sms(device) -> int:
+    return torch.cuda.get_device_properties(device).multi_processor_count
+
+
+def transpose_chunks(
+    dst: torch.Tensor, src: torch.Tensor, ws: int, rows: int, cols: int
+) -> None:
+    """Transpose each of ``ws`` contiguous ``[rows, cols]`` chunks of ``src`` into ``[cols, rows]``
+    in ``dst`` (both 1-D length ``ws*rows*cols``), bit-exact, at ~coalesced bandwidth.
+
+    ``rows`` and ``cols`` must be multiples of the SMEM tile (32). Graph-capture-safe (no host
+    sync / alloc); the caller owns ``dst``."""
+    if rows % _TILE or cols % _TILE:
+        raise ValueError(
+            f"transpose_chunks requires rows/cols % {_TILE} == 0, got {rows}x{cols}"
+        )
+    if src.dtype not in _CUTLASS_DTYPE:
+        raise ValueError(
+            f"transpose_chunks supports {list(_CUTLASS_DTYPE)}, got {src.dtype}"
+        )
+    cdtype, _ = _CUTLASS_DTYPE[src.dtype]
+    # High block count: the SMEM+barrier latency needs many waves to reach peak (H100 microbench:
+    # 48MB needed 4x SMs). Cap at the actual tile count so tiny chunks don't over-launch.
+    total_tiles = ws * (rows // _TILE) * (cols // _TILE)
+    num_blocks = min(total_tiles, 8 * _sms(src.device))
+    import cuda.bindings.driver as _drv
+
+    _ensure_cuda_rt_compat()
+    src_c = from_dlpack(src, assumed_align=16)
+    dst_c = from_dlpack(dst, assumed_align=16)
+    stream = _drv.CUstream(torch.cuda.current_stream().cuda_stream)
+    key = ("transpose", rows, cols, ws, src.dtype, num_blocks)
+    compiled = _COMPILED.get(key)
+    if compiled is None:
+        compiled = cute.compile(
+            _transpose_launch,
+            src_c,
+            dst_c,
+            rows,
+            cols,
+            ws,
+            _TILE,
+            _BLOCK_ROWS,
+            cdtype,
+            num_blocks,
+            stream,
+        )
+        _COMPILED[key] = compiled
+    compiled(src_c, dst_c, stream)

--- a/comms/dsl/tests/_bench_common.py
+++ b/comms/dsl/tests/_bench_common.py
@@ -1,0 +1,300 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# (suppression) Benchmark helpers over untyped torch.distributed / cute symbols pyre cannot
+# model; strict typing adds no value here (not shipped code).
+# Shared benchmark helpers (timing / bandwidth / NCCL grid + baseline), extracted from
+# benchmark_a2a so the Triton and CuTe a2a benchmarks import ONE lib instead of pulling the
+# whole driver module as a src. Behaviour is unchanged (verbatim move).
+
+"""Backend-agnostic a2a benchmark helpers: CUDA-graph capture/replay timing, bus-bandwidth
+math, the probed NCCL runtime-grid table + num_blocks policy, and the NCCL baseline."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import statistics
+from typing import Any, Callable
+
+import torch
+import torch.distributed as dist
+
+
+_DTYPE: torch.dtype = torch.bfloat16
+
+
+_NCCL_A2A_GRID_TABLE: dict[tuple[int, int], int] = {
+    (65536, 8): 8,  # 64KB cap=8
+    (65536, 16): 8,  # 64KB cap=16
+    (65536, 32): 8,  # 64KB cap=32
+    (262144, 8): 8,  # 256KB cap=8
+    (262144, 16): 8,  # 256KB cap=16
+    (262144, 32): 8,  # 256KB cap=32
+    (1048576, 8): 8,  # 1MB cap=8
+    (1048576, 16): 16,  # 1MB cap=16
+    (1048576, 32): 16,  # 1MB cap=32
+    (8388608, 8): 8,  # 8MB cap=8
+    (8388608, 16): 16,  # 8MB cap=16
+    (8388608, 32): 32,  # 8MB cap=32
+    (
+        50331648,
+        8,
+    ): 8,  # 48MB cap=8 (estimated: cap-plateau, between probed 8MB and 64MB)
+    (50331648, 16): 16,  # 48MB cap=16 (estimated)
+    (50331648, 32): 32,  # 48MB cap=32 (estimated)
+    (67108864, 8): 8,  # 64MB cap=8
+    (67108864, 16): 16,  # 64MB cap=16
+    (67108864, 32): 32,  # 64MB cap=32
+    (
+        100663296,
+        8,
+    ): 8,  # 96MB cap=8 (estimated: cap-plateau, between probed 64MB and 256MB)
+    (100663296, 16): 16,  # 96MB cap=16 (estimated)
+    (100663296, 32): 32,  # 96MB cap=32 (estimated)
+    (268435456, 8): 8,  # 256MB cap=8
+    (268435456, 16): 16,  # 256MB cap=16
+    (268435456, 32): 32,  # 256MB cap=32
+    # 512MB / 1GB: ESTIMATED at the cap-plateau (NCCL caps its P2P channels at the
+    # allocation; the 256MB row and the sendrecv 1GB row both plateau cap=grid).
+    # Re-probe with --nccl-only under nsys to lock exact values for these sizes.
+    (536870912, 8): 8,  # 512MB cap=8 (estimated)
+    (536870912, 16): 16,  # 512MB cap=16 (estimated)
+    (536870912, 32): 32,  # 512MB cap=32 (estimated)
+    (1073741824, 8): 8,  # 1GB cap=8 (estimated)
+    (1073741824, 16): 16,  # 1GB cap=16 (estimated)
+    (1073741824, 32): 32,  # 1GB cap=32 (estimated)
+}
+
+
+_WARMUP_ITERS: int = 20
+
+
+_CAPTURE_WARMUP_ITERS: int = 3
+
+
+def _iters_for_size(msg_bytes: int) -> int:
+    if msg_bytes <= 64 * 1024:
+        return 500
+    if msg_bytes <= 64 * 1024 * 1024:
+        return 200
+    return 50
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _capture_one_call(fn: Callable[[], None]) -> torch.cuda.CUDAGraph:
+    """Warm up ``fn`` on a side stream, then capture a single call into a graph."""
+    side_stream = torch.cuda.Stream()
+    side_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side_stream):
+        for _ in range(_CAPTURE_WARMUP_ITERS):
+            fn()
+    torch.cuda.current_stream().wait_stream(side_stream)
+
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g, stream=side_stream):
+        fn()
+    return g
+
+
+def _time_replays(
+    g: torch.cuda.CUDAGraph,
+    iters: int,
+    device: torch.device,
+    group: dist.ProcessGroup,
+    windows: int | None = None,
+) -> float:
+    """Steady-state μs/iter: median over ``windows`` warmed, re-barriered windows.
+
+    Mirrors the perf2.md stability method -- each window event-times ``iters``
+    graph replays after a fresh ``dist.barrier`` re-aligns both ranks, and the
+    median across windows rejects the occasional bad window (a transient SM-clock
+    dip or neighbour kernel) that a single long mean would bake in.
+    """
+    if windows is None:
+        # Read lazily (not at module scope) per python.md. `or "5"` covers an EMPTY value (env
+        # plumbing often sets ""), try/except covers a non-numeric typo, and max(1, ...) floors
+        # 0/negative -- so a bad A2A_PERF_WINDOWS falls back to 5 instead of crashing a MAST sweep.
+        try:
+            windows = max(1, int(os.environ.get("A2A_PERF_WINDOWS") or "5"))
+        except ValueError:
+            windows = 5
+    for _ in range(_WARMUP_ITERS):
+        g.replay()
+    torch.cuda.synchronize(device)
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    samples = []
+    for _ in range(windows):
+        dist.barrier(group)
+        torch.cuda.synchronize(device)
+        start.record()
+        for _ in range(iters):
+            g.replay()
+        end.record()
+        torch.cuda.synchronize(device)
+        samples.append((start.elapsed_time(end) * 1000.0) / iters)
+    return statistics.median(samples)
+
+
+def _max_rank_latency(
+    lat_us: float, device: torch.device, group: dist.ProcessGroup
+) -> float:
+    latency = torch.tensor([lat_us], dtype=torch.float64, device=device)
+    dist.all_reduce(latency, op=dist.ReduceOp.MAX, group=group)
+    return float(latency.item())
+
+
+def _bus_bytes(numel: int, ws: int) -> int:
+    """Per-rank NVLink-traversing bytes (diagonal chunk excluded)."""
+    chunk = numel // ws
+    return chunk * (ws - 1) * torch.tensor([], dtype=_DTYPE).element_size()
+
+
+def _bw_gbps(numel: int, ws: int, lat_us: float) -> float:
+    return (_bus_bytes(numel, ws) / 1e9) / (lat_us / 1e6) if lat_us > 0 else 0.0
+
+
+def _fmt_size(nbytes: int) -> str:
+    """Human-readable per-rank byte size for the result table, e.g. 65536 -> ``64KB``,
+    50331648 -> ``48MB``, 2147483648 -> ``2GB``."""
+    x = float(nbytes)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if x < 1024.0:
+            return f"{x:.0f}{unit}" if x == int(x) else f"{x:.1f}{unit}"
+        x /= 1024.0
+    return f"{x:.1f}PB"
+
+
+def _make_input(rank: int, numel: int, device: torch.device) -> torch.Tensor:
+    base = (rank + 1) * 4096
+    return (base + torch.arange(numel, device=device, dtype=torch.float32)).to(_DTYPE)
+
+
+def _max_num_blocks(ws: int, device: torch.device, mbp: int) -> int:
+    # Grid is ws * num_blocks (one CTA per (peer, block)), so the SM budget bounds
+    # num_blocks at sm // ws.
+    sm = torch.cuda.get_device_properties(device).multi_processor_count
+    return max(min(mbp, sm // ws), 1)
+
+
+def _framework_num_blocks(
+    msg_bytes: int, cap: int, ws: int, device: torch.device, mbp: int
+) -> tuple[int, int | None]:
+    """Pick framework num_blocks to track NCCL's runtime grid (SM-matched).
+
+    Returns ``(num_blocks, nccl_grid_or_None)``. The framework device grid is
+    ``ws * num_blocks``, matched to NCCL's active SMs via ``num_blocks ~=
+    nccl_grid / ws``. If the (msg, cap) grid has not been probed, fall back to the
+    SM-budget ceiling and return ``None`` so the row is flagged as not-yet-matched.
+    """
+    nb_cap = _max_num_blocks(ws, device, mbp)
+    nccl_grid = _NCCL_A2A_GRID_TABLE.get((msg_bytes, cap))
+    if nccl_grid is None:
+        return nb_cap, None
+    # Framework grid = ws * num_blocks; match it to NCCL's active SMs.
+    nb = max(round(nccl_grid / ws), 1)
+    return min(nb, nb_cap), nccl_grid
+
+
+def _full_sm_policy(
+    msg_bytes: int, ws: int, device: torch.device, mbp: int
+) -> tuple[int, dict[str, object]]:
+    """Production (full-GPU) config the autotuner emits: ``(num_blocks, extra_cfg)``.
+
+    NCCL P2P saturates at its channel ceiling (~32 SMs) and provably cannot use
+    more (forced 48/64 channels ~= default), so during a comm-bound a2a the rest
+    of the GPU is idle. The framework spends those idle SMs: small msgs stay
+    latency-bound (1 CTA/peer), >=1 MiB scale to the SM budget, and the >=64 MiB
+    band additionally takes the swept-best fine-slot (256 KiB) + deep run-ahead
+    (pipeline_depth 8) + warp specialization (SEND/RECV on disjoint warp groups,
+    which only wins at high CTA counts where each block's sub-chunk is small enough
+    that the WS register-cap doesn't cost copy ILP -- the reverse of the SM-matched
+    regime, where WS loses). Together these lift large-message bandwidth from the
+    SM-matched ~1.8x to ~1.06-1.11x of NCCL on otherwise-idle SMs. Mirrors what a
+    tuning run writes into TUNED_A2A_CONFIGS; the SM-matched table is the
+    per-SM-efficiency lens.
+    """
+    nb_cap = _max_num_blocks(ws, device, mbp)
+    if msg_bytes < 1024 * 1024:
+        return 1, {}
+    if msg_bytes < 64 * 1024 * 1024:
+        return nb_cap, {}
+    return nb_cap, {
+        "block_stride_bytes": 256 * 1024,
+        "pipeline_depth": 8,
+        "primitive": "ws",
+    }
+
+
+def _report_full_cfg(
+    msg_bytes: int, ws: int, device: torch.device, mbp: int
+) -> tuple[int, dict[str, object]]:
+    """Full-GPU launch base (num_blocks + stride/depth) WITHOUT a structure choice.
+
+    Same SM-budget + large-band fine-slot/run-ahead as ``_full_sm_policy`` but with
+    the ``primitive`` choice left out, so the perf report can layer each structure
+    (primitive = "copy"/"ws"/"tma") on top of one identical framing and compare
+    structures apple-to-apple at the full CTA count.
+    """
+    nb_cap = _max_num_blocks(ws, device, mbp)
+    if msg_bytes < 1024 * 1024:
+        return 1, {}
+    if msg_bytes < 64 * 1024 * 1024:
+        return nb_cap, {}
+    return nb_cap, {"block_stride_bytes": 256 * 1024, "pipeline_depth": 8}
+
+
+def _bench_nccl(
+    msg_bytes: int, rank: int, ws: int, group: dist.ProcessGroup
+) -> tuple[float, float]:
+    device = torch.device("cuda", torch.cuda.current_device())
+    numel = max(msg_bytes // torch.tensor([], dtype=_DTYPE).element_size(), ws)
+    numel -= numel % ws
+    inp: torch.Tensor = _make_input(rank, numel, device)
+    out: torch.Tensor = torch.empty_like(inp)
+
+    def fn() -> None:
+        dist.all_to_all_single(out, inp, group=group)
+
+    fn()
+    dist.barrier(group)
+    g = _capture_one_call(fn)
+    dist.barrier(group)
+
+    iters = _iters_for_size(msg_bytes)
+    lat = _max_rank_latency(_time_replays(g, iters, device, group), device, group)
+    return lat, _bw_gbps(numel, ws, lat)
+
+
+_RESULT_TAG: str = "A2A_RESULT_JSON"
+
+
+def emit_result_rows(rows: list[dict[str, Any]]) -> None:
+    """DSL-agnostic durable result sink: print one compact JSON object per row to stdout,
+    each tagged with a stable prefix.
+
+    This is the channel the UniBench / AnyBench parser
+    (``comms/dsl/tests/anybench_a2a_cute_parser.py``) reads back from each rank's
+    ``$ANYBENCH_LOGS_DIR/rank_*/stdout.log`` and pushes to the ``anybench_parser_output``
+    Scuba dataset -- replacing the previous private Scuba sink. stdout is durable on MAST via
+    the AnyBench log capture, so no benchmark-side Scuba/Scribe dependency is needed. Backend-
+    neutral (both DSLs' benchmarks call it). Best-effort: never raises into the benchmark."""
+    for row in rows:
+        try:
+            print(f"{_RESULT_TAG} " + json.dumps(row, sort_keys=True), flush=True)
+        except (TypeError, ValueError, OSError) as e:
+            # Best-effort sink: an unserializable row (TypeError/ValueError) or a broken stdout
+            # (OSError/BrokenPipeError, e.g. MAST log rotation) must not abort the benchmark. The
+            # fallback print can itself hit the broken stream, so it is guarded too.
+            try:
+                print(f"(emit_result_rows skipped a row: {e})", flush=True)
+            except OSError:
+                pass

--- a/comms/dsl/tests/_dist_harness.py
+++ b/comms/dsl/tests/_dist_harness.py
@@ -1,0 +1,60 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Shared multi-rank scaffolding for the distributed correctness suites.
+
+The small helpers every distributed test repeats: a free-port picker, the bit-exact
+input builder, the ``dist.all_to_all_single`` golden, the cross-rank PASS/FAIL
+min-reduce + reporter, and the transport rendezvous. Kept here so the scaffolding
+lives in one place; a test with a special need (e.g. multi-dtype bit-exact-per-dtype
+inputs) keeps its own local variant.
+"""
+
+import socket
+
+import torch
+import torch.distributed as dist
+
+_FP32_BYTES = 4
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _make_input(rank: int, numel: int, device: torch.device) -> torch.Tensor:
+    idx = torch.arange(numel, device=device, dtype=torch.int64)
+    return ((rank + 1) * 1_000_000 + idx).to(torch.float32)
+
+
+def _golden(group: dist.ProcessGroup, inp: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(inp)
+    dist.all_to_all_single(out, inp, group=group)
+    return out
+
+
+def _all_ok(local_ok: bool, device: torch.device, group: dist.ProcessGroup) -> bool:
+    status = torch.tensor([1 if local_ok else 0], dtype=torch.int32, device=device)
+    dist.all_reduce(status, op=dist.ReduceOp.MIN, group=group)
+    return bool(status.item())
+
+
+def _report(name: str, local_ok: bool, device, group, rank: int) -> bool:
+    ok = _all_ok(local_ok, device, group)
+    if rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: {name}", flush=True)
+    return ok
+
+
+def _rendezvous(group, device, max_chunk_numel: int, *, max_blocks_per_peer: int = 32):
+    from comms.dsl import nvl_rendezvous
+
+    return nvl_rendezvous(
+        group,
+        device,
+        per_peer_bytes=max_chunk_numel * _FP32_BYTES,
+        max_blocks_per_peer=max_blocks_per_peer,
+    )

--- a/comms/dsl/tests/anybench_a2a_cute.json
+++ b/comms/dsl/tests/anybench_a2a_cute.json
@@ -1,0 +1,33 @@
+{
+  "mast_job_request": {
+    "user_label": "AnyBench comms/dsl CuTe a2a vs NCCL (8x GB300)",
+    "hpc_cluster": "MastProdCluster",
+    "scheduler": "MAST",
+    "num_hosts": [2],
+    "entitlement": "infra_projects",
+    "hardware": "T20_CIC_GB300_278GB_HBM3E_NVLSO_NSF_LP",
+    "benchmark_config": {
+      "anybench_test_config": [
+        {
+          "fbpkg_name": "comms.dsl.benchmark_a2a.aarch64.gb300",
+          "binary_path": "penv.par",
+          "binary_args": "",
+          "env_vars": {
+            "A2A_CUTE_REPORT": "1",
+            "A2A_CAPS": "32",
+            "DISABLE_OILFS": "1",
+            "TRITON_CACHE_DIR": "/tmp/triton_cache"
+          },
+          "iteration": 1,
+          "timeout": 1800,
+          "ppn": 4,
+          "parser": {
+            "command": "python3 $ANYBENCH_PARSER",
+            "parser_path": "comms/dsl/tests/anybench_a2a_cute_parser.py",
+            "timeout": 120
+          }
+        }
+      ]
+    }
+  }
+}

--- a/comms/dsl/tests/anybench_a2a_cute_parser.py
+++ b/comms/dsl/tests/anybench_a2a_cute_parser.py
@@ -1,0 +1,105 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""AnyBench parser for the CuTe a2a benchmark -- the UniBench result sink (replaces Scuba).
+
+AnyBench runs ``benchmark_a2a_cute`` on MAST, then invokes this parser via ``bash -c`` with
+``$ANYBENCH_LOGS_DIR`` pointing at ``<dir>/rank_<n>/stdout.log`` per rank. The benchmark's
+rank 0 prints one ``A2A_RESULT_JSON {<json>}`` line per (size, variant) via
+``comms.dsl.tests._bench_common.emit_result_rows``; this parser scrapes those lines and
+prints a SINGLE JSON object to stdout, which AnyBench pushes to the ``anybench_parser_output``
+Scuba dataset (top-level keys become columns). See the AnyBench Getting Started wiki and
+``hpc_comms/uni_bench/parsers/_template.py``.
+
+Contract: read logs, print exactly one JSON object, exit 0. A parse miss is reported in the
+object (never a nonzero exit) so it does not fail the benchmark run.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import sys
+from typing import Any
+
+_TAG = "A2A_RESULT_JSON "
+
+
+def _collect_rows(logs_dir: str) -> list[dict[str, Any]]:
+    """Every ``A2A_RESULT_JSON`` row across all per-rank stdout logs (rank 0 emits them)."""
+    rows: list[dict[str, Any]] = []
+    for log in sorted(glob.glob(os.path.join(logs_dir, "rank_*", "stdout.log"))):
+        try:
+            with open(log, "r", errors="replace") as f:
+                for line in f:
+                    idx = line.find(_TAG)
+                    if idx == -1:
+                        continue
+                    try:
+                        obj = json.loads(line[idx + len(_TAG) :].strip())
+                    except json.JSONDecodeError:
+                        continue
+                    # json.loads can return a list/number/string; keep only dict rows so
+                    # _summarize's r.get(...) never hits a non-dict (never-fail contract).
+                    if isinstance(obj, dict):
+                        rows.append(obj)
+        except OSError:
+            continue
+    return rows
+
+
+def _summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate per-(size, variant) rows into one AnyBench result object.
+
+    Emits the perf verdict (min ratio vs NCCL over the default ``copy`` variant, and whether
+    every copy size cleared NCCL) plus per-size arrays and the raw rows (JSON-encoded)."""
+    perf = [r for r in rows if r.get("backend") == "cute" and "ratio" in r]
+    errors = [r for r in rows if r.get("backend") == "cute_error"]
+    copy_rows = sorted(
+        (r for r in perf if r.get("variant") == "copy"),
+        key=lambda r: int(r.get("size_bytes", 0)),
+    )
+    # Include ALL copy rows (not `if r.get("ratio")`): a ratio of 0.0 is the sentinel the benchmark
+    # emits when NCCL timing failed/was unavailable for that size, so a truthy filter would silently
+    # drop the failed sizes and let min_ratio_copy / all_clear_nccl over-report. Keep the 0.0s (they
+    # sink min_ratio_copy and fail the >=1.0 check) and surface the count as a coverage gap.
+    ratios = [float(r["ratio"]) for r in copy_rows]
+    n_nccl_failed = sum(1 for x in ratios if x <= 0.0)
+    out: dict[str, Any] = {
+        "n_result_rows": len(perf),
+        "n_errors": len(errors),
+        "n_nccl_failed": n_nccl_failed,
+        "world_size": int(copy_rows[0].get("world_size", 0)) if copy_rows else 0,
+        "min_ratio_copy": min(ratios) if ratios else 0.0,
+        "all_clear_nccl": bool(ratios) and all(x >= 1.0 for x in ratios),
+        "size_bytes": [int(r.get("size_bytes", 0)) for r in copy_rows],
+        "cute_busbw_gbps": [float(r.get("cute_busbw_gbps", 0.0)) for r in copy_rows],
+        "nccl_busbw_gbps": [float(r.get("nccl_busbw_gbps", 0.0)) for r in copy_rows],
+        "ratio": [float(r.get("ratio", 0.0)) for r in copy_rows],
+        # Full per-(size, variant) matrix for ad-hoc querying (JSON-encoded column).
+        "rows_json": json.dumps(perf, sort_keys=True),
+    }
+    if errors:
+        out["first_error"] = str(errors[0].get("error", ""))[:900]
+    return out
+
+
+def main() -> None:
+    # Honor the never-fail contract end-to-end: a malformed row value (wrong type / non-numeric)
+    # could still raise inside _summarize, so wrap it and always emit ONE JSON object + exit 0.
+    logs_dir = os.environ.get("ANYBENCH_LOGS_DIR", "")
+    try:
+        rows = _collect_rows(logs_dir) if logs_dir else []
+        result = _summarize(rows)
+    except Exception as e:  # noqa: BLE001 -- parser must never fail the benchmark run
+        result = {"parse_note": f"summarize error: {type(e).__name__}: {e}"[:900]}
+    if not logs_dir:
+        result["parse_note"] = "ANYBENCH_LOGS_DIR unset"
+    print(json.dumps(result, sort_keys=True))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/dsl/tests/benchmark_a2a_cute.py
+++ b/comms/dsl/tests/benchmark_a2a_cute.py
@@ -1,0 +1,545 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# Benchmark harness (not shipped code): exercises untyped cutlass/cute DSL kernels + dynamic
+# torch.distributed symbols that pyre cannot model, so strict typing adds no value here.
+
+"""Apple-to-apple all_to_all benchmark: CuTe-DSL framework vs NCCL.
+
+The CuTe counterpart of ``benchmark_a2a.py``. Same methodology -- runtime-SM
+matched (the framework grid ``world_size * num_blocks`` is set to NCCL's probed
+active-SM count), CUDA-graph timed, busbw/dir, median of windows -- so the CuTe
+copy kernel is compared to ``dist.all_to_all_single`` on the same SM budget.
+Reuses the backend-agnostic timing/bandwidth/NCCL helpers from ``benchmark_a2a``.
+
+Runs single-node (``mp.spawn``, default) for the local feedback loop, or
+one-process-per-rank under ``torchrun`` / the conda launcher for GB300 2x4.
+
+The CuTe kernel currently requires ``chunk % 256 == 0`` (no tail handling), so
+sub-tile sizes are reported as ``n/a (tail)`` until the masked-tail path lands;
+every runnable size is correctness-gated against NCCL gold before timing.
+
+The copy schedule's launch knobs come from the analytic adaptive default. Setting
+``A2A_CUTE_USE_TUNED=1`` instead drives them from the tuned table: rank builds the
+runtime key (``make_a2a_key``) and looks up its config (``get_a2a_config``,
+falling back to the analytic default when no tuned entry exists), so a single job can
+measure the tuned config against the analytic default at the same sizes -- the direct
+tuned-vs-default A/B. The toggle scopes to the copy schedule only; the ``direct``/``ce``
+zero-copy paths are unaffected.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from ._bench_common import (
+    _bench_nccl,
+    _bw_gbps,
+    _capture_one_call,
+    _DTYPE,
+    _find_free_port,
+    _fmt_size,
+    _framework_num_blocks,
+    _iters_for_size,
+    _make_input,
+    _max_num_blocks,
+    _max_rank_latency,
+    _time_replays,
+    emit_result_rows,
+)
+
+# 32 B -> 2 GB per rank, 2x stepping (27 sizes) plus 48 MB / 96 MB for mid-band resolution
+# where the Triton dip lives = 29 sizes, matched across all three benchmarks and the tuner.
+_DEFAULT_SIZES: list[int] = [
+    32,
+    64,
+    128,
+    256,
+    512,
+    1024,
+    2 * 1024,
+    4 * 1024,
+    8 * 1024,
+    16 * 1024,
+    32 * 1024,
+    64 * 1024,
+    128 * 1024,
+    256 * 1024,
+    512 * 1024,
+    1 * 1024 * 1024,
+    2 * 1024 * 1024,
+    4 * 1024 * 1024,
+    8 * 1024 * 1024,
+    16 * 1024 * 1024,
+    32 * 1024 * 1024,
+    48 * 1024 * 1024,
+    64 * 1024 * 1024,
+    96 * 1024 * 1024,
+    128 * 1024 * 1024,
+    256 * 1024 * 1024,
+    512 * 1024 * 1024,
+    1024 * 1024 * 1024,
+    2 * 1024 * 1024 * 1024,
+]
+
+
+def _get_sizes() -> list[int]:
+    """Size ladder, overridable via A2A_SIZES=csv. Read lazily (not at import) per python.md."""
+    env = os.environ.get("A2A_SIZES", "")
+    if env:
+        return [int(x) for x in env.split(",") if x]
+    return _DEFAULT_SIZES
+
+
+def _get_cap() -> int:
+    """SM cap, overridable via A2A_CAPS. Read lazily (not at import) per python.md."""
+    return int(os.environ.get("A2A_CAPS", "32"))
+
+
+def _bench_cute(transport, msg_bytes, rank, ws, group, *, num_blocks):
+    """CuTe a2a busbw at this size (None if unrunnable). NCCL-gold correctness gate.
+
+    The copy schedule uses the analytic adaptive config pinned to ``num_blocks``.
+    With ``A2A_CUTE_USE_TUNED=1`` it instead resolves the copy config from the tuned
+    table (key built from the live input + transport; analytic default when no entry),
+    measuring the tuned config head-to-head with the default. The toggle applies to the
+    copy schedule only; the ``direct``/``ce`` zero-copy paths keep the analytic config."""
+    from comms.dsl.cute import all_to_all, all_to_all_zc, CuteA2AConfig
+
+    direct = os.environ.get("A2A_CUTE_DIRECT") == "1"
+    ce = os.environ.get("A2A_CUTE_CE") == "1"
+    device = torch.device("cuda", torch.cuda.current_device())
+    elem = torch.tensor([], dtype=_DTYPE).element_size()
+    numel = max(msg_bytes // elem, ws)
+    numel -= numel % ws  # only need equal split; the kernel tiles any chunk now
+    if numel == 0:
+        return None, None
+    inp = _make_input(rank, numel, device)
+    gold = torch.empty_like(inp)
+    dist.all_to_all_single(gold, inp, group=group)
+    out = torch.empty_like(inp)
+
+    if ce:
+        # copy-engine zero-copy: cuMemcpyAsync moves data (zero SM), result read
+        # from the transport's symm-mem buffer (returned).
+        def fn():
+            return all_to_all_zc(transport, inp, primitive="ce")
+
+        out = fn()
+    elif direct:
+        # zero-copy: result is read from the transport's symm-mem buffer (returned).
+        def fn():
+            return all_to_all_zc(
+                transport,
+                inp,
+                primitive="direct",
+                config=CuteA2AConfig(num_blocks=num_blocks),
+            )
+
+        out = fn()
+    elif os.environ.get("A2A_CUTE_USE_TUNED") == "1":
+        from comms.dsl.cute.a2a.tuning import get_a2a_config, make_a2a_key
+
+        key = make_a2a_key(inp, transport)
+        cfg = get_a2a_config(key)
+
+        def fn():
+            all_to_all(transport, out, inp, config=cfg)
+
+        fn()
+    else:
+
+        def fn():
+            all_to_all(transport, out, inp, config=CuteA2AConfig(num_blocks=num_blocks))
+
+        fn()
+    torch.cuda.synchronize(device)
+    # A2A_CUTE_SENDONLY is a diagnostic that skips the drain leg (output is
+    # intentionally incomplete) to measure the SEND-leg NVLink ceiling.
+    #
+    # Decide correctness COLLECTIVELY before entering any follow-up collective. torch.equal is a
+    # LOCAL check, so a kernel bug that corrupts only some ranks' output would have the mismatching
+    # ranks raise here (their caller then jumps to its failure all_reduce) while the passing ranks
+    # march on into _capture_one_call's collectives -- a split where the survivors block inside a
+    # different collective than the aborted ranks, hanging the job instead of aborting cleanly. All-
+    # reduce the verdict so every rank raises together and the caller's flag mechanism stays in sync.
+    # (This does NOT cover a warmup fn() that itself raises on only some ranks -- a mid-collective,
+    # already-desynced failure that belongs to NCCL async-error-handling / timeouts, not this flag.)
+    correct = os.environ.get("A2A_CUTE_SENDONLY") == "1" or bool(torch.equal(out, gold))
+    verdict = torch.tensor([0 if correct else 1], device=device)
+    dist.all_reduce(verdict, group=group)
+    if verdict.item() > 0:
+        raise AssertionError(
+            f"cute a2a INCORRECT at msg_bytes={msg_bytes}, nb={num_blocks}"
+        )
+    g = _capture_one_call(fn)
+    dist.barrier(group)
+    iters = _iters_for_size(msg_bytes)
+    lat = _max_rank_latency(_time_replays(g, iters, device, group), device, group)
+    return lat, _bw_gbps(numel, ws, lat)
+
+
+def _run(rank, ws, group, device) -> bool:  # noqa: C901
+    from comms.dsl import nvl_rendezvous
+
+    mbp = 32
+    # Re-rendezvous one transport per size, sized to that size's chunk, so geometry stays
+    # uniform across the sweep.
+    rows: list[tuple[int, int | None, int | None, float | None, float | None]] = []
+    ok = True
+    for msg_bytes in _get_sizes():
+        elem = torch.tensor([], dtype=_DTYPE).element_size()
+        numel = max(msg_bytes // elem, ws)
+        numel -= numel % ws  # the kernel tiles any chunk (adaptive vec); no tail
+        if numel == 0:
+            if rank == 0:
+                rows.append((msg_bytes, None, None, None, None))
+            continue
+        chunk = numel // ws
+        nb, nccl_grid = _framework_num_blocks(msg_bytes, _get_cap(), ws, device, mbp)
+        nb = min(nb, _max_num_blocks(ws, device, mbp))
+        t = nvl_rendezvous(group, device, per_peer_bytes=chunk * elem)
+        failed = False
+        try:
+            _, cute_bw = _bench_cute(t, msg_bytes, rank, ws, group, num_blocks=nb)
+        except Exception as e:  # noqa: BLE001
+            if rank == 0:
+                msg = f"{type(e).__name__}: {e}"
+                print(f"  # {_fmt_size(msg_bytes)} FAILED: {msg}", flush=True)
+                emit_result_rows(
+                    [
+                        {
+                            "backend": "cute_error",
+                            "size_bytes": int(msg_bytes),
+                            "error": msg[:900],
+                        }
+                    ]
+                )
+            ok = False
+            cute_bw = None
+            failed = True
+        # Make the per-rank _bench_cute failure GLOBAL immediately after the raising call:
+        # a mid-collective raise on one rank desyncs NCCL, so a surviving rank must NOT march
+        # into the following dist.barrier / _bench_nccl while a peer aborted. MAX-reduce the
+        # failure flag and, on ANY rank's failure, stop the sweep on ALL ranks in lockstep.
+        flag = torch.tensor([1.0 if failed else 0.0], device=device)
+        dist.all_reduce(flag, group=group)
+        if flag.item() > 0:
+            ok = False
+            break
+        dist.barrier(group)
+        _, nccl_bw = _bench_nccl(msg_bytes, rank, ws, group)
+        dist.barrier(group)
+        if rank == 0:
+            rows.append((msg_bytes, nb, nccl_grid, cute_bw, nccl_bw))
+
+    if rank == 0:
+        lines = ["=== CuTe a2a vs NCCL (busbw GB/s/dir, x = cute/nccl) ==="]
+        lines.append(
+            f"{'size/rank':>10} {'fw_ctas':>7} {'nccl_grid':>9} {'cute':>8} "
+            f"{'nccl':>8} {'x':>6}"
+        )
+        for msg_bytes, nb, grid, cute_bw, nccl_bw in rows:
+            if cute_bw is None:
+                lines.append(f"{_fmt_size(msg_bytes):>10} {'n/a (tail)':>26}")
+                continue
+            ratio = cute_bw / nccl_bw if nccl_bw else 0.0
+            ctas = (nb or 0) * ws
+            flag = "" if ratio >= 1.0 else "  <NCCL"
+            lines.append(
+                f"{_fmt_size(msg_bytes):>10} {ctas:>7} {grid or 0:>9} "
+                f"{cute_bw:>8.1f} {nccl_bw:>8.1f} {ratio:>5.2f}x{flag}"
+            )
+        table = "\n".join(lines)
+        print("\n" + table, flush=True)
+        # Also write to A2A_RESULT_FILE so the conda launcher can cat it back to the
+        # task (agent) stdout that --logs fetches (worker stdout is redirected).
+        result_file = os.environ.get("A2A_RESULT_FILE")
+        if result_file:
+            try:
+                with open(result_file, "w") as f:
+                    f.write(table + "\n")
+            except OSError as e:
+                print(f"(could not write A2A_RESULT_FILE: {e})", flush=True)
+        # Durable retrieval on MAST via two readable sinks (best-effort, never fail the
+        # bench): (1) Manifold text table (`manifold get`), and (2) tagged JSON rows on
+        # stdout that the UniBench/AnyBench parser scrapes from the rank log into the
+        # ``anybench_parser_output`` dataset (see anybench_a2a_cute_parser.py).
+        _upload_result_to_manifold(table)
+        emit_result_rows(
+            [
+                {
+                    "backend": "cute",
+                    "variant": "copy",
+                    "world_size": ws,
+                    "size_bytes": int(msg_bytes),
+                    "fw_ctas": int((nb or 0) * ws),
+                    "nccl_grid": int(grid or 0),
+                    "cute_busbw_gbps": float(cute_bw),
+                    "nccl_busbw_gbps": float(nccl_bw or 0.0),
+                    "ratio": float(cute_bw / nccl_bw) if nccl_bw else 0.0,
+                }
+                for msg_bytes, nb, grid, cute_bw, nccl_bw in rows
+                if cute_bw is not None
+            ]
+        )
+    return ok
+
+
+# Schedule variants the report sweeps, each selected by the one env knob the kernel
+# reads at launch. ``copy`` is the default staging schedule (no knob); every other
+# variant flips exactly one selector, so a single transport + size loop covers the
+# whole matrix. ``tma`` is omitted: its multi-warp drain is still gated WIP.
+_REPORT_VARIANTS: tuple[tuple[str, dict[str, str]], ...] = (
+    ("copy", {}),
+    ("direct", {"A2A_CUTE_DIRECT": "1"}),
+    ("ce", {"A2A_CUTE_CE": "1"}),
+)
+# Env toggles cleared between variants so each report row measures exactly its labeled variant.
+# A2A_CUTE_USE_TUNED is included: the report has no tuned variant (copy = analytic default), so
+# an ambient A2A_CUTE_USE_TUNED=1 would otherwise make the "copy" row silently run the tuned
+# config while still emitting variant="copy" -- corrupting the AnyBench copy-vs-nccl aggregation.
+# Head-to-head tuned-vs-default measurement is a separate path (_bench_cute called directly).
+_VARIANT_SELECTORS: tuple[str, ...] = (
+    "A2A_CUTE_DIRECT",
+    "A2A_CUTE_CE",
+    "A2A_CUTE_TMA",
+    "A2A_CUTE_USE_TUNED",
+)
+
+
+def _run_report(rank, ws, group, device) -> bool:  # noqa: C901
+    """Every CuTe schedule variant vs NCCL across the size ladder (busbw + latency).
+
+    The apple-to-apple twin of ``benchmark_a2a``'s perf report for the CuTe backend:
+    one row per (size, variant) with cute/nccl busbw, ratio, and per-call latency, so
+    a single GB300 job covers the whole variant x size matrix. Each variant is timed
+    in isolation -- an unsupported or failing variant scores ``n/a`` and never aborts
+    the sweep -- and the rows are emitted as tagged JSON on stdout for the AnyBench parser.
+    """
+    from comms.dsl import nvl_rendezvous
+
+    mbp = 32
+    rows = []
+    ok = True
+    for msg_bytes in _get_sizes():
+        elem = torch.tensor([], dtype=_DTYPE).element_size()
+        numel = max(msg_bytes // elem, ws)
+        numel -= numel % ws
+        if numel == 0:
+            continue
+        chunk = numel // ws
+        nb, nccl_grid = _framework_num_blocks(msg_bytes, _get_cap(), ws, device, mbp)
+        nb = min(nb, _max_num_blocks(ws, device, mbp))
+        nccl_lat, nccl_bw = _bench_nccl(msg_bytes, rank, ws, group)
+        dist.barrier(group)
+        aborted = False
+        for vname, env in _REPORT_VARIANTS:
+            for sel in _VARIANT_SELECTORS:
+                os.environ.pop(sel, None)
+            os.environ.update(env)
+            # Re-rendezvous a fresh transport per variant so a partially-advanced failed
+            # variant cannot corrupt transport state for the next variant of this size.
+            t = nvl_rendezvous(group, device, per_peer_bytes=chunk * elem)
+            failed = False
+            try:
+                lat, bw = _bench_cute(t, msg_bytes, rank, ws, group, num_blocks=nb)
+            except Exception as e:  # noqa: BLE001 -- recorded per-rank, then made global
+                if rank == 0:
+                    msg = f"{type(e).__name__}: {e}"
+                    print(
+                        f"  # {_fmt_size(msg_bytes)}/{vname} FAILED: {msg}",
+                        flush=True,
+                    )
+                    # Emit a cute_error row like _run does, so the AnyBench parser's n_errors
+                    # reflects report-path failures too (it counts backend == "cute_error").
+                    emit_result_rows(
+                        [
+                            {
+                                "backend": "cute_error",
+                                "size_bytes": int(msg_bytes),
+                                "variant": vname,
+                                "error": msg[:900],
+                            }
+                        ]
+                    )
+                lat, bw = None, None
+                ok = False
+                failed = True
+            for sel in _VARIANT_SELECTORS:
+                os.environ.pop(sel, None)
+            # Make the per-rank _bench_cute failure GLOBAL right after the raising call: a
+            # mid-collective raise on one rank desyncs the communicator, so a surviving rank
+            # must not continue the inner loop (its next variant's rendezvous/collectives
+            # would mismatch the aborted peer). MAX-reduce the flag BEFORE the barrier; on
+            # ANY rank's failure stop both the variant loop and the size loop in lockstep.
+            flag = torch.tensor([1.0 if failed else 0.0], device=device)
+            dist.all_reduce(flag, group=group)
+            if flag.item() > 0:
+                ok = False
+                aborted = True
+                break
+            dist.barrier(group)
+            if rank == 0:
+                rows.append(
+                    (msg_bytes, vname, nb, nccl_grid, bw, lat, nccl_bw, nccl_lat)
+                )
+        if aborted:
+            break
+
+    if rank == 0:
+        _print_report(rows, ws)
+        emit_result_rows(
+            [
+                {
+                    "backend": "cute",
+                    "variant": vname,
+                    "world_size": ws,
+                    "size_bytes": int(msg_bytes),
+                    "fw_ctas": int((nb or 0) * ws),
+                    "nccl_grid": int(grid or 0),
+                    "cute_busbw_gbps": float(bw),
+                    "nccl_busbw_gbps": float(nccl_bw or 0.0),
+                    "ratio": float(bw / nccl_bw) if nccl_bw else 0.0,
+                    "cute_us": float(lat or 0.0),
+                    "nccl_us": float(nccl_lat or 0.0),
+                }
+                for msg_bytes, vname, nb, grid, bw, lat, nccl_bw, nccl_lat in rows
+                if bw is not None
+            ]
+        )
+    return ok
+
+
+def _print_report(rows, ws) -> None:
+    """Long-format matrix (one row per size+variant) with all three metrics."""
+    lines = ["=== CuTe a2a variants vs NCCL (busbw GB/s/dir, lat us, x=cute/nccl) ==="]
+    lines.append(
+        f"{'size/rank':>10} {'variant':>7} {'fw_ctas':>7} {'cute_bw':>8} "
+        f"{'nccl_bw':>8} {'x':>6} {'cute_us':>9} {'nccl_us':>9}"
+    )
+    for msg_bytes, vname, nb, _grid, bw, lat, nccl_bw, nccl_lat in rows:
+        if bw is None:
+            lines.append(f"{_fmt_size(msg_bytes):>10} {vname:>7} {'n/a':>7}")
+            continue
+        ratio = bw / nccl_bw if nccl_bw else 0.0
+        ctas = (nb or 0) * ws
+        lines.append(
+            f"{_fmt_size(msg_bytes):>10} {vname:>7} {ctas:>7} {bw:>8.1f} "
+            f"{nccl_bw:>8.1f} {ratio:>5.2f}x {lat or 0.0:>9.1f} {nccl_lat or 0.0:>9.1f}"
+        )
+    table = "\n".join(lines)
+    print("\n" + table, flush=True)
+    # Mirror to stderr: torchx keeps each worker's STDERR but truncates/drops STDOUT,
+    # so the report is only reliably fetchable from the MAST job's stderr log.
+    print("\n" + table, file=sys.stderr, flush=True)
+    result_file = os.environ.get("A2A_RESULT_FILE")
+    if result_file:
+        try:
+            with open(result_file, "w") as f:
+                f.write(table + "\n")
+        except OSError as e:
+            print(f"(could not write A2A_RESULT_FILE: {e})", flush=True)
+    _upload_result_to_manifold(table)
+
+
+def _upload_result_to_manifold(table: str) -> None:
+    """Best-effort upload of the result table to ``$A2A_RESULT_MANIFOLD`` (a
+    ``manifold://bucket/tree/...`` path). No-op if the env is unset; never raises."""
+    dest = os.environ.get("A2A_RESULT_MANIFOLD")
+    if not dest:
+        return
+    import shutil
+    import subprocess
+    import tempfile
+
+    # The MAST conda env has no `manifold` on PATH; the conda launcher installs the
+    # `manifold.cli:prod` fbpkg at /packages/manifold.cli/manifold for exactly this.
+    mf = "/packages/manifold.cli/manifold"
+    if not os.path.exists(mf):
+        mf = shutil.which("manifold") or "manifold"
+    local = None
+    try:
+        with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as f:
+            f.write(table + "\n")
+            local = f.name
+        out = subprocess.run(
+            [mf, "put", "--overwrite", local, dest],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if out.returncode == 0:
+            print(f"(uploaded result to {dest})", flush=True)
+        else:
+            print(
+                f"(manifold put failed rc={out.returncode}: {out.stderr})", flush=True
+            )
+    except (OSError, subprocess.SubprocessError) as e:
+        print(f"(manifold upload error: {e})", flush=True)
+    finally:
+        # delete=False above, so remove the temp file on every path (MAST would otherwise
+        # leak a /tmp/tmpXXXX.txt per invocation).
+        if local:
+            try:
+                os.remove(local)
+            except OSError:
+                pass
+
+
+def _worker(rank: int, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    device = torch.device(f"cuda:{rank}")
+    runner = _run_report if os.environ.get("A2A_CUTE_REPORT") == "1" else _run
+    ok = runner(rank, world_size, dist.group.WORLD, device)
+    dist.barrier(dist.group.WORLD)
+    dist.destroy_process_group()
+    if not ok:
+        sys.exit(1)
+
+
+def _torchrun_main() -> None:
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    device = torch.device(f"cuda:{local_rank}")
+    runner = _run_report if os.environ.get("A2A_CUTE_REPORT") == "1" else _run
+    ok = runner(rank, world_size, dist.group.WORLD, device)
+    dist.barrier(dist.group.WORLD)
+    dist.destroy_process_group()
+    if not ok:
+        sys.exit(1)
+
+
+def main() -> None:
+    import argparse
+
+    if "RANK" in os.environ and "WORLD_SIZE" in os.environ:
+        _torchrun_main()
+        return
+    p = argparse.ArgumentParser()
+    p.add_argument("--world-size", type=int, default=min(torch.cuda.device_count(), 8))
+    args = p.parse_args()
+    if args.world_size < 2:
+        print("needs >=2 GPUs")
+        return
+    mp.spawn(
+        _worker,
+        args=(args.world_size, _find_free_port()),
+        nprocs=args.world_size,
+        join=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/dsl/tests/mast_launch.py
+++ b/comms/dsl/tests/mast_launch.py
@@ -1,0 +1,614 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Unified MAST launcher for the comms/dsl CuTe benchmarks / tuner (module-agnostic).
+
+One launcher, two image-delivery paths selected by ``--delivery``:
+
+- ``--delivery fbpkg`` (canonical): submit a pre-built aarch64 GB300 ``fbpkg`` via
+  torchx ``fb.dist.hpc`` one-process-per-rank (scheduler ``mast``). Needs a full
+  ``buck2`` cross-build of the package (``--img`` required). Best for a stable,
+  reproducible perf run.
+- ``--delivery conda`` (fast iteration, default): the torchx ``mast_conda`` scheduler with a
+  :class:`~torchx.specs.Workspace` source overlay -- the remote conda env comes from a
+  pre-built conda ``fbpkg`` and the local ``fbcode/comms`` source is shipped at
+  submit-time as an ephemeral workspace fbpkg (CAF upload, no buck compile). Iterate on
+  the kernels and re-launch in seconds-to-a-minute.
+
+``--module`` picks what runs under torchrun (default the CuTe a2a benchmark; also the CuTe
+a2a tuner via ``--tune``), so this single file serves every comms/dsl MAST run.
+
+Capacity / access: ``--entitlement`` (rmAttribution, a tenant leaf that holds GPU quota) and
+``--identity`` / ``--oncall`` are caller/team-specific and have **no baked-in default** -- pass
+them as flags or via the ``$MAST_RM_ATTRIBUTION`` / ``$MAST_HPC_IDENTITY`` / ``$MAST_HPC_ONCALL``
+env vars (required for ``--submit``). ``--hw gb300_dsf`` is the sub-type MastProdCluster registers
+(the quota path). ``--flex-pool-id`` defaults to '' (the quota path); pass a pool id only if you
+have one -- flexpools are typically temporary, so none is hardcoded here.
+
+NVL co-placement: MAST has no NVLink-domain locality flag, so the trainer role overlays
+``HpcTaskGroupSpec.topologyConstraints = [{"domain": {"multiple": <nvl_hosts>}}]``.
+``multiple`` is a HOST count, so 2 GB300 hosts (8 GPUs) in one NVL72 domain is
+``--nvl-hosts 2``. A partial-host job (e.g. 2-GPU send/recv with ``--no-whole-host``)
+must NOT carry a topology constraint -- MAST rejects topology-constrained non-whole-host
+jobs.
+
+Dry-run by default (assembles + prints the MAST job spec -- and for conda, builds the
+workspace fbpkg -- but consumes NO capacity). Pass ``--submit`` to schedule.
+
+Examples::
+
+    # conda fast-iteration dry-run (validate spec + workspace build; consumes no capacity)
+    buck2 run @fbcode//mode/opt --prefer-local //comms/dsl/tests:mast_launch -- \\
+        --delivery conda --env "A2A_CAPS=32;A2A_REPORT=1" --bench-args=--nccl-only
+
+    # conda a2a autotuner (parent -> select -> cat table); supply your entitlement/identity/oncall
+    buck2 run @fbcode//mode/opt --prefer-local //comms/dsl/tests:mast_launch -- \\
+        --delivery conda --tune --bench-args="--max-sizes 2 --max-candidates 2" \\
+        --entitlement <tenant> --identity <data-project> --oncall <oncall> --submit
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import uuid
+from typing import Any
+
+import torchx.components.fb.conda as conda
+from torchx.components.fb.dist import hpc as fb_dist_hpc
+from torchx.runner import get_runner
+from torchx.specs import AppDef, CfgVal, named_resources, Workspace
+from torchx.specs.fb.named_resources import MAST_WHOLE_HOST_FEATURE
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+_MAST_TIER_MAPPING: dict[str, str] = {
+    "PROD": "mast.api.write",
+    "STAGING": "mast.api.write.staging",
+    "RC": "mast.api.write.rc",
+}
+
+# The conda workspace overlay names the ephemeral *workspace* fbpkg after role.image[0];
+# reuse the already-ACL'd benchmark package so no separate `fbpkg create` is needed.
+_DEFAULT_WS_PKG = "comms.dsl.benchmark_a2a.aarch64.gb300"
+# Pre-built GB300 (aarch64, CUDA 13.0) conda env.
+# @oss-disable[end= ]: _DEFAULT_CONDA = "xlformers_msl_rl_gb300_conda:20"
+_DEFAULT_MODULE = "comms.dsl.tests.benchmark_a2a_cute"
+# Source dirs overlaid into the ephemeral workspace, as ``relpath:remote`` (relpath is
+# under fbcode). The benchmark only needs comms/dsl; the tuner (comms.dsl.cute.a2a.tune)
+# also needs the comm_tuning engine, which lives at comms/tuning/comm_tuning and must map
+# to the top-level import name ``comm_tuning``.
+_DEFAULT_OVERLAYS = ["comms/dsl:comms/dsl"]
+_TUNE_OVERLAYS = ["comms/dsl:comms/dsl", "comms/tuning/comm_tuning:comm_tuning"]
+_TUNE_MODULE = "comms.dsl.cute.a2a.tune"
+
+
+def _parse_envs(env_str: str | None) -> dict[str, str]:
+    """Parse a ``K=V;K2=V2`` string into a dict (forwarded to every rank)."""
+    envs: dict[str, str] = {}
+    if not env_str:
+        return envs
+    for raw in env_str.split(";"):
+        entry = raw.strip()
+        if not entry:
+            continue
+        if "=" not in entry:
+            logger.warning("skipping malformed --env entry (no '='): %r", entry)
+            continue
+        key, _, val = entry.partition("=")
+        envs[key] = val
+    return envs
+
+
+def _job_name(args: argparse.Namespace) -> str:
+    if args.job_name:
+        return args.job_name
+    tag = "conda-gb300" if args.delivery == "conda" else "gb300"
+    return f"a2a-{tag}-n{args.nnode}x{args.ppn}-{uuid.uuid4().hex[0:6]}"
+
+
+def _locality(args: argparse.Namespace) -> list[str] | None:
+    """Region localityConstraints, or None. A flexpool already pins placement to its hosts,
+    so a region constraint is dropped when a flexpool is set (avoids a region/pool clash)."""
+    if args.flex_pool_id:
+        return None
+    return ["region", args.region] if args.region else None
+
+
+def _fbcode_root() -> str:
+    """Absolute path to this checkout's SOURCE ``fbcode`` dir (works in any worktree).
+
+    The workspace overlay does a literal ``shutil.copytree`` of the project dir, so it
+    MUST point at the source tree -- NOT the ``buck-out`` link-tree where ``__file__``
+    lives when run via ``buck2 run``. ``buck2 run`` preserves the caller's cwd, so derive
+    the root from cwd (or the buck-provided project root). Override with ``--src-fbcode``.
+    """
+    candidates = [os.environ.get("BUCK_PROJECT_ROOT"), os.getcwd()]
+    for base in candidates:
+        if not base:
+            continue
+        p = os.path.abspath(base)
+        # cwd may be fbcode itself, a subdir of it, or the repo root (has fbcode/).
+        while True:
+            if os.path.basename(p) == "fbcode" and os.path.isdir(
+                os.path.join(p, "comms")
+            ):
+                return p
+            if os.path.isdir(os.path.join(p, "fbcode", "comms")):
+                return os.path.join(p, "fbcode")
+            parent = os.path.dirname(p)
+            if parent == p:
+                break
+            p = parent
+    raise RuntimeError(
+        "could not locate source fbcode root from cwd; pass --src-fbcode <path>"
+    )
+
+
+def _build_fbpkg(args: argparse.Namespace) -> tuple[AppDef, dict[str, CfgVal]]:
+    """Assemble the torchx AppDef + MAST cfg for the pre-built fbpkg delivery path."""
+    if not args.img:
+        raise ValueError("--delivery fbpkg requires --img (the benchmark fbpkg)")
+    tier = _MAST_TIER_MAPPING.get(args.tier, args.tier)
+    if not tier.startswith("mast."):
+        raise ValueError(f"unrecognized MAST tier: {args.tier}")
+
+    rsrc = named_resources[args.hw]
+    env = _parse_envs(args.env)
+    env.setdefault("LOGLEVEL", "INFO")
+    # The fbpkg mount is read-only on the host; the CuTe/Triton JIT must write its
+    # compiled artifacts to a writable cache dir (default ~/.triton is not writable).
+    env.setdefault("TRITON_CACHE_DIR", "/tmp/triton_cache")
+    env["PPN"] = str(args.ppn)
+    env["LOCAL_SIZE"] = str(rsrc.gpu)
+
+    bench_args = args.bench_args.split() if args.bench_args else []
+    job_name = _job_name(args)
+    module = args.module
+
+    app = fb_dist_hpc(
+        *bench_args,
+        m=module,
+        img=args.img,
+        name=job_name,
+        h=args.hw,
+        j=f"{args.nnode}x{args.ppn}",
+        env=env,
+        max_retries=args.max_retries,
+        metadata={
+            "rmAttribution": args.entitlement,
+            "hpcIdentity": args.dp,
+            "hpcClusterUuid": args.cluster,
+            "hpcJobOncall": args.oncall,
+            "smcTier": tier,
+        },
+    )
+
+    # NVL co-placement: pin all hosts into one NVLink (NVL72) domain. multiple is a HOST
+    # count (GB300 = 4 GPU/host), so 2 hosts = 8 GPUs in one domain.
+    trainer = app.roles[0]  # pyre-ignore[16]
+    tg_spec: dict[str, Any] = {
+        "topologyConstraints": [{"domain": {"multiple": args.nvl_hosts}}],
+    }
+    if args.flex_pool_id:
+        tg_spec["flexPoolId"] = args.flex_pool_id
+    trainer.metadata["mast"] = {"HpcTaskGroupSpec": tg_spec}
+    # Domain/topology constraints require whole-host allocation; ppn == GPUs/host
+    # already selects the full resource, but set it explicitly for clarity.
+    trainer.resource.capabilities[MAST_WHOLE_HOST_FEATURE] = True
+
+    cfg: dict[str, CfgVal] = {
+        "localityConstraints": _locality(args),
+        "rmAttribution": args.entitlement,
+        "hpcIdentity": args.dp,
+        "hpcClusterUuid": args.cluster,
+        "hpcJobOncall": args.oncall,
+        "smcTier": tier,
+        "runningTimeoutSec": args.timeout,
+        "useStrictName": True,
+        "enableGracefulPreemption": True,
+        "runtimeAppMetadataJson": json.dumps(app.metadata),  # pyre-ignore[16]
+    }
+    # A flexpool pins placement to its own hosts, so no region locality is set; tell the
+    # scheduler not to require a single region (it otherwise rejects the no-region spec).
+    if args.flex_pool_id:
+        cfg["forceSingleRegion"] = False
+    return app, cfg
+
+
+def _build_conda(  # noqa: C901 - flat top-to-bottom AppDef assembler; splitting would scatter the spec
+    args: argparse.Namespace,
+) -> tuple[AppDef, dict[str, CfgVal]]:
+    """Assemble the torchx AppDef (conda.torchrun + workspace overlay) + mast_conda cfg."""
+    tier = _MAST_TIER_MAPPING.get(args.tier, args.tier)
+    if not tier.startswith("mast."):
+        raise ValueError(f"unrecognized MAST tier: {args.tier}")
+
+    env = _parse_envs(args.env)
+    env.setdefault("LOGLEVEL", "INFO")
+    # JIT must write its compiled artifacts to a writable dir (conda fbpkg is read-only).
+    env.setdefault("TRITON_CACHE_DIR", "/tmp/triton_cache")
+    # The conda_on_mast default mounts an OILFS warm-storage dir; the a2a benchmark needs
+    # no warm storage, and our region has no WS cluster mapping, so the scheduler rejects
+    # the spec ("WarmStorageSpec ... missing clusters field"). Disable it
+    # (mast_data_sources._get_warm_storage_spec returns None when DISABLE_OILFS == "1").
+    env.setdefault("DISABLE_OILFS", "1")
+    # The conda tuner re-execs candidate children as `python <tune.py> --mode child` (a
+    # SCRIPT, not `-m`), so sys.path[0] is the script's dir and the workspace root is NOT on
+    # the path. activate_conda cd's into the workspace root before torchrun, so the child
+    # inherits cwd=workspace-root; PYTHONPATH="." puts that root on the child's path.
+    # Harmless for the benchmark path (parent runs via `-m`).
+    env.setdefault("PYTHONPATH", ".")
+    env["PPN"] = str(args.ppn)
+
+    bench_args = args.bench_args.split() if args.bench_args else []
+    job_name = _job_name(args)
+    module = args.module
+
+    # For --tune, run the WHOLE pipeline in one job: parent (torchrun, multi-rank) ->
+    # select (single proc, picks winners) -> cat the generated table to stdout.
+    if args.tune:
+        # The tuner entrypoint requires an explicit --mode; the multi-rank torchrun step is
+        # the parent (it spawns per-candidate children as `--mode child`), and the select
+        # step below runs `--mode select`.
+        if "--mode" not in bench_args:
+            bench_args = ["--mode", "parent", *bench_args]
+        if "--output-dir" not in bench_args:
+            bench_args = [*bench_args, "--output-dir", args.tune_output_dir]
+
+    # torchrun runs `python -m <module> <prog_args>` one proc/rank.
+    torchrun_args = [
+        "--tee",
+        "3",
+        "--nnodes",
+        str(args.nnode),
+        "--nproc-per-node",
+        str(args.ppn),
+        "-m",
+        module,
+        *bench_args,
+    ]
+
+    job_spec = conda.torchrun(
+        *torchrun_args,
+        name=job_name,
+        h=args.hw,
+        env=env,
+        run_as_root=True,
+        torchrun_fbpkg_id="torchx_torchrun:stable",
+        conda_mast_core_fbpkg_id="conda_mast_core:stable",
+    )
+
+    role = job_spec.roles[0]  # pyre-ignore[16]
+
+    # --tune: replace the plain torchrun entrypoint with a parent -> select -> cat-table
+    # compound so one job produces AND surfaces the generated tuned table.
+    if args.tune:
+        od = args.tune_output_dir
+        gen_file = "a2a_tuned_configs.py"
+        # Reuse role.args (NOT the raw torchrun_args): conda.torchrun._override_rdzv already
+        # augmented role.args with the multi-host rendezvous flags. Swap the ${app_id} macro
+        # (unsubstituted in this raw shell string) for the concrete job name.
+        torchrun_cmd = "${torchx_torchrun_root}/torchrun " + " ".join(
+            role.args
+        ).replace("${app_id}", job_name)
+        select_cmd = (
+            f"python -m {module} --mode select --input-dir {od} --output-dir {od}"
+        )
+        cat_cmd = (
+            f"echo '===== best_configs.json =====' && cat {od}/best_configs.json && "
+            f"echo '===== sample result record =====' && "
+            f"(head -2 {od}/results/rank_000.jsonl 2>/dev/null || echo '(no sample record)') && "
+            f"echo '===== GENERATED TUNED TABLE ({od}/generated/{gen_file}) =====' && "
+            f"cat {od}/generated/{gen_file}"
+        )
+        role.entrypoint = " && ".join([torchrun_cmd, select_cmd, cat_cmd])
+        role.args = []
+
+    # Leave role.image as conda.torchrun produced it (torchx_torchrun + conda_mast_core).
+    # The conda workspace scheduler ADDS the conda env (conda_fbpkg_id) and the freshly
+    # built source-overlay (workspace_fbpkg_name) to the image itself via _get_image. Do
+    # NOT also put them in role.image ("Can't have 2 versions of the same package!").
+
+    # Source overlay: ship only the needed source dirs (fast CAF upload). `comms` is a
+    # PEP-420 namespace package, so mapping to "comms/dsl" keeps `import comms.dsl.*`
+    # working. Each --overlay is `relpath:remote` (relpath under fbcode).
+    fbcode_root = args.src_fbcode or _fbcode_root()
+    projects: dict[str, str] = {}
+    for entry in args.overlay:
+        relpath, _, remote = entry.partition(":")
+        projects[os.path.join(fbcode_root, relpath)] = remote or relpath
+    role.workspace = Workspace(projects=projects)
+
+    # NVL co-placement applies only to whole-host (multi-host) jobs like a2a. A partial-host
+    # 2-GPU send/recv (--no-whole-host) must NOT carry a topology constraint.
+    tg_spec: dict[str, Any] = {}
+    if args.whole_host:
+        tg_spec["topologyConstraints"] = [{"domain": {"multiple": args.nvl_hosts}}]
+    if args.flex_pool_id:
+        tg_spec["flexPoolId"] = args.flex_pool_id
+    role.metadata["mast"] = {"HpcTaskGroupSpec": tg_spec}
+    # a2a wants the whole GB300 host; a 2-rank send/recv job (ppn=2) must NOT request
+    # whole-host -- MAST rejects "< 4 GPUs AND whole host" (INVALID_JOB_DEFINITION).
+    if args.whole_host:
+        role.resource.capabilities[MAST_WHOLE_HOST_FEATURE] = True
+
+    cfg: dict[str, CfgVal] = {
+        "localityConstraints": _locality(args),
+        "rmAttribution": args.entitlement,
+        "hpcIdentity": args.dp,
+        "hpcClusterUuid": args.cluster,
+        "hpcJobOncall": args.oncall,
+        "smcTier": tier,
+        "runningTimeoutSec": args.timeout,
+        "useStrictName": True,
+        "enableGracefulPreemption": True,
+        # --- conda workspace scheduler knobs (mirror mccl_e2e/.torchxconfig) ---
+        "conda_fbpkg_id": args.conda,
+        "conda_path_in_fbpkg": "conda",
+        "workspace_fbpkg_name": args.ws_pkg,
+        "activate_conda": True,
+        "git": False,
+        "fbpkg_ids": [],
+    }
+    # A flexpool pins placement to its own hosts, so no region locality is set; tell the
+    # scheduler not to require a single region (it otherwise rejects the no-region spec as
+    # region-hop-unsafe).
+    if args.flex_pool_id:
+        cfg["forceSingleRegion"] = False
+    return job_spec, cfg
+
+
+def build_app_and_cfg(
+    args: argparse.Namespace,
+) -> tuple[AppDef, dict[str, CfgVal], str, str]:
+    """Dispatch on ``--delivery``; return (app, cfg, scheduler, resolved_module)."""
+    if args.delivery == "fbpkg":
+        app, cfg = _build_fbpkg(args)
+        return app, cfg, "mast", args.module
+    app, cfg = _build_conda(args)
+    return app, cfg, "mast_conda", args.module
+
+
+def _print_spec_summary(args: argparse.Namespace, app: object, module: str) -> None:
+    """Human-readable summary of the assembled job (shown even in dry-run)."""
+    role = app.roles[0]  # pyre-ignore[16]
+    tg = role.metadata["mast"]["HpcTaskGroupSpec"]
+    print("=" * 80)
+    print(f"MAST job spec (assembled, delivery={args.delivery}):")
+    print(f"  name             = {app.name}")  # pyre-ignore[16]
+    print(f"  module           = {module}")
+    if args.delivery == "fbpkg":
+        print(f"  img              = {args.img}")
+    else:
+        print(f"  overlay          = {args.overlay}")
+        print(f"  role image       = {role.image}")
+        print(f"  conda fbpkg      = {args.conda}")
+        print(f"  workspace fbpkg  = {args.ws_pkg} (overlay: {role.workspace})")
+        print(f"  entrypoint       = {role.entrypoint}")
+    print(
+        f"  hw / j           = {args.hw} / {args.nnode}x{args.ppn} "
+        f"(world_size={args.nnode * args.ppn})"
+    )
+    print(f"  cluster          = {args.cluster}")
+    print(f"  region           = {args.region}")
+    print(f"  entitlement      = {args.entitlement}")
+    print(f"  hpcIdentity      = {args.dp}")
+    print(f"  oncall           = {args.oncall}")
+    print(f"  topologyConstraints = {tg.get('topologyConstraints')}")
+    print(f"  flexPoolId       = {tg.get('flexPoolId')}")
+    print(f"  env              = {args.env}")
+    print(f"  bench_args       = {args.bench_args}")
+    print("=" * 80)
+
+
+def launch(args: argparse.Namespace) -> None:
+    # The access knobs are caller-specific (no baked default), so a real submit needs them; a
+    # dry-run does not (it only assembles + prints the spec). Fail fast with a clear message.
+    if args.submit:
+        missing = [
+            flag
+            for flag, val in (
+                ("--entitlement ($MAST_RM_ATTRIBUTION)", args.entitlement),
+                ("--identity ($MAST_HPC_IDENTITY)", args.dp),
+                ("--oncall ($MAST_HPC_ONCALL)", args.oncall),
+            )
+            if not val
+        ]
+        if missing:
+            raise SystemExit(
+                "--submit requires caller-specific access knobs with no default: "
+                + ", ".join(missing)
+                + ". Pass the flag(s) or export the env var(s)."
+            )
+    app, cfg, scheduler, module = build_app_and_cfg(args)
+    _print_spec_summary(args, app, module)
+    runner = get_runner()
+    try:
+        dryrun_info = runner.dryrun(app=app, scheduler=scheduler, cfg=cfg)
+    except ValueError as e:
+        # fbpkg dry-run: an unpublished fbpkg is expected (the spec itself is valid);
+        # surface it instead of crashing so the summary above is still useful.
+        if args.delivery == "fbpkg" and not args.submit and "do not exist" in str(e):
+            print(f"DRY-RUN: spec validated up to packaging; fbpkg not published: {e}")
+            return
+        raise
+    print(f"MAST dry-run (validated job request, scheduler={scheduler}):")
+    print(dryrun_info)
+    print("=" * 80)
+    if not args.submit:
+        print("DRY-RUN ONLY (pass --submit to schedule). No capacity consumed.")
+        return
+    app_handle = runner.schedule(dryrun_info)
+    status = runner.status(app_handle)
+    assert status, f"failed to get job status for {app_handle}"
+    print(f"SUBMITTED: {app_handle}")
+    print(f"UI: {status.ui_url}")
+
+
+def _init_argparse() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Unified MAST launcher for comms/dsl CuTe benchmarks / tuner (GB300)"
+    )
+    p.add_argument(
+        "--delivery",
+        default="conda",
+        choices=["fbpkg", "conda"],
+        help="image delivery: 'fbpkg' (pre-built package, needs --img) or 'conda' "
+        "(fast-iteration conda env + workspace source overlay). Default: conda.",
+    )
+    p.add_argument("--nnode", type=int, default=2, help="number of hosts")
+    p.add_argument(
+        "--ppn",
+        type=int,
+        default=4,
+        choices=[1, 2, 4, 8],
+        help="processes/GPUs per host (GB300 = 4)",
+    )
+    p.add_argument(
+        "--nvl-hosts",
+        type=int,
+        default=2,
+        help="hosts that must share one NVLink (NVL72) domain "
+        "(topologyConstraints domain.multiple; HOST count, not GPU)",
+    )
+    p.add_argument(
+        "--whole-host",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="request the whole GB300 host (4 GPU; the a2a default). Pass "
+        "--no-whole-host for a partial-host job (e.g. 2-GPU send/recv with "
+        "--ppn 2). Honored on the conda path; the fbpkg path is always whole-host.",
+    )
+    p.add_argument(
+        "--hw",
+        default="gb300_dsf",
+        help="torchx named resource. `gb300_dsf` is the sub-type MastProdCluster registers "
+        "(the quota path). With --flex-pool-id it is also the type to request even though the "
+        "flexpool hosts are physically NSF_LP: the flexPoolId routes placement to the pool, "
+        "while the cluster only schedules the registered sub-type (a bare `gb300` = NSF_LP "
+        "request is rejected as an unknown sub-type).",
+    )
+    p.add_argument("--cluster", default="MastProdCluster", help="hpcClusterUuid")
+    p.add_argument(
+        "--region",
+        default="uco",
+        help="region for localityConstraints (ignored when --flex-pool-id is set)",
+    )
+    # Caller/team-specific access knobs: NO hardcoded default (this launcher lands for everyone).
+    # Supply via flag or the $MAST_* env var; required for --submit (validated in launch()).
+    p.add_argument(
+        "--dp",
+        "--identity",
+        dest="dp",
+        default=os.environ.get("MAST_HPC_IDENTITY"),
+        help="hpcIdentity (data project / ACL). No default; flag or $MAST_HPC_IDENTITY.",
+    )
+    p.add_argument(
+        "--entitlement",
+        "--rm-attribution",
+        dest="entitlement",
+        default=os.environ.get("MAST_RM_ATTRIBUTION"),
+        help="rmAttribution (entitlement = tenant leaf holding GPU quota). No default; flag "
+        "or $MAST_RM_ATTRIBUTION.",
+    )
+    p.add_argument(
+        "--oncall",
+        default=os.environ.get("MAST_HPC_ONCALL"),
+        help="hpcJobOncall. No default; flag or $MAST_HPC_ONCALL.",
+    )
+    p.add_argument(
+        "--tier",
+        default="PROD",
+        choices=["PROD", "STAGING", "RC"],
+        help="MAST environment",
+    )
+    p.add_argument("--timeout", type=int, default=3600, help="runningTimeoutSec")
+    p.add_argument("--max-retries", type=int, default=1, help="MAST retries (fbpkg)")
+    p.add_argument(
+        "--flex-pool-id",
+        default="",
+        help="optional flexpool id for placement; default '' uses the quota path "
+        "(--entitlement). Pass a pool id only if you have one (flexpools are typically temporary).",
+    )
+    p.add_argument(
+        "--module",
+        default=_DEFAULT_MODULE,
+        help=f"python -m module to run under torchrun (default: {_DEFAULT_MODULE})",
+    )
+    # --- fbpkg delivery ---
+    p.add_argument(
+        "--img",
+        default=None,
+        help="benchmark fbpkg (REQUIRED for --delivery fbpkg), e.g. "
+        "comms.dsl.benchmark_a2a.aarch64.gb300:<ver>",
+    )
+    # --- conda delivery ---
+    p.add_argument(
+        "--conda",
+        default=_DEFAULT_CONDA,
+        help=f"conda env fbpkg (conda delivery; default: {_DEFAULT_CONDA})",
+    )
+    p.add_argument(
+        "--ws-pkg",
+        default=_DEFAULT_WS_PKG,
+        help="fbpkg NAME used for the ephemeral source-overlay workspace build "
+        f"(must be ACL-writable; default: {_DEFAULT_WS_PKG})",
+    )
+    p.add_argument(
+        "--overlay",
+        action="append",
+        default=None,
+        help="source dir to overlay as 'relpath:remote' (relpath under fbcode); "
+        f"repeatable (conda delivery). Default: {_DEFAULT_OVERLAYS}.",
+    )
+    p.add_argument(
+        "--tune",
+        action="store_true",
+        default=False,
+        help="convenience (conda): set --module to the CuTe a2a tuner and overlay "
+        "comm_tuning too, and run parent -> select -> cat-table in one job",
+    )
+    p.add_argument(
+        "--tune-output-dir",
+        default="/tmp/a2a_tune",
+        help="remote output dir for the --tune pipeline (parent results + select table)",
+    )
+    p.add_argument(
+        "--src-fbcode",
+        default=None,
+        help="source fbcode dir to overlay comms/ from (default: auto-detect from cwd)",
+    )
+    p.add_argument("--job-name", default=None, help="override the generated job name")
+    p.add_argument("--env", default=None, help="extra env as 'K=V;K2=V2' (per rank)")
+    p.add_argument(
+        "--bench-args",
+        default=None,
+        help="args forwarded to the module (space-separated), e.g. '--nccl-only'",
+    )
+    p.add_argument(
+        "--submit",
+        action="store_true",
+        default=False,
+        help="actually schedule the job (default: dry-run only, no capacity used)",
+    )
+    return p
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, force=True)
+    args = _init_argparse().parse_args()
+    # --tune is a convenience preset (conda): point at the CuTe tuner module + add the
+    # comm_tuning overlay (unless the user overrode --module/--overlay explicitly).
+    if args.tune and args.module == _DEFAULT_MODULE:
+        args.module = _TUNE_MODULE
+    if args.overlay is None:
+        args.overlay = _TUNE_OVERLAYS if args.tune else _DEFAULT_OVERLAYS
+    launch(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/dsl/tests/test_a2a_base.py
+++ b/comms/dsl/tests/test_a2a_base.py
@@ -1,0 +1,31 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+import unittest
+
+from comms.dsl.a2a_base import BaseA2AAdapter
+from comms.dsl.tuning_base import BaseInputSpec
+
+
+class TestA2ABase(unittest.TestCase):
+    def test_run_baseline_rejects_unknown_baseline(self):
+        adapter = object.__new__(BaseA2AAdapter)
+        with self.assertRaises(ValueError):
+            adapter.run_baseline(inputs=None, baseline="gloo", group=None)
+
+    def test_spec_from_json_rejects_unknown_spec_type(self):
+        adapter = object.__new__(BaseA2AAdapter)
+        adapter.spec_tag = "A2AInputSpec"
+        with self.assertRaises(ValueError):
+            adapter.spec_from_json("WrongSpec", {})
+
+    def test_enumerate_input_specs_rejects_non_int_non_spec_shape(self):
+        # A shapes entry that is neither a spec nor an int (per-rank bytes) must raise a
+        # clear TypeError, not an opaque `nbytes // elem` failure deep in _spec_from_bytes.
+        adapter = object.__new__(BaseA2AAdapter)
+        adapter.spec_cls = BaseInputSpec
+        adapter._shapes = [object()]
+        adapter._max_sizes = 0
+        with self.assertRaises(TypeError):
+            adapter.enumerate_input_specs(world_size=8)

--- a/comms/dsl/tests/test_a2a_entry_contract.py
+++ b/comms/dsl/tests/test_a2a_entry_contract.py
@@ -1,0 +1,41 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""The one machine-checked backend contract: the public a2a entry signatures.
+
+The ``comms.dsl.collectives`` facade forwards its keyword arguments uniformly to whichever
+backend ``backend=`` selects, so a backend entry must accept every kwarg the facade forwards
+-- otherwise ``all_to_all(backend=..., that_param=...)`` would break silently with no other
+test catching it. Today CuTe is the only registered backend; when a second DSL (Triton) is
+re-registered this test grows a cross-backend parameter-name parity assertion again (the
+entries' parameter names must match so the facade can forward uniformly).
+
+Needs the cutlass DSL to import the CuTe substrate, so it runs on a GPU host.
+"""
+
+import importlib
+import inspect
+import unittest
+
+_BACKENDS = ("cute",)
+# Public a2a entries the facade forwards uniformly, and the kwargs it forwards to each.
+_A2A_ENTRY_KWARGS = {
+    "all_to_all": ("produce", "consume", "rows", "config", "variant"),
+    "all_to_all_zc": ("primitive", "config"),
+}
+
+
+class A2AEntryContractTest(unittest.TestCase):
+    def test_backend_entries_accept_forwarded_kwargs(self) -> None:
+        # Every kwarg the facade forwards must be a parameter of each backend's entry.
+        for b in _BACKENDS:
+            mod = importlib.import_module(f"comms.dsl.{b}.a2a.host")
+            for entry, kwargs in _A2A_ENTRY_KWARGS.items():
+                params = tuple(inspect.signature(getattr(mod, entry)).parameters)
+                for kw in kwargs:
+                    self.assertIn(
+                        kw,
+                        params,
+                        f"{b}.{entry} is missing facade-forwarded kwarg {kw!r}: {params}",
+                    )

--- a/comms/dsl/tests/test_cute_a2a_adapter.py
+++ b/comms/dsl/tests/test_cute_a2a_adapter.py
@@ -1,0 +1,71 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# GPU adapter test: imports the untyped cutlass DSL and constructs adapters over untyped cute
+# handles that pyre cannot model, so strict typing adds no value here.
+
+"""GPU tests for the comms/dsl CuTe all_to_all tuning adapter + backend contract.
+
+The CuTe twin of the GPU half of ``test_a2a_adapter``. The CuTe adapter imports the cutlass
+DSL, so the pure-CPU adapter surface has no CuTe analogue; the cutlass-free config/key/lookup
+layer is covered by ``test_cute_tuned_roundtrip``. This suite covers the parts that need a GPU:
+
+* **Adapter round trip** (2-rank GPU) -- ``make_inputs`` / ``run_candidate`` / ``run_baseline``
+  / ``check_correctness`` plus the shared-key rule (adapter key == runtime
+  ``make_a2a_key``), proving a tuned CuTe config drives the CuTe kernel correctly.
+
+The fused CuTe staging schedules' produce/consume hook + ``rows>0`` transpose support -- and the
+TMA / zero-copy paths that reject those transforms -- are covered bit-exact by
+``test_a2a_cute_variants``.
+
+Gold is ``dist.all_to_all_single``. Skipped unless GPUs are present. The cutlass-importing
+adapter / host imports are deferred into the test bodies so collection stays clean without a
+GPU.
+"""
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+# cutlass-free; safe to import at module scope (see test_cute_tuned_roundtrip).
+from comms.dsl.cute.a2a.tuning import make_a2a_key
+from comms.dsl.tests._dist_harness import _find_free_port
+
+
+def _gpu_worker(rank: int, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    device = torch.device(f"cuda:{rank}")
+
+    from comms.dsl.cute.a2a.adapter import CuteA2AInputSpec, CuteA2ATuningAdapter
+
+    a = CuteA2ATuningAdapter()
+    spec = CuteA2AInputSpec(numel=8192, dtype=torch.bfloat16)
+    inputs = a.make_inputs(spec, rank=rank, world_size=world_size, device=device)
+
+    # shared-key rule: the adapter key must equal the runtime key.
+    rt_key = make_a2a_key(inputs.input, inputs.transport, rows=spec.rows)
+    assert a.make_key(spec, world_size) == rt_key, "adapter/runtime key mismatch"
+
+    group = dist.group.WORLD
+    assert group is not None, "distributed not initialized"
+    cfg = a.enumerate_candidate_configs(spec, rt_key)[0]
+    cand = a.run_candidate(inputs, cfg, group)
+    ref = a.run_baseline(inputs, "nccl", group)
+    torch.cuda.synchronize()
+    a.check_correctness(cand, ref)
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+class A2ACuteAdapterGpuTest(unittest.TestCase):
+    @unittest.skipUnless(torch.cuda.device_count() >= 2, "needs >=2 GPUs")
+    def test_adapter_roundtrip(self) -> None:
+        ws = min(4, torch.cuda.device_count())
+        mp.spawn(_gpu_worker, args=(ws, _find_free_port()), nprocs=ws, join=True)

--- a/comms/dsl/tests/test_cute_a2a_correctness.py
+++ b/comms/dsl/tests/test_cute_a2a_correctness.py
@@ -1,0 +1,108 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# Distributed correctness test: the worker runs under mp.spawn and touches untyped cutlass /
+# symmetric-memory symbols that pyre cannot model, so strict typing adds no value here.
+
+"""Correctness test for the fused CuTe all_to_all (vs dist.all_to_all_single).
+
+Bit-exact gold check across a couple of sizes + block counts, eager and under
+CUDA-graph replay (the persistent-counter graph-safety contract). Skipped unless
+>=2 GPUs are present.
+"""
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from comms.dsl.tests._dist_harness import _find_free_port, _golden, _make_input
+
+
+def _worker(rank: int, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    device = torch.device(f"cuda:{rank}")
+    group = dist.group.WORLD
+    assert group is not None
+
+    from comms.dsl import nvl_rendezvous
+    from comms.dsl.cute.a2a.host import all_to_all
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+    ok = True
+    # Adaptive (num_threads, vec) covers any chunk: tiny (chunk=2 -> scalar-ish),
+    # odd/non-power-of-2 (chunk=100 -> vec4), and large vectorized chunks.
+    for numel, nb in [
+        (world_size * 2, 1),
+        (world_size * 100, 1),
+        (world_size * 2048, 2),
+        (world_size * 16384, 4),
+        # Multi-slot pipeline coverage (chunk >= _MIN_PIPELINE_CHUNK_BYTES so
+        # _pick_slots returns num_slots > 1): exercises the credit-ring send/drain
+        # overlap -- the interleaved _recv_slot(s-1) and the deep (8-slot) path that
+        # the small sizes above (single-shot, num_slots=1) never reach.
+        (world_size * 2 * 1024 * 1024, 4),  # 8MB fp32 chunk -> ~4 slots
+        (world_size * 16 * 1024 * 1024, 4),  # 64MB fp32 chunk -> ~8 slots (deep)
+    ]:
+        chunk = numel // world_size
+        t = nvl_rendezvous(group, device, per_peer_bytes=chunk * 4)
+        inp = _make_input(rank, numel, device)
+        gold = _golden(group, inp)
+        out = torch.empty_like(inp)
+
+        all_to_all(t, out, inp, config=CuteA2AConfig(num_blocks=nb))
+        torch.cuda.synchronize(device)
+        eager_ok = torch.equal(out, gold)
+
+        # Graph replay with distinct data (persistent-counter graph safety).
+        buf = inp.clone()
+
+        def fn(out=out, buf=buf, t=t, nb=nb):
+            all_to_all(t, out, buf, config=CuteA2AConfig(num_blocks=nb))
+
+        fn()
+        torch.cuda.synchronize(device)
+        dist.barrier(group)
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            fn()
+        graph_ok = True
+        for i in range(3):
+            inp2 = _make_input(rank + 11 * (i + 1), numel, device)
+            buf.copy_(inp2)
+            out.zero_()
+            g.replay()
+            torch.cuda.synchronize(device)
+            graph_ok = graph_ok and torch.equal(out, _golden(group, inp2))
+        ok = ok and eager_ok and graph_ok
+        if rank == 0:
+            print(
+                f"  numel={numel} nb={nb}: eager={'ok' if eager_ok else 'FAIL'} "
+                f"graph={'ok' if graph_ok else 'FAIL'}",
+                flush=True,
+            )
+        dist.barrier(group)
+
+    status = torch.tensor([1 if ok else 0], dtype=torch.int32, device=device)
+    dist.all_reduce(status, op=dist.ReduceOp.MIN, group=group)
+    dist.destroy_process_group()
+    if not bool(status.item()):
+        raise RuntimeError(f"rank {rank}: cute a2a correctness failed")
+
+
+class A2ACuteTest(unittest.TestCase):
+    def test_cute_a2a(self) -> None:
+        if torch.cuda.device_count() < 2:
+            self.skipTest("needs >=2 GPUs")
+        ws = min(torch.cuda.device_count(), 4)
+        # mp.spawn(join=True) re-raises any worker's RuntimeError (the _worker correctness gate)
+        # into this process. The success-flag assertion makes the pass condition explicit: it is
+        # only reached (and only True) when every rank returned without raising.
+        all_ranks_passed = False
+        mp.spawn(_worker, args=(ws, _find_free_port()), nprocs=ws, join=True)
+        all_ranks_passed = True
+        self.assertTrue(all_ranks_passed, "a rank failed the cute a2a correctness gate")

--- a/comms/dsl/tests/test_cute_a2a_robust.py
+++ b/comms/dsl/tests/test_cute_a2a_robust.py
@@ -1,0 +1,237 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# Distributed test: runs under mp.spawn and touches untyped cutlass / symmetric-memory symbols
+# that pyre cannot model, so strict typing adds no value here.
+
+"""Race / corruption robustness tests for the CuTe-DSL all_to_all.
+
+The CuTe twin of the robustness half of ``test_a2a_robust.py`` (Triton). The CuTe kernel
+drives the transport's signal pad with the same per-(peer, block) TAIL protocol, so the same
+robustness bar applies:
+
+* **Concurrent transports** -- two independent transports interleaved on the same ranks must
+  not cross-talk; each keeps its own staging buffer + signal pad + step counters.
+* **Sustained graph replay** -- CUDA-graph replay must stay bit-exact under sustained reuse
+  with changing data (the persistent monotonic counters must never read a stale slot).
+* **Geometry guard** -- switching a geometry field (``num_blocks``) on a reused transport
+  must FIRE the runtime guard, exercised here through the zero-copy ``all_to_all_zc`` direct
+  entry (the CuTe twin of ``test_a2a_robust.py``'s ``zc_geometry_switch_guard``).
+
+(The hang watchdog is exercised in ``test_a2a_watchdog``, which covers both backends through
+the DSL-agnostic ``watch`` API.)
+
+Dual execution model so the same suite runs locally and on MAST GB300:
+
+* Locally / ``buck test``: the unittest entry point ``mp.spawn`` the ranks.
+* On GB300 2x4 via the conda launcher (``a2a_mast_launch_conda --module
+  comms.dsl.tests.test_a2a_cute_production``): ``torchrun`` runs one process per rank across
+  the two hosts and ``_torchrun_main`` drives the cases over the launcher-provided group.
+
+Gold is ``dist.all_to_all_single``. Skipped unless >=2 GPUs are present.
+"""
+
+import os
+import sys
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from comms.dsl.tests._dist_harness import (
+    _find_free_port,
+    _golden,
+    _make_input,
+    _rendezvous,
+    _report,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Race / corruption + observability cases (non-destructive; run together)
+# --------------------------------------------------------------------------- #
+
+
+def _case_concurrent_transports(group, rank, ws, device) -> bool:
+    """Two independent CuTe transports interleaved on the same ranks must not
+    cross-talk -- each keeps its own staging buffer + signal pad + step counters,
+    so interleaving their collectives stays bit-exact."""
+    from comms.dsl.cute.a2a.host import all_to_all
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+    numel = ws * 8192
+    chunk = numel // ws
+    t1 = _rendezvous(group, device, chunk)
+    t2 = _rendezvous(group, device, chunk)
+    inp = _make_input(rank, numel, device)
+    gold = _golden(group, inp)
+    o1 = torch.empty_like(inp)
+    o2 = torch.empty_like(inp)
+    all_to_all(t1, o1, inp, config=CuteA2AConfig(num_blocks=2))
+    all_to_all(t2, o2, inp, config=CuteA2AConfig(num_blocks=2))
+    all_to_all(t1, o1, inp, config=CuteA2AConfig(num_blocks=2))
+    all_to_all(t2, o2, inp, config=CuteA2AConfig(num_blocks=2))
+    torch.cuda.synchronize(device)
+    ok = torch.equal(o1, gold) and torch.equal(o2, gold)
+    dist.barrier(group)
+    return _report("concurrent_transports", ok, device, group, rank)
+
+
+def _case_graph_replay_stress(group, rank, ws, device) -> bool:
+    """Sustained CUDA-graph replay with changing data must stay bit-exact -- the
+    persistent monotonic step counters must never read a stale signal slot across
+    many replays (the production inference pattern)."""
+    from comms.dsl.cute.a2a.host import all_to_all
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+    numel = ws * 8192
+    chunk = numel // ws
+    n_iters = 20
+    t = _rendezvous(group, device, chunk)
+    inps = [_make_input(rank + 7 * i, numel, device) for i in range(n_iters)]
+    golds = [_golden(group, x) for x in inps]
+    buf = inps[0].clone()
+    out = torch.empty_like(buf)
+
+    def fn() -> None:
+        all_to_all(t, out, buf, config=CuteA2AConfig(num_blocks=2))
+
+    fn()  # warm/compile + prime counters before capture
+    torch.cuda.synchronize(device)
+    dist.barrier(group)
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        fn()
+    ok = True
+    for i in range(n_iters):
+        buf.copy_(inps[i])
+        out.zero_()
+        g.replay()
+        torch.cuda.synchronize(device)
+        ok = ok and torch.equal(out, golds[i])
+    dist.barrier(group)
+    return _report("graph_replay_stress", ok, device, group, rank)
+
+
+def _case_zc_geometry_switch_guard(group, rank, ws, device) -> bool:
+    """The geometry guard must FIRE on the CuTe zero-copy entry point (the CuTe twin of
+    ``test_a2a_robust.py``'s ``zc_geometry_switch_guard``).
+
+    The zero-copy direct path drives the transport's persistent step counters just like the
+    staging path, so switching ``num_blocks`` (one of ``CUTE_A2A_GEOMETRY_FIELDS``) on a
+    reused transport is the documented hazard the runtime guard catches -- this exercises the
+    guard in the CuTe ``all_to_all_zc`` so the firing test cannot be silently deleted. The
+    first call primes the geometry (num_blocks=2) and must SUCCEED; the second differs ONLY in
+    ``num_blocks`` (2 -> 4, same numel) so the guard -- not the zero-copy sizing assert -- is
+    what fires. Under ``COMMS_DSL_STRICT_GEOMETRY=1`` the guard raises ``ValueError`` before
+    dispatch; the env is saved/restored so strict mode doesn't leak into other cases. The
+    transport is sized ``per_peer_bytes == chunk * elem`` (the zero-copy contract), and both
+    grids (ws*2, ws*4) stay within the SM budget for ws<=8.
+    """
+    from comms.dsl.cute.a2a.host import all_to_all_zc
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+    numel = ws * 4096
+    chunk = numel // ws
+    t = _rendezvous(group, device, chunk)
+    inp = _make_input(rank, numel, device)
+
+    # Prime the geometry: this first zero-copy call must succeed (num_blocks=2).
+    out = all_to_all_zc(t, inp, primitive="direct", config=CuteA2AConfig(num_blocks=2))
+    torch.cuda.synchronize(device)
+    gold = _golden(group, inp)
+    primed_ok = torch.equal(out, gold)
+
+    # Switch geometry (num_blocks 2 -> 4) on the SAME transport under strict mode: the guard
+    # must raise ValueError before dispatch.
+    prev = os.environ.get("COMMS_DSL_STRICT_GEOMETRY")
+    raised = False
+    try:
+        os.environ["COMMS_DSL_STRICT_GEOMETRY"] = "1"
+        try:
+            all_to_all_zc(
+                t, inp, primitive="direct", config=CuteA2AConfig(num_blocks=4)
+            )
+        except ValueError:
+            raised = True
+    finally:
+        if prev is None:
+            os.environ.pop("COMMS_DSL_STRICT_GEOMETRY", None)
+        else:
+            os.environ["COMMS_DSL_STRICT_GEOMETRY"] = prev
+
+    dist.barrier(group)
+    return _report(
+        "zc_geometry_switch_guard", primed_ok and raised, device, group, rank
+    )
+
+
+def _run_clean_cases(group, rank, ws, device) -> list[bool]:
+    return [
+        _case_concurrent_transports(group, rank, ws, device),
+        _case_graph_replay_stress(group, rank, ws, device),
+        _case_zc_geometry_switch_guard(group, rank, ws, device),
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Entry points
+# --------------------------------------------------------------------------- #
+
+
+def _mp_worker(rank: int, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    device = torch.device(f"cuda:{rank}")
+    group = dist.group.WORLD
+    assert group is not None
+    results = _run_clean_cases(group, rank, world_size, device)
+    dist.barrier(group)
+    dist.destroy_process_group()
+    assert all(results), f"rank {rank}: cute production-hardening failed: {results}"
+
+
+class A2ACuteProductionTest(unittest.TestCase):
+    def _world(self) -> int:
+        return min(torch.cuda.device_count(), 8)
+
+    def test_production_robustness(self) -> None:
+        if torch.cuda.device_count() < 2:
+            self.skipTest("needs >=2 GPUs")
+        ws = self._world()
+        mp.spawn(_mp_worker, args=(ws, _find_free_port()), nprocs=ws, join=True)
+
+
+def _torchrun_main() -> None:
+    """Entry point for the GB300 conda/torchrun launcher (one process per rank).
+
+    Runs the clean, non-destructive cases (concurrent transports, graph-replay stress, zc
+    geometry-switch guard) over the launcher-provided process group.
+    """
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    device = torch.device(f"cuda:{local_rank}")
+    group = dist.group.WORLD
+    results = _run_clean_cases(group, rank, world_size, device)
+    dist.barrier(group)
+    if rank == 0:
+        print(
+            f"cute production-hardening: {'ALL PASS' if all(results) else 'FAIL'} "
+            f"({sum(results)}/{len(results)})",
+            flush=True,
+        )
+    dist.destroy_process_group()
+    if not all(results):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    if "RANK" in os.environ and "WORLD_SIZE" in os.environ:
+        _torchrun_main()
+    else:
+        unittest.main()

--- a/comms/dsl/tests/test_cute_a2a_variants.py
+++ b/comms/dsl/tests/test_cute_a2a_variants.py
@@ -1,0 +1,378 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# Distributed test: runs under mp.spawn and touches untyped cutlass / symmetric-memory symbols
+# that pyre cannot model, so strict typing adds no value here.
+
+"""Per-schedule correctness for the CuTe all_to_all variants.
+
+The eager `copy` schedule is covered by `test_a2a_cute.py` /
+`test_a2a_cute_production.py`; this suite is the bit-exact correctness net for the
+zero-copy `direct` (DirectWrite) and `ce` (copy-engine) paths, plus the `copy` staging
+schedule under CUDA-graph replay and the produce/consume hook and rows>0 transpose. Every
+schedule is checked eagerly against `dist.all_to_all_single` over several sizes; the
+staging schedule is additionally checked under CUDA-graph replay (the same
+persistent-counter credit handshake the `copy` graph-replay stress test exercises). The
+zero-copy paths return a view of the transport's symmetric-memory buffer, so their
+CUDA-graph behavior is covered by the graph-timed benchmark rather than asserted bit-exact
+here.
+
+A schedule whose hardware feature is unavailable on the running GPU raises at compile and
+is **skipped** uniformly — the launch fails on every rank before any cross-rank signal, so
+skipping cannot desync the group. A schedule that runs but produces a wrong result
+**fails** (it is not skipped).
+
+Dual execution model: `mp.spawn` locally / via `buck run`, and `_torchrun_main` for the
+GB300 conda launcher (`a2a_mast_launch_conda --module comms.dsl.tests.test_a2a_cute_variants`).
+Gold is `dist.all_to_all_single`. Skipped unless >=2 GPUs are present.
+"""
+
+import os
+import sys
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from comms.dsl.tests._dist_harness import (
+    _find_free_port,
+    _golden,
+    _make_input,
+    _rendezvous,
+    _report,
+)
+
+_STAGING = ("copy",)
+_ZEROCOPY = ("direct", "ce")
+_VARIANTS = _STAGING + _ZEROCOPY
+
+
+def _launch(t, inp, variant, *, out=None, num_blocks: int = 2):
+    """Run one CuTe a2a variant; return its output tensor.
+
+    Staging variants write the caller's ``out`` (allocated if absent); the zero-copy
+    variants own their output (a view of the transport's symm-mem buffer) and return it.
+    """
+    from comms.dsl.cute.a2a.host import all_to_all, all_to_all_zc
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+    if variant in ("direct", "ce"):
+        return all_to_all_zc(
+            t, inp, primitive=variant, config=CuteA2AConfig(num_blocks=num_blocks)
+        )
+    if out is None:
+        out = torch.empty_like(inp)
+    all_to_all(
+        t, out, inp, config=CuteA2AConfig(primitive=variant, num_blocks=num_blocks)
+    )
+    return out
+
+
+def _case_eager(group, rank, ws, device, variant) -> bool:
+    """Bit-exact vs gold across sizes for one variant (eager). Skip if unsupported here."""
+    ok, ran = True, False
+    for mult in (4096, 65536):
+        numel = ws * mult
+        t = _rendezvous(group, device, numel // ws)
+        inp = _make_input(rank, numel, device)
+        gold = _golden(group, inp)
+        try:
+            out = _launch(t, inp, variant)
+            torch.cuda.synchronize(device)
+            matched = torch.equal(out, gold)
+        except Exception as e:  # noqa: B902 -- unsupported schedule on this GPU: skip
+            if rank == 0:
+                print(
+                    f"  SKIP eager[{variant}] numel={numel}: {type(e).__name__}",
+                    flush=True,
+                )
+            dist.barrier(group)
+            continue
+        ok, ran = ok and matched, True
+        dist.barrier(group)
+    suffix = "" if ran else " (skipped: unsupported here)"
+    return _report(f"eager[{variant}]{suffix}", ok, device, group, rank)
+
+
+def _case_graph(group, rank, ws, device, variant) -> bool:
+    """Bit-exact vs gold under CUDA-graph replay for a staging variant. Skip if unsupported.
+
+    Used for the staging schedules only: their output is the caller's tensor, which is
+    stable across replays. (Zero-copy schedules return a transport-buffer view and are
+    graph-exercised via the benchmark.)
+    """
+    numel = ws * 16384
+    t = _rendezvous(group, device, numel // ws)
+    inps = [_make_input(rank + 5 * i, numel, device) for i in range(3)]
+    golds = [_golden(group, x) for x in inps]
+    buf = inps[0].clone()
+    out = torch.empty_like(buf)  # caller output for staging; ignored by zero-copy
+    try:
+        # Warm + compile (and prime the ce host buffer cache) before capture, since
+        # cute.compile and the device->host base-address read are illegal mid-capture.
+        _launch(t, buf, variant, out=out)
+        torch.cuda.synchronize(device)
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            captured = _launch(t, buf, variant, out=out)
+    except Exception as e:  # noqa: B902 -- unsupported schedule on this GPU: skip
+        if rank == 0:
+            print(f"  SKIP graph[{variant}]: {type(e).__name__}", flush=True)
+        dist.barrier(group)
+        return _report(f"graph[{variant}] (skipped)", True, device, group, rank)
+    ok = True
+    for i in range(3):
+        buf.copy_(inps[i])
+        g.replay()
+        torch.cuda.synchronize(device)
+        ok = ok and torch.equal(captured, golds[i])
+    dist.barrier(group)
+    return _report(f"graph[{variant}]", ok, device, group, rank)
+
+
+def _case_hook(group, rank, ws, device, variant) -> bool:
+    """produce/consume hooks on one fused staging schedule, bit-exact vs the transformed gold,
+    eager (tiny/odd/large) + CUDA-graph replay. Proves the CuTe fused schedule applies the hook
+    (the "5% the user writes"), not just an identity copy: `scale2_produce` scales each chunk on
+    the send leg (-> 2x the gold); `addone_consume` adds 1 on the recv leg (-> gold + 1).
+    Skipped if the schedule is unsupported on this GPU (same uniform skip as `_case_eager`).
+    """
+    from comms.dsl.cute.a2a.host import all_to_all
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+    from comms.dsl.cute.hooks import addone_consume, scale2_produce
+
+    ok, ran = True, False
+    for mult in (2, 100, 4096, 65536):
+        numel = ws * mult
+        t = _rendezvous(group, device, numel // ws)
+        inp = _make_input(rank, numel, device)
+        gold = _golden(group, inp)
+        cfg = CuteA2AConfig(primitive=variant, num_blocks=2)
+        try:
+            out_p = torch.empty_like(inp)
+            all_to_all(t, out_p, inp, produce=scale2_produce, config=cfg)
+            out_c = torch.empty_like(inp)
+            all_to_all(t, out_c, inp, consume=addone_consume, config=cfg)
+            torch.cuda.synchronize(device)
+            matched = torch.equal(out_p, gold * 2) and torch.equal(out_c, gold + 1)
+        except Exception as e:  # noqa: B902 -- unsupported schedule on this GPU: skip
+            if rank == 0:
+                print(
+                    f"  SKIP hook[{variant}] numel={numel}: {type(e).__name__}",
+                    flush=True,
+                )
+            dist.barrier(group)
+            continue
+        ok, ran = ok and matched, True
+        dist.barrier(group)
+    if ran:
+        # CUDA-graph replay with changing data: the hook must stay applied across replays.
+        numel = ws * 16384
+        t = _rendezvous(group, device, numel // ws)
+        inps = [_make_input(rank + 5 * i, numel, device) for i in range(3)]
+        golds = [_golden(group, x) for x in inps]
+        buf = inps[0].clone()
+        out_g = torch.empty_like(buf)
+        cfg = CuteA2AConfig(primitive=variant, num_blocks=2)
+        all_to_all(t, out_g, buf, produce=scale2_produce, config=cfg)  # warm/compile
+        torch.cuda.synchronize(device)
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            all_to_all(t, out_g, buf, produce=scale2_produce, config=cfg)
+        for i in range(3):
+            buf.copy_(inps[i])
+            g.replay()
+            torch.cuda.synchronize(device)
+            ok = ok and torch.equal(out_g, golds[i] * 2)
+        dist.barrier(group)
+        # The consume (recv-leg) hook is a distinct code path; cover it under graph replay too,
+        # matching the "hook must stay applied across replays" claim. Reuse inps/golds/buf.
+        out_gc = torch.empty_like(buf)
+        all_to_all(t, out_gc, buf, consume=addone_consume, config=cfg)  # warm/compile
+        torch.cuda.synchronize(device)
+        g2 = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g2):
+            all_to_all(t, out_gc, buf, consume=addone_consume, config=cfg)
+        for i in range(3):
+            buf.copy_(inps[i])
+            g2.replay()
+            torch.cuda.synchronize(device)
+            ok = ok and torch.equal(out_gc, golds[i] + 1)
+        dist.barrier(group)
+    suffix = "" if ran else " (skipped: unsupported here)"
+    return _report(f"hook[{variant}:scale2/addone]{suffix}", ok, device, group, rank)
+
+
+def _case_transpose(group, rank, ws, device, variant) -> bool:
+    """rows>0 layout transpose on one fused staging schedule, bit-exact vs the transposed gold,
+    eager (a couple of rows x cols shapes) + CUDA-graph replay. Proves the CuTe fused schedule
+    runs the design-doc headline non-contiguous transform on the production backend: each
+    [rows, cols] chunk is transposed to [cols, rows], fused into the transfer leg (the kernel
+    reads the chunk through a transposed layout -- no extra HBM pass). Skipped if the schedule
+    is unsupported on this GPU (same uniform skip as `_case_eager`).
+    """
+    from comms.dsl.cute.a2a.host import all_to_all
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+    def _ref(x):
+        return _golden(group, x).view(ws, rows, cols).transpose(1, 2).reshape(-1)
+
+    ok, ran = True, False
+    for rows, cols in ((64, 128), (32, 100)):
+        chunk = rows * cols
+        numel = ws * chunk
+        t = _rendezvous(group, device, chunk)
+        inp = _make_input(rank, numel, device)
+        ref = _ref(inp).contiguous()
+        cfg = CuteA2AConfig(primitive=variant, num_blocks=2)
+        try:
+            out = torch.empty_like(inp)
+            all_to_all(t, out, inp, rows=rows, config=cfg)
+            torch.cuda.synchronize(device)
+            matched = torch.equal(out, ref)
+        except Exception as e:  # noqa: B902 -- unsupported schedule on this GPU: skip
+            if rank == 0:
+                print(
+                    f"  SKIP transpose[{variant}] {rows}x{cols}: {type(e).__name__}",
+                    flush=True,
+                )
+            dist.barrier(group)
+            continue
+        ok, ran = ok and matched, True
+        dist.barrier(group)
+    if ran:
+        # CUDA-graph replay with changing data: the transpose must stay applied across replays.
+        rows, cols = 64, 128
+        numel = ws * rows * cols
+        t = _rendezvous(group, device, rows * cols)
+        inps = [_make_input(rank + 5 * i, numel, device) for i in range(3)]
+        refs = [_ref(x).contiguous() for x in inps]
+        buf = inps[0].clone()
+        out_g = torch.empty_like(buf)
+        cfg = CuteA2AConfig(primitive=variant, num_blocks=2)
+        all_to_all(t, out_g, buf, rows=rows, config=cfg)  # warm/compile
+        torch.cuda.synchronize(device)
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            all_to_all(t, out_g, buf, rows=rows, config=cfg)
+        for i in range(3):
+            buf.copy_(inps[i])
+            g.replay()
+            torch.cuda.synchronize(device)
+            ok = ok and torch.equal(out_g, refs[i])
+        dist.barrier(group)
+    suffix = "" if ran else " (skipped: unsupported here)"
+    return _report(f"transpose[{variant}]{suffix}", ok, device, group, rank)
+
+
+def _case_direct_tuned(group, rank, ws, device) -> bool:
+    """A tuned direct CuteA2AConfig must drive the ACTUAL direct launch -- not just match the
+    key. ``_all_to_all_direct`` now threads num_threads / unroll / cluster / cluster_y from the
+    config (a sentinel 0 = analytic). Run direct with an explicit tuned config and assert (a)
+    it is still bit-exact, and (b) the cute compile cache gains a DISTINCT entry vs the analytic
+    default -- which it can only do if the tuned knobs reached the resolved launch params (the
+    cache key). A config that the host silently ignored would collapse onto the default's key.
+    """
+    from comms.dsl.cute.a2a import host as cute_host
+    from comms.dsl.cute.a2a.host import all_to_all_zc
+    from comms.dsl.cute.a2a.tuning import CuteA2AConfig
+
+    numel = ws * 65536
+    t = _rendezvous(group, device, numel // ws)
+    inp = _make_input(rank, numel, device)
+    gold = _golden(group, inp)
+    try:
+        # Analytic default first (records its compile-cache key).
+        out0 = all_to_all_zc(
+            t, inp, primitive="direct", config=CuteA2AConfig(num_blocks=2)
+        )
+        torch.cuda.synchronize(device)
+        keys_after_default = {k for k in cute_host._COMPILED if k[0] == "a2a_direct"}
+        # Tuned config: force non-analytic num_threads + unroll + cluster (all applicable to
+        # direct). num_threads=128 differs from the analytic _pick_tile pick at this size, so
+        # the resolved launch params -- and the cache key -- must change.
+        tuned = CuteA2AConfig(
+            num_blocks=2, num_threads=128, unroll=4, cluster=2, primitive="direct"
+        )
+        out1 = all_to_all_zc(t, inp, primitive="direct", config=tuned)
+        torch.cuda.synchronize(device)
+        keys_after_tuned = {k for k in cute_host._COMPILED if k[0] == "a2a_direct"}
+        matched = torch.equal(out0, gold) and torch.equal(out1, gold)
+        # The tuned launch added at least one new compile-cache key (its knobs reached launch).
+        new_key = keys_after_tuned - keys_after_default
+        applied = len(new_key) >= 1
+    except Exception as e:  # noqa: B902 -- unsupported schedule on this GPU: skip
+        if rank == 0:
+            print(f"  SKIP direct_tuned: {type(e).__name__}: {e}", flush=True)
+        dist.barrier(group)
+        return _report("direct_tuned (skipped)", True, device, group, rank)
+    dist.barrier(group)
+    return _report("direct_tuned", matched and applied, device, group, rank)
+
+
+def _run_all_cases(group, rank, ws, device) -> list[bool]:
+    results: list[bool] = []
+    for variant in _VARIANTS:
+        results.append(_case_eager(group, rank, ws, device, variant))
+    for variant in _STAGING:
+        results.append(_case_graph(group, rank, ws, device, variant))
+    for variant in _STAGING:
+        results.append(_case_hook(group, rank, ws, device, variant))
+    for variant in _STAGING:
+        results.append(_case_transpose(group, rank, ws, device, variant))
+    results.append(_case_direct_tuned(group, rank, ws, device))
+    return results
+
+
+def _mp_worker(rank: int, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    device = torch.device(f"cuda:{rank}")
+    group = dist.group.WORLD
+    assert group is not None
+    results = _run_all_cases(group, rank, world_size, device)
+    dist.barrier(group)
+    dist.destroy_process_group()
+    assert all(results), f"rank {rank}: cute variant correctness failed: {results}"
+
+
+class A2ACuteVariantsTest(unittest.TestCase):
+    def _world(self) -> int:
+        return min(torch.cuda.device_count(), 8)
+
+    def test_variants(self) -> None:
+        if torch.cuda.device_count() < 2:
+            self.skipTest("needs >=2 GPUs")
+        ws = self._world()
+        mp.spawn(_mp_worker, args=(ws, _find_free_port()), nprocs=ws, join=True)
+
+
+def _torchrun_main() -> None:
+    """Entry point for the GB300 conda/torchrun launcher (one process per rank)."""
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    device = torch.device(f"cuda:{local_rank}")
+    group = dist.group.WORLD
+    results = _run_all_cases(group, rank, world_size, device)
+    dist.barrier(group)
+    if rank == 0:
+        print(
+            f"cute variant correctness: {'ALL PASS' if all(results) else 'FAIL'} "
+            f"({sum(results)}/{len(results)})",
+            flush=True,
+        )
+    dist.destroy_process_group()
+    if not all(results):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    if "RANK" in os.environ and "WORLD_SIZE" in os.environ:
+        _torchrun_main()
+    else:
+        unittest.main()

--- a/comms/dsl/tests/test_interface.py
+++ b/comms/dsl/tests/test_interface.py
@@ -1,0 +1,107 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+# Contract/interface test: touches untyped cute symbols and ``cast(Any, ...)`` stubs that
+# pyre cannot model, so strict typing adds no value here.
+
+"""GPU-free interface tests for the composable send/recv framework.
+
+Asserts the *contract* (transport abstraction, reserved stubs, CuTe ctx fields) without
+compiling or launching any kernel, so this runs in CI with no GPU. The real end-to-end path
+is exercised by the distributed ``test_cute_*`` suites.
+"""
+
+import unittest
+from typing import Any, cast
+
+from comms.dsl.cute import ib_ops as cute_ib_ops
+
+# Pure-Python cute submodules (no cutlass); importable GPU-free thanks to the
+# lazy cute/__init__.py, so they are safe to import at module scope.
+from comms.dsl.cute.ctx import Ctx as CuteCtx
+
+
+class TransportTest(unittest.TestCase):
+    def test_nvl_link_kind(self) -> None:
+        from comms.dsl import LinkKind, NvlTransport
+
+        # handle is not touched by link_kind, so we can build this GPU-free.
+        t = NvlTransport(
+            handle=cast(Any, None), world_size=4, local_rank=0, per_peer_bytes=1024
+        )
+        self.assertIs(t.link_kind(1), LinkKind.NVLINK)
+
+    def test_check_transfer_guards(self) -> None:
+        import torch
+        from comms.dsl import check_transfer, NvlTransport
+
+        # per_peer_bytes=4096, fp32 -> 1024 elems per peer; 4 signal slots.
+        t = NvlTransport(
+            handle=cast(Any, None),
+            world_size=2,
+            local_rank=0,
+            per_peer_bytes=4096,
+            max_blocks_per_peer=4,
+        )
+        # Valid transfer: no raise.
+        check_transfer(t, numel=512, dtype=torch.float32, num_blocks=2)
+        # numel exceeds per-peer capacity -> raise (would corrupt the next peer).
+        with self.assertRaises(ValueError):
+            check_transfer(t, numel=2000, dtype=torch.float32, num_blocks=2)
+        # num_blocks exceeds signal slots -> raise (would OOB-write the pad).
+        with self.assertRaises(ValueError):
+            check_transfer(t, numel=512, dtype=torch.float32, num_blocks=8)
+        # num_blocks must be >= 1.
+        with self.assertRaises(ValueError):
+            check_transfer(t, numel=512, dtype=torch.float32, num_blocks=0)
+
+    def test_step_state_cache_field(self) -> None:
+        # Lock the contract: _step_state_cache is a DECLARED dataclass field defaulting to None
+        # (eager allocation happens at rendezvous, not at construction), so a refactor that drops
+        # the field or changes its default is caught here. step_state()'s runtime behavior (lazy
+        # alloc + persistent per-(peer,block) counters) needs a device and is covered by the GPU
+        # send/recv + graph-replay tests.
+        import dataclasses
+
+        from comms.dsl import NvlTransport
+
+        defaults = {f.name: f.default for f in dataclasses.fields(NvlTransport)}
+        self.assertIn("_step_state_cache", defaults)
+        self.assertIsNone(defaults["_step_state_cache"])
+        t = NvlTransport(
+            handle=cast(Any, None),
+            world_size=2,
+            local_rank=0,
+            per_peer_bytes=1024,
+        )
+        self.assertIsNone(t._step_state_cache)
+        self.assertTrue(callable(t.step_state))
+
+
+class CuteInterfaceTest(unittest.TestCase):
+    def test_cute_ctx_contract(self) -> None:
+        # Lock the STABLE hook contract: the read-only facts default to None (a hook may branch on
+        # ctx.peer/coord being unset), and `cols` is DERIVED, not stored -- chunk // rows when
+        # rows > 0, else the whole chunk. The derivation is the only behavior on Ctx; asserting it
+        # (not just field storage) guards the shape math every layout hook relies on.
+        ctx = CuteCtx(part=1, atom=2)
+        self.assertEqual((ctx.part, ctx.atom), (1, 2))
+        self.assertIsNone(ctx.coord)
+        self.assertIsNone(ctx.peer)
+        self.assertIsNone(ctx.rank)
+        self.assertIsNone(ctx.world_size)
+        # cols derivation: rows>0 partitions the chunk; rows==0 (plain a2a) leaves it whole.
+        self.assertEqual(CuteCtx(part=0, atom=0, rows=4, chunk=32).cols, 8)
+        self.assertEqual(CuteCtx(part=0, atom=0, rows=0, chunk=32).cols, 32)
+
+    def test_cute_ib_ops_reserved(self) -> None:
+        # The four reserved IB transport ops must raise NotImplementedError until
+        # the IB stack wires them.
+        with self.assertRaises(NotImplementedError):
+            cute_ib_ops.put(None, None, None)
+        with self.assertRaises(NotImplementedError):
+            cute_ib_ops.get(None, None)
+        with self.assertRaises(NotImplementedError):
+            cute_ib_ops.signal(None, None)
+        with self.assertRaises(NotImplementedError):
+            cute_ib_ops.wait(None, None)

--- a/comms/dsl/tests/test_transport.py
+++ b/comms/dsl/tests/test_transport.py
@@ -1,0 +1,71 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Host-side (CPU, no device) coverage for transport.check_transfer.
+
+check_transfer is pure host validation -- it only reads per_peer_bytes /
+max_blocks_per_peer off the transport and dtype.itemsize -- so all three ValueError
+invariants (dtype divisibility, per-peer capacity, and signal-pad slot range) are
+exercisable without a symmetric-memory PG. The device rendezvous path (nvl_rendezvous)
+still needs a real symm-mem-capable group and is covered by the next-layer send/recv tests.
+"""
+
+import unittest
+from dataclasses import dataclass
+from typing import cast
+
+import torch
+from comms.dsl import check_transfer, P2pTransport
+
+
+@dataclass
+class _StubTransport:
+    """Minimal P2pTransport-shaped stub: just the fields check_transfer reads."""
+
+    world_size: int
+    per_peer_bytes: int
+    max_blocks_per_peer: int
+
+
+class TransportCheckTransferTest(unittest.TestCase):
+    def test_dtype_not_divisible_raises(self) -> None:
+        # per_peer_bytes must be a whole multiple of the dtype itemsize (mirrors endpoint()):
+        # 65 bytes is not divisible by bfloat16's 2-byte itemsize.
+        t = cast(
+            P2pTransport,
+            _StubTransport(world_size=2, per_peer_bytes=65, max_blocks_per_peer=8),
+        )
+        with self.assertRaises(ValueError):
+            check_transfer(t, numel=1, dtype=torch.bfloat16, num_blocks=1)
+
+    def test_numel_overrun_raises(self) -> None:
+        # per_peer_bytes=64 holds 64 uint8 / 32 bf16 elems; one past capacity raises.
+        for dtype, cap in ((torch.uint8, 64), (torch.bfloat16, 32)):
+            t = cast(
+                P2pTransport,
+                _StubTransport(world_size=2, per_peer_bytes=64, max_blocks_per_peer=8),
+            )
+            with self.assertRaises(ValueError):
+                check_transfer(t, numel=cap + 1, dtype=dtype, num_blocks=1)
+
+    def test_num_blocks_out_of_range_raises(self) -> None:
+        t = cast(
+            P2pTransport,
+            _StubTransport(world_size=2, per_peer_bytes=64, max_blocks_per_peer=8),
+        )
+        with self.assertRaises(ValueError):
+            check_transfer(t, numel=1, dtype=torch.uint8, num_blocks=0)
+        with self.assertRaises(ValueError):
+            check_transfer(
+                t, numel=1, dtype=torch.uint8, num_blocks=t.max_blocks_per_peer + 1
+            )
+
+    def test_valid_transfer_passes(self) -> None:
+        t = cast(
+            P2pTransport,
+            _StubTransport(world_size=2, per_peer_bytes=64, max_blocks_per_peer=8),
+        )
+        for dtype, cap in ((torch.uint8, 64), (torch.bfloat16, 32)):
+            check_transfer(t, numel=cap, dtype=dtype, num_blocks=1)
+            check_transfer(t, numel=cap, dtype=dtype, num_blocks=t.max_blocks_per_peer)

--- a/comms/dsl/tests/test_tuning_base.py
+++ b/comms/dsl/tests/test_tuning_base.py
@@ -1,0 +1,78 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+import unittest
+from unittest import mock
+
+import torch
+from comms.dsl.tuning_base import (
+    _device_tag,
+    BaseInputSpec,
+    BaseTunableConfig,
+    BaseTuningKey,
+)
+
+
+class TestTuningBase(unittest.TestCase):
+    def test_key_no_backend_default_in_base(self):
+        # The agnostic base stays backend-neutral: an empty backend is left as-is. A backend
+        # default belongs on a per-backend key subclass; a missing backend is attributed to the
+        # loading adapter only on the deserialization path (BaseAdapterMixin.key_from_json).
+        k = BaseTuningKey(
+            world_size=8,
+            dtype="bfloat16",
+            numel=1024,
+            rows=0,
+            transport_kind="NvlTransport",
+            device="H100",
+            backend="",
+            variant="",
+        )
+        self.assertEqual(k.backend, "")
+
+    def test_spec_json_roundtrip(self):
+        spec = BaseInputSpec(numel=8, dtype=torch.bfloat16, rows=0)
+        d = spec.to_json_dict()
+        self.assertEqual(d["dtype"], "bfloat16")
+        spec2 = BaseInputSpec.from_json_dict(d)
+        self.assertEqual(spec, spec2)
+
+    def test_config_hashable_as_dict_key(self):
+        cfg1 = BaseTunableConfig()
+        cfg2 = BaseTunableConfig()
+        d = {cfg1: "v"}
+        self.assertEqual(d[cfg2], "v")
+
+    def test_device_tag_cuda_absent_returns_unknown(self):
+        # CUDA unavailable raises RuntimeError -> the intended "unknown" fallback, no raise.
+        with mock.patch(
+            "torch.cuda.get_device_name", side_effect=RuntimeError("no CUDA")
+        ):
+            tag = _device_tag()
+        self.assertEqual(tag, "unknown")
+
+    def test_device_tag_cpu_device_returns_unknown(self):
+        # A CPU device (e.g. a CPU input tensor's .device) makes torch raise ValueError;
+        # the tag falls back to "unknown" rather than propagating (real make_a2a_key path).
+        self.assertEqual(_device_tag(torch.device("cpu")), "unknown")
+
+    def test_device_tag_known_models_match_exactly(self):
+        cases = {
+            "NVIDIA H100": "H100",
+            "NVIDIA GB300": "GB300",
+            "NVIDIA A100": "A100",
+            "NVIDIA B200": "B200",
+            "NVIDIA H200": "H200",
+            # GH (Grace+Hopper) must tag distinctly, not collide with the inner H200.
+            "NVIDIA GH200": "GH200",
+        }
+        for name, expected in cases.items():
+            with mock.patch("torch.cuda.get_device_name", return_value=name):
+                self.assertEqual(_device_tag(), expected)
+
+    def test_device_tag_four_digit_model_not_truncated(self):
+        # Regression: "RTX A6000" must NOT partial-match to "A600"; it falls through to the
+        # readable cleaned-name path.
+        with mock.patch("torch.cuda.get_device_name", return_value="NVIDIA RTX A6000"):
+            self.assertEqual(_device_tag(), "NVIDIA_RTX_A6000")

--- a/comms/dsl/transport.py
+++ b/comms/dsl/transport.py
@@ -1,0 +1,371 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""User-owned p2p transport objects for the composable send/recv framework.
+
+A transport owns all transport state (staging buffer + signal pads for the
+symmetric-memory case) behind an abstraction. A device schedule consumes a
+per-peer :class:`PeerEndpoint` resolved from a transport and never sees whether
+it is NVLink or IB.
+
+Design points realized here:
+
+* **User-owned, one rendezvous.** :func:`nvl_rendezvous` does a single collective
+  rendezvous for the whole group and returns an object the user holds (reused
+  across CUDA-graph replays). There is no hidden module-level cache.
+* **Mixed transport (future).** A ``MeshTransport`` would compose an intra-domain NVLink
+  transport with a (future) inter-domain IB transport and route per peer via
+  :meth:`P2pTransport.link_kind`, so a single collective could mix transports. Reserved
+  intent only -- not implemented here (see the future-note at the end of this module).
+
+Device transport-ops seam: a transport's only transport-specific device code is four
+primitives -- ``put`` (produced tile -> peer region), ``get`` (received tile <- region),
+``signal`` (publish "data ready"), ``wait`` (await a peer's data). A device schedule is
+written once against this seam and treats the per-peer buffers as opaque, so one schedule
+serves NVLink today and IB later, and a mixed-transport kernel can bind different ops per
+call site. There is no runtime dispatch -- the concrete ops are passed as compile-time
+constants; implementations live per transport + DSL.
+
+NVLink is implemented for real (minimal) here; IB and the mixed-transport mesh are reserved
+seams (the future-fabric interface contract, raising until their stack lands).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from torch._C._distributed_c10d import _SymmetricMemory
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+_SR_DEBUG: bool | None = None
+
+
+def _sr_debug() -> bool:
+    global _SR_DEBUG
+    if _SR_DEBUG is None:
+        _SR_DEBUG = os.environ.get("SENDRECV_DEBUG", "0") == "1"
+    return _SR_DEBUG
+
+
+def _rdv_dbg(group: dist.ProcessGroup, msg: str) -> None:
+    if _sr_debug():
+        logger.debug("[r%d] rdv: %s", dist.get_rank(group), msg)
+
+
+# Shape-independent default; the staging region per peer must hold the message.
+_DEFAULT_MAX_BLOCKS_PER_PEER: int = 32
+
+# Floor for the total symmetric-memory allocation (see nvl_rendezvous): GB300's NVL72
+# fabric rendezvous deadlocks on sub-MB allocations, so always allocate at least this much.
+_MIN_SYMM_TOTAL_BYTES: int = 4 * 1024 * 1024
+
+
+class LinkKind(Enum):
+    """How a given peer is reached. NVLINK is the only implemented kind today; IB is reserved
+    for the future IB (torchcomms window) transport and has no backing implementation yet."""
+
+    NVLINK = "nvlink"
+    IB = "ib"
+
+
+@dataclass(frozen=True)
+class PeerEndpoint:
+    """Host-resolved per-peer device state for one peer.
+
+    The four handles are passed directly to a device schedule (typed tensors, not
+    pointer-of-pointer indirection). Today each is a ``torch.Tensor`` (NVLink:
+    symm-mem-mapped); an IB transport will carry a ``(remote_addr, rkey)``
+    descriptor instead — a field-type change behind this same struct. The
+    ``send_dst``/``signal_dst`` pair drives this rank's writes to ``peer``; the
+    ``recv_src``/``signal_src`` pair drives this rank's reads of what ``peer`` wrote.
+    """
+
+    send_dst: torch.Tensor  # WHERE this rank writes for the peer (remote)
+    recv_src: torch.Tensor  # WHERE this rank reads what the peer wrote (local)
+    signal_dst: torch.Tensor  # signal this rank raises at the peer
+    signal_src: torch.Tensor  # signal this rank waits on (the peer raises it)
+
+
+@dataclass(frozen=True)
+class PeerTable:
+    """Device-side addressing for fused multi-peer schedules.
+
+    The multi-peer analogue of :class:`PeerEndpoint` (host-resolved, single
+    peer): every peer's staging-buffer and signal-pad base pointer as an int64
+    device tensor, indexed by peer id (cast int->ptr) inside the kernel. Used by
+    a fused multi-peer schedule that picks the peer on device via ``program_id``
+    instead of pre-slicing one ``PeerEndpoint`` per peer on the host.
+    """
+
+    buffer_ptrs: torch.Tensor  # int64[world_size]: peer -> staging-buffer base
+    signal_pad_ptrs: torch.Tensor  # int64[world_size]: peer -> signal-pad base
+
+
+@runtime_checkable
+class P2pTransport(Protocol):
+    """The transport abstraction a device schedule depends on (NVLink now, IB later)."""
+
+    world_size: int
+    per_peer_bytes: int
+    max_blocks_per_peer: int
+
+    def link_kind(self, peer: int) -> LinkKind: ...
+
+    def endpoint(self, peer: int, *, dtype: torch.dtype) -> PeerEndpoint: ...
+
+    def endpoints_device(self) -> PeerTable: ...
+
+
+@dataclass
+class NvlTransport:
+    """Symmetric-memory NVLink transport (real, minimal).
+
+    Owns the ``_SymmetricMemory`` handle. The buffer is ``per_peer_bytes`` per
+    peer (``per_peer_bytes * world_size`` total); the signal pad holds two int64
+    regions of ``world_size * max_blocks_per_peer`` entries each (tail then head),
+    laid out by ``[sender_rank * max_blocks_per_peer + block]``. Tail = sender
+    "data ready"; head = receiver "slot consumed" (so a sender never overwrites a
+    slot a receiver has not drained).
+    """
+
+    handle: _SymmetricMemory
+    world_size: int
+    # Rank within the NVLink rendezvous group (``dist.get_rank(group)``), i.e. the
+    # index used to address this rank's slot in the symmetric-memory buffer. This is
+    # NOT the node-local rank (``LOCAL_RANK`` env / ``get_node_local_rank``): on an
+    # NVL fabric the rendezvous group may span trays, so it is a group-relative rank.
+    local_rank: int
+    per_peer_bytes: int
+    max_blocks_per_peer: int = _DEFAULT_MAX_BLOCKS_PER_PEER
+    _endpoints_device_cache: PeerTable | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+    _step_state_cache: tuple[torch.Tensor, torch.Tensor] | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+
+    def link_kind(self, peer: int) -> LinkKind:
+        return LinkKind.NVLINK
+
+    def endpoint(self, peer: int, *, dtype: torch.dtype) -> PeerEndpoint:
+        if not (0 <= peer < self.world_size) or peer == self.local_rank:
+            raise ValueError(
+                f"peer={peer} must be in [0, {self.world_size}) and "
+                f"!= local_rank={self.local_rank}"
+            )
+        elem = dtype.itemsize
+        if self.per_peer_bytes % elem != 0:
+            raise ValueError(
+                f"per_peer_bytes={self.per_peer_bytes} not a multiple of {elem} "
+                f"(dtype={dtype})"
+            )
+        cap_elems = self.per_peer_bytes // elem
+        mbp = self.max_blocks_per_peer
+
+        # Staging regions are indexed by SENDER rank within each rank's buffer.
+        send_dst = self.handle.get_buffer(
+            peer,
+            sizes=[cap_elems],
+            dtype=dtype,
+            storage_offset=self.local_rank * cap_elems,
+        )
+        recv_src = self.handle.get_buffer(
+            self.local_rank,
+            sizes=[cap_elems],
+            dtype=dtype,
+            storage_offset=peer * cap_elems,
+        )
+        peer_sig = self.handle.get_signal_pad(peer).view(torch.int64)
+        local_sig = self.handle.get_signal_pad(self.local_rank).view(torch.int64)
+        signal_dst = peer_sig[self.local_rank * mbp : self.local_rank * mbp + mbp]
+        signal_src = local_sig[peer * mbp : peer * mbp + mbp]
+        return PeerEndpoint(send_dst, recv_src, signal_dst, signal_src)
+
+    def endpoints_device(self) -> PeerTable:
+        """All peers' buffer + signal-pad base pointers as a device :class:`PeerTable`.
+
+        The device-side counterpart of :meth:`endpoint` for a single fused
+        multi-peer kernel: index by peer on device (cast int->ptr) instead of
+        pre-slicing one :class:`PeerEndpoint` per peer. The per-peer staging
+        region for sender ``s`` inside a rank's buffer is at
+        ``s * (per_peer_bytes // elem)`` (same convention as :meth:`endpoint`),
+        and signal-pad slots for sender ``s`` start at ``s * max_blocks_per_peer``.
+        """
+        if self._endpoints_device_cache is None:
+            # Symm-mem base addresses are fixed after rendezvous, so build once and
+            # cache: repeated fused-schedule calls and CUDA-graph capture must not
+            # re-allocate / re-copy. Device is the transport's own symm-mem device,
+            # not the caller's current device.
+            dev = self.handle.get_buffer(
+                self.local_rank, sizes=[1], dtype=torch.uint8
+            ).device
+            self._endpoints_device_cache = PeerTable(
+                buffer_ptrs=torch.tensor(
+                    self.handle.buffer_ptrs, dtype=torch.int64, device=dev
+                ),
+                signal_pad_ptrs=torch.tensor(
+                    self.handle.signal_pad_ptrs, dtype=torch.int64, device=dev
+                ),
+            )
+        return self._endpoints_device_cache
+
+    def step_state(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """Persistent monotonic step counters for graph-safe signalling.
+
+        Returns ``(sender_step, recver_step)``, each an int64 device tensor of
+        ``world_size * max_blocks_per_peer`` entries indexed by
+        ``peer * max_blocks_per_peer + block``. Each slot has exactly one writer
+        (the local send leg writes ``sender_step``; the local recv leg writes
+        ``recver_step``), so no atomics are needed.
+
+        The schedule signals an absolute, monotonically increasing sequence
+        number per call and the kernel advances these counters itself, so a
+        reused transport / CUDA-graph replay never reads a stale signal slot.
+        Allocated once and cached (zero-initialized; the signal pad is zeroed at
+        rendezvous, so the first ``wait_ge(_, 1)`` is race-free).
+        """
+        if self._step_state_cache is None:
+            dev = self.handle.get_buffer(
+                self.local_rank, sizes=[1], dtype=torch.uint8
+            ).device
+            n = self.world_size * self.max_blocks_per_peer
+            self._step_state_cache = (
+                torch.zeros(n, dtype=torch.int64, device=dev),
+                torch.zeros(n, dtype=torch.int64, device=dev),
+            )
+        return self._step_state_cache
+
+
+def nvl_rendezvous(
+    group: dist.ProcessGroup,
+    device: torch.device,
+    per_peer_bytes: int,
+    max_blocks_per_peer: int = _DEFAULT_MAX_BLOCKS_PER_PEER,
+) -> NvlTransport:
+    """One collective rendezvous; returns a user-owned :class:`NvlTransport`.
+
+    Allocates ``per_peer_bytes * world_size`` of symmetric memory (one per-peer
+    staging region per peer), floored at ``_MIN_SYMM_TOTAL_BYTES`` (4 MiB) because
+    the GB300 NVL72 fabric rendezvous deadlocks on sub-MB allocations -- so a small
+    transfer allocates more than the raw product. Zeroes the signal pad so the first
+    ``wait(_, 1)`` is race-free after the barrier.
+    """
+    world_size = dist.get_world_size(group)
+    local_rank = dist.get_rank(group)
+    total = per_peer_bytes * world_size
+    # GB300 NVL72 symm-mem fabric rendezvous DEADLOCKS on a tiny allocation: a 32B-per-peer
+    # (64B total) transfer wedges the receiver inside symm_mem.rendezvous() while the sender
+    # returns (pinpointed via SENDRECV_DEBUG -- rank1 freezes at symm_mem.rendezvous start).
+    # Floor the symm-mem allocation to a fabric-safe size. The per-peer staging math
+    # (cap_elems = per_peer_bytes // elem) is unchanged, so the extra bytes are unused
+    # headroom and the measured transfer size is unaffected; the signal pad is sized
+    # separately. H100 does not need this (it handles tiny allocations fine).
+    total = max(total, _MIN_SYMM_TOTAL_BYTES)
+    logger.info(
+        "nvl_rendezvous on PG %s: allocating %d bytes (%d peers x %d)",
+        group.group_desc,
+        total,
+        world_size,
+        per_peer_bytes,
+    )
+    _rdv_dbg(group, f"symm_mem.empty({total}B) start")
+    raw = symm_mem.empty(total, dtype=torch.uint8, device=device)
+    _rdv_dbg(group, "symm_mem.empty done; symm_mem.rendezvous start")
+    handle = symm_mem.rendezvous(raw, group=group)
+    _rdv_dbg(group, "symm_mem.rendezvous done")
+
+    # Signal pad holds two int64 regions per (sender, block) slot:
+    #   tail [0 .. ws*MBP): sender publishes "data ready" (polled by receiver)
+    #   head [ws*MBP .. 2*ws*MBP): receiver publishes "slot consumed" (polled by
+    #       sender, so a sender never overwrites a slot the receiver has not yet
+    #       drained -> back-to-back / reuse is race-free).
+    need = 2 * world_size * max_blocks_per_peer
+    sig = handle.get_signal_pad(handle.rank).view(torch.int64)
+    if sig.numel() < need:
+        raise RuntimeError(
+            f"signal pad too small: {sig.numel()} int64 < required {need} "
+            f"(2 x world_size={world_size} x max_blocks_per_peer={max_blocks_per_peer})"
+        )
+    sig.zero_()
+    _rdv_dbg(group, "sig.zero_ done; barrier start")
+    dist.barrier(group)
+    _rdv_dbg(group, "barrier done")
+    transport = NvlTransport(
+        handle=handle,
+        world_size=world_size,
+        local_rank=local_rank,
+        per_peer_bytes=per_peer_bytes,
+        max_blocks_per_peer=max_blocks_per_peer,
+    )
+    # Eagerly materialize the device-side caches (peer table + step counters) now,
+    # so the first collective can be issued inside a CUDA-graph capture without the
+    # lazy allocation happening during capture.
+    transport.endpoints_device()
+    _rdv_dbg(group, "endpoints_device done")
+    transport.step_state()
+    _rdv_dbg(group, "step_state done")
+    return transport
+
+
+def check_transfer(
+    transport: P2pTransport,
+    numel: int,
+    dtype: torch.dtype,
+    num_blocks: int,
+) -> None:
+    """Validate a transfer against the transport before launch (fail loud).
+
+    Three invariants whose violation would otherwise cause **silent remote
+    corruption** (a kernel writing past a per-peer region overruns the next
+    peer's staging or signal-pad region on the remote rank):
+
+    * ``per_peer_bytes`` must be a whole multiple of the dtype itemsize (mirrors
+      ``endpoint()``), so the per-peer region holds whole elements.
+    * ``numel`` must fit the per-peer staging region (``per_peer_bytes``).
+    * ``num_blocks`` must fit the per-peer signal-pad slots
+      (``max_blocks_per_peer``), since each block signals slot ``block_id``.
+    """
+    elem = dtype.itemsize
+    # Mirror endpoint()'s divisibility guard so pre-launch validation is complete: a per-peer
+    # region that is not a whole number of elements would otherwise pass here and fail later
+    # inside endpoint() (or silently mis-slice the symm-mem buffer).
+    if transport.per_peer_bytes % elem != 0:
+        raise ValueError(
+            f"per_peer_bytes={transport.per_peer_bytes} not a multiple of dtype itemsize "
+            f"{elem} ({dtype}); the per-peer region cannot hold whole elements"
+        )
+    cap_elems = transport.per_peer_bytes // elem
+    if numel > cap_elems:
+        raise ValueError(
+            f"transfer numel={numel} exceeds per-peer capacity={cap_elems} elems "
+            f"(per_peer_bytes={transport.per_peer_bytes}, dtype={dtype}); "
+            f"increase per_peer_bytes at rendezvous"
+        )
+    mbp = transport.max_blocks_per_peer
+    if not (1 <= num_blocks <= mbp):
+        raise ValueError(
+            f"num_blocks={num_blocks} must be in [1, {mbp}] "
+            f"(one signal-pad slot per block per peer)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Future: IB / Mesh transports.
+#
+# The intent is retained but not implemented here: an IB (torchcomms window)
+# transport and a mixed-transport ``MeshTransport`` (intra-domain NVLink composed
+# with inter-domain IB, routed per peer via ``P2pTransport.link_kind``) would slot
+# onto the same ``P2pTransport`` protocol + four-op device seam above, so device
+# schedules stay fabric-agnostic. Not shipped in this framework (no kernel uses it);
+# ``LinkKind.IB`` is the reserved kind for the IB transport, and a mesh kind would be
+# added to ``LinkKind`` when ``MeshTransport`` lands (only NVLINK/IB exist today).
+# ---------------------------------------------------------------------------

--- a/comms/dsl/tuning_base.py
+++ b/comms/dsl/tuning_base.py
@@ -1,0 +1,384 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""DSL-agnostic tuning base: shared Config / Key / Spec / Adapter mixin for backends.
+
+This layer owns everything the backends share: the tunable Config / lookup Key /
+input Spec dataclasses, their JSON roundtrip, rendering, and the dict-grid candidate
+expansion. Backends inherit and add their core fields. A generated-table entry that
+does not name a backend is attributed to the loading adapter's backend.
+"""
+
+from __future__ import annotations
+
+import importlib
+import itertools
+import logging
+import os
+import re
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import torch
+
+try:  # optional dep: the comms-owned tuner engine; absent until comm_tuning lands.
+    # pyre-ignore[21]: optional dependency, resolved at runtime when the tuner is present.
+    from comm_tuning.adapter import CommKernelTuningAdapter as _CommTunerBase
+except ImportError:  # the adapter base is still importable/testable without the engine
+    _CommTunerBase = object
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _device_tag(device: torch.device | int | str | None = None) -> str:
+    """Short, stable hardware tag for the tuning key (e.g. ``H100``, ``GB300``,
+    ``B200``, ``A100``). Tuned configs are hardware-specific -- the best launch config
+    differs by GPU/NVLink generation -- so the key includes the device so an H100-tuned
+    table and a GB300-tuned table coexist in one map instead of colliding on identical
+    (world_size, dtype, numel, rows, transport) keys. Backend-agnostic, so both DSLs build
+    an identical tag; MUST be computed identically offline (tuner) and at runtime (lookup).
+    """
+    try:
+        name = torch.cuda.get_device_name(device)  # e.g. "NVIDIA H100", "NVIDIA GB300"
+    except (RuntimeError, ValueError, AssertionError):
+        # torch raises RuntimeError when CUDA is unavailable / the index is out of range,
+        # ValueError for a non-CUDA device (e.g. a CPU tensor's device), and AssertionError
+        # on a bad device arg; "unknown" is the intended fallback only for those. Anything
+        # else is a real bug and must not be folded into a tuning key.
+        return "unknown"
+    # The (?!\d) lookahead stops a 4-digit model (e.g. "RTX A6000") from partial-matching
+    # to "A600"; such names fall through to the readable cleaned-name path instead.
+    m = re.search(r"(GB\d{3}|GH\d{3}|B\d{3}|H\d{3}|A\d{3})(?!\d)", name.upper())
+    return m.group(1) if m else name.replace(" ", "_")
+
+
+# Default per-rank message-size ladder for the autotuner: the 32 B .. 2 GB 2x ladder (27 sizes)
+# plus 48 MB / 96 MB for mid-band resolution where the launch-config dip lives = 29 sizes. The
+# best launch config shifts across sizes, so each is tuned independently; mirrors the benchmark
+# size sweep. Used by the adapter's enumerate_input_specs when no explicit shapes are given.
+SIZE_LADDER: tuple[int, ...] = (
+    32,
+    64,
+    128,
+    256,
+    512,
+    1024,
+    2 * 1024,
+    4 * 1024,
+    8 * 1024,
+    16 * 1024,
+    32 * 1024,
+    64 * 1024,
+    128 * 1024,
+    256 * 1024,
+    512 * 1024,
+    1 * 1024 * 1024,
+    2 * 1024 * 1024,
+    4 * 1024 * 1024,
+    8 * 1024 * 1024,
+    16 * 1024 * 1024,
+    32 * 1024 * 1024,
+    48 * 1024 * 1024,
+    64 * 1024 * 1024,
+    96 * 1024 * 1024,
+    128 * 1024 * 1024,
+    256 * 1024 * 1024,
+    512 * 1024 * 1024,
+    1024 * 1024 * 1024,
+    2 * 1024 * 1024 * 1024,
+)
+
+
+def import_obj(path: str):
+    """Resolve a ``module:attr`` import path to the object, for CLI ``--produce`` /
+    ``--reference`` so a user can tune a custom hook with no adapter file."""
+    mod, _, name = path.partition(":")
+    if not mod or not name:
+        raise ValueError(f"expected 'module:attr', got {path!r}")
+    return getattr(importlib.import_module(mod), name)
+
+
+def resolve_variant(
+    produce, consume, variant: str, *, default_produce, default_consume
+) -> str:
+    """Single chokepoint for the tuned-table hook discriminator. The default identity copy
+    hooks map to ``""`` (back-compat). Any *non-default* hook MUST carry an explicit
+    ``variant`` -- else its tuned configs would silently collide with the default copy
+    hook's, for a kernel with a different access pattern."""
+    if produce is default_produce and consume is default_consume:
+        return variant
+    if not variant:
+        raise ValueError(
+            "a non-default produce/consume hook needs an explicit variant tag so its tuned "
+            "configs don't collide with the default copy hook; pass variant=... "
+            "(e.g. A2A(produce=my_op, variant='myq'))."
+        )
+    return variant
+
+
+def geometry_signature(config: Any, fields: frozenset[str]) -> tuple:
+    """Geometry-defining field values: two configs with the same signature can reuse one
+    transport back-to-back; a different signature on a reused transport is the documented
+    hazard the runtime geometry guard catches. ``fields`` is the per-collective set of
+    knobs that change the physical staging geometry."""
+    return tuple(getattr(config, f) for f in sorted(fields))
+
+
+def nondefault_inapplicable_fields(
+    config: Any,
+    *,
+    core_fields: frozenset[str],
+    primitive_applies: dict[str, frozenset[str]],
+    default: Any,
+) -> set[str]:
+    """Names of fields ``config`` sets to a NON-default value that its ``primitive`` does not
+    consume at launch (empty == honest). Shared skeleton for the per-backend feasibility
+    filter; the backend passes its ``core_fields`` / ``primitive_applies`` map / ``default``
+    config. ``num_blocks`` and ``primitive`` are always excluded (grid axes, not knobs)."""
+    applies = primitive_applies.get(config.primitive, frozenset())
+    checked = core_fields - {"num_blocks", "primitive"}
+    return {
+        name
+        for name in checked
+        if name not in applies and getattr(config, name) != getattr(default, name)
+    }
+
+
+def check_geometry(transport: Any, config: Any, fields: frozenset[str]) -> None:
+    """Guard against an unsafe staging-geometry switch on a reused transport (both backends).
+
+    The kernel's persistent step counters + shared staging buffer make back-to-back launches
+    safe only when the geometry-defining ``fields`` are unchanged (see ``geometry_signature``).
+    Switching geometry on the same transport without a drain reinterprets in-flight bytes; the
+    framework has no runtime drain, so this guard surfaces the hazard.
+
+    A geometry switch on a reused transport is a hard error by default: there is no runtime
+    drain, so reinterpreting in-flight bytes silently corrupts staging data and a warn-and-
+    proceed default would let that corruption through unnoticed. ``COMMS_DSL_ALLOW_GEOMETRY_SWITCH=1``
+    downgrades it to a silent advance for callers whose successive launches are device-sync-
+    separated (a benchmark / tuner sweeping configs at one size) -- they know no bytes are in
+    flight across the switch. The transport is a non-frozen dataclass, so we stash the last
+    accepted geometry on it directly (private attr).
+    """
+    sig = geometry_signature(config, fields)
+    prev = getattr(transport, "_last_geometry_signature", None)
+    # The cache advances only on an accepted switch: reseeding the baseline before the raise
+    # would let the next (still hazardous) switch slip through unflagged.
+    if prev is None or prev == sig:
+        transport._last_geometry_signature = (
+            sig  # pyre-ignore[16]: runtime cache on the transport
+        )
+        return
+    if os.environ.get("COMMS_DSL_ALLOW_GEOMETRY_SWITCH") == "1":
+        transport._last_geometry_signature = sig  # pyre-ignore[16]: runtime cache
+        return
+    names = sorted(fields)
+    raise ValueError(
+        "all_to_all: staging geometry changed on a reused transport "
+        f"({dict(zip(names, prev))} -> {dict(zip(names, sig))}). There is no runtime drain yet, "
+        "so back-to-back calls of differing geometry on one transport (without an intervening "
+        "device sync) would corrupt in-flight staging data. Use a fresh transport per "
+        "geometry/shape, or set COMMS_DSL_ALLOW_GEOMETRY_SWITCH=1 if your calls are sync-separated."
+    )
+
+
+@dataclass(frozen=True)
+class BaseTunableConfig:
+    """Base tunable config shared across backends.
+
+    Subclasses add backend-specific core fields.
+    """
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "BaseTunableConfig":
+        # Subclasses override to construct their core fields.
+        return cls(**data)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True)
+class BaseTuningKey:
+    """Base lookup key shared across backends.
+
+    The base stays backend-neutral: subclasses set the ``backend`` field (e.g. the Triton
+    ``A2AKey`` defaults it to ``"triton"``). A table entry that does not name a backend is
+    attributed to the loading adapter's backend on the deserialization path (see
+    ``BaseAdapterMixin.key_from_json``), not here -- a default baked into the agnostic base
+    would silently mislabel a different backend's key.
+    """
+
+    world_size: int
+    dtype: str
+    numel: int
+    rows: int
+    transport_kind: str
+    device: str = ""
+    backend: str = ""
+    variant: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "BaseTuningKey":
+        return cls(**data)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True)
+class BaseInputSpec:
+    """Serializable input spec shared across backends."""
+
+    numel: int
+    dtype: torch.dtype
+    rows: int = 0
+
+    def to_json_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        # torch.dtype -> string for JSON
+        d["dtype"] = str(self.dtype).removeprefix("torch.")
+        return d
+
+    @classmethod
+    def from_json_dict(cls, data: dict[str, Any]) -> "BaseInputSpec":
+        dtype_str = data["dtype"]
+        dtype = getattr(torch, dtype_str) if isinstance(dtype_str, str) else dtype_str
+        return cls(
+            numel=int(data["numel"]),
+            dtype=dtype,
+            rows=int(data.get("rows", 0)),
+        )
+
+
+def expand_config_grid(
+    grid: dict[str, list[Any]],
+    config_cls: type,
+    core_fields: frozenset[str],
+) -> list[Any]:
+    """Expand a flat ``{field: [values]}`` grid into the cartesian product of config objects.
+
+    Every grid key must name a declared core config field; an unknown name is rejected.
+    The single grid-expansion implementation, shared by
+    ``BaseAdapterMixin.expand_candidate_grid`` and the per-backend grid helpers.
+    """
+    unknown = [k for k in grid if k not in core_fields]
+    if unknown:
+        raise ValueError(
+            f"unknown grid field(s) {unknown}; allowed: {sorted(core_fields)}"
+        )
+    keys = list(grid)
+    values = [grid[k] for k in keys]
+    return [
+        config_cls(**dict(zip(keys, combo))) for combo in itertools.product(*values)
+    ]
+
+
+class BaseAdapterMixin:
+    """Shared adapter helpers for tuner adapters across backends.
+
+    Subclasses must define:
+      - core_config_fields: frozenset of core tunable field names
+      - config_cls
+      - key_cls
+      - spec_cls
+      - backend_name: str e.g. "triton" or "cute"
+    and implement backend-specific abstract methods: enumerate_candidate_configs core logic,
+    run_candidate, make_inputs, etc. This mixin provides shared JSON, render, expand, and key building.
+    """
+
+    # To be overridden by subclasses
+    core_config_fields: frozenset[str] = frozenset()
+    config_cls: type = BaseTunableConfig
+    key_cls: type = BaseTuningKey
+    spec_cls: type = BaseInputSpec
+    backend_name: str = ""
+
+    # Shared helpers below – subclasses may override for customization
+
+    def expand_candidate_grid(self, grid: dict[str, list[Any]]) -> list[Any]:
+        """Expand declarative grid into list of config objects."""
+        return expand_config_grid(grid, self.config_cls, self.core_config_fields)
+
+    def make_key_from_spec(
+        self,
+        spec: BaseInputSpec,
+        world_size: int,
+        transport_kind: str,
+        device: str,
+        variant: str,
+    ) -> BaseTuningKey:
+        # dtype string normalization
+        dtype_str = (
+            spec.dtype
+            if isinstance(spec.dtype, str)
+            else str(spec.dtype).removeprefix("torch.")
+        )
+        return self.key_cls(
+            world_size=world_size,
+            dtype=dtype_str,
+            numel=spec.numel,
+            rows=spec.rows,
+            transport_kind=transport_kind,
+            device=device,
+            backend=self.backend_name,
+            variant=variant,
+        )
+
+    def key_to_json(self, key: BaseTuningKey) -> tuple[str, dict[str, Any]]:
+        return (type(key).__name__, asdict(key))
+
+    def key_from_json(self, key_type: str, data: dict[str, Any]) -> BaseTuningKey:
+        # key_type ignored, we trust subclass key_cls.
+        data = dict(data)
+        # A table entry that does not name a backend is attributed to this adapter's backend
+        # (set by the subclass) and flagged, rather than assuming a backend in the base.
+        if not data.get("backend") and self.backend_name:
+            logger.warning(
+                "tuned-table key missing 'backend'; backfilling %r", self.backend_name
+            )
+            data["backend"] = self.backend_name
+        return self.key_cls(**data)
+
+    def config_to_json(self, config: BaseTunableConfig) -> tuple[str, dict[str, Any]]:
+        return (type(config).__name__, asdict(config))
+
+    def config_from_json(
+        self, config_type: str, data: dict[str, Any]
+    ) -> BaseTunableConfig:
+        return self.config_cls(**data)
+
+    def spec_to_json(self, spec: BaseInputSpec) -> tuple[str, dict[str, Any]]:
+        return ("BaseInputSpec", spec.to_json_dict())
+
+    def spec_from_json(self, spec_type: str, data: dict[str, Any]) -> BaseInputSpec:
+        # Subclass may override to return its specific spec subclass; base returns BaseInputSpec
+        return self.spec_cls.from_json_dict(data)
+
+    def render_key(self, key_type: str, key_dict: dict[str, Any]) -> str:
+        # Build dynamic string template preserving core order for readability.
+        base_order = [
+            "world_size",
+            "dtype",
+            "numel",
+            "rows",
+            "transport_kind",
+            "device",
+            "backend",
+            "variant",
+        ]
+        parts = []
+        for f in base_order:
+            if f in key_dict:
+                v = key_dict[f]
+                parts.append(f"{f}={v!r}" if isinstance(v, str) else f"{f}={v}")
+        return f"{key_type}({', '.join(parts)})"
+
+    def render_config(self, config_type: str, config_dict: dict[str, Any]) -> str:
+        # Subclass should override core order; base does generic sorted keys.
+        items = sorted(
+            config_dict.items()
+        )  # subclasses likely override for pretty order
+        parts = [f"{k}={v!r}" if isinstance(v, str) else f"{k}={v}" for k, v in items]
+        return f"{config_type}({', '.join(parts)})"


### PR DESCRIPTION
Summary:

Sixth layer of the lean CuTe-only comms/dsl stack. Lands the perf + robustness surface:
- `benchmark_a2a_cute` — apple-to-apple CuTe-vs-NCCL a2a benchmark over the 32 B -> 2 GB ladder (2x steps + 48 MB / 96 MB), runtime **SM-matched** (framework grid `world_size * num_blocks` = NCCL's probed active-SM count) and **CUDA-graph** timed (capture once, median over barriered replay windows), each size correctness-gated vs NCCL gold before timing.
- Shared backend-agnostic timing/busbw/NCCL helpers in `_bench_common`, including `emit_result_rows` — the DSL-agnostic result sink that prints tagged `A2A_RESULT_JSON` rows to stdout (replaces the private Scuba sink).
- UniBench/AnyBench integration: `anybench_a2a_cute_parser` scrapes those rows into one JSON object AnyBench pushes to the `anybench_parser_output` dataset; `anybench_a2a_cute.json` is the runnable AnyBench config (runs the full copy/direct/ce variant matrix via `A2A_CUTE_REPORT=1`).
- `mast_launch` — unified GB300 launcher (`--delivery conda|fbpkg`) with NVL72 domain co-placement. Hardware defaults to `gb300_dsf` (the quota path); the caller/tenant-specific access knobs (entitlement / identity / oncall) and the flexpool have NO baked-in default — supplied via flags or the `$MAST_*` env vars — so the launcher lands cleanly for any user. Plus the aarch64 GB300 fbpkg builder.
- CuTe a2a variant + robustness correctness suites.

Differential Revision: D110302965
