### PR TITLE
Migrate NCCLX comm-dump logs (#3539)

### DIFF
--- a/comms/ctran/backends/ib/ibutils.cc
+++ b/comms/ctran/backends/ib/ibutils.cc
@@ -12,6 +12,7 @@
 #include "comms/ctran/backends/ib/IbvWrap.h"
 #include "comms/ctran/backends/ib/ibutils.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
@@ -111,9 +112,9 @@ void IbUtils::timeoutHandler(
     std::string errorMessage = fmt::format(
         "Link down timeout reached for {} ({} ms).", devName, duration.count());
     CERR(commSystemError, "{}", errorMessage);
-    XLOGF(
+    CTRAN_LOG(
         WARN,
-        "ctranCommSetAsyncError: error comm NULL sets state %d",
+        "ctranCommSetAsyncError: error comm NULL sets state {}",
         commSystemError);
 
     ibutils->setLinkFlapState(
@@ -234,9 +235,9 @@ commResult_t IbUtils::triageIbAsyncEvents(
       CERR(commSystemError, "{}", msg);
       // preserve baseline functionality by not sending async error
       if (NCCL_IB_ASYNC_EVENT_LOOP == NCCL_IB_ASYNC_EVENT_LOOP::ctran) {
-        XLOGF(
+        CTRAN_LOG(
             WARN,
-            "ctranCommSetAsyncError: error comm NULL sets state %d",
+            "ctranCommSetAsyncError: error comm NULL sets state {}",
             commSystemError);
       }
       break;

--- a/comms/ctran/ibverbx/IbverbxSymbols.cc
+++ b/comms/ctran/ibverbx/IbverbxSymbols.cc
@@ -4,8 +4,9 @@
 
 #include <dlfcn.h>
 #include <folly/ScopeGuard.h>
-#include <folly/logging/xlog.h>
 #include <folly/synchronization/CallOnce.h>
+
+#include "comms/ctran/utils/CtranLogger.h"
 
 namespace ibverbx {
 
@@ -562,7 +563,7 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
   if (!ibvhandle) {
     ibvhandle = dlopen("libibverbs.so.1", RTLD_NOW);
     if (!ibvhandle) {
-      XLOG(ERR) << "Failed to open libibverbs.so.1";
+      CTRAN_LOG(ERR, "Failed to open libibverbs.so.1");
       return 1;
     }
   }
@@ -572,21 +573,26 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
   if (!mlx5dvhandle) {
     mlx5dvhandle = dlopen("libmlx5.so.1", RTLD_NOW);
     if (!mlx5dvhandle) {
-      XLOG(WARN)
-          << "Failed to open libmlx5.so[.1]. Advance features like CX-8 Direct-NIC will be disabled.";
+      CTRAN_LOG(
+          WARN,
+          "Failed to open libmlx5.so[.1]. Advance features like CX-8 Direct-NIC will be disabled.");
     }
   }
 
-#define LOAD_SYM(handle, symbol, funcptr, version)                            \
-  {                                                                           \
-    cast = (void**)&funcptr;                                                  \
-    tmp = dlvsym(handle, symbol, version);                                    \
-    if (tmp == nullptr) {                                                     \
-      XLOG(ERR) << fmt::format(                                               \
-          "dlvsym failed on {} - {} version {}", symbol, dlerror(), version); \
-      return 1;                                                               \
-    }                                                                         \
-    *cast = tmp;                                                              \
+#define LOAD_SYM(handle, symbol, funcptr, version) \
+  {                                                \
+    cast = (void**)&funcptr;                       \
+    tmp = dlvsym(handle, symbol, version);         \
+    if (tmp == nullptr) {                          \
+      CTRAN_LOG(                                   \
+          ERR,                                     \
+          "dlvsym failed on {} - {} version {}",   \
+          symbol,                                  \
+          dlerror(),                               \
+          version);                                \
+      return 1;                                    \
+    }                                              \
+    *cast = tmp;                                   \
   }
 
 #define LOAD_SYM_WARN_ONLY(handle, symbol, funcptr, version) \
@@ -594,7 +600,8 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
     cast = (void**)&funcptr;                                 \
     tmp = dlvsym(handle, symbol, version);                   \
     if (tmp == nullptr) {                                    \
-      XLOG(WARN) << fmt::format(                             \
+      CTRAN_LOG(                                             \
+          WARN,                                              \
           "dlvsym failed on {} - {} version {}, set null",   \
           symbol,                                            \
           dlerror(),                                         \
@@ -615,7 +622,8 @@ int buildIbvSymbols(IbvSymbols& symbols, const std::string& ibv_path) {
     tmp = dlsym(handle, symbol);                           \
     if (tmp == nullptr) {                                  \
       const char* dlErr = dlerror();                       \
-      XLOG(WARN) << fmt::format(                           \
+      CTRAN_LOG(                                           \
+          WARN,                                            \
           "dlsym failed on {} - {}, set null",             \
           symbol,                                          \
           dlErr ? dlErr : "unknown");                      \

--- a/comms/ctran/utils/AsyncError.h
+++ b/comms/ctran/utils/AsyncError.h
@@ -3,23 +3,22 @@
 #pragma once
 
 #include <folly/Synchronized.h>
-#include <folly/logging/xlog.h>
 
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/Exception.h"
 
 namespace ctran::utils {
-// NOTE: use XLOGF instead of CLOGF to avoid dependency on logging util. It
-// should use the same format (e.g., CTRAN ERROR prefix) following the logging
-// initialized in the caller file.
+// Use the named CTRAN logger so these header macros do not inherit the caller's
+// logging category.
 #define CTRAN_ASYNC_ERR_HANDLE_IMPL(asyncErr, e)                    \
   do {                                                              \
     const auto errLog = fmt::format(                                \
         "{}: Encountered exception: {}", asyncErr->desc, e.what()); \
     if (asyncErr->abortOnError) {                                   \
       /* FATAL will abort with error stack */                       \
-      XLOGF(FATAL, "{}; aborting", errLog);                         \
+      CTRAN_LOG(FATAL, "{}; aborting", errLog);                     \
     } else {                                                        \
-      XLOGF(ERR, "{}; setting async error flag", errLog);           \
+      CTRAN_LOG(ERR, "{}; setting async error flag", errLog);       \
       /* TODO: expose also error stack to user */                   \
       asyncErr->setAsyncException(e);                               \
     }                                                               \
@@ -40,7 +39,7 @@ namespace ctran::utils {
   do {                                                                        \
     CTRAN_ASYNC_ERR_HANDLE_IMPL(comm->getAsyncError(), e);                    \
     if (comm->abortEnabled()) {                                               \
-      XLOGF(                                                                  \
+      CTRAN_LOG(                                                              \
           ERR,                                                                \
           "Fault tolerance enabled; marking communicator aborted "            \
           "(opType={}, opCount={}) on rank {} commHash {:x}",                 \

--- a/comms/ncclx/meta/NcclxLogger.h
+++ b/comms/ncclx/meta/NcclxLogger.h
@@ -1,0 +1,16 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <string_view>
+
+#include "comms/utils/logger/SpdlogLogger.h"
+
+namespace ncclx::logging {
+
+inline constexpr std::string_view kNcclxLoggerName = "comms.ncclx";
+
+} // namespace ncclx::logging
+
+#define NCCLX_LOG(level, ...) \
+  COMMS_LOG_NAMED(::ncclx::logging::kNcclxLoggerName, level, __VA_ARGS__)

--- a/comms/ncclx/meta/NcclxLogger.h
+++ b/comms/ncclx/meta/NcclxLogger.h
@@ -4,6 +4,7 @@
 
 #include <string_view>
 
+#include "comms/utils/logger/RateLimit.h"
 #include "comms/utils/logger/SpdlogLogger.h"
 
 namespace ncclx::logging {
@@ -14,3 +15,28 @@ inline constexpr std::string_view kNcclxLoggerName = "comms.ncclx";
 
 #define NCCLX_LOG(level, ...) \
   COMMS_LOG_NAMED(::ncclx::logging::kNcclxLoggerName, level, __VA_ARGS__)
+
+#define NCCLX_LOG_FIRST_N_IMPL(level, spdlog_level, n, ...)                    \
+  do {                                                                         \
+    auto& _ncclx_logger = ::meta::comms::logger::getSpdlogLogger(              \
+        ::ncclx::logging::kNcclxLoggerName);                                   \
+    if (_ncclx_logger.should_log(spdlog_level) && [&] {                        \
+          struct ncclx_log_first_n_tag {};                                     \
+          return ::meta::comms::logger::firstNExact<ncclx_log_first_n_tag>(n); \
+        }()) {                                                                 \
+      NCCLX_LOG(level, __VA_ARGS__);                                           \
+    }                                                                          \
+  } while (false)
+
+#define NCCLX_LOG_FIRST_N_WARN(n, ...) \
+  NCCLX_LOG_FIRST_N_IMPL(WARN, ::spdlog::level::warn, n, __VA_ARGS__)
+#define NCCLX_LOG_FIRST_N_DBG(n, ...) \
+  NCCLX_LOG_FIRST_N_IMPL(DBG, ::spdlog::level::debug, n, __VA_ARGS__)
+#define NCCLX_LOG_FIRST_N_INFO(n, ...) \
+  NCCLX_LOG_FIRST_N_IMPL(INFO, ::spdlog::level::info, n, __VA_ARGS__)
+#define NCCLX_LOG_FIRST_N_ERR(n, ...) \
+  NCCLX_LOG_FIRST_N_IMPL(ERR, ::spdlog::level::err, n, __VA_ARGS__)
+#define NCCLX_LOG_FIRST_N_CRITICAL(n, ...) \
+  NCCLX_LOG_FIRST_N_IMPL(CRITICAL, ::spdlog::level::critical, n, __VA_ARGS__)
+#define NCCLX_LOG_FIRST_N(level, n, ...) \
+  NCCLX_LOG_FIRST_N_##level(n, __VA_ARGS__)

--- a/comms/ncclx/meta/collectives/quantCollectives.cc
+++ b/comms/ncclx/meta/collectives/quantCollectives.cc
@@ -5,12 +5,12 @@
 #include "info.h"
 #include "nccl.h"
 
+#include "meta/NcclxLogger.h"
 #include "meta/wrapper/DataTypeStrUtils.h"
 #include "meta/wrapper/MetaFactory.h"
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/utils/ExtUtils.h"
-#include "folly/logging/xlog.h"
 
 // For any nccl version that supports ncclReduceScatterQuantize, it should
 // define NCCL_REDUCE_SCATTER_QUANTIZE_SUPPORTED in the nccl.h header file.
@@ -23,7 +23,7 @@ static ncclResult_t validateReduceScatterQuantizeArgs(
     ncclRedOp_t op,
     uint64_t* seedPtr) {
   if (inputType != ncclFloat32) {
-    XLOGF(
+    NCCLX_LOG(
         ERR,
         "ncclReduceScatterQuantize: Unsupported input type: {}, input type must be FP32",
         ncclDatatypeToString(inputType));
@@ -31,7 +31,7 @@ static ncclResult_t validateReduceScatterQuantizeArgs(
   }
 
   if (transportType != ncclBfloat16) {
-    XLOGF(
+    NCCLX_LOG(
         ERR,
         "ncclReduceScatterQuantize: Unsupported transport type: {}, transport type must be BF16",
         ncclDatatypeToString(transportType));
@@ -39,7 +39,7 @@ static ncclResult_t validateReduceScatterQuantizeArgs(
   }
 
   if (op != ncclSum && op != ncclAvg) {
-    XLOGF(
+    NCCLX_LOG(
         ERR,
         "ncclReduceScatterQuantize: Unsupported reduction operation: {}",
         getRedOpStr(op));
@@ -59,11 +59,12 @@ static ncclResult_t validateReduceScatterQuantizeArgs(
         (err == cudaSuccess) && (attr.memoryType == cudaMemoryTypeDevice);
 #endif
     if (!isDevicePtr) {
-      XLOGF(ERR, "ncclReduceScatterQuantize: seedPtr must point to GPU memory");
+      NCCLX_LOG(
+          ERR, "ncclReduceScatterQuantize: seedPtr must point to GPU memory");
       return ncclInvalidArgument;
     }
   } else {
-    XLOGF(ERR, "ncclReduceScatterQuantize: seedPtr is null");
+    NCCLX_LOG(ERR, "ncclReduceScatterQuantize: seedPtr is null");
     return ncclInvalidArgument;
   }
 

--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
@@ -4,6 +4,9 @@
 
 #include <algorithm>
 
+#include <folly/Conv.h>
+#include <folly/Unit.h>
+
 #include "comms/utils/RankUtils.h"
 #include "comms/utils/checks.h"
 #include "comms/utils/colltrace/CollMetadataImpl.h"
@@ -17,6 +20,7 @@
 #include "comms/utils/colltrace/plugins/CommDumpPlugin.h"
 #include "comms/utils/colltrace/plugins/WatchdogPlugin.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/NcclxLogger.h"
 #include "meta/hints/GlobalHints.h"
 #include "meta/wrapper/DataTypeConv.h"
 
@@ -27,7 +31,6 @@
 #include "comms/utils/colltrace/AlgoStats.h"
 
 #include <fmt/core.h>
-#include <folly/logging/xlog.h>
 
 namespace meta::comms::ncclx {
 
@@ -62,12 +65,11 @@ bool isCapturingStream(cudaStream_t stream) {
   auto res = cudaStreamGetCaptureInfo(stream, &status);
 
   if (res != cudaSuccess) {
-    XLOG_FIRST_N(
+    NCCLX_LOG_FIRST_N(
         WARN,
         1,
-        fmt::format(
-            "Internal error: cudaStreamGetCaptureInfo failed by {}",
-            static_cast<int>(res)));
+        "Internal error: cudaStreamGetCaptureInfo failed by {}",
+        static_cast<int>(res));
     return false;
   }
   return status != cudaStreamCaptureStatusNone;
@@ -81,7 +83,7 @@ bool shouldCheckAsyncError() {
     if (checkAsyncError.hasValue()) {
       return checkAsyncError.value();
     } else {
-      XLOGF(
+      NCCLX_LOG(
           ERR,
           "CollTrace: Failed to parse {} as valid async error value, skip async error check in colltrace",
           checkAsyncErrorHintStr.value());
@@ -98,7 +100,7 @@ bool shouldCheckTimeout() {
     if (checkTimeout.hasValue()) {
       return checkTimeout.value();
     } else {
-      XLOGF(
+      NCCLX_LOG(
           ERR,
           "CollTrace: Failed to parse {} as valid timeout value, skip timeout check in colltrace",
           checkTimeoutHintStr.value());
@@ -115,7 +117,7 @@ std::chrono::milliseconds getCollTraceWatchdogTimeout() {
     if (timeoutSeconds.hasValue()) {
       return std::chrono::milliseconds{timeoutSeconds.value()};
     } else {
-      XLOGF(
+      NCCLX_LOG(
           ERR,
           "CollTrace: Failed to parse {} as valid timeout value, fallback to default timeout value.",
           timeoutSecondsHintStr.value());
@@ -301,7 +303,7 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
     }
   }
 
-  XLOGF(
+  NCCLX_LOG(
       INFO,
       "CollTrace init - NCCL_COLLTRACE: [algostat: {}, verbose: {}, trace: {}]",
       algoStatEnabled,
@@ -321,7 +323,7 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
     return ncclSuccess;
   }
 
-  XLOG(INFO, "Initializing new CollTrace");
+  NCCLX_LOG(INFO, "Initializing new CollTrace");
 
   auto plugins =
       std::vector<std::unique_ptr<meta::comms::colltrace::ICollTracePlugin>>{};
@@ -337,7 +339,7 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
   auto ifCheckAsync = shouldCheckAsyncError();
   auto ifCheckTimeout = shouldCheckTimeout();
   auto timeout = getCollTraceWatchdogTimeout();
-  XLOGF(
+  NCCLX_LOG(
       INFO,
       "CollTrace watchdog config: checkAsyncError: {}, checkTimeout: {}, timeout: {} sec",
       ifCheckAsync,
@@ -400,7 +402,7 @@ getMetadataFromNcclKernelPlan(ncclKernelPlan& plan, cudaStream_t stream) {
   // Handle invalid cases
   if (planInfo.collType == KernelPlanType::none &&
       planInfo.p2pType == KernelPlanType::none) {
-    XLOG_FIRST_N(
+    NCCLX_LOG_FIRST_N(
         ERR, 3, "CollTrace: No coll or p2p task in the NCCL Kenrel Plan!");
     if (isCapturingStream(stream)) {
       // Deadlock safety: a graph-captured plan with no coll/p2p task has no
@@ -454,8 +456,11 @@ getHandleFromNcclKernelPlan(ncclKernelPlan& plan, cudaStream_t stream) {
   auto res = colltrace->recordCollective(std::move(metadata), makeWaitEvent());
 
   if (res.hasError()) {
-    XLOG_FIRST_N(
-        ERR, 1, "Failed to get colltrace handle due to: ", res.error().message);
+    NCCLX_LOG_FIRST_N(
+        ERR,
+        1,
+        "Failed to get colltrace handle due to: {}",
+        res.error().message);
     return std::make_unique<meta::comms::colltrace::DummyCollTraceHandle>();
   }
   return res.value();

--- a/comms/ncclx/meta/commDump.cc
+++ b/comms/ncclx/meta/commDump.cc
@@ -19,6 +19,7 @@
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/memtrace/MemoryTrace.h"
+#include "meta/NcclxLogger.h"
 #include "meta/colltrace/ProxyTrace.h"
 #include "meta/commDump.h"
 #include "meta/comms-monitor/CommsMonitor.h"
@@ -142,7 +143,7 @@ static void dumpCommInfo(
       map["nRanks"] = std::to_string(logMetaData->nRanks);
     }
   } else {
-    XLOGF(DBG2, "CommDump: logMetaData is disabled. No trace to dump");
+    NCCLX_LOG(DBG, "CommDump: logMetaData is disabled. No trace to dump");
     return;
   }
 
@@ -169,8 +170,8 @@ static void dumpMapperTrace(
     const DumpFieldSet& requestFields = {}) {
   auto dump = mapperTrace.dump();
 
-  XLOGF(
-      DBG2,
+  NCCLX_LOG(
+      DBG,
       "CommDump: MAPPERTRACE dump: {} unfinished req, {} current collective records",
       dump.unfinishedRequests.size(),
       dump.currentColl != nullptr ? 1 : 0);
@@ -202,8 +203,8 @@ static void dumpProxyTrace(
   if (ProxyTrace) {
     auto dump = ProxyTrace->dump(commHash);
 
-    XLOGF(
-        DBG2,
+    NCCLX_LOG(
+        DBG,
         "CommDump: PROXYTRACE dump: {} past collectives, {} active network operations",
         dump.pastColls.size(),
         dump.activeOps.size());
@@ -218,7 +219,7 @@ static void dumpProxyTrace(
       map["PT_activeColls"] = serializeObjects(dump.activeColls);
     }
   } else {
-    XLOGF(DBG2, "CommDump: PROXYTRACE is disabled. No trace to dump");
+    NCCLX_LOG(DBG, "CommDump: PROXYTRACE is disabled. No trace to dump");
   }
 }
 
@@ -285,7 +286,7 @@ std::unordered_map<std::string, std::string> commDumpByMonitorInfo(
            "CT_currentIteration",
            "CT_currentIterationCommTimeUs"})) {
     map.merge(dumpNewCollTrace(*info.newCollTrace, requestFields));
-    XLOGF(DBG2, "commDumpByMonitorInfo: Dumped from colltrace");
+    NCCLX_LOG(DBG, "commDumpByMonitorInfo: Dumped from colltrace");
   }
 
   if (anyKeyRequested(
@@ -303,7 +304,7 @@ std::unordered_map<std::string, std::string> commDumpByMonitorInfo(
     if (info.mapperTrace != nullptr) {
       dumpMapperTrace(*info.mapperTrace, map, requestFields);
     } else {
-      XLOGF(DBG2, "CommDump: MAPPERTRACE is disabled. No trace to dump");
+      NCCLX_LOG(DBG, "CommDump: MAPPERTRACE is disabled. No trace to dump");
     }
   }
 
@@ -328,8 +329,8 @@ __attribute__((visibility("default"))) ncclResult_t ncclCommDump(
   }
 
   if (comm != nullptr) {
-    XLOGF(
-        DBG2,
+    NCCLX_LOG(
+        DBG,
         "ncclCommDump by comm: rank {} comm {} commHash {} commDesc {}",
         comm->rank,
         fmt::ptr(comm),
@@ -339,7 +340,7 @@ __attribute__((visibility("default"))) ncclResult_t ncclCommDump(
     dumpCommInfo(comm, map);
     if (comm->newCollTrace != nullptr) {
       map.merge(dumpNewCollTrace(*comm->newCollTrace));
-      XLOGF(DBG2, "CommDump: Dumped from colltrace");
+      NCCLX_LOG(DBG, "CommDump: Dumped from colltrace");
     }
     if (comm->proxyState != nullptr) {
       dumpProxyTrace(comm->proxyState->trace.get(), comm->commHash, map);
@@ -349,7 +350,7 @@ __attribute__((visibility("default"))) ncclResult_t ncclCommDump(
     if (mapperTrace != nullptr) {
       dumpMapperTrace(*mapperTrace, map);
     } else {
-      XLOGF(DBG2, "CommDump: MAPPERTRACE is disabled. No trace to dump");
+      NCCLX_LOG(DBG, "CommDump: MAPPERTRACE is disabled. No trace to dump");
     }
   }
 

--- a/comms/ncclx/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/meta/commstate/FactoryCommStateX.cc
@@ -1,4 +1,7 @@
 #include "meta/commstate/FactoryCommStateX.h"
+
+#include <folly/logging/xlog.h>
+
 #include "checks.h"
 #include "comm.h"
 #include "comms/ctran/CtranComm.h"

--- a/comms/ncclx/meta/logger/tests/LoggingUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggingUT.cc
@@ -14,6 +14,7 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/Logger.h"
 #include "comms/utils/logger/LoggingFormat.h"
+#include "meta/NcclxLogger.h"
 
 #include "debug.h" // @manual
 #include "param.h" // @manual
@@ -134,12 +135,20 @@ TEST_F(NcclLoggerTest, GetLastCommsErrorTest) {
   EXPECT_THAT(lastError, ::testing::HasSubstr(errorMsg2));
   EXPECT_THAT(lastError, ::testing::HasSubstr("NCCL Stack trace:"));
 
+  constexpr std::string_view spdlogErrorMsg = "SPDLOG ERROR MESSAGE";
+  NCCLX_LOG(ERR, "{}", spdlogErrorMsg);
+  meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName)
+      .flush();
+  lastError = meta::comms::logger::getLastCommsError();
+  EXPECT_THAT(lastError, ::testing::HasSubstr(spdlogErrorMsg));
+  EXPECT_THAT(lastError, ::testing::HasSubstr("NCCL Stack trace:"));
+
   // Log info and warn - last error should remain unchanged
   INFO(NCCL_ALL, "Another info");
   WARN("Another warn");
   sleep(1);
   lastError = meta::comms::logger::getLastCommsError();
-  EXPECT_THAT(lastError, ::testing::HasSubstr(errorMsg2));
+  EXPECT_THAT(lastError, ::testing::HasSubstr(spdlogErrorMsg));
 
   finishLogging();
 }
@@ -203,6 +212,11 @@ TEST_F(NcclLoggerTest, WarnLogTest) {
   ncclResetDebugInit();
 
   initLogging();
+  auto& spdlogLogger =
+      meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName);
+  EXPECT_TRUE(spdlogLogger.should_log(spdlog::level::err));
+  EXPECT_TRUE(spdlogLogger.should_log(spdlog::level::warn));
+  EXPECT_FALSE(spdlogLogger.should_log(spdlog::level::info));
   std::string TestStr = "TESTING";
 
   testing::internal::CaptureStdout();
@@ -340,6 +354,7 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
 
   constexpr std::string_view TestStr = "RAW TESTING";
   constexpr std::string_view TestStr2 = "TESTING";
+  constexpr std::string_view SpdlogTestStr = "SPDLOG TESTING";
 
   testing::internal::CaptureStderr();
 
@@ -350,6 +365,14 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
   INFO(NCCL_ALL, "%s", TestStr2.data());
   WARN("%s", TestStr2.data());
   ERR(ncclInternalError, "%s", TestStr2.data());
+
+  NCCLX_LOG(INFO, "{}", SpdlogTestStr);
+  NCCLX_LOG(WARN, "{}", SpdlogTestStr);
+  NCCLX_LOG(ERR, "{}", SpdlogTestStr);
+  auto& spdlogLogger =
+      meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName);
+  EXPECT_EQ(spdlogLogger.usesAsyncLogging(), NCCL_DEBUG_LOGGING_ASYNC);
+  spdlogLogger.flush();
 
   auto stderrOutput = testing::internal::GetCapturedStderr();
 
@@ -363,6 +386,9 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
     EXPECT_THAT(
         fileContents,
         testing::HasSubstr(fmt::format("NCCL {} {}", level, TestStr2)));
+    EXPECT_THAT(
+        fileContents,
+        testing::HasSubstr(fmt::format("NCCL {} {}", level, SpdlogTestStr)));
     if (level != "INFO") {
       // When logging to file, we should also log to stderr for WARN and ERROR
       EXPECT_THAT(
@@ -371,6 +397,9 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
       EXPECT_THAT(
           stderrOutput,
           testing::HasSubstr(fmt::format("NCCL {} {}", level, TestStr2)));
+      EXPECT_THAT(
+          stderrOutput,
+          testing::HasSubstr(fmt::format("NCCL {} {}", level, SpdlogTestStr)));
     }
   }
 }

--- a/comms/ncclx/meta/logger/tests/LoggingUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggingUT.cc
@@ -276,6 +276,9 @@ TEST_F(NcclLoggerTest, InfoLogTest) {
   ncclResetDebugInit();
 
   initLogging();
+  EXPECT_FALSE(
+      meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName)
+          .should_log(spdlog::level::debug));
   std::string TestStr = "TESTING";
 
   testing::internal::CaptureStdout();
@@ -295,6 +298,29 @@ TEST_F(NcclLoggerTest, InfoLogTest) {
   sleep(1);
   output = testing::internal::GetCapturedStdout();
   checkStringHasLogging(output, TestStr, "INFO");
+
+  finishLogging();
+}
+
+TEST_F(NcclLoggerTest, SpdlogDebugMatchesLegacyDbg2) {
+  auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"TRACE"});
+  auto asyncGuard = EnvRAII(NCCL_DEBUG_LOGGING_ASYNC, false);
+
+  initLogging();
+  auto& logger =
+      meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName);
+  EXPECT_TRUE(logger.should_log(spdlog::level::debug));
+
+  constexpr std::string_view legacyMessage = "LEGACY DBG2 MESSAGE";
+  constexpr std::string_view spdlogMessage = "SPDLOG DEBUG MESSAGE";
+  testing::internal::CaptureStdout();
+  XLOGF(DBG2, "{}", legacyMessage);
+  NCCLX_LOG(DBG, "{}", spdlogMessage);
+  logger.flush();
+  const auto output = testing::internal::GetCapturedStdout();
+
+  checkStringHasLogging(output, legacyMessage, "VERBOSE");
+  checkStringHasLogging(output, spdlogMessage, "VERBOSE");
 
   finishLogging();
 }

--- a/comms/ncclx/meta/logger/tests/LoggingUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggingUT.cc
@@ -240,6 +240,36 @@ TEST_F(NcclLoggerTest, WarnLogTest) {
   finishLogging();
 }
 
+TEST_F(NcclLoggerTest, SpdlogFirstNDoesNotConsumeWhileDisabled) {
+  auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"WARN"});
+
+  initLogging();
+  auto& logger =
+      meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName);
+  auto logFirstN = [](int value) {
+    NCCLX_LOG_FIRST_N(WARN, 2, "NCCLX FIRST N {}", value);
+  };
+
+  testing::internal::CaptureStdout();
+  logger.set_level(spdlog::level::err);
+  logFirstN(0);
+  logFirstN(1);
+  logger.set_level(spdlog::level::warn);
+  logFirstN(2);
+  logFirstN(3);
+  logFirstN(4);
+  logger.flush();
+  const auto output = testing::internal::GetCapturedStdout();
+
+  EXPECT_THAT(output, testing::Not(testing::HasSubstr("NCCLX FIRST N 0")));
+  EXPECT_THAT(output, testing::Not(testing::HasSubstr("NCCLX FIRST N 1")));
+  EXPECT_THAT(output, testing::HasSubstr("NCCLX FIRST N 2"));
+  EXPECT_THAT(output, testing::HasSubstr("NCCLX FIRST N 3"));
+  EXPECT_THAT(output, testing::Not(testing::HasSubstr("NCCLX FIRST N 4")));
+
+  finishLogging();
+}
+
 TEST_F(NcclLoggerTest, InfoLogTest) {
   auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"INFO"});
   setenv("NCCL_DEBUG", "INFO", 1);

--- a/comms/ncclx/v2_29/src/misc/param.cc
+++ b/comms/ncclx/v2_29/src/misc/param.cc
@@ -27,8 +27,32 @@
 #include "comms/utils/logger/LoggingFormat.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/InitFolly.h"
+#include "meta/NcclxLogger.h"
 
 #include "cuda_runtime_api.h"
+
+namespace {
+
+spdlog::level::level_enum loggerLevelToSpdlogLevel(
+    meta::comms::logger::LogLevel level) {
+  switch (level) {
+    case meta::comms::logger::LogLevel::NONE:
+    case meta::comms::logger::LogLevel::VERSION:
+      return spdlog::level::off;
+    case meta::comms::logger::LogLevel::ERROR:
+      return spdlog::level::err;
+    case meta::comms::logger::LogLevel::WARN:
+      return spdlog::level::warn;
+    case meta::comms::logger::LogLevel::INFO:
+      return spdlog::level::info;
+    case meta::comms::logger::LogLevel::ABORT:
+    case meta::comms::logger::LogLevel::TRACE:
+      return spdlog::level::debug;
+  }
+  return spdlog::level::off;
+}
+
+} // namespace
 
 const char* userHomeDir() {
   struct passwd *pwUser = getpwuid(getuid());
@@ -185,4 +209,20 @@ void initNcclLogger() {
         cudaGetDevice(&cudaDev);
         return cudaDev;
       }});
+  meta::comms::logger::configureSpdlogLogger(
+      ncclx::logging::kNcclxLoggerName,
+      "NCCL",
+      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
+      []() {
+        int cudaDev = -1;
+        (void)cudaGetDevice(&cudaDev);
+        return cudaDev;
+      },
+      [](std::string_view message) {
+        meta::comms::logger::setLastError(std::string{message}, {});
+      },
+      NCCL_DEBUG_LOGGING_ASYNC);
+  meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName)
+      .set_level(loggerLevelToSpdlogLevel(
+          meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
 }

--- a/comms/ncclx/v2_30/src/misc/param.cc
+++ b/comms/ncclx/v2_30/src/misc/param.cc
@@ -24,8 +24,32 @@
 #include "comms/utils/logger/LoggingFormat.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/InitFolly.h"
+#include "meta/NcclxLogger.h"
 
 #include "cuda_runtime_api.h"
+
+namespace {
+
+spdlog::level::level_enum loggerLevelToSpdlogLevel(
+    meta::comms::logger::LogLevel level) {
+  switch (level) {
+    case meta::comms::logger::LogLevel::NONE:
+    case meta::comms::logger::LogLevel::VERSION:
+      return spdlog::level::off;
+    case meta::comms::logger::LogLevel::ERROR:
+      return spdlog::level::err;
+    case meta::comms::logger::LogLevel::WARN:
+      return spdlog::level::warn;
+    case meta::comms::logger::LogLevel::INFO:
+      return spdlog::level::info;
+    case meta::comms::logger::LogLevel::ABORT:
+    case meta::comms::logger::LogLevel::TRACE:
+      return spdlog::level::debug;
+  }
+  return spdlog::level::off;
+}
+
+} // namespace
 
 const char* userHomeDir() {
   return getenv("HOME");
@@ -148,4 +172,20 @@ void initNcclLogger() {
         cudaGetDevice(&cudaDev);
         return cudaDev;
       }});
+  meta::comms::logger::configureSpdlogLogger(
+      ncclx::logging::kNcclxLoggerName,
+      "NCCL",
+      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
+      []() {
+        int cudaDev = -1;
+        (void)cudaGetDevice(&cudaDev);
+        return cudaDev;
+      },
+      [](std::string_view message) {
+        meta::comms::logger::setLastError(std::string{message}, {});
+      },
+      NCCL_DEBUG_LOGGING_ASYNC);
+  meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName)
+      .set_level(loggerLevelToSpdlogLevel(
+          meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
 }


### PR DESCRIPTION
Summary:

Replace the nine remaining direct `XLOGF(DBG2, ...)` calls in `commDump.cc` with `NCCLX_LOG(DBG, ...)`.

The focused logging test verifies that this mapping preserves both filtering and output severity: legacy `DBG2` and spdlog `debug` are enabled by `NCCL_DEBUG=TRACE`, both render as `NCCL VERBOSE`, and spdlog `debug` is disabled by `NCCL_DEBUG=INFO`.

Reviewed By: shr

Differential Revision: D115375534


