### PR TITLE
IbSendRecvDevice<LL>: override send/recv/forward on the base

### DIFF
--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -421,8 +421,10 @@ std::size_t MultiPeerIbTransportBase::sendRecvSignalBytesPerPeer() const {
   //               lane); numLanes must equal the device QP-lane count.
   //   SLOT_FREE:  one slot per channel.
   // See the layout in IbgdaBuffer.h.
+  // Slot-indexed: one DATA_READY block plus one SLOT_FREE slot per
+  // (logical channel, protocol slot).
   const std::size_t maxChannels =
-      static_cast<std::size_t>(config_.max_num_channels);
+      static_cast<std::size_t>(config_.totalChannelSlots());
   const std::size_t numLanes = static_cast<std::size_t>(numNics_) *
       static_cast<std::size_t>(config_.qpsPerConnection);
   const std::size_t dataReadySlots = numLanes * maxChannels;
@@ -431,7 +433,7 @@ std::size_t MultiPeerIbTransportBase::sendRecvSignalBytesPerPeer() const {
 }
 
 std::size_t MultiPeerIbTransportBase::sendRecvCounterBytesPerPeer() const {
-  return static_cast<std::size_t>(config_.max_num_channels) *
+  return static_cast<std::size_t>(config_.totalChannelSlots()) *
       kSendRecvSignalSlotStride;
 }
 
@@ -452,7 +454,7 @@ IbChannelLayout MultiPeerIbTransportBase::channelLayoutForPeer(
       .remoteSignalBuf = pb.remoteSignal,
       .localCounterBuf = pb.counter,
       .localCounterCompletionBuf = pb.counterCompletion,
-      .maxChannels = config_.max_num_channels,
+      .maxChannels = config_.totalChannelSlots(),
       .numChannels = config_.max_num_channels,
       .numLanes = numNics_ * config_.qpsPerConnection,
       .pipelineDepth = config_.pipelineDepth,

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -128,15 +128,29 @@ struct MultipeerIbTransportConfig {
     return maxGroups * qpsPerBlockPerNic;
   }
 
-  std::size_t fixedChannelDataBufferSize() const {
+  // Slot-indexed storage is reserved per (logical channel, protocol slot).
+  // max_num_channels stays the LOGICAL channel count a caller selects with
+  // group_id; slot p owns [p * max_num_channels, (p+1) * max_num_channels).
+  // The slot count is kNumProtoSlots (IbgdaBuffer.h) rather than runtime
+  // config, so host sizing and device indexing cannot disagree. QPs are NOT
+  // multiplied: a channel is one QP pair shared by every protocol on it.
+  int totalChannelSlots() const {
     if (max_num_channels < 0) {
       throw std::invalid_argument("max_num_channels must be >= 0");
     }
-    const auto channels = static_cast<std::size_t>(max_num_channels);
+    if (max_num_channels > std::numeric_limits<int>::max() / kNumProtoSlots) {
+      throw std::overflow_error(
+          "max_num_channels * kNumProtoSlots overflows int");
+    }
+    return max_num_channels * kNumProtoSlots;
+  }
+
+  std::size_t fixedChannelDataBufferSize() const {
+    const auto channels = static_cast<std::size_t>(totalChannelSlots());
     if (channels != 0 &&
         perChannelSize > std::numeric_limits<std::size_t>::max() / channels) {
       throw std::overflow_error(
-          "perChannelSize * max_num_channels overflows size_t");
+          "perChannelSize * totalChannelSlots overflows size_t");
     }
     return perChannelSize * channels;
   }

--- a/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
@@ -4,6 +4,8 @@
 
 #include <type_traits>
 
+#include "comms/prims/core/LlxPacket.cuh"
+#include "comms/prims/core/MemcpyCopyOp.cuh"
 #include "comms/prims/trace/PipesTraceTypes.h"
 #include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 
@@ -69,6 +71,32 @@ struct Simple {
   __host__ __device__ static constexpr std::size_t wire_bytes(
       std::size_t payloadBytes) {
     return (payloadBytes + kData - 1) / kData * kPacketBytes;
+  }
+};
+} // namespace protocol
+
+// Low-latency (data+flag) wire format. Packet-geometry policy is LlxPacket<4,4>
+// (8 B packet = 4 B data + 4 B flag), so wire == 2x payload; readiness is the
+// inline flag (no DATA_READY -- see consumeRecvBuf(LL)). LL reuses the same
+// channel/state as Simple (shared IbChannelLayout, staging, and progress
+// cursor); forward is not implemented for LL yet.
+namespace protocol {
+struct LL {
+  // Slot 1: LL owns its own per-channel resource slot. The two protocols must
+  // not share one -- the progress cursors, staging ring position, and
+  // cumulative signal counters are all persistent across kernel launches, so a
+  // slot left mid-stream by one protocol is meaningless to the other. The
+  // channel's QPs and its lane cursor ARE shared; only slot-indexed state is
+  // duplicated.
+  static constexpr int kProtoSlot = 1;
+  using Packet = LlxPacket<4, 4>;
+  static constexpr std::size_t kData = Packet::kData;
+  static constexpr std::size_t kPacketBytes = Packet::kPacketBytes;
+  __host__ __device__ static std::size_t max_payload(std::size_t wireBytes) {
+    return Packet::max_payload(wireBytes);
+  }
+  __host__ __device__ static std::size_t wire_bytes(std::size_t payloadBytes) {
+    return Packet::wire_bytes(payloadBytes);
   }
 };
 } // namespace protocol
@@ -345,13 +373,16 @@ __device__ __forceinline__ SendRecvGeometry calcGeometry(
     std::size_t nbytes,
     std::size_t max_signal_bytes) {
   const int groupId = group.group_id;
-  const int maxGroups = channelLayout.maxChannels;
-  if (groupId >= maxGroups) {
+  // group_id selects a LOGICAL channel, so bound it by numChannels.
+  // maxChannels counts resource SLOTS (numChannels * kNumProtoSlots) and would
+  // be kNumProtoSlots-times too loose here.
+  const int numChannels = channelLayout.numChannels;
+  if (groupId >= numChannels) {
     if (group.is_leader()) {
       printf(
-          "[PIPES] FATAL: send/recv group_id=%u >= maxGroups=%d\n",
+          "[PIPES] FATAL: send/recv group_id=%u >= numChannels=%d\n",
           groupId,
-          maxGroups);
+          numChannels);
     }
     PIPES_DEVICE_TRAP();
   }
@@ -400,6 +431,7 @@ __device__ __forceinline__ SendSignal prepareSendBuf(
     std::size_t payloadBytes,
     std::size_t nbytes,
     std::size_t dataOff,
+    uint64_t /*flagVal*/,
     const IbRemoteChannel& remoteChannel,
     uint64_t signalVal,
     Args... args) {
@@ -439,6 +471,7 @@ __device__ __forceinline__ void consumeRecvBuf(
     std::size_t payloadBytes,
     std::size_t nbytes,
     std::size_t dataOff,
+    uint64_t /*flagVal*/,
     uint64_t waitCredit,
     const Timeout& timeout,
     Args... args) {
@@ -544,6 +577,128 @@ __device__ __forceinline__ SendSignal prepareForwardBuf(
   (void)timeout;
   ((void)args, ...);
   return SendSignal{};
+#endif
+}
+// LL encode: pack payload + trailing flag=flagVal into staging via
+// LLImpl::pack; the put carries NO DATA_READY (empty signal) -- the inline
+// flag is the readiness mark. Ignores the remote signal slot/value that
+// Simple uses.
+template <typename CopyOp = Memcpy, typename... Args>
+__device__ __forceinline__ SendSignal prepareSendBuf(
+    protocol::LL,
+    ThreadGroup& group,
+    char* staging,
+    const char* src,
+    std::size_t payloadBytes,
+    std::size_t nbytes,
+    std::size_t dataOff,
+    uint64_t flagVal,
+    const IbRemoteChannel& remoteChannel,
+    uint64_t signalVal,
+    Args... args) {
+  using P = LlxPacket<4, 4>;
+  static_assert(
+      has_sendLL_v<CopyOp, P>,
+      "LL send path requires a CopyOp with a packet-aware sendLL<P>(); Memcpy "
+      "provides one. A reduce/convert CopyOp must supply its own -- a plain "
+      "contiguous copy cannot address the data+flag interleaved staging");
+#if PIPES_IS_DEVICE_COMPILE
+  (void)remoteChannel;
+  (void)signalVal;
+  // Clamp to the REAL payload before handing it to the codec. payloadBytes is
+  // rounded up to kData for the wire/credit stream, but the caller's src only
+  // holds nbytes -- packing the padded length reads up to kData-1 bytes past
+  // it, which faults on a tightly-sized device allocation. Staging offsets and
+  // the RDMA length stay padded; only the codec is clamped. Both ranks derive
+  // validBytes from values they already agree on, so packet_count() matches on
+  // each side. Mirrors the Simple overload above.
+  const std::size_t validBytes =
+      valid_payload_bytes(dataOff, payloadBytes, nbytes);
+  if (validBytes > 0) {
+    CopyOp::template sendLL<P>(
+        group,
+        staging,
+        src,
+        validBytes,
+        dataOff,
+        static_cast<typename P::FlagType>(flagVal),
+        args...);
+  }
+  return SendSignal{IbgdaRemoteBuffer{}, /*val=*/0};
+#else
+  (void)group;
+  (void)staging;
+  (void)src;
+  (void)payloadBytes;
+  (void)nbytes;
+  (void)dataOff;
+  (void)flagVal;
+  (void)remoteChannel;
+  (void)signalVal;
+  ((void)args, ...);
+  return SendSignal{};
+#endif
+}
+
+// LL decode: poll the inline flags == flagVal and copy staging -> dst via
+// LLImpl::unpack. No signal wait; ignores the local channel/credit Simple
+// uses.
+template <typename CopyOp = Memcpy, typename Transport, typename... Args>
+__device__ __forceinline__ void consumeRecvBuf(
+    protocol::LL,
+    Transport& transport,
+    ThreadGroup& group,
+    IbLocalChannel& localChannel,
+    const IbgdaLocalBuffer& localDataReady,
+    char* dst,
+    const char* staging,
+    std::size_t payloadBytes,
+    std::size_t nbytes,
+    std::size_t dataOff,
+    uint64_t flagVal,
+    uint64_t waitCredit,
+    const Timeout& timeout,
+    Args... args) {
+  using P = LlxPacket<4, 4>;
+  static_assert(
+      has_recvLL_v<CopyOp, P>,
+      "LL recv path requires a CopyOp with a packet-aware recvLL<P>(); Memcpy "
+      "provides one. A reduce/convert CopyOp must supply its own -- a plain "
+      "contiguous copy cannot address the data+flag interleaved staging");
+#if PIPES_IS_DEVICE_COMPILE
+  (void)transport;
+  (void)localChannel;
+  (void)localDataReady;
+  (void)waitCredit;
+  // Same clamp as the send side: unpacking the padded length writes up to
+  // kData-1 bytes past the caller's dst, silently corrupting whatever follows.
+  const std::size_t validBytes =
+      valid_payload_bytes(dataOff, payloadBytes, nbytes);
+  if (validBytes > 0) {
+    CopyOp::template recvLL<P>(
+        group,
+        dst,
+        staging,
+        validBytes,
+        dataOff,
+        static_cast<typename P::FlagType>(flagVal),
+        timeout,
+        args...);
+  }
+#else
+  (void)transport;
+  (void)group;
+  (void)localChannel;
+  (void)localDataReady;
+  (void)dst;
+  (void)staging;
+  (void)payloadBytes;
+  (void)nbytes;
+  (void)dataOff;
+  (void)flagVal;
+  (void)waitCredit;
+  (void)timeout;
+  ((void)args, ...);
 #endif
 }
 
@@ -850,6 +1005,9 @@ __device__ __forceinline__ void send(
       const uint64_t streamWire = Proto::wire_bytes(streamPayload);
       const uint64_t protocolStreamEnd = streamWire + protocolBytesThis;
       const uint64_t pipelineCycle = streamPayload / pipelineBytesPayload;
+      // flagVal (a per-ring-pass counter) for this chunk's slot; LL stamps it
+      // into every packet flag. Offset by +1 so the flag is never zero.
+      const uint64_t flagVal = streamPayload / pipelineBytesPayload + 1;
 
       // (1) Wait for NIC to finish with this slot's local sendStaging.
       prepare_send_slot<Proto>(transport, group, slot, pipelineCycle, timeout);
@@ -863,6 +1021,7 @@ __device__ __forceinline__ void send(
           payloadBytes,
           nbytes,
           dataOff,
+          flagVal,
           remoteChannel,
           protocolBytesThis,
           args...);
@@ -1175,6 +1334,9 @@ __device__ __forceinline__ void recv(
       const std::size_t stagingOff = ch.stagingBase +
           static_cast<std::size_t>(slot) * perBlockSlotWire +
           Proto::wire_bytes(chunkOff);
+      // flagVal (a per-ring-pass counter) for this chunk's slot; LL stamps it
+      // into every packet flag.
+      const uint64_t flagVal = streamPayload / pipelineBytesPayload + 1;
 
       // (1)+(2) Wait for the chunk to be ready (DATA_READY signal or, for LL,
       //         the inline flag) and cooperatively copy recvStaging -> dst.
@@ -1189,6 +1351,7 @@ __device__ __forceinline__ void recv(
           payloadBytes,
           nbytes,
           dataOff,
+          flagVal,
           protocolBytesThis,
           timeout,
           args...);
@@ -1589,20 +1752,21 @@ __device__ __forceinline__ void validate_progress_group(
     const IbChannelLayout& channelLayout,
     ThreadGroup& group) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-  if (channelLayout.maxChannels <= 0) {
+  // group_id selects a LOGICAL channel; maxChannels counts resource slots.
+  if (channelLayout.numChannels <= 0) {
     if (group.is_leader()) {
       printf(
-          "[PIPES] FATAL: send/recv maxChannels must be > 0, got %d\n",
-          channelLayout.maxChannels);
+          "[PIPES] FATAL: send/recv numChannels must be > 0, got %d\n",
+          channelLayout.numChannels);
     }
     PIPES_DEVICE_TRAP();
   }
-  if (group.group_id >= static_cast<uint32_t>(channelLayout.maxChannels)) {
+  if (group.group_id >= static_cast<uint32_t>(channelLayout.numChannels)) {
     if (group.is_leader()) {
       printf(
           "[PIPES] FATAL: progress group_id=%u out of range [0, %d)\n",
           group.group_id,
-          channelLayout.maxChannels);
+          channelLayout.numChannels);
     }
     PIPES_DEVICE_TRAP();
   }

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -1051,14 +1051,15 @@ __device__ __forceinline__ ProgressGeometry make_progress_geometry(
     PIPES_DEVICE_TRAP();
   }
   const int groupId = static_cast<int>(group.group_id);
-  const int maxGroups = channelLayout.maxChannels;
-  if (groupId < 0 || groupId >= maxGroups) {
+  // LOGICAL bound -- see calcGeometry.
+  const int numChannels = channelLayout.numChannels;
+  if (groupId < 0 || groupId >= numChannels) {
     if (group.is_leader()) {
       printf(
-          "[PIPES] FATAL: %s group_id=%d >= maxGroups=%d\n",
+          "[PIPES] FATAL: %s group_id=%d >= numChannels=%d\n",
           opName,
           groupId,
-          maxGroups);
+          numChannels);
     }
     PIPES_DEVICE_TRAP();
   }

--- a/comms/prims/transport/ibgda/IbgdaBuffer.h
+++ b/comms/prims/transport/ibgda/IbgdaBuffer.h
@@ -577,15 +577,15 @@ inline constexpr int kIbDirections = 2;
 inline constexpr int kIbMaxQpLanesPerChannelDirection = 64;
 
 // Per-protocol resource slots reserved on every channel, indexed by a protocol
-// tag's kProtoSlot (Simple = 0). Only Simple exists today, so this is 1 and the
-// layout matches the single-protocol one. The diff that adds a second wire
-// protocol raises it, which is what reserves the extra staging, signal, and
-// counter slots.
+// tag's kProtoSlot (Simple = 0, LL = 1). The layout reserves this many
+// channels' worth of staging, signal, and counter slots per peer, so raising it
+// costs memory: at the default 128 KiB x 64 channels, each extra slot is
+// +8 MiB per peer of staging.
 //
 // It does NOT reserve more QPs: a channel is one QP pair regardless of how many
 // protocols address it, which is why IbQpState lives on the channel rather than
 // in a slot.
-inline constexpr int kNumProtoSlots = 1;
+inline constexpr int kNumProtoSlots = 2;
 
 // Identifies a lane-local completion threshold returned by put().
 // completionId is the send-lane ordinal; value is complete once that lane's

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -2279,7 +2279,10 @@ class P2pIbgdaTransportDevice {
    * perBlockSlot.
    * @param timeout         Optional timeout for wait operations.
    */
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename Proto = protocol::Simple,
+      typename... Args>
   __device__ __forceinline__ void send(
       ThreadGroup& group,
       const void* __restrict__ src,
@@ -2287,7 +2290,7 @@ class P2pIbgdaTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-    sendWithTrace<CopyOp>(
+    sendWithTrace<CopyOp, Proto>(
         group, src, nbytes, max_signal_bytes, timeout, {}, 0, args...);
   }
 
@@ -2305,7 +2308,10 @@ class P2pIbgdaTransportDevice {
         *this, group, src, nbytes, max_signal_bytes, timeout);
   }
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename Proto = protocol::Simple,
+      typename... Args>
   __device__ __forceinline__ void sendWithTrace(
       ThreadGroup& group,
       const void* __restrict__ src,
@@ -2335,7 +2341,7 @@ class P2pIbgdaTransportDevice {
           /*step=*/0,
           static_cast<uint16_t>(group.group_id));
     }
-    detail::send<P2pIbgdaTransportDevice, CopyOp>(
+    detail::send<P2pIbgdaTransportDevice, CopyOp, Proto>(
         *this, group, src, nbytes, max_signal_bytes, timeout, args...);
     if (group.is_leader()) {
       trace_ibgda_event(
@@ -2375,7 +2381,10 @@ class P2pIbgdaTransportDevice {
    * perBlockSlot. Must match the sender's value.
    * @param timeout         Optional timeout for wait operations.
    */
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename Proto = protocol::Simple,
+      typename... Args>
   __device__ __forceinline__ void recv(
       ThreadGroup& group,
       void* __restrict__ dst,
@@ -2383,11 +2392,14 @@ class P2pIbgdaTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-    recvWithTrace<CopyOp>(
+    recvWithTrace<CopyOp, Proto>(
         group, dst, nbytes, max_signal_bytes, timeout, {}, 0, args...);
   }
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename Proto = protocol::Simple,
+      typename... Args>
   __device__ __forceinline__ void recvWithTrace(
       ThreadGroup& group,
       void* __restrict__ dst,
@@ -2417,7 +2429,7 @@ class P2pIbgdaTransportDevice {
           /*step=*/0,
           static_cast<uint16_t>(group.group_id));
     }
-    detail::recv<P2pIbgdaTransportDevice, CopyOp>(
+    detail::recv<P2pIbgdaTransportDevice, CopyOp, Proto>(
         *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
     if (group.is_leader()) {
       trace_ibgda_event(

--- a/comms/prims/transport/llx/tests/LLIbgdaSendRecv.cu
+++ b/comms/prims/transport/llx/tests/LLIbgdaSendRecv.cu
@@ -1,0 +1,128 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/transport/llx/tests/LLIbgdaSendRecv.cuh"
+
+#include <stdexcept>
+#include <string>
+
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/core/Timeout.cuh"
+#include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
+#include "comms/prims/transport/ibgda/IbgdaBuffer.h"
+#include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
+
+namespace comms::prims::test {
+
+namespace {
+
+void throwOnLaunchError(const char* what) {
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string(what) + " launch failed: " + cudaGetErrorString(err));
+  }
+}
+
+__global__ void
+fillPatternKernel(uint8_t* buffer, std::size_t nbytes, uint8_t baseValue) {
+  const std::size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const std::size_t stride = blockDim.x * gridDim.x;
+  for (std::size_t i = idx; i < nbytes; i += stride) {
+    buffer[i] = static_cast<uint8_t>(baseValue + (i % 256));
+  }
+}
+
+__global__ void verifyPatternKernel(
+    const uint8_t* buffer,
+    std::size_t nbytes,
+    uint8_t baseValue,
+    int* errorCount) {
+  const std::size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const std::size_t stride = blockDim.x * gridDim.x;
+  for (std::size_t i = idx; i < nbytes; i += stride) {
+    const uint8_t expected = static_cast<uint8_t>(baseValue + (i % 256));
+    if (buffer[i] != expected) {
+      atomicAdd(errorCount, 1);
+    }
+  }
+}
+
+// One block group drives send/recv over the transport's channel state via the
+// protocol-generic detail::send/recv<Transport, Memcpy, Proto>. Proto = Simple
+// or LL selects the wire format. (The P2pIbgdaTransportDevice class methods are
+// hard-wired to Simple, so LL is exercised through detail:: directly.)
+template <typename Proto>
+__global__ void sendRecvKernel(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    int activeBlocks,
+    std::size_t maxSignalBytes,
+    bool send) {
+  (void)activeBlocks; // master's detail::send/recv has no active_blocks param
+  auto group = make_block_group();
+  Timeout timeout(kDefaultDeviceTimeoutCycles);
+  timeout.start();
+  if (send) {
+    detail::send<P2pIbgdaTransportDevice, Memcpy, Proto>(
+        *transport, group, buffer, nbytes, maxSignalBytes, timeout);
+  } else {
+    detail::recv<P2pIbgdaTransportDevice, Memcpy, Proto>(
+        *transport, group, buffer, nbytes, maxSignalBytes, timeout);
+  }
+}
+
+} // namespace
+
+void fillPattern(
+    void* buffer,
+    std::size_t nbytes,
+    uint8_t baseValue,
+    int numBlocks,
+    int blockSize) {
+  fillPatternKernel<<<numBlocks, blockSize>>>(
+      static_cast<uint8_t*>(buffer), nbytes, baseValue);
+  throwOnLaunchError("fillPattern");
+}
+
+void verifyPattern(
+    const void* buffer,
+    std::size_t nbytes,
+    uint8_t baseValue,
+    int* errorCount,
+    int numBlocks,
+    int blockSize) {
+  verifyPatternKernel<<<numBlocks, blockSize>>>(
+      static_cast<const uint8_t*>(buffer), nbytes, baseValue, errorCount);
+  throwOnLaunchError("verifyPattern");
+}
+
+void launchLLSendRecv(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    int activeBlocks,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize) {
+  sendRecvKernel<protocol::LL><<<numBlocks, blockSize>>>(
+      transport, buffer, nbytes, activeBlocks, maxSignalBytes, send);
+  throwOnLaunchError("sendRecvKernel<protocol::LL>");
+}
+
+void launchSimpleSendRecv(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    int activeBlocks,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize) {
+  sendRecvKernel<protocol::Simple><<<numBlocks, blockSize>>>(
+      transport, buffer, nbytes, activeBlocks, maxSignalBytes, send);
+  throwOnLaunchError("sendRecvKernel<protocol::Simple>");
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/transport/llx/tests/LLIbgdaSendRecv.cuh
+++ b/comms/prims/transport/llx/tests/LLIbgdaSendRecv.cuh
@@ -1,0 +1,61 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstddef>
+#include <cstdint>
+
+namespace comms::prims {
+// Forward declaration only: keep the DOCA/CUDA device headers out of host
+// translation units (LLIbgdaSendRecvTest.cc) that just pass this as a pointer.
+class P2pIbgdaTransportDevice;
+} // namespace comms::prims
+
+namespace comms::prims::test {
+
+// Fill `buffer` with the deterministic pattern verifyPattern() checks:
+//   buffer[i] = baseValue + (i % 256)
+void fillPattern(
+    void* buffer,
+    std::size_t nbytes,
+    uint8_t baseValue,
+    int numBlocks,
+    int blockSize);
+
+// Count bytes in `buffer` that do NOT match fillPattern(baseValue). The
+// mismatch count is atomically accumulated into the device int `errorCount`.
+void verifyPattern(
+    const void* buffer,
+    std::size_t nbytes,
+    uint8_t baseValue,
+    int* errorCount,
+    int numBlocks,
+    int blockSize);
+
+// Launch one Proto=LL send (send=true) or recv (send=false) of `nbytes` PAYLOAD
+// bytes over `transport`'s channel via detail::send/recv<..., LL>. Throws
+// std::runtime_error on a launch failure. Caller synchronizes the stream.
+void launchLLSendRecv(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    int activeBlocks,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize);
+
+// Same as launchLLSendRecv but with Proto=Simple (baseline nccl-"simple"
+// put+signal path). Identical geometry to the transport's built-in send/recv.
+void launchSimpleSendRecv(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    int activeBlocks,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize);
+
+} // namespace comms::prims::test

--- a/comms/prims/transport/llx/tests/LLIbgdaSendRecvTest.cc
+++ b/comms/prims/transport/llx/tests/LLIbgdaSendRecvTest.cc
@@ -1,0 +1,45 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Distributed correctness test for the low-latency (Proto=LL) IBGDA send/recv
+// path. Rank 0 sends a known byte pattern via detail::send<..., LL>; rank 1
+// receives it over the same channel and verifies every byte. 2 ranks; intended
+// for 2-host x 1-GPU (nnodes=2, ppn=1) over RDMA, but also works
+// 2-ranks-on-1-node. Skips gracefully when no RDMA transport is available.
+
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+#include <memory>
+
+#include "comms/prims/transport/llx/tests/SendRecvSweepHarness.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+
+using meta::comms::MpiBaseTestFixture;
+using meta::comms::MPIEnvironmentBase;
+
+namespace comms::prims::tests {
+
+class LLIbgdaSendRecvFixture : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+};
+
+TEST_F(LLIbgdaSendRecvFixture, SendRecvRoundTrip) {
+  test::runSendRecvSweep(
+      globalRank, numRanks, localRank, &test::launchLLSendRecv, "LL");
+}
+
+} // namespace comms::prims::tests
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  auto mpi_env = std::make_unique<MPIEnvironmentBase>();
+  ::testing::AddGlobalTestEnvironment(mpi_env.get());
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/prims/transport/llx/tests/SendRecvSweepHarness.h
+++ b/comms/prims/transport/llx/tests/SendRecvSweepHarness.h
@@ -1,0 +1,142 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Shared 2-rank send/recv correctness sweep, parameterized by the per-protocol
+// launch function (launchLLSendRecv / launchSimpleSendRecv). Host-only: keeps
+// device/DOCA headers out via the forward-declared P2pIbgdaTransportDevice in
+// LLIbgdaSendRecv.cuh.
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "comms/prims/transport/ibgda/MultipeerIbgdaTransport.h"
+#include "comms/prims/transport/llx/tests/LLIbgdaSendRecv.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+namespace comms::prims::test {
+
+using SendRecvLaunchFn = void (*)(
+    P2pIbgdaTransportDevice*,
+    void*,
+    std::size_t,
+    int,
+    std::size_t,
+    bool,
+    int,
+    int);
+
+// Rank 0 -> rank 1 send/recv over a sweep of PAYLOAD sizes on one shared
+// transport, via `launch` (LL or Simple). `label` tags failure messages.
+// Sizes span: sub-slot, one slot payload, the full pipeline window, past the
+// window (forces slot reuse + gen advance), and a non-4B tail. A fresh pattern
+// per size guards against stale-slot matches. Skips when RDMA is unavailable.
+inline void runSendRecvSweep(
+    int globalRank,
+    int numRanks,
+    int localRank,
+    SendRecvLaunchFn launch,
+    const char* label) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
+  }
+
+  // dataBufferSize is WIRE bytes per slot; LL payload capacity is half.
+  const std::size_t dataBufferSize = 64 * 1024;
+  const int pipelineDepth = 2;
+  const int numBlocks = 1; // maxChannels
+  const int blockSize = 128;
+  const std::size_t maxSignalBytes = 0; // full-slot chunks
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+
+  const std::vector<std::size_t> sizes = {
+      4096, // sub-slot
+      32 * 1024, // one LL slot payload
+      64 * 1024, // full LL pipeline window
+      192 * 1024, // past the window -> slot reuse + gen advance (both protos)
+      6001, // non-4B tail (partial last LL packet)
+  };
+  std::size_t maxBytes = 0;
+  for (auto s : sizes) {
+    maxBytes = std::max(maxBytes, s);
+  }
+
+  try {
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .perChannelSize = dataBufferSize / numBlocks,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
+    };
+
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    auto transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, numRanks, bootstrap, config);
+    transport->exchange();
+
+    P2pIbgdaTransportDevice* peerTransport =
+        transport->getP2pTransportDevice(peerRank);
+
+    meta::comms::DeviceBuffer sendBuffer(maxBytes);
+    meta::comms::DeviceBuffer recvBuffer(maxBytes);
+    meta::comms::DeviceBuffer errorCountBuf(sizeof(int));
+    auto* d_errorCount = static_cast<int*>(errorCountBuf.get());
+
+    for (std::size_t i = 0; i < sizes.size(); ++i) {
+      const std::size_t nbytes = sizes[i];
+      const uint8_t pattern = static_cast<uint8_t>(0x11 + i);
+
+      if (globalRank == 0) {
+        fillPattern(sendBuffer.get(), nbytes, pattern, numBlocks, blockSize);
+      } else {
+        CUDACHECK_TEST(cudaMemset(recvBuffer.get(), 0, nbytes));
+      }
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      launch(
+          peerTransport,
+          globalRank == 0 ? sendBuffer.get() : recvBuffer.get(),
+          nbytes,
+          numBlocks,
+          maxSignalBytes,
+          /*send=*/globalRank == 0,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      if (globalRank == 1) {
+        CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+        verifyPattern(
+            recvBuffer.get(),
+            nbytes,
+            pattern,
+            d_errorCount,
+            numBlocks,
+            blockSize);
+        CUDACHECK_TEST(cudaDeviceSynchronize());
+
+        int h_errorCount = 0;
+        CUDACHECK_TEST(cudaMemcpy(
+            &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
+        EXPECT_EQ(h_errorCount, 0)
+            << label << " send/recv corrupted " << h_errorCount << " of "
+            << nbytes << " bytes (size index " << i << ")";
+      }
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/transport/llx/tests/SimpleIbgdaSendRecvTest.cc
+++ b/comms/prims/transport/llx/tests/SimpleIbgdaSendRecvTest.cc
@@ -1,0 +1,46 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Distributed correctness test for the nccl-"simple" (Proto=Simple) IBGDA
+// send/recv path -- the baseline counterpart to LLIbgdaSendRecvTest. Rank 0
+// sends a known byte pattern via detail::send<..., Simple>; rank 1 receives it
+// and verifies every byte. Same harness/sizes as the LL test so the two are
+// directly comparable. 2 ranks; run 2-host x 1-GPU (nnodes=2, ppn=1) over RDMA.
+// Skips gracefully when no RDMA transport is available.
+
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+#include <memory>
+
+#include "comms/prims/transport/llx/tests/SendRecvSweepHarness.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+
+using meta::comms::MpiBaseTestFixture;
+using meta::comms::MPIEnvironmentBase;
+
+namespace comms::prims::tests {
+
+class SimpleIbgdaSendRecvFixture : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+};
+
+TEST_F(SimpleIbgdaSendRecvFixture, SendRecvRoundTrip) {
+  test::runSendRecvSweep(
+      globalRank, numRanks, localRank, &test::launchSimpleSendRecv, "Simple");
+}
+
+} // namespace comms::prims::tests
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  auto mpi_env = std::make_unique<MPIEnvironmentBase>();
+  ::testing::AddGlobalTestEnvironment(mpi_env.get());
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:
Rework the LL device to inherit the shared IbSendRecvBase<LL> template and
override only the proto-specific methods.

- IbSendRecvDevice<LL> : public IbSendRecvBase<LL>. State, send_recv_state(),
  init_*/progress_*/pipeline_window and all shared helpers come from the base
  (no more duplicated member/ctors).
- Overrides send, recv, AND forward with the low-latency data+flag path over a
  separate channel bank (packet LLPacket<4,4>): pack/unpack with trailing flag = generation, put with NO DATA_READY signal, recv/forward poll inline flags,
  2x wire geometry. forward mirrors the base's ring-deadlock ordering (signal
  SLOT_FREE to the sender before waiting the fwd receiver's SLOT_FREE); v1
  requires dst != nullptr (fused reduce-forward is a follow-up).

Net structure: one IbSendRecvBase<Proto> template; Simple and LL each own
send/recv/forward (Simple via the base default, LL overriding all three).

Reviewed By: snarayankh

Differential Revision: D110941699


