### PR TITLE
Support c10d window APIs in BackendWrapper

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -68,6 +68,123 @@ std::vector<uint64_t> toVecUint64(const std::vector<int64_t>& vec) {
   return vecUint64;
 }
 
+#ifdef C10D_BACKEND_HAS_WINDOW
+PutOptions toTorchCommOptions(
+    const c10d::PutOptions& options,
+    std::chrono::milliseconds defaultTimeout) {
+  PutOptions result;
+  result.hints = options.hints;
+  result.timeout =
+      options.timeout != c10d::kUnsetTimeout ? options.timeout : defaultTimeout;
+  return result;
+}
+
+SignalOptions toTorchCommOptions(
+    const c10d::SignalOptions& options,
+    std::chrono::milliseconds defaultTimeout) {
+  SignalOptions result;
+  result.hints = options.hints;
+  result.timeout =
+      options.timeout != c10d::kUnsetTimeout ? options.timeout : defaultTimeout;
+  return result;
+}
+
+WaitSignalOptions toTorchCommOptions(
+    const c10d::WaitSignalOptions& options,
+    std::chrono::milliseconds defaultTimeout) {
+  WaitSignalOptions result;
+  result.hints = options.hints;
+  result.timeout =
+      options.timeout != c10d::kUnsetTimeout ? options.timeout : defaultTimeout;
+  return result;
+}
+
+class C10dWindowWrapper final : public c10d::Window {
+ public:
+  C10dWindowWrapper(
+      std::shared_ptr<TorchCommWindow> window,
+      std::chrono::milliseconds defaultTimeout)
+      : window_(std::move(window)), defaultTimeout_(defaultTimeout) {
+    TORCH_CHECK(window_ != nullptr, "TorchComm returned a null window");
+  }
+
+  void tensor_register(const at::Tensor& tensor, bool owning) override {
+    window_->tensor_register(tensor, owning);
+  }
+
+  void tensor_deregister() override {
+    window_->tensor_deregister();
+  }
+
+  c10::intrusive_ptr<c10d::Work> put(
+      const at::Tensor& tensor,
+      int64_t dstRank,
+      int64_t targetOffsetNelems,
+      bool asyncOp,
+      const c10d::PutOptions& options) override {
+    TORCH_CHECK(
+        targetOffsetNelems >= 0,
+        "Window target offset must be non-negative, got ",
+        targetOffsetNelems);
+    return c10::make_intrusive<WorkWrapper>(window_->put(
+        tensor,
+        static_cast<int>(dstRank),
+        static_cast<size_t>(targetOffsetNelems),
+        asyncOp,
+        toTorchCommOptions(options, defaultTimeout_)));
+  }
+
+  at::Tensor map_remote_tensor(int64_t rank) override {
+    return window_->map_remote_tensor(static_cast<int>(rank));
+  }
+
+  c10::intrusive_ptr<c10d::Work> signal(
+      int64_t peerRank,
+      bool asyncOp,
+      const c10d::SignalOptions& options) override {
+    return c10::make_intrusive<WorkWrapper>(window_->signal(
+        static_cast<int>(peerRank),
+        asyncOp,
+        toTorchCommOptions(options, defaultTimeout_)));
+  }
+
+  c10::intrusive_ptr<c10d::Work> wait_signal(
+      int64_t peerRank,
+      bool asyncOp,
+      const c10d::WaitSignalOptions& options) override {
+    return c10::make_intrusive<WorkWrapper>(window_->wait_signal(
+        static_cast<int>(peerRank),
+        asyncOp,
+        toTorchCommOptions(options, defaultTimeout_)));
+  }
+
+  c10d::WindowAttr get_attr(int64_t peerRank) override {
+    const auto attr = window_->get_attr(static_cast<int>(peerRank));
+    TORCH_CHECK(attr != nullptr, "TorchComm returned a null window attribute");
+
+    c10d::WindowAttr result;
+    switch (attr->accessType) {
+      case TorchCommWinAccessType::WIN_ACCESS_TYPE_UNIFIED:
+        result.access_type = c10d::WindowAccessType::UNIFIED;
+        break;
+      case TorchCommWinAccessType::WIN_ACCESS_TYPE_SEPARATE:
+        result.access_type = c10d::WindowAccessType::SEPARATE;
+        break;
+      default:
+        TORCH_CHECK(
+            false,
+            "Unknown TorchCommWinAccessType: ",
+            static_cast<int>(attr->accessType));
+    }
+    return result;
+  }
+
+ private:
+  std::shared_ptr<TorchCommWindow> window_;
+  std::chrono::milliseconds defaultTimeout_;
+};
+#endif
+
 } // namespace
 
 WorkWrapper::WorkWrapper(
@@ -855,6 +972,18 @@ std::shared_ptr<TorchComm> BackendWrapper::getComm() const {
 std::shared_ptr<c10::Allocator> BackendWrapper::getMemAllocator() {
   return comm_->getMemAllocator();
 }
+
+#ifdef C10D_BACKEND_HAS_WINDOW
+bool BackendWrapper::supportsWindow() const {
+  return comm_->supportsWindow();
+}
+
+c10::intrusive_ptr<c10d::Window> BackendWrapper::new_window(
+    const std::optional<at::Tensor>& tensor) {
+  return c10::make_intrusive<C10dWindowWrapper>(
+      comm_->new_window(tensor), options_->timeout);
+}
+#endif
 
 const std::string BackendWrapper::getBackendName() const {
   return comm_->getBackend();

--- a/comms/torchcomms/BackendWrapper.hpp
+++ b/comms/torchcomms/BackendWrapper.hpp
@@ -5,6 +5,9 @@
 #include <torch/csrc/distributed/c10d/Backend.hpp> // @manual=//caffe2:torch-cpp-cpu
 #include <torch/csrc/distributed/c10d/Store.hpp> // @manual=//caffe2:torch-cpp-cpu
 #include <torch/csrc/distributed/c10d/Work.hpp> // @manual=//caffe2:torch-cpp-cpu
+#ifdef C10D_BACKEND_HAS_WINDOW
+#include <torch/csrc/distributed/c10d/Window.hpp> // @manual=//caffe2:torch-cpp-cpu
+#endif
 
 #include "comms/torchcomms/TorchCommBackend.hpp"
 #include "comms/torchcomms/TorchCommBatch.hpp"
@@ -148,6 +151,12 @@ class BackendWrapper : public c10d::Backend {
   // Returns the symmetric (VMM-backed) CUDA allocator associated with this
   // communicator's backend. See `TorchComm::getMemAllocator()`.
   std::shared_ptr<c10::Allocator> getMemAllocator() override;
+
+#ifdef C10D_BACKEND_HAS_WINDOW
+  bool supportsWindow() const override;
+  c10::intrusive_ptr<c10d::Window> new_window(
+      const std::optional<at::Tensor>& tensor = std::nullopt) override;
+#endif
 
   c10::intrusive_ptr<Options> getOptions() {
     return options_;

--- a/comms/torchcomms/TorchComm.cpp
+++ b/comms/torchcomms/TorchComm.cpp
@@ -456,6 +456,10 @@ c10::intrusive_ptr<TorchWork> TorchComm::gather_single(
   return work;
 }
 
+bool TorchComm::supportsWindow() const {
+  return impl_->supportsWindow();
+}
+
 std::shared_ptr<TorchCommWindow> TorchComm::new_window(
     const std::optional<at::Tensor>& tensor) {
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();

--- a/comms/torchcomms/TorchComm.hpp
+++ b/comms/torchcomms/TorchComm.hpp
@@ -185,6 +185,8 @@ class TorchComm : public std::enable_shared_from_this<TorchComm> {
     return impl_;
   }
 
+  bool supportsWindow() const;
+
   std::shared_ptr<TorchCommWindow> new_window(
       const std::optional<at::Tensor>& tensor = std::nullopt);
 

--- a/comms/torchcomms/TorchCommBackend.hpp
+++ b/comms/torchcomms/TorchCommBackend.hpp
@@ -16,7 +16,7 @@
 
 namespace torch::comms {
 
-inline constexpr const char* TORCHCOMM_BACKEND_ABI_VERSION = "1.2";
+inline constexpr const char* TORCHCOMM_BACKEND_ABI_VERSION = "1.3";
 
 /**
  * TorchCommBackend - Abstract base class for communication backends.
@@ -184,6 +184,10 @@ class TorchCommBackend {
   virtual const at::Device& getDevice() const = 0;
   // Window & One-sided Operations, not required for all backends, so we added
   // default implementation here
+  virtual bool supportsWindow() const {
+    return false;
+  }
+
   virtual std::shared_ptr<TorchCommWindow> new_window(
       [[maybe_unused]] const std::optional<at::Tensor>& tensor = std::nullopt) {
     throw std::logic_error(

--- a/comms/torchcomms/fake/TorchCommFake.cpp
+++ b/comms/torchcomms/fake/TorchCommFake.cpp
@@ -25,7 +25,9 @@ class FakeTorchCommWindow : public TorchCommWindow {
     (void)dstRank;
     (void)targetOffsetNelems;
     (void)asyncOp;
-    (void)options;
+    TORCH_CHECK(
+        options.timeout.count() >= 0,
+        "Window operation timeout must be non-negative");
     return c10::make_intrusive<TorchWorkCompleted>();
   }
   at::Tensor map_remote_tensor(int rank) override {
@@ -36,7 +38,9 @@ class FakeTorchCommWindow : public TorchCommWindow {
   signal(int peerRank, bool asyncOp, const SignalOptions& options) override {
     (void)peerRank;
     (void)asyncOp;
-    (void)options;
+    TORCH_CHECK(
+        options.timeout.count() >= 0,
+        "Window operation timeout must be non-negative");
     return c10::make_intrusive<TorchWorkCompleted>();
   }
   c10::intrusive_ptr<TorchWork> wait_signal(
@@ -45,13 +49,17 @@ class FakeTorchCommWindow : public TorchCommWindow {
       const WaitSignalOptions& options) override {
     (void)peerRank;
     (void)asyncOp;
-    (void)options;
+    TORCH_CHECK(
+        options.timeout.count() >= 0,
+        "Window operation timeout must be non-negative");
     return c10::make_intrusive<TorchWorkCompleted>();
   }
 
   std::shared_ptr<TorchCommWindowAttr> get_attr(int peerRank) override {
     (void)peerRank;
-    return nullptr;
+    auto attr = std::make_shared<TorchCommWindowAttr>();
+    attr->accessType = TorchCommWinAccessType::WIN_ACCESS_TYPE_UNIFIED;
+    return attr;
   }
 
   std::shared_ptr<TorchCommWindow> clone() override {

--- a/comms/torchcomms/fake/TorchCommFake.hpp
+++ b/comms/torchcomms/fake/TorchCommFake.hpp
@@ -131,6 +131,9 @@ class TorchCommFake : public TorchCommBackend {
       const GatherOptions& options = {}) override;
 
   // Window & One-sided Operations
+  bool supportsWindow() const override {
+    return true;
+  }
   std::shared_ptr<TorchCommWindow> new_window(
       const std::optional<at::Tensor>& tensor = std::nullopt) override;
 

--- a/comms/torchcomms/lazy/LazyBackend.hpp
+++ b/comms/torchcomms/lazy/LazyBackend.hpp
@@ -370,8 +370,13 @@ class LazyBackend : public TorchCommBackend {
   // Window & one-sided ops
   // ---------------------------------------------------------------
 
+  bool supportsWindow() const override {
+    return initialized_ && primary_->supportsWindow();
+  }
+
   std::shared_ptr<TorchCommWindow> new_window(
       const std::optional<at::Tensor>& tensor = std::nullopt) override {
+    checkInitialized();
     return primary_->new_window(tensor);
   }
 

--- a/comms/torchcomms/nccl/TorchCommNCCL.hpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.hpp
@@ -208,6 +208,13 @@ class TorchCommNCCL : public TorchCommBackend,
       const CommOptions& options = {}) override;
 
   // Window / one-sided RMA. Requires NCCL 2.29+.
+  bool supportsWindow() const override {
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+    return true;
+#else
+    return false;
+#endif
+  }
   std::shared_ptr<TorchCommWindow> new_window(
       const std::optional<at::Tensor>& tensor = std::nullopt) override;
 

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -242,6 +242,9 @@ class TorchCommNCCLX : public TorchCommBackend,
       const GatherOptions& options = {}) override;
 
   // Window & One-sided Operations
+  bool supportsWindow() const override {
+    return true;
+  }
   std::shared_ptr<TorchCommWindow> new_window(
       const std::optional<at::Tensor>& tensor = std::nullopt) override;
 

--- a/comms/torchcomms/tests/unit/cpp/LazyBackendTest.cpp
+++ b/comms/torchcomms/tests/unit/cpp/LazyBackendTest.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <comms/torchcomms/fake/TorchCommFake.hpp>
+#include <comms/torchcomms/lazy/LazyBackend.hpp>
+
+namespace torch::comms::test {
+
+namespace {
+
+class LazyTorchCommFake final : public TorchCommFake {
+ public:
+  std::shared_ptr<LazyTorchCommFake> createPairComm(
+      int /* peerRank */,
+      const std::string& /* name */) {
+    return std::make_shared<LazyTorchCommFake>();
+  }
+
+  void setBootstrapStore(c10::intrusive_ptr<c10d::Store> /* store */) {}
+};
+
+} // namespace
+
+TEST(LazyBackendTest, WindowOperationsFollowBackendLifecycle) {
+  LazyBackend<LazyTorchCommFake> backend;
+
+  EXPECT_FALSE(backend.supportsWindow());
+  EXPECT_THROW(backend.new_window(), std::runtime_error);
+
+  backend.init(at::kCPU, "lazy-window-test");
+  EXPECT_TRUE(backend.supportsWindow());
+  EXPECT_NE(backend.new_window(), nullptr);
+
+  backend.finalize();
+  EXPECT_FALSE(backend.supportsWindow());
+  EXPECT_THROW(backend.new_window(), std::runtime_error);
+}
+
+} // namespace torch::comms::test

--- a/comms/torchcomms/tests/unit/cpp/TorchCommOptionsTest.cpp
+++ b/comms/torchcomms/tests/unit/cpp/TorchCommOptionsTest.cpp
@@ -144,4 +144,37 @@ TEST_F(BackendWrapperTagTest, RecvThreadsTagToBackend) {
   EXPECT_EQ(fake->getLastRecvSrcForTest(), 2);
 }
 
+#ifdef C10D_BACKEND_HAS_WINDOW
+TEST_F(BackendWrapperTagTest, WindowOperationsDelegateToTorchComm) {
+  EXPECT_TRUE(wrapper_->supportsWindow());
+
+  auto tensor = at::ones({4}, at::kFloat);
+  auto window = wrapper_->new_window(tensor);
+  ASSERT_NE(window, nullptr);
+
+  auto putWork = window->put(
+      tensor,
+      /*dstRank=*/0,
+      /*targetOffsetNelems=*/0,
+      /*asyncOp=*/false);
+  ASSERT_NE(putWork, nullptr);
+  EXPECT_TRUE(putWork->wait());
+
+  auto signalWork = window->signal(/*peerRank=*/0, /*asyncOp=*/false);
+  ASSERT_NE(signalWork, nullptr);
+  EXPECT_TRUE(signalWork->wait());
+
+  auto waitWork = window->wait_signal(/*peerRank=*/0, /*asyncOp=*/false);
+  ASSERT_NE(waitWork, nullptr);
+  EXPECT_TRUE(waitWork->wait());
+
+  EXPECT_FALSE(window->map_remote_tensor(/*rank=*/0).defined());
+  EXPECT_EQ(
+      window->get_attr(/*peerRank=*/0).access_type,
+      c10d::WindowAccessType::UNIFIED);
+
+  EXPECT_NO_THROW(window->tensor_deregister());
+}
+#endif
+
 } // namespace torch::comms::test

--- a/comms/torchcomms/tests/unit/py/test_backend_wrapper.py
+++ b/comms/torchcomms/tests/unit/py/test_backend_wrapper.py
@@ -4,8 +4,7 @@
 
 """
 Tests that BackendWrapper (the c10d::Backend shim around TorchComm) routes
-collectives through TorchComm so that pre/post hooks registered on the
-underlying TorchComm fire.
+c10d operations through the underlying TorchComm.
 """
 
 import unittest
@@ -29,12 +28,27 @@ def _make_wrapped_pg(name: str) -> tuple[torchcomms.TorchComm, dist.ProcessGroup
         # pyre-fixme[6]: _BackendWrapper implements dist.Backend but stubs aren't aware
         wrapper,
     )
+    pg._set_default_backend(dist.ProcessGroup.BackendType.CUSTOM)
     # pyre-fixme[6]: _set_group_name expects GroupName, which is an alias for str
     pg._set_group_name(name)
     return comm, pg
 
 
-class TestBackendWrapperHooks(unittest.TestCase):
+class TestBackendWrapper(unittest.TestCase):
+    @unittest.skipUnless(
+        hasattr(dist.ProcessGroup, "new_window"),
+        "PyTorch does not expose the c10d window API",
+    )
+    def test_window_dispatches_through_backend_wrapper(self) -> None:
+        comm, pg = _make_wrapped_pg("test_window_dispatch")
+
+        self.assertTrue(pg.supports_window)
+        window = pg.new_window(torch.ones(4))
+        self.assertIsNotNone(window)
+        window.tensor_deregister()
+
+        comm.finalize()
+
     def test_hooks_fire_when_invoked_through_backend_wrapper(self) -> None:
         """Pre/post hooks on TorchComm fire when collectives go through the wrapper."""
         comm, pg = _make_wrapped_pg("test_hooks_fire")


### PR DESCRIPTION
Summary:
PyTorch 2.14 adds `supportsWindow` and `new_window` to the c10d backend interface. TorchComms' `BackendWrapper` inherited c10d's default false and throwing implementations even though NCCLX already implements window operations, causing ProcessGroup window creation to fail.

Add an ABI-versioned window capability to TorchComms and propagate it through concrete and lazy backends. Adapt `c10d::Window` to `TorchCommWindow`, including operation options, default timeouts, work handles, remote mappings, and attributes. Guard older c10d headers and advertise NCCL window support only with NCCL 2.29 or newer.

Add C++ adapter coverage and ProcessGroup-level Python coverage for capability detection and window creation.

Reviewed By: kapilsh

Differential Revision: D115079413


