### PR TITLE
Migrate `IbvCq` logs

### DIFF
--- a/comms/ctran/algos/perftrace/Tracer.cc
+++ b/comms/ctran/algos/perftrace/Tracer.cc
@@ -1,10 +1,10 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/ctran/algos/perftrace/Tracer.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 #include <folly/String.h>
-#include <folly/logging/xlog.h>
 #include <fstream>
 #include <sstream>
 
@@ -35,7 +35,7 @@ void Tracer::reportTracing() {
   }
   auto lockedRecords = records_.wlock();
   if (lockedRecords->empty()) {
-    XLOG(INFO) << "No trace records to report; skip reporting";
+    CTRAN_LOG(INFO, "No trace records to report; skip reporting");
     return;
   }
 
@@ -52,7 +52,7 @@ void Tracer::reportTracing() {
       outputDir + "/" + std::string("ctran_trace_log.") + std::to_string(pid) +
       std::string(".rank") + std::to_string(this->rank_) + std::string(".") +
       std::to_string(reportCnt++) + std::string(".json"));
-  XLOG(INFO) << "Dumping logging output to " << filename;
+  CTRAN_LOG(INFO, "Dumping logging output to {}", filename);
 
   int id = 0;
   stream << "[" << std::endl;
@@ -63,7 +63,7 @@ void Tracer::reportTracing() {
   stream << folly::join(",", jsonEntries) << std::endl;
   stream << "]" << std::endl;
 
-  XLOG(INFO) << "Dumped logging output to " << filename << " with id " << id;
+  CTRAN_LOG(INFO, "Dumped logging output to {} with id {}", filename, id);
   std::ofstream f(filename);
   f << stream.str();
   f.close();

--- a/comms/ctran/bootstrap/AbortableSocket.cc
+++ b/comms/ctran/bootstrap/AbortableSocket.cc
@@ -11,7 +11,7 @@
 #include <unistd.h>
 
 #include <folly/ScopeGuard.h>
-#include <folly/logging/xlog.h>
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 using namespace std::literals::chrono_literals;
@@ -39,7 +39,7 @@ folly::SocketAddress getSocketAddress(int fd) {
   if (::getsockname(fd, (struct sockaddr*)&localAddr, &localLen) == 0) {
     sa.setFromSockaddr((struct sockaddr*)&localAddr, localLen);
   } else {
-    XLOGF(
+    CTRAN_LOG(
         WARN,
         "Failed to get local socket address for fd={}. errno={}, {}",
         fd,
@@ -101,14 +101,15 @@ int AbortableSocket::connect(
     size_t numRetries,
     bool async) {
   if (!async) {
-    XLOG(
+    CTRAN_LOG(
         DBG,
         "AbortableSocket::connect() called with async=false; ignoring flag.");
   }
   // Create socket
   fd_.store(::socket(addr.getFamily(), SOCK_STREAM, 0));
   if (fd_.load() < 0) {
-    XLOGF(ERR, "Failed to create socket. errno={}, {}", errno, strerror(errno));
+    CTRAN_LOG(
+        ERR, "Failed to create socket. errno={}, {}", errno, strerror(errno));
     return errno;
   }
   prepareSocket();
@@ -121,7 +122,7 @@ int AbortableSocket::connect(
             SO_BINDTODEVICE,
             ifName.c_str(),
             ifName.size()) < 0) {
-      XLOGF(
+      CTRAN_LOG(
           ERR,
           "Failed to bind socket to interface {}. errno={}, {}",
           ifName,
@@ -136,7 +137,7 @@ int AbortableSocket::connect(
   size_t retryCount{0};
 
   while (!abort_->isAborted()) {
-    XLOGF(DBG, "Connecting to {} via {}", addr.describe(), ifName);
+    CTRAN_LOG(DBG, "Connecting to {} via {}", addr.describe(), ifName);
     int ret = ::connect(fd_.load(), (const struct sockaddr*)&sockAddr, sockLen);
 
     if (ret == 0) {
@@ -147,7 +148,7 @@ int AbortableSocket::connect(
       break; // Connected successfully.
     }
 
-    XLOGF(
+    CTRAN_LOG(
         WARN,
         "Failed to connect to {} via {}. errno={}, {}",
         addr.describe(),
@@ -156,7 +157,7 @@ int AbortableSocket::connect(
         strerror(errno));
 
     if (!shouldRetry(errno)) {
-      XLOGF(ERR, "Connection attempt terminating on non-retryable error");
+      CTRAN_LOG(ERR, "Connection attempt terminating on non-retryable error");
       int err = errno;
       close();
       return err;
@@ -173,7 +174,7 @@ int AbortableSocket::connect(
   peerAddr_ = addr;
   localAddr_ = getSocketAddress(fd_.load());
 
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "Connected to {} via {}, fd={}",
       addr.describe(),
@@ -246,7 +247,7 @@ int AbortableSocket::send(const void* buf, const size_t len) {
         ::send(fd_.load(), (const uint8_t*)buf + totalSent, len - totalSent, 0);
     if (sent == -1 &&
         (errno != EINTR && errno != EWOULDBLOCK && errno != EAGAIN)) {
-      XLOGF(
+      CTRAN_LOG(
           ERR,
           "Failed to write to socket fd={}. errno={}, {}",
           fd_.load(),
@@ -286,7 +287,7 @@ int AbortableSocket::recv(void* buf, const size_t len) {
 
     if (rcvd == -1 &&
         (errno != EINTR && errno != EWOULDBLOCK && errno != EAGAIN)) {
-      XLOGF(
+      CTRAN_LOG(
           ERR,
           "Failed to read from socket fd={}. errno={}, {}",
           fd_.load(),
@@ -323,7 +324,7 @@ bool AbortableSocket::waitForEvent(
     const std::chrono::milliseconds timeout) {
   int fd = fd_.load();
   if (fd < 0) {
-    XLOG(INFO, "fd_ is < 0");
+    CTRAN_LOG(INFO, "fd_ is < 0");
     return false;
   }
 
@@ -355,7 +356,7 @@ bool AbortableSocket::waitForEvent(
 
     int ret = ::poll(&pfd, 1, remaining.count());
     if (ret < 0) {
-      XLOGF(
+      CTRAN_LOG(
           ERR,
           "poll failed on fd={}. errno={}, {}",
           fd,
@@ -370,7 +371,7 @@ bool AbortableSocket::waitForEvent(
     }
 
     if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
-      XLOGF(WARN, "poll returned error events: {}", pfd.revents);
+      CTRAN_LOG(WARN, "poll returned error events: {}", pfd.revents);
       return false;
     }
 
@@ -391,7 +392,7 @@ int AbortableSocket::waitForConnect(const std::chrono::milliseconds timeout) {
   int error = 0;
   socklen_t len = sizeof(error);
   if (getsockopt(fd_.load(), SOL_SOCKET, SO_ERROR, &error, &len) < 0) {
-    XLOGF(
+    CTRAN_LOG(
         ERR,
         "Failed to get socket error status. errno={}, {}",
         errno,
@@ -400,7 +401,7 @@ int AbortableSocket::waitForConnect(const std::chrono::milliseconds timeout) {
   }
 
   if (error != 0) {
-    XLOGF(
+    CTRAN_LOG(
         WARN,
         "Connection failed with error: errno={}, {}",
         error,
@@ -447,7 +448,7 @@ int AbortableServerSocket::bind(
     const folly::SocketAddress& addr,
     const std::string& ifName,
     bool reusePort) {
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "Binding AbortableServerSocket to {} via {}",
       addr.describe(),
@@ -455,7 +456,8 @@ int AbortableServerSocket::bind(
   // Create socket
   fd_ = ::socket(addr.getFamily(), SOCK_STREAM, 0);
   if (fd_ < 0) {
-    XLOGF(ERR, "Failed to create socket. errno={}, {}", errno, strerror(errno));
+    CTRAN_LOG(
+        ERR, "Failed to create socket. errno={}, {}", errno, strerror(errno));
     return errno;
   }
 
@@ -465,7 +467,7 @@ int AbortableServerSocket::bind(
     if (setsockopt(
             fd_, SOL_SOCKET, SO_BINDTODEVICE, ifName.c_str(), ifName.size()) <
         0) {
-      XLOGF(
+      CTRAN_LOG(
           ERR,
           "Failed to bind socket to interface {}. errno={}, {}",
           ifName.c_str(),
@@ -484,7 +486,7 @@ int AbortableServerSocket::bind(
             SO_REUSEADDR | SO_REUSEPORT,
             &reuse,
             sizeof(reuse)) < 0) {
-      XLOGF(
+      CTRAN_LOG(
           ERR,
           "Failed to set SO_REUSEADDR | SO_REUSEPORT. errno={}, {}",
           errno,
@@ -498,7 +500,7 @@ int AbortableServerSocket::bind(
   sockaddr_storage sockAddr;
   const auto sockLen = addr.getAddress(&sockAddr);
   if (::bind(fd_, reinterpret_cast<sockaddr*>(&sockAddr), sockLen) < 0) {
-    XLOGF(
+    CTRAN_LOG(
         ERR,
         "Failed to bind socket on {}. errno={}, {}",
         addr.describe(),
@@ -525,7 +527,7 @@ int AbortableServerSocket::bind(
           fd_, IPPROTO_IP, IP_TOS, (char*)&NCCL_SOCKET_TOS_CONFIG, sizeof(int));
     }
     if (setSockRet < 0) {
-      XLOGF(
+      CTRAN_LOG(
           ERR,
           "Failed to set socket TOS. errno={}, {}",
           errno,
@@ -533,7 +535,7 @@ int AbortableServerSocket::bind(
       return errno;
     }
   }
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "AbortableServerSocket is bound on {} via {}, fd={}",
       getListenAddress()->describe(),
@@ -545,7 +547,7 @@ int AbortableServerSocket::bind(
 int AbortableServerSocket::listen() {
   // Listen for incoming connections
   if (::listen(fd_, SOMAXCONN) < 0) {
-    XLOGF(
+    CTRAN_LOG(
         ERR,
         "Failed to listen on socket. errno={}, {}",
         errno,
@@ -553,7 +555,7 @@ int AbortableServerSocket::listen() {
     return errno;
   }
 
-  XLOGF(INFO, "AbortableServerSocket Started listening, fd={}", fd_);
+  CTRAN_LOG(INFO, "AbortableServerSocket Started listening, fd={}", fd_);
   return 0;
 }
 
@@ -573,7 +575,7 @@ AbortableServerSocket::getListenAddress() {
   socklen_t sockLen =
       isV4_ ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
   if (getsockname(fd_, (struct sockaddr*)&sockAddr, &sockLen) == -1) {
-    XLOGF(
+    CTRAN_LOG(
         ERR, "Failed to get socket name. errno={}, {}", errno, strerror(errno));
     return folly::makeUnexpected(errno);
   }
@@ -596,7 +598,7 @@ AbortableServerSocket::acceptAsync() {
        * retried
        */
       ++retryCnt;
-      XLOGF(
+      CTRAN_LOG(
           WARN,
           "Received {} in attempt {}/{}",
           strerror(errno),
@@ -606,7 +608,7 @@ AbortableServerSocket::acceptAsync() {
     }
     if (errno != EAGAIN && errno != EWOULDBLOCK) {
       if (!hasShutDown_) {
-        XLOGF(
+        CTRAN_LOG(
             ERR,
             "Failed to accept connection. errno={}, {}",
             errno,
@@ -614,7 +616,7 @@ AbortableServerSocket::acceptAsync() {
       }
       return folly::makeUnexpected(errno);
     } else {
-      XLOGF(
+      CTRAN_LOG(
           DBG,
           "Received error \"{}\" and will perform a free retry",
           strerror(errno));
@@ -624,7 +626,7 @@ AbortableServerSocket::acceptAsync() {
 
   folly::SocketAddress addr;
   addr.setFromSockaddr((struct sockaddr*)&sockAddr);
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "Accepted a new incoming connection {}, fd={}",
       addr.describe(),
@@ -651,7 +653,7 @@ AbortableServerSocket::acceptSocket() {
 
     if (ret < 0) {
       if (!hasShutDown_) {
-        XLOGF(
+        CTRAN_LOG(
             ERR,
             "poll failed on fd={}. errno={}, {}",
             fd_,
@@ -663,7 +665,7 @@ AbortableServerSocket::acceptSocket() {
     }
 
     if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
-      XLOGF(WARN, "poll returned error events: {}", pfd.revents);
+      CTRAN_LOG(WARN, "poll returned error events: {}", pfd.revents);
       return folly::makeUnexpected(EIO);
     }
   }
@@ -684,13 +686,13 @@ int AbortableServerSocket::shutdown() {
   // shutdown fd_ would fail accept on the listen thread. To avoid misleading
   // error logging at accept failure, mark intentional shutdown
   if (fd_ >= 0) {
-    XLOGF(
+    CTRAN_LOG(
         INFO,
         "AbortableServerSocket is shutting down on {}, fd={}",
         getListenAddress()->describe(),
         fd_);
     if (::shutdown(fd_, SHUT_RDWR) < 0 && errno != ENOTCONN) {
-      XLOGF(
+      CTRAN_LOG(
           WARN,
           "Failed to cleanly shutdown AbortableServerSocket. errno={}, {}",
           errno,

--- a/comms/ctran/bootstrap/AsyncSocket.cc
+++ b/comms/ctran/bootstrap/AsyncSocket.cc
@@ -2,8 +2,9 @@
 
 #include "AsyncSocket.h"
 
-#include <folly/logging/xlog.h>
 #include <cstring>
+
+#include "comms/ctran/utils/CtranLogger.h"
 
 namespace ctran::bootstrap {
 
@@ -56,7 +57,7 @@ void AsyncClientSocket::start(
 void AsyncClientSocket::connectSuccess() noexcept {
   folly::SocketAddress peer;
   sock_->getPeerAddress(&peer);
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "Connected to {}, fd={}",
       peer.describe(),
@@ -66,7 +67,7 @@ void AsyncClientSocket::connectSuccess() noexcept {
 
 void AsyncClientSocket::connectErr(
     const folly::AsyncSocketException& ex) noexcept {
-  XLOGF(ERR, "AsyncClientSocket connect failed: {}", ex.what());
+  CTRAN_LOG(ERR, "AsyncClientSocket connect failed: {}", ex.what());
   cancelTimeout();
   finish(&ex);
 }
@@ -79,7 +80,7 @@ void AsyncClientSocket::writeSuccess() noexcept {
 void AsyncClientSocket::writeErr(
     size_t bytesWritten,
     const folly::AsyncSocketException& ex) noexcept {
-  XLOGF(
+  CTRAN_LOG(
       ERR,
       "AsyncClientSocket write failed after {} bytes: {}",
       bytesWritten,
@@ -89,7 +90,7 @@ void AsyncClientSocket::writeErr(
 }
 
 void AsyncClientSocket::timeoutExpired() noexcept {
-  XLOGF(ERR, "AsyncClientSocket operation timed out");
+  CTRAN_LOG(ERR, "AsyncClientSocket operation timed out");
   auto ex = folly::AsyncSocketException(
       folly::AsyncSocketException::TIMED_OUT, "Operation timed out");
   finish(&ex);
@@ -145,7 +146,7 @@ folly::SemiFuture<folly::SocketAddress> AsyncServerSocket::start(
     server_->listen(1024 /* backlog */);
     server_->startAccepting();
     auto addr = server_->getAddress();
-    XLOGF(
+    CTRAN_LOG(
         INFO,
         "AsyncServerSocket started listening on {}, fd={}",
         addr.describe(),
@@ -176,7 +177,7 @@ folly::SemiFuture<folly::Unit> AsyncServerSocket::stop() {
   evb_.runInEventBaseThread([this, p = std::move(p)]() mutable {
     if (server_) {
       auto addr = server_->getAddress();
-      XLOGF(
+      CTRAN_LOG(
           INFO,
           "AsyncServerSocket is shutting down on {}, fd={}",
           addr.describe(),
@@ -205,7 +206,7 @@ void AsyncServerSocket::connectionAccepted(
   auto sock = folly::AsyncSocket::UniquePtr(new folly::AsyncSocket(&evb_, ns));
   folly::SocketAddress localAddr;
   localAddr.setFromLocalAddress(ns);
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "Accepted a new connection fd={}, local={}, peer={}. Waiting for 1 message to arrive.",
       ns.toFd(),
@@ -230,7 +231,7 @@ void AsyncServerSocket::connectionAccepted(
 }
 
 void AsyncServerSocket::acceptError(const std::exception& ex) noexcept {
-  XLOGF(ERR, "AsyncServerSocket accept failed: {}", ex.what());
+  CTRAN_LOG(ERR, "AsyncServerSocket accept failed: {}", ex.what());
 }
 
 //
@@ -291,7 +292,7 @@ void AsyncServerSocket::OneShotRecv::readEOF() noexcept {
 
 void AsyncServerSocket::OneShotRecv::readErr(
     const folly::AsyncSocketException& ex) noexcept {
-  XLOGF(ERR, "AsyncServerSocket read error: {}", ex.what());
+  CTRAN_LOG(ERR, "AsyncServerSocket read error: {}", ex.what());
   cancelTimeout();
   closeNow();
 }
@@ -305,7 +306,7 @@ void AsyncServerSocket::OneShotRecv::closeNow() {
 }
 
 void AsyncServerSocket::OneShotRecv::timeoutExpired() noexcept {
-  XLOGF(ERR, "AsyncServerSocket receive operation timed out");
+  CTRAN_LOG(ERR, "AsyncServerSocket receive operation timed out");
   closeNow();
 }
 

--- a/comms/ctran/bootstrap/ISocket.h
+++ b/comms/ctran/bootstrap/ISocket.h
@@ -13,7 +13,6 @@
 #include <string>
 
 #include <folly/ScopeGuard.h>
-#include <folly/logging/xlog.h>
 
 namespace ctran::bootstrap {
 

--- a/comms/ctran/bootstrap/Socket.cc
+++ b/comms/ctran/bootstrap/Socket.cc
@@ -12,8 +12,8 @@
 #include <vector>
 
 #include <folly/ScopeGuard.h>
-#include <folly/logging/xlog.h>
 #include "comms/ctran/bootstrap/NcclSocketNameFilter.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/Exception.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -37,7 +37,7 @@ folly::SocketAddress getSocketAdddress(int fd) {
   if (::getsockname(fd, (struct sockaddr*)&localAddr, &localLen) == 0) {
     sa.setFromSockaddr((struct sockaddr*)&localAddr, localLen);
   } else {
-    XLOGF(
+    CTRAN_LOG(
         WARN,
         "Failed to get local socket address after connect for fd={}. errno={}, {}",
         fd,
@@ -56,7 +56,7 @@ folly::Expected<folly::IPAddress, int> getInterfaceAddress(
     std::string* resolvedIfName) {
   struct ifaddrs* ifaddrs = nullptr;
 
-  XLOGF(
+  CTRAN_LOG(
       DBG,
       "getInterfaceAddress called with ifName=\"{}\" addrPrefix=\"{}\" preferV6={}",
       ifName,
@@ -75,30 +75,30 @@ folly::Expected<folly::IPAddress, int> getInterfaceAddress(
   std::vector<std::pair<folly::IPAddress, std::string>> addrs;
   for (auto ifa = ifaddrs; ifa != nullptr; ifa = ifa->ifa_next) {
     if (ifa->ifa_addr == nullptr) {
-      XLOGF(DBG, "  skip {}: no address", ifa->ifa_name);
+      CTRAN_LOG(DBG, "  skip {}: no address", ifa->ifa_name);
       continue;
     }
     if (!matchesIfName(ifNameFilter, ifa->ifa_name)) {
-      XLOGF(DBG, "  skip {}: ifname filter mismatch", ifa->ifa_name);
+      CTRAN_LOG(DBG, "  skip {}: ifname filter mismatch", ifa->ifa_name);
       continue;
     }
     if (ifa->ifa_flags & IFA_F_DEPRECATED) {
-      XLOGF(DBG, "  skip {}: deprecated address", ifa->ifa_name);
+      CTRAN_LOG(DBG, "  skip {}: deprecated address", ifa->ifa_name);
       continue;
     }
 
     auto addr = folly::IPAddress::tryFromSockAddr(ifa->ifa_addr);
     if (addr.hasError()) {
-      XLOGF(DBG, "  skip {}: failed to parse address", ifa->ifa_name);
+      CTRAN_LOG(DBG, "  skip {}: failed to parse address", ifa->ifa_name);
       continue;
     }
     if (addr->isLinkLocal()) {
-      XLOGF(
+      CTRAN_LOG(
           DBG, "  skip {}: link-local address {}", ifa->ifa_name, addr->str());
       continue;
     }
     if (!addrPrefix.empty() && addr->str().find(addrPrefix) != 0) {
-      XLOGF(
+      CTRAN_LOG(
           DBG,
           "  skip {}: address {} does not match prefix \"{}\"",
           ifa->ifa_name,
@@ -106,12 +106,12 @@ folly::Expected<folly::IPAddress, int> getInterfaceAddress(
           addrPrefix);
       continue;
     }
-    XLOGF(DBG, "  accept {}: {}", ifa->ifa_name, addr->str());
+    CTRAN_LOG(DBG, "  accept {}: {}", ifa->ifa_name, addr->str());
     addrs.emplace_back(addr.value(), std::string(ifa->ifa_name));
   }
 
   if (addrs.empty()) {
-    XLOGF(
+    CTRAN_LOG(
         WARN,
         "getInterfaceAddress: no matching address found for ifName=\"{}\" addrPrefix=\"{}\" preferV6={}",
         ifName,
@@ -198,11 +198,11 @@ int Socket::connect(
   const auto sockLen = addr.getAddress(&sockAddr);
   size_t retryCount{0};
   do {
-    XLOGF(DBG, "Connecting to {} via {}", addr.describe(), ifName);
+    CTRAN_LOG(DBG, "Connecting to {} via {}", addr.describe(), ifName);
     if (::connect(fd_, (const struct sockaddr*)&sockAddr, sockLen) == 0) {
       break;
     }
-    XLOGF(
+    CTRAN_LOG(
         WARN,
         "Failed to connect to {} via {}. errno={}, {}",
         addr.describe(),
@@ -212,20 +212,21 @@ int Socket::connect(
 
     // Break the loop on non-retryable errors
     if (!shouldRetry(errno)) {
-      XLOGF(ERR, "Connection attempt terminating on non-retryable error");
+      CTRAN_LOG(ERR, "Connection attempt terminating on non-retryable error");
       break;
     }
 
     // Break the loop if we've exhausted all retries
     if (retryCount >= numRetries) {
-      XLOGF(ERR, "Connection attempt terminating as we exhausted all retries");
+      CTRAN_LOG(
+          ERR, "Connection attempt terminating as we exhausted all retries");
       close();
       return errno;
     }
 
     // Retry after a delay
     const auto retryTimeout = retryCount * timeout;
-    XLOGF(INFO, "Will retry connecting in {}ms", retryTimeout.count());
+    CTRAN_LOG(INFO, "Will retry connecting in {}ms", retryTimeout.count());
     // Wait for a bit before retrying
     retryCount++;
     std::this_thread::sleep_for(retryCount * timeout);
@@ -234,7 +235,8 @@ int Socket::connect(
   peerAddr_ = addr;
   localAddr_ = getSocketAdddress(fd_);
 
-  XLOGF(INFO, "Connected to {} via {}, fd={}", addr.describe(), ifName, fd_);
+  CTRAN_LOG(
+      INFO, "Connected to {} via {}, fd={}", addr.describe(), ifName, fd_);
   return 0;
 }
 
@@ -289,7 +291,7 @@ int Socket::send(const void* buf, const size_t len) {
     int sent = ::send(fd_, (uint8_t*)buf + totalSent, len - totalSent, 0);
     if (sent == -1 &&
         (errno != EINTR && errno != EWOULDBLOCK && errno != EAGAIN)) {
-      XLOGF(
+      CTRAN_LOG(
           ERR,
           "Failed to write to socket fd={}. errno={}, {}",
           fd_,
@@ -311,7 +313,7 @@ int Socket::recv(void* buf, const size_t len) {
     int rcvd = ::recv(fd_, (uint8_t*)buf + totalRecvd, len - totalRecvd, 0);
     if (rcvd == -1 &&
         (errno != EINTR && errno != EWOULDBLOCK && errno != EAGAIN)) {
-      XLOGF(
+      CTRAN_LOG(
           ERR,
           "Failed to read from socket fd={}. errno={}, {}",
           fd_,
@@ -331,7 +333,7 @@ int Socket::recvAsync(void* buf, const size_t len) {
   int rcvd = ::recv(fd_, (uint8_t*)buf, len, 0);
   if (rcvd == -1 &&
       (errno != EINTR && errno != EWOULDBLOCK && errno != EAGAIN)) {
-    XLOGF(
+    CTRAN_LOG(
         ERR,
         "Failed to read from socket fd={}. errno={}, {}",
         fd_,
@@ -339,7 +341,7 @@ int Socket::recvAsync(void* buf, const size_t len) {
         strerror(errno));
     return -1;
   } else if (rcvd == 0) {
-    XLOGF(WARN, "Connection closed by peer");
+    CTRAN_LOG(WARN, "Connection closed by peer");
   }
   return rcvd;
 }
@@ -376,11 +378,12 @@ int ServerSocket::bind(
     const folly::SocketAddress& addr,
     const std::string& ifName,
     bool reusePort) {
-  XLOGF(INFO, "Binding ServerSocket to {} via {}", addr.describe(), ifName);
+  CTRAN_LOG(INFO, "Binding ServerSocket to {} via {}", addr.describe(), ifName);
   // Create socket
   fd_ = ::socket(addr.getFamily(), SOCK_STREAM, 0);
   if (fd_ < 0) {
-    XLOGF(ERR, "Failed to create socket. errno={}, {}", errno, strerror(errno));
+    CTRAN_LOG(
+        ERR, "Failed to create socket. errno={}, {}", errno, strerror(errno));
     return errno;
   }
 
@@ -389,7 +392,7 @@ int ServerSocket::bind(
     if (setsockopt(
             fd_, SOL_SOCKET, SO_BINDTODEVICE, ifName.c_str(), ifName.size()) <
         0) {
-      XLOGF(
+      CTRAN_LOG(
           ERR,
           "Failed to bind socket to interface {}. errno={}, {}",
           ifName.c_str(),
@@ -408,7 +411,7 @@ int ServerSocket::bind(
             SO_REUSEADDR | SO_REUSEPORT,
             &reuse,
             sizeof(reuse)) < 0) {
-      XLOGF(
+      CTRAN_LOG(
           ERR,
           "Failed to set SO_REUSEADDR | SO_REUSEPORT. errno={}, {}",
           errno,
@@ -422,7 +425,7 @@ int ServerSocket::bind(
   sockaddr_storage sockAddr;
   const auto sockLen = addr.getAddress(&sockAddr);
   if (::bind(fd_, reinterpret_cast<sockaddr*>(&sockAddr), sockLen) < 0) {
-    XLOGF(
+    CTRAN_LOG(
         ERR,
         "Failed to bind socket on {}. errno={}, {}",
         addr.describe(),
@@ -449,7 +452,7 @@ int ServerSocket::bind(
           fd_, IPPROTO_IP, IP_TOS, (char*)&NCCL_SOCKET_TOS_CONFIG, sizeof(int));
     }
     if (setSockRet < 0) {
-      XLOGF(
+      CTRAN_LOG(
           ERR,
           "Failed to set socket TOS. errno={}, {}",
           errno,
@@ -457,7 +460,7 @@ int ServerSocket::bind(
       return errno;
     }
   }
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "ServerSocket is bound on {} via {}, fd={}",
       getListenAddress()->describe(),
@@ -469,7 +472,7 @@ int ServerSocket::bind(
 int ServerSocket::listen() {
   // Listen for incoming connections
   if (::listen(fd_, SOMAXCONN) < 0) {
-    XLOGF(
+    CTRAN_LOG(
         ERR,
         "Failed to listen on socket. errno={}, {}",
         errno,
@@ -477,7 +480,7 @@ int ServerSocket::listen() {
     return errno;
   }
 
-  XLOGF(INFO, "ServerSocket Started listening, fd={}", fd_);
+  CTRAN_LOG(INFO, "ServerSocket Started listening, fd={}", fd_);
   return 0;
 }
 
@@ -496,7 +499,7 @@ folly::Expected<folly::SocketAddress, int> ServerSocket::getListenAddress() {
   socklen_t sockLen =
       isV4_ ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
   if (getsockname(fd_, (struct sockaddr*)&sockAddr, &sockLen) == -1) {
-    XLOGF(
+    CTRAN_LOG(
         ERR, "Failed to get socket name. errno={}, {}", errno, strerror(errno));
     return folly::makeUnexpected(errno);
   }
@@ -507,7 +510,11 @@ folly::Expected<folly::SocketAddress, int> ServerSocket::getListenAddress() {
 
 folly::Expected<Socket, int> ServerSocket::accept(bool async) {
   int retryCnt = 0;
-  XCHECK(acceptRetryCnt_ > 0) << "accept retry count must be positive";
+  if (acceptRetryCnt_ <= 0) {
+    CTRAN_LOG(
+        FATAL,
+        "Check failed: acceptRetryCnt_ > 0 accept retry count must be positive");
+  }
   sockaddr_storage sockAddr;
   socklen_t sockLen =
       isV4_ ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
@@ -523,7 +530,7 @@ folly::Expected<Socket, int> ServerSocket::accept(bool async) {
        * retried
        */
       ++retryCnt;
-      XLOGF(
+      CTRAN_LOG(
           WARN,
           "Received {} in attempt {}/{}",
           strerror(errno),
@@ -533,7 +540,7 @@ folly::Expected<Socket, int> ServerSocket::accept(bool async) {
     }
     if (errno != EAGAIN && errno != EWOULDBLOCK) {
       if (!hasShutDown_) {
-        XLOGF(
+        CTRAN_LOG(
             ERR,
             "Failed to accept connection. errno={}, {}",
             errno,
@@ -541,12 +548,13 @@ folly::Expected<Socket, int> ServerSocket::accept(bool async) {
       }
       return folly::makeUnexpected(errno);
     } else {
-      XLOGF(INFO, "Received {} and will perform a free retry", strerror(errno));
+      CTRAN_LOG(
+          INFO, "Received {} and will perform a free retry", strerror(errno));
     }
   }
   folly::SocketAddress addr;
   addr.setFromSockaddr((struct sockaddr*)&sockAddr);
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "Accepted a new incoming connection {}, fd={}",
       addr.describe(),
@@ -569,7 +577,7 @@ int ServerSocket::shutdown() {
   // error logging at accept failure, mark intentional shutdown
   hasShutDown_ = true;
   if (fd_ >= 0) {
-    XLOGF(
+    CTRAN_LOG(
         INFO,
         "ServerSocket is shutting down on {}, fd={}",
         getListenAddress()->describe(),

--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -1,13 +1,13 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <folly/String.h>
-#include <folly/logging/xlog.h>
 #include <string>
 
 #include "CommStateX.h"
 #include "comms/ctran/commstate/Topology.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 namespace ncclx {
@@ -310,7 +310,7 @@ void CommStateX::setNvlFabricTopos(
       state.cliqueRankToRank = cliqueRanks_.at(state.cliqueIndex);
     }
     myNvlFabricRankState_ = nvlFabricRankStates_.at(rank_);
-    XLOGF(
+    CTRAN_LOG(
         INFO,
         "CommStateX: effectiveVCliqueSize={} override NVL fabric topology",
         effectiveVCliqueSize);
@@ -406,7 +406,7 @@ void CommStateX::setRankStatesTopologies(
     state.nLocalRanks = state.localRankToRanks.size();
   }
 
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "CommStateX: set rankTopology with {}",
       topoNameMap[NCCL_COMM_STATE_DEBUG_TOPO]);

--- a/comms/ctran/ibverbx/IbvAh.cc
+++ b/comms/ctran/ibverbx/IbvAh.cc
@@ -2,8 +2,8 @@
 
 #include "comms/ctran/ibverbx/IbvAh.h"
 
-#include <folly/logging/xlog.h>
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
+#include "comms/ctran/utils/CtranLogger.h"
 
 namespace ibverbx {
 
@@ -28,7 +28,7 @@ IbvAh::~IbvAh() {
   if (ah_) {
     int rc = ibvSymbols.ibv_internal_destroy_ah(ah_);
     if (rc != 0) {
-      XLOGF(ERR, "Failed to destroy AH rc: {}, {}", rc, strerror(errno));
+      CTRAN_LOG(ERR, "Failed to destroy AH rc: {}, {}", rc, strerror(errno));
     }
   }
 }

--- a/comms/ctran/ibverbx/IbvCq.cc
+++ b/comms/ctran/ibverbx/IbvCq.cc
@@ -5,11 +5,11 @@
 #include <utility>
 
 #include <fmt/format.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/ctran/ibverbx/IbvCq.h"
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
 #include "comms/ctran/ibverbx/Mlx5dv.h"
+#include "comms/ctran/utils/CtranLogger.h"
 
 namespace {
 
@@ -47,7 +47,7 @@ IbvCq::~IbvCq() {
   if (cq_) {
     int rc = ibvSymbols.ibv_internal_destroy_cq(cq_);
     if (rc != 0) {
-      XLOGF(ERR, "Failed to destroy cq rc: {}, {}", rc, strerror(errno));
+      CTRAN_LOG(ERR, "Failed to destroy cq rc: {}, {}", rc, strerror(errno));
     }
   }
 }
@@ -114,7 +114,7 @@ folly::Expected<struct device_cq, Error> IbvCq::getDeviceCq() const noexcept {
           fmt::format(
               "Mapping CQ to GPU buffer failed: {}", cudaGetErrorString(ret))));
     }
-    XLOGF(
+    CTRAN_LOG(
         INFO,
         "Mapped CQ buffer host={} device={} ncqes={} cq_dbrec={}",
         fmt::ptr(mlx5_cq.buf),

--- a/comms/ctran/ibverbx/IbvDevice.cc
+++ b/comms/ctran/ibverbx/IbvDevice.cc
@@ -2,6 +2,7 @@
 
 #include "comms/ctran/ibverbx/IbvDevice.h"
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
+#include "comms/ctran/utils/CtranLogger.h"
 
 namespace ibverbx {
 
@@ -45,7 +46,7 @@ bool mlx5dvDmaBufDataDirectLinkCapable(
   ibv_pd* pd = nullptr;
   pd = ibvSymbols.ibv_internal_alloc_pd(context);
   if (!pd) {
-    XLOG(ERR) << "ibv_alloc_pd failed: " << folly::errnoStr(errno);
+    CTRAN_LOG(ERR, "ibv_alloc_pd failed: {}", folly::errnoStr(errno));
     return false;
   }
 
@@ -66,7 +67,7 @@ bool mlx5dvDmaBufDataDirectLinkCapable(
   // supported (EBADF otherwise)
   dev_fail |= (errno == EOPNOTSUPP) || (errno == EPROTONOSUPPORT);
   if (ibvSymbols.ibv_internal_dealloc_pd(pd) != 0) {
-    XLOGF(
+    CTRAN_LOG(
         WARN,
         "ibv_dealloc_pd failed: {} DMA-BUF support status: {}",
         folly::errnoStr(errno),
@@ -74,7 +75,7 @@ bool mlx5dvDmaBufDataDirectLinkCapable(
     return false;
   }
   if (dev_fail) {
-    XLOGF(
+    CTRAN_LOG(
         INFO,
         "MLX5DV Kernel DMA-BUF is not supported on device {}",
         device->name);
@@ -185,13 +186,13 @@ IbvDevice::IbvDevice(ibv_device* ibvDevice, int port, bool dataDirect)
   port_ = port;
   context_ = ibvSymbols.ibv_internal_open_device(device_);
   if (!context_) {
-    XLOGF(ERR, "Failed to open device {}", device_->name);
+    CTRAN_LOG(ERR, "Failed to open device {}", device_->name);
     throw std::runtime_error(
         fmt::format("Failed to open device {}", device_->name));
   }
   if (dataDirect && (mlx5dvDmaBufDataDirectLinkCapable(device_, context_))) {
     dataDirect_ = true;
-    XLOGF(
+    CTRAN_LOG(
         INFO,
         "NET/IB: Data Direct DMA Interface is detected for device: {} dataDirect: {}",
         device_->name,
@@ -203,7 +204,7 @@ IbvDevice::~IbvDevice() {
   if (context_) {
     int rc = ibvSymbols.ibv_internal_close_device(context_);
     if (rc != 0) {
-      XLOGF(
+      CTRAN_LOG(
           WARN,
           "Failed to close device rc: {}, {}. "
           "This is a post-failure warning likely due to an uncleaned RDMA resource on the failure path.",

--- a/comms/ctran/ibverbx/IbvMr.cc
+++ b/comms/ctran/ibverbx/IbvMr.cc
@@ -1,8 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 #include "comms/ctran/ibverbx/IbvMr.h"
 
-#include <folly/logging/xlog.h>
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
+#include "comms/ctran/utils/CtranLogger.h"
 
 namespace ibverbx {
 
@@ -27,7 +27,7 @@ IbvMr::~IbvMr() {
   if (mr_) {
     int rc = ibvSymbols.ibv_internal_dereg_mr(mr_);
     if (rc != 0) {
-      XLOGF(ERR, "Failed to deregister mr rc: {}, {}", rc, strerror(errno));
+      CTRAN_LOG(ERR, "Failed to deregister mr rc: {}, {}", rc, strerror(errno));
     }
   }
 }

--- a/comms/ctran/ibverbx/IbvPd.cc
+++ b/comms/ctran/ibverbx/IbvPd.cc
@@ -3,6 +3,7 @@
 #include "comms/ctran/ibverbx/IbvPd.h"
 #include "comms/ctran/ibverbx/IbvVirtualCq.h"
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
+#include "comms/ctran/utils/CtranLogger.h"
 
 namespace ibverbx {
 
@@ -34,7 +35,7 @@ IbvPd::~IbvPd() {
   if (pd_) {
     int rc = ibvSymbols.ibv_internal_dealloc_pd(pd_);
     if (rc != 0) {
-      XLOGF(
+      CTRAN_LOG(
           WARN,
           "Failed to deallocate pd rc: {}, {}. "
           "This is a post-failure warning likely due to an uncleaned RDMA resource on the failure path.",

--- a/comms/ctran/ibverbx/IbvSrq.cc
+++ b/comms/ctran/ibverbx/IbvSrq.cc
@@ -2,8 +2,8 @@
 
 #include "comms/ctran/ibverbx/IbvSrq.h"
 
-#include <folly/logging/xlog.h>
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
+#include "comms/ctran/utils/CtranLogger.h"
 
 namespace ibverbx {
 
@@ -28,7 +28,7 @@ IbvSrq::~IbvSrq() {
   if (srq_) {
     int rc = ibvSymbols.ibv_internal_destroy_srq(srq_);
     if (rc != 0) {
-      XLOGF(ERR, "Failed to destroy SRQ rc: {}, {}", rc, strerror(errno));
+      CTRAN_LOG(ERR, "Failed to destroy SRQ rc: {}, {}", rc, strerror(errno));
     }
   }
 }

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -13,6 +13,7 @@
 #endif
 #include "comms/ctran/mapper/CtranMapperTypes.h" // @manual=//comms/ctran:mapper_types
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/ctran/utils/ExtUtils.h"
 #include "comms/utils/CudaRAII.h"
@@ -580,7 +581,7 @@ void ctran::RegCache::registerExternalRegMemFn(
     externalRegMemFn_ = std::move(regMem);
     externalDeregMemFn_ = std::move(deregMem);
   } else {
-    XLOGF(
+    CTRAN_LOG(
         WARN,
         "RegCache: registerExternalRegMemFn called with null callback(s), "
         "both regMem and deregMem are required — ignoring");

--- a/comms/ctran/utils/CudaUtils.cc
+++ b/comms/ctran/utils/CudaUtils.cc
@@ -4,7 +4,6 @@
 #include <cuda_runtime.h>
 #include <folly/Singleton.h>
 #include <folly/SocketAddress.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/ctran/utils/CudaUtils.h"
 


### PR DESCRIPTION
Summary:
Replace the two Folly log calls in `IbvCq` with `CTRAN_LOG` and switch
its direct logging dependency to `ctran_logger`. Severities, format strings,
arguments, and control flow remain unchanged.

Differential Revision: D115370793


