### PR TITLE
Unify multimem staging configuration contract (#3491)

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -124,48 +124,19 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         ? static_cast<size_t>(MCCL_NVL_MULTIMEM_BUFSIZE)
         : nvlSharedDevbufSize;
     if (comm->statex_->nLocalRanks() > 2 && multimemDevbufSize > 0) {
-      const uint32_t multimemPipelineDepth = static_cast<uint32_t>(
-          std::max<size_t>(1, config.nvlConfig.pipelineDepth));
+      const size_t multimemPipelineDepth =
+          std::max<size_t>(1, config.nvlConfig.pipelineDepth);
       // Reuse the already-computed channel count (== std::max(1,
-      // MCCL_MAX_NBLOCKS)) as the group count so the signal sizing cannot drift
-      // from the transport's actual channel count.
+      // MCCL_MAX_NBLOCKS)) as the group count so allocation and launch policy
+      // share one immutable geometry snapshot.
       const uint32_t multimemMaxGroups =
           static_cast<uint32_t>(config.nvlConfig.maxNumChannels);
-      // Per-lane signal region, sized from the shared source of truth
-      // `multimem_staging_signals_per_lane` (MultimemNvlTransportDevice.cuh).
-      // The device-side `make_stage_layout` (MultimemNvlStageLayout.cuh, added
-      // by the ReduceScatter copy prereq stacked on this diff) is updated to
-      // call the same helper, so the host sizing here and the device layout
-      // stay in lockstep off one definition rather than duplicated literals.
-      const uint32_t multimemSignalsPerLane =
-          comms::prims::multimem_staging_signals_per_lane(
-              comm->statex_->nLocalRanks());
-      // Evaluate the product in u64 (all three factors are hardware-bounded to
-      // small values, so it cannot realistically overflow u64) and bound it
-      // against the transport's signal-count limit (INT_MAX; see
-      // MultimemNvlTransport's ctor) before narrowing into the u32 field, so a
-      // future large maxGroups/pipelineDepth/nLocalRanks fails loudly here with
-      // context rather than silently wrapping or throwing deeper in the ctor.
-      const uint64_t multimemInternalSignalCount =
-          static_cast<uint64_t>(multimemMaxGroups) * multimemPipelineDepth *
-          multimemSignalsPerLane;
-      if (multimemInternalSignalCount >
-          static_cast<uint64_t>(std::numeric_limits<int>::max())) {
-        CLOGF(
-            ERR,
-            "CTRAN-PRIMS: multimem internalSignalCount {} exceeds the transport signal-count limit (INT_MAX); maxGroups={} pipelineDepth={} signalsPerLane={}",
-            multimemInternalSignalCount,
-            multimemMaxGroups,
-            multimemPipelineDepth,
-            multimemSignalsPerLane);
-        return commInvalidArgument;
-      }
       config.nvlConfig.enableMultimem = true;
       config.nvlConfig.multimem = comms::prims::MultimemNvlTransportConfig{
           .dataBufferSize = multimemDevbufSize,
           .userSignalCount = 1,
-          .internalSignalCount =
-              static_cast<uint32_t>(multimemInternalSignalCount),
+          .pipelineDepth = multimemPipelineDepth,
+          .maxGroups = multimemMaxGroups,
       };
     }
 
@@ -332,7 +303,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
 
     CLOGF(
         INFO,
-        "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} enableMultimem={} multimemSignals={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={}",
+        "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} enableMultimem={} multimemPipelineDepth={} multimemMaxGroups={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={}",
         comm->statex_->rank(),
         config.nvlConfig.pipelineDepth,
         nvlSharedDevbufSize,
@@ -341,8 +312,10 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         config.nvlConfig.perChannelSize,
         config.nvlConfig.enableMultimem,
         config.nvlConfig.enableMultimem
-            ? config.nvlConfig.multimem.internalSignalCount
+            ? config.nvlConfig.multimem.pipelineDepth
             : 0,
+        config.nvlConfig.enableMultimem ? config.nvlConfig.multimem.maxGroups
+                                        : 0,
         hierAgOverlapEnabled,
         config.disableIb,
         config.topoConfig.p2pDisable,

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -133,49 +133,20 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         ? static_cast<size_t>(MCCL_NVL_MULTIMEM_BUFSIZE)
         : nvlSharedDevbufSize;
     if (comm->statex_->nLocalRanks() > 2 && multimemDevbufSize > 0) {
-      const uint32_t multimemPipelineDepth = static_cast<uint32_t>(
-          std::max<size_t>(1, config.nvlConfig.pipelineDepth));
+      const std::size_t multimemPipelineDepth =
+          std::max<std::size_t>(1, config.nvlConfig.pipelineDepth);
       // Reuse the already-computed channel count (config.nvlConfig
       // .maxNumChannels, resolved from primsConfig.maxBlocks or
-      // MCCL_MAX_NBLOCKS) as the group count so the signal sizing cannot drift
+      // MCCL_MAX_NBLOCKS) as the channel count so signal sizing cannot drift
       // from the transport's actual channel count. Do not re-derive it here.
-      const uint32_t multimemMaxGroups =
-          static_cast<uint32_t>(config.nvlConfig.maxNumChannels);
-      // Per-lane signal region, sized from the shared source of truth
-      // `multimem_staging_signals_per_lane` (MultimemNvlTransportDevice.cuh).
-      // The device-side `make_stage_layout` (MultimemNvlStageLayout.cuh, added
-      // by the ReduceScatter copy prereq stacked on this diff) is updated to
-      // call the same helper, so the host sizing here and the device layout
-      // stay in lockstep off one definition rather than duplicated literals.
-      const uint32_t multimemSignalsPerLane =
-          comms::prims::multimem_staging_signals_per_lane(
-              comm->statex_->nLocalRanks());
-      // Evaluate the product in u64 (all three factors are hardware-bounded to
-      // small values, so it cannot realistically overflow u64) and bound it
-      // against the transport's signal-count limit (INT_MAX; see
-      // MultimemNvlTransport's ctor) before narrowing into the u32 field, so a
-      // future large maxGroups/pipelineDepth/nLocalRanks fails loudly here with
-      // context rather than silently wrapping or throwing deeper in the ctor.
-      const uint64_t multimemInternalSignalCount =
-          static_cast<uint64_t>(multimemMaxGroups) * multimemPipelineDepth *
-          multimemSignalsPerLane;
-      if (multimemInternalSignalCount >
-          static_cast<uint64_t>(std::numeric_limits<int>::max())) {
-        CLOGF(
-            ERR,
-            "CTRAN-PRIMS: multimem internalSignalCount {} exceeds the transport signal-count limit (INT_MAX); maxGroups={} pipelineDepth={} signalsPerLane={}",
-            multimemInternalSignalCount,
-            multimemMaxGroups,
-            multimemPipelineDepth,
-            multimemSignalsPerLane);
-        return commInvalidArgument;
-      }
+      const std::size_t multimemMaxChannels =
+          static_cast<std::size_t>(config.nvlConfig.maxNumChannels);
       config.nvlConfig.enableMultimem = true;
       config.nvlConfig.multimem = comms::prims::MultimemNvlTransportConfig{
           .dataBufferSize = multimemDevbufSize,
           .userSignalCount = 1,
-          .internalSignalCount =
-              static_cast<uint32_t>(multimemInternalSignalCount),
+          .pipelineDepth = multimemPipelineDepth,
+          .maxChannels = multimemMaxChannels,
       };
     }
 
@@ -392,7 +363,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
 
     CLOGF(
         INFO,
-        "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} enableMultimem={} multimemSignals={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={}",
+        "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} enableMultimem={} multimemPipelineDepth={} multimemMaxChannels={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={}",
         comm->statex_->rank(),
         config.nvlConfig.pipelineDepth,
         nvlSharedDevbufSize,
@@ -401,8 +372,10 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         config.nvlConfig.perChannelSize,
         config.nvlConfig.enableMultimem,
         config.nvlConfig.enableMultimem
-            ? config.nvlConfig.multimem.internalSignalCount
+            ? config.nvlConfig.multimem.pipelineDepth
             : 0,
+        config.nvlConfig.enableMultimem ? config.nvlConfig.multimem.maxChannels
+                                        : 0,
         hierAgOverlapEnabled,
         config.disableIb,
         config.topoConfig.p2pDisable,

--- a/comms/prims/memory/GpuMemHandler.cc
+++ b/comms/prims/memory/GpuMemHandler.cc
@@ -316,7 +316,8 @@ const cudaIpcMemHandle_t& GpuMemHandler::getLocalIpcHandle() const {
 void GpuMemHandler::exchangeMulticast(
     int32_t commRank,
     std::vector<int> nvlRankToCommRank,
-    int cudaDevice) {
+    int cudaDevice,
+    MulticastExchangeContract contract) {
   // PRECONDITION: VMM allocation + unicast mapping must already exist (the
   // constructor does this for kFabric/kPosixFd modes). The multicast object
   // binds into this rank's physical handle and shares its VA with peers.
@@ -341,10 +342,10 @@ void GpuMemHandler::exchangeMulticast(
     // and surface as a multicast collective desync at runtime.
     if (commRank != multimemCommRank_ ||
         nvlRankToCommRank != multimemNvlRankToCommRank_ ||
-        cudaDevice != multimemCudaDevice_) {
+        cudaDevice != multimemCudaDevice_ || !(contract == multimemContract_)) {
       throw std::runtime_error(
           "GpuMemHandler::exchangeMulticast: re-entered with different "
-          "(commRank, nvlRankToCommRank, cudaDevice) than the existing "
+          "(commRank, nvlRankToCommRank, cudaDevice, contract) than the existing "
           "multicast overlay; the overlay is bound to the first call's "
           "topology");
     }
@@ -357,12 +358,18 @@ void GpuMemHandler::exchangeMulticast(
   // `if (multimem_) { return; }` would silently no-op while
   // getMultimemDeviceMemPtr() dereferenced an unexchanged overlay.
   auto pending = std::make_unique<MultimemHandler>(
-      allocation_, bootstrap_, commRank, nvlRankToCommRank, cudaDevice);
+      allocation_,
+      bootstrap_,
+      commRank,
+      nvlRankToCommRank,
+      cudaDevice,
+      contract);
   pending->exchange();
   multimem_ = std::move(pending);
   multimemCommRank_ = commRank;
   multimemNvlRankToCommRank_ = std::move(nvlRankToCommRank);
   multimemCudaDevice_ = cudaDevice;
+  multimemContract_ = contract;
 }
 
 void* GpuMemHandler::getMultimemDeviceMemPtr() const {
@@ -376,7 +383,8 @@ void* GpuMemHandler::getMultimemDeviceMemPtr() const {
 void GpuMemHandler::exchangeMulticast(
     int32_t /*commRank*/,
     std::vector<int> /*nvlRankToCommRank*/,
-    int /*cudaDevice*/) {
+    int /*cudaDevice*/,
+    MulticastExchangeContract /*contract*/) {
   throw std::runtime_error(
       "GpuMemHandler::exchangeMulticast: multicast is not supported on AMD");
 }

--- a/comms/prims/memory/GpuMemHandler.h
+++ b/comms/prims/memory/GpuMemHandler.h
@@ -240,11 +240,13 @@ class GpuMemHandler {
    * @param commRank This process's rank in the global communicator
    * @param nvlRankToCommRank Maps each NVLink-local rank to its global rank
    * @param cudaDevice CUDA device ordinal (already current)
+   * @param contract Protocol identity that must match across the NVLink team
    */
   void exchangeMulticast(
       int32_t commRank,
       std::vector<int> nvlRankToCommRank,
-      int cudaDevice);
+      int cudaDevice,
+      MulticastExchangeContract contract = {});
 
   /**
    * Returns this rank's multicast VA. PRECONDITION: exchangeMulticast() done.
@@ -329,6 +331,7 @@ class GpuMemHandler {
   int32_t multimemCommRank_{-1};
   std::vector<int> multimemNvlRankToCommRank_;
   int multimemCudaDevice_{-1};
+  MulticastExchangeContract multimemContract_;
 #endif
 
   // ---- CudaIpc mode state ----

--- a/comms/prims/memory/MultimemHandler.cc
+++ b/comms/prims/memory/MultimemHandler.cc
@@ -177,7 +177,8 @@ MultimemHandler::MultimemHandler(
     std::shared_ptr<meta::comms::IBootstrap> bootstrap,
     int32_t commRank,
     std::vector<int> nvlRankToCommRank,
-    int cudaDevice)
+    int cudaDevice,
+    MulticastExchangeContract contract)
     : bootstrap_(std::move(bootstrap)),
       commRank_(commRank),
       nvlRank_(computeNvlRankAndValidate(commRank, nvlRankToCommRank)),
@@ -185,6 +186,7 @@ MultimemHandler::MultimemHandler(
       nvlRankToCommRank_(std::move(nvlRankToCommRank)),
       cudaDevice_(cudaDevice),
       requestedSize_(requireBacking(backing)->size()),
+      contract_(contract),
       backing_(std::move(backing)) {
   if (requestedSize_ == 0) {
     throw std::runtime_error("MultimemHandler: backing size must be non-zero");
@@ -354,8 +356,8 @@ void MultimemHandler::exchange() {
     // (which embeds handleType_). A silent mismatch would surface as a
     // confusing export/import failure on the next phase; fail fast with a clear
     // message.
-    failedPhase = "agreeOnHandleType";
-    agreeOnHandleType();
+    failedPhase = "agreeOnSetup";
+    agreeOnSetup();
     completedPhase = failedPhase;
 
     failedPhase = "computeAllocationLayout";
@@ -604,10 +606,22 @@ void MultimemHandler::synchronizeRanks(const char* phase) {
   }
 }
 
-void MultimemHandler::agreeOnHandleType() {
-  std::vector<int> selections(static_cast<std::size_t>(nvlRanks_), 0);
-  selections[static_cast<std::size_t>(nvlRank_)] =
-      static_cast<int>(handleType_);
+void MultimemHandler::agreeOnSetup() {
+  struct SetupRecord {
+    uint64_t handleType{0};
+    uint64_t requestedSize{0};
+    MulticastExchangeContract contract;
+  };
+  static_assert(std::is_trivially_copyable_v<SetupRecord>);
+  static_assert(std::is_standard_layout_v<SetupRecord>);
+
+  const SetupRecord local{
+      .handleType = static_cast<uint64_t>(handleType_),
+      .requestedSize = requestedSize_,
+      .contract = contract_,
+  };
+  std::vector<SetupRecord> records(static_cast<std::size_t>(nvlRanks_));
+  records[static_cast<std::size_t>(nvlRank_)] = local;
   // Use the NVL-domain allGather (not the global one): nvlRank_/nvlRanks_ are
   // the NVLink-team indices, and the bootstrap's plain allGather expects
   // global comm ranks. Mirrors exchangeMulticastHandle's allGatherNvlDomain
@@ -616,28 +630,39 @@ void MultimemHandler::agreeOnHandleType() {
   // peers outside the NVL team contributed zeros).
   auto gatherResult = bootstrap_
                           ->allGatherNvlDomain(
-                              selections.data(),
-                              sizeof(int),
+                              records.data(),
+                              sizeof(SetupRecord),
                               nvlRank_,
                               nvlRanks_,
                               nvlRankToCommRank_)
                           .get();
   if (gatherResult != 0) {
     throw std::runtime_error(
-        "MultimemHandler::agreeOnHandleType allGatherNvlDomain failed");
+        "MultimemHandler::agreeOnSetup allGatherNvlDomain failed");
   }
   for (int32_t r = 0; r < nvlRanks_; ++r) {
-    const auto peerType = static_cast<HandleType>(selections[r]);
-    if (peerType != handleType_) {
+    const auto& peer = records[static_cast<std::size_t>(r)];
+    if (peer.handleType != local.handleType ||
+        peer.requestedSize != local.requestedSize ||
+        !(peer.contract == local.contract)) {
       throw std::runtime_error(
           fmt::format(
-              "MultimemHandler: ranks disagree on multicast handle type "
-              "(this rank nvl={} chose {}, peer nvl={} chose {}); all ranks "
-              "must select the same fabric / POSIX FD handle type",
+              "MultimemHandler: ranks disagree on multicast setup "
+              "(this rank nvl={} type={} size={} protocol={} version={} "
+              "parameters=[{}], peer nvl={} type={} size={} protocol={} "
+              "version={} parameters=[{}])",
               nvlRank_,
               handleTypeName(handleType_),
+              local.requestedSize,
+              local.contract.protocol,
+              local.contract.version,
+              fmt::join(local.contract.parameters, ", "),
               r,
-              handleTypeName(peerType)));
+              handleTypeName(static_cast<HandleType>(peer.handleType)),
+              peer.requestedSize,
+              peer.contract.protocol,
+              peer.contract.version,
+              fmt::join(peer.contract.parameters, ", ")));
     }
   }
 }

--- a/comms/prims/memory/MultimemHandler.h
+++ b/comms/prims/memory/MultimemHandler.h
@@ -81,6 +81,8 @@ class MultimemHandler {
    * multicast object. `backing->size()` becomes this handler's allocated size,
    * so the caller must have sized `backing` to a multiple of max(local
    * allocation granularity, multicast granularity) -- see backingGranularity().
+   * `contract` identifies any protocol layered over the allocation and must be
+   * identical on every rank. The empty default represents raw multicast use.
    *
    * Throws std::runtime_error if `backing` is null.
    */
@@ -89,7 +91,8 @@ class MultimemHandler {
       std::shared_ptr<meta::comms::IBootstrap> bootstrap,
       int32_t commRank,
       std::vector<int> nvlRankToCommRank,
-      int cudaDevice);
+      int cudaDevice,
+      MulticastExchangeContract contract = {});
 
   ~MultimemHandler();
 
@@ -170,12 +173,7 @@ class MultimemHandler {
   void bindLocalMemoryToMulticast(std::size_t allocatedSize);
   void mapMulticastMemory(const AllocationLayout& layout);
   void synchronizeRanks(const char* phase);
-  // AllGather handleType_ across the NVL team and throw if not every rank
-  // selected the same one. Called from exchange() before rank 0 creates the
-  // multicast object so a per-rank selection drift (e.g. one rank without IMEX
-  // chose POSIX FD while peers chose fabric) is reported as a clear error
-  // instead of a confusing export/import failure later.
-  void agreeOnHandleType();
+  void agreeOnSetup();
   std::string describeState(const char* failedPhase, const char* completedPhase)
       const;
   void cleanup();
@@ -187,6 +185,7 @@ class MultimemHandler {
   const std::vector<int> nvlRankToCommRank_;
   const int cudaDevice_{-1};
   const std::size_t requestedSize_{0};
+  const MulticastExchangeContract contract_;
   HandleType handleType_{HandleType::kUnsupported};
 
   bool exchanged_{false};

--- a/comms/prims/memory/NvlMemExchange.h
+++ b/comms/prims/memory/NvlMemExchange.h
@@ -16,6 +16,7 @@
 #endif
 
 #include <sys/types.h>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
@@ -24,6 +25,26 @@
 #include "comms/prims/memory/CuMemMapping.h"
 
 namespace comms::prims {
+
+/**
+ * Fixed-width identity for a protocol layered over a multicast allocation.
+ *
+ * Every rank in an NVLink team must supply the same value. The owning protocol
+ * assigns `protocol`, versions its parameter schema with `version`, and owns
+ * the interpretation of `parameters`. The all-zero default identifies raw
+ * multicast users with no additional protocol contract; it is still compared
+ * across ranks.
+ */
+struct MulticastExchangeContract {
+  uint64_t protocol{0};
+  uint64_t version{0};
+  std::array<uint64_t, 4> parameters{};
+
+  bool operator==(const MulticastExchangeContract& other) const {
+    return protocol == other.protocol && version == other.version &&
+        parameters == other.parameters;
+  }
+};
 
 #if defined(__HIP_PLATFORM_AMD__)
 // Stub the one CUDA driver-API type unique to this header (the shared

--- a/comms/prims/tests/GpuMemHandlerMulticastTest.cc
+++ b/comms/prims/tests/GpuMemHandlerMulticastTest.cc
@@ -437,6 +437,51 @@ TEST_F(
   ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 }
 
+TEST_F(
+    GpuMemHandlerMulticastTestFixture,
+    ExchangeMulticastMismatchedReentryContractThrows) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "multimem requires >=3 NVL ranks";
+  }
+  auto bootstrap = makeBootstrap("gpumem_multicast_mismatch_contract");
+  if (!allRanksMultimemSupported(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "multimem unsupported on this host";
+  }
+  const auto modeOpt = bestVmmModeForMulticast();
+  if (!modeOpt) {
+    GTEST_SKIP() << "multicast requires VMM mode (kFabric/kPosixFd); "
+                    "detectBestMode returned kCudaIpc";
+  }
+  const std::size_t allocSize = multicastBackingSize(localRank, numRanks);
+  GpuMemHandler handler(
+      bootstrap,
+      globalRank,
+      numRanks,
+      allocSize,
+      *modeOpt,
+      /*alignFloor=*/allocSize);
+  handler.exchangeMemPtrs();
+
+  const MulticastExchangeContract contract{
+      .protocol = 1, .version = 1, .parameters = {1, 2, 3, 4}};
+  handler.exchangeMulticast(
+      globalRank, identityRankMap(numRanks), localRank, contract);
+  auto changedContract = contract;
+  changedContract.parameters[3]++;
+  try {
+    handler.exchangeMulticast(
+        globalRank, identityRankMap(numRanks), localRank, changedContract);
+    FAIL() << "expected std::runtime_error on contract mismatch";
+  } catch (const std::runtime_error& ex) {
+    EXPECT_NE(
+        std::string(ex.what()).find("re-entered with different"),
+        std::string::npos)
+        << ex.what();
+  }
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
 } // namespace comms::prims::tests
 
 int main(int argc, char* argv[]) {

--- a/comms/prims/tests/MultimemHandlerTest.cc
+++ b/comms/prims/tests/MultimemHandlerTest.cc
@@ -161,7 +161,7 @@ std::shared_ptr<StrictMockBootstrap> makeDelegatingMock(
 // Identifies one of the four bootstrap call sites inside
 // `MultimemHandler::exchange`. `ordinal` is the 0-based occurrence of the
 // chosen `Api` within a single `exchange()` invocation:
-//   (kAllGatherNvlDomain, 0) -> agreeOnHandleType
+//   (kAllGatherNvlDomain, 0) -> agreeOnSetup
 //   (kAllGatherNvlDomain, 1) -> exchangeMulticastHandle
 //   (kBarrierNvlDomain,   0) -> synchronizeRanks("pre-bind")
 //   (kBarrierNvlDomain,   1) -> synchronizeRanks("post-map")
@@ -186,7 +186,7 @@ enum class FailureMode {
 };
 
 constexpr FailureCase kAllFailureCases[] = {
-    {"agreeOnHandleType", FailureCase::Api::kAllGatherNvlDomain, 0},
+    {"agreeOnSetup", FailureCase::Api::kAllGatherNvlDomain, 0},
     {"exchangeMulticastHandle", FailureCase::Api::kAllGatherNvlDomain, 1},
     {"preBindBarrier", FailureCase::Api::kBarrierNvlDomain, 0},
     {"postMapBarrier", FailureCase::Api::kBarrierNvlDomain, 1},
@@ -231,8 +231,23 @@ auto allGatherFailureAction(FailureMode mode) {
   };
 }
 
-auto barrierFailureAction(FailureMode mode) {
-  return [mode](int, int, const std::vector<int>&) -> folly::SemiFuture<int> {
+auto barrierFailureAction(
+    FailureMode mode,
+    const std::shared_ptr<meta::comms::IBootstrap>& real,
+    bool rendezvousBeforeFailure) {
+  return [mode, real, rendezvousBeforeFailure](
+             int rank,
+             int nRanks,
+             const std::vector<int>& rankMap) -> folly::SemiFuture<int> {
+    // Symmetric injection must let every rank reach the target before the
+    // first throw starts tearing down their shared multicast object.
+    if (rendezvousBeforeFailure) {
+      const int rendezvousResult =
+          real->barrierNvlDomain(rank, nRanks, rankMap).get();
+      if (rendezvousResult != 0) {
+        return folly::makeSemiFuture(rendezvousResult);
+      }
+    }
     switch (mode) {
       case FailureMode::kReturnNonZero:
         return folly::makeSemiFuture(-1);
@@ -262,7 +277,8 @@ void programFailureInjection(
     const std::shared_ptr<meta::comms::IBootstrap>& real,
     const FailureCase& fail,
     FailureMode mode,
-    bool injectOnThisRank = true) {
+    bool injectOnThisRank,
+    bool rendezvousBeforeFailure) {
   using ::testing::_;
   using ::testing::AnyNumber;
   using ::testing::InSequence;
@@ -323,7 +339,7 @@ void programFailureInjection(
       EXPECT_CALL(mock, barrierNvlDomain(_, _, _)).WillOnce(delegateBarrierNvl);
     }
     EXPECT_CALL(mock, barrierNvlDomain(_, _, _))
-        .WillOnce(barrierFailureAction(mode));
+        .WillOnce(barrierFailureAction(mode, real, rendezvousBeforeFailure));
   }
 }
 
@@ -334,13 +350,13 @@ void programFailureInjection(
 enum class RankPattern {
   kAllRanks,
   kRank0Only,
-  kAllExceptRank0,
+  kRank1Only,
 };
 
 constexpr RankPattern kAllRankPatterns[] = {
     RankPattern::kAllRanks,
     RankPattern::kRank0Only,
-    RankPattern::kAllExceptRank0,
+    RankPattern::kRank1Only,
 };
 
 const char* describePattern(RankPattern p) {
@@ -349,8 +365,8 @@ const char* describePattern(RankPattern p) {
       return "AllRanks";
     case RankPattern::kRank0Only:
       return "Rank0Only";
-    case RankPattern::kAllExceptRank0:
-      return "AllExceptRank0";
+    case RankPattern::kRank1Only:
+      return "Rank1Only";
   }
   return "Unknown";
 }
@@ -361,8 +377,8 @@ bool shouldInject(RankPattern p, int globalRank) {
       return true;
     case RankPattern::kRank0Only:
       return globalRank == 0;
-    case RankPattern::kAllExceptRank0:
-      return globalRank != 0;
+    case RankPattern::kRank1Only:
+      return globalRank == 1;
   }
   return false;
 }
@@ -482,6 +498,98 @@ TEST_F(MultimemHandlerTestFixture, ExchangeSupportsNonIdentityRankMap) {
   ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 }
 
+TEST_F(MultimemHandlerTestFixture, ExchangeRejectsMismatchedBackingSize) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "CUDA multimem transport is only useful for 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("multimem_mismatched_backing_size");
+  if (!allRanksMultimemSupported(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not supported";
+  }
+
+  const std::size_t granularity =
+      MultimemHandler::backingGranularity(localRank, numRanks);
+  ASSERT_GT(granularity, 0u);
+  const std::size_t requestedSize =
+      globalRank == 0 ? granularity : 2 * granularity;
+  auto backing = makeMulticastBacking(localRank, numRanks, requestedSize);
+  MultimemHandler handler(
+      backing, bootstrap, globalRank, identityRankMap(numRanks), localRank);
+
+  try {
+    handler.exchange();
+    FAIL() << "expected setup agreement to reject mismatched backing size";
+  } catch (const std::runtime_error& ex) {
+    EXPECT_NE(
+        std::string(ex.what()).find("ranks disagree on multicast setup"),
+        std::string::npos)
+        << ex.what();
+  }
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(MultimemHandlerTestFixture, ExchangeRejectsMismatchedProtocol) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "CUDA multimem transport is only useful for 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("multimem_mismatched_protocol");
+  if (!allRanksMultimemSupported(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not supported";
+  }
+
+  auto backing = makeMulticastBacking(localRank, numRanks, 4096);
+  const MulticastExchangeContract contract{
+      .protocol = globalRank == 0 ? 1u : 2u, .version = 1};
+  MultimemHandler handler(
+      backing,
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      localRank,
+      contract);
+  try {
+    handler.exchange();
+    FAIL() << "expected setup agreement to reject mismatched protocol";
+  } catch (const std::runtime_error& ex) {
+    EXPECT_NE(
+        std::string(ex.what()).find("ranks disagree on multicast setup"),
+        std::string::npos)
+        << ex.what();
+  }
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(MultimemHandlerTestFixture, ExchangeRejectsMismatchedVersion) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "CUDA multimem transport is only useful for 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("multimem_mismatched_version");
+  if (!allRanksMultimemSupported(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not supported";
+  }
+
+  auto backing = makeMulticastBacking(localRank, numRanks, 4096);
+  const MulticastExchangeContract contract{
+      .protocol = 1, .version = globalRank == 0 ? 1u : 2u};
+  MultimemHandler handler(
+      backing,
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      localRank,
+      contract);
+  try {
+    handler.exchange();
+    FAIL() << "expected setup agreement to reject mismatched version";
+  } catch (const std::runtime_error& ex) {
+    EXPECT_NE(
+        std::string(ex.what()).find("ranks disagree on multicast setup"),
+        std::string::npos)
+        << ex.what();
+  }
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
 TEST_F(MultimemHandlerTestFixture, SharingRejectsNullBacking) {
   auto bootstrap = makeBootstrap("multimem_null_backing_test");
   // A null backing must fail fast.
@@ -547,7 +655,7 @@ TEST_F(
 }
 
 // Locks down the bootstrap API surface used by `MultimemHandler::exchange()`:
-//   - allGatherNvlDomain: exactly 2 calls per exchange (agreeOnHandleType,
+//   - allGatherNvlDomain: exactly 2 calls per exchange (agreeOnSetup,
 //     then exchangeMulticastHandle).
 //   - barrierNvlDomain:   exactly 2 calls per exchange (pre-bind, post-map).
 //   - allGather/barrier/send/recv: never called by MultimemHandler itself.
@@ -596,36 +704,15 @@ TEST_F(MultimemHandlerTestFixture, SuccessPathCoversAllBootstrapApis) {
 }
 
 // Parameterized failure-injection suite. The product is
-//   {4 phases of exchange()} x {3 failure modes} = 12 cases.
+//   {4 phases} x {3 failure modes} x {all, rank 0, rank 1} = 36 cases.
 //
 // For each case:
-//   - A real bootstrap is created with a per-case prefix so prior keys cannot
-//     leak between cases.
-//   - A StrictMockBootstrap is built that delegates every call to the real
-//     bootstrap, then the (api, ordinal) call site under test is overridden
-//     to fail with the chosen mode (return -1, throw std::runtime_error, or
-//     throw a non-std exception).
-//   - All ranks inject the same failure at the same ordinal, so every rank's
-//     exchange() throws together -- avoiding the asymmetric-failure deadlock
-//     scenario that would require a peer-side timeout to remain deterministic.
-//
-// Assertions per case:
-//   1. exchange() throws std::runtime_error.
-//   2. The message tags the right failedPhase (`failedPhase=<name>`), which
-//      proves `describeState` ran with the right phase label.
-//   3. The message contains the phase-specific substring (e.g. "pre-bind").
-//   4. For kSyncThrowsNonStd: the message contains the `catch (...)` prefix
-//      "MultimemHandler::exchange failed with unknown exception", confirming
-//      the unknown-exception fallback is reached. For std-throw / non-zero
-//      cases, the message uses the "MultimemHandler::exchange failed: " prefix.
-//   5. After the throw, both getters still throw "exchange() must complete",
-//      proving the partial-init state was not committed.
-//   6. The realBootstrap is still healthy: a subsequent barrier() returns 0.
-//      Proves cleanup() didn't leave any bootstrap state poisoned.
-//   7. Constructing a fresh handler over the *same* `backing` shared_ptr with
-//      a fresh bootstrap (different prefix) lets exchange() complete cleanly.
-//      Proves cleanup() released only the handler-owned multicast state and
-//      left the caller-owned physical backing intact and bindable.
+//   - The target API returns an error, throws std::runtime_error, or throws a
+//     non-std exception on every rank, rank 0 only, or rank 1 only.
+//   - exchange() and both post-exchange getters must throw.
+//   - Symmetric cases must leave the failure bootstrap usable.
+//   - Every case must reuse the same physical backing successfully through a
+//     fresh handler and bootstrap after cleanup.
 class MultimemHandlerFailureInjectionTest
     : public ::testing::TestWithParam<
           std::tuple<FailureCase, FailureMode, RankPattern>>,
@@ -659,6 +746,7 @@ TEST_P(MultimemHandlerFailureInjectionTest, ExchangeReportsAndCleansUp) {
     GTEST_SKIP() << "asymmetric failure tests require TCPStore env";
   }
 
+  std::shared_ptr<CuMemAllocation> backing;
   {
     std::optional<ScopedShortTimeoutBootstrap> shortBs;
     std::shared_ptr<meta::comms::IBootstrap> bootstrap;
@@ -676,7 +764,7 @@ TEST_P(MultimemHandlerFailureInjectionTest, ExchangeReportsAndCleansUp) {
       GTEST_SKIP() << "CUDA multimem/NVLS multicast is not supported";
     }
 
-    auto backing = makeMulticastBacking(localRank, numRanks, 4096);
+    backing = makeMulticastBacking(localRank, numRanks, 4096);
 
     {
       auto mock = makeDelegatingMock(bootstrap);
@@ -685,7 +773,9 @@ TEST_P(MultimemHandlerFailureInjectionTest, ExchangeReportsAndCleansUp) {
           bootstrap,
           failCase,
           failMode,
-          /*injectOnThisRank=*/shouldInject(rankPattern, globalRank));
+          /*injectOnThisRank=*/shouldInject(rankPattern, globalRank),
+          /*rendezvousBeforeFailure=*/
+          rankPattern == RankPattern::kAllRanks);
 
       MultimemHandler handler(
           backing,
@@ -722,7 +812,7 @@ TEST_P(MultimemHandlerFailureInjectionTest, ExchangeReportsAndCleansUp) {
   // overlap with the failed exchange's keys.
   auto recoveryBootstrap = makeBootstrap(casePrefix + "_recovery");
   MultimemHandler recovery(
-      makeMulticastBacking(localRank, numRanks, 4096),
+      backing,
       recoveryBootstrap,
       globalRank,
       identityRankMap(numRanks),

--- a/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cc
+++ b/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cc
@@ -1,0 +1,34 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include "comms/prims/tests/MultimemNvlStageLayoutTrapTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+#ifndef STAGE_LAYOUT_TRAP_CASE
+#error "STAGE_LAYOUT_TRAP_CASE must select one isolated trap case"
+#endif
+
+namespace comms::prims::tests {
+
+TEST(MultimemNvlStageLayoutTrapTest, InvalidGeometryTraps) {
+  int deviceCount = 0;
+  CUDACHECK_TEST(cudaGetDeviceCount(&deviceCount));
+  if (deviceCount == 0) {
+    GTEST_SKIP() << "No CUDA devices available";
+  }
+  CUDACHECK_TEST(cudaSetDevice(0));
+
+  test::launchStageLayoutTrap(
+      static_cast<test::StageLayoutTrapCase>(STAGE_LAYOUT_TRAP_CASE));
+  const auto error = cudaDeviceSynchronize();
+  EXPECT_TRUE(
+      error == cudaErrorIllegalInstruction || error == cudaErrorAssert ||
+      error == cudaErrorLaunchFailure)
+      << cudaGetErrorString(error);
+
+  EXPECT_EQ(cudaDeviceReset(), cudaSuccess);
+}
+
+} // namespace comms::prims::tests

--- a/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cu
+++ b/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cu
@@ -1,0 +1,67 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/tests/MultimemNvlStageLayoutTrapTest.cuh"
+
+#include "comms/prims/core/SignalState.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlStageLayout.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+__global__ void stageLayoutTrapKernel(StageLayoutTrapCase testCase) {
+  constexpr uint32_t kNvlRanks = 4;
+  constexpr uint32_t kExpectedSignalsPerLane =
+      multimem_staging_signals_per_lane(kNvlRanks);
+  SignalState signal;
+  const uint32_t localSignalCount =
+      testCase == StageLayoutTrapCase::InsufficientLocalSignals
+      ? kExpectedSignalsPerLane - 1
+      : kExpectedSignalsPerLane;
+  const uint32_t multimemSignalCount =
+      testCase == StageLayoutTrapCase::InsufficientMultimemSignals
+      ? kExpectedSignalsPerLane - 1
+      : kExpectedSignalsPerLane;
+  MultimemNvlTransportDevice transport{
+      .localData = reinterpret_cast<char*>(1),
+      .multimemData = reinterpret_cast<char*>(1),
+      .internalLocalSignals =
+          DeviceSpan<SignalState>(&signal, localSignalCount),
+      .internalMultimemSignals =
+          DeviceSpan<SignalState>(&signal, multimemSignalCount),
+      .dataBufferSize = 64,
+      .pipelineDepth = 1,
+      .maxGroups = 1,
+      .signalsPerLane = kExpectedSignalsPerLane,
+      .nvlRank = 0,
+      .nvlRanks = kNvlRanks,
+  };
+  switch (testCase) {
+    case StageLayoutTrapCase::ZeroGeometry:
+      transport.pipelineDepth = 0;
+      break;
+    case StageLayoutTrapCase::TooManyGroups:
+      break;
+    case StageLayoutTrapCase::BadSignalsPerLane:
+      transport.signalsPerLane = kExpectedSignalsPerLane - 1;
+      break;
+    case StageLayoutTrapCase::InsufficientLocalSignals:
+    case StageLayoutTrapCase::InsufficientMultimemSignals:
+      break;
+  }
+  auto group = make_block_group();
+  static_cast<void>(multimem::make_stage_layout<uint32_t>(transport, group));
+}
+
+} // namespace
+
+void launchStageLayoutTrap(StageLayoutTrapCase testCase) {
+  const uint32_t numGroups =
+      testCase == StageLayoutTrapCase::TooManyGroups ? 2 : 1;
+  stageLayoutTrapKernel<<<numGroups, 32>>>(
+      testCase); // NOLINT(facebook-cuda-safe-kernel-call-check)
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cu
+++ b/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cu
@@ -1,0 +1,67 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/tests/MultimemNvlStageLayoutTrapTest.cuh"
+
+#include "comms/prims/core/SignalState.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlStageLayout.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+__global__ void stageLayoutTrapKernel(StageLayoutTrapCase testCase) {
+  constexpr uint32_t kNvlRanks = 4;
+  constexpr uint32_t kExpectedSignalsPerLane =
+      multimem_staging_signals_per_lane(kNvlRanks);
+  SignalState signal;
+  const uint32_t localSignalCount =
+      testCase == StageLayoutTrapCase::InsufficientLocalSignals
+      ? kExpectedSignalsPerLane - 1
+      : kExpectedSignalsPerLane;
+  const uint32_t multimemSignalCount =
+      testCase == StageLayoutTrapCase::InsufficientMultimemSignals
+      ? kExpectedSignalsPerLane - 1
+      : kExpectedSignalsPerLane;
+  MultimemNvlTransportDevice transport{
+      .localData = reinterpret_cast<char*>(1),
+      .multimemData = reinterpret_cast<char*>(1),
+      .internalLocalSignals =
+          DeviceSpan<SignalState>(&signal, localSignalCount),
+      .internalMultimemSignals =
+          DeviceSpan<SignalState>(&signal, multimemSignalCount),
+      .dataBufferSize = 64,
+      .nvlRank = 0,
+      .nvlRanks = kNvlRanks,
+      .pipelineDepth = 1,
+      .maxChannels = 1,
+      .signalsPerLane = kExpectedSignalsPerLane,
+  };
+  switch (testCase) {
+    case StageLayoutTrapCase::ZeroGeometry:
+      transport.pipelineDepth = 0;
+      break;
+    case StageLayoutTrapCase::TooManyGroups:
+      break;
+    case StageLayoutTrapCase::BadSignalsPerLane:
+      transport.signalsPerLane = kExpectedSignalsPerLane - 1;
+      break;
+    case StageLayoutTrapCase::InsufficientLocalSignals:
+    case StageLayoutTrapCase::InsufficientMultimemSignals:
+      break;
+  }
+  auto group = make_block_group();
+  static_cast<void>(multimem::make_stage_layout<uint32_t>(transport, group));
+}
+
+} // namespace
+
+void launchStageLayoutTrap(StageLayoutTrapCase testCase) {
+  const uint32_t numGroups =
+      testCase == StageLayoutTrapCase::TooManyGroups ? 2 : 1;
+  stageLayoutTrapKernel<<<numGroups, 32>>>(
+      testCase); // NOLINT(facebook-cuda-safe-kernel-call-check)
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cuh
+++ b/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cuh
@@ -1,0 +1,22 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#ifndef COMMS_PRIMS_TESTS_MULTIMEM_NVL_STAGE_LAYOUT_TRAP_TEST_CUH_
+#define COMMS_PRIMS_TESTS_MULTIMEM_NVL_STAGE_LAYOUT_TRAP_TEST_CUH_
+
+#include <cstdint>
+
+namespace comms::prims::test {
+
+enum class StageLayoutTrapCase : uint32_t {
+  ZeroGeometry,
+  TooManyGroups,
+  BadSignalsPerLane,
+  InsufficientLocalSignals,
+  InsufficientMultimemSignals,
+};
+
+void launchStageLayoutTrap(StageLayoutTrapCase testCase);
+
+} // namespace comms::prims::test
+
+#endif

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -76,11 +76,13 @@ bool allRanksMultimemEligible(
 MultimemNvlTransportConfig makeConfig(
     std::size_t dataBufferSize,
     uint32_t userSignalCount = 1,
-    uint32_t internalSignalCount = 0) {
+    std::size_t pipelineDepth = 0,
+    std::size_t maxGroups = 0) {
   MultimemNvlTransportConfig config{};
   config.dataBufferSize = dataBufferSize;
   config.userSignalCount = userSignalCount;
-  config.internalSignalCount = internalSignalCount;
+  config.pipelineDepth = pipelineDepth;
+  config.maxGroups = maxGroups;
   return config;
 }
 
@@ -214,6 +216,7 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
+      .multimem = makeConfig(4096, 1, 1, 1),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -246,6 +249,7 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
+      .multimem = makeConfig(4096, 1, 1, 1),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -271,6 +275,7 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
+      .multimem = makeConfig(4096, 1, 1, 1),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -297,6 +302,7 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
+      .multimem = makeConfig(4096, 1, 1, 1),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -329,6 +335,7 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
+      .multimem = makeConfig(4096, 1, 1, 1),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -381,7 +388,8 @@ TEST_F(
           MultimemNvlTransportConfig{
               .dataBufferSize = 0,
               .userSignalCount = 1,
-              .internalSignalCount = 1,
+              .pipelineDepth = 1,
+              .maxGroups = 1,
           },
   };
   MultiPeerNvlTransport transport(
@@ -426,7 +434,8 @@ TEST_F(
             MultimemNvlTransportConfig{
                 .dataBufferSize = 4096,
                 .userSignalCount = 1,
-                .internalSignalCount = 1,
+                .pipelineDepth = 1,
+                .maxGroups = 1,
             },
     };
     MultiPeerNvlTransport transport(
@@ -479,7 +488,8 @@ TEST_F(
           MultimemNvlTransportConfig{
               .dataBufferSize = 4096,
               .userSignalCount = 1,
-              .internalSignalCount = 1,
+              .pipelineDepth = 1,
+              .maxGroups = 1,
           },
   };
   MultiPeerNvlTransport transport(
@@ -531,7 +541,8 @@ TEST_F(
           MultimemNvlTransportConfig{
               .dataBufferSize = 4096,
               .userSignalCount = 1,
-              .internalSignalCount = 1,
+              .pipelineDepth = 1,
+              .maxGroups = 1,
           },
   };
   MultiPeerNvlTransport transport(
@@ -570,7 +581,8 @@ TEST_F(
               .dataBufferSize =
                   kBytesPerRank * static_cast<std::size_t>(numRanks),
               .userSignalCount = 1,
-              .internalSignalCount = 1,
+              .pipelineDepth = 1,
+              .maxGroups = 1,
           },
   };
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
@@ -599,7 +611,8 @@ TEST_F(
               .dataBufferSize =
                   globalRank == 0 ? std::size_t{0} : std::size_t{4096},
               .userSignalCount = 1,
-              .internalSignalCount = 1,
+              .pipelineDepth = 1,
+              .maxGroups = 1,
           },
   };
   MultiPeerNvlTransport transport(
@@ -656,13 +669,14 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
 
   constexpr std::size_t kDataBytes = 8192;
   constexpr uint32_t kUserSignals = 2;
-  constexpr uint32_t kInternalSignals = 3;
+  const uint32_t internalSignals =
+      multimem_staging_signals_per_lane(static_cast<uint32_t>(numRanks));
 
   MultimemNvlTransport transport(
       bootstrap,
       globalRank,
       identityRankMap(numRanks),
-      makeConfig(kDataBytes, kUserSignals, kInternalSignals));
+      makeConfig(kDataBytes, kUserSignals, 1, 1));
 
   transport.exchange();
   auto handle = transport.getDeviceTransport();
@@ -676,13 +690,16 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
   EXPECT_EQ(handle.dataBufferSize, kDataBytes);
   EXPECT_EQ(handle.userLocalSignals.size(), kUserSignals);
   EXPECT_EQ(handle.userMultimemSignals.size(), kUserSignals);
-  EXPECT_EQ(handle.internalLocalSignals.size(), kInternalSignals);
-  EXPECT_EQ(handle.internalMultimemSignals.size(), kInternalSignals);
+  EXPECT_EQ(handle.internalLocalSignals.size(), internalSignals);
+  EXPECT_EQ(handle.internalMultimemSignals.size(), internalSignals);
+  EXPECT_EQ(handle.pipelineDepth, 1);
+  EXPECT_EQ(handle.maxGroups, 1);
+  EXPECT_EQ(handle.signalsPerLane, internalSignals);
 
   EXPECT_EQ(transport.getAllocatedDataBufferSize(), kDataBytes);
   EXPECT_EQ(
       transport.getAllocatedSignalBufferSize(),
-      getSignalBufferSize(static_cast<int>(kUserSignals + kInternalSignals)));
+      getSignalBufferSize(static_cast<int>(kUserSignals + internalSignals)));
 
   // Idempotency: a second exchange() must be a no-op.
   auto* firstMultimemBase = handle.multimemData;
@@ -708,13 +725,11 @@ TEST_F(MultimemNvlTransportTestFixture, UserAndInternalSignalSpansAreDisjoint) {
   }
 
   constexpr uint32_t kUserSignals = 4;
-  constexpr uint32_t kInternalSignals = 2;
-
   MultimemNvlTransport transport(
       bootstrap,
       globalRank,
       identityRankMap(numRanks),
-      makeConfig(/*dataBufferSize=*/4096, kUserSignals, kInternalSignals));
+      makeConfig(/*dataBufferSize=*/4096, kUserSignals, 1, 1));
   transport.exchange();
   auto handle = transport.getDeviceTransport();
 
@@ -734,6 +749,70 @@ TEST_F(MultimemNvlTransportTestFixture, UserAndInternalSignalSpansAreDisjoint) {
   EXPECT_LE(
       handle.userMultimemSignals.data() + handle.userMultimemSignals.size(),
       handle.internalMultimemSignals.data());
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(MultimemNvlTransportTestFixture, StageLayoutUsesTransportGeometry) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_stage_layout_geometry");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kDataBytes = 12 * 1024;
+  constexpr uint32_t kPipelineDepth = 2;
+  constexpr uint32_t kMaxGroups = 4;
+  constexpr uint32_t kActiveGroups = 3;
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(kDataBytes, 0, kPipelineDepth, kMaxGroups));
+  transport.exchange();
+
+  test::StageLayoutResult* deviceResults = nullptr;
+  CUDACHECK_TEST(
+      cudaMalloc(&deviceResults, kMaxGroups * sizeof(test::StageLayoutResult)));
+  test::launchStageLayout(
+      transport.getDeviceTransport(), deviceResults, kActiveGroups);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<test::StageLayoutResult> results(kActiveGroups);
+  CUDACHECK_TEST(cudaMemcpy(
+      results.data(),
+      deviceResults,
+      results.size() * sizeof(test::StageLayoutResult),
+      cudaMemcpyDeviceToHost));
+  const uint64_t signalsPerLane =
+      multimem_staging_signals_per_lane(static_cast<uint32_t>(numRanks));
+  for (uint32_t group = 0; group < kActiveGroups; ++group) {
+    EXPECT_EQ(results[group].groupBeginBytes, group * 4096);
+    EXPECT_EQ(results[group].stagingBytes, 2048);
+    EXPECT_EQ(
+        results[group].signalBase, group * kPipelineDepth * signalsPerLane);
+    EXPECT_EQ(results[group].signalsPerLane, signalsPerLane);
+    EXPECT_EQ(results[group].pipelineDepth, kPipelineDepth);
+  }
+
+  test::launchStageLayout(
+      transport.getDeviceTransport(), deviceResults, kMaxGroups);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  results.resize(kMaxGroups);
+  CUDACHECK_TEST(cudaMemcpy(
+      results.data(),
+      deviceResults,
+      results.size() * sizeof(test::StageLayoutResult),
+      cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaFree(deviceResults));
+  for (uint32_t group = 0; group < kMaxGroups; ++group) {
+    EXPECT_EQ(results[group].groupBeginBytes, group * 3072);
+    EXPECT_EQ(results[group].stagingBytes, 1536);
+    EXPECT_EQ(
+        results[group].signalBase, group * kPipelineDepth * signalsPerLane);
+  }
 
   ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 }
@@ -875,12 +954,15 @@ std::unique_ptr<MultimemNvlTransport> makeExchangedTransport(
     int numRanks,
     int localRank,
     uint32_t userSignalCount,
-    uint32_t internalSignalCount) {
+    bool needsInternalSignals) {
   if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
     return nullptr;
   }
   auto config = makeConfig(
-      /*dataBufferSize=*/4096, userSignalCount, internalSignalCount);
+      /*dataBufferSize=*/4096,
+      userSignalCount,
+      needsInternalSignals ? 1 : 0,
+      needsInternalSignals ? 1 : 0);
   auto transport = std::make_unique<MultimemNvlTransport>(
       bootstrap, globalRank, identityRankMap(numRanks), config);
   transport->exchange();
@@ -903,7 +985,7 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceUserSignalSetBroadcasts) {
       numRanks,
       localRank,
       /*userSignalCount=*/1,
-      /*internalSignalCount=*/0);
+      /*needsInternalSignals=*/false);
   if (!transport) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
   }
@@ -939,7 +1021,7 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceUserSignalAddAccumulates) {
       numRanks,
       localRank,
       /*userSignalCount=*/1,
-      /*internalSignalCount=*/0);
+      /*needsInternalSignals=*/false);
   if (!transport) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
   }
@@ -973,7 +1055,7 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceInternalSignalSetBroadcasts) {
       numRanks,
       localRank,
       /*userSignalCount=*/1,
-      /*internalSignalCount=*/1);
+      /*needsInternalSignals=*/true);
   if (!transport) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
   }
@@ -1009,7 +1091,7 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceInternalSignalAddAccumulates) {
       numRanks,
       localRank,
       /*userSignalCount=*/1,
-      /*internalSignalCount=*/1);
+      /*needsInternalSignals=*/true);
   if (!transport) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
   }
@@ -1045,7 +1127,7 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceUserAndInternalSignalsIsolated) {
       numRanks,
       localRank,
       /*userSignalCount=*/1,
-      /*internalSignalCount=*/1);
+      /*needsInternalSignals=*/true);
   if (!transport) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
   }
@@ -1110,7 +1192,7 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceLoadReduceCoversPublicTypes) {
       numRanks,
       localRank,
       /*userSignalCount=*/1,
-      /*internalSignalCount=*/1);
+      /*needsInternalSignals=*/true);
   if (!transport) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
   }

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -76,11 +76,13 @@ bool allRanksMultimemEligible(
 MultimemNvlTransportConfig makeConfig(
     std::size_t dataBufferSize,
     uint32_t userSignalCount = 1,
-    uint32_t internalSignalCount = 0) {
+    std::size_t pipelineDepth = 0,
+    std::size_t maxChannels = 0) {
   MultimemNvlTransportConfig config{};
   config.dataBufferSize = dataBufferSize;
   config.userSignalCount = userSignalCount;
-  config.internalSignalCount = internalSignalCount;
+  config.pipelineDepth = pipelineDepth;
+  config.maxChannels = maxChannels;
   return config;
 }
 
@@ -214,6 +216,7 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
+      .multimem = makeConfig(4096, 1, 1, 1),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -246,6 +249,7 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
+      .multimem = makeConfig(4096, 1, 1, 1),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -271,6 +275,7 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
+      .multimem = makeConfig(4096, 1, 1, 1),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -297,6 +302,7 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
+      .multimem = makeConfig(4096, 1, 1, 1),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -329,6 +335,7 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
+      .multimem = makeConfig(4096, 1, 1, 1),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -381,7 +388,8 @@ TEST_F(
           MultimemNvlTransportConfig{
               .dataBufferSize = 0,
               .userSignalCount = 1,
-              .internalSignalCount = 1,
+              .pipelineDepth = 1,
+              .maxChannels = 1,
           },
   };
   MultiPeerNvlTransport transport(
@@ -426,7 +434,8 @@ TEST_F(
             MultimemNvlTransportConfig{
                 .dataBufferSize = 4096,
                 .userSignalCount = 1,
-                .internalSignalCount = 1,
+                .pipelineDepth = 1,
+                .maxChannels = 1,
             },
     };
     MultiPeerNvlTransport transport(
@@ -479,7 +488,8 @@ TEST_F(
           MultimemNvlTransportConfig{
               .dataBufferSize = 4096,
               .userSignalCount = 1,
-              .internalSignalCount = 1,
+              .pipelineDepth = 1,
+              .maxChannels = 1,
           },
   };
   MultiPeerNvlTransport transport(
@@ -531,7 +541,8 @@ TEST_F(
           MultimemNvlTransportConfig{
               .dataBufferSize = 4096,
               .userSignalCount = 1,
-              .internalSignalCount = 1,
+              .pipelineDepth = 1,
+              .maxChannels = 1,
           },
   };
   MultiPeerNvlTransport transport(
@@ -570,7 +581,8 @@ TEST_F(
               .dataBufferSize =
                   kBytesPerRank * static_cast<std::size_t>(numRanks),
               .userSignalCount = 1,
-              .internalSignalCount = 1,
+              .pipelineDepth = 1,
+              .maxChannels = 1,
           },
   };
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
@@ -599,7 +611,8 @@ TEST_F(
               .dataBufferSize =
                   globalRank == 0 ? std::size_t{0} : std::size_t{4096},
               .userSignalCount = 1,
-              .internalSignalCount = 1,
+              .pipelineDepth = 1,
+              .maxChannels = 1,
           },
   };
   MultiPeerNvlTransport transport(
@@ -656,13 +669,14 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
 
   constexpr std::size_t kDataBytes = 8192;
   constexpr uint32_t kUserSignals = 2;
-  constexpr uint32_t kInternalSignals = 3;
+  const uint32_t internalSignals =
+      multimem_staging_signals_per_lane(static_cast<uint32_t>(numRanks));
 
   MultimemNvlTransport transport(
       bootstrap,
       globalRank,
       identityRankMap(numRanks),
-      makeConfig(kDataBytes, kUserSignals, kInternalSignals));
+      makeConfig(kDataBytes, kUserSignals, 1, 1));
 
   transport.exchange();
   auto handle = transport.getDeviceTransport();
@@ -676,19 +690,57 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
   EXPECT_EQ(handle.dataBufferSize, kDataBytes);
   EXPECT_EQ(handle.userLocalSignals.size(), kUserSignals);
   EXPECT_EQ(handle.userMultimemSignals.size(), kUserSignals);
-  EXPECT_EQ(handle.internalLocalSignals.size(), kInternalSignals);
-  EXPECT_EQ(handle.internalMultimemSignals.size(), kInternalSignals);
+  EXPECT_EQ(handle.internalLocalSignals.size(), internalSignals);
+  EXPECT_EQ(handle.internalMultimemSignals.size(), internalSignals);
+  EXPECT_EQ(handle.pipelineDepth, 1);
+  EXPECT_EQ(handle.maxChannels, 1);
+  EXPECT_EQ(handle.signalsPerLane, internalSignals);
 
   EXPECT_EQ(transport.getAllocatedDataBufferSize(), kDataBytes);
   EXPECT_EQ(
       transport.getAllocatedSignalBufferSize(),
-      getSignalBufferSize(static_cast<int>(kUserSignals + kInternalSignals)));
+      getSignalBufferSize(static_cast<int>(kUserSignals + internalSignals)));
 
   // Idempotency: a second exchange() must be a no-op.
   auto* firstMultimemBase = handle.multimemData;
   transport.exchange();
   auto handle2 = transport.getDeviceTransport();
   EXPECT_EQ(handle2.multimemData, firstMultimemBase);
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    ExchangeRejectsMismatchedStagingGeometry) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_exchange_mismatched_geometry");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  const std::size_t pipelineDepth = globalRank == 0 ? 2 : 4;
+  const std::size_t maxChannels = globalRank == 0 ? 4 : 2;
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(8192, 1, pipelineDepth, maxChannels));
+  try {
+    transport.exchange();
+    FAIL() << "expected setup agreement to reject mismatched geometry";
+  } catch (const std::runtime_error& ex) {
+    const std::string message = ex.what();
+    EXPECT_NE(
+        message.find("ranks disagree on multicast setup"), std::string::npos)
+        << message;
+    EXPECT_NE(message.find("parameters=[8192, 1, 2, 4]"), std::string::npos)
+        << message;
+    EXPECT_NE(message.find("parameters=[8192, 1, 4, 2]"), std::string::npos)
+        << message;
+  }
 
   ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 }
@@ -708,13 +760,11 @@ TEST_F(MultimemNvlTransportTestFixture, UserAndInternalSignalSpansAreDisjoint) {
   }
 
   constexpr uint32_t kUserSignals = 4;
-  constexpr uint32_t kInternalSignals = 2;
-
   MultimemNvlTransport transport(
       bootstrap,
       globalRank,
       identityRankMap(numRanks),
-      makeConfig(/*dataBufferSize=*/4096, kUserSignals, kInternalSignals));
+      makeConfig(/*dataBufferSize=*/4096, kUserSignals, 1, 1));
   transport.exchange();
   auto handle = transport.getDeviceTransport();
 
@@ -734,6 +784,70 @@ TEST_F(MultimemNvlTransportTestFixture, UserAndInternalSignalSpansAreDisjoint) {
   EXPECT_LE(
       handle.userMultimemSignals.data() + handle.userMultimemSignals.size(),
       handle.internalMultimemSignals.data());
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(MultimemNvlTransportTestFixture, StageLayoutUsesTransportGeometry) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_stage_layout_geometry");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kDataBytes = 12 * 1024;
+  constexpr uint32_t kPipelineDepth = 2;
+  constexpr uint32_t kMaxChannels = 4;
+  constexpr uint32_t kActiveGroups = 3;
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(kDataBytes, 0, kPipelineDepth, kMaxChannels));
+  transport.exchange();
+
+  test::StageLayoutResult* deviceResults = nullptr;
+  CUDACHECK_TEST(cudaMalloc(
+      &deviceResults, kMaxChannels * sizeof(test::StageLayoutResult)));
+  test::launchStageLayout(
+      transport.getDeviceTransport(), deviceResults, kActiveGroups);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<test::StageLayoutResult> results(kActiveGroups);
+  CUDACHECK_TEST(cudaMemcpy(
+      results.data(),
+      deviceResults,
+      results.size() * sizeof(test::StageLayoutResult),
+      cudaMemcpyDeviceToHost));
+  const uint64_t signalsPerLane =
+      multimem_staging_signals_per_lane(static_cast<uint32_t>(numRanks));
+  for (uint32_t group = 0; group < kActiveGroups; ++group) {
+    EXPECT_EQ(results[group].groupBeginBytes, group * 4096);
+    EXPECT_EQ(results[group].stagingBytes, 2048);
+    EXPECT_EQ(
+        results[group].signalBase, group * kPipelineDepth * signalsPerLane);
+    EXPECT_EQ(results[group].signalsPerLane, signalsPerLane);
+    EXPECT_EQ(results[group].pipelineDepth, kPipelineDepth);
+  }
+
+  test::launchStageLayout(
+      transport.getDeviceTransport(), deviceResults, kMaxChannels);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  results.resize(kMaxChannels);
+  CUDACHECK_TEST(cudaMemcpy(
+      results.data(),
+      deviceResults,
+      results.size() * sizeof(test::StageLayoutResult),
+      cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaFree(deviceResults));
+  for (uint32_t group = 0; group < kMaxChannels; ++group) {
+    EXPECT_EQ(results[group].groupBeginBytes, group * 3072);
+    EXPECT_EQ(results[group].stagingBytes, 1536);
+    EXPECT_EQ(
+        results[group].signalBase, group * kPipelineDepth * signalsPerLane);
+  }
 
   ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 }
@@ -875,12 +989,15 @@ std::unique_ptr<MultimemNvlTransport> makeExchangedTransport(
     int numRanks,
     int localRank,
     uint32_t userSignalCount,
-    uint32_t internalSignalCount) {
+    bool needsInternalSignals) {
   if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
     return nullptr;
   }
   auto config = makeConfig(
-      /*dataBufferSize=*/4096, userSignalCount, internalSignalCount);
+      /*dataBufferSize=*/4096,
+      userSignalCount,
+      needsInternalSignals ? 1 : 0,
+      needsInternalSignals ? 1 : 0);
   auto transport = std::make_unique<MultimemNvlTransport>(
       bootstrap, globalRank, identityRankMap(numRanks), config);
   transport->exchange();
@@ -903,7 +1020,7 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceUserSignalSetBroadcasts) {
       numRanks,
       localRank,
       /*userSignalCount=*/1,
-      /*internalSignalCount=*/0);
+      /*needsInternalSignals=*/false);
   if (!transport) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
   }
@@ -939,7 +1056,7 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceUserSignalAddAccumulates) {
       numRanks,
       localRank,
       /*userSignalCount=*/1,
-      /*internalSignalCount=*/0);
+      /*needsInternalSignals=*/false);
   if (!transport) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
   }
@@ -973,7 +1090,7 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceInternalSignalSetBroadcasts) {
       numRanks,
       localRank,
       /*userSignalCount=*/1,
-      /*internalSignalCount=*/1);
+      /*needsInternalSignals=*/true);
   if (!transport) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
   }
@@ -1009,7 +1126,7 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceInternalSignalAddAccumulates) {
       numRanks,
       localRank,
       /*userSignalCount=*/1,
-      /*internalSignalCount=*/1);
+      /*needsInternalSignals=*/true);
   if (!transport) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
   }
@@ -1045,7 +1162,7 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceUserAndInternalSignalsIsolated) {
       numRanks,
       localRank,
       /*userSignalCount=*/1,
-      /*internalSignalCount=*/1);
+      /*needsInternalSignals=*/true);
   if (!transport) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
   }
@@ -1110,7 +1227,7 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceLoadReduceCoversPublicTypes) {
       numRanks,
       localRank,
       /*userSignalCount=*/1,
-      /*internalSignalCount=*/1);
+      /*needsInternalSignals=*/true);
   if (!transport) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
   }

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -7,6 +7,7 @@
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/tests/Checks.h"
 #include "comms/prims/transport/nvl/MultimemNvlReduce.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlStageLayout.cuh"
 
 namespace comms::prims::test {
 
@@ -115,6 +116,22 @@ __global__ void loadReduceKernel(
       reinterpret_cast<const T*>(transport.multimemData) + sourceOffsetElems;
   multimem::load_reduce_at<T, multimem::MultimemRedOp::Add, kAccF32>(
       group, output, source, elems);
+}
+
+__global__ void stageLayoutKernel(
+    MultimemNvlTransportDevice transport,
+    StageLayoutResult* results) {
+  auto group = make_block_group();
+  const auto layout = multimem::make_stage_layout<uint32_t>(transport, group);
+  if (group.is_leader()) {
+    results[group.group_id] = StageLayoutResult{
+        .groupBeginBytes = layout.groupBeginBytes,
+        .stagingBytes = layout.stagingBytes,
+        .signalBase = layout.signalBase,
+        .signalsPerLane = layout.signalsPerLane,
+        .pipelineDepth = layout.pipelineDepth,
+    };
+  }
 }
 
 template <typename T>
@@ -265,6 +282,15 @@ void launchLoadReduce(
       return launchLoadReduceTyped<__nv_bfloat16>(
           transport, accF32, output, elems, sourceOffsetElems, stream);
   }
+}
+
+void launchStageLayout(
+    MultimemNvlTransportDevice transport,
+    StageLayoutResult* results,
+    uint32_t numGroups,
+    cudaStream_t stream) {
+  stageLayoutKernel<<<numGroups, 32, 0, stream>>>(transport, results);
+  PIPES_KERNEL_LAUNCH_CHECK();
 }
 
 } // namespace comms::prims::test

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -14,6 +14,14 @@ namespace comms::prims::test {
 
 enum class MultimemReductionTestType { Float, Int32, Float16, Bfloat16 };
 
+struct StageLayoutResult {
+  std::size_t groupBeginBytes;
+  std::size_t stagingBytes;
+  uint64_t signalBase;
+  uint64_t signalsPerLane;
+  uint32_t pipelineDepth;
+};
+
 // Each launch is one warp -> one ThreadGroup. The leader performs the
 // multimem PTX store; the remaining lanes sync alongside it. Callers must
 // cudaStreamSynchronize (or cudaDeviceSynchronize) before observing effects
@@ -93,6 +101,12 @@ void launchLoadReduce(
     void* output,
     std::size_t elems,
     std::size_t sourceOffsetElems,
+    cudaStream_t stream = nullptr);
+
+void launchStageLayout(
+    MultimemNvlTransportDevice transport,
+    StageLayoutResult* results,
+    uint32_t numGroups,
     cudaStream_t stream = nullptr);
 
 } // namespace comms::prims::test

--- a/comms/prims/tests/MultimemNvlTransportValidationTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportValidationTest.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <climits>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <stdexcept>
@@ -27,7 +28,96 @@ void expectRuntimeErrorContains(Fn&& fn, const std::string& expected) {
   }
 }
 
+MultimemNvlTransportConfig makeConfig(
+    std::size_t dataBufferSize,
+    uint32_t userSignalCount = 1,
+    std::size_t pipelineDepth = 0,
+    std::size_t maxGroups = 0) {
+  MultimemNvlTransportConfig config{};
+  config.dataBufferSize = dataBufferSize;
+  config.userSignalCount = userSignalCount;
+  config.pipelineDepth = pipelineDepth;
+  config.maxGroups = maxGroups;
+  return config;
+}
+
 } // namespace
+
+TEST(MultimemNvlTransportConfigTest, DerivesUserOnlyConfiguration) {
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(makeConfig(256), 4), 0);
+}
+
+TEST(MultimemNvlTransportConfigTest, DerivesStagingOnlyConfiguration) {
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(256, 0, 2, 2), 4),
+      48);
+}
+
+TEST(MultimemNvlTransportConfigTest, DerivesMixedConfiguration) {
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(256, 7, 2, 2), 4),
+      48);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsPartialStagingGeometry) {
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(256, 1, 2, 0), 4),
+      std::nullopt);
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(256, 1, 0, 2), 4),
+      std::nullopt);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsInvalidRankCount) {
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(256, 1, 1, 1), 0),
+      std::nullopt);
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(std::numeric_limits<std::size_t>::max(), 1, 1, 1),
+          std::numeric_limits<int>::max()),
+      std::nullopt);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsInsufficientDataCapacity) {
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(255, 1, 2, 2), 4),
+      std::nullopt);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsInternalSignalOverflow) {
+  constexpr std::size_t kRanks = 4;
+  constexpr std::size_t kSignalsPerLane =
+      multimem_staging_signals_per_lane(static_cast<uint32_t>(kRanks));
+  const std::size_t pipelineDepth =
+      std::numeric_limits<int>::max() / kSignalsPerLane + 1;
+  const std::size_t requiredDataBytes = pipelineDepth * kRanks * 16;
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(requiredDataBytes, 1, pipelineDepth, 1), kRanks),
+      std::nullopt);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsTotalSignalOverflow) {
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(64, std::numeric_limits<int>::max(), 1, 1), 4),
+      std::nullopt);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsUserSignalCountOutsideSignedRange) {
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(64, std::numeric_limits<uint32_t>::max(), 0, 0), 4),
+      std::nullopt);
+}
 
 // validateRankMap runs before any GPU access in the constructor; these cases
 // must reject bad topologies on CPU-only hosts.
@@ -96,7 +186,7 @@ TEST(MultimemNvlTransportValidationTest, CompatCtorRejectsOutOfRangeNvlRank) {
       "nvlRank must be in [0, nvlRanks)");
 }
 
-// Config-validation guards. All three run in the primary ctor body BEFORE
+// These config-validation guards run in the primary ctor body before
 // cudaGetDevice, so they are exercisable on CPU-only hosts with a null
 // bootstrap: none of the code paths past these throws is reached.
 
@@ -115,11 +205,12 @@ TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroDataBufferSize) {
       "dataBufferSize must be non-zero");
 }
 
-TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroSignalCount) {
+TEST(
+    MultimemNvlTransportValidationTest,
+    PrimaryCtorRejectsDefaultZeroSignalCount) {
   MultimemNvlTransportConfig config{};
   config.dataBufferSize = 1024;
-  config.userSignalCount = 0;
-  config.internalSignalCount = 0;
+  EXPECT_EQ(config.userSignalCount, 0);
   expectRuntimeErrorContains(
       [&] {
         MultimemNvlTransport(
@@ -133,12 +224,12 @@ TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroSignalCount) {
 
 TEST(
     MultimemNvlTransportValidationTest,
-    PrimaryCtorRejectsSignalCountOverflow) {
-  // Sum of two uint32_t maxes overflows the int32 clamp used downstream.
+    PrimaryCtorRejectsTotalSignalCountOverflow) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize = 1024;
-  config.userSignalCount = std::numeric_limits<uint32_t>::max();
-  config.internalSignalCount = std::numeric_limits<uint32_t>::max();
+  config.dataBufferSize = 64;
+  config.userSignalCount = std::numeric_limits<int>::max();
+  config.pipelineDepth = 1;
+  config.maxGroups = 1;
   expectRuntimeErrorContains(
       [&] {
         MultimemNvlTransport(
@@ -147,7 +238,7 @@ TEST(
             /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
             config);
       },
-      "signalCount too large");
+      "invalid staging geometry or capacity");
 }
 
 TEST(

--- a/comms/prims/tests/MultimemNvlTransportValidationTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportValidationTest.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <climits>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <stdexcept>
@@ -27,7 +28,135 @@ void expectRuntimeErrorContains(Fn&& fn, const std::string& expected) {
   }
 }
 
+MultimemNvlTransportConfig makeConfig(
+    std::size_t dataBufferSize,
+    uint32_t userSignalCount = 1,
+    std::size_t pipelineDepth = 0,
+    std::size_t maxChannels = 0) {
+  MultimemNvlTransportConfig config{};
+  config.dataBufferSize = dataBufferSize;
+  config.userSignalCount = userSignalCount;
+  config.pipelineDepth = pipelineDepth;
+  config.maxChannels = maxChannels;
+  return config;
+}
+
 } // namespace
+
+TEST(MultimemNvlTransportConfigTest, DerivesUserOnlyConfiguration) {
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(makeConfig(256), 4), 0);
+}
+
+TEST(MultimemNvlTransportConfigTest, PreservesDefaultUserSignalCount) {
+  EXPECT_EQ(MultimemNvlTransportConfig{}.userSignalCount, 1);
+}
+
+TEST(MultimemNvlTransportDeviceTest, PreservesLegacyPositionalRankFields) {
+  const MultimemNvlTransportDevice device{
+      nullptr, nullptr, {}, {}, {}, {}, 0, 2, 4};
+  EXPECT_EQ(device.nvlRank, 2);
+  EXPECT_EQ(device.nvlRanks, 4);
+}
+
+TEST(MultimemNvlTransportConfigTest, DerivesStagingOnlyConfiguration) {
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(256, 0, 2, 2), 4),
+      48);
+}
+
+TEST(MultimemNvlTransportConfigTest, DerivesMixedConfiguration) {
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(256, 7, 2, 2), 4),
+      48);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsPartialStagingGeometry) {
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(256, 1, 2, 0), 4),
+      std::nullopt);
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(256, 1, 0, 2), 4),
+      std::nullopt);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsInvalidRankCount) {
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(256, 1, 1, 1), 0),
+      std::nullopt);
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(std::numeric_limits<std::size_t>::max(), 1, 1, 1),
+          std::numeric_limits<int>::max()),
+      std::nullopt);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsInsufficientDataCapacity) {
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(255, 1, 2, 2), 4),
+      std::nullopt);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsInternalSignalOverflow) {
+  constexpr std::size_t kRanks = 4;
+  constexpr std::size_t kSignalsPerLane =
+      multimem_staging_signals_per_lane(static_cast<uint32_t>(kRanks));
+  const std::size_t pipelineDepth =
+      std::numeric_limits<int>::max() / kSignalsPerLane + 1;
+  const std::size_t requiredDataBytes = pipelineDepth * kRanks * 16;
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(requiredDataBytes, 1, pipelineDepth, 1), kRanks),
+      std::nullopt);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsPipelineDepthOutsideDeviceRange) {
+  constexpr std::size_t kOutsideDeviceRange =
+      static_cast<std::size_t>(std::numeric_limits<uint32_t>::max()) + 1;
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(
+              std::numeric_limits<std::size_t>::max(),
+              1,
+              kOutsideDeviceRange,
+              1),
+          4),
+      std::nullopt);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsMaxChannelsOutsideDeviceRange) {
+  constexpr std::size_t kOutsideDeviceRange =
+      static_cast<std::size_t>(std::numeric_limits<uint32_t>::max()) + 1;
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(
+              std::numeric_limits<std::size_t>::max(),
+              1,
+              1,
+              kOutsideDeviceRange),
+          4),
+      std::nullopt);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsTotalSignalOverflow) {
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(64, std::numeric_limits<int>::max(), 1, 1), 4),
+      std::nullopt);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsUserSignalCountOutsideSignedRange) {
+  EXPECT_EQ(
+      detail::checked_multimem_internal_signal_count(
+          makeConfig(64, std::numeric_limits<uint32_t>::max(), 0, 0), 4),
+      std::nullopt);
+}
 
 // validateRankMap runs before any GPU access in the constructor; these cases
 // must reject bad topologies on CPU-only hosts.
@@ -96,7 +225,7 @@ TEST(MultimemNvlTransportValidationTest, CompatCtorRejectsOutOfRangeNvlRank) {
       "nvlRank must be in [0, nvlRanks)");
 }
 
-// Config-validation guards. All three run in the primary ctor body BEFORE
+// These config-validation guards run in the primary ctor body before
 // cudaGetDevice, so they are exercisable on CPU-only hosts with a null
 // bootstrap: none of the code paths past these throws is reached.
 
@@ -119,7 +248,6 @@ TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroSignalCount) {
   MultimemNvlTransportConfig config{};
   config.dataBufferSize = 1024;
   config.userSignalCount = 0;
-  config.internalSignalCount = 0;
   expectRuntimeErrorContains(
       [&] {
         MultimemNvlTransport(
@@ -133,12 +261,12 @@ TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroSignalCount) {
 
 TEST(
     MultimemNvlTransportValidationTest,
-    PrimaryCtorRejectsSignalCountOverflow) {
-  // Sum of two uint32_t maxes overflows the int32 clamp used downstream.
+    PrimaryCtorRejectsTotalSignalCountOverflow) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize = 1024;
-  config.userSignalCount = std::numeric_limits<uint32_t>::max();
-  config.internalSignalCount = std::numeric_limits<uint32_t>::max();
+  config.dataBufferSize = 64;
+  config.userSignalCount = std::numeric_limits<int>::max();
+  config.pipelineDepth = 1;
+  config.maxChannels = 1;
   expectRuntimeErrorContains(
       [&] {
         MultimemNvlTransport(
@@ -147,7 +275,7 @@ TEST(
             /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
             config);
       },
-      "signalCount too large");
+      "invalid staging geometry or capacity");
 }
 
 TEST(

--- a/comms/prims/transport/nvl/MultiPeerNvlTransport.h
+++ b/comms/prims/transport/nvl/MultiPeerNvlTransport.h
@@ -4,6 +4,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <optional>

--- a/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
@@ -63,11 +63,8 @@ struct StageLayout {
 template <typename T>
 __device__ __forceinline__ StageLayout make_stage_layout(
     const comms::prims::MultimemNvlTransportDevice& transport,
-    uint32_t pipelineDepth,
     comms::prims::ThreadGroup& group) {
-  if (pipelineDepth == 0) {
-    pipelineDepth = 1;
-  }
+  const uint32_t pipelineDepth = transport.pipelineDepth;
 
   // 16-byte (uint4) alignment for every staging-window slice, so the per-rank
   // lane offsets are 128-bit aligned and the v4 multimem.ld_reduce / store fast
@@ -88,6 +85,18 @@ __device__ __forceinline__ StageLayout make_stage_layout(
     printf(
         "NvlMultimem staging layout: invalid group_id=%u total_groups=%u\n",
         static_cast<unsigned>(group.group_id),
+        static_cast<unsigned>(group.total_groups));
+    __trap();
+  }
+  if (pipelineDepth == 0 || transport.maxGroups == 0 ||
+      transport.signalsPerLane == 0 ||
+      group.total_groups > transport.maxGroups) {
+    printf(
+        "NvlMultimem staging layout: invalid geometry depth=%u "
+        "maxGroups=%u signalsPerLane=%u total_groups=%u\n",
+        static_cast<unsigned>(pipelineDepth),
+        static_cast<unsigned>(transport.maxGroups),
+        static_cast<unsigned>(transport.signalsPerLane),
         static_cast<unsigned>(group.total_groups));
     __trap();
   }
@@ -139,14 +148,25 @@ __device__ __forceinline__ StageLayout make_stage_layout(
     __trap();
   }
 #endif
-  const uint64_t signalsPerLane = multimem_staging_signals_per_lane(
+  const uint64_t expectedSignalsPerLane = multimem_staging_signals_per_lane(
       static_cast<uint32_t>(transport.nvlRanks));
+  const uint64_t signalsPerLane = transport.signalsPerLane;
+#if defined(__CUDA_ARCH__)
+  if (signalsPerLane != expectedSignalsPerLane) {
+    printf(
+        "NvlMultimem staging layout: signalsPerLane=%llu expected=%llu\n",
+        static_cast<unsigned long long>(signalsPerLane),
+        static_cast<unsigned long long>(expectedSignalsPerLane));
+    __trap();
+  }
+#endif
   const uint64_t signalsPerGroup = detail::checked_signal_product(
       static_cast<uint64_t>(pipelineDepth), signalsPerLane);
   const uint64_t requiredSignals = detail::checked_signal_product(
       static_cast<uint64_t>(group.total_groups), signalsPerGroup);
 #if defined(__CUDA_ARCH__)
-  if (requiredSignals > transport.internalLocalSignals.size()) {
+  if (requiredSignals > transport.internalLocalSignals.size() ||
+      requiredSignals > transport.internalMultimemSignals.size()) {
     printf(
         "NvlMultimem requires %llu internal signals "
         "(available=%u, groups=%u, pipelineDepth=%u, nvlRanks=%d)\n",

--- a/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
@@ -63,11 +63,11 @@ struct StageLayout {
 template <typename T>
 __device__ __forceinline__ StageLayout make_stage_layout(
     const comms::prims::MultimemNvlTransportDevice& transport,
-    uint32_t pipelineDepth,
     comms::prims::ThreadGroup& group) {
-  if (pipelineDepth == 0) {
-    pipelineDepth = 1;
-  }
+  static_assert(sizeof(T) <= 16, "staging payloads must fit in 16 bytes");
+  static_assert(16 % sizeof(T) == 0, "staging payloads must divide 16 bytes");
+
+  const uint32_t pipelineDepth = transport.pipelineDepth;
 
   // 16-byte (uint4) alignment for every staging-window slice, so the per-rank
   // lane offsets are 128-bit aligned and the v4 multimem.ld_reduce / store fast
@@ -88,6 +88,18 @@ __device__ __forceinline__ StageLayout make_stage_layout(
     printf(
         "NvlMultimem staging layout: invalid group_id=%u total_groups=%u\n",
         static_cast<unsigned>(group.group_id),
+        static_cast<unsigned>(group.total_groups));
+    __trap();
+  }
+  if (pipelineDepth == 0 || transport.maxChannels == 0 ||
+      transport.signalsPerLane == 0 ||
+      group.total_groups > transport.maxChannels) {
+    printf(
+        "NvlMultimem staging layout: invalid geometry depth=%u "
+        "maxChannels=%u signalsPerLane=%u total_groups=%u\n",
+        static_cast<unsigned>(pipelineDepth),
+        static_cast<unsigned>(transport.maxChannels),
+        static_cast<unsigned>(transport.signalsPerLane),
         static_cast<unsigned>(group.total_groups));
     __trap();
   }
@@ -139,19 +151,32 @@ __device__ __forceinline__ StageLayout make_stage_layout(
     __trap();
   }
 #endif
-  const uint64_t signalsPerLane = multimem_staging_signals_per_lane(
+  const uint64_t expectedSignalsPerLane = multimem_staging_signals_per_lane(
       static_cast<uint32_t>(transport.nvlRanks));
+  const uint64_t signalsPerLane = transport.signalsPerLane;
+#if defined(__CUDA_ARCH__)
+  if (signalsPerLane != expectedSignalsPerLane) {
+    printf(
+        "NvlMultimem staging layout: signalsPerLane=%llu expected=%llu\n",
+        static_cast<unsigned long long>(signalsPerLane),
+        static_cast<unsigned long long>(expectedSignalsPerLane));
+    __trap();
+  }
+#endif
   const uint64_t signalsPerGroup = detail::checked_signal_product(
       static_cast<uint64_t>(pipelineDepth), signalsPerLane);
   const uint64_t requiredSignals = detail::checked_signal_product(
       static_cast<uint64_t>(group.total_groups), signalsPerGroup);
 #if defined(__CUDA_ARCH__)
-  if (requiredSignals > transport.internalLocalSignals.size()) {
+  if (requiredSignals > transport.internalLocalSignals.size() ||
+      requiredSignals > transport.internalMultimemSignals.size()) {
     printf(
         "NvlMultimem requires %llu internal signals "
-        "(available=%u, groups=%u, pipelineDepth=%u, nvlRanks=%d)\n",
+        "(localAvailable=%u, multimemAvailable=%u, groups=%u, "
+        "pipelineDepth=%u, nvlRanks=%d)\n",
         static_cast<unsigned long long>(requiredSignals),
         static_cast<unsigned>(transport.internalLocalSignals.size()),
+        static_cast<unsigned>(transport.internalMultimemSignals.size()),
         static_cast<unsigned>(group.total_groups),
         static_cast<unsigned>(pipelineDepth),
         transport.nvlRanks);

--- a/comms/prims/transport/nvl/MultimemNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.cc
@@ -87,9 +87,19 @@ MultimemNvlTransport::MultimemNvlTransport(
     throw std::runtime_error(
         "MultimemNvlTransport: dataBufferSize must be non-zero");
   }
+  const auto internalSignalCount =
+      detail::checked_multimem_internal_signal_count(config_, nvlRanks_);
+  if (!internalSignalCount.has_value()) {
+    throw std::runtime_error(
+        "MultimemNvlTransport: invalid staging geometry or capacity");
+  }
+  internalSignalCount_ = *internalSignalCount;
+  if (config_.pipelineDepth != 0) {
+    signalsPerLane_ =
+        multimem_staging_signals_per_lane(static_cast<uint32_t>(nvlRanks_));
+  }
   const uint64_t totalSignalCount =
-      static_cast<uint64_t>(config_.userSignalCount) +
-      static_cast<uint64_t>(config_.internalSignalCount);
+      static_cast<uint64_t>(config_.userSignalCount) + internalSignalCount_;
   if (totalSignalCount == 0) {
     throw std::runtime_error(
         "MultimemNvlTransport: at least one signal slot is required");
@@ -222,7 +232,7 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
   auto* multimemSignals =
       reinterpret_cast<SignalState*>(multimemBase + signalRegionOffset_);
   const auto userSignalCount = config_.userSignalCount;
-  const auto internalSignalCount = config_.internalSignalCount;
+  const auto internalSignalCount = internalSignalCount_;
 
   return MultimemNvlTransportDevice{
       .localData = localBase,
@@ -236,6 +246,9 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
       .internalMultimemSignals = DeviceSpan<SignalState>(
           multimemSignals + userSignalCount, internalSignalCount),
       .dataBufferSize = config_.dataBufferSize,
+      .pipelineDepth = static_cast<uint32_t>(config_.pipelineDepth),
+      .maxGroups = static_cast<uint32_t>(config_.maxGroups),
+      .signalsPerLane = signalsPerLane_,
       .nvlRank = nvlRank_,
       .nvlRanks = nvlRanks_,
   };
@@ -252,7 +265,7 @@ std::size_t MultimemNvlTransport::getAllocatedSignalBufferSize() const {
   // granularity, so combinedHandler_->getAllocatedSize() - signalRegionOffset_
   // would include trailing padding that is not addressable as SignalState.
   return getSignalBufferSize(
-      static_cast<int>(config_.userSignalCount + config_.internalSignalCount));
+      static_cast<int>(config_.userSignalCount + internalSignalCount_));
 }
 
 } // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.cc
@@ -16,6 +16,9 @@ namespace comms::prims {
 
 namespace {
 
+constexpr uint64_t kMultimemNvlTransportProtocol = 0x4D4D4E564CULL;
+constexpr uint64_t kMultimemNvlTransportProtocolVersion = 1;
+
 int getCurrentCudaDevice() {
   int cudaDevice = 0;
   const auto err = cudaGetDevice(&cudaDevice);
@@ -87,9 +90,19 @@ MultimemNvlTransport::MultimemNvlTransport(
     throw std::runtime_error(
         "MultimemNvlTransport: dataBufferSize must be non-zero");
   }
+  const auto internalSignalCount =
+      detail::checked_multimem_internal_signal_count(config_, nvlRanks_);
+  if (!internalSignalCount.has_value()) {
+    throw std::runtime_error(
+        "MultimemNvlTransport: invalid staging geometry or capacity");
+  }
+  internalSignalCount_ = *internalSignalCount;
+  if (config_.pipelineDepth != 0) {
+    signalsPerLane_ =
+        multimem_staging_signals_per_lane(static_cast<uint32_t>(nvlRanks_));
+  }
   const uint64_t totalSignalCount =
-      static_cast<uint64_t>(config_.userSignalCount) +
-      static_cast<uint64_t>(config_.internalSignalCount);
+      static_cast<uint64_t>(config_.userSignalCount) + internalSignalCount_;
   if (totalSignalCount == 0) {
     throw std::runtime_error(
         "MultimemNvlTransport: at least one signal slot is required");
@@ -198,8 +211,19 @@ void MultimemNvlTransport::exchange() {
         "a partial multicast setup)");
   }
   try {
+    const MulticastExchangeContract contract{
+        .protocol = kMultimemNvlTransportProtocol,
+        .version = kMultimemNvlTransportProtocolVersion,
+        .parameters =
+            {
+                config_.dataBufferSize,
+                config_.userSignalCount,
+                config_.pipelineDepth,
+                config_.maxChannels,
+            },
+    };
     combinedHandler_->exchangeMulticast(
-        commRank_, nvlRankToCommRank_, cudaDevice_);
+        commRank_, nvlRankToCommRank_, cudaDevice_, contract);
   } catch (...) {
     broken_ = true;
     throw;
@@ -222,7 +246,7 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
   auto* multimemSignals =
       reinterpret_cast<SignalState*>(multimemBase + signalRegionOffset_);
   const auto userSignalCount = config_.userSignalCount;
-  const auto internalSignalCount = config_.internalSignalCount;
+  const auto internalSignalCount = internalSignalCount_;
 
   return MultimemNvlTransportDevice{
       .localData = localBase,
@@ -238,6 +262,9 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
       .dataBufferSize = config_.dataBufferSize,
       .nvlRank = nvlRank_,
       .nvlRanks = nvlRanks_,
+      .pipelineDepth = static_cast<uint32_t>(config_.pipelineDepth),
+      .maxChannels = static_cast<uint32_t>(config_.maxChannels),
+      .signalsPerLane = signalsPerLane_,
   };
 }
 
@@ -252,7 +279,7 @@ std::size_t MultimemNvlTransport::getAllocatedSignalBufferSize() const {
   // granularity, so combinedHandler_->getAllocatedSize() - signalRegionOffset_
   // would include trailing padding that is not addressable as SignalState.
   return getSignalBufferSize(
-      static_cast<int>(config_.userSignalCount + config_.internalSignalCount));
+      static_cast<int>(config_.userSignalCount + internalSignalCount_));
 }
 
 } // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlTransport.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.h
@@ -4,7 +4,9 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "comms/common/bootstrap/IBootstrap.h"
@@ -19,12 +21,66 @@ struct MultimemNvlTransportConfig {
 
   // Signal slots exposed through signal(), read_signal(), and
   // wait_signal_until().
-  uint32_t userSignalCount{1};
+  uint32_t userSignalCount{0};
 
-  // Signal slots reserved for transport-internal protocols. These are not
-  // addressable through the public signal API.
-  uint32_t internalSignalCount{0};
+  // Immutable staging geometry. Both values must be zero when staging is not
+  // used, or both must be non-zero when staging is enabled. `maxGroups` is the
+  // maximum supported `ThreadGroup::total_groups`; each group, pipeline lane,
+  // and NVLink rank requires one 16-byte-aligned data unit. Construction
+  // derives and reserves the corresponding internal signal region after the
+  // user-visible signal slots.
+  std::size_t pipelineDepth{0};
+  std::size_t maxGroups{0};
 };
+
+namespace detail {
+
+inline std::optional<uint32_t> checked_multimem_internal_signal_count(
+    const MultimemNvlTransportConfig& config,
+    int nvlRanks) {
+  if (nvlRanks <= 0 ||
+      config.userSignalCount > std::numeric_limits<int>::max()) {
+    return std::nullopt;
+  }
+
+  const auto signalsPerLaneWide =
+      multimem_staging_signals_per_lane_wide(static_cast<uint64_t>(nvlRanks));
+  if (signalsPerLaneWide > std::numeric_limits<uint32_t>::max()) {
+    return std::nullopt;
+  }
+
+  const bool hasPipelineDepth = config.pipelineDepth != 0;
+  const bool hasMaxGroups = config.maxGroups != 0;
+  if (hasPipelineDepth != hasMaxGroups) {
+    return std::nullopt;
+  }
+  if (!hasPipelineDepth) {
+    return 0;
+  }
+
+  constexpr std::size_t kDataAlignment = 16;
+  const std::size_t alignedUnits = config.dataBufferSize / kDataAlignment;
+  const auto ranks = static_cast<std::size_t>(nvlRanks);
+  if (config.maxGroups > alignedUnits ||
+      config.pipelineDepth > alignedUnits / config.maxGroups ||
+      ranks > alignedUnits / config.maxGroups / config.pipelineDepth) {
+    return std::nullopt;
+  }
+
+  const auto maxInternalSignals = static_cast<std::size_t>(
+      std::numeric_limits<int>::max() - config.userSignalCount);
+  const auto signalsPerLane = static_cast<std::size_t>(signalsPerLaneWide);
+  if (config.maxGroups > maxInternalSignals / signalsPerLane) {
+    return std::nullopt;
+  }
+  const auto signalsPerRound = config.maxGroups * signalsPerLane;
+  if (config.pipelineDepth > maxInternalSignals / signalsPerRound) {
+    return std::nullopt;
+  }
+  return static_cast<uint32_t>(config.pipelineDepth * signalsPerRound);
+}
+
+} // namespace detail
 
 /**
  * Host-side owner for a copy-based NVL multimem transport.
@@ -109,6 +165,8 @@ class MultimemNvlTransport {
   // rank-map preconditions on CPU-only hosts).
   int cudaDevice_{-1};
   const MultimemNvlTransportConfig config_;
+  uint32_t internalSignalCount_{0};
+  uint32_t signalsPerLane_{0};
   bool exchanged_{false};
   // Set when exchange() throws; subsequent calls throw instead of silently
   // retrying. Multicast object create/import/bind failures can leave partial

--- a/comms/prims/transport/nvl/MultimemNvlTransport.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.h
@@ -4,7 +4,9 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "comms/common/bootstrap/IBootstrap.h"
@@ -21,10 +23,68 @@ struct MultimemNvlTransportConfig {
   // wait_signal_until().
   uint32_t userSignalCount{1};
 
-  // Signal slots reserved for transport-internal protocols. These are not
-  // addressable through the public signal API.
-  uint32_t internalSignalCount{0};
+  // Immutable staging geometry. Both values must be zero when staging is not
+  // used, or both must be non-zero when staging is enabled. `maxChannels` is
+  // the maximum supported `ThreadGroup::total_groups`; each group, pipeline
+  // lane, and NVLink rank requires one 16-byte-aligned data unit. Construction
+  // derives and reserves the corresponding internal signal region after the
+  // user-visible signal slots.
+  std::size_t pipelineDepth{0};
+  std::size_t maxChannels{0};
 };
+
+namespace detail {
+
+inline std::optional<uint32_t> checked_multimem_internal_signal_count(
+    const MultimemNvlTransportConfig& config,
+    int nvlRanks) {
+  if (nvlRanks <= 0 ||
+      config.userSignalCount > std::numeric_limits<int>::max()) {
+    return std::nullopt;
+  }
+
+  const auto signalsPerLaneWide =
+      multimem_staging_signals_per_lane_wide(static_cast<uint64_t>(nvlRanks));
+  if (signalsPerLaneWide > std::numeric_limits<uint32_t>::max()) {
+    return std::nullopt;
+  }
+
+  const bool hasPipelineDepth = config.pipelineDepth != 0;
+  const bool hasMaxChannels = config.maxChannels != 0;
+  if (hasPipelineDepth != hasMaxChannels) {
+    return std::nullopt;
+  }
+  if (!hasPipelineDepth) {
+    return 0;
+  }
+  if (config.pipelineDepth > std::numeric_limits<uint32_t>::max() ||
+      config.maxChannels > std::numeric_limits<uint32_t>::max()) {
+    return std::nullopt;
+  }
+
+  constexpr std::size_t kDataAlignment = 16;
+  const std::size_t alignedUnits = config.dataBufferSize / kDataAlignment;
+  const auto ranks = static_cast<std::size_t>(nvlRanks);
+  if (config.maxChannels > alignedUnits ||
+      config.pipelineDepth > alignedUnits / config.maxChannels ||
+      ranks > alignedUnits / config.maxChannels / config.pipelineDepth) {
+    return std::nullopt;
+  }
+
+  const auto maxInternalSignals = static_cast<std::size_t>(
+      std::numeric_limits<int>::max() - config.userSignalCount);
+  const auto signalsPerLane = static_cast<std::size_t>(signalsPerLaneWide);
+  if (config.maxChannels > maxInternalSignals / signalsPerLane) {
+    return std::nullopt;
+  }
+  const auto signalsPerRound = config.maxChannels * signalsPerLane;
+  if (config.pipelineDepth > maxInternalSignals / signalsPerRound) {
+    return std::nullopt;
+  }
+  return static_cast<uint32_t>(config.pipelineDepth * signalsPerRound);
+}
+
+} // namespace detail
 
 /**
  * Host-side owner for a copy-based NVL multimem transport.
@@ -109,6 +169,8 @@ class MultimemNvlTransport {
   // rank-map preconditions on CPU-only hosts).
   int cudaDevice_{-1};
   const MultimemNvlTransportConfig config_;
+  uint32_t internalSignalCount_{0};
+  uint32_t signalsPerLane_{0};
   bool exchanged_{false};
   // Set when exchange() throws; subsequent calls throw instead of silently
   // retrying. Multicast object create/import/bind failures can leave partial

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -16,15 +16,22 @@
 namespace comms::prims {
 
 // Per-lane internal-signal count for the staging pipeline: the single source of
-// truth shared by the host-side signal-region sizing (MCCL) and the
-// device-side `make_stage_layout` (MultimemNvlStageLayout.cuh) so the region is
-// sized identically on both sides. Layout per lane: `nvlRanks` per-peer ready[]
+// truth shared by the host-side signal-region sizing (MultimemNvlTransport)
+// and the device-side `make_stage_layout` (MultimemNvlStageLayout.cuh) so the
+// region is sized identically on both sides. Layout per lane: `nvlRanks`
+// per-peer ready[]
 // + `nvlRanks` per-peer ack[] + 4 staging arrival-barrier slots (ready/ack
 // counter+epoch, laid out past the SET-mode slots so ADD residue never
 // contaminates a later SET-mode CMP_GE wait) => 2 * nvlRanks + 4.
+__host__ __device__ constexpr uint64_t multimem_staging_signals_per_lane_wide(
+    uint64_t nvlRanks) {
+  return 2 * nvlRanks + 4;
+}
+
 __host__ __device__ constexpr uint32_t multimem_staging_signals_per_lane(
     uint32_t nvlRanks) {
-  return 2 * nvlRanks + 4;
+  return static_cast<uint32_t>(
+      multimem_staging_signals_per_lane_wide(nvlRanks));
 }
 
 namespace detail {
@@ -86,6 +93,9 @@ struct MultimemNvlTransportDevice {
   std::size_t dataBufferSize{0};
   int nvlRank{0};
   int nvlRanks{1};
+  uint32_t pipelineDepth{0};
+  uint32_t maxChannels{0};
+  uint32_t signalsPerLane{0};
 
   __device__ __forceinline__ char* local_data_ptr(std::size_t offset) const {
     return localData + offset;

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -16,15 +16,22 @@
 namespace comms::prims {
 
 // Per-lane internal-signal count for the staging pipeline: the single source of
-// truth shared by the host-side signal-region sizing (MCCL) and the
-// device-side `make_stage_layout` (MultimemNvlStageLayout.cuh) so the region is
-// sized identically on both sides. Layout per lane: `nvlRanks` per-peer ready[]
+// truth shared by the host-side signal-region sizing (MultimemNvlTransport)
+// and the device-side `make_stage_layout` (MultimemNvlStageLayout.cuh) so the
+// region is sized identically on both sides. Layout per lane: `nvlRanks`
+// per-peer ready[]
 // + `nvlRanks` per-peer ack[] + 4 staging arrival-barrier slots (ready/ack
 // counter+epoch, laid out past the SET-mode slots so ADD residue never
 // contaminates a later SET-mode CMP_GE wait) => 2 * nvlRanks + 4.
+__host__ __device__ constexpr uint64_t multimem_staging_signals_per_lane_wide(
+    uint64_t nvlRanks) {
+  return 2 * nvlRanks + 4;
+}
+
 __host__ __device__ constexpr uint32_t multimem_staging_signals_per_lane(
     uint32_t nvlRanks) {
-  return 2 * nvlRanks + 4;
+  return static_cast<uint32_t>(
+      multimem_staging_signals_per_lane_wide(nvlRanks));
 }
 
 namespace detail {
@@ -84,6 +91,9 @@ struct MultimemNvlTransportDevice {
   DeviceSpan<SignalState> internalLocalSignals{};
   DeviceSpan<SignalState> internalMultimemSignals{};
   std::size_t dataBufferSize{0};
+  uint32_t pipelineDepth{0};
+  uint32_t maxGroups{0};
+  uint32_t signalsPerLane{0};
   int nvlRank{0};
   int nvlRanks{1};
 


### PR DESCRIPTION
Summary:

Core implementation:

Replace caller-owned `MultimemNvlTransportConfig::internalSignalCount` with transport-owned `pipelineDepth` and `maxChannels` staging geometry.
Derive the internal signal allocation from that geometry with checked arithmetic before allocation.
Validate the signal total, data-window alignment and capacity, NVL rank count, and every host-to-device narrowing conversion.

Add `MulticastExchangeContract` to the public `GpuMemHandler::exchangeMulticast` and `MultimemHandler` APIs.
Expand the existing NVL-domain setup agreement from handle type alone to handle type, backing size, protocol identity, version, and protocol parameters.
Default arguments preserve source compatibility for callers that use raw multicast without a layered protocol.

Carry `pipelineDepth`, `maxChannels`, and `signalsPerLane` in `MultimemNvlTransportDevice`.
Make `make_stage_layout` consume that transport-owned geometry instead of a duplicate launch-time depth.
Reject invalid launch geometry, inconsistent signal stride, and short local or multicast internal-signal spans before device memory can be indexed incorrectly.
Keep ready and acknowledgement state isolated by pipeline lane because peers may publish later rounds out of order.
Preserve positional aggregate compatibility for existing `MultimemNvlTransportDevice` initializers by retaining the original field prefix and appending the new geometry fields.

Preserve the public `userSignalCount{1}` default.

Compatibility:

This diff removes the public aggregate member `MultimemNvlTransportConfig::internalSignalCount`.
Callers that explicitly size staging signals must instead provide `.pipelineDepth` and `.maxChannels` so the transport can derive the required storage.
Callers that do not use staging can omit both new fields and retain their zero defaults.

Background:

Allocation and launch previously carried independent staging inputs, so caller-provided internal signal capacity could disagree with the geometry used by device code.
The transport now owns one checked allocation and layout contract from host construction through kernel launch.
The communicator path propagates the existing channel and pipeline settings into that contract.
The stronger rank agreement piggybacks on the existing handle-type setup exchange without adding another setup collective.

#aup

Reviewed By: dboyda

Differential Revision: D114879901


