### PR TITLE
Cut compile coupling in core headers

### DIFF
--- a/comms/torchcomms/TorchComm.cpp
+++ b/comms/torchcomms/TorchComm.cpp
@@ -3,6 +3,10 @@
 #include "comms/torchcomms/TorchComm.hpp"
 #include "comms/torchcomms/TorchCommFactory.hpp"
 
+#include <c10/core/Allocator.h>
+#include <c10/core/Device.h>
+#include <c10/util/intrusive_ptr.h>
+#include <torch/csrc/distributed/c10d/Store.hpp> // @manual=//caffe2:torch-cpp-cpu
 #include <atomic>
 #include <limits>
 

--- a/comms/torchcomms/TorchComm.hpp
+++ b/comms/torchcomms/TorchComm.hpp
@@ -2,7 +2,9 @@
 
 #pragma once
 
-#include <ATen/ATen.h>
+// IWYU pragma: no_include <ATen/ATen.h>
+// IWYU pragma: no_include <torch/csrc/distributed/c10d/Store.hpp>
+#include <c10/core/Allocator.h>
 #include <c10/core/Device.h>
 #include <c10/util/intrusive_ptr.h>
 #include <comms/torchcomms/RemovableHandle.hpp>
@@ -11,9 +13,20 @@
 #include <comms/torchcomms/TorchCommHooks.hpp>
 #include <comms/torchcomms/TorchCommOptions.hpp>
 #include <comms/torchcomms/TorchCommTypes.hpp>
-#include <torch/csrc/distributed/c10d/Store.hpp> // @manual=//caffe2:torch-cpp-cpu
+#include <chrono>
 #include <memory>
+#include <optional>
 #include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace c10d {
+class Store;
+} // namespace c10d
+namespace at {
+class Tensor;
+} // namespace at
 
 namespace torch::comms {
 

--- a/comms/torchcomms/TorchCommBackend.hpp
+++ b/comms/torchcomms/TorchCommBackend.hpp
@@ -2,7 +2,8 @@
 
 #pragma once
 
-#include <ATen/ATen.h>
+// IWYU pragma: no_include <ATen/ATen.h>
+#include <ATen/core/Tensor.h> // @manual=//caffe2:ATen-core
 #include <c10/core/Device.h>
 #include <c10/util/intrusive_ptr.h>
 #include <comms/torchcomms/TorchCommBatch.hpp>
@@ -12,6 +13,7 @@
 #include <comms/torchcomms/TorchCommWindow.hpp>
 #include <comms/torchcomms/TorchWork.hpp>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace torch::comms {

--- a/comms/torchcomms/TorchCommBatch.hpp
+++ b/comms/torchcomms/TorchCommBatch.hpp
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include <ATen/ATen.h>
-#include <c10/core/Device.h>
+// IWYU pragma: no_include <ATen/ATen.h>
+#include <ATen/core/Tensor.h> // @manual=//caffe2:ATen-core
 #include <c10/util/intrusive_ptr.h>
 #include <memory>
 #include "comms/torchcomms/TorchCommOptions.hpp"

--- a/comms/torchcomms/TorchCommFactory.cpp
+++ b/comms/torchcomms/TorchCommFactory.cpp
@@ -2,6 +2,8 @@
 
 #include "comms/torchcomms/TorchCommFactory.hpp"
 
+#include <c10/core/Allocator.h>
+#include <c10/core/Device.h>
 #include <dlfcn.h>
 
 #include "comms/torchcomms/utils/Logging.hpp"

--- a/comms/torchcomms/TorchCommFactory.hpp
+++ b/comms/torchcomms/TorchCommFactory.hpp
@@ -8,11 +8,12 @@
 #include <string>
 #include <unordered_map>
 
-#include <ATen/ATen.h>
 #include <c10/core/Allocator.h>
 #include <c10/core/Device.h>
 #include <comms/torchcomms/TorchCommBackend.hpp>
 #include <comms/torchcomms/TorchCommOptions.hpp>
+
+// IWYU pragma: no_include <ATen/ATen.h>
 
 namespace torch::comms {
 

--- a/comms/torchcomms/TorchCommHooks.hpp
+++ b/comms/torchcomms/TorchCommHooks.hpp
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <ATen/ATen.h>
+// IWYU pragma: no_include <ATen/ATen.h>
 #include <c10/util/intrusive_ptr.h>
 #include <comms/torchcomms/TorchCommTypes.hpp>
 #include <comms/torchcomms/TorchWork.hpp>
@@ -13,6 +13,10 @@
 #include <string_view>
 #include <variant>
 #include <vector>
+
+namespace at {
+class Tensor;
+} // namespace at
 
 namespace torch::comms {
 

--- a/comms/torchcomms/TorchCommOptions.cpp
+++ b/comms/torchcomms/TorchCommOptions.cpp
@@ -2,6 +2,8 @@
 
 #include "comms/torchcomms/TorchCommOptions.hpp"
 
+#include <ATen/ATen.h>
+#include <torch/csrc/distributed/c10d/Store.hpp> // @manual=//caffe2:torch-cpp-cpu
 #include <sstream>
 #include <type_traits>
 
@@ -9,7 +11,7 @@
 
 namespace torch::comms {
 
-CommOptions::CommOptions() {
+CommOptions::CommOptions() : store(nullptr) {
   // Check environment variables for options
   abort_process_on_timeout_or_error =
       env_to_value<bool>("TORCHCOMM_ABORT_ON_ERROR", true);
@@ -23,6 +25,12 @@ CommOptions::CommOptions() {
   // Initialize hints to empty map (don't read from environment)
   hints = std::unordered_map<std::string, std::string>();
 }
+
+CommOptions::~CommOptions() = default;
+CommOptions::CommOptions(const CommOptions& other) = default;
+CommOptions::CommOptions(CommOptions&& other) noexcept = default;
+CommOptions& CommOptions::operator=(const CommOptions& other) = default;
+CommOptions& CommOptions::operator=(CommOptions&& other) noexcept = default;
 
 bool CommOptions::operator==(const CommOptions& other) const {
   return (

--- a/comms/torchcomms/TorchCommOptions.hpp
+++ b/comms/torchcomms/TorchCommOptions.hpp
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <ATen/ATen.h>
-#include <c10/core/Device.h>
 #include <c10/util/intrusive_ptr.h>
 #include <comms/torchcomms/TorchCommTypes.hpp>
 #include <torch/csrc/distributed/c10d/Store.hpp> // @manual=//caffe2:torch-cpp-cpu
@@ -11,6 +9,9 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+
+// IWYU pragma: no_include <ATen/ATen.h>
+// IWYU pragma: no_include <c10/core/Device.h>
 
 namespace torch::comms {
 
@@ -158,7 +159,7 @@ class CommOptions {
   bool abort_process_on_timeout_or_error{true};
   std::chrono::milliseconds timeout{kDefaultTimeout};
   bool is_high_priority_stream{false};
-  c10::intrusive_ptr<c10d::Store> store{nullptr};
+  c10::intrusive_ptr<c10d::Store> store;
   /**
    * If true, enables reconfigure() for fault tolerance.
    * With reconfigure enabled, the communicator is not initialized until
@@ -169,6 +170,11 @@ class CommOptions {
 
  public:
   CommOptions();
+  ~CommOptions();
+  CommOptions(const CommOptions& other);
+  CommOptions(CommOptions&& other) noexcept;
+  CommOptions& operator=(const CommOptions& other);
+  CommOptions& operator=(CommOptions&& other) noexcept;
 
   bool operator==(const CommOptions& other) const;
 

--- a/comms/torchcomms/TorchCommTypes.hpp
+++ b/comms/torchcomms/TorchCommTypes.hpp
@@ -2,9 +2,8 @@
 
 #pragma once
 
-#include <ATen/ATen.h>
-#include <c10/core/Device.h>
-#include <c10/util/intrusive_ptr.h>
+// IWYU pragma: no_include <ATen/ATen.h>
+#include <ATen/core/Tensor.h> // @manual=//caffe2:ATen-core
 #include <chrono>
 #include <optional>
 #include <unordered_map>

--- a/comms/torchcomms/TorchWork.cpp
+++ b/comms/torchcomms/TorchWork.cpp
@@ -2,6 +2,8 @@
 
 #include "comms/torchcomms/TorchWork.hpp"
 
+#include <ATen/ATen.h>
+#include <ATen/core/ivalue.h> // @manual=//caffe2:ATen-core
 #include <c10/core/DeviceGuard.h> // @manual=//caffe2:c10
 
 namespace torch::comms {

--- a/comms/torchcomms/TorchWork.hpp
+++ b/comms/torchcomms/TorchWork.hpp
@@ -2,12 +2,19 @@
 
 #pragma once
 
-#include <ATen/core/ivalue.h> // @manual=//caffe2:ATen-core
+// IWYU pragma: no_include <ATen/ATen.h>
 #include <c10/util/intrusive_ptr.h>
 #include <chrono>
 #include <functional>
 #include <future>
 #include <vector>
+
+namespace at {
+class Tensor;
+} // namespace at
+namespace c10::ivalue {
+struct Future;
+} // namespace c10::ivalue
 
 namespace torch::comms {
 


### PR DESCRIPTION
Summary:
The TorchComm core headers transitively pulled in heavyweight ATen and c10d headers into every translation unit, inflating compile time across downstream consumers.

This replaces the blanket ATen/ATen.h include with forward declarations or the minimal ATen/core/Tensor.h header depending on whether the header needs a complete type. Heavy includes (Store.hpp, ivalue.h) are moved to .cpp files where the complete type is actually used. CommOptions gains explicit out-of-line special members to satisfy the incomplete-type constraint from intrusive_ptr<Store>.

Differential Revision: D115216921


