### PR TITLE
Record internal abort causes

### DIFF
--- a/comms/common/fault_tolerance/Abort.cc
+++ b/comms/common/fault_tolerance/Abort.cc
@@ -9,11 +9,19 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <cstdio>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <thread>
 
 namespace comms::fault_tolerance {
+
+namespace {
+
+constexpr std::chrono::milliseconds kAbortInfoPublicationTimeout{300};
+
+} // namespace
 
 Abort::Abort(bool enabled, AbortBehavior behavior) : behavior_(behavior) {
   if (!enabled) {
@@ -43,6 +51,7 @@ Abort::Abort(bool enabled, AbortBehavior behavior) : behavior_(behavior) {
   state_ = new AbortState;
 #endif
   state_->abort = encode(AbortReason::NONE);
+  state_->contextReady = 0;
   state_->timeoutMs = -1;
 }
 
@@ -85,11 +94,27 @@ std::optional<AbortInfo> Abort::getAbortInfo() {
     return std::nullopt;
   }
 
-  std::string context;
-  if (contextReady_.load(std::memory_order_acquire)) {
-    context = context_;
+  const auto publicationDeadline =
+      std::chrono::steady_clock::now() + kAbortInfoPublicationTimeout;
+  auto contextReady = isContextReady();
+  while (!contextReady &&
+         std::chrono::steady_clock::now() < publicationDeadline) {
+    std::this_thread::yield();
+    contextReady = isContextReady();
   }
-  return AbortInfo{.reason = reason, .context = std::move(context)};
+
+  if (!contextReady) {
+    const auto reasonString = abortReasonToString(reason);
+    std::fprintf(
+        stderr,
+        "WARNING: AbortInfo publication did not complete within %lldms for "
+        "abort reason %.*s; returning empty context\n",
+        static_cast<long long>(kAbortInfoPublicationTimeout.count()),
+        static_cast<int>(reasonString.size()),
+        reasonString.data());
+    return AbortInfo{.reason = reason, .context = {}};
+  }
+  return AbortInfo{.reason = reason, .context = context_};
 }
 
 bool Abort::isAborted() {
@@ -203,6 +228,11 @@ int Abort::loadAbortReason() const {
   return std::atomic_ref<int>{state_->abort}.load(std::memory_order_acquire);
 }
 
+bool Abort::isContextReady() const {
+  return std::atomic_ref<int>{state_->contextReady}.load(
+             std::memory_order_acquire) != 0;
+}
+
 bool Abort::trySetAbort(AbortReason newReason, std::string context) {
   int expected = encode(AbortReason::NONE);
   const bool won = std::atomic_ref<int>{state_->abort}.compare_exchange_strong(
@@ -214,11 +244,12 @@ bool Abort::trySetAbort(AbortReason newReason, std::string context) {
     return false;
   }
 
-  // The reason CAS gives this call exclusive ownership of context_. Publishing
-  // happens afterwards on purpose: a racing reader may return the reason with
-  // empty context, but it never reads context_ while this swap is in progress.
+  // The reason CAS gives this call exclusive ownership of context_. Publish
+  // readiness only after the swap so getAbortInfo() cannot return a terminal
+  // reason with a transiently incomplete host context.
   context_.swap(context);
-  contextReady_.store(true, std::memory_order_release);
+  std::atomic_ref<int>{state_->contextReady}.store(
+      1, std::memory_order_release);
   return true;
 }
 

--- a/comms/common/fault_tolerance/Abort.h
+++ b/comms/common/fault_tolerance/Abort.h
@@ -24,7 +24,7 @@ enum class AbortCheckResult : int {
 /**
  * Host-owned state shared with CUDA device code through mapped pinned memory.
  *
- * Both fields are read and written with system-scope atomic operations. The
+ * All fields are read and written with system-scope atomic operations. The
  * allocation is owned by `Abort`; `AbortDevice` stores only a non-owning mapped
  * pointer to this same state.
  */
@@ -39,6 +39,16 @@ struct AbortState {
   int abort;
 
   /**
+   * Whether AbortInfo context publication is complete.
+   *
+   * Host winners set this after storing their context. Device winners also set
+   * it; their host-visible context is empty because device context is not
+   * persisted in mapped host state. Readers that observe a terminal reason
+   * wait while this remains false before returning AbortInfo.
+   */
+  int contextReady;
+
+  /**
    * Shared default timeout duration in milliseconds.
    *
    * `-1` means unset. Host code may update this value, and device handles read
@@ -50,6 +60,7 @@ struct AbortState {
 // Atomic operations require naturally aligned fields. Cacheline padding is a
 // performance choice, not a correctness requirement for this shared state.
 static_assert(offsetof(AbortState, abort) % alignof(int) == 0);
+static_assert(offsetof(AbortState, contextReady) % alignof(int) == 0);
 static_assert(offsetof(AbortState, timeoutMs) % alignof(int64_t) == 0);
 
 struct AbortDevice;
@@ -70,13 +81,16 @@ struct AbortDevice;
  * singleton returned by `createAbort(false)` is intended for code paths that
  * must accept an abort object without enabling fault tolerance.
  *
- * `AbortState::abort` and `AbortState::timeoutMs` are mutable shared fields.
- * Host code and device code access them with system-scope atomic operations so
- * updates from either side become visible to the other side. The abort reason
- * is first-writer-wins: an explicit abort records `AbortReason::ABORTED`; an
- * expired timeout records `AbortReason::TIMED_OUT` only if no earlier valid
- * terminal reason has been recorded. The default timeout duration is also
- * stored in shared state for graph-mode device code; host active-deadline
+ * `AbortState` fields are mutable shared state. Host code and device code
+ * access them with system-scope atomic operations so updates from either side
+ * become visible to the other side. The abort reason is first-writer-wins: an
+ * explicit abort records `AbortReason::ABORTED`; an expired timeout records
+ * `AbortReason::TIMED_OUT` only if no earlier valid terminal reason has been
+ * recorded. The winning writer then publishes `contextReady`, preventing a
+ * reader from returning a reason before its host context is stable. Device
+ * writers publish the same ready state after winning the reason transition;
+ * their host-visible context remains empty. The default timeout duration is
+ * also stored in shared state for graph-mode device code; host active-deadline
  * tracking remains host-only.
  */
 class Abort final {
@@ -131,10 +145,9 @@ class Abort final {
    * state.
    *
    * The context is copied before attempting the transition. When this call
-   * wins, that owned string is published in host-only state and becomes
-   * available through `getAbortInfo()`. A racing reader may observe the winning
-   * reason before the context is published and receive an empty context.
-   * Device-originated aborts never publish host context.
+   * wins, that owned string is published in host-only state before AbortInfo is
+   * marked ready. `getAbortInfo()` waits for that publication to complete.
+   * Device-originated aborts publish readiness without a host context.
    *
    * Returns whether this call performed the `NONE` to terminal transition.
    */
@@ -147,7 +160,14 @@ class Abort final {
    * std::nullopt when this controller has not been aborted.
    *
    * Like `isAborted()`, this materializes an expired host timeout before
-   * reading the snapshot. Device-originated aborts have an empty context.
+   * reading the snapshot. Once a terminal reason is visible, this waits up to
+   * 300ms for the winning host or device writer to complete AbortInfo
+   * publication. Device-originated aborts have an empty context. If the winner
+   * does not publish in time, this prints a warning and returns the reason with
+   * an empty context rather than waiting indefinitely. This fallback is best
+   * effort: publication may complete later and a subsequent call may return
+   * the context. Previously returned AbortInfo snapshots are values and are not
+   * updated, so a caller that caches the fallback retains its empty context.
    */
   std::optional<AbortInfo> getAbortInfo();
 
@@ -245,6 +265,7 @@ class Abort final {
   }
 
   int loadAbortReason() const;
+  bool isContextReady() const;
   bool trySetAbort(AbortReason newReason, std::string context);
 
   AbortState* state_{nullptr};
@@ -253,9 +274,7 @@ class Abort final {
   std::atomic<std::chrono::steady_clock::time_point> deadline_{
       std::chrono::steady_clock::time_point{}};
   // Only the host reason-CAS winner writes context_. Readers copy it only after
-  // an acquire load observes contextReady_, so no mutex is needed. The flag is
-  // host-only and is never accessed by AbortDevice.
-  std::atomic<bool> contextReady_{false};
+  // an acquire load observes READY, so no mutex is needed.
   std::string context_;
   AbortBehavior behavior_{AbortBehavior::SKIP};
 

--- a/comms/common/fault_tolerance/AbortDevice.cuh
+++ b/comms/common/fault_tolerance/AbortDevice.cuh
@@ -380,8 +380,15 @@ struct AbortDevice final {
     }
 
     int expected = static_cast<int>(AbortReason::NONE);
-    return detail::deviceCompareExchangeSystem(
+    const bool won = detail::deviceCompareExchangeSystem(
         &state_->abort, &expected, static_cast<int>(newReason));
+    if (won) {
+      // Device context is intentionally not persisted in mapped host state.
+      int expectedContextReady = 0;
+      (void)detail::deviceCompareExchangeSystem(
+          &state_->contextReady, &expectedContextReady, 1);
+    }
+    return won;
   }
 
  private:
@@ -450,6 +457,9 @@ struct AbortDevice final {
             &state_->abort,
             &expected,
             static_cast<int>(AbortReason::TIMED_OUT))) {
+      int expectedContextReady = 0;
+      (void)detail::deviceCompareExchangeSystem(
+          &state_->contextReady, &expectedContextReady, 1);
       return true;
     }
     return expected == static_cast<int>(AbortReason::TIMED_OUT);

--- a/comms/common/fault_tolerance/FAULT_TOLERANCE.md
+++ b/comms/common/fault_tolerance/FAULT_TOLERANCE.md
@@ -538,7 +538,7 @@ Two things this audit turned up that are worth keeping written down:
 ### What the caller sees
 
 - The collective completes; **output buffers are undefined** after an abort.
-- Check `IComm::isAborted()`, `getAbortReason()` and `getAbortReasonStr()`.
+- Check `IComm::isAborted()` and `getAbortInfo()`.
 - Where the host can determine it cheaply, the work handle also reports a
   non-success result — but a `commSuccess` after an abort is contract-legal and
   its data must still be ignored.

--- a/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
@@ -408,6 +408,9 @@ TEST(AbortDeviceTest, deviceTimeoutProducerHostAndDeviceConsumer) {
   EXPECT_EQ(readDeviceValue(observedIsAborted), 1);
   EXPECT_TRUE(abort.isAborted());
   EXPECT_TRUE(abort.isTimedOut());
+  EXPECT_EQ(
+      abort.getAbortInfo(),
+      (AbortInfo{.reason = AbortReason::TIMED_OUT, .context = ""}));
 }
 
 TEST(AbortDeviceTest, hostAbortWinsOverDeviceTimeout) {

--- a/comms/common/fault_tolerance/tests/AbortUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortUT.cc
@@ -5,6 +5,7 @@
 #include <optional>
 #include <stdexcept>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include <gmock/gmock.h>

--- a/comms/common/fault_tolerance/tests/AbortUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortUT.cc
@@ -146,6 +146,21 @@ TEST(AbortFactoryTest, disabledNoop) {
   EXPECT_FALSE(abort->isAborted());
 }
 
+TEST(AbortFactoryTest, DisabledSingletonDoesNotStoreAbortInfo) {
+  auto first = ::comms::fault_tolerance::createAbort(/*enabled=*/false);
+  auto second = ::comms::fault_tolerance::createAbort(/*enabled=*/false);
+
+  ASSERT_EQ(first.get(), second.get());
+
+  EXPECT_FALSE(
+      first->setAbort(AbortReason::NETWORK_ERROR, "ignored disabled abort"));
+
+  EXPECT_FALSE(first->isAborted());
+  EXPECT_EQ(first->getAbortInfo(), std::nullopt);
+  EXPECT_FALSE(second->isAborted());
+  EXPECT_EQ(second->getAbortInfo(), std::nullopt);
+}
+
 TEST(AbortTest, timeoutNotExpired) {
   Abort abort{/*enabled=*/true};
 

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -11,8 +11,10 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
+#include <folly/String.h>
 #include <folly/Synchronized.h>
 #include <folly/container/F14Set.h>
 #include "comms/common/fault_tolerance/Abort.h"
@@ -20,6 +22,7 @@
 #include "comms/ctran/bootstrap/ICtranBootstrap.h"
 #include "comms/ctran/commstate/CommStateX.h"
 #include "comms/ctran/interfaces/ICtran.h"
+#include "comms/ctran/utils/AbortUtils.h"
 #include "comms/ctran/utils/AsyncError.h"
 #include "comms/ctran/utils/Exception.h"
 #include "comms/ctran/window/WinCache.h"
@@ -171,8 +174,26 @@ class CtranComm {
     return abort_->isEnabled();
   }
 
-  inline void setAbort() {
-    abort_->setAbort();
+  inline void setAbort(const comms::fault_tolerance::AbortInfo& info = {}) {
+    abort_->setAbort(info.reason, info.context);
+  }
+
+  // This query may materialize an expired timeout as TIMED_OUT.
+  inline std::optional<comms::fault_tolerance::AbortInfo> getAbortInfo() const {
+    return abort_->getAbortInfo();
+  }
+
+  inline std::string abortMessage() const {
+    const auto info = getAbortInfo();
+    if (!info.has_value()) {
+      return "comm aborted";
+    }
+    auto message = "comm aborted reason=" + std::string{info->reasonString()};
+    if (!info->context.empty()) {
+      message +=
+          " context=\"" + folly::cEscape<std::string>(info->context) + "\"";
+    }
+    return message;
   }
 
   inline bool testAbort() const {

--- a/comms/ctran/algos/AllReduce/AllReduceDirect.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceDirect.cc
@@ -53,21 +53,19 @@ static const auto myAlgo = NCCL_ALLREDUCE_ALGO::ctdirect;
  *         registers and reduces them into the receive buffer.
  */
 
-#define THROW_IF_ABORTED(code, ...)                                           \
-  do {                                                                        \
-    code;                                                                     \
-    if (comm->testAbort()) {                                                  \
-      auto _abort = comm->getAbort();                                         \
-      std::string _ctx = _abort->isTimedOut() ? "comm aborted due to timeout" \
-                                              : "comm aborted";               \
-      std::string _desc{__VA_ARGS__};                                         \
-      throw ctran::utils::Exception(                                          \
-          _ctx,                                                               \
-          commRemoteError,                                                    \
-          comm->logMetaData_.rank,                                            \
-          comm->logMetaData_.commHash,                                        \
-          _desc.empty() ? std::nullopt : std::make_optional(_desc));          \
-    }                                                                         \
+#define THROW_IF_ABORTED(code, ...)                                  \
+  do {                                                               \
+    code;                                                            \
+    if (comm->testAbort()) {                                         \
+      std::string _ctx = comm->abortMessage();                       \
+      std::string _desc{__VA_ARGS__};                                \
+      throw ctran::utils::Exception(                                 \
+          _ctx,                                                      \
+          commRemoteError,                                           \
+          comm->logMetaData_.rank,                                   \
+          comm->logMetaData_.commHash,                               \
+          _desc.empty() ? std::nullopt : std::make_optional(_desc)); \
+    }                                                                \
   } while (0)
 
 static commResult_t impl(

--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -1032,17 +1032,15 @@ inline commResult_t completeHostResourceSetup(
 
 } // namespace
 
-#define HOST_ABORT(desc)                                                       \
-  if (comm->testAbort()) {                                                     \
-    auto _abort = comm->getAbort();                                            \
-    std::string _ctx =                                                         \
-        _abort->isTimedOut() ? "comm aborted due to timeout" : "comm aborted"; \
-    throw ctran::utils::Exception(                                             \
-        _ctx,                                                                  \
-        commRemoteError,                                                       \
-        comm->logMetaData_.rank,                                               \
-        comm->logMetaData_.commHash,                                           \
-        std::string(desc));                                                    \
+#define HOST_ABORT(desc)                     \
+  if (comm->testAbort()) {                   \
+    std::string _ctx = comm->abortMessage(); \
+    throw ctran::utils::Exception(           \
+        _ctx,                                \
+        commRemoteError,                     \
+        comm->logMetaData_.rank,             \
+        comm->logMetaData_.commHash,         \
+        std::string(desc));                  \
   }
 
 static commResult_t impl(

--- a/comms/ctran/backends/ib/BootstrapInternal.cc
+++ b/comms/ctran/backends/ib/BootstrapInternal.cc
@@ -4,6 +4,8 @@
 
 #include <chrono>
 #include <cstdint>
+#include <cstring>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -14,6 +16,7 @@
 
 #include <folly/ScopeGuard.h>
 #include <folly/SocketAddress.h>
+#include <folly/String.h>
 
 #include "comms/ctran/CtranComm.h" // @manual=//comms/ctran:ctran_comm
 #include "comms/ctran/backends/ib/CtranIbVc.h"
@@ -32,6 +35,20 @@ namespace {
 const std::string kCtranIbLogEventName{"CtranIb-QpExchange"};
 
 const uint64_t kBootstrapMagic = 0xfaceb00cdeadbeef;
+
+std::string socketErrorContext(int error) {
+  const bool hasValidMagnitude = error != std::numeric_limits<int>::min();
+  const int errnoValue = hasValidMagnitude && error < 0 ? -error : error;
+  const char* errorName =
+      hasValidMagnitude ? ::strerrorname_np(errnoValue) : nullptr;
+  const std::string description =
+      hasValidMagnitude ? folly::errnoStr(errnoValue) : "invalid errno value";
+  return fmt::format(
+      "origin=socket_error subsystem=ctran_ib error_code={} error_name={} error_description=\"{}\"",
+      error,
+      errorName != nullptr ? errorName : "UNKNOWN",
+      folly::cEscape<std::string>(description));
+}
 } // namespace
 
 // TODO: We may want to retry if err is ECONNRESET,
@@ -39,16 +56,20 @@ const uint64_t kBootstrapMagic = 0xfaceb00cdeadbeef;
 // may still want to throw an ctran::utils::Exception,
 // like what would happen if FT is disabled (via
 // the FB_SYSCHECKTHROW_EX macro).
-#define HANDLE_SOCKET_ERROR(cmd, self)                                       \
-  if (!self->abortCtrl_->isEnabled()) {                                      \
-    FB_SYSCHECKTHROW_EX(cmd, self->rank_, self->commHash_, self->commDesc_); \
-  } else {                                                                   \
-    int errCode = cmd;                                                       \
-    if (errCode || self->abortCtrl_->isAborted()) {                          \
-      CTRAN_LOG(ERR, "Socket error encountered: {}. Aborting.", errCode);    \
-      self->abortCtrl_->setAbort(); /* Ensure remote is notified */          \
-      break;                                                                 \
-    }                                                                        \
+#define HANDLE_SOCKET_ERROR(cmd, self)                                         \
+  if (!self->abortCtrl_->isEnabled()) {                                        \
+    FB_SYSCHECKTHROW_EX(cmd, self->rank_, self->commHash_, self->commDesc_);   \
+  } else {                                                                     \
+    int errCode = cmd;                                                         \
+    if (errCode || self->abortCtrl_->isAborted()) {                            \
+      if (errCode) {                                                           \
+        CTRAN_LOG(ERR, "Socket error encountered: {}. Aborting.", errCode);    \
+        const auto abortContext = socketErrorContext(errCode);                 \
+        self->abortCtrl_->setAbort(                                            \
+            comms::fault_tolerance::AbortReason::NETWORK_ERROR, abortContext); \
+      }                                                                        \
+      break;                                                                   \
+    }                                                                          \
   }
 
 namespace ctran::ib {

--- a/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
@@ -1032,6 +1032,18 @@ TEST_F(CtranIbBootstrapCommonTest, AbortDuringListenThreadAccept) {
   }
 
   EXPECT_TRUE(preparedServerSocket->abortCtrl->isAborted());
+  const auto abortInfo = preparedServerSocket->abortCtrl->getAbortInfo();
+  ASSERT_TRUE(abortInfo.has_value());
+  EXPECT_EQ(
+      abortInfo->reason, comms::fault_tolerance::AbortReason::NETWORK_ERROR);
+  EXPECT_THAT(
+      abortInfo->context,
+      ::testing::AllOf(
+          ::testing::HasSubstr("origin=socket_error"),
+          ::testing::HasSubstr("subsystem=ctran_ib"),
+          ::testing::HasSubstr("error_code=" + std::to_string(ECONNABORTED)),
+          ::testing::HasSubstr("error_name=ECONNABORTED"),
+          ::testing::HasSubstr("error_description=\"")));
 
   // Destroy CtranIb
   auto startDestroy = std::chrono::steady_clock::now();
@@ -1041,6 +1053,59 @@ TEST_F(CtranIbBootstrapCommonTest, AbortDuringListenThreadAccept) {
   auto destroyTime = std::chrono::steady_clock::now() - startDestroy;
   EXPECT_LT(destroyTime, 2s)
       << "Listen thread should terminate quickly after abort";
+}
+
+TEST_F(CtranIbBootstrapCommonTest, ExistingAbortDuringSocketRecvIsPreserved) {
+  auto abortCtrl = comms::fault_tolerance::createAbort(/*enabled=*/true);
+  folly::Baton<> recvCalledBaton;
+
+  auto mockSocket =
+      std::make_unique<StrictMock<ctran::bootstrap::testing::MockISocket>>();
+  EXPECT_CALL(*mockSocket, recv(_, sizeof(uint64_t)))
+      .WillOnce([&](void* buf, const size_t len) {
+        abortCtrl->setAbort(
+            comms::fault_tolerance::AbortReason::ABORTED,
+            "user requested abort");
+        recvCalledBaton.post();
+        return 0;
+      });
+  auto socketHolder =
+      std::make_shared<std::unique_ptr<ctran::bootstrap::testing::MockISocket>>(
+          std::move(mockSocket));
+
+  auto mockServerSocket = std::make_unique<
+      StrictMock<ctran::bootstrap::testing::MockIServerSocket>>();
+  EXPECT_CALL(*mockServerSocket, bindAndListen(_, _))
+      .WillOnce(
+          [](const folly::SocketAddress&, const std::string&) { return 0; });
+  EXPECT_CALL(*mockServerSocket, acceptSocket())
+      .WillOnce(
+          [socketHolder]() mutable
+              -> folly::
+                  Expected<std::unique_ptr<ctran::bootstrap::ISocket>, int> {
+                    return std::move(*socketHolder);
+                  });
+  EXPECT_CALL(*mockServerSocket, shutdown()).WillOnce([]() { return 0; });
+
+  std::vector<StrictMockIServerSocketPtr> mockServerSockets;
+  mockServerSockets.push_back(std::move(mockServerSocket));
+  auto socketFactory =
+      std::make_shared<ctran::bootstrap::testing::MockInjectorSocketFactory>(
+          std::move(mockServerSockets));
+
+  SocketServerAddr serverAddr = getSocketServerAddress();
+  auto ctranIb = createCtranIb(
+      /*rank=*/0,
+      CtranIb::BootstrapMode::kSpecifiedServer,
+      abortCtrl,
+      &serverAddr,
+      socketFactory);
+
+  recvCalledBaton.wait();
+  const auto abortInfo = abortCtrl->getAbortInfo();
+  ASSERT_TRUE(abortInfo.has_value());
+  EXPECT_EQ(abortInfo->reason, comms::fault_tolerance::AbortReason::ABORTED);
+  EXPECT_EQ(abortInfo->context, "user requested abort");
 }
 
 // Test that listen thread terminates cleanly via shutdown

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -8,6 +8,7 @@
 
 #include <folly/dynamic.h>
 
+#include "comms/common/fault_tolerance/AbortTypes.h"
 #include "comms/ctran/algos/AllToAll/AllToAllPImpl.h"
 #include "comms/ctran/algos/common/GpeKernel.h"
 #include "comms/ctran/colltrace/CollTraceWrapper.h"
@@ -774,22 +775,26 @@ void CtranGpe::Impl::gpeThreadFn() {
       }
       SCOPE_EXIT {
         if (comm->testAbort()) {
-          // Preserve abort state across cancelTimeout(): an aborted comm
-          // must never flip back to not-aborted.
-          comm->setAbort();
-          const std::string_view reason =
-              comm->getAbort()->isTimedOut() ? "timeout" : "explicit";
+          const auto abortInfo = comm->getAbortInfo();
+          const auto reasonAndContext = abortInfo.has_value()
+              ? fmt::format(
+                    "reason={} context=\"{}\"",
+                    comms::fault_tolerance::abortReasonToString(
+                        abortInfo->reason),
+                    folly::cEscape<std::string>(abortInfo->context))
+              : std::string{"reason=unknown context=\"\""};
 
           // TERMINATE was marked before SCOPE_EXIT — skip the marker here.
           if (!isTerminateCmd) {
-            gpeProfiler_->mark(ctran::GpeTracePoint::ALGO_ABORTED, reason);
+            gpeProfiler_->mark(
+                ctran::GpeTracePoint::ALGO_ABORTED, reasonAndContext);
           }
 
           const std::string_view phase = isTerminateCmd ? " now TERMINATE" : "";
           CTRAN_LOG(
               ERR,
               "Communicator aborted ({}){} on rank {} commHash {:x} {}",
-              reason,
+              reasonAndContext,
               phase,
               statex->rank(),
               statex->commHash(),

--- a/comms/ctran/gpe/tests/CtranGpeProfilerIntegrationUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeProfilerIntegrationUT.cc
@@ -8,6 +8,29 @@
 
 namespace ctran::fttesting {
 
+namespace {
+
+struct CapturedGpeProfilerReport {
+  ::ctran::GpeTracePoint tracePoint;
+  uint64_t iterUs;
+  uint64_t durationUs;
+  bool aborted;
+  std::string message;
+};
+
+CapturedGpeProfilerReport captureReport(
+    const ::ctran::GpeProfilerReport& report) {
+  return {
+      .tracePoint = report.tracePoint,
+      .iterUs = report.iterUs,
+      .durationUs = report.durationUs,
+      .aborted = report.aborted,
+      .message = std::string{report.message},
+  };
+}
+
+} // namespace
+
 // ---------------------------------------------------------------------------
 // GpeProfiler integration tests (T270778705).
 //
@@ -50,15 +73,18 @@ TEST_F(GpeProfilerIntegrationTest, GpeProfiler_RecordsAlgoAbortedOnAbort) {
   auto mockReporter = std::make_unique<::ctran::MockGpeProfilerReporter>();
   auto* mockPtr = mockReporter.get();
 
-  std::vector<::ctran::GpeProfilerReport> rows;
+  std::vector<CapturedGpeProfilerReport> rows;
   EXPECT_CALL(*mockPtr, report(::testing::_))
-      .WillRepeatedly(
-          [&](const ::ctran::GpeProfilerReport& r) { rows.push_back(r); });
+      .WillRepeatedly([&](const ::ctran::GpeProfilerReport& r) {
+        rows.push_back(captureReport(r));
+      });
 
+  // Keep synchronization state alive until after the GPE thread is joined,
+  // including when an ASSERT below returns early.
+  FtTestSync sync;
   auto gpe = std::make_unique<CtranGpe>(
       cudaDev, ctranComm.get(), std::move(mockReporter));
 
-  FtTestSync sync;
   sync.setTimeout();
   this->launchKernelFn(
       gpe.get(),
@@ -70,6 +96,9 @@ TEST_F(GpeProfilerIntegrationTest, GpeProfiler_RecordsAlgoAbortedOnAbort) {
   // Wait for kernel + abort handling to complete.
   tryQueryStreamFor(stream, kHostAlgoFnWait + std::chrono::milliseconds(2000));
   ASSERT_TRUE(ctranComm->testAbort());
+  const auto abortInfo = ctranComm->getAbortInfo();
+  ASSERT_TRUE(abortInfo.has_value());
+  EXPECT_EQ(abortInfo->reason, comms::fault_tolerance::AbortReason::TIMED_OUT);
 
   // Tear down gpe — ~Impl joins the GPE thread.
   gpe.reset();
@@ -92,7 +121,7 @@ TEST_F(GpeProfilerIntegrationTest, GpeProfiler_RecordsAlgoAbortedOnAbort) {
     } else if (r.tracePoint == ::ctran::GpeTracePoint::ALGO_ABORTED) {
       sawAlgoAborted = true;
       EXPECT_TRUE(r.aborted);
-      EXPECT_EQ(r.message, std::string_view{"timeout"});
+      EXPECT_EQ(r.message, "reason=timed_out context=\"timeout expired\"");
     }
   }
   EXPECT_TRUE(sawIterStart);
@@ -115,16 +144,19 @@ TEST_F(
   auto mockReporter = std::make_unique<::ctran::MockGpeProfilerReporter>();
   auto* mockPtr = mockReporter.get();
 
-  std::vector<::ctran::GpeProfilerReport> rows;
+  std::vector<CapturedGpeProfilerReport> rows;
   EXPECT_CALL(*mockPtr, report(::testing::_))
-      .WillRepeatedly(
-          [&](const ::ctran::GpeProfilerReport& r) { rows.push_back(r); });
+      .WillRepeatedly([&](const ::ctran::GpeProfilerReport& r) {
+        rows.push_back(captureReport(r));
+      });
 
+  // Keep synchronization state alive until after the GPE thread is joined,
+  // including when an ASSERT below returns early.
+  FtTestSync sync;
   auto gpe = std::make_unique<CtranGpe>(
       cudaDev, ctranComm.get(), std::move(mockReporter));
 
   // Run a happy-path iteration (no abort).
-  FtTestSync sync;
   this->launchKernelFn(
       gpe.get(), (void*)CtranGpeTestFtEnabledOobTerminateKernel, stream, &sync);
   *oobKernelTerminateFlag = true;
@@ -165,10 +197,11 @@ TEST_F(GpeProfilerIntegrationTest, GpeProfiler_TerminateIterEmitsAnchorPair) {
   auto mockReporter = std::make_unique<::ctran::MockGpeProfilerReporter>();
   auto* mockPtr = mockReporter.get();
 
-  std::vector<::ctran::GpeProfilerReport> rows;
+  std::vector<CapturedGpeProfilerReport> rows;
   EXPECT_CALL(*mockPtr, report(::testing::_))
-      .WillRepeatedly(
-          [&](const ::ctran::GpeProfilerReport& r) { rows.push_back(r); });
+      .WillRepeatedly([&](const ::ctran::GpeProfilerReport& r) {
+        rows.push_back(captureReport(r));
+      });
 
   auto gpe = std::make_unique<CtranGpe>(
       cudaDev, ctranComm.get(), std::move(mockReporter));
@@ -202,10 +235,11 @@ TEST_F(
   auto mockReporter = std::make_unique<::ctran::MockGpeProfilerReporter>();
   auto* mockPtr = mockReporter.get();
 
-  std::vector<::ctran::GpeProfilerReport> rows;
+  std::vector<CapturedGpeProfilerReport> rows;
   EXPECT_CALL(*mockPtr, report(::testing::_))
-      .WillRepeatedly(
-          [&](const ::ctran::GpeProfilerReport& r) { rows.push_back(r); });
+      .WillRepeatedly([&](const ::ctran::GpeProfilerReport& r) {
+        rows.push_back(captureReport(r));
+      });
 
   auto gpe = std::make_unique<CtranGpe>(
       cudaDev, ctranComm.get(), std::move(mockReporter));
@@ -214,11 +248,15 @@ TEST_F(
   // only cmd the GPE thread sees.
   ctranComm->setAbort();
   ASSERT_TRUE(ctranComm->testAbort());
+  const auto abortInfo = ctranComm->getAbortInfo();
+  ASSERT_TRUE(abortInfo.has_value());
+  EXPECT_EQ(abortInfo->reason, comms::fault_tolerance::AbortReason::ABORTED);
 
   gpe.reset();
 
   // Abort state must persist across cancelTimeout().
   EXPECT_TRUE(ctranComm->testAbort());
+  EXPECT_EQ(ctranComm->getAbortInfo(), abortInfo);
 
   // No ALGO_ABORTED row — TERMINATE branch skips the marker.
   bool sawAlgoAborted = false;

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -223,9 +223,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         comm->logMetaData_.commHash);
     this->ctranTcpDm->cancelQueuedRecv(&notify->tcpDmReq);
 
-    auto _abort = comm->getAbort();
-    std::string _ctx =
-        _abort->isTimedOut() ? "comm aborted due to timeout" : "comm aborted";
+    std::string _ctx = comm->abortMessage();
     throw ctran::utils::Exception(
         _ctx,
         commRemoteError,
@@ -235,9 +233,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
   }
 
   [[noreturn]] void throwTcpDmRequestsAbort(size_t numRequests) {
-    auto _abort = comm->getAbort();
-    std::string _ctx =
-        _abort->isTimedOut() ? "comm aborted due to timeout" : "comm aborted";
+    std::string _ctx = comm->abortMessage();
     throw ctran::utils::Exception(
         _ctx,
         commRemoteError,
@@ -1180,10 +1176,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
 
   [[noreturn]] inline void throwCommAbortException(
       const std::string& abortContext) {
-    auto commAbort = comm->getAbort();
-    std::string message = commAbort->isTimedOut()
-        ? "comm aborted due to timeout"
-        : "comm aborted";
+    std::string message = comm->abortMessage();
     throw ctran::utils::Exception(
         message,
         commRemoteError,
@@ -1300,9 +1293,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     }
 
     if (comm->testAbort()) {
-      auto _abort = comm->getAbort();
-      std::string _ctx =
-          _abort->isTimedOut() ? "comm aborted due to timeout" : "comm aborted";
+      std::string _ctx = comm->abortMessage();
       throw ctran::utils::Exception(
           _ctx,
           commRemoteError,

--- a/comms/ctran/tests/CtranCommTest.cc
+++ b/comms/ctran/tests/CtranCommTest.cc
@@ -32,6 +32,45 @@ TEST(CtranCommTest, AbortAvailableAndEnabled) {
   EXPECT_TRUE(comm.testAbort());
 }
 
+TEST(CtranCommTest, AbortReasonAndContextAreForwarded) {
+  auto abort = comms::fault_tolerance::createAbort(/*enabled=*/true);
+  CtranComm comm(abort);
+  const std::string context{"collective\0failed", 17};
+
+  comm.setAbort(
+      comms::fault_tolerance::AbortInfo{
+          .reason = comms::fault_tolerance::AbortReason::INTERNAL_ERROR,
+          .context = context,
+      });
+
+  const auto abortInfo = comm.getAbortInfo();
+  ASSERT_TRUE(abortInfo.has_value());
+  EXPECT_EQ(
+      *abortInfo,
+      (comms::fault_tolerance::AbortInfo{
+          .reason = comms::fault_tolerance::AbortReason::INTERNAL_ERROR,
+          .context = context,
+      }));
+  EXPECT_EQ(
+      comm.abortMessage(),
+      "comm aborted reason=internal_error context=\"collective\\000failed\"");
+}
+
+TEST(CtranCommTest, AbortMessageEscapesContext) {
+  auto abort = comms::fault_tolerance::createAbort(/*enabled=*/true);
+  CtranComm comm(abort);
+
+  comm.setAbort(
+      comms::fault_tolerance::AbortInfo{
+          .reason = comms::fault_tolerance::AbortReason::NETWORK_ERROR,
+          .context = "peer=\"rank 1\"\\socket",
+      });
+
+  EXPECT_EQ(
+      comm.abortMessage(),
+      "comm aborted reason=network_error context=\"peer=\\\"rank 1\\\"\\\\socket\"");
+}
+
 TEST(CtranCommTest, AbortAvailableAndEnabledDoubleAbort) {
   auto abort = comms::fault_tolerance::createAbort(/*enabled=*/true);
   CtranComm comm(abort);

--- a/comms/ctran/utils/AbortUtils.h
+++ b/comms/ctran/utils/AbortUtils.h
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include "comms/common/fault_tolerance/AbortTypes.h"
+#include "comms/ctran/utils/Exception.h"
+
+namespace ctran::utils {
+
+inline comms::fault_tolerance::AbortReason abortReason(commResult_t result) {
+  using comms::fault_tolerance::AbortReason;
+
+  switch (result) {
+    case commRemoteError:
+      // commRemoteError is CTRAN's legacy bucket for remote/transport
+      // failures. Callers with a more specific local cause should construct
+      // AbortInfo directly instead of using this coarse mapping.
+      return AbortReason::NETWORK_ERROR;
+    case commTimeout:
+      return AbortReason::TIMED_OUT;
+    case commUserAbort:
+      return AbortReason::ABORTED;
+    default:
+      return AbortReason::INTERNAL_ERROR;
+  }
+}
+
+inline comms::fault_tolerance::AbortInfo abortInfo(
+    const Exception& exception,
+    std::string context) {
+  return {
+      .reason = abortReason(exception.result()),
+      .context = std::move(context),
+  };
+}
+
+} // namespace ctran::utils

--- a/comms/ctran/utils/AsyncError.h
+++ b/comms/ctran/utils/AsyncError.h
@@ -2,8 +2,10 @@
 
 #pragma once
 
+#include <folly/String.h>
 #include <folly/Synchronized.h>
 
+#include "comms/ctran/utils/AbortUtils.h"
 #include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/Exception.h"
 
@@ -47,7 +49,17 @@ namespace ctran::utils {
           opCount,                                                            \
           comm->logMetaData_.rank,                                            \
           comm->logMetaData_.commHash);                                       \
-      comm->setAbort();                                                       \
+      comm->setAbort(                                                         \
+          comms::fault_tolerance::AbortInfo{                                  \
+              .reason = ctran::utils::abortReason(e.result()),                \
+              .context = fmt::format(                                         \
+                  "op_type={} op_count={} rank={} comm_hash={} error=\"{}\"", \
+                  opType,                                                     \
+                  opCount,                                                    \
+                  comm->logMetaData_.rank,                                    \
+                  comm->logMetaData_.commHash,                                \
+                  folly::cEscape<std::string>(e.what())),                     \
+          });                                                                 \
     } else {                                                                  \
       throw;                                                                  \
     }                                                                         \
@@ -60,10 +72,9 @@ namespace ctran::utils {
     CTRAN_ASYNC_ERR_HANDLE_IMPL_FAULT_TOLERANCE(comm, e, opType, opCount); \
   } catch (const std::runtime_error& e) {                                  \
     /*TODO: replace remaining runtime_error with Exception */              \
-    /*TODO(T238821628): improve from simple commRemoteError */             \
     CTRAN_ASYNC_ERR_HANDLE_IMPL_FAULT_TOLERANCE(                           \
         comm,                                                              \
-        ctran::utils::Exception(e.what(), commRemoteError),                \
+        ctran::utils::Exception(e.what(), commInternalError),              \
         opType,                                                            \
         opCount);                                                          \
   }

--- a/comms/ctran/utils/tests/AsyncErrorUT.cc
+++ b/comms/ctran/utils/tests/AsyncErrorUT.cc
@@ -3,6 +3,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/utils/AsyncError.h"
 #include "comms/ctran/utils/Exception.h"
@@ -15,6 +17,25 @@ class AsyncErrorTest : public ::testing::Test {
   void SetUp() override {}
   void TearDown() override {}
 };
+
+void expectFaultToleranceAbortReason(
+    commResult_t result,
+    comms::fault_tolerance::AbortReason expectedReason) {
+  auto comm = std::make_unique<CtranComm>(
+      comms::fault_tolerance::createAbort(/*enabled=*/true));
+  CTRAN_ASYNC_ERR_GUARD_FAULT_TOLERANCE(
+      comm, { throw ::ctran::utils::Exception("UT error", result); }, -1, 0);
+
+  const auto abortInfo = comm->getAbortInfo();
+  ASSERT_TRUE(abortInfo.has_value());
+  EXPECT_EQ(abortInfo->reason, expectedReason);
+  EXPECT_THAT(
+      abortInfo->context,
+      ::testing::AllOf(
+          ::testing::HasSubstr("op_type=-1"),
+          ::testing::HasSubstr("op_count=0"),
+          ::testing::HasSubstr("UT error")));
+}
 
 TEST(CtranAsyncErrorTest, SetAndGet) {
   constexpr auto numThreads = 10;
@@ -81,12 +102,32 @@ TEST(AsyncErrorTest, FaultToleranceDisabled) {
 }
 
 TEST(AsyncErrorTest, FaultToleranceEnabled) {
+  expectFaultToleranceAbortReason(
+      commRemoteError, comms::fault_tolerance::AbortReason::NETWORK_ERROR);
+  expectFaultToleranceAbortReason(
+      commTimeout, comms::fault_tolerance::AbortReason::TIMED_OUT);
+  expectFaultToleranceAbortReason(
+      commUserAbort, comms::fault_tolerance::AbortReason::ABORTED);
+  expectFaultToleranceAbortReason(
+      commInternalError, comms::fault_tolerance::AbortReason::INTERNAL_ERROR);
+}
+
+TEST(AsyncErrorTest, FaultToleranceEnabledRuntimeErrorRecordsInternalAbort) {
   auto comm = std::make_unique<CtranComm>(
       comms::fault_tolerance::createAbort(/*enabled=*/true));
+
   CTRAN_ASYNC_ERR_GUARD_FAULT_TOLERANCE(
-      comm,
-      { throw ::ctran::utils::Exception("UT error", commRemoteError); },
-      -1,
-      0);
-  EXPECT_TRUE(comm->testAbort());
+      comm, { throw std::runtime_error("UT runtime error"); }, -1, 0);
+
+  const auto abortInfo = comm->getAbortInfo();
+  ASSERT_TRUE(abortInfo.has_value());
+  EXPECT_EQ(
+      abortInfo->reason, comms::fault_tolerance::AbortReason::INTERNAL_ERROR);
+  EXPECT_THAT(
+      abortInfo->context,
+      ::testing::AllOf(
+          ::testing::HasSubstr("op_type=-1"),
+          ::testing::HasSubstr("op_count=0"),
+          ::testing::HasSubstr("UT runtime error"),
+          ::testing::HasSubstr("commInternalError")));
 }


### PR DESCRIPTION
Summary: Forward structured abort metadata through CTRAN and retain the winning reason during GPE cleanup. Classify CTRAN-IB socket failures and exception-driven aborts, attach diagnostic context, and surface that context in existing abort errors and profiler messages.

Reviewed By: saifhhasan, Scusemua

Differential Revision: D115748771


