### PR TITLE
Propagate AbortDevice wait results

### DIFF
--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -475,30 +475,36 @@ P2pIbTransportDevice::read_counter(const IbgdaLocalBuffer& counterBuf) const {
   return ibgda->read_counter(counterBuf);
 }
 
+// IBRC still drains under its own fixed device deadline; wiring it to the
+// abort handle is a separate change, so the handle stops at IBGDA for now.
 __device__ __forceinline__ void P2pIbTransportDevice::flush(
-    ThreadGroup& group) {
+    ThreadGroup& group,
+    const Timeout& timeout) {
   if (type == P2pIbBackendType::IBRC) {
     ibrc->flush(group);
   } else {
-    ibgda->flush(group);
+    ibgda->flush(group, IbDirection::Send, timeout);
   }
 }
 
-__device__ __forceinline__ void P2pIbTransportDevice::flush() {
+__device__ __forceinline__ void P2pIbTransportDevice::flush(
+    const Timeout& timeout) {
   if (type == P2pIbBackendType::IBRC) {
     ibrc->flush();
   } else {
-    ibgda->flush();
+    ibgda->flush(timeout);
   }
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::fence(
-    ThreadGroup& group) {
-  flush(group);
+    ThreadGroup& group,
+    const Timeout& timeout) {
+  flush(group, timeout);
 }
 
-__device__ __forceinline__ void P2pIbTransportDevice::fence() {
-  flush();
+__device__ __forceinline__ void P2pIbTransportDevice::fence(
+    const Timeout& timeout) {
+  flush(timeout);
 }
 
 // ===========================================================================

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -31,10 +31,17 @@ enum class P2pIbBackendType : uint8_t {
   IBRC,
 };
 
+// `Aborted` is terminal and distinct from `Done`: the operation stopped because
+// the communicator aborted, so the bytes never arrived. Reporting `Done` would
+// advance the caller's cursors and release its slots, letting a driver claim
+// success on data that was never transferred. Drivers loop until a terminal
+// status, so honoring `Aborted` is what lets them exit without every call site
+// having to poll the abort handle itself.
 enum class IbgdaSendRecvProgressStatus : uint8_t {
   Waiting,
   Progressed,
   Done,
+  Aborted,
 };
 
 enum class IbgdaRegisteredSendProgressStatus : uint8_t {
@@ -42,6 +49,7 @@ enum class IbgdaRegisteredSendProgressStatus : uint8_t {
   Progressed,
   Posted,
   Drained,
+  Aborted,
 };
 
 namespace detail {
@@ -295,13 +303,16 @@ struct P2pIbTransportDevice {
 
   __device__ uint64_t read_counter(const IbgdaLocalBuffer& counterBuf) const;
 
-  __device__ void flush(ThreadGroup& group);
+  // Takes the abort handle so the drain terminates on abort instead of waiting
+  // on a NIC that will never complete. Stays void: the wait terminates itself,
+  // and a caller draining its own WQEs has nothing to do with a status.
+  __device__ void flush(ThreadGroup& group, const Timeout& timeout = Timeout());
 
-  __device__ void flush();
+  __device__ void flush(const Timeout& timeout = Timeout());
 
-  __device__ void fence(ThreadGroup& group);
+  __device__ void fence(ThreadGroup& group, const Timeout& timeout = Timeout());
 
-  __device__ void fence();
+  __device__ void fence(const Timeout& timeout = Timeout());
 
   __device__ __forceinline__ void require_ibgda(
       ThreadGroup& group,

--- a/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
@@ -1306,6 +1306,15 @@ __device__ __forceinline__ void send_impl(
                 protocolBytesThis);
           }
         }
+        // The backpressure wait may have given up rather than been satisfied.
+        // Leave before the put below, whose fused DATA_READY would tell the
+        // receiver a chunk had landed that we never sent -- releasing a peer
+        // that is correctly blocked and preventing it from ever reaching its
+        // own deadline. The slot epilogue after this loop still runs, so the
+        // progress slot is left idle for the next op.
+        if (groupAborted(group, timeout)) {
+          break;
+        }
 
         // (4) Leader-only single-WQE RDMA put with fused signal.
         if (group.is_leader()) {
@@ -1750,6 +1759,14 @@ __device__ __forceinline__ void recv_impl(
             timeout,
             traceContext,
             args...);
+        // The DATA_READY wait inside consumeRecvBuf may have given up rather
+        // than been satisfied, in which case this chunk was never written.
+        // Leave before the SLOT_FREE credit below: signalling it would tell the
+        // sender we consumed a chunk it never sent, releasing a peer that is
+        // correctly blocked and preventing it from reaching its own deadline.
+        if (groupAborted(group, timeout)) {
+          break;
+        }
 
         if (group.is_leader()) {
           trace_allreduce_event(
@@ -2081,6 +2098,14 @@ __device__ __forceinline__ void forward_impl(
           recvTraceContext,
           sendTraceContext,
           args...);
+      // The DATA_READY wait inside prepareForwardBuf may have given up, so this
+      // chunk was never written. Forward is the worst of the three paths to get
+      // wrong on abort: continuing would ACK the predecessor for a chunk we
+      // never consumed *and* hand the successor data that never arrived,
+      // releasing two correctly-blocked peers at once.
+      if (groupAborted(group, timeout)) {
+        break;
+      }
 
       transport.signal(
           group,
@@ -2107,6 +2132,12 @@ __device__ __forceinline__ void forward_impl(
               static_cast<uint8_t>(kPipesTraceQpLaneMask),
               fwdProtocolBytesThis);
         }
+      }
+      // As in send_impl: the successor backpressure wait may have given up, and
+      // the put below carries a fused DATA_READY that would release the
+      // successor on data we never wrote.
+      if (groupAborted(group, timeout)) {
+        break;
       }
 
       // (6) Leader-only RDMA put via the forwarding transport.

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -7,6 +7,12 @@
 namespace comms::prims {
 namespace detail {
 
+// Readiness is carried as a word rather than a bool so one broadcast can report
+// three states, keeping the answer group-uniform without a second round trip.
+constexpr uint32_t kProgressNotReady = 0U;
+constexpr uint32_t kProgressReady = 1U;
+constexpr uint32_t kProgressAborted = 2U;
+
 /**
  * Physical staging range for the next resumable progress step.
  *
@@ -98,7 +104,9 @@ __device__ __forceinline__ ProgressChunk next_chunk(
     const ProgressGeometry& geometry);
 
 template <typename P, typename Transport>
-__device__ __forceinline__ bool try_prepare_send_slot(
+// Returns one of kProgressNotReady / kProgressReady / kProgressAborted, already
+// broadcast so every thread in the group agrees.
+__device__ __forceinline__ uint32_t try_prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
     uint32_t slotId,
@@ -438,12 +446,9 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
       detail::IbSendRecvProgressStage::WaitLocalCompletion) {
     const ProgressChunk chunk =
         next_chunk<Proto>(channelLayout, state, progress_params);
-    if (!try_prepare_send_slot<Proto>(
-            transport,
-            group,
-            chunk.slotId,
-            chunk.pipelineGeneration,
-            timeout)) {
+    const uint32_t slotReadiness = try_prepare_send_slot<Proto>(
+        transport, group, chunk.slotId, chunk.pipelineGeneration, timeout);
+    if (slotReadiness != kProgressReady) {
       if (fine_trace_enabled(traceContext) && traceState != nullptr &&
           !traceState->localCompletionWaitOpen && group.is_leader()) {
         trace_allreduce_event(
@@ -453,7 +458,9 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
             chunk.wireBytes);
         traceState->localCompletionWaitOpen = true;
       }
-      return IbgdaSendRecvProgressStatus::Waiting;
+      return slotReadiness == kProgressAborted
+          ? IbgdaSendRecvProgressStatus::Aborted
+          : IbgdaSendRecvProgressStatus::Waiting;
     }
     if (fine_trace_enabled(traceContext) && traceState != nullptr &&
         traceState->localCompletionWaitOpen && group.is_leader()) {
@@ -508,15 +515,21 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
             transport.read_signal(localSlotFree));
         ready = current >= expected ? 1U : 0U;
         if (!ready) {
-          (void)FT_ABORT_CHECK(
-              timeout,
-              "progress_send_once waiting for SLOT_FREE expected>=%llu, "
-              "current=%llu",
-              static_cast<unsigned long long>(expected),
-              current);
+          if (FT_ABORT_CHECK(
+                  timeout,
+                  "progress_send_once waiting for SLOT_FREE expected>=%llu, "
+                  "current=%llu",
+                  static_cast<unsigned long long>(expected),
+                  current)) {
+            ready = kProgressAborted;
+          }
         }
       }
       ready = group.broadcast<uint32_t>(ready);
+      if (ready == kProgressAborted) {
+        store_progress_state(group, progressSlot, state);
+        return IbgdaSendRecvProgressStatus::Aborted;
+      }
       if (!ready) {
         if (fine_trace_enabled(traceContext) && traceState != nullptr &&
             !traceState->remoteSlotFreeWaitOpen && group.is_leader()) {
@@ -689,13 +702,12 @@ progress_registered_send_once(
       detail::IbSendRecvProgressStage::WaitLocalCompletion) {
     const ProgressChunk chunk =
         next_chunk<protocol::Simple>(channelLayout, state, geometry);
-    if (!try_prepare_send_slot<protocol::Simple>(
-            transport,
-            group,
-            chunk.slotId,
-            chunk.pipelineGeneration,
-            timeout)) {
-      return IbgdaRegisteredSendProgressStatus::Waiting;
+    const uint32_t slotReadiness = try_prepare_send_slot<protocol::Simple>(
+        transport, group, chunk.slotId, chunk.pipelineGeneration, timeout);
+    if (slotReadiness != kProgressReady) {
+      return slotReadiness == kProgressAborted
+          ? IbgdaRegisteredSendProgressStatus::Aborted
+          : IbgdaRegisteredSendProgressStatus::Waiting;
     }
     transition_progress_stage(
         group, state, detail::IbSendRecvProgressStage::WaitSlotFree);
@@ -718,15 +730,21 @@ progress_registered_send_once(
             transport.read_signal(localSlotFree));
         ready = current >= expected ? 1U : 0U;
         if (!ready) {
-          (void)FT_ABORT_CHECK(
-              timeout,
-              "progress_registered_send_once waiting for SLOT_FREE "
-              "expected>=%llu, current=%llu",
-              static_cast<unsigned long long>(expected),
-              current);
+          if (FT_ABORT_CHECK(
+                  timeout,
+                  "progress_registered_send_once waiting for SLOT_FREE "
+                  "expected>=%llu, current=%llu",
+                  static_cast<unsigned long long>(expected),
+                  current)) {
+            ready = kProgressAborted;
+          }
         }
       }
       ready = group.broadcast<uint32_t>(ready);
+      if (ready == kProgressAborted) {
+        store_progress_state(group, progressSlot, state);
+        return IbgdaRegisteredSendProgressStatus::Aborted;
+      }
       if (!ready) {
         if (state.activeStage != initialStage ||
             state.activeNextByte != initialNextByte) {
@@ -807,12 +825,13 @@ progress_registered_send_drain_once(
   if (group.is_leader()) {
     bool foundPending = false;
     bool madeProgress = false;
+    bool aborted = false;
     auto& channel =
         transport.template local_channel_slot<protocol::Simple>(group.group_id);
     const uint32_t numLanes = transport.send_completion_lane_count();
     const int pipelineDepth = transport.channel_layout().pipelineDepth;
 
-    for (int slotId = 0; slotId < pipelineDepth; ++slotId) {
+    for (int slotId = 0; slotId < pipelineDepth && !aborted; ++slotId) {
       auto& slot = channel.sendCompletionSlots[slotId];
       uint64_t pending = slot.laneMask;
       for (uint32_t laneId = 0; laneId < numLanes; ++laneId) {
@@ -830,16 +849,24 @@ progress_registered_send_drain_once(
           continue;
         }
         foundPending = true;
-        (void)FT_ABORT_CHECK(
+        aborted = FT_ABORT_CHECK(
             timeout,
             "registered send local completion timed out slot=%d lane=%u",
             slotId,
             laneId);
+        if (aborted) {
+          break;
+        }
       }
+      // Persist the lanes drained so far even when unwinding, so a retry does
+      // not re-wait on completions that already landed.
       slot.laneMask = pending;
     }
 
-    if (foundPending) {
+    if (aborted) {
+      result =
+          static_cast<uint32_t>(IbgdaRegisteredSendProgressStatus::Aborted);
+    } else if (foundPending) {
       result = static_cast<uint32_t>(
           madeProgress ? IbgdaRegisteredSendProgressStatus::Progressed
                        : IbgdaRegisteredSendProgressStatus::Waiting);
@@ -866,12 +893,18 @@ __device__ __forceinline__ void send_registered(
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   init_registered_send_progress(transport, group, nbytes, max_signal_bytes);
   IbgdaRegisteredSendProgressStatus status;
+  // Both loops are unbounded by design: they spin until the NIC makes progress.
+  // `Aborted` is the only escape when the NIC never will, so it must terminate
+  // them - otherwise an abort on a dead NIC deadlocks here, which is the exact
+  // failure this abort plumbing exists to break.
   do {
     status = progress_registered_send_once(
         transport, group, src, nbytes, max_signal_bytes, timeout);
   } while (status != IbgdaRegisteredSendProgressStatus::Posted &&
-           status != IbgdaRegisteredSendProgressStatus::Drained);
-  while (status != IbgdaRegisteredSendProgressStatus::Drained) {
+           status != IbgdaRegisteredSendProgressStatus::Drained &&
+           status != IbgdaRegisteredSendProgressStatus::Aborted);
+  while (status != IbgdaRegisteredSendProgressStatus::Drained &&
+         status != IbgdaRegisteredSendProgressStatus::Aborted) {
     status = progress_registered_send_drain_once(transport, group, timeout);
   }
 #else
@@ -1015,7 +1048,7 @@ __device__ __forceinline__ bool poll_recv_data_ready(
 // packet geometry the LL overload polls); the seam passes them so both
 // protocols share the call site in progress_recv_once.
 template <typename Transport>
-__device__ __forceinline__ bool progress_recv_ready(
+__device__ __forceinline__ uint32_t progress_recv_ready(
     protocol::Simple,
     Transport& transport,
     ThreadGroup& group,
@@ -1054,12 +1087,14 @@ __device__ __forceinline__ bool progress_recv_ready(
             waitCredit);
         traceState->dataReadyWaitOpen = true;
       }
-      (void)FT_ABORT_CHECK(
-          timeout,
-          "progress_recv_once waiting for DATA_READY expected>=%llu, "
-          "current=%llu",
-          expected,
-          current);
+      if (FT_ABORT_CHECK(
+              timeout,
+              "progress_recv_once waiting for DATA_READY expected>=%llu, "
+              "current=%llu",
+              expected,
+              current)) {
+        ready = kProgressAborted;
+      }
     } else if (
         fine_trace_enabled(traceContext) && traceState != nullptr &&
         traceState->dataReadyWaitOpen) {
@@ -1071,7 +1106,10 @@ __device__ __forceinline__ bool progress_recv_ready(
       traceState->dataReadyWaitOpen = false;
     }
   }
-  return group.broadcast<uint32_t>(ready) != 0U;
+  // Broadcast makes the answer group-uniform, which is what lets abort ride out
+  // as `kProgressAborted` instead of an indistinguishable "not ready" that the
+  // caller's driver would retry forever.
+  return group.broadcast<uint32_t>(ready);
 #else
   (void)transport;
   (void)group;
@@ -1084,7 +1122,7 @@ __device__ __forceinline__ bool progress_recv_ready(
   (void)traceContext;
   (void)traceState;
   (void)qpLane;
-  return true;
+  return kProgressReady;
 #endif
 }
 
@@ -1163,7 +1201,7 @@ __device__ __forceinline__ bool group_all_ready(ThreadGroup& group, bool pred) {
 // never used. D115669516 completes that advance; it must land in the same batch
 // as this diff and the ones that enable LL progress on top of it.
 template <typename Transport>
-__device__ __forceinline__ bool progress_recv_ready(
+__device__ __forceinline__ uint32_t progress_recv_ready(
     protocol::LL,
     Transport& transport,
     ThreadGroup& group,
@@ -1200,9 +1238,8 @@ __device__ __forceinline__ bool progress_recv_ready(
       break;
     }
   }
-  const bool ready = group_all_ready(group, myReady != 0U);
-  if (group.is_leader()) {
-    if (ready) {
+  if (group_all_ready(group, myReady != 0U)) {
+    if (group.is_leader()) {
       // LL carries no DATA_READY, but its put still advanced the sender's
       // IbQpState::cursor -- select_put_lane_ordinal() increments that cursor
       // on every put regardless of protocol, and it is channel-scoped, not
@@ -1212,19 +1249,24 @@ __device__ __forceinline__ bool progress_recv_ready(
       // then waits on a lane the sender never wrote. Matches the unconditional
       // bump in poll_recv_data_ready() (a single lane makes it a no-op).
       ++localChannel.recvDataReadyLaneCursor;
-    } else {
-      // No loop to leave here -- this is a single resumable poll that returns
-      // Waiting to its driver. CHECK is only for the log-and-trap side effect
-      // on abort; the driver's own loop is what terminates.
-      (void)FT_ABORT_CHECK(
-          timeout,
-          "progress_recv_once(LL) waiting for packet flags flagVal=%llu, "
-          "wireBytes=%llu",
-          static_cast<unsigned long long>(chunk.flagVal),
-          static_cast<unsigned long long>(chunk.wireBytes));
+    }
+    return kProgressReady;
+  }
+  // Only the leader checks, so the answer has to be broadcast before it leaves:
+  // a per-thread verdict here would split the group at the caller's next
+  // collective step.
+  uint32_t status = kProgressNotReady;
+  if (group.is_leader()) {
+    if (FT_ABORT_CHECK(
+            timeout,
+            "progress_recv_once(LL) waiting for packet flags flagVal=%llu, "
+            "wireBytes=%llu",
+            static_cast<unsigned long long>(chunk.flagVal),
+            static_cast<unsigned long long>(chunk.wireBytes))) {
+      status = kProgressAborted;
     }
   }
-  return ready;
+  return group.broadcast<uint32_t>(status);
 #else
   (void)transport;
   (void)group;
@@ -1234,7 +1276,7 @@ __device__ __forceinline__ bool progress_recv_ready(
   (void)localDataReady;
   (void)waitCredit;
   (void)timeout;
-  return true;
+  return kProgressReady;
 #endif
 }
 
@@ -1351,20 +1393,23 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once_impl(
   const uint32_t numLanes = static_cast<uint32_t>(channelLayout.numLanes);
   const uint8_t qpLane = static_cast<uint8_t>(
       numLanes == 0 ? 0 : localChannel.recvDataReadyLaneCursor % numLanes);
-  if (!progress_recv_ready(
-          Proto{},
-          transport,
-          group,
-          channelLayout,
-          chunk,
-          localChannel,
-          localDataReady,
-          protocolBytesThis,
-          timeout,
-          traceContext,
-          traceState,
-          qpLane)) {
-    return IbgdaSendRecvProgressStatus::Waiting;
+  const uint32_t recvReadiness = progress_recv_ready(
+      Proto{},
+      transport,
+      group,
+      channelLayout,
+      chunk,
+      localChannel,
+      localDataReady,
+      protocolBytesThis,
+      timeout,
+      traceContext,
+      traceState,
+      qpLane);
+  if (recvReadiness != kProgressReady) {
+    return recvReadiness == kProgressAborted
+        ? IbgdaSendRecvProgressStatus::Aborted
+        : IbgdaSendRecvProgressStatus::Waiting;
   }
 
   progress_recv_consume_buf<CopyOp>(
@@ -1544,20 +1589,23 @@ progress_recv_acquire_once(
   const uint32_t numLanes = static_cast<uint32_t>(channelLayout.numLanes);
   const uint8_t qpLane = static_cast<uint8_t>(
       numLanes == 0 ? 0 : ch.channel.recvDataReadyLaneCursor % numLanes);
-  if (!progress_recv_ready(
-          Proto{},
-          transport,
-          group,
-          channelLayout,
-          chunk,
-          ch.channel,
-          ch.local.dataReady,
-          protocolBytesThis,
-          timeout,
-          nullptr,
-          nullptr,
-          qpLane)) {
-    return IbgdaSendRecvProgressStatus::Waiting;
+  const uint32_t recvReadiness = progress_recv_ready(
+      Proto{},
+      transport,
+      group,
+      channelLayout,
+      chunk,
+      ch.channel,
+      ch.local.dataReady,
+      protocolBytesThis,
+      timeout,
+      nullptr,
+      nullptr,
+      qpLane);
+  if (recvReadiness != kProgressReady) {
+    return recvReadiness == kProgressAborted
+        ? IbgdaSendRecvProgressStatus::Aborted
+        : IbgdaSendRecvProgressStatus::Waiting;
   }
 
   out.staging = channelLayout.recvStagingPtr + chunk.stagingOff;
@@ -1974,14 +2022,14 @@ __device__ __forceinline__ ProgressChunk next_chunk(
 }
 
 template <typename P, typename Transport>
-__device__ __forceinline__ bool try_prepare_send_slot(
+__device__ __forceinline__ uint32_t try_prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
     uint32_t slotId,
     uint64_t generation,
     const Timeout& timeout) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-  uint32_t ready = 1;
+  uint32_t ready = kProgressReady;
   if (group.is_leader()) {
     auto& slot = transport.template local_channel_slot<P>(group.group_id)
                      .sendCompletionSlots[slotId];
@@ -2005,26 +2053,27 @@ __device__ __forceinline__ bool try_prepare_send_slot(
       if (pending == 0) {
         slot.generation = generation;
       } else {
-        ready = 0;
-        (void)FT_ABORT_CHECK(
-            timeout,
-            "send slot local completion timed out slot=%u generation=%llu "
-            "pending=0x%llx",
-            slotId,
-            static_cast<unsigned long long>(generation),
-            static_cast<unsigned long long>(pending));
+        ready = kProgressNotReady;
+        if (FT_ABORT_CHECK(
+                timeout,
+                "send slot local completion timed out slot=%u generation=%llu "
+                "pending=0x%llx",
+                slotId,
+                static_cast<unsigned long long>(generation),
+                static_cast<unsigned long long>(pending))) {
+          ready = kProgressAborted;
+        }
       }
     }
   }
-  ready = group.broadcast<uint32_t>(ready);
-  return ready != 0;
+  return group.broadcast<uint32_t>(ready);
 #else
   (void)transport;
   (void)group;
   (void)slotId;
   (void)generation;
   (void)timeout;
-  return true;
+  return kProgressReady;
 #endif
 }
 

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -742,18 +742,19 @@ class P2pIbgdaTransportDevice {
    */
   __device__ void flush(
       ThreadGroup& group,
-      IbDirection direction = IbDirection::Send) {
+      IbDirection direction = IbDirection::Send,
+      const Timeout& timeout = Timeout()) {
     if (group.is_leader()) {
       validate_group_scope(group);
-      drain_flush_lanes(group, direction);
+      drain_flush_lanes(group, direction, timeout);
     }
     group.sync();
   }
 
   /** flush (thread-scope) - Single-thread variant. */
-  __device__ void flush() {
+  __device__ void flush(const Timeout& timeout = Timeout()) {
     ThreadGroup solo = make_thread_solo();
-    flush(solo);
+    flush(solo, IbDirection::Send, timeout);
   }
 
   /**
@@ -766,13 +767,14 @@ class P2pIbgdaTransportDevice {
    */
   __device__ void fence(
       ThreadGroup& group,
-      IbDirection direction = IbDirection::Send) {
-    flush(group, direction);
+      IbDirection direction = IbDirection::Send,
+      const Timeout& timeout = Timeout()) {
+    flush(group, direction, timeout);
   }
 
   /** fence (thread-scope) - Single-thread variant. */
-  __device__ void fence() {
-    flush();
+  __device__ void fence(const Timeout& timeout = Timeout()) {
+    flush(timeout);
   }
 
   // =========================================================================
@@ -1084,7 +1086,7 @@ class P2pIbgdaTransportDevice {
             DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
             doca_gpu_dev_verbs_qp_get_cq_sq(qp), ticket);
         if (status == EBUSY) {
-          (void)FT_ABORT_CHECK(
+          FT_ABORT_BREAK(
               timeout,
               "wait_local_on_qp timed out (ticket=%llu)",
               static_cast<unsigned long long>(ticket));
@@ -1097,21 +1099,25 @@ class P2pIbgdaTransportDevice {
       uint32_t channelId,
       IbDirection direction,
       uint64_t mask,
-      const uint64_t* tickets) {
+      const uint64_t* tickets,
+      const Timeout& timeout = Timeout()) {
     const uint32_t numLanes = num_qp_lanes();
     for (uint32_t laneId = 0; laneId < numLanes; ++laneId) {
       if ((mask & (1ULL << laneId)) == 0) {
         continue;
       }
       IbgdaLane lane = lane_from_ordinal(channelId, direction, laneId);
-      wait_local_on_qp(lane.qp, tickets[laneId]);
+      wait_local_on_qp(lane.qp, tickets[laneId], timeout);
     }
   }
 
-  __device__ void drain_flush_lanes(ThreadGroup& group, IbDirection direction) {
+  __device__ void drain_flush_lanes(
+      ThreadGroup& group,
+      IbDirection direction,
+      const Timeout& timeout = Timeout()) {
     auto& state = qp_state(group.group_id, direction);
     const uint64_t mask = atomic_exchange_u64(&state.pendingFlushLanesMask, 0);
-    wait_lanes(group.group_id, direction, mask, state.lastFlushWqe);
+    wait_lanes(group.group_id, direction, mask, state.lastFlushWqe, timeout);
   }
 
   __device__ IbLocalCompletionTicket put_impl(
@@ -1251,7 +1257,7 @@ class P2pIbgdaTransportDevice {
     if (group.is_leader()) {
       uint64_t current = load_acquire_system_u64(signalBuf.ptr);
       while (current < expected) {
-        (void)FT_ABORT_CHECK(
+        FT_ABORT_BREAK(
             timeout,
             "wait_signal: expected>=%llu, current=%llu",
             static_cast<unsigned long long>(expected),
@@ -1272,7 +1278,7 @@ class P2pIbgdaTransportDevice {
     if (group.is_leader()) {
       uint64_t current = load_acquire_system_u64(counterBuf.ptr);
       while (current < expected) {
-        (void)FT_ABORT_CHECK(
+        FT_ABORT_BREAK(
             timeout,
             "wait_counter: expected>=%llu, current=%llu",
             static_cast<unsigned long long>(expected),

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -383,14 +383,11 @@ class P2pIbrcTransportDevice {
       while (static_cast<int64_t>(
                  load_acquire_system_u64(queue.ci) - ticket.value) < 0) {
         check_status(queue);
-        if (timeout.checkExpired()) {
-          printf(
-              "P2pIbrcTransportDevice: wait_local timed out lane=%u "
-              "expected=%llu\n",
-              ticket.completionId,
-              static_cast<unsigned long long>(ticket.value));
-          PIPES_DEVICE_TRAP();
-        }
+        FT_ABORT_BREAK(
+            timeout,
+            "P2pIbrcTransportDevice: wait_local lane=%u expected=%llu",
+            ticket.completionId,
+            static_cast<unsigned long long>(ticket.value));
       }
     }
     group.sync();
@@ -940,13 +937,11 @@ class P2pIbrcTransportDevice {
       validate_group_scope(group);
       while (load_acquire_system_u64(ptr) < expected) {
         check_channel_status(group.group_id);
-        if (timeout.checkExpired()) {
-          printf(
-              "P2pIbrcTransportDevice: wait_%s timed out expected=%llu\n",
-              kind,
-              static_cast<unsigned long long>(expected));
-          PIPES_DEVICE_TRAP();
-        }
+        FT_ABORT_BREAK(
+            timeout,
+            "P2pIbrcTransportDevice: wait_%s expected=%llu",
+            kind,
+            static_cast<unsigned long long>(expected));
       }
     }
     group.sync();


### PR DESCRIPTION
Summary:
Propagates `AbortDevice` wait/check results through the IB transport paths while preserving the transport-facing API shape.

The key behavior is that transport waits can now unwind on SKIP-mode abort instead of only trapping on timeout, and the later P2P IB test diff owns the direct compile/runtime coverage for these paths.

Changes in this update:
- **Release the progress slot on every abort exit.** `send()`, `recv()` and `forward()` open with `assert_progress_slot_idle()`, which traps on a slot still marked `Busy`. Their abort exits returned without restoring `activeStage`/`activeBaseStep`/`activeNextByte`/`activeTailPadding`, so the *next* operation on the same channel -- native Direct AllReduce reusing a rail-peer transport in phase 2b after 2a -- turned a SKIP into a TRAP. New `abandon_progress_slot()` is called at all 8 abort exits (`forward()` releases both its recv and fwd slots). It restores only local reusability; the byte cursors stay where the abandoned operation stopped, since the communicator is aborted and recovery goes through a rebuild.
- **`flush()`/`fence()` take the abort handle.** The `P2pIbTransportDevice` dispatcher was `void`, took no handle, and discarded the IBGDA `bool`, so the completion drain -- the last unbounded wait in a kernel -- could still wedge after a clean unwind out of `recv()`. Dispatcher and IBRC `flush`/`fence` now accept an `AbortDevice` and return `bool`; IBGDA `fence()` forwards it too.
- **IBRC drain is abort-responsive.** `drain_queue()` consults the handle alongside its existing `kIbrcDefaultDeviceTimeoutCycles` watchdog, which stays as a NIC-liveness backstop independent of the communicator deadline.

Returned status is advisory throughout, per the non-blocking contract in `FAULT_TOLERANCE.md`: the waits terminate themselves, so a caller that ignores the `bool` still cannot hang.

Stack review guide: https://www.internalfb.com/intern/paste/P2459153030/

Reviewed By: arttianezhu

Differential Revision: D115656602


