### PR TITLE
Add the aggregate value type and its histogram math

### DIFF
--- a/comms/utils/collstats/CollStatsHistogram.h
+++ b/comms/utils/collstats/CollStatsHistogram.h
@@ -1,0 +1,138 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+/* Pure, deterministic bucketing math shared by the device finalizer and any
+ * host-side reconstruction. Duration bucketing happens on the device at
+ * finalize, so the duration must already be in nanoseconds: %globaltimer reads
+ * in ns, so a single-GPU duration (end - start) needs no calibration constant
+ * before bucketing. Size-class bucketing happens on the host at enqueue, where
+ * the message size is already known. Kept header-only and __host__ __device__
+ * so host gtest validates exactly what the kernel computes.
+ *
+ * Neither bucket set is compiled in. The duration geometry comes from
+ * MCCL_GPU_COLLSTATS_HIST_TMIN_NS / _HIST_TMAX_NS / _HIST_SUBBUCKETS and the
+ * size classes from MCCL_GPU_COLLSTATS_SIZE_CLASS_EDGES, both read by the
+ * owner at init and passed in here. See CollStatHistGeometry and
+ * CollStatSizeClasses. */
+
+namespace meta::comms::collstats {
+
+/* Log-bucket a duration (ns) into [0, geom.numBuckets). Index 0 is underflow
+ * (dur < tMinNs), the last index is the overflow/tail bucket (dur >= tMaxNs),
+ * and the interior is geom.subBucketsPerOctave sub-buckets per octave, giving a
+ * constant relative error of 2^(1/S)-1 -- 9.05% at the default S of 8.
+ *
+ * Note: the interior split uses double log2. On one GPU this is one op per
+ * finalize, not per element. Host and device IEEE-754 log2 can differ by at
+ * most one bucket at an exact octave edge, which is smaller than the
+ * histogram's own relative error and is therefore tolerated. */
+COLLSTATS_HD inline uint32_t logBucketNs(
+    const CollStatHistGeometry& geom,
+    uint64_t durNs) {
+  if (durNs < geom.tMinNs) {
+    return kHistUnderflowBucket;
+  }
+  if (durNs >= geom.tMaxNs) {
+    return geom.numBuckets - 1;
+  }
+  const double octaves =
+      log2(static_cast<double>(durNs) / static_cast<double>(geom.tMinNs));
+  const uint32_t sub =
+      static_cast<uint32_t>(octaves * geom.subBucketsPerOctave);
+  // The tMaxNs guard above bounds sub below the overflow index; shift past the
+  // underflow bucket at index 0.
+  return 1u + sub;
+}
+
+/* Build a geometry from configured bounds, deriving the bucket count from the
+ * octave span. Returns numBuckets 0 -- which collStatsAllocDeviceBlock rejects
+ * -- for bounds that are inverted, degenerate, or need more buckets than the
+ * compile-time capacity, so a bad cvar fails at init rather than silently
+ * reshaping the histogram. */
+inline CollStatHistGeometry collStatMakeHistGeometry(
+    uint64_t tMinNs,
+    uint64_t tMaxNs,
+    uint32_t subBucketsPerOctave) {
+  CollStatHistGeometry geom{tMinNs, tMaxNs, subBucketsPerOctave, 0};
+  if (tMinNs == 0 || tMaxNs <= tMinNs || subBucketsPerOctave == 0) {
+    return geom;
+  }
+  const double octaves =
+      std::log2(static_cast<double>(tMaxNs) / static_cast<double>(tMinNs));
+  const uint64_t interior =
+      static_cast<uint64_t>(std::ceil(octaves * subBucketsPerOctave));
+  const uint64_t total = interior + 2;
+  if (total > kHistMaxBuckets) {
+    return geom;
+  }
+  geom.numBuckets = static_cast<uint32_t>(total);
+  return geom;
+}
+
+/* The compiled-in defaults, derived through the same function rather than
+ * asserted, so the default geometry cannot drift from the capacity it is
+ * sized against. Host-only, like the derivation it calls: geometry is assembled
+ * on the host and handed to the device, never computed there. */
+inline CollStatHistGeometry collStatDefaultHistGeometry() {
+  return collStatMakeHistGeometry(
+      kDefaultHistTMinNs, kDefaultHistTMaxNs, kDefaultHistSubBucketsPerOctave);
+}
+
+/* Configured size-class edges, ascending. `edges[i]` is the inclusive lower
+ * bound of class i + 1, so anything below edges[0] is class 0. Held by value
+ * and capacity-bounded so it copies without allocating.
+ *
+ * Bounded by kMaxSizeClasses because sizeClass is a u8 field of CollStatKey,
+ * and because bounded key cardinality is the whole reason the size is bucketed
+ * rather than stored exactly. */
+struct CollStatSizeClasses {
+  uint64_t edges[kMaxSizeClasses];
+  uint32_t n;
+};
+
+/* The default edge set: powers of two from 2 bytes to 8 GiB, which reproduces
+ * exactly the floor(log2(bytes)) classes this started with, so data recorded
+ * before the edges became configurable stays comparable.
+ *
+ *   class  0   [0 B,    2 B)     empty, or a single byte
+ *   class  1   [2 B,    4 B)
+ *   class 10   [1 KiB,  2 KiB)
+ *   class 20   [1 MiB,  2 MiB)
+ *   class 30   [1 GiB,  2 GiB)
+ *   class 33   [8 GiB,  inf)     the tail bucket
+ *
+ * Powers of two spend most of their classes on sizes a training job never
+ * sends, and two shapes 40% apart share a class. A job that cares about a
+ * narrower range should configure edges around it. */
+COLLSTATS_HD inline CollStatSizeClasses collStatDefaultSizeClasses() {
+  CollStatSizeClasses sc{};
+  sc.n = 0;
+  for (uint32_t i = 1; i <= 33u && sc.n < kMaxSizeClasses; ++i) {
+    sc.edges[sc.n++] = 1ull << i;
+  }
+  return sc;
+}
+
+/* Map a logical message size (bytes) to its class: the index of the last edge
+ * at or below `msgBytes`, or 0 when it is below the first edge. Integer-only,
+ * so host and device agree exactly. A linear scan because the edge list is
+ * tens of entries and this runs once per launch on the enqueue thread. */
+COLLSTATS_HD inline uint8_t sizeClassOf(
+    const CollStatSizeClasses& sc,
+    uint64_t msgBytes) {
+  uint32_t cls = 0;
+  for (uint32_t i = 0; i < sc.n; ++i) {
+    if (msgBytes < sc.edges[i]) {
+      break;
+    }
+    cls = i + 1;
+  }
+  return static_cast<uint8_t>(cls);
+}
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsKeys.h
+++ b/comms/utils/collstats/CollStatsKeys.h
@@ -1,0 +1,72 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <cstdint>
+
+/* The vocabulary a collstats key is written in.
+ *
+ * Owned here rather than borrowed from a producer, because collstats is a sink
+ * with more than one of them. MCCL/ctran dispatch names an algorithm NCCL has
+ * no word for (`Direct`), NCCL names several MCCL has no word for (`NVLS`,
+ * `CollNet*`, `PAT`) and a protocol axis MCCL does not model at all. Neither
+ * side's enum is a superset, so keying on either would leave the other unable
+ * to say what it did. These are the union; each producer translates into them.
+ *
+ * A translator is also where drift gets caught: a `switch` over a producer's
+ * enum with no `default:` stops compiling when that producer gains a member,
+ * whereas sharing its enum would silently admit a value with no bucket here.
+ *
+ * The numeric values are an in-process detail, not a wire format: the exporter
+ * writes `magic_enum::enum_name`, so a consumer reads "AllReduce" rather than 1
+ * and renumbering cannot re-label recorded data.
+ *
+ * `Unknown = 0` on each, so a zero-filled bank slot reads as unset rather than
+ * as a real collective -- an untouched slot would otherwise be
+ * indistinguishable from a genuine small-message `Direct` `AllReduce`. Sized to
+ * u8 to match the `CollStatKey` fields that hold them. */
+
+namespace meta::comms::collstats {
+
+enum class CollStatOp : uint8_t {
+  Unknown = 0,
+  AllReduce,
+  AllGather,
+  ReduceScatter,
+  Broadcast,
+  Reduce,
+  AllToAll,
+  Scatter,
+  Gather,
+  SendRecv,
+  Send,
+  Recv,
+};
+
+enum class CollStatAlgo : uint8_t {
+  Unknown = 0,
+  Direct,
+  Ring,
+  Tree,
+  CollNetDirect,
+  CollNetChain,
+  NVLS,
+  NVLSTree,
+  PAT,
+};
+
+/* Modelled by NCCL, not by MCCL/ctran, which has no protocol axis: the ctran
+ * producer reports Unknown and the field waits for a producer that has one. */
+enum class CollStatProto : uint8_t {
+  Unknown = 0,
+  Simple,
+  LL,
+  LL128,
+};
+
+static_assert(
+    sizeof(CollStatOp) == sizeof(uint8_t) &&
+        sizeof(CollStatAlgo) == sizeof(uint8_t) &&
+        sizeof(CollStatProto) == sizeof(uint8_t),
+    "key codes must match the width of the CollStatKey fields holding them");
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsTypes.h
+++ b/comms/utils/collstats/CollStatsTypes.h
@@ -1,0 +1,170 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <cstdint>
+
+#include "comms/utils/collstats/CollStatsKeys.h"
+
+// Collective-stats data structures: the per-communicator, double-buffered,
+// device-resident aggregate and the per-stream span scratch. This header is the
+// shared vocabulary between the device finalizer (which accumulates) and the
+// host reader (which snapshots); it deliberately carries no atomics, no CUDA
+// types, and no key-provisioning logic, so it compiles on host for unit tests.
+
+namespace meta::comms::collstats {
+
+// Portability: device qualifiers vanish under a host-only compiler so the pure
+// math in CollStatsHistogram.h is exercised directly by host gtest.
+#if defined(__CUDACC__) || defined(__HIPCC__)
+#define COLLSTATS_HD __host__ __device__
+#else
+#define COLLSTATS_HD
+#endif
+
+/* ---------------------------------------------------------------------------
+ * Histogram geometry.
+ *
+ * Durations are bucketed log-spaced: `subBucketsPerOctave` sub-buckets per
+ * octave starting at `tMinNs`, plus one underflow bucket at index 0 and one
+ * overflow bucket at the last index. The geometry is per communicator, built
+ * at init from MCCL_GPU_COLLSTATS_HIST_TMIN_NS, _HIST_TMAX_NS and
+ * _HIST_SUBBUCKETS and carried in the device block, so a job retunes it
+ * without a rebuild. This header only defines the shape; the owner reads the
+ * cvars and hands the result down.
+ *
+ * The array in CollStatValue is sized to kHistMaxBuckets at compile time. The
+ * value struct is device-resident and copied out whole every window, so a
+ * runtime-length array would make the bank stride and the reader's prefix copy
+ * geometry-dependent. Init rejects a geometry needing more than the capacity.
+ *
+ * At the cvar defaults -- 8 sub-buckets per octave over [1us, 1024s], so 30
+ * octaves and 242 buckets -- every interior bucket is 2^(1/8) wide, a constant
+ * relative error of 9.05%:
+ *
+ *   bucket   0   underflow            dur <  1us
+ *   bucket   1   [1000ns, 1091ns)     1us, the first interior bucket
+ *   bucket   9   [2000ns, 2181ns)     2us, one octave in
+ *   bucket  27                        10us
+ *   bucket  80   [939us, 1024us)      1ms
+ *   bucket 160   [962ms, 1049ms)      1s
+ *   bucket 234                        600s, the watchdog backstop
+ *   bucket 241   overflow             dur >= 1024s
+ *
+ * Absolute width scales with magnitude, which is the point: ~90ns at 1us,
+ * ~85ms at 1s. Good enough to rank outliers, not a paging signal -- that is
+ * what the exact threshold counters below are for.
+ * ---------------------------------------------------------------------------
+ */
+inline constexpr uint32_t kHistMaxBuckets = 242;
+inline constexpr uint32_t kHistUnderflowBucket = 0;
+
+/* Per-communicator histogram geometry. `numBuckets` includes the underflow and
+ * overflow buckets, so the overflow index is numBuckets - 1. */
+struct CollStatHistGeometry {
+  uint64_t tMinNs;
+  uint64_t tMaxNs;
+  uint32_t subBucketsPerOctave;
+  uint32_t numBuckets;
+};
+
+/* Cvar defaults, and what kHistMaxBuckets was sized from. */
+inline constexpr uint32_t kDefaultHistSubBucketsPerOctave = 8;
+inline constexpr uint64_t kDefaultHistTMinNs = 1'000ull; // 1 us
+inline constexpr uint64_t kDefaultHistTMaxNs =
+    1'024ull * 1'000'000'000ull; // 1024 s
+inline constexpr uint32_t kDefaultHistOctaves = 30; // [1us, 1024s]
+
+/* Exact past-threshold counters. Durations >= each cut-point are counted with
+ * an exact atomic add, so a threshold-based page carries no bucket-boundary
+ * error. Cut-points are per communicator, read from
+ * MCCL_GPU_COLLSTATS_THRESHOLDS_NS at init; the array is capacity-bounded for
+ * the same reason the histogram is. */
+inline constexpr uint32_t kMaxThresholds = 4;
+inline constexpr uint64_t kDefaultThresholdsNs[kMaxThresholds] = {
+    1ull * 1'000'000'000ull, // 1 s
+    10ull * 1'000'000'000ull, // 10 s
+    60ull * 1'000'000'000ull, // 60 s
+    600ull * 1'000'000'000ull, // watchdog (CollTrace 10-min backstop)
+};
+
+/* Size-class capacity. sizeClass is a u8 key field, and a configured edge list
+ * longer than this would produce classes it cannot represent; init rejects
+ * one. 64 leaves room well past the 34 default power-of-two classes. */
+inline constexpr uint32_t kMaxSizeClasses = 64;
+
+/* ---------------------------------------------------------------------------
+ * Aggregate key: (op, algorithm, protocol, dtype, sizeClass).
+ *
+ * Every field is a small code, so all five are u8 and the key is 5 bytes. op,
+ * algorithm and protocol are the collstats vocabulary from CollStatsKeys.h,
+ * which every producer translates into, so this header pulls in no NCCL or
+ * MCCL headers and a zero-filled bank slot reads as Unknown rather than as a
+ * real collective. dtype is the raw datatype value, which is small. sizeClass
+ * is an index into the configured size-class edges, not a byte count -- see
+ * CollStatsHistogram.h.
+ *
+ * Bucketing the size is what keeps key cardinality bounded. An exact size in
+ * the key would make every distinct message size its own key, and a job with a
+ * few hundred tensor shapes would exhaust the registry and spill the rest into
+ * the catch-all.
+ * ---------------------------------------------------------------------------
+ */
+struct CollStatKey {
+  CollStatOp op;
+  CollStatAlgo algorithm;
+  CollStatProto protocol;
+  uint8_t dtype;
+  uint8_t sizeClass;
+};
+
+/* Per-key accumulated value. Per-window banking bounds every field far below
+ * wrap within a window, so no saturating math is needed. count, logicalBytes,
+ * durationSumNs, thresholdCounts and the histogram are add-only; durMaxNs and
+ * durMinNsComplement are atomicMax. The device finalizer applies the atomics;
+ * this struct is just the layout.
+ *
+ * The bucket and threshold counters are u32 for readout cost, not for range.
+ * Each counts finalized collectives inside one window, so together they sum to
+ * at most the collectives in that window -- far under u32. The width matters
+ * because the histogram is 242 of the struct's 246 counters, and the reader
+ * copies the full key capacity out of the retired bank every window whether or
+ * not a slot is occupied: at u32 that is 1024 bytes per key and 0.5 MiB per
+ * window at the default 512-key capacity, nearly twice that at u64. */
+struct CollStatValue {
+  uint64_t count;
+  uint64_t logicalBytes; // logical message size (count x dtype), written once
+  uint64_t durationSumNs;
+  uint64_t durMaxNs;
+  /* Minimum duration, stored bitwise-complemented so a zero-filled bank reads
+   * as "no observation": ~0 is UINT64_MAX, the identity for a minimum, and
+   * max(~a, ~b) == ~min(a, b), so one atomicMax maintains it. Storing the
+   * minimum directly would force the between-window bank reset to write
+   * UINT64_MAX into one field of every key instead of a single zero fill.
+   * Readers should un-complement through a named accessor rather than by
+   * hand, so the "count == 0 means unset" rule lives in one place. */
+  uint64_t durMinNsComplement;
+  uint32_t histogram[kHistMaxBuckets];
+  uint32_t thresholdCounts[kMaxThresholds];
+};
+
+/* Exact per-window minimum duration (ns); 0 when there were no observations.
+ * Lives here, beside the field and the rule above, rather than with the other
+ * derived metrics: it is the only reader of the complemented encoding, and
+ * keeping it here is what makes "never un-complement by hand" enforceable. */
+inline uint64_t collStatDurMinNs(const CollStatValue& v) {
+  return v.count == 0 ? 0ull : ~v.durMinNsComplement;
+}
+
+struct CollStatSpanScratch {
+  uint64_t start; // min entry %globaltimer over blocks; init UINT64_MAX
+  uint32_t
+      arrived; // exit-barrier arrival count; finalizer when == expectedBlocks
+  uint32_t expectedBlocks; // gridDim, from launch config
+  uint32_t kernelIndex; // multi-kernel collective: current kernel in sequence
+  uint32_t
+      kernelCount; // multi-kernel collective: total kernels; finalize on last
+};
+
+inline constexpr uint64_t kSpanStartInit = ~0ull; // UINT64_MAX
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/tests/CollStatsHistogramTest.cpp
+++ b/comms/utils/collstats/tests/CollStatsHistogramTest.cpp
@@ -1,0 +1,148 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/collstats/CollStatsHistogram.h"
+
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+namespace meta::comms::collstats {
+
+/* The tests assert against the cvar defaults explicitly, rather than against
+ * whatever the compiled-in constants happen to be. */
+const CollStatHistGeometry kTestGeom = collStatDefaultHistGeometry();
+namespace {
+
+TEST(CollStatsHistogramTest, DurationsBelowTMinAreUnderflow) {
+  EXPECT_EQ(logBucketNs(kTestGeom, 0), kHistUnderflowBucket);
+  EXPECT_EQ(logBucketNs(kTestGeom, 1), kHistUnderflowBucket);
+  EXPECT_EQ(
+      logBucketNs(kTestGeom, kDefaultHistTMinNs - 1), kHistUnderflowBucket);
+}
+
+TEST(CollStatsHistogramTest, DurationsAtOrAboveTMaxAreOverflow) {
+  EXPECT_EQ(logBucketNs(kTestGeom, kDefaultHistTMaxNs), (kHistMaxBuckets - 1));
+  EXPECT_EQ(
+      logBucketNs(kTestGeom, kDefaultHistTMaxNs + 1), (kHistMaxBuckets - 1));
+  EXPECT_EQ(logBucketNs(kTestGeom, ~0ull), (kHistMaxBuckets - 1));
+}
+
+TEST(CollStatsHistogramTest, TMinLandsInFirstInteriorBucket) {
+  // The first in-range bucket sits immediately after the underflow bucket.
+  EXPECT_EQ(
+      logBucketNs(kTestGeom, kDefaultHistTMinNs), kHistUnderflowBucket + 1);
+}
+
+TEST(CollStatsHistogramTest, OctaveStartsAreEvenlySpaced) {
+  // Independently derived expectation: a duration exactly k octaves above t_min
+  // must land at the start of octave k, i.e. bucket 1 + k*S.
+  for (uint32_t k = 0; k < kDefaultHistOctaves; ++k) {
+    const uint64_t durNs = kDefaultHistTMinNs << k;
+    const uint32_t expected = 1u + k * kDefaultHistSubBucketsPerOctave;
+    EXPECT_EQ(logBucketNs(kTestGeom, durNs), expected) << "octave k=" << k;
+  }
+}
+
+TEST(CollStatsHistogramTest, MidOctaveResolvesToSubBucket) {
+  // A point 0.3 octaves in (2^0.3 above the octave start) is sub-bucket
+  // floor(8 * 0.3) = 2. The fraction is kept well off a sub-bucket edge so the
+  // double->uint64 truncation of the test input can't tip it across a boundary.
+  const uint32_t k = 5;
+  const double frac = 0.3;
+  const double point =
+      static_cast<double>(kDefaultHistTMinNs << k) * 1.2311444133449163;
+  const uint32_t expectedSub =
+      static_cast<uint32_t>(frac * kDefaultHistSubBucketsPerOctave); // 2
+  const uint32_t expected =
+      1u + k * kDefaultHistSubBucketsPerOctave + expectedSub;
+  EXPECT_EQ(logBucketNs(kTestGeom, static_cast<uint64_t>(point)), expected);
+}
+
+TEST(CollStatsHistogramTest, BucketsAreMonotonicAndInRange) {
+  uint32_t prev = 0;
+  for (uint64_t durNs = 1; durNs < kDefaultHistTMaxNs * 2;
+       durNs += durNs / 16 + 1) {
+    const uint32_t b = logBucketNs(kTestGeom, durNs);
+    EXPECT_LT(b, kHistMaxBuckets);
+    EXPECT_GE(b, prev) << "non-monotonic at durNs=" << durNs;
+    prev = b;
+  }
+}
+
+// The one function here with a validation contract: a rejected geometry must
+// report numBuckets 0 rather than something a caller would bucket with.
+TEST(CollStatsHistogramTest, RejectedGeometriesReportZeroBuckets) {
+  EXPECT_EQ(collStatMakeHistGeometry(0, 1'000'000, 8).numBuckets, 0u)
+      << "tMin of zero has no log";
+  EXPECT_EQ(collStatMakeHistGeometry(1'000, 1'000, 8).numBuckets, 0u)
+      << "degenerate span";
+  EXPECT_EQ(collStatMakeHistGeometry(1'000'000, 1'000, 8).numBuckets, 0u)
+      << "inverted bounds";
+  EXPECT_EQ(collStatMakeHistGeometry(1'000, 1'000'000, 0).numBuckets, 0u)
+      << "no sub-buckets";
+  // 30 octaves at 16 sub-buckets is 482 buckets, well past the capacity.
+  EXPECT_EQ(
+      collStatMakeHistGeometry(kDefaultHistTMinNs, kDefaultHistTMaxNs, 16)
+          .numBuckets,
+      0u)
+      << "over kHistMaxBuckets";
+}
+
+// The defaults are derived, not asserted, so they must land exactly on the
+// capacity they are sized against.
+TEST(CollStatsHistogramTest, DefaultGeometryFillsTheCapacity) {
+  const CollStatHistGeometry g = collStatDefaultHistGeometry();
+  EXPECT_EQ(g.numBuckets, kHistMaxBuckets);
+  EXPECT_EQ(g.tMinNs, kDefaultHistTMinNs);
+  EXPECT_EQ(g.subBucketsPerOctave, kDefaultHistSubBucketsPerOctave);
+}
+
+// Bucketing must follow a configured geometry, not the compiled-in one --
+// that configurability is the whole point of carrying the geometry around.
+TEST(CollStatsHistogramTest, BucketingFollowsAConfiguredGeometry) {
+  // 1ms..1s at 4 sub-buckets per octave: ~9.97 octaves -> 40 interior + 2.
+  const CollStatHistGeometry g =
+      collStatMakeHistGeometry(1'000'000, 1'000'000'000, 4);
+  ASSERT_EQ(g.numBuckets, 42u);
+
+  EXPECT_EQ(logBucketNs(g, 999'999), kHistUnderflowBucket)
+      << "below tMin under this geometry, though interior under the default";
+  EXPECT_EQ(logBucketNs(g, 1'000'000), 1u);
+  EXPECT_EQ(logBucketNs(g, 2'000'000), 1u + 4u) << "one octave in";
+  EXPECT_EQ(logBucketNs(g, 1'000'000'000), g.numBuckets - 1) << "overflow";
+}
+
+// The default edges must keep reproducing floor(log2(bytes)) exactly, so rows
+// recorded before the edges became configurable stay comparable.
+TEST(CollStatsHistogramTest, DefaultSizeClassesAreFloorLog2) {
+  const CollStatSizeClasses sc = collStatDefaultSizeClasses();
+  EXPECT_EQ(sizeClassOf(sc, 0), 0u);
+  EXPECT_EQ(sizeClassOf(sc, 1), 0u);
+  EXPECT_EQ(sizeClassOf(sc, 2), 1u);
+  EXPECT_EQ(sizeClassOf(sc, 3), 1u);
+  EXPECT_EQ(sizeClassOf(sc, 1024), 10u);
+  EXPECT_EQ(sizeClassOf(sc, (1ull << 30) + 7), 30u);
+  EXPECT_EQ(sizeClassOf(sc, 8ull << 30), 33u);
+}
+
+// A configured edge set replaces the defaults wholesale: class 0 is everything
+// below the first edge, and the last class is open-ended.
+TEST(CollStatsHistogramTest, ConfiguredEdgesBucketByLastEdgeAtOrBelow) {
+  CollStatSizeClasses sc{};
+  sc.n = 3;
+  sc.edges[0] = 1024;
+  sc.edges[1] = 1ull << 20;
+  sc.edges[2] = 1ull << 30;
+
+  EXPECT_EQ(sizeClassOf(sc, 0), 0u);
+  EXPECT_EQ(sizeClassOf(sc, 1023), 0u);
+  EXPECT_EQ(sizeClassOf(sc, 1024), 1u);
+  EXPECT_EQ(sizeClassOf(sc, (1ull << 20) - 1), 1u);
+  EXPECT_EQ(sizeClassOf(sc, 1ull << 20), 2u);
+  EXPECT_EQ(sizeClassOf(sc, 8ull << 30), 3u);
+}
+
+} // namespace
+} // namespace meta::comms::collstats

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -18,6 +18,65 @@ cvars:
      Please change this line when you change the default value of
      NCCL_CVARS_LOG_INFO: https://fburl.com/code/d5f77k3d
 
+ - name        : MCCL_GPU_COLLSTATS_HIST_TMIN_NS
+   type        : uint64_t
+   default     : 1000
+   description : |-
+     Lower bound of the collective-stats duration histogram, in nanoseconds.
+     Durations below it land in the underflow bucket. With TMAX and SUBBUCKETS
+     this fixes the bucket count, which must not exceed the compiled-in
+     capacity of 242; a configuration that needs more is rejected at
+     communicator init and instrumentation stays off for that comm rather than
+     silently rebucketing. Defaults to 1us. Only takes effect when
+     MCCL_GPU_COLLSTATS_ENABLE is set.
+
+ - name        : MCCL_GPU_COLLSTATS_HIST_TMAX_NS
+   type        : uint64_t
+   default     : 1024000000000
+   description : |-
+     Upper bound of the collective-stats duration histogram, in nanoseconds.
+     Must agree with TMIN and SUBBUCKETS on a bucket count within the 242
+     capacity: the default spans 29.93 octaves at 8 sub-buckets, which is
+     exactly 242 including underflow and overflow. Raising it to 2^40 ns needs
+     243 and is rejected, which disables instrumentation for the comm.
+     Durations at or above it land in the overflow bucket, so a percentile
+     plateaus there during a hang while the exact maximum keeps climbing.
+     Defaults to 1024s. Only takes effect when MCCL_GPU_COLLSTATS_ENABLE is set.
+
+ - name        : MCCL_GPU_COLLSTATS_HIST_SUBBUCKETS
+   type        : int
+   default     : 8
+   description : |-
+     Sub-buckets per octave in the collective-stats duration histogram. This is
+     the resolution knob: relative error is 2^(1/N)-1, so the default of 8 gives
+     9.05% and 16 would give 4.4% at twice the buckets. Buckets are bounded at
+     242, so raising this narrows the representable time span unless TMIN and
+     TMAX are narrowed with it. Only takes effect when
+     MCCL_GPU_COLLSTATS_ENABLE is set.
+
+ - name        : MCCL_GPU_COLLSTATS_THRESHOLDS_NS
+   type        : stringlist
+   default     : ""
+   description : |-
+     Comma-separated duration cut-points in nanoseconds, at most four. Each is
+     counted with an exact atomic add rather than read off the histogram, so a
+     threshold-based page carries no bucket-boundary error -- this is what
+     alerting should key on. Empty (default) uses 1s, 10s, 60s and the 600s
+     watchdog backstop. Only takes effect when MCCL_GPU_COLLSTATS_ENABLE is set.
+
+ - name        : MCCL_GPU_COLLSTATS_SIZE_CLASS_EDGES
+   type        : stringlist
+   default     : ""
+   description : |-
+     Comma-separated message-size bucket edges in bytes, ascending, at most 64.
+     Edge i is the inclusive lower bound of class i+1; anything smaller is
+     class 0. The size class is a key field, so this directly sets how many
+     distinct keys a workload produces -- coarse edges merge shapes, fine edges
+     risk exhausting the key registry and spilling into the catch-all. Empty
+     (default) uses powers of two from 2B to 8GiB, which reproduces
+     floor(log2(bytes)). Only takes effect when MCCL_GPU_COLLSTATS_ENABLE is
+     set.
+
  - name        : NCCL_HPC_JOB_IDS
    type        : stringlist
    default     : ""


### PR DESCRIPTION
Summary:
`collstats` folds every finalized collective into a per-key aggregate. This adds that vocabulary -- `CollStatKey`, `CollStatValue`, `CollStatSpanScratch` -- and the pure bucketing math, header-only with no atomics and no CUDA types, so host gtest exercises exactly what a device finalizer will compute.

- The key names a collective with the collstats vocabulary from `CollStatsKeys.h` rather than a producer's own enum, so a row cannot drift from what the sink can express. Both are `uint8_t`-backed, so the key stays 5 bytes, and both have `Unknown = 0`, so a zero-filled bank slot reads as unset instead of as a real collective -- without that, an untouched slot is indistinguishable from a genuine small-message `Direct` `AllReduce`.
- Neither bucket set is compiled in. `CollStatHistGeometry` carries `tMinNs`, `tMaxNs` and `subBucketsPerOctave`; `collStatMakeHistGeometry` derives the bucket count and returns `numBuckets == 0` for bounds that are inverted, degenerate, or over capacity. That zero is the contract: a caller must treat it as "reject this configuration" rather than bucket with it. `CollStatSizeClasses` holds an ascending edge list, and the default set reproduces `floor(log2(bytes))` exactly, so rows recorded under the old fixed classes stay comparable.
- Widths are mixed deliberately: five `u64` scalars, `u32` histogram and threshold counters. That makes `CollStatValue` 1024 bytes rather than ~2008, and both arrays are capacity-bounded at compile time (`kHistMaxBuckets` 242, `kMaxThresholds` 4) so the per-key stride is a constant regardless of how the geometry is configured. The `u32` widths assume a counter only ever spans one readout window.
- `durMinNsComplement` stores the per-window minimum bitwise-complemented. A zero-filled bank then reads as "no observation", and `max(~a, ~b) == ~min(a, b)`, so a single `atomicMax` maintains it -- no second reset path writing `UINT64_MAX` into one field of every key. `collStatDurMinNs` un-complements it and lives here beside the field rather than with the derived metrics: it is the only reader of that encoding, which is what makes "never un-complement by hand" enforceable.
- At the defaults, 8 sub-buckets per octave over [1us, 1024s], relative error is a constant 9.05%: about 90ns wide at 1us, 85ms at 1s. Enough to rank outliers, not a paging signal. Paging is served by the exact past-threshold counters, defaulted to 1s, 10s, 60s and the 10-minute watchdog.

Reviewed By: saifhhasan

Differential Revision: D113593216


