### PR TITLE
Migrate CTRAN SendRecv logs (#3582)

### DIFF
--- a/comms/ctran/algos/SendRecv/SendRecv.cc
+++ b/comms/ctran/algos/SendRecv/SendRecv.cc
@@ -12,6 +12,7 @@
 #include "comms/ctran/algos/SendRecv/SendRecvImpl.h"
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/ctran/utils/ExtUtils.h"
 
@@ -69,7 +70,7 @@ bool ctranSendRecvSupport(
       algo == NCCL_SENDRECV_ALGO::ctgraph) {
     static std::once_flag warnedOnce;
     std::call_once(warnedOnce, []() {
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           WARN,
           COLL,
           "CTRAN SendRecv: ctp2p/ctgraph requires comms::prims device transports "
@@ -96,7 +97,7 @@ bool ctranSendRecvSupport(
         ctran::utils::cudagraph::getStreamCaptureInfo(stream, captureInfo);
     if (err != cudaSuccess ||
         captureInfo.status != cudaStreamCaptureStatusActive) {
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           COLL,
           "SendRecv ctgraph: not in capture mode. "

--- a/comms/ctran/algos/SendRecv/SendRecvCudagraphAware.cc
+++ b/comms/ctran/algos/SendRecv/SendRecvCudagraphAware.cc
@@ -17,6 +17,7 @@
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/SendRecv/SendRecvImpl.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/CudaRAII.h"
 
 commResult_t ctranSendRecvCudagraphAware(
@@ -27,7 +28,7 @@ commResult_t ctranSendRecvCudagraphAware(
   // Caller (ctranGroupEndHook) already verified active capture mode.
   const auto statex = comm->statex_.get();
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       COLL,
       "SendRecv cudagraph-aware: nOps {} commHash {:x} commDesc {} nRanks {} nLocalRanks {} nNodes {}",

--- a/comms/ctran/algos/SendRecv/SendRecvImpl.h
+++ b/comms/ctran/algos/SendRecv/SendRecvImpl.h
@@ -11,6 +11,7 @@
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 namespace ctran::sendrecv {
@@ -76,7 +77,7 @@ inline commResult_t selfSendRecvImpl(
     CtranComm* comm) {
   const auto statex = comm->statex_.get();
   if (selfSends.size() != selfRecvs.size()) {
-    CERR(
+    CTRAN_ERR(
         commInvalidUsage,
         "Invalid usage: number of self ncclSend ({}) and ncclRecv ({}) does not match on rank {}",
         selfSends.size(),


### PR DESCRIPTION
Summary:

Migrate all four remaining legacy production log calls in CTRAN SendRecv from the Folly-backed logging facade to the tested CTRAN spdlog facade.

Preserve severity, subsystem and one-time gating, message strings, arguments, capture fallback behavior, error reporting, and single-evaluation semantics. Add direct `CtranLogUtils.h` ownership without changing send/recv behavior or build metadata.

Reviewed By: shr

Differential Revision: D115553615


