### PR TITLE
Auto-enable CX8 DBR-less doorbells (#3618)

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -284,6 +284,16 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     config.ibConfig.maxGroups = maxChannels;
     config.ibConfig.qpsPerConnection =
         static_cast<int>(NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC);
+    switch (MCCL_IBGDA_RELIABLE_DOORBELL_MODE) {
+      case MCCL_IBGDA_RELIABLE_DOORBELL_MODE::auto_:
+        break;
+      case MCCL_IBGDA_RELIABLE_DOORBELL_MODE::enable:
+        config.ibConfig.enableReliableDoorbell = true;
+        break;
+      case MCCL_IBGDA_RELIABLE_DOORBELL_MODE::disable:
+        config.ibConfig.enableReliableDoorbell = false;
+        break;
+    }
 
     if (config.ibConfig.dataBufferSize == 0) {
       CLOGF(

--- a/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
+++ b/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+
 #include "comms/prims/transport/MultiPeerIbTransport.h"
 
 namespace comms::prims {
@@ -124,6 +126,38 @@ TEST(MultiPeerIbTransportConfigTest, RelaxedOrderingDisabledNeverActive) {
       relaxedOrderingActiveForNic(config, /*nicRelaxedOrderingCapable=*/true));
   EXPECT_FALSE(
       relaxedOrderingActiveForNic(config, /*nicRelaxedOrderingCapable=*/false));
+}
+
+TEST(MultiPeerIbTransportConfigTest, ReliableDoorbellAutoUsesNicCapability) {
+  const MultipeerIbTransportConfig config;
+  EXPECT_FALSE(config.enableReliableDoorbell.has_value());
+  EXPECT_TRUE(reliableDoorbellNeedsCapabilityQuery(config));
+  EXPECT_TRUE(reliableDoorbellActiveForNic(
+      config, /*nicReliableDoorbellCapable=*/true));
+  EXPECT_FALSE(reliableDoorbellActiveForNic(
+      config, /*nicReliableDoorbellCapable=*/false));
+}
+
+TEST(MultiPeerIbTransportConfigTest, ReliableDoorbellEnableRequiresCapability) {
+  MultipeerIbTransportConfig config;
+  config.enableReliableDoorbell = true;
+  EXPECT_TRUE(reliableDoorbellNeedsCapabilityQuery(config));
+  EXPECT_TRUE(reliableDoorbellActiveForNic(
+      config, /*nicReliableDoorbellCapable=*/true));
+  EXPECT_THROW(
+      reliableDoorbellActiveForNic(
+          config, /*nicReliableDoorbellCapable=*/false),
+      std::invalid_argument);
+}
+
+TEST(MultiPeerIbTransportConfigTest, ReliableDoorbellDisableForcesValidDbr) {
+  MultipeerIbTransportConfig config;
+  config.enableReliableDoorbell = false;
+  EXPECT_FALSE(reliableDoorbellNeedsCapabilityQuery(config));
+  EXPECT_FALSE(reliableDoorbellActiveForNic(
+      config, /*nicReliableDoorbellCapable=*/true));
+  EXPECT_FALSE(reliableDoorbellActiveForNic(
+      config, /*nicReliableDoorbellCapable=*/false));
 }
 
 TEST(MultiPeerIbTransportConfigTest, PeerMaterializationDefaultsOnDemand) {

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -116,6 +116,10 @@ struct MultipeerIbTransportConfig {
   // qpsPerConnection.
   int qpsPerConnection{1};
 
+  // IBGDA-only reliable-doorbell policy; ignored by IBRC and AMD. nullopt
+  // auto-detects NIC support, true requires support, and false disables it.
+  std::optional<bool> enableReliableDoorbell;
+
   int numQpsPerPeerPerNic() const {
     if (maxGroups < 0 || qpsPerBlockPerNic < 0) {
       throw std::invalid_argument(
@@ -308,6 +312,22 @@ struct IbBufferRegistrationView {
     return leaseGeneration != 0 && localBuffer.ptr != nullptr && size != 0;
   }
 };
+
+inline bool reliableDoorbellActiveForNic(
+    const MultipeerIbTransportConfig& config,
+    bool nicReliableDoorbellCapable) {
+  if (config.enableReliableDoorbell.value_or(false) &&
+      !nicReliableDoorbellCapable) {
+    throw std::invalid_argument(
+        "enableReliableDoorbell requires reliable-doorbell NIC support");
+  }
+  return config.enableReliableDoorbell.value_or(nicReliableDoorbellCapable);
+}
+
+inline bool reliableDoorbellNeedsCapabilityQuery(
+    const MultipeerIbTransportConfig& config) {
+  return config.enableReliableDoorbell.value_or(true);
+}
 
 /**
  * Transport connection information for RDMA QP setup.

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cerrno>
 #include <cstring>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -114,6 +115,41 @@ const char* docaErrorToString(doca_error_t err) {
   return "DOCA_ERROR_UNKNOWN_CODE";
 }
 
+#ifndef __HIP_PLATFORM_AMD__
+const char* reliableDoorbellModeName(const std::optional<bool>& enabled) {
+  if (!enabled.has_value()) {
+    return "auto";
+  }
+  return *enabled ? "enable" : "disable";
+}
+
+bool nicSupportsReliableDoorbell(
+    ::ibv_context* ibvContext,
+    const std::string& deviceName) {
+  doca_verbs_device_attr* deviceAttr = nullptr;
+  const doca_error_t queryErr =
+      doca_verbs_query_device(ibvContext, &deviceAttr);
+  if (queryErr != DOCA_SUCCESS) {
+    LOG(WARNING)
+        << "MultipeerIbgdaTransport: reliable doorbell capability query "
+           "failed for NIC "
+        << deviceName << ": " << docaErrorToString(queryErr)
+        << "; treating the NIC as unsupported";
+    return false;
+  }
+
+  const bool supported =
+      doca_verbs_device_attr_get_send_dbr_mode_no_dbr_ext(deviceAttr) != 0;
+  const doca_error_t freeErr = doca_verbs_device_attr_free(deviceAttr);
+  if (freeErr != DOCA_SUCCESS) {
+    LOG(WARNING) << "MultipeerIbgdaTransport: failed to free DOCA device "
+                    "attributes for NIC "
+                 << deviceName << ": " << docaErrorToString(freeErr);
+  }
+  return supported;
+}
+#endif
+
 // Check DOCA error and throw on failure
 void checkDocaError(doca_error_t err, const char* msg) {
   if (err != DOCA_SUCCESS) {
@@ -164,6 +200,22 @@ void MultipeerIbgdaTransport::openIbDevice() {
              ? DOCA_VERBS_ADDR_TYPE_IPv4
              : DOCA_VERBS_ADDR_TYPE_IPv6);
   for (int n = 0; n < numNics_; ++n) {
+#ifndef __HIP_PLATFORM_AMD__
+    const bool nicReliableDoorbellCapable =
+        reliableDoorbellNeedsCapabilityQuery(config_)
+        ? nicSupportsReliableDoorbell(
+              reinterpret_cast<::ibv_context*>(nics_[n].ibvCtx),
+              nics_[n].deviceName)
+        : false;
+    nicDoca_[n].useReliableDoorbell =
+        reliableDoorbellActiveForNic(config_, nicReliableDoorbellCapable);
+    LOG(INFO) << "MultipeerIbgdaTransport: NIC " << nics_[n].deviceName
+              << " reliable_doorbell_mode="
+              << reliableDoorbellModeName(config_.enableReliableDoorbell)
+              << " send_dbr_mode="
+              << (nicDoca_[n].useReliableDoorbell ? "NO_DBR_HW" : "VALID_DBR");
+#endif
+
     doca_error_t err = doca_verbs_ah_attr_create(
         reinterpret_cast<::ibv_context*>(nics_[n].ibvCtx), &nicDoca_[n].ahAttr);
     checkDocaError(err, "Failed to create AH attributes");
@@ -522,9 +574,18 @@ void MultipeerIbgdaTransport::createPeerQps(int peerIndex) {
     mainAttr.sq_nwqe = config_.qpDepth;
     mainAttr.nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO;
     mainAttr.mreg_type = DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_DEFAULT;
+#ifndef __HIP_PLATFORM_AMD__
+    mainAttr.send_dbr_mode_ext = nicDoca_[nic].useReliableDoorbell
+        ? DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_HW
+        : DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR;
+#endif
 
     doca_gpu_verbs_qp_init_attr_hl loopbackAttr = mainAttr;
     loopbackAttr.sq_nwqe = kLoopbackCompanionQpDepth;
+#ifndef __HIP_PLATFORM_AMD__
+    loopbackAttr.send_dbr_mode_ext =
+        DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR;
+#endif
 
     auto& nicQps = nicDoca_[nic].blockQpGroups;
     auto& nicLoopback = nicDoca_[nic].loopbackCompanionQps;

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
@@ -267,6 +267,7 @@ class MultipeerIbgdaTransport
   struct NicDocaResources {
     doca_verbs_ah_attr* ahAttr{nullptr};
     ibverbx::ibv_mr* sinkMr{nullptr};
+    bool useReliableDoorbell{false};
     std::vector<doca_gpu_verbs_qp_group_hl*> blockQpGroups;
     std::vector<doca_gpu_verbs_qp_hl*> extraMainQps;
     std::vector<doca_gpu_verbs_qp_hl*> loopbackCompanionQps;

--- a/comms/utils/cvars/extractcvars.py
+++ b/comms/utils/cvars/extractcvars.py
@@ -30,6 +30,14 @@ int_cvar_for_unit_tests: str = "__NCCL_UNIT_TEST_INT_CVAR__"
 bool_cvar_for_unit_tests: str = "__NCCL_UNIT_TEST_BOOL_CVAR__"
 double_cvar_for_unit_tests: str = "__NCCL_UNIT_TEST_DOUBLE_CVAR__"
 
+CPP_ENUM_CHOICE_ESCAPES: dict[str, str] = {
+    "auto": "auto_",
+}
+
+
+def cpp_enum_choice_name(choice: str) -> str:
+    return CPP_ENUM_CHOICE_ESCAPES.get(choice, choice)
+
 
 @functools.lru_cache(maxsize=1)
 def fbsource_root():
@@ -366,7 +374,7 @@ class enum(basetype):
         choiceList = self.choices.replace(" ", "").split(",")
         indent(file, "enum class %s {" % self.name)
         for c in choiceList:
-            indent(file, "%s," % c)
+            indent(file, "%s," % cpp_enum_choice_name(c))
         indent(file, "};")
         indent(file, "extern enum %s %s;" % (self.name, self.name))
         indent(file, "extern enum %s %s_DEFAULTCVARVALUE;" % (self.name, self.name))
@@ -378,7 +386,10 @@ class enum(basetype):
 
     def readenv(self, file):
         indent(file, 'if (getenv("%s") == nullptr) {' % self.envstr)
-        indent(file, "%s = %s::%s;" % (self.name, self.name, self.default))
+        indent(
+            file,
+            "%s = %s::%s;" % (self.name, self.name, cpp_enum_choice_name(self.default)),
+        )
         indent(file, "} else {")
         indent(file, 'std::string str(getenv("%s"));' % self.envstr)
         choices = self.choices.replace(" ", "").split(",")
@@ -387,13 +398,18 @@ class enum(basetype):
                 indent(file, 'if (str == std::string("%s")) {' % c)
             else:
                 indent(file, '} else if (str == std::string("%s")) {' % c)
-            indent(file, "%s = %s::%s;" % (self.name, self.name, c))
+            indent(
+                file,
+                "%s = %s::%s;" % (self.name, self.name, cpp_enum_choice_name(c)),
+            )
         indent(file, "} else {")
         indent(file, '  CVAR_WARN_UNKNOWN_VALUE("%s", str.c_str());' % self.name)
         indent(file, "}")
         indent(file, "}")
         indent(
-            file, "%s_DEFAULTCVARVALUE = %s::%s;" % (self.name, self.name, self.default)
+            file,
+            "%s_DEFAULTCVARVALUE = %s::%s;"
+            % (self.name, self.name, cpp_enum_choice_name(self.default)),
         )
         file.write("\n")
 
@@ -407,7 +423,7 @@ class enumlist(basetype):
         choiceList = self.choices.replace(" ", "").split(",")
         indent(file, "enum class %s {" % self.name)
         for c in choiceList:
-            indent(file, "%s," % c)
+            indent(file, "%s," % cpp_enum_choice_name(c))
         indent(file, "};")
         indent(file, "extern std::vector<enum %s> %s;" % (self.name, self.name))
         indent(
@@ -435,7 +451,11 @@ class enumlist(basetype):
                 indent(file, 'if (token == std::string("%s")) {' % c)
             else:
                 indent(file, '} else if (token == std::string("%s")) {' % c)
-            indent(file, "%s.emplace_back(%s::%s);" % (self.name, self.name, c))
+            indent(
+                file,
+                "%s.emplace_back(%s::%s);"
+                % (self.name, self.name, cpp_enum_choice_name(c)),
+            )
         indent(file, "} else {")
         indent(file, '  CVAR_WARN_UNKNOWN_VALUE("%s", token.c_str());' % self.name)
         indent(file, "}")
@@ -446,7 +466,8 @@ class enumlist(basetype):
         for d in default:
             indent(
                 file,
-                "%s_DEFAULTCVARVALUE.emplace_back(%s::%s);" % (self.name, self.name, d),
+                "%s_DEFAULTCVARVALUE.emplace_back(%s::%s);"
+                % (self.name, self.name, cpp_enum_choice_name(d)),
             )
         file.write("\n")
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3338,6 +3338,19 @@ cvars:
      ibgda - use GPU-posted IBGDA.
      ibrc - use CPU-posted IBRC.
 
+ - name        : MCCL_IBGDA_RELIABLE_DOORBELL_MODE
+   type        : enum
+   default     : auto
+   choices     : auto, enable, disable
+   description : |-
+     Select the reliable-doorbell policy for the Prims IBGDA transport.
+     auto queries each selected NIC for send_dbr_mode_no_dbr_ext and uses
+     NO_DBR_HW only when supported, falling back to VALID_DBR on unsupported
+     NICs or query failures. enable requires every selected NIC to report
+     support and fails transport initialization otherwise. disable skips the
+     capability query and forces VALID_DBR. Host-only loopback QPs always use
+     VALID_DBR. This policy is NVIDIA-only and ignored on AMD.
+
  - name        : MCCL_IB_QP_DEPTH
    type        : uint64_t
    default     : 1024

--- a/comms/utils/cvars/tests/CvarInitUT.cc
+++ b/comms/utils/cvars/tests/CvarInitUT.cc
@@ -9,6 +9,7 @@
 #include "comms/utils/cvars/nccl_cvars.h" // @manual
 
 #include <string>
+#include <utility>
 #include <vector>
 
 class NCCLCvarInitEnvironment : public ::testing::Environment {
@@ -49,12 +50,38 @@ class CvarInitTest : public ::testing::Test {
     unsetenv("CUDA_LAUNCH_BLOCKING");
     unsetenv("NCCL_MIN_CTAS");
     unsetenv("MCCL_BOOTSTRAP_TCP_KEEPALIVE_ENABLED");
+    unsetenv("MCCL_IBGDA_RELIABLE_DOORBELL_MODE");
   }
 };
 
 TEST_F(CvarInitTest, BasicInitialization) {
   // Test basic ncclCvarInit functionality
   EXPECT_NO_THROW(ncclCvarInit());
+}
+
+TEST_F(CvarInitTest, McclIbgdaReliableDoorbellModeDefaultsToAuto) {
+  MCCL_IBGDA_RELIABLE_DOORBELL_MODE =
+      MCCL_IBGDA_RELIABLE_DOORBELL_MODE::disable;
+  ncclCvarInit();
+  EXPECT_EQ(
+      MCCL_IBGDA_RELIABLE_DOORBELL_MODE,
+      MCCL_IBGDA_RELIABLE_DOORBELL_MODE::auto_);
+}
+
+TEST_F(CvarInitTest, McclIbgdaReliableDoorbellModeParsesAllModes) {
+  using Mode = decltype(MCCL_IBGDA_RELIABLE_DOORBELL_MODE);
+  const std::vector<std::pair<const char*, Mode>> modes{
+      {"auto", Mode::auto_},
+      {"enable", Mode::enable},
+      {"disable", Mode::disable},
+  };
+  for (const auto& [value, expected] : modes) {
+    MCCL_IBGDA_RELIABLE_DOORBELL_MODE =
+        expected == Mode::auto_ ? Mode::enable : Mode::auto_;
+    setenv("MCCL_IBGDA_RELIABLE_DOORBELL_MODE", value, 1);
+    ncclCvarInit();
+    EXPECT_EQ(MCCL_IBGDA_RELIABLE_DOORBELL_MODE, expected);
+  }
 }
 
 TEST_F(CvarInitTest, McclBootstrapTcpKeepaliveDisabledByDefault) {


### PR DESCRIPTION
Summary:

Query `send_dbr_mode_no_dbr_ext` once for each selected NIC and select `NO_DBR_HW` for main GPU QP groups when the hardware supports it. Fail closed to `VALID_DBR` for unsupported NICs and query failures, and keep host-only loopback QPs on `VALID_DBR`.

Differential Revision: D115639553


