### PR TITLE
Migrate CTRAN IPC regcache logs (#3555)

### DIFF
--- a/comms/ctran/backends/nvl/CtranNvl.cc
+++ b/comms/ctran/backends/nvl/CtranNvl.cc
@@ -6,9 +6,9 @@
 #include "comms/ctran/backends/nvl/CtranNvl.h"
 #include "comms/ctran/backends/nvl/CtranNvlImpl.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/utils/StrUtils.h"
-#include "comms/utils/logger/LogUtils.h"
 
 CtranNvl::CtranNvl(CtranComm* comm) {
   const auto statex = comm->statex_.get();
@@ -43,7 +43,7 @@ CtranNvl::CtranNvl(CtranComm* comm) {
         bool p2pAccess = comm->statex_->isSameDeviceRack(
             comm->logMetaData_.rank, statex->localRankToRank(i));
         if (!p2pAccess) {
-          CLOGF_SUBSYS(
+          CTRAN_LOG_SUBSYS(
               INFO,
               INIT,
               "NCCL_MNNVL_TRUNK_DISABLE set to True. P2P disabled between rank1: {} rank2: {} because rackserial mismatch",
@@ -75,7 +75,7 @@ CtranNvl::CtranNvl(CtranComm* comm) {
         supportedInraHostRanksStr.push_back(
             std::to_string(statex->localRankToRank(i)));
       } else {
-        CLOGF_SUBSYS(
+        CTRAN_LOG_SUBSYS(
             INFO,
             INIT,
             "CTRAN-NVL: Rank {} (local rank {} GPU {}) cannot access peer {} (local rank {} GPU {}), disable NVL support",
@@ -89,7 +89,7 @@ CtranNvl::CtranNvl(CtranComm* comm) {
     }
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-NVL: Initialized NVL backend on rank {} localRank {}, "
@@ -109,7 +109,7 @@ CtranNvl::CtranNvl(CtranComm* comm) {
 }
 
 CtranNvl::~CtranNvl() {
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       INIT,
       "CTRAN-NVL: Destroyed NVL backend on rank {} localRank {}",
       this->pimpl_->comm->statex_->rank(),

--- a/comms/ctran/backends/socket/CtranSocket.cc
+++ b/comms/ctran/backends/socket/CtranSocket.cc
@@ -7,12 +7,12 @@
 #include <vector>
 #include "comms/ctran/backends/socket/CtranSocketBase.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/ctran/utils/ExtUtils.h"
 #include "comms/utils/StrUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 
 CtranSocket::CtranSocket(CtranComm* comm)
     : comm(comm),
@@ -21,7 +21,7 @@ CtranSocket::CtranSocket(CtranComm* comm)
       commHash_(comm->statex_->commHash()),
       commDesc_(comm->statex_->commDesc()) {
   init(SocketServerAddr());
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-SOCKET: Initialized {} from comm {}",
@@ -41,7 +41,7 @@ CtranSocket::CtranSocket(
       commHash_(commHash),
       commDesc_(commDesc) {
   init(serverAddr);
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-SOCKET: Initialized {} from rank {} cudaDev {} commHash {:x} commDesc {}",
@@ -65,7 +65,7 @@ CtranSocket::~CtranSocket(void) {
     }
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-SOCKET: destroyed SOCKET backend {} for commHash {:x} commDesc {}",
@@ -100,7 +100,7 @@ commResult_t CtranSocket::preConnect(const std::unordered_set<int>& peerRanks) {
   }
 
   if (newConnection) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-SOCKET: Rank-{} Pre-connected peers: [{}]",
@@ -136,7 +136,7 @@ void CtranSocket::init(const SocketServerAddr& serverAddr) {
       throw ctran::utils::Exception(
           msg, commSystemError, rank_, commHash_, commDesc_);
     } else {
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           INIT,
           "CTRAN-SOCKET: socket address set to {} on interface {}",
@@ -148,7 +148,7 @@ void CtranSocket::init(const SocketServerAddr& serverAddr) {
     FB_SYSCHECKTHROW_EX(
         listenSocket_.bindAndListen(ifAddrSockAddr, resolvedIfName),
         ncclLogData_);
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-IB: Rank {} created listen socket based on a self-finding address {}",
@@ -175,7 +175,7 @@ void CtranSocket::init(const SocketServerAddr& serverAddr) {
     // use provided addr(i.e. ip, port, host) to initialize ctranSocket
     auto serverAddrSockAddr = toSocketAddress(serverAddr);
     listenSocket_.bindAndListen(serverAddrSockAddr, serverAddr.ifName);
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-SOCKET: Rank {} created listen socket based on provided address {} "
@@ -185,7 +185,7 @@ void CtranSocket::init(const SocketServerAddr& serverAddr) {
         serverAddr.ifName);
   }
   listenThread_ = std::thread{[this]() { bootstrapAccept(); }};
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-SOCKET: created SOCKET backend {} for commHash {} commDesc {}",
@@ -213,7 +213,7 @@ void CtranSocket::bootstrapAccept() {
         std::move(maybeSocket.value()));
     FB_SYSCHECKTHROW_EX(socket->recv(&peerRank, sizeof(int)), ncclLogData_);
 
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-SOCKET: Established connection: commHash {:x}, commDesc {}, "
@@ -230,7 +230,7 @@ void CtranSocket::bootstrapAccept() {
         updateSocket(std::move(socket), peerRank), comm->logMetaData_);
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-SOCKET: Listen thread terminating for commHash {:x}, commDesc {}, rank {}",
@@ -277,7 +277,7 @@ commResult_t CtranSocket::bootstrapConnect(
     goto exit;
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-SOCKET: Established connection: commHash {:x}, commDesc {}, pimpl {}, "
@@ -334,7 +334,7 @@ bool CtranSocket::addToPendingOpsIfRequired(
     if (!sock || it != locked->end()) {
       auto pendingOp = std::make_unique<SockPendingOp>(
           opType, const_cast<ControlMsg&>(msg), peerRank, req);
-      CLOGF_TRACE(
+      CTRAN_LOG_TRACE(
           COLL,
           "Enqueue pendingOp {} [{}], peer {}",
           opType,
@@ -393,7 +393,7 @@ commResult_t CtranSocket::progressPendingOps(void) {
     ctran::bootstrap::Socket* sock = getSocket(peerRank);
     for (auto& op : pendingOps) {
       if (op->type == SockPendingOp::OpType::ISEND_CTRL) {
-        CLOGF_TRACE(
+        CTRAN_LOG_TRACE(
             COLL, "CTRAN-SOCKET: socket {} send to {}", (void*)sock, peerRank);
         FB_SYSCHECKRETURN(
             sock->send((void*)&op->msg, sizeof(ControlMsg)), commInternalError);
@@ -435,7 +435,7 @@ commResult_t CtranSocket::progressInternal() {
           strerror(errno));
       return commInternalError;
     } else if (count > 0) {
-      CLOGF_TRACE(COLL, "CTRAN-SOCKET: polling returns {} events", count);
+      CTRAN_LOG_TRACE(COLL, "CTRAN-SOCKET: polling returns {} events", count);
       // there's a socket which receives data, let's continue
       continueWhileLoop = true;
     } else {
@@ -460,7 +460,7 @@ commResult_t CtranSocket::progressInternal() {
         }
         if (recvQueue.postedOps_.empty()) {
           // no posted op, let's read it and store as unexpected msg
-          CLOGF_TRACE(
+          CTRAN_LOG_TRACE(
               COLL,
               "CTRAN-SOCKET: Received ctrl-msg {} from peer {}, size {}, add to unexpected msg queue",
               msg->toString(),
@@ -471,7 +471,7 @@ commResult_t CtranSocket::progressInternal() {
           auto op = dequeFront(recvQueue.postedOps_);
           op->msg = *msg;
           op->req.complete();
-          CLOGF_TRACE(
+          CTRAN_LOG_TRACE(
               COLL,
               "CTRAN-SOCKET: Received ctrl-msg {} from peer {}, size {}, complete a posted recv",
               op->msg.toString(),
@@ -509,7 +509,7 @@ commResult_t CtranSocket::isendCtrlMsgImpl(
     sock = getSocket(peerRank);
   }
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-SOCKET: isendCtrlMsgImpl to {} socket: {}",
       peerRank,
@@ -517,7 +517,7 @@ commResult_t CtranSocket::isendCtrlMsgImpl(
 
   if (!addToPendingOpsIfRequired(
           msg, peerRank, req, SockPendingOp::OpType::ISEND_CTRL, sock)) {
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL, "CTRAN-SOCKET: socket {} send to {}", (void*)sock, peerRank);
     FB_SYSCHECKRETURN(
         sock->send((void*)&msg, sizeof(ControlMsg)), commInternalError);
@@ -545,7 +545,7 @@ commResult_t CtranSocket::irecvCtrlMsgImpl(
     sock = getSocket(peerRank);
   }
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-SOCKET: irecvCtrlMsgImpl from {} socket: {}",
       peerRank,
@@ -567,14 +567,14 @@ int CtranSocket::doRecvMsg(
     ControlMsg* msg) {
   int bytes_read = socket->recvAsync((void*)msg, sizeof(ControlMsg));
   if (bytes_read < 0) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         ERR,
         COLL,
         "CTRAN-SOCKET: peer {} socket recvAsync failure, errno {}",
         peerRank,
         strerror(errno));
   } else if (bytes_read == 0) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         WARN,
         COLL,
         "CTRAN-SOCKET: peer {} closed connection, remove socket",
@@ -595,7 +595,7 @@ commResult_t CtranSocket::postRecvOp(
     auto unexpMsg = dequeFront(recvQueue.unexpMsgs_);
     recvop->msg = *unexpMsg;
     FB_COMMCHECK(recvop->req.complete());
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-SOCKET: Received ctrl-msg {} from peer {}, complete a posted recv",
         recvop->msg.toString(),

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -6,10 +6,10 @@
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.h"
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/utils/StrUtils.h"
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/LogUtils.h"
 #include "folly/SocketAddress.h"
 #include "folly/synchronization/CallOnce.h"
 
@@ -54,7 +54,7 @@ commResult_t mapBootstrapSocketError(
     uint64_t commHash,
     const std::string& commDesc) {
   if (isPeerDisconnectErrno(err)) {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-TCPDM: bootstrap {} failed with peer {} on rank {} commHash {:x} commDesc {} errno={} (treating as remote error)",
         op,
@@ -95,7 +95,7 @@ void CtranTcpDm::bootstrapPrepare(meta::comms::IBootstrap* bootstrap) {
 
   std::string line =
       ::comms::tcp_devmem::addrToString(&dev->addr, 0, dev->name.c_str());
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-TCPDM: Rank {} created listen socket based on a self-finding address {} for cuda device {}",
@@ -127,7 +127,7 @@ void CtranTcpDm::bootstrapPrepare(meta::comms::IBootstrap* bootstrap) {
 
     std::string line = ::comms::tcp_devmem::addrToString(
         &sin->sin6_addr, sin->sin6_port, nullptr);
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO, INIT, "CTRAN-TCPDM: Rank {} bootstrap address {}", i, line);
   }
 
@@ -179,7 +179,7 @@ void CtranTcpDm::bootstrapAccept() {
 
     bootstrapAddRecvPeer(peerRank, recvComm);
 
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-TCPDM: Established data connection: commHash {:x}, "
@@ -190,7 +190,7 @@ void CtranTcpDm::bootstrapAccept() {
         peerRank);
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-TCPDM: Accept thread terminating for commHash {:x}, commDesc {}, rank {}",
@@ -243,7 +243,7 @@ commResult_t CtranTcpDm::bootstrapConnect(
 
   bootstrapAddSendPeer(peerRank, sendComm);
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-TCPDM: Established data connection: commHash {:x}, "
@@ -278,7 +278,7 @@ CtranTcpDm::CtranTcpDm(CtranComm* comm, ctran::Profiler* profiler) {
 
   registerProfilerHooks(profiler);
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-TCPDM: created TCPDM backend {} for commHash {:x} commDesc {}",
@@ -294,7 +294,7 @@ CtranTcpDm::~CtranTcpDm() {
   const uint32_t closeFlags = comm_ != nullptr && comm_->testAbort()
       ? ::comms::tcp_devmem::kCloseFlagForce
       : 0;
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-TCPDM: destroying backend {} commHash {:x} commDesc {} aborted {} closeFlags {:#x}",
@@ -347,7 +347,7 @@ void CtranTcpDm::closeComms(const char* reason, uint32_t closeFlags) {
 
   const bool forceClose = closeFlags & ::comms::tcp_devmem::kCloseFlagForce;
   if (forceClose) {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-TCPDM: closing backend {} rank {} commHash {:x} commDesc {} reason {} flags {:#x} sendComms {} recvComms {} queuedRecvs {} cancelledQueuedRecvs {} pendingRecvNotifies {} cancelledPendingRecvNotifies {}",
         (void*)this,
@@ -363,7 +363,7 @@ void CtranTcpDm::closeComms(const char* reason, uint32_t closeFlags) {
         pendingRecvNotifyCount,
         cancelledPendingRecvNotifyCount);
   } else {
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-TCPDM: closing backend {} rank {} commHash {:x} commDesc {} reason {} flags {:#x} sendComms {} recvComms {} queuedRecvs {} cancelledQueuedRecvs {} pendingRecvNotifies {} cancelledPendingRecvNotifies {}",
         (void*)this,
@@ -384,7 +384,7 @@ void CtranTcpDm::closeComms(const char* reason, uint32_t closeFlags) {
   for (auto& [peerRank, comm] : sendComms) {
     auto status = transport->closeSend(comm, closeFlags);
     if (status != ::comms::tcp_devmem::Status::Ok) {
-      CLOGF(
+      CTRAN_LOG(
           WARN,
           "CTRAN-TCPDM: closeSend failed for peer {} on rank {} commHash {:x} commDesc {} reason {} flags {:#x} status {}",
           peerRank,
@@ -400,7 +400,7 @@ void CtranTcpDm::closeComms(const char* reason, uint32_t closeFlags) {
   for (auto& [peerRank, comm] : recvComms) {
     auto status = transport->closeRecv(comm, closeFlags);
     if (status != ::comms::tcp_devmem::Status::Ok) {
-      CLOGF(
+      CTRAN_LOG(
           WARN,
           "CTRAN-TCPDM: closeRecv failed for peer {} on rank {} commHash {:x} commDesc {} reason {} flags {:#x} status {}",
           peerRank,
@@ -416,7 +416,7 @@ void CtranTcpDm::closeComms(const char* reason, uint32_t closeFlags) {
 
 void CtranTcpDm::abortOutstanding(const char* reason) {
   if (aborted_.exchange(true)) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-TCPDM: backend {} already aborted for rank {} commHash {:x} commDesc {} reason {}",
@@ -853,7 +853,7 @@ void CtranTcpDm::recvNotifyProgress() {
       try {
         complete = pending.front()->isComplete();
       } catch (const std::exception& e) {
-        CLOGF(
+        CTRAN_LOG(
             WARN,
             "CTRAN-TCPDM: counted recv notify failed for peer {} rank {} commHash {:x} commDesc {} error {}",
             peerRank,

--- a/comms/ctran/memory/SlabAllocator.cc
+++ b/comms/ctran/memory/SlabAllocator.cc
@@ -5,6 +5,7 @@
 #include "comms/ctran/memory/Utils.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/utils/DevUtils.cuh"
 
@@ -83,7 +84,7 @@ commResult_t SlabAllocator::allocateMem(
     if (newSlabSize != nullptr) {
       *newSlabSize = slabSize;
     }
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         ALLOC,
         "{}: allocate a slab with size {} (granularity_={}), freeSize_={}",

--- a/comms/ctran/memory/Utils.cc
+++ b/comms/ctran/memory/Utils.cc
@@ -2,13 +2,13 @@
 
 #include "comms/ctran/memory/Utils.h"
 
-#include <folly/Format.h>
 #include <sstream>
 
 #include "comms/ctran/memory/SlabAllocator.h"
 #include "comms/ctran/memory/memCacheAllocator.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaWrap.h"
 
 namespace ncclx::memory {
@@ -74,10 +74,9 @@ commResult_t allocateShareableBuffer(
     }
   }
 
-  // TODO: refactor this to CLOGF_SUBSYS once it supports oneof multiple masks
-  CLOGF_IF(
+  CTRAN_LOG_SUBSYS(
       INFO,
-      CLOGF_ENABLED(ALLOC) || CLOGF_ENABLED(P2P),
+      ALLOC | P2P,
       "commHash: {:x} Allocated shareable buffer {} size {} ipcDesc {} for {}",
       commHash,
       *ptr,

--- a/comms/ctran/memory/memCacheAllocator.cc
+++ b/comms/ctran/memory/memCacheAllocator.cc
@@ -4,10 +4,12 @@
 
 #include <fmt/format.h>
 #include <folly/Singleton.h>
+#include <cstdint>
 
 #include "comms/ctran/memory/Utils.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/DevUtils.cuh"
 
 #include "comms/utils/commSpecs.h"
@@ -20,7 +22,7 @@ static folly::Singleton<memCacheAllocator> memCacheAllocatorSingleton;
 std::shared_ptr<memCacheAllocator> memCacheAllocator::getInstance() {
   ctran::utils::commCudaLibraryInit();
   if (!ctran::utils::getCuMemSysSupported()) {
-    CLOGF(
+    CTRAN_LOG(
         ERR,
         "NCCLX memory cache allocator only works with low-level cuMem APIs. Make sure CUDA Toolkit is 11.3 or higher.");
     return nullptr;
@@ -51,17 +53,27 @@ commResult_t memCacheAllocator::init() {
           nullptr,
           &poolHandle_,
           &newSlabSize));
-      CLOGF_SUBSYS(
+#if defined(__HIP_PLATFORM_AMD__)
+      const auto getPoolHandleForLog = [this] {
+        return reinterpret_cast<std::uintptr_t>(
+            ctran::utils::toFormattableHandle(poolHandle_));
+      };
+#else
+      const auto getPoolHandleForLog = [this] {
+        return ctran::utils::toFormattableHandle(poolHandle_);
+      };
+#endif
+      CTRAN_LOG_SUBSYS(
           INFO,
           ALLOC,
           "ncclx::memory::memCacheAllocator::init size {} pointer {} handle {:x}",
           newSlabSize,
           poolPtr_,
-          ctran::utils::toFormattableHandle(poolHandle_));
+          getPoolHandleForLog());
       poolRemainSize_ = newSlabSize;
     }
     initialized_ = true;
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "Initialized NCCLX internal buffer pool, size {}",
@@ -74,7 +86,7 @@ commResult_t memCacheAllocator::init() {
 commResult_t memCacheAllocator::reset() {
   std::unique_lock lock(mutex_);
   if (initialized_) {
-    CLOGF_SUBSYS(INFO, INIT, "Reset NCCLX internal buffer pool");
+    CTRAN_LOG_SUBSYS(INFO, INIT, "Reset NCCLX internal buffer pool");
     printSnapshot();
 
     auto nOccupiedRegions = countOccupiedRegions();
@@ -97,7 +109,7 @@ commResult_t memCacheAllocator::reset() {
 }
 
 memCacheAllocator::~memCacheAllocator() {
-  CLOGF_SUBSYS(INFO, INIT, "Shutting down NCCLX memory cache allocator");
+  CTRAN_LOG_SUBSYS(INFO, INIT, "Shutting down NCCLX memory cache allocator");
   FB_COMMCHECKTHROW_EX_NOCOMM(reset());
 }
 
@@ -116,13 +128,13 @@ std::shared_ptr<memRegion> memCacheAllocator::getFreeMemReg(
     auto region = freeRegions->front();
     freeRegions->pop_front();
     if (region->refCnt > 0) {
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "Found a free region with size {} is already in use, region={}",
           nBytes,
           region->toString().c_str());
     }
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO, ALLOC, "Reusing free region {}", region->toString().c_str());
     return region;
   }
@@ -142,7 +154,7 @@ std::shared_ptr<memRegion> memCacheAllocator::createNewMemReg(
     region->cuHandle = poolHandle_;
     poolPtr_ = (char*)poolPtr_ + nBytes;
     poolRemainSize_ -= nBytes;
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         ALLOC,
         "Consume memory from pre-allocated pool ({} + {})",
@@ -156,7 +168,7 @@ std::shared_ptr<memRegion> memCacheAllocator::createNewMemReg(
         &region->ptr, nBytes, callsite, logMetaData, &handle));
     region->cuHandle = handle;
 
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         ALLOC,
         "Memory Pool is full, pool size {}, allocated new memory {} with size {}",
@@ -169,7 +181,7 @@ std::shared_ptr<memRegion> memCacheAllocator::createNewMemReg(
   region->size = nBytes;
   region->creatorTid = syscall(SYS_gettid);
   region->bucket = bucket;
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO, ALLOC, "Created new region {}", region->toString().c_str());
   return region;
 }
@@ -198,7 +210,7 @@ commResult_t memCacheAllocator::getCachedCuMemById(
     region = getFreeMemReg(alignedSize16, bucket);
     if (region == nullptr) {
       // Need to create a new region
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           ALLOC,
           "No free region with size {} is available, need to create a new region",
@@ -214,7 +226,7 @@ commResult_t memCacheAllocator::getCachedCuMemById(
           key,
           hashKey);
     }
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         ALLOC,
         "Caching new region for key {} hashKey {:x}: {}",
@@ -236,7 +248,7 @@ commResult_t memCacheAllocator::getCachedCuMemById(
   // insert/update the cached region
   cachedRegionMap_[hashKey] = region;
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       ALLOC,
       "Return the cached (requested key={}, hashKey={:x}, size {}) region {}",
@@ -267,7 +279,7 @@ commResult_t memCacheAllocator::reserve(const std::string& key) {
         key,
         hashKey,
         cachedRegion->ownerKey);
-    CLOGF_TRACE(ALLOC, "{}", errStr.c_str());
+    CTRAN_LOG_TRACE(ALLOC, "{}", errStr.c_str());
     return commInProgress;
   }
 
@@ -279,7 +291,7 @@ commResult_t memCacheAllocator::reserve(const std::string& key) {
 
   cachedRegion->refCnt++;
   cachedRegion->ownerKey = key;
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       ALLOC,
       "reserved region {} using key {} hash {:x}",
       cachedRegion->toString().c_str(),
@@ -307,7 +319,7 @@ commResult_t memCacheAllocator::release(const std::vector<std::string>& keys) {
     }
     cachedRegion->refCnt--;
     if (cachedRegion->refCnt == 0) {
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           ALLOC,
           "Releasing region {} back to free list",
@@ -353,7 +365,7 @@ void memCacheAllocator::printSnapshot() const {
   // convert to GiB
   double avai_mem = avai_bytes / (1024 * 1024 * 1024);
   double total_mem = total_bytes / (1024 * 1024 * 1024);
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "NCCLX memory allocator snapshot: NCCL used {} bytes, {} allocated regions ({} buckets) {} regions in-use, avai_mem: {:.2f} of {:.2f} GiB",
@@ -365,7 +377,7 @@ void memCacheAllocator::printSnapshot() const {
       total_mem);
   for (const auto& [bucket, regionMap] : freeRegionMaps_) {
     for (const auto& [size, vec] : regionMap) {
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           ALLOC,
           "\tFree region map size in bucket-{}: {}, count: {}",
@@ -373,7 +385,7 @@ void memCacheAllocator::printSnapshot() const {
           size,
           vec.size());
       for (const auto& region : vec) {
-        CLOGF_SUBSYS(
+        CTRAN_LOG_SUBSYS(
             INFO,
             ALLOC,
             "\t\tFree region with size {}: {}",
@@ -383,7 +395,7 @@ void memCacheAllocator::printSnapshot() const {
     }
   }
   for (const auto& [key, region] : cachedRegionMap_) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         ALLOC,
         "\tCached region map key: {} -> {}",

--- a/comms/ctran/regcache/IpcRegCache.cc
+++ b/comms/ctran/regcache/IpcRegCache.cc
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include "comms/ctran/bootstrap/Socket.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/ctran/utils/Utils.h"
 #include "comms/utils/CudaRAII.h"
@@ -26,7 +27,7 @@ commResult_t ctran::IpcRegCache::regMem(
 
   FB_COMMCHECK(reg->tryLoad(supported, shouldSupportCudaMalloc));
   if (supported) {
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL, "CTRAN-REGCACHE: Registered IPC memory {}", reg->toString());
 
     *ipcRegElem = reinterpret_cast<void*>(reg);
@@ -42,7 +43,7 @@ commResult_t ctran::IpcRegCache::regMem(
 void ctran::IpcRegCache::deregMem(void* ipcRegElem) {
   auto reg = reinterpret_cast<ctran::regcache::IpcRegElem*>(ipcRegElem);
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL, "CTRAN-REGCACHE: Deregistered IPC memory {}", reg->toString());
   // Memory handle release in ~CtranIpcMem()
   delete reg;
@@ -184,7 +185,7 @@ commResult_t ctran::IpcRegCache::importMem(
   std::snprintf(remKey->peerId, regcache::kMaxPeerIdLen, "%s", peerId.c_str());
   remKey->basePtr = ipcDesc.desc.base;
   remKey->uid = ipcDesc.uid;
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-REGCACHE: Imported NVL remote mem from peer {}: buf {} (base {} offset {} uid {})",
       peerId,
@@ -226,7 +227,7 @@ commResult_t ctran::IpcRegCache::importRemMemImpl(
       if (outRefCount != nullptr) {
         *outRefCount = newRefCount;
       }
-      CLOGF_TRACE(
+      CTRAN_LOG_TRACE(
           COLL,
           "CTRAN-REGCACHE: IPC remote registration cache hit peer:base:uid=<{}:{}:{}>, refCount now {}",
           peerId,
@@ -251,7 +252,7 @@ commResult_t ctran::IpcRegCache::importRemMemImpl(
     return commInternalError;
   }
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-REGCACHE: cache IPC remote registration peer:base:uid=<{}:{}:{}> {}",
       peerId,
@@ -295,7 +296,7 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
       elem->refCount.fetch_sub(exportCount, std::memory_order_acq_rel);
 
   if (prevCount < exportCount) {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-REGCACHE: over-release detected for IPC remote registration "
         "peer:base:uid=<{}:{}:{}>, prevCount {} < exportCount {}",
@@ -306,7 +307,7 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
         exportCount);
     // Fall through to invalidate — the entry is invalid regardless
   } else if (prevCount > exportCount) {
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-REGCACHE: decremented refCount for IPC remote registration "
         "peer:base:uid=<{}:{}:{}>, refCount now {}",
@@ -317,7 +318,7 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
     return commSuccess;
   }
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-REGCACHE: remove IPC remote registration from cache peer:base:uid=<{}:{}:{}> : {}",
       peerId,
@@ -348,7 +349,7 @@ void ctran::IpcRegCache::clearAllRemReg() {
   auto lockedMap = ipcRemRegMap_.wlock();
 
   for (auto& [peerId, regs] : *lockedMap) {
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         INIT,
         "CTRAN-REGCACHE: clear all {} cached IPC remote registrations from peer {}",
         regs.size(),
@@ -405,7 +406,7 @@ commResult_t ctran::IpcRegCache::notifyRemoteIpcRelease(
   remReleaseMem(ipcRegElem, reqCb->req.release);
   reqCb->req.release.exportCount = exportCount;
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-REGCACHE: Sending IPC_RELEASE to peerAddr {}: {}",
       peerAddr.describe(),
@@ -420,7 +421,7 @@ commResult_t ctran::IpcRegCache::notifyRemoteIpcRelease(
       sizeof(ctran::regcache::IpcReq),
       [reqCb, peerAddr](const folly::AsyncSocketException* err) {
         if (err != nullptr) {
-          CLOGF(
+          CTRAN_LOG(
               WARN,
               "CTRAN-REGCACHE: Failed to send IpcReq to peerAddr {}: {}",
               peerAddr.describe(),
@@ -458,7 +459,7 @@ commResult_t ctran::IpcRegCache::notifyRemoteIpcExport(
   // rather than polluting IpcReqCb which is shared with kRelease.
   auto wireBuf = serializeIpcReq(reqCb->req, extraSegments);
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-REGCACHE: Sending IPC_DESC to peerAddr {}: {} (wireSize={}, extraSegments={})",
       peerAddr.describe(),
@@ -475,7 +476,7 @@ commResult_t ctran::IpcRegCache::notifyRemoteIpcExport(
       wireBuf->size(),
       [reqCb, peerAddr, wireBuf](const folly::AsyncSocketException* err) {
         if (err != nullptr) {
-          CLOGF(
+          CTRAN_LOG(
               WARN,
               "CTRAN-REGCACHE: Failed to send IpcReq (DESC) to peerAddr {}: {}",
               peerAddr.describe(),
@@ -511,7 +512,7 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
   auto maybeAddr = ctran::bootstrap::getInterfaceAddress(
       NCCL_SOCKET_IFNAME, NCCL_SOCKET_IPADDR_PREFIX, true, &resolvedIfName);
   if (maybeAddr.hasError()) {
-    CLOGF(WARN, "CTRAN-REGCACHE: No socket interfaces found");
+    CTRAN_LOG(WARN, "CTRAN-REGCACHE: No socket interfaces found");
     throw ::ctran::utils::Exception(
         "CTRAN-IB : No socket interfaces found", commSystemError);
   }
@@ -541,7 +542,7 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
             // Handle release request - release the imported NVL memory
             std::string peerId = ipcReq.getPeerId();
 
-            CLOGF_TRACE(
+            CTRAN_LOG_TRACE(
                 COLL,
                 "CTRAN-REGCACHE: Received IPC_RELEASE from peer {}: {}",
                 peerId,
@@ -559,7 +560,7 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
             // Handle descriptor request - import the remote memory
             std::string peerId = ipcReq.getPeerId();
 
-            CLOGF_TRACE(
+            CTRAN_LOG_TRACE(
                 COLL,
                 "CTRAN-REGCACHE: Received IPC_DESC from peer {}: {}",
                 peerId,
@@ -574,7 +575,7 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
                   reinterpret_cast<const ctran::utils::CtranIpcSegDesc*>(
                       buf->data() + sizeof(ctran::regcache::IpcReq));
               extraSegments.assign(extraData, extraData + numExtra);
-              CLOGF_TRACE(
+              CTRAN_LOG_TRACE(
                   COLL,
                   "CTRAN-REGCACHE: IPC_DESC has {} extra segments beyond inline",
                   numExtra);
@@ -584,7 +585,7 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
             // the cudaDev is not passed in
             void* mappedBuf = nullptr;
             ctran::regcache::IpcRemHandle remKey;
-            CLOGF(
+            CTRAN_LOG(
                 WARN,
                 "CTRAN-REGCACHE: unsafe path to importMem with cudaDev 0 via async-socket");
             FB_COMMCHECKIGNORE(importMem(
@@ -603,7 +604,7 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
   // Get the server address
   serverAddr_ = std::move(serverAddrFuture).get();
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-REGCACHE: AsyncSocket server started at {} ifname {}",
@@ -617,7 +618,7 @@ void ctran::IpcRegCache::stopAsyncSocket() {
   if (asyncServerSocket_) {
     auto fut = asyncServerSocket_->stop();
     std::move(fut).get();
-    CLOGF_SUBSYS(INFO, INIT, "CTRAN-REGCACHE: AsyncSocket server stopped");
+    CTRAN_LOG_SUBSYS(INFO, INIT, "CTRAN-REGCACHE: AsyncSocket server stopped");
   }
 
   // Destroy the EVB thread BEFORE asyncServerSocket_ to drain pending


### PR DESCRIPTION
Summary:

Migrate all 20 production log calls in the CTRAN IPC registration cache from the Folly-backed `CLOGF` facade to the tested CTRAN spdlog facade.

Preserve severity, subsystem and trace gating, message strings, arguments, and evaluation behavior. Declare the new logger dependency directly on the `ipc_regcache` target.

Reviewed By: shr

Differential Revision: D115380567


