### PR TITLE
Add dedicated IB warp proxy prototype (#3631)

### DIFF
--- a/comms/prims/benchmarks/IbgdaSendRecv.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cu
@@ -1,5 +1,7 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include "comms/prims/benchmarks/IbgdaSendRecv.h"
+
 #include "comms/prims/benchmarks/IbgdaSendRecv.cuh"
 
 #include <algorithm>
@@ -9,13 +11,23 @@
 #include "comms/prims/core/TiledBuffer.cuh"
 #include "comms/prims/core/Timeout.cuh"
 #include "comms/prims/transport/P2pIbTransportProgressImpl.cuh"
+#ifndef __HIP_PLATFORM_AMD__
+#include "comms/prims/transport/ibgda/IbgdaWarpProxy.cuh"
+#endif
 
 namespace comms::prims::benchmark {
 
 namespace {
 
-__device__ __forceinline__ std::size_t benchmark_align_protocol_bytes(
-    std::size_t nbytes) {
+#ifndef __HIP_PLATFORM_AMD__
+constexpr uint32_t kWarpProxyWorkerThreads = 512;
+constexpr uint32_t kWarpProxyBlockThreads =
+    kWarpProxyWorkerThreads + comms::device::kWarpSize;
+using BenchmarkWarpProxy = IbgdaWarpProxy<kWarpProxyWorkerThreads>;
+#endif
+
+__device__ __forceinline__
+    std::size_t benchmark_align_protocol_bytes(std::size_t nbytes) {
   return (nbytes + 15ULL) & ~15ULL;
 }
 
@@ -268,6 +280,42 @@ __global__ void __launch_bounds__(512, 1) ibgda_recv_kernel(
   }
 }
 
+#ifndef __HIP_PLATFORM_AMD__
+template <bool IsSend>
+__global__ void __launch_bounds__(kWarpProxyBlockThreads, 1)
+    ibgda_warp_proxy_kernel(
+        P2pIbgdaTransportDevice* transport,
+        char* buffer,
+        std::size_t totalBytes,
+        std::size_t maxSignalBytes,
+        uint32_t queueDepth,
+        Timeout timeout) {
+  timeout.start();
+  auto block = make_block_group();
+  __shared__ BenchmarkWarpProxy::SharedState sharedState;
+  BenchmarkWarpProxy::run(
+      sharedState,
+      block,
+      BenchmarkWarpProxy::Config{.queueDepth = queueDepth},
+      timeout,
+      [&](auto& ops) {
+        auto& workers = ops.group();
+        const std::size_t sectionBytes = section_bytes(transport, totalBytes);
+        for (std::size_t offset = 0; offset < totalBytes;
+             offset += sectionBytes) {
+          const std::size_t bytes = min(sectionBytes, totalBytes - offset);
+          TiledBuffer<char> tiles(buffer + offset, bytes, workers);
+          if constexpr (IsSend) {
+            ops.send(*transport, tiles.data(), tiles.bytes(), maxSignalBytes);
+          } else {
+            ops.recv(*transport, tiles.data(), tiles.bytes(), maxSignalBytes);
+          }
+        }
+      });
+}
+
+#endif
+
 void launch_ibgda_send(
     P2pIbgdaTransportDevice* transport,
     char* src,
@@ -282,6 +330,38 @@ void launch_ibgda_send(
   if (err != cudaSuccess) {
     printf("[PIPES] send kernel launch failed: %s\n", cudaGetErrorString(err));
   }
+}
+
+void launch_ibgda_warp_proxy_send(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes,
+    Timeout timeout,
+    uint32_t queueDepth) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)src;
+  (void)nbytes;
+  (void)numBlocks;
+  (void)stream;
+  (void)maxSignalBytes;
+  (void)timeout;
+  (void)queueDepth;
+  printf("[PIPES] warp-proxy send benchmark is NVIDIA-only\n");
+#else
+  ibgda_warp_proxy_kernel<true>
+      <<<numBlocks, kWarpProxyBlockThreads, 0, stream>>>(
+          transport, src, nbytes, maxSignalBytes, queueDepth, timeout);
+  const cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] warp-proxy send kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+#endif
 }
 
 void launch_ibgda_recv(
@@ -426,6 +506,38 @@ void launch_ibgda_recv_ll(
     printf(
         "[PIPES] recv LL kernel launch failed: %s\n", cudaGetErrorString(err));
   }
+}
+
+void launch_ibgda_warp_proxy_recv(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes,
+    Timeout timeout,
+    uint32_t queueDepth) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)dst;
+  (void)nbytes;
+  (void)numBlocks;
+  (void)stream;
+  (void)maxSignalBytes;
+  (void)timeout;
+  (void)queueDepth;
+  printf("[PIPES] warp-proxy recv benchmark is NVIDIA-only\n");
+#else
+  ibgda_warp_proxy_kernel<false>
+      <<<numBlocks, kWarpProxyBlockThreads, 0, stream>>>(
+          transport, dst, nbytes, maxSignalBytes, queueDepth, timeout);
+  const cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] warp-proxy recv kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+#endif
 }
 
 __global__ void __launch_bounds__(512, 1) ibgda_drain_send_recv_kernel(

--- a/comms/prims/benchmarks/IbgdaSendRecv.h
+++ b/comms/prims/benchmarks/IbgdaSendRecv.h
@@ -15,6 +15,8 @@ class P2pIbgdaTransportDevice;
 
 namespace comms::prims::benchmark {
 
+inline constexpr uint32_t kDefaultIbgdaWarpProxyQueueDepth = 16;
+
 /**
  * Launch bidirectional tile sendrecv kernel for IBGDA transport.
  *
@@ -85,6 +87,19 @@ void launch_ibgda_send(
     Timeout timeout = Timeout());
 
 /**
+ * Launch NVIDIA-only unidirectional send with one IB service warp per block.
+ */
+void launch_ibgda_warp_proxy_send(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
+    Timeout timeout = Timeout(),
+    uint32_t queueDepth = kDefaultIbgdaWarpProxyQueueDepth);
+
+/**
  * Launch unidirectional tile recv kernel. All blocks receive.
  */
 void launch_ibgda_recv(
@@ -95,6 +110,19 @@ void launch_ibgda_recv(
     cudaStream_t stream,
     std::size_t maxSignalBytes = 0,
     Timeout timeout = Timeout());
+
+/**
+ * Launch NVIDIA-only unidirectional receive with one IB service warp per block.
+ */
+void launch_ibgda_warp_proxy_recv(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
+    Timeout timeout = Timeout(),
+    uint32_t queueDepth = kDefaultIbgdaWarpProxyQueueDepth);
 
 /**
  * Low-latency (LL) protocol counterparts of launch_ibgda_send_recv/send/recv.

--- a/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -52,13 +52,16 @@ DEFINE_int32(
     1,
     "QPs per channel, direction, and NIC");
 DEFINE_int32(ibgda_sendrecv_warmup_iters, 5, "Warmup iterations");
+DEFINE_uint32(
+    ibgda_warp_proxy_queue_depth,
+    comms::prims::benchmark::kDefaultIbgdaWarpProxyQueueDepth,
+    "Maximum outstanding commands per IB warp proxy queue");
 
 namespace comms::prims::benchmark {
 namespace {
 
 constexpr int kWorldSize = 2;
 constexpr const char* kDefaultBenchmarkIters = "20";
-constexpr const char* kDefaultBenchmarkMaxIters = "21";
 
 // Sub-1MB transfers finish below folly's ~100us timing floor at the default
 // iteration count, so folly drops their counters (printing
@@ -73,6 +76,7 @@ enum class SendRecvApi {
   Blocking,
   Progress,
   RegisteredProgress,
+  WarpProxy,
 };
 
 enum class SendRecvDirection {
@@ -199,12 +203,6 @@ void setDefaultBenchmarkFlags() {
       "bm_min_iters",
       kDefaultBenchmarkIters,
       folly::gflags::SET_FLAG_IF_DEFAULT);
-  folly::gflags::SetCommandLineOptionWithMode(
-      "bm_max_iters",
-      kDefaultBenchmarkMaxIters,
-      folly::gflags::SET_FLAG_IF_DEFAULT);
-  folly::gflags::SetCommandLineOptionWithMode(
-      "bm_max_trials", "1", folly::gflags::SET_FLAG_IF_DEFAULT);
 }
 
 struct BenchmarkSize {
@@ -412,6 +410,8 @@ const char* apiName(SendRecvApi api) {
       return "progress";
     case SendRecvApi::RegisteredProgress:
       return "registered_progress";
+    case SendRecvApi::WarpProxy:
+      return "warp_proxy";
   }
   return "unknown";
 }
@@ -519,6 +519,7 @@ class IbgdaSendRecvBenchmarkContext {
     transport_ = std::make_unique<MultipeerIbgdaTransport>(
         globalRank_, worldSize_, bootstrap_, transportConfig);
     transport_->exchange();
+    CHECK_GT(transport_->numNics(), 0);
 
     sendBuf_ = std::make_unique<DeviceBuffer>(maxBytes_);
     recvBuf_ = std::make_unique<DeviceBuffer>(maxBytes_);
@@ -569,6 +570,18 @@ class IbgdaSendRecvBenchmarkContext {
 
   std::size_t pipelineChunkBytes() const {
     return perChannelSize_ / static_cast<std::size_t>(pipelineDepth_);
+  }
+
+  std::size_t perChannelSize() const {
+    return perChannelSize_;
+  }
+
+  int pipelineDepth() const {
+    return pipelineDepth_;
+  }
+
+  int qpsPerConnection() const {
+    return FLAGS_ibgda_sendrecv_qps_per_connection;
   }
 
   bool registeredEnabled() const {
@@ -722,6 +735,14 @@ class IbgdaSendRecvBenchmarkContext {
     return globalRank_;
   }
 
+  int numNics() const {
+    return transport_->numNics();
+  }
+
+  int numLanes() const {
+    return numNics() * qpsPerConnection();
+  }
+
  private:
   void launchOperation(
       std::size_t nbytes,
@@ -735,6 +756,7 @@ class IbgdaSendRecvBenchmarkContext {
     // unidirectional progress path; registerBenchmarks never pairs LL with
     // bidirectional Progress, so that combination is Simple-only below.
     const bool useLL = (proto == SendRecvProto::LL);
+    (void)copyOp;
 
     if (direction == SendRecvDirection::Bidirectional) {
       if (api == SendRecvApi::Blocking) {
@@ -746,6 +768,7 @@ class IbgdaSendRecvBenchmarkContext {
               deviceTransport_, sendBuf, recvBuf, nbytes, numBlocks_, stream_);
         }
       } else {
+        CHECK(api == SendRecvApi::Progress);
         launch_ibgda_progress_send_recv(
             deviceTransport_, sendBuf, recvBuf, nbytes, numBlocks_, stream_);
       }
@@ -762,10 +785,11 @@ class IbgdaSendRecvBenchmarkContext {
               deviceTransport_, sendBuf, nbytes, numBlocks_, stream_);
         }
       } else if (api == SendRecvApi::RegisteredProgress) {
+        CHECK(!useLL);
         CHECK(registeredEnabled_);
         launch_ibgda_registered_progress_send(
             deviceTransport_, registeredSendBuf_, nbytes, numBlocks_, stream_);
-      } else {
+      } else if (api == SendRecvApi::Progress) {
         if (useLL) {
           launch_ibgda_progress_send_ll(
               deviceTransport_, sendBuf, nbytes, numBlocks_, stream_);
@@ -776,6 +800,19 @@ class IbgdaSendRecvBenchmarkContext {
           launch_ibgda_progress_send(
               deviceTransport_, sendBuf, nbytes, numBlocks_, stream_);
         }
+      } else if (api == SendRecvApi::WarpProxy) {
+        CHECK(!useLL);
+        launch_ibgda_warp_proxy_send(
+            deviceTransport_,
+            sendBuf,
+            nbytes,
+            numBlocks_,
+            stream_,
+            /*maxSignalBytes=*/0,
+            Timeout(),
+            FLAGS_ibgda_warp_proxy_queue_depth);
+      } else {
+        LOG(FATAL) << "unsupported send/recv API";
       }
       return;
     }
@@ -788,7 +825,7 @@ class IbgdaSendRecvBenchmarkContext {
         launch_ibgda_recv(
             deviceTransport_, recvBuf, nbytes, numBlocks_, stream_);
       }
-    } else {
+    } else if (api == SendRecvApi::Progress) {
       if (useLL) {
         launch_ibgda_progress_recv_ll(
             deviceTransport_, recvBuf, nbytes, numBlocks_, stream_);
@@ -796,6 +833,24 @@ class IbgdaSendRecvBenchmarkContext {
         launch_ibgda_progress_recv(
             deviceTransport_, recvBuf, nbytes, numBlocks_, stream_);
       }
+    } else if (api == SendRecvApi::RegisteredProgress) {
+      CHECK(!useLL);
+      CHECK(registeredEnabled_);
+      launch_ibgda_progress_recv(
+          deviceTransport_, recvBuf, nbytes, numBlocks_, stream_);
+    } else if (api == SendRecvApi::WarpProxy) {
+      CHECK(!useLL);
+      launch_ibgda_warp_proxy_recv(
+          deviceTransport_,
+          recvBuf,
+          nbytes,
+          numBlocks_,
+          stream_,
+          /*maxSignalBytes=*/0,
+          Timeout(),
+          FLAGS_ibgda_warp_proxy_queue_depth);
+    } else {
+      LOG(FATAL) << "unsupported send/recv API";
     }
   }
 
@@ -861,6 +916,33 @@ static unsigned int ibgdaSendRecv(
         folly::UserMetric::Type::METRIC);
     counters["pipeline_chunk_bytes"] = folly::UserMetric(
         static_cast<double>(context.pipelineChunkBytes()),
+        folly::UserMetric::Type::METRIC);
+    counters["pipeline_depth"] = folly::UserMetric(
+        static_cast<double>(context.pipelineDepth()),
+        folly::UserMetric::Type::METRIC);
+    counters["total_staging_bytes"] = folly::UserMetric(
+        static_cast<double>(context.perChannelSize()) * context.numBlocks(),
+        folly::UserMetric::Type::METRIC);
+    counters["per_channel_window_bytes"] = folly::UserMetric(
+        static_cast<double>(context.perChannelSize()),
+        folly::UserMetric::Type::METRIC);
+    counters["slot_bytes"] = folly::UserMetric(
+        static_cast<double>(context.pipelineChunkBytes()),
+        folly::UserMetric::Type::METRIC);
+    counters["warp_proxy_queue_depth"] = folly::UserMetric(
+        static_cast<double>(FLAGS_ibgda_warp_proxy_queue_depth),
+        folly::UserMetric::Type::METRIC);
+    counters["num_channels"] = folly::UserMetric(
+        static_cast<double>(context.numBlocks()),
+        folly::UserMetric::Type::METRIC);
+    counters["qps_per_connection"] = folly::UserMetric(
+        static_cast<double>(context.qpsPerConnection()),
+        folly::UserMetric::Type::METRIC);
+    counters["num_nics"] = folly::UserMetric(
+        static_cast<double>(context.numNics()),
+        folly::UserMetric::Type::METRIC);
+    counters["num_lanes"] = folly::UserMetric(
+        static_cast<double>(context.numLanes()),
         folly::UserMetric::Type::METRIC);
   }
   return iters;
@@ -960,7 +1042,18 @@ void registerBenchmarks(IbgdaSendRecvBenchmarkContext& context) {
         SendRecvDirection::Unidirectional,
         SendRecvCopyOp::Memcpy,
         proto);
-    if (context.registeredEnabled()) {
+#ifndef __HIP_PLATFORM_AMD__
+    if (proto == SendRecvProto::Simple) {
+      registerBenchmark(
+          context,
+          size,
+          SendRecvApi::WarpProxy,
+          SendRecvDirection::Unidirectional,
+          SendRecvCopyOp::Memcpy,
+          proto);
+    }
+#endif
+    if (context.registeredEnabled() && proto == SendRecvProto::Simple) {
       registerBenchmark(
           context,
           size,

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -5,6 +5,7 @@
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
 #include <array>
+#include <chrono>
 
 #include <memory>
 #include <string>
@@ -22,6 +23,7 @@
 #include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #ifndef __HIP_PLATFORM_AMD__
+#include "comms/prims/core/TimeoutUtils.h"
 #include "comms/utils/CudaRAII.h"
 #endif
 
@@ -1712,6 +1714,131 @@ TEST_F(
     GTEST_SKIP() << "IBGDA transport not available: " << e.what();
   }
 }
+
+#ifndef __HIP_PLATFORM_AMD__
+TEST_F(
+    MultipeerIbgdaTransportTestFixture,
+    WarpProxyQueueBackpressureAndSlotReuseAcross1024Commands) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+
+  constexpr std::size_t numChunks = 1024;
+  constexpr std::size_t maxSignalBytes = 1024;
+  constexpr int pipelineDepth = 16;
+  constexpr std::size_t perChannelSize =
+      static_cast<std::size_t>(pipelineDepth) * maxSignalBytes;
+  constexpr std::size_t nbytes = numChunks * maxSignalBytes;
+  constexpr uint32_t queueDepth = 1;
+  constexpr uint8_t patternBase = 0xA7;
+  constexpr std::size_t patternPeriod = 251;
+  constexpr std::size_t patternChunkStride = 17;
+  static_assert(numChunks % pipelineDepth == 0);
+  static_assert(numChunks / pipelineDepth == 64);
+  static_assert(perChannelSize / pipelineDepth == maxSignalBytes);
+  const bool isSender = globalRank == 0;
+  const int peerRank = isSender ? 1 : 0;
+
+  std::unique_ptr<MultipeerIbgdaTransport> transport;
+  try {
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .perChannelSize = perChannelSize,
+        .max_num_channels = 1,
+        .pipelineDepth = pipelineDepth,
+    };
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, numRanks, bootstrap, config);
+    transport->exchange();
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+
+  auto* peerTransport = transport->getP2pTransportDevice(peerRank);
+  DeviceBuffer dataBuffer(nbytes);
+  DeviceBuffer queueFullCountBuffer(sizeof(uint64_t));
+  auto* queueFullCount = static_cast<uint64_t*>(queueFullCountBuffer.get());
+  const Timeout timeout = makeTimeout(5000, localRank);
+
+  std::vector<uint8_t> expected(nbytes);
+  for (std::size_t i = 0; i < nbytes; ++i) {
+    const std::size_t chunk = i / maxSignalBytes;
+    const std::size_t chunkOffset = i % maxSignalBytes;
+    expected[i] = static_cast<uint8_t>(
+        patternBase +
+        (chunk * patternChunkStride + chunkOffset) % patternPeriod);
+  }
+  if (isSender) {
+    CUDACHECK_TEST(cudaMemcpy(
+        dataBuffer.get(), expected.data(), nbytes, cudaMemcpyHostToDevice));
+  } else {
+    CUDACHECK_TEST(cudaMemset(dataBuffer.get(), 0, nbytes));
+  }
+  CUDACHECK_TEST(cudaMemset(queueFullCount, 0, sizeof(*queueFullCount)));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  if (isSender) {
+    test::testWarpProxySendRecv(
+        peerTransport,
+        dataBuffer.get(),
+        nbytes,
+        maxSignalBytes,
+        /*send=*/true,
+        queueDepth,
+        queueFullCount,
+        timeout.timeout_cycles);
+  }
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  if (!isSender) {
+    test::testWarpProxySendRecv(
+        peerTransport,
+        dataBuffer.get(),
+        nbytes,
+        maxSignalBytes,
+        /*send=*/false,
+        queueDepth,
+        /*queueFullCount=*/nullptr,
+        timeout.timeout_cycles);
+  }
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  if (isSender) {
+    uint64_t hostQueueFullCount = 0;
+    CUDACHECK_TEST(cudaMemcpy(
+        &hostQueueFullCount,
+        queueFullCount,
+        sizeof(hostQueueFullCount),
+        cudaMemcpyDeviceToHost));
+    EXPECT_GT(hostQueueFullCount, 0)
+        << "warp proxy send did not observe command-queue backpressure";
+  }
+
+  if (!isSender) {
+    std::vector<uint8_t> received(nbytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        received.data(), dataBuffer.get(), nbytes, cudaMemcpyDeviceToHost));
+    std::size_t mismatchCount = 0;
+    std::size_t firstMismatch = 0;
+    for (std::size_t i = 0; i < nbytes; ++i) {
+      if (received[i] != expected[i]) {
+        if (mismatchCount == 0) {
+          firstMismatch = i;
+        }
+        ++mismatchCount;
+      }
+    }
+    EXPECT_EQ(mismatchCount, 0)
+        << "warp proxy staging-slot reuse corrupted payload; first mismatch "
+        << "at byte " << firstMismatch << ", expected "
+        << static_cast<int>(expected[firstMismatch]) << ", got "
+        << static_cast<int>(received[firstMismatch]);
+  }
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+#endif
 
 TEST_P(
     MultipeerIbTransportTestFixture,

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -8,6 +8,9 @@
 #include <string>
 
 #include "comms/prims/transport/P2pIbTransportProgressImpl.cuh"
+#ifndef __HIP_PLATFORM_AMD__
+#include "comms/prims/transport/ibgda/IbgdaWarpProxy.cuh"
+#endif
 
 namespace comms::prims::test {
 
@@ -429,6 +432,40 @@ void testTwoCallSendThenRecv(
 }
 
 #ifndef __HIP_PLATFORM_AMD__
+constexpr uint32_t kWarpProxyTestWorkerThreads = 512;
+using WarpProxyTest = IbgdaWarpProxy<kWarpProxyTestWorkerThreads>;
+
+__global__ void __launch_bounds__(WarpProxyTest::kBlockThreads, 1)
+    warpProxySendRecvKernel(
+        P2pIbgdaTransportDevice* transport,
+        void* buffer,
+        std::size_t nbytes,
+        std::size_t maxSignalBytes,
+        bool send,
+        uint32_t queueDepth,
+        uint64_t* queueFullCount,
+        uint64_t timeoutCycles) {
+  Timeout timeout(timeoutCycles);
+  timeout.start();
+  auto block = make_block_group();
+  __shared__ WarpProxyTest::SharedState sharedState;
+  WarpProxyTest::run(
+      sharedState,
+      block,
+      WarpProxyTest::Config{
+          .queueDepth = queueDepth,
+          .queueFullCount = queueFullCount,
+      },
+      timeout,
+      [&](auto& ops) {
+        if (send) {
+          ops.send(*transport, buffer, nbytes, maxSignalBytes);
+        } else {
+          ops.recv(*transport, buffer, nbytes, maxSignalBytes);
+        }
+      });
+}
+
 __global__ void progressSendRecvKernel(
     P2pIbgdaTransportDevice* transport,
     void* buffer,
@@ -663,6 +700,43 @@ __global__ void verifyTransportStagingKernel(
 }
 
 #endif
+
+void testWarpProxySendRecv(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    bool send,
+    uint32_t queueDepth,
+    uint64_t* queueFullCount,
+    uint64_t timeoutCycles) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)buffer;
+  (void)nbytes;
+  (void)maxSignalBytes;
+  (void)send;
+  (void)queueDepth;
+  (void)queueFullCount;
+  (void)timeoutCycles;
+  throw std::runtime_error("warp proxy is NVIDIA-only");
+#else
+  warpProxySendRecvKernel<<<1, WarpProxyTest::kBlockThreads>>>(
+      transport,
+      buffer,
+      nbytes,
+      maxSignalBytes,
+      send,
+      queueDepth,
+      queueFullCount,
+      timeoutCycles);
+  const cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+#endif
+}
 
 void testProgressSendRecv(
     P2pIbgdaTransportDevice* transport,

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -201,6 +201,19 @@ void testTwoCallSendThenRecv(
     int blockSize);
 
 /**
+ * Test kernel: Warp-proxy send or recv with queue-full observation.
+ */
+void testWarpProxySendRecv(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    bool send,
+    uint32_t queueDepth,
+    uint64_t* queueFullCount,
+    uint64_t timeoutCycles);
+
+/**
  * Test kernel: Resumable pipelined send or recv progress loop.
  */
 void testProgressSendRecv(

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -538,6 +538,11 @@ class MultiPeerIbTransportBase {
     return numNics_;
   }
 
+  /** @return Configured send/recv staging pipeline depth. */
+  int pipelineDepth() const {
+    return config_.pipelineDepth;
+  }
+
   /**
    * registerBuffer - Register a user GPU buffer for RDMA, refcounted per
    * allocation. Containment fast-path returns cached per-NIC lkeys without any

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -218,6 +218,13 @@ std::optional<int> MultiPeerTransport::ibgda_max_groups() const {
   return ibgdaTransport_->maxGroups();
 }
 
+std::optional<int> MultiPeerTransport::ibgda_pipeline_depth() const {
+  if (!ibgdaTransport_) {
+    return std::nullopt;
+  }
+  return ibgdaTransport_->pipelineDepth();
+}
+
 void MultiPeerTransport::setExternalNvlDataBuffers(
     ExternalStagingBuffers externalStagingBuffers) {
   if (nvlTransport_) {

--- a/comms/prims/transport/MultiPeerTransport.h
+++ b/comms/prims/transport/MultiPeerTransport.h
@@ -259,6 +259,11 @@ class MultiPeerTransport {
   std::optional<int> ibgda_max_groups() const;
 
   /*
+   * Resolved staging pipeline depth of the configured IBGDA transport.
+   */
+  std::optional<int> ibgda_pipeline_depth() const;
+
+  /*
    * Every requested edge must be requested by both endpoint ranks in the same
    * connect round. Peer-vector order may differ between ranks.
    */

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -447,4 +447,61 @@ struct P2pIbTransportDevice {
 static_assert(std::is_standard_layout_v<P2pIbTransportDevice>);
 static_assert(std::is_trivially_copyable_v<P2pIbTransportDevice>);
 
+template <uint32_t WorkerThreads>
+class BlockingIbOps {
+ public:
+  static constexpr uint32_t kWorkerThreads = WorkerThreads;
+
+  __device__ BlockingIbOps(ThreadGroup workers, const Timeout& timeout)
+      : workers_(workers), timeout_(timeout) {}
+
+  __device__ __forceinline__ ThreadGroup& group() {
+    return workers_;
+  }
+
+  __device__ __forceinline__ void sync() {
+    workers_.sync();
+  }
+
+  __device__ __forceinline__ void drain() {}
+
+  template <typename CopyOp = Memcpy, typename Transport, typename... Args>
+  __device__ __forceinline__ void send(
+      Transport& transport,
+      const void* src,
+      std::size_t nbytes,
+      std::size_t maxSignalBytes,
+      Args... args) {
+    transport.template send<CopyOp>(
+        workers_, src, nbytes, maxSignalBytes, timeout_, args...);
+  }
+
+  template <typename CopyOp = Memcpy, typename Transport, typename... Args>
+  __device__ __forceinline__ void recv(
+      Transport& transport,
+      void* dst,
+      std::size_t nbytes,
+      std::size_t maxSignalBytes,
+      Args... args) {
+    transport.template recv<CopyOp>(
+        workers_, dst, nbytes, maxSignalBytes, timeout_, args...);
+  }
+
+  template <typename CopyOp = Memcpy, typename Transport, typename... Args>
+  __device__ __forceinline__ void forward(
+      Transport& prev,
+      void* dst,
+      Transport& next,
+      std::size_t nbytes,
+      std::size_t maxSignalBytes,
+      Args... args) {
+    prev.template forward<CopyOp>(
+        workers_, dst, next, nbytes, maxSignalBytes, timeout_, args...);
+  }
+
+ private:
+  ThreadGroup workers_;
+  Timeout timeout_;
+};
+
 } // namespace comms::prims

--- a/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
@@ -783,6 +783,7 @@ __device__ __forceinline__ void consumeRecvBuf(
     uint64_t flagVal,
     uint64_t waitCredit,
     const Timeout& timeout,
+    const PipesTraceAllReduceContext* traceContext,
     Args... args) {
   using P = LlxPacket<4, 4>;
   static_assert(
@@ -791,6 +792,7 @@ __device__ __forceinline__ void consumeRecvBuf(
       "provides one. A reduce/convert CopyOp must supply its own -- a plain "
       "contiguous copy cannot address the data+flag interleaved staging");
 #if PIPES_IS_DEVICE_COMPILE
+  (void)traceContext;
   (void)transport;
   (void)localDataReady;
   (void)waitCredit;
@@ -833,6 +835,7 @@ __device__ __forceinline__ void consumeRecvBuf(
   (void)flagVal;
   (void)waitCredit;
   (void)timeout;
+  (void)traceContext;
   ((void)args, ...);
 #endif
 }
@@ -840,11 +843,13 @@ __device__ __forceinline__ void consumeRecvBuf(
 template <
     typename Transport,
     typename CopyOp = Memcpy,
+    typename IbOps = void,
     typename Proto = protocol::Simple,
     typename... Args>
 __device__ __forceinline__ void send_impl(
     Transport& transport,
     ThreadGroup& group,
+    IbOps* ibOps,
     const void* __restrict__ src,
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
@@ -861,15 +866,23 @@ __device__ __forceinline__ void send_impl(
       "variable-size CopyOps (e.g. AnsCompress) are supported on "
       "protocol::Simple only; the compressed loop is not behind the "
       "prepareSendBuf/consumeRecvBuf seam.");
+  static_assert(
+      std::is_void_v<IbOps> || !detail::copyop_variable_size_v<CopyOp>,
+      "IB operation policies support fixed-size CopyOps only");
+  static_assert(
+      std::is_void_v<IbOps> || std::is_same_v<Proto, protocol::Simple>,
+      "IB operation policies support protocol::Simple only");
 #if !PIPES_IS_DEVICE_COMPILE
   (void)transport;
   (void)group;
+  (void)ibOps;
   (void)src;
   (void)nbytes;
   (void)max_signal_bytes;
   (void)timeout;
   (void)traceContext;
 #else
+  (void)ibOps;
   if (nbytes == 0) {
     return;
   }
@@ -1161,7 +1174,13 @@ __device__ __forceinline__ void send_impl(
             static_cast<uint8_t>(kPipesTraceQpLaneMask),
             bytesThis);
       }
-      prepare_send_slot<Proto>(transport, group, slot, pipelineCycle, timeout);
+      if constexpr (std::is_void_v<IbOps>) {
+        prepare_send_slot<Proto>(
+            transport, group, slot, pipelineCycle, timeout);
+      } else {
+        ibOps->prepare_send_slot(
+            transport, group, slot, pipelineCycle, timeout);
+      }
       if (group.is_leader()) {
         trace_allreduce_event(
             traceContext,
@@ -1178,7 +1197,7 @@ __device__ __forceinline__ void send_impl(
             static_cast<uint8_t>(kPipesTraceQpLaneMask),
             validBytes);
       }
-      const SendSignal sig = prepareSendBuf<CopyOp>(
+      [[maybe_unused]] const SendSignal sig = prepareSendBuf<CopyOp>(
           Proto{},
           group,
           channelLayout.sendStagingPtr + stagingOff,
@@ -1198,89 +1217,109 @@ __device__ __forceinline__ void send_impl(
             validBytes);
       }
 
-      // (3) Backpressure: wait for receiver to free this byte range's
-      //     recvStaging offset. Symmetric with DATA_READY.
-      if (protocolStreamEnd > pipelineBytesWire) {
-        if (group.is_leader()) {
-          trace_allreduce_event(
-              traceContext,
-              PipesTraceEventType::kAllReduceRemoteSlotFreeWaitBegin,
-              static_cast<uint8_t>(kPipesTraceQpLaneMask),
-              protocolBytesThis);
+      const uint64_t slotFreeExpected = protocolStreamEnd > pipelineBytesWire
+          ? protocolStreamEnd - pipelineBytesWire
+          : 0;
+      if constexpr (std::is_void_v<IbOps>) {
+        // (3) Backpressure: wait for receiver to free this byte range's
+        //     recvStaging offset. Symmetric with DATA_READY.
+        if (slotFreeExpected != 0) {
+          if (group.is_leader()) {
+            trace_allreduce_event(
+                traceContext,
+                PipesTraceEventType::kAllReduceRemoteSlotFreeWaitBegin,
+                static_cast<uint8_t>(kPipesTraceQpLaneMask),
+                protocolBytesThis);
+          }
+          transport.wait_signal(
+              group, localSlotFree, slotFreeExpected, timeout);
+          if (group.is_leader()) {
+            trace_allreduce_event(
+                traceContext,
+                PipesTraceEventType::kAllReduceRemoteSlotFreeWaitEnd,
+                static_cast<uint8_t>(kPipesTraceQpLaneMask),
+                protocolBytesThis);
+          }
         }
-        transport.wait_signal(
-            group,
-            localSlotFree,
-            protocolStreamEnd - pipelineBytesWire,
-            timeout);
-        if (group.is_leader()) {
-          trace_allreduce_event(
-              traceContext,
-              PipesTraceEventType::kAllReduceRemoteSlotFreeWaitEnd,
-              static_cast<uint8_t>(kPipesTraceQpLaneMask),
-              protocolBytesThis);
-        }
-      }
 
-      // (4) Leader-only single-WQE RDMA put with fused signal.
-      if (group.is_leader()) {
-        trace_allreduce_event(
-            traceContext,
-            PipesTraceEventType::kAllReduceSendSyncBegin,
-            static_cast<uint8_t>(kPipesTraceQpLaneMask),
-            bytesThis);
-      }
-      group.sync();
-      if (group.is_leader()) {
-        __threadfence_system();
-        trace_allreduce_event(
-            traceContext,
-            PipesTraceEventType::kAllReduceSendSyncEnd,
-            static_cast<uint8_t>(kPipesTraceQpLaneMask),
-            bytesThis);
-        const uint32_t numLanes = static_cast<uint32_t>(channelLayout.numLanes);
-        const uint8_t qpLane = static_cast<uint8_t>(
-            numLanes == 0 ? 0 : localChannel.sendQp.cursor % numLanes);
-        ThreadGroup solo{
-            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
-        trace_allreduce_event(
-            traceContext,
-            PipesTraceEventType::kAllReduceWqeSubmitBegin,
-            qpLane,
-            bytesThis);
-        const auto completion = transport.put(
-            solo,
-            channelLayout.sendStagingBuf.subBuffer(stagingOff),
-            remoteChannel.recvStaging.subBuffer(stagingOff),
-            bytesThis,
-            sig.buf,
-            sig.val,
-            /*counterBuf=*/{},
-            /*counterVal=*/0,
-            /*signalPerLane=*/true);
-        trace_allreduce_event(
-            traceContext,
-            PipesTraceEventType::kAllReduceWqeSubmitEnd,
-            qpLane,
-            bytesThis);
-        trace_allreduce_event(
-            traceContext,
-            PipesTraceEventType::kAllReduceBookkeepingBegin,
-            qpLane,
-            protocolBytesThis);
-        record_send_completion<Proto>(
+        // (4) Leader-only single-WQE RDMA put with fused signal.
+        if (group.is_leader()) {
+          trace_allreduce_event(
+              traceContext,
+              PipesTraceEventType::kAllReduceSendSyncBegin,
+              static_cast<uint8_t>(kPipesTraceQpLaneMask),
+              bytesThis);
+        }
+        group.sync();
+        if (group.is_leader()) {
+          __threadfence_system();
+          trace_allreduce_event(
+              traceContext,
+              PipesTraceEventType::kAllReduceSendSyncEnd,
+              static_cast<uint8_t>(kPipesTraceQpLaneMask),
+              bytesThis);
+          const uint32_t numLanes =
+              static_cast<uint32_t>(channelLayout.numLanes);
+          const uint8_t qpLane = static_cast<uint8_t>(
+              numLanes == 0 ? 0 : localChannel.sendQp.cursor % numLanes);
+          ThreadGroup solo{
+              0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+          trace_allreduce_event(
+              traceContext,
+              PipesTraceEventType::kAllReduceWqeSubmitBegin,
+              qpLane,
+              bytesThis);
+          const auto completion = transport.put(
+              solo,
+              channelLayout.sendStagingBuf.subBuffer(stagingOff),
+              remoteChannel.recvStaging.subBuffer(stagingOff),
+              bytesThis,
+              sig.buf,
+              sig.val,
+              /*counterBuf=*/{},
+              /*counterVal=*/0,
+              /*signalPerLane=*/true);
+          trace_allreduce_event(
+              traceContext,
+              PipesTraceEventType::kAllReduceWqeSubmitEnd,
+              qpLane,
+              bytesThis);
+          trace_allreduce_event(
+              traceContext,
+              PipesTraceEventType::kAllReduceBookkeepingBegin,
+              qpLane,
+              protocolBytesThis);
+          record_send_completion<Proto>(
+              transport,
+              static_cast<uint32_t>(groupId),
+              slot,
+              pipelineCycle,
+              completion);
+          trace_allreduce_event(
+              traceContext,
+              PipesTraceEventType::kAllReduceBookkeepingEnd,
+              qpLane,
+              protocolBytesThis);
+        }
+        group.sync();
+      } else {
+        if (group.is_leader()) {
+          __threadfence_system();
+        }
+        group.sync();
+        ibOps->submit_send(
             transport,
-            static_cast<uint32_t>(groupId),
-            slot,
+            group,
+            channelLayout.sendStagingBuf.subBuffer(stagingOff),
+            stagingOff,
+            bytesThis,
+            protocolBytesThis,
+            slotFreeExpected,
+            static_cast<uint32_t>(slot),
             pipelineCycle,
-            completion);
-        trace_allreduce_event(
-            traceContext,
-            PipesTraceEventType::kAllReduceBookkeepingEnd,
-            qpLane,
-            protocolBytesThis);
+            /*requiredRecvCredit=*/0,
+            timeout);
       }
-      group.sync();
       dataOff += payloadBytes;
     }
 
@@ -1309,9 +1348,10 @@ __device__ __forceinline__ void send(
     std::size_t max_signal_bytes = 0,
     const Timeout& timeout = Timeout(),
     Args... args) {
-  send_impl<Transport, CopyOp, Proto>(
+  send_impl<Transport, CopyOp, void, Proto>(
       transport,
       group,
+      nullptr,
       src,
       nbytes,
       max_signal_bytes,
@@ -1334,9 +1374,10 @@ __device__ __forceinline__ void send_with_fine_trace(
     const Timeout& timeout,
     const PipesTraceAllReduceContext& traceContext,
     Args... args) {
-  send_impl<Transport, CopyOp, Proto>(
+  send_impl<Transport, CopyOp, void, Proto>(
       transport,
       group,
+      nullptr,
       src,
       nbytes,
       max_signal_bytes,
@@ -1375,11 +1416,13 @@ __device__ __forceinline__ void send_with_fine_trace(
 template <
     typename Transport,
     typename CopyOp = Memcpy,
+    typename IbOps = void,
     typename Proto = protocol::Simple,
     typename... Args>
 __device__ __forceinline__ void recv_impl(
     Transport& transport,
     ThreadGroup& group,
+    IbOps* ibOps,
     void* __restrict__ dst,
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
@@ -1396,15 +1439,23 @@ __device__ __forceinline__ void recv_impl(
       "variable-size CopyOps (e.g. AnsCompress) are supported on "
       "protocol::Simple only; the compressed loop is not behind the "
       "prepareSendBuf/consumeRecvBuf seam.");
+  static_assert(
+      std::is_void_v<IbOps> || !detail::copyop_variable_size_v<CopyOp>,
+      "IB operation policies support fixed-size CopyOps only");
+  static_assert(
+      std::is_void_v<IbOps> || std::is_same_v<Proto, protocol::Simple>,
+      "IB operation policies support protocol::Simple only");
 #if !PIPES_IS_DEVICE_COMPILE
   (void)transport;
   (void)group;
+  (void)ibOps;
   (void)dst;
   (void)nbytes;
   (void)max_signal_bytes;
   (void)timeout;
   (void)traceContext;
 #else
+  (void)ibOps;
   if (nbytes == 0) {
     return;
   }
@@ -1608,47 +1659,70 @@ __device__ __forceinline__ void recv_impl(
           Proto::wire_bytes(chunkOff);
       // flagVal (a per-ring-pass counter) for this chunk's slot; LL stamps it
       // into every packet flag.
-      const uint64_t flagVal = streamPayload / pipelineBytesPayload + 1;
+      [[maybe_unused]] const uint64_t flagVal =
+          streamPayload / pipelineBytesPayload + 1;
 
-      // (1)+(2) Wait for the chunk to be ready (DATA_READY signal or, for LL,
-      //         the inline flag) and cooperatively copy recvStaging -> dst.
-      const uint32_t numLanes = static_cast<uint32_t>(channelLayout.numLanes);
-      const uint8_t qpLane = static_cast<uint8_t>(
-          numLanes == 0 ? 0 : localChannel.recvDataReadyLaneCursor % numLanes);
-      consumeRecvBuf<CopyOp>(
-          Proto{},
-          transport,
-          group,
-          localChannel,
-          localDataReady,
-          static_cast<char*>(dst) + dataOff,
-          channelLayout.recvStagingPtr + stagingOff,
-          payloadBytes,
-          nbytes,
-          dataOff,
-          flagVal,
-          protocolBytesThis,
-          timeout,
-          traceContext,
-          args...);
-
-      if (group.is_leader()) {
-        trace_allreduce_event(
+      if constexpr (std::is_void_v<IbOps>) {
+        // (1)+(2) Wait for the chunk to be ready (DATA_READY signal or, for LL,
+        //         the inline flag) and cooperatively copy recvStaging -> dst.
+        const uint32_t numLanes = static_cast<uint32_t>(channelLayout.numLanes);
+        const uint8_t qpLane = static_cast<uint8_t>(
+            numLanes == 0 ? 0
+                          : localChannel.recvDataReadyLaneCursor % numLanes);
+        consumeRecvBuf<CopyOp>(
+            Proto{},
+            transport,
+            group,
+            localChannel,
+            localDataReady,
+            static_cast<char*>(dst) + dataOff,
+            channelLayout.recvStagingPtr + stagingOff,
+            payloadBytes,
+            nbytes,
+            dataOff,
+            flagVal,
+            protocolBytesThis,
+            timeout,
             traceContext,
-            PipesTraceEventType::kAllReduceBookkeepingBegin,
-            qpLane,
-            protocolBytesThis);
+            args...);
+
+        if (group.is_leader()) {
+          trace_allreduce_event(
+              traceContext,
+              PipesTraceEventType::kAllReduceBookkeepingBegin,
+              qpLane,
+              protocolBytesThis);
+        }
+        transport.signal(
+            group,
+            remoteChannel.slotFree,
+            protocolBytesThis,
+            IbDirection::Recv);
+        if (group.is_leader()) {
+          trace_allreduce_event(
+              traceContext,
+              PipesTraceEventType::kAllReduceBookkeepingEnd,
+              qpLane,
+              protocolBytesThis);
+        }
+      } else {
+        const uint64_t recvToken =
+            ibOps->wait_recv(transport, group, protocolBytesThis, timeout);
+        const std::size_t validBytes =
+            valid_payload_bytes(dataOff, payloadBytes, nbytes);
+        if (validBytes > 0) {
+          CopyOp::recv(
+              static_cast<char*>(dst) + dataOff,
+              channelLayout.recvStagingPtr + stagingOff,
+              validBytes,
+              group,
+              dataOff,
+              args...);
+        }
+        group.sync();
+        ibOps->publish_recv(transport, group, protocolBytesThis, recvToken);
       }
-      transport.signal(
-          group, remoteChannel.slotFree, protocolBytesThis, IbDirection::Recv);
       dataOff += payloadBytes;
-      if (group.is_leader()) {
-        trace_allreduce_event(
-            traceContext,
-            PipesTraceEventType::kAllReduceBookkeepingEnd,
-            qpLane,
-            protocolBytesThis);
-      }
     }
 
     if (group.is_leader()) {
@@ -1676,9 +1750,10 @@ __device__ __forceinline__ void recv(
     std::size_t max_signal_bytes = 0,
     const Timeout& timeout = Timeout(),
     Args... args) {
-  recv_impl<Transport, CopyOp, Proto>(
+  recv_impl<Transport, CopyOp, void, Proto>(
       transport,
       group,
+      nullptr,
       dst,
       nbytes,
       max_signal_bytes,
@@ -1701,9 +1776,10 @@ __device__ __forceinline__ void recv_with_fine_trace(
     const Timeout& timeout,
     const PipesTraceAllReduceContext& traceContext,
     Args... args) {
-  recv_impl<Transport, CopyOp, Proto>(
+  recv_impl<Transport, CopyOp, void, Proto>(
       transport,
       group,
+      nullptr,
       dst,
       nbytes,
       max_signal_bytes,
@@ -1767,11 +1843,13 @@ __device__ __forceinline__ void recv_with_fine_trace(
 template <
     typename CopyOp = Memcpy,
     typename Transport,
+    typename IbOps = void,
     typename Proto = protocol::Simple,
     typename... Args>
 __device__ __forceinline__ void forward_impl(
     Transport& transport,
     ThreadGroup& group,
+    IbOps* ibOps,
     void* __restrict__ dst,
     Transport& fwdTransport,
     std::size_t nbytes,
@@ -1780,12 +1858,19 @@ __device__ __forceinline__ void forward_impl(
     const PipesTraceAllReduceContext* recvTraceContext = nullptr,
     const PipesTraceAllReduceContext* sendTraceContext = nullptr,
     Args... args) {
+  static_assert(
+      std::is_void_v<IbOps> || !detail::copyop_variable_size_v<CopyOp>,
+      "IB operation policies support fixed-size CopyOps only");
+  static_assert(
+      std::is_void_v<IbOps> || std::is_same_v<Proto, protocol::Simple>,
+      "IB operation policies support protocol::Simple only");
 #if PIPES_IS_DEVICE_COMPILE
 #ifdef __HIP_PLATFORM_AMD__
   static_assert(
       sizeof(CopyOp) == 0,
       "detail::forward() requires NVIDIA GPU (DOCA/IBGDA)");
 #endif
+  (void)ibOps;
   if (nbytes == 0) {
     return;
   }
@@ -1900,122 +1985,165 @@ __device__ __forceinline__ void forward_impl(
     const uint64_t fwdPipelineCycle =
         fwdStreamPayload / fwdGeo.pipelineBytesPayload;
 
-    // (1) prepareForwardBuf: fwd slot-reuse backpressure + recv-side readiness
-    //     + fused transform recvStaging -> dst + fwdStaging, returning the
-    //     relay SendSignal for the put. Tag-dispatched on Proto.
-    const SendSignal sig = prepareForwardBuf<CopyOp>(
-        Proto{},
-        transport,
-        fwdTransport,
-        group,
-        recvLocalChannel,
-        recvDataReady,
-        dst ? static_cast<char*>(dst) + dataOff : nullptr,
-        fwdChannelLayout.sendStagingPtr + fwdStagingOff,
-        channelLayout.recvStagingPtr + recvStagingOff,
-        payloadBytes,
-        nbytes,
-        dataOff,
-        recvProtocolBytesThis,
-        fwdRemoteChannel,
-        fwdProtocolBytesThis,
-        static_cast<uint32_t>(fwdSlot),
-        fwdPipelineCycle,
-        timeout,
-        recvTraceContext,
-        sendTraceContext,
-        args...);
-
-    transport.signal(
-        group,
-        recvRemoteChannel.slotFree,
-        recvProtocolBytesThis,
-        IbDirection::Recv);
-
-    // (5) Wait for fwd receiver's SLOT_FREE (backpressure on fwd's
-    //     recvStaging).
-    if (fwdProtocolStreamEnd > fwdGeo.pipelineBytesWire) {
-      if (group.is_leader()) {
-        trace_allreduce_event(
-            sendTraceContext,
-            PipesTraceEventType::kAllReduceRemoteSlotFreeWaitBegin,
-            static_cast<uint8_t>(kPipesTraceQpLaneMask),
-            fwdProtocolBytesThis);
-      }
-      fwdTransport.wait_signal(
-          group,
-          fwdSlotFree,
-          fwdProtocolStreamEnd - fwdGeo.pipelineBytesWire,
-          timeout);
-      if (group.is_leader()) {
-        trace_allreduce_event(
-            sendTraceContext,
-            PipesTraceEventType::kAllReduceRemoteSlotFreeWaitEnd,
-            static_cast<uint8_t>(kPipesTraceQpLaneMask),
-            fwdProtocolBytesThis);
-      }
-    }
-
-    // (6) Leader-only RDMA put via the forwarding transport.
-    if (group.is_leader()) {
-      trace_allreduce_event(
-          sendTraceContext,
-          PipesTraceEventType::kAllReduceSendSyncBegin,
-          static_cast<uint8_t>(kPipesTraceQpLaneMask),
-          bytesThis);
-    }
-    group.sync();
-    if (group.is_leader()) {
-      __threadfence_system();
-      trace_allreduce_event(
-          sendTraceContext,
-          PipesTraceEventType::kAllReduceSendSyncEnd,
-          static_cast<uint8_t>(kPipesTraceQpLaneMask),
-          bytesThis);
-      const uint32_t numLanes =
-          static_cast<uint32_t>(fwdChannelLayout.numLanes);
-      const uint8_t qpLane = static_cast<uint8_t>(
-          numLanes == 0 ? 0 : fwdLocalChannel.sendQp.cursor % numLanes);
-      ThreadGroup solo{
-          0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
-      trace_allreduce_event(
-          sendTraceContext,
-          PipesTraceEventType::kAllReduceWqeSubmitBegin,
-          qpLane,
-          bytesThis);
-      const auto completion = fwdTransport.put(
-          solo,
-          fwdChannelLayout.sendStagingBuf.subBuffer(fwdStagingOff),
-          fwdRemoteChannel.recvStaging.subBuffer(fwdStagingOff),
-          bytesThis,
-          sig.buf,
-          sig.val,
-          /*counterBuf=*/{},
-          /*counterVal=*/0,
-          /*signalPerLane=*/true);
-      trace_allreduce_event(
-          sendTraceContext,
-          PipesTraceEventType::kAllReduceWqeSubmitEnd,
-          qpLane,
-          bytesThis);
-      trace_allreduce_event(
-          sendTraceContext,
-          PipesTraceEventType::kAllReduceBookkeepingBegin,
-          qpLane,
-          fwdProtocolBytesThis);
-      record_send_completion<Proto>(
+    const uint64_t fwdSlotFreeExpected =
+        fwdProtocolStreamEnd > fwdGeo.pipelineBytesWire
+        ? fwdProtocolStreamEnd - fwdGeo.pipelineBytesWire
+        : 0;
+    if constexpr (std::is_void_v<IbOps>) {
+      // (1) prepareForwardBuf: fwd slot-reuse backpressure + recv-side
+      // readiness
+      //     + fused transform recvStaging -> dst + fwdStaging, returning the
+      //     relay SendSignal for the put. Tag-dispatched on Proto.
+      const SendSignal sig = prepareForwardBuf<CopyOp>(
+          Proto{},
+          transport,
           fwdTransport,
-          static_cast<uint32_t>(groupId),
-          fwdSlot,
+          group,
+          recvLocalChannel,
+          recvDataReady,
+          dst ? static_cast<char*>(dst) + dataOff : nullptr,
+          fwdChannelLayout.sendStagingPtr + fwdStagingOff,
+          channelLayout.recvStagingPtr + recvStagingOff,
+          payloadBytes,
+          nbytes,
+          dataOff,
+          recvProtocolBytesThis,
+          fwdRemoteChannel,
+          fwdProtocolBytesThis,
+          static_cast<uint32_t>(fwdSlot),
           fwdPipelineCycle,
-          completion);
-      trace_allreduce_event(
+          timeout,
+          recvTraceContext,
           sendTraceContext,
-          PipesTraceEventType::kAllReduceBookkeepingEnd,
-          qpLane,
-          fwdProtocolBytesThis);
+          args...);
+
+      transport.signal(
+          group,
+          recvRemoteChannel.slotFree,
+          recvProtocolBytesThis,
+          IbDirection::Recv);
+
+      // (5) Wait for fwd receiver's SLOT_FREE (backpressure on fwd's
+      //     recvStaging).
+      if (fwdSlotFreeExpected != 0) {
+        if (group.is_leader()) {
+          trace_allreduce_event(
+              sendTraceContext,
+              PipesTraceEventType::kAllReduceRemoteSlotFreeWaitBegin,
+              static_cast<uint8_t>(kPipesTraceQpLaneMask),
+              fwdProtocolBytesThis);
+        }
+        fwdTransport.wait_signal(
+            group, fwdSlotFree, fwdSlotFreeExpected, timeout);
+        if (group.is_leader()) {
+          trace_allreduce_event(
+              sendTraceContext,
+              PipesTraceEventType::kAllReduceRemoteSlotFreeWaitEnd,
+              static_cast<uint8_t>(kPipesTraceQpLaneMask),
+              fwdProtocolBytesThis);
+        }
+      }
+
+      // (6) Leader-only RDMA put via the forwarding transport.
+      if (group.is_leader()) {
+        trace_allreduce_event(
+            sendTraceContext,
+            PipesTraceEventType::kAllReduceSendSyncBegin,
+            static_cast<uint8_t>(kPipesTraceQpLaneMask),
+            bytesThis);
+      }
+      group.sync();
+      if (group.is_leader()) {
+        __threadfence_system();
+        trace_allreduce_event(
+            sendTraceContext,
+            PipesTraceEventType::kAllReduceSendSyncEnd,
+            static_cast<uint8_t>(kPipesTraceQpLaneMask),
+            bytesThis);
+        const uint32_t numLanes =
+            static_cast<uint32_t>(fwdChannelLayout.numLanes);
+        const uint8_t qpLane = static_cast<uint8_t>(
+            numLanes == 0 ? 0 : fwdLocalChannel.sendQp.cursor % numLanes);
+        ThreadGroup solo{
+            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+        trace_allreduce_event(
+            sendTraceContext,
+            PipesTraceEventType::kAllReduceWqeSubmitBegin,
+            qpLane,
+            bytesThis);
+        const auto completion = fwdTransport.put(
+            solo,
+            fwdChannelLayout.sendStagingBuf.subBuffer(fwdStagingOff),
+            fwdRemoteChannel.recvStaging.subBuffer(fwdStagingOff),
+            bytesThis,
+            sig.buf,
+            sig.val,
+            /*counterBuf=*/{},
+            /*counterVal=*/0,
+            /*signalPerLane=*/true);
+        trace_allreduce_event(
+            sendTraceContext,
+            PipesTraceEventType::kAllReduceWqeSubmitEnd,
+            qpLane,
+            bytesThis);
+        trace_allreduce_event(
+            sendTraceContext,
+            PipesTraceEventType::kAllReduceBookkeepingBegin,
+            qpLane,
+            fwdProtocolBytesThis);
+        record_send_completion<Proto>(
+            fwdTransport,
+            static_cast<uint32_t>(groupId),
+            fwdSlot,
+            fwdPipelineCycle,
+            completion);
+        trace_allreduce_event(
+            sendTraceContext,
+            PipesTraceEventType::kAllReduceBookkeepingEnd,
+            qpLane,
+            fwdProtocolBytesThis);
+      }
+      group.sync();
+    } else {
+      const uint64_t recvToken =
+          ibOps->wait_recv(transport, group, recvProtocolBytesThis, timeout);
+      ibOps->prepare_send_slot(
+          fwdTransport,
+          group,
+          static_cast<uint32_t>(fwdSlot),
+          fwdPipelineCycle,
+          timeout);
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, payloadBytes, nbytes);
+      if (validBytes > 0) {
+        CopyOp::forward(
+            dst ? static_cast<char*>(dst) + dataOff : nullptr,
+            fwdChannelLayout.sendStagingPtr + fwdStagingOff,
+            channelLayout.recvStagingPtr + recvStagingOff,
+            validBytes,
+            group,
+            dataOff,
+            args...);
+      }
+      group.sync();
+      if (group.is_leader()) {
+        __threadfence_system();
+      }
+      group.sync();
+      ibOps->publish_recv(transport, group, recvProtocolBytesThis, recvToken);
+      ibOps->submit_send(
+          fwdTransport,
+          group,
+          fwdChannelLayout.sendStagingBuf.subBuffer(fwdStagingOff),
+          fwdStagingOff,
+          bytesThis,
+          fwdProtocolBytesThis,
+          fwdSlotFreeExpected,
+          static_cast<uint32_t>(fwdSlot),
+          fwdPipelineCycle,
+          recvToken + 1,
+          timeout);
     }
-    group.sync();
     dataOff += payloadBytes;
   }
 
@@ -2038,6 +2166,7 @@ __device__ __forceinline__ void forward_impl(
 #else
   (void)transport;
   (void)group;
+  (void)ibOps;
   (void)dst;
   (void)fwdTransport;
   (void)nbytes;
@@ -2062,9 +2191,10 @@ __device__ __forceinline__ void forward(
     std::size_t max_signal_bytes = 0,
     const Timeout& timeout = Timeout(),
     Args... args) {
-  forward_impl<CopyOp, Transport, Proto>(
+  forward_impl<CopyOp, Transport, void, Proto>(
       transport,
       group,
+      nullptr,
       dst,
       fwdTransport,
       nbytes,
@@ -2091,9 +2221,10 @@ __device__ __forceinline__ void forward_with_fine_trace(
     const PipesTraceAllReduceContext& recvTraceContext,
     const PipesTraceAllReduceContext& sendTraceContext,
     Args... args) {
-  forward_impl<CopyOp, Transport, Proto>(
+  forward_impl<CopyOp, Transport, void, Proto>(
       transport,
       group,
+      nullptr,
       dst,
       fwdTransport,
       nbytes,
@@ -2358,6 +2489,28 @@ __device__ __forceinline__ void record_send_completion(
   (void)generation;
   (void)ticket;
 #endif
+}
+
+template <typename Transport>
+__device__ __forceinline__ void prepare_send_slot(
+    Transport& transport,
+    ThreadGroup& group,
+    uint32_t slotId,
+    uint64_t generation,
+    const Timeout& timeout) {
+  prepare_send_slot<protocol::Simple>(
+      transport, group, slotId, generation, timeout);
+}
+
+template <typename Transport>
+__device__ __forceinline__ void record_send_completion(
+    Transport& transport,
+    uint32_t channelId,
+    uint32_t slotId,
+    uint64_t generation,
+    const IbLocalCompletionTicket& ticket) {
+  record_send_completion<protocol::Simple>(
+      transport, channelId, slotId, generation, ticket);
 }
 } // namespace detail
 

--- a/comms/prims/transport/ibgda/IbgdaWarpProxy.cuh
+++ b/comms/prims/transport/ibgda/IbgdaWarpProxy.cuh
@@ -1,0 +1,773 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+namespace comms::prims {
+
+inline constexpr uint32_t kIbgdaWarpProxyMaxPipelineDepth = 16;
+inline constexpr uint32_t kIbgdaWarpProxyQueueCapacity = 16;
+
+inline constexpr bool isIbgdaWarpProxyPipelineDepthSupported(int depth) {
+  return depth > 0 &&
+      depth <= static_cast<int>(kIbgdaWarpProxyMaxPipelineDepth);
+}
+
+} // namespace comms::prims
+
+#if defined(__CUDACC__) && !defined(__HIP_PLATFORM_AMD__)
+
+#include <cuda/atomic>
+
+#include <cstddef>
+
+#include "comms/prims/core/MemcpyCopyOp.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/core/Timeout.cuh"
+#include "comms/prims/transport/P2pIbTransportProgressImpl.cuh"
+#include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
+
+namespace comms::prims {
+
+/**
+ * Runs fixed-size IBGDA send/recv work with one trailing service warp.
+ *
+ * Workers own staging copies and staging-slot completion waits. The service
+ * warp owns remote readiness polling, WQE posting, ticket publication, and
+ * receive credits. A run exclusively owns every (transport, channel) passed
+ * through Ops until run() returns; transport objects must have shared or global
+ * lifetime. Ops calls may return after work is queued. run() returns after
+ * staged sends are posted and receive credits are issued. workerFn must use
+ * Ops::group() for synchronization and issue Ops calls collectively from that
+ * single producer group; block-wide barriers and concurrent subgroup issuers
+ * are unsupported. Fused forwarding releases each upstream receive credit
+ * before its dependent downstream send becomes eligible for posting.
+ */
+template <
+    uint32_t WorkerThreads,
+    uint32_t MaxPipelineDepth = kIbgdaWarpProxyMaxPipelineDepth>
+class IbgdaWarpProxy {
+ private:
+  static constexpr uint32_t kPipelineSlotCapacity = MaxPipelineDepth;
+  static constexpr uint32_t kQueueCapacity = kIbgdaWarpProxyQueueCapacity;
+  // Barrier 0 is reserved for full-block synchronization in this kernel.
+  static constexpr uint32_t kWorkerNamedBarrierId = 1;
+
+  static_assert(WorkerThreads > 0);
+  static_assert(MaxPipelineDepth > 0);
+  static_assert(WorkerThreads % comms::device::kWarpSize == 0);
+  static_assert(
+      WorkerThreads + comms::device::kWarpSize <= 1024,
+      "IbgdaWarpProxy exceeds the CUDA threads-per-block limit");
+
+  static constexpr uint32_t kServiceThreads = comms::device::kWarpSize;
+  static constexpr uint64_t kInvalidSequence = ~uint64_t{0};
+
+  struct SendCommand {
+    P2pIbgdaTransportDevice* transport;
+    IbgdaLocalBuffer source;
+    uint64_t remoteOffset;
+    uint64_t bytes;
+    uint64_t protocolBytes;
+    uint64_t slotFreeExpected;
+    uint64_t generation;
+    uint64_t requiredRecvCredit;
+    uint32_t channel;
+    uint32_t slot;
+  };
+
+  struct RecvCommand {
+    P2pIbgdaTransportDevice* transport;
+    uint64_t protocolBytes;
+    uint32_t channel;
+  };
+
+  struct SendSlotState {
+    uint64_t lastCommand;
+  };
+
+  struct alignas(16) SendQueue {
+    // Worker publishes tail. Service publishes posted after ticket recording.
+    alignas(8) uint64_t tail;
+    alignas(8) uint64_t posted;
+    SendSlotState slots[kPipelineSlotCapacity];
+    SendCommand commands[kQueueCapacity];
+  };
+
+  struct alignas(16) RecvQueue {
+    // Worker: tail/copied. Service: ready/credited.
+    alignas(8) uint64_t tail;
+    alignas(8) uint64_t ready;
+    alignas(8) uint64_t copied;
+    alignas(8) uint64_t credited;
+    RecvCommand commands[kQueueCapacity];
+  };
+
+ public:
+  static constexpr uint32_t kBlockThreads =
+      WorkerThreads + comms::device::kWarpSize;
+
+  struct Config {
+    uint32_t queueDepth{kQueueCapacity};
+    uint64_t* queueFullCount{nullptr};
+  };
+
+  struct alignas(16) SharedState {
+    SendQueue send;
+    RecvQueue recv;
+    alignas(8) uint64_t* queueFullCount;
+    alignas(4) uint32_t queueDepth;
+    alignas(4) uint32_t producerDone;
+  };
+
+  class Ops {
+   public:
+    static constexpr uint32_t kWorkerThreads = WorkerThreads;
+
+    __device__ __forceinline__ ThreadGroup& group() {
+      return workers_;
+    }
+
+    __device__ __forceinline__ void sync() {
+      workers_.sync();
+    }
+
+    // Posts staged sends and publishes receive credits.
+    __device__ __forceinline__ void drain() {
+      IbgdaWarpProxy::drain_queues(storage_, workers_, timeout_);
+    }
+
+    template <typename CopyOp = Memcpy, typename... Args>
+    __device__ __forceinline__ void send(
+        P2pIbgdaTransportDevice& transport,
+        const void* src,
+        std::size_t nbytes,
+        std::size_t maxSignalBytes = 0,
+        Args... args) {
+      static_assert(
+          !detail::copyop_variable_size_v<CopyOp>,
+          "IbgdaWarpProxy supports fixed-size CopyOps only");
+      IbgdaWarpProxy::validate_pipeline_depth(transport, workers_);
+      detail::send_impl<P2pIbgdaTransportDevice, CopyOp>(
+          transport,
+          workers_,
+          this,
+          src,
+          nbytes,
+          maxSignalBytes,
+          timeout_,
+          nullptr,
+          args...);
+    }
+
+    template <typename CopyOp = Memcpy, typename... Args>
+    __device__ __forceinline__ void recv(
+        P2pIbgdaTransportDevice& transport,
+        void* dst,
+        std::size_t nbytes,
+        std::size_t maxSignalBytes = 0,
+        Args... args) {
+      static_assert(
+          !detail::copyop_variable_size_v<CopyOp>,
+          "IbgdaWarpProxy supports fixed-size CopyOps only");
+      IbgdaWarpProxy::validate_pipeline_depth(transport, workers_);
+      detail::recv_impl<P2pIbgdaTransportDevice, CopyOp>(
+          transport,
+          workers_,
+          this,
+          dst,
+          nbytes,
+          maxSignalBytes,
+          timeout_,
+          nullptr,
+          args...);
+    }
+
+    template <typename CopyOp = Memcpy, typename... Args>
+    __device__ __forceinline__ void forward(
+        P2pIbgdaTransportDevice& prev,
+        void* dst,
+        P2pIbgdaTransportDevice& next,
+        std::size_t nbytes,
+        std::size_t maxSignalBytes = 0,
+        Args... args) {
+      static_assert(
+          !detail::copyop_variable_size_v<CopyOp>,
+          "IbgdaWarpProxy supports fixed-size CopyOps only");
+      IbgdaWarpProxy::validate_pipeline_depth(prev, workers_);
+      IbgdaWarpProxy::validate_pipeline_depth(next, workers_);
+      detail::forward_impl<CopyOp, P2pIbgdaTransportDevice>(
+          prev,
+          workers_,
+          this,
+          dst,
+          next,
+          nbytes,
+          maxSignalBytes,
+          timeout_,
+          nullptr,
+          nullptr,
+          args...);
+    }
+
+    __device__ __forceinline__ void prepare_send_slot(
+        P2pIbgdaTransportDevice& transport,
+        ThreadGroup& workers,
+        uint32_t slot,
+        uint64_t generation,
+        const Timeout& timeout) {
+      IbgdaWarpProxy::wait_prior_send_posted(storage_, workers, slot, timeout);
+      detail::prepare_send_slot(transport, workers, slot, generation, timeout);
+    }
+
+    __device__ __forceinline__ void submit_send(
+        P2pIbgdaTransportDevice& transport,
+        ThreadGroup& workers,
+        const IbgdaLocalBuffer& source,
+        std::size_t remoteOffset,
+        std::size_t bytes,
+        std::size_t protocolBytes,
+        uint64_t slotFreeExpected,
+        uint32_t slot,
+        uint64_t generation,
+        uint64_t requiredRecvCredit,
+        const Timeout& timeout) {
+      IbgdaWarpProxy::template wait_queue_space<true>(
+          storage_, workers, timeout);
+      IbgdaWarpProxy::enqueue_send(
+          storage_,
+          workers,
+          SendCommand{
+              .transport = &transport,
+              .source = source,
+              .remoteOffset = remoteOffset,
+              .bytes = bytes,
+              .protocolBytes = protocolBytes,
+              .slotFreeExpected = slotFreeExpected,
+              .generation = generation,
+              .requiredRecvCredit = requiredRecvCredit,
+              .channel = static_cast<uint32_t>(workers.group_id),
+              .slot = slot,
+          });
+    }
+
+    __device__ __forceinline__ uint64_t wait_recv(
+        P2pIbgdaTransportDevice& transport,
+        ThreadGroup& workers,
+        std::size_t protocolBytes,
+        const Timeout& timeout) {
+      IbgdaWarpProxy::template wait_queue_space<false>(
+          storage_, workers, timeout);
+      const uint64_t sequence = IbgdaWarpProxy::enqueue_recv(
+          storage_,
+          workers,
+          RecvCommand{
+              .transport = &transport,
+              .protocolBytes = protocolBytes,
+              .channel = static_cast<uint32_t>(workers.group_id),
+          });
+      IbgdaWarpProxy::wait_recv_ready(storage_, workers, sequence, timeout);
+      return sequence;
+    }
+
+    __device__ __forceinline__ void publish_recv(
+        P2pIbgdaTransportDevice& transport,
+        ThreadGroup& workers,
+        std::size_t protocolBytes,
+        uint64_t sequence) {
+      (void)transport;
+      (void)protocolBytes;
+      IbgdaWarpProxy::publish_recv_copied(storage_, workers, sequence);
+    }
+
+   private:
+    friend class IbgdaWarpProxy<WorkerThreads, MaxPipelineDepth>;
+
+    __device__
+    Ops(SharedState& storage, ThreadGroup workers, const Timeout& timeout)
+        : storage_(storage), workers_(workers), timeout_(timeout) {}
+
+    SharedState& storage_;
+    ThreadGroup workers_;
+    Timeout timeout_;
+  };
+
+  template <typename WorkerFn>
+  __device__ __forceinline__ static void run(
+      SharedState& storage,
+      ThreadGroup fullBlock,
+      const Timeout& timeout,
+      WorkerFn&& workerFn) {
+    run(storage,
+        fullBlock,
+        Config{},
+        timeout,
+        static_cast<WorkerFn&&>(workerFn));
+  }
+
+  template <typename WorkerFn>
+  __device__ __forceinline__ static void run(
+      SharedState& storage,
+      ThreadGroup fullBlock,
+      const Config& config,
+      const Timeout& timeout,
+      WorkerFn&& workerFn) {
+    validate_block(fullBlock);
+    validate_config(config, fullBlock);
+    initialize(storage, fullBlock, config);
+
+    if (fullBlock.thread_id_in_group < WorkerThreads) {
+      ThreadGroup workers = make_worker_group(fullBlock);
+      Ops ops(storage, workers, timeout);
+      workerFn(ops);
+      finish_workers(storage, workers);
+    } else {
+      ThreadGroup service = make_service_group(fullBlock);
+      run_service(storage, service, fullBlock, timeout);
+    }
+
+    fullBlock.sync();
+  }
+
+ private:
+  __device__ __forceinline__ static ThreadGroup make_worker_group(
+      const ThreadGroup& fullBlock) {
+    return ThreadGroup{
+        .thread_id_in_group = fullBlock.thread_id_in_group,
+        .group_size = WorkerThreads,
+        .group_id = fullBlock.group_id,
+        .block_id = fullBlock.block_id,
+        .total_groups = fullBlock.total_groups,
+        .scope = SyncScope::MULTIWARP,
+        .barrier_id = kWorkerNamedBarrierId,
+    };
+  }
+
+  using BlockAtomicU32 = cuda::atomic_ref<uint32_t, cuda::thread_scope_block>;
+  using BlockAtomicU64 = cuda::atomic_ref<uint64_t, cuda::thread_scope_block>;
+  using DeviceAtomicU64 = cuda::atomic_ref<uint64_t, cuda::thread_scope_device>;
+
+  __device__ __forceinline__ static void validate_block(
+      const ThreadGroup& fullBlock) {
+    const uint32_t expected = WorkerThreads + kServiceThreads;
+    const bool valid = blockDim.y == 1 && blockDim.z == 1 &&
+        fullBlock.group_size == expected && blockDim.x == expected &&
+        fullBlock.thread_id_in_group == threadIdx.x &&
+        fullBlock.scope == SyncScope::BLOCK;
+    if (!valid) {
+      if (fullBlock.is_leader()) {
+        printf(
+            "[PIPES] FATAL: IbgdaWarpProxy requires exactly %u workers and "
+            "one trailing service warp; block=(%u,%u,%u) group=%u\n",
+            WorkerThreads,
+            blockDim.x,
+            blockDim.y,
+            blockDim.z,
+            fullBlock.group_size);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+  }
+
+  __device__ __forceinline__ static void validate_config(
+      const Config& config,
+      const ThreadGroup& fullBlock) {
+    const bool valid = config.queueDepth > 0 &&
+        config.queueDepth <= static_cast<uint32_t>(kQueueCapacity);
+    if (!valid) {
+      if (fullBlock.is_leader()) {
+        printf(
+            "[PIPES] FATAL: IbgdaWarpProxy queue depth=%u outside [1, %u]\n",
+            config.queueDepth,
+            kQueueCapacity);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+  }
+
+  __device__ __forceinline__ static ThreadGroup make_service_group(
+      const ThreadGroup& fullBlock) {
+    return ThreadGroup{
+        .thread_id_in_group = fullBlock.thread_id_in_group - WorkerThreads,
+        .group_size = kServiceThreads,
+        .group_id = fullBlock.group_id,
+        .block_id = fullBlock.block_id,
+        .total_groups = fullBlock.total_groups,
+        .scope = SyncScope::WARP,
+    };
+  }
+
+  __device__ __forceinline__ static ThreadGroup make_solo_group(
+      uint32_t channel,
+      const ThreadGroup& fullBlock) {
+    return ThreadGroup{
+        .thread_id_in_group = 0,
+        .group_size = 1,
+        .group_id = channel,
+        .block_id = fullBlock.block_id,
+        .total_groups = fullBlock.total_groups,
+        .scope = SyncScope::THREAD,
+    };
+  }
+
+  __device__ __forceinline__ static void initialize(
+      SharedState& storage,
+      ThreadGroup& fullBlock,
+      const Config& config) {
+    if (fullBlock.is_leader()) {
+      storage.send.tail = 0;
+      storage.send.posted = 0;
+      storage.recv.tail = 0;
+      storage.recv.ready = 0;
+      storage.recv.copied = 0;
+      storage.recv.credited = 0;
+      storage.queueFullCount = config.queueFullCount;
+      storage.queueDepth = config.queueDepth;
+      storage.producerDone = 0;
+      for (uint32_t slot = 0; slot < kPipelineSlotCapacity; ++slot) {
+        auto& sendSlot = storage.send.slots[slot];
+        sendSlot.lastCommand = kInvalidSequence;
+      }
+    }
+    fullBlock.sync();
+  }
+
+  __device__ __forceinline__ static void finish_workers(
+      SharedState& storage,
+      ThreadGroup& workers) {
+    workers.sync();
+    if (workers.is_leader()) {
+      BlockAtomicU32 done(storage.producerDone);
+      done.store(1, cuda::memory_order_release);
+    }
+  }
+
+  __device__ __forceinline__ static void drain_queues(
+      SharedState& storage,
+      ThreadGroup& workers,
+      const Timeout& timeout) {
+    workers.sync();
+    if (workers.is_leader()) {
+      BlockAtomicU64 sendTail(storage.send.tail);
+      BlockAtomicU64 sendPosted(storage.send.posted);
+      BlockAtomicU64 recvTail(storage.recv.tail);
+      BlockAtomicU64 recvCredited(storage.recv.credited);
+      const uint64_t targetSend = sendTail.load(cuda::memory_order_acquire);
+      const uint64_t targetRecv = recvTail.load(cuda::memory_order_acquire);
+      uint64_t currentSend = sendPosted.load(cuda::memory_order_acquire);
+      uint64_t currentRecv = recvCredited.load(cuda::memory_order_acquire);
+      while (currentSend < targetSend || currentRecv < targetRecv) {
+        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+            timeout,
+            "IbgdaWarpProxy drain waiting for service progress "
+            "send=%llu/%llu recv=%llu/%llu",
+            static_cast<unsigned long long>(currentSend),
+            static_cast<unsigned long long>(targetSend),
+            static_cast<unsigned long long>(currentRecv),
+            static_cast<unsigned long long>(targetRecv));
+        currentSend = sendPosted.load(cuda::memory_order_acquire);
+        currentRecv = recvCredited.load(cuda::memory_order_acquire);
+      }
+    }
+    workers.sync();
+  }
+
+  __device__ __forceinline__ static void validate_pipeline_depth(
+      P2pIbgdaTransportDevice& transport,
+      ThreadGroup& workers) {
+    const int depth = transport.channel_layout().pipelineDepth;
+    if (depth <= 0 || depth > static_cast<int>(kPipelineSlotCapacity)) {
+      if (workers.is_leader()) {
+        printf(
+            "[PIPES] FATAL: IbgdaWarpProxy pipeline depth=%d outside "
+            "[1, %u]\n",
+            depth,
+            kPipelineSlotCapacity);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+  }
+
+  template <bool IsSend>
+  __device__ __forceinline__ static void wait_queue_space(
+      SharedState& storage,
+      ThreadGroup& workers,
+      const Timeout& timeout) {
+    if (workers.is_leader()) {
+      uint64_t& tailValue = IsSend ? storage.send.tail : storage.recv.tail;
+      uint64_t& headValue =
+          IsSend ? storage.send.posted : storage.recv.credited;
+      BlockAtomicU64 tail(tailValue);
+      BlockAtomicU64 head(headValue);
+      const uint64_t currentTail = tail.load(cuda::memory_order_relaxed);
+      uint64_t currentHead = head.load(cuda::memory_order_acquire);
+      if (currentTail - currentHead >= storage.queueDepth &&
+          storage.queueFullCount != nullptr) {
+        DeviceAtomicU64 queueFullCount(*storage.queueFullCount);
+        queueFullCount.fetch_add(1, cuda::memory_order_relaxed);
+      }
+      while (currentTail - currentHead >= storage.queueDepth) {
+        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+            timeout,
+            "IbgdaWarpProxy %s queue full channel=%u head=%llu tail=%llu",
+            IsSend ? "send" : "recv",
+            workers.group_id,
+            static_cast<unsigned long long>(currentHead),
+            static_cast<unsigned long long>(currentTail));
+        currentHead = head.load(cuda::memory_order_acquire);
+      }
+    }
+    workers.sync();
+  }
+
+  __device__ __forceinline__ static void wait_prior_send_posted(
+      SharedState& storage,
+      ThreadGroup& workers,
+      uint32_t slot,
+      const Timeout& timeout) {
+    auto& slotState = storage.send.slots[slot];
+    if (workers.is_leader()) {
+      const uint64_t requiredPosted = slotState.lastCommand == kInvalidSequence
+          ? 0
+          : slotState.lastCommand + 1;
+      BlockAtomicU64 posted(storage.send.posted);
+      uint64_t currentPosted = posted.load(cuda::memory_order_acquire);
+      while (currentPosted < requiredPosted) {
+        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+            timeout,
+            "IbgdaWarpProxy waiting for send WQE post channel=%u slot=%u "
+            "posted=%llu required=%llu",
+            workers.group_id,
+            slot,
+            static_cast<unsigned long long>(currentPosted),
+            static_cast<unsigned long long>(requiredPosted));
+        currentPosted = posted.load(cuda::memory_order_acquire);
+      }
+    }
+    workers.sync();
+  }
+
+  __device__ __forceinline__ static void enqueue_send(
+      SharedState& storage,
+      ThreadGroup& workers,
+      const SendCommand& command) {
+    if (workers.is_leader()) {
+      BlockAtomicU64 tail(storage.send.tail);
+      const uint64_t sequence = tail.load(cuda::memory_order_relaxed);
+      storage.send.commands[sequence % kQueueCapacity] = command;
+      storage.send.slots[command.slot].lastCommand = sequence;
+      tail.store(sequence + 1, cuda::memory_order_release);
+    }
+  }
+
+  __device__ __forceinline__ static uint64_t enqueue_recv(
+      SharedState& storage,
+      ThreadGroup& workers,
+      const RecvCommand& command) {
+    uint64_t sequence = 0;
+    if (workers.is_leader()) {
+      BlockAtomicU64 tail(storage.recv.tail);
+      sequence = tail.load(cuda::memory_order_relaxed);
+      storage.recv.commands[sequence % kQueueCapacity] = command;
+      tail.store(sequence + 1, cuda::memory_order_release);
+    }
+    return workers.broadcast(sequence);
+  }
+
+  __device__ __forceinline__ static void wait_recv_ready(
+      SharedState& storage,
+      ThreadGroup& workers,
+      uint64_t sequence,
+      const Timeout& timeout) {
+    if (workers.is_leader()) {
+      BlockAtomicU64 ready(storage.recv.ready);
+      uint64_t current = ready.load(cuda::memory_order_acquire);
+      while (current <= sequence) {
+        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+            timeout,
+            "IbgdaWarpProxy waiting for DATA_READY channel=%u ready=%llu "
+            "required=%llu",
+            workers.group_id,
+            static_cast<unsigned long long>(current),
+            static_cast<unsigned long long>(sequence + 1));
+        current = ready.load(cuda::memory_order_acquire);
+      }
+    }
+    workers.sync();
+  }
+
+  __device__ __forceinline__ static void publish_recv_copied(
+      SharedState& storage,
+      ThreadGroup& workers,
+      uint64_t sequence) {
+    if (workers.is_leader()) {
+      BlockAtomicU64 copied(storage.recv.copied);
+      copied.store(sequence + 1, cuda::memory_order_release);
+    }
+  }
+
+  __device__ __forceinline__ static void post_recv_credits(
+      SharedState& storage,
+      const ThreadGroup& fullBlock) {
+    BlockAtomicU64 copied(storage.recv.copied);
+    BlockAtomicU64 credited(storage.recv.credited);
+    uint64_t head = credited.load(cuda::memory_order_relaxed);
+    const uint64_t copiedTail = copied.load(cuda::memory_order_acquire);
+    while (head < copiedTail) {
+      const RecvCommand command = storage.recv.commands[head % kQueueCapacity];
+      const IbRemoteChannel remote = makeIbRemoteChannel(
+          command.transport->channel_layout(),
+          static_cast<int>(command.channel));
+      ThreadGroup solo = make_solo_group(command.channel, fullBlock);
+      command.transport->signal(
+          solo, remote.slotFree, command.protocolBytes, IbDirection::Recv);
+      credited.store(++head, cuda::memory_order_release);
+    }
+  }
+
+  __device__ __forceinline__ static void publish_recv_readiness(
+      SharedState& storage,
+      const Timeout& timeout) {
+    BlockAtomicU64 tail(storage.recv.tail);
+    BlockAtomicU64 ready(storage.recv.ready);
+    uint64_t currentReady = ready.load(cuda::memory_order_relaxed);
+    const uint64_t currentTail = tail.load(cuda::memory_order_acquire);
+    while (currentReady < currentTail) {
+      const RecvCommand command =
+          storage.recv.commands[currentReady % kQueueCapacity];
+      IbLocalChannel& local = command.transport->local_channel(command.channel);
+      IbChannelProtoSlot& localSlot =
+          command.transport->template local_channel_slot<protocol::Simple>(
+              command.channel);
+      unsigned long long current = 0;
+      unsigned long long expected = 0;
+      if (!detail::poll_recv_data_ready(
+              *command.transport,
+              local,
+              localSlot.dataReady,
+              command.protocolBytes,
+              current,
+              expected)) {
+        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+            timeout,
+            "IbgdaWarpProxy waiting for DATA_READY channel=%u "
+            "expected=%llu current=%llu",
+            command.channel,
+            expected,
+            current);
+        break;
+      }
+      ready.store(++currentReady, cuda::memory_order_release);
+    }
+  }
+
+  __device__ __forceinline__ static void post_send_once(
+      SharedState& storage,
+      const ThreadGroup& fullBlock,
+      const Timeout& timeout) {
+    BlockAtomicU64 tail(storage.send.tail);
+    BlockAtomicU64 posted(storage.send.posted);
+    const uint64_t head = posted.load(cuda::memory_order_relaxed);
+    const uint64_t currentTail = tail.load(cuda::memory_order_acquire);
+    if (head == currentTail) {
+      return;
+    }
+
+    const SendCommand command = storage.send.commands[head % kQueueCapacity];
+    if (command.transport->send_completion_lane_count() == 0) {
+      printf("[PIPES] FATAL: IbgdaWarpProxy has no send QP lanes\n");
+      PIPES_DEVICE_TRAP();
+    }
+
+    BlockAtomicU64 credited(storage.recv.credited);
+    const uint64_t creditedTail = credited.load(cuda::memory_order_acquire);
+    if (creditedTail < command.requiredRecvCredit) {
+      TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+          timeout,
+          "IbgdaWarpProxy waiting for receive credit channel=%u "
+          "credited=%llu required=%llu",
+          command.channel,
+          static_cast<unsigned long long>(creditedTail),
+          static_cast<unsigned long long>(command.requiredRecvCredit));
+      return;
+    }
+    if (command.slotFreeExpected != 0) {
+      const IbChannelProtoSlot& localSlot =
+          command.transport->template local_channel_slot<protocol::Simple>(
+              command.channel);
+      const uint64_t current =
+          command.transport->read_signal(localSlot.slotFree);
+      if (current < command.slotFreeExpected) {
+        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+            timeout,
+            "IbgdaWarpProxy waiting for SLOT_FREE channel=%u "
+            "expected=%llu current=%llu",
+            command.channel,
+            static_cast<unsigned long long>(command.slotFreeExpected),
+            static_cast<unsigned long long>(current));
+        return;
+      }
+    }
+
+    const IbRemoteChannel remote = makeIbRemoteChannel(
+        command.transport->channel_layout(), static_cast<int>(command.channel));
+    ThreadGroup solo = make_solo_group(command.channel, fullBlock);
+    const IbLocalCompletionTicket ticket = command.transport->put(
+        solo,
+        command.source,
+        remote.recvStaging.subBuffer(command.remoteOffset),
+        command.bytes,
+        remote.dataReady,
+        command.protocolBytes,
+        /*counterBuf=*/{},
+        /*counterVal=*/0,
+        /*signalPerLane=*/true);
+    detail::record_send_completion(
+        *command.transport,
+        command.channel,
+        command.slot,
+        command.generation,
+        ticket);
+    posted.store(head + 1, cuda::memory_order_release);
+  }
+
+  __device__ __forceinline__ static void run_service(
+      SharedState& storage,
+      ThreadGroup& service,
+      const ThreadGroup& fullBlock,
+      const Timeout& timeout) {
+    BlockAtomicU32 producerDone(storage.producerDone);
+    while (true) {
+      if (service.is_leader()) {
+        post_recv_credits(storage, fullBlock);
+        publish_recv_readiness(storage, timeout);
+        post_send_once(storage, fullBlock, timeout);
+      }
+
+      uint32_t stop = 0;
+      if (service.is_leader() &&
+          producerDone.load(cuda::memory_order_acquire) != 0) {
+        BlockAtomicU64 sendTail(storage.send.tail);
+        BlockAtomicU64 sendPosted(storage.send.posted);
+        BlockAtomicU64 recvTail(storage.recv.tail);
+        BlockAtomicU64 recvCredited(storage.recv.credited);
+        stop = sendPosted.load(cuda::memory_order_acquire) ==
+                    sendTail.load(cuda::memory_order_acquire) &&
+                recvCredited.load(cuda::memory_order_acquire) ==
+                    recvTail.load(cuda::memory_order_acquire)
+            ? 1U
+            : 0U;
+      }
+      stop = service.broadcast(stop);
+      if (stop != 0) {
+        break;
+      }
+    }
+    service.sync();
+  }
+};
+
+} // namespace comms::prims
+
+#endif // defined(__CUDACC__) && !defined(__HIP_PLATFORM_AMD__)

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3469,6 +3469,13 @@ cvars:
      capability query and forces VALID_DBR. Host-only loopback QPs always use
      VALID_DBR. This policy is NVIDIA-only and ignored on AMD.
 
+ - name        : MCCL_IBGDA_WARP_PROXY_ENABLE
+   type        : bool
+   default     : false
+   description : |-
+     Enable the dedicated IBGDA warp-proxy send, receive, and forward path for
+     fused Ring AllReduce. Disabled by default while the path is evaluated.
+
  - name        : MCCL_IB_QP_DEPTH
    type        : uint64_t
    default     : 1024


### PR DESCRIPTION
Summary:

IBGDA send, receive, and forward operations currently make worker warps perform remote-readiness polling and WQE posting inline with copy and reduction work. This change adds a reusable `IbgdaWarpProxy` wrapper that reserves one trailing service warp. Workers continue staging, copying, and reducing data, then publish bounded commands through block-scoped queues. The service warp polls remote readiness, posts WQEs, records send tickets, and returns receive credits. Release/acquire counters let worker and IB progress run independently while preserving staging-slot reuse and receive-credit ordering.

Extend the existing P2P IB primitive implementation with optional progress-policy hooks so the same send, receive, and forward APIs can execute either synchronously or through the proxy. Integrate the proxy into fused Ring AllReduce behind `MCCL_IBGDA_WARP_PROXY_ENABLE`. The launch adds exactly one warp only when an IB phase is present and registered-source zero copy is inactive. The CVAR defaults to false, leaving NVL-only, registered zero-copy, AMD, and existing blocking paths unchanged. The initial proxy supports fixed-size copy operations and one producer group per block.

Add an IB-only Ring correctness test and extend the send/receive benchmark coverage for proxy mode. On four GB300 nodes with two IBGDA NICs per rank, the proxy reduced out-of-place Ring AllReduce latency by 14.3-15.1% from 64 MiB through 4 GiB with 7/7 paired wins, and increased bus bandwidth by 17.7% for messages at least 256 MiB. The 1 MiB result remained neutral. All 98 A/B result rows ran with numerical validation enabled and reported `oop_wrong=0`, `ip_wrong=0`, and `exit_code=0`. The newly added IB-only Ring test was not run separately in this validation.

Reviewed By: snarayankh

Differential Revision: D115818912
