### PR TITLE
comms/uniflow/benchmarks: enable the send/recv bandwidth benchmark on AMD (#3549)

### DIFF
--- a/comms/uniflow/benchmarks/bench/SendRecvBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/SendRecvBandwidthBenchmark.cpp
@@ -73,7 +73,10 @@ struct Buffers {
     auto freeOne = [this](void* p) {
       if (p) {
         if (useGpu) {
-          cudaFree(p);
+          // hipFree and hipStreamDestroy are [[nodiscard]] on HIP, unlike their
+          // CUDA counterparts. These are best-effort cleanup/error paths, so
+          // explicitly discard their status at all three sites in this file.
+          (void)cudaFree(p);
         } else {
           std::free(p);
         }
@@ -105,7 +108,7 @@ allocateBuffers(size_t maxSize, int cudaDevice, int rank) {
         UNIFLOW_LOG_ERROR(
             "SendRecvBandwidthBenchmark: cudaMemset failed: {}",
             cudaGetErrorString(ret));
-        cudaFree(*out);
+        (void)cudaFree(*out);
         *out = nullptr;
         return false;
       }
@@ -178,7 +181,7 @@ struct MultiTransportSession {
         pt.transport->shutdown();
       }
       if (pt.stream) {
-        cudaStreamDestroy(pt.stream);
+        (void)cudaStreamDestroy(pt.stream);
       }
     }
   }

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -13,15 +13,16 @@
 #include "comms/uniflow/benchmarks/Rendezvous.h"
 #include "comms/uniflow/benchmarks/Reporter.h"
 #include "comms/uniflow/benchmarks/bench/RdmaBandwidthBenchmark.h"
+#include "comms/uniflow/benchmarks/bench/SendRecvBandwidthBenchmark.h"
 #include "comms/uniflow/logging/Logger.h"
-// ConnectionSetup/NVLink/NcclSendRecv/SendRecv benchmarks are NVIDIA-only
-// (NVLink/NCCL transports, or not yet wired for the AMD/hipify build) and are
-// compiled out on AMD.
+
+// ConnectionSetup/NVLink/NcclSendRecv benchmarks are NVIDIA-only (they depend
+// on the NVLink transport or NCCL) and are compiled out on AMD. The SendRecv
+// bandwidth benchmark is hipified and built on both platforms.
 #ifndef __HIP_PLATFORM_AMD__
 #include "comms/uniflow/benchmarks/bench/ConnectionSetupBenchmark.h"
 #include "comms/uniflow/benchmarks/bench/NVLinkBandwidthBenchmark.h"
 #include "comms/uniflow/benchmarks/bench/NcclSendRecvBenchmark.h"
-#include "comms/uniflow/benchmarks/bench/SendRecvBandwidthBenchmark.h"
 #endif
 
 namespace {
@@ -405,10 +406,10 @@ int main(int argc, char** argv) {
       std::make_unique<uniflow::benchmark::NVLinkBandwidthBenchmark>());
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::NcclSendRecvBenchmark>());
+#endif
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::SendRecvBandwidthBenchmark>(
           opts.rdmaDevices));
-#endif
 
   if (opts.benchmark == "__list__") {
     std::cout << "Available benchmarks:\n";


### PR DESCRIPTION
Summary:

The staging-buffer send/recv path had no way to be measured on AMD: the send/recv
bandwidth benchmark was excluded from the ROCm build, the only AMD test target that
covers those operations cannot currently be scheduled, and no cross-host test
exercises them on any platform. That left the host-staged VRAM transfer path — the
one that copies through pinned host slabs rather than using GPUDirect directly —
effectively unvalidated on AMD hardware.

This builds the benchmark for ROCm the same way the RDMA bandwidth benchmark is
already built, and registers it on both platforms. The NVLink, connection-setup and
NCCL benchmarks stay NVIDIA-only, since they genuinely depend on those transports.
A few cleanup calls needed their return values explicitly discarded because HIP
marks them nodiscard where CUDA does not.

Enabling this immediately paid off: it showed that the default staging slab size
caps large VRAM transfers at roughly a third of what the same hardware achieves
without staging, and that increasing the slab size closes the gap almost entirely
while pipeline depth makes no difference. That is a tuning conclusion we had no way
to reach before.

Reviewed By: saifhhasan

Differential Revision: D115383609


