### PR TITLE
Expose multimem backing through unicast peer views (#3550)

### DIFF
--- a/comms/prims/memory/NvlMemExchange.h
+++ b/comms/prims/memory/NvlMemExchange.h
@@ -38,7 +38,7 @@ namespace comms::prims {
 struct MulticastExchangeContract {
   uint64_t protocol{0};
   uint64_t version{0};
-  std::array<uint64_t, 5> parameters{};
+  std::array<uint64_t, 6> parameters{};
 
   bool operator==(const MulticastExchangeContract& other) const {
     return protocol == other.protocol && version == other.version &&

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -49,6 +49,12 @@ std::vector<int> identityRankMap(int size) {
   return rankMap;
 }
 
+std::vector<int> rotatedRankMap(int size) {
+  auto rankMap = identityRankMap(size);
+  std::rotate(rankMap.begin(), rankMap.begin() + 1, rankMap.end());
+  return rankMap;
+}
+
 // Collective check: returns true iff every rank reports that multimem is
 // eligible on the given CUDA device. Tests use this to skip cleanly on
 // non-NVLS hosts without leaving stragglers blocked in downstream collectives.
@@ -78,7 +84,8 @@ MultimemNvlTransportConfig makeConfig(
     std::size_t dataBufferSize,
     uint32_t userSignalCount = 1,
     std::size_t pipelineDepth = 0,
-    std::size_t maxChannels = 0) {
+    std::size_t maxChannels = 0,
+    bool enableUnicastPeerViews = false) {
   const std::size_t effectiveMaxChannels =
       std::max<std::size_t>(1, maxChannels);
   return make_multimem_nvl_transport_config({
@@ -87,6 +94,7 @@ MultimemNvlTransportConfig makeConfig(
       .maxChannels = effectiveMaxChannels,
       .maxBlocks = maxChannels,
       .userSignalCount = userSignalCount,
+      .enableUnicastPeerViews = enableUnicastPeerViews,
   });
 }
 
@@ -761,6 +769,7 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
   EXPECT_EQ(handle.pipelineDepth, 1);
   EXPECT_EQ(handle.maxChannels, 1);
   EXPECT_EQ(handle.signalsPerChannel, internalSignals);
+  EXPECT_TRUE(handle.internalUnicastSignalsByRank.empty());
 
   EXPECT_EQ(transport.getAllocatedDataBufferSize(), kDataBytes);
   EXPECT_EQ(
@@ -812,6 +821,61 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSupportsDataOnlyConfiguration) {
   ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 }
 
+TEST_F(MultimemNvlTransportTestFixture, PeerViewKernelsCoverNvl72) {
+  constexpr int kNvlRanks = 72;
+  constexpr int kSourceRank = kNvlRanks - 1;
+  constexpr uint64_t kValue = 0x123456789ABCDEF0ULL;
+  const std::size_t signalCount =
+      static_cast<std::size_t>(kNvlRanks) * kNvlRanks;
+
+  SignalState* signals = nullptr;
+  SignalState** pointerTable = nullptr;
+  uint64_t* output = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&signals, signalCount * sizeof(SignalState)));
+  CUDACHECK_TEST(cudaMemset(signals, 0, signalCount * sizeof(SignalState)));
+  CUDACHECK_TEST(cudaMalloc(&pointerTable, kNvlRanks * sizeof(SignalState*)));
+  CUDACHECK_TEST(cudaMalloc(&output, kNvlRanks * sizeof(uint64_t)));
+  CUDACHECK_TEST(cudaMemset(output, 0, kNvlRanks * sizeof(uint64_t)));
+
+  std::vector<SignalState*> hostPointerTable(kNvlRanks);
+  for (int destination = 0; destination < kNvlRanks; ++destination) {
+    hostPointerTable[static_cast<std::size_t>(destination)] =
+        signals + static_cast<std::size_t>(destination) * kNvlRanks;
+  }
+  CUDACHECK_TEST(cudaMemcpy(
+      pointerTable,
+      hostPointerTable.data(),
+      hostPointerTable.size() * sizeof(SignalState*),
+      cudaMemcpyHostToDevice));
+
+  MultimemNvlTransportDevice transport{
+      .internalLocalSignals = DeviceSpan<SignalState>(
+          signals + static_cast<std::size_t>(kSourceRank) * kNvlRanks,
+          kNvlRanks),
+      .nvlRank = kSourceRank,
+      .nvlRanks = kNvlRanks,
+      .internalUnicastSignalsByRank =
+          DeviceSpan<SignalState*>(pointerTable, kNvlRanks),
+  };
+  test::launchSetAllPeerInternalSignals(transport, kValue);
+  test::launchReadPeerInternalSignals(transport, output);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<uint64_t> values(kNvlRanks);
+  CUDACHECK_TEST(cudaMemcpy(
+      values.data(),
+      output,
+      values.size() * sizeof(uint64_t),
+      cudaMemcpyDeviceToHost));
+  std::vector<uint64_t> expected(kNvlRanks);
+  expected.back() = kValue;
+  EXPECT_EQ(values, expected);
+
+  CUDACHECK_TEST(cudaFree(output));
+  CUDACHECK_TEST(cudaFree(pointerTable));
+  CUDACHECK_TEST(cudaFree(signals));
+}
+
 TEST_F(
     MultimemNvlTransportTestFixture,
     ExchangeRejectsMismatchedStagingGeometry) {
@@ -838,9 +902,11 @@ TEST_F(
     EXPECT_NE(
         message.find("ranks disagree on multicast setup"), std::string::npos)
         << message;
-    EXPECT_NE(message.find("parameters=[2048, 2, 4, 4, 1]"), std::string::npos)
+    EXPECT_NE(
+        message.find("parameters=[2048, 2, 4, 4, 1, 0]"), std::string::npos)
         << message;
-    EXPECT_NE(message.find("parameters=[4096, 4, 2, 2, 1]"), std::string::npos)
+    EXPECT_NE(
+        message.find("parameters=[4096, 4, 2, 2, 1, 0]"), std::string::npos)
         << message;
   }
 
@@ -872,9 +938,47 @@ TEST_F(
     EXPECT_NE(
         message.find("ranks disagree on multicast setup"), std::string::npos)
         << message;
-    EXPECT_NE(message.find("parameters=[8192, 1, 1, 1, 1]"), std::string::npos)
+    EXPECT_NE(
+        message.find("parameters=[8192, 1, 1, 1, 1, 0]"), std::string::npos)
         << message;
-    EXPECT_NE(message.find("parameters=[8192, 1, 1, 1, 2]"), std::string::npos)
+    EXPECT_NE(
+        message.find("parameters=[8192, 1, 1, 1, 2, 0]"), std::string::npos)
+        << message;
+  }
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    ExchangeRejectsMismatchedUnicastPeerViewEnablement) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_exchange_mismatched_peer_views");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  const bool enableUnicastPeerViews = globalRank == 0;
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(4096, 0, 1, 1, enableUnicastPeerViews));
+  try {
+    transport.exchange();
+    FAIL() << "expected setup agreement to reject mismatched peer views";
+  } catch (const std::runtime_error& ex) {
+    const std::string message = ex.what();
+    EXPECT_NE(
+        message.find("ranks disagree on multicast setup"), std::string::npos)
+        << message;
+    EXPECT_NE(
+        message.find("parameters=[4096, 1, 1, 1, 0, 0]"), std::string::npos)
+        << message;
+    EXPECT_NE(
+        message.find("parameters=[4096, 1, 1, 1, 0, 1]"), std::string::npos)
         << message;
   }
 
@@ -1154,7 +1258,97 @@ std::unique_ptr<MultimemNvlTransport> makeExchangedTransport(
   return transport;
 }
 
+void verifyUnicastPeerViews(
+    const std::shared_ptr<meta::comms::IBootstrap>& bootstrap,
+    int globalRank,
+    int numRanks,
+    const std::vector<int>& rankMap,
+    MultimemNvlTransport& transport) {
+  const auto handle = transport.getDeviceTransport();
+  ASSERT_EQ(handle.internalUnicastSignalsByRank.size(), numRanks);
+
+  const auto nvlRankIt = std::find(rankMap.begin(), rankMap.end(), globalRank);
+  ASSERT_NE(nvlRankIt, rankMap.end());
+  const int nvlRank = static_cast<int>(nvlRankIt - rankMap.begin());
+  EXPECT_EQ(handle.nvlRank, nvlRank);
+
+  test::launchSetAllPeerInternalSignals(
+      handle, static_cast<uint64_t>(nvlRank + 1));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+
+  uint64_t* deviceValues = nullptr;
+  CUDACHECK_TEST(cudaMalloc(
+      &deviceValues, static_cast<std::size_t>(numRanks) * sizeof(uint64_t)));
+  test::launchReadPeerInternalSignals(handle, deviceValues);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  std::vector<uint64_t> values(static_cast<std::size_t>(numRanks));
+  CUDACHECK_TEST(cudaMemcpy(
+      values.data(),
+      deviceValues,
+      values.size() * sizeof(uint64_t),
+      cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaFree(deviceValues));
+
+  std::vector<uint64_t> expected(static_cast<std::size_t>(numRanks));
+  for (int rank = 0; rank < numRanks; ++rank) {
+    expected[static_cast<std::size_t>(rank)] = static_cast<uint64_t>(rank + 1);
+  }
+  EXPECT_EQ(values, expected);
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
 } // namespace
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    DeviceUnicastPeerViewsUseIdentityNvlRankOrder) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_unicast_peer_views_identity");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+  const auto rankMap = identityRankMap(numRanks);
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      rankMap,
+      makeConfig(
+          /*dataBufferSize=*/4096,
+          /*userSignalCount=*/0,
+          1,
+          1,
+          /*enableUnicastPeerViews=*/true));
+  transport.exchange();
+  verifyUnicastPeerViews(bootstrap, globalRank, numRanks, rankMap, transport);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    DeviceUnicastPeerViewsUseConfiguredNvlRankOrder) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_unicast_peer_views_rotated");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+  const auto rankMap = rotatedRankMap(numRanks);
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      rankMap,
+      makeConfig(
+          /*dataBufferSize=*/4096,
+          /*userSignalCount=*/0,
+          1,
+          1,
+          /*enableUnicastPeerViews=*/true));
+  transport.exchange();
+  verifyUnicastPeerViews(bootstrap, globalRank, numRanks, rankMap, transport);
+}
 
 // signal(SET) from rank 0 must broadcast a value to every rank's local
 // signal state; every rank observes it through wait_signal_until +

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -82,6 +82,28 @@ __global__ void readUserAndInternalKernel(
   }
 }
 
+__global__ void setAllPeerInternalSignalsKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t value) {
+  for (auto destination = blockIdx.x * blockDim.x + threadIdx.x;
+       destination < transport.nvlRanks;
+       destination += blockDim.x * gridDim.x) {
+    auto* destinationSignals =
+        transport.internalUnicastSignalsByRank[destination];
+    destinationSignals[transport.nvlRank].signal(SignalOp::SIGNAL_SET, value);
+  }
+}
+
+__global__ void readPeerInternalSignalsKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t* out) {
+  for (auto source = blockIdx.x * blockDim.x + threadIdx.x;
+       source < transport.nvlRanks;
+       source += blockDim.x * gridDim.x) {
+    out[source] = transport.internalLocalSignals[source].load();
+  }
+}
+
 template <typename T>
 __device__ T reductionValue(float value) {
   if constexpr (std::is_same_v<T, __half>) {
@@ -249,6 +271,28 @@ void launchReadUserAndInternal(
     cudaStream_t stream) {
   readUserAndInternalKernel<<<1, 32, 0, stream>>>(
       transport, userId, internalId, out);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchSetAllPeerInternalSignals(
+    MultimemNvlTransportDevice transport,
+    uint64_t value,
+    cudaStream_t stream) {
+  constexpr int kThreads = 256;
+  const int blocks = (transport.nvlRanks + kThreads - 1) / kThreads;
+  setAllPeerInternalSignalsKernel<<<blocks, kThreads, 0, stream>>>(
+      transport, value);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchReadPeerInternalSignals(
+    MultimemNvlTransportDevice transport,
+    uint64_t* out,
+    cudaStream_t stream) {
+  constexpr int kThreads = 256;
+  const int blocks = (transport.nvlRanks + kThreads - 1) / kThreads;
+  readPeerInternalSignalsKernel<<<blocks, kThreads, 0, stream>>>(
+      transport, out);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -100,6 +100,16 @@ void launchReadUserAndInternal(
     uint64_t* out,
     cudaStream_t stream = nullptr);
 
+void launchSetAllPeerInternalSignals(
+    MultimemNvlTransportDevice transport,
+    uint64_t value,
+    cudaStream_t stream = nullptr);
+
+void launchReadPeerInternalSignals(
+    MultimemNvlTransportDevice transport,
+    uint64_t* out,
+    cudaStream_t stream = nullptr);
+
 void launchFillReductionInput(
     MultimemNvlTransportDevice transport,
     MultimemReductionTestType type,

--- a/comms/prims/transport/nvl/MultimemNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.cc
@@ -2,20 +2,30 @@
 
 #include "comms/prims/transport/nvl/MultimemNvlTransport.h"
 
+#include <algorithm>
+#include <exception>
+#include <iterator>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <utility>
 
+#include "comms/prims/bootstrap/NvlBootstrapAdapter.h"
+#include "comms/prims/bootstrap/TeamStatusAgreement.h"
 #include "comms/prims/core/SignalState.cuh"
 #include "comms/utils/checks.h"
+#ifdef __HIP_PLATFORM_AMD__
+#include "comms/prims/transport/amd/HipHostCompat.h"
+#else
+#include "comms/utils/CudaRAII.h"
+#endif
 
 namespace comms::prims {
 
 namespace {
 
 constexpr uint64_t kMultimemNvlTransportProtocol = 0x4D4D4E564CULL;
-constexpr uint64_t kMultimemNvlTransportProtocolVersion = 5;
+constexpr uint64_t kMultimemNvlTransportProtocolVersion = 6;
 
 int getCurrentCudaDevice() {
   int cudaDevice = 0;
@@ -39,6 +49,8 @@ std::vector<int> identityRankMap(int nRanks) {
 }
 
 } // namespace
+
+MultimemNvlTransport::~MultimemNvlTransport() = default;
 
 void MultimemNvlTransport::validateRankMap(
     int commRank,
@@ -76,13 +88,10 @@ MultimemNvlTransport::MultimemNvlTransport(
     int commRank,
     std::vector<int> nvlRankToCommRank,
     const MultimemNvlTransportConfig& config)
-    : commRank_(commRank),
-      nvlRanks_(static_cast<int>(nvlRankToCommRank.size())),
-      nvlRankToCommRank_(std::move(nvlRankToCommRank)),
-      config_(config) {
+    : nvlRanks_(static_cast<int>(nvlRankToCommRank.size())), config_(config) {
   // Topology validation runs BEFORE cudaGetDevice so the rank-map preconditions
   // are exercisable on CPU-only hosts (see MultimemNvlTransportValidationTest).
-  validateRankMap(commRank_, nvlRankToCommRank_);
+  validateRankMap(commRank, nvlRankToCommRank);
 
   const auto validation =
       validate_multimem_nvl_transport_config(config_, nvlRanks_);
@@ -94,21 +103,12 @@ MultimemNvlTransport::MultimemNvlTransport(
   dataBufferSize_ = validation.dataBufferSize;
   internalSignalCount_ = validation.internalSignalCount;
   signalsPerChannel_ = validation.signalsPerChannel;
-  // commRank presence in the map is already verified by validateRankMap.
-  int nvlRank = -1;
-  for (int rank = 0; rank < nvlRanks_; ++rank) {
-    if (nvlRankToCommRank_[static_cast<std::size_t>(rank)] == commRank_) {
-      nvlRank = rank;
-      break;
-    }
-  }
-  // Defensive backstop for the validateRankMap invariant: a -1 here would flow
-  // into device-side signal-slot indexing and produce out-of-bounds offsets, so
-  // fail loudly rather than corrupt memory if the map ever omits this rank.
-  if (nvlRank < 0) {
-    throw std::runtime_error(
-        "MultimemNvlTransport: commRank not found in nvlRankToCommRank_");
-  }
+
+  // validateRankMap() guarantees that commRank appears exactly once.
+  const auto nvlRankIt =
+      std::find(nvlRankToCommRank.begin(), nvlRankToCommRank.end(), commRank);
+  const int nvlRank =
+      static_cast<int>(std::distance(nvlRankToCommRank.begin(), nvlRankIt));
   nvlRank_ = nvlRank;
 
   static_assert(alignof(SignalState) == detail::kMultimemSignalAlignment);
@@ -121,13 +121,14 @@ MultimemNvlTransport::MultimemNvlTransport(
 
   // The GpuMemHandler owns the unicast backing; exchange() adds the multicast
   // overlay over it. Size the allocation to the multicast granularity
-  // (alignFloor) so it is bindable into a multicast object. Only multicast is
-  // used (no P2P exchangeMemPtrs), so the selfRank/nRanks coordinates here are
-  // the NVL-team rank and size.
+  // (alignFloor) so it is bindable into a multicast object. The unicast peer
+  // exchange and multicast exchange both use NVL-team coordinates.
   const std::size_t alignFloor =
       GpuMemHandler::backingGranularity(cudaDevice_, nvlRanks_);
+  nvlBootstrap_ = std::make_shared<NvlBootstrapAdapter>(
+      std::move(bootstrap), std::move(nvlRankToCommRank));
   combinedHandler_ = std::make_unique<GpuMemHandler>(
-      std::move(bootstrap),
+      nvlBootstrap_,
       nvlRank,
       nvlRanks_,
       combinedSize,
@@ -173,11 +174,53 @@ MultimemNvlTransport::MultimemNvlTransport(
           }(),
           config) {}
 
+std::unique_ptr<meta::comms::DeviceBuffer>
+MultimemNvlTransport::exchangeUnicastPeerViews() {
+  combinedHandler_->exchangeMemPtrs();
+
+  std::unique_ptr<meta::comms::DeviceBuffer> devicePeerInternalSignals;
+  std::exception_ptr localError;
+  try {
+    std::vector<SignalState*> peerInternalSignals(
+        static_cast<std::size_t>(nvlRanks_));
+    for (int rank = 0; rank < nvlRanks_; ++rank) {
+      auto* peerBase =
+          static_cast<char*>(combinedHandler_->getPeerDeviceMemPtr(rank));
+      auto* peerSignals =
+          reinterpret_cast<SignalState*>(peerBase + signalRegionOffset_);
+      peerInternalSignals[static_cast<std::size_t>(rank)] =
+          peerSignals + config_.userSignalCount;
+    }
+
+    devicePeerInternalSignals = std::make_unique<meta::comms::DeviceBuffer>(
+        peerInternalSignals.size() * sizeof(SignalState*));
+    FB_CUDACHECKTHROW(cudaMemcpy(
+        devicePeerInternalSignals->get(),
+        peerInternalSignals.data(),
+        peerInternalSignals.size() * sizeof(SignalState*),
+        cudaMemcpyHostToDevice));
+  } catch (...) {
+    localError = std::current_exception();
+  }
+
+  std::vector<detail::TeamStatus> status(static_cast<std::size_t>(nvlRanks_));
+  detail::allGatherAndAgree(
+      *nvlBootstrap_,
+      nvlRank_,
+      nvlRanks_,
+      status,
+      localError,
+      "MultimemNvlTransport::exchange: construct the unicast peer pointer "
+      "table");
+
+  return devicePeerInternalSignals;
+}
+
 void MultimemNvlTransport::exchange() {
-  if (exchanged_) {
+  if (exchangeState_ == ExchangeState::kReady) {
     return;
   }
-  if (broken_) {
+  if (exchangeState_ == ExchangeState::kFailed) {
     throw std::runtime_error(
         "MultimemNvlTransport::exchange: previous exchange() failed; "
         "rebuild the transport to retry (same-object retry is unsafe after "
@@ -194,19 +237,24 @@ void MultimemNvlTransport::exchange() {
                 config_.maxChannels,
                 config_.maxBlocks,
                 config_.userSignalCount,
+                static_cast<uint64_t>(config_.enableUnicastPeerViews),
             },
     };
     combinedHandler_->exchangeMulticast(
-        commRank_, nvlRankToCommRank_, cudaDevice_, contract);
+        nvlRank_, identityRankMap(nvlRanks_), cudaDevice_, contract);
+
+    if (config_.enableUnicastPeerViews) {
+      internalUnicastSignalsByRank_ = exchangeUnicastPeerViews();
+    }
   } catch (...) {
-    broken_ = true;
+    exchangeState_ = ExchangeState::kFailed;
     throw;
   }
-  exchanged_ = true;
+  exchangeState_ = ExchangeState::kReady;
 }
 
 MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
-  if (!exchanged_) {
+  if (exchangeState_ != ExchangeState::kReady) {
     throw std::runtime_error(
         "MultimemNvlTransport: exchange() must complete before device use");
   }
@@ -239,6 +287,12 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
       .pipelineDepth = static_cast<uint32_t>(config_.pipelineDepth),
       .maxChannels = static_cast<uint32_t>(config_.maxChannels),
       .signalsPerChannel = signalsPerChannel_,
+      .internalUnicastSignalsByRank = internalUnicastSignalsByRank_
+          ? DeviceSpan<SignalState*>(
+                static_cast<SignalState**>(
+                    internalUnicastSignalsByRank_->get()),
+                static_cast<uint32_t>(nvlRanks_))
+          : DeviceSpan<SignalState*>{},
   };
 }
 

--- a/comms/prims/transport/nvl/MultimemNvlTransport.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.h
@@ -12,6 +12,10 @@
 #include "comms/prims/transport/nvl/MultimemNvlTransportConfig.h"
 #include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
 
+namespace meta::comms {
+class DeviceBuffer;
+}
+
 namespace comms::prims {
 
 /**
@@ -24,9 +28,8 @@ namespace comms::prims {
  * a signal. The numeric `multimemData` pointer is a process-local CUDA VA and
  * is not part of the cross-rank protocol.
  *
- * The caller must set the current CUDA device before construction. The
- * transport records that device ordinal and passes it to MultimemHandler; it
- * does not switch CUDA devices internally.
+ * The caller owns CUDA device selection and must keep the construction device
+ * current while calling exchange() and destroying the transport.
  *
  * `bootstrap` is the global communicator bootstrap. `commRank` is this
  * process's rank in that global communicator. `nvlRankToCommRank` maps each
@@ -50,7 +53,7 @@ class MultimemNvlTransport {
       std::shared_ptr<meta::comms::IBootstrap> bootstrap,
       const MultimemNvlTransportConfig& config);
 
-  ~MultimemNvlTransport() = default;
+  ~MultimemNvlTransport();
 
   MultimemNvlTransport(const MultimemNvlTransport&) = delete;
   MultimemNvlTransport& operator=(const MultimemNvlTransport&) = delete;
@@ -85,13 +88,21 @@ class MultimemNvlTransport {
       const std::vector<int>& nvlRankToCommRank);
 
  private:
-  const int commRank_{-1};
+  // Collectively imports the peer backing allocations and uploads the
+  // device-resident table of internal-signal pointers.
+  std::unique_ptr<meta::comms::DeviceBuffer> exchangeUnicastPeerViews();
+
+  enum class ExchangeState {
+    kNotStarted,
+    kReady,
+    kFailed,
+  };
+
   const int nvlRanks_{-1};
-  // This rank's index within the NVL team (its position in nvlRankToCommRank_).
+  // This rank's index within the NVL team.
   // Retained so getDeviceTransport() can expose it to the device staging
   // protocol, which keys its per-rank signal slots on the NVL-local rank.
   int nvlRank_{-1};
-  const std::vector<int> nvlRankToCommRank_;
   // Recorded after the rank-map validation in the constructor body so a bad
   // topology fails before cudaGetDevice is consulted (lets tests cover the
   // rank-map preconditions on CPU-only hosts).
@@ -100,12 +111,7 @@ class MultimemNvlTransport {
   std::size_t dataBufferSize_{0};
   uint32_t internalSignalCount_{0};
   uint32_t signalsPerChannel_{0};
-  bool exchanged_{false};
-  // Set when exchange() throws; subsequent calls throw instead of silently
-  // retrying. Multicast object create/import/bind failures can leave partial
-  // driver state, so a same-object retry is unsafe. Callers must rebuild the
-  // transport to recover.
-  bool broken_{false};
+  ExchangeState exchangeState_{ExchangeState::kNotStarted};
 
   // Single GpuMemHandler whose physical allocation contains both the data
   // window and the signal slots back-to-back. Layout: [data | pad-to-128B |
@@ -113,9 +119,11 @@ class MultimemNvlTransport {
   // and, via its multicast overlay (exchangeMulticast), the multicast VA
   // (getMultimemDeviceMemPtr) -- one cuMulticastCreate / one set of binds / one
   // MC VA range over one shared physical backing.
+  std::shared_ptr<meta::comms::IBootstrap> nvlBootstrap_;
   std::unique_ptr<GpuMemHandler> combinedHandler_;
   // Offset of the signal region within combinedHandler_'s allocation.
   std::size_t signalRegionOffset_{0};
+  std::unique_ptr<meta::comms::DeviceBuffer> internalUnicastSignalsByRank_;
 };
 
 } // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlTransportConfig.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransportConfig.h
@@ -31,6 +31,9 @@ struct MultimemNvlTransportConfigParams {
   // Signal slots exposed through signal(), read_signal(), and
   // wait_signal_until(). This is orthogonal to staging geometry.
   uint32_t userSignalCount{0};
+
+  // Import and map every peer's backing allocation for unicast signaling.
+  bool enableUnicastPeerViews{false};
 };
 
 struct MultimemNvlTransportConfig {
@@ -42,13 +45,15 @@ struct MultimemNvlTransportConfig {
         pipelineDepth(params.pipelineDepth),
         maxChannels(params.maxChannels),
         maxBlocks(params.maxBlocks),
-        userSignalCount(params.userSignalCount) {}
+        userSignalCount(params.userSignalCount),
+        enableUnicastPeerViews(params.enableUnicastPeerViews) {}
 
   std::size_t perChannelSize{0};
   std::size_t pipelineDepth{0};
   std::size_t maxChannels{0};
   std::size_t maxBlocks{0};
   uint32_t userSignalCount{0};
+  bool enableUnicastPeerViews{false};
 
   bool operator==(const MultimemNvlTransportConfig&) const = default;
 };

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -79,6 +79,9 @@ struct MultimemNvlTransportDevice {
   uint32_t pipelineDepth{0};
   uint32_t maxChannels{0};
   uint32_t signalsPerChannel{0};
+  // Indexed by NVL-local destination rank. Each entry addresses the base of
+  // that destination's internal signal slots through its unicast mapping.
+  DeviceSpan<SignalState*> internalUnicastSignalsByRank{};
 
   __device__ __forceinline__ char* local_data_ptr(std::size_t offset) const {
     return localData + offset;


### PR DESCRIPTION
Summary:

Expose a device-resident table of internal signal pointers indexed by NVL-local destination rank from MultimemNvlTransportDevice. Reuse NvlBootstrapAdapter, GpuMemHandler::exchangeMemPtrs(), and getPeerDeviceMemPtr() so unicast peer views and the multicast view address the same transport-owned physical backing.

Keep CUDA-device ownership at the existing MultiPeerNvlTransport boundary: the inner MultimemNvlTransport no longer duplicates device switching or teardown policy. Own the pointer table with DeviceBuffer and represent exchange lifecycle with one state enum.

Use TeamStatusAgreement only around pointer-table construction, where a rank-local allocation or upload failure must reach the whole NVL team.

Reviewed By: goelayu

Differential Revision: D115430338


