### PR TITLE
Fix v2_29 OSS Makefile: add the spdlog build flags (#3487)

### DIFF
--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -23,6 +23,8 @@ include ../makefiles/version.mk
 CXXFLAGS += -DMOCK_SCUBA_DATA -DFOLLY_XLOG_STRIP_PREFIXES=\"${BASE_DIR}\"
 # Use header-only fmt to avoid runtime dependency on libfmt.so
 CXXFLAGS += -DFMT_HEADER_ONLY=1
+CXXFLAGS += -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DSPDLOG_FMT_EXTERNAL
+NVCUFLAGS += -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DSPDLOG_FMT_EXTERNAL
 
 # Enable JSON parsing in the NCCLX built-in CSV/JSON tuner (meta/tuner) when
 # folly is available. The conda feedstock build sets NCCLX_TUNER_WITH_FOLLY_JSON=1


### PR DESCRIPTION
Summary:

The v2_29 OSS (`make`) build of ncclx is broken on master. Any
torchcomms-iter / conda build against `comms/ncclx/v2_29` fails with:

```
comms/utils/logger/SpdlogLogger.h:14:2: error: #error "SpdlogLogger requires SPDLOG_FMT_EXTERNAL from the build target"
comms/utils/logger/SpdlogLogger.h:18:2: error: #error "SpdlogLogger requires SPDLOG_ACTIVE_LEVEL from the build target"
make[1]: *** [Makefile:428: .../comms/utils/logger/LoggingFormat.o] Error 1
```

`SpdlogLogger.h` (added in D114807334) hard-errors unless the build defines
`SPDLOG_FMT_EXTERNAL` and `SPDLOG_ACTIVE_LEVEL`. That diff added the two flags
to `comms/ncclx/v2_30/src/Makefile`, but not to the v2_29 one. It was latent
until D114825986 / D114826772 made `LoggingFormat.cc` include
`SpdlogLogger.h` — and `src/Makefile` picks up the logger sources with a
wildcard that is identical in both versions:

```
LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/logger/*.cc)
```

so v2_29 now compiles `LoggingFormat.cc` (and `SpdlogLogger.cc`) with no
spdlog configuration. The Buck build is unaffected because
`comms/utils/logger/BUCK` supplies the same two flags via
`propagated_pp_flags`.

This diff copies the v2_30 lines verbatim into the v2_29 `src/Makefile`.

No link changes are needed: `SPDLOG_COMPILED_LIB` stays undefined, so spdlog
is consumed header-only and nothing links `libspdlog`. `SPDLOG_FMT_EXTERNAL`
routes spdlog at the build's external fmt rather than its bundled copy, which
is already header-only here via the adjacent `-DFMT_HEADER_ONLY=1`.

Reviewed By: rmahidhar

Differential Revision: D115058143


