### PR TITLE
Separate multimem capacity from launch geometry (#3619)

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -51,12 +51,12 @@ struct ctranPrimsConfig {
   // fixes the per-chunk size: chunk = channelBufferSize / channelPipelineDepth.
   int64_t channelPipelineDepth{-1};
   // -1 uses MCCL_MAX_NCHANNELS. Total IB staging for this communicator is
-  // channelBufferSize * maxChannels per peer per direction.
+  // channelBufferSize * maxChannels per peer per direction. Multimem staging
+  // capacity is also provisioned for this many channels.
   int64_t maxChannels{-1};
-  // -1 uses MCCL_MAX_NBLOCKS. As with the CVAR, this is both the NVL channel
-  // count and the collective launch-geometry block cap; the two must move
-  // together or the multimem signal sizing drifts from the transport's actual
-  // channel count.
+  // -1 uses MCCL_MAX_NBLOCKS. This is the collective launch-geometry block
+  // cap. Multimem requires it not to exceed maxChannels because a launch
+  // cannot consume more blocks than the provisioned channel capacity.
   int64_t maxBlocks{-1};
 
   bool operator==(const ctranPrimsConfig& other) const {

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -46,8 +46,18 @@ int ctranPipesNvlMaxNumChannels(const ctranPrimsConfig& pc) {
   return std::max(1, static_cast<int>(resolved));
 }
 
-size_t roundDownToMultiple(size_t value, size_t multiple) {
-  return multiple == 0 ? 0 : (value / multiple) * multiple;
+size_t alignedPerChannelSize(
+    size_t totalSize,
+    size_t maxChannels,
+    size_t pipelineDepth) {
+  constexpr size_t kDataAlignment = 16;
+  if (maxChannels == 0 || pipelineDepth == 0 ||
+      pipelineDepth > std::numeric_limits<size_t>::max() / kDataAlignment) {
+    return 0;
+  }
+
+  const size_t alignment = kDataAlignment * pipelineDepth;
+  return (totalSize / maxChannels / alignment) * alignment;
 }
 
 } // namespace
@@ -112,9 +122,8 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     config.nvlConfig.maxNumChannels = ctranPipesNvlMaxNumChannels(pc);
     const size_t nvlMaxNumChannels =
         static_cast<size_t>(config.nvlConfig.maxNumChannels);
-    const size_t nvlChannelAlign = 16ULL * config.nvlConfig.pipelineDepth;
-    config.nvlConfig.perChannelSize = roundDownToMultiple(
-        nvlSharedDevbufSize / nvlMaxNumChannels, nvlChannelAlign);
+    config.nvlConfig.perChannelSize = alignedPerChannelSize(
+        nvlSharedDevbufSize, nvlMaxNumChannels, config.nvlConfig.pipelineDepth);
     if (config.nvlConfig.perChannelSize == 0) {
       CLOGF(
           ERR,
@@ -139,19 +148,42 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     if (comm->statex_->nLocalRanks() > 2 && multimemDevbufSize > 0) {
       const std::size_t multimemPipelineDepth =
           std::max<std::size_t>(1, config.nvlConfig.pipelineDepth);
-      // Reuse the already-computed channel count (config.nvlConfig
-      // .maxNumChannels, resolved from primsConfig.maxBlocks or
-      // MCCL_MAX_NBLOCKS) as the channel count so signal sizing cannot drift
-      // from the transport's actual channel count. Do not re-derive it here.
-      const std::size_t multimemMaxChannels =
-          static_cast<std::size_t>(config.nvlConfig.maxNumChannels);
+      const auto resolvedMaxChannels = ctranPrimsResolvedMaxChannels(pc);
+      const auto resolvedMaxBlocks = ctranPrimsResolvedMaxBlocks(pc);
+      const size_t multimemMaxChannels = resolvedMaxChannels > 0
+          ? static_cast<size_t>(resolvedMaxChannels)
+          : 0;
+      const size_t multimemMaxBlocks =
+          resolvedMaxBlocks > 0 ? static_cast<size_t>(resolvedMaxBlocks) : 0;
+      if (multimemMaxBlocks > multimemMaxChannels) {
+        CLOGF(
+            ERR,
+            "CTRAN-PRIMS: invalid multimem config; maxBlocks={} exceeds maxChannels={}",
+            multimemMaxBlocks,
+            multimemMaxChannels);
+        return commInvalidArgument;
+      }
+      const size_t multimemPerChannelSize = alignedPerChannelSize(
+          multimemDevbufSize, multimemMaxChannels, multimemPipelineDepth);
+      if (multimemPerChannelSize == 0) {
+        CLOGF(
+            ERR,
+            "CTRAN-PRIMS: invalid multimem config; devbufSize={} maxChannels={} pipelineDepth={} cannot produce aligned perChannelSize",
+            multimemDevbufSize,
+            multimemMaxChannels,
+            multimemPipelineDepth);
+        return commInvalidArgument;
+      }
+
       config.nvlConfig.enableMultimem = true;
-      config.nvlConfig.multimem = comms::prims::MultimemNvlTransportConfig{
-          .dataBufferSize = multimemDevbufSize,
-          .userSignalCount = 1,
-          .pipelineDepth = multimemPipelineDepth,
-          .maxChannels = multimemMaxChannels,
-      };
+      config.nvlConfig.multimem =
+          comms::prims::make_multimem_nvl_transport_config({
+              .perChannelSize = multimemPerChannelSize,
+              .pipelineDepth = multimemPipelineDepth,
+              .maxChannels = multimemMaxChannels,
+              .maxBlocks = multimemMaxBlocks,
+              .userSignalCount = 1,
+          });
     }
 
     // LL128 buffer allocation for DeviceAllToAllv

--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -156,6 +156,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMulticastAllocation.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/MultimemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/NvlMemExchange.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultimemNvlTransportConfig.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultimemNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerTransport.cc

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -176,6 +176,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMulticastAllocation.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/MultimemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/NvlMemExchange.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultimemNvlTransportConfig.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultimemNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerTransport.cc

--- a/comms/prims/memory/NvlMemExchange.h
+++ b/comms/prims/memory/NvlMemExchange.h
@@ -38,7 +38,7 @@ namespace comms::prims {
 struct MulticastExchangeContract {
   uint64_t protocol{0};
   uint64_t version{0};
-  std::array<uint64_t, 4> parameters{};
+  std::array<uint64_t, 5> parameters{};
 
   bool operator==(const MulticastExchangeContract& other) const {
     return protocol == other.protocol && version == other.version &&

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -9,6 +9,7 @@
 #include <folly/futures/Future.h>
 #include <folly/init/Init.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -78,12 +79,15 @@ MultimemNvlTransportConfig makeConfig(
     uint32_t userSignalCount = 1,
     std::size_t pipelineDepth = 0,
     std::size_t maxChannels = 0) {
-  MultimemNvlTransportConfig config{};
-  config.dataBufferSize = dataBufferSize;
-  config.userSignalCount = userSignalCount;
-  config.pipelineDepth = pipelineDepth;
-  config.maxChannels = maxChannels;
-  return config;
+  const std::size_t effectiveMaxChannels =
+      std::max<std::size_t>(1, maxChannels);
+  return make_multimem_nvl_transport_config({
+      .perChannelSize = dataBufferSize / effectiveMaxChannels,
+      .pipelineDepth = pipelineDepth,
+      .maxChannels = effectiveMaxChannels,
+      .maxBlocks = maxChannels,
+      .userSignalCount = userSignalCount,
+  });
 }
 
 using meta::comms::testing::MockBootstrap;
@@ -384,13 +388,13 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
-      .multimem =
-          MultimemNvlTransportConfig{
-              .dataBufferSize = 0,
-              .userSignalCount = 1,
-              .pipelineDepth = 1,
-              .maxChannels = 1,
-          },
+      .multimem = make_multimem_nvl_transport_config({
+          .perChannelSize = 0,
+          .pipelineDepth = 1,
+          .maxChannels = 1,
+          .maxBlocks = 1,
+          .userSignalCount = 1,
+      }),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -430,13 +434,13 @@ TEST_F(
         .p2pSignalCount = 1,
         .maxNumChannels = 0,
         .enableMultimem = true,
-        .multimem =
-            MultimemNvlTransportConfig{
-                .dataBufferSize = 4096,
-                .userSignalCount = 1,
-                .pipelineDepth = 1,
-                .maxChannels = 1,
-            },
+        .multimem = make_multimem_nvl_transport_config({
+            .perChannelSize = 4096,
+            .pipelineDepth = 1,
+            .maxChannels = 1,
+            .maxBlocks = 1,
+            .userSignalCount = 1,
+        }),
     };
     MultiPeerNvlTransport transport(
         globalRank, numRanks, localRank, bootstrap, config);
@@ -484,13 +488,13 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
-      .multimem =
-          MultimemNvlTransportConfig{
-              .dataBufferSize = 4096,
-              .userSignalCount = 1,
-              .pipelineDepth = 1,
-              .maxChannels = 1,
-          },
+      .multimem = make_multimem_nvl_transport_config({
+          .perChannelSize = 4096,
+          .pipelineDepth = 1,
+          .maxChannels = 1,
+          .maxBlocks = 1,
+          .userSignalCount = 1,
+      }),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -537,13 +541,13 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
-      .multimem =
-          MultimemNvlTransportConfig{
-              .dataBufferSize = 4096,
-              .userSignalCount = 1,
-              .pipelineDepth = 1,
-              .maxChannels = 1,
-          },
+      .multimem = make_multimem_nvl_transport_config({
+          .perChannelSize = 4096,
+          .pipelineDepth = 1,
+          .maxChannels = 1,
+          .maxBlocks = 1,
+          .userSignalCount = 1,
+      }),
   };
   MultiPeerNvlTransport transport(
       /*myRank=*/0,
@@ -576,14 +580,13 @@ TEST_F(
       // channels (a nonzero maxNumChannels requires pipelineDepth >= 1).
       .maxNumChannels = 0,
       .enableMultimem = true,
-      .multimem =
-          MultimemNvlTransportConfig{
-              .dataBufferSize =
-                  kBytesPerRank * static_cast<std::size_t>(numRanks),
-              .userSignalCount = 1,
-              .pipelineDepth = 1,
-              .maxChannels = 1,
-          },
+      .multimem = make_multimem_nvl_transport_config({
+          .perChannelSize = kBytesPerRank * static_cast<std::size_t>(numRanks),
+          .pipelineDepth = 1,
+          .maxChannels = 1,
+          .maxBlocks = 1,
+          .userSignalCount = 1,
+      }),
   };
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   EXPECT_FALSE(transport.hasMultimemNvlTransport());
@@ -606,14 +609,14 @@ TEST_F(
       .p2pSignalCount = 1,
       .maxNumChannels = 0,
       .enableMultimem = true,
-      .multimem =
-          MultimemNvlTransportConfig{
-              .dataBufferSize =
-                  globalRank == 0 ? std::size_t{0} : std::size_t{4096},
-              .userSignalCount = 1,
-              .pipelineDepth = 1,
-              .maxChannels = 1,
-          },
+      .multimem = make_multimem_nvl_transport_config({
+          .perChannelSize =
+              globalRank == 0 ? std::size_t{0} : std::size_t{4096},
+          .pipelineDepth = 1,
+          .maxChannels = 1,
+          .maxBlocks = 1,
+          .userSignalCount = 1,
+      }),
   };
   MultiPeerNvlTransport transport(
       globalRank, numRanks, localRank, bootstrap, config);
@@ -710,6 +713,42 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
   ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 }
 
+TEST_F(MultimemNvlTransportTestFixture, ExchangeSupportsDataOnlyConfiguration) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_exchange_data_only");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kDataBytes = 4096;
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(
+          kDataBytes,
+          /*userSignalCount=*/0,
+          /*pipelineDepth=*/0,
+          /*maxChannels=*/0));
+
+  transport.exchange();
+  const auto handle = transport.getDeviceTransport();
+
+  EXPECT_EQ(handle.dataBufferSize, kDataBytes);
+  EXPECT_TRUE(handle.userLocalSignals.empty());
+  EXPECT_TRUE(handle.userMultimemSignals.empty());
+  EXPECT_TRUE(handle.internalLocalSignals.empty());
+  EXPECT_TRUE(handle.internalMultimemSignals.empty());
+  EXPECT_EQ(handle.pipelineDepth, 0);
+  EXPECT_EQ(handle.maxChannels, 1);
+  EXPECT_EQ(handle.signalsPerLane, 0);
+  EXPECT_EQ(transport.getAllocatedSignalBufferSize(), 0);
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
 TEST_F(
     MultimemNvlTransportTestFixture,
     ExchangeRejectsMismatchedStagingGeometry) {
@@ -736,9 +775,43 @@ TEST_F(
     EXPECT_NE(
         message.find("ranks disagree on multicast setup"), std::string::npos)
         << message;
-    EXPECT_NE(message.find("parameters=[8192, 1, 2, 4]"), std::string::npos)
+    EXPECT_NE(message.find("parameters=[2048, 2, 4, 4, 1]"), std::string::npos)
         << message;
-    EXPECT_NE(message.find("parameters=[8192, 1, 4, 2]"), std::string::npos)
+    EXPECT_NE(message.find("parameters=[4096, 4, 2, 2, 1]"), std::string::npos)
+        << message;
+  }
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    ExchangeRejectsMismatchedUserSignalLayout) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_exchange_mismatched_user_signals");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  const uint32_t userSignalCount = globalRank == 0 ? 1 : 2;
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(8192, userSignalCount, 1, 1));
+  try {
+    transport.exchange();
+    FAIL() << "expected setup agreement to reject mismatched signal layout";
+  } catch (const std::runtime_error& ex) {
+    const std::string message = ex.what();
+    EXPECT_NE(
+        message.find("ranks disagree on multicast setup"), std::string::npos)
+        << message;
+    EXPECT_NE(message.find("parameters=[8192, 1, 1, 1, 1]"), std::string::npos)
+        << message;
+    EXPECT_NE(message.find("parameters=[8192, 1, 1, 1, 2]"), std::string::npos)
         << message;
   }
 

--- a/comms/prims/tests/MultimemNvlTransportValidationTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportValidationTest.cc
@@ -8,6 +8,7 @@
 #include <limits>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -29,27 +30,72 @@ void expectRuntimeErrorContains(Fn&& fn, const std::string& expected) {
 }
 
 MultimemNvlTransportConfig makeConfig(
-    std::size_t dataBufferSize,
+    std::size_t perChannelSize,
     uint32_t userSignalCount = 1,
     std::size_t pipelineDepth = 0,
-    std::size_t maxChannels = 0) {
-  MultimemNvlTransportConfig config{};
-  config.dataBufferSize = dataBufferSize;
-  config.userSignalCount = userSignalCount;
-  config.pipelineDepth = pipelineDepth;
-  config.maxChannels = maxChannels;
-  return config;
+    std::size_t maxChannels = 1,
+    std::size_t maxBlocks = 0) {
+  return make_multimem_nvl_transport_config({
+      .perChannelSize = perChannelSize,
+      .pipelineDepth = pipelineDepth,
+      .maxChannels = maxChannels,
+      .maxBlocks = maxBlocks,
+      .userSignalCount = userSignalCount,
+  });
 }
 
 } // namespace
 
 TEST(MultimemNvlTransportConfigTest, DerivesUserOnlyConfiguration) {
+  const auto validation =
+      validate_multimem_nvl_transport_config(makeConfig(256), 4);
+  EXPECT_TRUE(validation);
+  EXPECT_EQ(validation.internalSignalCount, 0);
+}
+
+TEST(
+    MultimemNvlTransportConfigTest,
+    DerivesDataAndSignalsFromChannelCapacityAndIndependentBlockLimit) {
+  const auto config = make_multimem_nvl_transport_config({
+      .perChannelSize = 1024,
+      .pipelineDepth = 2,
+      .maxChannels = 8,
+      .maxBlocks = 3,
+      .userSignalCount = 1,
+  });
+
+  const auto validation = validate_multimem_nvl_transport_config(config, 4);
+
+  ASSERT_TRUE(validation);
+  EXPECT_EQ(validation.dataBufferSize, 8192);
+  EXPECT_EQ(validation.internalSignalCount, 192);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsDataBufferMultiplicationOverflow) {
+  const auto config = make_multimem_nvl_transport_config({
+      .perChannelSize = std::numeric_limits<std::size_t>::max(),
+      .pipelineDepth = 0,
+      .maxChannels = 2,
+      .maxBlocks = 0,
+      .userSignalCount = 1,
+  });
+
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(makeConfig(256), 4), 0);
+      validate_multimem_nvl_transport_config(config, 4).errorMessage,
+      "per-channel size times maximum channels overflows");
 }
 
 TEST(MultimemNvlTransportConfigTest, PreservesDefaultUserSignalCount) {
   EXPECT_EQ(MultimemNvlTransportConfig{}.userSignalCount, 1);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsLegacyPositionalConstruction) {
+  EXPECT_FALSE((std::is_constructible_v<
+                MultimemNvlTransportConfig,
+                std::size_t,
+                uint32_t,
+                std::size_t,
+                std::size_t>));
 }
 
 TEST(MultimemNvlTransportDeviceTest, PreservesLegacyPositionalRankFields) {
@@ -60,47 +106,99 @@ TEST(MultimemNvlTransportDeviceTest, PreservesLegacyPositionalRankFields) {
 }
 
 TEST(MultimemNvlTransportConfigTest, DerivesStagingOnlyConfiguration) {
-  EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(256, 0, 2, 2), 4),
-      48);
+  const auto validation =
+      validate_multimem_nvl_transport_config(makeConfig(128, 0, 2, 2, 2), 4);
+  EXPECT_TRUE(validation);
+  EXPECT_EQ(validation.internalSignalCount, 48);
 }
 
 TEST(MultimemNvlTransportConfigTest, DerivesMixedConfiguration) {
-  EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(256, 7, 2, 2), 4),
-      48);
+  const auto validation =
+      validate_multimem_nvl_transport_config(makeConfig(128, 7, 2, 2, 2), 4);
+  EXPECT_TRUE(validation);
+  EXPECT_EQ(validation.internalSignalCount, 48);
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsPartialStagingGeometry) {
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(256, 1, 2, 0), 4),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(256, 1, 2, 1, 0), 4)
+          .errorMessage,
+      "pipeline depth and maximum blocks must both be zero or non-zero");
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(256, 1, 0, 2), 4),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(128, 1, 0, 2, 2), 4)
+          .errorMessage,
+      "pipeline depth and maximum blocks must both be zero or non-zero");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsInvalidRankCount) {
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(256, 1, 1, 1), 0),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(256, 1, 1, 1, 1), 0)
+          .errorMessage,
+      "NVL rank count must be positive");
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsMissingPerChannelSize) {
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(std::numeric_limits<std::size_t>::max(), 1, 1, 1),
-          std::numeric_limits<int>::max()),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(0, 1), 4).errorMessage,
+      "per-channel size must be non-zero");
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsMissingMaxChannels) {
+  const auto config = make_multimem_nvl_transport_config({
+      .perChannelSize = 256,
+      .pipelineDepth = 0,
+      .maxChannels = 0,
+      .maxBlocks = 0,
+      .userSignalCount = 1,
+  });
+  EXPECT_EQ(
+      validate_multimem_nvl_transport_config(config, 4).errorMessage,
+      "maximum channels must be non-zero");
+}
+
+TEST(MultimemNvlTransportConfigTest, AcceptsNoSignalSlots) {
+  const auto validation =
+      validate_multimem_nvl_transport_config(makeConfig(256, 0), 4);
+
+  EXPECT_TRUE(validation);
+  EXPECT_EQ(validation.dataBufferSize, 256);
+  EXPECT_EQ(validation.internalSignalCount, 0);
+  EXPECT_EQ(validation.signalRegionOffset, 256);
+  EXPECT_EQ(validation.backingAllocationSize, 256);
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsMaxBlocksAboveMaxChannels) {
+  const auto config = make_multimem_nvl_transport_config({
+      .perChannelSize = 64,
+      .pipelineDepth = 1,
+      .maxChannels = 2,
+      .maxBlocks = 3,
+      .userSignalCount = 1,
+  });
+
+  EXPECT_EQ(
+      validate_multimem_nvl_transport_config(config, 4).errorMessage,
+      "maximum blocks must not exceed maximum channels");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsInsufficientDataCapacity) {
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(255, 1, 2, 2), 4),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(makeConfig(64, 1, 2, 2, 2), 4)
+          .errorMessage,
+      "data buffer is too small for the staging geometry");
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsMisalignedPerChannelSize) {
+  const auto config = make_multimem_nvl_transport_config({
+      .perChannelSize = 48,
+      .pipelineDepth = 2,
+      .maxChannels = 4,
+      .maxBlocks = 1,
+      .userSignalCount = 1,
+  });
+  EXPECT_EQ(
+      validate_multimem_nvl_transport_config(config, 4).errorMessage,
+      "per-channel size must be divisible by pipeline depth times 16");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsInternalSignalOverflow) {
@@ -111,51 +209,76 @@ TEST(MultimemNvlTransportConfigTest, RejectsInternalSignalOverflow) {
       std::numeric_limits<int>::max() / kSignalsPerLane + 1;
   const std::size_t requiredDataBytes = pipelineDepth * kRanks * 16;
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(requiredDataBytes, 1, pipelineDepth, 1), kRanks),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(
+          makeConfig(requiredDataBytes, 1, pipelineDepth, 1, 1), kRanks)
+          .errorMessage,
+      "signal count exceeds INT_MAX");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsPipelineDepthOutsideDeviceRange) {
   constexpr std::size_t kOutsideDeviceRange =
       static_cast<std::size_t>(std::numeric_limits<uint32_t>::max()) + 1;
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
+      validate_multimem_nvl_transport_config(
           makeConfig(
-              std::numeric_limits<std::size_t>::max(),
-              1,
-              kOutsideDeviceRange,
-              1),
-          4),
-      std::nullopt);
+              /*perChannelSize=*/16,
+              /*userSignalCount=*/1,
+              /*pipelineDepth=*/kOutsideDeviceRange,
+              /*maxChannels=*/1,
+              /*maxBlocks=*/1),
+          4)
+          .errorMessage,
+      "transport geometry exceeds UINT32_MAX");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsMaxChannelsOutsideDeviceRange) {
   constexpr std::size_t kOutsideDeviceRange =
       static_cast<std::size_t>(std::numeric_limits<uint32_t>::max()) + 1;
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
+      validate_multimem_nvl_transport_config(
           makeConfig(
-              std::numeric_limits<std::size_t>::max(),
-              1,
-              1,
-              kOutsideDeviceRange),
-          4),
-      std::nullopt);
+              /*perChannelSize=*/16,
+              /*userSignalCount=*/1,
+              /*pipelineDepth=*/1,
+              /*maxChannels=*/kOutsideDeviceRange,
+              /*maxBlocks=*/1),
+          4)
+          .errorMessage,
+      "transport geometry exceeds UINT32_MAX");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsTotalSignalOverflow) {
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(64, std::numeric_limits<int>::max(), 1, 1), 4),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(
+          makeConfig(64, std::numeric_limits<int>::max(), 1, 1, 1), 4)
+          .errorMessage,
+      "signal count exceeds INT_MAX");
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsDataAlignmentOverflow) {
+  EXPECT_EQ(
+      validate_multimem_nvl_transport_config(
+          makeConfig(std::numeric_limits<std::size_t>::max(), 1), 4)
+          .errorMessage,
+      "combined data and signal allocation size overflows");
+}
+
+TEST(MultimemNvlTransportConfigTest, RejectsCombinedAllocationOverflow) {
+  constexpr auto kAlignment = detail::kMultimemSignalAlignment;
+  const auto dataBufferSize =
+      std::numeric_limits<std::size_t>::max() - (kAlignment - 1);
+  EXPECT_EQ(
+      validate_multimem_nvl_transport_config(makeConfig(dataBufferSize, 1), 4)
+          .errorMessage,
+      "combined data and signal allocation size overflows");
 }
 
 TEST(MultimemNvlTransportConfigTest, RejectsUserSignalCountOutsideSignedRange) {
   EXPECT_EQ(
-      detail::checked_multimem_internal_signal_count(
-          makeConfig(64, std::numeric_limits<uint32_t>::max(), 0, 0), 4),
-      std::nullopt);
+      validate_multimem_nvl_transport_config(
+          makeConfig(64, std::numeric_limits<uint32_t>::max()), 4)
+          .errorMessage,
+      "signal count exceeds INT_MAX");
 }
 
 // validateRankMap runs before any GPU access in the constructor; these cases
@@ -205,7 +328,8 @@ TEST(MultimemNvlTransportValidationTest, IsEligibleRequiresMoreThanTwoRanks) {
 
 TEST(MultimemNvlTransportValidationTest, CompatCtorRejectsNegativeNvlRank) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize = 1024;
+  config.perChannelSize = 1024;
+  config.maxChannels = 1;
   expectRuntimeErrorContains(
       [&] {
         MultimemNvlTransport(
@@ -216,7 +340,8 @@ TEST(MultimemNvlTransportValidationTest, CompatCtorRejectsNegativeNvlRank) {
 
 TEST(MultimemNvlTransportValidationTest, CompatCtorRejectsOutOfRangeNvlRank) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize = 1024;
+  config.perChannelSize = 1024;
+  config.maxChannels = 1;
   expectRuntimeErrorContains(
       [&] {
         MultimemNvlTransport(
@@ -229,9 +354,10 @@ TEST(MultimemNvlTransportValidationTest, CompatCtorRejectsOutOfRangeNvlRank) {
 // cudaGetDevice, so they are exercisable on CPU-only hosts with a null
 // bootstrap: none of the code paths past these throws is reached.
 
-TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroDataBufferSize) {
+TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroPerChannelSize) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize = 0; // triggers the guard
+  config.perChannelSize = 0;
+  config.maxChannels = 1;
   config.userSignalCount = 1;
   expectRuntimeErrorContains(
       [&] {
@@ -241,32 +367,18 @@ TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroDataBufferSize) {
             /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
             config);
       },
-      "dataBufferSize must be non-zero");
-}
-
-TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroSignalCount) {
-  MultimemNvlTransportConfig config{};
-  config.dataBufferSize = 1024;
-  config.userSignalCount = 0;
-  expectRuntimeErrorContains(
-      [&] {
-        MultimemNvlTransport(
-            /*bootstrap=*/nullptr,
-            /*commRank=*/0,
-            /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
-            config);
-      },
-      "at least one signal slot is required");
+      "per-channel size must be non-zero");
 }
 
 TEST(
     MultimemNvlTransportValidationTest,
     PrimaryCtorRejectsTotalSignalCountOverflow) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize = 64;
+  config.perChannelSize = 64;
   config.userSignalCount = std::numeric_limits<int>::max();
   config.pipelineDepth = 1;
   config.maxChannels = 1;
+  config.maxBlocks = 1;
   expectRuntimeErrorContains(
       [&] {
         MultimemNvlTransport(
@@ -275,14 +387,15 @@ TEST(
             /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
             config);
       },
-      "invalid staging geometry or capacity");
+      "signal count exceeds INT_MAX");
 }
 
 TEST(
     MultimemNvlTransportValidationTest,
     PrimaryCtorRejectsDataBufferAlignmentOverflow) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize = std::numeric_limits<std::size_t>::max();
+  config.perChannelSize = std::numeric_limits<std::size_t>::max();
+  config.maxChannels = 1;
   config.userSignalCount = 1;
   expectRuntimeErrorContains(
       [&] {
@@ -292,15 +405,16 @@ TEST(
             /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
             config);
       },
-      "dataBufferSize alignment overflows");
+      "combined data and signal allocation size overflows");
 }
 
 TEST(
     MultimemNvlTransportValidationTest,
     PrimaryCtorRejectsCombinedAllocationSizeOverflow) {
   MultimemNvlTransportConfig config{};
-  config.dataBufferSize =
+  config.perChannelSize =
       std::numeric_limits<std::size_t>::max() - (alignof(SignalState) - 1);
+  config.maxChannels = 1;
   config.userSignalCount = 1;
   expectRuntimeErrorContains(
       [&] {
@@ -310,7 +424,7 @@ TEST(
             /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
             config);
       },
-      "combined allocation size overflows");
+      "combined data and signal allocation size overflows");
 }
 
 } // namespace comms::prims::tests

--- a/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlStageLayout.cuh
@@ -151,8 +151,9 @@ __device__ __forceinline__ StageLayout make_stage_layout(
     __trap();
   }
 #endif
-  const uint64_t expectedSignalsPerLane = multimem_staging_signals_per_lane(
-      static_cast<uint32_t>(transport.nvlRanks));
+  const uint64_t expectedSignalsPerLane =
+      comms::prims::multimem_staging_signals_per_lane(
+          static_cast<uint32_t>(transport.nvlRanks));
   const uint64_t signalsPerLane = transport.signalsPerLane;
 #if defined(__CUDA_ARCH__)
   if (signalsPerLane != expectedSignalsPerLane) {

--- a/comms/prims/transport/nvl/MultimemNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.cc
@@ -2,13 +2,11 @@
 
 #include "comms/prims/transport/nvl/MultimemNvlTransport.h"
 
-#include <limits>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <utility>
 
-#include "comms/common/BitOps.cuh"
 #include "comms/prims/core/SignalState.cuh"
 #include "comms/utils/checks.h"
 
@@ -17,7 +15,7 @@ namespace comms::prims {
 namespace {
 
 constexpr uint64_t kMultimemNvlTransportProtocol = 0x4D4D4E564CULL;
-constexpr uint64_t kMultimemNvlTransportProtocolVersion = 1;
+constexpr uint64_t kMultimemNvlTransportProtocolVersion = 4;
 
 int getCurrentCudaDevice() {
   int cudaDevice = 0;
@@ -86,32 +84,19 @@ MultimemNvlTransport::MultimemNvlTransport(
   // are exercisable on CPU-only hosts (see MultimemNvlTransportValidationTest).
   validateRankMap(commRank_, nvlRankToCommRank_);
 
-  if (config_.dataBufferSize == 0) {
+  const auto validation =
+      validate_multimem_nvl_transport_config(config_, nvlRanks_);
+  if (!validation) {
     throw std::runtime_error(
-        "MultimemNvlTransport: dataBufferSize must be non-zero");
+        std::string("MultimemNvlTransport: ") +
+        std::string(validation.errorMessage));
   }
-  const auto internalSignalCount =
-      detail::checked_multimem_internal_signal_count(config_, nvlRanks_);
-  if (!internalSignalCount.has_value()) {
-    throw std::runtime_error(
-        "MultimemNvlTransport: invalid staging geometry or capacity");
-  }
-  internalSignalCount_ = *internalSignalCount;
+  dataBufferSize_ = validation.dataBufferSize;
+  internalSignalCount_ = validation.internalSignalCount;
   if (config_.pipelineDepth != 0) {
     signalsPerLane_ =
         multimem_staging_signals_per_lane(static_cast<uint32_t>(nvlRanks_));
   }
-  const uint64_t totalSignalCount =
-      static_cast<uint64_t>(config_.userSignalCount) + internalSignalCount_;
-  if (totalSignalCount == 0) {
-    throw std::runtime_error(
-        "MultimemNvlTransport: at least one signal slot is required");
-  }
-  if (totalSignalCount >
-      static_cast<uint64_t>(std::numeric_limits<int>::max())) {
-    throw std::runtime_error("MultimemNvlTransport: signalCount too large");
-  }
-
   // commRank presence in the map is already verified by validateRankMap.
   int nvlRank = -1;
   for (int rank = 0; rank < nvlRanks_; ++rank) {
@@ -129,22 +114,11 @@ MultimemNvlTransport::MultimemNvlTransport(
   }
   nvlRank_ = nvlRank;
 
-  constexpr std::size_t kSignalAlignment = alignof(SignalState);
-  if (config_.dataBufferSize >
-      std::numeric_limits<std::size_t>::max() - (kSignalAlignment - 1)) {
-    throw std::runtime_error(
-        "MultimemNvlTransport: dataBufferSize alignment overflows");
-  }
-  signalRegionOffset_ =
-      comms::bitops::alignUp(config_.dataBufferSize, kSignalAlignment);
-  const std::size_t signalRegionBytes =
-      getSignalBufferSize(static_cast<int>(totalSignalCount));
-  if (signalRegionOffset_ >
-      std::numeric_limits<std::size_t>::max() - signalRegionBytes) {
-    throw std::runtime_error(
-        "MultimemNvlTransport: combined allocation size overflows");
-  }
-  const std::size_t combinedSize = signalRegionOffset_ + signalRegionBytes;
+  static_assert(alignof(SignalState) == detail::kMultimemSignalAlignment);
+  static_assert(sizeof(SignalState) == detail::kMultimemSignalStateSize);
+  signalRegionOffset_ = validation.signalRegionOffset;
+  const std::size_t combinedSize = validation.backingAllocationSize;
+  const std::size_t signalRegionBytes = combinedSize - signalRegionOffset_;
 
   cudaDevice_ = getCurrentCudaDevice();
 
@@ -172,11 +146,13 @@ MultimemNvlTransport::MultimemNvlTransport(
   // exchange()'s post-map barrier lets any peer signal into this region. This
   // mirrors MultiPeerNvlTransport, which zeroes its signal buffer at
   // construction.
-  auto* localSignalRegion =
-      static_cast<char*>(combinedHandler_->getLocalDeviceMemPtr()) +
-      signalRegionOffset_;
-  CUDA_CHECK(cudaMemset(localSignalRegion, 0, signalRegionBytes));
-  CUDA_CHECK(cudaStreamSynchronize(/*stream=*/0));
+  if (signalRegionBytes != 0) {
+    auto* localSignalRegion =
+        static_cast<char*>(combinedHandler_->getLocalDeviceMemPtr()) +
+        signalRegionOffset_;
+    CUDA_CHECK(cudaMemset(localSignalRegion, 0, signalRegionBytes));
+    CUDA_CHECK(cudaStreamSynchronize(/*stream=*/0));
+  }
 }
 
 MultimemNvlTransport::MultimemNvlTransport(
@@ -216,10 +192,11 @@ void MultimemNvlTransport::exchange() {
         .version = kMultimemNvlTransportProtocolVersion,
         .parameters =
             {
-                config_.dataBufferSize,
-                config_.userSignalCount,
+                config_.perChannelSize,
                 config_.pipelineDepth,
                 config_.maxChannels,
+                config_.maxBlocks,
+                config_.userSignalCount,
             },
     };
     combinedHandler_->exchangeMulticast(
@@ -259,7 +236,7 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
           localSignals + userSignalCount, internalSignalCount),
       .internalMultimemSignals = DeviceSpan<SignalState>(
           multimemSignals + userSignalCount, internalSignalCount),
-      .dataBufferSize = config_.dataBufferSize,
+      .dataBufferSize = dataBufferSize_,
       .nvlRank = nvlRank_,
       .nvlRanks = nvlRanks_,
       .pipelineDepth = static_cast<uint32_t>(config_.pipelineDepth),
@@ -269,7 +246,7 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
 }
 
 std::size_t MultimemNvlTransport::getAllocatedDataBufferSize() const {
-  return config_.dataBufferSize;
+  return dataBufferSize_;
 }
 
 std::size_t MultimemNvlTransport::getAllocatedSignalBufferSize() const {

--- a/comms/prims/transport/nvl/MultimemNvlTransport.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.h
@@ -4,87 +4,15 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <memory>
-#include <optional>
 #include <vector>
 
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/prims/memory/GpuMemHandler.h"
+#include "comms/prims/transport/nvl/MultimemNvlTransportConfig.h"
 #include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
 
 namespace comms::prims {
-
-struct MultimemNvlTransportConfig {
-  // Size in bytes of the multicast staging data window.
-  std::size_t dataBufferSize{0};
-
-  // Signal slots exposed through signal(), read_signal(), and
-  // wait_signal_until().
-  uint32_t userSignalCount{1};
-
-  // Immutable staging geometry. Both values must be zero when staging is not
-  // used, or both must be non-zero when staging is enabled. `maxChannels` is
-  // the maximum supported `ThreadGroup::total_groups`; each group, pipeline
-  // lane, and NVLink rank requires one 16-byte-aligned data unit. Construction
-  // derives and reserves the corresponding internal signal region after the
-  // user-visible signal slots.
-  std::size_t pipelineDepth{0};
-  std::size_t maxChannels{0};
-};
-
-namespace detail {
-
-inline std::optional<uint32_t> checked_multimem_internal_signal_count(
-    const MultimemNvlTransportConfig& config,
-    int nvlRanks) {
-  if (nvlRanks <= 0 ||
-      config.userSignalCount > std::numeric_limits<int>::max()) {
-    return std::nullopt;
-  }
-
-  const auto signalsPerLaneWide =
-      multimem_staging_signals_per_lane_wide(static_cast<uint64_t>(nvlRanks));
-  if (signalsPerLaneWide > std::numeric_limits<uint32_t>::max()) {
-    return std::nullopt;
-  }
-
-  const bool hasPipelineDepth = config.pipelineDepth != 0;
-  const bool hasMaxChannels = config.maxChannels != 0;
-  if (hasPipelineDepth != hasMaxChannels) {
-    return std::nullopt;
-  }
-  if (!hasPipelineDepth) {
-    return 0;
-  }
-  if (config.pipelineDepth > std::numeric_limits<uint32_t>::max() ||
-      config.maxChannels > std::numeric_limits<uint32_t>::max()) {
-    return std::nullopt;
-  }
-
-  constexpr std::size_t kDataAlignment = 16;
-  const std::size_t alignedUnits = config.dataBufferSize / kDataAlignment;
-  const auto ranks = static_cast<std::size_t>(nvlRanks);
-  if (config.maxChannels > alignedUnits ||
-      config.pipelineDepth > alignedUnits / config.maxChannels ||
-      ranks > alignedUnits / config.maxChannels / config.pipelineDepth) {
-    return std::nullopt;
-  }
-
-  const auto maxInternalSignals = static_cast<std::size_t>(
-      std::numeric_limits<int>::max() - config.userSignalCount);
-  const auto signalsPerLane = static_cast<std::size_t>(signalsPerLaneWide);
-  if (config.maxChannels > maxInternalSignals / signalsPerLane) {
-    return std::nullopt;
-  }
-  const auto signalsPerRound = config.maxChannels * signalsPerLane;
-  if (config.pipelineDepth > maxInternalSignals / signalsPerRound) {
-    return std::nullopt;
-  }
-  return static_cast<uint32_t>(config.pipelineDepth * signalsPerRound);
-}
-
-} // namespace detail
 
 /**
  * Host-side owner for a copy-based NVL multimem transport.
@@ -169,12 +97,13 @@ class MultimemNvlTransport {
   // rank-map preconditions on CPU-only hosts).
   int cudaDevice_{-1};
   const MultimemNvlTransportConfig config_;
+  std::size_t dataBufferSize_{0};
   uint32_t internalSignalCount_{0};
   uint32_t signalsPerLane_{0};
   bool exchanged_{false};
   // Set when exchange() throws; subsequent calls throw instead of silently
   // retrying. Multicast object create/import/bind failures can leave partial
-  // driver state, so a same-object retry is unsafe — callers must rebuild the
+  // driver state, so a same-object retry is unsafe. Callers must rebuild the
   // transport to recover.
   bool broken_{false};
 
@@ -185,8 +114,7 @@ class MultimemNvlTransport {
   // (getMultimemDeviceMemPtr) -- one cuMulticastCreate / one set of binds / one
   // MC VA range over one shared physical backing.
   std::unique_ptr<GpuMemHandler> combinedHandler_;
-  // Offset of the signal region within combinedHandler_'s allocation. Equals
-  // dataBufferSize rounded up to SignalState's 128-byte alignment.
+  // Offset of the signal region within combinedHandler_'s allocation.
   std::size_t signalRegionOffset_{0};
 };
 

--- a/comms/prims/transport/nvl/MultimemNvlTransportConfig.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransportConfig.cc
@@ -1,0 +1,116 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/transport/nvl/MultimemNvlTransportConfig.h"
+
+#include <limits>
+
+namespace comms::prims {
+
+MultimemNvlTransportConfigValidation validate_multimem_nvl_transport_config(
+    const MultimemNvlTransportConfig& config,
+    int nvlRanks) {
+  if (config.perChannelSize == 0) {
+    return {.errorMessage = "per-channel size must be non-zero"};
+  }
+  if (config.maxChannels == 0) {
+    return {.errorMessage = "maximum channels must be non-zero"};
+  }
+  if (nvlRanks <= 0) {
+    return {.errorMessage = "NVL rank count must be positive"};
+  }
+  if (config.userSignalCount > std::numeric_limits<int>::max()) {
+    return {.errorMessage = "signal count exceeds INT_MAX"};
+  }
+
+  const bool hasPipelineDepth = config.pipelineDepth != 0;
+  const bool hasMaxBlocks = config.maxBlocks != 0;
+  if (hasPipelineDepth != hasMaxBlocks) {
+    return {
+        .errorMessage =
+            "pipeline depth and maximum blocks must both be zero or non-zero"};
+  }
+  if (config.pipelineDepth > std::numeric_limits<uint32_t>::max() ||
+      config.maxChannels > std::numeric_limits<uint32_t>::max()) {
+    return {.errorMessage = "transport geometry exceeds UINT32_MAX"};
+  }
+  if (config.maxBlocks > config.maxChannels) {
+    return {.errorMessage = "maximum blocks must not exceed maximum channels"};
+  }
+  if (config.perChannelSize >
+      std::numeric_limits<std::size_t>::max() / config.maxChannels) {
+    return {
+        .errorMessage = "per-channel size times maximum channels overflows"};
+  }
+  const std::size_t dataBufferSize = config.perChannelSize * config.maxChannels;
+
+  uint32_t internalSignalCount = 0;
+  if (config.pipelineDepth != 0) {
+    constexpr std::size_t kDataAlignment = 16;
+    if (config.pipelineDepth >
+            std::numeric_limits<std::size_t>::max() / kDataAlignment ||
+        config.perChannelSize % (config.pipelineDepth * kDataAlignment) != 0) {
+      return {
+          .errorMessage =
+              "per-channel size must be divisible by pipeline depth times 16"};
+    }
+    const std::size_t alignedUnits = dataBufferSize / kDataAlignment;
+    const auto ranks = static_cast<std::size_t>(nvlRanks);
+    if (config.maxChannels > alignedUnits ||
+        config.pipelineDepth > alignedUnits / config.maxChannels ||
+        ranks > alignedUnits / config.maxChannels / config.pipelineDepth) {
+      return {
+          .errorMessage = "data buffer is too small for the staging geometry"};
+    }
+
+    const auto signalsPerLaneWide =
+        multimem_staging_signals_per_lane_wide(static_cast<uint64_t>(nvlRanks));
+    if (signalsPerLaneWide > std::numeric_limits<uint32_t>::max()) {
+      return {.errorMessage = "transport geometry exceeds UINT32_MAX"};
+    }
+    const auto maxInternalSignals = static_cast<std::size_t>(
+        std::numeric_limits<int>::max() - config.userSignalCount);
+    const auto signalsPerLane = static_cast<std::size_t>(signalsPerLaneWide);
+    if (config.maxChannels > maxInternalSignals / signalsPerLane) {
+      return {.errorMessage = "signal count exceeds INT_MAX"};
+    }
+    const auto signalsPerPipelineLane = config.maxChannels * signalsPerLane;
+    if (config.pipelineDepth > maxInternalSignals / signalsPerPipelineLane) {
+      return {.errorMessage = "signal count exceeds INT_MAX"};
+    }
+    internalSignalCount =
+        static_cast<uint32_t>(config.pipelineDepth * signalsPerPipelineLane);
+  }
+
+  constexpr auto kSignalAlignment = detail::kMultimemSignalAlignment;
+  constexpr auto kSignalStateSize = detail::kMultimemSignalStateSize;
+  if (dataBufferSize >
+      std::numeric_limits<std::size_t>::max() - (kSignalAlignment - 1)) {
+    return {
+        .errorMessage = "combined data and signal allocation size overflows"};
+  }
+  const std::size_t signalRegionOffset =
+      ((dataBufferSize + kSignalAlignment - 1) / kSignalAlignment) *
+      kSignalAlignment;
+  const auto totalSignalCount =
+      static_cast<std::size_t>(config.userSignalCount) + internalSignalCount;
+  if (totalSignalCount >
+      std::numeric_limits<std::size_t>::max() / kSignalStateSize) {
+    return {
+        .errorMessage = "combined data and signal allocation size overflows"};
+  }
+  const std::size_t signalRegionBytes = totalSignalCount * kSignalStateSize;
+  if (signalRegionOffset >
+      std::numeric_limits<std::size_t>::max() - signalRegionBytes) {
+    return {
+        .errorMessage = "combined data and signal allocation size overflows"};
+  }
+
+  return {
+      .dataBufferSize = dataBufferSize,
+      .internalSignalCount = internalSignalCount,
+      .signalRegionOffset = signalRegionOffset,
+      .backingAllocationSize = signalRegionOffset + signalRegionBytes,
+  };
+}
+
+} // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlTransportConfig.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransportConfig.h
@@ -1,0 +1,102 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#if defined(__CUDACC__)
+#include <cuda_runtime.h>
+#elif defined(__HIPCC__)
+#include <hip/hip_runtime.h>
+#endif
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+namespace comms::prims {
+
+struct MultimemNvlTransportConfigParams {
+  // Total data capacity is `perChannelSize * maxChannels`.
+  std::size_t perChannelSize{0};
+
+  // Staging pipeline depth. May be zero only when `maxBlocks` is also zero.
+  std::size_t pipelineDepth{0};
+
+  // Number of provisioned data channels.
+  std::size_t maxChannels{0};
+
+  // Maximum collective launch block count. Transport data and internal
+  // staging-signal capacity are provisioned independently by `maxChannels`.
+  std::size_t maxBlocks{0};
+
+  // Signal slots exposed through signal(), read_signal(), and
+  // wait_signal_until(). This is orthogonal to staging geometry.
+  uint32_t userSignalCount{1};
+};
+
+struct MultimemNvlTransportConfig {
+  constexpr MultimemNvlTransportConfig() = default;
+
+  explicit constexpr MultimemNvlTransportConfig(
+      MultimemNvlTransportConfigParams params)
+      : perChannelSize(params.perChannelSize),
+        pipelineDepth(params.pipelineDepth),
+        maxChannels(params.maxChannels),
+        maxBlocks(params.maxBlocks),
+        userSignalCount(params.userSignalCount) {}
+
+  std::size_t perChannelSize{0};
+  std::size_t pipelineDepth{0};
+  std::size_t maxChannels{0};
+  std::size_t maxBlocks{0};
+  uint32_t userSignalCount{1};
+
+  bool operator==(const MultimemNvlTransportConfig&) const = default;
+};
+
+constexpr MultimemNvlTransportConfig make_multimem_nvl_transport_config(
+    MultimemNvlTransportConfigParams params) {
+  return MultimemNvlTransportConfig{params};
+}
+
+struct MultimemNvlTransportConfigValidation {
+  std::size_t dataBufferSize{0};
+  uint32_t internalSignalCount{0};
+  std::size_t signalRegionOffset{0};
+  std::size_t backingAllocationSize{0};
+  std::string_view errorMessage{};
+
+  explicit operator bool() const {
+    return errorMessage.empty();
+  }
+};
+
+namespace detail {
+inline constexpr uint64_t kMultimemSignalsPerRank = 2;
+inline constexpr uint64_t kMultimemArrivalBarrierSignals = 4;
+inline constexpr std::size_t kMultimemSignalAlignment = 128;
+inline constexpr std::size_t kMultimemSignalStateSize = 128;
+} // namespace detail
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+__host__ __device__
+#endif
+    constexpr uint64_t multimem_staging_signals_per_lane_wide(
+        uint64_t nvlRanks) {
+  return detail::kMultimemSignalsPerRank * nvlRanks +
+      detail::kMultimemArrivalBarrierSignals;
+}
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+__host__ __device__
+#endif
+    constexpr uint32_t multimem_staging_signals_per_lane(uint32_t nvlRanks) {
+  return static_cast<uint32_t>(
+      multimem_staging_signals_per_lane_wide(nvlRanks));
+}
+
+// Validate the complete topology-aware config and derive all allocation sizes.
+MultimemNvlTransportConfigValidation validate_multimem_nvl_transport_config(
+    const MultimemNvlTransportConfig& config,
+    int nvlRanks);
+
+} // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -12,27 +12,9 @@
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/Timeout.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlTransportConfig.h"
 
 namespace comms::prims {
-
-// Per-lane internal-signal count for the staging pipeline: the single source of
-// truth shared by the host-side signal-region sizing (MultimemNvlTransport)
-// and the device-side `make_stage_layout` (MultimemNvlStageLayout.cuh) so the
-// region is sized identically on both sides. Layout per lane: `nvlRanks`
-// per-peer ready[]
-// + `nvlRanks` per-peer ack[] + 4 staging arrival-barrier slots (ready/ack
-// counter+epoch, laid out past the SET-mode slots so ADD residue never
-// contaminates a later SET-mode CMP_GE wait) => 2 * nvlRanks + 4.
-__host__ __device__ constexpr uint64_t multimem_staging_signals_per_lane_wide(
-    uint64_t nvlRanks) {
-  return 2 * nvlRanks + 4;
-}
-
-__host__ __device__ constexpr uint32_t multimem_staging_signals_per_lane(
-    uint32_t nvlRanks) {
-  return static_cast<uint32_t>(
-      multimem_staging_signals_per_lane_wide(nvlRanks));
-}
 
 namespace detail {
 


### PR DESCRIPTION
Summary:

Separate multimem storage capacity from launch geometry.
The transport config carries per-channel size, provisioned channel count, and the maximum block count.
Centralized validation derives allocation and signal requirements, accepts data-only configurations, rejects block limits above channel capacity, and guards geometry arithmetic required by the device representation.
Ctran preserves independent channel and block hints and rejects multimem initialization when the resolved block cap exceeds the provisioned channel capacity.
The device layout and NVL exchange contract consume the separated values.

This changes the exported `MultimemNvlTransportConfig` construction contract.
Callers must replace `dataBufferSize` and legacy positional construction with `perChannelSize`, `maxChannels`, and `maxBlocks`.
The multicast exchange protocol version is intentionally incompatible with the previous schema so mixed configurations fail agreement.

This diff contains only Prims and Ctran transport infrastructure extracted from D114879929.
Collective kernel and benchmark consumers land in later diffs.

Reviewed By: goelayu

Differential Revision: D115471115


