### PR TITLE
Migrate AutoTune debug logs (#3482)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduce.cc
+++ b/comms/ctran/algos/AllReduce/AllReduce.cc
@@ -6,6 +6,7 @@
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 
@@ -53,7 +54,7 @@ commResult_t ctranAllReduce(
       if (comm->statex_->nRanks() == 1) {
         // TODO(T242570177): this is a temp workaround for nRanks == 1. Remove
         // the warning below if fixed.
-        CLOGF(
+        CTRAN_LOG(
             DBG,
             "AllReduce ctring currently requires nRanks > 1, fallback to ctdirect");
         return ctranAllReduceDirect(
@@ -74,7 +75,7 @@ commResult_t ctranAllReduce(
               stream,
               timeout);
         }
-        CLOGF(
+        CTRAN_LOG(
             DBG,
             "AllReduce ctring requires count {} > nRanks {}, fallback to ctdirect",
             count,

--- a/comms/ctran/algos/AllReduce/AllReduceRingAutoTune.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRingAutoTune.cc
@@ -12,8 +12,8 @@
 
 #include "comms/ctran/algos/CtranAlgoConsts.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 
 namespace ctran::allreduce::ring {
 
@@ -263,7 +263,7 @@ void logAutoTuneDecisions(
       sizeof(size_t) >= 8, "logAutoTuneDecisions assumes 64-bit size_t");
   auto qpThMin = NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MIN;
   auto qpThMax = NCCL_CTRAN_ALLREDUCE_RING_QP_SCALING_TH_MAX;
-  CLOGF(
+  CTRAN_LOG(
       DBG,
       "AutoTune QP scaling: ThMin={}, ThMax={}, {}",
       qpThMin,
@@ -280,7 +280,7 @@ void logAutoTuneDecisions(
         maxOccupancyBlockSize,
         typeSize,
         arch);
-    CLOGF(
+    CTRAN_LOG(
         DBG,
         "AutoTune ranks {}, msg {}B: blocks {}, chunks {} x {}B",
         nRanks,
@@ -299,7 +299,7 @@ void logAutoTuneDecisions(
           maxOccupancyBlockSize,
           typeSize,
           arch);
-      CLOGF(
+      CTRAN_LOG(
           DBG,
           "AutoTune ranks {}, msg {}B: blocks {}, chunks {} x {}B",
           nRanks,

--- a/comms/ctran/algos/RMA/PutSignal.cc
+++ b/comms/ctran/algos/RMA/PutSignal.cc
@@ -11,6 +11,7 @@
 #include "comms/ctran/colltrace/CollTraceWrapper.h"
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/window/CtranWin.h"
 #include "comms/utils/logger/LogUtils.h"
@@ -400,7 +401,7 @@ waitSignalDriverApi(int peer, CtranWin* win, cudaStream_t stream) {
     // Other errors (e.g., INVALID_VALUE) may indicate prior async failures
     // that could cause the spinning kernel to hang, so propagate them
     if (result == CUDA_ERROR_NOT_SUPPORTED) {
-      CLOGF(
+      CTRAN_LOG(
           WARN,
           "CTRAN RMA: Hardware wait not supported ({}), falling back to spinning kernel",
           errStr ? errStr : "unknown error");
@@ -601,7 +602,7 @@ commResult_t ctranWaitSignal(int peer, CtranWin* win, cudaStream_t stream) {
   }
 
   // Fallback to spinning kernel implementation
-  CLOGF(
+  CTRAN_LOG(
       INFO,
       "CTRAN RMA: WaitSignal falling back to spinning kernel (peer={})",
       peer);

--- a/comms/ctran/utils/CtranLogger.h
+++ b/comms/ctran/utils/CtranLogger.h
@@ -1,0 +1,16 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <string_view>
+
+#include "comms/utils/logger/SpdlogLogger.h"
+
+namespace ctran::logging {
+
+inline constexpr std::string_view kCtranLoggerName = "comms.ctran";
+
+} // namespace ctran::logging
+
+#define CTRAN_LOG(level, ...) \
+  COMMS_LOG_NAMED(::ctran::logging::kCtranLoggerName, level, __VA_ARGS__)

--- a/comms/ctran/utils/CtranMulticast.cc
+++ b/comms/ctran/utils/CtranMulticast.cc
@@ -6,10 +6,9 @@
 #include "comms/ctran/utils/Alloc.h" // isCuMemFabricEnabled
 #include "comms/ctran/utils/Checks.h" // FB_COMMCHECK
 #include "comms/ctran/utils/CudaWrap.h"
-#include "comms/ctran/utils/LogInit.h"
 #include "comms/utils/logger/LogUtils.h"
 #if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12010
-#include "comms/utils/logger/SpdlogLogger.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #endif
 
 namespace ctran::utils {
@@ -67,8 +66,7 @@ bool CtranMulticast::isSupported(int cudaDev) {
         FB_CUPFN(cuMulticastBindMem) == nullptr ||
         FB_CUPFN(cuMulticastGetGranularity) == nullptr ||
         FB_CUPFN(cuMulticastUnbind) == nullptr) {
-      COMMS_LOG_CONTEXT(
-          ctran::logging::kCtranSpdlogContext,
+      CTRAN_LOG(
           WARN,
           "CTRAN-MC: multicast disabled -- driver multicast entry points unavailable (needs a newer CUDA driver)");
       return false;
@@ -82,8 +80,7 @@ bool CtranMulticast::isSupported(int cudaDev) {
             &sup, CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, cuDev),
         false);
     if (sup == 0) {
-      COMMS_LOG_CONTEXT(
-          ctran::logging::kCtranSpdlogContext,
+      CTRAN_LOG(
           WARN,
           "CTRAN-MC: multicast disabled -- device {} reports no multicast support",
           cudaDev);
@@ -102,8 +99,7 @@ bool CtranMulticast::isSupported(int cudaDev) {
     // cannot be shared across the domain -> declare unsupported so the group
     // falls back to unicast.
     if (!isCuMemFabricEnabled()) {
-      COMMS_LOG_CONTEXT(
-          ctran::logging::kCtranSpdlogContext,
+      CTRAN_LOG(
           WARN,
           "CTRAN-MC: multicast disabled -- device {} reports multicast support but fabric memory handles are unavailable (IMEX channel not enabled?); the multicast object cannot be shared across the NVL domain",
           cudaDev);

--- a/comms/ctran/utils/LogInit.cc
+++ b/comms/ctran/utils/LogInit.cc
@@ -11,7 +11,7 @@
 #include "comms/utils/logger/Logger.h"
 #include "comms/utils/logger/LoggingFormat.h"
 #if !defined(__HIP_PLATFORM_AMD__)
-#include "comms/utils/logger/SpdlogLogger.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #endif
 
 namespace ctran::logging {
@@ -106,7 +106,7 @@ void initCtranLoggingImpl() {
 #endif
 #if !defined(__HIP_PLATFORM_AMD__)
   meta::comms::logger::configureSpdlogLogger(
-      kCtranSpdlogContext,
+      kCtranLoggerName,
       "CTRAN",
       meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
       []() {
@@ -118,7 +118,7 @@ void initCtranLoggingImpl() {
         meta::comms::logger::setLastError(std::string{message}, {});
       },
       NCCL_DEBUG_LOGGING_ASYNC);
-  meta::comms::logger::getSpdlogLogger(kCtranSpdlogContext)
+  meta::comms::logger::getSpdlogLogger(kCtranLoggerName)
       .set_level(loggerLevelToSpdlogLevel(
           meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
 #endif

--- a/comms/ctran/utils/LogInit.h
+++ b/comms/ctran/utils/LogInit.h
@@ -4,18 +4,7 @@
 
 #include <string_view>
 
-//
-// This file defines Logging APIs modelled atop `folly/log.h`. Atop it intends
-// to add some additional features like GPU index prefixing and conditional
-// logging per sub-system
-//
-// Use this API specifically for logging in the context of GPU code. Otherwise,
-// prefer using `folly/log.h` directly for performance reasons.
-//
-
 namespace ctran::logging {
-
-constexpr std::string_view kCtranSpdlogContext = "comms.ctran";
 
 // AKA Ctran file path. This needs to be changed in refactoring
 constexpr std::string_view kCtranCategory = "comms.ncclx.v2_25.comms.ctran";

--- a/comms/ctran/utils/tests/LogUT.cc
+++ b/comms/ctran/utils/tests/LogUT.cc
@@ -12,12 +12,12 @@
 #include <gmock/gmock.h>
 #include "TestLogCategory.h"
 #include "comms/ctran/tests/CtranTestUtils.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/LogInit.h"
 #include "comms/ctran/utils/Utils.h"
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/Logger.h"
-#include "comms/utils/logger/SpdlogLogger.h"
 
 class CtranUtilsLogTest : public ::testing::Test {
  public:
@@ -70,14 +70,13 @@ TEST_F(CtranUtilsLogTest, TestCLOGF) {
   EXPECT_NE(messages[0].find(expectedContent), std::string::npos);
 }
 
-TEST_F(CtranUtilsLogTest, TestSpdlogContextPreservesLastError) {
+TEST_F(CtranUtilsLogTest, TestCtranLoggerPreservesLastError) {
   auto& logger =
-      meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranSpdlogContext);
-  EXPECT_EQ(logger.name(), ctran::logging::kCtranSpdlogContext);
+      meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName);
+  EXPECT_EQ(logger.name(), ctran::logging::kCtranLoggerName);
   logger.set_level(spdlog::level::info);
 
-  COMMS_LOG_CONTEXT(
-      ctran::logging::kCtranSpdlogContext, ERR, "Spdlog CTRAN error {}", 42);
+  CTRAN_LOG(ERR, "Spdlog CTRAN error {}", 42);
 
   EXPECT_THAT(
       meta::comms::logger::getLastCommsError(),

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -320,8 +320,8 @@ CommsSpdlogLogger& getSpdlogLogger() {
   return logger;
 }
 
-CommsSpdlogLogger& getSpdlogLogger(std::string_view contextName) {
-  if (contextName == kLoggerName) {
+CommsSpdlogLogger& getSpdlogLogger(std::string_view loggerName) {
+  if (loggerName == kLoggerName) {
     return getSpdlogLogger();
   }
   static std::shared_mutex mutex;
@@ -329,15 +329,15 @@ CommsSpdlogLogger& getSpdlogLogger(std::string_view contextName) {
       loggers;
   {
     std::shared_lock lock{mutex};
-    if (const auto it = loggers.find(contextName); it != loggers.end()) {
+    if (const auto it = loggers.find(loggerName); it != loggers.end()) {
       return *it->second;
     }
   }
   std::unique_lock lock{mutex};
-  if (const auto it = loggers.find(contextName); it != loggers.end()) {
+  if (const auto it = loggers.find(loggerName); it != loggers.end()) {
     return *it->second;
   }
-  auto name = std::string{contextName};
+  auto name = std::string{loggerName};
   auto logger = std::make_unique<CommsSpdlogLogger>(name);
   const auto it = loggers.emplace(std::move(name), std::move(logger)).first;
   return *it->second;
@@ -350,13 +350,13 @@ void configureSpdlogLogger(
 }
 
 void configureSpdlogLogger(
-    std::string_view contextName,
+    std::string_view loggerName,
     std::string prefix,
     std::string_view logFilePath,
     std::function<int(void)> threadContextFn,
     std::function<void(std::string_view)> errorCallback,
     bool asyncLogging) {
-  auto& logger = getSpdlogLogger(contextName);
+  auto& logger = getSpdlogLogger(loggerName);
   logger.configure(
       std::move(prefix),
       std::move(threadContextFn),

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -142,6 +142,9 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
     }                                                                      \
   } while (false)
 
+#define COMMS_LOGGER_DEBUG(logger, ...) \
+  SPDLOG_LOGGER_CALL(logger, ::spdlog::level::debug, __VA_ARGS__)
+
 #define COMMS_LOG_FATAL_IMPL(logger_expression, ...)               \
   do {                                                             \
     auto& _comms_logger = (logger_expression);                     \
@@ -157,13 +160,13 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
   COMMS_LOG_IMPL(                               \
       ::meta::comms::logger::getSpdlogLogger(), \
       ::spdlog::level::debug,                   \
-      SPDLOG_LOGGER_DEBUG,                      \
+      COMMS_LOGGER_DEBUG,                       \
       __VA_ARGS__)
 #define COMMS_LOG_NAMED_DBG(logger_name, ...)              \
   COMMS_LOG_IMPL(                                          \
       ::meta::comms::logger::getSpdlogLogger(logger_name), \
       ::spdlog::level::debug,                              \
-      SPDLOG_LOGGER_DEBUG,                                 \
+      COMMS_LOGGER_DEBUG,                                  \
       __VA_ARGS__)
 
 #define COMMS_LOG_INFO(...)                     \

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -114,14 +114,14 @@ class CommsSpdlogLogger {
 };
 
 CommsSpdlogLogger& getSpdlogLogger();
-CommsSpdlogLogger& getSpdlogLogger(std::string_view contextName);
+CommsSpdlogLogger& getSpdlogLogger(std::string_view loggerName);
 
 void configureSpdlogLogger(
     std::string prefix,
     std::function<int(void)> threadContextFn);
 
 void configureSpdlogLogger(
-    std::string_view contextName,
+    std::string_view loggerName,
     std::string prefix,
     std::string_view logFilePath,
     std::function<int(void)> threadContextFn,
@@ -159,11 +159,11 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
       ::spdlog::level::debug,                   \
       SPDLOG_LOGGER_DEBUG,                      \
       __VA_ARGS__)
-#define COMMS_LOG_CONTEXT_DBG(context, ...)            \
-  COMMS_LOG_IMPL(                                      \
-      ::meta::comms::logger::getSpdlogLogger(context), \
-      ::spdlog::level::debug,                          \
-      SPDLOG_LOGGER_DEBUG,                             \
+#define COMMS_LOG_NAMED_DBG(logger_name, ...)              \
+  COMMS_LOG_IMPL(                                          \
+      ::meta::comms::logger::getSpdlogLogger(logger_name), \
+      ::spdlog::level::debug,                              \
+      SPDLOG_LOGGER_DEBUG,                                 \
       __VA_ARGS__)
 
 #define COMMS_LOG_INFO(...)                     \
@@ -193,34 +193,34 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
 #define COMMS_LOG_FATAL(...) \
   COMMS_LOG_FATAL_IMPL(::meta::comms::logger::getSpdlogLogger(), __VA_ARGS__)
 
-#define COMMS_LOG_CONTEXT_INFO(context, ...)           \
-  COMMS_LOG_IMPL(                                      \
-      ::meta::comms::logger::getSpdlogLogger(context), \
-      ::spdlog::level::info,                           \
-      SPDLOG_LOGGER_INFO,                              \
+#define COMMS_LOG_NAMED_INFO(logger_name, ...)             \
+  COMMS_LOG_IMPL(                                          \
+      ::meta::comms::logger::getSpdlogLogger(logger_name), \
+      ::spdlog::level::info,                               \
+      SPDLOG_LOGGER_INFO,                                  \
       __VA_ARGS__)
-#define COMMS_LOG_CONTEXT_WARN(context, ...)           \
-  COMMS_LOG_IMPL(                                      \
-      ::meta::comms::logger::getSpdlogLogger(context), \
-      ::spdlog::level::warn,                           \
-      SPDLOG_LOGGER_WARN,                              \
+#define COMMS_LOG_NAMED_WARN(logger_name, ...)             \
+  COMMS_LOG_IMPL(                                          \
+      ::meta::comms::logger::getSpdlogLogger(logger_name), \
+      ::spdlog::level::warn,                               \
+      SPDLOG_LOGGER_WARN,                                  \
       __VA_ARGS__)
-#define COMMS_LOG_CONTEXT_ERR(context, ...)            \
-  COMMS_LOG_IMPL(                                      \
-      ::meta::comms::logger::getSpdlogLogger(context), \
-      ::spdlog::level::err,                            \
-      SPDLOG_LOGGER_ERROR,                             \
+#define COMMS_LOG_NAMED_ERR(logger_name, ...)              \
+  COMMS_LOG_IMPL(                                          \
+      ::meta::comms::logger::getSpdlogLogger(logger_name), \
+      ::spdlog::level::err,                                \
+      SPDLOG_LOGGER_ERROR,                                 \
       __VA_ARGS__)
-#define COMMS_LOG_CONTEXT_CRITICAL(context, ...)       \
-  COMMS_LOG_IMPL(                                      \
-      ::meta::comms::logger::getSpdlogLogger(context), \
-      ::spdlog::level::critical,                       \
-      SPDLOG_LOGGER_CRITICAL,                          \
+#define COMMS_LOG_NAMED_CRITICAL(logger_name, ...)         \
+  COMMS_LOG_IMPL(                                          \
+      ::meta::comms::logger::getSpdlogLogger(logger_name), \
+      ::spdlog::level::critical,                           \
+      SPDLOG_LOGGER_CRITICAL,                              \
       __VA_ARGS__)
-#define COMMS_LOG_CONTEXT_FATAL(context, ...) \
-  COMMS_LOG_FATAL_IMPL(                       \
-      ::meta::comms::logger::getSpdlogLogger(context), __VA_ARGS__)
+#define COMMS_LOG_NAMED_FATAL(logger_name, ...) \
+  COMMS_LOG_FATAL_IMPL(                         \
+      ::meta::comms::logger::getSpdlogLogger(logger_name), __VA_ARGS__)
 
 #define COMMS_LOG(level, ...) COMMS_LOG_##level(__VA_ARGS__)
-#define COMMS_LOG_CONTEXT(context, level, ...) \
-  COMMS_LOG_CONTEXT_##level(context, __VA_ARGS__)
+#define COMMS_LOG_NAMED(logger_name, level, ...) \
+  COMMS_LOG_NAMED_##level(logger_name, __VA_ARGS__)

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -135,18 +135,21 @@ TEST_F(LogLevelRestoringTest, FatalIsNotSuppressedByRuntimeLevel) {
       "FATAL fatal while logging is disabled");
 }
 
-TEST(SpdlogLoggerTest, CompileTimeGateSkipsArguments) {
+TEST_F(LogLevelRestoringTest, DebugIsAvailableWithInfoCompileGate) {
+  static_assert(SPDLOG_ACTIVE_LEVEL == SPDLOG_LEVEL_INFO);
   int evaluationCount = 0;
-  COMMS_LOG(DBG, "compiled out: {}", ++evaluationCount);
-  EXPECT_EQ(evaluationCount, 0);
+  getSpdlogLogger().set_level(spdlog::level::debug);
 
-  COMMS_LOG(INFO, "compiled in: {}", ++evaluationCount);
+  COMMS_LOG(DBG, "compiled in: {}", ++evaluationCount);
   EXPECT_EQ(evaluationCount, 1);
 }
 
 TEST_F(LogLevelRestoringTest, RuntimeGateSkipsArguments) {
   int evaluationCount = 0;
   getSpdlogLogger().set_level(spdlog::level::warn);
+
+  COMMS_LOG(DBG, "filtered at runtime: {}", ++evaluationCount);
+  EXPECT_EQ(evaluationCount, 0);
 
   COMMS_LOG(INFO, "filtered at runtime: {}", ++evaluationCount);
   EXPECT_EQ(evaluationCount, 0);

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -82,10 +82,10 @@ TEST(SpdlogLoggerTest, SynchronousFileDeliveryMatchesLegacyRouting) {
   logger.set_level(spdlog::level::info);
 
   testing::internal::CaptureStderr();
-  COMMS_LOG_CONTEXT(kContext, CRITICAL, "critical file message");
-  COMMS_LOG_CONTEXT(kContext, WARN, "warning mirrored message");
+  COMMS_LOG_NAMED(kContext, CRITICAL, "critical file message");
+  COMMS_LOG_NAMED(kContext, WARN, "warning mirrored message");
   logger.set_level(spdlog::level::off);
-  COMMS_LOG_CONTEXT(kContext, INFO, "filtered synchronous message");
+  COMMS_LOG_NAMED(kContext, INFO, "filtered synchronous message");
   const auto stderrOutput = testing::internal::GetCapturedStderr();
 
   std::ifstream logFile{logPath};
@@ -172,7 +172,7 @@ TEST(SpdlogLoggerTest, ErrorCallbackReceivesFormattedUserMessage) {
       []() { return 0; },
       [&](std::string_view message) { errorMessage = message; });
 
-  COMMS_LOG_CONTEXT("comms.callback_test", ERR, "error message: {}", 9);
+  COMMS_LOG_NAMED("comms.callback_test", ERR, "error message: {}", 9);
   EXPECT_EQ(errorMessage, "error message: 9");
   logger.configure("TEST", []() { return 0; }, {});
 }
@@ -186,10 +186,10 @@ TEST(SpdlogLoggerTest, ErrorCallbackDoesNotReenter) {
       []() { return 0; },
       [&](std::string_view) {
         ++callbackCount;
-        COMMS_LOG_CONTEXT(kContext, ERR, "nested error");
+        COMMS_LOG_NAMED(kContext, ERR, "nested error");
       });
 
-  COMMS_LOG_CONTEXT(kContext, ERR, "outer error");
+  COMMS_LOG_NAMED(kContext, ERR, "outer error");
   EXPECT_EQ(callbackCount, 1);
   logger.configure("TEST", []() { return 0; }, {});
 }
@@ -210,10 +210,10 @@ TEST(SpdlogLoggerTest, ErrorCallbackGuardSpansContexts) {
       []() { return 0; },
       [&](std::string_view) {
         ++outerCallbackCount;
-        COMMS_LOG_CONTEXT(kInnerContext, ERR, "nested error");
+        COMMS_LOG_NAMED(kInnerContext, ERR, "nested error");
       });
 
-  COMMS_LOG_CONTEXT(kOuterContext, ERR, "outer error");
+  COMMS_LOG_NAMED(kOuterContext, ERR, "outer error");
   EXPECT_EQ(outerCallbackCount, 1);
   EXPECT_EQ(innerCallbackCount, 0);
   outerLogger.configure("TEST", []() { return 0; }, {});
@@ -232,8 +232,8 @@ TEST(SpdlogLoggerTest, ErrorCallbackExceptionDoesNotEscapeLogCall) {
         throw std::runtime_error{"callback failure"};
       });
 
-  EXPECT_NO_THROW(COMMS_LOG_CONTEXT(kContext, ERR, "first error"));
-  EXPECT_NO_THROW(COMMS_LOG_CONTEXT(kContext, ERR, "second error"));
+  EXPECT_NO_THROW(COMMS_LOG_NAMED(kContext, ERR, "first error"));
+  EXPECT_NO_THROW(COMMS_LOG_NAMED(kContext, ERR, "second error"));
   EXPECT_EQ(callbackCount, 2);
   logger.configure("TEST", []() { return 0; }, {});
 }


### PR DESCRIPTION
Summary:

Migrate the three CTRAN AllReduce ring AutoTune diagnostics from `CLOGF` to the `CTRAN_LOG` domain wrapper. This preserves debug-level gating and the CTRAN prefix, and removes the no-longer-needed legacy logging include from this source file.

Reviewed By: shr

Differential Revision: D114833969


