### PR TITLE
Keep the recv lane cursor in step across protocols

### DIFF
--- a/comms/prims/core/LLImpl.cuh
+++ b/comms/prims/core/LLImpl.cuh
@@ -192,19 +192,10 @@ struct LLImpl {
       const std::size_t off = i * static_cast<std::size_t>(P::kData);
 
       if constexpr (P::kPacketBytes == static_cast<int>(sizeof(uint64_t))) {
-        // 8 B packet: {data:4, flag:4} in one 8 B atomic word. Fuse the poll
-        // and the data read -- one wide volatile load yields both.
-        const auto* p = reinterpret_cast<const volatile uint64_t*>(pkt);
-        uint64_t v;
-        uint32_t spins = 0;
-        do {
-          v = comms::device::ld_volatile_global(p);
-          if (((++spins & kTimeoutPollMask) == 0) && timeout.checkExpired()) {
-            PIPES_DEVICE_TRAP();
-          }
-        } while (static_cast<FlagType>(v >> 32) !=
-                 flagVal); // high half is the flag
-        const auto data = static_cast<uint32_t>(v); // low half is the payload
+        // 8 B packet: {data:4, flag:4} in one 8 B atomic word -- the poll and
+        // the data read are one load. Shared with unpack_reduce so there is a
+        // single spin loop in this file.
+        const uint32_t data = load_ready_payload(pkt, flagVal, timeout);
         const auto* db = reinterpret_cast<const char*>(&data);
 #pragma unroll
         for (int b = 0; b < P::kData; ++b) {
@@ -248,6 +239,123 @@ struct LLImpl {
     (void)staging;
     (void)nbytes;
     (void)flagVal;
+#endif
+  }
+
+  /// Spin until `pkt` carries flag == `flagVal`, then return its data half.
+  /// One wide volatile load yields both halves, so the readiness poll and the
+  /// payload read are the same instruction -- the fused 8 B path unpack() uses.
+  __device__ __forceinline__ static uint32_t load_ready_payload(
+      const char* pkt,
+      FlagType flagVal,
+      const Timeout& timeout) {
+#ifdef __CUDA_ARCH__
+    const auto* p = reinterpret_cast<const volatile uint64_t*>(pkt);
+    uint64_t v;
+    uint32_t spins = 0;
+    do {
+      v = comms::device::ld_volatile_global(p);
+      if (((++spins & kTimeoutPollMask) == 0) && timeout.checkExpired()) {
+        PIPES_DEVICE_TRAP();
+      }
+    } while (static_cast<FlagType>(v >> 32) !=
+             flagVal); // high half is the flag
+    return static_cast<uint32_t>(v); // low half is the payload
+#else
+    (void)pkt;
+    (void)flagVal;
+    (void)timeout;
+    return 0;
+#endif
+  }
+
+  /// Reduce the packet stream into `accum` under `Combine`: the accumulating
+  /// counterpart of unpack(), which assigns. A reduce CopyOp cannot call
+  /// unpack() -- that would overwrite the partial sum -- and staging into a
+  /// scratch buffer first would cost an extra chunk-sized write and read on
+  /// what is the latency path.
+  ///
+  /// Lives here rather than in the CopyOp so the packet walk, the valid-payload
+  /// masking and the wide-T reassembly stay in the one place that owns the
+  /// packet format, and so the readiness spin is not something each caller has
+  /// to remember. A reduce op that re-implemented this walk without the spin
+  /// would consume staging before the data landed.
+  ///
+  /// Two element/packet tilings, both reachable from the fused AllReduce's
+  /// instantiation set. When an element fits inside a packet's data region
+  /// (float, __half, __nv_bfloat16 against kData = 4) one thread owns one
+  /// packet. When an element is wider (double, int64_t) it spans
+  /// sizeof(T)/kData consecutive packets, so one thread instead owns one
+  /// element and reassembles it before reducing -- a per-packet reduce would
+  /// corrupt a value split across two packets.
+  ///
+  /// NOTE: scalar-granular by construction (one float / two halves per 4 B
+  /// packet); the packet layout rules out the 16 B vectorized tile reduce the
+  /// contiguous path uses.
+  /// `Combine` is a default-constructible functor with
+  /// `operator()(T& accum, const T& value)`. Passing the combiner in keeps the
+  /// reduce vocabulary out of the codec: LLImpl owns the packet format, the
+  /// caller owns what "reduce" means. It also keeps this header host-includable
+  /// -- pulling in VecOps would drag device-only math (fmaxf/fminf) into every
+  /// host TU that reaches LLImpl through MemcpyCopyOp.cuh.
+  template <typename T, typename Combine, typename Group>
+  __device__ __forceinline__ static void unpack_reduce(
+      Group& group,
+      T* accum,
+      const void* staging,
+      std::size_t nbytes,
+      FlagType flagVal,
+      const Timeout& timeout = Timeout()) {
+#ifdef __CUDA_ARCH__
+    constexpr std::size_t kData = static_cast<std::size_t>(P::kData);
+    constexpr std::size_t kPacket = static_cast<std::size_t>(P::kPacketBytes);
+    const auto* base = reinterpret_cast<const char*>(staging);
+
+    if constexpr (kData % sizeof(T) == 0) {
+      constexpr std::size_t kElemsPerPacket = kData / sizeof(T);
+      const std::size_t nPackets = P::packet_count(nbytes);
+      for (std::size_t i = group.thread_id_in_group; i < nPackets;
+           i += group.group_size) {
+        const uint32_t data =
+            load_ready_payload(base + i * kPacket, flagVal, timeout);
+        const T* payload = reinterpret_cast<const T*>(&data);
+        const std::size_t nElem = P::valid_payload(i, nbytes) / sizeof(T);
+        const std::size_t baseElem = i * kElemsPerPacket;
+#pragma unroll
+        for (std::size_t e = 0; e < kElemsPerPacket; ++e) {
+          if (e < nElem) {
+            Combine{}(accum[baseElem + e], payload[e]);
+          }
+        }
+      }
+    } else {
+      constexpr std::size_t kPacketsPerElem = sizeof(T) / kData;
+      const std::size_t nElems = nbytes / sizeof(T);
+      for (std::size_t e = group.thread_id_in_group; e < nElems;
+           e += group.group_size) {
+        T val;
+        auto* valBytes = reinterpret_cast<char*>(&val);
+#pragma unroll
+        for (std::size_t k = 0; k < kPacketsPerElem; ++k) {
+          const uint32_t word = load_ready_payload(
+              base + (e * kPacketsPerElem + k) * kPacket, flagVal, timeout);
+          const auto* wordBytes = reinterpret_cast<const char*>(&word);
+#pragma unroll
+          for (std::size_t b = 0; b < kData; ++b) {
+            valBytes[k * kData + b] = wordBytes[b];
+          }
+        }
+        Combine{}(accum[e], val);
+      }
+    }
+    group.sync();
+#else
+    (void)group;
+    (void)accum;
+    (void)staging;
+    (void)nbytes;
+    (void)flagVal;
+    (void)timeout;
 #endif
   }
 };

--- a/comms/prims/tests/LLImplTest.cc
+++ b/comms/prims/tests/LLImplTest.cc
@@ -1,7 +1,10 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <cuda_fp16.h>
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
+#include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
@@ -91,6 +94,136 @@ TEST_F(LLImplTest, LlRoundTrip) {
         std::size_t(4096)}) {
     roundTrip<LlxPacketGeometry>(test::test_ll_pack_unpack, n);
   }
+}
+
+namespace {
+
+// Seed accum, pack src, reduce src into accum on device, return accum.
+// `expected` is built independently on the host from the same inputs.
+template <typename T, typename Launch>
+std::vector<T> runUnpackReduce(
+    const std::vector<T>& src,
+    const std::vector<T>& seed,
+    Launch launch) {
+  const std::size_t nelems = src.size();
+  const std::size_t nbytes = nelems * sizeof(T);
+
+  DeviceBuffer srcBuf(nbytes);
+  DeviceBuffer accumBuf(nbytes);
+  DeviceBuffer staging(LlxPacketGeometry::wire_bytes(nbytes));
+
+  CUDACHECK_TEST(
+      cudaMemcpy(srcBuf.get(), src.data(), nbytes, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(
+      cudaMemcpy(accumBuf.get(), seed.data(), nbytes, cudaMemcpyHostToDevice));
+  // Poison staging: unpack_reduce must wait for pack()'s flags, so a missing
+  // readiness poll shows up as reduced garbage rather than a pass.
+  CUDACHECK_TEST(
+      cudaMemset(staging.get(), 0xEE, LlxPacketGeometry::wire_bytes(nbytes)));
+
+  launch(srcBuf.get(), static_cast<char*>(staging.get()), accumBuf.get());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<T> out(nelems);
+  CUDACHECK_TEST(
+      cudaMemcpy(out.data(), accumBuf.get(), nbytes, cudaMemcpyDeviceToHost));
+  return out;
+}
+
+} // namespace
+
+// sizeof(T) == kData: one element per packet, all three reduce ops.
+// Values are small integers so float arithmetic is exact and the expected
+// vector can be compared with ==.
+TEST_F(LLImplTest, UnpackReduceOneElemPerPacket) {
+  constexpr std::size_t kElems = 133; // not a multiple of the block size
+  std::vector<float> src(kElems), seed(kElems);
+  for (std::size_t i = 0; i < kElems; ++i) {
+    src[i] = static_cast<float>(i % 17);
+    seed[i] = static_cast<float>((i % 5) + 1);
+  }
+
+  const std::array<test::ReduceKind, 3> kinds{
+      test::ReduceKind::Sum, test::ReduceKind::Max, test::ReduceKind::Min};
+  for (const auto kind : kinds) {
+    std::vector<float> expected(kElems);
+    for (std::size_t i = 0; i < kElems; ++i) {
+      switch (kind) {
+        case test::ReduceKind::Sum:
+          expected[i] = seed[i] + src[i];
+          break;
+        case test::ReduceKind::Max:
+          expected[i] = std::max(seed[i], src[i]);
+          break;
+        case test::ReduceKind::Min:
+          expected[i] = std::min(seed[i], src[i]);
+          break;
+      }
+    }
+
+    const auto actual =
+        runUnpackReduce<float>(src, seed, [&](void* s, char* st, void* a) {
+          test::test_ll_unpack_reduce_f32(
+              static_cast<const float*>(s),
+              st,
+              static_cast<float*>(a),
+              kElems,
+              kind);
+        });
+    EXPECT_EQ(actual, expected)
+        << "float reduce mismatch for kind " << static_cast<int>(kind);
+  }
+}
+
+// sizeof(T) < kData: two elements per packet. kElems is odd so the final
+// packet carries one valid element and one that must be left alone -- the
+// valid_payload mask inside unpack_reduce.
+TEST_F(LLImplTest, UnpackReduceTwoElemsPerPacketPartialTail) {
+  constexpr std::size_t kElems = 101;
+  std::vector<__half> src(kElems), seed(kElems);
+  std::vector<float> expected(kElems);
+  for (std::size_t i = 0; i < kElems; ++i) {
+    const float s = static_cast<float>(i % 7);
+    const float a = static_cast<float>(i % 3);
+    src[i] = __float2half(s);
+    seed[i] = __float2half(a);
+    expected[i] = s + a; // <= 8, exactly representable in fp16
+  }
+
+  const auto actual =
+      runUnpackReduce<__half>(src, seed, [&](void* s, char* st, void* a) {
+        test::test_ll_unpack_reduce_f16(s, st, a, kElems);
+      });
+
+  std::vector<float> actualF(kElems);
+  for (std::size_t i = 0; i < kElems; ++i) {
+    actualF[i] = __half2float(actual[i]);
+  }
+  EXPECT_EQ(actualF, expected) << "fp16 two-elements-per-packet reduce wrong";
+}
+
+// sizeof(T) > kData: one element spans two packets and is reassembled
+// byte-wise. Integers make any byte-order or packet-ordering slip obvious
+// rather than a small numeric drift.
+TEST_F(LLImplTest, UnpackReduceElementSpansPackets) {
+  constexpr std::size_t kElems = 97;
+  std::vector<int64_t> src(kElems), seed(kElems), expected(kElems);
+  for (std::size_t i = 0; i < kElems; ++i) {
+    // Distinct high and low words so a swapped packet is not self-masking.
+    src[i] = static_cast<int64_t>((i + 1) * 0x0001'0000'0007ULL);
+    seed[i] = static_cast<int64_t>(i);
+    expected[i] = seed[i] + src[i];
+  }
+
+  const auto actual =
+      runUnpackReduce<int64_t>(src, seed, [&](void* s, char* st, void* a) {
+        test::test_ll_unpack_reduce_i64(
+            static_cast<const int64_t*>(s),
+            st,
+            static_cast<int64_t*>(a),
+            kElems);
+      });
+  EXPECT_EQ(actual, expected) << "int64 spanning-packet reduce wrong";
 }
 
 TEST_F(LLImplTest, FlagRoundTrip) {

--- a/comms/prims/tests/LLImplTest.cu
+++ b/comms/prims/tests/LLImplTest.cu
@@ -1,5 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <cuda_fp16.h>
 #include <cuda_runtime.h>
 #include <cstddef>
 #include <cstdint>
@@ -7,7 +8,9 @@
 #include "comms/prims/core/LLImpl.cuh"
 #include "comms/prims/core/LlxPacket.cuh"
 #include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/core/Tile.cuh"
 #include "comms/prims/tests/Checks.h"
+#include "comms/prims/tests/LLImplTest.cuh"
 
 namespace comms::prims::test {
 
@@ -92,6 +95,102 @@ __global__ void test_ll_flag_roundtrip_kernel(void* p8, uint32_t* errorCount) {
 void test_ll_flag_roundtrip(void* p8_d, uint32_t* errorCount_d) {
   test_ll_flag_roundtrip_kernel<<<1, 1>>>(p8_d, errorCount_d);
   PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// pack() the source into staging, then reduce it into `accum` with
+// unpack_reduce. Building staging with pack() rather than by hand is
+// deliberate: it also pins that the two agree on packet layout and flag
+// placement, so a change to one without the other fails here.
+// LLImpl takes a Combine functor rather than a reduce op, so the test supplies
+// its own -- which also checks that the seam is usable without VecOps.
+template <typename T, typename Op>
+struct TestCombine {
+  __device__ __forceinline__ void operator()(T& accum, const T& value) const {
+    VecOps<T>::reduce_scalar(Op{}, accum, value);
+  }
+};
+
+template <typename P, typename T, typename Op>
+__global__ void unpack_reduce_kernel(
+    const T* src,
+    char* staging,
+    T* accum,
+    std::size_t nelems) {
+  ThreadGroup g{
+      threadIdx.x,
+      blockDim.x,
+      blockIdx.x,
+      blockIdx.x,
+      gridDim.x,
+      SyncScope::BLOCK};
+
+  const std::size_t nbytes = nelems * sizeof(T);
+  const typename P::FlagType flagVal = static_cast<typename P::FlagType>(7);
+
+  LLImpl<P>::pack(
+      g, staging, reinterpret_cast<const char*>(src), nbytes, flagVal);
+  g.sync();
+  // unpack_reduce polls each packet's flag itself and syncs on the way out.
+  LLImpl<P>::template unpack_reduce<T, TestCombine<T, Op>>(
+      g, accum, staging, nbytes, flagVal);
+}
+
+namespace {
+
+template <typename T>
+void launchByKind(
+    const T* src,
+    char* staging,
+    T* accum,
+    std::size_t nelems,
+    ReduceKind kind) {
+  switch (kind) {
+    case ReduceKind::Sum:
+      unpack_reduce_kernel<LlxPacketGeometry, T, SumOp>
+          <<<1, 256>>>(src, staging, accum, nelems);
+      break;
+    case ReduceKind::Max:
+      unpack_reduce_kernel<LlxPacketGeometry, T, MaxOp>
+          <<<1, 256>>>(src, staging, accum, nelems);
+      break;
+    case ReduceKind::Min:
+      unpack_reduce_kernel<LlxPacketGeometry, T, MinOp>
+          <<<1, 256>>>(src, staging, accum, nelems);
+      break;
+  }
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace
+
+void test_ll_unpack_reduce_f32(
+    const float* src_d,
+    char* staging_d,
+    float* accum_d,
+    std::size_t nelems,
+    ReduceKind kind) {
+  launchByKind<float>(src_d, staging_d, accum_d, nelems, kind);
+}
+
+void test_ll_unpack_reduce_f16(
+    const void* src_d,
+    char* staging_d,
+    void* accum_d,
+    std::size_t nelems) {
+  launchByKind<__half>(
+      static_cast<const __half*>(src_d),
+      staging_d,
+      static_cast<__half*>(accum_d),
+      nelems,
+      ReduceKind::Sum);
+}
+
+void test_ll_unpack_reduce_i64(
+    const int64_t* src_d,
+    char* staging_d,
+    int64_t* accum_d,
+    std::size_t nelems) {
+  launchByKind<int64_t>(src_d, staging_d, accum_d, nelems, ReduceKind::Sum);
 }
 
 } // namespace comms::prims::test

--- a/comms/prims/tests/LLImplTest.cuh
+++ b/comms/prims/tests/LLImplTest.cuh
@@ -21,4 +21,35 @@ void test_ll_pack_unpack(
 /// I/O uses global volatile ops, which are illegal on shared memory.
 void test_ll_flag_roundtrip(void* p8_d, uint32_t* errorCount_d);
 
+/// Reduce op selector for the unpack_reduce launchers below.
+enum class ReduceKind { Sum, Max, Min };
+
+/// pack(src) then unpack_reduce into `accum`, i.e. accum[i] = Op(accum[i],
+/// src[i]). Each launcher pins one element/packet tiling of unpack_reduce:
+///
+///   f32  sizeof(T) == kData      -> one element per packet
+///   f16  sizeof(T) <  kData      -> two elements per packet (+ partial tail)
+///   i64  sizeof(T) >  kData      -> one element spanning two packets
+///
+/// `accum_d` is pre-seeded by the caller, so these also check that
+/// unpack_reduce accumulates rather than overwriting the way unpack() does.
+void test_ll_unpack_reduce_f32(
+    const float* src_d,
+    char* staging_d,
+    float* accum_d,
+    std::size_t nelems,
+    ReduceKind kind);
+
+void test_ll_unpack_reduce_f16(
+    const void* src_d,
+    char* staging_d,
+    void* accum_d,
+    std::size_t nelems);
+
+void test_ll_unpack_reduce_i64(
+    const int64_t* src_d,
+    char* staging_d,
+    int64_t* accum_d,
+    std::size_t nelems);
+
 } // namespace comms::prims::test

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -1179,7 +1179,6 @@ __device__ __forceinline__ bool progress_recv_ready(
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   using P = LlxPacket<4, 4>;
   (void)transport;
-  (void)localChannel;
   (void)localDataReady;
   (void)waitCredit;
   (void)traceContext;
@@ -1202,13 +1201,25 @@ __device__ __forceinline__ bool progress_recv_ready(
     }
   }
   const bool ready = group_all_ready(group, myReady != 0U);
-  if (!ready && group.is_leader()) {
-    TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
-        timeout,
-        "progress_recv_once(LL) waiting for packet flags flagVal=%llu, "
-        "wireBytes=%llu",
-        static_cast<unsigned long long>(chunk.flagVal),
-        static_cast<unsigned long long>(chunk.wireBytes));
+  if (group.is_leader()) {
+    if (ready) {
+      // LL carries no DATA_READY, but its put still advanced the sender's
+      // IbQpState::cursor -- select_put_lane_ordinal() increments that cursor
+      // on every put regardless of protocol, and it is channel-scoped, not
+      // slot-scoped. recvDataReadyLaneCursor mirrors it, so the mirror has to
+      // advance here too: consuming an LL chunk without it leaves the two one
+      // chunk apart per LL transfer, and Simple's next receive on this channel
+      // then waits on a lane the sender never wrote. Matches the unconditional
+      // bump in poll_recv_data_ready() (a single lane makes it a no-op).
+      ++localChannel.recvDataReadyLaneCursor;
+    } else {
+      TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+          timeout,
+          "progress_recv_once(LL) waiting for packet flags flagVal=%llu, "
+          "wireBytes=%llu",
+          static_cast<unsigned long long>(chunk.flagVal),
+          static_cast<unsigned long long>(chunk.wireBytes));
+    }
   }
   return ready;
 #else


### PR DESCRIPTION
Summary:
`recvDataReadyLaneCursor` is channel-scoped and mirrors the sender's
`IbQpState::cursor`, which `select_put_lane_ordinal()` advances on every put --
for every protocol, since the lane picker is shared by the channel. Simple
advances the mirror inside `poll_recv_data_ready()`. LL never did: it carries
readiness in the inline packet flag, so `progress_recv_ready(protocol::LL, ...)`
had `(void)localChannel` and returned without touching it.

Consuming an LL chunk therefore left the mirror one behind the sender's cursor.
Once both protocols were live on a channel, Simple's next receive resolved
`recvDataReadyLaneCursor % numLanes` to a lane the sender never wrote and
blocked forever. All-Simple and all-LL runs were unaffected -- the first keeps
both counters in step, the second never consults the lane mapping -- so this
only surfaced when a size gate put the two formats on one communicator.

Advance the mirror once per consumed LL chunk, leader-only, matching
`poll_recv_data_ready()`. It fires only on the transition to ready, so it is
exactly one bump per chunk. LL still neither sends nor waits on a DATA_READY
signal, and still does not touch Simple's slot-scoped `recvLaneExpected`
totals; this keeps only the shared chunk count honest. With a single lane the
bump is unobservable, matching the existing unconditional bump on the Simple
path.

The blocking LL path (`consumeRecvBuf(protocol::LL)`) has the same gap. It is
unreachable today because nothing mixes protocols over the blocking API; the
structural fix is to move both lane cursors into `IbChannelProtoSlot` so each
protocol counts independently, which also requires threading the protocol
through `select_put_lane_ordinal()`.

Differential Revision: D115669516


