### PR TITLE
Migrate mapper header logs (#3607)

### DIFF
--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -20,10 +20,10 @@
 #include "comms/ctran/transport/ib/HostZcTransport.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/CtranIpc.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/StrUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/memtrace/MemoryTrace.h"
 
 #ifdef ENABLE_META_COMPRESSION
@@ -51,7 +51,7 @@ std::vector<CtranMapperBackend> getToEnableBackends(
       enableBackends.emplace_back(NCCLCtranBackendMap.at(b));
     }
   } else {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-MAPPER: Try to override backends through Ctran Config. Currently it is specific config for MCCL. If you are using NCCL with NCCL_CTRAN_BACKENDS, please report this to MCCL team");
     for (auto& b : overrideBackend) {
@@ -110,7 +110,7 @@ CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
   this->comm = comm;
 
   if (NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-MAPPER: IpcRegCache socket server enabled, initializing");
@@ -126,7 +126,7 @@ CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
     // AllGather IPC server addresses after comm is set
     FB_COMMCHECKTHROW_EX(allGatherIpcServerAddrs(), comm->logMetaData_);
   } else {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-MAPPER: IpcRegCache socket server disabled via NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET=0, skipping init");
@@ -143,7 +143,7 @@ CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
     enableBackendsStrs.push_back(backendToStr(b));
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-MAPPER: configure NCCL_CTRAN_BACKENDS [{}]",
@@ -166,7 +166,7 @@ CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
     } catch ([[maybe_unused]] const std::bad_alloc& e) {
       ctranIb = nullptr;
       enableBackends_[CtranMapperBackend::IB] = false;
-      CLOGF(WARN, "CTRAN-MAPPER: IB backend not enabled");
+      CTRAN_LOG(WARN, "CTRAN-MAPPER: IB backend not enabled");
     }
   }
   if (enableBackends_[CtranMapperBackend::SOCKET]) {
@@ -174,7 +174,7 @@ CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
       this->ctranSock = std::make_unique<class CtranSocket>(comm);
     } else {
       enableBackends_[CtranMapperBackend::SOCKET] = false;
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           INIT,
           "CTRAN-MAPPER: SOCKET backend not enabled, since IB backend is enabled");
@@ -183,7 +183,7 @@ CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
   if (enableBackends_[CtranMapperBackend::TCPDM]) {
     this->ctranTcpDm =
         std::make_unique<class ctran::CtranTcpDm>(comm, profiler);
-    CLOGF(WARN, "CTRAN-MAPPER: TCPDM backend is enabled");
+    CTRAN_LOG(WARN, "CTRAN-MAPPER: TCPDM backend is enabled");
   }
 
   if (enableBackends_[CtranMapperBackend::NVL]) {
@@ -194,11 +194,11 @@ CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
       } catch ([[maybe_unused]] const std::bad_alloc& e) {
         enableBackends_[CtranMapperBackend::NVL] = false;
         // FIXME: give more specific exception + error message
-        CLOGF(
+        CTRAN_LOG(
             WARN, "CTRAN-MAPPER: NVL backend not enabled. Error {}", e.what());
       }
     } else {
-      CLOGF(
+      CTRAN_LOG(
           WARN,
           "CTRAN-MAPPER: NVL backend not enabled. Require valid IB, TCPDM or Socket backend");
     }
@@ -232,7 +232,7 @@ CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
       ::ctran::utils::rangesToStr(::ctran::utils::getRanges(sockRanks));
   const auto tcpRanksRangesStr =
       ::ctran::utils::rangesToStr(::ctran::utils::getRanges(tcpRanks));
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-MAPPER: NVL ranks: {}, IB ranks: {}, SOCKET ranks: {}, TCPDM ranks: {}",
@@ -305,7 +305,7 @@ void CtranMapper::reportProfiling(bool flush) {
              << std::endl;
         }
         if (NCCL_CTRAN_PROFILING == NCCL_CTRAN_PROFILING::info) {
-          CLOGF(INFO, "{}", ss.str());
+          CTRAN_LOG(INFO, "{}", ss.str());
           ss.str("");
           ss.clear();
         }
@@ -324,7 +324,7 @@ void CtranMapper::reportProfiling(bool flush) {
           std::to_string(this->rank) + "." + hostname + std::string(".comm") +
           hashToHexStr(this->logMetaData_.commHash) + std::string(".") +
           std::to_string(reportCnt++) + std::string(".json"));
-      CLOGF(INFO, "Dumping ctran profile to {}", filename);
+      CTRAN_LOG(INFO, "Dumping ctran profile to {}", filename);
 
       int id = 0;
       stream << "[" << std::endl;
@@ -500,7 +500,7 @@ commResult_t CtranMapper::allGatherIpcServerAddrs() {
       peerIpcServerAddrs_.data(), sizeof(sockaddr_storage), myRank, nRanks);
   FB_COMMCHECK(static_cast<commResult_t>(std::move(resFuture).get()));
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-MAPPER: AllGathered IPC server addresses from {} ranks",
@@ -528,7 +528,7 @@ commResult_t CtranMapper::remReleaseMem(ctran::regcache::RegElem* regElem) {
   // If peers have imported this memory but the async socket is disabled,
   // we cannot notify them to release. This is a fatal inconsistency.
   if (!NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
-    CLOGF(
+    CTRAN_LOG(
         FATAL,
         "CTRAN-REGCACHE: ipcRegElem was exported to {} peers but "
         "NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET is disabled",
@@ -824,7 +824,7 @@ commResult_t CtranMapper::searchRegHandle(
 
   if (!regHdl_) {
     if (!allowDynamic) {
-      CERR(
+      CTRAN_ERR(
           commInvalidUsage,
           "CTRAN-MAPPER: buffer {} len {} is not pre-registered by user. ",
           buf,
@@ -838,7 +838,7 @@ commResult_t CtranMapper::searchRegHandle(
     FB_COMMCHECK(regCache->regDynamic(
         buf, len, cudaDev, enableBackends_, &regHdl_, &logMetaData_));
     *dynamicRegist = true;
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-MAPPER: buffer {} len {} is not pre-registered by user. "
         "We have to one-time register it and deregister immediately after "
@@ -983,7 +983,7 @@ ctran::transport::IP2pHostTransport* CtranMapper::getP2pTransport(
 
   CtranIb* ib = ctranIb.get();
   if (ib == nullptr) {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-MAPPER: getP2pTransport(peer={}): no IB backend on this mapper",
         peerRank);

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -28,6 +28,7 @@
 #include "comms/ctran/transport/IP2pHostTransport.h"
 #include "comms/ctran/utils/AsyncError.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CtranPerf.h"
 #include "comms/ctran/utils/Exception.h"
 #include "comms/utils/commSpecs.h"
@@ -214,7 +215,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
   }
 
   [[noreturn]] void throwTcpDmNotifyAbort(CtranMapperNotify* notify) {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-MAPPER: TCPDM notify abort notify={} rank {} commHash {:x}",
         notify->toString(),
@@ -752,7 +753,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(
           const_cast<void*>(regHdl));
       if (!regElem) {
-        CLOGF(WARN, "CTRAN-MAPPER: No IB registration for flush, skip");
+        CTRAN_LOG(WARN, "CTRAN-MAPPER: No IB registration for flush, skip");
         return commSuccess;
       }
       auto regLk = regElem->stateMnger.rlock();
@@ -785,7 +786,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(
           const_cast<void*>(regHdl));
       if (!regElem) {
-        CLOGF(WARN, "CTRAN-MAPPER: No IB registration for flush, skip");
+        CTRAN_LOG(WARN, "CTRAN-MAPPER: No IB registration for flush, skip");
         return commSuccess;
       }
 
@@ -1219,7 +1220,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
           if (cudaErr == cudaSuccess) {
             *isComplete = true;
           } else if (cudaErr != cudaErrorNotReady) {
-            CERR(
+            CTRAN_ERR(
                 commSystemError,
                 "CTRAN: cudaStreamQuery returned error '{}'",
                 cudaGetErrorString(cudaErr));
@@ -1265,7 +1266,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         this->ctranTcpDm->cancelQueuedRecv(&notify->tcpDmReq);
       }
     } else {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-MAPPER: unexpected backend {}",
           notify->backend);
@@ -1370,7 +1371,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         FB_COMMCHECK(ipcRegCache->exportMem(
             buf, regElem->ipcRegElem, msg.ipcDesc, tmpExtraSegments));
         if (!tmpExtraSegments.empty()) {
-          CERR(
+          CTRAN_ERR(
               commInternalError,
               "CTRAN-MAPPER: exportMem to rank {} has overflow segments, which is "
               "not supported in this path.",
@@ -1390,7 +1391,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       // No need to export the buffers, TCP device memory is steered by
       // the receiver.
     } else {
-      CERR(
+      CTRAN_ERR(
           commInvalidUsage,
           "CTRAN-MAPPER: Cannot export buffer {} to rank {}. The rank may not be "
           "reachable by any backend, or buffer type is not supported.",
@@ -1420,7 +1421,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     switch (msg.type) {
       case ControlMsgType::IB_EXPORT_MEM:
         if (!this->ctranIb) {
-          CERR(
+          CTRAN_ERR(
               commInternalError,
               "CTRAN-MAPPER: IB backend is disabled but received unexpected internal control msg ({})",
               msg.toString());
@@ -1431,7 +1432,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         break;
       case ControlMsgType::NVL_EXPORT_MEM: {
         if (!this->ctranNvl) {
-          CERR(
+          CTRAN_ERR(
               commInternalError,
               "CTRAN-MAPPER: NVL backend is disabled but received unexpected internal control msg ({})",
               msg.toString());
@@ -1453,7 +1454,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         break;
       }
       default:
-        CERR(
+        CTRAN_ERR(
             commInternalError,
             "CTRAN-MAPPER: Received unexpected control message type {}",
             msg.type);
@@ -1480,7 +1481,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       const bool isCrossNode = this->ctranNvl->isNvlFabric(rank) &&
           !this->comm->statex_->isSameNode(this->comm->logMetaData_.rank, rank);
       if (isCrossNode && regElem->getType() != DevMemType::kCumem) {
-        CLOGF_SUBSYS(
+        CTRAN_LOG_SUBSYS(
             DBG,
             ALLOC,
             "CTRAN-MAPPER: cross-node nvlFabric peer rank {} with non-cuMem "
@@ -1513,7 +1514,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       return CtranMapperBackend::TCPDM;
     }
 
-    CLOGF(ERR, "No backend is available, please specify at least one backend.");
+    CTRAN_LOG(
+        ERR, "No backend is available, please specify at least one backend.");
 
     return CtranMapperBackend::UNSET;
   }
@@ -1630,7 +1632,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
           ControlMsgType::SYNC, payload, size, peerRank, req->ibReq);
     }
     // only support ib for now
-    CERR(
+    CTRAN_ERR(
         commInvalidArgument,
         "CTRAN-MAPPER: isendCtrlMsg only supports the IB backend for peerRank {}",
         peerRank);
@@ -1668,7 +1670,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       return ctranIb->irecvCtrlMsg<PerfConfig>(
           payload, size, peerRank, req->ibReq);
     }
-    CERR(
+    CTRAN_ERR(
         commInvalidArgument,
         "CTRAN-MAPPER: irecvCtrlMsg only supports the IB backend for peerRank {}",
         peerRank);
@@ -1750,7 +1752,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     } else if (ctranTcpDm) {
       return ctranTcpDm->isendCtrlMsg(msg, peerRank, req->tcpDmReq);
     }
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "CTRAN-MAPPER: isendCtrl found no available backend for peerRank {}",
         peerRank);
@@ -1787,7 +1789,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     } else if (ctranTcpDm) {
       return ctranTcpDm->irecvCtrlMsg(msg, peerRank, req->tcpDmReq);
     }
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "CTRAN-MAPPER: irecvCtrl found no available backend for peerRank {}",
         peerRank);
@@ -1800,7 +1802,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       const std::vector<CtranMapperPutMsg>& puts,
       int peerRank) {
     if (this->ctranIb == nullptr) {
-      CERR(commInternalError, "CTRAN-MAPPER: ctranIB is null in batch put.");
+      CTRAN_ERR(
+          commInternalError, "CTRAN-MAPPER: ctranIB is null in batch put.");
       return commInternalError;
     }
     std::vector<PutIbMsg> msgs;
@@ -1808,7 +1811,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     for (auto& put : puts) {
       const auto& remoteAccessKey = put.config.remoteAccessKey_;
       if (remoteAccessKey.backend != CtranMapperBackend::IB) {
-        CERR(
+        CTRAN_ERR(
             commInternalError,
             "CTRAN-MAPPER: Unsupported remote access key backend {}",
             backendToStr(remoteAccessKey.backend));
@@ -1926,13 +1929,13 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
             config.ibFastPath_));
       } else {
         if (req == nullptr) {
-          CERR(
+          CTRAN_ERR(
               commInternalError,
               "CTRAN-MAPPER: Unsupported TCPDM iput without request");
           return commInternalError;
         }
         if (!notify) {
-          CERR(
+          CTRAN_ERR(
               commInternalError,
               "CTRAN-MAPPER: Unsupported TCPDM iput without notify");
           return commInternalError;
@@ -1964,7 +1967,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
           len);
 
       if (!kernElem) {
-        CERR(
+        CTRAN_ERR(
             commInternalError,
             "CTRAN-MAPPER: NVL PUT requires valid kernElem. It indicates a COMM internal bug");
         return commInternalError;
@@ -1982,7 +1985,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       kernElem->post();
     } else {
       auto backendStr = backendToStr(remoteAccessKey.backend);
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-MAPPER: Unsupported remote access key backend {}",
           backendStr.c_str());
@@ -2022,7 +2025,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
           req->backend = CtranMapperBackend::IB;
           req->setConfig(config);
         } else {
-          CERR(
+          CTRAN_ERR(
               commInternalError,
               "CTRAN-MAPPER: Unsupported backend iget without IB backend");
           return commInternalError;
@@ -2055,7 +2058,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
             ibReqPtr,
             config.ibFastPath_));
       } else {
-        CERR(
+        CTRAN_ERR(
             commInternalError,
             "CTRAN-MAPPER: IB backend required for iget operation, but not available.");
 
@@ -2063,7 +2066,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       }
     } else {
       auto backendStr = backendToStr(remoteAccessKey.backend);
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-MAPPER: Unsupported remote access key backend {}",
           backendStr.c_str());
@@ -2082,7 +2085,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperRequest* req) {
     const auto& remoteAccessKey = config.remoteAccessKey_;
     if (remoteAccessKey.backend != CtranMapperBackend::IB) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-MAPPER: atomicSet only supports IB backend");
       return commInternalError;
@@ -2136,7 +2139,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         rbuff = kernElem->waitNotify.recvbuff;
         len = kernElem->waitNotify.nbytes;
         if (rbuff == nullptr || len == 0) {
-          CERR(
+          CTRAN_ERR(
               commInternalError,
               "TCP Device Memory requires recvbuff in the notifier");
           return commInternalError;
@@ -2144,7 +2147,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       } else {
         const DevMemType type = regElem->getType();
         if (type != kHostUnregistered && type != kHostPinned) {
-          CERR(
+          CTRAN_ERR(
               commInternalError,
               "TCP Device Memory requires kernElem in the notifier "
               "(memType {})",
@@ -2198,7 +2201,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       FB_COMMCHECK(this->ctranTcpDm->progress());
       FB_COMMCHECK(this->ctranTcpDm->checkNotify(notify->peer, done));
     } else {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-MAPPER: unexpected backend {}",
           notify->backend);
@@ -2244,7 +2247,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         // Only icopy request doesn't have peer; expect it is not used in
         // testSomeRequests with timepoints.
         if (req->peer == -1) {
-          CERR(commInternalError, "Expect peer is specified in request.");
+          CTRAN_ERR(commInternalError, "Expect peer is specified in request.");
           return commInternalError;
         }
 
@@ -2276,7 +2279,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     for (auto it = reqs.begin(); it != reqs.end(); it++) {
       auto& req = *it;
       if (req.peer == -1) {
-        CERR(commInternalError, "Expect peer is specified in request.");
+        CTRAN_ERR(commInternalError, "Expect peer is specified in request.");
         return commInternalError;
       }
       FB_COMMCHECK(waitRequest<PerfConfig>(&req));
@@ -2294,7 +2297,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperRequest** req,
       const char* fnName) {
     if (req == nullptr) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-MAPPER: Invalid request pointer. Unexpected {} indicates a COMM internal bug",
           fnName);
@@ -2310,7 +2313,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperRequest* req,
       const char* fnName) {
     if (req == nullptr) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-MAPPER: Invalid request pointer. Unexpected {} indicates a COMM internal bug",
           fnName);

--- a/comms/ctran/mapper/CtranMapperRequest.cc
+++ b/comms/ctran/mapper/CtranMapperRequest.cc
@@ -3,6 +3,7 @@
 #include "comms/ctran/gpe/CtranGpeDev.h"
 #include "comms/ctran/mapper/CtranMapperTypes.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 
 static std::unordered_map<CtranMapperRequest::ReqType, std::string> reqTypeStr =
     {{CtranMapperRequest::ReqType::SEND_CTRL, "SEND_CTRL"},
@@ -29,7 +30,7 @@ CtranMapperRequest::CtranMapperRequest(
   }
   if (backend != CtranMapperBackend::IB &&
       backend != CtranMapperBackend::SOCKET) {
-    CLOGF(
+    CTRAN_LOG(
         ERR,
         "CTRAN-MAPPER: Unsupported backend {} for CtranMapperRequest",
         backend);

--- a/comms/ctran/utils/Checks.h
+++ b/comms/ctran/utils/Checks.h
@@ -6,10 +6,10 @@
 #include <errno.h>
 #include <folly/Format.h>
 
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/Exception.h"
 #include "comms/utils/Conversion.h"
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/LogUtils.h"
 
 /**
  * Error check macros.
@@ -33,7 +33,7 @@
     cudaError_t err = cmd;                   \
     if (err != cudaSuccess) {                \
       auto errStr = cudaGetErrorString(err); \
-      CERR(                                  \
+      CTRAN_ERR(                             \
           commUnhandledCudaError,            \
           "Cuda failure {} '{}'",            \
           static_cast<int>(err),             \
@@ -48,7 +48,7 @@
   do {                                                             \
     cudaError_t err = cmd;                                         \
     if (err != cudaSuccess) {                                      \
-      CERR(                                                        \
+      CTRAN_ERR(                                                   \
           commUnhandledCudaError,                                  \
           "{}:{} Cuda failure {}",                                 \
           __FILE__,                                                \
@@ -95,30 +95,31 @@
   do {                                                                         \
     cudaError_t err = cmd;                                                     \
     if (err != cudaSuccess) {                                                  \
-      CERR(                                                                    \
+      CTRAN_ERR(                                                               \
           commUnhandledCudaError, "Cuda failure {}", cudaGetErrorString(err)); \
       RES = commUnhandledCudaError;                                            \
       goto label;                                                              \
     }                                                                          \
   } while (false)
 
-#define FB_CUCHECKGOTO(cmd, RES, label)                                     \
-  do {                                                                      \
-    CUresult err = cmd;                                                     \
-    if (err != CUDA_SUCCESS) {                                              \
-      const char* errStr;                                                   \
-      cuGetErrorString(err, &errStr);                                       \
-      CERR(commUnhandledCudaError, "Cuda failure {}", std::string(errStr)); \
-      RES = commUnhandledCudaError;                                         \
-      goto label;                                                           \
-    }                                                                       \
+#define FB_CUCHECKGOTO(cmd, RES, label)                                    \
+  do {                                                                     \
+    CUresult err = cmd;                                                    \
+    if (err != CUDA_SUCCESS) {                                             \
+      const char* errStr;                                                  \
+      cuGetErrorString(err, &errStr);                                      \
+      CTRAN_ERR(                                                           \
+          commUnhandledCudaError, "Cuda failure {}", std::string(errStr)); \
+      RES = commUnhandledCudaError;                                        \
+      goto label;                                                          \
+    }                                                                      \
   } while (false)
 
 #define FB_CUDACHECKGUARD(cmd, RES)                                            \
   do {                                                                         \
     cudaError_t err = cmd;                                                     \
     if (err != cudaSuccess) {                                                  \
-      CERR(                                                                    \
+      CTRAN_ERR(                                                               \
           commUnhandledCudaError, "Cuda failure {}", cudaGetErrorString(err)); \
       RES = commUnhandledCudaError;                                            \
       return;                                                                  \
@@ -130,7 +131,7 @@
   do {                              \
     cudaError_t err = cmd;          \
     if (err != cudaSuccess) {       \
-      CLOGF(                        \
+      CTRAN_LOG(                    \
           WARN,                     \
           "{}:{} Cuda failure {}",  \
           __FILE__,                 \
@@ -146,51 +147,55 @@
   do {                                                                         \
     cudaError_t err = cmd;                                                     \
     if (err != cudaSuccess) {                                                  \
-      CERR(                                                                    \
+      CTRAN_ERR(                                                               \
           commUnhandledCudaError, "Cuda failure {}", cudaGetErrorString(err)); \
       abort();                                                                 \
     }                                                                          \
   } while (false)
 
-#define FB_SYSCHECK(statement, name)                                         \
+#define FB_SYSCHECK(statement, name)                                        \
+  do {                                                                      \
+    int retval;                                                             \
+    FB_SYSCHECKSYNC((statement), name, retval);                             \
+    if (retval == -1) {                                                     \
+      CTRAN_ERR(                                                            \
+          commSystemError, "Call to " name " failed: {}", strerror(errno)); \
+      return commSystemError;                                               \
+    }                                                                       \
+  } while (false)
+
+#define FB_SYSCHECKVAL(call, name, retval)                                   \
   do {                                                                       \
-    int retval;                                                              \
-    FB_SYSCHECKSYNC((statement), name, retval);                              \
+    FB_SYSCHECKSYNC(call, name, retval);                                     \
     if (retval == -1) {                                                      \
-      CERR(commSystemError, "Call to " name " failed: {}", strerror(errno)); \
+      CTRAN_ERR(                                                             \
+          commSystemError, "Call to " name " failed : {}", strerror(errno)); \
       return commSystemError;                                                \
     }                                                                        \
   } while (false)
 
-#define FB_SYSCHECKVAL(call, name, retval)                                    \
-  do {                                                                        \
-    FB_SYSCHECKSYNC(call, name, retval);                                      \
-    if (retval == -1) {                                                       \
-      CERR(commSystemError, "Call to " name " failed : {}", strerror(errno)); \
-      return commSystemError;                                                 \
-    }                                                                         \
-  } while (false)
-
-#define FB_SYSCHECKSYNC(statement, name, retval)                             \
-  do {                                                                       \
-    retval = (statement);                                                    \
-    if (retval == -1 &&                                                      \
-        (errno == EINTR || errno == EWOULDBLOCK || errno == EAGAIN)) {       \
-      CLOGF(ERR, "Call to " name " returned {}, retrying", strerror(errno)); \
-    } else {                                                                 \
-      break;                                                                 \
-    }                                                                        \
+#define FB_SYSCHECKSYNC(statement, name, retval)                           \
+  do {                                                                     \
+    retval = (statement);                                                  \
+    if (retval == -1 &&                                                    \
+        (errno == EINTR || errno == EWOULDBLOCK || errno == EAGAIN)) {     \
+      CTRAN_LOG(                                                           \
+          ERR, "Call to " name " returned {}, retrying", strerror(errno)); \
+    } else {                                                               \
+      break;                                                               \
+    }                                                                      \
   } while (true)
 
-#define FB_SYSCHECKGOTO(statement, name, RES, label)                         \
-  do {                                                                       \
-    int retval;                                                              \
-    FB_SYSCHECKSYNC((statement), name, retval);                              \
-    if (retval == -1) {                                                      \
-      CERR(commSystemError, "Call to " name " failed: {}", strerror(errno)); \
-      RES = commSystemError;                                                 \
-      goto label;                                                            \
-    }                                                                        \
+#define FB_SYSCHECKGOTO(statement, name, RES, label)                        \
+  do {                                                                      \
+    int retval;                                                             \
+    FB_SYSCHECKSYNC((statement), name, retval);                             \
+    if (retval == -1) {                                                     \
+      CTRAN_ERR(                                                            \
+          commSystemError, "Call to " name " failed: {}", strerror(errno)); \
+      RES = commSystemError;                                                \
+      goto label;                                                           \
+    }                                                                       \
   } while (0)
 
 #define FB_SYSCHECKTHROW_EX_DIRECT(cmd, rank, commHash, desc) \
@@ -198,7 +203,7 @@
     int err = cmd;                                            \
     if (err != 0) {                                           \
       auto errstr = folly::errnoStr(err);                     \
-      CERR(                                                   \
+      CTRAN_ERR(                                              \
           commSystemError,                                    \
           "{}:{} -> {} ({})",                                 \
           __FILE__,                                           \
@@ -240,7 +245,7 @@
     int err = cmd;                        \
     if (err != 0) {                       \
       auto errstr = folly::errnoStr(err); \
-      CERR(                               \
+      CTRAN_ERR(                          \
           commSystemError,                \
           "{}:{} -> {} ({})",             \
           __FILE__,                       \
@@ -252,30 +257,32 @@
   } while (0)
 
 // Pthread calls don't set errno and never return EINTR.
-#define FB_PTHREADCHECK(statement, name)                                      \
-  do {                                                                        \
-    int retval = (statement);                                                 \
-    if (retval != 0) {                                                        \
-      CERR(commSystemError, "Call to " name " failed: {}", strerror(retval)); \
-      return commSystemError;                                                 \
-    }                                                                         \
+#define FB_PTHREADCHECK(statement, name)                                     \
+  do {                                                                       \
+    int retval = (statement);                                                \
+    if (retval != 0) {                                                       \
+      CTRAN_ERR(                                                             \
+          commSystemError, "Call to " name " failed: {}", strerror(retval)); \
+      return commSystemError;                                                \
+    }                                                                        \
   } while (0)
 
-#define FB_PTHREADCHECKGOTO(statement, name, RES, label)                      \
-  do {                                                                        \
-    int retval = (statement);                                                 \
-    if (retval != 0) {                                                        \
-      CERR(commSystemError, "Call to " name " failed: {}", strerror(retval)); \
-      RES = commSystemError;                                                  \
-      goto label;                                                             \
-    }                                                                         \
+#define FB_PTHREADCHECKGOTO(statement, name, RES, label)                     \
+  do {                                                                       \
+    int retval = (statement);                                                \
+    if (retval != 0) {                                                       \
+      CTRAN_ERR(                                                             \
+          commSystemError, "Call to " name " failed: {}", strerror(retval)); \
+      RES = commSystemError;                                                 \
+      goto label;                                                            \
+    }                                                                        \
   } while (0)
 
 #define FB_NEQCHECK(statement, value) \
   do {                                \
     if ((statement) != value) {       \
       /* Print the back trace*/       \
-      CERR(                           \
+      CTRAN_ERR(                      \
           commSystemError,            \
           "{}:{} -> {} ({})",         \
           __FILE__,                   \
@@ -291,7 +298,7 @@
     if ((statement) != value) {                       \
       /* Print the back trace*/                       \
       RES = commSystemError;                          \
-      CERR(                                           \
+      CTRAN_ERR(                                      \
           commSystemError,                            \
           "{}:{} -> {} ({})",                         \
           __FILE__,                                   \
@@ -306,7 +313,7 @@
   do {                               \
     if ((statement) == value) {      \
       /* Print the back trace*/      \
-      CERR(                          \
+      CTRAN_ERR(                     \
           commSystemError,           \
           "{}:{} -> {} ({})",        \
           __FILE__,                  \
@@ -322,7 +329,7 @@
     if ((statement) == value) {                      \
       /* Print the back trace*/                      \
       RES = commSystemError;                         \
-      CERR(                                          \
+      CTRAN_ERR(                                     \
           commSystemError,                           \
           "{}:{} -> {} ({})",                        \
           __FILE__,                                  \
@@ -334,20 +341,20 @@
   } while (0)
 
 // Propagate errors up
-#define FB_COMMCHECK(call)                                \
-  do {                                                    \
-    commResult_t RES = call;                              \
-    if (RES != commSuccess && RES != commInProgress) {    \
-      CLOGF(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
-      return RES;                                         \
-    }                                                     \
+#define FB_COMMCHECK(call)                                    \
+  do {                                                        \
+    commResult_t RES = call;                                  \
+    if (RES != commSuccess && RES != commInProgress) {        \
+      CTRAN_LOG(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
+      return RES;                                             \
+    }                                                         \
   } while (0)
 
 // Propagate errors up for ibverbx
 #define FOLLY_EXPECTED_CHECK(RES) \
   do {                            \
     if (RES.hasError()) {         \
-      CERR(                       \
+      CTRAN_ERR(                  \
           commSystemError,        \
           "{}:{} -> {}, {}",      \
           __FILE__,               \
@@ -361,7 +368,7 @@
 #define FOLLY_EXPECTED_CHECKTHROW_EX(RES, commLogData)                 \
   do {                                                                 \
     if (RES.hasError()) {                                              \
-      CLOGF(                                                           \
+      CTRAN_LOG(                                                       \
           ERR,                                                         \
           "{}:{} -> {} ({})",                                          \
           __FILE__,                                                    \
@@ -381,7 +388,7 @@
 #define FOLLY_EXPECTED_CHECKTHROW_EX_NOCOMM(RES)                       \
   do {                                                                 \
     if (RES.hasError()) {                                              \
-      CLOGF(                                                           \
+      CTRAN_LOG(                                                       \
           ERR,                                                         \
           "{}:{} -> {} ({})",                                          \
           __FILE__,                                                    \
@@ -397,7 +404,7 @@
 #define FOLLY_EXPECTED_CHECKGOTO(RES, label, info) \
   do {                                             \
     if (RES.hasError()) {                          \
-      CLOGF(                                       \
+      CTRAN_LOG(                                   \
           ERR,                                     \
           "{}:{} -> {} ({}). {}",                  \
           __FILE__,                                \
@@ -413,7 +420,7 @@
   do {                                                             \
     commResult_t RES = cmd;                                        \
     if (RES != commSuccess && RES != commInProgress) {             \
-      CLOGF(                                                       \
+      CTRAN_LOG(                                                   \
           ERR,                                                     \
           "{}:{} -> {} ({})",                                      \
           __FILE__,                                                \
@@ -455,7 +462,7 @@
   do {                                                 \
     commResult_t RES = cmd;                            \
     if (RES != commSuccess && RES != commInProgress) { \
-      CLOGF(                                           \
+      CTRAN_LOG(                                       \
           ERR,                                         \
           "{}:{} -> {} ({})",                          \
           __FILE__,                                    \
@@ -469,13 +476,13 @@
     }                                                  \
   } while (0)
 
-#define FB_COMMCHECKGOTO(call, RES, label)                \
-  do {                                                    \
-    RES = call;                                           \
-    if (RES != commSuccess && RES != commInProgress) {    \
-      CLOGF(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
-      goto label;                                         \
-    }                                                     \
+#define FB_COMMCHECKGOTO(call, RES, label)                    \
+  do {                                                        \
+    RES = call;                                               \
+    if (RES != commSuccess && RES != commInProgress) {        \
+      CTRAN_LOG(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
+      goto label;                                             \
+    }                                                         \
   } while (0)
 
 // Report failure but clear error and continue
@@ -483,7 +490,7 @@
   do {                                                 \
     commResult_t RES = call;                           \
     if (RES != commSuccess && RES != commInProgress) { \
-      CLOGF(                                           \
+      CTRAN_LOG(                                       \
           WARN,                                        \
           "{}:{}:{} -> {} ({})",                       \
           __FILE__,                                    \
@@ -494,39 +501,39 @@
     }                                                  \
   } while (0)
 
-#define FB_CHECKABORT(statement, ...)             \
-  do {                                            \
-    if (!(statement)) {                           \
-      CLOGF(ERR, "Check failed: {}", #statement); \
-      CLOGF(ERR, ##__VA_ARGS__);                  \
-      abort();                                    \
-    }                                             \
+#define FB_CHECKABORT(statement, ...)                     \
+  do {                                                    \
+    if (!(statement)) {                                   \
+      CTRAN_LOG_SYNC_ERR("Check failed: {}", #statement); \
+      CTRAN_LOG_SYNC_ERR(__VA_ARGS__);                    \
+      abort();                                            \
+    }                                                     \
   } while (0);
 
-#define FB_CHECKTHROW_EX_DIRECT(statement, rank, commHash, commDesc, msg) \
-  do {                                                                    \
-    if (!(statement)) {                                                   \
-      CERR(commInternalError, "Check failed: {} - {}", #statement, msg);  \
-      throw ctran::utils::Exception(                                      \
-          fmt::format("Check failed: {} - {}", #statement, msg),          \
-          commInternalError,                                              \
-          rank,                                                           \
-          commHash,                                                       \
-          commDesc);                                                      \
-    }                                                                     \
+#define FB_CHECKTHROW_EX_DIRECT(statement, rank, commHash, commDesc, msg)     \
+  do {                                                                        \
+    if (!(statement)) {                                                       \
+      CTRAN_ERR(commInternalError, "Check failed: {} - {}", #statement, msg); \
+      throw ctran::utils::Exception(                                          \
+          fmt::format("Check failed: {} - {}", #statement, msg),              \
+          commInternalError,                                                  \
+          rank,                                                               \
+          commHash,                                                           \
+          commDesc);                                                          \
+    }                                                                         \
   } while (0)
 
-#define FB_CHECKTHROW_EX_LOGDATA(statement, commLogData, msg)            \
-  do {                                                                   \
-    if (!(statement)) {                                                  \
-      CERR(commInternalError, "Check failed: {} - {}", #statement, msg); \
-      throw ctran::utils::Exception(                                     \
-          fmt::format("Check failed: {} - {}", #statement, msg),         \
-          commInternalError,                                             \
-          (commLogData).rank,                                            \
-          (commLogData).commHash,                                        \
-          (commLogData).commDesc);                                       \
-    }                                                                    \
+#define FB_CHECKTHROW_EX_LOGDATA(statement, commLogData, msg)                 \
+  do {                                                                        \
+    if (!(statement)) {                                                       \
+      CTRAN_ERR(commInternalError, "Check failed: {} - {}", #statement, msg); \
+      throw ctran::utils::Exception(                                          \
+          fmt::format("Check failed: {} - {}", #statement, msg),              \
+          commInternalError,                                                  \
+          (commLogData).rank,                                                 \
+          (commLogData).commHash,                                             \
+          (commLogData).commDesc);                                            \
+    }                                                                         \
   } while (0)
 
 // Selector macro, used with FB_CHECKTHROW_EX to delegate
@@ -553,21 +560,21 @@
     if (!(statement)) {                                                  \
       auto errorMsg =                                                    \
           fmt::format("Check failed: {} - {}", #statement, __VA_ARGS__); \
-      CERR(commInternalError, "{}", errorMsg);                           \
+      CTRAN_ERR(commInternalError, "{}", errorMsg);                      \
       throw ctran::utils::Exception(errorMsg, commInternalError);        \
     }                                                                    \
   } while (0)
 
-#define FB_COMMWAIT(call, cond, abortFlagPtr)             \
-  do {                                                    \
-    uint32_t* tmpAbortFlag = (abortFlagPtr);              \
-    commResult_t RES = call;                              \
-    if (RES != commSuccess && RES != commInProgress) {    \
-      CLOGF(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
-      return commInternalError;                           \
-    }                                                     \
-    if (__atomic_load(tmpAbortFlag, __ATOMIC_ACQUIRE))    \
-      FB_NEQCHECK(*tmpAbortFlag, 0);                      \
+#define FB_COMMWAIT(call, cond, abortFlagPtr)                 \
+  do {                                                        \
+    uint32_t* tmpAbortFlag = (abortFlagPtr);                  \
+    commResult_t RES = call;                                  \
+    if (RES != commSuccess && RES != commInProgress) {        \
+      CTRAN_LOG(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
+      return commInternalError;                               \
+    }                                                         \
+    if (__atomic_load(tmpAbortFlag, __ATOMIC_ACQUIRE))        \
+      FB_NEQCHECK(*tmpAbortFlag, 0);                          \
   } while (!(cond))
 
 #define FB_COMMWAITGOTO(call, cond, abortFlagPtr, RES, label) \
@@ -575,7 +582,7 @@
     uint32_t* tmpAbortFlag = (abortFlagPtr);                  \
     RES = call;                                               \
     if (RES != commSuccess && RES != commInProgress) {        \
-      CLOGF(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES);     \
+      CTRAN_LOG(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
       goto label;                                             \
     }                                                         \
     if (__atomic_load(tmpAbortFlag, __ATOMIC_ACQUIRE))        \
@@ -585,7 +592,7 @@
 #define FB_COMMCHECKTHREAD(a, args)                                            \
   do {                                                                         \
     if (((args)->ret = (a)) != commSuccess && (args)->ret != commInProgress) { \
-      CLOGF_SUBSYS(                                                            \
+      CTRAN_LOG_SUBSYS(                                                        \
           ERR,                                                                 \
           INIT,                                                                \
           "{}:{} -> {} [Async thread]",                                        \
@@ -600,7 +607,7 @@
   do {                                    \
     if ((a) != cudaSuccess) {             \
       args->ret = commUnhandledCudaError; \
-      CERR(                               \
+      CTRAN_ERR(                          \
           commUnhandledCudaError,         \
           "{}:{} -> {} [Async thread]",   \
           __FILE__,                       \
@@ -610,23 +617,23 @@
     }                                     \
   } while (0)
 
-#define FB_COMMARGCHECK(statement, ...)         \
-  do {                                          \
-    if (!(statement)) {                         \
-      CERR(commInvalidArgument, ##__VA_ARGS__); \
-      return commInvalidArgument;               \
-    }                                           \
+#define FB_COMMARGCHECK(statement, ...)              \
+  do {                                               \
+    if (!(statement)) {                              \
+      CTRAN_ERR(commInvalidArgument, ##__VA_ARGS__); \
+      return commInvalidArgument;                    \
+    }                                                \
   } while (0);
 
-#define FB_ERRORRETURN(error, ...) \
-  do {                             \
-    CERR(error, ##__VA_ARGS__);    \
-    return error;                  \
+#define FB_ERRORRETURN(error, ...)   \
+  do {                               \
+    CTRAN_ERR(error, ##__VA_ARGS__); \
+    return error;                    \
   } while (0)
 
 #define FB_ERRORTHROW_EX(error, logData, ...)       \
   do {                                              \
-    CLOGF(ERR, ##__VA_ARGS__);                      \
+    CTRAN_LOG(ERR, ##__VA_ARGS__);                  \
     throw ctran::utils::Exception(                  \
         std::string("COMM internal failure: ") +    \
             ::meta::comms::commCodeToString(error), \
@@ -639,7 +646,7 @@
 // For contexts where rank/commHash are not available
 #define FB_ERRORTHROW_EX_NOCOMM(error, ...)         \
   do {                                              \
-    CLOGF(ERR, ##__VA_ARGS__);                      \
+    CTRAN_LOG(ERR, ##__VA_ARGS__);                  \
     throw ctran::utils::Exception(                  \
         std::string("COMM internal failure: ") +    \
             ::meta::comms::commCodeToString(error), \

--- a/comms/ctran/utils/CtranLogger.h
+++ b/comms/ctran/utils/CtranLogger.h
@@ -16,6 +16,18 @@ inline constexpr std::string_view kCtranLoggerName = "comms.ctran";
 #define CTRAN_LOG(level, ...) \
   COMMS_LOG_NAMED(::ctran::logging::kCtranLoggerName, level, __VA_ARGS__)
 
+#define CTRAN_LOG_SYNC_ERR(...)                                      \
+  do {                                                               \
+    auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger(    \
+        ::ctran::logging::kCtranLoggerName);                         \
+    if (_ctran_logger.should_log(::spdlog::level::err)) {            \
+      _ctran_logger.logSynchronous(                                  \
+          ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, \
+          ::spdlog::level::err,                                      \
+          __VA_ARGS__);                                              \
+    }                                                                \
+  } while (false)
+
 #define CTRAN_LOG_IF_IMPL(level, spdlog_level, condition, ...)    \
   do {                                                            \
     auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger( \

--- a/comms/ctran/utils/CudaWrap.h
+++ b/comms/ctran/utils/CudaWrap.h
@@ -5,7 +5,7 @@
 #include <cuda_runtime.h>
 #include <fmt/format.h>
 
-#include "comms/utils/logger/LogUtils.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 
 #if CUDART_VERSION >= 11030
 #include <cudaTypedefs.h> // @manual
@@ -56,7 +56,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {              \
       const char* errStr;                   \
       (void)cuGetErrorString(err, &errStr); \
-      CERR(                                 \
+      CTRAN_ERR(                            \
           commUnhandledCudaError,           \
           "Cuda failure {} '{}'",           \
           static_cast<int>(err),            \
@@ -71,7 +71,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {              \
       const char* errStr;                   \
       (void)cuGetErrorString(err, &errStr); \
-      CERR(                                 \
+      CTRAN_ERR(                            \
           commUnhandledCudaError,           \
           "Cuda failure {} '{}'",           \
           static_cast<int>(err),            \
@@ -86,7 +86,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {           \
       const char* errStr;                \
       cuGetErrorString(err, &errStr);    \
-      CERR(                              \
+      CTRAN_ERR(                         \
           commUnhandledCudaError,        \
           "Cuda failure {} '{}'",        \
           static_cast<int>(err),         \
@@ -96,14 +96,14 @@ namespace ctran::utils {
     }                                    \
   } while (false)
 
-#define FB_CUCHECKRES(res)                                               \
-  do {                                                                   \
-    if (res != CUDA_SUCCESS) {                                           \
-      const char* errStr;                                                \
-      (void)cuGetErrorString(res, &errStr);                              \
-      CERR(commUnhandledCudaError, "Cuda failure {} '{}'", res, errStr); \
-      return commUnhandledCudaError;                                     \
-    }                                                                    \
+#define FB_CUCHECKRES(res)                                                    \
+  do {                                                                        \
+    if (res != CUDA_SUCCESS) {                                                \
+      const char* errStr;                                                     \
+      (void)cuGetErrorString(res, &errStr);                                   \
+      CTRAN_ERR(commUnhandledCudaError, "Cuda failure {} '{}'", res, errStr); \
+      return commUnhandledCudaError;                                          \
+    }                                                                         \
   } while (false)
 
 // Report failure but clear error and continue
@@ -113,7 +113,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {              \
       const char* errStr;                   \
       (void)cuGetErrorString(err, &errStr); \
-      CLOGF(                                \
+      CTRAN_LOG(                            \
           WARN,                             \
           "{}:{} Cuda failure {} '{}'",     \
           __FILE__,                         \
@@ -127,7 +127,7 @@ namespace ctran::utils {
   do {                                    \
     CUresult err = cmd;                   \
     if (err != CUDA_SUCCESS) {            \
-      CERR(                               \
+      CTRAN_ERR(                          \
           commUnhandledCudaError,         \
           "{}:{} -> {} [Async thread]",   \
           __FILE__,                       \
@@ -149,7 +149,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {                                  \
       const char* errStr;                                       \
       (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr); \
-      CERR(                                                     \
+      CTRAN_ERR(                                                \
           commUnhandledCudaError,                               \
           "Cuda failure {} '{}'",                               \
           static_cast<int>(err),                                \
@@ -164,7 +164,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {                                  \
       const char* errStr;                                       \
       (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr); \
-      CERR(                                                     \
+      CTRAN_ERR(                                                \
           commUnhandledCudaError,                               \
           "Cuda failure {} '{}'",                               \
           static_cast<int>(err),                                \
@@ -179,7 +179,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {                                  \
       const char* errStr;                                       \
       (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr); \
-      CERR(                                                     \
+      CTRAN_ERR(                                                \
           commUnhandledCudaError,                               \
           "Cuda failure {} '{}'",                               \
           static_cast<int>(err),                                \
@@ -189,14 +189,14 @@ namespace ctran::utils {
     }                                                           \
   } while (false)
 
-#define FB_CUCHECKRES(res)                                               \
-  do {                                                                   \
-    if (res != CUDA_SUCCESS) {                                           \
-      const char* errStr;                                                \
-      (void)::ctran::utils::pfn_cuGetErrorString(res, &errStr);          \
-      CERR(commUnhandledCudaError, "Cuda failure {} '{}'", res, errStr); \
-      return commUnhandledCudaError;                                     \
-    }                                                                    \
+#define FB_CUCHECKRES(res)                                                    \
+  do {                                                                        \
+    if (res != CUDA_SUCCESS) {                                                \
+      const char* errStr;                                                     \
+      (void)::ctran::utils::pfn_cuGetErrorString(res, &errStr);               \
+      CTRAN_ERR(commUnhandledCudaError, "Cuda failure {} '{}'", res, errStr); \
+      return commUnhandledCudaError;                                          \
+    }                                                                         \
   } while (false)
 
 // Report failure but clear error and continue
@@ -206,7 +206,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {                                  \
       const char* errStr;                                       \
       (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr); \
-      CLOGF(                                                    \
+      CTRAN_LOG(                                                \
           WARN,                                                 \
           "{}:{} Cuda failure {} '{}'",                         \
           __FILE__,                                             \
@@ -220,7 +220,7 @@ namespace ctran::utils {
   do {                                        \
     CUresult err = ::ctran::utils::pfn_##cmd; \
     if (err != CUDA_SUCCESS) {                \
-      CERR(                                   \
+      CTRAN_ERR(                              \
           commUnhandledCudaError,             \
           "{}:{} -> {} [Async thread]",       \
           __FILE__,                           \

--- a/comms/ctran/utils/tests/ChecksUT.cc
+++ b/comms/ctran/utils/tests/ChecksUT.cc
@@ -1,7 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <string>
-#include <vector>
 
 #include <cuda_runtime.h>
 #include <fmt/core.h>
@@ -9,12 +8,11 @@
 #include <gtest/gtest.h>
 
 #include <gmock/gmock.h>
-#include "TestLogCategory.h"
 #include "comms/ctran/utils/ArgCheck.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/LogInit.h"
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/Logger.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 class CtranUtilsCheckTest : public ::testing::Test {
  public:
@@ -22,20 +20,28 @@ class CtranUtilsCheckTest : public ::testing::Test {
 
   void SetUp() override {
     ctran::logging::initCtranLogging(true /*alwaysInit*/);
-
-    // Set up a test category
-    auto* category =
-        folly::LoggerDB::get().getCategory(XLOG_GET_CATEGORY_NAME());
-    ASSERT_TRUE(testCategory_.setup(category));
+    auto& logger =
+        meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName);
+    logger.configure("CTRAN", []() { return 0; }, {}, false);
+    logger.set_level(spdlog::level::info);
+    testing::internal::CaptureStdout();
+    capturingStdout_ = true;
   }
 
   void TearDown() override {
-    NcclLogger::close();
-    testCategory_.reset();
+    if (capturingStdout_) {
+      testing::internal::GetCapturedStdout();
+    }
+    auto& logger =
+        meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName);
+    logger.configure("CTRAN", []() { return 0; }, {}, false);
   }
 
-  const std::vector<std::string>& getMessages() const {
-    return testCategory_.getMessages();
+  std::string getOutput() {
+    meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName)
+        .flush();
+    capturingStdout_ = false;
+    return testing::internal::GetCapturedStdout();
   }
 
   const int getCurrentGpuIndex() {
@@ -53,7 +59,7 @@ class CtranUtilsCheckTest : public ::testing::Test {
   }
 
  private:
-  TestLogCategory testCategory_;
+  bool capturingStdout_{false};
 };
 
 TEST_F(CtranUtilsCheckTest, CudaCheck) {
@@ -65,10 +71,9 @@ TEST_F(CtranUtilsCheckTest, CudaCheck) {
   auto res = dummyFn();
   ASSERT_EQ(res, commUnhandledCudaError);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("invalid argument"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
+  EXPECT_THAT(output, ::testing::HasSubstr("invalid argument"));
 }
 
 TEST_F(CtranUtilsCheckTest, CudaCheckGoto) {
@@ -82,10 +87,9 @@ TEST_F(CtranUtilsCheckTest, CudaCheckGoto) {
   auto res = dummyFn();
   ASSERT_EQ(res, commUnhandledCudaError);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("unspecified launch failure"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
+  EXPECT_THAT(output, ::testing::HasSubstr("unspecified launch failure"));
 }
 
 TEST_F(CtranUtilsCheckTest, CudaCheckIgnore) {
@@ -96,10 +100,9 @@ TEST_F(CtranUtilsCheckTest, CudaCheckIgnore) {
   auto res = dummyFn();
   ASSERT_EQ(res, commSuccess);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN WARN"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("invalid argument"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN WARN"));
+  EXPECT_THAT(output, ::testing::HasSubstr("invalid argument"));
 }
 
 TEST_F(CtranUtilsCheckTest, SysCheck) {
@@ -111,10 +114,9 @@ TEST_F(CtranUtilsCheckTest, SysCheck) {
   auto res = dummyFn();
   ASSERT_EQ(res, commSystemError);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("Call to sysTestFn failed"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
+  EXPECT_THAT(output, ::testing::HasSubstr("Call to sysTestFn failed"));
 }
 
 TEST_F(CtranUtilsCheckTest, SysCheckGoto) {
@@ -128,10 +130,9 @@ TEST_F(CtranUtilsCheckTest, SysCheckGoto) {
   auto res = dummyFn();
   ASSERT_EQ(res, commSystemError);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("Call to sysTestFn failed"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
+  EXPECT_THAT(output, ::testing::HasSubstr("Call to sysTestFn failed"));
 }
 
 TEST_F(CtranUtilsCheckTest, ErrorReturn) {
@@ -142,10 +143,9 @@ TEST_F(CtranUtilsCheckTest, ErrorReturn) {
   auto res = dummyFn();
   ASSERT_EQ(res, commInvalidUsage);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("test ErrorReturn failure"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
+  EXPECT_THAT(output, ::testing::HasSubstr("test ErrorReturn failure"));
 }
 
 TEST_F(CtranUtilsCheckTest, ErrorThrowEx) {
@@ -172,9 +172,8 @@ TEST_F(CtranUtilsCheckTest, ErrorThrowEx) {
 
   ASSERT_TRUE(caughtException) << "Expected ctran::utils::Exception";
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
 }
 
 TEST_F(CtranUtilsCheckTest, ArgCheckNull) {
@@ -185,11 +184,10 @@ TEST_F(CtranUtilsCheckTest, ArgCheckNull) {
   auto res = dummyFn();
   ASSERT_EQ(res, commInvalidArgument);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
   EXPECT_THAT(
-      messages[0], ::testing::HasSubstr("ArgCheckNull ptr argument is NULL"));
+      output, ::testing::HasSubstr("ArgCheckNull ptr argument is NULL"));
 }
 
 TEST_F(CtranUtilsCheckTest, FB_SYSCHECKTHROW_EX_DIRECT) {

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -211,6 +211,15 @@ void CommsSpdlogLogger::log(
   }
 }
 
+void CommsSpdlogLogger::logSynchronous(
+    spdlog::source_loc location,
+    spdlog::level::level_enum level,
+    std::string_view message) {
+  if (should_log(level)) {
+    logFormatted(location, level, getLevelName(level), message, true);
+  }
+}
+
 void CommsSpdlogLogger::logFatal(
     spdlog::source_loc location,
     std::string_view message) {

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -51,6 +51,28 @@ class CommsSpdlogLogger {
       std::string_view message);
 
   template <typename... Args>
+  void logSynchronous(
+      spdlog::source_loc location,
+      spdlog::level::level_enum level,
+      spdlog::format_string_t<Args...> format,
+      Args&&... args) {
+    if (!should_log(level)) {
+      return;
+    }
+    logFormatted(
+        location,
+        level,
+        getLevelName(level),
+        fmt::format(format, std::forward<Args>(args)...),
+        true);
+  }
+
+  void logSynchronous(
+      spdlog::source_loc location,
+      spdlog::level::level_enum level,
+      std::string_view message);
+
+  template <typename... Args>
   void logFatal(
       spdlog::source_loc location,
       spdlog::format_string_t<Args...> format,


### PR DESCRIPTION
Summary:

Replace 33 legacy production log calls in the public `CtranMapper.h` header with the named CTRAN spdlog facade. Preserve levels, messages, arguments, subsystem gates, error and return behavior, backend selection, registration paths, and the checked hexadecimal `commHash` format.

Reviewed By: shr

Differential Revision: D115586139
