### PR TITLE
Key `pendingWqeQs_` by wr_id so completions do not need FIFO CQE order (#3614)

### DIFF
--- a/comms/ctran/backends/ib/CtranIbVc.cc
+++ b/comms/ctran/backends/ib/CtranIbVc.cc
@@ -126,7 +126,8 @@ inline commResult_t CtranIbVirtualConn::setDefaultQPConfig() {
     maxQpMsgs_ = MAX_SEND_WR;
   }
 
-  pendingWqeQs_.resize(maxNumQps_);
+  putWqesByQp_.resize(maxNumQps_);
+  getWqesByQp_.resize(maxNumQps_);
 
   // Cache the per-device QP count now that maxNumQps_ is finalized.
   // maxNumQps_ is guaranteed to be a multiple of activeDevices_.size() above.

--- a/comms/ctran/backends/ib/CtranIbVc.h
+++ b/comms/ctran/backends/ib/CtranIbVc.h
@@ -227,8 +227,9 @@ class CtranIbVirtualConn {
   // Caller needs to call this function before posting a put. If it returns
   // false, progress needs to be made to poll CQE completion.
   inline bool canTransferData() {
-    for (const auto& q : pendingWqeQs_) {
-      if (q.size() < maxQpMsgs_) {
+    for (int qpIdx = 0; qpIdx < static_cast<int>(putWqesByQp_.size());
+         qpIdx++) {
+      if (qpWqeDepth(qpIdx) < maxQpMsgs_) {
         return true;
       }
     }
@@ -495,8 +496,8 @@ class CtranIbVirtualConn {
   // numQpsPerDevice (= K) = maxNumQps_ / numActive.
   // For numActive == 1 this is the identity. The result is always
   // < numActive * numQpsPerDevice (== maxNumQps_) for any logical < maxNumQps_,
-  // so it stays in-bounds for pendingWqeQs_ even when the free-running qpIdxRR_
-  // briefly exceeds a smaller per-op qps.
+  // so it stays in-bounds for putWqesByQp_/getWqesByQp_ even when the
+  // free-running qpIdxRR_ briefly exceeds a smaller per-op qps.
   static inline int
   interleaveQpIdx(int logical, int numActive, int numQpsPerDevice) {
     return (logical % numActive) * numQpsPerDevice + (logical / numActive);
@@ -1375,6 +1376,15 @@ class CtranIbVirtualConn {
     }
   }
 
+  // Total WQEs in flight on one data QP. Puts and gets are tracked in separate
+  // maps but share that QP's single send queue, so both must be counted
+  // against maxQpMsgs_ (itself clamped to MAX_SEND_WR). Counting only one op
+  // type would let puts and gets each fill the queue independently and
+  // overrun it.
+  inline size_t qpWqeDepth(int qpIdx) const {
+    return putWqesByQp_.at(qpIdx).size() + getWqesByQp_.at(qpIdx).size();
+  }
+
   template <typename PendingOpQueue, typename FastOpQueue, typename QueueOpFunc>
   inline commResult_t tryToPostOp(
       PendingOpQueue& pendingOpQueue,
@@ -1404,7 +1414,7 @@ class CtranIbVirtualConn {
         const int qpIdx = doInterleave
             ? interleaveQpIdx(qpIdxRR_, numActive, numQpsPerDevice_)
             : qpIdxRR_;
-        auto pendingWqeSize = pendingWqeQs_.at(qpIdx).size();
+        auto pendingWqeSize = qpWqeDepth(qpIdx);
         if (qpIdx == fastQpIdx) {
           pendingWqeSize += outstandingFastQueue.size();
         }
@@ -1470,7 +1480,7 @@ class CtranIbVirtualConn {
       }
     }
 
-    pendingWqeQs_.at(i).emplace_back(sendPutWr_.wr_id, put.get());
+    putWqesByQp_.at(i).emplace(sendPutWr_.wr_id, put.get());
     put->outstandingWqes++;
     CLOGF_TRACE(
         COLL,
@@ -1533,7 +1543,7 @@ class CtranIbVirtualConn {
         get->sbuf,
         get->offset);
 
-    pendingWqeQs_.at(i).emplace_back(sendGetWr_.wr_id, get.get());
+    getWqesByQp_.at(i).emplace(sendGetWr_.wr_id, get.get());
     get->outstandingWqes++;
     auto maybeSend = ibvDataQps_[i].postSend(&sendGetWr_, &badSendGetWr_);
     FOLLY_EXPECTED_CHECK(maybeSend);
@@ -1608,25 +1618,23 @@ class CtranIbVirtualConn {
         // Post next data if exists
         FB_COMMCHECK(queueWriteOnQp(qpIdx));
       } else {
-        auto& q = pendingWqeQs_.at(qpIdx);
-        FB_CHECKABORT(q.size() > 0, "Unexpected empty pendingWqeQs");
-
-        auto wqeInfo = dequeFront(q);
-        auto& putInfo = *wqeInfo.putInfo;
+        auto& q = putWqesByQp_.at(qpIdx);
+        auto it = q.find(wrId);
         FB_CHECKABORT(
-            wqeInfo.wrId == wrId,
-            "wrId mismatch: {} != {}, qpIdx={}, outstandingFastPuts={}, outstandingPuts={}, pendingWqeQs={}",
-            wqeInfo.wrId,
+            it != q.end(),
+            "wrId {} not found in putWqesByQp[{}], size={}, outstandingFastPuts={}, outstandingPuts={}",
             wrId,
             qpIdx,
+            q.size(),
             outstandingFastPuts_.size(),
-            outstandingPuts_.size(),
-            pendingWqeQs_.size());
+            outstandingPuts_.size());
+        auto& putInfo = *it->second;
         FB_CHECKABORT(
             putInfo.outstandingWqes > 0,
             "Got CQE for put with 0 outstanding WQEs");
 
         --putInfo.outstandingWqes;
+        q.erase(it);
 
         // Check if put is complete and, if so, update req status
         FB_COMMCHECK(burnDownPuts());
@@ -1663,18 +1671,21 @@ class CtranIbVirtualConn {
       // Post next data if exists
       FB_COMMCHECK(queueReadOnQp(qpIdx));
     } else {
-      auto& q = pendingWqeQs_.at(qpIdx);
-      FB_CHECKABORT(q.size() > 0, "Unexpected empty pendingWqeQs");
-
-      auto wqeInfo = dequeFront(q);
-      auto& getInfo = *wqeInfo.getInfo;
+      auto& q = getWqesByQp_.at(qpIdx);
+      auto it = q.find(wrId);
       FB_CHECKABORT(
-          wqeInfo.wrId == wrId, "wrId mismatch: {} != {}", wqeInfo.wrId, wrId);
+          it != q.end(),
+          "wrId {} not found in getWqesByQp[{}], size={}",
+          wrId,
+          qpIdx,
+          q.size());
+      auto& getInfo = *it->second;
       FB_CHECKABORT(
           getInfo.outstandingWqes > 0,
-          "Got CQE for put with 0 outstanding WQEs");
+          "Got CQE for get with 0 outstanding WQEs");
 
       --getInfo.outstandingWqes;
+      q.erase(it);
 
       // Check if get is complete and, if so, update req status
       FB_COMMCHECK(burnDownGets());
@@ -1895,14 +1906,24 @@ class CtranIbVirtualConn {
   std::deque<std::unique_ptr<NotifyInfo>> pendingNotifies_;
   std::deque<std::unique_ptr<NotifyInfo>> outstandingNotifies_;
 
-  struct WqeInfo {
-    WqeInfo(uint64_t wrId, PutInfo* putInfo) : wrId(wrId), putInfo(putInfo) {}
-    WqeInfo(uint64_t wrId, GetInfo* getInfo) : wrId(wrId), getInfo(getInfo) {}
-    uint64_t wrId;
-    PutInfo* putInfo;
-    GetInfo* getInfo;
-  };
-  std::vector<std::deque<WqeInfo>> pendingWqeQs_;
+  // Per-QP WQEs that have been posted but whose CQE has not arrived yet, keyed
+  // by wr_id. Keyed rather than ordered so writeComplete/readComplete do not
+  // depend on per-QP FIFO CQE order, which no longer holds once data QPs are
+  // created with MLX5DV_QP_CREATE_OOO_DP.
+  //
+  // Puts and gets are tracked separately: the CQE opcode already selects the
+  // handler (IBV_WC_RDMA_WRITE -> writeComplete, IBV_WC_RDMA_READ ->
+  // readComplete), so an entry needs no discriminator and can hold the bare
+  // PutInfo/GetInfo pointer. The pointee is owned by pendingPuts_/
+  // outstandingPuts_ (resp. gets) and outlives every WQE referencing it; one
+  // op fans out to many WQEs across many QPs, tracked by
+  // PutInfo::outstandingWqes.
+  //
+  // NOTE: both maps index the same hardware send queue per QP, so the
+  // maxQpMsgs_ cap must be taken against their combined size -- see
+  // qpWqeDepth().
+  std::vector<std::unordered_map<uint64_t, PutInfo*>> putWqesByQp_;
+  std::vector<std::unordered_map<uint64_t, GetInfo*>> getWqesByQp_;
   int qpIdxRR_{0};
   const int iputFastQpIdx_{0};
   const int igetFastQpIdx_{0};

--- a/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
@@ -1487,6 +1487,48 @@ TEST_P(CtranIbTestParam, GpuMemPutNotifyNoSignalMultiQp) {
       /*isGpuMem*/ true);
 }
 
+// Stresses the wr_id-keyed `putWqesByQp_` map that backs `writeComplete`.
+// A small qpScalingThreshold splits each PUT into many WQEs which are then
+// round-robined across many QPs, so every QP holds several concurrent
+// outstanding entries in the map and each CQE must be resolved via find(wrId)
+// rather than front-of-queue.
+TEST_P(CtranIbTestParam, GpuMemPutManyWqePerQpMapLookup) {
+  this->printTestDesc(
+      "GpuMemPutManyWqePerQpMapLookup",
+      "Stress writeComplete's wr_id-keyed putWqesByQp_ lookup by "
+      "issuing many puts that each fan out to multiple WQEs on multiple QPs.");
+
+  EnvRAII env1(NCCL_CTRAN_IB_MAX_QPS, 16);
+  EnvRAII env2(NCCL_CTRAN_IB_QP_SCALING_THRESHOLD, 512UL);
+  EnvRAII env3(NCCL_CTRAN_IB_VC_MODE, GetParam());
+
+  runPutNotify(
+      /* bufCount */ 8192,
+      /* numPuts */ 500,
+      /* localSignal */ false,
+      NotifyMode::notifyAll,
+      /* isGpuMem */ true);
+}
+
+// Symmetric stress for readComplete's wr_id-keyed lookup: many gets, each
+// split into multiple WQEs across many QPs.
+TEST_P(CtranIbTestParam, GpuMemGetManyWqePerQpMapLookup) {
+  this->printTestDesc(
+      "GpuMemGetManyWqePerQpMapLookup",
+      "Stress readComplete's wr_id-keyed getWqesByQp_ lookup by "
+      "issuing many gets that each fan out to multiple WQEs on multiple QPs.");
+
+  EnvRAII env1(NCCL_CTRAN_IB_MAX_QPS, 16);
+  EnvRAII env2(NCCL_CTRAN_IB_QP_SCALING_THRESHOLD, 512UL);
+  EnvRAII env3(NCCL_CTRAN_IB_VC_MODE, GetParam());
+
+  runGet(
+      /* bufCount */ 8192,
+      /* numGets */ 500,
+      /* localSignal */ true,
+      /* isGpuMem */ true);
+}
+
 TEST_P(CtranIbTestParam, GpuMemPutNoNotify) {
   EnvRAII env1(NCCL_CTRAN_IB_VC_MODE, GetParam());
   this->printTestDesc(


### PR DESCRIPTION
Summary:

`CtranIbVirtualConn` tracked in-flight WQEs in a per-QP `std::deque<WqeInfo>`.
`writeComplete()` and `readComplete()` popped the *front* of that deque and
asserted `wqeInfo.wrId == wrId`. That assertion is only valid while send CQEs are
reported per-QP in FIFO order.

Once ctran data QPs are created with `MLX5DV_QP_CREATE_OOO_DP`
(`NCCL_CTRAN_IB_ENABLE_OOO_RQ=true`), that ordering guarantee no longer holds and
the front-of-queue assert would abort on the first reordered completion.

Switch `pendingWqeQs_` to `std::vector<std::unordered_map<uint64_t, WqeInfo>>` and
resolve each CQE with `find(wrId)` + `erase(it)` instead of `dequeFront()`. The
posting side is unchanged: per-QP `size()` still bounds the op against
`maxQpMsgs_` in `tryToPostOp()`, so flow control behaves exactly as before. The
`readComplete()` abort string also said "put" where it meant "get"; fixed.

With `NCCL_CTRAN_IB_ENABLE_OOO_RQ=false` (the default) behaviour is unchanged —
this only removes an ordering assumption, it does not change what is posted or
when a request completes.

One nuance worth flagging for review: `emplace()` on a map is a no-op when the key
already exists, whereas the old `emplace_back()` always appended. A duplicate
`wr_id` would therefore silently drop a WQE and hang rather than abort. `wr_id`
comes from a per-VC `uint64_t nextWrId_++`, so a collision requires 2^64
wraparound on a single VC and is not reachable in practice.

Also adds two stress tests that give each QP several concurrent outstanding
entries — small `NCCL_CTRAN_IB_QP_SCALING_THRESHOLD`, 16 QPs, 500 ops — so every
CQE must be resolved via `find(wrId)` rather than front-of-queue:
`GpuMemPutManyWqePerQpMapLookup` and `GpuMemGetManyWqePerQpMapLookup`.

Reviewed By: minsii

Differential Revision: D114658473


