### PR TITLE
Share CUDA device guard for comms

### DIFF
--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -25,6 +25,7 @@
 #include "comms/prims/memory/CuMemAllocation.h"
 #include "comms/prims/topology/TopologyDiscovery.h"
 #include "comms/prims/transport/MultiPeerDeviceHandle.cuh"
+#include "comms/utils/CudaRAII.h"
 
 namespace comms::prims {
 
@@ -52,38 +53,13 @@ namespace {
     }                                                                          \
   } while (0)
 
-class ScopedCudaDevice {
- public:
-  explicit ScopedCudaDevice(int device) : targetDevice_(device) {
-    CUDA_CHECK(cudaGetDevice(&previousDevice_));
-    if (previousDevice_ != targetDevice_) {
-      CUDA_CHECK(cudaSetDevice(targetDevice_));
-    }
-  }
-
-  ScopedCudaDevice(const ScopedCudaDevice&) = delete;
-  ScopedCudaDevice& operator=(const ScopedCudaDevice&) = delete;
-  ScopedCudaDevice(ScopedCudaDevice&&) = delete;
-  ScopedCudaDevice& operator=(ScopedCudaDevice&&) = delete;
-
-  ~ScopedCudaDevice() {
-    if (previousDevice_ != targetDevice_) {
-      (void)cudaSetDevice(previousDevice_);
-    }
-  }
-
- private:
-  int previousDevice_{-1};
-  int targetDevice_{-1};
-};
-
 comms::fault_tolerance::AbortDevice makeAbortDeviceHandle(
     const std::shared_ptr<comms::fault_tolerance::Abort>& abort,
     int deviceId) {
   if (abort == nullptr || !abort->isEnabled()) {
     return comms::fault_tolerance::AbortDevice{};
   }
-  ScopedCudaDevice guard{deviceId};
+  meta::comms::CudaDeviceGuard guard{deviceId};
   return abort->getDeviceHandle();
 }
 

--- a/comms/utils/CudaRAII.cc
+++ b/comms/utils/CudaRAII.cc
@@ -3,6 +3,9 @@
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/checks.h"
 
+#include <stdexcept>
+#include <string>
+
 namespace meta::comms {
 
 DeviceBuffer::DeviceBuffer(std::size_t size) : size_(size) {
@@ -95,6 +98,47 @@ CudaEvent& CudaEvent::operator=(CudaEvent&& other) noexcept {
 
 cudaEvent_t CudaEvent::get() const {
   return event_;
+}
+
+CudaDeviceGuard::CudaDeviceGuard(int device) {
+  auto status = cudaGetDevice(&previousDevice_);
+  if (status != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("failed to query current CUDA device: ") +
+        cudaGetErrorString(status));
+  }
+  if (previousDevice_ == device) {
+    return;
+  }
+
+  status = cudaSetDevice(device);
+  if (status == cudaSuccess) {
+    restore_ = true;
+    return;
+  }
+
+  const auto selectionStatus = status;
+  const auto restoreStatus = cudaSetDevice(previousDevice_);
+  if (restoreStatus != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("failed to select and restore CUDA device: ") +
+        cudaGetErrorString(selectionStatus) + "; " +
+        cudaGetErrorString(restoreStatus));
+  }
+  throw std::runtime_error(
+      std::string("failed to select CUDA device: ") +
+      cudaGetErrorString(selectionStatus));
+}
+
+CudaDeviceGuard::~CudaDeviceGuard() {
+  if (!restore_) {
+    return;
+  }
+  const auto status = cudaSetDevice(previousDevice_);
+  if (status != cudaSuccess) {
+    XLOG(ERR) << "CudaDeviceGuard: failed to restore CUDA device "
+              << previousDevice_ << ": " << cudaGetErrorString(status);
+  }
 }
 
 StreamCaptureModeGuard::StreamCaptureModeGuard(

--- a/comms/utils/CudaRAII.h
+++ b/comms/utils/CudaRAII.h
@@ -67,6 +67,21 @@ class CudaEvent {
   cudaEvent_t event_{nullptr};
 };
 
+class CudaDeviceGuard {
+ public:
+  explicit CudaDeviceGuard(int device);
+  ~CudaDeviceGuard();
+
+  CudaDeviceGuard(const CudaDeviceGuard&) = delete;
+  CudaDeviceGuard& operator=(const CudaDeviceGuard&) = delete;
+  CudaDeviceGuard(CudaDeviceGuard&&) = delete;
+  CudaDeviceGuard& operator=(CudaDeviceGuard&&) = delete;
+
+ private:
+  int previousDevice_{-1};
+  bool restore_{false};
+};
+
 // RAII guard that sets the calling thread's CUDA stream capture interaction
 // mode and restores the previous mode on destruction.
 //


### PR DESCRIPTION
Summary:
Move the CUDA device scope helper used by Prims MPT into the shared comms CUDA RAII utilities. MPT now uses the common guard instead of a file-local implementation.

The common guard sets the requested device only when needed, restores the previous device only when it changed, throws on construction failures, and logs restore failures from the destructor.

Differential Revision: D115514742


