### PR TITLE
Expose pull-based collective lifecycle events

### DIFF
--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
@@ -3,10 +3,11 @@
 #include "meta/colltrace/CollTraceWrapper.h"
 
 #include <algorithm>
+#include <atomic>
 
 #include <folly/Conv.h>
+#include <folly/Synchronized.h>
 #include <folly/Unit.h>
-
 #include "comms/utils/RankUtils.h"
 #include "comms/utils/checks.h"
 #include "comms/utils/colltrace/CollMetadataImpl.h"
@@ -18,6 +19,7 @@
 #include "comms/utils/colltrace/GenericMetadata.h"
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/colltrace/plugins/CommDumpPlugin.h"
+#include "comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.h"
 #include "comms/utils/colltrace/plugins/WatchdogPlugin.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/NcclxLogger.h"
@@ -35,6 +37,48 @@
 namespace meta::comms::ncclx {
 
 namespace {
+struct LifecycleFeedRegistryEntry {
+  ncclComm_t comm{nullptr};
+  std::weak_ptr<meta::comms::colltrace::ICollTrace> colltrace;
+};
+
+folly::Synchronized<std::vector<LifecycleFeedRegistryEntry>>&
+getLifecycleFeedRegistry() {
+  static folly::Synchronized<std::vector<LifecycleFeedRegistryEntry>> registry;
+  return registry;
+}
+
+void registerLifecycleFeed(
+    ncclComm_t comm,
+    const std::shared_ptr<meta::comms::colltrace::ICollTrace>& colltrace) {
+  auto registry = getLifecycleFeedRegistry().wlock();
+  const auto existing = std::find_if(
+      registry->begin(), registry->end(), [comm](const auto& entry) {
+        return entry.comm == comm;
+      });
+  if (existing != registry->end()) {
+    existing->colltrace = colltrace;
+    return;
+  }
+  registry->push_back(
+      LifecycleFeedRegistryEntry{.comm = comm, .colltrace = colltrace});
+}
+
+void deregisterLifecycleFeed(ncclComm_t comm) {
+  auto registry = getLifecycleFeedRegistry().wlock();
+  registry->erase(
+      std::remove_if(
+          registry->begin(),
+          registry->end(),
+          [comm](const auto& entry) { return entry.comm == comm; }),
+      registry->end());
+}
+
+uint64_t getNextLifecycleFeedCommId() {
+  static std::atomic<uint64_t> nextCommId{1};
+  return nextCommId.fetch_add(1, std::memory_order_relaxed);
+}
+
 enum class KernelPlanType { none, single, multiple };
 
 template <typename T, T* T::* next>
@@ -291,22 +335,36 @@ getEmptyKernelTaskMetadata(
 ncclResult_t newCollTraceInit(ncclComm* comm) {
   // Parse NCCL_COLLTRACE configuration flags
   bool algoStatEnabled = false;
+  bool lifecycleEnabled = false;
   bool verboseEnabled = false;
   bool traceEnabled = false;
   for (const auto& mode : NCCL_COLLTRACE) {
-    if (mode == "algostat") {
+    if (mode == "ALL" || mode == "all") {
       algoStatEnabled = true;
+      lifecycleEnabled = true;
+      traceEnabled = true;
+    } else if (mode == "algostat") {
+      algoStatEnabled = true;
+    } else if (mode == "lifecycle") {
+      lifecycleEnabled = true;
     } else if (mode == "verbose") {
       verboseEnabled = true;
     } else if (mode == "trace") {
       traceEnabled = true;
+    } else {
+      NCCLX_LOG(
+          ERR,
+          "Unknown NCCL_COLLTRACE mode '{}'. Valid modes are ALL, algostat, lifecycle, trace, and verbose.",
+          mode);
+      return ncclInvalidArgument;
     }
   }
 
   NCCLX_LOG(
       INFO,
-      "CollTrace init - NCCL_COLLTRACE: [algostat: {}, verbose: {}, trace: {}]",
+      "CollTrace init - NCCL_COLLTRACE: [algostat: {}, lifecycle: {}, verbose: {}, trace: {}]",
       algoStatEnabled,
+      lifecycleEnabled,
       verboseEnabled,
       traceEnabled);
 
@@ -317,9 +375,8 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
         comm->logMetaData.commHash, comm->logMetaData.commDesc);
   }
 
-  // Check if full colltrace is needed (verbose or trace modes)
-  // algostat alone does not require full colltrace infrastructure
-  if ((!verboseEnabled && !traceEnabled)) {
+  // AlgoStats alone does not require the full colltrace infrastructure.
+  if (!lifecycleEnabled && !verboseEnabled && !traceEnabled) {
     return ncclSuccess;
   }
 
@@ -328,13 +385,23 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
   auto plugins =
       std::vector<std::unique_ptr<meta::comms::colltrace::ICollTracePlugin>>{};
 
-  auto commDumpPlugin =
-      std::make_unique<meta::comms::colltrace::CommDumpPlugin>(
-          meta::comms::colltrace::CommDumpConfig{
-              .pastCollSize = NCCL_COLLTRACE_RECORD_MAX,
-              .pendingCollSize = NCCL_COLLTRACE_PENDING_QUEUE_SIZE,
-          });
-  plugins.push_back(std::move(commDumpPlugin));
+  if (verboseEnabled || traceEnabled) {
+    auto commDumpPlugin =
+        std::make_unique<meta::comms::colltrace::CommDumpPlugin>(
+            meta::comms::colltrace::CommDumpConfig{
+                .pastCollSize = NCCL_COLLTRACE_RECORD_MAX,
+                .pendingCollSize = NCCL_COLLTRACE_PENDING_QUEUE_SIZE,
+            });
+    plugins.push_back(std::move(commDumpPlugin));
+  }
+
+  if (lifecycleEnabled) {
+    plugins.push_back(
+        std::make_unique<meta::comms::colltrace::LifecycleEventFeedPlugin>(
+            meta::comms::colltrace::LifecycleEventFeedConfig{
+                .commId = getNextLifecycleFeedCommId(),
+            }));
+  }
 
   auto ifCheckAsync = shouldCheckAsyncError();
   auto ifCheckTimeout = shouldCheckTimeout();
@@ -386,11 +453,15 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
       std::move(plugins));
 
   comm->newCollTrace = std::move(colltraceNew);
+  if (lifecycleEnabled) {
+    registerLifecycleFeed(comm, comm->newCollTrace);
+  }
 
   return ncclSuccess;
 }
 
 ncclResult_t newCollTraceDestroy(ncclComm* comm) {
+  deregisterLifecycleFeed(comm);
   comm->newCollTrace.reset();
   return ncclSuccess;
 }
@@ -404,7 +475,7 @@ getMetadataFromNcclKernelPlan(ncclKernelPlan& plan, cudaStream_t stream) {
       planInfo.p2pType == KernelPlanType::none) {
     NCCLX_LOG_FIRST_N(
         ERR, 3, "CollTrace: No coll or p2p task in the NCCL Kenrel Plan!");
-    if (isCapturingStream(stream)) {
+    if (plan.persistent) {
       // Deadlock safety: a graph-captured plan with no coll/p2p task has no
       // kernel that will publish a start/end timestamp into the graph ring, so
       // registering a graph colltrace record for it would never complete and
@@ -446,7 +517,7 @@ getHandleFromNcclKernelPlan(ncclKernelPlan& plan, cudaStream_t stream) {
 
   auto makeWaitEvent =
       [&]() -> std::unique_ptr<meta::comms::colltrace::ICollWaitEvent> {
-    if (isCapturingStream(stream)) {
+    if (plan.persistent) {
       return std::make_unique<meta::comms::colltrace::GraphCudaWaitEvent>(
           stream);
     }
@@ -480,6 +551,130 @@ std::unordered_map<std::string, std::string> collTraceGetInfo() {
 } // namespace meta::comms::ncclx
 
 namespace ncclx::colltrace {
+
+namespace {
+
+meta::comms::colltrace::LifecycleEventFeedPlugin* getLifecycleEventFeedPlugin(
+    const std::shared_ptr<meta::comms::colltrace::ICollTrace>& colltrace) {
+  if (colltrace == nullptr) {
+    return nullptr;
+  }
+  return dynamic_cast<meta::comms::colltrace::LifecycleEventFeedPlugin*>(
+      colltrace->getPluginByName(
+          std::string{meta::comms::colltrace::LifecycleEventFeedPlugin::
+                          kLifecycleEventFeedPluginName}));
+}
+
+meta::comms::colltrace::LifecycleEventFeedPlugin* getLifecycleEventFeedPlugin(
+    ncclComm_t comm) {
+  if (comm == nullptr) {
+    return nullptr;
+  }
+  return getLifecycleEventFeedPlugin(comm->newCollTrace);
+}
+
+constexpr uint64_t toExternalLifecycleCollId(uint64_t internalCollId) {
+  return internalCollId + 1;
+}
+
+void appendLifecycleEvents(
+    const std::vector<meta::comms::colltrace::LifecycleEventRecord>&
+        unreadEvents,
+    std::vector<LifecycleEvent>& events) {
+  events.reserve(events.size() + unreadEvents.size());
+  for (const auto& event : unreadEvents) {
+    LifecycleEventType eventType{LifecycleEventType::Enqueue};
+    switch (event.eventType) {
+      case meta::comms::colltrace::LifecycleEventType::kEnqueue:
+        eventType = LifecycleEventType::Enqueue;
+        break;
+      case meta::comms::colltrace::LifecycleEventType::kStart:
+        eventType = LifecycleEventType::Start;
+        break;
+      case meta::comms::colltrace::LifecycleEventType::kEnd:
+        eventType = LifecycleEventType::End;
+        break;
+    }
+    events.push_back(
+        LifecycleEvent{
+            .replayId = event.replayId.value_or(kInvalidReplayId),
+            .commId = event.commId,
+            .collId = toExternalLifecycleCollId(
+                event.capturedCollId.value_or(event.collId)),
+            .executionCollId = toExternalLifecycleCollId(event.collId),
+            .eventType = eventType,
+            .timestamp = std::chrono::duration<double>(
+                             event.timestamp.time_since_epoch())
+                             .count(),
+        });
+  }
+}
+
+} // namespace
+
+__attribute__((visibility("default"))) ncclResult_t
+getCollTraceCommId(ncclComm_t comm, uint64_t& commId) {
+  commId = 0;
+  if (comm == nullptr) {
+    return ncclInvalidArgument;
+  }
+  auto* plugin = getLifecycleEventFeedPlugin(comm);
+  if (plugin == nullptr) {
+    return ncclInvalidUsage;
+  }
+  commId = plugin->getCommId();
+  return ncclSuccess;
+}
+
+__attribute__((visibility("default"))) ncclResult_t
+getLatestCollTraceCollectiveId(ncclComm_t comm, uint64_t& collId) {
+  collId = 0;
+  if (comm == nullptr) {
+    return ncclInvalidArgument;
+  }
+  auto* plugin = getLifecycleEventFeedPlugin(comm);
+  if (plugin == nullptr) {
+    return ncclInvalidUsage;
+  }
+  collId = plugin->getLatestLifecycleCollectiveId();
+  return ncclSuccess;
+}
+
+__attribute__((visibility("default"))) ncclResult_t
+drainUnreadLifecycleEvents(std::vector<LifecycleEvent>& events) {
+  events.clear();
+  auto registry = meta::comms::ncclx::getLifecycleFeedRegistry().wlock();
+  registry->erase(
+      std::remove_if(
+          registry->begin(),
+          registry->end(),
+          [](const auto& entry) { return entry.colltrace.expired(); }),
+      registry->end());
+
+  std::vector<
+      std::pair<std::shared_ptr<meta::comms::colltrace::ICollTrace>, uint64_t>>
+      flushes;
+  flushes.reserve(registry->size());
+  for (const auto& entry : *registry) {
+    if (auto colltrace = entry.colltrace.lock()) {
+      flushes.emplace_back(colltrace, colltrace->requestFlush());
+    }
+  }
+  for (const auto& [colltrace, generation] : flushes) {
+    colltrace->waitFlush(generation);
+  }
+  for (const auto& [colltrace, _] : flushes) {
+    auto* plugin = getLifecycleEventFeedPlugin(colltrace);
+    if (plugin != nullptr) {
+      appendLifecycleEvents(plugin->drainUnreadLifecycleEvents(), events);
+    }
+  }
+  std::stable_sort(
+      events.begin(), events.end(), [](const auto& lhs, const auto& rhs) {
+        return lhs.timestamp < rhs.timestamp;
+      });
+  return ncclSuccess;
+}
 
 __attribute__((visibility("default"))) void dumpAlgoStat(
     ncclComm_t comm,

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWrapperUT.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWrapperUT.cc
@@ -4,17 +4,81 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
+
+#include <folly/ScopeGuard.h>
 #include <folly/String.h>
 
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/utils/colltrace/CollMetadata.h"
 #include "comms/utils/colltrace/CollMetadataImpl.h"
+#include "comms/utils/colltrace/DummyCollTraceHandle.h"
+#include "comms/utils/colltrace/GraphCudaWaitEvent.h"
+#include "comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.h"
+#include "comms/utils/colltrace/tests/MockTypes.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/colltrace/CollTraceWrapper.h"
 
 using namespace meta::comms::ncclx;
 using namespace meta::comms::colltrace;
+using ::testing::_;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+TEST(CollTraceWrapperRegistrationTest, GetsOneBasedLatestCollectiveId) {
+  constexpr uint64_t kCommId = 17;
+  constexpr uint64_t kInternalCollId = 0;
+  constexpr uint64_t kExpectedCollId = 1;
+  ncclComm comm{};
+  LifecycleEventFeedPlugin plugin{LifecycleEventFeedConfig{.commId = kCommId}};
+  auto colltrace = std::make_shared<NiceMock<MockCollTrace>>();
+  ON_CALL(*colltrace, getPluginByName(_))
+      .WillByDefault(Return(static_cast<ICollTracePlugin*>(&plugin)));
+  comm.newCollTrace = colltrace;
+
+  uint64_t commId{0};
+  uint64_t collId{99};
+  EXPECT_EQ(ncclx::colltrace::getCollTraceCommId(&comm, commId), ncclSuccess);
+  EXPECT_EQ(commId, kCommId);
+  EXPECT_EQ(
+      ncclx::colltrace::getLatestCollTraceCollectiveId(&comm, collId),
+      ncclSuccess);
+  EXPECT_EQ(collId, 0);
+
+  auto event = CollTraceEvent{
+      .collRecord = std::make_shared<CollRecord>(
+          kInternalCollId, std::make_shared<NiceMock<MockCollMetadata>>()),
+  };
+  ASSERT_TRUE(plugin.afterCollRecorded(event).hasValue());
+
+  EXPECT_EQ(
+      ncclx::colltrace::getLatestCollTraceCollectiveId(&comm, collId),
+      ncclSuccess);
+  EXPECT_EQ(collId, kExpectedCollId);
+  EXPECT_EQ(
+      ncclx::colltrace::getLatestCollTraceCollectiveId(&comm, collId),
+      ncclSuccess);
+  EXPECT_EQ(collId, kExpectedCollId);
+}
+
+TEST(CollTraceWrapperLifecycleFeedTest, RejectsDisabledFeed) {
+  ncclComm comm{};
+  uint64_t commId{0};
+  uint64_t collId{0};
+
+  EXPECT_EQ(
+      ncclx::colltrace::getCollTraceCommId(nullptr, commId),
+      ncclInvalidArgument);
+  EXPECT_EQ(
+      ncclx::colltrace::getLatestCollTraceCollectiveId(nullptr, collId),
+      ncclInvalidArgument);
+  EXPECT_EQ(
+      ncclx::colltrace::getCollTraceCommId(&comm, commId), ncclInvalidUsage);
+  EXPECT_EQ(
+      ncclx::colltrace::getLatestCollTraceCollectiveId(&comm, collId),
+      ncclInvalidUsage);
+}
 
 class CollTraceWrapperUT : public ::testing::Test {
  public:
@@ -208,6 +272,34 @@ TEST_F(CollTraceWrapperUT, getMetadataFromNcclKernelPlan_EmptyPlan) {
   EXPECT_EQ(dynamic["algoName"].asString(), "EmptyKernelTask");
 }
 
+TEST_F(CollTraceWrapperUT, PersistentEmptyPlanReturnsNoMetadata) {
+  auto plan = createEmptyKernelPlan();
+  plan.persistent = true;
+
+  EXPECT_EQ(getMetadataFromNcclKernelPlan(plan, stream_), nullptr);
+}
+
+TEST_F(CollTraceWrapperUT, PersistentPlanUsesGraphWaitEvent) {
+  auto plan = createMockKernelPlanWithColl();
+  plan.persistent = true;
+  auto colltrace = std::make_shared<NiceMock<MockCollTrace>>();
+  comm_->newCollTrace = colltrace;
+
+  EXPECT_CALL(*colltrace, recordCollective(_, _))
+      .WillOnce(
+          [](std::unique_ptr<ICollMetadata>,
+             std::unique_ptr<ICollWaitEvent> waitEvent)
+              -> meta::comms::CommsMaybe<std::shared_ptr<ICollTraceHandle>> {
+            EXPECT_NE(
+                dynamic_cast<GraphCudaWaitEvent*>(waitEvent.get()), nullptr);
+            std::shared_ptr<ICollTraceHandle> handle =
+                std::make_shared<DummyCollTraceHandle>();
+            return handle;
+          });
+
+  EXPECT_NE(getHandleFromNcclKernelPlan(plan, stream_), nullptr);
+}
+
 // Test case for single collective - should be supported
 TEST_F(CollTraceWrapperUT, getMetadataFromNcclKernelPlan_SingleCollective) {
   auto plan = createMockKernelPlanWithColl();
@@ -313,6 +405,104 @@ class CollTraceInitConfigTest
   ncclComm_t comm_{nullptr};
 };
 
+TEST_F(CollTraceInitConfigTest, PullsIdsAndEventsAcrossLifecycleFeeds) {
+  constexpr uint64_t kCapturedCollId = 23;
+  constexpr uint64_t kExecutionCollId = 29;
+  constexpr uint64_t kOtherCollId = 31;
+  constexpr uint64_t kExternalCapturedCollId = 24;
+  constexpr uint64_t kExternalExecutionCollId = 30;
+  constexpr uint64_t kExternalOtherCollId = 32;
+  const auto firstEnqueueTs =
+      std::chrono::system_clock::time_point{std::chrono::milliseconds{200}};
+  const auto otherEnqueueTs =
+      std::chrono::system_clock::time_point{std::chrono::milliseconds{100}};
+  EnvRAII colltraceGuard(NCCL_COLLTRACE, std::vector<std::string>{"lifecycle"});
+  ASSERT_EQ(newCollTraceDestroy(comm_), ncclSuccess);
+  comm_->logMetaData.commId = 0;
+  ASSERT_EQ(newCollTraceInit(comm_), ncclSuccess);
+
+  ncclComm_t otherComm{nullptr};
+  ncclUniqueId otherId;
+  NCCLCHECK_TEST(ncclGetUniqueId(&otherId));
+  NCCLCHECK_TEST(ncclCommInitRank(&otherComm, 1, otherId, 0));
+  auto otherCommGuard = folly::makeGuard([&] {
+    if (otherComm != nullptr) {
+      ncclCommDestroy(otherComm);
+    }
+  });
+  ASSERT_EQ(newCollTraceDestroy(otherComm), ncclSuccess);
+  otherComm->logMetaData = comm_->logMetaData;
+  ASSERT_EQ(newCollTraceInit(otherComm), ncclSuccess);
+
+  auto getPlugin = [](ncclComm_t comm) {
+    return dynamic_cast<LifecycleEventFeedPlugin*>(
+        comm->newCollTrace->getPluginByName(
+            std::string{
+                LifecycleEventFeedPlugin::kLifecycleEventFeedPluginName}));
+  };
+  auto* plugin = getPlugin(comm_);
+  auto* otherPlugin = getPlugin(otherComm);
+  ASSERT_NE(plugin, nullptr);
+  ASSERT_NE(otherPlugin, nullptr);
+
+  auto executionEvent = CollTraceEvent{
+      .collRecord = std::make_shared<CollRecord>(
+          kExecutionCollId, std::make_shared<NiceMock<MockCollMetadata>>()),
+      .replayId = 1,
+      .capturedCollId = kCapturedCollId,
+  };
+  executionEvent.collRecord->getTimingInfo().setCollEnqueueTs(firstEnqueueTs);
+  ASSERT_TRUE(plugin->afterCollRecorded(executionEvent).hasValue());
+  ASSERT_TRUE(plugin->afterCollKernelScheduled(executionEvent).hasValue());
+
+  auto otherEvent = CollTraceEvent{
+      .collRecord = std::make_shared<CollRecord>(
+          kOtherCollId, std::make_shared<NiceMock<MockCollMetadata>>()),
+  };
+  otherEvent.collRecord->getTimingInfo().setCollEnqueueTs(otherEnqueueTs);
+  ASSERT_TRUE(otherPlugin->afterCollRecorded(otherEvent).hasValue());
+  ASSERT_TRUE(otherPlugin->afterCollKernelScheduled(otherEvent).hasValue());
+
+  uint64_t commId{0};
+  uint64_t otherCommId{0};
+  uint64_t collId{0};
+  uint64_t otherCollId{0};
+  EXPECT_EQ(ncclx::colltrace::getCollTraceCommId(comm_, commId), ncclSuccess);
+  EXPECT_EQ(
+      ncclx::colltrace::getCollTraceCommId(otherComm, otherCommId),
+      ncclSuccess);
+  EXPECT_NE(commId, 0);
+  EXPECT_NE(otherCommId, 0);
+  EXPECT_NE(commId, otherCommId);
+  EXPECT_EQ(
+      ncclx::colltrace::getLatestCollTraceCollectiveId(comm_, collId),
+      ncclSuccess);
+  EXPECT_EQ(
+      ncclx::colltrace::getLatestCollTraceCollectiveId(otherComm, otherCollId),
+      ncclSuccess);
+  EXPECT_EQ(collId, kExternalCapturedCollId);
+  EXPECT_EQ(otherCollId, kExternalOtherCollId);
+
+  std::vector<ncclx::colltrace::LifecycleEvent> events;
+  EXPECT_EQ(ncclx::colltrace::drainUnreadLifecycleEvents(events), ncclSuccess);
+  ASSERT_EQ(events.size(), 2);
+
+  EXPECT_EQ(events[0].commId, otherCommId);
+  EXPECT_EQ(events[0].collId, kExternalOtherCollId);
+  EXPECT_EQ(events[0].executionCollId, kExternalOtherCollId);
+  EXPECT_DOUBLE_EQ(events[0].timestamp, 0.1);
+
+  EXPECT_EQ(events[1].commId, commId);
+  EXPECT_EQ(events[1].collId, kExternalCapturedCollId);
+  EXPECT_EQ(events[1].executionCollId, kExternalExecutionCollId);
+  EXPECT_EQ(events[1].replayId, 1);
+  EXPECT_EQ(events[1].eventType, ncclx::colltrace::LifecycleEventType::Enqueue);
+  EXPECT_DOUBLE_EQ(events[1].timestamp, 0.2);
+
+  EXPECT_EQ(ncclx::colltrace::drainUnreadLifecycleEvents(events), ncclSuccess);
+  EXPECT_TRUE(events.empty());
+}
+
 TEST_P(CollTraceInitConfigTest, ConfigCombinations) {
   auto config = GetParam();
 
@@ -320,22 +510,56 @@ TEST_P(CollTraceInitConfigTest, ConfigCombinations) {
   EnvRAII colltraceGuard(NCCL_COLLTRACE, config);
 
   // Compute expected values based on config input
-  bool expectAlgoStats =
-      std::find(config.begin(), config.end(), "algostat") != config.end();
-  bool expectNewCollTrace =
+  const bool expectAll =
       std::any_of(config.begin(), config.end(), [](const auto& s) {
-        return s == "verbose" || s == "trace";
+        return s == "ALL" || s == "all";
+      });
+  const bool expectAlgoStats = expectAll ||
+      std::find(config.begin(), config.end(), "algostat") != config.end();
+  const bool expectNewCollTrace =
+      expectAll || std::any_of(config.begin(), config.end(), [](const auto& s) {
+        return s == "lifecycle" || s == "verbose" || s == "trace";
       });
 
   // Reset any existing state
   comm_->algoStats.reset();
-  comm_->newCollTrace.reset();
+  ASSERT_EQ(newCollTraceDestroy(comm_), ncclSuccess);
 
   auto result = newCollTraceInit(comm_);
 
   EXPECT_EQ(result, ncclSuccess);
   EXPECT_EQ(comm_->algoStats != nullptr, expectAlgoStats);
   EXPECT_EQ(comm_->newCollTrace != nullptr, expectNewCollTrace);
+}
+
+TEST_F(CollTraceInitConfigTest, AllAliasesEnableProductionFeatures) {
+  for (const auto* mode : {"ALL", "all"}) {
+    SCOPED_TRACE(mode);
+    EnvRAII colltraceGuard(NCCL_COLLTRACE, std::vector<std::string>{mode});
+    comm_->algoStats.reset();
+    ASSERT_EQ(newCollTraceDestroy(comm_), ncclSuccess);
+
+    ASSERT_EQ(newCollTraceInit(comm_), ncclSuccess);
+    EXPECT_NE(comm_->algoStats, nullptr);
+    ASSERT_NE(comm_->newCollTrace, nullptr);
+    EXPECT_NE(comm_->newCollTrace->getPluginByName("CommDumpPlugin"), nullptr);
+    EXPECT_NE(
+        comm_->newCollTrace->getPluginByName(
+            std::string{
+                LifecycleEventFeedPlugin::kLifecycleEventFeedPluginName}),
+        nullptr);
+  }
+}
+
+TEST_F(CollTraceInitConfigTest, RejectsUnknownModesWithoutPartialInit) {
+  EnvRAII colltraceGuard(
+      NCCL_COLLTRACE, std::vector<std::string>{"ALL", "bogus"});
+  comm_->algoStats.reset();
+  ASSERT_EQ(newCollTraceDestroy(comm_), ncclSuccess);
+
+  EXPECT_EQ(newCollTraceInit(comm_), ncclInvalidArgument);
+  EXPECT_EQ(comm_->algoStats, nullptr);
+  EXPECT_EQ(comm_->newCollTrace, nullptr);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -345,7 +569,10 @@ INSTANTIATE_TEST_SUITE_P(
         std::vector<std::string>{"algostat"},
         std::vector<std::string>{"trace"},
         std::vector<std::string>{"verbose"},
+        std::vector<std::string>{"lifecycle"},
         std::vector<std::string>{"algostat", "trace"},
+        std::vector<std::string>{"ALL"},
+        std::vector<std::string>{"all"},
         std::vector<std::string>{}),
     [](const ::testing::TestParamInfo<std::vector<std::string>>& info) {
       if (info.param.empty()) {

--- a/comms/ncclx/v2_29/src/nccl.h.in
+++ b/comms/ncclx/v2_29/src/nccl.h.in
@@ -1101,8 +1101,9 @@ ncclResult_t  pncclCommGetUniqueHash(ncclComm_t comm, uint64_t* uniqueHash);
 #define NCCL_COMM_DUMP_ALL
 
 #include <optional>
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
+#include <vector>
 /* Dump NCCL current internal state for a given communicator in a key-value store format.
  * define outside extern "C"{} to pass C++ template */
 ncclResult_t  ncclCommDump(ncclComm_t comm, std::unordered_map<std::string, std::string>& map);
@@ -1117,6 +1118,46 @@ ncclResult_t  ncclCommDump(ncclComm_t comm, std::unordered_map<std::string, std:
  */
 ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<std::string, std::string>>& map,
     const std::unordered_map<std::string, std::string>& hints = {});
+
+namespace ncclx::colltrace {
+
+inline constexpr uint64_t kInvalidReplayId = UINT64_MAX;
+
+enum class LifecycleEventType : uint8_t {
+  Enqueue,
+  Start,
+  End,
+};
+
+struct LifecycleEvent {
+  uint64_t replayId{kInvalidReplayId};
+  uint64_t commId{0};
+  // Stable one-based submission identity. Zero is reserved for no record.
+  // Matches getLatestCollTraceCollectiveId().
+  uint64_t collId{0};
+  // One-based per-execution identity. Differs from collId for graph replays.
+  uint64_t executionCollId{0};
+  LifecycleEventType eventType{LifecycleEventType::Enqueue};
+  double timestamp{0};
+};
+
+// Returns the process-local communicator identity used by lifecycle events.
+// Returns ncclInvalidArgument for a null communicator or ncclInvalidUsage if
+// the lifecycle feed is disabled.
+ncclResult_t getCollTraceCommId(ncclComm_t comm, uint64_t& commId);
+
+// Returns the latest one-based collective ID submitted on this communicator.
+// Writes zero and returns ncclSuccess if no collective has been submitted on
+// this communicator. Returns ncclInvalidArgument for a null communicator or
+// ncclInvalidUsage if the lifecycle feed is disabled.
+ncclResult_t getLatestCollTraceCollectiveId(ncclComm_t comm, uint64_t& collId);
+
+// Destructively drains lifecycle events across all lifecycle-enabled
+// communicators in this process. This call blocks until every registered
+// colltrace instance finishes a flush. Events are ordered by timestamp.
+ncclResult_t drainUnreadLifecycleEvents(std::vector<LifecycleEvent>& events);
+
+} // namespace ncclx::colltrace
 
 // NCCL_HAS_DUMP_ALGO_STAT controls whether dumpAlgoStat() is available.
 // To disable (e.g., when using a shim with a

--- a/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx_internal.pxd
+++ b/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx_internal.pxd
@@ -4,6 +4,7 @@
 from libc.stdint cimport uint64_t
 from libcpp.string cimport string
 from libcpp.unordered_map cimport unordered_map
+from libcpp.vector cimport vector
 
 
 cdef extern from "cuda_runtime_api.h" nogil:
@@ -64,3 +65,23 @@ cdef extern from "nccl.h" namespace "ncclx" nogil:
 
     # Live comm reconfiguration
     ncclResult_t commSetConfig(ncclComm_t comm, const ncclConfig_t* config)
+
+
+cdef extern from "nccl.h" namespace "ncclx::colltrace" nogil:
+    cdef enum class LifecycleEventType:
+        Enqueue
+        Start
+        End
+
+    cdef cppclass LifecycleEvent:
+        uint64_t replayId
+        uint64_t commId
+        uint64_t collId
+        uint64_t executionCollId
+        LifecycleEventType eventType
+        double timestamp
+
+    ncclResult_t getCollTraceCommId(ncclComm_t comm, uint64_t& comm_id)
+    ncclResult_t getLatestCollTraceCollectiveId(
+        ncclComm_t comm, uint64_t& coll_id)
+    ncclResult_t drainUnreadLifecycleEvents(vector[LifecycleEvent]& events)

--- a/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx_internal.pyx
+++ b/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx_internal.pyx
@@ -4,11 +4,17 @@
 from libc.stdint cimport intptr_t, uint64_t
 from libcpp.string cimport string
 from libcpp.unordered_map cimport unordered_map
+from libcpp.vector cimport vector
 
 from .ncclx_internal cimport (
     commSetConfig as _commSetConfig,
     cudaStream_t,
+    drainUnreadLifecycleEvents as _drainUnreadLifecycleEvents,
+    getCollTraceCommId as _getCollTraceCommId,
+    getLatestCollTraceCollectiveId as _getLatestCollTraceCollectiveId,
     Hints as CppHints,
+    LifecycleEvent as CppLifecycleEvent,
+    LifecycleEventType as CppLifecycleEventType,
     ncclAllToAllv as _ncclAllToAllv,
     ncclCommDump as _ncclCommDump,
     ncclCommDumpAll as _ncclCommDumpAll,
@@ -164,6 +170,55 @@ cpdef dict comm_dump_all():
         }
         for k, v in result
     }
+
+
+cdef list _colltrace_events_to_python(vector[CppLifecycleEvent]& result):
+    cdef uint64_t invalid_replay_id = <uint64_t>-1
+    cdef list events = []
+    cdef object event_type
+    for event in result:
+        if event.eventType == CppLifecycleEventType.Enqueue:
+            event_type = "enqueue"
+        elif event.eventType == CppLifecycleEventType.Start:
+            event_type = "start"
+        else:
+            event_type = "end"
+        events.append((
+            None if event.replayId == invalid_replay_id else event.replayId,
+            event.commId,
+            event.collId,
+            event.executionCollId,
+            event_type,
+            event.timestamp,
+        ))
+    return events
+
+
+cpdef uint64_t colltrace_get_comm_id(intptr_t comm) except? 0:
+    cdef uint64_t comm_id
+    cdef int status
+    with nogil:
+        status = _getCollTraceCommId(<ncclComm_t>comm, comm_id)
+    check_status(status)
+    return comm_id
+
+
+cpdef uint64_t colltrace_get_latest_coll_id(intptr_t comm) except? 0:
+    cdef uint64_t coll_id
+    cdef int status
+    with nogil:
+        status = _getLatestCollTraceCollectiveId(<ncclComm_t>comm, coll_id)
+    check_status(status)
+    return coll_id
+
+
+cpdef list colltrace_get_unread_events():
+    cdef vector[CppLifecycleEvent] result
+    cdef int status
+    with nogil:
+        status = _drainUnreadLifecycleEvents(result)
+    check_status(status)
+    return _colltrace_events_to_python(result)
 
 
 cpdef comm_set_config(intptr_t comm, intptr_t config):

--- a/comms/ncclx/v2_30/src/nccl.h.in
+++ b/comms/ncclx/v2_30/src/nccl.h.in
@@ -1109,8 +1109,9 @@ ncclResult_t  pncclCommGetUniqueHash(ncclComm_t comm, uint64_t* uniqueHash);
 #define NCCL_COMM_DUMP_ALL
 
 #include <optional>
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
+#include <vector>
 /* Dump NCCL current internal state for a given communicator in a key-value store format.
  * define outside extern "C"{} to pass C++ template */
 ncclResult_t  ncclCommDump(ncclComm_t comm, std::unordered_map<std::string, std::string>& map);
@@ -1125,6 +1126,46 @@ ncclResult_t  ncclCommDump(ncclComm_t comm, std::unordered_map<std::string, std:
  */
 ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<std::string, std::string>>& map,
     const std::unordered_map<std::string, std::string>& hints = {});
+
+namespace ncclx::colltrace {
+
+inline constexpr uint64_t kInvalidReplayId = UINT64_MAX;
+
+enum class LifecycleEventType : uint8_t {
+  Enqueue,
+  Start,
+  End,
+};
+
+struct LifecycleEvent {
+  uint64_t replayId{kInvalidReplayId};
+  uint64_t commId{0};
+  // Stable one-based submission identity. Zero is reserved for no record.
+  // Matches getLatestCollTraceCollectiveId().
+  uint64_t collId{0};
+  // One-based per-execution identity. Differs from collId for graph replays.
+  uint64_t executionCollId{0};
+  LifecycleEventType eventType{LifecycleEventType::Enqueue};
+  double timestamp{0};
+};
+
+// Returns the process-local communicator identity used by lifecycle events.
+// Returns ncclInvalidArgument for a null communicator or ncclInvalidUsage if
+// the lifecycle feed is disabled.
+ncclResult_t getCollTraceCommId(ncclComm_t comm, uint64_t& commId);
+
+// Returns the latest one-based collective ID submitted on this communicator.
+// Writes zero and returns ncclSuccess if no collective has been submitted on
+// this communicator. Returns ncclInvalidArgument for a null communicator or
+// ncclInvalidUsage if the lifecycle feed is disabled.
+ncclResult_t getLatestCollTraceCollectiveId(ncclComm_t comm, uint64_t& collId);
+
+// Destructively drains lifecycle events across all lifecycle-enabled
+// communicators in this process. This call blocks until every registered
+// colltrace instance finishes a flush. Events are ordered by timestamp.
+ncclResult_t drainUnreadLifecycleEvents(std::vector<LifecycleEvent>& events);
+
+} // namespace ncclx::colltrace
 
 // NCCL_HAS_DUMP_ALGO_STAT controls whether dumpAlgoStat() is available.
 // To disable (e.g., when using a shim with a

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -52,8 +52,8 @@ void validateIntDtype(const at::Tensor& tensor, std::string_view name) {
 
 std::atomic<int> g_graphTimeoutMonitoringState{-1};
 
-// Returns true if NCCL_COLLTRACE enables a full-trace mode ("trace" or
-// "verbose"), i.e. the colltrace worker thread and WatchdogPlugin will actually
+// Returns true if NCCL_COLLTRACE enables a full-trace mode ("trace", "verbose",
+// or "ALL"), i.e. the colltrace worker thread and WatchdogPlugin will actually
 // be created by CollTraceWrapper::newCollTraceInit. NCCL_COLLTRACE is a
 // comma-separated stringlist, so we tokenize and trim exactly like the cvar
 // parser (comms/utils/cvars) and newCollTraceInit do — an exact whole-string
@@ -67,7 +67,8 @@ bool colltraceTraceModeEnabled() {
   folly::split(',', env, tokens, true /* ignoreEmpty */);
   for (const auto& token : tokens) {
     const std::string trimmed = folly::trimWhitespace(token).str();
-    if (trimmed == "trace" || trimmed == "verbose") {
+    if (trimmed == "trace" || trimmed == "verbose" || trimmed == "ALL" ||
+        trimmed == "all") {
       return true;
     }
   }
@@ -86,7 +87,7 @@ bool colltraceCudaGraphTracingRequested() {
 }
 
 // The colltrace cudagraph watchdog only fires when BOTH the cudagraph tracing
-// flag is set AND colltrace itself is in trace/verbose mode — otherwise
+// flag is set AND colltrace itself is in trace/verbose/ALL mode — otherwise
 // CollTraceWrapper::newCollTraceInit short-circuits before installing the
 // WatchdogPlugin. Both conditions must hold before the colltrace watchdog can
 // serve as the fallback when GraphEventTracker monitoring is disabled.
@@ -240,7 +241,8 @@ void TorchCommNCCLX::init(
     LOG(WARNING)
         << "[TC] GraphEventTracker timeout monitoring is disabled and the "
         << "colltrace watchdog is unavailable (needs NCCL_COLLTRACE in a "
-        << "'trace'/'verbose' mode with NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1) — no "
+        << "'trace'/'verbose'/'ALL' mode with "
+        << "NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1) — no "
         << "graph-collective timeout watchdog will be active.";
   }
 

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -78,8 +78,9 @@ void resetGraphTimeoutMonitoringCacheForTest();
 // configures the colltrace WatchdogPlugin to handle async error checking and
 // timeout detection for graph-captured collectives via ncclx global hints.
 // Requires colltrace to be tracing graph-captured collectives (NCCL_COLLTRACE
-// in a "trace"/"verbose" mode AND NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1); otherwise
-// there is no WatchdogPlugin to configure. Returns true if the hints succeeded.
+// in a "trace"/"verbose"/"ALL" mode AND
+// NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1); otherwise there is no WatchdogPlugin to
+// configure. Returns true if the hints succeeded.
 bool tryEnableColltraceTimeoutWatchdog(std::chrono::milliseconds timeout);
 
 class TorchCommNCCLX : public TorchCommBackend,

--- a/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
@@ -1279,4 +1279,16 @@ TEST_F(
   ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
 }
 
+TEST_F(GraphEventTrackerTest, TryEnableColltraceWatchdog_AcceptsAllAliases) {
+  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
+  for (const auto* mode : {"ALL", "all"}) {
+    SCOPED_TRACE(mode);
+    ::setenv("NCCL_COLLTRACE", mode, 1);
+    EXPECT_TRUE(
+        tryEnableColltraceTimeoutWatchdog(std::chrono::milliseconds{5000}));
+  }
+  ::unsetenv("NCCL_COLLTRACE");
+  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
+}
+
 } // namespace torch::comms::test

--- a/comms/utils/colltrace/CPUWaitEvent.cc
+++ b/comms/utils/colltrace/CPUWaitEvent.cc
@@ -31,14 +31,14 @@ CommsMaybe<bool> CPUWaitEvent::waitCollEnd(
 }
 
 CommsMaybeVoid CPUWaitEvent::signalCollStart() noexcept {
-  startEvent_.waitSemaphore.post();
   startEvent_.timePoint = precisionNow();
+  startEvent_.waitSemaphore.post();
   return folly::unit;
 }
 
 CommsMaybeVoid CPUWaitEvent::signalCollEnd() noexcept {
-  endEvent_.waitSemaphore.post();
   endEvent_.timePoint = precisionNow();
+  endEvent_.waitSemaphore.post();
   return folly::unit;
 }
 

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -306,12 +306,16 @@ CommsMaybe<std::shared_ptr<ICollTraceHandle>> CollTrace::recordCollective(
     }
   }
 
-  pendingEnqueueColl_ = std::make_unique<CollTraceEvent>(
-      std::make_shared<CollRecord>(collId_.fetch_add(1), std::move(metadata)),
-      std::move(waitEvent));
+  const auto collId = collId_.fetch_add(1);
+  pendingEnqueueColl_ = std::make_unique<CollTraceEvent>(CollTraceEvent{
+      .collRecord = std::make_shared<CollRecord>(collId, std::move(metadata)),
+      .waitEvent = std::move(waitEvent),
+  });
   auto handle =
       std::make_shared<CollTraceHandle>(this, pendingEnqueueColl_.get());
   eventToHandleMap_.emplace(pendingEnqueueColl_.get(), handle);
+  triggerPlugins<&ICollTracePlugin::afterCollRecorded>(
+      plugins_, *pendingEnqueueColl_);
   return handle;
 }
 
@@ -421,7 +425,9 @@ CollTrace::recordGraphCollectiveImpl(
   auto collEvent = std::make_unique<CollTraceEvent>(CollTraceEvent{
       .collRecord = std::move(collRecord),
       .waitEvent = std::move(waitEvent),
+      .capturedCollId = collIdVal,
   });
+  auto* registrationEvent = collEvent.get();
 
   auto handle = std::make_shared<GraphCollTraceHandle>(
       rawWaitEvent, std::move(recordPtr));
@@ -441,6 +447,8 @@ CollTrace::recordGraphCollectiveImpl(
     std::lock_guard<std::mutex> lock(graphStateMutex_);
     graphState->collectives.emplace(collId, std::move(collectiveEntry));
   }
+  triggerPlugins<&ICollTracePlugin::afterCollRecorded>(
+      plugins_, *registrationEvent);
 
   return handle;
 }
@@ -563,6 +571,8 @@ void CollTrace::pollGraphEvents(
           auto replayEvent = std::make_unique<CollTraceEvent>(CollTraceEvent{
               .collRecord = std::move(frozenRecord),
               .waitEvent = nullptr,
+              .replayId = ++collEntry.replayId,
+              .capturedCollId = collId,
           });
           auto* replayPtr = replayEvent.get();
           if (auto replayIt = inFlightReplays_.find(collId);
@@ -641,7 +651,10 @@ void CollTrace::pollEagerEvents(
       if (event->waitEvent->waitCollStart(kPollTimeout).value_or(false)) {
         auto now = precisionNow();
         auto startTimeRes = event->waitEvent->getCollStartTime();
-        auto startTs = startTimeRes.hasValue() ? startTimeRes.value() : now;
+        auto startTs = now;
+        if (startTimeRes.hasValue() && startTimeRes.value() != kEpoch) {
+          startTs = startTimeRes.value();
+        }
         timing.setCollStartTs(startTs);
         actions.insert({event.get(), PendingActionType::kStart, startTs});
         started = true;
@@ -657,7 +670,10 @@ void CollTrace::pollEagerEvents(
       if (event->waitEvent->waitCollEnd(kPollTimeout).value_or(false)) {
         auto now = precisionNow();
         auto endTimeRes = event->waitEvent->getCollEndTime();
-        auto endTs = endTimeRes.hasValue() ? endTimeRes.value() : now;
+        auto endTs = now;
+        if (endTimeRes.hasValue() && endTimeRes.value() != kEpoch) {
+          endTs = endTimeRes.value();
+        }
         timing.setCollEndTs(endTs);
         actions.insert({event.get(), PendingActionType::kEnd, endTs});
       } else {
@@ -744,7 +760,11 @@ void CollTrace::collTraceThread(
         "{}: Error in calling colltrace thread setup function: {}",
         logPrefix_,
         res.error().message);
-    // Unblock the constructor so it doesn't hang forever.
+    {
+      std::lock_guard lock(flushState_.mutex);
+      threadShouldStop_.test_and_set();
+    }
+    flushState_.cv.notify_all();
     threadStarted_.count_down();
     return;
   }

--- a/comms/utils/colltrace/CollTraceEvent.h
+++ b/comms/utils/colltrace/CollTraceEvent.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
+#include <optional>
 
 #include <folly/dynamic.h>
 
@@ -17,6 +19,9 @@ struct CollTraceEvent {
   // shared pointer here
   std::shared_ptr<CollRecord> collRecord;
   std::unique_ptr<ICollWaitEvent> waitEvent; // How we wait the event
+  std::optional<uint64_t> replayId;
+  // Graph replay CollRecords get new IDs; this preserves the capture-time ID.
+  std::optional<uint64_t> capturedCollId;
 };
 
 } // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/CollTracePlugin.h
+++ b/comms/utils/colltrace/CollTracePlugin.h
@@ -10,13 +10,13 @@ namespace meta::comms::colltrace {
 // Abstract class for interfaces to implement for plugin of colltrace.
 // How the plugin is used:
 // 1. The plugin is registered in the colltrace library.
-// 2. The following callbacks will be triggered in the colltrace library in
-// order:
+// 2. afterCollRecorded runs once when the record is created. Each execution
+// then triggers the remaining callbacks in order:
 //    beforeCollKernelScheduled -> afterCollKernelScheduled ->
-//    afterCollKernelStart -> [whenCollKernelHang] -> afterCollKernelEnd
-// Please note that beforeCollKernelScheduled and afterCollKernelScheduled will
-// be triggered in the calling thread, while the rest will be triggered in the
-// colltrace thread.
+//    afterCollKernelStart -> [collEventProgressing] -> afterCollKernelEnd
+// afterCollRecorded, beforeCollKernelScheduled, and afterCollKernelScheduled
+// run in the calling thread. The remaining callbacks run in the colltrace
+// thread.
 class ICollTracePlugin {
  public:
   virtual ~ICollTracePlugin() = default;
@@ -28,6 +28,14 @@ class ICollTracePlugin {
   virtual std::string_view getName() const noexcept = 0;
 
   // ----- Callbacks below will be triggered in the calling (main) thread -----
+
+  // Callback that will be called after a collective record has been created
+  // and any capture identity is available. Graph collectives trigger this
+  // during capture, before any replay occurs.
+  virtual CommsMaybeVoid afterCollRecorded(
+      CollTraceEvent& /* curEvent */) noexcept {
+    return folly::unit;
+  }
 
   // Callback that will be called before a collective is scheduled. For cuda
   // event based tracking, this function will be called after the cuda event is

--- a/comms/utils/colltrace/GraphCollTraceState.h
+++ b/comms/utils/colltrace/GraphCollTraceState.h
@@ -21,6 +21,7 @@ struct GraphCollectiveEntry {
   // Owned by the CollTraceEvent below (unique_ptr), which we also own.
   GraphCudaWaitEvent* graphWaitEvent;
   std::unique_ptr<CollTraceEvent> event;
+  uint64_t replayId{0};
   // Weak reference to the handle returned to the caller. Used to invalidate
   // the handle when the CUDA graph is destroyed, preventing use-after-free
   // of the raw GraphCudaWaitEvent pointer held by the handle.

--- a/comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.cc
+++ b/comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.cc
@@ -1,0 +1,149 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.h"
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+
+#include <folly/Unit.h>
+#include <folly/logging/xlog.h>
+
+namespace meta::comms::colltrace {
+
+namespace {
+
+constexpr auto kEpoch = ICollWaitEvent::system_clock_time_point{};
+constexpr std::size_t kBacklogWarningThreshold = std::size_t{1} << 13;
+constexpr uint32_t kBacklogCheckPeriod = 256;
+
+} // namespace
+
+LifecycleEventFeedPlugin::LifecycleEventFeedPlugin(
+    LifecycleEventFeedConfig config)
+    : commId_(config.commId) {}
+
+std::string_view LifecycleEventFeedPlugin::getName() const noexcept {
+  return kLifecycleEventFeedPluginName;
+}
+
+CommsMaybeVoid LifecycleEventFeedPlugin::afterCollRecorded(
+    CollTraceEvent& curEvent) noexcept {
+  if (curEvent.collRecord == nullptr) {
+    return folly::makeUnexpected(CommsError(
+        "LifecycleEventFeedPlugin received an event without a collective record",
+        commInternalError));
+  }
+  const auto collId =
+      curEvent.capturedCollId.value_or(curEvent.collRecord->getCollId()) + 1;
+  auto latestCollId = latestCollId_.load(std::memory_order_relaxed);
+  while (latestCollId < collId &&
+         !latestCollId_.compare_exchange_weak(
+             latestCollId,
+             collId,
+             std::memory_order_relaxed,
+             std::memory_order_relaxed)) {
+  }
+  return folly::unit;
+}
+
+CommsMaybeVoid LifecycleEventFeedPlugin::beforeCollKernelScheduled(
+    CollTraceEvent&) noexcept {
+  return folly::unit;
+}
+
+CommsMaybeVoid LifecycleEventFeedPlugin::afterCollKernelScheduled(
+    CollTraceEvent& curEvent) noexcept {
+  return recordEvent(curEvent, LifecycleEventType::kEnqueue);
+}
+
+CommsMaybeVoid LifecycleEventFeedPlugin::afterCollKernelStart(
+    CollTraceEvent& curEvent) noexcept {
+  return recordEvent(curEvent, LifecycleEventType::kStart);
+}
+
+CommsMaybeVoid LifecycleEventFeedPlugin::collEventProgressing(
+    CollTraceEvent&) noexcept {
+  return folly::unit;
+}
+
+CommsMaybeVoid LifecycleEventFeedPlugin::afterCollKernelEnd(
+    CollTraceEvent& curEvent) noexcept {
+  return recordEvent(curEvent, LifecycleEventType::kEnd);
+}
+
+CommsMaybeVoid LifecycleEventFeedPlugin::recordEvent(
+    CollTraceEvent& curEvent,
+    LifecycleEventType eventType) noexcept {
+  if (curEvent.collRecord == nullptr) {
+    return folly::makeUnexpected(CommsError(
+        "LifecycleEventFeedPlugin received an event without a collective record",
+        commInternalError));
+  }
+
+  auto timestamp = kEpoch;
+  const auto& timingInfo = curEvent.collRecord->getTimingInfo();
+  switch (eventType) {
+    case LifecycleEventType::kEnqueue:
+      if (curEvent.waitEvent != nullptr) {
+        auto enqueueTime = curEvent.waitEvent->getCollEnqueueTime();
+        if (enqueueTime.hasValue()) {
+          timestamp = enqueueTime.value();
+          break;
+        }
+      }
+      timestamp = timingInfo.getCollEnqueueTs();
+      break;
+    case LifecycleEventType::kStart:
+      timestamp = timingInfo.getCollStartTs();
+      break;
+    case LifecycleEventType::kEnd:
+      timestamp = timingInfo.getCollEndTs();
+      break;
+  }
+  if (timestamp == kEpoch) {
+    timestamp = std::chrono::system_clock::now();
+  }
+
+  auto record = LifecycleEventRecord{
+      .replayId = curEvent.replayId,
+      .commId = commId_,
+      .collId = curEvent.collRecord->getCollId(),
+      .capturedCollId = curEvent.capturedCollId,
+      .eventType = eventType,
+      .timestamp = timestamp,
+  };
+  unreadEvents_.enqueue(std::move(record));
+  static thread_local uint32_t backlogCheckCounter = 0;
+  if (++backlogCheckCounter % kBacklogCheckPeriod == 0) {
+    const auto backlog = unreadEvents_.size();
+    if (backlog >= kBacklogWarningThreshold) [[unlikely]] {
+      XLOG_EVERY_MS(WARN, 60000)
+          << "LifecycleEventFeedPlugin estimated unread backlog is " << backlog
+          << " events for comm " << commId_
+          << "; consumer may be stalled and memory will continue to grow";
+    }
+  }
+  return folly::unit;
+}
+
+std::vector<LifecycleEventRecord>
+LifecycleEventFeedPlugin::drainUnreadLifecycleEvents() noexcept {
+  std::vector<LifecycleEventRecord> events;
+  LifecycleEventRecord event;
+  while (unreadEvents_.try_dequeue(event)) {
+    events.push_back(std::move(event));
+  }
+  return events;
+}
+
+uint64_t LifecycleEventFeedPlugin::getLatestLifecycleCollectiveId()
+    const noexcept {
+  return latestCollId_.load(std::memory_order_relaxed);
+}
+
+uint64_t LifecycleEventFeedPlugin::getCommId() const noexcept {
+  return commId_;
+}
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.h
+++ b/comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.h
@@ -1,0 +1,71 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+#include <folly/concurrency/UnboundedQueue.h>
+
+#include "comms/utils/colltrace/CollTracePlugin.h"
+
+namespace meta::comms::colltrace {
+
+enum class LifecycleEventType : uint8_t {
+  kEnqueue,
+  kStart,
+  kEnd,
+};
+
+struct LifecycleEventRecord {
+  std::optional<uint64_t> replayId;
+  uint64_t commId{0};
+  uint64_t collId{0};
+  std::optional<uint64_t> capturedCollId;
+  LifecycleEventType eventType{LifecycleEventType::kEnqueue};
+  ICollWaitEvent::system_clock_time_point timestamp{};
+
+  bool operator==(const LifecycleEventRecord&) const = default;
+};
+
+struct LifecycleEventFeedConfig {
+  uint64_t commId{0};
+};
+
+class LifecycleEventFeedPlugin : public ICollTracePlugin {
+ public:
+  explicit LifecycleEventFeedPlugin(LifecycleEventFeedConfig config = {});
+
+  std::string_view getName() const noexcept override;
+
+  CommsMaybeVoid afterCollRecorded(CollTraceEvent& curEvent) noexcept override;
+  CommsMaybeVoid beforeCollKernelScheduled(
+      CollTraceEvent& curEvent) noexcept override;
+  CommsMaybeVoid afterCollKernelScheduled(
+      CollTraceEvent& curEvent) noexcept override;
+  CommsMaybeVoid afterCollKernelStart(
+      CollTraceEvent& curEvent) noexcept override;
+  CommsMaybeVoid collEventProgressing(
+      CollTraceEvent& curEvent) noexcept override;
+  CommsMaybeVoid afterCollKernelEnd(CollTraceEvent& curEvent) noexcept override;
+
+  std::vector<LifecycleEventRecord> drainUnreadLifecycleEvents() noexcept;
+  uint64_t getLatestLifecycleCollectiveId() const noexcept;
+  uint64_t getCommId() const noexcept;
+  static constexpr std::string_view kLifecycleEventFeedPluginName =
+      "LifecycleEventFeedPlugin";
+
+ private:
+  CommsMaybeVoid recordEvent(
+      CollTraceEvent& curEvent,
+      LifecycleEventType eventType) noexcept;
+
+  uint64_t commId_{0};
+  folly::UMPMCQueue<LifecycleEventRecord, false> unreadEvents_;
+  std::atomic<uint64_t> latestCollId_{0};
+};
+
+} // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/plugins/tests/LifecycleEventFeedPluginUT.cc
+++ b/comms/utils/colltrace/plugins/tests/LifecycleEventFeedPluginUT.cc
@@ -1,0 +1,205 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <barrier>
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/colltrace/CPUWaitEvent.h"
+#include "comms/utils/colltrace/CollTraceEvent.h"
+#include "comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.h"
+#include "comms/utils/colltrace/tests/MockTypes.h"
+
+namespace meta::comms::colltrace {
+namespace {
+
+CollTraceEvent makeEvent(
+    uint64_t collId,
+    std::optional<uint64_t> replayId = std::nullopt,
+    std::optional<uint64_t> capturedCollId = std::nullopt) {
+  return CollTraceEvent{
+      .collRecord = std::make_shared<CollRecord>(
+          collId, std::make_unique<MockCollMetadata>()),
+      .replayId = replayId,
+      .capturedCollId = capturedCollId,
+  };
+}
+
+TEST(LifecycleEventFeedPluginTest, DrainsUnreadLifecycleEvents) {
+  constexpr uint64_t kCommId = 17;
+  constexpr uint64_t kCollId = 23;
+  constexpr uint64_t kCapturedCollId = 19;
+  constexpr uint64_t kReplayId = 4;
+  const auto enqueueTs =
+      std::chrono::system_clock::time_point{std::chrono::milliseconds{100}};
+  const auto startTs =
+      std::chrono::system_clock::time_point{std::chrono::milliseconds{200}};
+  const auto endTs =
+      std::chrono::system_clock::time_point{std::chrono::milliseconds{300}};
+  LifecycleEventFeedPlugin plugin{LifecycleEventFeedConfig{.commId = kCommId}};
+  auto event = makeEvent(kCollId, kReplayId, kCapturedCollId);
+  event.collRecord->getTimingInfo().setCollEnqueueTs(enqueueTs);
+  event.collRecord->getTimingInfo().setCollStartTs(startTs);
+  event.collRecord->getTimingInfo().setCollEndTs(endTs);
+
+  EXPECT_TRUE(plugin.afterCollKernelScheduled(event).hasValue());
+  EXPECT_TRUE(plugin.afterCollKernelStart(event).hasValue());
+  EXPECT_TRUE(plugin.afterCollKernelEnd(event).hasValue());
+
+  const std::vector<LifecycleEventRecord> expected{
+      LifecycleEventRecord{
+          .replayId = kReplayId,
+          .commId = kCommId,
+          .collId = kCollId,
+          .capturedCollId = kCapturedCollId,
+          .eventType = LifecycleEventType::kEnqueue,
+          .timestamp = enqueueTs,
+      },
+      LifecycleEventRecord{
+          .replayId = kReplayId,
+          .commId = kCommId,
+          .collId = kCollId,
+          .capturedCollId = kCapturedCollId,
+          .eventType = LifecycleEventType::kStart,
+          .timestamp = startTs,
+      },
+      LifecycleEventRecord{
+          .replayId = kReplayId,
+          .commId = kCommId,
+          .collId = kCollId,
+          .capturedCollId = kCapturedCollId,
+          .eventType = LifecycleEventType::kEnd,
+          .timestamp = endTs,
+      },
+  };
+  EXPECT_EQ(plugin.drainUnreadLifecycleEvents(), expected);
+  EXPECT_TRUE(plugin.drainUnreadLifecycleEvents().empty());
+}
+
+TEST(LifecycleEventFeedPluginTest, ReadsLatestCollectiveIdWhileRecordsArrive) {
+  constexpr uint64_t kNumColls = 1024;
+  LifecycleEventFeedPlugin plugin;
+  std::barrier phase{2};
+  bool writerSucceeded = true;
+
+  std::thread writer([&] {
+    for (uint64_t collId = 0; collId < kNumColls; ++collId) {
+      auto event = makeEvent(collId);
+      phase.arrive_and_wait();
+      writerSucceeded &= plugin.afterCollRecorded(event).hasValue();
+      phase.arrive_and_wait();
+    }
+  });
+
+  uint64_t previousCollId = 0;
+  bool remainedMonotonic = true;
+  for (uint64_t i = 0; i < kNumColls; ++i) {
+    phase.arrive_and_wait();
+    const auto collId = plugin.getLatestLifecycleCollectiveId();
+    remainedMonotonic &= collId >= previousCollId;
+    previousCollId = collId;
+    phase.arrive_and_wait();
+  }
+  writer.join();
+
+  EXPECT_TRUE(writerSucceeded);
+  EXPECT_TRUE(remainedMonotonic);
+  EXPECT_EQ(plugin.getLatestLifecycleCollectiveId(), kNumColls);
+}
+
+TEST(
+    LifecycleEventFeedPluginTest,
+    KeepsLargestCollectiveIdWhenRecordsArriveOutOfOrder) {
+  constexpr uint64_t kCommId = 17;
+  constexpr uint64_t kEarlierCollId = 23;
+  constexpr uint64_t kLatestCollId = 29;
+  LifecycleEventFeedPlugin plugin{LifecycleEventFeedConfig{.commId = kCommId}};
+  auto earlierEvent = makeEvent(kEarlierCollId);
+  auto latestEvent = makeEvent(kLatestCollId);
+
+  EXPECT_EQ(plugin.getLatestLifecycleCollectiveId(), 0);
+  EXPECT_TRUE(plugin.afterCollRecorded(latestEvent).hasValue());
+  EXPECT_TRUE(plugin.afterCollRecorded(earlierEvent).hasValue());
+
+  EXPECT_EQ(plugin.getLatestLifecycleCollectiveId(), kLatestCollId + 1);
+}
+
+TEST(LifecycleEventFeedPluginTest, PreservesBurstUntilDrained) {
+  constexpr std::size_t kBurstSize = 10'240;
+  const auto startTs = std::chrono::system_clock::now();
+  LifecycleEventFeedPlugin plugin{LifecycleEventFeedConfig{.commId = 1}};
+  auto event = makeEvent(2);
+  event.collRecord->getTimingInfo().setCollStartTs(startTs);
+
+  for (std::size_t i = 0; i < kBurstSize; ++i) {
+    EXPECT_TRUE(plugin.afterCollKernelStart(event).hasValue());
+  }
+
+  const auto expected = LifecycleEventRecord{
+      .commId = 1,
+      .collId = 2,
+      .eventType = LifecycleEventType::kStart,
+      .timestamp = startTs,
+  };
+  EXPECT_EQ(
+      plugin.drainUnreadLifecycleEvents(),
+      std::vector<LifecycleEventRecord>(kBurstSize, expected));
+}
+
+TEST(LifecycleEventFeedPluginTest, UsesCurrentTimeForUnsetTimestamps) {
+  LifecycleEventFeedPlugin plugin;
+  auto event = makeEvent(2);
+  const auto before = std::chrono::system_clock::now();
+
+  EXPECT_TRUE(plugin.afterCollKernelScheduled(event).hasValue());
+  EXPECT_TRUE(plugin.afterCollKernelStart(event).hasValue());
+  EXPECT_TRUE(plugin.afterCollKernelEnd(event).hasValue());
+
+  const auto after = std::chrono::system_clock::now();
+  const auto events = plugin.drainUnreadLifecycleEvents();
+  ASSERT_EQ(events.size(), 3);
+  for (const auto& recordedEvent : events) {
+    EXPECT_GE(recordedEvent.timestamp, before);
+    EXPECT_LE(recordedEvent.timestamp, after);
+  }
+}
+
+TEST(LifecycleEventFeedPluginTest, UsesWaitEventEnqueueTimeForEagerCollective) {
+  LifecycleEventFeedPlugin plugin;
+  auto event = makeEvent(2);
+  auto waitEvent = std::make_unique<CPUWaitEvent>();
+  const auto enqueueTs = waitEvent->getCollEnqueueTime().value();
+  event.waitEvent = std::move(waitEvent);
+  event.collRecord->getTimingInfo().setCollEnqueueTs(
+      enqueueTs + std::chrono::hours{1});
+
+  EXPECT_TRUE(plugin.afterCollKernelScheduled(event).hasValue());
+
+  const auto events = plugin.drainUnreadLifecycleEvents();
+  ASSERT_EQ(events.size(), 1);
+  EXPECT_EQ(events.front().timestamp, enqueueTs);
+}
+
+TEST(LifecycleEventFeedPluginTest, SeparatesReplayAndCapturedCollIds) {
+  constexpr uint64_t kReplayRecordId = 41;
+  constexpr uint64_t kCapturedCollId = 9;
+  LifecycleEventFeedPlugin plugin;
+  auto event = makeEvent(kReplayRecordId, 2, kCapturedCollId);
+  event.collRecord->getTimingInfo().setCollStartTs(
+      std::chrono::system_clock::now());
+
+  EXPECT_TRUE(plugin.afterCollKernelStart(event).hasValue());
+
+  const auto events = plugin.drainUnreadLifecycleEvents();
+  ASSERT_EQ(events.size(), 1);
+  EXPECT_EQ(events.front().collId, kReplayRecordId);
+  EXPECT_EQ(events.front().capturedCollId, kCapturedCollId);
+  EXPECT_EQ(events.front().replayId, 2);
+}
+
+} // namespace
+} // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/tests/CPUWaitEventUT.cc
+++ b/comms/utils/colltrace/tests/CPUWaitEventUT.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <chrono>
+#include <optional>
 #include <thread>
 
 #include <gtest/gtest.h>
@@ -29,11 +30,15 @@ TEST(CPUWaitEvent, Constructor) {
 
 TEST(CPUWaitEvent, SignalAndWaitCollStart) {
   auto event = std::make_unique<CPUWaitEvent>();
+  std::optional<ICollWaitEvent::system_clock_time_point> observedStartTime;
   // Start a thread that will wait for the collective to start
   std::thread waiterThread([&]() {
     auto waitResult = event->waitCollStart(std::chrono::milliseconds(10000));
     ASSERT_TRUE(waitResult.hasValue());
     EXPECT_TRUE(waitResult.value());
+    auto startTimeResult = event->getCollStartTime();
+    ASSERT_TRUE(startTimeResult.hasValue());
+    observedStartTime = startTimeResult.value();
   });
 
   // Sleep briefly to ensure the waiter thread is waiting
@@ -46,14 +51,10 @@ TEST(CPUWaitEvent, SignalAndWaitCollStart) {
   // Wait for the waiter thread to complete
   waiterThread.join();
 
-  // Verify that the start time was set
-  auto startTimeResult = event->getCollStartTime();
-  ASSERT_TRUE(startTimeResult.hasValue());
-
   // Start time should be after enqueue time
   auto enqueueTime = event->getCollEnqueueTime().value();
-  auto startTime = startTimeResult.value();
-  EXPECT_GE(startTime, enqueueTime);
+  ASSERT_TRUE(observedStartTime.has_value());
+  EXPECT_GE(observedStartTime.value(), enqueueTime);
 }
 
 TEST(CPUWaitEvent, SignalAndWaitCollStartTwice) {
@@ -126,11 +127,15 @@ TEST(CPUWaitEvent, SignalAndWaitCollEndTwice) {
 
 TEST(CPUWaitEvent, SignalAndWaitCollEnd) {
   auto event = std::make_unique<CPUWaitEvent>();
+  std::optional<ICollWaitEvent::system_clock_time_point> observedEndTime;
   // Start a thread that will wait for the collective to end
   std::thread waiterThread([&]() {
     auto waitResult = event->waitCollEnd(std::chrono::milliseconds(1000));
     ASSERT_TRUE(waitResult.hasValue());
     EXPECT_TRUE(waitResult.value());
+    auto endTimeResult = event->getCollEndTime();
+    ASSERT_TRUE(endTimeResult.hasValue());
+    observedEndTime = endTimeResult.value();
   });
 
   // Sleep briefly to ensure the waiter thread is waiting
@@ -143,14 +148,10 @@ TEST(CPUWaitEvent, SignalAndWaitCollEnd) {
   // Wait for the waiter thread to complete
   waiterThread.join();
 
-  // Verify that the end time was set
-  auto endTimeResult = event->getCollEndTime();
-  ASSERT_TRUE(endTimeResult.hasValue());
-
   // End time should be after enqueue time
   auto enqueueTime = event->getCollEnqueueTime().value();
-  auto endTime = endTimeResult.value();
-  EXPECT_GE(endTime, enqueueTime);
+  ASSERT_TRUE(observedEndTime.has_value());
+  EXPECT_GE(observedEndTime.value(), enqueueTime);
 }
 
 TEST(CPUWaitEvent, WaitCollStartTimeout) {

--- a/comms/utils/colltrace/tests/CollTraceUT.cc
+++ b/comms/utils/colltrace/tests/CollTraceUT.cc
@@ -35,6 +35,8 @@ class CollTraceTest : public ::testing::Test {
     ON_CALL(*mockPlugin, getName()).WillByDefault(Return("MockPlugin"));
 
     // Set default actions for CommsMaybeVoid methods to return folly::unit
+    ON_CALL(*mockPlugin, afterCollRecorded(_))
+        .WillByDefault(Return(folly::unit));
     ON_CALL(*mockPlugin, beforeCollKernelScheduled(_))
         .WillByDefault(Return(folly::unit));
     ON_CALL(*mockPlugin, afterCollKernelScheduled(_))
@@ -96,6 +98,22 @@ TEST_F(CollTraceTest, ConstructorAndDestructor) {
   trace.reset();
 }
 
+TEST(CollTraceSetupFailureTest, FlushReturnsAfterThreadSetupFailure) {
+  CollTrace trace(
+      CollTraceConfig{},
+      CommLogData{},
+      []() -> CommsMaybeVoid {
+        return folly::makeUnexpected(
+            CommsError("test setup failure", commInternalError));
+      },
+      {});
+
+  const auto firstGeneration = trace.requestFlush();
+  trace.waitFlush(firstGeneration);
+
+  EXPECT_EQ(trace.requestFlush(), firstGeneration + 1);
+}
+
 // Test getPluginByName method
 TEST_F(CollTraceTest, GetPluginByName) {
   // Get the plugin by name
@@ -109,6 +127,15 @@ TEST_F(CollTraceTest, GetPluginByName) {
 
 // Test recordCollective method
 TEST_F(CollTraceTest, RecordCollective) {
+  bool registrationObserved = false;
+  EXPECT_CALL(*mockPluginPtr, afterCollRecorded(_))
+      .WillOnce(::testing::Invoke([&](CollTraceEvent& event) {
+        EXPECT_NE(event.collRecord, nullptr);
+        EXPECT_FALSE(event.capturedCollId.has_value());
+        registrationObserved = true;
+        return folly::unit;
+      }));
+
   // Create metadata and wait event
   auto metadata = std::make_unique<::testing::StrictMock<MockCollMetadata>>();
   auto waitEvent = std::make_unique<NiceMock<MockCollWaitEvent>>();
@@ -126,6 +153,7 @@ TEST_F(CollTraceTest, RecordCollective) {
   // Verify that the handle was created successfully
   EXPECT_VALUE(handleMaybe);
   EXPECT_NE(handleMaybe.value().get(), nullptr);
+  EXPECT_TRUE(registrationObserved);
 }
 
 // Test triggerEventState method
@@ -269,18 +297,20 @@ TEST_F(CollTraceTest, CompleteWorkflowWithTriggerEvent) {
   EXPECT_VALUE(
       handle1->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel));
 
-  // Sleep briefly to allow the CollTrace thread to process the events
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  auto flushGeneration = collTrace->requestFlush();
+  collTrace->waitFlush(flushGeneration);
   EXPECT_GT(waitStartCount, 0);
 
-  handle1->trigger(CollTraceHandleTriggerState::KernelStarted);
+  EXPECT_VALUE(handle1->trigger(CollTraceHandleTriggerState::KernelStarted));
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  flushGeneration = collTrace->requestFlush();
+  collTrace->waitFlush(flushGeneration);
   EXPECT_GT(waitEndCount, 0);
 
-  handle1->trigger(CollTraceHandleTriggerState::KernelFinished);
+  EXPECT_VALUE(handle1->trigger(CollTraceHandleTriggerState::KernelFinished));
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  flushGeneration = collTrace->requestFlush();
+  collTrace->waitFlush(flushGeneration);
 }
 
 // Test plugin callbacks
@@ -319,6 +349,51 @@ TEST_F(CollTraceTest, PluginCallbacks) {
 
   // Sleep briefly to allow the CollTrace thread to process the events
   std::this_thread::sleep_for(std::chrono::milliseconds(10));
+}
+
+TEST_F(CollTraceTest, EpochWaitTimestampsDoNotRepeatLifecycleCallbacks) {
+  constexpr auto kEpoch = ICollWaitEvent::system_clock_time_point{};
+  auto metadata = std::make_unique<StrictMock<MockCollMetadata>>();
+  auto waitEvent = std::make_unique<NiceMock<MockCollWaitEvent>>();
+
+  ON_CALL(*waitEvent, beforeCollKernelScheduled())
+      .WillByDefault(Return(folly::unit));
+  ON_CALL(*waitEvent, afterCollKernelScheduled())
+      .WillByDefault(Return(folly::unit));
+  ON_CALL(*waitEvent, waitCollStart(_)).WillByDefault(Return(true));
+  ON_CALL(*waitEvent, waitCollEnd(_)).WillByDefault(Return(true));
+  ON_CALL(*waitEvent, getCollStartTime())
+      .WillByDefault(
+          Return(CommsMaybe<ICollWaitEvent::system_clock_time_point>{kEpoch}));
+  ON_CALL(*waitEvent, getCollEndTime())
+      .WillByDefault(
+          Return(CommsMaybe<ICollWaitEvent::system_clock_time_point>{kEpoch}));
+
+  EXPECT_CALL(*mockPluginPtr, afterCollKernelStart(_))
+      .WillOnce(::testing::Invoke([&](CollTraceEvent& event) {
+        EXPECT_NE(event.collRecord->getTimingInfo().getCollStartTs(), kEpoch);
+        return folly::unit;
+      }));
+  EXPECT_CALL(*mockPluginPtr, afterCollKernelEnd(_))
+      .WillOnce(::testing::Invoke([&](CollTraceEvent& event) {
+        EXPECT_NE(event.collRecord->getTimingInfo().getCollEndTs(), kEpoch);
+        return folly::unit;
+      }));
+
+  auto handleMaybe =
+      collTrace->recordCollective(std::move(metadata), std::move(waitEvent));
+  ASSERT_TRUE(handleMaybe.hasValue());
+  auto handle = handleMaybe.value();
+  EXPECT_VALUE(
+      handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel));
+  EXPECT_VALUE(
+      handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel));
+
+  for (int i = 0; i < 2; ++i) {
+    const auto flushGeneration = collTrace->requestFlush();
+    collTrace->waitFlush(flushGeneration);
+  }
+  collTrace.reset();
 }
 
 // Test handle invalidation when CollTrace is destroyed

--- a/comms/utils/colltrace/tests/GraphCollTraceUT.cc
+++ b/comms/utils/colltrace/tests/GraphCollTraceUT.cc
@@ -63,8 +63,26 @@ class SimpleMetadata : public ICollMetadata {
 // Plugin that tracks which collIds had collEventProgressing fired.
 class ProgressTrackingPlugin : public ICollTracePlugin {
  public:
+  struct EventIdentity {
+    uint64_t collId;
+    std::optional<uint64_t> replayId;
+    std::optional<uint64_t> capturedCollId;
+  };
+
   std::string_view getName() const noexcept override {
     return "ProgressTrackingPlugin";
+  }
+
+  meta::comms::CommsMaybeVoid afterCollRecorded(
+      CollTraceEvent& event) noexcept override {
+    std::lock_guard<std::mutex> lock(mu_);
+    recordedEventIdentities_.push_back(
+        EventIdentity{
+            .collId = event.collRecord->getCollId(),
+            .replayId = event.replayId,
+            .capturedCollId = event.capturedCollId,
+        });
+    return folly::unit;
   }
 
   meta::comms::CommsMaybeVoid beforeCollKernelScheduled(
@@ -82,6 +100,12 @@ class ProgressTrackingPlugin : public ICollTracePlugin {
     if (event.collRecord) {
       std::lock_guard<std::mutex> lock(mu_);
       startedCollIds_.insert(event.collRecord->getCollId());
+      startedEventIdentities_.push_back(
+          EventIdentity{
+              .collId = event.collRecord->getCollId(),
+              .replayId = event.replayId,
+              .capturedCollId = event.capturedCollId,
+          });
     }
     return folly::unit;
   }
@@ -115,6 +139,16 @@ class ProgressTrackingPlugin : public ICollTracePlugin {
     return startedCollIds_;
   }
 
+  std::vector<EventIdentity> getStartedEventIdentities() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return startedEventIdentities_;
+  }
+
+  std::vector<EventIdentity> getRecordedEventIdentities() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return recordedEventIdentities_;
+  }
+
   std::set<int64_t> getCompletedCollIds() const {
     std::lock_guard<std::mutex> lock(mu_);
     return completedCollIds_;
@@ -128,6 +162,8 @@ class ProgressTrackingPlugin : public ICollTracePlugin {
     std::lock_guard<std::mutex> lock(mu_);
     progressedCollIds_.clear();
     startedCollIds_.clear();
+    startedEventIdentities_.clear();
+    recordedEventIdentities_.clear();
     completedCollIds_.clear();
     progressCount_.store(0);
   }
@@ -136,6 +172,8 @@ class ProgressTrackingPlugin : public ICollTracePlugin {
   mutable std::mutex mu_;
   std::set<int64_t> progressedCollIds_;
   std::set<int64_t> startedCollIds_;
+  std::vector<EventIdentity> startedEventIdentities_;
+  std::vector<EventIdentity> recordedEventIdentities_;
   std::set<int64_t> completedCollIds_;
   std::atomic<int> progressCount_{0};
 };
@@ -327,6 +365,50 @@ TEST_F(GraphColltraceProgressingTest, DetectsInFlightCollective) {
   auto completedIds = progressPlugin_->getCompletedCollIds();
   EXPECT_EQ(completedIds.size(), kNumColls)
       << "All collectives should be marked completed after stream sync";
+}
+
+TEST_F(GraphColltraceProgressingTest, PreservesIdentityAcrossReplays) {
+  constexpr uint32_t kNumColls = 2;
+  constexpr uint64_t kNumReplays = 2;
+  auto cg = captureSerial(kNumColls, 0);
+
+  ASSERT_NE(progressPlugin_, nullptr);
+  const auto registrations = progressPlugin_->getRecordedEventIdentities();
+  ASSERT_EQ(registrations.size(), kNumColls);
+  for (uint32_t i = 0; i < kNumColls; ++i) {
+    EXPECT_FALSE(registrations[i].replayId.has_value());
+    EXPECT_EQ(registrations[i].collId, cg.collIds[i]);
+    EXPECT_EQ(registrations[i].capturedCollId, cg.collIds[i]);
+  }
+
+  for (uint64_t replayId = 1; replayId <= kNumReplays; ++replayId) {
+    ASSERT_EQ(cudaGraphLaunch(cg.instance, stream_), cudaSuccess);
+  }
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+  colltrace_->waitFlush(colltrace_->requestFlush());
+
+  const auto identities = progressPlugin_->getStartedEventIdentities();
+  ASSERT_EQ(identities.size(), kNumColls * kNumReplays);
+  std::multiset<std::pair<uint64_t, uint64_t>> actual;
+  std::set<uint64_t> replayCollIds;
+  for (const auto& identity : identities) {
+    ASSERT_TRUE(identity.replayId.has_value());
+    ASSERT_TRUE(identity.capturedCollId.has_value());
+    actual.emplace(*identity.capturedCollId, *identity.replayId);
+    replayCollIds.insert(identity.collId);
+  }
+
+  std::multiset<std::pair<uint64_t, uint64_t>> expected;
+  for (const auto collId : cg.collIds) {
+    for (uint64_t replayId = 1; replayId <= kNumReplays; ++replayId) {
+      expected.emplace(collId, replayId);
+    }
+  }
+  EXPECT_EQ(actual, expected);
+  EXPECT_EQ(replayCollIds.size(), kNumColls * kNumReplays);
+  for (const auto capturedCollId : cg.collIds) {
+    EXPECT_FALSE(replayCollIds.contains(capturedCollId));
+  }
 }
 
 // Capture concurrent collectives on separate streams so multiple start

--- a/comms/utils/colltrace/tests/MockTypes.h
+++ b/comms/utils/colltrace/tests/MockTypes.h
@@ -43,6 +43,11 @@ class MockCollTracePlugin : public ICollTracePlugin {
   MOCK_METHOD(std::string_view, getName, (), (const, noexcept, override));
   MOCK_METHOD(
       CommsMaybeVoid,
+      afterCollRecorded,
+      (CollTraceEvent & curEvent),
+      (noexcept, override));
+  MOCK_METHOD(
+      CommsMaybeVoid,
       beforeCollKernelScheduled,
       (CollTraceEvent & curEvent),
       (noexcept, override));

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2545,18 +2545,28 @@ cvars:
      Enable collective trace collection by leveraging cuda events
      and a background thread. Valid options are comma separated list
      of the following features. Leave empty to disable all features.
+     ALL - enable trace, lifecycle, and algostat (also accepted as `all`).
+           It intentionally excludes verbose; add verbose explicitly when
+           per-collective INFO logging is wanted.
      verbose - print every completed event as NCCL INFO log. Mostly for debug.
-     trace - Just enable collective trace.
+     trace - enable collective tracing and communicator dump retention.
+     lifecycle - enable the drainable enqueue/start/end lifecycle event feed.
+                 Consumers can correlate events with
+                 ncclx::colltrace::getCollTraceCommId(comm, commId) and
+                 getLatestCollTraceCollectiveId(comm, collId), then consume
+                 them with drainUnreadLifecycleEvents(events).
      algostat - lightweight algorithm counting (no CUDA events/worker thread).
                 Use ncclx::colltrace::dumpAlgoStat(comm) to retrieve stats.
+     An unrecognized option fails communicator initialization with
+     ncclInvalidArgument instead of silently disabling tracing.
 
  - name        : NCCL_COLLTRACE_PENDING_QUEUE_SIZE
    type        : int
    default     : 4096
    description : |-
      How many pending collectives to keep in the pending queue. If the queue
-     is full, the newest one will be dropped. Currently this only works for new
-     colltrace implementation.
+     is full, the newest one will be dropped. Currently this only works for the
+     new colltrace implementation.
 
  - name        : NCCL_COLLTRACE_TRACE_CUDA_GRAPH
    type        : bool


### PR DESCRIPTION
Summary:
Adds an opt-in, pull-based collective lifecycle feed in native CollTrace and exposes copied values through matched NCCLX and `nccl4py` builds.

Ownership and configuration

- `NCCL_COLLTRACE=lifecycle` creates one `LifecycleEventFeedPlugin` per lifecycle-enabled `ncclComm_t`. Lifecycle-only mode starts CollTrace without also installing CommDump.
- `NCCL_COLLTRACE=ALL` and lowercase `all` enable `algostat`, `lifecycle`, and `trace` without implicitly enabling `verbose`; explicit `verbose` composes with either alias. Unknown modes return `ncclInvalidArgument` before partial initialization.
- A process-local registry holds weak CollTrace references. The global reader flushes live instances, drains their plugin queues, and stable-sorts copied records by timestamp without extending communicator lifetimes.

Public API and identity

- `colltrace_get_comm_id(comm)` returns a monotonic process-local communicator ID.
- `colltrace_get_latest_coll_id(comm)` returns the latest identity for that communicator. `0` means no collective has been registered; real collective IDs are one-based. Captured collectives retain their capture identity across graph replays.
- `colltrace_get_unread_events()` destructively drains unread `enqueue`, `start`, and `end` records across lifecycle-enabled communicators. Each tuple is `(replay_id, comm_id, coll_id, execution_coll_id, event_type, timestamp)`.
- Latest-ID state belongs to the communicator plugin, not thread-local storage. Null communicators return `ncclInvalidArgument`; communicators without lifecycle mode return `ncclInvalidUsage`.

Lifecycle correctness and build boundary

- CPU start/end timestamps are stored before semaphore publication. If a ready wait event unexpectedly reports the epoch sentinel, the poller substitutes its current timestamp so start/end state remains sticky and callbacks are not emitted repeatedly.
- The Python bridge releases the GIL around native calls, maps absent replay IDs to `None`, and never exposes pointers into CollTrace state.
- NCCLX and `nccl4py` remain a matched-build boundary because the binding links the new native symbols and layouts directly.

Reviewed By: pavanbalaji

Differential Revision: D114815651


