### PR TITLE
Add CTRAN dispatch and arg validation to `ncclAlltoAll`

### DIFF
--- a/comms/ncclx/v2_29/src/collectives.cc
+++ b/comms/ncclx/v2_29/src/collectives.cc
@@ -118,8 +118,30 @@ NCCL_API(ncclResult_t, ncclAlltoAll, const void* sendbuff, void* recvbuff, size_
     ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream);
 ncclResult_t ncclAlltoAll(const void* sendbuff, void* recvbuff, size_t count,
     ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream) {
+  if (count == 0) {
+    return ncclSuccess;
+  }
+
+  SetCudaDevRAII setCudaDev(comm->cudaDev);
   NVTX3_FUNC_WITH_PARAMS(AlltoAll, NcclNvtxParamsAlltoAll,
     NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype)));
+
+  NCCLCHECK(CudaPtrCheck(sendbuff, comm, "sendbuff", "ncclAlltoAll"));
+  NCCLCHECK(CudaPtrCheck(recvbuff, comm, "recvbuff", "ncclAlltoAll"));
+  if (sendbuff == recvbuff) {
+    ERR(
+        ncclInvalidArgument,
+        "Found sendbuff %p == recvbuff %p. In-place ncclAlltoAll is not supported.",
+        sendbuff,
+        recvbuff);
+    return ncclInvalidArgument;
+  }
+
+  auto alltoallAlgo = NCCLX_CONFIG_FIELD(comm->config, alltoallAlgo);
+  if ((alltoallAlgo != NCCL_ALLTOALL_ALGO::orig) &&
+      ctranAllToAllSupport(count, ncclToMetaComm(datatype), comm->ctranComm_.get(), alltoallAlgo, stream, recvbuff)) {
+    return metaCommToNccl(ctranAllToAll(sendbuff, recvbuff, count, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, alltoallAlgo));
+  }
 
   struct ncclInfo info = { ncclFuncAlltoAll, "AlltoAll",
     sendbuff, recvbuff, count, datatype, ncclSum, 0, comm, stream, /* Args */

--- a/comms/ncclx/v2_30/src/collectives.cc
+++ b/comms/ncclx/v2_30/src/collectives.cc
@@ -118,8 +118,30 @@ NCCL_API(ncclResult_t, ncclAlltoAll, const void* sendbuff, void* recvbuff, size_
     ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream);
 ncclResult_t ncclAlltoAll(const void* sendbuff, void* recvbuff, size_t count,
     ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream) {
+  if (count == 0) {
+    return ncclSuccess;
+  }
+
+  SetCudaDevRAII setCudaDev(comm->cudaDev);
   NVTX3_FUNC_WITH_PARAMS(AlltoAll, NcclNvtxParamsAlltoAll,
     NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype)));
+
+  NCCLCHECK(CudaPtrCheck(sendbuff, comm, "sendbuff", "ncclAlltoAll"));
+  NCCLCHECK(CudaPtrCheck(recvbuff, comm, "recvbuff", "ncclAlltoAll"));
+  if (sendbuff == recvbuff) {
+    ERR(
+        ncclInvalidArgument,
+        "Found sendbuff %p == recvbuff %p. In-place ncclAlltoAll is not supported.",
+        sendbuff,
+        recvbuff);
+    return ncclInvalidArgument;
+  }
+
+  auto alltoallAlgo = NCCLX_CONFIG_FIELD(comm->config, alltoallAlgo);
+  if ((alltoallAlgo != NCCL_ALLTOALL_ALGO::orig) &&
+      ctranAllToAllSupport(count, ncclToMetaComm(datatype), comm->ctranComm_.get(), alltoallAlgo, stream, recvbuff)) {
+    return metaCommToNccl(ctranAllToAll(sendbuff, recvbuff, count, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, alltoallAlgo));
+  }
 
   struct ncclInfo info = { ncclFuncAlltoAll, "AlltoAll",
     sendbuff, recvbuff, count, datatype, ncclSum, 0, comm, stream, /* Args */


### PR DESCRIPTION
Summary:
NCCLX ships two all-to-all entry points with identical signatures but different
implementations, sitting ~230 lines apart in the same file:

- `ncclAlltoAll` (lowercase `t`, `collectives.cc:117`) — the upstream NVIDIA API,
  added in NCCL 2.28. Dispatches straight to `ncclEnqueueCheck(ncclFuncAlltoAll)`.
  No CTRAN, no argument validation.
- `ncclAllToAll` (capital `T`, `collectives.cc:346`) — Meta-created before upstream
  had an all-to-all. Has the CTRAN switch plus argument checks, and falls back to a
  hand-rolled grouped `baseSend`/`baseRecv` loop.

This is the first diff in a stack that de-dups the two down to `ncclAlltoAll`. It
brings `ncclAlltoAll` up to parity so it is a drop-in replacement, without touching
`ncclAllToAll` yet — both entry points remain fully functional after this diff, so
nothing is broken at any point in the stack.

Grafted onto `ncclAlltoAll`, mirroring how `ncclAllGather` (`collectives.cc:93`)
already layers CTRAN on top of the upstream baseline:
- `count == 0` early-out
- `SetCudaDevRAII`
- `CudaPtrCheck` on `sendbuff` and `recvbuff`
- in-place (`sendbuff == recvbuff`) rejection with `ncclInvalidArgument`
- the `NCCL_ALLTOALL_ALGO` / `ctranAllToAllSupport` / `ctranAllToAll` dispatch

The non-CTRAN fallback stays on the upstream `ncclEnqueueCheck(ncclFuncAlltoAll)`
path rather than adopting the Meta send/recv loop. These are closer than they look:
`taskAppend` (`enqueue.cc:3044-3051`) already decomposes `ncclFuncAlltoAll` into the
same `2 * nRanks` P2P send/recv tasks the Meta loop builds by hand — it never becomes
a `ncclTaskColl` and never reaches a device kernel. Staying on the upstream path also
propagates `collAPI = ncclFuncAlltoAll` to the net plugin (already whitelisted at
`net.cc:218`), emits one `AlltoAll` NVTX range instead of `2N` `Send`/`Recv` ranges,
and keeps divergence from upstream small for future rebases.

Applied identically to `v2_29` and `v2_30`; the two files are byte-identical here.

Differential Revision: D115510404


