### PR TITLE
Refactor options to share common base (#3514)

### DIFF
--- a/comms/torchcomms/TorchCommOptions.cpp
+++ b/comms/torchcomms/TorchCommOptions.cpp
@@ -32,7 +32,10 @@ bool CommOptions::operator==(const CommOptions& other) const {
 }
 
 template <typename T>
-T CommOptions::getHint(std::string_view key, const T& default_value) const {
+T detail::getHint(
+    const std::unordered_map<std::string, std::string>& hints,
+    std::string_view key,
+    const T& default_value) {
   auto it = hints.find(std::string(key));
   if (it == hints.end()) {
     return default_value;
@@ -55,6 +58,24 @@ T CommOptions::getHint(std::string_view key, const T& default_value) const {
     return result;
   }
 }
+
+template <typename T>
+T CommOptions::getHint(std::string_view key, const T& default_value) const {
+  return detail::getHint(hints, key, default_value);
+}
+
+template bool detail::getHint<bool>(
+    const std::unordered_map<std::string, std::string>&,
+    std::string_view,
+    const bool&);
+template size_t detail::getHint<size_t>(
+    const std::unordered_map<std::string, std::string>&,
+    std::string_view,
+    const size_t&);
+template std::string detail::getHint<std::string>(
+    const std::unordered_map<std::string, std::string>&,
+    std::string_view,
+    const std::string&);
 
 template bool CommOptions::getHint<bool>(std::string_view, const bool&) const;
 template size_t CommOptions::getHint<size_t>(std::string_view, const size_t&)

--- a/comms/torchcomms/TorchCommOptions.hpp
+++ b/comms/torchcomms/TorchCommOptions.hpp
@@ -15,144 +15,38 @@
 
 namespace torch::comms {
 
+// Derived is unused in the body on purpose: it gives every option type its own
+// base, so unrelated options cannot bind to a common OptionsBase reference.
+template <typename Derived>
+struct OptionsBase {
+  std::unordered_map<std::string, std::string> hints;
+  std::chrono::milliseconds timeout{kNoTimeout};
+};
+
 // Options classes for collective operations
-class SendOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
+struct SendOptions : OptionsBase<SendOptions> {
   int tag{0};
-
-  SendOptions() : timeout(kNoTimeout) {}
 };
 
-class RecvOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
+struct RecvOptions : OptionsBase<RecvOptions> {
   int tag{0};
-
-  RecvOptions() : timeout(kNoTimeout) {}
 };
 
-class BatchP2POptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  BatchP2POptions() : timeout(kNoTimeout) {}
-};
-
-class BroadcastOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  BroadcastOptions() : timeout(kNoTimeout) {}
-};
-
-class AllReduceOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  AllReduceOptions() : timeout(kNoTimeout) {}
-};
-
-class ReduceOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  ReduceOptions() : timeout(kNoTimeout) {}
-};
-
-class AllGatherOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  AllGatherOptions() : timeout(kNoTimeout) {}
-};
-
-class AllGatherSingleOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  AllGatherSingleOptions() : timeout(kNoTimeout) {}
-};
-
-class ReduceScatterOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  ReduceScatterOptions() : timeout(kNoTimeout) {}
-};
-
-class ReduceScatterSingleOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  ReduceScatterSingleOptions() : timeout(kNoTimeout) {}
-};
-
-class AllToAllOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  AllToAllOptions() : timeout(kNoTimeout) {}
-};
-
-class AllToAllSingleOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  AllToAllSingleOptions() : timeout(kNoTimeout) {}
-};
-
-class AllToAllvSingleOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  AllToAllvSingleOptions() : timeout(kNoTimeout) {}
-};
-
-class BarrierOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  BarrierOptions() : timeout(kNoTimeout) {}
-};
-
-class ScatterOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  ScatterOptions() : timeout(kNoTimeout) {}
-};
-
-class GatherOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  GatherOptions() : timeout(kNoTimeout) {}
-};
-
-class GatherSingleOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  GatherSingleOptions() : timeout(kNoTimeout) {}
-};
+struct BatchP2POptions : OptionsBase<BatchP2POptions> {};
+struct BroadcastOptions : OptionsBase<BroadcastOptions> {};
+struct AllReduceOptions : OptionsBase<AllReduceOptions> {};
+struct ReduceOptions : OptionsBase<ReduceOptions> {};
+struct AllGatherOptions : OptionsBase<AllGatherOptions> {};
+struct AllGatherSingleOptions : OptionsBase<AllGatherSingleOptions> {};
+struct ReduceScatterOptions : OptionsBase<ReduceScatterOptions> {};
+struct ReduceScatterSingleOptions : OptionsBase<ReduceScatterSingleOptions> {};
+struct AllToAllOptions : OptionsBase<AllToAllOptions> {};
+struct AllToAllSingleOptions : OptionsBase<AllToAllSingleOptions> {};
+struct AllToAllvSingleOptions : OptionsBase<AllToAllvSingleOptions> {};
+struct BarrierOptions : OptionsBase<BarrierOptions> {};
+struct ScatterOptions : OptionsBase<ScatterOptions> {};
+struct GatherOptions : OptionsBase<GatherOptions> {};
+struct GatherSingleOptions : OptionsBase<GatherSingleOptions> {};
 
 class CommOptions {
  public:
@@ -184,44 +78,12 @@ class CommOptions {
   T getHint(std::string_view key, const T& default_value) const;
 };
 
-class PutOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
+// Options classes for window operations
+struct PutOptions : OptionsBase<PutOptions> {};
+struct SignalOptions : OptionsBase<SignalOptions> {};
+struct WaitSignalOptions : OptionsBase<WaitSignalOptions> {};
 
-  PutOptions() : timeout(kNoTimeout) {}
-};
-
-class SignalOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  SignalOptions() : timeout(kNoTimeout) {}
-};
-
-class WaitSignalOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  WaitSignalOptions() : timeout(kNoTimeout) {}
-};
-
-class AllGatherPInitOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  AllGatherPInitOptions() : timeout(kNoTimeout) {}
-};
-
-class AllGatherPExecOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  AllGatherPExecOptions() : timeout(kNoTimeout) {}
-};
+struct AllGatherPInitOptions : OptionsBase<AllGatherPInitOptions> {};
+struct AllGatherPExecOptions : OptionsBase<AllGatherPExecOptions> {};
 
 } // namespace torch::comms

--- a/comms/torchcomms/TorchCommOptions.hpp
+++ b/comms/torchcomms/TorchCommOptions.hpp
@@ -14,144 +14,51 @@
 
 namespace torch::comms {
 
+namespace detail {
+
+template <typename T>
+T getHint(
+    const std::unordered_map<std::string, std::string>& hints,
+    std::string_view key,
+    const T& default_value);
+
+} // namespace detail
+
+template <typename Derived>
+struct OptionsBase {
+  std::unordered_map<std::string, std::string> hints;
+  std::chrono::milliseconds timeout{kNoTimeout};
+
+  template <typename T>
+  T getHint(std::string_view key, const T& default_value) const {
+    return detail::getHint(hints, key, default_value);
+  }
+};
+
 // Options classes for collective operations
-class SendOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
+struct SendOptions : OptionsBase<SendOptions> {
   int tag{0};
-
-  SendOptions() : timeout(kNoTimeout) {}
 };
 
-class RecvOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
+struct RecvOptions : OptionsBase<RecvOptions> {
   int tag{0};
-
-  RecvOptions() : timeout(kNoTimeout) {}
 };
 
-class BatchP2POptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  BatchP2POptions() : timeout(kNoTimeout) {}
-};
-
-class BroadcastOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  BroadcastOptions() : timeout(kNoTimeout) {}
-};
-
-class AllReduceOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  AllReduceOptions() : timeout(kNoTimeout) {}
-};
-
-class ReduceOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  ReduceOptions() : timeout(kNoTimeout) {}
-};
-
-class AllGatherOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  AllGatherOptions() : timeout(kNoTimeout) {}
-};
-
-class AllGatherSingleOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  AllGatherSingleOptions() : timeout(kNoTimeout) {}
-};
-
-class ReduceScatterOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  ReduceScatterOptions() : timeout(kNoTimeout) {}
-};
-
-class ReduceScatterSingleOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  ReduceScatterSingleOptions() : timeout(kNoTimeout) {}
-};
-
-class AllToAllOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  AllToAllOptions() : timeout(kNoTimeout) {}
-};
-
-class AllToAllSingleOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  AllToAllSingleOptions() : timeout(kNoTimeout) {}
-};
-
-class AllToAllvSingleOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  AllToAllvSingleOptions() : timeout(kNoTimeout) {}
-};
-
-class BarrierOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  BarrierOptions() : timeout(kNoTimeout) {}
-};
-
-class ScatterOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  ScatterOptions() : timeout(kNoTimeout) {}
-};
-
-class GatherOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  GatherOptions() : timeout(kNoTimeout) {}
-};
-
-class GatherSingleOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  GatherSingleOptions() : timeout(kNoTimeout) {}
-};
+struct BatchP2POptions : OptionsBase<BatchP2POptions> {};
+struct BroadcastOptions : OptionsBase<BroadcastOptions> {};
+struct AllReduceOptions : OptionsBase<AllReduceOptions> {};
+struct ReduceOptions : OptionsBase<ReduceOptions> {};
+struct AllGatherOptions : OptionsBase<AllGatherOptions> {};
+struct AllGatherSingleOptions : OptionsBase<AllGatherSingleOptions> {};
+struct ReduceScatterOptions : OptionsBase<ReduceScatterOptions> {};
+struct ReduceScatterSingleOptions : OptionsBase<ReduceScatterSingleOptions> {};
+struct AllToAllOptions : OptionsBase<AllToAllOptions> {};
+struct AllToAllSingleOptions : OptionsBase<AllToAllSingleOptions> {};
+struct AllToAllvSingleOptions : OptionsBase<AllToAllvSingleOptions> {};
+struct BarrierOptions : OptionsBase<BarrierOptions> {};
+struct ScatterOptions : OptionsBase<ScatterOptions> {};
+struct GatherOptions : OptionsBase<GatherOptions> {};
+struct GatherSingleOptions : OptionsBase<GatherSingleOptions> {};
 
 class CommOptions {
  public:
@@ -202,20 +109,7 @@ class WaitSignalOptions {
   WaitSignalOptions() : timeout(kNoTimeout) {}
 };
 
-class AllGatherPInitOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  AllGatherPInitOptions() : timeout(kNoTimeout) {}
-};
-
-class AllGatherPExecOptions {
- public:
-  std::unordered_map<std::string, std::string> hints;
-  std::chrono::milliseconds timeout;
-
-  AllGatherPExecOptions() : timeout(kNoTimeout) {}
-};
+struct AllGatherPInitOptions : OptionsBase<AllGatherPInitOptions> {};
+struct AllGatherPExecOptions : OptionsBase<AllGatherPExecOptions> {};
 
 } // namespace torch::comms

--- a/comms/torchcomms/tests/unit/cpp/TorchCommOptionsTest.cpp
+++ b/comms/torchcomms/tests/unit/cpp/TorchCommOptionsTest.cpp
@@ -81,6 +81,38 @@ TEST(TorchCommOptionsTest, StringToBool) {
   EXPECT_THROW(torch::comms::string_to_bool("falsey"), std::runtime_error);
 }
 
+TEST(TorchCommOptionsTest, OptionsBaseDefaults) {
+  AllGatherOptions gather;
+  EXPECT_EQ(gather.timeout, kNoTimeout);
+  EXPECT_TRUE(gather.hints.empty());
+
+  // Options with extra fields keep the shared defaults from the base.
+  SendOptions send;
+  EXPECT_EQ(send.timeout, kNoTimeout);
+  EXPECT_EQ(send.tag, 0);
+
+  RecvOptions recv;
+  EXPECT_EQ(recv.timeout, kNoTimeout);
+  EXPECT_EQ(recv.tag, 0);
+
+  // Window options share the same base defaults.
+  PutOptions put;
+  EXPECT_EQ(put.timeout, kNoTimeout);
+  EXPECT_TRUE(put.hints.empty());
+}
+
+TEST(TorchCommOptionsTest, CommOptionsGetHint) {
+  CommOptions options;
+  options.hints["enabled"] = "yes";
+  options.hints["count"] = "12";
+  options.hints["name"] = "value";
+
+  EXPECT_TRUE(options.getHint<bool>("enabled", false));
+  EXPECT_EQ(options.getHint<size_t>("count", 0), 12U);
+  EXPECT_EQ(options.getHint<std::string>("name", ""), "value");
+  EXPECT_EQ(options.getHint<size_t>("missing", 3), 3U);
+}
+
 namespace {
 constexpr const char* kBackendName = "fake_test";
 constexpr const char* kBackendEnvKey = "TORCHCOMMS_BACKEND_LIB_PATH_FAKE_TEST";


### PR DESCRIPTION
Summary:

- Deduplicates the `hints` and `timeout` members that were copy-pasted across all 22 collective and window option structs (`SendOptions`, `RecvOptions`, `AllGatherOptions`, `PutOptions`, etc) in torchcomms, so future changes to those two fields are single-site
- Introduces an `OptionsBase<Derived>` CRTP base holding the two shared members; specialized fields like `tag` stay on `SendOptions`/`RecvOptions` only. `Derived` is unused in the base body on purpose — it gives every option type its own base, so unrelated options cannot bind to a common `OptionsBase` reference
- `CommOptions` is deliberately left alone: it keeps its own `hints`/`timeout` and its out-of-line `getHint`, so the existing explicitly instantiated symbols stay exactly where they are

No behavior change: the option structs keep the same members and the same defaults, and no `getHint` API is added or moved.

Reviewed By: rmahidhar

Differential Revision: D115310686


