### PR TITLE
Add remaining direct iostream includes

### DIFF
--- a/comms/ctran/backends/ib/benchmarks/CtranIbBench.cc
+++ b/comms/ctran/backends/ib/benchmarks/CtranIbBench.cc
@@ -6,6 +6,7 @@
 #include <folly/logging/Init.h>
 #include <unistd.h>
 #include <chrono>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Summary: D114418456 removed a transitive Thrift include and exposed two remaining C++ sources that use `std::cout` or `std::cerr` without including `<iostream>`. Add the direct standard-library includes so the affected build targets no longer depend on the removed transitive path.

Reviewed By: saifhhasan

Differential Revision: D115502594


