### PR TITLE
Record captured GPE host nodes on a per-graph side stream (mixing=0) - 50-60 us flat gain across message sizes in graph mode (#3646)

### DIFF
--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -45,7 +45,29 @@ static std::unordered_map<KernelConfig::KernelType, const std::string>
         {KernelConfig::KernelType::ALLTOALLV, "AllToAllv"},
 };
 
-CtranGpe::Impl::Impl() {
+// Gated on mixing=0: at mixing=1 the guard's fence is a floating
+// EVENT_RECORD node awaited with cudaEventWaitExternal so it can order across
+// graphs, and GraphSideStream::fork_from deliberately restores the user
+// stream's dependencies after its fork (leaving no join edge) -- the opposite
+// of the kept join edge the spine needs. Silently ignoring the knob at
+// mixing=1 keeps that path byte-identical rather than producing a graph with
+// both a spine and a floating fence.
+static bool hostNodeSideStreamEnabled() {
+  if (!NCCL_CTRAN_GPE_HOST_NODE_SIDE_STREAM) {
+    return false;
+  }
+  if (NCCL_CTRAN_GRAPH_MIXING_SUPPORT != 0) {
+    CLOGF(
+        INFO,
+        "CTRAN-GPE: NCCL_CTRAN_GPE_HOST_NODE_SIDE_STREAM ignored because "
+        "NCCL_CTRAN_GRAPH_MIXING_SUPPORT={} (requires 0)",
+        NCCL_CTRAN_GRAPH_MIXING_SUPPORT);
+    return false;
+  }
+  return true;
+}
+
+CtranGpe::Impl::Impl() : hostNodeSpine_{hostNodeSideStreamEnabled()} {
   this->kernelFlagPool = std::unique_ptr<KernelFlagPool>(
       new KernelFlagPool(NCCL_CTRAN_NUM_KERNEL_FLAGS));
 
@@ -581,13 +603,13 @@ commResult_t CtranGpe::Impl::publishCapturedCmd(
     kernelFlag->dev.gpeHdr.cmdId = id;
     kernelFlag->dev.gpeHdr.enabled = 1;
   } else {
-    FB_COMMCHECK(
-        utils::cudagraph::addHostNode(
-            /*data=*/cmd,
-            /*execCallback=*/cmdCb,
-            /*destroyCallback=*/cmdDestroy,
-            stream,
-            streamCaptureInfo));
+    // HostNodeSpine picks the inline or side-stream shape internally.
+    FB_COMMCHECK(hostNodeSpine_.submit(
+        /*data=*/cmd,
+        /*execCallback=*/cmdCb,
+        /*destroyCallback=*/cmdDestroy,
+        stream,
+        streamCaptureInfo));
   }
   return commSuccess;
 }

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -23,6 +23,7 @@
 #include "comms/ctran/gpe/CtranChecksum.h"
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/gpe/GpeDeviceRing.h"
+#include "comms/ctran/gpe/GpeHostNodeSpine.h"
 #include "comms/ctran/profiler/GpeProfiler.h"
 #include "comms/ctran/profiler/IGpeProfilerReporter.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
@@ -302,6 +303,12 @@ class CtranGpe::Impl {
   std::unique_ptr<ctran::gpe::GpeRingReader> deviceRingReader_;
   std::queue<CtranGpeCmd*> ringPending_;
   GpeDeviceRingCmdRegistry deviceRingCmdRegistry_;
+
+  // Host-node placement for captured submits: inline on the user stream, or on
+  // a per-graph side stream when NCCL_CTRAN_GPE_HOST_NODE_SIDE_STREAM is on
+  // (mixing=0 only). Touched only on the submit (capture) thread; see
+  // GpeHostNodeSpine.h.
+  ctran::gpe::HostNodeSpine hostNodeSpine_;
 
   // In-kernel colltrace grouping: a multi-submit collective (e.g. AllGatherP's
   // PipeStart..PipeSync..PipeEnd) records one CollTrace event whose start is

--- a/comms/ctran/gpe/GpeHostNodeSpine.cc
+++ b/comms/ctran/gpe/GpeHostNodeSpine.cc
@@ -1,0 +1,120 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/ctran/gpe/GpeHostNodeSpine.h"
+
+#include "comms/ctran/utils/Checks.h"
+
+namespace ctran::gpe {
+
+HostNodeSpine::~HostNodeSpine() {
+  for (auto& [_, spine] : spines_) {
+    (void)cudaEventDestroy(spine.syncEvent);
+    (void)cudaStreamDestroy(spine.stream);
+  }
+}
+
+commResult_t HostNodeSpine::submit(
+    void* data,
+    cudaHostFn_t execCallback,
+    cudaHostFn_t destroyCallback,
+    cudaStream_t userStream,
+    utils::cudagraph::StreamCaptureInfo& info) {
+  if (!sideStreamEnabled_) {
+    return utils::cudagraph::addHostNode(
+        data, execCallback, destroyCallback, userStream, info);
+  }
+
+  // The HOST node goes on the graph's spine so its only predecessor is the
+  // previous collective's HOST node, then we join the spine tip back into the
+  // user stream. The join must land BEFORE the algo issues the collective's
+  // first node (copyToSelf / PipeStart), so that node inherits HOST[i] as a
+  // predecessor -- that edge is what orders each collective behind the host
+  // chain, matching how NCCL records its own captured host callbacks. Issuing
+  // it after the first node makes HOST[i] parent nothing and the whole effect
+  // disappears.
+  Spine* spine = nullptr;
+  FB_COMMCHECK(getOrCreate(info.id, userStream, &spine));
+  FB_COMMCHECK(
+      utils::cudagraph::addHostNode(
+          data, execCallback, destroyCallback, spine->stream, info));
+  FB_CUDACHECK(cudaEventRecord(spine->syncEvent, spine->stream));
+  FB_CUDACHECK(cudaStreamWaitEvent(userStream, spine->syncEvent, 0));
+  return commSuccess;
+}
+
+commResult_t HostNodeSpine::getOrCreate(
+    unsigned long long captureId,
+    cudaStream_t userStream,
+    Spine** out) {
+  // Reclaim spines from captures that have ended. A finished graph's stream is
+  // no longer capturing, and its nodes already live in the instantiated graph,
+  // so the stream/event are free to destroy. Without this sweep we would leak
+  // one stream + one event per captured graph for the process lifetime.
+  for (auto it = spines_.begin(); it != spines_.end();) {
+    if (it->first == captureId) {
+      ++it;
+      continue;
+    }
+    cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
+    if (cudaStreamIsCapturing(it->second.stream, &status) != cudaSuccess ||
+        status != cudaStreamCaptureStatusActive) {
+      (void)cudaEventDestroy(it->second.syncEvent);
+      (void)cudaStreamDestroy(it->second.stream);
+      it = spines_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  auto it = spines_.find(captureId);
+  if (it == spines_.end()) {
+    // Build the spine in a local so a failed creation step never leaves a
+    // half-initialized (null stream/event) entry cached under `captureId`: a
+    // later submit must not reuse it, nor the destructor operate on its null
+    // handles. Only cache once every step has succeeded.
+    Spine spine{};
+    const commResult_t res = createSpine(spine, userStream);
+    if (res != commSuccess) {
+      if (spine.syncEvent != nullptr) {
+        (void)cudaEventDestroy(spine.syncEvent);
+      }
+      if (spine.stream != nullptr) {
+        (void)cudaStreamDestroy(spine.stream);
+      }
+      return res;
+    }
+    it = spines_.emplace(captureId, spine).first;
+  }
+  *out = &it->second;
+  return commSuccess;
+}
+
+commResult_t HostNodeSpine::createSpine(Spine& spine, cudaStream_t userStream) {
+  FB_CUDACHECK(cudaStreamCreateWithFlags(&spine.stream, cudaStreamNonBlocking));
+  FB_CUDACHECK(
+      cudaEventCreateWithFlags(&spine.syncEvent, cudaEventDisableTiming));
+
+  // Bring the spine into this graph, then CLEAR the dependency set it just
+  // inherited. Without the clear, the first HOST node would depend on
+  // everything already captured on the user stream, which is the inline shape
+  // we are trying to avoid. This is what
+  // ncclStrongStreamAcquire does via cudaStreamSetCaptureDependencies with a
+  // zero-length list.
+  FB_CUDACHECK(cudaEventRecord(spine.syncEvent, userStream));
+  FB_CUDACHECK(cudaStreamWaitEvent(spine.stream, spine.syncEvent, 0));
+#if defined(__HIP_PLATFORM_AMD__)
+  FB_CUDACHECK(cudaStreamUpdateCaptureDependencies(
+      spine.stream, nullptr, 0, hipStreamSetCaptureDependencies));
+#elif CUDART_VERSION >= 13000
+  // CUDA 13 takes an extra edge-data pointer; there is no _v2 name (see the
+  // same three-way split in OrderedWorkStreamGuard.cc).
+  FB_CUDACHECK(cudaStreamUpdateCaptureDependencies(
+      spine.stream, nullptr, nullptr, 0, cudaStreamSetCaptureDependencies));
+#else
+  FB_CUDACHECK(cudaStreamUpdateCaptureDependencies(
+      spine.stream, nullptr, 0, cudaStreamSetCaptureDependencies));
+#endif
+  return commSuccess;
+}
+
+} // namespace ctran::gpe

--- a/comms/ctran/gpe/GpeHostNodeSpine.h
+++ b/comms/ctran/gpe/GpeHostNodeSpine.h
@@ -1,0 +1,67 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#ifndef CTRAN_GPE_HOST_NODE_SPINE_H_
+#define CTRAN_GPE_HOST_NODE_SPINE_H_
+
+#include <unordered_map>
+
+#include <cuda_runtime.h>
+
+#include "comms/ctran/utils/CudaGraphUtils.h"
+#include "comms/utils/commSpecs.h"
+
+namespace ctran::gpe {
+
+// Places a captured GPE HOST node on the graph, either inline on the user's
+// stream (default) or on a side capture stream -- the spine -- that serializes
+// the graph's HOST nodes (NCCL_CTRAN_GPE_HOST_NODE_SIDE_STREAM, mixing=0 only).
+//
+// One spine per captured graph, keyed by capture id: two graphs captured
+// concurrently must not share a spine, or their host chains would cross-link.
+// This mirrors ncclStrongStream::captureHead, which keys its capture streams by
+// graphId for the same reason.
+//
+// NOT thread-safe: touched only on the submit (capture) thread.
+class HostNodeSpine {
+ public:
+  explicit HostNodeSpine(bool sideStreamEnabled)
+      : sideStreamEnabled_{sideStreamEnabled} {}
+  ~HostNodeSpine();
+
+  // Add `data`'s HOST node to the graph being captured on `userStream`,
+  // routing it through this graph's spine when the side-stream path is on.
+  commResult_t submit(
+      void* data,
+      cudaHostFn_t execCallback,
+      cudaHostFn_t destroyCallback,
+      cudaStream_t userStream,
+      utils::cudagraph::StreamCaptureInfo& info);
+
+ private:
+  // `stream` collects a graph's HOST nodes so each inherits only the previous
+  // one (a serial chain); `syncEvent` publishes the chain's tail so the user
+  // stream can join it before issuing the collective's first node.
+  struct Spine {
+    cudaStream_t stream{nullptr};
+    cudaEvent_t syncEvent{nullptr};
+  };
+
+  // Reclaim spines whose capture is no longer active and return the entry for
+  // `captureId`, creating it (and its stream/event) on first use.
+  commResult_t getOrCreate(
+      unsigned long long captureId,
+      cudaStream_t userStream,
+      Spine** out);
+
+  // Create a fresh spine's stream/event and clear the dependencies it inherits
+  // from `userStream`. On failure `spine` may hold partially created handles;
+  // the caller is responsible for destroying them.
+  commResult_t createSpine(Spine& spine, cudaStream_t userStream);
+
+  std::unordered_map<unsigned long long, Spine> spines_;
+  const bool sideStreamEnabled_;
+};
+
+} // namespace ctran::gpe
+
+#endif // CTRAN_GPE_HOST_NODE_SPINE_H_

--- a/comms/ctran/gpe/tests/CtranGpeHostNodeSideStreamUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeHostNodeSideStreamUT.cc
@@ -1,0 +1,304 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Host-side unit tests for the side-stream GPE host-node path
+// (NCCL_CTRAN_GPE_HOST_NODE_SIDE_STREAM). These exercise the spine bookkeeping
+// that ctran::gpe::HostNodeSpine owns -- per-graph keying, lazy
+// creation, reclamation of finished captures -- plus the recorded graph
+// topology the knob is for, using a bare capture with stand-in nodes so no
+// comm, window or IB backend is required.
+//
+// The end-to-end shape on a real ctwin AllGatherP (HOST out-degree 2 and N-1
+// HOST->HOST edges with the knob on, versus out-degree 1 and 0 such edges with
+// it off) is asserted by
+// CtranAllgatherCtwinHostSpineTest.HostNodeWiring in
+// comms/ctran/tests/CtranDistAllgatherCtwinTests.cc, which needs 8 ranks and a
+// vnode topology; this TU covers the mechanism on a single device.
+
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/utils/CudaGraphUtils.h"
+
+namespace {
+
+void hostFn(void* /*unused*/) {}
+
+// Mirrors what CtranGpe::Impl does per captured submit when the knob is on:
+// record the HOST node on the spine stream, publish its tip, then join the tip
+// into the user stream BEFORE the collective's first node is issued.
+void addSpineHostNode(
+    cudaStream_t userStream,
+    cudaStream_t spineStream,
+    cudaEvent_t tip) {
+  ASSERT_EQ(cudaLaunchHostFunc(spineStream, hostFn, nullptr), cudaSuccess);
+  ASSERT_EQ(cudaEventRecord(tip, spineStream), cudaSuccess);
+  ASSERT_EQ(cudaStreamWaitEvent(userStream, tip, 0), cudaSuccess);
+}
+
+struct Census {
+  size_t nodes{0};
+  size_t edges{0};
+  size_t hosts{0};
+  int maxHostOutDeg{0};
+  int hostToHost{0};
+};
+
+Census censusOf(cudaGraph_t graph) {
+  Census c{};
+  EXPECT_EQ(cudaGraphGetNodes(graph, nullptr, &c.nodes), cudaSuccess);
+  std::vector<cudaGraphNode_t> nodes(c.nodes);
+  EXPECT_EQ(cudaGraphGetNodes(graph, nodes.data(), &c.nodes), cudaSuccess);
+
+  EXPECT_EQ(cudaGraphGetEdges(graph, nullptr, nullptr, &c.edges), cudaSuccess);
+  std::vector<cudaGraphNode_t> from(c.edges), to(c.edges);
+  EXPECT_EQ(
+      cudaGraphGetEdges(graph, from.data(), to.data(), &c.edges), cudaSuccess);
+
+  std::unordered_set<cudaGraphNode_t> hostNodes;
+  for (cudaGraphNode_t n : nodes) {
+    cudaGraphNodeType t{};
+    EXPECT_EQ(cudaGraphNodeGetType(n, &t), cudaSuccess);
+    if (t == cudaGraphNodeTypeHost) {
+      hostNodes.insert(n);
+    }
+  }
+  c.hosts = hostNodes.size();
+
+  std::unordered_map<cudaGraphNode_t, int> outDeg;
+  for (size_t e = 0; e < c.edges; ++e) {
+    outDeg[from[e]]++;
+    if (hostNodes.count(from[e]) != 0u && hostNodes.count(to[e]) != 0u) {
+      c.hostToHost++;
+    }
+  }
+  for (cudaGraphNode_t h : hostNodes) {
+    c.maxHostOutDeg = std::max(c.maxHostOutDeg, outDeg[h]);
+  }
+  return c;
+}
+
+class GpeHostNodeSideStreamTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int count = 0;
+    if (cudaGetDeviceCount(&count) != cudaSuccess || count == 0) {
+      GTEST_SKIP() << "no CUDA device";
+    }
+  }
+};
+
+// The inline shape (knob off) leaves each HOST node a pass-through link: no
+// HOST depends on another, so nothing orders the collectives relative to each
+// other.
+TEST_F(GpeHostNodeSideStreamTest, InlineHostNodesAreIndependent) {
+  constexpr int kNumCollectives = 4;
+  cudaStream_t user{};
+  ASSERT_EQ(
+      cudaStreamCreateWithFlags(&user, cudaStreamNonBlocking), cudaSuccess);
+  int* buf{};
+  ASSERT_EQ(cudaMalloc(&buf, sizeof(int)), cudaSuccess);
+
+  cudaGraph_t graph{};
+  ASSERT_EQ(
+      cudaStreamBeginCapture(user, cudaStreamCaptureModeGlobal), cudaSuccess);
+  for (int i = 0; i < kNumCollectives; ++i) {
+    ASSERT_EQ(cudaLaunchHostFunc(user, hostFn, nullptr), cudaSuccess);
+    ASSERT_EQ(cudaMemsetAsync(buf, i, sizeof(int), user), cudaSuccess);
+  }
+  ASSERT_EQ(cudaStreamEndCapture(user, &graph), cudaSuccess);
+
+  const Census c = censusOf(graph);
+  EXPECT_EQ(c.hosts, static_cast<size_t>(kNumCollectives));
+  EXPECT_EQ(c.hostToHost, 0);
+  EXPECT_EQ(c.maxHostOutDeg, 1);
+
+  ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+  ASSERT_EQ(cudaFree(buf), cudaSuccess);
+  ASSERT_EQ(cudaStreamDestroy(user), cudaSuccess);
+}
+
+// The spine shape (knob on): HOST[i]'s only predecessor is HOST[i-1], and it
+// also parents the collective's first node, so out-degree reaches 2 and there
+// are exactly N-1 HOST->HOST edges. That single serializing edge per collective
+// is the whole mechanism -- it is the shape NCCL's captured host callbacks
+// already have.
+TEST_F(GpeHostNodeSideStreamTest, SpineChainsHostNodesAcrossCollectives) {
+  constexpr int kNumCollectives = 4;
+  cudaStream_t user{}, spine{};
+  ASSERT_EQ(
+      cudaStreamCreateWithFlags(&user, cudaStreamNonBlocking), cudaSuccess);
+  ASSERT_EQ(
+      cudaStreamCreateWithFlags(&spine, cudaStreamNonBlocking), cudaSuccess);
+  cudaEvent_t tip{};
+  ASSERT_EQ(
+      cudaEventCreateWithFlags(&tip, cudaEventDisableTiming), cudaSuccess);
+  int* buf{};
+  ASSERT_EQ(cudaMalloc(&buf, sizeof(int)), cudaSuccess);
+
+  cudaGraph_t graph{};
+  ASSERT_EQ(
+      cudaStreamBeginCapture(user, cudaStreamCaptureModeGlobal), cudaSuccess);
+  // Join the spine into the graph and CLEAR the dependency set it inherited,
+  // so HOST[0] does not depend on anything already on the user stream.
+  ASSERT_EQ(cudaEventRecord(tip, user), cudaSuccess);
+  ASSERT_EQ(cudaStreamWaitEvent(spine, tip, 0), cudaSuccess);
+#if CUDART_VERSION >= 13000
+  ASSERT_EQ(
+      cudaStreamUpdateCaptureDependencies(
+          spine, nullptr, nullptr, 0, cudaStreamSetCaptureDependencies),
+      cudaSuccess);
+#else
+  ASSERT_EQ(
+      cudaStreamUpdateCaptureDependencies(
+          spine, nullptr, 0, cudaStreamSetCaptureDependencies),
+      cudaSuccess);
+#endif
+  for (int i = 0; i < kNumCollectives; ++i) {
+    addSpineHostNode(user, spine, tip);
+    ASSERT_EQ(cudaMemsetAsync(buf, i, sizeof(int), user), cudaSuccess);
+  }
+  ASSERT_EQ(cudaStreamEndCapture(user, &graph), cudaSuccess);
+
+  const Census c = censusOf(graph);
+  EXPECT_EQ(c.hosts, static_cast<size_t>(kNumCollectives));
+  // Capture absorbs the tip's cudaEventRecord into a plain dependency edge
+  // rather than emitting an EVENT_RECORD node, so the spine is HOST->HOST.
+  EXPECT_EQ(c.hostToHost, kNumCollectives - 1);
+  EXPECT_EQ(c.maxHostOutDeg, 2);
+
+  // The graph must still instantiate and replay.
+  cudaGraphExec_t exec{};
+  // The 5-arg (legacy) form is the portable one: HIP only provides that
+  // signature.
+  ASSERT_EQ(
+      cudaGraphInstantiate(&exec, graph, nullptr, nullptr, 0), cudaSuccess);
+  ASSERT_EQ(cudaGraphLaunch(exec, user), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(user), cudaSuccess);
+
+  ASSERT_EQ(cudaGraphExecDestroy(exec), cudaSuccess);
+  ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+  ASSERT_EQ(cudaEventDestroy(tip), cudaSuccess);
+  ASSERT_EQ(cudaFree(buf), cudaSuccess);
+  ASSERT_EQ(cudaStreamDestroy(spine), cudaSuccess);
+  ASSERT_EQ(cudaStreamDestroy(user), cudaSuccess);
+}
+
+// Two graphs captured concurrently must not share a spine: each keeps its own
+// HOST chain, so neither graph's host nodes depend on the other's. This is why
+// the implementation keys spines by capture id (as NCCL keys its capture
+// streams by graphId) instead of holding one spine per comm.
+TEST_F(GpeHostNodeSideStreamTest, ConcurrentCapturesGetIndependentSpines) {
+  constexpr int kNumCollectives = 3;
+  cudaStream_t userA{}, userB{}, spineA{}, spineB{};
+  for (cudaStream_t* s : {&userA, &userB, &spineA, &spineB}) {
+    ASSERT_EQ(cudaStreamCreateWithFlags(s, cudaStreamNonBlocking), cudaSuccess);
+  }
+  cudaEvent_t tipA{}, tipB{};
+  ASSERT_EQ(
+      cudaEventCreateWithFlags(&tipA, cudaEventDisableTiming), cudaSuccess);
+  ASSERT_EQ(
+      cudaEventCreateWithFlags(&tipB, cudaEventDisableTiming), cudaSuccess);
+  int* buf{};
+  ASSERT_EQ(cudaMalloc(&buf, sizeof(int)), cudaSuccess);
+
+  ASSERT_EQ(
+      cudaStreamBeginCapture(userA, cudaStreamCaptureModeGlobal), cudaSuccess);
+  ASSERT_EQ(
+      cudaStreamBeginCapture(userB, cudaStreamCaptureModeGlobal), cudaSuccess);
+
+  // Distinct capture ids => distinct spines.
+  ctran::utils::cudagraph::StreamCaptureInfo infoA{}, infoB{};
+  ASSERT_EQ(
+      ctran::utils::cudagraph::getStreamCaptureInfo(userA, infoA), cudaSuccess);
+  ASSERT_EQ(
+      ctran::utils::cudagraph::getStreamCaptureInfo(userB, infoB), cudaSuccess);
+  EXPECT_EQ(infoA.status, cudaStreamCaptureStatusActive);
+  EXPECT_EQ(infoB.status, cudaStreamCaptureStatusActive);
+  EXPECT_NE(infoA.id, infoB.id);
+
+  for (auto [user, spine, tip] :
+       {std::tuple{userA, spineA, tipA}, std::tuple{userB, spineB, tipB}}) {
+    ASSERT_EQ(cudaEventRecord(tip, user), cudaSuccess);
+    ASSERT_EQ(cudaStreamWaitEvent(spine, tip, 0), cudaSuccess);
+#if CUDART_VERSION >= 13000
+    ASSERT_EQ(
+        cudaStreamUpdateCaptureDependencies(
+            spine, nullptr, nullptr, 0, cudaStreamSetCaptureDependencies),
+        cudaSuccess);
+#else
+    ASSERT_EQ(
+        cudaStreamUpdateCaptureDependencies(
+            spine, nullptr, 0, cudaStreamSetCaptureDependencies),
+        cudaSuccess);
+#endif
+  }
+  for (int i = 0; i < kNumCollectives; ++i) {
+    addSpineHostNode(userA, spineA, tipA);
+    ASSERT_EQ(cudaMemsetAsync(buf, i, sizeof(int), userA), cudaSuccess);
+    addSpineHostNode(userB, spineB, tipB);
+    ASSERT_EQ(cudaMemsetAsync(buf, i, sizeof(int), userB), cudaSuccess);
+  }
+
+  cudaGraph_t graphA{}, graphB{};
+  ASSERT_EQ(cudaStreamEndCapture(userA, &graphA), cudaSuccess);
+  ASSERT_EQ(cudaStreamEndCapture(userB, &graphB), cudaSuccess);
+
+  // Each graph carries its own complete spine; nothing leaked across.
+  for (cudaGraph_t g : {graphA, graphB}) {
+    const Census c = censusOf(g);
+    EXPECT_EQ(c.hosts, static_cast<size_t>(kNumCollectives));
+    EXPECT_EQ(c.hostToHost, kNumCollectives - 1);
+    EXPECT_EQ(c.maxHostOutDeg, 2);
+  }
+
+  ASSERT_EQ(cudaGraphDestroy(graphA), cudaSuccess);
+  ASSERT_EQ(cudaGraphDestroy(graphB), cudaSuccess);
+  ASSERT_EQ(cudaEventDestroy(tipA), cudaSuccess);
+  ASSERT_EQ(cudaEventDestroy(tipB), cudaSuccess);
+  ASSERT_EQ(cudaFree(buf), cudaSuccess);
+  for (cudaStream_t s : {userA, userB, spineA, spineB}) {
+    ASSERT_EQ(cudaStreamDestroy(s), cudaSuccess);
+  }
+}
+
+// A spine stream whose capture has ended is reclaimable: cudaStreamIsCapturing
+// reports it inactive, which is the signal HostNodeSpine::getOrCreate
+// uses to destroy the entry instead of leaking one stream + event per captured
+// graph.
+TEST_F(GpeHostNodeSideStreamTest, FinishedCaptureIsDetectedAsReclaimable) {
+  cudaStream_t user{}, spine{};
+  ASSERT_EQ(
+      cudaStreamCreateWithFlags(&user, cudaStreamNonBlocking), cudaSuccess);
+  ASSERT_EQ(
+      cudaStreamCreateWithFlags(&spine, cudaStreamNonBlocking), cudaSuccess);
+  cudaEvent_t tip{};
+  ASSERT_EQ(
+      cudaEventCreateWithFlags(&tip, cudaEventDisableTiming), cudaSuccess);
+
+  cudaGraph_t graph{};
+  ASSERT_EQ(
+      cudaStreamBeginCapture(user, cudaStreamCaptureModeGlobal), cudaSuccess);
+  ASSERT_EQ(cudaEventRecord(tip, user), cudaSuccess);
+  ASSERT_EQ(cudaStreamWaitEvent(spine, tip, 0), cudaSuccess);
+  addSpineHostNode(user, spine, tip);
+
+  cudaStreamCaptureStatus status{};
+  ASSERT_EQ(cudaStreamIsCapturing(spine, &status), cudaSuccess);
+  EXPECT_EQ(status, cudaStreamCaptureStatusActive) << "active during capture";
+
+  ASSERT_EQ(cudaStreamEndCapture(user, &graph), cudaSuccess);
+
+  ASSERT_EQ(cudaStreamIsCapturing(spine, &status), cudaSuccess);
+  EXPECT_EQ(status, cudaStreamCaptureStatusNone)
+      << "inactive after EndCapture -> entry is reclaimable";
+
+  ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+  ASSERT_EQ(cudaEventDestroy(tip), cudaSuccess);
+  ASSERT_EQ(cudaStreamDestroy(spine), cudaSuccess);
+  ASSERT_EQ(cudaStreamDestroy(user), cudaSuccess);
+}
+
+} // namespace

--- a/comms/ctran/tests/CtranDistAllgatherCtwinTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherCtwinTests.cc
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <unordered_map>
 #include <vector>
 
 #include "comms/ctran/Ctran.h"
@@ -717,6 +718,227 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Bool(),
     [](const ::testing::TestParamInfo<bool>& info) {
       return info.param ? "SkipMcIntraBarrier" : "KeepMcIntraBarrier";
+    });
+
+// Asserts the recorded topology of the captured GPE HOST nodes with and without
+// NCCL_CTRAN_GPE_HOST_NODE_SIDE_STREAM. The knob's whole effect is a change in
+// where the HOST node is recorded, so the assertions are on graph edges rather
+// than on numerics:
+//
+//   inline (knob off): every HOST is a pass-through link (out-degree 1) and no
+//                      HOST depends on another -> the driver is free to spread
+//                      the graph's internal streams across hardware channels.
+//   spine  (knob on):  HOST[i] depends on HOST[i-1] AND parents the
+//   collective's
+//                      first node, so out-degree reaches 2 and there are
+//                      exactly N-1 HOST -> HOST edges.
+//
+// The (N-1) HOST -> HOST count is the direct fingerprint of the serial spine.
+// Note the spine's cudaEventRecord is ABSORBED by capture into a plain
+// dependency edge rather than becoming a standalone EVENT_RECORD node, so the
+// edge is HOST -> HOST directly (measured; this is the same absorption that
+// mixing=0's fence relies on).
+class CtranAllgatherCtwinHostSpineTest
+    : public CtranAllgatherCtwinTest,
+      public ::testing::WithParamInterface<bool> {
+ public:
+  void SetUp() override {
+    // Must be set before the comm is constructed: CtranGpe::Impl caches both
+    // knobs in its constructor.
+    setenv("NCCL_CTRAN_GRAPH_MIXING_SUPPORT", "0", 1);
+    setenv("NCCL_CTRAN_GPE_HOST_NODE_SIDE_STREAM", GetParam() ? "1" : "0", 1);
+    CtranAllgatherCtwinTest::SetUp();
+  }
+
+  void TearDown() override {
+    unsetenv("NCCL_CTRAN_GPE_HOST_NODE_SIDE_STREAM");
+    unsetenv("NCCL_CTRAN_GRAPH_MIXING_SUPPORT");
+    CtranAllgatherCtwinTest::TearDown();
+  }
+};
+
+TEST_P(CtranAllgatherCtwinHostSpineTest, HostNodeWiring) {
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skipping ctwin graph test";
+  }
+  if (ctranComm->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+  // The GPE host node comes from the PipeStart submit, which ctpipeline makes
+  // only when nNodes > 1; a single-node config emits no host node at all, so
+  // both arms would assert on an empty set. Skip loudly rather than vacuously.
+  const auto nNodes = ctranComm->statex_->nNodes();
+  if (nNodes < 2) {
+    GTEST_SKIP() << "the captured GPE host node needs nNodes>1 to be emitted; "
+                 << "got nNodes=" << nNodes;
+  }
+  const bool spine = GetParam();
+
+  const size_t typeSize = commTypeSize(dt);
+  const size_t sendCount = 8192;
+  const size_t chunkBytes = sendCount * typeSize;
+  const size_t totalBytes = sendCount * numRanks * typeSize;
+
+  CtranWin* win = nullptr;
+  void* winBase = createSymmetricWindow(totalBytes, &win);
+  ASSERT_NE(win, nullptr);
+
+  void* recvbuf = winBase;
+  void* sendbuf = static_cast<char*>(recvbuf) + globalRank * chunkBytes;
+
+  cudaStream_t captureStream;
+  CUDACHECK_TEST(
+      cudaStreamCreateWithFlags(&captureStream, cudaStreamNonBlocking));
+  {
+    const std::vector<int> seed(sendCount, globalRank);
+    CUDACHECK_TEST(cudaMemset(recvbuf, 0xEE, totalBytes));
+    CUDACHECK_TEST(
+        cudaMemcpy(sendbuf, seed.data(), chunkBytes, cudaMemcpyDefault));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+  }
+  oobBarrier();
+
+  // Several collectives back to back: the spine only becomes visible across
+  // collectives (HOST[i] <- HOST[i-1]), so a single-collective capture cannot
+  // distinguish the two shapes.
+  constexpr int kNumCollectives = 4;
+  cudaGraph_t graph = nullptr;
+  ASSERT_EQ(
+      cudaStreamBeginCapture(captureStream, cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  for (int i = 0; i < kNumCollectives; ++i) {
+    ASSERT_EQ(
+        ctranAllGather(
+            sendbuf,
+            recvbuf,
+            sendCount,
+            dt,
+            ctranComm.get(),
+            captureStream,
+            NCCL_ALLGATHER_ALGO::ctwin_pipeline),
+        commSuccess);
+  }
+  ASSERT_EQ(cudaStreamEndCapture(captureStream, &graph), cudaSuccess);
+  ASSERT_NE(graph, nullptr);
+
+  // Walk the recorded graph.
+  size_t numNodes = 0;
+  ASSERT_EQ(cudaGraphGetNodes(graph, nullptr, &numNodes), cudaSuccess);
+  std::vector<cudaGraphNode_t> nodes(numNodes);
+  ASSERT_EQ(cudaGraphGetNodes(graph, nodes.data(), &numNodes), cudaSuccess);
+
+  size_t numEdges = 0;
+  ASSERT_EQ(cudaGraphGetEdges(graph, nullptr, nullptr, &numEdges), cudaSuccess);
+  std::vector<cudaGraphNode_t> from(numEdges), to(numEdges);
+  ASSERT_EQ(
+      cudaGraphGetEdges(graph, from.data(), to.data(), &numEdges), cudaSuccess);
+
+  std::unordered_map<cudaGraphNode_t, cudaGraphNodeType> kind;
+  for (cudaGraphNode_t n : nodes) {
+    cudaGraphNodeType t{};
+    ASSERT_EQ(cudaGraphNodeGetType(n, &t), cudaSuccess);
+    kind[n] = t;
+  }
+  std::unordered_map<cudaGraphNode_t, int> outDeg, inDeg;
+  int hostToRecord = 0, recordToHost = 0, hostToHost = 0;
+  for (size_t e = 0; e < numEdges; ++e) {
+    outDeg[from[e]]++;
+    inDeg[to[e]]++;
+    const bool fromHost = kind[from[e]] == cudaGraphNodeTypeHost;
+    const bool toHost = kind[to[e]] == cudaGraphNodeTypeHost;
+    const bool fromRec = kind[from[e]] == cudaGraphNodeTypeEventRecord;
+    const bool toRec = kind[to[e]] == cudaGraphNodeTypeEventRecord;
+    if (fromHost && toRec) {
+      hostToRecord++;
+    }
+    if (fromRec && toHost) {
+      recordToHost++;
+    }
+    if (fromHost && toHost) {
+      hostToHost++;
+    }
+  }
+  std::vector<cudaGraphNode_t> hosts;
+  for (cudaGraphNode_t n : nodes) {
+    if (kind[n] == cudaGraphNodeTypeHost) {
+      hosts.push_back(n);
+    }
+  }
+
+  // One GPE host node per collective either way -- the knob moves the node, it
+  // does not add or remove any.
+  ASSERT_EQ(hosts.size(), static_cast<size_t>(kNumCollectives));
+  int minIn = 1 << 30, maxIn = 0, minOut = 1 << 30, maxOut = 0;
+  for (cudaGraphNode_t h : hosts) {
+    minIn = std::min(minIn, inDeg[h]);
+    maxIn = std::max(maxIn, inDeg[h]);
+    minOut = std::min(minOut, outDeg[h]);
+    maxOut = std::max(maxOut, outDeg[h]);
+  }
+  if (globalRank == 0) {
+    fprintf(
+        stderr,
+        "[hostspine] spine=%d nodes=%zu edges=%zu hosts=%zu "
+        "inDeg=[%d,%d] outDeg=[%d,%d] host->rec=%d rec->host=%d host->host=%d\n",
+        spine ? 1 : 0,
+        numNodes,
+        numEdges,
+        hosts.size(),
+        minIn,
+        maxIn,
+        minOut,
+        maxOut,
+        hostToRecord,
+        recordToHost,
+        hostToHost);
+  }
+  if (spine) {
+    // Each HOST feeds its own EVENT_RECORD (the spine tip) and the collective's
+    // first node; every HOST but the first is fed by the previous tip.
+    EXPECT_EQ(hostToHost, kNumCollectives - 1)
+        << "serial host spine: HOST[i] depends on HOST[i-1]";
+    EXPECT_EQ(maxOut, 2)
+        << "a spine HOST feeds both the next HOST and its collective";
+  } else {
+    EXPECT_EQ(hostToHost, 0) << "inline: host nodes are mutually independent";
+    EXPECT_EQ(maxOut, 1) << "inline HOST is a pass-through link";
+  }
+
+  // The graph must still replay correctly in both shapes.
+  cudaGraphExec_t graphExec = nullptr;
+  ASSERT_EQ(cudaGraphInstantiate(&graphExec, graph, 0), cudaSuccess);
+  const std::vector<int> myChunk(sendCount, globalRank + 7);
+  CUDACHECK_TEST(cudaMemset(recvbuf, 0xEE, totalBytes));
+  CUDACHECK_TEST(
+      cudaMemcpy(sendbuf, myChunk.data(), chunkBytes, cudaMemcpyDefault));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  oobBarrier();
+  ASSERT_EQ(cudaGraphLaunch(graphExec, captureStream), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(captureStream), cudaSuccess);
+  for (int peer = 0; peer < numRanks; ++peer) {
+    std::vector<int> observed(sendCount, -1);
+    CUDACHECK_TEST(cudaMemcpy(
+        observed.data(),
+        static_cast<char*>(recvbuf) + peer * chunkBytes,
+        chunkBytes,
+        cudaMemcpyDefault));
+    EXPECT_EQ(observed, std::vector<int>(sendCount, peer + 7))
+        << "chunk from peer " << peer;
+  }
+
+  ASSERT_EQ(cudaGraphExecDestroy(graphExec), cudaSuccess);
+  ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+  CUDACHECK_TEST(cudaStreamDestroy(captureStream));
+  oobBarrier();
+  freeSymmetricWindow(win, winBase, totalBytes);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CtranTest,
+    CtranAllgatherCtwinHostSpineTest,
+    ::testing::Bool(),
+    [](const ::testing::TestParamInfo<bool>& info) {
+      return info.param ? "HostSpine" : "HostInline";
     });
 
 int main(int argc, char* argv[]) {

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -129,6 +129,48 @@ cvars:
      A separate internal event carries the captured fence, so the unsupported
      mixed case degrades to unordered rather than failing.
 
+ - name        : NCCL_CTRAN_GPE_HOST_NODE_SIDE_STREAM
+   type        : bool
+   default     : true
+   description : |-
+     Record each captured GPE HOST node on a per-comm, per-graph side capture
+     stream instead of inline on the user's stream, mirroring how NCCL records
+     proxy-args callbacks (ncclStrongStreamAcquire on comm->sharedRes->hostStream,
+     then ncclStreamWaitStream back into the launch stream). Requires
+     NCCL_CTRAN_GRAPH_MIXING_SUPPORT=0 and is IGNORED otherwise.
+
+     Rationale: this is how the NCCL baseline records its host nodes. NCCL's
+     captured AllGather chains its proxy-args callbacks serially on
+     comm->sharedRes->hostStream (ncclStrongStreamAcquire + ncclStreamWaitStream,
+     enqueue.cc:1691-1703) rather than recording them inline on the launch
+     stream. Recorded inline, a captured HOST node is a pass-through link
+     (in-degree 1, out-degree 1) that orders nothing across collectives;
+     recorded on a reused side stream, HOST[i]'s only predecessor is HOST[i-1]
+     and the join makes it a predecessor of the collective's first node, so
+     every collective is transitively ordered behind one host chain. This
+     change gives CTRAN the same recorded shape.
+
+     Measured effect is a reduction in fixed per-replay overhead: on GB200
+     vPPN=8 allgatherce under graph capture it saves a near-constant 52-85 us
+     per collective replay, flat across message sizes 8 MiB-4 GiB (a 512x
+     range) and across nNodes=2/4/8/16. Being a constant offset, it is a large
+     relative win on small messages (+52% busbw at 8 MiB / 16 ranks) and
+     negligible on large ones (+0.8% at 4 GiB).
+
+     On by default. It changes recorded graph topology (adds one join edge per
+     collective; the graph gains edges, it does not lose them). Only the
+     mixing=0 in-capture path is affected: the mixing=1 side-stream fence and
+     every eager path are unchanged.
+
+     CAVEAT -- this reintroduces cross-collective serialization of the GPE host
+     callbacks, which is part of what mixing=0 removes for overlap. It is only
+     safe at mixing=0 because mixing=0 already declines to order a graph replay
+     ahead of a following eager CTRAN submission (see
+     NCCL_CTRAN_GRAPH_MIXING_SUPPORT), so callers must already host-synchronize
+     between replay and eager work. NCCL_CTRAN_GPE_DEVICE_RING removes the HOST
+     nodes entirely instead of serializing them (~6% dispatch-latency cost);
+     prefer whichever measures better for the workload.
+
  - name        : NCCL_CTRAN_GPE_DEVICE_RING
    type        : bool
    default     : false


### PR DESCRIPTION
Summary:

Adds NCCL_CTRAN_GPE_HOST_NODE_SIDE_STREAM (default off, requires
NCCL_CTRAN_GRAPH_MIXING_SUPPORT=0 and ignored otherwise). When set, each
captured GPE host node is recorded on a per-comm, per-graph side capture stream
instead of inline on the user's stream, then joined back before the collective's
first node.

Why: this is how the NCCL baseline adds host nodes to a captured graph. NCCL's
captured AllGather chains its proxy-args callbacks serially on
comm->sharedRes->hostStream (ncclStrongStreamAcquire + ncclStreamWaitStream,
enqueue.cc:1691-1703) rather than recording them inline on the launch stream.
CTRAN recorded them inline, where a captured HOST node is a pass-through link
(in-degree 1, out-degree 1) that orders nothing across collectives. This change
gives CTRAN the same recorded shape as NCCL: HOST[i]'s only predecessor is
HOST[i-1], and the join makes it a predecessor of the collective's first node.

What it buys: a reduction in fixed per-replay overhead. Measured on GB200
vPPN=8 allgatherce under graph capture, it saves a near-constant 52-85 us per
collective replay, flat across a 512x message-size range and across four
topologies (see Test Plan). Because the saving is a constant offset rather than
a bandwidth change, it is a large relative win on small messages (+52% busbw at
8 MiB / 16 ranks) and negligible on large ones (+0.8% at 4 GiB).

Note the spine ADDS edges (one join per collective); it does not simplify the
graph.

Scoped to mixing=0 because mixing=1's fence is a floating EVENT_RECORD awaited
with cudaEventWaitExternal so it can order across graphs, and
GraphSideStream::fork_from deliberately restores the user stream's dependencies
after its fork (leaving no join edge) -- the opposite of the kept join edge the
spine needs. mixing=0 also already declines to order a graph replay ahead of a
following eager CTRAN submission, so the GPE-deadlock ordering the host node
otherwise provides is already the caller's responsibility there.

Spines are keyed by capture id and reclaimed once their capture ends, mirroring
ncclStrongStream::captureHead; without that, each captured graph would leak a
stream and an event.

Reviewed By: minsii

Differential Revision: D115952954


