### PR TITLE
Stabilize TP optimizer test

### DIFF
--- a/comms/torchcomms/tests/integration/py/TPCommTest.py
+++ b/comms/torchcomms/tests/integration/py/TPCommTest.py
@@ -101,8 +101,10 @@ class TPCommTest(unittest.TestCase):
             },
         )
         LR = 8e-4  # Use the learning rate from torchtitan
-        local_optim = torch.optim.SGD(model.parameters(), lr=LR)
-        dist_optim = torch.optim.SGD(model_tp.parameters(), lr=LR)
+        # This test validates TorchComm TP semantics, not DTensor's foreach
+        # optimizer kernel. Keep both optimizers on the per-tensor path.
+        local_optim = torch.optim.SGD(model.parameters(), lr=LR, foreach=False)
+        dist_optim = torch.optim.SGD(model_tp.parameters(), lr=LR, foreach=False)
         self._compare_params(model, model_tp, rank0_only)
         for _ in range(30):
             inp = torch.rand(*inp_size, device=device)


### PR DESCRIPTION
Summary:
PyTorch SGD selects its foreach implementation by default for supported CUDA parameters. The CUDA 13 nightly TP integration job crashed in DTensor dispatch while executing `_foreach_add__List` during the distributed optimizer step.

Configure both reference and distributed SGD instances with `foreach=False`. This keeps their update algorithms equivalent, selects the per-tensor SGD path, and preserves all 30 training iterations plus parameter and gradient comparisons. The change is isolated below the logging migration stack because it fixes an independent test instability.

Differential Revision: D115334277


