### PR TITLE
comms/uniflow: correct stale AMD transport docs and comments (#3495)

### DIFF
--- a/comms/uniflow/amd/AMD_BUILD.md
+++ b/comms/uniflow/amd/AMD_BUILD.md
@@ -9,20 +9,47 @@ selected through `__HIP_PLATFORM_AMD__` and the CUDA runtime deps are swapped fo
 ROCm/HIP — there is no separate AMD library target.
 
 > **AMD transport status:** The unified `uniflow` target builds and runs on AMD
-> with **RDMA (RoCEv2) + GPUDirect** as the GPU transport. Features from the
-> Phase 2 stack (D107220750 D107220748 D107220757 D107346920 D107220749 D108381013
-> D108675437 D108942542):
+> supporting **two transport types**: **P2P (XGMI)** intra-node and **RDMA (RoCEv2)
+> + GPUDirect**. Neither is registered unconditionally — `MultiTransportFactory`
+> registers P2P only when `deviceId >= 0` and `P2pTransportFactory::supported()`
+> passes (it logs "P2P transport disabled for device N" otherwise), and RDMA only
+> when `selectNics()` returns a non-empty NIC list. Only NVLink is NVIDIA-only.
+>
+> `MultiTransport::selectTransport` resolves in this order:
+> 1. intra-node VRAM<->VRAM: `[intraNodeTransport]` -> on-host tier -> RDMA,
+>    where the on-host tier is NVLink on NVIDIA and **P2P/XGMI on AMD**;
+> 2. otherwise: RDMA.
+>
+> `intraNodeTransport` flips the intra-node first choice; both tiers stay
+> registered, so it is a per-transfer selection override rather than a
+> kill-switch.
+>
+> **P2P (XGMI)** — `transport/p2p`, takes the NVLink tier's place on AMD when its
+> capability checks pass
+> (`MultiTransport.cpp` registers `P2pTransportFactory` under
+> `__HIP_PLATFORM_AMD__`). Uses `hipIpc` memory handles.
+> `P2pTransportFactory::supported()` gates on an all-to-all-XGMI arch allowlist
+> (`gfx942` MI300, `gfx950` MI350, `gfx1250` MI450) so a non-XGMI part cannot let
+> presence-driven selection prefer a slow PCIe-P2P link over RDMA
+> (`hipDeviceCanAccessPeer` conflates the two).
+>
+> **RDMA / GPUDirect** — features from the Phase 2 stack (D107220750 D107220748
+> D107220757 D107346920 D107220749 D108381013 D108675437 D108942542):
 > - GPU-NIC PCIe affinity via `selectGpuNics` mapping each GPU to topologically-closest NIC
 > - RoCEv2 GID auto-selection skipping link-local (fe80::/10, 169.254/16), preferring IPv4-mapped then first global RoCEv2, with validation against gid_tbl_len
 > - Caller-configurable tunables via `MultiTransportFactoryOptions`: NicFilter (HCA selection), gidIndex (force GID, default auto-select), netdevPrefix (default `"beth"` for Broadcom bnxt NIC selection), trafficClass
 > - Netdev-prefix NIC selection capturing backing netdev name in topology
+> - GPUDirect registration probes AMD peer-mem support (`amdGpuDirectRdmaSupported()`:
+>   amdkfd sysfs + `/proc/kallsyms` fallback) and falls back to plain `ibv_reg_mr`
+>   when dma-buf export is unavailable
 > - Validated 2-host on MI350 (gfx950, ROCm 7.0) over Broadcom bnxt NICs with `cross_host_test` and `rdma_bandwidth` benchmarks
 >
 > The **NVLink** transport is NVIDIA-only and is compiled out on AMD (guarded by
-> `__HIP_PLATFORM_AMD__` in `MultiTransport.cpp`, BUCK deps select'd out).
-> Intra-node GPU-to-GPU P2P over XGMI is exercised at `CudaApi` level by
-> `PeerToPeerTransferTest` (`hipMemcpyPeerAsync` on AMD via `oss_gpu_cpp_unittest`),
-> but is not a registered uniflow transport on AMD.
+> `__HIP_PLATFORM_AMD__` in `MultiTransport.cpp`, BUCK deps select'd out). Note
+> that the **cuMem VMM allocator** (`cuMemCreate`/`AddressReserve`/`Map`/
+> `SetAccess`/`Export`/`Import`) is reached only by `NVLinkTransport` and the
+> NVLink benchmark, so it never executes on AMD; the AMD P2P tier uses `hipIpc`
+> handles instead.
 
 ## Prerequisites
 
@@ -63,28 +90,36 @@ buck2 build 'fbcode//comms/uniflow:uniflow?ovr_config//gpu:amd'
 
 ### Available ROCm Versions
 
-The `-m` flag selects the ROCm toolchain version:
+The `-m` flag selects the ROCm toolchain version. The authoritative version set
+is `ROCM_TP2_VERSIONS` in
+`fbsource/tools/build_defs/third_party/rocm_tp2_versions.bzl`:
 
-| Version | Flag | Description |
-|---------|------|-------------|
-| ROCm 7.0 | `-m rocm70` | Latest stable (recommended) |
-| ROCm 6.0 | `-m rocm60` | Previous stable |
-| ROCm 6.1 | `-m rocm61` | Previous stable |
+| Version | Flag | Status |
+|---------|------|--------|
+| ROCm 7.0 | `-m rocm70` | **Default and recommended.** `ROCM_DEFAULT_VERSION`; the version AMD ships backported fixes for. Required for MI350X+. Resolves to 7.0.2. |
+| ROCm 7.2 | `-m rocm_latest` | The `latest` tp2 label. Newest available and receives upstream test patches, but **explicitly not guaranteed stable** — intended for early enablement work (e.g. MI450X). Prefer asking AMD to backport into 7.0 over adopting it. |
+| ROCm 7.0.2.2 | — | Imported but **not publicly reachable**: its `constraint_value` visibility is restricted to buck infrastructure (see `arvr/tools/build_defs/config/third-party/rocm/constraints/BUCK`). |
+| ROCm 6.2.1 / 6.4.0 / 6.4.2 | `-m rocm621` / `rocm640` / `rocm642` | Legacy, do not use — scheduled for removal and no longer receiving patches. |
+
+There is no ROCm 6.0 or 6.1 in fbcode. Version policy is owned by AI Software
+Platform; see the "ROCm Version Strategy" posts in the ROCm Users group for the
+current plan of record.
 
 ### Default Behavior
 
-If `-m` is not specified, Buck uses the system default ROCm version configured in the build environment.
+If `-m` is not specified, Buck uses `ROCM_DEFAULT_VERSION` from
+`rocm_tp2_versions.bzl`, which is currently **7.0**.
 
 ### Examples
 
 ```bash
-# ROCm 7.0 (recommended)
+# ROCm 7.0 (default, recommended)
 buck build @//mode/opt-amd-gpu -m rocm70 fbcode//comms/uniflow:uniflow
 
-# ROCm 6.0
-buck build @//mode/opt-amd-gpu -m rocm60 fbcode//comms/uniflow:uniflow
+# ROCm 7.2, for early-enablement work only
+buck build @//mode/opt-amd-gpu -m rocm_latest fbcode//comms/uniflow:uniflow
 
-# System default
+# Default version (7.0)
 buck build @//mode/opt-amd-gpu fbcode//comms/uniflow:uniflow
 ```
 
@@ -179,8 +214,9 @@ NVML linkage.
 ```bash
 # Verify platform-agnostic modules stay free of GPU deps
 buck2 test @fbcode//mode/opt fbcode//comms/uniflow/amd:
-# 20 tests: per-target check_dependencies_test blocklisting drivers/cuda/*,
-# drivers/nvml/*, and external runtime libs (cuda-lazy, nvml-lazy, amdhip64-lazy)
+# One check_dependencies_test per neutral-zone target (10 targets in
+# NEUTRAL_ZONE_TARGETS), blocklisting drivers/cuda/*, drivers/nvml/*, and
+# external runtime libs (cuda-lazy, nvml-lazy, amdhip64-lazy, amdsmi)
 ```
 
 See `NEUTRAL_ZONES.md` for full architecture description of frozen modules

--- a/comms/uniflow/amd/AMD_ROCM_IMPLEMENTATION_SUMMARY.md
+++ b/comms/uniflow/amd/AMD_ROCM_IMPLEMENTATION_SUMMARY.md
@@ -9,8 +9,22 @@ sources. The **same `//comms/uniflow:uniflow` target builds for both NVIDIA and
 AMD** — platform selection is the `ovr_config//gpu:amd` constraint (set by the
 AMD build modes / modifier), not a separate library.
 
-On AMD the GPU transport is **RDMA (RoCEv2) with GPUDirect**; the NVLink
-transport is NVIDIA-only and is compiled out on AMD.
+On AMD, uniflow supports **two transport types**: **P2P (XGMI)** for the intra-node
+GPU tier and **RDMA (RoCEv2) with GPUDirect**. Only the NVLink transport is
+NVIDIA-only and compiled out on AMD.
+
+Both are registered by capability check rather than unconditionally, so a given
+process may end up with one, both, or neither:
+
+| Transport | Registered when |
+|---|---|
+| P2P (XGMI) | `deviceId >= 0` **and** `P2pTransportFactory::supported()` returns no error (the all-to-all-XGMI arch allowlist below). Otherwise `MultiTransportFactory` logs `P2P transport disabled for device N: <reason>` and continues. |
+| RDMA | `selectNics()` returns a non-empty NIC list (after `NicFilter` / `netdevPrefix` filtering). |
+
+If a transfer finds no transport common to all its local and remote segments,
+`selectTransport` fails rather than silently degrading — so a missing registration
+surfaces as a transfer error, and the `UNIFLOW_LOG_INFO` line above is the first
+place to look.
 
 ## Build-time translation (hipify-first)
 
@@ -69,19 +83,49 @@ Ordered from base to top matching the stacked diff series:
 | D107220749 | AMD build documentation. Adds `AMD_BUILD.md` and initial `AMD_ROCM_IMPLEMENTATION_SUMMARY.md` describing unified target build, ROCm versions, modes, and troubleshooting. |
 | D108381013 | Freeze neutral zones with GPU dep-guards. Adds `amd/neutral_zones.bzl` + `amd/BUCK` emitting per-target `check_dependencies_test` in blocklist mode for platform-agnostic modules (executor, controller, core result/segment, logging, sysfs, ibverbs core). Blocks first-party GPU seams (`drivers/cuda/*`: cuda-api, cuda-driver-api, cuda-device-adapter, cuda-topology-discovery; `drivers/nvml/*`) and external runtime libs (`cuda-lazy`, `nvml-lazy`, `amdhip64-lazy`, `amdsmi`). Documents architecture in `NEUTRAL_ZONES.md`. |
 | D108675437 | RoCE GID auto-selection, netdev-prefix NIC selection, and MultiTransportFactoryOptions consolidation. Wires `ibv_query_gid_ex` via `IbvApi`/`IbvCore`/`MockIbvApi` for GID table introspection. `RdmaResources` auto-selects RoCEv2 GID skipping link-local (fe80::/10 IPv6 and 169.254 IPv4-mapped), preferring IPv4-mapped then first global. Configuration via `MultiTransportFactoryOptions` struct (NicFilter, netdevPrefix, gidIndex, trafficClass) — no library-internal env vars. Topology captures backing netdev name; netdev-prefix NIC selection defaults to `"beth"` with predicate skipped when netdev names unknown. Makes single-host RDMA test vendor-agnostic. Unit tests for GID selection and netdev-prefix. |
-| D108942542 | Migrate landed uniflow GPU tests to `oss_gpu_cpp_unittest`. Migrates pre-existing GPU C++ test targets from `comms_gpu_cpp_unittest` to `oss_gpu_cpp_unittest` (=`comms_gpu_cpp_unittest` + OSS dep guard) for parity with production `oss_gpu_cpp_library` and CPU `oss_cpp_unittest`. AMD/HIP compile path, GPU CI labels, and RE config unchanged. Migrated: `drivers/cuda/tests`, `drivers/ibverbs/tests`, `drivers/nvml/tests`, `tests/integration`, `transport/tests/integration`. In-stack GPU test BUCKs folded into owning diffs (peer-to-peer test in D107346920, RDMA unit tests in D107220757/D108675437). Distributed rule left as-is. |
+| D108942542 | Migrate landed uniflow GPU tests to `oss_gpu_cpp_unittest`. Migrates pre-existing GPU C++ test targets from `comms_gpu_cpp_unittest` to `oss_gpu_cpp_unittest` (=`comms_gpu_cpp_unittest` + OSS dep guard) for parity with production `oss_gpu_cpp_library` and CPU `oss_cpp_unittest`. AMD/HIP compile path, GPU CI labels, and RE config unchanged. Migrated: `drivers/cuda/tests`, `drivers/ibverbs/tests`, `drivers/nvml/tests`, `tests/integration`, `transport/tests/integration`. Distributed rule left as-is. |
+| D114457575 | Intra-node transport selection. Adds the `intraNodeTransport` override to `MultiTransportFactoryOptions`, letting a caller flip the intra-node VRAM<->VRAM first choice (on-host tier -> RDMA) without unregistering a tier. |
 
 ## Transports on AMD
 
-### RDMA / GPUDirect (the AMD GPU transport)
+`MultiTransport::selectTransport` resolves in this order:
 
-RDMA is the GPU transport on AMD as well as NVIDIA (`transport/rdma/`):
+1. intra-node VRAM<->VRAM: `[intraNodeTransport]` -> on-host tier -> RDMA, where
+   the on-host tier is NVLink on NVIDIA and **P2P/XGMI on AMD**;
+2. otherwise: RDMA.
+
+Each tier falls through to the next when unavailable for a given request, so
+`intraNodeTransport` is a selection preference rather than a kill-switch.
+
+### P2P / XGMI (the AMD intra-node tier)
+
+`transport/p2p` serves the on-host GPU tier on AMD, in place of NVLink.
+`MultiTransport.cpp` registers `P2pTransportFactory` under
+`__HIP_PLATFORM_AMD__`; cross-process imports use `hipIpcOpenMemHandle`
+(`P2pRegistrationHandle`). Notably it does **not** use the cuMem VMM allocator.
+
+`P2pTransportFactory::supported()` gates on an all-to-all-XGMI architecture
+allowlist — `gfx942` (MI300), `gfx950` (MI350), `gfx1250` (MI450) — matching an
+exact gfx token while allowing a feature-flag suffix (`gfx942:sramecc+:xnack-`)
+but not a longer digit run (`gfx12500`). Without this gate, a non-XGMI part could
+let presence-driven selection prefer a slow PCIe-P2P link over RDMA, because
+`hipDeviceCanAccessPeer` conflates the two.
+
+### RDMA / GPUDirect
+
+RDMA is a GPU transport on AMD as well as NVIDIA (`transport/rdma/`):
 
 - **GPUDirect RDMA** registers GPU (VRAM) memory with the NIC via a dma-buf fd
   exported with `cuMemGetHandleForAddressRange` (hipified to
-  `hipMemGetHandleForAddressRange` on AMD).
+  `hipMemGetHandleForAddressRange` on AMD). AMD support is detected by
+  `amdGpuDirectRdmaSupported()` — an amdkfd peer-mem sysfs probe
+  (`/sys/kernel/mm/memory_peers/amdkfd/version` and two path variants) with an
+  `ib_register_peer_memory_client` `/proc/kallsyms` fallback, mirroring
+  `comms/ctran/utils/HipGdrCheck.h`. When the probe reports no support,
+  `RdmaTransport::registerSegment` falls back to plain `ibv_reg_mr`.
 - **RoCEv2 GID auto-selection** picks a valid RoCEv2 GID, with caller-supplied
-  options (via MultiTransportFactoryOptions) and **netdev-prefix (`beth`) NIC selection** (D108675437).
+  options (via `MultiTransportFactoryOptions`) and **netdev-prefix (`beth`) NIC
+  selection** (D108675437).
 - **GPU↔NIC PCIe affinity** (`selectGpuNics`) maps each GPU to its
   topologically-closest NIC, so per-GPU bandwidth tracks per-NIC bandwidth.
 - The `CopyEngine` VRAM path uses `streamWriteValue64` for completion signaling.
@@ -94,10 +138,12 @@ single-pair and 8-GPU-pair aggregate).
 
 `NVLinkTransport` (NVML-backed topology, fabric/FD IPC) is NVIDIA-only and is
 compiled out on AMD via `#ifndef __HIP_PLATFORM_AMD__` in `MultiTransport.cpp`,
-with its BUCK deps `select()`'d out on AMD. Intra-node GPU-to-GPU P2P over the
-GPU interconnect (XGMI on AMD, NVLink on NVIDIA) is exercised at the `CudaApi`
-level by `PeerToPeerTransferTest` (`hipMemcpyPeerAsync` on AMD), but it is not a
-registered uniflow transport on AMD.
+with its BUCK deps `select()`'d out on AMD; `P2pTransportFactory` takes its place
+when its capability checks pass. `NVLinkTransport` and the NVLink bandwidth benchmark are also the
+**only** consumers of the cuMem VMM allocator (`cuMemCreate`, `AddressReserve`,
+`Map`, `SetAccess`, `ExportToShareableHandle`, `ImportFromShareableHandle`), so
+that allocator never executes on AMD. The NVIDIA-only fabric-handle / IMEX path
+likewise does not apply — AMD uses POSIX-FD / dma-buf sharing.
 
 ## Build
 
@@ -122,8 +168,8 @@ troubleshooting.
   * `drivers/cuda/tests:cuda_device_adapter_test`, `:cuda_driver_api_test` — driver seam and device adapter via oss_gpu_cpp_library path
   * `drivers/ibverbs/tests:ibv_api_test` — ibverbs core verbs mocked
   * `drivers/nvml/tests:nvml_api_test` — NVML factory mocked, AMD stub covered
-  * `transport/nvlink/tests/integration:peer_to_peer_transfer_test` — intra-node P2P (XGMI/NVLink) via CudaApi, hip_ci enabled (D107346920)
-  * `transport/rdma/tests/integration:cross_host_test` — 2-host RDMA real NICs
+  * `transport/nvlink/tests/integration:peer_to_peer_transfer_test` — intra-node P2P (XGMI/NVLink) at the `CudaApi` level via `memcpyPeerAsync`, hip_ci enabled (D107346920)
+  * `transport/rdma/tests/integration:cross_host_test` — 2-host RDMA real NICs; `:cross_host_test_amd` is the AMD variant (`disable_nvidia_ci` flips it to the HIP-only, `opt-amd-gpu` CI path), run on baremetal with `-c comms.hosts=hostA,hostB`
   * `transport/rdma/tests/unit/*` — RDMA transport, slab pool, registration mocked; includes GID selection and netdev-prefix unit tests from D108675437
 - Neutral zone dependency guards: `buck2 test @fbcode//mode/opt fbcode//comms/uniflow/amd:` runs `check_dependencies_test` per neutral target to ensure no GPU dep leakage (D108381013).
 
@@ -144,11 +190,40 @@ real NVML on NVIDIA, no-op stub on AMD).
 - `cuda-driver-api` remains on `hipify-perl` (see the blocker above); migrating
   it to `oss_gpu_cpp_library` requires moving the RDMA consumers
   (`transport/rdma`) to `gpu_cpp_library` so both ends hipify consistently.
-- NVLink/XGMI is not exposed as a uniflow transport on AMD.
-- `resolveGidIndex` readability: extract GID-table scan into a separate
-  helper to de-duplicate the fallback logic (non-blocking, noted by reviewer).
-- Forced GID index path does not bound `configuredGidIndex` to <= 255
-  before `static_cast<uint8_t>` (follow-up to add the same guard as the auto path).
+- `drivers/nvml` has no amdsmi backend; `createNvmlApi()` returns a no-op stub on
+  AMD, so NVML-derived topology is empty there.
+- `comms_gpu_cpp_distributed_unittest` has no AMD remote-execution branch. Every RE
+  path in `comms_launch_distributed_binary` uses `platform = "gpu-remote-execution"`
+  (or `-multihost`), unlike `comms_gpu_cpp_unittest`, which selects
+  `platform = "amd-gpu"` + `subplatform = amd_gpu_name` under `ovr_config//gpu:amd`.
+  Consequences for the AMD RDMA tests:
+  * They are baremetal-oriented — run them with `-c comms.hosts=hostA,hostB`, where
+    the target GPUs come from the host list. This works on any AMD part
+    (MI300/MI350/MI355X) with no target change; AMD-ness comes from
+    `disable_nvidia_ci` -> `amd_only` (`target_compatible_with` HIP-only +
+    `amd_ci(mode = "fbcode//mode/opt-amd-gpu")`), not from `gpu_name`.
+  * `gpu_name` is the RE `subplatform` on three of the branches in
+    `comms_launch_distributed_binary` \u2014 baremetal/MAST, gang-RE, and single-host-RE \u2014
+    and is ignored only on the multihost-RE branch (`enable_multinode_re`, which
+    `nnodes >= 2` selects). Since the documented way to run these is the baremetal
+    path (`-c comms.hosts=...`), `gpu_name` **is** read in normal use.
+  * It therefore must **not** simply be deleted: the macro default is `"H100"`, so
+    dropping `gpu_name = "MI300"` would make an AMD-only target request an H100
+    subplatform. The value is load-bearing; the defect is the `platform`, not the
+    `subplatform`.
+  * Making these RE-schedulable on AMD requires adding the `platform = "amd-gpu"`
+    select to `comms_launch_distributed_binary` (and switching these callers to
+    `amd_gpu_name`), mirroring `comms_gpu_cpp_unittest`. Until then the AMD
+    subplatform is being requested against the NVIDIA pool. Note `MI300` is the only
+    AMD subplatform token present anywhere under `comms/`, so any MI350/MI355 token
+    needs confirming against the RE pool rather than inferred from source.
+  * **Observed consequence:** on an MI300X devgpu, `:single_host_test_amd` could not be
+    run at all. It resolves to RE-only with `platform = "gpu-remote-execution"` +
+    `subplatform = "MI300"`, and `global:tpx-default` has no quota for that pair;
+    `--local-only` is rejected ("desired execution strategy (LocalOnly) is incompatible
+    with the executor config"), and invoking the test binary directly hangs at
+    rendezvous. So the missing `amd-gpu` select is not cosmetic — it currently leaves
+    these targets unrunnable without an RE quota grant or a target-config change.
 
 ## References
 

--- a/comms/uniflow/drivers/cuda/CudaDriverApi.h
+++ b/comms/uniflow/drivers/cuda/CudaDriverApi.h
@@ -7,10 +7,17 @@
 #include "comms/uniflow/Result.h"
 
 #if defined(__HIP_PLATFORM_AMD__)
-// hipify-perl does not map this newer VMM dma-buf handle type; alias the CUDA
-// spelling (which survives hipification untranslated) to the HIP type so the
-// hipified interface still names a valid type on AMD. The dma-buf export path
-// that uses it is implemented for AMD in a later diff.
+// hipify-perl does not map the VMM dma-buf handle type; alias the CUDA spelling
+// (which survives hipification untranslated) to the HIP type so the hipified
+// interface still names a valid type on AMD. This is a hipify mapping gap, not
+// a ROCm version gate: hipMemRangeHandleTypeDmaBufFd exists with the same value
+// (0x1) in ROCm 7.0 and 7.2.
+//
+// The dma-buf export path that consumes it is implemented for AMD:
+// CudaDeviceAdapter::exportDmaBuff calls cuMemGetHandleForAddressRange, gated
+// by amdGpuDirectRdmaSupported() (amdkfd peer-mem sysfs + kallsyms probe, see
+// CudaDriverApi.cpp); RdmaTransport::registerSegment falls back to plain
+// ibv_reg_mr when the probe reports no peer-mem support.
 using CUmemRangeHandleType = hipMemRangeHandleType;
 // Same hipify gap for the dma-buf-fd enumerator used by callers of
 // cuMemGetHandleForAddressRange.

--- a/comms/uniflow/transport/p2p/P2pTransport.cpp
+++ b/comms/uniflow/transport/p2p/P2pTransport.cpp
@@ -376,7 +376,7 @@ Status P2pTransportFactory::supported(std::shared_ptr<CudaApi> cudaApi) {
   // all-to-all XGMI intra-node. Gate on this arch family so a non-XGMI part
   // never lets MultiTransport's presence-driven selectTransport prefer a slow
   // PCIe-P2P link over RDMA (hipDeviceCanAccessPeer conflates the two). See
-  // comms/uniflow/amd/AMD_SUPPORT_DESIGN.md §5.6.
+  // comms/uniflow/amd/AMD_ROCM_IMPLEMENTATION_SUMMARY.md ("P2P / XGMI").
   //
   // Match an exact gfx token, allowing a feature-flag suffix after ':'
   // (e.g. "gfx942:sramecc+:xnack-") but not a longer digit run ("gfx12500").


### PR DESCRIPTION
Summary:

The AMD docs and a few AMD-path comments had drifted from the implementation.
Most consequentially, both `amd/AMD_BUILD.md` and
`amd/AMD_ROCM_IMPLEMENTATION_SUMMARY.md` claimed that intra-node P2P over XGMI
"is not a registered uniflow transport on AMD". That is no longer true:
`transport/p2p` is registered on AMD in place of the NVLink tier
(`MultiTransport.cpp` registers `P2pTransportFactory` under
`__HIP_PLATFORM_AMD__`; see the root `BUCK` select), so AMD has two registered
transports -- P2P/XGMI and RDMA -- not one.

Docs (`amd/`):
- Rewrite the transport sections for both AMD transports, documenting the
  `selectTransport` order and the `intraNodeTransport` override, the
  all-to-all-XGMI arch allowlist in `P2pTransportFactory::supported()`
  (gfx942/gfx950/gfx1250) and why it exists, and the
  `amdGpuDirectRdmaSupported()` peer-mem probe with its `ibv_reg_mr` fallback.
- Fix the ROCm version table. It listed `-m rocm60` and `-m rocm61`, neither of
  which exists. The authoritative set is `ROCM_TP2_VERSIONS` in
  `tools/build_defs/third_party/rocm_tp2_versions.bzl`:
  6.2.1 / 6.4.0 / 6.4.2 / 7.0 / 7.0.2.2 / latest, with
  `ROCM_DEFAULT_VERSION = "7.0"` (not "the system default"). Also records that
  `latest` is currently ROCm 7.2 (`-m rocm_latest`, explicitly not stable) and
  that 7.0.2.2's constraint_value is visibility-restricted to buck infra.
- Correct the neutral-zone guard count from 20 to 10: `neutral_zone_dep_guards()`
  emits one `check_dependencies_test` per target and `NEUTRAL_ZONE_TARGETS` has
  10 entries.
- Add the D114457575 row (intra-node transport selection) to the implementation
  stack table.
- Drop two "known limitations" that are already fixed: `resolveGidIndex` does
  bound the forced index (`configuredGidIndex >= gid_tbl_len` throws, with
  `gid_tbl_len <= kMaxGidTblLen` as a precondition) and the scan is already
  factored into `scanForRoceV2Gid` / `getDefaultGidIndexOrThrow`. Replaced with
  two real ones (no amdsmi backend; and no AMD remote-execution branch in
  `comms_gpu_cpp_distributed_unittest`, which makes the AMD RDMA tests
  baremetal-oriented and leaves the AMD `subplatform` requested against the NVIDIA
  RE pool).

Comments:
- `drivers/cuda/CudaDriverApi.h`: the dma-buf export path is no longer "in a
  later diff" -- point at `CudaDeviceAdapter::exportDmaBuff`,
  `amdGpuDirectRdmaSupported()` and the `ibv_reg_mr` fallback. Also drop
  "newer": `hipMemRangeHandleTypeDmaBufFd` is present with the same value (0x1)
  in both ROCm 7.0 and 7.2, so this is a hipify-perl mapping gap rather than a
  ROCm version gate.
- Root `BUCK`: the transport `select()` comment said "RDMA is the GPU transport
  on AMD" and never mentioned p2p, contradicting the select it annotates.
- `transport/p2p/P2pTransport.cpp`: retarget a dangling reference to
  `amd/AMD_SUPPORT_DESIGN.md`, which does not exist in the tree.

This is based on master, so it deliberately documents only what is landed. The
TCP transport and the `preferredTransport` / `interNodeTransport` / `enableTcp` /
`tcpBindHost` options are not covered here because they arrive with D114431544;
those docs belong with that diff.

Also included: `transport/p2p/BUCK` moves `//comms/uniflow:result` from `deps`
to `exported_deps`. This was applied by AUTODEPS during `arc lint -a` rather
than by hand. It is correct -- `P2pTransport.h` includes `Result.h` and its
public API returns `Status`/`Result<>` -- but it is incidental to this cleanup
and can be split out if preferred.

Apart from that dep move, there is no compiled behavior change: every edit is a
comment or markdown change.

Addressed in review: the transport sections said "two registered transports", but
neither AMD transport is registered unconditionally -- `MultiTransportFactory`
registers P2P only when `deviceId >= 0` and `P2pTransportFactory::supported()` passes
(logging "P2P transport disabled for device N" otherwise), and RDMA only when
`selectNics()` is non-empty. Reworded to "two transport types" and added the actual
gates, plus the consequence that `selectTransport` fails rather than degrading when no
transport is common to all segments, so a missing registration surfaces as a transfer
error.

Also recorded an observed consequence of the missing AMD RE branch: on an MI300X
devgpu, `:single_host_test_amd` cannot run at all -- it resolves to RE-only with
`platform = "gpu-remote-execution"` + `subplatform = "MI300"`, `global:tpx-default` has
no quota for that pair, `--local-only` is rejected, and the raw binary hangs at
rendezvous.

Reviewed By: yexiangd

Differential Revision: D115084216


