### PR TITLE
Partition multimem staging signals by channel (#3553)

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -51,12 +51,12 @@ struct ctranPrimsConfig {
   // fixes the per-chunk size: chunk = channelBufferSize / channelPipelineDepth.
   int64_t channelPipelineDepth{-1};
   // -1 uses MCCL_MAX_NCHANNELS. Total IB staging for this communicator is
-  // channelBufferSize * maxChannels per peer per direction.
+  // channelBufferSize * maxChannels per peer per direction. Multimem staging
+  // capacity is also provisioned for this many channels.
   int64_t maxChannels{-1};
-  // -1 uses MCCL_MAX_NBLOCKS. As with the CVAR, this is both the NVL channel
-  // count and the collective launch-geometry block cap; the two must move
-  // together or the multimem signal sizing drifts from the transport's actual
-  // channel count.
+  // -1 uses MCCL_MAX_NBLOCKS. This is the collective launch-geometry block
+  // cap. Multimem requires it not to exceed maxChannels because a launch
+  // cannot consume more blocks than the provisioned channel capacity.
   int64_t maxBlocks{-1};
 
   bool operator==(const ctranPrimsConfig& other) const {

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -46,8 +46,18 @@ int ctranPipesNvlMaxNumChannels(const ctranPrimsConfig& pc) {
   return std::max(1, static_cast<int>(resolved));
 }
 
-size_t roundDownToMultiple(size_t value, size_t multiple) {
-  return multiple == 0 ? 0 : (value / multiple) * multiple;
+size_t alignedPerChannelSize(
+    size_t totalSize,
+    size_t maxChannels,
+    size_t pipelineDepth) {
+  constexpr size_t kDataAlignment = 16;
+  if (maxChannels == 0 || pipelineDepth == 0 ||
+      pipelineDepth > std::numeric_limits<size_t>::max() / kDataAlignment) {
+    return 0;
+  }
+
+  const size_t alignment = kDataAlignment * pipelineDepth;
+  return (totalSize / maxChannels / alignment) * alignment;
 }
 
 } // namespace
@@ -112,9 +122,8 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     config.nvlConfig.maxNumChannels = ctranPipesNvlMaxNumChannels(pc);
     const size_t nvlMaxNumChannels =
         static_cast<size_t>(config.nvlConfig.maxNumChannels);
-    const size_t nvlChannelAlign = 16ULL * config.nvlConfig.pipelineDepth;
-    config.nvlConfig.perChannelSize = roundDownToMultiple(
-        nvlSharedDevbufSize / nvlMaxNumChannels, nvlChannelAlign);
+    config.nvlConfig.perChannelSize = alignedPerChannelSize(
+        nvlSharedDevbufSize, nvlMaxNumChannels, config.nvlConfig.pipelineDepth);
     if (config.nvlConfig.perChannelSize == 0) {
       CLOGF(
           ERR,
@@ -139,19 +148,42 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     if (comm->statex_->nLocalRanks() > 2 && multimemDevbufSize > 0) {
       const std::size_t multimemPipelineDepth =
           std::max<std::size_t>(1, config.nvlConfig.pipelineDepth);
-      // Reuse the already-computed channel count (config.nvlConfig
-      // .maxNumChannels, resolved from primsConfig.maxBlocks or
-      // MCCL_MAX_NBLOCKS) as the channel count so signal sizing cannot drift
-      // from the transport's actual channel count. Do not re-derive it here.
-      const std::size_t multimemMaxChannels =
-          static_cast<std::size_t>(config.nvlConfig.maxNumChannels);
+      const auto resolvedMaxChannels = ctranPrimsResolvedMaxChannels(pc);
+      const auto resolvedMaxBlocks = ctranPrimsResolvedMaxBlocks(pc);
+      const size_t multimemMaxChannels = resolvedMaxChannels > 0
+          ? static_cast<size_t>(resolvedMaxChannels)
+          : 0;
+      const size_t multimemMaxBlocks =
+          resolvedMaxBlocks > 0 ? static_cast<size_t>(resolvedMaxBlocks) : 0;
+      if (multimemMaxBlocks > multimemMaxChannels) {
+        CLOGF(
+            ERR,
+            "CTRAN-PRIMS: invalid multimem config; maxBlocks={} exceeds maxChannels={}",
+            multimemMaxBlocks,
+            multimemMaxChannels);
+        return commInvalidArgument;
+      }
+      const size_t multimemPerChannelSize = alignedPerChannelSize(
+          multimemDevbufSize, multimemMaxChannels, multimemPipelineDepth);
+      if (multimemPerChannelSize == 0) {
+        CLOGF(
+            ERR,
+            "CTRAN-PRIMS: invalid multimem config; devbufSize={} maxChannels={} pipelineDepth={} cannot produce aligned perChannelSize",
+            multimemDevbufSize,
+            multimemMaxChannels,
+            multimemPipelineDepth);
+        return commInvalidArgument;
+      }
+
       config.nvlConfig.enableMultimem = true;
-      config.nvlConfig.multimem = comms::prims::MultimemNvlTransportConfig{
-          .dataBufferSize = multimemDevbufSize,
-          .userSignalCount = 1,
-          .pipelineDepth = multimemPipelineDepth,
-          .maxChannels = multimemMaxChannels,
-      };
+      config.nvlConfig.multimem =
+          comms::prims::make_multimem_nvl_transport_config({
+              .perChannelSize = multimemPerChannelSize,
+              .pipelineDepth = multimemPipelineDepth,
+              .maxChannels = multimemMaxChannels,
+              .maxBlocks = multimemMaxBlocks,
+              .userSignalCount = 1,
+          });
     }
 
     // LL128 buffer allocation for DeviceAllToAllv

--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -156,6 +156,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMulticastAllocation.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/MultimemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/NvlMemExchange.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultimemNvlTransportConfig.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultimemNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerTransport.cc

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -176,6 +176,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMulticastAllocation.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/MultimemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/NvlMemExchange.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultimemNvlTransportConfig.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultimemNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerTransport.cc

--- a/comms/prims/memory/NvlMemExchange.h
+++ b/comms/prims/memory/NvlMemExchange.h
@@ -38,7 +38,7 @@ namespace comms::prims {
 struct MulticastExchangeContract {
   uint64_t protocol{0};
   uint64_t version{0};
-  std::array<uint64_t, 4> parameters{};
+  std::array<uint64_t, 5> parameters{};
 
   bool operator==(const MulticastExchangeContract& other) const {
     return protocol == other.protocol && version == other.version &&

--- a/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cu
+++ b/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cu
@@ -13,17 +13,18 @@ namespace {
 
 __global__ void stageLayoutTrapKernel(StageLayoutTrapCase testCase) {
   constexpr uint32_t kNvlRanks = 4;
-  constexpr uint32_t kExpectedSignalsPerLane =
-      multimem_staging_signals_per_lane(kNvlRanks);
+  constexpr uint32_t kPipelineDepth = 1;
+  constexpr uint32_t kExpectedSignalsPerChannel = static_cast<uint32_t>(
+      multimem_staging_signals_per_channel(kNvlRanks, kPipelineDepth));
   SignalState signal;
   const uint32_t localSignalCount =
       testCase == StageLayoutTrapCase::InsufficientLocalSignals
-      ? kExpectedSignalsPerLane - 1
-      : kExpectedSignalsPerLane;
+      ? kExpectedSignalsPerChannel - 1
+      : kExpectedSignalsPerChannel;
   const uint32_t multimemSignalCount =
       testCase == StageLayoutTrapCase::InsufficientMultimemSignals
-      ? kExpectedSignalsPerLane - 1
-      : kExpectedSignalsPerLane;
+      ? kExpectedSignalsPerChannel - 1
+      : kExpectedSignalsPerChannel;
   MultimemNvlTransportDevice transport{
       .localData = reinterpret_cast<char*>(1),
       .multimemData = reinterpret_cast<char*>(1),
@@ -34,9 +35,9 @@ __global__ void stageLayoutTrapKernel(StageLayoutTrapCase testCase) {
       .dataBufferSize = 64,
       .nvlRank = 0,
       .nvlRanks = kNvlRanks,
-      .pipelineDepth = 1,
+      .pipelineDepth = kPipelineDepth,
       .maxChannels = 1,
-      .signalsPerLane = kExpectedSignalsPerLane,
+      .signalsPerChannel = kExpectedSignalsPerChannel,
   };
   switch (testCase) {
     case StageLayoutTrapCase::ZeroGeometry:
@@ -44,8 +45,8 @@ __global__ void stageLayoutTrapKernel(StageLayoutTrapCase testCase) {
       break;
     case StageLayoutTrapCase::TooManyGroups:
       break;
-    case StageLayoutTrapCase::BadSignalsPerLane:
-      transport.signalsPerLane = kExpectedSignalsPerLane - 1;
+    case StageLayoutTrapCase::BadSignalsPerChannel:
+      transport.signalsPerChannel = kExpectedSignalsPerChannel - 1;
       break;
     case StageLayoutTrapCase::InsufficientLocalSignals:
     case StageLayoutTrapCase::InsufficientMultimemSignals:

--- a/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cuh
+++ b/comms/prims/tests/MultimemNvlStageLayoutTrapTest.cuh
@@ -10,7 +10,7 @@ namespace comms::prims::test {
 enum class StageLayoutTrapCase : uint32_t {
   ZeroGeometry,
   TooManyGroups,
-  BadSignalsPerLane,
+  BadSignalsPerChannel,
   InsufficientLocalSignals,
   InsufficientMultimemSignals,
 };

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -9,6 +9,7 @@
 #include <folly/futures/Future.h>
 #include <folly/init/Init.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -78,12 +79,15 @@ MultimemNvlTransportConfig makeConfig(
     uint32_t userSignalCount = 1,
     std::size_t pipelineDepth = 0,
     std::size_t maxChannels = 0) {
-  MultimemNvlTransportConfig config{};
-  config.dataBufferSize = dataBufferSize;
-  config.userSignalCount = userSignalCount;
-  config.pipelineDepth = pipelineDepth;
-  config.maxChannels = maxChannels;
-  return config;
+  const std::size_t effectiveMaxChannels =
+      std::max<std::size_t>(1, maxChannels);
+  return make_multimem_nvl_transport_config({
+      .perChannelSize = dataBufferSize / effectiveMaxChannels,
+      .pipelineDepth = pipelineDepth,
+      .maxChannels = effectiveMaxChannels,
+      .maxBlocks = maxChannels,
+      .userSignalCount = userSignalCount,
+  });
 }
 
 using meta::comms::testing::MockBootstrap;
@@ -384,13 +388,13 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
-      .multimem =
-          MultimemNvlTransportConfig{
-              .dataBufferSize = 0,
-              .userSignalCount = 1,
-              .pipelineDepth = 1,
-              .maxChannels = 1,
-          },
+      .multimem = make_multimem_nvl_transport_config({
+          .perChannelSize = 0,
+          .pipelineDepth = 1,
+          .maxChannels = 1,
+          .maxBlocks = 1,
+          .userSignalCount = 1,
+      }),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -430,13 +434,13 @@ TEST_F(
         .p2pSignalCount = 1,
         .maxNumChannels = 0,
         .enableMultimem = true,
-        .multimem =
-            MultimemNvlTransportConfig{
-                .dataBufferSize = 4096,
-                .userSignalCount = 1,
-                .pipelineDepth = 1,
-                .maxChannels = 1,
-            },
+        .multimem = make_multimem_nvl_transport_config({
+            .perChannelSize = 4096,
+            .pipelineDepth = 1,
+            .maxChannels = 1,
+            .maxBlocks = 1,
+            .userSignalCount = 1,
+        }),
     };
     MultiPeerNvlTransport transport(
         globalRank, numRanks, localRank, bootstrap, config);
@@ -484,13 +488,13 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
-      .multimem =
-          MultimemNvlTransportConfig{
-              .dataBufferSize = 4096,
-              .userSignalCount = 1,
-              .pipelineDepth = 1,
-              .maxChannels = 1,
-          },
+      .multimem = make_multimem_nvl_transport_config({
+          .perChannelSize = 4096,
+          .pipelineDepth = 1,
+          .maxChannels = 1,
+          .maxBlocks = 1,
+          .userSignalCount = 1,
+      }),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -537,13 +541,13 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
-      .multimem =
-          MultimemNvlTransportConfig{
-              .dataBufferSize = 4096,
-              .userSignalCount = 1,
-              .pipelineDepth = 1,
-              .maxChannels = 1,
-          },
+      .multimem = make_multimem_nvl_transport_config({
+          .perChannelSize = 4096,
+          .pipelineDepth = 1,
+          .maxChannels = 1,
+          .maxBlocks = 1,
+          .userSignalCount = 1,
+      }),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -576,14 +580,13 @@ TEST_F(
       // channels (a nonzero maxNumChannels requires pipelineDepth >= 1).
       .maxNumChannels = 0,
       .enableMultimem = true,
-      .multimem =
-          MultimemNvlTransportConfig{
-              .dataBufferSize =
-                  kBytesPerRank * static_cast<std::size_t>(numRanks),
-              .userSignalCount = 1,
-              .pipelineDepth = 1,
-              .maxChannels = 1,
-          },
+      .multimem = make_multimem_nvl_transport_config({
+          .perChannelSize = kBytesPerRank * static_cast<std::size_t>(numRanks),
+          .pipelineDepth = 1,
+          .maxChannels = 1,
+          .maxBlocks = 1,
+          .userSignalCount = 1,
+      }),
   };
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   EXPECT_FALSE(transport.hasMultimemNvlTransport());
@@ -606,14 +609,14 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
-      .multimem =
-          MultimemNvlTransportConfig{
-              .dataBufferSize =
-                  globalRank == 0 ? std::size_t{0} : std::size_t{4096},
-              .userSignalCount = 1,
-              .pipelineDepth = 1,
-              .maxChannels = 1,
-          },
+      .multimem = make_multimem_nvl_transport_config({
+          .perChannelSize =
+              globalRank == 0 ? std::size_t{0} : std::size_t{4096},
+          .pipelineDepth = 1,
+          .maxChannels = 1,
+          .maxBlocks = 1,
+          .userSignalCount = 1,
+      }),
   };
   MultiPeerNvlTransport transport(
       globalRank, numRanks, localRank, bootstrap, config);
@@ -710,6 +713,42 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
   ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 }
 
+TEST_F(MultimemNvlTransportTestFixture, ExchangeSupportsDataOnlyConfiguration) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_exchange_data_only");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kDataBytes = 4096;
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(
+          kDataBytes,
+          /*userSignalCount=*/0,
+          /*pipelineDepth=*/0,
+          /*maxChannels=*/0));
+
+  transport.exchange();
+  const auto handle = transport.getDeviceTransport();
+
+  EXPECT_EQ(handle.dataBufferSize, kDataBytes);
+  EXPECT_TRUE(handle.userLocalSignals.empty());
+  EXPECT_TRUE(handle.userMultimemSignals.empty());
+  EXPECT_TRUE(handle.internalLocalSignals.empty());
+  EXPECT_TRUE(handle.internalMultimemSignals.empty());
+  EXPECT_EQ(handle.pipelineDepth, 0);
+  EXPECT_EQ(handle.maxChannels, 1);
+  EXPECT_EQ(handle.signalsPerLane, 0);
+  EXPECT_EQ(transport.getAllocatedSignalBufferSize(), 0);
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
 TEST_F(
     MultimemNvlTransportTestFixture,
     ExchangeRejectsMismatchedStagingGeometry) {
@@ -736,9 +775,43 @@ TEST_F(
     EXPECT_NE(
         message.find("ranks disagree on multicast setup"), std::string::npos)
         << message;
-    EXPECT_NE(message.find("parameters=[8192, 1, 2, 4]"), std::string::npos)
+    EXPECT_NE(message.find("parameters=[2048, 2, 4, 4, 1]"), std::string::npos)
         << message;
-    EXPECT_NE(message.find("parameters=[8192, 1, 4, 2]"), std::string::npos)
+    EXPECT_NE(message.find("parameters=[4096, 4, 2, 2, 1]"), std::string::npos)
+        << message;
+  }
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    ExchangeRejectsMismatchedUserSignalLayout) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_exchange_mismatched_user_signals");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  const uint32_t userSignalCount = globalRank == 0 ? 1 : 2;
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(8192, userSignalCount, 1, 1));
+  try {
+    transport.exchange();
+    FAIL() << "expected setup agreement to reject mismatched signal layout";
+  } catch (const std::runtime_error& ex) {
+    const std::string message = ex.what();
+    EXPECT_NE(
+        message.find("ranks disagree on multicast setup"), std::string::npos)
+        << message;
+    EXPECT_NE(message.find("parameters=[8192, 1, 1, 1, 1]"), std::string::npos)
+        << message;
+    EXPECT_NE(message.find("parameters=[8192, 1, 1, 1, 2]"), std::string::npos)
         << message;
   }
 

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -177,6 +177,37 @@ TEST_F(
       GpuMemHandler::isMultimemSupported(localRank));
 }
 
+TEST_F(MultimemNvlTransportTestFixture, SignalFreeConfigurationConstructs) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_signal_free_construction");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(/*dataBufferSize=*/4096, /*userSignalCount=*/0));
+  transport.exchange();
+  const auto handle = transport.getDeviceTransport();
+
+  EXPECT_EQ(transport.getAllocatedDataBufferSize(), 4096);
+  EXPECT_EQ(transport.getAllocatedSignalBufferSize(), 0);
+  EXPECT_NE(handle.localData, nullptr);
+  EXPECT_NE(handle.multimemData, nullptr);
+  EXPECT_TRUE(handle.userLocalSignals.empty());
+  EXPECT_TRUE(handle.userMultimemSignals.empty());
+  EXPECT_TRUE(handle.internalLocalSignals.empty());
+  EXPECT_TRUE(handle.internalMultimemSignals.empty());
+  EXPECT_EQ(handle.pipelineDepth, 0);
+  EXPECT_EQ(handle.maxChannels, 1);
+  EXPECT_EQ(handle.signalsPerChannel, 0);
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
 TEST_F(MultimemNvlTransportTestFixture, MultiPeerMultimemDisabled) {
   // No multimem-eligibility skip here: with enableMultimem=false this test
   // exercises only the disabled-path API (hasMultimemNvlTransport() == false,
@@ -672,8 +703,8 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
 
   constexpr std::size_t kDataBytes = 8192;
   constexpr uint32_t kUserSignals = 2;
-  const uint32_t internalSignals =
-      multimem_staging_signals_per_lane(static_cast<uint32_t>(numRanks));
+  const uint64_t internalSignals = multimem_staging_signals_per_channel(
+      static_cast<uint32_t>(numRanks), /*pipelineDepth=*/1);
 
   MultimemNvlTransport transport(
       bootstrap,
@@ -697,7 +728,7 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
   EXPECT_EQ(handle.internalMultimemSignals.size(), internalSignals);
   EXPECT_EQ(handle.pipelineDepth, 1);
   EXPECT_EQ(handle.maxChannels, 1);
-  EXPECT_EQ(handle.signalsPerLane, internalSignals);
+  EXPECT_EQ(handle.signalsPerChannel, internalSignals);
 
   EXPECT_EQ(transport.getAllocatedDataBufferSize(), kDataBytes);
   EXPECT_EQ(
@@ -743,7 +774,7 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSupportsDataOnlyConfiguration) {
   EXPECT_TRUE(handle.internalMultimemSignals.empty());
   EXPECT_EQ(handle.pipelineDepth, 0);
   EXPECT_EQ(handle.maxChannels, 1);
-  EXPECT_EQ(handle.signalsPerLane, 0);
+  EXPECT_EQ(handle.signalsPerChannel, 0);
   EXPECT_EQ(transport.getAllocatedSignalBufferSize(), 0);
 
   ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
@@ -894,14 +925,29 @@ TEST_F(MultimemNvlTransportTestFixture, StageLayoutUsesTransportGeometry) {
       deviceResults,
       results.size() * sizeof(test::StageLayoutResult),
       cudaMemcpyDeviceToHost));
-  const uint64_t signalsPerLane =
-      multimem_staging_signals_per_lane(static_cast<uint32_t>(numRanks));
+  const uint64_t signalsPerChannel = multimem_staging_signals_per_channel(
+      static_cast<uint32_t>(numRanks), kPipelineDepth);
   for (uint32_t group = 0; group < kActiveGroups; ++group) {
-    EXPECT_EQ(results[group].groupBeginBytes, group * 4096);
+    const uint64_t channelBase = group * signalsPerChannel;
+    const uint64_t laneBase = channelBase + 3 * numRanks;
+    EXPECT_EQ(results[group].channelBeginBytes, group * 4096);
     EXPECT_EQ(results[group].stagingBytes, 2048);
-    EXPECT_EQ(
-        results[group].signalBase, group * kPipelineDepth * signalsPerLane);
-    EXPECT_EQ(results[group].signalsPerLane, signalsPerLane);
+    EXPECT_EQ(results[group].signalBase, channelBase);
+    EXPECT_EQ(results[group].signalsPerChannel, signalsPerChannel);
+    EXPECT_EQ(results[group].readyFirst, channelBase);
+    EXPECT_EQ(results[group].readyLast, channelBase + numRanks - 1);
+    EXPECT_EQ(results[group].ackFirst, channelBase + numRanks);
+    EXPECT_EQ(results[group].ackLast, channelBase + 2 * numRanks - 1);
+    EXPECT_EQ(results[group].consumedFirst, channelBase + 2 * numRanks);
+    EXPECT_EQ(results[group].consumedLast, channelBase + 3 * numRanks - 1);
+    EXPECT_EQ(results[group].lane0ReadyCounter, laneBase);
+    EXPECT_EQ(results[group].lane0ReadyEpoch, laneBase + 1);
+    EXPECT_EQ(results[group].lane0AckCounter, laneBase + 2);
+    EXPECT_EQ(results[group].lane0AckEpoch, laneBase + 3);
+    EXPECT_EQ(results[group].lane1ReadyCounter, laneBase + 4);
+    EXPECT_EQ(results[group].lane1ReadyEpoch, laneBase + 5);
+    EXPECT_EQ(results[group].lane1AckCounter, laneBase + 6);
+    EXPECT_EQ(results[group].lane1AckEpoch, laneBase + 7);
     EXPECT_EQ(results[group].pipelineDepth, kPipelineDepth);
   }
 
@@ -916,10 +962,9 @@ TEST_F(MultimemNvlTransportTestFixture, StageLayoutUsesTransportGeometry) {
       cudaMemcpyDeviceToHost));
   CUDACHECK_TEST(cudaFree(deviceResults));
   for (uint32_t group = 0; group < kMaxChannels; ++group) {
-    EXPECT_EQ(results[group].groupBeginBytes, group * 3072);
+    EXPECT_EQ(results[group].channelBeginBytes, group * 3072);
     EXPECT_EQ(results[group].stagingBytes, 1536);
-    EXPECT_EQ(
-        results[group].signalBase, group * kPipelineDepth * signalsPerLane);
+    EXPECT_EQ(results[group].signalBase, group * signalsPerChannel);
   }
 
   ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -124,11 +124,26 @@ __global__ void stageLayoutKernel(
   auto group = make_block_group();
   const auto layout = multimem::make_stage_layout<uint32_t>(transport, group);
   if (group.is_leader()) {
+    const int lastRank = layout.nvlRanks - 1;
     results[group.group_id] = StageLayoutResult{
-        .groupBeginBytes = layout.groupBeginBytes,
+        .channelBeginBytes = layout.channelBeginBytes,
         .stagingBytes = layout.stagingBytes,
         .signalBase = layout.signalBase,
-        .signalsPerLane = layout.signalsPerLane,
+        .signalsPerChannel = layout.signalsPerChannel,
+        .readyFirst = multimem::ready_signal_id(layout, 0),
+        .readyLast = multimem::ready_signal_id(layout, lastRank),
+        .ackFirst = multimem::ack_signal_id(layout, 0),
+        .ackLast = multimem::ack_signal_id(layout, lastRank),
+        .consumedFirst = multimem::consumed_signal_id(layout, 0),
+        .consumedLast = multimem::consumed_signal_id(layout, lastRank),
+        .lane0ReadyCounter = multimem::ready_counter_signal_id(layout, 0),
+        .lane0ReadyEpoch = multimem::ready_epoch_signal_id(layout, 0),
+        .lane0AckCounter = multimem::ack_counter_signal_id(layout, 0),
+        .lane0AckEpoch = multimem::ack_epoch_signal_id(layout, 0),
+        .lane1ReadyCounter = multimem::ready_counter_signal_id(layout, 1),
+        .lane1ReadyEpoch = multimem::ready_epoch_signal_id(layout, 1),
+        .lane1AckCounter = multimem::ack_counter_signal_id(layout, 1),
+        .lane1AckEpoch = multimem::ack_epoch_signal_id(layout, 1),
         .pipelineDepth = layout.pipelineDepth,
     };
   }

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -15,10 +15,24 @@ namespace comms::prims::test {
 enum class MultimemReductionTestType { Float, Int32, Float16, Bfloat16 };
 
 struct StageLayoutResult {
-  std::size_t groupBeginBytes;
+  std::size_t channelBeginBytes;
   std::size_t stagingBytes;
   uint64_t signalBase;
-  uint64_t signalsPerLane;
+  uint64_t signalsPerChannel;
+  uint64_t readyFirst;
+  uint64_t readyLast;
+  uint64_t ackFirst;
+  uint64_t ackLast;
+  uint64_t consumedFirst;
+  uint64_t consumedLast;
+  uint64_t lane0ReadyCounter;
+  uint64_t lane0ReadyEpoch;
+  uint64_t lane0AckCounter;
+  uint64_t lane0AckEpoch;
+  uint64_t lane1ReadyCounter;
+  uint64_t lane1ReadyEpoch;
+  uint64_t lane1AckCounter;
+  uint64_t lane1AckEpoch;
   uint32_t pipelineDepth;
 };
 

--- a/comms/prims/tests/MultimemNvlTransportValidationTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportValidationTest.cc
@@ -8,6 +8,7 @@
 #include <limits>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -29,27 +30,72 @@ void expectRuntimeErrorContains(Fn&& fn, const std::string& expected) {
 }
 
 MultimemNvlTransportConfig makeConfig(
-    std::size_t dataBufferSize,
+    std::size_t perChannelSize,
     uint32_t userSignalCount = 1,
     std::size_t pipelineDepth = 0,
-    std::size_t maxChannels = 0) {
-  MultimemNvlTransportConfig config{};
-  config.dataBufferSize = dataBufferSize;
-  config.userSignalCount = userSignalCount;
-  config.pipelineDepth = pipelineDepth;
-  config.maxChannels = maxChannels;
-  return config;
+    std::size_t maxChannels = 1,
+    std::size_t maxBlocks = 0) {
+  return make_multimem_nvl_transport_config({
+      .perChannelSize = perChannelSize,
+      .pipelineDepth = pipelineDepth,
+      .maxChannels = maxChannels,
+      .maxBlocks = maxBlocks,
+      .userSignalCount = userSignalCount,
+  });
 }
 
 } // namespace
 
 TEST(MultimemNvlTransportConfigTest, DerivesUserOnlyConfiguration) {
+  const auto validation =
+      validate_multimem_nvl_transport_config(makeConfig(256), 4);
+  EXPECT_TRUE(validation);
+  EXPECT_EQ(validation.internalSignalCount, 0);
+}
+
+TEST(
+    MultimemNvlTransportConfigTest,
+    DerivesDataAndSignalsFromChannelCapacityAndIndependentBlockLimit) {
+  const auto config = make_multimem_nvl_transport_config({
+      .perChannelSize = 1024,
+      .pipelineDepth = 2,
+      .maxChannels = 8,
+      .maxBlocks = 3,
+      .userSignalCount = 1,
+  });
+
+  const auto validation = validate_multimem_nvl_transport_config(config, 4);
+
+  ASSERT_TRUE(validation);
+  EXPECT_EQ(validation.dataBufferSize, 8192);
+  EXPECT_EQ(validation.internalSignalCount, 192);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsDataBufferMultiplicationOverflow) {
+  const auto config = make_multimem_nvl_transport_config({
+      .perChannelSize = std::numeric_limits<std::size_t>::max(),
+      .pipelineDepth = 0,
+      .maxChannels = 2,
+      .maxBlocks = 0,
+      .userSignalCount = 1,
+  });
+
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(makeConfig(256), 4), 0);
+      validate_multimem_nvl_transport_config(config, 4).errorMessage,
+      "per-channel size times maximum channels overflows");
 }
 
 TEST(MultimemNvlTransportConfigTest, PreservesDefaultUserSignalCount) {
   EXPECT_EQ(MultimemNvlTransportConfig{}.userSignalCount, 1);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsLegacyPositionalConstruction) {
+  EXPECT_FALSE((std::is_constructible_v<
+                MultimemNvlTransportConfig,
+                std::size_t,
+                uint32_t,
+                std::size_t,
+                std::size_t>));
 }
 
 TEST(MultimemNvlTransportDeviceTest, PreservesLegacyPositionalRankFields) {
@@ -60,47 +106,99 @@ TEST(MultimemNvlTransportDeviceTest, PreservesLegacyPositionalRankFields) {
 }
 
 TEST(MultimemNvlTransportConfigTest, DerivesStagingOnlyConfiguration) {
-  EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(256, 0, 2, 2), 4),
-      48);
+  const auto validation =
+      validate_multimem_nvl_transport_config(makeConfig(128, 0, 2, 2, 2), 4);
+  EXPECT_TRUE(validation);
+  EXPECT_EQ(validation.internalSignalCount, 48);
 }
 
 TEST(MultimemNvlTransportConfigTest, DerivesMixedConfiguration) {
-  EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(256, 7, 2, 2), 4),
-      48);
+  const auto validation =
+      validate_multimem_nvl_transport_config(makeConfig(128, 7, 2, 2, 2), 4);
+  EXPECT_TRUE(validation);
+  EXPECT_EQ(validation.internalSignalCount, 48);
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsPartialStagingGeometry) {
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(256, 1, 2, 0), 4),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(256, 1, 2, 1, 0), 4)
+          .errorMessage,
+      "pipeline depth and maximum blocks must both be zero or non-zero");
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(256, 1, 0, 2), 4),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(128, 1, 0, 2, 2), 4)
+          .errorMessage,
+      "pipeline depth and maximum blocks must both be zero or non-zero");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsInvalidRankCount) {
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(256, 1, 1, 1), 0),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(256, 1, 1, 1, 1), 0)
+          .errorMessage,
+      "NVL rank count must be positive");
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsMissingPerChannelSize) {
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(std::numeric_limits<std::size_t>::max(), 1, 1, 1),
-          std::numeric_limits<int>::max()),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(0, 1), 4).errorMessage,
+      "per-channel size must be non-zero");
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsMissingMaxChannels) {
+  const auto config = make_multimem_nvl_transport_config({
+      .perChannelSize = 256,
+      .pipelineDepth = 0,
+      .maxChannels = 0,
+      .maxBlocks = 0,
+      .userSignalCount = 1,
+  });
+  EXPECT_EQ(
+      validate_multimem_nvl_transport_config(config, 4).errorMessage,
+      "maximum channels must be non-zero");
+}
+
+TEST(MultimemNvlTransportConfigTest, AcceptsNoSignalSlots) {
+  const auto validation =
+      validate_multimem_nvl_transport_config(makeConfig(256, 0), 4);
+
+  EXPECT_TRUE(validation);
+  EXPECT_EQ(validation.dataBufferSize, 256);
+  EXPECT_EQ(validation.internalSignalCount, 0);
+  EXPECT_EQ(validation.signalRegionOffset, 256);
+  EXPECT_EQ(validation.backingAllocationSize, 256);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsMaxBlocksAboveMaxChannels) {
+  const auto config = make_multimem_nvl_transport_config({
+      .perChannelSize = 64,
+      .pipelineDepth = 1,
+      .maxChannels = 2,
+      .maxBlocks = 3,
+      .userSignalCount = 1,
+  });
+
+  EXPECT_EQ(
+      validate_multimem_nvl_transport_config(config, 4).errorMessage,
+      "maximum blocks must not exceed maximum channels");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsInsufficientDataCapacity) {
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(255, 1, 2, 2), 4),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(64, 1, 2, 2, 2), 4)
+          .errorMessage,
+      "data buffer is too small for the staging geometry");
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsMisalignedPerChannelSize) {
+  const auto config = make_multimem_nvl_transport_config({
+      .perChannelSize = 48,
+      .pipelineDepth = 2,
+      .maxChannels = 4,
+      .maxBlocks = 1,
+      .userSignalCount = 1,
+  });
+  EXPECT_EQ(
+      validate_multimem_nvl_transport_config(config, 4).errorMessage,
+      "per-channel size must be divisible by pipeline depth times 16");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsInternalSignalOverflow) {
@@ -111,51 +209,76 @@ TEST(MultimemNvlTransportConfigTest, RejectsInternalSignalOverflow) {
       std::numeric_limits<int>::max() / kSignalsPerLane + 1;
   const std::size_t requiredDataBytes = pipelineDepth * kRanks * 16;
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(requiredDataBytes, 1, pipelineDepth, 1), kRanks),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(
+          makeConfig(requiredDataBytes, 1, pipelineDepth, 1, 1), kRanks)
+          .errorMessage,
+      "signal count exceeds INT_MAX");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsPipelineDepthOutsideDeviceRange) {
   constexpr std::size_t kOutsideDeviceRange =
       static_cast<std::size_t>(std::numeric_limits<uint32_t>::max()) + 1;
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
+      validate_multimem_nvl_transport_config(
           makeConfig(
-              std::numeric_limits<std::size_t>::max(),
-              1,
-              kOutsideDeviceRange,
-              1),
-          4),
-      std::nullopt);
+              /*perChannelSize=*/16,
+              /*userSignalCount=*/1,
+              /*pipelineDepth=*/kOutsideDeviceRange,
+              /*maxChannels=*/1,
+              /*maxBlocks=*/1),
+          4)
+          .errorMessage,
+      "transport geometry exceeds UINT32_MAX");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsMaxChannelsOutsideDeviceRange) {
   constexpr std::size_t kOutsideDeviceRange =
       static_cast<std::size_t>(std::numeric_limits<uint32_t>::max()) + 1;
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
+      validate_multimem_nvl_transport_config(
           makeConfig(
-              std::numeric_limits<std::size_t>::max(),
-              1,
-              1,
-              kOutsideDeviceRange),
-          4),
-      std::nullopt);
+              /*perChannelSize=*/16,
+              /*userSignalCount=*/1,
+              /*pipelineDepth=*/1,
+              /*maxChannels=*/kOutsideDeviceRange,
+              /*maxBlocks=*/1),
+          4)
+          .errorMessage,
+      "transport geometry exceeds UINT32_MAX");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsTotalSignalOverflow) {
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(64, std::numeric_limits<int>::max(), 1, 1), 4),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(
+          makeConfig(64, std::numeric_limits<int>::max(), 1, 1, 1), 4)
+          .errorMessage,
+      "signal count exceeds INT_MAX");
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsDataAlignmentOverflow) {
+  EXPECT_EQ(
+      validate_multimem_nvl_transport_config(
+          makeConfig(std::numeric_limits<std::size_t>::max(), 1), 4)
+          .errorMessage,
+      "combined data and signal allocation size overflows");
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsCombinedAllocationOverflow) {
+  constexpr auto kAlignment = detail::kMultimemSignalAlignment;
+  const auto dataBufferSize =
+      std::numeric_limits<std::size_t>::max() - (kAlignment - 1);
+  EXPECT_EQ(
+      validate_multimem_nvl_transport_config(makeConfig(dataBufferSize, 1), 4)
+          .errorMessage,
+      "combined data and signal allocation size overflows");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsUserSignalCountOutsideSignedRange) {
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(64, std::numeric_limits<uint32_t>::max(), 0, 0), 4),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(
+          makeConfig(64, std::numeric_limits<uint32_t>::max()), 4)
+          .errorMessage,
+      "signal count exceeds INT_MAX");
 }
 
 // validateRankMap runs before any GPU access in the constructor; these cases
@@ -205,7 +328,8 @@ TEST(MultimemNvlTransportValidationTest, IsEligibleRequiresMoreThanTwoRanks) {
 
 TEST(MultimemNvlTransportValidationTest, CompatCtorRejectsNegativeNvlRank) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize = 1024;
+  config.perChannelSize = 1024;
+  config.maxChannels = 1;
   expectRuntimeErrorContains(
       [&] {
         MultimemNvlTransport(
@@ -216,7 +340,8 @@ TEST(MultimemNvlTransportValidationTest, CompatCtorRejectsNegativeNvlRank) {
 
 TEST(MultimemNvlTransportValidationTest, CompatCtorRejectsOutOfRangeNvlRank) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize = 1024;
+  config.perChannelSize = 1024;
+  config.maxChannels = 1;
   expectRuntimeErrorContains(
       [&] {
         MultimemNvlTransport(
@@ -229,9 +354,10 @@ TEST(MultimemNvlTransportValidationTest, CompatCtorRejectsOutOfRangeNvlRank) {
 // cudaGetDevice, so they are exercisable on CPU-only hosts with a null
 // bootstrap: none of the code paths past these throws is reached.
 
-TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroDataBufferSize) {
+TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroPerChannelSize) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize = 0; // triggers the guard
+  config.perChannelSize = 0;
+  config.maxChannels = 1;
   config.userSignalCount = 1;
   expectRuntimeErrorContains(
       [&] {
@@ -241,32 +367,18 @@ TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroDataBufferSize) {
             /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
             config);
       },
-      "dataBufferSize must be non-zero");
-}
-
-TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroSignalCount) {
-  MultimemNvlTransportConfig config{};
-  config.dataBufferSize = 1024;
-  config.userSignalCount = 0;
-  expectRuntimeErrorContains(
-      [&] {
-        MultimemNvlTransport(
-            /*bootstrap=*/nullptr,
-            /*commRank=*/0,
-            /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
-            config);
-      },
-      "at least one signal slot is required");
+      "per-channel size must be non-zero");
 }
 
 TEST(
     MultimemNvlTransportValidationTest,
     PrimaryCtorRejectsTotalSignalCountOverflow) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize = 64;
+  config.perChannelSize = 64;
   config.userSignalCount = std::numeric_limits<int>::max();
   config.pipelineDepth = 1;
   config.maxChannels = 1;
+  config.maxBlocks = 1;
   expectRuntimeErrorContains(
       [&] {
         MultimemNvlTransport(
@@ -275,14 +387,15 @@ TEST(
             /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
             config);
       },
-      "invalid staging geometry or capacity");
+      "signal count exceeds INT_MAX");
 }
 
 TEST(
     MultimemNvlTransportValidationTest,
     PrimaryCtorRejectsDataBufferAlignmentOverflow) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize = std::numeric_limits<std::size_t>::max();
+  config.perChannelSize = std::numeric_limits<std::size_t>::max();
+  config.maxChannels = 1;
   config.userSignalCount = 1;
   expectRuntimeErrorContains(
       [&] {
@@ -292,15 +405,16 @@ TEST(
             /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
             config);
       },
-      "dataBufferSize alignment overflows");
+      "combined data and signal allocation size overflows");
 }
 
 TEST(
     MultimemNvlTransportValidationTest,
     PrimaryCtorRejectsCombinedAllocationSizeOverflow) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize =
+  config.perChannelSize =
       std::numeric_limits<std::size_t>::max() - (alignof(SignalState) - 1);
+  config.maxChannels = 1;
   config.userSignalCount = 1;
   expectRuntimeErrorContains(
       [&] {
@@ -310,7 +424,7 @@ TEST(
             /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
             config);
       },
-      "combined allocation size overflows");
+      "combined data and signal allocation size overflows");
 }
 
 } // namespace comms::prims::tests

--- a/comms/prims/tests/MultimemNvlTransportValidationTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportValidationTest.cc
@@ -31,7 +31,7 @@ void expectRuntimeErrorContains(Fn&& fn, const std::string& expected) {
 
 MultimemNvlTransportConfig makeConfig(
     std::size_t perChannelSize,
-    uint32_t userSignalCount = 1,
+    uint32_t userSignalCount = 0,
     std::size_t pipelineDepth = 0,
     std::size_t maxChannels = 1,
     std::size_t maxBlocks = 0) {
@@ -48,7 +48,7 @@ MultimemNvlTransportConfig makeConfig(
 
 TEST(MultimemNvlTransportConfigTest, DerivesUserOnlyConfiguration) {
   const auto validation =
-      validate_multimem_nvl_transport_config(makeConfig(256), 4);
+      validate_multimem_nvl_transport_config(makeConfig(256, 1), 4);
   EXPECT_TRUE(validation);
   EXPECT_EQ(validation.internalSignalCount, 0);
 }
@@ -68,7 +68,15 @@ TEST(
 
   ASSERT_TRUE(validation);
   EXPECT_EQ(validation.dataBufferSize, 8192);
-  EXPECT_EQ(validation.internalSignalCount, 192);
+  EXPECT_EQ(validation.internalSignalCount, 160);
+}
+
+TEST(MultimemNvlTransportConfigTest, DefinesSignalGeometryPerChannel) {
+  EXPECT_EQ(detail::kMultimemSignalsPerPeer, 3);
+  EXPECT_EQ(detail::kMultimemSignalsPerLane, 4);
+  EXPECT_EQ(multimem_staging_signals_per_channel(4, 2), 20);
+  constexpr uint64_t kMax = std::numeric_limits<uint32_t>::max();
+  EXPECT_EQ(multimem_staging_signals_per_channel(kMax, kMax), 7 * kMax);
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsDataBufferMultiplicationOverflow) {
@@ -86,7 +94,7 @@ TEST(MultimemNvlTransportConfigTest, RejectsDataBufferMultiplicationOverflow) {
 }
 
 TEST(MultimemNvlTransportConfigTest, PreservesDefaultUserSignalCount) {
-  EXPECT_EQ(MultimemNvlTransportConfig{}.userSignalCount, 1);
+  EXPECT_EQ(MultimemNvlTransportConfig{}.userSignalCount, 0);
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsLegacyPositionalConstruction) {
@@ -109,14 +117,14 @@ TEST(MultimemNvlTransportConfigTest, DerivesStagingOnlyConfiguration) {
   const auto validation =
       validate_multimem_nvl_transport_config(makeConfig(128, 0, 2, 2, 2), 4);
   EXPECT_TRUE(validation);
-  EXPECT_EQ(validation.internalSignalCount, 48);
+  EXPECT_EQ(validation.internalSignalCount, 40);
 }
 
 TEST(MultimemNvlTransportConfigTest, DerivesMixedConfiguration) {
   const auto validation =
       validate_multimem_nvl_transport_config(makeConfig(128, 7, 2, 2, 2), 4);
   EXPECT_TRUE(validation);
-  EXPECT_EQ(validation.internalSignalCount, 48);
+  EXPECT_EQ(validation.internalSignalCount, 40);
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsPartialStagingGeometry) {
@@ -156,12 +164,13 @@ TEST(MultimemNvlTransportConfigTest, RejectsMissingMaxChannels) {
       "maximum channels must be non-zero");
 }
 
-TEST(MultimemNvlTransportConfigTest, AcceptsNoSignalSlots) {
+TEST(MultimemNvlTransportConfigTest, AcceptsSignalFreeConfiguration) {
   const auto validation =
       validate_multimem_nvl_transport_config(makeConfig(256, 0), 4);
 
-  EXPECT_TRUE(validation);
+  ASSERT_TRUE(validation);
   EXPECT_EQ(validation.dataBufferSize, 256);
+  EXPECT_EQ(validation.signalsPerChannel, 0);
   EXPECT_EQ(validation.internalSignalCount, 0);
   EXPECT_EQ(validation.signalRegionOffset, 256);
   EXPECT_EQ(validation.backingAllocationSize, 256);
@@ -203,10 +212,12 @@ TEST(MultimemNvlTransportConfigTest, RejectsMisalignedPerChannelSize) {
 
 TEST(MultimemNvlTransportConfigTest, RejectsInternalSignalOverflow) {
   constexpr std::size_t kRanks = 4;
-  constexpr std::size_t kSignalsPerLane =
-      multimem_staging_signals_per_lane(static_cast<uint32_t>(kRanks));
+  constexpr std::size_t kSignalsPerPeer = detail::kMultimemSignalsPerPeer;
+  constexpr std::size_t kSignalsPerLane = detail::kMultimemSignalsPerLane;
   const std::size_t pipelineDepth =
-      std::numeric_limits<int>::max() / kSignalsPerLane + 1;
+      (std::numeric_limits<int>::max() - kRanks * kSignalsPerPeer) /
+          kSignalsPerLane +
+      1;
   const std::size_t requiredDataBytes = pipelineDepth * kRanks * 16;
   EXPECT_EQ(
       validate_multimem_nvl_transport_config(

--- a/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
@@ -151,8 +151,9 @@ __device__ __forceinline__ StageLayout make_stage_layout(
     __trap();
   }
 #endif
-  const uint64_t expectedSignalsPerLane = multimem_staging_signals_per_lane(
-      static_cast<uint32_t>(transport.nvlRanks));
+  const uint64_t expectedSignalsPerLane =
+      comms::prims::multimem_staging_signals_per_lane(
+          static_cast<uint32_t>(transport.nvlRanks));
   const uint64_t signalsPerLane = transport.signalsPerLane;
 #if defined(__CUDA_ARCH__)
   if (signalsPerLane != expectedSignalsPerLane) {

--- a/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
@@ -5,10 +5,10 @@
 //
 // Shared infrastructure used by all three staging paths (ReduceScatter /
 // AllGather / AllReduce): the per-CTA staging-window geometry (`StageLayout` /
-// `make_stage_layout`) and the internal-signal slot-id helpers (ready/ack
-// per-peer SET slots and the staging ADD barrier slots). It depends only on the
-// transport struct in MultimemNvlTransportDevice.cuh, not on the reduce/store
-// PTX.
+// `make_stage_layout`) and the internal-signal slot-id helpers (channel-wide
+// ready/ack/consumed SET stripes and lane-private aggregate barriers). It
+// depends only on the transport struct in MultimemNvlTransportDevice.cuh, not
+// on the reduce/store PTX.
 
 // clang-tidy analyzes this .cuh as a standalone main file and misflags the
 // pragma; it is a genuine include-once header. False positive, so suppress it.
@@ -45,18 +45,20 @@ checked_signal_product(uint64_t lhs, uint64_t rhs) {
 } // namespace detail
 
 /**
- * Layout of one CTA-group's slice of the shared staging window.
+ * Layout of one logical channel's slice of the shared staging window.
  *
- * The flat per-rank data buffer is split across CTAs (groups), and each group's
- * slice is further split into `pipelineDepth` lanes. A round picks its lane
- * round-robin so consecutive rounds use disjoint physical windows (pipelining).
+ * Each CUDA ThreadGroup selects one channel by group_id. The flat per-rank data
+ * buffer is split across active channels, and each channel's slice is further
+ * split into `pipelineDepth` lanes. A round picks its lane round-robin so
+ * consecutive rounds use disjoint physical windows.
  */
 struct StageLayout {
-  std::size_t groupBeginBytes{0}; // this group's slice origin into the buffer
+  std::size_t channelBeginBytes{0}; // channel slice origin in the data buffer
   std::size_t stagingElems{0}; // one lane window, in elements
   std::size_t stagingBytes{0}; // one lane window, in bytes
-  uint64_t signalBase{0}; // this group's base into the internal signals
-  uint64_t signalsPerLane{0}; // 2 * nvlRanks + 4
+  uint64_t signalBase{0}; // this channel's base into the internal signals
+  uint64_t signalsPerChannel{0}; // 3 * nvlRanks + 4 * pipelineDepth
+  int nvlRanks{0}; // ranks in this NVLink domain
   uint32_t pipelineDepth{1};
 };
 
@@ -92,14 +94,14 @@ __device__ __forceinline__ StageLayout make_stage_layout(
     __trap();
   }
   if (pipelineDepth == 0 || transport.maxChannels == 0 ||
-      transport.signalsPerLane == 0 ||
+      transport.signalsPerChannel == 0 ||
       group.total_groups > transport.maxChannels) {
     printf(
         "NvlMultimem staging layout: invalid geometry depth=%u "
-        "maxChannels=%u signalsPerLane=%u total_groups=%u\n",
+        "maxChannels=%u signalsPerChannel=%u total_groups=%u\n",
         static_cast<unsigned>(pipelineDepth),
         static_cast<unsigned>(transport.maxChannels),
-        static_cast<unsigned>(transport.signalsPerLane),
+        static_cast<unsigned>(transport.signalsPerChannel),
         static_cast<unsigned>(group.total_groups));
     __trap();
   }
@@ -109,7 +111,7 @@ __device__ __forceinline__ StageLayout make_stage_layout(
   const std::size_t groupId = group.group_id;
   const std::size_t unitsPerGroup = totalUnits / totalGroups;
   const std::size_t extraUnits = totalUnits % totalGroups;
-  const std::size_t groupBeginUnit =
+  const std::size_t channelBeginUnit =
       unitsPerGroup * groupId + (groupId < extraUnits ? groupId : extraUnits);
   const std::size_t groupUnits =
       unitsPerGroup + static_cast<std::size_t>(groupId < extraUnits);
@@ -129,45 +131,43 @@ __device__ __forceinline__ StageLayout make_stage_layout(
   }
 #endif
 
-  // Layout per (group, lane):
+  // Layout per channel:
   //   [0, nvlRanks)             ready[rank]           (SET, per-peer)
   //   [nvlRanks, 2*nvlRanks)    ack[rank]             (SET, per-peer)
-  //   2*nvlRanks + 0            staging_ready_counter (ADD, multicast)
-  //   2*nvlRanks + 1            staging_ready_epoch   (ADD, this rank baseline)
-  //   2*nvlRanks + 2            staging_ack_counter   (ADD, multicast)
-  //   2*nvlRanks + 3            staging_ack_epoch     (ADD, this rank baseline)
-  // The four ADD-mode barrier slots MUST live outside the SET-mode ready/ack
-  // region: without this separation, flipping stagingArrivalBarrier between ops
-  // in a single process leaves ADD counter residue in slots that a later
-  // SET-mode op reads with CMP_GE, and any past-op residue trivially satisfies
-  // the wait.
+  //   [2*nvlRanks, 3*nvlRanks)  consumed[rank]        (SET, per-peer)
+  // Each lane then owns four aggregate-barrier slots:
+  //   3*nvlRanks + 4*lane + 0   staging_ready_counter (ADD, multicast)
+  //   3*nvlRanks + 4*lane + 1   staging_ready_epoch   (local baseline)
+  //   3*nvlRanks + 4*lane + 2   staging_ack_counter   (ADD, multicast)
+  //   3*nvlRanks + 4*lane + 3   staging_ack_epoch     (local baseline)
+  // Only the counter slots are multicast ADD targets. The epoch slots hold
+  // rank-local baselines. All four slots MUST live outside the SET-mode peer
+  // stripes: otherwise ADD counter residue can satisfy a later SET-mode CMP_GE
+  // wait after the selected synchronization mode changes.
 #if defined(__CUDA_ARCH__)
-  if (transport.nvlRanks <= 0 ||
-      static_cast<uint64_t>(transport.nvlRanks) >
-          (static_cast<uint64_t>(~uint32_t{0}) - 4) / 2) {
+  if (transport.nvlRanks <= 0) {
     printf(
         "NvlMultimem staging layout: invalid nvlRanks=%d\n",
         transport.nvlRanks);
     __trap();
   }
 #endif
-  const uint64_t expectedSignalsPerLane =
-      comms::prims::multimem_staging_signals_per_lane(
-          static_cast<uint32_t>(transport.nvlRanks));
-  const uint64_t signalsPerLane = transport.signalsPerLane;
+  const uint64_t expectedSignalsPerChannel =
+      comms::prims::multimem_staging_signals_per_channel(
+          static_cast<uint32_t>(transport.nvlRanks), pipelineDepth);
+  const uint64_t signalsPerChannel = transport.signalsPerChannel;
 #if defined(__CUDA_ARCH__)
-  if (signalsPerLane != expectedSignalsPerLane) {
+  if (expectedSignalsPerChannel > ~uint32_t{0} ||
+      signalsPerChannel != expectedSignalsPerChannel) {
     printf(
-        "NvlMultimem staging layout: signalsPerLane=%llu expected=%llu\n",
-        static_cast<unsigned long long>(signalsPerLane),
-        static_cast<unsigned long long>(expectedSignalsPerLane));
+        "NvlMultimem staging layout: signalsPerChannel=%llu expected=%llu\n",
+        static_cast<unsigned long long>(signalsPerChannel),
+        static_cast<unsigned long long>(expectedSignalsPerChannel));
     __trap();
   }
 #endif
-  const uint64_t signalsPerGroup = detail::checked_signal_product(
-      static_cast<uint64_t>(pipelineDepth), signalsPerLane);
   const uint64_t requiredSignals = detail::checked_signal_product(
-      static_cast<uint64_t>(group.total_groups), signalsPerGroup);
+      static_cast<uint64_t>(group.total_groups), signalsPerChannel);
 #if defined(__CUDA_ARCH__)
   if (requiredSignals > transport.internalLocalSignals.size() ||
       requiredSignals > transport.internalMultimemSignals.size()) {
@@ -186,31 +186,66 @@ __device__ __forceinline__ StageLayout make_stage_layout(
 #endif
 
   return StageLayout{
-      .groupBeginBytes = groupBeginUnit * alignBytes,
+      .channelBeginBytes = channelBeginUnit * alignBytes,
       .stagingElems = stagingUnits * elemsPerAlign,
       .stagingBytes = stagingUnits * alignBytes,
       .signalBase = detail::checked_signal_product(
-          static_cast<uint64_t>(group.group_id), signalsPerGroup),
-      .signalsPerLane = signalsPerLane,
+          static_cast<uint64_t>(group.group_id), signalsPerChannel),
+      .signalsPerChannel = signalsPerChannel,
+      .nvlRanks = transport.nvlRanks,
       .pipelineDepth = pipelineDepth,
   };
 }
 
 __device__ __forceinline__ uint64_t
-ready_signal_id(const StageLayout& layout, uint32_t lane, int rank) {
-  return layout.signalBase +
-      static_cast<uint64_t>(lane) * layout.signalsPerLane +
-      static_cast<uint64_t>(rank);
+peer_signal_id(const StageLayout& layout, uint64_t stripeOffset, int rank) {
+  return layout.signalBase + stripeOffset + static_cast<uint64_t>(rank);
 }
 
-__device__ __forceinline__ uint64_t ack_signal_id(
-    const StageLayout& layout,
-    uint32_t lane,
-    int nvlRanks,
-    int rank) {
+__device__ __forceinline__ uint64_t
+ready_signal_id(const StageLayout& layout, int rank) {
+  return peer_signal_id(layout, /*stripeOffset=*/0, rank);
+}
+
+__device__ __forceinline__ uint64_t
+ack_signal_id(const StageLayout& layout, int rank) {
+  return peer_signal_id(layout, static_cast<uint64_t>(layout.nvlRanks), rank);
+}
+
+__device__ __forceinline__ uint64_t
+consumed_signal_id(const StageLayout& layout, int rank) {
+  return peer_signal_id(
+      layout,
+      static_cast<uint64_t>(2) * static_cast<uint64_t>(layout.nvlRanks),
+      rank);
+}
+
+__device__ __forceinline__ uint64_t
+lane_signal_base(const StageLayout& layout, uint32_t lane) {
   return layout.signalBase +
-      static_cast<uint64_t>(lane) * layout.signalsPerLane +
-      static_cast<uint64_t>(nvlRanks + rank);
+      static_cast<uint64_t>(3) * static_cast<uint64_t>(layout.nvlRanks) +
+      static_cast<uint64_t>(lane) *
+      comms::prims::detail::kMultimemSignalsPerLane;
+}
+
+__device__ __forceinline__ uint64_t
+ready_counter_signal_id(const StageLayout& layout, uint32_t lane) {
+  return lane_signal_base(layout, lane);
+}
+
+__device__ __forceinline__ uint64_t
+ready_epoch_signal_id(const StageLayout& layout, uint32_t lane) {
+  return lane_signal_base(layout, lane) + 1;
+}
+
+__device__ __forceinline__ uint64_t
+ack_counter_signal_id(const StageLayout& layout, uint32_t lane) {
+  return lane_signal_base(layout, lane) + 2;
+}
+
+__device__ __forceinline__ uint64_t
+ack_epoch_signal_id(const StageLayout& layout, uint32_t lane) {
+  return lane_signal_base(layout, lane) + 3;
 }
 
 __device__ __forceinline__ uint64_t
@@ -223,7 +258,7 @@ __device__ __forceinline__ std::size_t lane_begin(
     uint64_t primitiveRound) {
   const uint32_t lane =
       static_cast<uint32_t>(primitiveRound % layout.pipelineDepth);
-  return layout.groupBeginBytes +
+  return layout.channelBeginBytes +
       static_cast<std::size_t>(lane) * layout.stagingBytes;
 }
 

--- a/comms/prims/transport/nvl/MultimemNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.cc
@@ -15,7 +15,7 @@ namespace comms::prims {
 namespace {
 
 constexpr uint64_t kMultimemNvlTransportProtocol = 0x4D4D4E564CULL;
-constexpr uint64_t kMultimemNvlTransportProtocolVersion = 4;
+constexpr uint64_t kMultimemNvlTransportProtocolVersion = 5;
 
 int getCurrentCudaDevice() {
   int cudaDevice = 0;
@@ -93,10 +93,7 @@ MultimemNvlTransport::MultimemNvlTransport(
   }
   dataBufferSize_ = validation.dataBufferSize;
   internalSignalCount_ = validation.internalSignalCount;
-  if (config_.pipelineDepth != 0) {
-    signalsPerLane_ =
-        multimem_staging_signals_per_lane(static_cast<uint32_t>(nvlRanks_));
-  }
+  signalsPerChannel_ = validation.signalsPerChannel;
   // commRank presence in the map is already verified by validateRankMap.
   int nvlRank = -1;
   for (int rank = 0; rank < nvlRanks_; ++rank) {
@@ -241,7 +238,7 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
       .nvlRanks = nvlRanks_,
       .pipelineDepth = static_cast<uint32_t>(config_.pipelineDepth),
       .maxChannels = static_cast<uint32_t>(config_.maxChannels),
-      .signalsPerLane = signalsPerLane_,
+      .signalsPerChannel = signalsPerChannel_,
   };
 }
 

--- a/comms/prims/transport/nvl/MultimemNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.cc
@@ -2,13 +2,11 @@
 
 #include "comms/prims/transport/nvl/MultimemNvlTransport.h"
 
-#include <limits>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <utility>
 
-#include "comms/common/BitOps.cuh"
 #include "comms/prims/core/SignalState.cuh"
 #include "comms/utils/checks.h"
 
@@ -17,7 +15,7 @@ namespace comms::prims {
 namespace {
 
 constexpr uint64_t kMultimemNvlTransportProtocol = 0x4D4D4E564CULL;
-constexpr uint64_t kMultimemNvlTransportProtocolVersion = 1;
+constexpr uint64_t kMultimemNvlTransportProtocolVersion = 4;
 
 int getCurrentCudaDevice() {
   int cudaDevice = 0;
@@ -86,32 +84,19 @@ MultimemNvlTransport::MultimemNvlTransport(
   // are exercisable on CPU-only hosts (see MultimemNvlTransportValidationTest).
   validateRankMap(commRank_, nvlRankToCommRank_);
 
-  if (config_.dataBufferSize == 0) {
+  const auto validation =
+      validate_multimem_nvl_transport_config(config_, nvlRanks_);
+  if (!validation) {
     throw std::runtime_error(
-        "MultimemNvlTransport: dataBufferSize must be non-zero");
+        std::string("MultimemNvlTransport: ") +
+        std::string(validation.errorMessage));
   }
-  const auto internalSignalCount =
-      detail::checked_multimem_internal_signal_count(config_, nvlRanks_);
-  if (!internalSignalCount.has_value()) {
-    throw std::runtime_error(
-        "MultimemNvlTransport: invalid staging geometry or capacity");
-  }
-  internalSignalCount_ = *internalSignalCount;
+  dataBufferSize_ = validation.dataBufferSize;
+  internalSignalCount_ = validation.internalSignalCount;
   if (config_.pipelineDepth != 0) {
     signalsPerLane_ =
         multimem_staging_signals_per_lane(static_cast<uint32_t>(nvlRanks_));
   }
-  const uint64_t totalSignalCount =
-      static_cast<uint64_t>(config_.userSignalCount) + internalSignalCount_;
-  if (totalSignalCount == 0) {
-    throw std::runtime_error(
-        "MultimemNvlTransport: at least one signal slot is required");
-  }
-  if (totalSignalCount >
-      static_cast<uint64_t>(std::numeric_limits<int>::max())) {
-    throw std::runtime_error("MultimemNvlTransport: signalCount too large");
-  }
-
   // commRank presence in the map is already verified by validateRankMap.
   int nvlRank = -1;
   for (int rank = 0; rank < nvlRanks_; ++rank) {
@@ -129,22 +114,11 @@ MultimemNvlTransport::MultimemNvlTransport(
   }
   nvlRank_ = nvlRank;
 
-  constexpr std::size_t kSignalAlignment = alignof(SignalState);
-  if (config_.dataBufferSize >
-      std::numeric_limits<std::size_t>::max() - (kSignalAlignment - 1)) {
-    throw std::runtime_error(
-        "MultimemNvlTransport: dataBufferSize alignment overflows");
-  }
-  signalRegionOffset_ =
-      comms::bitops::alignUp(config_.dataBufferSize, kSignalAlignment);
-  const std::size_t signalRegionBytes =
-      getSignalBufferSize(static_cast<int>(totalSignalCount));
-  if (signalRegionOffset_ >
-      std::numeric_limits<std::size_t>::max() - signalRegionBytes) {
-    throw std::runtime_error(
-        "MultimemNvlTransport: combined allocation size overflows");
-  }
-  const std::size_t combinedSize = signalRegionOffset_ + signalRegionBytes;
+  static_assert(alignof(SignalState) == detail::kMultimemSignalAlignment);
+  static_assert(sizeof(SignalState) == detail::kMultimemSignalStateSize);
+  signalRegionOffset_ = validation.signalRegionOffset;
+  const std::size_t combinedSize = validation.backingAllocationSize;
+  const std::size_t signalRegionBytes = combinedSize - signalRegionOffset_;
 
   cudaDevice_ = getCurrentCudaDevice();
 
@@ -172,11 +146,13 @@ MultimemNvlTransport::MultimemNvlTransport(
   // exchange()'s post-map barrier lets any peer signal into this region. This
   // mirrors MultiPeerNvlTransport, which zeroes its signal buffer at
   // construction.
-  auto* localSignalRegion =
-      static_cast<char*>(combinedHandler_->getLocalDeviceMemPtr()) +
-      signalRegionOffset_;
-  CUDA_CHECK(cudaMemset(localSignalRegion, 0, signalRegionBytes));
-  CUDA_CHECK(cudaStreamSynchronize(/*stream=*/0));
+  if (signalRegionBytes != 0) {
+    auto* localSignalRegion =
+        static_cast<char*>(combinedHandler_->getLocalDeviceMemPtr()) +
+        signalRegionOffset_;
+    CUDA_CHECK(cudaMemset(localSignalRegion, 0, signalRegionBytes));
+    CUDA_CHECK(cudaStreamSynchronize(/*stream=*/0));
+  }
 }
 
 MultimemNvlTransport::MultimemNvlTransport(
@@ -216,10 +192,11 @@ void MultimemNvlTransport::exchange() {
         .version = kMultimemNvlTransportProtocolVersion,
         .parameters =
             {
-                config_.dataBufferSize,
-                config_.userSignalCount,
+                config_.perChannelSize,
                 config_.pipelineDepth,
                 config_.maxChannels,
+                config_.maxBlocks,
+                config_.userSignalCount,
             },
     };
     combinedHandler_->exchangeMulticast(
@@ -259,7 +236,7 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
           localSignals + userSignalCount, internalSignalCount),
       .internalMultimemSignals = DeviceSpan<SignalState>(
           multimemSignals + userSignalCount, internalSignalCount),
-      .dataBufferSize = config_.dataBufferSize,
+      .dataBufferSize = dataBufferSize_,
       .nvlRank = nvlRank_,
       .nvlRanks = nvlRanks_,
       .pipelineDepth = static_cast<uint32_t>(config_.pipelineDepth),
@@ -269,7 +246,7 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
 }
 
 std::size_t MultimemNvlTransport::getAllocatedDataBufferSize() const {
-  return config_.dataBufferSize;
+  return dataBufferSize_;
 }
 
 std::size_t MultimemNvlTransport::getAllocatedSignalBufferSize() const {

--- a/comms/prims/transport/nvl/MultimemNvlTransport.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.h
@@ -99,7 +99,7 @@ class MultimemNvlTransport {
   const MultimemNvlTransportConfig config_;
   std::size_t dataBufferSize_{0};
   uint32_t internalSignalCount_{0};
-  uint32_t signalsPerLane_{0};
+  uint32_t signalsPerChannel_{0};
   bool exchanged_{false};
   // Set when exchange() throws; subsequent calls throw instead of silently
   // retrying. Multicast object create/import/bind failures can leave partial

--- a/comms/prims/transport/nvl/MultimemNvlTransport.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.h
@@ -4,87 +4,15 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <memory>
-#include <optional>
 #include <vector>
 
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/prims/memory/GpuMemHandler.h"
+#include "comms/prims/transport/nvl/MultimemNvlTransportConfig.h"
 #include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
 
 namespace comms::prims {
-
-struct MultimemNvlTransportConfig {
-  // Size in bytes of the multicast staging data window.
-  std::size_t dataBufferSize{0};
-
-  // Signal slots exposed through signal(), read_signal(), and
-  // wait_signal_until().
-  uint32_t userSignalCount{1};
-
-  // Immutable staging geometry. Both values must be zero when staging is not
-  // used, or both must be non-zero when staging is enabled. `maxChannels` is
-  // the maximum supported `ThreadGroup::total_groups`; each group, pipeline
-  // lane, and NVLink rank requires one 16-byte-aligned data unit. Construction
-  // derives and reserves the corresponding internal signal region after the
-  // user-visible signal slots.
-  std::size_t pipelineDepth{0};
-  std::size_t maxChannels{0};
-};
-
-namespace detail {
-
-inline std::optional<uint32_t> checked_multimem_internal_signal_count(
-    const MultimemNvlTransportConfig& config,
-    int nvlRanks) {
-  if (nvlRanks <= 0 ||
-      config.userSignalCount > std::numeric_limits<int>::max()) {
-    return std::nullopt;
-  }
-
-  const auto signalsPerLaneWide =
-      multimem_staging_signals_per_lane_wide(static_cast<uint64_t>(nvlRanks));
-  if (signalsPerLaneWide > std::numeric_limits<uint32_t>::max()) {
-    return std::nullopt;
-  }
-
-  const bool hasPipelineDepth = config.pipelineDepth != 0;
-  const bool hasMaxChannels = config.maxChannels != 0;
-  if (hasPipelineDepth != hasMaxChannels) {
-    return std::nullopt;
-  }
-  if (!hasPipelineDepth) {
-    return 0;
-  }
-  if (config.pipelineDepth > std::numeric_limits<uint32_t>::max() ||
-      config.maxChannels > std::numeric_limits<uint32_t>::max()) {
-    return std::nullopt;
-  }
-
-  constexpr std::size_t kDataAlignment = 16;
-  const std::size_t alignedUnits = config.dataBufferSize / kDataAlignment;
-  const auto ranks = static_cast<std::size_t>(nvlRanks);
-  if (config.maxChannels > alignedUnits ||
-      config.pipelineDepth > alignedUnits / config.maxChannels ||
-      ranks > alignedUnits / config.maxChannels / config.pipelineDepth) {
-    return std::nullopt;
-  }
-
-  const auto maxInternalSignals = static_cast<std::size_t>(
-      std::numeric_limits<int>::max() - config.userSignalCount);
-  const auto signalsPerLane = static_cast<std::size_t>(signalsPerLaneWide);
-  if (config.maxChannels > maxInternalSignals / signalsPerLane) {
-    return std::nullopt;
-  }
-  const auto signalsPerRound = config.maxChannels * signalsPerLane;
-  if (config.pipelineDepth > maxInternalSignals / signalsPerRound) {
-    return std::nullopt;
-  }
-  return static_cast<uint32_t>(config.pipelineDepth * signalsPerRound);
-}
-
-} // namespace detail
 
 /**
  * Host-side owner for a copy-based NVL multimem transport.
@@ -169,12 +97,13 @@ class MultimemNvlTransport {
   // rank-map preconditions on CPU-only hosts).
   int cudaDevice_{-1};
   const MultimemNvlTransportConfig config_;
+  std::size_t dataBufferSize_{0};
   uint32_t internalSignalCount_{0};
   uint32_t signalsPerLane_{0};
   bool exchanged_{false};
   // Set when exchange() throws; subsequent calls throw instead of silently
   // retrying. Multicast object create/import/bind failures can leave partial
-  // driver state, so a same-object retry is unsafe — callers must rebuild the
+  // driver state, so a same-object retry is unsafe. Callers must rebuild the
   // transport to recover.
   bool broken_{false};
 
@@ -185,8 +114,7 @@ class MultimemNvlTransport {
   // (getMultimemDeviceMemPtr) -- one cuMulticastCreate / one set of binds / one
   // MC VA range over one shared physical backing.
   std::unique_ptr<GpuMemHandler> combinedHandler_;
-  // Offset of the signal region within combinedHandler_'s allocation. Equals
-  // dataBufferSize rounded up to SignalState's 128-byte alignment.
+  // Offset of the signal region within combinedHandler_'s allocation.
   std::size_t signalRegionOffset_{0};
 };
 

--- a/comms/prims/transport/nvl/MultimemNvlTransportConfig.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransportConfig.cc
@@ -44,6 +44,7 @@ MultimemNvlTransportConfigValidation validate_multimem_nvl_transport_config(
   const std::size_t dataBufferSize = config.perChannelSize * config.maxChannels;
 
   uint32_t internalSignalCount = 0;
+  uint32_t signalsPerChannel = 0;
   if (config.pipelineDepth != 0) {
     constexpr std::size_t kDataAlignment = 16;
     if (config.pipelineDepth >
@@ -62,23 +63,19 @@ MultimemNvlTransportConfigValidation validate_multimem_nvl_transport_config(
           .errorMessage = "data buffer is too small for the staging geometry"};
     }
 
-    const auto signalsPerLaneWide =
-        multimem_staging_signals_per_lane_wide(static_cast<uint64_t>(nvlRanks));
-    if (signalsPerLaneWide > std::numeric_limits<uint32_t>::max()) {
+    const auto signalsPerChannelWide = multimem_staging_signals_per_channel(
+        static_cast<uint64_t>(nvlRanks), config.pipelineDepth);
+    if (signalsPerChannelWide > std::numeric_limits<uint32_t>::max()) {
       return {.errorMessage = "transport geometry exceeds UINT32_MAX"};
     }
     const auto maxInternalSignals = static_cast<std::size_t>(
         std::numeric_limits<int>::max() - config.userSignalCount);
-    const auto signalsPerLane = static_cast<std::size_t>(signalsPerLaneWide);
-    if (config.maxChannels > maxInternalSignals / signalsPerLane) {
+    signalsPerChannel = static_cast<uint32_t>(signalsPerChannelWide);
+    if (config.maxChannels > maxInternalSignals / signalsPerChannel) {
       return {.errorMessage = "signal count exceeds INT_MAX"};
     }
-    const auto signalsPerPipelineLane = config.maxChannels * signalsPerLane;
-    if (config.pipelineDepth > maxInternalSignals / signalsPerPipelineLane) {
-      return {.errorMessage = "signal count exceeds INT_MAX"};
-    }
-    internalSignalCount =
-        static_cast<uint32_t>(config.pipelineDepth * signalsPerPipelineLane);
+    internalSignalCount = static_cast<uint32_t>(
+        config.maxChannels * static_cast<std::size_t>(signalsPerChannel));
   }
 
   constexpr auto kSignalAlignment = detail::kMultimemSignalAlignment;
@@ -107,6 +104,7 @@ MultimemNvlTransportConfigValidation validate_multimem_nvl_transport_config(
 
   return {
       .dataBufferSize = dataBufferSize,
+      .signalsPerChannel = signalsPerChannel,
       .internalSignalCount = internalSignalCount,
       .signalRegionOffset = signalRegionOffset,
       .backingAllocationSize = signalRegionOffset + signalRegionBytes,

--- a/comms/prims/transport/nvl/MultimemNvlTransportConfig.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransportConfig.cc
@@ -1,0 +1,116 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/transport/nvl/MultimemNvlTransportConfig.h"
+
+#include <limits>
+
+namespace comms::prims {
+
+MultimemNvlTransportConfigValidation validate_multimem_nvl_transport_config(
+    const MultimemNvlTransportConfig& config,
+    int nvlRanks) {
+  if (config.perChannelSize == 0) {
+    return {.errorMessage = "per-channel size must be non-zero"};
+  }
+  if (config.maxChannels == 0) {
+    return {.errorMessage = "maximum channels must be non-zero"};
+  }
+  if (nvlRanks <= 0) {
+    return {.errorMessage = "NVL rank count must be positive"};
+  }
+  if (config.userSignalCount > std::numeric_limits<int>::max()) {
+    return {.errorMessage = "signal count exceeds INT_MAX"};
+  }
+
+  const bool hasPipelineDepth = config.pipelineDepth != 0;
+  const bool hasMaxBlocks = config.maxBlocks != 0;
+  if (hasPipelineDepth != hasMaxBlocks) {
+    return {
+        .errorMessage =
+            "pipeline depth and maximum blocks must both be zero or non-zero"};
+  }
+  if (config.pipelineDepth > std::numeric_limits<uint32_t>::max() ||
+      config.maxChannels > std::numeric_limits<uint32_t>::max()) {
+    return {.errorMessage = "transport geometry exceeds UINT32_MAX"};
+  }
+  if (config.maxBlocks > config.maxChannels) {
+    return {.errorMessage = "maximum blocks must not exceed maximum channels"};
+  }
+  if (config.perChannelSize >
+      std::numeric_limits<std::size_t>::max() / config.maxChannels) {
+    return {
+        .errorMessage = "per-channel size times maximum channels overflows"};
+  }
+  const std::size_t dataBufferSize = config.perChannelSize * config.maxChannels;
+
+  uint32_t internalSignalCount = 0;
+  if (config.pipelineDepth != 0) {
+    constexpr std::size_t kDataAlignment = 16;
+    if (config.pipelineDepth >
+            std::numeric_limits<std::size_t>::max() / kDataAlignment ||
+        config.perChannelSize % (config.pipelineDepth * kDataAlignment) != 0) {
+      return {
+          .errorMessage =
+              "per-channel size must be divisible by pipeline depth times 16"};
+    }
+    const std::size_t alignedUnits = dataBufferSize / kDataAlignment;
+    const auto ranks = static_cast<std::size_t>(nvlRanks);
+    if (config.maxChannels > alignedUnits ||
+        config.pipelineDepth > alignedUnits / config.maxChannels ||
+        ranks > alignedUnits / config.maxChannels / config.pipelineDepth) {
+      return {
+          .errorMessage = "data buffer is too small for the staging geometry"};
+    }
+
+    const auto signalsPerLaneWide =
+        multimem_staging_signals_per_lane_wide(static_cast<uint64_t>(nvlRanks));
+    if (signalsPerLaneWide > std::numeric_limits<uint32_t>::max()) {
+      return {.errorMessage = "transport geometry exceeds UINT32_MAX"};
+    }
+    const auto maxInternalSignals = static_cast<std::size_t>(
+        std::numeric_limits<int>::max() - config.userSignalCount);
+    const auto signalsPerLane = static_cast<std::size_t>(signalsPerLaneWide);
+    if (config.maxChannels > maxInternalSignals / signalsPerLane) {
+      return {.errorMessage = "signal count exceeds INT_MAX"};
+    }
+    const auto signalsPerPipelineLane = config.maxChannels * signalsPerLane;
+    if (config.pipelineDepth > maxInternalSignals / signalsPerPipelineLane) {
+      return {.errorMessage = "signal count exceeds INT_MAX"};
+    }
+    internalSignalCount =
+        static_cast<uint32_t>(config.pipelineDepth * signalsPerPipelineLane);
+  }
+
+  constexpr auto kSignalAlignment = detail::kMultimemSignalAlignment;
+  constexpr auto kSignalStateSize = detail::kMultimemSignalStateSize;
+  if (dataBufferSize >
+      std::numeric_limits<std::size_t>::max() - (kSignalAlignment - 1)) {
+    return {
+        .errorMessage = "combined data and signal allocation size overflows"};
+  }
+  const std::size_t signalRegionOffset =
+      ((dataBufferSize + kSignalAlignment - 1) / kSignalAlignment) *
+      kSignalAlignment;
+  const auto totalSignalCount =
+      static_cast<std::size_t>(config.userSignalCount) + internalSignalCount;
+  if (totalSignalCount >
+      std::numeric_limits<std::size_t>::max() / kSignalStateSize) {
+    return {
+        .errorMessage = "combined data and signal allocation size overflows"};
+  }
+  const std::size_t signalRegionBytes = totalSignalCount * kSignalStateSize;
+  if (signalRegionOffset >
+      std::numeric_limits<std::size_t>::max() - signalRegionBytes) {
+    return {
+        .errorMessage = "combined data and signal allocation size overflows"};
+  }
+
+  return {
+      .dataBufferSize = dataBufferSize,
+      .internalSignalCount = internalSignalCount,
+      .signalRegionOffset = signalRegionOffset,
+      .backingAllocationSize = signalRegionOffset + signalRegionBytes,
+  };
+}
+
+} // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlTransportConfig.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransportConfig.h
@@ -30,7 +30,7 @@ struct MultimemNvlTransportConfigParams {
 
   // Signal slots exposed through signal(), read_signal(), and
   // wait_signal_until(). This is orthogonal to staging geometry.
-  uint32_t userSignalCount{1};
+  uint32_t userSignalCount{0};
 };
 
 struct MultimemNvlTransportConfig {
@@ -48,7 +48,7 @@ struct MultimemNvlTransportConfig {
   std::size_t pipelineDepth{0};
   std::size_t maxChannels{0};
   std::size_t maxBlocks{0};
-  uint32_t userSignalCount{1};
+  uint32_t userSignalCount{0};
 
   bool operator==(const MultimemNvlTransportConfig&) const = default;
 };
@@ -60,6 +60,7 @@ constexpr MultimemNvlTransportConfig make_multimem_nvl_transport_config(
 
 struct MultimemNvlTransportConfigValidation {
   std::size_t dataBufferSize{0};
+  uint32_t signalsPerChannel{0};
   uint32_t internalSignalCount{0};
   std::size_t signalRegionOffset{0};
   std::size_t backingAllocationSize{0};
@@ -71,8 +72,8 @@ struct MultimemNvlTransportConfigValidation {
 };
 
 namespace detail {
-inline constexpr uint64_t kMultimemSignalsPerRank = 2;
-inline constexpr uint64_t kMultimemArrivalBarrierSignals = 4;
+inline constexpr uint64_t kMultimemSignalsPerPeer = 3;
+inline constexpr uint64_t kMultimemSignalsPerLane = 4;
 inline constexpr std::size_t kMultimemSignalAlignment = 128;
 inline constexpr std::size_t kMultimemSignalStateSize = 128;
 } // namespace detail
@@ -80,18 +81,11 @@ inline constexpr std::size_t kMultimemSignalStateSize = 128;
 #if defined(__CUDACC__) || defined(__HIPCC__)
 __host__ __device__
 #endif
-    constexpr uint64_t multimem_staging_signals_per_lane_wide(
-        uint64_t nvlRanks) {
-  return detail::kMultimemSignalsPerRank * nvlRanks +
-      detail::kMultimemArrivalBarrierSignals;
-}
-
-#if defined(__CUDACC__) || defined(__HIPCC__)
-__host__ __device__
-#endif
-    constexpr uint32_t multimem_staging_signals_per_lane(uint32_t nvlRanks) {
-  return static_cast<uint32_t>(
-      multimem_staging_signals_per_lane_wide(nvlRanks));
+    constexpr uint64_t multimem_staging_signals_per_channel(
+        uint64_t nvlRanks,
+        uint64_t pipelineDepth) {
+  return detail::kMultimemSignalsPerPeer * nvlRanks +
+      detail::kMultimemSignalsPerLane * pipelineDepth;
 }
 
 // Validate the complete topology-aware config and derive all allocation sizes.

--- a/comms/prims/transport/nvl/MultimemNvlTransportConfig.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransportConfig.h
@@ -1,0 +1,102 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#if defined(__CUDACC__)
+#include <cuda_runtime.h>
+#elif defined(__HIPCC__)
+#include <hip/hip_runtime.h>
+#endif
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+namespace comms::prims {
+
+struct MultimemNvlTransportConfigParams {
+  // Total data capacity is `perChannelSize * maxChannels`.
+  std::size_t perChannelSize{0};
+
+  // Staging pipeline depth. May be zero only when `maxBlocks` is also zero.
+  std::size_t pipelineDepth{0};
+
+  // Number of provisioned data channels.
+  std::size_t maxChannels{0};
+
+  // Maximum collective launch block count. Transport data and internal
+  // staging-signal capacity are provisioned independently by `maxChannels`.
+  std::size_t maxBlocks{0};
+
+  // Signal slots exposed through signal(), read_signal(), and
+  // wait_signal_until(). This is orthogonal to staging geometry.
+  uint32_t userSignalCount{1};
+};
+
+struct MultimemNvlTransportConfig {
+  constexpr MultimemNvlTransportConfig() = default;
+
+  explicit constexpr MultimemNvlTransportConfig(
+      MultimemNvlTransportConfigParams params)
+      : perChannelSize(params.perChannelSize),
+        pipelineDepth(params.pipelineDepth),
+        maxChannels(params.maxChannels),
+        maxBlocks(params.maxBlocks),
+        userSignalCount(params.userSignalCount) {}
+
+  std::size_t perChannelSize{0};
+  std::size_t pipelineDepth{0};
+  std::size_t maxChannels{0};
+  std::size_t maxBlocks{0};
+  uint32_t userSignalCount{1};
+
+  bool operator==(const MultimemNvlTransportConfig&) const = default;
+};
+
+constexpr MultimemNvlTransportConfig make_multimem_nvl_transport_config(
+    MultimemNvlTransportConfigParams params) {
+  return MultimemNvlTransportConfig{params};
+}
+
+struct MultimemNvlTransportConfigValidation {
+  std::size_t dataBufferSize{0};
+  uint32_t internalSignalCount{0};
+  std::size_t signalRegionOffset{0};
+  std::size_t backingAllocationSize{0};
+  std::string_view errorMessage{};
+
+  explicit operator bool() const {
+    return errorMessage.empty();
+  }
+};
+
+namespace detail {
+inline constexpr uint64_t kMultimemSignalsPerRank = 2;
+inline constexpr uint64_t kMultimemArrivalBarrierSignals = 4;
+inline constexpr std::size_t kMultimemSignalAlignment = 128;
+inline constexpr std::size_t kMultimemSignalStateSize = 128;
+} // namespace detail
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+__host__ __device__
+#endif
+    constexpr uint64_t multimem_staging_signals_per_lane_wide(
+        uint64_t nvlRanks) {
+  return detail::kMultimemSignalsPerRank * nvlRanks +
+      detail::kMultimemArrivalBarrierSignals;
+}
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+__host__ __device__
+#endif
+    constexpr uint32_t multimem_staging_signals_per_lane(uint32_t nvlRanks) {
+  return static_cast<uint32_t>(
+      multimem_staging_signals_per_lane_wide(nvlRanks));
+}
+
+// Validate the complete topology-aware config and derive all allocation sizes.
+MultimemNvlTransportConfigValidation validate_multimem_nvl_transport_config(
+    const MultimemNvlTransportConfig& config,
+    int nvlRanks);
+
+} // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -1,5 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
 #pragma once
 
 #include <cuda_runtime.h>
@@ -77,7 +78,7 @@ struct MultimemNvlTransportDevice {
   int nvlRanks{1};
   uint32_t pipelineDepth{0};
   uint32_t maxChannels{0};
-  uint32_t signalsPerLane{0};
+  uint32_t signalsPerChannel{0};
 
   __device__ __forceinline__ char* local_data_ptr(std::size_t offset) const {
     return localData + offset;

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -12,27 +12,9 @@
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/Timeout.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlTransportConfig.h"
 
 namespace comms::prims {
-
-// Per-lane internal-signal count for the staging pipeline: the single source of
-// truth shared by the host-side signal-region sizing (MultimemNvlTransport)
-// and the device-side `make_stage_layout` (MultimemNvlStageLayout.cuh) so the
-// region is sized identically on both sides. Layout per lane: `nvlRanks`
-// per-peer ready[]
-// + `nvlRanks` per-peer ack[] + 4 staging arrival-barrier slots (ready/ack
-// counter+epoch, laid out past the SET-mode slots so ADD residue never
-// contaminates a later SET-mode CMP_GE wait) => 2 * nvlRanks + 4.
-__host__ __device__ constexpr uint64_t multimem_staging_signals_per_lane_wide(
-    uint64_t nvlRanks) {
-  return 2 * nvlRanks + 4;
-}
-
-__host__ __device__ constexpr uint32_t multimem_staging_signals_per_lane(
-    uint32_t nvlRanks) {
-  return static_cast<uint32_t>(
-      multimem_staging_signals_per_lane_wide(nvlRanks));
-}
 
 namespace detail {
 


### PR DESCRIPTION
Summary:

Partition each logical staging channel into three channel-wide peer stripes and four aggregate-barrier slots per pipeline lane.
Derive the internal capacity as `B * (3R + 4P)`.
Default public signal capacity to zero and permit signal-free configurations to skip CUDA signal initialization.
Bump the multicast exchange protocol to version 5 so ranks cannot mix incompatible layouts.

Background:

Peer SET epochs are monotonic across a channel.
Aggregate ADD counters require lane-private storage to prevent arrivals from concurrent rounds from mixing.

Reviewed By: goelayu

Differential Revision: D115359930


