### PR TITLE
Migrate QP logs

### DIFF
--- a/comms/ctran/CMakeLists.txt
+++ b/comms/ctran/CMakeLists.txt
@@ -36,7 +36,9 @@ add_library(ctran OBJECT
 )
 
 target_compile_features(ctran PRIVATE cxx_std_20)
-target_compile_definitions(ctran PRIVATE
+# CTRAN public headers expose the logger, so consumers need the same spdlog
+# configuration when compiling those headers.
+target_compile_definitions(ctran PUBLIC
     SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO
     SPDLOG_FMT_EXTERNAL
 )

--- a/comms/ctran/ibverbx/IbvQp.cc
+++ b/comms/ctran/ibverbx/IbvQp.cc
@@ -4,12 +4,12 @@
 #include <cuda_runtime.h>
 #include <fmt/format.h>
 #include <folly/json.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/ctran/ibverbx/IbvQp.h"
 #include "comms/ctran/ibverbx/Ibvcore.h"
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
 #include "comms/ctran/ibverbx/Mlx5dv.h"
+#include "comms/ctran/utils/CtranLogger.h"
 
 namespace ibverbx {
 
@@ -22,7 +22,7 @@ IbvQp::~IbvQp() {
   if (qp_) {
     int rc = ibvSymbols.ibv_internal_destroy_qp(qp_);
     if (rc != 0) {
-      XLOGF(ERR, "Failed to destroy qp rc: {}, {}", rc, strerror(errno));
+      CTRAN_LOG(ERR, "Failed to destroy qp rc: {}, {}", rc, strerror(errno));
     }
   }
 }
@@ -79,7 +79,7 @@ void IbvQp::logInfo() const {
   auto maybeQpAttrPair = queryQp(IBV_QP_STATE | IBV_QP_CAP | IBV_QP_PKEY_INDEX);
   if (maybeQpAttrPair.hasValue()) {
     auto [qpAttr, initAttr] = maybeQpAttrPair.value();
-    XLOGF(
+    CTRAN_LOG(
         INFO,
         "QP details: qp_num={}, qp_ptr={}, context={}, pd={}, state info: state={}, max_send_wr={}, max_recv_wr={}, max_send_sge={}, max_recv_sge={}, pkey_index={}",
         qp_->qp_num,
@@ -93,7 +93,7 @@ void IbvQp::logInfo() const {
         qpAttr.cap.max_recv_sge,
         qpAttr.pkey_index);
   } else {
-    XLOGF(
+    CTRAN_LOG(
         ERR,
         "QP details: qp_num={}, qp_ptr={}, context={}, pd={}, Failed to query local QP state: errno={} ({})",
         qp_->qp_num,
@@ -169,7 +169,7 @@ folly::Expected<struct device_qp, Error> IbvQp::getDeviceQp(
               "Mapping QP WQE to GPU buffer failed: {}",
               cudaGetErrorString(ret))));
     }
-    XLOGF(
+    CTRAN_LOG(
         INFO,
         "Mapped QP work queue host={} device={} wqe_cnt={} stride={}",
         fmt::ptr(mlx5_qp.sq.buf),
@@ -194,7 +194,7 @@ folly::Expected<struct device_qp, Error> IbvQp::getDeviceQp(
               "Mapping QP DBREC to GPU buffer failed: {}",
               cudaGetErrorString(ret))));
     }
-    XLOGF(
+    CTRAN_LOG(
         INFO,
         "Mapped QP doorbell host={} device={}",
         fmt::ptr(mlx5_qp.dbrec),
@@ -237,7 +237,7 @@ folly::Expected<struct device_qp, Error> IbvQp::getDeviceQp(
               "Mapping BlueFlame register to GPU buffer failed: {}",
               cudaGetErrorString(ret))));
     }
-    XLOGF(
+    CTRAN_LOG(
         INFO,
         "Mapped BlueFlame host={} device={} size={}",
         fmt::ptr(mlx5_qp.bf.reg),

--- a/comms/ctran/ibverbx/IbvVirtualQp.h
+++ b/comms/ctran/ibverbx/IbvVirtualQp.h
@@ -13,6 +13,7 @@
 #include "comms/ctran/ibverbx/IbvQp.h"
 #include "comms/ctran/ibverbx/IbvVirtualWr.h"
 #include "comms/ctran/ibverbx/Ibvcore.h"
+#include "comms/ctran/utils/CtranLogger.h"
 
 namespace ibverbx {
 
@@ -874,7 +875,7 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::updateWrState(
   // First error wins
   if (wr->aggregatedStatus == IBV_WC_SUCCESS && status != IBV_WC_SUCCESS) {
     wr->aggregatedStatus = status;
-    XLOGF(
+    CTRAN_LOG(
         ERR,
         "[Ibverbx] Physical WC error: status={}, WR internalId={}",
         static_cast<int>(status),

--- a/comms/prims/CMakeLists.txt
+++ b/comms/prims/CMakeLists.txt
@@ -67,14 +67,14 @@ target_include_directories(prims PRIVATE
 # top-level CMakeLists.txt.)
 target_compile_definitions(prims PRIVATE ENABLE_PRIMS=1)
 
-# spdlog config for transport/rdma/NicDiscovery.cc (the only spdlog consumer in
-# prims; no prims header includes spdlog). Consume spdlog header-only:
-# SPDLOG_FMT_EXTERNAL uses the build's external fmt (not spdlog's bundled copy,
-# an ODR hazard), while NOT defining SPDLOG_COMPILED_LIB inlines all spdlog code
-# into NicDiscovery.o, so no libspdlog.a is linked. This sidesteps the static-
-# archive ordering trap that otherwise left compiled-lib symbols (e.g.
-# spdlog::logger::err_handler_) undefined in the shared module at dlopen.
-target_compile_definitions(prims PRIVATE SPDLOG_FMT_EXTERNAL)
+# Some prims translation units include CTRAN public headers that use spdlog.
+# Keep their active level consistent with the CTRAN target. Consume spdlog
+# header-only with the build's external fmt: leaving SPDLOG_COMPILED_LIB unset
+# avoids the static-archive ordering failure at module load.
+target_compile_definitions(prims PRIVATE
+    SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO
+    SPDLOG_FMT_EXTERNAL
+)
 
 # Third-party link deps every consumer of the prims transports needs, declared
 # here so they propagate automatically to any target that links the `prims`


### PR DESCRIPTION
Summary:
Replace the six `IbvQp` and one `IbvVirtualQp` Folly log calls with
`CTRAN_LOG`, preserving severities, format strings, arguments, and control
flow. Add direct `ctran_logger` dependencies to both targets.

The migrated public header exposes `CtranLogger.h` to CMake consumers. Apply
the same spdlog active-level and external-fmt configuration to the CTRAN,
MCCL, and prims object targets and export it through the installed CTRAN and
MCCL targets. This keeps every translation unit on the same macro contract
while retaining header-only spdlog linkage.

Retain the existing Folly logging exports because these public headers still
use `XCHECK_NE` and `CHECK*`; migrating those fatal checks requires separate
behavioral proof and is intentionally outside this mechanical log-call change.

Reviewed By: shr

Differential Revision: D115371282


