### PR TITLE
Suppress new Pyrefly `constexpr` errors in comms Triton collectives

### DIFF
--- a/comms/prims/triton/collectives/ib/put_bw_kernel.py
+++ b/comms/prims/triton/collectives/ib/put_bw_kernel.py
@@ -113,7 +113,9 @@ if has_triton():  # noqa: C901
                     staging_byte_offset,  # src_offset in our staging
                     peer_rank,
                     section_bytes,
+                    # pyrefly: ignore [bad-argument-type]
                     0,  # signal_id = DATA_READY
+                    # pyrefly: ignore [bad-argument-type]
                     0,  # counter_id = NIC_DONE
                 )
 
@@ -123,13 +125,16 @@ if has_triton():  # noqa: C901
             # ALL_DONE increments by 1 per iteration (not per step), so
             # use iteration+1, NOT base+1 (base = iteration * total_steps
             # would grow too fast and deadlock on iteration >= 1).
+            # pyrefly: ignore [bad-argument-type]
             wait_signal_from(win, peer_rank, 1, iteration + 1)
         else:
             # -- Recv block --
             # Wait for all data to arrive.
+            # pyrefly: ignore [bad-argument-type]
             wait_signal_from(win, peer_rank, 0, base + total_steps)
             # Signal sender that all data was delivered.
             fence(win)
+            # pyrefly: ignore [bad-argument-type]
             signal_block(win, peer_rank, 1, 1)  # ALL_DONE
 
     # ------------------------------------------------------------------
@@ -184,9 +189,15 @@ if has_triton():  # noqa: C901
 
                 # Wait for NIC + receiver to free the slot before reuse.
                 if step >= pipeline_depth:
+                    # pyrefly: ignore [bad-argument-type]
                     wait_counter(win, 0, base + step - pipeline_depth + 1)
                     wait_signal_from(
-                        win, peer_rank, 1, base + step - pipeline_depth + 1
+                        # pyrefly: ignore [bad-argument-type]
+                        win,
+                        peer_rank,
+                        # pyrefly: ignore [bad-argument-type]
+                        1,
+                        base + step - pipeline_depth + 1,
                     )
 
                 staging_byte_offset = slot * section_elements * elem_size_bytes
@@ -207,16 +218,20 @@ if has_triton():  # noqa: C901
                     staging_byte_offset,  # src_offset in our staging
                     peer_rank,
                     section_bytes,
+                    # pyrefly: ignore [bad-argument-type]
                     0,  # signal_id = DATA_READY
+                    # pyrefly: ignore [bad-argument-type]
                     0,  # counter_id = NIC_DONE
                 )
         else:
             # -- Recv block --
             for step in range(total_steps):
                 # Wait for data to arrive for this step.
+                # pyrefly: ignore [bad-argument-type]
                 wait_signal_from(win, peer_rank, 0, base + step + 1)
                 fence(win)
                 # Signal sender that the slot is free for reuse.
+                # pyrefly: ignore [bad-argument-type]
                 signal_block(win, peer_rank, 1, 1)  # SLOT_FREE += 1
 
     # ------------------------------------------------------------------
@@ -321,6 +336,7 @@ if has_triton():  # noqa: C901
                 else:
                     # No data for this tile in the last (partial) section.
                     # Still signal DATA_READY so the receiver doesn't deadlock.
+                    # pyrefly: ignore [bad-argument-type]
                     signal_block(win, peer_rank, pid, 1)
         else:
             # -- Recv block --
@@ -331,4 +347,5 @@ if has_triton():  # noqa: C901
                 wait_signal_from(win, peer_rank, recv_pid, base + step + 1)
                 fence(win)
                 # Signal sender that my tile's slot is free.
+                # pyrefly: ignore [bad-argument-type]
                 signal_block(win, peer_rank, num_blocks + recv_pid, 1)

--- a/comms/prims/triton/collectives/ib/sendrecv.py
+++ b/comms/prims/triton/collectives/ib/sendrecv.py
@@ -180,6 +180,7 @@ if has_triton():  # noqa: C901
                     nic_counter,
                 )
             else:
+                # pyrefly: ignore [bad-argument-type]
                 signal_block(win, peer_rank, data_signal, 1)
 
         # -- Drain: SLOT_FREE only (implies NIC_DONE) --
@@ -258,6 +259,7 @@ if has_triton():  # noqa: C901
                     tl.store(dst_ptr + dst_start + offs, data, mask=mask)
 
             # -- Signal sender: this slot is free --
+            # pyrefly: ignore [bad-argument-type]
             signal_block(win, peer_rank, slot_free_signal, 1)
 
     @requires_torchcomms

--- a/comms/prims/triton/collectives/ib/sendrecv_cooperative_kernel.py
+++ b/comms/prims/triton/collectives/ib/sendrecv_cooperative_kernel.py
@@ -119,6 +119,7 @@ if has_triton():  # noqa: C901
 
             # -- Wait for slot reuse (NIC must have finished reading this slot) --
             if step >= pipeline_depth:
+                # pyrefly: ignore [bad-argument-type]
                 wait_counter(win, 0, base + step - pipeline_depth + 1)
 
             # -- Phase 1: Local copy src -> send_staging (all send blocks) --
@@ -147,7 +148,12 @@ if has_triton():  # noqa: C901
                 # Last block: wait for receiver to free recv_staging[slot].
                 if step >= pipeline_depth:
                     wait_signal_from(
-                        win, peer_rank, 1, base + step - pipeline_depth + 1
+                        # pyrefly: ignore [bad-argument-type]
+                        win,
+                        peer_rank,
+                        # pyrefly: ignore [bad-argument-type]
+                        1,
+                        base + step - pipeline_depth + 1,
                     )
 
                 # Compute actual bytes for this section (last section may be
@@ -170,7 +176,9 @@ if has_triton():  # noqa: C901
                     staging_byte_offset,  # src_offset (bytes)
                     peer_rank,
                     actual_section_bytes,
+                    # pyrefly: ignore [bad-argument-type]
                     0,  # signal_id = DATA_READY
+                    # pyrefly: ignore [bad-argument-type]
                     0,  # counter_id = NIC_DONE
                 )
 
@@ -211,6 +219,7 @@ if has_triton():  # noqa: C901
             slot = step % pipeline_depth
 
             # -- Wait for data to arrive from sender --
+            # pyrefly: ignore [bad-argument-type]
             wait_signal_from(win, peer_rank, 0, base + step + 1)
 
             # -- Local copy: recv_staging[slot] -> dst (all recv blocks) --
@@ -235,6 +244,7 @@ if has_triton():  # noqa: C901
             expected = num_recv_blocks * (step // pipeline_depth + 1)
 
             if old_count + 1 == expected:
+                # pyrefly: ignore [bad-argument-type]
                 signal_block(win, peer_rank, 1, 1)  # SLOT_FREE += 1
 
     @requires_torchcomms


### PR DESCRIPTION
Summary:
D115081437 (`[triton][stable] Promote 3.8.0+fb`) pulls in upstream PR #10048
("Python typing improvements"), which types `JITFunction.__call__` with a
`ParamSpec` bound to the wrapped kernel signature:

```
def __call__(self: "JITFunction[Callable[P, R]]", *args: P.args, **kwargs: P.kwargs) -> R
```

Previously this was an untyped `(*args, **kwargs)`. Pyrefly now validates
call-site arguments against kernel parameters annotated `X: tl.constexpr`, so
the standard Triton idiom of passing a plain `int` / `bool` / `float` / `str` to a
`tl.constexpr` parameter is reported as `bad-argument-type`. The more precise
return types also make `tl.make_block_ptr(...).dtype.element_ty` and similar
report `missing-attribute`. These are false positives -- `constexpr`-ness is a
Triton JIT concept the type checker cannot model.

No runtime code changes -- only `# pyrefly: ignore` comments, plus `black`
reflowing a few call argument lists that the inserted comments pushed over the
line limit. Generated mechanically with `arc pyre check <targets> --suppress`
followed by `arc f`, then re-run and re-suppressed, because `black` relocates
some inserted comments off the argument they were meant to cover.

This follows the established remediation for this exact breakage on the `beta`
channel -- D111539315, D110101874, D108930935 -- which suppress at the call site
and leave the vendored Triton bundle untouched.

Suppressions added in this diff: 30 `bad-argument-type`.

___

Differential Revision: D115312408


