### PR TITLE
Move CUDA completion event ownership to TorchComm

### DIFF
--- a/comms/torchcomms/device/cuda/CudaApi.cpp
+++ b/comms/torchcomms/device/cuda/CudaApi.cpp
@@ -203,6 +203,10 @@ cudaError_t DefaultCudaApi::eventQuery(cudaEvent_t event) {
   return cudaEventQuery(event);
 }
 
+cudaError_t DefaultCudaApi::eventSynchronize(cudaEvent_t event) {
+  return cudaEventSynchronize(event);
+}
+
 const char* DefaultCudaApi::getErrorString(cudaError_t error) {
   return cudaGetErrorString(error);
 }

--- a/comms/torchcomms/device/cuda/CudaApi.hpp
+++ b/comms/torchcomms/device/cuda/CudaApi.hpp
@@ -129,6 +129,7 @@ class CudaApi {
       cudaStream_t stream,
       unsigned int flags) = 0;
   [[nodiscard]] virtual cudaError_t eventQuery(cudaEvent_t event) = 0;
+  [[nodiscard]] virtual cudaError_t eventSynchronize(cudaEvent_t event) = 0;
 
   // Error handling
   virtual const char* getErrorString(cudaError_t error) = 0;
@@ -232,6 +233,7 @@ class DefaultCudaApi : public CudaApi {
       cudaStream_t stream,
       unsigned int flags) override;
   [[nodiscard]] cudaError_t eventQuery(cudaEvent_t event) override;
+  [[nodiscard]] cudaError_t eventSynchronize(cudaEvent_t event) override;
 
   // Error handling
   const char* getErrorString(cudaError_t error) override;

--- a/comms/torchcomms/nccl/tests/unit/cpp/mocks/CudaMock.hpp
+++ b/comms/torchcomms/nccl/tests/unit/cpp/mocks/CudaMock.hpp
@@ -160,6 +160,7 @@ class CudaMock : public CudaApi {
       (cudaEvent_t event, cudaStream_t stream, unsigned int flags),
       (override));
   MOCK_METHOD(cudaError_t, eventQuery, (cudaEvent_t event), (override));
+  MOCK_METHOD(cudaError_t, eventSynchronize, (cudaEvent_t event), (override));
 
   // Error handling
   MOCK_METHOD(const char*, getErrorString, (cudaError_t error), (override));

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.hpp
@@ -160,6 +160,7 @@ class CudaMock : public CudaApi {
       (cudaEvent_t event, cudaStream_t stream, unsigned int flags),
       (override));
   MOCK_METHOD(cudaError_t, eventQuery, (cudaEvent_t event), (override));
+  MOCK_METHOD(cudaError_t, eventSynchronize, (cudaEvent_t event), (override));
 
   // Error handling
   MOCK_METHOD(const char*, getErrorString, (cudaError_t error), (override));


### PR DESCRIPTION
Summary:
Remove per-collective CUDA event creation from core `McclWork`. Stream-backed work retains the caller-owned submission stream for direct waits and exposes immediately known asynchronous errors, while CPU-flag work keeps host completion polling.

Move exact per-operation completion event ownership to `TorchWorkMCCL`. TorchComm records the event after enqueue and uses it for cross-stream waits, host waits, event-first watchdog polling, result and timeout publication, and CUDA graph ordering. Captured work remains outside the eager watchdog queue.

Use explicit host/GPU construction and serialized terminal publication so CPU collectives, reconfigure, and PAFT retain their existing behavior. Direct MCCL and NCCL-adapter users avoid the per-collective CUDA event overhead.

Differential Revision: D113848783


