### PR TITLE
Scale copy-based Ring AllReduce to an opt-in ten virtual IB stripe geometry (#3575)

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3467,6 +3467,14 @@ cvars:
 
      Tree only today; ring and direct always use Simple.
 
+ - name        : MCCL_ALLREDUCE_IB_VIRTUAL_STRIPES
+   type        : int
+   default     : 1
+   description : |-
+     Number of independent Phase-2 IB progress groups per physical CUDA block
+     in MCCL fused AllReduce. Ring supports 1, 2, and 4; Tree currently uses 1.
+     The default preserves the existing full-block protocol.
+
  - name        : MCCL_MAX_NCHANNELS
    type        : int
    default     : 32

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3472,7 +3472,7 @@ cvars:
    default     : 1
    description : |-
      Number of independent Phase-2 IB progress groups per physical CUDA block
-     in MCCL fused AllReduce. Ring supports 1, 2, and 4; Tree currently uses 1.
+     in MCCL fused AllReduce. Ring supports 1, 2, and 4; Tree supports 1 and 2.
      The default preserves the existing full-block protocol.
 
  - name        : MCCL_MAX_NCHANNELS

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3472,8 +3472,8 @@ cvars:
    default     : 1
    description : |-
      Number of independent Phase-2 IB progress groups per physical CUDA block
-     in MCCL fused AllReduce. Ring supports 1, 2, and 4; Tree supports 1 and 2.
-     The default preserves the existing full-block protocol.
+     in MCCL fused AllReduce. Ring supports 1, 2, 4, and 10; Tree supports 1
+     and 2. The default preserves the existing full-block protocol.
 
  - name        : MCCL_MAX_NCHANNELS
    type        : int


### PR DESCRIPTION
Summary:

## Motivation

D115593804 established that Ring Phase-2 throughput is limited by how many independent IB progress streams a single CTA can drive, and took that from 1 to 4. This diff answers the natural follow-up -- **where does that curve flatten?** -- by extending the geometry to ten warp-aligned 64-thread stripes, the finest split a 640-thread CTA supports while keeping every stripe warp-aligned and inside the 16 named-barrier hardware limit.

## Geometry

```
kBlockSize = 640 threads, split every supported way

  stripes   thr/stripe   warps   barrier ids   channels/block
  ───────   ──────────   ─────   ───────────   ──────────────
      1         640        20         0               1
      2         320        10        1-2              2
      4         160         5        1-4              4
     10          64         2        1-10            10       <- new
                                     ▲
                       barrier 0 stays reserved for __syncthreads()
```

```
The 640-thread CTA at ten stripes

  ┌─────┬─────┬─────┬─────┬─────┬─────┬─────┬─────┬─────┬─────┐
  │ S0  │ S1  │ S2  │ S3  │ S4  │ S5  │ S6  │ S7  │ S8  │ S9  │
  │64thr│64thr│64thr│64thr│64thr│64thr│64thr│64thr│64thr│64thr│
  │ 2 wp│ 2 wp│ 2 wp│ 2 wp│ 2 wp│ 2 wp│ 2 wp│ 2 wp│ 2 wp│ 2 wp│
  └──┬──┴──┬──┴──┬──┴──┬──┴──┬──┴──┬──┴──┬──┴──┬──┴──┬──┴──┬──┘
     │     │     │     │     │     │     │     │     │     │
     ▼     ▼     ▼     ▼     ▼     ▼     ▼     ▼     ▼     ▼
   ch0   ch1   ch2   ch3   ch4   ch5   ch6   ch7   ch8   ch9
     gid = 10*blockId + s          barrier = 1 + s

  ten independent transport streams from one CTA
```

Each stripe still owns an independent data tile, IB transport group and named-barrier identity. `GroupTileElems<T, 64>` keeps vectors-per-thread at 6, unchanged from every other stripe count, so reduction ILP does not shift with the geometry.

## What changes

Host-side validation, device dispatch and the CVAR documentation are extended for the ten-stripe geometry. Existing 1-, 2- and 4-stripe modes are untouched, `MCCL_ALLREDUCE_IB_VIRTUAL_STRIPES` continues to default to 1, and the CUDA-only restriction and opt-in PipesTrace behaviour are unchanged.

## Result: the curve has flattened

```
Ring @ 1 GiB, one CTA, pipeline depth 2
(axis starts at 18.0 GB/s to make the differences visible)

   4 stripes,  4 MiB buffer  ████████████████████████████         18.83
  10 stripes,  4 MiB buffer  █████████████████████████████████    18.99
  10 stripes,  8 MiB buffer  ████████████████████████████████████ 19.09
                             └───────┴───────┴───────┴───────┴───┘
                            18.0    18.3    18.6    18.9    19.2

  +1.4% for 2.5x the stripes -- returns have clearly flattened
```

Compare that with the first step of the curve, where the same axis would run off the page: 1 stripe to 4 stripes was 9.33 to 16.30 GB/s.

## Why this ships as a knob, not a default

```
  stripe count ──> throughput
  1 ──────────────────> 4              steep   (+74.7%, D115593804)
  4 ──────────────────> 10             flat    (+1.4%,  this diff)
```

The configuration the rest of the stack settles on is four stripes, where this diff's attribution sweep is neutral by construction (-0.2%/-0.8%, within run variation). The value is twofold: the mode is available for topologies or message sizes where finer splitting wins, and the ceiling is now **measured** rather than assumed, so the question does not need re-litigating later.

## Channel budget

```
  ten stripes consumes ten channels per block

  numBlocks    4 stripes    10 stripes
  ─────────    ─────────    ──────────
      1             4           10      ok
      2             8           20      ok
      3            12           30      ok
      4            16           40      exceeds MCCL_MAX_NCHANNELS=32

  realistic at one to three CTAs, not at the default 16-block cap
```

Reviewed By: zhiyongww, Scusemua, rmahidhar

Differential Revision: D115593806


