### PR TITLE
Run ctree Phase 2 IB tree over the LL protocol (#3625)

### DIFF
--- a/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -1177,8 +1177,10 @@ bool runCorrectnessSweep(IbgdaSendRecvBenchmarkContext& context) {
   const bool mixed = correctnessMixed();
   const SendRecvProto proto = selectProto();
   const uint32_t iters = correctnessIters();
-  // Mixed uses the LL size list: every size in it is valid for both protocols,
-  // and it stays under the LL 1 MiB wire cap.
+  // Mixed uses the LL size list: every size in it is valid for both protocols.
+  // The list stops at 1 MiB because that is where LL has long since become
+  // bandwidth-bound (see kLlBenchmarkSizes), not because the protocol imposes
+  // any size limit -- LlxPacket computes its geometry in size_t with no cap.
   const bool useLlSizes = mixed || proto == SendRecvProto::LL;
   const BenchmarkSize* const sizes =
       useLlSizes ? kLlBenchmarkSizes.data() : kBenchmarkSizes.data();

--- a/comms/prims/core/LLImpl.cuh
+++ b/comms/prims/core/LLImpl.cuh
@@ -6,6 +6,7 @@
 #include <cstdint>
 
 #include "comms/common/AtomicUtils.cuh"
+#include "comms/prims/core/DeviceCheck.cuh"
 #include "comms/prims/core/DeviceMacros.cuh"
 #include "comms/prims/core/LlxPacket.cuh"
 #include "comms/prims/core/ThreadGroup.cuh"
@@ -192,19 +193,10 @@ struct LLImpl {
       const std::size_t off = i * static_cast<std::size_t>(P::kData);
 
       if constexpr (P::kPacketBytes == static_cast<int>(sizeof(uint64_t))) {
-        // 8 B packet: {data:4, flag:4} in one 8 B atomic word. Fuse the poll
-        // and the data read -- one wide volatile load yields both.
-        const auto* p = reinterpret_cast<const volatile uint64_t*>(pkt);
-        uint64_t v;
-        uint32_t spins = 0;
-        do {
-          v = comms::device::ld_volatile_global(p);
-          if (((++spins & kTimeoutPollMask) == 0) && timeout.checkExpired()) {
-            PIPES_DEVICE_TRAP();
-          }
-        } while (static_cast<FlagType>(v >> 32) !=
-                 flagVal); // high half is the flag
-        const auto data = static_cast<uint32_t>(v); // low half is the payload
+        // 8 B packet: {data:4, flag:4} in one 8 B atomic word -- the poll and
+        // the data read are one load. Shared with unpack_reduce so there is a
+        // single spin loop in this file.
+        const uint32_t data = load_ready_payload(pkt, flagVal, timeout);
         const auto* db = reinterpret_cast<const char*>(&data);
 #pragma unroll
         for (int b = 0; b < P::kData; ++b) {
@@ -248,6 +240,140 @@ struct LLImpl {
     (void)staging;
     (void)nbytes;
     (void)flagVal;
+#endif
+  }
+
+  /// Spin until `pkt` carries flag == `flagVal`, then return its data half.
+  /// One wide volatile load yields both halves, so the readiness poll and the
+  /// payload read are the same instruction -- the fused 8 B path unpack() uses.
+  __device__ __forceinline__ static uint32_t load_ready_payload(
+      const char* pkt,
+      FlagType flagVal,
+      const Timeout& timeout) {
+#ifdef __CUDA_ARCH__
+    const auto* p = reinterpret_cast<const volatile uint64_t*>(pkt);
+    uint64_t v;
+    uint32_t spins = 0;
+    do {
+      v = comms::device::ld_volatile_global(p);
+      if (((++spins & kTimeoutPollMask) == 0) && timeout.checkExpired()) {
+        PIPES_DEVICE_TRAP();
+      }
+    } while (static_cast<FlagType>(v >> 32) !=
+             flagVal); // high half is the flag
+    return static_cast<uint32_t>(v); // low half is the payload
+#else
+    (void)pkt;
+    (void)flagVal;
+    (void)timeout;
+    return 0;
+#endif
+  }
+
+  /// Reduce the packet stream into `accum` under `Combine`: the accumulating
+  /// counterpart of unpack(), which assigns. A reduce CopyOp cannot call
+  /// unpack() -- that would overwrite the partial sum -- and staging into a
+  /// scratch buffer first would cost an extra chunk-sized write and read on
+  /// what is the latency path.
+  ///
+  /// Lives here rather than in the CopyOp so the packet walk, the valid-payload
+  /// masking and the wide-T reassembly stay in the one place that owns the
+  /// packet format, and so the readiness spin is not something each caller has
+  /// to remember. A reduce op that re-implemented this walk without the spin
+  /// would consume staging before the data landed.
+  ///
+  /// Two element/packet tilings, both reachable from the fused AllReduce's
+  /// instantiation set. When an element fits inside a packet's data region
+  /// (float, __half, __nv_bfloat16 against kData = 4) one thread owns one
+  /// packet. When an element is wider (double, int64_t) it spans
+  /// sizeof(T)/kData consecutive packets, so one thread instead owns one
+  /// element and reassembles it before reducing -- a per-packet reduce would
+  /// corrupt a value split across two packets.
+  ///
+  /// NOTE: scalar-granular by construction (one float / two halves per 4 B
+  /// packet); the packet layout rules out the 16 B vectorized tile reduce the
+  /// contiguous path uses.
+  /// `Combine` is a default-constructible functor with
+  /// `operator()(T& accum, const T& value)`. Passing the combiner in keeps the
+  /// reduce vocabulary out of the codec: LLImpl owns the packet format, the
+  /// caller owns what "reduce" means. It also keeps this header host-includable
+  /// -- pulling in VecOps would drag device-only math (fmaxf/fminf) into every
+  /// host TU that reaches LLImpl through MemcpyCopyOp.cuh.
+  template <typename T, typename Combine, typename Group>
+  __device__ __forceinline__ static void unpack_reduce(
+      Group& group,
+      T* accum,
+      const void* staging,
+      std::size_t nbytes,
+      FlagType flagVal,
+      const Timeout& timeout = Timeout()) {
+#ifdef __CUDA_ARCH__
+    constexpr std::size_t kData = static_cast<std::size_t>(P::kData);
+    constexpr std::size_t kPacket = static_cast<std::size_t>(P::kPacketBytes);
+    const auto* base = reinterpret_cast<const char*>(staging);
+
+    if constexpr (kData % sizeof(T) == 0) {
+      constexpr std::size_t kElemsPerPacket = kData / sizeof(T);
+      const std::size_t nPackets = P::packet_count(nbytes);
+      for (std::size_t i = group.thread_id_in_group; i < nPackets;
+           i += group.group_size) {
+        const uint32_t data =
+            load_ready_payload(base + i * kPacket, flagVal, timeout);
+        const T* payload = reinterpret_cast<const T*>(&data);
+        const std::size_t nElem = P::valid_payload(i, nbytes) / sizeof(T);
+        const std::size_t baseElem = i * kElemsPerPacket;
+#pragma unroll
+        for (std::size_t e = 0; e < kElemsPerPacket; ++e) {
+          if (e < nElem) {
+            Combine{}(accum[baseElem + e], payload[e]);
+          }
+        }
+      }
+    } else {
+      // Entered when kData % sizeof(T) != 0, but the reassembly below needs the
+      // stronger property: an element must be a whole number of packets.
+      // Without it kPacketsPerElem truncates and each element is silently
+      // under-filled -- at sizeof(T) == 3 it would be zero packets and `val`
+      // would be reduced wholly uninitialized. Every currently instantiated
+      // type (double, int64_t against kData == 4) satisfies this.
+      static_assert(
+          sizeof(T) % kData == 0,
+          "LL wide-element reduce needs sizeof(T) to be a whole number of "
+          "packet payloads");
+      constexpr std::size_t kPacketsPerElem = sizeof(T) / kData;
+      // Whole elements only. A chunk carrying a partial element would drop it
+      // here (integer division) and leave the next chunk's `accum` misaligned.
+      // Chunk sizing guarantees this: calcGeometry/make_progress_geometry align
+      // chunkPayload to lcm(kData, 8), a multiple of sizeof(T). This check
+      // is the backstop for a caller that bypasses that sizing.
+      PIPES_DEVICE_CHECK_MSG(
+          nbytes % sizeof(T) == 0, "LL reduce chunk must hold whole elements");
+      const std::size_t nElems = nbytes / sizeof(T);
+      for (std::size_t e = group.thread_id_in_group; e < nElems;
+           e += group.group_size) {
+        T val;
+        auto* valBytes = reinterpret_cast<char*>(&val);
+#pragma unroll
+        for (std::size_t k = 0; k < kPacketsPerElem; ++k) {
+          const uint32_t word = load_ready_payload(
+              base + (e * kPacketsPerElem + k) * kPacket, flagVal, timeout);
+          const auto* wordBytes = reinterpret_cast<const char*>(&word);
+#pragma unroll
+          for (std::size_t b = 0; b < kData; ++b) {
+            valBytes[k * kData + b] = wordBytes[b];
+          }
+        }
+        Combine{}(accum[e], val);
+      }
+    }
+    group.sync();
+#else
+    (void)group;
+    (void)accum;
+    (void)staging;
+    (void)nbytes;
+    (void)flagVal;
+    (void)timeout;
 #endif
   }
 };

--- a/comms/prims/tests/LLImplTest.cc
+++ b/comms/prims/tests/LLImplTest.cc
@@ -1,7 +1,10 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <cuda_fp16.h>
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
+#include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
@@ -91,6 +94,136 @@ TEST_F(LLImplTest, LlRoundTrip) {
         std::size_t(4096)}) {
     roundTrip<LlxPacketGeometry>(test::test_ll_pack_unpack, n);
   }
+}
+
+namespace {
+
+// Seed accum, pack src, reduce src into accum on device, return accum.
+// `expected` is built independently on the host from the same inputs.
+template <typename T, typename Launch>
+std::vector<T> runUnpackReduce(
+    const std::vector<T>& src,
+    const std::vector<T>& seed,
+    Launch launch) {
+  const std::size_t nelems = src.size();
+  const std::size_t nbytes = nelems * sizeof(T);
+
+  DeviceBuffer srcBuf(nbytes);
+  DeviceBuffer accumBuf(nbytes);
+  DeviceBuffer staging(LlxPacketGeometry::wire_bytes(nbytes));
+
+  CUDACHECK_TEST(
+      cudaMemcpy(srcBuf.get(), src.data(), nbytes, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(
+      cudaMemcpy(accumBuf.get(), seed.data(), nbytes, cudaMemcpyHostToDevice));
+  // Poison staging: unpack_reduce must wait for pack()'s flags, so a missing
+  // readiness poll shows up as reduced garbage rather than a pass.
+  CUDACHECK_TEST(
+      cudaMemset(staging.get(), 0xEE, LlxPacketGeometry::wire_bytes(nbytes)));
+
+  launch(srcBuf.get(), static_cast<char*>(staging.get()), accumBuf.get());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<T> out(nelems);
+  CUDACHECK_TEST(
+      cudaMemcpy(out.data(), accumBuf.get(), nbytes, cudaMemcpyDeviceToHost));
+  return out;
+}
+
+} // namespace
+
+// sizeof(T) == kData: one element per packet, all three reduce ops.
+// Values are small integers so float arithmetic is exact and the expected
+// vector can be compared with ==.
+TEST_F(LLImplTest, UnpackReduceOneElemPerPacket) {
+  constexpr std::size_t kElems = 133; // not a multiple of the block size
+  std::vector<float> src(kElems), seed(kElems);
+  for (std::size_t i = 0; i < kElems; ++i) {
+    src[i] = static_cast<float>(i % 17);
+    seed[i] = static_cast<float>((i % 5) + 1);
+  }
+
+  const std::array<test::ReduceKind, 3> kinds{
+      test::ReduceKind::Sum, test::ReduceKind::Max, test::ReduceKind::Min};
+  for (const auto kind : kinds) {
+    std::vector<float> expected(kElems);
+    for (std::size_t i = 0; i < kElems; ++i) {
+      switch (kind) {
+        case test::ReduceKind::Sum:
+          expected[i] = seed[i] + src[i];
+          break;
+        case test::ReduceKind::Max:
+          expected[i] = std::max(seed[i], src[i]);
+          break;
+        case test::ReduceKind::Min:
+          expected[i] = std::min(seed[i], src[i]);
+          break;
+      }
+    }
+
+    const auto actual =
+        runUnpackReduce<float>(src, seed, [&](void* s, char* st, void* a) {
+          test::test_ll_unpack_reduce_f32(
+              static_cast<const float*>(s),
+              st,
+              static_cast<float*>(a),
+              kElems,
+              kind);
+        });
+    EXPECT_EQ(actual, expected)
+        << "float reduce mismatch for kind " << static_cast<int>(kind);
+  }
+}
+
+// sizeof(T) < kData: two elements per packet. kElems is odd so the final
+// packet carries one valid element and one that must be left alone -- the
+// valid_payload mask inside unpack_reduce.
+TEST_F(LLImplTest, UnpackReduceTwoElemsPerPacketPartialTail) {
+  constexpr std::size_t kElems = 101;
+  std::vector<__half> src(kElems), seed(kElems);
+  std::vector<float> expected(kElems);
+  for (std::size_t i = 0; i < kElems; ++i) {
+    const float s = static_cast<float>(i % 7);
+    const float a = static_cast<float>(i % 3);
+    src[i] = __float2half(s);
+    seed[i] = __float2half(a);
+    expected[i] = s + a; // <= 8, exactly representable in fp16
+  }
+
+  const auto actual =
+      runUnpackReduce<__half>(src, seed, [&](void* s, char* st, void* a) {
+        test::test_ll_unpack_reduce_f16(s, st, a, kElems);
+      });
+
+  std::vector<float> actualF(kElems);
+  for (std::size_t i = 0; i < kElems; ++i) {
+    actualF[i] = __half2float(actual[i]);
+  }
+  EXPECT_EQ(actualF, expected) << "fp16 two-elements-per-packet reduce wrong";
+}
+
+// sizeof(T) > kData: one element spans two packets and is reassembled
+// byte-wise. Integers make any byte-order or packet-ordering slip obvious
+// rather than a small numeric drift.
+TEST_F(LLImplTest, UnpackReduceElementSpansPackets) {
+  constexpr std::size_t kElems = 97;
+  std::vector<int64_t> src(kElems), seed(kElems), expected(kElems);
+  for (std::size_t i = 0; i < kElems; ++i) {
+    // Distinct high and low words so a swapped packet is not self-masking.
+    src[i] = static_cast<int64_t>((i + 1) * 0x0001'0000'0007ULL);
+    seed[i] = static_cast<int64_t>(i);
+    expected[i] = seed[i] + src[i];
+  }
+
+  const auto actual =
+      runUnpackReduce<int64_t>(src, seed, [&](void* s, char* st, void* a) {
+        test::test_ll_unpack_reduce_i64(
+            static_cast<const int64_t*>(s),
+            st,
+            static_cast<int64_t*>(a),
+            kElems);
+      });
+  EXPECT_EQ(actual, expected) << "int64 spanning-packet reduce wrong";
 }
 
 TEST_F(LLImplTest, FlagRoundTrip) {

--- a/comms/prims/tests/LLImplTest.cu
+++ b/comms/prims/tests/LLImplTest.cu
@@ -1,5 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <cuda_fp16.h>
 #include <cuda_runtime.h>
 #include <cstddef>
 #include <cstdint>
@@ -7,7 +8,9 @@
 #include "comms/prims/core/LLImpl.cuh"
 #include "comms/prims/core/LlxPacket.cuh"
 #include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/core/Tile.cuh"
 #include "comms/prims/tests/Checks.h"
+#include "comms/prims/tests/LLImplTest.cuh"
 
 namespace comms::prims::test {
 
@@ -92,6 +95,102 @@ __global__ void test_ll_flag_roundtrip_kernel(void* p8, uint32_t* errorCount) {
 void test_ll_flag_roundtrip(void* p8_d, uint32_t* errorCount_d) {
   test_ll_flag_roundtrip_kernel<<<1, 1>>>(p8_d, errorCount_d);
   PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// pack() the source into staging, then reduce it into `accum` with
+// unpack_reduce. Building staging with pack() rather than by hand is
+// deliberate: it also pins that the two agree on packet layout and flag
+// placement, so a change to one without the other fails here.
+// LLImpl takes a Combine functor rather than a reduce op, so the test supplies
+// its own -- which also checks that the seam is usable without VecOps.
+template <typename T, typename Op>
+struct TestCombine {
+  __device__ __forceinline__ void operator()(T& accum, const T& value) const {
+    VecOps<T>::reduce_scalar(Op{}, accum, value);
+  }
+};
+
+template <typename P, typename T, typename Op>
+__global__ void unpack_reduce_kernel(
+    const T* src,
+    char* staging,
+    T* accum,
+    std::size_t nelems) {
+  ThreadGroup g{
+      threadIdx.x,
+      blockDim.x,
+      blockIdx.x,
+      blockIdx.x,
+      gridDim.x,
+      SyncScope::BLOCK};
+
+  const std::size_t nbytes = nelems * sizeof(T);
+  const typename P::FlagType flagVal = static_cast<typename P::FlagType>(7);
+
+  LLImpl<P>::pack(
+      g, staging, reinterpret_cast<const char*>(src), nbytes, flagVal);
+  g.sync();
+  // unpack_reduce polls each packet's flag itself and syncs on the way out.
+  LLImpl<P>::template unpack_reduce<T, TestCombine<T, Op>>(
+      g, accum, staging, nbytes, flagVal);
+}
+
+namespace {
+
+template <typename T>
+void launchByKind(
+    const T* src,
+    char* staging,
+    T* accum,
+    std::size_t nelems,
+    ReduceKind kind) {
+  switch (kind) {
+    case ReduceKind::Sum:
+      unpack_reduce_kernel<LlxPacketGeometry, T, SumOp>
+          <<<1, 256>>>(src, staging, accum, nelems);
+      break;
+    case ReduceKind::Max:
+      unpack_reduce_kernel<LlxPacketGeometry, T, MaxOp>
+          <<<1, 256>>>(src, staging, accum, nelems);
+      break;
+    case ReduceKind::Min:
+      unpack_reduce_kernel<LlxPacketGeometry, T, MinOp>
+          <<<1, 256>>>(src, staging, accum, nelems);
+      break;
+  }
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace
+
+void test_ll_unpack_reduce_f32(
+    const float* src_d,
+    char* staging_d,
+    float* accum_d,
+    std::size_t nelems,
+    ReduceKind kind) {
+  launchByKind<float>(src_d, staging_d, accum_d, nelems, kind);
+}
+
+void test_ll_unpack_reduce_f16(
+    const void* src_d,
+    char* staging_d,
+    void* accum_d,
+    std::size_t nelems) {
+  launchByKind<__half>(
+      static_cast<const __half*>(src_d),
+      staging_d,
+      static_cast<__half*>(accum_d),
+      nelems,
+      ReduceKind::Sum);
+}
+
+void test_ll_unpack_reduce_i64(
+    const int64_t* src_d,
+    char* staging_d,
+    int64_t* accum_d,
+    std::size_t nelems) {
+  launchByKind<int64_t>(src_d, staging_d, accum_d, nelems, ReduceKind::Sum);
 }
 
 } // namespace comms::prims::test

--- a/comms/prims/tests/LLImplTest.cuh
+++ b/comms/prims/tests/LLImplTest.cuh
@@ -21,4 +21,35 @@ void test_ll_pack_unpack(
 /// I/O uses global volatile ops, which are illegal on shared memory.
 void test_ll_flag_roundtrip(void* p8_d, uint32_t* errorCount_d);
 
+/// Reduce op selector for the unpack_reduce launchers below.
+enum class ReduceKind { Sum, Max, Min };
+
+/// pack(src) then unpack_reduce into `accum`, i.e. accum[i] = Op(accum[i],
+/// src[i]). Each launcher pins one element/packet tiling of unpack_reduce:
+///
+///   f32  sizeof(T) == kData      -> one element per packet
+///   f16  sizeof(T) <  kData      -> two elements per packet (+ partial tail)
+///   i64  sizeof(T) >  kData      -> one element spanning two packets
+///
+/// `accum_d` is pre-seeded by the caller, so these also check that
+/// unpack_reduce accumulates rather than overwriting the way unpack() does.
+void test_ll_unpack_reduce_f32(
+    const float* src_d,
+    char* staging_d,
+    float* accum_d,
+    std::size_t nelems,
+    ReduceKind kind);
+
+void test_ll_unpack_reduce_f16(
+    const void* src_d,
+    char* staging_d,
+    void* accum_d,
+    std::size_t nelems);
+
+void test_ll_unpack_reduce_i64(
+    const int64_t* src_d,
+    char* staging_d,
+    int64_t* accum_d,
+    std::size_t nelems);
+
 } // namespace comms::prims::test

--- a/comms/prims/tests/ProgressGeometryTest.cc
+++ b/comms/prims/tests/ProgressGeometryTest.cc
@@ -1,0 +1,128 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cstddef>
+
+#include "comms/prims/tests/ProgressGeometryTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::prims {
+namespace {
+
+// MCCL_CHANNEL_BUFFER_SIZE's default. Chunk sizing is
+// perChannelBufferSize / pipelineDepth, then converted to payload bytes by
+// LL's max_payload (wire / 8 * 4), so both inputs shape the result.
+constexpr std::size_t kChannelBuffer = 4ull * 1024 * 1024;
+
+// The widest element the fused AllReduce instantiates (double, int64_t). LL's
+// payload quantum is only kData = 4, so a chunk that is a multiple of 4 but not
+// of 8 splits one of these elements across the chunk boundary:
+// LLImpl::unpack_reduce's wide-T branch truncates `nbytes / sizeof(T)` and
+// drops the trailing half element, and the next chunk's dst lands 4 bytes off a
+// natural 8-byte boundary.
+// Spelled as sizeof(double) rather than reusing the transport's
+// kMaxReducedTypeBytes, so the expectation is derived from the dtype the test
+// is reasoning about instead of mirroring the constant under test.
+constexpr std::size_t kWidestElem = sizeof(double);
+
+// Any non-zero payload works: chunkPayload depends only on the layout and
+// maxSignalBytes. Zero would trap in make_progress_geometry.
+constexpr std::size_t kNbytes = 1ull * 1024 * 1024;
+
+// The resumable and blocking paths duplicate the chunk-sizing arithmetic
+// (make_progress_geometry vs calcGeometry), so every case runs against both.
+using Launcher =
+    void (*)(std::size_t, int, std::size_t, std::size_t, std::size_t*);
+
+struct Path {
+  const char* name;
+  Launcher launch;
+};
+
+constexpr Path kPaths[] = {
+    {"progress", &test::launch_ll_chunk_payload},
+    {"blocking", &test::launch_ll_blocking_chunk_payload},
+};
+
+std::size_t llChunkPayload(
+    Launcher launch,
+    int pipelineDepth,
+    std::size_t maxSignalBytes,
+    std::size_t perChannelBufferSize = kChannelBuffer) {
+  DeviceBuffer out(sizeof(std::size_t));
+  launch(
+      perChannelBufferSize,
+      pipelineDepth,
+      kNbytes,
+      maxSignalBytes,
+      static_cast<std::size_t*>(out.get()));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::size_t chunkPayload = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &chunkPayload, out.get(), sizeof(chunkPayload), cudaMemcpyDeviceToHost));
+  return chunkPayload;
+}
+
+// Trigger 1: MCCL_ALLREDUCE_IB_SIGNAL_BYTES (benchmark_allreduce.sh
+// --signal-bytes) is unvalidated, so any 4-mod-8 value reaches the geometry.
+TEST(ProgressGeometryTest, SignalBytesChunkHoldsWholeWidestElements) {
+  for (const Path& path : kPaths) {
+    for (const std::size_t signalBytes : {std::size_t{12}, std::size_t{20}}) {
+      const std::size_t chunkPayload =
+          llChunkPayload(path.launch, /*pipelineDepth=*/8, signalBytes);
+      EXPECT_EQ(chunkPayload % kWidestElem, 0u)
+          << path.name << " signalBytes=" << signalBytes
+          << " chunkPayload=" << chunkPayload;
+    }
+  }
+}
+
+// Trigger 2: even with signal bytes untouched, perBlockSlotPayload itself is
+// 4-mod-8 at these pipeline depths, because max_payload halves an odd
+// wire-byte count. benchmark_allreduce.sh exposes this as --pipeline-depths.
+TEST(ProgressGeometryTest, PipelineDepthChunkHoldsWholeWidestElements) {
+  for (const Path& path : kPaths) {
+    for (const int pipelineDepth : {5, 6, 13, 14}) {
+      const std::size_t chunkPayload =
+          llChunkPayload(path.launch, pipelineDepth, /*maxSignalBytes=*/0);
+      EXPECT_EQ(chunkPayload % kWidestElem, 0u)
+          << path.name << " pipelineDepth=" << pipelineDepth
+          << " chunkPayload=" << chunkPayload;
+    }
+  }
+}
+
+// Guards against over-tightening: the default configuration is already aligned
+// and must keep its full chunk size, not get rounded down to something smaller.
+TEST(ProgressGeometryTest, DefaultConfigurationChunkIsUnchanged) {
+  for (const Path& path : kPaths) {
+    const std::size_t chunkPayload =
+        llChunkPayload(path.launch, /*pipelineDepth=*/8, /*maxSignalBytes=*/0);
+    EXPECT_EQ(chunkPayload, 262144u) << path.name;
+  }
+}
+
+// The cvar is documented as a MAXIMUM ("Maximum bytes per signaled sub-chunk"),
+// so a request below one element cannot be honoured exactly: rounding down to a
+// whole element yields zero. Clamp to the finest granularity that still holds a
+// whole element -- one packet -- rather than falling back to the whole slot,
+// which would overshoot the requested maximum by five orders of magnitude.
+// Rounding *up* instead would also violate the documented maximum.
+TEST(ProgressGeometryTest, SubElementSignalBytesClampsToOnePacket) {
+  // lcm(LL's kData = 4, sizeof(double) = 8) == 8.
+  constexpr std::size_t kLlChunkAlign = kWidestElem;
+  for (const Path& path : kPaths) {
+    const std::size_t chunkPayload =
+        llChunkPayload(path.launch, /*pipelineDepth=*/8, /*maxSignalBytes=*/4);
+    EXPECT_EQ(chunkPayload, kLlChunkAlign)
+        << path.name << " chunkPayload=" << chunkPayload;
+  }
+}
+
+} // namespace
+} // namespace comms::prims

--- a/comms/prims/tests/ProgressGeometryTest.cu
+++ b/comms/prims/tests/ProgressGeometryTest.cu
@@ -1,0 +1,100 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <cstddef>
+
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/tests/Checks.h"
+#include "comms/prims/tests/ProgressGeometryTest.cuh"
+#include "comms/prims/transport/P2pIbTransportProgressImpl.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+__global__ void chunk_payload_kernel(
+    IbChannelLayout layout,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    std::size_t* out) {
+  ThreadGroup g{
+      threadIdx.x,
+      blockDim.x,
+      blockIdx.x,
+      blockIdx.x,
+      gridDim.x,
+      SyncScope::BLOCK};
+
+  const detail::ProgressGeometry geometry =
+      detail::make_progress_geometry<protocol::LL>(
+          layout, g, nbytes, maxSignalBytes, "ProgressGeometryTest");
+
+  if (g.is_leader()) {
+    *out = geometry.chunkPayload;
+  }
+}
+
+__global__ void blocking_chunk_payload_kernel(
+    IbChannelLayout layout,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    std::size_t* out) {
+  ThreadGroup g{
+      threadIdx.x,
+      blockDim.x,
+      blockIdx.x,
+      blockIdx.x,
+      gridDim.x,
+      SyncScope::BLOCK};
+
+  const detail::SendRecvGeometry geometry =
+      detail::calcGeometry(protocol::LL{}, layout, g, nbytes, maxSignalBytes);
+
+  if (g.is_leader()) {
+    *out = geometry.chunkPayload;
+  }
+}
+
+IbChannelLayout makeLayout(
+    std::size_t perChannelBufferSize,
+    int pipelineDepth) {
+  IbChannelLayout layout{};
+  // One logical channel, so group_id 0 stays in bounds.
+  layout.numChannels = 1;
+  layout.maxChannels = 1;
+  layout.numLanes = 1;
+  layout.pipelineDepth = pipelineDepth;
+  layout.perChannelBufferSize = perChannelBufferSize;
+  return layout;
+}
+
+} // namespace
+
+void launch_ll_chunk_payload(
+    std::size_t perChannelBufferSize,
+    int pipelineDepth,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    std::size_t* out_d) {
+  chunk_payload_kernel<<<1, 32>>>(
+      makeLayout(perChannelBufferSize, pipelineDepth),
+      nbytes,
+      maxSignalBytes,
+      out_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launch_ll_blocking_chunk_payload(
+    std::size_t perChannelBufferSize,
+    int pipelineDepth,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    std::size_t* out_d) {
+  blocking_chunk_payload_kernel<<<1, 32>>>(
+      makeLayout(perChannelBufferSize, pipelineDepth),
+      nbytes,
+      maxSignalBytes,
+      out_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/ProgressGeometryTest.cuh
+++ b/comms/prims/tests/ProgressGeometryTest.cuh
@@ -1,0 +1,38 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+namespace comms::prims::test {
+
+/// Runs make_progress_geometry<protocol::LL> against a synthetic channel layout
+/// and writes the resulting `chunkPayload` to `out_d`.
+///
+/// The layout is built inside the .cu from these scalars so this header stays
+/// free of transport includes. Only the fields make_progress_geometry reads are
+/// populated: `numChannels` (bounds the group id), `pipelineDepth` and
+/// `perChannelBufferSize` (which together give perBlockSlotWire).
+///
+/// Note the deliberate absence of a CopyOp or element-type parameter: chunk
+/// sizing is a property of the protocol alone, which is what makes the sender's
+/// and receiver's view of the chunk boundary identical even though the tree's
+/// send lane uses Memcpy and its recv lane uses IbReduceCopy<T>. Keying the
+/// alignment on the CopyOp would let the two sides disagree and deadlock.
+void launch_ll_chunk_payload(
+    std::size_t perChannelBufferSize,
+    int pipelineDepth,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    std::size_t* out_d);
+
+/// Same, for the blocking path's calcGeometry. The two functions duplicate the
+/// chunk-sizing arithmetic, so both need the alignment and both need covering.
+void launch_ll_blocking_chunk_payload(
+    std::size_t perChannelBufferSize,
+    int pipelineDepth,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    std::size_t* out_d);
+
+} // namespace comms::prims::test

--- a/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
@@ -85,6 +85,22 @@ __device__ __forceinline__ void trace_ibgda_event(
  * policies are added in later diffs. Tags live in `protocol` to avoid
  * collisions with the generic name `Simple` at comms::prims scope.
  */
+/**
+ * Largest element a reducing CopyOp can be instantiated with: fp64 / int64.
+ * The fused AllReduce's set is fp16 and bf16 (2 B), fp32 (4 B), fp64 and int64
+ * (8 B) -- see isSupportedFusedType.
+ *
+ * Chunk sizing aligns to this so every chunk holds a whole number of elements.
+ * That works because the supported sizes are all powers of two dividing this
+ * one, which makes the maximum coincide with their least common multiple -- a
+ * chunk that is a multiple of 8 B is also a multiple of 4 B and 2 B. The
+ * requirement is divisibility, not magnitude: a 12 B chunk exceeds the widest
+ * element and still splits it. Adding a non-power-of-two element size (a 3 B
+ * type, say) would break that coincidence and this would have to become an
+ * explicit lcm.
+ */
+inline constexpr std::size_t kMaxReducedTypeBytes = 8;
+
 namespace protocol {
 struct Simple {
   // Resource slot this protocol owns on every channel. Slot 0 is the default
@@ -427,25 +443,70 @@ __device__ __forceinline__ SendRecvGeometry calcGeometry(
     }
     PIPES_DEVICE_TRAP();
   }
+  // Chunk size in PAYLOAD bytes, aligned down to whole packets AND whole
+  // reduced elements, not merely to kData.
+  //
+  // kData alone is not enough for a reducing CopyOp. A chunk must hold a whole
+  // number of elements, or LLImpl::unpack_reduce's wide-T branch splits one
+  // across the boundary: it truncates `nbytes / sizeof(T)` and drops the
+  // trailing half element, and the next chunk's dst lands 4 bytes off a natural
+  // 8-byte boundary. LL's kData is only 4, so a double/int64 element spans two
+  // packets and an odd packet count cuts it in half.
+  //
+  // A chunk holds whole elements iff the element size DIVIDES the chunk size --
+  // being merely larger than the element is not enough. So the chunk must be a
+  // multiple of both:
+  //   - kData, so it stays a whole number of packets (the original rule), and
+  //   - kMaxReducedTypeBytes, so it stays a whole number of elements.
+  // Both quantities are payload bytes, and both are powers of two, so their
+  // least common multiple is simply the larger. Note this is deliberately NOT
+  // kPacketBytes: that is a WIRE size (kData + kFlag) and only coincides with
+  // the right answer for today's geometries -- an LlxPacket<4, 8> would give
+  // kPacketBytes == 12, which does not divide 8 and would split a double.
+  //
+  // The alignment must NOT be derived from the CopyOp. The tree's send lane
+  // uses Memcpy while its recv lane uses IbReduceCopy<T>, so a CopyOp-keyed
+  // alignment would give the two sides different chunk boundaries -- the
+  // receiver would wait on a chunk the sender never produces. Keying it on the
+  // protocol keeps both sides in step by construction.
+  constexpr std::size_t kDataBytes = static_cast<std::size_t>(P::kData);
+  static_assert(
+      (kDataBytes & (kDataBytes - 1)) == 0,
+      "kData must be a power of two, so that max() is its lcm with "
+      "kMaxReducedTypeBytes");
+  constexpr std::size_t kChunkAlign =
+      kDataBytes > kMaxReducedTypeBytes ? kDataBytes : kMaxReducedTypeBytes;
+
   const std::size_t perBlockSlotWire = pipeline_chunk(channelLayout);
-  if (perBlockSlotWire == 0) {
+  const std::size_t perBlockSlotPayload = P::max_payload(perBlockSlotWire);
+  // Widened from `perBlockSlotWire == 0` to one aligned chunk unit: the sizing
+  // below rounds to kChunkAlign, so a slot that cannot hold one such unit would
+  // be overrun by the smallest legal chunk. Same single branch as before.
+  if (perBlockSlotPayload < kChunkAlign) {
     if (group.is_leader()) {
       printf(
-          "[PIPES] FATAL: send/recv perBlockSlot=0 "
-          "(perChannelBufferSize=%llu, pipelineDepth=%d)\n",
+          "[PIPES] FATAL: send/recv perBlockSlotPayload=%llu holds no whole "
+          "chunk unit (perChannelBufferSize=%llu, pipelineDepth=%d)\n",
+          (unsigned long long)perBlockSlotPayload,
           (unsigned long long)pipeline_window(channelLayout),
           channelLayout.pipelineDepth);
     }
     PIPES_DEVICE_TRAP();
   }
-  const std::size_t perBlockSlotPayload = P::max_payload(perBlockSlotWire);
-  // Chunk size in PAYLOAD bytes, aligned down to whole packets (kData).
+  // Guaranteed >= kChunkAlign by the slot check above.
+  const std::size_t alignedSlotPayload =
+      perBlockSlotPayload / kChunkAlign * kChunkAlign;
   std::size_t chunkPayload =
-      (max_signal_bytes > 0 && max_signal_bytes < perBlockSlotPayload)
-      ? (max_signal_bytes / P::kData * P::kData)
-      : perBlockSlotPayload;
+      (max_signal_bytes > 0 && max_signal_bytes < alignedSlotPayload)
+      ? (max_signal_bytes / kChunkAlign * kChunkAlign)
+      : alignedSlotPayload;
   if (chunkPayload == 0) {
-    chunkPayload = perBlockSlotPayload;
+    // max_signal_bytes is documented as a MAXIMUM, and a request below one
+    // aligned unit cannot be honoured exactly. Clamp to the finest granularity
+    // that still holds whole packets and whole elements, rather than falling
+    // back to the whole slot, which would overshoot the requested maximum
+    // enormously. Rounding up to the next unit would also exceed the maximum.
+    chunkPayload = kChunkAlign;
   }
   const std::size_t pipelineBytesWire = pipeline_window(channelLayout);
   // Payload bytes rounded up to a whole packet (kData). For Simple == round-16.

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -1179,7 +1179,6 @@ __device__ __forceinline__ bool progress_recv_ready(
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   using P = LlxPacket<4, 4>;
   (void)transport;
-  (void)localChannel;
   (void)localDataReady;
   (void)waitCredit;
   (void)traceContext;
@@ -1202,13 +1201,25 @@ __device__ __forceinline__ bool progress_recv_ready(
     }
   }
   const bool ready = group_all_ready(group, myReady != 0U);
-  if (!ready && group.is_leader()) {
-    TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
-        timeout,
-        "progress_recv_once(LL) waiting for packet flags flagVal=%llu, "
-        "wireBytes=%llu",
-        static_cast<unsigned long long>(chunk.flagVal),
-        static_cast<unsigned long long>(chunk.wireBytes));
+  if (group.is_leader()) {
+    if (ready) {
+      // LL carries no DATA_READY, but its put still advanced the sender's
+      // IbQpState::cursor -- select_put_lane_ordinal() increments that cursor
+      // on every put regardless of protocol, and it is channel-scoped, not
+      // slot-scoped. recvDataReadyLaneCursor mirrors it, so the mirror has to
+      // advance here too: consuming an LL chunk without it leaves the two one
+      // chunk apart per LL transfer, and Simple's next receive on this channel
+      // then waits on a lane the sender never wrote. Matches the unconditional
+      // bump in poll_recv_data_ready() (a single lane makes it a no-op).
+      ++localChannel.recvDataReadyLaneCursor;
+    } else {
+      TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+          timeout,
+          "progress_recv_once(LL) waiting for packet flags flagVal=%llu, "
+          "wireBytes=%llu",
+          static_cast<unsigned long long>(chunk.flagVal),
+          static_cast<unsigned long long>(chunk.wireBytes));
+    }
   }
   return ready;
 #else

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -1688,14 +1688,34 @@ __device__ __forceinline__ ProgressGeometry make_progress_geometry(
     PIPES_DEVICE_TRAP();
   }
 
+  // Chunks align to lcm(kData, widest reduced element), not to kData alone --
+  // see calcGeometry for the full reasoning: a reducing CopyOp needs each chunk
+  // to hold a whole number of elements, LL's kData of 4 splits a double/int64,
+  // and the alignment must come from the protocol rather than the CopyOp so the
+  // Memcpy send lane and the IbReduceCopy recv lane agree on the chunk
+  // boundary. Both terms are payload bytes; this is NOT kPacketBytes, which is
+  // a wire size. No-op for Simple (kData == 16 already covers 8).
+  constexpr std::size_t kDataBytes = static_cast<std::size_t>(Proto::kData);
+  static_assert(
+      (kDataBytes & (kDataBytes - 1)) == 0,
+      "kData must be a power of two, so that max() is its lcm with "
+      "kMaxReducedTypeBytes");
+  constexpr std::size_t kChunkAlign =
+      kDataBytes > kMaxReducedTypeBytes ? kDataBytes : kMaxReducedTypeBytes;
+
   const std::size_t perBlockSlotWire = pipeline_chunk(channelLayout);
   const std::size_t perBlockSlotPayload = Proto::max_payload(perBlockSlotWire);
-  if (perBlockSlotPayload == 0) {
+  // Widened from `== 0` to one aligned chunk unit: the chunk sizing below
+  // rounds to kChunkAlign, so a slot that cannot hold one such unit would be
+  // overrun by the smallest legal chunk. Same single branch as before, so this
+  // costs nothing extra on the progress hot path.
+  if (perBlockSlotPayload < kChunkAlign) {
     if (group.is_leader()) {
       printf(
-          "[PIPES] FATAL: %s perBlockSlotPayload=0 "
-          "(perChannelBufferSize=%llu, pipelineDepth=%d)\n",
+          "[PIPES] FATAL: %s perBlockSlotPayload=%llu holds no whole chunk "
+          "unit (perChannelBufferSize=%llu, pipelineDepth=%d)\n",
           opName,
+          (unsigned long long)perBlockSlotPayload,
           (unsigned long long)pipeline_window(channelLayout),
           channelLayout.pipelineDepth);
     }
@@ -1708,12 +1728,19 @@ __device__ __forceinline__ ProgressGeometry make_progress_geometry(
   // Simple (kData == 16) this is the original 16B alignment.
   const std::size_t protocolBytes =
       (nbytes + Proto::kData - 1) / Proto::kData * Proto::kData;
+  // Guaranteed >= kChunkAlign by the slot check above.
+  const std::size_t alignedSlotPayload =
+      perBlockSlotPayload / kChunkAlign * kChunkAlign;
   std::size_t chunkPayload =
-      (max_signal_bytes > 0 && max_signal_bytes < perBlockSlotPayload)
-      ? (max_signal_bytes / Proto::kData * Proto::kData)
-      : perBlockSlotPayload;
+      (max_signal_bytes > 0 && max_signal_bytes < alignedSlotPayload)
+      ? (max_signal_bytes / kChunkAlign * kChunkAlign)
+      : alignedSlotPayload;
   if (chunkPayload == 0) {
-    chunkPayload = perBlockSlotPayload;
+    // Sub-unit request: clamp to one aligned unit, the finest granularity that
+    // still holds whole packets and whole elements. See calcGeometry --
+    // max_signal_bytes is a MAXIMUM, so neither the whole slot nor rounding up
+    // would respect it.
+    chunkPayload = kChunkAlign;
   }
   return ProgressGeometry{
       .groupId = groupId,

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3449,6 +3449,24 @@ cvars:
      Applies to tree and ring. 0 preserves the transport default signaling
      cadence.
 
+ - name        : MCCL_ALLREDUCE_LL_MAX_BYTES
+   type        : int64_t
+   default     : 0
+   description : |-
+     Total message bytes strictly below which MCCL fused AllReduce runs its IB
+     phase on the LL (low-latency, inline-flag) wire format instead of Simple.
+     LL spends half of each 8 B packet on the flag, so it costs 2x on the wire
+     but drops the DATA_READY signal round trip -- a win only for small,
+     latency-bound messages.
+
+       0  (default) never use LL; every size stays on Simple.
+      -1  always use LL, at every size. Diagnostic only -- it forces LL past the
+          crossover where it is strictly slower.
+      >0  use LL strictly below this many bytes (16384 is the measured crossover
+          on GB300).
+
+     Tree only today; ring and direct always use Simple.
+
  - name        : MCCL_MAX_NCHANNELS
    type        : int
    default     : 32


### PR DESCRIPTION
Summary:

Run the fused AllReduce Phase 2 (inter-node dual tree) on the low-latency (LL)
wire format for small messages, keeping Simple for everything else.

LL carries its readiness mark inline in every packet (`LlxPacket<4,4>`: 4 B data
+ 4 B flag) instead of a separate DATA_READY signal. That drops a round trip per
chunk but doubles wire bytes, so it only pays off while the collective is
latency-bound -- hence the size gate.

Selection is host-side and baked into the kernel symbol. `Proto` is a template
parameter all the way down to `progress_send_once`, so it cannot be branched on
device. Each dtype therefore gets a second translation unit:

  - `AllReduceIbTree<Type>.cu` defines `MCCL_ALLREDUCE_TREE_PROTO` as
    `protocol::Simple`.
  - `AllReduceIbTree<Type>Ll.cu` (new, 5 files) defines it as `protocol::LL`.

`AllReduceIbTreeImpl.cuh` `#error`s if the owning `.cu` leaves the macro
undefined, and aliases it to `TreeProto`. Both the chunk sizing and the
transport progression derive from that single alias, so they cannot drift apart.
This yields the `mcclKernelAllReduceTree<Type>Ll` symbols, and
`selectAllReduceTreeKernel(datatype, traceEnabled, useLL)` picks between them.

`MCCL_ALLREDUCE_LL_MAX_BYTES` (new cvar, int64_t) gates the choice:

  -  0  (default) never use LL; every size stays on Simple. LL ships off.
  - -1  always use LL. Diagnostic: correct at every size, but progressively
        slower than Simple past ~1 MiB, so a full-range sweep needs a large
        --run-timeout.
  - >0  use LL strictly below this many bytes (16384 is the measured GB300
        crossover).

`totalBytes` and the cvar are both collective-uniform, so every rank in a launch
reaches the same verdict -- a split decision would hang, since the two formats
disagree on packet layout and land on different per-protocol channel banks.
Tree only; ring and direct stay on Simple.

Trace and LL are separate symbol axes and there is no combined LlTrace kernel:
the traced entry points carry no LL wire geometry. When both are requested LL
wins and the request is downgraded to an untraced LL kernel with a one-shot
warning, rather than silently running Simple. `static_assert`s keep the
registered-source and traced paths on Simple.

Threading `Proto` through the tree:

  - `progressLaneSend` / `progressLaneRecv` take a defaulted `Proto` and forward
    it to `init_*_progress` / `progress_*_once`. All six Phase-2 lane phases
    (reduce leaf/internal send, reduce recv, bcast internal send, bcast
    internal/leaf recv) pass `TreeProto`.
  - the reduce-up receive stays `IbReduceCopy<T>`; under LL the progress recv
    dispatch routes it to `IbReduceCopy<T>::recvLL<P>` (packet-aware
    receive-reduce). Sends and broadcast receives use `Memcpy` (LL pack/unpack).
  - the pipeline chunk becomes `TreeProto::max_payload()` of the transport's
    wire-sized ring slot, since an LL chunk's 2x wire footprint still has to fit
    that slot. Identity under Simple.

Transport plumbing: the generic `P2pIbTransportDevice` dispatcher and the IBRC
backend device gain the same defaulted `Proto` parameter on `init_*_progress` /
`progress_*_once`, forwarding to the shared `detail::` free functions and
matching the IBGDA device. These replace the bare `template <typename = void>`
instantiation guards introduced by D115219978 -- a named defaulted parameter
defers instantiation just as well. `P2pIbTransportDeviceDecl.cuh` gains a
`protocol::Simple` forward declaration so it can spell that default without
including `P2pIbTransportDeviceImpl.cuh`, which includes it.

The send/recv benchmark drives the IBGDA device directly, so only the tree --
which calls through the generic dispatcher -- needed this.

Follow-ups: a dedicated LL recv-reduce correctness test, and flipping the
default off 0 once the crossover is tuned per platform.

Reviewed By: zhiyongww, Scusemua, snarayankh

Differential Revision: D115257409


