### PR TITLE
Self-import the multicast handle on the root to keep CE-multicast off the host copy engines (#3498)

### DIFF
--- a/comms/ctran/utils/CtranMulticast.cc
+++ b/comms/ctran/utils/CtranMulticast.cc
@@ -127,10 +127,11 @@ commResult_t CtranMulticast::createRoot(
     size_t mcSize,
     CUmemAllocationHandleType handleType,
     CUmemGenericAllocationHandle& outHandle) {
-  // Single-use, symmetric with adoptImported(): release any handle we already
-  // hold before creating a new one, so a misuse (double createRoot, or
-  // createRoot after adoptImported) cannot silently drop -- and leak -- the
-  // previously-held multicast object.
+  // Release any handle we already hold before creating a new one, so a misuse
+  // (double createRoot, or createRoot after adoptImported) cannot silently drop
+  // -- and leak -- the previously-held multicast object. The reverse order
+  // (createRoot then adoptImported) is NOT a misuse: it is the root's
+  // self-import.
   if (mcHandle_ != 0) {
     FB_CUCHECKIGNORE(cuMemRelease(mcHandle_));
     mcHandle_ = 0; // so a cuMulticastCreate failure below can't double-release
@@ -147,10 +148,11 @@ commResult_t CtranMulticast::createRoot(
 }
 
 void CtranMulticast::adoptImported(CUmemGenericAllocationHandle handle) {
-  // Single-use: an instance is either the root (createRoot) or a non-root
-  // (adoptImported), each exactly once. Release any handle we already hold
-  // before overwriting so a misuse (double-adopt, or adopt after createRoot)
-  // cannot silently drop -- and leak -- the previously-held multicast object.
+  // Release any handle we already hold before overwriting, so neither a misuse
+  // (double-adopt) nor the root's create-then-self-import sequence silently
+  // drops -- and leaks -- the previously-held multicast object. Each successful
+  // import carries its own reference and the caller imports before calling
+  // here, so the incoming handle keeps the object alive across the release.
   if (mcHandle_ != 0) {
     FB_CUCHECKIGNORE(cuMemRelease(mcHandle_));
   }

--- a/comms/ctran/utils/CtranMulticast.h
+++ b/comms/ctran/utils/CtranMulticast.h
@@ -66,7 +66,9 @@ class CtranMulticast {
       CUmemAllocationHandleType handleType,
       CUmemGenericAllocationHandle& outHandle);
 
-  // Non-root: adopt the object handle the caller imported from the root.
+  // Adopt an object handle the caller imported from the root, releasing the
+  // previously-held one, if any. Callable after createRoot(), which is how a
+  // root swaps its created handle for a self-imported one.
   void adoptImported(CUmemGenericAllocationHandle handle);
 
   // Every rank: enumerate the physical VMM segments backing [dptr, dptr+len)

--- a/comms/ctran/utils/tests/CtranMulticastDistTest.cc
+++ b/comms/ctran/utils/tests/CtranMulticastDistTest.cc
@@ -23,7 +23,8 @@
 // Distributed test for the NVL CE-multicast registration mechanism, driven the
 // way production drives it: one rank per GPU. The root createRoot()s the
 // multicast object and broadcasts its fabric handle over allGatherNvlDomain;
-// every peer importShareableHandle()s + adoptImported()s it; each rank
+// EVERY rank -- the root included, which self-imports and drops its create
+// reference -- importShareableHandle()s + adoptImported()s it; each rank
 // retainSegments() its own buffer -- self-detecting + retaining its own segment
 // handles -- then addDeviceAndBind()s and mapVA()s. A single multicast write
 // from the root must then fan out (via NVSwitch) into every rank's own buffer
@@ -107,7 +108,7 @@ class MulticastDistTest : public ctran::CtranDistTestFixture {
             ctran::utils::getCuMemAllocHandleType()));
 
     // Root (rank 0) creates the object sized to the summed segments; its fabric
-    // handle is all-gathered so peers import a distinct reference.
+    // handle is all-gathered so every rank imports its own reference.
     constexpr int kRoot = 0;
     auto mc = std::make_shared<CtranMulticast>(lRank, nLocalRanks, lRank);
     std::vector<CtranIpcHandle> handles(nLocalRanks);
@@ -121,13 +122,16 @@ class MulticastDistTest : public ctran::CtranDistTestFixture {
               rootHandle, handles[lRank], /*isFabric=*/true));
     }
     allGatherNvlDomain(comm_.get(), handles);
-    if (rank != kRoot) {
-      CUmemGenericAllocationHandle imported{};
-      COMMCHECK_TEST(
-          ctran::utils::importShareableHandle(
-              handles[kRoot], imported, /*isFabric=*/true));
-      mc->adoptImported(imported);
-    }
+    // Every rank adopts an IMPORTED handle, root included -- production relies
+    // on uniform provenance to keep the multicast write off the copy engines
+    // that service host transfers. For the root this is a same-process
+    // self-import that also drops its createRoot reference, so the broadcast
+    // below doubles as the check that the object outlives that release.
+    CUmemGenericAllocationHandle imported{};
+    COMMCHECK_TEST(
+        ctran::utils::importShareableHandle(
+            handles[kRoot], imported, /*isFabric=*/true));
+    mc->adoptImported(imported);
 
     // Each rank retains its own buffer's segments (self-detect + retain its own
     // handles), then binds them and maps the multicast VA. Both are local ops

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -267,21 +267,26 @@ commResult_t setupMulticast(
     return commSuccess;
   }
 
-  // Non-root: import the root's fabric handle.
-  if (!isRoot) {
-    CUmemGenericAllocationHandle mcHandle = 0;
-    // Abort (not return) on failure: post-vote, every domain rank proceeds to
-    // the second windowBarrier below, so a one-rank error return here would
-    // hang its peers there. The regular NVL buffer import earlier in this same
-    // registration already proved fabric/IMEX works, so a failure now is a
-    // genuine anomaly -- fail loudly rather than deadlock.
-    FB_CHECKABORT(
-        ctran::utils::importShareableHandle(
-            allRzv[0].handle, mcHandle, /*isFabric=*/true) == commSuccess,
-        "CTRAN-MC: rank {} failed to import the root multicast handle post-vote",
-        rank);
-    mc->adoptImported(mcHandle);
-  }
+  // EVERY rank imports, the root included (self-importing what it just
+  // exported). Provenance selects the copy path: over a natively-created handle
+  // the driver treats a write to the multicast VA as a local device-to-device
+  // copy on the engines that also service pinned HtoD/DtoH, so nvlCeBcast's
+  // memcpy serializes behind concurrent host transfers; an imported handle
+  // takes the peer path on a separate engine.
+  CUmemGenericAllocationHandle mcHandle = 0;
+  // Abort (not return) on failure: post-vote, every domain rank proceeds to the
+  // second windowBarrier below, so a one-rank error return here would hang its
+  // peers there. The regular NVL buffer import earlier in this same
+  // registration already proved fabric/IMEX works, so a failure now is a
+  // genuine anomaly -- fail loudly rather than deadlock.
+  FB_CHECKABORT(
+      ctran::utils::importShareableHandle(
+          allRzv[0].handle, mcHandle, /*isFabric=*/true) == commSuccess,
+      "CTRAN-MC: rank {} failed to import the root multicast handle post-vote",
+      rank);
+  // The import holds its own reference, so adoptImported() can safely drop the
+  // root's create reference.
+  mc->adoptImported(mcHandle);
 
   // Every rank: add local device, bind each segment, map the multicast VA.
   // Abort (not return) on failure for the same reason as the import above --


### PR DESCRIPTION
Summary:

In `window::setupMulticast` the NVL-domain root kept the
`CUmemGenericAllocationHandle` it got from `cuMulticastCreate`, while every
other rank adopted a handle obtained via `importShareableHandle` on a FABRIC
handle. This diff makes the root self-import its own exported handle too, so
every rank's multicast mapping has identical provenance.

Handle provenance is not cosmetic -- it selects the copy path the driver uses
for `nvlCeBcast`'s `cudaMemcpyAsync` into the multicast VA:

- Natively-created handle: the driver treats the write as a plain local
  device-to-device copy and schedules it on the async copy engines that also
  service pinned `HtoD`/`DtoH`. The multicast copy then serializes behind any
  concurrent host transfer.
- Imported (fabric) handle: the same write takes the peer copy path on a
  separate engine and overlaps host traffic freely.

Found while reading profiles for the 256-rank ctwin AllGather job.  Eight
ranks -- `{0, 4, 64, 68, 128, 132, 192, 196}`, exactly the multicast roots that
land on `cudaDev 0` -- reported their AllGather copies as `Memcpy DtoD` while
the other 248 reported `Memcpy PtoP`. Roots on `cudaDev` 1-3 escape because the
multicast aperture always reports device ordinal 0, so `src != dst` forces the
peer path regardless of provenance (verified directly: a native root on
`cudaDev 1` still reports `Peer-to-Peer`). 

The import is unconditional and a failure is fatal on EVERY rank, root included
-- the same treatment non-roots already got. Post-vote all domain ranks head to
the second `windowBarrier`, so a one-rank error return would hang its peers;
and the regular NVL buffer import earlier in the same registration already
proved fabric/IMEX works, so a failure here is a genuine anomaly.

Reviewed By: minsii

Differential Revision: D115154306


