### PR TITLE
Make BackendWrapperShutdownTest work on multi-node again

### DIFF
--- a/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
+++ b/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
@@ -22,8 +22,6 @@ Two regressions guarded against:
 from __future__ import annotations
 
 import os
-import tempfile
-import time
 import unittest
 
 import torch
@@ -55,63 +53,37 @@ def _local_rank() -> int:
     return int(os.environ.get("LOCAL_RANK", get_rank_and_size()[0]))
 
 
-def _store_port_file(store_name: str) -> str:
-    return os.path.join(
-        tempfile.gettempdir(),
-        f"torchcomms_backend_wrapper_shutdown_{os.environ['MASTER_PORT']}_{store_name}.port",
-    )
+_root_store: dist.TCPStore | None = None
 
 
-def _create_store_on_free_port(store_name: str) -> dist.TCPStore:
-    rank, world_size = get_rank_and_size()
-    host = os.environ["MASTER_ADDR"]
-    port_file = _store_port_file(store_name)
+def _create_isolated_store(store_name: str) -> dist.Store:
+    """Give each test its own rendezvous namespace.
 
-    if rank == 0:
-        try:
-            os.unlink(port_file)
-        except FileNotFoundError:
-            pass
+    Both tests call ``init_process_group`` in the same process, and c10d
+    restarts its internal group-name numbering after
+    ``destroy_process_group``, so the second PG can collide with keys the
+    first one left behind. A per-test ``PrefixStore`` isolates them.
 
-        store = dist.TCPStore(
-            host_name=host,
-            port=0,
-            world_size=world_size,
-            is_master=True,
+    Isolation is by *namespace*, not by port: the root ``TCPStore`` is bound
+    once to the launcher's ``MASTER_ADDR``/``MASTER_PORT``, which is the only
+    rendezvous endpoint every rank knows without a cross-rank hand-off. That
+    is what makes this multi-node safe -- an ephemeral port has to be
+    communicated somehow, and a node-local file (the previous approach) is
+    invisible to ranks on other hosts.
+
+    Keyed on ``store_name`` rather than a per-process counter so that ranks
+    agree on the namespace regardless of how many stores each has created.
+    """
+    global _root_store
+    if _root_store is None:
+        rank, _ = get_rank_and_size()
+        _root_store = dist.TCPStore(
+            host_name=os.environ["MASTER_ADDR"],
+            port=int(os.environ["MASTER_PORT"]),
+            is_master=(rank == 0),
             wait_for_workers=False,
         )
-        with open(port_file, "w", encoding="utf-8") as f:
-            f.write(str(store.port))
-        return store
-
-    deadline = time.monotonic() + 120
-    while True:
-        try:
-            with open(port_file, encoding="utf-8") as f:
-                port = int(f.read().strip())
-            break
-        except (FileNotFoundError, ValueError):
-            if time.monotonic() >= deadline:
-                raise RuntimeError(f"Timed out waiting for store port file {port_file}")
-            time.sleep(0.05)
-
-    return dist.TCPStore(
-        host_name=host,
-        port=port,
-        world_size=world_size,
-        is_master=False,
-        wait_for_workers=False,
-    )
-
-
-def _cleanup_store_port_file(store_name: str) -> None:
-    if get_rank_and_size()[0] != 0:
-        return
-
-    try:
-        os.unlink(_store_port_file(store_name))
-    except FileNotFoundError:
-        pass
+    return dist.PrefixStore(store_name, _root_store)
 
 
 @unittest.skipUnless(
@@ -138,7 +110,7 @@ class TestBackendWrapperShutdown(unittest.TestCase):
         dist.config.use_torchcomms = True
         dist.init_process_group(
             backend=backend,
-            store=_create_store_on_free_port(store_name),
+            store=_create_isolated_store(store_name),
             rank=rank,
             world_size=world_size,
         )
@@ -155,7 +127,6 @@ class TestBackendWrapperShutdown(unittest.TestCase):
             self.assertEqual(tensor[0].item(), float(dist.get_world_size()))
         finally:
             dist.destroy_process_group()
-            _cleanup_store_port_file(store_name)
 
     def test_mixed_backend_destroy_idempotent(self):
         """Mixed ``cpu:gloo,cuda:nccl`` PG: ``destroy_process_group``
@@ -182,7 +153,7 @@ class TestBackendWrapperShutdown(unittest.TestCase):
         local_device_str = f"{device_str}:{local_rank}"
         dist.init_process_group(
             backend=f"cpu:gloo,{device_str}:{backend_str}",
-            store=_create_store_on_free_port(store_name),
+            store=_create_isolated_store(store_name),
             rank=rank,
             world_size=world_size,
             device_id=torch.device(local_device_str),
@@ -198,7 +169,6 @@ class TestBackendWrapperShutdown(unittest.TestCase):
         finally:
             # Must not raise even though both sub-backends share the comm.
             dist.destroy_process_group()
-            _cleanup_store_port_file(store_name)
 
 
 if __name__ == "__main__":

--- a/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
+++ b/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
@@ -53,27 +53,10 @@ def _local_rank() -> int:
     return int(os.environ.get("LOCAL_RANK", get_rank_and_size()[0]))
 
 
-_root_store: dist.TCPStore | None = None
+_root_store = None
 
 
 def _create_isolated_store(store_name: str) -> dist.Store:
-    """Give each test its own rendezvous namespace.
-
-    Both tests call ``init_process_group`` in the same process, and c10d
-    restarts its internal group-name numbering after
-    ``destroy_process_group``, so the second PG can collide with keys the
-    first one left behind. A per-test ``PrefixStore`` isolates them.
-
-    Isolation is by *namespace*, not by port: the root ``TCPStore`` is bound
-    once to the launcher's ``MASTER_ADDR``/``MASTER_PORT``, which is the only
-    rendezvous endpoint every rank knows without a cross-rank hand-off. That
-    is what makes this multi-node safe -- an ephemeral port has to be
-    communicated somehow, and a node-local file (the previous approach) is
-    invisible to ranks on other hosts.
-
-    Keyed on ``store_name`` rather than a per-process counter so that ranks
-    agree on the namespace regardless of how many stores each has created.
-    """
     global _root_store
     if _root_store is None:
         rank, _ = get_rank_and_size()


### PR DESCRIPTION
To fix the flaky issue, https://github.com/meta-pytorch/torchcomms/pull/2951 introduced use of ephemeral port and publish the port thru node-local file from rank 0. Rank on other hosts cannot find the file so currently the scale-out cases will timeout.  

The PR now uses a single global TCPStore and per-test PrefixStore to avoid rebinding MASTER_PORT in the second test, which also fixes the previous flake issue. At the same time the fix doesn't use any node-local files so the multi-node cases are enabled again.