### PR TITLE
Add resumable forward (init_forward_progress / progress_forward_once) (#3488)

### DIFF
--- a/comms/prims/tests/P2pIbgdaTransportDeviceTest.cu
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTest.cu
@@ -416,4 +416,212 @@ void runTestWaitSignalNoTimeout(
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
+// =============================================================================
+// Resumable-forward (init_forward_progress / progress_forward_once) no-QP tests
+//
+// These exercise ONLY the no-NIC control paths: zero-byte init, init state
+// layout, the Done/idle-pairing early-return, and the paired-slot desync trap.
+// They never reach a signal wait or RDMA put (which need real QPs); those are
+// covered by the distributed recv_forward_chain_test. A geometry-only
+// IbChannelLayout + a zeroed IbLocalChannel array is enough because the trap
+// and init paths touch only progress-slot state, not staging/signal buffers.
+// Guarded NVIDIA-only because progress_forward_once carries a dependent
+// static_assert(sizeof(CopyOp)==0) on AMD.
+// =============================================================================
+#ifndef __HIP_PLATFORM_AMD__
+namespace {
+
+// Build a QP-less transport over a caller-provided (zeroed) IbLocalChannel
+// array with a geometry-only channel layout.
+__device__ __forceinline__ P2pIbgdaTransportDevice makeNoQpForwardTransport(
+    IbLocalChannel* channels,
+    int maxChannels,
+    int pipelineDepth,
+    std::size_t perChannelBufferSize) {
+  IbChannelLayout layout{};
+  layout.maxChannels = maxChannels;
+  layout.numLanes = 1;
+  layout.pipelineDepth = pipelineDepth;
+  layout.perChannelBufferSize = perChannelBufferSize;
+  layout.perChannelSize = perChannelBufferSize;
+  return P2pIbgdaTransportDevice(
+      DeviceSpan<NicDeviceIbgdaResources>{}, // empty NIC span => no QPs
+      IbgdaRemoteBuffer{},
+      IbgdaLocalBuffer{},
+      IbgdaLocalBuffer{},
+      /*numSignalSlots=*/0,
+      /*numCounterSlots=*/0,
+      maxChannels,
+      /*qpsPerConnection=*/1,
+      /*qpDirectionCount=*/kIbDirections,
+      DeviceSpan<IbLocalChannel>(channels, static_cast<uint32_t>(maxChannels)),
+      layout);
+}
+
+} // namespace
+
+// scenario: 0 = zero-byte init -> both slots Done, both nextStep preserved;
+// 1 = non-zero init state layout; 2 = completed op (both slots Done, equal
+// cursors) -> progress_forward_once returns Done.
+__global__ void testForwardProgressNoQp(
+    int scenario,
+    IbLocalChannel* self_channels,
+    IbLocalChannel* fwd_channels,
+    int maxChannels,
+    int pipelineDepth,
+    unsigned long long perChannelBufferSize,
+    unsigned long long nbytes,
+    bool* success) {
+  auto group = make_block_group();
+  P2pIbgdaTransportDevice self = makeNoQpForwardTransport(
+      self_channels,
+      maxChannels,
+      pipelineDepth,
+      static_cast<std::size_t>(perChannelBufferSize));
+  P2pIbgdaTransportDevice fwd = makeNoQpForwardTransport(
+      fwd_channels,
+      maxChannels,
+      pipelineDepth,
+      static_cast<std::size_t>(perChannelBufferSize));
+  IbLocalChannel& selfCh = self.local_channel(0u);
+  IbLocalChannel& fwdCh = fwd.local_channel(0u);
+  const std::size_t proto = (static_cast<std::size_t>(nbytes) + 15ULL) & ~15ULL;
+
+  bool ok = true;
+  if (scenario == 0) {
+    if (group.is_leader()) {
+      selfCh.recvProgress.nextStep = 777;
+      fwdCh.sendProgress.nextStep = 888;
+    }
+    group.sync();
+    self.init_forward_progress(group, fwd, /*nbytes=*/0);
+    if (group.is_leader()) {
+      ok = selfCh.recvProgress.activeStage ==
+              detail::IbSendRecvProgressStage::Done &&
+          fwdCh.sendProgress.activeStage ==
+              detail::IbSendRecvProgressStage::Done &&
+          selfCh.recvProgress.nextStep == 777 &&
+          fwdCh.sendProgress.nextStep == 888;
+    }
+  } else if (scenario == 1) {
+    self.init_forward_progress(group, fwd, static_cast<std::size_t>(nbytes));
+    if (group.is_leader()) {
+      ok = selfCh.recvProgress.activeStage ==
+              detail::IbSendRecvProgressStage::FwdWaitDataReady &&
+          fwdCh.sendProgress.activeStage ==
+              detail::IbSendRecvProgressStage::Busy &&
+          selfCh.recvProgress.activeNextByte == 0 &&
+          fwdCh.sendProgress.activeNextByte == 0 &&
+          static_cast<std::size_t>(selfCh.recvProgress.nextStep) >= proto &&
+          static_cast<std::size_t>(fwdCh.sendProgress.nextStep) >= proto;
+    }
+  } else if (scenario == 2) {
+    if (group.is_leader()) {
+      selfCh.recvProgress.activeStage = detail::IbSendRecvProgressStage::Done;
+      selfCh.recvProgress.activeNextByte = proto;
+      fwdCh.sendProgress.activeStage = detail::IbSendRecvProgressStage::Done;
+      fwdCh.sendProgress.activeNextByte = proto;
+    }
+    group.sync();
+    const IbgdaSendRecvProgressStatus st = self.progress_forward_once(
+        group, nullptr, fwd, static_cast<std::size_t>(nbytes));
+    if (group.is_leader()) {
+      ok = st == IbgdaSendRecvProgressStatus::Done &&
+          selfCh.recvProgress.activeNextByte ==
+              fwdCh.sendProgress.activeNextByte;
+    }
+  }
+  if (group.is_leader()) {
+    *success = ok;
+  }
+}
+
+// scenario: 0 = paired-slot cursor desync (init, then corrupt the fwd send
+// slot's cursor) -> validate_forward_paired_slots traps; 1 = Done recv slot
+// paired with a still-Busy fwd slot -> Done-pairing assert traps.
+__global__ void testForwardProgressTrap(
+    int scenario,
+    IbLocalChannel* self_channels,
+    IbLocalChannel* fwd_channels,
+    int maxChannels,
+    int pipelineDepth,
+    unsigned long long perChannelBufferSize,
+    unsigned long long nbytes) {
+  auto group = make_block_group();
+  P2pIbgdaTransportDevice self = makeNoQpForwardTransport(
+      self_channels,
+      maxChannels,
+      pipelineDepth,
+      static_cast<std::size_t>(perChannelBufferSize));
+  P2pIbgdaTransportDevice fwd = makeNoQpForwardTransport(
+      fwd_channels,
+      maxChannels,
+      pipelineDepth,
+      static_cast<std::size_t>(perChannelBufferSize));
+  IbLocalChannel& selfCh = self.local_channel(0u);
+  IbLocalChannel& fwdCh = fwd.local_channel(0u);
+
+  if (scenario == 0) {
+    self.init_forward_progress(group, fwd, static_cast<std::size_t>(nbytes));
+    if (group.is_leader()) {
+      fwdCh.sendProgress.activeNextByte += 16; // desync the paired cursor
+    }
+    group.sync();
+    self.progress_forward_once(
+        group, nullptr, fwd, static_cast<std::size_t>(nbytes));
+  } else if (scenario == 1) {
+    if (group.is_leader()) {
+      selfCh.recvProgress.activeStage = detail::IbSendRecvProgressStage::Done;
+      fwdCh.sendProgress.activeStage = detail::IbSendRecvProgressStage::Busy;
+    }
+    group.sync();
+    self.progress_forward_once(
+        group, nullptr, fwd, static_cast<std::size_t>(nbytes));
+  }
+}
+
+void runTestForwardProgressNoQp(
+    int scenario,
+    IbLocalChannel* self_channels,
+    IbLocalChannel* fwd_channels,
+    int maxChannels,
+    int pipelineDepth,
+    unsigned long long perChannelBufferSize,
+    unsigned long long nbytes,
+    bool* d_success) {
+  testForwardProgressNoQp<<<1, 1>>>(
+      scenario,
+      self_channels,
+      fwd_channels,
+      maxChannels,
+      pipelineDepth,
+      perChannelBufferSize,
+      nbytes,
+      d_success);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+cudaError_t runTestForwardProgressTrap(
+    int scenario,
+    IbLocalChannel* self_channels,
+    IbLocalChannel* fwd_channels,
+    int maxChannels,
+    int pipelineDepth,
+    unsigned long long perChannelBufferSize,
+    unsigned long long nbytes) {
+  // Intentionally unchecked - we expect the kernel to trap.
+  // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
+  testForwardProgressTrap<<<1, 1>>>(
+      scenario,
+      self_channels,
+      fwd_channels,
+      maxChannels,
+      pipelineDepth,
+      perChannelBufferSize,
+      nbytes);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  return cudaDeviceSynchronize();
+}
+#endif // !__HIP_PLATFORM_AMD__
+
 } // namespace comms::prims::tests

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh
@@ -94,4 +94,35 @@ void runTestWaitSignalNoTimeout(
     uint32_t timeout_ms,
     bool* d_success);
 
+// =============================================================================
+// Resumable-forward no-QP tests (NVIDIA-only). `self_channels`/`fwd_channels`
+// are zeroed device IbLocalChannel arrays of length `maxChannels`.
+// =============================================================================
+#ifndef __HIP_PLATFORM_AMD__
+// scenario 0/1/2: zero-byte init / init layout / completed-Done. Sets
+// *d_success.
+void runTestForwardProgressNoQp(
+    int scenario,
+    IbLocalChannel* self_channels,
+    IbLocalChannel* fwd_channels,
+    int maxChannels,
+    int pipelineDepth,
+    unsigned long long perChannelBufferSize,
+    unsigned long long nbytes,
+    bool* d_success);
+
+// scenario 0/1: paired-slot cursor desync / Done-recv-with-Busy-fwd. Expected
+// to
+// __trap(); returns the cudaError from cudaDeviceSynchronize for trap
+// detection.
+cudaError_t runTestForwardProgressTrap(
+    int scenario,
+    IbLocalChannel* self_channels,
+    IbLocalChannel* fwd_channels,
+    int maxChannels,
+    int pipelineDepth,
+    unsigned long long perChannelBufferSize,
+    unsigned long long nbytes);
+#endif // !__HIP_PLATFORM_AMD__
+
 } // namespace comms::prims::tests

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTestMain.cc
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTestMain.cc
@@ -392,6 +392,143 @@ TEST_F(P2pIbgdaWaitSignalTimeoutTest, WaitSignalNoTimeoutWhenSatisfied) {
 
 #endif // !__HIP_PLATFORM_AMD__
 
+// =============================================================================
+// Resumable-forward no-QP tests
+// Exercise the no-NIC control paths of init_forward_progress /
+// progress_forward_once: init state, the Done/idle pairing, and the paired-slot
+// desync trap. End-to-end correctness (real RDMA) is covered by
+// recv_forward_chain_test.
+// =============================================================================
+#ifndef __HIP_PLATFORM_AMD__
+
+namespace {
+constexpr int kFwdMaxChannels = 1;
+constexpr int kFwdPipelineDepth = 2;
+constexpr unsigned long long kFwdPerChannelBufferSize = 4096;
+constexpr unsigned long long kFwdNbytes = 1024;
+constexpr std::size_t kFwdChannelsBytes =
+    kFwdMaxChannels * sizeof(IbLocalChannel);
+} // namespace
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, ForwardProgressZeroByteInit) {
+  DeviceBuffer selfCh(kFwdChannelsBytes);
+  DeviceBuffer fwdCh(kFwdChannelsBytes);
+  CUDACHECK_TEST(cudaMemset(selfCh.get(), 0, kFwdChannelsBytes));
+  CUDACHECK_TEST(cudaMemset(fwdCh.get(), 0, kFwdChannelsBytes));
+  runAndVerify([&](bool* d_success) {
+    runTestForwardProgressNoQp(
+        /*scenario=*/0,
+        static_cast<IbLocalChannel*>(selfCh.get()),
+        static_cast<IbLocalChannel*>(fwdCh.get()),
+        kFwdMaxChannels,
+        kFwdPipelineDepth,
+        kFwdPerChannelBufferSize,
+        kFwdNbytes,
+        d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, ForwardProgressInitLayout) {
+  DeviceBuffer selfCh(kFwdChannelsBytes);
+  DeviceBuffer fwdCh(kFwdChannelsBytes);
+  CUDACHECK_TEST(cudaMemset(selfCh.get(), 0, kFwdChannelsBytes));
+  CUDACHECK_TEST(cudaMemset(fwdCh.get(), 0, kFwdChannelsBytes));
+  runAndVerify([&](bool* d_success) {
+    runTestForwardProgressNoQp(
+        /*scenario=*/1,
+        static_cast<IbLocalChannel*>(selfCh.get()),
+        static_cast<IbLocalChannel*>(fwdCh.get()),
+        kFwdMaxChannels,
+        kFwdPipelineDepth,
+        kFwdPerChannelBufferSize,
+        kFwdNbytes,
+        d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, ForwardProgressCompletedDone) {
+  DeviceBuffer selfCh(kFwdChannelsBytes);
+  DeviceBuffer fwdCh(kFwdChannelsBytes);
+  CUDACHECK_TEST(cudaMemset(selfCh.get(), 0, kFwdChannelsBytes));
+  CUDACHECK_TEST(cudaMemset(fwdCh.get(), 0, kFwdChannelsBytes));
+  runAndVerify([&](bool* d_success) {
+    runTestForwardProgressNoQp(
+        /*scenario=*/2,
+        static_cast<IbLocalChannel*>(selfCh.get()),
+        static_cast<IbLocalChannel*>(fwdCh.get()),
+        kFwdMaxChannels,
+        kFwdPipelineDepth,
+        kFwdPerChannelBufferSize,
+        kFwdNbytes,
+        d_success);
+  });
+}
+
+// Trap fixture: resets the device after each test to clear __trap() state.
+class P2pIbgdaForwardProgressTrapTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+
+  void TearDown() override {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaDeviceReset();
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaSetDevice(0);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaGetLastError();
+  }
+
+  bool isExpectedTrapError(cudaError_t err) {
+    return err == cudaErrorIllegalInstruction || err == cudaErrorAssert ||
+        err == cudaErrorLaunchFailure;
+  }
+
+  // Raw cudaMalloc (not DeviceBuffer): after the expected trap, cudaFree would
+  // report the launch failure before TearDown can reset the device.
+  IbLocalChannel* allocZeroedChannels() {
+    IbLocalChannel* p = nullptr;
+    CUDACHECK_TEST(cudaMalloc(&p, kFwdChannelsBytes));
+    CUDACHECK_TEST(cudaMemset(p, 0, kFwdChannelsBytes));
+    return p;
+  }
+};
+
+TEST_F(P2pIbgdaForwardProgressTrapTest, PairedSlotDesyncTraps) {
+  IbLocalChannel* selfCh = allocZeroedChannels();
+  IbLocalChannel* fwdCh = allocZeroedChannels();
+  const cudaError_t err = runTestForwardProgressTrap(
+      /*scenario=*/0,
+      selfCh,
+      fwdCh,
+      kFwdMaxChannels,
+      kFwdPipelineDepth,
+      kFwdPerChannelBufferSize,
+      kFwdNbytes);
+  EXPECT_TRUE(isExpectedTrapError(err))
+      << "Expected trap from paired-slot desync, got: "
+      << cudaGetErrorString(err);
+}
+
+TEST_F(P2pIbgdaForwardProgressTrapTest, DoneRecvWithBusyFwdTraps) {
+  IbLocalChannel* selfCh = allocZeroedChannels();
+  IbLocalChannel* fwdCh = allocZeroedChannels();
+  const cudaError_t err = runTestForwardProgressTrap(
+      /*scenario=*/1,
+      selfCh,
+      fwdCh,
+      kFwdMaxChannels,
+      kFwdPipelineDepth,
+      kFwdPerChannelBufferSize,
+      kFwdNbytes);
+  EXPECT_TRUE(isExpectedTrapError(err))
+      << "Expected trap from Done recv paired with Busy fwd, got: "
+      << cudaGetErrorString(err);
+}
+
+#endif // !__HIP_PLATFORM_AMD__
+
 } // namespace comms::prims::tests
 
 int main(int argc, char** argv) {

--- a/comms/prims/tests/RecvForwardChainTest.cc
+++ b/comms/prims/tests/RecvForwardChainTest.cc
@@ -351,6 +351,352 @@ TEST_F(RecvForwardChainTest, MultiSection) {
   }
 }
 
+// ===========================================================================
+// Resumable-forward parity: same chains as above, but intermediates drive
+// init_forward_progress / progress_forward_once to completion. These exercise
+// the new resumable forward against blocking send/recv endpoints on the real
+// wire protocol. Multi-block / multi-section geometries run the forward across
+// multiple chunks, validating the fwd cursor advancing (in lockstep) between
+// puts.
+// ===========================================================================
+
+TEST_F(RecvForwardChainTest, ForwardWithCopyProgress) {
+  // >= 3: a 2-rank chain has no intermediate rank, so the forward under test
+  // never runs and the case would report a vacuous pass.
+  if (worldSize < 3) {
+    GTEST_SKIP()
+        << "requires >= 3 ranks for an intermediate forwarding rank, got "
+        << worldSize;
+  }
+
+  constexpr std::size_t kDataBytes = 1 * 1024 * 1024;
+  constexpr int kNumBlocks = 4;
+
+  try {
+    auto transport = create_transport(kDataBytes, kNumBlocks);
+
+    DeviceBuffer sendBuf(kDataBytes);
+    DeviceBuffer recvBuf(kDataBytes);
+
+    const uint8_t fillPattern = 0xAC;
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
+    for (int r = 0; r < worldSize; ++r) {
+      if (r != globalRank) {
+        peer_transports[r] = transport->getP2pTransportDevice(r);
+      }
+    }
+    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_transports.get(),
+        peer_transports.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+
+    bootstrap->barrierAll();
+
+    ASSERT_EQ(
+        test::launch_recv_forward_chain_progress(
+            static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
+            static_cast<const char*>(sendBuf.get()),
+            static_cast<char*>(recvBuf.get()),
+            kDataBytes,
+            globalRank,
+            worldSize,
+            kNumBlocks,
+            stream_),
+        cudaSuccess)
+        << "kernel launch failed";
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+    bootstrap->barrierAll();
+
+    if (globalRank != 0) {
+      std::vector<uint8_t> hostBuf(kDataBytes);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
+
+      int errors = 0;
+      for (std::size_t i = 0; i < kDataBytes; ++i) {
+        if (hostBuf[i] != fillPattern) {
+          if (errors < 10) {
+            XLOGF(
+                ERR,
+                "Rank {}: byte {} expected 0x{:02X} got 0x{:02X}",
+                globalRank,
+                i,
+                fillPattern,
+                hostBuf[i]);
+          }
+          ++errors;
+        }
+      }
+      EXPECT_EQ(errors, 0) << "Rank " << globalRank << ": " << errors
+                           << " byte mismatches (resumable forward)";
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+TEST_F(RecvForwardChainTest, ForwardOnlyProgress) {
+  if (worldSize < 3) {
+    GTEST_SKIP() << "requires >= 3 ranks for forward-only test, got "
+                 << worldSize;
+  }
+
+  constexpr std::size_t kDataBytes = 1 * 1024 * 1024;
+  constexpr int kNumBlocks = 4;
+
+  try {
+    auto transport = create_transport(kDataBytes, kNumBlocks);
+
+    DeviceBuffer sendBuf(kDataBytes);
+    DeviceBuffer recvBuf(kDataBytes);
+
+    const uint8_t fillPattern = 0xEF;
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
+    for (int r = 0; r < worldSize; ++r) {
+      if (r != globalRank) {
+        peer_transports[r] = transport->getP2pTransportDevice(r);
+      }
+    }
+    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_transports.get(),
+        peer_transports.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+
+    bootstrap->barrierAll();
+
+    ASSERT_EQ(
+        test::launch_recv_forward_chain_progress_no_dst(
+            static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
+            static_cast<const char*>(sendBuf.get()),
+            static_cast<char*>(recvBuf.get()),
+            kDataBytes,
+            globalRank,
+            worldSize,
+            kNumBlocks,
+            stream_),
+        cudaSuccess)
+        << "kernel launch failed";
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+    bootstrap->barrierAll();
+
+    if (globalRank == worldSize - 1) {
+      std::vector<uint8_t> hostBuf(kDataBytes);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
+
+      int errors = 0;
+      for (std::size_t i = 0; i < kDataBytes; ++i) {
+        if (hostBuf[i] != fillPattern) {
+          ++errors;
+        }
+      }
+      EXPECT_EQ(errors, 0) << "Last rank: " << errors
+                           << " byte mismatches (resumable forward-only)";
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+// Resumable forward across more data than one slot: per-block bytes span
+// several pipeline windows, so each forward runs many chunks and the fwd cursor
+// is advanced/validated between puts.
+TEST_F(RecvForwardChainTest, MultiSectionProgress) {
+  // >= 3: a 2-rank chain has no intermediate rank, so the forward under test
+  // never runs and the case would report a vacuous pass.
+  if (worldSize < 3) {
+    GTEST_SKIP() << "requires >= 3 ranks for an intermediate forwarding rank, "
+                    "got "
+                 << worldSize;
+  }
+
+  constexpr std::size_t kSlotSize = 512 * 1024;
+  constexpr std::size_t kDataBytes = 4 * kSlotSize; // 4 sections
+  constexpr int kNumBlocks = 2;
+
+  try {
+    auto transport = create_transport(kSlotSize, kNumBlocks);
+
+    DeviceBuffer sendBuf(kDataBytes);
+    DeviceBuffer recvBuf(kDataBytes);
+
+    const uint8_t fillPattern = 0x9C;
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
+    for (int r = 0; r < worldSize; ++r) {
+      if (r != globalRank) {
+        peer_transports[r] = transport->getP2pTransportDevice(r);
+      }
+    }
+    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_transports.get(),
+        peer_transports.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+
+    bootstrap->barrierAll();
+
+    ASSERT_EQ(
+        test::launch_recv_forward_chain_progress(
+            static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
+            static_cast<const char*>(sendBuf.get()),
+            static_cast<char*>(recvBuf.get()),
+            kDataBytes,
+            globalRank,
+            worldSize,
+            kNumBlocks,
+            stream_),
+        cudaSuccess)
+        << "kernel launch failed";
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+    bootstrap->barrierAll();
+
+    if (globalRank != 0) {
+      std::vector<uint8_t> hostBuf(kDataBytes);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
+
+      int errors = 0;
+      for (std::size_t i = 0; i < kDataBytes; ++i) {
+        if (hostBuf[i] != fillPattern) {
+          ++errors;
+        }
+      }
+      EXPECT_EQ(errors, 0)
+          << "Rank " << globalRank << ": " << errors
+          << " byte mismatches (resumable multi-section forward)";
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+// ===========================================================================
+// Guards resumable-forward slot completion when a forward reuses a send slot an
+// ordinary resumable send just released: rank 1 does a resumable send (op A)
+// then a reduce-forward (op B) to the SAME next transport, reusing the send
+// slot across a pipeline-window boundary. This is the send->forward same-slot
+// pattern the step-halved ring uses. Requires >= 3 ranks.
+// ===========================================================================
+TEST_F(RecvForwardChainTest, SendThenReduceForward) {
+  if (worldSize < 3) {
+    GTEST_SKIP() << "send-then-reduce-forward requires >= 3 ranks, got "
+                 << worldSize;
+  }
+
+  constexpr std::size_t kSlotSize = 1 * 1024 * 1024; // one pipeline window
+  constexpr std::size_t kDataBytes = kSlotSize; // one window per op
+  constexpr int kNumBlocks = 1;
+  const std::size_t nElems = kDataBytes / sizeof(float);
+
+  try {
+    auto transport = create_transport(kSlotSize, kNumBlocks);
+
+    DeviceBuffer sendBuf(kDataBytes); // rank0: op B data; rank1: op A data
+    DeviceBuffer localBuf(kDataBytes); // rank1: reduce input for op B
+    DeviceBuffer recvA(kDataBytes); // rank2: op A result
+    DeviceBuffer recvB(kDataBytes); // rank2: op B result
+
+    // rank0 sends 10; rank1 op A sends 5, op B reduces rank0(10)+local(20)=30.
+    const float rank0Value = 10.0f;
+    const float rank1SendValue = 5.0f;
+    const float rank1LocalValue = 20.0f;
+    const float mySend =
+        (globalRank == 0) ? rank0Value : rank1SendValue; // used by rank0/rank1
+    std::vector<float> hostSend(nElems, mySend);
+    std::vector<float> hostLocal(nElems, rank1LocalValue);
+    CUDACHECK_TEST(cudaMemcpy(
+        sendBuf.get(), hostSend.data(), kDataBytes, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        localBuf.get(), hostLocal.data(), kDataBytes, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemset(recvA.get(), 0, kDataBytes));
+    CUDACHECK_TEST(cudaMemset(recvB.get(), 0, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
+    for (int r = 0; r < worldSize; ++r) {
+      if (r != globalRank) {
+        peer_transports[r] = transport->getP2pTransportDevice(r);
+      }
+    }
+    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_transports.get(),
+        peer_transports.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+
+    bootstrap->barrierAll();
+
+    ASSERT_EQ(
+        test::launch_send_then_reduce_forward(
+            static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
+            static_cast<const char*>(sendBuf.get()),
+            static_cast<const char*>(localBuf.get()),
+            static_cast<char*>(recvA.get()),
+            static_cast<char*>(recvB.get()),
+            kDataBytes,
+            globalRank,
+            worldSize,
+            kNumBlocks,
+            stream_),
+        cudaSuccess)
+        << "kernel launch failed";
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+    bootstrap->barrierAll();
+
+    // rank 2 holds op A (rank1's send=5) and op B (rank0 10 + rank1 local 20).
+    if (globalRank == 2) {
+      auto check = [&](DeviceBuffer& buf, float expect, const char* which) {
+        std::vector<float> hostBuf(nElems);
+        CUDACHECK_TEST(cudaMemcpy(
+            hostBuf.data(), buf.get(), kDataBytes, cudaMemcpyDeviceToHost));
+        int errors = 0;
+        for (std::size_t i = 0; i < nElems; ++i) {
+          if (std::abs(hostBuf[i] - expect) > 1e-3f) {
+            ++errors;
+          }
+        }
+        EXPECT_EQ(errors, 0)
+            << which << ": " << errors << " element mismatches (expected "
+            << expect << ")";
+      };
+      check(recvA, rank1SendValue, "op A (send)");
+      check(recvB, rank0Value + rank1LocalValue, "op B (reduce-forward)");
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
 } // namespace comms::prims::tests
 
 int main(int argc, char* argv[]) {

--- a/comms/prims/tests/RecvForwardChainTest.cu
+++ b/comms/prims/tests/RecvForwardChainTest.cu
@@ -10,6 +10,69 @@
 
 namespace comms::prims::test {
 
+// Test-local accumulating CopyOp. Mirrors the reduce contract of MCCL's
+// `IbReduceCopy` WITHOUT depending on MCCL (Prims must not depend on
+// comms/mccl): `recv` accumulates staging into dst (`dst += staging`,
+// byteOffset ignored — the transport advances `dst` per sub-chunk); `forward`
+// writes `fwd_staging = staging + local_input[byteOffset]` and leaves `dst`
+// unused (the transport advances staging/fwd_staging per sub-chunk but passes
+// `local_input` un-advanced). Element type T. Used by the send-then-reduce-
+// forward regression to exercise the resumable REDUCE forward path.
+template <typename T>
+struct AccumCopy {
+  template <typename... Args>
+  __device__ __forceinline__ static std::size_t send(
+      char* staging,
+      const char* src,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    for (std::size_t i = group.thread_id_in_group; i < nbytes;
+         i += group.group_size) {
+      staging[i] = src[i];
+    }
+    return nbytes;
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void recv(
+      char* dst,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    T* d = reinterpret_cast<T*>(dst);
+    const T* s = reinterpret_cast<const T*>(staging);
+    const std::size_t n = nbytes / sizeof(T);
+    for (std::size_t i = group.thread_id_in_group; i < n;
+         i += group.group_size) {
+      d[i] += s[i];
+    }
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void forward(
+      char* /*dst*/,
+      char* fwd_staging,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t byte_offset,
+      const char* local_input,
+      Args...) {
+    T* f = reinterpret_cast<T*>(fwd_staging);
+    const T* s = reinterpret_cast<const T*>(staging);
+    const T* l = reinterpret_cast<const T*>(local_input + byte_offset);
+    const std::size_t n = nbytes / sizeof(T);
+    for (std::size_t i = group.thread_id_in_group; i < n;
+         i += group.group_size) {
+      f[i] = s[i] + l[i];
+    }
+  }
+};
+
 // Chain kernel: rank 0 sends, intermediates recv_forward, last rank receives.
 __global__ void recv_forward_chain_kernel(
     P2pIbgdaTransportDevice** transports,
@@ -94,6 +157,201 @@ void launch_recv_forward_chain_no_dst(
         "recv_forward_chain_no_dst kernel launch failed: %s\n",
         cudaGetErrorString(err));
   }
+}
+
+// Same chain topology as recv_forward_chain_kernel, but intermediates drive the
+// RESUMABLE forward (init_forward_progress / progress_forward_once) to
+// completion instead of the blocking forward. The endpoints stay blocking
+// (send/recv): they interoperate with the resumable forward on the same
+// group_id slots because the wire protocol (DATA_READY/SLOT_FREE/NIC_DONE per
+// chunk) is identical. With per-block bytes > one pipeline slot the forward
+// runs multiple chunks, exercising the fwd cursor advancing between puts.
+__global__ void recv_forward_chain_progress_kernel(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    bool use_dst) {
+  auto group = make_block_group();
+  const auto num_blocks = gridDim.x;
+
+  const std::size_t per_block = (nbytes / num_blocks) & ~15ULL;
+  const std::size_t my_off = group.group_id * per_block;
+  const std::size_t my_bytes =
+      (group.group_id == num_blocks - 1) ? (nbytes - my_off) : per_block;
+
+  const int prev_rank = (my_rank - 1 + world_size) % world_size;
+  const int next_rank = (my_rank + 1) % world_size;
+
+  if (my_rank == 0) {
+    P2pIbgdaTransportDevice& next = *transports[next_rank];
+    next.send(group, send_buf + my_off, my_bytes);
+  } else if (my_rank == world_size - 1) {
+    P2pIbgdaTransportDevice& prev = *transports[prev_rank];
+    prev.recv(group, recv_buf + my_off, my_bytes);
+  } else {
+    P2pIbgdaTransportDevice& prev = *transports[prev_rank];
+    P2pIbgdaTransportDevice& next = *transports[next_rank];
+    char* dst = use_dst ? (recv_buf + my_off) : nullptr;
+    prev.init_forward_progress(group, next, my_bytes);
+    IbgdaSendRecvProgressStatus st = IbgdaSendRecvProgressStatus::Waiting;
+    do {
+      st = prev.progress_forward_once(group, dst, next, my_bytes);
+    } while (st != IbgdaSendRecvProgressStatus::Done);
+  }
+}
+
+cudaError_t launch_recv_forward_chain_progress(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream) {
+  recv_forward_chain_progress_kernel<<<num_blocks, 128, 0, stream>>>(
+      transports,
+      send_buf,
+      recv_buf,
+      nbytes,
+      my_rank,
+      world_size,
+      /*use_dst=*/true);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "recv_forward_chain_progress kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+  // Propagate (not just print) the launch status: cudaGetLastError()
+  // above already consumed it, so a caller's later cudaStreamSynchronize
+  // would report success and the test would pass silently on a failed
+  // launch.
+  return err;
+}
+
+cudaError_t launch_recv_forward_chain_progress_no_dst(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream) {
+  recv_forward_chain_progress_kernel<<<num_blocks, 128, 0, stream>>>(
+      transports,
+      send_buf,
+      recv_buf,
+      nbytes,
+      my_rank,
+      world_size,
+      /*use_dst=*/false);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "recv_forward_chain_progress_no_dst kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+  // Propagate (not just print) the launch status: cudaGetLastError()
+  // above already consumed it, so a caller's later cudaStreamSynchronize
+  // would report success and the test would pass silently on a failed
+  // launch.
+  return err;
+}
+
+// Guards resumable-forward slot completion when a forward REUSES a send slot an
+// ordinary resumable send just released: rank 1 issues a resumable SEND (op A)
+// then a reduce-FORWARD (op B) to the SAME `next` transport, so op B's send
+// reuses op A's send slot and crosses a pipeline-window boundary (nbytes == one
+// window) -- the per-round "seed send then forward on the same slot" pattern
+// the step-halved ring uses. rank 0 feeds op B's recv; rank 2 receives op A
+// then op B. After the run: rank 2's recv_a == rank 1's send_buf; recv_b ==
+// rank 0's send_buf + rank 1's local_buf (reduced). Requires world_size >= 3;
+// single block (nbytes sized to one window by the caller).
+__global__ void send_then_reduce_forward_kernel(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    const char* local_buf,
+    char* recv_a,
+    char* recv_b,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size) {
+  auto group = make_block_group();
+  const int prev_rank = (my_rank - 1 + world_size) % world_size;
+  const int next_rank = (my_rank + 1) % world_size;
+
+  if (my_rank == 0) {
+    // Feed rank 1's reduce-forward recv (op B) with a blocking send.
+    P2pIbgdaTransportDevice& next = *transports[next_rank];
+    next.send(group, send_buf, nbytes);
+  } else if (my_rank == 1) {
+    P2pIbgdaTransportDevice& prev = *transports[prev_rank];
+    P2pIbgdaTransportDevice& next = *transports[next_rank];
+    // op A: ordinary resumable send (window 0) on next's send slot.
+    next.init_send_progress(group, nbytes);
+    IbgdaSendRecvProgressStatus st = IbgdaSendRecvProgressStatus::Waiting;
+    do {
+      st = next.progress_send_once(group, send_buf, nbytes);
+    } while (st != IbgdaSendRecvProgressStatus::Done);
+    // op B: reduce-forward (window 1) REUSING next's send slot -> crosses the
+    // pipeline-window boundary.
+    prev.init_forward_progress(group, next, nbytes);
+    st = IbgdaSendRecvProgressStatus::Waiting;
+    do {
+      st = prev.progress_forward_once<AccumCopy<float>>(
+          group,
+          /*dst=*/nullptr,
+          next,
+          nbytes,
+          /*max_signal_bytes=*/0,
+          comms::prims::Timeout(),
+          /*local_input=*/local_buf);
+    } while (st != IbgdaSendRecvProgressStatus::Done);
+  } else if (my_rank == 2) {
+    // Receive op A then op B (blocking) on the same prev recv slot.
+    P2pIbgdaTransportDevice& prev = *transports[prev_rank];
+    prev.recv(group, recv_a, nbytes);
+    prev.recv(group, recv_b, nbytes);
+  }
+  // ranks >= 3: idle.
+}
+
+cudaError_t launch_send_then_reduce_forward(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    const char* local_buf,
+    char* recv_a,
+    char* recv_b,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream) {
+  send_then_reduce_forward_kernel<<<num_blocks, 128, 0, stream>>>(
+      transports,
+      send_buf,
+      local_buf,
+      recv_a,
+      recv_b,
+      nbytes,
+      my_rank,
+      world_size);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "send_then_reduce_forward kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+  // Propagate (not just print) the launch status: cudaGetLastError()
+  // above already consumed it, so a caller's later cudaStreamSynchronize
+  // would report success and the test would pass silently on a failed
+  // launch.
+  return err;
 }
 
 } // namespace comms::prims::test

--- a/comms/prims/tests/RecvForwardChainTest.h
+++ b/comms/prims/tests/RecvForwardChainTest.h
@@ -50,4 +50,56 @@ void launch_recv_forward_chain_no_dst(
     int num_blocks,
     cudaStream_t stream);
 
+/**
+ * Same chain as launch_recv_forward_chain, but intermediates drive the
+ * resumable forward (init_forward_progress / progress_forward_once) to
+ * completion instead of the blocking forward. Validates the resumable forward
+ * end-to-end against the blocking send/recv endpoints on the same wire
+ * protocol.
+ */
+cudaError_t launch_recv_forward_chain_progress(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream);
+
+/**
+ * Resumable-forward chain with dst=nullptr for intermediates (forward-only).
+ * Only the last rank writes to recv_buf.
+ */
+cudaError_t launch_recv_forward_chain_progress_no_dst(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream);
+
+/**
+ * Regression for the resumable-forward slot-completion bug: rank 1 does an
+ * ordinary resumable send (op A) then a reduce-forward (op B) to the same
+ * `next` transport, so op B reuses op A's send slot across a pipeline-window
+ * boundary (nbytes == one window). rank 0 feeds op B's recv; rank 2 receives op
+ * A into recv_a and op B into recv_b. After the run: recv_a == rank 1's
+ * send_buf; recv_b == rank 0's send_buf + rank 1's local_buf (float reduce).
+ * Requires world_size >= 3.
+ */
+cudaError_t launch_send_then_reduce_forward(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    const char* local_buf,
+    char* recv_a,
+    char* recv_b,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream);
+
 } // namespace comms::prims::test

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -220,6 +220,17 @@ __device__ __forceinline__ void validate_recv_progress_stage(
     ThreadGroup& group,
     const IbChannelProgress& state);
 
+__device__ __forceinline__ void validate_forward_progress_stage(
+    ThreadGroup& group,
+    const IbChannelProgress& state);
+
+__device__ __forceinline__ void validate_forward_paired_slots(
+    ThreadGroup& group,
+    const IbChannelProgress& recvState,
+    const IbChannelProgress& fwdSlot,
+    uint64_t recvExpectedEnd,
+    uint64_t fwdExpectedEnd);
+
 __device__ __forceinline__ void transition_progress_stage(
     ThreadGroup& group,
     IbChannelProgress& state,
@@ -1883,6 +1894,419 @@ __device__ __forceinline__ void forward(
 }
 
 /**
+ * Initialize transport-owned state for one resumable fused forward.
+ *
+ * A forward acts as a recv on `transport` and a send on `fwdTransport` for the
+ * same `group.group_id`. The combined progress lives in this transport's recv
+ * slot (driven through the `Fwd*` stages); `fwdTransport`'s send slot is held
+ * `Busy` for the whole op so a concurrent send on that group traps instead of
+ * silently sharing the fwd staging cursor.
+ *
+ * Init is all-or-nothing: both slots must be idle and both staging geometries
+ * are validated before either byte cursor is reserved. Zero-byte forwards mark
+ * both slots `Done` without reserving, matching blocking `forward()`.
+ */
+template <typename Transport>
+__device__ __forceinline__ void init_forward_progress(
+    Transport& transport,
+    ThreadGroup& group,
+    Transport& fwdTransport,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  /*
+   * NOTE: deliberately NO `static_assert(!AMD)` here, unlike progress_*_once.
+   * That asymmetry is required, not an oversight: the public wrapper
+   * P2pIbgdaTransportDevice::init_forward_progress() is a NON-template member,
+   * so it is instantiated in every AMD translation unit that merely includes
+   * the header -- a fail-closed assert here breaks the whole AMD build rather
+   * than only AMD *users* of the resumable API. The progress_*_once wrappers
+   * are templates (on CopyOp), so their guards fire only on real instantiation.
+   * NVIDIA-only enforcement therefore lives on the progress calls; an op cannot
+   * be driven to completion without them.
+   */
+  auto& recvChannelLayout = transport.channel_layout();
+  auto& fwdChannelLayout = fwdTransport.channel_layout();
+  auto& recvSlot = progress_recv_slot(transport, group);
+  auto& fwdSlot = progress_send_slot(fwdTransport, group);
+  assert_progress_slot_idle(group, recvSlot, "forward recv");
+  assert_progress_slot_idle(group, fwdSlot, "forward send");
+
+  IbChannelProgress recvState{};
+  IbChannelProgress fwdState{};
+  if (nbytes == 0) {
+    recvState.activeStage = detail::IbSendRecvProgressStage::Done;
+    fwdState.activeStage = detail::IbSendRecvProgressStage::Done;
+    store_progress_state(group, recvSlot, recvState);
+    store_progress_state(group, fwdSlot, fwdState);
+    return;
+  }
+  // All-or-nothing: validate both geometries (each traps on invalid) before
+  // reserving either transport byte cursor.
+  const ProgressGeometry recvGeometry = make_progress_geometry(
+      recvChannelLayout,
+      group,
+      nbytes,
+      max_signal_bytes,
+      "init_forward_progress recv");
+  const ProgressGeometry fwdGeometry = make_progress_geometry(
+      fwdChannelLayout,
+      group,
+      nbytes,
+      max_signal_bytes,
+      "init_forward_progress send");
+  reserve_progress_step(group, recvSlot, recvState, recvGeometry);
+  reserve_progress_step(group, fwdSlot, fwdState, fwdGeometry);
+  recvState.activeStage = detail::IbSendRecvProgressStage::FwdWaitDataReady;
+  fwdState.activeStage = detail::IbSendRecvProgressStage::Busy;
+  store_progress_state(group, recvSlot, recvState);
+  store_progress_state(group, fwdSlot, fwdState);
+#else
+  (void)transport;
+  (void)group;
+  (void)fwdTransport;
+  (void)nbytes;
+  (void)max_signal_bytes;
+#endif
+}
+
+/**
+ * Attempt bounded progress on one initialized fused forward.
+ *
+ * One call advances at most one chunk through the three `Fwd*` stages,
+ * mirroring the blocking `forward()` per-chunk ordering (recv DATA_READY -> fwd
+ * NIC_DONE -> CopyOp::forward -> recv SLOT_FREE -> fwd SLOT_FREE -> put). It
+ * never spins: each dependency check returns `Waiting`/`Progressed` so a
+ * scheduler can drive another lane. Non-idempotent side effects (DATA_READY
+ * consumption, the reduce, the recv SLOT_FREE signal, the fwd put) run during a
+ * stage transition and the new stage is persisted only after them, so a resume
+ * never replays them.
+ *
+ * The combined state is the recv slot; `fwdTransport`'s send slot stays `Busy`
+ * for the whole op, holding the fwd side's (constant) base cursor + tail
+ * padding and an `activeNextByte` that is advanced and validated in lockstep
+ * with the recv cursor after every put (`validate_forward_paired_slots`), so a
+ * corrupted or reused paired slot traps instead of silently desyncing.
+ * `bytesThis` is the min over both sides' chunk geometries, so the wire
+ * protocol stays compatible with `send()`/`recv()`/`forward()` in a homogeneous
+ * ring.
+ */
+template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus progress_forward_once(
+    Transport& transport,
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    Transport& fwdTransport,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0,
+    const Timeout& timeout = Timeout(),
+    Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#ifdef __HIP_PLATFORM_AMD__
+  static_assert(
+      sizeof(CopyOp) == 0,
+      "detail::progress_forward_once() requires NVIDIA GPU");
+#endif
+  auto& recvChannelLayout = transport.channel_layout();
+  auto& fwdChannelLayout = fwdTransport.channel_layout();
+  auto& recvSlot = progress_recv_slot(transport, group);
+  auto& fwdSlot = progress_send_slot(fwdTransport, group);
+  IbChannelProgress state = recvSlot; // combined forward state (recv slot)
+  if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
+    // A Done recv slot must pair with an idle (Done) fwd send slot; a
+    // still-Busy fwd slot here is a desync, not a benign early-out.
+    assert_progress_slot_idle(
+        group, fwdSlot, "forward send (paired, recv Done)");
+    return IbgdaSendRecvProgressStatus::Done;
+  }
+  validate_forward_progress_stage(group, state);
+
+  const ProgressGeometry recvGeom = make_progress_geometry(
+      recvChannelLayout,
+      group,
+      nbytes,
+      max_signal_bytes,
+      "progress_forward_once recv");
+  const ProgressGeometry fwdGeom = make_progress_geometry(
+      fwdChannelLayout,
+      group,
+      nbytes,
+      max_signal_bytes,
+      "progress_forward_once send");
+  if (active_payload_offset(state) >= recvGeom.protocolBytes) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: progress_forward_once payloadOffset=%llu >= "
+          "protocolBytes=%llu without Done stage\n",
+          static_cast<unsigned long long>(active_payload_offset(state)),
+          static_cast<unsigned long long>(recvGeom.protocolBytes));
+    }
+    PIPES_DEVICE_TRAP();
+  }
+
+  const detail::IbSendRecvProgressStage initialStage = state.activeStage;
+  const std::size_t initialNextByte = state.activeNextByte;
+
+  // Per-side constants. The recv side's base/tail live in the (loaded) combined
+  // state; the fwd side's live in the still-Busy fwd send slot (set at init,
+  // constant for the op). The shared payload cursor is state.activeNextByte.
+  const uint64_t recvBase = static_cast<uint64_t>(state.activeBaseStep);
+  const std::size_t recvTailPadding = state.activeTailPadding;
+  const std::size_t recvPipelineBytes = recvGeom.perChannelBufferSize;
+  const uint64_t fwdBase = static_cast<uint64_t>(fwdSlot.activeBaseStep);
+  const std::size_t fwdTailPadding = fwdSlot.activeTailPadding;
+  const std::size_t fwdPipelineBytes = fwdGeom.perChannelBufferSize;
+
+  // The paired fwd send slot must still be the same Busy op, cursor-locked to
+  // the recv side, with both reserved ranges intact (see
+  // init_forward_progress).
+  validate_forward_paired_slots(
+      group,
+      state,
+      fwdSlot,
+      recvBase + recvGeom.protocolBytes + recvTailPadding,
+      fwdBase + fwdGeom.protocolBytes + fwdTailPadding);
+
+  IbLocalChannel& recvLocalChannel =
+      transport.local_channel(static_cast<uint32_t>(recvGeom.groupId));
+  const IbgdaLocalBuffer recvDataReady = recvLocalChannel.dataReady;
+  const IbRemoteChannel recvRemoteChannel =
+      makeIbRemoteChannel(recvChannelLayout, recvGeom.groupId);
+  IbLocalChannel& fwdLocalChannel =
+      fwdTransport.local_channel(static_cast<uint32_t>(fwdGeom.groupId));
+  const IbgdaLocalBuffer fwdSlotFree = fwdLocalChannel.slotFree;
+  const IbRemoteChannel fwdRemoteChannel =
+      makeIbRemoteChannel(fwdChannelLayout, fwdGeom.groupId);
+
+  // Dual-geometry chunk offsets from the shared payload cursor (mirrors the
+  // blocking forward loop; bytesThis is the min across both sides and slots).
+  const std::size_t payloadOff = state.activeNextByte;
+  const uint64_t recvStreamStart = recvBase + payloadOff;
+  const std::size_t recvPipelineOff =
+      static_cast<std::size_t>(recvStreamStart % recvPipelineBytes);
+  const int recvSlotIdx =
+      static_cast<int>(recvPipelineOff / recvGeom.perBlockSlot);
+  const std::size_t recvSlotOff =
+      static_cast<std::size_t>(recvSlotIdx) * recvGeom.perBlockSlot;
+  const std::size_t recvChunkOff = recvPipelineOff - recvSlotOff;
+  const std::size_t recvSlotRemaining = recvGeom.perBlockSlot - recvChunkOff;
+  const std::size_t recvStagingOff =
+      static_cast<std::size_t>(recvGeom.groupId) * recvPipelineBytes +
+      recvSlotOff + recvChunkOff;
+
+  const uint64_t fwdStreamStart = fwdBase + payloadOff;
+  // Pipeline generation (ring-buffer pass) of this chunk's fwd send slot -- the
+  // key for the per-slot completion-ticket mechanism (mirrors the blocking
+  // forward's fwdPipelineCycle), so a preceding progress_send_once on this slot
+  // is correctly awaited before staging reuse.
+  const uint64_t fwdPipelineGeneration = fwdStreamStart / fwdPipelineBytes;
+  const std::size_t fwdPipelineOff =
+      static_cast<std::size_t>(fwdStreamStart % fwdPipelineBytes);
+  const int fwdSlotIdx =
+      static_cast<int>(fwdPipelineOff / fwdGeom.perBlockSlot);
+  const std::size_t fwdSlotOff =
+      static_cast<std::size_t>(fwdSlotIdx) * fwdGeom.perBlockSlot;
+  const std::size_t fwdChunkOff = fwdPipelineOff - fwdSlotOff;
+  const std::size_t fwdSlotRemaining = fwdGeom.perBlockSlot - fwdChunkOff;
+  const std::size_t fwdStagingOff =
+      static_cast<std::size_t>(fwdGeom.groupId) * fwdPipelineBytes +
+      fwdSlotOff + fwdChunkOff;
+
+  const std::size_t dataRemaining = recvGeom.protocolBytes - payloadOff;
+  std::size_t bytesThis = recvGeom.chunkSize < fwdGeom.chunkSize
+      ? recvGeom.chunkSize
+      : fwdGeom.chunkSize;
+  bytesThis = bytesThis < dataRemaining ? bytesThis : dataRemaining;
+  bytesThis = bytesThis < recvSlotRemaining ? bytesThis : recvSlotRemaining;
+  bytesThis = bytesThis < fwdSlotRemaining ? bytesThis : fwdSlotRemaining;
+  const bool isFinalChunk = payloadOff + bytesThis >= recvGeom.protocolBytes;
+  const std::size_t recvProtocolBytesThis =
+      bytesThis + (isFinalChunk ? recvTailPadding : 0);
+  const std::size_t fwdProtocolBytesThis =
+      bytesThis + (isFinalChunk ? fwdTailPadding : 0);
+  const uint64_t fwdProtocolStreamEnd = fwdStreamStart + fwdProtocolBytesThis;
+
+  // Stage 1: wait for the upstream sender's DATA_READY on this chunk's lane.
+  if (state.activeStage == detail::IbSendRecvProgressStage::FwdWaitDataReady) {
+    uint32_t ready = 1;
+    if (group.is_leader()) {
+      unsigned long long current = 0;
+      unsigned long long expected = 0;
+      ready = poll_recv_data_ready(
+                  transport,
+                  recvLocalChannel,
+                  recvDataReady,
+                  recvProtocolBytesThis,
+                  current,
+                  expected)
+          ? 1U
+          : 0U;
+      if (!ready) {
+        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+            timeout,
+            "progress_forward_once waiting for DATA_READY expected>=%llu, "
+            "current=%llu",
+            expected,
+            current);
+      }
+    }
+    ready = group.broadcast<uint32_t>(ready);
+    if (!ready) {
+      // Nothing consumed (poll left receiver state untouched) -> Waiting.
+      return IbgdaSendRecvProgressStatus::Waiting;
+    }
+    transition_progress_stage(
+        group, state, detail::IbSendRecvProgressStage::FwdWaitNicDone);
+  }
+
+  // Stage 2: wait for LOCAL COMPLETION of the fwd send slot (staging reuse),
+  // then reduce recv-staging into fwd-staging and release the upstream sender
+  // (recv SLOT_FREE) BEFORE waiting on the fwd receiver (ring-deadlock
+  // avoidance). Completion is tracked with the per-slot completion-ticket
+  // mechanism (try_prepare_send_slot), identical to ordinary
+  // progress_send_once and the blocking forward. Sharing that one mechanism is
+  // what lets a forward reuse a slot an ordinary send released (the ring's
+  // per-round seed send followed by a forward across a pipeline-window
+  // boundary).
+  if (state.activeStage == detail::IbSendRecvProgressStage::FwdWaitNicDone) {
+    if (!try_prepare_send_slot(
+            fwdTransport,
+            group,
+            static_cast<uint32_t>(fwdSlotIdx),
+            fwdPipelineGeneration,
+            timeout)) {
+      // Local completion not ready. If DATA_READY was consumed this call,
+      // persist the FwdWaitNicDone stage so the resume does not re-poll (and
+      // re-consume) DATA_READY.
+      if (state.activeStage != initialStage ||
+          state.activeNextByte != initialNextByte) {
+        store_progress_state(group, recvSlot, state);
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return IbgdaSendRecvProgressStatus::Waiting;
+    }
+
+    const std::size_t validBytes =
+        valid_payload_bytes(payloadOff, bytesThis, recvGeom.payloadBytes);
+    if (validBytes > 0) {
+      CopyOp::forward(
+          dst ? static_cast<char*>(dst) + payloadOff : nullptr,
+          fwdChannelLayout.sendStagingPtr + fwdStagingOff,
+          recvChannelLayout.recvStagingPtr + recvStagingOff,
+          validBytes,
+          group,
+          payloadOff,
+          args...);
+    }
+    group.sync();
+    transport.signal(
+        group,
+        recvRemoteChannel.slotFree,
+        recvProtocolBytesThis,
+        IbDirection::Recv);
+    transition_progress_stage(
+        group, state, detail::IbSendRecvProgressStage::FwdWaitSlotFree);
+  }
+
+  // Stage 3: wait for the fwd receiver's SLOT_FREE, then put onto the next
+  // peer.
+  if (state.activeStage == detail::IbSendRecvProgressStage::FwdWaitSlotFree) {
+    if (fwdProtocolStreamEnd > fwdPipelineBytes) {
+      const uint64_t expected = fwdProtocolStreamEnd - fwdPipelineBytes;
+      uint32_t ready = 1;
+      unsigned long long current = 0;
+      if (group.is_leader()) {
+        current = static_cast<unsigned long long>(
+            fwdTransport.read_signal(fwdSlotFree));
+        ready = current >= expected ? 1U : 0U;
+        if (!ready) {
+          TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+              timeout,
+              "progress_forward_once waiting for SLOT_FREE expected>=%llu, "
+              "current=%llu",
+              static_cast<unsigned long long>(expected),
+              current);
+        }
+      }
+      ready = group.broadcast<uint32_t>(ready);
+      if (!ready) {
+        if (state.activeStage != initialStage ||
+            state.activeNextByte != initialNextByte) {
+          store_progress_state(group, recvSlot, state);
+          return IbgdaSendRecvProgressStatus::Progressed;
+        }
+        return IbgdaSendRecvProgressStatus::Waiting;
+      }
+    }
+
+    __threadfence_system();
+    group.sync();
+    if (group.is_leader()) {
+      ThreadGroup solo{
+          0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+      const auto completion = fwdTransport.put(
+          solo,
+          fwdChannelLayout.sendStagingBuf.subBuffer(fwdStagingOff),
+          fwdRemoteChannel.recvStaging.subBuffer(fwdStagingOff),
+          bytesThis,
+          fwdRemoteChannel.dataReady,
+          fwdProtocolBytesThis,
+          /*counterBuf=*/{},
+          /*counterVal=*/0,
+          /*signalPerLane=*/true);
+      // Record the send completion on the fwd slot's ticket (same mechanism as
+      // ordinary/blocking sends), so a later op reusing this slot awaits it via
+      // try_prepare_send_slot in Stage 2.
+      record_send_completion(
+          fwdTransport,
+          static_cast<uint32_t>(fwdGeom.groupId),
+          static_cast<uint32_t>(fwdSlotIdx),
+          fwdPipelineGeneration,
+          completion);
+      // Keep the paired fwd send slot's cursor lockstep with the recv cursor
+      // (state.activeNextByte advances by the same bytesThis just below).
+      fwdSlot.activeNextByte += bytesThis;
+    }
+    group.sync();
+
+    state.activeNextByte += bytesThis;
+    if (active_payload_offset(state) >= recvGeom.protocolBytes) {
+      transition_progress_stage(
+          group, state, detail::IbSendRecvProgressStage::Done);
+      // reserve_progress_step already advanced both slots' nextStep at init and
+      // the final put advanced fwdSlot.activeNextByte in lockstep, so
+      // completion only releases the fwd send slot's Busy hold. The next init
+      // resets both slots' active* fields via reserve_progress_step.
+      if (group.is_leader()) {
+        fwdSlot.activeStage = detail::IbSendRecvProgressStage::Done;
+      }
+      store_progress_state(group, recvSlot, state);
+      return IbgdaSendRecvProgressStatus::Done;
+    }
+    transition_progress_stage(
+        group, state, detail::IbSendRecvProgressStage::FwdWaitDataReady);
+  }
+
+  // Advanced at least one stage/byte this call but did not complete.
+  if (state.activeStage != initialStage ||
+      state.activeNextByte != initialNextByte) {
+    store_progress_state(group, recvSlot, state);
+    return IbgdaSendRecvProgressStatus::Progressed;
+  }
+  return IbgdaSendRecvProgressStatus::Waiting;
+#else
+  (void)transport;
+  (void)group;
+  (void)dst;
+  (void)fwdTransport;
+  (void)nbytes;
+  (void)max_signal_bytes;
+  (void)timeout;
+  return IbgdaSendRecvProgressStatus::Done;
+#endif
+}
+
+/**
  * Maximum bytes one channel can send without blocking on pipeline backpressure.
  */
 __device__ __forceinline__ std::size_t pipeline_window(
@@ -2268,6 +2692,90 @@ __device__ __forceinline__ void validate_recv_progress_stage(
 }
 
 /**
+ * Trap if a forward progress state is not in a forward-owned stage.
+ *
+ * The resumable forward drives the recv slot through the `Fwd*` stages only.
+ * Any send/recv-owned stage here is protocol misuse.
+ *
+ * `Done` is accepted for defensiveness only: the sole caller
+ * (`progress_forward_once`) already returns early on `Done`, so this validator
+ * is never reached in that stage today. It stays in the accepted set so that a
+ * future caller which validates before the early-out does not trap on a
+ * legitimately-completed op.
+ */
+__device__ __forceinline__ void validate_forward_progress_stage(
+    ThreadGroup& group,
+    const IbChannelProgress& state) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  if (state.activeStage != detail::IbSendRecvProgressStage::FwdWaitDataReady &&
+      state.activeStage != detail::IbSendRecvProgressStage::FwdWaitNicDone &&
+      state.activeStage != detail::IbSendRecvProgressStage::FwdWaitSlotFree &&
+      state.activeStage != detail::IbSendRecvProgressStage::Done) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: progress_forward_once invalid stage=%d\n",
+          static_cast<int>(state.activeStage));
+    }
+    PIPES_DEVICE_TRAP();
+  }
+#endif
+}
+
+/**
+ * Trap if the recv slot's forward op and its paired fwd send slot have drifted.
+ *
+ * The resumable forward keeps the fwd send slot `Busy` and advances its byte
+ * cursor in lockstep with the recv slot after every put. This validates that
+ * pairing every progress call: the fwd slot is still the same `Busy` op, its
+ * in-flight cursor matches the recv side exactly, and both reserved byte ranges
+ * still end where init left them. A mismatch means the fwd slot was corrupted
+ * or reused (e.g. a stray send on the same group), which would otherwise desync
+ * the two staging streams silently.
+ */
+__device__ __forceinline__ void validate_forward_paired_slots(
+    ThreadGroup& group,
+    const IbChannelProgress& recvState,
+    const IbChannelProgress& fwdSlot,
+    uint64_t recvExpectedEnd,
+    uint64_t fwdExpectedEnd) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  uint32_t ok = 1;
+  if (group.is_leader()) {
+    ok = (fwdSlot.activeStage == detail::IbSendRecvProgressStage::Busy &&
+          fwdSlot.activeNextByte == recvState.activeNextByte &&
+          static_cast<uint64_t>(recvState.nextStep) == recvExpectedEnd &&
+          static_cast<uint64_t>(fwdSlot.nextStep) == fwdExpectedEnd)
+        ? 1U
+        : 0U;
+    if (!ok) {
+      printf(
+          "[PIPES] FATAL: progress_forward_once paired-slot desync "
+          "fwdStage=%d fwdNextByte=%llu recvNextByte=%llu "
+          "recvNextStep=%llu recvExpectedEnd=%llu "
+          "fwdNextStep=%llu fwdExpectedEnd=%llu\n",
+          static_cast<int>(fwdSlot.activeStage),
+          static_cast<unsigned long long>(fwdSlot.activeNextByte),
+          static_cast<unsigned long long>(recvState.activeNextByte),
+          static_cast<unsigned long long>(recvState.nextStep),
+          static_cast<unsigned long long>(recvExpectedEnd),
+          static_cast<unsigned long long>(fwdSlot.nextStep),
+          static_cast<unsigned long long>(fwdExpectedEnd));
+    }
+  }
+  ok = group.broadcast<uint32_t>(ok);
+  if (!ok) {
+    PIPES_DEVICE_TRAP();
+  }
+#else
+  (void)group;
+  (void)recvState;
+  (void)fwdSlot;
+  (void)recvExpectedEnd;
+  (void)fwdExpectedEnd;
+#endif
+}
+
+/**
  * Return whether `current -> next` is a valid progress-state transition.
  */
 __device__ __forceinline__ bool is_valid_progress_transition(
@@ -2281,6 +2789,16 @@ __device__ __forceinline__ bool is_valid_progress_transition(
           next == detail::IbSendRecvProgressStage::Done;
     case detail::IbSendRecvProgressStage::WaitDataReady:
       return next == detail::IbSendRecvProgressStage::Done;
+    // Resumable fused forward: recv one chunk (FwdWaitDataReady), then wait for
+    // the fwd send-staging to drain (FwdWaitNicDone), then wait fwd SLOT_FREE +
+    // put (FwdWaitSlotFree), then loop to the next chunk or complete.
+    case detail::IbSendRecvProgressStage::FwdWaitDataReady:
+      return next == detail::IbSendRecvProgressStage::FwdWaitNicDone;
+    case detail::IbSendRecvProgressStage::FwdWaitNicDone:
+      return next == detail::IbSendRecvProgressStage::FwdWaitSlotFree;
+    case detail::IbSendRecvProgressStage::FwdWaitSlotFree:
+      return next == detail::IbSendRecvProgressStage::FwdWaitDataReady ||
+          next == detail::IbSendRecvProgressStage::Done;
     case detail::IbSendRecvProgressStage::Done:
       return false;
     case detail::IbSendRecvProgressStage::Busy:

--- a/comms/prims/transport/ibgda/IbgdaBuffer.h
+++ b/comms/prims/transport/ibgda/IbgdaBuffer.h
@@ -429,6 +429,12 @@ namespace detail {
  * Send operations use `WaitLocalCompletion` and `WaitSlotFree`; recv
  * operations use `WaitDataReady`. Blocking send/recv temporarily use `Busy` to
  * make same-direction overlap fail explicitly instead of sharing a cursor.
+ *
+ * The `Fwd*` stages drive one resumable fused forward (recv-into-staging,
+ * reduce, then RDMA put on to the next peer). Their combined state lives in the
+ * recv slot's `activeStage`; the fwd transport's send slot stays `Busy` for the
+ * whole op. They are appended so the on-HBM encoding of the existing values is
+ * unchanged. Ordinary (non-forward) send/recv progress rejects them.
  */
 enum class IbSendRecvProgressStage : uint8_t {
   Done,
@@ -436,6 +442,9 @@ enum class IbSendRecvProgressStage : uint8_t {
   WaitSlotFree,
   WaitDataReady,
   Busy,
+  FwdWaitDataReady,
+  FwdWaitNicDone,
+  FwdWaitSlotFree,
 };
 
 } // namespace detail

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -2197,6 +2197,74 @@ class P2pIbgdaTransportDevice {
   }
 
   /**
+   * Initialize transport-owned state for one resumable fused forward.
+   *
+   * A forward acts as a recv on `*this` and a send on `fwd` for the same
+   * `group.group_id`. The combined progress lives in this transport's recv slot
+   * (driven through the `Fwd*` stages); `fwd`'s send slot is held `Busy` for
+   * the whole op. Init is all-or-nothing across both slots and validates both
+   * geometries before reserving either cursor. Zero-byte forwards mark both
+   * slots `Done`, matching blocking `forward()`. IBGDA-only.
+   *
+   * @param group Thread group that will execute all later progress calls.
+   * @param fwd Forward transport (sends to the next peer in the ring).
+   * @param nbytes Number of user-buffer bytes to receive and forward.
+   * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
+   *
+   * @pre Every `progress_forward_once()` call driving this op must pass the
+   *      same `group`, `fwd`, `nbytes` and `max_signal_bytes`. Per-call
+   *      geometry is recomputed in registers rather than persisted alongside
+   *      the cursor (see `detail::ProgressGeometry`), so this is NOT
+   *      validated: changing any of them mid-op silently reinterprets the
+   *      reserved byte cursor against a different chunk layout.
+   */
+  __device__ __forceinline__ void init_forward_progress(
+      ThreadGroup& group,
+      P2pIbgdaTransportDevice& fwd,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0) {
+    detail::init_forward_progress(*this, group, fwd, nbytes, max_signal_bytes);
+  }
+
+  /**
+   * Attempt bounded progress on one initialized fused forward.
+   *
+   * One call advances at most one chunk through the three `Fwd*` stages,
+   * mirroring the blocking `forward()` per-chunk ordering (recv DATA_READY ->
+   * fwd NIC_DONE -> `CopyOp::forward` -> recv SLOT_FREE -> fwd SLOT_FREE ->
+   * put). It never spins: each dependency check returns `Waiting`/`Progressed`
+   * so a scheduler can drive another lane. Returning `Done` means the reserved
+   * protocol byte range has completed. `CopyOp` must expose
+   * `forward(dst, fwd_staging, staging, bytes, group, dataOffset, args...)`;
+   * `dst` may be nullptr for fused reduce-scatter. IBGDA-only.
+   *
+   * @param group Thread group matching the one used during initialization.
+   * @param dst Application destination, or nullptr if `CopyOp` handles it.
+   * @param fwd Forward transport matching the one used during initialization.
+   * @param nbytes Number of user-buffer bytes from the matching init call.
+   * @param max_signal_bytes Maximum signaled sub-chunk size from init.
+   * @param timeout Optional device timeout checked while dependencies wait.
+   * @param args Additional arguments forwarded to `CopyOp::forward`.
+   *
+   * @pre `group`, `fwd`, `nbytes` and `max_signal_bytes` must be identical on
+   *      every call for this op and equal to those given to
+   *      `init_forward_progress()`. This is NOT validated -- see that
+   *      function's precondition for why.
+   */
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_forward_once(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      P2pIbgdaTransportDevice& fwd,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+    return detail::progress_forward_once<P2pIbgdaTransportDevice, CopyOp>(
+        *this, group, dst, fwd, nbytes, max_signal_bytes, timeout, args...);
+  }
+
+  /**
    * send — send one block's tile via pipelined RDMA.
    *
    * Copies src → sendStaging, then RDMA puts sendStaging → peer's recvStaging.


### PR DESCRIPTION
Summary:

NOTE: See P2450602235 for a review guide / overview of the diff). 

Ports the resumable fused forward to trunk's IBGDA prims transport as the prerequisite for the `cthierarchical_ring` bidirectional all-gather (the next diff). Adds a yield-able counterpart of the blocking `forward()` (`init_forward_progress` / `progress_forward_once`) so a single kernel can drive two ring directions concurrently. This is a re-derivation of D108772570 against trunk's current per-channel transport state model (`IbLocalChannel` / `IbChannelProgress`, per-QP-lane `DATA_READY`, protocol padding), not a cherry-pick -- the original targeted the pre-refactor `IbSendRecvState` / flat `2*maxGroups` model that no longer exists.

**Design (mirrors the blocking forward per-chunk order, made resumable):**
- Three appended `IbSendRecvProgressStage` values (`FwdWaitDataReady`, `FwdWaitNicDone`, `FwdWaitSlotFree`) drive the op on the recv slot's `activeStage`; the fwd transport's send slot stays Busy for the whole op. Appended so the on-HBM encoding of the existing values is unchanged.
- `init_forward_progress` is all-or-nothing: both staging geometries are validated before either slot's byte cursor is reserved; zero-byte forwards mark both slots Done.
- `progress_forward_once` advances at most one chunk per call: recv `DATA_READY` -> fwd `NIC_DONE` -> `CopyOp::forward` -> recv `SLOT_FREE` (before the fwd wait, ring-deadlock avoidance) -> fwd `SLOT_FREE` -> put. Each non-idempotent side effect runs during a stage transition and the new stage is persisted only after it, so a Waiting/resume never replays it (the `FwdWaitNicDone` stage is persisted before yielding so a resume cannot re-poll and re-consume `DATA_READY`).
- The paired fwd send slot is kept in true lockstep: its `activeNextByte` advances by `bytesThis` after every put, and `validate_forward_paired_slots` traps on any drift (fwd not Busy, cursor mismatch, or a reserved range that no longer ends where init left it).
- `bytesThis` is the min over both sides' chunk geometries, keeping the wire protocol compatible with `send()`/`recv()`/`forward()` in a homogeneous ring.
- IBGDA-only: exposed via thin wrappers on `P2pIbgdaTransportDevice` only (not the generic `P2pIbTransportDevice` dispatch struct, no IBRC changes); the AMD dependent `static_assert` lives in the `detail::` body, matching the resumable send/recv.

Tests (included in this commit): the resumable-forward `recv_forward_chain` distributed tests (`ForwardWithCopyProgress` / `ForwardOnlyProgress` / `MultiSectionProgress` -- the last exercises the fwd cursor advancing in lockstep across multiple chunks) and the no-QP unit tests (zero-byte init, init state layout, completed-Done equal cursors, paired-slot desync trap, Done-pairing trap).

Differential Revision: D112606191


