### PR TITLE
Parallelize copy-based Tree AllReduce Phase 2 with two virtual IB stripes (+22.1% at 1 GiB) (#3574)

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3467,6 +3467,14 @@ cvars:
 
      Tree only today; ring and direct always use Simple.
 
+ - name        : MCCL_ALLREDUCE_IB_VIRTUAL_STRIPES
+   type        : int
+   default     : 1
+   description : |-
+     Number of independent Phase-2 IB progress groups per physical CUDA block
+     in MCCL fused AllReduce. Ring supports 1, 2, and 4; Tree currently uses 1.
+     The default preserves the existing full-block protocol.
+
  - name        : MCCL_MAX_NCHANNELS
    type        : int
    default     : 32

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3472,7 +3472,7 @@ cvars:
    default     : 1
    description : |-
      Number of independent Phase-2 IB progress groups per physical CUDA block
-     in MCCL fused AllReduce. Ring supports 1, 2, and 4; Tree currently uses 1.
+     in MCCL fused AllReduce. Ring supports 1, 2, and 4; Tree supports 1 and 2.
      The default preserves the existing full-block protocol.
 
  - name        : MCCL_MAX_NCHANNELS


### PR DESCRIPTION
Summary:

## Where this sits

```
Fused AllReduce kernel, one CUDA block
──────────────────────────────────────────────────────────────────────
  Phase 1                 Phase 2                  Phase 3
  NVL ReduceScatter  ──>  IB cross-node       ──>  NVL AllGather
  across local peers      exchange (dual tree)     across local peers
                          ▲
                          └── this diff changes only this phase
```

```
What "dual tree" means here
──────────────────────────────────────────────────────────────────────
  each tile is split in half; the halves travel two independent trees
  with different roots, so both directions of every link carry traffic

     lane Tree0   ── reduce up ──> root A ── broadcast down ──>
     lane Tree1   ── reduce up ──> root B ── broadcast down ──>

  one thread group alternates between them: whichever lane is not
  blocked on a remote signal gets advanced
```

## Problem

The Tree already overlapped work two ways -- when Tree0 blocked, the block advanced Tree1. What it could not overlap was the **transport** dimension. Both lanes belonged to one physical block with only two IB progress groups, so when both lanes were waiting on completions the CTA had nothing left to issue.

```
Time ─────────────────────────────────────────────────────────────>

  BEFORE   one progress group, two lanes
    L0  [iss]├──── wait ────┤[iss]├──── wait ────┤
    L1      [iss]├──── wait ────┤[iss]├──── wait ────┤
                             ▲▲▲
                             both lanes waiting -> CTA idle
```

At one CTA and 1 GiB the Tree sat at 12.82 GB/s.

## The change

Apply the virtual-stripe mechanism from D115593804. Split the CTA into two 320-thread subgroups with distinct transport group and named-barrier identities, and give **each** subgroup its own complete dual-tree lane scheduler.

```
BEFORE   MCCL_ALLREDUCE_IB_VIRTUAL_STRIPES=1
──────────────────────────────────────────────────────────────────────
  ┌──────────────────────────────────┐
  │  CTA · 640 threads · barrier 0   │
  │    ├─ lane Tree0  ───────────────┼──>  channel[2*blockId]
  │    └─ lane Tree1  ───────────────┼──>  channel[2*blockId + 1]
  └──────────────────────────────────┘
                    2 concurrent tree lanes per CTA


AFTER    MCCL_ALLREDUCE_IB_VIRTUAL_STRIPES=2
──────────────────────────────────────────────────────────────────────
  ┌──────────────────────────────────────────────────────────┐
  │  CTA · 640 threads                                       │
  ├──────────────────────────────────────────────────────────┤
  │  stripe 0 · 320 thr · barrier 1 ·  g = 2*blockId + 0     │
  │     ├─ lane Tree0 ───────────────────>  channel[2*g]     │
  │     └─ lane Tree1 ───────────────────>  channel[2*g + 1] │
  ├──────────────────────────────────────────────────────────┤
  │  stripe 1 · 320 thr · barrier 2 ·  g = 2*blockId + 1     │
  │     ├─ lane Tree0 ───────────────────>  channel[2*g]     │
  │     └─ lane Tree1 ───────────────────>  channel[2*g + 1] │
  └──────────────────────────────────────────────────────────┘
                    4 concurrent tree lanes per CTA
```

Every channel carries its own QP lanes, `IbQpState` cursor and staging ring, so the stripes progress genuinely independently rather than contending for one ordered stream.

## Why that is faster

```
Time ─────────────────────────────────────────────────────────────>

  AFTER   two stripes x two lanes
    S0 L0  [iss]├─── wait ───┤[iss]├─── wait ───┤
    S0 L1     [iss]├─── wait ───┤[iss]├─── wait ───┤
    S1 L0        [iss]├─── wait ───┤[iss]├─── wait ───┤
    S1 L1           [iss]├─── wait ───┤[iss]├─── wait ──┤
                    ▲
                    └── four independent lanes: the both-waiting
                        gap closes, the NIC stays fed
```

## Data ownership

```
phase2Buf  (this rank's owner segment)
│
└─ block tile
     ├─ stripe 0 tile ─┬─ lane tile  ──>  Tree0   channel[2*g]
     │                 └─ lane tile  ──>  Tree1   channel[2*g + 1]
     └─ stripe 1 tile ─┬─ lane tile  ──>  Tree0   channel[2*g']
                       └─ lane tile  ──>  Tree1   channel[2*g' + 1]

  four disjoint slices, four channels, no coordination needed
```

## Implementation notes

**Device.** `phase2IbDualTree()` dispatches into `phase2IbDualTreeGroup<T, TraceEnabled, kGroupSize>`, parameterised on the subgroup width. Lane group ids become `ibGroup.group_id * kTreeLanes (+1)`, and the geometry assertion now accounts for stripes. `IbReduceCopy<T, kGroupSize>` and `progressTreeLane<T, TraceEnabled, kGroupSize>` take the real group width so tile striding matches the threads actually present. A `blockGroup.sync()` brackets the striped region, ordering Phase 1's block-wide tiling against the stripes' re-partitioned reads.

**Host.** Accepts one or two Tree stripes, counts both stripes when validating capacity (`numBlocks * stripes * kTreeLanes` against `MCCL_MAX_NCHANNELS`), requires IBGDA on every tree peer when striping is enabled, and rejects striped execution on AMD where CUDA named barriers are unavailable.

## Compatibility

`MCCL_ALLREDUCE_IB_VIRTUAL_STRIPES` remains 1 by default, preserving the existing Tree execution path exactly. PipesTrace remains disabled by default and records stripe-local scheduler and phase contexts only when explicitly enabled.

```
Channel budget: numBlocks x stripes x 2 lanes  <=  MCCL_MAX_NCHANNELS (32)

  numBlocks    1 stripe    2 stripes
  ─────────    ────────    ─────────
      1            2            4     ok
      4            8           16     ok
      8           16           32     ok (at the cap)
     16           32           64     exceeds -> rejected
```

## Result

```
Tree @ 1 GiB, one CTA, 4x1 GB300 NLH, IB-only FP32 sum
(1 char = 0.5 GB/s)

  before  D115593804    ██████████████████████████       12.82 GB/s
  NCCL Simple Tree      ██████████████████████████████   15.10 GB/s
  after   this diff     ███████████████████████████████  15.65 GB/s
                                                         ▲
                        crosses the NCCL Simple reference┘  +22.1%
```

```
Tree @ 1 GiB, two CTAs  (1 char = 1.0 GB/s)

  before                █████████████████████████        25.22 GB/s
  after                 ███████████████████████████████  30.74 GB/s  +21.9%
```

| CTAs | before | after | absolute gain | delta | vs D115527617 |
| --- | --- | --- | --- | --- | --- |
| 1 | 12.82 GB/s | 15.65 GB/s | +2.83 GB/s | +22.1% | +26.1% |
| 2 | 25.22 GB/s | 30.74 GB/s | +5.52 GB/s | +21.9% | +24.5% |

Geometric mean over 128 MiB - 1 GiB: +21.4%/+19.5%. The Ring is unaffected (+0.1%/+0.6% at 1 GiB, within run variation), confirming the two stripe implementations are independent.

Reviewed By: Scusemua, zhiyongww, rmahidhar

Differential Revision: D115593811


