### PR TITLE
Extend PipesTrace for PRIMS AllReduce profiling (#3568)

### DIFF
--- a/comms/pipes/scripts/pipestrace_to_perfetto.py
+++ b/comms/pipes/scripts/pipestrace_to_perfetto.py
@@ -43,6 +43,16 @@ IB_RECV_BEGIN = "ib_recv_begin"
 IB_RECV_END = "ib_recv_end"
 IB_FORWARD_BEGIN = "ib_forward_begin"
 IB_FORWARD_END = "ib_forward_end"
+AR_PHASE1_BEGIN = "allreduce_phase1_begin"
+AR_PHASE1_END = "allreduce_phase1_end"
+AR_PHASE2_BEGIN = "allreduce_phase2_begin"
+AR_PHASE2_END = "allreduce_phase2_end"
+AR_PHASE3_BEGIN = "allreduce_phase3_begin"
+AR_PHASE3_END = "allreduce_phase3_end"
+AR_RING_RS_BEGIN = "allreduce_ring_rs_begin"
+AR_RING_RS_END = "allreduce_ring_rs_end"
+AR_RING_AG_BEGIN = "allreduce_ring_ag_begin"
+AR_RING_AG_END = "allreduce_ring_ag_end"
 
 IB_SEND = "ib_send"
 IB_RECV = "ib_recv"
@@ -61,14 +71,29 @@ IB_NAMES = frozenset(
     }
 )
 NVL_NAMES = frozenset({AG_NVL_WAIT_BEGIN, AG_NVL_CHUNK_READY, AG_NVL_TASK_DONE})
-KNOWN_EVENT_NAMES = IB_NAMES | NVL_NAMES
+AR_PAIRS = {
+    AR_PHASE1_END: (AR_PHASE1_BEGIN, "allreduce_phase1", "input/reduce-scatter"),
+    AR_PHASE2_END: (AR_PHASE2_BEGIN, "allreduce_phase2", "inter-node"),
+    AR_PHASE3_END: (AR_PHASE3_BEGIN, "allreduce_phase3", "output/all-gather"),
+    AR_RING_RS_END: (AR_RING_RS_BEGIN, "allreduce_ring_rs", "ring reduce-scatter"),
+    AR_RING_AG_END: (AR_RING_AG_BEGIN, "allreduce_ring_ag", "ring all-gather"),
+}
+AR_BEGIN_NAMES = frozenset(v[0] for v in AR_PAIRS.values())
+AR_NAMES = frozenset(AR_PAIRS) | AR_BEGIN_NAMES
+KNOWN_EVENT_NAMES = IB_NAMES | NVL_NAMES | AR_NAMES
 
-# +100/+200 keep IB and NVL tracks visually grouped per process, with room
-# for additional virtual tracks without colliding.
+# `detail` is uint16_t, so one full uint16 range per kind makes track IDs
+# disjoint for every representable block index.
+THREAD_KIND_STRIDE = 1 << 16
 THREAD_OFFSET_IB = 100
-THREAD_OFFSET_NVL = 200
+THREAD_OFFSET_NVL = THREAD_OFFSET_IB + THREAD_KIND_STRIDE
+THREAD_OFFSET_AR = THREAD_OFFSET_NVL + THREAD_KIND_STRIDE
 
-_PREFIX = r"^\[1,(?P<mpi_rank>\d+)\]<(?:stderr|stdout)>:"
+_PREFIX = (
+    r"^(?:\[1,(?P<mpi_rank>\d+)\]<(?:stderr|stdout)>:"
+    r"|\[(?P<mast_rank>\d+)\]:)"
+)
+_MAST_STREAM_WRAPPER = r"(?:\[(?:stderr|stdout)\]\s*)?"
 _TRACE_LOG_PREFIX = r"(?:Prims|Pipes) trace"
 
 # `[^\[]*?` forbids a stray "[" in the gap between rank prefix and the trace
@@ -76,7 +101,7 @@ _TRACE_LOG_PREFIX = r"(?:Prims|Pipes) trace"
 # mid-line under load. Without this, the regex would backtrack across the
 # splice and synthesize a wrong-rank event.
 EVENT_RE: re.Pattern[str] = re.compile(
-    _PREFIX + rf"[^\[]*?{_TRACE_LOG_PREFIX} event=(?P<name>\w+)"
+    _PREFIX + rf"[^\[]*?{_MAST_STREAM_WRAPPER}{_TRACE_LOG_PREFIX} event=(?P<name>\w+)"
     r" step=(?P<step>\d+)"
     r" rank=(?P<rank>-?\d+)"
     r" detail=(?P<detail>\d+)"
@@ -85,11 +110,13 @@ EVENT_RE: re.Pattern[str] = re.compile(
 )
 
 LOSS_RE: re.Pattern[str] = re.compile(
-    _PREFIX + rf"[^\[]*?{_TRACE_LOG_PREFIX} lost (?P<lost>\d+) entries\s*$"
+    _PREFIX
+    + rf"[^\[]*?{_MAST_STREAM_WRAPPER}{_TRACE_LOG_PREFIX} lost (?P<lost>\d+) entries\s*$"
 )
 
 LEGACY_DRAIN_RE: re.Pattern[str] = re.compile(
-    _PREFIX + rf"[^\[]*?{_TRACE_LOG_PREFIX} drain entries_read=(?P<read>\d+)"
+    _PREFIX
+    + rf"[^\[]*?{_MAST_STREAM_WRAPPER}{_TRACE_LOG_PREFIX} drain entries_read=(?P<read>\d+)"
     r" entries_lost=(?P<lost>\d+)"
     r" last_read=(?P<last>\d+)\s*$"
 )
@@ -163,6 +190,9 @@ class PairState:
     pending_ib_forward: dict[tuple[int, int], Event] = dataclasses.field(
         default_factory=dict
     )
+    pending_allreduce: dict[tuple[str, int, int], Event] = dataclasses.field(
+        default_factory=dict
+    )
 
 
 def _open_log(path: str) -> TextIO:
@@ -189,8 +219,9 @@ def _parse_event_line(line: str) -> Event | None:
     name = m["name"]
     if name not in KNOWN_EVENT_NAMES:
         return None
+    prefix_rank = m["mpi_rank"] or m["mast_rank"]
     return Event(
-        mpi_rank=int(m["mpi_rank"]),
+        mpi_rank=int(prefix_rank),
         name=name,
         step=int(m["step"]),
         rank=int(m["rank"]),
@@ -273,6 +304,8 @@ def filter_events(
         if "ib" not in type_filter and e.name in IB_NAMES:
             continue
         if "nvl" not in type_filter and e.name in NVL_NAMES:
+            continue
+        if "allreduce" not in type_filter and e.name in AR_NAMES:
             continue
         if time_start is not None and e.ns < time_start:
             continue
@@ -540,6 +573,48 @@ def _drain_state(state: PairState, unmatched: list[tuple[Event, str]]) -> None:
         unmatched.append((event, f"{event.name} without matching end"))
     for _, event in state.pending_ib_forward.items():
         unmatched.append((event, f"{event.name} without matching end"))
+    for _, event in state.pending_allreduce.items():
+        unmatched.append((event, f"{event.name} without matching end"))
+
+
+def _handle_allreduce_event(
+    state: PairState,
+    e: Event,
+    slices: list[Slice_],
+    unmatched: list[tuple[Event, str]],
+) -> None:
+    if e.name in AR_BEGIN_NAMES:
+        key = (e.name, e.group, e.step)
+        previous = state.pending_allreduce.get(key)
+        if previous is not None:
+            unmatched.append((previous, f"{previous.name} without matching end"))
+        state.pending_allreduce[key] = e
+        return
+
+    begin_name, category, display_name = AR_PAIRS[e.name]
+    begin = state.pending_allreduce.pop((begin_name, e.group, e.step), None)
+    if begin is None:
+        unmatched.append((e, f"{e.name} without matching begin"))
+        return
+    slices.append(
+        Slice_(
+            pid=state.mpi_rank,
+            tid=THREAD_OFFSET_AR + e.group,
+            cat=category,
+            name=display_name,
+            begin_ns=begin.ns,
+            end_ns=e.ns,
+            args={
+                "block": e.group,
+                "step": e.step,
+                "slot_begin": begin.slot,
+                "slot_end": e.slot,
+                "begin_ns": begin.ns,
+                "end_ns": e.ns,
+                "dur_ns": e.ns - begin.ns,
+            },
+        )
+    )
 
 
 def _handle_ib_event(
@@ -609,6 +684,8 @@ def pair_events(
                 unpaired_instant_count += _handle_ib_event(state, e, slices, unmatched)
             elif e.name in NVL_NAMES:
                 _handle_nvl_event(state, e, slices, unmatched)
+            elif e.name in AR_NAMES:
+                _handle_allreduce_event(state, e, slices, unmatched)
             else:
                 unmatched.append((e, f"unknown event name {e.name!r}"))
         _drain_state(state, unmatched)
@@ -654,7 +731,9 @@ def _emit_metadata(
             }
         )
         for tid in sorted(used_tids.get(pid, set())):
-            if tid >= THREAD_OFFSET_NVL:
+            if tid >= THREAD_OFFSET_AR:
+                kind, block = "AllReduce", tid - THREAD_OFFSET_AR
+            elif tid >= THREAD_OFFSET_NVL:
                 kind, block = "NVL", tid - THREAD_OFFSET_NVL
             else:
                 kind, block = "IB", tid - THREAD_OFFSET_IB
@@ -790,8 +869,8 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--types",
         type=parse_csv_strs,
-        default={"ib", "nvl"},
-        help="Block kinds to include: ib,nvl. Default: ib,nvl.",
+        default={"ib", "nvl", "allreduce"},
+        help=("Block kinds to include: ib,nvl,allreduce. Default: ib,nvl,allreduce."),
     )
     p.add_argument(
         "--time-start",
@@ -823,8 +902,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         format="%(levelname)s %(name)s: %(message)s",
     )
 
-    if "ib" not in args.types and "nvl" not in args.types:
-        logger.error("--types must include at least one of ib,nvl")
+    if not args.types.intersection({"ib", "nvl", "allreduce"}):
+        logger.error("--types must include at least one of ib,nvl,allreduce")
         return 1
 
     stats = ParseStats()

--- a/comms/pipes/scripts/tests/test_pipestrace_to_perfetto.py
+++ b/comms/pipes/scripts/tests/test_pipestrace_to_perfetto.py
@@ -38,6 +38,38 @@ def _loss_line(rank: int, lost: int) -> str:
     )
 
 
+def _mast_event_line(
+    local_rank: int,
+    name: str,
+    step: int,
+    comm_rank: int,
+    detail: int,
+    slot: int,
+    ns: int,
+) -> str:
+    return (
+        f"[{local_rank}]:I0531 12:00:00.000000 1234 PipesTrace.cc:168] "
+        f"Prims trace event={name} step={step} rank={comm_rank} "
+        f"detail={detail} slot={slot} wall_time_ns={ns}\n"
+    )
+
+
+def _mast_wrapped_event_line(
+    local_rank: int,
+    name: str,
+    step: int,
+    comm_rank: int,
+    detail: int,
+    slot: int,
+    ns: int,
+) -> str:
+    return (
+        f"[{local_rank}]:INFO:root:[stderr] Prims trace event={name} "
+        f"step={step} rank={comm_rank} detail={detail} slot={slot} "
+        f"wall_time_ns={ns}\n"
+    )
+
+
 class EventRegexTest(unittest.TestCase):
     def test_matches_well_formed_event(self) -> None:
         line = _event_line(7, ptp.AG_IB_BEGIN, 3, 3, 0, 0, 1780268274964010916)
@@ -61,6 +93,22 @@ class EventRegexTest(unittest.TestCase):
         assert event is not None
         self.assertEqual(0, event.step)
         self.assertEqual(-1, event.rank)
+
+    def test_allreduce_mast_line_uses_log_prefix_rank(self) -> None:
+        line = _mast_event_line(0, ptp.AR_PHASE2_BEGIN, 0, 3, 0, 0, 100)
+        event = ptp._parse_event_line(line)
+        self.assertIsNotNone(event)
+        assert event is not None
+        self.assertEqual(0, event.mpi_rank)
+        self.assertEqual(ptp.AR_PHASE2_BEGIN, event.name)
+
+    def test_allreduce_mast_stream_wrapper(self) -> None:
+        line = _mast_wrapped_event_line(0, ptp.AR_PHASE2_BEGIN, 7, 3, 2, 11, 100)
+        event = ptp._parse_event_line(line)
+        self.assertIsNotNone(event)
+        assert event is not None
+        self.assertEqual(0, event.mpi_rank)
+        self.assertEqual(2, event.group)
 
 
 class ParseEventsTest(unittest.TestCase):
@@ -188,6 +236,27 @@ class PairNvlTest(unittest.TestCase):
         self.assertEqual([], slices)
         self.assertEqual(1, len(unmatched))
         self.assertIn("task_done", unmatched[0][1])
+
+
+class PairAllReduceTest(unittest.TestCase):
+    def test_phase_and_nested_ring_slices(self) -> None:
+        evs = [
+            ptp.Event(3, ptp.AR_PHASE2_BEGIN, 0, 3, 0, 0, 100),
+            ptp.Event(3, ptp.AR_RING_RS_BEGIN, 0, 3, 0, 1, 110),
+            ptp.Event(3, ptp.AR_RING_RS_END, 0, 3, 0, 2, 150),
+            ptp.Event(3, ptp.AR_RING_AG_BEGIN, 0, 3, 0, 3, 160),
+            ptp.Event(3, ptp.AR_RING_AG_END, 0, 3, 0, 4, 190),
+            ptp.Event(3, ptp.AR_PHASE2_END, 0, 3, 0, 5, 200),
+        ]
+        slices, unpaired_instant_count, unmatched = ptp.pair_events({3: evs})
+        self.assertEqual(0, unpaired_instant_count)
+        self.assertEqual([], unmatched)
+        self.assertCountEqual(
+            ["inter-node", "ring reduce-scatter", "ring all-gather"],
+            [s.name for s in slices],
+        )
+        phase2 = next(s for s in slices if s.name == "inter-node")
+        self.assertEqual(100, phase2.args["dur_ns"])
 
 
 class BuildTraceTest(unittest.TestCase):

--- a/comms/prims/trace/PipesTrace.cc
+++ b/comms/prims/trace/PipesTrace.cc
@@ -5,6 +5,7 @@
 #include <pthread.h>
 
 #include <chrono>
+#include <cstdio>
 #include <exception>
 #include <memory>
 #include <mutex>
@@ -43,6 +44,26 @@ const char* pipesTraceEventTypeName(uint8_t type) {
       return "ib_forward_begin";
     case Type::kIbForwardEnd:
       return "ib_forward_end";
+    case Type::kAllReducePhase1Begin:
+      return "allreduce_phase1_begin";
+    case Type::kAllReducePhase1End:
+      return "allreduce_phase1_end";
+    case Type::kAllReducePhase2Begin:
+      return "allreduce_phase2_begin";
+    case Type::kAllReducePhase2End:
+      return "allreduce_phase2_end";
+    case Type::kAllReducePhase3Begin:
+      return "allreduce_phase3_begin";
+    case Type::kAllReducePhase3End:
+      return "allreduce_phase3_end";
+    case Type::kAllReduceRingReduceScatterBegin:
+      return "allreduce_ring_rs_begin";
+    case Type::kAllReduceRingReduceScatterEnd:
+      return "allreduce_ring_rs_end";
+    case Type::kAllReduceRingAllGatherBegin:
+      return "allreduce_ring_ag_begin";
+    case Type::kAllReduceRingAllGatherEnd:
+      return "allreduce_ring_ag_end";
   }
   return "unknown";
 }
@@ -119,11 +140,12 @@ void PipesTrace::ensure(
   pollInterval_ = pollInterval;
   eventCallback_ = std::move(eventCallback);
   startPollThread();
-  CLOGF(
-      INFO,
-      "Prims trace buffer ready ring_size={} poll_interval_ms={}",
-      buffer_->size(),
+  std::fprintf(
+      stderr,
+      "Prims trace buffer ready ring_size=%u poll_interval_ms=%lld\n",
+      static_cast<unsigned int>(buffer_->size()),
       static_cast<long long>(pollInterval_.count()));
+  std::fflush(stderr);
 }
 
 PipesTraceHandle PipesTrace::deviceHandle() const {
@@ -169,15 +191,15 @@ void PipesTrace::logBatch(const PendingLogBatch& batch) const {
             wallTime.time_since_epoch())
             .count();
     const auto& event = entry.data;
-    CLOGF(
-        INFO,
-        "Prims trace event={} step={} rank={} detail={} slot={} wall_time_ns={}",
+    std::fprintf(
+        stderr,
+        "Prims trace event=%s step=%u rank=%u detail=%u slot=%llu wall_time_ns=%lld\n",
         pipesTraceEventTypeName(event.type),
         event.step,
-        static_cast<int>(event.rank),
+        static_cast<unsigned int>(event.rank),
         event.detail,
-        pendingEntry.slot,
-        wallTimeNs);
+        static_cast<unsigned long long>(pendingEntry.slot),
+        static_cast<long long>(wallTimeNs));
     if (eventCallback_ != nullptr) {
       eventCallback_(event, pendingEntry.slot);
     }
@@ -185,6 +207,9 @@ void PipesTrace::logBatch(const PendingLogBatch& batch) const {
 
   if (batch.entriesLost != 0) {
     CLOGF(WARN, "Prims trace lost {} entries", batch.entriesLost);
+  }
+  if (!batch.entries.empty()) {
+    std::fflush(stderr);
   }
 }
 

--- a/comms/prims/trace/PipesTraceTypes.h
+++ b/comms/prims/trace/PipesTraceTypes.h
@@ -24,6 +24,17 @@ enum class PipesTraceEventType : uint8_t {
   kIbRecvEnd = 9,
   kIbForwardBegin = 10,
   kIbForwardEnd = 11,
+
+  kAllReducePhase1Begin = 12,
+  kAllReducePhase1End = 13,
+  kAllReducePhase2Begin = 14,
+  kAllReducePhase2End = 15,
+  kAllReducePhase3Begin = 16,
+  kAllReducePhase3End = 17,
+  kAllReduceRingReduceScatterBegin = 18,
+  kAllReduceRingReduceScatterEnd = 19,
+  kAllReduceRingAllGatherBegin = 20,
+  kAllReduceRingAllGatherEnd = 21,
 };
 
 struct PipesTraceEvent {


### PR DESCRIPTION
Summary:

Extend PipesTrace event metadata and Perfetto conversion so sampled PRIMS AllReduce events retain rank, phase, dependency, lane, peer, QP, and byte context. Add converter coverage for the new metadata.

Reviewed By: rmahidhar

Differential Revision: D114979116


