### PR TITLE
Migrate `perftrace` logs

### DIFF
--- a/comms/ctran/algos/perftrace/Tracer.cc
+++ b/comms/ctran/algos/perftrace/Tracer.cc
@@ -1,10 +1,10 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/ctran/algos/perftrace/Tracer.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 #include <folly/String.h>
-#include <folly/logging/xlog.h>
 #include <fstream>
 #include <sstream>
 
@@ -35,7 +35,7 @@ void Tracer::reportTracing() {
   }
   auto lockedRecords = records_.wlock();
   if (lockedRecords->empty()) {
-    XLOG(INFO) << "No trace records to report; skip reporting";
+    CTRAN_LOG(INFO, "No trace records to report; skip reporting");
     return;
   }
 
@@ -52,7 +52,7 @@ void Tracer::reportTracing() {
       outputDir + "/" + std::string("ctran_trace_log.") + std::to_string(pid) +
       std::string(".rank") + std::to_string(this->rank_) + std::string(".") +
       std::to_string(reportCnt++) + std::string(".json"));
-  XLOG(INFO) << "Dumping logging output to " << filename;
+  CTRAN_LOG(INFO, "Dumping logging output to {}", filename);
 
   int id = 0;
   stream << "[" << std::endl;
@@ -63,7 +63,7 @@ void Tracer::reportTracing() {
   stream << folly::join(",", jsonEntries) << std::endl;
   stream << "]" << std::endl;
 
-  XLOG(INFO) << "Dumped logging output to " << filename << " with id " << id;
+  CTRAN_LOG(INFO, "Dumped logging output to {} with id {}", filename, id);
   std::ofstream f(filename);
   f << stream.str();
   f.close();

--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -1,13 +1,13 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <folly/String.h>
-#include <folly/logging/xlog.h>
 #include <string>
 
 #include "CommStateX.h"
 #include "comms/ctran/commstate/Topology.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 namespace ncclx {
@@ -310,7 +310,7 @@ void CommStateX::setNvlFabricTopos(
       state.cliqueRankToRank = cliqueRanks_.at(state.cliqueIndex);
     }
     myNvlFabricRankState_ = nvlFabricRankStates_.at(rank_);
-    XLOGF(
+    CTRAN_LOG(
         INFO,
         "CommStateX: effectiveVCliqueSize={} override NVL fabric topology",
         effectiveVCliqueSize);
@@ -406,7 +406,7 @@ void CommStateX::setRankStatesTopologies(
     state.nLocalRanks = state.localRankToRanks.size();
   }
 
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "CommStateX: set rankTopology with {}",
       topoNameMap[NCCL_COMM_STATE_DEBUG_TOPO]);

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -13,6 +13,7 @@
 #endif
 #include "comms/ctran/mapper/CtranMapperTypes.h" // @manual=//comms/ctran:mapper_types
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/ctran/utils/ExtUtils.h"
 #include "comms/utils/CudaRAII.h"
@@ -580,7 +581,7 @@ void ctran::RegCache::registerExternalRegMemFn(
     externalRegMemFn_ = std::move(regMem);
     externalDeregMemFn_ = std::move(deregMem);
   } else {
-    XLOGF(
+    CTRAN_LOG(
         WARN,
         "RegCache: registerExternalRegMemFn called with null callback(s), "
         "both regMem and deregMem are required — ignoring");


### PR DESCRIPTION
Summary:
Migrate the three direct `XLOG` calls in `Tracer.cc` to the CTRAN logging facade while preserving their `INFO` severity and rendered messages.

Replace the production target direct Folly logging dependency with `ctran_logger`. The separately built example targets are unchanged.

Reviewed By: shr

Differential Revision: D115368344


