### PR TITLE
Migrate `AsyncSocket` logs

### DIFF
--- a/comms/ctran/algos/perftrace/Tracer.cc
+++ b/comms/ctran/algos/perftrace/Tracer.cc
@@ -1,10 +1,10 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/ctran/algos/perftrace/Tracer.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 #include <folly/String.h>
-#include <folly/logging/xlog.h>
 #include <fstream>
 #include <sstream>
 
@@ -35,7 +35,7 @@ void Tracer::reportTracing() {
   }
   auto lockedRecords = records_.wlock();
   if (lockedRecords->empty()) {
-    XLOG(INFO) << "No trace records to report; skip reporting";
+    CTRAN_LOG(INFO, "No trace records to report; skip reporting");
     return;
   }
 
@@ -52,7 +52,7 @@ void Tracer::reportTracing() {
       outputDir + "/" + std::string("ctran_trace_log.") + std::to_string(pid) +
       std::string(".rank") + std::to_string(this->rank_) + std::string(".") +
       std::to_string(reportCnt++) + std::string(".json"));
-  XLOG(INFO) << "Dumping logging output to " << filename;
+  CTRAN_LOG(INFO, "Dumping logging output to {}", filename);
 
   int id = 0;
   stream << "[" << std::endl;
@@ -63,7 +63,7 @@ void Tracer::reportTracing() {
   stream << folly::join(",", jsonEntries) << std::endl;
   stream << "]" << std::endl;
 
-  XLOG(INFO) << "Dumped logging output to " << filename << " with id " << id;
+  CTRAN_LOG(INFO, "Dumped logging output to {} with id {}", filename, id);
   std::ofstream f(filename);
   f << stream.str();
   f.close();

--- a/comms/ctran/bootstrap/AsyncSocket.cc
+++ b/comms/ctran/bootstrap/AsyncSocket.cc
@@ -2,8 +2,9 @@
 
 #include "AsyncSocket.h"
 
-#include <folly/logging/xlog.h>
 #include <cstring>
+
+#include "comms/ctran/utils/CtranLogger.h"
 
 namespace ctran::bootstrap {
 
@@ -56,7 +57,7 @@ void AsyncClientSocket::start(
 void AsyncClientSocket::connectSuccess() noexcept {
   folly::SocketAddress peer;
   sock_->getPeerAddress(&peer);
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "Connected to {}, fd={}",
       peer.describe(),
@@ -66,7 +67,7 @@ void AsyncClientSocket::connectSuccess() noexcept {
 
 void AsyncClientSocket::connectErr(
     const folly::AsyncSocketException& ex) noexcept {
-  XLOGF(ERR, "AsyncClientSocket connect failed: {}", ex.what());
+  CTRAN_LOG(ERR, "AsyncClientSocket connect failed: {}", ex.what());
   cancelTimeout();
   finish(&ex);
 }
@@ -79,7 +80,7 @@ void AsyncClientSocket::writeSuccess() noexcept {
 void AsyncClientSocket::writeErr(
     size_t bytesWritten,
     const folly::AsyncSocketException& ex) noexcept {
-  XLOGF(
+  CTRAN_LOG(
       ERR,
       "AsyncClientSocket write failed after {} bytes: {}",
       bytesWritten,
@@ -89,7 +90,7 @@ void AsyncClientSocket::writeErr(
 }
 
 void AsyncClientSocket::timeoutExpired() noexcept {
-  XLOGF(ERR, "AsyncClientSocket operation timed out");
+  CTRAN_LOG(ERR, "AsyncClientSocket operation timed out");
   auto ex = folly::AsyncSocketException(
       folly::AsyncSocketException::TIMED_OUT, "Operation timed out");
   finish(&ex);
@@ -145,7 +146,7 @@ folly::SemiFuture<folly::SocketAddress> AsyncServerSocket::start(
     server_->listen(1024 /* backlog */);
     server_->startAccepting();
     auto addr = server_->getAddress();
-    XLOGF(
+    CTRAN_LOG(
         INFO,
         "AsyncServerSocket started listening on {}, fd={}",
         addr.describe(),
@@ -176,7 +177,7 @@ folly::SemiFuture<folly::Unit> AsyncServerSocket::stop() {
   evb_.runInEventBaseThread([this, p = std::move(p)]() mutable {
     if (server_) {
       auto addr = server_->getAddress();
-      XLOGF(
+      CTRAN_LOG(
           INFO,
           "AsyncServerSocket is shutting down on {}, fd={}",
           addr.describe(),
@@ -205,7 +206,7 @@ void AsyncServerSocket::connectionAccepted(
   auto sock = folly::AsyncSocket::UniquePtr(new folly::AsyncSocket(&evb_, ns));
   folly::SocketAddress localAddr;
   localAddr.setFromLocalAddress(ns);
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "Accepted a new connection fd={}, local={}, peer={}. Waiting for 1 message to arrive.",
       ns.toFd(),
@@ -230,7 +231,7 @@ void AsyncServerSocket::connectionAccepted(
 }
 
 void AsyncServerSocket::acceptError(const std::exception& ex) noexcept {
-  XLOGF(ERR, "AsyncServerSocket accept failed: {}", ex.what());
+  CTRAN_LOG(ERR, "AsyncServerSocket accept failed: {}", ex.what());
 }
 
 //
@@ -291,7 +292,7 @@ void AsyncServerSocket::OneShotRecv::readEOF() noexcept {
 
 void AsyncServerSocket::OneShotRecv::readErr(
     const folly::AsyncSocketException& ex) noexcept {
-  XLOGF(ERR, "AsyncServerSocket read error: {}", ex.what());
+  CTRAN_LOG(ERR, "AsyncServerSocket read error: {}", ex.what());
   cancelTimeout();
   closeNow();
 }
@@ -305,7 +306,7 @@ void AsyncServerSocket::OneShotRecv::closeNow() {
 }
 
 void AsyncServerSocket::OneShotRecv::timeoutExpired() noexcept {
-  XLOGF(ERR, "AsyncServerSocket receive operation timed out");
+  CTRAN_LOG(ERR, "AsyncServerSocket receive operation timed out");
   closeNow();
 }
 

--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -1,13 +1,13 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <folly/String.h>
-#include <folly/logging/xlog.h>
 #include <string>
 
 #include "CommStateX.h"
 #include "comms/ctran/commstate/Topology.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 namespace ncclx {
@@ -310,7 +310,7 @@ void CommStateX::setNvlFabricTopos(
       state.cliqueRankToRank = cliqueRanks_.at(state.cliqueIndex);
     }
     myNvlFabricRankState_ = nvlFabricRankStates_.at(rank_);
-    XLOGF(
+    CTRAN_LOG(
         INFO,
         "CommStateX: effectiveVCliqueSize={} override NVL fabric topology",
         effectiveVCliqueSize);
@@ -406,7 +406,7 @@ void CommStateX::setRankStatesTopologies(
     state.nLocalRanks = state.localRankToRanks.size();
   }
 
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "CommStateX: set rankTopology with {}",
       topoNameMap[NCCL_COMM_STATE_DEBUG_TOPO]);

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -13,6 +13,7 @@
 #endif
 #include "comms/ctran/mapper/CtranMapperTypes.h" // @manual=//comms/ctran:mapper_types
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/ctran/utils/ExtUtils.h"
 #include "comms/utils/CudaRAII.h"
@@ -580,7 +581,7 @@ void ctran::RegCache::registerExternalRegMemFn(
     externalRegMemFn_ = std::move(regMem);
     externalDeregMemFn_ = std::move(deregMem);
   } else {
-    XLOGF(
+    CTRAN_LOG(
         WARN,
         "RegCache: registerExternalRegMemFn called with null callback(s), "
         "both regMem and deregMem are required — ignoring");

--- a/comms/ctran/utils/CudaUtils.cc
+++ b/comms/ctran/utils/CudaUtils.cc
@@ -4,7 +4,6 @@
 #include <cuda_runtime.h>
 #include <folly/Singleton.h>
 #include <folly/SocketAddress.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/ctran/utils/CudaUtils.h"
 


### PR DESCRIPTION
Summary:
Migrate all ten direct `XLOGF` calls in `AsyncSocket.cc` to the CTRAN logging facade. Preserve every severity, format string, and argument.

Replace the target direct Folly logging dependency with `ctran_logger`.

Reviewed By: shr

Differential Revision: D115368646


