### PR TITLE
Add MCCL_NVL_FABRIC_ENABLE opt-out for MNNVL topology collapse (#3516)

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1936,6 +1936,20 @@ cvars:
      NCCLX or standalone Ctran users. Set false to roll MCCL communicators back
      to the legacy transport policy.
 
+ - name        : MCCL_NVL_FABRIC_ENABLE
+   type        : bool
+   default     : false
+   description : |-
+     Recognize the MNNVL cross-host NVL fabric domain when initializing an MCCL
+     communicator's topology. When true, ranks sharing an NVL fabric clusterUuid
+     collapse into a single NVL domain, so nLocalRanks spans hosts and cross-host
+     peers are classified as NVL rather than IB. When false, the NVL logical
+     group is constrained to same-host ranks and cross-host peers route over IB.
+     Defaults to false because the collapse is only valid where fabric handles
+     are importable between the peers: a fleet that advertises fabric without a
+     shared IMEX domain fails communicator init outright. Set true on fleets
+     known to share an IMEX domain.
+
  - name        : NCCL_CTRAN_PIPES_TRACE_ENABLE
    type        : bool
    default     : false


### PR DESCRIPTION
Summary:

`D113320384` made `initRankTopology` call `initNvlFabricTopos` unconditionally, so
an MCCL communicator now recognizes the MNNVL cross-host NVL fabric domain. On an
MNNVL rack, ranks sharing an NVL fabric `clusterUuid` collapse into a single NVL
domain: `nLocalRanks` spans hosts and cross-host peers are classified as NVL
rather than IB.

That collapse is correct only when fabric handles are actually importable between
the peers. The readiness probe in `initNvlFabricTopos` checks local capability --
`NvmlFabricInfo::query()` plus `selectShareableHandleType(cudaDev) == kFabric` --
but nothing establishes that the peers share an IMEX domain, which is what a
`CU_MEM_HANDLE_TYPE_FABRIC` handle requires in order to import.

On a GB200 PAFT job the probe passes and the domain collapses, but the subsequent
import fails:

```
CtranIpc.cc:120] Cuda failure 400 'invalid resource handle'
CtranIpc.cc:588 -> commUnhandledCudaError   (importShareableHandle, isFabric=true)
CtranIpc.cc:551 -> commUnhandledCudaError   (importCuMem)
CtranIpc.cc:512 -> commUnhandledCudaError   (CtranIpcRemMem ctor)
Ctran.cc:181] Ctran initialization failed
```

Communicator init then fails on every rank, so no collective runs. There is
currently no way to opt out: D96026371 removed `NCCL_CTRAN_NVL_FABRIC_ENABLE`
and made fabric support auto-detected, and neither `NCCL_MNNVL_ENABLE=0` nor
`MCCL_PRIMS_ENABLE=0` reaches this path -- `cuMemHandleType_` is derived from the
allocation's `requestedHandleTypes` (`CudaWrap.h:296-303`), not from a cvar.

Add `MCCL_NVL_FABRIC_ENABLE` (default `true`, so behavior is unchanged) and gate
the `initNvlFabricTopos` call on it. Setting it false restores the pre-`D113320384`
classification: the NVL logical group is constrained to same-host ranks and
cross-host peers route over IB. This is the same fallback the existing unit tests
already cover as the no-IMEX case (`CommStateXTest.cc`, `fabricHwSupported=false`).

This is an escape hatch, not the fix. The probe itself should establish
cross-host importability before collapsing the domain; that is tracked separately.

Reviewed By: arttianezhu

Differential Revision: D115317781


