### PR TITLE
Accept commBfloat16 in the ring AllReduce datatype whitelist

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -1166,6 +1166,12 @@ static commResult_t impl(
           op->allreduce.datatype == commFloat32 ||
           op->allreduce.datatype == commFloat ||
           op->allreduce.datatype == commFloat64 ||
+// Kept in sync with makeKernelMap()'s bf16 registration: accepting a
+// datatype here that has no kernel entry fails later in kernelFuncMap
+// lookup with a much less obvious error.
+#if defined(__CUDA_BF16_TYPES_EXIST__)
+          op->allreduce.datatype == commBfloat16 ||
+#endif
           op->allreduce.datatype == commDouble) {
         // TODO: enable other data types
       } else {


### PR DESCRIPTION
Summary:
`AllReduceRing.cc` validates `op->allreduce.datatype` against a whitelist before
progressing the ring. `commFloat16` is on that list, `commBfloat16` is not, so a
bf16 AllReduce is rejected with `Unsupported data type` / `commInvalidArgument`
above the existing `// TODO: enable other data types`.

The bf16 kernel is already instantiated: `makeKernelMap()` registers
`ncclKernelAllReduceCtranRing<__nv_bfloat16, ...>` for every reduction op,
guarded by `__CUDA_BF16_TYPES_EXIST__`. Only the host-side gate was missing, so
this adds `commBfloat16` to the whitelist under the same guard — accepting a
datatype with no kernel entry would otherwise fail later in the `kernelFuncMap`
lookup with a much less obvious error.

This blocks every BF16 model running on PAFT: FSDP hands `paft_hook` a BF16
gradient and the FTAR AllReduce is rejected at argument validation, which turns
into `allreduces_succeeded() == false` -> `Unsuccessful should_commit` -> step
retry. The current workaround is to force `reduce_dtype: FP32` in the model
config, which doubles gradient bytes on the wire.

Note this is the CTRAN ring path only. The MCCL fused algorithms
(`AllReduceFusedRing` and friends) already accept bf16 for sum/max/min, but
still reject `commAvg` on bf16, which is what PAFT uses.

Differential Revision: D115935246


