### PR TITLE
Add P2P IB AbortDevice wait tests (#3637)

### DIFF
--- a/comms/common/fault_tolerance/FAULT_TOLERANCE.md
+++ b/comms/common/fault_tolerance/FAULT_TOLERANCE.md
@@ -45,6 +45,23 @@ rules the detail exists to serve.
     silently means "no override".
 11. **Fault tolerance is an MCCL-communicator feature.** Communicators created
     through the NCCLX/CTRAN factory get a disabled `Abort`; see *Scope*.
+12. **Terminate the kernel cleanly; never trap to do it.** A trap takes the CUDA
+    context down and loses every other stream on the device, which is a worse
+    outcome than the hang it replaces. Abort must unwind to a normal kernel
+    exit. `FT_DEVICE_TRAP()` stays reserved for the death tests that assert trap
+    semantics deliberately.
+13. **Contain the abort path in the transport.** The transport leaves its
+    per-channel state releasable on abort -- an unwinding operation drives its
+    progress slot to the terminal stage (`abandon_progress_state()`), so a
+    kernel already queued on the same channel re-initializes without tripping
+    `assert_progress_slot_idle()`, and any further progress call short-circuits
+    to `Done`. A collective therefore drains and exits on its existing loop
+    conditions. This is a liveness guarantee, not a promise that the channel
+    still carries meaningful data: after an abort the flow-control counters are
+    skewed against the peer's, and recovery is still `reconfigure()`. Do not add
+    group-uniform abort gates, entry guards, or slot bookkeeping to a
+    collective: if a collective needs one, the transport is leaving state behind
+    and that is where the fix belongs.
 
 ## Host `Abort`
 
@@ -250,6 +267,19 @@ unlikely case of a `commSuccess`, the comm result data should still be ignored."
    and the IB progress path returns `Aborted`; that lets callers stop sooner and
    more precisely. Callers are not *obliged* to consume it, so never rely on
    propagation for liveness.
+7. **Leave the channel state releasable.** A wait that unwinds must not strand
+   the resource it was waiting on. In the IB progress path this is
+   `abandon_progress_state()` (`P2pIbTransportProgressImpl.cuh`): every abort
+   exit drives the progress slot to `Done` before returning `Aborted`, so the
+   next `init_send_progress()` / `init_recv_progress()` on that channel passes
+   `assert_progress_slot_idle()` instead of trapping, and a driver loop that
+   keeps calling progress simply drains. The reserved byte range is abandoned
+   rather than returned to the channel cursor: a peer RDMA write may still land
+   in it, and the flow-control counters are skewed after an abort regardless —
+   the point is that the queued kernel exits instead of trapping, not that the
+   channel is fit to reuse. If a new wait acquires state of its own, releasing
+   it on abort is part of adding the wait — pushing that onto the collective
+   violates the containment principle.
 
 ### Collective Enablement — onboarding a collective
 
@@ -262,6 +292,9 @@ unlikely case of a `commSuccess`, the comm result data should still be ignored."
    **only** from a timeout the caller supplied on the collective API. Never seed
    it from the communicator default; see *Per-operation timeouts*.
 5. You do **not** need to check the return value of any wait to be hang-safe.
+6. You do **not** need an abort gate, an entry guard, or slot bookkeeping of your
+   own. The transport releases its state on abort (see *Principles*), so a loop that
+   already retires on `Done` retires on an aborted channel too.
 
 Steps 1–3 are the entire integration. Forgetting them means the collective runs
 with a disabled handle and silently has no fault tolerance.

--- a/comms/prims/tests/P2pIbTransportDeviceAbortTest.cc
+++ b/comms/prims/tests/P2pIbTransportDeviceAbortTest.cc
@@ -1,0 +1,244 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <cuda_runtime.h>
+
+#include <chrono>
+#include <thread>
+
+#include "comms/common/fault_tolerance/Abort.h"
+#include "comms/prims/tests/P2pIbTransportDeviceAbortTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+namespace comms::prims {
+
+namespace {
+
+using Launcher = void (*)(
+    uint64_t*,
+    bool*,
+    uint64_t,
+    comms::fault_tolerance::AbortDevice,
+    uint32_t*);
+
+// Host-mapped flag the kernel raises just before entering the wait.
+//
+// This replaces a fixed sleep. A sleep only bounds how long the host waits; it
+// proves nothing about the kernel, so a slow launch silently turns an
+// abort-during-wait test into a pre-abort one and every assertion still passes.
+// Polling the flag makes that failure loud instead.
+class EnteredWaitFlag {
+ public:
+  EnteredWaitFlag() {
+    CUDACHECK_TEST(cudaSetDevice(0));
+    CUDACHECK_TEST(cudaHostAlloc(
+        reinterpret_cast<void**>(&host_),
+        sizeof(uint32_t),
+        cudaHostAllocMapped));
+    *host_ = 0;
+    CUDACHECK_TEST(
+        cudaHostGetDevicePointer(reinterpret_cast<void**>(&device_), host_, 0));
+  }
+
+  ~EnteredWaitFlag() {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaFreeHost(host_);
+  }
+
+  EnteredWaitFlag(const EnteredWaitFlag&) = delete;
+  EnteredWaitFlag& operator=(const EnteredWaitFlag&) = delete;
+  EnteredWaitFlag(EnteredWaitFlag&&) = delete;
+  EnteredWaitFlag& operator=(EnteredWaitFlag&&) = delete;
+
+  uint32_t* device() {
+    return device_;
+  }
+
+  // Bounded because a kernel that never reaches the wait must fail the test
+  // rather than hang it.
+  bool await(std::chrono::milliseconds bound) const {
+    const auto deadline = std::chrono::steady_clock::now() + bound;
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (__atomic_load_n(host_, __ATOMIC_ACQUIRE) != 0U) {
+        return true;
+      }
+      // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+  }
+
+ private:
+  uint32_t* host_{nullptr};
+  uint32_t* device_{nullptr};
+};
+
+// Device-side signal the wait polls, plus the slot it reports its result in.
+class WaitFixture {
+ public:
+  WaitFixture() {
+    CUDACHECK_TEST(cudaSetDevice(0));
+    CUDACHECK_TEST(cudaMalloc(&signal_, sizeof(uint64_t)));
+    CUDACHECK_TEST(cudaMalloc(&waitResult_, sizeof(bool)));
+    CUDACHECK_TEST(cudaMemset(signal_, 0, sizeof(uint64_t)));
+    CUDACHECK_TEST(cudaMemset(waitResult_, 0, sizeof(bool)));
+  }
+
+  ~WaitFixture() {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaFree(waitResult_);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaFree(signal_);
+  }
+
+  WaitFixture(const WaitFixture&) = delete;
+  WaitFixture& operator=(const WaitFixture&) = delete;
+  WaitFixture(WaitFixture&&) = delete;
+  WaitFixture& operator=(WaitFixture&&) = delete;
+
+  uint64_t* signal() {
+    return signal_;
+  }
+
+  bool* waitResult() {
+    return waitResult_;
+  }
+
+  bool readWaitResult() {
+    bool value = false;
+    CUDACHECK_TEST(
+        cudaMemcpy(&value, waitResult_, sizeof(bool), cudaMemcpyDeviceToHost));
+    return value;
+  }
+
+ private:
+  uint64_t* signal_{nullptr};
+  bool* waitResult_{nullptr};
+};
+
+// A satisfied wait must report success and must not touch abort state.
+void runAlreadySatisfiedWait(Launcher launcher) {
+  WaitFixture fixture;
+  comms::fault_tolerance::AbortDevice disabled;
+
+  launcher(
+      fixture.signal(),
+      fixture.waitResult(),
+      /*expected=*/0,
+      disabled,
+      /*enteredWait=*/nullptr);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  EXPECT_TRUE(fixture.readWaitResult());
+}
+
+// An abort recorded before launch must make the wait give up immediately.
+void runPreAbortedWait(Launcher launcher) {
+  WaitFixture fixture;
+  comms::fault_tolerance::Abort abort(/*enabled=*/true);
+  abort.setAbort();
+
+  launcher(
+      fixture.signal(),
+      fixture.waitResult(),
+      /*expected=*/1,
+      abort.getDeviceHandle(),
+      /*enteredWait=*/nullptr);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  EXPECT_FALSE(fixture.readWaitResult());
+}
+
+// The liveness property: a wait already spinning on a signal that will never
+// arrive still exits once the host aborts. Without this the kernel runs until
+// the CUDA launch timeout, which is the hang this stack exists to remove.
+void runAbortDuringWait(Launcher launcher) {
+  WaitFixture fixture;
+  EnteredWaitFlag entered;
+  comms::fault_tolerance::Abort abort(/*enabled=*/true);
+
+  launcher(
+      fixture.signal(),
+      fixture.waitResult(),
+      /*expected=*/1,
+      abort.getDeviceHandle(),
+      entered.device());
+  const bool reachedWait = entered.await(std::chrono::seconds(10));
+  // Abort and drain before asserting on the handshake. `setAbort()` is what
+  // releases the kernel, so failing out first would run `abort`'s and
+  // `fixture`'s destructors -- unmapping the abort state and freeing the signal
+  // buffer -- while the kernel is still polling both.
+  abort.setAbort();
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  ASSERT_TRUE(reachedWait)
+      << "kernel never reached the wait, so this would silently degenerate "
+         "into the pre-abort case";
+
+  EXPECT_FALSE(fixture.readWaitResult());
+  EXPECT_TRUE(abort.isAborted());
+  EXPECT_FALSE(abort.isTimedOut())
+      << "an explicit abort must win the first-writer race";
+}
+
+// The device deadline reaches the same wait with no host involvement, and the
+// expiry is recorded in shared state where host code can see it.
+void runTimeoutDuringWait(Launcher launcher) {
+  constexpr std::chrono::milliseconds kTimeout{500};
+  WaitFixture fixture;
+  comms::fault_tolerance::Abort abort(/*enabled=*/true);
+  abort.setDefaultTimeout(kTimeout);
+
+  const auto start = std::chrono::steady_clock::now();
+  launcher(
+      fixture.signal(),
+      fixture.waitResult(),
+      /*expected=*/1,
+      abort.getDeviceHandle(),
+      /*enteredWait=*/nullptr);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - start);
+
+  EXPECT_FALSE(fixture.readWaitResult());
+  EXPECT_TRUE(abort.isTimedOut());
+  // Only an upper bound is asserted: the lower bound is timing-sensitive under
+  // load, while "finished long before any watchdog" is the property at stake.
+  EXPECT_LT(elapsed, std::chrono::seconds(10));
+}
+
+} // namespace
+
+TEST(P2pIbTransportDeviceAbortTest, WrapperWaitSignalSucceedsWhenSatisfied) {
+  runAlreadySatisfiedWait(test::launchIbWrapperWaitSignal);
+}
+
+TEST(P2pIbTransportDeviceAbortTest, IbrcWaitSignalSucceedsWhenSatisfied) {
+  runAlreadySatisfiedWait(test::launchIbrcWaitSignal);
+}
+
+TEST(P2pIbTransportDeviceAbortTest, WrapperWaitSignalSkipsWhenPreAborted) {
+  runPreAbortedWait(test::launchIbWrapperWaitSignal);
+}
+
+TEST(P2pIbTransportDeviceAbortTest, IbrcWaitSignalSkipsWhenPreAborted) {
+  runPreAbortedWait(test::launchIbrcWaitSignal);
+}
+
+TEST(P2pIbTransportDeviceAbortTest, WrapperWaitSignalExitsOnAbortDuringWait) {
+  runAbortDuringWait(test::launchIbWrapperWaitSignal);
+}
+
+TEST(P2pIbTransportDeviceAbortTest, IbrcWaitSignalExitsOnAbortDuringWait) {
+  runAbortDuringWait(test::launchIbrcWaitSignal);
+}
+
+TEST(P2pIbTransportDeviceAbortTest, WrapperWaitSignalExitsOnDeviceTimeout) {
+  runTimeoutDuringWait(test::launchIbWrapperWaitSignal);
+}
+
+TEST(P2pIbTransportDeviceAbortTest, IbrcWaitSignalExitsOnDeviceTimeout) {
+  runTimeoutDuringWait(test::launchIbrcWaitSignal);
+}
+
+} // namespace comms::prims

--- a/comms/prims/tests/P2pIbTransportDeviceAbortTest.cu
+++ b/comms/prims/tests/P2pIbTransportDeviceAbortTest.cu
@@ -1,0 +1,115 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/prims/tests/P2pIbTransportDeviceAbortTest.cuh"
+
+#include <cstddef>
+
+#include "comms/common/fault_tolerance/AbortDevice.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/tests/Checks.h"
+#include "comms/prims/transport/P2pIbTransportDevice.cuh"
+#include "comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh"
+
+namespace comms::prims::test {
+
+namespace {
+
+// Queue and channel state backing the transport under test.
+//
+// Must be one block-wide object: `wait_signal` is a group primitive whose
+// leader reads this state on behalf of every thread. Per-thread locals would
+// give each thread its own copy, so the leader would be polling storage no
+// other thread can see.
+struct IbrcScratch {
+  IbrcCmdQueueDevice queues[2];
+  IbLocalChannel channels[1];
+};
+
+__device__ void zeroScratch(ThreadGroup& group, IbrcScratch& scratch) {
+  auto* raw = reinterpret_cast<char*>(&scratch);
+  for (std::size_t i = group.thread_id_in_group; i < sizeof(IbrcScratch);
+       i += group.group_size) {
+    raw[i] = 0;
+  }
+  group.sync();
+}
+
+__device__ P2pIbrcTransportDevice makeLocalIbrcTransport(IbrcScratch& scratch) {
+  return P2pIbrcTransportDevice(
+      DeviceSpan<IbrcCmdQueueDevice>{scratch.queues, 2},
+      /*nics=*/1,
+      /*maxChannels=*/1,
+      /*qpsPerConnection=*/1,
+      DeviceSpan<IbLocalChannel>{scratch.channels, 1});
+}
+
+// Which of the two production call paths reaches the same IBRC wait.
+enum class IbEntryPoint { Wrapper, Ibrc };
+
+template <IbEntryPoint kEntry>
+__global__ void waitSignalKernel(
+    uint64_t* signal,
+    bool* waitResult,
+    uint64_t expected,
+    comms::fault_tolerance::AbortDevice abort,
+    uint32_t* enteredWait) {
+  auto group = make_block_group();
+  __shared__ IbrcScratch scratch;
+  zeroScratch(group, scratch);
+
+  P2pIbrcTransportDevice ibrc = makeLocalIbrcTransport(scratch);
+  IbgdaLocalBuffer localSignal{signal, NetworkLKeys{}};
+
+  abort.start();
+  // Published last, after the handle is armed, so a host that sees it knows
+  // every precondition of the wait is already in place.
+  if (group.is_leader() && enteredWait != nullptr) {
+    __threadfence_system();
+    *static_cast<volatile uint32_t*>(enteredWait) = 1U;
+  }
+  group.sync();
+
+  if constexpr (kEntry == IbEntryPoint::Wrapper) {
+    P2pIbTransportDevice transport(&ibrc);
+    transport.wait_signal(group, localSignal, expected, abort);
+  } else {
+    ibrc.wait_signal(group, localSignal, expected, abort);
+  }
+  // Reaching this line at all is the liveness guarantee under test: the wait
+  // reports no status, so a wait that failed to terminate hangs the kernel
+  // rather than returning something for the host to inspect.
+  //
+  // Whether the condition actually held on exit is read back from the signal
+  // itself. That is what separates "the signal arrived" from "the abort
+  // released us", without the wait having to hand back a status.
+  if (group.is_leader()) {
+    const uint64_t current = *static_cast<volatile uint64_t*>(signal);
+    *waitResult = current >= expected;
+  }
+}
+
+} // namespace
+
+void launchIbWrapperWaitSignal(
+    uint64_t* signal,
+    bool* waitResult,
+    uint64_t expected,
+    comms::fault_tolerance::AbortDevice abort,
+    uint32_t* enteredWait) {
+  waitSignalKernel<IbEntryPoint::Wrapper>
+      <<<1, 32>>>(signal, waitResult, expected, abort, enteredWait);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchIbrcWaitSignal(
+    uint64_t* signal,
+    bool* waitResult,
+    uint64_t expected,
+    comms::fault_tolerance::AbortDevice abort,
+    uint32_t* enteredWait) {
+  waitSignalKernel<IbEntryPoint::Ibrc>
+      <<<1, 32>>>(signal, waitResult, expected, abort, enteredWait);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/P2pIbTransportDeviceAbortTest.cuh
+++ b/comms/prims/tests/P2pIbTransportDeviceAbortTest.cuh
@@ -1,0 +1,48 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef COMMS_PRIMS_TESTS_P2P_IB_TRANSPORT_DEVICE_ABORT_TEST_CUH_
+#define COMMS_PRIMS_TESTS_P2P_IB_TRANSPORT_DEVICE_ABORT_TEST_CUH_
+
+#include <cstdint>
+
+#include "comms/common/fault_tolerance/AbortDevice.cuh"
+
+namespace comms::prims::test {
+
+/*
+ * Runs `wait_signal(group, signal, expected, abort)` on a locally constructed
+ * IBRC transport and stores the wait's return value in `waitResult`.
+ *
+ * Both entry points exercise the same wait through the two call paths that
+ * production uses: the `P2pIbTransportDevice` dispatcher and the IBRC backend
+ * directly. `expected == 0` is satisfied immediately by a zeroed signal;
+ * anything higher never completes, so the wait can only return by observing
+ * the abort handle.
+ *
+ * Asynchronous: the caller synchronizes and reads `waitResult` itself, which
+ * is what lets a test abort the handle while the kernel is spinning.
+ *
+ * `enteredWait` must point at host-mapped memory. The kernel raises it, with a
+ * system release fence, immediately before entering the wait. A test that
+ * aborts mid-flight polls it first so it knows the kernel is resident and at
+ * the wait, rather than sleeping and hoping. Without that, a slow launch turns
+ * the abort-during-wait case into the pre-abort case with every assertion still
+ * passing. May be null when the caller does not need the handshake.
+ */
+void launchIbWrapperWaitSignal(
+    uint64_t* signal,
+    bool* waitResult,
+    uint64_t expected,
+    comms::fault_tolerance::AbortDevice abort,
+    uint32_t* enteredWait = nullptr);
+
+void launchIbrcWaitSignal(
+    uint64_t* signal,
+    bool* waitResult,
+    uint64_t expected,
+    comms::fault_tolerance::AbortDevice abort,
+    uint32_t* enteredWait = nullptr);
+
+} // namespace comms::prims::test
+
+#endif // COMMS_PRIMS_TESTS_P2P_IB_TRANSPORT_DEVICE_ABORT_TEST_CUH_

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTest.cu
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTest.cu
@@ -129,6 +129,37 @@ __global__ void testWaitSignalWithDisabledAbort(
   *success = true;
 }
 
+__global__ void testWaitSignalUntilAbort(
+    uint64_t* d_signalBuf,
+    comms::fault_tolerance::AbortDevice abort,
+    bool* success,
+    uint32_t* enteredWait) {
+  IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{});
+  P2pIbgdaTransportDevice transport(
+      DeviceSpan<NicDeviceIbgdaResources>{},
+      IbgdaRemoteBuffer{},
+      localSigBuf,
+      IbgdaLocalBuffer{},
+      1);
+
+  // Arm the deadline the way a production kernel does. Without this the
+  // handle observes explicit aborts only, and a communicator timeout never
+  // reaches the wait.
+  abort.start();
+  // Published after the handle is armed, so a host that sees it knows every
+  // precondition of the wait is already in place.
+  if (enteredWait != nullptr) {
+    __threadfence_system();
+    *static_cast<volatile uint32_t*>(enteredWait) = 1U;
+  }
+  transport.wait_signal(0, 1, abort);
+  // Reaching this line is the liveness guarantee: the wait reports no status,
+  // so one that failed to terminate hangs the kernel instead. The signal slot
+  // is what distinguishes the two ways out -- it is still short of the expected
+  // value here, so the abort released the wait rather than the signal landing.
+  *success = *static_cast<volatile uint64_t*>(localSigBuf.ptr) < 1;
+}
+
 // =============================================================================
 // Wrapper functions to launch the kernels (called from .cc test file)
 // =============================================================================
@@ -166,6 +197,15 @@ void runTestWaitSignalWithDisabledAbort(
     uint64_t* d_signalBuf,
     bool* d_success) {
   testWaitSignalWithDisabledAbort<<<1, 1>>>(d_signalBuf, d_success);
+}
+
+void runTestWaitSignalUntilAbort(
+    uint64_t* d_signalBuf,
+    comms::fault_tolerance::AbortDevice abort,
+    bool* d_success,
+    uint32_t* d_enteredWait) {
+  testWaitSignalUntilAbort<<<1, 1>>>(
+      d_signalBuf, abort, d_success, d_enteredWait);
 }
 
 // =============================================================================

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 
+#include "comms/common/fault_tolerance/AbortDevice.cuh"
 #include "comms/prims/trace/PipesTraceTypes.h"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 
@@ -44,6 +45,22 @@ void runTestWaitSignalMultipleSlots(
     uint64_t* d_signalBuf,
     int numSignals,
     bool* d_success);
+
+void runTestWaitSignalWithDisabledAbort(uint64_t* d_signalBuf, bool* d_success);
+
+// Waits on a signal that never arrives, so the wait can only end by observing
+// the abort handle. Used by three scenarios -- a handle aborted before launch,
+// one aborted mid-wait, and one whose device deadline expires -- which is why
+// it is not named after any single one of them.
+//
+// `d_enteredWait`, when non-null, must point at host-mapped memory. The kernel
+// raises it immediately before entering the wait so a test aborting mid-flight
+// can confirm the kernel got there instead of sleeping and hoping.
+void runTestWaitSignalUntilAbort(
+    uint64_t* d_signalBuf,
+    comms::fault_tolerance::AbortDevice abort,
+    bool* d_success,
+    uint32_t* d_enteredWait = nullptr);
 
 // =============================================================================
 // Group-level API tests

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTestMain.cc
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTestMain.cc
@@ -8,9 +8,13 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstdint>
 #include <functional>
+#include <thread>
 #include <vector>
+
+#include "comms/common/fault_tolerance/Abort.h"
 
 // On AMD (`__HIP_PLATFORM_AMD__`), this maps `cuda*` runtime APIs to
 // `hip*` and provides a HIP-backed `meta::comms::DeviceBuffer`. No-op
@@ -207,6 +211,108 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalZeroValue) {
   runAndVerify([&](bool* d_success) {
     runTestWaitSignalGE(d_signalBuf, targetValue, d_success);
   });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalAcceptsDisabledAbort) {
+  DeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+  CUDACHECK_TEST(cudaMemset(d_signalBuf, 0, sizeof(uint64_t)));
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalWithDisabledAbort(d_signalBuf, d_success);
+  });
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalSkipsWhenPreAborted) {
+  DeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+  CUDACHECK_TEST(cudaMemset(d_signalBuf, 0, sizeof(uint64_t)));
+
+  comms::fault_tolerance::Abort abort(/*enabled=*/true);
+  abort.setAbort();
+  auto abortDevice = abort.getDeviceHandle();
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalUntilAbort(d_signalBuf, abortDevice, d_success);
+  });
+}
+
+// Liveness on the IBGDA path: a wait already spinning on a signal that will
+// never arrive still exits once the host aborts, and once the device deadline
+// expires. Both go through the same shared abort state the kernel polls.
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalExitsOnAbortDuringWait) {
+  DeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+  CUDACHECK_TEST(cudaMemset(d_signalBuf, 0, sizeof(uint64_t)));
+
+  DeviceBuffer successBuf(sizeof(bool));
+  auto* d_success = static_cast<bool*>(successBuf.get());
+  CUDACHECK_TEST(cudaMemset(d_success, 0, sizeof(bool)));
+
+  // Host-mapped so the host can watch the kernel reach the wait. A fixed sleep
+  // bounds only the host, so a slow launch would silently turn this into the
+  // pre-abort case with every assertion still passing.
+  uint32_t* h_entered = nullptr;
+  uint32_t* d_entered = nullptr;
+  CUDACHECK_TEST(cudaHostAlloc(
+      reinterpret_cast<void**>(&h_entered),
+      sizeof(uint32_t),
+      cudaHostAllocMapped));
+  *h_entered = 0;
+  CUDACHECK_TEST(cudaHostGetDevicePointer(
+      reinterpret_cast<void**>(&d_entered), h_entered, 0));
+
+  comms::fault_tolerance::Abort abort(/*enabled=*/true);
+  runTestWaitSignalUntilAbort(
+      d_signalBuf, abort.getDeviceHandle(), d_success, d_entered);
+
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(10);
+  bool entered = false;
+  while (!entered && std::chrono::steady_clock::now() < deadline) {
+    entered = __atomic_load_n(h_entered, __ATOMIC_ACQUIRE) != 0U;
+    // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  // Abort and drain before asserting on the handshake. `setAbort()` is what
+  // releases the kernel, so failing out first would run the `DeviceBuffer` and
+  // `Abort` destructors -- freeing the signal buffer and unmapping the abort
+  // state -- while the kernel is still polling both, and would leak
+  // `h_entered` on top.
+  abort.setAbort();
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  // Cast to void, not just NOLINT: this file is hipified for the AMD build,
+  // where `hipHostFree` is `[[nodiscard]]` and an ignored result is a
+  // `-Werror,-Wunused-value` build failure. The NOLINT suppresses the lint, not
+  // the compiler. Discarding is deliberate -- this is teardown on a path that
+  // is already unwinding, and there is nothing useful to do with a failure
+  // here. NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  (void)cudaFreeHost(h_entered);
+  ASSERT_TRUE(entered) << "kernel never reached the wait";
+
+  bool success = false;
+  CUDACHECK_TEST(
+      cudaMemcpy(&success, d_success, sizeof(bool), cudaMemcpyDeviceToHost));
+  // The kernel stores `!wait_signal(...)`, so true means the wait gave up.
+  EXPECT_TRUE(success);
+  EXPECT_TRUE(abort.isAborted());
+  EXPECT_FALSE(abort.isTimedOut())
+      << "an explicit abort must win the first-writer race";
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalExitsOnDeviceTimeout) {
+  DeviceBuffer signalBuf(sizeof(uint64_t));
+  auto* d_signalBuf = static_cast<uint64_t*>(signalBuf.get());
+  CUDACHECK_TEST(cudaMemset(d_signalBuf, 0, sizeof(uint64_t)));
+
+  comms::fault_tolerance::Abort abort(/*enabled=*/true);
+  abort.setDefaultTimeout(std::chrono::milliseconds(500));
+  auto abortDevice = abort.getDeviceHandle();
+
+  runAndVerify([&](bool* d_success) {
+    runTestWaitSignalUntilAbort(d_signalBuf, abortDevice, d_success);
+  });
+  EXPECT_TRUE(abort.isTimedOut());
 }
 
 TEST_F(P2pIbgdaTransportDeviceTestFixture, WaitSignalMaxValue) {

--- a/comms/prims/tests/ProgressSlotReleaseTest.cc
+++ b/comms/prims/tests/ProgressSlotReleaseTest.cc
@@ -1,0 +1,63 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+#include <cstddef>
+
+#include "comms/prims/tests/ProgressSlotReleaseTest.cuh"
+
+namespace comms::prims {
+namespace {
+
+using test::SlotProbe;
+
+// Every non-terminal stage a transfer can unwind from. `Busy` is deliberately
+// absent: it belongs to the blocking send()/recv(), which runs its waits to
+// completion under SKIP and clears the stage itself.
+constexpr int kNonTerminalStages[] = {
+    test::kStageWaitLocalCompletion,
+    test::kStageWaitSlotFree,
+    test::kStageWaitDataReady,
+};
+
+// Half a chunk in, so the slot is unambiguously mid-transfer.
+constexpr std::size_t kNextByte = 8192;
+
+// Control. If staging did not actually produce a non-idle slot, the test below
+// would pass without proving anything.
+TEST(ProgressSlotReleaseTest, StagedSlotIsNotIdle) {
+  for (const int stage : kNonTerminalStages) {
+    const SlotProbe probe = test::stage_slot(stage, kNextByte);
+    EXPECT_EQ(probe.stage, stage);
+    EXPECT_NE(probe.stage, test::kStageDone) << "stage=" << stage;
+  }
+}
+
+// The containment property: an aborted transfer leaves the slot reusable, so
+// the next kernel on the channel re-initializes instead of trapping. The
+// assert_progress_slot_idle() call inside the second kernel launch is itself
+// half the assertion -- it traps the whole context if the slot is not released,
+// which surfaces here as a CUDA error from the readback.
+TEST(ProgressSlotReleaseTest, AbandonedSlotIsIdleForTheNextKernel) {
+  for (const int stage : kNonTerminalStages) {
+    const SlotProbe probe = test::abandon_then_reinit(stage, kNextByte);
+    EXPECT_EQ(probe.stage, test::kStageDone) << "stage=" << stage;
+    EXPECT_EQ(probe.nextByte, 0u) << "stage=" << stage;
+    EXPECT_EQ(probe.tailPadding, 0u) << "stage=" << stage;
+    EXPECT_EQ(probe.baseStep, 0) << "stage=" << stage;
+  }
+}
+
+// The reserved range is abandoned, not recycled. A peer's RDMA write may still
+// land in it, so rewinding the channel cursor would hand those bytes to the
+// next operation.
+TEST(ProgressSlotReleaseTest, AbandonKeepsTheChannelCursorAdvanced) {
+  const SlotProbe staged =
+      test::stage_slot(test::kStageWaitSlotFree, kNextByte);
+  const SlotProbe abandoned =
+      test::abandon_then_reinit(test::kStageWaitSlotFree, kNextByte);
+  EXPECT_GT(staged.nextStep, 0);
+  EXPECT_EQ(abandoned.nextStep, staged.nextStep);
+}
+
+} // namespace
+} // namespace comms::prims

--- a/comms/prims/tests/ProgressSlotReleaseTest.cu
+++ b/comms/prims/tests/ProgressSlotReleaseTest.cu
@@ -1,0 +1,142 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <cstddef>
+
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/tests/Checks.h"
+#include "comms/prims/tests/ProgressSlotReleaseTest.cuh"
+#include "comms/prims/transport/P2pIbTransportProgressImpl.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+using detail::IbSendRecvProgressStage;
+
+static_assert(static_cast<int>(IbSendRecvProgressStage::Done) == kStageDone);
+static_assert(
+    static_cast<int>(IbSendRecvProgressStage::WaitLocalCompletion) ==
+    kStageWaitLocalCompletion);
+static_assert(
+    static_cast<int>(IbSendRecvProgressStage::WaitSlotFree) ==
+    kStageWaitSlotFree);
+static_assert(
+    static_cast<int>(IbSendRecvProgressStage::WaitDataReady) ==
+    kStageWaitDataReady);
+
+// Arbitrary non-zero cursors. They exist only so the probe can tell an
+// abandoned slot from an untouched one.
+constexpr std::size_t kTailPadding = 64;
+constexpr int64_t kBaseStep = 4096;
+constexpr int64_t kNextStep = 1ll << 20;
+
+__device__ ThreadGroup make_group() {
+  return ThreadGroup{
+      threadIdx.x,
+      blockDim.x,
+      blockIdx.x,
+      blockIdx.x,
+      gridDim.x,
+      SyncScope::BLOCK};
+}
+
+// Reproduces the state a transfer leaves behind when it unwinds part-way
+// through: the byte range is reserved (nextStep advanced) and the state machine
+// sits in a non-terminal stage.
+__global__ void stage_slot_kernel(
+    int startStage,
+    std::size_t startNextByte,
+    IbChannelProgress* slot) {
+  if (threadIdx.x != 0 || blockIdx.x != 0) {
+    return;
+  }
+  slot->nextStep = kNextStep;
+  slot->activeNextByte = startNextByte;
+  slot->activeTailPadding = kTailPadding;
+  slot->activeBaseStep = kBaseStep;
+  slot->activeStage = static_cast<IbSendRecvProgressStage>(startStage);
+  slot->activeVariableSize = false;
+}
+
+__global__ void abandon_kernel(IbChannelProgress* slot) {
+  ThreadGroup g = make_group();
+  IbChannelProgress state = *slot;
+  detail::abandon_progress_state(g, *slot, state);
+}
+
+// Stands in for the next collective queued on this channel. Traps unless the
+// preceding abort left the slot idle.
+__global__ void reinit_kernel(IbChannelProgress* slot) {
+  ThreadGroup g = make_group();
+  detail::assert_progress_slot_idle(g, *slot, "send");
+}
+
+__global__ void read_slot_kernel(
+    const IbChannelProgress* slot,
+    SlotProbe* out) {
+  if (threadIdx.x != 0 || blockIdx.x != 0) {
+    return;
+  }
+  out->stage = static_cast<int>(slot->activeStage);
+  out->nextByte = static_cast<unsigned long long>(slot->activeNextByte);
+  out->tailPadding = static_cast<unsigned long long>(slot->activeTailPadding);
+  out->baseStep = static_cast<long long>(slot->activeBaseStep);
+  out->nextStep = static_cast<long long>(slot->nextStep);
+}
+
+// The slot lives in device global memory, not shared or local, because the
+// property under test is that it survives the aborted kernel in a reusable
+// state for the next one.
+class SlotFixture {
+ public:
+  SlotFixture(int startStage, std::size_t startNextByte) {
+    PIPES_CUDA_CHECK(cudaMalloc(&slot_, sizeof(IbChannelProgress)));
+    PIPES_CUDA_CHECK(cudaMalloc(&probe_, sizeof(SlotProbe)));
+    stage_slot_kernel<<<1, 1>>>(startStage, startNextByte, slot_);
+    PIPES_KERNEL_LAUNCH_CHECK();
+  }
+
+  ~SlotFixture() {
+    (void)cudaFree(slot_);
+    (void)cudaFree(probe_);
+  }
+
+  SlotFixture(const SlotFixture&) = delete;
+  SlotFixture& operator=(const SlotFixture&) = delete;
+
+  IbChannelProgress* slot() {
+    return slot_;
+  }
+
+  SlotProbe read() {
+    read_slot_kernel<<<1, 1>>>(slot_, probe_);
+    PIPES_KERNEL_LAUNCH_CHECK();
+    PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+    SlotProbe host{};
+    PIPES_CUDA_CHECK(
+        cudaMemcpy(&host, probe_, sizeof(host), cudaMemcpyDeviceToHost));
+    return host;
+  }
+
+ private:
+  IbChannelProgress* slot_{nullptr};
+  SlotProbe* probe_{nullptr};
+};
+
+} // namespace
+
+SlotProbe stage_slot(int startStage, std::size_t startNextByte) {
+  SlotFixture fixture(startStage, startNextByte);
+  return fixture.read();
+}
+
+SlotProbe abandon_then_reinit(int startStage, std::size_t startNextByte) {
+  SlotFixture fixture(startStage, startNextByte);
+  abandon_kernel<<<1, 32>>>(fixture.slot());
+  PIPES_KERNEL_LAUNCH_CHECK();
+  reinit_kernel<<<1, 32>>>(fixture.slot());
+  PIPES_KERNEL_LAUNCH_CHECK();
+  return fixture.read();
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/ProgressSlotReleaseTest.cuh
+++ b/comms/prims/tests/ProgressSlotReleaseTest.cuh
@@ -1,0 +1,42 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+namespace comms::prims::test {
+
+/// Host-visible copy of the fields of one `IbChannelProgress` slot, so the .cc
+/// can assert on the slot without including any transport header.
+struct SlotProbe {
+  int stage;
+  unsigned long long nextByte;
+  unsigned long long tailPadding;
+  long long baseStep;
+  long long nextStep;
+};
+
+/// `detail::IbSendRecvProgressStage` mirrored as plain ints, same reason.
+/// Static-asserted against the enum in the .cu.
+constexpr int kStageDone = 0;
+constexpr int kStageWaitLocalCompletion = 1;
+constexpr int kStageWaitSlotFree = 2;
+constexpr int kStageWaitDataReady = 3;
+
+/// Writes a mid-transfer progress slot into device memory and reads it back
+/// without touching it, so a test can show the staged state is one that
+/// `assert_progress_slot_idle()` would reject.
+SlotProbe stage_slot(int startStage, std::size_t startNextByte);
+
+/// Stages the same mid-transfer slot, runs `abandon_progress_state()` over it,
+/// then -- from a SECOND kernel launch -- runs `assert_progress_slot_idle()`
+/// and reads the slot back.
+///
+/// The second launch is the whole point. The trap this containment change
+/// exists to remove does not fire in the kernel that aborted; it fires in the
+/// next kernel queued on the same channel, when its `init_send_progress()`
+/// finds the slot still mid-transfer. Running the assert in the same kernel
+/// would not exercise that.
+SlotProbe abandon_then_reinit(int startStage, std::size_t startNextByte);
+
+} // namespace comms::prims::test

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -67,6 +67,11 @@ __device__ __forceinline__ void store_progress_state(
     IbChannelProgress& slot,
     const IbChannelProgress& state);
 
+__device__ __forceinline__ void abandon_progress_state(
+    ThreadGroup& group,
+    IbChannelProgress& slot,
+    IbChannelProgress& state);
+
 template <typename Proto = protocol::Simple>
 __device__ __forceinline__ ProgressGeometry make_progress_geometry(
     const IbChannelLayout& channelLayout,
@@ -458,9 +463,11 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
             chunk.wireBytes);
         traceState->localCompletionWaitOpen = true;
       }
-      return slotReadiness == kProgressAborted
-          ? IbgdaSendRecvProgressStatus::Aborted
-          : IbgdaSendRecvProgressStatus::Waiting;
+      if (slotReadiness == kProgressAborted) {
+        abandon_progress_state(group, progressSlot, state);
+        return IbgdaSendRecvProgressStatus::Aborted;
+      }
+      return IbgdaSendRecvProgressStatus::Waiting;
     }
     if (fine_trace_enabled(traceContext) && traceState != nullptr &&
         traceState->localCompletionWaitOpen && group.is_leader()) {
@@ -527,7 +534,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
       }
       ready = group.broadcast<uint32_t>(ready);
       if (ready == kProgressAborted) {
-        store_progress_state(group, progressSlot, state);
+        abandon_progress_state(group, progressSlot, state);
         return IbgdaSendRecvProgressStatus::Aborted;
       }
       if (!ready) {
@@ -705,9 +712,11 @@ progress_registered_send_once(
     const uint32_t slotReadiness = try_prepare_send_slot<protocol::Simple>(
         transport, group, chunk.slotId, chunk.pipelineGeneration, timeout);
     if (slotReadiness != kProgressReady) {
-      return slotReadiness == kProgressAborted
-          ? IbgdaRegisteredSendProgressStatus::Aborted
-          : IbgdaRegisteredSendProgressStatus::Waiting;
+      if (slotReadiness == kProgressAborted) {
+        abandon_progress_state(group, progressSlot, state);
+        return IbgdaRegisteredSendProgressStatus::Aborted;
+      }
+      return IbgdaRegisteredSendProgressStatus::Waiting;
     }
     transition_progress_stage(
         group, state, detail::IbSendRecvProgressStage::WaitSlotFree);
@@ -742,7 +751,7 @@ progress_registered_send_once(
       }
       ready = group.broadcast<uint32_t>(ready);
       if (ready == kProgressAborted) {
-        store_progress_state(group, progressSlot, state);
+        abandon_progress_state(group, progressSlot, state);
         return IbgdaRegisteredSendProgressStatus::Aborted;
       }
       if (!ready) {
@@ -813,6 +822,30 @@ progress_registered_send_once(
 #endif
 }
 
+/**
+ * Drain outstanding local send completions for this channel, one bounded pass.
+ *
+ * Terminal once the abort is latched, which is the drain-side counterpart of
+ * `abandon_progress_state()`. Without it this call is not terminal at all: the
+ * abort path persists the lanes it did NOT drain (`slot.laneMask = pending`
+ * below) and stops the outer loop early, so every later call re-finds the same
+ * lanes and returns `Aborted` again forever. A caller that loops until
+ * `Drained`
+ * -- `ReduceScatterDirectIbV2.cu` does exactly that -- then spins for the life
+ * of the kernel. The `activeStage == Done` short-circuit that saves the other
+ * progress entry points has no analogue here, because the drain reads the
+ * completion lane masks rather than the progress slot.
+ *
+ * The masks are deliberately left ALONE rather than cleared. Clearing would
+ * tell `try_prepare_send_slot()` that those completions have landed when they
+ * have not, dropping the one guard that stops a later operation overwriting
+ * send-staging while the NIC is still reading out of it. Reporting `Drained`
+ * costs nothing by comparison: after an abort the channel is not expected to
+ * carry meaningful traffic anyway, and recovery is a `reconfigure()`.
+ *
+ * The call that first observes the abort mid-scan still reports `Aborted`, so
+ * the signal is not lost; only subsequent calls short-circuit.
+ */
 template <typename Transport>
 __device__ __forceinline__ IbgdaRegisteredSendProgressStatus
 progress_registered_send_drain_once(
@@ -822,7 +855,7 @@ progress_registered_send_drain_once(
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t result =
       static_cast<uint32_t>(IbgdaRegisteredSendProgressStatus::Drained);
-  if (group.is_leader()) {
+  if (group.is_leader() && !timeout.isAborted()) {
     bool foundPending = false;
     bool madeProgress = false;
     bool aborted = false;
@@ -1407,9 +1440,11 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once_impl(
       traceState,
       qpLane);
   if (recvReadiness != kProgressReady) {
-    return recvReadiness == kProgressAborted
-        ? IbgdaSendRecvProgressStatus::Aborted
-        : IbgdaSendRecvProgressStatus::Waiting;
+    if (recvReadiness == kProgressAborted) {
+      abandon_progress_state(group, progressSlot, state);
+      return IbgdaSendRecvProgressStatus::Aborted;
+    }
+    return IbgdaSendRecvProgressStatus::Waiting;
   }
 
   progress_recv_consume_buf<CopyOp>(
@@ -1603,9 +1638,11 @@ progress_recv_acquire_once(
       nullptr,
       qpLane);
   if (recvReadiness != kProgressReady) {
-    return recvReadiness == kProgressAborted
-        ? IbgdaSendRecvProgressStatus::Aborted
-        : IbgdaSendRecvProgressStatus::Waiting;
+    if (recvReadiness == kProgressAborted) {
+      abandon_progress_state(group, progressSlot, state);
+      return IbgdaSendRecvProgressStatus::Aborted;
+    }
+    return IbgdaSendRecvProgressStatus::Waiting;
   }
 
   out.staging = channelLayout.recvStagingPtr + chunk.stagingOff;
@@ -1692,6 +1729,49 @@ __device__ __forceinline__ void store_progress_state(
     slot.activeStage = state.activeStage;
   }
   group.sync();
+#else
+  (void)group;
+  (void)slot;
+  (void)state;
+#endif
+}
+
+/**
+ * Drive an aborted progress slot to its terminal stage.
+ *
+ * A transfer that unwinds on abort leaves the slot mid-state machine, and
+ * `assert_progress_slot_idle()` traps on anything but `Done`. The next kernel
+ * queued on this channel would therefore trap inside init_send_progress() --
+ * turning a clean abort into a device fault one kernel later. Marking the slot
+ * terminal converts that into a clean exit, and keeps the collective path free
+ * of abort bookkeeping: every later progress call on this slot short-circuits
+ * to `Done`, so a driver loop simply drains and the kernel exits.
+ *
+ * This buys LIVENESS, not a usable channel. After an abort the DATA_READY /
+ * SLOT_FREE counters are skewed against the peer's, so traffic that follows on
+ * this channel is not meaningful -- which the abort contract already says
+ * ("results from work that completes after an abort should be treated as the
+ * reason for abort"). Recovery is still a `reconfigure()` that destroys and
+ * rebuilds the transport with zeroed state. What changes is that the host now
+ * reaches that point, instead of losing the CUDA context to a trap first.
+ *
+ * The reserved byte range is deliberately NOT returned to `slot.nextStep`. The
+ * peer may still land an RDMA write into it, so the cursor stays advanced and
+ * the range is abandoned rather than recycled.
+ *
+ * Bypasses transition_progress_stage() on purpose: abandoning is not a protocol
+ * transition, and it is legal from every stage.
+ */
+__device__ __forceinline__ void abandon_progress_state(
+    ThreadGroup& group,
+    IbChannelProgress& slot,
+    IbChannelProgress& state) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  state.activeStage = detail::IbSendRecvProgressStage::Done;
+  state.activeNextByte = 0;
+  state.activeTailPadding = 0;
+  state.activeBaseStep = 0;
+  store_progress_state(group, slot, state);
 #else
   (void)group;
   (void)slot;


### PR DESCRIPTION
Summary:

Adds P2P IB/IBRC `AbortDevice` wait coverage and owns the corresponding test targets.

This update moves `p2p_ib_transport_device_abort_test` and its kernel library into this diff, matching the diff that introduces `P2pIbTransportDeviceAbortTest.*` sources.

Changes in this update, from review:

- **Fix per-thread state passed to a group primitive.** The kernels declared `IbrcCmdQueueDevice queues[2]{}` and `IbLocalChannel channels[1]{}` as *thread-local* arrays and handed them to `wait_signal(group, ...)`, whose leader polls that state on behalf of the whole block -- so the leader was reading storage no other thread could see. They are now one `__shared__ IbrcScratch`, zeroed cooperatively before use.
- **DRY the scaffolding.** Four near-identical kernels and four launchers collapse to one kernel templated on the entry point (`P2pIbTransportDevice` dispatcher vs the IBRC backend) plus two launchers. The kernel now takes `expected` and the abort handle and simply reports the wait's return value, so the host decides what to assert. Test-side setup moved into a small RAII `WaitFixture`.
- **Rename `launchIbWrapperWaitSignalAbortCompileCheck`.** It runs a kernel and checks a result; it was never a compile check. It is now `launchIbWrapperWaitSignal`, alongside `launchIbrcWaitSignal`.
- **Add the cases that actually cover abort.** The previous tests only covered a disabled handle and an abort recorded *before* launch. Added, on both the wrapper and IBRC paths, and on IBGDA: a wait already spinning that exits when the host aborts mid-flight, and one that exits on the device deadline with `isTimedOut()` observed from the host. These are the liveness and fast-lapse properties the stack exists to provide; the pre-abort case never exercised either.

The new IBGDA timeout case caught its own kernel: it hung until the test runner killed it, because the kernel never called `AbortDevice::start()`. That is the documented step 2 of collective enablement -- an unarmed handle observes explicit aborts only -- so the kernel now arms the deadline the way production kernels do.

Multi-rank abort coverage over real NVL/IBGDA/IBRC transports lands with the AllReduce FT diff at the top of the stack; these are the single-GPU unit-level guarantees.

Stack review guide: https://www.internalfb.com/intern/paste/P2459153030/

Reviewed By: Scusemua

Differential Revision: D115656603


