### PR TITLE
Accept AbortDevice in IBRC waits (#3477)

### DIFF
--- a/comms/common/fault_tolerance/Abort.cc
+++ b/comms/common/fault_tolerance/Abort.cc
@@ -15,7 +15,7 @@
 
 namespace comms::fault_tolerance {
 
-Abort::Abort(bool enabled) {
+Abort::Abort(bool enabled, AbortBehavior behavior) : behavior_(behavior) {
   if (!enabled) {
     return;
   }
@@ -185,9 +185,9 @@ void Abort::markAbort(AbortReason newReason) {
       std::memory_order_acquire);
 }
 
-std::shared_ptr<Abort> createAbort(bool enabled) {
+std::shared_ptr<Abort> createAbort(bool enabled, AbortBehavior behavior) {
   if (enabled) {
-    return std::make_shared<Abort>(/*enabled=*/true);
+    return std::make_shared<Abort>(/*enabled=*/true, behavior);
   } else {
     static const std::shared_ptr<Abort> disabled =
         std::make_shared<Abort>(/*enabled=*/false);

--- a/comms/common/fault_tolerance/Abort.h
+++ b/comms/common/fault_tolerance/Abort.h
@@ -17,6 +17,17 @@ enum class AbortReason : int {
   TIMED_OUT = 2,
 };
 
+enum class AbortBehavior : int {
+  SKIP = 0,
+  TRAP = 1,
+};
+
+enum class AbortCheckResult : int {
+  CONTINUE = 0,
+  SKIP = 1,
+  TRAP = 2,
+};
+
 /**
  * Host-owned state shared with CUDA device code through mapped pinned memory.
  *
@@ -87,7 +98,7 @@ class Abort final {
    * host-side state semantics. Disabled controllers are no-op placeholders for
    * callers that must pass an `Abort` object while fault tolerance is disabled.
    */
-  explicit Abort(bool enabled);
+  explicit Abort(bool enabled, AbortBehavior behavior = AbortBehavior::SKIP);
   ~Abort();
   Abort(const Abort&) = delete;
   Abort& operator=(const Abort&) = delete;
@@ -103,6 +114,17 @@ class Abort final {
    */
   inline bool isEnabled() const {
     return state_ != nullptr;
+  }
+
+  /**
+   * Returns the device-side behavior selected for this controller.
+   *
+   * `SKIP` asks device waits to return without trapping when an abort is
+   * observed. `TRAP` asks Prims wait helpers to preserve the legacy device
+   * trap behavior. The behavior is captured into each `AbortDevice` handle.
+   */
+  AbortBehavior behavior() const {
+    return behavior_;
   }
 
   /**
@@ -220,6 +242,7 @@ class Abort final {
   std::atomic<bool> hasTimeout_{false};
   std::atomic<std::chrono::steady_clock::time_point> deadline_{
       std::chrono::steady_clock::time_point{}};
+  AbortBehavior behavior_{AbortBehavior::SKIP};
 
   static_assert(std::atomic<bool>::is_always_lock_free);
   static_assert(
@@ -230,6 +253,8 @@ class Abort final {
  * Creates an enabled abort controller or returns the shared disabled
  * controller.
  */
-std::shared_ptr<Abort> createAbort(bool enabled);
+std::shared_ptr<Abort> createAbort(
+    bool enabled,
+    AbortBehavior behavior = AbortBehavior::SKIP);
 
 } // namespace comms::fault_tolerance

--- a/comms/common/fault_tolerance/AbortDevice.cuh
+++ b/comms/common/fault_tolerance/AbortDevice.cuh
@@ -138,6 +138,13 @@ struct AbortDevice final {
   }
 
   /**
+   * Returns the abort behavior captured when this device handle was created.
+   */
+  __host__ __device__ AbortBehavior behavior() const {
+    return behavior_;
+  }
+
+  /**
    * Starts this handle's device-side timeout from the shared default duration.
    *
    * Non-positive or unset default timeouts leave the device deadline inactive.
@@ -195,6 +202,23 @@ struct AbortDevice final {
    */
   __device__ bool isAborted() const {
     return checkExpired();
+  }
+
+  /**
+   * Checks abort state and returns the action the caller should take.
+   *
+   * `CONTINUE` means no abort is visible. `SKIP` means the caller should
+   * unwind or return without consuming incomplete transport data. `TRAP` means
+   * the caller should preserve legacy Prims trap behavior; the trap itself is
+   * performed by Prims helpers so common fault-tolerance code stays transport
+   * agnostic.
+   */
+  __device__ AbortCheckResult check() const {
+    if (!checkExpired()) {
+      return AbortCheckResult::CONTINUE;
+    }
+    return behavior_ == AbortBehavior::TRAP ? AbortCheckResult::TRAP
+                                            : AbortCheckResult::SKIP;
   }
 
   /**
@@ -298,8 +322,11 @@ struct AbortDevice final {
    *
    * TODO: Evaluate CUPTI APIs for a more accurate timeout conversion source.
    */
-  explicit AbortDevice(AbortState* state, uint64_t cyclesPerMs)
-      : state_{state}, cyclesPerMs_{cyclesPerMs} {}
+  explicit AbortDevice(
+      AbortState* state,
+      uint64_t cyclesPerMs,
+      AbortBehavior behavior = AbortBehavior::SKIP)
+      : state_{state}, cyclesPerMs_{cyclesPerMs}, behavior_{behavior} {}
 
   __device__ bool deadlineExpired() const {
     return deadlineCycles_ != 0 && detail::deviceClock() >= deadlineCycles_;
@@ -337,6 +364,11 @@ struct AbortDevice final {
   uint64_t cyclesPerMs_{0};
 
   /**
+   * Device abort behavior selected by the owning host `Abort`.
+   */
+  AbortBehavior behavior_{AbortBehavior::SKIP};
+
+  /**
    * Per-handle device deadline in `detail::deviceClock()` cycles.
    *
    * A value of zero means no device-side timeout is active. This is local to
@@ -347,7 +379,7 @@ struct AbortDevice final {
 
 inline AbortDevice Abort::getDeviceHandle() const {
   if (state_ == nullptr) {
-    return AbortDevice{/*state=*/nullptr, /*cyclesPerMs=*/0};
+    return AbortDevice{/*state=*/nullptr, /*cyclesPerMs=*/0, behavior_};
   }
   if (!stateMapped_) {
     throw std::runtime_error(
@@ -363,7 +395,8 @@ inline AbortDevice Abort::getDeviceHandle() const {
   }
   return AbortDevice{
       static_cast<AbortState*>(deviceState),
-      detail::hostDeviceCyclesPerMs(device)};
+      detail::hostDeviceCyclesPerMs(device),
+      behavior_};
 }
 
 } // namespace comms::fault_tolerance

--- a/comms/common/fault_tolerance/FAULT_TOLERANCE.md
+++ b/comms/common/fault_tolerance/FAULT_TOLERANCE.md
@@ -37,6 +37,19 @@ the caller must create a new handle after switching devices.
 Disabled handles are valid kernel arguments. They have a null state pointer and
 all APIs behave as no-op or non-aborted.
 
+`AbortBehavior` selects what device wait code should do after observing an
+abort:
+
+- `AbortBehavior::SKIP` is the default. Device waits should return a failure
+  status so the caller can unwind without consuming incomplete transport data.
+- `AbortBehavior::TRAP` preserves legacy Prims behavior. Common fault-tolerance
+  code returns `AbortCheckResult::TRAP`; Prims helpers perform the actual
+  `__trap()` so this package stays transport-agnostic.
+
+Callers that only need the old boolean predicate may continue using
+`AbortDevice::isAborted()` or `checkExpired()`. New Prims wait loops should use
+`AbortDevice::check()` and handle `SKIP` explicitly.
+
 ## Device Timeout Semantics
 
 `AbortDevice::startTimeout()` starts a timeout on the copied device handle. The
@@ -115,9 +128,14 @@ __global__ void kernel(KernArgs args) {
   abort.startTimeout();
 
   while (!ready()) {
-    if (abort.isAborted()) {
-      printf("CUDA ABORT ERROR: wait aborted\n");
-      __trap();
+    switch (abort.check()) {
+      case comms::fault_tolerance::AbortCheckResult::CONTINUE:
+        break;
+      case comms::fault_tolerance::AbortCheckResult::SKIP:
+        return;
+      case comms::fault_tolerance::AbortCheckResult::TRAP:
+        printf("CUDA ABORT ERROR: wait aborted\n");
+        __trap();
     }
   }
 }
@@ -133,8 +151,8 @@ Device timeout:
 ```cpp
 abort.startTimeout();
 while (!ready()) {
-  if (abort.isAborted()) {
-    __trap();
+  if (abort.check() != comms::fault_tolerance::AbortCheckResult::CONTINUE) {
+    return;
   }
 }
 ```

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
@@ -75,6 +75,14 @@ __global__ void deviceReadCheckExpiredKernel(
   }
 }
 
+__global__ void deviceReadCheckResultKernel(
+    AbortDevice abort,
+    int* observedCheckResult) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    *observedCheckResult = static_cast<int>(abort.check());
+  }
+}
+
 __global__ void deviceWaitForTimeoutKernel(
     AbortDevice abort,
     int* observedMode,
@@ -210,6 +218,14 @@ cudaError_t launchDeviceReadCheckExpired(
     cudaStream_t stream) {
   deviceReadCheckExpiredKernel<<<1, 1, 0, stream>>>(
       abort, observedCheckExpired, observedReason);
+  return cudaGetLastError();
+}
+
+cudaError_t launchDeviceReadCheckResult(
+    AbortDevice abort,
+    int* observedCheckResult,
+    cudaStream_t stream) {
+  deviceReadCheckResultKernel<<<1, 1, 0, stream>>>(abort, observedCheckResult);
   return cudaGetLastError();
 }
 

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
@@ -45,6 +45,11 @@ cudaError_t launchDeviceReadCheckExpired(
     int* observedReason,
     cudaStream_t stream);
 
+cudaError_t launchDeviceReadCheckResult(
+    AbortDevice abort,
+    int* observedCheckResult,
+    cudaStream_t stream);
+
 cudaError_t launchDeviceWaitForTimeout(
     AbortDevice abort,
     int* observedMode,

--- a/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
@@ -117,6 +117,58 @@ TEST(AbortDeviceTest, checkExpiredSeesHostAbort) {
       readDeviceValue(observedReason), static_cast<int>(AbortReason::ABORTED));
 }
 
+TEST(AbortDeviceTest, deviceCheckContinuesBeforeAbort) {
+  Abort abort{/*enabled=*/true};
+  auto observedCheckResult = makeDeviceValue<int>();
+  ASSERT_NE(observedCheckResult, nullptr);
+
+  EXPECT_EQ(
+      launchDeviceReadCheckResult(
+          abort.getDeviceHandle(), observedCheckResult.get(), nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(
+      readDeviceValue(observedCheckResult),
+      static_cast<int>(AbortCheckResult::CONTINUE));
+}
+
+TEST(AbortDeviceTest, deviceCheckDefaultsToSkipOnAbort) {
+  Abort abort{/*enabled=*/true};
+  auto observedCheckResult = makeDeviceValue<int>();
+  ASSERT_NE(observedCheckResult, nullptr);
+
+  abort.setAbort();
+
+  EXPECT_EQ(
+      launchDeviceReadCheckResult(
+          abort.getDeviceHandle(), observedCheckResult.get(), nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(
+      readDeviceValue(observedCheckResult),
+      static_cast<int>(AbortCheckResult::SKIP));
+}
+
+TEST(AbortDeviceTest, deviceCheckReturnsTrapWhenConfigured) {
+  Abort abort{/*enabled=*/true, AbortBehavior::TRAP};
+  auto observedCheckResult = makeDeviceValue<int>();
+  ASSERT_NE(observedCheckResult, nullptr);
+
+  abort.setAbort();
+
+  EXPECT_EQ(
+      launchDeviceReadCheckResult(
+          abort.getDeviceHandle(), observedCheckResult.get(), nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(
+      readDeviceValue(observedCheckResult),
+      static_cast<int>(AbortCheckResult::TRAP));
+}
+
 TEST(AbortDeviceTest, deviceProducerHostConsumer) {
   Abort abort{/*enabled=*/true};
 

--- a/comms/ctran/CMakeLists.txt
+++ b/comms/ctran/CMakeLists.txt
@@ -65,6 +65,7 @@ target_include_directories(ctran PRIVATE
     ${ROOT}
     ${CONDA_INCLUDE}
     ${CUDA_INCLUDE_DIRS}
+    ${CUDA_INCLUDE_DIRS}/cccl
 )
 
 # ctran is the primary prims consumer: enabling this activates the (otherwise

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -390,7 +390,9 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
             comm->statex_->nRanks(),
             comm->statex_->cudaDev(),
             bootstrapPtr,
-            config);
+            config,
+            std::nullopt,
+            comm->getAbort());
     auto primsOrderedWorkStreamGuard =
         std::make_unique<ctran::algos::OrderedWorkStreamGuard>();
     primsOrderedWorkStreamGuard->init(

--- a/comms/prims/CMakeLists.txt
+++ b/comms/prims/CMakeLists.txt
@@ -57,6 +57,7 @@ target_include_directories(prims PRIVATE
     ${ROOT}
     ${CONDA_INCLUDE}
     ${CUDA_INCLUDE_DIRS}
+    ${CUDA_INCLUDE_DIRS}/cccl
 )
 
 # prims is only compiled when the top level does add_subdirectory(comms/prims),

--- a/comms/prims/core/BarrierState.cuh
+++ b/comms/prims/core/BarrierState.cuh
@@ -77,7 +77,9 @@ struct alignas(128) BarrierState {
    *
    * @param timeout Optional timeout (default: no timeout, infinite wait)
    */
-  __device__ __forceinline__ void wait(const Timeout& timeout = Timeout()) {
+  template <typename TimeoutLike = Timeout>
+  __device__ __forceinline__ void wait(
+      const TimeoutLike& timeout = TimeoutLike()) {
     uint64_t expected = expected_counter_.atomic_fetch_add(1) + 1;
     while (current_counter_.load() < expected) {
       TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
@@ -118,9 +120,10 @@ struct alignas(128) BarrierState {
    *
    * All threads in the group must call this function (collective operation).
    */
+  template <typename TimeoutLike = Timeout>
   __device__ __forceinline__ void wait(
       ThreadGroup& group,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
     if (group.is_leader()) {
       wait(timeout);
     }

--- a/comms/prims/core/SignalState.cuh
+++ b/comms/prims/core/SignalState.cuh
@@ -173,8 +173,9 @@ struct alignas(128) SignalState {
    *
    * Used internally by wait_until to avoid code duplication.
    */
+  template <typename TimeoutLike>
   __device__ __forceinline__ void checkTimeoutAndTrap(
-      const Timeout& timeout,
+      const TimeoutLike& timeout,
       CmpOp op,
       uint64_t expected) const {
     TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
@@ -199,8 +200,11 @@ struct alignas(128) SignalState {
    * @param expected The expected value to compare against
    * @param timeout Timeout config (default: no timeout)
    */
-  __device__ __forceinline__ void
-  wait_until(CmpOp op, uint64_t expected, const Timeout& timeout = Timeout()) {
+  template <typename TimeoutLike = Timeout>
+  __device__ __forceinline__ void wait_until(
+      CmpOp op,
+      uint64_t expected,
+      const TimeoutLike& timeout = TimeoutLike()) {
     switch (op) {
       case CmpOp::CMP_EQ:
         while (load() != expected) {
@@ -275,11 +279,12 @@ struct alignas(128) SignalState {
    * @param expected The expected value to compare against
    * @param timeout Timeout config (default: no timeout)
    */
+  template <typename TimeoutLike = Timeout>
   __device__ __forceinline__ void wait_until(
       ThreadGroup& group,
       CmpOp op,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
     wait_until(op, expected, timeout);
   }
 };

--- a/comms/prims/tests/BarrierTest.cc
+++ b/comms/prims/tests/BarrierTest.cc
@@ -80,10 +80,10 @@ class BarrierTwoGpuFixture : public ::testing::Test {
 
   void TearDown() override {
     // Cleanup streams
-    CUDACHECK_TEST(cudaSetDevice(kGpu0));
-    CUDACHECK_TEST(cudaStreamDestroy(stream0_));
-    CUDACHECK_TEST(cudaSetDevice(kGpu1));
-    CUDACHECK_TEST(cudaStreamDestroy(stream1_));
+    (void)cudaSetDevice(kGpu0);
+    (void)cudaStreamDestroy(stream0_);
+    (void)cudaSetDevice(kGpu1);
+    (void)cudaStreamDestroy(stream1_);
   }
 };
 

--- a/comms/prims/tests/DeviceWindowTest.cu
+++ b/comms/prims/tests/DeviceWindowTest.cu
@@ -92,6 +92,7 @@ struct NvlOnlyDeviceWindowBuffers {
         myRank,
         nRanks,
         DeviceSpan<Transport>(transportsPtr, nRanks),
+        {},
         nPeers,
         0};
     dw.nNvlPeers_ = nPeers;
@@ -631,6 +632,7 @@ struct IbgdaOnlyDeviceWindowBuffers {
         myRank,
         nRanks,
         DeviceSpan<Transport>(transportsPtr, nRanks),
+        {},
         0,
         nPeers};
     dw.nNvlPeers_ = 0;

--- a/comms/prims/tests/MultiPeerTransportIntegrationTest.cc
+++ b/comms/prims/tests/MultiPeerTransportIntegrationTest.cc
@@ -6,6 +6,7 @@
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
 
+#include "comms/common/fault_tolerance/Abort.h"
 #include "comms/prims/tests/MultiPeerTransportKernelTest.cuh"
 #include "comms/prims/transport/MultiPeerDeviceHandle.cuh"
 #include "comms/prims/transport/MultiPeerTransport.h"
@@ -29,7 +30,8 @@ class MultiPeerIntegrationTestFixture : public MpiBaseTestFixture {
     CUDACHECK_TEST(cudaSetDevice(localRank));
   }
 
-  std::unique_ptr<MultiPeerTransport> create_and_exchange() {
+  std::unique_ptr<MultiPeerTransport> create_and_exchange(
+      std::shared_ptr<comms::fault_tolerance::Abort> abort = nullptr) {
     MultiPeerTransportConfig config{
         .nvlConfig =
             {
@@ -45,7 +47,13 @@ class MultiPeerIntegrationTestFixture : public MpiBaseTestFixture {
     };
     auto bootstrap = std::make_shared<MpiBootstrap>();
     auto states = std::make_unique<MultiPeerTransport>(
-        globalRank, numRanks, localRank, bootstrap, config);
+        globalRank,
+        numRanks,
+        localRank,
+        bootstrap,
+        config,
+        std::nullopt,
+        std::move(abort));
     states->exchange();
     return states;
   }
@@ -89,6 +97,39 @@ TEST_F(MultiPeerIntegrationTestFixture, DeviceHandleTypeMap) {
   }
 
   CUDACHECK_TEST(cudaFree(output_d));
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_F(MultiPeerIntegrationTestFixture, DeviceHandleAbortObservesHostAbort) {
+  auto abort = comms::fault_tolerance::createAbort(/*enabled=*/true);
+  auto states = create_and_exchange(abort);
+  auto handle = states->get_device_handle(states->ib_peer_ranks());
+
+  abort->setAbort();
+
+  int* observed_d = nullptr;
+  int* observedReason_d = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&observed_d, sizeof(int)));
+  CUDACHECK_TEST(cudaMalloc(&observedReason_d, sizeof(int)));
+  CUDACHECK_TEST(cudaMemset(observed_d, 0, sizeof(int)));
+  CUDACHECK_TEST(cudaMemset(observedReason_d, 0, sizeof(int)));
+
+  test::test_device_handle_abort(handle, observed_d, observedReason_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  int observed = 0;
+  int observedReason = 0;
+  CUDACHECK_TEST(
+      cudaMemcpy(&observed, observed_d, sizeof(int), cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaMemcpy(
+      &observedReason, observedReason_d, sizeof(int), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(observed, 1);
+  EXPECT_EQ(
+      observedReason,
+      static_cast<int>(comms::fault_tolerance::AbortReason::ABORTED));
+
+  CUDACHECK_TEST(cudaFree(observed_d));
+  CUDACHECK_TEST(cudaFree(observedReason_d));
   MPI_Barrier(MPI_COMM_WORLD);
 }
 

--- a/comms/prims/tests/MultiPeerTransportKernelTest.cu
+++ b/comms/prims/tests/MultiPeerTransportKernelTest.cu
@@ -18,6 +18,16 @@ __global__ void test_device_handle_type_map_kernel(
   }
 }
 
+__global__ void test_device_handle_abort_kernel(
+    MultiPeerDeviceHandle handle,
+    int* observed,
+    int* observedReason) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    *observed = handle.abort.checkExpired() ? 1 : 0;
+    *observedReason = static_cast<int>(handle.abort.reason());
+  }
+}
+
 __global__ void test_multi_peer_self_put_kernel(
     MultiPeerDeviceHandle handle,
     void* dst_d,
@@ -44,6 +54,14 @@ void test_device_handle_type_map(
     int blockSize) {
   test_device_handle_type_map_kernel<<<numBlocks, blockSize>>>(
       handle, output_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void test_device_handle_abort(
+    MultiPeerDeviceHandle handle,
+    int* observed,
+    int* observedReason) {
+  test_device_handle_abort_kernel<<<1, 1>>>(handle, observed, observedReason);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/prims/tests/MultiPeerTransportKernelTest.cuh
+++ b/comms/prims/tests/MultiPeerTransportKernelTest.cuh
@@ -26,6 +26,19 @@ void test_device_handle_type_map(
     int blockSize);
 
 /**
+ * Verify that the abort handle embedded in MultiPeerDeviceHandle is visible on
+ * device.
+ *
+ * @param handle Device handle to test.
+ * @param observed GPU int set to 1 when the handle observes an abort.
+ * @param observedReason GPU int set to the observed AbortReason value.
+ */
+void test_device_handle_abort(
+    MultiPeerDeviceHandle handle,
+    int* observed,
+    int* observedReason);
+
+/**
  * Test self-transport put via MultiPeerDeviceHandle.
  *
  * @param handle Device handle.

--- a/comms/prims/tests/MultiPeerTransportTest.cc
+++ b/comms/prims/tests/MultiPeerTransportTest.cc
@@ -12,6 +12,7 @@
 #include <folly/init/Init.h>
 
 #include "comms/common/bootstrap/tests/MockBootstrap.h"
+#include "comms/common/fault_tolerance/Abort.h"
 #include "comms/prims/memory/GpuMemHandler.h"
 #include "comms/prims/tests/TopologyTestUtils.h"
 #include "comms/prims/topology/TopologyDiscovery.h"
@@ -43,7 +44,8 @@ class MultiPeerTransportTestFixture : public MpiBaseTestFixture {
     detectLocalSize();
   }
 
-  std::unique_ptr<MultiPeerTransport> createTransport() {
+  std::unique_ptr<MultiPeerTransport> createTransport(
+      std::shared_ptr<comms::fault_tolerance::Abort> abort = nullptr) {
     MultiPeerTransportConfig config{
         .nvlConfig =
             {
@@ -62,7 +64,9 @@ class MultiPeerTransportTestFixture : public MpiBaseTestFixture {
         numRanks,
         localRank,
         std::make_shared<MpiBootstrap>(),
-        config);
+        config,
+        std::nullopt,
+        std::move(abort));
   }
 
   std::unique_ptr<MultiPeerTransport> createDisableIbTransport() {
@@ -223,11 +227,23 @@ TEST_F(MultiPeerTransportTestFixture, DeviceHandleMetadata) {
   EXPECT_EQ(handle.myRank, globalRank);
   EXPECT_EQ(handle.nRanks, numRanks);
   EXPECT_EQ(handle.transports.size(), static_cast<uint32_t>(numRanks));
+  EXPECT_FALSE(handle.abort.isEnabled());
   EXPECT_GT(handle.numNvlPeers, 0);
   // Every remote rank is classified either as NVL or IB (see
   // TopologyDiscovery). Old assertion `numIbPeers == numRanks-1` held only on
   // non-MNNVL topologies where NVL was intra-host and everything remote was IB.
   EXPECT_EQ(handle.numNvlPeers + handle.numIbPeers, numRanks - 1);
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_F(MultiPeerTransportTestFixture, DeviceHandleCarriesEnabledAbort) {
+  auto abort = comms::fault_tolerance::createAbort(/*enabled=*/true);
+  auto transport = createTransport(abort);
+  transport->exchange();
+
+  auto handle = transport->get_device_handle(transport->ib_peer_ranks());
+  EXPECT_TRUE(handle.abort.isEnabled());
 
   MPI_Barrier(MPI_COMM_WORLD);
 }

--- a/comms/prims/tests/P2pIbTransportDeviceAbortTest.cc
+++ b/comms/prims/tests/P2pIbTransportDeviceAbortTest.cc
@@ -1,0 +1,18 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <cuda_runtime.h>
+
+#include "comms/prims/tests/P2pIbTransportDeviceAbortTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+namespace comms::prims {
+
+TEST(P2pIbTransportDeviceAbortTest, WrapperWaitSignalAcceptsAbortDevice) {
+  CUDACHECK_TEST(cudaSetDevice(0));
+  test::launchIbWrapperWaitSignalAbortCompileCheck();
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+}
+
+} // namespace comms::prims

--- a/comms/prims/tests/P2pIbTransportDeviceAbortTest.cc
+++ b/comms/prims/tests/P2pIbTransportDeviceAbortTest.cc
@@ -15,4 +15,26 @@ TEST(P2pIbTransportDeviceAbortTest, WrapperWaitSignalAcceptsAbortDevice) {
   CUDACHECK_TEST(cudaDeviceSynchronize());
 }
 
+TEST(P2pIbTransportDeviceAbortTest, IbrcWaitSignalAcceptsDisabledAbortDevice) {
+  CUDACHECK_TEST(cudaSetDevice(0));
+
+  uint64_t* signal = nullptr;
+  bool* success = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&signal, sizeof(uint64_t)));
+  CUDACHECK_TEST(cudaMalloc(&success, sizeof(bool)));
+  CUDACHECK_TEST(cudaMemset(signal, 0, sizeof(uint64_t)));
+  CUDACHECK_TEST(cudaMemset(success, 0, sizeof(bool)));
+
+  test::launchIbrcWaitSignalWithDisabledAbort(signal, success);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  bool hostSuccess = false;
+  CUDACHECK_TEST(
+      cudaMemcpy(&hostSuccess, success, sizeof(bool), cudaMemcpyDeviceToHost));
+  EXPECT_TRUE(hostSuccess);
+
+  CUDACHECK_TEST(cudaFree(success));
+  CUDACHECK_TEST(cudaFree(signal));
+}
+
 } // namespace comms::prims

--- a/comms/prims/tests/P2pIbTransportDeviceAbortTest.cu
+++ b/comms/prims/tests/P2pIbTransportDeviceAbortTest.cu
@@ -1,0 +1,32 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/prims/tests/P2pIbTransportDeviceAbortTest.cuh"
+
+#include "comms/common/fault_tolerance/AbortDevice.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/tests/Checks.h"
+#include "comms/prims/transport/P2pIbTransportDevice.cuh"
+
+namespace comms::prims::test {
+
+namespace {
+
+__global__ void waitSignalWithDisabledAbortKernel(
+    P2pIbTransportDevice transport,
+    bool runWait) {
+  auto group = make_block_group();
+  comms::fault_tolerance::AbortDevice abort;
+  if (runWait) {
+    transport.wait_signal(group, 0, 0, abort);
+  }
+}
+
+} // namespace
+
+void launchIbWrapperWaitSignalAbortCompileCheck() {
+  P2pIbTransportDevice transport{};
+  waitSignalWithDisabledAbortKernel<<<1, 32>>>(transport, false);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/P2pIbTransportDeviceAbortTest.cu
+++ b/comms/prims/tests/P2pIbTransportDeviceAbortTest.cu
@@ -6,6 +6,7 @@
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/tests/Checks.h"
 #include "comms/prims/transport/P2pIbTransportDevice.cuh"
+#include "comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh"
 
 namespace comms::prims::test {
 
@@ -21,11 +22,43 @@ __global__ void waitSignalWithDisabledAbortKernel(
   }
 }
 
+__global__ void waitIbrcSignalWithDisabledAbortKernel(
+    uint64_t* signal,
+    bool* success,
+    bool runWait) {
+  auto group = make_block_group();
+  IbgdaLocalBuffer localSignal{signal, NetworkLKeys{}};
+  P2pIbrcTransportDevice transport(
+      DeviceSpan<IbrcCmdQueueDevice>{},
+      /*nics=*/0,
+      /*maxChannels=*/0,
+      /*qpsPerConnection=*/0,
+      DeviceSpan<IbLocalChannel>{},
+      IbgdaRemoteBuffer{},
+      localSignal,
+      IbgdaLocalBuffer{},
+      IbgdaLocalBuffer{},
+      /*numSignalSlots=*/1);
+  comms::fault_tolerance::AbortDevice abort;
+  if (runWait) {
+    transport.wait_signal(group, /*signalId=*/0, /*expected=*/0, abort);
+  }
+  if (group.is_leader()) {
+    *success = true;
+  }
+}
+
 } // namespace
 
 void launchIbWrapperWaitSignalAbortCompileCheck() {
   P2pIbTransportDevice transport{};
   waitSignalWithDisabledAbortKernel<<<1, 32>>>(transport, false);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchIbrcWaitSignalWithDisabledAbort(uint64_t* signal, bool* success) {
+  waitIbrcSignalWithDisabledAbortKernel<<<1, 32>>>(
+      signal, success, /*runWait=*/false);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/prims/tests/P2pIbTransportDeviceAbortTest.cuh
+++ b/comms/prims/tests/P2pIbTransportDeviceAbortTest.cuh
@@ -1,0 +1,12 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef COMMS_PRIMS_TESTS_P2P_IB_TRANSPORT_DEVICE_ABORT_TEST_CUH_
+#define COMMS_PRIMS_TESTS_P2P_IB_TRANSPORT_DEVICE_ABORT_TEST_CUH_
+
+namespace comms::prims::test {
+
+void launchIbWrapperWaitSignalAbortCompileCheck();
+
+} // namespace comms::prims::test
+
+#endif // COMMS_PRIMS_TESTS_P2P_IB_TRANSPORT_DEVICE_ABORT_TEST_CUH_

--- a/comms/prims/tests/P2pIbTransportDeviceAbortTest.cuh
+++ b/comms/prims/tests/P2pIbTransportDeviceAbortTest.cuh
@@ -3,9 +3,13 @@
 #ifndef COMMS_PRIMS_TESTS_P2P_IB_TRANSPORT_DEVICE_ABORT_TEST_CUH_
 #define COMMS_PRIMS_TESTS_P2P_IB_TRANSPORT_DEVICE_ABORT_TEST_CUH_
 
+#include <cstdint>
+
 namespace comms::prims::test {
 
 void launchIbWrapperWaitSignalAbortCompileCheck();
+
+void launchIbrcWaitSignalWithDisabledAbort(uint64_t* signal, bool* success);
 
 } // namespace comms::prims::test
 

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTest.cu
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTest.cu
@@ -5,6 +5,7 @@
 // `cudaSuccess` / `cudaGetErrorString` / `cudaGetLastError` directly).
 #include "comms/prims/transport/amd/HipHostCompat.h"
 
+#include "comms/common/fault_tolerance/AbortDevice.cuh"
 #include "comms/prims/core/TimeoutUtils.h"
 #include "comms/prims/tests/Checks.h"
 #include "comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh"
@@ -110,6 +111,22 @@ __global__ void testWaitSignalMultipleSlots(
   }
 }
 
+__global__ void testWaitSignalWithDisabledAbort(
+    uint64_t* d_signalBuf,
+    bool* success) {
+  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{});
+  P2pIbgdaTransportDevice transport(
+      DeviceSpan<NicDeviceIbgdaResources>{},
+      IbgdaRemoteBuffer{},
+      localSigBuf,
+      IbgdaLocalBuffer{},
+      1);
+
+  comms::fault_tolerance::AbortDevice abort;
+  transport.wait_signal(0, 0, abort);
+  *success = true;
+}
+
 // =============================================================================
 // Wrapper functions to launch the kernels (called from .cc test file)
 // =============================================================================
@@ -141,6 +158,12 @@ void runTestWaitSignalMultipleSlots(
     int numSignals,
     bool* d_success) {
   testWaitSignalMultipleSlots<<<1, 1>>>(d_signalBuf, numSignals, d_success);
+}
+
+void runTestWaitSignalWithDisabledAbort(
+    uint64_t* d_signalBuf,
+    bool* d_success) {
+  testWaitSignalWithDisabledAbort<<<1, 1>>>(d_signalBuf, d_success);
 }
 
 // =============================================================================

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh
@@ -45,6 +45,10 @@ void runTestWaitSignalMultipleSlots(
     int numSignals,
     bool* d_success);
 
+// Test wait_signal accepts a disabled AbortDevice and completes when the signal
+// already satisfies the condition.
+void runTestWaitSignalWithDisabledAbort(uint64_t* d_signalBuf, bool* d_success);
+
 // =============================================================================
 // Group-level API tests
 // =============================================================================

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTestMain.cc
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTestMain.cc
@@ -209,6 +209,16 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalZeroValue) {
   });
 }
 
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalAcceptsDisabledAbort) {
+  DeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+  CUDACHECK_TEST(cudaMemset(d_signalBuf, 0, sizeof(uint64_t)));
+
+  runAndVerify([d_signalBuf](bool* d_success) {
+    runTestWaitSignalWithDisabledAbort(d_signalBuf, d_success);
+  });
+}
+
 TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalMaxValue) {
   // Test wait_signal with max uint64 value (edge case)
   const uint64_t targetValue = UINT64_MAX;

--- a/comms/prims/tests/P2pNvlTransportDeviceTest.cc
+++ b/comms/prims/tests/P2pNvlTransportDeviceTest.cc
@@ -80,10 +80,10 @@ class P2pNvlTransportDeviceTwoGpuFixture : public ::testing::Test {
 
   void TearDown() override {
     // Cleanup streams
-    CUDACHECK_TEST(cudaSetDevice(kGpu0));
-    CUDACHECK_TEST(cudaStreamDestroy(stream0_));
-    CUDACHECK_TEST(cudaSetDevice(kGpu1));
-    CUDACHECK_TEST(cudaStreamDestroy(stream1_));
+    (void)cudaSetDevice(kGpu0);
+    (void)cudaStreamDestroy(stream0_);
+    (void)cudaSetDevice(kGpu1);
+    (void)cudaStreamDestroy(stream1_);
   }
 
   /**
@@ -399,6 +399,42 @@ TEST_F(P2pNvlTransportDeviceTestFixture, SignalWaitCmpNe) {
   SUCCEED();
 
   CUDACHECK_TEST(cudaFree(signal_d));
+}
+
+TEST_F(P2pNvlTransportDeviceTestFixture, DeviceWaitAcceptsDisabledAbortDevice) {
+  const int numSignals = 1;
+  SignalState* signalBuffer;
+  CUDACHECK_TEST(cudaMalloc(&signalBuffer, numSignals * sizeof(SignalState)));
+  CUDACHECK_TEST(cudaMemset(signalBuffer, 0, numSignals * sizeof(SignalState)));
+
+  P2pNvlTransportOptions options{
+      .dataBufferSize = 1024,
+      .pipelineDepth = 2,
+  };
+  LocalState localState{
+      .dataBuffer = nullptr,
+      .signalBuffer = DeviceSpan<SignalState>(signalBuffer, numSignals),
+  };
+  RemoteState remoteState{
+      .dataBuffer = nullptr,
+      .signalBuffer = DeviceSpan<SignalState>(signalBuffer, numSignals),
+  };
+  P2pNvlTransportDevice transport(0, 0, options, localState, remoteState);
+
+  P2pNvlTransportDevice* transport_d;
+  CUDACHECK_TEST(cudaMalloc(&transport_d, sizeof(P2pNvlTransportDevice)));
+  CUDACHECK_TEST(cudaMemcpy(
+      transport_d,
+      &transport,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
+
+  test::testDeviceSignalThenWaitWithDisabledAbort(
+      transport_d, 0, SignalOp::SIGNAL_SET, 7, CmpOp::CMP_EQ, 7, 1, 32);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  CUDACHECK_TEST(cudaFree(transport_d));
+  CUDACHECK_TEST(cudaFree(signalBuffer));
 }
 
 TEST_F(P2pNvlTransportDeviceTestFixture, SignalBlockGroups) {

--- a/comms/prims/tests/P2pNvlTransportDeviceTest.cu
+++ b/comms/prims/tests/P2pNvlTransportDeviceTest.cu
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include "comms/common/fault_tolerance/AbortDevice.cuh"
 #include "comms/prims/core/TiledBuffer.cuh"
 #include "comms/prims/tests/Checks.h"
 #include "comms/prims/tests/P2pNvlTransportDeviceTest.cuh"
@@ -56,6 +57,20 @@ __global__ void testDeviceSignalThenWaitKernel(
   p2p->wait_signal_until(group, signalId, waitOp, waitValue);
 }
 
+__global__ void testDeviceSignalThenWaitWithDisabledAbortKernel(
+    P2pNvlTransportDevice* p2p,
+    uint64_t signalId,
+    SignalOp signalOp,
+    uint64_t signalValue,
+    CmpOp waitOp,
+    uint64_t waitValue,
+    GroupType groupType) {
+  auto group = make_group(groupType);
+  p2p->signal(group, signalId, signalOp, signalValue);
+  comms::fault_tolerance::AbortDevice abort;
+  p2p->wait_signal_until(group, signalId, waitOp, waitValue, abort);
+}
+
 void testDeviceSignal(
     P2pNvlTransportDevice* p2p,
     uint64_t signalId,
@@ -93,6 +108,21 @@ void testDeviceSignalThenWait(
     int blockSize,
     GroupType groupType) {
   testDeviceSignalThenWaitKernel<<<numBlocks, blockSize>>>(
+      p2p, signalId, signalOp, signalValue, waitOp, waitValue, groupType);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testDeviceSignalThenWaitWithDisabledAbort(
+    P2pNvlTransportDevice* p2p,
+    uint64_t signalId,
+    SignalOp signalOp,
+    uint64_t signalValue,
+    CmpOp waitOp,
+    uint64_t waitValue,
+    int numBlocks,
+    int blockSize,
+    GroupType groupType) {
+  testDeviceSignalThenWaitWithDisabledAbortKernel<<<numBlocks, blockSize>>>(
       p2p, signalId, signalOp, signalValue, waitOp, waitValue, groupType);
   PIPES_KERNEL_LAUNCH_CHECK();
 }

--- a/comms/prims/tests/P2pNvlTransportDeviceTest.cuh
+++ b/comms/prims/tests/P2pNvlTransportDeviceTest.cuh
@@ -55,6 +55,18 @@ void testDeviceSignalThenWait(
     int blockSize,
     GroupType groupType = GroupType::WARP);
 
+// Signal then wait using a disabled AbortDevice as the wait guard.
+void testDeviceSignalThenWaitWithDisabledAbort(
+    P2pNvlTransportDevice* p2p,
+    uint64_t signalId,
+    SignalOp signalOp,
+    uint64_t signalValue,
+    CmpOp waitOp,
+    uint64_t waitValue,
+    int numBlocks,
+    int blockSize,
+    GroupType groupType = GroupType::WARP);
+
 // =============================================================================
 // Direct Signal struct test helpers
 // These test the Signal struct directly without P2pNvlTransportDevice

--- a/comms/prims/transport/MultiPeerDeviceHandle.cuh
+++ b/comms/prims/transport/MultiPeerDeviceHandle.cuh
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "comms/common/fault_tolerance/AbortDevice.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
 #include "comms/prims/transport/Transport.cuh"
 
@@ -56,6 +57,10 @@ struct MultiPeerDeviceHandle {
   // Unified transport array indexed by global rank.
   // transports[rank].type gives the transport type for that rank.
   DeviceSpan<Transport> transports;
+
+  // Communicator-scoped abort handle. Kernels should copy this value and start
+  // per-operation timeout state on the copy, not on persistent transports.
+  comms::fault_tolerance::AbortDevice abort;
 
   // Number of NVL peers (excluding self)
   int numNvlPeers{0};

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -20,6 +20,7 @@
 
 #include <glog/logging.h>
 
+#include "comms/common/fault_tolerance/Abort.h"
 #include "comms/prims/bootstrap/NvlBootstrapAdapter.h"
 #include "comms/prims/memory/CuMemAllocation.h"
 #include "comms/prims/topology/TopologyDiscovery.h"
@@ -51,6 +52,41 @@ namespace {
     }                                                                          \
   } while (0)
 
+class ScopedCudaDevice {
+ public:
+  explicit ScopedCudaDevice(int device) : targetDevice_(device) {
+    CUDA_CHECK(cudaGetDevice(&previousDevice_));
+    if (previousDevice_ != targetDevice_) {
+      CUDA_CHECK(cudaSetDevice(targetDevice_));
+    }
+  }
+
+  ScopedCudaDevice(const ScopedCudaDevice&) = delete;
+  ScopedCudaDevice& operator=(const ScopedCudaDevice&) = delete;
+  ScopedCudaDevice(ScopedCudaDevice&&) = delete;
+  ScopedCudaDevice& operator=(ScopedCudaDevice&&) = delete;
+
+  ~ScopedCudaDevice() {
+    if (previousDevice_ != targetDevice_) {
+      (void)cudaSetDevice(previousDevice_);
+    }
+  }
+
+ private:
+  int previousDevice_{-1};
+  int targetDevice_{-1};
+};
+
+comms::fault_tolerance::AbortDevice makeAbortDeviceHandle(
+    const std::shared_ptr<comms::fault_tolerance::Abort>& abort,
+    int deviceId) {
+  if (abort == nullptr || !abort->isEnabled()) {
+    return comms::fault_tolerance::AbortDevice{};
+  }
+  ScopedCudaDevice guard{deviceId};
+  return abort->getDeviceHandle();
+}
+
 } // namespace
 
 MultiPeerTransport::MultiPeerTransport(
@@ -59,11 +95,13 @@ MultiPeerTransport::MultiPeerTransport(
     int deviceId,
     std::shared_ptr<meta::comms::IBootstrap> bootstrap,
     const MultiPeerTransportConfig& config,
-    std::optional<TopologyResult> topo)
+    std::optional<TopologyResult> topo,
+    std::shared_ptr<comms::fault_tolerance::Abort> abort)
     : myRank_(myRank),
       nRanks_(nRanks),
       deviceId_(deviceId),
-      bootstrap_(std::move(bootstrap)) {
+      bootstrap_(std::move(bootstrap)),
+      abort_(std::move(abort)) {
   if (!topo.has_value()) {
     TopologyDiscovery topoDiscovery;
     topo = topoDiscovery.discover(
@@ -317,6 +355,7 @@ MultiPeerDeviceHandle MultiPeerTransport::get_device_handle(
       myRank_,
       nRanks_,
       {transportsGpu_, static_cast<uint32_t>(nRanks_)},
+      makeAbortDeviceHandle(abort_, deviceId_),
       static_cast<int>(nvlPeerRanks_.size()),
       static_cast<int>(ibPeerRanks_.size()),
   };

--- a/comms/prims/transport/MultiPeerTransport.h
+++ b/comms/prims/transport/MultiPeerTransport.h
@@ -19,6 +19,7 @@
 #endif
 
 #include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/common/fault_tolerance/AbortDevice.cuh"
 #include "comms/prims/memory/GpuMemHandler.h"
 #include "comms/prims/memory/NvlMemExchange.h"
 #include "comms/prims/topology/TopologyDiscovery.h"
@@ -28,6 +29,10 @@
 #include "comms/prims/transport/ibrc/MultipeerIbrcTransport.h"
 #include "comms/prims/transport/nvl/MultiPeerNvlTransport.h"
 #include "comms/prims/transport/self/P2pSelfTransportDevice.cuh"
+
+namespace comms::fault_tolerance {
+class Abort;
+} // namespace comms::fault_tolerance
 
 namespace comms::prims {
 
@@ -82,7 +87,8 @@ class MultiPeerTransport {
       int deviceId,
       std::shared_ptr<meta::comms::IBootstrap> bootstrap,
       const MultiPeerTransportConfig& config,
-      std::optional<TopologyResult> topo = std::nullopt);
+      std::optional<TopologyResult> topo = std::nullopt,
+      std::shared_ptr<comms::fault_tolerance::Abort> abort = nullptr);
 
   ~MultiPeerTransport();
 
@@ -325,6 +331,7 @@ class MultiPeerTransport {
   const int nRanks_;
   const int deviceId_;
   std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
+  std::shared_ptr<comms::fault_tolerance::Abort> abort_;
 
   // --- Topology (populated in constructor) ---
   std::vector<int> nvlPeerRanks_;

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -123,11 +123,12 @@ __device__ __forceinline__ void P2pIbTransportDevice::put_cooperative(
   }
 }
 
+template <typename TimeoutLike>
 __device__ __forceinline__ void P2pIbTransportDevice::wait_signal(
     ThreadGroup& group,
     int signalId,
     uint64_t expected,
-    const Timeout& timeout) {
+    const TimeoutLike& timeout) {
   if (type == P2pIbBackendType::IBRC) {
     ibrc->wait_signal(group, signalId, expected, timeout);
   } else {
@@ -135,10 +136,11 @@ __device__ __forceinline__ void P2pIbTransportDevice::wait_signal(
   }
 }
 
+template <typename TimeoutLike>
 __device__ __forceinline__ void P2pIbTransportDevice::wait_signal(
     int signalId,
     uint64_t expected,
-    const Timeout& timeout) {
+    const TimeoutLike& timeout) {
   if (type == P2pIbBackendType::IBRC) {
     ibrc->wait_signal(signalId, expected, timeout);
   } else {
@@ -146,11 +148,12 @@ __device__ __forceinline__ void P2pIbTransportDevice::wait_signal(
   }
 }
 
+template <typename TimeoutLike>
 __device__ __forceinline__ void P2pIbTransportDevice::wait_counter(
     ThreadGroup& group,
     int counterId,
     uint64_t expected,
-    const Timeout& timeout) {
+    const TimeoutLike& timeout) {
   if (type == P2pIbBackendType::IBRC) {
     ibrc->wait_counter(group, counterId, expected, timeout);
   } else {
@@ -158,10 +161,11 @@ __device__ __forceinline__ void P2pIbTransportDevice::wait_counter(
   }
 }
 
+template <typename TimeoutLike>
 __device__ __forceinline__ void P2pIbTransportDevice::wait_counter(
     int counterId,
     uint64_t expected,
-    const Timeout& timeout) {
+    const TimeoutLike& timeout) {
   if (type == P2pIbBackendType::IBRC) {
     ibrc->wait_counter(counterId, expected, timeout);
   } else {
@@ -169,10 +173,11 @@ __device__ __forceinline__ void P2pIbTransportDevice::wait_counter(
   }
 }
 
+template <typename TimeoutLike>
 __device__ __forceinline__ void P2pIbTransportDevice::wait_local(
     ThreadGroup& group,
     const IbLocalCompletionTicket& ticket,
-    const Timeout& timeout) {
+    const TimeoutLike& timeout) {
   if (type == P2pIbBackendType::IBRC) {
     ibrc->wait_local(group, ticket, timeout);
   } else {
@@ -375,11 +380,12 @@ __device__ __forceinline__ void P2pIbTransportDevice::put_cooperative(
       counterVal);
 }
 
+template <typename TimeoutLike>
 __device__ __forceinline__ void P2pIbTransportDevice::wait_signal(
     ThreadGroup& group,
     const IbgdaLocalBuffer& signalBuf,
     uint64_t expected,
-    const Timeout& timeout) {
+    const TimeoutLike& timeout) {
   if (type == P2pIbBackendType::IBRC) {
     ibrc->wait_signal(group, signalBuf, expected, timeout);
   } else {
@@ -387,10 +393,11 @@ __device__ __forceinline__ void P2pIbTransportDevice::wait_signal(
   }
 }
 
+template <typename TimeoutLike>
 __device__ __forceinline__ void P2pIbTransportDevice::wait_signal(
     const IbgdaLocalBuffer& signalBuf,
     uint64_t expected,
-    const Timeout& timeout) {
+    const TimeoutLike& timeout) {
   if (type == P2pIbBackendType::IBRC) {
     ibrc->wait_signal(signalBuf, expected, timeout);
   } else {
@@ -398,11 +405,12 @@ __device__ __forceinline__ void P2pIbTransportDevice::wait_signal(
   }
 }
 
+template <typename TimeoutLike>
 __device__ __forceinline__ void P2pIbTransportDevice::wait_counter(
     ThreadGroup& group,
     const IbgdaLocalBuffer& counterBuf,
     uint64_t expected,
-    const Timeout& timeout) {
+    const TimeoutLike& timeout) {
   if (type == P2pIbBackendType::IBRC) {
     ibrc->wait_counter(group, counterBuf, expected, timeout);
   } else {
@@ -410,10 +418,11 @@ __device__ __forceinline__ void P2pIbTransportDevice::wait_counter(
   }
 }
 
+template <typename TimeoutLike>
 __device__ __forceinline__ void P2pIbTransportDevice::wait_counter(
     const IbgdaLocalBuffer& counterBuf,
     uint64_t expected,
-    const Timeout& timeout) {
+    const TimeoutLike& timeout) {
   if (type == P2pIbBackendType::IBRC) {
     ibrc->wait_counter(counterBuf, expected, timeout);
   } else {
@@ -505,13 +514,13 @@ __device__ __forceinline__ void P2pIbTransportDevice::fence() {
 // Pipelined send/recv — forwarded to the active backend.
 // ===========================================================================
 
-template <typename CopyOp, typename... Args>
+template <typename CopyOp, typename TimeoutLike, typename... Args>
 __device__ __forceinline__ void P2pIbTransportDevice::send(
     ThreadGroup& group,
     const void* __restrict__ src,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const TimeoutLike& timeout,
     Args... args) {
   if (type == P2pIbBackendType::IBRC) {
     ibrc->send<CopyOp>(group, src, nbytes, max_signal_bytes, timeout, args...);
@@ -520,13 +529,13 @@ __device__ __forceinline__ void P2pIbTransportDevice::send(
   }
 }
 
-template <typename CopyOp, typename... Args>
+template <typename CopyOp, typename TimeoutLike, typename... Args>
 __device__ __forceinline__ void P2pIbTransportDevice::recv(
     ThreadGroup& group,
     void* __restrict__ dst,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const TimeoutLike& timeout,
     Args... args) {
   if (type == P2pIbBackendType::IBRC) {
     ibrc->recv<CopyOp>(group, dst, nbytes, max_signal_bytes, timeout, args...);
@@ -535,14 +544,14 @@ __device__ __forceinline__ void P2pIbTransportDevice::recv(
   }
 }
 
-template <typename CopyOp, typename... Args>
+template <typename CopyOp, typename TimeoutLike, typename... Args>
 __device__ __forceinline__ void P2pIbTransportDevice::forward(
     ThreadGroup& group,
     void* __restrict__ dst,
     P2pIbTransportDevice& fwd,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const TimeoutLike& timeout,
     Args... args) {
   if (type == P2pIbBackendType::IBRC && fwd.type == P2pIbBackendType::IBRC) {
     ibrc->forward<CopyOp>(
@@ -605,14 +614,14 @@ __device__ __forceinline__ void P2pIbTransportDevice::init_recv_progress(
   }
 }
 
-template <typename CopyOp, typename... Args>
+template <typename CopyOp, typename TimeoutLike, typename... Args>
 __device__ __forceinline__ IbgdaSendRecvProgressStatus
 P2pIbTransportDevice::progress_send_once(
     ThreadGroup& group,
     const void* __restrict__ src,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const TimeoutLike& timeout,
     Args... args) {
   if (type == P2pIbBackendType::IBRC) {
     return ibrc->progress_send_once<CopyOp>(
@@ -622,14 +631,14 @@ P2pIbTransportDevice::progress_send_once(
       group, src, nbytes, max_signal_bytes, timeout, args...);
 }
 
-template <typename CopyOp, typename... Args>
+template <typename CopyOp, typename TimeoutLike, typename... Args>
 __device__ __forceinline__ IbgdaSendRecvProgressStatus
 P2pIbTransportDevice::progress_recv_once(
     ThreadGroup& group,
     void* __restrict__ dst,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const TimeoutLike& timeout,
     Args... args) {
   if (type == P2pIbBackendType::IBRC) {
     return ibrc->progress_recv_once<CopyOp>(

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -230,21 +230,21 @@ __device__ __forceinline__ ProgressChunk next_chunk(
     const IbChannelProgress& state,
     const ProgressGeometry& geometry);
 
-template <typename Transport>
+template <typename Transport, typename TimeoutLike = Timeout>
 __device__ __forceinline__ bool try_prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
     uint32_t slotId,
     uint64_t generation,
-    const Timeout& timeout = Timeout());
+    const TimeoutLike& timeout = TimeoutLike());
 
-template <typename Transport>
+template <typename Transport, typename TimeoutLike = Timeout>
 __device__ __forceinline__ void prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
     uint32_t slotId,
     uint64_t generation,
-    const Timeout& timeout = Timeout());
+    const TimeoutLike& timeout = TimeoutLike());
 
 template <typename Transport>
 __device__ __forceinline__ void record_send_completion(
@@ -415,14 +415,18 @@ __device__ __forceinline__ void init_recv_progress(
  * @param timeout Optional device timeout checked while dependencies wait.
  * @param args Additional arguments forwarded to `CopyOp::send`.
  */
-template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+template <
+    typename Transport,
+    typename CopyOp = Memcpy,
+    typename TimeoutLike = Timeout,
+    typename... Args>
 __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
     Transport& transport,
     ThreadGroup& group,
     const void* __restrict__ src,
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
-    const Timeout& timeout = Timeout(),
+    const TimeoutLike& timeout = TimeoutLike(),
     Args... args) {
   // The progress API drives the FIXED-size protocol only: it signals in wire
   // bytes and ignores CopyOp::send()'s returned wire size, so a variable-size
@@ -605,14 +609,14 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
  * on lane 0. On success the leader advances `recvDataReadyLaneCursor` and this
  * lane's `recvLaneExpected` by exactly one chunk.
  */
-template <typename Transport>
+template <typename Transport, typename TimeoutLike>
 __device__ __forceinline__ void wait_recv_data_ready(
     Transport& transport,
     ThreadGroup& group,
     IbLocalChannel& localChannel,
     const IbgdaLocalBuffer& localDataReady,
     std::size_t chunkBytes,
-    const Timeout& timeout) {
+    const TimeoutLike& timeout) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   const uint32_t numLanes =
       static_cast<uint32_t>(transport.channel_layout().numLanes);
@@ -720,14 +724,18 @@ __device__ __forceinline__ bool poll_recv_data_ready(
  * @param timeout Optional device timeout checked while dependencies wait.
  * @param args Additional arguments forwarded to `CopyOp::recv`.
  */
-template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+template <
+    typename Transport,
+    typename CopyOp = Memcpy,
+    typename TimeoutLike = Timeout,
+    typename... Args>
 __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
     Transport& transport,
     ThreadGroup& group,
     void* __restrict__ dst,
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
-    const Timeout& timeout = Timeout(),
+    const TimeoutLike& timeout = TimeoutLike(),
     Args... args) {
   // Mirror of progress_send_once: the progress API is fixed-size only. A
   // variable-size policy would mis-size the DATA_READY/SLOT_FREE protocol and
@@ -950,6 +958,7 @@ template <
     typename Transport,
     typename CopyOp = Memcpy,
     typename Proto = protocol::Simple,
+    typename TimeoutLike = Timeout,
     typename... Args>
 __device__ __forceinline__ void send(
     Transport& transport,
@@ -957,7 +966,7 @@ __device__ __forceinline__ void send(
     const void* __restrict__ src,
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
-    const Timeout& timeout = Timeout(),
+    const TimeoutLike& timeout = TimeoutLike(),
     Args... args) {
 #if !PIPES_IS_DEVICE_COMPILE
   (void)transport;
@@ -1338,6 +1347,7 @@ template <
     typename Transport,
     typename CopyOp = Memcpy,
     typename Proto = protocol::Simple,
+    typename TimeoutLike = Timeout,
     typename... Args>
 __device__ __forceinline__ void recv(
     Transport& transport,
@@ -1345,7 +1355,7 @@ __device__ __forceinline__ void recv(
     void* __restrict__ dst,
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
-    const Timeout& timeout = Timeout(),
+    const TimeoutLike& timeout = TimeoutLike(),
     Args... args) {
 #if !PIPES_IS_DEVICE_COMPILE
   (void)transport;
@@ -1655,6 +1665,7 @@ template <
     typename CopyOp = Memcpy,
     typename Transport,
     typename Proto = protocol::Simple,
+    typename TimeoutLike = Timeout,
     typename... Args>
 __device__ __forceinline__ void forward(
     Transport& transport,
@@ -1663,7 +1674,7 @@ __device__ __forceinline__ void forward(
     Transport& fwdTransport,
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
-    const Timeout& timeout = Timeout(),
+    const TimeoutLike& timeout = TimeoutLike(),
     Args... args) {
 #if PIPES_IS_DEVICE_COMPILE
 #ifdef __HIP_PLATFORM_AMD__
@@ -2362,13 +2373,13 @@ __device__ __forceinline__ ProgressChunk next_chunk(
   };
 }
 
-template <typename Transport>
+template <typename Transport, typename TimeoutLike>
 __device__ __forceinline__ bool try_prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
     uint32_t slotId,
     uint64_t generation,
-    const Timeout& timeout) {
+    const TimeoutLike& timeout) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t ready = 1;
   if (group.is_leader()) {
@@ -2417,13 +2428,13 @@ __device__ __forceinline__ bool try_prepare_send_slot(
 #endif
 }
 
-template <typename Transport>
+template <typename Transport, typename TimeoutLike>
 __device__ __forceinline__ void prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
     uint32_t slotId,
     uint64_t generation,
-    const Timeout& timeout) {
+    const TimeoutLike& timeout) {
   if (group.is_leader()) {
     auto& slot =
         transport.local_channel(group.group_id).sendCompletionSlots[slotId];
@@ -2523,27 +2534,31 @@ struct P2pIbTransportDevice {
       int counterId = -1,
       uint64_t counterVal = 1);
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_signal(
       ThreadGroup& group,
       int signalId,
       uint64_t expected,
-      const Timeout& timeout = Timeout());
+      const TimeoutLike& timeout = TimeoutLike());
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_signal(
       int signalId,
       uint64_t expected,
-      const Timeout& timeout = Timeout());
+      const TimeoutLike& timeout = TimeoutLike());
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_counter(
       ThreadGroup& group,
       int counterId,
       uint64_t expected,
-      const Timeout& timeout = Timeout());
+      const TimeoutLike& timeout = TimeoutLike());
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_counter(
       int counterId,
       uint64_t expected,
-      const Timeout& timeout = Timeout());
+      const TimeoutLike& timeout = TimeoutLike());
 
   __device__ void reset_signal(ThreadGroup& group, int signalId);
 
@@ -2606,32 +2621,37 @@ struct P2pIbTransportDevice {
       const IbgdaLocalBuffer& counterBuf = {},
       uint64_t counterVal = 1);
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_signal(
       ThreadGroup& group,
       const IbgdaLocalBuffer& signalBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout());
+      const TimeoutLike& timeout = TimeoutLike());
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_signal(
       const IbgdaLocalBuffer& signalBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout());
+      const TimeoutLike& timeout = TimeoutLike());
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_counter(
       ThreadGroup& group,
       const IbgdaLocalBuffer& counterBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout());
+      const TimeoutLike& timeout = TimeoutLike());
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_counter(
       const IbgdaLocalBuffer& counterBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout());
+      const TimeoutLike& timeout = TimeoutLike());
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_local(
       ThreadGroup& group,
       const IbLocalCompletionTicket& ticket,
-      const Timeout& timeout = Timeout());
+      const TimeoutLike& timeout = TimeoutLike());
 
   __device__ void reset_signal(
       ThreadGroup& group,
@@ -2658,32 +2678,41 @@ struct P2pIbTransportDevice {
   __device__ void fence();
 
   // Pipelined send/recv — forwarded to the active backend's shared helpers.
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ void send(
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const TimeoutLike& timeout = TimeoutLike(),
       Args... args);
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ void recv(
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const TimeoutLike& timeout = TimeoutLike(),
       Args... args);
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ void forward(
       ThreadGroup& group,
       void* __restrict__ dst,
       P2pIbTransportDevice& fwd,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const TimeoutLike& timeout = TimeoutLike(),
       Args... args);
 
   // Total staging bytes for one channel, forwarded to the active backend.
@@ -2705,22 +2734,28 @@ struct P2pIbTransportDevice {
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0);
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const TimeoutLike& timeout = TimeoutLike(),
       Args... args);
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const TimeoutLike& timeout = TimeoutLike(),
       Args... args);
 };
 

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -367,19 +367,21 @@ class P2pIbgdaTransportDevice {
    * @param timeout   Optional spin timeout. On expiry, prints diagnostic and
    *                  __trap()s.
    */
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_signal(
       ThreadGroup& group,
       int signalId,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
     wait_signal(group, local_signal_slot(signalId), expected, timeout);
   }
 
   /** wait_signal (thread-scope, slot-index) - Single-thread variant. */
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_signal(
       int signalId,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
     ThreadGroup solo = make_thread_solo();
     wait_signal(solo, signalId, expected, timeout);
   }
@@ -393,19 +395,21 @@ class P2pIbgdaTransportDevice {
    * @param expected  Threshold; wait returns when slot value >= expected.
    * @param timeout   Optional spin timeout.
    */
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_counter(
       ThreadGroup& group,
       int counterId,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
     wait_counter(group, counter_slot(counterId), expected, timeout);
   }
 
   /** wait_counter (thread-scope, slot-index) - Single-thread variant. */
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_counter(
       int counterId,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
     ThreadGroup solo = make_thread_solo();
     wait_counter(solo, counterId, expected, timeout);
   }
@@ -636,19 +640,21 @@ class P2pIbgdaTransportDevice {
    * @param timeout   Optional spin timeout. On expiry, prints diagnostic and
    *                  __trap()s.
    */
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_signal(
       ThreadGroup& group,
       const IbgdaLocalBuffer& signalBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
     wait_signal_impl(group, signalBuf, expected, timeout);
   }
 
   /** wait_signal (thread-scope) - Single-thread variant. */
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_signal(
       const IbgdaLocalBuffer& signalBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
     ThreadGroup solo = make_thread_solo();
     wait_signal(solo, signalBuf, expected, timeout);
   }
@@ -661,18 +667,20 @@ class P2pIbgdaTransportDevice {
    * @param expected   Threshold; returns when slot value >= expected.
    * @param timeout    Optional spin timeout.
    */
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_counter(
       ThreadGroup& group,
       const IbgdaLocalBuffer& counterBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
     wait_counter_impl(group, counterBuf, expected, timeout);
   }
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_local(
       ThreadGroup& group,
       const IbLocalCompletionTicket& ticket,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
     if (group.is_leader()) {
       IbgdaLane lane = lane_from_ordinal(
           group.group_id, IbDirection::Send, ticket.completionId);
@@ -705,10 +713,11 @@ class P2pIbgdaTransportDevice {
     return false;
   }
 
+  template <typename TimeoutLike>
   __device__ __forceinline__ void wait_local_completion(
       uint32_t channelId,
       const IbLocalCompletionTicket& ticket,
-      const Timeout& timeout) {
+      const TimeoutLike& timeout) {
     IbgdaLane lane =
         lane_from_ordinal(channelId, IbDirection::Send, ticket.completionId);
     wait_local_on_qp(lane.qp, ticket.value, timeout);
@@ -719,10 +728,11 @@ class P2pIbgdaTransportDevice {
   }
 
   /** wait_counter (thread-scope) - Single-thread variant. */
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_counter(
       const IbgdaLocalBuffer& counterBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
     ThreadGroup solo = make_thread_solo();
     wait_counter(solo, counterBuf, expected, timeout);
   }
@@ -1068,10 +1078,11 @@ class P2pIbgdaTransportDevice {
     record_flush_wqe(lane, ticket);
   }
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_local_on_qp(
       doca_gpu_dev_verbs_qp* qp,
       doca_gpu_dev_verbs_ticket_t ticket,
-      Timeout timeout = Timeout()) {
+      TimeoutLike timeout = TimeoutLike()) {
     if (!timeout.isEnabled()) {
       doca_gpu_dev_verbs_wait<
           DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
@@ -1242,11 +1253,12 @@ class P2pIbgdaTransportDevice {
   // Signal waits use system-scope acquire loads. This matches NCCLX GIN's
   // waitSignal path and avoids the heavier post-poll __threadfence_system().
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_signal_impl(
       ThreadGroup& group,
       const IbgdaLocalBuffer& signalBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
     if (group.is_leader()) {
       uint64_t current = load_acquire_system_u64(signalBuf.ptr);
       while (current < expected) {
@@ -1263,11 +1275,12 @@ class P2pIbgdaTransportDevice {
 
   // --- wait_counter_impl ---
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_counter_impl(
       ThreadGroup& group,
       const IbgdaLocalBuffer& counterBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
     if (group.is_leader()) {
       uint64_t current = load_acquire_system_u64(counterBuf.ptr);
       while (current < expected) {
@@ -2143,13 +2156,16 @@ class P2pIbgdaTransportDevice {
    * @param timeout Optional device timeout checked while dependencies wait.
    * @param args Additional arguments forwarded to `CopyOp::send`.
    */
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const TimeoutLike& timeout = TimeoutLike(),
       Args... args) {
     return detail::progress_send_once<P2pIbgdaTransportDevice, CopyOp>(
         *this, group, src, nbytes, max_signal_bytes, timeout, args...);
@@ -2184,13 +2200,16 @@ class P2pIbgdaTransportDevice {
    * @param timeout Optional device timeout checked while dependencies wait.
    * @param args Additional arguments forwarded to `CopyOp::recv`.
    */
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const TimeoutLike& timeout = TimeoutLike(),
       Args... args) {
     return detail::progress_recv_once<P2pIbgdaTransportDevice, CopyOp>(
         *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
@@ -2235,25 +2254,31 @@ class P2pIbgdaTransportDevice {
    * perBlockSlot.
    * @param timeout         Optional timeout for wait operations.
    */
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ void send(
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const TimeoutLike& timeout = TimeoutLike(),
       Args... args) {
     sendWithTrace<CopyOp>(
         group, src, nbytes, max_signal_bytes, timeout, {}, 0, args...);
   }
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ void sendWithTrace(
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes,
-      const Timeout& timeout,
+      const TimeoutLike& timeout,
       PipesTraceHandle trace,
       uint8_t self_rank,
       Args... args) {
@@ -2317,25 +2342,31 @@ class P2pIbgdaTransportDevice {
    * perBlockSlot. Must match the sender's value.
    * @param timeout         Optional timeout for wait operations.
    */
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ void recv(
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const TimeoutLike& timeout = TimeoutLike(),
       Args... args) {
     recvWithTrace<CopyOp>(
         group, dst, nbytes, max_signal_bytes, timeout, {}, 0, args...);
   }
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ void recvWithTrace(
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes,
-      const Timeout& timeout,
+      const TimeoutLike& timeout,
       PipesTraceHandle trace,
       uint8_t self_rank,
       Args... args) {
@@ -2424,27 +2455,33 @@ class P2pIbgdaTransportDevice {
    * @param timeout         Optional timeout for wait operations.
    * @param args            Extra args forwarded to CopyOp::forward.
    */
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ void forward(
       ThreadGroup& group,
       void* __restrict__ dst,
       P2pIbgdaTransportDevice& fwd,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const TimeoutLike& timeout = TimeoutLike(),
       Args... args) {
     forwardWithTrace<CopyOp>(
         group, dst, fwd, nbytes, max_signal_bytes, timeout, {}, 0, args...);
   }
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ void forwardWithTrace(
       ThreadGroup& group,
       void* __restrict__ dst,
       P2pIbgdaTransportDevice& fwd,
       std::size_t nbytes,
       std::size_t max_signal_bytes,
-      const Timeout& timeout,
+      const TimeoutLike& timeout,
       PipesTraceHandle trace,
       uint8_t self_rank,
       Args... args) {

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -181,34 +181,38 @@ class P2pIbrcTransportDevice {
     signal(solo, signalId, signalVal);
   }
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_signal(
       ThreadGroup& group,
       int signalId,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) const {
+      const TimeoutLike& timeout = TimeoutLike()) const {
     wait_signal(group, local_signal_slot(signalId), expected, timeout);
   }
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_signal(
       int signalId,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) const {
+      const TimeoutLike& timeout = TimeoutLike()) const {
     ThreadGroup solo = make_thread_solo();
     wait_signal(solo, signalId, expected, timeout);
   }
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_counter(
       ThreadGroup& group,
       int counterId,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) const {
+      const TimeoutLike& timeout = TimeoutLike()) const {
     wait_counter(group, counter_device_slot(counterId), expected, timeout);
   }
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_counter(
       int counterId,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) const {
+      const TimeoutLike& timeout = TimeoutLike()) const {
     ThreadGroup solo = make_thread_solo();
     wait_counter(solo, counterId, expected, timeout);
   }
@@ -370,10 +374,11 @@ class P2pIbrcTransportDevice {
         counterVal);
   }
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_local(
       ThreadGroup& group,
       const IbLocalCompletionTicket& ticket,
-      const Timeout& timeout = Timeout()) const {
+      const TimeoutLike& timeout = TimeoutLike()) const {
     if (group.is_leader()) {
       const auto& queue = cmdQueues[queue_for_lane(
           group.group_id, IbDirection::Send, ticket.completionId)];
@@ -403,10 +408,11 @@ class P2pIbrcTransportDevice {
                load_acquire_system_u64(queue.ci) - ticket.value) >= 0;
   }
 
+  template <typename TimeoutLike>
   __device__ __forceinline__ void wait_local_completion(
       uint32_t channelId,
       const IbLocalCompletionTicket& ticket,
-      const Timeout& timeout) const {
+      const TimeoutLike& timeout) const {
     const auto& queue = cmdQueues[queue_for_lane(
         channelId, IbDirection::Send, ticket.completionId)];
     while (static_cast<int64_t>(
@@ -466,18 +472,20 @@ class P2pIbrcTransportDevice {
         counterVal);
   }
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_signal(
       ThreadGroup& group,
       const IbgdaLocalBuffer& signalBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) const {
+      const TimeoutLike& timeout = TimeoutLike()) const {
     wait_local(group, signalBuf.ptr, expected, timeout, "signal");
   }
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_signal(
       const IbgdaLocalBuffer& signalBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) const {
+      const TimeoutLike& timeout = TimeoutLike()) const {
     ThreadGroup solo = make_thread_solo();
     wait_signal(solo, signalBuf, expected, timeout);
   }
@@ -504,18 +512,20 @@ class P2pIbrcTransportDevice {
     reset_counter(solo, counterBuf);
   }
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_counter(
       ThreadGroup& group,
       const IbgdaLocalBuffer& counterBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) const {
+      const TimeoutLike& timeout = TimeoutLike()) const {
     wait_local(group, counterBuf.ptr, expected, timeout, "counter");
   }
 
+  template <typename TimeoutLike = Timeout>
   __device__ void wait_counter(
       const IbgdaLocalBuffer& counterBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) const {
+      const TimeoutLike& timeout = TimeoutLike()) const {
     ThreadGroup solo = make_thread_solo();
     wait_counter(solo, counterBuf, expected, timeout);
   }
@@ -617,62 +627,77 @@ class P2pIbrcTransportDevice {
     detail::init_recv_progress(*this, group, nbytes, max_signal_bytes);
   }
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const TimeoutLike& timeout = TimeoutLike(),
       Args... args) {
     return detail::progress_send_once<P2pIbrcTransportDevice, CopyOp>(
         *this, group, src, nbytes, max_signal_bytes, timeout, args...);
   }
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const TimeoutLike& timeout = TimeoutLike(),
       Args... args) {
     return detail::progress_recv_once<P2pIbrcTransportDevice, CopyOp>(
         *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
   }
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ void send(
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const TimeoutLike& timeout = TimeoutLike(),
       Args... args) {
     detail::send<P2pIbrcTransportDevice, CopyOp>(
         *this, group, src, nbytes, max_signal_bytes, timeout, args...);
   }
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ void recv(
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const TimeoutLike& timeout = TimeoutLike(),
       Args... args) {
     detail::recv<P2pIbrcTransportDevice, CopyOp>(
         *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
   }
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ void forward(
       ThreadGroup& group,
       void* __restrict__ dst,
       P2pIbrcTransportDevice& fwd,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const TimeoutLike& timeout = TimeoutLike(),
       Args... args) {
     detail::forward<CopyOp>(
         *this, group, dst, fwd, nbytes, max_signal_bytes, timeout, args...);
@@ -868,11 +893,12 @@ class P2pIbrcTransportDevice {
     }
   }
 
+  template <typename TimeoutLike>
   __device__ void wait_local(
       ThreadGroup& group,
       const void* ptr,
       uint64_t expected,
-      const Timeout& timeout,
+      const TimeoutLike& timeout,
       const char* kind) const {
     if (ptr == nullptr) {
       trap("P2pIbrcTransportDevice: wait buffer is null");

--- a/comms/prims/transport/ll/LlOps.cuh
+++ b/comms/prims/transport/ll/LlOps.cuh
@@ -80,12 +80,13 @@ namespace comms::prims {
  *                          >0 and < total lines = windowed/chunked mode.
  *                          Must be >= kLlLinesPerWarp (32) when chunking.
  */
+template <typename TimeoutLike>
 __device__ __forceinline__ void ll_send(
     const ThreadGroup& group,
     const char* __restrict__ src,
     size_t nbytes,
     LlLine* __restrict__ remote_ll_buf,
-    const Timeout& timeout,
+    const TimeoutLike& timeout,
     size_t buffer_num_lines = 0) {
 #ifdef __CUDA_ARCH__
   const uint32_t flag_value = 1;
@@ -183,12 +184,13 @@ __device__ __forceinline__ void ll_send(
  *                          >0 and < total lines = windowed/chunked mode.
  *                          Must be >= kLlLinesPerWarp (32) when chunking.
  */
+template <typename TimeoutLike>
 __device__ __forceinline__ void ll_recv(
     const ThreadGroup& group,
     char* __restrict__ dst,
     size_t nbytes,
     LlLine* __restrict__ local_ll_buf,
-    const Timeout& timeout,
+    const TimeoutLike& timeout,
     size_t buffer_num_lines = 0) {
 #ifdef __CUDA_ARCH__
   const uint32_t flag_value = 1;
@@ -289,13 +291,14 @@ __device__ __forceinline__ void ll_recv(
  *                          >0 and < total lines = windowed/chunked mode.
  *                          Must be >= kLlLinesPerWarp (32) when chunking.
  */
+template <typename TimeoutLike>
 __device__ __forceinline__ void ll_forward(
     const ThreadGroup& group,
     char* __restrict__ dst,
     size_t nbytes,
     LlLine* __restrict__ local_ll_buf,
     LlLine* __restrict__ remote_ll_buf,
-    const Timeout& timeout,
+    const TimeoutLike& timeout,
     size_t buffer_num_lines = 0) {
 #ifdef __CUDA_ARCH__
   const uint32_t flag_value = 1;

--- a/comms/prims/transport/ll128/Ll128Ops.cuh
+++ b/comms/prims/transport/ll128/Ll128Ops.cuh
@@ -135,12 +135,13 @@ namespace comms::prims {
  *                            windowed/chunked mode. Must be >=
  *                            kLl128PacketsPerWarp (4) when chunking.
  */
+template <typename TimeoutLike>
 __device__ __forceinline__ void ll128_send(
     const ThreadGroup& group,
     const char* __restrict__ src,
     size_t nbytes,
     Ll128Packet* __restrict__ remote_ll128_buf,
-    const Timeout& timeout,
+    const TimeoutLike& timeout,
     size_t buffer_num_packets = 0) {
 #ifdef __CUDA_ARCH__
   // Constant base flag. Multi-step works via receiver ACK (-1) reset between
@@ -311,12 +312,13 @@ __device__ __forceinline__ void ll128_send(
  *                            windowed/chunked mode. Must be >=
  *                            kLl128PacketsPerWarp (4) when chunking.
  */
+template <typename TimeoutLike>
 __device__ __forceinline__ void ll128_recv(
     const ThreadGroup& group,
     char* __restrict__ dst,
     size_t nbytes,
     Ll128Packet* __restrict__ local_ll128_buf,
-    const Timeout& timeout,
+    const TimeoutLike& timeout,
     size_t buffer_num_packets = 0) {
 #ifdef __CUDA_ARCH__
   // Constant base flag. Multi-step works via receiver ACK (-1) reset between
@@ -485,13 +487,14 @@ __device__ __forceinline__ void ll128_recv(
  *                            windowed/chunked mode. Must be >=
  *                            kLl128PacketsPerWarp (4) when chunking.
  */
+template <typename TimeoutLike>
 __device__ __forceinline__ void ll128_forward(
     const ThreadGroup& group,
     char* __restrict__ dst,
     size_t nbytes,
     Ll128Packet* __restrict__ local_ll128_buf,
     Ll128Packet* __restrict__ remote_ll128_buf,
-    const Timeout& timeout,
+    const TimeoutLike& timeout,
     size_t buffer_num_packets = 0) {
 #ifdef __CUDA_ARCH__
   // Constant base flag. Multi-step works via receiver ACK (-1) reset between

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -107,12 +107,13 @@ struct MultimemNvlTransportDevice {
     return user_local_signal_ptr(signal_id)->load();
   }
 
+  template <typename TimeoutLike = Timeout>
   __device__ __forceinline__ void wait_signal_until(
       ThreadGroup& group,
       uint64_t signal_id,
       CmpOp op,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) const {
+      const TimeoutLike& timeout = TimeoutLike()) const {
     user_local_signal_ptr(signal_id)->wait_until(group, op, expected, timeout);
   }
 
@@ -129,12 +130,13 @@ struct MultimemNvlTransportDevice {
     return internal_local_signal_ptr(signal_id)->load();
   }
 
+  template <typename TimeoutLike = Timeout>
   __device__ __forceinline__ void wait_internal_signal_until(
       ThreadGroup& group,
       uint64_t signal_id,
       CmpOp op,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) const {
+      const TimeoutLike& timeout = TimeoutLike()) const {
     internal_local_signal_ptr(signal_id)->wait_until(
         group, op, expected, timeout);
   }

--- a/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
@@ -286,12 +286,13 @@ class P2pNvlTransportDevice {
    * @param op The comparison operation (CMP_EQ, CMP_GE, etc.)
    * @param value The value to compare against
    */
+  template <typename TimeoutLike = Timeout>
   __device__ __forceinline__ void wait_signal_until(
       ThreadGroup& group,
       uint64_t signal_id,
       CmpOp op,
       uint64_t value,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
     localState_.signalBuffer[signal_id].wait_until(group, op, value, timeout);
   }
 
@@ -338,10 +339,11 @@ class P2pNvlTransportDevice {
    * All threads in the group must call this function (collective operation).
    * Both GPUs must call with the same barrier_id to synchronize.
    */
+  template <typename TimeoutLike = Timeout>
   __device__ __forceinline__ void barrier_sync(
       ThreadGroup& group,
       uint64_t barrier_id,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
     // Ensure all prior memory operations are complete
     group.sync();
 
@@ -376,11 +378,12 @@ class P2pNvlTransportDevice {
    * @param nbytes  Total bytes (must be a multiple of 16)
    * @param timeout Timeout for flag polling
    */
+  template <typename TimeoutLike = Timeout>
   __device__ __forceinline__ void ll128_send_group(
       const ThreadGroup& group,
       const char* src,
       size_t nbytes,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
 #if PIPES_IS_DEVICE_COMPILE
     PIPES_DEVICE_CHECK(remoteState_.ll128Buffer != nullptr);
     PIPES_DEVICE_CHECK(can_use_ll128(src, nbytes));
@@ -408,11 +411,12 @@ class P2pNvlTransportDevice {
    * @param nbytes  Total bytes (must be a multiple of 16)
    * @param timeout Timeout for flag polling
    */
+  template <typename TimeoutLike = Timeout>
   __device__ __forceinline__ void ll128_recv_group(
       const ThreadGroup& group,
       char* dst,
       size_t nbytes,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
 #if PIPES_IS_DEVICE_COMPILE
     PIPES_DEVICE_CHECK(localState_.ll128Buffer != nullptr);
     PIPES_DEVICE_CHECK(can_use_ll128(dst, nbytes));
@@ -442,12 +446,13 @@ class P2pNvlTransportDevice {
    * @param successor_transport  Transport for the successor peer
    * @param timeout              Timeout for flag polling
    */
+  template <typename TimeoutLike = Timeout>
   __device__ __forceinline__ void ll128_forward_group(
       const ThreadGroup& group,
       char* dst,
       size_t nbytes,
       const P2pNvlTransportDevice& successor_transport,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
 #if PIPES_IS_DEVICE_COMPILE
     PIPES_DEVICE_CHECK(localState_.ll128Buffer != nullptr);
     PIPES_DEVICE_CHECK(successor_transport.remoteState_.ll128Buffer != nullptr);
@@ -489,12 +494,13 @@ class P2pNvlTransportDevice {
    * @param max_signal_bytes Hint for max bytes between DATA_READY signals.
    *   0 means one signal per slot fill. Capped at per_channel_slot.
    */
+  template <typename TimeoutLike = Timeout>
   __device__ __forceinline__ void send(
       ThreadGroup& group,
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
 #if PIPES_IS_DEVICE_COMPILE
     if (nbytes == 0) {
       return;
@@ -563,13 +569,16 @@ class P2pNvlTransportDevice {
 #endif
   }
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ void recv(
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      [[maybe_unused]] const Timeout& timeout = Timeout(),
+      [[maybe_unused]] const TimeoutLike& timeout = TimeoutLike(),
       [[maybe_unused]] Args... args) {
 #if PIPES_IS_DEVICE_COMPILE
     if (nbytes == 0) {
@@ -661,14 +670,17 @@ class P2pNvlTransportDevice {
    * @param max_signal_bytes Hint for max bytes between signals.
    *   0 means one signal per slot fill. Capped at per_channel_slot.
    */
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename TimeoutLike = Timeout,
+      typename... Args>
   __device__ __forceinline__ void forward(
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
       P2pNvlTransportDevice& successor,
       std::size_t max_signal_bytes = 0,
-      [[maybe_unused]] const Timeout& timeout = Timeout(),
+      [[maybe_unused]] const TimeoutLike& timeout = TimeoutLike(),
       [[maybe_unused]] Args... args) {
 #if PIPES_IS_DEVICE_COMPILE
     if (nbytes == 0) {
@@ -826,12 +838,13 @@ class P2pNvlTransportDevice {
    *   >0 = explicit group count; buffer partitioned per group.group_id.
    * @param timeout       Timeout for flag polling
    */
+  template <typename TimeoutLike = Timeout>
   __device__ __forceinline__ void ll_send(
       const ThreadGroup& group,
       const char* src,
       size_t nbytes,
       int active_groups = 0,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
 #ifdef __CUDA_ARCH__ // NVIDIA-only: depends on ll_send/ll_recv/ll128_* not yet
                      // ported to AMD
     PIPES_DEVICE_CHECK(remoteState_.llBuffer != nullptr);
@@ -884,12 +897,13 @@ class P2pNvlTransportDevice {
    *   >0 = explicit group count; buffer partitioned per group.group_id.
    * @param timeout       Timeout for flag polling
    */
+  template <typename TimeoutLike = Timeout>
   __device__ __forceinline__ void ll_recv(
       const ThreadGroup& group,
       char* dst,
       size_t nbytes,
       int active_groups = 0,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
 #ifdef __CUDA_ARCH__ // NVIDIA-only: depends on ll_send/ll_recv/ll128_* not yet
                      // ported to AMD
     PIPES_DEVICE_CHECK(localState_.llBuffer != nullptr);
@@ -944,13 +958,14 @@ class P2pNvlTransportDevice {
    *   >0 = explicit group count; buffer partitioned per group.group_id.
    * @param timeout              Timeout for flag polling
    */
+  template <typename TimeoutLike = Timeout>
   __device__ __forceinline__ void ll_forward(
       const ThreadGroup& group,
       char* dst,
       size_t nbytes,
       const P2pNvlTransportDevice& successor_transport,
       int active_groups = 0,
-      const Timeout& timeout = Timeout()) {
+      const TimeoutLike& timeout = TimeoutLike()) {
 #ifdef __CUDA_ARCH__ // NVIDIA-only: depends on ll_send/ll_recv/ll128_* not yet
                      // ported to AMD
     PIPES_DEVICE_CHECK(localState_.llBuffer != nullptr);

--- a/comms/torchcomms/RegisteredBuffer.hpp
+++ b/comms/torchcomms/RegisteredBuffer.hpp
@@ -24,7 +24,7 @@ namespace torch::comms {
 
 // Maximum number of IBGDA NICs per GPU surfaced through RegisteredBuffer.
 // Must match NCCLX_MAX_NICS_PER_GPU in nccl.h and comms::prims::kMaxNicsPerGpu
-// — verified by static_assert at the bridge layer (PipesDeviceBackend.cpp,
+// — verified by static_assert at the bridge layer (PrimsDeviceBackend.cpp,
 // the only translation unit that pulls in all three headers). Increase
 // only if a future platform supports > 2 NICs per GPU; update all three
 // constants in lockstep.
@@ -43,7 +43,7 @@ struct RegisteredBuffer {
   size_t size{0};
   void* backend_window{
       nullptr}; // Backend-specific window handle (e.g., ncclWindow_t)
-  // Per-NIC RDMA local keys for IBGDA puts (PipesDeviceBackend). One entry
+  // Per-NIC RDMA local keys for IBGDA puts (PrimsDeviceBackend). One entry
   // per NIC up to kMaxNicsPerGpu; the device-side put selects
   // lkey_per_device.values[nic] based on the slot. `size` is the actual NIC
   // count populated by the backend (0 for backends that do not use IBGDA,

--- a/comms/torchcomms/device/prims/PrimsDeviceBackend.cpp
+++ b/comms/torchcomms/device/prims/PrimsDeviceBackend.cpp
@@ -241,6 +241,7 @@ comms::prims::MultiPeerDeviceHandle PrimsDeviceBackend::fetch_transport_handle(
        static_cast<
            comms::prims::DeviceSpan<comms::prims::Transport>::size_type>(
            n_ranks)},
+      {},
       num_nvl_peers,
       num_ib_peers};
 }

--- a/comms/torchcomms/device/prims/PrimsDeviceBackend.cpp
+++ b/comms/torchcomms/device/prims/PrimsDeviceBackend.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
-// PipesDeviceBackend - Static method implementations
+// PrimsDeviceBackend - Static method implementations
 
 #if defined(ENABLE_PRIMS)
 
-#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
+#include "comms/torchcomms/device/prims/PrimsDeviceBackend.hpp"
 #include "comms/prims/transport/MultiPeerDeviceHandle.cuh"
 #include "comms/prims/transport/rdma/NicConstants.h"
 #include "comms/torchcomms/device/DeviceBackendTraits.hpp"
@@ -19,9 +19,9 @@ namespace torchcomms::device {
 
 using torch::comms::RegisteredBuffer;
 
-// PipesDeviceBackend is the bridge layer where torchcomms, ncclx, and
-// pipes per-NIC IBGDA constants meet. Verify they all agree at compile
-// time so RegisteredBuffer.hpp can stay free of NCCLx and pipes deps.
+// PrimsDeviceBackend is the bridge layer where torchcomms, ncclx, and
+// Prims per-NIC IBGDA constants meet. Verify they all agree at compile
+// time so RegisteredBuffer.hpp can stay free of NCCLx and Prims deps.
 static_assert(
     NCCLX_MAX_NICS_PER_GPU == ::comms::prims::kMaxNicsPerGpu,
     "NCCLX_MAX_NICS_PER_GPU must match comms::prims::kMaxNicsPerGpu");
@@ -33,25 +33,25 @@ static_assert(
 // DeviceWindowDeleter Implementation
 // =============================================================================
 
-void PipesDeviceBackend::DeviceWindowDeleter::operator()(
-    TorchCommDeviceWindow<PipesDeviceBackend>* ptr) const {
+void PrimsDeviceBackend::DeviceWindowDeleter::operator()(
+    TorchCommDeviceWindow<PrimsDeviceBackend>* ptr) const {
   if (cuda_api == nullptr) {
     return;
   }
-  // Destroy the Pipes DeviceWindow via the ncclx API.
+  // Destroy the Prims DeviceWindow via the ncclx API.
   // This mirrors the error-cleanup paths in create_device_window() and
   // ensures ncclx internal state (CtranWin, HostWindow) is properly torn down.
-  if (pipes_device_window != nullptr && nccl_api != nullptr) {
-    auto result = nccl_api->winDestroyDeviceWin(pipes_device_window);
+  if (prims_device_window != nullptr && nccl_api != nullptr) {
+    auto result = nccl_api->winDestroyDeviceWin(prims_device_window);
     if (result != ncclSuccess) {
-      TC_LOG(ERROR) << "[PipesDeviceBackend]: winDestroyDeviceWin failed "
+      TC_LOG(ERROR) << "[PrimsDeviceBackend]: winDestroyDeviceWin failed "
                     << "during cleanup";
     }
   }
   // Free the TorchCommDeviceWindow struct in device memory.
   if (ptr != nullptr) {
     CUDA_CHECK_IGNORE(
-        cuda_api, cuda_api->free(ptr), "Failed to free Pipes device window");
+        cuda_api, cuda_api->free(ptr), "Failed to free Prims device window");
   }
 }
 
@@ -59,7 +59,7 @@ void PipesDeviceBackend::DeviceWindowDeleter::operator()(
 // create_device_window Implementation
 // =============================================================================
 
-PipesDeviceBackend::Ptr PipesDeviceBackend::create_device_window(
+PrimsDeviceBackend::Ptr PrimsDeviceBackend::create_device_window(
     ncclComm_t /* nccl_comm */,
     torch::comms::NcclxApi* nccl_api,
     torch::comms::CudaApi* cuda_api,
@@ -69,60 +69,60 @@ PipesDeviceBackend::Ptr PipesDeviceBackend::create_device_window(
     size_t size) {
   if (nccl_api == nullptr) {
     throw std::runtime_error(
-        "[PipesDeviceBackend::create_device_window]: nccl_api cannot be null");
+        "[PrimsDeviceBackend::create_device_window]: nccl_api cannot be null");
   }
   if (nccl_win == nullptr) {
     throw std::runtime_error(
-        "[PipesDeviceBackend::create_device_window]: nccl_win cannot be null");
+        "[PrimsDeviceBackend::create_device_window]: nccl_win cannot be null");
   }
   if (cuda_api == nullptr) {
     throw std::runtime_error(
-        "[PipesDeviceBackend::create_device_window]: cuda_api cannot be null");
+        "[PrimsDeviceBackend::create_device_window]: cuda_api cannot be null");
   }
 
-  // Step 1: Create the Pipes DeviceWindow in device memory via ncclx.
+  // Step 1: Create the Prims DeviceWindow in device memory via ncclx.
   // COLLECTIVE on first call — all ranks must call together.
-  void* pipes_device_win = nullptr;
+  void* prims_device_win = nullptr;
   auto nccl_result = nccl_api->winCreateDeviceWin(
       nccl_win,
       config.signal_count,
       config.counter_count,
       config.barrier_count,
-      &pipes_device_win);
+      &prims_device_win);
   if (nccl_result != ncclSuccess) {
     throw std::runtime_error(
-        "[PipesDeviceBackend::create_device_window]: "
+        "[PrimsDeviceBackend::create_device_window]: "
         "winCreateDeviceWin failed");
   }
 
-  // Step 2: Build TorchCommDeviceWindow<PipesDeviceBackend> on host.
-  // comm_ = nullptr (unused for Pipes; no separate communicator handle)
+  // Step 2: Build TorchCommDeviceWindow<PrimsDeviceBackend> on host.
+  // comm_ = nullptr (unused for Prims; no separate communicator handle)
   // window_ = typed device pointer to DeviceWindow
-  auto* device_win = static_cast<comms::prims::DeviceWindow*>(pipes_device_win);
-  TorchCommDeviceWindow<PipesDeviceBackend> host_dev_window(
-      nullptr, // Comm = void*, unused for Pipes
+  auto* device_win = static_cast<comms::prims::DeviceWindow*>(prims_device_win);
+  TorchCommDeviceWindow<PrimsDeviceBackend> host_dev_window(
+      nullptr, // Comm = void*, unused for Prims
       device_win, // Window = DeviceWindow*, device pointer
       base,
       size,
       config.comm_rank,
       config.comm_size,
-      0 /* signal_buffer_handle, unused for Pipes */);
+      0 /* signal_buffer_handle, unused for Prims */);
 
   // Step 3: Allocate device memory for the TorchCommDeviceWindow struct.
-  TorchCommDeviceWindow<PipesDeviceBackend>* device_ptr = nullptr;
+  TorchCommDeviceWindow<PrimsDeviceBackend>* device_ptr = nullptr;
   cudaError_t cuda_result = cuda_api->malloc(
       reinterpret_cast<void**>(&device_ptr),
-      sizeof(TorchCommDeviceWindow<PipesDeviceBackend>));
+      sizeof(TorchCommDeviceWindow<PrimsDeviceBackend>));
   if (cuda_result != cudaSuccess) {
-    // Clean up Pipes DeviceWindow on failure.
+    // Clean up Prims DeviceWindow on failure.
     // NOLINTNEXTLINE(facebook-hte-NullableDereference)
-    auto destroy_result = nccl_api->winDestroyDeviceWin(pipes_device_win);
+    auto destroy_result = nccl_api->winDestroyDeviceWin(prims_device_win);
     if (destroy_result != ncclSuccess) {
-      TC_LOG(ERROR) << "[PipesDeviceBackend]: Failed to clean up Pipes device "
+      TC_LOG(ERROR) << "[PrimsDeviceBackend]: Failed to clean up Prims device "
                     << "window after malloc failure";
     }
     throw std::runtime_error(
-        "[PipesDeviceBackend::create_device_window]: Failed to allocate "
+        "[PrimsDeviceBackend::create_device_window]: Failed to allocate "
         "device memory for TorchCommDeviceWindow. CUDA error: " +
         std::string(cuda_api->getErrorString(cuda_result)));
   }
@@ -132,7 +132,7 @@ PipesDeviceBackend::Ptr PipesDeviceBackend::create_device_window(
   cuda_result = cuda_api->memcpy(
       device_ptr,
       &host_dev_window,
-      sizeof(TorchCommDeviceWindow<PipesDeviceBackend>),
+      sizeof(TorchCommDeviceWindow<PrimsDeviceBackend>),
       cudaMemcpyHostToDevice);
   if (cuda_result != cudaSuccess) {
     // NOLINTNEXTLINE(facebook-hte-NullableDereference)
@@ -141,18 +141,18 @@ PipesDeviceBackend::Ptr PipesDeviceBackend::create_device_window(
         cuda_api->free(device_ptr),
         "Failed to free device window during error cleanup");
     // NOLINTNEXTLINE(facebook-hte-NullableDereference)
-    auto destroy_result = nccl_api->winDestroyDeviceWin(pipes_device_win);
+    auto destroy_result = nccl_api->winDestroyDeviceWin(prims_device_win);
     if (destroy_result != ncclSuccess) {
-      TC_LOG(ERROR) << "[PipesDeviceBackend]: Failed to clean up Pipes device "
+      TC_LOG(ERROR) << "[PrimsDeviceBackend]: Failed to clean up Prims device "
                     << "window after memcpy failure";
     }
     throw std::runtime_error(
-        "[PipesDeviceBackend::create_device_window]: Failed to copy "
+        "[PrimsDeviceBackend::create_device_window]: Failed to copy "
         "TorchCommDeviceWindow to device memory. CUDA error: " +
         std::string(cuda_api->getErrorString(cuda_result)));
   }
 
-  DeviceWindowDeleter deleter(nccl_api, cuda_api, pipes_device_win);
+  DeviceWindowDeleter deleter(nccl_api, cuda_api, prims_device_win);
   return Ptr(device_ptr, deleter);
 }
 
@@ -160,26 +160,26 @@ PipesDeviceBackend::Ptr PipesDeviceBackend::create_device_window(
 // register_local_buffer / deregister_local_buffer Implementation
 // =============================================================================
 
-RegisteredBuffer PipesDeviceBackend::register_local_buffer(
+RegisteredBuffer PrimsDeviceBackend::register_local_buffer(
     torch::comms::NcclxApi* nccl_api,
     ncclComm_t nccl_comm,
     void* ptr,
     size_t size) {
-  // Pipes (IBGDA) put uses per-NIC lkeys for WQE construction during RDMA
+  // Prims (IBGDA) put uses per-NIC lkeys for WQE construction during RDMA
   // writes. The kernel-side put selects lkeys[nic] based on the slot it
   // dispatches on, so the full per-NIC array must be populated (using only
   // [0] would corrupt WQEs for slots landing on NIC[1..N-1] on multi-NIC HW).
   // ABI returns into a C struct (ncclLkeyPerDevice) which we field-copy
   // into the C++ wrapper (LkeyPerDevice) so the caller-visible
   // RegisteredBuffer.lkey_per_device gets bounds-checked operator[] and a
-  // populated `size` field. backend_window is unused by Pipes — only the
+  // populated `size` field. backend_window is unused by Prims — only the
   // GIN backend needs it.
   RegisteredBuffer buf;
   ncclLkeyPerDevice raw{};
   auto result = nccl_api->winLocalRegisterBuffer(nccl_comm, ptr, size, &raw);
   if (result != ncclSuccess) {
     throw std::runtime_error(
-        "[PipesDeviceBackend::register_local_buffer]: "
+        "[PrimsDeviceBackend::register_local_buffer]: "
         "winLocalRegisterBuffer failed");
   }
   buf.lkey_per_device.size = raw.size;
@@ -192,7 +192,7 @@ RegisteredBuffer PipesDeviceBackend::register_local_buffer(
   return buf;
 }
 
-void PipesDeviceBackend::deregister_local_buffer(
+void PrimsDeviceBackend::deregister_local_buffer(
     torch::comms::NcclxApi* nccl_api,
     ncclComm_t nccl_comm,
     RegisteredBuffer& buf) {
@@ -201,7 +201,7 @@ void PipesDeviceBackend::deregister_local_buffer(
   }
   auto result = nccl_api->winLocalDeregisterBuffer(nccl_comm, buf.base_ptr);
   if (result != ncclSuccess) {
-    TC_LOG(ERROR) << "[PipesDeviceBackend]: Failed to deregister local buffer";
+    TC_LOG(ERROR) << "[PrimsDeviceBackend]: Failed to deregister local buffer";
   }
   buf = RegisteredBuffer{};
 }
@@ -210,7 +210,7 @@ void PipesDeviceBackend::deregister_local_buffer(
 // fetch_transport_handle Implementation
 // =============================================================================
 
-comms::prims::MultiPeerDeviceHandle PipesDeviceBackend::fetch_transport_handle(
+comms::prims::MultiPeerDeviceHandle PrimsDeviceBackend::fetch_transport_handle(
     ncclComm_t nccl_comm,
     torch::comms::NcclxApi* nccl_api) {
   void* transports_ptr = nullptr;
@@ -229,7 +229,7 @@ comms::prims::MultiPeerDeviceHandle PipesDeviceBackend::fetch_transport_handle(
 
   if (result != ncclSuccess) {
     throw std::runtime_error(
-        "[PipesDeviceBackend::fetch_transport_handle] "
+        "[PrimsDeviceBackend::fetch_transport_handle] "
         "Failed to get MultiPeerDeviceHandle. "
         "Ensure NCCL_CTRAN_USE_PIPES=1 is set.");
   }
@@ -249,7 +249,7 @@ comms::prims::MultiPeerDeviceHandle PipesDeviceBackend::fetch_transport_handle(
 // TransportHandleDeleter Implementation
 // =============================================================================
 
-void PipesDeviceBackend::TransportHandleDeleter::operator()(void* ptr) const {
+void PrimsDeviceBackend::TransportHandleDeleter::operator()(void* ptr) const {
   if (ptr != nullptr && cuda_api != nullptr) {
     CUDA_CHECK_IGNORE(
         cuda_api, cuda_api->free(ptr), "Failed to free transport handle");
@@ -260,14 +260,14 @@ void PipesDeviceBackend::TransportHandleDeleter::operator()(void* ptr) const {
 // get_device_transport Implementation
 // =============================================================================
 
-PipesDeviceBackend::TransportHandleDevPtr
-PipesDeviceBackend::get_device_transport(
+PrimsDeviceBackend::TransportHandleDevPtr
+PrimsDeviceBackend::get_device_transport(
     ncclComm_t nccl_comm,
     torch::comms::NcclxApi* nccl_api,
     torch::comms::CudaApi* cuda_api) {
   if (nccl_api == nullptr || cuda_api == nullptr) {
     throw std::runtime_error(
-        "[PipesDeviceBackend::get_device_transport]: "
+        "[PrimsDeviceBackend::get_device_transport]: "
         "nccl_api and cuda_api must not be null");
   }
 
@@ -280,7 +280,7 @@ PipesDeviceBackend::get_device_transport(
       &device_ptr, sizeof(comms::prims::MultiPeerDeviceHandle));
   if (err != cudaSuccess) {
     throw std::runtime_error(
-        "[PipesDeviceBackend::get_device_transport]: "
+        "[PrimsDeviceBackend::get_device_transport]: "
         "cudaMalloc failed: " +
         std::string(cuda_api->getErrorString(err)));
   }
@@ -298,7 +298,7 @@ PipesDeviceBackend::get_device_transport(
         cuda_api->free(device_ptr),
         "Failed to free transport handle during error cleanup");
     throw std::runtime_error(
-        "[PipesDeviceBackend::get_device_transport]: "
+        "[PrimsDeviceBackend::get_device_transport]: "
         "cudaMemcpy failed: " +
         std::string(cuda_api->getErrorString(err)));
   }

--- a/comms/torchcomms/device/prims/PrimsDeviceBackend.hpp
+++ b/comms/torchcomms/device/prims/PrimsDeviceBackend.hpp
@@ -1,11 +1,11 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
-// TorchComms Device API - Pipes Backend Traits
+// TorchComms Device API - Prims Backend Traits
 //
-// Defines the PipesDeviceBackend trait type for compile-time polymorphism
-// in TorchCommDeviceWindow. Uses Pipes IBGDA and NVLink transports via the
+// Defines the PrimsDeviceBackend trait type for compile-time polymorphism
+// in TorchCommDeviceWindow. Uses Prims IBGDA and NVLink transports via the
 // ctran window infrastructure (accessed through opaque ncclx APIs).
 //
-// This backend replaces GIN (GPU Initiated Networking) with Pipes for
+// This backend replaces GIN (GPU Initiated Networking) with Prims for
 // device-side P2P operations:
 //   - NVLink peers (same node): direct memcpy with NVLink-mapped pointers
 //   - IBGDA peers (cross-node): RDMA writes via DOCA GPUNetIO
@@ -45,20 +45,20 @@ template <typename Backend>
 class TorchCommDeviceWindow;
 
 // =============================================================================
-// PipesDeviceBackend - IBGDA + NVLink backend
+// PrimsDeviceBackend - IBGDA + NVLink backend
 // =============================================================================
 //
 // Types:
-//   - Comm:   void* — unused for Pipes (no separate communicator handle).
+//   - Comm:   void* — unused for Prims (no separate communicator handle).
 //   - Window: comms::prims::DeviceWindow* — typed device pointer to the
 //             transport window allocated by ncclx via winCreateDeviceWin().
 
-struct PipesDeviceBackend {
-  // Comm is unused for Pipes: there is no separate communicator handle.
+struct PrimsDeviceBackend {
+  // Comm is unused for Prims: there is no separate communicator handle.
   // Set to nullptr in the TorchCommDeviceWindow constructor.
   using Comm = void*;
 
-  // Typed device pointer to the Pipes DeviceWindow. Device-side code accesses
+  // Typed device pointer to the Prims DeviceWindow. Device-side code accesses
   // transport handles, NVLink-mapped remote pointers, and IBGDA descriptors
   // directly through this pointer without casting.
   using Window = comms::prims::DeviceWindow*;
@@ -67,7 +67,7 @@ struct PipesDeviceBackend {
   // DeviceWindowDeleter - Custom deleter for device window cleanup
   // =========================================================================
   //
-  // Frees both the TorchCommDeviceWindow<PipesDeviceBackend> struct in device
+  // Frees both the TorchCommDeviceWindow<PrimsDeviceBackend> struct in device
   // memory AND the separate DeviceWindow allocation.
   struct DeviceWindowDeleter {
     torch::comms::NcclxApi* nccl_api{nullptr};
@@ -76,7 +76,7 @@ struct PipesDeviceBackend {
     // winCreateDeviceWin(). Must be freed via winDestroyDeviceWin() since
     // it cannot be reached through ptr from host code (ptr is in device
     // memory).
-    void* pipes_device_window{nullptr};
+    void* prims_device_window{nullptr};
 
     DeviceWindowDeleter() = default;
     DeviceWindowDeleter(
@@ -85,13 +85,13 @@ struct PipesDeviceBackend {
         void* win_dev)
         : nccl_api(nccl_api),
           cuda_api(cuda_api),
-          pipes_device_window(win_dev) {}
+          prims_device_window(win_dev) {}
 
-    void operator()(TorchCommDeviceWindow<PipesDeviceBackend>* ptr) const;
+    void operator()(TorchCommDeviceWindow<PrimsDeviceBackend>* ptr) const;
   };
 
   using Ptr = std::unique_ptr<
-      TorchCommDeviceWindow<PipesDeviceBackend>,
+      TorchCommDeviceWindow<PrimsDeviceBackend>,
       DeviceWindowDeleter>;
 
   // Create fully initialized device window struct in DEVICE memory.
@@ -103,7 +103,7 @@ struct PipesDeviceBackend {
   // winCreateDeviceWin() performs an allGather internally.
   //
   // Signature matches NCCLDeviceBackend::create_device_window for unified
-  // call sites. nccl_comm is unused for Pipes (no separate communicator).
+  // call sites. nccl_comm is unused for Prims (no separate communicator).
   //
   // Parameters:
   //   - nccl_comm:  NCCL communicator (unused, for API consistency with GIN)
@@ -136,7 +136,7 @@ struct PipesDeviceBackend {
   // Backend-specific hooks called from TorchCommWindowNCCLX
   // =========================================================================
 
-  // No additional window registration needed for Pipes.
+  // No additional window registration needed for Prims.
   static void register_extra_window(
       torch::comms::NcclxApi*,
       ncclComm_t,
@@ -144,19 +144,19 @@ struct PipesDeviceBackend {
       void*,
       size_t) {}
 
-  // No additional window to deregister for Pipes.
+  // No additional window to deregister for Prims.
   static void
   deregister_extra_window(torch::comms::NcclxApi*, ncclComm_t, NcclWin*) {}
 
-  // Pipes deleter handles all cleanup via winDestroyDeviceWin.
+  // Prims deleter handles all cleanup via winDestroyDeviceWin.
   static void destroy_device_comm(Ptr&) {}
 
-  // Pipes uses the regular ctran window for device window creation.
+  // Prims uses the regular ctran window for device window creation.
   static NcclWin select_device_win(NcclWin win, NcclWin /* nccl_orig_win */) {
     return win;
   }
 
-  // Register a local buffer for device-side put operations (Pipes/IBGDA path).
+  // Register a local buffer for device-side put operations (Prims/IBGDA path).
   // Uses MultiPeerTransport::localRegisterIbgdaBuffer for non-collective
   // local memory registration. Returns RegisteredBuffer with lkey.
   static torch::comms::RegisteredBuffer register_local_buffer(
@@ -165,7 +165,7 @@ struct PipesDeviceBackend {
       void* ptr,
       size_t size);
 
-  // Deregister a previously registered local buffer (Pipes/IBGDA path).
+  // Deregister a previously registered local buffer (Prims/IBGDA path).
   static void deregister_local_buffer(
       torch::comms::NcclxApi* nccl_api,
       ncclComm_t nccl_comm,
@@ -191,14 +191,14 @@ struct PipesDeviceBackend {
       torch::comms::CudaApi* cuda_api);
 
  private:
-  // Get the pipes transport device handle from the communicator.
+  // Get the Prims transport device handle from the communicator.
   // NON-COLLECTIVE — reads already-exchanged state.
   //
   // Returns a MultiPeerDeviceHandle by value. The handle contains a
   // device pointer to the Transport[] array (already GPU-allocated by
   // MultiPeerTransport::exchange() during ctran init).
   //
-  // Throws std::runtime_error if pipes transport is not initialized.
+  // Throws std::runtime_error if Prims transport is not initialized.
   static comms::prims::MultiPeerDeviceHandle fetch_transport_handle(
       ncclComm_t nccl_comm,
       torch::comms::NcclxApi* nccl_api);

--- a/comms/torchcomms/device/prims/TorchCommDevicePrims.cuh
+++ b/comms/torchcomms/device/prims/TorchCommDevicePrims.cuh
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
-// TorchComms Device API - Pipes Backend Implementation (IBGDA + NVLink)
+// TorchComms Device API - Prims Backend Implementation (IBGDA + NVLink)
 //
-// Device-side implementations for TorchComms using Pipes:
+// Device-side implementations for TorchComms using Prims:
 //   - NVLink peers: direct vectorized memcpy via NVLink-mapped pointers
 //   - IBGDA peers: RDMA Write via DOCA GPUNetIO (P2pIbgdaTransportDevice)
 //   - SELF: NVLink local copy
@@ -20,7 +20,7 @@
 #if defined(ENABLE_PRIMS)
 
 #ifndef __CUDACC__
-#error "TorchCommDevicePipes.cuh must be compiled with nvcc."
+#error "TorchCommDevicePrims.cuh must be compiled with nvcc."
 #endif
 
 #include <cuda_runtime.h>
@@ -32,8 +32,8 @@
 #include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
 #include "comms/prims/transport/nvl/P2pNvlTransportDevice.cuh"
 #include "comms/prims/window/DeviceWindow.cuh"
-#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
-#include "comms/torchcomms/device/pipes/TorchCommDevicePipesTypes.hpp"
+#include "comms/torchcomms/device/prims/PrimsDeviceBackend.hpp"
+#include "comms/torchcomms/device/prims/TorchCommDevicePrimsTypes.hpp"
 
 namespace torchcomms::device {
 
@@ -43,14 +43,14 @@ namespace torchcomms::device {
 
 namespace detail {
 
-// Map TorchComms SignalOp to Pipes SignalOp.
-__device__ inline comms::prims::SignalOp to_pipes_signal_op(SignalOp op) {
+// Map TorchComms SignalOp to Prims SignalOp.
+__device__ inline comms::prims::SignalOp to_prims_signal_op(SignalOp op) {
   return (op == SignalOp::ADD) ? comms::prims::SignalOp::SIGNAL_ADD
                                : comms::prims::SignalOp::SIGNAL_SET;
 }
 
-// Map TorchComms CmpOp to Pipes CmpOp.
-__device__ inline comms::prims::CmpOp to_pipes_cmp_op(CmpOp cmp) {
+// Map TorchComms CmpOp to Prims CmpOp.
+__device__ inline comms::prims::CmpOp to_prims_cmp_op(CmpOp cmp) {
   switch (cmp) {
     case CmpOp::EQ:
       return comms::prims::CmpOp::CMP_EQ;
@@ -68,8 +68,8 @@ __device__ inline comms::prims::CmpOp to_pipes_cmp_op(CmpOp cmp) {
   return comms::prims::CmpOp::CMP_GE;
 }
 
-// Build a pipes::ThreadGroup for the given CoopScope.
-__device__ inline comms::prims::ThreadGroup make_pipes_thread_group(
+// Build a Prims ThreadGroup for the given CoopScope.
+__device__ inline comms::prims::ThreadGroup make_prims_thread_group(
     CoopScope scope) {
   switch (scope) {
     case CoopScope::WARP:
@@ -85,7 +85,7 @@ __device__ inline comms::prims::ThreadGroup make_pipes_thread_group(
 } // namespace detail
 
 // =============================================================================
-// TorchCommDeviceWindow<PipesDeviceBackend> Signal Operations
+// TorchCommDeviceWindow<PrimsDeviceBackend> Signal Operations
 // =============================================================================
 //
 // Delegates to comms::prims::DeviceWindow::signal_peer() which handles
@@ -93,30 +93,30 @@ __device__ inline comms::prims::ThreadGroup make_pipes_thread_group(
 // by (peer, signal_id) pairs.
 
 template <>
-__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::signal(
+__device__ inline int TorchCommDeviceWindow<PrimsDeviceBackend>::signal(
     int peer,
     int signal_id,
     SignalOp op,
     uint64_t value,
     CoopScope scope) {
   auto& win = *window_;
-  auto pipes_op = detail::to_pipes_signal_op(op);
+  auto prims_op = detail::to_prims_signal_op(op);
 
   if (scope == CoopScope::THREAD) {
-    win.signal_peer(peer, signal_id, pipes_op, value);
+    win.signal_peer(peer, signal_id, prims_op, value);
   } else {
-    auto group = detail::make_pipes_thread_group(scope);
-    win.signal_peer(group, peer, signal_id, pipes_op, value);
+    auto group = detail::make_prims_thread_group(scope);
+    win.signal_peer(group, peer, signal_id, prims_op, value);
   }
   return 0;
 }
 
 // =============================================================================
-// TorchCommDeviceWindow<PipesDeviceBackend> RMA Operations
+// TorchCommDeviceWindow<PrimsDeviceBackend> RMA Operations
 // =============================================================================
 
 template <>
-__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::put(
+__device__ inline int TorchCommDeviceWindow<PrimsDeviceBackend>::put(
     size_t dst_offset,
     const torch::comms::RegisteredBuffer& src_buf,
     size_t src_offset,
@@ -126,23 +126,23 @@ __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::put(
     int counter_id,
     CoopScope scope) {
   auto& win = *window_;
-  auto group = detail::make_pipes_thread_group(scope);
+  auto group = detail::make_prims_thread_group(scope);
 
-  // Build Pipes LocalBufferRegistration from RegisteredBuffer.
-  // Pipes uses per-NIC lkeys (IBGDA local keys); GIN uses backend_window.
+  // Build Prims LocalBufferRegistration from RegisteredBuffer.
+  // Prims uses per-NIC lkeys (IBGDA local keys); GIN uses backend_window.
   // The kernel-side put selects lkeys[nic] based on slot dispatch, so all
   // per-NIC keys must be forwarded — partial population would leave
   // NIC[1..size-1] keys zero and corrupt WQEs on multi-NIC HW.
   // Loop bounded by src_buf.lkey_per_device.size (the populated NIC count
   // returned by the backend); on a 1-NIC host only slot 0 is read.
   const int numNics = src_buf.lkey_per_device.size;
-  ::comms::prims::NetworkLKeys pipes_lkeys(numNics);
+  ::comms::prims::NetworkLKeys prims_lkeys(numNics);
   for (int n = 0; n < numNics; ++n) {
-    pipes_lkeys[n] =
+    prims_lkeys[n] =
         ::comms::prims::NetworkLKey{src_buf.lkey_per_device.values[n]};
   }
-  ::comms::prims::LocalBufferRegistration pipes_src{
-      src_buf.base_ptr, src_buf.size, pipes_lkeys};
+  ::comms::prims::LocalBufferRegistration prims_src{
+      src_buf.base_ptr, src_buf.size, prims_lkeys};
 
   bool has_signal = signal_id >= 0;
   bool has_counter = counter_id >= 0;
@@ -152,7 +152,7 @@ __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::put(
         group,
         dst_rank,
         dst_offset,
-        pipes_src,
+        prims_src,
         src_offset,
         bytes,
         signal_id,
@@ -164,7 +164,7 @@ __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::put(
         group,
         dst_rank,
         dst_offset,
-        pipes_src,
+        prims_src,
         src_offset,
         bytes,
         signal_id,
@@ -174,53 +174,53 @@ __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::put(
         group,
         dst_rank,
         dst_offset,
-        pipes_src,
+        prims_src,
         src_offset,
         bytes,
         counter_id,
         /*counterVal=*/1);
   } else {
-    win.put(group, dst_rank, dst_offset, pipes_src, src_offset, bytes);
+    win.put(group, dst_rank, dst_offset, prims_src, src_offset, bytes);
   }
 
   return 0;
 }
 
 // =============================================================================
-// TorchCommDeviceWindow<PipesDeviceBackend> Wait Signal Operations
+// TorchCommDeviceWindow<PrimsDeviceBackend> Wait Signal Operations
 // =============================================================================
 
 template <>
-__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::wait_signal(
+__device__ inline int TorchCommDeviceWindow<PrimsDeviceBackend>::wait_signal(
     int signal_id,
     CmpOp cmp,
     uint64_t value,
     CoopScope scope) {
   auto& win = *window_;
-  auto pipes_cmp = detail::to_pipes_cmp_op(cmp);
-  auto group = detail::make_pipes_thread_group(scope);
-  win.wait_signal(group, signal_id, pipes_cmp, value);
+  auto prims_cmp = detail::to_prims_cmp_op(cmp);
+  auto group = detail::make_prims_thread_group(scope);
+  win.wait_signal(group, signal_id, prims_cmp, value);
   return 0;
 }
 
 template <>
 __device__ inline int
-TorchCommDeviceWindow<PipesDeviceBackend>::wait_signal_from(
+TorchCommDeviceWindow<PrimsDeviceBackend>::wait_signal_from(
     int peer,
     int signal_id,
     CmpOp cmp,
     uint64_t value,
     CoopScope scope) {
   auto& win = *window_;
-  auto pipes_cmp = detail::to_pipes_cmp_op(cmp);
-  auto group = detail::make_pipes_thread_group(scope);
-  win.wait_signal_from(group, peer, signal_id, pipes_cmp, value);
+  auto prims_cmp = detail::to_prims_cmp_op(cmp);
+  auto group = detail::make_prims_thread_group(scope);
+  win.wait_signal_from(group, peer, signal_id, prims_cmp, value);
   return 0;
 }
 
 template <>
 __device__ inline uint64_t
-TorchCommDeviceWindow<PipesDeviceBackend>::read_signal(int signal_id) const {
+TorchCommDeviceWindow<PrimsDeviceBackend>::read_signal(int signal_id) const {
   // window_ is DeviceWindow* (not const), so dereference works in const
   // methods. DeviceWindow::read_signal() only reads inbox values despite being
   // non-const.
@@ -229,10 +229,10 @@ TorchCommDeviceWindow<PipesDeviceBackend>::read_signal(int signal_id) const {
 }
 
 template <>
-__device__ inline void TorchCommDeviceWindow<PipesDeviceBackend>::reset_signal(
+__device__ inline void TorchCommDeviceWindow<PrimsDeviceBackend>::reset_signal(
     int signal_id,
     CoopScope scope) {
-  // Pipes DeviceWindow does not support device-side signal reset.
+  // Prims DeviceWindow does not support device-side signal reset.
   // Use monotonically increasing signal values, or reset from host side.
   (void)signal_id;
   (void)scope;
@@ -240,7 +240,7 @@ __device__ inline void TorchCommDeviceWindow<PipesDeviceBackend>::reset_signal(
 }
 
 // =============================================================================
-// TorchCommDeviceWindow<PipesDeviceBackend> Counter Operations
+// TorchCommDeviceWindow<PrimsDeviceBackend> Counter Operations
 // =============================================================================
 // Counters use companion RDMA QP loopback atomic signaling for NIC completion
 // tracking. read_counter/reset_counter must precede wait_counter (which calls
@@ -248,7 +248,7 @@ __device__ inline void TorchCommDeviceWindow<PipesDeviceBackend>::reset_signal(
 
 template <>
 __device__ inline uint64_t
-TorchCommDeviceWindow<PipesDeviceBackend>::read_counter(int counter_id) const {
+TorchCommDeviceWindow<PrimsDeviceBackend>::read_counter(int counter_id) const {
   // Sum the counter across all peers (aggregate model).
   auto& win = *window_;
   int nPeers = win.num_peers();
@@ -261,10 +261,10 @@ TorchCommDeviceWindow<PipesDeviceBackend>::read_counter(int counter_id) const {
 }
 
 template <>
-__device__ inline void TorchCommDeviceWindow<PipesDeviceBackend>::reset_counter(
+__device__ inline void TorchCommDeviceWindow<PrimsDeviceBackend>::reset_counter(
     int counter_id,
     CoopScope scope) {
-  auto group = detail::make_pipes_thread_group(scope);
+  auto group = detail::make_prims_thread_group(scope);
   group.sync();
 
   if (group.is_leader()) {
@@ -278,12 +278,12 @@ __device__ inline void TorchCommDeviceWindow<PipesDeviceBackend>::reset_counter(
 }
 
 template <>
-__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::wait_counter(
+__device__ inline int TorchCommDeviceWindow<PrimsDeviceBackend>::wait_counter(
     int counter_id,
     CmpOp cmp,
     uint64_t value,
     CoopScope scope) {
-  auto group = detail::make_pipes_thread_group(scope);
+  auto group = detail::make_prims_thread_group(scope);
 
   if (group.is_leader()) {
     while (true) {
@@ -320,18 +320,18 @@ __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::wait_counter(
 }
 
 // =============================================================================
-// TorchCommDeviceWindow<PipesDeviceBackend> Synchronization Operations
+// TorchCommDeviceWindow<PrimsDeviceBackend> Synchronization Operations
 // =============================================================================
 
 template <>
-__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::fence() {
+__device__ inline int TorchCommDeviceWindow<PrimsDeviceBackend>::fence() {
   // Compiler barrier: prevents reordering of put() calls across this point.
   asm volatile("" ::: "memory");
   return 0;
 }
 
 template <>
-__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::flush(
+__device__ inline int TorchCommDeviceWindow<PrimsDeviceBackend>::flush(
     CoopScope scope) {
   // flush() = local completion: source buffers are safe to reuse.
   //
@@ -340,7 +340,7 @@ __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::flush(
   //
   // IBGDA: fence() drains each QP by posting a NOP WQE and waiting for
   // completion, ensuring all prior puts have been handed off to the NIC.
-  auto group = detail::make_pipes_thread_group(scope);
+  auto group = detail::make_prims_thread_group(scope);
   group.sync();
 
   auto& win = *window_;
@@ -356,36 +356,36 @@ __device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::flush(
 }
 
 template <>
-__device__ inline int TorchCommDeviceWindow<PipesDeviceBackend>::barrier(
+__device__ inline int TorchCommDeviceWindow<PrimsDeviceBackend>::barrier(
     int barrier_id,
     CoopScope scope) {
   // Delegate to DeviceWindow::barrier() which handles the full
   // arrive + wait protocol across NVL and IBGDA peers.
   auto& win = *window_;
-  auto group = detail::make_pipes_thread_group(scope);
+  auto group = detail::make_prims_thread_group(scope);
   win.barrier(group, barrier_id);
   return 0;
 }
 
 // =============================================================================
-// TorchCommDeviceWindow<PipesDeviceBackend> NVLink Address Query
+// TorchCommDeviceWindow<PrimsDeviceBackend> NVLink Address Query
 // =============================================================================
 
 template <>
 __device__ inline void*
-TorchCommDeviceWindow<PipesDeviceBackend>::get_nvlink_address(int peer) {
+TorchCommDeviceWindow<PrimsDeviceBackend>::get_nvlink_address(int peer) {
   return window_->get_nvlink_address(peer);
 }
 
 // =============================================================================
-// TorchCommDeviceWindow<PipesDeviceBackend> Multimem Address Query
+// TorchCommDeviceWindow<PrimsDeviceBackend> Multimem Address Query
 // =============================================================================
 
 template <>
 __device__ inline void*
-TorchCommDeviceWindow<PipesDeviceBackend>::get_multimem_address(
+TorchCommDeviceWindow<PrimsDeviceBackend>::get_multimem_address(
     size_t /*offset*/) {
-  // Multimem (NVLS multicast) is an NCCL/GIN feature, not available via Pipes.
+  // Multimem (NVLS multicast) is an NCCL/GIN feature, not available via Prims.
   return nullptr;
 }
 

--- a/comms/torchcomms/device/prims/TorchCommDevicePrimsTypes.hpp
+++ b/comms/torchcomms/device/prims/TorchCommDevicePrimsTypes.hpp
@@ -1,11 +1,11 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
-// TorchComms Device API - Pipes Backend Type Definitions
+// TorchComms Device API - Prims Backend Type Definitions
 //
-// Provides type aliases for the Pipes device backend that are safe to include
+// Provides type aliases for the Prims device backend that are safe to include
 // from both CUDA (.cu) and non-CUDA (.cpp/.cc) code compiled with clang.
 //
 // For device-side implementations (IBGDA/NVLink usage), include
-// TorchCommDevicePipes.cuh instead - but ONLY from .cu files compiled with
+// TorchCommDevicePrims.cuh instead - but ONLY from .cu files compiled with
 // nvcc.
 
 #pragma once
@@ -13,7 +13,7 @@
 #if defined(ENABLE_PRIMS)
 
 #include "comms/torchcomms/device/TorchCommDeviceWindow.hpp"
-#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
+#include "comms/torchcomms/device/prims/PrimsDeviceBackend.hpp"
 
 namespace torchcomms::device {
 
@@ -21,8 +21,11 @@ namespace torchcomms::device {
 // Type Aliases (safe for non-CUDA code)
 // =============================================================================
 
-using DeviceWindowPipes = TorchCommDeviceWindow<PipesDeviceBackend>;
-using RegisteredBufferPipes = torch::comms::RegisteredBuffer;
+using DeviceWindowPrims = TorchCommDeviceWindow<PrimsDeviceBackend>;
+using RegisteredBufferPrims = torch::comms::RegisteredBuffer;
+
+using DeviceWindowPipes = DeviceWindowPrims;
+using RegisteredBufferPipes = RegisteredBufferPrims;
 
 } // namespace torchcomms::device
 

--- a/comms/torchcomms/ncclx/CMakeLists.txt
+++ b/comms/torchcomms/ncclx/CMakeLists.txt
@@ -89,14 +89,14 @@ if("$ENV{ENABLE_PRIMS}" STREQUAL "1")
     set(TORCHCOMMS_ENABLE_PRIMS ON)
     message(STATUS "ENABLE_PRIMS=1 set, building with prims support")
     if(TORCHCOMMS_HAS_NCCL_DEVICE_API)
-        file(GLOB TORCHCOMMS_DEVICE_PIPES_SOURCE
-            "comms/torchcomms/device/pipes/*.cpp")
+        file(GLOB TORCHCOMMS_DEVICE_PRIMS_SOURCE
+            "comms/torchcomms/device/prims/*.cpp")
     else()
-        set(TORCHCOMMS_DEVICE_PIPES_SOURCE "")
+        set(TORCHCOMMS_DEVICE_PRIMS_SOURCE "")
     endif()
 else()
     set(TORCHCOMMS_ENABLE_PRIMS OFF)
-    set(TORCHCOMMS_DEVICE_PIPES_SOURCE "")
+    set(TORCHCOMMS_DEVICE_PRIMS_SOURCE "")
     message(STATUS "ENABLE_PRIMS not set, building without prims support")
 endif()
 
@@ -104,7 +104,7 @@ add_library(torchcomms_comms_ncclx MODULE
     ${TORCHCOMMS_NCCLX_SOURCES}
     ${TORCHCOMMS_CUDA_DEVICE_SOURCES}
     ${TORCHCOMMS_DEVICE_NCCLX_SOURCE}
-    ${TORCHCOMMS_DEVICE_PIPES_SOURCE}
+    ${TORCHCOMMS_DEVICE_PRIMS_SOURCE}
     comms/utils/CudaRAII.cc
     comms/utils/GraphCaptureSideStream.cc
 )

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -22,7 +22,7 @@
 #include "comms/utils/CudaRAII.h"
 
 #if defined(ENABLE_PRIMS)
-#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
+#include "comms/torchcomms/device/prims/PrimsDeviceBackend.hpp"
 #endif
 
 namespace torch::comms {
@@ -2160,7 +2160,7 @@ std::shared_ptr<TorchCommWindow> TorchCommNCCLX::new_window(
   std::shared_ptr<TorchCommWindow> win;
 #if defined(ENABLE_PRIMS)
   // Select Pipes backend when NCCL_CTRAN_USE_PIPES is enabled.
-  // Pipes uses ctran IBGDA/NVLink instead of GIN for device-side P2P.
+  // Prims uses ctran IBGDA/NVLink instead of GIN for device-side P2P.
   const char* pipes_env = std::getenv("NCCL_CTRAN_USE_PIPES");
   if (pipes_env != nullptr && std::string_view(pipes_env) == "1") {
     win = std::make_shared<TorchCommWindowNCCLXPipes>(
@@ -2388,7 +2388,7 @@ static const NCCLXRegistration registration{};
 int64_t TorchCommNCCLX::get_device_transport() {
   if (!device_transport_handle_) {
     device_transport_handle_ =
-        torchcomms::device::PipesDeviceBackend::get_device_transport(
+        torchcomms::device::PrimsDeviceBackend::get_device_transport(
             nccl_comm_, nccl_api_.get(), cuda_api_.get());
   }
   return reinterpret_cast<int64_t>(device_transport_handle_.get());

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -26,7 +26,7 @@
 #include "comms/utils/GraphCaptureSideStream.h"
 
 #if defined(ENABLE_PRIMS)
-#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
+#include "comms/torchcomms/device/prims/PrimsDeviceBackend.hpp"
 #endif
 
 namespace torch::comms {
@@ -500,7 +500,7 @@ class TorchCommNCCLX : public TorchCommBackend,
   void attachMemoryHook();
 
 #if defined(ENABLE_PRIMS)
-  torchcomms::device::PipesDeviceBackend::TransportHandleDevPtr
+  torchcomms::device::PrimsDeviceBackend::TransportHandleDevPtr
       device_transport_handle_;
 #endif
 

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #if defined(ENABLE_PRIMS)
-#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
+#include "comms/torchcomms/device/prims/PrimsDeviceBackend.hpp"
 #endif
 
 namespace torch::comms {
@@ -686,7 +686,7 @@ template class TorchCommWindowNCCLX<HostOnlyBackend>;
 // (get_device_window, register_local_buffer) fall back to the base class
 // default that throws "not yet supported".
 #if defined(ENABLE_PRIMS)
-template class TorchCommWindowNCCLX<torchcomms::device::PipesDeviceBackend>;
+template class TorchCommWindowNCCLX<torchcomms::device::PrimsDeviceBackend>;
 #endif
 
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp
@@ -20,8 +20,8 @@
 #endif
 
 #if defined(ENABLE_PRIMS)
-#include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
-#include "comms/torchcomms/device/pipes/TorchCommDevicePipesTypes.hpp"
+#include "comms/torchcomms/device/prims/PrimsDeviceBackend.hpp"
+#include "comms/torchcomms/device/prims/TorchCommDevicePrimsTypes.hpp"
 #endif
 
 namespace torch::comms {
@@ -112,7 +112,7 @@ class TorchCommWindowNCCLX : public TorchCommWindow {
   //
   // Backend dispatch:
   //   - NCCLDeviceBackend: NCCL_WIN_DEVICE_API | NCCL_WIN_LOCAL_ONLY
-  //   - PipesDeviceBackend: MultiPeerTransport::localRegisterIbgdaBuffer
+  //   - PrimsDeviceBackend: MultiPeerTransport::localRegisterIbgdaBuffer
   //
   // Prerequisites: Must call tensor_register() then get_device_window() first.
   RegisteredBuffer register_local_buffer(const at::Tensor& tensor) override;
@@ -219,7 +219,7 @@ class TorchCommWindowNCCLX : public TorchCommWindow {
   // D2H copy is needed on deregister — we use the cached host copy.
   std::unordered_map<int64_t, RegisteredBuffer> device_buffer_handles_;
 
-  // No ctran_win_ member needed — Pipes device windows are created
+  // No ctran_win_ member needed — Prims device windows are created
   // on-demand via nccl_api_->winCreateDeviceWin() in get_device_window().
 #endif
 
@@ -242,7 +242,7 @@ using TorchCommWindowNCCLXGin = TorchCommWindowNCCLX<HostOnlyBackend>;
 // Only available when ENABLE_PRIMS is defined (propagated from ctran_lib).
 #if defined(ENABLE_PRIMS)
 using TorchCommWindowNCCLXPipes =
-    TorchCommWindowNCCLX<torchcomms::device::PipesDeviceBackend>;
+    TorchCommWindowNCCLX<torchcomms::device::PrimsDeviceBackend>;
 #endif
 
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommWindowNCCLXPipesTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommWindowNCCLXPipesTest.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
-// Unit tests for TorchCommWindowNCCLX with PipesDeviceBackend.
+// Unit tests for TorchCommWindowNCCLX with PrimsDeviceBackend.
 //
 // These tests verify Pipes-specific error paths without real hardware:
 //   1. register_local_buffer() throws when device window not initialized
@@ -145,7 +145,7 @@ TEST_F(TorchCommWindowNCCLXPipesTest, RegisterLocalBufferSuccess) {
   EXPECT_NO_THROW(win->tensor_register(dst_tensor));
 
   // Mock winCreateDeviceWin to succeed — returns a fake device pointer.
-  // PipesDeviceBackend::create_device_window() calls this, then malloc+memcpy.
+  // PrimsDeviceBackend::create_device_window() calls this, then malloc+memcpy.
   void* fake_pipes_dev_win = reinterpret_cast<void*>(0xBEEF);
   EXPECT_CALL(*nccl_mock_, winCreateDeviceWin(_, _, _, _, _))
       .WillOnce(

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cu
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cu
@@ -7,7 +7,7 @@
 #include "PipesDeviceApiTestKernels.cuh"
 #include "StressTestKernelUtils.cuh"
 
-#include "comms/torchcomms/device/pipes/TorchCommDevicePipes.cuh"
+#include "comms/torchcomms/device/prims/TorchCommDevicePrims.cuh"
 
 // Kernel launch error check for test code.
 #define KERNEL_LAUNCH_CHECK()                        \

--- a/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cuh
+++ b/comms/torchcomms/tests/integration/cpp/PipesDeviceApiTestKernels.cuh
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <cuda_runtime.h>
-#include "comms/torchcomms/device/pipes/TorchCommDevicePipesTypes.hpp"
+#include "comms/torchcomms/device/prims/TorchCommDevicePrimsTypes.hpp"
 
 namespace torchcomms::device::test {
 

--- a/comms/torchcomms/triton/device_transport.h
+++ b/comms/torchcomms/triton/device_transport.h
@@ -6,7 +6,7 @@
 // Compiled to LLVM bitcode with clang for linking with Triton kernels.
 //
 // Handle: void* device pointer to comms::prims::MultiPeerDeviceHandle,
-// allocated by PipesDeviceBackend::create_device_transport().
+// allocated by PrimsDeviceBackend::create_device_transport().
 //
 // All operations use comms::prims::make_block_group() internally —
 // all 128 Triton threads cooperate as one block group.

--- a/comms/torchcomms/triton/device_window.cu
+++ b/comms/torchcomms/triton/device_window.cu
@@ -5,7 +5,7 @@
 // It is compiled TWICE to produce two bitcode files:
 //   - Without USE_PIPES_BACKEND → libdevice_window.bc (GIN/NCCLGinBackend)
 //   - With USE_PIPES_BACKEND    → libdevice_window_pipes.bc
-//   (PipesDeviceBackend)
+//   (PrimsDeviceBackend)
 //
 // All functions in this file use the generic TorchCommDeviceWindow API
 // (win->put(), win->signal(), win->flush(), etc.) and work with both backends.
@@ -27,7 +27,7 @@
 #include <cuda_runtime.h>
 
 #ifdef USE_PIPES_BACKEND
-#include "comms/torchcomms/device/pipes/TorchCommDevicePipes.cuh"
+#include "comms/torchcomms/device/prims/TorchCommDevicePrims.cuh"
 #else
 #include "comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh"
 #endif
@@ -36,7 +36,7 @@ using namespace torchcomms::device;
 using torch::comms::RegisteredBuffer;
 
 #ifdef USE_PIPES_BACKEND
-using DeviceWindow = TorchCommDeviceWindow<PipesDeviceBackend>;
+using DeviceWindow = TorchCommDeviceWindow<PrimsDeviceBackend>;
 #else
 using DeviceWindow = TorchCommDeviceWindow<NCCLGinBackend>;
 #endif
@@ -58,7 +58,7 @@ __device__ int torchcomms_self_copy_block(
   auto* dst = reinterpret_cast<char*>(dst_ptr) + dst_offset;
   auto* src = reinterpret_cast<const char*>(src_ptr) + src_offset;
 #ifdef USE_PIPES_BACKEND
-  auto group = detail::make_pipes_thread_group(CoopScope::BLOCK);
+  auto group = detail::make_prims_thread_group(CoopScope::BLOCK);
 #else
   auto group = detail::make_thread_group(CoopScope::BLOCK);
 #endif


### PR DESCRIPTION
Summary:

Review guide: https://www.internalfb.com/intern/paste/P2450872115/

Split out the IBRC backend wait migration so reviewers can inspect the CPU-progress-thread path separately from IBGDA. The test added here compiles the IBRC wait path with AbortDevice without requiring live command queues.

Differential Revision: D115016728
