### PR TITLE
Rename device pipes backend to prims (#3475)

### DIFF
--- a/comms/torchcomms/RegisteredBuffer.hpp
+++ b/comms/torchcomms/RegisteredBuffer.hpp
@@ -24,7 +24,7 @@ namespace torch::comms {
 
 // Maximum number of IBGDA NICs per GPU surfaced through RegisteredBuffer.
 // Must match NCCLX_MAX_NICS_PER_GPU in nccl.h and comms::prims::kMaxNicsPerGpu
-// — verified by static_assert at the bridge layer (PipesDeviceBackend.cpp,
+// — verified by static_assert at the bridge layer (PrimsDeviceBackend.cpp,
 // the only translation unit that pulls in all three headers). Increase
 // only if a future platform supports > 2 NICs per GPU; update all three
 // constants in lockstep.
@@ -43,7 +43,7 @@ struct RegisteredBuffer {
   size_t size{0};
   void* backend_window{
       nullptr}; // Backend-specific window handle (e.g., ncclWindow_t)
-  // Per-NIC RDMA local keys for IBGDA puts (PipesDeviceBackend). One entry
+  // Per-NIC RDMA local keys for IBGDA puts (PrimsDeviceBackend). One entry
   // per NIC up to kMaxNicsPerGpu; the device-side put selects
   // lkey_per_device.values[nic] based on the slot. `size` is the actual NIC
   // count populated by the backend (0 for backends that do not use IBGDA,

--- a/comms/torchcomms/device/prims/PrimsDeviceBackend.cpp
+++ b/comms/torchcomms/device/prims/PrimsDeviceBackend.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
-// PipesDeviceBackend - Static method implementations
+// PrimsDeviceBackend - Static method implementations
 
 #if defined(ENABLE_PRIMS)
 
-#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
+#include "comms/torchcomms/device/prims/PrimsDeviceBackend.hpp"
 #include "comms/prims/transport/MultiPeerDeviceHandle.cuh"
 #include "comms/prims/transport/rdma/NicConstants.h"
 #include "comms/torchcomms/device/DeviceBackendTraits.hpp"
@@ -19,9 +19,9 @@ namespace torchcomms::device {
 
 using torch::comms::RegisteredBuffer;
 
-// PipesDeviceBackend is the bridge layer where torchcomms, ncclx, and
-// pipes per-NIC IBGDA constants meet. Verify they all agree at compile
-// time so RegisteredBuffer.hpp can stay free of NCCLx and pipes deps.
+// PrimsDeviceBackend is the bridge layer where torchcomms, ncclx, and
+// Prims per-NIC IBGDA constants meet. Verify they all agree at compile
+// time so RegisteredBuffer.hpp can stay free of NCCLx and Prims deps.
 static_assert(
     NCCLX_MAX_NICS_PER_GPU == ::comms::prims::kMaxNicsPerGpu,
     "NCCLX_MAX_NICS_PER_GPU must match comms::prims::kMaxNicsPerGpu");
@@ -33,25 +33,25 @@ static_assert(
 // DeviceWindowDeleter Implementation
 // =============================================================================
 
-void PipesDeviceBackend::DeviceWindowDeleter::operator()(
-    TorchCommDeviceWindow<PipesDeviceBackend>* ptr) const {
+void PrimsDeviceBackend::DeviceWindowDeleter::operator()(
+    TorchCommDeviceWindow<PrimsDeviceBackend>* ptr) const {
   if (cuda_api == nullptr) {
     return;
   }
-  // Destroy the Pipes DeviceWindow via the ncclx API.
+  // Destroy the Prims DeviceWindow via the ncclx API.
   // This mirrors the error-cleanup paths in create_device_window() and
   // ensures ncclx internal state (CtranWin, HostWindow) is properly torn down.
-  if (pipes_device_window != nullptr && nccl_api != nullptr) {
-    auto result = nccl_api->winDestroyDeviceWin(pipes_device_window);
+  if (prims_device_window != nullptr && nccl_api != nullptr) {
+    auto result = nccl_api->winDestroyDeviceWin(prims_device_window);
     if (result != ncclSuccess) {
-      TC_LOG(ERROR) << "[PipesDeviceBackend]: winDestroyDeviceWin failed "
+      TC_LOG(ERROR) << "[PrimsDeviceBackend]: winDestroyDeviceWin failed "
                     << "during cleanup";
     }
   }
   // Free the TorchCommDeviceWindow struct in device memory.
   if (ptr != nullptr) {
     CUDA_CHECK_IGNORE(
-        cuda_api, cuda_api->free(ptr), "Failed to free Pipes device window");
+        cuda_api, cuda_api->free(ptr), "Failed to free Prims device window");
   }
 }
 
@@ -59,7 +59,7 @@ void PipesDeviceBackend::DeviceWindowDeleter::operator()(
 // create_device_window Implementation
 // =============================================================================
 
-PipesDeviceBackend::Ptr PipesDeviceBackend::create_device_window(
+PrimsDeviceBackend::Ptr PrimsDeviceBackend::create_device_window(
     ncclComm_t /* nccl_comm */,
     torch::comms::NcclxApi* nccl_api,
     torch::comms::CudaApi* cuda_api,
@@ -69,60 +69,60 @@ PipesDeviceBackend::Ptr PipesDeviceBackend::create_device_window(
     size_t size) {
   if (nccl_api == nullptr) {
     throw std::runtime_error(
-        "[PipesDeviceBackend::create_device_window]: nccl_api cannot be null");
+        "[PrimsDeviceBackend::create_device_window]: nccl_api cannot be null");
   }
   if (nccl_win == nullptr) {
     throw std::runtime_error(
-        "[PipesDeviceBackend::create_device_window]: nccl_win cannot be null");
+        "[PrimsDeviceBackend::create_device_window]: nccl_win cannot be null");
   }
   if (cuda_api == nullptr) {
     throw std::runtime_error(
-        "[PipesDeviceBackend::create_device_window]: cuda_api cannot be null");
+        "[PrimsDeviceBackend::create_device_window]: cuda_api cannot be null");
   }
 
-  // Step 1: Create the Pipes DeviceWindow in device memory via ncclx.
+  // Step 1: Create the Prims DeviceWindow in device memory via ncclx.
   // COLLECTIVE on first call — all ranks must call together.
-  void* pipes_device_win = nullptr;
+  void* prims_device_win = nullptr;
   auto nccl_result = nccl_api->winCreateDeviceWin(
       nccl_win,
       config.signal_count,
       config.counter_count,
       config.barrier_count,
-      &pipes_device_win);
+      &prims_device_win);
   if (nccl_result != ncclSuccess) {
     throw std::runtime_error(
-        "[PipesDeviceBackend::create_device_window]: "
+        "[PrimsDeviceBackend::create_device_window]: "
         "winCreateDeviceWin failed");
   }
 
-  // Step 2: Build TorchCommDeviceWindow<PipesDeviceBackend> on host.
-  // comm_ = nullptr (unused for Pipes; no separate communicator handle)
+  // Step 2: Build TorchCommDeviceWindow<PrimsDeviceBackend> on host.
+  // comm_ = nullptr (unused for Prims; no separate communicator handle)
   // window_ = typed device pointer to DeviceWindow
-  auto* device_win = static_cast<comms::prims::DeviceWindow*>(pipes_device_win);
-  TorchCommDeviceWindow<PipesDeviceBackend> host_dev_window(
-      nullptr, // Comm = void*, unused for Pipes
+  auto* device_win = static_cast<comms::prims::DeviceWindow*>(prims_device_win);
+  TorchCommDeviceWindow<PrimsDeviceBackend> host_dev_window(
+      nullptr, // Comm = void*, unused for Prims
       device_win, // Window = DeviceWindow*, device pointer
       base,
       size,
       config.comm_rank,
       config.comm_size,
-      0 /* signal_buffer_handle, unused for Pipes */);
+      0 /* signal_buffer_handle, unused for Prims */);
 
   // Step 3: Allocate device memory for the TorchCommDeviceWindow struct.
-  TorchCommDeviceWindow<PipesDeviceBackend>* device_ptr = nullptr;
+  TorchCommDeviceWindow<PrimsDeviceBackend>* device_ptr = nullptr;
   cudaError_t cuda_result = cuda_api->malloc(
       reinterpret_cast<void**>(&device_ptr),
-      sizeof(TorchCommDeviceWindow<PipesDeviceBackend>));
+      sizeof(TorchCommDeviceWindow<PrimsDeviceBackend>));
   if (cuda_result != cudaSuccess) {
-    // Clean up Pipes DeviceWindow on failure.
+    // Clean up Prims DeviceWindow on failure.
     // NOLINTNEXTLINE(facebook-hte-NullableDereference)
-    auto destroy_result = nccl_api->winDestroyDeviceWin(pipes_device_win);
+    auto destroy_result = nccl_api->winDestroyDeviceWin(prims_device_win);
     if (destroy_result != ncclSuccess) {
-      TC_LOG(ERROR) << "[PipesDeviceBackend]: Failed to clean up Pipes device "
+      TC_LOG(ERROR) << "[PrimsDeviceBackend]: Failed to clean up Prims device "
                     << "window after malloc failure";
     }
     throw std::runtime_error(
-        "[PipesDeviceBackend::create_device_window]: Failed to allocate "
+        "[PrimsDeviceBackend::create_device_window]: Failed to allocate "
         "device memory for TorchCommDeviceWindow. CUDA error: " +
         std::string(cuda_api->getErrorString(cuda_result)));
   }
@@ -132,7 +132,7 @@ PipesDeviceBackend::Ptr PipesDeviceBackend::create_device_window(
   cuda_result = cuda_api->memcpy(
       device_ptr,
       &host_dev_window,
-      sizeof(TorchCommDeviceWindow<PipesDeviceBackend>),
+      sizeof(TorchCommDeviceWindow<PrimsDeviceBackend>),
       cudaMemcpyHostToDevice);
   if (cuda_result != cudaSuccess) {
     // NOLINTNEXTLINE(facebook-hte-NullableDereference)
@@ -141,18 +141,18 @@ PipesDeviceBackend::Ptr PipesDeviceBackend::create_device_window(
         cuda_api->free(device_ptr),
         "Failed to free device window during error cleanup");
     // NOLINTNEXTLINE(facebook-hte-NullableDereference)
-    auto destroy_result = nccl_api->winDestroyDeviceWin(pipes_device_win);
+    auto destroy_result = nccl_api->winDestroyDeviceWin(prims_device_win);
     if (destroy_result != ncclSuccess) {
-      TC_LOG(ERROR) << "[PipesDeviceBackend]: Failed to clean up Pipes device "
+      TC_LOG(ERROR) << "[PrimsDeviceBackend]: Failed to clean up Prims device "
                     << "window after memcpy failure";
     }
     throw std::runtime_error(
-        "[PipesDeviceBackend::create_device_window]: Failed to copy "
+        "[PrimsDeviceBackend::create_device_window]: Failed to copy "
         "TorchCommDeviceWindow to device memory. CUDA error: " +
         std::string(cuda_api->getErrorString(cuda_result)));
   }
 
-  DeviceWindowDeleter deleter(nccl_api, cuda_api, pipes_device_win);
+  DeviceWindowDeleter deleter(nccl_api, cuda_api, prims_device_win);
   return Ptr(device_ptr, deleter);
 }
 
@@ -160,26 +160,26 @@ PipesDeviceBackend::Ptr PipesDeviceBackend::create_device_window(
 // register_local_buffer / deregister_local_buffer Implementation
 // =============================================================================
 
-RegisteredBuffer PipesDeviceBackend::register_local_buffer(
+RegisteredBuffer PrimsDeviceBackend::register_local_buffer(
     torch::comms::NcclxApi* nccl_api,
     ncclComm_t nccl_comm,
     void* ptr,
     size_t size) {
-  // Pipes (IBGDA) put uses per-NIC lkeys for WQE construction during RDMA
+  // Prims (IBGDA) put uses per-NIC lkeys for WQE construction during RDMA
   // writes. The kernel-side put selects lkeys[nic] based on the slot it
   // dispatches on, so the full per-NIC array must be populated (using only
   // [0] would corrupt WQEs for slots landing on NIC[1..N-1] on multi-NIC HW).
   // ABI returns into a C struct (ncclLkeyPerDevice) which we field-copy
   // into the C++ wrapper (LkeyPerDevice) so the caller-visible
   // RegisteredBuffer.lkey_per_device gets bounds-checked operator[] and a
-  // populated `size` field. backend_window is unused by Pipes — only the
+  // populated `size` field. backend_window is unused by Prims — only the
   // GIN backend needs it.
   RegisteredBuffer buf;
   ncclLkeyPerDevice raw{};
   auto result = nccl_api->winLocalRegisterBuffer(nccl_comm, ptr, size, &raw);
   if (result != ncclSuccess) {
     throw std::runtime_error(
-        "[PipesDeviceBackend::register_local_buffer]: "
+        "[PrimsDeviceBackend::register_local_buffer]: "
         "winLocalRegisterBuffer failed");
   }
   buf.lkey_per_device.size = raw.size;
@@ -192,7 +192,7 @@ RegisteredBuffer PipesDeviceBackend::register_local_buffer(
   return buf;
 }
 
-void PipesDeviceBackend::deregister_local_buffer(
+void PrimsDeviceBackend::deregister_local_buffer(
     torch::comms::NcclxApi* nccl_api,
     ncclComm_t nccl_comm,
     RegisteredBuffer& buf) {
@@ -201,7 +201,7 @@ void PipesDeviceBackend::deregister_local_buffer(
   }
   auto result = nccl_api->winLocalDeregisterBuffer(nccl_comm, buf.base_ptr);
   if (result != ncclSuccess) {
-    TC_LOG(ERROR) << "[PipesDeviceBackend]: Failed to deregister local buffer";
+    TC_LOG(ERROR) << "[PrimsDeviceBackend]: Failed to deregister local buffer";
   }
   buf = RegisteredBuffer{};
 }
@@ -210,7 +210,7 @@ void PipesDeviceBackend::deregister_local_buffer(
 // fetch_transport_handle Implementation
 // =============================================================================
 
-comms::prims::MultiPeerDeviceHandle PipesDeviceBackend::fetch_transport_handle(
+comms::prims::MultiPeerDeviceHandle PrimsDeviceBackend::fetch_transport_handle(
     ncclComm_t nccl_comm,
     torch::comms::NcclxApi* nccl_api) {
   void* transports_ptr = nullptr;
@@ -229,7 +229,7 @@ comms::prims::MultiPeerDeviceHandle PipesDeviceBackend::fetch_transport_handle(
 
   if (result != ncclSuccess) {
     throw std::runtime_error(
-        "[PipesDeviceBackend::fetch_transport_handle] "
+        "[PrimsDeviceBackend::fetch_transport_handle] "
         "Failed to get MultiPeerDeviceHandle. "
         "Ensure NCCL_CTRAN_USE_PIPES=1 is set.");
   }
@@ -249,7 +249,7 @@ comms::prims::MultiPeerDeviceHandle PipesDeviceBackend::fetch_transport_handle(
 // TransportHandleDeleter Implementation
 // =============================================================================
 
-void PipesDeviceBackend::TransportHandleDeleter::operator()(void* ptr) const {
+void PrimsDeviceBackend::TransportHandleDeleter::operator()(void* ptr) const {
   if (ptr != nullptr && cuda_api != nullptr) {
     CUDA_CHECK_IGNORE(
         cuda_api, cuda_api->free(ptr), "Failed to free transport handle");
@@ -260,14 +260,14 @@ void PipesDeviceBackend::TransportHandleDeleter::operator()(void* ptr) const {
 // get_device_transport Implementation
 // =============================================================================
 
-PipesDeviceBackend::TransportHandleDevPtr
-PipesDeviceBackend::get_device_transport(
+PrimsDeviceBackend::TransportHandleDevPtr
+PrimsDeviceBackend::get_device_transport(
     ncclComm_t nccl_comm,
     torch::comms::NcclxApi* nccl_api,
     torch::comms::CudaApi* cuda_api) {
   if (nccl_api == nullptr || cuda_api == nullptr) {
     throw std::runtime_error(
-        "[PipesDeviceBackend::get_device_transport]: "
+        "[PrimsDeviceBackend::get_device_transport]: "
         "nccl_api and cuda_api must not be null");
   }
 
@@ -280,7 +280,7 @@ PipesDeviceBackend::get_device_transport(
       &device_ptr, sizeof(comms::prims::MultiPeerDeviceHandle));
   if (err != cudaSuccess) {
     throw std::runtime_error(
-        "[PipesDeviceBackend::get_device_transport]: "
+        "[PrimsDeviceBackend::get_device_transport]: "
         "cudaMalloc failed: " +
         std::string(cuda_api->getErrorString(err)));
   }
@@ -298,7 +298,7 @@ PipesDeviceBackend::get_device_transport(
         cuda_api->free(device_ptr),
         "Failed to free transport handle during error cleanup");
     throw std::runtime_error(
-        "[PipesDeviceBackend::get_device_transport]: "
+        "[PrimsDeviceBackend::get_device_transport]: "
         "cudaMemcpy failed: " +
         std::string(cuda_api->getErrorString(err)));
   }

--- a/comms/torchcomms/device/prims/PrimsDeviceBackend.hpp
+++ b/comms/torchcomms/device/prims/PrimsDeviceBackend.hpp
@@ -1,11 +1,11 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
-// TorchComms Device API - Pipes Backend Traits
+// TorchComms Device API - Prims Backend Traits
 //
-// Defines the PipesDeviceBackend trait type for compile-time polymorphism
-// in TorchCommDeviceWindow. Uses Pipes IBGDA and NVLink transports via the
+// Defines the PrimsDeviceBackend trait type for compile-time polymorphism
+// in TorchCommDeviceWindow. Uses Prims IBGDA and NVLink transports via the
 // ctran window infrastructure (accessed through opaque ncclx APIs).
 //
-// This backend replaces GIN (GPU Initiated Networking) with Pipes for
+// This backend replaces GIN (GPU Initiated Networking) with Prims for
 // device-side P2P operations:
 //   - NVLink peers (same node): direct memcpy with NVLink-mapped pointers
 //   - IBGDA peers (cross-node): RDMA writes via DOCA GPUNetIO
@@ -45,20 +45,20 @@ template <typename Backend>
 class TorchCommDeviceWindow;
 
 // =============================================================================
-// PipesDeviceBackend - IBGDA + NVLink backend
+// PrimsDeviceBackend - IBGDA + NVLink backend
 // =============================================================================
 //
 // Types:
-//   - Comm:   void* — unused for Pipes (no separate communicator handle).
+//   - Comm:   void* — unused for Prims (no separate communicator handle).
 //   - Window: comms::prims::DeviceWindow* — typed device pointer to the
 //             transport window allocated by ncclx via winCreateDeviceWin().
 
-struct PipesDeviceBackend {
-  // Comm is unused for Pipes: there is no separate communicator handle.
+struct PrimsDeviceBackend {
+  // Comm is unused for Prims: there is no separate communicator handle.
   // Set to nullptr in the TorchCommDeviceWindow constructor.
   using Comm = void*;
 
-  // Typed device pointer to the Pipes DeviceWindow. Device-side code accesses
+  // Typed device pointer to the Prims DeviceWindow. Device-side code accesses
   // transport handles, NVLink-mapped remote pointers, and IBGDA descriptors
   // directly through this pointer without casting.
   using Window = comms::prims::DeviceWindow*;
@@ -67,7 +67,7 @@ struct PipesDeviceBackend {
   // DeviceWindowDeleter - Custom deleter for device window cleanup
   // =========================================================================
   //
-  // Frees both the TorchCommDeviceWindow<PipesDeviceBackend> struct in device
+  // Frees both the TorchCommDeviceWindow<PrimsDeviceBackend> struct in device
   // memory AND the separate DeviceWindow allocation.
   struct DeviceWindowDeleter {
     torch::comms::NcclxApi* nccl_api{nullptr};
@@ -76,7 +76,7 @@ struct PipesDeviceBackend {
     // winCreateDeviceWin(). Must be freed via winDestroyDeviceWin() since
     // it cannot be reached through ptr from host code (ptr is in device
     // memory).
-    void* pipes_device_window{nullptr};
+    void* prims_device_window{nullptr};
 
     DeviceWindowDeleter() = default;
     DeviceWindowDeleter(
@@ -85,13 +85,13 @@ struct PipesDeviceBackend {
         void* win_dev)
         : nccl_api(nccl_api),
           cuda_api(cuda_api),
-          pipes_device_window(win_dev) {}
+          prims_device_window(win_dev) {}
 
-    void operator()(TorchCommDeviceWindow<PipesDeviceBackend>* ptr) const;
+    void operator()(TorchCommDeviceWindow<PrimsDeviceBackend>* ptr) const;
   };
 
   using Ptr = std::unique_ptr<
-      TorchCommDeviceWindow<PipesDeviceBackend>,
+      TorchCommDeviceWindow<PrimsDeviceBackend>,
       DeviceWindowDeleter>;
 
   // Create fully initialized device window struct in DEVICE memory.
@@ -103,7 +103,7 @@ struct PipesDeviceBackend {
   // winCreateDeviceWin() performs an allGather internally.
   //
   // Signature matches NCCLDeviceBackend::create_device_window for unified
-  // call sites. nccl_comm is unused for Pipes (no separate communicator).
+  // call sites. nccl_comm is unused for Prims (no separate communicator).
   //
   // Parameters:
   //   - nccl_comm:  NCCL communicator (unused, for API consistency with GIN)
@@ -136,7 +136,7 @@ struct PipesDeviceBackend {
   // Backend-specific hooks called from TorchCommWindowNCCLX
   // =========================================================================
 
-  // No additional window registration needed for Pipes.
+  // No additional window registration needed for Prims.
   static void register_extra_window(
       torch::comms::NcclxApi*,
       ncclComm_t,
@@ -144,19 +144,19 @@ struct PipesDeviceBackend {
       void*,
       size_t) {}
 
-  // No additional window to deregister for Pipes.
+  // No additional window to deregister for Prims.
   static void
   deregister_extra_window(torch::comms::NcclxApi*, ncclComm_t, NcclWin*) {}
 
-  // Pipes deleter handles all cleanup via winDestroyDeviceWin.
+  // Prims deleter handles all cleanup via winDestroyDeviceWin.
   static void destroy_device_comm(Ptr&) {}
 
-  // Pipes uses the regular ctran window for device window creation.
+  // Prims uses the regular ctran window for device window creation.
   static NcclWin select_device_win(NcclWin win, NcclWin /* nccl_orig_win */) {
     return win;
   }
 
-  // Register a local buffer for device-side put operations (Pipes/IBGDA path).
+  // Register a local buffer for device-side put operations (Prims/IBGDA path).
   // Uses MultiPeerTransport::localRegisterIbgdaBuffer for non-collective
   // local memory registration. Returns RegisteredBuffer with lkey.
   static torch::comms::RegisteredBuffer register_local_buffer(
@@ -165,7 +165,7 @@ struct PipesDeviceBackend {
       void* ptr,
       size_t size);
 
-  // Deregister a previously registered local buffer (Pipes/IBGDA path).
+  // Deregister a previously registered local buffer (Prims/IBGDA path).
   static void deregister_local_buffer(
       torch::comms::NcclxApi* nccl_api,
       ncclComm_t nccl_comm,
@@ -191,14 +191,14 @@ struct PipesDeviceBackend {
       torch::comms::CudaApi* cuda_api);
 
  private:
-  // Get the pipes transport device handle from the communicator.
+  // Get the Prims transport device handle from the communicator.
   // NON-COLLECTIVE — reads already-exchanged state.
   //
   // Returns a MultiPeerDeviceHandle by value. The handle contains a
   // device pointer to the Transport[] array (already GPU-allocated by
   // MultiPeerTransport::exchange() during ctran init).
   //
-  // Throws std::runtime_error if pipes transport is not initialized.
+  // Throws std::runtime_error if Prims transport is not initialized.
   static comms::prims::MultiPeerDeviceHandle fetch_transport_handle(
       ncclComm_t nccl_comm,
       torch::comms::NcclxApi* nccl_api);

--- a/comms/torchcomms/device/prims/TorchCommDevicePrims.cuh
+++ b/comms/torchcomms/device/prims/TorchCommDevicePrims.cuh
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
-// TorchComms Device API - Pipes Backend Implementation (IBGDA + NVLink)
+// TorchComms Device API - Prims Backend Implementation (IBGDA + NVLink)
 //
-// Device-side implementations for TorchComms using Pipes:
+// Device-side implementations for TorchComms using Prims:
 //   - NVLink peers: direct vectorized memcpy via NVLink-mapped pointers
 //   - IBGDA peers: RDMA Write via DOCA GPUNetIO (P2pIbgdaTransportDevice)
 //   - SELF: NVLink local copy
@@ -20,7 +20,7 @@
 #if defined(ENABLE_PRIMS)
 
 #ifndef __CUDACC__
-#error "TorchCommDevicePipes.cuh must be compiled with nvcc."
+#error "TorchCommDevicePrims.cuh must be compiled with nvcc."
 #endif
 
 #include <cuda_runtime.h>
@@ -32,8 +32,8 @@
 #include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
 #include "comms/prims/transport/nvl/P2pNvlTransportDevice.cuh"
 #include "comms/prims/window/DeviceWindow.cuh"
-#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
-#include "comms/torchcomms/device/pipes/TorchCommDevicePipesTypes.hpp"
+#include "comms/torchcomms/device/prims/PrimsDeviceBackend.hpp"
+#include "comms/torchcomms/device/prims/TorchCommDevicePrimsTypes.hpp"
 
 namespace torchcomms::device {
 
@@ -43,14 +43,14 @@ namespace torchcomms::device {
 
 namespace detail {
 
-// Map TorchComms SignalOp to Pipes SignalOp.
-__device__ inline comms::prims::SignalOp to_pipes_signal_op(SignalOp op) {
+// Map TorchComms SignalOp to Prims SignalOp.
+__device__ inline comms::prims::SignalOp to_prims_signal_op(SignalOp op) {
   return (op == SignalOp::ADD) ? comms::prims::SignalOp::SIGNAL_ADD
                                : comms::prims::SignalOp::SIGNAL_SET;
 }
 
-// Map TorchComms CmpOp to Pipes CmpOp.
-__device__ inline comms::prims::CmpOp to_pipes_cmp_op(CmpOp cmp) {
+// Map TorchComms CmpOp to Prims CmpOp.
+__device__ inline comms::prims::CmpOp to_prims_cmp_op(CmpOp cmp) {
   switch (cmp) {
     case CmpOp::EQ:
       return comms::prims::CmpOp::CMP_EQ;
@@ -68,8 +68,8 @@ __device__ inline comms::prims::CmpOp to_pipes_cmp_op(CmpOp cmp) {
   return comms::prims::CmpOp::CMP_GE;
 }
 
-// Build a pipes::ThreadGroup for the given CoopScope.
-__device__ inline comms::prims::ThreadGroup make_pipes_thread_group(
+// Build a Prims ThreadGroup for the given CoopScope.
+__device__ inline comms::prims::ThreadGroup make_prims_thread_group(
     CoopScope scope) {
   switch (scope) {
     case CoopScope::WARP:
@@ -85,7 +85,7 @@ __device__ inline comms::prims::ThreadGroup make_pipes_thread_group(
 } // namespace detail
 
 // =============================================================================
-// TorchCommDeviceWindow<PipesDeviceBackend> Signal Operations
+// TorchCommDeviceWindow<PrimsDeviceBackend> Signal Operations
 // =============================================================================
 //
 // Delegates to comms::prims::DeviceWindow::signal_peer() which handles
@@ -93,30 +93,30 @@ __device__ inline comms::prims::ThreadGroup make_pipes_thread_group(
 // by (peer, signal_id) pairs.
 
 template <>
-__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::signal(
+__device__ inline int TorchCommDeviceWindow<PrimsDeviceBackend>::signal(
     int peer,
     int signal_id,
     SignalOp op,
     uint64_t value,
     CoopScope scope) {
   auto& win = *window_;
-  auto pipes_op = detail::to_pipes_signal_op(op);
+  auto prims_op = detail::to_prims_signal_op(op);
 
   if (scope == CoopScope::THREAD) {
-    win.signal_peer(peer, signal_id, pipes_op, value);
+    win.signal_peer(peer, signal_id, prims_op, value);
   } else {
-    auto group = detail::make_pipes_thread_group(scope);
-    win.signal_peer(group, peer, signal_id, pipes_op, value);
+    auto group = detail::make_prims_thread_group(scope);
+    win.signal_peer(group, peer, signal_id, prims_op, value);
   }
   return 0;
 }
 
 // =============================================================================
-// TorchCommDeviceWindow<PipesDeviceBackend> RMA Operations
+// TorchCommDeviceWindow<PrimsDeviceBackend> RMA Operations
 // =============================================================================
 
 template <>
-__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::put(
+__device__ inline int TorchCommDeviceWindow<PrimsDeviceBackend>::put(
     size_t dst_offset,
     const torch::comms::RegisteredBuffer& src_buf,
     size_t src_offset,
@@ -126,23 +126,23 @@ __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::put(
     int counter_id,
     CoopScope scope) {
   auto& win = *window_;
-  auto group = detail::make_pipes_thread_group(scope);
+  auto group = detail::make_prims_thread_group(scope);
 
-  // Build Pipes LocalBufferRegistration from RegisteredBuffer.
-  // Pipes uses per-NIC lkeys (IBGDA local keys); GIN uses backend_window.
+  // Build Prims LocalBufferRegistration from RegisteredBuffer.
+  // Prims uses per-NIC lkeys (IBGDA local keys); GIN uses backend_window.
   // The kernel-side put selects lkeys[nic] based on slot dispatch, so all
   // per-NIC keys must be forwarded — partial population would leave
   // NIC[1..size-1] keys zero and corrupt WQEs on multi-NIC HW.
   // Loop bounded by src_buf.lkey_per_device.size (the populated NIC count
   // returned by the backend); on a 1-NIC host only slot 0 is read.
   const int numNics = src_buf.lkey_per_device.size;
-  ::comms::prims::NetworkLKeys pipes_lkeys(numNics);
+  ::comms::prims::NetworkLKeys prims_lkeys(numNics);
   for (int n = 0; n < numNics; ++n) {
-    pipes_lkeys[n] =
+    prims_lkeys[n] =
         ::comms::prims::NetworkLKey{src_buf.lkey_per_device.values[n]};
   }
-  ::comms::prims::LocalBufferRegistration pipes_src{
-      src_buf.base_ptr, src_buf.size, pipes_lkeys};
+  ::comms::prims::LocalBufferRegistration prims_src{
+      src_buf.base_ptr, src_buf.size, prims_lkeys};
 
   bool has_signal = signal_id >= 0;
   bool has_counter = counter_id >= 0;
@@ -152,7 +152,7 @@ __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::put(
         group,
         dst_rank,
         dst_offset,
-        pipes_src,
+        prims_src,
         src_offset,
         bytes,
         signal_id,
@@ -164,7 +164,7 @@ __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::put(
         group,
         dst_rank,
         dst_offset,
-        pipes_src,
+        prims_src,
         src_offset,
         bytes,
         signal_id,
@@ -174,53 +174,53 @@ __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::put(
         group,
         dst_rank,
         dst_offset,
-        pipes_src,
+        prims_src,
         src_offset,
         bytes,
         counter_id,
         /*counterVal=*/1);
   } else {
-    win.put(group, dst_rank, dst_offset, pipes_src, src_offset, bytes);
+    win.put(group, dst_rank, dst_offset, prims_src, src_offset, bytes);
   }
 
   return 0;
 }
 
 // =============================================================================
-// TorchCommDeviceWindow<PipesDeviceBackend> Wait Signal Operations
+// TorchCommDeviceWindow<PrimsDeviceBackend> Wait Signal Operations
 // =============================================================================
 
 template <>
-__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::wait_signal(
+__device__ inline int TorchCommDeviceWindow<PrimsDeviceBackend>::wait_signal(
     int signal_id,
     CmpOp cmp,
     uint64_t value,
     CoopScope scope) {
   auto& win = *window_;
-  auto pipes_cmp = detail::to_pipes_cmp_op(cmp);
-  auto group = detail::make_pipes_thread_group(scope);
-  win.wait_signal(group, signal_id, pipes_cmp, value);
+  auto prims_cmp = detail::to_prims_cmp_op(cmp);
+  auto group = detail::make_prims_thread_group(scope);
+  win.wait_signal(group, signal_id, prims_cmp, value);
   return 0;
 }
 
 template <>
 __device__ inline int
-TorchCommDeviceWindow<PipesDeviceBackend>::wait_signal_from(
+TorchCommDeviceWindow<PrimsDeviceBackend>::wait_signal_from(
     int peer,
     int signal_id,
     CmpOp cmp,
     uint64_t value,
     CoopScope scope) {
   auto& win = *window_;
-  auto pipes_cmp = detail::to_pipes_cmp_op(cmp);
-  auto group = detail::make_pipes_thread_group(scope);
-  win.wait_signal_from(group, peer, signal_id, pipes_cmp, value);
+  auto prims_cmp = detail::to_prims_cmp_op(cmp);
+  auto group = detail::make_prims_thread_group(scope);
+  win.wait_signal_from(group, peer, signal_id, prims_cmp, value);
   return 0;
 }
 
 template <>
 __device__ inline uint64_t
-TorchCommDeviceWindow<PipesDeviceBackend>::read_signal(int signal_id) const {
+TorchCommDeviceWindow<PrimsDeviceBackend>::read_signal(int signal_id) const {
   // window_ is DeviceWindow* (not const), so dereference works in const
   // methods. DeviceWindow::read_signal() only reads inbox values despite being
   // non-const.
@@ -229,10 +229,10 @@ TorchCommDeviceWindow<PipesDeviceBackend>::read_signal(int signal_id) const {
 }
 
 template <>
-__device__ inline void TorchCommDeviceWindow<PipesDeviceBackend>::reset_signal(
+__device__ inline void TorchCommDeviceWindow<PrimsDeviceBackend>::reset_signal(
     int signal_id,
     CoopScope scope) {
-  // Pipes DeviceWindow does not support device-side signal reset.
+  // Prims DeviceWindow does not support device-side signal reset.
   // Use monotonically increasing signal values, or reset from host side.
   (void)signal_id;
   (void)scope;
@@ -240,7 +240,7 @@ __device__ inline void TorchCommDeviceWindow<PipesDeviceBackend>::reset_signal(
 }
 
 // =============================================================================
-// TorchCommDeviceWindow<PipesDeviceBackend> Counter Operations
+// TorchCommDeviceWindow<PrimsDeviceBackend> Counter Operations
 // =============================================================================
 // Counters use companion RDMA QP loopback atomic signaling for NIC completion
 // tracking. read_counter/reset_counter must precede wait_counter (which calls
@@ -248,7 +248,7 @@ __device__ inline void TorchCommDeviceWindow<PipesDeviceBackend>::reset_signal(
 
 template <>
 __device__ inline uint64_t
-TorchCommDeviceWindow<PipesDeviceBackend>::read_counter(int counter_id) const {
+TorchCommDeviceWindow<PrimsDeviceBackend>::read_counter(int counter_id) const {
   // Sum the counter across all peers (aggregate model).
   auto& win = *window_;
   int nPeers = win.num_peers();
@@ -261,10 +261,10 @@ TorchCommDeviceWindow<PipesDeviceBackend>::read_counter(int counter_id) const {
 }
 
 template <>
-__device__ inline void TorchCommDeviceWindow<PipesDeviceBackend>::reset_counter(
+__device__ inline void TorchCommDeviceWindow<PrimsDeviceBackend>::reset_counter(
     int counter_id,
     CoopScope scope) {
-  auto group = detail::make_pipes_thread_group(scope);
+  auto group = detail::make_prims_thread_group(scope);
   group.sync();
 
   if (group.is_leader()) {
@@ -278,12 +278,12 @@ __device__ inline void TorchCommDeviceWindow<PipesDeviceBackend>::reset_counter(
 }
 
 template <>
-__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::wait_counter(
+__device__ inline int TorchCommDeviceWindow<PrimsDeviceBackend>::wait_counter(
     int counter_id,
     CmpOp cmp,
     uint64_t value,
     CoopScope scope) {
-  auto group = detail::make_pipes_thread_group(scope);
+  auto group = detail::make_prims_thread_group(scope);
 
   if (group.is_leader()) {
     while (true) {
@@ -320,18 +320,18 @@ __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::wait_counter(
 }
 
 // =============================================================================
-// TorchCommDeviceWindow<PipesDeviceBackend> Synchronization Operations
+// TorchCommDeviceWindow<PrimsDeviceBackend> Synchronization Operations
 // =============================================================================
 
 template <>
-__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::fence() {
+__device__ inline int TorchCommDeviceWindow<PrimsDeviceBackend>::fence() {
   // Compiler barrier: prevents reordering of put() calls across this point.
   asm volatile("" ::: "memory");
   return 0;
 }
 
 template <>
-__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::flush(
+__device__ inline int TorchCommDeviceWindow<PrimsDeviceBackend>::flush(
     CoopScope scope) {
   // flush() = local completion: source buffers are safe to reuse.
   //
@@ -340,7 +340,7 @@ __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::flush(
   //
   // IBGDA: fence() drains each QP by posting a NOP WQE and waiting for
   // completion, ensuring all prior puts have been handed off to the NIC.
-  auto group = detail::make_pipes_thread_group(scope);
+  auto group = detail::make_prims_thread_group(scope);
   group.sync();
 
   auto& win = *window_;
@@ -356,36 +356,36 @@ __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::flush(
 }
 
 template <>
-__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::barrier(
+__device__ inline int TorchCommDeviceWindow<PrimsDeviceBackend>::barrier(
     int barrier_id,
     CoopScope scope) {
   // Delegate to DeviceWindow::barrier() which handles the full
   // arrive + wait protocol across NVL and IBGDA peers.
   auto& win = *window_;
-  auto group = detail::make_pipes_thread_group(scope);
+  auto group = detail::make_prims_thread_group(scope);
   win.barrier(group, barrier_id);
   return 0;
 }
 
 // =============================================================================
-// TorchCommDeviceWindow<PipesDeviceBackend> NVLink Address Query
+// TorchCommDeviceWindow<PrimsDeviceBackend> NVLink Address Query
 // =============================================================================
 
 template <>
 __device__ inline void*
-TorchCommDeviceWindow<PipesDeviceBackend>::get_nvlink_address(int peer) {
+TorchCommDeviceWindow<PrimsDeviceBackend>::get_nvlink_address(int peer) {
   return window_->get_nvlink_address(peer);
 }
 
 // =============================================================================
-// TorchCommDeviceWindow<PipesDeviceBackend> Multimem Address Query
+// TorchCommDeviceWindow<PrimsDeviceBackend> Multimem Address Query
 // =============================================================================
 
 template <>
 __device__ inline void*
-TorchCommDeviceWindow<PipesDeviceBackend>::get_multimem_address(
+TorchCommDeviceWindow<PrimsDeviceBackend>::get_multimem_address(
     size_t /*offset*/) {
-  // Multimem (NVLS multicast) is an NCCL/GIN feature, not available via Pipes.
+  // Multimem (NVLS multicast) is an NCCL/GIN feature, not available via Prims.
   return nullptr;
 }
 

--- a/comms/torchcomms/device/prims/TorchCommDevicePrimsTypes.hpp
+++ b/comms/torchcomms/device/prims/TorchCommDevicePrimsTypes.hpp
@@ -1,11 +1,11 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
-// TorchComms Device API - Pipes Backend Type Definitions
+// TorchComms Device API - Prims Backend Type Definitions
 //
-// Provides type aliases for the Pipes device backend that are safe to include
+// Provides type aliases for the Prims device backend that are safe to include
 // from both CUDA (.cu) and non-CUDA (.cpp/.cc) code compiled with clang.
 //
 // For device-side implementations (IBGDA/NVLink usage), include
-// TorchCommDevicePipes.cuh instead - but ONLY from .cu files compiled with
+// TorchCommDevicePrims.cuh instead - but ONLY from .cu files compiled with
 // nvcc.
 
 #pragma once
@@ -13,7 +13,7 @@
 #if defined(ENABLE_PRIMS)
 
 #include "comms/torchcomms/device/TorchCommDeviceWindow.hpp"
-#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
+#include "comms/torchcomms/device/prims/PrimsDeviceBackend.hpp"
 
 namespace torchcomms::device {
 
@@ -21,8 +21,11 @@ namespace torchcomms::device {
 // Type Aliases (safe for non-CUDA code)
 // =============================================================================
 
-using DeviceWindowPipes = TorchCommDeviceWindow<PipesDeviceBackend>;
-using RegisteredBufferPipes = torch::comms::RegisteredBuffer;
+using DeviceWindowPrims = TorchCommDeviceWindow<PrimsDeviceBackend>;
+using RegisteredBufferPrims = torch::comms::RegisteredBuffer;
+
+using DeviceWindowPipes = DeviceWindowPrims;
+using RegisteredBufferPipes = RegisteredBufferPrims;
 
 } // namespace torchcomms::device
 

--- a/comms/torchcomms/ncclx/CMakeLists.txt
+++ b/comms/torchcomms/ncclx/CMakeLists.txt
@@ -89,14 +89,14 @@ if("$ENV{ENABLE_PRIMS}" STREQUAL "1")
     set(TORCHCOMMS_ENABLE_PRIMS ON)
     message(STATUS "ENABLE_PRIMS=1 set, building with prims support")
     if(TORCHCOMMS_HAS_NCCL_DEVICE_API)
-        file(GLOB TORCHCOMMS_DEVICE_PIPES_SOURCE
-            "comms/torchcomms/device/pipes/*.cpp")
+        file(GLOB TORCHCOMMS_DEVICE_PRIMS_SOURCE
+            "comms/torchcomms/device/prims/*.cpp")
     else()
-        set(TORCHCOMMS_DEVICE_PIPES_SOURCE "")
+        set(TORCHCOMMS_DEVICE_PRIMS_SOURCE "")
     endif()
 else()
     set(TORCHCOMMS_ENABLE_PRIMS OFF)
-    set(TORCHCOMMS_DEVICE_PIPES_SOURCE "")
+    set(TORCHCOMMS_DEVICE_PRIMS_SOURCE "")
     message(STATUS "ENABLE_PRIMS not set, building without prims support")
 endif()
 
@@ -104,7 +104,7 @@ add_library(torchcomms_comms_ncclx MODULE
     ${TORCHCOMMS_NCCLX_SOURCES}
     ${TORCHCOMMS_CUDA_DEVICE_SOURCES}
     ${TORCHCOMMS_DEVICE_NCCLX_SOURCE}
-    ${TORCHCOMMS_DEVICE_PIPES_SOURCE}
+    ${TORCHCOMMS_DEVICE_PRIMS_SOURCE}
     comms/utils/CudaRAII.cc
     comms/utils/GraphCaptureSideStream.cc
 )

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -22,7 +22,7 @@
 #include "comms/utils/CudaRAII.h"
 
 #if defined(ENABLE_PRIMS)
-#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
+#include "comms/torchcomms/device/prims/PrimsDeviceBackend.hpp"
 #endif
 
 namespace torch::comms {
@@ -2160,7 +2160,7 @@ std::shared_ptr<TorchCommWindow> TorchCommNCCLX::new_window(
   std::shared_ptr<TorchCommWindow> win;
 #if defined(ENABLE_PRIMS)
   // Select Pipes backend when NCCL_CTRAN_USE_PIPES is enabled.
-  // Pipes uses ctran IBGDA/NVLink instead of GIN for device-side P2P.
+  // Prims uses ctran IBGDA/NVLink instead of GIN for device-side P2P.
   const char* pipes_env = std::getenv("NCCL_CTRAN_USE_PIPES");
   if (pipes_env != nullptr && std::string_view(pipes_env) == "1") {
     win = std::make_shared<TorchCommWindowNCCLXPipes>(
@@ -2388,7 +2388,7 @@ static const NCCLXRegistration registration{};
 int64_t TorchCommNCCLX::get_device_transport() {
   if (!device_transport_handle_) {
     device_transport_handle_ =
-        torchcomms::device::PipesDeviceBackend::get_device_transport(
+        torchcomms::device::PrimsDeviceBackend::get_device_transport(
             nccl_comm_, nccl_api_.get(), cuda_api_.get());
   }
   return reinterpret_cast<int64_t>(device_transport_handle_.get());

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -26,7 +26,7 @@
 #include "comms/utils/GraphCaptureSideStream.h"
 
 #if defined(ENABLE_PRIMS)
-#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
+#include "comms/torchcomms/device/prims/PrimsDeviceBackend.hpp"
 #endif
 
 namespace torch::comms {
@@ -500,7 +500,7 @@ class TorchCommNCCLX : public TorchCommBackend,
   void attachMemoryHook();
 
 #if defined(ENABLE_PRIMS)
-  torchcomms::device::PipesDeviceBackend::TransportHandleDevPtr
+  torchcomms::device::PrimsDeviceBackend::TransportHandleDevPtr
       device_transport_handle_;
 #endif
 

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #if defined(ENABLE_PRIMS)
-#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
+#include "comms/torchcomms/device/prims/PrimsDeviceBackend.hpp"
 #endif
 
 namespace torch::comms {
@@ -686,7 +686,7 @@ template class TorchCommWindowNCCLX<HostOnlyBackend>;
 // (get_device_window, register_local_buffer) fall back to the base class
 // default that throws "not yet supported".
 #if defined(ENABLE_PRIMS)
-template class TorchCommWindowNCCLX<torchcomms::device::PipesDeviceBackend>;
+template class TorchCommWindowNCCLX<torchcomms::device::PrimsDeviceBackend>;
 #endif
 
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp
@@ -20,8 +20,8 @@
 #endif
 
 #if defined(ENABLE_PRIMS)
-#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
-#include "comms/torchcomms/device/pipes/TorchCommDevicePipesTypes.hpp"
+#include "comms/torchcomms/device/prims/PrimsDeviceBackend.hpp"
+#include "comms/torchcomms/device/prims/TorchCommDevicePrimsTypes.hpp"
 #endif
 
 namespace torch::comms {
@@ -112,7 +112,7 @@ class TorchCommWindowNCCLX : public TorchCommWindow {
   //
   // Backend dispatch:
   //   - NCCLDeviceBackend: NCCL_WIN_DEVICE_API | NCCL_WIN_LOCAL_ONLY
-  //   - PipesDeviceBackend: MultiPeerTransport::localRegisterIbgdaBuffer
+  //   - PrimsDeviceBackend: MultiPeerTransport::localRegisterIbgdaBuffer
   //
   // Prerequisites: Must call tensor_register() then get_device_window() first.
   RegisteredBuffer register_local_buffer(const at::Tensor& tensor) override;
@@ -219,7 +219,7 @@ class TorchCommWindowNCCLX : public TorchCommWindow {
   // D2H copy is needed on deregister — we use the cached host copy.
   std::unordered_map<int64_t, RegisteredBuffer> device_buffer_handles_;
 
-  // No ctran_win_ member needed — Pipes device windows are created
+  // No ctran_win_ member needed — Prims device windows are created
   // on-demand via nccl_api_->winCreateDeviceWin() in get_device_window().
 #endif
 
@@ -242,7 +242,7 @@ using TorchCommWindowNCCLXGin = TorchCommWindowNCCLX<HostOnlyBackend>;
 // Only available when ENABLE_PRIMS is defined (propagated from ctran_lib).
 #if defined(ENABLE_PRIMS)
 using TorchCommWindowNCCLXPipes =
-    TorchCommWindowNCCLX<torchcomms::device::PipesDeviceBackend>;
+    TorchCommWindowNCCLX<torchcomms::device::PrimsDeviceBackend>;
 #endif
 
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommWindowNCCLXPipesTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommWindowNCCLXPipesTest.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
-// Unit tests for TorchCommWindowNCCLX with PipesDeviceBackend.
+// Unit tests for TorchCommWindowNCCLX with PrimsDeviceBackend.
 //
 // These tests verify Pipes-specific error paths without real hardware:
 //   1. register_local_buffer() throws when device window not initialized
@@ -145,7 +145,7 @@ TEST_F(TorchCommWindowNCCLXPipesTest, RegisterLocalBufferSuccess) {
   EXPECT_NO_THROW(win->tensor_register(dst_tensor));
 
   // Mock winCreateDeviceWin to succeed — returns a fake device pointer.
-  // PipesDeviceBackend::create_device_window() calls this, then malloc+memcpy.
+  // PrimsDeviceBackend::create_device_window() calls this, then malloc+memcpy.
   void* fake_pipes_dev_win = reinterpret_cast<void*>(0xBEEF);
   EXPECT_CALL(*nccl_mock_, winCreateDeviceWin(_, _, _, _, _))
       .WillOnce(

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cu
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cu
@@ -7,7 +7,7 @@
 #include "PipesDeviceApiTestKernels.cuh"
 #include "StressTestKernelUtils.cuh"
 
-#include "comms/torchcomms/device/pipes/TorchCommDevicePipes.cuh"
+#include "comms/torchcomms/device/prims/TorchCommDevicePrims.cuh"
 
 // Kernel launch error check for test code.
 #define KERNEL_LAUNCH_CHECK()                        \

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cuh
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cuh
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <cuda_runtime.h>
-#include "comms/torchcomms/device/pipes/TorchCommDevicePipesTypes.hpp"
+#include "comms/torchcomms/device/prims/TorchCommDevicePrimsTypes.hpp"
 
 namespace torchcomms::device::test {
 

--- a/comms/torchcomms/triton/device_transport.h
+++ b/comms/torchcomms/triton/device_transport.h
@@ -6,7 +6,7 @@
 // Compiled to LLVM bitcode with clang for linking with Triton kernels.
 //
 // Handle: void* device pointer to comms::prims::MultiPeerDeviceHandle,
-// allocated by PipesDeviceBackend::create_device_transport().
+// allocated by PrimsDeviceBackend::create_device_transport().
 //
 // All operations use comms::prims::make_block_group() internally —
 // all 128 Triton threads cooperate as one block group.

--- a/comms/torchcomms/triton/device_window.cu
+++ b/comms/torchcomms/triton/device_window.cu
@@ -5,7 +5,7 @@
 // It is compiled TWICE to produce two bitcode files:
 //   - Without USE_PIPES_BACKEND → libdevice_window.bc (GIN/NCCLGinBackend)
 //   - With USE_PIPES_BACKEND    → libdevice_window_pipes.bc
-//   (PipesDeviceBackend)
+//   (PrimsDeviceBackend)
 //
 // All functions in this file use the generic TorchCommDeviceWindow API
 // (win->put(), win->signal(), win->flush(), etc.) and work with both backends.
@@ -27,7 +27,7 @@
 #include <cuda_runtime.h>
 
 #ifdef USE_PIPES_BACKEND
-#include "comms/torchcomms/device/pipes/TorchCommDevicePipes.cuh"
+#include "comms/torchcomms/device/prims/TorchCommDevicePrims.cuh"
 #else
 #include "comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh"
 #endif
@@ -36,7 +36,7 @@ using namespace torchcomms::device;
 using torch::comms::RegisteredBuffer;
 
 #ifdef USE_PIPES_BACKEND
-using DeviceWindow = TorchCommDeviceWindow<PipesDeviceBackend>;
+using DeviceWindow = TorchCommDeviceWindow<PrimsDeviceBackend>;
 #else
 using DeviceWindow = TorchCommDeviceWindow<NCCLGinBackend>;
 #endif
@@ -58,7 +58,7 @@ __device__ int torchcomms_self_copy_block(
   auto* dst = reinterpret_cast<char*>(dst_ptr) + dst_offset;
   auto* src = reinterpret_cast<const char*>(src_ptr) + src_offset;
 #ifdef USE_PIPES_BACKEND
-  auto group = detail::make_pipes_thread_group(CoopScope::BLOCK);
+  auto group = detail::make_prims_thread_group(CoopScope::BLOCK);
 #else
   auto group = detail::make_thread_group(CoopScope::BLOCK);
 #endif


### PR DESCRIPTION
Summary:

Review guide: https://www.internalfb.com/intern/paste/P2450872115/

Reviewer-requested naming cleanup below the FT stack: move the torchcomms device backend implementation from device/pipes to device/prims and rename the backend trait/files/targets. Compatibility aliases such as TorchCommWindowNCCLXPipes remain.

Reviewed By: arttianezhu

Differential Revision: D115016727
