### PR TITLE
Order lazy peer materialization by XOR distance

### DIFF
--- a/comms/prims/benchmarks/QpGroupCreationBench.cc
+++ b/comms/prims/benchmarks/QpGroupCreationBench.cc
@@ -1,0 +1,286 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/*
+ * Cost of the DOCA GPU verbs object creation behind createPeerQps(), which is
+ * ~75% of per-peer materialization (0.86s of 1.15s measured on GB300). Creates
+ * the same shape createPeerQps() does -- one QP group plus one loopback
+ * companion QP per channel slot -- and reports per-slot cost.
+ *
+ * WARNING on --unsafe_threads: creating DOCA objects concurrently against one
+ * doca_gpu context is NOT SAFE and this mode exists only to measure what a
+ * batched materialization hook could win if it ever became safe. doca_gpu holds
+ * an unsynchronized std::unordered_map (doca_gpunetio.hpp, `mtable`) that
+ * doca_gpu_mem_alloc inserts into and doca_gpu_mem_free finds/erases from, so
+ * concurrent creation corrupts the heap. Reproduced under ASAN as a
+ * heap-use-after-free (allocated on one thread, freed and re-read on another)
+ * and independently as a SIGSEGV inside jemalloc's own metadata. Serial runs
+ * are clean at every scale tested. The threaded numbers are therefore
+ * measurements of an unshippable configuration, not a recommendation -- see
+ * P2458066730. The default sweep is serial for this reason.
+ */
+
+// Include order mirrors MultipeerIbgdaTransport.cc: the transport header pulls
+// in Ibvcore.h before <doca_gpunetio_host.h>, which the ibverbx headers below
+// need in order to see a complete ibv_context.
+#include "comms/prims/transport/ibgda/MultipeerIbgdaTransport.h"
+
+#include <folly/init/Init.h>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/ibverbx/IbverbxSymbols.h"
+#include "comms/prims/transport/rdma/NicDiscovery.h"
+
+DEFINE_int32(
+    slots,
+    0,
+    "Measure this many channel slots as a single configuration. 0 runs the "
+    "default serial sweep instead.");
+DEFINE_int32(
+    unsafe_threads,
+    0,
+    "Create slots across this many threads. UNSAFE: concurrent DOCA object "
+    "creation on one doca_gpu context corrupts the heap (see file header). "
+    "0 keeps creation serial.");
+DEFINE_int32(warmup, 1, "Discard a small first allocation before measuring.");
+DEFINE_int32(
+    cycles,
+    1,
+    "Repeat the --slots configuration this many create/destroy rounds, "
+    "reporting the running total.");
+
+namespace {
+
+constexpr int kQpDepth = 1024;
+constexpr int kLoopbackQpDepth = 8;
+
+struct Slot {
+  doca_gpu_verbs_qp_group_hl* group{nullptr};
+  doca_gpu_verbs_qp_hl* loopback{nullptr};
+};
+
+// One channel slot, matching createPeerQps().
+void createSlot(
+    doca_gpu_verbs_qp_init_attr_hl mainAttr,
+    doca_gpu_verbs_qp_init_attr_hl loopbackAttr,
+    Slot& slot) {
+  doca_error_t err = doca_gpu_verbs_create_qp_group_hl(&mainAttr, &slot.group);
+  if (err != DOCA_SUCCESS) {
+    throw std::runtime_error("doca_gpu_verbs_create_qp_group_hl failed");
+  }
+  err = doca_gpu_verbs_create_qp_hl(&loopbackAttr, &slot.loopback);
+  if (err != DOCA_SUCCESS) {
+    throw std::runtime_error("doca_gpu_verbs_create_qp_hl failed");
+  }
+}
+
+void destroySlots(std::vector<Slot>& slots) {
+  for (auto& slot : slots) {
+    if (slot.group != nullptr) {
+      doca_gpu_verbs_destroy_qp_group_hl(slot.group);
+      slot.group = nullptr;
+    }
+    if (slot.loopback != nullptr) {
+      doca_gpu_verbs_destroy_qp_hl(slot.loopback);
+      slot.loopback = nullptr;
+    }
+  }
+}
+
+double runSerial(
+    doca_gpu_verbs_qp_init_attr_hl mainAttr,
+    doca_gpu_verbs_qp_init_attr_hl loopbackAttr,
+    int totalSlots) {
+  std::vector<Slot> slots(totalSlots);
+  const auto start = std::chrono::steady_clock::now();
+  for (int i = 0; i < totalSlots; ++i) {
+    createSlot(mainAttr, loopbackAttr, slots[i]);
+  }
+  const double ms = std::chrono::duration<double, std::milli>(
+                        std::chrono::steady_clock::now() - start)
+                        .count();
+  destroySlots(slots);
+  return ms;
+}
+
+double runThreaded(
+    doca_gpu_verbs_qp_init_attr_hl mainAttr,
+    doca_gpu_verbs_qp_init_attr_hl loopbackAttr,
+    int totalSlots,
+    int numThreads) {
+  std::vector<Slot> slots(totalSlots);
+  std::vector<std::thread> workers;
+  workers.reserve(numThreads);
+  const auto start = std::chrono::steady_clock::now();
+  for (int t = 0; t < numThreads; ++t) {
+    workers.emplace_back([&, t]() {
+      // Each DOCA call needs the CUDA context of the target device.
+      const cudaError_t err = cudaSetDevice(0);
+      if (err != cudaSuccess) {
+        LOG(FATAL) << "cudaSetDevice(0) failed in worker: "
+                   << cudaGetErrorString(err);
+      }
+      for (int i = t; i < totalSlots; i += numThreads) {
+        createSlot(mainAttr, loopbackAttr, slots[i]);
+      }
+    });
+  }
+  for (auto& worker : workers) {
+    worker.join();
+  }
+  const double ms = std::chrono::duration<double, std::milli>(
+                        std::chrono::steady_clock::now() - start)
+                        .count();
+  destroySlots(slots);
+  return ms;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  // Unbuffered: a hang must still show how far it got.
+  setvbuf(stdout, nullptr, _IONBF, 0);
+
+  if (cudaSetDevice(0) != cudaSuccess) {
+    fprintf(stderr, "cudaSetDevice(0) failed\n");
+    return 1;
+  }
+
+  const std::string pciBusId =
+      comms::prims::GpuNicDiscovery::getCudaPciBusId(0);
+  printf("GPU 0 PCIe %s\n", pciBusId.c_str());
+
+  doca_gpu* docaGpu = nullptr;
+  doca_error_t err = doca_gpu_create(pciBusId.c_str(), &docaGpu);
+  if (err != DOCA_SUCCESS) {
+    fprintf(
+        stderr,
+        "doca_gpu_create failed (err=%d) -- DOCA GPUNetIO is not\n",
+        err);
+    fprintf(
+        stderr, "usable on this host; run this benchmark on GB200/GB300.\n");
+    return 2;
+  }
+  CHECK(docaGpu != nullptr);
+  printf("DOCA GPU context created\n");
+
+  auto initResult = ibverbx::ibvInit();
+  if (!initResult) {
+    fprintf(
+        stderr,
+        "failed to initialize ibverbx: %s\n",
+        initResult.error().errStr.c_str());
+    return 3;
+  }
+  auto& symbols = ibverbx::ibvSymbols;
+
+  int numDevices = 0;
+  ibverbx::ibv_device** devices =
+      symbols.ibv_internal_get_device_list(&numDevices);
+  if (devices == nullptr || numDevices == 0) {
+    fprintf(stderr, "no IB devices found\n");
+    return 4;
+  }
+  ibverbx::ibv_context* ctx = symbols.ibv_internal_open_device(devices[0]);
+  symbols.ibv_internal_free_device_list(devices);
+  if (ctx == nullptr) {
+    fprintf(stderr, "ibv_open_device failed\n");
+    return 5;
+  }
+  ibverbx::ibv_pd* pd = symbols.ibv_internal_alloc_pd(ctx);
+  if (pd == nullptr) {
+    fprintf(stderr, "ibv_alloc_pd failed\n");
+    return 6;
+  }
+  printf("IB device opened (%d available), PD allocated\n", numDevices);
+
+  doca_gpu_verbs_qp_init_attr_hl mainAttr{};
+  mainAttr.gpu_dev = docaGpu;
+  mainAttr.ibpd = reinterpret_cast<decltype(mainAttr.ibpd)>(pd);
+  mainAttr.sq_nwqe = kQpDepth;
+  mainAttr.nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO;
+  mainAttr.mreg_type = DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_DEFAULT;
+
+  doca_gpu_verbs_qp_init_attr_hl loopbackAttr = mainAttr;
+  loopbackAttr.sq_nwqe = kLoopbackQpDepth;
+
+  if (FLAGS_warmup != 0) {
+    // First creation pays one-off driver/context warmup; discard it.
+    printf("warmup...\n");
+    runSerial(mainAttr, loopbackAttr, 32);
+    printf("warmup done\n");
+  }
+
+  // Single explicit configuration, for isolating one data point. With
+  // --cycles N the same create/destroy round is repeated N times, printing the
+  // running total so a stall can be attributed to cumulative churn rather than
+  // to the number of simultaneously live objects.
+  if (FLAGS_slots > 0) {
+    if (FLAGS_unsafe_threads > 0) {
+      printf(
+          "WARNING: concurrent DOCA object creation on one doca_gpu context is\n"
+          "unsafe (unsynchronized mtable); expect heap corruption. Measurement\n"
+          "only -- do not treat these numbers as shippable.\n");
+    }
+    printf(
+        "slots=%d threads=%d warmup=%d cycles=%d\n",
+        FLAGS_slots,
+        FLAGS_unsafe_threads,
+        FLAGS_warmup,
+        FLAGS_cycles);
+    long cumulative = 0;
+    for (int cycle = 0; cycle < FLAGS_cycles; ++cycle) {
+      const double ms = (FLAGS_unsafe_threads <= 0)
+          ? runSerial(mainAttr, loopbackAttr, FLAGS_slots)
+          : runThreaded(
+                mainAttr, loopbackAttr, FLAGS_slots, FLAGS_unsafe_threads);
+      cumulative += FLAGS_slots;
+      printf(
+          "  cycle %3d  %8.1f ms  (%.2f ms/slot)  cumulative slots=%ld objects=%ld\n",
+          cycle,
+          ms,
+          ms / FLAGS_slots,
+          cumulative,
+          cumulative * 2);
+    }
+    symbols.ibv_internal_dealloc_pd(pd);
+    symbols.ibv_internal_close_device(ctx);
+    doca_gpu_destroy(docaGpu);
+    return 0;
+  }
+
+  // Default sweep is serial only: the threaded path corrupts the heap (see the
+  // file header), so running it must be an explicit opt-in via
+  // --unsafe_threads.
+  // 64 slots is one peer on one NIC at the default MCCL_MAX_NCHANNELS=32
+  // (32 channels x 2 directions), so 128 slots is one full peer.
+  printf("\nserial sweep (pass --slots to measure one configuration)\n");
+  for (const int slotsPerPeer : {64}) {
+    for (const int peers : {1, 2, 4, 8}) {
+      const int total = slotsPerPeer * peers;
+      const double serialMs = runSerial(mainAttr, loopbackAttr, total);
+      printf(
+          "  %d x %d = %4d slots  %8.1f ms  (%.2f ms/slot)\n",
+          peers,
+          slotsPerPeer,
+          total,
+          serialMs,
+          serialMs / total);
+    }
+  }
+
+  symbols.ibv_internal_dealloc_pd(pd);
+  symbols.ibv_internal_close_device(ctx);
+  doca_gpu_destroy(docaGpu);
+  return 0;
+}

--- a/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
+++ b/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
@@ -2,7 +2,14 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <set>
 #include <stdexcept>
+#include <utility>
+#include <vector>
 
 #include "comms/prims/transport/MultiPeerIbTransport.h"
 
@@ -163,6 +170,176 @@ TEST(MultiPeerIbTransportConfigTest, ReliableDoorbellDisableForcesValidDbr) {
 TEST(MultiPeerIbTransportConfigTest, PeerMaterializationDefaultsOnDemand) {
   const MultipeerIbTransportConfig config;
   EXPECT_TRUE(config.ibLazyConnect);
+}
+
+// connectPeers() walks each rank's pending peers in peerMaterializationKey
+// order and materializes them one at a time against a peer that must be doing
+// the same. The checks below cover the two properties that buys: the schedule
+// never stalls on a symmetric request graph, and a ring pairs up in a constant
+// number of rounds rather than one per rank.
+
+using PeerKey = int (*)(int myRank, int peerRank);
+
+// Rendezvous rounds needed to materialize every edge of `adjacency` when each
+// rank walks its peers in `key` order. Mirrors the connectPeers() loop for a
+// single connect round from a clean state: an edge advances only once both ends
+// have selected it, so a round is one doMaterializePeer() of wall clock.
+// Returns -1 if the schedule stalls. Does not model the peerMaterialized_ skip
+// across repeated calls, nor the failure/cleanup path.
+// `key == nullptr` orders peers with the production `sortPendingPeers`, so a
+// change to the shipped schedule moves these results. Passing a key overrides
+// that, which is only used to model the pre-change rank ordering.
+int rendezvousRounds(
+    std::vector<std::vector<int>> adjacency,
+    PeerKey key = nullptr) {
+  const int nRanks = static_cast<int>(adjacency.size());
+  int remainingEdges = 0;
+  for (int rank = 0; rank < nRanks; ++rank) {
+    auto& peers = adjacency[rank];
+    if (key == nullptr) {
+      sortPendingPeers(rank, peers);
+    } else {
+      std::sort(peers.begin(), peers.end(), [rank, key](int lhs, int rhs) {
+        return key(rank, lhs) < key(rank, rhs);
+      });
+    }
+    remainingEdges += static_cast<int>(peers.size());
+  }
+  remainingEdges /= 2;
+
+  std::vector<std::size_t> head(nRanks, 0);
+  int rounds = 0;
+  while (remainingEdges > 0) {
+    std::vector<std::pair<int, int>> paired;
+    for (int a = 0; a < nRanks; ++a) {
+      if (head[a] >= adjacency[a].size()) {
+        continue;
+      }
+      const int b = adjacency[a][head[a]];
+      if (b > a && head[b] < adjacency[b].size() &&
+          adjacency[b][head[b]] == a) {
+        paired.emplace_back(a, b);
+      }
+    }
+    if (paired.empty()) {
+      return -1;
+    }
+    for (const auto& [a, b] : paired) {
+      ++head[a];
+      ++head[b];
+    }
+    remainingEdges -= static_cast<int>(paired.size());
+    ++rounds;
+  }
+  return rounds;
+}
+
+// queuePeerForMaterialization() rejects self-peers and dedups, so the models
+// below must too -- a 2-rank ring has one edge, not two.
+std::vector<std::vector<int>> fromEdges(
+    int nRanks,
+    const std::vector<std::pair<int, int>>& edges) {
+  std::vector<std::set<int>> unique(nRanks);
+  for (const auto& [a, b] : edges) {
+    if (a != b) {
+      unique[a].insert(b);
+      unique[b].insert(a);
+    }
+  }
+  std::vector<std::vector<int>> adjacency(nRanks);
+  for (int rank = 0; rank < nRanks; ++rank) {
+    adjacency[rank].assign(unique[rank].begin(), unique[rank].end());
+  }
+  return adjacency;
+}
+
+std::vector<std::vector<int>> ringAdjacency(int nRanks) {
+  std::vector<std::pair<int, int>> edges;
+  edges.reserve(nRanks);
+  for (int rank = 0; rank < nRanks; ++rank) {
+    edges.emplace_back(rank, (rank + 1) % nRanks);
+  }
+  return fromEdges(nRanks, edges);
+}
+
+std::vector<std::vector<int>> cliqueAdjacency(int nRanks) {
+  std::vector<std::pair<int, int>> edges;
+  edges.reserve(static_cast<std::size_t>(nRanks) * (nRanks - 1) / 2);
+  for (int a = 0; a < nRanks; ++a) {
+    for (int b = a + 1; b < nRanks; ++b) {
+      edges.emplace_back(a, b);
+    }
+  }
+  return fromEdges(nRanks, edges);
+}
+
+std::vector<std::vector<int>> binaryTreeAdjacency(int nRanks) {
+  std::vector<std::pair<int, int>> edges;
+  edges.reserve(nRanks);
+  for (int rank = 1; rank < nRanks; ++rank) {
+    edges.emplace_back(rank, (rank - 1) / 2);
+  }
+  return fromEdges(nRanks, edges);
+}
+
+std::vector<std::vector<int>>
+randomSymmetricAdjacency(int nRanks, int degree, uint32_t seed) {
+  std::mt19937 rng(seed);
+  std::uniform_int_distribution<int> pick(0, nRanks - 1);
+  std::vector<std::pair<int, int>> edges;
+  edges.reserve(static_cast<std::size_t>(nRanks) * degree);
+  for (int rank = 0; rank < nRanks; ++rank) {
+    for (int i = 0; i < degree; ++i) {
+      edges.emplace_back(rank, pick(rng));
+    }
+  }
+  return fromEdges(nRanks, edges);
+}
+
+// The regression this ordering exists for. A ring is the shape every ring
+// collective requests, and rank order pairs it off one edge at a time.
+int rankOrderKey(int /*myRank*/, int peerRank) {
+  return peerRank;
+}
+
+TEST(MultiPeerIbTransportConfigTest, RankOrderSerializesRing) {
+  for (const int nRanks : {8, 64, 256, 644}) {
+    EXPECT_EQ(rendezvousRounds(ringAdjacency(nRanks), rankOrderKey), nRanks - 1)
+        << "nRanks=" << nRanks;
+  }
+}
+
+// Under peerMaterializationKey the same ring costs a constant instead: two
+// rounds when the ring can be 2-edge-coloured, three when it cannot.
+TEST(MultiPeerIbTransportConfigTest, RingPairsUpInConstantRounds) {
+  for (const int nRanks : {8, 64, 256, 644, 9, 65, 645}) {
+    const int expected = (nRanks % 2 == 0) ? 2 : 3;
+    EXPECT_EQ(rendezvousRounds(ringAdjacency(nRanks)), expected)
+        << "nRanks=" << nRanks;
+  }
+}
+
+// The invariant the ordering has to preserve: given the symmetric request graph
+// materializePeers requires, every edge eventually pairs up. Covers the other
+// shapes comms requests -- cliques from the direct algorithms, trees from
+// AllReduceFusedTree -- plus irregular graphs the fixed topologies do not
+// reach.
+TEST(MultiPeerIbTransportConfigTest, SymmetricRequestGraphsNeverStall) {
+  for (const int nRanks : {2, 3, 8, 33, 64}) {
+    EXPECT_GT(rendezvousRounds(ringAdjacency(nRanks)), 0)
+        << "ring nRanks=" << nRanks;
+    EXPECT_GT(rendezvousRounds(cliqueAdjacency(nRanks)), 0)
+        << "clique nRanks=" << nRanks;
+    EXPECT_GT(rendezvousRounds(binaryTreeAdjacency(nRanks)), 0)
+        << "tree nRanks=" << nRanks;
+  }
+  for (uint32_t seed = 0; seed < 200; ++seed) {
+    EXPECT_GT(
+        rendezvousRounds(
+            randomSymmetricAdjacency(/*nRanks=*/32, /*degree=*/3, seed)),
+        0)
+        << "random seed=" << seed;
+  }
 }
 
 } // namespace

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -1997,6 +1997,20 @@ bool MultiPeerIbTransportBase::isPeerMaterialized(int peerRank) const {
   return peerMaterialized_[rankToPeerIndex(peerRank)];
 }
 
+void MultiPeerIbTransportBase::logPeersMaterialized(
+    std::size_t peerCount,
+    std::int64_t elapsedMs,
+    bool failed) const {
+  if (failed) {
+    LOG(WARNING) << "MultiPeerIbTransport: rank " << myRank_
+                 << " failed after materializing " << peerCount
+                 << " peer(s) in " << elapsedMs << " ms";
+    return;
+  }
+  LOG(INFO) << "MultiPeerIbTransport: rank " << myRank_ << " materialized "
+            << peerCount << " peer(s) in " << elapsedMs << " ms";
+}
+
 void MultiPeerIbTransportBase::queuePeerForMaterialization(int peerRank) {
   const std::lock_guard<std::mutex> lock(materializationMutex_);
   if (materializationFailed_) {

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -329,6 +330,42 @@ inline bool reliableDoorbellNeedsCapabilityQuery(
   return config.enableReliableDoorbell.value_or(true);
 }
 
+// Order in which connectPeers() walks a rank's pending peers.
+// doMaterializePeer() is a rendezvous, so an edge only progresses while both
+// ends are working on each other. Deadlock freedom needs a key that is
+// symmetric (k(a,b) == k(b,a)) and injective in the peer for a fixed rank: the
+// globally lowest-keyed pending edge then always has both ends selecting it.
+// Both properties hold for XOR; the caller-side precondition is unchanged and
+// still the one documented on MultiPeerTransport::materializePeers.
+//
+// The key also decides how much of the graph pairs up at once. Ordering by peer
+// rank is equally deadlock-free but serializes a ring into nRanks - 1 rounds,
+// because rank r takes r-1 before r+1 and so edge (r, r+1) cannot start until
+// (r-1, r) has finished. XOR distance instead puts every (2i, 2i+1) edge at
+// key 1 and every (2i+1, 2i+2) edge above it, collapsing a contiguous ring to
+// two rounds when nRanks is even and three when it is odd. Rings the collective
+// layer actually builds are strided (node * nvlSize + nvlRank), and a stride
+// that is not a power of two costs a round or two more; the win is that the
+// round count stays a small constant instead of scaling with nRanks. XOR is not
+// optimal for every graph -- a few strided and irregular shapes need one to
+// three rounds more than rank order -- but no topology in comms regresses more
+// than that, against O(nRanks) rounds saved on every ring.
+//
+// Free function so the schedule is unit-testable without a NIC.
+constexpr int peerMaterializationKey(int myRank, int peerRank) {
+  return myRank ^ peerRank;
+}
+
+// Order a rank's pending peers into the sequence connectPeers() materializes
+// them in. Free function so the schedule the transport actually runs is
+// unit-testable without a NIC.
+inline void sortPendingPeers(int myRank, std::vector<int>& peers) {
+  std::sort(peers.begin(), peers.end(), [myRank](int lhs, int rhs) {
+    return peerMaterializationKey(myRank, lhs) <
+        peerMaterializationKey(myRank, rhs);
+  });
+}
+
 /**
  * Transport connection information for RDMA QP setup.
  *
@@ -551,6 +588,22 @@ class MultiPeerIbTransportBase {
 
   /** Queue a peer for lazy materialization (no network I/O). */
   void queuePeerForMaterialization(int peerRank);
+
+  /**
+   * Report the outcome of a connectPeers() round. Defined out-of-line so this
+   * header, which every IB backend includes, does not pull in glog.
+   */
+  void logPeersMaterialized(
+      std::size_t peerCount,
+      std::int64_t elapsedMs,
+      bool failed) const;
+
+  static std::int64_t elapsedMsSince(
+      std::chrono::steady_clock::time_point start) {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - start)
+        .count();
+  }
 
   /** @return true if the peer is materialized and ready for kernel use. */
   bool isPeerMaterialized(int peerRank) const;
@@ -889,7 +942,10 @@ class MultiPeerIbTransport : public MultiPeerIbTransportBase {
     connectPeers();
   }
 
-  /** Connect all queued peers in sorted order (deadlock-safe for >2 ranks). */
+  /**
+   * Connect all queued peers in peerMaterializationKey order (deadlock-safe for
+   * >2 ranks, given the symmetric request graph materializePeers requires).
+   */
   void connectPeers();
 
  protected:
@@ -929,15 +985,15 @@ void MultiPeerIbTransport<Backend>::connectPeers() {
   if (pendingPeers_.empty()) {
     return;
   }
-  // For a symmetric request graph, ascending local order is deadlock-free: the
-  // lowest remaining rank and its lowest pending neighbor select each other.
-  std::sort(pendingPeers_.begin(), pendingPeers_.end());
+  // Deadlock-free on a symmetric request graph; see peerMaterializationKey.
+  sortPendingPeers(myRank_, pendingPeers_);
 
   std::vector<int> peers;
   peers.swap(pendingPeers_);
   std::vector<int> touchedPeerIndexes;
   touchedPeerIndexes.reserve(peers.size());
 
+  const auto startTime = std::chrono::steady_clock::now();
   try {
     for (int peerRank : peers) {
       if (peerMaterialized_[rankToPeerIndex(peerRank)]) {
@@ -948,11 +1004,20 @@ void MultiPeerIbTransport<Backend>::connectPeers() {
     }
   } catch (...) {
     materializationFailed_ = true;
+    // Report elapsed on the way out too: a rendezvous that stalls and then
+    // errors is the case where the timing matters most.
+    logPeersMaterialized(
+        touchedPeerIndexes.size(), elapsedMsSince(startTime), /*failed=*/true);
     for (int peerIndex : touchedPeerIndexes) {
       backend().cleanupPeerOnFailure(peerIndex);
     }
     throw;
   }
+  // A rank blocks here until each peer reaches the matching rendezvous, so this
+  // reports queue wait as well as local work. Elapsed far above the per-peer
+  // cost means peers are arriving late, not that materialization is slow.
+  logPeersMaterialized(
+      touchedPeerIndexes.size(), elapsedMsSince(startTime), /*failed=*/false);
 }
 
 } // namespace comms::prims


### PR DESCRIPTION
Summary:
`connectPeers()` materializes pending IB peers one at a time, and
`doMaterializePeer()` is a rendezvous — an edge only progresses while both
endpoints are inside it for each other. Sorting the pending list by peer rank is
deadlock-free but pairs a ring off one edge at a time: rank r takes `r-1` before
`r+1`, so edge `(r, r+1)` cannot start until `(r-1, r)` finished. First-collective
cost becomes `nRanks - 1` rendezvous rounds instead of a constant.

Measured on `mccl-ring-prims-644x1` (GB300, 644 ranks, `MCCL_ALGO=ring`): the
init barrier AllReduce took 741 s, of which each rank spent ~2.3 s materializing
its two neighbours and the rest blocked. `materialized peer` traces at
`GLOG_v=1` show edge `(r, r+1)` completing at `1.158 * r - 1.56` s. Cost is
linear in world size — 128 ranks 145 s, 256 ranks 298 s, 644 ranks 742 s. The
CTRAN-IB path on the same ring is 0.2 s, because its connection setup is
client/server and has no rendezvous chain.

Order by `myRank ^ peer` instead. Any key that is symmetric and injective per
rank preserves the minimality argument, so the caller-side precondition is
unchanged: the request graph must be symmetric, exactly as
`MultiPeerTransport::materializePeers` already documents. XOR additionally puts
every `(2i, 2i+1)` edge at key 1 and every `(2i+1, 2i+2)` edge above it, so a
ring collapses to a constant number of rounds.

Simulated rounds over the request graphs comms actually builds, rank order -> XOR:

| graph | before | after |
| --- | --- | --- |
| contiguous ring, 644 ranks | 643 | 2 |
| contiguous ring, 4096 ranks | 4095 | 2 |
| strided ring, `nvlSize=8`, 80 nodes | 79 | 2 |
| double binary tree, 644 ranks | 962 | 33 |
| clique, 256 ranks | 509 | 255 (optimal) |
| rail clique, `ppn=4`, 644 ranks | 319 | 255 |

XOR is not optimal everywhere. Odd world sizes need 3 rounds, strided rings with
a non-power-of-two stride 3-4, and a few irregular shapes cost 1-3 rounds more
than rank order — against `O(nRanks)` rounds saved on every ring. No shape any
caller builds regresses by more than that.

`SendRecv` is worth calling out: it is the only caller whose peers come from the
application rather than from a computed topology, so it is the only one that can
violate the same-connect-round precondition, by batching an edge's two endpoints
into different `sendRecv` calls. Such a program can already hang under rank
order; changing the key changes *which* of them do. Over 30k random non-lockstep
workloads the two orderings are comparable (XOR-only 576, rank-order-only 520),
so this is not a regression, but it is a silent behaviour change worth knowing
about.

Per-edge cost (~1.15 s, three quarters of it `createPeerQps` building 64 QP
groups per peer per NIC) is unchanged and tracked separately.

Also adds `comms/prims/benchmarks:qp_group_creation_bench`, which isolates the
DOCA object creation behind `createPeerQps` (one QP group + one loopback QP per
channel slot) so per-peer materialization cost can be measured without a
cluster. Serial cost on an H100 devgpu is ~8 ms/slot, i.e. ~3.9-4.2 ms per DOCA
create call against ~3.4 ms measured on GB300, so the local numbers track
production. Its `--threads` mode measures what a batched materialization hook
could win, and is documented in the file as unshippable: concurrent creation on
one `doca_gpu` context corrupts the heap, because `doca_gpu_mem_alloc` /
`doca_gpu_mem_free` mutate an unsynchronized `std::unordered_map` with no
documented thread-safety guarantee. Reproduced under ASAN as a
heap-use-after-free across threads; serial runs are clean at every scale tested.
The default sweep is serial so the benchmark is safe to run as-is. Details in
P2458066730.

`connectPeers()` now logs peer count and elapsed time at INFO. Note it measures
queue wait as well as local work: a rank blocks until each peer reaches the
matching rendezvous, so an elapsed time far above the per-peer cost means peers
arrived late, not that materialization itself was slow.

Reviewed By: saifhhasan

Differential Revision: D115600707


