### PR TITLE
Improve benchmark for ibgdaSendrecv. (#3511)

### DIFF
--- a/comms/prims/benchmarks/IbgdaSendRecv.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cu
@@ -320,9 +320,10 @@ __global__ void __launch_bounds__(512, 1) ibgda_drain_send_recv_kernel(
   if (expectedBytes == 0) {
     return;
   }
-  auto& channel = transport->local_channel(static_cast<uint32_t>(groupId));
-  transport->wait_counter(group, channel.nicDoneWait, expectedBytes, timeout);
-  transport->wait_signal(group, channel.slotFree, expectedBytes, timeout);
+  auto& protoSlot = transport->local_channel_slot<protocol::Simple>(
+      static_cast<uint32_t>(groupId));
+  transport->wait_counter(group, protoSlot.nicDoneWait, expectedBytes, timeout);
+  transport->wait_signal(group, protoSlot.slotFree, expectedBytes, timeout);
 }
 
 void launch_ibgda_drain_send_recv(
@@ -361,17 +362,23 @@ __global__ void __launch_bounds__(256, 1) ibgda_reset_send_recv_kernel(
     if (SignalState* signal = layout.localSignalState(static_cast<int>(slot))) {
       signal->signal_ = 0;
     }
-    if (slot < static_cast<uint32_t>(maxGroups)) {
+    if (slot < static_cast<uint32_t>(layout.numChannels)) {
       auto& channel = transport->local_channel(slot);
-      channel.sendProgress = IbChannelProgress{};
-      channel.recvProgress = IbChannelProgress{};
-      // Zero the per-lane receiver DATA_READY expectations so they stay aligned
-      // with the DATA_READY slots zeroed above. recvDataReadyLaneCursor is
-      // deliberately NOT reset here: it mirrors the sender's free-running
-      // IbQpState::cursor, which this kernel also leaves untouched, so zeroing
-      // it would desync the round-robin lane mapping on the next stream.
-      for (int lane = 0; lane < kIbMaxQpLanesPerChannelDirection; ++lane) {
-        channel.recvLaneExpected[lane] = 0;
+      // Every protocol slot on this channel: the signal region zeroed above
+      // spans all of them.
+      for (int protoSlot = 0; protoSlot < kNumProtoSlots; ++protoSlot) {
+        auto& proto = channel.protos[protoSlot];
+        proto.sendProgress = IbChannelProgress{};
+        proto.recvProgress = IbChannelProgress{};
+        // Zero the per-lane receiver DATA_READY expectations so they stay
+        // aligned with the DATA_READY slots zeroed above.
+        // recvDataReadyLaneCursor is deliberately NOT reset here: it mirrors
+        // the channel-shared sendQp.cursor, which this kernel also leaves
+        // untouched, so zeroing it would desync the round-robin lane mapping
+        // on the next stream.
+        for (int lane = 0; lane < kIbMaxQpLanesPerChannelDirection; ++lane) {
+          proto.recvLaneExpected[lane] = 0;
+        }
       }
     }
   }
@@ -513,12 +520,14 @@ __global__ void ibgda_snapshot_step_state_kernel(
   const auto idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < count) {
     const auto& layout = transport->channel_layout();
-    const auto maxChannels = static_cast<uint32_t>(layout.maxChannels);
-    if (idx < maxChannels) {
-      dst[idx] = transport->local_channel(idx).sendProgress.nextStep;
+    const auto numChannels = static_cast<uint32_t>(layout.numChannels);
+    if (idx < numChannels) {
+      dst[idx] = transport->local_channel_slot<protocol::Simple>(idx)
+                     .sendProgress.nextStep;
     } else {
       dst[idx] =
-          transport->local_channel(idx - maxChannels).recvProgress.nextStep;
+          transport->local_channel_slot<protocol::Simple>(idx - numChannels)
+              .recvProgress.nextStep;
     }
   }
 }

--- a/comms/prims/benchmarks/IbgdaSendRecv.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cu
@@ -319,9 +319,10 @@ __global__ void __launch_bounds__(512, 1) ibgda_drain_send_recv_kernel(
   if (expectedBytes == 0) {
     return;
   }
-  auto& channel = transport->local_channel(static_cast<uint32_t>(groupId));
-  transport->wait_counter(group, channel.nicDoneWait, expectedBytes, timeout);
-  transport->wait_signal(group, channel.slotFree, expectedBytes, timeout);
+  auto& protoSlot = transport->local_channel_slot<protocol::Simple>(
+      static_cast<uint32_t>(groupId));
+  transport->wait_counter(group, protoSlot.nicDoneWait, expectedBytes, timeout);
+  transport->wait_signal(group, protoSlot.slotFree, expectedBytes, timeout);
 }
 
 void launch_ibgda_drain_send_recv(
@@ -360,17 +361,23 @@ __global__ void __launch_bounds__(256, 1) ibgda_reset_send_recv_kernel(
     if (SignalState* signal = layout.localSignalState(static_cast<int>(slot))) {
       signal->signal_ = 0;
     }
-    if (slot < static_cast<uint32_t>(maxGroups)) {
+    if (slot < static_cast<uint32_t>(layout.numChannels)) {
       auto& channel = transport->local_channel(slot);
-      channel.sendProgress = IbChannelProgress{};
-      channel.recvProgress = IbChannelProgress{};
-      // Zero the per-lane receiver DATA_READY expectations so they stay aligned
-      // with the DATA_READY slots zeroed above. recvDataReadyLaneCursor is
-      // deliberately NOT reset here: it mirrors the sender's free-running
-      // IbQpState::cursor, which this kernel also leaves untouched, so zeroing
-      // it would desync the round-robin lane mapping on the next stream.
-      for (int lane = 0; lane < kIbMaxQpLanesPerChannelDirection; ++lane) {
-        channel.recvLaneExpected[lane] = 0;
+      // Every protocol slot on this channel: the signal region zeroed above
+      // spans all of them.
+      for (int protoSlot = 0; protoSlot < kNumProtoSlots; ++protoSlot) {
+        auto& proto = channel.protos[protoSlot];
+        proto.sendProgress = IbChannelProgress{};
+        proto.recvProgress = IbChannelProgress{};
+        // Zero the per-lane receiver DATA_READY expectations so they stay
+        // aligned with the DATA_READY slots zeroed above.
+        // recvDataReadyLaneCursor is deliberately NOT reset here: it mirrors
+        // the channel-shared sendQp.cursor, which this kernel also leaves
+        // untouched, so zeroing it would desync the round-robin lane mapping
+        // on the next stream.
+        for (int lane = 0; lane < kIbMaxQpLanesPerChannelDirection; ++lane) {
+          proto.recvLaneExpected[lane] = 0;
+        }
       }
     }
   }
@@ -512,12 +519,14 @@ __global__ void ibgda_snapshot_step_state_kernel(
   const auto idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < count) {
     const auto& layout = transport->channel_layout();
-    const auto maxChannels = static_cast<uint32_t>(layout.maxChannels);
-    if (idx < maxChannels) {
-      dst[idx] = transport->local_channel(idx).sendProgress.nextStep;
+    const auto numChannels = static_cast<uint32_t>(layout.numChannels);
+    if (idx < numChannels) {
+      dst[idx] = transport->local_channel_slot<protocol::Simple>(idx)
+                     .sendProgress.nextStep;
     } else {
       dst[idx] =
-          transport->local_channel(idx - maxChannels).recvProgress.nextStep;
+          transport->local_channel_slot<protocol::Simple>(idx - numChannels)
+              .recvProgress.nextStep;
     }
   }
 }

--- a/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -39,6 +39,15 @@ constexpr int kWarmupIters = 5;
 constexpr const char* kDefaultBenchmarkIters = "20";
 constexpr const char* kDefaultBenchmarkMaxIters = "21";
 
+// Sub-1MB transfers finish below folly's ~100us timing floor at the default
+// iteration count, so folly drops their counters (printing
+// 0.00fs/Infinity/NaN). Override just those sizes with a high, deterministic
+// count: both ranks derive it identically from nbytes, so the paired send/recv
+// stays in lockstep. Larger messages already clear the floor and keep folly's
+// count.
+constexpr std::size_t kSmallMessageThreshold = 1ULL << 20; // 1 MiB
+constexpr uint32_t kSmallMessageIters = 2048;
+
 enum class SendRecvApi {
   Blocking,
   Progress,
@@ -416,12 +425,17 @@ class IbgdaSendRecvBenchmarkContext {
 
 static unsigned int ibgdaSendRecv(
     IbgdaSendRecvBenchmarkContext& context,
-    uint32_t iters,
+    uint32_t follyIters,
     std::size_t nbytes,
     SendRecvApi api,
     SendRecvDirection direction,
     SendRecvCopyOp copyOp,
     folly::UserCounters& counters) {
+  // Small messages would run too briefly at folly's count and be dropped as
+  // NaN; use a deterministic high count for them (identical on both ranks, so
+  // the paired transfer stays in lockstep). Larger messages keep folly's count.
+  const uint32_t iters =
+      nbytes < kSmallMessageThreshold ? kSmallMessageIters : follyIters;
   CHECK_GT(iters, 0);
 
   BENCHMARK_SUSPEND {
@@ -505,9 +519,17 @@ int main(int argc, char** argv) {
   comms::prims::benchmark::setDefaultBenchmarkFlags();
   comms::prims::benchmark::DistributedBenchmarkEnvironment environment;
   auto bootstrap = comms::prims::benchmark::makeBootstrap();
+  const int globalRank = bootstrap->getGlobalRank();
   comms::prims::benchmark::IbgdaSendRecvBenchmarkContext context(
       std::move(bootstrap), comms::prims::benchmark::kMaxBenchmarkBytes);
   comms::prims::benchmark::registerBenchmarks(context);
-  folly::runBenchmarks();
+  // Both ranks must run every benchmark in lockstep (paired send/recv), but
+  // only rank 0 prints the results table. Rank 1 runs and discards its output.
+  if (globalRank == 0) {
+    folly::runBenchmarks();
+  } else {
+    // NOLINTNEXTLINE(facebook-hte-DetailCall)
+    (void)folly::detail::runBenchmarksWithResults();
+  }
   return 0;
 }

--- a/comms/prims/docs/tile_sendrecv.md
+++ b/comms/prims/docs/tile_sendrecv.md
@@ -121,11 +121,24 @@ the channel index and the per-channel staging slice index are `group.group_id`.
 ### IB: `IbLocalChannel`, `IbRemoteChannel`, and `IbChannelLayout`
 
 ```cpp
-struct IbLocalChannel {
+// One protocol's resources on a channel. Duplicated per protocol because these
+// cursors are resumable across kernel launches. Reach it through
+// acquire_channel<P>(), never by naming a slot index.
+struct IbChannelProtoSlot {
   IbChannelProgress sendProgress;
   IbChannelProgress recvProgress;
-  // Local DATA_READY, SLOT_FREE, and NIC_DONE endpoints.
-  // Local send staging and channel-owned QP state.
+  // Local DATA_READY, SLOT_FREE, and NIC_DONE endpoints for this protocol.
+  // Per-lane receiver DATA_READY expectations for this protocol.
+};
+
+struct IbLocalChannel {
+  // Shared by every protocol on the channel: a channel is one QP pair, and
+  // recvDataReadyLaneCursor mirrors sendQp.cursor.
+  IbQpState sendQp;
+  IbQpState recvQp;
+  uint64_t recvDataReadyLaneCursor;
+
+  IbChannelProtoSlot protos[kNumProtoSlots];
 };
 
 struct IbRemoteChannel {

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -470,9 +470,10 @@ __global__ void progressReservationKernel(
   transport->init_recv_progress(group, recvBytes);
 
   if (group.is_leader()) {
-    const auto& channel = transport->local_channel(group.group_id);
-    output[0] = channel.sendProgress.nextStep;
-    output[1] = channel.recvProgress.nextStep;
+    const auto& protoSlot =
+        transport->local_channel_slot<protocol::Simple>(group.group_id);
+    output[0] = protoSlot.sendProgress.nextStep;
+    output[1] = protoSlot.recvProgress.nextStep;
   }
 }
 

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -472,9 +472,10 @@ __global__ void progressReservationKernel(
   transport->init_recv_progress(group, recvBytes);
 
   if (group.is_leader()) {
-    const auto& channel = transport->local_channel(group.group_id);
-    output[0] = channel.sendProgress.nextStep;
-    output[1] = channel.recvProgress.nextStep;
+    const auto& protoSlot =
+        transport->local_channel_slot<protocol::Simple>(group.group_id);
+    output[0] = protoSlot.sendProgress.nextStep;
+    output[1] = protoSlot.recvProgress.nextStep;
   }
 }
 

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -432,6 +432,7 @@ IbChannelLayout MultiPeerIbTransportBase::channelLayoutForPeer(
       .localCounterBuf = pb.counter,
       .localCounterCompletionBuf = pb.counterCompletion,
       .maxChannels = config_.max_num_channels,
+      .numChannels = config_.max_num_channels,
       .numLanes = numNics_ * config_.qpsPerConnection,
       .pipelineDepth = config_.pipelineDepth,
       .perChannelSize = config_.perChannelSize,

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -92,6 +92,9 @@ __device__ __forceinline__ void trace_ibgda_event(
  */
 namespace protocol {
 struct Simple {
+  // Resource slot this protocol owns on every channel. Slot 0 is the default
+  // protocol; additional protocols take higher slots (see kNumProtoSlots).
+  static constexpr int kProtoSlot = 0;
   static constexpr std::size_t kData = 16; // protocol alignment quantum
   static constexpr std::size_t kPacketBytes = 16; // wire == payload
   __host__ __device__ static constexpr std::size_t max_payload(
@@ -140,7 +143,12 @@ struct ProgressChunk {
  * HBM-backed progress state.
  */
 struct ProgressGeometry {
+  // Two independent coordinates, never merged: `groupId` is the LOGICAL channel
+  // (and therefore the QP channel); `slotIndex` is this protocol's flat
+  // resource slot, addressing slot-indexed storage. Merging them would force a
+  // division to recover one from the other on the QP path.
   int groupId;
+  int slotIndex;
   std::size_t payloadBytes; // raw nbytes, for valid-byte masking
   std::size_t
       protocolBytes; // payload rounded up to Proto::kData (cursor bound)
@@ -151,14 +159,37 @@ struct ProgressGeometry {
   int pipelineDepth;
 };
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ IbChannelProgress& progress_send_slot(
     Transport& transport,
     ThreadGroup& group);
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ IbChannelProgress& progress_recv_slot(
     Transport& transport,
+    ThreadGroup& group);
+
+/**
+ * Every channel resource one (channel, protocol) transfer addresses, resolved
+ * in one place.
+ *
+ * Callers must never derive a channel or slot index themselves: the whole point
+ * is that the protocol coordinate lives here and nowhere else, so adding a
+ * protocol cannot silently miss a site. `groupId` stays the LOGICAL channel --
+ * which is also the QP channel -- and the protocol is a separate compile-time
+ * coordinate, never folded into it.
+ */
+struct ChannelSlotView {
+  IbLocalChannel& channel; ///< shared: sendQp, recvQp, recvDataReadyLaneCursor
+  IbChannelProtoSlot& local; ///< this protocol's cursors and local buffer views
+  IbRemoteChannel remote; ///< this protocol's peer-side views
+  std::size_t stagingBase; ///< byte offset of this slot's staging window
+};
+
+template <typename P, typename Transport>
+__device__ __forceinline__ ChannelSlotView acquire_channel(
+    Transport& transport,
+    const IbChannelLayout& channelLayout,
     ThreadGroup& group);
 
 __device__ __forceinline__ static std::size_t valid_payload_bytes(
@@ -236,7 +267,7 @@ __device__ __forceinline__ ProgressChunk next_chunk(
     const IbChannelProgress& state,
     const ProgressGeometry& geometry);
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ bool try_prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
@@ -244,7 +275,7 @@ __device__ __forceinline__ bool try_prepare_send_slot(
     uint64_t generation,
     const Timeout& timeout = Timeout());
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ void prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
@@ -252,7 +283,7 @@ __device__ __forceinline__ void prepare_send_slot(
     uint64_t generation,
     const Timeout& timeout = Timeout());
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ void record_send_completion(
     Transport& transport,
     uint32_t channelId,
@@ -311,7 +342,7 @@ __device__ __forceinline__ void init_send_progress(
     std::size_t max_signal_bytes = 0) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   auto& channelLayout = transport.channel_layout();
-  auto& slot = progress_send_slot(transport, group);
+  auto& slot = progress_send_slot<protocol::Simple>(transport, group);
   assert_progress_slot_idle(group, slot, "send");
   IbChannelProgress state{};
   state.activeStage = nbytes == 0
@@ -366,7 +397,7 @@ __device__ __forceinline__ void init_recv_progress(
     std::size_t max_signal_bytes = 0) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   auto& channelLayout = transport.channel_layout();
-  auto& slot = progress_recv_slot(transport, group);
+  auto& slot = progress_recv_slot<protocol::Simple>(transport, group);
   assert_progress_slot_idle(group, slot, "recv");
   IbChannelProgress state{};
   state.activeStage = nbytes == 0
@@ -508,7 +539,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
       sizeof(CopyOp) == 0, "detail::progress_send_once() requires NVIDIA GPU");
 #endif
   auto& channelLayout = transport.channel_layout();
-  auto& progressSlot = progress_send_slot(transport, group);
+  auto& progressSlot = progress_send_slot<Proto>(transport, group);
   IbChannelProgress state = progressSlot;
   if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
     return IbgdaSendRecvProgressStatus::Done;
@@ -531,17 +562,17 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
   const std::size_t initialNextByte = state.activeNextByte;
   const std::size_t pipelineBytesWire = progress_params.perBlockSlotWire *
       static_cast<std::size_t>(channelLayout.pipelineDepth);
-  IbLocalChannel& localChannel =
-      transport.local_channel(static_cast<uint32_t>(progress_params.groupId));
-  const IbgdaLocalBuffer localSlotFree = localChannel.slotFree;
-  const IbRemoteChannel remoteChannel =
-      makeIbRemoteChannel(channelLayout, progress_params.groupId);
+  const ChannelSlotView ch =
+      acquire_channel<Proto>(transport, channelLayout, group);
+  IbLocalChannel& localChannel = ch.channel;
+  const IbgdaLocalBuffer localSlotFree = ch.local.slotFree;
+  const IbRemoteChannel remoteChannel = ch.remote;
 
   if (state.activeStage ==
       detail::IbSendRecvProgressStage::WaitLocalCompletion) {
     const ProgressChunk chunk =
         next_chunk<Proto>(channelLayout, state, progress_params);
-    if (!try_prepare_send_slot(
+    if (!try_prepare_send_slot<Proto>(
             transport,
             group,
             chunk.slotId,
@@ -617,7 +648,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
           /*counterBuf=*/{},
           /*counterVal=*/0,
           /*signalPerLane=*/true);
-      record_send_completion(
+      record_send_completion<Proto>(
           transport,
           static_cast<uint32_t>(progress_params.groupId),
           chunk.slotId,
@@ -686,18 +717,25 @@ __device__ __forceinline__ void wait_recv_data_ready(
       static_cast<uint32_t>(transport.channel_layout().numLanes);
   const uint32_t lanes = numLanes == 0 ? 1U : numLanes;
   if (group.is_leader()) {
+    // Simple's slot unconditionally: an explicit DATA_READY signal IS Simple's
+    // readiness mark. A protocol that carries its flag inline never reaches
+    // here, so there is no other slot to select. The lane cursor is
+    // channel-scoped (it mirrors the shared sendQp.cursor); the per-lane
+    // expected totals are slot-scoped, mirroring Simple's own DATA_READY slots.
+    IbChannelProtoSlot& protoSlot =
+        localChannel.protos[protocol::Simple::kProtoSlot];
     // Truncate recvDataReadyLaneCursor to 32 bits BEFORE the modulo so the lane
     // matches the sender's uint32 Send cursor once it wraps at 2^32; otherwise
     // a non-power-of-two numLanes would desync the lane after wrap.
     const uint32_t lane =
         static_cast<uint32_t>(localChannel.recvDataReadyLaneCursor) % lanes;
-    const uint64_t expected = localChannel.recvLaneExpected[lane] + chunkBytes;
+    const uint64_t expected = protoSlot.recvLaneExpected[lane] + chunkBytes;
     const IbgdaLocalBuffer laneBuf = localDataReady.subBuffer(
         sendRecvSignalSlotOffset(static_cast<int>(lane)));
     ThreadGroup solo{
         0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
     transport.wait_signal(solo, laneBuf, expected, timeout);
-    localChannel.recvLaneExpected[lane] = expected;
+    protoSlot.recvLaneExpected[lane] = expected;
     ++localChannel.recvDataReadyLaneCursor;
   }
   group.sync();
@@ -733,11 +771,14 @@ __device__ __forceinline__ bool poll_recv_data_ready(
   const uint32_t numLanes =
       static_cast<uint32_t>(transport.channel_layout().numLanes);
   const uint32_t lanes = numLanes == 0 ? 1U : numLanes;
+  // Simple's slot unconditionally -- see wait_recv_data_ready.
+  IbChannelProtoSlot& protoSlot =
+      localChannel.protos[protocol::Simple::kProtoSlot];
   // Truncate to 32 bits before the modulo to match the sender's uint32 cursor
   // wrap (see wait_recv_data_ready).
   const uint32_t lane =
       static_cast<uint32_t>(localChannel.recvDataReadyLaneCursor) % lanes;
-  const uint64_t expected = localChannel.recvLaneExpected[lane] + chunkBytes;
+  const uint64_t expected = protoSlot.recvLaneExpected[lane] + chunkBytes;
   const IbgdaLocalBuffer laneBuf = localDataReady.subBuffer(
       sendRecvSignalSlotOffset(static_cast<int>(lane)));
   const uint64_t current = transport.read_signal(laneBuf);
@@ -746,7 +787,7 @@ __device__ __forceinline__ bool poll_recv_data_ready(
   if (current < expected) {
     return false;
   }
-  localChannel.recvLaneExpected[lane] = expected;
+  protoSlot.recvLaneExpected[lane] = expected;
   ++localChannel.recvDataReadyLaneCursor;
   return true;
 #else
@@ -893,7 +934,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
       sizeof(CopyOp) == 0, "detail::progress_recv_once() requires NVIDIA GPU");
 #endif
   auto& channelLayout = transport.channel_layout();
-  auto& progressSlot = progress_recv_slot(transport, group);
+  auto& progressSlot = progress_recv_slot<Proto>(transport, group);
   IbChannelProgress state = progressSlot;
   if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
     return IbgdaSendRecvProgressStatus::Done;
@@ -918,11 +959,11 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
       chunk.dataOff + chunk.payloadBytes >= progress_params.protocolBytes;
   const std::size_t protocolBytesThis = chunk.wireBytes +
       (isFinalChunk ? Proto::wire_bytes(state.activeTailPadding) : 0);
-  IbLocalChannel& localChannel =
-      transport.local_channel(static_cast<uint32_t>(progress_params.groupId));
-  const IbgdaLocalBuffer localDataReady = localChannel.dataReady;
-  const IbRemoteChannel remoteChannel =
-      makeIbRemoteChannel(channelLayout, progress_params.groupId);
+  const ChannelSlotView ch =
+      acquire_channel<Proto>(transport, channelLayout, group);
+  IbLocalChannel& localChannel = ch.channel;
+  const IbgdaLocalBuffer localDataReady = ch.local.dataReady;
+  const IbRemoteChannel remoteChannel = ch.remote;
   if (!progress_recv_ready(
           Proto{},
           transport,
@@ -1014,7 +1055,10 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
 // geometry is added in a later diff. Blocking-path analog of
 // make_progress_geometry().
 struct SendRecvGeometry {
+  // See ProgressGeometry: logical channel and protocol resource slot stay
+  // separate coordinates.
   int groupId;
+  int slotIndex;
   std::size_t perBlockSlotWire; // physical (wire) bytes per (slot, group)
   std::size_t perBlockSlotPayload; // payload capacity of that region
   std::size_t chunkPayload; // max payload per signaled chunk (>= 1 packet)
@@ -1068,6 +1112,7 @@ __device__ __forceinline__ SendRecvGeometry calcGeometry(
       (nbytes + P::kData - 1) / P::kData * P::kData;
   return SendRecvGeometry{
       .groupId = groupId,
+      .slotIndex = channelLayout.protoChannelSlot(groupId, P::kProtoSlot),
       .perBlockSlotWire = perBlockSlotWire,
       .perBlockSlotPayload = perBlockSlotPayload,
       .chunkPayload = chunkPayload,
@@ -1200,7 +1245,8 @@ __device__ __forceinline__ SendSignal prepareForwardBuf(
       recvDataReady,
       recvWaitCredit,
       timeout);
-  prepare_send_slot(fwdTransport, group, fwdSlot, fwdPipelineCycle, timeout);
+  prepare_send_slot<protocol::Simple>(
+      fwdTransport, group, fwdSlot, fwdPipelineCycle, timeout);
   const std::size_t validBytes =
       valid_payload_bytes(dataOff, payloadBytes, nbytes);
   if (validBytes > 0) {
@@ -1279,12 +1325,11 @@ __device__ __forceinline__ void send(
   [[maybe_unused]] const std::size_t payloadProtocolBytes =
       geometry.payloadProtocolBytes;
 
-  auto& state = progress_send_slot(transport, group);
-  IbLocalChannel& localChannel =
-      transport.local_channel(static_cast<uint32_t>(groupId));
-  const IbgdaLocalBuffer localSlotFree = localChannel.slotFree;
-  const IbRemoteChannel remoteChannel =
-      makeIbRemoteChannel(channelLayout, groupId);
+  auto& state = progress_send_slot<Proto>(transport, group);
+  const ChannelSlotView ch =
+      acquire_channel<Proto>(transport, channelLayout, group);
+  const IbgdaLocalBuffer localSlotFree = ch.local.slotFree;
+  const IbRemoteChannel remoteChannel = ch.remote;
   assert_progress_slot_idle(group, state, "send");
   const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
   // Category of the previous op on this slot, read before the leader overwrites
@@ -1431,7 +1476,8 @@ __device__ __forceinline__ void send(
           (dataOff + chunkSize <= nbytes) ? chunkSize : (nbytes - dataOff);
 
       // (1) Wait for NIC to finish with this slot's local sendStaging.
-      prepare_send_slot(transport, group, ringSlot, pipelineCycle, timeout);
+      prepare_send_slot<Proto>(
+          transport, group, ringSlot, pipelineCycle, timeout);
 
       // (2) Cooperative compress: src -> local sendStaging via CopyOp. The
       //     return value is the compressed byte count the leader uses to size
@@ -1484,7 +1530,7 @@ __device__ __forceinline__ void send(
             /*counterBuf=*/{},
             /*counterVal=*/0,
             /*signalPerLane=*/true);
-        record_send_completion(
+        record_send_completion<Proto>(
             transport,
             static_cast<uint32_t>(groupId),
             ringSlot,
@@ -1529,8 +1575,7 @@ __device__ __forceinline__ void send(
       // wire_bytes(cursor)). Identity for Simple; kPacketBytes:kData for LL.
       const std::size_t protocolBytesThis = bytesThis +
           (isFinalChunk ? Proto::wire_bytes(protocolTailPadding) : 0);
-      const std::size_t stagingOff =
-          static_cast<std::size_t>(groupId) * pipelineBytesWire +
+      const std::size_t stagingOff = ch.stagingBase +
           static_cast<std::size_t>(slot) * perBlockSlotWire +
           Proto::wire_bytes(chunkOff);
       const uint64_t streamWire = Proto::wire_bytes(streamPayload);
@@ -1538,7 +1583,7 @@ __device__ __forceinline__ void send(
       const uint64_t pipelineCycle = streamPayload / pipelineBytesPayload;
 
       // (1) Wait for NIC to finish with this slot's local sendStaging.
-      prepare_send_slot(transport, group, slot, pipelineCycle, timeout);
+      prepare_send_slot<Proto>(transport, group, slot, pipelineCycle, timeout);
 
       // (2) Cooperative copy: src -> local sendStaging via CopyOp.
       const SendSignal sig = prepareSendBuf<CopyOp>(
@@ -1579,7 +1624,7 @@ __device__ __forceinline__ void send(
             /*counterBuf=*/{},
             /*counterVal=*/0,
             /*signalPerLane=*/true);
-        record_send_completion(
+        record_send_completion<Proto>(
             transport,
             static_cast<uint32_t>(groupId),
             slot,
@@ -1676,12 +1721,12 @@ __device__ __forceinline__ void recv(
   [[maybe_unused]] const std::size_t payloadProtocolBytes =
       geometry.payloadProtocolBytes;
 
-  auto& state = progress_recv_slot(transport, group);
-  IbLocalChannel& localChannel =
-      transport.local_channel(static_cast<uint32_t>(groupId));
-  const IbgdaLocalBuffer localDataReady = localChannel.dataReady;
-  const IbRemoteChannel remoteChannel =
-      makeIbRemoteChannel(channelLayout, groupId);
+  auto& state = progress_recv_slot<Proto>(transport, group);
+  const ChannelSlotView ch =
+      acquire_channel<Proto>(transport, channelLayout, group);
+  IbLocalChannel& localChannel = ch.channel;
+  const IbgdaLocalBuffer localDataReady = ch.local.dataReady;
+  const IbRemoteChannel remoteChannel = ch.remote;
   assert_progress_slot_idle(group, state, "recv");
   const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
   // Category of the previous op on this slot, read before the leader overwrites
@@ -1858,8 +1903,7 @@ __device__ __forceinline__ void recv(
       // wire_bytes(cursor)). Identity for Simple; kPacketBytes:kData for LL.
       const std::size_t protocolBytesThis = bytesThis +
           (isFinalChunk ? Proto::wire_bytes(protocolTailPadding) : 0);
-      const std::size_t stagingOff =
-          static_cast<std::size_t>(groupId) * pipelineBytesWire +
+      const std::size_t stagingOff = ch.stagingBase +
           static_cast<std::size_t>(slot) * perBlockSlotWire +
           Proto::wire_bytes(chunkOff);
 
@@ -1988,12 +2032,12 @@ __device__ __forceinline__ void forward(
   const std::size_t payloadProtocolBytes = recvGeo.payloadProtocolBytes;
 
   // --- recv side (this transport) ---
-  auto& recvSlotState = progress_recv_slot(transport, group);
-  IbLocalChannel& recvLocalChannel =
-      transport.local_channel(static_cast<uint32_t>(groupId));
-  const IbgdaLocalBuffer recvDataReady = recvLocalChannel.dataReady;
-  const IbRemoteChannel recvRemoteChannel =
-      makeIbRemoteChannel(channelLayout, groupId);
+  auto& recvSlotState = progress_recv_slot<Proto>(transport, group);
+  const ChannelSlotView recvCh =
+      acquire_channel<Proto>(transport, channelLayout, group);
+  IbLocalChannel& recvLocalChannel = recvCh.channel;
+  const IbgdaLocalBuffer recvDataReady = recvCh.local.dataReady;
+  const IbRemoteChannel recvRemoteChannel = recvCh.remote;
   assert_progress_slot_idle(group, recvSlotState, "forward recv");
   const uint64_t recvBaseByte = static_cast<uint64_t>(recvSlotState.nextStep);
   const std::size_t recvProtocolTailPadding =
@@ -2004,12 +2048,11 @@ __device__ __forceinline__ void forward(
       payloadProtocolBytes + recvProtocolTailPadding;
 
   // --- fwd side (fwd transport) ---
-  auto& fwdSlotState = progress_send_slot(fwdTransport, group);
-  IbLocalChannel& fwdLocalChannel =
-      fwdTransport.local_channel(static_cast<uint32_t>(groupId));
-  const IbgdaLocalBuffer fwdSlotFree = fwdLocalChannel.slotFree;
-  const IbRemoteChannel fwdRemoteChannel =
-      makeIbRemoteChannel(fwdChannelLayout, groupId);
+  auto& fwdSlotState = progress_send_slot<Proto>(fwdTransport, group);
+  const ChannelSlotView fwdCh =
+      acquire_channel<Proto>(fwdTransport, fwdChannelLayout, group);
+  const IbgdaLocalBuffer fwdSlotFree = fwdCh.local.slotFree;
+  const IbRemoteChannel fwdRemoteChannel = fwdCh.remote;
   assert_progress_slot_idle(group, fwdSlotState, "forward send");
   const uint64_t fwdBaseByte = static_cast<uint64_t>(fwdSlotState.nextStep);
   const std::size_t fwdProtocolTailPadding =
@@ -2038,8 +2081,7 @@ __device__ __forceinline__ void forward(
         static_cast<int>(recvPipelineOff / recvGeo.perBlockSlotPayload);
     const std::size_t recvChunkOff =
         recvPipelineOff - recvSlot * recvGeo.perBlockSlotPayload;
-    const std::size_t recvStagingOff =
-        static_cast<std::size_t>(groupId) * recvGeo.pipelineBytesWire +
+    const std::size_t recvStagingOff = recvCh.stagingBase +
         static_cast<std::size_t>(recvSlot) * recvGeo.perBlockSlotWire +
         Proto::wire_bytes(recvChunkOff);
     const std::size_t recvSlotRemaining =
@@ -2053,8 +2095,7 @@ __device__ __forceinline__ void forward(
         static_cast<int>(fwdPipelineOff / fwdGeo.perBlockSlotPayload);
     const std::size_t fwdChunkOff =
         fwdPipelineOff - fwdSlot * fwdGeo.perBlockSlotPayload;
-    const std::size_t fwdStagingOff =
-        static_cast<std::size_t>(groupId) * fwdGeo.pipelineBytesWire +
+    const std::size_t fwdStagingOff = fwdCh.stagingBase +
         static_cast<std::size_t>(fwdSlot) * fwdGeo.perBlockSlotWire +
         Proto::wire_bytes(fwdChunkOff);
     const std::size_t fwdSlotRemaining =
@@ -2137,7 +2178,7 @@ __device__ __forceinline__ void forward(
           /*counterBuf=*/{},
           /*counterVal=*/0,
           /*signalPerLane=*/true);
-      record_send_completion(
+      record_send_completion<Proto>(
           fwdTransport,
           static_cast<uint32_t>(groupId),
           fwdSlot,
@@ -2302,20 +2343,41 @@ __device__ __forceinline__ void validate_progress_group(
 #endif
 }
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ IbChannelProgress& progress_send_slot(
     Transport& transport,
     ThreadGroup& group) {
   validate_progress_group(transport.channel_layout(), group);
-  return transport.local_channel(group).sendProgress;
+  return transport.template local_channel_slot<P>(group).sendProgress;
 }
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ IbChannelProgress& progress_recv_slot(
     Transport& transport,
     ThreadGroup& group) {
   validate_progress_group(transport.channel_layout(), group);
-  return transport.local_channel(group).recvProgress;
+  return transport.template local_channel_slot<P>(group).recvProgress;
+}
+
+// No default on P: omitting the protocol must be a compile error, not a silent
+// read of the default protocol's slot.
+template <typename P, typename Transport>
+__device__ __forceinline__ ChannelSlotView acquire_channel(
+    Transport& transport,
+    const IbChannelLayout& channelLayout,
+    ThreadGroup& group) {
+  validate_progress_group(channelLayout, group);
+  const int channelId = static_cast<int>(group.group_id);
+  const int slotIndex =
+      channelLayout.protoChannelSlot(channelId, P::kProtoSlot);
+  return ChannelSlotView{
+      .channel = transport.local_channel(static_cast<uint32_t>(channelId)),
+      .local = transport.template local_channel_slot<P>(
+          static_cast<uint32_t>(channelId)),
+      .remote = makeIbRemoteChannel(channelLayout, slotIndex),
+      .stagingBase =
+          static_cast<std::size_t>(slotIndex) * pipeline_window(channelLayout),
+  };
 }
 
 /**
@@ -2457,6 +2519,7 @@ __device__ __forceinline__ ProgressGeometry make_progress_geometry(
   }
   return ProgressGeometry{
       .groupId = groupId,
+      .slotIndex = channelLayout.protoChannelSlot(groupId, Proto::kProtoSlot),
       .payloadBytes = nbytes,
       .protocolBytes = protocolBytes,
       .perBlockSlotWire = perBlockSlotWire,
@@ -2656,7 +2719,7 @@ __device__ __forceinline__ ProgressChunk next_chunk(
       : dataRemaining;
   payloadBytes = payloadBytes < slotRemaining ? payloadBytes : slotRemaining;
   return ProgressChunk{
-      .stagingOff = static_cast<std::size_t>(geometry.groupId) *
+      .stagingOff = static_cast<std::size_t>(geometry.slotIndex) *
               geometry.perChannelBufferSize +
           static_cast<std::size_t>(slot) * geometry.perBlockSlotWire +
           Proto::wire_bytes(chunkOff),
@@ -2671,7 +2734,7 @@ __device__ __forceinline__ ProgressChunk next_chunk(
   };
 }
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ bool try_prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
@@ -2681,8 +2744,8 @@ __device__ __forceinline__ bool try_prepare_send_slot(
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t ready = 1;
   if (group.is_leader()) {
-    auto& slot =
-        transport.local_channel(group.group_id).sendCompletionSlots[slotId];
+    auto& slot = transport.template local_channel_slot<P>(group.group_id)
+                     .sendCompletionSlots[slotId];
     if (slot.generation != generation) {
       uint64_t pending = slot.laneMask;
       const uint32_t numLanes = transport.send_completion_lane_count();
@@ -2726,7 +2789,7 @@ __device__ __forceinline__ bool try_prepare_send_slot(
 #endif
 }
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ void prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
@@ -2734,8 +2797,8 @@ __device__ __forceinline__ void prepare_send_slot(
     uint64_t generation,
     const Timeout& timeout) {
   if (group.is_leader()) {
-    auto& slot =
-        transport.local_channel(group.group_id).sendCompletionSlots[slotId];
+    auto& slot = transport.template local_channel_slot<P>(group.group_id)
+                     .sendCompletionSlots[slotId];
     if (slot.generation != generation) {
       const uint64_t pending = slot.laneMask;
       const uint32_t numLanes = transport.send_completion_lane_count();
@@ -2758,7 +2821,7 @@ __device__ __forceinline__ void prepare_send_slot(
   group.sync();
 }
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ void record_send_completion(
     Transport& transport,
     uint32_t channelId,
@@ -2766,7 +2829,8 @@ __device__ __forceinline__ void record_send_completion(
     uint64_t generation,
     const IbLocalCompletionTicket& ticket) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-  auto& slot = transport.local_channel(channelId).sendCompletionSlots[slotId];
+  auto& slot = transport.template local_channel_slot<P>(channelId)
+                   .sendCompletionSlots[slotId];
   slot.generation = generation;
   slot.values[ticket.completionId] = ticket.value;
   slot.laneMask |= 1ULL << ticket.completionId;

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -415,6 +415,65 @@ __device__ __forceinline__ void init_recv_progress(
  * @param timeout Optional device timeout checked while dependencies wait.
  * @param args Additional arguments forwarded to `CopyOp::send`.
  */
+// What the leader put hands to the wire: the DATA_READY signal slot + credit.
+// protocol::Simple returns the remote DATA_READY slot + credit; protocol::LL
+// returns an empty buffer (its inline flag is the readiness mark, so the put
+// carries data only).
+struct SendSignal {
+  IbgdaRemoteBuffer buf;
+  uint64_t val;
+};
+
+// ---- Resumable-progress protocol seams (tag-dispatched) ------------------
+// These isolate the four protocol-specific steps of progress_send_once() /
+// progress_recv_once() so the resumable state machine stays protocol-agnostic.
+// Only the protocol::Simple overloads exist here (behavior identical to the
+// former inline code); later protocols (e.g. protocol::LL) add their own
+// overloads without touching the state machine. Split differently from the
+// blocking prepareSendBuf()/consumeRecvBuf(): encode and signal are issued at
+// different stages, and recv needs a non-blocking readiness check.
+
+// Encode one send chunk into send-staging (Simple: contiguous CopyOp::send).
+template <typename CopyOp = Memcpy, typename... Args>
+__device__ __forceinline__ void progress_send_prepare_buf(
+    protocol::Simple,
+    ThreadGroup& group,
+    const IbChannelLayout& channelLayout,
+    const ProgressChunk& chunk,
+    const void* __restrict__ src,
+    std::size_t payloadBytes,
+    Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  const std::size_t validBytes =
+      valid_payload_bytes(chunk.dataOff, chunk.bytes, payloadBytes);
+  if (validBytes > 0) {
+    CopyOp::send(
+        channelLayout.sendStagingPtr + chunk.stagingOff,
+        static_cast<const char*>(src) + chunk.dataOff,
+        validBytes,
+        group,
+        chunk.dataOff,
+        args...);
+  }
+#else
+  (void)group;
+  (void)channelLayout;
+  (void)chunk;
+  (void)src;
+  (void)payloadBytes;
+  ((void)args, ...);
+#endif
+}
+
+// The DATA_READY signal the leader put piggybacks (Simple: remote slot +
+// cumulative-bytes credit).
+__device__ __forceinline__ SendSignal progress_send_signal(
+    protocol::Simple,
+    const IbRemoteChannel& remoteChannel,
+    uint64_t signalVal) {
+  return SendSignal{remoteChannel.dataReady, signalVal};
+}
+
 template <typename Transport, typename CopyOp = Memcpy, typename... Args>
 __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
     Transport& transport,
@@ -481,17 +540,14 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
       return IbgdaSendRecvProgressStatus::Waiting;
     }
 
-    const std::size_t validBytes = valid_payload_bytes(
-        chunk.dataOff, chunk.bytes, progress_params.payloadBytes);
-    if (validBytes > 0) {
-      CopyOp::send(
-          channelLayout.sendStagingPtr + chunk.stagingOff,
-          static_cast<const char*>(src) + chunk.dataOff,
-          validBytes,
-          group,
-          chunk.dataOff,
-          args...);
-    }
+    progress_send_prepare_buf<CopyOp>(
+        protocol::Simple{},
+        group,
+        channelLayout,
+        chunk,
+        src,
+        progress_params.payloadBytes,
+        args...);
     group.sync();
     transition_progress_stage(
         group, state, detail::IbSendRecvProgressStage::WaitSlotFree);
@@ -539,13 +595,15 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
           0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
       const std::size_t protocolBytesThis =
           chunk.bytes + (isFinalChunk ? state.activeTailPadding : 0);
+      const SendSignal sig = progress_send_signal(
+          protocol::Simple{}, remoteChannel, protocolBytesThis);
       const auto completion = transport.put(
           solo,
           channelLayout.sendStagingBuf.subBuffer(chunk.stagingOff),
           remoteChannel.recvStaging.subBuffer(chunk.stagingOff),
           chunk.bytes,
-          remoteChannel.dataReady,
-          protocolBytesThis,
+          sig.buf,
+          sig.val,
           /*counterBuf=*/{},
           /*counterVal=*/0,
           /*signalPerLane=*/true);
@@ -720,6 +778,85 @@ __device__ __forceinline__ bool poll_recv_data_ready(
  * @param timeout Optional device timeout checked while dependencies wait.
  * @param args Additional arguments forwarded to `CopyOp::recv`.
  */
+// Non-blocking readiness check for one recv chunk (Simple: poll the round-robin
+// DATA_READY lane that carried this chunk; leader-only + broadcast, no spin).
+template <typename Transport>
+__device__ __forceinline__ bool progress_recv_ready(
+    protocol::Simple,
+    Transport& transport,
+    ThreadGroup& group,
+    IbLocalChannel& localChannel,
+    const IbgdaLocalBuffer& localDataReady,
+    uint64_t waitCredit,
+    const Timeout& timeout) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  uint32_t ready = 1;
+  if (group.is_leader()) {
+    unsigned long long current = 0;
+    unsigned long long expected = 0;
+    ready = poll_recv_data_ready(
+                transport,
+                localChannel,
+                localDataReady,
+                waitCredit,
+                current,
+                expected)
+        ? 1U
+        : 0U;
+    if (!ready) {
+      TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+          timeout,
+          "progress_recv_once waiting for DATA_READY expected>=%llu, "
+          "current=%llu",
+          expected,
+          current);
+    }
+  }
+  return group.broadcast<uint32_t>(ready) != 0U;
+#else
+  (void)transport;
+  (void)group;
+  (void)localChannel;
+  (void)localDataReady;
+  (void)waitCredit;
+  (void)timeout;
+  return true;
+#endif
+}
+
+// Decode one ready recv chunk from recv-staging into dst (Simple: contiguous
+// CopyOp::recv).
+template <typename CopyOp = Memcpy, typename... Args>
+__device__ __forceinline__ void progress_recv_consume_buf(
+    protocol::Simple,
+    ThreadGroup& group,
+    const IbChannelLayout& channelLayout,
+    const ProgressChunk& chunk,
+    void* __restrict__ dst,
+    std::size_t payloadBytes,
+    Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  const std::size_t validBytes =
+      valid_payload_bytes(chunk.dataOff, chunk.bytes, payloadBytes);
+  if (validBytes > 0) {
+    CopyOp::recv(
+        static_cast<char*>(dst) + chunk.dataOff,
+        channelLayout.recvStagingPtr + chunk.stagingOff,
+        validBytes,
+        group,
+        chunk.dataOff,
+        args...);
+  }
+#else
+  (void)group;
+  (void)channelLayout;
+  (void)chunk;
+  (void)dst;
+  (void)payloadBytes;
+  ((void)args, ...);
+#endif
+}
+
 template <typename Transport, typename CopyOp = Memcpy, typename... Args>
 __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
     Transport& transport,
@@ -771,46 +908,25 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
   const IbgdaLocalBuffer localDataReady = localChannel.dataReady;
   const IbRemoteChannel remoteChannel =
       makeIbRemoteChannel(channelLayout, progress_params.groupId);
-  uint32_t ready = 1;
-  if (group.is_leader()) {
-    // Poll the specific round-robin lane that carried this chunk and commit
-    // recvDataReadyLaneCursor/recvLaneExpected only on a ready result.
-    unsigned long long current = 0;
-    unsigned long long expected = 0;
-    ready = poll_recv_data_ready(
-                transport,
-                localChannel,
-                localDataReady,
-                protocolBytesThis,
-                current,
-                expected)
-        ? 1U
-        : 0U;
-    if (!ready) {
-      TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
-          timeout,
-          "progress_recv_once waiting for DATA_READY expected>=%llu, "
-          "current=%llu",
-          expected,
-          current);
-    }
-  }
-  ready = group.broadcast<uint32_t>(ready);
-  if (!ready) {
+  if (!progress_recv_ready(
+          protocol::Simple{},
+          transport,
+          group,
+          localChannel,
+          localDataReady,
+          protocolBytesThis,
+          timeout)) {
     return IbgdaSendRecvProgressStatus::Waiting;
   }
 
-  const std::size_t validBytes = valid_payload_bytes(
-      chunk.dataOff, chunk.bytes, progress_params.payloadBytes);
-  if (validBytes > 0) {
-    CopyOp::recv(
-        static_cast<char*>(dst) + chunk.dataOff,
-        channelLayout.recvStagingPtr + chunk.stagingOff,
-        validBytes,
-        group,
-        chunk.dataOff,
-        args...);
-  }
+  progress_recv_consume_buf<CopyOp>(
+      protocol::Simple{},
+      group,
+      channelLayout,
+      chunk,
+      dst,
+      progress_params.payloadBytes,
+      args...);
   group.sync();
 
   transport.signal(
@@ -945,11 +1061,6 @@ __device__ __forceinline__ SendRecvGeometry calcGeometry(
       .payloadProtocolBytes = payloadProtocolBytes,
   };
 }
-
-struct SendSignal {
-  IbgdaRemoteBuffer buf;
-  uint64_t val;
-};
 
 template <typename CopyOp = Memcpy, typename... Args>
 __device__ __forceinline__ SendSignal prepareSendBuf(

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -121,12 +121,14 @@ namespace detail {
  * copy callbacks.
  */
 struct ProgressChunk {
-  std::size_t stagingOff;
-  std::size_t dataOff;
-  std::size_t bytes;
-  uint64_t streamEnd;
-  uint32_t slotId;
-  uint64_t pipelineGeneration;
+  std::size_t stagingOff; // WIRE offset into send/recv staging
+  std::size_t dataOff; // PAYLOAD offset into the user buffer
+  std::size_t payloadBytes; // cursor advance (payload)
+  std::size_t wireBytes; // RDMA length + signal/counter delta (wire)
+  uint64_t streamEndWire; // absolute WIRE byte value after this chunk
+  uint64_t flagVal; // packet flag/generation (ring cursor); ignored by Simple
+  uint32_t slotId; // local-completion slot for send-staging backpressure
+  uint64_t pipelineGeneration; // slot reuse generation (prepare_send_slot)
 };
 
 /**
@@ -139,11 +141,13 @@ struct ProgressChunk {
  */
 struct ProgressGeometry {
   int groupId;
-  std::size_t payloadBytes;
-  std::size_t protocolBytes;
-  std::size_t perBlockSlot;
-  std::size_t perChannelBufferSize;
-  std::size_t chunkSize;
+  std::size_t payloadBytes; // raw nbytes, for valid-byte masking
+  std::size_t
+      protocolBytes; // payload rounded up to Proto::kData (cursor bound)
+  std::size_t perBlockSlotWire; // physical (wire) bytes per (slot, group)
+  std::size_t perBlockSlotPayload; // payload capacity of that region
+  std::size_t perChannelBufferSize; // wire ring window (group stride)
+  std::size_t chunkPayload; // max payload per chunk (>= 1 packet)
   int pipelineDepth;
 };
 
@@ -196,6 +200,7 @@ __device__ __forceinline__ void store_progress_state(
     IbChannelProgress& slot,
     const IbChannelProgress& state);
 
+template <typename Proto = protocol::Simple>
 __device__ __forceinline__ ProgressGeometry make_progress_geometry(
     const IbChannelLayout& channelLayout,
     ThreadGroup& group,
@@ -225,6 +230,7 @@ __device__ __forceinline__ void transition_progress_stage(
     IbChannelProgress& state,
     detail::IbSendRecvProgressStage next);
 
+template <typename Proto = protocol::Simple>
 __device__ __forceinline__ ProgressChunk next_chunk(
     const IbChannelLayout& channelLayout,
     const IbChannelProgress& state,
@@ -445,7 +451,7 @@ __device__ __forceinline__ void progress_send_prepare_buf(
     Args... args) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   const std::size_t validBytes =
-      valid_payload_bytes(chunk.dataOff, chunk.bytes, payloadBytes);
+      valid_payload_bytes(chunk.dataOff, chunk.payloadBytes, payloadBytes);
   if (validBytes > 0) {
     CopyOp::send(
         channelLayout.sendStagingPtr + chunk.stagingOff,
@@ -474,7 +480,11 @@ __device__ __forceinline__ SendSignal progress_send_signal(
   return SendSignal{remoteChannel.dataReady, signalVal};
 }
 
-template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+template <
+    typename Transport,
+    typename CopyOp = Memcpy,
+    typename Proto = protocol::Simple,
+    typename... Args>
 __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
     Transport& transport,
     ThreadGroup& group,
@@ -503,7 +513,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
   if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
     return IbgdaSendRecvProgressStatus::Done;
   }
-  const ProgressGeometry progress_params = make_progress_geometry(
+  const ProgressGeometry progress_params = make_progress_geometry<Proto>(
       channelLayout, group, nbytes, max_signal_bytes, "progress_send_once");
   if (active_payload_offset(state) >= progress_params.protocolBytes) {
     if (group.is_leader()) {
@@ -519,7 +529,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
 
   const detail::IbSendRecvProgressStage initialStage = state.activeStage;
   const std::size_t initialNextByte = state.activeNextByte;
-  const std::size_t pipelineBytes = progress_params.perBlockSlot *
+  const std::size_t pipelineBytesWire = progress_params.perBlockSlotWire *
       static_cast<std::size_t>(channelLayout.pipelineDepth);
   IbLocalChannel& localChannel =
       transport.local_channel(static_cast<uint32_t>(progress_params.groupId));
@@ -530,7 +540,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
   if (state.activeStage ==
       detail::IbSendRecvProgressStage::WaitLocalCompletion) {
     const ProgressChunk chunk =
-        next_chunk(channelLayout, state, progress_params);
+        next_chunk<Proto>(channelLayout, state, progress_params);
     if (!try_prepare_send_slot(
             transport,
             group,
@@ -541,7 +551,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
     }
 
     progress_send_prepare_buf<CopyOp>(
-        protocol::Simple{},
+        Proto{},
         group,
         channelLayout,
         chunk,
@@ -555,13 +565,13 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
 
   if (state.activeStage == detail::IbSendRecvProgressStage::WaitSlotFree) {
     const ProgressChunk chunk =
-        next_chunk(channelLayout, state, progress_params);
+        next_chunk<Proto>(channelLayout, state, progress_params);
     const bool isFinalChunk =
-        chunk.dataOff + chunk.bytes >= progress_params.protocolBytes;
-    const uint64_t protocolStreamEnd =
-        chunk.streamEnd + (isFinalChunk ? state.activeTailPadding : 0);
-    if (protocolStreamEnd > pipelineBytes) {
-      const uint64_t expected = protocolStreamEnd - pipelineBytes;
+        chunk.dataOff + chunk.payloadBytes >= progress_params.protocolBytes;
+    const uint64_t protocolStreamEnd = chunk.streamEndWire +
+        (isFinalChunk ? Proto::wire_bytes(state.activeTailPadding) : 0);
+    if (protocolStreamEnd > pipelineBytesWire) {
+      const uint64_t expected = protocolStreamEnd - pipelineBytesWire;
       uint32_t ready = 1;
       unsigned long long current = 0;
       if (group.is_leader()) {
@@ -593,15 +603,15 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
       __threadfence_system();
       ThreadGroup solo{
           0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
-      const std::size_t protocolBytesThis =
-          chunk.bytes + (isFinalChunk ? state.activeTailPadding : 0);
-      const SendSignal sig = progress_send_signal(
-          protocol::Simple{}, remoteChannel, protocolBytesThis);
+      const std::size_t protocolBytesThis = chunk.wireBytes +
+          (isFinalChunk ? Proto::wire_bytes(state.activeTailPadding) : 0);
+      const SendSignal sig =
+          progress_send_signal(Proto{}, remoteChannel, protocolBytesThis);
       const auto completion = transport.put(
           solo,
           channelLayout.sendStagingBuf.subBuffer(chunk.stagingOff),
           remoteChannel.recvStaging.subBuffer(chunk.stagingOff),
-          chunk.bytes,
+          chunk.wireBytes,
           sig.buf,
           sig.val,
           /*counterBuf=*/{},
@@ -616,7 +626,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
     }
     group.sync();
 
-    state.activeNextByte += chunk.bytes;
+    state.activeNextByte += chunk.payloadBytes;
     if (active_payload_offset(state) >= progress_params.protocolBytes) {
       transition_progress_stage(
           group, state, detail::IbSendRecvProgressStage::Done);
@@ -837,7 +847,7 @@ __device__ __forceinline__ void progress_recv_consume_buf(
     Args... args) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   const std::size_t validBytes =
-      valid_payload_bytes(chunk.dataOff, chunk.bytes, payloadBytes);
+      valid_payload_bytes(chunk.dataOff, chunk.payloadBytes, payloadBytes);
   if (validBytes > 0) {
     CopyOp::recv(
         static_cast<char*>(dst) + chunk.dataOff,
@@ -857,7 +867,11 @@ __device__ __forceinline__ void progress_recv_consume_buf(
 #endif
 }
 
-template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+template <
+    typename Transport,
+    typename CopyOp = Memcpy,
+    typename Proto = protocol::Simple,
+    typename... Args>
 __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
     Transport& transport,
     ThreadGroup& group,
@@ -884,7 +898,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
   if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
     return IbgdaSendRecvProgressStatus::Done;
   }
-  const ProgressGeometry progress_params = make_progress_geometry(
+  const ProgressGeometry progress_params = make_progress_geometry<Proto>(
       channelLayout, group, nbytes, max_signal_bytes, "progress_recv_once");
   if (active_payload_offset(state) >= progress_params.protocolBytes) {
     if (group.is_leader()) {
@@ -898,18 +912,19 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
   }
   validate_recv_progress_stage(group, state);
 
-  const ProgressChunk chunk = next_chunk(channelLayout, state, progress_params);
+  const ProgressChunk chunk =
+      next_chunk<Proto>(channelLayout, state, progress_params);
   const bool isFinalChunk =
-      chunk.dataOff + chunk.bytes >= progress_params.protocolBytes;
-  const std::size_t protocolBytesThis =
-      chunk.bytes + (isFinalChunk ? state.activeTailPadding : 0);
+      chunk.dataOff + chunk.payloadBytes >= progress_params.protocolBytes;
+  const std::size_t protocolBytesThis = chunk.wireBytes +
+      (isFinalChunk ? Proto::wire_bytes(state.activeTailPadding) : 0);
   IbLocalChannel& localChannel =
       transport.local_channel(static_cast<uint32_t>(progress_params.groupId));
   const IbgdaLocalBuffer localDataReady = localChannel.dataReady;
   const IbRemoteChannel remoteChannel =
       makeIbRemoteChannel(channelLayout, progress_params.groupId);
   if (!progress_recv_ready(
-          protocol::Simple{},
+          Proto{},
           transport,
           group,
           localChannel,
@@ -920,7 +935,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
   }
 
   progress_recv_consume_buf<CopyOp>(
-      protocol::Simple{},
+      Proto{},
       group,
       channelLayout,
       chunk,
@@ -932,7 +947,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
   transport.signal(
       group, remoteChannel.slotFree, protocolBytesThis, IbDirection::Recv);
 
-  state.activeNextByte += chunk.bytes;
+  state.activeNextByte += chunk.payloadBytes;
   if (active_payload_offset(state) >= progress_params.protocolBytes) {
     transition_progress_stage(
         group, state, detail::IbSendRecvProgressStage::Done);
@@ -2383,6 +2398,7 @@ __device__ __forceinline__ void store_progress_state(
  * already `Done`. Non-empty payload byte counts are rounded up to 16-byte
  * protocol counts here; copy callbacks still see only valid payload bytes.
  */
+template <typename Proto>
 __device__ __forceinline__ ProgressGeometry make_progress_geometry(
     const IbChannelLayout& channelLayout,
     ThreadGroup& group,
@@ -2412,11 +2428,12 @@ __device__ __forceinline__ ProgressGeometry make_progress_geometry(
     PIPES_DEVICE_TRAP();
   }
 
-  const std::size_t perBlockSlot = pipeline_chunk(channelLayout);
-  if (perBlockSlot == 0) {
+  const std::size_t perBlockSlotWire = pipeline_chunk(channelLayout);
+  const std::size_t perBlockSlotPayload = Proto::max_payload(perBlockSlotWire);
+  if (perBlockSlotPayload == 0) {
     if (group.is_leader()) {
       printf(
-          "[PIPES] FATAL: %s perBlockSlot=0 "
+          "[PIPES] FATAL: %s perBlockSlotPayload=0 "
           "(perChannelBufferSize=%llu, pipelineDepth=%d)\n",
           opName,
           (unsigned long long)pipeline_window(channelLayout),
@@ -2426,21 +2443,26 @@ __device__ __forceinline__ ProgressGeometry make_progress_geometry(
   }
   const std::size_t perChannelBufferSize = pipeline_window(channelLayout);
 
-  const std::size_t protocolBytes = align_protocol_bytes(nbytes);
-  std::size_t chunkSize =
-      (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
-      ? (max_signal_bytes & ~15ULL)
-      : perBlockSlot;
-  if (chunkSize == 0) {
-    chunkSize = perBlockSlot;
+  // Cursor + chunk sizing run in PAYLOAD bytes, aligned to whole packets
+  // (Proto::kData); wire quantities are derived via Proto::wire_bytes. For
+  // Simple (kData == 16) this is the original 16B alignment.
+  const std::size_t protocolBytes =
+      (nbytes + Proto::kData - 1) / Proto::kData * Proto::kData;
+  std::size_t chunkPayload =
+      (max_signal_bytes > 0 && max_signal_bytes < perBlockSlotPayload)
+      ? (max_signal_bytes / Proto::kData * Proto::kData)
+      : perBlockSlotPayload;
+  if (chunkPayload == 0) {
+    chunkPayload = perBlockSlotPayload;
   }
   return ProgressGeometry{
       .groupId = groupId,
       .payloadBytes = nbytes,
       .protocolBytes = protocolBytes,
-      .perBlockSlot = perBlockSlot,
+      .perBlockSlotWire = perBlockSlotWire,
+      .perBlockSlotPayload = perBlockSlotPayload,
       .perChannelBufferSize = perChannelBufferSize,
-      .chunkSize = chunkSize,
+      .chunkPayload = chunkPayload,
       .pipelineDepth = channelLayout.pipelineDepth,
   };
 #else
@@ -2478,8 +2500,8 @@ __device__ __forceinline__ void reserve_progress_step(
     baseStep = static_cast<uint64_t>(slot.nextStep);
     protocolTailPadding = tail_padding_for_signal_granularity(
         baseStep,
-        geometry.chunkSize,
-        geometry.perBlockSlot,
+        geometry.chunkPayload,
+        geometry.perBlockSlotPayload,
         geometry.payloadBytes);
     slot.nextStep = static_cast<int64_t>(
         baseStep + geometry.protocolBytes + protocolTailPadding);
@@ -2608,35 +2630,44 @@ __device__ __forceinline__ void transition_progress_stage(
  * bounded and prevents a single RDMA put or recv copy from spanning two
  * staging slots.
  */
+template <typename Proto>
 __device__ __forceinline__ ProgressChunk next_chunk(
     const IbChannelLayout& channelLayout,
     const IbChannelProgress& state,
     const ProgressGeometry& geometry) {
+  // The ring cursor advances in PAYLOAD bytes; staging offsets, RDMA lengths,
+  // and readiness thresholds are derived in WIRE bytes via Proto::wire_bytes
+  // (1:1 for Simple, kPacketBytes:kData for LL).
   const uint64_t streamStart =
       static_cast<uint64_t>(state.activeBaseStep) + state.activeNextByte;
   (void)channelLayout;
-  const std::size_t pipelineBytes = geometry.perChannelBufferSize;
+  const std::size_t pipelineBytesPayload =
+      Proto::max_payload(geometry.perChannelBufferSize);
   const std::size_t pipelineOff =
-      static_cast<std::size_t>(streamStart % pipelineBytes);
-  const int slot = static_cast<int>(pipelineOff / geometry.perBlockSlot);
-  const std::size_t slotOff =
-      static_cast<std::size_t>(slot) * geometry.perBlockSlot;
-  const std::size_t chunkOff =
-      pipelineOff - static_cast<std::size_t>(slot) * geometry.perBlockSlot;
-  const std::size_t slotRemaining = geometry.perBlockSlot - chunkOff;
+      static_cast<std::size_t>(streamStart % pipelineBytesPayload);
+  const int slot = static_cast<int>(pipelineOff / geometry.perBlockSlotPayload);
+  const std::size_t chunkOff = pipelineOff -
+      static_cast<std::size_t>(slot) * geometry.perBlockSlotPayload;
+  const std::size_t slotRemaining = geometry.perBlockSlotPayload - chunkOff;
   const std::size_t payloadNextByte = active_payload_offset(state);
   const std::size_t dataRemaining = geometry.protocolBytes - payloadNextByte;
-  std::size_t bytes =
-      geometry.chunkSize < dataRemaining ? geometry.chunkSize : dataRemaining;
-  bytes = bytes < slotRemaining ? bytes : slotRemaining;
+  std::size_t payloadBytes = geometry.chunkPayload < dataRemaining
+      ? geometry.chunkPayload
+      : dataRemaining;
+  payloadBytes = payloadBytes < slotRemaining ? payloadBytes : slotRemaining;
   return ProgressChunk{
-      .stagingOff = static_cast<std::size_t>(geometry.groupId) * pipelineBytes +
-          slotOff + chunkOff,
+      .stagingOff = static_cast<std::size_t>(geometry.groupId) *
+              geometry.perChannelBufferSize +
+          static_cast<std::size_t>(slot) * geometry.perBlockSlotWire +
+          Proto::wire_bytes(chunkOff),
       .dataOff = payloadNextByte,
-      .bytes = bytes,
-      .streamEnd = streamStart + bytes,
+      .payloadBytes = payloadBytes,
+      .wireBytes = Proto::wire_bytes(payloadBytes),
+      .streamEndWire =
+          Proto::wire_bytes(streamStart) + Proto::wire_bytes(payloadBytes),
+      .flagVal = streamStart / pipelineBytesPayload + 1,
       .slotId = static_cast<uint32_t>(slot),
-      .pipelineGeneration = streamStart / pipelineBytes,
+      .pipelineGeneration = streamStart / pipelineBytesPayload,
   };
 }
 

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -946,6 +946,166 @@ __device__ __forceinline__ SendRecvGeometry calcGeometry(
   };
 }
 
+struct SendSignal {
+  IbgdaRemoteBuffer buf;
+  uint64_t val;
+};
+
+template <typename CopyOp = Memcpy, typename... Args>
+__device__ __forceinline__ SendSignal prepareSendBuf(
+    protocol::Simple,
+    ThreadGroup& group,
+    char* staging,
+    const char* src,
+    std::size_t payloadBytes,
+    std::size_t nbytes,
+    std::size_t dataOff,
+    const IbRemoteChannel& remoteChannel,
+    uint64_t signalVal,
+    Args... args) {
+#if PIPES_IS_DEVICE_COMPILE
+  const std::size_t validBytes =
+      valid_payload_bytes(dataOff, payloadBytes, nbytes);
+  if (validBytes > 0) {
+    CopyOp::send(staging, src, validBytes, group, dataOff, args...);
+  }
+  group.sync();
+  return SendSignal{remoteChannel.dataReady, signalVal};
+#else
+  (void)group;
+  (void)staging;
+  (void)src;
+  (void)payloadBytes;
+  (void)nbytes;
+  (void)dataOff;
+  (void)remoteChannel;
+  (void)signalVal;
+  ((void)args, ...);
+  return SendSignal{};
+#endif
+}
+
+// Simple decode: wait for the sender's DATA_READY on this chunk's lane, then
+// cooperative CopyOp::recv from contiguous staging.
+template <typename CopyOp = Memcpy, typename Transport, typename... Args>
+__device__ __forceinline__ void consumeRecvBuf(
+    protocol::Simple,
+    Transport& transport,
+    ThreadGroup& group,
+    IbLocalChannel& localChannel,
+    const IbgdaLocalBuffer& localDataReady,
+    char* dst,
+    const char* staging,
+    std::size_t payloadBytes,
+    std::size_t nbytes,
+    std::size_t dataOff,
+    uint64_t waitCredit,
+    const Timeout& timeout,
+    Args... args) {
+#if PIPES_IS_DEVICE_COMPILE
+  wait_recv_data_ready(
+      transport, group, localChannel, localDataReady, waitCredit, timeout);
+  const std::size_t validBytes =
+      valid_payload_bytes(dataOff, payloadBytes, nbytes);
+  if (validBytes > 0) {
+    CopyOp::recv(dst, staging, validBytes, group, dataOff, args...);
+  }
+  group.sync();
+#else
+  (void)transport;
+  (void)group;
+  (void)localChannel;
+  (void)localDataReady;
+  (void)dst;
+  (void)staging;
+  (void)payloadBytes;
+  (void)nbytes;
+  (void)dataOff;
+  (void)waitCredit;
+  (void)timeout;
+  ((void)args, ...);
+#endif
+}
+
+// Simple forward: wait for the upstream chunk's DATA_READY, then a single fused
+// CopyOp::forward transforms recvStaging -> dst + fwdStaging, and return the
+// DATA_READY SendSignal that the relay put piggybacks. This is the forward
+// analog of consumeRecvBuf (recv-side readiness) fused with prepareSendBuf
+// (relay signal); LL later overrides it to poll inline flags, repack the fwd
+// staging, and return an empty signal.
+template <
+    typename CopyOp = Memcpy,
+    typename Transport,
+    typename FwdTransport,
+    typename... Args>
+__device__ __forceinline__ SendSignal prepareForwardBuf(
+    protocol::Simple,
+    Transport& transport,
+    FwdTransport& fwdTransport,
+    ThreadGroup& group,
+    IbLocalChannel& recvLocalChannel,
+    const IbgdaLocalBuffer& recvDataReady,
+    char* dst,
+    char* fwdStaging,
+    const char* recvStaging,
+    std::size_t payloadBytes,
+    std::size_t nbytes,
+    std::size_t dataOff,
+    uint64_t recvWaitCredit,
+    const IbRemoteChannel& fwdRemoteChannel,
+    uint64_t fwdSignalVal,
+    uint32_t fwdSlot,
+    uint64_t fwdPipelineCycle,
+    const Timeout& timeout,
+    Args... args) {
+#if PIPES_IS_DEVICE_COMPILE
+  // Both waits must clear before CopyOp::forward, which reads recvStaging and
+  // writes fwdStaging; they are independent, so the order is a latency choice,
+  // not a correctness one. Upstream readiness goes first because it is the
+  // remote-dependent wait: by the time the peer's data lands, the local NIC has
+  // usually already released this fwdStaging slot, so prepare_send_slot
+  // degenerates to a single completion check instead of a CQ-polling spin.
+  // Folded in here rather than left to the caller -- both are correctness
+  // requirements of this function, not of its call site.
+  wait_recv_data_ready(
+      transport,
+      group,
+      recvLocalChannel,
+      recvDataReady,
+      recvWaitCredit,
+      timeout);
+  prepare_send_slot(fwdTransport, group, fwdSlot, fwdPipelineCycle, timeout);
+  const std::size_t validBytes =
+      valid_payload_bytes(dataOff, payloadBytes, nbytes);
+  if (validBytes > 0) {
+    CopyOp::forward(
+        dst, fwdStaging, recvStaging, validBytes, group, dataOff, args...);
+  }
+  group.sync();
+  return SendSignal{fwdRemoteChannel.dataReady, fwdSignalVal};
+#else
+  (void)transport;
+  (void)fwdTransport;
+  (void)group;
+  (void)recvLocalChannel;
+  (void)recvDataReady;
+  (void)dst;
+  (void)fwdStaging;
+  (void)recvStaging;
+  (void)payloadBytes;
+  (void)nbytes;
+  (void)dataOff;
+  (void)recvWaitCredit;
+  (void)fwdRemoteChannel;
+  (void)fwdSignalVal;
+  (void)fwdSlot;
+  (void)fwdPipelineCycle;
+  (void)timeout;
+  ((void)args, ...);
+  return SendSignal{};
+#endif
+}
+
 template <
     typename Transport,
     typename CopyOp = Memcpy,
@@ -959,6 +1119,16 @@ __device__ __forceinline__ void send(
     std::size_t max_signal_bytes = 0,
     const Timeout& timeout = Timeout(),
     Args... args) {
+  // The variable-size (compressed) loop below keeps its encode inline rather
+  // than behind the prepareSendBuf/consumeRecvBuf seam, so it is Simple-shaped
+  // and a non-default protocol would silently drive the wrong encode. Forbid
+  // the pairing; there is no LL-over-compressed use case today.
+  static_assert(
+      !detail::copyop_variable_size_v<CopyOp> ||
+          std::is_same_v<Proto, protocol::Simple>,
+      "variable-size CopyOps (e.g. AnsCompress) are supported on "
+      "protocol::Simple only; the compressed loop is not behind the "
+      "prepareSendBuf/consumeRecvBuf seam.");
 #if !PIPES_IS_DEVICE_COMPILE
   (void)transport;
   (void)group;
@@ -1245,18 +1415,17 @@ __device__ __forceinline__ void send(
       prepare_send_slot(transport, group, slot, pipelineCycle, timeout);
 
       // (2) Cooperative copy: src -> local sendStaging via CopyOp.
-      const std::size_t validBytes =
-          valid_payload_bytes(dataOff, payloadBytes, nbytes);
-      if (validBytes > 0) {
-        CopyOp::send(
-            channelLayout.sendStagingPtr + stagingOff,
-            static_cast<const char*>(src) + dataOff,
-            validBytes,
-            group,
-            dataOff,
-            args...);
-      }
-      group.sync();
+      const SendSignal sig = prepareSendBuf<CopyOp>(
+          Proto{},
+          group,
+          channelLayout.sendStagingPtr + stagingOff,
+          static_cast<const char*>(src) + dataOff,
+          payloadBytes,
+          nbytes,
+          dataOff,
+          remoteChannel,
+          protocolBytesThis,
+          args...);
 
       // (3) Backpressure: wait for receiver to free this byte range's
       //     recvStaging offset. Symmetric with DATA_READY.
@@ -1279,8 +1448,8 @@ __device__ __forceinline__ void send(
             channelLayout.sendStagingBuf.subBuffer(stagingOff),
             remoteChannel.recvStaging.subBuffer(stagingOff),
             bytesThis,
-            remoteChannel.dataReady,
-            protocolBytesThis,
+            sig.buf,
+            sig.val,
             /*counterBuf=*/{},
             /*counterVal=*/0,
             /*signalPerLane=*/true);
@@ -1347,6 +1516,16 @@ __device__ __forceinline__ void recv(
     std::size_t max_signal_bytes = 0,
     const Timeout& timeout = Timeout(),
     Args... args) {
+  // The variable-size (compressed) loop below keeps its encode inline rather
+  // than behind the prepareSendBuf/consumeRecvBuf seam, so it is Simple-shaped
+  // and a non-default protocol would silently drive the wrong encode. Forbid
+  // the pairing; there is no LL-over-compressed use case today.
+  static_assert(
+      !detail::copyop_variable_size_v<CopyOp> ||
+          std::is_same_v<Proto, protocol::Simple>,
+      "variable-size CopyOps (e.g. AnsCompress) are supported on "
+      "protocol::Simple only; the compressed loop is not behind the "
+      "prepareSendBuf/consumeRecvBuf seam.");
 #if !PIPES_IS_DEVICE_COMPILE
   (void)transport;
   (void)group;
@@ -1558,29 +1737,22 @@ __device__ __forceinline__ void recv(
           static_cast<std::size_t>(slot) * perBlockSlotWire +
           Proto::wire_bytes(chunkOff);
 
-      // (1) Wait for sender's DATA_READY on the specific round-robin lane that
-      //     carried this chunk (mirrors the sender's per-channel Send cursor).
-      wait_recv_data_ready(
+      // (1)+(2) Wait for the chunk to be ready (DATA_READY signal or, for LL,
+      //         the inline flag) and cooperatively copy recvStaging -> dst.
+      consumeRecvBuf<CopyOp>(
+          Proto{},
           transport,
           group,
           localChannel,
           localDataReady,
+          static_cast<char*>(dst) + dataOff,
+          channelLayout.recvStagingPtr + stagingOff,
+          payloadBytes,
+          nbytes,
+          dataOff,
           protocolBytesThis,
-          timeout);
-
-      // (2) Cooperative copy: local recvStaging -> dst via CopyOp.
-      const std::size_t validBytes =
-          valid_payload_bytes(dataOff, payloadBytes, nbytes);
-      if (validBytes > 0) {
-        CopyOp::recv(
-            static_cast<char*>(dst) + dataOff,
-            channelLayout.recvStagingPtr + stagingOff,
-            validBytes,
-            group,
-            dataOff,
-            args...);
-      }
-      group.sync();
+          timeout,
+          args...);
 
       transport.signal(
           group, remoteChannel.slotFree, protocolBytesThis, IbDirection::Recv);
@@ -1783,34 +1955,29 @@ __device__ __forceinline__ void forward(
     const uint64_t fwdPipelineCycle =
         fwdStreamPayload / fwdGeo.pipelineBytesPayload;
 
-    // (1) Wait for the upstream sender's DATA_READY on the specific round-robin
-    //     lane that carried this chunk (mirrors the upstream sender's Send
-    //     cursor via recvLocalChannel.recvDataReadyLaneCursor).
-    wait_recv_data_ready(
+    // (1) prepareForwardBuf: fwd slot-reuse backpressure + recv-side readiness
+    //     + fused transform recvStaging -> dst + fwdStaging, returning the
+    //     relay SendSignal for the put. Tag-dispatched on Proto.
+    const SendSignal sig = prepareForwardBuf<CopyOp>(
+        Proto{},
         transport,
+        fwdTransport,
         group,
         recvLocalChannel,
         recvDataReady,
+        dst ? static_cast<char*>(dst) + dataOff : nullptr,
+        fwdChannelLayout.sendStagingPtr + fwdStagingOff,
+        channelLayout.recvStagingPtr + recvStagingOff,
+        payloadBytes,
+        nbytes,
+        dataOff,
         recvProtocolBytesThis,
-        timeout);
-
-    // (2) Wait for local completion on fwd's sendStaging.
-    prepare_send_slot(fwdTransport, group, fwdSlot, fwdPipelineCycle, timeout);
-
-    // (3) CopyOp::forward — transform recv staging -> dst + fwd staging.
-    const std::size_t validBytes =
-        valid_payload_bytes(dataOff, payloadBytes, nbytes);
-    if (validBytes > 0) {
-      CopyOp::forward(
-          dst ? static_cast<char*>(dst) + dataOff : nullptr,
-          fwdChannelLayout.sendStagingPtr + fwdStagingOff,
-          channelLayout.recvStagingPtr + recvStagingOff,
-          validBytes,
-          group,
-          dataOff,
-          args...);
-    }
-    group.sync();
+        fwdRemoteChannel,
+        fwdProtocolBytesThis,
+        static_cast<uint32_t>(fwdSlot),
+        fwdPipelineCycle,
+        timeout,
+        args...);
 
     transport.signal(
         group,
@@ -1839,8 +2006,8 @@ __device__ __forceinline__ void forward(
           fwdChannelLayout.sendStagingBuf.subBuffer(fwdStagingOff),
           fwdRemoteChannel.recvStaging.subBuffer(fwdStagingOff),
           bytesThis,
-          fwdRemoteChannel.dataReady,
-          fwdProtocolBytesThis,
+          sig.buf,
+          sig.val,
           /*counterBuf=*/{},
           /*counterVal=*/0,
           /*signalPerLane=*/true);

--- a/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
@@ -146,7 +146,11 @@ __device__ __forceinline__ void init_recv_progress(
     std::size_t nbytes,
     std::size_t max_signal_bytes);
 
-template <typename Transport, typename CopyOp, typename... Args>
+template <
+    typename Transport,
+    typename CopyOp,
+    typename Proto = protocol::Simple,
+    typename... Args>
 __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
     Transport& transport,
     ThreadGroup& group,
@@ -156,7 +160,11 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
     const Timeout& timeout,
     Args... args);
 
-template <typename Transport, typename CopyOp, typename... Args>
+template <
+    typename Transport,
+    typename CopyOp,
+    typename Proto = protocol::Simple,
+    typename... Args>
 __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
     Transport& transport,
     ThreadGroup& group,

--- a/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
@@ -57,6 +57,9 @@ __device__ __forceinline__ void trace_ibgda_event(
  */
 namespace protocol {
 struct Simple {
+  // Resource slot this protocol owns on every channel. Slot 0 is the default
+  // protocol; additional protocols take higher slots (see kNumProtoSlots).
+  static constexpr int kProtoSlot = 0;
   static constexpr std::size_t kData = 16; // protocol alignment quantum
   static constexpr std::size_t kPacketBytes = 16; // wire == payload
   __host__ __device__ static constexpr std::size_t max_payload(
@@ -72,14 +75,37 @@ struct Simple {
 
 namespace detail {
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ IbChannelProgress& progress_send_slot(
     Transport& transport,
     ThreadGroup& group);
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ IbChannelProgress& progress_recv_slot(
     Transport& transport,
+    ThreadGroup& group);
+
+/**
+ * Every channel resource one (channel, protocol) transfer addresses, resolved
+ * in one place.
+ *
+ * Callers must never derive a channel or slot index themselves: the whole point
+ * is that the protocol coordinate lives here and nowhere else, so adding a
+ * protocol cannot silently miss a site. `groupId` stays the LOGICAL channel --
+ * which is also the QP channel -- and the protocol is a separate compile-time
+ * coordinate, never folded into it.
+ */
+struct ChannelSlotView {
+  IbLocalChannel& channel; ///< shared: sendQp, recvQp, recvDataReadyLaneCursor
+  IbChannelProtoSlot& local; ///< this protocol's cursors and local buffer views
+  IbRemoteChannel remote; ///< this protocol's peer-side views
+  std::size_t stagingBase; ///< byte offset of this slot's staging window
+};
+
+template <typename P, typename Transport>
+__device__ __forceinline__ ChannelSlotView acquire_channel(
+    Transport& transport,
+    const IbChannelLayout& channelLayout,
     ThreadGroup& group);
 
 __device__ __forceinline__ static std::size_t valid_payload_bytes(
@@ -116,7 +142,7 @@ __device__ __forceinline__ void assert_progress_slot_idle(
     const IbChannelProgress& slot,
     const char* opName);
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ void prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
@@ -124,7 +150,7 @@ __device__ __forceinline__ void prepare_send_slot(
     uint64_t generation,
     const Timeout& timeout = Timeout());
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ void record_send_completion(
     Transport& transport,
     uint32_t channelId,
@@ -220,18 +246,25 @@ __device__ __forceinline__ void wait_recv_data_ready(
       static_cast<uint32_t>(transport.channel_layout().numLanes);
   const uint32_t lanes = numLanes == 0 ? 1U : numLanes;
   if (group.is_leader()) {
+    // Simple's slot unconditionally: an explicit DATA_READY signal IS Simple's
+    // readiness mark. A protocol that carries its flag inline never reaches
+    // here, so there is no other slot to select. The lane cursor is
+    // channel-scoped (it mirrors the shared sendQp.cursor); the per-lane
+    // expected totals are slot-scoped, mirroring Simple's own DATA_READY slots.
+    IbChannelProtoSlot& protoSlot =
+        localChannel.protos[protocol::Simple::kProtoSlot];
     // Truncate recvDataReadyLaneCursor to 32 bits BEFORE the modulo so the lane
     // matches the sender's uint32 Send cursor once it wraps at 2^32; otherwise
     // a non-power-of-two numLanes would desync the lane after wrap.
     const uint32_t lane =
         static_cast<uint32_t>(localChannel.recvDataReadyLaneCursor) % lanes;
-    const uint64_t expected = localChannel.recvLaneExpected[lane] + chunkBytes;
+    const uint64_t expected = protoSlot.recvLaneExpected[lane] + chunkBytes;
     const IbgdaLocalBuffer laneBuf = localDataReady.subBuffer(
         sendRecvSignalSlotOffset(static_cast<int>(lane)));
     ThreadGroup solo{
         0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
     transport.wait_signal(solo, laneBuf, expected, timeout);
-    localChannel.recvLaneExpected[lane] = expected;
+    protoSlot.recvLaneExpected[lane] = expected;
     ++localChannel.recvDataReadyLaneCursor;
   }
   group.sync();
@@ -291,7 +324,10 @@ __device__ __forceinline__ void wait_recv_data_ready(
 // geometry is added in a later diff. Blocking-path analog of
 // make_progress_geometry().
 struct SendRecvGeometry {
+  // See ProgressGeometry: logical channel and protocol resource slot stay
+  // separate coordinates.
   int groupId;
+  int slotIndex;
   std::size_t perBlockSlotWire; // physical (wire) bytes per (slot, group)
   std::size_t perBlockSlotPayload; // payload capacity of that region
   std::size_t chunkPayload; // max payload per signaled chunk (>= 1 packet)
@@ -345,6 +381,7 @@ __device__ __forceinline__ SendRecvGeometry calcGeometry(
       (nbytes + P::kData - 1) / P::kData * P::kData;
   return SendRecvGeometry{
       .groupId = groupId,
+      .slotIndex = channelLayout.protoChannelSlot(groupId, P::kProtoSlot),
       .perBlockSlotWire = perBlockSlotWire,
       .perBlockSlotPayload = perBlockSlotPayload,
       .chunkPayload = chunkPayload,
@@ -477,7 +514,8 @@ __device__ __forceinline__ SendSignal prepareForwardBuf(
       recvDataReady,
       recvWaitCredit,
       timeout);
-  prepare_send_slot(fwdTransport, group, fwdSlot, fwdPipelineCycle, timeout);
+  prepare_send_slot<protocol::Simple>(
+      fwdTransport, group, fwdSlot, fwdPipelineCycle, timeout);
   const std::size_t validBytes =
       valid_payload_bytes(dataOff, payloadBytes, nbytes);
   if (validBytes > 0) {
@@ -556,12 +594,11 @@ __device__ __forceinline__ void send(
   [[maybe_unused]] const std::size_t payloadProtocolBytes =
       geometry.payloadProtocolBytes;
 
-  auto& state = progress_send_slot(transport, group);
-  IbLocalChannel& localChannel =
-      transport.local_channel(static_cast<uint32_t>(groupId));
-  const IbgdaLocalBuffer localSlotFree = localChannel.slotFree;
-  const IbRemoteChannel remoteChannel =
-      makeIbRemoteChannel(channelLayout, groupId);
+  auto& state = progress_send_slot<Proto>(transport, group);
+  const ChannelSlotView ch =
+      acquire_channel<Proto>(transport, channelLayout, group);
+  const IbgdaLocalBuffer localSlotFree = ch.local.slotFree;
+  const IbRemoteChannel remoteChannel = ch.remote;
   assert_progress_slot_idle(group, state, "send");
   const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
   // Category of the previous op on this slot, read before the leader overwrites
@@ -708,7 +745,8 @@ __device__ __forceinline__ void send(
           (dataOff + chunkSize <= nbytes) ? chunkSize : (nbytes - dataOff);
 
       // (1) Wait for NIC to finish with this slot's local sendStaging.
-      prepare_send_slot(transport, group, ringSlot, pipelineCycle, timeout);
+      prepare_send_slot<Proto>(
+          transport, group, ringSlot, pipelineCycle, timeout);
 
       // (2) Cooperative compress: src -> local sendStaging via CopyOp. The
       //     return value is the compressed byte count the leader uses to size
@@ -761,7 +799,7 @@ __device__ __forceinline__ void send(
             /*counterBuf=*/{},
             /*counterVal=*/0,
             /*signalPerLane=*/true);
-        record_send_completion(
+        record_send_completion<Proto>(
             transport,
             static_cast<uint32_t>(groupId),
             ringSlot,
@@ -806,8 +844,7 @@ __device__ __forceinline__ void send(
       // wire_bytes(cursor)). Identity for Simple; kPacketBytes:kData for LL.
       const std::size_t protocolBytesThis = bytesThis +
           (isFinalChunk ? Proto::wire_bytes(protocolTailPadding) : 0);
-      const std::size_t stagingOff =
-          static_cast<std::size_t>(groupId) * pipelineBytesWire +
+      const std::size_t stagingOff = ch.stagingBase +
           static_cast<std::size_t>(slot) * perBlockSlotWire +
           Proto::wire_bytes(chunkOff);
       const uint64_t streamWire = Proto::wire_bytes(streamPayload);
@@ -815,7 +852,7 @@ __device__ __forceinline__ void send(
       const uint64_t pipelineCycle = streamPayload / pipelineBytesPayload;
 
       // (1) Wait for NIC to finish with this slot's local sendStaging.
-      prepare_send_slot(transport, group, slot, pipelineCycle, timeout);
+      prepare_send_slot<Proto>(transport, group, slot, pipelineCycle, timeout);
 
       // (2) Cooperative copy: src -> local sendStaging via CopyOp.
       const SendSignal sig = prepareSendBuf<CopyOp>(
@@ -856,7 +893,7 @@ __device__ __forceinline__ void send(
             /*counterBuf=*/{},
             /*counterVal=*/0,
             /*signalPerLane=*/true);
-        record_send_completion(
+        record_send_completion<Proto>(
             transport,
             static_cast<uint32_t>(groupId),
             slot,
@@ -953,12 +990,12 @@ __device__ __forceinline__ void recv(
   [[maybe_unused]] const std::size_t payloadProtocolBytes =
       geometry.payloadProtocolBytes;
 
-  auto& state = progress_recv_slot(transport, group);
-  IbLocalChannel& localChannel =
-      transport.local_channel(static_cast<uint32_t>(groupId));
-  const IbgdaLocalBuffer localDataReady = localChannel.dataReady;
-  const IbRemoteChannel remoteChannel =
-      makeIbRemoteChannel(channelLayout, groupId);
+  auto& state = progress_recv_slot<Proto>(transport, group);
+  const ChannelSlotView ch =
+      acquire_channel<Proto>(transport, channelLayout, group);
+  IbLocalChannel& localChannel = ch.channel;
+  const IbgdaLocalBuffer localDataReady = ch.local.dataReady;
+  const IbRemoteChannel remoteChannel = ch.remote;
   assert_progress_slot_idle(group, state, "recv");
   const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
   // Category of the previous op on this slot, read before the leader overwrites
@@ -1135,8 +1172,7 @@ __device__ __forceinline__ void recv(
       // wire_bytes(cursor)). Identity for Simple; kPacketBytes:kData for LL.
       const std::size_t protocolBytesThis = bytesThis +
           (isFinalChunk ? Proto::wire_bytes(protocolTailPadding) : 0);
-      const std::size_t stagingOff =
-          static_cast<std::size_t>(groupId) * pipelineBytesWire +
+      const std::size_t stagingOff = ch.stagingBase +
           static_cast<std::size_t>(slot) * perBlockSlotWire +
           Proto::wire_bytes(chunkOff);
 
@@ -1265,12 +1301,12 @@ __device__ __forceinline__ void forward(
   const std::size_t payloadProtocolBytes = recvGeo.payloadProtocolBytes;
 
   // --- recv side (this transport) ---
-  auto& recvSlotState = progress_recv_slot(transport, group);
-  IbLocalChannel& recvLocalChannel =
-      transport.local_channel(static_cast<uint32_t>(groupId));
-  const IbgdaLocalBuffer recvDataReady = recvLocalChannel.dataReady;
-  const IbRemoteChannel recvRemoteChannel =
-      makeIbRemoteChannel(channelLayout, groupId);
+  auto& recvSlotState = progress_recv_slot<Proto>(transport, group);
+  const ChannelSlotView recvCh =
+      acquire_channel<Proto>(transport, channelLayout, group);
+  IbLocalChannel& recvLocalChannel = recvCh.channel;
+  const IbgdaLocalBuffer recvDataReady = recvCh.local.dataReady;
+  const IbRemoteChannel recvRemoteChannel = recvCh.remote;
   assert_progress_slot_idle(group, recvSlotState, "forward recv");
   const uint64_t recvBaseByte = static_cast<uint64_t>(recvSlotState.nextStep);
   const std::size_t recvProtocolTailPadding =
@@ -1281,12 +1317,11 @@ __device__ __forceinline__ void forward(
       payloadProtocolBytes + recvProtocolTailPadding;
 
   // --- fwd side (fwd transport) ---
-  auto& fwdSlotState = progress_send_slot(fwdTransport, group);
-  IbLocalChannel& fwdLocalChannel =
-      fwdTransport.local_channel(static_cast<uint32_t>(groupId));
-  const IbgdaLocalBuffer fwdSlotFree = fwdLocalChannel.slotFree;
-  const IbRemoteChannel fwdRemoteChannel =
-      makeIbRemoteChannel(fwdChannelLayout, groupId);
+  auto& fwdSlotState = progress_send_slot<Proto>(fwdTransport, group);
+  const ChannelSlotView fwdCh =
+      acquire_channel<Proto>(fwdTransport, fwdChannelLayout, group);
+  const IbgdaLocalBuffer fwdSlotFree = fwdCh.local.slotFree;
+  const IbRemoteChannel fwdRemoteChannel = fwdCh.remote;
   assert_progress_slot_idle(group, fwdSlotState, "forward send");
   const uint64_t fwdBaseByte = static_cast<uint64_t>(fwdSlotState.nextStep);
   const std::size_t fwdProtocolTailPadding =
@@ -1315,8 +1350,7 @@ __device__ __forceinline__ void forward(
         static_cast<int>(recvPipelineOff / recvGeo.perBlockSlotPayload);
     const std::size_t recvChunkOff =
         recvPipelineOff - recvSlot * recvGeo.perBlockSlotPayload;
-    const std::size_t recvStagingOff =
-        static_cast<std::size_t>(groupId) * recvGeo.pipelineBytesWire +
+    const std::size_t recvStagingOff = recvCh.stagingBase +
         static_cast<std::size_t>(recvSlot) * recvGeo.perBlockSlotWire +
         Proto::wire_bytes(recvChunkOff);
     const std::size_t recvSlotRemaining =
@@ -1330,8 +1364,7 @@ __device__ __forceinline__ void forward(
         static_cast<int>(fwdPipelineOff / fwdGeo.perBlockSlotPayload);
     const std::size_t fwdChunkOff =
         fwdPipelineOff - fwdSlot * fwdGeo.perBlockSlotPayload;
-    const std::size_t fwdStagingOff =
-        static_cast<std::size_t>(groupId) * fwdGeo.pipelineBytesWire +
+    const std::size_t fwdStagingOff = fwdCh.stagingBase +
         static_cast<std::size_t>(fwdSlot) * fwdGeo.perBlockSlotWire +
         Proto::wire_bytes(fwdChunkOff);
     const std::size_t fwdSlotRemaining =
@@ -1414,7 +1447,7 @@ __device__ __forceinline__ void forward(
           /*counterBuf=*/{},
           /*counterVal=*/0,
           /*signalPerLane=*/true);
-      record_send_completion(
+      record_send_completion<Proto>(
           fwdTransport,
           static_cast<uint32_t>(groupId),
           fwdSlot,
@@ -1579,20 +1612,41 @@ __device__ __forceinline__ void validate_progress_group(
 #endif
 }
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ IbChannelProgress& progress_send_slot(
     Transport& transport,
     ThreadGroup& group) {
   validate_progress_group(transport.channel_layout(), group);
-  return transport.local_channel(group).sendProgress;
+  return transport.template local_channel_slot<P>(group).sendProgress;
 }
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ IbChannelProgress& progress_recv_slot(
     Transport& transport,
     ThreadGroup& group) {
   validate_progress_group(transport.channel_layout(), group);
-  return transport.local_channel(group).recvProgress;
+  return transport.template local_channel_slot<P>(group).recvProgress;
+}
+
+// No default on P: omitting the protocol must be a compile error, not a silent
+// read of the default protocol's slot.
+template <typename P, typename Transport>
+__device__ __forceinline__ ChannelSlotView acquire_channel(
+    Transport& transport,
+    const IbChannelLayout& channelLayout,
+    ThreadGroup& group) {
+  validate_progress_group(channelLayout, group);
+  const int channelId = static_cast<int>(group.group_id);
+  const int slotIndex =
+      channelLayout.protoChannelSlot(channelId, P::kProtoSlot);
+  return ChannelSlotView{
+      .channel = transport.local_channel(static_cast<uint32_t>(channelId)),
+      .local = transport.template local_channel_slot<P>(
+          static_cast<uint32_t>(channelId)),
+      .remote = makeIbRemoteChannel(channelLayout, slotIndex),
+      .stagingBase =
+          static_cast<std::size_t>(slotIndex) * pipeline_window(channelLayout),
+  };
 }
 
 /**
@@ -1632,7 +1686,7 @@ __device__ __forceinline__ void assert_progress_slot_idle(
 #endif
 }
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ void prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
@@ -1640,8 +1694,8 @@ __device__ __forceinline__ void prepare_send_slot(
     uint64_t generation,
     const Timeout& timeout) {
   if (group.is_leader()) {
-    auto& slot =
-        transport.local_channel(group.group_id).sendCompletionSlots[slotId];
+    auto& slot = transport.template local_channel_slot<P>(group.group_id)
+                     .sendCompletionSlots[slotId];
     if (slot.generation != generation) {
       const uint64_t pending = slot.laneMask;
       const uint32_t numLanes = transport.send_completion_lane_count();
@@ -1664,7 +1718,7 @@ __device__ __forceinline__ void prepare_send_slot(
   group.sync();
 }
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ void record_send_completion(
     Transport& transport,
     uint32_t channelId,
@@ -1672,7 +1726,8 @@ __device__ __forceinline__ void record_send_completion(
     uint64_t generation,
     const IbLocalCompletionTicket& ticket) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-  auto& slot = transport.local_channel(channelId).sendCompletionSlots[slotId];
+  auto& slot = transport.template local_channel_slot<P>(channelId)
+                   .sendCompletionSlots[slotId];
   slot.generation = generation;
   slot.values[ticket.completionId] = ticket.value;
   slot.laneMask |= 1ULL << ticket.completionId;

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -21,12 +21,14 @@ namespace detail {
  * copy callbacks.
  */
 struct ProgressChunk {
-  std::size_t stagingOff;
-  std::size_t dataOff;
-  std::size_t bytes;
-  uint64_t streamEnd;
-  uint32_t slotId;
-  uint64_t pipelineGeneration;
+  std::size_t stagingOff; // WIRE offset into send/recv staging
+  std::size_t dataOff; // PAYLOAD offset into the user buffer
+  std::size_t payloadBytes; // cursor advance (payload)
+  std::size_t wireBytes; // RDMA length + signal/counter delta (wire)
+  uint64_t streamEndWire; // absolute WIRE byte value after this chunk
+  uint64_t flagVal; // packet flag/generation (ring cursor); ignored by Simple
+  uint32_t slotId; // local-completion slot for send-staging backpressure
+  uint64_t pipelineGeneration; // slot reuse generation (prepare_send_slot)
 };
 
 /**
@@ -39,11 +41,13 @@ struct ProgressChunk {
  */
 struct ProgressGeometry {
   int groupId;
-  std::size_t payloadBytes;
-  std::size_t protocolBytes;
-  std::size_t perBlockSlot;
-  std::size_t perChannelBufferSize;
-  std::size_t chunkSize;
+  std::size_t payloadBytes; // raw nbytes, for valid-byte masking
+  std::size_t
+      protocolBytes; // payload rounded up to Proto::kData (cursor bound)
+  std::size_t perBlockSlotWire; // physical (wire) bytes per (slot, group)
+  std::size_t perBlockSlotPayload; // payload capacity of that region
+  std::size_t perChannelBufferSize; // wire ring window (group stride)
+  std::size_t chunkPayload; // max payload per chunk (>= 1 packet)
   int pipelineDepth;
 };
 
@@ -52,6 +56,7 @@ __device__ __forceinline__ void store_progress_state(
     IbChannelProgress& slot,
     const IbChannelProgress& state);
 
+template <typename Proto = protocol::Simple>
 __device__ __forceinline__ ProgressGeometry make_progress_geometry(
     const IbChannelLayout& channelLayout,
     ThreadGroup& group,
@@ -81,6 +86,7 @@ __device__ __forceinline__ void transition_progress_stage(
     IbChannelProgress& state,
     detail::IbSendRecvProgressStage next);
 
+template <typename Proto = protocol::Simple>
 __device__ __forceinline__ ProgressChunk next_chunk(
     const IbChannelLayout& channelLayout,
     const IbChannelProgress& state,
@@ -259,7 +265,7 @@ __device__ __forceinline__ void progress_send_prepare_buf(
     Args... args) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   const std::size_t validBytes =
-      valid_payload_bytes(chunk.dataOff, chunk.bytes, payloadBytes);
+      valid_payload_bytes(chunk.dataOff, chunk.payloadBytes, payloadBytes);
   if (validBytes > 0) {
     CopyOp::send(
         channelLayout.sendStagingPtr + chunk.stagingOff,
@@ -288,7 +294,7 @@ __device__ __forceinline__ SendSignal progress_send_signal(
   return SendSignal{remoteChannel.dataReady, signalVal};
 }
 
-template <typename Transport, typename CopyOp, typename... Args>
+template <typename Transport, typename CopyOp, typename Proto, typename... Args>
 __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
     Transport& transport,
     ThreadGroup& group,
@@ -317,7 +323,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
   if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
     return IbgdaSendRecvProgressStatus::Done;
   }
-  const ProgressGeometry progress_params = make_progress_geometry(
+  const ProgressGeometry progress_params = make_progress_geometry<Proto>(
       channelLayout, group, nbytes, max_signal_bytes, "progress_send_once");
   if (active_payload_offset(state) >= progress_params.protocolBytes) {
     if (group.is_leader()) {
@@ -333,7 +339,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
 
   const detail::IbSendRecvProgressStage initialStage = state.activeStage;
   const std::size_t initialNextByte = state.activeNextByte;
-  const std::size_t pipelineBytes = progress_params.perBlockSlot *
+  const std::size_t pipelineBytesWire = progress_params.perBlockSlotWire *
       static_cast<std::size_t>(channelLayout.pipelineDepth);
   IbLocalChannel& localChannel =
       transport.local_channel(static_cast<uint32_t>(progress_params.groupId));
@@ -344,7 +350,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
   if (state.activeStage ==
       detail::IbSendRecvProgressStage::WaitLocalCompletion) {
     const ProgressChunk chunk =
-        next_chunk(channelLayout, state, progress_params);
+        next_chunk<Proto>(channelLayout, state, progress_params);
     if (!try_prepare_send_slot(
             transport,
             group,
@@ -355,7 +361,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
     }
 
     progress_send_prepare_buf<CopyOp>(
-        protocol::Simple{},
+        Proto{},
         group,
         channelLayout,
         chunk,
@@ -369,13 +375,13 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
 
   if (state.activeStage == detail::IbSendRecvProgressStage::WaitSlotFree) {
     const ProgressChunk chunk =
-        next_chunk(channelLayout, state, progress_params);
+        next_chunk<Proto>(channelLayout, state, progress_params);
     const bool isFinalChunk =
-        chunk.dataOff + chunk.bytes >= progress_params.protocolBytes;
-    const uint64_t protocolStreamEnd =
-        chunk.streamEnd + (isFinalChunk ? state.activeTailPadding : 0);
-    if (protocolStreamEnd > pipelineBytes) {
-      const uint64_t expected = protocolStreamEnd - pipelineBytes;
+        chunk.dataOff + chunk.payloadBytes >= progress_params.protocolBytes;
+    const uint64_t protocolStreamEnd = chunk.streamEndWire +
+        (isFinalChunk ? Proto::wire_bytes(state.activeTailPadding) : 0);
+    if (protocolStreamEnd > pipelineBytesWire) {
+      const uint64_t expected = protocolStreamEnd - pipelineBytesWire;
       uint32_t ready = 1;
       unsigned long long current = 0;
       if (group.is_leader()) {
@@ -407,15 +413,15 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
       __threadfence_system();
       ThreadGroup solo{
           0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
-      const std::size_t protocolBytesThis =
-          chunk.bytes + (isFinalChunk ? state.activeTailPadding : 0);
-      const SendSignal sig = progress_send_signal(
-          protocol::Simple{}, remoteChannel, protocolBytesThis);
+      const std::size_t protocolBytesThis = chunk.wireBytes +
+          (isFinalChunk ? Proto::wire_bytes(state.activeTailPadding) : 0);
+      const SendSignal sig =
+          progress_send_signal(Proto{}, remoteChannel, protocolBytesThis);
       const auto completion = transport.put(
           solo,
           channelLayout.sendStagingBuf.subBuffer(chunk.stagingOff),
           remoteChannel.recvStaging.subBuffer(chunk.stagingOff),
-          chunk.bytes,
+          chunk.wireBytes,
           sig.buf,
           sig.val,
           /*counterBuf=*/{},
@@ -430,7 +436,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
     }
     group.sync();
 
-    state.activeNextByte += chunk.bytes;
+    state.activeNextByte += chunk.payloadBytes;
     if (active_payload_offset(state) >= progress_params.protocolBytes) {
       transition_progress_stage(
           group, state, detail::IbSendRecvProgressStage::Done);
@@ -597,7 +603,7 @@ __device__ __forceinline__ void progress_recv_consume_buf(
     Args... args) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   const std::size_t validBytes =
-      valid_payload_bytes(chunk.dataOff, chunk.bytes, payloadBytes);
+      valid_payload_bytes(chunk.dataOff, chunk.payloadBytes, payloadBytes);
   if (validBytes > 0) {
     CopyOp::recv(
         static_cast<char*>(dst) + chunk.dataOff,
@@ -617,7 +623,7 @@ __device__ __forceinline__ void progress_recv_consume_buf(
 #endif
 }
 
-template <typename Transport, typename CopyOp, typename... Args>
+template <typename Transport, typename CopyOp, typename Proto, typename... Args>
 __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
     Transport& transport,
     ThreadGroup& group,
@@ -644,7 +650,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
   if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
     return IbgdaSendRecvProgressStatus::Done;
   }
-  const ProgressGeometry progress_params = make_progress_geometry(
+  const ProgressGeometry progress_params = make_progress_geometry<Proto>(
       channelLayout, group, nbytes, max_signal_bytes, "progress_recv_once");
   if (active_payload_offset(state) >= progress_params.protocolBytes) {
     if (group.is_leader()) {
@@ -658,18 +664,19 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
   }
   validate_recv_progress_stage(group, state);
 
-  const ProgressChunk chunk = next_chunk(channelLayout, state, progress_params);
+  const ProgressChunk chunk =
+      next_chunk<Proto>(channelLayout, state, progress_params);
   const bool isFinalChunk =
-      chunk.dataOff + chunk.bytes >= progress_params.protocolBytes;
-  const std::size_t protocolBytesThis =
-      chunk.bytes + (isFinalChunk ? state.activeTailPadding : 0);
+      chunk.dataOff + chunk.payloadBytes >= progress_params.protocolBytes;
+  const std::size_t protocolBytesThis = chunk.wireBytes +
+      (isFinalChunk ? Proto::wire_bytes(state.activeTailPadding) : 0);
   IbLocalChannel& localChannel =
       transport.local_channel(static_cast<uint32_t>(progress_params.groupId));
   const IbgdaLocalBuffer localDataReady = localChannel.dataReady;
   const IbRemoteChannel remoteChannel =
       makeIbRemoteChannel(channelLayout, progress_params.groupId);
   if (!progress_recv_ready(
-          protocol::Simple{},
+          Proto{},
           transport,
           group,
           localChannel,
@@ -680,7 +687,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
   }
 
   progress_recv_consume_buf<CopyOp>(
-      protocol::Simple{},
+      Proto{},
       group,
       channelLayout,
       chunk,
@@ -692,7 +699,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
   transport.signal(
       group, remoteChannel.slotFree, protocolBytesThis, IbDirection::Recv);
 
-  state.activeNextByte += chunk.bytes;
+  state.activeNextByte += chunk.payloadBytes;
   if (active_payload_offset(state) >= progress_params.protocolBytes) {
     transition_progress_stage(
         group, state, detail::IbSendRecvProgressStage::Done);
@@ -756,6 +763,7 @@ __device__ __forceinline__ void store_progress_state(
  * already `Done`. Non-empty payload byte counts are rounded up to 16-byte
  * protocol counts here; copy callbacks still see only valid payload bytes.
  */
+template <typename Proto>
 __device__ __forceinline__ ProgressGeometry make_progress_geometry(
     const IbChannelLayout& channelLayout,
     ThreadGroup& group,
@@ -785,11 +793,12 @@ __device__ __forceinline__ ProgressGeometry make_progress_geometry(
     PIPES_DEVICE_TRAP();
   }
 
-  const std::size_t perBlockSlot = pipeline_chunk(channelLayout);
-  if (perBlockSlot == 0) {
+  const std::size_t perBlockSlotWire = pipeline_chunk(channelLayout);
+  const std::size_t perBlockSlotPayload = Proto::max_payload(perBlockSlotWire);
+  if (perBlockSlotPayload == 0) {
     if (group.is_leader()) {
       printf(
-          "[PIPES] FATAL: %s perBlockSlot=0 "
+          "[PIPES] FATAL: %s perBlockSlotPayload=0 "
           "(perChannelBufferSize=%llu, pipelineDepth=%d)\n",
           opName,
           (unsigned long long)pipeline_window(channelLayout),
@@ -799,21 +808,26 @@ __device__ __forceinline__ ProgressGeometry make_progress_geometry(
   }
   const std::size_t perChannelBufferSize = pipeline_window(channelLayout);
 
-  const std::size_t protocolBytes = align_protocol_bytes(nbytes);
-  std::size_t chunkSize =
-      (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
-      ? (max_signal_bytes & ~15ULL)
-      : perBlockSlot;
-  if (chunkSize == 0) {
-    chunkSize = perBlockSlot;
+  // Cursor + chunk sizing run in PAYLOAD bytes, aligned to whole packets
+  // (Proto::kData); wire quantities are derived via Proto::wire_bytes. For
+  // Simple (kData == 16) this is the original 16B alignment.
+  const std::size_t protocolBytes =
+      (nbytes + Proto::kData - 1) / Proto::kData * Proto::kData;
+  std::size_t chunkPayload =
+      (max_signal_bytes > 0 && max_signal_bytes < perBlockSlotPayload)
+      ? (max_signal_bytes / Proto::kData * Proto::kData)
+      : perBlockSlotPayload;
+  if (chunkPayload == 0) {
+    chunkPayload = perBlockSlotPayload;
   }
   return ProgressGeometry{
       .groupId = groupId,
       .payloadBytes = nbytes,
       .protocolBytes = protocolBytes,
-      .perBlockSlot = perBlockSlot,
+      .perBlockSlotWire = perBlockSlotWire,
+      .perBlockSlotPayload = perBlockSlotPayload,
       .perChannelBufferSize = perChannelBufferSize,
-      .chunkSize = chunkSize,
+      .chunkPayload = chunkPayload,
       .pipelineDepth = channelLayout.pipelineDepth,
   };
 #else
@@ -851,8 +865,8 @@ __device__ __forceinline__ void reserve_progress_step(
     baseStep = static_cast<uint64_t>(slot.nextStep);
     protocolTailPadding = tail_padding_for_signal_granularity(
         baseStep,
-        geometry.chunkSize,
-        geometry.perBlockSlot,
+        geometry.chunkPayload,
+        geometry.perBlockSlotPayload,
         geometry.payloadBytes);
     slot.nextStep = static_cast<int64_t>(
         baseStep + geometry.protocolBytes + protocolTailPadding);
@@ -981,35 +995,44 @@ __device__ __forceinline__ void transition_progress_stage(
  * bounded and prevents a single RDMA put or recv copy from spanning two
  * staging slots.
  */
+template <typename Proto>
 __device__ __forceinline__ ProgressChunk next_chunk(
     const IbChannelLayout& channelLayout,
     const IbChannelProgress& state,
     const ProgressGeometry& geometry) {
+  // The ring cursor advances in PAYLOAD bytes; staging offsets, RDMA lengths,
+  // and readiness thresholds are derived in WIRE bytes via Proto::wire_bytes
+  // (1:1 for Simple, kPacketBytes:kData for LL).
   const uint64_t streamStart =
       static_cast<uint64_t>(state.activeBaseStep) + state.activeNextByte;
   (void)channelLayout;
-  const std::size_t pipelineBytes = geometry.perChannelBufferSize;
+  const std::size_t pipelineBytesPayload =
+      Proto::max_payload(geometry.perChannelBufferSize);
   const std::size_t pipelineOff =
-      static_cast<std::size_t>(streamStart % pipelineBytes);
-  const int slot = static_cast<int>(pipelineOff / geometry.perBlockSlot);
-  const std::size_t slotOff =
-      static_cast<std::size_t>(slot) * geometry.perBlockSlot;
-  const std::size_t chunkOff =
-      pipelineOff - static_cast<std::size_t>(slot) * geometry.perBlockSlot;
-  const std::size_t slotRemaining = geometry.perBlockSlot - chunkOff;
+      static_cast<std::size_t>(streamStart % pipelineBytesPayload);
+  const int slot = static_cast<int>(pipelineOff / geometry.perBlockSlotPayload);
+  const std::size_t chunkOff = pipelineOff -
+      static_cast<std::size_t>(slot) * geometry.perBlockSlotPayload;
+  const std::size_t slotRemaining = geometry.perBlockSlotPayload - chunkOff;
   const std::size_t payloadNextByte = active_payload_offset(state);
   const std::size_t dataRemaining = geometry.protocolBytes - payloadNextByte;
-  std::size_t bytes =
-      geometry.chunkSize < dataRemaining ? geometry.chunkSize : dataRemaining;
-  bytes = bytes < slotRemaining ? bytes : slotRemaining;
+  std::size_t payloadBytes = geometry.chunkPayload < dataRemaining
+      ? geometry.chunkPayload
+      : dataRemaining;
+  payloadBytes = payloadBytes < slotRemaining ? payloadBytes : slotRemaining;
   return ProgressChunk{
-      .stagingOff = static_cast<std::size_t>(geometry.groupId) * pipelineBytes +
-          slotOff + chunkOff,
+      .stagingOff = static_cast<std::size_t>(geometry.groupId) *
+              geometry.perChannelBufferSize +
+          static_cast<std::size_t>(slot) * geometry.perBlockSlotWire +
+          Proto::wire_bytes(chunkOff),
       .dataOff = payloadNextByte,
-      .bytes = bytes,
-      .streamEnd = streamStart + bytes,
+      .payloadBytes = payloadBytes,
+      .wireBytes = Proto::wire_bytes(payloadBytes),
+      .streamEndWire =
+          Proto::wire_bytes(streamStart) + Proto::wire_bytes(payloadBytes),
+      .flagVal = streamStart / pipelineBytesPayload + 1,
       .slotId = static_cast<uint32_t>(slot),
-      .pipelineGeneration = streamStart / pipelineBytes,
+      .pipelineGeneration = streamStart / pipelineBytesPayload,
   };
 }
 

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -40,7 +40,12 @@ struct ProgressChunk {
  * HBM-backed progress state.
  */
 struct ProgressGeometry {
+  // Two independent coordinates, never merged: `groupId` is the LOGICAL channel
+  // (and therefore the QP channel); `slotIndex` is this protocol's flat
+  // resource slot, addressing slot-indexed storage. Merging them would force a
+  // division to recover one from the other on the QP path.
   int groupId;
+  int slotIndex;
   std::size_t payloadBytes; // raw nbytes, for valid-byte masking
   std::size_t
       protocolBytes; // payload rounded up to Proto::kData (cursor bound)
@@ -92,7 +97,7 @@ __device__ __forceinline__ ProgressChunk next_chunk(
     const IbChannelProgress& state,
     const ProgressGeometry& geometry);
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ bool try_prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
@@ -134,7 +139,7 @@ __device__ __forceinline__ void init_send_progress(
     std::size_t max_signal_bytes) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   auto& channelLayout = transport.channel_layout();
-  auto& slot = progress_send_slot(transport, group);
+  auto& slot = progress_send_slot<protocol::Simple>(transport, group);
   assert_progress_slot_idle(group, slot, "send");
   IbChannelProgress state{};
   state.activeStage = nbytes == 0
@@ -189,7 +194,7 @@ __device__ __forceinline__ void init_recv_progress(
     std::size_t max_signal_bytes) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   auto& channelLayout = transport.channel_layout();
-  auto& slot = progress_recv_slot(transport, group);
+  auto& slot = progress_recv_slot<protocol::Simple>(transport, group);
   assert_progress_slot_idle(group, slot, "recv");
   IbChannelProgress state{};
   state.activeStage = nbytes == 0
@@ -318,7 +323,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
       sizeof(CopyOp) == 0, "detail::progress_send_once() requires NVIDIA GPU");
 #endif
   auto& channelLayout = transport.channel_layout();
-  auto& progressSlot = progress_send_slot(transport, group);
+  auto& progressSlot = progress_send_slot<Proto>(transport, group);
   IbChannelProgress state = progressSlot;
   if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
     return IbgdaSendRecvProgressStatus::Done;
@@ -341,17 +346,16 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
   const std::size_t initialNextByte = state.activeNextByte;
   const std::size_t pipelineBytesWire = progress_params.perBlockSlotWire *
       static_cast<std::size_t>(channelLayout.pipelineDepth);
-  IbLocalChannel& localChannel =
-      transport.local_channel(static_cast<uint32_t>(progress_params.groupId));
-  const IbgdaLocalBuffer localSlotFree = localChannel.slotFree;
-  const IbRemoteChannel remoteChannel =
-      makeIbRemoteChannel(channelLayout, progress_params.groupId);
+  const ChannelSlotView ch =
+      acquire_channel<Proto>(transport, channelLayout, group);
+  const IbgdaLocalBuffer localSlotFree = ch.local.slotFree;
+  const IbRemoteChannel remoteChannel = ch.remote;
 
   if (state.activeStage ==
       detail::IbSendRecvProgressStage::WaitLocalCompletion) {
     const ProgressChunk chunk =
         next_chunk<Proto>(channelLayout, state, progress_params);
-    if (!try_prepare_send_slot(
+    if (!try_prepare_send_slot<Proto>(
             transport,
             group,
             chunk.slotId,
@@ -427,7 +431,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
           /*counterBuf=*/{},
           /*counterVal=*/0,
           /*signalPerLane=*/true);
-      record_send_completion(
+      record_send_completion<Proto>(
           transport,
           static_cast<uint32_t>(progress_params.groupId),
           chunk.slotId,
@@ -489,11 +493,14 @@ __device__ __forceinline__ bool poll_recv_data_ready(
   const uint32_t numLanes =
       static_cast<uint32_t>(transport.channel_layout().numLanes);
   const uint32_t lanes = numLanes == 0 ? 1U : numLanes;
+  // Simple's slot unconditionally -- see wait_recv_data_ready.
+  IbChannelProtoSlot& protoSlot =
+      localChannel.protos[protocol::Simple::kProtoSlot];
   // Truncate to 32 bits before the modulo to match the sender's uint32 cursor
   // wrap (see wait_recv_data_ready).
   const uint32_t lane =
       static_cast<uint32_t>(localChannel.recvDataReadyLaneCursor) % lanes;
-  const uint64_t expected = localChannel.recvLaneExpected[lane] + chunkBytes;
+  const uint64_t expected = protoSlot.recvLaneExpected[lane] + chunkBytes;
   const IbgdaLocalBuffer laneBuf = localDataReady.subBuffer(
       sendRecvSignalSlotOffset(static_cast<int>(lane)));
   const uint64_t current = transport.read_signal(laneBuf);
@@ -502,7 +509,7 @@ __device__ __forceinline__ bool poll_recv_data_ready(
   if (current < expected) {
     return false;
   }
-  localChannel.recvLaneExpected[lane] = expected;
+  protoSlot.recvLaneExpected[lane] = expected;
   ++localChannel.recvDataReadyLaneCursor;
   return true;
 #else
@@ -645,7 +652,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
       sizeof(CopyOp) == 0, "detail::progress_recv_once() requires NVIDIA GPU");
 #endif
   auto& channelLayout = transport.channel_layout();
-  auto& progressSlot = progress_recv_slot(transport, group);
+  auto& progressSlot = progress_recv_slot<Proto>(transport, group);
   IbChannelProgress state = progressSlot;
   if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
     return IbgdaSendRecvProgressStatus::Done;
@@ -670,11 +677,11 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
       chunk.dataOff + chunk.payloadBytes >= progress_params.protocolBytes;
   const std::size_t protocolBytesThis = chunk.wireBytes +
       (isFinalChunk ? Proto::wire_bytes(state.activeTailPadding) : 0);
-  IbLocalChannel& localChannel =
-      transport.local_channel(static_cast<uint32_t>(progress_params.groupId));
-  const IbgdaLocalBuffer localDataReady = localChannel.dataReady;
-  const IbRemoteChannel remoteChannel =
-      makeIbRemoteChannel(channelLayout, progress_params.groupId);
+  const ChannelSlotView ch =
+      acquire_channel<Proto>(transport, channelLayout, group);
+  IbLocalChannel& localChannel = ch.channel;
+  const IbgdaLocalBuffer localDataReady = ch.local.dataReady;
+  const IbRemoteChannel remoteChannel = ch.remote;
   if (!progress_recv_ready(
           Proto{},
           transport,
@@ -822,6 +829,7 @@ __device__ __forceinline__ ProgressGeometry make_progress_geometry(
   }
   return ProgressGeometry{
       .groupId = groupId,
+      .slotIndex = channelLayout.protoChannelSlot(groupId, Proto::kProtoSlot),
       .payloadBytes = nbytes,
       .protocolBytes = protocolBytes,
       .perBlockSlotWire = perBlockSlotWire,
@@ -1021,7 +1029,7 @@ __device__ __forceinline__ ProgressChunk next_chunk(
       : dataRemaining;
   payloadBytes = payloadBytes < slotRemaining ? payloadBytes : slotRemaining;
   return ProgressChunk{
-      .stagingOff = static_cast<std::size_t>(geometry.groupId) *
+      .stagingOff = static_cast<std::size_t>(geometry.slotIndex) *
               geometry.perChannelBufferSize +
           static_cast<std::size_t>(slot) * geometry.perBlockSlotWire +
           Proto::wire_bytes(chunkOff),
@@ -1036,7 +1044,7 @@ __device__ __forceinline__ ProgressChunk next_chunk(
   };
 }
 
-template <typename Transport>
+template <typename P, typename Transport>
 __device__ __forceinline__ bool try_prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
@@ -1046,8 +1054,8 @@ __device__ __forceinline__ bool try_prepare_send_slot(
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t ready = 1;
   if (group.is_leader()) {
-    auto& slot =
-        transport.local_channel(group.group_id).sendCompletionSlots[slotId];
+    auto& slot = transport.template local_channel_slot<P>(group.group_id)
+                     .sendCompletionSlots[slotId];
     if (slot.generation != generation) {
       uint64_t pending = slot.laneMask;
       const uint32_t numLanes = transport.send_completion_lane_count();

--- a/comms/prims/transport/ibgda/IbgdaBuffer.h
+++ b/comms/prims/transport/ibgda/IbgdaBuffer.h
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 #include <endian.h>
 
@@ -477,7 +478,13 @@ struct IbChannelLayout {
   IbgdaRemoteBuffer remoteSignalBuf; ///< Peer's signal inbox
   IbgdaLocalBuffer localCounterBuf; ///< GPU-readable NIC_DONE counter inbox
   IbgdaLocalBuffer localCounterCompletionBuf; ///< Transport completion target
-  int maxChannels{0}; ///< Layout size for channel-indexed resources
+  int maxChannels{0}; ///< Layout size for SLOT-indexed resources. Equals
+                      ///< numChannels today; the diff that adds a second
+                      ///< protocol makes it numChannels * kNumProtoSlots.
+  int numChannels{0}; ///< Logical channels; a caller's group_id selects within
+                      ///< [0, numChannels). Also the QP channel: protocols
+                      ///< share a channel's QPs and are separated by resource
+                      ///< slot, never by channel id.
   int numLanes{1}; ///< QP lanes = numNics * qpsPerConnection; each lane owns a
                    ///< single-writer DATA_READY slot per channel
   int pipelineDepth{0}; ///< Number of slots/chunks in one channel
@@ -488,6 +495,14 @@ struct IbChannelLayout {
     const std::size_t perChannel =
         perChannelBufferSize != 0 ? perChannelBufferSize : perChannelSize;
     return perChannel * static_cast<std::size_t>(maxChannels);
+  }
+
+  // Flat resource slot for (logical channel, protocol slot). Proto-major, so
+  // kNumProtoSlots == 1 is the identity and a protocol's channels stay
+  // contiguous. Every slot-indexed accessor below takes this flat slot, NOT a
+  // logical channel.
+  IBGDA_HOST_DEVICE int protoChannelSlot(int channelId, int protoSlot) const {
+    return protoSlot * numChannels + channelId;
   }
 
   IBGDA_HOST_DEVICE int dataReadySignalSlot(int channelId) const {
@@ -561,6 +576,17 @@ enum class IbDirection : uint8_t {
 inline constexpr int kIbDirections = 2;
 inline constexpr int kIbMaxQpLanesPerChannelDirection = 64;
 
+// Per-protocol resource slots reserved on every channel, indexed by a protocol
+// tag's kProtoSlot (Simple = 0). Only Simple exists today, so this is 1 and the
+// layout matches the single-protocol one. The diff that adds a second wire
+// protocol raises it, which is what reserves the extra staging, signal, and
+// counter slots.
+//
+// It does NOT reserve more QPs: a channel is one QP pair regardless of how many
+// protocols address it, which is why IbQpState lives on the channel rather than
+// in a slot.
+inline constexpr int kNumProtoSlots = 1;
+
 // Identifies a lane-local completion threshold returned by put().
 // completionId is the send-lane ordinal; value is complete once that lane's
 // backend-specific completion frontier reaches it.
@@ -584,7 +610,13 @@ struct IbQpState {
   uint64_t lastFlushWqe[kIbMaxQpLanesPerChannelDirection]{};
 };
 
-struct IbLocalChannel {
+// Everything ONE wire protocol owns on one channel, selected by the protocol
+// tag's kProtoSlot. Duplicated per protocol: these cursors are resumable across
+// kernel launches, so two protocols sharing a slot would corrupt each other's
+// progress even though they never run concurrently within one kernel.
+//
+// Reach it through detail::acquire_channel<P>(), never by naming a slot index.
+struct IbChannelProtoSlot {
   IbChannelProgress sendProgress;
   IbChannelProgress recvProgress;
 
@@ -607,7 +639,6 @@ struct IbLocalChannel {
   //    zeroing it on a partial reset would desync the round-robin lane mapping.
   //  - `recvLaneExpected` mirrors the DATA_READY slots; zero it whenever those
   //    slots are zeroed (channel construction AND the device reset kernel).
-  uint64_t recvDataReadyLaneCursor{0};
   uint64_t recvLaneExpected[kIbMaxQpLanesPerChannelDirection]{};
 
   IbgdaLocalBuffer dataReady;
@@ -616,10 +647,39 @@ struct IbLocalChannel {
   IbgdaLocalBuffer nicDoneCompletion;
 
   IbSendCompletionSlot* sendCompletionSlots{nullptr};
+};
 
+// A channel: the state every protocol on it shares, plus one slot per protocol.
+//
+// `sendQp` / `recvQp` are shared because a channel is one QP pair no matter how
+// many protocols address it, so `lastFlushWqe` and `pendingFlushLanesMask`
+// cover whatever any protocol actually posted on a lane.
+//
+// `recvDataReadyLaneCursor` is shared because it mirrors `sendQp.cursor`, which
+// counts puts POSTED on this (channel, Send) -- NOT DATA_READY events. Every
+// put must have exactly one receiver-observable event advancing the mirror, or
+// the round-robin lane mapping desyncs and the receiver waits on a slot that a
+// later chunk will satisfy, reading data that has not landed. A signal-less raw
+// put() gives the receiver nothing to observe, so it must never share a
+// (channel, direction) with send()/recv().
+//
+// Reset semantics: `recvDataReadyLaneCursor` is free-running and only zeroed at
+// channel (re)construction -- never by the device reset kernel. Reset it only
+// in lock-step with `sendQp.cursor`.
+//
+// `recvLaneExpected` is deliberately NOT shared: it mirrors the contents of a
+// protocol's own DATA_READY slots, so it belongs with those slots.
+struct IbLocalChannel {
   IbQpState sendQp;
   IbQpState recvQp;
+  uint64_t recvDataReadyLaneCursor{0};
+
+  IbChannelProtoSlot protos[kNumProtoSlots];
 };
+
+// Built on the host and cudaMemcpy'd to the device, so it must stay trivially
+// copyable.
+static_assert(std::is_trivially_copyable_v<IbLocalChannel>);
 
 struct IbRemoteChannel {
   IbgdaRemoteBuffer dataReady;
@@ -631,12 +691,18 @@ IBGDA_HOST_DEVICE inline IbLocalChannel makeIbLocalChannel(
     const IbChannelLayout& layout,
     int channelId,
     IbSendCompletionSlot* sendCompletionSlots = nullptr) {
+  // channelId is the LOGICAL channel; every protocol slot on it gets its own
+  // views, resolved at that slot's flat index.
   IbLocalChannel channel{};
-  channel.dataReady = layout.localDataReadySignal(channelId);
-  channel.slotFree = layout.localSlotFreeSignal(channelId);
-  channel.nicDoneWait = layout.localCounter(channelId);
-  channel.nicDoneCompletion = layout.localCompletionCounter(channelId);
-  channel.sendCompletionSlots = sendCompletionSlots;
+  for (int protoSlot = 0; protoSlot < kNumProtoSlots; ++protoSlot) {
+    const int slot = layout.protoChannelSlot(channelId, protoSlot);
+    IbChannelProtoSlot& proto = channel.protos[protoSlot];
+    proto.dataReady = layout.localDataReadySignal(slot);
+    proto.slotFree = layout.localSlotFreeSignal(slot);
+    proto.nicDoneWait = layout.localCounter(slot);
+    proto.nicDoneCompletion = layout.localCompletionCounter(slot);
+    proto.sendCompletionSlots = sendCompletionSlots;
+  }
   return channel;
 }
 

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -2482,6 +2482,25 @@ class P2pIbgdaTransportDevice {
     return local_channel(group.group_id);
   }
 
+  // Per-protocol resources on a channel. `P::kProtoSlot` is a compile-time
+  // constant, so this resolves to a fixed offset. What stays on the channel
+  // itself is the state every protocol shares: sendQp, recvQp, and
+  // recvDataReadyLaneCursor.
+  //
+  // No default on P: omitting the protocol must be a compile error, not a
+  // silent read of the default protocol's cursors.
+  template <typename P>
+  __device__ __forceinline__ IbChannelProtoSlot& local_channel_slot(
+      uint32_t channelId) {
+    return local_channel(channelId).protos[P::kProtoSlot];
+  }
+
+  template <typename P>
+  __device__ __forceinline__ IbChannelProtoSlot& local_channel_slot(
+      ThreadGroup& group) {
+    return local_channel_slot<P>(group.group_id);
+  }
+
   __host__ __device__ IbChannelLayout& channel_layout() {
     return channelLayout_;
   }

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -2485,6 +2485,25 @@ class P2pIbgdaTransportDevice {
     return local_channel(group.group_id);
   }
 
+  // Per-protocol resources on a channel. `P::kProtoSlot` is a compile-time
+  // constant, so this resolves to a fixed offset. What stays on the channel
+  // itself is the state every protocol shares: sendQp, recvQp, and
+  // recvDataReadyLaneCursor.
+  //
+  // No default on P: omitting the protocol must be a compile error, not a
+  // silent read of the default protocol's cursors.
+  template <typename P>
+  __device__ __forceinline__ IbChannelProtoSlot& local_channel_slot(
+      uint32_t channelId) {
+    return local_channel(channelId).protos[P::kProtoSlot];
+  }
+
+  template <typename P>
+  __device__ __forceinline__ IbChannelProtoSlot& local_channel_slot(
+      ThreadGroup& group) {
+    return local_channel_slot<P>(group.group_id);
+  }
+
   __host__ __device__ IbChannelLayout& channel_layout() {
     return channelLayout_;
   }

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -573,6 +573,25 @@ class P2pIbrcTransportDevice {
     return local_channel(group.group_id);
   }
 
+  // Per-protocol resources on a channel. `P::kProtoSlot` is a compile-time
+  // constant, so this resolves to a fixed offset. What stays on the channel
+  // itself is the state every protocol shares: sendQp, recvQp, and
+  // recvDataReadyLaneCursor.
+  //
+  // No default on P: omitting the protocol must be a compile error, not a
+  // silent read of the default protocol's cursors.
+  template <typename P>
+  __device__ __forceinline__ IbChannelProtoSlot& local_channel_slot(
+      uint32_t channelId) {
+    return local_channel(channelId).protos[P::kProtoSlot];
+  }
+
+  template <typename P>
+  __device__ __forceinline__ IbChannelProtoSlot& local_channel_slot(
+      ThreadGroup& group) {
+    return local_channel_slot<P>(group.group_id);
+  }
+
   __host__ __device__ IbChannelLayout& channel_layout() {
     return channelLayout_;
   }

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -574,6 +574,25 @@ class P2pIbrcTransportDevice {
     return local_channel(group.group_id);
   }
 
+  // Per-protocol resources on a channel. `P::kProtoSlot` is a compile-time
+  // constant, so this resolves to a fixed offset. What stays on the channel
+  // itself is the state every protocol shares: sendQp, recvQp, and
+  // recvDataReadyLaneCursor.
+  //
+  // No default on P: omitting the protocol must be a compile error, not a
+  // silent read of the default protocol's cursors.
+  template <typename P>
+  __device__ __forceinline__ IbChannelProtoSlot& local_channel_slot(
+      uint32_t channelId) {
+    return local_channel(channelId).protos[P::kProtoSlot];
+  }
+
+  template <typename P>
+  __device__ __forceinline__ IbChannelProtoSlot& local_channel_slot(
+      ThreadGroup& group) {
+    return local_channel_slot<P>(group.group_id);
+  }
+
   __host__ __device__ IbChannelLayout& channel_layout() {
     return channelLayout_;
   }


### PR DESCRIPTION
Summary:

Two robustness fixes for the distributed (2-rank) `IbgdaSendRecvBenchmark` so paired send/recv runs produce clean, comparable numbers instead of duplicated output and `NaN`/`Infinity` rows. Benchmark harness only; no change to the transport or protocol paths.

**1. Print the results table on rank 0 only.**
Both ranks must run every benchmark in lockstep (the paired send/recv deadlocks if only one side issues ops), but previously both ranks also printed the results table, interleaving two copies of the output. Now only global rank 0 calls `folly::runBenchmarks()` (which prints); rank 1 calls `folly::detail::runBenchmarksWithResults()` and discards the output while still executing the full benchmark set in lockstep.

**2. Deterministic iteration count for small (<1MB) messages.**
folly drops a benchmark's counters unless the timed region lasts >= ~100us (`bm_min_usec`). At the pinned count (`bm_min_iters`/`bm_max_iters` = 20/21) sub-1MB transfers finish well under that floor and print `0.00fs`/`Infinity`/`NaN`. We can't let folly auto-scale to fix this: its scaling is driven by each rank's own measured time, so the two ranks would pick different counts and the paired transfer would deadlock.

`ibgdaSendRecv()` now overrides the count for `nbytes < 1MiB` with a fixed high value (`kSmallMessageIters = 2048`), derived identically on both ranks from `nbytes` so they stay in lockstep. Messages >= 1MB already clear the timing floor at folly's count and are left unchanged.

Reviewed By: snarayankh

Differential Revision: D112405995


