### PR TITLE
Fall back to folly XLOG in CTRAN_LOG on AMD (#3558)

### DIFF
--- a/comms/ctran/utils/CtranLogger.h
+++ b/comms/ctran/utils/CtranLogger.h
@@ -4,14 +4,44 @@
 
 #include <string_view>
 
+// The standalone RCCL/conda build is the only AMD/HIP build and it has no
+// spdlog, which SpdlogLogger.h hard-requires. Fall back to folly XLOG there,
+// which is what these call sites used before the spdlog migration: LogInit.cc
+// already configures the folly "comms.ctran" categories on ROCm, so the level
+// gating, CTRAN prefix, NCCL_DEBUG_FILE output and per-thread device context
+// are unchanged.
+#if defined(__HIP_PLATFORM_AMD__)
+#include <folly/logging/xlog.h>
+#else
 #include "comms/utils/logger/RateLimit.h"
 #include "comms/utils/logger/SpdlogLogger.h"
+#endif
 
 namespace ctran::logging {
 
 inline constexpr std::string_view kCtranLoggerName = "comms.ctran";
 
 } // namespace ctran::logging
+
+#if defined(__HIP_PLATFORM_AMD__)
+
+#define CTRAN_LOG(level, ...) XLOGF(level, __VA_ARGS__)
+#define CTRAN_LOG_FIRST_N_WARN(n, ...) XLOGF_FIRST_N(WARN, n, __VA_ARGS__)
+#define CTRAN_LOG_FIRST_N_ERR(n, ...) XLOGF_FIRST_N(ERR, n, __VA_ARGS__)
+
+// XLOGF_IF is the legacy form the spdlog CTRAN_LOG_IF_* macros were modelled
+// on, so FATAL needs no special case here: it already evaluates the condition
+// unconditionally.
+#define CTRAN_LOG_IF_WARN(condition, ...) XLOGF_IF(WARN, condition, __VA_ARGS__)
+#define CTRAN_LOG_IF_DBG(condition, ...) XLOGF_IF(DBG, condition, __VA_ARGS__)
+#define CTRAN_LOG_IF_INFO(condition, ...) XLOGF_IF(INFO, condition, __VA_ARGS__)
+#define CTRAN_LOG_IF_ERR(condition, ...) XLOGF_IF(ERR, condition, __VA_ARGS__)
+#define CTRAN_LOG_IF_CRITICAL(condition, ...) \
+  XLOGF_IF(CRITICAL, condition, __VA_ARGS__)
+#define CTRAN_LOG_IF_FATAL(condition, ...) \
+  XLOGF_IF(FATAL, condition, __VA_ARGS__)
+
+#else
 
 #define CTRAN_LOG(level, ...) \
   COMMS_LOG_NAMED(::ctran::logging::kCtranLoggerName, level, __VA_ARGS__)
@@ -42,8 +72,6 @@ inline constexpr std::string_view kCtranLoggerName = "comms.ctran";
       CTRAN_LOG(FATAL, __VA_ARGS__);       \
     }                                      \
   } while (false)
-#define CTRAN_LOG_IF(level, condition, ...) \
-  CTRAN_LOG_IF_##level(condition, __VA_ARGS__)
 
 #define CTRAN_LOG_FIRST_N_IMPL(level, spdlog_level, n, ...)                    \
   do {                                                                         \
@@ -61,5 +89,11 @@ inline constexpr std::string_view kCtranLoggerName = "comms.ctran";
   CTRAN_LOG_FIRST_N_IMPL(WARN, ::spdlog::level::warn, n, __VA_ARGS__)
 #define CTRAN_LOG_FIRST_N_ERR(n, ...) \
   CTRAN_LOG_FIRST_N_IMPL(ERR, ::spdlog::level::err, n, __VA_ARGS__)
+
+#endif
+
+#define CTRAN_LOG_IF(level, condition, ...) \
+  CTRAN_LOG_IF_##level(condition, __VA_ARGS__)
+
 #define CTRAN_LOG_FIRST_N(level, n, ...) \
   CTRAN_LOG_FIRST_N_##level(n, __VA_ARGS__)

--- a/comms/ctran/utils/tests/LogUT.cc
+++ b/comms/ctran/utils/tests/LogUT.cc
@@ -70,6 +70,12 @@ TEST_F(CtranUtilsLogTest, TestCLOGF) {
   EXPECT_NE(messages[0].find(expectedContent), std::string::npos);
 }
 
+// These assert spdlog-specific semantics: the last-error callback, spdlog level
+// gating of the rate-limit / CTRAN_LOG_IF / CTRAN_LOG_EVERY_MS budgets, and the
+// CTRAN_LOG_TRACE format. On AMD, CTRAN_LOG maps to folly XLOG and none of them
+// are reachable, so the assertions do not apply there.
+#if !defined(__HIP_PLATFORM_AMD__)
+
 TEST_F(CtranUtilsLogTest, TestCtranLoggerPreservesLastError) {
   auto& logger =
       meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName);
@@ -214,6 +220,8 @@ TEST_F(CtranUtilsLogTest, TestCtranTraceFormat) {
 
   EXPECT_THAT(output, testing::HasSubstr("[TRACE] TestBody: trace value 42"));
 }
+
+#endif
 
 TEST_F(CtranUtilsLogTest, TestCLOGF_IF) {
   CLOGF_IF(INFO, true, "Conditional message with value: {}", 42);


### PR DESCRIPTION
Summary:

The standalone RCCL/conda build (`comms/rcclx/develop/projects/rccl`) globs all
of `comms/ctran` into `librccl` and deliberately has no spdlog -- the same
premise as D115067885. The recent defolly work re-broke that build:

- D115082769 added `comms/ctran/utils/CtranLogger.h`, which includes
  `comms/utils/logger/SpdlogLogger.h` unconditionally.
- Subsequent diffs swapped `folly/logging/xlog.h` for that header across ctran,
  including in `comms/ctran/utils/AsyncError.h` -- a header reached from
  `src/include/comm.h` via `comms/ctran/CtranComm.h`.

`SpdlogLogger.h` hard-requires `SPDLOG_FMT_EXTERNAL` / `SPDLOG_ACTIVE_LEVEL` and
the spdlog headers, so every affected TU fails:

```
SpdlogLogger.h:15: error: "SpdlogLogger requires SPDLOG_FMT_EXTERNAL from the build target"
SpdlogLogger.h:19: error: "SpdlogLogger requires SPDLOG_ACTIVE_LEVEL from the build target"
SpdlogLogger.h:22: fatal error: 'spdlog/sinks/dist_sink.h' file not found
```

Because `AsyncError.h` is reachable from `comm.h`, this is not confined to ctran
sources -- it hits RCCL core (`src/transport/shm.cc` and effectively every TU
that includes `comm.h`). Trunk is currently red for this build.

Guard, do not exclude. `CtranAlgo.cc`, `AsyncError.h` and the bootstrap sources
are core ctran; dropping them from the CMake source list leaves undefined
symbols at link. Guard instead at the `CtranLogger.h` facade, on the condition
D115067885 established -- `defined(__HIP_PLATFORM_AMD__)`. Guarding the facade
rather than each consumer is what makes this hold up: the `AsyncError.h` include
landed after the first call sites and would otherwise have needed its own guard,
and `CTRAN_LOG_FIRST_N_*` arrived after that.

Fall back to folly XLOG rather than compiling the macros out. That is what these
call sites used before the spdlog migration, and it keeps ROCm logging alive
instead of silently dropping ~119 call sites. `LogInit.cc` already registers the
folly categories unconditionally -- `kCtranCategory`, `kCtranHeaderCategory`,
and a ROCm-only `getHipCtranCategory()` under `#if defined(USE_ROCM)` -- each
with `logPrefix = "CTRAN"`, `logFilePath` from `NCCL_DEBUG_FILE`, `logLevel`
from `NCCL_DEBUG`, and the per-thread device-id context. So level gating, the
CTRAN prefix, debug-file output and thread context are preserved on ROCm.

Scope note, worth a reviewer's attention. `__HIP_PLATFORM_AMD__` is true for
*every* AMD build, not just the spdlog-less CMake one. Buck's AMD config does
have spdlog, so this changes its behavior too: `CTRAN_LOG(ERR, ...)` there no
longer feeds `getLastCommsError()` (the folly path has no equivalent hook), and
`CTRAN_LOG_FIRST_N` gating moves from spdlog levels to folly. `LogUT.cc` is the
evidence -- its two spdlog-semantics cases,
`TestCtranLoggerPreservesLastError` and
`TestCtranLogFirstNPreservesEnabledBudget`, assert exactly those behaviors and
cannot hold on the folly path, so they are guarded off on AMD. That is a real
loss of AMD coverage with nothing replacing it. Keying the facade on
`SPDLOG_FMT_EXTERNAL` / `SPDLOG_ACTIVE_LEVEL` instead would confine the change
to the CMake build and leave both tests intact; the platform macro was chosen
for consistency with D115067885. Happy to switch if reviewers prefer the
narrower condition.

Also adds `//folly/logging:logging` to the `exported_deps` of the target owning
`CtranLogger.h`. The include sits behind `__HIP_PLATFORM_AMD__`, but autodeps is
not preprocessor-aware and the Buck ROCm build needs the dep to compile.

No behavior change on NVIDIA: the spdlog branch, including
`CTRAN_LOG_FIRST_N_IMPL` and its `RateLimit.h` dependency, is untouched.

Thanks to the reviewer suggestion in P2456385988, which replaced an earlier
version of this diff that made `CTRAN_LOG` a no-op on AMD.

Reviewed By: srinathb-meta

Differential Revision: D115468117


