### PR TITLE
DirectIB v2 reduce-scatter kernel

### DIFF
--- a/comms/prims/collectives/ReduceScatterDirectIbV2.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIbV2.cu
@@ -1,0 +1,501 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/collectives/ReduceScatterDirectIbV2.cuh"
+
+#include "comms/prims/core/Checks.h"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/core/TiledBuffer.cuh"
+#include "comms/prims/transport/P2pIbTransportDevice.cuh"
+#include "comms/prims/transport/P2pIbTransportProgressImpl.cuh"
+
+namespace comms::prims {
+
+namespace {
+
+// Peers whose streams are in flight together. At W <= 9 this is one wave and
+// the accumulator is hoisted across every peer; larger worlds run in waves and
+// fold each wave into the output, costing an extra read+write per wave.
+constexpr int kMaxPeersInFlight = 8;
+
+// 8 floats as two float4s. Deliberately not a float[8]: passing a local array
+// by reference defeats register allocation and the accumulator spills to local
+// memory, which is the HBM traffic the hoist exists to avoid.
+struct Acc8 {
+  float4 lo;
+  float4 hi;
+};
+
+__device__ __forceinline__ Acc8 unpack_bf16x8(const uint4& raw) {
+  const auto* h = reinterpret_cast<const __nv_bfloat162*>(&raw);
+  const float2 a = __bfloat1622float2(h[0]);
+  const float2 b = __bfloat1622float2(h[1]);
+  const float2 c = __bfloat1622float2(h[2]);
+  const float2 d = __bfloat1622float2(h[3]);
+  Acc8 r;
+  r.lo = make_float4(a.x, a.y, b.x, b.y);
+  r.hi = make_float4(c.x, c.y, d.x, d.y);
+  return r;
+}
+
+__device__ __forceinline__ void acc_add(Acc8& a, const Acc8& b) {
+  a.lo.x += b.lo.x;
+  a.lo.y += b.lo.y;
+  a.lo.z += b.lo.z;
+  a.lo.w += b.lo.w;
+  a.hi.x += b.hi.x;
+  a.hi.y += b.hi.y;
+  a.hi.z += b.hi.z;
+  a.hi.w += b.hi.w;
+}
+
+__device__ __forceinline__ bool all_aligned(
+    const detail::RecvChunkAcquisition* views,
+    int count) {
+  for (int i = 0; i < count; ++i) {
+    if ((reinterpret_cast<uintptr_t>(views[i].staging) & 15u) != 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+__device__ __forceinline__ std::size_t send_offset_bytes(
+    const DirectReduceScatterIbV2Args& args,
+    int peer,
+    std::size_t tile_offset_elements) {
+  return (static_cast<std::size_t>(peer) * args.chunk_elements +
+          tile_offset_elements) *
+      sizeof(__nv_bfloat16);
+}
+
+// Sum this rank's own shard with every peer's landed tile and write FP32 once.
+//
+// The peer loop is unrolled over a compile-time bound and the staging pointers
+// are hoisted into registers first. With a runtime peer count the compiler
+// cannot unroll, and every global load then waits on a shared-memory load to
+// resolve its own address, serialising the eight loads.
+template <int kUnroll>
+__device__ __forceinline__ void reduce_chunk(
+    float* out_base,
+    const __nv_bfloat16* own_base,
+    const detail::RecvChunkAcquisition* views,
+    int count,
+    int wave_base,
+    std::size_t tid,
+    std::size_t stride) {
+  // validBytes, not protocolBytes: the RDMA write covers only validBytes,
+  // while the rounding and tail padding are credit-only and hold stale bytes
+  // from whichever chunk last used this slot. Deriving elems from anything
+  // else here reads plausible-looking garbage.
+  static_assert(
+      kUnroll == 1,
+      "the vector loop drops a trailing partial group when kUnroll > 1; "
+      "write the residual loop before raising it");
+  const std::size_t elems = views[0].validBytes / sizeof(__nv_bfloat16);
+  const std::size_t elem_off = views[0].dataOff / sizeof(__nv_bfloat16);
+  float* const out = out_base + elem_off;
+  const __nv_bfloat16* const own = own_base + elem_off;
+
+  constexpr std::size_t kVec = 8;
+  const bool vec_ok = elems >= kVec &&
+      ((reinterpret_cast<uintptr_t>(out) & 15u) == 0) &&
+      ((reinterpret_cast<uintptr_t>(own) & 15u) == 0) &&
+      all_aligned(views, count);
+  const std::size_t nvec = vec_ok ? elems / kVec : 0;
+
+  const uint4* sp[kMaxPeersInFlight];
+#pragma unroll
+  for (int i = 0; i < kMaxPeersInFlight; ++i) {
+    sp[i] = reinterpret_cast<const uint4*>(views[i < count ? i : 0].staging);
+  }
+  const uint4* const ownv = reinterpret_cast<const uint4*>(own);
+  float4* const outv = reinterpret_cast<float4*>(out);
+
+  std::size_t v = tid;
+  for (; v + (kUnroll - 1) * stride < nvec; v += kUnroll * stride) {
+    Acc8 acc[kUnroll];
+    // Wave 0 seeds from this rank's own shard; later waves fold into what the
+    // previous wave already wrote.
+    if (wave_base == 0) {
+      uint4 o[kUnroll];
+#pragma unroll
+      for (int u = 0; u < kUnroll; ++u) {
+        o[u] = ownv[v + u * stride];
+      }
+#pragma unroll
+      for (int u = 0; u < kUnroll; ++u) {
+        acc[u] = unpack_bf16x8(o[u]);
+      }
+    } else {
+#pragma unroll
+      for (int u = 0; u < kUnroll; ++u) {
+        acc[u].lo = outv[2 * (v + u * stride)];
+        acc[u].hi = outv[2 * (v + u * stride) + 1];
+      }
+    }
+#pragma unroll
+    for (int i = 0; i < kMaxPeersInFlight; ++i) {
+      if (i >= count) {
+        continue;
+      }
+      uint4 raw[kUnroll];
+#pragma unroll
+      for (int u = 0; u < kUnroll; ++u) {
+        raw[u] = sp[i][v + u * stride];
+      }
+#pragma unroll
+      for (int u = 0; u < kUnroll; ++u) {
+        acc_add(acc[u], unpack_bf16x8(raw[u]));
+      }
+    }
+#pragma unroll
+    for (int u = 0; u < kUnroll; ++u) {
+      outv[2 * (v + u * stride)] = acc[u].lo;
+      outv[2 * (v + u * stride) + 1] = acc[u].hi;
+    }
+  }
+  // Ragged tail, and the whole chunk when alignment rules out the vector path.
+  for (std::size_t idx = nvec * kVec + tid; idx < elems; idx += stride) {
+    float a = (wave_base == 0) ? __bfloat162float(own[idx]) : out[idx];
+    for (int i = 0; i < count; ++i) {
+      a += __bfloat162float(
+          reinterpret_cast<const __nv_bfloat16*>(views[i].staging)[idx]);
+    }
+    out[idx] = a;
+  }
+}
+
+} // namespace
+
+// BF16 in, BF16 on the wire, FP32 out. The receive side is warp-specialised:
+// one warp owns the network while the rest only reduce, so a chunk's
+// DATA_READY latency and the previous chunk's SLOT_FREE round trip overlap the
+// current chunk's arithmetic instead of serialising with it.
+template <int kRecvThreads, int kBlockSize, int kUnroll>
+__global__
+__launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
+    const __grid_constant__ DirectReduceScatterIbV2Args args,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  timeout.start();
+
+  // The send only needs its leader to post a WQE; one warp keeps its sync at
+  // __syncwarp() and hands every other thread to the reduce.
+  constexpr int kSendThreads = comms::device::kWarpSize;
+  static_assert(kRecvThreads % comms::device::kWarpSize == 0);
+  static_assert(kSendThreads + kRecvThreads == kBlockSize);
+
+  const ThreadGroup block = make_block_group();
+  const bool is_recv = block.thread_id_in_group < kRecvThreads;
+  ThreadGroup group = is_recv
+      ? ThreadGroup{
+            .thread_id_in_group = block.thread_id_in_group,
+            .group_size = kRecvThreads,
+            .group_id = block.group_id,
+            .block_id = block.block_id,
+            .total_groups = block.total_groups,
+            .scope = SyncScope::MULTIWARP,
+            .barrier_id = 1}
+      : ThreadGroup{
+            .thread_id_in_group = block.thread_id_in_group - kRecvThreads,
+            .group_size = kSendThreads,
+            .group_id = block.group_id,
+            .block_id = block.block_id,
+            .total_groups = block.total_groups,
+            .scope = SyncScope::WARP,
+            .barrier_id = ThreadGroup::kAutoBarrierId};
+
+  const int channel = static_cast<int>(group.group_id);
+  const int my_rank = args.my_rank;
+  const int W = args.num_ranks;
+  const std::size_t max_sig = args.signaling_data_size;
+  if (W <= 1) {
+    return;
+  }
+
+  // Both roles tile in wire (bf16) elements off the same chunk_elements so the
+  // two sides agree on each channel's byte range. Tiling the fp32 output
+  // instead would round to a different multiple and desync them.
+  TiledBuffer<const __nv_bfloat16> wire_tile(
+      args.input, args.chunk_elements, group);
+  const std::size_t wire_bytes = wire_tile.bytes();
+  if (wire_bytes == 0) {
+    return;
+  }
+  const std::size_t tile_offset_elements =
+      static_cast<std::size_t>(channel) * wire_tile.tile_elements;
+  const int num_peers = W - 1;
+
+  // Solo THREAD-scope group: the progress calls are leader-only and their
+  // internal group.sync() degenerates to a no-op, so one thread can drive every
+  // peer without dragging the other warps into a barrier per peer.
+  ThreadGroup solo{
+      0,
+      1,
+      group.group_id,
+      group.block_id,
+      group.total_groups,
+      SyncScope::THREAD,
+      ThreadGroup::kAutoBarrierId};
+
+  if (is_recv) {
+    // Index output and own shard by the SAME element offsets as the wire tile.
+    float* const out_base = args.output + tile_offset_elements;
+    const __nv_bfloat16* const own_base = args.input +
+        static_cast<std::size_t>(my_rank) * args.chunk_elements +
+        tile_offset_elements;
+
+    // Two slots so the bookkeeper can acquire chunk c+1 while the reducers are
+    // still on chunk c. With one slot the acquire cannot start until the reduce
+    // finishes, and the network stops overlapping the arithmetic entirely.
+    constexpr int kSlots = 2;
+    // Chunk c-1 is released only after chunk c is acquired, so the pipeline
+    // must hold two chunks at once. A shallower pipeline never completes the
+    // acquire and the bookkeeper stalls with no diagnostic.
+    if (group.is_leader()) {
+      auto probe = args.peers[(my_rank + 1) % W];
+      if (probe.pipeline_depth() < kSlots) {
+        printf(
+            "[PIPES] FATAL: DirectIB v2 needs pipeline_depth >= %d, got %d\n",
+            kSlots,
+            probe.pipeline_depth());
+        PIPES_DEVICE_TRAP();
+      }
+    }
+    __shared__ int rpeer_of[kMaxPeersInFlight];
+    __shared__ detail::RecvChunkAcquisition rviews[kSlots][kMaxPeersInFlight];
+    __shared__ volatile int s_published;
+    __shared__ volatile int s_consumed;
+    __shared__ volatile int s_nchunks;
+
+    constexpr int kBookThreads = comms::device::kWarpSize;
+    const bool is_book = group.thread_id_in_group < kBookThreads;
+
+    for (int base = 0; base < num_peers; base += kMaxPeersInFlight) {
+      const int count = min(kMaxPeersInFlight, num_peers - base);
+
+      if (group.is_leader()) {
+        for (int i = 0; i < count; ++i) {
+          const int step = base + i;
+          rpeer_of[i] = (my_rank + 1 + (step + channel) % (W - 1)) % W;
+          for (int sl = 0; sl < kSlots; ++sl) {
+            rviews[sl][i] = detail::RecvChunkAcquisition{};
+          }
+          auto transport = args.peers[rpeer_of[i]];
+          transport.init_recv_progress(solo, wire_bytes, max_sig);
+        }
+        s_published = -1;
+        s_consumed = -1;
+        s_nchunks = -1;
+      }
+      group.sync();
+
+      if (is_book) {
+        if (group.thread_id_in_group == 0) {
+          int c = 0;
+          int released = -1;
+          while (true) {
+            const int s = c % kSlots;
+            // Acquire chunk c from every peer. Each call is non-blocking, so a
+            // slow peer never stops us polling the others.
+            int ready = 0;
+            bool finished = false;
+            while (ready < count && !finished) {
+              ready = 0;
+              for (int i = 0; i < count; ++i) {
+                if (rviews[s][i].staging != nullptr) {
+                  ++ready;
+                  continue;
+                }
+                detail::RecvChunkAcquisition view{};
+                auto transport = args.peers[rpeer_of[i]];
+                const auto st = transport.progress_recv_acquire_once(
+                    solo, wire_bytes, max_sig, timeout, view);
+                if (st == IbgdaSendRecvProgressStatus::Done) {
+                  finished = true;
+                  break;
+                }
+                if (st == IbgdaSendRecvProgressStatus::Progressed) {
+                  rviews[s][i] = view;
+                  ++ready;
+                }
+              }
+            }
+            if (finished) {
+              s_nchunks = c;
+              __threadfence_block();
+              s_published = c;
+              break;
+            }
+
+            __threadfence_block();
+            s_published = c;
+
+            // Release chunk c-1 only now: the acquire above already overlapped
+            // the reducers' work on it, which is the point of the second slot.
+            if (c >= 1) {
+              while (s_consumed < c - 1) {
+              }
+              const int ps = (c - 1) % kSlots;
+              for (int i = 0; i < count; ++i) {
+                auto transport = args.peers[rpeer_of[i]];
+                transport.progress_recv_release_once(solo, rviews[ps][i]);
+                rviews[ps][i] = detail::RecvChunkAcquisition{};
+              }
+              released = c - 1;
+            }
+            ++c;
+          }
+          // Drain the slots the reducers still hold.
+          while (released < c - 1) {
+            const int d = released + 1;
+            while (s_consumed < d) {
+            }
+            const int ds = d % kSlots;
+            for (int i = 0; i < count; ++i) {
+              auto transport = args.peers[rpeer_of[i]];
+              transport.progress_recv_release_once(solo, rviews[ds][i]);
+              rviews[ds][i] = detail::RecvChunkAcquisition{};
+            }
+            released = d;
+          }
+        }
+      } else {
+        // Reducers get their own barrier id so the bookkeeper warp is not
+        // counted in it.
+        ThreadGroup rgroup{
+            .thread_id_in_group = group.thread_id_in_group - kBookThreads,
+            .group_size = kRecvThreads - kBookThreads,
+            .group_id = group.group_id,
+            .block_id = group.block_id,
+            .total_groups = group.total_groups,
+            .scope = SyncScope::MULTIWARP,
+            .barrier_id = 3};
+        int c = 0;
+        while (true) {
+          while (s_published < c) {
+            if (s_nchunks >= 0 && c >= s_nchunks) {
+              break;
+            }
+          }
+          if (s_nchunks >= 0 && c >= s_nchunks) {
+            break;
+          }
+          __threadfence_block();
+          reduce_chunk<kUnroll>(
+              out_base,
+              own_base,
+              rviews[c % kSlots],
+              count,
+              base,
+              rgroup.thread_id_in_group,
+              rgroup.group_size);
+          rgroup.sync();
+          if (rgroup.thread_id_in_group == 0) {
+            __threadfence_block();
+            s_consumed = c;
+          }
+          ++c;
+        }
+      }
+      group.sync();
+    }
+  } else if (group.is_leader()) {
+    // Chunk-outer / peer-inner: chunk c goes to every peer before chunk c+1,
+    // so a receiver gets the same byte range from all peers at once (what the
+    // hoist needs) and all W-1 QPs stay busy instead of one.
+    //
+    // progress_registered_send_once() is non-blocking for its protocol
+    // dependencies but not for queue space: the WQE reservation spins when a
+    // peer's send queue is full. It is a stall, not a deadlock -- each QP has
+    // one driver thread -- but it idles this round-robin. Outstanding WQEs are
+    // (window / chunkWire) * (ceil(chunkWire / max_write) + 1), which must stay
+    // under sq_wqe_num; a small max_signal_bytes is what breaches it.
+    for (int base = 0; base < num_peers; base += kMaxPeersInFlight) {
+      const int count = min(kMaxPeersInFlight, num_peers - base);
+      int peer_of[kMaxPeersInFlight];
+      bool posted[kMaxPeersInFlight];
+      for (int i = 0; i < count; ++i) {
+        const int step = base + i;
+        peer_of[i] = (my_rank + W - 1 - (step + channel) % (W - 1)) % W;
+        posted[i] = false;
+        auto transport = args.peers[peer_of[i]];
+        transport.init_registered_send_progress(solo, wire_bytes, max_sig);
+      }
+
+      int remaining = count;
+      while (remaining > 0) {
+        for (int i = 0; i < count; ++i) {
+          if (posted[i]) {
+            continue;
+          }
+          auto transport = args.peers[peer_of[i]];
+          const auto st = transport.progress_registered_send_once(
+              solo,
+              args.input_reg.subBuffer(
+                  send_offset_bytes(args, peer_of[i], tile_offset_elements)),
+              wire_bytes,
+              max_sig,
+              timeout);
+          if (st == IbgdaRegisteredSendProgressStatus::Posted) {
+            posted[i] = true;
+            --remaining;
+          }
+        }
+      }
+
+      // The NIC reads the caller's input buffer directly, so the transfer is
+      // not finished when the last WQE is posted. Drain before returning or the
+      // caller may reuse that buffer while it is still being read.
+      for (int i = 0; i < count; ++i) {
+        auto transport = args.peers[peer_of[i]];
+        while (transport.progress_registered_send_drain_once(solo, timeout) !=
+               IbgdaRegisteredSendProgressStatus::Drained) {
+        }
+      }
+    }
+  }
+#endif
+}
+
+template __global__ void direct_reduce_scatter_ib_v2_kernel<224, 256, 1>(
+    const __grid_constant__ DirectReduceScatterIbV2Args,
+    Timeout);
+template __global__ void direct_reduce_scatter_ib_v2_kernel<480, 512, 1>(
+    const __grid_constant__ DirectReduceScatterIbV2Args,
+    Timeout);
+template __global__ void direct_reduce_scatter_ib_v2_kernel<736, 768, 1>(
+    const __grid_constant__ DirectReduceScatterIbV2Args,
+    Timeout);
+template __global__ void direct_reduce_scatter_ib_v2_kernel<992, 1024, 1>(
+    const __grid_constant__ DirectReduceScatterIbV2Args,
+    Timeout);
+
+void launch_direct_reduce_scatter_ib_v2(
+    const DirectReduceScatterIbV2Args& args,
+    int num_blocks,
+    int block_threads,
+    cudaStream_t stream,
+    Timeout timeout) {
+  switch (block_threads) {
+    case 256:
+      direct_reduce_scatter_ib_v2_kernel<224, 256, 1>
+          <<<num_blocks, 256, 0, stream>>>(args, timeout);
+      break;
+    case 512:
+      direct_reduce_scatter_ib_v2_kernel<480, 512, 1>
+          <<<num_blocks, 512, 0, stream>>>(args, timeout);
+      break;
+    case 768:
+      direct_reduce_scatter_ib_v2_kernel<736, 768, 1>
+          <<<num_blocks, 768, 0, stream>>>(args, timeout);
+      break;
+    default:
+      direct_reduce_scatter_ib_v2_kernel<992, 1024, 1>
+          <<<num_blocks, 1024, 0, stream>>>(args, timeout);
+      break;
+  }
+  PIPES_CUDA_CHECK(cudaGetLastError());
+}
+
+} // namespace comms::prims

--- a/comms/prims/collectives/ReduceScatterDirectIbV2.cuh
+++ b/comms/prims/collectives/ReduceScatterDirectIbV2.cuh
@@ -1,0 +1,44 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/prims/core/Timeout.cuh"
+#include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
+#include "comms/prims/transport/ibgda/IbgdaBuffer.h"
+
+namespace comms::prims {
+
+inline constexpr int kDirectIbV2DeviceMaxRanks = 256;
+
+// DirectIB v2 reduce-scatter: BF16 in, BF16 on the wire, FP32 out. Stochastic
+// rounding moved into the FSDP copy-in (D114734625), so unlike v1 this kernel
+// neither quantizes nor carries a seed.
+struct DirectReduceScatterIbV2Args {
+  int my_rank{0};
+  int num_ranks{0};
+  // Elements per rank shard -- the output size, not the input size.
+  std::size_t chunk_elements{0};
+  std::size_t signaling_data_size{0};
+  P2pIbTransportDevice peers[kDirectIbV2DeviceMaxRanks]{};
+  const __nv_bfloat16* input{nullptr};
+  float* output{nullptr};
+  // `input` registered with the multi-peer transport so the NIC reads the send
+  // payload directly out of it. Must cover the whole input buffer; offsets are
+  // taken relative to `input`.
+  IbgdaLocalBuffer input_reg{};
+};
+
+void launch_direct_reduce_scatter_ib_v2(
+    const DirectReduceScatterIbV2Args& args,
+    int num_blocks,
+    int block_threads,
+    cudaStream_t stream,
+    Timeout timeout);
+
+} // namespace comms::prims

--- a/comms/prims/collectives/ReduceScatterDirectIbV2Launcher.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIbV2Launcher.cu
@@ -1,0 +1,86 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/collectives/ReduceScatterDirectIbV2Launcher.h"
+
+#include <cuda_runtime.h>
+
+#include <stdexcept>
+#include <string>
+
+#include "comms/prims/collectives/ReduceScatterDirectIbV2.cuh"
+#include "comms/prims/core/Checks.h"
+#include "comms/prims/core/TimeoutUtils.h"
+
+namespace comms::prims {
+
+namespace {
+
+void validate(const DirectReduceScatterIbV2LaunchParams& params) {
+  // num_ranks == 1 is rejected, not handled: the kernel has no single-rank
+  // path, so it would return having written nothing to a caller expecting a
+  // BF16 -> FP32 converted copy of its own shard. ctran's support check
+  // already excludes it; this makes the contract explicit for direct callers.
+  if (params.num_ranks < 2 ||
+      params.num_ranks > kDirectReduceScatterIbV2MaxRanks) {
+    throw std::runtime_error(
+        "Unsupported direct IB v2 num_ranks=" +
+        std::to_string(params.num_ranks) + " (supported: 2.." +
+        std::to_string(kDirectReduceScatterIbV2MaxRanks) + ")");
+  }
+  if (params.num_blocks < 1) {
+    throw std::runtime_error(
+        "direct IB v2 requires num_blocks >= 1, got " +
+        std::to_string(params.num_blocks));
+  }
+  // The NIC reads `input` directly, so an unregistered buffer has no lkey and
+  // the put would reference memory the NIC cannot translate.
+  if (params.input_reg.ptr == nullptr) {
+    throw std::runtime_error("direct IB v2 requires a registered input buffer");
+  }
+  // Send offsets are computed relative to `input` and applied to `input_reg`,
+  // so registering a different buffer would silently send the wrong bytes.
+  if (params.input_reg.ptr != static_cast<const void*>(params.input)) {
+    throw std::runtime_error(
+        "direct IB v2 registered buffer must start at the input pointer");
+  }
+}
+
+Timeout make_launch_timeout(float timeout_ms) {
+  Timeout timeout;
+  if (timeout_ms > 0) {
+    int device = 0;
+    PIPES_CUDA_CHECK(cudaGetDevice(&device));
+    timeout = makeTimeout(timeout_ms, device);
+  }
+  return timeout;
+}
+
+} // namespace
+
+void launch_direct_reduce_scatter_ib_v2_impl(
+    const DirectReduceScatterIbV2LaunchParams& params) {
+  validate(params);
+
+  DirectReduceScatterIbV2Args args{};
+  args.my_rank = params.my_rank;
+  args.num_ranks = params.num_ranks;
+  args.chunk_elements = params.chunk_elements;
+  args.signaling_data_size = params.signaling_data_size;
+  args.input = params.input;
+  args.output = params.output;
+  args.input_reg = params.input_reg;
+  for (int peer = 0; peer < params.num_ranks; ++peer) {
+    if (peer != params.my_rank) {
+      args.peers[peer] = params.peers[peer];
+    }
+  }
+
+  launch_direct_reduce_scatter_ib_v2(
+      args,
+      params.num_blocks,
+      params.block_threads,
+      params.stream,
+      make_launch_timeout(params.timeout_ms));
+}
+
+} // namespace comms::prims

--- a/comms/prims/collectives/ReduceScatterDirectIbV2Launcher.h
+++ b/comms/prims/collectives/ReduceScatterDirectIbV2Launcher.h
@@ -1,0 +1,36 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
+#include "comms/prims/transport/ibgda/IbgdaBuffer.h"
+
+namespace comms::prims {
+
+inline constexpr int kDirectReduceScatterIbV2MaxRanks = 256;
+
+struct DirectReduceScatterIbV2LaunchParams {
+  int my_rank{0};
+  int num_ranks{0};
+  std::size_t chunk_elements{0};
+  std::size_t signaling_data_size{0};
+  const __nv_bfloat16* input{nullptr};
+  float* output{nullptr};
+  IbgdaLocalBuffer input_reg{};
+  int num_blocks{2};
+  int block_threads{1024};
+  float timeout_ms{0.0f};
+  cudaStream_t stream{nullptr};
+  P2pIbTransportDevice peers[kDirectReduceScatterIbV2MaxRanks]{};
+};
+
+void launch_direct_reduce_scatter_ib_v2_impl(
+    const DirectReduceScatterIbV2LaunchParams& params);
+
+} // namespace comms::prims

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -747,4 +747,32 @@ P2pIbTransportDevice::progress_recv_once_with_trace(
       args...);
 }
 
+template <typename>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus
+P2pIbTransportDevice::progress_recv_acquire_once(
+    ThreadGroup& group,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    detail::RecvChunkAcquisition& out) {
+  if (type == P2pIbBackendType::IBRC) {
+    return ibrc->progress_recv_acquire_once(
+        group, nbytes, max_signal_bytes, timeout, out);
+  }
+  return ibgda->progress_recv_acquire_once(
+      group, nbytes, max_signal_bytes, timeout, out);
+}
+
+template <typename>
+__device__ __forceinline__ void
+P2pIbTransportDevice::progress_recv_release_once(
+    ThreadGroup& group,
+    const detail::RecvChunkAcquisition& view) {
+  if (type == P2pIbBackendType::IBRC) {
+    ibrc->progress_recv_release_once(group, view);
+  } else {
+    ibgda->progress_recv_release_once(group, view);
+  }
+}
+
 } // namespace comms::prims

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -40,6 +40,15 @@ enum class IbgdaRegisteredSendProgressStatus : uint8_t {
 
 namespace detail {
 
+// One landed recv chunk, handed back by progress_recv_acquire_once() without
+// consuming it. Held until progress_recv_release_once() frees the slot.
+struct RecvChunkAcquisition {
+  const char* staging{nullptr}; // this chunk's recv staging
+  std::size_t validBytes{0}; // payload bytes valid in it
+  std::size_t dataOff{0}; // payload offset into the user buffer
+  std::size_t protocolBytes{0}; // SLOT_FREE credit owed for this chunk
+};
+
 template <typename Transport>
 __device__ __forceinline__ void init_registered_send_progress(
     Transport& transport,
@@ -63,6 +72,22 @@ progress_registered_send_drain_once(
     Transport& transport,
     ThreadGroup& group,
     const Timeout& timeout = Timeout());
+
+template <typename Transport, typename Proto>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus
+progress_recv_acquire_once(
+    Transport& transport,
+    ThreadGroup& group,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    RecvChunkAcquisition& out);
+
+template <typename Transport, typename Proto>
+__device__ __forceinline__ void progress_recv_release_once(
+    Transport& transport,
+    ThreadGroup& group,
+    const RecvChunkAcquisition& view);
 
 template <typename Transport>
 __device__ __forceinline__ void send_registered(
@@ -371,6 +396,19 @@ struct P2pIbTransportDevice {
       const PipesTraceAllReduceContext& traceContext,
       PipesTraceProgressState& traceState,
       Args... args);
+  template <typename = void>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus
+  progress_recv_acquire_once(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      detail::RecvChunkAcquisition& out);
+
+  template <typename = void>
+  __device__ __forceinline__ void progress_recv_release_once(
+      ThreadGroup& group,
+      const detail::RecvChunkAcquisition& view);
 
   template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -1246,6 +1246,161 @@ progress_recv_once_with_trace(
 }
 
 /**
+ * Acquire one landed recv chunk WITHOUT consuming it.
+ *
+ * progress_recv_once() fuses wait, CopyOp and SLOT_FREE into one call, which
+ * forces a caller to finish with a chunk before it can look at the next peer.
+ * A reduce-scatter that sums N peers into one accumulator needs the opposite:
+ * hold all N peers' chunks for the same byte range at once, reduce across them
+ * in registers, and only then release all N slots. Splitting the wait from the
+ * release is what makes that possible; fusing them would force an accumulator
+ * round-trip through HBM per peer.
+ *
+ * Advances the progress cursor, so successive calls hand back successive
+ * chunks and several acquisitions may be outstanding at once. The slot stays
+ * owned by the caller until progress_recv_release_once() returns its credit;
+ * every acquire that returns Progressed must eventually be released, or the
+ * sender starves for SLOT_FREE.
+ *
+ * @return Waiting if the chunk has not landed, Progressed if `out` is valid,
+ *         Done if the stream is already complete.
+ */
+template <typename Transport, typename Proto>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus
+progress_recv_acquire_once(
+    Transport& transport,
+    ThreadGroup& group,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    RecvChunkAcquisition& out) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  auto& channelLayout = transport.channel_layout();
+  auto& progressSlot = progress_recv_slot<Proto>(transport, group);
+  IbChannelProgress state = progressSlot;
+  if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
+    return IbgdaSendRecvProgressStatus::Done;
+  }
+  const ProgressGeometry geometry = make_progress_geometry<Proto>(
+      channelLayout,
+      group,
+      nbytes,
+      max_signal_bytes,
+      "progress_recv_acquire_once");
+  // Parity with progress_recv_once: a cursor past the end of the stream while
+  // the stage is not Done means the progress state is corrupted or
+  // desynchronised from the sender. Should be unreachable given the Done
+  // transition below, but this is the diagnostic that catches that bug class on
+  // the fused path, and the split path is no less prone to it.
+  if (active_payload_offset(state) >= geometry.protocolBytes) {
+    if (group.is_leader()) {
+      printf(
+          "[PIPES] FATAL: progress_recv_acquire_once payloadOffset=%llu >= "
+          "protocolBytes=%llu without Done stage\n",
+          static_cast<unsigned long long>(active_payload_offset(state)),
+          static_cast<unsigned long long>(geometry.protocolBytes));
+    }
+    PIPES_DEVICE_TRAP();
+  }
+  validate_recv_progress_stage(group, state);
+
+  const ProgressChunk chunk = next_chunk<Proto>(channelLayout, state, geometry);
+  const bool isFinalChunk =
+      chunk.dataOff + chunk.payloadBytes >= geometry.protocolBytes;
+  const std::size_t protocolBytesThis = chunk.wireBytes +
+      (isFinalChunk ? Proto::wire_bytes(state.activeTailPadding) : 0);
+  const ChannelSlotView ch =
+      acquire_channel<Proto>(transport, channelLayout, group);
+  // qpLane mirrors progress_recv_once_impl: DATA_READY is delivered round-robin
+  // across lanes, so the readiness poll must look at the lane that carried THIS
+  // chunk. Tracing is not plumbed through the acquire/release path, so the
+  // trace context and state are null here.
+  const uint32_t numLanes = static_cast<uint32_t>(channelLayout.numLanes);
+  const uint8_t qpLane = static_cast<uint8_t>(
+      numLanes == 0 ? 0 : ch.channel.recvDataReadyLaneCursor % numLanes);
+  if (!progress_recv_ready(
+          Proto{},
+          transport,
+          group,
+          ch.channel,
+          ch.local.dataReady,
+          protocolBytesThis,
+          timeout,
+          nullptr,
+          nullptr,
+          qpLane)) {
+    return IbgdaSendRecvProgressStatus::Waiting;
+  }
+
+  out.staging = channelLayout.recvStagingPtr + chunk.stagingOff;
+  out.validBytes = valid_payload_bytes(
+      chunk.dataOff, chunk.payloadBytes, geometry.payloadBytes);
+  out.dataOff = chunk.dataOff;
+  out.protocolBytes = protocolBytesThis;
+
+  // Advance the cursor here, not in release: successive acquires must hand
+  // back successive chunks so a caller can hold several at once. The slot is
+  // still owned by the caller until it releases this view.
+  state.activeNextByte += chunk.payloadBytes;
+  if (active_payload_offset(state) >= geometry.protocolBytes) {
+    transition_progress_stage(
+        group, state, detail::IbSendRecvProgressStage::Done);
+  }
+  store_progress_state(group, progressSlot, state);
+  return IbgdaSendRecvProgressStatus::Progressed;
+#else
+  (void)transport;
+  (void)group;
+  (void)nbytes;
+  (void)max_signal_bytes;
+  (void)timeout;
+  (void)out;
+  return IbgdaSendRecvProgressStatus::Done;
+#endif
+}
+
+/**
+ * Return the SLOT_FREE credit for a chunk a previous
+ * progress_recv_acquire_once() handed back.
+ *
+ * The caller MUST have finished reading `view.staging` and synchronised every
+ * thread that read it first: this frees the slot for the sender to overwrite,
+ * so releasing early corrupts data still being consumed. Does not touch the
+ * progress cursor -- acquire already advanced it -- so several acquisitions may
+ * be outstanding at once.
+ *
+ * Release them in ACQUISITION ORDER per channel. SLOT_FREE is a cumulative byte
+ * counter and the sender gates on `current >= streamEnd - pipelineWindow`, so
+ * the credit records how many bytes were freed, never which chunk. An
+ * out-of-order release can therefore satisfy the sender's threshold while an
+ * older chunk is still being read, and the sender then overwrites that slot --
+ * silent data corruption, not a fault. At pipelineDepth 2 with equal chunks,
+ * releasing chunk 2 before chunk 1 already lets chunk 3 land on chunk 1's slot.
+ * Supporting genuine out-of-order release would need per-slot credits instead
+ * of one counter; no caller needs that today.
+ */
+template <typename Transport, typename Proto>
+__device__ __forceinline__ void progress_recv_release_once(
+    Transport& transport,
+    ThreadGroup& group,
+    const RecvChunkAcquisition& view) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  if (view.staging == nullptr) {
+    return;
+  }
+  auto& channelLayout = transport.channel_layout();
+  const ChannelSlotView ch =
+      acquire_channel<Proto>(transport, channelLayout, group);
+  transport.signal(
+      group, ch.remote.slotFree, view.protocolBytes, IbDirection::Recv);
+#else
+  (void)transport;
+  (void)group;
+  (void)view;
+#endif
+}
+
+/**
  * Commit an updated local progress state back to its transport-owned slot.
  * The trailing sync orders the leader's store before later group work.
  */

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -2288,6 +2288,35 @@ class P2pIbgdaTransportDevice {
             args...);
   }
 
+  // Templated for the same reason P2pIbTransportDevice templates its
+  // dispatchers: the definitions live in the progress-impl header, which this
+  // header deliberately does not include. A non-template body is compiled
+  // eagerly in every translation unit, so the HIP/ROCm build -- which never
+  // pulls in that impl header -- failed with -Werror,-Wundefined-inline. A
+  // template body is only instantiated where it is actually called, i.e. where
+  // the definition is visible.
+  template <typename = void>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus
+  progress_recv_acquire_once(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      detail::RecvChunkAcquisition& out) {
+    return detail::
+        progress_recv_acquire_once<P2pIbgdaTransportDevice, protocol::Simple>(
+            *this, group, nbytes, max_signal_bytes, timeout, out);
+  }
+
+  template <typename = void>
+  __device__ __forceinline__ void progress_recv_release_once(
+      ThreadGroup& group,
+      const detail::RecvChunkAcquisition& view) {
+    detail::
+        progress_recv_release_once<P2pIbgdaTransportDevice, protocol::Simple>(
+            *this, group, view);
+  }
+
   /**
    * send — send one block's tile via pipelined RDMA.
    *

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -665,6 +665,35 @@ class P2pIbrcTransportDevice {
         *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
   }
 
+  // Templated for the same reason P2pIbTransportDevice templates its
+  // dispatchers: the definitions live in the progress-impl header, which this
+  // header deliberately does not include. A non-template body is compiled
+  // eagerly in every translation unit, so the HIP/ROCm build -- which never
+  // pulls in that impl header -- failed with -Werror,-Wundefined-inline. A
+  // template body is only instantiated where it is actually called, i.e. where
+  // the definition is visible.
+  template <typename = void>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus
+  progress_recv_acquire_once(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      detail::RecvChunkAcquisition& out) {
+    return detail::
+        progress_recv_acquire_once<P2pIbrcTransportDevice, protocol::Simple>(
+            *this, group, nbytes, max_signal_bytes, timeout, out);
+  }
+
+  template <typename = void>
+  __device__ __forceinline__ void progress_recv_release_once(
+      ThreadGroup& group,
+      const detail::RecvChunkAcquisition& view) {
+    detail::
+        progress_recv_release_once<P2pIbrcTransportDevice, protocol::Simple>(
+            *this, group, view);
+  }
+
   template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void send(
       ThreadGroup& group,


### PR DESCRIPTION
Summary:
BF16 in, BF16 on the wire, FP32 out, for the post-SR-fusion world where
fsdp_chunk_cat_downcast_sr (D114734625) already emits BF16, so the collective
has nothing to quantize and needs no seed.

Three things make it fast at low block counts:
- the NIC reads the caller's registered input directly (send_registered), so
  the send side touches no HBM and needs one warp;
- chunk-outer / peer-inner posting keeps all W-1 QPs busy and delivers the
  same byte range from every peer at once, which is what lets the receiver
  hoist one accumulator across all peers instead of one per peer;
- the receive side is warp-specialised: one warp owns the network while the
  rest only reduce, so DATA_READY latency and SLOT_FREE round trips overlap
  the arithmetic.

Reviewed By: saifhhasan, snarayankh

Differential Revision: D115666433


