### PR TITLE
Migrate CTRAN check logs (#3602)

### DIFF
--- a/comms/ctran/utils/Checks.h
+++ b/comms/ctran/utils/Checks.h
@@ -6,10 +6,10 @@
 #include <errno.h>
 #include <folly/Format.h>
 
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/Exception.h"
 #include "comms/utils/Conversion.h"
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/LogUtils.h"
 
 /**
  * Error check macros.
@@ -33,7 +33,7 @@
     cudaError_t err = cmd;                   \
     if (err != cudaSuccess) {                \
       auto errStr = cudaGetErrorString(err); \
-      CERR(                                  \
+      CTRAN_ERR(                             \
           commUnhandledCudaError,            \
           "Cuda failure {} '{}'",            \
           static_cast<int>(err),             \
@@ -48,7 +48,7 @@
   do {                                                             \
     cudaError_t err = cmd;                                         \
     if (err != cudaSuccess) {                                      \
-      CERR(                                                        \
+      CTRAN_ERR(                                                   \
           commUnhandledCudaError,                                  \
           "{}:{} Cuda failure {}",                                 \
           __FILE__,                                                \
@@ -95,30 +95,31 @@
   do {                                                                         \
     cudaError_t err = cmd;                                                     \
     if (err != cudaSuccess) {                                                  \
-      CERR(                                                                    \
+      CTRAN_ERR(                                                               \
           commUnhandledCudaError, "Cuda failure {}", cudaGetErrorString(err)); \
       RES = commUnhandledCudaError;                                            \
       goto label;                                                              \
     }                                                                          \
   } while (false)
 
-#define FB_CUCHECKGOTO(cmd, RES, label)                                     \
-  do {                                                                      \
-    CUresult err = cmd;                                                     \
-    if (err != CUDA_SUCCESS) {                                              \
-      const char* errStr;                                                   \
-      cuGetErrorString(err, &errStr);                                       \
-      CERR(commUnhandledCudaError, "Cuda failure {}", std::string(errStr)); \
-      RES = commUnhandledCudaError;                                         \
-      goto label;                                                           \
-    }                                                                       \
+#define FB_CUCHECKGOTO(cmd, RES, label)                                    \
+  do {                                                                     \
+    CUresult err = cmd;                                                    \
+    if (err != CUDA_SUCCESS) {                                             \
+      const char* errStr;                                                  \
+      cuGetErrorString(err, &errStr);                                      \
+      CTRAN_ERR(                                                           \
+          commUnhandledCudaError, "Cuda failure {}", std::string(errStr)); \
+      RES = commUnhandledCudaError;                                        \
+      goto label;                                                          \
+    }                                                                      \
   } while (false)
 
 #define FB_CUDACHECKGUARD(cmd, RES)                                            \
   do {                                                                         \
     cudaError_t err = cmd;                                                     \
     if (err != cudaSuccess) {                                                  \
-      CERR(                                                                    \
+      CTRAN_ERR(                                                               \
           commUnhandledCudaError, "Cuda failure {}", cudaGetErrorString(err)); \
       RES = commUnhandledCudaError;                                            \
       return;                                                                  \
@@ -130,7 +131,7 @@
   do {                              \
     cudaError_t err = cmd;          \
     if (err != cudaSuccess) {       \
-      CLOGF(                        \
+      CTRAN_LOG(                    \
           WARN,                     \
           "{}:{} Cuda failure {}",  \
           __FILE__,                 \
@@ -146,51 +147,55 @@
   do {                                                                         \
     cudaError_t err = cmd;                                                     \
     if (err != cudaSuccess) {                                                  \
-      CERR(                                                                    \
+      CTRAN_ERR(                                                               \
           commUnhandledCudaError, "Cuda failure {}", cudaGetErrorString(err)); \
       abort();                                                                 \
     }                                                                          \
   } while (false)
 
-#define FB_SYSCHECK(statement, name)                                         \
+#define FB_SYSCHECK(statement, name)                                        \
+  do {                                                                      \
+    int retval;                                                             \
+    FB_SYSCHECKSYNC((statement), name, retval);                             \
+    if (retval == -1) {                                                     \
+      CTRAN_ERR(                                                            \
+          commSystemError, "Call to " name " failed: {}", strerror(errno)); \
+      return commSystemError;                                               \
+    }                                                                       \
+  } while (false)
+
+#define FB_SYSCHECKVAL(call, name, retval)                                   \
   do {                                                                       \
-    int retval;                                                              \
-    FB_SYSCHECKSYNC((statement), name, retval);                              \
+    FB_SYSCHECKSYNC(call, name, retval);                                     \
     if (retval == -1) {                                                      \
-      CERR(commSystemError, "Call to " name " failed: {}", strerror(errno)); \
+      CTRAN_ERR(                                                             \
+          commSystemError, "Call to " name " failed : {}", strerror(errno)); \
       return commSystemError;                                                \
     }                                                                        \
   } while (false)
 
-#define FB_SYSCHECKVAL(call, name, retval)                                    \
-  do {                                                                        \
-    FB_SYSCHECKSYNC(call, name, retval);                                      \
-    if (retval == -1) {                                                       \
-      CERR(commSystemError, "Call to " name " failed : {}", strerror(errno)); \
-      return commSystemError;                                                 \
-    }                                                                         \
-  } while (false)
-
-#define FB_SYSCHECKSYNC(statement, name, retval)                             \
-  do {                                                                       \
-    retval = (statement);                                                    \
-    if (retval == -1 &&                                                      \
-        (errno == EINTR || errno == EWOULDBLOCK || errno == EAGAIN)) {       \
-      CLOGF(ERR, "Call to " name " returned {}, retrying", strerror(errno)); \
-    } else {                                                                 \
-      break;                                                                 \
-    }                                                                        \
+#define FB_SYSCHECKSYNC(statement, name, retval)                           \
+  do {                                                                     \
+    retval = (statement);                                                  \
+    if (retval == -1 &&                                                    \
+        (errno == EINTR || errno == EWOULDBLOCK || errno == EAGAIN)) {     \
+      CTRAN_LOG(                                                           \
+          ERR, "Call to " name " returned {}, retrying", strerror(errno)); \
+    } else {                                                               \
+      break;                                                               \
+    }                                                                      \
   } while (true)
 
-#define FB_SYSCHECKGOTO(statement, name, RES, label)                         \
-  do {                                                                       \
-    int retval;                                                              \
-    FB_SYSCHECKSYNC((statement), name, retval);                              \
-    if (retval == -1) {                                                      \
-      CERR(commSystemError, "Call to " name " failed: {}", strerror(errno)); \
-      RES = commSystemError;                                                 \
-      goto label;                                                            \
-    }                                                                        \
+#define FB_SYSCHECKGOTO(statement, name, RES, label)                        \
+  do {                                                                      \
+    int retval;                                                             \
+    FB_SYSCHECKSYNC((statement), name, retval);                             \
+    if (retval == -1) {                                                     \
+      CTRAN_ERR(                                                            \
+          commSystemError, "Call to " name " failed: {}", strerror(errno)); \
+      RES = commSystemError;                                                \
+      goto label;                                                           \
+    }                                                                       \
   } while (0)
 
 #define FB_SYSCHECKTHROW_EX_DIRECT(cmd, rank, commHash, desc) \
@@ -198,7 +203,7 @@
     int err = cmd;                                            \
     if (err != 0) {                                           \
       auto errstr = folly::errnoStr(err);                     \
-      CERR(                                                   \
+      CTRAN_ERR(                                              \
           commSystemError,                                    \
           "{}:{} -> {} ({})",                                 \
           __FILE__,                                           \
@@ -240,7 +245,7 @@
     int err = cmd;                        \
     if (err != 0) {                       \
       auto errstr = folly::errnoStr(err); \
-      CERR(                               \
+      CTRAN_ERR(                          \
           commSystemError,                \
           "{}:{} -> {} ({})",             \
           __FILE__,                       \
@@ -252,30 +257,32 @@
   } while (0)
 
 // Pthread calls don't set errno and never return EINTR.
-#define FB_PTHREADCHECK(statement, name)                                      \
-  do {                                                                        \
-    int retval = (statement);                                                 \
-    if (retval != 0) {                                                        \
-      CERR(commSystemError, "Call to " name " failed: {}", strerror(retval)); \
-      return commSystemError;                                                 \
-    }                                                                         \
+#define FB_PTHREADCHECK(statement, name)                                     \
+  do {                                                                       \
+    int retval = (statement);                                                \
+    if (retval != 0) {                                                       \
+      CTRAN_ERR(                                                             \
+          commSystemError, "Call to " name " failed: {}", strerror(retval)); \
+      return commSystemError;                                                \
+    }                                                                        \
   } while (0)
 
-#define FB_PTHREADCHECKGOTO(statement, name, RES, label)                      \
-  do {                                                                        \
-    int retval = (statement);                                                 \
-    if (retval != 0) {                                                        \
-      CERR(commSystemError, "Call to " name " failed: {}", strerror(retval)); \
-      RES = commSystemError;                                                  \
-      goto label;                                                             \
-    }                                                                         \
+#define FB_PTHREADCHECKGOTO(statement, name, RES, label)                     \
+  do {                                                                       \
+    int retval = (statement);                                                \
+    if (retval != 0) {                                                       \
+      CTRAN_ERR(                                                             \
+          commSystemError, "Call to " name " failed: {}", strerror(retval)); \
+      RES = commSystemError;                                                 \
+      goto label;                                                            \
+    }                                                                        \
   } while (0)
 
 #define FB_NEQCHECK(statement, value) \
   do {                                \
     if ((statement) != value) {       \
       /* Print the back trace*/       \
-      CERR(                           \
+      CTRAN_ERR(                      \
           commSystemError,            \
           "{}:{} -> {} ({})",         \
           __FILE__,                   \
@@ -291,7 +298,7 @@
     if ((statement) != value) {                       \
       /* Print the back trace*/                       \
       RES = commSystemError;                          \
-      CERR(                                           \
+      CTRAN_ERR(                                      \
           commSystemError,                            \
           "{}:{} -> {} ({})",                         \
           __FILE__,                                   \
@@ -306,7 +313,7 @@
   do {                               \
     if ((statement) == value) {      \
       /* Print the back trace*/      \
-      CERR(                          \
+      CTRAN_ERR(                     \
           commSystemError,           \
           "{}:{} -> {} ({})",        \
           __FILE__,                  \
@@ -322,7 +329,7 @@
     if ((statement) == value) {                      \
       /* Print the back trace*/                      \
       RES = commSystemError;                         \
-      CERR(                                          \
+      CTRAN_ERR(                                     \
           commSystemError,                           \
           "{}:{} -> {} ({})",                        \
           __FILE__,                                  \
@@ -334,20 +341,20 @@
   } while (0)
 
 // Propagate errors up
-#define FB_COMMCHECK(call)                                \
-  do {                                                    \
-    commResult_t RES = call;                              \
-    if (RES != commSuccess && RES != commInProgress) {    \
-      CLOGF(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
-      return RES;                                         \
-    }                                                     \
+#define FB_COMMCHECK(call)                                    \
+  do {                                                        \
+    commResult_t RES = call;                                  \
+    if (RES != commSuccess && RES != commInProgress) {        \
+      CTRAN_LOG(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
+      return RES;                                             \
+    }                                                         \
   } while (0)
 
 // Propagate errors up for ibverbx
 #define FOLLY_EXPECTED_CHECK(RES) \
   do {                            \
     if (RES.hasError()) {         \
-      CERR(                       \
+      CTRAN_ERR(                  \
           commSystemError,        \
           "{}:{} -> {}, {}",      \
           __FILE__,               \
@@ -361,7 +368,7 @@
 #define FOLLY_EXPECTED_CHECKTHROW_EX(RES, commLogData)                 \
   do {                                                                 \
     if (RES.hasError()) {                                              \
-      CLOGF(                                                           \
+      CTRAN_LOG(                                                       \
           ERR,                                                         \
           "{}:{} -> {} ({})",                                          \
           __FILE__,                                                    \
@@ -381,7 +388,7 @@
 #define FOLLY_EXPECTED_CHECKTHROW_EX_NOCOMM(RES)                       \
   do {                                                                 \
     if (RES.hasError()) {                                              \
-      CLOGF(                                                           \
+      CTRAN_LOG(                                                       \
           ERR,                                                         \
           "{}:{} -> {} ({})",                                          \
           __FILE__,                                                    \
@@ -397,7 +404,7 @@
 #define FOLLY_EXPECTED_CHECKGOTO(RES, label, info) \
   do {                                             \
     if (RES.hasError()) {                          \
-      CLOGF(                                       \
+      CTRAN_LOG(                                   \
           ERR,                                     \
           "{}:{} -> {} ({}). {}",                  \
           __FILE__,                                \
@@ -413,7 +420,7 @@
   do {                                                             \
     commResult_t RES = cmd;                                        \
     if (RES != commSuccess && RES != commInProgress) {             \
-      CLOGF(                                                       \
+      CTRAN_LOG(                                                   \
           ERR,                                                     \
           "{}:{} -> {} ({})",                                      \
           __FILE__,                                                \
@@ -455,7 +462,7 @@
   do {                                                 \
     commResult_t RES = cmd;                            \
     if (RES != commSuccess && RES != commInProgress) { \
-      CLOGF(                                           \
+      CTRAN_LOG(                                       \
           ERR,                                         \
           "{}:{} -> {} ({})",                          \
           __FILE__,                                    \
@@ -469,13 +476,13 @@
     }                                                  \
   } while (0)
 
-#define FB_COMMCHECKGOTO(call, RES, label)                \
-  do {                                                    \
-    RES = call;                                           \
-    if (RES != commSuccess && RES != commInProgress) {    \
-      CLOGF(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
-      goto label;                                         \
-    }                                                     \
+#define FB_COMMCHECKGOTO(call, RES, label)                    \
+  do {                                                        \
+    RES = call;                                               \
+    if (RES != commSuccess && RES != commInProgress) {        \
+      CTRAN_LOG(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
+      goto label;                                             \
+    }                                                         \
   } while (0)
 
 // Report failure but clear error and continue
@@ -483,7 +490,7 @@
   do {                                                 \
     commResult_t RES = call;                           \
     if (RES != commSuccess && RES != commInProgress) { \
-      CLOGF(                                           \
+      CTRAN_LOG(                                       \
           WARN,                                        \
           "{}:{}:{} -> {} ({})",                       \
           __FILE__,                                    \
@@ -494,39 +501,39 @@
     }                                                  \
   } while (0)
 
-#define FB_CHECKABORT(statement, ...)             \
-  do {                                            \
-    if (!(statement)) {                           \
-      CLOGF(ERR, "Check failed: {}", #statement); \
-      CLOGF(ERR, ##__VA_ARGS__);                  \
-      abort();                                    \
-    }                                             \
+#define FB_CHECKABORT(statement, ...)                     \
+  do {                                                    \
+    if (!(statement)) {                                   \
+      CTRAN_LOG_SYNC_ERR("Check failed: {}", #statement); \
+      CTRAN_LOG_SYNC_ERR(__VA_ARGS__);                    \
+      abort();                                            \
+    }                                                     \
   } while (0);
 
-#define FB_CHECKTHROW_EX_DIRECT(statement, rank, commHash, commDesc, msg) \
-  do {                                                                    \
-    if (!(statement)) {                                                   \
-      CERR(commInternalError, "Check failed: {} - {}", #statement, msg);  \
-      throw ctran::utils::Exception(                                      \
-          fmt::format("Check failed: {} - {}", #statement, msg),          \
-          commInternalError,                                              \
-          rank,                                                           \
-          commHash,                                                       \
-          commDesc);                                                      \
-    }                                                                     \
+#define FB_CHECKTHROW_EX_DIRECT(statement, rank, commHash, commDesc, msg)     \
+  do {                                                                        \
+    if (!(statement)) {                                                       \
+      CTRAN_ERR(commInternalError, "Check failed: {} - {}", #statement, msg); \
+      throw ctran::utils::Exception(                                          \
+          fmt::format("Check failed: {} - {}", #statement, msg),              \
+          commInternalError,                                                  \
+          rank,                                                               \
+          commHash,                                                           \
+          commDesc);                                                          \
+    }                                                                         \
   } while (0)
 
-#define FB_CHECKTHROW_EX_LOGDATA(statement, commLogData, msg)            \
-  do {                                                                   \
-    if (!(statement)) {                                                  \
-      CERR(commInternalError, "Check failed: {} - {}", #statement, msg); \
-      throw ctran::utils::Exception(                                     \
-          fmt::format("Check failed: {} - {}", #statement, msg),         \
-          commInternalError,                                             \
-          (commLogData).rank,                                            \
-          (commLogData).commHash,                                        \
-          (commLogData).commDesc);                                       \
-    }                                                                    \
+#define FB_CHECKTHROW_EX_LOGDATA(statement, commLogData, msg)                 \
+  do {                                                                        \
+    if (!(statement)) {                                                       \
+      CTRAN_ERR(commInternalError, "Check failed: {} - {}", #statement, msg); \
+      throw ctran::utils::Exception(                                          \
+          fmt::format("Check failed: {} - {}", #statement, msg),              \
+          commInternalError,                                                  \
+          (commLogData).rank,                                                 \
+          (commLogData).commHash,                                             \
+          (commLogData).commDesc);                                            \
+    }                                                                         \
   } while (0)
 
 // Selector macro, used with FB_CHECKTHROW_EX to delegate
@@ -553,21 +560,21 @@
     if (!(statement)) {                                                  \
       auto errorMsg =                                                    \
           fmt::format("Check failed: {} - {}", #statement, __VA_ARGS__); \
-      CERR(commInternalError, "{}", errorMsg);                           \
+      CTRAN_ERR(commInternalError, "{}", errorMsg);                      \
       throw ctran::utils::Exception(errorMsg, commInternalError);        \
     }                                                                    \
   } while (0)
 
-#define FB_COMMWAIT(call, cond, abortFlagPtr)             \
-  do {                                                    \
-    uint32_t* tmpAbortFlag = (abortFlagPtr);              \
-    commResult_t RES = call;                              \
-    if (RES != commSuccess && RES != commInProgress) {    \
-      CLOGF(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
-      return commInternalError;                           \
-    }                                                     \
-    if (__atomic_load(tmpAbortFlag, __ATOMIC_ACQUIRE))    \
-      FB_NEQCHECK(*tmpAbortFlag, 0);                      \
+#define FB_COMMWAIT(call, cond, abortFlagPtr)                 \
+  do {                                                        \
+    uint32_t* tmpAbortFlag = (abortFlagPtr);                  \
+    commResult_t RES = call;                                  \
+    if (RES != commSuccess && RES != commInProgress) {        \
+      CTRAN_LOG(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
+      return commInternalError;                               \
+    }                                                         \
+    if (__atomic_load(tmpAbortFlag, __ATOMIC_ACQUIRE))        \
+      FB_NEQCHECK(*tmpAbortFlag, 0);                          \
   } while (!(cond))
 
 #define FB_COMMWAITGOTO(call, cond, abortFlagPtr, RES, label) \
@@ -575,7 +582,7 @@
     uint32_t* tmpAbortFlag = (abortFlagPtr);                  \
     RES = call;                                               \
     if (RES != commSuccess && RES != commInProgress) {        \
-      CLOGF(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES);     \
+      CTRAN_LOG(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
       goto label;                                             \
     }                                                         \
     if (__atomic_load(tmpAbortFlag, __ATOMIC_ACQUIRE))        \
@@ -585,7 +592,7 @@
 #define FB_COMMCHECKTHREAD(a, args)                                            \
   do {                                                                         \
     if (((args)->ret = (a)) != commSuccess && (args)->ret != commInProgress) { \
-      CLOGF_SUBSYS(                                                            \
+      CTRAN_LOG_SUBSYS(                                                        \
           ERR,                                                                 \
           INIT,                                                                \
           "{}:{} -> {} [Async thread]",                                        \
@@ -600,7 +607,7 @@
   do {                                    \
     if ((a) != cudaSuccess) {             \
       args->ret = commUnhandledCudaError; \
-      CERR(                               \
+      CTRAN_ERR(                          \
           commUnhandledCudaError,         \
           "{}:{} -> {} [Async thread]",   \
           __FILE__,                       \
@@ -610,23 +617,23 @@
     }                                     \
   } while (0)
 
-#define FB_COMMARGCHECK(statement, ...)         \
-  do {                                          \
-    if (!(statement)) {                         \
-      CERR(commInvalidArgument, ##__VA_ARGS__); \
-      return commInvalidArgument;               \
-    }                                           \
+#define FB_COMMARGCHECK(statement, ...)              \
+  do {                                               \
+    if (!(statement)) {                              \
+      CTRAN_ERR(commInvalidArgument, ##__VA_ARGS__); \
+      return commInvalidArgument;                    \
+    }                                                \
   } while (0);
 
-#define FB_ERRORRETURN(error, ...) \
-  do {                             \
-    CERR(error, ##__VA_ARGS__);    \
-    return error;                  \
+#define FB_ERRORRETURN(error, ...)   \
+  do {                               \
+    CTRAN_ERR(error, ##__VA_ARGS__); \
+    return error;                    \
   } while (0)
 
 #define FB_ERRORTHROW_EX(error, logData, ...)       \
   do {                                              \
-    CLOGF(ERR, ##__VA_ARGS__);                      \
+    CTRAN_LOG(ERR, ##__VA_ARGS__);                  \
     throw ctran::utils::Exception(                  \
         std::string("COMM internal failure: ") +    \
             ::meta::comms::commCodeToString(error), \
@@ -639,7 +646,7 @@
 // For contexts where rank/commHash are not available
 #define FB_ERRORTHROW_EX_NOCOMM(error, ...)         \
   do {                                              \
-    CLOGF(ERR, ##__VA_ARGS__);                      \
+    CTRAN_LOG(ERR, ##__VA_ARGS__);                  \
     throw ctran::utils::Exception(                  \
         std::string("COMM internal failure: ") +    \
             ::meta::comms::commCodeToString(error), \

--- a/comms/ctran/utils/CtranLogger.h
+++ b/comms/ctran/utils/CtranLogger.h
@@ -16,6 +16,18 @@ inline constexpr std::string_view kCtranLoggerName = "comms.ctran";
 #define CTRAN_LOG(level, ...) \
   COMMS_LOG_NAMED(::ctran::logging::kCtranLoggerName, level, __VA_ARGS__)
 
+#define CTRAN_LOG_SYNC_ERR(...)                                      \
+  do {                                                               \
+    auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger(    \
+        ::ctran::logging::kCtranLoggerName);                         \
+    if (_ctran_logger.should_log(::spdlog::level::err)) {            \
+      _ctran_logger.logSynchronous(                                  \
+          ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, \
+          ::spdlog::level::err,                                      \
+          __VA_ARGS__);                                              \
+    }                                                                \
+  } while (false)
+
 #define CTRAN_LOG_IF_IMPL(level, spdlog_level, condition, ...)    \
   do {                                                            \
     auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger( \

--- a/comms/ctran/utils/CudaWrap.h
+++ b/comms/ctran/utils/CudaWrap.h
@@ -5,7 +5,7 @@
 #include <cuda_runtime.h>
 #include <fmt/format.h>
 
-#include "comms/utils/logger/LogUtils.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 
 #if CUDART_VERSION >= 11030
 #include <cudaTypedefs.h> // @manual
@@ -56,7 +56,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {              \
       const char* errStr;                   \
       (void)cuGetErrorString(err, &errStr); \
-      CERR(                                 \
+      CTRAN_ERR(                            \
           commUnhandledCudaError,           \
           "Cuda failure {} '{}'",           \
           static_cast<int>(err),            \
@@ -71,7 +71,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {              \
       const char* errStr;                   \
       (void)cuGetErrorString(err, &errStr); \
-      CERR(                                 \
+      CTRAN_ERR(                            \
           commUnhandledCudaError,           \
           "Cuda failure {} '{}'",           \
           static_cast<int>(err),            \
@@ -86,7 +86,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {           \
       const char* errStr;                \
       cuGetErrorString(err, &errStr);    \
-      CERR(                              \
+      CTRAN_ERR(                         \
           commUnhandledCudaError,        \
           "Cuda failure {} '{}'",        \
           static_cast<int>(err),         \
@@ -96,14 +96,14 @@ namespace ctran::utils {
     }                                    \
   } while (false)
 
-#define FB_CUCHECKRES(res)                                               \
-  do {                                                                   \
-    if (res != CUDA_SUCCESS) {                                           \
-      const char* errStr;                                                \
-      (void)cuGetErrorString(res, &errStr);                              \
-      CERR(commUnhandledCudaError, "Cuda failure {} '{}'", res, errStr); \
-      return commUnhandledCudaError;                                     \
-    }                                                                    \
+#define FB_CUCHECKRES(res)                                                    \
+  do {                                                                        \
+    if (res != CUDA_SUCCESS) {                                                \
+      const char* errStr;                                                     \
+      (void)cuGetErrorString(res, &errStr);                                   \
+      CTRAN_ERR(commUnhandledCudaError, "Cuda failure {} '{}'", res, errStr); \
+      return commUnhandledCudaError;                                          \
+    }                                                                         \
   } while (false)
 
 // Report failure but clear error and continue
@@ -113,7 +113,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {              \
       const char* errStr;                   \
       (void)cuGetErrorString(err, &errStr); \
-      CLOGF(                                \
+      CTRAN_LOG(                            \
           WARN,                             \
           "{}:{} Cuda failure {} '{}'",     \
           __FILE__,                         \
@@ -127,7 +127,7 @@ namespace ctran::utils {
   do {                                    \
     CUresult err = cmd;                   \
     if (err != CUDA_SUCCESS) {            \
-      CERR(                               \
+      CTRAN_ERR(                          \
           commUnhandledCudaError,         \
           "{}:{} -> {} [Async thread]",   \
           __FILE__,                       \
@@ -149,7 +149,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {                                  \
       const char* errStr;                                       \
       (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr); \
-      CERR(                                                     \
+      CTRAN_ERR(                                                \
           commUnhandledCudaError,                               \
           "Cuda failure {} '{}'",                               \
           static_cast<int>(err),                                \
@@ -164,7 +164,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {                                  \
       const char* errStr;                                       \
       (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr); \
-      CERR(                                                     \
+      CTRAN_ERR(                                                \
           commUnhandledCudaError,                               \
           "Cuda failure {} '{}'",                               \
           static_cast<int>(err),                                \
@@ -179,7 +179,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {                                  \
       const char* errStr;                                       \
       (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr); \
-      CERR(                                                     \
+      CTRAN_ERR(                                                \
           commUnhandledCudaError,                               \
           "Cuda failure {} '{}'",                               \
           static_cast<int>(err),                                \
@@ -189,14 +189,14 @@ namespace ctran::utils {
     }                                                           \
   } while (false)
 
-#define FB_CUCHECKRES(res)                                               \
-  do {                                                                   \
-    if (res != CUDA_SUCCESS) {                                           \
-      const char* errStr;                                                \
-      (void)::ctran::utils::pfn_cuGetErrorString(res, &errStr);          \
-      CERR(commUnhandledCudaError, "Cuda failure {} '{}'", res, errStr); \
-      return commUnhandledCudaError;                                     \
-    }                                                                    \
+#define FB_CUCHECKRES(res)                                                    \
+  do {                                                                        \
+    if (res != CUDA_SUCCESS) {                                                \
+      const char* errStr;                                                     \
+      (void)::ctran::utils::pfn_cuGetErrorString(res, &errStr);               \
+      CTRAN_ERR(commUnhandledCudaError, "Cuda failure {} '{}'", res, errStr); \
+      return commUnhandledCudaError;                                          \
+    }                                                                         \
   } while (false)
 
 // Report failure but clear error and continue
@@ -206,7 +206,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {                                  \
       const char* errStr;                                       \
       (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr); \
-      CLOGF(                                                    \
+      CTRAN_LOG(                                                \
           WARN,                                                 \
           "{}:{} Cuda failure {} '{}'",                         \
           __FILE__,                                             \
@@ -220,7 +220,7 @@ namespace ctran::utils {
   do {                                        \
     CUresult err = ::ctran::utils::pfn_##cmd; \
     if (err != CUDA_SUCCESS) {                \
-      CERR(                                   \
+      CTRAN_ERR(                              \
           commUnhandledCudaError,             \
           "{}:{} -> {} [Async thread]",       \
           __FILE__,                           \

--- a/comms/ctran/utils/tests/ChecksUT.cc
+++ b/comms/ctran/utils/tests/ChecksUT.cc
@@ -1,7 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <string>
-#include <vector>
 
 #include <cuda_runtime.h>
 #include <fmt/core.h>
@@ -9,12 +8,11 @@
 #include <gtest/gtest.h>
 
 #include <gmock/gmock.h>
-#include "TestLogCategory.h"
 #include "comms/ctran/utils/ArgCheck.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/LogInit.h"
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/Logger.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 class CtranUtilsCheckTest : public ::testing::Test {
  public:
@@ -22,20 +20,28 @@ class CtranUtilsCheckTest : public ::testing::Test {
 
   void SetUp() override {
     ctran::logging::initCtranLogging(true /*alwaysInit*/);
-
-    // Set up a test category
-    auto* category =
-        folly::LoggerDB::get().getCategory(XLOG_GET_CATEGORY_NAME());
-    ASSERT_TRUE(testCategory_.setup(category));
+    auto& logger =
+        meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName);
+    logger.configure("CTRAN", []() { return 0; }, {}, false);
+    logger.set_level(spdlog::level::info);
+    testing::internal::CaptureStdout();
+    capturingStdout_ = true;
   }
 
   void TearDown() override {
-    NcclLogger::close();
-    testCategory_.reset();
+    if (capturingStdout_) {
+      testing::internal::GetCapturedStdout();
+    }
+    auto& logger =
+        meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName);
+    logger.configure("CTRAN", []() { return 0; }, {}, false);
   }
 
-  const std::vector<std::string>& getMessages() const {
-    return testCategory_.getMessages();
+  std::string getOutput() {
+    meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName)
+        .flush();
+    capturingStdout_ = false;
+    return testing::internal::GetCapturedStdout();
   }
 
   const int getCurrentGpuIndex() {
@@ -53,7 +59,7 @@ class CtranUtilsCheckTest : public ::testing::Test {
   }
 
  private:
-  TestLogCategory testCategory_;
+  bool capturingStdout_{false};
 };
 
 TEST_F(CtranUtilsCheckTest, CudaCheck) {
@@ -65,10 +71,9 @@ TEST_F(CtranUtilsCheckTest, CudaCheck) {
   auto res = dummyFn();
   ASSERT_EQ(res, commUnhandledCudaError);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("invalid argument"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
+  EXPECT_THAT(output, ::testing::HasSubstr("invalid argument"));
 }
 
 TEST_F(CtranUtilsCheckTest, CudaCheckGoto) {
@@ -82,10 +87,9 @@ TEST_F(CtranUtilsCheckTest, CudaCheckGoto) {
   auto res = dummyFn();
   ASSERT_EQ(res, commUnhandledCudaError);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("unspecified launch failure"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
+  EXPECT_THAT(output, ::testing::HasSubstr("unspecified launch failure"));
 }
 
 TEST_F(CtranUtilsCheckTest, CudaCheckIgnore) {
@@ -96,10 +100,9 @@ TEST_F(CtranUtilsCheckTest, CudaCheckIgnore) {
   auto res = dummyFn();
   ASSERT_EQ(res, commSuccess);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN WARN"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("invalid argument"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN WARN"));
+  EXPECT_THAT(output, ::testing::HasSubstr("invalid argument"));
 }
 
 TEST_F(CtranUtilsCheckTest, SysCheck) {
@@ -111,10 +114,9 @@ TEST_F(CtranUtilsCheckTest, SysCheck) {
   auto res = dummyFn();
   ASSERT_EQ(res, commSystemError);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("Call to sysTestFn failed"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
+  EXPECT_THAT(output, ::testing::HasSubstr("Call to sysTestFn failed"));
 }
 
 TEST_F(CtranUtilsCheckTest, SysCheckGoto) {
@@ -128,10 +130,9 @@ TEST_F(CtranUtilsCheckTest, SysCheckGoto) {
   auto res = dummyFn();
   ASSERT_EQ(res, commSystemError);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("Call to sysTestFn failed"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
+  EXPECT_THAT(output, ::testing::HasSubstr("Call to sysTestFn failed"));
 }
 
 TEST_F(CtranUtilsCheckTest, ErrorReturn) {
@@ -142,10 +143,9 @@ TEST_F(CtranUtilsCheckTest, ErrorReturn) {
   auto res = dummyFn();
   ASSERT_EQ(res, commInvalidUsage);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("test ErrorReturn failure"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
+  EXPECT_THAT(output, ::testing::HasSubstr("test ErrorReturn failure"));
 }
 
 TEST_F(CtranUtilsCheckTest, ErrorThrowEx) {
@@ -172,9 +172,8 @@ TEST_F(CtranUtilsCheckTest, ErrorThrowEx) {
 
   ASSERT_TRUE(caughtException) << "Expected ctran::utils::Exception";
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
 }
 
 TEST_F(CtranUtilsCheckTest, ArgCheckNull) {
@@ -185,11 +184,10 @@ TEST_F(CtranUtilsCheckTest, ArgCheckNull) {
   auto res = dummyFn();
   ASSERT_EQ(res, commInvalidArgument);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
   EXPECT_THAT(
-      messages[0], ::testing::HasSubstr("ArgCheckNull ptr argument is NULL"));
+      output, ::testing::HasSubstr("ArgCheckNull ptr argument is NULL"));
 }
 
 TEST_F(CtranUtilsCheckTest, FB_SYSCHECKTHROW_EX_DIRECT) {

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -211,6 +211,15 @@ void CommsSpdlogLogger::log(
   }
 }
 
+void CommsSpdlogLogger::logSynchronous(
+    spdlog::source_loc location,
+    spdlog::level::level_enum level,
+    std::string_view message) {
+  if (should_log(level)) {
+    logFormatted(location, level, getLevelName(level), message, true);
+  }
+}
+
 void CommsSpdlogLogger::logFatal(
     spdlog::source_loc location,
     std::string_view message) {

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -51,6 +51,28 @@ class CommsSpdlogLogger {
       std::string_view message);
 
   template <typename... Args>
+  void logSynchronous(
+      spdlog::source_loc location,
+      spdlog::level::level_enum level,
+      spdlog::format_string_t<Args...> format,
+      Args&&... args) {
+    if (!should_log(level)) {
+      return;
+    }
+    logFormatted(
+        location,
+        level,
+        getLevelName(level),
+        fmt::format(format, std::forward<Args>(args)...),
+        true);
+  }
+
+  void logSynchronous(
+      spdlog::source_loc location,
+      spdlog::level::level_enum level,
+      std::string_view message);
+
+  template <typename... Args>
   void logFatal(
       spdlog::source_loc location,
       spdlog::format_string_t<Args...> format,


### PR DESCRIPTION
Summary:

Replace all 41 legacy production log calls in `Checks.h` with the named CTRAN spdlog facade. Preserve every level, message, argument, subsystem gate, error return, exception, abort, goto, retry, and Scuba error-reporting path, and export the direct CTRAN logging dependency from the public checks target.

`ChecksUT` previously captured only the legacy Folly category. Move its existing level and content assertions to the synchronous named CTRAN logger and remove the obsolete Folly test-handler dependencies so the suite continues validating the actual production output path.

Abort checks require both `ERROR` messages to be delivered before `abort()`. Add a runtime-gated synchronous logger path and use it only for `FB_CHECKABORT`, preserving levels, callbacks, formatting, and argument evaluation while avoiding loss in the asynchronous queue.

Reviewed By: shr

Differential Revision: D115583840


