### PR TITLE
Keep PipesTrace off the AllReduce hot path (#3565)

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -80,6 +80,8 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     CTRAN_LOG(INFO, "CTRAN-PRIMS: initialization skipped; prims are disabled");
     return commSuccess;
   }
+  comms::prims::PipesTraceHandle trace;
+  FB_COMMCHECK(ctran::ctranPreparePipesTrace(comm, trace));
   try {
     CTRAN_LOG(
         INFO,

--- a/comms/pipes/scripts/pipestrace_to_perfetto.py
+++ b/comms/pipes/scripts/pipestrace_to_perfetto.py
@@ -2,8 +2,8 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 """Convert supported `PipesTrace` log lines into Perfetto JSON.
 
-Current event pairing is focused on hierarchical allgather overlap traces:
-IB chunk readiness, NVL wait/broadcast work, and IB send/recv/forward spans.
+Supports hierarchical allgather overlap traces and fine-grained AllReduce
+transport traces, including the staged/registered path actually selected.
 
 Run from `fbcode/comms` with either:
   buck2 run @fbcode//mode/opt \
@@ -49,10 +49,26 @@ AR_PHASE2_BEGIN = "allreduce_phase2_begin"
 AR_PHASE2_END = "allreduce_phase2_end"
 AR_PHASE3_BEGIN = "allreduce_phase3_begin"
 AR_PHASE3_END = "allreduce_phase3_end"
-AR_RING_RS_BEGIN = "allreduce_ring_rs_begin"
-AR_RING_RS_END = "allreduce_ring_rs_end"
-AR_RING_AG_BEGIN = "allreduce_ring_ag_begin"
-AR_RING_AG_END = "allreduce_ring_ag_end"
+AR_SEND_SYNC_BEGIN = "allreduce_send_sync_begin"
+AR_SEND_SYNC_END = "allreduce_send_sync_end"
+AR_WQE_SUBMIT_BEGIN = "allreduce_wqe_submit_begin"
+AR_WQE_SUBMIT_END = "allreduce_wqe_submit_end"
+AR_DATA_READY_WAIT_BEGIN = "allreduce_data_ready_wait_begin"
+AR_DATA_READY_WAIT_END = "allreduce_data_ready_wait_end"
+AR_REDUCE_COPY_BEGIN = "allreduce_reduce_copy_begin"
+AR_REDUCE_COPY_END = "allreduce_reduce_copy_end"
+AR_DRAIN_BEGIN = "allreduce_drain_begin"
+AR_DRAIN_END = "allreduce_drain_end"
+AR_BOOKKEEPING_BEGIN = "allreduce_bookkeeping_begin"
+AR_BOOKKEEPING_END = "allreduce_bookkeeping_end"
+AR_LOCAL_COMPLETION_WAIT_BEGIN = "allreduce_local_completion_wait_begin"
+AR_LOCAL_COMPLETION_WAIT_END = "allreduce_local_completion_wait_end"
+AR_REMOTE_SLOT_FREE_WAIT_BEGIN = "allreduce_remote_slot_free_wait_begin"
+AR_REMOTE_SLOT_FREE_WAIT_END = "allreduce_remote_slot_free_wait_end"
+AR_STAGE_COPY_BEGIN = "allreduce_stage_copy_begin"
+AR_STAGE_COPY_END = "allreduce_stage_copy_end"
+AR_PATH_STAGED = "allreduce_path_staged"
+AR_PATH_REGISTERED_PROGRESS = "allreduce_path_registered_progress"
 
 IB_SEND = "ib_send"
 IB_RECV = "ib_recv"
@@ -75,12 +91,38 @@ AR_PAIRS = {
     AR_PHASE1_END: (AR_PHASE1_BEGIN, "allreduce_phase1", "input/reduce-scatter"),
     AR_PHASE2_END: (AR_PHASE2_BEGIN, "allreduce_phase2", "inter-node"),
     AR_PHASE3_END: (AR_PHASE3_BEGIN, "allreduce_phase3", "output/all-gather"),
-    AR_RING_RS_END: (AR_RING_RS_BEGIN, "allreduce_ring_rs", "ring reduce-scatter"),
-    AR_RING_AG_END: (AR_RING_AG_BEGIN, "allreduce_ring_ag", "ring all-gather"),
 }
 AR_BEGIN_NAMES = frozenset(v[0] for v in AR_PAIRS.values())
 AR_NAMES = frozenset(AR_PAIRS) | AR_BEGIN_NAMES
-KNOWN_EVENT_NAMES = IB_NAMES | NVL_NAMES | AR_NAMES
+FINE_AR_PAIRS = {
+    AR_SEND_SYNC_END: (AR_SEND_SYNC_BEGIN, "send sync"),
+    AR_WQE_SUBMIT_END: (AR_WQE_SUBMIT_BEGIN, "WQE submit"),
+    AR_DATA_READY_WAIT_END: (AR_DATA_READY_WAIT_BEGIN, "DATA_READY wait"),
+    AR_REDUCE_COPY_END: (AR_REDUCE_COPY_BEGIN, "reduce/copy"),
+    AR_DRAIN_END: (AR_DRAIN_BEGIN, "registered drain"),
+    AR_BOOKKEEPING_END: (AR_BOOKKEEPING_BEGIN, "bookkeeping"),
+    AR_LOCAL_COMPLETION_WAIT_END: (
+        AR_LOCAL_COMPLETION_WAIT_BEGIN,
+        "local completion wait",
+    ),
+    AR_REMOTE_SLOT_FREE_WAIT_END: (
+        AR_REMOTE_SLOT_FREE_WAIT_BEGIN,
+        "remote SLOT_FREE wait",
+    ),
+    AR_STAGE_COPY_END: (AR_STAGE_COPY_BEGIN, "staging copy"),
+}
+FINE_AR_PATHS = {
+    AR_PATH_STAGED: "path: staged",
+    AR_PATH_REGISTERED_PROGRESS: "path: registered progress",
+}
+FINE_AR_NAMES = (
+    frozenset(FINE_AR_PAIRS)
+    | frozenset(v[0] for v in FINE_AR_PAIRS.values())
+    | frozenset(FINE_AR_PATHS)
+)
+FINE_AR_BEGIN_NAMES = frozenset(v[0] for v in FINE_AR_PAIRS.values())
+ALL_AR_NAMES = AR_NAMES | FINE_AR_NAMES
+KNOWN_EVENT_NAMES = IB_NAMES | NVL_NAMES | ALL_AR_NAMES
 
 # `detail` is uint16_t, so one full uint16 range per kind makes track IDs
 # disjoint for every representable block index.
@@ -105,6 +147,20 @@ EVENT_RE: re.Pattern[str] = re.compile(
     r" step=(?P<step>\d+)"
     r" rank=(?P<rank>-?\d+)"
     r" detail=(?P<detail>\d+)"
+    r" slot=(?P<slot>\d+)"
+    r" wall_time_ns=(?P<ns>\d+)\s*$"
+)
+
+FINE_EVENT_RE: re.Pattern[str] = re.compile(
+    _PREFIX + rf"[^\[]*?{_MAST_STREAM_WRAPPER}Prims fine trace event=(?P<name>\w+)"
+    r" rank=(?P<rank>\d+)"
+    r" phase=(?P<phase>\w+)"
+    r" dependency_step=(?P<dependency_step>\d+)"
+    r" stripe=(?P<stripe>\d+)"
+    r" lane=(?P<lane>\d+)"
+    r" peer=(?P<peer>\d+)"
+    r" qp_lane=(?P<qp_lane>\d+)"
+    r" bytes=(?P<bytes>\d+)"
     r" slot=(?P<slot>\d+)"
     r" wall_time_ns=(?P<ns>\d+)\s*$"
 )
@@ -136,6 +192,13 @@ class Event:
     group: int  # detail = group.group_id
     slot: int
     ns: int
+    phase: str | None = None
+    dependency_step: int = 0
+    stripe: int = 0
+    lane: int = 0
+    peer: int = 0
+    qp_lane: int = 0
+    bytes: int = 0
 
 
 @dataclasses.dataclass
@@ -162,6 +225,7 @@ class Slice_:
     begin_ns: int
     end_ns: int
     args: dict[str, object]
+    instant: bool = False
 
 
 @dataclasses.dataclass
@@ -193,6 +257,9 @@ class PairState:
     pending_allreduce: dict[tuple[str, int, int], Event] = dataclasses.field(
         default_factory=dict
     )
+    pending_fine_allreduce: dict[
+        tuple[str, str, int, int, int, int, int, int], Event
+    ] = dataclasses.field(default_factory=dict)
 
 
 def _open_log(path: str) -> TextIO:
@@ -214,25 +281,48 @@ def _detect_nvl_from_mpirun(line: str) -> int | None:
 
 def _parse_event_line(line: str) -> Event | None:
     m = EVENT_RE.fullmatch(line)
-    if m is None:
+    if m is not None:
+        name = m["name"]
+        if name not in KNOWN_EVENT_NAMES:
+            return None
+        prefix_rank = m["mpi_rank"] or m["mast_rank"]
+        return Event(
+            mpi_rank=int(prefix_rank),
+            name=name,
+            step=int(m["step"]),
+            rank=int(m["rank"]),
+            group=int(m["detail"]),
+            slot=int(m["slot"]),
+            ns=int(m["ns"]),
+        )
+
+    fine = FINE_EVENT_RE.fullmatch(line)
+    if fine is None or fine["name"] not in FINE_AR_NAMES:
         return None
-    name = m["name"]
-    if name not in KNOWN_EVENT_NAMES:
-        return None
-    prefix_rank = m["mpi_rank"] or m["mast_rank"]
+    dependency_step = int(fine["dependency_step"])
+    stripe = int(fine["stripe"])
+    peer = int(fine["peer"])
+    fine_prefix_rank = fine["mpi_rank"] or fine["mast_rank"]
     return Event(
-        mpi_rank=int(prefix_rank),
-        name=name,
-        step=int(m["step"]),
-        rank=int(m["rank"]),
-        group=int(m["detail"]),
-        slot=int(m["slot"]),
-        ns=int(m["ns"]),
+        mpi_rank=int(fine_prefix_rank),
+        name=fine["name"],
+        step=dependency_step,
+        rank=peer,
+        group=stripe,
+        slot=int(fine["slot"]),
+        ns=int(fine["ns"]),
+        phase=fine["phase"],
+        dependency_step=dependency_step,
+        stripe=stripe,
+        lane=int(fine["lane"]),
+        peer=peer,
+        qp_lane=int(fine["qp_lane"]),
+        bytes=int(fine["bytes"]),
     )
 
 
 def _is_trace_line(line: str) -> bool:
-    return "Prims trace" in line or "Pipes trace" in line
+    return "Prims trace" in line or "Prims fine trace" in line or "Pipes trace" in line
 
 
 def parse_events(
@@ -305,7 +395,7 @@ def filter_events(
             continue
         if "nvl" not in type_filter and e.name in NVL_NAMES:
             continue
-        if "allreduce" not in type_filter and e.name in AR_NAMES:
+        if "allreduce" not in type_filter and e.name in ALL_AR_NAMES:
             continue
         if time_start is not None and e.ns < time_start:
             continue
@@ -575,6 +665,8 @@ def _drain_state(state: PairState, unmatched: list[tuple[Event, str]]) -> None:
         unmatched.append((event, f"{event.name} without matching end"))
     for _, event in state.pending_allreduce.items():
         unmatched.append((event, f"{event.name} without matching end"))
+    for _, event in state.pending_fine_allreduce.items():
+        unmatched.append((event, f"{event.name} without matching end"))
 
 
 def _handle_allreduce_event(
@@ -613,6 +705,93 @@ def _handle_allreduce_event(
                 "end_ns": e.ns,
                 "dur_ns": e.ns - begin.ns,
             },
+        )
+    )
+
+
+def _fine_allreduce_key(
+    e: Event, begin_name: str
+) -> tuple[str, str, int, int, int, int, int, int]:
+    return (
+        begin_name,
+        e.phase or "unknown",
+        e.dependency_step,
+        e.stripe,
+        e.lane,
+        e.peer,
+        e.qp_lane,
+        e.bytes,
+    )
+
+
+def _fine_allreduce_args(e: Event) -> dict[str, object]:
+    return {
+        "phase": e.phase or "unknown",
+        "dependency_step": e.dependency_step,
+        "stripe": e.stripe,
+        "lane": e.lane,
+        "peer": e.peer,
+        "qp_lane": e.qp_lane,
+        "bytes": e.bytes,
+        "slot": e.slot,
+        "wall_time_ns": e.ns,
+    }
+
+
+def _handle_fine_allreduce_event(
+    state: PairState,
+    e: Event,
+    slices: list[Slice_],
+    unmatched: list[tuple[Event, str]],
+) -> None:
+    path_name = FINE_AR_PATHS.get(e.name)
+    if path_name is not None:
+        slices.append(
+            Slice_(
+                pid=state.mpi_rank,
+                tid=THREAD_OFFSET_AR + e.stripe,
+                cat="allreduce_path",
+                name=path_name,
+                begin_ns=e.ns,
+                end_ns=e.ns,
+                args=_fine_allreduce_args(e),
+                instant=True,
+            )
+        )
+        return
+
+    if e.name in FINE_AR_BEGIN_NAMES:
+        key = _fine_allreduce_key(e, e.name)
+        previous = state.pending_fine_allreduce.get(key)
+        if previous is not None:
+            unmatched.append((previous, f"{previous.name} without matching end"))
+        state.pending_fine_allreduce[key] = e
+        return
+
+    begin_name, display_name = FINE_AR_PAIRS[e.name]
+    begin = state.pending_fine_allreduce.pop(_fine_allreduce_key(e, begin_name), None)
+    if begin is None:
+        unmatched.append((e, f"{e.name} without matching begin"))
+        return
+    event_args = _fine_allreduce_args(e)
+    event_args.update(
+        {
+            "slot_begin": begin.slot,
+            "slot_end": e.slot,
+            "begin_ns": begin.ns,
+            "end_ns": e.ns,
+            "dur_ns": e.ns - begin.ns,
+        }
+    )
+    slices.append(
+        Slice_(
+            pid=state.mpi_rank,
+            tid=THREAD_OFFSET_AR + e.stripe,
+            cat="allreduce_fine",
+            name=display_name,
+            begin_ns=begin.ns,
+            end_ns=e.ns,
+            args=event_args,
         )
     )
 
@@ -686,6 +865,8 @@ def pair_events(
                 _handle_nvl_event(state, e, slices, unmatched)
             elif e.name in AR_NAMES:
                 _handle_allreduce_event(state, e, slices, unmatched)
+            elif e.name in FINE_AR_NAMES:
+                _handle_fine_allreduce_event(state, e, slices, unmatched)
             else:
                 unmatched.append((e, f"unknown event name {e.name!r}"))
         _drain_state(state, unmatched)
@@ -769,6 +950,20 @@ def build_trace(
     trace_events: list[dict[str, object]] = _emit_metadata(pids, used_tids, topology)
 
     for s in slices:
+        if s.instant:
+            trace_events.append(
+                {
+                    "ph": "i",
+                    "s": "t",
+                    "name": s.name,
+                    "cat": s.cat,
+                    "pid": s.pid,
+                    "tid": s.tid,
+                    "ts": (s.begin_ns - min_ns) / 1000.0,
+                    "args": s.args,
+                }
+            )
+            continue
         trace_events.append(
             {
                 "ph": "X",
@@ -828,7 +1023,7 @@ def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="pipestrace_to_perfetto",
         description=(
-            "Convert supported hierarchical-allgather PipesTrace log lines "
+            "Convert supported collective PipesTrace log lines "
             "into a Perfetto / Chrome Trace Event JSON timeline that can be "
             "opened at https://ui.perfetto.dev/."
         ),

--- a/comms/pipes/scripts/pipestrace_to_perfetto.py
+++ b/comms/pipes/scripts/pipestrace_to_perfetto.py
@@ -43,6 +43,16 @@ IB_RECV_BEGIN = "ib_recv_begin"
 IB_RECV_END = "ib_recv_end"
 IB_FORWARD_BEGIN = "ib_forward_begin"
 IB_FORWARD_END = "ib_forward_end"
+AR_PHASE1_BEGIN = "allreduce_phase1_begin"
+AR_PHASE1_END = "allreduce_phase1_end"
+AR_PHASE2_BEGIN = "allreduce_phase2_begin"
+AR_PHASE2_END = "allreduce_phase2_end"
+AR_PHASE3_BEGIN = "allreduce_phase3_begin"
+AR_PHASE3_END = "allreduce_phase3_end"
+AR_RING_RS_BEGIN = "allreduce_ring_rs_begin"
+AR_RING_RS_END = "allreduce_ring_rs_end"
+AR_RING_AG_BEGIN = "allreduce_ring_ag_begin"
+AR_RING_AG_END = "allreduce_ring_ag_end"
 
 IB_SEND = "ib_send"
 IB_RECV = "ib_recv"
@@ -61,14 +71,29 @@ IB_NAMES = frozenset(
     }
 )
 NVL_NAMES = frozenset({AG_NVL_WAIT_BEGIN, AG_NVL_CHUNK_READY, AG_NVL_TASK_DONE})
-KNOWN_EVENT_NAMES = IB_NAMES | NVL_NAMES
+AR_PAIRS = {
+    AR_PHASE1_END: (AR_PHASE1_BEGIN, "allreduce_phase1", "input/reduce-scatter"),
+    AR_PHASE2_END: (AR_PHASE2_BEGIN, "allreduce_phase2", "inter-node"),
+    AR_PHASE3_END: (AR_PHASE3_BEGIN, "allreduce_phase3", "output/all-gather"),
+    AR_RING_RS_END: (AR_RING_RS_BEGIN, "allreduce_ring_rs", "ring reduce-scatter"),
+    AR_RING_AG_END: (AR_RING_AG_BEGIN, "allreduce_ring_ag", "ring all-gather"),
+}
+AR_BEGIN_NAMES = frozenset(v[0] for v in AR_PAIRS.values())
+AR_NAMES = frozenset(AR_PAIRS) | AR_BEGIN_NAMES
+KNOWN_EVENT_NAMES = IB_NAMES | NVL_NAMES | AR_NAMES
 
-# +100/+200 keep IB and NVL tracks visually grouped per process, with room
-# for additional virtual tracks without colliding.
+# `detail` is uint16_t, so one full uint16 range per kind makes track IDs
+# disjoint for every representable block index.
+THREAD_KIND_STRIDE = 1 << 16
 THREAD_OFFSET_IB = 100
-THREAD_OFFSET_NVL = 200
+THREAD_OFFSET_NVL = THREAD_OFFSET_IB + THREAD_KIND_STRIDE
+THREAD_OFFSET_AR = THREAD_OFFSET_NVL + THREAD_KIND_STRIDE
 
-_PREFIX = r"^\[1,(?P<mpi_rank>\d+)\]<(?:stderr|stdout)>:"
+_PREFIX = (
+    r"^(?:\[1,(?P<mpi_rank>\d+)\]<(?:stderr|stdout)>:"
+    r"|\[(?P<mast_rank>\d+)\]:)"
+)
+_MAST_STREAM_WRAPPER = r"(?:\[(?:stderr|stdout)\]\s*)?"
 _TRACE_LOG_PREFIX = r"(?:Prims|Pipes) trace"
 
 # `[^\[]*?` forbids a stray "[" in the gap between rank prefix and the trace
@@ -76,7 +101,7 @@ _TRACE_LOG_PREFIX = r"(?:Prims|Pipes) trace"
 # mid-line under load. Without this, the regex would backtrack across the
 # splice and synthesize a wrong-rank event.
 EVENT_RE: re.Pattern[str] = re.compile(
-    _PREFIX + rf"[^\[]*?{_TRACE_LOG_PREFIX} event=(?P<name>\w+)"
+    _PREFIX + rf"[^\[]*?{_MAST_STREAM_WRAPPER}{_TRACE_LOG_PREFIX} event=(?P<name>\w+)"
     r" step=(?P<step>\d+)"
     r" rank=(?P<rank>-?\d+)"
     r" detail=(?P<detail>\d+)"
@@ -85,11 +110,13 @@ EVENT_RE: re.Pattern[str] = re.compile(
 )
 
 LOSS_RE: re.Pattern[str] = re.compile(
-    _PREFIX + rf"[^\[]*?{_TRACE_LOG_PREFIX} lost (?P<lost>\d+) entries\s*$"
+    _PREFIX
+    + rf"[^\[]*?{_MAST_STREAM_WRAPPER}{_TRACE_LOG_PREFIX} lost (?P<lost>\d+) entries\s*$"
 )
 
 LEGACY_DRAIN_RE: re.Pattern[str] = re.compile(
-    _PREFIX + rf"[^\[]*?{_TRACE_LOG_PREFIX} drain entries_read=(?P<read>\d+)"
+    _PREFIX
+    + rf"[^\[]*?{_MAST_STREAM_WRAPPER}{_TRACE_LOG_PREFIX} drain entries_read=(?P<read>\d+)"
     r" entries_lost=(?P<lost>\d+)"
     r" last_read=(?P<last>\d+)\s*$"
 )
@@ -163,6 +190,9 @@ class PairState:
     pending_ib_forward: dict[tuple[int, int], Event] = dataclasses.field(
         default_factory=dict
     )
+    pending_allreduce: dict[tuple[str, int, int], Event] = dataclasses.field(
+        default_factory=dict
+    )
 
 
 def _open_log(path: str) -> TextIO:
@@ -189,8 +219,9 @@ def _parse_event_line(line: str) -> Event | None:
     name = m["name"]
     if name not in KNOWN_EVENT_NAMES:
         return None
+    prefix_rank = m["mpi_rank"] or m["mast_rank"]
     return Event(
-        mpi_rank=int(m["mpi_rank"]),
+        mpi_rank=int(prefix_rank),
         name=name,
         step=int(m["step"]),
         rank=int(m["rank"]),
@@ -273,6 +304,8 @@ def filter_events(
         if "ib" not in type_filter and e.name in IB_NAMES:
             continue
         if "nvl" not in type_filter and e.name in NVL_NAMES:
+            continue
+        if "allreduce" not in type_filter and e.name in AR_NAMES:
             continue
         if time_start is not None and e.ns < time_start:
             continue
@@ -540,6 +573,48 @@ def _drain_state(state: PairState, unmatched: list[tuple[Event, str]]) -> None:
         unmatched.append((event, f"{event.name} without matching end"))
     for _, event in state.pending_ib_forward.items():
         unmatched.append((event, f"{event.name} without matching end"))
+    for _, event in state.pending_allreduce.items():
+        unmatched.append((event, f"{event.name} without matching end"))
+
+
+def _handle_allreduce_event(
+    state: PairState,
+    e: Event,
+    slices: list[Slice_],
+    unmatched: list[tuple[Event, str]],
+) -> None:
+    if e.name in AR_BEGIN_NAMES:
+        key = (e.name, e.group, e.step)
+        previous = state.pending_allreduce.get(key)
+        if previous is not None:
+            unmatched.append((previous, f"{previous.name} without matching end"))
+        state.pending_allreduce[key] = e
+        return
+
+    begin_name, category, display_name = AR_PAIRS[e.name]
+    begin = state.pending_allreduce.pop((begin_name, e.group, e.step), None)
+    if begin is None:
+        unmatched.append((e, f"{e.name} without matching begin"))
+        return
+    slices.append(
+        Slice_(
+            pid=state.mpi_rank,
+            tid=THREAD_OFFSET_AR + e.group,
+            cat=category,
+            name=display_name,
+            begin_ns=begin.ns,
+            end_ns=e.ns,
+            args={
+                "block": e.group,
+                "step": e.step,
+                "slot_begin": begin.slot,
+                "slot_end": e.slot,
+                "begin_ns": begin.ns,
+                "end_ns": e.ns,
+                "dur_ns": e.ns - begin.ns,
+            },
+        )
+    )
 
 
 def _handle_ib_event(
@@ -609,6 +684,8 @@ def pair_events(
                 unpaired_instant_count += _handle_ib_event(state, e, slices, unmatched)
             elif e.name in NVL_NAMES:
                 _handle_nvl_event(state, e, slices, unmatched)
+            elif e.name in AR_NAMES:
+                _handle_allreduce_event(state, e, slices, unmatched)
             else:
                 unmatched.append((e, f"unknown event name {e.name!r}"))
         _drain_state(state, unmatched)
@@ -654,7 +731,9 @@ def _emit_metadata(
             }
         )
         for tid in sorted(used_tids.get(pid, set())):
-            if tid >= THREAD_OFFSET_NVL:
+            if tid >= THREAD_OFFSET_AR:
+                kind, block = "AllReduce", tid - THREAD_OFFSET_AR
+            elif tid >= THREAD_OFFSET_NVL:
                 kind, block = "NVL", tid - THREAD_OFFSET_NVL
             else:
                 kind, block = "IB", tid - THREAD_OFFSET_IB
@@ -790,8 +869,8 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--types",
         type=parse_csv_strs,
-        default={"ib", "nvl"},
-        help="Block kinds to include: ib,nvl. Default: ib,nvl.",
+        default={"ib", "nvl", "allreduce"},
+        help=("Block kinds to include: ib,nvl,allreduce. Default: ib,nvl,allreduce."),
     )
     p.add_argument(
         "--time-start",
@@ -823,8 +902,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         format="%(levelname)s %(name)s: %(message)s",
     )
 
-    if "ib" not in args.types and "nvl" not in args.types:
-        logger.error("--types must include at least one of ib,nvl")
+    if not args.types.intersection({"ib", "nvl", "allreduce"}):
+        logger.error("--types must include at least one of ib,nvl,allreduce")
         return 1
 
     stats = ParseStats()

--- a/comms/pipes/scripts/tests/test_pipestrace_to_perfetto.py
+++ b/comms/pipes/scripts/tests/test_pipestrace_to_perfetto.py
@@ -38,6 +38,38 @@ def _loss_line(rank: int, lost: int) -> str:
     )
 
 
+def _mast_event_line(
+    local_rank: int,
+    name: str,
+    step: int,
+    comm_rank: int,
+    detail: int,
+    slot: int,
+    ns: int,
+) -> str:
+    return (
+        f"[{local_rank}]:I0531 12:00:00.000000 1234 PipesTrace.cc:168] "
+        f"Prims trace event={name} step={step} rank={comm_rank} "
+        f"detail={detail} slot={slot} wall_time_ns={ns}\n"
+    )
+
+
+def _mast_wrapped_event_line(
+    local_rank: int,
+    name: str,
+    step: int,
+    comm_rank: int,
+    detail: int,
+    slot: int,
+    ns: int,
+) -> str:
+    return (
+        f"[{local_rank}]:INFO:root:[stderr] Prims trace event={name} "
+        f"step={step} rank={comm_rank} detail={detail} slot={slot} "
+        f"wall_time_ns={ns}\n"
+    )
+
+
 class EventRegexTest(unittest.TestCase):
     def test_matches_well_formed_event(self) -> None:
         line = _event_line(7, ptp.AG_IB_BEGIN, 3, 3, 0, 0, 1780268274964010916)
@@ -61,6 +93,22 @@ class EventRegexTest(unittest.TestCase):
         assert event is not None
         self.assertEqual(0, event.step)
         self.assertEqual(-1, event.rank)
+
+    def test_allreduce_mast_line_uses_log_prefix_rank(self) -> None:
+        line = _mast_event_line(0, ptp.AR_PHASE2_BEGIN, 0, 3, 0, 0, 100)
+        event = ptp._parse_event_line(line)
+        self.assertIsNotNone(event)
+        assert event is not None
+        self.assertEqual(0, event.mpi_rank)
+        self.assertEqual(ptp.AR_PHASE2_BEGIN, event.name)
+
+    def test_allreduce_mast_stream_wrapper(self) -> None:
+        line = _mast_wrapped_event_line(0, ptp.AR_PHASE2_BEGIN, 7, 3, 2, 11, 100)
+        event = ptp._parse_event_line(line)
+        self.assertIsNotNone(event)
+        assert event is not None
+        self.assertEqual(0, event.mpi_rank)
+        self.assertEqual(2, event.group)
 
 
 class ParseEventsTest(unittest.TestCase):
@@ -188,6 +236,27 @@ class PairNvlTest(unittest.TestCase):
         self.assertEqual([], slices)
         self.assertEqual(1, len(unmatched))
         self.assertIn("task_done", unmatched[0][1])
+
+
+class PairAllReduceTest(unittest.TestCase):
+    def test_phase_and_nested_ring_slices(self) -> None:
+        evs = [
+            ptp.Event(3, ptp.AR_PHASE2_BEGIN, 0, 3, 0, 0, 100),
+            ptp.Event(3, ptp.AR_RING_RS_BEGIN, 0, 3, 0, 1, 110),
+            ptp.Event(3, ptp.AR_RING_RS_END, 0, 3, 0, 2, 150),
+            ptp.Event(3, ptp.AR_RING_AG_BEGIN, 0, 3, 0, 3, 160),
+            ptp.Event(3, ptp.AR_RING_AG_END, 0, 3, 0, 4, 190),
+            ptp.Event(3, ptp.AR_PHASE2_END, 0, 3, 0, 5, 200),
+        ]
+        slices, unpaired_instant_count, unmatched = ptp.pair_events({3: evs})
+        self.assertEqual(0, unpaired_instant_count)
+        self.assertEqual([], unmatched)
+        self.assertCountEqual(
+            ["inter-node", "ring reduce-scatter", "ring all-gather"],
+            [s.name for s in slices],
+        )
+        phase2 = next(s for s in slices if s.name == "inter-node")
+        self.assertEqual(100, phase2.args["dur_ns"])
 
 
 class BuildTraceTest(unittest.TestCase):

--- a/comms/pipes/scripts/tests/test_pipestrace_to_perfetto.py
+++ b/comms/pipes/scripts/tests/test_pipestrace_to_perfetto.py
@@ -38,6 +38,28 @@ def _loss_line(rank: int, lost: int) -> str:
     )
 
 
+def _fine_event_line(
+    local_rank: int,
+    name: str,
+    comm_rank: int,
+    phase: str,
+    dependency_step: int,
+    stripe: int,
+    lane: int,
+    peer: int,
+    qp_lane: int,
+    bytes_: int,
+    slot: int,
+    ns: int,
+) -> str:
+    return (
+        f"[{local_rank}]:INFO:root:[stderr] Prims fine trace event={name} "
+        f"rank={comm_rank} phase={phase} dependency_step={dependency_step} "
+        f"stripe={stripe} lane={lane} peer={peer} qp_lane={qp_lane} "
+        f"bytes={bytes_} slot={slot} wall_time_ns={ns}\n"
+    )
+
+
 def _mast_event_line(
     local_rank: int,
     name: str,
@@ -110,6 +132,33 @@ class EventRegexTest(unittest.TestCase):
         self.assertEqual(0, event.mpi_rank)
         self.assertEqual(2, event.group)
 
+    def test_fine_allreduce_line_uses_structured_context(self) -> None:
+        line = _fine_event_line(
+            0,
+            ptp.AR_WQE_SUBMIT_BEGIN,
+            3,
+            "ring_reduce_scatter",
+            2,
+            1,
+            4,
+            7,
+            5,
+            4096,
+            11,
+            100,
+        )
+        event = ptp._parse_event_line(line)
+        self.assertIsNotNone(event)
+        assert event is not None
+        self.assertEqual(0, event.mpi_rank)
+        self.assertEqual("ring_reduce_scatter", event.phase)
+        self.assertEqual(2, event.dependency_step)
+        self.assertEqual(1, event.stripe)
+        self.assertEqual(4, event.lane)
+        self.assertEqual(7, event.peer)
+        self.assertEqual(5, event.qp_lane)
+        self.assertEqual(4096, event.bytes)
+
 
 class ParseEventsTest(unittest.TestCase):
     def test_concatenated_tagged_events_are_dropped(self) -> None:
@@ -138,6 +187,30 @@ class ParseEventsTest(unittest.TestCase):
         self.assertEqual(1, len(events))
         self.assertEqual(1, stats.loss_reports)
         self.assertEqual(3, stats.lost_entries)
+
+    def test_malformed_fine_trace_is_counted_as_dropped(self) -> None:
+        log = _fine_event_line(
+            0,
+            ptp.AR_PATH_STAGED,
+            0,
+            "tree_reduce",
+            0,
+            0,
+            0,
+            1,
+            0,
+            4096,
+            0,
+            100,
+        ).replace(" peer=1", "")
+        with tempfile.TemporaryDirectory() as d:
+            log_path = os.path.join(d, "x.log")
+            with open(log_path, "w") as f:
+                f.write(log)
+            stats = ptp.ParseStats()
+            events, _ = ptp.parse_events([log_path], stats)
+        self.assertEqual([], events)
+        self.assertEqual(1, stats.dropped_lines)
 
 
 class FilterEventsTest(unittest.TestCase):
@@ -239,24 +312,69 @@ class PairNvlTest(unittest.TestCase):
 
 
 class PairAllReduceTest(unittest.TestCase):
-    def test_phase_and_nested_ring_slices(self) -> None:
+    def test_phase_slice(self) -> None:
         evs = [
             ptp.Event(3, ptp.AR_PHASE2_BEGIN, 0, 3, 0, 0, 100),
-            ptp.Event(3, ptp.AR_RING_RS_BEGIN, 0, 3, 0, 1, 110),
-            ptp.Event(3, ptp.AR_RING_RS_END, 0, 3, 0, 2, 150),
-            ptp.Event(3, ptp.AR_RING_AG_BEGIN, 0, 3, 0, 3, 160),
-            ptp.Event(3, ptp.AR_RING_AG_END, 0, 3, 0, 4, 190),
-            ptp.Event(3, ptp.AR_PHASE2_END, 0, 3, 0, 5, 200),
+            ptp.Event(3, ptp.AR_PHASE2_END, 0, 3, 0, 1, 200),
         ]
         slices, unpaired_instant_count, unmatched = ptp.pair_events({3: evs})
         self.assertEqual(0, unpaired_instant_count)
         self.assertEqual([], unmatched)
-        self.assertCountEqual(
-            ["inter-node", "ring reduce-scatter", "ring all-gather"],
-            [s.name for s in slices],
-        )
-        phase2 = next(s for s in slices if s.name == "inter-node")
+        self.assertEqual(["inter-node"], [s.name for s in slices])
+        phase2 = slices[0]
         self.assertEqual(100, phase2.args["dur_ns"])
+
+    def test_fine_span_and_actual_path_marker(self) -> None:
+        common = {
+            "mpi_rank": 3,
+            "step": 2,
+            "rank": 7,
+            "group": 1,
+            "phase": "ring_reduce_scatter",
+            "dependency_step": 2,
+            "stripe": 1,
+            "lane": 4,
+            "peer": 7,
+            "qp_lane": 5,
+            "bytes": 4096,
+        }
+        evs = [
+            ptp.Event(
+                name=ptp.AR_PATH_REGISTERED_PROGRESS,
+                slot=9,
+                ns=90,
+                **common,
+            ),
+            ptp.Event(name=ptp.AR_WQE_SUBMIT_BEGIN, slot=10, ns=100, **common),
+            ptp.Event(name=ptp.AR_WQE_SUBMIT_END, slot=11, ns=140, **common),
+        ]
+        slices, unpaired_instant_count, unmatched = ptp.pair_events({3: evs})
+        self.assertEqual(0, unpaired_instant_count)
+        self.assertEqual([], unmatched)
+        path = next(s for s in slices if s.instant)
+        self.assertEqual("path: registered progress", path.name)
+        wqe = next(s for s in slices if not s.instant)
+        self.assertEqual("WQE submit", wqe.name)
+        self.assertEqual((100, 140), (wqe.begin_ns, wqe.end_ns))
+        self.assertEqual(7, wqe.args["peer"])
+        self.assertEqual(5, wqe.args["qp_lane"])
+
+    def test_unmatched_fine_begin_is_reported(self) -> None:
+        event = ptp.Event(
+            mpi_rank=0,
+            name=ptp.AR_STAGE_COPY_BEGIN,
+            step=0,
+            rank=1,
+            group=0,
+            slot=0,
+            ns=100,
+            phase="tree_reduce",
+            peer=1,
+            bytes=4096,
+        )
+        _, _, unmatched = ptp.pair_events({0: [event]})
+        self.assertEqual(1, len(unmatched))
+        self.assertIn("without matching end", unmatched[0][1])
 
 
 class BuildTraceTest(unittest.TestCase):
@@ -335,6 +453,66 @@ class EndToEndCliTest(unittest.TestCase):
             self.assertEqual(0, rc)
         self.assertTrue(
             any("1 unpaired instants suppressed" in message for message in logs.output)
+        )
+
+    def test_fine_allreduce_emits_path_instant_and_span(self) -> None:
+        log = _fine_event_line(
+            0,
+            ptp.AR_PATH_STAGED,
+            0,
+            "tree_reduce",
+            1,
+            2,
+            3,
+            4,
+            5,
+            4096,
+            10,
+            100,
+        )
+        log += _fine_event_line(
+            0,
+            ptp.AR_STAGE_COPY_BEGIN,
+            0,
+            "tree_reduce",
+            1,
+            2,
+            3,
+            4,
+            5,
+            4096,
+            11,
+            110,
+        )
+        log += _fine_event_line(
+            0,
+            ptp.AR_STAGE_COPY_END,
+            0,
+            "tree_reduce",
+            1,
+            2,
+            3,
+            4,
+            5,
+            4096,
+            12,
+            150,
+        )
+        with tempfile.TemporaryDirectory() as d:
+            log_path = os.path.join(d, "x.log")
+            out_path = os.path.join(d, "x.perfetto.json")
+            with open(log_path, "w") as f:
+                f.write(log)
+            rc = ptp.main([log_path, "-o", out_path, "--nvl-size", "1"])
+            self.assertEqual(0, rc)
+            with open(out_path) as f:
+                trace = json.load(f)
+        events = trace["traceEvents"]
+        self.assertTrue(
+            any(e.get("ph") == "i" and e.get("name") == "path: staged" for e in events)
+        )
+        self.assertTrue(
+            any(e.get("ph") == "X" and e.get("name") == "staging copy" for e in events)
         )
 
     def test_strict_returns_2_on_unmatched(self) -> None:

--- a/comms/prims/trace/PipesTrace.cc
+++ b/comms/prims/trace/PipesTrace.cc
@@ -64,6 +64,71 @@ const char* pipesTraceEventTypeName(uint8_t type) {
       return "allreduce_ring_ag_begin";
     case Type::kAllReduceRingAllGatherEnd:
       return "allreduce_ring_ag_end";
+    case Type::kAllReduceSendSyncBegin:
+      return "allreduce_send_sync_begin";
+    case Type::kAllReduceSendSyncEnd:
+      return "allreduce_send_sync_end";
+    case Type::kAllReduceSlotPrepareBegin:
+      return "allreduce_slot_prepare_begin";
+    case Type::kAllReduceSlotPrepareEnd:
+      return "allreduce_slot_prepare_end";
+    case Type::kAllReduceWqeSubmitBegin:
+      return "allreduce_wqe_submit_begin";
+    case Type::kAllReduceWqeSubmitEnd:
+      return "allreduce_wqe_submit_end";
+    case Type::kAllReduceDataReadyWaitBegin:
+      return "allreduce_data_ready_wait_begin";
+    case Type::kAllReduceDataReadyWaitEnd:
+      return "allreduce_data_ready_wait_end";
+    case Type::kAllReduceReduceCopyBegin:
+      return "allreduce_reduce_copy_begin";
+    case Type::kAllReduceReduceCopyEnd:
+      return "allreduce_reduce_copy_end";
+    case Type::kAllReduceDrainBegin:
+      return "allreduce_drain_begin";
+    case Type::kAllReduceDrainEnd:
+      return "allreduce_drain_end";
+    case Type::kAllReduceBookkeepingBegin:
+      return "allreduce_bookkeeping_begin";
+    case Type::kAllReduceBookkeepingEnd:
+      return "allreduce_bookkeeping_end";
+    case Type::kAllReduceLocalCompletionWaitBegin:
+      return "allreduce_local_completion_wait_begin";
+    case Type::kAllReduceLocalCompletionWaitEnd:
+      return "allreduce_local_completion_wait_end";
+    case Type::kAllReduceRemoteSlotFreeWaitBegin:
+      return "allreduce_remote_slot_free_wait_begin";
+    case Type::kAllReduceRemoteSlotFreeWaitEnd:
+      return "allreduce_remote_slot_free_wait_end";
+    case Type::kAllReduceStageCopyBegin:
+      return "allreduce_stage_copy_begin";
+    case Type::kAllReduceStageCopyEnd:
+      return "allreduce_stage_copy_end";
+    case Type::kAllReducePathStaged:
+      return "allreduce_path_staged";
+    case Type::kAllReducePathRegisteredProgress:
+      return "allreduce_path_registered_progress";
+  }
+  return "unknown";
+}
+
+bool isFineAllReduceEvent(uint8_t type) {
+  using Type = PipesTraceEventType;
+  return type >= static_cast<uint8_t>(Type::kAllReduceSendSyncBegin) &&
+      type <= static_cast<uint8_t>(Type::kAllReducePathRegisteredProgress);
+}
+
+const char* allReducePhaseName(uint32_t phase) {
+  using Phase = PipesTraceAllReducePhase;
+  switch (static_cast<Phase>(phase)) {
+    case Phase::RingReduceScatter:
+      return "ring_reduce_scatter";
+    case Phase::RingAllGather:
+      return "ring_all_gather";
+    case Phase::TreeReduce:
+      return "tree_reduce";
+    case Phase::TreeBroadcast:
+      return "tree_broadcast";
   }
   return "unknown";
 }
@@ -191,6 +256,30 @@ void PipesTrace::logBatch(const PendingLogBatch& batch) const {
             wallTime.time_since_epoch())
             .count();
     const auto& event = entry.data;
+    if (isFineAllReduceEvent(event.type)) {
+      const uint32_t packed = event.step;
+      const uint32_t phase =
+          (packed >> kPipesTracePhaseShift) & kPipesTracePhaseMask;
+      std::fprintf(
+          stderr,
+          "Prims fine trace event=%s rank=%u phase=%s dependency_step=%u stripe=%u lane=%u peer=%u qp_lane=%u bytes=%u slot=%llu wall_time_ns=%lld\n",
+          pipesTraceEventTypeName(event.type),
+          static_cast<unsigned int>(event.rank),
+          allReducePhaseName(phase),
+          (packed >> kPipesTraceDependencyStepShift) &
+              kPipesTraceDependencyStepMask,
+          (packed >> kPipesTraceStripeShift) & kPipesTraceStripeMask,
+          (packed >> kPipesTraceLaneShift) & kPipesTraceLaneMask,
+          (packed >> kPipesTracePeerShift) & kPipesTracePeerMask,
+          (packed >> kPipesTraceQpLaneShift) & kPipesTraceQpLaneMask,
+          static_cast<unsigned int>(event.detail) * kPipesTraceBytesQuantum,
+          static_cast<unsigned long long>(pendingEntry.slot),
+          static_cast<long long>(wallTimeNs));
+      if (eventCallback_ != nullptr) {
+        eventCallback_(event, pendingEntry.slot);
+      }
+      continue;
+    }
     std::fprintf(
         stderr,
         "Prims trace event=%s step=%u rank=%u detail=%u slot=%llu wall_time_ns=%lld\n",

--- a/comms/prims/trace/PipesTrace.cc
+++ b/comms/prims/trace/PipesTrace.cc
@@ -5,6 +5,7 @@
 #include <pthread.h>
 
 #include <chrono>
+#include <cstdio>
 #include <exception>
 #include <memory>
 #include <mutex>
@@ -43,6 +44,26 @@ const char* pipesTraceEventTypeName(uint8_t type) {
       return "ib_forward_begin";
     case Type::kIbForwardEnd:
       return "ib_forward_end";
+    case Type::kAllReducePhase1Begin:
+      return "allreduce_phase1_begin";
+    case Type::kAllReducePhase1End:
+      return "allreduce_phase1_end";
+    case Type::kAllReducePhase2Begin:
+      return "allreduce_phase2_begin";
+    case Type::kAllReducePhase2End:
+      return "allreduce_phase2_end";
+    case Type::kAllReducePhase3Begin:
+      return "allreduce_phase3_begin";
+    case Type::kAllReducePhase3End:
+      return "allreduce_phase3_end";
+    case Type::kAllReduceRingReduceScatterBegin:
+      return "allreduce_ring_rs_begin";
+    case Type::kAllReduceRingReduceScatterEnd:
+      return "allreduce_ring_rs_end";
+    case Type::kAllReduceRingAllGatherBegin:
+      return "allreduce_ring_ag_begin";
+    case Type::kAllReduceRingAllGatherEnd:
+      return "allreduce_ring_ag_end";
   }
   return "unknown";
 }
@@ -119,11 +140,12 @@ void PipesTrace::ensure(
   pollInterval_ = pollInterval;
   eventCallback_ = std::move(eventCallback);
   startPollThread();
-  CLOGF(
-      INFO,
-      "Prims trace buffer ready ring_size={} poll_interval_ms={}",
-      buffer_->size(),
+  std::fprintf(
+      stderr,
+      "Prims trace buffer ready ring_size=%u poll_interval_ms=%lld\n",
+      static_cast<unsigned int>(buffer_->size()),
       static_cast<long long>(pollInterval_.count()));
+  std::fflush(stderr);
 }
 
 PipesTraceHandle PipesTrace::deviceHandle() const {
@@ -169,15 +191,15 @@ void PipesTrace::logBatch(const PendingLogBatch& batch) const {
             wallTime.time_since_epoch())
             .count();
     const auto& event = entry.data;
-    CLOGF(
-        INFO,
-        "Prims trace event={} step={} rank={} detail={} slot={} wall_time_ns={}",
+    std::fprintf(
+        stderr,
+        "Prims trace event=%s step=%u rank=%u detail=%u slot=%llu wall_time_ns=%lld\n",
         pipesTraceEventTypeName(event.type),
         event.step,
-        static_cast<int>(event.rank),
+        static_cast<unsigned int>(event.rank),
         event.detail,
-        pendingEntry.slot,
-        wallTimeNs);
+        static_cast<unsigned long long>(pendingEntry.slot),
+        static_cast<long long>(wallTimeNs));
     if (eventCallback_ != nullptr) {
       eventCallback_(event, pendingEntry.slot);
     }
@@ -185,6 +207,9 @@ void PipesTrace::logBatch(const PendingLogBatch& batch) const {
 
   if (batch.entriesLost != 0) {
     CLOGF(WARN, "Prims trace lost {} entries", batch.entriesLost);
+  }
+  if (!batch.entries.empty()) {
+    std::fflush(stderr);
   }
 }
 

--- a/comms/prims/trace/PipesTraceTypes.h
+++ b/comms/prims/trace/PipesTraceTypes.h
@@ -24,6 +24,17 @@ enum class PipesTraceEventType : uint8_t {
   kIbRecvEnd = 9,
   kIbForwardBegin = 10,
   kIbForwardEnd = 11,
+
+  kAllReducePhase1Begin = 12,
+  kAllReducePhase1End = 13,
+  kAllReducePhase2Begin = 14,
+  kAllReducePhase2End = 15,
+  kAllReducePhase3Begin = 16,
+  kAllReducePhase3End = 17,
+  kAllReduceRingReduceScatterBegin = 18,
+  kAllReduceRingReduceScatterEnd = 19,
+  kAllReduceRingAllGatherBegin = 20,
+  kAllReduceRingAllGatherEnd = 21,
 };
 
 struct PipesTraceEvent {

--- a/comms/prims/trace/PipesTraceTypes.h
+++ b/comms/prims/trace/PipesTraceTypes.h
@@ -35,6 +35,35 @@ enum class PipesTraceEventType : uint8_t {
   kAllReduceRingReduceScatterEnd = 19,
   kAllReduceRingAllGatherBegin = 20,
   kAllReduceRingAllGatherEnd = 21,
+  kAllReduceSendSyncBegin = 22,
+  kAllReduceSendSyncEnd = 23,
+  kAllReduceSlotPrepareBegin = 24,
+  kAllReduceSlotPrepareEnd = 25,
+  kAllReduceWqeSubmitBegin = 26,
+  kAllReduceWqeSubmitEnd = 27,
+  kAllReduceDataReadyWaitBegin = 28,
+  kAllReduceDataReadyWaitEnd = 29,
+  kAllReduceReduceCopyBegin = 30,
+  kAllReduceReduceCopyEnd = 31,
+  kAllReduceDrainBegin = 32,
+  kAllReduceDrainEnd = 33,
+  kAllReduceBookkeepingBegin = 34,
+  kAllReduceBookkeepingEnd = 35,
+  kAllReduceLocalCompletionWaitBegin = 36,
+  kAllReduceLocalCompletionWaitEnd = 37,
+  kAllReduceRemoteSlotFreeWaitBegin = 38,
+  kAllReduceRemoteSlotFreeWaitEnd = 39,
+  kAllReduceStageCopyBegin = 40,
+  kAllReduceStageCopyEnd = 41,
+  kAllReducePathStaged = 42,
+  kAllReducePathRegisteredProgress = 43,
+};
+
+enum class PipesTraceAllReducePhase : uint8_t {
+  RingReduceScatter = 0,
+  RingAllGather = 1,
+  TreeReduce = 2,
+  TreeBroadcast = 3,
 };
 
 struct PipesTraceEvent {
@@ -61,6 +90,38 @@ struct PipesTraceHandle {
   uint32_t mask{0};
   uint32_t shift{0};
 };
+
+struct PipesTraceAllReduceContext {
+  PipesTraceHandle trace;
+  uint8_t rank{0};
+  uint8_t phase{0};
+  uint8_t dependencyStep{0};
+  uint8_t stripe{0};
+  uint8_t lane{0};
+  uint8_t peer{0};
+  uint8_t qpLane{0};
+  uint32_t bytes{0};
+};
+
+struct PipesTraceProgressState {
+  bool localCompletionWaitOpen{false};
+  bool remoteSlotFreeWaitOpen{false};
+  bool dataReadyWaitOpen{false};
+};
+
+inline constexpr uint32_t kPipesTraceDependencyStepShift = 0;
+inline constexpr uint32_t kPipesTraceStripeShift = 6;
+inline constexpr uint32_t kPipesTraceLaneShift = 10;
+inline constexpr uint32_t kPipesTracePeerShift = 14;
+inline constexpr uint32_t kPipesTraceQpLaneShift = 22;
+inline constexpr uint32_t kPipesTracePhaseShift = 28;
+inline constexpr uint32_t kPipesTraceDependencyStepMask = 0x3f;
+inline constexpr uint32_t kPipesTraceStripeMask = 0x0f;
+inline constexpr uint32_t kPipesTraceLaneMask = 0x0f;
+inline constexpr uint32_t kPipesTracePeerMask = 0xff;
+inline constexpr uint32_t kPipesTraceQpLaneMask = 0x3f;
+inline constexpr uint32_t kPipesTracePhaseMask = 0x07;
+inline constexpr uint32_t kPipesTraceBytesQuantum = 32;
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
 __device__ __forceinline__ uint64_t read_pipes_trace_globaltimer() {
@@ -126,6 +187,34 @@ __device__ __forceinline__ void write_pipes_trace(
       : "l"(packed_lo), "l"(packed_hi), "l"(&trace.ring[idx])
       : "memory");
 #endif
+}
+
+__device__ __forceinline__ void write_pipes_trace_allreduce(
+    const PipesTraceAllReduceContext& context,
+    PipesTraceEventType type) {
+  if (context.trace.ring == nullptr || context.trace.writeIndex == nullptr) {
+    return;
+  }
+
+  const uint32_t packed = ((static_cast<uint32_t>(context.dependencyStep) &
+                            kPipesTraceDependencyStepMask)
+                           << kPipesTraceDependencyStepShift) |
+      ((static_cast<uint32_t>(context.stripe) & kPipesTraceStripeMask)
+       << kPipesTraceStripeShift) |
+      ((static_cast<uint32_t>(context.lane) & kPipesTraceLaneMask)
+       << kPipesTraceLaneShift) |
+      ((static_cast<uint32_t>(context.peer) & kPipesTracePeerMask)
+       << kPipesTracePeerShift) |
+      ((static_cast<uint32_t>(context.qpLane) & kPipesTraceQpLaneMask)
+       << kPipesTraceQpLaneShift) |
+      ((static_cast<uint32_t>(context.phase) & kPipesTracePhaseMask)
+       << kPipesTracePhaseShift);
+  const uint64_t byteQuanta =
+      (static_cast<uint64_t>(context.bytes) + kPipesTraceBytesQuantum - 1) /
+      kPipesTraceBytesQuantum;
+  const uint16_t packedBytes =
+      static_cast<uint16_t>(byteQuanta > UINT16_MAX ? UINT16_MAX : byteQuanta);
+  write_pipes_trace(context.trace, type, packed, packedBytes, context.rank);
 }
 #endif
 

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -680,6 +680,32 @@ P2pIbTransportDevice::progress_registered_send_drain_once(
 
 template <typename CopyOp, typename... Args>
 __device__ __forceinline__ IbgdaSendRecvProgressStatus
+P2pIbTransportDevice::progress_send_once_with_trace(
+    ThreadGroup& group,
+    const void* __restrict__ src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    const PipesTraceAllReduceContext& traceContext,
+    PipesTraceProgressState& traceState,
+    Args... args) {
+  if (type == P2pIbBackendType::IBRC) {
+    return ibrc->progress_send_once<CopyOp>(
+        group, src, nbytes, max_signal_bytes, timeout, args...);
+  }
+  return ibgda->progress_send_once_with_trace<CopyOp>(
+      group,
+      src,
+      nbytes,
+      max_signal_bytes,
+      timeout,
+      traceContext,
+      traceState,
+      args...);
+}
+
+template <typename CopyOp, typename... Args>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus
 P2pIbTransportDevice::progress_recv_once(
     ThreadGroup& group,
     void* __restrict__ dst,
@@ -693,6 +719,32 @@ P2pIbTransportDevice::progress_recv_once(
   }
   return ibgda->progress_recv_once<CopyOp>(
       group, dst, nbytes, max_signal_bytes, timeout, args...);
+}
+
+template <typename CopyOp, typename... Args>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus
+P2pIbTransportDevice::progress_recv_once_with_trace(
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    const PipesTraceAllReduceContext& traceContext,
+    PipesTraceProgressState& traceState,
+    Args... args) {
+  if (type == P2pIbBackendType::IBRC) {
+    return ibrc->progress_recv_once<CopyOp>(
+        group, dst, nbytes, max_signal_bytes, timeout, args...);
+  }
+  return ibgda->progress_recv_once_with_trace<CopyOp>(
+      group,
+      dst,
+      nbytes,
+      max_signal_bytes,
+      timeout,
+      traceContext,
+      traceState,
+      args...);
 }
 
 } // namespace comms::prims

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -14,6 +14,8 @@
 namespace comms::prims {
 
 struct Memcpy;
+struct PipesTraceAllReduceContext;
+struct PipesTraceProgressState;
 
 class P2pIbgdaTransportDevice;
 class P2pIbrcTransportDevice;
@@ -70,6 +72,19 @@ __device__ __forceinline__ void send_registered(
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
     const Timeout& timeout = Timeout());
+
+template <typename Transport, typename CopyOp, typename... Args>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus
+progress_send_once_with_trace(
+    Transport& transport,
+    ThreadGroup& group,
+    const void* __restrict__ src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    const PipesTraceAllReduceContext& traceContext,
+    PipesTraceProgressState& traceState,
+    Args... args);
 
 } // namespace detail
 
@@ -346,12 +361,36 @@ struct P2pIbTransportDevice {
       const Timeout& timeout = Timeout());
 
   template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus
+  progress_send_once_with_trace(
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      const PipesTraceAllReduceContext& traceContext,
+      PipesTraceProgressState& traceState,
+      Args... args);
+
+  template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
+      Args... args);
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus
+  progress_recv_once_with_trace(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      const PipesTraceAllReduceContext& traceContext,
+      PipesTraceProgressState& traceState,
       Args... args);
 };
 

--- a/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
@@ -23,6 +23,24 @@ struct copyop_variable_size<C, std::void_t<decltype(C::kVariableSize)>>
     : std::bool_constant<C::kVariableSize> {};
 template <typename C>
 inline constexpr bool copyop_variable_size_v = copyop_variable_size<C>::value;
+
+__device__ __forceinline__ bool fine_trace_enabled(
+    const PipesTraceAllReduceContext* context) {
+  return context != nullptr && context->trace.ring != nullptr &&
+      context->trace.writeIndex != nullptr;
+}
+
+__device__ __forceinline__ void trace_allreduce_event(
+    const PipesTraceAllReduceContext* context,
+    PipesTraceEventType type,
+    uint8_t qpLane) {
+  if (!fine_trace_enabled(context)) {
+    return;
+  }
+  auto tagged = *context;
+  tagged.qpLane = qpLane;
+  write_pipes_trace_allreduce(tagged, type);
+}
 } // namespace detail
 
 #if PIPES_IS_DEVICE_COMPILE
@@ -226,6 +244,19 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
     std::size_t nbytes,
     std::size_t max_signal_bytes,
     const Timeout& timeout,
+    Args... args);
+
+template <typename Transport, typename CopyOp, typename... Args>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus
+progress_recv_once_with_trace(
+    Transport& transport,
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    const PipesTraceAllReduceContext& traceContext,
+    PipesTraceProgressState& traceState,
     Args... args);
 
 /**
@@ -474,14 +505,37 @@ __device__ __forceinline__ void consumeRecvBuf(
     uint64_t /*flagVal*/,
     uint64_t waitCredit,
     const Timeout& timeout,
+    const PipesTraceAllReduceContext* traceContext,
     Args... args) {
 #if PIPES_IS_DEVICE_COMPILE
+  const uint32_t numLanes =
+      static_cast<uint32_t>(transport.channel_layout().numLanes);
+  const uint8_t qpLane = static_cast<uint8_t>(
+      numLanes == 0 ? 0 : localChannel.recvDataReadyLaneCursor % numLanes);
+  if (group.is_leader()) {
+    trace_allreduce_event(
+        traceContext,
+        PipesTraceEventType::kAllReduceDataReadyWaitBegin,
+        qpLane);
+  }
   wait_recv_data_ready(
       transport, group, localChannel, localDataReady, waitCredit, timeout);
+  if (group.is_leader()) {
+    trace_allreduce_event(
+        traceContext, PipesTraceEventType::kAllReduceDataReadyWaitEnd, qpLane);
+  }
   const std::size_t validBytes =
       valid_payload_bytes(dataOff, payloadBytes, nbytes);
   if (validBytes > 0) {
+    if (group.is_leader()) {
+      trace_allreduce_event(
+          traceContext, PipesTraceEventType::kAllReduceReduceCopyBegin, qpLane);
+    }
     CopyOp::recv(dst, staging, validBytes, group, dataOff, args...);
+    if (group.is_leader()) {
+      trace_allreduce_event(
+          traceContext, PipesTraceEventType::kAllReduceReduceCopyEnd, qpLane);
+    }
   }
   group.sync();
 #else
@@ -496,6 +550,7 @@ __device__ __forceinline__ void consumeRecvBuf(
   (void)dataOff;
   (void)waitCredit;
   (void)timeout;
+  (void)traceContext;
   ((void)args, ...);
 #endif
 }
@@ -530,6 +585,8 @@ __device__ __forceinline__ SendSignal prepareForwardBuf(
     uint32_t fwdSlot,
     uint64_t fwdPipelineCycle,
     const Timeout& timeout,
+    const PipesTraceAllReduceContext* recvTraceContext,
+    const PipesTraceAllReduceContext* sendTraceContext,
     Args... args) {
 #if PIPES_IS_DEVICE_COMPILE
   // Both waits must clear before CopyOp::forward, which reads recvStaging and
@@ -540,6 +597,18 @@ __device__ __forceinline__ SendSignal prepareForwardBuf(
   // degenerates to a single completion check instead of a CQ-polling spin.
   // Folded in here rather than left to the caller -- both are correctness
   // requirements of this function, not of its call site.
+  const uint32_t recvNumLanes =
+      static_cast<uint32_t>(transport.channel_layout().numLanes);
+  const uint8_t recvQpLane = static_cast<uint8_t>(
+      recvNumLanes == 0
+          ? 0
+          : recvLocalChannel.recvDataReadyLaneCursor % recvNumLanes);
+  if (group.is_leader()) {
+    trace_allreduce_event(
+        recvTraceContext,
+        PipesTraceEventType::kAllReduceDataReadyWaitBegin,
+        recvQpLane);
+  }
   wait_recv_data_ready(
       transport,
       group,
@@ -547,13 +616,41 @@ __device__ __forceinline__ SendSignal prepareForwardBuf(
       recvDataReady,
       recvWaitCredit,
       timeout);
+  if (group.is_leader()) {
+    trace_allreduce_event(
+        recvTraceContext,
+        PipesTraceEventType::kAllReduceDataReadyWaitEnd,
+        recvQpLane);
+    trace_allreduce_event(
+        sendTraceContext,
+        PipesTraceEventType::kAllReduceLocalCompletionWaitBegin,
+        static_cast<uint8_t>(kPipesTraceQpLaneMask));
+  }
   prepare_send_slot<protocol::Simple>(
       fwdTransport, group, fwdSlot, fwdPipelineCycle, timeout);
+  if (group.is_leader()) {
+    trace_allreduce_event(
+        sendTraceContext,
+        PipesTraceEventType::kAllReduceLocalCompletionWaitEnd,
+        static_cast<uint8_t>(kPipesTraceQpLaneMask));
+  }
   const std::size_t validBytes =
       valid_payload_bytes(dataOff, payloadBytes, nbytes);
   if (validBytes > 0) {
+    if (group.is_leader()) {
+      trace_allreduce_event(
+          recvTraceContext,
+          PipesTraceEventType::kAllReduceStageCopyBegin,
+          recvQpLane);
+    }
     CopyOp::forward(
         dst, fwdStaging, recvStaging, validBytes, group, dataOff, args...);
+    if (group.is_leader()) {
+      trace_allreduce_event(
+          recvTraceContext,
+          PipesTraceEventType::kAllReduceStageCopyEnd,
+          recvQpLane);
+    }
   }
   group.sync();
   return SendSignal{fwdRemoteChannel.dataReady, fwdSignalVal};
@@ -575,6 +672,8 @@ __device__ __forceinline__ SendSignal prepareForwardBuf(
   (void)fwdSlot;
   (void)fwdPipelineCycle;
   (void)timeout;
+  (void)recvTraceContext;
+  (void)sendTraceContext;
   ((void)args, ...);
   return SendSignal{};
 #endif
@@ -707,13 +806,14 @@ template <
     typename CopyOp = Memcpy,
     typename Proto = protocol::Simple,
     typename... Args>
-__device__ __forceinline__ void send(
+__device__ __forceinline__ void send_impl(
     Transport& transport,
     ThreadGroup& group,
     const void* __restrict__ src,
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
     const Timeout& timeout = Timeout(),
+    const PipesTraceAllReduceContext* traceContext = nullptr,
     Args... args) {
   // The variable-size (compressed) loop below keeps its encode inline rather
   // than behind the prepareSendBuf/consumeRecvBuf seam, so it is Simple-shaped
@@ -732,6 +832,7 @@ __device__ __forceinline__ void send(
   (void)nbytes;
   (void)max_signal_bytes;
   (void)timeout;
+  (void)traceContext;
 #else
   if (nbytes == 0) {
     return;
@@ -752,6 +853,7 @@ __device__ __forceinline__ void send(
   auto& state = progress_send_slot<Proto>(transport, group);
   const ChannelSlotView ch =
       acquire_channel<Proto>(transport, channelLayout, group);
+  IbLocalChannel& localChannel = ch.channel;
   const IbgdaLocalBuffer localSlotFree = ch.local.slotFree;
   const IbRemoteChannel remoteChannel = ch.remote;
   assert_progress_slot_idle(group, state, "send");
@@ -775,6 +877,10 @@ __device__ __forceinline__ void send(
     state.activeBaseStep = static_cast<int64_t>(baseByte);
     state.activeNextByte = 0;
     state.activeTailPadding = protocolTailPadding;
+    trace_allreduce_event(
+        traceContext,
+        PipesTraceEventType::kAllReducePathStaged,
+        static_cast<uint8_t>(kPipesTraceQpLaneMask));
   }
 
   if constexpr (detail::copyop_variable_size_v<CopyOp>) {
@@ -1010,9 +1116,27 @@ __device__ __forceinline__ void send(
       const uint64_t flagVal = streamPayload / pipelineBytesPayload + 1;
 
       // (1) Wait for NIC to finish with this slot's local sendStaging.
+      if (group.is_leader()) {
+        trace_allreduce_event(
+            traceContext,
+            PipesTraceEventType::kAllReduceLocalCompletionWaitBegin,
+            static_cast<uint8_t>(kPipesTraceQpLaneMask));
+      }
       prepare_send_slot<Proto>(transport, group, slot, pipelineCycle, timeout);
+      if (group.is_leader()) {
+        trace_allreduce_event(
+            traceContext,
+            PipesTraceEventType::kAllReduceLocalCompletionWaitEnd,
+            static_cast<uint8_t>(kPipesTraceQpLaneMask));
+      }
 
       // (2) Cooperative copy: src -> local sendStaging via CopyOp.
+      if (group.is_leader()) {
+        trace_allreduce_event(
+            traceContext,
+            PipesTraceEventType::kAllReduceStageCopyBegin,
+            static_cast<uint8_t>(kPipesTraceQpLaneMask));
+      }
       const SendSignal sig = prepareSendBuf<CopyOp>(
           Proto{},
           group,
@@ -1025,23 +1149,58 @@ __device__ __forceinline__ void send(
           remoteChannel,
           protocolBytesThis,
           args...);
+      if (group.is_leader()) {
+        trace_allreduce_event(
+            traceContext,
+            PipesTraceEventType::kAllReduceStageCopyEnd,
+            static_cast<uint8_t>(kPipesTraceQpLaneMask));
+      }
 
       // (3) Backpressure: wait for receiver to free this byte range's
       //     recvStaging offset. Symmetric with DATA_READY.
       if (protocolStreamEnd > pipelineBytesWire) {
+        if (group.is_leader()) {
+          trace_allreduce_event(
+              traceContext,
+              PipesTraceEventType::kAllReduceRemoteSlotFreeWaitBegin,
+              static_cast<uint8_t>(kPipesTraceQpLaneMask));
+        }
         transport.wait_signal(
             group,
             localSlotFree,
             protocolStreamEnd - pipelineBytesWire,
             timeout);
+        if (group.is_leader()) {
+          trace_allreduce_event(
+              traceContext,
+              PipesTraceEventType::kAllReduceRemoteSlotFreeWaitEnd,
+              static_cast<uint8_t>(kPipesTraceQpLaneMask));
+        }
       }
 
       // (4) Leader-only single-WQE RDMA put with fused signal.
+      if (group.is_leader()) {
+        trace_allreduce_event(
+            traceContext,
+            PipesTraceEventType::kAllReduceSendSyncBegin,
+            static_cast<uint8_t>(kPipesTraceQpLaneMask));
+      }
       group.sync();
       if (group.is_leader()) {
         __threadfence_system();
+        trace_allreduce_event(
+            traceContext,
+            PipesTraceEventType::kAllReduceSendSyncEnd,
+            static_cast<uint8_t>(kPipesTraceQpLaneMask));
+        const uint32_t numLanes = static_cast<uint32_t>(channelLayout.numLanes);
+        const uint8_t qpLane = static_cast<uint8_t>(
+            numLanes == 0 ? 0 : localChannel.sendQp.cursor % numLanes);
         ThreadGroup solo{
             0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+        trace_allreduce_event(
+            traceContext,
+            PipesTraceEventType::kAllReduceWqeSubmitBegin,
+            qpLane);
         const auto completion = transport.put(
             solo,
             channelLayout.sendStagingBuf.subBuffer(stagingOff),
@@ -1052,12 +1211,22 @@ __device__ __forceinline__ void send(
             /*counterBuf=*/{},
             /*counterVal=*/0,
             /*signalPerLane=*/true);
+        trace_allreduce_event(
+            traceContext, PipesTraceEventType::kAllReduceWqeSubmitEnd, qpLane);
+        trace_allreduce_event(
+            traceContext,
+            PipesTraceEventType::kAllReduceBookkeepingBegin,
+            qpLane);
         record_send_completion<Proto>(
             transport,
             static_cast<uint32_t>(groupId),
             slot,
             pipelineCycle,
             completion);
+        trace_allreduce_event(
+            traceContext,
+            PipesTraceEventType::kAllReduceBookkeepingEnd,
+            qpLane);
       }
       group.sync();
       dataOff += payloadBytes;
@@ -1073,6 +1242,55 @@ __device__ __forceinline__ void send(
     group.sync();
   }
 #endif
+}
+
+template <
+    typename Transport,
+    typename CopyOp = Memcpy,
+    typename Proto = protocol::Simple,
+    typename... Args>
+__device__ __forceinline__ void send(
+    Transport& transport,
+    ThreadGroup& group,
+    const void* __restrict__ src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0,
+    const Timeout& timeout = Timeout(),
+    Args... args) {
+  send_impl<Transport, CopyOp, Proto>(
+      transport,
+      group,
+      src,
+      nbytes,
+      max_signal_bytes,
+      timeout,
+      nullptr,
+      args...);
+}
+
+template <
+    typename Transport,
+    typename CopyOp = Memcpy,
+    typename Proto = protocol::Simple,
+    typename... Args>
+__device__ __forceinline__ void send_with_fine_trace(
+    Transport& transport,
+    ThreadGroup& group,
+    const void* __restrict__ src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    const PipesTraceAllReduceContext& traceContext,
+    Args... args) {
+  send_impl<Transport, CopyOp, Proto>(
+      transport,
+      group,
+      src,
+      nbytes,
+      max_signal_bytes,
+      timeout,
+      &traceContext,
+      args...);
 }
 
 /**
@@ -1107,13 +1325,14 @@ template <
     typename CopyOp = Memcpy,
     typename Proto = protocol::Simple,
     typename... Args>
-__device__ __forceinline__ void recv(
+__device__ __forceinline__ void recv_impl(
     Transport& transport,
     ThreadGroup& group,
     void* __restrict__ dst,
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
     const Timeout& timeout = Timeout(),
+    const PipesTraceAllReduceContext* traceContext = nullptr,
     Args... args) {
   // The variable-size (compressed) loop below keeps its encode inline rather
   // than behind the prepareSendBuf/consumeRecvBuf seam, so it is Simple-shaped
@@ -1132,6 +1351,7 @@ __device__ __forceinline__ void recv(
   (void)nbytes;
   (void)max_signal_bytes;
   (void)timeout;
+  (void)traceContext;
 #else
   if (nbytes == 0) {
     return;
@@ -1340,6 +1560,9 @@ __device__ __forceinline__ void recv(
 
       // (1)+(2) Wait for the chunk to be ready (DATA_READY signal or, for LL,
       //         the inline flag) and cooperatively copy recvStaging -> dst.
+      const uint32_t numLanes = static_cast<uint32_t>(channelLayout.numLanes);
+      const uint8_t qpLane = static_cast<uint8_t>(
+          numLanes == 0 ? 0 : localChannel.recvDataReadyLaneCursor % numLanes);
       consumeRecvBuf<CopyOp>(
           Proto{},
           transport,
@@ -1354,11 +1577,24 @@ __device__ __forceinline__ void recv(
           flagVal,
           protocolBytesThis,
           timeout,
+          traceContext,
           args...);
 
+      if (group.is_leader()) {
+        trace_allreduce_event(
+            traceContext,
+            PipesTraceEventType::kAllReduceBookkeepingBegin,
+            qpLane);
+      }
       transport.signal(
           group, remoteChannel.slotFree, protocolBytesThis, IbDirection::Recv);
       dataOff += payloadBytes;
+      if (group.is_leader()) {
+        trace_allreduce_event(
+            traceContext,
+            PipesTraceEventType::kAllReduceBookkeepingEnd,
+            qpLane);
+      }
     }
 
     if (group.is_leader()) {
@@ -1371,6 +1607,55 @@ __device__ __forceinline__ void recv(
     group.sync();
   }
 #endif
+}
+
+template <
+    typename Transport,
+    typename CopyOp = Memcpy,
+    typename Proto = protocol::Simple,
+    typename... Args>
+__device__ __forceinline__ void recv(
+    Transport& transport,
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0,
+    const Timeout& timeout = Timeout(),
+    Args... args) {
+  recv_impl<Transport, CopyOp, Proto>(
+      transport,
+      group,
+      dst,
+      nbytes,
+      max_signal_bytes,
+      timeout,
+      nullptr,
+      args...);
+}
+
+template <
+    typename Transport,
+    typename CopyOp = Memcpy,
+    typename Proto = protocol::Simple,
+    typename... Args>
+__device__ __forceinline__ void recv_with_fine_trace(
+    Transport& transport,
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    const PipesTraceAllReduceContext& traceContext,
+    Args... args) {
+  recv_impl<Transport, CopyOp, Proto>(
+      transport,
+      group,
+      dst,
+      nbytes,
+      max_signal_bytes,
+      timeout,
+      &traceContext,
+      args...);
 }
 
 /**
@@ -1430,7 +1715,7 @@ template <
     typename Transport,
     typename Proto = protocol::Simple,
     typename... Args>
-__device__ __forceinline__ void forward(
+__device__ __forceinline__ void forward_impl(
     Transport& transport,
     ThreadGroup& group,
     void* __restrict__ dst,
@@ -1438,6 +1723,8 @@ __device__ __forceinline__ void forward(
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
     const Timeout& timeout = Timeout(),
+    const PipesTraceAllReduceContext* recvTraceContext = nullptr,
+    const PipesTraceAllReduceContext* sendTraceContext = nullptr,
     Args... args) {
 #if PIPES_IS_DEVICE_COMPILE
 #ifdef __HIP_PLATFORM_AMD__
@@ -1483,6 +1770,7 @@ __device__ __forceinline__ void forward(
   auto& fwdSlotState = progress_send_slot<Proto>(fwdTransport, group);
   const ChannelSlotView fwdCh =
       acquire_channel<Proto>(fwdTransport, fwdChannelLayout, group);
+  IbLocalChannel& fwdLocalChannel = fwdCh.channel;
   const IbgdaLocalBuffer fwdSlotFree = fwdCh.local.slotFree;
   const IbRemoteChannel fwdRemoteChannel = fwdCh.remote;
   assert_progress_slot_idle(group, fwdSlotState, "forward send");
@@ -1502,6 +1790,10 @@ __device__ __forceinline__ void forward(
     fwdSlotState.activeBaseStep = static_cast<int64_t>(fwdBaseByte);
     fwdSlotState.activeNextByte = 0;
     fwdSlotState.activeTailPadding = fwdProtocolTailPadding;
+    trace_allreduce_event(
+        sendTraceContext,
+        PipesTraceEventType::kAllReducePathStaged,
+        static_cast<uint8_t>(kPipesTraceQpLaneMask));
   }
 
   for (std::size_t dataOff = 0; dataOff < payloadProtocolBytes;) {
@@ -1576,6 +1868,8 @@ __device__ __forceinline__ void forward(
         static_cast<uint32_t>(fwdSlot),
         fwdPipelineCycle,
         timeout,
+        recvTraceContext,
+        sendTraceContext,
         args...);
 
     transport.signal(
@@ -1587,19 +1881,49 @@ __device__ __forceinline__ void forward(
     // (5) Wait for fwd receiver's SLOT_FREE (backpressure on fwd's
     //     recvStaging).
     if (fwdProtocolStreamEnd > fwdGeo.pipelineBytesWire) {
+      if (group.is_leader()) {
+        trace_allreduce_event(
+            sendTraceContext,
+            PipesTraceEventType::kAllReduceRemoteSlotFreeWaitBegin,
+            static_cast<uint8_t>(kPipesTraceQpLaneMask));
+      }
       fwdTransport.wait_signal(
           group,
           fwdSlotFree,
           fwdProtocolStreamEnd - fwdGeo.pipelineBytesWire,
           timeout);
+      if (group.is_leader()) {
+        trace_allreduce_event(
+            sendTraceContext,
+            PipesTraceEventType::kAllReduceRemoteSlotFreeWaitEnd,
+            static_cast<uint8_t>(kPipesTraceQpLaneMask));
+      }
     }
 
     // (6) Leader-only RDMA put via the forwarding transport.
+    if (group.is_leader()) {
+      trace_allreduce_event(
+          sendTraceContext,
+          PipesTraceEventType::kAllReduceSendSyncBegin,
+          static_cast<uint8_t>(kPipesTraceQpLaneMask));
+    }
     group.sync();
     if (group.is_leader()) {
       __threadfence_system();
+      trace_allreduce_event(
+          sendTraceContext,
+          PipesTraceEventType::kAllReduceSendSyncEnd,
+          static_cast<uint8_t>(kPipesTraceQpLaneMask));
+      const uint32_t numLanes =
+          static_cast<uint32_t>(fwdChannelLayout.numLanes);
+      const uint8_t qpLane = static_cast<uint8_t>(
+          numLanes == 0 ? 0 : fwdLocalChannel.sendQp.cursor % numLanes);
       ThreadGroup solo{
           0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+      trace_allreduce_event(
+          sendTraceContext,
+          PipesTraceEventType::kAllReduceWqeSubmitBegin,
+          qpLane);
       const auto completion = fwdTransport.put(
           solo,
           fwdChannelLayout.sendStagingBuf.subBuffer(fwdStagingOff),
@@ -1610,12 +1934,24 @@ __device__ __forceinline__ void forward(
           /*counterBuf=*/{},
           /*counterVal=*/0,
           /*signalPerLane=*/true);
+      trace_allreduce_event(
+          sendTraceContext,
+          PipesTraceEventType::kAllReduceWqeSubmitEnd,
+          qpLane);
+      trace_allreduce_event(
+          sendTraceContext,
+          PipesTraceEventType::kAllReduceBookkeepingBegin,
+          qpLane);
       record_send_completion<Proto>(
           fwdTransport,
           static_cast<uint32_t>(groupId),
           fwdSlot,
           fwdPipelineCycle,
           completion);
+      trace_allreduce_event(
+          sendTraceContext,
+          PipesTraceEventType::kAllReduceBookkeepingEnd,
+          qpLane);
     }
     group.sync();
     dataOff += payloadBytes;
@@ -1645,7 +1981,65 @@ __device__ __forceinline__ void forward(
   (void)nbytes;
   (void)max_signal_bytes;
   (void)timeout;
+  (void)recvTraceContext;
+  (void)sendTraceContext;
 #endif
+}
+
+template <
+    typename CopyOp = Memcpy,
+    typename Transport,
+    typename Proto = protocol::Simple,
+    typename... Args>
+__device__ __forceinline__ void forward(
+    Transport& transport,
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    Transport& fwdTransport,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0,
+    const Timeout& timeout = Timeout(),
+    Args... args) {
+  forward_impl<CopyOp, Transport, Proto>(
+      transport,
+      group,
+      dst,
+      fwdTransport,
+      nbytes,
+      max_signal_bytes,
+      timeout,
+      nullptr,
+      nullptr,
+      args...);
+}
+
+template <
+    typename CopyOp = Memcpy,
+    typename Transport,
+    typename Proto = protocol::Simple,
+    typename... Args>
+__device__ __forceinline__ void forward_with_fine_trace(
+    Transport& transport,
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    Transport& fwdTransport,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    const PipesTraceAllReduceContext& recvTraceContext,
+    const PipesTraceAllReduceContext& sendTraceContext,
+    Args... args) {
+  forward_impl<CopyOp, Transport, Proto>(
+      transport,
+      group,
+      dst,
+      fwdTransport,
+      nbytes,
+      max_signal_bytes,
+      timeout,
+      &recvTraceContext,
+      &sendTraceContext,
+      args...);
 }
 
 /**

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -320,13 +320,15 @@ __device__ __forceinline__ SendSignal progress_send_signal(
 }
 
 template <typename Transport, typename CopyOp, typename Proto, typename... Args>
-__device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
+__device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
     Transport& transport,
     ThreadGroup& group,
     const void* __restrict__ src,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
     const Timeout& timeout,
+    const PipesTraceAllReduceContext* traceContext,
+    PipesTraceProgressState* traceState,
     Args... args) {
   // The progress API drives the FIXED-size protocol only: it signals in wire
   // bytes and ignores CopyOp::send()'s returned wire size, so a variable-size
@@ -368,6 +370,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
       static_cast<std::size_t>(channelLayout.pipelineDepth);
   const ChannelSlotView ch =
       acquire_channel<Proto>(transport, channelLayout, group);
+  IbLocalChannel& localChannel = ch.channel;
   const IbgdaLocalBuffer localSlotFree = ch.local.slotFree;
   const IbRemoteChannel remoteChannel = ch.remote;
 
@@ -375,6 +378,14 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
       detail::IbSendRecvProgressStage::WaitLocalCompletion) {
     const ProgressChunk chunk =
         next_chunk<Proto>(channelLayout, state, progress_params);
+    if (fine_trace_enabled(traceContext) && traceState != nullptr &&
+        !traceState->localCompletionWaitOpen && group.is_leader()) {
+      trace_allreduce_event(
+          traceContext,
+          PipesTraceEventType::kAllReduceLocalCompletionWaitBegin,
+          static_cast<uint8_t>(kPipesTraceQpLaneMask));
+      traceState->localCompletionWaitOpen = true;
+    }
     if (!try_prepare_send_slot<Proto>(
             transport,
             group,
@@ -383,7 +394,21 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
             timeout)) {
       return IbgdaSendRecvProgressStatus::Waiting;
     }
+    if (fine_trace_enabled(traceContext) && traceState != nullptr &&
+        traceState->localCompletionWaitOpen && group.is_leader()) {
+      trace_allreduce_event(
+          traceContext,
+          PipesTraceEventType::kAllReduceLocalCompletionWaitEnd,
+          static_cast<uint8_t>(kPipesTraceQpLaneMask));
+      traceState->localCompletionWaitOpen = false;
+    }
 
+    if (group.is_leader()) {
+      trace_allreduce_event(
+          traceContext,
+          PipesTraceEventType::kAllReduceStageCopyBegin,
+          static_cast<uint8_t>(kPipesTraceQpLaneMask));
+    }
     progress_send_prepare_buf<CopyOp>(
         Proto{},
         group,
@@ -392,6 +417,12 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
         src,
         progress_params.payloadBytes,
         args...);
+    if (group.is_leader()) {
+      trace_allreduce_event(
+          traceContext,
+          PipesTraceEventType::kAllReduceStageCopyEnd,
+          static_cast<uint8_t>(kPipesTraceQpLaneMask));
+    }
     group.sync();
     transition_progress_stage(
         group, state, detail::IbSendRecvProgressStage::WaitSlotFree);
@@ -405,6 +436,14 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
     const uint64_t protocolStreamEnd = chunk.streamEndWire +
         (isFinalChunk ? Proto::wire_bytes(state.activeTailPadding) : 0);
     if (protocolStreamEnd > pipelineBytesWire) {
+      if (fine_trace_enabled(traceContext) && traceState != nullptr &&
+          !traceState->remoteSlotFreeWaitOpen && group.is_leader()) {
+        trace_allreduce_event(
+            traceContext,
+            PipesTraceEventType::kAllReduceRemoteSlotFreeWaitBegin,
+            static_cast<uint8_t>(kPipesTraceQpLaneMask));
+        traceState->remoteSlotFreeWaitOpen = true;
+      }
       const uint64_t expected = protocolStreamEnd - pipelineBytesWire;
       uint32_t ready = 1;
       unsigned long long current = 0;
@@ -430,17 +469,40 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
         }
         return IbgdaSendRecvProgressStatus::Waiting;
       }
+      if (fine_trace_enabled(traceContext) && traceState != nullptr &&
+          traceState->remoteSlotFreeWaitOpen && group.is_leader()) {
+        trace_allreduce_event(
+            traceContext,
+            PipesTraceEventType::kAllReduceRemoteSlotFreeWaitEnd,
+            static_cast<uint8_t>(kPipesTraceQpLaneMask));
+        traceState->remoteSlotFreeWaitOpen = false;
+      }
     }
 
+    if (group.is_leader()) {
+      trace_allreduce_event(
+          traceContext,
+          PipesTraceEventType::kAllReduceSendSyncBegin,
+          static_cast<uint8_t>(kPipesTraceQpLaneMask));
+    }
     group.sync();
     if (group.is_leader()) {
       __threadfence_system();
+      trace_allreduce_event(
+          traceContext,
+          PipesTraceEventType::kAllReduceSendSyncEnd,
+          static_cast<uint8_t>(kPipesTraceQpLaneMask));
+      const uint32_t numLanes = static_cast<uint32_t>(channelLayout.numLanes);
+      const uint8_t qpLane = static_cast<uint8_t>(
+          numLanes == 0 ? 0 : localChannel.sendQp.cursor % numLanes);
       ThreadGroup solo{
           0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
       const std::size_t protocolBytesThis = chunk.wireBytes +
           (isFinalChunk ? Proto::wire_bytes(state.activeTailPadding) : 0);
       const SendSignal sig =
           progress_send_signal(Proto{}, remoteChannel, protocolBytesThis);
+      trace_allreduce_event(
+          traceContext, PipesTraceEventType::kAllReduceWqeSubmitBegin, qpLane);
       const auto completion = transport.put(
           solo,
           channelLayout.sendStagingBuf.subBuffer(chunk.stagingOff),
@@ -451,12 +513,20 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
           /*counterBuf=*/{},
           /*counterVal=*/0,
           /*signalPerLane=*/true);
+      trace_allreduce_event(
+          traceContext, PipesTraceEventType::kAllReduceWqeSubmitEnd, qpLane);
+      trace_allreduce_event(
+          traceContext,
+          PipesTraceEventType::kAllReduceBookkeepingBegin,
+          qpLane);
       record_send_completion<Proto>(
           transport,
           static_cast<uint32_t>(progress_params.groupId),
           chunk.slotId,
           chunk.pipelineGeneration,
           completion);
+      trace_allreduce_event(
+          traceContext, PipesTraceEventType::kAllReduceBookkeepingEnd, qpLane);
     }
     group.sync();
 
@@ -487,6 +557,8 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
   (void)nbytes;
   (void)max_signal_bytes;
   (void)timeout;
+  (void)traceContext;
+  (void)traceState;
   return IbgdaSendRecvProgressStatus::Done;
 #endif
 }
@@ -734,6 +806,51 @@ __device__ __forceinline__ void send_registered(
 #endif
 }
 
+template <typename Transport, typename CopyOp, typename Proto, typename... Args>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
+    Transport& transport,
+    ThreadGroup& group,
+    const void* __restrict__ src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    Args... args) {
+  return progress_send_once_impl<Transport, CopyOp, Proto>(
+      transport,
+      group,
+      src,
+      nbytes,
+      max_signal_bytes,
+      timeout,
+      nullptr,
+      nullptr,
+      args...);
+}
+
+template <typename Transport, typename CopyOp, typename... Args>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus
+progress_send_once_with_trace(
+    Transport& transport,
+    ThreadGroup& group,
+    const void* __restrict__ src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    const PipesTraceAllReduceContext& traceContext,
+    PipesTraceProgressState& traceState,
+    Args... args) {
+  return progress_send_once_impl<Transport, CopyOp, protocol::Simple>(
+      transport,
+      group,
+      src,
+      nbytes,
+      max_signal_bytes,
+      timeout,
+      &traceContext,
+      &traceState,
+      args...);
+}
+
 /**
  * Non-blocking poll for one receive chunk's DATA_READY on its round-robin lane.
  *
@@ -824,10 +941,21 @@ __device__ __forceinline__ bool progress_recv_ready(
     IbLocalChannel& localChannel,
     const IbgdaLocalBuffer& localDataReady,
     uint64_t waitCredit,
-    const Timeout& timeout) {
+    const Timeout& timeout,
+    const PipesTraceAllReduceContext* traceContext,
+    PipesTraceProgressState* traceState,
+    uint8_t qpLane) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t ready = 1;
   if (group.is_leader()) {
+    if (fine_trace_enabled(traceContext) && traceState != nullptr &&
+        !traceState->dataReadyWaitOpen) {
+      trace_allreduce_event(
+          traceContext,
+          PipesTraceEventType::kAllReduceDataReadyWaitBegin,
+          qpLane);
+      traceState->dataReadyWaitOpen = true;
+    }
     unsigned long long current = 0;
     unsigned long long expected = 0;
     ready = poll_recv_data_ready(
@@ -846,6 +974,14 @@ __device__ __forceinline__ bool progress_recv_ready(
           "current=%llu",
           expected,
           current);
+    } else if (
+        fine_trace_enabled(traceContext) && traceState != nullptr &&
+        traceState->dataReadyWaitOpen) {
+      trace_allreduce_event(
+          traceContext,
+          PipesTraceEventType::kAllReduceDataReadyWaitEnd,
+          qpLane);
+      traceState->dataReadyWaitOpen = false;
     }
   }
   return group.broadcast<uint32_t>(ready) != 0U;
@@ -856,6 +992,9 @@ __device__ __forceinline__ bool progress_recv_ready(
   (void)localDataReady;
   (void)waitCredit;
   (void)timeout;
+  (void)traceContext;
+  (void)traceState;
+  (void)qpLane;
   return true;
 #endif
 }
@@ -870,11 +1009,17 @@ __device__ __forceinline__ void progress_recv_consume_buf(
     const ProgressChunk& chunk,
     void* __restrict__ dst,
     std::size_t payloadBytes,
+    const PipesTraceAllReduceContext* traceContext,
+    uint8_t qpLane,
     Args... args) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   const std::size_t validBytes =
       valid_payload_bytes(chunk.dataOff, chunk.payloadBytes, payloadBytes);
   if (validBytes > 0) {
+    if (group.is_leader()) {
+      trace_allreduce_event(
+          traceContext, PipesTraceEventType::kAllReduceReduceCopyBegin, qpLane);
+    }
     CopyOp::recv(
         static_cast<char*>(dst) + chunk.dataOff,
         channelLayout.recvStagingPtr + chunk.stagingOff,
@@ -882,6 +1027,10 @@ __device__ __forceinline__ void progress_recv_consume_buf(
         group,
         chunk.dataOff,
         args...);
+    if (group.is_leader()) {
+      trace_allreduce_event(
+          traceContext, PipesTraceEventType::kAllReduceReduceCopyEnd, qpLane);
+    }
   }
 #else
   (void)group;
@@ -889,18 +1038,22 @@ __device__ __forceinline__ void progress_recv_consume_buf(
   (void)chunk;
   (void)dst;
   (void)payloadBytes;
+  (void)traceContext;
+  (void)qpLane;
   ((void)args, ...);
 #endif
 }
 
 template <typename Transport, typename CopyOp, typename Proto, typename... Args>
-__device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
+__device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once_impl(
     Transport& transport,
     ThreadGroup& group,
     void* __restrict__ dst,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
     const Timeout& timeout,
+    const PipesTraceAllReduceContext* traceContext,
+    PipesTraceProgressState* traceState,
     Args... args) {
   // Mirror of progress_send_once: the progress API is fixed-size only. A
   // variable-size policy would mis-size the DATA_READY/SLOT_FREE protocol and
@@ -945,6 +1098,9 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
   IbLocalChannel& localChannel = ch.channel;
   const IbgdaLocalBuffer localDataReady = ch.local.dataReady;
   const IbRemoteChannel remoteChannel = ch.remote;
+  const uint32_t numLanes = static_cast<uint32_t>(channelLayout.numLanes);
+  const uint8_t qpLane = static_cast<uint8_t>(
+      numLanes == 0 ? 0 : localChannel.recvDataReadyLaneCursor % numLanes);
   if (!progress_recv_ready(
           Proto{},
           transport,
@@ -952,7 +1108,10 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
           localChannel,
           localDataReady,
           protocolBytesThis,
-          timeout)) {
+          timeout,
+          traceContext,
+          traceState,
+          qpLane)) {
     return IbgdaSendRecvProgressStatus::Waiting;
   }
 
@@ -963,9 +1122,15 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
       chunk,
       dst,
       progress_params.payloadBytes,
+      traceContext,
+      qpLane,
       args...);
   group.sync();
 
+  if (group.is_leader()) {
+    trace_allreduce_event(
+        traceContext, PipesTraceEventType::kAllReduceBookkeepingBegin, qpLane);
+  }
   transport.signal(
       group, remoteChannel.slotFree, protocolBytesThis, IbDirection::Recv);
 
@@ -974,10 +1139,18 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
     transition_progress_stage(
         group, state, detail::IbSendRecvProgressStage::Done);
     store_progress_state(group, progressSlot, state);
+    if (group.is_leader()) {
+      trace_allreduce_event(
+          traceContext, PipesTraceEventType::kAllReduceBookkeepingEnd, qpLane);
+    }
     return IbgdaSendRecvProgressStatus::Done;
   }
 
   store_progress_state(group, progressSlot, state);
+  if (group.is_leader()) {
+    trace_allreduce_event(
+        traceContext, PipesTraceEventType::kAllReduceBookkeepingEnd, qpLane);
+  }
   return IbgdaSendRecvProgressStatus::Progressed;
 #else
   (void)transport;
@@ -986,8 +1159,55 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
   (void)nbytes;
   (void)max_signal_bytes;
   (void)timeout;
+  (void)traceContext;
+  (void)traceState;
   return IbgdaSendRecvProgressStatus::Done;
 #endif
+}
+
+template <typename Transport, typename CopyOp, typename Proto, typename... Args>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
+    Transport& transport,
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    Args... args) {
+  return progress_recv_once_impl<Transport, CopyOp, Proto>(
+      transport,
+      group,
+      dst,
+      nbytes,
+      max_signal_bytes,
+      timeout,
+      nullptr,
+      nullptr,
+      args...);
+}
+
+template <typename Transport, typename CopyOp, typename... Args>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus
+progress_recv_once_with_trace(
+    Transport& transport,
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    const PipesTraceAllReduceContext& traceContext,
+    PipesTraceProgressState& traceState,
+    Args... args) {
+  return progress_recv_once_impl<Transport, CopyOp, protocol::Simple>(
+      transport,
+      group,
+      dst,
+      nbytes,
+      max_signal_bytes,
+      timeout,
+      &traceContext,
+      &traceState,
+      args...);
 }
 
 /**

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -2199,6 +2199,30 @@ class P2pIbgdaTransportDevice {
     return detail::progress_registered_send_drain_once(*this, group, timeout);
   }
 
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus
+  progress_send_once_with_trace(
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      const PipesTraceAllReduceContext& traceContext,
+      PipesTraceProgressState& traceState,
+      Args... args) {
+    return detail::
+        progress_send_once_with_trace<P2pIbgdaTransportDevice, CopyOp>(
+            *this,
+            group,
+            src,
+            nbytes,
+            max_signal_bytes,
+            timeout,
+            traceContext,
+            traceState,
+            args...);
+  }
+
   /**
    * Attempt bounded progress on one initialized recv.
    *
@@ -2238,6 +2262,30 @@ class P2pIbgdaTransportDevice {
       Args... args) {
     return detail::progress_recv_once<P2pIbgdaTransportDevice, CopyOp>(
         *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus
+  progress_recv_once_with_trace(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      const PipesTraceAllReduceContext& traceContext,
+      PipesTraceProgressState& traceState,
+      Args... args) {
+    return detail::
+        progress_recv_once_with_trace<P2pIbgdaTransportDevice, CopyOp>(
+            *this,
+            group,
+            dst,
+            nbytes,
+            max_signal_bytes,
+            timeout,
+            traceContext,
+            traceState,
+            args...);
   }
 
   /**
@@ -2354,6 +2402,26 @@ class P2pIbgdaTransportDevice {
 #endif
   }
 
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void sendWithFineTrace(
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      const PipesTraceAllReduceContext& traceContext,
+      Args... args) {
+    detail::send_with_fine_trace<P2pIbgdaTransportDevice, CopyOp>(
+        *this,
+        group,
+        src,
+        nbytes,
+        max_signal_bytes,
+        timeout,
+        traceContext,
+        args...);
+  }
+
   /**
    * recv — receive one block's tile from pipelined RDMA.
    *
@@ -2440,6 +2508,26 @@ class P2pIbgdaTransportDevice {
           static_cast<uint16_t>(group.group_id));
     }
 #endif
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void recvWithFineTrace(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      const PipesTraceAllReduceContext& traceContext,
+      Args... args) {
+    detail::recv_with_fine_trace<P2pIbgdaTransportDevice, CopyOp>(
+        *this,
+        group,
+        dst,
+        nbytes,
+        max_signal_bytes,
+        timeout,
+        traceContext,
+        args...);
   }
 
   /**
@@ -2541,6 +2629,30 @@ class P2pIbgdaTransportDevice {
           static_cast<uint16_t>(group.group_id));
     }
 #endif
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void forwardWithFineTrace(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      P2pIbgdaTransportDevice& fwd,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      const PipesTraceAllReduceContext& recvTraceContext,
+      const PipesTraceAllReduceContext& sendTraceContext,
+      Args... args) {
+    detail::forward_with_fine_trace<CopyOp>(
+        *this,
+        group,
+        dst,
+        fwd,
+        nbytes,
+        max_signal_bytes,
+        timeout,
+        recvTraceContext,
+        sendTraceContext,
+        args...);
   }
 
   __device__ __forceinline__ IbLocalChannel& local_channel(uint32_t channelId) {

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1967,7 +1967,9 @@ cvars:
      Enable generic Pipes algorithm tracing. When enabled, CTA leaders write
      compact per-phase events to an HRDW ring buffer and a host background
      thread polls the buffer on an interval, so breadcrumbs are logged while
-     the kernel is still running (including when it hangs).
+     the kernel is still running (including when it hangs). This value is
+     sampled when the communicator initializes; leave it false for the normal
+     untraced kernel path.
 
  - name        : NCCL_CTRAN_PIPES_TRACE_RING_SIZE
    type        : uint64_t


### PR DESCRIPTION
Summary:

Select separate compile-time traced and untraced Ring/Tree kernel bodies. Initialize tracing once per communicator only when `NCCL_CTRAN_PIPES_TRACE_ENABLE` is set, leaving the default path free of fine-trace branches and atomics.

Reviewed By: rmahidhar

Differential Revision: D115527377


