### PR TITLE
Preserve spdlog delivery semantics (#3480)

### DIFF
--- a/comms/ctran/utils/LogInit.cc
+++ b/comms/ctran/utils/LogInit.cc
@@ -111,7 +111,8 @@ void initCtranLoggingImpl() {
       },
       [](std::string_view message) {
         meta::comms::logger::setLastError(std::string{message}, {});
-      });
+      },
+      NCCL_DEBUG_LOGGING_ASYNC);
   meta::comms::logger::getSpdlogLogger(kCtranSpdlogContext)
       .set_level(loggerLevelToSpdlogLevel(
           meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));

--- a/comms/utils/logger/CommsLogFormatter.h
+++ b/comms/utils/logger/CommsLogFormatter.h
@@ -21,6 +21,7 @@ struct CommsLogMetadata {
   std::string_view prefix;
 };
 
+// The first byte is the legacy severity initial used by stderr routing.
 std::string formatCommsLogMessage(
     std::string_view levelName,
     std::string_view message,

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -57,7 +57,8 @@ class StderrRoutingSink final : public spdlog::sinks::sink {
 
   void log(const spdlog::details::log_msg& message) override {
     if (should_log(message.level) &&
-        shouldWriteCommsLogToStderr(message.level)) {
+        shouldWriteCommsLogToStderr(
+            std::string_view{message.payload.data(), message.payload.size()})) {
       sink_->log(message);
     }
   }
@@ -142,8 +143,16 @@ std::shared_ptr<spdlog::logger> createLogger(std::string name) {
 
 } // namespace
 
-bool shouldWriteCommsLogToStderr(spdlog::level::level_enum level) {
-  return level >= spdlog::level::warn && level < spdlog::level::off;
+bool shouldWriteCommsLogToStderr(std::string_view formattedMessage) {
+  /*
+   * CRITICAL and FATAL share spdlog's critical level. The formatter begins
+   * with the legacy level name so stderr routing can still distinguish them.
+   */
+  if (formattedMessage.empty()) {
+    return false;
+  }
+  const auto levelInitial = formattedMessage.front();
+  return levelInitial == 'W' || levelInitial == 'E' || levelInitial == 'F';
 }
 
 CommsSpdlogLogger::CommsSpdlogLogger()
@@ -154,6 +163,9 @@ CommsSpdlogLogger::CommsSpdlogLogger(std::string name)
       outputSink_(
           std::make_shared<spdlog::sinks::dist_sink_mt>(logger_->sinks())) {
   logger_->sinks() = {outputSink_};
+  synchronousLogger_ = std::make_shared<spdlog::logger>(
+      logger_->name(), logger_->sinks().begin(), logger_->sinks().end());
+  synchronousLogger_->set_level(spdlog::level::trace);
   storeConfiguration(std::make_shared<const Configuration>());
 }
 
@@ -172,10 +184,22 @@ const std::string& CommsSpdlogLogger::name() const {
 
 void CommsSpdlogLogger::set_level(spdlog::level::level_enum level) {
   logger_->set_level(level);
+  /*
+   * logger_ applies the runtime gate before either delivery path. The
+   * synchronous logger stays at trace so it accepts enabled synchronous
+   * messages while logFatal can bypass the primary gate.
+   */
+}
+
+bool CommsSpdlogLogger::usesAsyncLogging() const {
+  return loadConfiguration()->asyncLogging;
 }
 
 void CommsSpdlogLogger::flush() {
   logger_->flush();
+  if (!usesAsyncLogging()) {
+    synchronousLogger_->flush();
+  }
 }
 
 void CommsSpdlogLogger::log(
@@ -196,7 +220,8 @@ void CommsSpdlogLogger::logFatal(
 void CommsSpdlogLogger::configure(
     std::string prefix,
     std::function<int(void)> threadContextFn,
-    std::function<void(std::string_view)> errorCallback) {
+    std::function<void(std::string_view)> errorCallback,
+    bool asyncLogging) {
   if (!threadContextFn) {
     threadContextFn = []() { return 0; };
   }
@@ -204,7 +229,8 @@ void CommsSpdlogLogger::configure(
       std::make_shared<const Configuration>(Configuration{
           std::move(prefix),
           std::move(threadContextFn),
-          std::move(errorCallback)});
+          std::move(errorCallback),
+          asyncLogging});
   storeConfiguration(std::move(configuration));
 }
 
@@ -235,13 +261,15 @@ void CommsSpdlogLogger::configureOutput(std::string_view logFilePath) {
     sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
   } else {
     const auto path = std::string{logFilePath};
+    std::shared_ptr<spdlog::sinks::sink> fileSink;
     try {
-      sinks.push_back(
-          std::make_shared<spdlog::sinks::basic_file_sink_mt>(path, false));
+      fileSink =
+          std::make_shared<spdlog::sinks::basic_file_sink_mt>(path, false);
     } catch (const spdlog::spdlog_ex& error) {
       throw spdlog::spdlog_ex(
           "Failed to open comms log file '" + path + "': " + error.what());
     }
+    sinks.push_back(std::move(fileSink));
     sinks.push_back(std::make_shared<StderrRoutingSink>());
   }
   for (auto& sink : sinks) {
@@ -279,11 +307,9 @@ void CommsSpdlogLogger::logFormatted(
        configuration->threadContextFn(),
        threadName,
        configuration->prefix});
-  if (bypassLevelGate) {
-    spdlog::logger fatalLogger{
-        logger_->name(), logger_->sinks().begin(), logger_->sinks().end()};
-    fatalLogger.log(location, level, formatted);
-    fatalLogger.flush();
+  if (bypassLevelGate || !configuration->asyncLogging) {
+    synchronousLogger_->log(location, level, formatted);
+    synchronousLogger_->flush();
   } else {
     logger_->log(location, level, formatted);
   }
@@ -328,10 +354,14 @@ void configureSpdlogLogger(
     std::string prefix,
     std::string_view logFilePath,
     std::function<int(void)> threadContextFn,
-    std::function<void(std::string_view)> errorCallback) {
+    std::function<void(std::string_view)> errorCallback,
+    bool asyncLogging) {
   auto& logger = getSpdlogLogger(contextName);
   logger.configure(
-      std::move(prefix), std::move(threadContextFn), std::move(errorCallback));
+      std::move(prefix),
+      std::move(threadContextFn),
+      std::move(errorCallback),
+      asyncLogging);
   logger.configureOutput(logFilePath);
 }
 

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -68,12 +68,14 @@ class CommsSpdlogLogger {
   bool should_log(spdlog::level::level_enum level) const;
   const std::string& name() const;
   void set_level(spdlog::level::level_enum level);
+  bool usesAsyncLogging() const;
   void flush();
 
   void configure(
       std::string prefix,
       std::function<int(void)> threadContextFn,
-      std::function<void(std::string_view)> errorCallback = {});
+      std::function<void(std::string_view)> errorCallback = {},
+      bool asyncLogging = true);
   void configureOutput(std::string_view logFilePath);
 
  private:
@@ -81,6 +83,7 @@ class CommsSpdlogLogger {
     std::string prefix{"COMMS"};
     std::function<int(void)> threadContextFn{[]() { return 0; }};
     std::function<void(std::string_view)> errorCallback;
+    bool asyncLogging{true};
   };
 
 #if defined(__cpp_lib_atomic_shared_ptr) && \
@@ -106,6 +109,7 @@ class CommsSpdlogLogger {
 
   std::shared_ptr<spdlog::logger> logger_;
   std::shared_ptr<spdlog::sinks::dist_sink_mt> outputSink_;
+  std::shared_ptr<spdlog::logger> synchronousLogger_;
   ConfigurationStorage configuration_;
 };
 
@@ -121,11 +125,12 @@ void configureSpdlogLogger(
     std::string prefix,
     std::string_view logFilePath,
     std::function<int(void)> threadContextFn,
-    std::function<void(std::string_view)> errorCallback);
+    std::function<void(std::string_view)> errorCallback,
+    bool asyncLogging = true);
 
 void setSpdlogThreadName(std::string_view threadName);
 
-bool shouldWriteCommsLogToStderr(spdlog::level::level_enum level);
+bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
 
 } // namespace meta::comms::logger
 

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -5,12 +5,40 @@
 
 #include "comms/utils/logger/SpdlogLogger.h"
 
+#include <filesystem>
+#include <fstream>
+#include <iterator>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #include <gtest/gtest.h>
 
 using meta::comms::logger::getSpdlogLogger;
+
+class ScopedTestFile {
+ public:
+  explicit ScopedTestFile(std::string filename)
+      : path_{std::filesystem::path{testing::TempDir()} / std::move(filename)} {
+    std::filesystem::remove(path_);
+  }
+
+  ~ScopedTestFile() {
+    removeNoexcept();
+  }
+
+  const std::filesystem::path& path() const {
+    return path_;
+  }
+
+ private:
+  void removeNoexcept() noexcept {
+    std::error_code error;
+    std::filesystem::remove(path_, error);
+  }
+
+  std::filesystem::path path_;
+};
 
 class LogLevelRestoringTest : public testing::Test {
  protected:
@@ -32,17 +60,45 @@ TEST(SpdlogLoggerTest, ReturnsStableLoggerPerContext) {
 }
 
 TEST(SpdlogLoggerTest, MatchesLegacyStderrRouting) {
+  EXPECT_TRUE(meta::comms::logger::shouldWriteCommsLogToStderr("WARN message"));
   EXPECT_TRUE(
-      meta::comms::logger::shouldWriteCommsLogToStderr(spdlog::level::warn));
+      meta::comms::logger::shouldWriteCommsLogToStderr("ERROR message"));
   EXPECT_TRUE(
-      meta::comms::logger::shouldWriteCommsLogToStderr(spdlog::level::err));
-  EXPECT_TRUE(
-      meta::comms::logger::shouldWriteCommsLogToStderr(
-          spdlog::level::critical));
+      meta::comms::logger::shouldWriteCommsLogToStderr("FATAL message"));
   EXPECT_FALSE(
-      meta::comms::logger::shouldWriteCommsLogToStderr(spdlog::level::info));
+      meta::comms::logger::shouldWriteCommsLogToStderr("CRITICAL message"));
   EXPECT_FALSE(
-      meta::comms::logger::shouldWriteCommsLogToStderr(spdlog::level::off));
+      meta::comms::logger::shouldWriteCommsLogToStderr("INFO message"));
+  EXPECT_FALSE(meta::comms::logger::shouldWriteCommsLogToStderr(""));
+}
+
+TEST(SpdlogLoggerTest, SynchronousFileDeliveryMatchesLegacyRouting) {
+  constexpr std::string_view kContext = "comms.synchronous_file_test";
+  const ScopedTestFile scopedLogFile{"comms_spdlog_sync.log"};
+  const auto logPath = scopedLogFile.path().string();
+  meta::comms::logger::configureSpdlogLogger(
+      kContext, "TEST", logPath, []() { return 0; }, {}, false);
+  auto& logger = getSpdlogLogger(kContext);
+  logger.set_level(spdlog::level::info);
+
+  testing::internal::CaptureStderr();
+  COMMS_LOG_CONTEXT(kContext, CRITICAL, "critical file message");
+  COMMS_LOG_CONTEXT(kContext, WARN, "warning mirrored message");
+  logger.set_level(spdlog::level::off);
+  COMMS_LOG_CONTEXT(kContext, INFO, "filtered synchronous message");
+  const auto stderrOutput = testing::internal::GetCapturedStderr();
+
+  std::ifstream logFile{logPath};
+  const std::string fileOutput{
+      std::istreambuf_iterator<char>{logFile},
+      std::istreambuf_iterator<char>{}};
+
+  EXPECT_FALSE(logger.usesAsyncLogging());
+  EXPECT_NE(fileOutput.find("critical file message"), std::string::npos);
+  EXPECT_NE(fileOutput.find("warning mirrored message"), std::string::npos);
+  EXPECT_EQ(fileOutput.find("filtered synchronous message"), std::string::npos);
+  EXPECT_EQ(stderrOutput.find("critical file message"), std::string::npos);
+  EXPECT_NE(stderrOutput.find("warning mirrored message"), std::string::npos);
 }
 
 TEST(SpdlogLoggerTest, MapsFollyLevelNames) {


### PR DESCRIPTION
Summary:

Preserve explicit synchronous logging during the incremental CTRAN migration. The spdlog facade now writes through a synchronous logger when `NCCL_DEBUG_LOGGING_ASYNC` is false while retaining the default nonblocking asynchronous path.

Match legacy file routing by duplicating only W/E/F-prefixed formatted messages to stderr. Nonfatal `CRITICAL` remains file-only, while `WARN`, `ERROR`, and `FATAL` continue to mirror to stderr.

Reviewed By: shr

Differential Revision: D115011610


