### PR TITLE
Parallelize copy-based Ring AllReduce Phase 2 with virtual IB stripes (+18.6% at 1 GiB) (#3573)

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3467,6 +3467,14 @@ cvars:
 
      Tree only today; ring and direct always use Simple.
 
+ - name        : MCCL_ALLREDUCE_IB_VIRTUAL_STRIPES
+   type        : int
+   default     : 1
+   description : |-
+     Number of independent Phase-2 IB progress groups per physical CUDA block
+     in MCCL fused AllReduce. Ring supports 1, 2, and 4; Tree currently uses 1.
+     The default preserves the existing full-block protocol.
+
  - name        : MCCL_MAX_NCHANNELS
    type        : int
    default     : 32


### PR DESCRIPTION
Summary:

## Where this sits

```
Fused AllReduce kernel, one CUDA block
──────────────────────────────────────────────────────────────────────
  Phase 1                 Phase 2                  Phase 3
  NVL ReduceScatter  ──>  IB cross-node       ──>  NVL AllGather
  across local peers      exchange (ring)          across local peers
                          ▲
                          └── everything below changes only this phase
──────────────────────────────────────────────────────────────────────
  nNodes == 1      -> Phase 2 skipped
  nLocalRanks == 1 -> Phase 3 skipped, Phase 1 degenerates to a copy
```

## Problem

Phase 2 ran with **one IB progress group per physical CUDA block**. A 640-thread CTA therefore had exactly one logical send/recv stream to advance, so most of the block sat blocked on a single QP's completions while the reduce and copy units idled.

```
Time ─────────────────────────────────────────────────────────────>

  1 stripe    [issue]├──────── wait on NIC ────────┤[issue]├── wait ──┤
              one channel: the CTA has nothing else to issue,
              so the whole block stalls on every completion
```

At one CTA and 1 GiB the Ring reached only 9.33 GB/s. The obvious remedy -- launch more CTAs -- buys parallel streams with SM residency, which is precisely what training jobs want back. The parallelism has to come from inside the block.

## Why sub-block groups work

IBGDA keys its channel resources off `ThreadGroup::group_id`, **not** the physical block. `select_put_lane()` and `lane_from_ordinal()` derive the QP slot, the per-channel `IbQpState` cursor and the staging ring from `group.group_id`; `validate_channel_id()` bounds it by `MCCL_MAX_NCHANNELS`.

So a sub-block thread group with its own `group_id` gets a genuinely independent transport stream. This sidesteps -- rather than bets against -- the transport's documented warning that "the block_id owns one logical ordered stream" and that same-block multi-warp batching is not an ordering contract.

## The change

`MCCL_ALLREDUCE_IB_VIRTUAL_STRIPES` (new, default 1) partitions each block tile into 2 or 4 independent progress groups.

```
BEFORE   MCCL_ALLREDUCE_IB_VIRTUAL_STRIPES=1
──────────────────────────────────────────────────────────────────────
  ┌────────────────────────────────┐
  │  CTA  ·  640 threads           │
  │  one progress group            │        ┌──────────────────────┐
  │  group_id = blockId            │───────>│  channel[blockId]    │
  │  barrier  = 0  (whole block)   │        │   QP lanes           │
  └────────────────────────────────┘        │   IbQpState cursor   │
                                            │   staging ring       │
                                            └──────────────────────┘
              1 serialized transport stream per CTA


AFTER    MCCL_ALLREDUCE_IB_VIRTUAL_STRIPES=4
──────────────────────────────────────────────────────────────────────
  ┌────────────────────────────────┐
  │  CTA  ·  640 threads           │
  ├────────────────────────────────┤
  │ stripe 0 · 160 thr · barrier 1 │───────>  channel[4*blockId + 0]
  │ stripe 1 · 160 thr · barrier 2 │───────>  channel[4*blockId + 1]
  │ stripe 2 · 160 thr · barrier 3 │───────>  channel[4*blockId + 2]
  │ stripe 3 · 160 thr · barrier 4 │───────>  channel[4*blockId + 3]
  └────────────────────────────────┘
              4 independent transport streams per CTA
              each with its own QP lanes, cursor and staging ring
              identical SM residency
```

## Why that is faster

```
Time ─────────────────────────────────────────────────────────────>

  1 stripe   [issue]├─────── wait ───────┤[issue]├─────── wait ──────┤

  4 stripes  S0 [iss]├────── wait ──────┤[iss]├────── wait ──────┤
             S1    [iss]├────── wait ──────┤[iss]├────── wait ─────┤
             S2       [iss]├────── wait ──────┤[iss]├────── wait ──┤
             S3          [iss]├────── wait ──────┤[iss]├─── wait ──┤
                        ▲
                        └── one stripe's wait is another's issue window;
                            the NIC stays fed, the CTA stops idling
```

## Data ownership

Each stripe owns a disjoint slice, so no coordination is needed between them:

```
phase2Buf  (this rank's owner segment)
│
├─ block tile 0
│    ├─ stripe 0 tile ─┬─ node sub-shard 0    ┐
│    │                 ├─ node sub-shard 1    ├─ ring reduce-scatter,
│    │                 ├─ ...                 │  then ring all-gather
│    │                 └─ node sub-shard W-1  ┘
│    ├─ stripe 1 tile ── same structure, own channel
│    ├─ stripe 2 tile ── same structure, own channel
│    └─ stripe 3 tile ── same structure, own channel
│
└─ block tile 1 .. N-1 ── same structure
```

```
Ring Phase 2 over W nodes, per stripe tile (W = 4 shown)

     node 0 ──> node 1 ──> node 2 ──> node 3 ──┐
        ▲                                      │
        └──────────────────────────────────────┘

  reduce-scatter                    all-gather
  ─────────────────────────────     ─────────────────────────────
  step 0    send shard[me]          step 0    send shard[me+1]
  step 1..W-2  recv, reduce         step 1..W-2  recv, store,
               local, forward                    forward
  step W-1  recv, reduce into       step W-1  recv, store into
            tile shard[me+1]                  tile shard[me+2]
```

## Named barriers

```
CTA named-barrier map (hardware limit: 16 ids)

  id 0     __syncthreads()  ── whole block: Phase 1/3, phase transitions
  id 1     stripe 0
  id 2     stripe 1
  id 3     stripe 2
  id 4     stripe 3
  id 5-15  unused (headroom for the 10-stripe geometry)
```

Barrier 0 is deliberately left to `__syncthreads()`, so stripe barriers never collide with a block-wide sync.

## Implementation notes

**Device.** `splitIbPhaseGroup()` and `makeIbPhaseStripe()` build the stripe group and its tile. `phase2IbRing()` dispatches into `phase2IbRingGroup<T, TraceEnabled, kGroupSize>`, parameterised on the group width instead of assuming a whole block. A `blockGroup.sync()` brackets the striped region -- load-bearing, not defensive: Phase 1 tiles `phase2Buf` across the *block* group and syncs only when it actually copied, so without the leading barrier a stripe could read bytes a different thread had not yet written. `GroupTileElems<T, kGroupSize>` derives tile geometry from the real group width, holding vectors-per-thread at 6 for every stripe count (640/320/160 threads) so reduction ILP is stripe-invariant.

**Host.** Reserves `numBlocks * virtualStripes` IB groups and validates against `MCCL_MAX_NCHANNELS`; rejects stripe counts other than 1, 2 and 4; rejects striped execution on AMD, which has no CUDA named barriers.

## Compatibility

The CVAR defaults to 1, reproducing the existing full-block protocol and launch geometry exactly. PipesTrace stays disabled by default and keeps its traced/untraced kernel separation.

```
Channel budget when enabling stripes

  numBlocks x stripes  must fit inside  MCCL_MAX_NCHANNELS (default 32)

  numBlocks   1 stripe   2 stripes   4 stripes
  ─────────   ────────   ─────────   ─────────
      1           1          2           4      ok
      2           2          4           8      ok
      8           8         16          32      ok (at the cap)
     16          16         32          64      exceeds -> rejected

  MCCL_MAX_NBLOCKS defaults to 16, and large messages select 16 blocks,
  so 4 stripes needs a lower block cap or a raised channel cap.
```

## Result

```
Ring bus bandwidth @ 1 GiB, one CTA, 4x1 GB300 NLH, IB-only FP32 sum

  1 stripe    ███████████████████                      9.33 GB/s
  4 stripes   █████████████████████████████████       16.30 GB/s  +74.7%
              └────┴────┴────┴────┴────┴────┴────┴────┘
              0    2    4    6    8   10   12   14   16
```

| measurement | before | after | delta |
| --- | --- | --- | --- |
| 1 CTA, 1 vs 4 stripes, same job | 9.33 GB/s | 16.30 GB/s | +74.7% |
| 1 CTA, sweep vs D115527617 | 16.19 GB/s | 19.20 GB/s | +18.6% |
| 2 CTAs, sweep vs D115527617 | 31.93 GB/s | 37.85 GB/s | +18.5% |

Geometric mean over 128 MiB - 1 GiB: +18.7% at one CTA, +6.1% at two.

Reviewed By: rmahidhar, saifhhasan, zhiyongww, Scusemua

Differential Revision: D115593804


