### PR TITLE
Migrate tests to `ncclAlltoAll`

### DIFF
--- a/comms/ncclx/meta/colltrace/tests/MapperTraceDistTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/MapperTraceDistTest.cc
@@ -126,7 +126,7 @@ TEST_F(MapperTraceTest, CtranAllToAll) {
   });
   for (int i = 0; i < nColl; i++) {
     NCCLCHECK_TEST(
-        ncclAllToAll(sendBuf, recvBuf, count, ncclInt, comm, stream));
+        ncclAlltoAll(sendBuf, recvBuf, count, ncclInt, comm, stream));
   }
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
   ASSERT_EQ(dumpBaton.try_wait_for(std::chrono::seconds(1)), true);

--- a/comms/ncclx/meta/colltrace/tests/ProxyTraceDistTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/ProxyTraceDistTest.cc
@@ -66,7 +66,7 @@ class ProxyTraceTest : public NcclxBaseTestFixture {
     CUDACHECK_TEST(cudaMalloc(&recvBuf, count * comm->nRanks * sizeof(int)));
     for (int i = 0; i < nColl; i++) {
       NCCLCHECK_TEST(
-          ncclAllToAll(sendBuf, recvBuf, count, ncclInt, comm, stream));
+          ncclAlltoAll(sendBuf, recvBuf, count, ncclInt, comm, stream));
     }
   }
 

--- a/comms/ncclx/meta/tests/AllToAllTest.cc
+++ b/comms/ncclx/meta/tests/AllToAllTest.cc
@@ -70,7 +70,7 @@ class AllToAllTest : public NcclxBaseTestFixture {
 
     // run alltoall
     for (int i = 0; i < kTotalColls; i++) {
-      auto res = ncclAllToAll(sendBuf, recvBuf, count, ncclInt, comm, stream);
+      auto res = ncclAlltoAll(sendBuf, recvBuf, count, ncclInt, comm, stream);
       ASSERT_EQ(res, ncclSuccess);
     }
     CUDACHECK_TEST(cudaStreamSynchronize(stream));
@@ -170,7 +170,7 @@ TEST_F(AllToAllTest, InvalidSendbuf) {
   CUDACHECK_TEST(cudaMalloc(&buf, count * numRanks * sizeof(int)));
 
   // run alltoall
-  auto res = ncclAllToAll(nullptr, buf, count, ncclInt, comm, stream);
+  auto res = ncclAlltoAll(nullptr, buf, count, ncclInt, comm, stream);
   ASSERT_EQ(res, ncclInvalidArgument);
   CUDACHECK_TEST(cudaFree(buf));
 #endif
@@ -183,7 +183,7 @@ TEST_F(AllToAllTest, InvalidRecvbuf) {
   CUDACHECK_TEST(cudaMalloc(&buf, count * numRanks * sizeof(int)));
 
   // run alltoall
-  auto res = ncclAllToAll(buf, nullptr, count, ncclInt, comm, stream);
+  auto res = ncclAlltoAll(buf, nullptr, count, ncclInt, comm, stream);
   ASSERT_EQ(res, ncclInvalidArgument);
   CUDACHECK_TEST(cudaFree(buf));
 #endif
@@ -196,7 +196,7 @@ TEST_F(AllToAllTest, InvalidInPlace) {
   CUDACHECK_TEST(cudaMalloc(&buf, count * numRanks * sizeof(int)));
 
   // run alltoall
-  auto res = ncclAllToAll(buf, buf, count, ncclInt, comm, stream);
+  auto res = ncclAlltoAll(buf, buf, count, ncclInt, comm, stream);
   ASSERT_EQ(res, ncclInvalidArgument);
   CUDACHECK_TEST(cudaFree(buf));
 #endif

--- a/comms/ncclx/meta/tests/CommDumpTest.cc
+++ b/comms/ncclx/meta/tests/CommDumpTest.cc
@@ -488,7 +488,7 @@ TEST_F(CommDumpTest, DumpAfterCtranColl) {
   prepareCtranAllToAll(this->comm, count);
 
   for (int i = 0; i < nColl; i++) {
-    NCCLCHECK_TEST(ncclAllToAll(
+    NCCLCHECK_TEST(ncclAlltoAll(
         this->sendBuf,
         this->recvBuf,
         count,

--- a/comms/ncclx/meta/tests/LazyConnectTest.cc
+++ b/comms/ncclx/meta/tests/LazyConnectTest.cc
@@ -293,7 +293,7 @@ TEST_P(NcclxLazyConnectTestFixture, Alltoall) {
   prepBuffers(sendBytes, recvBytes, rootComm);
 
   // run small alltoall
-  auto res = ncclAllToAll(sendBuf, recvBuf, 2, dataType, rootComm, stream);
+  auto res = ncclAlltoAll(sendBuf, recvBuf, 2, dataType, rootComm, stream);
   EXPECT_EQ(res, ncclSuccess);
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
 
@@ -309,7 +309,7 @@ TEST_P(NcclxLazyConnectTestFixture, Alltoall) {
   }
 
   // run large alltoall
-  res = ncclAllToAll(sendBuf, recvBuf, count, dataType, rootComm, stream);
+  res = ncclAlltoAll(sendBuf, recvBuf, count, dataType, rootComm, stream);
   EXPECT_EQ(res, ncclSuccess);
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
 
@@ -343,7 +343,7 @@ TEST_P(NcclxLazyConnectTestFixture, AlltoallAndAllGather) {
   prepBuffers(sendBytes, recvBytes, rootComm);
 
   // run alltoall
-  auto res = ncclAllToAll(sendBuf, recvBuf, count, dataType, rootComm, stream);
+  auto res = ncclAlltoAll(sendBuf, recvBuf, count, dataType, rootComm, stream);
   EXPECT_EQ(res, ncclSuccess);
   // run allgather
   res = ncclAllGather(sendBuf, recvBuf, count, dataType, rootComm, stream);
@@ -387,7 +387,7 @@ TEST_P(NcclxLazyConnectTestFixture, higherP2pChThanColl) {
   prepBuffers(sendBytes, recvBytes, rootComm);
 
   // run alltoall
-  auto res = ncclAllToAll(sendBuf, recvBuf, count, dataType, rootComm, stream);
+  auto res = ncclAlltoAll(sendBuf, recvBuf, count, dataType, rootComm, stream);
   EXPECT_EQ(res, ncclSuccess);
   // run allgather
   res = ncclAllGather(

--- a/comms/ncclx/meta/tests/MultiStreamTest.cc
+++ b/comms/ncclx/meta/tests/MultiStreamTest.cc
@@ -166,7 +166,7 @@ TEST_P(MultiStreamAllToAllTestParam, Test) {
   for (int x = 0; x < numIter; x++) {
     for (int i = 0; i < numStreams; i++) {
       ASSERT_EQ(
-          ncclAllToAll(
+          ncclAlltoAll(
               sbufs[i], rbufs[i], counts[i], ncclInt, comm, streams[i]),
           ncclSuccess);
     }

--- a/comms/ncclx/v2_29/src/collectives.cc
+++ b/comms/ncclx/v2_29/src/collectives.cc
@@ -118,8 +118,30 @@ NCCL_API(ncclResult_t, ncclAlltoAll, const void* sendbuff, void* recvbuff, size_
     ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream);
 ncclResult_t ncclAlltoAll(const void* sendbuff, void* recvbuff, size_t count,
     ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream) {
+  if (count == 0) {
+    return ncclSuccess;
+  }
+
+  SetCudaDevRAII setCudaDev(comm->cudaDev);
   NVTX3_FUNC_WITH_PARAMS(AlltoAll, NcclNvtxParamsAlltoAll,
     NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype)));
+
+  NCCLCHECK(CudaPtrCheck(sendbuff, comm, "sendbuff", "ncclAlltoAll"));
+  NCCLCHECK(CudaPtrCheck(recvbuff, comm, "recvbuff", "ncclAlltoAll"));
+  if (sendbuff == recvbuff) {
+    ERR(
+        ncclInvalidArgument,
+        "Found sendbuff %p == recvbuff %p. In-place ncclAlltoAll is not supported.",
+        sendbuff,
+        recvbuff);
+    return ncclInvalidArgument;
+  }
+
+  auto alltoallAlgo = NCCLX_CONFIG_FIELD(comm->config, alltoallAlgo);
+  if ((alltoallAlgo != NCCL_ALLTOALL_ALGO::orig) &&
+      ctranAllToAllSupport(count, ncclToMetaComm(datatype), comm->ctranComm_.get(), alltoallAlgo, stream, recvbuff)) {
+    return metaCommToNccl(ctranAllToAll(sendbuff, recvbuff, count, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, alltoallAlgo));
+  }
 
   struct ncclInfo info = { ncclFuncAlltoAll, "AlltoAll",
     sendbuff, recvbuff, count, datatype, ncclSum, 0, comm, stream, /* Args */

--- a/comms/ncclx/v2_30/src/collectives.cc
+++ b/comms/ncclx/v2_30/src/collectives.cc
@@ -118,8 +118,30 @@ NCCL_API(ncclResult_t, ncclAlltoAll, const void* sendbuff, void* recvbuff, size_
     ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream);
 ncclResult_t ncclAlltoAll(const void* sendbuff, void* recvbuff, size_t count,
     ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream) {
+  if (count == 0) {
+    return ncclSuccess;
+  }
+
+  SetCudaDevRAII setCudaDev(comm->cudaDev);
   NVTX3_FUNC_WITH_PARAMS(AlltoAll, NcclNvtxParamsAlltoAll,
     NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype)));
+
+  NCCLCHECK(CudaPtrCheck(sendbuff, comm, "sendbuff", "ncclAlltoAll"));
+  NCCLCHECK(CudaPtrCheck(recvbuff, comm, "recvbuff", "ncclAlltoAll"));
+  if (sendbuff == recvbuff) {
+    ERR(
+        ncclInvalidArgument,
+        "Found sendbuff %p == recvbuff %p. In-place ncclAlltoAll is not supported.",
+        sendbuff,
+        recvbuff);
+    return ncclInvalidArgument;
+  }
+
+  auto alltoallAlgo = NCCLX_CONFIG_FIELD(comm->config, alltoallAlgo);
+  if ((alltoallAlgo != NCCL_ALLTOALL_ALGO::orig) &&
+      ctranAllToAllSupport(count, ncclToMetaComm(datatype), comm->ctranComm_.get(), alltoallAlgo, stream, recvbuff)) {
+    return metaCommToNccl(ctranAllToAll(sendbuff, recvbuff, count, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, alltoallAlgo));
+  }
 
   struct ncclInfo info = { ncclFuncAlltoAll, "AlltoAll",
     sendbuff, recvbuff, count, datatype, ncclSum, 0, comm, stream, /* Args */

--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -266,7 +266,7 @@ ncclResult_t DefaultNcclxApi::allToAll(
     ncclComm_t comm,
     cudaStream_t stream) {
   std::lock_guard<std::mutex> lock(api_mutex_);
-  return ncclAllToAll(sendbuff, recvbuff, count, datatype, comm, stream);
+  return ncclAlltoAll(sendbuff, recvbuff, count, datatype, comm, stream);
 }
 
 #ifdef NCCL_REDUCE_SCATTER_QUANTIZE_SUPPORTED


### PR DESCRIPTION
Summary:
Part of the stack that de-dups NCCLX's two all-to-all entry points down to the
upstream-named `ncclAlltoAll`. See the base diff for the full rationale.

Swaps the last remaining `ncclAllToAll` callers — 12 call sites across 6 test files:

- `tests/AllToAllTest.cc` (4) — the correctness fixture plus the three
  `Invalid{Sendbuf,Recvbuf,InPlace}` cases
- `tests/LazyConnectTest.cc` (4)
- `tests/MultiStreamTest.cc` (1)
- `tests/CommDumpTest.cc` (1)
- `colltrace/tests/MapperTraceDistTest.cc` (1)
- `colltrace/tests/ProxyTraceDistTest.cc` (1)

Symbol swap only. File names, fixture class names, test names, and the
`#ifdef NCCL_ALLTOALL_SUPPORTED` guards are all left as-is — renaming
`AllToAllTest.cc` and friends is out of scope for this stack.

`AllToAllTest.{InvalidSendbuf,InvalidRecvbuf,InvalidInPlace}` are the regression net
for the `CudaPtrCheck` and in-place-rejection logic that the base diff moved onto
`ncclAlltoAll`; they still assert `ncclInvalidArgument` and are unmodified apart from
the symbol.

Two tests worth calling out because they observe the dispatch path rather than just
the result:
- `ProxyTraceTest.QueryFinishedAllToAll` pins `NCCL_ALLTOALL_ALGO::orig` and asserts
  `collInfo.coll == ncclFuncSendRecv` plus `nProxyOps == numRemoteRanks * 2 *
  nChannels`. These should still hold: the upstream path's `p2pTaskAppend` sets
  `func = ncclFuncSend/Recv` exactly as `baseSend`/`baseRecv` did, and the proxy
  trace keys off `func`, not the new `collAPI` field
  (`enqueue.cc:1046` -> `ProxyTraceFunc.cc:18`).
- `MapperTraceTest.CtranAllToAll` pins `NCCL_ALLTOALL_ALGO::ctran`, so it returns
  through the CTRAN branch and never reaches the changed fallback.

After this diff no caller of `ncclAllToAll` remains in fbcode; the next diff deletes
the symbol.

Differential Revision: D115510403


