### PR TITLE
Split recv chunk acquire from slot release

### DIFF
--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -747,4 +747,32 @@ P2pIbTransportDevice::progress_recv_once_with_trace(
       args...);
 }
 
+template <typename>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus
+P2pIbTransportDevice::progress_recv_acquire_once(
+    ThreadGroup& group,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    detail::RecvChunkAcquisition& out) {
+  if (type == P2pIbBackendType::IBRC) {
+    return ibrc->progress_recv_acquire_once(
+        group, nbytes, max_signal_bytes, timeout, out);
+  }
+  return ibgda->progress_recv_acquire_once(
+      group, nbytes, max_signal_bytes, timeout, out);
+}
+
+template <typename>
+__device__ __forceinline__ void
+P2pIbTransportDevice::progress_recv_release_once(
+    ThreadGroup& group,
+    const detail::RecvChunkAcquisition& view) {
+  if (type == P2pIbBackendType::IBRC) {
+    ibrc->progress_recv_release_once(group, view);
+  } else {
+    ibgda->progress_recv_release_once(group, view);
+  }
+}
+
 } // namespace comms::prims

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -40,6 +40,15 @@ enum class IbgdaRegisteredSendProgressStatus : uint8_t {
 
 namespace detail {
 
+// One landed recv chunk, handed back by progress_recv_acquire_once() without
+// consuming it. Held until progress_recv_release_once() frees the slot.
+struct RecvChunkAcquisition {
+  const char* staging{nullptr}; // this chunk's recv staging
+  std::size_t validBytes{0}; // payload bytes valid in it
+  std::size_t dataOff{0}; // payload offset into the user buffer
+  std::size_t protocolBytes{0}; // SLOT_FREE credit owed for this chunk
+};
+
 template <typename Transport>
 __device__ __forceinline__ void init_registered_send_progress(
     Transport& transport,
@@ -63,6 +72,22 @@ progress_registered_send_drain_once(
     Transport& transport,
     ThreadGroup& group,
     const Timeout& timeout = Timeout());
+
+template <typename Transport, typename Proto>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus
+progress_recv_acquire_once(
+    Transport& transport,
+    ThreadGroup& group,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    RecvChunkAcquisition& out);
+
+template <typename Transport, typename Proto>
+__device__ __forceinline__ void progress_recv_release_once(
+    Transport& transport,
+    ThreadGroup& group,
+    const RecvChunkAcquisition& view);
 
 template <typename Transport>
 __device__ __forceinline__ void send_registered(
@@ -371,6 +396,19 @@ struct P2pIbTransportDevice {
       const PipesTraceAllReduceContext& traceContext,
       PipesTraceProgressState& traceState,
       Args... args);
+  template <typename = void>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus
+  progress_recv_acquire_once(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      detail::RecvChunkAcquisition& out);
+
+  template <typename = void>
+  __device__ __forceinline__ void progress_recv_release_once(
+      ThreadGroup& group,
+      const detail::RecvChunkAcquisition& view);
 
   template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -1246,6 +1246,161 @@ progress_recv_once_with_trace(
 }
 
 /**
+ * Acquire one landed recv chunk WITHOUT consuming it.
+ *
+ * progress_recv_once() fuses wait, CopyOp and SLOT_FREE into one call, which
+ * forces a caller to finish with a chunk before it can look at the next peer.
+ * A reduce-scatter that sums N peers into one accumulator needs the opposite:
+ * hold all N peers' chunks for the same byte range at once, reduce across them
+ * in registers, and only then release all N slots. Splitting the wait from the
+ * release is what makes that possible; fusing them would force an accumulator
+ * round-trip through HBM per peer.
+ *
+ * Advances the progress cursor, so successive calls hand back successive
+ * chunks and several acquisitions may be outstanding at once. The slot stays
+ * owned by the caller until progress_recv_release_once() returns its credit;
+ * every acquire that returns Progressed must eventually be released, or the
+ * sender starves for SLOT_FREE.
+ *
+ * @return Waiting if the chunk has not landed, Progressed if `out` is valid,
+ *         Done if the stream is already complete.
+ */
+template <typename Transport, typename Proto>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus
+progress_recv_acquire_once(
+    Transport& transport,
+    ThreadGroup& group,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    RecvChunkAcquisition& out) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  auto& channelLayout = transport.channel_layout();
+  auto& progressSlot = progress_recv_slot<Proto>(transport, group);
+  IbChannelProgress state = progressSlot;
+  if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
+    return IbgdaSendRecvProgressStatus::Done;
+  }
+  const ProgressGeometry geometry = make_progress_geometry<Proto>(
+      channelLayout,
+      group,
+      nbytes,
+      max_signal_bytes,
+      "progress_recv_acquire_once");
+  // Parity with progress_recv_once: a cursor past the end of the stream while
+  // the stage is not Done means the progress state is corrupted or
+  // desynchronised from the sender. Should be unreachable given the Done
+  // transition below, but this is the diagnostic that catches that bug class on
+  // the fused path, and the split path is no less prone to it.
+  if (active_payload_offset(state) >= geometry.protocolBytes) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: progress_recv_acquire_once payloadOffset=%llu >= "
+          "protocolBytes=%llu without Done stage\n",
+          static_cast<unsigned long long>(active_payload_offset(state)),
+          static_cast<unsigned long long>(geometry.protocolBytes));
+    }
+    PIPES_DEVICE_TRAP();
+  }
+  validate_recv_progress_stage(group, state);
+
+  const ProgressChunk chunk = next_chunk<Proto>(channelLayout, state, geometry);
+  const bool isFinalChunk =
+      chunk.dataOff + chunk.payloadBytes >= geometry.protocolBytes;
+  const std::size_t protocolBytesThis = chunk.wireBytes +
+      (isFinalChunk ? Proto::wire_bytes(state.activeTailPadding) : 0);
+  const ChannelSlotView ch =
+      acquire_channel<Proto>(transport, channelLayout, group);
+  // qpLane mirrors progress_recv_once_impl: DATA_READY is delivered round-robin
+  // across lanes, so the readiness poll must look at the lane that carried THIS
+  // chunk. Tracing is not plumbed through the acquire/release path, so the
+  // trace context and state are null here.
+  const uint32_t numLanes = static_cast<uint32_t>(channelLayout.numLanes);
+  const uint8_t qpLane = static_cast<uint8_t>(
+      numLanes == 0 ? 0 : ch.channel.recvDataReadyLaneCursor % numLanes);
+  if (!progress_recv_ready(
+          Proto{},
+          transport,
+          group,
+          ch.channel,
+          ch.local.dataReady,
+          protocolBytesThis,
+          timeout,
+          nullptr,
+          nullptr,
+          qpLane)) {
+    return IbgdaSendRecvProgressStatus::Waiting;
+  }
+
+  out.staging = channelLayout.recvStagingPtr + chunk.stagingOff;
+  out.validBytes = valid_payload_bytes(
+      chunk.dataOff, chunk.payloadBytes, geometry.payloadBytes);
+  out.dataOff = chunk.dataOff;
+  out.protocolBytes = protocolBytesThis;
+
+  // Advance the cursor here, not in release: successive acquires must hand
+  // back successive chunks so a caller can hold several at once. The slot is
+  // still owned by the caller until it releases this view.
+  state.activeNextByte += chunk.payloadBytes;
+  if (active_payload_offset(state) >= geometry.protocolBytes) {
+    transition_progress_stage(
+        group, state, detail::IbSendRecvProgressStage::Done);
+  }
+  store_progress_state(group, progressSlot, state);
+  return IbgdaSendRecvProgressStatus::Progressed;
+#else
+  (void)transport;
+  (void)group;
+  (void)nbytes;
+  (void)max_signal_bytes;
+  (void)timeout;
+  (void)out;
+  return IbgdaSendRecvProgressStatus::Done;
+#endif
+}
+
+/**
+ * Return the SLOT_FREE credit for a chunk a previous
+ * progress_recv_acquire_once() handed back.
+ *
+ * The caller MUST have finished reading `view.staging` and synchronised every
+ * thread that read it first: this frees the slot for the sender to overwrite,
+ * so releasing early corrupts data still being consumed. Does not touch the
+ * progress cursor -- acquire already advanced it -- so several acquisitions may
+ * be outstanding at once.
+ *
+ * Release them in ACQUISITION ORDER per channel. SLOT_FREE is a cumulative byte
+ * counter and the sender gates on `current >= streamEnd - pipelineWindow`, so
+ * the credit records how many bytes were freed, never which chunk. An
+ * out-of-order release can therefore satisfy the sender's threshold while an
+ * older chunk is still being read, and the sender then overwrites that slot --
+ * silent data corruption, not a fault. At pipelineDepth 2 with equal chunks,
+ * releasing chunk 2 before chunk 1 already lets chunk 3 land on chunk 1's slot.
+ * Supporting genuine out-of-order release would need per-slot credits instead
+ * of one counter; no caller needs that today.
+ */
+template <typename Transport, typename Proto>
+__device__ __forceinline__ void progress_recv_release_once(
+    Transport& transport,
+    ThreadGroup& group,
+    const RecvChunkAcquisition& view) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  if (view.staging == nullptr) {
+    return;
+  }
+  auto& channelLayout = transport.channel_layout();
+  const ChannelSlotView ch =
+      acquire_channel<Proto>(transport, channelLayout, group);
+  transport.signal(
+      group, ch.remote.slotFree, view.protocolBytes, IbDirection::Recv);
+#else
+  (void)transport;
+  (void)group;
+  (void)view;
+#endif
+}
+
+/**
  * Commit an updated local progress state back to its transport-owned slot.
  * The trailing sync orders the leader's store before later group work.
  */

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -2288,6 +2288,35 @@ class P2pIbgdaTransportDevice {
             args...);
   }
 
+  // Templated for the same reason P2pIbTransportDevice templates its
+  // dispatchers: the definitions live in the progress-impl header, which this
+  // header deliberately does not include. A non-template body is compiled
+  // eagerly in every translation unit, so the HIP/ROCm build -- which never
+  // pulls in that impl header -- failed with -Werror,-Wundefined-inline. A
+  // template body is only instantiated where it is actually called, i.e. where
+  // the definition is visible.
+  template <typename = void>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus
+  progress_recv_acquire_once(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      detail::RecvChunkAcquisition& out) {
+    return detail::
+        progress_recv_acquire_once<P2pIbgdaTransportDevice, protocol::Simple>(
+            *this, group, nbytes, max_signal_bytes, timeout, out);
+  }
+
+  template <typename = void>
+  __device__ __forceinline__ void progress_recv_release_once(
+      ThreadGroup& group,
+      const detail::RecvChunkAcquisition& view) {
+    detail::
+        progress_recv_release_once<P2pIbgdaTransportDevice, protocol::Simple>(
+            *this, group, view);
+  }
+
   /**
    * send — send one block's tile via pipelined RDMA.
    *

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -665,6 +665,35 @@ class P2pIbrcTransportDevice {
         *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
   }
 
+  // Templated for the same reason P2pIbTransportDevice templates its
+  // dispatchers: the definitions live in the progress-impl header, which this
+  // header deliberately does not include. A non-template body is compiled
+  // eagerly in every translation unit, so the HIP/ROCm build -- which never
+  // pulls in that impl header -- failed with -Werror,-Wundefined-inline. A
+  // template body is only instantiated where it is actually called, i.e. where
+  // the definition is visible.
+  template <typename = void>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus
+  progress_recv_acquire_once(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      detail::RecvChunkAcquisition& out) {
+    return detail::
+        progress_recv_acquire_once<P2pIbrcTransportDevice, protocol::Simple>(
+            *this, group, nbytes, max_signal_bytes, timeout, out);
+  }
+
+  template <typename = void>
+  __device__ __forceinline__ void progress_recv_release_once(
+      ThreadGroup& group,
+      const detail::RecvChunkAcquisition& view) {
+    detail::
+        progress_recv_release_once<P2pIbrcTransportDevice, protocol::Simple>(
+            *this, group, view);
+  }
+
   template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void send(
       ThreadGroup& group,


### PR DESCRIPTION
Summary:
progress_recv_once() fuses waiting for DATA_READY, the CopyOp and the
SLOT_FREE signal into one call, so a caller must finish with one peer's chunk
before looking at the next. A reduce-scatter that sums N peers into a single
accumulator needs the opposite: hold all N peers' chunks for the same byte
range, reduce across them in registers, then release all N slots. Fusing the
release forces an accumulator round-trip through HBM per peer.

progress_recv_acquire_once() hands back a landed chunk and advances the
cursor, so several acquisitions can be outstanding; progress_recv_release_once()
returns that chunk's SLOT_FREE credit once every reader has finished.

Reviewed By: snarayankh, saifhhasan

Differential Revision: D115666430


