### PR TITLE
Migrate CtranAlgo diagnostics (#3484)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -25,6 +25,7 @@
 #include "comms/ctran/algos/CtranAlgoConsts.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/profiler/Profiler.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/CudaUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -1433,7 +1434,7 @@ commResult_t ctranAllReduceRing(
   std::tie(hostResource.tmpRecvBufRev, hostResource.tmpRecvBufRevHdl) =
       comm->ctran_->algo->getTmpBufInfo(
           CtranAlgo::TmpbufType::RING_TMP_RECV_BUF_REV);
-  CLOGF(
+  CTRAN_LOG(
       DBG,
       "AutoTune: {} blocks of {} threads, tmpbuf {} x {} chunks, bidirAg={}",
       numBlocks,

--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -9,6 +9,7 @@
 #include "comms/ctran/algos/CtranAlgoConsts.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/TmpBufSegManager.h"
 #if defined(ENABLE_PRIMS)
 #include "comms/prims/transport/nvl/NvlChannelState.cuh"
@@ -108,7 +109,7 @@ CtranAlgoDeviceState* CtranAlgo::getDevState() {
 
 comms::prims::P2pNvlTransportDevice* CtranAlgo::getNvlTransportsBase() {
   if (!isResInitialized_) {
-    CLOGF(
+    CTRAN_LOG(
         ERR,
         "CTRAN-ALGO: getNvlTransportsBase() called before initKernelResources() is called. ");
     return nullptr;
@@ -245,7 +246,7 @@ commResult_t CtranAlgo::initKernelResources() {
     return commInternalError;
   }
 
-  CLOGF(
+  CTRAN_LOG(
       INFO,
       "CTRAN-ALGO: prepare device global state {} bytes (sharedMemPerBlockOptin {} bytes) on rank {} localRank {} nLocalRanks {} commHash {:x}",
       sizeof(CtranAlgoDeviceState),
@@ -524,7 +525,7 @@ CtranAlgo::SharedResource::SharedResource(CtranComm* comm) {
       static_cast<commResult_t>(std::move(resFuture).get()),
       comm_->logMetaData_);
 
-  CLOGF(
+  CTRAN_LOG(
       INFO,
       "CTRAN-ALGO: requested {} bytes (allocated {}) of device buffer as shared resource on rank {} localRank {}",
       shmSize,

--- a/comms/torchcomms/tests/integration/py/TPCommTest.py
+++ b/comms/torchcomms/tests/integration/py/TPCommTest.py
@@ -101,8 +101,10 @@ class TPCommTest(unittest.TestCase):
             },
         )
         LR = 8e-4  # Use the learning rate from torchtitan
-        local_optim = torch.optim.SGD(model.parameters(), lr=LR)
-        dist_optim = torch.optim.SGD(model_tp.parameters(), lr=LR)
+        # This test validates TorchComm TP semantics, not DTensor's foreach
+        # optimizer kernel. Keep both optimizers on the per-tensor path.
+        local_optim = torch.optim.SGD(model.parameters(), lr=LR, foreach=False)
+        dist_optim = torch.optim.SGD(model_tp.parameters(), lr=LR, foreach=False)
         self._compare_params(model, model_tp, rank0_only)
         for _ in range(30):
             inp = torch.rand(*inp_size, device=device)


### PR DESCRIPTION
Summary:

Migrate three direct CTRAN algorithm-resource diagnostics from `CLOGF` to the `CTRAN_LOG` domain wrapper. CTRAN initializes its logger before constructing `CtranAlgo`, so the resource setup and invariant diagnostics retain configured levels and the CTRAN prefix; trace and subsystem logging remain unchanged.

Reviewed By: shr

Differential Revision: D114834261


