### PR TITLE
Initialize NCCLX spdlog logging (#3537)

### DIFF
--- a/comms/ctran/backends/ib/ibutils.cc
+++ b/comms/ctran/backends/ib/ibutils.cc
@@ -12,6 +12,7 @@
 #include "comms/ctran/backends/ib/IbvWrap.h"
 #include "comms/ctran/backends/ib/ibutils.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
@@ -111,9 +112,9 @@ void IbUtils::timeoutHandler(
     std::string errorMessage = fmt::format(
         "Link down timeout reached for {} ({} ms).", devName, duration.count());
     CERR(commSystemError, "{}", errorMessage);
-    XLOGF(
+    CTRAN_LOG(
         WARN,
-        "ctranCommSetAsyncError: error comm NULL sets state %d",
+        "ctranCommSetAsyncError: error comm NULL sets state {}",
         commSystemError);
 
     ibutils->setLinkFlapState(
@@ -234,9 +235,9 @@ commResult_t IbUtils::triageIbAsyncEvents(
       CERR(commSystemError, "{}", msg);
       // preserve baseline functionality by not sending async error
       if (NCCL_IB_ASYNC_EVENT_LOOP == NCCL_IB_ASYNC_EVENT_LOOP::ctran) {
-        XLOGF(
+        CTRAN_LOG(
             WARN,
-            "ctranCommSetAsyncError: error comm NULL sets state %d",
+            "ctranCommSetAsyncError: error comm NULL sets state {}",
             commSystemError);
       }
       break;

--- a/comms/ctran/ibverbx/IbverbxSymbols.cc
+++ b/comms/ctran/ibverbx/IbverbxSymbols.cc
@@ -4,8 +4,9 @@
 
 #include <dlfcn.h>
 #include <folly/ScopeGuard.h>
-#include <folly/logging/xlog.h>
 #include <folly/synchronization/CallOnce.h>
+
+#include "comms/ctran/utils/CtranLogger.h"
 
 namespace ibverbx {
 
@@ -562,7 +563,7 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
   if (!ibvhandle) {
     ibvhandle = dlopen("libibverbs.so.1", RTLD_NOW);
     if (!ibvhandle) {
-      XLOG(ERR) << "Failed to open libibverbs.so.1";
+      CTRAN_LOG(ERR, "Failed to open libibverbs.so.1");
       return 1;
     }
   }
@@ -572,21 +573,26 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
   if (!mlx5dvhandle) {
     mlx5dvhandle = dlopen("libmlx5.so.1", RTLD_NOW);
     if (!mlx5dvhandle) {
-      XLOG(WARN)
-          << "Failed to open libmlx5.so[.1]. Advance features like CX-8 Direct-NIC will be disabled.";
+      CTRAN_LOG(
+          WARN,
+          "Failed to open libmlx5.so[.1]. Advance features like CX-8 Direct-NIC will be disabled.");
     }
   }
 
-#define LOAD_SYM(handle, symbol, funcptr, version)                            \
-  {                                                                           \
-    cast = (void**)&funcptr;                                                  \
-    tmp = dlvsym(handle, symbol, version);                                    \
-    if (tmp == nullptr) {                                                     \
-      XLOG(ERR) << fmt::format(                                               \
-          "dlvsym failed on {} - {} version {}", symbol, dlerror(), version); \
-      return 1;                                                               \
-    }                                                                         \
-    *cast = tmp;                                                              \
+#define LOAD_SYM(handle, symbol, funcptr, version) \
+  {                                                \
+    cast = (void**)&funcptr;                       \
+    tmp = dlvsym(handle, symbol, version);         \
+    if (tmp == nullptr) {                          \
+      CTRAN_LOG(                                   \
+          ERR,                                     \
+          "dlvsym failed on {} - {} version {}",   \
+          symbol,                                  \
+          dlerror(),                               \
+          version);                                \
+      return 1;                                    \
+    }                                              \
+    *cast = tmp;                                   \
   }
 
 #define LOAD_SYM_WARN_ONLY(handle, symbol, funcptr, version) \
@@ -594,7 +600,8 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
     cast = (void**)&funcptr;                                 \
     tmp = dlvsym(handle, symbol, version);                   \
     if (tmp == nullptr) {                                    \
-      XLOG(WARN) << fmt::format(                             \
+      CTRAN_LOG(                                             \
+          WARN,                                              \
           "dlvsym failed on {} - {} version {}, set null",   \
           symbol,                                            \
           dlerror(),                                         \
@@ -615,7 +622,8 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
     tmp = dlsym(handle, symbol);                           \
     if (tmp == nullptr) {                                  \
       const char* dlErr = dlerror();                       \
-      XLOG(WARN) << fmt::format(                           \
+      CTRAN_LOG(                                           \
+          WARN,                                            \
           "dlsym failed on {} - {}, set null",             \
           symbol,                                          \
           dlErr ? dlErr : "unknown");                      \

--- a/comms/ctran/utils/AsyncError.h
+++ b/comms/ctran/utils/AsyncError.h
@@ -3,23 +3,22 @@
 #pragma once
 
 #include <folly/Synchronized.h>
-#include <folly/logging/xlog.h>
 
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/Exception.h"
 
 namespace ctran::utils {
-// NOTE: use XLOGF instead of CLOGF to avoid dependency on logging util. It
-// should use the same format (e.g., CTRAN ERROR prefix) following the logging
-// initialized in the caller file.
+// Use the named CTRAN logger so these header macros do not inherit the caller's
+// logging category.
 #define CTRAN_ASYNC_ERR_HANDLE_IMPL(asyncErr, e)                    \
   do {                                                              \
     const auto errLog = fmt::format(                                \
         "{}: Encountered exception: {}", asyncErr->desc, e.what()); \
     if (asyncErr->abortOnError) {                                   \
       /* FATAL will abort with error stack */                       \
-      XLOGF(FATAL, "{}; aborting", errLog);                         \
+      CTRAN_LOG(FATAL, "{}; aborting", errLog);                     \
     } else {                                                        \
-      XLOGF(ERR, "{}; setting async error flag", errLog);           \
+      CTRAN_LOG(ERR, "{}; setting async error flag", errLog);       \
       /* TODO: expose also error stack to user */                   \
       asyncErr->setAsyncException(e);                               \
     }                                                               \
@@ -40,7 +39,7 @@ namespace ctran::utils {
   do {                                                                        \
     CTRAN_ASYNC_ERR_HANDLE_IMPL(comm->getAsyncError(), e);                    \
     if (comm->abortEnabled()) {                                               \
-      XLOGF(                                                                  \
+      CTRAN_LOG(                                                              \
           ERR,                                                                \
           "Fault tolerance enabled; marking communicator aborted "            \
           "(opType={}, opCount={}) on rank {} commHash {:x}",                 \

--- a/comms/ncclx/meta/NcclxLogger.h
+++ b/comms/ncclx/meta/NcclxLogger.h
@@ -1,0 +1,16 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <string_view>
+
+#include "comms/utils/logger/SpdlogLogger.h"
+
+namespace ncclx::logging {
+
+inline constexpr std::string_view kNcclxLoggerName = "comms.ncclx";
+
+} // namespace ncclx::logging
+
+#define NCCLX_LOG(level, ...) \
+  COMMS_LOG_NAMED(::ncclx::logging::kNcclxLoggerName, level, __VA_ARGS__)

--- a/comms/ncclx/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/meta/commstate/FactoryCommStateX.cc
@@ -1,4 +1,7 @@
 #include "meta/commstate/FactoryCommStateX.h"
+
+#include <folly/logging/xlog.h>
+
 #include "checks.h"
 #include "comm.h"
 #include "comms/ctran/CtranComm.h"

--- a/comms/ncclx/meta/logger/tests/LoggingUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggingUT.cc
@@ -14,6 +14,7 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/Logger.h"
 #include "comms/utils/logger/LoggingFormat.h"
+#include "meta/NcclxLogger.h"
 
 #include "debug.h" // @manual
 #include "param.h" // @manual
@@ -134,12 +135,20 @@ TEST_F(NcclLoggerTest, GetLastCommsErrorTest) {
   EXPECT_THAT(lastError, ::testing::HasSubstr(errorMsg2));
   EXPECT_THAT(lastError, ::testing::HasSubstr("NCCL Stack trace:"));
 
+  constexpr std::string_view spdlogErrorMsg = "SPDLOG ERROR MESSAGE";
+  NCCLX_LOG(ERR, "{}", spdlogErrorMsg);
+  meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName)
+      .flush();
+  lastError = meta::comms::logger::getLastCommsError();
+  EXPECT_THAT(lastError, ::testing::HasSubstr(spdlogErrorMsg));
+  EXPECT_THAT(lastError, ::testing::HasSubstr("NCCL Stack trace:"));
+
   // Log info and warn - last error should remain unchanged
   INFO(NCCL_ALL, "Another info");
   WARN("Another warn");
   sleep(1);
   lastError = meta::comms::logger::getLastCommsError();
-  EXPECT_THAT(lastError, ::testing::HasSubstr(errorMsg2));
+  EXPECT_THAT(lastError, ::testing::HasSubstr(spdlogErrorMsg));
 
   finishLogging();
 }
@@ -203,6 +212,11 @@ TEST_F(NcclLoggerTest, WarnLogTest) {
   ncclResetDebugInit();
 
   initLogging();
+  auto& spdlogLogger =
+      meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName);
+  EXPECT_TRUE(spdlogLogger.should_log(spdlog::level::err));
+  EXPECT_TRUE(spdlogLogger.should_log(spdlog::level::warn));
+  EXPECT_FALSE(spdlogLogger.should_log(spdlog::level::info));
   std::string TestStr = "TESTING";
 
   testing::internal::CaptureStdout();
@@ -340,6 +354,7 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
 
   constexpr std::string_view TestStr = "RAW TESTING";
   constexpr std::string_view TestStr2 = "TESTING";
+  constexpr std::string_view SpdlogTestStr = "SPDLOG TESTING";
 
   testing::internal::CaptureStderr();
 
@@ -350,6 +365,14 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
   INFO(NCCL_ALL, "%s", TestStr2.data());
   WARN("%s", TestStr2.data());
   ERR(ncclInternalError, "%s", TestStr2.data());
+
+  NCCLX_LOG(INFO, "{}", SpdlogTestStr);
+  NCCLX_LOG(WARN, "{}", SpdlogTestStr);
+  NCCLX_LOG(ERR, "{}", SpdlogTestStr);
+  auto& spdlogLogger =
+      meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName);
+  EXPECT_EQ(spdlogLogger.usesAsyncLogging(), NCCL_DEBUG_LOGGING_ASYNC);
+  spdlogLogger.flush();
 
   auto stderrOutput = testing::internal::GetCapturedStderr();
 
@@ -363,6 +386,9 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
     EXPECT_THAT(
         fileContents,
         testing::HasSubstr(fmt::format("NCCL {} {}", level, TestStr2)));
+    EXPECT_THAT(
+        fileContents,
+        testing::HasSubstr(fmt::format("NCCL {} {}", level, SpdlogTestStr)));
     if (level != "INFO") {
       // When logging to file, we should also log to stderr for WARN and ERROR
       EXPECT_THAT(
@@ -371,6 +397,9 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
       EXPECT_THAT(
           stderrOutput,
           testing::HasSubstr(fmt::format("NCCL {} {}", level, TestStr2)));
+      EXPECT_THAT(
+          stderrOutput,
+          testing::HasSubstr(fmt::format("NCCL {} {}", level, SpdlogTestStr)));
     }
   }
 }

--- a/comms/ncclx/v2_29/src/misc/param.cc
+++ b/comms/ncclx/v2_29/src/misc/param.cc
@@ -27,8 +27,32 @@
 #include "comms/utils/logger/LoggingFormat.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/InitFolly.h"
+#include "meta/NcclxLogger.h"
 
 #include "cuda_runtime_api.h"
+
+namespace {
+
+spdlog::level::level_enum loggerLevelToSpdlogLevel(
+    meta::comms::logger::LogLevel level) {
+  switch (level) {
+    case meta::comms::logger::LogLevel::NONE:
+    case meta::comms::logger::LogLevel::VERSION:
+      return spdlog::level::off;
+    case meta::comms::logger::LogLevel::ERROR:
+      return spdlog::level::err;
+    case meta::comms::logger::LogLevel::WARN:
+      return spdlog::level::warn;
+    case meta::comms::logger::LogLevel::INFO:
+      return spdlog::level::info;
+    case meta::comms::logger::LogLevel::ABORT:
+    case meta::comms::logger::LogLevel::TRACE:
+      return spdlog::level::debug;
+  }
+  return spdlog::level::off;
+}
+
+} // namespace
 
 const char* userHomeDir() {
   struct passwd *pwUser = getpwuid(getuid());
@@ -185,4 +209,20 @@ void initNcclLogger() {
         cudaGetDevice(&cudaDev);
         return cudaDev;
       }});
+  meta::comms::logger::configureSpdlogLogger(
+      ncclx::logging::kNcclxLoggerName,
+      "NCCL",
+      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
+      []() {
+        int cudaDev = -1;
+        (void)cudaGetDevice(&cudaDev);
+        return cudaDev;
+      },
+      [](std::string_view message) {
+        meta::comms::logger::setLastError(std::string{message}, {});
+      },
+      NCCL_DEBUG_LOGGING_ASYNC);
+  meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName)
+      .set_level(loggerLevelToSpdlogLevel(
+          meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
 }

--- a/comms/ncclx/v2_30/src/misc/param.cc
+++ b/comms/ncclx/v2_30/src/misc/param.cc
@@ -24,8 +24,32 @@
 #include "comms/utils/logger/LoggingFormat.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/InitFolly.h"
+#include "meta/NcclxLogger.h"
 
 #include "cuda_runtime_api.h"
+
+namespace {
+
+spdlog::level::level_enum loggerLevelToSpdlogLevel(
+    meta::comms::logger::LogLevel level) {
+  switch (level) {
+    case meta::comms::logger::LogLevel::NONE:
+    case meta::comms::logger::LogLevel::VERSION:
+      return spdlog::level::off;
+    case meta::comms::logger::LogLevel::ERROR:
+      return spdlog::level::err;
+    case meta::comms::logger::LogLevel::WARN:
+      return spdlog::level::warn;
+    case meta::comms::logger::LogLevel::INFO:
+      return spdlog::level::info;
+    case meta::comms::logger::LogLevel::ABORT:
+    case meta::comms::logger::LogLevel::TRACE:
+      return spdlog::level::debug;
+  }
+  return spdlog::level::off;
+}
+
+} // namespace
 
 const char* userHomeDir() {
   return getenv("HOME");
@@ -148,4 +172,20 @@ void initNcclLogger() {
         cudaGetDevice(&cudaDev);
         return cudaDev;
       }});
+  meta::comms::logger::configureSpdlogLogger(
+      ncclx::logging::kNcclxLoggerName,
+      "NCCL",
+      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
+      []() {
+        int cudaDev = -1;
+        (void)cudaGetDevice(&cudaDev);
+        return cudaDev;
+      },
+      [](std::string_view message) {
+        meta::comms::logger::setLastError(std::string{message}, {});
+      },
+      NCCL_DEBUG_LOGGING_ASYNC);
+  meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName)
+      .set_level(loggerLevelToSpdlogLevel(
+          meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
 }


### PR DESCRIPTION
Summary:

Add a Folly-free named logging facade for NCCLX and initialize it alongside the existing logger in both supported NCCLX versions. Preserve the current NCCL prefix, debug-level thresholds, output file routing, async setting, CUDA device context, and last-error updates so production call sites can migrate independently without changing behavior.

Reviewed By: shr

Differential Revision: D115373831


