### PR TITLE
Keep the recv lane cursor in step on the blocking LL path

### DIFF
--- a/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
@@ -667,7 +667,6 @@ __device__ __forceinline__ void consumeRecvBuf(
       "contiguous copy cannot address the data+flag interleaved staging");
 #if PIPES_IS_DEVICE_COMPILE
   (void)transport;
-  (void)localChannel;
   (void)localDataReady;
   (void)waitCredit;
   // Same clamp as the send side: unpacking the padded length writes up to
@@ -684,6 +683,17 @@ __device__ __forceinline__ void consumeRecvBuf(
         static_cast<typename P::FlagType>(flagVal),
         timeout,
         args...);
+  }
+  if (group.is_leader()) {
+    // LL carries no DATA_READY, but the sender's put still advanced the
+    // channel-scoped IbQpState::cursor -- select_put_lane_ordinal() increments
+    // it on every put regardless of protocol. recvDataReadyLaneCursor mirrors
+    // that cursor, so it has to advance here too, or Simple's next receive on
+    // this channel resolves to a lane the sender never wrote and blocks
+    // forever. Outside the validBytes guard on purpose: the sender puts a chunk
+    // even when its valid payload is zero (tail padding), so the mirror must
+    // move for every chunk. A single lane makes this a no-op.
+    ++localChannel.recvDataReadyLaneCursor;
   }
 #else
   (void)transport;


### PR DESCRIPTION
Summary:
`recvDataReadyLaneCursor` is channel-scoped and mirrors the sender's
`IbQpState::cursor`, which `select_put_lane_ordinal()` advances on every put --
for every protocol, since the lane picker belongs to the channel, not the
protocol slot. The receiver reconstructs which lane a chunk rode by mirroring
that cursor, so the two must stay in lock-step.

Simple advances the mirror in `wait_recv_data_ready()`. The blocking LL path
never did: it carries readiness in the inline packet flag, so
`consumeRecvBuf(protocol::LL, ...)` had `(void)localChannel` and returned
without touching it.

Consuming an LL chunk therefore left the mirror one behind the sender's cursor.
Once both protocols are live on a channel, Simple's next receive resolves
`recvDataReadyLaneCursor % numLanes` to a lane the sender never wrote and blocks
forever.

Advance the mirror once per consumed chunk, leader-only. Deliberately outside
the `validBytes > 0` guard: the sender puts a chunk even when its valid payload
is zero (tail padding), so the mirror has to move for every chunk or it drifts
on any padded transfer. LL still neither sends nor waits on a DATA_READY
signal, and still does not touch Simple's slot-scoped `recvLaneExpected`; this
keeps only the shared chunk count honest. With a single lane the bump is
unobservable, matching the unconditional bump on the Simple path.

This sits at the base of the LL stack because it patches already-landed code
(D110941699) and is a prerequisite for anything that puts both wire formats on
one channel. The resumable-progress twin of this bug is fixed separately in
D115669516, which has to sit higher because the function it patches is
introduced by D112334774.

Reviewed By: Scusemua

Differential Revision: D115768923


