### PR TITLE
Migrate CTRAN AllToAll logs (#3579)

### DIFF
--- a/comms/ctran/algos/AllGather/AllGather.cc
+++ b/comms/ctran/algos/AllGather/AllGather.cc
@@ -5,6 +5,7 @@
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/ctran/utils/MathUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -55,7 +56,7 @@ bool ctranAllGatherSupport(
     case NCCL_ALLGATHER_ALGO::ctsrd:
       supported = statex->nLocalRanks() == 1;
       if (!supported) {
-        CLOGF_SUBSYS(
+        CTRAN_LOG_SUBSYS(
             WARN,
             COLL,
             "AllGather algorithm {} only support nLocalRanks=1. Falling back to baseline",
@@ -89,7 +90,7 @@ bool ctranAllGatherSupport(
       supported = (err == cudaSuccess) &&
           (captureInfo.status == cudaStreamCaptureStatusActive);
       if (!supported) {
-        CLOGF_SUBSYS(
+        CTRAN_LOG_SUBSYS(
             INFO,
             COLL,
             "AllGather {}: not in capture mode. "
@@ -108,7 +109,7 @@ bool ctranAllGatherSupport(
       if ((algo == NCCL_ALLGATHER_ALGO::ctgraph_ring ||
            algo == NCCL_ALLGATHER_ALGO::ctgraph_rd) &&
           statex->nLocalRanks() > 1) {
-        CLOGF_SUBSYS(
+        CTRAN_LOG_SUBSYS(
             WARN,
             COLL,
             "AllGather {} requires nLocalRanks==1, got {}. "
@@ -120,7 +121,7 @@ bool ctranAllGatherSupport(
       }
       if (algo == NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline &&
           !ctran::utils::isPowerOfTwo(statex->nNodes())) {
-        CLOGF_SUBSYS(
+        CTRAN_LOG_SUBSYS(
             WARN,
             COLL,
             "AllGather {} requires power-of-2 nNodes, got {}. "
@@ -132,7 +133,7 @@ bool ctranAllGatherSupport(
       }
       if (algo == NCCL_ALLGATHER_ALGO::ctgraph_rd &&
           !ctran::utils::isPowerOfTwo(statex->nRanks())) {
-        CLOGF_SUBSYS(
+        CTRAN_LOG_SUBSYS(
             WARN,
             COLL,
             "AllGather {} requires power-of-2 nRanks, got {}. "
@@ -194,13 +195,13 @@ commResult_t ctranAllGather(
   if (algo == NCCL_ALLGATHER_ALGO::ctran) {
     if (statex->nLocalRanks() > 1) {
       algo = NCCL_ALLGATHER_ALGO::ctdirect;
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO, COLL, "Running AllGather ctdirect algorithm for nLocalRanks>1");
     }
     // pick ctring for nLocalRanks=1 if user doesn't provide specific algo
     else if (statex->nLocalRanks() == 1) {
       algo = NCCL_ALLGATHER_ALGO::ctring;
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO, COLL, "Running AllGather ctring algorithm for nLocalRanks=1");
     }
   }

--- a/comms/ctran/algos/AllGather/AllGatherCtwin.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCtwin.cc
@@ -13,11 +13,11 @@
 #include "comms/ctran/algos/PersistentCleanup.h"
 #include "comms/ctran/mapper/CtranMapperTypes.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/MathUtils.h"
 #include "comms/ctran/window/CtranWin.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 
 using ctran::allgatherp::AlgoImpl;
 using ctran::allgatherp::destroyPersistentRequest;
@@ -136,7 +136,7 @@ bool checkCtranAllGatherCtwinSupport(
   }
   // Dormant until a caller passes a non-empty recvbuff.
   if (recvbuff == nullptr || recvBytes == 0) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         COLL,
         "AllGather {} unsupported: needs a non-empty recvbuff (recvbuff={}, recvBytes={}).",
@@ -149,7 +149,7 @@ bool checkCtranAllGatherCtwinSupport(
   // computes each peer's recvbuf as its window buffer at the same offset).
   auto* win = comm->findWindowForBuffer(recvbuff, recvBytes);
   if (win == nullptr || !win->isSymmetric() || !win->allGatherPSupported()) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         COLL,
         "AllGather {} unsupported: recvbuff {} ({} bytes) is not covered by a symmetric AllGatherP window.",
@@ -165,7 +165,7 @@ bool checkCtranAllGatherCtwinSupport(
   if ((algo == NCCL_ALLGATHER_ALGO::ctwin_ring ||
        algo == NCCL_ALLGATHER_ALGO::ctwin_srd) &&
       statex->nLocalRanks() != 1) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         COLL,
         "AllGather {} unsupported: forced dedicated ring/streamed-RD requires nLocalRanks==1, got {}.",
@@ -175,7 +175,7 @@ bool checkCtranAllGatherCtwinSupport(
   }
   if (algo == NCCL_ALLGATHER_ALGO::ctwin_srd &&
       !ctran::utils::isPowerOfTwo(statex->nRanks())) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         COLL,
         "AllGather {} unsupported: forced streamed-RD requires power-of-2 nRanks, got {}.",
@@ -185,7 +185,7 @@ bool checkCtranAllGatherCtwinSupport(
   }
   if (algo == NCCL_ALLGATHER_ALGO::ctwin_rdpipeline &&
       !ctran::utils::isPowerOfTwo(statex->nNodes())) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         COLL,
         "AllGather {} unsupported: forced rdpipeline requires power-of-2 nNodes, got {}.",
@@ -273,7 +273,7 @@ commResult_t ctranAllGatherCtwin(
 
   // Log the resolved window id so a rank-divergent window pick (all ranks must
   // resolve a buffer to the same window) is debuggable.
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       COLL,
       "AllGather ctwin: rank {} resolved recvbuff {} ({} bytes, offset {}) to window id {}",

--- a/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
@@ -28,6 +28,7 @@
 #include "comms/ctran/algos/AllGatherP/CommUtils.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/regcache/RegCache.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/ctran/utils/MathUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -71,7 +72,7 @@ commResult_t ctranAllGatherCudagraphAware(
     algo = selectCtgraphAlgo(sendcount * commTypeSize(datatype), statex);
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-AGP: AllGather cudagraph-aware: algo {} "

--- a/comms/ctran/algos/AllGather/AllGatherDirect.cc
+++ b/comms/ctran/algos/AllGather/AllGatherDirect.cc
@@ -8,10 +8,10 @@
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/profiler/Profiler.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/ExtUtils.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 
 CTRAN_DATATYPE_TO_FUNC_MAPPER(kernFnMap, ncclKernelAllGatherCtranDirect);
 
@@ -110,7 +110,7 @@ static commResult_t impl(
       // Wait for receiving remote recv buffer from a local peer
       comm->ctran_->mapper->waitRequest(irecvReq[pRank].get());
       if (remoteAccessKeys[pRank].backend != CtranMapperBackend::NVL) {
-        CERR(
+        CTRAN_ERR(
             commInternalError,
             "NVLink backend not available between rank {} and {}",
             rank,

--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -11,6 +11,7 @@
 #include "comms/ctran/mapper/CtranMapperTypes.h"
 #include "comms/ctran/regcache/IpcRegCache.h"
 #include "comms/ctran/regcache/RegCache.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/utils/DevMemType.h"
 
@@ -62,7 +63,7 @@ commResult_t exchangeMemHdl(
 
   if (NCCL_CTRAN_ENABLE_TRACE_LOG) {
     for (int i = 0; i < nRanks; i++) {
-      CLOGF_TRACE(
+      CTRAN_LOG_TRACE(
           INIT,
           "    remoteRecvBuffs[{}]: {}, remoteAccessKey: {}",
           i,
@@ -95,7 +96,8 @@ commResult_t createPersistentRequest(
     CtranPersistentRequest** out,
     bool waitForInit) {
   if (out == nullptr) {
-    CERR(commInvalidArgument, "AllGatherP: output buffer must not be null");
+    CTRAN_ERR(
+        commInvalidArgument, "AllGatherP: output buffer must not be null");
     return commInvalidArgument;
   }
   *out = nullptr;
@@ -186,7 +188,7 @@ commResult_t createPersistentRequest(
     ipcExchangeUs = ipcExchangeTimer.durationUs();
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-AGP: Rank {} createPersistentRequest ({}): comm {} recvbuff {} recvHdl {} nLocalRanks {} commHash {:x}: scopedRegister {} us, ipcExchange {} us",
@@ -364,7 +366,7 @@ commResult_t allGatherPExec(
     case NCCL_ALLGATHER_P_ALGO::ctsrdpipeline:
       return algo->execStreamedRecursiveDoubling(sendbuff, count, datatype);
     default:
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "AllGatherP: unknown algorithm variant {}",
           static_cast<int>(variant));
@@ -398,7 +400,7 @@ commResult_t allGatherPDestroy(CtranPersistentRequest* request) {
   ctran::CHECK_VALID_IPC_REGCACHE(ipcRegCache);
   ipcRegCache->cleanupInvalidImports();
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "allGatherPDestroy: rank {} destroyed request {}",

--- a/comms/ctran/algos/AllGatherP/CommUtils.h
+++ b/comms/ctran/algos/AllGatherP/CommUtils.h
@@ -11,6 +11,7 @@
 #include "comms/ctran/algos/common/NvlUtils.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/regcache/RegCache.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/ctran/utils/ExtUtils.h"
 #include "comms/utils/logger/ScubaLogger.h"
@@ -70,7 +71,7 @@ inline commResult_t exchangeIpcReg(CtranComm* comm, PersistArgs& pArgs) {
   FB_COMMCHECK(mapper->intraBarrier());
   const double barrierUs = barrierTimer.durationUs();
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-AGP: Rank {} IPC exchange breakdown: intraAllGatherCtrl {} us, intraBarrier {} us, nLocalRanks {}",
@@ -98,7 +99,7 @@ inline commResult_t exchangeIpcReg(CtranComm* comm, PersistArgs& pArgs) {
   const int nLocalRanks = statex->nLocalRanks();
   for (int i = 0; i < nLocalRanks; ++i) {
     const int peerRank = statex->localRankToRank(i);
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-AGP     Peer {}: addr {} ipcImport {}",

--- a/comms/ctran/algos/AllReduce/AllReduce.cc
+++ b/comms/ctran/algos/AllReduce/AllReduce.cc
@@ -6,9 +6,9 @@
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 
 bool ctranAllReduceSupport(CtranComm* comm, enum NCCL_ALLREDUCE_ALGO algo) {
   if (!ctranInitialized(comm) || !comm->ctran_->mapper->hasBackend()) {
@@ -22,7 +22,7 @@ bool ctranAllReduceSupport(CtranComm* comm, enum NCCL_ALLREDUCE_ALGO algo) {
       if (comm->statex_->nLocalRanks() == 1) {
         return true;
       }
-      CLOGF(
+      CTRAN_LOG(
           WARN,
           "ctring algo currently only supported for nLocalRanks=1 for ctranAllReduce, falling back to baseline");
       return false;

--- a/comms/ctran/algos/AllReduce/AllReduceDirect.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceDirect.cc
@@ -8,9 +8,9 @@
 #include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 
 CTRAN_DATATYPE_REDOP_TO_FUNC_MAPPER(typeToFunc, ncclKernelAllReduceCtranDirect);
 
@@ -163,7 +163,7 @@ static commResult_t impl(
           intraNodeLocalSendbuffReq[lr].get()));
       if (intraNodeRemoteSendAccessKeys[lr].backend !=
           CtranMapperBackend::NVL) {
-        CLOGF(
+        CTRAN_LOG(
             WARN,
             "NVLink backend not available between rank {} and {}",
             rank,
@@ -199,7 +199,7 @@ static commResult_t impl(
           intraNodeLocalRecvbuffReq[lr].get()));
       if (intraNodeRemoteRecvAccessKeys[lr].backend !=
           CtranMapperBackend::NVL) {
-        CERR(
+        CTRAN_ERR(
             commInternalError,
             "NVLink backend not available between rank {} and {}",
             rank,
@@ -576,7 +576,7 @@ commResult_t ctranAllReduceDirect(
 
   // Prevent buffer overflow in localReduce.srcs array
   if (nLocalRanks > CTRAN_MAX_NVL_PEERS) {
-    CERR(
+    CTRAN_ERR(
         commInvalidUsage,
         "nLocalRanks ({}) exceeds CTRAN_MAX_NVL_PEERS ({}). This will cause buffer overflow in localReduce.srcs array! ",
         nLocalRanks,

--- a/comms/ctran/algos/AllReduce/AllReduceResourceImpl.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceResourceImpl.cc
@@ -5,6 +5,7 @@
 #include "comms/ctran/algos/AllReduce/AllReduceDevTypes.h"
 #include "comms/ctran/algos/AllReduce/AllReduceNetTypes.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 
 #define SET_BUFF(bufMngr_, memType, bufName)                          \
   {                                                                   \
@@ -13,7 +14,7 @@
     auto ret = bufMngr_->assignBuf(                                   \
         memType, AllReduceResourceBufName::bufName, basicBuf);        \
     FB_CHECKABORT(ret, "Failed to assign buf {}", ARGTOSTR(bufName)); \
-    CLOGF_SUBSYS(                                                     \
+    CTRAN_LOG_SUBSYS(                                                 \
         INFO,                                                         \
         INIT,                                                         \
         "Rank {} assigned {} = {}",                                   \
@@ -29,7 +30,7 @@
     auto ret = bufMngr_->assignRegBuf(                                   \
         memType, AllReduceResourceBufName::bufName, regBuf);             \
     FB_CHECKABORT(ret, "Failed to assign regbuf {}", ARGTOSTR(bufName)); \
-    CLOGF_SUBSYS(                                                        \
+    CTRAN_LOG_SUBSYS(                                                    \
         INFO,                                                            \
         INIT,                                                            \
         "Rank {} assigned {} = {}",                                      \
@@ -48,7 +49,7 @@
     FB_CHECKABORT(                                                            \
         ret, "Failed to assign remote regbuf {}", ARGTOSTR(bufName));         \
     for (int i = 0; i < peerRanks.size(); i++) {                              \
-      CLOGF_SUBSYS(                                                           \
+      CTRAN_LOG_SUBSYS(                                                       \
           INFO,                                                               \
           INIT,                                                               \
           "Rank {} assigned {} remRegBufVec[{}] = {}",                        \
@@ -136,14 +137,14 @@ commResult_t AllReduceResourceImpl::initAllReduceDirectResourceAsync(
 
   // allocate memory
   FB_COMMCHECK(bufMngr_->commit());
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "AllReduceResourceImpl: Rank {} committed buffer allocation",
       statex_->rank());
 
   FB_COMMCHECK(bufMngr_->exchange(peers, statex_->nRanks()));
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "AllReduceResourceImpl: Rank {} exchanged with peer {}",

--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -25,11 +25,11 @@
 #include "comms/ctran/algos/CtranAlgoConsts.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/profiler/Profiler.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/CudaUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 
 // Key for kernel function lookup: (datatype, redOp, enableBidirAg, unpack)
 using KernelFuncKey = std::tuple<commDataType_t, commRedOp_t, bool, bool>;
@@ -80,7 +80,7 @@ commResult_t getGpuArch(ctran::allreduce::ring::GpuArch* arch) {
   FB_CUDACHECK(cudaGetDevice(&cudaDev));
   auto cudaArch = ctran::utils::getCudaArch(cudaDev);
   if (!cudaArch.hasValue()) {
-    CERR(commUnhandledCudaError, "{}", cudaArch.error());
+    CTRAN_ERR(commUnhandledCudaError, "{}", cudaArch.error());
     return commUnhandledCudaError;
   }
   if (cudaArch.value() < 1000) {
@@ -175,7 +175,7 @@ inline bool progressSendCheckSendBuf(const AlgoContext& algoCtx) {
 
   bool done = algoCtx.opRounds[Op::kSendTrans].done > prevRound;
   if (done) {
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "{} waited tmpChunkId {} algoCtx.numChunks {} prevRound {}",
         roundLogPrefix<Op::kSendCopy>(round, step, algoCtx),
@@ -230,7 +230,7 @@ inline bool progressSendCheckRemRecvBuf(
         resource.comm->logMetaData_);
     if (isComplete) {
       int tmpChunkId = getTmpChunkId(algoCtx, round);
-      CLOGF_TRACE(
+      CTRAN_LOG_TRACE(
           COLL,
           "{} done tmpChunkId {}",
           roundLogPrefix<Op::kSendTrans>(round, step, algoCtx),
@@ -260,7 +260,7 @@ inline void progressSendCheckTrans(
           resource.comm->ctran_->mapper->testRequest(resp.get(), &isComplete),
           resource.comm->logMetaData_);
       if (isComplete) {
-        CLOGF_TRACE(
+        CTRAN_LOG_TRACE(
             COLL,
             "progressSendCheckTrans {} done",
             roundLogPrefix<Op::kSendTrans>(r, step, algoCtx));
@@ -276,7 +276,7 @@ inline void progressSendPostCopyKern(
     const AlgoContext& algoCtx) {
   int round = algoCtx.opRounds[Op::kSendCopy].post;
   int step = algoCtx.opRounds[Op::kSendCopy].postStep.step;
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL, "{} posted", roundLogPrefix<Op::kSendCopy>(round, step, algoCtx));
   resource.sendCopySync->post(round);
 }
@@ -292,7 +292,7 @@ inline bool progressSendCheckCopyKern(
   bool done = resource.sendCopySync->isComplete(round);
 
   if (done) {
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "{} done: tmpChunkId {}",
         roundLogPrefix<Op::kSendCopy>(round, step, algoCtx),
@@ -342,7 +342,7 @@ inline void progressSendPostTrans(
       resource.comm->logMetaData_);
   dataSResps.at(round).reset(req);
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "{} from tmpSendBuf {} to tmpRemoteRecvBuf {} shardId {} shardDataChunkId {} dataOffsetElem {} tmpChunkId {} numel {}",
       roundLogPrefix<Op::kSendTrans>(round, step, algoCtx),
@@ -373,7 +373,7 @@ inline bool progressRecvCheckTrans(
       resource.comm->ctran_->mapper->checkNotify(args.leftNotify.get(), &done),
       resource.comm->logMetaData_);
   if (done) {
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "{} to tmpRecvBuf {} shardId {} shardDataChunkId {} dataOffsetElem {} tmpChunkId {}",
         roundLogPrefix<Op::kRecvTrans>(round, step, algoCtx),
@@ -432,7 +432,7 @@ inline bool progressRecvCheckFlush(
       resource.comm->ctran_->mapper->testRequest(resp.get(), &isComplete),
       resource.comm->logMetaData_);
   if (isComplete) {
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL, "{} done", roundLogPrefix<Op::kRecvFlush>(round, step, algoCtx));
   }
   return isComplete;
@@ -455,7 +455,7 @@ inline bool progressRecvCheckSendBuf(const AlgoContext& algoCtx) {
 
   bool done = algoCtx.opRounds[Op::kSendTrans].done > prevRound;
   if (done) {
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "{} waited tmpChunkId {} algoCtx.numChunks {} prevRound {}",
         roundLogPrefix<Op::kRecvRedCopy>(round, step, algoCtx),
@@ -473,7 +473,7 @@ inline void progressRecvPostRedCopyKern(
   int round = algoCtx.opRounds[Op::kRecvRedCopy].post;
   int step = algoCtx.opRounds[Op::kRecvRedCopy].postStep.step;
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "{} posted",
       roundLogPrefix<Op::kRecvRedCopy>(round, step, algoCtx));
@@ -494,7 +494,7 @@ inline bool progressRecvCheckRedCopyKern(
     int fwdRound = isRecvFwd_ ? getRecvFwdSendRound(algoCtx, round) : -1;
     int tmpFwdChunkId = isRecvFwd_ ? getTmpChunkId(algoCtx, fwdRound) : -1;
 
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "{} done: tmpChunkId {} fwdRound {} tmpFwdChunkId {} ",
         roundLogPrefix<Op::kRecvRedCopy>(round, opStep.step, algoCtx),
@@ -514,7 +514,7 @@ inline void progressRecvPostRecvBuf(
   int step = algoCtx.opRounds[Op::kRecvRedCopy].doneStep.step;
   int tmpChunkId = getTmpChunkId(algoCtx, round);
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "{} posted tmpChunkId {}",
       roundLogPrefix<Op::kRecvRedCopy>(round, step, algoCtx),
@@ -1116,7 +1116,7 @@ static commResult_t impl(
       profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
   while (algoCtx.partitionOffset < algoCtx.numElements) {
     updatePartitionCtxHost(args, resource, algoCtx);
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         ALGO_CXT_LOG_FMT_HOST,
         ALGO_CXT_LOG_FIELDS(algoCtx, args.numBlocks));
@@ -1320,7 +1320,7 @@ commResult_t ctranAllReduceRing(
         count,
         count * typeSize,
         typeSize);
-    CERR(commInvalidArgument, "{}", errorMsg);
+    CTRAN_ERR(commInvalidArgument, "{}", errorMsg);
     throw ctran::utils::Exception(errorMsg, commInvalidArgument);
   }
 

--- a/comms/ctran/algos/AllToAll/AllToAll.cc
+++ b/comms/ctran/algos/AllToAll/AllToAll.cc
@@ -16,6 +16,7 @@
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/algos/common/GpeRing.h"
 #include "comms/ctran/gpe/CtranGpe.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CtranPerf.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -219,7 +220,7 @@ bool ctranAllToAllSupport(
         ctran::utils::cudagraph::getStreamCaptureInfo(stream, captureInfo);
     if (err != cudaSuccess ||
         captureInfo.status != cudaStreamCaptureStatusActive) {
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           COLL,
           "AllToAll {}: not in capture mode. "
@@ -270,7 +271,7 @@ commResult_t ctranDeviceAllToAllv(
     int64_t recvcountsMultiplier,
     const std::unordered_map<std::string, std::string>& hints) {
   if (!ctranDeviceAllToAllvSupport(comm)) {
-    CERR(
+    CTRAN_ERR(
         commInvalidArgument,
         "DeviceAllToAllvPipes requires an initialized NVLink-only communicator");
     return commInvalidArgument;
@@ -289,7 +290,7 @@ commResult_t ctranDeviceAllToAllv(
   ctran::device_alltoallv_pipes::CollectiveConfig collConfig(
       comm->statex_->nLocalRanks(), &hints);
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       COLL,
       "DeviceAllToAllvPipes: opCount {} numBlocks {} numThreads {} "

--- a/comms/ctran/algos/AllToAll/AllToAllCtwin.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllCtwin.cc
@@ -14,10 +14,10 @@
 #include "comms/ctran/algos/PersistentCleanup.h"
 #include "comms/ctran/mapper/CtranMapperTypes.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/window/CtranWin.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 
 using ctran::alltoallp::AlgoImpl;
 using ctran::alltoallp::destroyPersistentRequest;
@@ -113,7 +113,7 @@ bool checkCtranAllToAllCtwinSupport(
   }
   // Dormant until a caller passes a non-empty recvbuff.
   if (recvbuff == nullptr || recvBytes == 0) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         COLL,
         "AllToAll {} unsupported: needs a non-empty recvbuff (recvbuff={}, recvBytes={}).",
@@ -126,7 +126,7 @@ bool checkCtranAllToAllCtwinSupport(
   // computes each peer's recvbuf as its window buffer at the same offset).
   auto* win = comm->findWindowForBuffer(recvbuff, recvBytes);
   if (win == nullptr || !win->isSymmetric() || !ctran::AllToAllPSupport(comm)) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         COLL,
         "AllToAll {} unsupported: recvbuff {} ({} bytes) is not covered by a symmetric AllToAllP window.",
@@ -173,7 +173,7 @@ commResult_t ctranAllToAllCtwin(
 
   // Log the resolved window id so a rank-divergent window pick (all ranks must
   // resolve a buffer to the same window) is debuggable.
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       COLL,
       "AllToAll ctwin: rank {} resolved recvbuff {} ({} bytes, offset {}) to window id {}",

--- a/comms/ctran/algos/AllToAll/AllToAllCudagraphAware.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllCudagraphAware.cc
@@ -15,6 +15,7 @@
 #include "comms/ctran/algos/AllToAll/AllToAllImpl.h"
 #include "comms/ctran/algos/AllToAll/AllToAllPImpl.h"
 #include "comms/ctran/algos/AllToAll/AllToAllvImpl.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -33,7 +34,7 @@ commResult_t ctranAllToAllCudagraphAware(
   const auto statex = comm->statex_.get();
   const int nRanks = statex->nRanks();
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-A2AP: AllToAll cudagraph-aware: algo {} "

--- a/comms/ctran/algos/AllToAll/AllToAllP.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllP.cc
@@ -3,7 +3,7 @@
 #include "comms/ctran/algos/AllToAll/AllToAllPImpl.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/regcache/IpcRegCache.h"
-#include "comms/utils/logger/LogUtils.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 
 #include <folly/ScopeGuard.h>
 
@@ -62,7 +62,7 @@ commResult_t AllToAllPInit(
     request = nullptr;
   });
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       COLL,
       "AllToAllPInit: rank {} initialized request {}, recvbuff {}, comm {} commHash {:x} commDesc {} [nranks={}, localRanks={}] stream={}",
@@ -87,7 +87,7 @@ commResult_t AllToAllPExec(
     CtranPersistentRequest* request) {
   CHECK_VALID_PREQ(request);
   auto* algo = reinterpret_cast<AlgoImpl*>(request->algo);
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "AllToAllPExec: rank {} started executing request {}, sendbuff {} recvbuff {} count {} ",
       request->comm_->statex_->rank(),
@@ -121,7 +121,7 @@ commResult_t AllToAllPDestroy(CtranPersistentRequest* request) {
   ctran::CHECK_VALID_IPC_REGCACHE(ipcRegCache);
   ipcRegCache->cleanupInvalidImports();
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "AllToAllPDestroy: rank {} destroyed request {}",

--- a/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
@@ -11,6 +11,7 @@
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/regcache/IpcRegCache.h"
 #include "comms/ctran/regcache/RegCache.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CtranPerf.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -293,7 +294,7 @@ commResult_t ctranAllToAllPIbImpl(
     FB_COMMCHECK(comm->ctran_->mapper->deregDynamic(hdl));
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       COLL,
       "AllToAllPIbImpl: rank {} completed AllToAllP execution sendbuff {} recvbuff {} count {} size {} ibPeers {}",
@@ -410,7 +411,7 @@ commResult_t createPersistentRequest(
     bool waitForInit,
     bool skipCtrlMsg) {
   if (out == nullptr) {
-    CERR(commInvalidArgument, "AllToAllP: output buffer must not be null");
+    CTRAN_ERR(commInvalidArgument, "AllToAllP: output buffer must not be null");
     return commInvalidArgument;
   }
   *out = nullptr;
@@ -488,7 +489,7 @@ commResult_t createPersistentRequest(
     FB_COMMCHECK(algoPtr->waitInit());
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-A2AP: Rank {} createPersistentRequest ({}): comm {} recvbuff {} recvHdl {} nLocalRanks {} commHash {:x}",
@@ -617,7 +618,7 @@ commResult_t AlgoImpl::exec(const void* sendbuff, const size_t count) {
     op->alltoallP.sendbuff = sendbuff;
     op->alltoallP.count = count;
     opGroup.push_back(std::move(op));
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "AllToAllPExec: rank {} submit op sendbuff {} count {}",
         comm_->statex_->rank(),

--- a/comms/ctran/algos/AllToAll/AllToAllv.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllv.cc
@@ -7,9 +7,9 @@
 #include "comms/ctran/algos/AllToAll/AllToAllvImpl.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/gpe/CtranGpe.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 
 #ifdef ENABLE_META_COMPRESSION
 #include "comms/ctran/algos/AllToAll/fb/compressed/CompressedAllToAllv.h"
@@ -269,7 +269,7 @@ commResult_t ctranAllToAllv(
       stream);
   const auto statex = comm->statex_.get();
   for (int i = 0; i < statex->nRanks(); i++) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         COLL,
         "{}: opCount {} - sendcounts[{}] {} sdispls[{}] {} recvcounts[{}] {} rdispls[{}] {}",

--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.cc
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.cc
@@ -4,8 +4,8 @@
 
 #include "comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -146,7 +146,7 @@ commResult_t setupKernelConfig(
 
   // Build local rank -> global rank mapping
   if (kernArgs.nLocalRanks > CTRAN_MAX_NVL_PEERS) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "DeviceAllToAllvPipes: nLocalRanks {} exceeds CTRAN_MAX_NVL_PEERS {}",
         kernArgs.nLocalRanks,

--- a/comms/ctran/algos/Broadcast/Broadcast.cc
+++ b/comms/ctran/algos/Broadcast/Broadcast.cc
@@ -6,6 +6,7 @@
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/Broadcast/BroadcastImpl.h"
 #include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 
 commResult_t ctranBroadcast(
     const void* sendbuff,
@@ -27,7 +28,7 @@ commResult_t ctranBroadcast(
       stream);
 
   if (algo == NCCL_BROADCAST_ALGO::ctran) {
-    CLOGF_SUBSYS(INFO, COLL, "Running Broadcast ctbtree algorithm");
+    CTRAN_LOG_SUBSYS(INFO, COLL, "Running Broadcast ctbtree algorithm");
     algo = NCCL_BROADCAST_ALGO::ctbtree;
   }
 

--- a/comms/ctran/algos/Broadcast/BroadcastBinomialTree.cc
+++ b/comms/ctran/algos/Broadcast/BroadcastBinomialTree.cc
@@ -8,8 +8,8 @@
 #include "comms/ctran/algos/Broadcast/BroadcastImpl.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/gpe/CtranGpe.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/ExtUtils.h"
-#include "comms/utils/logger/LogUtils.h"
 
 using namespace ctran;
 
@@ -253,7 +253,7 @@ static commResult_t impl(
       if (waitNotifyMap.contains(parent)) {
         elem = waitNotifyMap[parent];
       } else {
-        CLOGF(
+        CTRAN_LOG(
             WARN,
             "Expecting NVLink waitNotify for parent {}. Something bad probably happened.",
             parent);
@@ -303,7 +303,7 @@ static commResult_t impl(
         if (putNotifyMap.contains(peer)) {
           elem = putNotifyMap[peer];
         } else {
-          CLOGF(
+          CTRAN_LOG(
               WARN,
               "Expecting NVLink putNotify for peer {}. Something bad probably happened.",
               peer);

--- a/comms/ctran/algos/Broadcast/BroadcastDirect.cc
+++ b/comms/ctran/algos/Broadcast/BroadcastDirect.cc
@@ -7,8 +7,8 @@
 #include "comms/ctran/algos/Broadcast/BroadcastImpl.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/gpe/CtranGpe.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/ExtUtils.h"
-#include "comms/utils/logger/LogUtils.h"
 
 static unsigned int bestThreadBlockSize = 0;
 static const auto myAlgo = NCCL_BROADCAST_ALGO::ctdirect;
@@ -175,7 +175,7 @@ static commResult_t impl(
             if (putNotifyMap.contains(peer)) {
               elem = putNotifyMap[peer];
             } else {
-              CLOGF(
+              CTRAN_LOG(
                   WARN,
                   "Expecting NVLink putNotify for peer {}. Something bad probably happened.",
                   peer);
@@ -217,7 +217,7 @@ static commResult_t impl(
       if (waitNotifyMap.contains(root)) {
         elem = waitNotifyMap[root];
       } else {
-        CLOGF(
+        CTRAN_LOG(
             WARN,
             "Expecting NVLink waitNotify for root {}. Something bad probably happened.",
             root);

--- a/comms/ctran/algos/common/AdaptiveTransfer.h
+++ b/comms/ctran/algos/common/AdaptiveTransfer.h
@@ -7,6 +7,7 @@
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/mapper/CtranMapperTypes.h"
 #include "comms/ctran/regcache/RegCache.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/commSpecs.h"
 
 namespace ctran {
@@ -42,7 +43,7 @@ inline commResult_t checkAndSetTransferMode(
   if (backend == CtranMapperBackend::IB) {
     auto regCache = ctran::RegCache::getInstance();
     if (!regCache) {
-      CERR(
+      CTRAN_ERR(
           commInternalError, "CTRAN-ADAPTIVE: Failed to get RegCache instance");
       return commInternalError;
     }
@@ -55,7 +56,7 @@ inline commResult_t checkAndSetTransferMode(
       // Store the handle directly to avoid lookup in collective
       dirConfig->mode = TransferMode::ZERO_COPY;
       dirConfig->memHdl = regHdl;
-      CLOGF_TRACE(
+      CTRAN_LOG_TRACE(
           ALLOC,
           "CTRAN-ADAPTIVE: Buffer {} len {} is registered, using zero-copy (direction={})",
           buf,
@@ -71,7 +72,7 @@ inline commResult_t checkAndSetTransferMode(
     // Step 3: Trigger async registration for future calls
     FB_COMMCHECK(comm->ctran_->mapper->regAsync(buf, len));
 
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         ALLOC,
         "CTRAN-ADAPTIVE: Buffer {} len {} not registered, using copy-based, "
         "triggered async registration (direction={})",

--- a/comms/ctran/algos/common/BufManager.cc
+++ b/comms/ctran/algos/common/BufManager.cc
@@ -4,6 +4,7 @@
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/mapper/CtranMapperTypes.h"
 #include "comms/ctran/memory/memCacheAllocator.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 
 namespace ctran::algos::bufmanager {
 commResult_t commitBase(
@@ -28,7 +29,7 @@ commResult_t commitBase(
       break;
   }
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       INIT,
       "Rank {} allocated {} bufBase: {}",
       statex->rank(),
@@ -54,7 +55,7 @@ commResult_t releaseBase(
     base.segHdl = nullptr;
   }
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       INIT,
       "Rank {} deregistered {} bufBase: {}",
       statex->rank(),
@@ -75,7 +76,7 @@ commResult_t releaseBase(
       default:
         break;
     }
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         INIT,
         "Rank {} released {} bufBase: {}",
         statex->rank(),
@@ -109,7 +110,7 @@ commResult_t exchangeBase(
       true /* forceRegist */,
       true /* ncclManaged */,
       &base.regHdl));
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       INIT,
       "Rank {} allocated {} bufBase: {}",
       statex->rank(),
@@ -130,7 +131,7 @@ commResult_t exchangeBase(
   // Barrier to ensure all local ranks have finished NVL import before any rank
   // starts destroy
   FB_COMMCHECK(mapper->intraBarrier());
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       INIT,
       "Rank {} exchanged {} bufBase: {} with {} peers",
       statex->rank(),

--- a/comms/ctran/algos/common/NvlUtils.h
+++ b/comms/ctran/algos/common/NvlUtils.h
@@ -8,6 +8,7 @@
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/ctran/mapper/CtranMapperTypes.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 
 extern __global__ void
@@ -111,7 +112,7 @@ inline commResult_t copyToSelf(
     const size_t size,
     cudaStream_t stream) {
   if (dst != src) {
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "Rank {} CE copy to self, src {} -> dst {}, size {}",
         comm->statex_->rank(),
@@ -158,7 +159,7 @@ inline commResult_t nvlCeBcast(
   // captured as exactly one Memcpy node (vs numOps per-peer nodes below).
   if (mcWrite) {
     void* recvPtr = static_cast<char*>(*mcWrite) + recvOffset;
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "Rank {} CE multicast bcast, sendBuff {} -> mcRecvBuff {} (mcWrite {} + recvOffset {}), sendSize {}",
         rank,
@@ -194,7 +195,7 @@ inline commResult_t nvlCeBcast(
     }
 
     void* recvPtr = static_cast<char*>(remoteRecvBuffs[peer]) + recvOffset;
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "Rank {} CE copy to peer {}, sendBuff {} -> recvBuff {} ({} + recvOffset {}), sendSize {}",
         rank,
@@ -257,7 +258,7 @@ inline commResult_t nvlCeAllToAll(
     auto* dst = static_cast<char*>(remoteRecvBuffs[peer]) + recvOffset;
     auto* src = const_cast<char*>(
         static_cast<const char*>(sendbuff) + peer * chunkSize);
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "Rank {} CE copy to peer {}, sendBuff {} -> recvBuff {} ({} + recvOffset {}), chunkSize {}",
         myRank,

--- a/comms/ctran/backends/nvl/CtranNvl.cc
+++ b/comms/ctran/backends/nvl/CtranNvl.cc
@@ -6,9 +6,9 @@
 #include "comms/ctran/backends/nvl/CtranNvl.h"
 #include "comms/ctran/backends/nvl/CtranNvlImpl.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/utils/StrUtils.h"
-#include "comms/utils/logger/LogUtils.h"
 
 CtranNvl::CtranNvl(CtranComm* comm) {
   const auto statex = comm->statex_.get();
@@ -43,7 +43,7 @@ CtranNvl::CtranNvl(CtranComm* comm) {
         bool p2pAccess = comm->statex_->isSameDeviceRack(
             comm->logMetaData_.rank, statex->localRankToRank(i));
         if (!p2pAccess) {
-          CLOGF_SUBSYS(
+          CTRAN_LOG_SUBSYS(
               INFO,
               INIT,
               "NCCL_MNNVL_TRUNK_DISABLE set to True. P2P disabled between rank1: {} rank2: {} because rackserial mismatch",
@@ -75,7 +75,7 @@ CtranNvl::CtranNvl(CtranComm* comm) {
         supportedInraHostRanksStr.push_back(
             std::to_string(statex->localRankToRank(i)));
       } else {
-        CLOGF_SUBSYS(
+        CTRAN_LOG_SUBSYS(
             INFO,
             INIT,
             "CTRAN-NVL: Rank {} (local rank {} GPU {}) cannot access peer {} (local rank {} GPU {}), disable NVL support",
@@ -89,7 +89,7 @@ CtranNvl::CtranNvl(CtranComm* comm) {
     }
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-NVL: Initialized NVL backend on rank {} localRank {}, "
@@ -109,7 +109,7 @@ CtranNvl::CtranNvl(CtranComm* comm) {
 }
 
 CtranNvl::~CtranNvl() {
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       INIT,
       "CTRAN-NVL: Destroyed NVL backend on rank {} localRank {}",
       this->pimpl_->comm->statex_->rank(),

--- a/comms/ctran/backends/socket/CtranSocket.cc
+++ b/comms/ctran/backends/socket/CtranSocket.cc
@@ -7,12 +7,12 @@
 #include <vector>
 #include "comms/ctran/backends/socket/CtranSocketBase.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/ctran/utils/ExtUtils.h"
 #include "comms/utils/StrUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 
 CtranSocket::CtranSocket(CtranComm* comm)
     : comm(comm),
@@ -21,7 +21,7 @@ CtranSocket::CtranSocket(CtranComm* comm)
       commHash_(comm->statex_->commHash()),
       commDesc_(comm->statex_->commDesc()) {
   init(SocketServerAddr());
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-SOCKET: Initialized {} from comm {}",
@@ -41,7 +41,7 @@ CtranSocket::CtranSocket(
       commHash_(commHash),
       commDesc_(commDesc) {
   init(serverAddr);
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-SOCKET: Initialized {} from rank {} cudaDev {} commHash {:x} commDesc {}",
@@ -65,7 +65,7 @@ CtranSocket::~CtranSocket(void) {
     }
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-SOCKET: destroyed SOCKET backend {} for commHash {:x} commDesc {}",
@@ -100,7 +100,7 @@ commResult_t CtranSocket::preConnect(const std::unordered_set<int>& peerRanks) {
   }
 
   if (newConnection) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-SOCKET: Rank-{} Pre-connected peers: [{}]",
@@ -136,7 +136,7 @@ void CtranSocket::init(const SocketServerAddr& serverAddr) {
       throw ctran::utils::Exception(
           msg, commSystemError, rank_, commHash_, commDesc_);
     } else {
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           INIT,
           "CTRAN-SOCKET: socket address set to {} on interface {}",
@@ -148,7 +148,7 @@ void CtranSocket::init(const SocketServerAddr& serverAddr) {
     FB_SYSCHECKTHROW_EX(
         listenSocket_.bindAndListen(ifAddrSockAddr, resolvedIfName),
         ncclLogData_);
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-IB: Rank {} created listen socket based on a self-finding address {}",
@@ -175,7 +175,7 @@ void CtranSocket::init(const SocketServerAddr& serverAddr) {
     // use provided addr(i.e. ip, port, host) to initialize ctranSocket
     auto serverAddrSockAddr = toSocketAddress(serverAddr);
     listenSocket_.bindAndListen(serverAddrSockAddr, serverAddr.ifName);
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-SOCKET: Rank {} created listen socket based on provided address {} "
@@ -185,7 +185,7 @@ void CtranSocket::init(const SocketServerAddr& serverAddr) {
         serverAddr.ifName);
   }
   listenThread_ = std::thread{[this]() { bootstrapAccept(); }};
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-SOCKET: created SOCKET backend {} for commHash {} commDesc {}",
@@ -213,7 +213,7 @@ void CtranSocket::bootstrapAccept() {
         std::move(maybeSocket.value()));
     FB_SYSCHECKTHROW_EX(socket->recv(&peerRank, sizeof(int)), ncclLogData_);
 
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-SOCKET: Established connection: commHash {:x}, commDesc {}, "
@@ -230,7 +230,7 @@ void CtranSocket::bootstrapAccept() {
         updateSocket(std::move(socket), peerRank), comm->logMetaData_);
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-SOCKET: Listen thread terminating for commHash {:x}, commDesc {}, rank {}",
@@ -277,7 +277,7 @@ commResult_t CtranSocket::bootstrapConnect(
     goto exit;
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-SOCKET: Established connection: commHash {:x}, commDesc {}, pimpl {}, "
@@ -334,7 +334,7 @@ bool CtranSocket::addToPendingOpsIfRequired(
     if (!sock || it != locked->end()) {
       auto pendingOp = std::make_unique<SockPendingOp>(
           opType, const_cast<ControlMsg&>(msg), peerRank, req);
-      CLOGF_TRACE(
+      CTRAN_LOG_TRACE(
           COLL,
           "Enqueue pendingOp {} [{}], peer {}",
           opType,
@@ -393,7 +393,7 @@ commResult_t CtranSocket::progressPendingOps(void) {
     ctran::bootstrap::Socket* sock = getSocket(peerRank);
     for (auto& op : pendingOps) {
       if (op->type == SockPendingOp::OpType::ISEND_CTRL) {
-        CLOGF_TRACE(
+        CTRAN_LOG_TRACE(
             COLL, "CTRAN-SOCKET: socket {} send to {}", (void*)sock, peerRank);
         FB_SYSCHECKRETURN(
             sock->send((void*)&op->msg, sizeof(ControlMsg)), commInternalError);
@@ -435,7 +435,7 @@ commResult_t CtranSocket::progressInternal() {
           strerror(errno));
       return commInternalError;
     } else if (count > 0) {
-      CLOGF_TRACE(COLL, "CTRAN-SOCKET: polling returns {} events", count);
+      CTRAN_LOG_TRACE(COLL, "CTRAN-SOCKET: polling returns {} events", count);
       // there's a socket which receives data, let's continue
       continueWhileLoop = true;
     } else {
@@ -460,7 +460,7 @@ commResult_t CtranSocket::progressInternal() {
         }
         if (recvQueue.postedOps_.empty()) {
           // no posted op, let's read it and store as unexpected msg
-          CLOGF_TRACE(
+          CTRAN_LOG_TRACE(
               COLL,
               "CTRAN-SOCKET: Received ctrl-msg {} from peer {}, size {}, add to unexpected msg queue",
               msg->toString(),
@@ -471,7 +471,7 @@ commResult_t CtranSocket::progressInternal() {
           auto op = dequeFront(recvQueue.postedOps_);
           op->msg = *msg;
           op->req.complete();
-          CLOGF_TRACE(
+          CTRAN_LOG_TRACE(
               COLL,
               "CTRAN-SOCKET: Received ctrl-msg {} from peer {}, size {}, complete a posted recv",
               op->msg.toString(),
@@ -509,7 +509,7 @@ commResult_t CtranSocket::isendCtrlMsgImpl(
     sock = getSocket(peerRank);
   }
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-SOCKET: isendCtrlMsgImpl to {} socket: {}",
       peerRank,
@@ -517,7 +517,7 @@ commResult_t CtranSocket::isendCtrlMsgImpl(
 
   if (!addToPendingOpsIfRequired(
           msg, peerRank, req, SockPendingOp::OpType::ISEND_CTRL, sock)) {
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL, "CTRAN-SOCKET: socket {} send to {}", (void*)sock, peerRank);
     FB_SYSCHECKRETURN(
         sock->send((void*)&msg, sizeof(ControlMsg)), commInternalError);
@@ -545,7 +545,7 @@ commResult_t CtranSocket::irecvCtrlMsgImpl(
     sock = getSocket(peerRank);
   }
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-SOCKET: irecvCtrlMsgImpl from {} socket: {}",
       peerRank,
@@ -567,14 +567,14 @@ int CtranSocket::doRecvMsg(
     ControlMsg* msg) {
   int bytes_read = socket->recvAsync((void*)msg, sizeof(ControlMsg));
   if (bytes_read < 0) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         ERR,
         COLL,
         "CTRAN-SOCKET: peer {} socket recvAsync failure, errno {}",
         peerRank,
         strerror(errno));
   } else if (bytes_read == 0) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         WARN,
         COLL,
         "CTRAN-SOCKET: peer {} closed connection, remove socket",
@@ -595,7 +595,7 @@ commResult_t CtranSocket::postRecvOp(
     auto unexpMsg = dequeFront(recvQueue.unexpMsgs_);
     recvop->msg = *unexpMsg;
     FB_COMMCHECK(recvop->req.complete());
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-SOCKET: Received ctrl-msg {} from peer {}, complete a posted recv",
         recvop->msg.toString(),

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -6,10 +6,10 @@
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.h"
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/utils/StrUtils.h"
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/LogUtils.h"
 #include "folly/SocketAddress.h"
 #include "folly/synchronization/CallOnce.h"
 
@@ -54,7 +54,7 @@ commResult_t mapBootstrapSocketError(
     uint64_t commHash,
     const std::string& commDesc) {
   if (isPeerDisconnectErrno(err)) {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-TCPDM: bootstrap {} failed with peer {} on rank {} commHash {:x} commDesc {} errno={} (treating as remote error)",
         op,
@@ -95,7 +95,7 @@ void CtranTcpDm::bootstrapPrepare(meta::comms::IBootstrap* bootstrap) {
 
   std::string line =
       ::comms::tcp_devmem::addrToString(&dev->addr, 0, dev->name.c_str());
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-TCPDM: Rank {} created listen socket based on a self-finding address {} for cuda device {}",
@@ -127,7 +127,7 @@ void CtranTcpDm::bootstrapPrepare(meta::comms::IBootstrap* bootstrap) {
 
     std::string line = ::comms::tcp_devmem::addrToString(
         &sin->sin6_addr, sin->sin6_port, nullptr);
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO, INIT, "CTRAN-TCPDM: Rank {} bootstrap address {}", i, line);
   }
 
@@ -179,7 +179,7 @@ void CtranTcpDm::bootstrapAccept() {
 
     bootstrapAddRecvPeer(peerRank, recvComm);
 
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-TCPDM: Established data connection: commHash {:x}, "
@@ -190,7 +190,7 @@ void CtranTcpDm::bootstrapAccept() {
         peerRank);
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-TCPDM: Accept thread terminating for commHash {:x}, commDesc {}, rank {}",
@@ -243,7 +243,7 @@ commResult_t CtranTcpDm::bootstrapConnect(
 
   bootstrapAddSendPeer(peerRank, sendComm);
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-TCPDM: Established data connection: commHash {:x}, "
@@ -278,7 +278,7 @@ CtranTcpDm::CtranTcpDm(CtranComm* comm, ctran::Profiler* profiler) {
 
   registerProfilerHooks(profiler);
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-TCPDM: created TCPDM backend {} for commHash {:x} commDesc {}",
@@ -294,7 +294,7 @@ CtranTcpDm::~CtranTcpDm() {
   const uint32_t closeFlags = comm_ != nullptr && comm_->testAbort()
       ? ::comms::tcp_devmem::kCloseFlagForce
       : 0;
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-TCPDM: destroying backend {} commHash {:x} commDesc {} aborted {} closeFlags {:#x}",
@@ -347,7 +347,7 @@ void CtranTcpDm::closeComms(const char* reason, uint32_t closeFlags) {
 
   const bool forceClose = closeFlags & ::comms::tcp_devmem::kCloseFlagForce;
   if (forceClose) {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-TCPDM: closing backend {} rank {} commHash {:x} commDesc {} reason {} flags {:#x} sendComms {} recvComms {} queuedRecvs {} cancelledQueuedRecvs {} pendingRecvNotifies {} cancelledPendingRecvNotifies {}",
         (void*)this,
@@ -363,7 +363,7 @@ void CtranTcpDm::closeComms(const char* reason, uint32_t closeFlags) {
         pendingRecvNotifyCount,
         cancelledPendingRecvNotifyCount);
   } else {
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-TCPDM: closing backend {} rank {} commHash {:x} commDesc {} reason {} flags {:#x} sendComms {} recvComms {} queuedRecvs {} cancelledQueuedRecvs {} pendingRecvNotifies {} cancelledPendingRecvNotifies {}",
         (void*)this,
@@ -384,7 +384,7 @@ void CtranTcpDm::closeComms(const char* reason, uint32_t closeFlags) {
   for (auto& [peerRank, comm] : sendComms) {
     auto status = transport->closeSend(comm, closeFlags);
     if (status != ::comms::tcp_devmem::Status::Ok) {
-      CLOGF(
+      CTRAN_LOG(
           WARN,
           "CTRAN-TCPDM: closeSend failed for peer {} on rank {} commHash {:x} commDesc {} reason {} flags {:#x} status {}",
           peerRank,
@@ -400,7 +400,7 @@ void CtranTcpDm::closeComms(const char* reason, uint32_t closeFlags) {
   for (auto& [peerRank, comm] : recvComms) {
     auto status = transport->closeRecv(comm, closeFlags);
     if (status != ::comms::tcp_devmem::Status::Ok) {
-      CLOGF(
+      CTRAN_LOG(
           WARN,
           "CTRAN-TCPDM: closeRecv failed for peer {} on rank {} commHash {:x} commDesc {} reason {} flags {:#x} status {}",
           peerRank,
@@ -416,7 +416,7 @@ void CtranTcpDm::closeComms(const char* reason, uint32_t closeFlags) {
 
 void CtranTcpDm::abortOutstanding(const char* reason) {
   if (aborted_.exchange(true)) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-TCPDM: backend {} already aborted for rank {} commHash {:x} commDesc {} reason {}",
@@ -853,7 +853,7 @@ void CtranTcpDm::recvNotifyProgress() {
       try {
         complete = pending.front()->isComplete();
       } catch (const std::exception& e) {
-        CLOGF(
+        CTRAN_LOG(
             WARN,
             "CTRAN-TCPDM: counted recv notify failed for peer {} rank {} commHash {:x} commDesc {} error {}",
             peerRank,

--- a/comms/ctran/memory/SlabAllocator.cc
+++ b/comms/ctran/memory/SlabAllocator.cc
@@ -5,6 +5,7 @@
 #include "comms/ctran/memory/Utils.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/utils/DevUtils.cuh"
 
@@ -83,7 +84,7 @@ commResult_t SlabAllocator::allocateMem(
     if (newSlabSize != nullptr) {
       *newSlabSize = slabSize;
     }
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         ALLOC,
         "{}: allocate a slab with size {} (granularity_={}), freeSize_={}",

--- a/comms/ctran/memory/Utils.cc
+++ b/comms/ctran/memory/Utils.cc
@@ -2,13 +2,13 @@
 
 #include "comms/ctran/memory/Utils.h"
 
-#include <folly/Format.h>
 #include <sstream>
 
 #include "comms/ctran/memory/SlabAllocator.h"
 #include "comms/ctran/memory/memCacheAllocator.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaWrap.h"
 
 namespace ncclx::memory {
@@ -74,10 +74,9 @@ commResult_t allocateShareableBuffer(
     }
   }
 
-  // TODO: refactor this to CLOGF_SUBSYS once it supports oneof multiple masks
-  CLOGF_IF(
+  CTRAN_LOG_SUBSYS(
       INFO,
-      CLOGF_ENABLED(ALLOC) || CLOGF_ENABLED(P2P),
+      ALLOC | P2P,
       "commHash: {:x} Allocated shareable buffer {} size {} ipcDesc {} for {}",
       commHash,
       *ptr,

--- a/comms/ctran/memory/memCacheAllocator.cc
+++ b/comms/ctran/memory/memCacheAllocator.cc
@@ -4,10 +4,12 @@
 
 #include <fmt/format.h>
 #include <folly/Singleton.h>
+#include <cstdint>
 
 #include "comms/ctran/memory/Utils.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/DevUtils.cuh"
 
 #include "comms/utils/commSpecs.h"
@@ -20,7 +22,7 @@ static folly::Singleton<memCacheAllocator> memCacheAllocatorSingleton;
 std::shared_ptr<memCacheAllocator> memCacheAllocator::getInstance() {
   ctran::utils::commCudaLibraryInit();
   if (!ctran::utils::getCuMemSysSupported()) {
-    CLOGF(
+    CTRAN_LOG(
         ERR,
         "NCCLX memory cache allocator only works with low-level cuMem APIs. Make sure CUDA Toolkit is 11.3 or higher.");
     return nullptr;
@@ -51,17 +53,27 @@ commResult_t memCacheAllocator::init() {
           nullptr,
           &poolHandle_,
           &newSlabSize));
-      CLOGF_SUBSYS(
+#if defined(__HIP_PLATFORM_AMD__)
+      const auto getPoolHandleForLog = [this] {
+        return reinterpret_cast<std::uintptr_t>(
+            ctran::utils::toFormattableHandle(poolHandle_));
+      };
+#else
+      const auto getPoolHandleForLog = [this] {
+        return ctran::utils::toFormattableHandle(poolHandle_);
+      };
+#endif
+      CTRAN_LOG_SUBSYS(
           INFO,
           ALLOC,
           "ncclx::memory::memCacheAllocator::init size {} pointer {} handle {:x}",
           newSlabSize,
           poolPtr_,
-          ctran::utils::toFormattableHandle(poolHandle_));
+          getPoolHandleForLog());
       poolRemainSize_ = newSlabSize;
     }
     initialized_ = true;
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "Initialized NCCLX internal buffer pool, size {}",
@@ -74,7 +86,7 @@ commResult_t memCacheAllocator::init() {
 commResult_t memCacheAllocator::reset() {
   std::unique_lock lock(mutex_);
   if (initialized_) {
-    CLOGF_SUBSYS(INFO, INIT, "Reset NCCLX internal buffer pool");
+    CTRAN_LOG_SUBSYS(INFO, INIT, "Reset NCCLX internal buffer pool");
     printSnapshot();
 
     auto nOccupiedRegions = countOccupiedRegions();
@@ -97,7 +109,7 @@ commResult_t memCacheAllocator::reset() {
 }
 
 memCacheAllocator::~memCacheAllocator() {
-  CLOGF_SUBSYS(INFO, INIT, "Shutting down NCCLX memory cache allocator");
+  CTRAN_LOG_SUBSYS(INFO, INIT, "Shutting down NCCLX memory cache allocator");
   FB_COMMCHECKTHROW_EX_NOCOMM(reset());
 }
 
@@ -116,13 +128,13 @@ std::shared_ptr<memRegion> memCacheAllocator::getFreeMemReg(
     auto region = freeRegions->front();
     freeRegions->pop_front();
     if (region->refCnt > 0) {
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "Found a free region with size {} is already in use, region={}",
           nBytes,
           region->toString().c_str());
     }
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO, ALLOC, "Reusing free region {}", region->toString().c_str());
     return region;
   }
@@ -142,7 +154,7 @@ std::shared_ptr<memRegion> memCacheAllocator::createNewMemReg(
     region->cuHandle = poolHandle_;
     poolPtr_ = (char*)poolPtr_ + nBytes;
     poolRemainSize_ -= nBytes;
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         ALLOC,
         "Consume memory from pre-allocated pool ({} + {})",
@@ -156,7 +168,7 @@ std::shared_ptr<memRegion> memCacheAllocator::createNewMemReg(
         &region->ptr, nBytes, callsite, logMetaData, &handle));
     region->cuHandle = handle;
 
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         ALLOC,
         "Memory Pool is full, pool size {}, allocated new memory {} with size {}",
@@ -169,7 +181,7 @@ std::shared_ptr<memRegion> memCacheAllocator::createNewMemReg(
   region->size = nBytes;
   region->creatorTid = syscall(SYS_gettid);
   region->bucket = bucket;
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO, ALLOC, "Created new region {}", region->toString().c_str());
   return region;
 }
@@ -198,7 +210,7 @@ commResult_t memCacheAllocator::getCachedCuMemById(
     region = getFreeMemReg(alignedSize16, bucket);
     if (region == nullptr) {
       // Need to create a new region
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           ALLOC,
           "No free region with size {} is available, need to create a new region",
@@ -214,7 +226,7 @@ commResult_t memCacheAllocator::getCachedCuMemById(
           key,
           hashKey);
     }
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         ALLOC,
         "Caching new region for key {} hashKey {:x}: {}",
@@ -236,7 +248,7 @@ commResult_t memCacheAllocator::getCachedCuMemById(
   // insert/update the cached region
   cachedRegionMap_[hashKey] = region;
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       ALLOC,
       "Return the cached (requested key={}, hashKey={:x}, size {}) region {}",
@@ -267,7 +279,7 @@ commResult_t memCacheAllocator::reserve(const std::string& key) {
         key,
         hashKey,
         cachedRegion->ownerKey);
-    CLOGF_TRACE(ALLOC, "{}", errStr.c_str());
+    CTRAN_LOG_TRACE(ALLOC, "{}", errStr.c_str());
     return commInProgress;
   }
 
@@ -279,7 +291,7 @@ commResult_t memCacheAllocator::reserve(const std::string& key) {
 
   cachedRegion->refCnt++;
   cachedRegion->ownerKey = key;
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       ALLOC,
       "reserved region {} using key {} hash {:x}",
       cachedRegion->toString().c_str(),
@@ -307,7 +319,7 @@ commResult_t memCacheAllocator::release(const std::vector<std::string>& keys) {
     }
     cachedRegion->refCnt--;
     if (cachedRegion->refCnt == 0) {
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           ALLOC,
           "Releasing region {} back to free list",
@@ -353,7 +365,7 @@ void memCacheAllocator::printSnapshot() const {
   // convert to GiB
   double avai_mem = avai_bytes / (1024 * 1024 * 1024);
   double total_mem = total_bytes / (1024 * 1024 * 1024);
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "NCCLX memory allocator snapshot: NCCL used {} bytes, {} allocated regions ({} buckets) {} regions in-use, avai_mem: {:.2f} of {:.2f} GiB",
@@ -365,7 +377,7 @@ void memCacheAllocator::printSnapshot() const {
       total_mem);
   for (const auto& [bucket, regionMap] : freeRegionMaps_) {
     for (const auto& [size, vec] : regionMap) {
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           ALLOC,
           "\tFree region map size in bucket-{}: {}, count: {}",
@@ -373,7 +385,7 @@ void memCacheAllocator::printSnapshot() const {
           size,
           vec.size());
       for (const auto& region : vec) {
-        CLOGF_SUBSYS(
+        CTRAN_LOG_SUBSYS(
             INFO,
             ALLOC,
             "\t\tFree region with size {}: {}",
@@ -383,7 +395,7 @@ void memCacheAllocator::printSnapshot() const {
     }
   }
   for (const auto& [key, region] : cachedRegionMap_) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         ALLOC,
         "\tCached region map key: {} -> {}",

--- a/comms/ctran/regcache/IpcRegCache.cc
+++ b/comms/ctran/regcache/IpcRegCache.cc
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include "comms/ctran/bootstrap/Socket.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/ctran/utils/Utils.h"
 #include "comms/utils/CudaRAII.h"
@@ -26,7 +27,7 @@ commResult_t ctran::IpcRegCache::regMem(
 
   FB_COMMCHECK(reg->tryLoad(supported, shouldSupportCudaMalloc));
   if (supported) {
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL, "CTRAN-REGCACHE: Registered IPC memory {}", reg->toString());
 
     *ipcRegElem = reinterpret_cast<void*>(reg);
@@ -42,7 +43,7 @@ commResult_t ctran::IpcRegCache::regMem(
 void ctran::IpcRegCache::deregMem(void* ipcRegElem) {
   auto reg = reinterpret_cast<ctran::regcache::IpcRegElem*>(ipcRegElem);
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL, "CTRAN-REGCACHE: Deregistered IPC memory {}", reg->toString());
   // Memory handle release in ~CtranIpcMem()
   delete reg;
@@ -184,7 +185,7 @@ commResult_t ctran::IpcRegCache::importMem(
   std::snprintf(remKey->peerId, regcache::kMaxPeerIdLen, "%s", peerId.c_str());
   remKey->basePtr = ipcDesc.desc.base;
   remKey->uid = ipcDesc.uid;
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-REGCACHE: Imported NVL remote mem from peer {}: buf {} (base {} offset {} uid {})",
       peerId,
@@ -226,7 +227,7 @@ commResult_t ctran::IpcRegCache::importRemMemImpl(
       if (outRefCount != nullptr) {
         *outRefCount = newRefCount;
       }
-      CLOGF_TRACE(
+      CTRAN_LOG_TRACE(
           COLL,
           "CTRAN-REGCACHE: IPC remote registration cache hit peer:base:uid=<{}:{}:{}>, refCount now {}",
           peerId,
@@ -251,7 +252,7 @@ commResult_t ctran::IpcRegCache::importRemMemImpl(
     return commInternalError;
   }
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-REGCACHE: cache IPC remote registration peer:base:uid=<{}:{}:{}> {}",
       peerId,
@@ -295,7 +296,7 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
       elem->refCount.fetch_sub(exportCount, std::memory_order_acq_rel);
 
   if (prevCount < exportCount) {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-REGCACHE: over-release detected for IPC remote registration "
         "peer:base:uid=<{}:{}:{}>, prevCount {} < exportCount {}",
@@ -306,7 +307,7 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
         exportCount);
     // Fall through to invalidate — the entry is invalid regardless
   } else if (prevCount > exportCount) {
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-REGCACHE: decremented refCount for IPC remote registration "
         "peer:base:uid=<{}:{}:{}>, refCount now {}",
@@ -317,7 +318,7 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
     return commSuccess;
   }
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-REGCACHE: remove IPC remote registration from cache peer:base:uid=<{}:{}:{}> : {}",
       peerId,
@@ -348,7 +349,7 @@ void ctran::IpcRegCache::clearAllRemReg() {
   auto lockedMap = ipcRemRegMap_.wlock();
 
   for (auto& [peerId, regs] : *lockedMap) {
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         INIT,
         "CTRAN-REGCACHE: clear all {} cached IPC remote registrations from peer {}",
         regs.size(),
@@ -405,7 +406,7 @@ commResult_t ctran::IpcRegCache::notifyRemoteIpcRelease(
   remReleaseMem(ipcRegElem, reqCb->req.release);
   reqCb->req.release.exportCount = exportCount;
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-REGCACHE: Sending IPC_RELEASE to peerAddr {}: {}",
       peerAddr.describe(),
@@ -420,7 +421,7 @@ commResult_t ctran::IpcRegCache::notifyRemoteIpcRelease(
       sizeof(ctran::regcache::IpcReq),
       [reqCb, peerAddr](const folly::AsyncSocketException* err) {
         if (err != nullptr) {
-          CLOGF(
+          CTRAN_LOG(
               WARN,
               "CTRAN-REGCACHE: Failed to send IpcReq to peerAddr {}: {}",
               peerAddr.describe(),
@@ -458,7 +459,7 @@ commResult_t ctran::IpcRegCache::notifyRemoteIpcExport(
   // rather than polluting IpcReqCb which is shared with kRelease.
   auto wireBuf = serializeIpcReq(reqCb->req, extraSegments);
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-REGCACHE: Sending IPC_DESC to peerAddr {}: {} (wireSize={}, extraSegments={})",
       peerAddr.describe(),
@@ -475,7 +476,7 @@ commResult_t ctran::IpcRegCache::notifyRemoteIpcExport(
       wireBuf->size(),
       [reqCb, peerAddr, wireBuf](const folly::AsyncSocketException* err) {
         if (err != nullptr) {
-          CLOGF(
+          CTRAN_LOG(
               WARN,
               "CTRAN-REGCACHE: Failed to send IpcReq (DESC) to peerAddr {}: {}",
               peerAddr.describe(),
@@ -511,7 +512,7 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
   auto maybeAddr = ctran::bootstrap::getInterfaceAddress(
       NCCL_SOCKET_IFNAME, NCCL_SOCKET_IPADDR_PREFIX, true, &resolvedIfName);
   if (maybeAddr.hasError()) {
-    CLOGF(WARN, "CTRAN-REGCACHE: No socket interfaces found");
+    CTRAN_LOG(WARN, "CTRAN-REGCACHE: No socket interfaces found");
     throw ::ctran::utils::Exception(
         "CTRAN-IB : No socket interfaces found", commSystemError);
   }
@@ -541,7 +542,7 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
             // Handle release request - release the imported NVL memory
             std::string peerId = ipcReq.getPeerId();
 
-            CLOGF_TRACE(
+            CTRAN_LOG_TRACE(
                 COLL,
                 "CTRAN-REGCACHE: Received IPC_RELEASE from peer {}: {}",
                 peerId,
@@ -559,7 +560,7 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
             // Handle descriptor request - import the remote memory
             std::string peerId = ipcReq.getPeerId();
 
-            CLOGF_TRACE(
+            CTRAN_LOG_TRACE(
                 COLL,
                 "CTRAN-REGCACHE: Received IPC_DESC from peer {}: {}",
                 peerId,
@@ -574,7 +575,7 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
                   reinterpret_cast<const ctran::utils::CtranIpcSegDesc*>(
                       buf->data() + sizeof(ctran::regcache::IpcReq));
               extraSegments.assign(extraData, extraData + numExtra);
-              CLOGF_TRACE(
+              CTRAN_LOG_TRACE(
                   COLL,
                   "CTRAN-REGCACHE: IPC_DESC has {} extra segments beyond inline",
                   numExtra);
@@ -584,7 +585,7 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
             // the cudaDev is not passed in
             void* mappedBuf = nullptr;
             ctran::regcache::IpcRemHandle remKey;
-            CLOGF(
+            CTRAN_LOG(
                 WARN,
                 "CTRAN-REGCACHE: unsafe path to importMem with cudaDev 0 via async-socket");
             FB_COMMCHECKIGNORE(importMem(
@@ -603,7 +604,7 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
   // Get the server address
   serverAddr_ = std::move(serverAddrFuture).get();
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-REGCACHE: AsyncSocket server started at {} ifname {}",
@@ -617,7 +618,7 @@ void ctran::IpcRegCache::stopAsyncSocket() {
   if (asyncServerSocket_) {
     auto fut = asyncServerSocket_->stop();
     std::move(fut).get();
-    CLOGF_SUBSYS(INFO, INIT, "CTRAN-REGCACHE: AsyncSocket server stopped");
+    CTRAN_LOG_SUBSYS(INFO, INIT, "CTRAN-REGCACHE: AsyncSocket server stopped");
   }
 
   // Destroy the EVB thread BEFORE asyncServerSocket_ to drain pending

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -13,7 +13,7 @@
 #endif
 #include "comms/ctran/mapper/CtranMapperTypes.h" // @manual=//comms/ctran:mapper_types
 #include "comms/ctran/utils/Checks.h"
-#include "comms/ctran/utils/CtranLogger.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/ctran/utils/ExtUtils.h"
 #include "comms/utils/CudaRAII.h"
@@ -126,7 +126,7 @@ void ctran::regcache::Profiler::record(ctran::regcache::EventType type) {
 void ctran::regcache::Profiler::reportSnapshot(void) const {
   const std::string prefix = "CTRAN-REGCACHE RegCache Snapshot";
   for (const auto type : totalEvents) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "[{}] Total count of {}: {}",
@@ -136,7 +136,7 @@ void ctran::regcache::Profiler::reportSnapshot(void) const {
   }
   for (const auto type : latencyEvents) {
     auto count = totalCountMap.at(type);
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "[{}] Average latency (us) of {}: {:.2f}",
@@ -146,7 +146,7 @@ void ctran::regcache::Profiler::reportSnapshot(void) const {
   }
 
   for (const auto type : currentEvents) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "[{}] Current count of {}: {}",
@@ -205,7 +205,7 @@ void ctran::RegCache::init() {
         break;
     }
   }
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-REGCACHE: Global backends initialized from NCCL_CTRAN_BACKENDS: "
@@ -226,7 +226,7 @@ void ctran::RegCache::init() {
     try {
       ibSingleton_ = CtranIbSingleton::getInstance();
     } catch (const ctran::utils::Exception& e) {
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           WARN,
           INIT,
           "CTRAN-REGCACHE: IB backend not available, disabling. {}",
@@ -252,7 +252,7 @@ commResult_t ctran::RegCache::destroy() {
         folly::acquireLocked(segmentsAvl_, regElemsMaps_);
     auto& regHdlToElemMap = regElemsMaps->regHdlToElemMap;
     if (segmentsAvl->size() > 0 || regHdlToElemMap.size() > 0) {
-      CLOGF(
+      CTRAN_LOG(
           WARN,
           "Total {}/{} remaining segments are still in RegCache at destroy time. ",
           segmentsAvl->size(),
@@ -262,7 +262,7 @@ commResult_t ctran::RegCache::destroy() {
     auto it = regHdlToElemMap.begin();
     while (!regHdlToElemMap.empty()) {
       auto& regElem = it->second;
-      CLOGF_TRACE(
+      CTRAN_LOG_TRACE(
           ALLOC,
           "Remaining regElem {} buf {} len {} isDynamic {} in regHdlToElemMap",
           (void*)regElem.get(),
@@ -280,7 +280,7 @@ commResult_t ctran::RegCache::destroy() {
     for (auto avlHdl : segmentsAvl->getAllElems()) {
       auto seg = reinterpret_cast<ctran::regcache::Segment*>(
           segmentsAvl->lookup(avlHdl));
-      CLOGF_TRACE(
+      CTRAN_LOG_TRACE(
           ALLOC,
           "Remaining avlHdl {} range {} ncclManaged {} in segmentsAvl",
           (void*)avlHdl,
@@ -476,7 +476,7 @@ void ctran::RegCache::asyncRegThreadFn(int cudaDev) {
     }
 
     if (cmd.stopFlag) {
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO, INIT, "CTranMapperRegCache asyncRegThreadFn: terminate");
       return;
     }
@@ -519,7 +519,7 @@ void ctran::RegCache::asyncRegThreadFn(int cudaDev) {
 
     // NOTE: regHdl may already be released by concurrent deregMem from main
     // thread; unsafe to read its content
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         ALLOC,
         "CTRAN-REGCACHE: async registered buf {} len {} didRegister {} regHdl {}",
         cmd.buf,
@@ -751,7 +751,7 @@ commResult_t ctran::regcache::SegmentRange::pinRange(
   DevMemType memType{DevMemType::kCumem};
   FB_COMMCHECK(getDevMemType(ptr, cudaDev, memType));
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       ALLOC,
       "CTRAN-MAPPER pinRange: input ptr={} len={} cudaDev={} fbMemType={}",
@@ -764,7 +764,7 @@ commResult_t ctran::regcache::SegmentRange::pinRange(
   // entire range as a single segment
   if (memType != DevMemType::kCumem) {
     segRangs.emplace_back(ptr, len, memType);
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         ALLOC,
         "CTRAN-MAPPER pinRange: non-cumem single segment ptr={} len={}",
@@ -781,7 +781,7 @@ commResult_t ctran::regcache::SegmentRange::pinRange(
   FB_CUCHECK(cuMemGetAddressRange(&curPbase, &curRange, ptr_));
   segRangs.emplace_back(
       reinterpret_cast<const void*>(curPbase), curRange, memType);
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       ALLOC,
       "CTRAN-MAPPER pinRange: discovered segment[0] pbase={:#x} range={}",
@@ -798,7 +798,7 @@ commResult_t ctran::regcache::SegmentRange::pinRange(
         cuMemGetAddressRange(&curPbase, &curRange, (CUdeviceptr)curPtr_));
     segRangs.emplace_back(
         reinterpret_cast<const void*>(curPbase), curRange, memType);
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         ALLOC,
         "CTRAN-MAPPER pinRange: discovered segment[{}] pbase={:#x} range={} (offset={})",
@@ -812,7 +812,7 @@ commResult_t ctran::regcache::SegmentRange::pinRange(
     segmentIdx++;
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       ALLOC,
       "CTRAN-MAPPER pinRange: total {} segments discovered for input len={}",
@@ -840,7 +840,7 @@ commResult_t ctran::RegCache::cacheSegment(
   FB_COMMCHECK(
       ctran::regcache::SegmentRange::pinRange(ptr, cudaDev, len, ranges));
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       ALLOC,
       "CTRAN-MAPPER cacheSegment: ptr={} len={} discovered {} physical segments",
@@ -871,7 +871,7 @@ commResult_t ctran::RegCache::cacheSegment(
         segments.push_back(foundSeg);
         segHdls.push_back(foundSeg->avlHdl_);
 
-        CLOGF_TRACE(
+        CTRAN_LOG_TRACE(
             ALLOC,
             "CTRAN-MAPPER cacheSegment: segment[{}] already cached ptr={} len={} refCount={}",
             i,
@@ -888,7 +888,7 @@ commResult_t ctran::RegCache::cacheSegment(
         newSegmentCreated = true;
 
         const auto type = newSeg->getType();
-        CLOGF_TRACE(
+        CTRAN_LOG_TRACE(
             ALLOC,
             "CTRAN-MAPPER cacheSegment: segment[{}] cached type={} ({}) segHdl={} ptr={} len={} ncclManaged={} cudaDev={}, cache size={}",
             i,
@@ -1040,7 +1040,7 @@ commResult_t ctran::RegCache::regRangeCachedImpl(
       auto& segRange = ranges.at(i);
       void* avlHdl = segmentsAvl->search(segRange.buf, segRange.len);
       if (!avlHdl) {
-        CLOGF(
+        CTRAN_LOG(
             WARN,
             "CTRAN-REGCACHE:[pbase {} range {}] associated with [ptr {} len {}] is not pre-registered by user",
             (void*)segRange.buf,
@@ -1217,7 +1217,7 @@ commResult_t ctran::RegCache::freeSegment(
         if (inUseCnt > 0) {
           // Intentionally error logging as this is invalid usage to free buffer
           // before releasing all registrations.
-          CLOGF(
+          CTRAN_LOG(
               ERR,
               "freeSegment: RegElem [buf {} len {}] still has {} live ScopedRegHdl owner(s)",
               regIt->second->buf,
@@ -1256,7 +1256,7 @@ commResult_t ctran::RegCache::freeSegment(
     // - Remove segment from cache
     segmentState->refCount = 0;
     FB_COMMCHECK(segmentsAvl->remove(segment->avlHdl_));
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         ALLOC,
         "Removed segment {} segHdl {} ptr {} len {} ncclManaged {} cudaDev {}, cache size {}",
         (void*)segment,
@@ -1319,7 +1319,7 @@ void ctran::RegCache::releaseScopedRegHdl(
   auto it = regElemsMaps->regHdlToElemMap.find(regHdl);
   if (it == regElemsMaps->regHdlToElemMap.end() ||
       it->second->regId_ != regId) {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "releaseScopedRegHdl: regElem {} not found or its address was reused (may have been force-freed by a buffer-release path)",
         (void*)regHdl);
@@ -1431,7 +1431,7 @@ ctran::ScopedRegHdl::~ScopedRegHdl() {
   try {
     regCache_->releaseScopedRegHdl(regHdl_, regId_);
   } catch (const std::exception& e) {
-    CLOGF(ERR, "~ScopedRegHdl: cleanup failed: {}", e.what());
+    CTRAN_LOG(ERR, "~ScopedRegHdl: cleanup failed: {}", e.what());
   }
   regCache_ = nullptr;
   regHdl_ = nullptr;
@@ -1674,7 +1674,7 @@ std::vector<std::vector<ctran::regcache::Segment*>> getContiguousRegions(
         reinterpret_cast<uintptr_t>(region.back()->range.buf) +
         region.back()->range.len;
     size_t regionLen = regionEnd - regionStart;
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         ALLOC,
         "getContiguousRegions: region[{}] ptr=0x{:x} len={} ({} segments)",
         i,
@@ -1713,7 +1713,7 @@ commResult_t ctran::RegCache::regAll() {
     // Get all segment values directly from AVL tree
     auto allSegmentVals = segmentsAvl->getAllElemVals();
     if (allSegmentVals.empty()) {
-      CLOGF(WARN, "regAll: no cached segments found");
+      CTRAN_LOG(WARN, "regAll: no cached segments found");
       return commSuccess;
     }
 
@@ -1729,7 +1729,7 @@ commResult_t ctran::RegCache::regAll() {
     auto contiguousRegions = getContiguousRegions(std::move(segments));
 
     if (contiguousRegions.empty()) {
-      CLOGF(WARN, "regAll: no cached segments found");
+      CTRAN_LOG(WARN, "regAll: no cached segments found");
       return commSuccess;
     }
 
@@ -1759,7 +1759,7 @@ commResult_t ctran::RegCache::regAll() {
           regionSegments.back()->range.len;
       size_t regionLen = regionEndAddr - regionStartAddr;
 
-      CLOGF_TRACE(
+      CTRAN_LOG_TRACE(
           ALLOC,
           "regAll: registering region {} with {} segments, ptr {} len {}",
           regionIdx,
@@ -1810,7 +1810,7 @@ commResult_t ctran::RegCache::regAll() {
             : std::nullopt);
   }
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       ALLOC,
       "regAll: completed - registered {} contiguous regions, "
       "total {} segments, {} bytes",
@@ -1878,7 +1878,7 @@ commResult_t ctran::RegCache::deregAll() {
   for (auto& regElem : toDeregister) {
     auto res = regCache->deregElem(regElem.get());
     if (res != commSuccess) {
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "deregAll: failed to deregister regElem ptr {} len {}",
           regElem->buf,
@@ -1886,7 +1886,7 @@ commResult_t ctran::RegCache::deregAll() {
     }
   }
 
-  CLOGF(
+  CTRAN_LOG(
       INFO,
       "deregAll: completed - deregistered {} registrations, "
       "skipped {} dynamic",
@@ -1908,7 +1908,7 @@ commResult_t ctran::regcache::RegElem::doRegister(
     try {
       FB_COMMCHECK(externalRegMemFn(buf, len, cudaDev_, &externalRegElem));
     } catch (const std::exception& e) {
-      CLOGF(
+      CTRAN_LOG(
           WARN,
           "CTRAN-REGCACHE: external backend registration failed for buf {} len {}, error: {}",
           (void*)buf,
@@ -1935,7 +1935,7 @@ commResult_t ctran::regcache::RegElem::doRegister(
           ctran::IpcRegCache::regMem(
               buf, len, cudaDev_, &ipcRegElem, ncclManaged_));
     } catch ([[maybe_unused]] const std::bad_alloc& e) {
-      CLOGF(
+      CTRAN_LOG(
           WARN,
           "CTRAN-REGCACHE: NVL backend not enabled. Skip IPC registration for buf {} len {}",
           (void*)buf,
@@ -1948,7 +1948,7 @@ commResult_t ctran::regcache::RegElem::doRegister(
     try {
       FB_COMMCHECK(CtranIb::regMem(buf, len, cudaDev_, &ibRegElem));
     } catch ([[maybe_unused]] const std::bad_alloc& e) {
-      CLOGF(
+      CTRAN_LOG(
           WARN,
           "CTRAN-REGCACHE: IB backend not enabled. Skip IB registration for buf {} len {}",
           (void*)buf,
@@ -1964,7 +1964,7 @@ commResult_t ctran::regcache::RegElem::doRegister(
 
 exit:
   stat->state = ctran::regcache::RegElemState::REGISTERED;
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       ALLOC,
       "CTRAN-REGCACHE: registered RegElem {} [{}] ",
@@ -2004,7 +2004,7 @@ commResult_t ctran::regcache::RegElem::doDeregister(
   }
 
   stat->state = ctran::regcache::RegElemState::DEREGISTERED;
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       ALLOC,
       "CTRAN-REGCACHE: deregistered RegElem {} [{}] ",

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -12,6 +12,7 @@
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/CtranIpc.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CtranMulticast.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/utils/DevMemType.h"
@@ -256,7 +257,7 @@ commResult_t setupMulticast(
         declined++;
       }
     }
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-MC: rank {} falling back to unicast -- {} of {} NVL-domain ranks declined multicast (unsupported HW/IMEX, or a non-cuMem / unregistered buffer)",
         rank,
@@ -303,7 +304,7 @@ commResult_t setupMulticast(
       "CTRAN-MC: rank {} failed mapVA post-vote",
       rank);
   outMulticast = std::move(mc);
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-MC: rank {} bound multicast over {} NVL ranks ({} bytes)",
@@ -528,7 +529,7 @@ commResult_t CtranWin::exchange() {
       remWinInfo[r].signalRkey = remoteBaseBufAccessKeys[exchangeRank];
     }
   }
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-WINDOW: Rank {} exchanged remote windowInfo in win {} comm {} commHash {:x}:",
@@ -538,7 +539,7 @@ commResult_t CtranWin::exchange() {
       statex->commHash());
 
   for (int i = 0; i < nRanks; ++i) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-WINDOW     Peer {}: addr {} size {} rkey {}",
@@ -570,7 +571,7 @@ commResult_t CtranWin::exchange() {
       mc_ = std::move(mc);
     }
     FB_COMMCHECK(windowBarrier(comm, mapper));
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-WINDOW: Rank {} {} NVL CE-multicast on win {} comm {} commHash {:x} ({} bytes)",
@@ -668,7 +669,7 @@ commResult_t CtranWin::allocate(void* userBufPtr) {
         : nullptr;
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-WINDOW: Rank {} window buffer is {} window data buffer base {} signal buffer base {} "
@@ -701,7 +702,7 @@ commResult_t CtranWin::free(bool skipBarrier) {
   FB_COMMCHECK(getWindowMapper(comm, &mapper));
   CtranMapperEpochRAII epochRAII(mapper);
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-WINDOW: Rank {} free win {} comm {} commHash {:x}",
@@ -863,7 +864,7 @@ commResult_t CtranWin::getDeviceWin(
   if (!hostWindow_) {
     const auto myRank = transport->my_rank();
 
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-WINDOW: Rank {} creating HostWindow with signalCount={} "
@@ -880,7 +881,7 @@ commResult_t CtranWin::getDeviceWin(
 
     hostWindow_->exchange();
 
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO, INIT, "CTRAN-WINDOW: Rank {} device window built", myRank);
   }
 
@@ -896,7 +897,7 @@ commResult_t ctranWinAllocate(
     CtranWin** win,
     const meta::comms::Hints& hints) {
   if (size < CTRAN_MIN_REGISTRATION_SIZE) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "ctranWinAllocate size {} is smaller than {}, resize to CTRAN_MIN_REGISTRATION_SIZE",
@@ -939,7 +940,7 @@ commResult_t checkUserBufType(const DevMemType bufType) {
   if (bufType == DevMemType::kCumem || bufType == DevMemType::kHostPinned ||
       bufType == DevMemType::kHostUnregistered ||
       bufType == DevMemType::kCudaMalloc) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-WINDOW: Buffer Type {} is provided by user while registering window",


### PR DESCRIPTION
Summary:

Migrate all 16 legacy production log calls in the core CTRAN AllToAll paths from the Folly-backed logging facade to the tested CTRAN spdlog facade. Keep the compressed AllToAll implementation separate for an independently reviewable follow-up.

Preserve severity, subsystem gating, trace gating, message strings, arguments, error reporting, and control flow. Replace direct legacy logging includes with direct `CtranLogUtils.h` ownership without changing collective behavior or build metadata.

Reviewed By: shr

Differential Revision: D115524420
