### PR TITLE
Configure independent multimem pipeline depth

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -51,12 +51,12 @@ struct ctranPrimsConfig {
   // fixes the per-chunk size: chunk = channelBufferSize / channelPipelineDepth.
   int64_t channelPipelineDepth{-1};
   // -1 uses MCCL_MAX_NCHANNELS. Total IB staging for this communicator is
-  // channelBufferSize * maxChannels per peer per direction.
+  // channelBufferSize * maxChannels per peer per direction. Multimem staging
+  // capacity is also provisioned for this many channels.
   int64_t maxChannels{-1};
-  // -1 uses MCCL_MAX_NBLOCKS. As with the CVAR, this is both the NVL channel
-  // count and the collective launch-geometry block cap; the two must move
-  // together or the multimem signal sizing drifts from the transport's actual
-  // channel count.
+  // -1 uses MCCL_MAX_NBLOCKS. This is the collective launch-geometry block
+  // cap. Multimem requires it not to exceed maxChannels because a launch
+  // cannot consume more blocks than the provisioned channel capacity.
   int64_t maxBlocks{-1};
 
   bool operator==(const ctranPrimsConfig& other) const {

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -23,6 +23,7 @@
 #include "comms/ctran/utils/AsyncError.h"
 #include "comms/ctran/utils/Exception.h"
 #include "comms/ctran/window/WinCache.h"
+#include "comms/prims/transport/nvl/MultimemNvlTransportConfig.h"
 #include "comms/utils/colltrace/AlgoStats.h"
 #include "comms/utils/colltrace/CollTraceInterface.h"
 #include "comms/utils/commSpecs.h"
@@ -35,8 +36,6 @@ struct Transport;
 
 using meta::comms::CommBackend;
 
-// Per-communicator Prims transport overrides.
-// -1 means use CVAR default.
 struct ctranPipesConfig {
   // -1 uses NCCL_CTRAN_USE_PIPES. MCCL sets this explicitly so its Prims
   // policy does not affect NCCLX or standalone Ctran communicators.
@@ -44,9 +43,11 @@ struct ctranPipesConfig {
   int64_t nvlChunkSize{-1};
   bool ibLazyConnect{true};
   int64_t ibgdaDataBufferSize{-1};
+  std::optional<comms::prims::MultimemNvlTransportConfig> multimemConfig;
 
   bool operator==(const ctranPipesConfig& other) const {
     return enablePrims == other.enablePrims &&
+        multimemConfig == other.multimemConfig &&
         nvlChunkSize == other.nvlChunkSize &&
         ibLazyConnect == other.ibLazyConnect &&
         ibgdaDataBufferSize == other.ibgdaDataBufferSize;

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -46,8 +46,18 @@ int ctranPipesNvlMaxNumChannels(const ctranPrimsConfig& pc) {
   return std::max(1, static_cast<int>(resolved));
 }
 
-size_t roundDownToMultiple(size_t value, size_t multiple) {
-  return multiple == 0 ? 0 : (value / multiple) * multiple;
+size_t alignedPerChannelSize(
+    size_t totalSize,
+    size_t maxChannels,
+    size_t pipelineDepth) {
+  constexpr size_t kDataAlignment = 16;
+  if (maxChannels == 0 || pipelineDepth == 0 ||
+      pipelineDepth > std::numeric_limits<size_t>::max() / kDataAlignment) {
+    return 0;
+  }
+
+  const size_t alignment = kDataAlignment * pipelineDepth;
+  return (totalSize / maxChannels / alignment) * alignment;
 }
 
 } // namespace
@@ -112,9 +122,8 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     config.nvlConfig.maxNumChannels = ctranPipesNvlMaxNumChannels(pc);
     const size_t nvlMaxNumChannels =
         static_cast<size_t>(config.nvlConfig.maxNumChannels);
-    const size_t nvlChannelAlign = 16ULL * config.nvlConfig.pipelineDepth;
-    config.nvlConfig.perChannelSize = roundDownToMultiple(
-        nvlSharedDevbufSize / nvlMaxNumChannels, nvlChannelAlign);
+    config.nvlConfig.perChannelSize = alignedPerChannelSize(
+        nvlSharedDevbufSize, nvlMaxNumChannels, config.nvlConfig.pipelineDepth);
     if (config.nvlConfig.perChannelSize == 0) {
       CLOGF(
           ERR,
@@ -139,19 +148,42 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     if (comm->statex_->nLocalRanks() > 2 && multimemDevbufSize > 0) {
       const std::size_t multimemPipelineDepth =
           std::max<std::size_t>(1, config.nvlConfig.pipelineDepth);
-      // Reuse the already-computed channel count (config.nvlConfig
-      // .maxNumChannels, resolved from primsConfig.maxBlocks or
-      // MCCL_MAX_NBLOCKS) as the channel count so signal sizing cannot drift
-      // from the transport's actual channel count. Do not re-derive it here.
-      const std::size_t multimemMaxChannels =
-          static_cast<std::size_t>(config.nvlConfig.maxNumChannels);
+      const auto resolvedMaxChannels = ctranPrimsResolvedMaxChannels(pc);
+      const auto resolvedMaxBlocks = ctranPrimsResolvedMaxBlocks(pc);
+      const size_t multimemMaxChannels = resolvedMaxChannels > 0
+          ? static_cast<size_t>(resolvedMaxChannels)
+          : 0;
+      const size_t multimemMaxBlocks =
+          resolvedMaxBlocks > 0 ? static_cast<size_t>(resolvedMaxBlocks) : 0;
+      if (multimemMaxBlocks > multimemMaxChannels) {
+        CLOGF(
+            ERR,
+            "CTRAN-PRIMS: invalid multimem config; maxBlocks={} exceeds maxChannels={}",
+            multimemMaxBlocks,
+            multimemMaxChannels);
+        return commInvalidArgument;
+      }
+      const size_t multimemPerChannelSize = alignedPerChannelSize(
+          multimemDevbufSize, multimemMaxChannels, multimemPipelineDepth);
+      if (multimemPerChannelSize == 0) {
+        CLOGF(
+            ERR,
+            "CTRAN-PRIMS: invalid multimem config; devbufSize={} maxChannels={} pipelineDepth={} cannot produce aligned perChannelSize",
+            multimemDevbufSize,
+            multimemMaxChannels,
+            multimemPipelineDepth);
+        return commInvalidArgument;
+      }
+
       config.nvlConfig.enableMultimem = true;
-      config.nvlConfig.multimem = comms::prims::MultimemNvlTransportConfig{
-          .dataBufferSize = multimemDevbufSize,
-          .userSignalCount = 1,
-          .pipelineDepth = multimemPipelineDepth,
-          .maxChannels = multimemMaxChannels,
-      };
+      config.nvlConfig.multimem =
+          comms::prims::make_multimem_nvl_transport_config({
+              .perChannelSize = multimemPerChannelSize,
+              .pipelineDepth = multimemPipelineDepth,
+              .maxChannels = multimemMaxChannels,
+              .maxBlocks = multimemMaxBlocks,
+              .userSignalCount = 1,
+          });
     }
 
     // LL128 buffer allocation for DeviceAllToAllv

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -43,6 +43,37 @@ size_t roundDownToMultiple(size_t value, size_t multiple) {
 
 } // namespace
 
+commResult_t ctran::ctranApplyMultimemConfig(
+    const ctranPipesConfig& config,
+    const comms::prims::MultimemNvlTransportConfig& fallbackConfig,
+    size_t topologyDataBufferSize,
+    int nLocalRanks,
+    comms::prims::MultiPeerNvlTransportConfig& nvlConfig) {
+  if (nLocalRanks <= 2) {
+    return commSuccess;
+  }
+  const auto resolved = comms::prims::resolve_multimem_nvl_transport_config(
+      config.multimemConfig,
+      fallbackConfig,
+      topologyDataBufferSize,
+      nLocalRanks);
+  if (!resolved) {
+    CLOGF(
+        ERR,
+        "CTRAN-PRIMS: invalid multimem config: {} (dataBufferSize={} userSignalCount={} pipelineDepth={} maxGroups={})",
+        comms::prims::multimem_nvl_transport_config_error_string(
+            resolved.error),
+        resolved.config.dataBufferSize,
+        resolved.config.userSignalCount,
+        resolved.config.pipelineDepth,
+        resolved.config.maxGroups);
+    return commInvalidArgument;
+  }
+  nvlConfig.enableMultimem = true;
+  nvlConfig.multimem = resolved.config;
+  return commSuccess;
+}
+
 commResult_t ctran::ctranPreparePipesTrace(
     CtranComm* comm,
     comms::prims::PipesTraceHandle& trace) {
@@ -120,24 +151,23 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     // dedicated cvar is 0. Computed before the enable guard so setting only the
     // multimem cvar (with the P2P devbuf at 0) is sufficient to enable the
     // path.
-    const size_t multimemDevbufSize = MCCL_NVL_MULTIMEM_BUFSIZE > 0
+    const size_t fallbackMultimemDataBufferSize = MCCL_NVL_MULTIMEM_BUFSIZE > 0
         ? static_cast<size_t>(MCCL_NVL_MULTIMEM_BUFSIZE)
         : nvlSharedDevbufSize;
-    if (comm->statex_->nLocalRanks() > 2 && multimemDevbufSize > 0) {
-      const size_t multimemPipelineDepth =
-          std::max<size_t>(1, config.nvlConfig.pipelineDepth);
-      // Reuse the already-computed channel count (== std::max(1,
-      // MCCL_MAX_NBLOCKS)) as the group count so allocation and launch policy
-      // share one immutable geometry snapshot.
-      const uint32_t multimemMaxGroups =
-          static_cast<uint32_t>(config.nvlConfig.maxNumChannels);
-      config.nvlConfig.enableMultimem = true;
-      config.nvlConfig.multimem = comms::prims::MultimemNvlTransportConfig{
-          .dataBufferSize = multimemDevbufSize,
-          .userSignalCount = 1,
-          .pipelineDepth = multimemPipelineDepth,
-          .maxGroups = multimemMaxGroups,
-      };
+    const comms::prims::MultimemNvlTransportConfig fallbackConfig{
+        .dataBufferSize = fallbackMultimemDataBufferSize,
+        .userSignalCount = 1,
+        .pipelineDepth = std::max<size_t>(1, config.nvlConfig.pipelineDepth),
+        .maxGroups = static_cast<size_t>(config.nvlConfig.maxNumChannels),
+    };
+    if (const auto result = ctran::ctranApplyMultimemConfig(
+            pc,
+            fallbackConfig,
+            nvlSharedDevbufSize,
+            comm->statex_->nLocalRanks(),
+            config.nvlConfig);
+        result != commSuccess) {
+      return result;
     }
 
     // LL128 buffer allocation for DeviceAllToAllv

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -124,48 +124,19 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         ? static_cast<size_t>(MCCL_NVL_MULTIMEM_BUFSIZE)
         : nvlSharedDevbufSize;
     if (comm->statex_->nLocalRanks() > 2 && multimemDevbufSize > 0) {
-      const uint32_t multimemPipelineDepth = static_cast<uint32_t>(
-          std::max<size_t>(1, config.nvlConfig.pipelineDepth));
+      const size_t multimemPipelineDepth =
+          std::max<size_t>(1, config.nvlConfig.pipelineDepth);
       // Reuse the already-computed channel count (== std::max(1,
-      // MCCL_MAX_NBLOCKS)) as the group count so the signal sizing cannot drift
-      // from the transport's actual channel count.
+      // MCCL_MAX_NBLOCKS)) as the group count so allocation and launch policy
+      // share one immutable geometry snapshot.
       const uint32_t multimemMaxGroups =
           static_cast<uint32_t>(config.nvlConfig.maxNumChannels);
-      // Per-lane signal region, sized from the shared source of truth
-      // `multimem_staging_signals_per_lane` (MultimemNvlTransportDevice.cuh).
-      // The device-side `make_stage_layout` (MultimemNvlStageLayout.cuh, added
-      // by the ReduceScatter copy prereq stacked on this diff) is updated to
-      // call the same helper, so the host sizing here and the device layout
-      // stay in lockstep off one definition rather than duplicated literals.
-      const uint32_t multimemSignalsPerLane =
-          comms::prims::multimem_staging_signals_per_lane(
-              comm->statex_->nLocalRanks());
-      // Evaluate the product in u64 (all three factors are hardware-bounded to
-      // small values, so it cannot realistically overflow u64) and bound it
-      // against the transport's signal-count limit (INT_MAX; see
-      // MultimemNvlTransport's ctor) before narrowing into the u32 field, so a
-      // future large maxGroups/pipelineDepth/nLocalRanks fails loudly here with
-      // context rather than silently wrapping or throwing deeper in the ctor.
-      const uint64_t multimemInternalSignalCount =
-          static_cast<uint64_t>(multimemMaxGroups) * multimemPipelineDepth *
-          multimemSignalsPerLane;
-      if (multimemInternalSignalCount >
-          static_cast<uint64_t>(std::numeric_limits<int>::max())) {
-        CLOGF(
-            ERR,
-            "CTRAN-PRIMS: multimem internalSignalCount {} exceeds the transport signal-count limit (INT_MAX); maxGroups={} pipelineDepth={} signalsPerLane={}",
-            multimemInternalSignalCount,
-            multimemMaxGroups,
-            multimemPipelineDepth,
-            multimemSignalsPerLane);
-        return commInvalidArgument;
-      }
       config.nvlConfig.enableMultimem = true;
       config.nvlConfig.multimem = comms::prims::MultimemNvlTransportConfig{
           .dataBufferSize = multimemDevbufSize,
           .userSignalCount = 1,
-          .internalSignalCount =
-              static_cast<uint32_t>(multimemInternalSignalCount),
+          .pipelineDepth = multimemPipelineDepth,
+          .maxGroups = multimemMaxGroups,
       };
     }
 
@@ -332,7 +303,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
 
     CLOGF(
         INFO,
-        "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} enableMultimem={} multimemSignals={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={}",
+        "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} enableMultimem={} multimemPipelineDepth={} multimemMaxGroups={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={}",
         comm->statex_->rank(),
         config.nvlConfig.pipelineDepth,
         nvlSharedDevbufSize,
@@ -341,8 +312,10 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         config.nvlConfig.perChannelSize,
         config.nvlConfig.enableMultimem,
         config.nvlConfig.enableMultimem
-            ? config.nvlConfig.multimem.internalSignalCount
+            ? config.nvlConfig.multimem.pipelineDepth
             : 0,
+        config.nvlConfig.enableMultimem ? config.nvlConfig.multimem.maxGroups
+                                        : 0,
         hierAgOverlapEnabled,
         config.disableIb,
         config.topoConfig.p2pDisable,

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -62,6 +62,58 @@ size_t alignedPerChannelSize(
 
 } // namespace
 
+commResult_t ctran::ctranBuildMultimemNvlTransportConfig(
+    const ctranPrimsConfig& config,
+    size_t bufferSize,
+    int nLocalRanks,
+    comms::prims::MultimemNvlTransportConfig& multimemConfig) {
+  const size_t pipelineDepth = MCCL_NVL_MULTIMEM_PIPELINE_DEPTH;
+  constexpr size_t kMaxPipelineDepth = std::min(
+      static_cast<size_t>(std::numeric_limits<uint32_t>::max()),
+      std::numeric_limits<size_t>::max() / 16);
+  if (pipelineDepth == 0 || pipelineDepth > kMaxPipelineDepth) {
+    CLOGF(
+        ERR,
+        "MCCL_NVL_MULTIMEM_PIPELINE_DEPTH must be in [1, {}], got {}",
+        kMaxPipelineDepth,
+        pipelineDepth);
+    return commInvalidArgument;
+  }
+
+  const int64_t resolvedMaxChannels = ctranPrimsResolvedMaxChannels(config);
+  const int64_t resolvedMaxBlocks = ctranPrimsResolvedMaxBlocks(config);
+  const size_t maxChannels =
+      resolvedMaxChannels > 0 ? static_cast<size_t>(resolvedMaxChannels) : 0;
+  const size_t maxBlocks =
+      resolvedMaxBlocks > 0 ? static_cast<size_t>(resolvedMaxBlocks) : 0;
+  const size_t perChannelSize =
+      alignedPerChannelSize(bufferSize, maxChannels, pipelineDepth);
+  const auto candidate = comms::prims::make_multimem_nvl_transport_config({
+      .perChannelSize = perChannelSize,
+      .pipelineDepth = pipelineDepth,
+      .maxChannels = maxChannels,
+      .maxBlocks = maxBlocks,
+      .userSignalCount = 1,
+  });
+  const auto validation = comms::prims::validate_multimem_nvl_transport_config(
+      candidate, nLocalRanks);
+  if (!validation) {
+    CLOGF(
+        ERR,
+        "CTRAN-PRIMS: invalid NVL multimem config: {} (bufferSize={} perChannelSize={} pipelineDepth={} maxChannels={} maxBlocks={})",
+        validation.errorMessage,
+        bufferSize,
+        candidate.perChannelSize,
+        candidate.pipelineDepth,
+        candidate.maxChannels,
+        candidate.maxBlocks);
+    return commInvalidArgument;
+  }
+
+  multimemConfig = candidate;
+  return commSuccess;
+}
+
 commResult_t ctran::ctranPreparePipesTrace(
     CtranComm* comm,
     comms::prims::PipesTraceHandle& trace) {
@@ -136,54 +188,23 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     const size_t nvlDataBufferSize =
         nvlMaxNumChannels * config.nvlConfig.perChannelSize;
 
-    // The multimem staging window is decoupled from the P2P shared devbuf: a
-    // larger window means fewer staging rounds, which is the dominant cnvlmm
-    // throughput lever at large sizes. Falls back to the P2P size when the
-    // dedicated cvar is 0. Computed before the enable guard so setting only the
-    // multimem cvar (with the P2P devbuf at 0) is sufficient to enable the
-    // path.
-    const size_t multimemDevbufSize = MCCL_NVL_MULTIMEM_BUFSIZE > 0
-        ? static_cast<size_t>(MCCL_NVL_MULTIMEM_BUFSIZE)
-        : nvlSharedDevbufSize;
+    // The multimem staging window is independent of the P2P shared devbuf.
+    // A larger window means fewer staging rounds, which is the dominant
+    // cnvlmm throughput lever at large sizes. A zero size disables multimem.
+    const size_t multimemDevbufSize =
+        static_cast<size_t>(MCCL_NVL_MULTIMEM_BUFSIZE);
     if (comm->statex_->nLocalRanks() > 2 && multimemDevbufSize > 0) {
-      const std::size_t multimemPipelineDepth =
-          std::max<std::size_t>(1, config.nvlConfig.pipelineDepth);
-      const auto resolvedMaxChannels = ctranPrimsResolvedMaxChannels(pc);
-      const auto resolvedMaxBlocks = ctranPrimsResolvedMaxBlocks(pc);
-      const size_t multimemMaxChannels = resolvedMaxChannels > 0
-          ? static_cast<size_t>(resolvedMaxChannels)
-          : 0;
-      const size_t multimemMaxBlocks =
-          resolvedMaxBlocks > 0 ? static_cast<size_t>(resolvedMaxBlocks) : 0;
-      if (multimemMaxBlocks > multimemMaxChannels) {
-        CLOGF(
-            ERR,
-            "CTRAN-PRIMS: invalid multimem config; maxBlocks={} exceeds maxChannels={}",
-            multimemMaxBlocks,
-            multimemMaxChannels);
-        return commInvalidArgument;
+      comms::prims::MultimemNvlTransportConfig multimemConfig{};
+      if (const auto result = ctran::ctranBuildMultimemNvlTransportConfig(
+              pc,
+              multimemDevbufSize,
+              comm->statex_->nLocalRanks(),
+              multimemConfig);
+          result != commSuccess) {
+        return result;
       }
-      const size_t multimemPerChannelSize = alignedPerChannelSize(
-          multimemDevbufSize, multimemMaxChannels, multimemPipelineDepth);
-      if (multimemPerChannelSize == 0) {
-        CLOGF(
-            ERR,
-            "CTRAN-PRIMS: invalid multimem config; devbufSize={} maxChannels={} pipelineDepth={} cannot produce aligned perChannelSize",
-            multimemDevbufSize,
-            multimemMaxChannels,
-            multimemPipelineDepth);
-        return commInvalidArgument;
-      }
-
       config.nvlConfig.enableMultimem = true;
-      config.nvlConfig.multimem =
-          comms::prims::make_multimem_nvl_transport_config({
-              .perChannelSize = multimemPerChannelSize,
-              .pipelineDepth = multimemPipelineDepth,
-              .maxChannels = multimemMaxChannels,
-              .maxBlocks = multimemMaxBlocks,
-              .userSignalCount = 1,
-          });
+      config.nvlConfig.multimem = multimemConfig;
     }
 
     // LL128 buffer allocation for DeviceAllToAllv
@@ -409,7 +430,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
 
     CLOGF(
         INFO,
-        "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} enableMultimem={} multimemPipelineDepth={} multimemMaxChannels={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={}",
+        "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} enableMultimem={} multimemPerChannelSize={} multimemPipelineDepth={} multimemMaxChannels={} multimemMaxBlocks={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={}",
         comm->statex_->rank(),
         config.nvlConfig.pipelineDepth,
         nvlSharedDevbufSize,
@@ -418,9 +439,14 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         config.nvlConfig.perChannelSize,
         config.nvlConfig.enableMultimem,
         config.nvlConfig.enableMultimem
+            ? config.nvlConfig.multimem.perChannelSize
+            : 0,
+        config.nvlConfig.enableMultimem
             ? config.nvlConfig.multimem.pipelineDepth
             : 0,
         config.nvlConfig.enableMultimem ? config.nvlConfig.multimem.maxChannels
+                                        : 0,
+        config.nvlConfig.enableMultimem ? config.nvlConfig.multimem.maxBlocks
                                         : 0,
         hierAgOverlapEnabled,
         config.disableIb,

--- a/comms/ctran/CtranPipes.h
+++ b/comms/ctran/CtranPipes.h
@@ -14,6 +14,7 @@
 
 class CtranComm;
 class CtranAlgo;
+struct ctranPrimsConfig;
 
 inline size_t ctranEffectiveP2pNvlSharedDevbufSize(int nLocalRanks) {
   uint64_t size = NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE;
@@ -38,7 +39,17 @@ bool ctranPrimsEnabled(const CtranComm* comm);
 commResult_t ctranInitPipesResources(CtranAlgo* algo);
 
 #if defined(ENABLE_PRIMS)
+namespace comms::prims {
+struct MultimemNvlTransportConfig;
+} // namespace comms::prims
+
 namespace ctran {
+
+commResult_t ctranBuildMultimemNvlTransportConfig(
+    const ctranPrimsConfig& config,
+    size_t bufferSize,
+    int nLocalRanks,
+    comms::prims::MultimemNvlTransportConfig& multimemConfig);
 
 commResult_t ctranPreparePipesTrace(
     CtranComm* comm,

--- a/comms/ctran/CtranPipes.h
+++ b/comms/ctran/CtranPipes.h
@@ -8,12 +8,14 @@
 
 #if defined(ENABLE_PRIMS)
 #include "comms/prims/trace/PipesTraceTypes.h"
+#include "comms/prims/transport/nvl/MultiPeerNvlTransport.h"
 #endif // defined(ENABLE_PRIMS)
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 class CtranComm;
 class CtranAlgo;
+struct ctranPipesConfig;
 
 inline size_t ctranEffectiveP2pNvlSharedDevbufSize(int nLocalRanks) {
   uint64_t size = NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE;
@@ -28,8 +30,8 @@ inline size_t ctranEffectiveP2pNvlSharedDevbufSize(int nLocalRanks) {
 // exchange() is deferred to ctranInitPipesResources().
 commResult_t ctranInitializePipes(CtranComm* comm);
 
-// Resolve the per-communicator override, falling back to the legacy CTRAN
-// CVAR for NCCLX and standalone Ctran callers.
+// Resolve the per-communicator override, falling back to the process-wide
+// CTRAN CVAR for NCCLX and standalone Ctran callers.
 bool ctranPrimsEnabled(const CtranComm* comm);
 
 // Wire SharedResource staging buffers as external data buffers to
@@ -39,6 +41,13 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo);
 
 #if defined(ENABLE_PRIMS)
 namespace ctran {
+
+commResult_t ctranApplyMultimemConfig(
+    const ctranPipesConfig& config,
+    const comms::prims::MultimemNvlTransportConfig& fallbackConfig,
+    size_t topologyDataBufferSize,
+    int nLocalRanks,
+    comms::prims::MultiPeerNvlTransportConfig& nvlConfig);
 
 commResult_t ctranPreparePipesTrace(
     CtranComm* comm,

--- a/comms/ctran/tests/CtranCommTest.cc
+++ b/comms/ctran/tests/CtranCommTest.cc
@@ -79,7 +79,7 @@ TEST(CtranCommTest, PrimsPolicyIsPerCommunicator) {
   EXPECT_FALSE(ctranPrimsEnabled(&ncclxComm));
 }
 
-TEST(CtranCommTest, ExplicitPrimsDisableDoesNotAffectLegacyPolicy) {
+TEST(CtranCommTest, ExplicitPrimsDisableDoesNotAffectProcessDefault) {
   auto abort = comms::fault_tolerance::createAbort(/*enabled=*/true);
   const bool savedUsePipes = NCCL_CTRAN_USE_PIPES;
   NCCL_CTRAN_USE_PIPES = true;
@@ -92,5 +92,97 @@ TEST(CtranCommTest, ExplicitPrimsDisableDoesNotAffectLegacyPolicy) {
   EXPECT_FALSE(ctranPrimsEnabled(&mcclComm));
   EXPECT_TRUE(ctranPrimsEnabled(&ncclxComm));
 }
+
+#if defined(ENABLE_PRIMS)
+TEST(CtranApplyMultimemConfigTest, UsesFallbackConfig) {
+  const comms::prims::MultimemNvlTransportConfig fallback{
+      .dataBufferSize = 4096,
+      .userSignalCount = 1,
+      .pipelineDepth = 2,
+      .maxGroups = 4,
+  };
+  comms::prims::MultiPeerNvlTransportConfig nvlConfig{};
+
+  EXPECT_EQ(
+      ctranApplyMultimemConfig(
+          ctranPipesConfig{}, fallback, 8192, 4, nvlConfig),
+      commSuccess);
+  EXPECT_TRUE(nvlConfig.enableMultimem);
+  EXPECT_EQ(nvlConfig.multimem, fallback);
+}
+
+TEST(CtranApplyMultimemConfigTest, UsesExplicitConfigExactly) {
+  const comms::prims::MultimemNvlTransportConfig fallback{
+      .dataBufferSize = 4096,
+      .userSignalCount = 1,
+      .pipelineDepth = 2,
+      .maxGroups = 4,
+  };
+  const comms::prims::MultimemNvlTransportConfig explicitConfig{
+      .dataBufferSize = 8192,
+      .userSignalCount = 3,
+      .pipelineDepth = 4,
+      .maxGroups = 8,
+  };
+  const ctranPipesConfig pipesConfig{.multimemConfig = explicitConfig};
+  comms::prims::MultiPeerNvlTransportConfig nvlConfig{};
+
+  EXPECT_EQ(
+      ctranApplyMultimemConfig(pipesConfig, fallback, 16384, 4, nvlConfig),
+      commSuccess);
+  EXPECT_TRUE(nvlConfig.enableMultimem);
+  EXPECT_EQ(nvlConfig.multimem, explicitConfig);
+}
+
+TEST(CtranApplyMultimemConfigTest, ResolvesTopologyDataBufferSize) {
+  const comms::prims::MultimemNvlTransportConfig explicitConfig{
+      .dataBufferSize = 0,
+      .userSignalCount = 1,
+      .pipelineDepth = 2,
+      .maxGroups = 4,
+  };
+  const ctranPipesConfig pipesConfig{.multimemConfig = explicitConfig};
+  comms::prims::MultiPeerNvlTransportConfig nvlConfig{};
+
+  EXPECT_EQ(
+      ctranApplyMultimemConfig(pipesConfig, explicitConfig, 8192, 4, nvlConfig),
+      commSuccess);
+  EXPECT_EQ(nvlConfig.multimem.dataBufferSize, 8192);
+}
+
+TEST(CtranApplyMultimemConfigTest, RejectsInvalidConfigWithoutMutation) {
+  const comms::prims::MultimemNvlTransportConfig invalidConfig{
+      .dataBufferSize = 4096,
+      .userSignalCount = 1,
+      .pipelineDepth = 2,
+      .maxGroups = 0,
+  };
+  const ctranPipesConfig pipesConfig{.multimemConfig = invalidConfig};
+  comms::prims::MultiPeerNvlTransportConfig nvlConfig{};
+  const auto original = nvlConfig;
+
+  EXPECT_EQ(
+      ctranApplyMultimemConfig(pipesConfig, invalidConfig, 4096, 4, nvlConfig),
+      commInvalidArgument);
+  EXPECT_EQ(nvlConfig.enableMultimem, original.enableMultimem);
+  EXPECT_EQ(nvlConfig.multimem, original.multimem);
+}
+
+TEST(CtranApplyMultimemConfigTest, LeavesTwoRankTransportDisabled) {
+  const comms::prims::MultimemNvlTransportConfig invalidConfig{
+      .dataBufferSize = 4096,
+      .userSignalCount = 1,
+      .pipelineDepth = 2,
+      .maxGroups = 0,
+  };
+  const ctranPipesConfig pipesConfig{.multimemConfig = invalidConfig};
+  comms::prims::MultiPeerNvlTransportConfig nvlConfig{};
+
+  EXPECT_EQ(
+      ctranApplyMultimemConfig(pipesConfig, invalidConfig, 4096, 2, nvlConfig),
+      commSuccess);
+  EXPECT_FALSE(nvlConfig.enableMultimem);
+}
+#endif // defined(ENABLE_PRIMS)
 
 } // namespace ctran::testing

--- a/comms/ctran/tests/CtranCommTest.cc
+++ b/comms/ctran/tests/CtranCommTest.cc
@@ -3,9 +3,15 @@
 #include <folly/ScopeGuard.h>
 #include <gtest/gtest.h>
 
+#include <cstdint>
+#include <limits>
+
 #include "comms/common/fault_tolerance/Abort.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/CtranPipes.h"
+#if defined(ENABLE_PRIMS)
+#include "comms/prims/transport/nvl/MultimemNvlTransportConfig.h"
+#endif
 #include "comms/utils/cvars/nccl_cvars.h"
 
 namespace ctran::testing {
@@ -128,5 +134,68 @@ TEST(CtranCommTest, ExplicitPrimsDisableDoesNotAffectLegacyPolicy) {
   EXPECT_FALSE(ctranPrimsEnabled(&mcclComm));
   EXPECT_TRUE(ctranPrimsEnabled(&ncclxComm));
 }
+
+#if defined(ENABLE_PRIMS)
+TEST(CtranBuildMultimemConfigTest, UsesDedicatedDepthAndBufferSize) {
+  const auto savedMultimemDepth = MCCL_NVL_MULTIMEM_PIPELINE_DEPTH;
+  const auto savedP2pDepth = NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH;
+  auto restoreCvars = folly::makeGuard([&] {
+    MCCL_NVL_MULTIMEM_PIPELINE_DEPTH = savedMultimemDepth;
+    NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH = savedP2pDepth;
+  });
+  MCCL_NVL_MULTIMEM_PIPELINE_DEPTH = 3;
+  NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH = 7;
+
+  comms::prims::MultimemNvlTransportConfig config{};
+  EXPECT_EQ(
+      ctranBuildMultimemNvlTransportConfig(
+          ctranPrimsConfig{.maxChannels = 4, .maxBlocks = 2},
+          /*bufferSize=*/4096,
+          /*nLocalRanks=*/4,
+          config),
+      commSuccess);
+  EXPECT_EQ(config.pipelineDepth, 3);
+  EXPECT_EQ(config.maxChannels, 4);
+  EXPECT_EQ(config.maxBlocks, 2);
+  EXPECT_EQ(config.perChannelSize, 1008);
+  EXPECT_EQ(config.userSignalCount, 1);
+}
+
+TEST(CtranBuildMultimemConfigTest, RejectsZeroBufferSize) {
+  const auto savedMultimemDepth = MCCL_NVL_MULTIMEM_PIPELINE_DEPTH;
+  auto restoreCvars = folly::makeGuard(
+      [&] { MCCL_NVL_MULTIMEM_PIPELINE_DEPTH = savedMultimemDepth; });
+  MCCL_NVL_MULTIMEM_PIPELINE_DEPTH = 4;
+
+  comms::prims::MultimemNvlTransportConfig config{};
+  EXPECT_EQ(
+      ctranBuildMultimemNvlTransportConfig(
+          ctranPrimsConfig{.maxChannels = 8, .maxBlocks = 3},
+          /*bufferSize=*/0,
+          /*nLocalRanks=*/4,
+          config),
+      commInvalidArgument);
+}
+
+TEST(CtranBuildMultimemConfigTest, RejectsInvalidDedicatedDepth) {
+  const auto savedMultimemDepth = MCCL_NVL_MULTIMEM_PIPELINE_DEPTH;
+  auto restoreCvars = folly::makeGuard(
+      [&] { MCCL_NVL_MULTIMEM_PIPELINE_DEPTH = savedMultimemDepth; });
+
+  comms::prims::MultimemNvlTransportConfig config{};
+  for (const size_t invalidDepth :
+       {size_t{0},
+        static_cast<size_t>(std::numeric_limits<uint32_t>::max()) + 1}) {
+    MCCL_NVL_MULTIMEM_PIPELINE_DEPTH = invalidDepth;
+    EXPECT_EQ(
+        ctranBuildMultimemNvlTransportConfig(
+            ctranPrimsConfig{.maxChannels = 4, .maxBlocks = 2},
+            /*bufferSize=*/4096,
+            /*nLocalRanks=*/4,
+            config),
+        commInvalidArgument);
+  }
+}
+#endif // defined(ENABLE_PRIMS)
 
 } // namespace ctran::testing

--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -156,6 +156,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMulticastAllocation.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/MultimemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/NvlMemExchange.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultimemNvlTransportConfig.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultimemNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerTransport.cc

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -176,6 +176,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMulticastAllocation.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/MultimemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/NvlMemExchange.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultimemNvlTransportConfig.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultimemNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerTransport.cc

--- a/comms/prims/memory/NvlMemExchange.h
+++ b/comms/prims/memory/NvlMemExchange.h
@@ -38,7 +38,7 @@ namespace comms::prims {
 struct MulticastExchangeContract {
   uint64_t protocol{0};
   uint64_t version{0};
-  std::array<uint64_t, 4> parameters{};
+  std::array<uint64_t, 5> parameters{};
 
   bool operator==(const MulticastExchangeContract& other) const {
     return protocol == other.protocol && version == other.version &&

--- a/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cc
+++ b/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cc
@@ -1,0 +1,34 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include "comms/prims/tests/MultimemNvlStageLayoutTrapTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+#ifndef STAGE_LAYOUT_TRAP_CASE
+#error "STAGE_LAYOUT_TRAP_CASE must select one isolated trap case"
+#endif
+
+namespace comms::prims::tests {
+
+TEST(MultimemNvlStageLayoutTrapTest, InvalidGeometryTraps) {
+  int deviceCount = 0;
+  CUDACHECK_TEST(cudaGetDeviceCount(&deviceCount));
+  if (deviceCount == 0) {
+    GTEST_SKIP() << "No CUDA devices available";
+  }
+  CUDACHECK_TEST(cudaSetDevice(0));
+
+  test::launchStageLayoutTrap(
+      static_cast<test::StageLayoutTrapCase>(STAGE_LAYOUT_TRAP_CASE));
+  const auto error = cudaDeviceSynchronize();
+  EXPECT_TRUE(
+      error == cudaErrorIllegalInstruction || error == cudaErrorAssert ||
+      error == cudaErrorLaunchFailure)
+      << cudaGetErrorString(error);
+
+  EXPECT_EQ(cudaDeviceReset(), cudaSuccess);
+}
+
+} // namespace comms::prims::tests

--- a/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cu
+++ b/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cu
@@ -13,17 +13,18 @@ namespace {
 
 __global__ void stageLayoutTrapKernel(StageLayoutTrapCase testCase) {
   constexpr uint32_t kNvlRanks = 4;
-  constexpr uint32_t kExpectedSignalsPerLane =
-      multimem_staging_signals_per_lane(kNvlRanks);
+  constexpr uint32_t kPipelineDepth = 1;
+  constexpr uint32_t kExpectedSignalsPerChannel = static_cast<uint32_t>(
+      multimem_staging_signals_per_channel(kNvlRanks, kPipelineDepth));
   SignalState signal;
   const uint32_t localSignalCount =
       testCase == StageLayoutTrapCase::InsufficientLocalSignals
-      ? kExpectedSignalsPerLane - 1
-      : kExpectedSignalsPerLane;
+      ? kExpectedSignalsPerChannel - 1
+      : kExpectedSignalsPerChannel;
   const uint32_t multimemSignalCount =
       testCase == StageLayoutTrapCase::InsufficientMultimemSignals
-      ? kExpectedSignalsPerLane - 1
-      : kExpectedSignalsPerLane;
+      ? kExpectedSignalsPerChannel - 1
+      : kExpectedSignalsPerChannel;
   MultimemNvlTransportDevice transport{
       .localData = reinterpret_cast<char*>(1),
       .multimemData = reinterpret_cast<char*>(1),
@@ -34,9 +35,9 @@ __global__ void stageLayoutTrapKernel(StageLayoutTrapCase testCase) {
       .dataBufferSize = 64,
       .nvlRank = 0,
       .nvlRanks = kNvlRanks,
-      .pipelineDepth = 1,
+      .pipelineDepth = kPipelineDepth,
       .maxChannels = 1,
-      .signalsPerLane = kExpectedSignalsPerLane,
+      .signalsPerChannel = kExpectedSignalsPerChannel,
   };
   switch (testCase) {
     case StageLayoutTrapCase::ZeroGeometry:
@@ -44,8 +45,8 @@ __global__ void stageLayoutTrapKernel(StageLayoutTrapCase testCase) {
       break;
     case StageLayoutTrapCase::TooManyGroups:
       break;
-    case StageLayoutTrapCase::BadSignalsPerLane:
-      transport.signalsPerLane = kExpectedSignalsPerLane - 1;
+    case StageLayoutTrapCase::BadSignalsPerChannel:
+      transport.signalsPerChannel = kExpectedSignalsPerChannel - 1;
       break;
     case StageLayoutTrapCase::InsufficientLocalSignals:
     case StageLayoutTrapCase::InsufficientMultimemSignals:

--- a/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cu
+++ b/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cu
@@ -1,0 +1,60 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/tests/MultimemNvlStageLayoutTrapTest.cuh"
+
+#include "comms/prims/core/SignalState.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlStageLayout.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+__global__ void stageLayoutTrapKernel(StageLayoutTrapCase testCase) {
+  SignalState signal;
+  const uint32_t localSignalCount =
+      testCase == StageLayoutTrapCase::InsufficientLocalSignals ? 11 : 12;
+  const uint32_t multimemSignalCount =
+      testCase == StageLayoutTrapCase::InsufficientMultimemSignals ? 11 : 12;
+  MultimemNvlTransportDevice transport{
+      .localData = reinterpret_cast<char*>(1),
+      .multimemData = reinterpret_cast<char*>(1),
+      .internalLocalSignals =
+          DeviceSpan<SignalState>(&signal, localSignalCount),
+      .internalMultimemSignals =
+          DeviceSpan<SignalState>(&signal, multimemSignalCount),
+      .dataBufferSize = 64,
+      .pipelineDepth = 1,
+      .maxGroups = 1,
+      .signalsPerLane = 12,
+      .nvlRank = 0,
+      .nvlRanks = 4,
+  };
+  switch (testCase) {
+    case StageLayoutTrapCase::ZeroGeometry:
+      transport.pipelineDepth = 0;
+      break;
+    case StageLayoutTrapCase::TooManyGroups:
+      break;
+    case StageLayoutTrapCase::BadSignalsPerLane:
+      transport.signalsPerLane = 11;
+      break;
+    case StageLayoutTrapCase::InsufficientLocalSignals:
+    case StageLayoutTrapCase::InsufficientMultimemSignals:
+      break;
+  }
+  auto group = make_block_group();
+  static_cast<void>(multimem::make_stage_layout<uint32_t>(transport, group));
+}
+
+} // namespace
+
+void launchStageLayoutTrap(StageLayoutTrapCase testCase) {
+  const uint32_t numGroups =
+      testCase == StageLayoutTrapCase::TooManyGroups ? 2 : 1;
+  stageLayoutTrapKernel<<<numGroups, 32>>>(
+      testCase); // NOLINT(facebook-cuda-safe-kernel-call-check)
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cuh
+++ b/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cuh
@@ -10,7 +10,7 @@ namespace comms::prims::test {
 enum class StageLayoutTrapCase : uint32_t {
   ZeroGeometry,
   TooManyGroups,
-  BadSignalsPerLane,
+  BadSignalsPerChannel,
   InsufficientLocalSignals,
   InsufficientMultimemSignals,
 };

--- a/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cuh
+++ b/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cuh
@@ -1,0 +1,19 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+namespace comms::prims::test {
+
+enum class StageLayoutTrapCase : uint32_t {
+  ZeroGeometry,
+  TooManyGroups,
+  BadSignalsPerLane,
+  InsufficientLocalSignals,
+  InsufficientMultimemSignals,
+};
+
+void launchStageLayoutTrap(StageLayoutTrapCase testCase);
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -12,6 +12,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -76,11 +77,13 @@ bool allRanksMultimemEligible(
 MultimemNvlTransportConfig makeConfig(
     std::size_t dataBufferSize,
     uint32_t userSignalCount = 1,
-    uint32_t internalSignalCount = 0) {
+    std::size_t pipelineDepth = 0,
+    std::size_t maxGroups = 0) {
   MultimemNvlTransportConfig config{};
   config.dataBufferSize = dataBufferSize;
   config.userSignalCount = userSignalCount;
-  config.internalSignalCount = internalSignalCount;
+  config.pipelineDepth = pipelineDepth;
+  config.maxGroups = maxGroups;
   return config;
 }
 
@@ -171,6 +174,70 @@ TEST_F(
       GpuMemHandler::isMultimemSupported(localRank));
 }
 
+TEST(MultimemNvlTransportConfigTest, DerivesUserOnlyConfiguration) {
+  EXPECT_EQ(checked_multimem_internal_signal_count(makeConfig(256), 4), 0);
+}
+
+TEST(MultimemNvlTransportConfigTest, DerivesStagingOnlyConfiguration) {
+  EXPECT_EQ(
+      checked_multimem_internal_signal_count(makeConfig(256, 0, 2, 2), 4), 48);
+}
+
+TEST(MultimemNvlTransportConfigTest, DerivesMixedConfiguration) {
+  EXPECT_EQ(
+      checked_multimem_internal_signal_count(makeConfig(256, 7, 2, 2), 4), 48);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsPartialStagingGeometry) {
+  EXPECT_EQ(
+      checked_multimem_internal_signal_count(makeConfig(256, 1, 2, 0), 4),
+      std::nullopt);
+  EXPECT_EQ(
+      checked_multimem_internal_signal_count(makeConfig(256, 1, 0, 2), 4),
+      std::nullopt);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsInvalidRankCount) {
+  EXPECT_EQ(
+      checked_multimem_internal_signal_count(makeConfig(256, 1, 1, 1), 0),
+      std::nullopt);
+  EXPECT_EQ(
+      checked_multimem_internal_signal_count(
+          makeConfig(std::numeric_limits<std::size_t>::max(), 1, 1, 1),
+          std::numeric_limits<int>::max()),
+      std::nullopt);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsInsufficientDataCapacity) {
+  EXPECT_EQ(
+      checked_multimem_internal_signal_count(makeConfig(255, 1, 2, 2), 4),
+      std::nullopt);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsInternalSignalOverflow) {
+  EXPECT_EQ(
+      checked_multimem_internal_signal_count(
+          makeConfig(
+              std::numeric_limits<std::size_t>::max(),
+              1,
+              std::numeric_limits<std::size_t>::max(),
+              2),
+          4),
+      std::nullopt);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsTotalSignalOverflow) {
+  EXPECT_EQ(
+      checked_multimem_internal_signal_count(
+          makeConfig(
+              std::numeric_limits<std::size_t>::max(),
+              std::numeric_limits<uint32_t>::max(),
+              1,
+              1),
+          4),
+      std::nullopt);
+}
+
 TEST_F(MultimemNvlTransportTestFixture, MultiPeerMultimemDisabled) {
   // No multimem-eligibility skip here: with enableMultimem=false this test
   // exercises only the disabled-path API (hasMultimemNvlTransport() == false,
@@ -214,6 +281,7 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
+      .multimem = makeConfig(4096, 1, 1, 1),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -246,6 +314,7 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
+      .multimem = makeConfig(4096, 1, 1, 1),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -271,6 +340,7 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
+      .multimem = makeConfig(4096, 1, 1, 1),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -297,6 +367,7 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
+      .multimem = makeConfig(4096, 1, 1, 1),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -329,6 +400,7 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
+      .multimem = makeConfig(4096, 1, 1, 1),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -381,7 +453,8 @@ TEST_F(
           MultimemNvlTransportConfig{
               .dataBufferSize = 0,
               .userSignalCount = 1,
-              .internalSignalCount = 1,
+              .pipelineDepth = 1,
+              .maxGroups = 1,
           },
   };
   MultiPeerNvlTransport transport(
@@ -426,7 +499,8 @@ TEST_F(
             MultimemNvlTransportConfig{
                 .dataBufferSize = 4096,
                 .userSignalCount = 1,
-                .internalSignalCount = 1,
+                .pipelineDepth = 1,
+                .maxGroups = 1,
             },
     };
     MultiPeerNvlTransport transport(
@@ -479,7 +553,8 @@ TEST_F(
           MultimemNvlTransportConfig{
               .dataBufferSize = 4096,
               .userSignalCount = 1,
-              .internalSignalCount = 1,
+              .pipelineDepth = 1,
+              .maxGroups = 1,
           },
   };
   MultiPeerNvlTransport transport(
@@ -531,7 +606,8 @@ TEST_F(
           MultimemNvlTransportConfig{
               .dataBufferSize = 4096,
               .userSignalCount = 1,
-              .internalSignalCount = 1,
+              .pipelineDepth = 1,
+              .maxGroups = 1,
           },
   };
   MultiPeerNvlTransport transport(
@@ -570,7 +646,8 @@ TEST_F(
               .dataBufferSize =
                   kBytesPerRank * static_cast<std::size_t>(numRanks),
               .userSignalCount = 1,
-              .internalSignalCount = 1,
+              .pipelineDepth = 1,
+              .maxGroups = 1,
           },
   };
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
@@ -599,7 +676,8 @@ TEST_F(
               .dataBufferSize =
                   globalRank == 0 ? std::size_t{0} : std::size_t{4096},
               .userSignalCount = 1,
-              .internalSignalCount = 1,
+              .pipelineDepth = 1,
+              .maxGroups = 1,
           },
   };
   MultiPeerNvlTransport transport(
@@ -656,13 +734,14 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
 
   constexpr std::size_t kDataBytes = 8192;
   constexpr uint32_t kUserSignals = 2;
-  constexpr uint32_t kInternalSignals = 3;
+  const uint32_t internalSignals =
+      multimem_staging_signals_per_lane(static_cast<uint32_t>(numRanks));
 
   MultimemNvlTransport transport(
       bootstrap,
       globalRank,
       identityRankMap(numRanks),
-      makeConfig(kDataBytes, kUserSignals, kInternalSignals));
+      makeConfig(kDataBytes, kUserSignals, 1, 1));
 
   transport.exchange();
   auto handle = transport.getDeviceTransport();
@@ -676,13 +755,16 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
   EXPECT_EQ(handle.dataBufferSize, kDataBytes);
   EXPECT_EQ(handle.userLocalSignals.size(), kUserSignals);
   EXPECT_EQ(handle.userMultimemSignals.size(), kUserSignals);
-  EXPECT_EQ(handle.internalLocalSignals.size(), kInternalSignals);
-  EXPECT_EQ(handle.internalMultimemSignals.size(), kInternalSignals);
+  EXPECT_EQ(handle.internalLocalSignals.size(), internalSignals);
+  EXPECT_EQ(handle.internalMultimemSignals.size(), internalSignals);
+  EXPECT_EQ(handle.pipelineDepth, 1);
+  EXPECT_EQ(handle.maxGroups, 1);
+  EXPECT_EQ(handle.signalsPerLane, internalSignals);
 
   EXPECT_EQ(transport.getAllocatedDataBufferSize(), kDataBytes);
   EXPECT_EQ(
       transport.getAllocatedSignalBufferSize(),
-      getSignalBufferSize(static_cast<int>(kUserSignals + kInternalSignals)));
+      getSignalBufferSize(static_cast<int>(kUserSignals + internalSignals)));
 
   // Idempotency: a second exchange() must be a no-op.
   auto* firstMultimemBase = handle.multimemData;
@@ -708,13 +790,11 @@ TEST_F(MultimemNvlTransportTestFixture, UserAndInternalSignalSpansAreDisjoint) {
   }
 
   constexpr uint32_t kUserSignals = 4;
-  constexpr uint32_t kInternalSignals = 2;
-
   MultimemNvlTransport transport(
       bootstrap,
       globalRank,
       identityRankMap(numRanks),
-      makeConfig(/*dataBufferSize=*/4096, kUserSignals, kInternalSignals));
+      makeConfig(/*dataBufferSize=*/4096, kUserSignals, 1, 1));
   transport.exchange();
   auto handle = transport.getDeviceTransport();
 
@@ -734,6 +814,70 @@ TEST_F(MultimemNvlTransportTestFixture, UserAndInternalSignalSpansAreDisjoint) {
   EXPECT_LE(
       handle.userMultimemSignals.data() + handle.userMultimemSignals.size(),
       handle.internalMultimemSignals.data());
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(MultimemNvlTransportTestFixture, StageLayoutUsesTransportGeometry) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_stage_layout_geometry");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kDataBytes = 12 * 1024;
+  constexpr uint32_t kPipelineDepth = 2;
+  constexpr uint32_t kMaxGroups = 4;
+  constexpr uint32_t kActiveGroups = 3;
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(kDataBytes, 0, kPipelineDepth, kMaxGroups));
+  transport.exchange();
+
+  test::StageLayoutResult* deviceResults = nullptr;
+  CUDACHECK_TEST(
+      cudaMalloc(&deviceResults, kMaxGroups * sizeof(test::StageLayoutResult)));
+  test::launchStageLayout(
+      transport.getDeviceTransport(), deviceResults, kActiveGroups);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<test::StageLayoutResult> results(kActiveGroups);
+  CUDACHECK_TEST(cudaMemcpy(
+      results.data(),
+      deviceResults,
+      results.size() * sizeof(test::StageLayoutResult),
+      cudaMemcpyDeviceToHost));
+  const uint64_t signalsPerLane =
+      multimem_staging_signals_per_lane(static_cast<uint32_t>(numRanks));
+  for (uint32_t group = 0; group < kActiveGroups; ++group) {
+    EXPECT_EQ(results[group].groupBeginBytes, group * 4096);
+    EXPECT_EQ(results[group].stagingBytes, 2048);
+    EXPECT_EQ(
+        results[group].signalBase, group * kPipelineDepth * signalsPerLane);
+    EXPECT_EQ(results[group].signalsPerLane, signalsPerLane);
+    EXPECT_EQ(results[group].pipelineDepth, kPipelineDepth);
+  }
+
+  test::launchStageLayout(
+      transport.getDeviceTransport(), deviceResults, kMaxGroups);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  results.resize(kMaxGroups);
+  CUDACHECK_TEST(cudaMemcpy(
+      results.data(),
+      deviceResults,
+      results.size() * sizeof(test::StageLayoutResult),
+      cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaFree(deviceResults));
+  for (uint32_t group = 0; group < kMaxGroups; ++group) {
+    EXPECT_EQ(results[group].groupBeginBytes, group * 3072);
+    EXPECT_EQ(results[group].stagingBytes, 1536);
+    EXPECT_EQ(
+        results[group].signalBase, group * kPipelineDepth * signalsPerLane);
+  }
 
   ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 }
@@ -875,12 +1019,15 @@ std::unique_ptr<MultimemNvlTransport> makeExchangedTransport(
     int numRanks,
     int localRank,
     uint32_t userSignalCount,
-    uint32_t internalSignalCount) {
+    bool needsInternalSignals) {
   if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
     return nullptr;
   }
   auto config = makeConfig(
-      /*dataBufferSize=*/4096, userSignalCount, internalSignalCount);
+      /*dataBufferSize=*/4096,
+      userSignalCount,
+      needsInternalSignals ? 1 : 0,
+      needsInternalSignals ? 1 : 0);
   auto transport = std::make_unique<MultimemNvlTransport>(
       bootstrap, globalRank, identityRankMap(numRanks), config);
   transport->exchange();
@@ -903,7 +1050,7 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceUserSignalSetBroadcasts) {
       numRanks,
       localRank,
       /*userSignalCount=*/1,
-      /*internalSignalCount=*/0);
+      /*needsInternalSignals=*/false);
   if (!transport) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
   }
@@ -939,7 +1086,7 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceUserSignalAddAccumulates) {
       numRanks,
       localRank,
       /*userSignalCount=*/1,
-      /*internalSignalCount=*/0);
+      /*needsInternalSignals=*/false);
   if (!transport) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
   }
@@ -973,7 +1120,7 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceInternalSignalSetBroadcasts) {
       numRanks,
       localRank,
       /*userSignalCount=*/1,
-      /*internalSignalCount=*/1);
+      /*needsInternalSignals=*/true);
   if (!transport) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
   }
@@ -1009,7 +1156,7 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceInternalSignalAddAccumulates) {
       numRanks,
       localRank,
       /*userSignalCount=*/1,
-      /*internalSignalCount=*/1);
+      /*needsInternalSignals=*/true);
   if (!transport) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
   }
@@ -1045,7 +1192,7 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceUserAndInternalSignalsIsolated) {
       numRanks,
       localRank,
       /*userSignalCount=*/1,
-      /*internalSignalCount=*/1);
+      /*needsInternalSignals=*/true);
   if (!transport) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
   }
@@ -1110,7 +1257,7 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceLoadReduceCoversPublicTypes) {
       numRanks,
       localRank,
       /*userSignalCount=*/1,
-      /*internalSignalCount=*/1);
+      /*needsInternalSignals=*/true);
   if (!transport) {
     GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
   }

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -9,6 +9,7 @@
 #include <folly/futures/Future.h>
 #include <folly/init/Init.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -78,12 +79,15 @@ MultimemNvlTransportConfig makeConfig(
     uint32_t userSignalCount = 1,
     std::size_t pipelineDepth = 0,
     std::size_t maxChannels = 0) {
-  MultimemNvlTransportConfig config{};
-  config.dataBufferSize = dataBufferSize;
-  config.userSignalCount = userSignalCount;
-  config.pipelineDepth = pipelineDepth;
-  config.maxChannels = maxChannels;
-  return config;
+  const std::size_t effectiveMaxChannels =
+      std::max<std::size_t>(1, maxChannels);
+  return make_multimem_nvl_transport_config({
+      .perChannelSize = dataBufferSize / effectiveMaxChannels,
+      .pipelineDepth = pipelineDepth,
+      .maxChannels = effectiveMaxChannels,
+      .maxBlocks = maxChannels,
+      .userSignalCount = userSignalCount,
+  });
 }
 
 using meta::comms::testing::MockBootstrap;
@@ -384,13 +388,13 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
-      .multimem =
-          MultimemNvlTransportConfig{
-              .dataBufferSize = 0,
-              .userSignalCount = 1,
-              .pipelineDepth = 1,
-              .maxChannels = 1,
-          },
+      .multimem = make_multimem_nvl_transport_config({
+          .perChannelSize = 0,
+          .pipelineDepth = 1,
+          .maxChannels = 1,
+          .maxBlocks = 1,
+          .userSignalCount = 1,
+      }),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -430,13 +434,13 @@ TEST_F(
         .p2pSignalCount = 1,
         .maxNumChannels = 0,
         .enableMultimem = true,
-        .multimem =
-            MultimemNvlTransportConfig{
-                .dataBufferSize = 4096,
-                .userSignalCount = 1,
-                .pipelineDepth = 1,
-                .maxChannels = 1,
-            },
+        .multimem = make_multimem_nvl_transport_config({
+            .perChannelSize = 4096,
+            .pipelineDepth = 1,
+            .maxChannels = 1,
+            .maxBlocks = 1,
+            .userSignalCount = 1,
+        }),
     };
     MultiPeerNvlTransport transport(
         globalRank, numRanks, localRank, bootstrap, config);
@@ -484,13 +488,13 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
-      .multimem =
-          MultimemNvlTransportConfig{
-              .dataBufferSize = 4096,
-              .userSignalCount = 1,
-              .pipelineDepth = 1,
-              .maxChannels = 1,
-          },
+      .multimem = make_multimem_nvl_transport_config({
+          .perChannelSize = 4096,
+          .pipelineDepth = 1,
+          .maxChannels = 1,
+          .maxBlocks = 1,
+          .userSignalCount = 1,
+      }),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -537,13 +541,13 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
-      .multimem =
-          MultimemNvlTransportConfig{
-              .dataBufferSize = 4096,
-              .userSignalCount = 1,
-              .pipelineDepth = 1,
-              .maxChannels = 1,
-          },
+      .multimem = make_multimem_nvl_transport_config({
+          .perChannelSize = 4096,
+          .pipelineDepth = 1,
+          .maxChannels = 1,
+          .maxBlocks = 1,
+          .userSignalCount = 1,
+      }),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -576,14 +580,13 @@ TEST_F(
       // channels (a nonzero maxNumChannels requires pipelineDepth >= 1).
       .maxNumChannels = 0,
       .enableMultimem = true,
-      .multimem =
-          MultimemNvlTransportConfig{
-              .dataBufferSize =
-                  kBytesPerRank * static_cast<std::size_t>(numRanks),
-              .userSignalCount = 1,
-              .pipelineDepth = 1,
-              .maxChannels = 1,
-          },
+      .multimem = make_multimem_nvl_transport_config({
+          .perChannelSize = kBytesPerRank * static_cast<std::size_t>(numRanks),
+          .pipelineDepth = 1,
+          .maxChannels = 1,
+          .maxBlocks = 1,
+          .userSignalCount = 1,
+      }),
   };
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   EXPECT_FALSE(transport.hasMultimemNvlTransport());
@@ -606,14 +609,14 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
-      .multimem =
-          MultimemNvlTransportConfig{
-              .dataBufferSize =
-                  globalRank == 0 ? std::size_t{0} : std::size_t{4096},
-              .userSignalCount = 1,
-              .pipelineDepth = 1,
-              .maxChannels = 1,
-          },
+      .multimem = make_multimem_nvl_transport_config({
+          .perChannelSize =
+              globalRank == 0 ? std::size_t{0} : std::size_t{4096},
+          .pipelineDepth = 1,
+          .maxChannels = 1,
+          .maxBlocks = 1,
+          .userSignalCount = 1,
+      }),
   };
   MultiPeerNvlTransport transport(
       globalRank, numRanks, localRank, bootstrap, config);
@@ -710,6 +713,42 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
   ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 }
 
+TEST_F(MultimemNvlTransportTestFixture, ExchangeSupportsDataOnlyConfiguration) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_exchange_data_only");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kDataBytes = 4096;
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(
+          kDataBytes,
+          /*userSignalCount=*/0,
+          /*pipelineDepth=*/0,
+          /*maxChannels=*/0));
+
+  transport.exchange();
+  const auto handle = transport.getDeviceTransport();
+
+  EXPECT_EQ(handle.dataBufferSize, kDataBytes);
+  EXPECT_TRUE(handle.userLocalSignals.empty());
+  EXPECT_TRUE(handle.userMultimemSignals.empty());
+  EXPECT_TRUE(handle.internalLocalSignals.empty());
+  EXPECT_TRUE(handle.internalMultimemSignals.empty());
+  EXPECT_EQ(handle.pipelineDepth, 0);
+  EXPECT_EQ(handle.maxChannels, 1);
+  EXPECT_EQ(handle.signalsPerLane, 0);
+  EXPECT_EQ(transport.getAllocatedSignalBufferSize(), 0);
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
 TEST_F(
     MultimemNvlTransportTestFixture,
     ExchangeRejectsMismatchedStagingGeometry) {
@@ -736,9 +775,43 @@ TEST_F(
     EXPECT_NE(
         message.find("ranks disagree on multicast setup"), std::string::npos)
         << message;
-    EXPECT_NE(message.find("parameters=[8192, 1, 2, 4]"), std::string::npos)
+    EXPECT_NE(message.find("parameters=[2048, 2, 4, 4, 1]"), std::string::npos)
         << message;
-    EXPECT_NE(message.find("parameters=[8192, 1, 4, 2]"), std::string::npos)
+    EXPECT_NE(message.find("parameters=[4096, 4, 2, 2, 1]"), std::string::npos)
+        << message;
+  }
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    ExchangeRejectsMismatchedUserSignalLayout) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_exchange_mismatched_user_signals");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  const uint32_t userSignalCount = globalRank == 0 ? 1 : 2;
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(8192, userSignalCount, 1, 1));
+  try {
+    transport.exchange();
+    FAIL() << "expected setup agreement to reject mismatched signal layout";
+  } catch (const std::runtime_error& ex) {
+    const std::string message = ex.what();
+    EXPECT_NE(
+        message.find("ranks disagree on multicast setup"), std::string::npos)
+        << message;
+    EXPECT_NE(message.find("parameters=[8192, 1, 1, 1, 1]"), std::string::npos)
+        << message;
+    EXPECT_NE(message.find("parameters=[8192, 1, 1, 1, 2]"), std::string::npos)
         << message;
   }
 

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -177,6 +177,37 @@ TEST_F(
       GpuMemHandler::isMultimemSupported(localRank));
 }
 
+TEST_F(MultimemNvlTransportTestFixture, SignalFreeConfigurationConstructs) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_signal_free_construction");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(/*dataBufferSize=*/4096, /*userSignalCount=*/0));
+  transport.exchange();
+  const auto handle = transport.getDeviceTransport();
+
+  EXPECT_EQ(transport.getAllocatedDataBufferSize(), 4096);
+  EXPECT_EQ(transport.getAllocatedSignalBufferSize(), 0);
+  EXPECT_NE(handle.localData, nullptr);
+  EXPECT_NE(handle.multimemData, nullptr);
+  EXPECT_TRUE(handle.userLocalSignals.empty());
+  EXPECT_TRUE(handle.userMultimemSignals.empty());
+  EXPECT_TRUE(handle.internalLocalSignals.empty());
+  EXPECT_TRUE(handle.internalMultimemSignals.empty());
+  EXPECT_EQ(handle.pipelineDepth, 0);
+  EXPECT_EQ(handle.maxChannels, 1);
+  EXPECT_EQ(handle.signalsPerChannel, 0);
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
 TEST_F(MultimemNvlTransportTestFixture, MultiPeerMultimemDisabled) {
   // No multimem-eligibility skip here: with enableMultimem=false this test
   // exercises only the disabled-path API (hasMultimemNvlTransport() == false,
@@ -672,8 +703,8 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
 
   constexpr std::size_t kDataBytes = 8192;
   constexpr uint32_t kUserSignals = 2;
-  const uint32_t internalSignals =
-      multimem_staging_signals_per_lane(static_cast<uint32_t>(numRanks));
+  const uint64_t internalSignals = multimem_staging_signals_per_channel(
+      static_cast<uint32_t>(numRanks), /*pipelineDepth=*/1);
 
   MultimemNvlTransport transport(
       bootstrap,
@@ -697,7 +728,7 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
   EXPECT_EQ(handle.internalMultimemSignals.size(), internalSignals);
   EXPECT_EQ(handle.pipelineDepth, 1);
   EXPECT_EQ(handle.maxChannels, 1);
-  EXPECT_EQ(handle.signalsPerLane, internalSignals);
+  EXPECT_EQ(handle.signalsPerChannel, internalSignals);
 
   EXPECT_EQ(transport.getAllocatedDataBufferSize(), kDataBytes);
   EXPECT_EQ(
@@ -743,7 +774,7 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSupportsDataOnlyConfiguration) {
   EXPECT_TRUE(handle.internalMultimemSignals.empty());
   EXPECT_EQ(handle.pipelineDepth, 0);
   EXPECT_EQ(handle.maxChannels, 1);
-  EXPECT_EQ(handle.signalsPerLane, 0);
+  EXPECT_EQ(handle.signalsPerChannel, 0);
   EXPECT_EQ(transport.getAllocatedSignalBufferSize(), 0);
 
   ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
@@ -894,14 +925,29 @@ TEST_F(MultimemNvlTransportTestFixture, StageLayoutUsesTransportGeometry) {
       deviceResults,
       results.size() * sizeof(test::StageLayoutResult),
       cudaMemcpyDeviceToHost));
-  const uint64_t signalsPerLane =
-      multimem_staging_signals_per_lane(static_cast<uint32_t>(numRanks));
+  const uint64_t signalsPerChannel = multimem_staging_signals_per_channel(
+      static_cast<uint32_t>(numRanks), kPipelineDepth);
   for (uint32_t group = 0; group < kActiveGroups; ++group) {
-    EXPECT_EQ(results[group].groupBeginBytes, group * 4096);
+    const uint64_t channelBase = group * signalsPerChannel;
+    const uint64_t laneBase = channelBase + 3 * numRanks;
+    EXPECT_EQ(results[group].channelBeginBytes, group * 4096);
     EXPECT_EQ(results[group].stagingBytes, 2048);
-    EXPECT_EQ(
-        results[group].signalBase, group * kPipelineDepth * signalsPerLane);
-    EXPECT_EQ(results[group].signalsPerLane, signalsPerLane);
+    EXPECT_EQ(results[group].signalBase, channelBase);
+    EXPECT_EQ(results[group].signalsPerChannel, signalsPerChannel);
+    EXPECT_EQ(results[group].readyFirst, channelBase);
+    EXPECT_EQ(results[group].readyLast, channelBase + numRanks - 1);
+    EXPECT_EQ(results[group].ackFirst, channelBase + numRanks);
+    EXPECT_EQ(results[group].ackLast, channelBase + 2 * numRanks - 1);
+    EXPECT_EQ(results[group].consumedFirst, channelBase + 2 * numRanks);
+    EXPECT_EQ(results[group].consumedLast, channelBase + 3 * numRanks - 1);
+    EXPECT_EQ(results[group].lane0ReadyCounter, laneBase);
+    EXPECT_EQ(results[group].lane0ReadyEpoch, laneBase + 1);
+    EXPECT_EQ(results[group].lane0AckCounter, laneBase + 2);
+    EXPECT_EQ(results[group].lane0AckEpoch, laneBase + 3);
+    EXPECT_EQ(results[group].lane1ReadyCounter, laneBase + 4);
+    EXPECT_EQ(results[group].lane1ReadyEpoch, laneBase + 5);
+    EXPECT_EQ(results[group].lane1AckCounter, laneBase + 6);
+    EXPECT_EQ(results[group].lane1AckEpoch, laneBase + 7);
     EXPECT_EQ(results[group].pipelineDepth, kPipelineDepth);
   }
 
@@ -916,10 +962,9 @@ TEST_F(MultimemNvlTransportTestFixture, StageLayoutUsesTransportGeometry) {
       cudaMemcpyDeviceToHost));
   CUDACHECK_TEST(cudaFree(deviceResults));
   for (uint32_t group = 0; group < kMaxChannels; ++group) {
-    EXPECT_EQ(results[group].groupBeginBytes, group * 3072);
+    EXPECT_EQ(results[group].channelBeginBytes, group * 3072);
     EXPECT_EQ(results[group].stagingBytes, 1536);
-    EXPECT_EQ(
-        results[group].signalBase, group * kPipelineDepth * signalsPerLane);
+    EXPECT_EQ(results[group].signalBase, group * signalsPerChannel);
   }
 
   ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -175,67 +175,176 @@ TEST_F(
 }
 
 TEST(MultimemNvlTransportConfigTest, DerivesUserOnlyConfiguration) {
-  EXPECT_EQ(checked_multimem_internal_signal_count(makeConfig(256), 4), 0);
+  const auto validation =
+      validate_multimem_nvl_transport_config(makeConfig(256), 4);
+  EXPECT_TRUE(validation);
+  EXPECT_EQ(validation.internalSignalCount, 0);
 }
 
 TEST(MultimemNvlTransportConfigTest, DerivesStagingOnlyConfiguration) {
-  EXPECT_EQ(
-      checked_multimem_internal_signal_count(makeConfig(256, 0, 2, 2), 4), 48);
+  const auto validation =
+      validate_multimem_nvl_transport_config(makeConfig(256, 0, 2, 2), 4);
+  EXPECT_TRUE(validation);
+  EXPECT_EQ(validation.internalSignalCount, 48);
 }
 
 TEST(MultimemNvlTransportConfigTest, DerivesMixedConfiguration) {
-  EXPECT_EQ(
-      checked_multimem_internal_signal_count(makeConfig(256, 7, 2, 2), 4), 48);
+  const auto validation =
+      validate_multimem_nvl_transport_config(makeConfig(256, 7, 2, 2), 4);
+  EXPECT_TRUE(validation);
+  EXPECT_EQ(validation.internalSignalCount, 48);
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsPartialStagingGeometry) {
   EXPECT_EQ(
-      checked_multimem_internal_signal_count(makeConfig(256, 1, 2, 0), 4),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(256, 1, 2, 0), 4).error,
+      MultimemNvlTransportConfigError::PartialStagingGeometry);
   EXPECT_EQ(
-      checked_multimem_internal_signal_count(makeConfig(256, 1, 0, 2), 4),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(256, 1, 0, 2), 4).error,
+      MultimemNvlTransportConfigError::PartialStagingGeometry);
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsInvalidRankCount) {
   EXPECT_EQ(
-      checked_multimem_internal_signal_count(makeConfig(256, 1, 1, 1), 0),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(256, 1, 1, 1), 0).error,
+      MultimemNvlTransportConfigError::InvalidRankCount);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsMissingDataBuffer) {
   EXPECT_EQ(
-      checked_multimem_internal_signal_count(
-          makeConfig(std::numeric_limits<std::size_t>::max(), 1, 1, 1),
-          std::numeric_limits<int>::max()),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(0, 1), 4).error,
+      MultimemNvlTransportConfigError::MissingDataBuffer);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsNoSignalSlots) {
+  EXPECT_EQ(
+      validate_multimem_nvl_transport_config(makeConfig(256, 0), 4).error,
+      MultimemNvlTransportConfigError::NoSignalSlots);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsMaxGroupsOutOfRange) {
+  EXPECT_EQ(
+      validate_multimem_nvl_transport_config(
+          makeConfig(
+              std::numeric_limits<std::size_t>::max(),
+              1,
+              1,
+              static_cast<std::size_t>(std::numeric_limits<uint32_t>::max()) +
+                  1),
+          4)
+          .error,
+      MultimemNvlTransportConfigError::GeometryOutOfRange);
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsInsufficientDataCapacity) {
   EXPECT_EQ(
-      checked_multimem_internal_signal_count(makeConfig(255, 1, 2, 2), 4),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(255, 1, 2, 2), 4).error,
+      MultimemNvlTransportConfigError::InsufficientDataCapacity);
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsInternalSignalOverflow) {
   EXPECT_EQ(
-      checked_multimem_internal_signal_count(
+      validate_multimem_nvl_transport_config(
           makeConfig(
               std::numeric_limits<std::size_t>::max(),
               1,
               std::numeric_limits<std::size_t>::max(),
               2),
-          4),
-      std::nullopt);
+          4)
+          .error,
+      MultimemNvlTransportConfigError::GeometryOutOfRange);
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsTotalSignalOverflow) {
   EXPECT_EQ(
-      checked_multimem_internal_signal_count(
+      validate_multimem_nvl_transport_config(
           makeConfig(
               std::numeric_limits<std::size_t>::max(),
               std::numeric_limits<uint32_t>::max(),
               1,
               1),
-          4),
-      std::nullopt);
+          4)
+          .error,
+      MultimemNvlTransportConfigError::SignalCountOverflow);
+}
+
+TEST(MultimemNvlTransportConfigTest, ResolvesExplicitOverride) {
+  const auto overrideConfig = makeConfig(8192, 3, 2, 2);
+  const auto fallbackConfig = makeConfig(4096, 1, 1, 1);
+  const auto resolved = resolve_multimem_nvl_transport_config(
+      overrideConfig, fallbackConfig, 2048, 4);
+
+  EXPECT_TRUE(resolved);
+  EXPECT_EQ(resolved.config, overrideConfig);
+  EXPECT_EQ(resolved.internalSignalCount, 48);
+}
+
+TEST(MultimemNvlTransportConfigTest, ResolvesAbsentOverrideFromFallback) {
+  const auto fallbackConfig = makeConfig(4096, 1, 1, 1);
+  const auto resolved = resolve_multimem_nvl_transport_config(
+      std::nullopt, fallbackConfig, 2048, 4);
+
+  EXPECT_TRUE(resolved);
+  EXPECT_EQ(resolved.config, fallbackConfig);
+}
+
+TEST(MultimemNvlTransportConfigTest, ResolvesTopologyDataBufferSize) {
+  const auto overrideConfig = makeConfig(0, 1, 1, 1);
+  const auto resolved = resolve_multimem_nvl_transport_config(
+      overrideConfig, makeConfig(4096, 1, 1, 1), 2048, 4);
+
+  EXPECT_TRUE(resolved);
+  EXPECT_EQ(resolved.config.dataBufferSize, 2048);
+}
+
+TEST(MultimemNvlTransportConfigTest, ReturnsAttemptedConfigOnError) {
+  const auto overrideConfig = makeConfig(8192, 1, 0, 1);
+  const auto resolved = resolve_multimem_nvl_transport_config(
+      overrideConfig, makeConfig(4096, 1, 1, 1), 2048, 4);
+
+  EXPECT_FALSE(resolved);
+  EXPECT_EQ(resolved.config, overrideConfig);
+  EXPECT_EQ(
+      resolved.error, MultimemNvlTransportConfigError::PartialStagingGeometry);
+}
+
+TEST(MultimemNvlTransportConfigTest, DescribesEveryError) {
+  EXPECT_STREQ(
+      multimem_nvl_transport_config_error_string(
+          MultimemNvlTransportConfigError::None),
+      "none");
+  EXPECT_STREQ(
+      multimem_nvl_transport_config_error_string(
+          MultimemNvlTransportConfigError::MissingDataBuffer),
+      "data buffer size must be non-zero");
+  EXPECT_STREQ(
+      multimem_nvl_transport_config_error_string(
+          MultimemNvlTransportConfigError::InvalidRankCount),
+      "NVL rank count must be positive");
+  EXPECT_STREQ(
+      multimem_nvl_transport_config_error_string(
+          MultimemNvlTransportConfigError::PartialStagingGeometry),
+      "pipeline depth and maximum groups must both be zero or non-zero");
+  EXPECT_STREQ(
+      multimem_nvl_transport_config_error_string(
+          MultimemNvlTransportConfigError::GeometryOutOfRange),
+      "pipeline depth or maximum groups exceeds UINT32_MAX");
+  EXPECT_STREQ(
+      multimem_nvl_transport_config_error_string(
+          MultimemNvlTransportConfigError::InsufficientDataCapacity),
+      "data buffer is too small for the staging geometry");
+  EXPECT_STREQ(
+      multimem_nvl_transport_config_error_string(
+          MultimemNvlTransportConfigError::SignalCountOverflow),
+      "signal count exceeds INT_MAX");
+  EXPECT_STREQ(
+      multimem_nvl_transport_config_error_string(
+          MultimemNvlTransportConfigError::NoSignalSlots),
+      "at least one signal slot is required");
+  EXPECT_STREQ(
+      multimem_nvl_transport_config_error_string(
+          static_cast<MultimemNvlTransportConfigError>(-1)),
+      "unknown configuration error");
 }
 
 TEST_F(MultimemNvlTransportTestFixture, MultiPeerMultimemDisabled) {

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -266,6 +266,38 @@ TEST_F(
 
 TEST_F(
     MultimemNvlTransportTestFixture,
+    MultiPeerCollectivelyRejectsAsymmetricEnablement) {
+  using ::testing::_;
+
+  auto mock = std::make_shared<StrictMockBootstrap>();
+  EXPECT_CALL(*mock, allGather(_, sizeof(int), 0, 2))
+      .WillOnce([](void* buf, int, int, int) {
+        auto* eligible = static_cast<int*>(buf);
+        EXPECT_EQ(eligible[0], 0);
+        eligible[1] = 1;
+        return folly::makeSemiFuture(0);
+      });
+
+  MultiPeerNvlTransportConfig config{
+      .pipelineDepth = 0,
+      .p2pSignalCount = 1,
+      .maxNumChannels = 0,
+      .enableMultimem = false,
+  };
+  MultiPeerNvlTransport transport(
+      /*myRank=*/0,
+      /*nRanks=*/2,
+      std::shared_ptr<meta::comms::IBootstrap>(mock),
+      config);
+
+  EXPECT_FALSE(transport.hasMultimemNvlTransport());
+  EXPECT_FALSE(transport.initializeMultimemNvlTransportIfEligible());
+  EXPECT_FALSE(transport.initializeMultimemNvlTransportIfEligible());
+  EXPECT_FALSE(transport.hasMultimemNvlTransport());
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
     MultiPeerRemoteEligibilityQueryErrorPoisonsRetry) {
   using ::testing::_;
 

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -124,11 +124,26 @@ __global__ void stageLayoutKernel(
   auto group = make_block_group();
   const auto layout = multimem::make_stage_layout<uint32_t>(transport, group);
   if (group.is_leader()) {
+    const int lastRank = layout.nvlRanks - 1;
     results[group.group_id] = StageLayoutResult{
-        .groupBeginBytes = layout.groupBeginBytes,
+        .channelBeginBytes = layout.channelBeginBytes,
         .stagingBytes = layout.stagingBytes,
         .signalBase = layout.signalBase,
-        .signalsPerLane = layout.signalsPerLane,
+        .signalsPerChannel = layout.signalsPerChannel,
+        .readyFirst = multimem::ready_signal_id(layout, 0),
+        .readyLast = multimem::ready_signal_id(layout, lastRank),
+        .ackFirst = multimem::ack_signal_id(layout, 0),
+        .ackLast = multimem::ack_signal_id(layout, lastRank),
+        .consumedFirst = multimem::consumed_signal_id(layout, 0),
+        .consumedLast = multimem::consumed_signal_id(layout, lastRank),
+        .lane0ReadyCounter = multimem::ready_counter_signal_id(layout, 0),
+        .lane0ReadyEpoch = multimem::ready_epoch_signal_id(layout, 0),
+        .lane0AckCounter = multimem::ack_counter_signal_id(layout, 0),
+        .lane0AckEpoch = multimem::ack_epoch_signal_id(layout, 0),
+        .lane1ReadyCounter = multimem::ready_counter_signal_id(layout, 1),
+        .lane1ReadyEpoch = multimem::ready_epoch_signal_id(layout, 1),
+        .lane1AckCounter = multimem::ack_counter_signal_id(layout, 1),
+        .lane1AckEpoch = multimem::ack_epoch_signal_id(layout, 1),
         .pipelineDepth = layout.pipelineDepth,
     };
   }

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -7,6 +7,7 @@
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/tests/Checks.h"
 #include "comms/prims/transport/nvl/MultimemNvlReduce.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlStageLayout.cuh"
 
 namespace comms::prims::test {
 
@@ -115,6 +116,22 @@ __global__ void loadReduceKernel(
       reinterpret_cast<const T*>(transport.multimemData) + sourceOffsetElems;
   multimem::load_reduce_at<T, multimem::MultimemRedOp::Add, kAccF32>(
       group, output, source, elems);
+}
+
+__global__ void stageLayoutKernel(
+    MultimemNvlTransportDevice transport,
+    StageLayoutResult* results) {
+  auto group = make_block_group();
+  const auto layout = multimem::make_stage_layout<uint32_t>(transport, group);
+  if (group.is_leader()) {
+    results[group.group_id] = StageLayoutResult{
+        .groupBeginBytes = layout.groupBeginBytes,
+        .stagingBytes = layout.stagingBytes,
+        .signalBase = layout.signalBase,
+        .signalsPerLane = layout.signalsPerLane,
+        .pipelineDepth = layout.pipelineDepth,
+    };
+  }
 }
 
 template <typename T>
@@ -265,6 +282,15 @@ void launchLoadReduce(
       return launchLoadReduceTyped<__nv_bfloat16>(
           transport, accF32, output, elems, sourceOffsetElems, stream);
   }
+}
+
+void launchStageLayout(
+    MultimemNvlTransportDevice transport,
+    StageLayoutResult* results,
+    uint32_t numGroups,
+    cudaStream_t stream) {
+  stageLayoutKernel<<<numGroups, 32, 0, stream>>>(transport, results);
+  PIPES_KERNEL_LAUNCH_CHECK();
 }
 
 } // namespace comms::prims::test

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -15,10 +15,24 @@ namespace comms::prims::test {
 enum class MultimemReductionTestType { Float, Int32, Float16, Bfloat16 };
 
 struct StageLayoutResult {
-  std::size_t groupBeginBytes;
+  std::size_t channelBeginBytes;
   std::size_t stagingBytes;
   uint64_t signalBase;
-  uint64_t signalsPerLane;
+  uint64_t signalsPerChannel;
+  uint64_t readyFirst;
+  uint64_t readyLast;
+  uint64_t ackFirst;
+  uint64_t ackLast;
+  uint64_t consumedFirst;
+  uint64_t consumedLast;
+  uint64_t lane0ReadyCounter;
+  uint64_t lane0ReadyEpoch;
+  uint64_t lane0AckCounter;
+  uint64_t lane0AckEpoch;
+  uint64_t lane1ReadyCounter;
+  uint64_t lane1ReadyEpoch;
+  uint64_t lane1AckCounter;
+  uint64_t lane1AckEpoch;
   uint32_t pipelineDepth;
 };
 

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -14,6 +14,14 @@ namespace comms::prims::test {
 
 enum class MultimemReductionTestType { Float, Int32, Float16, Bfloat16 };
 
+struct StageLayoutResult {
+  std::size_t groupBeginBytes;
+  std::size_t stagingBytes;
+  uint64_t signalBase;
+  uint64_t signalsPerLane;
+  uint32_t pipelineDepth;
+};
+
 // Each launch is one warp -> one ThreadGroup. The leader performs the
 // multimem PTX store; the remaining lanes sync alongside it. Callers must
 // cudaStreamSynchronize (or cudaDeviceSynchronize) before observing effects
@@ -93,6 +101,12 @@ void launchLoadReduce(
     void* output,
     std::size_t elems,
     std::size_t sourceOffsetElems,
+    cudaStream_t stream = nullptr);
+
+void launchStageLayout(
+    MultimemNvlTransportDevice transport,
+    StageLayoutResult* results,
+    uint32_t numGroups,
     cudaStream_t stream = nullptr);
 
 } // namespace comms::prims::test

--- a/comms/prims/tests/MultimemNvlTransportValidationTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportValidationTest.cc
@@ -112,7 +112,7 @@ TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroDataBufferSize) {
             /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
             config);
       },
-      "dataBufferSize must be non-zero");
+      "data buffer size must be non-zero");
 }
 
 TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroSignalCount) {
@@ -147,7 +147,7 @@ TEST(
             /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
             config);
       },
-      "invalid staging geometry or capacity");
+      "signal count exceeds INT_MAX");
 }
 
 TEST(

--- a/comms/prims/tests/MultimemNvlTransportValidationTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportValidationTest.cc
@@ -8,6 +8,7 @@
 #include <limits>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -29,27 +30,72 @@ void expectRuntimeErrorContains(Fn&& fn, const std::string& expected) {
 }
 
 MultimemNvlTransportConfig makeConfig(
-    std::size_t dataBufferSize,
+    std::size_t perChannelSize,
     uint32_t userSignalCount = 1,
     std::size_t pipelineDepth = 0,
-    std::size_t maxChannels = 0) {
-  MultimemNvlTransportConfig config{};
-  config.dataBufferSize = dataBufferSize;
-  config.userSignalCount = userSignalCount;
-  config.pipelineDepth = pipelineDepth;
-  config.maxChannels = maxChannels;
-  return config;
+    std::size_t maxChannels = 1,
+    std::size_t maxBlocks = 0) {
+  return make_multimem_nvl_transport_config({
+      .perChannelSize = perChannelSize,
+      .pipelineDepth = pipelineDepth,
+      .maxChannels = maxChannels,
+      .maxBlocks = maxBlocks,
+      .userSignalCount = userSignalCount,
+  });
 }
 
 } // namespace
 
 TEST(MultimemNvlTransportConfigTest, DerivesUserOnlyConfiguration) {
+  const auto validation =
+      validate_multimem_nvl_transport_config(makeConfig(256), 4);
+  EXPECT_TRUE(validation);
+  EXPECT_EQ(validation.internalSignalCount, 0);
+}
+
+TEST(
+    MultimemNvlTransportConfigTest,
+    DerivesDataAndSignalsFromChannelCapacityAndIndependentBlockLimit) {
+  const auto config = make_multimem_nvl_transport_config({
+      .perChannelSize = 1024,
+      .pipelineDepth = 2,
+      .maxChannels = 8,
+      .maxBlocks = 3,
+      .userSignalCount = 1,
+  });
+
+  const auto validation = validate_multimem_nvl_transport_config(config, 4);
+
+  ASSERT_TRUE(validation);
+  EXPECT_EQ(validation.dataBufferSize, 8192);
+  EXPECT_EQ(validation.internalSignalCount, 192);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsDataBufferMultiplicationOverflow) {
+  const auto config = make_multimem_nvl_transport_config({
+      .perChannelSize = std::numeric_limits<std::size_t>::max(),
+      .pipelineDepth = 0,
+      .maxChannels = 2,
+      .maxBlocks = 0,
+      .userSignalCount = 1,
+  });
+
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(makeConfig(256), 4), 0);
+      validate_multimem_nvl_transport_config(config, 4).errorMessage,
+      "per-channel size times maximum channels overflows");
 }
 
 TEST(MultimemNvlTransportConfigTest, PreservesDefaultUserSignalCount) {
   EXPECT_EQ(MultimemNvlTransportConfig{}.userSignalCount, 1);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsLegacyPositionalConstruction) {
+  EXPECT_FALSE((std::is_constructible_v<
+                MultimemNvlTransportConfig,
+                std::size_t,
+                uint32_t,
+                std::size_t,
+                std::size_t>));
 }
 
 TEST(MultimemNvlTransportDeviceTest, PreservesLegacyPositionalRankFields) {
@@ -60,47 +106,99 @@ TEST(MultimemNvlTransportDeviceTest, PreservesLegacyPositionalRankFields) {
 }
 
 TEST(MultimemNvlTransportConfigTest, DerivesStagingOnlyConfiguration) {
-  EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(256, 0, 2, 2), 4),
-      48);
+  const auto validation =
+      validate_multimem_nvl_transport_config(makeConfig(128, 0, 2, 2, 2), 4);
+  EXPECT_TRUE(validation);
+  EXPECT_EQ(validation.internalSignalCount, 48);
 }
 
 TEST(MultimemNvlTransportConfigTest, DerivesMixedConfiguration) {
-  EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(256, 7, 2, 2), 4),
-      48);
+  const auto validation =
+      validate_multimem_nvl_transport_config(makeConfig(128, 7, 2, 2, 2), 4);
+  EXPECT_TRUE(validation);
+  EXPECT_EQ(validation.internalSignalCount, 48);
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsPartialStagingGeometry) {
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(256, 1, 2, 0), 4),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(256, 1, 2, 1, 0), 4)
+          .errorMessage,
+      "pipeline depth and maximum blocks must both be zero or non-zero");
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(256, 1, 0, 2), 4),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(128, 1, 0, 2, 2), 4)
+          .errorMessage,
+      "pipeline depth and maximum blocks must both be zero or non-zero");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsInvalidRankCount) {
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(256, 1, 1, 1), 0),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(256, 1, 1, 1, 1), 0)
+          .errorMessage,
+      "NVL rank count must be positive");
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsMissingPerChannelSize) {
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(std::numeric_limits<std::size_t>::max(), 1, 1, 1),
-          std::numeric_limits<int>::max()),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(0, 1), 4).errorMessage,
+      "per-channel size must be non-zero");
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsMissingMaxChannels) {
+  const auto config = make_multimem_nvl_transport_config({
+      .perChannelSize = 256,
+      .pipelineDepth = 0,
+      .maxChannels = 0,
+      .maxBlocks = 0,
+      .userSignalCount = 1,
+  });
+  EXPECT_EQ(
+      validate_multimem_nvl_transport_config(config, 4).errorMessage,
+      "maximum channels must be non-zero");
+}
+
+TEST(MultimemNvlTransportConfigTest, AcceptsNoSignalSlots) {
+  const auto validation =
+      validate_multimem_nvl_transport_config(makeConfig(256, 0), 4);
+
+  EXPECT_TRUE(validation);
+  EXPECT_EQ(validation.dataBufferSize, 256);
+  EXPECT_EQ(validation.internalSignalCount, 0);
+  EXPECT_EQ(validation.signalRegionOffset, 256);
+  EXPECT_EQ(validation.backingAllocationSize, 256);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsMaxBlocksAboveMaxChannels) {
+  const auto config = make_multimem_nvl_transport_config({
+      .perChannelSize = 64,
+      .pipelineDepth = 1,
+      .maxChannels = 2,
+      .maxBlocks = 3,
+      .userSignalCount = 1,
+  });
+
+  EXPECT_EQ(
+      validate_multimem_nvl_transport_config(config, 4).errorMessage,
+      "maximum blocks must not exceed maximum channels");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsInsufficientDataCapacity) {
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(255, 1, 2, 2), 4),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(64, 1, 2, 2, 2), 4)
+          .errorMessage,
+      "data buffer is too small for the staging geometry");
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsMisalignedPerChannelSize) {
+  const auto config = make_multimem_nvl_transport_config({
+      .perChannelSize = 48,
+      .pipelineDepth = 2,
+      .maxChannels = 4,
+      .maxBlocks = 1,
+      .userSignalCount = 1,
+  });
+  EXPECT_EQ(
+      validate_multimem_nvl_transport_config(config, 4).errorMessage,
+      "per-channel size must be divisible by pipeline depth times 16");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsInternalSignalOverflow) {
@@ -111,51 +209,76 @@ TEST(MultimemNvlTransportConfigTest, RejectsInternalSignalOverflow) {
       std::numeric_limits<int>::max() / kSignalsPerLane + 1;
   const std::size_t requiredDataBytes = pipelineDepth * kRanks * 16;
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(requiredDataBytes, 1, pipelineDepth, 1), kRanks),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(
+          makeConfig(requiredDataBytes, 1, pipelineDepth, 1, 1), kRanks)
+          .errorMessage,
+      "signal count exceeds INT_MAX");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsPipelineDepthOutsideDeviceRange) {
   constexpr std::size_t kOutsideDeviceRange =
       static_cast<std::size_t>(std::numeric_limits<uint32_t>::max()) + 1;
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
+      validate_multimem_nvl_transport_config(
           makeConfig(
-              std::numeric_limits<std::size_t>::max(),
-              1,
-              kOutsideDeviceRange,
-              1),
-          4),
-      std::nullopt);
+              /*perChannelSize=*/16,
+              /*userSignalCount=*/1,
+              /*pipelineDepth=*/kOutsideDeviceRange,
+              /*maxChannels=*/1,
+              /*maxBlocks=*/1),
+          4)
+          .errorMessage,
+      "transport geometry exceeds UINT32_MAX");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsMaxChannelsOutsideDeviceRange) {
   constexpr std::size_t kOutsideDeviceRange =
       static_cast<std::size_t>(std::numeric_limits<uint32_t>::max()) + 1;
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
+      validate_multimem_nvl_transport_config(
           makeConfig(
-              std::numeric_limits<std::size_t>::max(),
-              1,
-              1,
-              kOutsideDeviceRange),
-          4),
-      std::nullopt);
+              /*perChannelSize=*/16,
+              /*userSignalCount=*/1,
+              /*pipelineDepth=*/1,
+              /*maxChannels=*/kOutsideDeviceRange,
+              /*maxBlocks=*/1),
+          4)
+          .errorMessage,
+      "transport geometry exceeds UINT32_MAX");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsTotalSignalOverflow) {
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(64, std::numeric_limits<int>::max(), 1, 1), 4),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(
+          makeConfig(64, std::numeric_limits<int>::max(), 1, 1, 1), 4)
+          .errorMessage,
+      "signal count exceeds INT_MAX");
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsDataAlignmentOverflow) {
+  EXPECT_EQ(
+      validate_multimem_nvl_transport_config(
+          makeConfig(std::numeric_limits<std::size_t>::max(), 1), 4)
+          .errorMessage,
+      "combined data and signal allocation size overflows");
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsCombinedAllocationOverflow) {
+  constexpr auto kAlignment = detail::kMultimemSignalAlignment;
+  const auto dataBufferSize =
+      std::numeric_limits<std::size_t>::max() - (kAlignment - 1);
+  EXPECT_EQ(
+      validate_multimem_nvl_transport_config(makeConfig(dataBufferSize, 1), 4)
+          .errorMessage,
+      "combined data and signal allocation size overflows");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsUserSignalCountOutsideSignedRange) {
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(64, std::numeric_limits<uint32_t>::max(), 0, 0), 4),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(
+          makeConfig(64, std::numeric_limits<uint32_t>::max()), 4)
+          .errorMessage,
+      "signal count exceeds INT_MAX");
 }
 
 // validateRankMap runs before any GPU access in the constructor; these cases
@@ -205,7 +328,8 @@ TEST(MultimemNvlTransportValidationTest, IsEligibleRequiresMoreThanTwoRanks) {
 
 TEST(MultimemNvlTransportValidationTest, CompatCtorRejectsNegativeNvlRank) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize = 1024;
+  config.perChannelSize = 1024;
+  config.maxChannels = 1;
   expectRuntimeErrorContains(
       [&] {
         MultimemNvlTransport(
@@ -216,7 +340,8 @@ TEST(MultimemNvlTransportValidationTest, CompatCtorRejectsNegativeNvlRank) {
 
 TEST(MultimemNvlTransportValidationTest, CompatCtorRejectsOutOfRangeNvlRank) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize = 1024;
+  config.perChannelSize = 1024;
+  config.maxChannels = 1;
   expectRuntimeErrorContains(
       [&] {
         MultimemNvlTransport(
@@ -229,9 +354,10 @@ TEST(MultimemNvlTransportValidationTest, CompatCtorRejectsOutOfRangeNvlRank) {
 // cudaGetDevice, so they are exercisable on CPU-only hosts with a null
 // bootstrap: none of the code paths past these throws is reached.
 
-TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroDataBufferSize) {
+TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroPerChannelSize) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize = 0; // triggers the guard
+  config.perChannelSize = 0;
+  config.maxChannels = 1;
   config.userSignalCount = 1;
   expectRuntimeErrorContains(
       [&] {
@@ -241,32 +367,18 @@ TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroDataBufferSize) {
             /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
             config);
       },
-      "dataBufferSize must be non-zero");
-}
-
-TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroSignalCount) {
-  MultimemNvlTransportConfig config{};
-  config.dataBufferSize = 1024;
-  config.userSignalCount = 0;
-  expectRuntimeErrorContains(
-      [&] {
-        MultimemNvlTransport(
-            /*bootstrap=*/nullptr,
-            /*commRank=*/0,
-            /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
-            config);
-      },
-      "at least one signal slot is required");
+      "per-channel size must be non-zero");
 }
 
 TEST(
     MultimemNvlTransportValidationTest,
     PrimaryCtorRejectsTotalSignalCountOverflow) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize = 64;
+  config.perChannelSize = 64;
   config.userSignalCount = std::numeric_limits<int>::max();
   config.pipelineDepth = 1;
   config.maxChannels = 1;
+  config.maxBlocks = 1;
   expectRuntimeErrorContains(
       [&] {
         MultimemNvlTransport(
@@ -275,14 +387,15 @@ TEST(
             /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
             config);
       },
-      "invalid staging geometry or capacity");
+      "signal count exceeds INT_MAX");
 }
 
 TEST(
     MultimemNvlTransportValidationTest,
     PrimaryCtorRejectsDataBufferAlignmentOverflow) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize = std::numeric_limits<std::size_t>::max();
+  config.perChannelSize = std::numeric_limits<std::size_t>::max();
+  config.maxChannels = 1;
   config.userSignalCount = 1;
   expectRuntimeErrorContains(
       [&] {
@@ -292,15 +405,16 @@ TEST(
             /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
             config);
       },
-      "dataBufferSize alignment overflows");
+      "combined data and signal allocation size overflows");
 }
 
 TEST(
     MultimemNvlTransportValidationTest,
     PrimaryCtorRejectsCombinedAllocationSizeOverflow) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize =
+  config.perChannelSize =
       std::numeric_limits<std::size_t>::max() - (alignof(SignalState) - 1);
+  config.maxChannels = 1;
   config.userSignalCount = 1;
   expectRuntimeErrorContains(
       [&] {
@@ -310,7 +424,7 @@ TEST(
             /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
             config);
       },
-      "combined allocation size overflows");
+      "combined data and signal allocation size overflows");
 }
 
 } // namespace comms::prims::tests

--- a/comms/prims/tests/MultimemNvlTransportValidationTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportValidationTest.cc
@@ -31,7 +31,7 @@ void expectRuntimeErrorContains(Fn&& fn, const std::string& expected) {
 
 MultimemNvlTransportConfig makeConfig(
     std::size_t perChannelSize,
-    uint32_t userSignalCount = 1,
+    uint32_t userSignalCount = 0,
     std::size_t pipelineDepth = 0,
     std::size_t maxChannels = 1,
     std::size_t maxBlocks = 0) {
@@ -48,7 +48,7 @@ MultimemNvlTransportConfig makeConfig(
 
 TEST(MultimemNvlTransportConfigTest, DerivesUserOnlyConfiguration) {
   const auto validation =
-      validate_multimem_nvl_transport_config(makeConfig(256), 4);
+      validate_multimem_nvl_transport_config(makeConfig(256, 1), 4);
   EXPECT_TRUE(validation);
   EXPECT_EQ(validation.internalSignalCount, 0);
 }
@@ -68,7 +68,15 @@ TEST(
 
   ASSERT_TRUE(validation);
   EXPECT_EQ(validation.dataBufferSize, 8192);
-  EXPECT_EQ(validation.internalSignalCount, 192);
+  EXPECT_EQ(validation.internalSignalCount, 160);
+}
+
+TEST(MultimemNvlTransportConfigTest, DefinesSignalGeometryPerChannel) {
+  EXPECT_EQ(detail::kMultimemSignalsPerPeer, 3);
+  EXPECT_EQ(detail::kMultimemSignalsPerLane, 4);
+  EXPECT_EQ(multimem_staging_signals_per_channel(4, 2), 20);
+  constexpr uint64_t kMax = std::numeric_limits<uint32_t>::max();
+  EXPECT_EQ(multimem_staging_signals_per_channel(kMax, kMax), 7 * kMax);
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsDataBufferMultiplicationOverflow) {
@@ -86,7 +94,7 @@ TEST(MultimemNvlTransportConfigTest, RejectsDataBufferMultiplicationOverflow) {
 }
 
 TEST(MultimemNvlTransportConfigTest, PreservesDefaultUserSignalCount) {
-  EXPECT_EQ(MultimemNvlTransportConfig{}.userSignalCount, 1);
+  EXPECT_EQ(MultimemNvlTransportConfig{}.userSignalCount, 0);
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsLegacyPositionalConstruction) {
@@ -109,14 +117,14 @@ TEST(MultimemNvlTransportConfigTest, DerivesStagingOnlyConfiguration) {
   const auto validation =
       validate_multimem_nvl_transport_config(makeConfig(128, 0, 2, 2, 2), 4);
   EXPECT_TRUE(validation);
-  EXPECT_EQ(validation.internalSignalCount, 48);
+  EXPECT_EQ(validation.internalSignalCount, 40);
 }
 
 TEST(MultimemNvlTransportConfigTest, DerivesMixedConfiguration) {
   const auto validation =
       validate_multimem_nvl_transport_config(makeConfig(128, 7, 2, 2, 2), 4);
   EXPECT_TRUE(validation);
-  EXPECT_EQ(validation.internalSignalCount, 48);
+  EXPECT_EQ(validation.internalSignalCount, 40);
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsPartialStagingGeometry) {
@@ -156,12 +164,13 @@ TEST(MultimemNvlTransportConfigTest, RejectsMissingMaxChannels) {
       "maximum channels must be non-zero");
 }
 
-TEST(MultimemNvlTransportConfigTest, AcceptsNoSignalSlots) {
+TEST(MultimemNvlTransportConfigTest, AcceptsSignalFreeConfiguration) {
   const auto validation =
       validate_multimem_nvl_transport_config(makeConfig(256, 0), 4);
 
-  EXPECT_TRUE(validation);
+  ASSERT_TRUE(validation);
   EXPECT_EQ(validation.dataBufferSize, 256);
+  EXPECT_EQ(validation.signalsPerChannel, 0);
   EXPECT_EQ(validation.internalSignalCount, 0);
   EXPECT_EQ(validation.signalRegionOffset, 256);
   EXPECT_EQ(validation.backingAllocationSize, 256);
@@ -203,10 +212,12 @@ TEST(MultimemNvlTransportConfigTest, RejectsMisalignedPerChannelSize) {
 
 TEST(MultimemNvlTransportConfigTest, RejectsInternalSignalOverflow) {
   constexpr std::size_t kRanks = 4;
-  constexpr std::size_t kSignalsPerLane =
-      multimem_staging_signals_per_lane(static_cast<uint32_t>(kRanks));
+  constexpr std::size_t kSignalsPerPeer = detail::kMultimemSignalsPerPeer;
+  constexpr std::size_t kSignalsPerLane = detail::kMultimemSignalsPerLane;
   const std::size_t pipelineDepth =
-      std::numeric_limits<int>::max() / kSignalsPerLane + 1;
+      (std::numeric_limits<int>::max() - kRanks * kSignalsPerPeer) /
+          kSignalsPerLane +
+      1;
   const std::size_t requiredDataBytes = pipelineDepth * kRanks * 16;
   EXPECT_EQ(
       validate_multimem_nvl_transport_config(

--- a/comms/prims/tests/MultimemNvlTransportValidationTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportValidationTest.cc
@@ -119,7 +119,6 @@ TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroSignalCount) {
   MultimemNvlTransportConfig config{};
   config.dataBufferSize = 1024;
   config.userSignalCount = 0;
-  config.internalSignalCount = 0;
   expectRuntimeErrorContains(
       [&] {
         MultimemNvlTransport(
@@ -138,7 +137,8 @@ TEST(
   MultimemNvlTransportConfig config{};
   config.dataBufferSize = 1024;
   config.userSignalCount = std::numeric_limits<uint32_t>::max();
-  config.internalSignalCount = std::numeric_limits<uint32_t>::max();
+  config.pipelineDepth = 1;
+  config.maxGroups = 1;
   expectRuntimeErrorContains(
       [&] {
         MultimemNvlTransport(
@@ -147,7 +147,7 @@ TEST(
             /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
             config);
       },
-      "signalCount too large");
+      "invalid staging geometry or capacity");
 }
 
 TEST(

--- a/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
@@ -177,7 +177,8 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
   dataBufferSize_ = dataBufferSize(config_);
   perPeerDataBufferSize_ = dataBufferSize_;
 
-  perPeerSignalBufferSize_ = getSignalBufferSize(config_.p2pSignalCount);
+  perPeerSignalBufferSize_ =
+      getSignalBufferSize(static_cast<int>(config_.p2pSignalCount));
 
   // Allocate signal buffer (always needed)
   const std::size_t totalSignalBufferSize =
@@ -216,7 +217,8 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
 
   // Conditionally allocate barrier buffer
   if (config_.p2pBarrierCount > 0) {
-    perPeerBarrierBufferSize_ = getBarrierBufferSize(config_.p2pBarrierCount);
+    perPeerBarrierBufferSize_ =
+        getBarrierBufferSize(static_cast<int>(config_.p2pBarrierCount));
     std::size_t totalBarrierSize = perPeerBarrierBufferSize_ * (nRanks_ - 1);
     barrierBufferHandler_ = std::make_unique<GpuMemHandler>(
         bootstrap_, myRank_, nRanks_, totalBarrierSize, memSharingMode_);
@@ -542,8 +544,7 @@ bool MultiPeerNvlTransport::hasMultimemNvlTransport() const {
 }
 
 bool MultiPeerNvlTransport::initializeMultimemNvlTransportIfEligible() const {
-  if (!config_.enableMultimem ||
-      multimemNvlIneligible_.load(std::memory_order_acquire)) {
+  if (multimemNvlIneligible_.load(std::memory_order_acquire)) {
     return false;
   }
   try {
@@ -579,11 +580,6 @@ void MultiPeerNvlTransport::initializeMultimemNvlTransport() const {
   if (multimemNvlTransport_) {
     return;
   }
-  if (!config_.enableMultimem) {
-    throw std::runtime_error(
-        "MultiPeerNvlTransport: multimem NVL transport is not enabled "
-        "(config.enableMultimem is false)");
-  }
   if (multimemNvlUnavailable_) {
     throw std::runtime_error(
         "MultiPeerNvlTransport: multimem NVL transport is not available: " +
@@ -593,16 +589,22 @@ void MultiPeerNvlTransport::initializeMultimemNvlTransport() const {
   std::vector<int> multimemEligible(nRanks_, 0);
   std::vector<int> multimemReady(nRanks_, 0);
   std::optional<ScopedCudaDevice> deviceGuard;
-  // A local CUDA/driver query failure is an error vote, not an early return:
-  // every rank must still enter the allGather so peers cannot hang.
-  try {
-    deviceGuard.emplace(multimemCudaDevice_);
-    multimemEligible[myRank_] =
-        MultimemNvlTransport::isEligible(nRanks_, multimemCudaDevice_)
-        ? kMultimemEligible
-        : kMultimemIneligible;
-  } catch (...) {
-    multimemEligible[myRank_] = kMultimemEligibilityError;
+  if (!config_.enableMultimem) {
+    // A disabled rank must still vote so enabled peers cannot hang in the
+    // communicator-wide eligibility agreement.
+    multimemEligible[myRank_] = kMultimemIneligible;
+  } else {
+    // A local CUDA/driver query failure is an error vote, not an early return:
+    // every rank must still enter the allGather so peers cannot hang.
+    try {
+      deviceGuard.emplace(multimemCudaDevice_);
+      multimemEligible[myRank_] =
+          MultimemNvlTransport::isEligible(nRanks_, multimemCudaDevice_)
+          ? kMultimemEligible
+          : kMultimemIneligible;
+    } catch (...) {
+      multimemEligible[myRank_] = kMultimemEligibilityError;
+    }
   }
   int eligibilityResult = 0;
   try {

--- a/comms/prims/transport/nvl/MultiPeerNvlTransport.h
+++ b/comms/prims/transport/nvl/MultiPeerNvlTransport.h
@@ -4,6 +4,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <optional>

--- a/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
@@ -63,11 +63,8 @@ struct StageLayout {
 template <typename T>
 __device__ __forceinline__ StageLayout make_stage_layout(
     const comms::prims::MultimemNvlTransportDevice& transport,
-    uint32_t pipelineDepth,
     comms::prims::ThreadGroup& group) {
-  if (pipelineDepth == 0) {
-    pipelineDepth = 1;
-  }
+  const uint32_t pipelineDepth = transport.pipelineDepth;
 
   // 16-byte (uint4) alignment for every staging-window slice, so the per-rank
   // lane offsets are 128-bit aligned and the v4 multimem.ld_reduce / store fast
@@ -88,6 +85,18 @@ __device__ __forceinline__ StageLayout make_stage_layout(
     printf(
         "NvlMultimem staging layout: invalid group_id=%u total_groups=%u\n",
         static_cast<unsigned>(group.group_id),
+        static_cast<unsigned>(group.total_groups));
+    __trap();
+  }
+  if (pipelineDepth == 0 || transport.maxGroups == 0 ||
+      transport.signalsPerLane == 0 ||
+      group.total_groups > transport.maxGroups) {
+    printf(
+        "NvlMultimem staging layout: invalid geometry depth=%u "
+        "maxGroups=%u signalsPerLane=%u total_groups=%u\n",
+        static_cast<unsigned>(pipelineDepth),
+        static_cast<unsigned>(transport.maxGroups),
+        static_cast<unsigned>(transport.signalsPerLane),
         static_cast<unsigned>(group.total_groups));
     __trap();
   }
@@ -139,14 +148,25 @@ __device__ __forceinline__ StageLayout make_stage_layout(
     __trap();
   }
 #endif
-  const uint64_t signalsPerLane = multimem_staging_signals_per_lane(
+  const uint64_t expectedSignalsPerLane = multimem_staging_signals_per_lane(
       static_cast<uint32_t>(transport.nvlRanks));
+  const uint64_t signalsPerLane = transport.signalsPerLane;
+#if defined(__CUDA_ARCH__)
+  if (signalsPerLane != expectedSignalsPerLane) {
+    printf(
+        "NvlMultimem staging layout: signalsPerLane=%llu expected=%llu\n",
+        static_cast<unsigned long long>(signalsPerLane),
+        static_cast<unsigned long long>(expectedSignalsPerLane));
+    __trap();
+  }
+#endif
   const uint64_t signalsPerGroup = detail::checked_signal_product(
       static_cast<uint64_t>(pipelineDepth), signalsPerLane);
   const uint64_t requiredSignals = detail::checked_signal_product(
       static_cast<uint64_t>(group.total_groups), signalsPerGroup);
 #if defined(__CUDA_ARCH__)
-  if (requiredSignals > transport.internalLocalSignals.size()) {
+  if (requiredSignals > transport.internalLocalSignals.size() ||
+      requiredSignals > transport.internalMultimemSignals.size()) {
     printf(
         "NvlMultimem requires %llu internal signals "
         "(available=%u, groups=%u, pipelineDepth=%u, nvlRanks=%d)\n",

--- a/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
@@ -151,8 +151,9 @@ __device__ __forceinline__ StageLayout make_stage_layout(
     __trap();
   }
 #endif
-  const uint64_t expectedSignalsPerLane = multimem_staging_signals_per_lane(
-      static_cast<uint32_t>(transport.nvlRanks));
+  const uint64_t expectedSignalsPerLane =
+      comms::prims::multimem_staging_signals_per_lane(
+          static_cast<uint32_t>(transport.nvlRanks));
   const uint64_t signalsPerLane = transport.signalsPerLane;
 #if defined(__CUDA_ARCH__)
   if (signalsPerLane != expectedSignalsPerLane) {

--- a/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
@@ -5,10 +5,10 @@
 //
 // Shared infrastructure used by all three staging paths (ReduceScatter /
 // AllGather / AllReduce): the per-CTA staging-window geometry (`StageLayout` /
-// `make_stage_layout`) and the internal-signal slot-id helpers (ready/ack
-// per-peer SET slots and the staging ADD barrier slots). It depends only on the
-// transport struct in MultimemNvlTransportDevice.cuh, not on the reduce/store
-// PTX.
+// `make_stage_layout`) and the internal-signal slot-id helpers (channel-wide
+// ready/ack/consumed SET stripes and lane-private aggregate barriers). It
+// depends only on the transport struct in MultimemNvlTransportDevice.cuh, not
+// on the reduce/store PTX.
 
 // clang-tidy analyzes this .cuh as a standalone main file and misflags the
 // pragma; it is a genuine include-once header. False positive, so suppress it.
@@ -45,18 +45,20 @@ checked_signal_product(uint64_t lhs, uint64_t rhs) {
 } // namespace detail
 
 /**
- * Layout of one CTA-group's slice of the shared staging window.
+ * Layout of one logical channel's slice of the shared staging window.
  *
- * The flat per-rank data buffer is split across CTAs (groups), and each group's
- * slice is further split into `pipelineDepth` lanes. A round picks its lane
- * round-robin so consecutive rounds use disjoint physical windows (pipelining).
+ * Each CUDA ThreadGroup selects one channel by group_id. The flat per-rank data
+ * buffer is split across active channels, and each channel's slice is further
+ * split into `pipelineDepth` lanes. A round picks its lane round-robin so
+ * consecutive rounds use disjoint physical windows.
  */
 struct StageLayout {
-  std::size_t groupBeginBytes{0}; // this group's slice origin into the buffer
+  std::size_t channelBeginBytes{0}; // channel slice origin in the data buffer
   std::size_t stagingElems{0}; // one lane window, in elements
   std::size_t stagingBytes{0}; // one lane window, in bytes
-  uint64_t signalBase{0}; // this group's base into the internal signals
-  uint64_t signalsPerLane{0}; // 2 * nvlRanks + 4
+  uint64_t signalBase{0}; // this channel's base into the internal signals
+  uint64_t signalsPerChannel{0}; // 3 * nvlRanks + 4 * pipelineDepth
+  int nvlRanks{0}; // ranks in this NVLink domain
   uint32_t pipelineDepth{1};
 };
 
@@ -92,14 +94,14 @@ __device__ __forceinline__ StageLayout make_stage_layout(
     __trap();
   }
   if (pipelineDepth == 0 || transport.maxChannels == 0 ||
-      transport.signalsPerLane == 0 ||
+      transport.signalsPerChannel == 0 ||
       group.total_groups > transport.maxChannels) {
     printf(
         "NvlMultimem staging layout: invalid geometry depth=%u "
-        "maxChannels=%u signalsPerLane=%u total_groups=%u\n",
+        "maxChannels=%u signalsPerChannel=%u total_groups=%u\n",
         static_cast<unsigned>(pipelineDepth),
         static_cast<unsigned>(transport.maxChannels),
-        static_cast<unsigned>(transport.signalsPerLane),
+        static_cast<unsigned>(transport.signalsPerChannel),
         static_cast<unsigned>(group.total_groups));
     __trap();
   }
@@ -109,7 +111,7 @@ __device__ __forceinline__ StageLayout make_stage_layout(
   const std::size_t groupId = group.group_id;
   const std::size_t unitsPerGroup = totalUnits / totalGroups;
   const std::size_t extraUnits = totalUnits % totalGroups;
-  const std::size_t groupBeginUnit =
+  const std::size_t channelBeginUnit =
       unitsPerGroup * groupId + (groupId < extraUnits ? groupId : extraUnits);
   const std::size_t groupUnits =
       unitsPerGroup + static_cast<std::size_t>(groupId < extraUnits);
@@ -129,45 +131,43 @@ __device__ __forceinline__ StageLayout make_stage_layout(
   }
 #endif
 
-  // Layout per (group, lane):
+  // Layout per channel:
   //   [0, nvlRanks)             ready[rank]           (SET, per-peer)
   //   [nvlRanks, 2*nvlRanks)    ack[rank]             (SET, per-peer)
-  //   2*nvlRanks + 0            staging_ready_counter (ADD, multicast)
-  //   2*nvlRanks + 1            staging_ready_epoch   (ADD, this rank baseline)
-  //   2*nvlRanks + 2            staging_ack_counter   (ADD, multicast)
-  //   2*nvlRanks + 3            staging_ack_epoch     (ADD, this rank baseline)
-  // The four ADD-mode barrier slots MUST live outside the SET-mode ready/ack
-  // region: without this separation, flipping stagingArrivalBarrier between ops
-  // in a single process leaves ADD counter residue in slots that a later
-  // SET-mode op reads with CMP_GE, and any past-op residue trivially satisfies
-  // the wait.
+  //   [2*nvlRanks, 3*nvlRanks)  consumed[rank]        (SET, per-peer)
+  // Each lane then owns four aggregate-barrier slots:
+  //   3*nvlRanks + 4*lane + 0   staging_ready_counter (ADD, multicast)
+  //   3*nvlRanks + 4*lane + 1   staging_ready_epoch   (local baseline)
+  //   3*nvlRanks + 4*lane + 2   staging_ack_counter   (ADD, multicast)
+  //   3*nvlRanks + 4*lane + 3   staging_ack_epoch     (local baseline)
+  // Only the counter slots are multicast ADD targets. The epoch slots hold
+  // rank-local baselines. All four slots MUST live outside the SET-mode peer
+  // stripes: otherwise ADD counter residue can satisfy a later SET-mode CMP_GE
+  // wait after the selected synchronization mode changes.
 #if defined(__CUDA_ARCH__)
-  if (transport.nvlRanks <= 0 ||
-      static_cast<uint64_t>(transport.nvlRanks) >
-          (static_cast<uint64_t>(~uint32_t{0}) - 4) / 2) {
+  if (transport.nvlRanks <= 0) {
     printf(
         "NvlMultimem staging layout: invalid nvlRanks=%d\n",
         transport.nvlRanks);
     __trap();
   }
 #endif
-  const uint64_t expectedSignalsPerLane =
-      comms::prims::multimem_staging_signals_per_lane(
-          static_cast<uint32_t>(transport.nvlRanks));
-  const uint64_t signalsPerLane = transport.signalsPerLane;
+  const uint64_t expectedSignalsPerChannel =
+      comms::prims::multimem_staging_signals_per_channel(
+          static_cast<uint32_t>(transport.nvlRanks), pipelineDepth);
+  const uint64_t signalsPerChannel = transport.signalsPerChannel;
 #if defined(__CUDA_ARCH__)
-  if (signalsPerLane != expectedSignalsPerLane) {
+  if (expectedSignalsPerChannel > ~uint32_t{0} ||
+      signalsPerChannel != expectedSignalsPerChannel) {
     printf(
-        "NvlMultimem staging layout: signalsPerLane=%llu expected=%llu\n",
-        static_cast<unsigned long long>(signalsPerLane),
-        static_cast<unsigned long long>(expectedSignalsPerLane));
+        "NvlMultimem staging layout: signalsPerChannel=%llu expected=%llu\n",
+        static_cast<unsigned long long>(signalsPerChannel),
+        static_cast<unsigned long long>(expectedSignalsPerChannel));
     __trap();
   }
 #endif
-  const uint64_t signalsPerGroup = detail::checked_signal_product(
-      static_cast<uint64_t>(pipelineDepth), signalsPerLane);
   const uint64_t requiredSignals = detail::checked_signal_product(
-      static_cast<uint64_t>(group.total_groups), signalsPerGroup);
+      static_cast<uint64_t>(group.total_groups), signalsPerChannel);
 #if defined(__CUDA_ARCH__)
   if (requiredSignals > transport.internalLocalSignals.size() ||
       requiredSignals > transport.internalMultimemSignals.size()) {
@@ -186,31 +186,66 @@ __device__ __forceinline__ StageLayout make_stage_layout(
 #endif
 
   return StageLayout{
-      .groupBeginBytes = groupBeginUnit * alignBytes,
+      .channelBeginBytes = channelBeginUnit * alignBytes,
       .stagingElems = stagingUnits * elemsPerAlign,
       .stagingBytes = stagingUnits * alignBytes,
       .signalBase = detail::checked_signal_product(
-          static_cast<uint64_t>(group.group_id), signalsPerGroup),
-      .signalsPerLane = signalsPerLane,
+          static_cast<uint64_t>(group.group_id), signalsPerChannel),
+      .signalsPerChannel = signalsPerChannel,
+      .nvlRanks = transport.nvlRanks,
       .pipelineDepth = pipelineDepth,
   };
 }
 
 __device__ __forceinline__ uint64_t
-ready_signal_id(const StageLayout& layout, uint32_t lane, int rank) {
-  return layout.signalBase +
-      static_cast<uint64_t>(lane) * layout.signalsPerLane +
-      static_cast<uint64_t>(rank);
+peer_signal_id(const StageLayout& layout, uint64_t stripeOffset, int rank) {
+  return layout.signalBase + stripeOffset + static_cast<uint64_t>(rank);
 }
 
-__device__ __forceinline__ uint64_t ack_signal_id(
-    const StageLayout& layout,
-    uint32_t lane,
-    int nvlRanks,
-    int rank) {
+__device__ __forceinline__ uint64_t
+ready_signal_id(const StageLayout& layout, int rank) {
+  return peer_signal_id(layout, /*stripeOffset=*/0, rank);
+}
+
+__device__ __forceinline__ uint64_t
+ack_signal_id(const StageLayout& layout, int rank) {
+  return peer_signal_id(layout, static_cast<uint64_t>(layout.nvlRanks), rank);
+}
+
+__device__ __forceinline__ uint64_t
+consumed_signal_id(const StageLayout& layout, int rank) {
+  return peer_signal_id(
+      layout,
+      static_cast<uint64_t>(2) * static_cast<uint64_t>(layout.nvlRanks),
+      rank);
+}
+
+__device__ __forceinline__ uint64_t
+lane_signal_base(const StageLayout& layout, uint32_t lane) {
   return layout.signalBase +
-      static_cast<uint64_t>(lane) * layout.signalsPerLane +
-      static_cast<uint64_t>(nvlRanks + rank);
+      static_cast<uint64_t>(3) * static_cast<uint64_t>(layout.nvlRanks) +
+      static_cast<uint64_t>(lane) *
+      comms::prims::detail::kMultimemSignalsPerLane;
+}
+
+__device__ __forceinline__ uint64_t
+ready_counter_signal_id(const StageLayout& layout, uint32_t lane) {
+  return lane_signal_base(layout, lane);
+}
+
+__device__ __forceinline__ uint64_t
+ready_epoch_signal_id(const StageLayout& layout, uint32_t lane) {
+  return lane_signal_base(layout, lane) + 1;
+}
+
+__device__ __forceinline__ uint64_t
+ack_counter_signal_id(const StageLayout& layout, uint32_t lane) {
+  return lane_signal_base(layout, lane) + 2;
+}
+
+__device__ __forceinline__ uint64_t
+ack_epoch_signal_id(const StageLayout& layout, uint32_t lane) {
+  return lane_signal_base(layout, lane) + 3;
 }
 
 __device__ __forceinline__ uint64_t
@@ -223,7 +258,7 @@ __device__ __forceinline__ std::size_t lane_begin(
     uint64_t primitiveRound) {
   const uint32_t lane =
       static_cast<uint32_t>(primitiveRound % layout.pipelineDepth);
-  return layout.groupBeginBytes +
+  return layout.channelBeginBytes +
       static_cast<std::size_t>(lane) * layout.stagingBytes;
 }
 

--- a/comms/prims/transport/nvl/MultimemNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.cc
@@ -15,7 +15,7 @@ namespace comms::prims {
 namespace {
 
 constexpr uint64_t kMultimemNvlTransportProtocol = 0x4D4D4E564CULL;
-constexpr uint64_t kMultimemNvlTransportProtocolVersion = 4;
+constexpr uint64_t kMultimemNvlTransportProtocolVersion = 5;
 
 int getCurrentCudaDevice() {
   int cudaDevice = 0;
@@ -93,10 +93,7 @@ MultimemNvlTransport::MultimemNvlTransport(
   }
   dataBufferSize_ = validation.dataBufferSize;
   internalSignalCount_ = validation.internalSignalCount;
-  if (config_.pipelineDepth != 0) {
-    signalsPerLane_ =
-        multimem_staging_signals_per_lane(static_cast<uint32_t>(nvlRanks_));
-  }
+  signalsPerChannel_ = validation.signalsPerChannel;
   // commRank presence in the map is already verified by validateRankMap.
   int nvlRank = -1;
   for (int rank = 0; rank < nvlRanks_; ++rank) {
@@ -241,7 +238,7 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
       .nvlRanks = nvlRanks_,
       .pipelineDepth = static_cast<uint32_t>(config_.pipelineDepth),
       .maxChannels = static_cast<uint32_t>(config_.maxChannels),
-      .signalsPerLane = signalsPerLane_,
+      .signalsPerChannel = signalsPerChannel_,
   };
 }
 

--- a/comms/prims/transport/nvl/MultimemNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.cc
@@ -87,9 +87,19 @@ MultimemNvlTransport::MultimemNvlTransport(
     throw std::runtime_error(
         "MultimemNvlTransport: dataBufferSize must be non-zero");
   }
+  const auto internalSignalCount =
+      checked_multimem_internal_signal_count(config_, nvlRanks_);
+  if (!internalSignalCount.has_value()) {
+    throw std::runtime_error(
+        "MultimemNvlTransport: invalid staging geometry or capacity");
+  }
+  internalSignalCount_ = *internalSignalCount;
+  if (config_.pipelineDepth != 0) {
+    signalsPerLane_ =
+        multimem_staging_signals_per_lane(static_cast<uint32_t>(nvlRanks_));
+  }
   const uint64_t totalSignalCount =
-      static_cast<uint64_t>(config_.userSignalCount) +
-      static_cast<uint64_t>(config_.internalSignalCount);
+      static_cast<uint64_t>(config_.userSignalCount) + internalSignalCount_;
   if (totalSignalCount == 0) {
     throw std::runtime_error(
         "MultimemNvlTransport: at least one signal slot is required");
@@ -222,7 +232,7 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
   auto* multimemSignals =
       reinterpret_cast<SignalState*>(multimemBase + signalRegionOffset_);
   const auto userSignalCount = config_.userSignalCount;
-  const auto internalSignalCount = config_.internalSignalCount;
+  const auto internalSignalCount = internalSignalCount_;
 
   return MultimemNvlTransportDevice{
       .localData = localBase,
@@ -236,6 +246,9 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
       .internalMultimemSignals = DeviceSpan<SignalState>(
           multimemSignals + userSignalCount, internalSignalCount),
       .dataBufferSize = config_.dataBufferSize,
+      .pipelineDepth = static_cast<uint32_t>(config_.pipelineDepth),
+      .maxGroups = static_cast<uint32_t>(config_.maxGroups),
+      .signalsPerLane = signalsPerLane_,
       .nvlRank = nvlRank_,
       .nvlRanks = nvlRanks_,
   };
@@ -252,7 +265,7 @@ std::size_t MultimemNvlTransport::getAllocatedSignalBufferSize() const {
   // granularity, so combinedHandler_->getAllocatedSize() - signalRegionOffset_
   // would include trailing padding that is not addressable as SignalState.
   return getSignalBufferSize(
-      static_cast<int>(config_.userSignalCount + config_.internalSignalCount));
+      static_cast<int>(config_.userSignalCount + internalSignalCount_));
 }
 
 } // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.cc
@@ -83,31 +83,21 @@ MultimemNvlTransport::MultimemNvlTransport(
   // are exercisable on CPU-only hosts (see MultimemNvlTransportValidationTest).
   validateRankMap(commRank_, nvlRankToCommRank_);
 
-  if (config_.dataBufferSize == 0) {
+  const auto validation =
+      validate_multimem_nvl_transport_config(config_, nvlRanks_);
+  if (!validation) {
     throw std::runtime_error(
-        "MultimemNvlTransport: dataBufferSize must be non-zero");
+        std::string("MultimemNvlTransport: ") +
+        multimem_nvl_transport_config_error_string(validation.error));
   }
-  const auto internalSignalCount =
-      checked_multimem_internal_signal_count(config_, nvlRanks_);
-  if (!internalSignalCount.has_value()) {
-    throw std::runtime_error(
-        "MultimemNvlTransport: invalid staging geometry or capacity");
-  }
-  internalSignalCount_ = *internalSignalCount;
+  internalSignalCount_ = validation.internalSignalCount;
   if (config_.pipelineDepth != 0) {
     signalsPerLane_ =
         multimem_staging_signals_per_lane(static_cast<uint32_t>(nvlRanks_));
   }
   const uint64_t totalSignalCount =
       static_cast<uint64_t>(config_.userSignalCount) + internalSignalCount_;
-  if (totalSignalCount == 0) {
-    throw std::runtime_error(
-        "MultimemNvlTransport: at least one signal slot is required");
-  }
-  if (totalSignalCount >
-      static_cast<uint64_t>(std::numeric_limits<int>::max())) {
-    throw std::runtime_error("MultimemNvlTransport: signalCount too large");
-  }
+  // The shared validator bounds the combined user and internal signal count.
 
   // commRank presence in the map is already verified by validateRankMap.
   int nvlRank = -1;

--- a/comms/prims/transport/nvl/MultimemNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.cc
@@ -2,13 +2,11 @@
 
 #include "comms/prims/transport/nvl/MultimemNvlTransport.h"
 
-#include <limits>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <utility>
 
-#include "comms/common/BitOps.cuh"
 #include "comms/prims/core/SignalState.cuh"
 #include "comms/utils/checks.h"
 
@@ -17,7 +15,7 @@ namespace comms::prims {
 namespace {
 
 constexpr uint64_t kMultimemNvlTransportProtocol = 0x4D4D4E564CULL;
-constexpr uint64_t kMultimemNvlTransportProtocolVersion = 1;
+constexpr uint64_t kMultimemNvlTransportProtocolVersion = 4;
 
 int getCurrentCudaDevice() {
   int cudaDevice = 0;
@@ -86,32 +84,19 @@ MultimemNvlTransport::MultimemNvlTransport(
   // are exercisable on CPU-only hosts (see MultimemNvlTransportValidationTest).
   validateRankMap(commRank_, nvlRankToCommRank_);
 
-  if (config_.dataBufferSize == 0) {
+  const auto validation =
+      validate_multimem_nvl_transport_config(config_, nvlRanks_);
+  if (!validation) {
     throw std::runtime_error(
-        "MultimemNvlTransport: dataBufferSize must be non-zero");
+        std::string("MultimemNvlTransport: ") +
+        std::string(validation.errorMessage));
   }
-  const auto internalSignalCount =
-      detail::checked_multimem_internal_signal_count(config_, nvlRanks_);
-  if (!internalSignalCount.has_value()) {
-    throw std::runtime_error(
-        "MultimemNvlTransport: invalid staging geometry or capacity");
-  }
-  internalSignalCount_ = *internalSignalCount;
+  dataBufferSize_ = validation.dataBufferSize;
+  internalSignalCount_ = validation.internalSignalCount;
   if (config_.pipelineDepth != 0) {
     signalsPerLane_ =
         multimem_staging_signals_per_lane(static_cast<uint32_t>(nvlRanks_));
   }
-  const uint64_t totalSignalCount =
-      static_cast<uint64_t>(config_.userSignalCount) + internalSignalCount_;
-  if (totalSignalCount == 0) {
-    throw std::runtime_error(
-        "MultimemNvlTransport: at least one signal slot is required");
-  }
-  if (totalSignalCount >
-      static_cast<uint64_t>(std::numeric_limits<int>::max())) {
-    throw std::runtime_error("MultimemNvlTransport: signalCount too large");
-  }
-
   // commRank presence in the map is already verified by validateRankMap.
   int nvlRank = -1;
   for (int rank = 0; rank < nvlRanks_; ++rank) {
@@ -129,22 +114,11 @@ MultimemNvlTransport::MultimemNvlTransport(
   }
   nvlRank_ = nvlRank;
 
-  constexpr std::size_t kSignalAlignment = alignof(SignalState);
-  if (config_.dataBufferSize >
-      std::numeric_limits<std::size_t>::max() - (kSignalAlignment - 1)) {
-    throw std::runtime_error(
-        "MultimemNvlTransport: dataBufferSize alignment overflows");
-  }
-  signalRegionOffset_ =
-      comms::bitops::alignUp(config_.dataBufferSize, kSignalAlignment);
-  const std::size_t signalRegionBytes =
-      getSignalBufferSize(static_cast<int>(totalSignalCount));
-  if (signalRegionOffset_ >
-      std::numeric_limits<std::size_t>::max() - signalRegionBytes) {
-    throw std::runtime_error(
-        "MultimemNvlTransport: combined allocation size overflows");
-  }
-  const std::size_t combinedSize = signalRegionOffset_ + signalRegionBytes;
+  static_assert(alignof(SignalState) == detail::kMultimemSignalAlignment);
+  static_assert(sizeof(SignalState) == detail::kMultimemSignalStateSize);
+  signalRegionOffset_ = validation.signalRegionOffset;
+  const std::size_t combinedSize = validation.backingAllocationSize;
+  const std::size_t signalRegionBytes = combinedSize - signalRegionOffset_;
 
   cudaDevice_ = getCurrentCudaDevice();
 
@@ -172,11 +146,13 @@ MultimemNvlTransport::MultimemNvlTransport(
   // exchange()'s post-map barrier lets any peer signal into this region. This
   // mirrors MultiPeerNvlTransport, which zeroes its signal buffer at
   // construction.
-  auto* localSignalRegion =
-      static_cast<char*>(combinedHandler_->getLocalDeviceMemPtr()) +
-      signalRegionOffset_;
-  CUDA_CHECK(cudaMemset(localSignalRegion, 0, signalRegionBytes));
-  CUDA_CHECK(cudaStreamSynchronize(/*stream=*/0));
+  if (signalRegionBytes != 0) {
+    auto* localSignalRegion =
+        static_cast<char*>(combinedHandler_->getLocalDeviceMemPtr()) +
+        signalRegionOffset_;
+    CUDA_CHECK(cudaMemset(localSignalRegion, 0, signalRegionBytes));
+    CUDA_CHECK(cudaStreamSynchronize(/*stream=*/0));
+  }
 }
 
 MultimemNvlTransport::MultimemNvlTransport(
@@ -216,10 +192,11 @@ void MultimemNvlTransport::exchange() {
         .version = kMultimemNvlTransportProtocolVersion,
         .parameters =
             {
-                config_.dataBufferSize,
-                config_.userSignalCount,
+                config_.perChannelSize,
                 config_.pipelineDepth,
                 config_.maxChannels,
+                config_.maxBlocks,
+                config_.userSignalCount,
             },
     };
     combinedHandler_->exchangeMulticast(
@@ -259,7 +236,7 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
           localSignals + userSignalCount, internalSignalCount),
       .internalMultimemSignals = DeviceSpan<SignalState>(
           multimemSignals + userSignalCount, internalSignalCount),
-      .dataBufferSize = config_.dataBufferSize,
+      .dataBufferSize = dataBufferSize_,
       .nvlRank = nvlRank_,
       .nvlRanks = nvlRanks_,
       .pipelineDepth = static_cast<uint32_t>(config_.pipelineDepth),
@@ -269,7 +246,7 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
 }
 
 std::size_t MultimemNvlTransport::getAllocatedDataBufferSize() const {
-  return config_.dataBufferSize;
+  return dataBufferSize_;
 }
 
 std::size_t MultimemNvlTransport::getAllocatedSignalBufferSize() const {

--- a/comms/prims/transport/nvl/MultimemNvlTransport.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.h
@@ -4,75 +4,15 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <memory>
-#include <optional>
 #include <vector>
 
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/prims/memory/GpuMemHandler.h"
+#include "comms/prims/transport/nvl/MultimemNvlTransportConfig.h"
 #include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
 
 namespace comms::prims {
-
-struct MultimemNvlTransportConfig {
-  // Size in bytes of the multicast staging data window.
-  std::size_t dataBufferSize{0};
-
-  // Signal slots exposed through signal(), read_signal(), and
-  // wait_signal_until().
-  uint32_t userSignalCount{0};
-
-  // Immutable staging geometry. Both values must be zero when staging is not
-  // used, or both must be non-zero when staging is enabled.
-  std::size_t pipelineDepth{0};
-  std::size_t maxGroups{0};
-};
-
-inline std::optional<uint32_t> checked_multimem_internal_signal_count(
-    const MultimemNvlTransportConfig& config,
-    int nvlRanks) {
-  if (nvlRanks <= 0 ||
-      config.userSignalCount > std::numeric_limits<int>::max()) {
-    return std::nullopt;
-  }
-
-  const auto signalsPerLaneWide =
-      multimem_staging_signals_per_lane_wide(static_cast<uint64_t>(nvlRanks));
-  if (signalsPerLaneWide > std::numeric_limits<uint32_t>::max()) {
-    return std::nullopt;
-  }
-
-  const bool hasPipelineDepth = config.pipelineDepth != 0;
-  const bool hasMaxGroups = config.maxGroups != 0;
-  if (hasPipelineDepth != hasMaxGroups) {
-    return std::nullopt;
-  }
-  if (!hasPipelineDepth) {
-    return 0;
-  }
-
-  constexpr std::size_t kDataAlignment = 16;
-  const std::size_t alignedUnits = config.dataBufferSize / kDataAlignment;
-  const auto ranks = static_cast<std::size_t>(nvlRanks);
-  if (config.maxGroups > alignedUnits ||
-      config.pipelineDepth > alignedUnits / config.maxGroups ||
-      ranks > alignedUnits / config.maxGroups / config.pipelineDepth) {
-    return std::nullopt;
-  }
-
-  const auto maxInternalSignals = static_cast<std::size_t>(
-      std::numeric_limits<int>::max() - config.userSignalCount);
-  const auto signalsPerLane = static_cast<std::size_t>(signalsPerLaneWide);
-  if (config.maxGroups > maxInternalSignals / signalsPerLane) {
-    return std::nullopt;
-  }
-  const auto signalsPerRound = config.maxGroups * signalsPerLane;
-  if (config.pipelineDepth > maxInternalSignals / signalsPerRound) {
-    return std::nullopt;
-  }
-  return static_cast<uint32_t>(config.pipelineDepth * signalsPerRound);
-}
 
 /**
  * Host-side owner for a copy-based NVL multimem transport.

--- a/comms/prims/transport/nvl/MultimemNvlTransport.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.h
@@ -99,7 +99,7 @@ class MultimemNvlTransport {
   const MultimemNvlTransportConfig config_;
   std::size_t dataBufferSize_{0};
   uint32_t internalSignalCount_{0};
-  uint32_t signalsPerLane_{0};
+  uint32_t signalsPerChannel_{0};
   bool exchanged_{false};
   // Set when exchange() throws; subsequent calls throw instead of silently
   // retrying. Multicast object create/import/bind failures can leave partial

--- a/comms/prims/transport/nvl/MultimemNvlTransport.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.h
@@ -4,87 +4,15 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <memory>
-#include <optional>
 #include <vector>
 
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/prims/memory/GpuMemHandler.h"
+#include "comms/prims/transport/nvl/MultimemNvlTransportConfig.h"
 #include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
 
 namespace comms::prims {
-
-struct MultimemNvlTransportConfig {
-  // Size in bytes of the multicast staging data window.
-  std::size_t dataBufferSize{0};
-
-  // Signal slots exposed through signal(), read_signal(), and
-  // wait_signal_until().
-  uint32_t userSignalCount{1};
-
-  // Immutable staging geometry. Both values must be zero when staging is not
-  // used, or both must be non-zero when staging is enabled. `maxChannels` is
-  // the maximum supported `ThreadGroup::total_groups`; each group, pipeline
-  // lane, and NVLink rank requires one 16-byte-aligned data unit. Construction
-  // derives and reserves the corresponding internal signal region after the
-  // user-visible signal slots.
-  std::size_t pipelineDepth{0};
-  std::size_t maxChannels{0};
-};
-
-namespace detail {
-
-inline std::optional<uint32_t> checked_multimem_internal_signal_count(
-    const MultimemNvlTransportConfig& config,
-    int nvlRanks) {
-  if (nvlRanks <= 0 ||
-      config.userSignalCount > std::numeric_limits<int>::max()) {
-    return std::nullopt;
-  }
-
-  const auto signalsPerLaneWide =
-      multimem_staging_signals_per_lane_wide(static_cast<uint64_t>(nvlRanks));
-  if (signalsPerLaneWide > std::numeric_limits<uint32_t>::max()) {
-    return std::nullopt;
-  }
-
-  const bool hasPipelineDepth = config.pipelineDepth != 0;
-  const bool hasMaxChannels = config.maxChannels != 0;
-  if (hasPipelineDepth != hasMaxChannels) {
-    return std::nullopt;
-  }
-  if (!hasPipelineDepth) {
-    return 0;
-  }
-  if (config.pipelineDepth > std::numeric_limits<uint32_t>::max() ||
-      config.maxChannels > std::numeric_limits<uint32_t>::max()) {
-    return std::nullopt;
-  }
-
-  constexpr std::size_t kDataAlignment = 16;
-  const std::size_t alignedUnits = config.dataBufferSize / kDataAlignment;
-  const auto ranks = static_cast<std::size_t>(nvlRanks);
-  if (config.maxChannels > alignedUnits ||
-      config.pipelineDepth > alignedUnits / config.maxChannels ||
-      ranks > alignedUnits / config.maxChannels / config.pipelineDepth) {
-    return std::nullopt;
-  }
-
-  const auto maxInternalSignals = static_cast<std::size_t>(
-      std::numeric_limits<int>::max() - config.userSignalCount);
-  const auto signalsPerLane = static_cast<std::size_t>(signalsPerLaneWide);
-  if (config.maxChannels > maxInternalSignals / signalsPerLane) {
-    return std::nullopt;
-  }
-  const auto signalsPerRound = config.maxChannels * signalsPerLane;
-  if (config.pipelineDepth > maxInternalSignals / signalsPerRound) {
-    return std::nullopt;
-  }
-  return static_cast<uint32_t>(config.pipelineDepth * signalsPerRound);
-}
-
-} // namespace detail
 
 /**
  * Host-side owner for a copy-based NVL multimem transport.
@@ -169,12 +97,13 @@ class MultimemNvlTransport {
   // rank-map preconditions on CPU-only hosts).
   int cudaDevice_{-1};
   const MultimemNvlTransportConfig config_;
+  std::size_t dataBufferSize_{0};
   uint32_t internalSignalCount_{0};
   uint32_t signalsPerLane_{0};
   bool exchanged_{false};
   // Set when exchange() throws; subsequent calls throw instead of silently
   // retrying. Multicast object create/import/bind failures can leave partial
-  // driver state, so a same-object retry is unsafe — callers must rebuild the
+  // driver state, so a same-object retry is unsafe. Callers must rebuild the
   // transport to recover.
   bool broken_{false};
 
@@ -185,8 +114,7 @@ class MultimemNvlTransport {
   // (getMultimemDeviceMemPtr) -- one cuMulticastCreate / one set of binds / one
   // MC VA range over one shared physical backing.
   std::unique_ptr<GpuMemHandler> combinedHandler_;
-  // Offset of the signal region within combinedHandler_'s allocation. Equals
-  // dataBufferSize rounded up to SignalState's 128-byte alignment.
+  // Offset of the signal region within combinedHandler_'s allocation.
   std::size_t signalRegionOffset_{0};
 };
 

--- a/comms/prims/transport/nvl/MultimemNvlTransport.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.h
@@ -4,7 +4,9 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "comms/common/bootstrap/IBootstrap.h"
@@ -19,12 +21,58 @@ struct MultimemNvlTransportConfig {
 
   // Signal slots exposed through signal(), read_signal(), and
   // wait_signal_until().
-  uint32_t userSignalCount{1};
+  uint32_t userSignalCount{0};
 
-  // Signal slots reserved for transport-internal protocols. These are not
-  // addressable through the public signal API.
-  uint32_t internalSignalCount{0};
+  // Immutable staging geometry. Both values must be zero when staging is not
+  // used, or both must be non-zero when staging is enabled.
+  std::size_t pipelineDepth{0};
+  std::size_t maxGroups{0};
 };
+
+inline std::optional<uint32_t> checked_multimem_internal_signal_count(
+    const MultimemNvlTransportConfig& config,
+    int nvlRanks) {
+  if (nvlRanks <= 0 ||
+      config.userSignalCount > std::numeric_limits<int>::max()) {
+    return std::nullopt;
+  }
+
+  const auto signalsPerLaneWide =
+      multimem_staging_signals_per_lane_wide(static_cast<uint64_t>(nvlRanks));
+  if (signalsPerLaneWide > std::numeric_limits<uint32_t>::max()) {
+    return std::nullopt;
+  }
+
+  const bool hasPipelineDepth = config.pipelineDepth != 0;
+  const bool hasMaxGroups = config.maxGroups != 0;
+  if (hasPipelineDepth != hasMaxGroups) {
+    return std::nullopt;
+  }
+  if (!hasPipelineDepth) {
+    return 0;
+  }
+
+  constexpr std::size_t kDataAlignment = 16;
+  const std::size_t alignedUnits = config.dataBufferSize / kDataAlignment;
+  const auto ranks = static_cast<std::size_t>(nvlRanks);
+  if (config.maxGroups > alignedUnits ||
+      config.pipelineDepth > alignedUnits / config.maxGroups ||
+      ranks > alignedUnits / config.maxGroups / config.pipelineDepth) {
+    return std::nullopt;
+  }
+
+  const auto maxInternalSignals = static_cast<std::size_t>(
+      std::numeric_limits<int>::max() - config.userSignalCount);
+  const auto signalsPerLane = static_cast<std::size_t>(signalsPerLaneWide);
+  if (config.maxGroups > maxInternalSignals / signalsPerLane) {
+    return std::nullopt;
+  }
+  const auto signalsPerRound = config.maxGroups * signalsPerLane;
+  if (config.pipelineDepth > maxInternalSignals / signalsPerRound) {
+    return std::nullopt;
+  }
+  return static_cast<uint32_t>(config.pipelineDepth * signalsPerRound);
+}
 
 /**
  * Host-side owner for a copy-based NVL multimem transport.
@@ -109,6 +157,8 @@ class MultimemNvlTransport {
   // rank-map preconditions on CPU-only hosts).
   int cudaDevice_{-1};
   const MultimemNvlTransportConfig config_;
+  uint32_t internalSignalCount_{0};
+  uint32_t signalsPerLane_{0};
   bool exchanged_{false};
   // Set when exchange() throws; subsequent calls throw instead of silently
   // retrying. Multicast object create/import/bind failures can leave partial

--- a/comms/prims/transport/nvl/MultimemNvlTransportConfig.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransportConfig.cc
@@ -1,0 +1,117 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/transport/nvl/MultimemNvlTransportConfig.h"
+
+#include <limits>
+
+namespace comms::prims {
+
+const char* multimem_nvl_transport_config_error_string(
+    MultimemNvlTransportConfigError error) {
+  switch (error) {
+    case MultimemNvlTransportConfigError::None:
+      return "none";
+    case MultimemNvlTransportConfigError::MissingDataBuffer:
+      return "data buffer size must be non-zero";
+    case MultimemNvlTransportConfigError::InvalidRankCount:
+      return "NVL rank count must be positive";
+    case MultimemNvlTransportConfigError::PartialStagingGeometry:
+      return "pipeline depth and maximum groups must both be zero or non-zero";
+    case MultimemNvlTransportConfigError::GeometryOutOfRange:
+      return "pipeline depth or maximum groups exceeds UINT32_MAX";
+    case MultimemNvlTransportConfigError::InsufficientDataCapacity:
+      return "data buffer is too small for the staging geometry";
+    case MultimemNvlTransportConfigError::SignalCountOverflow:
+      return "signal count exceeds INT_MAX";
+    case MultimemNvlTransportConfigError::NoSignalSlots:
+      return "at least one signal slot is required";
+  }
+  return "unknown configuration error";
+}
+
+MultimemNvlTransportConfigValidation validate_multimem_nvl_transport_geometry(
+    const MultimemNvlTransportConfig& config) {
+  if (config.userSignalCount > std::numeric_limits<int>::max()) {
+    return {0, MultimemNvlTransportConfigError::SignalCountOverflow};
+  }
+
+  const bool hasPipelineDepth = config.pipelineDepth != 0;
+  const bool hasMaxGroups = config.maxGroups != 0;
+  if (hasPipelineDepth != hasMaxGroups) {
+    return {0, MultimemNvlTransportConfigError::PartialStagingGeometry};
+  }
+  if (!hasPipelineDepth) {
+    if (config.userSignalCount == 0) {
+      return {0, MultimemNvlTransportConfigError::NoSignalSlots};
+    }
+    return {};
+  }
+  if (config.pipelineDepth > std::numeric_limits<uint32_t>::max() ||
+      config.maxGroups > std::numeric_limits<uint32_t>::max()) {
+    return {0, MultimemNvlTransportConfigError::GeometryOutOfRange};
+  }
+  return {};
+}
+
+MultimemNvlTransportConfigValidation validate_multimem_nvl_transport_config(
+    const MultimemNvlTransportConfig& config,
+    int nvlRanks) {
+  const auto geometry = validate_multimem_nvl_transport_geometry(config);
+  if (!geometry) {
+    return geometry;
+  }
+  if (config.dataBufferSize == 0) {
+    return {0, MultimemNvlTransportConfigError::MissingDataBuffer};
+  }
+  if (nvlRanks <= 0) {
+    return {0, MultimemNvlTransportConfigError::InvalidRankCount};
+  }
+  if (config.pipelineDepth == 0) {
+    return {};
+  }
+
+  constexpr std::size_t kDataAlignment = 16;
+  const std::size_t alignedUnits = config.dataBufferSize / kDataAlignment;
+  const auto ranks = static_cast<std::size_t>(nvlRanks);
+  if (config.maxGroups > alignedUnits ||
+      config.pipelineDepth > alignedUnits / config.maxGroups ||
+      ranks > alignedUnits / config.maxGroups / config.pipelineDepth) {
+    return {0, MultimemNvlTransportConfigError::InsufficientDataCapacity};
+  }
+
+  const auto signalsPerLaneWide =
+      multimem_staging_signals_per_lane_wide(static_cast<uint64_t>(nvlRanks));
+  if (signalsPerLaneWide > std::numeric_limits<uint32_t>::max()) {
+    return {0, MultimemNvlTransportConfigError::GeometryOutOfRange};
+  }
+  const auto maxInternalSignals = static_cast<std::size_t>(
+      std::numeric_limits<int>::max() - config.userSignalCount);
+  const auto signalsPerLane = static_cast<std::size_t>(signalsPerLaneWide);
+  if (config.maxGroups > maxInternalSignals / signalsPerLane) {
+    return {0, MultimemNvlTransportConfigError::SignalCountOverflow};
+  }
+  const auto signalsPerRound = config.maxGroups * signalsPerLane;
+  if (config.pipelineDepth > maxInternalSignals / signalsPerRound) {
+    return {0, MultimemNvlTransportConfigError::SignalCountOverflow};
+  }
+  return {
+      static_cast<uint32_t>(config.pipelineDepth * signalsPerRound),
+      MultimemNvlTransportConfigError::None,
+  };
+}
+
+ResolvedMultimemNvlTransportConfig resolve_multimem_nvl_transport_config(
+    const std::optional<MultimemNvlTransportConfig>& overrideConfig,
+    const MultimemNvlTransportConfig& fallbackConfig,
+    std::size_t topologyDataBufferSize,
+    int nvlRanks) {
+  auto config = overrideConfig.value_or(fallbackConfig);
+  if (config.dataBufferSize == 0) {
+    config.dataBufferSize = topologyDataBufferSize;
+  }
+  const auto validation =
+      validate_multimem_nvl_transport_config(config, nvlRanks);
+  return {config, validation.internalSignalCount, validation.error};
+}
+
+} // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlTransportConfig.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransportConfig.cc
@@ -44,6 +44,7 @@ MultimemNvlTransportConfigValidation validate_multimem_nvl_transport_config(
   const std::size_t dataBufferSize = config.perChannelSize * config.maxChannels;
 
   uint32_t internalSignalCount = 0;
+  uint32_t signalsPerChannel = 0;
   if (config.pipelineDepth != 0) {
     constexpr std::size_t kDataAlignment = 16;
     if (config.pipelineDepth >
@@ -62,23 +63,19 @@ MultimemNvlTransportConfigValidation validate_multimem_nvl_transport_config(
           .errorMessage = "data buffer is too small for the staging geometry"};
     }
 
-    const auto signalsPerLaneWide =
-        multimem_staging_signals_per_lane_wide(static_cast<uint64_t>(nvlRanks));
-    if (signalsPerLaneWide > std::numeric_limits<uint32_t>::max()) {
+    const auto signalsPerChannelWide = multimem_staging_signals_per_channel(
+        static_cast<uint64_t>(nvlRanks), config.pipelineDepth);
+    if (signalsPerChannelWide > std::numeric_limits<uint32_t>::max()) {
       return {.errorMessage = "transport geometry exceeds UINT32_MAX"};
     }
     const auto maxInternalSignals = static_cast<std::size_t>(
         std::numeric_limits<int>::max() - config.userSignalCount);
-    const auto signalsPerLane = static_cast<std::size_t>(signalsPerLaneWide);
-    if (config.maxChannels > maxInternalSignals / signalsPerLane) {
+    signalsPerChannel = static_cast<uint32_t>(signalsPerChannelWide);
+    if (config.maxChannels > maxInternalSignals / signalsPerChannel) {
       return {.errorMessage = "signal count exceeds INT_MAX"};
     }
-    const auto signalsPerPipelineLane = config.maxChannels * signalsPerLane;
-    if (config.pipelineDepth > maxInternalSignals / signalsPerPipelineLane) {
-      return {.errorMessage = "signal count exceeds INT_MAX"};
-    }
-    internalSignalCount =
-        static_cast<uint32_t>(config.pipelineDepth * signalsPerPipelineLane);
+    internalSignalCount = static_cast<uint32_t>(
+        config.maxChannels * static_cast<std::size_t>(signalsPerChannel));
   }
 
   constexpr auto kSignalAlignment = detail::kMultimemSignalAlignment;
@@ -107,6 +104,7 @@ MultimemNvlTransportConfigValidation validate_multimem_nvl_transport_config(
 
   return {
       .dataBufferSize = dataBufferSize,
+      .signalsPerChannel = signalsPerChannel,
       .internalSignalCount = internalSignalCount,
       .signalRegionOffset = signalRegionOffset,
       .backingAllocationSize = signalRegionOffset + signalRegionBytes,

--- a/comms/prims/transport/nvl/MultimemNvlTransportConfig.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransportConfig.cc
@@ -1,0 +1,116 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/transport/nvl/MultimemNvlTransportConfig.h"
+
+#include <limits>
+
+namespace comms::prims {
+
+MultimemNvlTransportConfigValidation validate_multimem_nvl_transport_config(
+    const MultimemNvlTransportConfig& config,
+    int nvlRanks) {
+  if (config.perChannelSize == 0) {
+    return {.errorMessage = "per-channel size must be non-zero"};
+  }
+  if (config.maxChannels == 0) {
+    return {.errorMessage = "maximum channels must be non-zero"};
+  }
+  if (nvlRanks <= 0) {
+    return {.errorMessage = "NVL rank count must be positive"};
+  }
+  if (config.userSignalCount > std::numeric_limits<int>::max()) {
+    return {.errorMessage = "signal count exceeds INT_MAX"};
+  }
+
+  const bool hasPipelineDepth = config.pipelineDepth != 0;
+  const bool hasMaxBlocks = config.maxBlocks != 0;
+  if (hasPipelineDepth != hasMaxBlocks) {
+    return {
+        .errorMessage =
+            "pipeline depth and maximum blocks must both be zero or non-zero"};
+  }
+  if (config.pipelineDepth > std::numeric_limits<uint32_t>::max() ||
+      config.maxChannels > std::numeric_limits<uint32_t>::max()) {
+    return {.errorMessage = "transport geometry exceeds UINT32_MAX"};
+  }
+  if (config.maxBlocks > config.maxChannels) {
+    return {.errorMessage = "maximum blocks must not exceed maximum channels"};
+  }
+  if (config.perChannelSize >
+      std::numeric_limits<std::size_t>::max() / config.maxChannels) {
+    return {
+        .errorMessage = "per-channel size times maximum channels overflows"};
+  }
+  const std::size_t dataBufferSize = config.perChannelSize * config.maxChannels;
+
+  uint32_t internalSignalCount = 0;
+  if (config.pipelineDepth != 0) {
+    constexpr std::size_t kDataAlignment = 16;
+    if (config.pipelineDepth >
+            std::numeric_limits<std::size_t>::max() / kDataAlignment ||
+        config.perChannelSize % (config.pipelineDepth * kDataAlignment) != 0) {
+      return {
+          .errorMessage =
+              "per-channel size must be divisible by pipeline depth times 16"};
+    }
+    const std::size_t alignedUnits = dataBufferSize / kDataAlignment;
+    const auto ranks = static_cast<std::size_t>(nvlRanks);
+    if (config.maxChannels > alignedUnits ||
+        config.pipelineDepth > alignedUnits / config.maxChannels ||
+        ranks > alignedUnits / config.maxChannels / config.pipelineDepth) {
+      return {
+          .errorMessage = "data buffer is too small for the staging geometry"};
+    }
+
+    const auto signalsPerLaneWide =
+        multimem_staging_signals_per_lane_wide(static_cast<uint64_t>(nvlRanks));
+    if (signalsPerLaneWide > std::numeric_limits<uint32_t>::max()) {
+      return {.errorMessage = "transport geometry exceeds UINT32_MAX"};
+    }
+    const auto maxInternalSignals = static_cast<std::size_t>(
+        std::numeric_limits<int>::max() - config.userSignalCount);
+    const auto signalsPerLane = static_cast<std::size_t>(signalsPerLaneWide);
+    if (config.maxChannels > maxInternalSignals / signalsPerLane) {
+      return {.errorMessage = "signal count exceeds INT_MAX"};
+    }
+    const auto signalsPerPipelineLane = config.maxChannels * signalsPerLane;
+    if (config.pipelineDepth > maxInternalSignals / signalsPerPipelineLane) {
+      return {.errorMessage = "signal count exceeds INT_MAX"};
+    }
+    internalSignalCount =
+        static_cast<uint32_t>(config.pipelineDepth * signalsPerPipelineLane);
+  }
+
+  constexpr auto kSignalAlignment = detail::kMultimemSignalAlignment;
+  constexpr auto kSignalStateSize = detail::kMultimemSignalStateSize;
+  if (dataBufferSize >
+      std::numeric_limits<std::size_t>::max() - (kSignalAlignment - 1)) {
+    return {
+        .errorMessage = "combined data and signal allocation size overflows"};
+  }
+  const std::size_t signalRegionOffset =
+      ((dataBufferSize + kSignalAlignment - 1) / kSignalAlignment) *
+      kSignalAlignment;
+  const auto totalSignalCount =
+      static_cast<std::size_t>(config.userSignalCount) + internalSignalCount;
+  if (totalSignalCount >
+      std::numeric_limits<std::size_t>::max() / kSignalStateSize) {
+    return {
+        .errorMessage = "combined data and signal allocation size overflows"};
+  }
+  const std::size_t signalRegionBytes = totalSignalCount * kSignalStateSize;
+  if (signalRegionOffset >
+      std::numeric_limits<std::size_t>::max() - signalRegionBytes) {
+    return {
+        .errorMessage = "combined data and signal allocation size overflows"};
+  }
+
+  return {
+      .dataBufferSize = dataBufferSize,
+      .internalSignalCount = internalSignalCount,
+      .signalRegionOffset = signalRegionOffset,
+      .backingAllocationSize = signalRegionOffset + signalRegionBytes,
+  };
+}
+
+} // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlTransportConfig.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransportConfig.h
@@ -30,7 +30,7 @@ struct MultimemNvlTransportConfigParams {
 
   // Signal slots exposed through signal(), read_signal(), and
   // wait_signal_until(). This is orthogonal to staging geometry.
-  uint32_t userSignalCount{1};
+  uint32_t userSignalCount{0};
 };
 
 struct MultimemNvlTransportConfig {
@@ -48,7 +48,7 @@ struct MultimemNvlTransportConfig {
   std::size_t pipelineDepth{0};
   std::size_t maxChannels{0};
   std::size_t maxBlocks{0};
-  uint32_t userSignalCount{1};
+  uint32_t userSignalCount{0};
 
   bool operator==(const MultimemNvlTransportConfig&) const = default;
 };
@@ -60,6 +60,7 @@ constexpr MultimemNvlTransportConfig make_multimem_nvl_transport_config(
 
 struct MultimemNvlTransportConfigValidation {
   std::size_t dataBufferSize{0};
+  uint32_t signalsPerChannel{0};
   uint32_t internalSignalCount{0};
   std::size_t signalRegionOffset{0};
   std::size_t backingAllocationSize{0};
@@ -71,8 +72,8 @@ struct MultimemNvlTransportConfigValidation {
 };
 
 namespace detail {
-inline constexpr uint64_t kMultimemSignalsPerRank = 2;
-inline constexpr uint64_t kMultimemArrivalBarrierSignals = 4;
+inline constexpr uint64_t kMultimemSignalsPerPeer = 3;
+inline constexpr uint64_t kMultimemSignalsPerLane = 4;
 inline constexpr std::size_t kMultimemSignalAlignment = 128;
 inline constexpr std::size_t kMultimemSignalStateSize = 128;
 } // namespace detail
@@ -80,18 +81,11 @@ inline constexpr std::size_t kMultimemSignalStateSize = 128;
 #if defined(__CUDACC__) || defined(__HIPCC__)
 __host__ __device__
 #endif
-    constexpr uint64_t multimem_staging_signals_per_lane_wide(
-        uint64_t nvlRanks) {
-  return detail::kMultimemSignalsPerRank * nvlRanks +
-      detail::kMultimemArrivalBarrierSignals;
-}
-
-#if defined(__CUDACC__) || defined(__HIPCC__)
-__host__ __device__
-#endif
-    constexpr uint32_t multimem_staging_signals_per_lane(uint32_t nvlRanks) {
-  return static_cast<uint32_t>(
-      multimem_staging_signals_per_lane_wide(nvlRanks));
+    constexpr uint64_t multimem_staging_signals_per_channel(
+        uint64_t nvlRanks,
+        uint64_t pipelineDepth) {
+  return detail::kMultimemSignalsPerPeer * nvlRanks +
+      detail::kMultimemSignalsPerLane * pipelineDepth;
 }
 
 // Validate the complete topology-aware config and derive all allocation sizes.

--- a/comms/prims/transport/nvl/MultimemNvlTransportConfig.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransportConfig.h
@@ -1,0 +1,85 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+namespace comms::prims {
+
+struct MultimemNvlTransportConfig {
+  std::size_t dataBufferSize{0};
+  uint32_t userSignalCount{0};
+  std::size_t pipelineDepth{0};
+  std::size_t maxGroups{0};
+
+  bool operator==(const MultimemNvlTransportConfig&) const = default;
+};
+
+enum class MultimemNvlTransportConfigError {
+  None,
+  MissingDataBuffer,
+  InvalidRankCount,
+  PartialStagingGeometry,
+  GeometryOutOfRange,
+  InsufficientDataCapacity,
+  SignalCountOverflow,
+  NoSignalSlots,
+};
+
+struct MultimemNvlTransportConfigValidation {
+  uint32_t internalSignalCount{0};
+  MultimemNvlTransportConfigError error{MultimemNvlTransportConfigError::None};
+
+  explicit operator bool() const {
+    return error == MultimemNvlTransportConfigError::None;
+  }
+};
+
+struct ResolvedMultimemNvlTransportConfig {
+  MultimemNvlTransportConfig config;
+  uint32_t internalSignalCount{0};
+  MultimemNvlTransportConfigError error{MultimemNvlTransportConfigError::None};
+
+  explicit operator bool() const {
+    return error == MultimemNvlTransportConfigError::None;
+  }
+};
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+#define MULTIMEM_HOST_DEVICE __host__ __device__
+#else
+#define MULTIMEM_HOST_DEVICE
+#endif
+
+MULTIMEM_HOST_DEVICE constexpr uint64_t multimem_staging_signals_per_lane_wide(
+    uint64_t nvlRanks) {
+  return 2 * nvlRanks + 4;
+}
+
+MULTIMEM_HOST_DEVICE constexpr uint32_t multimem_staging_signals_per_lane(
+    uint32_t nvlRanks) {
+  return static_cast<uint32_t>(
+      multimem_staging_signals_per_lane_wide(nvlRanks));
+}
+
+#undef MULTIMEM_HOST_DEVICE
+
+const char* multimem_nvl_transport_config_error_string(
+    MultimemNvlTransportConfigError error);
+
+MultimemNvlTransportConfigValidation validate_multimem_nvl_transport_geometry(
+    const MultimemNvlTransportConfig& config);
+
+MultimemNvlTransportConfigValidation validate_multimem_nvl_transport_config(
+    const MultimemNvlTransportConfig& config,
+    int nvlRanks);
+
+ResolvedMultimemNvlTransportConfig resolve_multimem_nvl_transport_config(
+    const std::optional<MultimemNvlTransportConfig>& overrideConfig,
+    const MultimemNvlTransportConfig& fallbackConfig,
+    std::size_t topologyDataBufferSize,
+    int nvlRanks);
+
+} // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlTransportConfig.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransportConfig.h
@@ -1,0 +1,102 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#if defined(__CUDACC__)
+#include <cuda_runtime.h>
+#elif defined(__HIPCC__)
+#include <hip/hip_runtime.h>
+#endif
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+namespace comms::prims {
+
+struct MultimemNvlTransportConfigParams {
+  // Total data capacity is `perChannelSize * maxChannels`.
+  std::size_t perChannelSize{0};
+
+  // Staging pipeline depth. May be zero only when `maxBlocks` is also zero.
+  std::size_t pipelineDepth{0};
+
+  // Number of provisioned data channels.
+  std::size_t maxChannels{0};
+
+  // Maximum collective launch block count. Transport data and internal
+  // staging-signal capacity are provisioned independently by `maxChannels`.
+  std::size_t maxBlocks{0};
+
+  // Signal slots exposed through signal(), read_signal(), and
+  // wait_signal_until(). This is orthogonal to staging geometry.
+  uint32_t userSignalCount{1};
+};
+
+struct MultimemNvlTransportConfig {
+  constexpr MultimemNvlTransportConfig() = default;
+
+  explicit constexpr MultimemNvlTransportConfig(
+      MultimemNvlTransportConfigParams params)
+      : perChannelSize(params.perChannelSize),
+        pipelineDepth(params.pipelineDepth),
+        maxChannels(params.maxChannels),
+        maxBlocks(params.maxBlocks),
+        userSignalCount(params.userSignalCount) {}
+
+  std::size_t perChannelSize{0};
+  std::size_t pipelineDepth{0};
+  std::size_t maxChannels{0};
+  std::size_t maxBlocks{0};
+  uint32_t userSignalCount{1};
+
+  bool operator==(const MultimemNvlTransportConfig&) const = default;
+};
+
+constexpr MultimemNvlTransportConfig make_multimem_nvl_transport_config(
+    MultimemNvlTransportConfigParams params) {
+  return MultimemNvlTransportConfig{params};
+}
+
+struct MultimemNvlTransportConfigValidation {
+  std::size_t dataBufferSize{0};
+  uint32_t internalSignalCount{0};
+  std::size_t signalRegionOffset{0};
+  std::size_t backingAllocationSize{0};
+  std::string_view errorMessage{};
+
+  explicit operator bool() const {
+    return errorMessage.empty();
+  }
+};
+
+namespace detail {
+inline constexpr uint64_t kMultimemSignalsPerRank = 2;
+inline constexpr uint64_t kMultimemArrivalBarrierSignals = 4;
+inline constexpr std::size_t kMultimemSignalAlignment = 128;
+inline constexpr std::size_t kMultimemSignalStateSize = 128;
+} // namespace detail
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+__host__ __device__
+#endif
+    constexpr uint64_t multimem_staging_signals_per_lane_wide(
+        uint64_t nvlRanks) {
+  return detail::kMultimemSignalsPerRank * nvlRanks +
+      detail::kMultimemArrivalBarrierSignals;
+}
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+__host__ __device__
+#endif
+    constexpr uint32_t multimem_staging_signals_per_lane(uint32_t nvlRanks) {
+  return static_cast<uint32_t>(
+      multimem_staging_signals_per_lane_wide(nvlRanks));
+}
+
+// Validate the complete topology-aware config and derive all allocation sizes.
+MultimemNvlTransportConfigValidation validate_multimem_nvl_transport_config(
+    const MultimemNvlTransportConfig& config,
+    int nvlRanks);
+
+} // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -12,26 +12,9 @@
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/Timeout.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlTransportConfig.h"
 
 namespace comms::prims {
-
-// Per-lane internal-signal count for the staging pipeline: the single source of
-// truth shared by the host-side signal-region sizing (MCCL) and the
-// device-side `make_stage_layout` (MultimemNvlStageLayout.cuh) so the region is
-// sized identically on both sides. Layout per lane: `nvlRanks` per-peer ready[]
-// + `nvlRanks` per-peer ack[] + 4 staging arrival-barrier slots (ready/ack
-// counter+epoch, laid out past the SET-mode slots so ADD residue never
-// contaminates a later SET-mode CMP_GE wait) => 2 * nvlRanks + 4.
-__host__ __device__ constexpr uint64_t multimem_staging_signals_per_lane_wide(
-    uint64_t nvlRanks) {
-  return 2 * nvlRanks + 4;
-}
-
-__host__ __device__ constexpr uint32_t multimem_staging_signals_per_lane(
-    uint32_t nvlRanks) {
-  return static_cast<uint32_t>(
-      multimem_staging_signals_per_lane_wide(nvlRanks));
-}
 
 namespace detail {
 

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -1,5 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
 #pragma once
 
 #include <cuda_runtime.h>
@@ -77,7 +78,7 @@ struct MultimemNvlTransportDevice {
   int nvlRanks{1};
   uint32_t pipelineDepth{0};
   uint32_t maxChannels{0};
-  uint32_t signalsPerLane{0};
+  uint32_t signalsPerChannel{0};
 
   __device__ __forceinline__ char* local_data_ptr(std::size_t offset) const {
     return localData + offset;

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -12,27 +12,9 @@
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/Timeout.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlTransportConfig.h"
 
 namespace comms::prims {
-
-// Per-lane internal-signal count for the staging pipeline: the single source of
-// truth shared by the host-side signal-region sizing (MultimemNvlTransport)
-// and the device-side `make_stage_layout` (MultimemNvlStageLayout.cuh) so the
-// region is sized identically on both sides. Layout per lane: `nvlRanks`
-// per-peer ready[]
-// + `nvlRanks` per-peer ack[] + 4 staging arrival-barrier slots (ready/ack
-// counter+epoch, laid out past the SET-mode slots so ADD residue never
-// contaminates a later SET-mode CMP_GE wait) => 2 * nvlRanks + 4.
-__host__ __device__ constexpr uint64_t multimem_staging_signals_per_lane_wide(
-    uint64_t nvlRanks) {
-  return 2 * nvlRanks + 4;
-}
-
-__host__ __device__ constexpr uint32_t multimem_staging_signals_per_lane(
-    uint32_t nvlRanks) {
-  return static_cast<uint32_t>(
-      multimem_staging_signals_per_lane_wide(nvlRanks));
-}
 
 namespace detail {
 

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -22,9 +22,15 @@ namespace comms::prims {
 // + `nvlRanks` per-peer ack[] + 4 staging arrival-barrier slots (ready/ack
 // counter+epoch, laid out past the SET-mode slots so ADD residue never
 // contaminates a later SET-mode CMP_GE wait) => 2 * nvlRanks + 4.
+__host__ __device__ constexpr uint64_t multimem_staging_signals_per_lane_wide(
+    uint64_t nvlRanks) {
+  return 2 * nvlRanks + 4;
+}
+
 __host__ __device__ constexpr uint32_t multimem_staging_signals_per_lane(
     uint32_t nvlRanks) {
-  return 2 * nvlRanks + 4;
+  return static_cast<uint32_t>(
+      multimem_staging_signals_per_lane_wide(nvlRanks));
 }
 
 namespace detail {
@@ -84,6 +90,9 @@ struct MultimemNvlTransportDevice {
   DeviceSpan<SignalState> internalLocalSignals{};
   DeviceSpan<SignalState> internalMultimemSignals{};
   std::size_t dataBufferSize{0};
+  uint32_t pipelineDepth{0};
+  uint32_t maxGroups{0};
+  uint32_t signalsPerLane{0};
   int nvlRank{0};
   int nvlRanks{1};
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1580,13 +1580,18 @@ cvars:
    default     : 33554432
    description : |-
     Size in bytes of the cnvlmm (NVLink multimem) staging window, per rank.
-    Decoupled from NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE so the multimem path can
-    use a larger window without growing the P2P staging buffers. A larger window
-    means fewer staging rounds, which is the dominant cnvlmm throughput lever at
-    large message sizes. 0 falls back to the effective P2P NVL shared devbuf
-    size (the larger of the P2P and hier-AG NVL devbuf sizes when hier-AG
-    overlap is enabled). Default 32 MiB.
+    This allocation is independent of
+    NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE. A larger window means fewer staging
+    rounds, which is the dominant cnvlmm throughput lever at large message
+    sizes. Set to 0 to disable the NVL multimem transport. Default 32 MiB.
 
+ - name        : MCCL_NVL_MULTIMEM_PIPELINE_DEPTH
+   type        : size_t
+   default     : 2
+   description : |-
+     Number of staging lanes per channel used by the Prims NVL multimem
+     transport. Ctran consumes this value when constructing the transport DTO.
+     Values must be in [1, UINT32_MAX].
 
  - name        : CTRAN_P2P_NVL_DEVMEM_MAX_CHUNKS
    type        : uint64_t

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3346,6 +3346,13 @@ cvars:
      Usage: If the NCCL_CTRAN_BACKENS is set with certain values,
      this config will allow MCCL to override backends.
 
+ - name        : MCCL_CNVLMM_PIPELINE_DEPTH
+   type        : size_t
+   default     : 2
+   description : |-
+     Number of staging lanes used by MCCL CNVLMM copy collectives. Values must
+     be in [1, UINT32_MAX].
+
  - name        : MCCL_BOOTSTRAP_SOCKET_HEALTH_POLL_ENABLED
    type        : bool
    default     : true


### PR DESCRIPTION
Summary:
Ctran constructs the Prims `MultimemNvlTransportConfig` directly from transport CVARs and communicator geometry.
Add `MCCL_NVL_MULTIMEM_PIPELINE_DEPTH` so multimem staging depth is independent of the P2P NVL copy pipeline depth.
Use `MCCL_NVL_MULTIMEM_BUFSIZE` exclusively for multimem staging capacity, with zero disabling multimem rather than inheriting the P2P NVL buffer size.
MCCL and `CommStateX` do not capture, store, or exchange this DTO.
Prims transport exchange remains the cross-rank agreement point.

Reviewed By: dboyda, goelayu

Differential Revision: D114879929
