### PR TITLE
Migrate NCCLX backend to `ncclAlltoAll`

### DIFF
--- a/comms/ncclx/v2_29/src/collectives.cc
+++ b/comms/ncclx/v2_29/src/collectives.cc
@@ -118,8 +118,30 @@ NCCL_API(ncclResult_t, ncclAlltoAll, const void* sendbuff, void* recvbuff, size_
     ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream);
 ncclResult_t ncclAlltoAll(const void* sendbuff, void* recvbuff, size_t count,
     ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream) {
+  if (count == 0) {
+    return ncclSuccess;
+  }
+
+  SetCudaDevRAII setCudaDev(comm->cudaDev);
   NVTX3_FUNC_WITH_PARAMS(AlltoAll, NcclNvtxParamsAlltoAll,
     NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype)));
+
+  NCCLCHECK(CudaPtrCheck(sendbuff, comm, "sendbuff", "ncclAlltoAll"));
+  NCCLCHECK(CudaPtrCheck(recvbuff, comm, "recvbuff", "ncclAlltoAll"));
+  if (sendbuff == recvbuff) {
+    ERR(
+        ncclInvalidArgument,
+        "Found sendbuff %p == recvbuff %p. In-place ncclAlltoAll is not supported.",
+        sendbuff,
+        recvbuff);
+    return ncclInvalidArgument;
+  }
+
+  auto alltoallAlgo = NCCLX_CONFIG_FIELD(comm->config, alltoallAlgo);
+  if ((alltoallAlgo != NCCL_ALLTOALL_ALGO::orig) &&
+      ctranAllToAllSupport(count, ncclToMetaComm(datatype), comm->ctranComm_.get(), alltoallAlgo, stream, recvbuff)) {
+    return metaCommToNccl(ctranAllToAll(sendbuff, recvbuff, count, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, alltoallAlgo));
+  }
 
   struct ncclInfo info = { ncclFuncAlltoAll, "AlltoAll",
     sendbuff, recvbuff, count, datatype, ncclSum, 0, comm, stream, /* Args */

--- a/comms/ncclx/v2_30/src/collectives.cc
+++ b/comms/ncclx/v2_30/src/collectives.cc
@@ -118,8 +118,30 @@ NCCL_API(ncclResult_t, ncclAlltoAll, const void* sendbuff, void* recvbuff, size_
     ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream);
 ncclResult_t ncclAlltoAll(const void* sendbuff, void* recvbuff, size_t count,
     ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream) {
+  if (count == 0) {
+    return ncclSuccess;
+  }
+
+  SetCudaDevRAII setCudaDev(comm->cudaDev);
   NVTX3_FUNC_WITH_PARAMS(AlltoAll, NcclNvtxParamsAlltoAll,
     NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype)));
+
+  NCCLCHECK(CudaPtrCheck(sendbuff, comm, "sendbuff", "ncclAlltoAll"));
+  NCCLCHECK(CudaPtrCheck(recvbuff, comm, "recvbuff", "ncclAlltoAll"));
+  if (sendbuff == recvbuff) {
+    ERR(
+        ncclInvalidArgument,
+        "Found sendbuff %p == recvbuff %p. In-place ncclAlltoAll is not supported.",
+        sendbuff,
+        recvbuff);
+    return ncclInvalidArgument;
+  }
+
+  auto alltoallAlgo = NCCLX_CONFIG_FIELD(comm->config, alltoallAlgo);
+  if ((alltoallAlgo != NCCL_ALLTOALL_ALGO::orig) &&
+      ctranAllToAllSupport(count, ncclToMetaComm(datatype), comm->ctranComm_.get(), alltoallAlgo, stream, recvbuff)) {
+    return metaCommToNccl(ctranAllToAll(sendbuff, recvbuff, count, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, alltoallAlgo));
+  }
 
   struct ncclInfo info = { ncclFuncAlltoAll, "AlltoAll",
     sendbuff, recvbuff, count, datatype, ncclSum, 0, comm, stream, /* Args */

--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -266,7 +266,7 @@ ncclResult_t DefaultNcclxApi::allToAll(
     ncclComm_t comm,
     cudaStream_t stream) {
   std::lock_guard<std::mutex> lock(api_mutex_);
-  return ncclAllToAll(sendbuff, recvbuff, count, datatype, comm, stream);
+  return ncclAlltoAll(sendbuff, recvbuff, count, datatype, comm, stream);
 }
 
 #ifdef NCCL_REDUCE_SCATTER_QUANTIZE_SUPPORTED


### PR DESCRIPTION
Summary:
Part of the stack that de-dups NCCLX's two all-to-all entry points down to the
upstream-named `ncclAlltoAll`. See the base diff for the full rationale.

`DefaultNcclxApi::allToAll` is a straight pass-through to the raw NCCL symbol, so
this is a one-line swap from the Meta-created `ncclAllToAll` to `ncclAlltoAll`. The
signatures are identical (6 args, same per-rank `count` semantics), and the earlier
diff in this stack already gave `ncclAlltoAll` the CTRAN dispatch and the argument
validation, so behavior is preserved.

Scope note: only the NCCL symbol changes. The C++ wrapper method name
`DefaultNcclxApi::allToAll` and its `INcclxApi` declaration are left alone, so
`TorchCommNCCLX::all_to_all_single` (`TorchCommNCCLX.cpp:1567`) needs no edit.

The sibling RCCL backends (`comms/torchcomms/rccl`, `comms/torchcomms/rcclx`) are
deliberately untouched — they call AMD RCCL's own `ncclAllToAll`, a different symbol
from a different header, which RCCL already marks `__attribute__((deprecated))` in
favor of its own `ncclAlltoAll`. Aligning those is a separate change.

`ncclAllToAll` still exists and still works after this diff — it is deleted at the
top of the stack, once every caller has moved.

Differential Revision: D115510406


