### PR TITLE
Add LL protocol benchmark

### DIFF
--- a/comms/prims/benchmarks/IbgdaSendRecv.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cu
@@ -300,6 +300,134 @@ void launch_ibgda_recv(
   }
 }
 
+// ==========================================================================
+// Low-latency (LL) protocol benchmark kernels. Mirror the Simple send/recv
+// kernels above but dispatch to the transport's send<LL>/recv<LL> (data+inline
+// flag, 2x wire, no DATA_READY wait; Memcpy only). Section sizing is identical:
+// the pipelined LL loop maps each payload section onto the wire ring
+// internally.
+// ==========================================================================
+__global__ void __launch_bounds__(512, 1) ibgda_send_recv_ll_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  auto [role, sub] = group.partition(2);
+  const bool isSender = (role == 0);
+
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    const std::size_t offset = s * sectionBytes;
+    if (isSender) {
+      TiledBuffer<char> tiles(src + offset, sectionBytes, sub);
+      transport->send<Memcpy, protocol::LL>(
+          sub, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
+    } else {
+      TiledBuffer<char> tiles(dst + offset, sectionBytes, sub);
+      transport->recv<Memcpy, protocol::LL>(
+          sub, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
+    }
+  }
+}
+
+void launch_ibgda_send_recv_ll(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  ibgda_send_recv_ll_kernel<<<2 * numBlocks, 512, 0, stream>>>(
+      transport, src, dst, nbytes, numBlocks, maxSignalBytes, timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] send/recv LL kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+}
+
+__global__ void __launch_bounds__(512, 1) ibgda_send_ll_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    TiledBuffer<char> tiles(src + s * sectionBytes, sectionBytes, group);
+    transport->send<Memcpy, protocol::LL>(
+        group, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
+  }
+}
+
+__global__ void __launch_bounds__(512, 1) ibgda_recv_ll_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    TiledBuffer<char> tiles(dst + s * sectionBytes, sectionBytes, group);
+    transport->recv<Memcpy, protocol::LL>(
+        group, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
+  }
+}
+
+void launch_ibgda_send_ll(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  ibgda_send_ll_kernel<<<numBlocks, 512, 0, stream>>>(
+      transport, src, nbytes, numBlocks, maxSignalBytes, timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] send LL kernel launch failed: %s\n", cudaGetErrorString(err));
+  }
+}
+
+void launch_ibgda_recv_ll(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  ibgda_recv_ll_kernel<<<numBlocks, 512, 0, stream>>>(
+      transport, dst, nbytes, numBlocks, maxSignalBytes, timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] recv LL kernel launch failed: %s\n", cudaGetErrorString(err));
+  }
+}
+
 __global__ void __launch_bounds__(512, 1) ibgda_drain_send_recv_kernel(
     P2pIbgdaTransportDevice* transport,
     int numBlocks,

--- a/comms/prims/benchmarks/IbgdaSendRecv.h
+++ b/comms/prims/benchmarks/IbgdaSendRecv.h
@@ -97,6 +97,39 @@ void launch_ibgda_recv(
     Timeout timeout = Timeout());
 
 /**
+ * Low-latency (LL) protocol counterparts of launch_ibgda_send_recv/send/recv.
+ * Same grid layout; dispatch to the transport's send_ll/recv_ll (data + inline
+ * flag, 2x wire, no DATA_READY wait; Memcpy only).
+ */
+void launch_ibgda_send_recv_ll(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
+    Timeout timeout = Timeout());
+
+void launch_ibgda_send_ll(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
+    Timeout timeout = Timeout());
+
+void launch_ibgda_recv_ll(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
+    Timeout timeout = Timeout());
+
+/**
  * Drain outstanding bidirectional send/recv transport work for benchmark
  * measurement and safe teardown.
  */

--- a/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -83,6 +83,14 @@ enum class SendRecvCopyOp {
   Memcpy,
 };
 
+// Wire protocol: Simple (put data + explicit DATA_READY signal) vs LL
+// (low-latency data + inline flag, 2x wire). LL is wired for the blocking path
+// only (the resumable Progress API has no LL wire/payload geometry yet).
+enum class SendRecvProto {
+  Simple,
+  LL,
+};
+
 bool isTcpEnvironment() {
   return std::getenv("MASTER_ADDR") != nullptr &&
       std::getenv("MASTER_PORT") != nullptr && std::getenv("RANK") != nullptr &&
@@ -267,13 +275,26 @@ const char* copyOpName(SendRecvCopyOp copyOp) {
   return "unknown";
 }
 
+const char* protoName(SendRecvProto proto) {
+  switch (proto) {
+    case SendRecvProto::Simple:
+      return "simple";
+    case SendRecvProto::LL:
+      return "ll";
+  }
+  return "unknown";
+}
+
 std::string benchmarkName(
     SendRecvApi api,
     SendRecvDirection direction,
     SendRecvCopyOp copyOp,
+    SendRecvProto proto,
     const char* sizeName,
     int repeat = -1) {
   std::string name = "ibgdaSendRecv(";
+  name += protoName(proto);
+  name += "_";
   name += apiName(api);
   name += "_";
   name += directionName(direction);
@@ -399,11 +420,12 @@ class IbgdaSendRecvBenchmarkContext {
       std::size_t nbytes,
       SendRecvApi api,
       SendRecvDirection direction,
-      SendRecvCopyOp copyOp) {
+      SendRecvCopyOp copyOp,
+      SendRecvProto proto) {
     CHECK_LE(nbytes, maxBytes_);
     bootstrap_->barrierAll();
     for (int i = 0; i < warmupIters_; ++i) {
-      launchOperation(nbytes, api, direction, copyOp);
+      launchOperation(nbytes, api, direction, copyOp, proto);
       CHECK_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
     }
     bootstrap_->barrierAll();
@@ -414,7 +436,8 @@ class IbgdaSendRecvBenchmarkContext {
       std::size_t nbytes,
       SendRecvApi api,
       SendRecvDirection direction,
-      SendRecvCopyOp copyOp) {
+      SendRecvCopyOp copyOp,
+      SendRecvProto proto) {
     CHECK_LE(nbytes, maxBytes_);
 
     cudaEvent_t start{};
@@ -424,7 +447,7 @@ class IbgdaSendRecvBenchmarkContext {
 
     CHECK_EQ(cudaEventRecord(start, stream_), cudaSuccess);
     for (uint32_t i = 0; i < iters; ++i) {
-      launchOperation(nbytes, api, direction, copyOp);
+      launchOperation(nbytes, api, direction, copyOp, proto);
     }
     CHECK_EQ(cudaEventRecord(stop, stream_), cudaSuccess);
     CHECK_EQ(cudaEventSynchronize(stop), cudaSuccess);
@@ -450,14 +473,23 @@ class IbgdaSendRecvBenchmarkContext {
       std::size_t nbytes,
       SendRecvApi api,
       SendRecvDirection direction,
-      SendRecvCopyOp copyOp) {
+      SendRecvCopyOp copyOp,
+      SendRecvProto proto) {
     auto* sendBuf = static_cast<char*>(sendBuf_->get());
     auto* recvBuf = static_cast<char*>(recvBuf_->get());
+    // LL is wired only for the blocking path (registerBenchmarks never pairs LL
+    // with Progress); dispatch to the send_ll/recv_ll launchers.
+    const bool useLL = (proto == SendRecvProto::LL);
 
     if (direction == SendRecvDirection::Bidirectional) {
       if (api == SendRecvApi::Blocking) {
-        launch_ibgda_send_recv(
-            deviceTransport_, sendBuf, recvBuf, nbytes, numBlocks_, stream_);
+        if (useLL) {
+          launch_ibgda_send_recv_ll(
+              deviceTransport_, sendBuf, recvBuf, nbytes, numBlocks_, stream_);
+        } else {
+          launch_ibgda_send_recv(
+              deviceTransport_, sendBuf, recvBuf, nbytes, numBlocks_, stream_);
+        }
       } else {
         launch_ibgda_progress_send_recv(
             deviceTransport_, sendBuf, recvBuf, nbytes, numBlocks_, stream_);
@@ -467,8 +499,13 @@ class IbgdaSendRecvBenchmarkContext {
 
     if (globalRank_ == 0) {
       if (api == SendRecvApi::Blocking) {
-        launch_ibgda_send(
-            deviceTransport_, sendBuf, nbytes, numBlocks_, stream_);
+        if (useLL) {
+          launch_ibgda_send_ll(
+              deviceTransport_, sendBuf, nbytes, numBlocks_, stream_);
+        } else {
+          launch_ibgda_send(
+              deviceTransport_, sendBuf, nbytes, numBlocks_, stream_);
+        }
       } else if (api == SendRecvApi::RegisteredProgress) {
         CHECK(registeredEnabled_);
         launch_ibgda_registered_progress_send(
@@ -486,7 +523,13 @@ class IbgdaSendRecvBenchmarkContext {
     }
 
     if (api == SendRecvApi::Blocking) {
-      launch_ibgda_recv(deviceTransport_, recvBuf, nbytes, numBlocks_, stream_);
+      if (useLL) {
+        launch_ibgda_recv_ll(
+            deviceTransport_, recvBuf, nbytes, numBlocks_, stream_);
+      } else {
+        launch_ibgda_recv(
+            deviceTransport_, recvBuf, nbytes, numBlocks_, stream_);
+      }
     } else {
       launch_ibgda_progress_recv(
           deviceTransport_, recvBuf, nbytes, numBlocks_, stream_);
@@ -518,6 +561,7 @@ static unsigned int ibgdaSendRecv(
     SendRecvApi api,
     SendRecvDirection direction,
     SendRecvCopyOp copyOp,
+    SendRecvProto proto,
     folly::UserCounters& counters) {
   // Small messages would run too briefly at folly's count and be dropped as
   // NaN; use a deterministic high count for them (identical on both ranks, so
@@ -527,11 +571,11 @@ static unsigned int ibgdaSendRecv(
   CHECK_GT(iters, 0);
 
   BENCHMARK_SUSPEND {
-    context.warmup(nbytes, api, direction, copyOp);
+    context.warmup(nbytes, api, direction, copyOp, proto);
   }
 
   const float elapsedMs =
-      context.runLocalElapsed(iters, nbytes, api, direction, copyOp);
+      context.runLocalElapsed(iters, nbytes, api, direction, copyOp, proto);
   folly::doNotOptimizeAway(elapsedMs);
 
   BENCHMARK_SUSPEND {
@@ -562,50 +606,78 @@ void registerBenchmark(
     SendRecvApi api,
     SendRecvDirection direction,
     SendRecvCopyOp copyOp,
+    SendRecvProto proto,
     int repeat = -1) {
   folly::addBenchmark(
       __FILE__,
-      benchmarkName(api, direction, copyOp, size.name, repeat),
-      [&context, nbytes = size.nbytes, api, direction, copyOp](
+      benchmarkName(api, direction, copyOp, proto, size.name, repeat),
+      [&context, nbytes = size.nbytes, api, direction, copyOp, proto](
           folly::UserCounters& counters, unsigned int iters) -> unsigned int {
         return ibgdaSendRecv(
-            context, iters, nbytes, api, direction, copyOp, counters);
+            context, iters, nbytes, api, direction, copyOp, proto, counters);
       });
 }
 
 void registerBenchmarks(IbgdaSendRecvBenchmarkContext& context) {
+  // A single run benchmarks exactly one protocol, selected via
+  // IBGDA_BENCH_PROTO (default: simple). Run the binary once per protocol to
+  // compare.
+  SendRecvProto proto = SendRecvProto::Simple;
+  if (const char* p = std::getenv("IBGDA_BENCH_PROTO")) {
+    const std::string protoStr(p);
+    if (protoStr == "ll") {
+      proto = SendRecvProto::LL;
+    } else if (protoStr == "simple") {
+      proto = SendRecvProto::Simple;
+    } else {
+      LOG(WARNING) << "Unknown IBGDA_BENCH_PROTO='" << protoStr
+                   << "', defaulting to simple";
+    }
+  }
+
   for (const auto& size : kBenchmarkSizes) {
+    // Blocking + fixed-size memcpy is supported by every protocol.
     registerBenchmark(
         context,
         size,
         SendRecvApi::Blocking,
         SendRecvDirection::Bidirectional,
-        SendRecvCopyOp::Memcpy);
-    registerBenchmark(
-        context,
-        size,
-        SendRecvApi::Progress,
-        SendRecvDirection::Bidirectional,
-        SendRecvCopyOp::Memcpy);
+        SendRecvCopyOp::Memcpy,
+        proto);
     registerBenchmark(
         context,
         size,
         SendRecvApi::Blocking,
         SendRecvDirection::Unidirectional,
-        SendRecvCopyOp::Memcpy);
+        SendRecvCopyOp::Memcpy,
+        proto);
+    // Neither the resumable Progress API nor the variable-size ANS CopyOp has
+    // LL wire geometry; both stay on Simple.
+    if (proto != SendRecvProto::Simple) {
+      continue;
+    }
+    registerBenchmark(
+        context,
+        size,
+        SendRecvApi::Progress,
+        SendRecvDirection::Bidirectional,
+        SendRecvCopyOp::Memcpy,
+        proto);
     registerBenchmark(
         context,
         size,
         SendRecvApi::Progress,
         SendRecvDirection::Unidirectional,
-        SendRecvCopyOp::Memcpy);
+        SendRecvCopyOp::Memcpy,
+        proto);
     if (context.registeredEnabled()) {
       registerBenchmark(
           context,
           size,
           SendRecvApi::RegisteredProgress,
           SendRecvDirection::Unidirectional,
-          SendRecvCopyOp::Memcpy);
+          SendRecvCopyOp::Memcpy,
+          proto);
     }
 
     if (context.registeredEnabled() &&
@@ -618,6 +690,7 @@ void registerBenchmarks(IbgdaSendRecvBenchmarkContext& context) {
             SendRecvApi::Progress,
             SendRecvDirection::Unidirectional,
             SendRecvCopyOp::Memcpy,
+            proto,
             repeat);
         registerBenchmark(
             context,
@@ -625,6 +698,7 @@ void registerBenchmarks(IbgdaSendRecvBenchmarkContext& context) {
             SendRecvApi::RegisteredProgress,
             SendRecvDirection::Unidirectional,
             SendRecvCopyOp::Memcpy,
+            proto,
             repeat);
       }
     }

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -2315,6 +2315,16 @@ class P2pIbgdaTransportDevice {
    * flight. `max_signal_bytes` may vary across calls because it only changes
    * the signal cadence within the fixed per-channel staging slice.
    *
+   * `Proto` is a call-site choice and is never negotiated on the wire, so the
+   * sender and receiver must select the same one: mixing them deadlocks, with
+   * Simple waiting on a DATA_READY counter the LL sender never posts while LL
+   * polls for an inline flag Simple never writes. Callers own that agreement
+   * and must derive the protocol from a collective-uniform input rather than
+   * from per-rank state. MCCL's tree does this on the host, picking from the
+   * total message size and baking the result into the kernel symbol (see
+   * `selectAllReduceTreeKernel` / `MCCL_ALLREDUCE_LL_MAX_BYTES`), so every rank
+   * in a launch runs the same format.
+   *
    * @param group           ThreadGroup (all threads participate in memcpy,
    *                        leader does RDMA ops).
    * @param src             Source data for this block's tile.


### PR DESCRIPTION
Summary:
Add LL (low-latency) protocol coverage to the IBGDA send/recv benchmark, selectable at runtime, so LL can be measured head-to-head against the existing Simple path. Additive only — the Simple path is unchanged.

**Transport (`P2pIbgdaTransportDevice.cuh`)**
Thread a `typename Proto = protocol::Simple` template parameter through `send` / `sendWithTrace` / `recv` / `recvWithTrace` down to `detail::send` / `detail::recv`, so a caller can pick the wire protocol. The default is `protocol::Simple`, so existing callers are unaffected.

**Benchmark kernels (`IbgdaSendRecv.cu` / `IbgdaSendRecv.h`)**
Add LL counterparts of the launch kernels — `launch_ibgda_send_recv_ll`, `launch_ibgda_send_ll`, `launch_ibgda_recv_ll` (and their kernels). They mirror the Simple kernels' grid layout and section sizing but dispatch to `transport->send/recv<Memcpy, protocol::LL>` (data + inline flag, 2x wire, no DATA_READY wait; Memcpy only).

**Benchmark driver (`IbgdaSendRecvBenchmark.cc`)**
- Add a `SendRecvProto {Simple, LL}` enum + `protoName()`, and thread `proto` through `benchmarkName` / `warmup` / `runLocalElapsed` / `launchOperation` / `ibgdaSendRecv` / `registerBenchmark`. Benchmark rows now carry the protocol in their name, e.g. `ibgdaSendRecv(ll_blocking_bidirectional_1MB)`.
- Protocol is chosen at runtime via the `IBGDA_BENCH_PROTO` env var (default `simple`; `ll` selects LL; anything else warns and falls back to simple). Run the binary once per protocol to compare.
- LL is wired for the **blocking** path only. The resumable Progress API has no LL wire/payload geometry yet, so Progress benchmarks are registered for Simple only.

Reviewed By: snarayankh, Scusemua

Differential Revision: D112334703


