### PR TITLE
Coordinate VMM exchange failures

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -62,6 +62,58 @@ size_t alignedPerChannelSize(
 
 } // namespace
 
+commResult_t ctran::ctranBuildMultimemNvlTransportConfig(
+    const ctranPrimsConfig& config,
+    size_t bufferSize,
+    int nLocalRanks,
+    comms::prims::MultimemNvlTransportConfig& multimemConfig) {
+  const size_t pipelineDepth = MCCL_NVL_MULTIMEM_PIPELINE_DEPTH;
+  constexpr size_t kMaxPipelineDepth = std::min(
+      static_cast<size_t>(std::numeric_limits<uint32_t>::max()),
+      std::numeric_limits<size_t>::max() / 16);
+  if (pipelineDepth == 0 || pipelineDepth > kMaxPipelineDepth) {
+    CLOGF(
+        ERR,
+        "MCCL_NVL_MULTIMEM_PIPELINE_DEPTH must be in [1, {}], got {}",
+        kMaxPipelineDepth,
+        pipelineDepth);
+    return commInvalidArgument;
+  }
+
+  const int64_t resolvedMaxChannels = ctranPrimsResolvedMaxChannels(config);
+  const int64_t resolvedMaxBlocks = ctranPrimsResolvedMaxBlocks(config);
+  const size_t maxChannels =
+      resolvedMaxChannels > 0 ? static_cast<size_t>(resolvedMaxChannels) : 0;
+  const size_t maxBlocks =
+      resolvedMaxBlocks > 0 ? static_cast<size_t>(resolvedMaxBlocks) : 0;
+  const size_t perChannelSize =
+      alignedPerChannelSize(bufferSize, maxChannels, pipelineDepth);
+  const auto candidate = comms::prims::make_multimem_nvl_transport_config({
+      .perChannelSize = perChannelSize,
+      .pipelineDepth = pipelineDepth,
+      .maxChannels = maxChannels,
+      .maxBlocks = maxBlocks,
+      .userSignalCount = 1,
+  });
+  const auto validation = comms::prims::validate_multimem_nvl_transport_config(
+      candidate, nLocalRanks);
+  if (!validation) {
+    CLOGF(
+        ERR,
+        "CTRAN-PRIMS: invalid NVL multimem config: {} (bufferSize={} perChannelSize={} pipelineDepth={} maxChannels={} maxBlocks={})",
+        validation.errorMessage,
+        bufferSize,
+        candidate.perChannelSize,
+        candidate.pipelineDepth,
+        candidate.maxChannels,
+        candidate.maxBlocks);
+    return commInvalidArgument;
+  }
+
+  multimemConfig = candidate;
+  return commSuccess;
+}
+
 commResult_t ctran::ctranPreparePipesTrace(
     CtranComm* comm,
     comms::prims::PipesTraceHandle& trace) {
@@ -136,54 +188,23 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     const size_t nvlDataBufferSize =
         nvlMaxNumChannels * config.nvlConfig.perChannelSize;
 
-    // The multimem staging window is decoupled from the P2P shared devbuf: a
-    // larger window means fewer staging rounds, which is the dominant cnvlmm
-    // throughput lever at large sizes. Falls back to the P2P size when the
-    // dedicated cvar is 0. Computed before the enable guard so setting only the
-    // multimem cvar (with the P2P devbuf at 0) is sufficient to enable the
-    // path.
-    const size_t multimemDevbufSize = MCCL_NVL_MULTIMEM_BUFSIZE > 0
-        ? static_cast<size_t>(MCCL_NVL_MULTIMEM_BUFSIZE)
-        : nvlSharedDevbufSize;
+    // The multimem staging window is independent of the P2P shared devbuf.
+    // A larger window means fewer staging rounds, which is the dominant
+    // cnvlmm throughput lever at large sizes. A zero size disables multimem.
+    const size_t multimemDevbufSize =
+        static_cast<size_t>(MCCL_NVL_MULTIMEM_BUFSIZE);
     if (comm->statex_->nLocalRanks() > 2 && multimemDevbufSize > 0) {
-      const std::size_t multimemPipelineDepth =
-          std::max<std::size_t>(1, config.nvlConfig.pipelineDepth);
-      const auto resolvedMaxChannels = ctranPrimsResolvedMaxChannels(pc);
-      const auto resolvedMaxBlocks = ctranPrimsResolvedMaxBlocks(pc);
-      const size_t multimemMaxChannels = resolvedMaxChannels > 0
-          ? static_cast<size_t>(resolvedMaxChannels)
-          : 0;
-      const size_t multimemMaxBlocks =
-          resolvedMaxBlocks > 0 ? static_cast<size_t>(resolvedMaxBlocks) : 0;
-      if (multimemMaxBlocks > multimemMaxChannels) {
-        CLOGF(
-            ERR,
-            "CTRAN-PRIMS: invalid multimem config; maxBlocks={} exceeds maxChannels={}",
-            multimemMaxBlocks,
-            multimemMaxChannels);
-        return commInvalidArgument;
+      comms::prims::MultimemNvlTransportConfig multimemConfig{};
+      if (const auto result = ctran::ctranBuildMultimemNvlTransportConfig(
+              pc,
+              multimemDevbufSize,
+              comm->statex_->nLocalRanks(),
+              multimemConfig);
+          result != commSuccess) {
+        return result;
       }
-      const size_t multimemPerChannelSize = alignedPerChannelSize(
-          multimemDevbufSize, multimemMaxChannels, multimemPipelineDepth);
-      if (multimemPerChannelSize == 0) {
-        CLOGF(
-            ERR,
-            "CTRAN-PRIMS: invalid multimem config; devbufSize={} maxChannels={} pipelineDepth={} cannot produce aligned perChannelSize",
-            multimemDevbufSize,
-            multimemMaxChannels,
-            multimemPipelineDepth);
-        return commInvalidArgument;
-      }
-
       config.nvlConfig.enableMultimem = true;
-      config.nvlConfig.multimem =
-          comms::prims::make_multimem_nvl_transport_config({
-              .perChannelSize = multimemPerChannelSize,
-              .pipelineDepth = multimemPipelineDepth,
-              .maxChannels = multimemMaxChannels,
-              .maxBlocks = multimemMaxBlocks,
-              .userSignalCount = 1,
-          });
+      config.nvlConfig.multimem = multimemConfig;
     }
 
     // LL128 buffer allocation for DeviceAllToAllv
@@ -409,7 +430,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
 
     CLOGF(
         INFO,
-        "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} enableMultimem={} multimemPipelineDepth={} multimemMaxChannels={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={}",
+        "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} enableMultimem={} multimemPerChannelSize={} multimemPipelineDepth={} multimemMaxChannels={} multimemMaxBlocks={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={}",
         comm->statex_->rank(),
         config.nvlConfig.pipelineDepth,
         nvlSharedDevbufSize,
@@ -418,9 +439,14 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         config.nvlConfig.perChannelSize,
         config.nvlConfig.enableMultimem,
         config.nvlConfig.enableMultimem
+            ? config.nvlConfig.multimem.perChannelSize
+            : 0,
+        config.nvlConfig.enableMultimem
             ? config.nvlConfig.multimem.pipelineDepth
             : 0,
         config.nvlConfig.enableMultimem ? config.nvlConfig.multimem.maxChannels
+                                        : 0,
+        config.nvlConfig.enableMultimem ? config.nvlConfig.multimem.maxBlocks
                                         : 0,
         hierAgOverlapEnabled,
         config.disableIb,

--- a/comms/ctran/CtranPipes.h
+++ b/comms/ctran/CtranPipes.h
@@ -14,6 +14,7 @@
 
 class CtranComm;
 class CtranAlgo;
+struct ctranPrimsConfig;
 
 inline size_t ctranEffectiveP2pNvlSharedDevbufSize(int nLocalRanks) {
   uint64_t size = NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE;
@@ -38,7 +39,17 @@ bool ctranPrimsEnabled(const CtranComm* comm);
 commResult_t ctranInitPipesResources(CtranAlgo* algo);
 
 #if defined(ENABLE_PRIMS)
+namespace comms::prims {
+struct MultimemNvlTransportConfig;
+} // namespace comms::prims
+
 namespace ctran {
+
+commResult_t ctranBuildMultimemNvlTransportConfig(
+    const ctranPrimsConfig& config,
+    size_t bufferSize,
+    int nLocalRanks,
+    comms::prims::MultimemNvlTransportConfig& multimemConfig);
 
 commResult_t ctranPreparePipesTrace(
     CtranComm* comm,

--- a/comms/ctran/tests/CtranCommTest.cc
+++ b/comms/ctran/tests/CtranCommTest.cc
@@ -3,9 +3,15 @@
 #include <folly/ScopeGuard.h>
 #include <gtest/gtest.h>
 
+#include <cstdint>
+#include <limits>
+
 #include "comms/common/fault_tolerance/Abort.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/CtranPipes.h"
+#if defined(ENABLE_PRIMS)
+#include "comms/prims/transport/nvl/MultimemNvlTransportConfig.h"
+#endif
 #include "comms/utils/cvars/nccl_cvars.h"
 
 namespace ctran::testing {
@@ -128,5 +134,68 @@ TEST(CtranCommTest, ExplicitPrimsDisableDoesNotAffectLegacyPolicy) {
   EXPECT_FALSE(ctranPrimsEnabled(&mcclComm));
   EXPECT_TRUE(ctranPrimsEnabled(&ncclxComm));
 }
+
+#if defined(ENABLE_PRIMS)
+TEST(CtranBuildMultimemConfigTest, UsesDedicatedDepthAndBufferSize) {
+  const auto savedMultimemDepth = MCCL_NVL_MULTIMEM_PIPELINE_DEPTH;
+  const auto savedP2pDepth = NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH;
+  auto restoreCvars = folly::makeGuard([&] {
+    MCCL_NVL_MULTIMEM_PIPELINE_DEPTH = savedMultimemDepth;
+    NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH = savedP2pDepth;
+  });
+  MCCL_NVL_MULTIMEM_PIPELINE_DEPTH = 3;
+  NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH = 7;
+
+  comms::prims::MultimemNvlTransportConfig config{};
+  EXPECT_EQ(
+      ctranBuildMultimemNvlTransportConfig(
+          ctranPrimsConfig{.maxChannels = 4, .maxBlocks = 2},
+          /*bufferSize=*/4096,
+          /*nLocalRanks=*/4,
+          config),
+      commSuccess);
+  EXPECT_EQ(config.pipelineDepth, 3);
+  EXPECT_EQ(config.maxChannels, 4);
+  EXPECT_EQ(config.maxBlocks, 2);
+  EXPECT_EQ(config.perChannelSize, 1008);
+  EXPECT_EQ(config.userSignalCount, 1);
+}
+
+TEST(CtranBuildMultimemConfigTest, RejectsZeroBufferSize) {
+  const auto savedMultimemDepth = MCCL_NVL_MULTIMEM_PIPELINE_DEPTH;
+  auto restoreCvars = folly::makeGuard(
+      [&] { MCCL_NVL_MULTIMEM_PIPELINE_DEPTH = savedMultimemDepth; });
+  MCCL_NVL_MULTIMEM_PIPELINE_DEPTH = 4;
+
+  comms::prims::MultimemNvlTransportConfig config{};
+  EXPECT_EQ(
+      ctranBuildMultimemNvlTransportConfig(
+          ctranPrimsConfig{.maxChannels = 8, .maxBlocks = 3},
+          /*bufferSize=*/0,
+          /*nLocalRanks=*/4,
+          config),
+      commInvalidArgument);
+}
+
+TEST(CtranBuildMultimemConfigTest, RejectsInvalidDedicatedDepth) {
+  const auto savedMultimemDepth = MCCL_NVL_MULTIMEM_PIPELINE_DEPTH;
+  auto restoreCvars = folly::makeGuard(
+      [&] { MCCL_NVL_MULTIMEM_PIPELINE_DEPTH = savedMultimemDepth; });
+
+  comms::prims::MultimemNvlTransportConfig config{};
+  for (const size_t invalidDepth :
+       {size_t{0},
+        static_cast<size_t>(std::numeric_limits<uint32_t>::max()) + 1}) {
+    MCCL_NVL_MULTIMEM_PIPELINE_DEPTH = invalidDepth;
+    EXPECT_EQ(
+        ctranBuildMultimemNvlTransportConfig(
+            ctranPrimsConfig{.maxChannels = 4, .maxBlocks = 2},
+            /*bufferSize=*/4096,
+            /*nLocalRanks=*/4,
+            config),
+        commInvalidArgument);
+  }
+}
+#endif // defined(ENABLE_PRIMS)
 
 } // namespace ctran::testing

--- a/comms/prims/bootstrap/TeamStatusAgreement.h
+++ b/comms/prims/bootstrap/TeamStatusAgreement.h
@@ -1,0 +1,112 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "comms/common/bootstrap/IBootstrap.h"
+
+namespace comms::prims::detail {
+
+// Common wire status for NVLink-team exchanges. Payload records place this
+// field alongside the data needed by that exchange; status-only stages use it
+// directly.
+struct TeamStatus {
+  uint32_t success{0};
+};
+
+inline TeamStatus& getTeamStatus(TeamStatus& status) {
+  return status;
+}
+
+template <typename Record>
+TeamStatus& getTeamStatus(Record& record) {
+  return record.status;
+}
+
+/**
+ * All-gathers one record per rank and turns a rank-local failure into the same
+ * team-wide result. The lowest failed rank is the deterministic primary
+ * failure. Every rank with a local failure receives its local error text and
+ * retains its exception as a nested cause; successful peers receive the
+ * primary rank and operation context.
+ *
+ * Record must be TeamStatus or an allGather-safe wire type with a
+ * `TeamStatus status` member. The caller owns any payload validation after
+ * this function returns.
+ */
+template <typename Record, typename Gather>
+void gatherAndAgree(
+    int rank,
+    int nranks,
+    std::vector<Record>& records,
+    const std::exception_ptr& localError,
+    std::string_view operation,
+    Gather&& gather) {
+  static_assert(std::is_trivially_copyable_v<Record>);
+
+  if (records.size() != static_cast<std::size_t>(nranks)) {
+    throw std::invalid_argument(
+        "gatherAndAgree records size must equal nranks");
+  }
+
+  getTeamStatus(records[static_cast<std::size_t>(rank)]).success =
+      localError ? 0u : 1u;
+  const int result = std::forward<Gather>(gather)(
+      records.data(), static_cast<int>(sizeof(Record)));
+  if (result != 0) {
+    throw std::runtime_error(
+        std::string(operation) + " status allGather failed");
+  }
+
+  for (int failedRank = 0; failedRank < nranks; ++failedRank) {
+    if (getTeamStatus(records[static_cast<std::size_t>(failedRank)]).success !=
+        0) {
+      continue;
+    }
+
+    std::string message = std::string(operation) + " failed on rank " +
+        std::to_string(failedRank);
+    if (localError) {
+      if (failedRank != rank) {
+        message += "; local rank ";
+        message += std::to_string(rank);
+        message += " also failed";
+      }
+      try {
+        std::rethrow_exception(localError);
+      } catch (const std::exception& error) {
+        std::throw_with_nested(
+            std::runtime_error(message + ": " + error.what()));
+      } catch (...) {
+        std::throw_with_nested(
+            std::runtime_error(message + ": non-standard exception"));
+      }
+    }
+    throw std::runtime_error(message);
+  }
+}
+
+template <typename Record>
+void allGatherAndAgree(
+    meta::comms::IBootstrap& bootstrap,
+    int rank,
+    int nranks,
+    std::vector<Record>& records,
+    const std::exception_ptr& localError,
+    std::string_view operation) {
+  gatherAndAgree(
+      rank, nranks, records, localError, operation, [&](void* data, int size) {
+        return bootstrap.allGather(data, size, rank, nranks).get();
+      });
+}
+
+} // namespace comms::prims::detail

--- a/comms/prims/bootstrap/tests/TeamStatusAgreementTest.cc
+++ b/comms/prims/bootstrap/tests/TeamStatusAgreementTest.cc
@@ -1,0 +1,167 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "comms/prims/bootstrap/TeamStatusAgreement.h"
+
+namespace comms::prims::detail {
+namespace {
+
+auto gatherWithStatuses(
+    std::vector<uint32_t> statuses,
+    int result = 0,
+    int* callCount = nullptr) {
+  return [statuses = std::move(statuses), result, callCount](
+             void* data, int recordSize) {
+    if (callCount != nullptr) {
+      ++*callCount;
+    }
+    EXPECT_EQ(recordSize, static_cast<int>(sizeof(TeamStatus)));
+    auto* records = static_cast<TeamStatus*>(data);
+    for (std::size_t rank = 0; rank < statuses.size(); ++rank) {
+      records[rank].success = statuses[rank];
+    }
+    return result;
+  };
+}
+
+void expectNestedRuntimeError(
+    const std::runtime_error& error,
+    std::string_view expected) {
+  try {
+    std::rethrow_if_nested(error);
+    ADD_FAILURE() << "expected nested runtime_error";
+  } catch (const std::runtime_error& nested) {
+    EXPECT_EQ(nested.what(), expected);
+  } catch (...) {
+    ADD_FAILURE() << "unexpected nested exception type";
+  }
+}
+
+TEST(TeamStatusAgreementTest, AllRanksSucceed) {
+  std::vector<TeamStatus> records(3);
+  int gatherCalls = 0;
+
+  EXPECT_NO_THROW(gatherAndAgree(
+      /*rank=*/1,
+      /*nranks=*/3,
+      records,
+      std::exception_ptr{},
+      "test operation",
+      gatherWithStatuses({1, 1, 1}, /*result=*/0, &gatherCalls)));
+  EXPECT_EQ(gatherCalls, 1);
+}
+
+TEST(TeamStatusAgreementTest, RemoteFailureUsesLowestRank) {
+  std::vector<TeamStatus> records(3);
+
+  try {
+    gatherAndAgree(
+        /*rank=*/0,
+        /*nranks=*/3,
+        records,
+        std::exception_ptr{},
+        "test operation",
+        gatherWithStatuses({1, 0, 0}));
+    FAIL() << "expected team failure";
+  } catch (const std::runtime_error& error) {
+    EXPECT_STREQ(error.what(), "test operation failed on rank 1");
+    EXPECT_NO_THROW(std::rethrow_if_nested(error));
+  }
+}
+
+TEST(TeamStatusAgreementTest, PrimaryLocalFailureRetainsCause) {
+  std::vector<TeamStatus> records(3);
+  const auto localError =
+      std::make_exception_ptr(std::runtime_error("rank 0 local error"));
+
+  try {
+    gatherAndAgree(
+        /*rank=*/0,
+        /*nranks=*/3,
+        records,
+        localError,
+        "test operation",
+        gatherWithStatuses({0, 1, 0}));
+    FAIL() << "expected team failure";
+  } catch (const std::runtime_error& error) {
+    EXPECT_STREQ(
+        error.what(), "test operation failed on rank 0: rank 0 local error");
+    expectNestedRuntimeError(error, "rank 0 local error");
+  }
+}
+
+TEST(TeamStatusAgreementTest, LocalFailureRetainedWhenLowerRankFails) {
+  std::vector<TeamStatus> records(3);
+  const auto localError =
+      std::make_exception_ptr(std::runtime_error("rank 2 local error"));
+
+  try {
+    gatherAndAgree(
+        /*rank=*/2,
+        /*nranks=*/3,
+        records,
+        localError,
+        "test operation",
+        gatherWithStatuses({0, 1, 0}));
+    FAIL() << "expected team failure";
+  } catch (const std::runtime_error& error) {
+    EXPECT_STREQ(
+        error.what(),
+        "test operation failed on rank 0; local rank 2 also failed: "
+        "rank 2 local error");
+    expectNestedRuntimeError(error, "rank 2 local error");
+  }
+}
+
+TEST(TeamStatusAgreementTest, AllGatherFailureIsReported) {
+  std::vector<TeamStatus> records(2);
+  int gatherCalls = 0;
+
+  try {
+    gatherAndAgree(
+        /*rank=*/0,
+        /*nranks=*/2,
+        records,
+        std::exception_ptr{},
+        "test operation",
+        gatherWithStatuses({1, 1}, /*result=*/1, &gatherCalls));
+    FAIL() << "expected allGather failure";
+  } catch (const std::runtime_error& error) {
+    EXPECT_STREQ(error.what(), "test operation status allGather failed");
+  }
+  EXPECT_EQ(gatherCalls, 1);
+}
+
+TEST(TeamStatusAgreementTest, RejectsWrongRecordCount) {
+  std::vector<TeamStatus> records(1);
+  bool gatherCalled = false;
+
+  try {
+    gatherAndAgree(
+        /*rank=*/0,
+        /*nranks=*/2,
+        records,
+        std::exception_ptr{},
+        "test operation",
+        [&](void*, int) {
+          gatherCalled = true;
+          return 0;
+        });
+    FAIL() << "expected invalid record count";
+  } catch (const std::invalid_argument& error) {
+    EXPECT_STREQ(error.what(), "gatherAndAgree records size must equal nranks");
+  }
+  EXPECT_FALSE(gatherCalled);
+}
+
+} // namespace
+} // namespace comms::prims::detail

--- a/comms/prims/docs/UniformNvlSignals.md
+++ b/comms/prims/docs/UniformNvlSignals.md
@@ -1,0 +1,233 @@
+# Uniform NVL Signals
+
+## Scope
+
+Uniform NVL signals provide one compile-time device API over the internal signal storage owned by `MultimemNvlTransport`.
+The API supports unicast and multicast access without changing the physical signal allocation.
+It does not use or modify `P2pNvlTransportDevice`, `p2pSignalCount`, or pair-specific P2P signal buffers.
+
+The signal API has four compile-time dimensions:
+
+- Access selects a unicast mapping or the multicast mapping of the same backing allocation.
+- Topology selects per-peer slots or aggregate counters.
+- Phase selects ready, acknowledgment, or consumed storage.
+- Wait policy selects how participating threads observe a per-peer stripe.
+
+Compile-time selection keeps access-path and topology branches out of measured device code.
+
+## Storage
+
+For `R` NVL ranks, pipeline depth `P`, and `B` channels, the internal allocation contains:
+
+```text
+signalsPerPeer = 3
+signalsPerLane = 4
+signalsPerChannel = 3R + 4P
+internalSignalCount = B * signalsPerChannel
+```
+
+Each channel starts with three peer stripes:
+
+```text
+channelBase = channel * signalsPerChannel
+
+ready(peer)    = channelBase + 0 * R + peer
+ack(peer)      = channelBase + 1 * R + peer
+consumed(peer) = channelBase + 2 * R + peer
+```
+
+Each pipeline lane then owns four aggregate slots:
+
+```text
+laneBase = channelBase + 3 * R + lane * 4
+
+readyCounter(lane) = laneBase + 0
+readyEpoch(lane)   = laneBase + 1
+ackCounter(lane)   = laneBase + 2
+ackEpoch(lane)     = laneBase + 3
+```
+
+The peer stripes are shared across pipeline lanes and carry monotonic round values.
+Aggregate counters are lane-private so concurrent pipeline rounds cannot mix their arrivals.
+Aggregate consumed signaling is unsupported because the layout has no consumed counter or epoch.
+
+## Address Views
+
+`MultimemNvlTransport` owns one combined physical allocation per NVL rank:
+
+```text
+[data][alignment padding][user signals][internal signals]
+```
+
+The transport exposes the same internal signal offsets through three address views:
+
+```text
+internalLocalSignals
+    This NVL rank's local unicast mapping.
+
+internalUnicastSignalsByRank[rank]
+    This process's unicast mapping of NVL rank `rank`'s backing allocation.
+
+internalMultimemSignals
+    The multicast mapping over every rank's backing allocation.
+```
+
+The peer pointer table is indexed by NVL-local rank rather than communicator rank.
+It includes the local rank so signal code uses one indexing contract for local and remote destinations.
+The host transport owns the device pointer table and keeps it valid for the lifetime of every device handle derived from that transport.
+
+The unicast mappings and multicast mapping retain the same physical allocations.
+No signal API creates a second signal buffer or aliases the legacy P2P signal allocation.
+
+## Public Device Contract
+
+The API uses these compile-time selectors:
+
+```cpp
+enum class NvlSignalAccess {
+  Unicast,
+  Multimem,
+};
+
+enum class NvlSignalTopology {
+  PerPeer,
+  Aggregate,
+};
+
+enum class NvlSignalPhase {
+  Ready,
+  Ack,
+  Consumed,
+};
+
+enum class NvlPerPeerWaitPolicy {
+  WaitAll,
+  SerialMin,
+  TreeMin,
+  ButterflyMin,
+};
+```
+
+`signal_publish`, `signal_wait`, and `signal_publish_and_wait` take the transport device handle, a channel and round description, participant roles, a thread group, and a timeout where waiting is required.
+`NvlSignalParticipants` identifies the coordinator, active publishers, active waiters, and expected arrival count without embedding benchmark-specific control flow in the primitive.
+
+The following combinations are rejected at compile time:
+
+- Aggregate topology with a non-default per-peer wait policy.
+- Aggregate topology with consumed phase.
+- A phase or access operation that has no storage or instruction mapping.
+
+Host launch validation rejects aggregate pipeline depth above one warp and per-peer teams above two warps.
+Device validation traps on an out-of-range channel, lane, rank, or signal offset before issuing a signal operation.
+
+## Execution Ownership
+
+One CUDA block owns one logical channel.
+A channel is the logical staging group selected by the block index.
+
+Aggregate topology uses one warp per channel.
+Pipeline depth determines the active lane owners:
+
+```text
+thread 0     owns pipeline lane 0
+thread 1     owns pipeline lane 1
+...
+thread P - 1 owns pipeline lane P - 1
+threads P..31 do not publish or wait
+```
+
+Per-peer topology uses two warps per channel:
+
+```text
+thread 0     owns NVL peer 0
+thread 1     owns NVL peer 1
+...
+thread R - 1 owns NVL peer R - 1
+threads R..63 do not publish or wait
+```
+
+Per-peer slots are shared across pipeline lanes, so per-peer operations use pipeline depth one.
+Their round value is monotonic across reuse of the same stripe.
+
+## Per-Peer Topology
+
+For unicast publication, a publisher writes its sender-owned slot through the destination rank's entry in `internalUnicastSignalsByRank`.
+Fan-in publication targets only the coordinator.
+Global publication targets every destination rank.
+
+For multicast publication, one publisher writes its sender-owned slot through `internalMultimemSignals`.
+The multicast store replicates that slot value into every rank's local backing.
+
+Waiters observe their local peer stripe through `internalLocalSignals`.
+The wait policies have identical completion and timeout semantics:
+
+1. `WaitAll` assigns one required peer slot to each participating peer-owner thread.
+2. `SerialMin` has one thread scan every required peer slot.
+3. `TreeMin` distributes slot loads and reduces completion through a block-wide tree.
+4. `ButterflyMin` distributes slot loads and reduces completion through a block-wide butterfly exchange.
+
+The completion predicate is always that every required peer slot has reached the selected round.
+Wait-policy selection changes observation geometry, not protocol semantics.
+
+## Aggregate Topology
+
+Aggregate multicast publication issues one `multimem.red.release.sys.global.add.u64` for each active lane.
+Every publisher targets the counter owned by its channel and lane.
+Global completion advances each counter by `R`.
+Fan-in completion advances each coordinator-observed counter by `R - 1`.
+
+Aggregate unicast publication atomically adds through the destination's unicast mapping.
+Fan-in publishers target the coordinator's lane counter.
+Global publishers update every destination's lane counter, including their local destination.
+
+Each active lane owner waits on the corresponding local counter with acquire semantics.
+After completion it advances the lane's local epoch baseline.
+For `B` channels and `P` active lanes, the protocol uses `B * P` independent counters.
+It never redirects all channel arrivals into one counter.
+
+## Ordering
+
+Unicast publication uses the existing system-scope release store or atomic add in `SignalState`.
+Unicast waiting uses the existing system-scope acquire load in `SignalState::wait_until`.
+
+Multicast per-peer publication uses `multimem.st.release.sys.global.u64`.
+Multicast aggregate publication uses `multimem.red.release.sys.global.add.u64`.
+Waiters read their local backing with system-scope acquire semantics.
+
+The primitive performs the topology-required warp or block synchronization before publication and before receipt.
+The caller remains responsible for ensuring payload writes precede ready publication and payload reads complete before consumed publication.
+
+## Fixed RTT Return
+
+Signal benchmarks use one return protocol for every forward access path and topology:
+
+```text
+access = Multimem
+topology = Aggregate
+phase = Ack
+publisher rank count = 1
+publisher rank = designated coordinator
+operations per publisher rank = active pipeline lanes
+expected increment per active lane = 1
+```
+
+The coordinator issues one multicast aggregate acknowledgment per active channel and lane.
+Every producer waits on its local acknowledgment counter.
+The return path has no per-peer wait-policy dimension and does not reproduce the forward topology.
+
+## Lifetime And Failure
+
+The transport exchanges all unicast mappings before constructing its multicast overlay and device pointer table.
+Every rank executes the same collective setup order.
+Device handles are unavailable until every setup phase succeeds.
+
+If any exchange phase fails, the transport instance is poisoned for subsequent `exchange()` calls.
+Callers must destroy it and construct a new transport before retrying.
+Destruction releases the device pointer table, multicast mapping, peer unicast mappings, local unicast mapping, and retained physical allocations in dependency order.
+
+## Non-Goals
+
+This API does not change collective algorithms, payload staging, user signal storage, or automatic memory registration.
+It does not add operation tracing.
+It does not add a P2P transport adapter.
+It does not define performance acceptance thresholds.

--- a/comms/prims/memory/NvlMemExchange.cc
+++ b/comms/prims/memory/NvlMemExchange.cc
@@ -3,6 +3,7 @@
 #include "comms/prims/memory/NvlMemExchange.h"
 
 #include "comms/common/BitOps.cuh"
+#include "comms/prims/bootstrap/TeamStatusAgreement.h"
 #include "comms/prims/core/Checks.h"
 #include "comms/prims/memory/CuMemAllocation.h"
 #include "comms/prims/platform/CudaDriverLazy.h"
@@ -15,6 +16,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <exception>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -32,22 +34,27 @@ namespace {
 // (and only on scope exit -- no detach escape hatch; copy + move are deleted
 // so the fd cannot escape this scope). Used for the local POSIX-FD shareable
 // handle that nvlMemExchangeVmm exports before allGather: keeps the fd closed
-// on every exit path (success, allGather throw, import throw, barrier throw)
+// on every exit path (success, allGather throw, or import failure)
 // without the try/catch boilerplate. C++ has no std::scope_exit — P0052 /
 // <experimental/scope> never landed — so we roll a 5-line guard rather than
 // reach for folly (comms/prims is zero-folly).
 class FdGuard {
  public:
-  explicit FdGuard(int fd) : fd_(fd) {}
+  FdGuard() = default;
   ~FdGuard() {
-    if (fd_ >= 0) {
-      ::close(fd_);
-    }
+    reset();
   }
   FdGuard(const FdGuard&) = delete;
   FdGuard& operator=(const FdGuard&) = delete;
   FdGuard(FdGuard&&) = delete;
   FdGuard& operator=(FdGuard&&) = delete;
+
+  void reset(int fd = -1) {
+    if (fd_ >= 0) {
+      ::close(fd_);
+    }
+    fd_ = fd;
+  }
 
  private:
   int fd_{-1};
@@ -473,68 +480,71 @@ NvlPeerMem nvlMemExchangeVmm(
   (void)preferFabric;
   throw std::runtime_error("nvlMemExchangeVmm requires CUDA 12.3+");
 #else
-  // Export the local handle once, as fabric if requested/supported, otherwise
-  // as a POSIX file descriptor (single-host).
   const ShareableHandleType exportType = preferFabric
       ? ShareableHandleType::kFabric
       : ShareableHandleType::kPosixFd;
-  ShareableHandle localShareable =
-      exportShareableHandle(localHandle, exportType);
-
-  // The local POSIX-FD export owns a file descriptor that must stay open
-  // through the import barrier so peers can pidfd_getfd it, then be closed on
-  // every exit path. FdGuard wraps it for RAII; it's a no-op for fabric
-  // exports (fd stays -1). Constructed BEFORE the allGather so an allGather
-  // throw also closes the fd.
-  FdGuard localFdGuard(
-      localShareable.type == ShareableHandleType::kPosixFd ? localShareable.fd
-                                                           : -1);
 
   struct ExchangeData {
     ShareableHandle handle{};
     std::size_t allocatedSize{};
+    detail::TeamStatus status{};
   };
 
   std::vector<ExchangeData> allData(static_cast<std::size_t>(nRanks));
+  std::vector<detail::TeamStatus> importStatus(
+      static_cast<std::size_t>(nRanks));
   // ExchangeData has padding between ShareableHandle (mixed enum + union +
   // ints) and allocatedSize (size_t). Value-init does not guarantee zeroed
   // padding bytes, and the buffer is broadcast verbatim via allGather — zero
   // it out before filling so peers don't receive uninitialized stack bytes.
   std::memset(allData.data(), 0, allData.size() * sizeof(ExchangeData));
-  allData[static_cast<std::size_t>(rank)].handle = localShareable;
-  allData[static_cast<std::size_t>(rank)].allocatedSize = allocatedSize;
-
-  auto gatherResult =
-      bootstrap.allGather(allData.data(), sizeof(ExchangeData), rank, nRanks)
-          .get();
-  if (gatherResult != 0) {
-    throw std::runtime_error("nvlMemExchangeVmm allGather failed");
-  }
-
-  // Import peer memory from received shareable handles. For POSIX FD exports
-  // the local fd must stay open through this import loop so peers can
-  // duplicate it via pidfd_getfd; localFdGuard's destructor closes it on
-  // every exit (import throw, barrier throw, or success).
-  for (int32_t peer = 0; peer < nRanks; ++peer) {
-    if (peer == rank) {
-      continue;
+  FdGuard localFdGuard;
+  std::exception_ptr exportError;
+  try {
+    auto& localData = allData[static_cast<std::size_t>(rank)];
+    localData.handle = exportShareableHandle(localHandle, exportType);
+    localData.allocatedSize = allocatedSize;
+    if (localData.handle.type == ShareableHandleType::kPosixFd) {
+      localFdGuard.reset(localData.handle.fd);
     }
-    const auto peerIdx = static_cast<std::size_t>(peer);
-    importAndMapPeerMemory(
-        peer,
-        allData[peerIdx].handle,
-        allData[peerIdx].allocatedSize,
-        cuDev,
-        result);
+  } catch (...) {
+    exportError = std::current_exception();
   }
+  detail::allGatherAndAgree(
+      bootstrap,
+      rank,
+      nRanks,
+      allData,
+      exportError,
+      "nvlMemExchangeVmm handle export");
 
-  // Hold all ranks here until every peer has finished importing, so no rank
-  // closes its exported POSIX FD before others have duplicated it. Mirrors
-  // the keep-fd-open-until-barrier ordering in MultiPeerTransport.
-  auto barrierResult = bootstrap.barrier(rank, nRanks).get();
-  if (barrierResult != 0) {
-    throw std::runtime_error("nvlMemExchangeVmm post-import barrier failed");
+  // Every rank must reach the status exchange even if a local import fails.
+  // Besides propagating that failure, this collective keeps each exported
+  // POSIX FD open until every peer has finished attempting its imports.
+  std::exception_ptr importError;
+  try {
+    for (int32_t peer = 0; peer < nRanks; ++peer) {
+      if (peer == rank) {
+        continue;
+      }
+      const auto peerIdx = static_cast<std::size_t>(peer);
+      importAndMapPeerMemory(
+          peer,
+          allData[peerIdx].handle,
+          allData[peerIdx].allocatedSize,
+          cuDev,
+          result);
+    }
+  } catch (...) {
+    importError = std::current_exception();
   }
+  detail::allGatherAndAgree(
+      bootstrap,
+      rank,
+      nRanks,
+      importStatus,
+      importError,
+      "nvlMemExchangeVmm peer import");
 
   return result;
 #endif

--- a/comms/prims/memory/NvlMemExchange.h
+++ b/comms/prims/memory/NvlMemExchange.h
@@ -165,11 +165,11 @@ struct NvlPeerMem {
 /**
  * VMM (fabric / POSIX FD) peer exchange.
  *
- * Exports `localHandle` (as fabric when `preferFabric`, else POSIX FD),
- * all-gathers every rank's shareable handle + allocated size, imports and maps
- * each peer's backing allocation, holds a post-import barrier so no rank closes
- * its exported POSIX FD before peers have duplicated it, then closes the local
- * exported fd.
+ * Exports `localHandle` (as fabric when `preferFabric`, else POSIX FD) and
+ * all-gathers export status with every rank's shareable handle + allocated
+ * size. It then imports and maps each peer's backing allocation and all-gathers
+ * import status. These agreements propagate rank-local failures and keep every
+ * exported POSIX FD open until all peers have finished their import attempts.
  *
  * `peerPtrs[rank]` is null for self; the caller fills the self slot with
  * `localPtr`. Throws std::runtime_error on any failure. Requires CUDA 12.3+.

--- a/comms/prims/tests/GpuMemHandlerTest.cc
+++ b/comms/prims/tests/GpuMemHandlerTest.cc
@@ -1,11 +1,19 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
 
+#include <cstddef>
+#include <cstring>
+#include <string>
+
+#include "comms/common/bootstrap/tests/MockBootstrap.h"
+#include "comms/prims/memory/CuMemAllocation.h"
 #include "comms/prims/memory/GpuMemHandler.h"
+#include "comms/prims/memory/NvlMemExchange.h"
 #include "comms/prims/tests/Utils.cuh"
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/testinfra/mpi/MpiBootstrap.h"
@@ -247,6 +255,110 @@ TEST_F(GpuMemHandlerTestFixture, SingleRankExchange) {
   ASSERT_EQ(h_errorCount, 0) << "Single-rank exchange verification failed";
 
   XLOGF(INFO, "MPI Rank {} single-rank exchange test passed", globalRank);
+}
+
+TEST_F(GpuMemHandlerTestFixture, VmmImportFailurePropagatesToEveryRank) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Test requires exactly two ranks";
+  }
+
+  using meta::comms::testing::MockBootstrap;
+  using ::testing::_;
+
+  auto realBootstrap = std::make_shared<MpiBootstrap>();
+  auto bootstrap = std::make_shared<::testing::NiceMock<MockBootstrap>>();
+  int allGatherCalls = 0;
+
+  // The first allGather exchanges one VMM record per rank. After the real
+  // collective completes, rank 0 changes rank 1's received handle type to
+  // kUnsupported in rank 0's local receive buffer. Rank 0 therefore fails
+  // while importing rank 1's handle. The following status allGather propagates
+  // that rank-local import failure to rank 1. Later calls are not corrupted,
+  // allowing the final exchangeMemPtrs() call to verify recovery.
+  ON_CALL(*bootstrap, allGather(_, _, _, _))
+      .WillByDefault([&](void* buf, int len, int rank, int nRanks) {
+        // MpiBootstrap completes MPI_Allgather synchronously before returning
+        // its ready future, so the received records are stable here.
+        auto result = realBootstrap->allGather(buf, len, rank, nRanks);
+        if (allGatherCalls++ == 0 && globalRank == 0) {
+          if (len < static_cast<int>(sizeof(ShareableHandle))) {
+            ADD_FAILURE() << "VMM exchange record is smaller than its handle";
+            return result;
+          }
+          const auto unsupported = ShareableHandleType::kUnsupported;
+          // len is the per-rank record size, so this selects rank 1's record.
+          auto* peerRecord = static_cast<std::byte*>(buf) + len;
+          std::memcpy(peerRecord, &unsupported, sizeof(unsupported));
+        }
+        return result;
+      });
+  EXPECT_CALL(*bootstrap, barrier(_, _)).Times(0);
+
+  GpuMemHandler handler(bootstrap, globalRank, numRanks, 4096);
+  if (handler.getMode() == MemSharingMode::kCudaIpc ||
+      handler.getMode() == MemSharingMode::kCudaIpcUncached) {
+    GTEST_SKIP() << "Test requires a VMM-backed sharing mode";
+  }
+
+  std::string error;
+  try {
+    handler.exchangeMemPtrs();
+  } catch (const std::exception& ex) {
+    error = ex.what();
+  }
+
+  EXPECT_THAT(error, ::testing::HasSubstr("peer import failed on rank 0"));
+  if (globalRank == 0) {
+    EXPECT_THAT(
+        error,
+        ::testing::HasSubstr(
+            "NvlMemExchange: cannot import unsupported handle type"));
+  }
+  EXPECT_NO_THROW(handler.exchangeMemPtrs());
+}
+
+TEST_F(GpuMemHandlerTestFixture, VmmExportFailurePropagatesToEveryRank) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Test requires exactly two ranks";
+  }
+
+#if CUDART_VERSION < 12030
+  GTEST_SKIP() << "VMM exchange requires CUDA 12.3+";
+#else
+  int cudaDevice = 0;
+  CUDACHECK_TEST(cudaGetDevice(&cudaDevice));
+  const auto cuDevice = static_cast<CUdevice>(cudaDevice);
+  auto allocation = CuMemAllocation::create(
+      cuDevice, 4096, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+
+  // Rank 0 passes an invalid zero allocation handle while rank 1 passes its
+  // valid allocation handle. Rank 0 consequently fails inside
+  // cuMemExportToShareableHandle. The handle/status allGather then reports
+  // rank 0's local export failure to both ranks.
+  auto bootstrap = std::make_shared<MpiBootstrap>();
+  std::string error;
+  try {
+    (void)nvlMemExchangeVmm(
+        *bootstrap,
+        globalRank,
+        numRanks,
+        cuDevice,
+        globalRank == 0 ? 0 : allocation->handle(),
+        nullptr,
+        allocation->size(),
+        /*preferFabric=*/false);
+  } catch (const std::exception& ex) {
+    error = ex.what();
+  }
+
+  EXPECT_THAT(error, ::testing::HasSubstr("handle export failed on rank 0"));
+  if (globalRank == 0) {
+    EXPECT_THAT(
+        error,
+        ::testing::HasSubstr(
+            "cuMemExportToShareableHandle for POSIX FD failed"));
+  }
+#endif
 }
 
 } // namespace comms::prims::tests

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -266,6 +266,38 @@ TEST_F(
 
 TEST_F(
     MultimemNvlTransportTestFixture,
+    MultiPeerCollectivelyRejectsAsymmetricEnablement) {
+  using ::testing::_;
+
+  auto mock = std::make_shared<StrictMockBootstrap>();
+  EXPECT_CALL(*mock, allGather(_, sizeof(int), 0, 2))
+      .WillOnce([](void* buf, int, int, int) {
+        auto* eligible = static_cast<int*>(buf);
+        EXPECT_EQ(eligible[0], 0);
+        eligible[1] = 1;
+        return folly::makeSemiFuture(0);
+      });
+
+  MultiPeerNvlTransportConfig config{
+      .pipelineDepth = 0,
+      .p2pSignalCount = 1,
+      .maxNumChannels = 0,
+      .enableMultimem = false,
+  };
+  MultiPeerNvlTransport transport(
+      /*myRank=*/0,
+      /*nRanks=*/2,
+      std::shared_ptr<meta::comms::IBootstrap>(mock),
+      config);
+
+  EXPECT_FALSE(transport.hasMultimemNvlTransport());
+  EXPECT_FALSE(transport.initializeMultimemNvlTransportIfEligible());
+  EXPECT_FALSE(transport.initializeMultimemNvlTransportIfEligible());
+  EXPECT_FALSE(transport.hasMultimemNvlTransport());
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
     MultiPeerRemoteEligibilityQueryErrorPoisonsRetry) {
   using ::testing::_;
 

--- a/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
@@ -177,7 +177,8 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
   dataBufferSize_ = dataBufferSize(config_);
   perPeerDataBufferSize_ = dataBufferSize_;
 
-  perPeerSignalBufferSize_ = getSignalBufferSize(config_.p2pSignalCount);
+  perPeerSignalBufferSize_ =
+      getSignalBufferSize(static_cast<int>(config_.p2pSignalCount));
 
   // Allocate signal buffer (always needed)
   const std::size_t totalSignalBufferSize =
@@ -216,7 +217,8 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
 
   // Conditionally allocate barrier buffer
   if (config_.p2pBarrierCount > 0) {
-    perPeerBarrierBufferSize_ = getBarrierBufferSize(config_.p2pBarrierCount);
+    perPeerBarrierBufferSize_ =
+        getBarrierBufferSize(static_cast<int>(config_.p2pBarrierCount));
     std::size_t totalBarrierSize = perPeerBarrierBufferSize_ * (nRanks_ - 1);
     barrierBufferHandler_ = std::make_unique<GpuMemHandler>(
         bootstrap_, myRank_, nRanks_, totalBarrierSize, memSharingMode_);
@@ -542,8 +544,7 @@ bool MultiPeerNvlTransport::hasMultimemNvlTransport() const {
 }
 
 bool MultiPeerNvlTransport::initializeMultimemNvlTransportIfEligible() const {
-  if (!config_.enableMultimem ||
-      multimemNvlIneligible_.load(std::memory_order_acquire)) {
+  if (multimemNvlIneligible_.load(std::memory_order_acquire)) {
     return false;
   }
   try {
@@ -579,11 +580,6 @@ void MultiPeerNvlTransport::initializeMultimemNvlTransport() const {
   if (multimemNvlTransport_) {
     return;
   }
-  if (!config_.enableMultimem) {
-    throw std::runtime_error(
-        "MultiPeerNvlTransport: multimem NVL transport is not enabled "
-        "(config.enableMultimem is false)");
-  }
   if (multimemNvlUnavailable_) {
     throw std::runtime_error(
         "MultiPeerNvlTransport: multimem NVL transport is not available: " +
@@ -593,16 +589,22 @@ void MultiPeerNvlTransport::initializeMultimemNvlTransport() const {
   std::vector<int> multimemEligible(nRanks_, 0);
   std::vector<int> multimemReady(nRanks_, 0);
   std::optional<ScopedCudaDevice> deviceGuard;
-  // A local CUDA/driver query failure is an error vote, not an early return:
-  // every rank must still enter the allGather so peers cannot hang.
-  try {
-    deviceGuard.emplace(multimemCudaDevice_);
-    multimemEligible[myRank_] =
-        MultimemNvlTransport::isEligible(nRanks_, multimemCudaDevice_)
-        ? kMultimemEligible
-        : kMultimemIneligible;
-  } catch (...) {
-    multimemEligible[myRank_] = kMultimemEligibilityError;
+  if (!config_.enableMultimem) {
+    // A disabled rank must still vote so enabled peers cannot hang in the
+    // communicator-wide eligibility agreement.
+    multimemEligible[myRank_] = kMultimemIneligible;
+  } else {
+    // A local CUDA/driver query failure is an error vote, not an early return:
+    // every rank must still enter the allGather so peers cannot hang.
+    try {
+      deviceGuard.emplace(multimemCudaDevice_);
+      multimemEligible[myRank_] =
+          MultimemNvlTransport::isEligible(nRanks_, multimemCudaDevice_)
+          ? kMultimemEligible
+          : kMultimemIneligible;
+    } catch (...) {
+      multimemEligible[myRank_] = kMultimemEligibilityError;
+    }
   }
   int eligibilityResult = 0;
   try {

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1580,13 +1580,18 @@ cvars:
    default     : 33554432
    description : |-
     Size in bytes of the cnvlmm (NVLink multimem) staging window, per rank.
-    Decoupled from NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE so the multimem path can
-    use a larger window without growing the P2P staging buffers. A larger window
-    means fewer staging rounds, which is the dominant cnvlmm throughput lever at
-    large message sizes. 0 falls back to the effective P2P NVL shared devbuf
-    size (the larger of the P2P and hier-AG NVL devbuf sizes when hier-AG
-    overlap is enabled). Default 32 MiB.
+    This allocation is independent of
+    NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE. A larger window means fewer staging
+    rounds, which is the dominant cnvlmm throughput lever at large message
+    sizes. Set to 0 to disable the NVL multimem transport. Default 32 MiB.
 
+ - name        : MCCL_NVL_MULTIMEM_PIPELINE_DEPTH
+   type        : size_t
+   default     : 2
+   description : |-
+     Number of staging lanes per channel used by the Prims NVL multimem
+     transport. Ctran consumes this value when constructing the transport DTO.
+     Values must be in [1, UINT32_MAX].
 
  - name        : CTRAN_P2P_NVL_DEVMEM_MAX_CHUNKS
    type        : uint64_t


### PR DESCRIPTION
Summary:
Before this change, a rank-local VMM handle export failure occurred before the handle all-gather, and a peer-import failure occurred before the post-import barrier.
In either case, the failed rank returned while its peers remained blocked in the next collective.
A failed rank could also close its exported POSIX FD while peers were still attempting to duplicate it.

This change attaches rank-local status to the handle exchange and adds a second status agreement after peer import.
Every rank reaches the same agreement boundary, reports the failed operation and rank, and keeps exported POSIX FDs alive until all import attempts complete.
The deterministic team error identifies the lowest failed rank, while every locally failing rank retains its own error text and nested exception for debugging.

The shared TeamStatusAgreement helper carries a bounded rank-local failure record through an existing team all-gather and raises the team-visible failure on every rank.

Reviewed By: goelayu

Differential Revision: D115479200


