### PR TITLE
Per-communicator Prims channel buffer size and pipeline depth

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -26,6 +26,7 @@
 #include "comms/utils/colltrace/AlgoStats.h"
 #include "comms/utils/colltrace/CollTraceInterface.h"
 #include "comms/utils/commSpecs.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 
 namespace comms::prims {
 class MultiPeerTransport;
@@ -37,33 +38,64 @@ using meta::comms::CommBackend;
 
 // Per-communicator Prims transport overrides.
 // -1 means use CVAR default.
-struct ctranPipesConfig {
+struct ctranPrimsConfig {
   // -1 uses NCCL_CTRAN_USE_PIPES. MCCL sets this explicitly so its Prims
   // policy does not affect NCCLX or standalone Ctran communicators.
   int64_t enablePrims{-1};
   int64_t nvlChunkSize{-1};
   bool ibLazyConnect{true};
-  int64_t ibgdaDataBufferSize{-1};
+  // Per-channel, per-direction IB staging size. Same unit as
+  // MCCL_CHANNEL_BUFFER_SIZE, which it overrides for this communicator.
+  int64_t channelBufferSize{-1};
+  // -1 uses MCCL_CHANNEL_PIPELINE_DEPTH. Together with channelBufferSize this
+  // fixes the per-chunk size: chunk = channelBufferSize / channelPipelineDepth.
+  int64_t channelPipelineDepth{-1};
+  // -1 uses MCCL_MAX_NCHANNELS. Total IB staging for this communicator is
+  // channelBufferSize * maxChannels per peer per direction.
+  int64_t maxChannels{-1};
+  // -1 uses MCCL_MAX_NBLOCKS. As with the CVAR, this is both the NVL channel
+  // count and the collective launch-geometry block cap; the two must move
+  // together or the multimem signal sizing drifts from the transport's actual
+  // channel count.
+  int64_t maxBlocks{-1};
 
-  bool operator==(const ctranPipesConfig& other) const {
+  bool operator==(const ctranPrimsConfig& other) const {
     return enablePrims == other.enablePrims &&
         nvlChunkSize == other.nvlChunkSize &&
         ibLazyConnect == other.ibLazyConnect &&
-        ibgdaDataBufferSize == other.ibgdaDataBufferSize;
+        channelBufferSize == other.channelBufferSize &&
+        channelPipelineDepth == other.channelPipelineDepth &&
+        maxChannels == other.maxChannels && maxBlocks == other.maxBlocks;
   }
 };
+
+// Per-communicator override first, global CVAR second. Both the transport
+// (comm init) and the collective launch geometry (per call) must resolve these
+// the same way, so they share these helpers rather than reading the CVAR
+// directly. NOTE: mccl's own launch-geometry validation still reads
+// MCCL_MAX_NCHANNELS / MCCL_MAX_NBLOCKS globally; a communicator that overrides
+// these and also runs mccl collectives would be validated against the global.
+inline int64_t ctranPrimsResolvedMaxChannels(const ctranPrimsConfig& pc) {
+  return pc.maxChannels > 0 ? pc.maxChannels
+                            : static_cast<int64_t>(MCCL_MAX_NCHANNELS);
+}
+
+inline int64_t ctranPrimsResolvedMaxBlocks(const ctranPrimsConfig& pc) {
+  return pc.maxBlocks > 0 ? pc.maxBlocks
+                          : static_cast<int64_t>(MCCL_MAX_NBLOCKS);
+}
 
 struct ctranConfig {
   int blocking{-1};
   std::string commDesc;
   std::vector<enum CommBackend> backends = {};
-  ctranPipesConfig pipesConfig;
+  ctranPrimsConfig primsConfig;
   bool enableProfiler{NCCL_CTRAN_TRANSPORT_PROFILER};
 
   bool operator==(const ctranConfig& other) const {
     return (
         blocking == other.blocking && commDesc == other.commDesc &&
-        backends == other.backends && pipesConfig == other.pipesConfig &&
+        backends == other.backends && primsConfig == other.primsConfig &&
         enableProfiler == other.enableProfiler);
   }
 };

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -17,7 +17,7 @@
 #include "comms/utils/logger/LogUtils.h"
 
 bool ctranPrimsEnabled(const CtranComm* comm) {
-  const auto enablePrims = comm->config_.pipesConfig.enablePrims;
+  const auto enablePrims = comm->config_.primsConfig.enablePrims;
   return enablePrims < 0 ? NCCL_CTRAN_USE_PIPES : enablePrims != 0;
 }
 
@@ -33,8 +33,16 @@ bool ctranPipesTraceEnabled() {
   return NCCL_CTRAN_PIPES_TRACE_ENABLE;
 }
 
-int ctranPipesNvlMaxNumChannels() {
-  return std::max(1, MCCL_MAX_NBLOCKS);
+// Resolves the per-communicator override first, MCCL_MAX_NBLOCKS second. As
+// with the CVAR this is both the NVL channel count and the collective
+// launch-geometry block cap -- see ctranPrimsResolvedMaxBlocks().
+// Clamped into int range before narrowing: an int64 hint of 2^32 would
+// otherwise truncate to 0 and 2^31 to INT_MIN, both silently collapsing to a
+// single channel.
+int ctranPipesNvlMaxNumChannels(const ctranPrimsConfig& pc) {
+  const int64_t resolved = std::min<int64_t>(
+      ctranPrimsResolvedMaxBlocks(pc), std::numeric_limits<int>::max());
+  return std::max(1, static_cast<int>(resolved));
 }
 
 size_t roundDownToMultiple(size_t value, size_t multiple) {
@@ -86,7 +94,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         comm->bootstrap_.get(),
         [](meta::comms::IBootstrap*) {}); // no-op deleter
 
-    const auto& pc = comm->config_.pipesConfig;
+    const auto& pc = comm->config_.primsConfig;
     comms::prims::MultiPeerTransportConfig config{};
 
     config.nvlConfig.pipelineDepth =
@@ -96,7 +104,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         NCCL_CTRAN_HIER_AG_OVERLAP_ENABLE && comm->statex_->nLocalRanks() > 1;
     const size_t nvlSharedDevbufSize =
         ctranEffectiveP2pNvlSharedDevbufSize(comm->statex_->nLocalRanks());
-    config.nvlConfig.maxNumChannels = ctranPipesNvlMaxNumChannels();
+    config.nvlConfig.maxNumChannels = ctranPipesNvlMaxNumChannels(pc);
     const size_t nvlMaxNumChannels =
         static_cast<size_t>(config.nvlConfig.maxNumChannels);
     const size_t nvlChannelAlign = 16ULL * config.nvlConfig.pipelineDepth;
@@ -126,9 +134,10 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     if (comm->statex_->nLocalRanks() > 2 && multimemDevbufSize > 0) {
       const uint32_t multimemPipelineDepth = static_cast<uint32_t>(
           std::max<size_t>(1, config.nvlConfig.pipelineDepth));
-      // Reuse the already-computed channel count (== std::max(1,
-      // MCCL_MAX_NBLOCKS)) as the group count so the signal sizing cannot drift
-      // from the transport's actual channel count.
+      // Reuse the already-computed channel count (config.nvlConfig
+      // .maxNumChannels, resolved from primsConfig.maxBlocks or
+      // MCCL_MAX_NBLOCKS) as the group count so the signal sizing cannot drift
+      // from the transport's actual channel count. Do not re-derive it here.
       const uint32_t multimemMaxGroups =
           static_cast<uint32_t>(config.nvlConfig.maxNumChannels);
       // Per-lane signal region, sized from the shared source of truth
@@ -205,43 +214,70 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
       }
       config.ibConfig.ibHca = std::move(hcaStr);
     }
-    if (MCCL_MAX_NCHANNELS <= 0) {
+    const bool channelsFromHint = pc.maxChannels > 0;
+    const char* const channelsSource =
+        channelsFromHint ? "primsConfig.maxChannels" : "MCCL_MAX_NCHANNELS";
+    const int64_t requestedMaxChannels = ctranPrimsResolvedMaxChannels(pc);
+    if (requestedMaxChannels <= 0 ||
+        requestedMaxChannels >
+            static_cast<int64_t>(std::numeric_limits<int>::max())) {
       CLOGF(
           ERR,
-          "MCCL_MAX_NCHANNELS must be positive, got {}",
-          MCCL_MAX_NCHANNELS);
+          "max channels must be in [1, {}], got {} (from {})",
+          std::numeric_limits<int>::max(),
+          requestedMaxChannels,
+          channelsSource);
       return commInvalidArgument;
     }
-    const int maxChannels = static_cast<int>(MCCL_MAX_NCHANNELS);
-    const int channelPipelineDepth =
-        static_cast<int>(MCCL_CHANNEL_PIPELINE_DEPTH);
-    if (channelPipelineDepth <= 0) {
+    const int maxChannels = static_cast<int>(requestedMaxChannels);
+    // Each knob resolves per-communicator hint first, global CVAR second. The
+    // source is carried into every diagnostic below so a bad value points at
+    // the setting that produced it rather than at an internal constant.
+    const bool depthFromHint = pc.channelPipelineDepth > 0;
+    const char* const depthSource = depthFromHint
+        ? "primsConfig.channelPipelineDepth"
+        : "MCCL_CHANNEL_PIPELINE_DEPTH";
+    // Range-check before narrowing: an int64 hint of 2^32+8 would otherwise
+    // truncate to a silently-different depth of 8, and 2^32 would truncate to 0
+    // and be reported as "got 0" rather than as the value the user set.
+    const int64_t requestedPipelineDepth = depthFromHint
+        ? pc.channelPipelineDepth
+        : static_cast<int64_t>(MCCL_CHANNEL_PIPELINE_DEPTH);
+    if (requestedPipelineDepth <= 0 ||
+        requestedPipelineDepth >
+            static_cast<int64_t>(std::numeric_limits<int>::max())) {
       CLOGF(
           ERR,
-          "MCCL_CHANNEL_PIPELINE_DEPTH must be positive, got {}",
-          channelPipelineDepth);
+          "channel pipeline depth must be in [1, {}], got {} (from {})",
+          std::numeric_limits<int>::max(),
+          requestedPipelineDepth,
+          depthSource);
       return commInvalidArgument;
     }
+    const int channelPipelineDepth = static_cast<int>(requestedPipelineDepth);
 
-    size_t ibgdaDataBufferSize = 0;
-    if (pc.ibgdaDataBufferSize > 0) {
-      ibgdaDataBufferSize = static_cast<size_t>(pc.ibgdaDataBufferSize);
-    } else {
-      const auto perDirectionChannelBuffer =
-          static_cast<size_t>(MCCL_CHANNEL_BUFFER_SIZE);
-      if (perDirectionChannelBuffer > std::numeric_limits<size_t>::max() /
-              static_cast<size_t>(maxChannels)) {
-        CLOGF(
-            ERR,
-            "MCCL_CHANNEL_BUFFER_SIZE={} overflows total size for {} channels",
-            perDirectionChannelBuffer,
-            maxChannels);
-        return commInvalidArgument;
-      }
-      ibgdaDataBufferSize =
-          perDirectionChannelBuffer * static_cast<size_t>(maxChannels);
+    // Both sources are per-channel, per-direction, so the total is always an
+    // exact multiple of the channel count -- no divisibility check needed.
+    const bool bufferFromHint = pc.channelBufferSize > 0;
+    const char* const bufferSource = bufferFromHint
+        ? "primsConfig.channelBufferSize"
+        : "MCCL_CHANNEL_BUFFER_SIZE";
+    const size_t perDirectionChannelBuffer = bufferFromHint
+        ? static_cast<size_t>(pc.channelBufferSize)
+        : static_cast<size_t>(MCCL_CHANNEL_BUFFER_SIZE);
+    if (perDirectionChannelBuffer >
+        std::numeric_limits<size_t>::max() / static_cast<size_t>(maxChannels)) {
+      CLOGF(
+          ERR,
+          "channel buffer size {} (from {}) overflows total size for {} channels (from {})",
+          perDirectionChannelBuffer,
+          bufferSource,
+          maxChannels,
+          channelsSource);
+      return commInvalidArgument;
     }
-    config.ibConfig.dataBufferSize = ibgdaDataBufferSize;
+    config.ibConfig.dataBufferSize =
+        perDirectionChannelBuffer * static_cast<size_t>(maxChannels);
     config.ibConfig.qpDepth = MCCL_IB_QP_DEPTH;
     if (NCCL_IB_TIMEOUT != NCCL_IB_TIMEOUT_DEFAULTCVARVALUE) {
       config.ibConfig.timeout = static_cast<uint8_t>(NCCL_IB_TIMEOUT);
@@ -280,42 +316,65 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     if (config.ibConfig.dataBufferSize == 0) {
       CLOGF(
           ERR,
-          "send/recv requires a positive staging size via MCCL_CHANNEL_BUFFER_SIZE or pipesIbgdaDataBufferSize");
+          "send/recv requires a positive staging size via MCCL_CHANNEL_BUFFER_SIZE or primsConfig.channelBufferSize");
       return commInvalidArgument;
     }
-    if (config.ibConfig.dataBufferSize % static_cast<size_t>(maxChannels) !=
-        0) {
-      CLOGF(
-          ERR,
-          "IB data-buffer size {} must be divisible by channel count {}",
-          config.ibConfig.dataBufferSize,
-          maxChannels);
-      return commInvalidArgument;
-    }
-    const size_t perDirectionChannelBuffer =
-        config.ibConfig.dataBufferSize / static_cast<size_t>(maxChannels);
     const auto pipelineDepth = static_cast<size_t>(channelPipelineDepth);
     if (perDirectionChannelBuffer % pipelineDepth != 0) {
       CLOGF(
           ERR,
-          "IB per-direction channel buffer {} must be divisible by pipeline depth {}",
+          "IB per-direction channel buffer {} (from {}) must be divisible by pipeline depth {}",
           perDirectionChannelBuffer,
+          bufferSource,
           channelPipelineDepth);
+      return commInvalidArgument;
+    }
+    // MultiPeerIbTransport enforces these too, but it throws
+    // std::invalid_argument which the catch below turns into commInternalError
+    // with no mention of the offending setting. Now that both values are
+    // settable per communicator, check them here so a bad hint is reported as
+    // what it is.
+    const size_t channelChunkSize = perDirectionChannelBuffer / pipelineDepth;
+    auto check16ByteAligned =
+        [](const char* what, size_t value, const std::string& source) {
+          if (value >= 16 && value % 16 == 0) {
+            return true;
+          }
+          CLOGF(
+              ERR,
+              "IB {} must be >= 16 and 16-byte aligned, got {} (from {})",
+              what,
+              value,
+              source);
+          return false;
+        };
+    // The chunk is derived from both knobs, so name both: a bad depth must not
+    // report the buffer as the culprit.
+    if (!check16ByteAligned(
+            "per-direction channel buffer",
+            perDirectionChannelBuffer,
+            bufferSource) ||
+        !check16ByteAligned(
+            "channel chunk (buffer / pipeline depth)",
+            channelChunkSize,
+            fmt::format("{} / {}", bufferSource, depthSource))) {
       return commInvalidArgument;
     }
 
     config.ibConfig.perChannelSize = perDirectionChannelBuffer;
     config.ibConfig.max_num_channels = config.ibConfig.maxGroups;
     config.ibConfig.pipelineDepth = channelPipelineDepth;
-    const size_t channelChunkSize = config.ibConfig.perChannelSize /
-        static_cast<size_t>(config.ibConfig.pipelineDepth);
     CLOGF(
         INFO,
-        "Prims IB sendRecv configured: perChannelSize={}, channelChunkSize={}, maxNumChannels={}, pipelineDepth={}, dataBufferSize={}",
+        "Prims IB sendRecv configured: rank={}, commDesc={}, perChannelSize={} (from {}), channelChunkSize={}, maxNumChannels={}, pipelineDepth={} (from {}), dataBufferSize={}",
+        comm->statex_->rank(),
+        comm->config_.commDesc,
         config.ibConfig.perChannelSize,
+        bufferSource,
         channelChunkSize,
         config.ibConfig.max_num_channels,
         config.ibConfig.pipelineDepth,
+        depthSource,
         config.ibConfig.dataBufferSize);
 
     if (MCCL_IB_MODE == MCCL_IB_MODE::ibrc) {

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterDirectIb.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterDirectIb.cc
@@ -283,9 +283,15 @@ static commResult_t ctranReduceScatterDirectIbImpl(
       return commInvalidArgument;
     }
 
+    // Resolve through the same helpers the transport used at comm init, so a
+    // communicator that overrides these does not end up with a launch geometry
+    // that disagrees with its staging layout.
+    const auto& primsConfig = comm->config_.primsConfig;
     const int numBlocks =
         ctran::reducescatter::direct_ib::numBlocksForTotalBytes(
-            wireTotalBytes, MCCL_MAX_NCHANNELS, MCCL_MAX_NBLOCKS);
+            wireTotalBytes,
+            static_cast<int>(ctranPrimsResolvedMaxChannels(primsConfig)),
+            static_cast<int>(ctranPrimsResolvedMaxBlocks(primsConfig)));
 
     comms::prims::DirectReduceScatterIbLaunchParams params{};
     params.my_rank = statex->rank();

--- a/comms/ctran/tests/CtranCommTest.cc
+++ b/comms/ctran/tests/CtranCommTest.cc
@@ -72,11 +72,47 @@ TEST(CtranCommTest, PrimsPolicyIsPerCommunicator) {
   auto restoreUsePipes = folly::makeGuard(
       [savedUsePipes] { NCCL_CTRAN_USE_PIPES = savedUsePipes; });
 
-  CtranComm mcclComm(abort, ctranConfig{.pipesConfig = {.enablePrims = 1}});
+  CtranComm mcclComm(abort, ctranConfig{.primsConfig = {.enablePrims = 1}});
   CtranComm ncclxComm(abort);
 
   EXPECT_TRUE(ctranPrimsEnabled(&mcclComm));
   EXPECT_FALSE(ctranPrimsEnabled(&ncclxComm));
+}
+
+// The transport binds its staging geometry at comm init while the collective
+// resolves its launch geometry per call. Both go through these helpers so the
+// two cannot disagree -- pin that hint-first / CVAR-second contract here.
+TEST(CtranCommTest, PrimsGeometryResolvesHintBeforeCvar) {
+  const int64_t savedChannels = MCCL_MAX_NCHANNELS;
+  const int64_t savedBlocks = MCCL_MAX_NBLOCKS;
+  auto restore = folly::makeGuard([savedChannels, savedBlocks] {
+    MCCL_MAX_NCHANNELS = savedChannels;
+    MCCL_MAX_NBLOCKS = savedBlocks;
+  });
+  MCCL_MAX_NCHANNELS = 32;
+  MCCL_MAX_NBLOCKS = 16;
+
+  // Unset (-1) falls back to the CVAR.
+  const ctranPrimsConfig unset{};
+  EXPECT_EQ(ctranPrimsResolvedMaxChannels(unset), 32);
+  EXPECT_EQ(ctranPrimsResolvedMaxBlocks(unset), 16);
+
+  // Set overrides the CVAR, independently per knob.
+  ctranPrimsConfig channelsOnly{};
+  channelsOnly.maxChannels = 8;
+  EXPECT_EQ(ctranPrimsResolvedMaxChannels(channelsOnly), 8);
+  EXPECT_EQ(ctranPrimsResolvedMaxBlocks(channelsOnly), 16);
+
+  ctranPrimsConfig blocksOnly{};
+  blocksOnly.maxBlocks = 12;
+  EXPECT_EQ(ctranPrimsResolvedMaxChannels(blocksOnly), 32);
+  EXPECT_EQ(ctranPrimsResolvedMaxBlocks(blocksOnly), 12);
+
+  ctranPrimsConfig both{};
+  both.maxChannels = 8;
+  both.maxBlocks = 12;
+  EXPECT_EQ(ctranPrimsResolvedMaxChannels(both), 8);
+  EXPECT_EQ(ctranPrimsResolvedMaxBlocks(both), 12);
 }
 
 TEST(CtranCommTest, ExplicitPrimsDisableDoesNotAffectLegacyPolicy) {
@@ -86,7 +122,7 @@ TEST(CtranCommTest, ExplicitPrimsDisableDoesNotAffectLegacyPolicy) {
   auto restoreUsePipes = folly::makeGuard(
       [savedUsePipes] { NCCL_CTRAN_USE_PIPES = savedUsePipes; });
 
-  CtranComm mcclComm(abort, ctranConfig{.pipesConfig = {.enablePrims = 0}});
+  CtranComm mcclComm(abort, ctranConfig{.primsConfig = {.enablePrims = 0}});
   CtranComm ncclxComm(abort);
 
   EXPECT_FALSE(ctranPrimsEnabled(&mcclComm));

--- a/comms/ctran/tests/CtranDistTestUtils.cc
+++ b/comms/ctran/tests/CtranDistTestUtils.cc
@@ -167,7 +167,7 @@ std::unique_ptr<CtranComm> CtranDistTestFixture::makeCtranComm(
   comm->config_.commDesc = comm->statex_->commDesc().c_str();
   // Preserve the compatibility setting through the standalone Ctran path.
   // Peer materialization remains on demand for either value.
-  comm->config_.pipesConfig.ibLazyConnect = ibLazyConnect;
+  comm->config_.primsConfig.ibLazyConnect = ibLazyConnect;
   // Consumed during ctranInit (inside CtranAlgo's ctor), so must be set on the
   // comm before ctranInit runs.
   comm->tmpbufEagerAlloc_ = tmpbufEagerAlloc;

--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -179,21 +179,101 @@ Config::Config(const ncclConfig_t* config) {
       }
     }
   }
+  // Per-communicator Prims transport overrides.
   {
-    std::string val = getHintStr("pipesIbgdaDataBufferSize");
+    // Tri-state: absent leaves the optional unset so ctranPrimsEnabled() falls
+    // back to NCCL_CTRAN_USE_PIPES. When present, accept the same spellings as
+    // every other boolean hint (1/0, true/false, yes/no, y/n, t/f) rather than
+    // digits only -- 'enablePrims=true' silently doing nothing is the kind of
+    // per-rank divergence that surfaces only as a comm-init hang.
+    //
+    // An UNPARSEABLE value leaves the optional unset, degrading to the global
+    // default with a WARN, which matches how every other bool hint in this
+    // file behaves. Note this does NOT make a typo safe: if only some ranks
+    // carry it, those ranks fall back to the CVAR while the rest honour the
+    // hint, and a transport mismatch across a communicator hangs comm init.
+    // Cross-rank hint consistency remains the caller's responsibility.
+    // parseHintBool cannot express the tri-state (its default doubles as the
+    // absent value), so parse the spellings directly here. Unlike
+    // parseHintBool there is deliberately no numeric fallback, so
+    // 'enablePrims=2' is rejected rather than treated as true.
+    std::string val = getHintStr("enablePrims");
+    if (!val.empty()) {
+      std::string lower(val.size(), '\0');
+      std::transform(val.begin(), val.end(), lower.begin(), ::tolower);
+      if (lower == "1" || lower == "yes" || lower == "true" || lower == "y" ||
+          lower == "t") {
+        enablePrims = 1;
+      } else if (
+          lower == "0" || lower == "no" || lower == "false" || lower == "n" ||
+          lower == "f") {
+        enablePrims = 0;
+      } else {
+        WARN(
+            "NCCLX hint 'enablePrims': invalid value '%s'; falling back to NCCL_CTRAN_USE_PIPES",
+            val.c_str());
+      }
+    }
+  }
+  {
+    std::string val = getHintStr("primsChannelBufferSize");
     if (!val.empty()) {
       try {
-        auto parsed = std::stoull(val);
-        if (parsed > 0) {
-          pipesIbgdaDataBufferSize = parsed;
+        // std::stoull silently wraps a leading '-', so "-1" would parse as
+        // 2^64-1 and pass the positivity check. Reject the sign explicitly.
+        if (val.find('-') != std::string::npos) {
+          WARN(
+              "NCCLX hint 'primsChannelBufferSize': value must be positive, got '%s'",
+              val.c_str());
+        } else if (auto parsed = std::stoull(val); parsed > 0) {
+          primsChannelBufferSize = parsed;
         } else {
-          WARN("NCCLX hint 'pipesIbgdaDataBufferSize': value must be positive");
+          WARN("NCCLX hint 'primsChannelBufferSize': value must be positive");
         }
       } catch (const std::exception&) {
         WARN(
-            "NCCLX hint 'pipesIbgdaDataBufferSize': invalid value '%s'",
+            "NCCLX hint 'primsChannelBufferSize': invalid value '%s'",
             val.c_str());
       }
+    }
+  }
+  {
+    std::string val = getHintStr("primsChannelPipelineDepth");
+    if (!val.empty()) {
+      try {
+        auto parsed = std::stoll(val);
+        if (parsed > 0) {
+          primsChannelPipelineDepth = static_cast<int64_t>(parsed);
+        } else {
+          WARN(
+              "NCCLX hint 'primsChannelPipelineDepth': value must be positive");
+        }
+      } catch (const std::exception&) {
+        WARN(
+            "NCCLX hint 'primsChannelPipelineDepth': invalid value '%s'",
+            val.c_str());
+      }
+    }
+  }
+
+  for (const auto& [key, field] :
+       {std::pair<const char*, std::optional<int64_t>*>{
+            "primsMaxChannels", &primsMaxChannels},
+        std::pair<const char*, std::optional<int64_t>*>{
+            "primsMaxBlocks", &primsMaxBlocks}}) {
+    std::string val = getHintStr(key);
+    if (val.empty()) {
+      continue;
+    }
+    try {
+      auto parsed = std::stoll(val);
+      if (parsed > 0) {
+        *field = static_cast<int64_t>(parsed);
+      } else {
+        WARN("NCCLX hint '%s': value must be positive", key);
+      }
+    } catch (const std::exception&) {
+      WARN("NCCLX hint '%s': invalid value '%s'", key, val.c_str());
     }
   }
 
@@ -419,7 +499,11 @@ void ncclxLogCommConfig(ncclComm_t comm) {
       append(fmt::format("vCliqueSize={}", xCfg->vCliqueSize));
     }
     appendIfSet("pipesNvlChunkSize", xCfg->pipesNvlChunkSize);
-    appendIfSet("pipesIbgdaDataBufferSize", xCfg->pipesIbgdaDataBufferSize);
+    appendIfSet("enablePrims", xCfg->enablePrims);
+    appendIfSet("primsChannelBufferSize", xCfg->primsChannelBufferSize);
+    appendIfSet("primsChannelPipelineDepth", xCfg->primsChannelPipelineDepth);
+    appendIfSet("primsMaxChannels", xCfg->primsMaxChannels);
+    appendIfSet("primsMaxBlocks", xCfg->primsMaxBlocks);
     appendIfSet("ncclBuffSize", xCfg->ncclBuffSize);
     appendIfSet("ibSplitDataOnQps", xCfg->ibSplitDataOnQps);
     appendIfSet("ibQpsPerConnection", xCfg->ibQpsPerConnection);

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -55,10 +55,23 @@ class Config {
   enum NCCL_ALLTOALLV_ALGO alltoallvAlgo = NCCL_ALLTOALLV_ALGO::orig;
   enum NCCL_RMA_ALGO rmaAlgo = NCCL_RMA_ALGO::orig;
 
-  // Per-communicator MultiPeerTransport (pipes) NVL config overrides.
-  // When set, override the corresponding CVARs for this communicator.
+  // Per-communicator Prims (MultiPeerTransport) overrides. When set, each
+  // overrides the corresponding CVAR for this communicator only.
+  // enablePrims overrides NCCL_CTRAN_USE_PIPES, so Prims -- and the IB staging
+  // it allocates -- can be turned on for one process group without paying the
+  // memory on every other communicator in the job.
   std::optional<size_t> pipesNvlChunkSize;
-  std::optional<size_t> pipesIbgdaDataBufferSize;
+  std::optional<int64_t> enablePrims;
+  // Per-channel, per-direction. Same unit as MCCL_CHANNEL_BUFFER_SIZE.
+  std::optional<size_t> primsChannelBufferSize;
+  // chunk = primsChannelBufferSize / primsChannelPipelineDepth.
+  std::optional<int64_t> primsChannelPipelineDepth;
+  // Override MCCL_MAX_NCHANNELS / MCCL_MAX_NBLOCKS for this communicator.
+  // Total IB staging is primsChannelBufferSize * primsMaxChannels per peer per
+  // direction. primsMaxBlocks is both the NVL channel count and the collective
+  // launch-geometry block cap, matching the CVAR it overrides.
+  std::optional<int64_t> primsMaxChannels;
+  std::optional<int64_t> primsMaxBlocks;
   int vCliqueSize = 0;
 
   // Per-communicator buffer size override (Simple protocol).
@@ -93,11 +106,15 @@ inline const std::vector<std::string>& knownHintKeys() {
       "sendrecvAlgo",
       "allgatherAlgo",
       "allreduceAlgo",
-      "pipesIbgdaDataBufferSize",
       "alltoallAlgo",
       "alltoallvAlgo",
       "rmaAlgo",
       "pipesNvlChunkSize",
+      "enablePrims",
+      "primsChannelBufferSize",
+      "primsChannelPipelineDepth",
+      "primsMaxChannels",
+      "primsMaxBlocks",
       "vCliqueSize",
       "ncclBuffSize",
       "ibSplitDataOnQps",

--- a/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
+++ b/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
@@ -480,3 +480,274 @@ TEST(ConfigHintsUT, InvalidAlgoHintFallsBackToDefault) {
   EXPECT_EQ(NCCLX_CONFIG_FIELD(config, sendrecvAlgo), NCCL_SENDRECV_ALGO::orig);
   delete static_cast<ncclx::Config*>(config.ncclxConfig);
 }
+
+// ----- Per-communicator Prims transport overrides -----
+//
+// These three hints override MCCL_CHANNEL_BUFFER_SIZE,
+// MCCL_CHANNEL_PIPELINE_DEPTH and NCCL_CTRAN_USE_PIPES for a single
+// communicator. `primsChannelBufferSize` is per-channel, per-direction --
+// the same unit as the CVAR it overrides.
+
+TEST(ConfigHintsUT, PrimsChannelBufferSizeSetViaHint) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("primsChannelBufferSize", "4194304");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  ASSERT_TRUE(ncclxCfg->primsChannelBufferSize.has_value());
+  EXPECT_EQ(ncclxCfg->primsChannelBufferSize.value(), 4194304U);
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, PrimsChannelBufferSizeDefaultUnset) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->primsChannelBufferSize.has_value());
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, PrimsChannelBufferSizeRejectsZero) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("primsChannelBufferSize", "0");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->primsChannelBufferSize.has_value());
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, PrimsChannelBufferSizeRejectsInvalidString) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("primsChannelBufferSize", "four-megabytes");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->primsChannelBufferSize.has_value());
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, PrimsChannelPipelineDepthSetViaHint) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("primsChannelPipelineDepth", "4");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  ASSERT_TRUE(ncclxCfg->primsChannelPipelineDepth.has_value());
+  EXPECT_EQ(ncclxCfg->primsChannelPipelineDepth.value(), 4);
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, PrimsChannelPipelineDepthDefaultUnset) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->primsChannelPipelineDepth.has_value());
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, PrimsChannelPipelineDepthRejectsZeroAndNegative) {
+  for (const char* bad : {"0", "-4"}) {
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints;
+    hints.set("primsChannelPipelineDepth", bad);
+    config.hints = &hints;
+
+    EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+    auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+    EXPECT_FALSE(ncclxCfg->primsChannelPipelineDepth.has_value()) << bad;
+
+    delete ncclxCfg;
+  }
+}
+
+// enablePrims is tri-state: absent leaves the optional unset so
+// ctranPrimsEnabled() falls back to NCCL_CTRAN_USE_PIPES; 0 is an explicit
+// disable and must NOT be confused with absent.
+TEST(ConfigHintsUT, EnablePrimsAcceptsBooleanSpellings) {
+  const std::vector<std::pair<const char*, int64_t>> cases = {
+      {"1", 1},
+      {"0", 0},
+      {"true", 1},
+      {"false", 0},
+      {"yes", 1},
+      {"no", 0},
+      {"t", 1},
+      {"f", 0},
+  };
+  for (const auto& [text, expected] : cases) {
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints;
+    hints.set("enablePrims", text);
+    config.hints = &hints;
+
+    EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+    auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+    EXPECT_TRUE(ncclxCfg->enablePrims.has_value()) << text;
+    if (ncclxCfg->enablePrims.has_value()) {
+      EXPECT_EQ(ncclxCfg->enablePrims.value(), expected) << text;
+    }
+
+    delete ncclxCfg;
+  }
+}
+
+TEST(ConfigHintsUT, EnablePrimsDefaultUnset) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->enablePrims.has_value());
+
+  delete ncclxCfg;
+}
+
+// The torchcomms bootstrap only forwards "ncclx::"-prefixed hints; Hints::set
+// strips the prefix. A mismatch between the prefixed and bare spelling would
+// silently drop the hint, so pin both to the same result.
+TEST(ConfigHintsUT, PrimsPrefixedKeysMatchBareKeys) {
+  ncclConfig_t prefixed = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints prefixedHints;
+  prefixedHints.set("ncclx::enablePrims", "1");
+  prefixedHints.set("ncclx::primsChannelBufferSize", "4194304");
+  prefixedHints.set("ncclx::primsChannelPipelineDepth", "4");
+  prefixedHints.set("ncclx::primsMaxChannels", "8");
+  prefixedHints.set("ncclx::primsMaxBlocks", "12");
+  prefixed.hints = &prefixedHints;
+  EXPECT_EQ(ncclxParseCommConfig(&prefixed), ncclSuccess);
+
+  ncclConfig_t bare = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints bareHints;
+  bareHints.set("enablePrims", "1");
+  bareHints.set("primsChannelBufferSize", "4194304");
+  bareHints.set("primsChannelPipelineDepth", "4");
+  bareHints.set("primsMaxChannels", "8");
+  bareHints.set("primsMaxBlocks", "12");
+  bare.hints = &bareHints;
+  EXPECT_EQ(ncclxParseCommConfig(&bare), ncclSuccess);
+
+  auto* p = static_cast<ncclx::Config*>(prefixed.ncclxConfig);
+  auto* b = static_cast<ncclx::Config*>(bare.ncclxConfig);
+  EXPECT_EQ(p->enablePrims, b->enablePrims);
+  EXPECT_EQ(p->primsChannelBufferSize, b->primsChannelBufferSize);
+  EXPECT_EQ(p->primsChannelPipelineDepth, b->primsChannelPipelineDepth);
+  EXPECT_EQ(p->primsMaxChannels, b->primsMaxChannels);
+  EXPECT_EQ(p->primsMaxBlocks, b->primsMaxBlocks);
+  ASSERT_TRUE(p->primsChannelBufferSize.has_value());
+  EXPECT_EQ(p->primsChannelBufferSize.value(), 4194304U);
+
+  delete p;
+  delete b;
+}
+
+// An unparseable enablePrims must leave the optional UNSET so every rank falls
+// back to the same CVAR. Resolving a typo to an explicit disable on only the
+// ranks carrying it is what produces a mismatched-transport comm-init hang.
+TEST(ConfigHintsUT, EnablePrimsInvalidLeavesUnset) {
+  for (const char* bad : {"maybe", "2x", ""}) {
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints;
+    hints.set("enablePrims", bad);
+    config.hints = &hints;
+
+    EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+    auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+    EXPECT_FALSE(ncclxCfg->enablePrims.has_value()) << bad;
+
+    delete ncclxCfg;
+  }
+}
+
+// std::stoull wraps a leading '-', so "-1" would otherwise parse as 2^64-1 and
+// pass the positivity check.
+TEST(ConfigHintsUT, PrimsChannelBufferSizeRejectsNegative) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("primsChannelBufferSize", "-1");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->primsChannelBufferSize.has_value());
+
+  delete ncclxCfg;
+}
+
+// primsMaxChannels / primsMaxBlocks override MCCL_MAX_NCHANNELS /
+// MCCL_MAX_NBLOCKS for one communicator. Both the transport (comm init) and
+// the collective launch geometry resolve through the same helpers.
+TEST(ConfigHintsUT, PrimsMaxChannelsAndBlocksSetViaHint) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("primsMaxChannels", "8");
+  hints.set("primsMaxBlocks", "12");
+  config.hints = &hints;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  ASSERT_TRUE(ncclxCfg->primsMaxChannels.has_value());
+  EXPECT_EQ(ncclxCfg->primsMaxChannels.value(), 8);
+  ASSERT_TRUE(ncclxCfg->primsMaxBlocks.has_value());
+  EXPECT_EQ(ncclxCfg->primsMaxBlocks.value(), 12);
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, PrimsMaxChannelsAndBlocksDefaultUnset) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+  auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+  EXPECT_FALSE(ncclxCfg->primsMaxChannels.has_value());
+  EXPECT_FALSE(ncclxCfg->primsMaxBlocks.has_value());
+
+  delete ncclxCfg;
+}
+
+TEST(ConfigHintsUT, PrimsMaxChannelsAndBlocksRejectBadValues) {
+  for (const char* key : {"primsMaxChannels", "primsMaxBlocks"}) {
+    for (const char* bad : {"0", "-1", "lots"}) {
+      ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+      ncclx::Hints hints;
+      hints.set(key, bad);
+      config.hints = &hints;
+
+      EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+
+      auto* ncclxCfg = static_cast<ncclx::Config*>(config.ncclxConfig);
+      EXPECT_FALSE(ncclxCfg->primsMaxChannels.has_value()) << key << "=" << bad;
+      EXPECT_FALSE(ncclxCfg->primsMaxBlocks.has_value()) << key << "=" << bad;
+
+      delete ncclxCfg;
+    }
+  }
+}

--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -43,13 +43,26 @@ ctranConfig makeCtranConfigFrom(ncclComm* comm) {
     const auto* ncclxCfg =
         static_cast<ncclx::Config*>(comm->config.ncclxConfig);
     if (ncclxCfg->pipesNvlChunkSize.has_value()) {
-      tconfig.pipesConfig.nvlChunkSize =
+      tconfig.primsConfig.nvlChunkSize =
           static_cast<int64_t>(ncclxCfg->pipesNvlChunkSize.value());
     }
-    tconfig.pipesConfig.ibLazyConnect = ncclxCfg->deviceIbLazyConnect;
-    if (ncclxCfg->pipesIbgdaDataBufferSize.has_value()) {
-      tconfig.pipesConfig.ibgdaDataBufferSize =
-          static_cast<int64_t>(ncclxCfg->pipesIbgdaDataBufferSize.value());
+    tconfig.primsConfig.ibLazyConnect = ncclxCfg->deviceIbLazyConnect;
+    if (ncclxCfg->enablePrims.has_value()) {
+      tconfig.primsConfig.enablePrims = ncclxCfg->enablePrims.value();
+    }
+    if (ncclxCfg->primsChannelBufferSize.has_value()) {
+      tconfig.primsConfig.channelBufferSize =
+          static_cast<int64_t>(ncclxCfg->primsChannelBufferSize.value());
+    }
+    if (ncclxCfg->primsChannelPipelineDepth.has_value()) {
+      tconfig.primsConfig.channelPipelineDepth =
+          ncclxCfg->primsChannelPipelineDepth.value();
+    }
+    if (ncclxCfg->primsMaxChannels.has_value()) {
+      tconfig.primsConfig.maxChannels = ncclxCfg->primsMaxChannels.value();
+    }
+    if (ncclxCfg->primsMaxBlocks.has_value()) {
+      tconfig.primsConfig.maxBlocks = ncclxCfg->primsMaxBlocks.value();
     }
   }
   return tconfig;


### PR DESCRIPTION
Summary:
Adds five per-communicator Prims transport overrides so a single process group
can tune its IB staging geometry without changing it for every other
communicator in the job. Each resolves per-comm hint first, global CVAR second:

| hint | overrides |
|---|---|
| `enablePrims` | `NCCL_CTRAN_USE_PIPES` |
| `primsChannelBufferSize` | `MCCL_CHANNEL_BUFFER_SIZE` |
| `primsChannelPipelineDepth` | `MCCL_CHANNEL_PIPELINE_DEPTH` |
| `primsMaxChannels` | `MCCL_MAX_NCHANNELS` |
| `primsMaxBlocks` | `MCCL_MAX_NBLOCKS` |

Motivation: on the quantized ReduceScatter DirectIB path, raising the
per-channel buffer from 2 MiB to 4 MiB (i.e. the chunk from 512 KiB to 1 MiB) is
worth +1.5% at 2 GiB and +4.3% at 512 MiB at 8 blocks, 8 ranks cross-node. Doing
that with the global CVAR would multiply IB staging on every Prims-enabled
communicator; only the DP-mod-EP group benefits. `enablePrims` further lets a
job leave Prims off globally and enable it for that one group, so no other
communicator allocates staging at all.

**Unit fix.** The staging-size hint already existed as `pipesIbgdaDataBufferSize`
but had **no callers**, and its unit disagreed with the CVAR it overrode: the
CVAR is per-channel-per-direction and gets multiplied by the channel count,
while the hint was the already-multiplied total. Both now use the CVAR's unit,
which removes the factor-of-`MCCL_MAX_NCHANNELS` trap between the two spellings
of the same setting, makes the chunk size invariant to the channel count rather
than silently moving with it, makes the `dataBufferSize % maxChannels` check
unviolatable by construction (so it is deleted), and collapses a
multiply-up-then-divide-back-down round trip in `CtranPipes.cc`.

**Shared resolvers.** `ctranPrimsResolvedMaxChannels` / `...MaxBlocks`
(`CtranComm.h`) are used by both the transport at comm init (`CtranPipes.cc`)
and the collective launch geometry per call
(`ReduceScatterDirectIb.cc`), so the kernel grid cannot disagree with the
staging layout. As with the CVAR, `primsMaxBlocks` is both the NVL channel count
and the launch block cap; the multimem signal sizing continues to read the
already-resolved `config.nvlConfig.maxNumChannels` rather than re-deriving it.

**Diagnosability.** `MultiPeerIbTransport`'s `>= 16` / 16-byte-alignment checks
are hoisted into `CtranPipes.cc`, so a bad hint returns `commInvalidArgument`
naming the setting that produced it instead of throwing and surfacing as
`commInternalError`. Every diagnostic in the block now carries a provenance
string, and the resolved-geometry INFO log gains `rank=` and `commDesc=` -- with
several PGs at different geometries in one process, that line previously could
not be attributed to a communicator.

**Renames**, since these files are all touched anyway: `ctranPipesConfig` ->
`ctranPrimsConfig`, `pipesConfig` -> `primsConfig` ("pipes" is the old name for
Prims). The `NCCL_CTRAN_*_PIPES*` CVARs, `PipesTrace` and `CtranPipes.{cc,h}`
are deliberately NOT renamed: the CVARs are a public interface and the rest is a
larger mechanical change that belongs in its own diff.

No compatibility alias for the old hint name, as it had no callers.

**Known scope limit.** mccl's own launch-geometry validation still reads
`MCCL_MAX_NCHANNELS` / `MCCL_MAX_NBLOCKS` globally (AllGatherHierarchicalRing,
AllReduceFused{Ring,Tree,Helpers}, ReduceScatterRingIb). This is currently
unreachable: `McclComm.cpp` builds its own `ctranConfig` and sets only
`enablePrims`, so an mccl comm cannot carry these overrides. Documented next to
the resolvers; making mccl hint-aware is a separate change.

Reviewed By: saifhhasan

Differential Revision: D115122064


