### PR TITLE
Add uniform NVL signal primitives (#3551)

### DIFF
--- a/comms/prims/docs/UniformNvlSignals.md
+++ b/comms/prims/docs/UniformNvlSignals.md
@@ -48,6 +48,9 @@ ackEpoch(lane)     = laneBase + 3
 ```
 
 The peer stripes are shared across pipeline lanes and carry monotonic round values.
+Every `StageRound` must carry a nonzero value.
+Per-peer round values begin at one and advance monotonically, with successive comparisons remaining within half of the `uint64_t` sequence space.
+Callers skip the reserved zero value when a per-peer sequence wraps.
 Aggregate counters are lane-private so concurrent pipeline rounds cannot mix their arrivals.
 Aggregate consumed signaling is unsupported because the layout has no consumed counter or epoch.
 
@@ -109,12 +112,17 @@ enum class NvlPerPeerWaitPolicy {
 ```
 
 `signal_publish`, `signal_wait`, and `signal_publish_and_wait` take the transport device handle, a channel and round description, participant roles, a thread group, and a timeout where waiting is required.
-`NvlSignalParticipants` identifies the coordinator, active publishers, active waiters, and expected arrival count without embedding benchmark-specific control flow in the primitive.
+`NvlSignalParticipants` identifies the active publishers, active waiters, and expected arrival count without embedding benchmark-specific control flow in the primitive.
+
+Aggregate multimem operations require `signal_publish_and_wait` on every rank because every multicast destination must reserve the same epoch increment.
+The split `signal_publish` and `signal_wait` entry points reject aggregate multimem at compile time.
+They remain available for per-peer protocols and aggregate unicast protocols whose counter updates target only selected waiters.
 
 The following combinations are rejected at compile time:
 
 - Aggregate topology with a non-default per-peer wait policy.
 - Aggregate topology with consumed phase.
+- Split aggregate multimem publication or waiting.
 - A phase or access operation that has no storage or instruction mapping.
 
 Host launch validation rejects aggregate pipeline depth above one warp and per-peer teams above two warps.
@@ -143,8 +151,11 @@ thread 0     owns NVL peer 0
 thread 1     owns NVL peer 1
 ...
 thread R - 1 owns NVL peer R - 1
-threads R..63 do not publish or wait
+threads R..63 own no peer slot
 ```
+
+All 64 threads participate in required block synchronization.
+`TreeMin` and `ButterflyMin` additionally use all threads for their reductions.
 
 Per-peer slots are shared across pipeline lanes, so per-peer operations use pipeline depth one.
 Their round value is monotonic across reuse of the same stripe.
@@ -166,29 +177,36 @@ The wait policies have identical completion and timeout semantics:
 3. `TreeMin` distributes slot loads and reduces completion through a block-wide tree.
 4. `ButterflyMin` distributes slot loads and reduces completion through a block-wide butterfly exchange.
 
-The completion predicate is always that every required peer slot has reached the selected round.
+The completion predicate is always that every required peer slot has reached or advanced beyond the selected round within half of the `uint64_t` sequence space.
+This modular comparison remains correct across wraparound and prevents a faster publisher from stranding a waiter on an earlier exact value.
 Wait-policy selection changes observation geometry, not protocol semantics.
 
 ## Aggregate Topology
 
 Aggregate multicast publication issues one `multimem.red.release.sys.global.add.u64` for each active lane.
 Every publisher targets the counter owned by its channel and lane.
-Global completion advances each counter by `R`.
-Fan-in completion advances each coordinator-observed counter by `R - 1`.
+The multicast instruction advances the corresponding counter on every rank, regardless of which ranks wait for that operation.
+Global completion advances each rank's counter by `R`.
+Fan-in completion advances each rank's counter by `R - 1`.
 
 Aggregate unicast publication atomically adds through the destination's unicast mapping.
 Fan-in publishers target the coordinator's lane counter.
 Global publishers update every destination's lane counter, including their local destination.
 
 Each active lane owner waits on the corresponding local counter with acquire semantics.
-After completion it advances the lane's local epoch baseline.
+For multicast access, every rank advances its local epoch by the expected arrival count for every operation.
+A selected waiter advances the epoch after observing the counter, while a nonwaiter reserves the same arrival count without blocking.
+This keeps each rank's counter and epoch accounting aligned when the waiter mask changes on a reused channel and lane.
+For unicast access, only selected waiters receive counter updates and advance their epochs.
+If the counter already contains later arrivals, the waiter completes the current epoch and leaves the additional arrivals available to later epochs.
 For `B` channels and `P` active lanes, the protocol uses `B * P` independent counters.
 It never redirects all channel arrivals into one counter.
 
 ## Ordering
 
 Unicast publication uses the existing system-scope release store or atomic add in `SignalState`.
-Unicast waiting uses the existing system-scope acquire load in `SignalState::wait_until`.
+Waiting polls `SignalState::load` with system-scope acquire semantics and the modular sequence predicate.
+A caller that enables a timeout starts the `Timeout` before entering the primitive.
 
 Multicast per-peer publication uses `multimem.st.release.sys.global.u64`.
 Multicast aggregate publication uses `multimem.red.release.sys.global.add.u64`.

--- a/comms/prims/memory/NvlMemExchange.h
+++ b/comms/prims/memory/NvlMemExchange.h
@@ -38,7 +38,7 @@ namespace comms::prims {
 struct MulticastExchangeContract {
   uint64_t protocol{0};
   uint64_t version{0};
-  std::array<uint64_t, 5> parameters{};
+  std::array<uint64_t, 6> parameters{};
 
   bool operator==(const MulticastExchangeContract& other) const {
     return protocol == other.protocol && version == other.version &&

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cc
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cc
@@ -1,0 +1,33 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include "comms/prims/tests/MultimemNvlSignalTrapTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+#ifndef NVL_SIGNAL_TRAP_CASE
+#error "NVL_SIGNAL_TRAP_CASE must select one isolated trap case"
+#endif
+
+namespace comms::prims::tests {
+
+TEST(MultimemNvlSignalTrapTest, InvalidGeometryTraps) {
+  int deviceCount = 0;
+  CUDACHECK_TEST(cudaGetDeviceCount(&deviceCount));
+  if (deviceCount == 0) {
+    GTEST_SKIP() << "No CUDA devices available";
+  }
+  CUDACHECK_TEST(cudaSetDevice(0));
+
+  test::launchNvlSignalTrap(
+      static_cast<test::NvlSignalTrapCase>(NVL_SIGNAL_TRAP_CASE));
+  const auto error = cudaDeviceSynchronize();
+  EXPECT_TRUE(
+      error == cudaErrorIllegalInstruction || error == cudaErrorAssert ||
+      error == cudaErrorLaunchFailure)
+      << cudaGetErrorString(error);
+  EXPECT_EQ(cudaDeviceReset(), cudaSuccess);
+}
+
+} // namespace comms::prims::tests

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cu
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cu
@@ -1,0 +1,92 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/tests/MultimemNvlSignalTrapTest.cuh"
+
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlSignal.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+__device__ alignas(SignalState) uint64_t
+    trapSignalStorage[16 * sizeof(SignalState) / sizeof(uint64_t)];
+
+__global__ void nvlSignalTrapKernel(NvlSignalTrapCase testCase) {
+  auto* trapSignals = reinterpret_cast<SignalState*>(trapSignalStorage);
+  SignalState* peerSignals[4] = {
+      trapSignals, trapSignals, trapSignals, trapSignals};
+  const bool tooManyRanks = testCase == NvlSignalTrapCase::RankCountTooLarge;
+  const uint32_t pipelineDepth =
+      testCase == NvlSignalTrapCase::AggregateDepthTooLarge ? 33 : 1;
+  const int nvlRanks = tooManyRanks ? 65 : 4;
+  const uint32_t signalsPerChannel =
+      static_cast<uint32_t>(3 * nvlRanks + 4 * pipelineDepth);
+  MultimemNvlTransportDevice transport{
+      .internalLocalSignals =
+          DeviceSpan<SignalState>(trapSignals, signalsPerChannel),
+      .internalMultimemSignals =
+          DeviceSpan<SignalState>(trapSignals, signalsPerChannel),
+      .nvlRank = 0,
+      .nvlRanks = nvlRanks,
+      .pipelineDepth = pipelineDepth,
+      .maxChannels = 1,
+      .signalsPerChannel = signalsPerChannel,
+      .internalUnicastSignalsByRank = DeviceSpan<SignalState*>(peerSignals, 4),
+  };
+  const NvlSignalParticipants participants{
+      .publisherMask = 1,
+      .waiterMask = 1,
+      .expectedArrivals =
+          testCase == NvlSignalTrapCase::ArrivalCountMismatch ? 2u : 1u,
+  };
+  const StageRound round{
+      .channel = 0,
+      .value = testCase == NvlSignalTrapCase::ZeroRound ? 0u : 1u,
+  };
+  if (testCase == NvlSignalTrapCase::WaitTimeout) {
+    auto group = make_block_group();
+    Timeout timeout{1};
+    timeout.start();
+    signal_wait<
+        NvlSignalAccess::Unicast,
+        NvlSignalTopology::PerPeer,
+        NvlSignalPhase::Ready>(
+        transport,
+        round,
+        NvlSignalParticipants{
+            .publisherMask = uint64_t{1} << 1,
+            .waiterMask = 1,
+            .expectedArrivals = 1,
+        },
+        group,
+        timeout);
+    return;
+  }
+  if (testCase == NvlSignalTrapCase::AggregateDepthTooLarge ||
+      testCase == NvlSignalTrapCase::ArrivalCountMismatch) {
+    auto group = make_warp_group();
+    signal_publish_and_wait<
+        NvlSignalAccess::Multimem,
+        NvlSignalTopology::Aggregate,
+        NvlSignalPhase::Ready>(
+        transport, round, participants, group, Timeout{});
+    return;
+  }
+  auto group = make_block_group();
+  signal_publish<
+      NvlSignalAccess::Multimem,
+      NvlSignalTopology::PerPeer,
+      NvlSignalPhase::Ready>(transport, round, participants, group);
+}
+
+} // namespace
+
+void launchNvlSignalTrap(NvlSignalTrapCase testCase) {
+  const uint32_t threads =
+      testCase == NvlSignalTrapCase::PerPeerGroupTooSmall ? 32 : 64;
+  nvlSignalTrapKernel<<<1, threads>>>(
+      testCase); // NOLINT(facebook-cuda-safe-kernel-call-check)
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
@@ -1,0 +1,21 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#include <cstdint>
+
+namespace comms::prims::test {
+
+enum class NvlSignalTrapCase : uint32_t {
+  AggregateDepthTooLarge,
+  RankCountTooLarge,
+  ArrivalCountMismatch,
+  PerPeerGroupTooSmall,
+  WaitTimeout,
+  ZeroRound,
+};
+
+void launchNvlSignalTrap(NvlSignalTrapCase testCase);
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -49,6 +49,12 @@ std::vector<int> identityRankMap(int size) {
   return rankMap;
 }
 
+std::vector<int> rotatedRankMap(int size) {
+  auto rankMap = identityRankMap(size);
+  std::rotate(rankMap.begin(), rankMap.begin() + 1, rankMap.end());
+  return rankMap;
+}
+
 // Collective check: returns true iff every rank reports that multimem is
 // eligible on the given CUDA device. Tests use this to skip cleanly on
 // non-NVLS hosts without leaving stragglers blocked in downstream collectives.
@@ -78,7 +84,8 @@ MultimemNvlTransportConfig makeConfig(
     std::size_t dataBufferSize,
     uint32_t userSignalCount = 1,
     std::size_t pipelineDepth = 0,
-    std::size_t maxChannels = 0) {
+    std::size_t maxChannels = 0,
+    bool enableUnicastPeerViews = false) {
   const std::size_t effectiveMaxChannels =
       std::max<std::size_t>(1, maxChannels);
   return make_multimem_nvl_transport_config({
@@ -87,6 +94,7 @@ MultimemNvlTransportConfig makeConfig(
       .maxChannels = effectiveMaxChannels,
       .maxBlocks = maxChannels,
       .userSignalCount = userSignalCount,
+      .enableUnicastPeerViews = enableUnicastPeerViews,
   });
 }
 
@@ -761,6 +769,7 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
   EXPECT_EQ(handle.pipelineDepth, 1);
   EXPECT_EQ(handle.maxChannels, 1);
   EXPECT_EQ(handle.signalsPerChannel, internalSignals);
+  EXPECT_TRUE(handle.internalUnicastSignalsByRank.empty());
 
   EXPECT_EQ(transport.getAllocatedDataBufferSize(), kDataBytes);
   EXPECT_EQ(
@@ -812,6 +821,61 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSupportsDataOnlyConfiguration) {
   ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 }
 
+TEST_F(MultimemNvlTransportTestFixture, PeerViewKernelsCoverNvl72) {
+  constexpr int kNvlRanks = 72;
+  constexpr int kSourceRank = kNvlRanks - 1;
+  constexpr uint64_t kValue = 0x123456789ABCDEF0ULL;
+  const std::size_t signalCount =
+      static_cast<std::size_t>(kNvlRanks) * kNvlRanks;
+
+  SignalState* signals = nullptr;
+  SignalState** pointerTable = nullptr;
+  uint64_t* output = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&signals, signalCount * sizeof(SignalState)));
+  CUDACHECK_TEST(cudaMemset(signals, 0, signalCount * sizeof(SignalState)));
+  CUDACHECK_TEST(cudaMalloc(&pointerTable, kNvlRanks * sizeof(SignalState*)));
+  CUDACHECK_TEST(cudaMalloc(&output, kNvlRanks * sizeof(uint64_t)));
+  CUDACHECK_TEST(cudaMemset(output, 0, kNvlRanks * sizeof(uint64_t)));
+
+  std::vector<SignalState*> hostPointerTable(kNvlRanks);
+  for (int destination = 0; destination < kNvlRanks; ++destination) {
+    hostPointerTable[static_cast<std::size_t>(destination)] =
+        signals + static_cast<std::size_t>(destination) * kNvlRanks;
+  }
+  CUDACHECK_TEST(cudaMemcpy(
+      pointerTable,
+      hostPointerTable.data(),
+      hostPointerTable.size() * sizeof(SignalState*),
+      cudaMemcpyHostToDevice));
+
+  MultimemNvlTransportDevice transport{
+      .internalLocalSignals = DeviceSpan<SignalState>(
+          signals + static_cast<std::size_t>(kSourceRank) * kNvlRanks,
+          kNvlRanks),
+      .nvlRank = kSourceRank,
+      .nvlRanks = kNvlRanks,
+      .internalUnicastSignalsByRank =
+          DeviceSpan<SignalState*>(pointerTable, kNvlRanks),
+  };
+  test::launchSetAllPeerInternalSignals(transport, kValue);
+  test::launchReadPeerInternalSignals(transport, output);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<uint64_t> values(kNvlRanks);
+  CUDACHECK_TEST(cudaMemcpy(
+      values.data(),
+      output,
+      values.size() * sizeof(uint64_t),
+      cudaMemcpyDeviceToHost));
+  std::vector<uint64_t> expected(kNvlRanks);
+  expected.back() = kValue;
+  EXPECT_EQ(values, expected);
+
+  CUDACHECK_TEST(cudaFree(output));
+  CUDACHECK_TEST(cudaFree(pointerTable));
+  CUDACHECK_TEST(cudaFree(signals));
+}
+
 TEST_F(
     MultimemNvlTransportTestFixture,
     ExchangeRejectsMismatchedStagingGeometry) {
@@ -838,9 +902,11 @@ TEST_F(
     EXPECT_NE(
         message.find("ranks disagree on multicast setup"), std::string::npos)
         << message;
-    EXPECT_NE(message.find("parameters=[2048, 2, 4, 4, 1]"), std::string::npos)
+    EXPECT_NE(
+        message.find("parameters=[2048, 2, 4, 4, 1, 0]"), std::string::npos)
         << message;
-    EXPECT_NE(message.find("parameters=[4096, 4, 2, 2, 1]"), std::string::npos)
+    EXPECT_NE(
+        message.find("parameters=[4096, 4, 2, 2, 1, 0]"), std::string::npos)
         << message;
   }
 
@@ -872,9 +938,47 @@ TEST_F(
     EXPECT_NE(
         message.find("ranks disagree on multicast setup"), std::string::npos)
         << message;
-    EXPECT_NE(message.find("parameters=[8192, 1, 1, 1, 1]"), std::string::npos)
+    EXPECT_NE(
+        message.find("parameters=[8192, 1, 1, 1, 1, 0]"), std::string::npos)
         << message;
-    EXPECT_NE(message.find("parameters=[8192, 1, 1, 1, 2]"), std::string::npos)
+    EXPECT_NE(
+        message.find("parameters=[8192, 1, 1, 1, 2, 0]"), std::string::npos)
+        << message;
+  }
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    ExchangeRejectsMismatchedUnicastPeerViewEnablement) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_exchange_mismatched_peer_views");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  const bool enableUnicastPeerViews = globalRank == 0;
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(4096, 0, 1, 1, enableUnicastPeerViews));
+  try {
+    transport.exchange();
+    FAIL() << "expected setup agreement to reject mismatched peer views";
+  } catch (const std::runtime_error& ex) {
+    const std::string message = ex.what();
+    EXPECT_NE(
+        message.find("ranks disagree on multicast setup"), std::string::npos)
+        << message;
+    EXPECT_NE(
+        message.find("parameters=[4096, 1, 1, 1, 0, 0]"), std::string::npos)
+        << message;
+    EXPECT_NE(
+        message.find("parameters=[4096, 1, 1, 1, 0, 1]"), std::string::npos)
         << message;
   }
 
@@ -1154,7 +1258,97 @@ std::unique_ptr<MultimemNvlTransport> makeExchangedTransport(
   return transport;
 }
 
+void verifyUnicastPeerViews(
+    const std::shared_ptr<meta::comms::IBootstrap>& bootstrap,
+    int globalRank,
+    int numRanks,
+    const std::vector<int>& rankMap,
+    MultimemNvlTransport& transport) {
+  const auto handle = transport.getDeviceTransport();
+  ASSERT_EQ(handle.internalUnicastSignalsByRank.size(), numRanks);
+
+  const auto nvlRankIt = std::find(rankMap.begin(), rankMap.end(), globalRank);
+  ASSERT_NE(nvlRankIt, rankMap.end());
+  const int nvlRank = static_cast<int>(nvlRankIt - rankMap.begin());
+  EXPECT_EQ(handle.nvlRank, nvlRank);
+
+  test::launchSetAllPeerInternalSignals(
+      handle, static_cast<uint64_t>(nvlRank + 1));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+
+  uint64_t* deviceValues = nullptr;
+  CUDACHECK_TEST(cudaMalloc(
+      &deviceValues, static_cast<std::size_t>(numRanks) * sizeof(uint64_t)));
+  test::launchReadPeerInternalSignals(handle, deviceValues);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  std::vector<uint64_t> values(static_cast<std::size_t>(numRanks));
+  CUDACHECK_TEST(cudaMemcpy(
+      values.data(),
+      deviceValues,
+      values.size() * sizeof(uint64_t),
+      cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaFree(deviceValues));
+
+  std::vector<uint64_t> expected(static_cast<std::size_t>(numRanks));
+  for (int rank = 0; rank < numRanks; ++rank) {
+    expected[static_cast<std::size_t>(rank)] = static_cast<uint64_t>(rank + 1);
+  }
+  EXPECT_EQ(values, expected);
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
 } // namespace
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    DeviceUnicastPeerViewsUseIdentityNvlRankOrder) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_unicast_peer_views_identity");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+  const auto rankMap = identityRankMap(numRanks);
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      rankMap,
+      makeConfig(
+          /*dataBufferSize=*/4096,
+          /*userSignalCount=*/0,
+          1,
+          1,
+          /*enableUnicastPeerViews=*/true));
+  transport.exchange();
+  verifyUnicastPeerViews(bootstrap, globalRank, numRanks, rankMap, transport);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    DeviceUnicastPeerViewsUseConfiguredNvlRankOrder) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_unicast_peer_views_rotated");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+  const auto rankMap = rotatedRankMap(numRanks);
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      rankMap,
+      makeConfig(
+          /*dataBufferSize=*/4096,
+          /*userSignalCount=*/0,
+          1,
+          1,
+          /*enableUnicastPeerViews=*/true));
+  transport.exchange();
+  verifyUnicastPeerViews(bootstrap, globalRank, numRanks, rankMap, transport);
+}
 
 // signal(SET) from rank 0 must broadcast a value to every rank's local
 // signal state; every rank observes it through wait_signal_until +

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -1235,6 +1235,23 @@ struct DeviceUint64Slot {
   uint64_t* ptr_{nullptr};
 };
 
+template <typename Launch>
+std::vector<uint64_t> runSignalProtocol(std::size_t valueCount, Launch launch) {
+  uint64_t* deviceValues = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&deviceValues, valueCount * sizeof(uint64_t)));
+  CUDACHECK_TEST(cudaMemset(deviceValues, 0, valueCount * sizeof(uint64_t)));
+  launch(deviceValues);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  std::vector<uint64_t> values(valueCount);
+  CUDACHECK_TEST(cudaMemcpy(
+      values.data(),
+      deviceValues,
+      values.size() * sizeof(uint64_t),
+      cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaFree(deviceValues));
+  return values;
+}
+
 // Convenience: construct + exchange a transport with the given signal
 // counts. Skips the caller test if the NVL team isn't multimem-eligible.
 std::unique_ptr<MultimemNvlTransport> makeExchangedTransport(
@@ -1348,6 +1365,531 @@ TEST_F(
           /*enableUnicastPeerViews=*/true));
   transport.exchange();
   verifyUnicastPeerViews(bootstrap, globalRank, numRanks, rankMap, transport);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    UniformSignalAggregateSupportsBothAccessPathsAndScopes) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  constexpr uint32_t kPipelineDepth = 4;
+  uint32_t caseIndex = 0;
+  for (const auto access :
+       {NvlSignalAccess::Unicast, NvlSignalAccess::Multimem}) {
+    for (const bool fanIn : {false, true}) {
+      auto bootstrap = makeBootstrap(
+          "mmnvl_uniform_aggregate_matrix_" + std::to_string(caseIndex++));
+      if (!allRanksMultimemEligible(
+              bootstrap, globalRank, numRanks, localRank)) {
+        GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+      }
+      MultimemNvlTransport transport(
+          bootstrap,
+          globalRank,
+          identityRankMap(numRanks),
+          makeConfig(
+              4096,
+              0,
+              kPipelineDepth,
+              1,
+              /*enableUnicastPeerViews=*/true));
+      transport.exchange();
+      const auto values =
+          runSignalProtocol(2 * kPipelineDepth, [&](uint64_t* output) {
+            test::launchAggregateSignalProtocol(
+                transport.getDeviceTransport(),
+                access,
+                NvlSignalPhase::Ready,
+                fanIn,
+                /*roundValue=*/1,
+                output);
+          });
+      if (!fanIn || globalRank == 0) {
+        const std::vector<uint64_t> expected(
+            values.size(),
+            static_cast<uint64_t>(fanIn ? numRanks - 1 : numRanks));
+        EXPECT_EQ(values, expected);
+      }
+      ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+    }
+  }
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    UniformSignalPerPeerCoversPhasePolicyAccessAndScope) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_uniform_per_peer_matrix");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(
+          4096,
+          0,
+          /*pipelineDepth=*/1,
+          /*maxChannels=*/1,
+          /*enableUnicastPeerViews=*/true));
+  transport.exchange();
+
+  struct PerPeerProtocolCase {
+    NvlSignalAccess access;
+    NvlSignalPhase phase;
+    NvlPerPeerWaitPolicy waitPolicy;
+  };
+  // Access and phase affect publication and signal selection. Wait policy
+  // affects only observation. Cover those dimensions orthogonally instead of
+  // instantiating their full Cartesian product.
+  constexpr PerPeerProtocolCase kProtocols[] = {
+      {
+          NvlSignalAccess::Unicast,
+          NvlSignalPhase::Ready,
+          NvlPerPeerWaitPolicy::WaitAll,
+      },
+      {
+          NvlSignalAccess::Unicast,
+          NvlSignalPhase::Ack,
+          NvlPerPeerWaitPolicy::WaitAll,
+      },
+      {
+          NvlSignalAccess::Unicast,
+          NvlSignalPhase::Consumed,
+          NvlPerPeerWaitPolicy::WaitAll,
+      },
+      {
+          NvlSignalAccess::Multimem,
+          NvlSignalPhase::Ready,
+          NvlPerPeerWaitPolicy::WaitAll,
+      },
+      {
+          NvlSignalAccess::Multimem,
+          NvlSignalPhase::Ack,
+          NvlPerPeerWaitPolicy::WaitAll,
+      },
+      {
+          NvlSignalAccess::Multimem,
+          NvlSignalPhase::Consumed,
+          NvlPerPeerWaitPolicy::WaitAll,
+      },
+      {
+          NvlSignalAccess::Multimem,
+          NvlSignalPhase::Ready,
+          NvlPerPeerWaitPolicy::SerialMin,
+      },
+      {
+          NvlSignalAccess::Multimem,
+          NvlSignalPhase::Ready,
+          NvlPerPeerWaitPolicy::TreeMin,
+      },
+      {
+          NvlSignalAccess::Multimem,
+          NvlSignalPhase::Ready,
+          NvlPerPeerWaitPolicy::ButterflyMin,
+      },
+  };
+
+  uint64_t roundValue = 1;
+  for (const auto& protocol : kProtocols) {
+    for (const bool fanIn : {false, true}) {
+      const auto values = runSignalProtocol(
+          static_cast<std::size_t>(numRanks), [&](uint64_t* output) {
+            if (protocol.waitPolicy == NvlPerPeerWaitPolicy::WaitAll) {
+              test::launchPerPeerWaitAllSignalProtocol(
+                  transport.getDeviceTransport(),
+                  protocol.access,
+                  protocol.phase,
+                  fanIn,
+                  roundValue,
+                  output);
+            } else {
+              test::launchMultimemReadyPerPeerSignalProtocol(
+                  transport.getDeviceTransport(),
+                  protocol.waitPolicy,
+                  fanIn,
+                  roundValue,
+                  output);
+            }
+          });
+      if (!fanIn || globalRank == 0) {
+        std::vector<uint64_t> expected(static_cast<std::size_t>(numRanks), 0);
+        if (fanIn) {
+          expected[0] = roundValue - 1;
+        }
+        for (int source = fanIn ? 1 : 0; source < numRanks; ++source) {
+          expected[static_cast<std::size_t>(source)] = roundValue;
+        }
+        EXPECT_EQ(values, expected);
+      }
+      ++roundValue;
+      ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+    }
+  }
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    UniformSignalRoundTripUsesOneMultimemAggregateAckPublisher) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  constexpr uint32_t kPipelineDepth = 4;
+  auto bootstrap = makeBootstrap("mmnvl_uniform_rtt");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(4096, 0, kPipelineDepth, 1));
+  transport.exchange();
+  const auto handle = transport.getDeviceTransport();
+  const auto values =
+      runSignalProtocol(4 * kPipelineDepth, [&](uint64_t* output) {
+        test::launchAggregateSignalProtocol(
+            handle,
+            NvlSignalAccess::Multimem,
+            NvlSignalPhase::Ready,
+            /*fanIn=*/true,
+            /*roundValue=*/1,
+            output);
+        test::launchAggregateAckSignalProtocol(
+            handle, /*roundValue=*/1, output + 2 * kPipelineDepth);
+      });
+  const std::vector<uint64_t> expectedAck(2 * kPipelineDepth, 1);
+  EXPECT_EQ(
+      std::vector<uint64_t>(values.begin() + 2 * kPipelineDepth, values.end()),
+      expectedAck);
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    UniformSignalAggregateSupportsEveryPipelineDepth) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  for (const uint32_t pipelineDepth : {1, 2, 4, 8, 16, 32}) {
+    auto bootstrap =
+        makeBootstrap("mmnvl_uniform_depth_" + std::to_string(pipelineDepth));
+    if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+      GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+    }
+    MultimemNvlTransport transport(
+        bootstrap,
+        globalRank,
+        identityRankMap(numRanks),
+        makeConfig(4096, 0, pipelineDepth, 1));
+    transport.exchange();
+    const auto values =
+        runSignalProtocol(2 * pipelineDepth, [&](uint64_t* output) {
+          test::launchAggregateSignalProtocol(
+              transport.getDeviceTransport(),
+              NvlSignalAccess::Multimem,
+              NvlSignalPhase::Ready,
+              /*fanIn=*/false,
+              /*roundValue=*/1,
+              output);
+        });
+    const std::vector<uint64_t> expected(
+        values.size(), static_cast<uint64_t>(numRanks));
+    EXPECT_EQ(values, expected);
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+  }
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    UniformSignalPerPeerRoundTripUsesAggregateAck) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_uniform_per_peer_rtt");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(4096, 0, /*pipelineDepth=*/1, /*maxChannels=*/1));
+  transport.exchange();
+
+  constexpr uint64_t kRoundValue = 1;
+  const auto handle = transport.getDeviceTransport();
+  const auto values = runSignalProtocol(
+      static_cast<std::size_t>(numRanks + 2), [&](uint64_t* output) {
+        test::launchPerPeerWaitAllSignalProtocol(
+            handle,
+            NvlSignalAccess::Multimem,
+            NvlSignalPhase::Ready,
+            /*fanIn=*/true,
+            kRoundValue,
+            output);
+        test::launchAggregateAckSignalProtocol(
+            handle, kRoundValue, output + numRanks);
+      });
+  EXPECT_EQ(values[static_cast<std::size_t>(numRanks)], kRoundValue);
+  EXPECT_EQ(values[static_cast<std::size_t>(numRanks + 1)], kRoundValue);
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    UniformSignalKeepsChannelsAndLanesIndependent) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  constexpr uint32_t kChannels = 4;
+  constexpr uint32_t kPipelineDepth = 4;
+  auto bootstrap = makeBootstrap("mmnvl_uniform_channel_isolation");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(16384, 0, kPipelineDepth, kChannels));
+  transport.exchange();
+  const auto values =
+      runSignalProtocol(2 * kChannels * kPipelineDepth, [&](uint64_t* output) {
+        test::launchMultiChannelAggregateSignal(
+            transport.getDeviceTransport(), kChannels, output);
+      });
+  const std::vector<uint64_t> expected(
+      values.size(), static_cast<uint64_t>(numRanks));
+  EXPECT_EQ(values, expected);
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    UniformSignalAggregateMultimemAccountsForWaiterTransitions) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  constexpr uint32_t kPipelineDepth = 4;
+  auto bootstrap = makeBootstrap("mmnvl_uniform_waiter_transition");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(4096, 0, kPipelineDepth, /*maxChannels=*/1));
+  transport.exchange();
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+
+  const auto values =
+      runSignalProtocol(2 * kPipelineDepth, [&](uint64_t* output) {
+        test::launchAggregateMultimemWaiterTransition(
+            transport.getDeviceTransport(), output);
+      });
+  const uint64_t expected = static_cast<uint64_t>(2 * numRanks - 1);
+  EXPECT_EQ(values, std::vector<uint64_t>(values.size(), expected));
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    UniformSignalPublishAndWaitComposeAcrossRanks) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_uniform_separate_publish_wait");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(
+          4096,
+          0,
+          /*pipelineDepth=*/1,
+          /*maxChannels=*/1,
+          /*enableUnicastPeerViews=*/true));
+  transport.exchange();
+  constexpr uint64_t kRound = 17;
+  const auto values = runSignalProtocol(
+      static_cast<std::size_t>(numRanks), [&](uint64_t* output) {
+        test::launchSeparatePublishAndWait(
+            transport.getDeviceTransport(), kRound, output);
+      });
+  if (globalRank == 0) {
+    std::vector<uint64_t> expected(static_cast<std::size_t>(numRanks), kRound);
+    expected[0] = 0;
+    EXPECT_EQ(values, expected);
+  }
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    UniformSignalPerPeerRoundValuesSkipReservedZero) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_uniform_per_peer_wrap");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(
+          4096,
+          0,
+          /*pipelineDepth=*/1,
+          /*maxChannels=*/1,
+          /*enableUnicastPeerViews=*/true));
+  transport.exchange();
+  test::launchSetAllPeerInternalSignals(
+      transport.getDeviceTransport(), ~uint64_t{0} - 1);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+  for (const uint64_t roundValue : {~uint64_t{0}, uint64_t{1}}) {
+    const auto values = runSignalProtocol(
+        static_cast<std::size_t>(numRanks), [&](uint64_t* output) {
+          test::launchPerPeerWaitAllSignalProtocol(
+              transport.getDeviceTransport(),
+              NvlSignalAccess::Multimem,
+              NvlSignalPhase::Ready,
+              /*fanIn=*/false,
+              roundValue,
+              output);
+        });
+    EXPECT_EQ(
+        values,
+        std::vector<uint64_t>(static_cast<std::size_t>(numRanks), roundValue));
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+  }
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    UniformSignalAggregateCountersAndEpochsWrapToZero) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  constexpr uint32_t kPipelineDepth = 4;
+  auto bootstrap = makeBootstrap("mmnvl_uniform_aggregate_wrap");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(4096, 0, kPipelineDepth, /*maxChannels=*/1));
+  transport.exchange();
+  const uint64_t initial = ~uint64_t{0} - static_cast<uint64_t>(numRanks - 1);
+  test::launchInitializeAggregateSignals(
+      transport.getDeviceTransport(), initial, initial);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+
+  const auto values =
+      runSignalProtocol(2 * kPipelineDepth, [&](uint64_t* output) {
+        test::launchAggregateSignalProtocol(
+            transport.getDeviceTransport(),
+            NvlSignalAccess::Multimem,
+            NvlSignalPhase::Ready,
+            /*fanIn=*/false,
+            /*roundValue=*/1,
+            output);
+      });
+  EXPECT_EQ(values, std::vector<uint64_t>(values.size(), 0));
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    UniformSignalWaitAcceptsAlreadyAdvancedPeerRounds) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_uniform_per_peer_advanced");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(
+          4096,
+          0,
+          /*pipelineDepth=*/1,
+          /*maxChannels=*/1,
+          /*enableUnicastPeerViews=*/true));
+  transport.exchange();
+  constexpr uint64_t kExpectedRound = 41;
+  constexpr uint64_t kObservedRound = kExpectedRound + 1;
+  test::launchSetAllPeerInternalSignals(
+      transport.getDeviceTransport(), kObservedRound);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+  const auto values = runSignalProtocol(
+      static_cast<std::size_t>(numRanks), [&](uint64_t* output) {
+        test::launchPerPeerWaitOnly(
+            transport.getDeviceTransport(), kExpectedRound, output);
+      });
+  EXPECT_EQ(
+      values,
+      std::vector<uint64_t>(
+          static_cast<std::size_t>(numRanks), kObservedRound));
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    UniformSignalWaitAcceptsAlreadyAdvancedAggregateCounters) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  constexpr uint32_t kPipelineDepth = 4;
+  auto bootstrap = makeBootstrap("mmnvl_uniform_aggregate_advanced");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(4096, 0, kPipelineDepth, /*maxChannels=*/1));
+  transport.exchange();
+  const uint64_t arrivals = static_cast<uint64_t>(numRanks);
+  test::launchInitializeAggregateSignals(
+      transport.getDeviceTransport(), 2 * arrivals, /*epochValue=*/0);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+  const auto values =
+      runSignalProtocol(2 * kPipelineDepth, [&](uint64_t* output) {
+        test::launchAggregateSignalProtocol(
+            transport.getDeviceTransport(),
+            NvlSignalAccess::Multimem,
+            NvlSignalPhase::Ready,
+            /*fanIn=*/false,
+            /*roundValue=*/1,
+            output);
+      });
+  for (uint32_t lane = 0; lane < kPipelineDepth; ++lane) {
+    EXPECT_GE(values[lane], 2 * arrivals);
+    EXPECT_LE(values[lane], 3 * arrivals);
+    EXPECT_EQ(values[kPipelineDepth + lane], arrivals);
+  }
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 }
 
 // signal(SET) from rank 0 must broadcast a value to every rank's local

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -82,6 +82,28 @@ __global__ void readUserAndInternalKernel(
   }
 }
 
+__global__ void setAllPeerInternalSignalsKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t value) {
+  for (auto destination = blockIdx.x * blockDim.x + threadIdx.x;
+       destination < transport.nvlRanks;
+       destination += blockDim.x * gridDim.x) {
+    auto* destinationSignals =
+        transport.internalUnicastSignalsByRank[destination];
+    destinationSignals[transport.nvlRank].signal(SignalOp::SIGNAL_SET, value);
+  }
+}
+
+__global__ void readPeerInternalSignalsKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t* out) {
+  for (auto source = blockIdx.x * blockDim.x + threadIdx.x;
+       source < transport.nvlRanks;
+       source += blockDim.x * gridDim.x) {
+    out[source] = transport.internalLocalSignals[source].load();
+  }
+}
+
 template <typename T>
 __device__ T reductionValue(float value) {
   if constexpr (std::is_same_v<T, __half>) {
@@ -249,6 +271,28 @@ void launchReadUserAndInternal(
     cudaStream_t stream) {
   readUserAndInternalKernel<<<1, 32, 0, stream>>>(
       transport, userId, internalId, out);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchSetAllPeerInternalSignals(
+    MultimemNvlTransportDevice transport,
+    uint64_t value,
+    cudaStream_t stream) {
+  constexpr int kThreads = 256;
+  const int blocks = (transport.nvlRanks + kThreads - 1) / kThreads;
+  setAllPeerInternalSignalsKernel<<<blocks, kThreads, 0, stream>>>(
+      transport, value);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchReadPeerInternalSignals(
+    MultimemNvlTransportDevice transport,
+    uint64_t* out,
+    cudaStream_t stream) {
+  constexpr int kThreads = 256;
+  const int blocks = (transport.nvlRanks + kThreads - 1) / kThreads;
+  readPeerInternalSignalsKernel<<<blocks, kThreads, 0, stream>>>(
+      transport, out);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -2,11 +2,13 @@
 
 #include "comms/prims/tests/MultimemNvlTransportTest.cuh"
 
+#include <stdexcept>
 #include <type_traits>
 
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/tests/Checks.h"
 #include "comms/prims/transport/nvl/MultimemNvlReduce.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlSignal.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlStageLayout.cuh"
 
 namespace comms::prims::test {
@@ -101,6 +103,314 @@ __global__ void readPeerInternalSignalsKernel(
        source < transport.nvlRanks;
        source += blockDim.x * gridDim.x) {
     out[source] = transport.internalLocalSignals[source].load();
+  }
+}
+
+__device__ NvlSignalParticipants
+makeTestParticipants(const MultimemNvlTransportDevice& transport, bool fanIn) {
+  const uint64_t allRanks = transport.nvlRanks == 64
+      ? ~uint64_t{0}
+      : (uint64_t{1} << transport.nvlRanks) - 1;
+  return NvlSignalParticipants{
+      .publisherMask = fanIn ? allRanks & ~uint64_t{1} : allRanks,
+      .waiterMask = fanIn ? uint64_t{1} : allRanks,
+      .expectedArrivals = static_cast<uint32_t>(
+          fanIn ? transport.nvlRanks - 1 : transport.nvlRanks),
+  };
+}
+
+__device__ NvlSignalParticipants
+makeAckParticipants(const MultimemNvlTransportDevice& transport) {
+  const uint64_t allRanks = transport.nvlRanks == 64
+      ? ~uint64_t{0}
+      : (uint64_t{1} << transport.nvlRanks) - 1;
+  return NvlSignalParticipants{
+      .publisherMask = 1,
+      .waiterMask = allRanks,
+      .expectedArrivals = 1,
+  };
+}
+
+template <NvlSignalAccess access, NvlSignalPhase phase>
+__global__ void aggregateSignalProtocolKernel(
+    MultimemNvlTransportDevice transport,
+    bool fanIn,
+    uint64_t roundValue,
+    uint64_t* out) {
+  auto group = make_warp_group();
+  const StageRound round{.channel = 0, .value = roundValue};
+  signal_publish_and_wait<access, NvlSignalTopology::Aggregate, phase>(
+      transport,
+      round,
+      makeTestParticipants(transport, fanIn),
+      group,
+      Timeout{});
+
+  const uint32_t lane = group.thread_id_in_group;
+  if (lane < transport.pipelineDepth) {
+    const uint64_t phaseOffset =
+        phase == NvlSignalPhase::Ready ? uint64_t{0} : uint64_t{2};
+    const uint64_t laneBase =
+        static_cast<uint64_t>(3 * transport.nvlRanks) + 4 * lane;
+    out[lane] = transport.internalLocalSignals[laneBase + phaseOffset].load();
+    out[transport.pipelineDepth + lane] =
+        transport.internalLocalSignals[laneBase + phaseOffset + 1].load();
+  }
+}
+
+template <
+    NvlSignalAccess access,
+    NvlSignalPhase phase,
+    NvlPerPeerWaitPolicy waitPolicy>
+__global__ void perPeerSignalProtocolKernel(
+    MultimemNvlTransportDevice transport,
+    bool fanIn,
+    uint64_t roundValue,
+    uint64_t* out) {
+  auto group = make_block_group();
+  const StageRound round{.channel = 0, .value = roundValue};
+  signal_publish_and_wait<
+      access,
+      NvlSignalTopology::PerPeer,
+      phase,
+      waitPolicy>(
+      transport,
+      round,
+      makeTestParticipants(transport, fanIn),
+      group,
+      Timeout{});
+
+  const int source = static_cast<int>(group.thread_id_in_group);
+  if (source < transport.nvlRanks) {
+    uint64_t stripe = 0;
+    if constexpr (phase == NvlSignalPhase::Ack) {
+      stripe = static_cast<uint64_t>(transport.nvlRanks);
+    } else if constexpr (phase == NvlSignalPhase::Consumed) {
+      stripe = static_cast<uint64_t>(2 * transport.nvlRanks);
+    }
+    out[source] = transport.internalLocalSignals[stripe + source].load();
+  }
+}
+
+__global__ void aggregateAckSignalProtocolKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t roundValue,
+    uint64_t* out) {
+  auto group = make_warp_group();
+  signal_publish_and_wait<
+      NvlSignalAccess::Multimem,
+      NvlSignalTopology::Aggregate,
+      NvlSignalPhase::Ack>(
+      transport,
+      StageRound{.channel = 0, .value = roundValue},
+      makeAckParticipants(transport),
+      group,
+      Timeout{});
+
+  const uint32_t lane = group.thread_id_in_group;
+  if (lane < transport.pipelineDepth) {
+    const uint64_t signalId =
+        static_cast<uint64_t>(3 * transport.nvlRanks) + 4 * lane + 2;
+    out[lane] = transport.internalLocalSignals[signalId].load();
+    out[transport.pipelineDepth + lane] =
+        transport.internalLocalSignals[signalId + 1].load();
+  }
+}
+
+__global__ void multiChannelAggregateSignalKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t* out) {
+  auto group = make_warp_group();
+  const StageRound round{
+      .channel = static_cast<uint32_t>(blockIdx.x),
+      .value = 1,
+  };
+  signal_publish_and_wait<
+      NvlSignalAccess::Multimem,
+      NvlSignalTopology::Aggregate,
+      NvlSignalPhase::Ready>(
+      transport,
+      round,
+      makeTestParticipants(transport, /*fanIn=*/false),
+      group,
+      Timeout{});
+  const uint32_t lane = group.thread_id_in_group;
+  if (lane < transport.pipelineDepth) {
+    const uint64_t signalId =
+        static_cast<uint64_t>(round.channel) * transport.signalsPerChannel +
+        static_cast<uint64_t>(3 * transport.nvlRanks) + 4 * lane;
+    const uint64_t outputBase =
+        static_cast<uint64_t>(round.channel) * 2 * transport.pipelineDepth;
+    out[outputBase + lane] = transport.internalLocalSignals[signalId].load();
+    out[outputBase + transport.pipelineDepth + lane] =
+        transport.internalLocalSignals[signalId + 1].load();
+  }
+}
+
+__global__ void aggregateMultimemWaiterTransitionKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t* out) {
+  auto group = make_warp_group();
+  const StageRound round{.channel = 0, .value = 1};
+  signal_publish_and_wait<
+      NvlSignalAccess::Multimem,
+      NvlSignalTopology::Aggregate,
+      NvlSignalPhase::Ready>(
+      transport,
+      round,
+      makeTestParticipants(transport, /*fanIn=*/true),
+      group,
+      Timeout{});
+
+  if (transport.nvlRank == transport.nvlRanks - 1) {
+    __nanosleep(100'000'000);
+  }
+  group.sync();
+  signal_publish_and_wait<
+      NvlSignalAccess::Multimem,
+      NvlSignalTopology::Aggregate,
+      NvlSignalPhase::Ready>(
+      transport,
+      round,
+      makeTestParticipants(transport, /*fanIn=*/false),
+      group,
+      Timeout{});
+
+  const uint32_t lane = group.thread_id_in_group;
+  if (lane < transport.pipelineDepth) {
+    const uint64_t signalId =
+        static_cast<uint64_t>(3 * transport.nvlRanks) + 4 * lane;
+    out[lane] = transport.internalLocalSignals[signalId].load();
+    out[transport.pipelineDepth + lane] =
+        transport.internalLocalSignals[signalId + 1].load();
+  }
+}
+
+__global__ void separatePublishAndWaitKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t roundValue,
+    uint64_t* out) {
+  auto group = make_block_group();
+  const uint64_t allRanks = transport.nvlRanks == 64
+      ? ~uint64_t{0}
+      : (uint64_t{1} << transport.nvlRanks) - 1;
+  const NvlSignalParticipants participants{
+      .publisherMask = allRanks & ~uint64_t{1},
+      .waiterMask = 1,
+      .expectedArrivals = static_cast<uint32_t>(transport.nvlRanks - 1),
+  };
+  const StageRound round{.channel = 0, .value = roundValue};
+  if (transport.nvlRank == 0) {
+    signal_wait<
+        NvlSignalAccess::Unicast,
+        NvlSignalTopology::PerPeer,
+        NvlSignalPhase::Ready>(
+        transport, round, participants, group, Timeout{});
+  } else {
+    signal_publish<
+        NvlSignalAccess::Unicast,
+        NvlSignalTopology::PerPeer,
+        NvlSignalPhase::Ready>(transport, round, participants, group);
+  }
+  const int source = static_cast<int>(group.thread_id_in_group);
+  if (transport.nvlRank == 0 && source < transport.nvlRanks) {
+    out[source] = transport.internalLocalSignals[source].load();
+  }
+}
+
+__global__ void initializeAggregateSignalsKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t counterValue,
+    uint64_t epochValue) {
+  const uint32_t lane = threadIdx.x;
+  if (lane < transport.pipelineDepth) {
+    const uint64_t laneBase = static_cast<uint64_t>(3) * transport.nvlRanks +
+        static_cast<uint64_t>(lane) * 4;
+    transport.internalLocalSignals[laneBase].store(counterValue);
+    transport.internalLocalSignals[laneBase + 1].store(epochValue);
+  }
+}
+
+__global__ void perPeerWaitOnlyKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t roundValue,
+    uint64_t* out) {
+  auto group = make_block_group();
+  const auto participants = makeTestParticipants(transport, /*fanIn=*/false);
+  signal_wait<
+      NvlSignalAccess::Unicast,
+      NvlSignalTopology::PerPeer,
+      NvlSignalPhase::Ready>(
+      transport,
+      StageRound{.channel = 0, .value = roundValue},
+      participants,
+      group,
+      Timeout{});
+  const int source = static_cast<int>(group.thread_id_in_group);
+  if (source < transport.nvlRanks) {
+    out[source] = transport.internalLocalSignals[source].load();
+  }
+}
+
+template <NvlSignalAccess access, NvlSignalPhase phase>
+void launchAggregateSignalProtocolTyped(
+    MultimemNvlTransportDevice transport,
+    bool fanIn,
+    uint64_t roundValue,
+    uint64_t* out,
+    cudaStream_t stream) {
+  aggregateSignalProtocolKernel<access, phase>
+      <<<1, 32, 0, stream>>>(transport, fanIn, roundValue, out);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+template <
+    NvlSignalAccess access,
+    NvlSignalPhase phase,
+    NvlPerPeerWaitPolicy waitPolicy>
+void launchPerPeerSignalProtocolTyped(
+    MultimemNvlTransportDevice transport,
+    bool fanIn,
+    uint64_t roundValue,
+    uint64_t* out,
+    cudaStream_t stream) {
+  perPeerSignalProtocolKernel<access, phase, waitPolicy>
+      <<<1, 64, 0, stream>>>(transport, fanIn, roundValue, out);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchMultimemReadyPerPeerSignalProtocolTyped(
+    MultimemNvlTransportDevice transport,
+    NvlPerPeerWaitPolicy waitPolicy,
+    bool fanIn,
+    uint64_t roundValue,
+    uint64_t* out,
+    cudaStream_t stream) {
+  switch (waitPolicy) {
+    case NvlPerPeerWaitPolicy::WaitAll:
+      return launchPerPeerSignalProtocolTyped<
+          NvlSignalAccess::Multimem,
+          NvlSignalPhase::Ready,
+          NvlPerPeerWaitPolicy::WaitAll>(
+          transport, fanIn, roundValue, out, stream);
+    case NvlPerPeerWaitPolicy::SerialMin:
+      return launchPerPeerSignalProtocolTyped<
+          NvlSignalAccess::Multimem,
+          NvlSignalPhase::Ready,
+          NvlPerPeerWaitPolicy::SerialMin>(
+          transport, fanIn, roundValue, out, stream);
+    case NvlPerPeerWaitPolicy::TreeMin:
+      return launchPerPeerSignalProtocolTyped<
+          NvlSignalAccess::Multimem,
+          NvlSignalPhase::Ready,
+          NvlPerPeerWaitPolicy::TreeMin>(
+          transport, fanIn, roundValue, out, stream);
+    case NvlPerPeerWaitPolicy::ButterflyMin:
+      return launchPerPeerSignalProtocolTyped<
+          NvlSignalAccess::Multimem,
+          NvlSignalPhase::Ready,
+          NvlPerPeerWaitPolicy::ButterflyMin>(
+          transport, fanIn, roundValue, out, stream);
   }
 }
 
@@ -293,6 +603,139 @@ void launchReadPeerInternalSignals(
   const int blocks = (transport.nvlRanks + kThreads - 1) / kThreads;
   readPeerInternalSignalsKernel<<<blocks, kThreads, 0, stream>>>(
       transport, out);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchAggregateSignalProtocol(
+    MultimemNvlTransportDevice transport,
+    NvlSignalAccess access,
+    NvlSignalPhase phase,
+    bool fanIn,
+    uint64_t roundValue,
+    uint64_t* out,
+    cudaStream_t stream) {
+  if (phase == NvlSignalPhase::Consumed) {
+    throw std::runtime_error("aggregate consumed signal is unsupported");
+  }
+  if (access == NvlSignalAccess::Unicast) {
+    if (phase == NvlSignalPhase::Ready) {
+      return launchAggregateSignalProtocolTyped<
+          NvlSignalAccess::Unicast,
+          NvlSignalPhase::Ready>(transport, fanIn, roundValue, out, stream);
+    }
+    return launchAggregateSignalProtocolTyped<
+        NvlSignalAccess::Unicast,
+        NvlSignalPhase::Ack>(transport, fanIn, roundValue, out, stream);
+  }
+  if (phase == NvlSignalPhase::Ready) {
+    return launchAggregateSignalProtocolTyped<
+        NvlSignalAccess::Multimem,
+        NvlSignalPhase::Ready>(transport, fanIn, roundValue, out, stream);
+  }
+  return launchAggregateSignalProtocolTyped<
+      NvlSignalAccess::Multimem,
+      NvlSignalPhase::Ack>(transport, fanIn, roundValue, out, stream);
+}
+
+void launchAggregateAckSignalProtocol(
+    MultimemNvlTransportDevice transport,
+    uint64_t roundValue,
+    uint64_t* out,
+    cudaStream_t stream) {
+  aggregateAckSignalProtocolKernel<<<1, 32, 0, stream>>>(
+      transport, roundValue, out);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchPerPeerWaitAllSignalProtocol(
+    MultimemNvlTransportDevice transport,
+    NvlSignalAccess access,
+    NvlSignalPhase phase,
+    bool fanIn,
+    uint64_t roundValue,
+    uint64_t* out,
+    cudaStream_t stream) {
+#define LAUNCH_PER_PEER_WAIT_ALL(ACCESS, PHASE) \
+  return launchPerPeerSignalProtocolTyped<      \
+      ACCESS,                                   \
+      PHASE,                                    \
+      NvlPerPeerWaitPolicy::WaitAll>(           \
+      transport, fanIn, roundValue, out, stream)
+  if (access == NvlSignalAccess::Unicast) {
+    if (phase == NvlSignalPhase::Ready) {
+      LAUNCH_PER_PEER_WAIT_ALL(NvlSignalAccess::Unicast, NvlSignalPhase::Ready);
+    }
+    if (phase == NvlSignalPhase::Ack) {
+      LAUNCH_PER_PEER_WAIT_ALL(NvlSignalAccess::Unicast, NvlSignalPhase::Ack);
+    }
+    LAUNCH_PER_PEER_WAIT_ALL(
+        NvlSignalAccess::Unicast, NvlSignalPhase::Consumed);
+  }
+  if (phase == NvlSignalPhase::Ready) {
+    LAUNCH_PER_PEER_WAIT_ALL(NvlSignalAccess::Multimem, NvlSignalPhase::Ready);
+  }
+  if (phase == NvlSignalPhase::Ack) {
+    LAUNCH_PER_PEER_WAIT_ALL(NvlSignalAccess::Multimem, NvlSignalPhase::Ack);
+  }
+  LAUNCH_PER_PEER_WAIT_ALL(NvlSignalAccess::Multimem, NvlSignalPhase::Consumed);
+#undef LAUNCH_PER_PEER_WAIT_ALL
+}
+
+void launchMultimemReadyPerPeerSignalProtocol(
+    MultimemNvlTransportDevice transport,
+    NvlPerPeerWaitPolicy waitPolicy,
+    bool fanIn,
+    uint64_t roundValue,
+    uint64_t* out,
+    cudaStream_t stream) {
+  launchMultimemReadyPerPeerSignalProtocolTyped(
+      transport, waitPolicy, fanIn, roundValue, out, stream);
+}
+
+void launchMultiChannelAggregateSignal(
+    MultimemNvlTransportDevice transport,
+    uint32_t channels,
+    uint64_t* out,
+    cudaStream_t stream) {
+  multiChannelAggregateSignalKernel<<<channels, 32, 0, stream>>>(
+      transport, out);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchAggregateMultimemWaiterTransition(
+    MultimemNvlTransportDevice transport,
+    uint64_t* out,
+    cudaStream_t stream) {
+  aggregateMultimemWaiterTransitionKernel<<<1, 32, 0, stream>>>(transport, out);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchSeparatePublishAndWait(
+    MultimemNvlTransportDevice transport,
+    uint64_t roundValue,
+    uint64_t* out,
+    cudaStream_t stream) {
+  separatePublishAndWaitKernel<<<1, 64, 0, stream>>>(
+      transport, roundValue, out);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchInitializeAggregateSignals(
+    MultimemNvlTransportDevice transport,
+    uint64_t counterValue,
+    uint64_t epochValue,
+    cudaStream_t stream) {
+  initializeAggregateSignalsKernel<<<1, 32, 0, stream>>>(
+      transport, counterValue, epochValue);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchPerPeerWaitOnly(
+    MultimemNvlTransportDevice transport,
+    uint64_t roundValue,
+    uint64_t* out,
+    cudaStream_t stream) {
+  perPeerWaitOnlyKernel<<<1, 64, 0, stream>>>(transport, roundValue, out);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -100,6 +100,16 @@ void launchReadUserAndInternal(
     uint64_t* out,
     cudaStream_t stream = nullptr);
 
+void launchSetAllPeerInternalSignals(
+    MultimemNvlTransportDevice transport,
+    uint64_t value,
+    cudaStream_t stream = nullptr);
+
+void launchReadPeerInternalSignals(
+    MultimemNvlTransportDevice transport,
+    uint64_t* out,
+    cudaStream_t stream = nullptr);
+
 void launchFillReductionInput(
     MultimemNvlTransportDevice transport,
     MultimemReductionTestType type,

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -8,6 +8,7 @@
 #include <cstdint>
 
 #include "comms/prims/core/SignalState.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlSignal.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
 
 namespace comms::prims::test {
@@ -108,6 +109,67 @@ void launchSetAllPeerInternalSignals(
 void launchReadPeerInternalSignals(
     MultimemNvlTransportDevice transport,
     uint64_t* out,
+    cudaStream_t stream = nullptr);
+
+void launchAggregateSignalProtocol(
+    MultimemNvlTransportDevice transport,
+    NvlSignalAccess access,
+    NvlSignalPhase phase,
+    bool fanIn,
+    uint64_t roundValue,
+    uint64_t* out,
+    cudaStream_t stream = nullptr);
+
+void launchAggregateAckSignalProtocol(
+    MultimemNvlTransportDevice transport,
+    uint64_t roundValue,
+    uint64_t* out,
+    cudaStream_t stream = nullptr);
+
+void launchPerPeerWaitAllSignalProtocol(
+    MultimemNvlTransportDevice transport,
+    NvlSignalAccess access,
+    NvlSignalPhase phase,
+    bool fanIn,
+    uint64_t roundValue,
+    uint64_t* out,
+    cudaStream_t stream = nullptr);
+
+void launchMultimemReadyPerPeerSignalProtocol(
+    MultimemNvlTransportDevice transport,
+    NvlPerPeerWaitPolicy waitPolicy,
+    bool fanIn,
+    uint64_t roundValue,
+    uint64_t* out,
+    cudaStream_t stream = nullptr);
+
+void launchMultiChannelAggregateSignal(
+    MultimemNvlTransportDevice transport,
+    uint32_t channels,
+    uint64_t* out,
+    cudaStream_t stream = nullptr);
+
+void launchAggregateMultimemWaiterTransition(
+    MultimemNvlTransportDevice transport,
+    uint64_t* out,
+    cudaStream_t stream = nullptr);
+
+void launchSeparatePublishAndWait(
+    MultimemNvlTransportDevice transport,
+    uint64_t roundValue,
+    uint64_t* out,
+    cudaStream_t stream = nullptr);
+
+void launchPerPeerWaitOnly(
+    MultimemNvlTransportDevice transport,
+    uint64_t roundValue,
+    uint64_t* out,
+    cudaStream_t stream = nullptr);
+
+void launchInitializeAggregateSignals(
+    MultimemNvlTransportDevice transport,
+    uint64_t counterValue,
+    uint64_t epochValue,
     cudaStream_t stream = nullptr);
 
 void launchFillReductionInput(

--- a/comms/prims/transport/nvl/MultimemNvlSignal.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlSignal.cuh
@@ -1,0 +1,587 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#include <cstdint>
+
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/core/Timeout.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
+
+namespace comms::prims {
+
+/** Selects the virtual-address path used to publish a signal. */
+enum class NvlSignalAccess { Unicast, Multimem };
+
+/** Selects peer-owned slots or lane-owned aggregate counters. */
+enum class NvlSignalTopology { PerPeer, Aggregate };
+
+/** Selects one stripe from the transport's internal signal layout. */
+enum class NvlSignalPhase { Ready, Ack, Consumed };
+
+/** Selects how a per-peer waiter combines peer completion state. */
+enum class NvlPerPeerWaitPolicy { WaitAll, SerialMin, TreeMin, ButterflyMin };
+
+/** Identifies one channel and one monotonic per-peer round value. */
+struct StageRound {
+  uint32_t channel;
+  uint64_t value;
+};
+
+/** Describes the ranks participating in one signal operation. */
+struct NvlSignalParticipants {
+  uint64_t publisherMask{0};
+  uint64_t waiterMask{0};
+  uint32_t expectedArrivals{0};
+};
+
+namespace nvl_signal_detail {
+
+__device__ __forceinline__ bool rank_selected(uint64_t mask, int rank) {
+  return rank >= 0 && rank < 64 && ((mask >> rank) & uint64_t{1}) != 0;
+}
+
+__device__ __forceinline__ bool sequence_reached(
+    uint64_t observed,
+    uint64_t expected) {
+  // Sequence values must remain within half of the uint64_t range so modular
+  // ordering distinguishes an advanced value across wraparound.
+  return observed - expected < (uint64_t{1} << 63);
+}
+
+template <
+    NvlSignalAccess access,
+    NvlSignalTopology topology,
+    NvlSignalPhase phase,
+    NvlPerPeerWaitPolicy waitPolicy>
+__device__ __forceinline__ void validate_protocol() {
+  static_assert(
+      access == NvlSignalAccess::Unicast ||
+      access == NvlSignalAccess::Multimem);
+  static_assert(
+      topology == NvlSignalTopology::PerPeer ||
+      topology == NvlSignalTopology::Aggregate);
+  static_assert(
+      phase == NvlSignalPhase::Ready || phase == NvlSignalPhase::Ack ||
+      phase == NvlSignalPhase::Consumed);
+  static_assert(
+      waitPolicy == NvlPerPeerWaitPolicy::WaitAll ||
+      waitPolicy == NvlPerPeerWaitPolicy::SerialMin ||
+      waitPolicy == NvlPerPeerWaitPolicy::TreeMin ||
+      waitPolicy == NvlPerPeerWaitPolicy::ButterflyMin);
+  static_assert(
+      topology == NvlSignalTopology::PerPeer ||
+      waitPolicy == NvlPerPeerWaitPolicy::WaitAll);
+  static_assert(
+      topology == NvlSignalTopology::PerPeer ||
+      phase != NvlSignalPhase::Consumed);
+}
+
+__device__ __forceinline__ void wait_until_reached(
+    const SignalState& signal,
+    uint64_t expected,
+    const Timeout& timeout) {
+  while (!sequence_reached(signal.load(), expected)) {
+    TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+        timeout,
+        "NVL signal wait for sequence=%llu",
+        static_cast<unsigned long long>(expected));
+  }
+}
+
+template <NvlSignalPhase phase>
+__device__ __forceinline__ uint64_t peer_signal_id(
+    const MultimemNvlTransportDevice& transport,
+    const StageRound& round,
+    int sourceRank) {
+  const uint64_t channelBase =
+      static_cast<uint64_t>(round.channel) * transport.signalsPerChannel;
+  uint64_t stripe = 0;
+  if constexpr (phase == NvlSignalPhase::Ack) {
+    stripe = static_cast<uint64_t>(transport.nvlRanks);
+  } else if constexpr (phase == NvlSignalPhase::Consumed) {
+    stripe = static_cast<uint64_t>(2) * transport.nvlRanks;
+  }
+  return channelBase + stripe + static_cast<uint64_t>(sourceRank);
+}
+
+template <NvlSignalPhase phase>
+__device__ __forceinline__ uint64_t aggregate_counter_id(
+    const MultimemNvlTransportDevice& transport,
+    const StageRound& round,
+    uint32_t lane) {
+  static_assert(
+      phase != NvlSignalPhase::Consumed,
+      "aggregate consumed signaling has no allocated counter");
+  const uint64_t channelBase =
+      static_cast<uint64_t>(round.channel) * transport.signalsPerChannel;
+  const uint64_t laneBase = channelBase +
+      static_cast<uint64_t>(3) * static_cast<uint64_t>(transport.nvlRanks) +
+      static_cast<uint64_t>(lane) * detail::kMultimemSignalsPerLane;
+  if constexpr (phase == NvlSignalPhase::Ready) {
+    return laneBase;
+  } else {
+    return laneBase + 2;
+  }
+}
+
+__device__ __forceinline__ void validate_common(
+    const MultimemNvlTransportDevice& transport,
+    const StageRound& round,
+    const NvlSignalParticipants& participants) {
+#if defined(__CUDA_ARCH__)
+  const bool validRankCount =
+      transport.nvlRanks > 0 && transport.nvlRanks <= 64;
+  uint64_t validRankMask = ~uint64_t{0};
+  if (validRankCount && transport.nvlRanks < 64) {
+    validRankMask = (uint64_t{1} << transport.nvlRanks) - 1;
+  }
+  if (!validRankCount || transport.nvlRank < 0 ||
+      transport.nvlRank >= transport.nvlRanks ||
+      participants.publisherMask == 0 || participants.waiterMask == 0 ||
+      (participants.publisherMask & ~validRankMask) != 0 ||
+      (participants.waiterMask & ~validRankMask) != 0 ||
+      participants.expectedArrivals == 0 ||
+      participants.expectedArrivals !=
+          static_cast<uint32_t>(__popcll(participants.publisherMask)) ||
+      round.channel >= transport.maxChannels || round.value == 0 ||
+      transport.signalsPerChannel == 0) {
+    printf(
+        "NVL signal invalid geometry: rank=%d ranks=%d channel=%u "
+        "round=%llu maxChannels=%u publishers=%llu waiters=%llu arrivals=%u\n",
+        transport.nvlRank,
+        transport.nvlRanks,
+        static_cast<unsigned>(round.channel),
+        static_cast<unsigned long long>(round.value),
+        static_cast<unsigned>(transport.maxChannels),
+        static_cast<unsigned long long>(participants.publisherMask),
+        static_cast<unsigned long long>(participants.waiterMask),
+        static_cast<unsigned>(participants.expectedArrivals));
+    __trap();
+  }
+#else
+  (void)transport;
+  (void)round;
+  (void)participants;
+#endif
+}
+
+template <NvlSignalAccess access>
+__device__ __forceinline__ void validate_per_peer(
+    const MultimemNvlTransportDevice& transport,
+    const ThreadGroup& group) {
+#if defined(__CUDA_ARCH__)
+  const uint64_t requiredSignals =
+      static_cast<uint64_t>(transport.maxChannels) *
+      transport.signalsPerChannel;
+  if (group.scope != SyncScope::BLOCK || group.group_size != 64 ||
+      transport.nvlRanks > 64 ||
+      requiredSignals > transport.internalLocalSignals.size() ||
+      requiredSignals > transport.internalMultimemSignals.size() ||
+      (access == NvlSignalAccess::Unicast &&
+       transport.internalUnicastSignalsByRank.size() !=
+           static_cast<uint32_t>(transport.nvlRanks))) {
+    printf(
+        "NVL per-peer signal invalid execution geometry: groupSize=%u "
+        "ranks=%d localSignals=%u multimemSignals=%u peers=%u\n",
+        static_cast<unsigned>(group.group_size),
+        transport.nvlRanks,
+        static_cast<unsigned>(transport.internalLocalSignals.size()),
+        static_cast<unsigned>(transport.internalMultimemSignals.size()),
+        static_cast<unsigned>(transport.internalUnicastSignalsByRank.size()));
+    __trap();
+  }
+#else
+  (void)transport;
+  (void)group;
+#endif
+}
+
+template <NvlSignalPhase phase>
+__device__ __forceinline__ void wait_per_peer_all(
+    const MultimemNvlTransportDevice& transport,
+    const StageRound& round,
+    const NvlSignalParticipants& participants,
+    ThreadGroup& group,
+    const Timeout& timeout) {
+  const int source = static_cast<int>(group.thread_id_in_group);
+  if (source < transport.nvlRanks &&
+      rank_selected(participants.publisherMask, source)) {
+    wait_until_reached(
+        transport.internalLocalSignals[peer_signal_id<phase>(
+            transport, round, source)],
+        round.value,
+        timeout);
+  }
+  group.sync();
+}
+
+template <NvlSignalPhase phase>
+__device__ __forceinline__ void wait_per_peer_serial(
+    const MultimemNvlTransportDevice& transport,
+    const StageRound& round,
+    const NvlSignalParticipants& participants,
+    ThreadGroup& group,
+    const Timeout& timeout) {
+  if (group.is_leader()) {
+    bool complete = false;
+    while (!complete) {
+      complete = true;
+      for (int source = 0; source < transport.nvlRanks; ++source) {
+        if (rank_selected(participants.publisherMask, source) &&
+            !sequence_reached(
+                transport
+                    .internalLocalSignals[peer_signal_id<phase>(
+                        transport, round, source)]
+                    .load(),
+                round.value)) {
+          complete = false;
+        }
+      }
+      if (!complete) {
+        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+            timeout,
+            "NVL serial per-peer wait for round=%llu",
+            static_cast<unsigned long long>(round.value));
+      }
+    }
+  }
+  group.sync();
+}
+
+template <NvlSignalPhase phase>
+__device__ __forceinline__ void wait_per_peer_tree(
+    const MultimemNvlTransportDevice& transport,
+    const StageRound& round,
+    const NvlSignalParticipants& participants,
+    ThreadGroup& group,
+    const Timeout& timeout) {
+  __shared__ uint32_t completeByPeer[64];
+  const uint32_t thread = group.thread_id_in_group;
+  bool complete = false;
+  while (!complete) {
+    const int source = static_cast<int>(thread);
+    completeByPeer[thread] = source >= transport.nvlRanks ||
+            !rank_selected(participants.publisherMask, source) ||
+            sequence_reached(transport
+                                 .internalLocalSignals[peer_signal_id<phase>(
+                                     transport, round, source)]
+                                 .load(),
+                             round.value)
+        ? 1
+        : 0;
+    group.sync();
+    for (uint32_t stride = 32; stride != 0; stride /= 2) {
+      if (thread < stride) {
+        completeByPeer[thread] &= completeByPeer[thread + stride];
+      }
+      group.sync();
+    }
+    complete = completeByPeer[0] != 0;
+    if (!complete && group.is_leader()) {
+      TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+          timeout,
+          "NVL tree per-peer wait for round=%llu",
+          static_cast<unsigned long long>(round.value));
+    }
+    group.sync();
+  }
+}
+
+template <NvlSignalPhase phase>
+__device__ __forceinline__ void wait_per_peer_butterfly(
+    const MultimemNvlTransportDevice& transport,
+    const StageRound& round,
+    const NvlSignalParticipants& participants,
+    ThreadGroup& group,
+    const Timeout& timeout) {
+  __shared__ uint32_t completeByWarp[2];
+  const uint32_t thread = group.thread_id_in_group;
+  const uint32_t lane = thread % kWarpSize;
+  const uint32_t warp = thread / kWarpSize;
+  bool complete = false;
+  while (!complete) {
+    const int source = static_cast<int>(thread);
+    uint32_t laneComplete = source >= transport.nvlRanks ||
+            !rank_selected(participants.publisherMask, source) ||
+            sequence_reached(transport
+                                 .internalLocalSignals[peer_signal_id<phase>(
+                                     transport, round, source)]
+                                 .load(),
+                             round.value)
+        ? 1
+        : 0;
+#if defined(__CUDA_ARCH__)
+    for (uint32_t delta = 1; delta < kWarpSize; delta *= 2) {
+      laneComplete &= __shfl_xor_sync(~0u, laneComplete, delta);
+    }
+#endif
+    if (lane == 0) {
+      completeByWarp[warp] = laneComplete;
+    }
+    group.sync();
+    complete = completeByWarp[0] != 0 && completeByWarp[1] != 0;
+    if (!complete && group.is_leader()) {
+      TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+          timeout,
+          "NVL butterfly per-peer wait for round=%llu",
+          static_cast<unsigned long long>(round.value));
+    }
+    group.sync();
+  }
+}
+
+template <NvlSignalAccess access>
+__device__ __forceinline__ void validate_aggregate(
+    const MultimemNvlTransportDevice& transport,
+    const ThreadGroup& group) {
+#if defined(__CUDA_ARCH__)
+  const uint64_t requiredSignals =
+      static_cast<uint64_t>(transport.maxChannels) *
+      transport.signalsPerChannel;
+  if (group.scope != SyncScope::WARP || group.group_size != kWarpSize ||
+      transport.pipelineDepth == 0 || transport.pipelineDepth > kWarpSize ||
+      requiredSignals > transport.internalLocalSignals.size() ||
+      requiredSignals > transport.internalMultimemSignals.size() ||
+      (access == NvlSignalAccess::Unicast &&
+       transport.internalUnicastSignalsByRank.size() !=
+           static_cast<uint32_t>(transport.nvlRanks))) {
+    printf(
+        "NVL aggregate signal invalid execution geometry: groupSize=%u "
+        "pipelineDepth=%u localSignals=%u multimemSignals=%u peers=%u\n",
+        static_cast<unsigned>(group.group_size),
+        static_cast<unsigned>(transport.pipelineDepth),
+        static_cast<unsigned>(transport.internalLocalSignals.size()),
+        static_cast<unsigned>(transport.internalMultimemSignals.size()),
+        static_cast<unsigned>(transport.internalUnicastSignalsByRank.size()));
+    __trap();
+  }
+#else
+  (void)transport;
+  (void)group;
+#endif
+}
+
+} // namespace nvl_signal_detail
+
+/**
+ * Publishes one signal operation from every selected publisher rank.
+ *
+ * Aggregate topology requires one warp and maps active threads to pipeline
+ * lanes.
+ * Per-peer topology requires one 64-thread block and maps threads to peers.
+ *
+ * @param transport Exchanged multimem transport device view.
+ * @param round Logical channel and per-peer round value.
+ * @param participants Rank masks and expected arrival count.
+ * @param group Topology-specific cooperative thread group.
+ */
+namespace nvl_signal_detail {
+
+template <
+    NvlSignalAccess access,
+    NvlSignalTopology topology,
+    NvlSignalPhase phase,
+    NvlPerPeerWaitPolicy waitPolicy>
+__device__ __forceinline__ void signal_publish_impl(
+    const MultimemNvlTransportDevice& transport,
+    const StageRound& round,
+    const NvlSignalParticipants& participants,
+    ThreadGroup& group) {
+  nvl_signal_detail::validate_protocol<access, topology, phase, waitPolicy>();
+  nvl_signal_detail::validate_common(transport, round, participants);
+  if constexpr (topology == NvlSignalTopology::Aggregate) {
+    nvl_signal_detail::validate_aggregate<access>(transport, group);
+  } else {
+    nvl_signal_detail::validate_per_peer<access>(transport, group);
+  }
+
+  comms::device::fence_acq_rel_sys();
+  group.sync();
+  if (nvl_signal_detail::rank_selected(
+          participants.publisherMask, transport.nvlRank)) {
+    if constexpr (topology == NvlSignalTopology::Aggregate) {
+      const uint32_t lane = group.thread_id_in_group;
+      if (lane < transport.pipelineDepth) {
+        const uint64_t signalId =
+            nvl_signal_detail::aggregate_counter_id<phase>(
+                transport, round, lane);
+        if constexpr (access == NvlSignalAccess::Multimem) {
+          transport.template signal_internal_scalar<SignalOp::SIGNAL_ADD>(
+              signalId, 1);
+        } else {
+          for (int destination = 0; destination < transport.nvlRanks;
+               ++destination) {
+            if (nvl_signal_detail::rank_selected(
+                    participants.waiterMask, destination)) {
+              transport.internalUnicastSignalsByRank[destination][signalId]
+                  .atomic_fetch_add(1);
+            }
+          }
+        }
+      }
+    } else {
+      const uint64_t signalId = nvl_signal_detail::peer_signal_id<phase>(
+          transport, round, transport.nvlRank);
+      if constexpr (access == NvlSignalAccess::Multimem) {
+        if (group.is_leader()) {
+          transport.template signal_internal_scalar<SignalOp::SIGNAL_SET>(
+              signalId, round.value);
+        }
+      } else {
+        const int destination = static_cast<int>(group.thread_id_in_group);
+        if (destination < transport.nvlRanks &&
+            nvl_signal_detail::rank_selected(
+                participants.waiterMask, destination)) {
+          transport.internalUnicastSignalsByRank[destination][signalId].store(
+              round.value);
+        }
+      }
+    }
+  }
+  group.sync();
+}
+
+} // namespace nvl_signal_detail
+
+/** Publishes one split signal operation for a supported protocol. */
+template <
+    NvlSignalAccess access,
+    NvlSignalTopology topology,
+    NvlSignalPhase phase,
+    NvlPerPeerWaitPolicy waitPolicy = NvlPerPeerWaitPolicy::WaitAll>
+__device__ __forceinline__ void signal_publish(
+    const MultimemNvlTransportDevice& transport,
+    const StageRound& round,
+    const NvlSignalParticipants& participants,
+    ThreadGroup& group) {
+  static_assert(
+      access != NvlSignalAccess::Multimem ||
+          topology != NvlSignalTopology::Aggregate,
+      "aggregate multimem requires signal_publish_and_wait on every rank");
+  nvl_signal_detail::signal_publish_impl<access, topology, phase, waitPolicy>(
+      transport, round, participants, group);
+}
+
+/**
+ * Waits for the selected publishers on every selected waiter rank.
+ *
+ * A caller that enables timeout checking must call `Timeout::start()` before
+ * this function.
+ *
+ * @param transport Exchanged multimem transport device view.
+ * @param round Logical channel and per-peer round value.
+ * @param participants Rank masks and expected arrival count.
+ * @param group Topology-specific cooperative thread group.
+ * @param timeout Started timeout or the disabled default timeout.
+ */
+namespace nvl_signal_detail {
+
+template <
+    NvlSignalAccess access,
+    NvlSignalTopology topology,
+    NvlSignalPhase phase,
+    NvlPerPeerWaitPolicy waitPolicy>
+__device__ __forceinline__ void signal_wait_impl(
+    const MultimemNvlTransportDevice& transport,
+    const StageRound& round,
+    const NvlSignalParticipants& participants,
+    ThreadGroup& group,
+    const Timeout& timeout) {
+  nvl_signal_detail::validate_protocol<access, topology, phase, waitPolicy>();
+  nvl_signal_detail::validate_common(transport, round, participants);
+  if constexpr (topology == NvlSignalTopology::Aggregate) {
+    nvl_signal_detail::validate_aggregate<access>(transport, group);
+  } else {
+    nvl_signal_detail::validate_per_peer<access>(transport, group);
+  }
+
+  const bool isWaiter = nvl_signal_detail::rank_selected(
+      participants.waiterMask, transport.nvlRank);
+  if constexpr (topology == NvlSignalTopology::Aggregate) {
+    const uint32_t lane = group.thread_id_in_group;
+    if (lane < transport.pipelineDepth) {
+      const uint64_t signalId = nvl_signal_detail::aggregate_counter_id<phase>(
+          transport, round, lane);
+      auto* counter = transport.internalLocalSignals.data() + signalId;
+      auto* epoch = counter + 1;
+      const uint64_t expected =
+          epoch->load() + static_cast<uint64_t>(participants.expectedArrivals);
+      if (isWaiter) {
+        nvl_signal_detail::wait_until_reached(*counter, expected, timeout);
+      }
+      if constexpr (access == NvlSignalAccess::Multimem) {
+        epoch->store(expected);
+      } else if (isWaiter) {
+        epoch->store(expected);
+      }
+    }
+    group.sync();
+  } else if (!isWaiter) {
+    return;
+  } else if constexpr (waitPolicy == NvlPerPeerWaitPolicy::WaitAll) {
+    nvl_signal_detail::wait_per_peer_all<phase>(
+        transport, round, participants, group, timeout);
+  } else if constexpr (waitPolicy == NvlPerPeerWaitPolicy::SerialMin) {
+    nvl_signal_detail::wait_per_peer_serial<phase>(
+        transport, round, participants, group, timeout);
+  } else if constexpr (waitPolicy == NvlPerPeerWaitPolicy::TreeMin) {
+    nvl_signal_detail::wait_per_peer_tree<phase>(
+        transport, round, participants, group, timeout);
+  } else {
+    nvl_signal_detail::wait_per_peer_butterfly<phase>(
+        transport, round, participants, group, timeout);
+  }
+  (void)access;
+}
+
+} // namespace nvl_signal_detail
+
+/** Waits for one split signal operation for a supported protocol. */
+template <
+    NvlSignalAccess access,
+    NvlSignalTopology topology,
+    NvlSignalPhase phase,
+    NvlPerPeerWaitPolicy waitPolicy = NvlPerPeerWaitPolicy::WaitAll>
+__device__ __forceinline__ void signal_wait(
+    const MultimemNvlTransportDevice& transport,
+    const StageRound& round,
+    const NvlSignalParticipants& participants,
+    ThreadGroup& group,
+    const Timeout& timeout) {
+  static_assert(
+      access != NvlSignalAccess::Multimem ||
+          topology != NvlSignalTopology::Aggregate,
+      "aggregate multimem requires signal_publish_and_wait on every rank");
+  nvl_signal_detail::signal_wait_impl<access, topology, phase, waitPolicy>(
+      transport, round, participants, group, timeout);
+}
+
+/**
+ * Publishes and then waits using the same compile-time protocol.
+ *
+ * @param transport Exchanged multimem transport device view.
+ * @param round Logical channel and per-peer round value.
+ * @param participants Rank masks and expected arrival count.
+ * @param group Topology-specific cooperative thread group.
+ * @param timeout Started timeout or the disabled default timeout.
+ */
+template <
+    NvlSignalAccess access,
+    NvlSignalTopology topology,
+    NvlSignalPhase phase,
+    NvlPerPeerWaitPolicy waitPolicy = NvlPerPeerWaitPolicy::WaitAll>
+__device__ __forceinline__ void signal_publish_and_wait(
+    const MultimemNvlTransportDevice& transport,
+    const StageRound& round,
+    const NvlSignalParticipants& participants,
+    ThreadGroup& group,
+    const Timeout& timeout) {
+  nvl_signal_detail::signal_publish_impl<access, topology, phase, waitPolicy>(
+      transport, round, participants, group);
+  nvl_signal_detail::signal_wait_impl<access, topology, phase, waitPolicy>(
+      transport, round, participants, group, timeout);
+}
+
+} // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.cc
@@ -2,20 +2,30 @@
 
 #include "comms/prims/transport/nvl/MultimemNvlTransport.h"
 
+#include <algorithm>
+#include <exception>
+#include <iterator>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <utility>
 
+#include "comms/prims/bootstrap/NvlBootstrapAdapter.h"
+#include "comms/prims/bootstrap/TeamStatusAgreement.h"
 #include "comms/prims/core/SignalState.cuh"
 #include "comms/utils/checks.h"
+#ifdef __HIP_PLATFORM_AMD__
+#include "comms/prims/transport/amd/HipHostCompat.h"
+#else
+#include "comms/utils/CudaRAII.h"
+#endif
 
 namespace comms::prims {
 
 namespace {
 
 constexpr uint64_t kMultimemNvlTransportProtocol = 0x4D4D4E564CULL;
-constexpr uint64_t kMultimemNvlTransportProtocolVersion = 5;
+constexpr uint64_t kMultimemNvlTransportProtocolVersion = 6;
 
 int getCurrentCudaDevice() {
   int cudaDevice = 0;
@@ -39,6 +49,8 @@ std::vector<int> identityRankMap(int nRanks) {
 }
 
 } // namespace
+
+MultimemNvlTransport::~MultimemNvlTransport() = default;
 
 void MultimemNvlTransport::validateRankMap(
     int commRank,
@@ -76,13 +88,10 @@ MultimemNvlTransport::MultimemNvlTransport(
     int commRank,
     std::vector<int> nvlRankToCommRank,
     const MultimemNvlTransportConfig& config)
-    : commRank_(commRank),
-      nvlRanks_(static_cast<int>(nvlRankToCommRank.size())),
-      nvlRankToCommRank_(std::move(nvlRankToCommRank)),
-      config_(config) {
+    : nvlRanks_(static_cast<int>(nvlRankToCommRank.size())), config_(config) {
   // Topology validation runs BEFORE cudaGetDevice so the rank-map preconditions
   // are exercisable on CPU-only hosts (see MultimemNvlTransportValidationTest).
-  validateRankMap(commRank_, nvlRankToCommRank_);
+  validateRankMap(commRank, nvlRankToCommRank);
 
   const auto validation =
       validate_multimem_nvl_transport_config(config_, nvlRanks_);
@@ -94,21 +103,12 @@ MultimemNvlTransport::MultimemNvlTransport(
   dataBufferSize_ = validation.dataBufferSize;
   internalSignalCount_ = validation.internalSignalCount;
   signalsPerChannel_ = validation.signalsPerChannel;
-  // commRank presence in the map is already verified by validateRankMap.
-  int nvlRank = -1;
-  for (int rank = 0; rank < nvlRanks_; ++rank) {
-    if (nvlRankToCommRank_[static_cast<std::size_t>(rank)] == commRank_) {
-      nvlRank = rank;
-      break;
-    }
-  }
-  // Defensive backstop for the validateRankMap invariant: a -1 here would flow
-  // into device-side signal-slot indexing and produce out-of-bounds offsets, so
-  // fail loudly rather than corrupt memory if the map ever omits this rank.
-  if (nvlRank < 0) {
-    throw std::runtime_error(
-        "MultimemNvlTransport: commRank not found in nvlRankToCommRank_");
-  }
+
+  // validateRankMap() guarantees that commRank appears exactly once.
+  const auto nvlRankIt =
+      std::find(nvlRankToCommRank.begin(), nvlRankToCommRank.end(), commRank);
+  const int nvlRank =
+      static_cast<int>(std::distance(nvlRankToCommRank.begin(), nvlRankIt));
   nvlRank_ = nvlRank;
 
   static_assert(alignof(SignalState) == detail::kMultimemSignalAlignment);
@@ -121,13 +121,14 @@ MultimemNvlTransport::MultimemNvlTransport(
 
   // The GpuMemHandler owns the unicast backing; exchange() adds the multicast
   // overlay over it. Size the allocation to the multicast granularity
-  // (alignFloor) so it is bindable into a multicast object. Only multicast is
-  // used (no P2P exchangeMemPtrs), so the selfRank/nRanks coordinates here are
-  // the NVL-team rank and size.
+  // (alignFloor) so it is bindable into a multicast object. The unicast peer
+  // exchange and multicast exchange both use NVL-team coordinates.
   const std::size_t alignFloor =
       GpuMemHandler::backingGranularity(cudaDevice_, nvlRanks_);
+  nvlBootstrap_ = std::make_shared<NvlBootstrapAdapter>(
+      std::move(bootstrap), std::move(nvlRankToCommRank));
   combinedHandler_ = std::make_unique<GpuMemHandler>(
-      std::move(bootstrap),
+      nvlBootstrap_,
       nvlRank,
       nvlRanks_,
       combinedSize,
@@ -173,11 +174,53 @@ MultimemNvlTransport::MultimemNvlTransport(
           }(),
           config) {}
 
+std::unique_ptr<meta::comms::DeviceBuffer>
+MultimemNvlTransport::exchangeUnicastPeerViews() {
+  combinedHandler_->exchangeMemPtrs();
+
+  std::unique_ptr<meta::comms::DeviceBuffer> devicePeerInternalSignals;
+  std::exception_ptr localError;
+  try {
+    std::vector<SignalState*> peerInternalSignals(
+        static_cast<std::size_t>(nvlRanks_));
+    for (int rank = 0; rank < nvlRanks_; ++rank) {
+      auto* peerBase =
+          static_cast<char*>(combinedHandler_->getPeerDeviceMemPtr(rank));
+      auto* peerSignals =
+          reinterpret_cast<SignalState*>(peerBase + signalRegionOffset_);
+      peerInternalSignals[static_cast<std::size_t>(rank)] =
+          peerSignals + config_.userSignalCount;
+    }
+
+    devicePeerInternalSignals = std::make_unique<meta::comms::DeviceBuffer>(
+        peerInternalSignals.size() * sizeof(SignalState*));
+    FB_CUDACHECKTHROW(cudaMemcpy(
+        devicePeerInternalSignals->get(),
+        peerInternalSignals.data(),
+        peerInternalSignals.size() * sizeof(SignalState*),
+        cudaMemcpyHostToDevice));
+  } catch (...) {
+    localError = std::current_exception();
+  }
+
+  std::vector<detail::TeamStatus> status(static_cast<std::size_t>(nvlRanks_));
+  detail::allGatherAndAgree(
+      *nvlBootstrap_,
+      nvlRank_,
+      nvlRanks_,
+      status,
+      localError,
+      "MultimemNvlTransport::exchange: construct the unicast peer pointer "
+      "table");
+
+  return devicePeerInternalSignals;
+}
+
 void MultimemNvlTransport::exchange() {
-  if (exchanged_) {
+  if (exchangeState_ == ExchangeState::kReady) {
     return;
   }
-  if (broken_) {
+  if (exchangeState_ == ExchangeState::kFailed) {
     throw std::runtime_error(
         "MultimemNvlTransport::exchange: previous exchange() failed; "
         "rebuild the transport to retry (same-object retry is unsafe after "
@@ -194,19 +237,24 @@ void MultimemNvlTransport::exchange() {
                 config_.maxChannels,
                 config_.maxBlocks,
                 config_.userSignalCount,
+                static_cast<uint64_t>(config_.enableUnicastPeerViews),
             },
     };
     combinedHandler_->exchangeMulticast(
-        commRank_, nvlRankToCommRank_, cudaDevice_, contract);
+        nvlRank_, identityRankMap(nvlRanks_), cudaDevice_, contract);
+
+    if (config_.enableUnicastPeerViews) {
+      internalUnicastSignalsByRank_ = exchangeUnicastPeerViews();
+    }
   } catch (...) {
-    broken_ = true;
+    exchangeState_ = ExchangeState::kFailed;
     throw;
   }
-  exchanged_ = true;
+  exchangeState_ = ExchangeState::kReady;
 }
 
 MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
-  if (!exchanged_) {
+  if (exchangeState_ != ExchangeState::kReady) {
     throw std::runtime_error(
         "MultimemNvlTransport: exchange() must complete before device use");
   }
@@ -239,6 +287,12 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
       .pipelineDepth = static_cast<uint32_t>(config_.pipelineDepth),
       .maxChannels = static_cast<uint32_t>(config_.maxChannels),
       .signalsPerChannel = signalsPerChannel_,
+      .internalUnicastSignalsByRank = internalUnicastSignalsByRank_
+          ? DeviceSpan<SignalState*>(
+                static_cast<SignalState**>(
+                    internalUnicastSignalsByRank_->get()),
+                static_cast<uint32_t>(nvlRanks_))
+          : DeviceSpan<SignalState*>{},
   };
 }
 

--- a/comms/prims/transport/nvl/MultimemNvlTransport.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.h
@@ -12,6 +12,10 @@
 #include "comms/prims/transport/nvl/MultimemNvlTransportConfig.h"
 #include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
 
+namespace meta::comms {
+class DeviceBuffer;
+}
+
 namespace comms::prims {
 
 /**
@@ -24,9 +28,8 @@ namespace comms::prims {
  * a signal. The numeric `multimemData` pointer is a process-local CUDA VA and
  * is not part of the cross-rank protocol.
  *
- * The caller must set the current CUDA device before construction. The
- * transport records that device ordinal and passes it to MultimemHandler; it
- * does not switch CUDA devices internally.
+ * The caller owns CUDA device selection and must keep the construction device
+ * current while calling exchange() and destroying the transport.
  *
  * `bootstrap` is the global communicator bootstrap. `commRank` is this
  * process's rank in that global communicator. `nvlRankToCommRank` maps each
@@ -50,7 +53,7 @@ class MultimemNvlTransport {
       std::shared_ptr<meta::comms::IBootstrap> bootstrap,
       const MultimemNvlTransportConfig& config);
 
-  ~MultimemNvlTransport() = default;
+  ~MultimemNvlTransport();
 
   MultimemNvlTransport(const MultimemNvlTransport&) = delete;
   MultimemNvlTransport& operator=(const MultimemNvlTransport&) = delete;
@@ -85,13 +88,21 @@ class MultimemNvlTransport {
       const std::vector<int>& nvlRankToCommRank);
 
  private:
-  const int commRank_{-1};
+  // Collectively imports the peer backing allocations and uploads the
+  // device-resident table of internal-signal pointers.
+  std::unique_ptr<meta::comms::DeviceBuffer> exchangeUnicastPeerViews();
+
+  enum class ExchangeState {
+    kNotStarted,
+    kReady,
+    kFailed,
+  };
+
   const int nvlRanks_{-1};
-  // This rank's index within the NVL team (its position in nvlRankToCommRank_).
+  // This rank's index within the NVL team.
   // Retained so getDeviceTransport() can expose it to the device staging
   // protocol, which keys its per-rank signal slots on the NVL-local rank.
   int nvlRank_{-1};
-  const std::vector<int> nvlRankToCommRank_;
   // Recorded after the rank-map validation in the constructor body so a bad
   // topology fails before cudaGetDevice is consulted (lets tests cover the
   // rank-map preconditions on CPU-only hosts).
@@ -100,12 +111,7 @@ class MultimemNvlTransport {
   std::size_t dataBufferSize_{0};
   uint32_t internalSignalCount_{0};
   uint32_t signalsPerChannel_{0};
-  bool exchanged_{false};
-  // Set when exchange() throws; subsequent calls throw instead of silently
-  // retrying. Multicast object create/import/bind failures can leave partial
-  // driver state, so a same-object retry is unsafe. Callers must rebuild the
-  // transport to recover.
-  bool broken_{false};
+  ExchangeState exchangeState_{ExchangeState::kNotStarted};
 
   // Single GpuMemHandler whose physical allocation contains both the data
   // window and the signal slots back-to-back. Layout: [data | pad-to-128B |
@@ -113,9 +119,11 @@ class MultimemNvlTransport {
   // and, via its multicast overlay (exchangeMulticast), the multicast VA
   // (getMultimemDeviceMemPtr) -- one cuMulticastCreate / one set of binds / one
   // MC VA range over one shared physical backing.
+  std::shared_ptr<meta::comms::IBootstrap> nvlBootstrap_;
   std::unique_ptr<GpuMemHandler> combinedHandler_;
   // Offset of the signal region within combinedHandler_'s allocation.
   std::size_t signalRegionOffset_{0};
+  std::unique_ptr<meta::comms::DeviceBuffer> internalUnicastSignalsByRank_;
 };
 
 } // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlTransportConfig.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransportConfig.h
@@ -31,6 +31,9 @@ struct MultimemNvlTransportConfigParams {
   // Signal slots exposed through signal(), read_signal(), and
   // wait_signal_until(). This is orthogonal to staging geometry.
   uint32_t userSignalCount{0};
+
+  // Import and map every peer's backing allocation for unicast signaling.
+  bool enableUnicastPeerViews{false};
 };
 
 struct MultimemNvlTransportConfig {
@@ -42,13 +45,15 @@ struct MultimemNvlTransportConfig {
         pipelineDepth(params.pipelineDepth),
         maxChannels(params.maxChannels),
         maxBlocks(params.maxBlocks),
-        userSignalCount(params.userSignalCount) {}
+        userSignalCount(params.userSignalCount),
+        enableUnicastPeerViews(params.enableUnicastPeerViews) {}
 
   std::size_t perChannelSize{0};
   std::size_t pipelineDepth{0};
   std::size_t maxChannels{0};
   std::size_t maxBlocks{0};
   uint32_t userSignalCount{0};
+  bool enableUnicastPeerViews{false};
 
   bool operator==(const MultimemNvlTransportConfig&) const = default;
 };

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -120,6 +120,19 @@ struct MultimemNvlTransportDevice {
     signal_at(group, internal_multimem_signal_ptr(signal_id), op, value);
   }
 
+  template <SignalOp op>
+  __device__ __forceinline__ void signal_internal_scalar(
+      uint64_t signal_id,
+      uint64_t value) const {
+    auto* signal = internal_multimem_signal_ptr(signal_id);
+    comms::device::fence_acq_rel_sys();
+    if constexpr (op == SignalOp::SIGNAL_SET) {
+      detail::multimem_store_release_sys_u64(&signal->signal_, value);
+    } else {
+      detail::multimem_red_release_sys_add_u64(&signal->signal_, value);
+    }
+  }
+
   __device__ __forceinline__ uint64_t
   read_internal_signal(uint64_t signal_id) const {
     return internal_local_signal_ptr(signal_id)->load();

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -79,6 +79,9 @@ struct MultimemNvlTransportDevice {
   uint32_t pipelineDepth{0};
   uint32_t maxChannels{0};
   uint32_t signalsPerChannel{0};
+  // Indexed by NVL-local destination rank. Each entry addresses the base of
+  // that destination's internal signal slots through its unicast mapping.
+  DeviceSpan<SignalState*> internalUnicastSignalsByRank{};
 
   __device__ __forceinline__ char* local_data_ptr(std::size_t offset) const {
     return localData + offset;


### PR DESCRIPTION
Summary:

Introduce a compile-time device API for unicast and multicast NVL signaling over per-peer slots and aggregate pipeline-lane counters.

Provide fan-in and global participant masks, four per-peer wait policies, wrap-safe sequence progression, timeout handling, and topology-specific launch validation.

Extend `MultimemNvlTransportDevice` with a scalar multicast signal operation so lane owners can publish independently without changing the existing group-level API.

Background:
The transport already reserves one `3R + 4P` internal signal layout per channel.
A uniform primitive lets collective and benchmark code select the publication path, topology, phase, and wait policy at compile time while using the same physical backing.

Reviewed By: dboyda

Differential Revision: D115430406


