### PR TITLE
Migrate CTRAN regcache errors (#3593)

### DIFF
--- a/comms/ctran/algos/CollUtils.h
+++ b/comms/ctran/algos/CollUtils.h
@@ -12,6 +12,8 @@
 #include <cuda_fp8.h>
 #endif
 
+#include "comms/ctran/utils/CtranLogUtils.h"
+
 // Use "static const" definitions here.  constness helps disallow []
 // usage of the unordered map, which is risky and causes the key to be
 // automatically created if it doesn't already exist.  Declaring this
@@ -156,7 +158,7 @@ struct CtranTupleHash {
 #define CTRAN_COLL_INFO(                                                         \
     algoStr, sendbuff, recvbuff, count, datatype, peer, comm, stream)            \
   do {                                                                           \
-    CLOGF_SUBSYS(                                                                \
+    CTRAN_LOG_SUBSYS(                                                            \
         INFO,                                                                    \
         COLL,                                                                    \
         "{}: opCount {} sendbuff {} recvbuff {} count {} datatype {} peer {} "   \
@@ -181,7 +183,7 @@ struct CtranTupleHash {
 #define CTRAN_HOST_COLL_INFO(                                                    \
     algoStr, sendbuff, recvbuff, count, datatype, peer, comm, ctran, req)        \
   do {                                                                           \
-    CLOGF_SUBSYS(                                                                \
+    CTRAN_LOG_SUBSYS(                                                            \
         INFO,                                                                    \
         COLL,                                                                    \
         "{}: opCount {} sendbuff {} recvbuff {} count {} datatype {} peer {} "   \
@@ -206,7 +208,7 @@ struct CtranTupleHash {
 #define CTRAN_REDCOLL_INFO(                                                  \
     algoStr, sendbuff, recvbuff, count, datatype, redOp, peer, comm, stream) \
   do {                                                                       \
-    CLOGF_SUBSYS(                                                            \
+    CTRAN_LOG_SUBSYS(                                                        \
         INFO,                                                                \
         COLL,                                                                \
         "{}: opCount {} sendbuff {} recvbuff {} count {} datatype {} "       \
@@ -242,7 +244,7 @@ struct CtranTupleHash {
     comm,                                                                                               \
     stream)                                                                                             \
   do {                                                                                                  \
-    CLOGF_SUBSYS(                                                                                       \
+    CTRAN_LOG_SUBSYS(                                                                                   \
         INFO,                                                                                           \
         COLL,                                                                                           \
         "CTRAN-RMA {}: opCount {} winOpCount {} originBuff {} targetDisp {} count {} "                  \

--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -9,6 +9,7 @@
 #include "comms/ctran/algos/CtranAlgoConsts.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/TmpBufSegManager.h"
 #if defined(ENABLE_PRIMS)
@@ -17,7 +18,6 @@
 #endif // defined(ENABLE_PRIMS)
 
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 
 #if defined(ENABLE_PRIMS)
 using comms::prims::NvlChannelState;
@@ -194,7 +194,7 @@ commResult_t CtranAlgo::initKernelResources() {
   int rank = statex->rank();
 
   if (nLocalRanks > CTRAN_MAX_NVL_PEERS) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "CTRAN only supports NVL peers up to {}, but nLocalRanks is {}. "
         "This will likely cause seg fault or data corruption! "
@@ -237,7 +237,7 @@ commResult_t CtranAlgo::initKernelResources() {
       statex->cudaDev()));
 
   if (maxSharedMemOptin < sizeof(CtranAlgoDeviceState)) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "CTRAN-ALGO: sharedMemPerBlockOptin {} on device {} is smaller than the size of CtranAlgoDeviceState {}",
         maxSharedMemOptin,
@@ -302,7 +302,7 @@ commResult_t CtranAlgo::initKernelResources() {
       // Next chunk is for bcastBuf
       peerBcastBufsMap[i] = (char*)this->sharedRes_->mappedDevShmPtrs[i] +
           getBcastBufOffset(nLocalRanks, nvlSharedDevbufSize);
-      CLOGF_TRACE(
+      CTRAN_LOG_TRACE(
           INIT,
           "CTRAN-ALGO: allocated local peerBcastBufsMap[{}] = {}, size {}",
           i,
@@ -339,7 +339,7 @@ commResult_t CtranAlgo::initKernelResources() {
     const size_t nvlMaxNumChannels =
         static_cast<size_t>(std::max(1, CTRAN_ALGO_MAX_THREAD_BLOCKS));
     if (nvlPipelineDepth == 0) {
-      CERR(
+      CTRAN_ERR(
           commInvalidArgument,
           "CTRAN-ALGO: invalid NVL P2P config; pipelineDepth=0");
       return commInvalidArgument;
@@ -348,7 +348,7 @@ commResult_t CtranAlgo::initKernelResources() {
     const size_t nvlPerChannelBuffer =
         alignDown(nvlSharedDevbufSize / nvlMaxNumChannels, nvlChannelAlign);
     if (nvlPerChannelBuffer == 0) {
-      CERR(
+      CTRAN_ERR(
           commInvalidArgument,
           "CTRAN-ALGO: invalid NVL P2P config; sharedDevbufSize={} maxNumChannels={} pipelineDepth={} cannot produce aligned per-channel buffer",
           nvlSharedDevbufSize,
@@ -500,7 +500,8 @@ CtranAlgo::SharedResource::SharedResource(CtranComm* comm) {
   this->mappedDevShmPtrs.resize(nLocalRanks);
 
   for (int i = 0; i < nLocalRanks; ++i) {
-    CLOGF_TRACE(INIT, "Received ipcDescs[{}]={}", i, ipcDescs[i].toString());
+    CTRAN_LOG_TRACE(
+        INIT, "Received ipcDescs[{}]={}", i, ipcDescs[i].toString());
     if (localRank == i) {
       this->mappedDevShmPtrs[i] = devShmPtr;
     } else {
@@ -560,7 +561,7 @@ CtranAlgoLogger::CtranAlgoLogger(
     std::optional<const ICtran*> ctran)
     : name(name), opCount_(opCount), comm_(comm), ctran_(ctran) {
   auto& statex = comm_->statex_;
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       COLL,
       "{} GPE-START: opCount {} comm {} commHash {:x} Ctran {}",
@@ -573,7 +574,7 @@ CtranAlgoLogger::CtranAlgoLogger(
 
 CtranAlgoLogger::~CtranAlgoLogger() {
   auto& statex = comm_->statex_;
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       COLL,
       "{} GPE-DONE: opCount {} comm {} commHash {:x} Ctran {}",
@@ -596,7 +597,7 @@ CtranAlgoRMALogger::CtranAlgoRMALogger(
       win_(win),
       comm_(comm) {
   auto& statex = comm_->statex_;
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       COLL,
       "{} GPE-START: opCount {} rank {} peer {} win {} comm {} commHash {:x} Ctran {}",
@@ -612,7 +613,7 @@ CtranAlgoRMALogger::CtranAlgoRMALogger(
 
 CtranAlgoRMALogger::~CtranAlgoRMALogger() {
   auto& statex = comm_->statex_;
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       COLL,
       "{} GPE-DONE: opCount {} rank {} peer {} win {} comm {} commHash {:x} Ctran {}",
@@ -684,7 +685,7 @@ enum NCCL_ALLREDUCE_ALGO CtranAlgo::getAllReduceAlgo() {
 commResult_t CtranAlgo::exchangePeerTmpbuf(int peer) {
   // if peer is out of range, we report an error
   if (comm_->statex_->nRanks() < peer) {
-    CERR(commInvalidArgument, "Invalid value for peer: {}", peer);
+    CTRAN_ERR(commInvalidArgument, "Invalid value for peer: {}", peer);
     return commInvalidArgument;
   }
   // if tmpbuffs are already exchanged, we don't need to do anything
@@ -963,7 +964,7 @@ commResult_t CtranAlgo::initializeCommAttributesMap() {
     auto coll = getCollType(commAttrKeyValuePair.first);
     auto& statex = comm_->statex_;
     if (coll == CollType::UNKNOWN) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-ALGO: Unknown collective type {} in pimpl {} commHash {:x}, commDesc {}.",
           commAttrKeyValuePair.first,
@@ -989,7 +990,7 @@ commResult_t CtranAlgo::initializeCommAttributesMap() {
           commAttrKeyValuePair.second[qpConfigIndex::VC_MODE] == "dqplb") {
         config.vcMode = NCCL_CTRAN_IB_VC_MODE::dqplb;
       } else {
-        CERR(
+        CTRAN_ERR(
             commInternalError,
             "CTRAN-ALGO: Invalid VC mode {} in pimpl {} commHash {:x}, commDesc {}.",
             commAttrKeyValuePair.second[qpConfigIndex::VC_MODE],
@@ -1000,7 +1001,7 @@ commResult_t CtranAlgo::initializeCommAttributesMap() {
       }
       collToVcConfigMap_[coll] = config;
     } else {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-ALGO: Invalid collective->vc config specified for {} in pimpl {} commHash {:x}, commDesc {}. Expected {} parameters but received only {}",
           commAttrKeyValuePair.first,

--- a/comms/ctran/algos/RMA/Get.cc
+++ b/comms/ctran/algos/RMA/Get.cc
@@ -9,8 +9,8 @@
 #include "comms/ctran/colltrace/CollTraceWrapper.h"
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/window/CtranWin.h"
-#include "comms/utils/logger/LogUtils.h"
 
 using namespace ctran;
 using ::meta::comms::colltrace::CollTraceHandleTriggerState;
@@ -30,7 +30,7 @@ static commResult_t getImpl(
 
   // IB backend must be available for current Get implementation
   if (!comm->ctran_->mapper->hasBackend(peerRank, CtranMapperBackend::IB)) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "GET only support IB backend for now, and no IB backend found");
     return commInternalError;
@@ -48,7 +48,7 @@ static commResult_t getImpl(
   FB_COMMCHECK(comm->ctran_->mapper->searchRegHandle(
       op->get.recvbuff, getSize, &localMemHdl, &localReg));
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "getImpl: dstbuf {}, srcbuf {} (base {} + offset {}), size {}",
       op->get.recvbuff,
@@ -111,7 +111,7 @@ commResult_t ctranGet(
   size_t countNbytes = count * commTypeSize(datatype);
   size_t peerWinSize = win->getDataSize(peer);
   if ((targetDispNbytes + countNbytes) > peerWinSize) {
-    CERR(
+    CTRAN_ERR(
         commInvalidArgument,
         "Invalid target displacement from {} bytes to {} bytes exceeding peer {}'s window size {}",
         targetDispNbytes,

--- a/comms/ctran/algos/RMA/PutSignal.cc
+++ b/comms/ctran/algos/RMA/PutSignal.cc
@@ -11,10 +11,10 @@
 #include "comms/ctran/colltrace/CollTraceWrapper.h"
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/window/CtranWin.h"
-#include "comms/utils/logger/LogUtils.h"
 
 using namespace ctran;
 using meta::comms::colltrace::CollTraceHandleTriggerState;
@@ -58,7 +58,7 @@ inline static commResult_t checkDisplacementBounds(
   size_t totalBytes = dispNbytes + (elemSize * elemCount);
 
   if (totalBytes > winSize) {
-    CERR(
+    CTRAN_ERR(
         commInvalidArgument,
         "Invalid displacement from {} bytes to {} bytes exceeding the window size {}",
         dispNbytes,
@@ -73,7 +73,7 @@ inline static commResult_t checkSignalDisplacement(
     size_t disp,
     size_t signalSize) {
   if (disp > signalSize) {
-    CERR(
+    CTRAN_ERR(
         commInvalidArgument,
         "Invalid displacement {} exceeding the signal buffer size {}",
         disp,
@@ -99,7 +99,7 @@ static commResult_t putSignalImpl(
 
   // The IB backend must be available
   if (!comm->ctran_->mapper->hasBackend(peerRank, CtranMapperBackend::IB)) {
-    CERR(commInternalError, "Put signal doesn't have IB backend");
+    CTRAN_ERR(commInternalError, "Put signal doesn't have IB backend");
     return commInternalError;
   }
 
@@ -116,7 +116,7 @@ static commResult_t putSignalImpl(
   FB_COMMCHECK(comm->ctran_->mapper->searchRegHandle(
       op->putsignal.sendbuff, putSize, &localMemHdl, &localReg));
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "putSignalImpl: sbuf {}, rbuf {} (base {} + offset {}), size {}, signalAddr {} signalVal {}",
       op->putsignal.sendbuff,
@@ -174,11 +174,11 @@ static commResult_t signalImpl(
 
   // The IB backend must be available
   if (!comm->ctran_->mapper->hasBackend(peerRank, CtranMapperBackend::IB)) {
-    CERR(commInternalError, "Signal doesn't have IB backend");
+    CTRAN_ERR(commInternalError, "Signal doesn't have IB backend");
     return commInternalError;
   }
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "signalImpl: peer {} signalAddr {} signalVal {}",
       op->signal.peerRank,
@@ -206,7 +206,7 @@ static commResult_t waitSignalSpinningKernelImpl(
   const std::atomic<uint64_t>* addr =
       reinterpret_cast<const std::atomic<uint64_t>*>(op->waitsignal.signalAddr);
   CtranAlgoRMALogger logger("ctranWaitSignal", op->opCount, -1, win, comm);
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "waitSignalSpinningKernelImpl: signalAddr {}, cmpVal={}",
       (void*)const_cast<uint64_t*>(op->waitsignal.signalAddr),
@@ -410,7 +410,7 @@ waitSignalDriverApi(int peer, CtranWin* win, cudaStream_t stream) {
 
     // Propagate other errors - do not fallback as they may indicate
     // stream corruption from prior async operations
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "CTRAN RMA: Hardware wait failed with error ({}), not falling back",
         errStr ? errStr : "unknown error");
@@ -588,7 +588,7 @@ commResult_t ctranWaitSignal(int peer, CtranWin* win, cudaStream_t stream) {
     colltraceHandle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
 
     if (hwResult == commSuccess) {
-      CLOGF_TRACE(
+      CTRAN_LOG_TRACE(
           COLL, "CTRAN RMA: WaitSignal successful using hardware acceleration");
       return commSuccess;
     }

--- a/comms/ctran/algos/SendRecv/SendRecv.cc
+++ b/comms/ctran/algos/SendRecv/SendRecv.cc
@@ -12,6 +12,7 @@
 #include "comms/ctran/algos/SendRecv/SendRecvImpl.h"
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/ctran/utils/ExtUtils.h"
 
@@ -69,7 +70,7 @@ bool ctranSendRecvSupport(
       algo == NCCL_SENDRECV_ALGO::ctgraph) {
     static std::once_flag warnedOnce;
     std::call_once(warnedOnce, []() {
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           WARN,
           COLL,
           "CTRAN SendRecv: ctp2p/ctgraph requires comms::prims device transports "
@@ -96,7 +97,7 @@ bool ctranSendRecvSupport(
         ctran::utils::cudagraph::getStreamCaptureInfo(stream, captureInfo);
     if (err != cudaSuccess ||
         captureInfo.status != cudaStreamCaptureStatusActive) {
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           COLL,
           "SendRecv ctgraph: not in capture mode. "

--- a/comms/ctran/algos/SendRecv/SendRecvCudagraphAware.cc
+++ b/comms/ctran/algos/SendRecv/SendRecvCudagraphAware.cc
@@ -17,6 +17,7 @@
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/SendRecv/SendRecvImpl.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/CudaRAII.h"
 
 commResult_t ctranSendRecvCudagraphAware(
@@ -27,7 +28,7 @@ commResult_t ctranSendRecvCudagraphAware(
   // Caller (ctranGroupEndHook) already verified active capture mode.
   const auto statex = comm->statex_.get();
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       COLL,
       "SendRecv cudagraph-aware: nOps {} commHash {:x} commDesc {} nRanks {} nLocalRanks {} nNodes {}",

--- a/comms/ctran/algos/SendRecv/SendRecvImpl.h
+++ b/comms/ctran/algos/SendRecv/SendRecvImpl.h
@@ -11,6 +11,7 @@
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 namespace ctran::sendrecv {
@@ -76,7 +77,7 @@ inline commResult_t selfSendRecvImpl(
     CtranComm* comm) {
   const auto statex = comm->statex_.get();
   if (selfSends.size() != selfRecvs.size()) {
-    CERR(
+    CTRAN_ERR(
         commInvalidUsage,
         "Invalid usage: number of self ncclSend ({}) and ncclRecv ({}) does not match on rank {}",
         selfSends.size(),

--- a/comms/ctran/gpe/CtranGpe.cc
+++ b/comms/ctran/gpe/CtranGpe.cc
@@ -11,8 +11,8 @@
 #include "comms/ctran/profiler/DefaultGpeProfilerReporter.h"
 #include "comms/ctran/profiler/GpeProfiler.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 
 using namespace ctran;
 
@@ -387,7 +387,7 @@ commResult_t CtranGpe::allocKernelElems(
     this->pimpl->kernelElemPool->reclaim();
 
     if (numElems > this->pimpl->kernelElemPool->size()) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-GPE: Internal KernelElem pool has unexpected high usage (capacity: {}, available: {}, current request: {}). "
           "It is likely that some COMM kernels are not released properly",
@@ -402,7 +402,7 @@ commResult_t CtranGpe::allocKernelElems(
   if (numElems > 0) {
     *elemsList = this->pimpl->kernelElemPool->pop(ngroups);
     if (!*elemsList) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-GPE: failed to allocate KernelElem from pool (pop returned null)");
       return commInternalError;
@@ -412,7 +412,7 @@ commResult_t CtranGpe::allocKernelElems(
   for (int i = 1; i < numElems; i++) {
     elem->next = this->pimpl->kernelElemPool->pop(ngroups);
     if (!elem->next) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-GPE: failed to allocate chained KernelElem from pool (pop returned null)");
       return commInternalError;

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -19,6 +19,7 @@
 #include "comms/ctran/gpe/CtranGpeImpl.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/ctran/utils/Exception.h"
@@ -27,7 +28,6 @@
 #include "comms/utils/colltrace/CollRecord.h"
 #include "comms/utils/colltrace/ColltraceDeviceHandle.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 
 using namespace ctran;
 using namespace ncclx::colltrace;
@@ -100,7 +100,7 @@ CtranGpeCmd::~CtranGpeCmd() {
 void CUDART_CB CtranGpe::Impl::cmdDestroy(void* data) {
   CtranGpeCmd* cmd = reinterpret_cast<CtranGpeCmd*>(data);
   if (!cmd->persistent) {
-    CLOGF(WARN, "CTranGPE: cmd desctructor called for non-persistent cmd");
+    CTRAN_LOG(WARN, "CTranGPE: cmd desctructor called for non-persistent cmd");
   }
   // Erase the registry entry BEFORE waiting on inFlight: erase() and the
   // worker's lookupAndFire() are mutually exclusive under the registry lock, so
@@ -135,7 +135,7 @@ commResult_t CtranGpe::Impl::submit(
 
   // Error checking before GPE cmd and kernel submission
   if (kernelConfig.args.devState_d == nullptr) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "COMM internally passed invalid devState_d (nullptr) to kernel {}",
         kernelTypeToName[kernelConfig.type]);
@@ -303,7 +303,7 @@ commResult_t CtranGpe::Impl::submit(
           auto result =
               comm->ctran_->mapper->teardownUnpackConsumer(unpackPool);
           if (result != commSuccess) {
-            CLOGF_SUBSYS(
+            CTRAN_LOG_SUBSYS(
                 WARN,
                 COLL,
                 "CTRAN-GPE: failed to teardown graph unpack pool {}: result {}",
@@ -434,7 +434,7 @@ commResult_t CtranGpe::Impl::submit(
     launchConfig.hStream = launchStream;
     CUfunction cuFn;
     FB_CUDACHECKGOTO(cudaGetFuncBySymbol(&cuFn, ncclKernel), res, fail);
-    CLOGF_TRACE(COLL, "CTranGPE: submit {}", kernelConfig.toString());
+    CTRAN_LOG_TRACE(COLL, "CTranGPE: submit {}", kernelConfig.toString());
 
     if (colltraceHandle != nullptr) {
       colltraceHandle->trigger(
@@ -451,7 +451,7 @@ commResult_t CtranGpe::Impl::submit(
     dim3 grid = {kernelConfig.numBlocks, 1, 1};
     dim3 blocks = {kernelConfig.numThreads, 1, 1};
 
-    CLOGF_TRACE(COLL, "CTranGPE: submit {}", kernelConfig.toString());
+    CTRAN_LOG_TRACE(COLL, "CTranGPE: submit {}", kernelConfig.toString());
 
     if (colltraceHandle != nullptr) {
       colltraceHandle->trigger(
@@ -503,7 +503,7 @@ commResult_t CtranGpe::Impl::submit(
           launchStream);
       if (res != cudaSuccess && checksumItem != nullptr) {
         // Do not return error if the internal checksum fails
-        CLOGF(WARN, "CTranGPE: Failed to launch checksum kernel");
+        CTRAN_LOG(WARN, "CTranGPE: Failed to launch checksum kernel");
         checksumItem->reset();
       } else if (colltraceHandle != nullptr) {
         folly::dynamic dynamicObj = folly::dynamic::object();
@@ -521,7 +521,7 @@ commResult_t CtranGpe::Impl::submit(
     colltraceHandle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       COLL,
       "CTRAN-GPE: Launched kernelType {} (opGroup size {}) with kernelFlag={}",
@@ -680,8 +680,8 @@ void CtranGpe::Impl::terminate() {
     if (now >= nextLog) {
       const auto elapsedSec =
           std::chrono::duration_cast<std::chrono::seconds>(now - start).count();
-      CLOGF_SUBSYS(
-          WARNING,
+      CTRAN_LOG_SUBSYS(
+          WARN,
           INIT,
           "terminate() spin-wait: pools still draining after {}s on rank {} commHash {:x}"
           " -- kernelFlag {}/{} kernelElem {}/{} gpeKernelSync {}/{}."
@@ -701,7 +701,7 @@ void CtranGpe::Impl::terminate() {
     std::this_thread::yield();
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTranGPE thread joined on rank {} commHash {:x} commDesc {}",
@@ -765,7 +765,7 @@ void CtranGpe::Impl::gpeThreadFn() {
           }
 
           const std::string_view phase = isTerminateCmd ? " now TERMINATE" : "";
-          CLOGF(
+          CTRAN_LOG(
               ERR,
               "Communicator aborted ({}){} on rank {} commHash {:x} {}",
               reason,
@@ -789,7 +789,7 @@ void CtranGpe::Impl::gpeThreadFn() {
             pending->inFlight.fetch_sub(1, std::memory_order_release);
           }
         }
-        CLOGF_SUBSYS(
+        CTRAN_LOG_SUBSYS(
             INFO,
             INIT,
             "[COMM THREAD] CTranGPE thread terminated on rank {} commHash {:x} commDesc {}",
@@ -865,7 +865,7 @@ void CtranGpe::Impl::gpeThreadFn() {
           // Comm already aborted — skip collective to prevent
           // progressInternal() from accessing stale VC queue entries
           // left by a previously aborted collective (double-complete bug).
-          CLOGF(
+          CTRAN_LOG(
               WARN,
               "Communicator aborted, skipping collective (opType={}, opCount={}) on rank {} commHash {:x}",
               cmd->coll.opGroup.empty()
@@ -1005,7 +1005,7 @@ void KernelElem::unuse() {
   for (int i = 0; i < this->ngroups; i++) {
     this->status[i] = KernelElem::ElemStatus::RESET;
   }
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-GPE: elem {} set to unuse with ngroups {}",
       (void*)this,
@@ -1017,7 +1017,7 @@ void KernelElem::setStatus(KernelElem::ElemStatus s) {
   for (int i = 0; i < this->ngroups; i++) {
     this->status[i] = s;
   }
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-GPE: elem {} set to {} with ngroups {}",
       (void*)this,
@@ -1055,7 +1055,7 @@ void KernelElem::free() {
   for (int i = 0; i < this->ngroups; i++) {
     this->status[i] = KernelElem::ElemStatus::RESET;
   }
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-GPE: elem {} freed with ngroups {}",
       (void*)this,
@@ -1072,7 +1072,7 @@ bool KernelElem::isFree() {
     allFree &= (this->status[i] == KernelElem::ElemStatus::RESET);
   }
   if (allFree) {
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-GPE: elem {} isFree = true with ngroups {}",
         (void*)this,
@@ -1093,7 +1093,7 @@ void KernelElem::post(int groupId) {
     for (int i = 0; i < this->ngroups; i++) {
       this->status[i] = KernelElem::ElemStatus::POSTED;
     }
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-GPE: elem {} posted with ngroups {}",
         (void*)this,
@@ -1103,7 +1103,7 @@ void KernelElem::post(int groupId) {
 
     // Ring doorbell to each thread block on kernel side
     this->status[groupId] = KernelElem::ElemStatus::POSTED;
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-GPE: elem {} posted with groupId {}",
         (void*)this,
@@ -1120,7 +1120,7 @@ void KernelElem::revoke() {
   for (int i = 0; i < this->ngroups; i++) {
     this->status[i] = KernelElem::ElemStatus::REVOKED;
   }
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-GPE: elem {} revoked with ngroups {}",
       (void*)this,
@@ -1141,7 +1141,7 @@ bool KernelElem::isComplete(int groupId) {
     complete = (this->status[groupId] == KernelElem::ElemStatus::DONE);
   }
   if (complete) {
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-GPE: elem {} completed at step {}",
         (void*)this,
@@ -1185,7 +1185,7 @@ KernelElemPool::KernelElemPool(size_t capacity) : capacity_(capacity) {
 KernelElemPool::~KernelElemPool() {
   this->reclaim();
   if (this->inuseWorkElems_.size()) {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-GPE: Internal KernelElem pool has {} inuse elements",
         this->inuseWorkElems_.size());
@@ -1216,7 +1216,7 @@ size_t KernelElemPool::capacity() {
 
 KernelElem* KernelElemPool::pop(int ngroups) {
   if (ngroups > CTRAN_ALGO_MAX_THREAD_BLOCKS) {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-GPE: ngroups {} exceeds max thread blocks {}",
         ngroups,
@@ -1231,7 +1231,7 @@ KernelElem* KernelElemPool::pop(int ngroups) {
     workElem->status[i] = KernelElem::ElemStatus::INUSE;
   }
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "CTRAN-GPE: elem {} popped with ngroups {}",
       (void*)workElem,
@@ -1290,7 +1290,7 @@ std::optional<ChecksumArgs> ctranFillChecksumArgs(
       return ChecksumHandler<KT::RECV>::ctranFillChecksumArgs(
           kernelConfig, checksumItem, comm);
     default:
-      CLOGF(
+      CTRAN_LOG(
           WARN,
           "CTRAN-GPE: Unsupported kernel type {} for checksum",
           kernelConfig.type);

--- a/comms/ctran/gpe/GpeDeviceRing.cc
+++ b/comms/ctran/gpe/GpeDeviceRing.cc
@@ -7,10 +7,10 @@
 #include <memory>
 
 #include "comms/ctran/gpe/CtranGpeImpl.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 
 ctran::gpe::GpeCmdId GpeDeviceRingCmdRegistry::registerCmd(CtranGpeCmd* cmd) {
   ctran::gpe::GpeCmdId id = nextId_.fetch_add(1, std::memory_order_relaxed);
@@ -88,13 +88,13 @@ void CtranGpe::Impl::initDeviceRing() {
     return major;
   }();
   if (ccMajor < 0) {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-GPE: could not query compute capability; leaving device ring disabled");
     return;
   }
   if (ccMajor < 9) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-GPE: device ring requires sm_90+ (found compute capability {}.x); using host-node dispatch",
@@ -106,7 +106,7 @@ void CtranGpe::Impl::initDeviceRing() {
   // allocation. Reject it with a clear diagnostic and fall back to host nodes.
   const int configuredRingSize = NCCL_CTRAN_GPE_DEVICE_RING_SIZE;
   if (configuredRingSize <= 0) {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-GPE: NCCL_CTRAN_GPE_DEVICE_RING_SIZE={} must be > 0; using host-node dispatch",
         configuredRingSize);
@@ -115,14 +115,14 @@ void CtranGpe::Impl::initDeviceRing() {
   auto ring = std::make_unique<ctran::gpe::GpeRing>(
       static_cast<uint32_t>(configuredRingSize));
   if (!ring->valid()) {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-GPE: device ring allocation failed; falling back to host-node dispatch");
     return;
   }
   deviceRingReader_ = std::make_unique<ctran::gpe::GpeRingReader>(*ring);
   deviceRing_ = std::move(ring);
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-GPE: device-ring dispatch enabled (ring size {})",
@@ -185,7 +185,7 @@ CtranGpeCmd* CtranGpe::Impl::acquireNextCmd() {
         // The cmd was destroyed (graph teardown) after publishing, or an id
         // was never registered. Drop it — safe because a destroyed cmd's
         // registry entry is erased before free.
-        CLOGF(
+        CTRAN_LOG(
             WARN,
             "CTRAN-GPE: device ring entry cmd_id {} has no live registry entry; skipping",
             entry.data);
@@ -196,7 +196,7 @@ CtranGpeCmd* CtranGpe::Impl::acquireNextCmd() {
     // waiting for us to drain, so device work is being throttled by the GPE
     // consumer. Rate-limited so a sustained stall logs periodically.
     if (pollResult.writerThrottled) {
-      CLOGF_EVERY_MS(
+      CTRAN_LOG_EVERY_MS(
           WARN,
           1000,
           "CTRAN-GPE: device ring full (size {}); kernel writes throttled — GPE consumer not draining fast enough",

--- a/comms/ctran/regcache/IpcRegCache.cc
+++ b/comms/ctran/regcache/IpcRegCache.cc
@@ -243,7 +243,7 @@ commResult_t ctran::IpcRegCache::importRemMemImpl(
     reg = std::make_unique<ctran::regcache::IpcRemRegElem>(
         ipcDesc.desc, cudaDev, logMetaData, extraSegments);
   } catch (std::exception& e) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "CTRAN-REGCACHE: failed to import IPC remote registration from peer {} ipcDesc {}, error {}",
         peerId,
@@ -281,7 +281,7 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
   auto peerIt = lockedMap->find(peerId);
   if (peerIt == lockedMap->end() ||
       peerIt->second.find(key) == peerIt->second.end()) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "CTRAN-REGCACHE: Unknown IPC remote memory registration from peer {} base {} uid {}",
         peerId,
@@ -393,7 +393,7 @@ commResult_t ctran::IpcRegCache::notifyRemoteIpcRelease(
     int32_t exportCount) {
   // Check if AsyncSocket is initialized
   if (!asyncSocketEvbThread_ || !asyncServerSocket_) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "CTRAN-REGCACHE: AsyncSocket not initialized, skipping remote release");
     return commInternalError;
@@ -442,7 +442,7 @@ commResult_t ctran::IpcRegCache::notifyRemoteIpcExport(
     ctran::regcache::IpcReqCb* reqCb) {
   // Check if AsyncSocket is initialized
   if (!asyncSocketEvbThread_ || !asyncServerSocket_) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "CTRAN-REGCACHE: AsyncSocket not initialized, skipping remote export");
     return commInternalError;
@@ -493,7 +493,7 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
   // Initialize local peer ID (hostname:pid) for IPC communications
   char hostname[256];
   if (gethostname(hostname, sizeof(hostname)) != 0) {
-    CERR(commInternalError, "CTRAN-REGCACHE: Failed to get hostname");
+    CTRAN_ERR(commInternalError, "CTRAN-REGCACHE: Failed to get hostname");
     return commInternalError;
   }
   hostname[sizeof(hostname) - 1] = '\0';

--- a/comms/ctran/regcache/IpcRegCache.h
+++ b/comms/ctran/regcache/IpcRegCache.h
@@ -18,6 +18,7 @@
 #include "comms/ctran/bootstrap/AsyncSocket.h"
 #include "comms/ctran/regcache/IpcRegCacheBase.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 
 namespace ctran {
 
@@ -198,7 +199,7 @@ class IpcRegCache {
       ctran::regcache::IpcDesc& ipcDesc,
       std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments) {
     if (ipcRegElem == nullptr) {
-      CERR(
+      CTRAN_ERR(
           commInvalidArgument,
           "CTRAN-REGCACHE: ipcRegElem is nullptr in exportMem");
       return commInvalidArgument;

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -543,7 +543,7 @@ commResult_t ctran::RegCache::asyncRegRange(
     const struct CommLogData& logMetaData,
     const std::vector<bool>& backend) {
   if (!asyncRegThread_.joinable()) {
-    CERR(
+    CTRAN_ERR(
         commInvalidUsage,
         "AsyncReg thread is not running. Check whether NCCL_CTRAN_REGISTER=async is set.");
     return commInvalidUsage;
@@ -1344,7 +1344,7 @@ commResult_t ctran::RegCache::acquireScopedRegister(
     const CommLogData& logMetaData,
     ctran::ScopedRegHdl& scopedRegHdl) {
   if (buf == nullptr || len == 0) {
-    CERR(
+    CTRAN_ERR(
         commInvalidUsage,
         "acquireScopedRegister: invalid buf {} len {}",
         (void*)buf,
@@ -1369,7 +1369,7 @@ commResult_t ctran::RegCache::acquireScopedRegister(
       true /* acquireRef */);
 
   if (regResult != commSuccess || regHdl == nullptr) {
-    CERR(
+    CTRAN_ERR(
         commInvalidUsage,
         "acquireScopedRegister: buffer [buf {} len {}] is not backed by a cached "
         "segment. Scoped registration requires the buffer's memory to be pre-registered "
@@ -1576,7 +1576,8 @@ commResult_t ctran::RegCache::deregRange(ctran::regcache::RegElem* regHdl) {
 
     auto it = regHdlToElemMap.find(regHdl);
     if (it == regHdlToElemMap.end()) {
-      CERR(commInvalidUsage, "deregRange: regElem {} not found", (void*)regHdl);
+      CTRAN_ERR(
+          commInvalidUsage, "deregRange: regElem {} not found", (void*)regHdl);
       return commInvalidUsage;
     }
 
@@ -1585,7 +1586,7 @@ commResult_t ctran::RegCache::deregRange(ctran::regcache::RegElem* regHdl) {
       // The caller may already have performed mapper-side remote release, so
       // this error is not a retry contract. Keep regcache state intact and let
       // higher-level failure cleanup or allocator force-free reclaim memory.
-      CERR(
+      CTRAN_ERR(
           commInvalidUsage,
           "deregRange: RegElem {} still has {} live use-side owner(s)",
           (void*)regHdl,
@@ -1691,7 +1692,7 @@ std::vector<std::vector<ctran::regcache::Segment*>> getContiguousRegions(
 commResult_t ctran::RegCache::regAll() {
   auto regCache = ctran::RegCache::getInstance();
   if (!regCache) {
-    CERR(commInternalError, "regAll: RegCache instance not available");
+    CTRAN_ERR(commInternalError, "regAll: RegCache instance not available");
     return commInternalError;
   }
 
@@ -1735,7 +1736,7 @@ commResult_t ctran::RegCache::regAll() {
 
     int cudaDev = contiguousRegions[0].front()->cudaDev;
     if (cudaDev < 0) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "regAll: could not determine cudaDev from cached segments");
       return commInternalError;
@@ -1826,7 +1827,7 @@ commResult_t ctran::RegCache::regAll() {
 commResult_t ctran::RegCache::deregAll() {
   auto regCache = ctran::RegCache::getInstance();
   if (!regCache) {
-    CERR(commInternalError, "deregAll: RegCache instance not available");
+    CTRAN_ERR(commInternalError, "deregAll: RegCache instance not available");
     return commInternalError;
   }
 


### PR DESCRIPTION
Summary:

Migrate the remaining eight legacy error logs in CTRAN registration-cache operations to `CTRAN_ERR`. Preserve error codes, messages, pointer formatting, Scuba reporting, return values, and control flow.

Reviewed By: shr

Differential Revision: D115554858


