### PR TITLE
Support PyTorch's renamed `tp_getattro_impl` dynamo hook

### DIFF
--- a/comms/torchcomms/functional/dynamo.py
+++ b/comms/torchcomms/functional/dynamo.py
@@ -634,12 +634,19 @@ def _patch_var_getattr() -> None:
     """
     from torch._dynamo.source import AttrSource
 
-    # PyTorch 2.14+ renamed var_getattr to getattro_impl
-    # (pytorch/pytorch#186013); patch whichever the installed version has.
-    if hasattr(TorchScriptObjectVariable, "getattro_impl"):
-        getattr_method_name = "getattro_impl"
-    else:
-        getattr_method_name = "var_getattr"
+    # PyTorch renamed this hook twice: var_getattr -> getattro_impl
+    # (pytorch/pytorch#186013) -> tp_getattro_impl; patch whichever the
+    # installed version has.
+    getattr_method_name: str | None = None
+    for candidate in ("tp_getattro_impl", "getattro_impl", "var_getattr"):
+        if hasattr(TorchScriptObjectVariable, candidate):
+            getattr_method_name = candidate
+            break
+    if getattr_method_name is None:
+        raise RuntimeError(
+            "torchcomms: no known dynamo attribute hook on "
+            f"{TorchScriptObjectVariable.__name__}; unsupported PyTorch version"
+        )
 
     # Store the original method
     original_var_getattr = getattr(TorchScriptObjectVariable, getattr_method_name)


### PR DESCRIPTION
Summary:
`_patch_var_getattr()` probes for Dynamo's attribute hook by name so that torchcomms can intercept collective methods (`all_reduce`, etc.) during tracing. It only checked `getattro_impl`, falling back to `var_getattr`. PyTorch has since renamed the hook a third time, to `tp_getattro_impl`, as part of the `object_protocol.py` / `generic_getattr` refactor. Neither probed name exists on `CustomClassObjectVariable`, so `getattr()` raised `AttributeError` at import time.

This broke `test_wait_proxy_propagation.py` in OSS CI with two errors that look unrelated but share one cause:

- The first test failed in `setUp` with `AttributeError: type object 'CustomClassObjectVariable' has no attribute 'var_getattr'`.
- The second failed later with `UnsafeScriptObjectError: Attempted to access unregistered member on an OpaqueObject`. That one is a cascade. After the first import raised, `collectives.py` was re-imported, `torch.library.Library("torchcomms", "DEF")` hit "Only a single TORCH_LIBRARY can be used to register the namespace torchcomms", and the `except RuntimeError: lib = None` guard silently skipped the whole registration block. With no patch installed, tracing reached PyTorch's own `CustomClassObjectVariable.tp_getattro_impl`, which rejects `all_reduce` because torchcomms intentionally does not register collectives as opaque members.

Probe the three known hook names newest-first, and raise an explicit `RuntimeError` naming the class when none match, rather than letting `getattr()` fail with an opaque `AttributeError`.

Also adds a `python_unittest` target for `test_wait_proxy_propagation.py`, which had no internal target -- the reason internal CI never caught this. The failure only reaches code that sets `TORCHCOMMS_PATCH_FOR_COMPILE=1`, since `torchcomms/__init__.py` gates the `collectives` import on `is_torch_compile_supported_and_enabled()`.

Differential Revision: D115754103


