### PR TITLE
Enable spdlog in RCCLX builds (#3588)

### DIFF
--- a/comms/ctran/utils/LogInit.cc
+++ b/comms/ctran/utils/LogInit.cc
@@ -6,13 +6,11 @@
 
 #include <folly/synchronization/CallOnce.h>
 
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
 #include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/Logger.h"
 #include "comms/utils/logger/LoggingFormat.h"
-#if !defined(__HIP_PLATFORM_AMD__)
-#include "comms/ctran/utils/CtranLogger.h"
-#endif
 
 namespace ctran::logging {
 
@@ -32,7 +30,6 @@ std::string getHipCtranCategory() {
   return fullFilePath.substr(0, ctranComponentIdx + kCtranComponent.size());
 };
 
-#if !defined(__HIP_PLATFORM_AMD__)
 spdlog::level::level_enum loggerLevelToSpdlogLevel(
     meta::comms::logger::LogLevel level) {
   switch (level) {
@@ -53,7 +50,6 @@ spdlog::level::level_enum loggerLevelToSpdlogLevel(
   }
   return spdlog::level::off;
 }
-#endif
 
 } // namespace
 
@@ -104,7 +100,6 @@ void initCtranLoggingImpl() {
             return cudaDev;
           }});
 #endif
-#if !defined(__HIP_PLATFORM_AMD__)
   meta::comms::logger::configureSpdlogLogger(
       kCtranLoggerName,
       "CTRAN",
@@ -121,7 +116,6 @@ void initCtranLoggingImpl() {
   meta::comms::logger::getSpdlogLogger(kCtranLoggerName)
       .set_level(loggerLevelToSpdlogLevel(
           meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
-#endif
 }
 } // anonymous namespace
 

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -1110,6 +1110,8 @@ set(COMMON_FILES
   comms/utils/logger/ScubaFileUtils.h
   comms/utils/logger/ScubaLogger.cc
   comms/utils/logger/ScubaLogger.h
+  comms/utils/logger/SpdlogLogger.cc
+  comms/utils/logger/SpdlogLogger.h
   comms/utils/MemUtils.cc
   comms/utils/MemUtils.h
   comms/utils/memtrace/MemoryTrace.cc
@@ -1296,6 +1298,25 @@ endif()
 # comms/utils/hrdw_ring_buffer/GpuClockCalibration.cc, which is compiled into
 # librccl. Resolved from CONDA_PREFIX via CMAKE_PREFIX_PATH (env), same as fmt.
 find_package(absl CONFIG REQUIRED)
+find_package(spdlog 1.16.0 CONFIG QUIET)
+if(NOT spdlog_FOUND)
+  include(FetchContent)
+  set(SPDLOG_BUILD_SHARED OFF CACHE BOOL "" FORCE)
+  set(SPDLOG_BUILD_PIC ON CACHE BOOL "" FORCE)
+  set(SPDLOG_FMT_EXTERNAL ON CACHE BOOL "" FORCE)
+  set(SPDLOG_BUILD_EXAMPLE OFF CACHE BOOL "" FORCE)
+  set(SPDLOG_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+  FetchContent_Declare(
+    spdlog
+    SOURCE_DIR "${FBCODE_DIR}/../third-party/spdlog"
+  )
+  # spdlog treats BUILD_SHARED_LIBS as an override of SPDLOG_BUILD_SHARED.
+  set(_rccl_saved_build_shared_libs "${BUILD_SHARED_LIBS}")
+  set(BUILD_SHARED_LIBS OFF)
+  FetchContent_MakeAvailable(spdlog)
+  set(BUILD_SHARED_LIBS "${_rccl_saved_build_shared_libs}")
+  unset(_rccl_saved_build_shared_libs)
+endif()
 
 set(GEN_DIR "${HIPIFY_DIR}/gensrc")
 set(GEN_SYM_DIR "${GEN_DIR}/symmetric")
@@ -1404,6 +1425,11 @@ list(APPEND HIP_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/git_version.cpp)
 #==================================================================================================
 ## Set RCCL source files
 add_library(rccl ${HIP_SOURCES})
+
+target_compile_definitions(rccl PRIVATE
+  SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO
+  SPDLOG_FMT_EXTERNAL
+)
 
 ## Set RCCL dependencies
 ## Ensure git version is updated before building rccl
@@ -1871,6 +1897,7 @@ target_link_libraries(rccl PRIVATE   dl)
 target_link_libraries(rccl PRIVATE   atomic)
 target_link_libraries(rccl PRIVATE   ${SMI_LIBRARIES})
 target_link_libraries(rccl PRIVATE fmt::fmt-header-only)
+target_link_libraries(rccl PRIVATE spdlog::spdlog)
 target_link_libraries(rccl PRIVATE absl::log absl::check)  # GpuClockCalibration.cc
 if(ENABLE_MSCCLPP)
   target_link_libraries(rccl PRIVATE mscclpp_nccl)

--- a/comms/utils/logger/LoggingFormat.cc
+++ b/comms/utils/logger/LoggingFormat.cc
@@ -20,9 +20,7 @@
 #include "comms/utils/logger/ErrorStackUtil.h"
 #include "comms/utils/logger/EventsScubaUtil.h"
 #include "comms/utils/logger/NcclScubaSample.h"
-#if !defined(__HIP_PLATFORM_AMD__)
 #include "comms/utils/logger/SpdlogLogger.h"
-#endif
 
 namespace {
 std::string getHostName(const char delim) {
@@ -250,9 +248,7 @@ void initThreadMetaData(std::string_view threadName) {
   static thread_local folly::once_flag threadNameFlag;
   folly::call_once(threadNameFlag, [&]() {
     myThreadName = threadName;
-#if !defined(__HIP_PLATFORM_AMD__)
     setSpdlogThreadName(threadName);
-#endif
   });
 }
 


### PR DESCRIPTION
Summary:

The standalone RCCLX conda build compiles CTRAN and shared logging sources directly, bypassing MCCL's `comms/utils` CMake target. CTRAN's spdlog facade therefore reached this build without the spdlog headers, compile definitions, implementation, or link dependency.

Mirror MCCL's dependency contract in the RCCL CMake project: discover spdlog 1.16.0, use `FetchContent` with fbsource's checked-in source as the offline fallback, compile `SpdlogLogger` into `librccl`, apply the required compile definitions to its sources, and link the static PIC target. Remove the temporary AMD guards so CTRAN logger initialization, last-error callbacks, and thread metadata use the same spdlog path on NVIDIA and AMD.

The checked-in fallback avoids adding a conda runtime dependency or relying on GitHub access, and static linkage leaves no `libspdlog.so` dependency.

Differential Revision: D115610523


