### PR TITLE
Add LL overloads for the progress helpers

### DIFF
--- a/comms/prims/benchmarks/IbgdaSendRecv.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cu
@@ -300,6 +300,134 @@ void launch_ibgda_recv(
   }
 }
 
+// ==========================================================================
+// Low-latency (LL) protocol benchmark kernels. Mirror the Simple send/recv
+// kernels above but dispatch to the transport's send<LL>/recv<LL> (data+inline
+// flag, 2x wire, no DATA_READY wait; Memcpy only). Section sizing is identical:
+// the pipelined LL loop maps each payload section onto the wire ring
+// internally.
+// ==========================================================================
+__global__ void __launch_bounds__(512, 1) ibgda_send_recv_ll_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  auto [role, sub] = group.partition(2);
+  const bool isSender = (role == 0);
+
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    const std::size_t offset = s * sectionBytes;
+    if (isSender) {
+      TiledBuffer<char> tiles(src + offset, sectionBytes, sub);
+      transport->send<Memcpy, protocol::LL>(
+          sub, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
+    } else {
+      TiledBuffer<char> tiles(dst + offset, sectionBytes, sub);
+      transport->recv<Memcpy, protocol::LL>(
+          sub, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
+    }
+  }
+}
+
+void launch_ibgda_send_recv_ll(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  ibgda_send_recv_ll_kernel<<<2 * numBlocks, 512, 0, stream>>>(
+      transport, src, dst, nbytes, numBlocks, maxSignalBytes, timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] send/recv LL kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+}
+
+__global__ void __launch_bounds__(512, 1) ibgda_send_ll_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    TiledBuffer<char> tiles(src + s * sectionBytes, sectionBytes, group);
+    transport->send<Memcpy, protocol::LL>(
+        group, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
+  }
+}
+
+__global__ void __launch_bounds__(512, 1) ibgda_recv_ll_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    TiledBuffer<char> tiles(dst + s * sectionBytes, sectionBytes, group);
+    transport->recv<Memcpy, protocol::LL>(
+        group, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
+  }
+}
+
+void launch_ibgda_send_ll(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  ibgda_send_ll_kernel<<<numBlocks, 512, 0, stream>>>(
+      transport, src, nbytes, numBlocks, maxSignalBytes, timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] send LL kernel launch failed: %s\n", cudaGetErrorString(err));
+  }
+}
+
+void launch_ibgda_recv_ll(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  ibgda_recv_ll_kernel<<<numBlocks, 512, 0, stream>>>(
+      transport, dst, nbytes, numBlocks, maxSignalBytes, timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] recv LL kernel launch failed: %s\n", cudaGetErrorString(err));
+  }
+}
+
 __global__ void __launch_bounds__(512, 1) ibgda_drain_send_recv_kernel(
     P2pIbgdaTransportDevice* transport,
     int numBlocks,

--- a/comms/prims/benchmarks/IbgdaSendRecv.h
+++ b/comms/prims/benchmarks/IbgdaSendRecv.h
@@ -97,6 +97,39 @@ void launch_ibgda_recv(
     Timeout timeout = Timeout());
 
 /**
+ * Low-latency (LL) protocol counterparts of launch_ibgda_send_recv/send/recv.
+ * Same grid layout; dispatch to the transport's send_ll/recv_ll (data + inline
+ * flag, 2x wire, no DATA_READY wait; Memcpy only).
+ */
+void launch_ibgda_send_recv_ll(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
+    Timeout timeout = Timeout());
+
+void launch_ibgda_send_ll(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
+    Timeout timeout = Timeout());
+
+void launch_ibgda_recv_ll(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
+    Timeout timeout = Timeout());
+
+/**
  * Drain outstanding bidirectional send/recv transport work for benchmark
  * measurement and safe teardown.
  */

--- a/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -12,10 +12,15 @@
 #include <array>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <fstream>
+#include <iomanip>
+#include <iostream>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "comms/prims/benchmarks/IbgdaSendRecv.h"
 #include "comms/prims/transport/ibgda/MultipeerIbgdaTransport.h"
@@ -207,6 +212,63 @@ struct BenchmarkSize {
   std::size_t nbytes;
 };
 
+// ---------------------------------------------------------------------------
+// Correctness pass (separate from the timed benchmarks; see
+// runCorrectnessSweep)
+// ---------------------------------------------------------------------------
+
+constexpr uint32_t kDefaultCorrectnessIters = 32;
+constexpr int kCorrectnessPoison = 0xEE;
+
+// Bytes checked past the payload to catch a decoder that writes a padded
+// length. LL's quantum is kData = 4, so 3 stray bytes is the worst case; 16
+// covers any plausible future packet geometry.
+constexpr std::size_t kCorrectnessGuardBytes = 16;
+
+// Correctness verifies on the host, so each iteration costs an H2D of the
+// pattern plus a D2H of the result, and holds two host buffers of `nbytes`.
+// Simple's sweep runs to 4 GB, which would mean 8 GB of host memory and
+// hundreds of GB over PCIe -- so the correctness pass caps the size instead of
+// carrying a separate list. Sizes above the cap are skipped and reported (never
+// silently dropped). Override with IBGDA_BENCH_CORRECTNESS_MAX_BYTES.
+constexpr std::size_t kDefaultCorrectnessMaxBytes = 1ULL << 20; // 1 MiB
+
+// SplitMix64 finalizer: cheap full-avalanche mixing.
+inline uint64_t mix64(uint64_t x) {
+  x += 0x9E3779B97F4A7C15ULL;
+  x = (x ^ (x >> 30)) * 0xBF58476D1CE4E5B9ULL;
+  x = (x ^ (x >> 27)) * 0x94D049BB133111EBULL;
+  return x ^ (x >> 31);
+}
+
+// Payload seed for one (iteration, size) case. Both ranks derive it from
+// values they already agree on, so the pattern never has to be exchanged.
+// Mixing in `nbytes` keeps two different sizes from sharing a prefix, so a
+// stale buffer left by an earlier size cannot match either.
+inline uint64_t correctnessSeed(uint32_t iter, std::size_t nbytes) {
+  return mix64((static_cast<uint64_t>(iter) << 32) ^ nbytes);
+}
+
+// Fill `buf` with `nbytes` of pseudo-random payload for `seed`.
+//
+// Deliberately NOT a linear ramp: with a constant stride k, a whole-buffer
+// shift of `s` bytes reproduces the expected values whenever k*s is a multiple
+// of 256, so shifted-copy bugs at those offsets pass unnoticed. Mixing each
+// 8 B word independently removes any stride, so no shift aliases.
+inline void
+fillPattern(std::vector<char>& buf, std::size_t nbytes, uint64_t seed) {
+  buf.resize(nbytes);
+  std::size_t i = 0;
+  for (; i + sizeof(uint64_t) <= nbytes; i += sizeof(uint64_t)) {
+    const uint64_t word = mix64(seed ^ i);
+    std::memcpy(buf.data() + i, &word, sizeof(word));
+  }
+  if (i < nbytes) {
+    const uint64_t word = mix64(seed ^ i);
+    std::memcpy(buf.data() + i, &word, nbytes - i);
+  }
+}
+
 constexpr std::array<BenchmarkSize, 33> kBenchmarkSizes{{
     {"1B", 1ULL},
     {"2B", 2ULL},
@@ -241,6 +303,103 @@ constexpr std::array<BenchmarkSize, 33> kBenchmarkSizes{{
     {"1GB", 1ULL << 30},
     {"2GB", 2ULL << 30},
     {"4GB", 4ULL << 30},
+}};
+
+// LL sweep. Capped at 1 MiB: LL puts 2x payload on the wire (8 B packet per
+// 4 B of data), so past ~1 MiB it is bandwidth-bound and strictly worse than
+// Simple -- the interesting region is small-message latency. 1..64 B is
+// enumerated byte-by-byte so every partial-final-packet remainder
+// (nbytes % kData, kData = 4) and every packet count up to 16 is covered;
+// past 64 B the sweep doubles, with a few deliberately non-4B-aligned sizes
+// interleaved to keep exercising the partial final packet at scale.
+constexpr std::array<BenchmarkSize, 86> kLlBenchmarkSizes{{
+    {"1B", 1ULL},
+    {"2B", 2ULL},
+    {"3B", 3ULL},
+    {"4B", 4ULL},
+    {"5B", 5ULL},
+    {"6B", 6ULL},
+    {"7B", 7ULL},
+    {"8B", 8ULL},
+    {"9B", 9ULL},
+    {"10B", 10ULL},
+    {"11B", 11ULL},
+    {"12B", 12ULL},
+    {"13B", 13ULL},
+    {"14B", 14ULL},
+    {"15B", 15ULL},
+    {"16B", 16ULL},
+    {"17B", 17ULL},
+    {"18B", 18ULL},
+    {"19B", 19ULL},
+    {"20B", 20ULL},
+    {"21B", 21ULL},
+    {"22B", 22ULL},
+    {"23B", 23ULL},
+    {"24B", 24ULL},
+    {"25B", 25ULL},
+    {"26B", 26ULL},
+    {"27B", 27ULL},
+    {"28B", 28ULL},
+    {"29B", 29ULL},
+    {"30B", 30ULL},
+    {"31B", 31ULL},
+    {"32B", 32ULL},
+    {"33B", 33ULL},
+    {"34B", 34ULL},
+    {"35B", 35ULL},
+    {"36B", 36ULL},
+    {"37B", 37ULL},
+    {"38B", 38ULL},
+    {"39B", 39ULL},
+    {"40B", 40ULL},
+    {"41B", 41ULL},
+    {"42B", 42ULL},
+    {"43B", 43ULL},
+    {"44B", 44ULL},
+    {"45B", 45ULL},
+    {"46B", 46ULL},
+    {"47B", 47ULL},
+    {"48B", 48ULL},
+    {"49B", 49ULL},
+    {"50B", 50ULL},
+    {"51B", 51ULL},
+    {"52B", 52ULL},
+    {"53B", 53ULL},
+    {"54B", 54ULL},
+    {"55B", 55ULL},
+    {"56B", 56ULL},
+    {"57B", 57ULL},
+    {"58B", 58ULL},
+    {"59B", 59ULL},
+    {"60B", 60ULL},
+    {"61B", 61ULL},
+    {"62B", 62ULL},
+    {"63B", 63ULL},
+    {"64B", 64ULL},
+    // Doubling from 64 B, with non-4B-aligned sizes interleaved in order.
+    {"127B", 127ULL},
+    {"128B", 128ULL},
+    {"256B", 256ULL},
+    {"333B", 333ULL},
+    {"512B", 512ULL},
+    {"1023B", 1023ULL},
+    {"1KB", 1ULL << 10},
+    {"2KB", 2ULL << 10},
+    {"3001B", 3001ULL},
+    {"4KB", 4ULL << 10},
+    {"8KB", 8ULL << 10},
+    {"12345B", 12345ULL},
+    {"16KB", 16ULL << 10},
+    {"32KB", 32ULL << 10},
+    {"64KB", 64ULL << 10},
+    {"65537B", 65537ULL},
+    {"128KB", 128ULL << 10},
+    {"256KB", 256ULL << 10},
+    {"300007B", 300007ULL},
+    {"512KB", 512ULL << 10},
+    {"999983B", 999983ULL},
+    {"1MB", 1ULL << 20},
 }};
 
 constexpr std::size_t kMaxBenchmarkBytes = 4ULL << 30;
@@ -468,6 +627,96 @@ class IbgdaSendRecvBenchmarkContext {
     return *std::max_element(rankElapsed.begin(), rankElapsed.end());
   }
 
+  // One correctness iteration: fill -> transfer -> verify. Untimed.
+  //
+  // The payload pattern is re-derived from `iter` every call, so a receiver
+  // that accepts a previous ring pass's bytes (the stale-flag failure LL's
+  // inline readiness is most exposed to) cannot match. recvBuf is poisoned
+  // first for the same reason: a recv that writes nothing must not pass on
+  // leftovers. Returns false on mismatch and reports the first bad offset.
+  bool runVerifiedIteration(
+      std::size_t nbytes,
+      uint32_t iter,
+      SendRecvDirection direction,
+      SendRecvProto proto,
+      std::size_t& badOffset) {
+    // The guard bytes are poisoned and read back past the payload, so the recv
+    // buffer must hold them too -- `maxBytes_` alone would let a large
+    // IBGDA_BENCH_CORRECTNESS_MAX_BYTES run off the end of the allocation.
+    CHECK_LE(nbytes + kCorrectnessGuardBytes, maxBytes_);
+    const bool bidir = direction == SendRecvDirection::Bidirectional;
+    const bool sends = bidir || globalRank_ == 0;
+    const bool receives = bidir || globalRank_ == 1;
+
+    // Both ranks build the same pattern from the same seed: the sender puts it
+    // on the wire, the receiver compares against it. No exchange needed.
+    fillPattern(hostPattern_, nbytes, correctnessSeed(iter, nbytes));
+
+    if (sends) {
+      CHECK_EQ(
+          cudaMemcpyAsync(
+              sendBuf_->get(),
+              hostPattern_.data(),
+              nbytes,
+              cudaMemcpyHostToDevice,
+              stream_),
+          cudaSuccess);
+    }
+    if (receives) {
+      // Poison the payload AND a guard region past it. A protocol that decodes
+      // a padded length (LL rounds chunks up to kData) would write past nbytes;
+      // without the guard those bytes land in allocated-but-unchecked memory
+      // and the comparison below, which only covers nbytes, never sees them.
+      CHECK_EQ(
+          cudaMemsetAsync(
+              recvBuf_->get(),
+              kCorrectnessPoison,
+              nbytes + kCorrectnessGuardBytes,
+              stream_),
+          cudaSuccess);
+    }
+    CHECK_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+    // Keep both ranks on the same iteration so the pattern they encode and the
+    // pattern the peer expects always agree.
+    bootstrap_->barrierAll();
+    launchOperation(nbytes, SendRecvApi::Blocking, direction, proto);
+    CHECK_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+    if (!receives) {
+      return true;
+    }
+    hostRecv_.resize(nbytes + kCorrectnessGuardBytes);
+    CHECK_EQ(
+        cudaMemcpy(
+            hostRecv_.data(),
+            recvBuf_->get(),
+            nbytes + kCorrectnessGuardBytes,
+            cudaMemcpyDeviceToHost),
+        cudaSuccess);
+    // Guard must still be poison: anything else is a write past the payload.
+    for (std::size_t g = 0; g < kCorrectnessGuardBytes; ++g) {
+      if (hostRecv_[nbytes + g] != static_cast<char>(kCorrectnessPoison)) {
+        badOffset = nbytes + g;
+        return false;
+      }
+    }
+    if (std::memcmp(hostRecv_.data(), hostPattern_.data(), nbytes) == 0) {
+      return true;
+    }
+    for (std::size_t i = 0; i < nbytes; ++i) {
+      if (hostRecv_[i] != hostPattern_[i]) {
+        badOffset = i;
+        break;
+      }
+    }
+    return false;
+  }
+
+  int globalRank() const {
+    return globalRank_;
+  }
+
  private:
   void launchOperation(
       std::size_t nbytes,
@@ -541,6 +790,9 @@ class IbgdaSendRecvBenchmarkContext {
   std::unique_ptr<DeviceBuffer> sendBuf_;
   std::unique_ptr<DeviceBuffer> recvBuf_;
   IbgdaLocalBuffer registeredSendBuf_{};
+  // Correctness-pass staging (unused by the timed benchmarks).
+  std::vector<char> hostPattern_;
+  std::vector<char> hostRecv_;
   P2pIbgdaTransportDevice* deviceTransport_{nullptr};
   std::size_t maxBytes_{0};
   std::size_t perChannelSize_{0};
@@ -618,24 +870,49 @@ void registerBenchmark(
       });
 }
 
-void registerBenchmarks(IbgdaSendRecvBenchmarkContext& context) {
-  // A single run benchmarks exactly one protocol, selected via
-  // IBGDA_BENCH_PROTO (default: simple). Run the binary once per protocol to
-  // compare.
+// A single run uses exactly one protocol, selected via IBGDA_BENCH_PROTO
+// (default: simple). Run the binary once per protocol to compare.
+// Mixed mode: alternate Simple and LL on the SAME group_id within one run.
+// This is the only configuration that exercises the protocol banks against each
+// other -- both land on the same hardware QP (channelId % channelsPerBank) but
+// must keep separate per-channel state. A bank mix-up shows up here as a
+// payload mismatch; running the protocols in separate processes cannot catch
+// it.
+bool correctnessMixed() {
+  if (const char* p = std::getenv("IBGDA_BENCH_PROTO")) {
+    return std::string(p) == "mixed";
+  }
+  return false;
+}
+
+SendRecvProto selectProto() {
   SendRecvProto proto = SendRecvProto::Simple;
   if (const char* p = std::getenv("IBGDA_BENCH_PROTO")) {
     const std::string protoStr(p);
     if (protoStr == "ll") {
       proto = SendRecvProto::LL;
-    } else if (protoStr == "simple") {
+    } else if (protoStr == "simple" || protoStr == "mixed") {
       proto = SendRecvProto::Simple;
     } else {
       LOG(WARNING) << "Unknown IBGDA_BENCH_PROTO='" << protoStr
                    << "', defaulting to simple";
     }
   }
+  return proto;
+}
 
-  for (const auto& size : kBenchmarkSizes) {
+void registerBenchmarks(IbgdaSendRecvBenchmarkContext& context) {
+  const SendRecvProto proto = selectProto();
+
+  // LL uses its own sweep: denser below 64 B and capped at 1 MiB.
+  const bool isLl = proto == SendRecvProto::LL;
+  const BenchmarkSize* const sizes =
+      isLl ? kLlBenchmarkSizes.data() : kBenchmarkSizes.data();
+  const std::size_t numSizes =
+      isLl ? kLlBenchmarkSizes.size() : kBenchmarkSizes.size();
+
+  for (std::size_t i = 0; i < numSizes; ++i) {
+    const auto& size = sizes[i];
     // Blocking + fixed-size memcpy is supported by every protocol.
     registerBenchmark(
         context,
@@ -705,6 +982,164 @@ void registerBenchmarks(IbgdaSendRecvBenchmarkContext& context) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Correctness sweep
+//
+// A separate, untimed pass over the same size list. Unlike the folly
+// benchmarks it verifies EVERY iteration and prints its own table -- no
+// latency/bandwidth columns, because nothing here is timed and the
+// per-iteration host round-trip would dominate if it were.
+// Enabled with IBGDA_BENCH_CORRECTNESS=1; iteration count overridable with
+// IBGDA_BENCH_CORRECTNESS_ITERS.
+// ---------------------------------------------------------------------------
+
+struct CorrectnessResult {
+  const char* name;
+  std::size_t nbytes;
+  SendRecvDirection direction;
+  uint32_t iters;
+  uint32_t failures;
+  uint32_t firstBadIter;
+  std::size_t firstBadOffset;
+};
+
+uint32_t correctnessIters() {
+  if (const char* s = std::getenv("IBGDA_BENCH_CORRECTNESS_ITERS")) {
+    const int parsed = std::atoi(s);
+    if (parsed > 0) {
+      return static_cast<uint32_t>(parsed);
+    }
+    LOG(WARNING) << "Ignoring invalid IBGDA_BENCH_CORRECTNESS_ITERS='" << s
+                 << "'";
+  }
+  return kDefaultCorrectnessIters;
+}
+
+std::size_t correctnessMaxBytes() {
+  if (const char* s = std::getenv("IBGDA_BENCH_CORRECTNESS_MAX_BYTES")) {
+    const long long parsed = std::atoll(s);
+    if (parsed > 0) {
+      return static_cast<std::size_t>(parsed);
+    }
+    LOG(WARNING) << "Ignoring invalid IBGDA_BENCH_CORRECTNESS_MAX_BYTES='" << s
+                 << "'";
+  }
+  return kDefaultCorrectnessMaxBytes;
+}
+
+void printCorrectnessTable(
+    const std::vector<CorrectnessResult>& results,
+    SendRecvProto proto,
+    uint32_t iters,
+    int globalRank) {
+  std::ostringstream ss;
+  ss << "\n=== ibgdaSendRecv correctness (proto="
+     << (correctnessMixed() ? "mixed(simple+ll)" : protoName(proto))
+     << ", iters=" << iters << "/size, rank=" << globalRank << ") ===\n";
+  ss << std::left << std::setw(12) << "size" << std::right << std::setw(12)
+     << "bytes" << std::right << std::setw(16) << "direction" << std::right
+     << std::setw(10) << "verified" << std::right << std::setw(10) << "failures"
+     << std::right << std::setw(22) << "first bad (iter@off)"
+     << "\n";
+  ss << std::string(82, '-') << "\n";
+
+  uint32_t totalFailures = 0;
+  for (const auto& r : results) {
+    totalFailures += r.failures;
+    ss << std::left << std::setw(12) << r.name << std::right << std::setw(12)
+       << r.nbytes << std::right << std::setw(16) << directionName(r.direction)
+       << std::right << std::setw(10) << r.iters << std::right << std::setw(10)
+       << r.failures << std::right << std::setw(22);
+    if (r.failures == 0) {
+      ss << "-";
+    } else {
+      ss
+          << (std::to_string(r.firstBadIter) + "@" +
+              std::to_string(r.firstBadOffset));
+    }
+    ss << "\n";
+  }
+  ss << std::string(82, '-') << "\n";
+  ss << (totalFailures == 0 ? "RESULT: PASS" : "RESULT: FAIL") << " ("
+     << totalFailures << " failing iterations across " << results.size()
+     << " cases)\n";
+  std::cout << ss.str() << std::flush;
+}
+
+// Returns true if every verified iteration matched.
+bool runCorrectnessSweep(IbgdaSendRecvBenchmarkContext& context) {
+  const bool mixed = correctnessMixed();
+  const SendRecvProto proto = selectProto();
+  const uint32_t iters = correctnessIters();
+  // Mixed uses the LL size list: every size in it is valid for both protocols,
+  // and it stays under the LL 1 MiB wire cap.
+  const bool useLlSizes = mixed || proto == SendRecvProto::LL;
+  const BenchmarkSize* const sizes =
+      useLlSizes ? kLlBenchmarkSizes.data() : kBenchmarkSizes.data();
+  const std::size_t numSizes =
+      useLlSizes ? kLlBenchmarkSizes.size() : kBenchmarkSizes.size();
+
+  constexpr std::array<SendRecvDirection, 2> kDirections{
+      SendRecvDirection::Bidirectional, SendRecvDirection::Unidirectional};
+
+  std::vector<CorrectnessResult> results;
+  results.reserve(numSizes * kDirections.size());
+
+  const std::size_t maxBytes = correctnessMaxBytes();
+  std::size_t skipped = 0;
+  std::size_t largestSkipped = 0;
+
+  for (std::size_t i = 0; i < numSizes; ++i) {
+    const auto& size = sizes[i];
+    if (size.nbytes > maxBytes) {
+      ++skipped;
+      largestSkipped = std::max(largestSkipped, size.nbytes);
+      continue;
+    }
+    for (const auto direction : kDirections) {
+      CorrectnessResult r{
+          .name = size.name,
+          .nbytes = size.nbytes,
+          .direction = direction,
+          .iters = iters,
+          .failures = 0,
+          .firstBadIter = 0,
+          .firstBadOffset = 0};
+      for (uint32_t it = 0; it < iters; ++it) {
+        std::size_t badOffset = 0;
+        // Mixed: alternate protocols on the SAME group_id so consecutive
+        // iterations hit different banks over one shared QP.
+        const SendRecvProto iterProto = mixed
+            ? ((it % 2 == 0) ? SendRecvProto::Simple : SendRecvProto::LL)
+            : proto;
+        if (!context.runVerifiedIteration(
+                size.nbytes, it, direction, iterProto, badOffset)) {
+          if (r.failures == 0) {
+            r.firstBadIter = it;
+            r.firstBadOffset = badOffset;
+          }
+          ++r.failures;
+        }
+      }
+      results.push_back(r);
+    }
+  }
+
+  if (skipped != 0) {
+    LOG(WARNING) << "Correctness: skipped " << skipped << " size(s) above "
+                 << maxBytes << " B (largest " << largestSkipped
+                 << " B); raise IBGDA_BENCH_CORRECTNESS_MAX_BYTES to include "
+                 << "them (needs 2x that in host memory per rank)";
+  }
+  printCorrectnessTable(results, proto, iters, context.globalRank());
+  for (const auto& r : results) {
+    if (r.failures != 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
 } // namespace
 } // namespace comms::prims::benchmark
 
@@ -720,6 +1155,16 @@ int main(int argc, char** argv) {
   const int globalRank = bootstrap->getGlobalRank();
   comms::prims::benchmark::IbgdaSendRecvBenchmarkContext context(
       std::move(bootstrap), comms::prims::benchmark::kMaxBenchmarkBytes);
+
+  // Correctness mode is a distinct run: it verifies every iteration and prints
+  // its own table, so it deliberately does not also run the timed benchmarks
+  // (the verified path is not representative of steady-state timing). Both
+  // ranks participate; each prints the results for the transfers it received.
+  if (const char* c = std::getenv("IBGDA_BENCH_CORRECTNESS");
+      c != nullptr && std::string(c) != "0") {
+    return comms::prims::benchmark::runCorrectnessSweep(context) ? 0 : 1;
+  }
+
   comms::prims::benchmark::registerBenchmarks(context);
   // Both ranks must run every benchmark in lockstep (paired send/recv), but
   // only rank 0 prints the results table. Rank 1 runs and discards its output.

--- a/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -83,6 +83,14 @@ enum class SendRecvCopyOp {
   Memcpy,
 };
 
+// Wire protocol: Simple (put data + explicit DATA_READY signal) vs LL
+// (low-latency data + inline flag, 2x wire). LL is wired for the blocking path
+// only (the resumable Progress API has no LL wire/payload geometry yet).
+enum class SendRecvProto {
+  Simple,
+  LL,
+};
+
 bool isTcpEnvironment() {
   return std::getenv("MASTER_ADDR") != nullptr &&
       std::getenv("MASTER_PORT") != nullptr && std::getenv("RANK") != nullptr &&
@@ -267,13 +275,26 @@ const char* copyOpName(SendRecvCopyOp copyOp) {
   return "unknown";
 }
 
+const char* protoName(SendRecvProto proto) {
+  switch (proto) {
+    case SendRecvProto::Simple:
+      return "simple";
+    case SendRecvProto::LL:
+      return "ll";
+  }
+  return "unknown";
+}
+
 std::string benchmarkName(
     SendRecvApi api,
     SendRecvDirection direction,
     SendRecvCopyOp copyOp,
+    SendRecvProto proto,
     const char* sizeName,
     int repeat = -1) {
   std::string name = "ibgdaSendRecv(";
+  name += protoName(proto);
+  name += "_";
   name += apiName(api);
   name += "_";
   name += directionName(direction);
@@ -399,11 +420,12 @@ class IbgdaSendRecvBenchmarkContext {
       std::size_t nbytes,
       SendRecvApi api,
       SendRecvDirection direction,
-      SendRecvCopyOp copyOp) {
+      SendRecvCopyOp copyOp,
+      SendRecvProto proto) {
     CHECK_LE(nbytes, maxBytes_);
     bootstrap_->barrierAll();
     for (int i = 0; i < warmupIters_; ++i) {
-      launchOperation(nbytes, api, direction, copyOp);
+      launchOperation(nbytes, api, direction, copyOp, proto);
       CHECK_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
     }
     bootstrap_->barrierAll();
@@ -414,7 +436,8 @@ class IbgdaSendRecvBenchmarkContext {
       std::size_t nbytes,
       SendRecvApi api,
       SendRecvDirection direction,
-      SendRecvCopyOp copyOp) {
+      SendRecvCopyOp copyOp,
+      SendRecvProto proto) {
     CHECK_LE(nbytes, maxBytes_);
 
     cudaEvent_t start{};
@@ -424,7 +447,7 @@ class IbgdaSendRecvBenchmarkContext {
 
     CHECK_EQ(cudaEventRecord(start, stream_), cudaSuccess);
     for (uint32_t i = 0; i < iters; ++i) {
-      launchOperation(nbytes, api, direction, copyOp);
+      launchOperation(nbytes, api, direction, copyOp, proto);
     }
     CHECK_EQ(cudaEventRecord(stop, stream_), cudaSuccess);
     CHECK_EQ(cudaEventSynchronize(stop), cudaSuccess);
@@ -450,14 +473,23 @@ class IbgdaSendRecvBenchmarkContext {
       std::size_t nbytes,
       SendRecvApi api,
       SendRecvDirection direction,
-      SendRecvCopyOp copyOp) {
+      SendRecvCopyOp copyOp,
+      SendRecvProto proto) {
     auto* sendBuf = static_cast<char*>(sendBuf_->get());
     auto* recvBuf = static_cast<char*>(recvBuf_->get());
+    // LL is wired only for the blocking path (registerBenchmarks never pairs LL
+    // with Progress); dispatch to the send_ll/recv_ll launchers.
+    const bool useLL = (proto == SendRecvProto::LL);
 
     if (direction == SendRecvDirection::Bidirectional) {
       if (api == SendRecvApi::Blocking) {
-        launch_ibgda_send_recv(
-            deviceTransport_, sendBuf, recvBuf, nbytes, numBlocks_, stream_);
+        if (useLL) {
+          launch_ibgda_send_recv_ll(
+              deviceTransport_, sendBuf, recvBuf, nbytes, numBlocks_, stream_);
+        } else {
+          launch_ibgda_send_recv(
+              deviceTransport_, sendBuf, recvBuf, nbytes, numBlocks_, stream_);
+        }
       } else {
         launch_ibgda_progress_send_recv(
             deviceTransport_, sendBuf, recvBuf, nbytes, numBlocks_, stream_);
@@ -467,8 +499,13 @@ class IbgdaSendRecvBenchmarkContext {
 
     if (globalRank_ == 0) {
       if (api == SendRecvApi::Blocking) {
-        launch_ibgda_send(
-            deviceTransport_, sendBuf, nbytes, numBlocks_, stream_);
+        if (useLL) {
+          launch_ibgda_send_ll(
+              deviceTransport_, sendBuf, nbytes, numBlocks_, stream_);
+        } else {
+          launch_ibgda_send(
+              deviceTransport_, sendBuf, nbytes, numBlocks_, stream_);
+        }
       } else if (api == SendRecvApi::RegisteredProgress) {
         CHECK(registeredEnabled_);
         launch_ibgda_registered_progress_send(
@@ -486,7 +523,13 @@ class IbgdaSendRecvBenchmarkContext {
     }
 
     if (api == SendRecvApi::Blocking) {
-      launch_ibgda_recv(deviceTransport_, recvBuf, nbytes, numBlocks_, stream_);
+      if (useLL) {
+        launch_ibgda_recv_ll(
+            deviceTransport_, recvBuf, nbytes, numBlocks_, stream_);
+      } else {
+        launch_ibgda_recv(
+            deviceTransport_, recvBuf, nbytes, numBlocks_, stream_);
+      }
     } else {
       launch_ibgda_progress_recv(
           deviceTransport_, recvBuf, nbytes, numBlocks_, stream_);
@@ -518,6 +561,7 @@ static unsigned int ibgdaSendRecv(
     SendRecvApi api,
     SendRecvDirection direction,
     SendRecvCopyOp copyOp,
+    SendRecvProto proto,
     folly::UserCounters& counters) {
   // Small messages would run too briefly at folly's count and be dropped as
   // NaN; use a deterministic high count for them (identical on both ranks, so
@@ -527,11 +571,11 @@ static unsigned int ibgdaSendRecv(
   CHECK_GT(iters, 0);
 
   BENCHMARK_SUSPEND {
-    context.warmup(nbytes, api, direction, copyOp);
+    context.warmup(nbytes, api, direction, copyOp, proto);
   }
 
   const float elapsedMs =
-      context.runLocalElapsed(iters, nbytes, api, direction, copyOp);
+      context.runLocalElapsed(iters, nbytes, api, direction, copyOp, proto);
   folly::doNotOptimizeAway(elapsedMs);
 
   BENCHMARK_SUSPEND {
@@ -562,50 +606,78 @@ void registerBenchmark(
     SendRecvApi api,
     SendRecvDirection direction,
     SendRecvCopyOp copyOp,
+    SendRecvProto proto,
     int repeat = -1) {
   folly::addBenchmark(
       __FILE__,
-      benchmarkName(api, direction, copyOp, size.name, repeat),
-      [&context, nbytes = size.nbytes, api, direction, copyOp](
+      benchmarkName(api, direction, copyOp, proto, size.name, repeat),
+      [&context, nbytes = size.nbytes, api, direction, copyOp, proto](
           folly::UserCounters& counters, unsigned int iters) -> unsigned int {
         return ibgdaSendRecv(
-            context, iters, nbytes, api, direction, copyOp, counters);
+            context, iters, nbytes, api, direction, copyOp, proto, counters);
       });
 }
 
 void registerBenchmarks(IbgdaSendRecvBenchmarkContext& context) {
+  // A single run benchmarks exactly one protocol, selected via
+  // IBGDA_BENCH_PROTO (default: simple). Run the binary once per protocol to
+  // compare.
+  SendRecvProto proto = SendRecvProto::Simple;
+  if (const char* p = std::getenv("IBGDA_BENCH_PROTO")) {
+    const std::string protoStr(p);
+    if (protoStr == "ll") {
+      proto = SendRecvProto::LL;
+    } else if (protoStr == "simple") {
+      proto = SendRecvProto::Simple;
+    } else {
+      LOG(WARNING) << "Unknown IBGDA_BENCH_PROTO='" << protoStr
+                   << "', defaulting to simple";
+    }
+  }
+
   for (const auto& size : kBenchmarkSizes) {
+    // Blocking + fixed-size memcpy is supported by every protocol.
     registerBenchmark(
         context,
         size,
         SendRecvApi::Blocking,
         SendRecvDirection::Bidirectional,
-        SendRecvCopyOp::Memcpy);
-    registerBenchmark(
-        context,
-        size,
-        SendRecvApi::Progress,
-        SendRecvDirection::Bidirectional,
-        SendRecvCopyOp::Memcpy);
+        SendRecvCopyOp::Memcpy,
+        proto);
     registerBenchmark(
         context,
         size,
         SendRecvApi::Blocking,
         SendRecvDirection::Unidirectional,
-        SendRecvCopyOp::Memcpy);
+        SendRecvCopyOp::Memcpy,
+        proto);
+    // Neither the resumable Progress API nor the variable-size ANS CopyOp has
+    // LL wire geometry; both stay on Simple.
+    if (proto != SendRecvProto::Simple) {
+      continue;
+    }
+    registerBenchmark(
+        context,
+        size,
+        SendRecvApi::Progress,
+        SendRecvDirection::Bidirectional,
+        SendRecvCopyOp::Memcpy,
+        proto);
     registerBenchmark(
         context,
         size,
         SendRecvApi::Progress,
         SendRecvDirection::Unidirectional,
-        SendRecvCopyOp::Memcpy);
+        SendRecvCopyOp::Memcpy,
+        proto);
     if (context.registeredEnabled()) {
       registerBenchmark(
           context,
           size,
           SendRecvApi::RegisteredProgress,
           SendRecvDirection::Unidirectional,
-          SendRecvCopyOp::Memcpy);
+          SendRecvCopyOp::Memcpy,
+          proto);
     }
 
     if (context.registeredEnabled() &&
@@ -618,6 +690,7 @@ void registerBenchmarks(IbgdaSendRecvBenchmarkContext& context) {
             SendRecvApi::Progress,
             SendRecvDirection::Unidirectional,
             SendRecvCopyOp::Memcpy,
+            proto,
             repeat);
         registerBenchmark(
             context,
@@ -625,6 +698,7 @@ void registerBenchmarks(IbgdaSendRecvBenchmarkContext& context) {
             SendRecvApi::RegisteredProgress,
             SendRecvDirection::Unidirectional,
             SendRecvCopyOp::Memcpy,
+            proto,
             repeat);
       }
     }

--- a/comms/prims/core/ThreadGroup.cuh
+++ b/comms/prims/core/ThreadGroup.cuh
@@ -308,6 +308,72 @@ struct ThreadGroup {
   }
 
   /**
+   * Group-wide AND: returns true iff `pred` holds on every thread of the group.
+   *
+   * Lives next to broadcast() and derives its scratch index the same way, so
+   * the slot a group reduces into always matches the barrier it rendezvouses
+   * on. That pairing matters more here than for broadcast(): every thread
+   * atomicAnds into the slot rather than only the leader writing it, so a group
+   * reducing into the wrong index corrupts another group's result instead of
+   * merely reading a stale one.
+   *
+   * All threads in the group must call this -- it barriers.
+   *
+   * @param pred This thread's predicate
+   * @return Whether the predicate held on every thread in the group
+   */
+  __device__ __forceinline__ bool all(bool pred) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    switch (scope) {
+      case SyncScope::THREAD:
+        return pred;
+      case SyncScope::WARP:
+#ifdef __HIP_PLATFORM_AMD__
+        // A wavefront is kWarpSize == 64 lanes here, so __all() already spans
+        // the whole WARP group; HIP's __all_sync() would additionally reject
+        // the 32-bit full-warp mask NVIDIA wants (it static_asserts on a 64-bit
+        // one).
+        return __all(pred) != 0;
+#else
+        return __all_sync(0xFFFFFFFFU, pred) != 0;
+#endif
+      case SyncScope::MULTIWARP: {
+        __shared__ int __tg_all_scratch[kMaxMultiwarpsPerBlock];
+        uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
+            threadIdx.z * blockDim.x * blockDim.y;
+        uint32_t scratch_idx =
+            barrier_id == kAutoBarrierId ? tid / group_size : barrier_id;
+        if (is_leader()) {
+          __tg_all_scratch[scratch_idx] = 1;
+        }
+        sync();
+        atomicAnd(&__tg_all_scratch[scratch_idx], pred ? 1 : 0);
+        sync();
+        bool result = __tg_all_scratch[scratch_idx] != 0;
+        sync(); // Prevent leader re-seeding before all threads read
+        return result;
+      }
+      case SyncScope::BLOCK: {
+        __shared__ int __tg_all_block;
+        if (is_leader()) {
+          __tg_all_block = 1;
+        }
+        sync();
+        atomicAnd(&__tg_all_block, pred ? 1 : 0);
+        sync();
+        bool result = __tg_all_block != 0;
+        sync(); // Prevent leader re-seeding before all threads read
+        return result;
+      }
+      case SyncScope::CLUSTER:
+        printf("ThreadGroup::all: CLUSTER scope not yet supported\n");
+        __trap();
+    }
+#endif
+    return pred;
+  }
+
+  /**
    * for_each_item_contiguous - Distribute work items using CONTIGUOUS
    * assignment
    *

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -605,15 +605,15 @@ __device__ __forceinline__ std::size_t P2pIbTransportDevice::pipeline_chunk()
   return ibgda->pipeline_chunk();
 }
 
-template <typename>
+template <typename Proto>
 __device__ __forceinline__ void P2pIbTransportDevice::init_send_progress(
     ThreadGroup& group,
     std::size_t nbytes,
     std::size_t max_signal_bytes) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->init_send_progress(group, nbytes, max_signal_bytes);
+    ibrc->init_send_progress<Proto>(group, nbytes, max_signal_bytes);
   } else {
-    ibgda->init_send_progress(group, nbytes, max_signal_bytes);
+    ibgda->init_send_progress<Proto>(group, nbytes, max_signal_bytes);
   }
 }
 
@@ -627,19 +627,19 @@ P2pIbTransportDevice::init_registered_send_progress(
   ibgda->init_registered_send_progress(group, nbytes, max_signal_bytes);
 }
 
-template <typename>
+template <typename Proto>
 __device__ __forceinline__ void P2pIbTransportDevice::init_recv_progress(
     ThreadGroup& group,
     std::size_t nbytes,
     std::size_t max_signal_bytes) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->init_recv_progress(group, nbytes, max_signal_bytes);
+    ibrc->init_recv_progress<Proto>(group, nbytes, max_signal_bytes);
   } else {
-    ibgda->init_recv_progress(group, nbytes, max_signal_bytes);
+    ibgda->init_recv_progress<Proto>(group, nbytes, max_signal_bytes);
   }
 }
 
-template <typename CopyOp, typename... Args>
+template <typename CopyOp, typename Proto, typename... Args>
 __device__ __forceinline__ IbgdaSendRecvProgressStatus
 P2pIbTransportDevice::progress_send_once(
     ThreadGroup& group,
@@ -649,10 +649,10 @@ P2pIbTransportDevice::progress_send_once(
     const Timeout& timeout,
     Args... args) {
   if (type == P2pIbBackendType::IBRC) {
-    return ibrc->progress_send_once<CopyOp>(
+    return ibrc->progress_send_once<CopyOp, Proto>(
         group, src, nbytes, max_signal_bytes, timeout, args...);
   }
-  return ibgda->progress_send_once<CopyOp>(
+  return ibgda->progress_send_once<CopyOp, Proto>(
       group, src, nbytes, max_signal_bytes, timeout, args...);
 }
 
@@ -704,7 +704,7 @@ P2pIbTransportDevice::progress_send_once_with_trace(
       args...);
 }
 
-template <typename CopyOp, typename... Args>
+template <typename CopyOp, typename Proto, typename... Args>
 __device__ __forceinline__ IbgdaSendRecvProgressStatus
 P2pIbTransportDevice::progress_recv_once(
     ThreadGroup& group,
@@ -714,10 +714,10 @@ P2pIbTransportDevice::progress_recv_once(
     const Timeout& timeout,
     Args... args) {
   if (type == P2pIbBackendType::IBRC) {
-    return ibrc->progress_recv_once<CopyOp>(
+    return ibrc->progress_recv_once<CopyOp, Proto>(
         group, dst, nbytes, max_signal_bytes, timeout, args...);
   }
-  return ibgda->progress_recv_once<CopyOp>(
+  return ibgda->progress_recv_once<CopyOp, Proto>(
       group, dst, nbytes, max_signal_bytes, timeout, args...);
 }
 

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -17,6 +17,12 @@ struct Memcpy;
 struct PipesTraceAllReduceContext;
 struct PipesTraceProgressState;
 
+// Defined in P2pIbTransportDeviceImpl.cuh, which includes this header; only the
+// name is needed here to spell the default protocol template argument.
+namespace protocol {
+struct Simple;
+} // namespace protocol
+
 class P2pIbgdaTransportDevice;
 class P2pIbrcTransportDevice;
 
@@ -318,7 +324,7 @@ struct P2pIbTransportDevice {
 
   __device__ __forceinline__ std::size_t pipeline_chunk() const;
 
-  template <typename = void>
+  template <typename Proto = protocol::Simple>
   __device__ __forceinline__ void init_send_progress(
       ThreadGroup& group,
       std::size_t nbytes,
@@ -330,13 +336,16 @@ struct P2pIbTransportDevice {
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0);
 
-  template <typename = void>
+  template <typename Proto = protocol::Simple>
   __device__ __forceinline__ void init_recv_progress(
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0);
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename Proto = protocol::Simple,
+      typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
       ThreadGroup& group,
       const void* __restrict__ src,
@@ -372,7 +381,10 @@ struct P2pIbTransportDevice {
       PipesTraceProgressState& traceState,
       Args... args);
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename Proto = protocol::Simple,
+      typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
       ThreadGroup& group,
       void* __restrict__ dst,

--- a/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
@@ -214,14 +214,14 @@ __device__ __forceinline__ void record_send_completion(
     uint64_t generation,
     const IbLocalCompletionTicket& ticket);
 
-template <typename Transport>
+template <typename Transport, typename Proto = protocol::Simple>
 __device__ __forceinline__ void init_send_progress(
     Transport& transport,
     ThreadGroup& group,
     std::size_t nbytes,
     std::size_t max_signal_bytes);
 
-template <typename Transport>
+template <typename Transport, typename Proto = protocol::Simple>
 __device__ __forceinline__ void init_recv_progress(
     Transport& transport,
     ThreadGroup& group,

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -131,7 +131,7 @@ __device__ __forceinline__ bool try_prepare_send_slot(
  * @param nbytes Number of user-buffer bytes to send for this group.
  * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
  */
-template <typename Transport>
+template <typename Transport, typename Proto>
 __device__ __forceinline__ void init_send_progress(
     Transport& transport,
     ThreadGroup& group,
@@ -139,7 +139,7 @@ __device__ __forceinline__ void init_send_progress(
     std::size_t max_signal_bytes) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   auto& channelLayout = transport.channel_layout();
-  auto& slot = progress_send_slot<protocol::Simple>(transport, group);
+  auto& slot = progress_send_slot<Proto>(transport, group);
   assert_progress_slot_idle(group, slot, "send");
   IbChannelProgress state{};
   state.activeStage = nbytes == 0
@@ -149,8 +149,10 @@ __device__ __forceinline__ void init_send_progress(
     store_progress_state(group, slot, state);
     return;
   }
-  // Validate the transfer before reserving the transport byte cursor.
-  const ProgressGeometry geometry = make_progress_geometry(
+  // Validate the transfer before reserving the transport byte cursor. The
+  // reservation runs in Proto's payload/wire geometry so init and every later
+  // progress_send_once() agree on the cursor + tail padding.
+  const ProgressGeometry geometry = make_progress_geometry<Proto>(
       channelLayout, group, nbytes, max_signal_bytes, "init_send_progress");
   reserve_progress_step(group, slot, state, geometry);
   store_progress_state(group, slot, state);
@@ -206,7 +208,7 @@ __device__ __forceinline__ void init_registered_send_progress(
  * @param nbytes Number of user-buffer bytes to receive for this group.
  * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
  */
-template <typename Transport>
+template <typename Transport, typename Proto>
 __device__ __forceinline__ void init_recv_progress(
     Transport& transport,
     ThreadGroup& group,
@@ -214,7 +216,7 @@ __device__ __forceinline__ void init_recv_progress(
     std::size_t max_signal_bytes) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   auto& channelLayout = transport.channel_layout();
-  auto& slot = progress_recv_slot<protocol::Simple>(transport, group);
+  auto& slot = progress_recv_slot<Proto>(transport, group);
   assert_progress_slot_idle(group, slot, "recv");
   IbChannelProgress state{};
   state.activeStage = nbytes == 0
@@ -224,8 +226,10 @@ __device__ __forceinline__ void init_recv_progress(
     store_progress_state(group, slot, state);
     return;
   }
-  // Validate the transfer before reserving the transport byte cursor.
-  const ProgressGeometry geometry = make_progress_geometry(
+  // Validate the transfer before reserving the transport byte cursor. The
+  // reservation runs in Proto's payload/wire geometry so init and every later
+  // progress_recv_once() agree on the cursor + tail padding.
+  const ProgressGeometry geometry = make_progress_geometry<Proto>(
       channelLayout, group, nbytes, max_signal_bytes, "init_recv_progress");
   reserve_progress_step(group, slot, state, geometry);
   store_progress_state(group, slot, state);
@@ -317,6 +321,62 @@ __device__ __forceinline__ SendSignal progress_send_signal(
     const IbRemoteChannel& remoteChannel,
     uint64_t signalVal) {
   return SendSignal{remoteChannel.dataReady, signalVal};
+}
+
+// ---- LL (data + inline flag) progress send overloads ---------------------
+// The LL siblings of the Simple send seams above. Encode packs payload+flag
+// via the CopyOp's packet-aware sendLL<P> hook (Memcpy delegates to
+// LLImpl::pack) so the put carries the readiness mark inline; the signal is
+// therefore empty (no DATA_READY). This mirrors the blocking LL path
+// (prepareSendBuf(protocol::LL)) -- the CopyOp must provide sendLL<P>, so a
+// reduce/convert op can plug in; a plain contiguous copy cannot address the
+// packet-interleaved staging.
+
+// Encode one send chunk into send-staging (LL: CopyOp::sendLL<P>,
+// payload+flag).
+template <typename CopyOp = Memcpy, typename... Args>
+__device__ __forceinline__ void progress_send_prepare_buf(
+    protocol::LL,
+    ThreadGroup& group,
+    const IbChannelLayout& channelLayout,
+    const ProgressChunk& chunk,
+    const void* __restrict__ src,
+    std::size_t payloadBytes,
+    Args... args) {
+  using P = LlxPacket<4, 4>;
+  static_assert(
+      has_sendLL_v<CopyOp, P>,
+      "LL progress send requires a CopyOp with a packet-aware sendLL<P>(); "
+      "Memcpy provides one. A reduce/convert CopyOp must supply its own -- a "
+      "plain contiguous copy cannot address the data+flag interleaved staging");
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  const std::size_t validBytes =
+      valid_payload_bytes(chunk.dataOff, chunk.payloadBytes, payloadBytes);
+  CopyOp::template sendLL<P>(
+      group,
+      channelLayout.sendStagingPtr + chunk.stagingOff,
+      static_cast<const char*>(src) + chunk.dataOff,
+      validBytes,
+      chunk.dataOff,
+      static_cast<typename P::FlagType>(chunk.flagVal),
+      args...);
+#else
+  (void)group;
+  (void)channelLayout;
+  (void)chunk;
+  (void)src;
+  (void)payloadBytes;
+  ((void)args, ...);
+#endif
+}
+
+// The signal the leader put piggybacks (LL: none -- the inline packet flag is
+// the readiness mark, so the put carries data only).
+__device__ __forceinline__ SendSignal progress_send_signal(
+    protocol::LL,
+    const IbRemoteChannel& /*remoteChannel*/,
+    uint64_t /*signalVal*/) {
+  return SendSignal{IbgdaRemoteBuffer{}, /*val=*/0};
 }
 
 template <typename Transport, typename CopyOp, typename Proto, typename... Args>
@@ -951,11 +1011,16 @@ __device__ __forceinline__ bool poll_recv_data_ready(
  */
 // Non-blocking readiness check for one recv chunk (Simple: poll the round-robin
 // DATA_READY lane that carried this chunk; leader-only + broadcast, no spin).
+// `channelLayout`/`chunk` are unused by Simple (they carry the recv staging +
+// packet geometry the LL overload polls); the seam passes them so both
+// protocols share the call site in progress_recv_once.
 template <typename Transport>
 __device__ __forceinline__ bool progress_recv_ready(
     protocol::Simple,
     Transport& transport,
     ThreadGroup& group,
+    const IbChannelLayout& channelLayout,
+    const ProgressChunk& chunk,
     IbLocalChannel& localChannel,
     const IbgdaLocalBuffer& localDataReady,
     uint64_t waitCredit,
@@ -964,6 +1029,8 @@ __device__ __forceinline__ bool progress_recv_ready(
     PipesTraceProgressState* traceState,
     uint8_t qpLane) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  (void)channelLayout;
+  (void)chunk;
   uint32_t ready = 1;
   if (group.is_leader()) {
     unsigned long long current = 0;
@@ -1008,6 +1075,8 @@ __device__ __forceinline__ bool progress_recv_ready(
 #else
   (void)transport;
   (void)group;
+  (void)channelLayout;
+  (void)chunk;
   (void)localChannel;
   (void)localDataReady;
   (void)waitCredit;
@@ -1066,6 +1135,147 @@ __device__ __forceinline__ void progress_recv_consume_buf(
   (void)payloadBytes;
   (void)traceContext;
   (void)qpLane;
+  ((void)args, ...);
+#endif
+}
+
+// Group-wide AND, used by the LL readiness poll to fold each thread's local
+// packet-flag check into one collective decision. Delegates to
+// ThreadGroup::all() so the scratch index stays tied to the group's barrier;
+// keeping a second copy of that indexing here is what let it drift from
+// ThreadGroup::broadcast().
+__device__ __forceinline__ bool group_all_ready(ThreadGroup& group, bool pred) {
+  return group.all(pred);
+}
+
+// Non-blocking readiness check for one recv chunk (LL: cooperative,
+// non-spinning poll of every packet's inline flag == chunk.flagVal, then a
+// group AND-reduce). There is no DATA_READY counter for LL, so
+// transport/localChannel/waitCredit are unused. The trace parameters are part
+// of the shared seam that progress_recv_once_impl calls through; LL emits no
+// trace events, so they are accepted and ignored.
+//
+// Landing constraint: leaving localChannel untouched here skips the
+// receiver-side mirror advance that IbgdaBuffer.h documents as a cross-protocol
+// invariant -- put_impl bumps the send cursor unconditionally, so without a
+// matching receiver-side advance the round-robin lane mapping desyncs and a
+// later Simple collective on the same channel can wait on a lane the sender
+// never used. D115669516 completes that advance; it must land in the same batch
+// as this diff and the ones that enable LL progress on top of it.
+template <typename Transport>
+__device__ __forceinline__ bool progress_recv_ready(
+    protocol::LL,
+    Transport& transport,
+    ThreadGroup& group,
+    const IbChannelLayout& channelLayout,
+    const ProgressChunk& chunk,
+    IbLocalChannel& localChannel,
+    const IbgdaLocalBuffer& localDataReady,
+    uint64_t waitCredit,
+    const Timeout& timeout,
+    const PipesTraceAllReduceContext* traceContext,
+    PipesTraceProgressState* traceState,
+    uint8_t qpLane) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  using P = LlxPacket<4, 4>;
+  (void)transport;
+  (void)localChannel;
+  (void)localDataReady;
+  (void)waitCredit;
+  (void)traceContext;
+  (void)traceState;
+  (void)qpLane;
+  const char* staging = channelLayout.recvStagingPtr + chunk.stagingOff;
+  const std::size_t nPackets =
+      chunk.wireBytes / static_cast<std::size_t>(P::kPacketBytes);
+  const auto flagVal = static_cast<typename P::FlagType>(chunk.flagVal);
+  // Each thread inspects the packets it owns (grid-strided, mirroring
+  // LLImpl::unpack) with early-exit, then the group AND-reduces so all threads
+  // agree to decode or to return Waiting -- no spin.
+  uint32_t myReady = 1;
+  for (std::size_t i = group.thread_id_in_group; i < nPackets;
+       i += group.group_size) {
+    if (!LLImpl<P>::is_flag_set(
+            staging + i * static_cast<std::size_t>(P::kPacketBytes), flagVal)) {
+      myReady = 0;
+      break;
+    }
+  }
+  const bool ready = group_all_ready(group, myReady != 0U);
+  if (!ready && group.is_leader()) {
+    TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+        timeout,
+        "progress_recv_once(LL) waiting for packet flags flagVal=%llu, "
+        "wireBytes=%llu",
+        static_cast<unsigned long long>(chunk.flagVal),
+        static_cast<unsigned long long>(chunk.wireBytes));
+  }
+  return ready;
+#else
+  (void)transport;
+  (void)group;
+  (void)channelLayout;
+  (void)chunk;
+  (void)localChannel;
+  (void)localDataReady;
+  (void)waitCredit;
+  (void)timeout;
+  return true;
+#endif
+}
+
+// Decode one ready recv chunk from recv-staging into dst via the CopyOp's
+// packet-aware recvLL<P> hook (Memcpy delegates to LLImpl::unpack; a
+// reduce/convert op sums each packet's payload into the accumulator).
+// progress_recv_ready already confirmed every packet flag == chunk.flagVal, so
+// the decode does not spin. Mirrors the blocking LL path
+// (consumeRecvBuf(protocol::LL)) -- this is the CopyOp dispatch point for the
+// LL progress recv path.
+//
+// traceContext/qpLane are named rather than swept into `Args...`: the pack is
+// forwarded to the CopyOp, so leaving them unnamed would silently hand the
+// reduce op two extra arguments instead of failing to compile.
+template <typename CopyOp = Memcpy, typename... Args>
+__device__ __forceinline__ void progress_recv_consume_buf(
+    protocol::LL,
+    ThreadGroup& group,
+    const IbChannelLayout& channelLayout,
+    const ProgressChunk& chunk,
+    void* __restrict__ dst,
+    std::size_t payloadBytes,
+    const PipesTraceAllReduceContext* traceContext,
+    uint8_t qpLane,
+    Args... args) {
+  using P = LlxPacket<4, 4>;
+  (void)traceContext;
+  (void)qpLane;
+  static_assert(
+      has_recvLL_v<CopyOp, P>,
+      "LL progress recv requires a CopyOp with a packet-aware recvLL<P>(); "
+      "Memcpy provides one. A reduce/convert CopyOp must supply its own -- a "
+      "plain contiguous copy cannot address the data+flag interleaved staging");
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  const std::size_t validBytes =
+      valid_payload_bytes(chunk.dataOff, chunk.payloadBytes, payloadBytes);
+  // progress_recv_ready() above already confirmed every packet flag equals
+  // chunk.flagVal, so unpack's readiness spin exits on its first load and a
+  // disabled Timeout cannot hang here. If that pre-check ever stops being
+  // exhaustive, thread progress_recv_once()'s timeout through instead.
+  CopyOp::template recvLL<P>(
+      group,
+      static_cast<char*>(dst) + chunk.dataOff,
+      channelLayout.recvStagingPtr + chunk.stagingOff,
+      validBytes,
+      chunk.dataOff,
+      static_cast<typename P::FlagType>(chunk.flagVal),
+      Timeout(),
+      args...);
+#else
+  (void)group;
+  (void)channelLayout;
+  (void)chunk;
+  (void)dst;
+  (void)payloadBytes;
   ((void)args, ...);
 #endif
 }
@@ -1131,6 +1341,8 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once_impl(
           Proto{},
           transport,
           group,
+          channelLayout,
+          chunk,
           localChannel,
           localDataReady,
           protocolBytesThis,

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -2315,6 +2315,16 @@ class P2pIbgdaTransportDevice {
    * flight. `max_signal_bytes` may vary across calls because it only changes
    * the signal cadence within the fixed per-channel staging slice.
    *
+   * `Proto` is a call-site choice and is never negotiated on the wire, so the
+   * sender and receiver must select the same one: mixing them deadlocks, with
+   * Simple waiting on a DATA_READY counter the LL sender never posts while LL
+   * polls for an inline flag Simple never writes. Callers own that agreement
+   * and must derive the protocol from a collective-uniform input rather than
+   * from per-rank state. MCCL's tree does this on the host, picking from the
+   * total message size and baking the result into the kernel symbol (see
+   * `selectAllReduceTreeKernel` / `MCCL_ALLREDUCE_LL_MAX_BYTES`), so every rank
+   * in a launch runs the same format.
+   *
    * @param group           ThreadGroup (all threads participate in memcpy,
    *                        leader does RDMA ops).
    * @param src             Source data for this block's tile.

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -2072,12 +2072,13 @@ class P2pIbgdaTransportDevice {
    * @param nbytes Number of user-buffer bytes to send for this group.
    * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
    */
-  template <typename = void>
+  template <typename Proto = protocol::Simple>
   __device__ __forceinline__ void init_send_progress(
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0) {
-    detail::init_send_progress(*this, group, nbytes, max_signal_bytes);
+    detail::init_send_progress<P2pIbgdaTransportDevice, Proto>(
+        *this, group, nbytes, max_signal_bytes);
   }
 
   /**
@@ -2119,12 +2120,13 @@ class P2pIbgdaTransportDevice {
    * @param nbytes Number of user-buffer bytes to receive for this group.
    * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
    */
-  template <typename = void>
+  template <typename Proto = protocol::Simple>
   __device__ __forceinline__ void init_recv_progress(
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0) {
-    detail::init_recv_progress(*this, group, nbytes, max_signal_bytes);
+    detail::init_recv_progress<P2pIbgdaTransportDevice, Proto>(
+        *this, group, nbytes, max_signal_bytes);
   }
 
   /**
@@ -2159,7 +2161,10 @@ class P2pIbgdaTransportDevice {
    * @param timeout Optional device timeout checked while dependencies wait.
    * @param args Additional arguments forwarded to `CopyOp::send`.
    */
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename Proto = protocol::Simple,
+      typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
       ThreadGroup& group,
       const void* __restrict__ src,
@@ -2167,7 +2172,7 @@ class P2pIbgdaTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-    return detail::progress_send_once<P2pIbgdaTransportDevice, CopyOp>(
+    return detail::progress_send_once<P2pIbgdaTransportDevice, CopyOp, Proto>(
         *this, group, src, nbytes, max_signal_bytes, timeout, args...);
   }
 
@@ -2252,7 +2257,10 @@ class P2pIbgdaTransportDevice {
    * @param timeout Optional device timeout checked while dependencies wait.
    * @param args Additional arguments forwarded to `CopyOp::recv`.
    */
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename Proto = protocol::Simple,
+      typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
       ThreadGroup& group,
       void* __restrict__ dst,
@@ -2260,7 +2268,7 @@ class P2pIbgdaTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-    return detail::progress_recv_once<P2pIbgdaTransportDevice, CopyOp>(
+    return detail::progress_recv_once<P2pIbgdaTransportDevice, CopyOp, Proto>(
         *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
   }
 

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -625,23 +625,28 @@ class P2pIbrcTransportDevice {
         static_cast<std::size_t>(channelLayout_.pipelineDepth);
   }
 
-  template <typename = void>
+  template <typename Proto = protocol::Simple>
   __device__ __forceinline__ void init_send_progress(
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0) {
-    detail::init_send_progress(*this, group, nbytes, max_signal_bytes);
+    detail::init_send_progress<P2pIbrcTransportDevice, Proto>(
+        *this, group, nbytes, max_signal_bytes);
   }
 
-  template <typename = void>
+  template <typename Proto = protocol::Simple>
   __device__ __forceinline__ void init_recv_progress(
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0) {
-    detail::init_recv_progress(*this, group, nbytes, max_signal_bytes);
+    detail::init_recv_progress<P2pIbrcTransportDevice, Proto>(
+        *this, group, nbytes, max_signal_bytes);
   }
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename Proto = protocol::Simple,
+      typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
       ThreadGroup& group,
       const void* __restrict__ src,
@@ -649,11 +654,14 @@ class P2pIbrcTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-    return detail::progress_send_once<P2pIbrcTransportDevice, CopyOp>(
+    return detail::progress_send_once<P2pIbrcTransportDevice, CopyOp, Proto>(
         *this, group, src, nbytes, max_signal_bytes, timeout, args...);
   }
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename Proto = protocol::Simple,
+      typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
       ThreadGroup& group,
       void* __restrict__ dst,
@@ -661,7 +669,7 @@ class P2pIbrcTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-    return detail::progress_recv_once<P2pIbrcTransportDevice, CopyOp>(
+    return detail::progress_recv_once<P2pIbrcTransportDevice, CopyOp, Proto>(
         *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
   }
 


### PR DESCRIPTION
Summary:
Additive: implement the LL siblings of the four resumable-progress seams,
plus a group-wide AND reduction they need. The state machine is untouched
(progress_send_once/progress_recv_once already dispatch via Proto{} after the
earlier extraction + wire/payload geometry commits), so the LL protocol now
has a working resumable progress path.

  - progress_send_prepare_buf(LL)  -- CopyOp::sendLL<P> (payload + inline flag;
                                      Memcpy delegates to LLImpl::pack)
  - progress_send_signal(LL)       -- empty signal (the inline flag is the
                                      readiness mark, so the put carries data
                                      only, no DATA_READY)
  - progress_recv_ready(LL)        -- cooperative, non-spinning poll of packet
                                      flags: each thread checks its grid-strided
                                      packets (LLImpl::is_flag_set), then
                                      group_all_ready() AND-reduces
  - progress_recv_consume_buf(LL)  -- CopyOp::recvLL<P> (Memcpy delegates to
                                      LLImpl::unpack; no spin, readiness already
                                      confirmed)
  - group_all_ready()              -- per-scope group AND reduce (ThreadGroup
                                      only offered broadcast); parallelizes the
                                      O(nPackets) flag scan across the group

The encode/decode seams dispatch through the CopyOp's packet-aware
sendLL<P>/recvLL<P> hooks (gated by has_sendLL_v/has_recvLL_v), exactly as the
blocking LL path does (prepareSendBuf/consumeRecvBuf(protocol::LL)). Memcpy's
hooks wrap LLImpl::pack/unpack, so behavior is identical for the default op --
and progress_recv_consume_buf(LL) is thereby a real CopyOp dispatch point, so a
packet-aware reduce/convert op (e.g. an LL receive-reduce) can plug into the LL
progress recv path without touching the state machine.

progress_recv_ready gains channelLayout + chunk params (the LL overload needs
the recv staging + packet geometry to poll flags); Simple ignores them, so the
two protocols share the one call site in progress_recv_once.

No Simple behavior change.

Reviewed By: zhiyongww

Differential Revision: D112334774


