### PR TITLE
Guard spdlog usage behind non-AMD for spdlog-less RCCL build (#3490)

### DIFF
--- a/comms/ctran/utils/CtranMulticast.cc
+++ b/comms/ctran/utils/CtranMulticast.cc
@@ -8,7 +8,9 @@
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/utils/LogInit.h"
 #include "comms/utils/logger/LogUtils.h"
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12010
 #include "comms/utils/logger/SpdlogLogger.h"
+#endif
 
 namespace ctran::utils {
 

--- a/comms/ctran/utils/LogInit.cc
+++ b/comms/ctran/utils/LogInit.cc
@@ -10,7 +10,9 @@
 #include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/Logger.h"
 #include "comms/utils/logger/LoggingFormat.h"
+#if !defined(__HIP_PLATFORM_AMD__)
 #include "comms/utils/logger/SpdlogLogger.h"
+#endif
 
 namespace ctran::logging {
 
@@ -30,6 +32,7 @@ std::string getHipCtranCategory() {
   return fullFilePath.substr(0, ctranComponentIdx + kCtranComponent.size());
 };
 
+#if !defined(__HIP_PLATFORM_AMD__)
 spdlog::level::level_enum loggerLevelToSpdlogLevel(
     meta::comms::logger::LogLevel level) {
   switch (level) {
@@ -50,6 +53,7 @@ spdlog::level::level_enum loggerLevelToSpdlogLevel(
   }
   return spdlog::level::off;
 }
+#endif
 
 } // namespace
 
@@ -100,6 +104,7 @@ void initCtranLoggingImpl() {
             return cudaDev;
           }});
 #endif
+#if !defined(__HIP_PLATFORM_AMD__)
   meta::comms::logger::configureSpdlogLogger(
       kCtranSpdlogContext,
       "CTRAN",
@@ -115,6 +120,7 @@ void initCtranLoggingImpl() {
   meta::comms::logger::getSpdlogLogger(kCtranSpdlogContext)
       .set_level(loggerLevelToSpdlogLevel(
           meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
+#endif
 }
 } // anonymous namespace
 

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -1081,6 +1081,8 @@ set(COMMON_FILES
   comms/utils/logger/alloc.h
   comms/utils/logger/BackendTopologyUtil.cc
   comms/utils/logger/BackendTopologyUtil.h
+  comms/utils/logger/CommsLogFormatter.cc
+  comms/utils/logger/CommsLogFormatter.h
   comms/utils/logger/DataSink.h
   comms/utils/logger/DataTable.cc
   comms/utils/logger/DataTable.h

--- a/comms/utils/logger/LoggingFormat.cc
+++ b/comms/utils/logger/LoggingFormat.cc
@@ -20,7 +20,9 @@
 #include "comms/utils/logger/ErrorStackUtil.h"
 #include "comms/utils/logger/EventsScubaUtil.h"
 #include "comms/utils/logger/NcclScubaSample.h"
+#if !defined(__HIP_PLATFORM_AMD__)
 #include "comms/utils/logger/SpdlogLogger.h"
+#endif
 
 namespace {
 std::string getHostName(const char delim) {
@@ -248,7 +250,9 @@ void initThreadMetaData(std::string_view threadName) {
   static thread_local folly::once_flag threadNameFlag;
   folly::call_once(threadNameFlag, [&]() {
     myThreadName = threadName;
+#if !defined(__HIP_PLATFORM_AMD__)
     setSpdlogThreadName(threadName);
+#endif
   });
 }
 


### PR DESCRIPTION
Summary:

The standalone RCCL/conda build (comms/rcclx/develop/projects/rccl) compiles a
subset of the comms sources (all of comms/ctran via glob, plus an explicit
COMMON_FILES list from comms/utils) and deliberately has no spdlog available
(see the existing rdma/ibrc exclusions that note "spdlog which is not available
in this build").

The recent comms-simplification/defolly work wove spdlog into the comms logging
stack, adding unguarded spdlog includes/usage to files that this build compiles:
- D114829369 ("Migrate CTRAN capability warnings"): comms/ctran/utils/LogInit.cc
  and comms/ctran/utils/CtranMulticast.cc.
- D114826772 ("Preserve log metadata in spdlog"): comms/utils/logger/
  LoggingFormat.cc.

comms/utils/logger/SpdlogLogger.h hard-requires the SPDLOG_FMT_EXTERNAL /
SPDLOG_ACTIVE_LEVEL compile definitions and the spdlog headers, so every
rccl.dir TU that pulls in any of these files fails to compile:

    SpdlogLogger.h:15: error: "SpdlogLogger requires SPDLOG_FMT_EXTERNAL from the build target"
    SpdlogLogger.h:19: error: "SpdlogLogger requires SPDLOG_ACTIVE_LEVEL from the build target"
    SpdlogLogger.h:22: fatal error: 'spdlog/sinks/dist_sink.h' file not found

Simply excluding the files from the CMake build does not work:
- Ctran.cc calls ctran::logging::initCtranLogging() unconditionally, so dropping
  LogInit.cc leaves an undefined symbol at link.
- CtranMulticast.cc's #else branch provides the AMD stub symbols that
  comms/ctran/window/window.cc links against, so it cannot be dropped either.
- LoggingFormat.cc is core logging (folly LogFormatter) used throughout.

Instead, guard the spdlog dependency behind !defined(__HIP_PLATFORM_AMD__) (the
condition that already gates the spdlog-using code paths). The spdlog-less RCCL
build is the only AMD/HIP build; on NVIDIA (BUCK) the includes/usage stay active
and behavior is unchanged.

- CtranMulticast.cc: move the SpdlogLogger.h include inside the existing
  `#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12010` block. All
  COMMS_LOG_CONTEXT usage was already inside that guard; only the include leaked
  out. The AMD #else stubs are unaffected.
- LogInit.cc: guard the SpdlogLogger.h include, the spdlog-only
  loggerLevelToSpdlogLevel() helper, and the configureSpdlogLogger/
  getSpdlogLogger block. The folly-based NcclLogger init path (and thus
  initCtranLogging) remains intact on ROCm.
- LoggingFormat.cc: guard the SpdlogLogger.h include and the single
  setSpdlogThreadName() call in initThreadMetaData(). The folly LogFormatter
  path is otherwise unchanged.

No behavior change on NVIDIA (spdlog includes/usage stay active there); the
comms/ctran/utils and comms/utils/logger BUCK targets already dep
//comms/utils/logger:spdlog_logger. On the ROCm RCCL build the spdlog-based
logging is omitted (folly logging still works); CtranMulticast's warnings were
NVIDIA-only anyway.

Reviewed By: JinghanHuang

Differential Revision: D115067885


