### PR TITLE
Fix spelling: funcitonality -> functionality (github-exported files)

### DIFF
--- a/comms/rcclx/develop/projects/rocprofiler-register/external/glog/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rocprofiler-register/external/glog/CMakeLists.txt
@@ -424,7 +424,7 @@ unset (_glog_USE_WINDOWS_PORT)
 if (WIN32)
   # Do not define min and max as macros
   target_compile_definitions (glog PRIVATE NOMINMAX)
-  # Exclude unnecessary funcitonality
+  # Exclude unnecessary functionality
   target_compile_definitions (glog PRIVATE WIN32_LEAN_AND_MEAN)
 endif (WIN32)
 

--- a/comms/rcclx/develop/projects/rocprofiler-sdk/external/glog/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rocprofiler-sdk/external/glog/CMakeLists.txt
@@ -424,7 +424,7 @@ unset (_glog_USE_WINDOWS_PORT)
 if (WIN32)
   # Do not define min and max as macros
   target_compile_definitions (glog PRIVATE NOMINMAX)
-  # Exclude unnecessary funcitonality
+  # Exclude unnecessary functionality
   target_compile_definitions (glog PRIVATE WIN32_LEAN_AND_MEAN)
 endif (WIN32)
 


### PR DESCRIPTION
Summary:
Split from D98319569 to isolate files that are mirrored to public
GitHub repos (rocprofiler glog CMakeLists.txt, surreal third_party) —
these were correlated with the failing `github-export-checks` job.

Reviewed By: eugene-gurevich

Differential Revision: D113857953


