### PR TITLE
Add CUDA toolkit CCCL include (#3571)

### DIFF
--- a/comms/torchcomms/ncclx/CMakeLists.txt
+++ b/comms/torchcomms/ncclx/CMakeLists.txt
@@ -118,6 +118,8 @@ target_include_directories(torchcomms_comms_ncclx PRIVATE
     ${ROOT}
     ${NCCLX_INCLUDE}
     ${CONDA_INCLUDE}
+    ${CUDA_INCLUDE_DIRS}
+    ${CUDA_INCLUDE_DIRS}/cccl
     ${Python3_INCLUDE_DIRS}
 )
 torchcomms_use_torch_pybind11(torchcomms_comms_ncclx)


### PR DESCRIPTION
Summary:

Add `${CUDA_INCLUDE_DIRS}` and `${CUDA_INCLUDE_DIRS}/cccl` to `torchcomms_comms_ncclx` so host C++ compilation can find the CCCL headers shipped with the matching CUDA toolkit. D114901579 exposed the dependency and added the nested toolkit include path to the sibling Prims, CTRAN, MCCL, and NCCLX builds, but missed the standalone TorchComms NCCLX target. H100 build logs show CUDA 13.1 at `/usr/local/cuda`; the failing command included `/usr/local/cuda/include` but omitted `/usr/local/cuda/include/cccl`.

Reviewed By: Scusemua

Differential Revision: D115584514
