### PR TITLE
Keep the multicast root's create reference alive until teardown (#3506)

### DIFF
--- a/comms/ctran/utils/CtranMulticast.cc
+++ b/comms/ctran/utils/CtranMulticast.cc
@@ -37,6 +37,12 @@ CtranMulticast::~CtranMulticast() {
   if (mcHandle_ != 0) {
     FB_CUCHECKIGNORE(cuMemRelease(mcHandle_));
   }
+  // The root's create reference, held all along so it outlived every peer's
+  // import (see its declaration). By now every domain rank is done with the
+  // object -- teardown is past the window's barriers -- so it is safe to drop.
+  if (createdHandle_ != 0) {
+    FB_CUCHECKIGNORE(cuMemRelease(createdHandle_));
+  }
   // Release our own retained segment handles (from retainSegments()). Because
   // these are
   // this object's own references, teardown order relative to any other owner of
@@ -129,32 +135,41 @@ commResult_t CtranMulticast::createRoot(
     size_t mcSize,
     CUmemAllocationHandleType handleType,
     CUmemGenericAllocationHandle& outHandle) {
-  // Release any handle we already hold before creating a new one, so a misuse
+  // Release anything we already hold before creating a new one, so a misuse
   // (double createRoot, or createRoot after adoptImported) cannot silently drop
-  // -- and leak -- the previously-held multicast object. The reverse order
-  // (createRoot then adoptImported) is NOT a misuse: it is the root's
-  // self-import.
+  // -- and leak -- the previously-held multicast object. Zero each first so a
+  // cuMulticastCreate failure below cannot double-release. createRoot followed
+  // by adoptImported is NOT a misuse: it is the root's self-import.
+  if (createdHandle_ != 0) {
+    FB_CUCHECKIGNORE(cuMemRelease(createdHandle_));
+    createdHandle_ = 0;
+  }
   if (mcHandle_ != 0) {
     FB_CUCHECKIGNORE(cuMemRelease(mcHandle_));
-    mcHandle_ = 0; // so a cuMulticastCreate failure below can't double-release
+    mcHandle_ = 0;
   }
   CUmulticastObjectProp prop = {};
   prop.numDevices = static_cast<unsigned int>(nLocalRanks_);
   prop.size = mcSize;
   prop.handleTypes = handleType;
   prop.flags = 0;
-  FB_CUCHECK(cuMulticastCreate(&mcHandle_, &prop));
+  // Straight into createdHandle_, leaving mcHandle_ at 0 until adoptImported(),
+  // so mcHandle_ == 0 means "nothing adopted yet". createdHandle_ and mcHandle_
+  // are independent REFERENCES; the driver is free to hand back the same handle
+  // value for the self-import, which is harmless because each release drops one
+  // reference (measured drivers do mint a distinct value).
+  FB_CUCHECK(cuMulticastCreate(&createdHandle_, &prop));
   mcSize_ = mcSize;
-  outHandle = mcHandle_;
+  outHandle = createdHandle_;
   return commSuccess;
 }
 
 void CtranMulticast::adoptImported(CUmemGenericAllocationHandle handle) {
-  // Release any handle we already hold before overwriting, so neither a misuse
-  // (double-adopt) nor the root's create-then-self-import sequence silently
-  // drops -- and leaks -- the previously-held multicast object. Each successful
-  // import carries its own reference and the caller imports before calling
-  // here, so the incoming handle keeps the object alive across the release.
+  // mcHandle_ is only ever non-zero once we have already adopted, so this is a
+  // double-adopt: release the old reference rather than silently dropping --
+  // and leaking -- it. A root's create reference lives in createdHandle_ and is
+  // untouched here; it must outlive every peer's import (see its declaration),
+  // so the dtor releases it.
   if (mcHandle_ != 0) {
     FB_CUCHECKIGNORE(cuMemRelease(mcHandle_));
   }
@@ -220,6 +235,11 @@ bool CtranMulticast::segmentsAlignedTo(size_t gran) const {
 }
 
 commResult_t CtranMulticast::addDeviceAndBind() {
+  // Every rank, the root included, binds and maps through its IMPORTED handle,
+  // so adoptImported() must have run: createRoot() alone leaves mcHandle_ at 0.
+  if (mcHandle_ == 0) {
+    return commInvalidUsage;
+  }
   FB_CUCHECK(cuDeviceGet(&cuDev_, cudaDev_));
   FB_CUCHECK(cuMulticastAddDevice(mcHandle_, cuDev_));
   size_t offset = 0;

--- a/comms/ctran/utils/CtranMulticast.h
+++ b/comms/ctran/utils/CtranMulticast.h
@@ -60,7 +60,8 @@ class CtranMulticast {
 
   // NVL-team root only: create the multicast object (mcSize bytes, agreed
   // handle type) and return the raw object handle for the caller to
-  // export+broadcast.
+  // export+broadcast. Does NOT make the object usable on its own -- the root
+  // still adoptImported()s its own exported handle before binding/mapping.
   commResult_t createRoot(
       size_t mcSize,
       CUmemAllocationHandleType handleType,
@@ -91,7 +92,7 @@ class CtranMulticast {
 
   // Every rank: add the local device to the object, then bind each imported
   // backing segment at its running multicast offset (address order). Requires a
-  // prior retainSegments() and createRoot()/adoptImported().
+  // prior retainSegments() and adoptImported().
   commResult_t addDeviceAndBind();
 
   // Every rank: reserve + map + grant device access to one contiguous
@@ -138,7 +139,22 @@ class CtranMulticast {
   const int cudaDev_{-1};
   CUdevice cuDev_{0}; // driver device handle for this cudaDev_
 
-  CUmemGenericAllocationHandle mcHandle_{0}; // the multicast object
+  // The IMPORTED reference every rank binds and maps through -- 0 until
+  // adoptImported(), which is the invariant addDeviceAndBind() checks.
+  CUmemGenericAllocationHandle mcHandle_{0};
+
+  // Root only: the reference cuMulticastCreate handed back, kept ALIVE for this
+  // object's whole lifetime and released in the dtor. It must outlive every
+  // peer's import: an exported fabric handle stops resolving to the multicast
+  // object once the create reference is gone, and a peer importing after that
+  // silently gets a fresh, EMPTY object instead of an error -- each rank then
+  // adds its device to a different object and every rank blocks forever in
+  // cuMulticastBindMem waiting for a device count it will never reach.
+  //
+  // Independent of mcHandle_ even if the driver hands back the same handle
+  // value for the self-import: each is one reference, so each needs its own
+  // release.
+  CUmemGenericAllocationHandle createdHandle_{0};
   CUdeviceptr mcVA_{0}; // mapped multicast VA (0 until mapVA)
   size_t mcSize_{0};
 

--- a/comms/ctran/utils/tests/CtranMulticastDistTest.cc
+++ b/comms/ctran/utils/tests/CtranMulticastDistTest.cc
@@ -5,8 +5,10 @@
 
 #include <folly/init/Init.h>
 
+#include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <thread>
 #include <vector>
 
 #include "nccl.h"
@@ -23,8 +25,8 @@
 // Distributed test for the NVL CE-multicast registration mechanism, driven the
 // way production drives it: one rank per GPU. The root createRoot()s the
 // multicast object and broadcasts its fabric handle over allGatherNvlDomain;
-// EVERY rank -- the root included, which self-imports and drops its create
-// reference -- importShareableHandle()s + adoptImported()s it; each rank
+// EVERY rank -- the root included, which self-imports its own exported handle
+// -- importShareableHandle()s + adoptImported()s it; each rank
 // retainSegments() its own buffer -- self-detecting + retaining its own segment
 // handles -- then addDeviceAndBind()s and mapVA()s. A single multicast write
 // from the root must then fan out (via NVSwitch) into every rank's own buffer
@@ -124,9 +126,8 @@ class MulticastDistTest : public ctran::CtranDistTestFixture {
     allGatherNvlDomain(comm_.get(), handles);
     // Every rank adopts an IMPORTED handle, root included -- production relies
     // on uniform provenance to keep the multicast write off the copy engines
-    // that service host transfers. For the root this is a same-process
-    // self-import that also drops its createRoot reference, so the broadcast
-    // below doubles as the check that the object outlives that release.
+    // that service host transfers. The root's create reference stays alive
+    // until teardown; RootCreateRefOutlivesPeerImports covers why.
     CUmemGenericAllocationHandle imported{};
     COMMCHECK_TEST(
         ctran::utils::importShareableHandle(
@@ -184,6 +185,100 @@ TEST_F(MulticastDistTest, CreateBindBroadcast) {
 // fan out across both segments.
 TEST_F(MulticastDistTest, CreateBindBroadcastMultiSegment) {
   runCreateBindBroadcast(/*numSegments=*/2);
+}
+
+// The root's create reference must outlive every peer's import. An exported
+// fabric handle stops resolving to the multicast object once that reference is
+// gone, and a peer importing afterwards gets a fresh, EMPTY object rather than
+// an error -- so each rank binds a different object and every rank blocks
+// forever in cuMulticastBindMem waiting for a device count it can never reach.
+//
+// The production rendezvous puts an all-gather immediately before every rank's
+// import, so the racy window is microseconds wide and a regression here almost
+// always wins it. This test loses it deliberately: the root imports (and would
+// release) first, then peers stall kPeerImportStallSec before importing. A
+// regression therefore shows up as this test HANGING in addDeviceAndBind, not
+// as a clean assertion failure -- there is no CUDA API that reports the empty
+// object, which is exactly why the ordering needs a test at all.
+TEST_F(MulticastDistTest, RootCreateRefOutlivesPeerImports) {
+  const int rank = comm_->statex_->rank();
+  const int lRank = comm_->statex_->localRank();
+  const int nLocalRanks = comm_->statex_->nLocalRanks();
+  if (comm_->statex_->nRanks() < 2 || comm_->statex_->nNodes() > 1) {
+    GTEST_SKIP() << "requires >= 2 ranks in a single NVL domain";
+  }
+  if (!ctran::utils::getCuMemSysSupported() ||
+      !CtranMulticast::isSupported(lRank)) {
+    GTEST_SKIP() << "cuMem + multicast not supported on this device";
+  }
+  if ((ctran::utils::getCuMemAllocHandleType() & CU_MEM_HANDLE_TYPE_FABRIC) ==
+      0) {
+    GTEST_SKIP() << "FABRIC handle type required to share the multicast object";
+  }
+  constexpr int kPeerImportStallSec = 5;
+  constexpr int kRoot = 0;
+
+  size_t gran = 0;
+  COMMCHECK_TEST(CtranMulticast::granularity(lRank, nLocalRanks, gran));
+  const size_t total = roundUp(2 * 1024 * 1024, gran);
+  std::vector<size_t> segSizes(1, total);
+  void* buf = nullptr;
+  std::vector<TestMemSegment> allocSegs;
+  COMMCHECK_TEST(
+      ctran::commMemAllocDisjoint(
+          &buf,
+          segSizes,
+          allocSegs,
+          true,
+          ctran::utils::getCuMemAllocHandleType()));
+
+  auto mc = std::make_shared<CtranMulticast>(lRank, nLocalRanks, lRank);
+  std::vector<CtranIpcHandle> handles(nLocalRanks);
+  std::memset(handles.data(), 0, handles.size() * sizeof(CtranIpcHandle));
+  if (rank == kRoot) {
+    CUmemGenericAllocationHandle rootHandle{};
+    COMMCHECK_TEST(
+        mc->createRoot(total, CU_MEM_HANDLE_TYPE_FABRIC, rootHandle));
+    COMMCHECK_TEST(
+        ctran::utils::exportShareableHandle(
+            rootHandle, handles[lRank], /*isFabric=*/true));
+  }
+  allGatherNvlDomain(comm_.get(), handles);
+
+  // Root adopts first (dropping its create reference would happen here), peers
+  // only well afterwards.
+  if (rank != kRoot) {
+    std::this_thread::sleep_for(std::chrono::seconds(kPeerImportStallSec));
+  }
+  CUmemGenericAllocationHandle imported{};
+  COMMCHECK_TEST(
+      ctran::utils::importShareableHandle(
+          handles[kRoot], imported, /*isFabric=*/true));
+  mc->adoptImported(imported);
+
+  // Hangs here on a regression: bind blocks until all nLocalRanks devices are
+  // added to the SAME object.
+  COMMCHECK_TEST(mc->retainSegments(buf, total));
+  COMMCHECK_TEST(mc->addDeviceAndBind());
+  COMMCHECK_TEST(mc->mapVA(total, gran));
+  barrierNvlDomain(comm_.get());
+
+  constexpr uint8_t kPattern = 0x5A;
+  if (rank == kRoot) {
+    CUDACHECK_TEST(cudaMemset(mc->getMulticastPtr(), kPattern, total));
+  }
+  barrierNvlDomain(comm_.get());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  std::vector<uint8_t> observed(total, 0x00);
+  CUDACHECK_TEST(
+      cudaMemcpy(observed.data(), buf, total, cudaMemcpyDeviceToHost));
+  EXPECT_EQ(observed, std::vector<uint8_t>(total, kPattern))
+      << "rank " << rank
+      << " missed the fan-out, so the late import resolved to a different "
+         "multicast object";
+
+  mc.reset();
+  ctran::commMemFreeDisjoint(buf, segSizes);
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
Summary:

Follow-up to D115154306, which made the NVL-domain root self-import its own
exported fabric handle so every rank's multicast mapping has imported
provenance. That diff had the root drop its `cuMulticastCreate` reference inside
`adoptImported`, immediately after self-importing. That is unsafe: the create
reference must outlive EVERY peer's import.

An exported fabric handle stops resolving to the multicast object once the
create reference is gone, and a peer importing after that point gets a fresh,
EMPTY object rather than an error. `importShareableHandle` returns
`commSuccess`, so nothing detects it. Each rank then adds its device to a
different object and every rank blocks forever in `cuMulticastBindMem` waiting
for a device count it can never reach.

`CtranMulticast` now keeps the created handle in its own member,
`createdHandle_`, released in the dtor alongside the imported one. `mcHandle_`
still swaps to the self-imported handle, so the bind/map provenance -- the whole
point of D115154306 -- is unchanged. Holding the reference to teardown restores
exactly the pre-D115154306 lifetime and needs no extra synchronization; the
alternative, releasing after a post-import barrier, would have to rely on
`cuMulticastBindMem`'s blocking as an implicit barrier or add a real one.

Why this escaped review: Claude claimed the opposite on the parent diff, on the
strength of two probes that were both wrong. A standalone single-process probe
tested "release all references, then import succeeds" -- which only shows the
import returns a handle, not that it resolves to the SAME object, and a
one-process probe cannot tell the difference. A 2-GPU probe printed the import's
return code, `rc=0`, which is exactly the silent-failure signature; the test
then hung in `cuMulticastBindMem` and I read the printed line as the result
without noticing the test never completed. Credit to the upstream PyTorch
symmetric-memory work, which hit the same ordering and probed it properly.

Reviewed By: minsii

Differential Revision: D115237686


