### PR TITLE
Add CTRAN log migration helpers (#3542)

### DIFF
--- a/comms/ctran/utils/CtranLogUtils.h
+++ b/comms/ctran/utils/CtranLogUtils.h
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <chrono>
+
+#include "comms/ctran/utils/CtranLogger.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/LogUtils.h"
+
+#define CTRAN_LOG_SUBSYS(level, subsys, ...) \
+  CTRAN_LOG_IF(level, CLOGF_ENABLED(subsys), __VA_ARGS__)
+
+// The interval is fixed on first use at each expansion site, matching
+// CLOGF_EVERY_MS; callers must pass a call-site constant.
+#define CTRAN_LOG_EVERY_MS(level, ms, ...)                          \
+  CTRAN_LOG_IF(                                                     \
+      level,                                                        \
+      [_ctran_log_every_ms = (ms)] {                                \
+        static ::meta::comms::logger::IntervalRateLimiter           \
+            ctran_log_rate_limiter(                                 \
+                1, std::chrono::milliseconds(_ctran_log_every_ms)); \
+        return ctran_log_rate_limiter.check();                      \
+      }(),                                                          \
+      __VA_ARGS__)
+
+#define CTRAN_LOG_TRACE(subsys, format, ...)                             \
+  do {                                                                   \
+    if (NCCL_CTRAN_ENABLE_TRACE_LOG) {                                   \
+      CTRAN_LOG_SUBSYS(                                                  \
+          INFO, subsys, "[TRACE] {}: " format, __func__, ##__VA_ARGS__); \
+    }                                                                    \
+  } while (false)
+
+#define CTRAN_ERR(code, ...)                                                  \
+  do {                                                                        \
+    const auto _ctran_error_message = fmt::format(__VA_ARGS__);               \
+    CTRAN_LOG(ERR, "{}", _ctran_error_message);                               \
+    ::meta::comms::logger::logCommErrorToScuba((code), _ctran_error_message); \
+  } while (false)

--- a/comms/ctran/utils/CtranLogger.h
+++ b/comms/ctran/utils/CtranLogger.h
@@ -16,6 +16,35 @@ inline constexpr std::string_view kCtranLoggerName = "comms.ctran";
 #define CTRAN_LOG(level, ...) \
   COMMS_LOG_NAMED(::ctran::logging::kCtranLoggerName, level, __VA_ARGS__)
 
+#define CTRAN_LOG_IF_IMPL(level, spdlog_level, condition, ...)    \
+  do {                                                            \
+    auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger( \
+        ::ctran::logging::kCtranLoggerName);                      \
+    if (_ctran_logger.should_log(spdlog_level) && (condition)) {  \
+      CTRAN_LOG(level, __VA_ARGS__);                              \
+    }                                                             \
+  } while (false)
+
+#define CTRAN_LOG_IF_WARN(condition, ...) \
+  CTRAN_LOG_IF_IMPL(WARN, ::spdlog::level::warn, condition, __VA_ARGS__)
+#define CTRAN_LOG_IF_DBG(condition, ...) \
+  CTRAN_LOG_IF_IMPL(DBG, ::spdlog::level::debug, condition, __VA_ARGS__)
+#define CTRAN_LOG_IF_INFO(condition, ...) \
+  CTRAN_LOG_IF_IMPL(INFO, ::spdlog::level::info, condition, __VA_ARGS__)
+#define CTRAN_LOG_IF_ERR(condition, ...) \
+  CTRAN_LOG_IF_IMPL(ERR, ::spdlog::level::err, condition, __VA_ARGS__)
+#define CTRAN_LOG_IF_CRITICAL(condition, ...) \
+  CTRAN_LOG_IF_IMPL(CRITICAL, ::spdlog::level::critical, condition, __VA_ARGS__)
+// Legacy XLOGF_IF never filters FATAL, so its condition is always evaluated.
+#define CTRAN_LOG_IF_FATAL(condition, ...) \
+  do {                                     \
+    if ((condition)) {                     \
+      CTRAN_LOG(FATAL, __VA_ARGS__);       \
+    }                                      \
+  } while (false)
+#define CTRAN_LOG_IF(level, condition, ...) \
+  CTRAN_LOG_IF_##level(condition, __VA_ARGS__)
+
 #define CTRAN_LOG_FIRST_N_IMPL(level, spdlog_level, n, ...)                    \
   do {                                                                         \
     auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger(              \

--- a/comms/ctran/utils/tests/LogUT.cc
+++ b/comms/ctran/utils/tests/LogUT.cc
@@ -12,7 +12,7 @@
 #include <gmock/gmock.h>
 #include "TestLogCategory.h"
 #include "comms/ctran/tests/CtranTestUtils.h"
-#include "comms/ctran/utils/CtranLogger.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/LogInit.h"
 #include "comms/ctran/utils/Utils.h"
 #include "comms/testinfra/TestXPlatUtils.h"
@@ -83,6 +83,20 @@ TEST_F(CtranUtilsLogTest, TestCtranLoggerPreservesLastError) {
       testing::HasSubstr("Spdlog CTRAN error 42"));
 }
 
+TEST_F(CtranUtilsLogTest, TestCtranErrEvaluatesArgumentsOnce) {
+  auto& logger =
+      meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName);
+  logger.set_level(spdlog::level::err);
+
+  int evaluated = 0;
+  CTRAN_ERR(commInternalError, "CTRAN error {}", ++evaluated);
+
+  EXPECT_EQ(evaluated, 1);
+  EXPECT_THAT(
+      meta::comms::logger::getLastCommsError(),
+      testing::HasSubstr("CTRAN error 1"));
+}
+
 TEST_F(CtranUtilsLogTest, TestCtranLogFirstNPreservesEnabledBudget) {
   auto& logger =
       meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName);
@@ -112,6 +126,93 @@ TEST_F(CtranUtilsLogTest, TestCtranLogFirstNPreservesEnabledBudget) {
       errors,
       testing::ElementsAre("rate-limited error 1", "rate-limited error 2"));
   EXPECT_EQ(evaluated, 2);
+}
+
+TEST_F(CtranUtilsLogTest, TestCtranLogIfPreservesLevelAndSubsystemGates) {
+  auto& logger =
+      meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName);
+  logger.configure("CTRAN", []() { return 0; }, {}, false);
+
+  int filteredConditionEvaluations = 0;
+  int fatalConditionEvaluations = 0;
+  int conditionEvaluations = 0;
+  int argumentEvaluations = 0;
+  auto logIf = [&] {
+    CTRAN_LOG_IF(
+        INFO,
+        ++conditionEvaluations == 1,
+        "CTRAN IF {}",
+        ++argumentEvaluations);
+  };
+
+  testing::internal::CaptureStdout();
+  logger.set_level(spdlog::level::off);
+  CTRAN_LOG_IF(DBG, ++filteredConditionEvaluations, "FILTERED DBG");
+  CTRAN_LOG_IF(WARN, ++filteredConditionEvaluations, "FILTERED WARN");
+  CTRAN_LOG_IF(ERR, ++filteredConditionEvaluations, "FILTERED ERR");
+  CTRAN_LOG_IF(CRITICAL, ++filteredConditionEvaluations, "FILTERED CRITICAL");
+  CTRAN_LOG_IF(FATAL, ++fatalConditionEvaluations == 0, "DISABLED FATAL");
+  logger.set_level(spdlog::level::warn);
+  logIf();
+  logger.set_level(spdlog::level::info);
+  logIf();
+  logIf();
+
+  meta::comms::logger::setSubSystemMask(meta::comms::logger::SubSystem::ENV);
+  CTRAN_LOG_SUBSYS(INFO, ENV, "CTRAN ENABLED SUBSYSTEM");
+  CTRAN_LOG_SUBSYS(INFO, COLL, "CTRAN DISABLED SUBSYSTEM");
+  logger.flush();
+  const auto output = testing::internal::GetCapturedStdout();
+
+  EXPECT_EQ(filteredConditionEvaluations, 0);
+  EXPECT_EQ(fatalConditionEvaluations, 1);
+  EXPECT_EQ(conditionEvaluations, 2);
+  EXPECT_EQ(argumentEvaluations, 1);
+  EXPECT_THAT(output, testing::HasSubstr("CTRAN IF 1"));
+  EXPECT_THAT(output, testing::HasSubstr("CTRAN ENABLED SUBSYSTEM"));
+  EXPECT_THAT(
+      output, testing::Not(testing::HasSubstr("CTRAN DISABLED SUBSYSTEM")));
+}
+
+TEST_F(CtranUtilsLogTest, TestCtranLogEveryMsPreservesEnabledBudget) {
+  auto& logger =
+      meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName);
+  std::vector<std::string> errors;
+  logger.configure(
+      "CTRAN",
+      []() { return 0; },
+      [&](std::string_view error) { errors.emplace_back(error); },
+      false);
+
+  int evaluated = 0;
+  auto log = [&] {
+    CTRAN_LOG_EVERY_MS(ERR, 60'000, "rate-limited error {}", ++evaluated);
+  };
+
+  logger.set_level(spdlog::level::off);
+  log();
+  logger.set_level(spdlog::level::err);
+  log();
+  log();
+
+  EXPECT_THAT(errors, testing::ElementsAre("rate-limited error 1"));
+  EXPECT_EQ(evaluated, 1);
+}
+
+TEST_F(CtranUtilsLogTest, TestCtranTraceFormat) {
+  auto traceGuard = EnvRAII(NCCL_CTRAN_ENABLE_TRACE_LOG, true);
+  auto& logger =
+      meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName);
+  logger.configure("CTRAN", []() { return 0; }, {}, false);
+  logger.set_level(spdlog::level::info);
+  meta::comms::logger::setSubSystemMask(meta::comms::logger::SubSystem::COLL);
+
+  testing::internal::CaptureStdout();
+  CTRAN_LOG_TRACE(COLL, "trace value {}", 42);
+  logger.flush();
+  const auto output = testing::internal::GetCapturedStdout();
+
+  EXPECT_THAT(output, testing::HasSubstr("[TRACE] TestBody: trace value 42"));
 }
 
 TEST_F(CtranUtilsLogTest, TestCLOGF_IF) {

--- a/comms/ncclx/meta/NcclxLogUtils.h
+++ b/comms/ncclx/meta/NcclxLogUtils.h
@@ -1,0 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comms/utils/logger/LogUtils.h"
+#include "meta/NcclxLogger.h"
+
+#define NCCLX_LOG_SUBSYS(level, subsys, ...) \
+  NCCLX_LOG_IF(level, CLOGF_ENABLED(subsys), __VA_ARGS__)

--- a/comms/ncclx/meta/NcclxLogger.h
+++ b/comms/ncclx/meta/NcclxLogger.h
@@ -16,6 +16,35 @@ inline constexpr std::string_view kNcclxLoggerName = "comms.ncclx";
 #define NCCLX_LOG(level, ...) \
   COMMS_LOG_NAMED(::ncclx::logging::kNcclxLoggerName, level, __VA_ARGS__)
 
+#define NCCLX_LOG_IF_IMPL(level, spdlog_level, condition, ...)    \
+  do {                                                            \
+    auto& _ncclx_logger = ::meta::comms::logger::getSpdlogLogger( \
+        ::ncclx::logging::kNcclxLoggerName);                      \
+    if (_ncclx_logger.should_log(spdlog_level) && (condition)) {  \
+      NCCLX_LOG(level, __VA_ARGS__);                              \
+    }                                                             \
+  } while (false)
+
+#define NCCLX_LOG_IF_WARN(condition, ...) \
+  NCCLX_LOG_IF_IMPL(WARN, ::spdlog::level::warn, condition, __VA_ARGS__)
+#define NCCLX_LOG_IF_DBG(condition, ...) \
+  NCCLX_LOG_IF_IMPL(DBG, ::spdlog::level::debug, condition, __VA_ARGS__)
+#define NCCLX_LOG_IF_INFO(condition, ...) \
+  NCCLX_LOG_IF_IMPL(INFO, ::spdlog::level::info, condition, __VA_ARGS__)
+#define NCCLX_LOG_IF_ERR(condition, ...) \
+  NCCLX_LOG_IF_IMPL(ERR, ::spdlog::level::err, condition, __VA_ARGS__)
+#define NCCLX_LOG_IF_CRITICAL(condition, ...) \
+  NCCLX_LOG_IF_IMPL(CRITICAL, ::spdlog::level::critical, condition, __VA_ARGS__)
+// Legacy XLOGF_IF never filters FATAL, so its condition is always evaluated.
+#define NCCLX_LOG_IF_FATAL(condition, ...) \
+  do {                                     \
+    if ((condition)) {                     \
+      NCCLX_LOG(FATAL, __VA_ARGS__);       \
+    }                                      \
+  } while (false)
+#define NCCLX_LOG_IF(level, condition, ...) \
+  NCCLX_LOG_IF_##level(condition, __VA_ARGS__)
+
 #define NCCLX_LOG_FIRST_N_IMPL(level, spdlog_level, n, ...)                    \
   do {                                                                         \
     auto& _ncclx_logger = ::meta::comms::logger::getSpdlogLogger(              \

--- a/comms/ncclx/meta/collectives/pCollectives.cc
+++ b/comms/ncclx/meta/collectives/pCollectives.cc
@@ -8,6 +8,7 @@
 #include "comms/ctran/Ctran.h"
 #include "comms/utils/checks.h"
 
+#include "meta/NcclxLogUtils.h"
 #include "meta/wrapper/MetaFactory.h"
 
 namespace ncclx {
@@ -112,7 +113,7 @@ __attribute__((visibility("default"))) ncclResult_t allToAllvDedupExec(
 __attribute__((visibility("default"))) ncclResult_t pExec(void* request) {
   CtranPersistentRequest* pReq = nullptr;
   GET_VALID_PREQ_OR_ERRRETURN(request, &pReq);
-  CLOGF(
+  NCCLX_LOG(
       INFO,
       "Executing persistent request {} comm {}",
       (void*)pReq,

--- a/comms/ncclx/meta/hints/GlobalHints.cc
+++ b/comms/ncclx/meta/hints/GlobalHints.cc
@@ -5,8 +5,8 @@
 
 #include <folly/Singleton.h>
 #include <folly/Synchronized.h>
-#include "comms/utils/logger/LogUtils.h"
 
+#include "meta/NcclxLogUtils.h"
 #include "meta/hints/GlobalHints.h"
 #include "nccl.h"
 
@@ -25,7 +25,7 @@ GlobalHints::GlobalHints() {
 bool GlobalHints::setHint(std::string key, std::string val) {
   for (const auto& dep : kDeprecatedCommHintKeys) {
     if (key == dep.first) {
-      CLOGF(
+      NCCLX_LOG(
           WARN,
           "GLOBAL-HINTS: GlobalHint key '{}' is deprecated and no longer affects communicator behavior. Use per-comm ncclx::Hints with key '{}' instead.",
           key,
@@ -35,7 +35,7 @@ bool GlobalHints::setHint(std::string key, std::string val) {
   }
   auto entry = getHintEntry(key);
   if (!entry) {
-    CLOGF(
+    NCCLX_LOG(
         WARN,
         "GLOBAL-HINTS: Hint key {} is not registered. Ignore setHint.",
         key);
@@ -73,7 +73,7 @@ bool GlobalHints::resetHint(const std::string& key) {
   }
   auto entry = getHintEntry(key);
   if (!entry) {
-    CLOGF(
+    NCCLX_LOG(
         WARN,
         "GLOBAL-HINTS: Hint key {} is not registered. Ignore resetHint.",
         key);
@@ -118,7 +118,7 @@ bool GlobalHints::regHintEntry(std::string key) {
   auto entries = hintEntries_.wlock();
   // If entry is not provided, create a default entry with no hooks
   auto entry_ = GlobalHintEntry{};
-  CLOGF(INFO, "GLOBAL-HINTS: Hint key {} is registered.", key);
+  NCCLX_LOG(INFO, "GLOBAL-HINTS: Hint key {} is registered.", key);
   const auto& res = entries->insert({std::move(key), std::move(entry_)});
   return res.second; // insert success or already exists
 }

--- a/comms/ncclx/meta/logger/tests/LoggingUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggingUT.cc
@@ -14,7 +14,7 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/Logger.h"
 #include "comms/utils/logger/LoggingFormat.h"
-#include "meta/NcclxLogger.h"
+#include "meta/NcclxLogUtils.h"
 
 #include "debug.h" // @manual
 #include "param.h" // @manual
@@ -266,6 +266,56 @@ TEST_F(NcclLoggerTest, SpdlogFirstNDoesNotConsumeWhileDisabled) {
   EXPECT_THAT(output, testing::HasSubstr("NCCLX FIRST N 2"));
   EXPECT_THAT(output, testing::HasSubstr("NCCLX FIRST N 3"));
   EXPECT_THAT(output, testing::Not(testing::HasSubstr("NCCLX FIRST N 4")));
+
+  finishLogging();
+}
+
+TEST_F(NcclLoggerTest, SpdlogIfPreservesLevelAndSubsystemGates) {
+  auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"INFO"});
+  auto asyncGuard = EnvRAII(NCCL_DEBUG_LOGGING_ASYNC, false);
+
+  initLogging();
+  auto& logger =
+      meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName);
+  int filteredConditionEvaluations = 0;
+  int fatalConditionEvaluations = 0;
+  int conditionEvaluations = 0;
+  int argumentEvaluations = 0;
+  auto logIf = [&] {
+    NCCLX_LOG_IF(
+        INFO,
+        ++conditionEvaluations == 1,
+        "NCCLX IF {}",
+        ++argumentEvaluations);
+  };
+
+  testing::internal::CaptureStdout();
+  logger.set_level(spdlog::level::off);
+  NCCLX_LOG_IF(DBG, ++filteredConditionEvaluations, "FILTERED DBG");
+  NCCLX_LOG_IF(WARN, ++filteredConditionEvaluations, "FILTERED WARN");
+  NCCLX_LOG_IF(ERR, ++filteredConditionEvaluations, "FILTERED ERR");
+  NCCLX_LOG_IF(CRITICAL, ++filteredConditionEvaluations, "FILTERED CRITICAL");
+  NCCLX_LOG_IF(FATAL, ++fatalConditionEvaluations == 0, "DISABLED FATAL");
+  logger.set_level(spdlog::level::warn);
+  logIf();
+  logger.set_level(spdlog::level::info);
+  logIf();
+  logIf();
+
+  meta::comms::logger::setSubSystemMask(meta::comms::logger::SubSystem::ENV);
+  NCCLX_LOG_SUBSYS(INFO, ENV, "NCCLX ENABLED SUBSYSTEM");
+  NCCLX_LOG_SUBSYS(INFO, COLL, "NCCLX DISABLED SUBSYSTEM");
+  logger.flush();
+  const auto output = testing::internal::GetCapturedStdout();
+
+  EXPECT_EQ(filteredConditionEvaluations, 0);
+  EXPECT_EQ(fatalConditionEvaluations, 1);
+  EXPECT_EQ(conditionEvaluations, 2);
+  EXPECT_EQ(argumentEvaluations, 1);
+  EXPECT_THAT(output, testing::HasSubstr("NCCLX IF 1"));
+  EXPECT_THAT(output, testing::HasSubstr("NCCLX ENABLED SUBSYSTEM"));
+  EXPECT_THAT(
+      output, testing::Not(testing::HasSubstr("NCCLX DISABLED SUBSYSTEM")));
 
   finishLogging();
 }

--- a/comms/ncclx/meta/transport/transportConnect.cc
+++ b/comms/ncclx/meta/transport/transportConnect.cc
@@ -11,6 +11,7 @@
 #include "comms/ctran/utils/Utils.h"
 
 #include "comms/utils/logger/EventsScubaUtil.h"
+#include "meta/NcclxLogUtils.h"
 #include "meta/transport/transportConnect.h"
 #include "meta/transport/transportExt.h"
 #include "meta/transport/transportProxy.h"
@@ -569,7 +570,7 @@ ncclResult_t transportReConnect(
         myReconnInfo,
         sizeof(ncclxPeerReConnInfo)));
 
-    CLOGF_SUBSYS(
+    NCCLX_LOG_SUBSYS(
         INFO,
         ALLOC,
         "rank-{} sent reconnect state to peer-{} (tag {}): [{}]",
@@ -609,7 +610,7 @@ ncclResult_t transportReConnect(
         &peerReconnInfo,
         sizeof(ncclxPeerReConnInfo)));
 
-    CLOGF_SUBSYS(
+    NCCLX_LOG_SUBSYS(
         INFO,
         ALLOC,
         "rank-{} received reconnect state from peer-{} (tag {}): [{}]",
@@ -644,7 +645,7 @@ ncclResult_t transportReConnect(
 
   if (collNeedReConnect || p2pNeedReConnect) {
     NCCLCHECK(setupTransports(comm, p2pNeedReConnect, algoNeedReConnect));
-    CLOGF_SUBSYS(
+    NCCLX_LOG_SUBSYS(
         INFO,
         ALLOC,
         "{}: comm {} re-connected all peers for current plan",

--- a/comms/ncclx/meta/transport/transportExt.h
+++ b/comms/ncclx/meta/transport/transportExt.h
@@ -5,8 +5,8 @@
 #include "comm.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 #include "meta/NcclMemoryUtils.h"
+#include "meta/NcclxLogUtils.h"
 
 // [META]: Extension to store local/remote memory for synchronization, i.e.,
 // fifo information, used in p2p.cc
@@ -25,7 +25,7 @@ inline enum NCCL_CHANNEL_METADATA_LOCATION getChannelMetadataLoc() {
     val = (NCCL_USE_MEM_CACHE) ? NCCL_CHANNEL_METADATA_LOCATION::host
                                : NCCL_CHANNEL_METADATA_LOCATION::device;
   }
-  CLOGF_SUBSYS(
+  NCCLX_LOG_SUBSYS(
       INFO, ENV, "NCCL_CHANNEL_METADATA_LOCATION={}", static_cast<int>(val));
   return val;
 }

--- a/comms/ncclx/meta/transport/transportProxy.cc
+++ b/comms/ncclx/meta/transport/transportProxy.cc
@@ -9,8 +9,8 @@
 #include "comms/ctran/utils/Utils.h"
 #include "comms/utils/checks.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/trainer/TrainerContext.h"
+#include "meta/NcclxLogUtils.h"
 #include "meta/transport/transportConnect.h"
 #include "meta/transport/transportExt.h"
 #include "meta/transport/transportProxy.h"
@@ -25,7 +25,8 @@ inline enum NCCL_USE_TRANSPORT_PROXY getTransportProxyMode() {
     val = (NCCL_USE_MEM_CACHE) ? NCCL_USE_TRANSPORT_PROXY::shared
                                : NCCL_USE_TRANSPORT_PROXY::none;
   }
-  CLOGF_SUBSYS(INFO, ENV, "NCCL_USE_TRANSPORT_PROXY={}", static_cast<int>(val));
+  NCCLX_LOG_SUBSYS(
+      INFO, ENV, "NCCL_USE_TRANSPORT_PROXY={}", static_cast<int>(val));
   return val;
 }
 }; // namespace
@@ -97,7 +98,7 @@ void TransportProxy::shutdown() {
     cv_.notify_one();
   }
   if (getTransportProxyMode() != NCCL_USE_TRANSPORT_PROXY::none) {
-    CLOGF_SUBSYS(
+    NCCLX_LOG_SUBSYS(
         INFO,
         INIT,
         "Shutting down NCCLX transport worker: join worker thread...");
@@ -135,7 +136,7 @@ inline bool TransportProxy::canSkipPrepBufs(ncclComm* comm, uint64_t opCount) {
   // Early return if buffers are not shared, or we reach a pre-defined limit to
   // skip exchanging info
   if (!NCCL_USE_SHARED_BUFFER_POOL || skipReconnect) {
-    CLOGF_SUBSYS(
+    NCCLX_LOG_SUBSYS(
         INFO,
         COLL,
         "Rank-{} skip re-connect check: NCCL_TRANSPORT_PREP_TRAINER_ITERATION_LIMIT={} and ncclxGetIteration={} "
@@ -163,7 +164,7 @@ commResult_t TransportProxy::getNextChannelsReadyPtr(
 
   *channelsReadyPtr = ptr;
 
-  CLOGF_SUBSYS(
+  NCCLX_LOG_SUBSYS(
       INFO,
       COLL,
       "Transport proxy thread: get next sync flag pointer {:x}",
@@ -193,7 +194,7 @@ commResult_t TransportProxy::enqueuePrepRequest(
   reqQueue_.push_back(req);
   cv_.notify_one();
 
-  CLOGF_SUBSYS(
+  NCCLX_LOG_SUBSYS(
       INFO,
       COLL,
       "{}: Enqueued request to prepare resources for current kernel plan: "
@@ -217,7 +218,7 @@ commResult_t TransportProxy::enqueueP2pPreconnect(ncclComm* comm) {
   cv_.notify_one();
   preconnReqQueue_.push_back(req);
 
-  CLOGF_SUBSYS(
+  NCCLX_LOG_SUBSYS(
       INFO,
       INIT,
       "Enqueue p2p preconnect request ({} in queue) for comm {:x}",
@@ -239,7 +240,7 @@ commResult_t TransportProxy::enqueueCollPreconnect(
 
   preconnReqQueue_.push_back(req);
 
-  CLOGF_SUBSYS(
+  NCCLX_LOG_SUBSYS(
       INFO,
       INIT,
       "Enqueue coll preconnect request ({} in queue) for comm {:x}",
@@ -258,7 +259,7 @@ commResult_t TransportProxy::waitPreconnect() {
     preconnCv_.wait(lock, [&] { return req->state != commInProgress; });
     FB_COMMCHECK(req->state);
   }
-  CLOGF_SUBSYS(
+  NCCLX_LOG_SUBSYS(
       INFO,
       INIT,
       "Waited for {} preconnect requests to complete",
@@ -274,7 +275,7 @@ void TransportProxy::testAny() {
     auto ptr = req->channelsReadyPtr;
     if (*ptr == 0) {
       FB_COMMCHECKTHROW(req->comm->memCache->release(req->bufKeys));
-      CLOGF_SUBSYS(
+      NCCLX_LOG_SUBSYS(
           INFO,
           COLL,
           "Releasing {} bufKeys for comm {}",
@@ -282,7 +283,7 @@ void TransportProxy::testAny() {
           NCCLX_CONFIG_FIELD(req->comm->config, commDesc).c_str());
       syncFlagPool_.push_back(ptr);
       req->state = commSuccess;
-      CLOGF_SUBSYS(
+      NCCLX_LOG_SUBSYS(
           INFO,
           COLL,
           "Garbage collect sync flag pointer {:x}, {} collectives in progress",
@@ -334,7 +335,7 @@ void TransportProxy::prepResources(std::shared_ptr<TransportRequest> req) {
   // ready to start collectives
   *req->channelsReadyPtr = req->channelMask;
 
-  CLOGF_SUBSYS(
+  NCCLX_LOG_SUBSYS(
       INFO,
       COLL,
       "{}: Transport is ready for reqCount={}, req->channelMask={:x}, req->channelsReadyPtr={:x} ({:#x})",
@@ -399,7 +400,7 @@ void TransportProxy::workerThreadFn() {
     } else if (req->type == TransportRequestType::TERNIMATE) {
       break;
     } else {
-      CLOGF(
+      NCCLX_LOG(
           ERR,
           "Unknown request type {} in transport worker thread",
           static_cast<int>(req->type));

--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -10,6 +10,7 @@
 #include "comms/utils/checks.h"
 #include "comms/utils/commSpecs.h"
 #include "meta/NcclxConfig.h" // @manual
+#include "meta/NcclxLogUtils.h"
 #include "meta/commstate/FactoryCommStateX.h"
 #include "meta/ctran-integration/BaselineBootstrap.h"
 #include "meta/wrapper/MetaFactory.h"
@@ -119,7 +120,7 @@ ncclResult_t destroyCtranComm(ncclComm* comm) {
     comm->ctranComm_->destroy();
     comm->ctranComm_.reset();
   } catch (const std::exception& e) {
-    CLOGF(ERR, "CtranComm destruction failed: {}", e.what());
+    NCCLX_LOG(ERR, "CtranComm destruction failed: {}", e.what());
     return ncclInternalError;
   }
   return ncclSuccess;


### PR DESCRIPTION
Summary:

Add CTRAN spdlog facade helpers that preserve the remaining legacy conditional, subsystem, interval-rate-limited, trace, and communication-error logging contracts. This provides a tested migration boundary for subsequent production call-site diffs without changing their logging semantics.

Preserve runtime level gating before conditional and rate-limit evaluation, including the legacy always-evaluated `FATAL` condition. Reuse the existing folly-free `IntervalRateLimiter`, retain subsystem masks and trace formatting, and continue reporting `CTRAN_ERR` messages through the existing Scuba error path.

Differential Revision: D115377630


