### PR TITLE
Add a cross-host fabric-handle importability primitive

### DIFF
--- a/comms/prims/memory/NvlMemExchange.cc
+++ b/comms/prims/memory/NvlMemExchange.cc
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <system_error>
@@ -450,6 +451,104 @@ CUmemGenericAllocationHandle importShareableHandle(const ShareableHandle& h) {
   }
 #endif
   return imported;
+}
+
+std::optional<TrialFabricExport> exportTrialFabricHandle(int cudaDevice) {
+#if CUDART_VERSION < 12030
+  (void)cudaDevice;
+  return std::nullopt;
+#else
+  // Every failure path below logs its stage. The caller folds a nullopt into a
+  // communicator-wide "fabric unusable" verdict, so an unexpected driver fault
+  // must stay distinguishable from a genuine no-IMEX rejection.
+  if (cudaDevice < 0) {
+    LOG_FIRST_N(WARNING, 1)
+        << "exportTrialFabricHandle: invalid cudaDevice " << cudaDevice;
+    return std::nullopt;
+  }
+  if (cuda_driver_lazy_init() != 0) {
+    LOG_FIRST_N(WARNING, 1)
+        << "exportTrialFabricHandle: CUDA driver lazy init failed";
+    return std::nullopt;
+  }
+  CUdevice cuDev = 0;
+  if (pfn_cuDeviceGet(&cuDev, cudaDevice) != CUDA_SUCCESS) {
+    LOG_FIRST_N(WARNING, 1)
+        << "exportTrialFabricHandle: cuDeviceGet failed for device "
+        << cudaDevice;
+    return std::nullopt;
+  }
+
+  // catch(...) is deliberate, not lazy: this runs immediately before a
+  // collective all-gather, so ANY escaping exception would drop this rank out
+  // of the collective while its peers block in it. CuMemAllocation::create
+  // rethrows std::bad_alloc, which is not a std::runtime_error.
+  try {
+    TrialFabricExport result;
+    result.allocation = CuMemAllocation::create(
+        cuDev, kTrialAllocSize, CU_MEM_HANDLE_TYPE_FABRIC);
+    // create() drops FABRIC and retries when the driver refuses it, so the
+    // allocation can come back without fabric support; exporting it as fabric
+    // would then fail with a misleading error.
+    if (!result.allocation->supportsFabric()) {
+      LOG_FIRST_N(WARNING, 1)
+          << "exportTrialFabricHandle: allocation has no fabric support "
+             "(cuMemCreate refused CU_MEM_HANDLE_TYPE_FABRIC)";
+      return std::nullopt;
+    }
+    result.handle =
+        exportShareableHandle(
+            result.allocation->handle(), ShareableHandleType::kFabric)
+            .fabric;
+    return result;
+  } catch (const std::exception& e) {
+    LOG_FIRST_N(WARNING, 1)
+        << "exportTrialFabricHandle: trial fabric export failed: " << e.what();
+    return std::nullopt;
+  } catch (...) {
+    LOG_FIRST_N(WARNING, 1)
+        << "exportTrialFabricHandle: trial fabric export failed with a "
+           "non-std exception";
+    return std::nullopt;
+  }
+#endif
+}
+
+bool tryImportPeerFabricHandle(const FabricHandle& handle) {
+#if CUDART_VERSION < 12030
+  (void)handle;
+  return false;
+#else
+  if (cuda_driver_lazy_init() != 0) {
+    LOG_FIRST_N(WARNING, 1)
+        << "tryImportPeerFabricHandle: CUDA driver lazy init failed";
+    return false;
+  }
+  // Local copy: cuMemImportFromShareableHandle takes a non-const void*.
+  FabricHandle local = handle;
+  CUmemGenericAllocationHandle imported = 0;
+  const CUresult err = pfn_cuMemImportFromShareableHandle(
+      &imported, &local, CU_MEM_HANDLE_TYPE_FABRIC);
+  if (err != CUDA_SUCCESS) {
+    const char* errStr = nullptr;
+    (void)pfn_cuGetErrorString(err, &errStr);
+    LOG_FIRST_N(WARNING, 1)
+        << "tryImportPeerFabricHandle: cuMemImportFromShareableHandle failed: "
+        << static_cast<int>(err) << " '" << (errStr ? errStr : "unknown")
+        << "'";
+    return false;
+  }
+  // A release failure is a leak worth reporting, but it does not change the
+  // verdict: the import -- the thing being measured -- already succeeded, and
+  // disabling MNNVL fleet-wide over a cleanup fault would be the wrong trade.
+  const CUresult releaseErr = pfn_cuMemRelease(imported);
+  if (releaseErr != CUDA_SUCCESS) {
+    LOG_FIRST_N(WARNING, 1)
+        << "tryImportPeerFabricHandle: cuMemRelease leaked the probe handle: "
+        << static_cast<int>(releaseErr);
+  }
+  return true;
+#endif
 }
 
 NvlPeerMem nvlMemExchangeVmm(

--- a/comms/prims/memory/NvlMemExchange.h
+++ b/comms/prims/memory/NvlMemExchange.h
@@ -18,9 +18,12 @@
 #include <sys/types.h>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
+#include <optional>
 #include <vector>
 
 #include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/prims/memory/CuMemAllocation.h"
 #include "comms/prims/memory/CuMemMapping.h"
 
 namespace comms::prims {
@@ -123,6 +126,49 @@ ShareableHandle exportShareableHandle(
  * eventually cuMemRelease it). Throws std::runtime_error on any failure.
  */
 CUmemGenericAllocationHandle importShareableHandle(const ShareableHandle& h);
+
+/**
+ * A live fabric-capable trial allocation together with its exported handle.
+ *
+ * selectShareableHandleType() proves only that this rank can import its OWN
+ * exported fabric handle, which succeeds whenever a node-local IMEX channel
+ * exists. It cannot observe whether two hosts share an IMEX domain, which is
+ * what importing a PEER's CU_MEM_HANDLE_TYPE_FABRIC handle requires. Pair this
+ * with tryImportPeerFabricHandle() on the far side to establish that.
+ *
+ * `allocation` keeps the exported handle importable; it must outlive every
+ * peer's import attempt.
+ */
+struct TrialFabricExport {
+  std::unique_ptr<CuMemAllocation> allocation;
+  FabricHandle handle{};
+};
+
+/**
+ * Creates a small fabric-capable allocation on `cudaDevice` and exports its
+ * fabric handle.
+ *
+ * Returns std::nullopt (without throwing) when the device cannot create or
+ * export a fabric handle, so a caller can report itself as not exportable
+ * rather than failing communicator init.
+ *
+ * Requires a CUDA context current on the calling thread for `cudaDevice`.
+ */
+std::optional<TrialFabricExport> exportTrialFabricHandle(int cudaDevice);
+
+/**
+ * Attempts to import a fabric handle exported by another process or host.
+ *
+ * Returns false (without throwing) when the import fails, which is what happens
+ * with CUDA_ERROR_INVALID_HANDLE when the exporting and importing hosts do not
+ * share an IMEX domain. On success the imported handle is released before
+ * returning; a release failure is logged but does not change the verdict, since
+ * the import itself is what is being measured. Does not map the imported
+ * allocation -- the guarantee is import viability only.
+ *
+ * Requires a CUDA context current on the calling thread.
+ */
+bool tryImportPeerFabricHandle(const FabricHandle& handle);
 
 /**
  * The per-rank peer memory state produced by an NVLink-domain exchange.

--- a/comms/prims/tests/NvlMemExchangeTest.cc
+++ b/comms/prims/tests/NvlMemExchangeTest.cc
@@ -95,6 +95,42 @@ TEST(NvlMemExchangeTest, SelectShareableHandleTypeReturnsSupported) {
       type == ShareableHandleType::kPosixFd);
 }
 
+TEST(NvlMemExchangeTest, ExportTrialFabricHandleRoundTripsLoopback) {
+  CUdevice cuDev = 0;
+  int cudaDevice = 0;
+  if (!vmmDevice(cuDev, cudaDevice)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+  if (selectShareableHandleType(cudaDevice) != ShareableHandleType::kFabric) {
+    GTEST_SKIP() << "fabric handles unsupported on this device";
+  }
+
+  auto exported = exportTrialFabricHandle(cudaDevice);
+  ASSERT_TRUE(exported.has_value());
+  EXPECT_TRUE(exported->allocation->supportsFabric());
+
+  // A same-process import proves only that a node-local IMEX channel exists.
+  // Cross-host importability is what MCCL's initNvlFabricTopos establishes via
+  // a peer handshake; this asserts the loopback baseline that probe builds on.
+  EXPECT_TRUE(tryImportPeerFabricHandle(exported->handle));
+}
+
+TEST(NvlMemExchangeTest, TryImportPeerFabricHandleRejectsBogusHandle) {
+  CUdevice cuDev = 0;
+  int cudaDevice = 0;
+  if (!vmmDevice(cuDev, cudaDevice)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+  // A handle that was never exported must be rejected, not throw: the caller
+  // relies on a false return to fall back to per-host NVL groups.
+  const FabricHandle bogus = {};
+  EXPECT_FALSE(tryImportPeerFabricHandle(bogus));
+}
+
+TEST(NvlMemExchangeTest, ExportTrialFabricHandleRejectsInvalidDevice) {
+  EXPECT_FALSE(exportTrialFabricHandle(-1).has_value());
+}
+
 TEST(NvlMemExchangeTest, PosixFdExportImportRoundTripSharesMemory) {
   CUdevice cuDev = 0;
   int cudaDevice = 0;

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1936,6 +1936,19 @@ cvars:
      NCCLX or standalone Ctran users. Set false to roll MCCL communicators back
      to the legacy transport policy.
 
+ - name        : MCCL_NVL_FABRIC_ENABLE
+   type        : bool
+   default     : true
+   description : |-
+     Recognize the MNNVL cross-host NVL fabric domain when initializing an MCCL
+     communicator's topology. When true, ranks sharing an NVL fabric clusterUuid
+     collapse into a single NVL domain, so nLocalRanks spans hosts and cross-host
+     peers are classified as NVL rather than IB. Set false to constrain the NVL
+     logical group to same-host ranks and route cross-host peers over IB. Use the
+     opt-out on fabrics where fabric handles are advertised as available but are
+     not importable across hosts (for example when no shared IMEX domain is
+     provisioned), which otherwise fails communicator init.
+
  - name        : NCCL_CTRAN_PIPES_TRACE_ENABLE
    type        : bool
    default     : false


### PR DESCRIPTION
Summary:
`selectShareableHandleType` -> `fabricHandleSupported` proves only that a rank
can import its OWN exported fabric handle, which succeeds whenever a node-local
IMEX channel exists. NVIDIA's `ncclMnnvlCheck` (`comms/ncclx/v2_30/src/mnnvl.cc`)
does the same self-trial. Neither can observe whether two hosts share an IMEX
domain -- which is what importing a PEER's `CU_MEM_HANDLE_TYPE_FABRIC` handle
actually requires, and no NVML field reports IMEX domain membership.

Add the two pieces a caller needs to establish that with a real peer handshake:

- `exportTrialFabricHandle(cudaDevice)` creates a trial fabric-capable
  allocation and exports its handle, returning both so the allocation stays
  alive while peers import it. Built on the existing `CuMemAllocation` and
  `exportShareableHandle` rather than a new RAII type. `CuMemAllocation::create`
  silently drops FABRIC and retries when the driver refuses it, so the result is
  gated on `supportsFabric()`.
- `tryImportPeerFabricHandle(handle)` attempts a peer import and returns false
  rather than throwing on the no-shared-IMEX-domain failure, so the caller can
  fall back instead of failing communicator init.

Both are non-throwing by contract because the intended caller invokes them
immediately before collective all-gathers, where an escaping exception would
drop one rank out of a collective its peers are blocked in. `catch (...)` is
deliberate: `CuMemAllocation::create` rethrows `std::bad_alloc`, which is not a
`std::runtime_error`. Every early-return path logs its stage and `CUresult` so
an unexpected driver fault stays distinguishable from a genuine no-IMEX verdict.

The probe deliberately stops at import and does not trial-map: the failure this
targets is at `cuMemImportFromShareableHandle`, and the local
`selectShareableHandleType` probe has already proved map/setAccess work on the
device.

`:cu_mem_allocation` moves from `deps` to `exported_deps` because
`TrialFabricExport` holds a `unique_ptr<CuMemAllocation>` in the header.

No behavior change: nothing calls these yet.

Differential Revision: D115317780


