### PR TITLE
Add LLImpl pack/unpack over LLPacket geometry (#3554)

### DIFF
--- a/comms/prims/core/LLImpl.cuh
+++ b/comms/prims/core/LLImpl.cuh
@@ -1,0 +1,255 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/common/AtomicUtils.cuh"
+#include "comms/prims/core/DeviceMacros.cuh"
+#include "comms/prims/core/LlxPacket.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/core/Timeout.cuh"
+
+namespace comms::prims {
+
+// =============================================================================
+// LLImpl<P> — low-latency pack / unpack over LlxPacket geometry P
+// =============================================================================
+//
+// Cooperative, ThreadGroup-driven encode/decode of a byte range into/out of the
+// packet-formatted staging region:
+//
+//   pack:   user src   -> staging packets {data, flag=flagVal}
+//   unpack: staging packets (flag==flagVal) -> user dst
+//
+// Parallelism (v1): one thread owns one whole packet, grid-strided across the
+// group. `pack` writes each packet's trailing flag last; on the wire the whole
+// staging region is fenced and RDMA-put as one unit, so the flag is never
+// observed before its data. `unpack` spins only on the packets a thread owns
+// (no group-wide readiness barrier), then decodes.
+template <typename P>
+struct LLImpl {
+  using FlagType = typename P::FlagType;
+
+  // Spins between timeout clock reads. A power-of-two minus one so the check
+  // is a mask, not a modulo.
+  static constexpr uint32_t kTimeoutPollMask = 1023;
+
+  // Replicate the (32-bit) flagVal across a 64-bit flag word, so an 8 B flag
+  // can be written/compared as one wide transfer.
+  __device__ __forceinline__ static uint64_t replicated(FlagType flagVal) {
+    return (static_cast<uint64_t>(flagVal) << 32) |
+        static_cast<uint64_t>(flagVal);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Flag I/O — vectorized volatile access to the packet's trailing flag.
+  //
+  // The flag occupies the last `P::kFlag` bytes of the packet, entirely inside
+  // `P::kFlagLane`'s 16 B slot, so it is read/written as ONE wide volatile
+  // transfer (a u32 for the 4 B flag) instead of the old per-word
+  // (`P::kFlagWords`) scalar loop. `flagVal` is
+  // replicated across the full flag width, so a torn transfer where only part
+  // of the flag carries the new flagVal fails `is_flag_set` — unpack never
+  // accepts half-arrived data.
+  //
+  // These are single-lane primitives: only `P::kFlagLane` touches the flag.
+  // Sharing that lane's readiness across the packet's `P::kThreadsPerPacket`
+  // lanes (the warp reduction) is the ops layer's job and lives in unpack.
+  // ---------------------------------------------------------------------------
+
+  /// Volatile-store the trailing flag as one wide transfer, replicating
+  /// `flagVal` across the full flag width.
+  __device__ __forceinline__ static void store_flag(
+      void* pkt,
+      FlagType flagVal) {
+#ifdef __CUDA_ARCH__
+    void* fp = P::flag_ptr(pkt);
+    if constexpr (P::kFlag == static_cast<int>(sizeof(uint32_t))) {
+      comms::device::st_volatile_global(
+          reinterpret_cast<volatile uint32_t*>(fp), flagVal);
+    } else if constexpr (P::kFlag == static_cast<int>(sizeof(uint64_t))) {
+      comms::device::st_volatile_global(
+          reinterpret_cast<volatile uint64_t*>(fp), replicated(flagVal));
+    } else {
+      auto* p = reinterpret_cast<volatile FlagType*>(fp);
+#pragma unroll
+      for (int i = 0; i < P::kFlagWords; ++i) {
+        comms::device::st_volatile_global(p + i, flagVal);
+      }
+    }
+#else
+    (void)pkt;
+    (void)flagVal;
+#endif
+  }
+
+  /// Volatile-load the trailing flag (first word).
+  __device__ __forceinline__ static FlagType load_flag(const void* pkt) {
+#ifdef __CUDA_ARCH__
+    const auto* p =
+        reinterpret_cast<const volatile FlagType*>(P::flag_ptr(pkt));
+    return comms::device::ld_volatile_global(p);
+#else
+    (void)pkt;
+    return 0;
+#endif
+  }
+
+  /// True if the whole flag equals `flagVal`, read as one wide volatile load.
+  __device__ __forceinline__ static bool is_flag_set(
+      const void* pkt,
+      FlagType flagVal) {
+#ifdef __CUDA_ARCH__
+    const void* fp = P::flag_ptr(pkt);
+    if constexpr (P::kFlag == static_cast<int>(sizeof(uint32_t))) {
+      return comms::device::ld_volatile_global(
+                 reinterpret_cast<const volatile uint32_t*>(fp)) == flagVal;
+    } else if constexpr (P::kFlag == static_cast<int>(sizeof(uint64_t))) {
+      return comms::device::ld_volatile_global(
+                 reinterpret_cast<const volatile uint64_t*>(fp)) ==
+          replicated(flagVal);
+    } else {
+      const auto* p = reinterpret_cast<const volatile FlagType*>(fp);
+#pragma unroll
+      for (int i = 0; i < P::kFlagWords; ++i) {
+        if (comms::device::ld_volatile_global(p + i) != flagVal) {
+          return false;
+        }
+      }
+      return true;
+    }
+#else
+    (void)pkt;
+    (void)flagVal;
+    return true;
+#endif
+  }
+
+  /// Encode `nbytes` of `src` into consecutive packets in `staging`, stamping
+  /// every packet's trailing flag with `flagVal`. Cooperative across `group`.
+  template <typename Group>
+  __device__ __forceinline__ static void pack(
+      Group& group,
+      void* staging,
+      const void* src,
+      std::size_t nbytes,
+      FlagType flagVal) {
+#ifdef __CUDA_ARCH__
+    const std::size_t nPackets = P::packet_count(nbytes);
+    auto* base = reinterpret_cast<char*>(staging);
+    const auto* s = reinterpret_cast<const char*>(src);
+    for (std::size_t i = group.thread_id_in_group; i < nPackets;
+         i += group.group_size) {
+      char* pkt = base + i * static_cast<std::size_t>(P::kPacketBytes);
+      const std::size_t valid = P::valid_payload(i, nbytes);
+      const std::size_t off = i * static_cast<std::size_t>(P::kData);
+      // Payload bytes, zero-padding the packet's data-region tail.
+      for (int b = 0; b < P::kData; ++b) {
+        pkt[b] = static_cast<std::size_t>(b) < valid ? s[off + b] : char(0);
+      }
+      // Flag last (see class note on wire-side ordering).
+      store_flag(pkt, flagVal);
+    }
+    group.sync();
+#else
+    (void)group;
+    (void)staging;
+    (void)src;
+    (void)nbytes;
+    (void)flagVal;
+#endif
+  }
+
+  /// Wait until every packet covering `nbytes` carries flag == `flagVal`, then
+  /// decode its payload into `dst`. Cooperative across `group`; each thread
+  /// spins only on the packets it owns.
+  // `timeout` bounds the readiness spin. Unlike Simple, LL's readiness lives in
+  // the payload, so the wait happens HERE rather than in wait_signal -- without
+  // a deadline a lost WQE, a dead peer, or a flagVal desync spins forever and
+  // then holds the whole group at the group.sync() below. Each thread polls
+  // only the packets it owns, so the check is per-thread (checkExpired()) and
+  // not the leader-only group form. The clock is read once per
+  // kTimeoutPollMask+1 spins: LL is the latency path, and a clock64() on every
+  // poll is a measurable cost on a hot loop.
+  template <typename Group>
+  __device__ __forceinline__ static void unpack(
+      Group& group,
+      void* dst,
+      const void* staging,
+      std::size_t nbytes,
+      FlagType flagVal,
+      const Timeout& timeout = Timeout()) {
+#ifdef __CUDA_ARCH__
+    const std::size_t nPackets = P::packet_count(nbytes);
+    const auto* base = reinterpret_cast<const char*>(staging);
+    auto* d = reinterpret_cast<char*>(dst);
+    for (std::size_t i = group.thread_id_in_group; i < nPackets;
+         i += group.group_size) {
+      const char* pkt = base + i * static_cast<std::size_t>(P::kPacketBytes);
+      const std::size_t valid = P::valid_payload(i, nbytes);
+      const std::size_t off = i * static_cast<std::size_t>(P::kData);
+
+      if constexpr (P::kPacketBytes == static_cast<int>(sizeof(uint64_t))) {
+        // 8 B packet: {data:4, flag:4} in one 8 B atomic word. Fuse the poll
+        // and the data read -- one wide volatile load yields both.
+        const auto* p = reinterpret_cast<const volatile uint64_t*>(pkt);
+        uint64_t v;
+        uint32_t spins = 0;
+        do {
+          v = comms::device::ld_volatile_global(p);
+          if (((++spins & kTimeoutPollMask) == 0) && timeout.checkExpired()) {
+            PIPES_DEVICE_TRAP();
+          }
+        } while (static_cast<FlagType>(v >> 32) !=
+                 flagVal); // high half is the flag
+        const auto data = static_cast<uint32_t>(v); // low half is the payload
+        const auto* db = reinterpret_cast<const char*>(&data);
+#pragma unroll
+        for (int b = 0; b < P::kData; ++b) {
+          if (static_cast<std::size_t>(b) < valid) {
+            d[off + b] = db[b];
+          }
+        }
+      } else {
+        // Large packet: poll the trailing flag, then read the payload with
+        // vectorized volatile (L1-bypassing) loads.
+        uint32_t spins = 0;
+        while (!is_flag_set(pkt, flagVal)) {
+          // Spin until this packet's flag reaches the current flagVal.
+          if (((++spins & kTimeoutPollMask) == 0) && timeout.checkExpired()) {
+            PIPES_DEVICE_TRAP();
+          }
+        }
+        constexpr int kDataWords =
+            P::kData / static_cast<int>(sizeof(uint64_t));
+        const auto* sp = reinterpret_cast<const volatile uint64_t*>(pkt);
+#pragma unroll
+        for (int w = 0; w < kDataWords; ++w) {
+          const uint64_t word = comms::device::ld_volatile_global(sp + w);
+          const auto* wb = reinterpret_cast<const char*>(&word);
+#pragma unroll
+          for (int b = 0; b < static_cast<int>(sizeof(uint64_t)); ++b) {
+            const std::size_t gb =
+                static_cast<std::size_t>(w) * sizeof(uint64_t) +
+                static_cast<std::size_t>(b);
+            if (gb < valid) {
+              d[off + gb] = wb[b];
+            }
+          }
+        }
+      }
+    }
+    group.sync();
+#else
+    (void)group;
+    (void)dst;
+    (void)staging;
+    (void)nbytes;
+    (void)flagVal;
+#endif
+  }
+};
+
+} // namespace comms::prims

--- a/comms/prims/tests/LLImplTest.cc
+++ b/comms/prims/tests/LLImplTest.cc
@@ -1,0 +1,106 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "comms/prims/core/LlxPacket.cuh"
+#include "comms/prims/tests/LLImplTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::prims {
+
+namespace {
+
+using LaunchFn = void (*)(const char*, char*, char*, std::size_t, uint32_t*);
+
+// Drive one pack->unpack round-trip on device for geometry P and verify the
+// payload comes back byte-identical.
+template <typename P>
+void roundTrip(LaunchFn launch, std::size_t nbytes) {
+  const std::size_t wire = P::wire_bytes(nbytes);
+
+  std::vector<char> h_src(nbytes);
+  for (std::size_t i = 0; i < nbytes; ++i) {
+    h_src[i] = static_cast<char>(i * 131u + 7u);
+  }
+
+  DeviceBuffer src(nbytes);
+  DeviceBuffer staging(wire);
+  DeviceBuffer dst(nbytes);
+  DeviceBuffer errBuf(sizeof(uint32_t));
+  auto* err_d = static_cast<uint32_t*>(errBuf.get());
+
+  CUDACHECK_TEST(
+      cudaMemcpy(src.get(), h_src.data(), nbytes, cudaMemcpyHostToDevice));
+  // Poison staging so a missed flag/decode surfaces as a mismatch.
+  CUDACHECK_TEST(cudaMemset(staging.get(), 0xEE, wire));
+  CUDACHECK_TEST(cudaMemset(dst.get(), 0, nbytes));
+  CUDACHECK_TEST(cudaMemset(err_d, 0, sizeof(uint32_t)));
+
+  launch(
+      static_cast<const char*>(src.get()),
+      static_cast<char*>(staging.get()),
+      static_cast<char*>(dst.get()),
+      nbytes,
+      err_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  uint32_t err_h = 0;
+  CUDACHECK_TEST(
+      cudaMemcpy(&err_h, err_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(err_h, 0u) << "payload round-trip mismatch at nbytes=" << nbytes;
+
+  std::vector<char> h_dst(nbytes);
+  CUDACHECK_TEST(
+      cudaMemcpy(h_dst.data(), dst.get(), nbytes, cudaMemcpyDeviceToHost));
+  EXPECT_EQ(h_dst, h_src) << "decoded payload differs at nbytes=" << nbytes;
+}
+
+} // namespace
+
+class LLImplTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+  void TearDown() override {
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+  }
+};
+
+TEST_F(LLImplTest, LlRoundTrip) {
+  // Exact multiples and partial final packet (kData = 4).
+  for (std::size_t n :
+       {std::size_t(4),
+        std::size_t(7),
+        std::size_t(64),
+        std::size_t(1000),
+        std::size_t(4096)}) {
+    roundTrip<LlxPacketGeometry>(test::test_ll_pack_unpack, n);
+  }
+}
+
+TEST_F(LLImplTest, FlagRoundTrip) {
+  DeviceBuffer p8(LlxPacketGeometry::kPacketBytes);
+  CUDACHECK_TEST(cudaMemset(p8.get(), 0, LlxPacketGeometry::kPacketBytes));
+
+  DeviceBuffer errBuf(sizeof(uint32_t));
+  auto* err_d = static_cast<uint32_t*>(errBuf.get());
+  CUDACHECK_TEST(cudaMemset(err_d, 0, sizeof(uint32_t)));
+
+  test::test_ll_flag_roundtrip(p8.get(), err_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  uint32_t err_h = 0;
+  CUDACHECK_TEST(
+      cudaMemcpy(&err_h, err_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(err_h, 0u) << "store_flag/load_flag/is_flag_set round-trip wrong";
+}
+
+} // namespace comms::prims

--- a/comms/prims/tests/LLImplTest.cu
+++ b/comms/prims/tests/LLImplTest.cu
@@ -1,0 +1,97 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/prims/core/LLImpl.cuh"
+#include "comms/prims/core/LlxPacket.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/tests/Checks.h"
+
+namespace comms::prims::test {
+
+// A single block packs then unpacks the same staging region and verifies the
+// payload round-trips. pack/unpack use the same grid-stride mapping, so a
+// thread reads back the packets it wrote; block syncs order the phases.
+template <typename P>
+__global__ void pack_unpack_kernel(
+    const char* src,
+    char* staging,
+    char* dst,
+    std::size_t nbytes,
+    uint32_t* errorCount) {
+  ThreadGroup g{
+      threadIdx.x,
+      blockDim.x,
+      blockIdx.x,
+      blockIdx.x,
+      gridDim.x,
+      SyncScope::BLOCK};
+
+  const typename P::FlagType flagVal = static_cast<typename P::FlagType>(7);
+
+  LLImpl<P>::pack(g, staging, src, nbytes, flagVal);
+  g.sync();
+  LLImpl<P>::unpack(g, dst, staging, nbytes, flagVal);
+  g.sync();
+
+  for (std::size_t i = threadIdx.x; i < nbytes; i += blockDim.x) {
+    if (dst[i] != src[i]) {
+      atomicAdd(errorCount, 1u);
+    }
+  }
+}
+
+void test_ll_pack_unpack(
+    const char* src_d,
+    char* staging_d,
+    char* dst_d,
+    std::size_t nbytes,
+    uint32_t* errorCount_d) {
+  pack_unpack_kernel<LlxPacketGeometry>
+      <<<1, 256>>>(src_d, staging_d, dst_d, nbytes, errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// LLImpl::store_flag/load_flag/is_flag_set round-trip over a single global
+// packet. `pkt` is GLOBAL memory -> flag I/O uses global volatile ops.
+template <typename P>
+__device__ void check_flag(void* pkt, uint32_t* errorCount) {
+  for (typename P::FlagType g :
+       {typename P::FlagType(1),
+        typename P::FlagType(42),
+        static_cast<typename P::FlagType>(0xABCDu)}) {
+    LLImpl<P>::store_flag(pkt, g);
+    if (LLImpl<P>::load_flag(pkt) != g) {
+      atomicAdd(errorCount, 1);
+    }
+    // All flag words should be replicated.
+    const auto* flagWords = P::flag_ptr(pkt);
+    for (int i = 0; i < P::kFlagWords; ++i) {
+      if (flagWords[i] != g) {
+        atomicAdd(errorCount, 1);
+      }
+    }
+    // is_flag_set should agree.
+    if (!LLImpl<P>::is_flag_set(pkt, g)) {
+      atomicAdd(errorCount, 1);
+    }
+    if (LLImpl<P>::is_flag_set(pkt, g + 1)) {
+      atomicAdd(errorCount, 1);
+    }
+  }
+}
+
+__global__ void test_ll_flag_roundtrip_kernel(void* p8, uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    check_flag<LlxPacketGeometry>(p8, errorCount);
+  }
+}
+
+void test_ll_flag_roundtrip(void* p8_d, uint32_t* errorCount_d) {
+  test_ll_flag_roundtrip_kernel<<<1, 1>>>(p8_d, errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/LLImplTest.cuh
+++ b/comms/prims/tests/LLImplTest.cuh
@@ -1,0 +1,24 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace comms::prims::test {
+
+/// Pack `nbytes` of `src_d` into `staging_d` then unpack into `dst_d`, using
+/// LlxPacketGeometry (8 B packets). `errorCount_d` counts payload mismatches.
+void test_ll_pack_unpack(
+    const char* src_d,
+    char* staging_d,
+    char* dst_d,
+    std::size_t nbytes,
+    uint32_t* errorCount_d);
+
+/// Device-side: LLImpl::store_flag/load_flag/is_flag_set round-trip for both
+/// tiers. `p8_d` are global device buffers (>= 128 B / 8 B); flag
+/// I/O uses global volatile ops, which are illegal on shared memory.
+void test_ll_flag_roundtrip(void* p8_d, uint32_t* errorCount_d);
+
+} // namespace comms::prims::test


### PR DESCRIPTION
Summary:

Second llx building block: `LLImpl<P>`, the ThreadGroup-driven encode/decode of
a byte range into/out of an `LLPacket`-formatted staging region.

- `pack(group, staging, src, nbytes, flagVal)`: encode the payload into
  consecutive packets, stamping each packet's trailing flag with `flagVal`.
- `unpack(group, dst, staging, nbytes, flagVal)`: spin until each owned
  packet's flag == `flagVal`, then decode the payload out.
- Flag I/O (`store_flag` / `load_flag` / `is_flag_set`): the flag sits entirely
  inside `P::kFlagLane`'s 16 B slot, so it is read/written as ONE wide volatile
  transfer instead of a per-word scalar loop. `flagVal` is replicated across the
  full flag width, so a torn transfer that carries the new value in only part of
  the flag fails `is_flag_set` — `unpack` never accepts half-arrived data.

Parallelism (v1): one thread owns one whole packet, grid-strided across the
group. `pack` writes each packet's trailing flag last; on the wire the whole
staging region is fenced and RDMA-put as one unit, so the flag is never observed
before its data. `unpack` spins only on the packets a thread owns (no
group-wide readiness barrier), then decodes.

Additive only: new header `comms/prims/core/LLImpl.cuh` behind a new
`//comms/prims:ll_impl` target, plus `//comms/prims/tests:ll_impl_test` and its
`:ll_impl_test_kernels` companion. No existing code path is modified.

Reviewed By: snarayankh

Differential Revision: D110940544


