### PR TITLE
Move Collective and Algorithm into a leaf header (#3616)

### DIFF
--- a/comms/utils/CollectiveSpecs.h
+++ b/comms/utils/CollectiveSpecs.h
@@ -1,0 +1,39 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstdint>
+
+/*
+ * Names a collective and the algorithm that runs it.
+ *
+ * Keep this header a leaf -- <cstdint> and nothing more -- so that layers below
+ * MCCL can name a collective without depending on the MCCL interface headers,
+ * which would close a cycle.
+ */
+namespace comms::collectives {
+
+/*
+ * `Unknown` is zero on both enums so a zero-filled record reads as "not set"
+ * rather than as a real collective. It is never selectable: parsing rejects it
+ * and dispatch never routes to it.
+ *
+ * Fixed to uint8_t so a value packs into a telemetry key without narrowing.
+ */
+enum class Collective : uint8_t {
+  Unknown = 0,
+  AllReduce,
+  AllGather,
+  ReduceScatter,
+  SendRecv,
+};
+
+enum class Algorithm : uint8_t {
+  Unknown = 0,
+  Direct,
+  Ring,
+  Tree,
+  Max = Tree,
+};
+
+} // namespace comms::collectives


### PR DESCRIPTION
Summary:

`Collective` and `Algorithm` are declared in `comms/mccl/collectives/ICollective.h`, which reaches `CommContext.h`, `McclTypes.h` and `<cuda_runtime.h>`. Layers below MCCL cannot name a collective without pulling that in, and for ctran the include would close a dependency cycle. So they mint private, drifting copies of the same vocabulary instead.

Move the two enums to `comms/utils/CollectiveSpecs.h`, a leaf header whose only include is `<cstdint>`, in namespace `comms::collectives`. `ICollective.h` re-exports both names, so every existing MCCL call site is untouched.

Two deliberate changes come with the move:

- **`Unknown = 0` on both enums.** A zero-filled record now reads as "not set" rather than as a real collective. Without it a never-written slot in a zero-initialized telemetry bank decodes as a genuine `Direct` `AllReduce`, which is indistinguishable from the real thing -- `Direct` is what small-message AllReduce actually reports. `Unknown` is not selectable: `fromString` rejects it and nothing registers or dispatches it.
- **Both enums fixed to `uint8_t`,** so a value packs into a telemetry key without a narrowing conversion.

`Unknown = 0` renumbers an enum whose values are used as array indices, so two sites move together with it. `kAlgorithmCount` is `static_cast<size_t>(Algorithm::Max) + 1` and bounds `CollectiveRegistry`'s array; `algorithmIndex()` indexes that array by raw enum value. The bound grows by one to cover index 0, which stays `nullptr` -- `find(Algorithm::Unknown)` returns `nullptr`, the existing answer for an unsupported algorithm. The `kAlgorithms` `static_assert` is restated as `size() + 1 == kAlgorithmCount`, since that list holds only the selectable values.

Differential Revision: D115631251
