### PR TITLE
Per-collective host-drive timing stats in the GPE thread

### DIFF
--- a/comms/common/CollectiveStats.h
+++ b/comms/common/CollectiveStats.h
@@ -1,0 +1,131 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include <fmt/core.h>
+#include <folly/Synchronized.h>
+#include <folly/Utility.h>
+#include <folly/container/F14Map.h>
+#include <folly/hash/Hash.h>
+
+namespace comms {
+
+// Host-drive timing for one bucket of collectives, in microseconds.
+struct CollectiveStat {
+  uint64_t count{0};
+  uint64_t total_us{0};
+  uint64_t min_us{0};
+  uint64_t max_us{0};
+
+  void add(uint64_t durationUs) {
+    if (count == 0) {
+      min_us = max_us = durationUs;
+    } else {
+      min_us = std::min(min_us, durationUs);
+      max_us = std::max(max_us, durationUs);
+    }
+    total_us += durationUs;
+    ++count;
+  }
+
+  void merge(const CollectiveStat& other) {
+    if (other.count == 0) {
+      return;
+    }
+    if (count == 0) {
+      *this = other;
+      return;
+    }
+    min_us = std::min(min_us, other.min_us);
+    max_us = std::max(max_us, other.max_us);
+    total_us += other.total_us;
+    count += other.count;
+  }
+
+  bool operator==(const CollectiveStat&) const = default;
+};
+
+// std::unordered_map, not F14: this crosses the mccl public interface and the
+// pybind boundary, which has no F14 type caster.
+using CollectiveStatsMap = std::unordered_map<std::string, CollectiveStat>;
+
+// Reserved: getAndClear() publishes roll-ups under "<collective>.all" and a
+// bare "all", so record() keys must not collide with either.
+inline constexpr std::string_view kCollectiveStatsAllKey = "all";
+
+// Shared by the comms backends (ctran, prims, mccl). Writers are the
+// collective-issuing threads; the reader is a single consumer draining once
+// per training step.
+class CollectiveStats {
+ public:
+  // `collective` is the bare op name ("allreduce"); `key` is the fully
+  // qualified bucket ("allreduce.ctring.1048576"). Roll-ups are derived in
+  // getAndClear() to keep this to one lookup with no key allocation.
+  void record(
+      std::string_view collective,
+      std::string_view key,
+      uint64_t durationUs) {
+    stats_.withWLock([&](auto& m) {
+      auto it = m.find(key);
+      if (it == m.end()) {
+        it = m.emplace(std::string(key), Entry{std::string(collective), {}})
+                 .first;
+      }
+      it->second.stat.add(durationUs);
+    });
+  }
+
+  CollectiveStatsMap getAndClear() {
+    EntryMap drained;
+    stats_.withWLock([&](auto& m) { drained.swap(m); });
+
+    CollectiveStatsMap out;
+    out.reserve(2 * drained.size() + 1);
+
+    CollectiveStat overall;
+    for (const auto& [key, entry] : drained) {
+      overall.merge(entry.stat);
+      if (!entry.collective.empty()) {
+        out[fmt::format("{}.{}", entry.collective, kCollectiveStatsAllKey)]
+            .merge(entry.stat);
+      }
+      out[key].merge(entry.stat);
+    }
+    if (overall.count > 0) {
+      out[std::string(kCollectiveStatsAllKey)].merge(overall);
+    }
+    return out;
+  }
+
+ private:
+  struct Entry {
+    std::string collective;
+    CollectiveStat stat;
+  };
+
+  // Transparent hash so record() can look up by string_view without allocating.
+  using EntryMap = folly::F14FastMap<
+      std::string,
+      Entry,
+      folly::transparent<folly::hasher<std::string_view>>,
+      folly::transparent<std::equal_to<std::string_view>>>;
+
+  folly::Synchronized<EntryMap> stats_;
+};
+
+inline std::ostream& operator<<(std::ostream& os, const CollectiveStat& s) {
+  return os << fmt::format(
+             "count={} total_us={} min_us={} max_us={}",
+             s.count,
+             s.total_us,
+             s.min_us,
+             s.max_us);
+}
+
+} // namespace comms

--- a/comms/common/tests/CollectiveStatsUT.cc
+++ b/comms/common/tests/CollectiveStatsUT.cc
@@ -1,0 +1,94 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/common/CollectiveStats.h"
+
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace comms {
+namespace {
+
+TEST(CollectiveStatsTest, RecordAccumulatesTotalMinMaxCount) {
+  CollectiveStats stats;
+  stats.record("allreduce", "allreduce.ctring.1024", 10);
+  stats.record("allreduce", "allreduce.ctring.1024", 30);
+  stats.record("allreduce", "allreduce.ctring.1024", 20);
+
+  const auto out = stats.getAndClear();
+  const CollectiveStat expected{
+      .count = 3, .total_us = 60, .min_us = 10, .max_us = 30};
+  EXPECT_EQ(out.at("allreduce.ctring.1024"), expected);
+}
+
+TEST(CollectiveStatsTest, SeparateKeysTrackedIndependently) {
+  CollectiveStats stats;
+  stats.record("allreduce", "allreduce.ctring.1024", 5);
+  stats.record("reducescatter", "reducescatter.ctring.2048", 7);
+
+  const auto out = stats.getAndClear();
+  EXPECT_EQ(
+      out.at("allreduce.ctring.1024"),
+      (CollectiveStat{.count = 1, .total_us = 5, .min_us = 5, .max_us = 5}));
+  EXPECT_EQ(
+      out.at("reducescatter.ctring.2048"),
+      (CollectiveStat{.count = 1, .total_us = 7, .min_us = 7, .max_us = 7}));
+}
+
+// The same collective recorded under two algorithms rolls up into
+// "<collective>.all"; everything rolls up into "all".
+TEST(CollectiveStatsTest, GetAndClearDerivesCollectiveAndOverallAggregates) {
+  CollectiveStats stats;
+  stats.record("allreduce", "allreduce.ctring.1024", 10);
+  stats.record("allreduce", "allreduce.ctdirect.4096", 30);
+  stats.record("reducescatter", "reducescatter.ctring.2048", 4);
+
+  const auto out = stats.getAndClear();
+  EXPECT_EQ(
+      out.at("allreduce.all"),
+      (CollectiveStat{.count = 2, .total_us = 40, .min_us = 10, .max_us = 30}));
+  EXPECT_EQ(
+      out.at("reducescatter.all"),
+      (CollectiveStat{.count = 1, .total_us = 4, .min_us = 4, .max_us = 4}));
+  EXPECT_EQ(
+      out.at("all"),
+      (CollectiveStat{.count = 3, .total_us = 44, .min_us = 4, .max_us = 30}));
+}
+
+TEST(CollectiveStatsTest, GetAndClearResetsState) {
+  CollectiveStats stats;
+  stats.record("allreduce", "allreduce.ctring.1024", 10);
+  EXPECT_FALSE(stats.getAndClear().empty());
+  EXPECT_TRUE(stats.getAndClear().empty());
+}
+
+TEST(CollectiveStatsTest, ConcurrentRecordIsThreadSafe) {
+  CollectiveStats stats;
+  constexpr uint64_t kThreads = 8;
+  constexpr uint64_t kPerThread = 1000;
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (uint64_t t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&] {
+      for (uint64_t i = 0; i < kPerThread; ++i) {
+        stats.record("allreduce", "allreduce.ctring.1024", 1);
+      }
+    });
+  }
+  for (auto& th : threads) {
+    th.join();
+  }
+
+  const auto out = stats.getAndClear();
+  const CollectiveStat expected{
+      .count = kThreads * kPerThread,
+      .total_us = kThreads * kPerThread,
+      .min_us = 1,
+      .max_us = 1};
+  EXPECT_EQ(out.at("allreduce.ctring.1024"), expected);
+  EXPECT_EQ(out.at("all"), expected);
+}
+
+} // namespace
+} // namespace comms

--- a/comms/ctran/algos/common/AlgoShortName.cc
+++ b/comms/ctran/algos/common/AlgoShortName.cc
@@ -1,0 +1,103 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/ctran/algos/common/AlgoShortName.h"
+
+#include <string>
+
+#include <folly/Utility.h>
+#include <folly/container/F14Map.h>
+#include <folly/hash/Hash.h>
+
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
+#include "comms/ctran/algos/AllToAll/AllToAllvImpl.h"
+#include "comms/ctran/algos/Broadcast/BroadcastImpl.h"
+#include "comms/ctran/algos/ReduceScatter/ReduceScatterImpl.h"
+
+namespace ctran {
+namespace {
+
+using ShortNameMap = folly::F14FastMap<
+    std::string,
+    std::string,
+    folly::transparent<folly::hasher<std::string_view>>,
+    folly::transparent<std::equal_to<std::string_view>>>;
+
+// Built from the *AlgoName() functions rather than literals so display-name
+// edits stay in one place. Names shared across collectives (CtranAuto,
+// Baseline) map to the same token, so first-wins insertion is safe.
+//
+// CTRAN algorithms use their NCCL_*_ALGO cvar token; the MCCL-hosted ones
+// (ctree/cthierarchical_ring/ctmdirect) use their MCCL names instead, so
+// "ring" always means MCCL Ring and never CTRAN's ctring. Those three run
+// natively via Prims and do not reach the GPE today, so they are reserved
+// rather than currently emitted.
+ShortNameMap buildShortNames() {
+  ShortNameMap m;
+  const auto add = [&m](const std::string& display, const char* token) {
+    m.emplace(display, token);
+  };
+
+  add(allReduceAlgoName(NCCL_ALLREDUCE_ALGO::orig), "orig");
+  add(allReduceAlgoName(NCCL_ALLREDUCE_ALGO::ctran), "ctran");
+  add(allReduceAlgoName(NCCL_ALLREDUCE_ALGO::ctdirect), "ctdirect");
+  add(allReduceAlgoName(NCCL_ALLREDUCE_ALGO::ctring), "ctring");
+  add(allReduceAlgoName(NCCL_ALLREDUCE_ALGO::ctree), "tree");
+  add(allReduceAlgoName(NCCL_ALLREDUCE_ALGO::cthierarchical_ring), "ring");
+  add(allReduceAlgoName(NCCL_ALLREDUCE_ALGO::ctmdirect), "direct");
+
+  add(allGatherAlgoName(NCCL_ALLGATHER_ALGO::orig), "orig");
+  add(allGatherAlgoName(NCCL_ALLGATHER_ALGO::ctran), "ctran");
+  add(allGatherAlgoName(NCCL_ALLGATHER_ALGO::ctdirect), "ctdirect");
+  add(allGatherAlgoName(NCCL_ALLGATHER_ALGO::ctring), "ctring");
+  add(allGatherAlgoName(NCCL_ALLGATHER_ALGO::ctsrd), "ctsrd");
+  add(allGatherAlgoName(NCCL_ALLGATHER_ALGO::ctbrucks), "ctbrucks");
+  add(allGatherAlgoName(NCCL_ALLGATHER_ALGO::cthierarchical_ring), "ring");
+  add(allGatherAlgoName(NCCL_ALLGATHER_ALGO::ctgraph), "ctgraph");
+  add(allGatherAlgoName(NCCL_ALLGATHER_ALGO::ctgraph_pipeline),
+      "ctgraph_pipeline");
+  add(allGatherAlgoName(NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline),
+      "ctgraph_rdpipeline");
+  add(allGatherAlgoName(NCCL_ALLGATHER_ALGO::ctgraph_ring), "ctgraph_ring");
+  add(allGatherAlgoName(NCCL_ALLGATHER_ALGO::ctgraph_rd), "ctgraph_rd");
+  add(allGatherAlgoName(NCCL_ALLGATHER_ALGO::ctwin), "ctwin");
+  add(allGatherAlgoName(NCCL_ALLGATHER_ALGO::ctwin_ring), "ctwin_ring");
+  add(allGatherAlgoName(NCCL_ALLGATHER_ALGO::ctwin_srd), "ctwin_srd");
+  add(allGatherAlgoName(NCCL_ALLGATHER_ALGO::ctwin_pipeline), "ctwin_pipeline");
+  add(allGatherAlgoName(NCCL_ALLGATHER_ALGO::ctwin_rdpipeline),
+      "ctwin_rdpipeline");
+
+  add(reduceScatterAlgoName(NCCL_REDUCESCATTER_ALGO::orig), "orig");
+  add(reduceScatterAlgoName(NCCL_REDUCESCATTER_ALGO::ctran), "ctran");
+  add(reduceScatterAlgoName(NCCL_REDUCESCATTER_ALGO::ctdirect), "ctdirect");
+  add(reduceScatterAlgoName(NCCL_REDUCESCATTER_ALGO::ctring), "ctring");
+  add(reduceScatterAlgoName(NCCL_REDUCESCATTER_ALGO::ctrhd), "ctrhd");
+  add(reduceScatterAlgoName(NCCL_REDUCESCATTER_ALGO::ctdirect_ib),
+      "ctdirect_ib");
+
+  add(broadcastAlgoName(NCCL_BROADCAST_ALGO::ctran), "ctran");
+  add(broadcastAlgoName(NCCL_BROADCAST_ALGO::ctdirect), "ctdirect");
+  add(broadcastAlgoName(NCCL_BROADCAST_ALGO::ctbtree), "ctbtree");
+
+  add(allToAllAlgoName(NCCL_ALLTOALL_ALGO::orig), "orig");
+  add(allToAllAlgoName(NCCL_ALLTOALL_ALGO::ctran), "ctran");
+  add(allToAllAlgoName(NCCL_ALLTOALL_ALGO::ctgraph), "ctgraph");
+  add(allToAllAlgoName(NCCL_ALLTOALL_ALGO::ctwin), "ctwin");
+
+  add(allToAllvAlgoName(NCCL_ALLTOALLV_ALGO::orig), "orig");
+  add(allToAllvAlgoName(NCCL_ALLTOALLV_ALGO::ctran), "ctran");
+  add(allToAllvAlgoName(NCCL_ALLTOALLV_ALGO::compCtran), "compCtran");
+  add(allToAllvAlgoName(NCCL_ALLTOALLV_ALGO::bsCompCtran), "bsCompCtran");
+
+  return m;
+}
+
+} // namespace
+
+std::string_view algoShortName(std::string_view displayName) {
+  static const ShortNameMap kShortNames = buildShortNames();
+  const auto it = kShortNames.find(displayName);
+  return it == kShortNames.end() ? displayName : it->second;
+}
+
+} // namespace ctran

--- a/comms/ctran/algos/common/AlgoShortName.h
+++ b/comms/ctran/algos/common/AlgoShortName.h
@@ -1,0 +1,13 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+#pragma once
+
+#include <string_view>
+
+namespace ctran {
+
+// Maps an algorithm display name (KernelConfig::algoName) to its NCCL_*_ALGO
+// cvar token, e.g. "CtranAllReduceRing" -> "ctring". Unmapped names are
+// returned unchanged.
+std::string_view algoShortName(std::string_view displayName);
+
+} // namespace ctran

--- a/comms/ctran/gpe/CtranGpe.cc
+++ b/comms/ctran/gpe/CtranGpe.cc
@@ -319,6 +319,10 @@ CtranGpe::~CtranGpe() {
   this->pimpl->terminate();
 }
 
+comms::CollectiveStatsMap CtranGpe::getAndClearCollectiveStats() {
+  return this->pimpl->collectiveStats_.getAndClear();
+}
+
 namespace {
 inline size_t getMsgSizeFromOpGroup(
     const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -6,10 +6,13 @@
 #include <chrono>
 #include <memory>
 #include <optional>
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include <fmt/format.h>
 
+#include "comms/common/CollectiveStats.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGather/Types.h"
 #include "comms/ctran/algos/AllReduce/Types.h"
@@ -18,6 +21,7 @@
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/ctran/algos/ReduceScatter/Types.h"
 #include "comms/ctran/algos/SendRecv/Types.h"
+#include "comms/ctran/algos/common/AlgoShortName.h"
 #include "comms/ctran/algos/common/GpeKernelSync.h"
 #include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/gpe/CtranGpeDev.h"
@@ -357,6 +361,101 @@ struct fmt::formatter<KernelConfig::KernelType> : fmt::formatter<int> {
   }
 };
 
+inline const char* ctranCollectiveOpName(OpElem::opType t) {
+  switch (t) {
+    case OpElem::ALLGATHER:
+      return "allgather";
+    case OpElem::ALLGATHERP_INIT:
+      return "allgatherp_init";
+    case OpElem::ALLGATHERP:
+      return "allgatherp";
+    case OpElem::ALLREDUCE:
+      return "allreduce";
+    case OpElem::SEND:
+      return "send";
+    case OpElem::RECV:
+      return "recv";
+    case OpElem::ALLTOALL:
+      return "alltoall";
+    case OpElem::ALLTOALLP:
+      return "alltoallp";
+    case OpElem::ALLTOALLV:
+      return "alltoallv";
+    case OpElem::DEVICE_ALLTOALLV:
+      return "device_alltoallv";
+    case OpElem::ALLTOALLV_DEDUP:
+      return "alltoallv_dedup";
+    case OpElem::BROADCAST:
+      return "broadcast";
+    case OpElem::REDUCESCATTER:
+      return "reducescatter";
+    case OpElem::PUTNOTIFY:
+      return "putnotify";
+    case OpElem::WAITNOTIFY:
+      return "waitnotify";
+    case OpElem::PUTSIGNAL:
+      return "putsignal";
+    case OpElem::WAITSIGNAL:
+      return "waitsignal";
+    case OpElem::SIGNAL:
+      return "signal";
+    case OpElem::GET:
+      return "get";
+  }
+  return "unknown";
+}
+
+// Bytes moved by a single op; 0 for the variable-size and one-sided ops,
+// whose extent is not on the OpElem. Those share a "<op>.<algo>.0" bucket.
+inline size_t ctranCollectiveMsgSize(const OpElem& op) {
+  switch (op.type) {
+    case OpElem::ALLGATHER:
+      return op.allgather.sendcount * commTypeSize(op.allgather.datatype);
+    case OpElem::ALLREDUCE:
+      return op.allreduce.count * commTypeSize(op.allreduce.datatype);
+    case OpElem::REDUCESCATTER:
+      return op.reducescatter.recvcount *
+          commTypeSize(op.reducescatter.datatype);
+    case OpElem::ALLTOALL:
+      return op.alltoall.count * commTypeSize(op.alltoall.datatype);
+    case OpElem::SEND:
+      return op.send.count * commTypeSize(op.send.datatype);
+    case OpElem::RECV:
+      return op.recv.count * commTypeSize(op.recv.datatype);
+    case OpElem::BROADCAST:
+      return op.broadcast.count * commTypeSize(op.broadcast.datatype);
+    default:
+      return 0;
+  }
+}
+
+struct CtranCollectiveStatsKey {
+  std::string collective;
+  // "<collective>.<algo>.<bytes>", e.g. "allreduce.ctring.1048576".
+  std::string key;
+};
+
+// Built once at submit and cached on the cmd: the GPE thread re-runs on every
+// graph replay, and the key is identical across replays.
+// A grouped submit is attributed to opGroup.front() and timed as a whole.
+inline CtranCollectiveStatsKey ctranCollectiveStatsKey(
+    const std::vector<std::unique_ptr<struct OpElem>>& opGroup,
+    std::string_view algoName) {
+  if (opGroup.empty()) {
+    return {};
+  }
+  const auto& op = *opGroup.front();
+  const char* collective = ctranCollectiveOpName(op.type);
+  return {
+      collective,
+      fmt::format(
+          "{}.{}.{}",
+          collective,
+          algoName.empty() ? std::string_view{"unknown"}
+                           : ctran::algoShortName(algoName),
+          ctranCollectiveMsgSize(op))};
+}
+
 class CtranGpe {
  public:
   // Optional reporter injection for tests. The cvar
@@ -426,6 +525,8 @@ class CtranGpe {
   // The mapper enforces this by clearing its per-peer host-transport
   // cache in setAtDestruction() before gpe is torn down.
   GpeKernelSyncPool* gpeKernelSyncPool();
+
+  comms::CollectiveStatsMap getAndClearCollectiveStats();
 
  private:
   class Impl;

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -277,6 +277,10 @@ commResult_t CtranGpe::Impl::submit(
         cmd->coll.collHandle = colltraceHandle;
       }
       cmd->coll.comm = comm;
+      if (MCCL_COLLECTIVE_STATS_ENABLE) {
+        cmd->coll.statsKey =
+            ctranCollectiveStatsKey(cmd->coll.opGroup, kernelConfig.algoName);
+      }
     }
 
     FB_COMMCHECK(maybeAcquireWorkStreamScope());
@@ -609,6 +613,10 @@ commResult_t CtranGpe::Impl::submitHost(
       cmd->coll.opGroup = std::move(opGroup);
       cmd->coll.func = func;
       cmd->coll.comm = comm;
+      if (MCCL_COLLECTIVE_STATS_ENABLE) {
+        cmd->coll.statsKey =
+            ctranCollectiveStatsKey(cmd->coll.opGroup, kernelConfig.algoName);
+      }
       auto colltraceHandle = meta::comms::colltrace::getCollTraceHandle(
           comm, cmd->coll.opGroup, kernelConfig, false /* ifChecksum */);
       if (colltraceHandle != nullptr) {
@@ -809,6 +817,15 @@ void CtranGpe::Impl::gpeThreadFn() {
       }
       gpeProfiler_->mark(ctran::GpeTracePoint::WAIT_KERNEL);
 
+      // Keyed off statsKey, not the cvar: re-reading the cvar at the record
+      // site would let a false->true flip mid-collective time from a
+      // default-constructed start point.
+      const bool collectiveStatsEnabled = !cmd->coll.statsKey.key.empty();
+      std::chrono::steady_clock::time_point collectiveStatsStart;
+      if (collectiveStatsEnabled) {
+        collectiveStatsStart = std::chrono::steady_clock::now();
+      }
+
       if (cmd->coll.collHandle != nullptr) {
         cmd->coll.collHandle->trigger(
             CollTraceHandleTriggerState::KernelStarted);
@@ -889,6 +906,19 @@ void CtranGpe::Impl::gpeThreadFn() {
                 static_cast<int>(cmd->coll.opGroup.front()->type),
                 cmd->coll.opGroup.front()->opCount);
           }
+        }
+
+        // Aborted collectives are recorded too: duration-until-abort is
+        // still useful.
+        if (collectiveStatsEnabled && comm != nullptr) {
+          const auto durationUs =
+              std::chrono::duration_cast<std::chrono::microseconds>(
+                  std::chrono::steady_clock::now() - collectiveStatsStart)
+                  .count();
+          collectiveStats_.record(
+              cmd->coll.statsKey.collective,
+              cmd->coll.statsKey.key,
+              static_cast<uint64_t>(durationUs));
         }
 
         if (cmd->persistent) {

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -134,6 +134,8 @@ class CtranGpeCmd {
     opFunc func;
     std::shared_ptr<meta::comms::colltrace::ICollTraceHandle> collHandle;
     CtranComm* comm;
+    // Stats bucket, resolved at submit. Empty when stats are disabled.
+    CtranCollectiveStatsKey statsKey;
   } coll;
 
   // kernelFlag to assist device mem communication
@@ -277,6 +279,9 @@ class CtranGpe::Impl {
 
   // Used only by the GPE thread.
   std::unique_ptr<ctran::GpeProfiler> gpeProfiler_;
+
+  // Written by the GPE thread per collective; drained via getAndClear.
+  comms::CollectiveStats collectiveStats_;
 
  private:
   struct CmdQueue {

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3373,6 +3373,11 @@ cvars:
      events to dedicated MCCL Scuba tables for observability and debugging.
      This is separate from NCCLX logging to minimize risk.
 
+ - name        : MCCL_COLLECTIVE_STATS_ENABLE
+   type        : bool
+   default     : true
+   description : Enable per-(collective_op, algorithm, msg_size) host-drive timing stats accumulated by the GPE thread and drained each training step.
+
  - name        : MCCL_SCUBA_LOG_LEVEL
    type        : enum
    default     : NORMAL


### PR DESCRIPTION
Summary:
Add `CollectiveStats`, a thread-safe timing accumulator (count + total/min/max host-drive microseconds) written by the GPE worker thread once per collective. Because `gpeThreadFn` re-runs on every CUDA-graph replay, this captures per-replay stats in PAFT graph mode, unlike the API-layer op-trace path which only fires at capture.

`gpeThreadFn` times the `WAIT_KERNEL` -> host-algo span and records it, gated by the new `MCCL_COLLECTIVE_STATS_ENABLE` cvar (default true). `CtranGpe::getAndClearCollectiveStats()` drains and resets the map via a swap-under-lock (single training-loop reader, GPE-thread writer).

Addressing review feedback:

**Lives in `fbcode/comms/common/`, namespace `comms`.** Moved out of `ctran/gpe/` so ctran, prims and mccl can share one accumulator. The following diff drops mccl's duplicate `CollectiveStat` struct in favor of `comms::CollectiveStat`.

**Buckets are keyed `<collective>.<algo>.<bytes>`**, e.g. `allreduce.ctring.1048576`. `ctran::algoShortName()` (new, in `algos/common/`) maps the `KernelConfig::algoName` display string to a short token. CTRAN algorithms use their `NCCL_*_ALGO` cvar value (`CtranAllReduceRing` -> `ctring`), so the bucket names the selector that produced it; the MCCL-hosted algorithms use their MCCL names instead (`ctree` -> `tree`, `cthierarchical_ring` -> `ring`, `ctmdirect` -> `direct`), so `ring` always means MCCL Ring and never CTRAN's `ctring`. Those three run natively via Prims and never reach the GPE today, so they are reserved rather than currently emitted.

The table is built from the existing `*AlgoName()` functions rather than string literals so display-name edits stay in one place, and it lives in the algos module so GPE stays free of per-algorithm conditionals. It keys off display names, not the selector, so it survives the in-flight `MCCL_ALGO` migration untouched.

**`record()` takes `collective` and `key` separately; `getAndClear()` derives the roll-ups.** Per-collective and comm-wide aggregates are folded once per drain rather than maintained on every record:

```
allreduce.ctring.1048576.{count,total_us,min_us,max_us}
allreduce.ctdirect.4096.{...}
allreduce.all.{...}
reducescatter.all.{...}
all.{...}
```

Sizes stay raw bytes rather than `1G`/`4K`. Abbreviating only exact binary multiples would emit a mixed format (`1G` next to `1000`) that every consumer has to parse two ways, and real gradient-AR sizes come from parameter counts, so the abbreviation would rarely fire. Formatting belongs at the presentation layer, not in a data key.

They roll up exactly — counts and totals sum, min is the min of mins, max the max of maxes — so deferring costs no accuracy.

**The hot path does no formatting or allocation.** The key is identical across every graph replay, so it is built once at submit and cached on `CtranGpeCmd`. The GPE thread does one heterogeneous F14 lookup (transparent hash, so no key allocation) plus four adds. `getAndClear()` returns `std::unordered_map`, not F14 — it crosses the mccl public interface and the pybind boundary, which has no F14 caster.

Also: fixed the copyright header, and latched the stats gate once per collective — reading `MCCL_COLLECTIVE_STATS_ENABLE` twice let a `false`->`true` flip mid-collective record a since-boot duration against a default-constructed start point. Documented that `ctranCollectiveMsgSize` returns 0 for the variable-size and one-sided ops, and that a grouped submit is attributed to `opGroup.front()`.

Differential Revision: D113297904


