### PR TITLE
Migrate core IB logs (#3609)

### DIFF
--- a/comms/ctran/backends/ib/BootstrapExternal.cc
+++ b/comms/ctran/backends/ib/BootstrapExternal.cc
@@ -12,7 +12,7 @@
 #include "comms/ctran/backends/ib/CtranIbVc.h"
 #include "comms/ctran/backends/ib/VcState.h"
 #include "comms/ctran/utils/Checks.h"
-#include "comms/utils/logger/LogUtils.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 
 namespace ctran::ib {
 
@@ -82,7 +82,7 @@ commResult_t BootstrapExternal::connectVc(
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = pendingVcs_.find(peerRank);
     if (it == pendingVcs_.end()) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-IB: BootstrapExternal::connectVc called for peerRank {} before "
           "getLocalVcId. commHash {:x}, commDesc {}",

--- a/comms/ctran/backends/ib/BootstrapInternal.cc
+++ b/comms/ctran/backends/ib/BootstrapInternal.cc
@@ -20,12 +20,12 @@
 #include "comms/ctran/backends/ib/VcState.h"
 #include "comms/ctran/bootstrap/Socket.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/ctran/utils/Exception.h"
 #include "comms/ctran/utils/ExtUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/ScubaLogger.h"
 
 namespace {
@@ -45,7 +45,7 @@ const uint64_t kBootstrapMagic = 0xfaceb00cdeadbeef;
   } else {                                                                   \
     int errCode = cmd;                                                       \
     if (errCode || self->abortCtrl_->isAborted()) {                          \
-      CLOGF(ERR, "Socket error encountered: {}. Aborting.", errCode);        \
+      CTRAN_LOG(ERR, "Socket error encountered: {}. Aborting.", errCode);    \
       self->abortCtrl_->setAbort(); /* Ensure remote is notified */          \
       break;                                                                 \
     }                                                                        \
@@ -113,7 +113,7 @@ void Bootstrap::start(std::optional<const SocketServerAddr*> qpServerAddr) {
     auto maybeAddr = ::ctran::bootstrap::getInterfaceAddress(
         NCCL_SOCKET_IFNAME, NCCL_SOCKET_IPADDR_PREFIX, true, &resolvedIfName);
     if (maybeAddr.hasError()) {
-      CLOGF(WARN, "CTRAN-IB: No socket interfaces found");
+      CTRAN_LOG(WARN, "CTRAN-IB: No socket interfaces found");
       throw ::ctran::utils::Exception(
           "CTRAN-IB : No socket interfaces found",
           commSystemError,
@@ -135,7 +135,7 @@ void Bootstrap::start(std::optional<const SocketServerAddr*> qpServerAddr) {
       rank_,
       commHash_,
       commDesc_);
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-IB: Rank {} created listen socket with {} listenAddr {} ifname {}",
@@ -192,7 +192,7 @@ commResult_t Bootstrap::connect(
     scubaEvent.stopAndRecord();
   };
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-IB: Establishing connection: commHash {:x}, commDesc {}, rank {}, peer {}, peer listenAddr {} clientIfName {}",
@@ -224,7 +224,7 @@ commResult_t Bootstrap::exchangeAndPublish(
     bool isServer,
     int peerRank) {
   if (peerRank < 0 || (comm_ && peerRank >= comm_->statex_->nRanks())) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "invalid peerRank ({}) < 0 or >= nRanks {}",
         peerRank,
@@ -333,7 +333,7 @@ void Bootstrap::acceptLoop(Bootstrap* self) {
     uint64_t magic{0};
     HANDLE_SOCKET_ERROR(socket->recv(&magic, sizeof(uint64_t)), self);
     if (magic != kBootstrapMagic) {
-      CLOGF(
+      CTRAN_LOG(
           WARN,
           "CTRAN-IB: Invalid magic - received {:x} but expected {:x} for commHash {:x} commDesc {}. "
           "Likely unexpected connection attempt. Ignoring. Local Addr: {},  Peer Addr: {}",
@@ -351,7 +351,7 @@ void Bootstrap::acceptLoop(Bootstrap* self) {
     const auto err = self->exchangeAndPublish(
         std::move(socket), /*isServer=*/true, peerRank);
     if (err != 0) { // TODO: We may want to handle certain errors differently?
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "CTRAN-IB: Failed to establish connection with peer rank {} for commHash {:x} commDesc {}, err={}",
           peerRank,
@@ -362,7 +362,7 @@ void Bootstrap::acceptLoop(Bootstrap* self) {
     }
   }
 
-  CLOGF(
+  CTRAN_LOG(
       INFO,
       "CTRAN-IB: Listen thread terminating, rank {} commHash {:x} commDesc {}",
       self->rank_,

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -24,6 +24,7 @@
 #include "comms/ctran/interfaces/ICtran.h"
 #include "comms/ctran/utils/ArgCheck.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/ctran/utils/Exception.h"
@@ -33,7 +34,6 @@
 #include "comms/utils/StrUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 #include "folly/synchronization/CallOnce.h"
 
 using namespace ctran::ib;
@@ -66,7 +66,7 @@ bool CtranIb::shouldEnableLocalFlushByDefault(int cudaArch) {
 commResult_t checkEpochLock(CtranIb* ctranIb) {
   if (NCCL_CTRAN_IB_EPOCH_LOCK_ENFORCE_CHECK &&
       NCCL_CTRAN_IB_EPOCH_LOCK_ENABLE && !epochLockedFlags[ctranIb].load()) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "NCCL_CTRAN_IB_EPOCH_LOCK_ENABLE is set to true, but the critical section is called "
         "without acquiring the epoch lock on the calling thread. It is likely a NCCL bug.");
@@ -87,7 +87,7 @@ CtranIbSingleton::CtranIbSingleton() {
   try {
     FOLLY_EXPECTED_CHECKTHROW_EX_NOCOMM(ibvInitResult);
   } catch (const ctran::utils::Exception& e) {
-    CLOGF(
+    CTRAN_LOG(
         ERR,
         "CTRAN-IB: Failed to initialize ibverbs (libibverbs.so): {}. "
         "Set NCCL_CTRAN_BACKENDS=nvl,socket to use alternative backends.",
@@ -99,7 +99,7 @@ CtranIbSingleton::CtranIbSingleton() {
   try {
     FOLLY_EXPECTED_CHECKTHROW_EX_NOCOMM(maybeDeviceList);
   } catch (const ctran::utils::Exception& e) {
-    CLOGF(
+    CTRAN_LOG(
         ERR,
         "CTRAN-IB: Failed to get InfiniBand device list: {}. "
         "Set NCCL_CTRAN_BACKENDS=nvl,socket to use alternative backends.",
@@ -115,7 +115,7 @@ CtranIbSingleton::CtranIbSingleton() {
         "Set NCCL_CTRAN_BACKENDS=nvl,socket to use alternative backends.",
         ibvDevices.size(),
         NCCL_CTRAN_IB_DEVICES_PER_RANK);
-    CERR(commSystemError, "{}", msg);
+    CTRAN_ERR(commSystemError, "{}", msg);
     throw ctran::utils::Exception(msg, commSystemError);
   }
 
@@ -151,7 +151,7 @@ commResult_t CtranIbSingleton::destroy() {
   // Report traffic if enabled
   if (NCCL_SLOW_RANK_ENABLE) {
     for (int i = 0; i < devBytes_.size(); i++) {
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           INIT,
           "CTRAN-IB: [traffic profiling] cudaDev {} total traffic: {} bytes",
@@ -173,7 +173,7 @@ commResult_t CtranIbSingleton::destroy() {
   this->comms_.withRLock([&](auto& comms) {
     if (comms.size()) {
       for (auto& it : comms) {
-        CLOGF(
+        CTRAN_LOG(
             WARN,
             "CTRAN-IB: communicator {} are still alive when CtranIbSingleton is destroyed.",
             (void*)it);
@@ -183,7 +183,7 @@ commResult_t CtranIbSingleton::destroy() {
 
   size_t activeRegCount = getActiveRegCount();
   if (activeRegCount > 0) {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-IB: {} active buffer registrations when CtranIbSingleton is destroyed.",
         activeRegCount);
@@ -324,7 +324,7 @@ void CtranIbSingleton::ibAsyncEventHandler(const int cudaDev) {
       break;
     }
   }
-  CLOGF_SUBSYS(INFO, INIT, "CTRAN-IB: Exiting ibAsyncEventHandler");
+  CTRAN_LOG_SUBSYS(INFO, INIT, "CTRAN-IB: Exiting ibAsyncEventHandler");
 }
 
 CtranIb::CtranIb(
@@ -348,7 +348,7 @@ CtranIb::CtranIb(
       ::comms::fault_tolerance::createAbort(/*enabled=*/false),
       socketFactory,
       maxNumCqe);
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-IB: Initialized {} from comm {} enableLocalFlush {}",
@@ -386,7 +386,7 @@ CtranIb::CtranIb(
       maxNumCqe,
       maxNumNic);
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-IB: Initialized {} from rank {} cudaDev {} commHash {:x} commDesc {} enableLocalFlush {}",
@@ -463,7 +463,7 @@ void CtranIb::init(
         std::to_string(NCCL_CTRAN_IB_DEVICES_PER_RANK) +
         ") exceeds CTRAN_MAX_IB_DEVICES_PER_RANK (" +
         std::to_string(CTRAN_MAX_IB_DEVICES_PER_RANK) + ")";
-    CERR(commInvalidArgument, "CTRAN-IB: {}", msg);
+    CTRAN_ERR(commInvalidArgument, "CTRAN-IB: {}", msg);
     throw ::ctran::utils::Exception(
         msg.c_str(),
         commInvalidArgument,
@@ -478,7 +478,7 @@ void CtranIb::init(
     std::string msg = "cudaDev (" + std::to_string(cudaDev) +
         ") * NCCL_CTRAN_IB_DEVICES_PER_RANK * NCCL_CTRAN_IB_DEVICE_STRIDE exceeds the number of contexts (" +
         std::to_string(s->ibvDevices.size()) + ")";
-    CERR(commSystemError, "CTRAN-IB: {}", msg);
+    CTRAN_ERR(commSystemError, "CTRAN-IB: {}", msg);
     throw ::ctran::utils::Exception(
         msg.c_str(),
         commSystemError,
@@ -504,7 +504,7 @@ void CtranIb::init(
       ibverbx::ibv_port_attr portAttr;
       auto maybePortAttr = s->ibvDevices[singletonDevIdx].queryPort(port);
       if (maybePortAttr.hasError()) {
-        CLOGF(
+        CTRAN_LOG(
             WARN,
             "CTRAN-IB : Unable to query port {} on device {}",
             port,
@@ -543,7 +543,7 @@ void CtranIb::init(
           // Covers: libmlx5 dlopen failed (EOPNOTSUPP from null symbol);
           // driver didn't populate the requested caps (EOPNOTSUPP from
           // firmware/kernel too old); any other errno from the driver.
-          CLOGF(
+          CTRAN_LOG(
               WARN,
               "CTRAN-IB: OOO_RQ detection FAILED on {}: {} (errno {}).",
               devices[device].devName,
@@ -552,14 +552,14 @@ void CtranIb::init(
         } else if (maybeCtx->ooo_recv_wrs_caps.max_rc == 0) {
           // Driver populated the caps struct but HW/firmware reports zero
           // capability — the query API works; the feature is just absent.
-          CLOGF(
+          CTRAN_LOG(
               WARN,
               "CTRAN-IB: OOO_RQ not supported by HW on {}: "
               "ooo_recv_wrs_caps.max_rc == 0.",
               devices[device].devName);
         } else {
           devices[device].oooRqSize = maybeCtx->ooo_recv_wrs_caps.max_rc;
-          CLOGF(
+          CTRAN_LOG(
               INFO,
               "CTRAN-IB: OOO_RQ detected on {}: max_rc={}.",
               devices[device].devName,
@@ -567,7 +567,7 @@ void CtranIb::init(
         }
       }
 
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           INIT,
           "CTRAN-IB: using device {}, port {} commHash {:x} commDesc {}",
@@ -576,7 +576,7 @@ void CtranIb::init(
           commHash,
           commDesc);
     } else {
-      CLOGF(
+      CTRAN_LOG(
           WARN,
           "CTRAN-IB : No active port found on device {}. Disable IB backend.",
           s->ibvDevices[singletonDevIdx].device()->name);
@@ -611,7 +611,7 @@ void CtranIb::init(
     // device-reported maximum.
     const int cqeCap = maxNumCqe.value_or(NCCL_CTRAN_IB_MAX_NUM_CQE);
     if (cqeCap > 0 && maxCqe > cqeCap) {
-      CLOGF(
+      CTRAN_LOG(
           INFO,
           "CTRAN-IB: Capping CQ size from {} to {} ({}) to reduce memory overhead",
           maxCqe,
@@ -620,7 +620,7 @@ void CtranIb::init(
                                 : "NCCL_CTRAN_IB_MAX_NUM_CQE");
       maxCqe = cqeCap;
     } else {
-      CLOGF(INFO, "CTRAN-IB: CQ size is {}", maxCqe);
+      CTRAN_LOG(INFO, "CTRAN-IB: CQ size is {}", maxCqe);
     }
 
     // Skip lock for cq and localVc in constructor since no other thread can
@@ -648,7 +648,7 @@ void CtranIb::init(
   // Reset flags for invalid use case check in epochLock() and epochUnlock()
   epochLockedFlags[this].store(false);
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-IB: dmabuf support for device {} is {}",
@@ -675,11 +675,11 @@ void CtranIb::init(
         "gets at least one data QP.",
         NCCL_CTRAN_IB_MAX_QPS,
         maxVcsPerPeer);
-    CERR(commInvalidArgument, "{}", msg);
+    CTRAN_ERR(commInvalidArgument, "{}", msg);
     throw ctran::utils::Exception(msg, commInvalidArgument);
   }
   vcLayout_ = ctran::ib::VcLayout(numNics, maxVcsPerPeer);
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-IB: VC layout: {} (numNics={}, NCCL_CTRAN_IB_MAX_QPS={}). "
@@ -701,7 +701,7 @@ void CtranIb::init(
         commDesc,
         ncclLogData,
         getPgToTrafficClassValue());
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-IB: skip internal bootstrap for IB backend {} commHash {:x} commDesc {}",
@@ -725,7 +725,7 @@ void CtranIb::init(
     bootstrap_->start(qpServerAddr);
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-IB: created IB backend {} for commHash {:x} commDesc {}",
@@ -752,7 +752,7 @@ CtranIb::~CtranIb(void) {
 
   FB_COMMCHECKIGNORE(releaseRemoteTransStates(true /* fromDestructor */));
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-IB: destroyed IB backend {} for commHash {:x} commDesc {}",
@@ -784,7 +784,7 @@ commResult_t CtranIb::epochLock() {
   }
 
   if (epochLockedFlags[this].load()) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "epochLock() already called on the same thread without epochUnlock(). It is likely a COMM bug.");
     return commInternalError;
@@ -802,7 +802,7 @@ commResult_t CtranIb::epochTryLock() {
   }
 
   if (epochLockedFlags[this].load()) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "epochLock() already called on the same thread without epochUnlock(). It is likely a COMM bug.");
     return commInternalError;
@@ -822,7 +822,7 @@ commResult_t CtranIb::epochUnlock() {
   }
 
   if (!epochLockedFlags[this].load()) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "epochUnlock() is called without an outstanding epochLock() on the thread. It is likely a COMM bug.");
     return commInternalError;
@@ -840,7 +840,7 @@ commResult_t CtranIb::regMem(
     void** ibRegElem) {
   commResult_t res = commSuccess;
   if (len < CTRAN_MIN_REGISTRATION_SIZE && NCCL_CTRAN_REGISTRATION_SIZE_CHECK) {
-    CERR(
+    CTRAN_ERR(
         commSystemError,
         "CTRAN-IB: cannot register buffer, size ({}) < {}",
         len,
@@ -901,7 +901,7 @@ commResult_t CtranIb::regMem(
       // fall back to ibv_reg_mr
       if (comms::utils::cumem::isBackedByMultipleCuMemAllocations(
               buf, cudaDev, len)) {
-        CERR(
+        CTRAN_ERR(
             commInvalidUsage,
             "CTRAN-IB: Memory region (buf {}, len {}) spans multiple cuMem allocations, ibv_reg_mr may fail!",
             buf,
@@ -1058,7 +1058,7 @@ commResult_t CtranIb::preConnect(const std::unordered_set<int>& peerRanks) {
   }
 
   if (newConnection) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-IB: Rank-{} Pre-connected peers: [{}]",
@@ -1130,7 +1130,7 @@ commResult_t CtranIb::setPgToTrafficClassMap() {
     std::vector<std::string> pgTrafficClassPair;
     folly::split(":", pgTrafficClassPairStr, pgTrafficClassPair);
     if (pgTrafficClassPair.size() != 2) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-IB: Invalid PG->Traffic class pair {} in pimpl {} commHash {:x}, commDesc {}.",
           pgTrafficClassPairStr,
@@ -1142,7 +1142,7 @@ commResult_t CtranIb::setPgToTrafficClassMap() {
     std::string tcStr = pgTrafficClassPair[1];
     auto tc = folly::tryTo<uint32_t>(tcStr);
     if (!tc.hasValue()) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-IB: Invalid Traffic Class value provided {} in pimpl {} commHash {:x}, commDesc {}.",
           tcStr,
@@ -1151,7 +1151,7 @@ commResult_t CtranIb::setPgToTrafficClassMap() {
           commDesc);
       return commInternalError;
     }
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-IB: commHash {:x}, commDesc {} override traffic class to {}",

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -23,6 +23,7 @@
 #include "comms/ctran/bootstrap/AbortableSocket.h"
 #include "comms/ctran/bootstrap/ISocketFactory.h"
 #include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CtranPerf.h"
 #include "comms/ctran/utils/Exception.h"
 #include "comms/ctran/utils/ExtUtils.h"
@@ -599,7 +600,7 @@ class CtranIb {
 
   inline commResult_t checkValidPeer(int peerRank) {
     if (peerRank < 0 || (comm && peerRank >= comm->statex_->nRanks())) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "invalid peerRank ({}) < 0 or >= nRanks {}",
           peerRank,
@@ -613,7 +614,7 @@ class CtranIb {
       std::shared_ptr<CtranIbVirtualConn>& vc,
       int peerRank) {
     if (vc == nullptr) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "No valid VirtualConnection (VC) found for peerRank {}",
           peerRank);
@@ -633,7 +634,7 @@ class CtranIb {
     deviceEnd = numNics;
     if (device.has_value()) {
       if (*device < 0 || *device >= numNics) {
-        CERR(
+        CTRAN_ERR(
             commInternalError,
             "CTRAN-IB: invalid device {} (numNics={})",
             *device,
@@ -1046,7 +1047,7 @@ class CtranIb {
         CTRAN_IB_PER_OBJ_LOCK_GUARD(cqMutex, {
           auto maybeWcsVector = devices[device].ibvCq->pollCq(1);
           if (maybeWcsVector.hasError()) {
-            CERR(
+            CTRAN_ERR(
                 commSystemError,
                 "Call to pollCq() on device {} failed with error {}",
                 device,
@@ -1083,7 +1084,7 @@ class CtranIb {
         std::shared_ptr<CtranIbVirtualConn> vc =
             vcState_.getVcByQp<PerfConfig>(std::make_pair(wc.qp_num, device));
         if (vc == nullptr) {
-          CERR(
+          CTRAN_ERR(
               commInternalError,
               "No valid VirtualConnection (VC) found for qpn {}",
               wc.qp_num);

--- a/comms/ctran/backends/ib/CtranIbBase.h
+++ b/comms/ctran/backends/ib/CtranIbBase.h
@@ -6,8 +6,8 @@
 #include <folly/String.h>
 #include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/LogUtils.h"
 
 struct CtranIbRemoteAccessKey {
   std::array<uint32_t, CTRAN_MAX_IB_DEVICES_PER_RANK> rkeys{};
@@ -68,7 +68,8 @@ class CtranIbRequest {
   inline commResult_t complete() {
     this->refCount_--;
     if (this->refCount_ < 0) {
-      CERR(commInternalError, "CTRAN-IB: req {} refCount_ < 0", (void*)this);
+      CTRAN_ERR(
+          commInternalError, "CTRAN-IB: req {} refCount_ < 0", (void*)this);
       return commInternalError;
     }
     if (this->refCount_ == 0) {

--- a/comms/ctran/backends/ib/CtranIbImpl.h
+++ b/comms/ctran/backends/ib/CtranIbImpl.h
@@ -7,9 +7,9 @@
 #include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/ibverbx/Ibvcore.h"
 #include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/ScubaLogger.h"
 
 #define CTRAN_IB_PER_OBJ_LOCK_GUARD(mutex_, code) \
@@ -32,7 +32,7 @@
           wc.qp_num,                                                                                  \
           wc.status,                                                                                  \
           ibv_wc_status_str(wc.status));                                                              \
-      CERR(commRemoteError, "{}", errMsg);                                                            \
+      CTRAN_ERR(commRemoteError, "{}", errMsg);                                                       \
       return commRemoteError;                                                                         \
     }                                                                                                 \
   } while (0)

--- a/comms/ctran/backends/ib/CtranIbLocalVc.cc
+++ b/comms/ctran/backends/ib/CtranIbLocalVc.cc
@@ -5,7 +5,7 @@
 #include "comms/ctran/backends/ib/IbvWrap.h"
 #include "comms/ctran/ibverbx/IbvQpUtils.h"
 #include "comms/ctran/utils/Checks.h"
-#include "comms/utils/logger/LogUtils.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 
 using namespace ctran::ibvwrap;
 
@@ -93,7 +93,7 @@ LocalVirtualConn::LocalVirtualConn(
         rtsQp(ibvQps_[device], NCCL_IB_TIMEOUT, NCCL_IB_RETRY_CNT),
         commLogData_);
 
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-IB: Established connection: commHash {:x}, commDesc {}, flush qpn {} on port {}",

--- a/comms/ctran/backends/ib/IbvWrap.cc
+++ b/comms/ctran/backends/ib/IbvWrap.cc
@@ -4,7 +4,7 @@
 
 #include "comms/ctran/backends/ib/IbvWrap.h"
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
-#include "comms/utils/logger/LogUtils.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 
 #include "comms/ctran/utils/Checks.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -29,10 +29,10 @@ commResult_t wrap_ibv_symbols(void) {
 }
 
 /* CHECK_NOT_NULL: helper macro to check for NULL symbol */
-#define CHECK_NOT_NULL(container, internal_name)             \
-  if (container.internal_name == nullptr) {                  \
-    CERR(commInternalError, "lib wrapper not initialized."); \
-    return commInternalError;                                \
+#define CHECK_NOT_NULL(container, internal_name)                  \
+  if (container.internal_name == nullptr) {                       \
+    CTRAN_ERR(commInternalError, "lib wrapper not initialized."); \
+    return commInternalError;                                     \
   }
 
 #define IBV_PTR_CHECK_ERRNO(                                    \
@@ -40,7 +40,7 @@ commResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name);                     \
   retval = container.call;                                      \
   if (retval == error_retval) {                                 \
-    CERR(                                                       \
+    CTRAN_ERR(                                                  \
         commSystemError,                                        \
         "Call to {} failed with error {}",                      \
         name,                                                   \
@@ -54,7 +54,7 @@ commResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name);                     \
   retval = container.call;                                      \
   if (retval == error_retval) {                                 \
-    CERR(commSystemError, "Call to {} failed", name);           \
+    CTRAN_ERR(commSystemError, "Call to {} failed", name);      \
     return commSystemError;                                     \
   }                                                             \
   return commSuccess;
@@ -62,18 +62,18 @@ commResult_t wrap_ibv_symbols(void) {
 #define IBV_INT_CHECK_RET_ERRNO_OPTIONAL(                                    \
     container, internal_name, call, success_retval, name, supported)         \
   if (container.internal_name == nullptr) {                                  \
-    CLOGF_SUBSYS(                                                            \
+    CTRAN_LOG_SUBSYS(                                                        \
         INFO, NET, "Call to {} skipped, internal_name doesn't exist", name); \
     *supported = 0;                                                          \
     return commSuccess;                                                      \
   }                                                                          \
   int ret = container.call;                                                  \
   if (ret == ENOTSUP || ret == EOPNOTSUPP) {                                 \
-    CLOGF_SUBSYS(INFO, NET, "Call to {} not supported", name);               \
+    CTRAN_LOG_SUBSYS(INFO, NET, "Call to {} not supported", name);           \
     *supported = 0;                                                          \
     return commSuccess;                                                      \
   } else if (ret != success_retval) {                                        \
-    CLOGF(                                                                   \
+    CTRAN_LOG(                                                               \
         WARN,                                                                \
         "Call to failed with error {} errno {}",                             \
         name,                                                                \
@@ -90,7 +90,7 @@ commResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name);               \
   int ret = container.call;                               \
   if (ret != success_retval) {                            \
-    CERR(                                                 \
+    CTRAN_ERR(                                            \
         commSystemError,                                  \
         "Call to {} failed with error {} errno {}",       \
         name,                                             \
@@ -104,7 +104,7 @@ commResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name);                               \
   int ret = container.call;                                               \
   if (ret == error_retval) {                                              \
-    CERR(commSystemError, "Call to failed", name);                        \
+    CTRAN_ERR(commSystemError, "Call to failed", name);                   \
     return commSystemError;                                               \
   }                                                                       \
   return commSuccess;
@@ -147,7 +147,7 @@ commResult_t wrap_ibv_free_device_list(struct ibv_device** list) {
 
 const char* wrap_ibv_get_device_name(struct ibv_device* device) {
   if (ibvSymbols.ibv_internal_get_device_name == nullptr) {
-    CLOGF(WARN, "lib wrapper not initialized.");
+    CTRAN_LOG(WARN, "lib wrapper not initialized.");
     exit(-1);
   }
   return ibvSymbols.ibv_internal_get_device_name(device);
@@ -287,7 +287,7 @@ commResult_t wrap_ibv_reg_mr(
 ibv_mr*
 wrap_direct_ibv_reg_mr(ibv_pd* pd, void* addr, size_t length, int access) {
   if (ibvSymbols.ibv_internal_reg_mr == nullptr) {
-    CLOGF(WARN, "lib wrapper not initialized.");
+    CTRAN_LOG(WARN, "lib wrapper not initialized.");
     return nullptr;
   }
   return ibvSymbols.ibv_internal_reg_mr(pd, addr, length, access);
@@ -524,7 +524,7 @@ wrap_ibv_modify_qp(struct ibv_qp* qp, struct ibv_qp_attr* attr, int attr_mask) {
     if (attempts > 0) {
       unsigned int sleepTime = timeOut * attempts;
       ibvModifyQpLog(qp, attr->qp_state, attr, attr_mask, qpMsg, sizeof(qpMsg));
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           NET,
           "Call to ibv_modify_qp failed with {} {}, {}, retrying {}/{} after {} msec of sleep",
@@ -545,7 +545,7 @@ wrap_ibv_modify_qp(struct ibv_qp* qp, struct ibv_qp_attr* attr, int attr_mask) {
   } while (IBV_MQP_RETRY_ERRNO_ALL(ret) && attempts < maxCnt);
   if (ret != 0) {
     ibvModifyQpLog(qp, attr->qp_state, attr, attr_mask, qpMsg, sizeof(qpMsg));
-    CERR(
+    CTRAN_ERR(
         commSystemError,
         "Call to ibv_modify_qp failed with {} {}, {}",
         ret,

--- a/comms/ctran/backends/ib/IbvWrap.h
+++ b/comms/ctran/backends/ib/IbvWrap.h
@@ -12,8 +12,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/LogUtils.h"
 
 // Copy-pasted from NCCL with minor modifications (ncclResult_t -> commResult_t,
 // etc.) [WIP]TODO: replace this c-style interface with comms/ctran/ibverbx
@@ -117,7 +117,7 @@ static inline commResult_t wrap_ibv_poll_cq(
       cq, num_entries, wc); /*returns the number of wcs or 0 on success, a
                                negative number otherwise*/
   if (done < 0) {
-    CERR(commSystemError, "Call to ibv_poll_cq() returned {}", done);
+    CTRAN_ERR(commSystemError, "Call to ibv_poll_cq() returned {}", done);
     return commSystemError;
   }
   *num_done = done;
@@ -145,7 +145,7 @@ static inline commResult_t wrap_ibv_post_send(
       qp, wr, bad_wr); /*returns 0 on success, or the value of errno on failure
                           (which indicates the failure reason)*/
   if (ret != IBV_SUCCESS) {
-    CERR(
+    CTRAN_ERR(
         commSystemError,
         "ibv_post_send() failed with error {}, Bad WR {}, First WR {}",
         strerror(ret),
@@ -164,7 +164,7 @@ static inline commResult_t wrap_ibv_post_recv(
       qp, wr, bad_wr); /*returns 0 on success, or the value of errno on failure
                           (which indicates the failure reason)*/
   if (ret != IBV_SUCCESS) {
-    CERR(
+    CTRAN_ERR(
         commSystemError, "ibv_post_recv() failed with error {}", strerror(ret));
     return commSystemError;
   }

--- a/comms/ctran/backends/ib/VcState.cc
+++ b/comms/ctran/backends/ib/VcState.cc
@@ -8,9 +8,9 @@
 #include <vector>
 
 #include "comms/ctran/backends/ib/CtranIbVc.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/StrUtils.h"
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/LogUtils.h"
 
 namespace ctran::ib {
 
@@ -43,7 +43,7 @@ commResult_t VcState::setupAndPublishVc(
     const std::vector<std::string>& remoteVcIdentifiers,
     int peerRank) {
   if (vcs.empty() || vcs.size() != remoteVcIdentifiers.size()) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "CTRAN-IB: setupAndPublishVc called with vcs.size()={} remoteVcIdentifiers.size()={} for peerRank {} in pimpl {} commHash {:x} commDesc {}",
         vcs.size(),
@@ -68,7 +68,7 @@ commResult_t VcState::setupAndPublishVc(
   {
     auto locked = vcStateMaps_.wlock();
     if (locked->rankToVcs.find(peerRank) != locked->rankToVcs.end()) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-IB: VirtualConnection (VC) already exists for peerRank {} in pimpl {} commHash {:x}, commDesc {}. It likely indicates a COMM bug.",
           peerRank,
@@ -113,7 +113,7 @@ commResult_t VcState::setupAndPublishVc(
 
     // Log each established VC while we still own a stable reference.
     for (const auto& vc : vcs) {
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           INIT,
           "CTRAN-IB: Established connection: commHash {:x}, commDesc {}, "
@@ -152,7 +152,7 @@ commResult_t VcState::checkAndInsertQpToVcMap(
     QpUniqueId& qpId,
     std::shared_ptr<CtranIbVirtualConn>& vc) {
   if (map.find(qpId) != map.end()) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "CTRAN-IB: QP {} on device {} already exists in pimpl {} commHash {:x}, commDesc {}. It likely indicates a COMM bug.",
         qpId.first,

--- a/comms/ctran/backends/ib/VcState.h
+++ b/comms/ctran/backends/ib/VcState.h
@@ -12,10 +12,10 @@
 #include <folly/container/F14Map.h>
 
 #include "comms/ctran/backends/ib/CtranIbVc.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CtranPerf.h"
 #include "comms/utils/StrUtils.h"
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/LogUtils.h"
 
 namespace ctran::ib {
 
@@ -139,7 +139,7 @@ class VcState {
       // found, it likely indicates a COMM bug, e.g., not using CtranIb
       // epoch lock.
       if (it == maybeLockedVcStateMapsPtr->qpToVcMap.end()) {
-        CLOGF(
+        CTRAN_LOG(
             ERR,
             "CTRAN-IB: Received unknown QP number {} on IB device {} in pimpl {} commHash {:x}, commDesc {}. Known QPs: {}. It likely indicates a COMM bug.",
             qpUniqueId.first,

--- a/comms/ctran/backends/ib/ibutils.cc
+++ b/comms/ctran/backends/ib/ibutils.cc
@@ -12,10 +12,10 @@
 #include "comms/ctran/backends/ib/IbvWrap.h"
 #include "comms/ctran/backends/ib/ibutils.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 
 using namespace ctran::ibvwrap;
 
@@ -38,12 +38,12 @@ commResult_t IbUtils::pollForAsyncEvent(
   int flags = fcntl(fdSet.fd, F_GETFL);
 
   if (flags == -1) {
-    CERR(commSystemError, "fcntl flags failure");
+    CTRAN_ERR(commSystemError, "fcntl flags failure");
     return commSystemError;
   }
   auto ret = fcntl(fdSet.fd, F_SETFL, flags | O_NONBLOCK);
   if (ret == -1) {
-    CERR(commSystemError, "fcntl set NONBLOCK failure");
+    CTRAN_ERR(commSystemError, "fcntl set NONBLOCK failure");
     return commSystemError;
   }
 
@@ -64,24 +64,25 @@ commResult_t IbUtils::pollForAsyncEvent(
 
   if (stopRequested) {
     // stop requested during cleanup; hence exiting this loop.
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO, NET, "CTRAN-IB: Exiting ibAsyncEventHandler (requested)");
     return commInProgress;
   }
   if (linkDown) {
-    CLOGF_SUBSYS(INFO, NET, "NET/IB : Exiting ibAsyncEventHandler (link down)");
+    CTRAN_LOG_SUBSYS(
+        INFO, NET, "NET/IB : Exiting ibAsyncEventHandler (link down)");
     joinTimeoutThread();
     return commSystemError;
   }
   if (ret < 0) {
-    CERR(
+    CTRAN_ERR(
         commSystemError,
         "NET/IB : poll for IB async events failed with error code:{}",
         ret);
     return commSystemError;
   }
   if ((fdSet.revents & POLLIN) != POLLIN) {
-    CERR(
+    CTRAN_ERR(
         commSystemError,
         "NET/IB : poll returned unexpected POLLERR or POLLHUP for dev={} (probably a bad device)",
         ibvContext->device->name);
@@ -111,7 +112,7 @@ void IbUtils::timeoutHandler(
           locked.as_lock(), duration, [&] { return *locked; })) {
     std::string errorMessage = fmt::format(
         "Link down timeout reached for {} ({} ms).", devName, duration.count());
-    CERR(commSystemError, "{}", errorMessage);
+    CTRAN_ERR(commSystemError, "{}", errorMessage);
     CTRAN_LOG(
         WARN,
         "ctranCommSetAsyncError: error comm NULL sets state {}",
@@ -120,7 +121,7 @@ void IbUtils::timeoutHandler(
     ibutils->setLinkFlapState(
         ctran::ibutils::LinkFlapState::IB_ASYNC_LINK_TIMEOUT);
   } else {
-    CLOGF_SUBSYS(INFO, NET, "NET/IB : timeoutHandler: link back up.");
+    CTRAN_LOG_SUBSYS(INFO, NET, "NET/IB : timeoutHandler: link back up.");
   }
 }
 
@@ -177,7 +178,8 @@ commResult_t IbUtils::triageIbAsyncEvents(
     const int port) {
   char* asyncErrorMsg = nullptr;
   if (commSuccess != wrap_ibv_event_type_str(&asyncErrorMsg, eventType)) {
-    CLOGF(WARN, "ibv_event_type_str not parsable - eventType={}", eventType);
+    CTRAN_LOG(
+        WARN, "ibv_event_type_str not parsable - eventType={}", eventType);
   }
   auto msg = fmt::format(
       "NET/IB: {}:{} Got async event: {} ({})",
@@ -202,11 +204,11 @@ commResult_t IbUtils::triageIbAsyncEvents(
     case ibverbx::IBV_EVENT_GID_CHANGE:
     case ibverbx::IBV_EVENT_SM_CHANGE:
     case ibverbx::IBV_EVENT_CLIENT_REREGISTER:
-      CLOGF_SUBSYS(INFO, NET, "{}", msg.c_str());
+      CTRAN_LOG_SUBSYS(INFO, NET, "{}", msg.c_str());
       break;
 
     case ibverbx::IBV_EVENT_PORT_ACTIVE:
-      CLOGF_SUBSYS(INFO, NET, "{}", msg.c_str());
+      CTRAN_LOG_SUBSYS(INFO, NET, "{}", msg.c_str());
       sendLinkUpEvent();
       break;
 
@@ -214,7 +216,7 @@ commResult_t IbUtils::triageIbAsyncEvents(
       // a link down event is not considered an error unless it is down
       // for a period longer than the configured timeout
       // so do not return commSystemError here
-      CERR(commSystemError, "{}", msg);
+      CTRAN_ERR(commSystemError, "{}", msg);
       // for now, only ctran supports timer
       if (NCCL_IB_ASYNC_EVENT_LOOP == NCCL_IB_ASYNC_EVENT_LOOP::ctran) {
         // set timer; if timer expires it will trigger an error
@@ -232,7 +234,7 @@ commResult_t IbUtils::triageIbAsyncEvents(
     case ibverbx::IBV_EVENT_SRQ_ERR:
     case ibverbx::IBV_EVENT_DEVICE_FATAL:
       ret = commSystemError;
-      CERR(commSystemError, "{}", msg);
+      CTRAN_ERR(commSystemError, "{}", msg);
       // preserve baseline functionality by not sending async error
       if (NCCL_IB_ASYNC_EVENT_LOOP == NCCL_IB_ASYNC_EVENT_LOOP::ctran) {
         CTRAN_LOG(
@@ -243,7 +245,7 @@ commResult_t IbUtils::triageIbAsyncEvents(
       break;
 
     default:
-      CLOGF_SUBSYS(INFO, NET, "{}", msg.c_str());
+      CTRAN_LOG_SUBSYS(INFO, NET, "{}", msg.c_str());
       break;
   }
   return ret;

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -554,7 +554,7 @@ commResult_t CtranMapper::remReleaseMem(ctran::regcache::RegElem* regElem) {
         req.get(),
         exportCount));
 
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-MAPPER: Posted IPC release to rank {} with exportCount {}",
         peerRank,
@@ -782,12 +782,12 @@ commResult_t CtranMapper::regAsync(const void* buf, const size_t len) {
     bool dynamicRegist = false;
     FB_COMMCHECK(searchRegHandle(
         buf, len, &regHdl, &dynamicRegist, false /* allowDynamic */));
-    CLOGF_TRACE(COLL, "regAsync registered buf {} len {}", buf, len);
+    CTRAN_LOG_TRACE(COLL, "regAsync registered buf {} len {}", buf, len);
     return commSuccess;
   } else {
     FB_COMMCHECK(regCache->asyncRegRange(
         buf, len, cudaDev, logMetaData_, enableBackends_));
-    CLOGF_TRACE(COLL, "regAsync submitted buf {} len {}", buf, len);
+    CTRAN_LOG_TRACE(COLL, "regAsync submitted buf {} len {}", buf, len);
     return commInProgress;
   }
 }
@@ -847,7 +847,7 @@ commResult_t CtranMapper::searchRegHandle(
         len);
   }
 
-  CLOGF_TRACE(
+  CTRAN_LOG_TRACE(
       COLL,
       "searchRegHandle buf {} len {} returned handle (regElem) {} dynamicRegist {}",
       buf,

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -20,10 +20,10 @@
 #include "comms/ctran/transport/ib/HostZcTransport.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/CtranIpc.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/StrUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/memtrace/MemoryTrace.h"
 
 #ifdef ENABLE_META_COMPRESSION
@@ -51,7 +51,7 @@ std::vector<CtranMapperBackend> getToEnableBackends(
       enableBackends.emplace_back(NCCLCtranBackendMap.at(b));
     }
   } else {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-MAPPER: Try to override backends through Ctran Config. Currently it is specific config for MCCL. If you are using NCCL with NCCL_CTRAN_BACKENDS, please report this to MCCL team");
     for (auto& b : overrideBackend) {
@@ -110,7 +110,7 @@ CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
   this->comm = comm;
 
   if (NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-MAPPER: IpcRegCache socket server enabled, initializing");
@@ -126,7 +126,7 @@ CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
     // AllGather IPC server addresses after comm is set
     FB_COMMCHECKTHROW_EX(allGatherIpcServerAddrs(), comm->logMetaData_);
   } else {
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-MAPPER: IpcRegCache socket server disabled via NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET=0, skipping init");
@@ -143,7 +143,7 @@ CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
     enableBackendsStrs.push_back(backendToStr(b));
   }
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-MAPPER: configure NCCL_CTRAN_BACKENDS [{}]",
@@ -166,7 +166,7 @@ CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
     } catch ([[maybe_unused]] const std::bad_alloc& e) {
       ctranIb = nullptr;
       enableBackends_[CtranMapperBackend::IB] = false;
-      CLOGF(WARN, "CTRAN-MAPPER: IB backend not enabled");
+      CTRAN_LOG(WARN, "CTRAN-MAPPER: IB backend not enabled");
     }
   }
   if (enableBackends_[CtranMapperBackend::SOCKET]) {
@@ -174,7 +174,7 @@ CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
       this->ctranSock = std::make_unique<class CtranSocket>(comm);
     } else {
       enableBackends_[CtranMapperBackend::SOCKET] = false;
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           INIT,
           "CTRAN-MAPPER: SOCKET backend not enabled, since IB backend is enabled");
@@ -183,7 +183,7 @@ CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
   if (enableBackends_[CtranMapperBackend::TCPDM]) {
     this->ctranTcpDm =
         std::make_unique<class ctran::CtranTcpDm>(comm, profiler);
-    CLOGF(WARN, "CTRAN-MAPPER: TCPDM backend is enabled");
+    CTRAN_LOG(WARN, "CTRAN-MAPPER: TCPDM backend is enabled");
   }
 
   if (enableBackends_[CtranMapperBackend::NVL]) {
@@ -194,11 +194,11 @@ CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
       } catch ([[maybe_unused]] const std::bad_alloc& e) {
         enableBackends_[CtranMapperBackend::NVL] = false;
         // FIXME: give more specific exception + error message
-        CLOGF(
+        CTRAN_LOG(
             WARN, "CTRAN-MAPPER: NVL backend not enabled. Error {}", e.what());
       }
     } else {
-      CLOGF(
+      CTRAN_LOG(
           WARN,
           "CTRAN-MAPPER: NVL backend not enabled. Require valid IB, TCPDM or Socket backend");
     }
@@ -232,7 +232,7 @@ CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
       ::ctran::utils::rangesToStr(::ctran::utils::getRanges(sockRanks));
   const auto tcpRanksRangesStr =
       ::ctran::utils::rangesToStr(::ctran::utils::getRanges(tcpRanks));
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-MAPPER: NVL ranks: {}, IB ranks: {}, SOCKET ranks: {}, TCPDM ranks: {}",
@@ -305,7 +305,7 @@ void CtranMapper::reportProfiling(bool flush) {
              << std::endl;
         }
         if (NCCL_CTRAN_PROFILING == NCCL_CTRAN_PROFILING::info) {
-          CLOGF(INFO, "{}", ss.str());
+          CTRAN_LOG(INFO, "{}", ss.str());
           ss.str("");
           ss.clear();
         }
@@ -324,7 +324,7 @@ void CtranMapper::reportProfiling(bool flush) {
           std::to_string(this->rank) + "." + hostname + std::string(".comm") +
           hashToHexStr(this->logMetaData_.commHash) + std::string(".") +
           std::to_string(reportCnt++) + std::string(".json"));
-      CLOGF(INFO, "Dumping ctran profile to {}", filename);
+      CTRAN_LOG(INFO, "Dumping ctran profile to {}", filename);
 
       int id = 0;
       stream << "[" << std::endl;
@@ -500,7 +500,7 @@ commResult_t CtranMapper::allGatherIpcServerAddrs() {
       peerIpcServerAddrs_.data(), sizeof(sockaddr_storage), myRank, nRanks);
   FB_COMMCHECK(static_cast<commResult_t>(std::move(resFuture).get()));
 
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-MAPPER: AllGathered IPC server addresses from {} ranks",
@@ -528,7 +528,7 @@ commResult_t CtranMapper::remReleaseMem(ctran::regcache::RegElem* regElem) {
   // If peers have imported this memory but the async socket is disabled,
   // we cannot notify them to release. This is a fatal inconsistency.
   if (!NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
-    CLOGF(
+    CTRAN_LOG(
         FATAL,
         "CTRAN-REGCACHE: ipcRegElem was exported to {} peers but "
         "NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET is disabled",
@@ -824,7 +824,7 @@ commResult_t CtranMapper::searchRegHandle(
 
   if (!regHdl_) {
     if (!allowDynamic) {
-      CERR(
+      CTRAN_ERR(
           commInvalidUsage,
           "CTRAN-MAPPER: buffer {} len {} is not pre-registered by user. ",
           buf,
@@ -838,7 +838,7 @@ commResult_t CtranMapper::searchRegHandle(
     FB_COMMCHECK(regCache->regDynamic(
         buf, len, cudaDev, enableBackends_, &regHdl_, &logMetaData_));
     *dynamicRegist = true;
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-MAPPER: buffer {} len {} is not pre-registered by user. "
         "We have to one-time register it and deregister immediately after "
@@ -983,7 +983,7 @@ ctran::transport::IP2pHostTransport* CtranMapper::getP2pTransport(
 
   CtranIb* ib = ctranIb.get();
   if (ib == nullptr) {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-MAPPER: getP2pTransport(peer={}): no IB backend on this mapper",
         peerRank);

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -1234,7 +1234,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
 
     if (*isComplete) {
       req->setComplete();
-      CLOGF_TRACE(
+      CTRAN_LOG_TRACE(
           COLL,
           "CTRAN-MAPPER: request {} completed, reqType {}, peer {}",
           (void*)this,
@@ -1285,7 +1285,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
           fmt::format("waitNotify for peer {}", notify->peer));
     }
 
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL, "CTRAN-MAPPER: check notify({}) completed", notify->toString());
     if (this->mapperTrace) {
       this->mapperTrace->recordMapperEvent(
@@ -1541,7 +1541,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
               .peerRank = peerRank,
               .req = req});
     }
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-MAPPER: Post {} SEND ctrlmsg to rank {} with req {} {} {}: {}",
         ctranIb ? "IB" : "SOCKET",
@@ -1581,7 +1581,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
               .peerRank = peerRank,
               .req = req});
     }
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-MAPPER: Post {} RECV ctrlmsg from rank {} with req {} {} {}: {}",
         ctranIb ? "IB" : "SOCKET",
@@ -1618,7 +1618,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
               .peerRank = peerRank,
               .req = req});
     }
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-MAPPER: Post {} SEND msg to rank {} with req {} {} {}: {}",
         ctranIb ? "IB" : "SOCKET",
@@ -1657,7 +1657,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
               .peerRank = peerRank,
               .req = req});
     }
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-MAPPER: Post {} RECV msg from rank {} with req {} {} {}: {}",
         ctranIb ? "IB" : "SOCKET",
@@ -1699,7 +1699,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       req.peer = peer;
       msg.ibDesc.remoteAddr = reinterpret_cast<uint64_t>(bufs[peer]);
       msg.aux = reqs[idx - 1].aux;
-      CLOGF_TRACE(
+      CTRAN_LOG_TRACE(
           COLL,
           "CTRAN-MAPPER: Post SEND ctrlmsg to rank {} with req {} ibReq {}: {}",
           req.peer,
@@ -1735,7 +1735,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
           ncclx::colltrace::SendSyncCtrlStart{
               .peerRank = peerRank, .req = req});
     }
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-MAPPER: Post {} SEND(SYNC) ctrlmsg to rank {} with req {} {} {}: {}",
         ctranIb ? "IB" : "SOCKET",
@@ -1773,7 +1773,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
           ncclx::colltrace::RecvSyncCtrlStart{
               .peerRank = peerRank, .req = req});
     }
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-MAPPER: Post {} RECV(SYNC) ctrlmsg from rank {} with req {} {} {}: {}",
         ctranIb ? "IB" : "SOCKET",
@@ -1830,7 +1830,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       struct ctran::regcache::RegElem* regElem =
           reinterpret_cast<struct ctran::regcache::RegElem*>(shdl);
       auto regLk = regElem->stateMnger.rlock();
-      CLOGF_TRACE(
+      CTRAN_LOG_TRACE(
           COLL,
           "CTRAN-MAPPER: Post IB PUT to rank {}: sbuf {} -> dbuf {} len {} kernElem {}",
           peerRank,
@@ -1906,7 +1906,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
 
       if (this->ctranIb != nullptr) {
         CtranIbRequest* ibReqPtr = (req == nullptr ? nullptr : &(req->ibReq));
-        CLOGF_TRACE(
+        CTRAN_LOG_TRACE(
             COLL,
             "CTRAN-MAPPER: Post IB PUT to rank {}: sbuf {} -> dbuf {} len {} kernElem {}",
             peerRank,
@@ -1958,7 +1958,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       }
     } else if (remoteAccessKey.backend == CtranMapperBackend::NVL) {
       iPutCount[CtranMapperBackend::NVL]++;
-      CLOGF_TRACE(
+      CTRAN_LOG_TRACE(
           COLL,
           "CTRAN-MAPPER: Post NVL PUT to rank {}: sbuf {} -> dbuf {} len {}",
           peerRank,
@@ -2038,7 +2038,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
 
       if (this->ctranIb != nullptr) {
         CtranIbRequest* ibReqPtr = (req == nullptr ? nullptr : &(req->ibReq));
-        CLOGF_TRACE(
+        CTRAN_LOG_TRACE(
             COLL,
             "CTRAN-MAPPER: Post IB Get to rank {}: sbuf {} -> dbuf {} len {}",
             peerRank,
@@ -2097,7 +2097,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       req->setConfig(config);
     }
     CtranIbRequest* ibReqPtr = (req == nullptr ? nullptr : &(req->ibReq));
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-MAPPER: Post IB ATOMIC_SET to rank {}: val {} dbuf {}",
         peerRank,
@@ -2171,7 +2171,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     }
 
     notify->update(peerRank, kernElem, backend, notifyCnt);
-    CLOGF_TRACE(
+    CTRAN_LOG_TRACE(
         COLL, "CTRAN-MAPPER: initialized notify {}", notify->toString());
     return commSuccess;
   }
@@ -2213,7 +2213,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     }
 
     if (*done) {
-      CLOGF_TRACE(
+      CTRAN_LOG_TRACE(
           COLL, "CTRAN-MAPPER: check notify({}) completed", notify->toString());
       if (this->mapperTrace) {
         this->mapperTrace->recordMapperEvent(

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -28,6 +28,7 @@
 #include "comms/ctran/transport/IP2pHostTransport.h"
 #include "comms/ctran/utils/AsyncError.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/CtranPerf.h"
 #include "comms/ctran/utils/Exception.h"
 #include "comms/utils/commSpecs.h"
@@ -214,7 +215,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
   }
 
   [[noreturn]] void throwTcpDmNotifyAbort(CtranMapperNotify* notify) {
-    CLOGF(
+    CTRAN_LOG(
         WARN,
         "CTRAN-MAPPER: TCPDM notify abort notify={} rank {} commHash {:x}",
         notify->toString(),
@@ -752,7 +753,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(
           const_cast<void*>(regHdl));
       if (!regElem) {
-        CLOGF(WARN, "CTRAN-MAPPER: No IB registration for flush, skip");
+        CTRAN_LOG(WARN, "CTRAN-MAPPER: No IB registration for flush, skip");
         return commSuccess;
       }
       auto regLk = regElem->stateMnger.rlock();
@@ -785,7 +786,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(
           const_cast<void*>(regHdl));
       if (!regElem) {
-        CLOGF(WARN, "CTRAN-MAPPER: No IB registration for flush, skip");
+        CTRAN_LOG(WARN, "CTRAN-MAPPER: No IB registration for flush, skip");
         return commSuccess;
       }
 
@@ -1219,7 +1220,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
           if (cudaErr == cudaSuccess) {
             *isComplete = true;
           } else if (cudaErr != cudaErrorNotReady) {
-            CERR(
+            CTRAN_ERR(
                 commSystemError,
                 "CTRAN: cudaStreamQuery returned error '{}'",
                 cudaGetErrorString(cudaErr));
@@ -1265,7 +1266,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         this->ctranTcpDm->cancelQueuedRecv(&notify->tcpDmReq);
       }
     } else {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-MAPPER: unexpected backend {}",
           notify->backend);
@@ -1370,7 +1371,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         FB_COMMCHECK(ipcRegCache->exportMem(
             buf, regElem->ipcRegElem, msg.ipcDesc, tmpExtraSegments));
         if (!tmpExtraSegments.empty()) {
-          CERR(
+          CTRAN_ERR(
               commInternalError,
               "CTRAN-MAPPER: exportMem to rank {} has overflow segments, which is "
               "not supported in this path.",
@@ -1390,7 +1391,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       // No need to export the buffers, TCP device memory is steered by
       // the receiver.
     } else {
-      CERR(
+      CTRAN_ERR(
           commInvalidUsage,
           "CTRAN-MAPPER: Cannot export buffer {} to rank {}. The rank may not be "
           "reachable by any backend, or buffer type is not supported.",
@@ -1420,7 +1421,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     switch (msg.type) {
       case ControlMsgType::IB_EXPORT_MEM:
         if (!this->ctranIb) {
-          CERR(
+          CTRAN_ERR(
               commInternalError,
               "CTRAN-MAPPER: IB backend is disabled but received unexpected internal control msg ({})",
               msg.toString());
@@ -1431,7 +1432,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         break;
       case ControlMsgType::NVL_EXPORT_MEM: {
         if (!this->ctranNvl) {
-          CERR(
+          CTRAN_ERR(
               commInternalError,
               "CTRAN-MAPPER: NVL backend is disabled but received unexpected internal control msg ({})",
               msg.toString());
@@ -1453,7 +1454,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         break;
       }
       default:
-        CERR(
+        CTRAN_ERR(
             commInternalError,
             "CTRAN-MAPPER: Received unexpected control message type {}",
             msg.type);
@@ -1480,7 +1481,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       const bool isCrossNode = this->ctranNvl->isNvlFabric(rank) &&
           !this->comm->statex_->isSameNode(this->comm->logMetaData_.rank, rank);
       if (isCrossNode && regElem->getType() != DevMemType::kCumem) {
-        CLOGF_SUBSYS(
+        CTRAN_LOG_SUBSYS(
             DBG,
             ALLOC,
             "CTRAN-MAPPER: cross-node nvlFabric peer rank {} with non-cuMem "
@@ -1513,7 +1514,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       return CtranMapperBackend::TCPDM;
     }
 
-    CLOGF(ERR, "No backend is available, please specify at least one backend.");
+    CTRAN_LOG(
+        ERR, "No backend is available, please specify at least one backend.");
 
     return CtranMapperBackend::UNSET;
   }
@@ -1630,7 +1632,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
           ControlMsgType::SYNC, payload, size, peerRank, req->ibReq);
     }
     // only support ib for now
-    CERR(
+    CTRAN_ERR(
         commInvalidArgument,
         "CTRAN-MAPPER: isendCtrlMsg only supports the IB backend for peerRank {}",
         peerRank);
@@ -1668,7 +1670,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       return ctranIb->irecvCtrlMsg<PerfConfig>(
           payload, size, peerRank, req->ibReq);
     }
-    CERR(
+    CTRAN_ERR(
         commInvalidArgument,
         "CTRAN-MAPPER: irecvCtrlMsg only supports the IB backend for peerRank {}",
         peerRank);
@@ -1750,7 +1752,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     } else if (ctranTcpDm) {
       return ctranTcpDm->isendCtrlMsg(msg, peerRank, req->tcpDmReq);
     }
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "CTRAN-MAPPER: isendCtrl found no available backend for peerRank {}",
         peerRank);
@@ -1787,7 +1789,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     } else if (ctranTcpDm) {
       return ctranTcpDm->irecvCtrlMsg(msg, peerRank, req->tcpDmReq);
     }
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "CTRAN-MAPPER: irecvCtrl found no available backend for peerRank {}",
         peerRank);
@@ -1800,7 +1802,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       const std::vector<CtranMapperPutMsg>& puts,
       int peerRank) {
     if (this->ctranIb == nullptr) {
-      CERR(commInternalError, "CTRAN-MAPPER: ctranIB is null in batch put.");
+      CTRAN_ERR(
+          commInternalError, "CTRAN-MAPPER: ctranIB is null in batch put.");
       return commInternalError;
     }
     std::vector<PutIbMsg> msgs;
@@ -1808,7 +1811,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     for (auto& put : puts) {
       const auto& remoteAccessKey = put.config.remoteAccessKey_;
       if (remoteAccessKey.backend != CtranMapperBackend::IB) {
-        CERR(
+        CTRAN_ERR(
             commInternalError,
             "CTRAN-MAPPER: Unsupported remote access key backend {}",
             backendToStr(remoteAccessKey.backend));
@@ -1926,13 +1929,13 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
             config.ibFastPath_));
       } else {
         if (req == nullptr) {
-          CERR(
+          CTRAN_ERR(
               commInternalError,
               "CTRAN-MAPPER: Unsupported TCPDM iput without request");
           return commInternalError;
         }
         if (!notify) {
-          CERR(
+          CTRAN_ERR(
               commInternalError,
               "CTRAN-MAPPER: Unsupported TCPDM iput without notify");
           return commInternalError;
@@ -1964,7 +1967,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
           len);
 
       if (!kernElem) {
-        CERR(
+        CTRAN_ERR(
             commInternalError,
             "CTRAN-MAPPER: NVL PUT requires valid kernElem. It indicates a COMM internal bug");
         return commInternalError;
@@ -1982,7 +1985,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       kernElem->post();
     } else {
       auto backendStr = backendToStr(remoteAccessKey.backend);
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-MAPPER: Unsupported remote access key backend {}",
           backendStr.c_str());
@@ -2022,7 +2025,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
           req->backend = CtranMapperBackend::IB;
           req->setConfig(config);
         } else {
-          CERR(
+          CTRAN_ERR(
               commInternalError,
               "CTRAN-MAPPER: Unsupported backend iget without IB backend");
           return commInternalError;
@@ -2055,7 +2058,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
             ibReqPtr,
             config.ibFastPath_));
       } else {
-        CERR(
+        CTRAN_ERR(
             commInternalError,
             "CTRAN-MAPPER: IB backend required for iget operation, but not available.");
 
@@ -2063,7 +2066,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       }
     } else {
       auto backendStr = backendToStr(remoteAccessKey.backend);
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-MAPPER: Unsupported remote access key backend {}",
           backendStr.c_str());
@@ -2082,7 +2085,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperRequest* req) {
     const auto& remoteAccessKey = config.remoteAccessKey_;
     if (remoteAccessKey.backend != CtranMapperBackend::IB) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-MAPPER: atomicSet only supports IB backend");
       return commInternalError;
@@ -2136,7 +2139,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         rbuff = kernElem->waitNotify.recvbuff;
         len = kernElem->waitNotify.nbytes;
         if (rbuff == nullptr || len == 0) {
-          CERR(
+          CTRAN_ERR(
               commInternalError,
               "TCP Device Memory requires recvbuff in the notifier");
           return commInternalError;
@@ -2144,7 +2147,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       } else {
         const DevMemType type = regElem->getType();
         if (type != kHostUnregistered && type != kHostPinned) {
-          CERR(
+          CTRAN_ERR(
               commInternalError,
               "TCP Device Memory requires kernElem in the notifier "
               "(memType {})",
@@ -2198,7 +2201,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       FB_COMMCHECK(this->ctranTcpDm->progress());
       FB_COMMCHECK(this->ctranTcpDm->checkNotify(notify->peer, done));
     } else {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-MAPPER: unexpected backend {}",
           notify->backend);
@@ -2244,7 +2247,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         // Only icopy request doesn't have peer; expect it is not used in
         // testSomeRequests with timepoints.
         if (req->peer == -1) {
-          CERR(commInternalError, "Expect peer is specified in request.");
+          CTRAN_ERR(commInternalError, "Expect peer is specified in request.");
           return commInternalError;
         }
 
@@ -2276,7 +2279,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     for (auto it = reqs.begin(); it != reqs.end(); it++) {
       auto& req = *it;
       if (req.peer == -1) {
-        CERR(commInternalError, "Expect peer is specified in request.");
+        CTRAN_ERR(commInternalError, "Expect peer is specified in request.");
         return commInternalError;
       }
       FB_COMMCHECK(waitRequest<PerfConfig>(&req));
@@ -2294,7 +2297,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperRequest** req,
       const char* fnName) {
     if (req == nullptr) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-MAPPER: Invalid request pointer. Unexpected {} indicates a COMM internal bug",
           fnName);
@@ -2310,7 +2313,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperRequest* req,
       const char* fnName) {
     if (req == nullptr) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-MAPPER: Invalid request pointer. Unexpected {} indicates a COMM internal bug",
           fnName);

--- a/comms/ctran/mapper/CtranMapperRequest.cc
+++ b/comms/ctran/mapper/CtranMapperRequest.cc
@@ -3,6 +3,7 @@
 #include "comms/ctran/gpe/CtranGpeDev.h"
 #include "comms/ctran/mapper/CtranMapperTypes.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 
 static std::unordered_map<CtranMapperRequest::ReqType, std::string> reqTypeStr =
     {{CtranMapperRequest::ReqType::SEND_CTRL, "SEND_CTRL"},
@@ -29,7 +30,7 @@ CtranMapperRequest::CtranMapperRequest(
   }
   if (backend != CtranMapperBackend::IB &&
       backend != CtranMapperBackend::SOCKET) {
-    CLOGF(
+    CTRAN_LOG(
         ERR,
         "CTRAN-MAPPER: Unsupported backend {} for CtranMapperRequest",
         backend);

--- a/comms/ctran/utils/Checks.h
+++ b/comms/ctran/utils/Checks.h
@@ -6,10 +6,10 @@
 #include <errno.h>
 #include <folly/Format.h>
 
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/Exception.h"
 #include "comms/utils/Conversion.h"
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/LogUtils.h"
 
 /**
  * Error check macros.
@@ -33,7 +33,7 @@
     cudaError_t err = cmd;                   \
     if (err != cudaSuccess) {                \
       auto errStr = cudaGetErrorString(err); \
-      CERR(                                  \
+      CTRAN_ERR(                             \
           commUnhandledCudaError,            \
           "Cuda failure {} '{}'",            \
           static_cast<int>(err),             \
@@ -48,7 +48,7 @@
   do {                                                             \
     cudaError_t err = cmd;                                         \
     if (err != cudaSuccess) {                                      \
-      CERR(                                                        \
+      CTRAN_ERR(                                                   \
           commUnhandledCudaError,                                  \
           "{}:{} Cuda failure {}",                                 \
           __FILE__,                                                \
@@ -95,30 +95,31 @@
   do {                                                                         \
     cudaError_t err = cmd;                                                     \
     if (err != cudaSuccess) {                                                  \
-      CERR(                                                                    \
+      CTRAN_ERR(                                                               \
           commUnhandledCudaError, "Cuda failure {}", cudaGetErrorString(err)); \
       RES = commUnhandledCudaError;                                            \
       goto label;                                                              \
     }                                                                          \
   } while (false)
 
-#define FB_CUCHECKGOTO(cmd, RES, label)                                     \
-  do {                                                                      \
-    CUresult err = cmd;                                                     \
-    if (err != CUDA_SUCCESS) {                                              \
-      const char* errStr;                                                   \
-      cuGetErrorString(err, &errStr);                                       \
-      CERR(commUnhandledCudaError, "Cuda failure {}", std::string(errStr)); \
-      RES = commUnhandledCudaError;                                         \
-      goto label;                                                           \
-    }                                                                       \
+#define FB_CUCHECKGOTO(cmd, RES, label)                                    \
+  do {                                                                     \
+    CUresult err = cmd;                                                    \
+    if (err != CUDA_SUCCESS) {                                             \
+      const char* errStr;                                                  \
+      cuGetErrorString(err, &errStr);                                      \
+      CTRAN_ERR(                                                           \
+          commUnhandledCudaError, "Cuda failure {}", std::string(errStr)); \
+      RES = commUnhandledCudaError;                                        \
+      goto label;                                                          \
+    }                                                                      \
   } while (false)
 
 #define FB_CUDACHECKGUARD(cmd, RES)                                            \
   do {                                                                         \
     cudaError_t err = cmd;                                                     \
     if (err != cudaSuccess) {                                                  \
-      CERR(                                                                    \
+      CTRAN_ERR(                                                               \
           commUnhandledCudaError, "Cuda failure {}", cudaGetErrorString(err)); \
       RES = commUnhandledCudaError;                                            \
       return;                                                                  \
@@ -130,7 +131,7 @@
   do {                              \
     cudaError_t err = cmd;          \
     if (err != cudaSuccess) {       \
-      CLOGF(                        \
+      CTRAN_LOG(                    \
           WARN,                     \
           "{}:{} Cuda failure {}",  \
           __FILE__,                 \
@@ -146,51 +147,55 @@
   do {                                                                         \
     cudaError_t err = cmd;                                                     \
     if (err != cudaSuccess) {                                                  \
-      CERR(                                                                    \
+      CTRAN_ERR(                                                               \
           commUnhandledCudaError, "Cuda failure {}", cudaGetErrorString(err)); \
       abort();                                                                 \
     }                                                                          \
   } while (false)
 
-#define FB_SYSCHECK(statement, name)                                         \
+#define FB_SYSCHECK(statement, name)                                        \
+  do {                                                                      \
+    int retval;                                                             \
+    FB_SYSCHECKSYNC((statement), name, retval);                             \
+    if (retval == -1) {                                                     \
+      CTRAN_ERR(                                                            \
+          commSystemError, "Call to " name " failed: {}", strerror(errno)); \
+      return commSystemError;                                               \
+    }                                                                       \
+  } while (false)
+
+#define FB_SYSCHECKVAL(call, name, retval)                                   \
   do {                                                                       \
-    int retval;                                                              \
-    FB_SYSCHECKSYNC((statement), name, retval);                              \
+    FB_SYSCHECKSYNC(call, name, retval);                                     \
     if (retval == -1) {                                                      \
-      CERR(commSystemError, "Call to " name " failed: {}", strerror(errno)); \
+      CTRAN_ERR(                                                             \
+          commSystemError, "Call to " name " failed : {}", strerror(errno)); \
       return commSystemError;                                                \
     }                                                                        \
   } while (false)
 
-#define FB_SYSCHECKVAL(call, name, retval)                                    \
-  do {                                                                        \
-    FB_SYSCHECKSYNC(call, name, retval);                                      \
-    if (retval == -1) {                                                       \
-      CERR(commSystemError, "Call to " name " failed : {}", strerror(errno)); \
-      return commSystemError;                                                 \
-    }                                                                         \
-  } while (false)
-
-#define FB_SYSCHECKSYNC(statement, name, retval)                             \
-  do {                                                                       \
-    retval = (statement);                                                    \
-    if (retval == -1 &&                                                      \
-        (errno == EINTR || errno == EWOULDBLOCK || errno == EAGAIN)) {       \
-      CLOGF(ERR, "Call to " name " returned {}, retrying", strerror(errno)); \
-    } else {                                                                 \
-      break;                                                                 \
-    }                                                                        \
+#define FB_SYSCHECKSYNC(statement, name, retval)                           \
+  do {                                                                     \
+    retval = (statement);                                                  \
+    if (retval == -1 &&                                                    \
+        (errno == EINTR || errno == EWOULDBLOCK || errno == EAGAIN)) {     \
+      CTRAN_LOG(                                                           \
+          ERR, "Call to " name " returned {}, retrying", strerror(errno)); \
+    } else {                                                               \
+      break;                                                               \
+    }                                                                      \
   } while (true)
 
-#define FB_SYSCHECKGOTO(statement, name, RES, label)                         \
-  do {                                                                       \
-    int retval;                                                              \
-    FB_SYSCHECKSYNC((statement), name, retval);                              \
-    if (retval == -1) {                                                      \
-      CERR(commSystemError, "Call to " name " failed: {}", strerror(errno)); \
-      RES = commSystemError;                                                 \
-      goto label;                                                            \
-    }                                                                        \
+#define FB_SYSCHECKGOTO(statement, name, RES, label)                        \
+  do {                                                                      \
+    int retval;                                                             \
+    FB_SYSCHECKSYNC((statement), name, retval);                             \
+    if (retval == -1) {                                                     \
+      CTRAN_ERR(                                                            \
+          commSystemError, "Call to " name " failed: {}", strerror(errno)); \
+      RES = commSystemError;                                                \
+      goto label;                                                           \
+    }                                                                       \
   } while (0)
 
 #define FB_SYSCHECKTHROW_EX_DIRECT(cmd, rank, commHash, desc) \
@@ -198,7 +203,7 @@
     int err = cmd;                                            \
     if (err != 0) {                                           \
       auto errstr = folly::errnoStr(err);                     \
-      CERR(                                                   \
+      CTRAN_ERR(                                              \
           commSystemError,                                    \
           "{}:{} -> {} ({})",                                 \
           __FILE__,                                           \
@@ -240,7 +245,7 @@
     int err = cmd;                        \
     if (err != 0) {                       \
       auto errstr = folly::errnoStr(err); \
-      CERR(                               \
+      CTRAN_ERR(                          \
           commSystemError,                \
           "{}:{} -> {} ({})",             \
           __FILE__,                       \
@@ -252,30 +257,32 @@
   } while (0)
 
 // Pthread calls don't set errno and never return EINTR.
-#define FB_PTHREADCHECK(statement, name)                                      \
-  do {                                                                        \
-    int retval = (statement);                                                 \
-    if (retval != 0) {                                                        \
-      CERR(commSystemError, "Call to " name " failed: {}", strerror(retval)); \
-      return commSystemError;                                                 \
-    }                                                                         \
+#define FB_PTHREADCHECK(statement, name)                                     \
+  do {                                                                       \
+    int retval = (statement);                                                \
+    if (retval != 0) {                                                       \
+      CTRAN_ERR(                                                             \
+          commSystemError, "Call to " name " failed: {}", strerror(retval)); \
+      return commSystemError;                                                \
+    }                                                                        \
   } while (0)
 
-#define FB_PTHREADCHECKGOTO(statement, name, RES, label)                      \
-  do {                                                                        \
-    int retval = (statement);                                                 \
-    if (retval != 0) {                                                        \
-      CERR(commSystemError, "Call to " name " failed: {}", strerror(retval)); \
-      RES = commSystemError;                                                  \
-      goto label;                                                             \
-    }                                                                         \
+#define FB_PTHREADCHECKGOTO(statement, name, RES, label)                     \
+  do {                                                                       \
+    int retval = (statement);                                                \
+    if (retval != 0) {                                                       \
+      CTRAN_ERR(                                                             \
+          commSystemError, "Call to " name " failed: {}", strerror(retval)); \
+      RES = commSystemError;                                                 \
+      goto label;                                                            \
+    }                                                                        \
   } while (0)
 
 #define FB_NEQCHECK(statement, value) \
   do {                                \
     if ((statement) != value) {       \
       /* Print the back trace*/       \
-      CERR(                           \
+      CTRAN_ERR(                      \
           commSystemError,            \
           "{}:{} -> {} ({})",         \
           __FILE__,                   \
@@ -291,7 +298,7 @@
     if ((statement) != value) {                       \
       /* Print the back trace*/                       \
       RES = commSystemError;                          \
-      CERR(                                           \
+      CTRAN_ERR(                                      \
           commSystemError,                            \
           "{}:{} -> {} ({})",                         \
           __FILE__,                                   \
@@ -306,7 +313,7 @@
   do {                               \
     if ((statement) == value) {      \
       /* Print the back trace*/      \
-      CERR(                          \
+      CTRAN_ERR(                     \
           commSystemError,           \
           "{}:{} -> {} ({})",        \
           __FILE__,                  \
@@ -322,7 +329,7 @@
     if ((statement) == value) {                      \
       /* Print the back trace*/                      \
       RES = commSystemError;                         \
-      CERR(                                          \
+      CTRAN_ERR(                                     \
           commSystemError,                           \
           "{}:{} -> {} ({})",                        \
           __FILE__,                                  \
@@ -334,20 +341,20 @@
   } while (0)
 
 // Propagate errors up
-#define FB_COMMCHECK(call)                                \
-  do {                                                    \
-    commResult_t RES = call;                              \
-    if (RES != commSuccess && RES != commInProgress) {    \
-      CLOGF(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
-      return RES;                                         \
-    }                                                     \
+#define FB_COMMCHECK(call)                                    \
+  do {                                                        \
+    commResult_t RES = call;                                  \
+    if (RES != commSuccess && RES != commInProgress) {        \
+      CTRAN_LOG(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
+      return RES;                                             \
+    }                                                         \
   } while (0)
 
 // Propagate errors up for ibverbx
 #define FOLLY_EXPECTED_CHECK(RES) \
   do {                            \
     if (RES.hasError()) {         \
-      CERR(                       \
+      CTRAN_ERR(                  \
           commSystemError,        \
           "{}:{} -> {}, {}",      \
           __FILE__,               \
@@ -361,7 +368,7 @@
 #define FOLLY_EXPECTED_CHECKTHROW_EX(RES, commLogData)                 \
   do {                                                                 \
     if (RES.hasError()) {                                              \
-      CLOGF(                                                           \
+      CTRAN_LOG(                                                       \
           ERR,                                                         \
           "{}:{} -> {} ({})",                                          \
           __FILE__,                                                    \
@@ -381,7 +388,7 @@
 #define FOLLY_EXPECTED_CHECKTHROW_EX_NOCOMM(RES)                       \
   do {                                                                 \
     if (RES.hasError()) {                                              \
-      CLOGF(                                                           \
+      CTRAN_LOG(                                                       \
           ERR,                                                         \
           "{}:{} -> {} ({})",                                          \
           __FILE__,                                                    \
@@ -397,7 +404,7 @@
 #define FOLLY_EXPECTED_CHECKGOTO(RES, label, info) \
   do {                                             \
     if (RES.hasError()) {                          \
-      CLOGF(                                       \
+      CTRAN_LOG(                                   \
           ERR,                                     \
           "{}:{} -> {} ({}). {}",                  \
           __FILE__,                                \
@@ -413,7 +420,7 @@
   do {                                                             \
     commResult_t RES = cmd;                                        \
     if (RES != commSuccess && RES != commInProgress) {             \
-      CLOGF(                                                       \
+      CTRAN_LOG(                                                   \
           ERR,                                                     \
           "{}:{} -> {} ({})",                                      \
           __FILE__,                                                \
@@ -455,7 +462,7 @@
   do {                                                 \
     commResult_t RES = cmd;                            \
     if (RES != commSuccess && RES != commInProgress) { \
-      CLOGF(                                           \
+      CTRAN_LOG(                                       \
           ERR,                                         \
           "{}:{} -> {} ({})",                          \
           __FILE__,                                    \
@@ -469,13 +476,13 @@
     }                                                  \
   } while (0)
 
-#define FB_COMMCHECKGOTO(call, RES, label)                \
-  do {                                                    \
-    RES = call;                                           \
-    if (RES != commSuccess && RES != commInProgress) {    \
-      CLOGF(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
-      goto label;                                         \
-    }                                                     \
+#define FB_COMMCHECKGOTO(call, RES, label)                    \
+  do {                                                        \
+    RES = call;                                               \
+    if (RES != commSuccess && RES != commInProgress) {        \
+      CTRAN_LOG(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
+      goto label;                                             \
+    }                                                         \
   } while (0)
 
 // Report failure but clear error and continue
@@ -483,7 +490,7 @@
   do {                                                 \
     commResult_t RES = call;                           \
     if (RES != commSuccess && RES != commInProgress) { \
-      CLOGF(                                           \
+      CTRAN_LOG(                                       \
           WARN,                                        \
           "{}:{}:{} -> {} ({})",                       \
           __FILE__,                                    \
@@ -494,39 +501,39 @@
     }                                                  \
   } while (0)
 
-#define FB_CHECKABORT(statement, ...)             \
-  do {                                            \
-    if (!(statement)) {                           \
-      CLOGF(ERR, "Check failed: {}", #statement); \
-      CLOGF(ERR, ##__VA_ARGS__);                  \
-      abort();                                    \
-    }                                             \
+#define FB_CHECKABORT(statement, ...)                     \
+  do {                                                    \
+    if (!(statement)) {                                   \
+      CTRAN_LOG_SYNC_ERR("Check failed: {}", #statement); \
+      CTRAN_LOG_SYNC_ERR(__VA_ARGS__);                    \
+      abort();                                            \
+    }                                                     \
   } while (0);
 
-#define FB_CHECKTHROW_EX_DIRECT(statement, rank, commHash, commDesc, msg) \
-  do {                                                                    \
-    if (!(statement)) {                                                   \
-      CERR(commInternalError, "Check failed: {} - {}", #statement, msg);  \
-      throw ctran::utils::Exception(                                      \
-          fmt::format("Check failed: {} - {}", #statement, msg),          \
-          commInternalError,                                              \
-          rank,                                                           \
-          commHash,                                                       \
-          commDesc);                                                      \
-    }                                                                     \
+#define FB_CHECKTHROW_EX_DIRECT(statement, rank, commHash, commDesc, msg)     \
+  do {                                                                        \
+    if (!(statement)) {                                                       \
+      CTRAN_ERR(commInternalError, "Check failed: {} - {}", #statement, msg); \
+      throw ctran::utils::Exception(                                          \
+          fmt::format("Check failed: {} - {}", #statement, msg),              \
+          commInternalError,                                                  \
+          rank,                                                               \
+          commHash,                                                           \
+          commDesc);                                                          \
+    }                                                                         \
   } while (0)
 
-#define FB_CHECKTHROW_EX_LOGDATA(statement, commLogData, msg)            \
-  do {                                                                   \
-    if (!(statement)) {                                                  \
-      CERR(commInternalError, "Check failed: {} - {}", #statement, msg); \
-      throw ctran::utils::Exception(                                     \
-          fmt::format("Check failed: {} - {}", #statement, msg),         \
-          commInternalError,                                             \
-          (commLogData).rank,                                            \
-          (commLogData).commHash,                                        \
-          (commLogData).commDesc);                                       \
-    }                                                                    \
+#define FB_CHECKTHROW_EX_LOGDATA(statement, commLogData, msg)                 \
+  do {                                                                        \
+    if (!(statement)) {                                                       \
+      CTRAN_ERR(commInternalError, "Check failed: {} - {}", #statement, msg); \
+      throw ctran::utils::Exception(                                          \
+          fmt::format("Check failed: {} - {}", #statement, msg),              \
+          commInternalError,                                                  \
+          (commLogData).rank,                                                 \
+          (commLogData).commHash,                                             \
+          (commLogData).commDesc);                                            \
+    }                                                                         \
   } while (0)
 
 // Selector macro, used with FB_CHECKTHROW_EX to delegate
@@ -553,21 +560,21 @@
     if (!(statement)) {                                                  \
       auto errorMsg =                                                    \
           fmt::format("Check failed: {} - {}", #statement, __VA_ARGS__); \
-      CERR(commInternalError, "{}", errorMsg);                           \
+      CTRAN_ERR(commInternalError, "{}", errorMsg);                      \
       throw ctran::utils::Exception(errorMsg, commInternalError);        \
     }                                                                    \
   } while (0)
 
-#define FB_COMMWAIT(call, cond, abortFlagPtr)             \
-  do {                                                    \
-    uint32_t* tmpAbortFlag = (abortFlagPtr);              \
-    commResult_t RES = call;                              \
-    if (RES != commSuccess && RES != commInProgress) {    \
-      CLOGF(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
-      return commInternalError;                           \
-    }                                                     \
-    if (__atomic_load(tmpAbortFlag, __ATOMIC_ACQUIRE))    \
-      FB_NEQCHECK(*tmpAbortFlag, 0);                      \
+#define FB_COMMWAIT(call, cond, abortFlagPtr)                 \
+  do {                                                        \
+    uint32_t* tmpAbortFlag = (abortFlagPtr);                  \
+    commResult_t RES = call;                                  \
+    if (RES != commSuccess && RES != commInProgress) {        \
+      CTRAN_LOG(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
+      return commInternalError;                               \
+    }                                                         \
+    if (__atomic_load(tmpAbortFlag, __ATOMIC_ACQUIRE))        \
+      FB_NEQCHECK(*tmpAbortFlag, 0);                          \
   } while (!(cond))
 
 #define FB_COMMWAITGOTO(call, cond, abortFlagPtr, RES, label) \
@@ -575,7 +582,7 @@
     uint32_t* tmpAbortFlag = (abortFlagPtr);                  \
     RES = call;                                               \
     if (RES != commSuccess && RES != commInProgress) {        \
-      CLOGF(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES);     \
+      CTRAN_LOG(ERR, "{}:{} -> {}", __FILE__, __LINE__, RES); \
       goto label;                                             \
     }                                                         \
     if (__atomic_load(tmpAbortFlag, __ATOMIC_ACQUIRE))        \
@@ -585,7 +592,7 @@
 #define FB_COMMCHECKTHREAD(a, args)                                            \
   do {                                                                         \
     if (((args)->ret = (a)) != commSuccess && (args)->ret != commInProgress) { \
-      CLOGF_SUBSYS(                                                            \
+      CTRAN_LOG_SUBSYS(                                                        \
           ERR,                                                                 \
           INIT,                                                                \
           "{}:{} -> {} [Async thread]",                                        \
@@ -600,7 +607,7 @@
   do {                                    \
     if ((a) != cudaSuccess) {             \
       args->ret = commUnhandledCudaError; \
-      CERR(                               \
+      CTRAN_ERR(                          \
           commUnhandledCudaError,         \
           "{}:{} -> {} [Async thread]",   \
           __FILE__,                       \
@@ -610,23 +617,23 @@
     }                                     \
   } while (0)
 
-#define FB_COMMARGCHECK(statement, ...)         \
-  do {                                          \
-    if (!(statement)) {                         \
-      CERR(commInvalidArgument, ##__VA_ARGS__); \
-      return commInvalidArgument;               \
-    }                                           \
+#define FB_COMMARGCHECK(statement, ...)              \
+  do {                                               \
+    if (!(statement)) {                              \
+      CTRAN_ERR(commInvalidArgument, ##__VA_ARGS__); \
+      return commInvalidArgument;                    \
+    }                                                \
   } while (0);
 
-#define FB_ERRORRETURN(error, ...) \
-  do {                             \
-    CERR(error, ##__VA_ARGS__);    \
-    return error;                  \
+#define FB_ERRORRETURN(error, ...)   \
+  do {                               \
+    CTRAN_ERR(error, ##__VA_ARGS__); \
+    return error;                    \
   } while (0)
 
 #define FB_ERRORTHROW_EX(error, logData, ...)       \
   do {                                              \
-    CLOGF(ERR, ##__VA_ARGS__);                      \
+    CTRAN_LOG(ERR, ##__VA_ARGS__);                  \
     throw ctran::utils::Exception(                  \
         std::string("COMM internal failure: ") +    \
             ::meta::comms::commCodeToString(error), \
@@ -639,7 +646,7 @@
 // For contexts where rank/commHash are not available
 #define FB_ERRORTHROW_EX_NOCOMM(error, ...)         \
   do {                                              \
-    CLOGF(ERR, ##__VA_ARGS__);                      \
+    CTRAN_LOG(ERR, ##__VA_ARGS__);                  \
     throw ctran::utils::Exception(                  \
         std::string("COMM internal failure: ") +    \
             ::meta::comms::commCodeToString(error), \

--- a/comms/ctran/utils/CtranLogger.h
+++ b/comms/ctran/utils/CtranLogger.h
@@ -16,6 +16,18 @@ inline constexpr std::string_view kCtranLoggerName = "comms.ctran";
 #define CTRAN_LOG(level, ...) \
   COMMS_LOG_NAMED(::ctran::logging::kCtranLoggerName, level, __VA_ARGS__)
 
+#define CTRAN_LOG_SYNC_ERR(...)                                      \
+  do {                                                               \
+    auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger(    \
+        ::ctran::logging::kCtranLoggerName);                         \
+    if (_ctran_logger.should_log(::spdlog::level::err)) {            \
+      _ctran_logger.logSynchronous(                                  \
+          ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, \
+          ::spdlog::level::err,                                      \
+          __VA_ARGS__);                                              \
+    }                                                                \
+  } while (false)
+
 #define CTRAN_LOG_IF_IMPL(level, spdlog_level, condition, ...)    \
   do {                                                            \
     auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger( \

--- a/comms/ctran/utils/CudaWrap.h
+++ b/comms/ctran/utils/CudaWrap.h
@@ -5,7 +5,7 @@
 #include <cuda_runtime.h>
 #include <fmt/format.h>
 
-#include "comms/utils/logger/LogUtils.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 
 #if CUDART_VERSION >= 11030
 #include <cudaTypedefs.h> // @manual
@@ -56,7 +56,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {              \
       const char* errStr;                   \
       (void)cuGetErrorString(err, &errStr); \
-      CERR(                                 \
+      CTRAN_ERR(                            \
           commUnhandledCudaError,           \
           "Cuda failure {} '{}'",           \
           static_cast<int>(err),            \
@@ -71,7 +71,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {              \
       const char* errStr;                   \
       (void)cuGetErrorString(err, &errStr); \
-      CERR(                                 \
+      CTRAN_ERR(                            \
           commUnhandledCudaError,           \
           "Cuda failure {} '{}'",           \
           static_cast<int>(err),            \
@@ -86,7 +86,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {           \
       const char* errStr;                \
       cuGetErrorString(err, &errStr);    \
-      CERR(                              \
+      CTRAN_ERR(                         \
           commUnhandledCudaError,        \
           "Cuda failure {} '{}'",        \
           static_cast<int>(err),         \
@@ -96,14 +96,14 @@ namespace ctran::utils {
     }                                    \
   } while (false)
 
-#define FB_CUCHECKRES(res)                                               \
-  do {                                                                   \
-    if (res != CUDA_SUCCESS) {                                           \
-      const char* errStr;                                                \
-      (void)cuGetErrorString(res, &errStr);                              \
-      CERR(commUnhandledCudaError, "Cuda failure {} '{}'", res, errStr); \
-      return commUnhandledCudaError;                                     \
-    }                                                                    \
+#define FB_CUCHECKRES(res)                                                    \
+  do {                                                                        \
+    if (res != CUDA_SUCCESS) {                                                \
+      const char* errStr;                                                     \
+      (void)cuGetErrorString(res, &errStr);                                   \
+      CTRAN_ERR(commUnhandledCudaError, "Cuda failure {} '{}'", res, errStr); \
+      return commUnhandledCudaError;                                          \
+    }                                                                         \
   } while (false)
 
 // Report failure but clear error and continue
@@ -113,7 +113,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {              \
       const char* errStr;                   \
       (void)cuGetErrorString(err, &errStr); \
-      CLOGF(                                \
+      CTRAN_LOG(                            \
           WARN,                             \
           "{}:{} Cuda failure {} '{}'",     \
           __FILE__,                         \
@@ -127,7 +127,7 @@ namespace ctran::utils {
   do {                                    \
     CUresult err = cmd;                   \
     if (err != CUDA_SUCCESS) {            \
-      CERR(                               \
+      CTRAN_ERR(                          \
           commUnhandledCudaError,         \
           "{}:{} -> {} [Async thread]",   \
           __FILE__,                       \
@@ -149,7 +149,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {                                  \
       const char* errStr;                                       \
       (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr); \
-      CERR(                                                     \
+      CTRAN_ERR(                                                \
           commUnhandledCudaError,                               \
           "Cuda failure {} '{}'",                               \
           static_cast<int>(err),                                \
@@ -164,7 +164,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {                                  \
       const char* errStr;                                       \
       (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr); \
-      CERR(                                                     \
+      CTRAN_ERR(                                                \
           commUnhandledCudaError,                               \
           "Cuda failure {} '{}'",                               \
           static_cast<int>(err),                                \
@@ -179,7 +179,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {                                  \
       const char* errStr;                                       \
       (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr); \
-      CERR(                                                     \
+      CTRAN_ERR(                                                \
           commUnhandledCudaError,                               \
           "Cuda failure {} '{}'",                               \
           static_cast<int>(err),                                \
@@ -189,14 +189,14 @@ namespace ctran::utils {
     }                                                           \
   } while (false)
 
-#define FB_CUCHECKRES(res)                                               \
-  do {                                                                   \
-    if (res != CUDA_SUCCESS) {                                           \
-      const char* errStr;                                                \
-      (void)::ctran::utils::pfn_cuGetErrorString(res, &errStr);          \
-      CERR(commUnhandledCudaError, "Cuda failure {} '{}'", res, errStr); \
-      return commUnhandledCudaError;                                     \
-    }                                                                    \
+#define FB_CUCHECKRES(res)                                                    \
+  do {                                                                        \
+    if (res != CUDA_SUCCESS) {                                                \
+      const char* errStr;                                                     \
+      (void)::ctran::utils::pfn_cuGetErrorString(res, &errStr);               \
+      CTRAN_ERR(commUnhandledCudaError, "Cuda failure {} '{}'", res, errStr); \
+      return commUnhandledCudaError;                                          \
+    }                                                                         \
   } while (false)
 
 // Report failure but clear error and continue
@@ -206,7 +206,7 @@ namespace ctran::utils {
     if (err != CUDA_SUCCESS) {                                  \
       const char* errStr;                                       \
       (void)::ctran::utils::pfn_cuGetErrorString(err, &errStr); \
-      CLOGF(                                                    \
+      CTRAN_LOG(                                                \
           WARN,                                                 \
           "{}:{} Cuda failure {} '{}'",                         \
           __FILE__,                                             \
@@ -220,7 +220,7 @@ namespace ctran::utils {
   do {                                        \
     CUresult err = ::ctran::utils::pfn_##cmd; \
     if (err != CUDA_SUCCESS) {                \
-      CERR(                                   \
+      CTRAN_ERR(                              \
           commUnhandledCudaError,             \
           "{}:{} -> {} [Async thread]",       \
           __FILE__,                           \

--- a/comms/ctran/utils/tests/ChecksUT.cc
+++ b/comms/ctran/utils/tests/ChecksUT.cc
@@ -1,7 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <string>
-#include <vector>
 
 #include <cuda_runtime.h>
 #include <fmt/core.h>
@@ -9,12 +8,11 @@
 #include <gtest/gtest.h>
 
 #include <gmock/gmock.h>
-#include "TestLogCategory.h"
 #include "comms/ctran/utils/ArgCheck.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/LogInit.h"
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/Logger.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 class CtranUtilsCheckTest : public ::testing::Test {
  public:
@@ -22,20 +20,28 @@ class CtranUtilsCheckTest : public ::testing::Test {
 
   void SetUp() override {
     ctran::logging::initCtranLogging(true /*alwaysInit*/);
-
-    // Set up a test category
-    auto* category =
-        folly::LoggerDB::get().getCategory(XLOG_GET_CATEGORY_NAME());
-    ASSERT_TRUE(testCategory_.setup(category));
+    auto& logger =
+        meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName);
+    logger.configure("CTRAN", []() { return 0; }, {}, false);
+    logger.set_level(spdlog::level::info);
+    testing::internal::CaptureStdout();
+    capturingStdout_ = true;
   }
 
   void TearDown() override {
-    NcclLogger::close();
-    testCategory_.reset();
+    if (capturingStdout_) {
+      testing::internal::GetCapturedStdout();
+    }
+    auto& logger =
+        meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName);
+    logger.configure("CTRAN", []() { return 0; }, {}, false);
   }
 
-  const std::vector<std::string>& getMessages() const {
-    return testCategory_.getMessages();
+  std::string getOutput() {
+    meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName)
+        .flush();
+    capturingStdout_ = false;
+    return testing::internal::GetCapturedStdout();
   }
 
   const int getCurrentGpuIndex() {
@@ -53,7 +59,7 @@ class CtranUtilsCheckTest : public ::testing::Test {
   }
 
  private:
-  TestLogCategory testCategory_;
+  bool capturingStdout_{false};
 };
 
 TEST_F(CtranUtilsCheckTest, CudaCheck) {
@@ -65,10 +71,9 @@ TEST_F(CtranUtilsCheckTest, CudaCheck) {
   auto res = dummyFn();
   ASSERT_EQ(res, commUnhandledCudaError);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("invalid argument"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
+  EXPECT_THAT(output, ::testing::HasSubstr("invalid argument"));
 }
 
 TEST_F(CtranUtilsCheckTest, CudaCheckGoto) {
@@ -82,10 +87,9 @@ TEST_F(CtranUtilsCheckTest, CudaCheckGoto) {
   auto res = dummyFn();
   ASSERT_EQ(res, commUnhandledCudaError);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("unspecified launch failure"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
+  EXPECT_THAT(output, ::testing::HasSubstr("unspecified launch failure"));
 }
 
 TEST_F(CtranUtilsCheckTest, CudaCheckIgnore) {
@@ -96,10 +100,9 @@ TEST_F(CtranUtilsCheckTest, CudaCheckIgnore) {
   auto res = dummyFn();
   ASSERT_EQ(res, commSuccess);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN WARN"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("invalid argument"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN WARN"));
+  EXPECT_THAT(output, ::testing::HasSubstr("invalid argument"));
 }
 
 TEST_F(CtranUtilsCheckTest, SysCheck) {
@@ -111,10 +114,9 @@ TEST_F(CtranUtilsCheckTest, SysCheck) {
   auto res = dummyFn();
   ASSERT_EQ(res, commSystemError);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("Call to sysTestFn failed"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
+  EXPECT_THAT(output, ::testing::HasSubstr("Call to sysTestFn failed"));
 }
 
 TEST_F(CtranUtilsCheckTest, SysCheckGoto) {
@@ -128,10 +130,9 @@ TEST_F(CtranUtilsCheckTest, SysCheckGoto) {
   auto res = dummyFn();
   ASSERT_EQ(res, commSystemError);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("Call to sysTestFn failed"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
+  EXPECT_THAT(output, ::testing::HasSubstr("Call to sysTestFn failed"));
 }
 
 TEST_F(CtranUtilsCheckTest, ErrorReturn) {
@@ -142,10 +143,9 @@ TEST_F(CtranUtilsCheckTest, ErrorReturn) {
   auto res = dummyFn();
   ASSERT_EQ(res, commInvalidUsage);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("test ErrorReturn failure"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
+  EXPECT_THAT(output, ::testing::HasSubstr("test ErrorReturn failure"));
 }
 
 TEST_F(CtranUtilsCheckTest, ErrorThrowEx) {
@@ -172,9 +172,8 @@ TEST_F(CtranUtilsCheckTest, ErrorThrowEx) {
 
   ASSERT_TRUE(caughtException) << "Expected ctran::utils::Exception";
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
 }
 
 TEST_F(CtranUtilsCheckTest, ArgCheckNull) {
@@ -185,11 +184,10 @@ TEST_F(CtranUtilsCheckTest, ArgCheckNull) {
   auto res = dummyFn();
   ASSERT_EQ(res, commInvalidArgument);
 
-  const auto& messages = getMessages();
-  ASSERT_EQ(messages.size(), 1);
-  EXPECT_THAT(messages[0], ::testing::HasSubstr("CTRAN ERROR"));
+  const auto output = getOutput();
+  EXPECT_THAT(output, ::testing::HasSubstr("CTRAN ERROR"));
   EXPECT_THAT(
-      messages[0], ::testing::HasSubstr("ArgCheckNull ptr argument is NULL"));
+      output, ::testing::HasSubstr("ArgCheckNull ptr argument is NULL"));
 }
 
 TEST_F(CtranUtilsCheckTest, FB_SYSCHECKTHROW_EX_DIRECT) {

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -211,6 +211,15 @@ void CommsSpdlogLogger::log(
   }
 }
 
+void CommsSpdlogLogger::logSynchronous(
+    spdlog::source_loc location,
+    spdlog::level::level_enum level,
+    std::string_view message) {
+  if (should_log(level)) {
+    logFormatted(location, level, getLevelName(level), message, true);
+  }
+}
+
 void CommsSpdlogLogger::logFatal(
     spdlog::source_loc location,
     std::string_view message) {

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -51,6 +51,28 @@ class CommsSpdlogLogger {
       std::string_view message);
 
   template <typename... Args>
+  void logSynchronous(
+      spdlog::source_loc location,
+      spdlog::level::level_enum level,
+      spdlog::format_string_t<Args...> format,
+      Args&&... args) {
+    if (!should_log(level)) {
+      return;
+    }
+    logFormatted(
+        location,
+        level,
+        getLevelName(level),
+        fmt::format(format, std::forward<Args>(args)...),
+        true);
+  }
+
+  void logSynchronous(
+      spdlog::source_loc location,
+      spdlog::level::level_enum level,
+      std::string_view message);
+
+  template <typename... Args>
   void logFatal(
       spdlog::source_loc location,
       spdlog::format_string_t<Args...> format,


### PR DESCRIPTION
Summary:

Replace the legacy CTRAN logging compatibility macros in the core IB backend with the named CTRAN spdlog facade. Preserve log levels, message text, format arguments, error returns, and all surrounding control flow. Include `CtranLogUtils.h` directly at the five use sites so the core sources and public headers no longer obtain logging macros through the generic compatibility header.

Reviewed By: shr

Differential Revision: D115595103


