### PR TITLE
Support per-op AbortDevice timeout override

### DIFF
--- a/comms/common/fault_tolerance/AbortDevice.cuh
+++ b/comms/common/fault_tolerance/AbortDevice.cuh
@@ -145,6 +145,37 @@ struct AbortDevice final {
   }
 
   /**
+   * Overrides the deadline for one operation, in milliseconds.
+   *
+   * Set this on a per-operation COPY of the handle. Handles obtained from
+   * `MultiPeerTransport::get_device_handle()` are communicator-scoped and
+   * shared, so mutating one in place would leak the override into unrelated
+   * operations:
+   *
+   *     auto abort = mpt->get_device_handle(peers).abort;  // copy
+   *     abort.setOpTimeoutMs(opTimeoutMs);
+   *     params.abort = abort;                              // into kern args
+   *
+   * A negative value (the default) means "no override": the deadline then
+   * comes from the communicator-level timeout in shared state, which stays
+   * late-bound so `Abort::setDefaultTimeout()` is always observed.
+   *
+   * Only set this from a timeout the caller explicitly supplied on the
+   * collective API. Seeding it from the communicator default would snapshot
+   * that value at launch and defeat late-binding.
+   */
+  __host__ __device__ void setOpTimeoutMs(int64_t timeoutMs) {
+    opTimeoutMs_ = timeoutMs;
+  }
+
+  /**
+   * Returns the per-operation override, or a negative value when unset.
+   */
+  __host__ __device__ int64_t opTimeoutMs() const {
+    return opTimeoutMs_;
+  }
+
+  /**
    * Starts this handle's device-side timeout from the shared default duration.
    *
    * Non-positive or unset default timeouts leave the device deadline inactive.
@@ -157,7 +188,7 @@ struct AbortDevice final {
       deadlineCycles_ = 0;
       return;
     }
-    const auto timeoutMs = getTimeoutMs();
+    const auto timeoutMs = resolveTimeoutMs();
     if (timeoutMs <= 0 || cyclesPerMs_ == 0) {
       deadlineCycles_ = 0;
       return;
@@ -303,6 +334,22 @@ struct AbortDevice final {
   friend class Abort;
 
   /**
+   * Deadline duration for this operation, in milliseconds.
+   *
+   * A per-operation override wins because it is the more specific request and
+   * it travels by value in the kernel arguments, so it costs no shared-state
+   * read. Otherwise the communicator-level timeout is read from mapped shared
+   * state on every start, which keeps it late-bound: a handle created before
+   * `setDefaultTimeout()` still observes the new value.
+   */
+  __device__ int64_t resolveTimeoutMs() const {
+    if (opTimeoutMs_ >= 0) {
+      return opTimeoutMs_;
+    }
+    return getTimeoutMs();
+  }
+
+  /**
    * Creates a device handle for mapped pinned state owned by `Abort`.
    *
    * Passing this handle by value to a kernel passes only this small non-owning
@@ -362,6 +409,14 @@ struct AbortDevice final {
    * milliseconds into device clock cycles.
    */
   uint64_t cyclesPerMs_{0};
+
+  /**
+   * Per-operation deadline override in milliseconds; negative means unset.
+   *
+   * Copied into kernel arguments with the rest of the handle, so device code
+   * reads it from registers rather than mapped host memory.
+   */
+  int64_t opTimeoutMs_{-1};
 
   /**
    * Device abort behavior selected by the owning host `Abort`.

--- a/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
@@ -428,6 +428,128 @@ TEST(AbortDeviceTest, deviceTimeoutCanBeCancelledAndRestarted) {
   EXPECT_TRUE(abort.isTimedOut());
 }
 
+// The communicator timeout must stay late-bound. Transports cache one device
+// handle for the communicator's lifetime (MultiPeerTransport builds it in its
+// constructor), so a handle created before setDefaultTimeout() must still honor
+// the new value. Note this asserts the DEADLINE path, not a raw
+// getTimeoutMs() read: deviceHandleSeesHostDefaultTimeoutUpdates covers the
+// latter and would not catch a stale value cached inside startTimeout().
+TEST(AbortDeviceTest, deadlineHonorsDefaultTimeoutSetAfterHandleCreation) {
+  Abort abort{/*enabled=*/true};
+  // Handle created BEFORE any timeout exists, then again after one is set, to
+  // cover both orderings a communicator can produce.
+  abort.setDefaultTimeout(std::chrono::milliseconds{60000});
+  auto handle = abort.getDeviceHandle();
+
+  auto observedMode = makeDeviceValue<int>();
+  auto observedIsAborted = makeDeviceValue<int>();
+  ASSERT_NE(observedMode, nullptr);
+  ASSERT_NE(observedIsAborted, nullptr);
+
+  // Shorten well below the value present at handle creation. If the handle
+  // cached that value, this waits ~60s and the bound below fails.
+  abort.setDefaultTimeout(std::chrono::milliseconds{kDeviceTimeoutExpectedMs});
+
+  cudaEvent_t start = nullptr;
+  cudaEvent_t end = nullptr;
+  ASSERT_EQ(cudaEventCreate(&start), cudaSuccess);
+  ASSERT_EQ(cudaEventCreate(&end), cudaSuccess);
+
+  ASSERT_EQ(cudaEventRecord(start, /*stream=*/nullptr), cudaSuccess);
+  EXPECT_EQ(
+      launchDeviceWaitForTimeout(
+          handle,
+          observedMode.get(),
+          observedIsAborted.get(),
+          kDeviceTimeoutPollIterations,
+          /*stream=*/nullptr),
+      cudaSuccess);
+  ASSERT_EQ(cudaEventRecord(end, /*stream=*/nullptr), cudaSuccess);
+  ASSERT_EQ(cudaEventSynchronize(end), cudaSuccess);
+
+  float elapsedMs = 0.0F;
+  ASSERT_EQ(cudaEventElapsedTime(&elapsedMs, start, end), cudaSuccess);
+  destroyEvent(end);
+  destroyEvent(start);
+
+  EXPECT_EQ(
+      readDeviceValue(observedMode), static_cast<int>(AbortReason::TIMED_OUT));
+  EXPECT_LE(
+      elapsedMs,
+      static_cast<float>(kDeviceTimeoutExpectedMs) + kDeviceTimeoutAccuracyMs)
+      << "deadline used a stale timeout captured at handle creation";
+}
+
+// A per-op override beats the communicator default, and clearing it falls back
+// to shared state.
+TEST(AbortDeviceTest, perOpTimeoutOverridesCommunicatorDefault) {
+  Abort abort{/*enabled=*/true};
+  abort.setDefaultTimeout(std::chrono::milliseconds{60000});
+
+  auto handle = abort.getDeviceHandle();
+  EXPECT_LT(handle.opTimeoutMs(), 0) << "override must default to unset";
+  handle.setOpTimeoutMs(kDeviceTimeoutExpectedMs);
+
+  auto observedMode = makeDeviceValue<int>();
+  auto observedIsAborted = makeDeviceValue<int>();
+  ASSERT_NE(observedMode, nullptr);
+  ASSERT_NE(observedIsAborted, nullptr);
+
+  cudaEvent_t start = nullptr;
+  cudaEvent_t end = nullptr;
+  ASSERT_EQ(cudaEventCreate(&start), cudaSuccess);
+  ASSERT_EQ(cudaEventCreate(&end), cudaSuccess);
+
+  ASSERT_EQ(cudaEventRecord(start, /*stream=*/nullptr), cudaSuccess);
+  EXPECT_EQ(
+      launchDeviceWaitForTimeout(
+          handle,
+          observedMode.get(),
+          observedIsAborted.get(),
+          kDeviceTimeoutPollIterations,
+          /*stream=*/nullptr),
+      cudaSuccess);
+  ASSERT_EQ(cudaEventRecord(end, /*stream=*/nullptr), cudaSuccess);
+  ASSERT_EQ(cudaEventSynchronize(end), cudaSuccess);
+
+  float elapsedMs = 0.0F;
+  ASSERT_EQ(cudaEventElapsedTime(&elapsedMs, start, end), cudaSuccess);
+  destroyEvent(end);
+  destroyEvent(start);
+
+  EXPECT_EQ(
+      readDeviceValue(observedMode), static_cast<int>(AbortReason::TIMED_OUT));
+  EXPECT_GE(
+      elapsedMs,
+      static_cast<float>(kDeviceTimeoutExpectedMs) - kDeviceTimeoutAccuracyMs);
+  EXPECT_LE(
+      elapsedMs,
+      static_cast<float>(kDeviceTimeoutExpectedMs) + kDeviceTimeoutAccuracyMs)
+      << "per-op override did not take precedence over the 60s comm default";
+}
+
+TEST(AbortDeviceTest, perOpTimeoutUnsetFallsBackToCommunicatorDefault) {
+  Abort abort{/*enabled=*/true};
+  abort.setDefaultTimeout(std::chrono::milliseconds{1234});
+
+  auto handle = abort.getDeviceHandle();
+  handle.setOpTimeoutMs(4321);
+  EXPECT_EQ(handle.opTimeoutMs(), 4321);
+
+  // Negative clears the override; the deadline reverts to shared state.
+  handle.setOpTimeoutMs(-1);
+  EXPECT_LT(handle.opTimeoutMs(), 0);
+
+  auto observedTimeoutMs = makeDeviceValue<int64_t>();
+  ASSERT_NE(observedTimeoutMs, nullptr);
+  EXPECT_EQ(
+      launchDeviceReadDefaultTimeoutMs(
+          handle, observedTimeoutMs.get(), /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  EXPECT_EQ(readDeviceValue(observedTimeoutMs), 1234);
+}
+
 TEST(AbortDeviceTest, deviceTimeoutAccuracyMeasuredWithCudaEvents) {
   Abort abort{/*enabled=*/true};
   auto observedMode = makeDeviceValue<int>();


### PR DESCRIPTION
Summary:
Lets a caller override the device abort deadline for a single operation, while
keeping the communicator-level deadline late-bound.

After the `Timeout` -> `AbortDevice` migration the deadline became purely
communicator-scoped, read from mapped pinned `AbortState::timeoutMs`. That
dropped per-operation timeouts (`AllReduceOpts::timeout`,
`SingleSendOpts::timeout`, ...) - they no longer reached the device at all.

`AbortDevice` now carries an optional `opTimeoutMs_`, set on a per-operation
COPY of the handle and travelling by value in the kernel arguments alongside
the peers/transports. Resolution order in `startTimeout()`:

1. per-op override, when `opTimeoutMs_ >= 0` - no shared-state read at all;
2. otherwise the communicator timeout, read from mapped shared state.

Two properties this deliberately preserves:

- **The override is only ever set from a timeout the caller passed on the MCCL
  collective API.** `MCCL_ABORT_TIMEOUT_MS` keeps exactly one job: seeding the
  communicator deadline. Seeding the per-op slot from the communicator default
  would snapshot it at launch and defeat late-binding.
- **The communicator deadline stays late-bound.** Transports cache one device
  handle for the communicator's lifetime (`MultiPeerTransport` builds it in its
  constructor), so a handle created before `setDefaultTimeout()` must still
  observe the new value. Anything that caches the timeout inside the handle
  breaks `IComm::setTimeout()` silently.

Handles are shared, so callers must set the override on a copy:

```cpp
auto abort = mpt->get_device_handle(peers).abort;  // copy
abort.setOpTimeoutMs(opTimeoutMs);                 // -1 == no override
params.abort = abort;
```

Behavior notes:
- No change when no override is set: the deadline resolves exactly as before.
- CUDA graphs: an op captured WITH an override bakes it in and replays honor it,
  since the override is a property of the captured op. An op captured WITHOUT
  one keeps late-binding from shared state, so a post-capture `setTimeout()`
  still applies.
- The launcher/collective plumbing that supplies the override lands in the
  diffs above this one.

Differential Revision: D115894464


