### PR TITLE
Migrate CTRAN NVL logs (#3547)

### DIFF
--- a/comms/ctran/backends/nvl/CtranNvl.cc
+++ b/comms/ctran/backends/nvl/CtranNvl.cc
@@ -6,9 +6,9 @@
 #include "comms/ctran/backends/nvl/CtranNvl.h"
 #include "comms/ctran/backends/nvl/CtranNvlImpl.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/utils/StrUtils.h"
-#include "comms/utils/logger/LogUtils.h"
 
 CtranNvl::CtranNvl(CtranComm* comm) {
   const auto statex = comm->statex_.get();
@@ -43,7 +43,7 @@ CtranNvl::CtranNvl(CtranComm* comm) {
         bool p2pAccess = comm->statex_->isSameDeviceRack(
             comm->logMetaData_.rank, statex->localRankToRank(i));
         if (!p2pAccess) {
-          CLOGF_SUBSYS(
+          CTRAN_LOG_SUBSYS(
               INFO,
               INIT,
               "NCCL_MNNVL_TRUNK_DISABLE set to True. P2P disabled between rank1: {} rank2: {} because rackserial mismatch",
@@ -75,7 +75,7 @@ CtranNvl::CtranNvl(CtranComm* comm) {
         supportedInraHostRanksStr.push_back(
             std::to_string(statex->localRankToRank(i)));
       } else {
-        CLOGF_SUBSYS(
+        CTRAN_LOG_SUBSYS(
             INFO,
             INIT,
             "CTRAN-NVL: Rank {} (local rank {} GPU {}) cannot access peer {} (local rank {} GPU {}), disable NVL support",
@@ -89,7 +89,7 @@ CtranNvl::CtranNvl(CtranComm* comm) {
     }
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-NVL: Initialized NVL backend on rank {} localRank {}, "
@@ -109,7 +109,7 @@ CtranNvl::CtranNvl(CtranComm* comm) {
 }
 
 CtranNvl::~CtranNvl() {
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       INIT,
       "CTRAN-NVL: Destroyed NVL backend on rank {} localRank {}",
       this->pimpl_->comm->statex_->rank(),

--- a/comms/ctran/memory/SlabAllocator.cc
+++ b/comms/ctran/memory/SlabAllocator.cc
@@ -5,6 +5,7 @@
 #include "comms/ctran/memory/Utils.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/utils/DevUtils.cuh"
 
@@ -83,7 +84,7 @@ commResult_t SlabAllocator::allocateMem(
     if (newSlabSize != nullptr) {
       *newSlabSize = slabSize;
     }
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         ALLOC,
         "{}: allocate a slab with size {} (granularity_={}), freeSize_={}",

--- a/comms/ctran/memory/Utils.cc
+++ b/comms/ctran/memory/Utils.cc
@@ -2,13 +2,13 @@
 
 #include "comms/ctran/memory/Utils.h"
 
-#include <folly/Format.h>
 #include <sstream>
 
 #include "comms/ctran/memory/SlabAllocator.h"
 #include "comms/ctran/memory/memCacheAllocator.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaWrap.h"
 
 namespace ncclx::memory {
@@ -74,10 +74,9 @@ commResult_t allocateShareableBuffer(
     }
   }
 
-  // TODO: refactor this to CLOGF_SUBSYS once it supports oneof multiple masks
-  CLOGF_IF(
+  CTRAN_LOG_SUBSYS(
       INFO,
-      CLOGF_ENABLED(ALLOC) || CLOGF_ENABLED(P2P),
+      ALLOC | P2P,
       "commHash: {:x} Allocated shareable buffer {} size {} ipcDesc {} for {}",
       commHash,
       *ptr,

--- a/comms/ctran/memory/memCacheAllocator.cc
+++ b/comms/ctran/memory/memCacheAllocator.cc
@@ -4,10 +4,12 @@
 
 #include <fmt/format.h>
 #include <folly/Singleton.h>
+#include <cstdint>
 
 #include "comms/ctran/memory/Utils.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/DevUtils.cuh"
 
 #include "comms/utils/commSpecs.h"
@@ -20,7 +22,7 @@ static folly::Singleton<memCacheAllocator> memCacheAllocatorSingleton;
 std::shared_ptr<memCacheAllocator> memCacheAllocator::getInstance() {
   ctran::utils::commCudaLibraryInit();
   if (!ctran::utils::getCuMemSysSupported()) {
-    CLOGF(
+    CTRAN_LOG(
         ERR,
         "NCCLX memory cache allocator only works with low-level cuMem APIs. Make sure CUDA Toolkit is 11.3 or higher.");
     return nullptr;
@@ -51,17 +53,27 @@ commResult_t memCacheAllocator::init() {
           nullptr,
           &poolHandle_,
           &newSlabSize));
-      CLOGF_SUBSYS(
+#if defined(__HIP_PLATFORM_AMD__)
+      const auto getPoolHandleForLog = [this] {
+        return reinterpret_cast<std::uintptr_t>(
+            ctran::utils::toFormattableHandle(poolHandle_));
+      };
+#else
+      const auto getPoolHandleForLog = [this] {
+        return ctran::utils::toFormattableHandle(poolHandle_);
+      };
+#endif
+      CTRAN_LOG_SUBSYS(
           INFO,
           ALLOC,
           "ncclx::memory::memCacheAllocator::init size {} pointer {} handle {:x}",
           newSlabSize,
           poolPtr_,
-          ctran::utils::toFormattableHandle(poolHandle_));
+          getPoolHandleForLog());
       poolRemainSize_ = newSlabSize;
     }
     initialized_ = true;
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "Initialized NCCLX internal buffer pool, size {}",
@@ -74,7 +86,7 @@ commResult_t memCacheAllocator::init() {
 commResult_t memCacheAllocator::reset() {
   std::unique_lock lock(mutex_);
   if (initialized_) {
-    CLOGF_SUBSYS(INFO, INIT, "Reset NCCLX internal buffer pool");
+    CTRAN_LOG_SUBSYS(INFO, INIT, "Reset NCCLX internal buffer pool");
     printSnapshot();
 
     auto nOccupiedRegions = countOccupiedRegions();
@@ -97,7 +109,7 @@ commResult_t memCacheAllocator::reset() {
 }
 
 memCacheAllocator::~memCacheAllocator() {
-  CLOGF_SUBSYS(INFO, INIT, "Shutting down NCCLX memory cache allocator");
+  CTRAN_LOG_SUBSYS(INFO, INIT, "Shutting down NCCLX memory cache allocator");
   FB_COMMCHECKTHROW_EX_NOCOMM(reset());
 }
 
@@ -116,13 +128,13 @@ std::shared_ptr<memRegion> memCacheAllocator::getFreeMemReg(
     auto region = freeRegions->front();
     freeRegions->pop_front();
     if (region->refCnt > 0) {
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "Found a free region with size {} is already in use, region={}",
           nBytes,
           region->toString().c_str());
     }
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO, ALLOC, "Reusing free region {}", region->toString().c_str());
     return region;
   }
@@ -142,7 +154,7 @@ std::shared_ptr<memRegion> memCacheAllocator::createNewMemReg(
     region->cuHandle = poolHandle_;
     poolPtr_ = (char*)poolPtr_ + nBytes;
     poolRemainSize_ -= nBytes;
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         ALLOC,
         "Consume memory from pre-allocated pool ({} + {})",
@@ -156,7 +168,7 @@ std::shared_ptr<memRegion> memCacheAllocator::createNewMemReg(
         &region->ptr, nBytes, callsite, logMetaData, &handle));
     region->cuHandle = handle;
 
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         ALLOC,
         "Memory Pool is full, pool size {}, allocated new memory {} with size {}",
@@ -169,7 +181,7 @@ std::shared_ptr<memRegion> memCacheAllocator::createNewMemReg(
   region->size = nBytes;
   region->creatorTid = syscall(SYS_gettid);
   region->bucket = bucket;
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO, ALLOC, "Created new region {}", region->toString().c_str());
   return region;
 }
@@ -198,7 +210,7 @@ commResult_t memCacheAllocator::getCachedCuMemById(
     region = getFreeMemReg(alignedSize16, bucket);
     if (region == nullptr) {
       // Need to create a new region
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           ALLOC,
           "No free region with size {} is available, need to create a new region",
@@ -214,7 +226,7 @@ commResult_t memCacheAllocator::getCachedCuMemById(
           key,
           hashKey);
     }
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         ALLOC,
         "Caching new region for key {} hashKey {:x}: {}",
@@ -236,7 +248,7 @@ commResult_t memCacheAllocator::getCachedCuMemById(
   // insert/update the cached region
   cachedRegionMap_[hashKey] = region;
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       ALLOC,
       "Return the cached (requested key={}, hashKey={:x}, size {}) region {}",
@@ -267,7 +279,7 @@ commResult_t memCacheAllocator::reserve(const std::string& key) {
         key,
         hashKey,
         cachedRegion->ownerKey);
-    CLOGF_TRACE(ALLOC, "{}", errStr.c_str());
+    CTRAN_LOG_TRACE(ALLOC, "{}", errStr.c_str());
     return commInProgress;
   }
 
@@ -279,7 +291,7 @@ commResult_t memCacheAllocator::reserve(const std::string& key) {
 
   cachedRegion->refCnt++;
   cachedRegion->ownerKey = key;
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       ALLOC,
       "reserved region {} using key {} hash {:x}",
       cachedRegion->toString().c_str(),
@@ -307,7 +319,7 @@ commResult_t memCacheAllocator::release(const std::vector<std::string>& keys) {
     }
     cachedRegion->refCnt--;
     if (cachedRegion->refCnt == 0) {
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           ALLOC,
           "Releasing region {} back to free list",
@@ -353,7 +365,7 @@ void memCacheAllocator::printSnapshot() const {
   // convert to GiB
   double avai_mem = avai_bytes / (1024 * 1024 * 1024);
   double total_mem = total_bytes / (1024 * 1024 * 1024);
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "NCCLX memory allocator snapshot: NCCL used {} bytes, {} allocated regions ({} buckets) {} regions in-use, avai_mem: {:.2f} of {:.2f} GiB",
@@ -365,7 +377,7 @@ void memCacheAllocator::printSnapshot() const {
       total_mem);
   for (const auto& [bucket, regionMap] : freeRegionMaps_) {
     for (const auto& [size, vec] : regionMap) {
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           ALLOC,
           "\tFree region map size in bucket-{}: {}, count: {}",
@@ -373,7 +385,7 @@ void memCacheAllocator::printSnapshot() const {
           size,
           vec.size());
       for (const auto& region : vec) {
-        CLOGF_SUBSYS(
+        CTRAN_LOG_SUBSYS(
             INFO,
             ALLOC,
             "\t\tFree region with size {}: {}",
@@ -383,7 +395,7 @@ void memCacheAllocator::printSnapshot() const {
     }
   }
   for (const auto& [key, region] : cachedRegionMap_) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         ALLOC,
         "\tCached region map key: {} -> {}",


### PR DESCRIPTION
Summary:

Migrate all four production log calls in the CTRAN NVL backend from the Folly-backed `CLOGF` facade to the tested CTRAN spdlog facade.

Preserve severity, subsystem and trace gating, message strings, arguments, and evaluation behavior. Replace the backend's direct legacy `log_utils` dependency with `ctran_log_utils`.

Reviewed By: shr

Differential Revision: D115379013


