### PR TITLE
Add A=4 single-group sharded-relay tests + fix perf-bench A=4 reduce-scatter helper sizing (#3683)

### DIFF
--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
@@ -488,15 +488,47 @@ static ncclResult_t shardedRelayAllGatherFlat(
   const int A = nActiveRanksPerGroup;
   const int H = numHelpers;
 
-  // Tuned constants (MI350X, A=4, fp16, BM-FM sizes):
-  //   - direct (intra, 1-hop) share = 429/1000 (~3/7); offload (2-hop via
-  //     helpers) is the rest. Balances the intra direct link against the
-  //     helper->dest link.
-  //   - pipeline depth P = 16 overlap stages: enough to overlap the
-  //     helper-forward and active-send hops without per-superstep launch
-  //     overhead dominating (P=32 regressed).
-  constexpr size_t kOffPermille = 1000 - 429;
-  constexpr int P = 16;
+  // Largest per-group message drives the size-adaptive tuning below. All groups
+  // march through the same superstep count to keep XGMI traffic phase-synced,
+  // so tune off the max.
+  size_t maxSc = 0;
+  for (int g = 0; g < nGroups; g++) {
+    if (sendCounts[g] > maxSc) {
+      maxSc = sendCounts[g];
+    }
+  }
+  const size_t maxBytes = maxSc * elementSize;
+
+  // Size-adaptive helper offload. The offload (2-hop active->helper->active)
+  // share spreads traffic across otherwise-idle cross links and is a bandwidth
+  // win only at large sizes, but it costs an extra group boundary + a hop of
+  // latency. Below the threshold, disable it: the kernel degenerates to a
+  // single-group pure-direct all-gather (each active rank exchanges its shard
+  // directly with the other A-1 active ranks, helpers idle) -- the same
+  // minimal-latency shape as all-to-all.
+  //
+  // The crossover depends on cross-link contention: a fused multi-group call
+  // runs all groups phase-synced, so the offload cross links contend with the
+  // other groups and only pay off at the very top end (>=256 MB); an
+  // independent single-group call has those cross links free, so offload pays
+  // off ~2x earlier (>=128 MB). Measured on MI350X (A=4, bf16, 8 GPUs): fused
+  // offload ties/loses to pure-direct until 256 MB (1.03x @512MB), while
+  // independent offload wins from 135 MB (1.10x) -- so cross over per-scenario.
+  // Above the threshold the direct share is 429/1000 (~3/7), balancing the
+  // intra direct link against the helper->dest link.
+  const size_t kOffloadMinBytes = (nGroups > 1)
+      ? (static_cast<size_t>(256) << 20) // fused: >= 256 MB
+      : (static_cast<size_t>(128) << 20); // independent: >= 128 MB
+  const bool useOffload = (H > 0) && (maxBytes >= kOffloadMinBytes);
+  const size_t kOffPermille = useOffload ? (1000 - 429) : 0;
+
+  // Pipeline depth. Only the offload path has a helper->active forward hop to
+  // overlap against the next active->helper scatter hop; the pure-direct path
+  // is a single group. In the offload regime the superstep loop runs P+1
+  // ncclGroup boundaries (each ~25us of fixed launch+handshake tax); at these
+  // large sizes the deep pipeline (P=16; P=32 regressed) amortizes that tax
+  // against the per-slice transfer.
+  const int P = useOffload ? 16 : 1;
 
   // Per-group geometry (same as the flat path): cs = per-source helper chunk
   // (128-aligned); directSz absorbs the remainder so directSz + H*cs == sc.
@@ -550,8 +582,21 @@ static ncclResult_t shardedRelayAllGatherFlat(
         stream);
   }
 
-  // Supersteps 0..P (one ncclGroup each).
-  for (int k = 0; k <= P; k++) {
+  // When offload is disabled (small messages), csArr is all zero and every
+  // forward stage is a no-op, so the loop only needs the P direct-send
+  // supersteps -- drop the trailing forward-only superstep to save one
+  // boundary.
+  bool anyOffload = false;
+  for (int g = 0; g < nGroups; g++) {
+    if (csArr[g] > 0) {
+      anyOffload = true;
+      break;
+    }
+  }
+  const int lastK = anyOffload ? P : (P - 1);
+
+  // Supersteps 0..lastK (one ncclGroup each).
+  for (int k = 0; k <= lastK; k++) {
     NCCLCHECK(ncclGroupStart());
     for (int g = 0; g < nGroups; g++) {
       if (sendCounts[g] == 0)
@@ -774,7 +819,29 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
   }
 
   ncclResult_t r;
-  if (nActiveRanksPerGroup == 2) {
+  // Size-adaptive routing for A==2. The 2Active relay wins on bandwidth at
+  // large sizes, but at small sizes it is latency-bound; the A-generic Flat
+  // path (with its own small-size pure-direct mode) does a single-group direct
+  // shard exchange with minimal latency. Route small A==2 to Flat, large to
+  // 2Active. maxBytes (sendCount*elemSize) equals the bench per-rank input
+  // shard label.
+  size_t maxScAg = 0;
+  for (int g = 0; g < nGroups; g++) {
+    if (sendCounts[g] > maxScAg) {
+      maxScAg = sendCounts[g];
+    }
+  }
+  const size_t maxBytesAg = maxScAg * elementSize;
+  // Crossover measured MI350X (bf16, 8 GPUs): fused 2Active relay overtakes
+  // Flat at ~4.5 MB (Flat wins the small end, 576 KB 0.75x->1.31x), independent
+  // at ~13.5 MB (0.34->0.51 @4KB). Independent has no cross-group contention so
+  // direct holds on longer. Cross over below each.
+  const size_t kAgA2PureDirectMaxBytes = (nGroups > 1)
+      ? (static_cast<size_t>(2) << 20) // fused: < 2 MB
+      : (static_cast<size_t>(12) << 20); // independent: < 12 MB
+  const bool agA2UseFlat =
+      (nActiveRanksPerGroup == 2) && (maxBytesAg < kAgA2PureDirectMaxBytes);
+  if (nActiveRanksPerGroup == 2 && !agA2UseFlat) {
     r = shardedRelayAllGather2Active(
         sendBuffs2,
         recvBuffs2,
@@ -788,9 +855,8 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
         nGroups,
         elementSize);
   } else {
-    // A>2: bandwidth-optimal flat scatter->forward relay (the dual of
-    // reduce-scatter), pipelined to overlap the helper-forward and active-send
-    // hops.
+    // A>2, or small A==2: flat scatter->forward relay (dual of reduce-scatter)
+    // with a size-adaptive pure-direct small-size mode.
     r = shardedRelayAllGatherFlat(
         sendBuffs2,
         recvBuffs2,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
@@ -213,7 +213,8 @@ static ncclResult_t shardedRelayAllGather2Active(
   const int numChunks = numHelpers + 2;
 
   size_t chunkSizes[SHARDED_RELAY_MAX_GROUPS];
-  size_t relayTotals[SHARDED_RELAY_MAX_GROUPS]; // == direct chunk A's offset
+  size_t dirAOffsets[SHARDED_RELAY_MAX_GROUPS];
+  size_t dirASizes[SHARDED_RELAY_MAX_GROUPS];
   size_t dirBOffsets[SHARDED_RELAY_MAX_GROUPS];
   size_t dirBSizes[SHARDED_RELAY_MAX_GROUPS]; // absorbs the remainder
 
@@ -223,22 +224,27 @@ static ncclResult_t shardedRelayAllGather2Active(
     // Zero-count groups are skipped by every loop below.
     if (count == 0) {
       chunkSizes[g] = 0;
-      relayTotals[g] = 0;
+      dirAOffsets[g] = 0;
+      dirASizes[g] = 0;
       dirBOffsets[g] = 0;
       dirBSizes[g] = 0;
       continue;
     }
 
-    // A chunk size that rounds down to zero means the send buffer is too small
-    // to scatter; the caller should fall back to a regular all-gather.
     size_t chunkSize = count / numChunks;
     chunkSize = (chunkSize / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
-    if (chunkSize == 0) {
-      return ncclInvalidArgument;
-    }
     chunkSizes[g] = chunkSize;
-    relayTotals[g] = static_cast<size_t>(numHelpers) * chunkSize;
-    dirBOffsets[g] = relayTotals[g] + chunkSize;
+    if (chunkSize == 0) {
+      dirAOffsets[g] = 0;
+      dirASizes[g] = count / 2;
+      dirBOffsets[g] = dirASizes[g];
+      dirBSizes[g] = count - dirASizes[g];
+      continue;
+    }
+
+    dirAOffsets[g] = static_cast<size_t>(numHelpers) * chunkSize;
+    dirASizes[g] = chunkSize;
+    dirBOffsets[g] = dirAOffsets[g] + dirASizes[g];
     dirBSizes[g] = count - dirBOffsets[g];
   }
 
@@ -294,7 +300,7 @@ static ncclResult_t shardedRelayAllGather2Active(
       char* recvbuff = static_cast<char*>(recvBuffs[g]);
 
       // Scatter: chunk h of my sendBuff goes to helper h.
-      for (int h = 0; h < cfg.numHelpers; h++) {
+      for (int h = 0; h < cfg.numHelpers && chunkSize > 0; h++) {
         NCCLCHECK(ncclSend(
             sendbuff + static_cast<size_t>(h) * chunkSize * elementSize,
             chunkSize,
@@ -308,20 +314,20 @@ static ncclResult_t shardedRelayAllGather2Active(
       // gather slot never overlaps the send source, so this is safe in-place.
       int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
       NCCLCHECK(ncclSend(
-          sendbuff + relayTotals[g] * elementSize,
-          chunkSize,
+          sendbuff + dirAOffsets[g] * elementSize,
+          dirASizes[g],
           datatype,
           partner,
           comm,
           stream));
       NCCLCHECK(ncclRecv(
-          recvbuff + (gatherSlotOffset + relayTotals[g]) * elementSize,
-          chunkSize,
+          recvbuff + (gatherSlotOffset + dirAOffsets[g]) * elementSize,
+          dirASizes[g],
           datatype,
           partner,
           comm,
           stream));
-    } else {
+    } else if (chunkSize > 0) {
       // Helper: receive active rank a's chunk into slot a.
       char* helperBuf = static_cast<char*>(recvBuffs[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {
@@ -355,7 +361,7 @@ static ncclResult_t shardedRelayAllGather2Active(
     if (cfg.isActiveRank) {
       char* recvbuff = static_cast<char*>(recvBuffs[g]);
 
-      for (int h = 0; h < cfg.numHelpers; h++) {
+      for (int h = 0; h < cfg.numHelpers && chunkSize > 0; h++) {
         NCCLCHECK(ncclRecv(
             recvbuff +
                 (gatherSlotOffset + static_cast<size_t>(h) * chunkSize) *
@@ -383,7 +389,7 @@ static ncclResult_t shardedRelayAllGather2Active(
           partner,
           comm,
           stream));
-    } else {
+    } else if (chunkSize > 0) {
       const char* helperBuf = static_cast<const char*>(recvBuffs[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {
         NCCLCHECK(ncclSend(

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
@@ -810,7 +810,7 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
   // direct holds on longer. Cross over below each.
   const size_t kAgA2PureDirectMaxBytes = (nGroups > 1)
       ? (static_cast<size_t>(2) << 20) // fused: < 2 MB
-      : (static_cast<size_t>(4) << 20); // independent: < 4 MB
+      : (static_cast<size_t>(9) << 20); // independent: < 9 MB
   const bool agA2UseFlat =
       (nActiveRanksPerGroup == 2) && (maxBytesAg < kAgA2PureDirectMaxBytes);
   if (nActiveRanksPerGroup == 2 && !agA2UseFlat) {

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
@@ -1,0 +1,810 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "sharded_relay_all_gather.h"
+#include "comm.h"
+
+// GPU memory access alignment in elements for chunk size rounding.
+// Distinct from the CPU CACHE_LINE_SIZE (64 bytes) defined in comm.h
+// which is used for struct padding.
+static constexpr size_t CHUNK_ALIGN_ELEMENTS = 128;
+
+// The rank-config builder below is a deliberate copy of the file-local helper
+// in sharded_relay_allreduce.cc (also mirrored in the reduce-scatter and
+// all-to-all relays). It is file-local there, so it cannot be linked across
+// translation units; this TU re-declares its own copy in an anonymous namespace
+// to keep it internal and ODR-safe. All-gather performs no reduction, so NO
+// reduction kernels are used, and the relay paths land every byte directly in
+// recvBuff / the helper passthrough buffers (no working-buffer scratch).
+namespace {
+
+// Maximum number of helper ranks supported per group.
+constexpr int SHARDED_RELAY_MAX_HELPERS = 8;
+
+// Maximum number of active ranks per group. The relay schedule requires
+// nActiveRanks to be a power of two; supported values are 2 and 4 (on an 8-GPU
+// node this leaves 6 or 4 helpers respectively).
+constexpr int SHARDED_RELAY_MAX_ACTIVE = 8;
+
+// Returns true if v is a power of two (v >= 1).
+inline bool isPowerOfTwo(int v) {
+  return v > 0 && (v & (v - 1)) == 0;
+}
+
+/**
+ * Rank Configuration for Sharded Relay All-Gather
+ *
+ * Holds parsed active and helper rank information for a single group.
+ * Supports a power-of-two number of active ranks per group (2 or 4).
+ */
+struct ShardedRelayRankConfig {
+  int activeRanks[SHARDED_RELAY_MAX_ACTIVE]; // Active rank IDs (power of two)
+  int nActiveRanks; // Number of active ranks (2 or 4)
+  int helperRanks[SHARDED_RELAY_MAX_HELPERS]; // Helper rank IDs
+  int numHelpers; // Number of helper ranks
+  bool isActiveRank; // Is current rank active?
+  int myActiveIndex; // Index in activeRanks array (-1 if helper)
+  int myHelperIndex; // Index in helperRanks array (-1 if active)
+};
+
+/**
+ * Build rank configuration from provided active ranks array.
+ *
+ * Requires a power-of-two active-rank count in [2, SHARDED_RELAY_MAX_ACTIVE]
+ * (supported values: 2 and 4).
+ */
+bool buildShardedRelayRankConfig(
+    int nRanks,
+    int rank,
+    const int* activeRanksInput,
+    int nActiveRanksInput,
+    ShardedRelayRankConfig& config) {
+  config.nActiveRanks = 0;
+  config.numHelpers = 0;
+  config.isActiveRank = false;
+  config.myActiveIndex = -1;
+  config.myHelperIndex = -1;
+
+  // Validate input - require a power-of-two active-rank count in
+  // [2, SHARDED_RELAY_MAX_ACTIVE] (supported values: 2 and 4).
+  if (activeRanksInput == nullptr || nActiveRanksInput < 2 ||
+      nActiveRanksInput > SHARDED_RELAY_MAX_ACTIVE ||
+      !isPowerOfTwo(nActiveRanksInput)) {
+    return false;
+  }
+
+  // Copy active ranks and validate
+  for (int i = 0; i < nActiveRanksInput; i++) {
+    int rankId = activeRanksInput[i];
+    if (rankId >= 0 && rankId < nRanks) {
+      config.activeRanks[config.nActiveRanks++] = rankId;
+    }
+  }
+
+  // Validate: need exactly nActiveRanksInput valid active ranks
+  if (config.nActiveRanks != nActiveRanksInput) {
+    return false;
+  }
+
+  // Build list of helper ranks (all ranks NOT in activeRanks).
+  for (int r = 0; r < nRanks; r++) {
+    bool isActive = false;
+    for (int a = 0; a < config.nActiveRanks; a++) {
+      if (r == config.activeRanks[a]) {
+        isActive = true;
+        break;
+      }
+    }
+    if (!isActive) {
+      if (config.numHelpers >= SHARDED_RELAY_MAX_HELPERS) {
+        return false;
+      }
+      config.helperRanks[config.numHelpers++] = r;
+    }
+  }
+
+  // Validate: need at least 1 helper
+  if (config.numHelpers < 1) {
+    return false;
+  }
+
+  // Determine if this rank is active
+  for (int a = 0; a < config.nActiveRanks; a++) {
+    if (rank == config.activeRanks[a]) {
+      config.isActiveRank = true;
+      config.myActiveIndex = a;
+      break;
+    }
+  }
+
+  // For helpers, determine which chunk index this rank handles
+  if (!config.isActiveRank) {
+    for (int i = 0; i < config.numHelpers; i++) {
+      if (config.helperRanks[i] == rank) {
+        config.myHelperIndex = i;
+        break;
+      }
+    }
+  }
+  return true;
+}
+
+// All-gather only moves bytes, so it has no reduce kernels to dispatch on --
+// but the relay presents ONE supported type set across all four collectives,
+// and only these ten are exercised anywhere in it. Two concrete hazards make
+// this worth rejecting up front rather than trusting the caller:
+//   - ncclTypeSize() returns int -1 for a type it does not know, and the
+//     callers below store it in a `size_t elementSize`, turning it into
+//     SIZE_MAX rather than 0. Every subsequent count * elementSize and
+//     offset * elementSize then overflows into wild addresses.
+//   - ncclFloat8e4m3 / ncclFloat8e5m2 are valid NCCL types that size cleanly
+//     at 1 byte, so a range check against ncclNumTypes would admit them even
+//     though no relay collective has ever been exercised with them.
+bool isSupportedRelayDataType(ncclDataType_t datatype) {
+  switch (datatype) {
+    case ncclInt8:
+    case ncclUint8:
+    case ncclInt32:
+    case ncclUint32:
+    case ncclInt64:
+    case ncclUint64:
+    case ncclFloat16:
+    case ncclFloat:
+    case ncclDouble:
+    case ncclBfloat16:
+      return true;
+    default:
+      return false;
+  }
+}
+
+} // namespace
+
+/**
+ * Two-active sharded relay all-gather (original path), the dual of the 2-active
+ * reduce-scatter relay.
+ *
+ * Each group has exactly 2 active ranks; the logical collective is a 2-rank
+ * all-gather between them, accelerated by passthrough helpers that relay
+ * sharded chunks of each active rank's sendBuff (sendCounts[g] elements). There
+ * is NO reduction: helpers and active ranks only move data, so no kernels and
+ * no scratch buffers are required. This is byte-for-byte unchanged from the
+ * original implementation; the A>2 path lives in
+ * shardedRelayAllGatherFlat.
+ *
+ * Per active rank (index m, o = 1 - m), with sendCount = sendCounts[g]:
+ *   - sendBuff holds sendCount elements; recvBuff holds 2 x sendCount elements
+ *     (recvBuff[i x sendCount] receives the contribution from active index i).
+ *   - Diagonal: recvBuff[m x sendCount] = sendBuff.
+ *   - Gather: ship sendBuff to the other rank; receive the other rank's
+ *     sendBuff into recvBuff[o x sendCount].
+ *
+ * Both in-place and out-of-place are supported. In-place is detected when
+ * sendBuff == recvBuff + m x sendCount; in that case the diagonal copy is a
+ * no-op. No scratch is needed in either mode because the gather destination
+ * (slot o) never overlaps the send source (slot m).
+ */
+static ncclResult_t shardedRelayAllGather2Active(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* sendCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nGroups,
+    size_t elementSize) {
+  int numChunks = numHelpers + 1;
+
+  // =========================================================================
+  // CALCULATE PER-GROUP CHUNK SIZES (from the per-rank sendCount)
+  // =========================================================================
+  size_t chunkSizes[SHARDED_RELAY_MAX_GROUPS];
+  size_t lastChunkSizes[SHARDED_RELAY_MAX_GROUPS];
+  size_t directChunkOffsets[SHARDED_RELAY_MAX_GROUPS];
+  size_t directChunkSizes[SHARDED_RELAY_MAX_GROUPS];
+
+  for (int g = 0; g < nGroups; g++) {
+    size_t count = sendCounts[g];
+
+    // Skip groups with sendCount == 0; the per-phase loops below already check
+    // sendCounts[g] == 0 and bypass NCCL ops for those groups.
+    if (count == 0) {
+      chunkSizes[g] = 0;
+      lastChunkSizes[g] = 0;
+      directChunkOffsets[g] = 0;
+      directChunkSizes[g] = 0;
+      continue;
+    }
+
+    // Calculate chunk size (aligned to CHUNK_ALIGN_ELEMENTS). When the
+    // per-chunk size rounded down to CHUNK_ALIGN_ELEMENTS is zero, the send
+    // buffer is too small to scatter and the caller should fall back to a
+    // regular all-gather.
+    size_t chunkSize = count / numChunks;
+    chunkSize = (chunkSize / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
+    if (chunkSize == 0) {
+      return ncclInvalidArgument;
+    }
+    chunkSizes[g] = chunkSize;
+
+    // Calculate the size of the last chunk (absorbs the remainder)
+    size_t totalChunkedElements = static_cast<size_t>(numChunks) * chunkSize;
+    size_t lastChunkSize = chunkSize;
+    if (totalChunkedElements < count) {
+      lastChunkSize = chunkSize + (count - totalChunkedElements);
+    }
+    lastChunkSizes[g] = lastChunkSize;
+
+    // Direct exchange chunk info (within the sendCount-element send buffer)
+    int directChunkIndex = numHelpers;
+    directChunkOffsets[g] = static_cast<size_t>(directChunkIndex) * chunkSize;
+    directChunkSizes[g] = lastChunkSize;
+  }
+
+  // For an active rank, compute its slot offsets and detect in-place.
+  size_t gatherSlotOffset = 0; // recvBuff slot for the other rank (o x count)
+  size_t diagSlotOffset = 0; // recvBuff slot for my own data (m x count)
+  bool isInPlace = false;
+  if (myActiveGroup >= 0 && sendCounts[myActiveGroup] > 0) {
+    const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
+    size_t sendCount = sendCounts[myActiveGroup];
+    int otherActiveIndex = 1 - cfg.myActiveIndex;
+    diagSlotOffset = static_cast<size_t>(cfg.myActiveIndex) * sendCount;
+    gatherSlotOffset = static_cast<size_t>(otherActiveIndex) * sendCount;
+
+    // In-place when sendBuff aliases its own slot of recvBuff
+    // (sendBuff == recvBuff + m x sendCount).
+    const char* mySlotStart =
+        static_cast<const char*>(recvBuffs[myActiveGroup]) +
+        diagSlotOffset * elementSize;
+    isInPlace =
+        (static_cast<const void*>(sendBuffs[myActiveGroup]) ==
+         static_cast<const void*>(mySlotStart));
+  }
+
+  // =========================================================================
+  // PHASE 1 (active->helpers): active ranks scatter their sendBuff chunks
+  // =========================================================================
+  // Helpers receive from each active rank into offset-based slots:
+  //   slot a at offset (a x chunkSize) holds data from active rank a.
+  NCCLCHECK(ncclGroupStart());
+
+  for (int g = 0; g < nGroups; g++) {
+    if (sendCounts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    const void* sendbuff = sendBuffs[g];
+    void* recvbuff = recvBuffs[g];
+    size_t chunkSize = chunkSizes[g];
+
+    if (cfg.isActiveRank) {
+      // Active rank: send chunk h of my sendBuff to helper h
+      for (int h = 0; h < cfg.numHelpers; h++) {
+        int helperRank = cfg.helperRanks[h];
+        size_t chunkOffset = static_cast<size_t>(h) * chunkSize;
+
+        NCCLCHECK(ncclSend(
+            static_cast<const char*>(sendbuff) + chunkOffset * elementSize,
+            chunkSize,
+            datatype,
+            helperRank,
+            comm,
+            stream));
+      }
+    } else {
+      // Helper rank: receive from each active rank into slot a
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        int activeRank = cfg.activeRanks[a];
+        size_t helperOffset = static_cast<size_t>(a) * chunkSize;
+
+        NCCLCHECK(ncclRecv(
+            static_cast<char*>(recvbuff) + helperOffset * elementSize,
+            chunkSize,
+            datatype,
+            activeRank,
+            comm,
+            stream));
+      }
+    }
+  }
+
+  NCCLCHECK(ncclGroupEnd());
+
+  // =========================================================================
+  // PHASE 2 (helpers->active, batched): Passthrough forward
+  // =========================================================================
+  // Each helper sends slot 0 (a0's data) -> a1 and slot 1 (a1's data) -> a0.
+  // The active rank receives all numHelpers chunks DIRECTLY into the OTHER
+  // rank's slot of recvBuff (recvBuff[o x sendCount + h x chunkSize]). No
+  // reduction and no relay scratch are required.
+  NCCLCHECK(ncclGroupStart());
+
+  for (int g = 0; g < nGroups; g++) {
+    if (sendCounts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    void* recvbuff = recvBuffs[g];
+    size_t chunkSize = chunkSizes[g];
+
+    if (!cfg.isActiveRank) {
+      // Helper for group g: forward each slot to the OTHER active rank.
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        int targetActive = cfg.activeRanks[1 - a];
+        NCCLCHECK(ncclSend(
+            static_cast<const char*>(recvbuff) +
+                static_cast<size_t>(a) * chunkSize * elementSize,
+            chunkSize,
+            datatype,
+            targetActive,
+            comm,
+            stream));
+      }
+    } else {
+      // Active rank: receive forwarded data from each helper directly into the
+      // other rank's slot of recvBuff at offset gatherSlotOffset + h x
+      // chunkSize.
+      for (int h = 0; h < cfg.numHelpers; h++) {
+        int helperRank = cfg.helperRanks[h];
+        size_t dstOffset =
+            gatherSlotOffset + static_cast<size_t>(h) * chunkSize;
+        NCCLCHECK(ncclRecv(
+            static_cast<char*>(recvbuff) + dstOffset * elementSize,
+            chunkSize,
+            datatype,
+            helperRank,
+            comm,
+            stream));
+      }
+    }
+  }
+
+  NCCLCHECK(ncclGroupEnd());
+
+  // =========================================================================
+  // PHASE 3 (diagonal copy): recvBuff[m x sendCount] = sendBuff
+  // =========================================================================
+  // Place this rank's own contribution into its slot. In-place already has it
+  // (sendBuff aliases recvBuff[m x sendCount]), so the copy is skipped.
+  if (myActiveGroup >= 0 && sendCounts[myActiveGroup] > 0 && !isInPlace) {
+    const void* sendbuff = sendBuffs[myActiveGroup];
+    void* recvbuff = recvBuffs[myActiveGroup];
+    size_t sendBytes = sendCounts[myActiveGroup] * elementSize;
+    cudaMemcpyAsync(
+        static_cast<char*>(recvbuff) + diagSlotOffset * elementSize,
+        sendbuff,
+        sendBytes,
+        cudaMemcpyDeviceToDevice,
+        stream);
+  }
+
+  // =========================================================================
+  // PHASE 4 (active<->active): Direct exchange of the last chunk
+  // =========================================================================
+  // Active ranks exchange the direct chunk of their sendBuff; it is received
+  // directly into the other rank's slot of recvBuff. The gather destination
+  // (slot o) never overlaps the send source (slot m), so this is safe in-place.
+  NCCLCHECK(ncclGroupStart());
+
+  for (int g = 0; g < nGroups; g++) {
+    if (sendCounts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+
+    if (cfg.isActiveRank) {
+      const void* sendbuff = sendBuffs[g];
+      void* recvbuff = recvBuffs[g];
+      size_t directChunkOffset = directChunkOffsets[g];
+      size_t directChunkSize = directChunkSizes[g];
+      size_t recvDirectOffset = gatherSlotOffset + directChunkOffset;
+
+      // Send my direct chunk to all other active ranks
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        if (a == cfg.myActiveIndex)
+          continue;
+        int otherActiveRank = cfg.activeRanks[a];
+
+        NCCLCHECK(ncclSend(
+            static_cast<const char*>(sendbuff) +
+                directChunkOffset * elementSize,
+            directChunkSize,
+            datatype,
+            otherActiveRank,
+            comm,
+            stream));
+      }
+
+      // Receive direct chunks from all other active ranks directly into the
+      // other rank's slot of recvBuff.
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        if (a == cfg.myActiveIndex)
+          continue;
+        int otherActiveRank = cfg.activeRanks[a];
+
+        NCCLCHECK(ncclRecv(
+            static_cast<char*>(recvbuff) + recvDirectOffset * elementSize,
+            directChunkSize,
+            datatype,
+            otherActiveRank,
+            comm,
+            stream));
+      }
+    }
+  }
+
+  NCCLCHECK(ncclGroupEnd());
+
+  // Phase 5: none. All-gather performs no reduction; the gathered and diagonal
+  // slots are already in place in recvBuff.
+  return ncclSuccess;
+}
+
+/**
+ * All-gather for > 2 active ranks (flat scatter->forward relay, pipelined; the
+ * dual of the reduce-scatter). Every active SOURCE delivers its sc to every
+ * other active DEST's recvBuff slot: a DIRECT share over the 1-hop intra links
+ * (active<->active), and an OFFLOAD share 2-hop through the idle helper GPUs
+ * (active->helper, then helper broadcasts to the dests). The offload is sliced
+ * into P stages and software-pipelined so the helper-forward of stage i
+ * (helper->active) overlaps the active-send of stage i+1 (active->helper)
+ * within one ncclGroup, recruiting the otherwise-idle helper links.
+ *
+ * Superstep schedule (one ncclGroup each; P+1 supersteps):
+ *   k = 0:        S_0                  (send stage for slice 0 only)
+ *   k = 1..P-1:   F_{k-1}  ||  S_k     (forward slice k-1 + send slice k)
+ *   k = P:        F_{P-1}              (forward stage for last slice)
+ * The group boundary between superstep k-1 and k guarantees S_{k-1} completed
+ * before F_{k-1} reads it. Within a superstep, F_{k-1} reads helper slot
+ * sub-slice k-1 while S_k writes sub-slice k (disjoint), so there is no hazard,
+ * and every superstep is one ncclGroup with a fully matched send/recv set (no
+ * deadlock). Slicing is plain even division (last part absorbs the remainder);
+ * all slice sizes derive only from sendCounts[g], so they are identical across
+ * ranks.
+ *
+ * Helper scratch = recvBuffs[g] for helper groups; it holds one offload chunk
+ * of `cs` per active source (A*cs <= sc elements). Both in-place (sendBuff ==
+ * recvBuff + m*sc) and out-of-place are supported.
+ */
+static ncclResult_t shardedRelayAllGatherFlat(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* sendCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nActiveRanksPerGroup,
+    int nGroups,
+    size_t elementSize) {
+  const int A = nActiveRanksPerGroup;
+  const int H = numHelpers;
+
+  // Tuned constants (MI350X, A=4, fp16, BM-FM sizes):
+  //   - direct (intra, 1-hop) share = 429/1000 (~3/7); offload (2-hop via
+  //     helpers) is the rest. Balances the intra direct link against the
+  //     helper->dest link.
+  //   - pipeline depth P = 16 overlap stages: enough to overlap the
+  //     helper-forward and active-send hops without per-superstep launch
+  //     overhead dominating (P=32 regressed).
+  constexpr size_t kOffPermille = 1000 - 429;
+  constexpr int P = 16;
+
+  // Per-group geometry (same as the flat path): cs = per-source helper chunk
+  // (128-aligned); directSz absorbs the remainder so directSz + H*cs == sc.
+  size_t csArr[SHARDED_RELAY_MAX_GROUPS];
+  size_t directArr[SHARDED_RELAY_MAX_GROUPS];
+  for (int g = 0; g < nGroups; g++) {
+    size_t sc = sendCounts[g];
+    if (sc == 0) {
+      csArr[g] = 0;
+      directArr[g] = 0;
+      continue;
+    }
+    size_t offTarget = (sc * kOffPermille) / 1000;
+    size_t cs = (H > 0) ? (offTarget / static_cast<size_t>(H)) : 0;
+    cs = (cs / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
+    csArr[g] = cs;
+    directArr[g] = sc - static_cast<size_t>(H) * cs;
+  }
+
+  // In-place detection for the diagonal copy.
+  bool isInPlace = false;
+  size_t myDiagOffset = 0;
+  if (myActiveGroup >= 0 && sendCounts[myActiveGroup] > 0) {
+    const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
+    myDiagOffset =
+        static_cast<size_t>(cfg.myActiveIndex) * sendCounts[myActiveGroup];
+    const char* mySlot = static_cast<const char*>(recvBuffs[myActiveGroup]) +
+        myDiagOffset * elementSize;
+    isInPlace =
+        (static_cast<const void*>(sendBuffs[myActiveGroup]) ==
+         static_cast<const void*>(mySlot));
+  }
+
+  // Even-division slice geometry (last slice absorbs the remainder).
+  auto sliceOff = [P](size_t total, int k) -> size_t {
+    return static_cast<size_t>(k) * (total / static_cast<size_t>(P));
+  };
+  auto sliceLen = [P](size_t total, int k) -> size_t {
+    size_t base = total / static_cast<size_t>(P);
+    return (k == P - 1) ? (total - static_cast<size_t>(k) * base) : base;
+  };
+
+  // Diagonal: recvBuff[m*sc] = sendBuff.
+  if (myActiveGroup >= 0 && sendCounts[myActiveGroup] > 0 && !isInPlace) {
+    cudaMemcpyAsync(
+        static_cast<char*>(recvBuffs[myActiveGroup]) +
+            myDiagOffset * elementSize,
+        sendBuffs[myActiveGroup],
+        sendCounts[myActiveGroup] * elementSize,
+        cudaMemcpyDeviceToDevice,
+        stream);
+  }
+
+  // Supersteps 0..P (one ncclGroup each).
+  for (int k = 0; k <= P; k++) {
+    NCCLCHECK(ncclGroupStart());
+    for (int g = 0; g < nGroups; g++) {
+      if (sendCounts[g] == 0)
+        continue;
+      const ShardedRelayRankConfig& cfg = configs[g];
+      size_t sc = sendCounts[g];
+      size_t cs = csArr[g];
+      size_t directSz = directArr[g];
+
+      // ---- S_k: send stage for slice k (active->helper + active<->active)
+      // ----
+      if (k < P) {
+        size_t dOff = sliceOff(directSz, k);
+        size_t dLen = sliceLen(directSz, k);
+        size_t cOff = sliceOff(cs, k);
+        size_t cLen = sliceLen(cs, k);
+        if (cfg.isActiveRank) {
+          const char* sendbuff = static_cast<const char*>(sendBuffs[g]);
+          char* recvbuff = static_cast<char*>(recvBuffs[g]);
+          int m = cfg.myActiveIndex;
+          // Direct slice k: send to each dest, recv from each source (same
+          // group -> csz==0-safe).
+          if (dLen > 0) {
+            for (int d = 0; d < A; d++) {
+              if (d == m)
+                continue;
+              NCCLCHECK(ncclSend(
+                  sendbuff + dOff * elementSize,
+                  dLen,
+                  datatype,
+                  cfg.activeRanks[d],
+                  comm,
+                  stream));
+            }
+            for (int s = 0; s < A; s++) {
+              if (s == m)
+                continue;
+              NCCLCHECK(ncclRecv(
+                  recvbuff + (static_cast<size_t>(s) * sc + dOff) * elementSize,
+                  dLen,
+                  datatype,
+                  cfg.activeRanks[s],
+                  comm,
+                  stream));
+            }
+          }
+          // Offload sub-slice k: send to each helper once.
+          if (cs > 0 && cLen > 0) {
+            for (int h = 0; h < cfg.numHelpers; h++) {
+              NCCLCHECK(ncclSend(
+                  sendbuff +
+                      (directSz + static_cast<size_t>(h) * cs + cOff) *
+                          elementSize,
+                  cLen,
+                  datatype,
+                  cfg.helperRanks[h],
+                  comm,
+                  stream));
+            }
+          }
+        } else if (cs > 0 && cLen > 0) {
+          // Helper: recv offload sub-slice k from each source into slot s.
+          char* hbuff = static_cast<char*>(recvBuffs[g]);
+          for (int s = 0; s < cfg.nActiveRanks; s++) {
+            NCCLCHECK(ncclRecv(
+                hbuff + (static_cast<size_t>(s) * cs + cOff) * elementSize,
+                cLen,
+                datatype,
+                cfg.activeRanks[s],
+                comm,
+                stream));
+          }
+        }
+      }
+
+      // ---- F_{k-1}: forward stage for slice k-1 (helper->active) ----
+      if (k >= 1 && cs > 0) {
+        int kf = k - 1;
+        size_t cOffF = sliceOff(cs, kf);
+        size_t cLenF = sliceLen(cs, kf);
+        if (cLenF > 0) {
+          if (cfg.isActiveRank) {
+            char* recvbuff = static_cast<char*>(recvBuffs[g]);
+            int m = cfg.myActiveIndex;
+            for (int h = 0; h < cfg.numHelpers; h++) {
+              for (int s = 0; s < A; s++) {
+                if (s == m)
+                  continue;
+                NCCLCHECK(ncclRecv(
+                    recvbuff +
+                        (static_cast<size_t>(s) * sc + directSz +
+                         static_cast<size_t>(h) * cs + cOffF) *
+                            elementSize,
+                    cLenF,
+                    datatype,
+                    cfg.helperRanks[h],
+                    comm,
+                    stream));
+              }
+            }
+          } else {
+            const char* hbuff = static_cast<const char*>(recvBuffs[g]);
+            for (int s = 0; s < cfg.nActiveRanks; s++) {
+              for (int d = 0; d < A; d++) {
+                if (d == s)
+                  continue;
+                NCCLCHECK(ncclSend(
+                    hbuff + (static_cast<size_t>(s) * cs + cOffF) * elementSize,
+                    cLenF,
+                    datatype,
+                    cfg.activeRanks[d],
+                    comm,
+                    stream));
+              }
+            }
+          }
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+  }
+
+  return ncclSuccess;
+}
+
+/**
+ * Fused Multi-Group Sharded Relay All-Gather.
+ *
+ * Executes multiple sharded relay all-gathers in one fused call, phase-synced
+ * across all groups so XGMI links carry unidirectional traffic. Helpers are
+ * pure passthrough. Each rank is ACTIVE for exactly one group and a HELPER for
+ * the others. Both in-place and out-of-place are supported.
+ *
+ * nActiveRanksPerGroup must be a power of two (2 or 4): A==2 uses the original
+ * 2-active path; A>2 uses the bandwidth-optimal flat scatter->forward path.
+ */
+HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* sendCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const int* const* allActiveRanks,
+    int nActiveRanksPerGroup,
+    int nGroups) {
+  int nRanks, rank;
+  NCCLCHECK(ncclCommCount(comm, &nRanks));
+  NCCLCHECK(ncclCommUserRank(comm, &rank));
+
+  // Validate every argument before touching sendCounts: the all-zero scan
+  // below indexes sendCounts[0..nGroups), so a null pointer or an out-of-range
+  // nGroups has to be rejected first. Bounds-checking nGroups up here also
+  // means nGroups <= 0 reports ncclInvalidArgument rather than skipping the
+  // scan entirely and returning ncclSuccess.
+  if (nGroups < 1 || nGroups > SHARDED_RELAY_MAX_GROUPS) {
+    return ncclInvalidArgument;
+  }
+
+  if (recvBuffs == nullptr || allActiveRanks == nullptr ||
+      sendCounts == nullptr || sendBuffs == nullptr) {
+    return ncclInvalidArgument;
+  }
+
+  // Require a power-of-two active-rank count (>= 2) for the XOR schedule.
+  if (nActiveRanksPerGroup < 2 || !isPowerOfTwo(nActiveRanksPerGroup)) {
+    return ncclInvalidArgument;
+  }
+
+  if (!isSupportedRelayDataType(datatype)) {
+    return ncclInvalidArgument;
+  }
+
+  // Check if all sendCounts are zero
+  bool allZero = true;
+  for (int g = 0; g < nGroups; g++) {
+    if (sendCounts[g] != 0) {
+      allZero = false;
+      break;
+    }
+  }
+  if (allZero) {
+    return ncclSuccess;
+  }
+
+  size_t elementSize = ncclTypeSize(datatype);
+
+  // =========================================================================
+  // BUILD RANK CONFIGURATION FOR ALL GROUPS
+  // =========================================================================
+  ShardedRelayRankConfig configs[SHARDED_RELAY_MAX_GROUPS];
+  int myActiveGroup = -1; // Which group is this rank active for?
+
+  for (int g = 0; g < nGroups; g++) {
+    if (!buildShardedRelayRankConfig(
+            nRanks,
+            rank,
+            allActiveRanks[g],
+            nActiveRanksPerGroup,
+            configs[g])) {
+      return ncclInvalidArgument;
+    }
+    if (configs[g].isActiveRank) {
+      myActiveGroup = g;
+    }
+  }
+
+  // All groups should have the same number of helpers (same chunk structure)
+  int numHelpers = configs[0].numHelpers;
+
+  // Build per-group buffer arrays for the unchanged kernels. Helper groups use
+  // their scratch (recvBuffs[g]); the active group uses the caller's contiguous
+  // input/output buffers directly. All-gather may be in-place (sendBuffs[g]
+  // aliases recvBuffs[g] + myActiveIndex*sendCount) or out-of-place.
+  const void* sendBuffs2[SHARDED_RELAY_MAX_GROUPS];
+  void* recvBuffs2[SHARDED_RELAY_MAX_GROUPS];
+  for (int g = 0; g < nGroups; g++) {
+    sendBuffs2[g] = sendBuffs[g];
+    recvBuffs2[g] = recvBuffs[g];
+  }
+
+  ncclResult_t r;
+  if (nActiveRanksPerGroup == 2) {
+    r = shardedRelayAllGather2Active(
+        sendBuffs2,
+        recvBuffs2,
+        sendCounts,
+        datatype,
+        comm,
+        stream,
+        configs,
+        myActiveGroup,
+        numHelpers,
+        nGroups,
+        elementSize);
+  } else {
+    // A>2: bandwidth-optimal flat scatter->forward relay (the dual of
+    // reduce-scatter), pipelined to overlap the helper-forward and active-send
+    // hops.
+    r = shardedRelayAllGatherFlat(
+        sendBuffs2,
+        recvBuffs2,
+        sendCounts,
+        datatype,
+        comm,
+        stream,
+        configs,
+        myActiveGroup,
+        numHelpers,
+        nActiveRanksPerGroup,
+        nGroups,
+        elementSize);
+  }
+
+  return r;
+}

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
@@ -201,52 +201,45 @@ static ncclResult_t shardedRelayAllGather2Active(
     int numHelpers,
     int nGroups,
     size_t elementSize) {
-  int numChunks = numHelpers + 1;
+  // =========================================================================
+  // CHUNK GEOMETRY: numHelpers relayed chunks + TWO direct chunks
+  // =========================================================================
+  // The active<->active link is idle while the relay scatter and forward run on
+  // the cross links, so instead of a third comm group for a single direct
+  // chunk, one direct chunk rides along with each relay group. With numChunks =
+  // numHelpers + 2 every link carries exactly one chunk per direction per
+  // group, making the critical path 2*sendCount/numChunks instead of the
+  // 3*sendCount/(numHelpers+1) of a separate direct phase.
+  const int numChunks = numHelpers + 2;
 
-  // =========================================================================
-  // CALCULATE PER-GROUP CHUNK SIZES (from the per-rank sendCount)
-  // =========================================================================
   size_t chunkSizes[SHARDED_RELAY_MAX_GROUPS];
-  size_t lastChunkSizes[SHARDED_RELAY_MAX_GROUPS];
-  size_t directChunkOffsets[SHARDED_RELAY_MAX_GROUPS];
-  size_t directChunkSizes[SHARDED_RELAY_MAX_GROUPS];
+  size_t relayTotals[SHARDED_RELAY_MAX_GROUPS]; // == direct chunk A's offset
+  size_t dirBOffsets[SHARDED_RELAY_MAX_GROUPS];
+  size_t dirBSizes[SHARDED_RELAY_MAX_GROUPS]; // absorbs the remainder
 
   for (int g = 0; g < nGroups; g++) {
     size_t count = sendCounts[g];
 
-    // Skip groups with sendCount == 0; the per-phase loops below already check
-    // sendCounts[g] == 0 and bypass NCCL ops for those groups.
+    // Zero-count groups are skipped by every loop below.
     if (count == 0) {
       chunkSizes[g] = 0;
-      lastChunkSizes[g] = 0;
-      directChunkOffsets[g] = 0;
-      directChunkSizes[g] = 0;
+      relayTotals[g] = 0;
+      dirBOffsets[g] = 0;
+      dirBSizes[g] = 0;
       continue;
     }
 
-    // Calculate chunk size (aligned to CHUNK_ALIGN_ELEMENTS). When the
-    // per-chunk size rounded down to CHUNK_ALIGN_ELEMENTS is zero, the send
-    // buffer is too small to scatter and the caller should fall back to a
-    // regular all-gather.
+    // A chunk size that rounds down to zero means the send buffer is too small
+    // to scatter; the caller should fall back to a regular all-gather.
     size_t chunkSize = count / numChunks;
     chunkSize = (chunkSize / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
     if (chunkSize == 0) {
       return ncclInvalidArgument;
     }
     chunkSizes[g] = chunkSize;
-
-    // Calculate the size of the last chunk (absorbs the remainder)
-    size_t totalChunkedElements = static_cast<size_t>(numChunks) * chunkSize;
-    size_t lastChunkSize = chunkSize;
-    if (totalChunkedElements < count) {
-      lastChunkSize = chunkSize + (count - totalChunkedElements);
-    }
-    lastChunkSizes[g] = lastChunkSize;
-
-    // Direct exchange chunk info (within the sendCount-element send buffer)
-    int directChunkIndex = numHelpers;
-    directChunkOffsets[g] = static_cast<size_t>(directChunkIndex) * chunkSize;
-    directChunkSizes[g] = lastChunkSize;
+    relayTotals[g] = static_cast<size_t>(numHelpers) * chunkSize;
+    dirBOffsets[g] = relayTotals[g] + chunkSize;
+    dirBSizes[g] = count - dirBOffsets[g];
   }
 
   // For an active rank, compute its slot offsets and detect in-place.
@@ -256,9 +249,8 @@ static ncclResult_t shardedRelayAllGather2Active(
   if (myActiveGroup >= 0 && sendCounts[myActiveGroup] > 0) {
     const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
     size_t sendCount = sendCounts[myActiveGroup];
-    int otherActiveIndex = 1 - cfg.myActiveIndex;
     diagSlotOffset = static_cast<size_t>(cfg.myActiveIndex) * sendCount;
-    gatherSlotOffset = static_cast<size_t>(otherActiveIndex) * sendCount;
+    gatherSlotOffset = static_cast<size_t>(1 - cfg.myActiveIndex) * sendCount;
 
     // In-place when sendBuff aliases its own slot of recvBuff
     // (sendBuff == recvBuff + m x sendCount).
@@ -271,168 +263,73 @@ static ncclResult_t shardedRelayAllGather2Active(
   }
 
   // =========================================================================
-  // PHASE 1 (active->helpers): active ranks scatter their sendBuff chunks
+  // DIAGONAL COPY: recvBuff[m x sendCount] = sendBuff
   // =========================================================================
-  // Helpers receive from each active rank into offset-based slots:
-  //   slot a at offset (a x chunkSize) holds data from active rank a.
-  NCCLCHECK(ncclGroupStart());
-
-  for (int g = 0; g < nGroups; g++) {
-    if (sendCounts[g] == 0)
-      continue;
-    const ShardedRelayRankConfig& cfg = configs[g];
-    const void* sendbuff = sendBuffs[g];
-    void* recvbuff = recvBuffs[g];
-    size_t chunkSize = chunkSizes[g];
-
-    if (cfg.isActiveRank) {
-      // Active rank: send chunk h of my sendBuff to helper h
-      for (int h = 0; h < cfg.numHelpers; h++) {
-        int helperRank = cfg.helperRanks[h];
-        size_t chunkOffset = static_cast<size_t>(h) * chunkSize;
-
-        NCCLCHECK(ncclSend(
-            static_cast<const char*>(sendbuff) + chunkOffset * elementSize,
-            chunkSize,
-            datatype,
-            helperRank,
-            comm,
-            stream));
-      }
-    } else {
-      // Helper rank: receive from each active rank into slot a
-      for (int a = 0; a < cfg.nActiveRanks; a++) {
-        int activeRank = cfg.activeRanks[a];
-        size_t helperOffset = static_cast<size_t>(a) * chunkSize;
-
-        NCCLCHECK(ncclRecv(
-            static_cast<char*>(recvbuff) + helperOffset * elementSize,
-            chunkSize,
-            datatype,
-            activeRank,
-            comm,
-            stream));
-      }
-    }
-  }
-
-  NCCLCHECK(ncclGroupEnd());
-
-  // =========================================================================
-  // PHASE 2 (helpers->active, batched): Passthrough forward
-  // =========================================================================
-  // Each helper sends slot 0 (a0's data) -> a1 and slot 1 (a1's data) -> a0.
-  // The active rank receives all numHelpers chunks DIRECTLY into the OTHER
-  // rank's slot of recvBuff (recvBuff[o x sendCount + h x chunkSize]). No
-  // reduction and no relay scratch are required.
-  NCCLCHECK(ncclGroupStart());
-
-  for (int g = 0; g < nGroups; g++) {
-    if (sendCounts[g] == 0)
-      continue;
-    const ShardedRelayRankConfig& cfg = configs[g];
-    void* recvbuff = recvBuffs[g];
-    size_t chunkSize = chunkSizes[g];
-
-    if (!cfg.isActiveRank) {
-      // Helper for group g: forward each slot to the OTHER active rank.
-      for (int a = 0; a < cfg.nActiveRanks; a++) {
-        int targetActive = cfg.activeRanks[1 - a];
-        NCCLCHECK(ncclSend(
-            static_cast<const char*>(recvbuff) +
-                static_cast<size_t>(a) * chunkSize * elementSize,
-            chunkSize,
-            datatype,
-            targetActive,
-            comm,
-            stream));
-      }
-    } else {
-      // Active rank: receive forwarded data from each helper directly into the
-      // other rank's slot of recvBuff at offset gatherSlotOffset + h x
-      // chunkSize.
-      for (int h = 0; h < cfg.numHelpers; h++) {
-        int helperRank = cfg.helperRanks[h];
-        size_t dstOffset =
-            gatherSlotOffset + static_cast<size_t>(h) * chunkSize;
-        NCCLCHECK(ncclRecv(
-            static_cast<char*>(recvbuff) + dstOffset * elementSize,
-            chunkSize,
-            datatype,
-            helperRank,
-            comm,
-            stream));
-      }
-    }
-  }
-
-  NCCLCHECK(ncclGroupEnd());
-
-  // =========================================================================
-  // PHASE 3 (diagonal copy): recvBuff[m x sendCount] = sendBuff
-  // =========================================================================
-  // Place this rank's own contribution into its slot. In-place already has it
-  // (sendBuff aliases recvBuff[m x sendCount]), so the copy is skipped.
+  // Issued before the comm groups so it overlaps nothing that reads it.
+  // In-place already has it (sendBuff aliases recvBuff[m x sendCount]).
   if (myActiveGroup >= 0 && sendCounts[myActiveGroup] > 0 && !isInPlace) {
-    const void* sendbuff = sendBuffs[myActiveGroup];
-    void* recvbuff = recvBuffs[myActiveGroup];
-    size_t sendBytes = sendCounts[myActiveGroup] * elementSize;
     cudaMemcpyAsync(
-        static_cast<char*>(recvbuff) + diagSlotOffset * elementSize,
-        sendbuff,
-        sendBytes,
+        static_cast<char*>(recvBuffs[myActiveGroup]) +
+            diagSlotOffset * elementSize,
+        sendBuffs[myActiveGroup],
+        sendCounts[myActiveGroup] * elementSize,
         cudaMemcpyDeviceToDevice,
         stream);
   }
 
   // =========================================================================
-  // PHASE 4 (active<->active): Direct exchange of the last chunk
+  // GROUP 1: relay scatter (active->helpers) || direct chunk A
+  // (active<->active)
   // =========================================================================
-  // Active ranks exchange the direct chunk of their sendBuff; it is received
-  // directly into the other rank's slot of recvBuff. The gather destination
-  // (slot o) never overlaps the send source (slot m), so this is safe in-place.
   NCCLCHECK(ncclGroupStart());
 
   for (int g = 0; g < nGroups; g++) {
     if (sendCounts[g] == 0)
       continue;
     const ShardedRelayRankConfig& cfg = configs[g];
+    size_t chunkSize = chunkSizes[g];
 
     if (cfg.isActiveRank) {
-      const void* sendbuff = sendBuffs[g];
-      void* recvbuff = recvBuffs[g];
-      size_t directChunkOffset = directChunkOffsets[g];
-      size_t directChunkSize = directChunkSizes[g];
-      size_t recvDirectOffset = gatherSlotOffset + directChunkOffset;
+      const char* sendbuff = static_cast<const char*>(sendBuffs[g]);
+      char* recvbuff = static_cast<char*>(recvBuffs[g]);
 
-      // Send my direct chunk to all other active ranks
-      for (int a = 0; a < cfg.nActiveRanks; a++) {
-        if (a == cfg.myActiveIndex)
-          continue;
-        int otherActiveRank = cfg.activeRanks[a];
-
+      // Scatter: chunk h of my sendBuff goes to helper h.
+      for (int h = 0; h < cfg.numHelpers; h++) {
         NCCLCHECK(ncclSend(
-            static_cast<const char*>(sendbuff) +
-                directChunkOffset * elementSize,
-            directChunkSize,
+            sendbuff + static_cast<size_t>(h) * chunkSize * elementSize,
+            chunkSize,
             datatype,
-            otherActiveRank,
+            cfg.helperRanks[h],
             comm,
             stream));
       }
 
-      // Receive direct chunks from all other active ranks directly into the
-      // other rank's slot of recvBuff.
+      // Direct chunk A over the otherwise-idle active<->active link. The
+      // gather slot never overlaps the send source, so this is safe in-place.
+      int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      NCCLCHECK(ncclSend(
+          sendbuff + relayTotals[g] * elementSize,
+          chunkSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+      NCCLCHECK(ncclRecv(
+          recvbuff + (gatherSlotOffset + relayTotals[g]) * elementSize,
+          chunkSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else {
+      // Helper: receive active rank a's chunk into slot a.
+      char* helperBuf = static_cast<char*>(recvBuffs[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {
-        if (a == cfg.myActiveIndex)
-          continue;
-        int otherActiveRank = cfg.activeRanks[a];
-
         NCCLCHECK(ncclRecv(
-            static_cast<char*>(recvbuff) + recvDirectOffset * elementSize,
-            directChunkSize,
+            helperBuf + static_cast<size_t>(a) * chunkSize * elementSize,
+            chunkSize,
             datatype,
-            otherActiveRank,
+            cfg.activeRanks[a],
             comm,
             stream));
       }
@@ -441,36 +338,105 @@ static ncclResult_t shardedRelayAllGather2Active(
 
   NCCLCHECK(ncclGroupEnd());
 
-  // Phase 5: none. All-gather performs no reduction; the gathered and diagonal
-  // slots are already in place in recvBuff.
+  // =========================================================================
+  // GROUP 2: relay forward (helpers->active) || direct chunk B
+  // (active<->active)
+  // =========================================================================
+  // Helpers are pure passthrough: slot a goes to the OTHER active rank, landing
+  // directly in that rank's gather slot. No reduction, no relay scratch.
+  NCCLCHECK(ncclGroupStart());
+
+  for (int g = 0; g < nGroups; g++) {
+    if (sendCounts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    size_t chunkSize = chunkSizes[g];
+
+    if (cfg.isActiveRank) {
+      char* recvbuff = static_cast<char*>(recvBuffs[g]);
+
+      for (int h = 0; h < cfg.numHelpers; h++) {
+        NCCLCHECK(ncclRecv(
+            recvbuff +
+                (gatherSlotOffset + static_cast<size_t>(h) * chunkSize) *
+                    elementSize,
+            chunkSize,
+            datatype,
+            cfg.helperRanks[h],
+            comm,
+            stream));
+      }
+
+      // Direct chunk B, again over the idle active<->active link.
+      int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      NCCLCHECK(ncclSend(
+          static_cast<const char*>(sendBuffs[g]) + dirBOffsets[g] * elementSize,
+          dirBSizes[g],
+          datatype,
+          partner,
+          comm,
+          stream));
+      NCCLCHECK(ncclRecv(
+          recvbuff + (gatherSlotOffset + dirBOffsets[g]) * elementSize,
+          dirBSizes[g],
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else {
+      const char* helperBuf = static_cast<const char*>(recvBuffs[g]);
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        NCCLCHECK(ncclSend(
+            helperBuf + static_cast<size_t>(a) * chunkSize * elementSize,
+            chunkSize,
+            datatype,
+            cfg.activeRanks[1 - a],
+            comm,
+            stream));
+      }
+    }
+  }
+
+  NCCLCHECK(ncclGroupEnd());
+
   return ncclSuccess;
 }
 
 /**
- * All-gather for > 2 active ranks (flat scatter->forward relay, pipelined; the
- * dual of the reduce-scatter). Every active SOURCE delivers its sc to every
- * other active DEST's recvBuff slot: a DIRECT share over the 1-hop intra links
- * (active<->active), and an OFFLOAD share 2-hop through the idle helper GPUs
- * (active->helper, then helper broadcasts to the dests). The offload is sliced
- * into P stages and software-pipelined so the helper-forward of stage i
- * (helper->active) overlaps the active-send of stage i+1 (active->helper)
- * within one ncclGroup, recruiting the otherwise-idle helper links.
+ * All-gather for > 2 active ranks (two-group scatter/forward relay).
  *
- * Superstep schedule (one ncclGroup each; P+1 supersteps):
- *   k = 0:        S_0                  (send stage for slice 0 only)
- *   k = 1..P-1:   F_{k-1}  ||  S_k     (forward slice k-1 + send slice k)
- *   k = P:        F_{P-1}              (forward stage for last slice)
- * The group boundary between superstep k-1 and k guarantees S_{k-1} completed
- * before F_{k-1} reads it. Within a superstep, F_{k-1} reads helper slot
- * sub-slice k-1 while S_k writes sub-slice k (disjoint), so there is no hazard,
- * and every superstep is one ncclGroup with a fully matched send/recv set (no
- * deadlock). Slicing is plain even division (last part absorbs the remainder);
- * all slice sizes derive only from sendCounts[g], so they are identical across
- * ranks.
+ * Every active SOURCE must deliver its sc elements to the A-1 other active
+ * DESTs. Part of sc goes DIRECT over the 1-hop intra links (active<->active)
+ * and part is OFFLOADED 2-hop through the otherwise-idle helper GPUs
+ * (active->helper, then the helper forwards to every dest).
  *
- * Helper scratch = recvBuffs[g] for helper groups; it holds one offload chunk
- * of `cs` per active source (A*cs <= sc elements). Both in-place (sendBuff ==
- * recvBuff + m*sc) and out-of-place are supported.
+ * Link accounting, per direction, in units of the per-(source,helper) chunk cs.
+ * Note that on this topology a rank's helpers ARE the active ranks of another
+ * group, so a rank's scatter and its helper-forward duty are egress on the SAME
+ * cross links -- they add, they do not overlap. Hence two groups, not a
+ * pipeline:
+ *
+ *   group 1:  cross = cs (scatter one slice per helper)   intra = direct part 1
+ *   group 2:  cross = (A-1)*cs (forward every source's    intra = direct part 2
+ *                      slice to every other dest)
+ *
+ * Balancing each group's cross and intra load gives direct part 1 = cs and
+ * direct part 2 = (A-1)*cs, so the direct region is A*cs and the offload region
+ * is H*cs: cs = sc/(A+H) -- eight equal units on the 8-GPU node, exactly as in
+ * the 2-active path. The critical path is then cs + (A-1)*cs = A*cs = sc/2
+ * against a pure-direct sc, a 2x ceiling.
+ *
+ * Buffer layout of sendBuff [0, sc): direct region [0, A*cs) whose first cs go
+ * out in group 1 and whose remaining (A-1)*cs go out in group 2, then the
+ * offload region [A*cs, sc) as H slices of cs, slice h owned by helper h.
+ *
+ * Helper scratch = recvBuffs[g], holding one cs slice per active source
+ * (A*cs <= sc elements). Both in-place (sendBuff == recvBuff + m*sc) and
+ * out-of-place are supported.
+ *
+ * At small sizes the 2-hop offload only adds a helper hop and a group boundary,
+ * so below a threshold the offload is disabled and this degenerates to a
+ * single-group pure-direct all-gather with the helpers idle.
  */
 static ncclResult_t shardedRelayAllGatherFlat(
     const void* const* sendBuffs,
@@ -488,9 +454,8 @@ static ncclResult_t shardedRelayAllGatherFlat(
   const int A = nActiveRanksPerGroup;
   const int H = numHelpers;
 
-  // Largest per-group message drives the size-adaptive tuning below. All groups
-  // march through the same superstep count to keep XGMI traffic phase-synced,
-  // so tune off the max.
+  // All groups march through the same schedule to keep XGMI traffic
+  // phase-synced, so tune off the largest per-group message.
   size_t maxSc = 0;
   for (int g = 0; g < nGroups; g++) {
     if (sendCounts[g] > maxSc) {
@@ -499,53 +464,40 @@ static ncclResult_t shardedRelayAllGatherFlat(
   }
   const size_t maxBytes = maxSc * elementSize;
 
-  // Size-adaptive helper offload. The offload (2-hop active->helper->active)
-  // share spreads traffic across otherwise-idle cross links and is a bandwidth
-  // win only at large sizes, but it costs an extra group boundary + a hop of
-  // latency. Below the threshold, disable it: the kernel degenerates to a
-  // single-group pure-direct all-gather (each active rank exchanges its shard
-  // directly with the other A-1 active ranks, helpers idle) -- the same
-  // minimal-latency shape as all-to-all.
-  //
-  // The crossover depends on cross-link contention: a fused multi-group call
-  // runs all groups phase-synced, so the offload cross links contend with the
-  // other groups and only pay off at the very top end (>=256 MB); an
-  // independent single-group call has those cross links free, so offload pays
-  // off ~2x earlier (>=128 MB). Measured on MI350X (A=4, bf16, 8 GPUs): fused
-  // offload ties/loses to pure-direct until 256 MB (1.03x @512MB), while
-  // independent offload wins from 135 MB (1.10x) -- so cross over per-scenario.
-  // Above the threshold the direct share is 429/1000 (~3/7), balancing the
-  // intra direct link against the helper->dest link.
+  // An independent call has the cross links to itself, so the offload pays off
+  // earlier than in a fused call where every group is driving them at once.
+  // Measured crossover (MI350X, A=4, bf16, 8 GPUs): a fused call has every
+  // group driving the cross links at once so the offload needs ~12 MB to pay
+  // off, while an independent call has them to itself and turns a profit from
+  // ~8 MB.
   const size_t kOffloadMinBytes = (nGroups > 1)
-      ? (static_cast<size_t>(256) << 20) // fused: >= 256 MB
-      : (static_cast<size_t>(128) << 20); // independent: >= 128 MB
-  const bool useOffload = (H > 0) && (maxBytes >= kOffloadMinBytes);
-  const size_t kOffPermille = useOffload ? (1000 - 429) : 0;
+      ? (static_cast<size_t>(12) << 20) // fused: >= 12 MB
+      : (static_cast<size_t>(8) << 20); // independent: >= 8 MB
+  // A == 2 only reaches this function in the small-message regime, where the
+  // dedicated 2-active relay has already been ruled out; running the offload
+  // there just re-adds the hop it was routed here to avoid.
+  const bool useOffload = (H > 0) && (A > 2) && (maxBytes >= kOffloadMinBytes);
 
-  // Pipeline depth. Only the offload path has a helper->active forward hop to
-  // overlap against the next active->helper scatter hop; the pure-direct path
-  // is a single group. In the offload regime the superstep loop runs P+1
-  // ncclGroup boundaries (each ~25us of fixed launch+handshake tax); at these
-  // large sizes the deep pipeline (P=16; P=32 regressed) amortizes that tax
-  // against the per-slice transfer.
-  const int P = useOffload ? 16 : 1;
-
-  // Per-group geometry (same as the flat path): cs = per-source helper chunk
-  // (128-aligned); directSz absorbs the remainder so directSz + H*cs == sc.
+  // Per-group geometry. cs = sc/(A+H) aligned down; the direct region absorbs
+  // the remainder so directSz + H*cs == sc.
   size_t csArr[SHARDED_RELAY_MAX_GROUPS];
   size_t directArr[SHARDED_RELAY_MAX_GROUPS];
+  size_t d1Arr[SHARDED_RELAY_MAX_GROUPS]; // direct bytes sent in group 1
   for (int g = 0; g < nGroups; g++) {
     size_t sc = sendCounts[g];
     if (sc == 0) {
       csArr[g] = 0;
       directArr[g] = 0;
+      d1Arr[g] = 0;
       continue;
     }
-    size_t offTarget = (sc * kOffPermille) / 1000;
-    size_t cs = (H > 0) ? (offTarget / static_cast<size_t>(H)) : 0;
+    size_t cs = useOffload ? (sc / static_cast<size_t>(A + H)) : 0;
     cs = (cs / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
     csArr[g] = cs;
     directArr[g] = sc - static_cast<size_t>(H) * cs;
+    // Group 1's cross links carry one cs, group 2's carry (A-1)*cs, so split
+    // the direct region the same way to keep both groups balanced.
+    d1Arr[g] = (cs > 0) ? cs : directArr[g];
   }
 
   // In-place detection for the diagonal copy.
@@ -562,15 +514,6 @@ static ncclResult_t shardedRelayAllGatherFlat(
          static_cast<const void*>(mySlot));
   }
 
-  // Even-division slice geometry (last slice absorbs the remainder).
-  auto sliceOff = [P](size_t total, int k) -> size_t {
-    return static_cast<size_t>(k) * (total / static_cast<size_t>(P));
-  };
-  auto sliceLen = [P](size_t total, int k) -> size_t {
-    size_t base = total / static_cast<size_t>(P);
-    return (k == P - 1) ? (total - static_cast<size_t>(k) * base) : base;
-  };
-
   // Diagonal: recvBuff[m*sc] = sendBuff.
   if (myActiveGroup >= 0 && sendCounts[myActiveGroup] > 0 && !isInPlace) {
     cudaMemcpyAsync(
@@ -582,142 +525,165 @@ static ncclResult_t shardedRelayAllGatherFlat(
         stream);
   }
 
-  // When offload is disabled (small messages), csArr is all zero and every
-  // forward stage is a no-op, so the loop only needs the P direct-send
-  // supersteps -- drop the trailing forward-only superstep to save one
-  // boundary.
-  bool anyOffload = false;
+  // =========================================================================
+  // GROUP 1: direct part 1 (active<->active) || offload scatter
+  // (active->helper)
+  // =========================================================================
+  NCCLCHECK(ncclGroupStart());
   for (int g = 0; g < nGroups; g++) {
-    if (csArr[g] > 0) {
-      anyOffload = true;
+    if (sendCounts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    size_t sc = sendCounts[g];
+    size_t cs = csArr[g];
+    size_t directSz = directArr[g];
+    size_t d1 = d1Arr[g];
+
+    if (cfg.isActiveRank) {
+      const char* sendbuff = static_cast<const char*>(sendBuffs[g]);
+      char* recvbuff = static_cast<char*>(recvBuffs[g]);
+      int m = cfg.myActiveIndex;
+
+      if (d1 > 0) {
+        for (int d = 0; d < A; d++) {
+          if (d == m)
+            continue;
+          NCCLCHECK(ncclSend(
+              sendbuff, d1, datatype, cfg.activeRanks[d], comm, stream));
+        }
+        for (int s = 0; s < A; s++) {
+          if (s == m)
+            continue;
+          NCCLCHECK(ncclRecv(
+              recvbuff + static_cast<size_t>(s) * sc * elementSize,
+              d1,
+              datatype,
+              cfg.activeRanks[s],
+              comm,
+              stream));
+        }
+      }
+
+      // Offload scatter: slice h of my offload region goes to helper h.
+      for (int h = 0; h < cfg.numHelpers && cs > 0; h++) {
+        NCCLCHECK(ncclSend(
+            sendbuff + (directSz + static_cast<size_t>(h) * cs) * elementSize,
+            cs,
+            datatype,
+            cfg.helperRanks[h],
+            comm,
+            stream));
+      }
+    } else if (cs > 0) {
+      // Helper: receive each source's slice into slot s.
+      char* hbuff = static_cast<char*>(recvBuffs[g]);
+      for (int s = 0; s < cfg.nActiveRanks; s++) {
+        NCCLCHECK(ncclRecv(
+            hbuff + static_cast<size_t>(s) * cs * elementSize,
+            cs,
+            datatype,
+            cfg.activeRanks[s],
+            comm,
+            stream));
+      }
+    }
+  }
+  NCCLCHECK(ncclGroupEnd());
+
+  // When the offload is disabled the whole direct region went out in group 1,
+  // so there is nothing left to do.
+  bool anyGroup2 = false;
+  for (int g = 0; g < nGroups; g++) {
+    if (sendCounts[g] > 0 && csArr[g] > 0) {
+      anyGroup2 = true;
       break;
     }
   }
-  const int lastK = anyOffload ? P : (P - 1);
+  if (!anyGroup2) {
+    return ncclSuccess;
+  }
 
-  // Supersteps 0..lastK (one ncclGroup each).
-  for (int k = 0; k <= lastK; k++) {
-    NCCLCHECK(ncclGroupStart());
-    for (int g = 0; g < nGroups; g++) {
-      if (sendCounts[g] == 0)
-        continue;
-      const ShardedRelayRankConfig& cfg = configs[g];
-      size_t sc = sendCounts[g];
-      size_t cs = csArr[g];
-      size_t directSz = directArr[g];
+  // =========================================================================
+  // GROUP 2: direct part 2 (active<->active) || offload forward
+  // (helper->active)
+  // =========================================================================
+  NCCLCHECK(ncclGroupStart());
+  for (int g = 0; g < nGroups; g++) {
+    if (sendCounts[g] == 0 || csArr[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    size_t sc = sendCounts[g];
+    size_t cs = csArr[g];
+    size_t directSz = directArr[g];
+    size_t d1 = d1Arr[g];
+    size_t d2 = directSz - d1;
 
-      // ---- S_k: send stage for slice k (active->helper + active<->active)
-      // ----
-      if (k < P) {
-        size_t dOff = sliceOff(directSz, k);
-        size_t dLen = sliceLen(directSz, k);
-        size_t cOff = sliceOff(cs, k);
-        size_t cLen = sliceLen(cs, k);
-        if (cfg.isActiveRank) {
-          const char* sendbuff = static_cast<const char*>(sendBuffs[g]);
-          char* recvbuff = static_cast<char*>(recvBuffs[g]);
-          int m = cfg.myActiveIndex;
-          // Direct slice k: send to each dest, recv from each source (same
-          // group -> csz==0-safe).
-          if (dLen > 0) {
-            for (int d = 0; d < A; d++) {
-              if (d == m)
-                continue;
-              NCCLCHECK(ncclSend(
-                  sendbuff + dOff * elementSize,
-                  dLen,
-                  datatype,
-                  cfg.activeRanks[d],
-                  comm,
-                  stream));
-            }
-            for (int s = 0; s < A; s++) {
-              if (s == m)
-                continue;
-              NCCLCHECK(ncclRecv(
-                  recvbuff + (static_cast<size_t>(s) * sc + dOff) * elementSize,
-                  dLen,
-                  datatype,
-                  cfg.activeRanks[s],
-                  comm,
-                  stream));
-            }
-          }
-          // Offload sub-slice k: send to each helper once.
-          if (cs > 0 && cLen > 0) {
-            for (int h = 0; h < cfg.numHelpers; h++) {
-              NCCLCHECK(ncclSend(
-                  sendbuff +
-                      (directSz + static_cast<size_t>(h) * cs + cOff) *
-                          elementSize,
-                  cLen,
-                  datatype,
-                  cfg.helperRanks[h],
-                  comm,
-                  stream));
-            }
-          }
-        } else if (cs > 0 && cLen > 0) {
-          // Helper: recv offload sub-slice k from each source into slot s.
-          char* hbuff = static_cast<char*>(recvBuffs[g]);
-          for (int s = 0; s < cfg.nActiveRanks; s++) {
-            NCCLCHECK(ncclRecv(
-                hbuff + (static_cast<size_t>(s) * cs + cOff) * elementSize,
-                cLen,
-                datatype,
-                cfg.activeRanks[s],
-                comm,
-                stream));
-          }
+    if (cfg.isActiveRank) {
+      const char* sendbuff = static_cast<const char*>(sendBuffs[g]);
+      char* recvbuff = static_cast<char*>(recvBuffs[g]);
+      int m = cfg.myActiveIndex;
+
+      if (d2 > 0) {
+        for (int d = 0; d < A; d++) {
+          if (d == m)
+            continue;
+          NCCLCHECK(ncclSend(
+              sendbuff + d1 * elementSize,
+              d2,
+              datatype,
+              cfg.activeRanks[d],
+              comm,
+              stream));
+        }
+        for (int s = 0; s < A; s++) {
+          if (s == m)
+            continue;
+          NCCLCHECK(ncclRecv(
+              recvbuff + (static_cast<size_t>(s) * sc + d1) * elementSize,
+              d2,
+              datatype,
+              cfg.activeRanks[s],
+              comm,
+              stream));
         }
       }
 
-      // ---- F_{k-1}: forward stage for slice k-1 (helper->active) ----
-      if (k >= 1 && cs > 0) {
-        int kf = k - 1;
-        size_t cOffF = sliceOff(cs, kf);
-        size_t cLenF = sliceLen(cs, kf);
-        if (cLenF > 0) {
-          if (cfg.isActiveRank) {
-            char* recvbuff = static_cast<char*>(recvBuffs[g]);
-            int m = cfg.myActiveIndex;
-            for (int h = 0; h < cfg.numHelpers; h++) {
-              for (int s = 0; s < A; s++) {
-                if (s == m)
-                  continue;
-                NCCLCHECK(ncclRecv(
-                    recvbuff +
-                        (static_cast<size_t>(s) * sc + directSz +
-                         static_cast<size_t>(h) * cs + cOffF) *
-                            elementSize,
-                    cLenF,
-                    datatype,
-                    cfg.helperRanks[h],
-                    comm,
-                    stream));
-              }
-            }
-          } else {
-            const char* hbuff = static_cast<const char*>(recvBuffs[g]);
-            for (int s = 0; s < cfg.nActiveRanks; s++) {
-              for (int d = 0; d < A; d++) {
-                if (d == s)
-                  continue;
-                NCCLCHECK(ncclSend(
-                    hbuff + (static_cast<size_t>(s) * cs + cOffF) * elementSize,
-                    cLenF,
-                    datatype,
-                    cfg.activeRanks[d],
-                    comm,
-                    stream));
-              }
-            }
-          }
+      // Offload forward: helper h delivers every other source's slice h.
+      for (int h = 0; h < cfg.numHelpers; h++) {
+        for (int s = 0; s < A; s++) {
+          if (s == m)
+            continue;
+          NCCLCHECK(ncclRecv(
+              recvbuff +
+                  (static_cast<size_t>(s) * sc + directSz +
+                   static_cast<size_t>(h) * cs) *
+                      elementSize,
+              cs,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+    } else {
+      // Helper: forward source s's slice to every dest other than s.
+      const char* hbuff = static_cast<const char*>(recvBuffs[g]);
+      for (int s = 0; s < cfg.nActiveRanks; s++) {
+        for (int d = 0; d < A; d++) {
+          if (d == s)
+            continue;
+          NCCLCHECK(ncclSend(
+              hbuff + static_cast<size_t>(s) * cs * elementSize,
+              cs,
+              datatype,
+              cfg.activeRanks[d],
+              comm,
+              stream));
         }
       }
     }
-    NCCLCHECK(ncclGroupEnd());
   }
+  NCCLCHECK(ncclGroupEnd());
 
   return ncclSuccess;
 }
@@ -838,7 +804,7 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
   // direct holds on longer. Cross over below each.
   const size_t kAgA2PureDirectMaxBytes = (nGroups > 1)
       ? (static_cast<size_t>(2) << 20) // fused: < 2 MB
-      : (static_cast<size_t>(12) << 20); // independent: < 12 MB
+      : (static_cast<size_t>(4) << 20); // independent: < 4 MB
   const bool agA2UseFlat =
       (nActiveRanksPerGroup == 2) && (maxBytesAg < kAgA2PureDirectMaxBytes);
   if (nActiveRanksPerGroup == 2 && !agA2UseFlat) {

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.h
@@ -26,11 +26,13 @@
  * reuses the same phase-synchronized passthrough-helper scheme; helpers perform
  * no compute and simply relay sharded chunks.
  *
- * nActiveRanksPerGroup must be a power of two (2 or 4). A==2 uses the original
- * 2-active passthrough path; A>2 uses the bandwidth-optimal flat
+ * nActiveRanksPerGroup must be a power of two (2 or 4). A==2 uses the 2-active
+ * passthrough relay described below; A>2 uses a two-group flat
  * scatter->forward relay (the dual of the reduce-scatter path): a direct intra
- * all-to-all woven with a 2-hop offload through the idle helper GPUs, in two
- * ncclGroups.
+ * exchange woven with a 2-hop offload through the idle helper GPUs. Group 1's
+ * cross links carry one chunk and group 2's carry A-1 (the helper fans each
+ * source's slice out to every other dest), so the direct region is split
+ * 1:(A-1) across the two groups to keep both balanced.
  *
  * All-gather performs NO reduction (pure data movement), so no reduction
  * kernels are used and there is no reduction op parameter. It is the dual of
@@ -57,25 +59,29 @@
  * either mode: the gather destination (slot o) never overlaps the send source
  * (slot m), so there is no send/recv aliasing hazard.
  *
- * Five Phases (no reduction; pure relay + placement copies):
- * ==========================================================
- *   Phase 1 (active->helpers): each active rank scatters numHelpers chunks of
- *            its sendBuff to helpers; each helper stores two slots.
- *   Phase 2 (helpers->active, batched): each helper forwards slot-from-a0 -> a1
- *            and slot-from-a1 -> a0; the active rank receives numHelpers chunks
- *            DIRECTLY into recvBuff[o x sendCount + h x chunkSize].
- *   Phase 3 (diagonal copy): recvBuff[m x sendCount] = sendBuff (a no-op when
- *            in-place).
- *   Phase 4 (active<->active): direct exchange of the last (direct) chunk,
- *            received directly into recvBuff[o x sendCount].
- *   Phase 5: none (no reduction).
+ * Two Comm Groups (no reduction; pure relay + a placement copy):
+ * ==============================================================
+ *   Diagonal: recvBuff[m x sendCount] = sendBuff (a no-op when in-place).
+ *   Group 1:  each active rank scatters numHelpers chunks of its sendBuff to
+ *             helpers (each helper stores two slots) AND the two active ranks
+ *             directly exchange one chunk over the otherwise-idle
+ *             active<->active link, straight into recvBuff[o x sendCount].
+ *   Group 2:  each helper forwards slot-from-a0 -> a1 and slot-from-a1 -> a0,
+ *             landing DIRECTLY in recvBuff[o x sendCount + h x chunkSize], AND
+ *             the active ranks directly exchange a second chunk over the same
+ *             idle link.
  *
  * Chunking:
  * =========
- *   chunkSize  = sendCounts[g] / numChunks rounded down to 128 elements,
- *   numChunks  = numHelpers + 1 (last chunk is the direct-exchange chunk).
- * Returns ncclInvalidArgument when sendCounts[g] < numChunks x 128 (too small
- * to scatter); callers should fall back to a plain all-gather.
+ *   chunkSize = sendCounts[g] / numChunks rounded down to 128 elements,
+ *   numChunks = numHelpers + 2. The active<->active link is idle while the
+ * relay scatter and forward run on the cross links, so instead of a third comm
+ * group for one direct chunk, one direct chunk rides along with each relay
+ * group. Every link then carries exactly one chunk per direction per group and
+ * the critical path is 2 x chunkSize instead of 3 x
+ * sendCounts[g]/(numHelpers+1). Returns ncclInvalidArgument when sendCounts[g]
+ * < numChunks x 128 (too small to scatter); callers should fall back to a plain
+ * all-gather.
  *
  * Helper-Buffer Contract (passthrough-at-helper):
  * ===============================================

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "nccl.h"
+
+// Maximum number of groups supported in multi-group all-gather.
+// Mirrors SHARDED_RELAY_MAX_GROUPS in sharded_relay_allreduce.h; redefined
+// here so this header is self-contained (the two values must stay in sync).
+#ifndef SHARDED_RELAY_MAX_GROUPS
+#define SHARDED_RELAY_MAX_GROUPS 8
+#endif
+
+/**
+ * Fused Multi-Group Sharded Relay All-Gather for 2D Sparse Parallelism.
+ *
+ * This API performs multiple sharded relay all-gathers in a single fused call,
+ * coordinating phases across all groups to prevent XGMI link contention. It is
+ * the all-gather analogue of the sharded relay allreduce/reduce-scatter and
+ * reuses the same phase-synchronized passthrough-helper scheme; helpers perform
+ * no compute and simply relay sharded chunks.
+ *
+ * nActiveRanksPerGroup must be a power of two (2 or 4). A==2 uses the original
+ * 2-active passthrough path; A>2 uses the bandwidth-optimal flat
+ * scatter->forward relay (the dual of the reduce-scatter path): a direct intra
+ * all-to-all woven with a 2-hop offload through the idle helper GPUs, in two
+ * ncclGroups.
+ *
+ * All-gather performs NO reduction (pure data movement), so no reduction
+ * kernels are used and there is no reduction op parameter. It is the dual of
+ * reduce-scatter.
+ *
+ * All-Gather Semantics (per group, A active ranks):
+ * =======================================================
+ * Each active rank's sendBuff holds sendCounts[g] elements (its own
+ * contribution); each active recvBuff holds nActiveRanksPerGroup x
+ * sendCounts[g] (= 2 x sendCounts[g]) elements, where recvBuff[i x sendCount]
+ * receives the contribution from active index i.
+ *
+ * For the active rank with myActiveIndex = m, otherActiveIndex = o = 1 - m:
+ *   - Diagonal (self): recvBuff[m x sendCount] = sendBuff (my own data in my
+ *     slot).
+ *   - Gather: ship sendBuff to the other rank and receive the other rank's
+ *     sendBuff into recvBuff[o x sendCount]. This single-segment exchange is
+ *     sharded across helpers.
+ *
+ * Both IN-PLACE and OUT-OF-PLACE are supported (like reduce-scatter and unlike
+ * all-to-all). In-place is detected when sendBuff == recvBuff + m x sendCount
+ * (the standard NCCL all-gather in-place convention: each rank's send data
+ * already sits in its slot of recvBuff). No scratch buffers are required in
+ * either mode: the gather destination (slot o) never overlaps the send source
+ * (slot m), so there is no send/recv aliasing hazard.
+ *
+ * Five Phases (no reduction; pure relay + placement copies):
+ * ==========================================================
+ *   Phase 1 (active->helpers): each active rank scatters numHelpers chunks of
+ *            its sendBuff to helpers; each helper stores two slots.
+ *   Phase 2 (helpers->active, batched): each helper forwards slot-from-a0 -> a1
+ *            and slot-from-a1 -> a0; the active rank receives numHelpers chunks
+ *            DIRECTLY into recvBuff[o x sendCount + h x chunkSize].
+ *   Phase 3 (diagonal copy): recvBuff[m x sendCount] = sendBuff (a no-op when
+ *            in-place).
+ *   Phase 4 (active<->active): direct exchange of the last (direct) chunk,
+ *            received directly into recvBuff[o x sendCount].
+ *   Phase 5: none (no reduction).
+ *
+ * Chunking:
+ * =========
+ *   chunkSize  = sendCounts[g] / numChunks rounded down to 128 elements,
+ *   numChunks  = numHelpers + 1 (last chunk is the direct-exchange chunk).
+ * Returns ncclInvalidArgument when sendCounts[g] < numChunks x 128 (too small
+ * to scatter); callers should fall back to a plain all-gather.
+ *
+ * Helper-Buffer Contract (passthrough-at-helper):
+ * ===============================================
+ * A==2 path: caller MUST supply at least nActiveRanksPerGroup x
+ * chunkSize_aligned elements per helper group, where chunkSize_aligned is
+ * computed from sendCounts[g].
+ *
+ * A>2 (flat) path: the helper stores one offload chunk of `cs` elements per
+ * active source, so the caller MUST supply at least A*cs elements per helper
+ * group, where cs is the 128-aligned offload fraction of sendCounts[g] divided
+ * by numHelpers. This is bounded above by sendCounts[g], so allocating A x
+ * sendCounts[g] per helper group (as the C++ tests do) always satisfies it.
+ *
+ * Memory Model:
+ * =============
+ * Each rank is ACTIVE for exactly ONE group (has real tensor data).
+ * For other groups, the rank is a HELPER (uses provided two-slot scratch).
+ *   - sendBuffs[nGroups]: one contiguous input buffer per group. For the active
+ *     group it holds this rank's contribution (sendCounts[g] elements); helper
+ *     groups may pass the same pointer as recvBuffs.
+ *   - recvBuffs[nGroups]: one base buffer per group. For helper groups this is
+ *     the two-slot passthrough scratch (>= nActiveRanks x chunkSize); for the
+ *     active group it is the gathered-output base (nActiveRanksPerGroup x
+ *     sendCounts[g] elements).
+ *   - In-place is detected when the input aliases the active rank's own output
+ *     slot (sendBuffs[g] == recvBuffs[g] + myActiveIndex x sendCount).
+ *   - Each helper group MUST have its own buffer (no aliasing across groups)
+ *     because all groups are processed simultaneously under phase-sync.
+ *
+ * @param sendBuffs Array of per-group contiguous input buffer pointers (one per
+ *        group); the active group holds this rank's contribution (sendCounts[g]
+ *        elements)
+ * @param recvBuffs Array of per-group base buffer pointers (one per group);
+ *        helper groups pass two-slot passthrough scratch
+ * @param sendCounts Array of per-group per-rank contribution element counts
+ *        (one per group); the active output together holds
+ *        nActiveRanksPerGroup x sendCounts[g] elements
+ * @param datatype NCCL data type
+ * @param comm NCCL communicator
+ * @param stream CUDA stream
+ * @param allActiveRanks 2D array of active ranks
+ * [nGroups][nActiveRanksPerGroup]
+ * @param nActiveRanksPerGroup Number of active ranks per group (2 or 4)
+ * @param nGroups Number of groups (typically 4 for 8-GPU node)
+ * @return ncclResult_t Success or error code
+ */
+ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* sendCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const int* const* allActiveRanks,
+    int nActiveRanksPerGroup,
+    int nGroups);

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
@@ -1,0 +1,664 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "sharded_relay_all_to_all.h"
+#include "comm.h"
+
+// GPU memory access alignment in elements for chunk size rounding.
+// Distinct from the CPU CACHE_LINE_SIZE (64 bytes) defined in comm.h
+// which is used for struct padding.
+static constexpr size_t CHUNK_ALIGN_ELEMENTS = 128;
+
+// The rank-config builder below is a deliberate copy of the file-local helper
+// in sharded_relay_allreduce.cc (also mirrored in
+// sharded_relay_reduce_scatter.cc). It is file-local there, so it cannot be
+// linked across translation units; this TU re-declares its own copy in an
+// anonymous namespace to keep it internal and ODR-safe. All-to-all performs no
+// reduction, so NO reduction kernels are used.
+namespace {
+
+// Maximum number of helper ranks supported per group.
+constexpr int SHARDED_RELAY_MAX_HELPERS = 8;
+
+// Maximum number of active ranks per group. The flat all-to-all uses an XOR
+// round schedule (round-r partner = myActiveIndex XOR r) that requires
+// nActiveRanks to be a power of two; supported values are 2 and 4 (on an 8-GPU
+// node this leaves 6 or 4 helpers respectively).
+constexpr int SHARDED_RELAY_MAX_ACTIVE = 8;
+
+// Returns true if v is a power of two (v >= 1).
+inline bool isPowerOfTwo(int v) {
+  return v > 0 && (v & (v - 1)) == 0;
+}
+
+/**
+ * Rank Configuration for Sharded Relay All-to-All
+ *
+ * Holds parsed active and helper rank information for a single group.
+ * Supports a power-of-two number of active ranks per group (2 or 4).
+ */
+struct ShardedRelayRankConfig {
+  int activeRanks[SHARDED_RELAY_MAX_ACTIVE]; // Active rank IDs (power of two)
+  int nActiveRanks; // Number of active ranks (2 or 4)
+  int helperRanks[SHARDED_RELAY_MAX_HELPERS]; // Helper rank IDs
+  int numHelpers; // Number of helper ranks
+  bool isActiveRank; // Is current rank active?
+  int myActiveIndex; // Index in activeRanks array (-1 if helper)
+  int myHelperIndex; // Index in helperRanks array (-1 if active)
+};
+
+/**
+ * Build rank configuration from provided active ranks array.
+ *
+ * Requires a power-of-two active-rank count in [2, SHARDED_RELAY_MAX_ACTIVE];
+ * the XOR round schedule of the A>2 flat path depends on it.
+ */
+bool buildShardedRelayRankConfig(
+    int nRanks,
+    int rank,
+    const int* activeRanksInput,
+    int nActiveRanksInput,
+    ShardedRelayRankConfig& config) {
+  config.nActiveRanks = 0;
+  config.numHelpers = 0;
+  config.isActiveRank = false;
+  config.myActiveIndex = -1;
+  config.myHelperIndex = -1;
+
+  // Validate input - require a power-of-two active-rank count in
+  // [2, SHARDED_RELAY_MAX_ACTIVE]. The XOR round schedule depends on it.
+  if (activeRanksInput == nullptr || nActiveRanksInput < 2 ||
+      nActiveRanksInput > SHARDED_RELAY_MAX_ACTIVE ||
+      !isPowerOfTwo(nActiveRanksInput)) {
+    return false;
+  }
+
+  // Copy active ranks and validate
+  for (int i = 0; i < nActiveRanksInput; i++) {
+    int rankId = activeRanksInput[i];
+    if (rankId >= 0 && rankId < nRanks) {
+      config.activeRanks[config.nActiveRanks++] = rankId;
+    }
+  }
+
+  // Validate: need exactly nActiveRanksInput valid active ranks
+  if (config.nActiveRanks != nActiveRanksInput) {
+    return false;
+  }
+
+  // Build list of helper ranks (all ranks NOT in activeRanks).
+  for (int r = 0; r < nRanks; r++) {
+    bool isActive = false;
+    for (int a = 0; a < config.nActiveRanks; a++) {
+      if (r == config.activeRanks[a]) {
+        isActive = true;
+        break;
+      }
+    }
+    if (!isActive) {
+      if (config.numHelpers >= SHARDED_RELAY_MAX_HELPERS) {
+        return false;
+      }
+      config.helperRanks[config.numHelpers++] = r;
+    }
+  }
+
+  // Validate: need at least 1 helper
+  if (config.numHelpers < 1) {
+    return false;
+  }
+
+  // Determine if this rank is active
+  for (int a = 0; a < config.nActiveRanks; a++) {
+    if (rank == config.activeRanks[a]) {
+      config.isActiveRank = true;
+      config.myActiveIndex = a;
+      break;
+    }
+  }
+
+  // For helpers, determine which chunk index this rank handles
+  if (!config.isActiveRank) {
+    for (int i = 0; i < config.numHelpers; i++) {
+      if (config.helperRanks[i] == rank) {
+        config.myHelperIndex = i;
+        break;
+      }
+    }
+  }
+  return true;
+}
+
+// All-to-all only moves bytes, so it has no reduce kernels to dispatch on --
+// but the relay presents ONE supported type set across all four collectives,
+// and only these ten are exercised anywhere in it. Two concrete hazards make
+// this worth rejecting up front rather than trusting the caller:
+//   - ncclTypeSize() returns int -1 for a type it does not know, and the
+//     callers below store it in a `size_t elementSize`, turning it into
+//     SIZE_MAX rather than 0. Every subsequent count * elementSize and
+//     offset * elementSize then overflows into wild addresses.
+//   - ncclFloat8e4m3 / ncclFloat8e5m2 are valid NCCL types that size cleanly
+//     at 1 byte, so a range check against ncclNumTypes would admit them even
+//     though no relay collective has ever been exercised with them.
+bool isSupportedRelayDataType(ncclDataType_t datatype) {
+  switch (datatype) {
+    case ncclInt8:
+    case ncclUint8:
+    case ncclInt32:
+    case ncclUint32:
+    case ncclInt64:
+    case ncclUint64:
+    case ncclFloat16:
+    case ncclFloat:
+    case ncclDouble:
+    case ncclBfloat16:
+      return true;
+    default:
+      return false;
+  }
+}
+
+} // namespace
+
+/**
+ * Two-active sharded relay all-to-all (original path).
+ *
+ * Each group has exactly 2 active ranks; the logical collective is a 2-rank
+ * all-to-all between them, accelerated by passthrough helpers that relay
+ * sharded chunks of a single exchange segment (segmentCounts[g] elements).
+ * There is NO reduction: helpers and active ranks only move data, so no kernels
+ * and no relay scratch are required. This is byte-for-byte unchanged from the
+ * original implementation; the A>2 path lives in shardedRelayAllToAllFlat.
+ *
+ * Per active rank (index m, o = 1 - m), with segmentCount = segmentCounts[g]:
+ *   - sendBuff/recvBuff hold 2 x segmentCount elements; segment i is at offset
+ *     i x segmentCount.
+ *   - Diagonal: recvBuff[m x segmentCount] = sendBuff[m x segmentCount].
+ *   - Exchange: ship sendBuff[o x segmentCount] to the other rank; receive the
+ *     other rank's segment into recvBuff[o x segmentCount].
+ *
+ * In-place is NOT supported (matches native RCCL ncclAllToAll): sendBuff and
+ * recvBuff must be distinct (validated by the caller).
+ */
+static ncclResult_t shardedRelayAllToAll2Active(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* segmentCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nGroups,
+    size_t elementSize) {
+  int numChunks = numHelpers + 1;
+
+  // =========================================================================
+  // CALCULATE PER-GROUP CHUNK SIZES (from the per-segment segmentCount)
+  // =========================================================================
+  size_t chunkSizes[SHARDED_RELAY_MAX_GROUPS];
+  size_t lastChunkSizes[SHARDED_RELAY_MAX_GROUPS];
+  size_t directChunkOffsets[SHARDED_RELAY_MAX_GROUPS];
+  size_t directChunkSizes[SHARDED_RELAY_MAX_GROUPS];
+
+  for (int g = 0; g < nGroups; g++) {
+    size_t count = segmentCounts[g];
+
+    // Skip groups with segmentCount == 0; the per-phase loops below already
+    // check segmentCounts[g] == 0 and bypass NCCL ops for those groups.
+    if (count == 0) {
+      chunkSizes[g] = 0;
+      lastChunkSizes[g] = 0;
+      directChunkOffsets[g] = 0;
+      directChunkSizes[g] = 0;
+      continue;
+    }
+
+    // Calculate chunk size (aligned to CHUNK_ALIGN_ELEMENTS). When the
+    // per-chunk size rounded down to CHUNK_ALIGN_ELEMENTS is zero, the segment
+    // is too small to scatter and the caller should fall back to a regular
+    // all-to-all.
+    size_t chunkSize = count / numChunks;
+    chunkSize = (chunkSize / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
+    if (chunkSize == 0) {
+      return ncclInvalidArgument;
+    }
+    chunkSizes[g] = chunkSize;
+
+    // Calculate the size of the last chunk (absorbs the remainder)
+    size_t totalChunkedElements = static_cast<size_t>(numChunks) * chunkSize;
+    size_t lastChunkSize = chunkSize;
+    if (totalChunkedElements < count) {
+      lastChunkSize = chunkSize + (count - totalChunkedElements);
+    }
+    lastChunkSizes[g] = lastChunkSize;
+
+    // Direct exchange chunk info (within the single exchange segment)
+    int directChunkIndex = numHelpers;
+    directChunkOffsets[g] = static_cast<size_t>(directChunkIndex) * chunkSize;
+    directChunkSizes[g] = lastChunkSize;
+  }
+
+  // For an active rank, compute its segment offsets up-front.
+  size_t recvSegOffset = 0; // exchange segment in recvBuff (recvSeg[o])
+  size_t sendSegOffset = 0; // exchange segment in sendBuff (sendSeg[o])
+  size_t diagOffset = 0; // diagonal segment offset (m x segmentCount)
+  if (myActiveGroup >= 0 && segmentCounts[myActiveGroup] > 0) {
+    const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
+    size_t segmentCount = segmentCounts[myActiveGroup];
+    int otherActiveIndex = 1 - cfg.myActiveIndex;
+    diagOffset = static_cast<size_t>(cfg.myActiveIndex) * segmentCount;
+    sendSegOffset = static_cast<size_t>(otherActiveIndex) * segmentCount;
+    recvSegOffset = sendSegOffset; // exchange segment shares offset o x count
+  }
+
+  // =========================================================================
+  // PHASE 1 (active->helpers): active ranks scatter their sendSeg[o] chunks
+  // =========================================================================
+  // Helpers receive from each active rank into offset-based slots:
+  //   slot a at offset (a x chunkSize) holds data from active rank a.
+  NCCLCHECK(ncclGroupStart());
+
+  for (int g = 0; g < nGroups; g++) {
+    if (segmentCounts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    const void* sendbuff = sendBuffs[g];
+    void* recvbuff = recvBuffs[g];
+    size_t chunkSize = chunkSizes[g];
+
+    if (cfg.isActiveRank) {
+      // Active rank: send chunk h of my sendSeg[o] to helper h
+      for (int h = 0; h < cfg.numHelpers; h++) {
+        int helperRank = cfg.helperRanks[h];
+        size_t chunkOffset = sendSegOffset + static_cast<size_t>(h) * chunkSize;
+
+        NCCLCHECK(ncclSend(
+            static_cast<const char*>(sendbuff) + chunkOffset * elementSize,
+            chunkSize,
+            datatype,
+            helperRank,
+            comm,
+            stream));
+      }
+    } else {
+      // Helper rank: receive from each active rank into slot a
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        int activeRank = cfg.activeRanks[a];
+        size_t helperOffset = static_cast<size_t>(a) * chunkSize;
+
+        NCCLCHECK(ncclRecv(
+            static_cast<char*>(recvbuff) + helperOffset * elementSize,
+            chunkSize,
+            datatype,
+            activeRank,
+            comm,
+            stream));
+      }
+    }
+  }
+
+  NCCLCHECK(ncclGroupEnd());
+
+  // =========================================================================
+  // PHASE 2 (helpers->active, batched): Passthrough forward
+  // =========================================================================
+  // Each helper sends slot 0 (a0's data) -> a1 and slot 1 (a1's data) -> a0.
+  // The active rank receives all numHelpers chunks DIRECTLY into the exchange
+  // segment of recvBuff (recvSeg[o]) at offset recvSegOffset + h x chunkSize.
+  // No reduction and no relay scratch are required.
+  NCCLCHECK(ncclGroupStart());
+
+  for (int g = 0; g < nGroups; g++) {
+    if (segmentCounts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    void* recvbuff = recvBuffs[g];
+    size_t chunkSize = chunkSizes[g];
+
+    if (!cfg.isActiveRank) {
+      // Helper for group g: forward each slot to the OTHER active rank.
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        int targetActive = cfg.activeRanks[1 - a];
+        NCCLCHECK(ncclSend(
+            static_cast<const char*>(recvbuff) +
+                static_cast<size_t>(a) * chunkSize * elementSize,
+            chunkSize,
+            datatype,
+            targetActive,
+            comm,
+            stream));
+      }
+    } else {
+      // Active rank: receive forwarded data from each helper directly into the
+      // exchange segment of recvBuff at offset recvSegOffset + h x chunkSize.
+      for (int h = 0; h < cfg.numHelpers; h++) {
+        int helperRank = cfg.helperRanks[h];
+        size_t dstOffset = recvSegOffset + static_cast<size_t>(h) * chunkSize;
+        NCCLCHECK(ncclRecv(
+            static_cast<char*>(recvbuff) + dstOffset * elementSize,
+            chunkSize,
+            datatype,
+            helperRank,
+            comm,
+            stream));
+      }
+    }
+  }
+
+  NCCLCHECK(ncclGroupEnd());
+
+  // =========================================================================
+  // PHASE 3 (diagonal copy): recvSeg[m] = sendSeg[m]
+  // =========================================================================
+  // The self segment is copied locally (out-of-place); both reside at offset
+  // m x segmentCount in their respective buffers.
+  if (myActiveGroup >= 0 && segmentCounts[myActiveGroup] > 0) {
+    const void* sendbuff = sendBuffs[myActiveGroup];
+    void* recvbuff = recvBuffs[myActiveGroup];
+    size_t segmentBytes = segmentCounts[myActiveGroup] * elementSize;
+    cudaMemcpyAsync(
+        static_cast<char*>(recvbuff) + diagOffset * elementSize,
+        static_cast<const char*>(sendbuff) + diagOffset * elementSize,
+        segmentBytes,
+        cudaMemcpyDeviceToDevice,
+        stream);
+  }
+
+  // =========================================================================
+  // PHASE 4 (active<->active): Direct exchange of the last chunk
+  // =========================================================================
+  // Active ranks exchange the direct chunk of the exchange segment; it is
+  // received directly into recvSeg[o]'s direct-chunk slot (out-of-place).
+  NCCLCHECK(ncclGroupStart());
+
+  for (int g = 0; g < nGroups; g++) {
+    if (segmentCounts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+
+    if (cfg.isActiveRank) {
+      const void* sendbuff = sendBuffs[g];
+      void* recvbuff = recvBuffs[g];
+      size_t directChunkOffset = directChunkOffsets[g];
+      size_t directChunkSize = directChunkSizes[g];
+      size_t sendDirectOffset = sendSegOffset + directChunkOffset;
+      size_t recvDirectOffset = recvSegOffset + directChunkOffset;
+
+      // Send my direct chunk to all other active ranks
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        if (a == cfg.myActiveIndex)
+          continue;
+        int otherActiveRank = cfg.activeRanks[a];
+
+        NCCLCHECK(ncclSend(
+            static_cast<const char*>(sendbuff) + sendDirectOffset * elementSize,
+            directChunkSize,
+            datatype,
+            otherActiveRank,
+            comm,
+            stream));
+      }
+
+      // Receive direct chunks from all other active ranks directly into the
+      // exchange segment of recvBuff (out-of-place, so no aliasing hazard).
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        if (a == cfg.myActiveIndex)
+          continue;
+        int otherActiveRank = cfg.activeRanks[a];
+
+        NCCLCHECK(ncclRecv(
+            static_cast<char*>(recvbuff) + recvDirectOffset * elementSize,
+            directChunkSize,
+            datatype,
+            otherActiveRank,
+            comm,
+            stream));
+      }
+    }
+  }
+
+  NCCLCHECK(ncclGroupEnd());
+
+  // Phase 5: none. All-to-all performs no reduction; the exchange and diagonal
+  // segments are already in place in recvBuff.
+  return ncclSuccess;
+}
+
+/**
+ * All-to-all for > 2 active ranks (flat, pure-direct 1-hop).
+ *
+ * All-to-all is a permutation, not a reduction. Every (source m, owner j) pair
+ * carries a distinct segment; each active rank's sendBuff/recvBuff hold A
+ * segments of segmentCount (sendSeg[j] -> owner j, recvSeg[s] <- source s).
+ *
+ * For A>2 this is a plain direct all-to-all among the active ranks over the
+ * 1-hop intra links: each active sends sendSeg[j] straight to owner j and recvs
+ * source s's segment into recvSeg[s]; the diagonal recvSeg[m] = sendSeg[m] is
+ * copied locally. NO helper relay is used -- the 2-hop offload that helps the
+ * other collectives is a net loss for A>2 all-to-all (its serial
+ * source->helper->owner path plus the helper HBM round-trip costs more than the
+ * extra link-spreading buys, with only A helpers), and the fused multi-group
+ * direct exchange already outruns NCCL's own P2P-bound 4-GPU all_to_all by a
+ * wide margin (~1.4x). Helper ranks do no work for a group they are not active
+ * in.
+ *
+ * OUT-OF-PLACE ONLY (sendBuff != recvBuff, validated by the caller). Requires a
+ * power-of-two active count. (The 2-active path still uses the helper relay,
+ * which wins there thanks to 6 dedicated helpers per group.)
+ */
+static ncclResult_t shardedRelayAllToAllFlat(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* segmentCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nActiveRanksPerGroup,
+    int nGroups,
+    size_t elementSize) {
+  const int A = nActiveRanksPerGroup;
+  (void)numHelpers; // pure-direct: no helper relay for A>2 all-to-all.
+
+  // Diagonal copy recvSeg[m] = sendSeg[m] (active group only, out-of-place).
+  if (myActiveGroup >= 0 && segmentCounts[myActiveGroup] > 0) {
+    const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
+    size_t sc = segmentCounts[myActiveGroup];
+    size_t diagOffset = static_cast<size_t>(cfg.myActiveIndex) * sc;
+    cudaMemcpyAsync(
+        static_cast<char*>(recvBuffs[myActiveGroup]) + diagOffset * elementSize,
+        static_cast<const char*>(sendBuffs[myActiveGroup]) +
+            diagOffset * elementSize,
+        sc * elementSize,
+        cudaMemcpyDeviceToDevice,
+        stream);
+  }
+
+  // Direct all-to-all: each active sends sendSeg[j] to owner j and recvs source
+  // s's segment into recvSeg[s] over the 1-hop intra links, in one ncclGroup
+  // (send AND recv together so the exchange cannot deadlock). A rank that is a
+  // helper (not active) for a group does nothing for it.
+  NCCLCHECK(ncclGroupStart());
+  for (int g = 0; g < nGroups; g++) {
+    if (segmentCounts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    if (!cfg.isActiveRank)
+      continue;
+    size_t sc = segmentCounts[g];
+    const char* sendbuff = static_cast<const char*>(sendBuffs[g]);
+    char* recvbuff = static_cast<char*>(recvBuffs[g]);
+    int m = cfg.myActiveIndex;
+    for (int j = 0; j < A; j++) {
+      if (j == m)
+        continue;
+      NCCLCHECK(ncclSend(
+          sendbuff + static_cast<size_t>(j) * sc * elementSize,
+          sc,
+          datatype,
+          cfg.activeRanks[j],
+          comm,
+          stream));
+    }
+    for (int s = 0; s < A; s++) {
+      if (s == m)
+        continue;
+      NCCLCHECK(ncclRecv(
+          recvbuff + static_cast<size_t>(s) * sc * elementSize,
+          sc,
+          datatype,
+          cfg.activeRanks[s],
+          comm,
+          stream));
+    }
+  }
+  NCCLCHECK(ncclGroupEnd());
+
+  return ncclSuccess;
+}
+
+/**
+ * Fused Multi-Group Sharded Relay All-to-All.
+ *
+ * Executes multiple sharded relay all-to-alls in one fused call. Each rank is
+ * ACTIVE for exactly one group and a HELPER for the others. In-place is NOT
+ * supported (matches native RCCL ncclAllToAll).
+ *
+ * nActiveRanksPerGroup must be a power of two (2 or 4): A==2 uses the original
+ * 2-active path (helper relay, which wins there); A>2 uses a pure-direct
+ * all-to-all among the active ranks (no helper relay -- the 2-hop offload is a
+ * net loss at A>2, see shardedRelayAllToAllFlat), so helper ranks do no work.
+ */
+HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* segmentCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const int* const* allActiveRanks,
+    int nActiveRanksPerGroup,
+    int nGroups) {
+  int nRanks, rank;
+  NCCLCHECK(ncclCommCount(comm, &nRanks));
+  NCCLCHECK(ncclCommUserRank(comm, &rank));
+
+  // Validate every argument before touching segmentCounts: the all-zero scan
+  // below indexes segmentCounts[0..nGroups), so a null pointer or an
+  // out-of-range nGroups has to be rejected first. Bounds-checking nGroups up
+  // here also means nGroups <= 0 reports ncclInvalidArgument rather than
+  // skipping the scan entirely and returning ncclSuccess.
+  if (nGroups < 1 || nGroups > SHARDED_RELAY_MAX_GROUPS) {
+    return ncclInvalidArgument;
+  }
+
+  if (recvBuffs == nullptr || allActiveRanks == nullptr ||
+      segmentCounts == nullptr || sendBuffs == nullptr) {
+    return ncclInvalidArgument;
+  }
+
+  // Require a power-of-two active-rank count (>= 2) for the XOR schedule.
+  if (nActiveRanksPerGroup < 2 || !isPowerOfTwo(nActiveRanksPerGroup)) {
+    return ncclInvalidArgument;
+  }
+
+  if (!isSupportedRelayDataType(datatype)) {
+    return ncclInvalidArgument;
+  }
+
+  // Check if all segmentCounts are zero
+  bool allZero = true;
+  for (int g = 0; g < nGroups; g++) {
+    if (segmentCounts[g] != 0) {
+      allZero = false;
+      break;
+    }
+  }
+  if (allZero) {
+    return ncclSuccess;
+  }
+
+  size_t elementSize = ncclTypeSize(datatype);
+
+  // =========================================================================
+  // BUILD RANK CONFIGURATION FOR ALL GROUPS
+  // =========================================================================
+  ShardedRelayRankConfig configs[SHARDED_RELAY_MAX_GROUPS];
+  int myActiveGroup = -1; // Which group is this rank active for?
+
+  for (int g = 0; g < nGroups; g++) {
+    if (!buildShardedRelayRankConfig(
+            nRanks,
+            rank,
+            allActiveRanks[g],
+            nActiveRanksPerGroup,
+            configs[g])) {
+      return ncclInvalidArgument;
+    }
+    if (configs[g].isActiveRank) {
+      myActiveGroup = g;
+    }
+  }
+
+  // All groups should have the same number of helpers (same chunk structure)
+  int numHelpers = configs[0].numHelpers;
+
+  // In-place is NOT supported for all-to-all: reject when the active group's
+  // input and output alias (matches native ncclAllToAll).
+  if (myActiveGroup >= 0 && segmentCounts[myActiveGroup] > 0 &&
+      sendBuffs[myActiveGroup] == recvBuffs[myActiveGroup]) {
+    return ncclInvalidArgument;
+  }
+
+  // Build per-group buffer arrays for the unchanged kernels. Helper groups use
+  // their scratch (recvBuffs[g]); the active group uses the caller's contiguous
+  // input/output buffers directly (out-of-place).
+  const void* sendBuffs2[SHARDED_RELAY_MAX_GROUPS];
+  void* recvBuffs2[SHARDED_RELAY_MAX_GROUPS];
+  for (int g = 0; g < nGroups; g++) {
+    sendBuffs2[g] = sendBuffs[g];
+    recvBuffs2[g] = recvBuffs[g];
+  }
+
+  ncclResult_t r;
+  if (nActiveRanksPerGroup == 2) {
+    r = shardedRelayAllToAll2Active(
+        sendBuffs2,
+        recvBuffs2,
+        segmentCounts,
+        datatype,
+        comm,
+        stream,
+        configs,
+        myActiveGroup,
+        numHelpers,
+        nGroups,
+        elementSize);
+  } else {
+    // A>2: flat all-to-all + 2-hop relay over A-1 XOR-matching rounds.
+    r = shardedRelayAllToAllFlat(
+        sendBuffs2,
+        recvBuffs2,
+        segmentCounts,
+        datatype,
+        comm,
+        stream,
+        configs,
+        myActiveGroup,
+        numHelpers,
+        nActiveRanksPerGroup,
+        nGroups,
+        elementSize);
+  }
+
+  return r;
+}

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
@@ -624,7 +624,7 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
   // direct holds on longer. Cross over below each.
   const size_t kA2PureDirectMaxBytes = (nGroups > 1)
       ? (static_cast<size_t>(2) << 20) // fused: < 2 MB
-      : (static_cast<size_t>(6) << 20); // independent: < 6 MB
+      : (static_cast<size_t>(27) << 20); // independent: < 27 MB
   const bool a2UseFlat =
       (nActiveRanksPerGroup == 2) && (maxBytes < kA2PureDirectMaxBytes);
   if (nActiveRanksPerGroup == 2 && !a2UseFlat) {

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
@@ -134,6 +134,62 @@ bool buildShardedRelayRankConfig(
   return true;
 }
 
+struct A4RelayTask {
+  int sourceIndex;
+  int destIndex;
+  int helperIndex;
+  int helperSlot;
+};
+
+constexpr int A4_RELAY_TASKS = 12;
+constexpr int A4_RELAY_TASKS_PER_HELPER = 3;
+
+bool buildA4RelayTasks(
+    const ShardedRelayRankConfig& config,
+    A4RelayTask (&tasks)[A4_RELAY_TASKS]) {
+  if (config.nActiveRanks != 4 || config.numHelpers != 4) {
+    return false;
+  }
+
+  // p is a Latin permutation: h = source XOR p[dest]. Excluding the diagonal
+  // leaves each helper with three distinct (source, destination) tasks and
+  // three distinct destinations. helperIndex indexes config.helperRanks, so
+  // every assignment is also checked against the actual helper set.
+  constexpr int p[4] = {0, 2, 3, 1};
+  int helperTaskCounts[4] = {0, 0, 0, 0};
+  bool helperDestSeen[4][4] = {};
+  int taskIndex = 0;
+  for (int source = 0; source < 4; source++) {
+    for (int dest = 0; dest < 4; dest++) {
+      if (source == dest) {
+        continue;
+      }
+      const int helperIndex = source ^ p[dest];
+      if (helperIndex < 0 || helperIndex >= config.numHelpers ||
+          config.helperRanks[helperIndex] < 0 ||
+          helperDestSeen[helperIndex][dest]) {
+        return false;
+      }
+      const int helperSlot = helperTaskCounts[helperIndex]++;
+      if (helperSlot >= A4_RELAY_TASKS_PER_HELPER) {
+        return false;
+      }
+      helperDestSeen[helperIndex][dest] = true;
+      tasks[taskIndex++] = {source, dest, helperIndex, helperSlot};
+    }
+  }
+
+  if (taskIndex != A4_RELAY_TASKS) {
+    return false;
+  }
+  for (int helper = 0; helper < 4; helper++) {
+    if (helperTaskCounts[helper] != A4_RELAY_TASKS_PER_HELPER) {
+      return false;
+    }
+  }
+  return true;
+}
+
 // All-to-all only moves bytes, so it has no reduce kernels to dispatch on --
 // but the relay presents ONE supported type set across all four collectives,
 // and only these ten are exercised anywhere in it. Two concrete hazards make
@@ -398,34 +454,177 @@ static ncclResult_t shardedRelayAllToAll2Active(
 }
 
 /**
- * All-to-all for > 2 active ranks (flat, pure-direct 1-hop).
+ * A=4 no-pack XOR/Latin relay path.
  *
- * All-to-all is a permutation, not a reduction. Every (source m, owner j) pair
- * carries a distinct segment; each active rank's sendBuff/recvBuff hold A
- * segments of segmentCount (sendSeg[j] -> owner j, recvSeg[s] <- source s).
- *
- * For A>2 this is a plain direct all-to-all among the active ranks over the
- * 1-hop intra links: each active sends sendSeg[j] straight to owner j and recvs
- * source s's segment into recvSeg[s]; the diagonal recvSeg[m] = sendSeg[m] is
- * copied locally. NO helper relay is used.
- *
- * The 2-hop helper offload that pays off for the other A>2 collectives was
- * implemented and measured here, and it loses. Its link model promises 1.67x
- * (direct 2*(A-1)*cs + offload H*cs per segment, both groups balanced at
- * (A-1)*cs per link), but a permutation gives the helper A*(A-1) = 12 distinct
- * (dest, source) chunks per group with no reduction to amortize them, and the
- * resulting p2p op count costs more than the extra link-spreading buys:
- * measured on MI350X (A=4, bf16, 8 GPUs) it ran 0.75-0.97x against pure-direct
- * from 13.5 MB to 135 MB and only reached 1.03-1.07x at 256 MB-1 GB. Coalescing
- * the helper's sends per dest (its slots are already grouped by dest) would
- * need a gather kernel on the send side and a scatter kernel on the recv side,
- * since both ends are strided by segmentCount; that is the open lead if this is
- * revisited.
- *
- * OUT-OF-PLACE ONLY (sendBuff != recvBuff, validated by the caller). Requires a
- * power-of-two active count. (The 2-active path still uses the helper relay,
- * which wins there thanks to 6 dedicated helpers per group.)
+ * Each off-diagonal segment stays in place and is split into contiguous
+ * directA, relay, and directB regions. The relay region takes two hops through
+ * one of the four helpers; both direct regions take one hop to the destination.
+ * The diagonal remains a local copy. OUT-OF-PLACE ONLY.
  */
+static ncclResult_t shardedRelayAllToAllA4XorRelay(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* segmentCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int nGroups,
+    size_t elementSize) {
+  size_t directACounts[SHARDED_RELAY_MAX_GROUPS];
+  size_t relayCounts[SHARDED_RELAY_MAX_GROUPS];
+  size_t directBCounts[SHARDED_RELAY_MAX_GROUPS];
+  A4RelayTask tasks[SHARDED_RELAY_MAX_GROUPS][A4_RELAY_TASKS];
+
+  for (int g = 0; g < nGroups; g++) {
+    const size_t third = segmentCounts[g] / 3;
+    directACounts[g] = third;
+    relayCounts[g] = (third / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
+    directBCounts[g] = segmentCounts[g] - directACounts[g] - relayCounts[g];
+    if (!buildA4RelayTasks(configs[g], tasks[g])) {
+      return ncclInvalidArgument;
+    }
+  }
+
+  // Keep the existing out-of-place diagonal copy unchanged.
+  if (myActiveGroup >= 0) {
+    const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
+    const size_t sc = segmentCounts[myActiveGroup];
+    const size_t diagOffset = static_cast<size_t>(cfg.myActiveIndex) * sc;
+    cudaMemcpyAsync(
+        static_cast<char*>(recvBuffs[myActiveGroup]) + diagOffset * elementSize,
+        static_cast<const char*>(sendBuffs[myActiveGroup]) +
+            diagOffset * elementSize,
+        sc * elementSize,
+        cudaMemcpyDeviceToDevice,
+        stream);
+  }
+
+  // Phase 1 sends the first direct third to its final destination while the
+  // middle third goes to its assigned helper's compact three-slot scratch.
+  NCCLCHECK(ncclGroupStart());
+  for (int g = 0; g < nGroups; g++) {
+    const ShardedRelayRankConfig& cfg = configs[g];
+    const size_t sc = segmentCounts[g];
+    const size_t directA = directACounts[g];
+    const size_t relay = relayCounts[g];
+    for (const A4RelayTask& task : tasks[g]) {
+      if (cfg.isActiveRank) {
+        const int myIndex = cfg.myActiveIndex;
+        if (task.sourceIndex == myIndex) {
+          const char* sendSegment = static_cast<const char*>(sendBuffs[g]) +
+              static_cast<size_t>(task.destIndex) * sc * elementSize;
+          if (directA > 0) {
+            NCCLCHECK(ncclSend(
+                sendSegment,
+                directA,
+                datatype,
+                cfg.activeRanks[task.destIndex],
+                comm,
+                stream));
+          }
+          if (relay > 0) {
+            NCCLCHECK(ncclSend(
+                sendSegment + directA * elementSize,
+                relay,
+                datatype,
+                cfg.helperRanks[task.helperIndex],
+                comm,
+                stream));
+          }
+        }
+        if (task.destIndex == myIndex) {
+          char* recvSegment = static_cast<char*>(recvBuffs[g]) +
+              static_cast<size_t>(task.sourceIndex) * sc * elementSize;
+          if (directA > 0) {
+            NCCLCHECK(ncclRecv(
+                recvSegment,
+                directA,
+                datatype,
+                cfg.activeRanks[task.sourceIndex],
+                comm,
+                stream));
+          }
+        }
+      } else if (relay > 0 && task.helperIndex == cfg.myHelperIndex) {
+        char* helperSlot = static_cast<char*>(recvBuffs[g]) +
+            static_cast<size_t>(task.helperSlot) * relay * elementSize;
+        NCCLCHECK(ncclRecv(
+            helperSlot,
+            relay,
+            datatype,
+            cfg.activeRanks[task.sourceIndex],
+            comm,
+            stream));
+      }
+    }
+  }
+  NCCLCHECK(ncclGroupEnd());
+
+  // Phase 2 sends the tail directly and forwards each compact helper slot into
+  // recv[source * sc + directA]. Every byte is covered by the adjacent
+  // [directA, relay, directB] regions; alignment loss and division tails are in
+  // directB.
+  NCCLCHECK(ncclGroupStart());
+  for (int g = 0; g < nGroups; g++) {
+    const ShardedRelayRankConfig& cfg = configs[g];
+    const size_t sc = segmentCounts[g];
+    const size_t directA = directACounts[g];
+    const size_t relay = relayCounts[g];
+    const size_t directB = directBCounts[g];
+    for (const A4RelayTask& task : tasks[g]) {
+      if (cfg.isActiveRank) {
+        const int myIndex = cfg.myActiveIndex;
+        if (task.sourceIndex == myIndex) {
+          const char* sendSegment = static_cast<const char*>(sendBuffs[g]) +
+              static_cast<size_t>(task.destIndex) * sc * elementSize;
+          NCCLCHECK(ncclSend(
+              sendSegment + (directA + relay) * elementSize,
+              directB,
+              datatype,
+              cfg.activeRanks[task.destIndex],
+              comm,
+              stream));
+        }
+        if (task.destIndex == myIndex) {
+          char* recvSegment = static_cast<char*>(recvBuffs[g]) +
+              static_cast<size_t>(task.sourceIndex) * sc * elementSize;
+          NCCLCHECK(ncclRecv(
+              recvSegment + (directA + relay) * elementSize,
+              directB,
+              datatype,
+              cfg.activeRanks[task.sourceIndex],
+              comm,
+              stream));
+          if (relay > 0) {
+            NCCLCHECK(ncclRecv(
+                recvSegment + directA * elementSize,
+                relay,
+                datatype,
+                cfg.helperRanks[task.helperIndex],
+                comm,
+                stream));
+          }
+        }
+      } else if (relay > 0 && task.helperIndex == cfg.myHelperIndex) {
+        const char* helperSlot = static_cast<const char*>(recvBuffs[g]) +
+            static_cast<size_t>(task.helperSlot) * relay * elementSize;
+        NCCLCHECK(ncclSend(
+            helperSlot,
+            relay,
+            datatype,
+            cfg.activeRanks[task.destIndex],
+            comm,
+            stream));
+      }
+    }
+  }
+  NCCLCHECK(ncclGroupEnd());
+
+  return ncclSuccess;
+}
+
 static ncclResult_t shardedRelayAllToAllFlat(
     const void* const* sendBuffs,
     void* const* recvBuffs,
@@ -506,10 +705,9 @@ static ncclResult_t shardedRelayAllToAllFlat(
  * ACTIVE for exactly one group and a HELPER for the others. In-place is NOT
  * supported (matches native RCCL ncclAllToAll).
  *
- * nActiveRanksPerGroup must be a power of two (2 or 4): A==2 uses the dedicated
- * 2-active relay (6 helpers per group), A>2 a pure-direct all-to-all among the
- * active ranks -- see shardedRelayAllToAllFlat for why the helper offload loses
- * for a permutation.
+ * nActiveRanksPerGroup must be a power of two (2 or 4). A==2 selects its direct
+ * or dedicated 6-helper relay schedule by size. A==4 uses the deterministic
+ * XOR/Latin helper schedule in its retained window and exact direct otherwise.
  */
 HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
     const void* const* sendBuffs,
@@ -627,6 +825,18 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
       : (static_cast<size_t>(27) << 20); // independent: < 27 MB
   const bool a2UseFlat =
       (nActiveRanksPerGroup == 2) && (maxBytes < kA2PureDirectMaxBytes);
+  bool allSegmentCountsPositive = true;
+  for (int g = 0; g < nGroups; g++) {
+    allSegmentCountsPositive &= segmentCounts[g] > 0;
+  }
+  // Use the common maximum across groups so every rank selects the same A=4
+  // schedule. One segment of helper scratch is sufficient for all three relay
+  // slots because 3 * alignDown(segmentCount / 3, 128) <= segmentCount.
+  constexpr size_t kA4XorRelayMinBytes = static_cast<size_t>(63) << 20;
+  constexpr size_t kA4XorRelayMaxBytes = static_cast<size_t>(256) << 20;
+  const bool useA4XorRelay = nActiveRanksPerGroup == 4 && numHelpers == 4 &&
+      allSegmentCountsPositive && maxBytes >= kA4XorRelayMinBytes &&
+      maxBytes < kA4XorRelayMaxBytes;
   if (nActiveRanksPerGroup == 2 && !a2UseFlat) {
     r = shardedRelayAllToAll2Active(
         sendBuffs2,
@@ -640,8 +850,20 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
         numHelpers,
         nGroups,
         elementSize);
+  } else if (useA4XorRelay) {
+    r = shardedRelayAllToAllA4XorRelay(
+        sendBuffs2,
+        recvBuffs2,
+        segmentCounts,
+        datatype,
+        comm,
+        stream,
+        configs,
+        myActiveGroup,
+        nGroups,
+        elementSize);
   } else {
-    // A>2, or small A==2: flat single-group pure-direct all-to-all.
+    // A==4 outside the routed window, or small A==2: exact direct all-to-all.
     r = shardedRelayAllToAllFlat(
         sendBuffs2,
         recvBuffs2,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
@@ -197,227 +197,126 @@ static ncclResult_t shardedRelayAllToAll2Active(
     int numHelpers,
     int nGroups,
     size_t elementSize) {
-  int numChunks = numHelpers + 1;
+  // =========================================================================
+  // CHUNK GEOMETRY: numHelpers relayed chunks + TWO direct chunks
+  // =========================================================================
+  // The active<->active link is idle while the relay scatter and forward run on
+  // the cross links, so instead of a third comm group for a single direct
+  // chunk, one direct chunk rides along with each relay group. With numChunks =
+  // numHelpers + 2 every link carries exactly one chunk per direction per
+  // group, making the critical path 2*segmentCount/numChunks instead of the
+  // 3*segmentCount/(numHelpers+1) of a separate direct phase.
+  const int numChunks = numHelpers + 2;
 
-  // =========================================================================
-  // CALCULATE PER-GROUP CHUNK SIZES (from the per-segment segmentCount)
-  // =========================================================================
   size_t chunkSizes[SHARDED_RELAY_MAX_GROUPS];
-  size_t lastChunkSizes[SHARDED_RELAY_MAX_GROUPS];
-  size_t directChunkOffsets[SHARDED_RELAY_MAX_GROUPS];
-  size_t directChunkSizes[SHARDED_RELAY_MAX_GROUPS];
+  size_t relayTotals[SHARDED_RELAY_MAX_GROUPS]; // == direct chunk A's offset
+  size_t dirBOffsets[SHARDED_RELAY_MAX_GROUPS];
+  size_t dirBSizes[SHARDED_RELAY_MAX_GROUPS]; // absorbs the remainder
 
   for (int g = 0; g < nGroups; g++) {
     size_t count = segmentCounts[g];
 
-    // Skip groups with segmentCount == 0; the per-phase loops below already
-    // check segmentCounts[g] == 0 and bypass NCCL ops for those groups.
+    // Zero-count groups are skipped by every loop below.
     if (count == 0) {
       chunkSizes[g] = 0;
-      lastChunkSizes[g] = 0;
-      directChunkOffsets[g] = 0;
-      directChunkSizes[g] = 0;
+      relayTotals[g] = 0;
+      dirBOffsets[g] = 0;
+      dirBSizes[g] = 0;
       continue;
     }
 
-    // Calculate chunk size (aligned to CHUNK_ALIGN_ELEMENTS). When the
-    // per-chunk size rounded down to CHUNK_ALIGN_ELEMENTS is zero, the segment
-    // is too small to scatter and the caller should fall back to a regular
-    // all-to-all.
+    // A chunk size that rounds down to zero means the segment is too small to
+    // scatter; the caller should fall back to a regular all-to-all.
     size_t chunkSize = count / numChunks;
     chunkSize = (chunkSize / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
     if (chunkSize == 0) {
       return ncclInvalidArgument;
     }
     chunkSizes[g] = chunkSize;
-
-    // Calculate the size of the last chunk (absorbs the remainder)
-    size_t totalChunkedElements = static_cast<size_t>(numChunks) * chunkSize;
-    size_t lastChunkSize = chunkSize;
-    if (totalChunkedElements < count) {
-      lastChunkSize = chunkSize + (count - totalChunkedElements);
-    }
-    lastChunkSizes[g] = lastChunkSize;
-
-    // Direct exchange chunk info (within the single exchange segment)
-    int directChunkIndex = numHelpers;
-    directChunkOffsets[g] = static_cast<size_t>(directChunkIndex) * chunkSize;
-    directChunkSizes[g] = lastChunkSize;
+    relayTotals[g] = static_cast<size_t>(numHelpers) * chunkSize;
+    dirBOffsets[g] = relayTotals[g] + chunkSize;
+    dirBSizes[g] = count - dirBOffsets[g];
   }
 
-  // For an active rank, compute its segment offsets up-front.
-  size_t recvSegOffset = 0; // exchange segment in recvBuff (recvSeg[o])
-  size_t sendSegOffset = 0; // exchange segment in sendBuff (sendSeg[o])
-  size_t diagOffset = 0; // diagonal segment offset (m x segmentCount)
+  // For an active rank, compute its segment offsets up-front. The exchange
+  // segment shares the same offset (o x segmentCount) in both buffers.
+  size_t exchangeSegOffset = 0;
+  size_t diagOffset = 0;
   if (myActiveGroup >= 0 && segmentCounts[myActiveGroup] > 0) {
     const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
     size_t segmentCount = segmentCounts[myActiveGroup];
-    int otherActiveIndex = 1 - cfg.myActiveIndex;
     diagOffset = static_cast<size_t>(cfg.myActiveIndex) * segmentCount;
-    sendSegOffset = static_cast<size_t>(otherActiveIndex) * segmentCount;
-    recvSegOffset = sendSegOffset; // exchange segment shares offset o x count
+    exchangeSegOffset =
+        static_cast<size_t>(1 - cfg.myActiveIndex) * segmentCount;
   }
 
   // =========================================================================
-  // PHASE 1 (active->helpers): active ranks scatter their sendSeg[o] chunks
+  // DIAGONAL COPY: recvSeg[m] = sendSeg[m]
   // =========================================================================
-  // Helpers receive from each active rank into offset-based slots:
-  //   slot a at offset (a x chunkSize) holds data from active rank a.
-  NCCLCHECK(ncclGroupStart());
-
-  for (int g = 0; g < nGroups; g++) {
-    if (segmentCounts[g] == 0)
-      continue;
-    const ShardedRelayRankConfig& cfg = configs[g];
-    const void* sendbuff = sendBuffs[g];
-    void* recvbuff = recvBuffs[g];
-    size_t chunkSize = chunkSizes[g];
-
-    if (cfg.isActiveRank) {
-      // Active rank: send chunk h of my sendSeg[o] to helper h
-      for (int h = 0; h < cfg.numHelpers; h++) {
-        int helperRank = cfg.helperRanks[h];
-        size_t chunkOffset = sendSegOffset + static_cast<size_t>(h) * chunkSize;
-
-        NCCLCHECK(ncclSend(
-            static_cast<const char*>(sendbuff) + chunkOffset * elementSize,
-            chunkSize,
-            datatype,
-            helperRank,
-            comm,
-            stream));
-      }
-    } else {
-      // Helper rank: receive from each active rank into slot a
-      for (int a = 0; a < cfg.nActiveRanks; a++) {
-        int activeRank = cfg.activeRanks[a];
-        size_t helperOffset = static_cast<size_t>(a) * chunkSize;
-
-        NCCLCHECK(ncclRecv(
-            static_cast<char*>(recvbuff) + helperOffset * elementSize,
-            chunkSize,
-            datatype,
-            activeRank,
-            comm,
-            stream));
-      }
-    }
-  }
-
-  NCCLCHECK(ncclGroupEnd());
-
-  // =========================================================================
-  // PHASE 2 (helpers->active, batched): Passthrough forward
-  // =========================================================================
-  // Each helper sends slot 0 (a0's data) -> a1 and slot 1 (a1's data) -> a0.
-  // The active rank receives all numHelpers chunks DIRECTLY into the exchange
-  // segment of recvBuff (recvSeg[o]) at offset recvSegOffset + h x chunkSize.
-  // No reduction and no relay scratch are required.
-  NCCLCHECK(ncclGroupStart());
-
-  for (int g = 0; g < nGroups; g++) {
-    if (segmentCounts[g] == 0)
-      continue;
-    const ShardedRelayRankConfig& cfg = configs[g];
-    void* recvbuff = recvBuffs[g];
-    size_t chunkSize = chunkSizes[g];
-
-    if (!cfg.isActiveRank) {
-      // Helper for group g: forward each slot to the OTHER active rank.
-      for (int a = 0; a < cfg.nActiveRanks; a++) {
-        int targetActive = cfg.activeRanks[1 - a];
-        NCCLCHECK(ncclSend(
-            static_cast<const char*>(recvbuff) +
-                static_cast<size_t>(a) * chunkSize * elementSize,
-            chunkSize,
-            datatype,
-            targetActive,
-            comm,
-            stream));
-      }
-    } else {
-      // Active rank: receive forwarded data from each helper directly into the
-      // exchange segment of recvBuff at offset recvSegOffset + h x chunkSize.
-      for (int h = 0; h < cfg.numHelpers; h++) {
-        int helperRank = cfg.helperRanks[h];
-        size_t dstOffset = recvSegOffset + static_cast<size_t>(h) * chunkSize;
-        NCCLCHECK(ncclRecv(
-            static_cast<char*>(recvbuff) + dstOffset * elementSize,
-            chunkSize,
-            datatype,
-            helperRank,
-            comm,
-            stream));
-      }
-    }
-  }
-
-  NCCLCHECK(ncclGroupEnd());
-
-  // =========================================================================
-  // PHASE 3 (diagonal copy): recvSeg[m] = sendSeg[m]
-  // =========================================================================
-  // The self segment is copied locally (out-of-place); both reside at offset
-  // m x segmentCount in their respective buffers.
   if (myActiveGroup >= 0 && segmentCounts[myActiveGroup] > 0) {
-    const void* sendbuff = sendBuffs[myActiveGroup];
-    void* recvbuff = recvBuffs[myActiveGroup];
-    size_t segmentBytes = segmentCounts[myActiveGroup] * elementSize;
     cudaMemcpyAsync(
-        static_cast<char*>(recvbuff) + diagOffset * elementSize,
-        static_cast<const char*>(sendbuff) + diagOffset * elementSize,
-        segmentBytes,
+        static_cast<char*>(recvBuffs[myActiveGroup]) + diagOffset * elementSize,
+        static_cast<const char*>(sendBuffs[myActiveGroup]) +
+            diagOffset * elementSize,
+        segmentCounts[myActiveGroup] * elementSize,
         cudaMemcpyDeviceToDevice,
         stream);
   }
 
   // =========================================================================
-  // PHASE 4 (active<->active): Direct exchange of the last chunk
+  // GROUP 1: relay scatter (active->helpers) || direct chunk A
+  // (active<->active)
   // =========================================================================
-  // Active ranks exchange the direct chunk of the exchange segment; it is
-  // received directly into recvSeg[o]'s direct-chunk slot (out-of-place).
   NCCLCHECK(ncclGroupStart());
 
   for (int g = 0; g < nGroups; g++) {
     if (segmentCounts[g] == 0)
       continue;
     const ShardedRelayRankConfig& cfg = configs[g];
+    size_t chunkSize = chunkSizes[g];
 
     if (cfg.isActiveRank) {
-      const void* sendbuff = sendBuffs[g];
-      void* recvbuff = recvBuffs[g];
-      size_t directChunkOffset = directChunkOffsets[g];
-      size_t directChunkSize = directChunkSizes[g];
-      size_t sendDirectOffset = sendSegOffset + directChunkOffset;
-      size_t recvDirectOffset = recvSegOffset + directChunkOffset;
+      const char* sendSeg = static_cast<const char*>(sendBuffs[g]) +
+          exchangeSegOffset * elementSize;
+      char* recvSeg =
+          static_cast<char*>(recvBuffs[g]) + exchangeSegOffset * elementSize;
 
-      // Send my direct chunk to all other active ranks
-      for (int a = 0; a < cfg.nActiveRanks; a++) {
-        if (a == cfg.myActiveIndex)
-          continue;
-        int otherActiveRank = cfg.activeRanks[a];
-
+      // Scatter: chunk h of my exchange segment goes to helper h.
+      for (int h = 0; h < cfg.numHelpers; h++) {
         NCCLCHECK(ncclSend(
-            static_cast<const char*>(sendbuff) + sendDirectOffset * elementSize,
-            directChunkSize,
+            sendSeg + static_cast<size_t>(h) * chunkSize * elementSize,
+            chunkSize,
             datatype,
-            otherActiveRank,
+            cfg.helperRanks[h],
             comm,
             stream));
       }
 
-      // Receive direct chunks from all other active ranks directly into the
-      // exchange segment of recvBuff (out-of-place, so no aliasing hazard).
+      // Direct chunk A over the otherwise-idle active<->active link.
+      int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      NCCLCHECK(ncclSend(
+          sendSeg + relayTotals[g] * elementSize,
+          chunkSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+      NCCLCHECK(ncclRecv(
+          recvSeg + relayTotals[g] * elementSize,
+          chunkSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else {
+      // Helper: receive active rank a's chunk into slot a.
+      char* helperBuf = static_cast<char*>(recvBuffs[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {
-        if (a == cfg.myActiveIndex)
-          continue;
-        int otherActiveRank = cfg.activeRanks[a];
-
         NCCLCHECK(ncclRecv(
-            static_cast<char*>(recvbuff) + recvDirectOffset * elementSize,
-            directChunkSize,
+            helperBuf + static_cast<size_t>(a) * chunkSize * elementSize,
+            chunkSize,
             datatype,
-            otherActiveRank,
+            cfg.activeRanks[a],
             comm,
             stream));
       }
@@ -426,8 +325,68 @@ static ncclResult_t shardedRelayAllToAll2Active(
 
   NCCLCHECK(ncclGroupEnd());
 
-  // Phase 5: none. All-to-all performs no reduction; the exchange and diagonal
-  // segments are already in place in recvBuff.
+  // =========================================================================
+  // GROUP 2: relay forward (helpers->active) || direct chunk B
+  // (active<->active)
+  // =========================================================================
+  // Helpers are pure passthrough: slot a goes to the OTHER active rank, landing
+  // directly in that rank's exchange segment.
+  NCCLCHECK(ncclGroupStart());
+
+  for (int g = 0; g < nGroups; g++) {
+    if (segmentCounts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    size_t chunkSize = chunkSizes[g];
+
+    if (cfg.isActiveRank) {
+      const char* sendSeg = static_cast<const char*>(sendBuffs[g]) +
+          exchangeSegOffset * elementSize;
+      char* recvSeg =
+          static_cast<char*>(recvBuffs[g]) + exchangeSegOffset * elementSize;
+
+      for (int h = 0; h < cfg.numHelpers; h++) {
+        NCCLCHECK(ncclRecv(
+            recvSeg + static_cast<size_t>(h) * chunkSize * elementSize,
+            chunkSize,
+            datatype,
+            cfg.helperRanks[h],
+            comm,
+            stream));
+      }
+
+      // Direct chunk B, again over the idle active<->active link.
+      int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      NCCLCHECK(ncclSend(
+          sendSeg + dirBOffsets[g] * elementSize,
+          dirBSizes[g],
+          datatype,
+          partner,
+          comm,
+          stream));
+      NCCLCHECK(ncclRecv(
+          recvSeg + dirBOffsets[g] * elementSize,
+          dirBSizes[g],
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else {
+      const char* helperBuf = static_cast<const char*>(recvBuffs[g]);
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        NCCLCHECK(ncclSend(
+            helperBuf + static_cast<size_t>(a) * chunkSize * elementSize,
+            chunkSize,
+            datatype,
+            cfg.activeRanks[1 - a],
+            comm,
+            stream));
+      }
+    }
+  }
+
+  NCCLCHECK(ncclGroupEnd());
+
   return ncclSuccess;
 }
 
@@ -441,13 +400,20 @@ static ncclResult_t shardedRelayAllToAll2Active(
  * For A>2 this is a plain direct all-to-all among the active ranks over the
  * 1-hop intra links: each active sends sendSeg[j] straight to owner j and recvs
  * source s's segment into recvSeg[s]; the diagonal recvSeg[m] = sendSeg[m] is
- * copied locally. NO helper relay is used -- the 2-hop offload that helps the
- * other collectives is a net loss for A>2 all-to-all (its serial
- * source->helper->owner path plus the helper HBM round-trip costs more than the
- * extra link-spreading buys, with only A helpers), and the fused multi-group
- * direct exchange already outruns NCCL's own P2P-bound 4-GPU all_to_all by a
- * wide margin (~1.4x). Helper ranks do no work for a group they are not active
- * in.
+ * copied locally. NO helper relay is used.
+ *
+ * The 2-hop helper offload that pays off for the other A>2 collectives was
+ * implemented and measured here, and it loses. Its link model promises 1.67x
+ * (direct 2*(A-1)*cs + offload H*cs per segment, both groups balanced at
+ * (A-1)*cs per link), but a permutation gives the helper A*(A-1) = 12 distinct
+ * (dest, source) chunks per group with no reduction to amortize them, and the
+ * resulting p2p op count costs more than the extra link-spreading buys:
+ * measured on MI350X (A=4, bf16, 8 GPUs) it ran 0.75-0.97x against pure-direct
+ * from 13.5 MB to 135 MB and only reached 1.03-1.07x at 256 MB-1 GB. Coalescing
+ * the helper's sends per dest (its slots are already grouped by dest) would
+ * need a gather kernel on the send side and a scatter kernel on the recv side,
+ * since both ends are strided by segmentCount; that is the open lead if this is
+ * revisited.
  *
  * OUT-OF-PLACE ONLY (sendBuff != recvBuff, validated by the caller). Requires a
  * power-of-two active count. (The 2-active path still uses the helper relay,
@@ -533,10 +499,10 @@ static ncclResult_t shardedRelayAllToAllFlat(
  * ACTIVE for exactly one group and a HELPER for the others. In-place is NOT
  * supported (matches native RCCL ncclAllToAll).
  *
- * nActiveRanksPerGroup must be a power of two (2 or 4): A==2 uses the original
- * 2-active path (helper relay, which wins there); A>2 uses a pure-direct
- * all-to-all among the active ranks (no helper relay -- the 2-hop offload is a
- * net loss at A>2, see shardedRelayAllToAllFlat), so helper ranks do no work.
+ * nActiveRanksPerGroup must be a power of two (2 or 4): A==2 uses the dedicated
+ * 2-active relay (6 helpers per group), A>2 a pure-direct all-to-all among the
+ * active ranks -- see shardedRelayAllToAllFlat for why the helper offload loses
+ * for a permutation.
  */
 HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
     const void* const* sendBuffs,
@@ -650,8 +616,8 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
   // at ~27 MB (0.38->0.53 @4KB). Independent has no cross-group contention so
   // direct holds on longer. Cross over below each.
   const size_t kA2PureDirectMaxBytes = (nGroups > 1)
-      ? (static_cast<size_t>(6) << 20) // fused: < 6 MB
-      : (static_cast<size_t>(16) << 20); // independent: < 16 MB
+      ? (static_cast<size_t>(2) << 20) // fused: < 2 MB
+      : (static_cast<size_t>(6) << 20); // independent: < 6 MB
   const bool a2UseFlat =
       (nActiveRanksPerGroup == 2) && (maxBytes < kA2PureDirectMaxBytes);
   if (nActiveRanksPerGroup == 2 && !a2UseFlat) {

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
@@ -210,6 +210,7 @@ static ncclResult_t shardedRelayAllToAll2Active(
 
   size_t chunkSizes[SHARDED_RELAY_MAX_GROUPS];
   size_t relayTotals[SHARDED_RELAY_MAX_GROUPS]; // == direct chunk A's offset
+  size_t dirASizes[SHARDED_RELAY_MAX_GROUPS];
   size_t dirBOffsets[SHARDED_RELAY_MAX_GROUPS];
   size_t dirBSizes[SHARDED_RELAY_MAX_GROUPS]; // absorbs the remainder
 
@@ -220,21 +221,23 @@ static ncclResult_t shardedRelayAllToAll2Active(
     if (count == 0) {
       chunkSizes[g] = 0;
       relayTotals[g] = 0;
+      dirASizes[g] = 0;
       dirBOffsets[g] = 0;
       dirBSizes[g] = 0;
       continue;
     }
 
-    // A chunk size that rounds down to zero means the segment is too small to
-    // scatter; the caller should fall back to a regular all-to-all.
     size_t chunkSize = count / numChunks;
     chunkSize = (chunkSize / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
-    if (chunkSize == 0) {
-      return ncclInvalidArgument;
-    }
     chunkSizes[g] = chunkSize;
     relayTotals[g] = static_cast<size_t>(numHelpers) * chunkSize;
-    dirBOffsets[g] = relayTotals[g] + chunkSize;
+    if (chunkSize == 0) {
+      dirASizes[g] = count / 2;
+      dirBOffsets[g] = dirASizes[g];
+    } else {
+      dirASizes[g] = chunkSize;
+      dirBOffsets[g] = relayTotals[g] + chunkSize;
+    }
     dirBSizes[g] = count - dirBOffsets[g];
   }
 
@@ -282,33 +285,35 @@ static ncclResult_t shardedRelayAllToAll2Active(
           static_cast<char*>(recvBuffs[g]) + exchangeSegOffset * elementSize;
 
       // Scatter: chunk h of my exchange segment goes to helper h.
-      for (int h = 0; h < cfg.numHelpers; h++) {
-        NCCLCHECK(ncclSend(
-            sendSeg + static_cast<size_t>(h) * chunkSize * elementSize,
-            chunkSize,
-            datatype,
-            cfg.helperRanks[h],
-            comm,
-            stream));
+      if (chunkSize > 0) {
+        for (int h = 0; h < cfg.numHelpers; h++) {
+          NCCLCHECK(ncclSend(
+              sendSeg + static_cast<size_t>(h) * chunkSize * elementSize,
+              chunkSize,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
       }
 
       // Direct chunk A over the otherwise-idle active<->active link.
       int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
       NCCLCHECK(ncclSend(
           sendSeg + relayTotals[g] * elementSize,
-          chunkSize,
+          dirASizes[g],
           datatype,
           partner,
           comm,
           stream));
       NCCLCHECK(ncclRecv(
           recvSeg + relayTotals[g] * elementSize,
-          chunkSize,
+          dirASizes[g],
           datatype,
           partner,
           comm,
           stream));
-    } else {
+    } else if (chunkSize > 0) {
       // Helper: receive active rank a's chunk into slot a.
       char* helperBuf = static_cast<char*>(recvBuffs[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {
@@ -345,14 +350,16 @@ static ncclResult_t shardedRelayAllToAll2Active(
       char* recvSeg =
           static_cast<char*>(recvBuffs[g]) + exchangeSegOffset * elementSize;
 
-      for (int h = 0; h < cfg.numHelpers; h++) {
-        NCCLCHECK(ncclRecv(
-            recvSeg + static_cast<size_t>(h) * chunkSize * elementSize,
-            chunkSize,
-            datatype,
-            cfg.helperRanks[h],
-            comm,
-            stream));
+      if (chunkSize > 0) {
+        for (int h = 0; h < cfg.numHelpers; h++) {
+          NCCLCHECK(ncclRecv(
+              recvSeg + static_cast<size_t>(h) * chunkSize * elementSize,
+              chunkSize,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
       }
 
       // Direct chunk B, again over the idle active<->active link.
@@ -371,7 +378,7 @@ static ncclResult_t shardedRelayAllToAll2Active(
           partner,
           comm,
           stream));
-    } else {
+    } else if (chunkSize > 0) {
       const char* helperBuf = static_cast<const char*>(recvBuffs[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {
         NCCLCHECK(ncclSend(

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
@@ -630,7 +630,31 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
   }
 
   ncclResult_t r;
-  if (nActiveRanksPerGroup == 2) {
+  // Size-adaptive routing for A==2. The 2Active relay (scatter/forward/direct =
+  // 3 group boundaries + a helper HBM round trip) wins on bandwidth at large
+  // sizes, but at small sizes it is latency-bound; the A-generic Flat path does
+  // a single-group pure-direct exchange (the two active ranks swap their off-
+  // diagonal segment directly, helpers idle) with minimal latency. Route small
+  // A==2 to Flat, large to the relay. maxBytes (A*segment*elemSize) equals the
+  // bench per-rank input label; crossover set nGroups-aware below.
+  size_t maxSeg = 0;
+  for (int g = 0; g < nGroups; g++) {
+    if (segmentCounts[g] > maxSeg) {
+      maxSeg = segmentCounts[g];
+    }
+  }
+  const size_t maxBytes =
+      static_cast<size_t>(nActiveRanksPerGroup) * maxSeg * elementSize;
+  // Crossover measured MI350X (bf16, 8 GPUs): fused relay overtakes Flat at
+  // ~9 MB (Flat wins the small end big, e.g. 576 KB 0.92x->1.45x), independent
+  // at ~27 MB (0.38->0.53 @4KB). Independent has no cross-group contention so
+  // direct holds on longer. Cross over below each.
+  const size_t kA2PureDirectMaxBytes = (nGroups > 1)
+      ? (static_cast<size_t>(6) << 20) // fused: < 6 MB
+      : (static_cast<size_t>(16) << 20); // independent: < 16 MB
+  const bool a2UseFlat =
+      (nActiveRanksPerGroup == 2) && (maxBytes < kA2PureDirectMaxBytes);
+  if (nActiveRanksPerGroup == 2 && !a2UseFlat) {
     r = shardedRelayAllToAll2Active(
         sendBuffs2,
         recvBuffs2,
@@ -644,7 +668,7 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
         nGroups,
         elementSize);
   } else {
-    // A>2: flat all-to-all + 2-hop relay over A-1 XOR-matching rounds.
+    // A>2, or small A==2: flat single-group pure-direct all-to-all.
     r = shardedRelayAllToAllFlat(
         sendBuffs2,
         recvBuffs2,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.h
@@ -26,14 +26,13 @@
  * reuses the same phase-synchronized passthrough-helper scheme; helpers perform
  * no compute and simply relay sharded chunks.
  *
- * nActiveRanksPerGroup must be a power of two (2 or 4). A==2 uses the original
- * 2-active passthrough relay (which wins there with 6 dedicated helpers per
- * group); A>2 uses a PURE-DIRECT all-to-all among the active ranks over the
- * 1-hop intra links -- NO helper relay, because the 2-hop offload is a net loss
- * at A>2 (only A helpers, serial source->helper->owner) and the fused direct
- * exchange already beats NCCL's P2P-bound 4-GPU all_to_all by ~1.4x. Helper
- * ranks do no work for a group they are not active in. OUT-OF-PLACE ONLY in
- * both cases.
+ * nActiveRanksPerGroup must be a power of two (2 or 4). A==2 selects between
+ * the exact direct exchange at small sizes and the original 2-active
+ * passthrough relay with 6 dedicated helpers. A==4 with 4
+ * helpers uses the no-pack XOR/Latin relay when the common maximum per-active-
+ * rank input size, A * max(segmentCounts) * elementSize, is in [63 MiB,
+ * 256 MiB) and every group count is positive. Other A==4 calls use the exact
+ * pure-direct all-to-all. OUT-OF-PLACE ONLY in all cases.
  *
  * Unlike allreduce/reduce-scatter, all-to-all performs NO reduction — it is
  * pure data movement — so no reduction kernels are used and there is no
@@ -42,68 +41,64 @@
  * All-to-All Semantics (per group, A active ranks):
  * =======================================================
  * Each active rank's sendBuff and recvBuff hold nActiveRanksPerGroup x
- * segmentCounts[g] (= 2 x segmentCounts[g]) elements:
- *   - sendBuff = [sendSeg[0] | sendSeg[1]]; sendSeg[j] is the segment destined
- *     for active index j.
- *   - recvBuff = [recvSeg[0] | recvSeg[1]]; recvSeg[i] receives the segment
- *     from active index i.
+ * segmentCounts[g] elements:
+ *   - sendBuff = [sendSeg[0] | ... | sendSeg[A-1]]; sendSeg[j] is destined for
+ *     active index j.
+ *   - recvBuff = [recvSeg[0] | ... | recvSeg[A-1]]; recvSeg[i] receives from
+ *     active index i.
  *
- * For the active rank with myActiveIndex = m, otherActiveIndex = o = 1 - m:
- *   - Diagonal (self -> self): recvSeg[m] = sendSeg[m]; both at offset
- *     m x segmentCount. A local copy.
- *   - Exchange: rank m ships sendSeg[o] (offset o x segmentCount) to the other
- *     rank and receives the other rank's sendSeg[m] into recvSeg[o] (offset
- *     o x segmentCount). This single-segment exchange is sharded across
- * helpers.
+ * For active index m, recvSeg[m] = sendSeg[m] is a local diagonal copy. Every
+ * off-diagonal sendSeg[j] is transferred to active index j and placed in its
+ * recvSeg[m].
  *
  * IN-PLACE IS NOT SUPPORTED. Like the native RCCL ncclAllToAll, sendBuff and
  * recvBuff MUST be distinct; passing sendBuff == recvBuff returns
  * ncclInvalidArgument.
  *
- * Two Comm Groups (no reduction; pure relay + a placement copy):
- * ==============================================================
+ * Schedules (no reduction; data movement + a placement copy):
+ * ============================================================
  *   Diagonal: recvSeg[m] = sendSeg[m] (cudaMemcpyAsync).
- *   Group 1:  each active rank scatters numHelpers chunks of its sendSeg[o] to
- *             helpers (each helper stores two slots, one per active rank) AND
- *             the two active ranks directly exchange one chunk over the
- *             otherwise-idle active<->active link.
- *   Group 2:  each helper forwards slot-from-a0 -> a1 and slot-from-a1 -> a0,
- *             landing DIRECTLY in recvSeg[o] at h x chunkSize, AND the active
- *             ranks directly exchange a second chunk over the same idle link.
- *   No relay scratch and no reduction are needed.
+ *   A==2: group 1 scatters helper chunks and exchanges directA; group 2
+ *         forwards helper slots and exchanges directB.
+ *   Routed A==4: each off-diagonal segment is split contiguously into directA,
+ *         relay, and directB. Group 1 transfers directA to the destination and
+ *         relay to helper index source XOR p[destination], p={0,2,3,1}. Group 2
+ *         transfers directB and forwards each compact helper slot directly to
+ *         recvSeg[source] + directA. Each helper receives and forwards exactly
+ *         three tasks to three distinct destinations.
+ *   Direct A==4: one grouped active-to-active exchange; helpers are idle.
  *
  * Chunking:
  * =========
- *   chunkSize = segmentCounts[g] / numChunks rounded down to 128 elements,
- *   numChunks = numHelpers + 2. The active<->active link is idle while the
- * relay scatter and forward run on the cross links, so instead of a third comm
- * group for one direct chunk, one direct chunk rides along with each relay
- * group. Every link then carries exactly one chunk per direction per group and
- * the critical path is 2 x chunkSize instead of 3 x
- * segmentCounts[g]/(numHelpers+1). Returns ncclInvalidArgument when
- * segmentCounts[g] < numChunks x 128 (too small to scatter); callers should
- * fall back to a plain all-to-all.
+ * A==2 relay: chunkSize = segmentCounts[g] / (numHelpers + 2), rounded down to
+ * 128 elements. One direct chunk rides with each relay group; if alignment
+ * makes chunkSize zero, directA/directB cover the whole segment.
+ * Routed A==4: directA = floor(segmentCounts[g] / 3), relayCount is directA
+ * rounded down to 128 elements, and directB absorbs every alignment and
+ * division tail. The three contiguous regions cover every element once.
  *
  * Helper-Buffer Contract (passthrough-at-helper):
  * ===============================================
  * A==2: caller MUST supply at least nActiveRanksPerGroup x chunkSize_aligned
  * elements per helper group, where chunkSize_aligned is computed from
  * segmentCounts[g].
- * A>2: PURE-DIRECT (no helper relay), so helper ranks do no work and need NO
- * helper buffer; the caller may pass any small placeholder tensor for the
- * groups it is a helper for.
+ * A==4 routed window: caller MUST supply at least 3 x relayCount elements per
+ * helper group, where relayCount = alignDown(segmentCounts[g] / 3, 128). This
+ * is bounded by one segment, so allocating segmentCounts[g] elements suffices.
+ * A==4 direct routes: helpers do no work and need no scratch, though callers
+ * may retain the one-segment allocation used for the routed window.
  *
  * Memory Model:
  * =============
  * Each rank is ACTIVE for exactly ONE group (has real tensor data).
- * For other groups, the rank is a HELPER (uses provided two-slot scratch).
+ * For other groups, the rank is a HELPER (uses the provided scratch when the
+ * selected route relays data).
  *   - sendBuffs[nGroups]: one contiguous input buffer per group. For the active
  *     group it holds nActiveRanksPerGroup x segmentCounts[g] elements; helper
- *     groups may pass a small placeholder.
+ *     groups provide scratch sized by the selected route's contract above.
  *   - recvBuffs[nGroups]: one base buffer per group. For helper groups this is
- *     the two-slot passthrough scratch (>= nActiveRanks x chunkSize); for the
- *     active group it is the output base (nActiveRanksPerGroup x
- *     segmentCounts[g] elements).
+ *     the passthrough scratch; for the active group it is the output base
+ *     (nActiveRanksPerGroup x segmentCounts[g] elements).
  *   - IN-PLACE IS NOT SUPPORTED: sendBuffs[g] and recvBuffs[g] MUST be distinct
  *     (matching native ncclAllToAll); aliasing returns ncclInvalidArgument.
  *   - Each helper group MUST have its own buffer (no aliasing across groups)
@@ -113,7 +108,7 @@
  *        group); the active group holds nActiveRanksPerGroup x segmentCounts[g]
  *        elements
  * @param recvBuffs Array of per-group base buffer pointers (one per group);
- *        helper groups pass two-slot passthrough scratch
+ *        helper groups pass scratch satisfying the helper-buffer contract
  * @param segmentCounts Array of per-group per-segment element counts (one per
  *        group); the active group's input/output together hold
  *        nActiveRanksPerGroup x segmentCounts[g] elements

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "nccl.h"
+
+// Maximum number of groups supported in multi-group all-to-all.
+// Mirrors SHARDED_RELAY_MAX_GROUPS in sharded_relay_allreduce.h; redefined
+// here so this header is self-contained (the two values must stay in sync).
+#ifndef SHARDED_RELAY_MAX_GROUPS
+#define SHARDED_RELAY_MAX_GROUPS 8
+#endif
+
+/**
+ * Fused Multi-Group Sharded Relay All-to-All for 2D Sparse Parallelism.
+ *
+ * This API performs multiple sharded relay all-to-alls in a single fused call,
+ * coordinating phases across all groups to prevent XGMI link contention. It is
+ * the all-to-all analogue of the sharded relay allreduce/reduce-scatter and
+ * reuses the same phase-synchronized passthrough-helper scheme; helpers perform
+ * no compute and simply relay sharded chunks.
+ *
+ * nActiveRanksPerGroup must be a power of two (2 or 4). A==2 uses the original
+ * 2-active passthrough relay (which wins there with 6 dedicated helpers per
+ * group); A>2 uses a PURE-DIRECT all-to-all among the active ranks over the
+ * 1-hop intra links -- NO helper relay, because the 2-hop offload is a net loss
+ * at A>2 (only A helpers, serial source->helper->owner) and the fused direct
+ * exchange already beats NCCL's P2P-bound 4-GPU all_to_all by ~1.4x. Helper
+ * ranks do no work for a group they are not active in. OUT-OF-PLACE ONLY in
+ * both cases.
+ *
+ * Unlike allreduce/reduce-scatter, all-to-all performs NO reduction — it is
+ * pure data movement — so no reduction kernels are used and there is no
+ * reduction op parameter.
+ *
+ * All-to-All Semantics (per group, A active ranks):
+ * =======================================================
+ * Each active rank's sendBuff and recvBuff hold nActiveRanksPerGroup x
+ * segmentCounts[g] (= 2 x segmentCounts[g]) elements:
+ *   - sendBuff = [sendSeg[0] | sendSeg[1]]; sendSeg[j] is the segment destined
+ *     for active index j.
+ *   - recvBuff = [recvSeg[0] | recvSeg[1]]; recvSeg[i] receives the segment
+ *     from active index i.
+ *
+ * For the active rank with myActiveIndex = m, otherActiveIndex = o = 1 - m:
+ *   - Diagonal (self -> self): recvSeg[m] = sendSeg[m]; both at offset
+ *     m x segmentCount. A local copy.
+ *   - Exchange: rank m ships sendSeg[o] (offset o x segmentCount) to the other
+ *     rank and receives the other rank's sendSeg[m] into recvSeg[o] (offset
+ *     o x segmentCount). This single-segment exchange is sharded across
+ * helpers.
+ *
+ * IN-PLACE IS NOT SUPPORTED. Like the native RCCL ncclAllToAll, sendBuff and
+ * recvBuff MUST be distinct; passing sendBuff == recvBuff returns
+ * ncclInvalidArgument.
+ *
+ * Five Phases (no reduction; pure relay + placement copies):
+ * ==========================================================
+ *   Phase 1 (active->helpers): each active rank scatters numHelpers chunks of
+ *            its sendSeg[o] segment to helpers; each helper stores two slots
+ *            (one per active rank).
+ *   Phase 2 (helpers->active, batched): each helper forwards slot-from-a0 -> a1
+ *            and slot-from-a1 -> a0; the active rank receives numHelpers chunks
+ *            DIRECTLY into recvSeg[o] (offset o x segmentCount + h x
+ * chunkSize). No relay scratch and no reduction are needed. Phase 3 (diagonal
+ * copy): recvSeg[m] = sendSeg[m] (cudaMemcpyAsync). Phase 4 (active<->active):
+ * direct exchange of the last (direct) chunk of the exchange segment, received
+ * directly into recvSeg[o]. Phase 5: none (no reduction).
+ *
+ * Chunking:
+ * =========
+ *   chunkSize  = segmentCounts[g] / numChunks rounded down to 128 elements,
+ *   numChunks  = numHelpers + 1 (last chunk is the direct-exchange chunk).
+ * Returns ncclInvalidArgument when segmentCounts[g] < numChunks x 128 (too
+ * small to scatter); callers should fall back to a plain all-to-all.
+ *
+ * Helper-Buffer Contract (passthrough-at-helper):
+ * ===============================================
+ * A==2: caller MUST supply at least nActiveRanksPerGroup x chunkSize_aligned
+ * elements per helper group, where chunkSize_aligned is computed from
+ * segmentCounts[g].
+ * A>2: PURE-DIRECT (no helper relay), so helper ranks do no work and need NO
+ * helper buffer; the caller may pass any small placeholder tensor for the
+ * groups it is a helper for.
+ *
+ * Memory Model:
+ * =============
+ * Each rank is ACTIVE for exactly ONE group (has real tensor data).
+ * For other groups, the rank is a HELPER (uses provided two-slot scratch).
+ *   - sendBuffs[nGroups]: one contiguous input buffer per group. For the active
+ *     group it holds nActiveRanksPerGroup x segmentCounts[g] elements; helper
+ *     groups may pass a small placeholder.
+ *   - recvBuffs[nGroups]: one base buffer per group. For helper groups this is
+ *     the two-slot passthrough scratch (>= nActiveRanks x chunkSize); for the
+ *     active group it is the output base (nActiveRanksPerGroup x
+ *     segmentCounts[g] elements).
+ *   - IN-PLACE IS NOT SUPPORTED: sendBuffs[g] and recvBuffs[g] MUST be distinct
+ *     (matching native ncclAllToAll); aliasing returns ncclInvalidArgument.
+ *   - Each helper group MUST have its own buffer (no aliasing across groups)
+ *     because all groups are processed simultaneously under phase-sync.
+ *
+ * @param sendBuffs Array of per-group contiguous input buffer pointers (one per
+ *        group); the active group holds nActiveRanksPerGroup x segmentCounts[g]
+ *        elements
+ * @param recvBuffs Array of per-group base buffer pointers (one per group);
+ *        helper groups pass two-slot passthrough scratch
+ * @param segmentCounts Array of per-group per-segment element counts (one per
+ *        group); the active group's input/output together hold
+ *        nActiveRanksPerGroup x segmentCounts[g] elements
+ * @param datatype NCCL data type
+ * @param comm NCCL communicator
+ * @param stream CUDA stream
+ * @param allActiveRanks 2D array of active ranks
+ * [nGroups][nActiveRanksPerGroup]
+ * @param nActiveRanksPerGroup Number of active ranks per group (2 or 4)
+ * @param nGroups Number of groups (typically 4 for 8-GPU node)
+ * @return ncclResult_t Success or error code
+ */
+ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* segmentCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const int* const* allActiveRanks,
+    int nActiveRanksPerGroup,
+    int nGroups);

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.h
@@ -60,25 +60,29 @@
  * recvBuff MUST be distinct; passing sendBuff == recvBuff returns
  * ncclInvalidArgument.
  *
- * Five Phases (no reduction; pure relay + placement copies):
- * ==========================================================
- *   Phase 1 (active->helpers): each active rank scatters numHelpers chunks of
- *            its sendSeg[o] segment to helpers; each helper stores two slots
- *            (one per active rank).
- *   Phase 2 (helpers->active, batched): each helper forwards slot-from-a0 -> a1
- *            and slot-from-a1 -> a0; the active rank receives numHelpers chunks
- *            DIRECTLY into recvSeg[o] (offset o x segmentCount + h x
- * chunkSize). No relay scratch and no reduction are needed. Phase 3 (diagonal
- * copy): recvSeg[m] = sendSeg[m] (cudaMemcpyAsync). Phase 4 (active<->active):
- * direct exchange of the last (direct) chunk of the exchange segment, received
- * directly into recvSeg[o]. Phase 5: none (no reduction).
+ * Two Comm Groups (no reduction; pure relay + a placement copy):
+ * ==============================================================
+ *   Diagonal: recvSeg[m] = sendSeg[m] (cudaMemcpyAsync).
+ *   Group 1:  each active rank scatters numHelpers chunks of its sendSeg[o] to
+ *             helpers (each helper stores two slots, one per active rank) AND
+ *             the two active ranks directly exchange one chunk over the
+ *             otherwise-idle active<->active link.
+ *   Group 2:  each helper forwards slot-from-a0 -> a1 and slot-from-a1 -> a0,
+ *             landing DIRECTLY in recvSeg[o] at h x chunkSize, AND the active
+ *             ranks directly exchange a second chunk over the same idle link.
+ *   No relay scratch and no reduction are needed.
  *
  * Chunking:
  * =========
- *   chunkSize  = segmentCounts[g] / numChunks rounded down to 128 elements,
- *   numChunks  = numHelpers + 1 (last chunk is the direct-exchange chunk).
- * Returns ncclInvalidArgument when segmentCounts[g] < numChunks x 128 (too
- * small to scatter); callers should fall back to a plain all-to-all.
+ *   chunkSize = segmentCounts[g] / numChunks rounded down to 128 elements,
+ *   numChunks = numHelpers + 2. The active<->active link is idle while the
+ * relay scatter and forward run on the cross links, so instead of a third comm
+ * group for one direct chunk, one direct chunk rides along with each relay
+ * group. Every link then carries exactly one chunk per direction per group and
+ * the critical path is 2 x chunkSize instead of 3 x
+ * segmentCounts[g]/(numHelpers+1). Returns ncclInvalidArgument when
+ * segmentCounts[g] < numChunks x 128 (too small to scatter); callers should
+ * fall back to a plain all-to-all.
  *
  * Helper-Buffer Contract (passthrough-at-helper):
  * ===============================================

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -597,12 +597,12 @@ static bool buildShardedRelayRankConfig(
 }
 
 /**
- * Two-active sharded relay allreduce (original, performant path).
+ * Two-active sharded relay allreduce.
  *
- * Helpers forward slot a -> activeRanks[1-a]; the active rank batches all
- * numHelpers forwarded chunks into relay scratch, fuses add+scale into
- * recvBuff, then directly exchanges the final chunk between the two active
- * ranks.
+ * Two comm groups; helpers reduce the pair of chunks they receive and hand the
+ * result straight back to both active ranks. Each of the two direct
+ * active<->active chunks rides along with one of the relay groups, so no link
+ * ever idles.
  */
 static ncclResult_t shardedRelayAllReduce2Active(
     const void* const* sendBuffs,
@@ -617,17 +617,16 @@ static ncclResult_t shardedRelayAllReduce2Active(
     int numHelpers,
     int nGroups,
     size_t elementSize) {
-  int numChunks = numHelpers + 1; // 7 for 8 ranks with 2 active per group
-
   // ==========================================================================
   // SIZE-ADAPTIVE PURE-DIRECT FAST PATH (A==2)
   // ==========================================================================
-  // At small sizes the 3-group helper relay (scatter/forward/direct + a helper
-  // HBM round trip) is dominated by launch+handshake latency. Instead do a
-  // classic 2-rank RS+AG allreduce directly between the two active ranks (two
-  // groups, helpers idle): swap owned halves and reduce, then swap the reduced
-  // halves back. maxBytes (count*elemSize) equals the bench per-rank input
-  // label.
+  // At small sizes the helper relay is dominated by launch and handshake
+  // latency, not bandwidth. Fall back to a single full exchange between the two
+  // active ranks (helpers idle) and reduce locally. A reduce-scatter +
+  // all-gather pair would move the same count per link direction (count/2
+  // twice) but needs TWO group boundaries, so the plain exchange is strictly
+  // better in this regime. maxBytes (count*elemSize) equals the bench per-rank
+  // input label.
   size_t maxCount2 = 0;
   for (int g = 0; g < nGroups; g++) {
     if (counts[g] > maxCount2) {
@@ -635,46 +634,24 @@ static ncclResult_t shardedRelayAllReduce2Active(
     }
   }
   const size_t maxBytes2 = maxCount2 * elementSize;
-  // A=2 relay wins big at large (one group across all helpers -> ~1.7x fused);
-  // pure-direct only helps small. Crossover (measured MI350X, bf16, 8 GPUs):
-  // fused relay overtakes at ~4.5 MB, independent at ~9 MB. Cross over below.
+  // A=2 relay wins big at large sizes (one group spread across all helpers), so
+  // the crossover is low; an independent call has no cross-group contention on
+  // the direct link, so pure-direct holds on longer there.
   const size_t kA2PureDirectMaxBytes = (nGroups > 1)
       ? (static_cast<size_t>(2) << 20) // fused: < 2 MB
       : (static_cast<size_t>(6) << 20); // independent: < 6 MB
   if (maxBytes2 < kA2PureDirectMaxBytes) {
     void* pdScratch = nullptr;
-    size_t pdCount = 0, pdOwnOff = 0, pdOwnLen = 0, pdOthOff = 0, pdOthLen = 0;
-    int pdPartner = -1;
     if (myActiveGroup >= 0 && counts[myActiveGroup] > 0) {
-      const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
-      pdCount = counts[myActiveGroup];
-      size_t h0 = pdCount / 2;
-      size_t h1 = pdCount - h0;
-      int mi = cfg.myActiveIndex;
-      pdOwnOff = (mi == 0) ? 0 : h0;
-      pdOwnLen = (mi == 0) ? h0 : h1;
-      pdOthOff = (mi == 0) ? h0 : 0;
-      pdOthLen = (mi == 0) ? h1 : h0;
-      pdPartner = cfg.activeRanks[1 - mi];
       pdScratch = ScratchBufferCache::getInstance().get(
-          SHARDED_RELAY_MAX_GROUPS, (pdOwnLen + 1) * elementSize, stream);
+          SHARDED_RELAY_MAX_GROUPS,
+          counts[myActiveGroup] * elementSize,
+          stream);
       if (pdScratch == nullptr) {
         return ncclInternalError;
       }
-      // Seed recvBuff with local contribution (out-of-place); in-place already
-      // holds it.
-      if (sendBuffs[myActiveGroup] != recvBuffs[myActiveGroup]) {
-        cudaMemcpyAsync(
-            recvBuffs[myActiveGroup],
-            sendBuffs[myActiveGroup],
-            pdCount * elementSize,
-            cudaMemcpyDeviceToDevice,
-            stream);
-      }
     }
 
-    // Group 1 (reduce-scatter swap): send my partner's owned half; receive my
-    // owned half's other contribution into scratch.
     NCCLCHECK(ncclGroupStart());
     for (int g = 0; g < nGroups; g++) {
       if (counts[g] == 0) {
@@ -684,261 +661,161 @@ static ncclResult_t shardedRelayAllReduce2Active(
       if (!cfg.isActiveRank) {
         continue; // helpers idle
       }
-      char* recvbuff = static_cast<char*>(recvBuffs[g]);
-      if (pdOthLen > 0) {
-        NCCLCHECK(ncclSend(
-            recvbuff + pdOthOff * elementSize,
-            pdOthLen,
-            datatype,
-            pdPartner,
-            comm,
-            stream));
-      }
-      if (pdOwnLen > 0) {
-        NCCLCHECK(ncclRecv(
-            static_cast<char*>(pdScratch),
-            pdOwnLen,
-            datatype,
-            pdPartner,
-            comm,
-            stream));
-      }
+      int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      NCCLCHECK(
+          ncclSend(sendBuffs[g], counts[g], datatype, partner, comm, stream));
+      NCCLCHECK(
+          ncclRecv(pdScratch, counts[g], datatype, partner, comm, stream));
     }
     NCCLCHECK(ncclGroupEnd());
 
-    // Reduce my owned half (local + received), scale for AVG.
-    if (myActiveGroup >= 0 && pdOwnLen > 0) {
-      char* ownDst =
-          static_cast<char*>(recvBuffs[myActiveGroup]) + pdOwnOff * elementSize;
-      if (reductionDivisor > 1) {
-        DISPATCH_INCREMENTAL_ADD_AND_SCALE(
-            datatype, ownDst, pdScratch, pdOwnLen, reductionDivisor, stream);
+    if (myActiveGroup >= 0 && counts[myActiveGroup] > 0) {
+      size_t count = counts[myActiveGroup];
+      void* out = recvBuffs[myActiveGroup];
+      if (sendBuffs[myActiveGroup] == out) {
+        if (reductionDivisor > 1) {
+          DISPATCH_INCREMENTAL_ADD_AND_SCALE(
+              datatype, out, pdScratch, count, reductionDivisor, stream);
+        } else {
+          DISPATCH_INCREMENTAL_ADD(datatype, out, pdScratch, count, stream);
+        }
       } else {
-        DISPATCH_INCREMENTAL_ADD(datatype, ownDst, pdScratch, pdOwnLen, stream);
+        DISPATCH_FUSED_REDUCE(
+            datatype,
+            out,
+            sendBuffs[myActiveGroup],
+            pdScratch,
+            count,
+            reductionDivisor,
+            stream);
       }
     }
-
-    // Group 2 (all-gather swap): exchange the reduced owned halves.
-    NCCLCHECK(ncclGroupStart());
-    for (int g = 0; g < nGroups; g++) {
-      if (counts[g] == 0) {
-        continue;
-      }
-      const ShardedRelayRankConfig& cfg = configs[g];
-      if (!cfg.isActiveRank) {
-        continue;
-      }
-      char* recvbuff = static_cast<char*>(recvBuffs[g]);
-      if (pdOwnLen > 0) {
-        NCCLCHECK(ncclSend(
-            recvbuff + pdOwnOff * elementSize,
-            pdOwnLen,
-            datatype,
-            pdPartner,
-            comm,
-            stream));
-      }
-      if (pdOthLen > 0) {
-        NCCLCHECK(ncclRecv(
-            recvbuff + pdOthOff * elementSize,
-            pdOthLen,
-            datatype,
-            pdPartner,
-            comm,
-            stream));
-      }
-    }
-    NCCLCHECK(ncclGroupEnd());
     return ncclSuccess;
   }
 
   // =========================================================================
-  // CALCULATE PER-GROUP CHUNK SIZES
+  // CHUNK GEOMETRY: numHelpers relayed chunks + TWO direct chunks
   // =========================================================================
-  // Each group may have a different count, so we compute chunk sizes per group
+  // The active<->active link carries nothing while the relay scatter and
+  // forward run on the cross links, so instead of a third comm group for a
+  // single direct chunk, one direct chunk rides along with each relay group.
+  // With numChunks = numHelpers + 2 every link then carries exactly one chunk
+  // per direction per group, making the critical path 2*count/numChunks. A
+  // separate direct phase costs 3*count/(numHelpers+1) — 1.7x more on an 8-GPU
+  // node.
+  const int numChunks = numHelpers + 2;
+
   size_t chunkSizes[SHARDED_RELAY_MAX_GROUPS];
-  size_t lastChunkSizes[SHARDED_RELAY_MAX_GROUPS];
-  size_t directChunkOffsets[SHARDED_RELAY_MAX_GROUPS];
-  size_t directChunkSizes[SHARDED_RELAY_MAX_GROUPS];
+  size_t relayTotals[SHARDED_RELAY_MAX_GROUPS]; // == direct chunk A's offset
+  size_t dirBOffsets[SHARDED_RELAY_MAX_GROUPS];
+  size_t dirBSizes[SHARDED_RELAY_MAX_GROUPS]; // absorbs the remainder
 
   for (int g = 0; g < nGroups; g++) {
     size_t count = counts[g];
 
-    // Skip groups with count == 0; the per-phase loops below already check
-    // counts[g] == 0 and bypass NCCL ops for those groups, so chunkSizes
-    // entries for zero-count groups are never read.
+    // Zero-count groups are skipped by every loop below, so their geometry is
+    // never read.
     if (count == 0) {
       chunkSizes[g] = 0;
-      lastChunkSizes[g] = 0;
-      directChunkOffsets[g] = 0;
-      directChunkSizes[g] = 0;
+      relayTotals[g] = 0;
+      dirBOffsets[g] = 0;
+      dirBSizes[g] = 0;
       continue;
     }
 
-    // Calculate chunk size (aligned to cache line).
-    // The algorithm scatters numChunks chunks of size chunkSize over the
-    // input buffer, which requires count >= numChunks * chunkSize. When the
-    // per-chunk size rounded down to CHUNK_ALIGN_ELEMENTS is zero, the
-    // buffer is too small to scatter and the algorithm cannot proceed
-    // safely; the caller should fall back to a regular allreduce.
+    // A chunk size that rounds down to zero means the buffer is too small to
+    // scatter; the caller should fall back to a regular allreduce.
     size_t chunkSize = count / numChunks;
     chunkSize = (chunkSize / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
     if (chunkSize == 0) {
       return ncclInvalidArgument;
     }
     chunkSizes[g] = chunkSize;
-
-    // Calculate the size of the last chunk
-    size_t totalChunkedElements = static_cast<size_t>(numChunks) * chunkSize;
-    size_t lastChunkSize = chunkSize;
-    if (totalChunkedElements < count) {
-      lastChunkSize = chunkSize + (count - totalChunkedElements);
-    }
-    lastChunkSizes[g] = lastChunkSize;
-
-    // Direct exchange chunk info
-    int directChunkIndex = numHelpers;
-    directChunkOffsets[g] = static_cast<size_t>(directChunkIndex) * chunkSize;
-    directChunkSizes[g] = lastChunkSize;
+    relayTotals[g] = static_cast<size_t>(numHelpers) * chunkSize;
+    dirBOffsets[g] = relayTotals[g] + chunkSize;
+    dirBSizes[g] = count - dirBOffsets[g];
   }
 
   // =========================================================================
-  // SCRATCH BUFFER ALLOCATION
+  // SCRATCH: the two received direct chunks, contiguous (in-place only)
   // =========================================================================
-  // Relay scratch: numHelpers × chunkSize for batched passthrough recv.
-  //   Sized to receive ALL forwarded chunks from helpers in a single
-  //   ncclGroupStart/End — matches original phase-sync structure.
-  // Direct-exchange scratch: (nActiveRanks-1) × directChunkSize (in-place)
-  void* relayScratch = nullptr;
+  // Out-of-place receives the direct chunks straight into recvBuff and reduces
+  // against sendBuff. In-place must stage them so the local contribution is
+  // still readable when the fused reduce runs.
   void* directScratch = nullptr;
+  bool isInPlace = false;
+  size_t myDirOffset = 0; // offset of direct chunk A within the active buffers
+  size_t myDirTotal = 0; // both direct chunks together
 
   if (myActiveGroup >= 0 && counts[myActiveGroup] > 0) {
-    // Relay scratch sized to numHelpers × chunkSize so that the active rank
-    // can receive ALL forwarded chunks in one batched phase.
-    size_t relayScratchBytes = static_cast<size_t>(numHelpers) *
-        chunkSizes[myActiveGroup] * elementSize;
-    relayScratch = ScratchBufferCache::getInstance().get(
-        SHARDED_RELAY_MAX_GROUPS, relayScratchBytes, stream);
-    if (relayScratch == nullptr) {
-      return ncclInternalError;
-    }
-
-    // Direct-exchange scratch (in-place only)
-    bool isInPlace = (sendBuffs[myActiveGroup] == recvBuffs[myActiveGroup]);
+    isInPlace = (sendBuffs[myActiveGroup] == recvBuffs[myActiveGroup]);
+    myDirOffset = relayTotals[myActiveGroup];
+    myDirTotal = counts[myActiveGroup] - myDirOffset;
     if (isInPlace) {
-      int nOtherActives = configs[myActiveGroup].nActiveRanks - 1;
-      size_t directScratchBytes = static_cast<size_t>(nOtherActives) *
-          directChunkSizes[myActiveGroup] * elementSize;
       directScratch = ScratchBufferCache::getInstance().get(
-          myActiveGroup, directScratchBytes, stream);
+          myActiveGroup, myDirTotal * elementSize, stream);
       if (directScratch == nullptr) {
         return ncclInternalError;
       }
     }
   }
 
+  // Destination for received direct chunk A / chunk B.
+  auto directDst = [&](size_t offsetWithinDirect) -> char* {
+    if (isInPlace) {
+      return static_cast<char*>(directScratch) +
+          offsetWithinDirect * elementSize;
+    }
+    return static_cast<char*>(recvBuffs[myActiveGroup]) +
+        (myDirOffset + offsetWithinDirect) * elementSize;
+  };
+
   // =========================================================================
-  // PHASE 1 (active→helpers): Both active ranks scatter chunks to helpers
+  // GROUP 1: relay scatter (active->helpers) || direct chunk A
+  // (active<->active)
   // =========================================================================
-  // Helpers receive from each active rank into offset-based slots:
-  //   slot a at offset (a × chunkSize) holds data from active rank a
   NCCLCHECK(ncclGroupStart());
 
   for (int g = 0; g < nGroups; g++) {
     if (counts[g] == 0)
       continue;
     const ShardedRelayRankConfig& cfg = configs[g];
-    const void* sendbuff = sendBuffs[g];
-    void* recvbuff = recvBuffs[g];
     size_t chunkSize = chunkSizes[g];
 
     if (cfg.isActiveRank) {
-      // Active rank: send my chunk h to helper h
+      const char* sendbuff = static_cast<const char*>(sendBuffs[g]);
+
+      // Scatter: chunk h goes to helper h.
       for (int h = 0; h < cfg.numHelpers; h++) {
-        int helperRank = cfg.helperRanks[h];
-        size_t chunkOffset = static_cast<size_t>(h) * chunkSize;
-
         NCCLCHECK(ncclSend(
-            static_cast<const char*>(sendbuff) + chunkOffset * elementSize,
+            sendbuff + static_cast<size_t>(h) * chunkSize * elementSize,
             chunkSize,
             datatype,
-            helperRank,
+            cfg.helperRanks[h],
             comm,
             stream));
       }
+
+      // Direct chunk A over the otherwise-idle active<->active link.
+      int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      NCCLCHECK(ncclSend(
+          sendbuff + relayTotals[g] * elementSize,
+          chunkSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+      NCCLCHECK(
+          ncclRecv(directDst(0), chunkSize, datatype, partner, comm, stream));
     } else {
-      // Helper rank: receive from each active rank into slot a
+      // Helper: receive active rank a's chunk into slot a.
+      char* helperBuf = static_cast<char*>(recvBuffs[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {
-        int activeRank = cfg.activeRanks[a];
-        size_t helperOffset = static_cast<size_t>(a) * chunkSize;
-
         NCCLCHECK(ncclRecv(
-            static_cast<char*>(recvbuff) + helperOffset * elementSize,
+            helperBuf + static_cast<size_t>(a) * chunkSize * elementSize,
             chunkSize,
             datatype,
-            activeRank,
-            comm,
-            stream));
-      }
-    }
-  }
-
-  NCCLCHECK(ncclGroupEnd());
-
-  // For out-of-place active groups: copy sendbuff relay region to recvbuff
-  // so that the incremental add in Phase 3 works uniformly.
-  if (myActiveGroup >= 0 && counts[myActiveGroup] > 0) {
-    const void* sendbuff = sendBuffs[myActiveGroup];
-    void* recvbuff = recvBuffs[myActiveGroup];
-    if (sendbuff != recvbuff) {
-      size_t relayBytes = static_cast<size_t>(numHelpers) *
-          chunkSizes[myActiveGroup] * elementSize;
-      cudaMemcpyAsync(
-          recvbuff, sendbuff, relayBytes, cudaMemcpyDeviceToDevice, stream);
-    }
-  }
-
-  // =========================================================================
-  // PHASE 2 (helpers→active, batched): Passthrough forward
-  // =========================================================================
-  // ALL helpers forward simultaneously in ONE ncclGroupStart/End.
-  // Each helper sends slot 0 (a0's data) → a1 and slot 1 (a1's data) → a0.
-  // Active rank receives all numHelpers chunks into relay scratch
-  // (numHelpers × chunkSize), at offset h × chunkSize per helper h.
-  NCCLCHECK(ncclGroupStart());
-
-  for (int g = 0; g < nGroups; g++) {
-    if (counts[g] == 0)
-      continue;
-    const ShardedRelayRankConfig& cfg = configs[g];
-    void* recvbuff = recvBuffs[g];
-    size_t chunkSize = chunkSizes[g];
-
-    if (!cfg.isActiveRank) {
-      // I am a helper for group g: forward each slot to the OTHER active.
-      // slot a → activeRanks[1-a] (swap for 2 active ranks)
-      for (int a = 0; a < cfg.nActiveRanks; a++) {
-        int targetActive = cfg.activeRanks[1 - a];
-        NCCLCHECK(ncclSend(
-            static_cast<const char*>(recvbuff) +
-                static_cast<size_t>(a) * chunkSize * elementSize,
-            chunkSize,
-            datatype,
-            targetActive,
-            comm,
-            stream));
-      }
-    } else {
-      // Active rank: receive ALL forwarded data from each helper into the
-      // relay scratch at offset h × chunkSize.
-      for (int h = 0; h < cfg.numHelpers; h++) {
-        int helperRank = cfg.helperRanks[h];
-        size_t scratchOffset = static_cast<size_t>(h) * chunkSize;
-        NCCLCHECK(ncclRecv(
-            static_cast<char*>(relayScratch) + scratchOffset * elementSize,
-            chunkSize,
-            datatype,
-            helperRank,
+            cfg.activeRanks[a],
             comm,
             stream));
       }
@@ -948,156 +825,105 @@ static ncclResult_t shardedRelayAllReduce2Active(
   NCCLCHECK(ncclGroupEnd());
 
   // =========================================================================
-  // PHASE 3 (active reduce): Fused add + scale on the relay region
+  // HELPER REDUCE: slot 0 = (slot 0 + slot 1) / divisor
   // =========================================================================
-  // Single-pass fused kernel: recvbuff[i] = (recvbuff[i] + relayScratch[i]) /
-  // divisor.  Halves HBM traffic vs separate ADD + SCALE passes.
+  // Both active ranks send the SAME logical chunk index, so their sum is the
+  // final allreduced value for that chunk. Reducing here instead of forwarding
+  // both slots keeps the link cost identical (the helper still sends one chunk
+  // to each active rank) while removing the active rank's relay scratch and its
+  // fused add+scale over numHelpers/numChunks of the whole buffer. The work is
+  // also spread over every helper GPU rather than piled onto the two actives.
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] == 0 || configs[g].isActiveRank)
+      continue;
+    char* helperBuf = static_cast<char*>(recvBuffs[g]);
+    size_t chunkSize = chunkSizes[g];
+    DISPATCH_FUSED_REDUCE(
+        datatype,
+        helperBuf,
+        helperBuf,
+        helperBuf + chunkSize * elementSize,
+        chunkSize,
+        reductionDivisor,
+        stream);
+  }
+
+  // =========================================================================
+  // GROUP 2: reduced relay (helpers->active) || direct chunk B
+  // (active<->active)
+  // =========================================================================
+  NCCLCHECK(ncclGroupStart());
+
   for (int g = 0; g < nGroups; g++) {
     if (counts[g] == 0)
       continue;
     const ShardedRelayRankConfig& cfg = configs[g];
-    if (cfg.isActiveRank) {
-      void* recvbuff = recvBuffs[g];
-      size_t chunkSize = chunkSizes[g];
-      size_t relayTotal = static_cast<size_t>(numHelpers) * chunkSize;
+    size_t chunkSize = chunkSizes[g];
 
+    if (cfg.isActiveRank) {
+      char* recvbuff = static_cast<char*>(recvBuffs[g]);
+
+      // The helper's chunk is already reduced, so it lands directly in its
+      // final place in recvBuff — no active-side reduction for this region.
+      for (int h = 0; h < cfg.numHelpers; h++) {
+        NCCLCHECK(ncclRecv(
+            recvbuff + static_cast<size_t>(h) * chunkSize * elementSize,
+            chunkSize,
+            datatype,
+            cfg.helperRanks[h],
+            comm,
+            stream));
+      }
+
+      // Direct chunk B, again over the idle active<->active link.
+      int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      NCCLCHECK(ncclSend(
+          static_cast<const char*>(sendBuffs[g]) + dirBOffsets[g] * elementSize,
+          dirBSizes[g],
+          datatype,
+          partner,
+          comm,
+          stream));
+      NCCLCHECK(ncclRecv(
+          directDst(chunkSize), dirBSizes[g], datatype, partner, comm, stream));
+    } else {
+      // Helper: hand the reduced chunk to both active ranks.
+      const char* helperBuf = static_cast<const char*>(recvBuffs[g]);
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        NCCLCHECK(ncclSend(
+            helperBuf, chunkSize, datatype, cfg.activeRanks[a], comm, stream));
+      }
+    }
+  }
+
+  NCCLCHECK(ncclGroupEnd());
+
+  // =========================================================================
+  // DIRECT REDUCE: fold both received direct chunks in one fused pass
+  // =========================================================================
+  // Chunks A and B are adjacent in both the active buffers and the scratch, so
+  // a single launch covers [relayTotal, count).
+  if (myActiveGroup >= 0 && myDirTotal > 0) {
+    char* dst = static_cast<char*>(recvBuffs[myActiveGroup]) +
+        myDirOffset * elementSize;
+    if (isInPlace) {
       if (reductionDivisor > 1) {
-        // Fused: add + AVG-scale in one HBM pass.
         DISPATCH_INCREMENTAL_ADD_AND_SCALE(
-            datatype,
-            recvbuff,
-            relayScratch,
-            relayTotal,
-            reductionDivisor,
-            stream);
+            datatype, dst, directScratch, myDirTotal, reductionDivisor, stream);
       } else {
-        // SUM only: plain incremental add.
         DISPATCH_INCREMENTAL_ADD(
-            datatype, recvbuff, relayScratch, relayTotal, stream);
+            datatype, dst, directScratch, myDirTotal, stream);
       }
-    }
-  }
-
-  // =========================================================================
-  // PHASE 4 (active↔active): Direct exchange between active ranks
-  // =========================================================================
-  NCCLCHECK(ncclGroupStart());
-
-  for (int g = 0; g < nGroups; g++) {
-    if (counts[g] == 0)
-      continue;
-    const ShardedRelayRankConfig& cfg = configs[g];
-
-    if (cfg.isActiveRank) {
-      const void* sendbuff = sendBuffs[g];
-      void* recvbuff = recvBuffs[g];
-      bool isInPlace = (sendbuff == recvbuff);
-      size_t directChunkOffset = directChunkOffsets[g];
-      size_t directChunkSize = directChunkSizes[g];
-
-      // Send my direct chunk to all other active ranks
-      for (int a = 0; a < cfg.nActiveRanks; a++) {
-        if (a == cfg.myActiveIndex)
-          continue;
-        int otherActiveRank = cfg.activeRanks[a];
-
-        NCCLCHECK(ncclSend(
-            static_cast<const char*>(sendbuff) +
-                directChunkOffset * elementSize,
-            directChunkSize,
-            datatype,
-            otherActiveRank,
-            comm,
-            stream));
-      }
-
-      // Receive direct chunks from all other active ranks
-      int scratchIdx = 0;
-      for (int a = 0; a < cfg.nActiveRanks; a++) {
-        if (a == cfg.myActiveIndex)
-          continue;
-        int otherActiveRank = cfg.activeRanks[a];
-
-        if (isInPlace) {
-          size_t scratchOffset =
-              static_cast<size_t>(scratchIdx) * directChunkSize;
-          NCCLCHECK(ncclRecv(
-              static_cast<char*>(directScratch) + scratchOffset * elementSize,
-              directChunkSize,
-              datatype,
-              otherActiveRank,
-              comm,
-              stream));
-        } else {
-          NCCLCHECK(ncclRecv(
-              static_cast<char*>(recvbuff) + directChunkOffset * elementSize,
-              directChunkSize,
-              datatype,
-              otherActiveRank,
-              comm,
-              stream));
-        }
-        scratchIdx++;
-      }
-    }
-  }
-
-  NCCLCHECK(ncclGroupEnd());
-
-  // =========================================================================
-  // PHASE 5 (active reduce): Final reduction on the direct-exchange chunk
-  // =========================================================================
-  for (int g = 0; g < nGroups; g++) {
-    if (counts[g] == 0)
-      continue;
-    const ShardedRelayRankConfig& cfg = configs[g];
-
-    if (cfg.isActiveRank) {
-      const void* sendbuff = sendBuffs[g];
-      void* recvbuff = recvBuffs[g];
-      bool isInPlace = (sendbuff == recvbuff);
-      size_t directChunkOffset = directChunkOffsets[g];
-      size_t directChunkSize = directChunkSizes[g];
-
-      void* directChunkDst =
-          static_cast<char*>(recvbuff) + directChunkOffset * elementSize;
-
-      if (isInPlace) {
-        int scratchIdx2 = 0;
-        for (int a = 0; a < cfg.nActiveRanks; a++) {
-          if (a == cfg.myActiveIndex)
-            continue;
-          size_t scratchOffset =
-              static_cast<size_t>(scratchIdx2) * directChunkSize;
-          const void* received = static_cast<const char*>(directScratch) +
-              scratchOffset * elementSize;
-          DISPATCH_INCREMENTAL_ADD(
-              datatype, directChunkDst, received, directChunkSize, stream);
-          scratchIdx2++;
-        }
-
-        if (reductionDivisor > 1) {
-          DISPATCH_SCALE(
-              datatype,
-              directChunkDst,
-              directChunkSize,
-              reductionDivisor,
-              stream);
-        }
-      } else {
-        const void* localContribution = static_cast<const char*>(sendbuff) +
-            directChunkOffset * elementSize;
-        const void* receivedContribution = directChunkDst;
-
-        DISPATCH_FUSED_REDUCE(
-            datatype,
-            directChunkDst,
-            localContribution,
-            receivedContribution,
-            directChunkSize,
-            reductionDivisor,
-            stream);
-      }
+    } else {
+      DISPATCH_FUSED_REDUCE(
+          datatype,
+          dst,
+          static_cast<const char*>(sendBuffs[myActiveGroup]) +
+              myDirOffset * elementSize,
+          dst,
+          myDirTotal,
+          reductionDivisor,
+          stream);
     }
   }
 
@@ -1147,13 +973,18 @@ static ncclResult_t shardedRelayAllReduceFlat(
   const int A = nActiveRanksPerGroup;
   const int H = numHelpers;
 
-  // Offload (helper reduce+broadcast) share. Empirically ~0.78 is optimal at
-  // large sizes on MI350X (the offload path through otherwise-idle cross links
-  // is more efficient per byte than direct intra RS+AG). But at small sizes the
-  // 2-hop offload only adds helper-hop latency, so disable it there and run a
-  // pure-direct RS+AG among the A active ranks (helpers idle). maxBytes here
-  // (count*elemSize) equals the bench per-rank input label; crossover set
-  // below.
+  // Offload (helper reduce+broadcast) share. Per comm group the intra links
+  // carry pD/A and the cross links carry pO/H, and with A == H on the 8-GPU
+  // 4-active topology the two-group critical path is 2*max(pD, pO)/A. That is
+  // minimized when the direct and offload regions are EQUAL, giving count/4 per
+  // link against NCCL's count/2 over the intra links alone — a 2x ceiling. (The
+  // previous 780 skewed everything onto the cross links for a 1.28x ceiling,
+  // which matches the ~1.03x that was measured.)
+  //
+  // At small sizes the 2-hop offload only adds helper-hop latency, so disable
+  // it there and run a pure-direct RS+AG among the A active ranks (helpers
+  // idle). maxBytes here (count*elemSize) equals the bench per-rank input
+  // label.
   size_t maxCount = 0;
   for (int g = 0; g < nGroups; g++) {
     if (counts[g] > maxCount) {
@@ -1161,16 +992,14 @@ static ncclResult_t shardedRelayAllReduceFlat(
     }
   }
   const size_t maxBytes = maxCount * elementSize;
-  // Crossover is scenario-dependent (measured MI350X, A=4, bf16, 8 GPUs): fused
-  // offload overtakes pure-direct at ~4.5 MB (pure-direct wins the small end,
-  // e.g. 576 KB 1.08x->1.23x), independent at ~27 MB (0.62->0.74 @4KB,
-  // 0.69->0.86 @4.5MB). Independent has no cross-group contention so direct
-  // holds on longer. A=4 fused was already >=1.02x, so keep the threshold low
-  // there.
+  // Crossover is scenario-dependent (measured MI350X, A=4, bf16, 8 GPUs): the
+  // fused sweep phase-syncs every group so the offload cross links stay clean
+  // and it pays off almost immediately, while an independent call contends with
+  // whatever else is in flight and pure-direct holds on longer.
   const size_t kFlatPureDirectMaxBytes = (nGroups > 1)
-      ? 0 // fused A=4 already >=1.02x with offload; pure-direct doesn't help
+      ? (static_cast<size_t>(2) << 20) // fused: < 2 MB
       : (static_cast<size_t>(12) << 20); // independent: < 12 MB
-  const size_t kOffPermille = (maxBytes < kFlatPureDirectMaxBytes) ? 0 : 780;
+  const size_t kOffPermille = (maxBytes < kFlatPureDirectMaxBytes) ? 0 : 500;
 
   for (int g = 0; g < nGroups; g++) {
     if (counts[g] != 0 && (counts[g] % static_cast<size_t>(A)) != 0) {

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -20,6 +20,14 @@
 // which is used for struct padding.
 static constexpr size_t CHUNK_ALIGN_ELEMENTS = 128;
 
+// The helpers below are duplicated, by design, across every sharded-relay TU
+// (reduce-scatter, all-gather, all-to-all, hierarchical all-to-all). Each of
+// those TUs keeps its copy in an anonymous namespace so the class types and
+// their inline members have internal linkage and can never be merged across
+// translation units; this TU does the same. The GPU kernels are NOT duplicated
+// -- they are shared via sharded_relay_allreduce_kernels.h.
+namespace {
+
 /**
  * Scratch Buffer Cache Singleton
  *
@@ -43,6 +51,14 @@ class ScratchBufferCache {
    * Get a scratch buffer with a specific key (for multi-group support).
    * Each key maintains its own buffer, allowing multiple independent scratch
    * buffers per device.
+   *
+   * The returned memory is UNINITIALISED: it is either a fresh pool allocation
+   * or a recycled one still holding bytes from an earlier call. Callers must
+   * fully overwrite every element they later read; each one does so today by
+   * receiving into the whole buffer before reducing over it. Zeroing here
+   * instead would add a full HBM pass per call, and would convert any future
+   * coverage gap into a silently wrong sum (zero is the SUM identity) rather
+   * than visible garbage.
    *
    * @param key Unique key to identify this scratch buffer (e.g., group index)
    * @param requiredBytes Minimum size in bytes needed
@@ -133,6 +149,8 @@ class ScratchBufferCache {
   std::mutex mutex_;
   std::unordered_map<int64_t, BufferEntry> buffers_; // compositeKey -> buffer
 };
+
+} // namespace
 
 /**
  * GPU kernel for incremental reduction: output[i] += input[i]
@@ -496,6 +514,8 @@ static inline bool isPowerOfTwo(int v) {
  * Holds parsed active and helper rank information for a single group.
  * Supports a power-of-two number of active ranks per group (2 or 4).
  */
+namespace {
+
 struct ShardedRelayRankConfig {
   int activeRanks[SHARDED_RELAY_MAX_ACTIVE]; // Active rank IDs (power of two)
   int nActiveRanks; // Number of active ranks (2 or 4)
@@ -505,6 +525,8 @@ struct ShardedRelayRankConfig {
   int myActiveIndex; // Index in activeRanks array (-1 if helper)
   int myHelperIndex; // Index in helperRanks array (-1 if active)
 };
+
+} // namespace
 
 /**
  * Build rank configuration from provided active ranks array.

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -707,6 +707,7 @@ static ncclResult_t shardedRelayAllReduce2Active(
 
   size_t chunkSizes[SHARDED_RELAY_MAX_GROUPS];
   size_t relayTotals[SHARDED_RELAY_MAX_GROUPS]; // == direct chunk A's offset
+  size_t dirASizes[SHARDED_RELAY_MAX_GROUPS];
   size_t dirBOffsets[SHARDED_RELAY_MAX_GROUPS];
   size_t dirBSizes[SHARDED_RELAY_MAX_GROUPS]; // absorbs the remainder
 
@@ -718,21 +719,23 @@ static ncclResult_t shardedRelayAllReduce2Active(
     if (count == 0) {
       chunkSizes[g] = 0;
       relayTotals[g] = 0;
+      dirASizes[g] = 0;
       dirBOffsets[g] = 0;
       dirBSizes[g] = 0;
       continue;
     }
 
-    // A chunk size that rounds down to zero means the buffer is too small to
-    // scatter; the caller should fall back to a regular allreduce.
     size_t chunkSize = count / numChunks;
     chunkSize = (chunkSize / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
-    if (chunkSize == 0) {
-      return ncclInvalidArgument;
-    }
     chunkSizes[g] = chunkSize;
     relayTotals[g] = static_cast<size_t>(numHelpers) * chunkSize;
-    dirBOffsets[g] = relayTotals[g] + chunkSize;
+    if (chunkSize == 0) {
+      dirASizes[g] = count / 2;
+      dirBOffsets[g] = dirASizes[g];
+    } else {
+      dirASizes[g] = chunkSize;
+      dirBOffsets[g] = relayTotals[g] + chunkSize;
+    }
     dirBSizes[g] = count - dirBOffsets[g];
   }
 
@@ -786,7 +789,7 @@ static ncclResult_t shardedRelayAllReduce2Active(
       const char* sendbuff = static_cast<const char*>(sendBuffs[g]);
 
       // Scatter: chunk h goes to helper h.
-      for (int h = 0; h < cfg.numHelpers; h++) {
+      for (int h = 0; h < cfg.numHelpers && chunkSize > 0; h++) {
         NCCLCHECK(ncclSend(
             sendbuff + static_cast<size_t>(h) * chunkSize * elementSize,
             chunkSize,
@@ -798,16 +801,18 @@ static ncclResult_t shardedRelayAllReduce2Active(
 
       // Direct chunk A over the otherwise-idle active<->active link.
       int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
-      NCCLCHECK(ncclSend(
-          sendbuff + relayTotals[g] * elementSize,
-          chunkSize,
-          datatype,
-          partner,
-          comm,
-          stream));
-      NCCLCHECK(
-          ncclRecv(directDst(0), chunkSize, datatype, partner, comm, stream));
-    } else {
+      if (dirASizes[g] > 0) {
+        NCCLCHECK(ncclSend(
+            sendbuff + relayTotals[g] * elementSize,
+            dirASizes[g],
+            datatype,
+            partner,
+            comm,
+            stream));
+        NCCLCHECK(ncclRecv(
+            directDst(0), dirASizes[g], datatype, partner, comm, stream));
+      }
+    } else if (chunkSize > 0) {
       // Helper: receive active rank a's chunk into slot a.
       char* helperBuf = static_cast<char*>(recvBuffs[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {
@@ -834,7 +839,7 @@ static ncclResult_t shardedRelayAllReduce2Active(
   // fused add+scale over numHelpers/numChunks of the whole buffer. The work is
   // also spread over every helper GPU rather than piled onto the two actives.
   for (int g = 0; g < nGroups; g++) {
-    if (counts[g] == 0 || configs[g].isActiveRank)
+    if (counts[g] == 0 || chunkSizes[g] == 0 || configs[g].isActiveRank)
       continue;
     char* helperBuf = static_cast<char*>(recvBuffs[g]);
     size_t chunkSize = chunkSizes[g];
@@ -865,7 +870,7 @@ static ncclResult_t shardedRelayAllReduce2Active(
 
       // The helper's chunk is already reduced, so it lands directly in its
       // final place in recvBuff — no active-side reduction for this region.
-      for (int h = 0; h < cfg.numHelpers; h++) {
+      for (int h = 0; h < cfg.numHelpers && chunkSize > 0; h++) {
         NCCLCHECK(ncclRecv(
             recvbuff + static_cast<size_t>(h) * chunkSize * elementSize,
             chunkSize,
@@ -885,8 +890,13 @@ static ncclResult_t shardedRelayAllReduce2Active(
           comm,
           stream));
       NCCLCHECK(ncclRecv(
-          directDst(chunkSize), dirBSizes[g], datatype, partner, comm, stream));
-    } else {
+          directDst(dirASizes[g]),
+          dirBSizes[g],
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else if (chunkSize > 0) {
       // Helper: hand the reduced chunk to both active ranks.
       const char* helperBuf = static_cast<const char*>(recvBuffs[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -380,20 +380,125 @@ class ScratchBufferCache {
     }                                                                       \
   } while (0)
 
+#define LAUNCH_MULTI_REDUCE_KERNEL(                           \
+    TYPE, dst, contribs, numContribs, count, divisor, stream) \
+  launchMultiReduceKernel<TYPE>(                              \
+      dst, contribs, numContribs, count, divisor, stream)
+
+// Fused multi-input reduce: dst = (dst + sum of `numContribs` contiguous
+// contribution blocks) [/ divisor], in one launch. Replaces a loop of
+// per-contribution incremental adds plus a trailing scale.
+#define DISPATCH_MULTI_REDUCE(                                             \
+    datatype, dst, contribs, numContribs, count, divisor, stream)          \
+  do {                                                                     \
+    switch (datatype) {                                                    \
+      case ncclInt8:                                                       \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            int8_t, dst, contribs, numContribs, count, divisor, stream);   \
+        break;                                                             \
+      case ncclUint8:                                                      \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            uint8_t, dst, contribs, numContribs, count, divisor, stream);  \
+        break;                                                             \
+      case ncclInt32:                                                      \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            int32_t, dst, contribs, numContribs, count, divisor, stream);  \
+        break;                                                             \
+      case ncclUint32:                                                     \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            uint32_t, dst, contribs, numContribs, count, divisor, stream); \
+        break;                                                             \
+      case ncclInt64:                                                      \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            int64_t, dst, contribs, numContribs, count, divisor, stream);  \
+        break;                                                             \
+      case ncclUint64:                                                     \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            uint64_t, dst, contribs, numContribs, count, divisor, stream); \
+        break;                                                             \
+      case ncclFloat16:                                                    \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            __half, dst, contribs, numContribs, count, divisor, stream);   \
+        break;                                                             \
+      case ncclFloat:                                                      \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            float, dst, contribs, numContribs, count, divisor, stream);    \
+        break;                                                             \
+      case ncclDouble:                                                     \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            double, dst, contribs, numContribs, count, divisor, stream);   \
+        break;                                                             \
+      case ncclBfloat16:                                                   \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            __nv_bfloat16,                                                 \
+            dst,                                                           \
+            contribs,                                                      \
+            numContribs,                                                   \
+            count,                                                         \
+            divisor,                                                       \
+            stream);                                                       \
+        break;                                                             \
+      default:                                                             \
+        break;                                                             \
+    }                                                                      \
+  } while (0)
+
+namespace {
+
+// The DISPATCH_* macros above instantiate reduce kernels for exactly these
+// types and fall through silently (default: break) for anything else, so an
+// unsupported datatype would return ncclSuccess having never reduced anything.
+//
+// This is deliberately a supported-set test rather than the
+// `datatype < 0 || datatype >= ncclNumTypes` range test used by upstream
+// ArgsCheck: ncclFloat8e4m3 and ncclFloat8e5m2 are valid NCCL types that
+// ncclTypeSize() sizes at 1 byte, so they pass a range test but have no reduce
+// kernel here. It also keeps ncclTypeSize()'s int -1 for an unknown type out of
+// the `size_t elementSize` below, where it would become SIZE_MAX rather than 0.
+// Keep this list in sync with the DISPATCH_* macros above.
+bool isSupportedRelayDataType(ncclDataType_t datatype) {
+  switch (datatype) {
+    case ncclInt8:
+    case ncclUint8:
+    case ncclInt32:
+    case ncclUint32:
+    case ncclInt64:
+    case ncclUint64:
+    case ncclFloat16:
+    case ncclFloat:
+    case ncclDouble:
+    case ncclBfloat16:
+      return true;
+    default:
+      return false;
+  }
+}
+
+} // namespace
+
 // Maximum number of helper ranks supported per group.
-// With exactly 2 active ranks, this implies a maximum communicator size of
-// SHARDED_RELAY_MAX_HELPERS + 2 ranks for this algorithm.
 static constexpr int SHARDED_RELAY_MAX_HELPERS = 8;
+
+// Maximum number of active ranks per group. The hypercube exchange schedule
+// (round-r partner = myActiveIndex XOR round) requires nActiveRanks to be a
+// power of two; supported values are 2 and 4 (on an 8-GPU node this leaves 6
+// or 4 helpers respectively).
+static constexpr int SHARDED_RELAY_MAX_ACTIVE = 8;
+
+// Returns true if v is a power of two (v >= 1).
+static inline bool isPowerOfTwo(int v) {
+  return v > 0 && (v & (v - 1)) == 0;
+}
 
 /**
  * Rank Configuration for Sharded Relay AllReduce
  *
  * Holds parsed active and helper rank information for a single group.
- * NOTE: This implementation requires exactly 2 active ranks per group.
+ * Supports a power-of-two number of active ranks per group (2 or 4).
  */
 struct ShardedRelayRankConfig {
-  int activeRanks[2]; // Active rank IDs (exactly 2 required)
-  int nActiveRanks; // Number of active ranks (must be 2)
+  int activeRanks[SHARDED_RELAY_MAX_ACTIVE]; // Active rank IDs (power of two)
+  int nActiveRanks; // Number of active ranks (2 or 4)
   int helperRanks[SHARDED_RELAY_MAX_HELPERS]; // Helper rank IDs
   int numHelpers; // Number of helper ranks
   bool isActiveRank; // Is current rank active?
@@ -425,21 +530,24 @@ static bool buildShardedRelayRankConfig(
   config.myActiveIndex = -1;
   config.myHelperIndex = -1;
 
-  // Validate input - require EXACTLY 2 active ranks
-  if (activeRanksInput == nullptr || nActiveRanksInput != 2) {
+  // Validate input - require a power-of-two active-rank count in
+  // [2, SHARDED_RELAY_MAX_ACTIVE]. The XOR round schedule depends on it.
+  if (activeRanksInput == nullptr || nActiveRanksInput < 2 ||
+      nActiveRanksInput > SHARDED_RELAY_MAX_ACTIVE ||
+      !isPowerOfTwo(nActiveRanksInput)) {
     return false;
   }
 
   // Copy active ranks and validate
-  for (int i = 0; i < 2; i++) {
+  for (int i = 0; i < nActiveRanksInput; i++) {
     int rankId = activeRanksInput[i];
     if (rankId >= 0 && rankId < nRanks) {
       config.activeRanks[config.nActiveRanks++] = rankId;
     }
   }
 
-  // Validate: need exactly 2 valid active ranks
-  if (config.nActiveRanks != 2) {
+  // Validate: need exactly nActiveRanksInput valid active ranks
+  if (config.nActiveRanks != nActiveRanksInput) {
     return false;
   }
 
@@ -489,129 +597,26 @@ static bool buildShardedRelayRankConfig(
 }
 
 /**
- * Fused Multi-Group Sharded Relay AllReduce — Phase-Synchronized Passthrough
+ * Two-active sharded relay allreduce (original, performant path).
  *
- * This implementation executes multiple sharded relay allreduces in a single
- * fused call, coordinating phases across ALL groups to prevent XGMI link
- * contention.  Helpers act as pure passthrough (no local compute); all
- * reductions are performed on the active ranks.
- *
- * Phase-Synchronized Execution with Passthrough Helpers:
- * ======================================================
- *
- *   PHASE 1 (active→helpers): ALL groups scatter simultaneously.
- *            Both active ranks send their chunks to helpers.
- *            Helpers receive into a two-slot buffer:
- *              slot 0 = data from active rank a0
- *              slot 1 = data from active rank a1
- *            All XGMI links carry unidirectional traffic: active→helper
- *
- *   PHASE 2 (helpers→active, batched): ALL helpers forward simultaneously
- *            in ONE ncclGroupStart/End.  Each helper sends slot 0 (a0's data)
- *            to a1 and slot 1 (a1's data) to a0.  Active rank receives all
- *            numHelpers chunks into relay scratch (numHelpers × chunkSize).
- *
- *   PHASE 3 (active reduce): Active ranks add the relay scratch to recvBuff
- *            using a single fused add+scale kernel
- *            (recvBuff[i] = (recvBuff[i] + scratch[i]) / nActiveRanks)
- *            over the whole relay region (numHelpers × chunkSize) — halves
- *            HBM traffic vs separate add + scale passes.
- *
- *   PHASE 4 (active↔active): Direct exchange of the last chunk between
- *            the two active ranks (same as the original algorithm).
- *
- *   PHASE 5 (active reduce): Final reduction on the direct-exchange chunk.
- *            Compute-only, no XGMI traffic.
- *
- * Memory Model:
- * =============
- * Each rank is ACTIVE for exactly ONE group (has real tensor data).
- * For other groups, the rank is a HELPER (uses provided two-slot scratch).
- *
- * For ACTIVE ranks:
- *   - sendBuff and recvBuff can be the same (in-place) or different
- *   - Relay scratch: numHelpers × chunkSize (from ScratchBufferCache, batched)
- *   - Direct-exchange scratch: (nActiveRanks-1) × directChunkSize (in-place)
- *
- * For HELPER ranks:
- *   - Buffer must hold nActiveRanks × chunkSize elements (two slots)
- *   - Slot a at offset a × chunkSize holds data from active rank a
- *   - Each helper group MUST have its own buffer (no aliasing across groups)
- *     because all groups are processed simultaneously under phase-sync
+ * Helpers forward slot a -> activeRanks[1-a]; the active rank batches all
+ * numHelpers forwarded chunks into relay scratch, fuses add+scale into
+ * recvBuff, then directly exchanges the final chunk between the two active
+ * ranks.
  */
-HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
+static ncclResult_t shardedRelayAllReduce2Active(
     const void* const* sendBuffs,
     void* const* recvBuffs,
     const size_t* counts,
     ncclDataType_t datatype,
-    ncclRedOp_t op,
+    int reductionDivisor,
     ncclComm_t comm,
     cudaStream_t stream,
-    const int* const* allActiveRanks,
-    int nActiveRanksPerGroup,
-    int nGroups) {
-  int nRanks, rank;
-  NCCLCHECK(ncclCommCount(comm, &nRanks));
-  NCCLCHECK(ncclCommUserRank(comm, &rank));
-
-  // Require at least 2 active ranks per group
-  if (nActiveRanksPerGroup < 2) {
-    return ncclInvalidArgument;
-  }
-
-  // Check if all counts are zero
-  bool allZero = true;
-  for (int g = 0; g < nGroups; g++) {
-    if (counts[g] != 0) {
-      allZero = false;
-      break;
-    }
-  }
-  if (allZero) {
-    return ncclSuccess;
-  }
-
-  // Validate operation - only SUM and AVG are supported
-  if (op != ncclSum && op != ncclAvg) {
-    return ncclInvalidArgument;
-  }
-
-  if (nGroups < 1 || nGroups > SHARDED_RELAY_MAX_GROUPS) {
-    return ncclInvalidArgument;
-  }
-
-  if (sendBuffs == nullptr || recvBuffs == nullptr ||
-      allActiveRanks == nullptr || counts == nullptr) {
-    return ncclInvalidArgument;
-  }
-
-  size_t elementSize = ncclTypeSize(datatype);
-
-  // Compute divisor for reduction: 1 for SUM, nActiveRanksPerGroup for AVG
-  int reductionDivisor = (op == ncclAvg) ? nActiveRanksPerGroup : 1;
-
-  // =========================================================================
-  // BUILD RANK CONFIGURATION FOR ALL GROUPS
-  // =========================================================================
-  ShardedRelayRankConfig configs[SHARDED_RELAY_MAX_GROUPS];
-  int myActiveGroup = -1; // Which group is this rank active for?
-
-  for (int g = 0; g < nGroups; g++) {
-    if (!buildShardedRelayRankConfig(
-            nRanks,
-            rank,
-            allActiveRanks[g],
-            nActiveRanksPerGroup,
-            configs[g])) {
-      return ncclInvalidArgument;
-    }
-    if (configs[g].isActiveRank) {
-      myActiveGroup = g;
-    }
-  }
-
-  // All groups should have the same number of helpers (same chunk structure)
-  int numHelpers = configs[0].numHelpers;
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nGroups,
+    size_t elementSize) {
   int numChunks = numHelpers + 1; // 7 for 8 ranks with 2 active per group
 
   // =========================================================================
@@ -964,4 +969,413 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
   }
 
   return ncclSuccess;
+}
+
+/**
+ * AllReduce for > 2 active ranks (flat helper-reduce-AND-broadcast). Combines
+ * the two patterns that individually beat NCCL at 4-active: the
+ * reduce-AT-helper of the flat reduce-scatter and the broadcast-AT-helper of
+ * the flat all-gather.
+ *
+ * Each rank's `count` is split into a DIRECT region pD (allreduced among the A
+ * active ranks over the 1-hop intra links via a direct all-to-all
+ * reduce-scatter + all-gather) and an OFFLOAD region pO (allreduced 2-hop
+ * through the otherwise-idle helpers: every helper SUMS all A active ranks'
+ * chunk and BROADCASTS the result back to all A). Both regions run concurrently
+ * in two ncclGroups -- G1 scatter and G2 gather/broadcast -- with the
+ * reductions in between. With f = pO/count = 0.5 each XGMI link carries
+ * ~0.25*count (intra: 0.5*(1-f)*count for the direct RS+AG; cross:
+ * 2*f*count/H for the offload scatter+broadcast), vs ~0.5*count/link for a
+ * 4-rank NCCL allreduce that uses only the intra links. Replaces the
+ * recursive-halving path.
+ *
+ * Scratch: dScratch holds the A-1 received direct shards. The helper's scratch
+ * is recvBuffs[g] = rawBuf [0, A*oChunk) (one chunk per active source); the
+ * fused helper reduce sums all A chunks in place into rawBuf[0], which is then
+ * broadcast back to the active ranks. recvBuff is operated on in
+ * place after being seeded from sendBuff (out-of-place) or aliasing it
+ * (in-place). Requires count % A == 0 and assumes A == numHelpers (the 8-GPU
+ * 4-active topology); the AVG divisor is applied once over the whole count.
+ */
+static ncclResult_t shardedRelayAllReduceFlat(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* counts,
+    ncclDataType_t datatype,
+    int reductionDivisor,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nActiveRanksPerGroup,
+    int nGroups,
+    size_t elementSize) {
+  const int A = nActiveRanksPerGroup;
+  const int H = numHelpers;
+
+  // Offload (helper reduce+broadcast) share = 571/1000. Like the flat
+  // reduce-scatter, the cross-link cost is dominated by the source->helper 1st
+  // hop, so shifting slightly more onto the (idle) cross links beats the
+  // equal-load f = 0.5 split empirically on MI350X.
+  // Offload (helper reduce+broadcast) share = 780/1000. Empirically optimal on
+  // MI350X (swept 0.5..0.85): far above the 0.5 equal-link-load point because
+  // the offload path (reduce+broadcast through the otherwise-idle cross links)
+  // is more efficient per byte than the direct intra RS+AG, so it pays to push
+  // most of the data onto the helpers. Kernel measures ~1.03x vs NCCL.
+  constexpr size_t kOffPermille = 780;
+
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] != 0 && (counts[g] % static_cast<size_t>(A)) != 0) {
+      return ncclInvalidArgument;
+    }
+  }
+
+  // Per-group geometry: pO (offload) aligned to H*CHUNK_ALIGN; pD = count - pO
+  // is then divisible by A (== H). dShard = pD/A, oChunk = pO/H.
+  size_t pDArr[SHARDED_RELAY_MAX_GROUPS];
+  size_t pOArr[SHARDED_RELAY_MAX_GROUPS];
+  for (int g = 0; g < nGroups; g++) {
+    size_t count = counts[g];
+    if (count == 0) {
+      pDArr[g] = 0;
+      pOArr[g] = 0;
+      continue;
+    }
+    size_t alignH = static_cast<size_t>(H) * CHUNK_ALIGN_ELEMENTS;
+    size_t pO = (count * kOffPermille) / 1000;
+    pO = (pO / alignH) * alignH;
+    if (pO > count) {
+      pO = (count / alignH) * alignH;
+    }
+    pOArr[g] = pO;
+    pDArr[g] = count - pO;
+  }
+
+  // Out-of-place: seed recvBuff = sendBuff once, then operate in place.
+  if (myActiveGroup >= 0 && counts[myActiveGroup] > 0 &&
+      sendBuffs[myActiveGroup] != recvBuffs[myActiveGroup]) {
+    cudaMemcpyAsync(
+        recvBuffs[myActiveGroup],
+        sendBuffs[myActiveGroup],
+        counts[myActiveGroup] * elementSize,
+        cudaMemcpyDeviceToDevice,
+        stream);
+  }
+
+  // Direct reduce-scatter scratch: the A-1 received direct shards.
+  void* dScratch = nullptr;
+  if (myActiveGroup >= 0 && counts[myActiveGroup] > 0 &&
+      pDArr[myActiveGroup] > 0) {
+    size_t dShard = pDArr[myActiveGroup] / A;
+    size_t dBytes = static_cast<size_t>(A - 1) * dShard * elementSize;
+    dScratch = ScratchBufferCache::getInstance().get(
+        SHARDED_RELAY_MAX_GROUPS, dBytes, stream);
+    if (dScratch == nullptr) {
+      return ncclInternalError;
+    }
+  }
+
+  // ===== Group 1: direct RS (active<->active) + offload scatter
+  // (active->helper). ========================================================
+  NCCLCHECK(ncclGroupStart());
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    size_t pD = pDArr[g];
+    size_t pO = pOArr[g];
+    size_t dShard = (pD > 0) ? pD / A : 0;
+    size_t oChunk = (pO > 0) ? pO / H : 0;
+    if (cfg.isActiveRank) {
+      char* recvbuff = static_cast<char*>(recvBuffs[g]);
+      int m = cfg.myActiveIndex;
+      // Direct RS: send my shard k to owner k; recv source s's shard m into its
+      // dScratch slot p.
+      if (dShard > 0) {
+        for (int k = 0; k < A; k++) {
+          if (k == m)
+            continue;
+          NCCLCHECK(ncclSend(
+              recvbuff + static_cast<size_t>(k) * dShard * elementSize,
+              dShard,
+              datatype,
+              cfg.activeRanks[k],
+              comm,
+              stream));
+        }
+        for (int s = 0; s < A; s++) {
+          if (s == m)
+            continue;
+          int p = (s < m) ? s : s - 1;
+          NCCLCHECK(ncclRecv(
+              static_cast<char*>(dScratch) +
+                  static_cast<size_t>(p) * dShard * elementSize,
+              dShard,
+              datatype,
+              cfg.activeRanks[s],
+              comm,
+              stream));
+        }
+      }
+      // Offload scatter: send my offload chunk h to helper h.
+      if (oChunk > 0) {
+        for (int h = 0; h < cfg.numHelpers; h++) {
+          NCCLCHECK(ncclSend(
+              recvbuff + (pD + static_cast<size_t>(h) * oChunk) * elementSize,
+              oChunk,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+    } else if (oChunk > 0) {
+      // Helper: recv this helper's offload chunk from each active a into
+      // rawBuf[a].
+      char* rawBuf = static_cast<char*>(recvBuffs[g]);
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        NCCLCHECK(ncclRecv(
+            rawBuf + static_cast<size_t>(a) * oChunk * elementSize,
+            oChunk,
+            datatype,
+            cfg.activeRanks[a],
+            comm,
+            stream));
+      }
+    }
+  }
+  NCCLCHECK(ncclGroupEnd());
+
+  // ===== Reduce: direct (active sums its shard) + offload (helper sums all A).
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    size_t pD = pDArr[g];
+    size_t pO = pOArr[g];
+    size_t dShard = (pD > 0) ? pD / A : 0;
+    size_t oChunk = (pO > 0) ? pO / H : 0;
+    if (cfg.isActiveRank) {
+      if (dShard > 0 && g == myActiveGroup) {
+        char* recvbuff = static_cast<char*>(recvBuffs[g]);
+        int m = cfg.myActiveIndex;
+        char* dst = recvbuff + static_cast<size_t>(m) * dShard * elementSize;
+        // Fused single-pass reduce: dst = (dst + A-1 direct contribs) / divisor
+        // (AVG folded in), before the all-gather broadcasts the owned shard.
+        DISPATCH_MULTI_REDUCE(
+            datatype, dst, dScratch, A - 1, dShard, reductionDivisor, stream);
+      }
+    } else if (oChunk > 0) {
+      // Helper: fused single-pass reduce of the A received chunks into
+      // rawBuf[0] in-place (rawBuf[0] = (sum_a rawBuf[a]) / divisor), one
+      // launch instead of memcpy + A-1 adds + scale. The broadcast below reads
+      // rawBuf[0].
+      char* rawBuf = static_cast<char*>(recvBuffs[g]);
+      DISPATCH_MULTI_REDUCE(
+          datatype,
+          rawBuf,
+          rawBuf + oChunk * elementSize,
+          cfg.nActiveRanks - 1,
+          oChunk,
+          reductionDivisor,
+          stream);
+    }
+  }
+
+  // ===== Group 2: direct AG (active<->active) + offload broadcast
+  // (helper->active). ========================================================
+  NCCLCHECK(ncclGroupStart());
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    size_t pD = pDArr[g];
+    size_t pO = pOArr[g];
+    size_t dShard = (pD > 0) ? pD / A : 0;
+    size_t oChunk = (pO > 0) ? pO / H : 0;
+    if (cfg.isActiveRank) {
+      char* recvbuff = static_cast<char*>(recvBuffs[g]);
+      int m = cfg.myActiveIndex;
+      // Direct AG: send my reduced shard m to every other active; recv their
+      // reduced shard k into recvBuff[k].
+      if (dShard > 0) {
+        for (int k = 0; k < A; k++) {
+          if (k == m)
+            continue;
+          NCCLCHECK(ncclSend(
+              recvbuff + static_cast<size_t>(m) * dShard * elementSize,
+              dShard,
+              datatype,
+              cfg.activeRanks[k],
+              comm,
+              stream));
+          NCCLCHECK(ncclRecv(
+              recvbuff + static_cast<size_t>(k) * dShard * elementSize,
+              dShard,
+              datatype,
+              cfg.activeRanks[k],
+              comm,
+              stream));
+        }
+      }
+      // Offload broadcast: recv reduced chunk h from helper h into recvBuff.
+      if (oChunk > 0) {
+        for (int h = 0; h < cfg.numHelpers; h++) {
+          NCCLCHECK(ncclRecv(
+              recvbuff + (pD + static_cast<size_t>(h) * oChunk) * elementSize,
+              oChunk,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+    } else if (oChunk > 0) {
+      // Helper: broadcast the reduced chunk (now in rawBuf[0]) to all A active
+      // ranks.
+      char* rawBuf = static_cast<char*>(recvBuffs[g]);
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        NCCLCHECK(ncclSend(
+            rawBuf, oChunk, datatype, cfg.activeRanks[a], comm, stream));
+      }
+    }
+  }
+  NCCLCHECK(ncclGroupEnd());
+
+  // The AVG divisor was already folded into the per-shard direct reduce and the
+  // per-chunk helper reduce above, so no separate whole-count scale is needed.
+  return ncclSuccess;
+}
+
+/**
+ * Fused Multi-Group Sharded Relay AllReduce.
+ *
+ * Executes multiple sharded relay allreduces in one fused call, phase-synced
+ * across all groups so XGMI links carry unidirectional traffic. Helpers are
+ * pure passthrough; reductions happen on the active ranks. Each rank is ACTIVE
+ * for exactly one group and a HELPER for the others.
+ *
+ * nActiveRanksPerGroup must be a power of two (2 or 4): A==2 uses the original
+ * 2-active path; A>2 uses the flat helper-reduce-and-broadcast path.
+ */
+HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* counts,
+    ncclDataType_t datatype,
+    ncclRedOp_t op,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const int* const* allActiveRanks,
+    int nActiveRanksPerGroup,
+    int nGroups) {
+  int nRanks, rank;
+  NCCLCHECK(ncclCommCount(comm, &nRanks));
+  NCCLCHECK(ncclCommUserRank(comm, &rank));
+
+  // Validate every argument before touching counts: the all-zero scan below
+  // indexes counts[0..nGroups), so a null pointer or an out-of-range nGroups
+  // has to be rejected first. Bounds-checking nGroups up here also means
+  // nGroups <= 0 reports ncclInvalidArgument rather than skipping the scan
+  // entirely and returning ncclSuccess.
+  if (nGroups < 1 || nGroups > SHARDED_RELAY_MAX_GROUPS) {
+    return ncclInvalidArgument;
+  }
+  if (recvBuffs == nullptr || allActiveRanks == nullptr || counts == nullptr ||
+      sendBuffs == nullptr) {
+    return ncclInvalidArgument;
+  }
+
+  // Require a power-of-two active-rank count (>= 2) for the XOR schedule.
+  if (nActiveRanksPerGroup < 2 || !isPowerOfTwo(nActiveRanksPerGroup)) {
+    return ncclInvalidArgument;
+  }
+
+  if (op != ncclSum && op != ncclAvg) {
+    return ncclInvalidArgument;
+  }
+
+  if (!isSupportedRelayDataType(datatype)) {
+    return ncclInvalidArgument;
+  }
+
+  bool allZero = true;
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] != 0) {
+      allZero = false;
+      break;
+    }
+  }
+  if (allZero) {
+    return ncclSuccess;
+  }
+
+  size_t elementSize = ncclTypeSize(datatype);
+  int reductionDivisor = (op == ncclAvg) ? nActiveRanksPerGroup : 1;
+
+  ShardedRelayRankConfig configs[SHARDED_RELAY_MAX_GROUPS];
+  int myActiveGroup = -1;
+  for (int g = 0; g < nGroups; g++) {
+    if (!buildShardedRelayRankConfig(
+            nRanks,
+            rank,
+            allActiveRanks[g],
+            nActiveRanksPerGroup,
+            configs[g])) {
+      return ncclInvalidArgument;
+    }
+    if (configs[g].isActiveRank) {
+      myActiveGroup = g;
+    }
+  }
+  int numHelpers = configs[0].numHelpers;
+
+  // Build per-group buffer arrays for the unchanged kernels. Helper groups use
+  // their scratch (recvBuffs[g]); the active group uses the caller's contiguous
+  // input/output buffers directly. Allreduce may be in-place (sendBuffs[g]
+  // aliases recvBuffs[g]) or out-of-place, keyed off
+  // sendBuffs[g]==recvBuffs[g].
+  const void* sendBuffs2[SHARDED_RELAY_MAX_GROUPS];
+  void* recvBuffs2[SHARDED_RELAY_MAX_GROUPS];
+  for (int g = 0; g < nGroups; g++) {
+    sendBuffs2[g] = sendBuffs[g];
+    recvBuffs2[g] = recvBuffs[g];
+  }
+
+  ncclResult_t r;
+  if (nActiveRanksPerGroup == 2) {
+    r = shardedRelayAllReduce2Active(
+        sendBuffs2,
+        recvBuffs2,
+        counts,
+        datatype,
+        reductionDivisor,
+        comm,
+        stream,
+        configs,
+        myActiveGroup,
+        numHelpers,
+        nGroups,
+        elementSize);
+  } else {
+    // A>2: flat helper-reduce-and-broadcast (direct RS+AG over intra woven with
+    // offload reduce+broadcast through the helpers).
+    r = shardedRelayAllReduceFlat(
+        sendBuffs2,
+        recvBuffs2,
+        counts,
+        datatype,
+        reductionDivisor,
+        comm,
+        stream,
+        configs,
+        myActiveGroup,
+        numHelpers,
+        nActiveRanksPerGroup,
+        nGroups,
+        elementSize);
+  }
+
+  return r;
 }

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -619,6 +619,139 @@ static ncclResult_t shardedRelayAllReduce2Active(
     size_t elementSize) {
   int numChunks = numHelpers + 1; // 7 for 8 ranks with 2 active per group
 
+  // ==========================================================================
+  // SIZE-ADAPTIVE PURE-DIRECT FAST PATH (A==2)
+  // ==========================================================================
+  // At small sizes the 3-group helper relay (scatter/forward/direct + a helper
+  // HBM round trip) is dominated by launch+handshake latency. Instead do a
+  // classic 2-rank RS+AG allreduce directly between the two active ranks (two
+  // groups, helpers idle): swap owned halves and reduce, then swap the reduced
+  // halves back. maxBytes (count*elemSize) equals the bench per-rank input
+  // label.
+  size_t maxCount2 = 0;
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] > maxCount2) {
+      maxCount2 = counts[g];
+    }
+  }
+  const size_t maxBytes2 = maxCount2 * elementSize;
+  // A=2 relay wins big at large (one group across all helpers -> ~1.7x fused);
+  // pure-direct only helps small. Crossover (measured MI350X, bf16, 8 GPUs):
+  // fused relay overtakes at ~4.5 MB, independent at ~9 MB. Cross over below.
+  const size_t kA2PureDirectMaxBytes = (nGroups > 1)
+      ? (static_cast<size_t>(2) << 20) // fused: < 2 MB
+      : (static_cast<size_t>(6) << 20); // independent: < 6 MB
+  if (maxBytes2 < kA2PureDirectMaxBytes) {
+    void* pdScratch = nullptr;
+    size_t pdCount = 0, pdOwnOff = 0, pdOwnLen = 0, pdOthOff = 0, pdOthLen = 0;
+    int pdPartner = -1;
+    if (myActiveGroup >= 0 && counts[myActiveGroup] > 0) {
+      const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
+      pdCount = counts[myActiveGroup];
+      size_t h0 = pdCount / 2;
+      size_t h1 = pdCount - h0;
+      int mi = cfg.myActiveIndex;
+      pdOwnOff = (mi == 0) ? 0 : h0;
+      pdOwnLen = (mi == 0) ? h0 : h1;
+      pdOthOff = (mi == 0) ? h0 : 0;
+      pdOthLen = (mi == 0) ? h1 : h0;
+      pdPartner = cfg.activeRanks[1 - mi];
+      pdScratch = ScratchBufferCache::getInstance().get(
+          SHARDED_RELAY_MAX_GROUPS, (pdOwnLen + 1) * elementSize, stream);
+      if (pdScratch == nullptr) {
+        return ncclInternalError;
+      }
+      // Seed recvBuff with local contribution (out-of-place); in-place already
+      // holds it.
+      if (sendBuffs[myActiveGroup] != recvBuffs[myActiveGroup]) {
+        cudaMemcpyAsync(
+            recvBuffs[myActiveGroup],
+            sendBuffs[myActiveGroup],
+            pdCount * elementSize,
+            cudaMemcpyDeviceToDevice,
+            stream);
+      }
+    }
+
+    // Group 1 (reduce-scatter swap): send my partner's owned half; receive my
+    // owned half's other contribution into scratch.
+    NCCLCHECK(ncclGroupStart());
+    for (int g = 0; g < nGroups; g++) {
+      if (counts[g] == 0) {
+        continue;
+      }
+      const ShardedRelayRankConfig& cfg = configs[g];
+      if (!cfg.isActiveRank) {
+        continue; // helpers idle
+      }
+      char* recvbuff = static_cast<char*>(recvBuffs[g]);
+      if (pdOthLen > 0) {
+        NCCLCHECK(ncclSend(
+            recvbuff + pdOthOff * elementSize,
+            pdOthLen,
+            datatype,
+            pdPartner,
+            comm,
+            stream));
+      }
+      if (pdOwnLen > 0) {
+        NCCLCHECK(ncclRecv(
+            static_cast<char*>(pdScratch),
+            pdOwnLen,
+            datatype,
+            pdPartner,
+            comm,
+            stream));
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+
+    // Reduce my owned half (local + received), scale for AVG.
+    if (myActiveGroup >= 0 && pdOwnLen > 0) {
+      char* ownDst =
+          static_cast<char*>(recvBuffs[myActiveGroup]) + pdOwnOff * elementSize;
+      if (reductionDivisor > 1) {
+        DISPATCH_INCREMENTAL_ADD_AND_SCALE(
+            datatype, ownDst, pdScratch, pdOwnLen, reductionDivisor, stream);
+      } else {
+        DISPATCH_INCREMENTAL_ADD(datatype, ownDst, pdScratch, pdOwnLen, stream);
+      }
+    }
+
+    // Group 2 (all-gather swap): exchange the reduced owned halves.
+    NCCLCHECK(ncclGroupStart());
+    for (int g = 0; g < nGroups; g++) {
+      if (counts[g] == 0) {
+        continue;
+      }
+      const ShardedRelayRankConfig& cfg = configs[g];
+      if (!cfg.isActiveRank) {
+        continue;
+      }
+      char* recvbuff = static_cast<char*>(recvBuffs[g]);
+      if (pdOwnLen > 0) {
+        NCCLCHECK(ncclSend(
+            recvbuff + pdOwnOff * elementSize,
+            pdOwnLen,
+            datatype,
+            pdPartner,
+            comm,
+            stream));
+      }
+      if (pdOthLen > 0) {
+        NCCLCHECK(ncclRecv(
+            recvbuff + pdOthOff * elementSize,
+            pdOthLen,
+            datatype,
+            pdPartner,
+            comm,
+            stream));
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+    return ncclSuccess;
+  }
+
   // =========================================================================
   // CALCULATE PER-GROUP CHUNK SIZES
   // =========================================================================
@@ -1014,16 +1147,30 @@ static ncclResult_t shardedRelayAllReduceFlat(
   const int A = nActiveRanksPerGroup;
   const int H = numHelpers;
 
-  // Offload (helper reduce+broadcast) share = 571/1000. Like the flat
-  // reduce-scatter, the cross-link cost is dominated by the source->helper 1st
-  // hop, so shifting slightly more onto the (idle) cross links beats the
-  // equal-load f = 0.5 split empirically on MI350X.
-  // Offload (helper reduce+broadcast) share = 780/1000. Empirically optimal on
-  // MI350X (swept 0.5..0.85): far above the 0.5 equal-link-load point because
-  // the offload path (reduce+broadcast through the otherwise-idle cross links)
-  // is more efficient per byte than the direct intra RS+AG, so it pays to push
-  // most of the data onto the helpers. Kernel measures ~1.03x vs NCCL.
-  constexpr size_t kOffPermille = 780;
+  // Offload (helper reduce+broadcast) share. Empirically ~0.78 is optimal at
+  // large sizes on MI350X (the offload path through otherwise-idle cross links
+  // is more efficient per byte than direct intra RS+AG). But at small sizes the
+  // 2-hop offload only adds helper-hop latency, so disable it there and run a
+  // pure-direct RS+AG among the A active ranks (helpers idle). maxBytes here
+  // (count*elemSize) equals the bench per-rank input label; crossover set
+  // below.
+  size_t maxCount = 0;
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] > maxCount) {
+      maxCount = counts[g];
+    }
+  }
+  const size_t maxBytes = maxCount * elementSize;
+  // Crossover is scenario-dependent (measured MI350X, A=4, bf16, 8 GPUs): fused
+  // offload overtakes pure-direct at ~4.5 MB (pure-direct wins the small end,
+  // e.g. 576 KB 1.08x->1.23x), independent at ~27 MB (0.62->0.74 @4KB,
+  // 0.69->0.86 @4.5MB). Independent has no cross-group contention so direct
+  // holds on longer. A=4 fused was already >=1.02x, so keep the threshold low
+  // there.
+  const size_t kFlatPureDirectMaxBytes = (nGroups > 1)
+      ? 0 // fused A=4 already >=1.02x with offload; pure-direct doesn't help
+      : (static_cast<size_t>(12) << 20); // independent: < 12 MB
+  const size_t kOffPermille = (maxBytes < kFlatPureDirectMaxBytes) ? 0 : 780;
 
   for (int g = 0; g < nGroups; g++) {
     if (counts[g] != 0 && (counts[g] % static_cast<size_t>(A)) != 0) {

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -1008,7 +1008,7 @@ static ncclResult_t shardedRelayAllReduceFlat(
   // whatever else is in flight and pure-direct holds on longer.
   const size_t kFlatPureDirectMaxBytes = (nGroups > 1)
       ? (static_cast<size_t>(2) << 20) // fused: < 2 MB
-      : (static_cast<size_t>(12) << 20); // independent: < 12 MB
+      : (static_cast<size_t>(9) << 20); // independent: < 9 MB
   const size_t kOffPermille = (maxBytes < kFlatPureDirectMaxBytes) ? 0 : 500;
 
   for (int g = 0; g < nGroups; g++) {

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.h
@@ -41,59 +41,63 @@
  * This causes bidirectional contention on shared XGMI links, degrading
  * bandwidth by up to 10x.
  *
- * Solution - Phase-Synchronized Execution with Passthrough Helpers:
+ * Solution - Phase-Synchronized Execution with Reduce-at-Helper:
  * =================================================================
- * This fused API executes ALL groups in lockstep phases:
+ * This fused API executes ALL groups in lockstep so that at any instant every
+ * group is driving the XGMI links the same way. For A==2 there are exactly TWO
+ * comm groups:
  *
- *   Phase 1: ALL groups scatter (active→helpers) simultaneously.
- *            Each helper receives one chunk per active rank into a
- *            two-slot helper buffer (slot 0 from a0, slot 1 from a1).
+ *   Group 1: ALL groups scatter (active->helpers) simultaneously -- each helper
+ *            receives one chunk per active rank into a two-slot helper buffer
+ * -- AND the two active ranks directly exchange one chunk over the
+ *            active<->active link, which the scatter leaves idle.
  *
- *   Phase 2: ALL groups forward (helpers→other active) simultaneously.
- *            Helpers act as PURE PASSTHROUGH (no local compute):
- *            they forward slot 0 to a1 and slot 1 to a0.  Active ranks
- *            receive into a per-group recv-scratch slot.
+ *   Helper reduce: each helper sums its two slots (both active ranks send the
+ *            SAME logical chunk index, so the sum is the final allreduced
+ * value) and applies the AVG divisor.
  *
- *   Phase 3: ALL active ranks reduce the numHelpers helper-relayed chunks
- *            into their own active buffer (pipelined with Phase 2 recvs)
- *            and apply the AVG scaling once across the reduced region.
+ *   Group 2: ALL helpers hand their single reduced chunk to BOTH active ranks,
+ *            landing directly in its final place in recvBuff -- AND the active
+ *            ranks directly exchange a second chunk over the same idle link.
  *
- *   Phase 4: ALL groups direct-exchange the last (chunk N) data
- *            simultaneously between the two active ranks.
+ *   Final reduce: each active rank folds the two directly exchanged chunks into
+ *            its own contribution in one fused pass.
  *
- *   Phase 5: Active ranks perform the final reduction on the directly
- *            exchanged chunk.
+ * Why numChunks = numHelpers + 2:
+ * ===============================
+ * Let d be the bytes exchanged directly on the active<->active link and
+ * r = count - d the bytes relayed through the numHelpers helpers. A rank's
+ * egress is d + r (its own scatter) + r (its helper duty for the other groups),
+ * spread over its (numHelpers + 1) links, and the direct link alone bounds the
+ * runtime by d. Both bounds meet at r/(numHelpers/2) == d, i.e. one chunk per
+ * link per group, which is numChunks = numHelpers + 2 with one direct chunk in
+ * each group. The critical path is then 2*count/numChunks -- on an 8-GPU node
+ * count/4, versus count for a plain 2-rank allreduce.
  *
- * Since all groups are in the same phase at any time, XGMI links carry
- * unidirectional traffic only, eliminating contention.
+ * Reducing at the helper rather than forwarding both slots costs the same link
+ * time (the helper still sends one chunk to each active rank) but removes the
+ * active rank's relay scratch and its fused add+scale over most of the buffer,
+ * and spreads the reduction over every helper GPU instead of the two actives.
  *
- * Helper-Buffer Contract (passthrough-at-helper):
- * ===============================================
- * Helpers no longer perform local reductions; they simply forward each
- * received chunk to the OTHER active rank.  Two slots are needed per
- * helper group so that the recv from a0 (slot 0) and the recv from a1
- * (slot 1) can proceed concurrently — without two slots, a helper would
- * have to serialize the two directions and halve its instantaneous
- * network bandwidth.
+ * Helper-Buffer Contract:
+ * =======================
+ * A helper needs two slots so the recv from a0 (slot 0) and the recv from a1
+ * (slot 1) can proceed concurrently; without two slots it would serialize the
+ * two directions and halve its instantaneous network bandwidth. The reduction
+ * is done in place into slot 0.
  *
  * Caller MUST supply at least
- *   nActiveRanksPerGroup × chunkSize_aligned
+ *   nActiveRanksPerGroup x chunkSize_aligned
  * elements per helper group, where:
  *   chunkSize_aligned = (per_group_count / numChunks) rounded down to
  *                       CHUNK_ALIGN_ELEMENTS (128 elements).
- * Returns ncclInvalidArgument when per_group_count < numChunks × 128
- * (the buffer is too small to scatter); callers should fall back to a
- * regular allreduce in that case.
- *
- * Across the (nGroups - 1) helper groups per rank, that totals:
- *   (nGroups - 1) × nActiveRanksPerGroup × chunkSize
- * For the BM-FM 4-group / 2-active topology this is:
- *   3 × 2 × chunkSize = 6 × chunkSize per rank.
+ * Returns ncclInvalidArgument when per_group_count < numChunks x 128 (the
+ * buffer is too small to scatter); callers should fall back to a regular
+ * allreduce in that case.
  *
  * For A=4 the helper (reduce-and-broadcast) holds A source chunks plus one
- * reduced chunk per offload slice, so the caller must supply a larger scratch:
- * at least 2 × counts[g] elements per helper group (covers (A+1) × oChunk for
- * any offload fraction).
+ * reduced chunk per offload slice, so the caller must supply at least
+ * 2 x counts[g] elements per helper group.
  *
  * Memory Model:
  * =============

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.h
@@ -19,6 +19,19 @@
  * This API performs multiple sharded relay allreduces in a single fused call,
  * coordinating phases across all groups to prevent XGMI link contention.
  *
+ * Active ranks per group (nActiveRanksPerGroup) must be a power of two — 2 or 4
+ * are supported (on an 8-GPU node: 2 active + 6 helpers, or 4 active + 4
+ * helpers). A=2 uses the original single-pass flow. A=4 uses a flat
+ * helper-reduce-AND-broadcast: count is split into a DIRECT region (allreduced
+ * among the active ranks over the 1-hop intra links via a direct reduce-scatter
+ * + all-gather) and an OFFLOAD region (allreduced 2-hop through the otherwise-
+ * idle helpers, which SUM all active ranks' chunk and BROADCAST the result
+ * back); the AVG divisor is nActiveRanks. Both the direct owned-shard reduce
+ * and the helper SUM use a single fused multi-input reduce pass (read the owned
+ * shard plus all peer contributions once, apply the AVG divisor, write once)
+ * rather than a loop of per-contribution add + scale passes. The two paths live
+ * in separate internal functions selected by nActiveRanksPerGroup.
+ *
  * Problem with Separate Calls:
  * ============================
  * When 4 separate sharded relay allreduces run in parallel (one per sparse
@@ -77,15 +90,24 @@
  * For the BM-FM 4-group / 2-active topology this is:
  *   3 × 2 × chunkSize = 6 × chunkSize per rank.
  *
+ * For A=4 the helper (reduce-and-broadcast) holds A source chunks plus one
+ * reduced chunk per offload slice, so the caller must supply a larger scratch:
+ * at least 2 × counts[g] elements per helper group (covers (A+1) × oChunk for
+ * any offload fraction).
+ *
  * Memory Model:
  * =============
  * Each rank is ACTIVE for exactly ONE group (has real tensor data).
  * For other groups, the rank is a HELPER (uses provided two-slot scratch).
  * The caller must provide:
- *   - sendBuffs[nGroups]: One buffer per group
- *   - recvBuffs[nGroups]: One buffer per group
- *   - For the group where rank is active: full per_group_counts[g] elements
- *   - For other groups: two-slot scratch (>= nActiveRanks * chunkSize)
+ *   - sendBuffs[nGroups]: one contiguous input buffer per group. For the active
+ *     group it is the real input tensor (counts[g] elements); helper groups may
+ *     pass the same pointer as recvBuffs.
+ *   - recvBuffs[nGroups]: one base buffer per group. For helper groups this is
+ *     the two-slot passthrough scratch (>= nActiveRanks * chunkSize); for the
+ *     active group it is the working/output base (counts[g] elements).
+ *   - Allreduce may be in-place (recvBuffs[g] aliases sendBuffs[g]) or
+ *     out-of-place (distinct buffers), keyed off sendBuffs[g]==recvBuffs[g].
  *   - Each helper group MUST have its own buffer (no aliasing across groups)
  *     because all groups are processed simultaneously under phase-sync
  *
@@ -96,16 +118,19 @@
  *   Group 2: activeRanks = {4, 5}, helpers = {0,1,2,3,6,7}
  *   Group 3: activeRanks = {6, 7}, helpers = {0,1,2,3,4,5}
  *
- * @param sendBuffs Array of send buffer pointers (one per group)
- * @param recvBuffs Array of receive buffer pointers (one per group)
- * @param counts Array of element counts (one per group, allows different sizes)
+ * @param sendBuffs Array of per-group contiguous input buffer pointers (one per
+ *        group); the active group holds counts[g] elements
+ * @param recvBuffs Array of per-group base buffer pointers (one per group);
+ *        helper groups pass two-slot passthrough scratch
+ * @param counts Array of element counts (one per group, allows different
+ *        sizes); the active group's input/output each hold counts[g] elements
  * @param datatype NCCL data type
  * @param op Reduction operation (only ncclSum and ncclAvg supported)
  * @param comm NCCL communicator
  * @param stream CUDA stream
  * @param allActiveRanks 2D array of active ranks
  * [nGroups][nActiveRanksPerGroup]
- * @param nActiveRanksPerGroup Number of active ranks per group (typically 2)
+ * @param nActiveRanksPerGroup Number of active ranks per group (2 or 4)
  * @param nGroups Number of groups (typically 4 for 8-GPU node)
  * @return ncclResult_t Success or error code
  */

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.cu
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.cu
@@ -14,8 +14,8 @@
  */
 template <typename T>
 __global__ void incrementalAddKernel(T* output, const T* input, size_t count) {
-  size_t threadId = blockIdx.x * blockDim.x + threadIdx.x;
-  size_t totalThreads = blockDim.x * gridDim.x;
+  size_t threadId = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t totalThreads = static_cast<size_t>(blockDim.x) * gridDim.x;
 
   for (size_t elemIdx = threadId; elemIdx < count; elemIdx += totalThreads) {
     output[elemIdx] += input[elemIdx];
@@ -40,8 +40,8 @@ void launchIncrementalAddKernel(
  */
 template <typename T>
 __global__ void scaleKernel(T* data, size_t count, int divisor) {
-  size_t threadId = blockIdx.x * blockDim.x + threadIdx.x;
-  size_t totalThreads = blockDim.x * gridDim.x;
+  size_t threadId = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t totalThreads = static_cast<size_t>(blockDim.x) * gridDim.x;
 
   for (size_t elemIdx = threadId; elemIdx < count; elemIdx += totalThreads) {
     data[elemIdx] = data[elemIdx] / static_cast<T>(divisor);
@@ -79,8 +79,8 @@ __global__ void incrementalAddAndScaleKernel(
     const T* input,
     size_t count,
     int divisor) {
-  size_t threadId = blockIdx.x * blockDim.x + threadIdx.x;
-  size_t totalThreads = blockDim.x * gridDim.x;
+  size_t threadId = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t totalThreads = static_cast<size_t>(blockDim.x) * gridDim.x;
 
   for (size_t elemIdx = threadId; elemIdx < count; elemIdx += totalThreads) {
     T sum = output[elemIdx] + input[elemIdx];
@@ -120,8 +120,8 @@ __global__ void fusedReduceKernel(
     const T* inputB,
     size_t count,
     int divisor) {
-  size_t threadId = blockIdx.x * blockDim.x + threadIdx.x;
-  size_t totalThreads = blockDim.x * gridDim.x;
+  size_t threadId = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t totalThreads = static_cast<size_t>(blockDim.x) * gridDim.x;
 
   for (size_t elemIdx = threadId; elemIdx < count; elemIdx += totalThreads) {
     T sum = inputA[elemIdx] + inputB[elemIdx];
@@ -151,6 +151,57 @@ void launchFusedReduceKernel(
       divisor);
 }
 
+/*
+ * Fused multi-input reduce: dst[i] = (dst[i] + sum_p contribs[p*count + i]),
+ * optionally divided by `divisor`, in a single pass / single launch.
+ *
+ * `contribs` is a contiguous array of `numContribs` blocks, each `count`
+ * elements (block p starts at contribs + p*count).  This replaces a loop of
+ * `numContribs` separate incremental-add launches (each read-modify-writing
+ * dst) plus a trailing scale — reading dst once and writing it once instead of
+ * numContribs+1 times, which cuts reduce-path HBM traffic.
+ */
+template <typename T>
+__global__ void multiReduceKernel(
+    T* dst,
+    const T* contribs,
+    int numContribs,
+    size_t count,
+    int divisor) {
+  size_t threadId = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t totalThreads = static_cast<size_t>(blockDim.x) * gridDim.x;
+
+  for (size_t elemIdx = threadId; elemIdx < count; elemIdx += totalThreads) {
+    T acc = dst[elemIdx];
+    for (int p = 0; p < numContribs; p++) {
+      acc += contribs[static_cast<size_t>(p) * count + elemIdx];
+    }
+    if (divisor > 1) {
+      dst[elemIdx] = acc / static_cast<T>(divisor);
+    } else {
+      dst[elemIdx] = acc;
+    }
+  }
+}
+
+template <typename T>
+void launchMultiReduceKernel(
+    void* dst,
+    const void* contribs,
+    int numContribs,
+    size_t count,
+    int divisor,
+    cudaStream_t stream) {
+  const int blockSize = 256;
+  int gridSize = (count + blockSize - 1) / blockSize;
+  multiReduceKernel<T><<<gridSize, blockSize, 0, stream>>>(
+      static_cast<T*>(dst),
+      static_cast<const T*>(contribs),
+      numContribs,
+      count,
+      divisor);
+}
+
 // Explicit template instantiations for every dtype used by the DISPATCH_*
 // macros in sharded_relay_allreduce.cc.  Without these, the symbols would
 // not exist with external linkage in the device object, and the host TU
@@ -172,6 +223,13 @@ void launchFusedReduceKernel(
       void* output,                                                        \
       const void* inputA,                                                  \
       const void* inputB,                                                  \
+      size_t count,                                                        \
+      int divisor,                                                         \
+      cudaStream_t stream);                                                \
+  template void launchMultiReduceKernel<T>(                                \
+      void* dst,                                                           \
+      const void* contribs,                                                \
+      int numContribs,                                                     \
       size_t count,                                                        \
       int divisor,                                                         \
       cudaStream_t stream);

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.cu
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.cu
@@ -202,6 +202,57 @@ void launchMultiReduceKernel(
       divisor);
 }
 
+/*
+ * Seeded multi-input reduce. Each scalar result follows the exact sequence:
+ * seed[i], then contribs[0][i] through contribs[numContribs - 1][i], then one
+ * optional divide. The loop controls prevent reassociation and vectorization.
+ */
+template <typename T>
+__global__ void seededMultiReduceKernel(
+    T* dst,
+    const T* seed,
+    const T* contribs,
+    int numContribs,
+    size_t count,
+    int divisor) {
+#pragma clang fp reassociate(off)
+  size_t threadId = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t totalThreads = static_cast<size_t>(blockDim.x) * gridDim.x;
+
+#pragma clang loop vectorize(disable) interleave(disable)
+  for (size_t elemIdx = threadId; elemIdx < count; elemIdx += totalThreads) {
+    T acc = seed[elemIdx];
+#pragma clang loop unroll(disable) vectorize(disable) interleave(disable)
+    for (int p = 0; p < numContribs; p++) {
+      acc = acc + contribs[static_cast<size_t>(p) * count + elemIdx];
+    }
+    if (divisor > 1) {
+      acc = acc / static_cast<T>(divisor);
+    }
+    dst[elemIdx] = acc;
+  }
+}
+
+template <typename T>
+void launchSeededMultiReduceKernel(
+    void* dst,
+    const void* seed,
+    const void* contribs,
+    int numContribs,
+    size_t count,
+    int divisor,
+    cudaStream_t stream) {
+  const int blockSize = 256;
+  int gridSize = (count + blockSize - 1) / blockSize;
+  seededMultiReduceKernel<T><<<gridSize, blockSize, 0, stream>>>(
+      static_cast<T*>(dst),
+      static_cast<const T*>(seed),
+      static_cast<const T*>(contribs),
+      numContribs,
+      count,
+      divisor);
+}
+
 // Explicit template instantiations for every dtype used by the DISPATCH_*
 // macros in sharded_relay_allreduce.cc.  Without these, the symbols would
 // not exist with external linkage in the device object, and the host TU
@@ -228,6 +279,14 @@ void launchMultiReduceKernel(
       cudaStream_t stream);                                                \
   template void launchMultiReduceKernel<T>(                                \
       void* dst,                                                           \
+      const void* contribs,                                                \
+      int numContribs,                                                     \
+      size_t count,                                                        \
+      int divisor,                                                         \
+      cudaStream_t stream);                                                \
+  template void launchSeededMultiReduceKernel<T>(                          \
+      void* dst,                                                           \
+      const void* seed,                                                    \
       const void* contribs,                                                \
       int numContribs,                                                     \
       size_t count,                                                        \

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.h
@@ -68,6 +68,16 @@ void launchMultiReduceKernel(
     int divisor,
     cudaStream_t stream);
 
+template <typename T>
+void launchSeededMultiReduceKernel(
+    void* dst,
+    const void* seed,
+    const void* contribs,
+    int numContribs,
+    size_t count,
+    int divisor,
+    cudaStream_t stream);
+
 // Suppress instantiation in the host TU; the actual instantiations live in
 // sharded_relay_allreduce_kernels.cu.
 #define RCCLX_DECLARE_RELAY_KERNEL_INSTANTIATIONS(T)                       \
@@ -90,6 +100,14 @@ void launchMultiReduceKernel(
       cudaStream_t stream);                                                \
   extern template void launchMultiReduceKernel<T>(                         \
       void* dst,                                                           \
+      const void* contribs,                                                \
+      int numContribs,                                                     \
+      size_t count,                                                        \
+      int divisor,                                                         \
+      cudaStream_t stream);                                                \
+  extern template void launchSeededMultiReduceKernel<T>(                   \
+      void* dst,                                                           \
+      const void* seed,                                                    \
       const void* contribs,                                                \
       int numContribs,                                                     \
       size_t count,                                                        \

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.h
@@ -59,6 +59,15 @@ void launchFusedReduceKernel(
     int divisor,
     cudaStream_t stream);
 
+template <typename T>
+void launchMultiReduceKernel(
+    void* dst,
+    const void* contribs,
+    int numContribs,
+    size_t count,
+    int divisor,
+    cudaStream_t stream);
+
 // Suppress instantiation in the host TU; the actual instantiations live in
 // sharded_relay_allreduce_kernels.cu.
 #define RCCLX_DECLARE_RELAY_KERNEL_INSTANTIATIONS(T)                       \
@@ -76,6 +85,13 @@ void launchFusedReduceKernel(
       void* output,                                                        \
       const void* inputA,                                                  \
       const void* inputB,                                                  \
+      size_t count,                                                        \
+      int divisor,                                                         \
+      cudaStream_t stream);                                                \
+  extern template void launchMultiReduceKernel<T>(                         \
+      void* dst,                                                           \
+      const void* contribs,                                                \
+      int numContribs,                                                     \
       size_t count,                                                        \
       int divisor,                                                         \
       cudaStream_t stream);

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -530,7 +530,7 @@ bool isSupportedRelayDataType(ncclDataType_t datatype) {
  * reduce-scatter between them, accelerated by passthrough helpers that relay
  * sharded chunks of a single block (recvCounts[g] elements). This is the
  * production BM-FM path and is byte-for-byte unchanged from the original
- * implementation; the A>2 path lives in shardedRelayReduceScatterRecursive.
+ * implementation; the A>2 path lives in shardedRelayReduceScatterFlat.
  *
  * Per active rank (index myActiveIndex), with recvcount = recvCounts[g]:
  *   - sendBuff holds 2 × recvcount elements; block[i] = sendBuff[i*recvcount].
@@ -561,8 +561,6 @@ static ncclResult_t shardedRelayReduceScatter2Active(
     int numHelpers,
     int nGroups,
     size_t elementSize) {
-  int numChunks = numHelpers + 1;
-
   // ==========================================================================
   // SIZE-ADAPTIVE PURE-DIRECT FAST PATH (A==2)
   // ==========================================================================
@@ -586,8 +584,8 @@ static ncclResult_t shardedRelayReduceScatter2Active(
   // independent at ~27 MB (independent has no cross-group contention, so direct
   // holds on longer). Cross over just below each.
   const size_t kA2PureDirectMaxBytes = (nGroups > 1)
-      ? (static_cast<size_t>(8) << 20) // fused: < 8 MB
-      : (static_cast<size_t>(16) << 20); // independent: < 16 MB
+      ? (static_cast<size_t>(2) << 20) // fused: < 2 MB
+      : (static_cast<size_t>(6) << 20); // independent: < 6 MB
   if (maxBytes2 < kA2PureDirectMaxBytes) {
     void* pdScratch = nullptr;
     size_t pdRecvcount = 0;
@@ -659,368 +657,227 @@ static ncclResult_t shardedRelayReduceScatter2Active(
   }
 
   // =========================================================================
-  // CALCULATE PER-GROUP CHUNK SIZES (from the OUTPUT recvCount, i.e. one block)
+  // CHUNK GEOMETRY: numHelpers relayed chunks + TWO direct chunks
   // =========================================================================
+  // The active<->active link is idle while the relay scatter and forward run on
+  // the cross links, so instead of a third comm group for a single direct
+  // chunk, one direct chunk rides along with each relay group. With numChunks =
+  // numHelpers + 2 every link carries exactly one chunk per direction per
+  // group, making the critical path 2*recvCount/numChunks instead of the
+  // 3*recvCount/(numHelpers+1) of a separate direct phase.
+  //
+  // Unlike allreduce, the helper CANNOT reduce here: its slot 0 holds a0's
+  // contribution to a1's output and slot 1 holds a1's contribution to a0's
+  // output — different outputs. Helpers stay pure passthrough and the active
+  // rank reduces.
+  const int numChunks = numHelpers + 2;
+
   size_t chunkSizes[SHARDED_RELAY_MAX_GROUPS];
-  size_t lastChunkSizes[SHARDED_RELAY_MAX_GROUPS];
-  size_t directChunkOffsets[SHARDED_RELAY_MAX_GROUPS];
-  size_t directChunkSizes[SHARDED_RELAY_MAX_GROUPS];
+  size_t relayTotals[SHARDED_RELAY_MAX_GROUPS]; // == direct chunk A's offset
+  size_t dirBOffsets[SHARDED_RELAY_MAX_GROUPS];
+  size_t dirBSizes[SHARDED_RELAY_MAX_GROUPS]; // absorbs the remainder
 
   for (int g = 0; g < nGroups; g++) {
     size_t count = recvCounts[g];
 
-    // Skip groups with recvCount == 0; the per-phase loops below already check
-    // recvCounts[g] == 0 and bypass NCCL ops for those groups.
+    // Zero-count groups are skipped by every loop below.
     if (count == 0) {
       chunkSizes[g] = 0;
-      lastChunkSizes[g] = 0;
-      directChunkOffsets[g] = 0;
-      directChunkSizes[g] = 0;
+      relayTotals[g] = 0;
+      dirBOffsets[g] = 0;
+      dirBSizes[g] = 0;
       continue;
     }
 
-    // Calculate chunk size (aligned to CHUNK_ALIGN_ELEMENTS). When the
-    // per-chunk size rounded down to CHUNK_ALIGN_ELEMENTS is zero, the block
-    // is too small to scatter and the caller should fall back to a regular
-    // reduce-scatter.
+    // A chunk size that rounds down to zero means the block is too small to
+    // scatter; the caller should fall back to a regular reduce-scatter.
     size_t chunkSize = count / numChunks;
     chunkSize = (chunkSize / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
     if (chunkSize == 0) {
       return ncclInvalidArgument;
     }
     chunkSizes[g] = chunkSize;
-
-    // Calculate the size of the last chunk (absorbs the remainder)
-    size_t totalChunkedElements = static_cast<size_t>(numChunks) * chunkSize;
-    size_t lastChunkSize = chunkSize;
-    if (totalChunkedElements < count) {
-      lastChunkSize = chunkSize + (count - totalChunkedElements);
-    }
-    lastChunkSizes[g] = lastChunkSize;
-
-    // Direct exchange chunk info (within the single output block)
-    int directChunkIndex = numHelpers;
-    directChunkOffsets[g] = static_cast<size_t>(directChunkIndex) * chunkSize;
-    directChunkSizes[g] = lastChunkSize;
+    relayTotals[g] = static_cast<size_t>(numHelpers) * chunkSize;
+    dirBOffsets[g] = relayTotals[g] + chunkSize;
+    dirBSizes[g] = count - dirBOffsets[g];
   }
 
   // =========================================================================
-  // SCRATCH BUFFER ALLOCATION
+  // SCRATCH: the whole foreign contribution to my output block, contiguous
   // =========================================================================
-  // Relay scratch: numHelpers × chunkSize for batched passthrough recv.
-  // Direct-exchange scratch: (nActiveRanks-1) × directChunkSize (in-place).
-  void* relayScratch = nullptr;
-  void* directScratch = nullptr;
-
-  // For an active rank, compute its block offsets up-front.
+  // One recvCount-element buffer laid out exactly like the output block: the
+  // relayed chunks land at [0, relayTotal) and the two direct chunks fill
+  // [relayTotal, recvCount). Because it mirrors the output layout, the entire
+  // reduction collapses to ONE fused kernel launch at the end.
+  void* foreignScratch = nullptr;
   size_t ownBlockOffset = 0;
   size_t sendBlockOffset = 0;
   bool isInPlace = false;
   if (myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0) {
     const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
     size_t recvcount = recvCounts[myActiveGroup];
-    int otherActiveIndex = 1 - cfg.myActiveIndex;
     ownBlockOffset = static_cast<size_t>(cfg.myActiveIndex) * recvcount;
-    sendBlockOffset = static_cast<size_t>(otherActiveIndex) * recvcount;
+    sendBlockOffset = static_cast<size_t>(1 - cfg.myActiveIndex) * recvcount;
 
     // In-place when recvBuff aliases the local contribution block of sendBuff.
-    const char* sendBlockStart =
-        static_cast<const char*>(sendBuffs[myActiveGroup]) +
+    const char* ownBlock = static_cast<const char*>(sendBuffs[myActiveGroup]) +
         ownBlockOffset * elementSize;
     isInPlace =
         (static_cast<const void*>(recvBuffs[myActiveGroup]) ==
-         static_cast<const void*>(sendBlockStart));
+         static_cast<const void*>(ownBlock));
 
-    // Relay scratch sized to numHelpers × chunkSize.
-    size_t relayScratchBytes = static_cast<size_t>(numHelpers) *
-        chunkSizes[myActiveGroup] * elementSize;
-    relayScratch = ScratchBufferCache::getInstance().get(
-        SHARDED_RELAY_MAX_GROUPS, relayScratchBytes, stream);
-    if (relayScratch == nullptr) {
+    foreignScratch = ScratchBufferCache::getInstance().get(
+        SHARDED_RELAY_MAX_GROUPS, recvcount * elementSize, stream);
+    if (foreignScratch == nullptr) {
       return ncclInternalError;
     }
+  }
 
-    // Direct-exchange scratch (in-place only)
+  // =========================================================================
+  // GROUP 1: relay scatter (active->helpers) || direct chunk A
+  // (active<->active)
+  // =========================================================================
+  NCCLCHECK(ncclGroupStart());
+
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    size_t chunkSize = chunkSizes[g];
+
+    if (cfg.isActiveRank) {
+      // The block shipped to the other active rank.
+      const char* sendBlock = static_cast<const char*>(sendBuffs[g]) +
+          sendBlockOffset * elementSize;
+
+      for (int h = 0; h < cfg.numHelpers; h++) {
+        NCCLCHECK(ncclSend(
+            sendBlock + static_cast<size_t>(h) * chunkSize * elementSize,
+            chunkSize,
+            datatype,
+            cfg.helperRanks[h],
+            comm,
+            stream));
+      }
+
+      // Direct chunk A over the otherwise-idle active<->active link.
+      int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      NCCLCHECK(ncclSend(
+          sendBlock + relayTotals[g] * elementSize,
+          chunkSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+      NCCLCHECK(ncclRecv(
+          static_cast<char*>(foreignScratch) + relayTotals[g] * elementSize,
+          chunkSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else {
+      // Helper: receive active rank a's chunk into slot a.
+      char* helperBuf = static_cast<char*>(recvBuffs[g]);
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        NCCLCHECK(ncclRecv(
+            helperBuf + static_cast<size_t>(a) * chunkSize * elementSize,
+            chunkSize,
+            datatype,
+            cfg.activeRanks[a],
+            comm,
+            stream));
+      }
+    }
+  }
+
+  NCCLCHECK(ncclGroupEnd());
+
+  // =========================================================================
+  // GROUP 2: relay forward (helpers->active) || direct chunk B
+  // (active<->active)
+  // =========================================================================
+  NCCLCHECK(ncclGroupStart());
+
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    size_t chunkSize = chunkSizes[g];
+
+    if (cfg.isActiveRank) {
+      char* scratch = static_cast<char*>(foreignScratch);
+
+      for (int h = 0; h < cfg.numHelpers; h++) {
+        NCCLCHECK(ncclRecv(
+            scratch + static_cast<size_t>(h) * chunkSize * elementSize,
+            chunkSize,
+            datatype,
+            cfg.helperRanks[h],
+            comm,
+            stream));
+      }
+
+      // Direct chunk B, again over the idle active<->active link.
+      int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      NCCLCHECK(ncclSend(
+          static_cast<const char*>(sendBuffs[g]) +
+              (sendBlockOffset + dirBOffsets[g]) * elementSize,
+          dirBSizes[g],
+          datatype,
+          partner,
+          comm,
+          stream));
+      NCCLCHECK(ncclRecv(
+          scratch + dirBOffsets[g] * elementSize,
+          dirBSizes[g],
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else {
+      // Passthrough: slot a goes to the OTHER active rank, which owns it.
+      const char* helperBuf = static_cast<const char*>(recvBuffs[g]);
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        NCCLCHECK(ncclSend(
+            helperBuf + static_cast<size_t>(a) * chunkSize * elementSize,
+            chunkSize,
+            datatype,
+            cfg.activeRanks[1 - a],
+            comm,
+            stream));
+      }
+    }
+  }
+
+  NCCLCHECK(ncclGroupEnd());
+
+  // =========================================================================
+  // REDUCE: one fused pass over the whole output block
+  // =========================================================================
+  // foreignScratch mirrors the output layout, so relayed and direct chunks are
+  // reduced together in a single launch.
+  if (myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0) {
+    size_t recvcount = recvCounts[myActiveGroup];
+    void* out = recvBuffs[myActiveGroup];
     if (isInPlace) {
-      int nOtherActives = cfg.nActiveRanks - 1;
-      size_t directScratchBytes = static_cast<size_t>(nOtherActives) *
-          directChunkSizes[myActiveGroup] * elementSize;
-      directScratch = ScratchBufferCache::getInstance().get(
-          myActiveGroup, directScratchBytes, stream);
-      if (directScratch == nullptr) {
-        return ncclInternalError;
-      }
-    }
-  }
-
-  // =========================================================================
-  // PHASE 1 (active→helpers): Both active ranks scatter their sendBlock chunks
-  // =========================================================================
-  // Helpers receive from each active rank into offset-based slots:
-  //   slot a at offset (a × chunkSize) holds data from active rank a.
-  // Active ranks send chunks of the sendBlockOffset block (block destined for
-  // the OTHER active rank).
-  NCCLCHECK(ncclGroupStart());
-
-  for (int g = 0; g < nGroups; g++) {
-    if (recvCounts[g] == 0)
-      continue;
-    const ShardedRelayRankConfig& cfg = configs[g];
-    const void* sendbuff = sendBuffs[g];
-    void* recvbuff = recvBuffs[g];
-    size_t chunkSize = chunkSizes[g];
-
-    if (cfg.isActiveRank) {
-      // Active rank: send chunk h of my sendBlock to helper h
-      for (int h = 0; h < cfg.numHelpers; h++) {
-        int helperRank = cfg.helperRanks[h];
-        size_t chunkOffset =
-            sendBlockOffset + static_cast<size_t>(h) * chunkSize;
-
-        NCCLCHECK(ncclSend(
-            static_cast<const char*>(sendbuff) + chunkOffset * elementSize,
-            chunkSize,
-            datatype,
-            helperRank,
-            comm,
-            stream));
-      }
-    } else {
-      // Helper rank: receive from each active rank into slot a
-      for (int a = 0; a < cfg.nActiveRanks; a++) {
-        int activeRank = cfg.activeRanks[a];
-        size_t helperOffset = static_cast<size_t>(a) * chunkSize;
-
-        NCCLCHECK(ncclRecv(
-            static_cast<char*>(recvbuff) + helperOffset * elementSize,
-            chunkSize,
-            datatype,
-            activeRank,
-            comm,
-            stream));
-      }
-    }
-  }
-
-  NCCLCHECK(ncclGroupEnd());
-
-  // For out-of-place active groups: seed recvbuff's relay region with the
-  // local contribution (the ownBlockOffset block of sendbuff) so the
-  // incremental add in Phase 3 works uniformly. In-place already has it.
-  if (myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0 && !isInPlace) {
-    const void* sendbuff = sendBuffs[myActiveGroup];
-    void* recvbuff = recvBuffs[myActiveGroup];
-    size_t relayBytes = static_cast<size_t>(numHelpers) *
-        chunkSizes[myActiveGroup] * elementSize;
-    cudaMemcpyAsync(
-        recvbuff,
-        static_cast<const char*>(sendbuff) + ownBlockOffset * elementSize,
-        relayBytes,
-        cudaMemcpyDeviceToDevice,
-        stream);
-  }
-
-  // =========================================================================
-  // PHASE 2 (helpers→active, batched): Passthrough forward
-  // =========================================================================
-  // Each helper sends slot 0 (a0's data) → a1 and slot 1 (a1's data) → a0.
-  // Active rank receives all numHelpers chunks into relay scratch at offset
-  // h × chunkSize per helper h.
-  NCCLCHECK(ncclGroupStart());
-
-  for (int g = 0; g < nGroups; g++) {
-    if (recvCounts[g] == 0)
-      continue;
-    const ShardedRelayRankConfig& cfg = configs[g];
-    void* recvbuff = recvBuffs[g];
-    size_t chunkSize = chunkSizes[g];
-
-    if (!cfg.isActiveRank) {
-      // Helper for group g: forward each slot to the OTHER active rank.
-      for (int a = 0; a < cfg.nActiveRanks; a++) {
-        int targetActive = cfg.activeRanks[1 - a];
-        NCCLCHECK(ncclSend(
-            static_cast<const char*>(recvbuff) +
-                static_cast<size_t>(a) * chunkSize * elementSize,
-            chunkSize,
-            datatype,
-            targetActive,
-            comm,
-            stream));
-      }
-    } else {
-      // Active rank: receive ALL forwarded data from each helper into the
-      // relay scratch at offset h × chunkSize.
-      for (int h = 0; h < cfg.numHelpers; h++) {
-        int helperRank = cfg.helperRanks[h];
-        size_t scratchOffset = static_cast<size_t>(h) * chunkSize;
-        NCCLCHECK(ncclRecv(
-            static_cast<char*>(relayScratch) + scratchOffset * elementSize,
-            chunkSize,
-            datatype,
-            helperRank,
-            comm,
-            stream));
-      }
-    }
-  }
-
-  NCCLCHECK(ncclGroupEnd());
-
-  // =========================================================================
-  // PHASE 3 (active reduce): Fused add + scale on the relay region
-  // =========================================================================
-  // recvbuff[i] = (recvbuff[i] + relayScratch[i]) / divisor over the relay
-  // region (numHelpers × chunkSize). recvbuff was seeded with the local
-  // ownBlock contribution above.
-  for (int g = 0; g < nGroups; g++) {
-    if (recvCounts[g] == 0)
-      continue;
-    const ShardedRelayRankConfig& cfg = configs[g];
-    if (cfg.isActiveRank) {
-      void* recvbuff = recvBuffs[g];
-      size_t chunkSize = chunkSizes[g];
-      size_t relayTotal = static_cast<size_t>(numHelpers) * chunkSize;
-
       if (reductionDivisor > 1) {
         DISPATCH_INCREMENTAL_ADD_AND_SCALE(
-            datatype,
-            recvbuff,
-            relayScratch,
-            relayTotal,
-            reductionDivisor,
-            stream);
+            datatype, out, foreignScratch, recvcount, reductionDivisor, stream);
       } else {
         DISPATCH_INCREMENTAL_ADD(
-            datatype, recvbuff, relayScratch, relayTotal, stream);
+            datatype, out, foreignScratch, recvcount, stream);
       }
-    }
-  }
-
-  // =========================================================================
-  // PHASE 4 (active↔active): Direct exchange of the last chunk
-  // =========================================================================
-  // Active ranks exchange the direct chunk of their sendBlock; it lands in the
-  // output block's direct-chunk slot (offset directChunkOffset in recvbuff).
-  NCCLCHECK(ncclGroupStart());
-
-  for (int g = 0; g < nGroups; g++) {
-    if (recvCounts[g] == 0)
-      continue;
-    const ShardedRelayRankConfig& cfg = configs[g];
-
-    if (cfg.isActiveRank) {
-      const void* sendbuff = sendBuffs[g];
-      void* recvbuff = recvBuffs[g];
-      size_t directChunkOffset = directChunkOffsets[g];
-      size_t directChunkSize = directChunkSizes[g];
-      // Source in sendbuff is within the sendBlock (shipped to other rank).
-      size_t sendDirectOffset = sendBlockOffset + directChunkOffset;
-
-      // Send my direct chunk to all other active ranks
-      for (int a = 0; a < cfg.nActiveRanks; a++) {
-        if (a == cfg.myActiveIndex)
-          continue;
-        int otherActiveRank = cfg.activeRanks[a];
-
-        NCCLCHECK(ncclSend(
-            static_cast<const char*>(sendbuff) + sendDirectOffset * elementSize,
-            directChunkSize,
-            datatype,
-            otherActiveRank,
-            comm,
-            stream));
-      }
-
-      // Receive direct chunks from all other active ranks
-      int scratchIdx = 0;
-      for (int a = 0; a < cfg.nActiveRanks; a++) {
-        if (a == cfg.myActiveIndex)
-          continue;
-        int otherActiveRank = cfg.activeRanks[a];
-
-        if (isInPlace) {
-          size_t scratchOffset =
-              static_cast<size_t>(scratchIdx) * directChunkSize;
-          NCCLCHECK(ncclRecv(
-              static_cast<char*>(directScratch) + scratchOffset * elementSize,
-              directChunkSize,
-              datatype,
-              otherActiveRank,
-              comm,
-              stream));
-        } else {
-          NCCLCHECK(ncclRecv(
-              static_cast<char*>(recvbuff) + directChunkOffset * elementSize,
-              directChunkSize,
-              datatype,
-              otherActiveRank,
-              comm,
-              stream));
-        }
-        scratchIdx++;
-      }
-    }
-  }
-
-  NCCLCHECK(ncclGroupEnd());
-
-  // =========================================================================
-  // PHASE 5 (active reduce): Final reduction on the direct-exchange chunk
-  // =========================================================================
-  for (int g = 0; g < nGroups; g++) {
-    if (recvCounts[g] == 0)
-      continue;
-    const ShardedRelayRankConfig& cfg = configs[g];
-
-    if (cfg.isActiveRank) {
-      const void* sendbuff = sendBuffs[g];
-      void* recvbuff = recvBuffs[g];
-      size_t directChunkOffset = directChunkOffsets[g];
-      size_t directChunkSize = directChunkSizes[g];
-
-      void* directChunkDst =
-          static_cast<char*>(recvbuff) + directChunkOffset * elementSize;
-
-      if (isInPlace) {
-        // recvbuff direct slot already holds the local contribution.
-        int scratchIdx2 = 0;
-        for (int a = 0; a < cfg.nActiveRanks; a++) {
-          if (a == cfg.myActiveIndex)
-            continue;
-          size_t scratchOffset =
-              static_cast<size_t>(scratchIdx2) * directChunkSize;
-          const void* received = static_cast<const char*>(directScratch) +
-              scratchOffset * elementSize;
-          DISPATCH_INCREMENTAL_ADD(
-              datatype, directChunkDst, received, directChunkSize, stream);
-          scratchIdx2++;
-        }
-
-        if (reductionDivisor > 1) {
-          DISPATCH_SCALE(
-              datatype,
-              directChunkDst,
-              directChunkSize,
-              reductionDivisor,
-              stream);
-        }
-      } else {
-        // Out-of-place: local contribution is in sendbuff's ownBlock; the
-        // received chunk is already in recvbuff's direct slot.
-        const void* localContribution = static_cast<const char*>(sendbuff) +
-            (ownBlockOffset + directChunkOffset) * elementSize;
-        const void* receivedContribution = directChunkDst;
-
-        DISPATCH_FUSED_REDUCE(
-            datatype,
-            directChunkDst,
-            localContribution,
-            receivedContribution,
-            directChunkSize,
-            reductionDivisor,
-            stream);
-      }
+    } else {
+      DISPATCH_FUSED_REDUCE(
+          datatype,
+          out,
+          static_cast<const char*>(sendBuffs[myActiveGroup]) +
+              ownBlockOffset * elementSize,
+          foreignScratch,
+          recvcount,
+          reductionDivisor,
+          stream);
     }
   }
 
@@ -1028,36 +885,48 @@ static ncclResult_t shardedRelayReduceScatter2Active(
 }
 
 /**
- * Reduce-scatter for > 2 active ranks (bandwidth-optimal recursive path).
+ * Reduce-scatter for > 2 active ranks (two-group flat relay with
+ * reduce-at-helper).
  *
- * A recursive-halving relay over the cross links (active<->helper, 2-hop) woven
- * with a direct all-to-all over the intra links (active<->active, 1-hop), split
- * DIRECT_NUM=60% / 40% to equalize per-link load. There is NO all-gather phase
- * (reduce-scatter keeps only the owner's reduced shard).
+ * Each active rank's sendBuff holds A blocks of recvCount; block[j] is this
+ * rank's contribution to owner j's output. Owner j's output is the sum over all
+ * A sources of block[j].
  *
- * The active rank's sendBuff holds A blocks of recvCount (block[j] is this
- * rank's contribution to owner j). It is gathered into a working buffer W of
- * size A*recvCount laid out as [R region (pR) | D region (pD)], where every
- * block contributes an R part (pR/A elements, its first elements) and a D part
- * (pD/A elements, the rest):
- *   - block[j]_R is placed at R-part bitReverse(j): the recursive-halving
- *     reduce-scatter leaves owner mi holding R-part bitReverse(mi), so owner j
- *     ends up with the reduced block[j]_R.
- *   - block[j]_D is placed at D-part j: the direct all-to-all reduce-scatter
- *     keeps index j with owner j.
- * After the halving relay + direct all-to-all reduce, owner mi holds the
- * reduced block[mi] in two pieces in W (R at the final segOff, D at
- * pR + mi*(pD/A)); both are copied into recvBuff (recvCount = pR/A + pD/A).
+ * Every block is split into a DIRECT region, exchanged 1-hop over the intra
+ * active<->active links, and an OFFLOAD region, routed 2-hop through the
+ * otherwise-idle helpers. A helper owns one position slice of every block: it
+ * collects that slice from the A-1 non-owner sources, SUMS them, and sends the
+ * single reduced slice on to the owner, which folds in its own contribution.
+ * Reducing at the helper is what keeps the return hop cheap -- (A-1) chunks in,
+ * one chunk out.
  *
- * In-place (recvBuff == sendBuff + myActiveIndex*recvCount) and out-of-place
- * are both supported transparently: W is a separate scratch, so sendBuff is
- * fully read into W before recvBuff is written, and the only difference is the
- * (identical) final copy destination.
+ * Link accounting, per direction, in units of the per-(owner, helper) chunk cs.
+ * A rank's helpers are the active ranks of another group, so its scatter and
+ * its helper duty are egress on the same cross links:
  *
- * Requires a power-of-two active count (count = A*recvCount is divisible by A
- * by construction, so the R/D split and per-block parts are exact).
+ *   group 1:  cross = (A-1)*cs (my A-1 foreign blocks' slice h)   intra =
+ * (A-1)*cs group 2:  cross = cs       (one reduced slice per owner)      intra
+ * = cs
+ *
+ * Balancing intra against cross in each group puts (A-1)*cs of the direct
+ * region in group 1 and cs in group 2, so the direct region is A*cs and the
+ * offload region is H*cs: cs = recvCount/(A+H), eight equal units on the 8-GPU
+ * node. The critical path is (A-1)*cs + cs = A*cs = recvCount/2, against
+ * recvCount for NCCL's intra-only reduce-scatter -- a 2x ceiling. (The previous
+ * recursive-halving path measured ~0.96x.)
+ *
+ * Block layout [0, recvCount): direct region [0, A*cs) whose first (A-1)*cs go
+ * out in group 1 and whose last cs goes out in group 2, then the offload region
+ * [A*cs, recvCount) as H slices of cs, slice h owned by helper h.
+ *
+ * Helper scratch = recvBuffs[g], holding one cs chunk per (owner, contributing
+ * source) pair: A*(A-1)*cs elements. The reduction is done in place into each
+ * owner's first slot.
+ *
+ * Below a size threshold the offload is disabled and this degenerates to a
+ * single-group pure-direct all-to-all reduce-scatter with the helpers idle.
  */
-static ncclResult_t shardedRelayReduceScatterRecursive(
+static ncclResult_t shardedRelayReduceScatterFlat(
     const void* const* sendBuffs,
     void* const* recvBuffs,
     const size_t* recvCounts,
@@ -1072,396 +941,309 @@ static ncclResult_t shardedRelayReduceScatterRecursive(
     int nGroups,
     size_t elementSize) {
   const int A = nActiveRanksPerGroup;
-  const int numChunks = numHelpers + 1;
-  int logA = 0;
-  while ((1 << logA) < A) {
-    logA++;
-  }
-  const int nRsGroups = 2 * logA;
+  const int H = numHelpers;
 
-  // Largest per-group message drives the size-adaptive tuning. All groups march
-  // through the same superstep count to stay phase-synced, so tune off the max.
   size_t maxRc = 0;
   for (int g = 0; g < nGroups; g++) {
     if (recvCounts[g] > maxRc) {
       maxRc = recvCounts[g];
     }
   }
+  // maxBytes (A*recvCount*elemSize) equals the bench per-rank input label.
   const size_t maxBytes = static_cast<size_t>(A) * maxRc * elementSize;
+  // Measured crossover (MI350X, A=4, bf16, 8 GPUs): the offload's 2-hop hop
+  // plus the second group boundary only pays for itself past ~48 MB; below that
+  // the single-group pure-direct all-to-all reduce-scatter wins outright
+  // (1.24-1.42x at <= 576 KB, vs 0.69x if the offload is forced on at 4.5 MB).
+  const size_t kOffloadMinBytes = static_cast<size_t>(48) << 20;
+  const bool useOffload = (H > 0) && (maxBytes >= kOffloadMinBytes);
 
-  // Size-adaptive routing. The recursive-halving relay spreads traffic across
-  // helper cross links for bandwidth, but it costs 2*logA group boundaries
-  // (~25us each) plus 2-hop latency. Below the threshold that is pure overhead,
-  // so degenerate to a single-group pure-direct all-to-all reduce-scatter (each
-  // active rank swaps its foreign shards directly with the other A-1 owners and
-  // reduces locally; helpers idle) -- the same minimal-latency shape as
-  // all-to-all. Above it, keep the recursive relay with a 60% direct / 40%
-  // relay split (balances per-link load: intra links carry 0.5*D at 1 hop,
-  // cross links 0.75*R at 2 hops; equal at D:R = 0.6:0.4). The crossover is
-  // scenario-independent here (unlike all-gather): measured on MI350X (A=4,
-  // bf16, 8 GPUs) pure-direct wins or ties across the whole range up to 144 MB
-  // in both fused and independent modes (e.g. 4.5 MB 0.44x->0.99x, 72 MB
-  // 0.86x->0.98x fused), and the recursive relay only pulls ahead at
-  // >=256 MB where its helper-cross-link bandwidth beats intra-only direct. max
-  // bytes here (A*recvCount*elemSize) equals the bench's per-rank input label.
-  const size_t kFlatPureDirectMaxBytes = static_cast<size_t>(256)
-      << 20; // 256 MB
-  const bool pureDirect = (maxBytes < kFlatPureDirectMaxBytes);
-  const size_t DIRECT_NUM = pureDirect ? 100 : 60, DIRECT_DEN = 100;
-
-  // Per-group working-buffer total count = A * recvCount (the full input), and
-  // its R/D split. count is divisible by A by construction.
-  size_t countArr[SHARDED_RELAY_MAX_GROUPS];
-  size_t pRArr[SHARDED_RELAY_MAX_GROUPS];
-  size_t pDArr[SHARDED_RELAY_MAX_GROUPS];
+  // Per-group geometry. cs = recvCount/(A+H) aligned down; the direct region
+  // absorbs the remainder so directSz + H*cs == recvCount.
+  size_t csArr[SHARDED_RELAY_MAX_GROUPS];
+  size_t directArr[SHARDED_RELAY_MAX_GROUPS];
+  size_t d1Arr[SHARDED_RELAY_MAX_GROUPS];
   for (int g = 0; g < nGroups; g++) {
-    size_t recvcount = recvCounts[g];
-    if (recvcount == 0) {
-      countArr[g] = 0;
-      pRArr[g] = 0;
-      pDArr[g] = 0;
+    size_t rc = recvCounts[g];
+    if (rc == 0) {
+      csArr[g] = 0;
+      directArr[g] = 0;
+      d1Arr[g] = 0;
       continue;
     }
-    size_t count = static_cast<size_t>(A) * recvcount;
-    countArr[g] = count;
-    size_t alignA = static_cast<size_t>(A) * CHUNK_ALIGN_ELEMENTS;
-    size_t pD = (count * DIRECT_NUM) / DIRECT_DEN;
-    pD = (pD / alignA) * alignA;
-    if (pD > count) {
-      pD = (count / alignA) * alignA;
-    }
-    pDArr[g] = pD;
-    pRArr[g] = count - pD;
+    size_t cs = useOffload ? (rc / static_cast<size_t>(A + H)) : 0;
+    cs = (cs / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
+    csArr[g] = cs;
+    directArr[g] = rc - static_cast<size_t>(H) * cs;
+    d1Arr[g] = (cs > 0) ? (directArr[g] - cs) : directArr[g];
   }
 
-  // =========================================================================
-  // SCRATCH BUFFER ALLOCATION
-  // =========================================================================
-  // workScratch (W): A*recvCount working buffer (active rank only).
-  // rsScratch: relay reduce-scatter receive buffer (max half pR/2).
-  // directScratch: direct all-to-all reduce-scatter buffer ((A-1) shards).
-  void* workScratch = nullptr;
-  void* rsScratch = nullptr;
-  void* directScratch = nullptr;
+  // Active-rank scratch. dScratch holds the A-1 peer contributions to my direct
+  // region, one contiguous directSz block each, so the whole direct region
+  // reduces in a single multi-input pass. oScratch mirrors my output's offload
+  // region and receives the H helper-reduced slices straight into place.
+  void* dScratch = nullptr;
+  void* oScratch = nullptr;
+  bool isInPlace = false;
   if (myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0) {
-    size_t count = countArr[myActiveGroup];
-    size_t pR = pRArr[myActiveGroup];
-    size_t pD = pDArr[myActiveGroup];
+    const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
+    const char* ownBlock = static_cast<const char*>(sendBuffs[myActiveGroup]) +
+        static_cast<size_t>(cfg.myActiveIndex) * recvCounts[myActiveGroup] *
+            elementSize;
+    isInPlace =
+        (static_cast<const void*>(recvBuffs[myActiveGroup]) ==
+         static_cast<const void*>(ownBlock));
 
-    size_t workBytes = count * elementSize;
-    workScratch = ScratchBufferCache::getInstance().get(
-        SHARDED_RELAY_MAX_GROUPS, workBytes, stream);
-    if (workScratch == nullptr) {
+    dScratch = ScratchBufferCache::getInstance().get(
+        SHARDED_RELAY_MAX_GROUPS,
+        static_cast<size_t>(A - 1) * directArr[myActiveGroup] * elementSize,
+        stream);
+    if (dScratch == nullptr) {
       return ncclInternalError;
     }
-    if (pR > 0) {
-      size_t maxHalfBytes = (pR / 2 + CHUNK_ALIGN_ELEMENTS) * elementSize;
-      rsScratch = ScratchBufferCache::getInstance().get(
-          SHARDED_RELAY_MAX_GROUPS + 1, maxHalfBytes, stream);
-      if (rsScratch == nullptr) {
-        return ncclInternalError;
-      }
-    }
-    if (pD > 0) {
-      size_t directBytes = static_cast<size_t>(A - 1) * (pD / A) * elementSize;
-      directScratch = ScratchBufferCache::getInstance().get(
-          SHARDED_RELAY_MAX_GROUPS + 2, directBytes, stream);
-      if (directScratch == nullptr) {
+    if (csArr[myActiveGroup] > 0) {
+      oScratch = ScratchBufferCache::getInstance().get(
+          myActiveGroup,
+          static_cast<size_t>(H) * csArr[myActiveGroup] * elementSize,
+          stream);
+      if (oScratch == nullptr) {
         return ncclInternalError;
       }
     }
   }
 
   // =========================================================================
-  // GATHER: scatter the A input blocks into W with the R/D split + bit-reversed
-  // R placement (active rank only). Reads directly from the caller's contiguous
-  // input buffer (block j spans logical [j*recvcount, (j+1)*recvcount)).
+  // GROUP 1: direct part 1 (active<->active) || offload scatter
+  // (active->helper)
   // =========================================================================
-  if (myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0) {
-    char* W = static_cast<char*>(workScratch);
-    const char* inPtr = static_cast<const char*>(sendBuffs[myActiveGroup]);
-    size_t recvcount = recvCounts[myActiveGroup];
-    size_t pR = pRArr[myActiveGroup];
-    size_t rPart = pR / A; // per-block R part
-    size_t dPart = pDArr[myActiveGroup] / A; // per-block D part
-    for (int j = 0; j < A; j++) {
-      size_t blkOff = static_cast<size_t>(j) * recvcount;
-      if (rPart > 0) {
-        int p = bitReverse(j, logA);
-        cudaMemcpyAsync(
-            W + static_cast<size_t>(p) * rPart * elementSize,
-            inPtr + blkOff * elementSize,
-            rPart * elementSize,
-            cudaMemcpyDeviceToDevice,
-            stream);
-      }
-      if (dPart > 0) {
-        cudaMemcpyAsync(
-            W + (pR + static_cast<size_t>(j) * dPart) * elementSize,
-            inPtr + (blkOff + rPart) * elementSize,
-            dPart * elementSize,
-            cudaMemcpyDeviceToDevice,
-            stream);
-      }
-    }
-  }
+  NCCLCHECK(ncclGroupStart());
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    size_t rc = recvCounts[g];
+    size_t cs = csArr[g];
+    size_t directSz = directArr[g];
+    size_t d1 = d1Arr[g];
 
-  // Direct shard geometry for this rank's active group.
-  size_t myShardLen = 0, dBase = 0;
-  int myIdx = -1;
-  if (myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0 &&
-      pDArr[myActiveGroup] > 0) {
-    myShardLen = pDArr[myActiveGroup] / A;
-    dBase = pRArr[myActiveGroup];
-    myIdx = configs[myActiveGroup].myActiveIndex;
-  }
+    if (cfg.isActiveRank) {
+      const char* sendbuff = static_cast<const char*>(sendBuffs[g]);
+      int m = cfg.myActiveIndex;
 
-  // Relay segment within the R region [0, pR).
-  size_t segOff = 0;
-  size_t segLen = (myActiveGroup >= 0) ? pRArr[myActiveGroup] : 0;
-
-  // ===== Reduce-scatter: relay halving (R) + direct all-to-all (D) =====
-  int giRs = 0;
-  for (int k = 0; k < logA; k++) {
-    int mask = 1 << k;
-    bool lastRsStep = (k == logA - 1);
-
-    size_t halfLen = 0, sendOff = 0, keepOff = 0;
-    int partner = -1;
-    if (myActiveGroup >= 0 && pRArr[myActiveGroup] > 0) {
-      const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
-      halfLen = segLen / 2;
-      int mi = cfg.myActiveIndex;
-      if (mi & mask) {
-        keepOff = segOff + halfLen;
-        sendOff = segOff;
-      } else {
-        keepOff = segOff;
-        sendOff = segOff + halfLen;
-      }
-      partner = cfg.activeRanks[mi ^ mask];
-    }
-
-    for (int phase = 0; phase < 2; phase++) { // 0 = scatter, 1 = forward
-      int gi = giRs + phase;
-      size_t dSliceLen = 0, dSliceOff = 0;
-      if (myShardLen > 0) {
-        if (pureDirect) {
-          // No relay traffic to overlap against: carry the whole direct
-          // all-to-all in the first superstep and leave the rest empty.
-          dSliceOff = 0;
-          dSliceLen = (gi == 0) ? myShardLen : 0;
-        } else {
-          size_t base = myShardLen / nRsGroups;
-          dSliceOff = static_cast<size_t>(gi) * base;
-          dSliceLen = (gi == nRsGroups - 1) ? (myShardLen - dSliceOff) : base;
+      if (d1 > 0) {
+        for (int k = 0; k < A; k++) {
+          if (k == m)
+            continue;
+          NCCLCHECK(ncclSend(
+              sendbuff + static_cast<size_t>(k) * rc * elementSize,
+              d1,
+              datatype,
+              cfg.activeRanks[k],
+              comm,
+              stream));
+        }
+        for (int s = 0; s < A; s++) {
+          if (s == m)
+            continue;
+          int p = (s < m) ? s : s - 1;
+          NCCLCHECK(ncclRecv(
+              static_cast<char*>(dScratch) +
+                  static_cast<size_t>(p) * directSz * elementSize,
+              d1,
+              datatype,
+              cfg.activeRanks[s],
+              comm,
+              stream));
         }
       }
 
-      // Skip supersteps with no work: in pure-direct mode pR==0 (no relay) and
-      // all direct traffic is in gi==0, so gi>0 would be an empty group
-      // boundary.
-      if (pureDirect && gi > 0) {
+      // Offload scatter: helper h gets slice h of each of my foreign blocks.
+      for (int h = 0; h < cfg.numHelpers && cs > 0; h++) {
+        for (int j = 0; j < A; j++) {
+          if (j == m)
+            continue;
+          NCCLCHECK(ncclSend(
+              sendbuff +
+                  (static_cast<size_t>(j) * rc + directSz +
+                   static_cast<size_t>(h) * cs) *
+                      elementSize,
+              cs,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+    } else if (cs > 0) {
+      // Helper: collect owner j's slice from each contributing source s != j.
+      char* hbuff = static_cast<char*>(recvBuffs[g]);
+      for (int s = 0; s < cfg.nActiveRanks; s++) {
+        for (int j = 0; j < A; j++) {
+          if (j == s)
+            continue;
+          int t = (s < j) ? s : s - 1;
+          size_t slot = static_cast<size_t>(j) * (A - 1) + t;
+          NCCLCHECK(ncclRecv(
+              hbuff + slot * cs * elementSize,
+              cs,
+              datatype,
+              cfg.activeRanks[s],
+              comm,
+              stream));
+        }
+      }
+    }
+  }
+  NCCLCHECK(ncclGroupEnd());
+
+  bool anyOffload = false;
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] > 0 && csArr[g] > 0) {
+      anyOffload = true;
+      break;
+    }
+  }
+
+  // =========================================================================
+  // HELPER REDUCE: sum each owner's A-1 contributions in place
+  // =========================================================================
+  // No divisor here: the owner applies the AVG divisor once when it folds in
+  // its own contribution.
+  if (anyOffload) {
+    for (int g = 0; g < nGroups; g++) {
+      if (recvCounts[g] == 0 || csArr[g] == 0 || configs[g].isActiveRank)
         continue;
-      }
-
-      NCCLCHECK(ncclGroupStart());
-      for (int g = 0; g < nGroups; g++) {
-        if (recvCounts[g] == 0)
-          continue;
-        const ShardedRelayRankConfig& cfg = configs[g];
-        void* workbuff = (g == myActiveGroup) ? workScratch : recvBuffs[g];
-        size_t pRg = pRArr[g];
-
-        // ---- RELAY (cross links), R region ----
-        if (pRg > 0) {
-          size_t xg = pRg >> (k + 1);
-          size_t csz = (xg / numChunks);
-          csz = (csz / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
-          if (cfg.isActiveRank) {
-            if (csz == 0) {
-              // No helpers: the whole half is a direct partner swap. Send AND
-              // recv MUST be in the same ncclGroup (phase 0) — NCCL matches P2P
-              // within a group, so splitting send/recv across phases deadlocks.
-              if (phase == 0) {
-                NCCLCHECK(ncclSend(
-                    static_cast<const char*>(workbuff) + sendOff * elementSize,
-                    xg,
-                    datatype,
-                    partner,
-                    comm,
-                    stream));
-                NCCLCHECK(ncclRecv(
-                    static_cast<char*>(rsScratch),
-                    xg,
-                    datatype,
-                    partner,
-                    comm,
-                    stream));
-              }
-            } else {
-              size_t directSz = xg - static_cast<size_t>(numHelpers) * csz;
-              if (phase == 0) {
-                for (int h = 0; h < cfg.numHelpers; h++) {
-                  NCCLCHECK(ncclSend(
-                      static_cast<const char*>(workbuff) +
-                          (sendOff + (size_t)h * csz) * elementSize,
-                      csz,
-                      datatype,
-                      cfg.helperRanks[h],
-                      comm,
-                      stream));
-                }
-                NCCLCHECK(ncclSend(
-                    static_cast<const char*>(workbuff) +
-                        (sendOff + (size_t)numHelpers * csz) * elementSize,
-                    directSz,
-                    datatype,
-                    partner,
-                    comm,
-                    stream));
-                NCCLCHECK(ncclRecv(
-                    static_cast<char*>(rsScratch) +
-                        (size_t)numHelpers * csz * elementSize,
-                    directSz,
-                    datatype,
-                    partner,
-                    comm,
-                    stream));
-              } else {
-                for (int h = 0; h < cfg.numHelpers; h++) {
-                  NCCLCHECK(ncclRecv(
-                      static_cast<char*>(rsScratch) +
-                          (size_t)h * csz * elementSize,
-                      csz,
-                      datatype,
-                      cfg.helperRanks[h],
-                      comm,
-                      stream));
-                }
-              }
-            }
-          } else {
-            size_t cszH = (xg / numChunks);
-            cszH = (cszH / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
-            if (cszH != 0) {
-              if (phase == 0) {
-                for (int a = 0; a < cfg.nActiveRanks; a++) {
-                  NCCLCHECK(ncclRecv(
-                      static_cast<char*>(workbuff) +
-                          (size_t)a * cszH * elementSize,
-                      cszH,
-                      datatype,
-                      cfg.activeRanks[a],
-                      comm,
-                      stream));
-                }
-              } else {
-                for (int a = 0; a < cfg.nActiveRanks; a++) {
-                  int target = cfg.activeRanks[a ^ mask];
-                  NCCLCHECK(ncclSend(
-                      static_cast<const char*>(workbuff) +
-                          (size_t)a * cszH * elementSize,
-                      cszH,
-                      datatype,
-                      target,
-                      comm,
-                      stream));
-                }
-              }
-            }
-          }
-        }
-
-        // ---- DIRECT all-to-all RS (intra links), D region ----
-        if (g == myActiveGroup && myShardLen > 0 && dSliceLen > 0) {
-          int peerIdx = 0;
-          for (int j = 0; j < A; j++) {
-            if (j == myIdx) {
-              continue;
-            }
-            NCCLCHECK(ncclSend(
-                static_cast<const char*>(workbuff) +
-                    (dBase + (size_t)j * myShardLen + dSliceOff) * elementSize,
-                dSliceLen,
-                datatype,
-                cfg.activeRanks[j],
-                comm,
-                stream));
-            NCCLCHECK(ncclRecv(
-                static_cast<char*>(directScratch) +
-                    ((size_t)peerIdx * myShardLen + dSliceOff) * elementSize,
-                dSliceLen,
-                datatype,
-                cfg.activeRanks[j],
-                comm,
-                stream));
-            peerIdx++;
-          }
-        }
-      }
-      NCCLCHECK(ncclGroupEnd());
-
-      if (phase == 1 && myActiveGroup >= 0 && pRArr[myActiveGroup] > 0) {
-        void* keepDst = static_cast<char*>(workScratch) + keepOff * elementSize;
-        if (lastRsStep && reductionDivisor > 1) {
-          DISPATCH_INCREMENTAL_ADD_AND_SCALE(
-              datatype, keepDst, rsScratch, halfLen, reductionDivisor, stream);
-        } else {
-          DISPATCH_INCREMENTAL_ADD(
-              datatype, keepDst, rsScratch, halfLen, stream);
-        }
-        segOff = keepOff;
-        segLen = halfLen;
+      char* hbuff = static_cast<char*>(recvBuffs[g]);
+      size_t cs = csArr[g];
+      for (int j = 0; j < A; j++) {
+        char* dst = hbuff + static_cast<size_t>(j) * (A - 1) * cs * elementSize;
+        DISPATCH_MULTI_REDUCE(
+            datatype, dst, dst + cs * elementSize, A - 2, cs, 1, stream);
       }
     }
-    giRs += 2;
-  }
-
-  // Direct RS reduce: fold the A-1 contributions into the owned shard, scale.
-  // Fused single-pass multi-input reduce (read owned + all A-1 contribs once,
-  // write owned once) instead of A-1 separate read-modify-write adds + scale.
-  if (myShardLen > 0) {
-    void* ownedDst = static_cast<char*>(workScratch) +
-        (dBase + (size_t)myIdx * myShardLen) * elementSize;
-    DISPATCH_MULTI_REDUCE(
-        datatype,
-        ownedDst,
-        directScratch,
-        A - 1,
-        myShardLen,
-        reductionDivisor,
-        stream);
   }
 
   // =========================================================================
-  // SCATTER OUT: copy owner mi's reduced block from W into the caller's output
-  // buffer (recvCount = rPart + dPart elements). R result at logical
-  // [0, rPart); D result at [rPart, rPart+dPart).
+  // GROUP 2: direct part 2 (active<->active) || reduced offload
+  // (helper->active)
+  // =========================================================================
+  if (anyOffload) {
+    NCCLCHECK(ncclGroupStart());
+    for (int g = 0; g < nGroups; g++) {
+      if (recvCounts[g] == 0 || csArr[g] == 0)
+        continue;
+      const ShardedRelayRankConfig& cfg = configs[g];
+      size_t rc = recvCounts[g];
+      size_t cs = csArr[g];
+      size_t directSz = directArr[g];
+      size_t d1 = d1Arr[g];
+      size_t d2 = directSz - d1;
+
+      if (cfg.isActiveRank) {
+        const char* sendbuff = static_cast<const char*>(sendBuffs[g]);
+        int m = cfg.myActiveIndex;
+
+        if (d2 > 0) {
+          for (int k = 0; k < A; k++) {
+            if (k == m)
+              continue;
+            NCCLCHECK(ncclSend(
+                sendbuff + (static_cast<size_t>(k) * rc + d1) * elementSize,
+                d2,
+                datatype,
+                cfg.activeRanks[k],
+                comm,
+                stream));
+          }
+          for (int s = 0; s < A; s++) {
+            if (s == m)
+              continue;
+            int p = (s < m) ? s : s - 1;
+            NCCLCHECK(ncclRecv(
+                static_cast<char*>(dScratch) +
+                    (static_cast<size_t>(p) * directSz + d1) * elementSize,
+                d2,
+                datatype,
+                cfg.activeRanks[s],
+                comm,
+                stream));
+          }
+        }
+
+        // Reduced offload slices land contiguously, mirroring my output.
+        for (int h = 0; h < cfg.numHelpers; h++) {
+          NCCLCHECK(ncclRecv(
+              static_cast<char*>(oScratch) +
+                  static_cast<size_t>(h) * cs * elementSize,
+              cs,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      } else {
+        // Helper: hand owner j its single reduced slice.
+        const char* hbuff = static_cast<const char*>(recvBuffs[g]);
+        for (int j = 0; j < A; j++) {
+          NCCLCHECK(ncclSend(
+              hbuff + static_cast<size_t>(j) * (A - 1) * cs * elementSize,
+              cs,
+              datatype,
+              cfg.activeRanks[j],
+              comm,
+              stream));
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+  }
+
+  // =========================================================================
+  // OWNER REDUCE: fold my own contribution into the direct and offload regions
   // =========================================================================
   if (myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0) {
-    const char* W = static_cast<const char*>(workScratch);
-    char* outPtr = static_cast<char*>(recvBuffs[myActiveGroup]);
-    size_t pR = pRArr[myActiveGroup];
-    size_t rPart = pR / A;
-    size_t dPart = pDArr[myActiveGroup] / A;
-    int mi = configs[myActiveGroup].myActiveIndex;
-    if (rPart > 0) {
-      // Owner mi's R result sits at the final segOff (== bitReverse(mi)*rPart).
+    const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
+    size_t rc = recvCounts[myActiveGroup];
+    size_t cs = csArr[myActiveGroup];
+    size_t directSz = directArr[myActiveGroup];
+    char* out = static_cast<char*>(recvBuffs[myActiveGroup]);
+    const char* ownBlock = static_cast<const char*>(sendBuffs[myActiveGroup]) +
+        static_cast<size_t>(cfg.myActiveIndex) * rc * elementSize;
+
+    // Direct region: own + the A-1 peer blocks, one fused multi-input pass.
+    if (!isInPlace) {
       cudaMemcpyAsync(
-          outPtr,
-          W + segOff * elementSize,
-          rPart * elementSize,
+          out,
+          ownBlock,
+          directSz * elementSize,
           cudaMemcpyDeviceToDevice,
           stream);
     }
-    if (dPart > 0) {
-      cudaMemcpyAsync(
-          outPtr + rPart * elementSize,
-          W + (pR + static_cast<size_t>(mi) * dPart) * elementSize,
-          dPart * elementSize,
-          cudaMemcpyDeviceToDevice,
-          stream);
+    DISPATCH_MULTI_REDUCE(
+        datatype, out, dScratch, A - 1, directSz, reductionDivisor, stream);
+
+    // Offload region: own + the H helper-reduced slices (each already a sum of
+    // the A-1 other sources).
+    if (cs > 0) {
+      char* oOut = out + directSz * elementSize;
+      size_t oCount = rc - directSz;
+      if (isInPlace) {
+        if (reductionDivisor > 1) {
+          DISPATCH_INCREMENTAL_ADD_AND_SCALE(
+              datatype, oOut, oScratch, oCount, reductionDivisor, stream);
+        } else {
+          DISPATCH_INCREMENTAL_ADD(datatype, oOut, oScratch, oCount, stream);
+        }
+      } else {
+        DISPATCH_FUSED_REDUCE(
+            datatype,
+            oOut,
+            ownBlock + directSz * elementSize,
+            oScratch,
+            oCount,
+            reductionDivisor,
+            stream);
+      }
     }
   }
 
@@ -1586,8 +1368,9 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
         nGroups,
         elementSize);
   }
-  // A>2: bandwidth-optimal recursive-halving relay + woven direct all-to-all.
-  return shardedRelayReduceScatterRecursive(
+  // A>2: two-group flat relay with reduce-at-helper woven with a direct
+  // all-to-all reduce-scatter over the intra links.
+  return shardedRelayReduceScatterFlat(
       sendBuffs,
       recvBuffs,
       recvCounts,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -492,6 +492,102 @@ bool buildShardedRelayRankConfig(
     }                                                                      \
   } while (0)
 
+#define LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                          \
+    TYPE, dst, seed, contribs, numContribs, count, divisor, stream) \
+  launchSeededMultiReduceKernel<TYPE>(                              \
+      dst, seed, contribs, numContribs, count, divisor, stream)
+
+#define DISPATCH_SEEDED_MULTI_REDUCE(                                          \
+    datatype, dst, seed, contribs, numContribs, count, divisor, stream)        \
+  do {                                                                         \
+    switch (datatype) {                                                        \
+      case ncclInt8:                                                           \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            int8_t, dst, seed, contribs, numContribs, count, divisor, stream); \
+        break;                                                                 \
+      case ncclUint8:                                                          \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            uint8_t,                                                           \
+            dst,                                                               \
+            seed,                                                              \
+            contribs,                                                          \
+            numContribs,                                                       \
+            count,                                                             \
+            divisor,                                                           \
+            stream);                                                           \
+        break;                                                                 \
+      case ncclInt32:                                                          \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            int32_t,                                                           \
+            dst,                                                               \
+            seed,                                                              \
+            contribs,                                                          \
+            numContribs,                                                       \
+            count,                                                             \
+            divisor,                                                           \
+            stream);                                                           \
+        break;                                                                 \
+      case ncclUint32:                                                         \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            uint32_t,                                                          \
+            dst,                                                               \
+            seed,                                                              \
+            contribs,                                                          \
+            numContribs,                                                       \
+            count,                                                             \
+            divisor,                                                           \
+            stream);                                                           \
+        break;                                                                 \
+      case ncclInt64:                                                          \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            int64_t,                                                           \
+            dst,                                                               \
+            seed,                                                              \
+            contribs,                                                          \
+            numContribs,                                                       \
+            count,                                                             \
+            divisor,                                                           \
+            stream);                                                           \
+        break;                                                                 \
+      case ncclUint64:                                                         \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            uint64_t,                                                          \
+            dst,                                                               \
+            seed,                                                              \
+            contribs,                                                          \
+            numContribs,                                                       \
+            count,                                                             \
+            divisor,                                                           \
+            stream);                                                           \
+        break;                                                                 \
+      case ncclFloat16:                                                        \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            __half, dst, seed, contribs, numContribs, count, divisor, stream); \
+        break;                                                                 \
+      case ncclFloat:                                                          \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            float, dst, seed, contribs, numContribs, count, divisor, stream);  \
+        break;                                                                 \
+      case ncclDouble:                                                         \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            double, dst, seed, contribs, numContribs, count, divisor, stream); \
+        break;                                                                 \
+      case ncclBfloat16:                                                       \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            __nv_bfloat16,                                                     \
+            dst,                                                               \
+            seed,                                                              \
+            contribs,                                                          \
+            numContribs,                                                       \
+            count,                                                             \
+            divisor,                                                           \
+            stream);                                                           \
+        break;                                                                 \
+      default:                                                                 \
+        break;                                                                 \
+    }                                                                          \
+  } while (0)
+
 namespace {
 
 // The DISPATCH_* macros above instantiate reduce kernels for exactly these
@@ -1218,16 +1314,28 @@ static ncclResult_t shardedRelayReduceScatterFlat(
         static_cast<size_t>(cfg.myActiveIndex) * rc * elementSize;
 
     // Direct region: own + the A-1 peer blocks, one fused multi-input pass.
-    if (!isInPlace) {
-      cudaMemcpyAsync(
+    if (A == 4 && directSz > 0 && !isInPlace) {
+      DISPATCH_SEEDED_MULTI_REDUCE(
+          datatype,
           out,
           ownBlock,
-          directSz * elementSize,
-          cudaMemcpyDeviceToDevice,
+          dScratch,
+          A - 1,
+          directSz,
+          reductionDivisor,
           stream);
+    } else {
+      if (!isInPlace) {
+        cudaMemcpyAsync(
+            out,
+            ownBlock,
+            directSz * elementSize,
+            cudaMemcpyDeviceToDevice,
+            stream);
+      }
+      DISPATCH_MULTI_REDUCE(
+          datatype, out, dScratch, A - 1, directSz, reductionDivisor, stream);
     }
-    DISPATCH_MULTI_REDUCE(
-        datatype, out, dScratch, A - 1, directSz, reductionDivisor, stream);
 
     // Offload region: own + the H helper-reduced slices (each already a sum of
     // the A-1 other sources).

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -112,15 +112,38 @@ class ScratchBufferCache {
 // Maximum number of helper ranks supported per group.
 constexpr int SHARDED_RELAY_MAX_HELPERS = 8;
 
+// Maximum number of active ranks per group. The recursive-halving relay
+// schedule (round-r partner = myActiveIndex XOR round) requires nActiveRanks to
+// be a power of two; supported values are 2 and 4 (on an 8-GPU node this leaves
+// 6 or 4 helpers respectively).
+constexpr int SHARDED_RELAY_MAX_ACTIVE = 8;
+
+// Returns true if v is a power of two (v >= 1).
+inline bool isPowerOfTwo(int v) {
+  return v > 0 && (v & (v - 1)) == 0;
+}
+
+// Reverse the low `bits` bits of x. The recursive-halving reduce-scatter leaves
+// active rank mi owning the segment at bit-reversed position bitReverse(mi);
+// the reduce-scatter gather places block[j] at bit-reversed position so owner j
+// ends up holding the reduced block[j].
+inline int bitReverse(int x, int bits) {
+  int r = 0;
+  for (int b = 0; b < bits; b++) {
+    r = (r << 1) | ((x >> b) & 1);
+  }
+  return r;
+}
+
 /**
  * Rank Configuration for Sharded Relay Reduce-Scatter
  *
  * Holds parsed active and helper rank information for a single group.
- * NOTE: This implementation requires exactly 2 active ranks per group.
+ * Supports a power-of-two number of active ranks per group (2 or 4).
  */
 struct ShardedRelayRankConfig {
-  int activeRanks[2]; // Active rank IDs (exactly 2 required)
-  int nActiveRanks; // Number of active ranks (must be 2)
+  int activeRanks[SHARDED_RELAY_MAX_ACTIVE]; // Active rank IDs (power of two)
+  int nActiveRanks; // Number of active ranks (2 or 4)
   int helperRanks[SHARDED_RELAY_MAX_HELPERS]; // Helper rank IDs
   int numHelpers; // Number of helper ranks
   bool isActiveRank; // Is current rank active?
@@ -130,7 +153,9 @@ struct ShardedRelayRankConfig {
 
 /**
  * Build rank configuration from provided active ranks array.
- * NOTE: This implementation requires exactly 2 active ranks per group.
+ *
+ * Requires a power-of-two active-rank count in [2, SHARDED_RELAY_MAX_ACTIVE];
+ * the XOR round schedule of the A>2 recursive path depends on it.
  */
 bool buildShardedRelayRankConfig(
     int nRanks,
@@ -144,21 +169,24 @@ bool buildShardedRelayRankConfig(
   config.myActiveIndex = -1;
   config.myHelperIndex = -1;
 
-  // Validate input - require EXACTLY 2 active ranks
-  if (activeRanksInput == nullptr || nActiveRanksInput != 2) {
+  // Validate input - require a power-of-two active-rank count in
+  // [2, SHARDED_RELAY_MAX_ACTIVE]. The XOR round schedule depends on it.
+  if (activeRanksInput == nullptr || nActiveRanksInput < 2 ||
+      nActiveRanksInput > SHARDED_RELAY_MAX_ACTIVE ||
+      !isPowerOfTwo(nActiveRanksInput)) {
     return false;
   }
 
   // Copy active ranks and validate
-  for (int i = 0; i < 2; i++) {
+  for (int i = 0; i < nActiveRanksInput; i++) {
     int rankId = activeRanksInput[i];
     if (rankId >= 0 && rankId < nRanks) {
       config.activeRanks[config.nActiveRanks++] = rankId;
     }
   }
 
-  // Validate: need exactly 2 valid active ranks
-  if (config.nActiveRanks != 2) {
+  // Validate: need exactly nActiveRanksInput valid active ranks
+  if (config.nActiveRanks != nActiveRanksInput) {
     return false;
   }
 
@@ -401,6 +429,69 @@ bool buildShardedRelayRankConfig(
     }                                                                       \
   } while (0)
 
+#define LAUNCH_MULTI_REDUCE_KERNEL(                           \
+    TYPE, dst, contribs, numContribs, count, divisor, stream) \
+  launchMultiReduceKernel<TYPE>(                              \
+      dst, contribs, numContribs, count, divisor, stream)
+
+// Fused multi-input reduce: dst = (dst + sum of `numContribs` contiguous
+// contribution blocks) [/ divisor], in one launch. Replaces a loop of
+// per-contribution incremental adds plus a trailing scale.
+#define DISPATCH_MULTI_REDUCE(                                             \
+    datatype, dst, contribs, numContribs, count, divisor, stream)          \
+  do {                                                                     \
+    switch (datatype) {                                                    \
+      case ncclInt8:                                                       \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            int8_t, dst, contribs, numContribs, count, divisor, stream);   \
+        break;                                                             \
+      case ncclUint8:                                                      \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            uint8_t, dst, contribs, numContribs, count, divisor, stream);  \
+        break;                                                             \
+      case ncclInt32:                                                      \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            int32_t, dst, contribs, numContribs, count, divisor, stream);  \
+        break;                                                             \
+      case ncclUint32:                                                     \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            uint32_t, dst, contribs, numContribs, count, divisor, stream); \
+        break;                                                             \
+      case ncclInt64:                                                      \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            int64_t, dst, contribs, numContribs, count, divisor, stream);  \
+        break;                                                             \
+      case ncclUint64:                                                     \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            uint64_t, dst, contribs, numContribs, count, divisor, stream); \
+        break;                                                             \
+      case ncclFloat16:                                                    \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            __half, dst, contribs, numContribs, count, divisor, stream);   \
+        break;                                                             \
+      case ncclFloat:                                                      \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            float, dst, contribs, numContribs, count, divisor, stream);    \
+        break;                                                             \
+      case ncclDouble:                                                     \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            double, dst, contribs, numContribs, count, divisor, stream);   \
+        break;                                                             \
+      case ncclBfloat16:                                                   \
+        LAUNCH_MULTI_REDUCE_KERNEL(                                        \
+            __nv_bfloat16,                                                 \
+            dst,                                                           \
+            contribs,                                                      \
+            numContribs,                                                   \
+            count,                                                         \
+            divisor,                                                       \
+            stream);                                                       \
+        break;                                                             \
+      default:                                                             \
+        break;                                                             \
+    }                                                                      \
+  } while (0)
+
 namespace {
 
 // The DISPATCH_* macros above instantiate reduce kernels for exactly these
@@ -433,13 +524,13 @@ bool isSupportedRelayDataType(ncclDataType_t datatype) {
 } // namespace
 
 /**
- * Fused Multi-Group Sharded Relay Reduce-Scatter — Phase-Synchronized
- * Passthrough.
+ * Two-active sharded relay reduce-scatter (original, performant path).
  *
- * Reduce-scatter analogue of ncclShardedRelayMultiGroupAllReduceImpl. Each
- * group has exactly 2 active ranks; the logical collective is a 2-rank
+ * Each group has exactly 2 active ranks; the logical collective is a 2-rank
  * reduce-scatter between them, accelerated by passthrough helpers that relay
- * sharded chunks of a single block (recvCounts[g] elements).
+ * sharded chunks of a single block (recvCounts[g] elements). This is the
+ * production BM-FM path and is byte-for-byte unchanged from the original
+ * implementation; the A>2 path lives in shardedRelayReduceScatterRecursive.
  *
  * Per active rank (index myActiveIndex), with recvcount = recvCounts[g]:
  *   - sendBuff holds 2 × recvcount elements; block[i] = sendBuff[i*recvcount].
@@ -457,88 +548,19 @@ bool isSupportedRelayDataType(ncclDataType_t datatype) {
  * local contribution (no seeding copy) and the direct chunk is reduced via a
  * scratch buffer to avoid overwriting the local data before it is read.
  */
-HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
+static ncclResult_t shardedRelayReduceScatter2Active(
     const void* const* sendBuffs,
     void* const* recvBuffs,
     const size_t* recvCounts,
     ncclDataType_t datatype,
-    ncclRedOp_t op,
+    int reductionDivisor,
     ncclComm_t comm,
     cudaStream_t stream,
-    const int* const* allActiveRanks,
-    int nActiveRanksPerGroup,
-    int nGroups) {
-  int nRanks, rank;
-  NCCLCHECK(ncclCommCount(comm, &nRanks));
-  NCCLCHECK(ncclCommUserRank(comm, &rank));
-
-  // Validate every argument before touching recvCounts: the all-zero scan
-  // below indexes recvCounts[0..nGroups), so a null pointer or an out-of-range
-  // nGroups has to be rejected first. Bounds-checking nGroups up here also
-  // means nGroups <= 0 reports ncclInvalidArgument rather than skipping the
-  // scan entirely and returning ncclSuccess.
-  if (nGroups < 1 || nGroups > SHARDED_RELAY_MAX_GROUPS) {
-    return ncclInvalidArgument;
-  }
-
-  if (sendBuffs == nullptr || recvBuffs == nullptr ||
-      allActiveRanks == nullptr || recvCounts == nullptr) {
-    return ncclInvalidArgument;
-  }
-
-  // Require at least 2 active ranks per group
-  if (nActiveRanksPerGroup < 2) {
-    return ncclInvalidArgument;
-  }
-
-  // Validate operation - only SUM and AVG are supported
-  if (op != ncclSum && op != ncclAvg) {
-    return ncclInvalidArgument;
-  }
-
-  if (!isSupportedRelayDataType(datatype)) {
-    return ncclInvalidArgument;
-  }
-
-  // Check if all recvCounts are zero
-  bool allZero = true;
-  for (int g = 0; g < nGroups; g++) {
-    if (recvCounts[g] != 0) {
-      allZero = false;
-      break;
-    }
-  }
-  if (allZero) {
-    return ncclSuccess;
-  }
-
-  size_t elementSize = ncclTypeSize(datatype);
-
-  // Compute divisor for reduction: 1 for SUM, nActiveRanksPerGroup for AVG
-  int reductionDivisor = (op == ncclAvg) ? nActiveRanksPerGroup : 1;
-
-  // =========================================================================
-  // BUILD RANK CONFIGURATION FOR ALL GROUPS
-  // =========================================================================
-  ShardedRelayRankConfig configs[SHARDED_RELAY_MAX_GROUPS];
-  int myActiveGroup = -1; // Which group is this rank active for?
-
-  for (int g = 0; g < nGroups; g++) {
-    if (!buildShardedRelayRankConfig(
-            nRanks,
-            rank,
-            allActiveRanks[g],
-            nActiveRanksPerGroup,
-            configs[g])) {
-      return ncclInvalidArgument;
-    }
-    if (configs[g].isActiveRank) {
-      myActiveGroup = g;
-    }
-  }
-
-  // All groups should have the same number of helpers (same chunk structure)
-  int numHelpers = configs[0].numHelpers;
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nGroups,
+    size_t elementSize) {
   int numChunks = numHelpers + 1;
 
   // =========================================================================
@@ -908,4 +930,541 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
   }
 
   return ncclSuccess;
+}
+
+/**
+ * Reduce-scatter for > 2 active ranks (bandwidth-optimal recursive path).
+ *
+ * A recursive-halving relay over the cross links (active<->helper, 2-hop) woven
+ * with a direct all-to-all over the intra links (active<->active, 1-hop), split
+ * DIRECT_NUM=60% / 40% to equalize per-link load. There is NO all-gather phase
+ * (reduce-scatter keeps only the owner's reduced shard).
+ *
+ * The active rank's sendBuff holds A blocks of recvCount (block[j] is this
+ * rank's contribution to owner j). It is gathered into a working buffer W of
+ * size A*recvCount laid out as [R region (pR) | D region (pD)], where every
+ * block contributes an R part (pR/A elements, its first elements) and a D part
+ * (pD/A elements, the rest):
+ *   - block[j]_R is placed at R-part bitReverse(j): the recursive-halving
+ *     reduce-scatter leaves owner mi holding R-part bitReverse(mi), so owner j
+ *     ends up with the reduced block[j]_R.
+ *   - block[j]_D is placed at D-part j: the direct all-to-all reduce-scatter
+ *     keeps index j with owner j.
+ * After the halving relay + direct all-to-all reduce, owner mi holds the
+ * reduced block[mi] in two pieces in W (R at the final segOff, D at
+ * pR + mi*(pD/A)); both are copied into recvBuff (recvCount = pR/A + pD/A).
+ *
+ * In-place (recvBuff == sendBuff + myActiveIndex*recvCount) and out-of-place
+ * are both supported transparently: W is a separate scratch, so sendBuff is
+ * fully read into W before recvBuff is written, and the only difference is the
+ * (identical) final copy destination.
+ *
+ * Requires a power-of-two active count (count = A*recvCount is divisible by A
+ * by construction, so the R/D split and per-block parts are exact).
+ */
+static ncclResult_t shardedRelayReduceScatterRecursive(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* recvCounts,
+    ncclDataType_t datatype,
+    int reductionDivisor,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nActiveRanksPerGroup,
+    int nGroups,
+    size_t elementSize) {
+  const int A = nActiveRanksPerGroup;
+  const int numChunks = numHelpers + 1;
+  int logA = 0;
+  while ((1 << logA) < A) {
+    logA++;
+  }
+  const int nRsGroups = 2 * logA;
+
+  // Direct (intra) fraction = 60%. Balances per-link load: each intra link
+  // carries 0.5*D (1-hop), each cross link 0.75*R (2-hop); equal at
+  // D:R=0.6:0.4.
+  const size_t DIRECT_NUM = 60, DIRECT_DEN = 100;
+
+  // Per-group working-buffer total count = A * recvCount (the full input), and
+  // its R/D split. count is divisible by A by construction.
+  size_t countArr[SHARDED_RELAY_MAX_GROUPS];
+  size_t pRArr[SHARDED_RELAY_MAX_GROUPS];
+  size_t pDArr[SHARDED_RELAY_MAX_GROUPS];
+  for (int g = 0; g < nGroups; g++) {
+    size_t recvcount = recvCounts[g];
+    if (recvcount == 0) {
+      countArr[g] = 0;
+      pRArr[g] = 0;
+      pDArr[g] = 0;
+      continue;
+    }
+    size_t count = static_cast<size_t>(A) * recvcount;
+    countArr[g] = count;
+    size_t alignA = static_cast<size_t>(A) * CHUNK_ALIGN_ELEMENTS;
+    size_t pD = (count * DIRECT_NUM) / DIRECT_DEN;
+    pD = (pD / alignA) * alignA;
+    if (pD > count) {
+      pD = (count / alignA) * alignA;
+    }
+    pDArr[g] = pD;
+    pRArr[g] = count - pD;
+  }
+
+  // =========================================================================
+  // SCRATCH BUFFER ALLOCATION
+  // =========================================================================
+  // workScratch (W): A*recvCount working buffer (active rank only).
+  // rsScratch: relay reduce-scatter receive buffer (max half pR/2).
+  // directScratch: direct all-to-all reduce-scatter buffer ((A-1) shards).
+  void* workScratch = nullptr;
+  void* rsScratch = nullptr;
+  void* directScratch = nullptr;
+  if (myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0) {
+    size_t count = countArr[myActiveGroup];
+    size_t pR = pRArr[myActiveGroup];
+    size_t pD = pDArr[myActiveGroup];
+
+    size_t workBytes = count * elementSize;
+    workScratch = ScratchBufferCache::getInstance().get(
+        SHARDED_RELAY_MAX_GROUPS, workBytes, stream);
+    if (workScratch == nullptr) {
+      return ncclInternalError;
+    }
+    if (pR > 0) {
+      size_t maxHalfBytes = (pR / 2 + CHUNK_ALIGN_ELEMENTS) * elementSize;
+      rsScratch = ScratchBufferCache::getInstance().get(
+          SHARDED_RELAY_MAX_GROUPS + 1, maxHalfBytes, stream);
+      if (rsScratch == nullptr) {
+        return ncclInternalError;
+      }
+    }
+    if (pD > 0) {
+      size_t directBytes = static_cast<size_t>(A - 1) * (pD / A) * elementSize;
+      directScratch = ScratchBufferCache::getInstance().get(
+          SHARDED_RELAY_MAX_GROUPS + 2, directBytes, stream);
+      if (directScratch == nullptr) {
+        return ncclInternalError;
+      }
+    }
+  }
+
+  // =========================================================================
+  // GATHER: scatter the A input blocks into W with the R/D split + bit-reversed
+  // R placement (active rank only). Reads directly from the caller's contiguous
+  // input buffer (block j spans logical [j*recvcount, (j+1)*recvcount)).
+  // =========================================================================
+  if (myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0) {
+    char* W = static_cast<char*>(workScratch);
+    const char* inPtr = static_cast<const char*>(sendBuffs[myActiveGroup]);
+    size_t recvcount = recvCounts[myActiveGroup];
+    size_t pR = pRArr[myActiveGroup];
+    size_t rPart = pR / A; // per-block R part
+    size_t dPart = pDArr[myActiveGroup] / A; // per-block D part
+    for (int j = 0; j < A; j++) {
+      size_t blkOff = static_cast<size_t>(j) * recvcount;
+      if (rPart > 0) {
+        int p = bitReverse(j, logA);
+        cudaMemcpyAsync(
+            W + static_cast<size_t>(p) * rPart * elementSize,
+            inPtr + blkOff * elementSize,
+            rPart * elementSize,
+            cudaMemcpyDeviceToDevice,
+            stream);
+      }
+      if (dPart > 0) {
+        cudaMemcpyAsync(
+            W + (pR + static_cast<size_t>(j) * dPart) * elementSize,
+            inPtr + (blkOff + rPart) * elementSize,
+            dPart * elementSize,
+            cudaMemcpyDeviceToDevice,
+            stream);
+      }
+    }
+  }
+
+  // Direct shard geometry for this rank's active group.
+  size_t myShardLen = 0, dBase = 0;
+  int myIdx = -1;
+  if (myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0 &&
+      pDArr[myActiveGroup] > 0) {
+    myShardLen = pDArr[myActiveGroup] / A;
+    dBase = pRArr[myActiveGroup];
+    myIdx = configs[myActiveGroup].myActiveIndex;
+  }
+
+  // Relay segment within the R region [0, pR).
+  size_t segOff = 0;
+  size_t segLen = (myActiveGroup >= 0) ? pRArr[myActiveGroup] : 0;
+
+  // ===== Reduce-scatter: relay halving (R) + direct all-to-all (D) =====
+  int giRs = 0;
+  for (int k = 0; k < logA; k++) {
+    int mask = 1 << k;
+    bool lastRsStep = (k == logA - 1);
+
+    size_t halfLen = 0, sendOff = 0, keepOff = 0;
+    int partner = -1;
+    if (myActiveGroup >= 0 && pRArr[myActiveGroup] > 0) {
+      const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
+      halfLen = segLen / 2;
+      int mi = cfg.myActiveIndex;
+      if (mi & mask) {
+        keepOff = segOff + halfLen;
+        sendOff = segOff;
+      } else {
+        keepOff = segOff;
+        sendOff = segOff + halfLen;
+      }
+      partner = cfg.activeRanks[mi ^ mask];
+    }
+
+    for (int phase = 0; phase < 2; phase++) { // 0 = scatter, 1 = forward
+      int gi = giRs + phase;
+      size_t dSliceLen = 0, dSliceOff = 0;
+      if (myShardLen > 0) {
+        size_t base = myShardLen / nRsGroups;
+        dSliceOff = static_cast<size_t>(gi) * base;
+        dSliceLen = (gi == nRsGroups - 1) ? (myShardLen - dSliceOff) : base;
+      }
+
+      NCCLCHECK(ncclGroupStart());
+      for (int g = 0; g < nGroups; g++) {
+        if (recvCounts[g] == 0)
+          continue;
+        const ShardedRelayRankConfig& cfg = configs[g];
+        void* workbuff = (g == myActiveGroup) ? workScratch : recvBuffs[g];
+        size_t pRg = pRArr[g];
+
+        // ---- RELAY (cross links), R region ----
+        if (pRg > 0) {
+          size_t xg = pRg >> (k + 1);
+          size_t csz = (xg / numChunks);
+          csz = (csz / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
+          if (cfg.isActiveRank) {
+            if (csz == 0) {
+              // No helpers: the whole half is a direct partner swap. Send AND
+              // recv MUST be in the same ncclGroup (phase 0) — NCCL matches P2P
+              // within a group, so splitting send/recv across phases deadlocks.
+              if (phase == 0) {
+                NCCLCHECK(ncclSend(
+                    static_cast<const char*>(workbuff) + sendOff * elementSize,
+                    xg,
+                    datatype,
+                    partner,
+                    comm,
+                    stream));
+                NCCLCHECK(ncclRecv(
+                    static_cast<char*>(rsScratch),
+                    xg,
+                    datatype,
+                    partner,
+                    comm,
+                    stream));
+              }
+            } else {
+              size_t directSz = xg - static_cast<size_t>(numHelpers) * csz;
+              if (phase == 0) {
+                for (int h = 0; h < cfg.numHelpers; h++) {
+                  NCCLCHECK(ncclSend(
+                      static_cast<const char*>(workbuff) +
+                          (sendOff + (size_t)h * csz) * elementSize,
+                      csz,
+                      datatype,
+                      cfg.helperRanks[h],
+                      comm,
+                      stream));
+                }
+                NCCLCHECK(ncclSend(
+                    static_cast<const char*>(workbuff) +
+                        (sendOff + (size_t)numHelpers * csz) * elementSize,
+                    directSz,
+                    datatype,
+                    partner,
+                    comm,
+                    stream));
+                NCCLCHECK(ncclRecv(
+                    static_cast<char*>(rsScratch) +
+                        (size_t)numHelpers * csz * elementSize,
+                    directSz,
+                    datatype,
+                    partner,
+                    comm,
+                    stream));
+              } else {
+                for (int h = 0; h < cfg.numHelpers; h++) {
+                  NCCLCHECK(ncclRecv(
+                      static_cast<char*>(rsScratch) +
+                          (size_t)h * csz * elementSize,
+                      csz,
+                      datatype,
+                      cfg.helperRanks[h],
+                      comm,
+                      stream));
+                }
+              }
+            }
+          } else {
+            size_t cszH = (xg / numChunks);
+            cszH = (cszH / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
+            if (cszH != 0) {
+              if (phase == 0) {
+                for (int a = 0; a < cfg.nActiveRanks; a++) {
+                  NCCLCHECK(ncclRecv(
+                      static_cast<char*>(workbuff) +
+                          (size_t)a * cszH * elementSize,
+                      cszH,
+                      datatype,
+                      cfg.activeRanks[a],
+                      comm,
+                      stream));
+                }
+              } else {
+                for (int a = 0; a < cfg.nActiveRanks; a++) {
+                  int target = cfg.activeRanks[a ^ mask];
+                  NCCLCHECK(ncclSend(
+                      static_cast<const char*>(workbuff) +
+                          (size_t)a * cszH * elementSize,
+                      cszH,
+                      datatype,
+                      target,
+                      comm,
+                      stream));
+                }
+              }
+            }
+          }
+        }
+
+        // ---- DIRECT all-to-all RS (intra links), D region ----
+        if (g == myActiveGroup && myShardLen > 0 && dSliceLen > 0) {
+          int peerIdx = 0;
+          for (int j = 0; j < A; j++) {
+            if (j == myIdx) {
+              continue;
+            }
+            NCCLCHECK(ncclSend(
+                static_cast<const char*>(workbuff) +
+                    (dBase + (size_t)j * myShardLen + dSliceOff) * elementSize,
+                dSliceLen,
+                datatype,
+                cfg.activeRanks[j],
+                comm,
+                stream));
+            NCCLCHECK(ncclRecv(
+                static_cast<char*>(directScratch) +
+                    ((size_t)peerIdx * myShardLen + dSliceOff) * elementSize,
+                dSliceLen,
+                datatype,
+                cfg.activeRanks[j],
+                comm,
+                stream));
+            peerIdx++;
+          }
+        }
+      }
+      NCCLCHECK(ncclGroupEnd());
+
+      if (phase == 1 && myActiveGroup >= 0 && pRArr[myActiveGroup] > 0) {
+        void* keepDst = static_cast<char*>(workScratch) + keepOff * elementSize;
+        if (lastRsStep && reductionDivisor > 1) {
+          DISPATCH_INCREMENTAL_ADD_AND_SCALE(
+              datatype, keepDst, rsScratch, halfLen, reductionDivisor, stream);
+        } else {
+          DISPATCH_INCREMENTAL_ADD(
+              datatype, keepDst, rsScratch, halfLen, stream);
+        }
+        segOff = keepOff;
+        segLen = halfLen;
+      }
+    }
+    giRs += 2;
+  }
+
+  // Direct RS reduce: fold the A-1 contributions into the owned shard, scale.
+  // Fused single-pass multi-input reduce (read owned + all A-1 contribs once,
+  // write owned once) instead of A-1 separate read-modify-write adds + scale.
+  if (myShardLen > 0) {
+    void* ownedDst = static_cast<char*>(workScratch) +
+        (dBase + (size_t)myIdx * myShardLen) * elementSize;
+    DISPATCH_MULTI_REDUCE(
+        datatype,
+        ownedDst,
+        directScratch,
+        A - 1,
+        myShardLen,
+        reductionDivisor,
+        stream);
+  }
+
+  // =========================================================================
+  // SCATTER OUT: copy owner mi's reduced block from W into the caller's output
+  // buffer (recvCount = rPart + dPart elements). R result at logical
+  // [0, rPart); D result at [rPart, rPart+dPart).
+  // =========================================================================
+  if (myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0) {
+    const char* W = static_cast<const char*>(workScratch);
+    char* outPtr = static_cast<char*>(recvBuffs[myActiveGroup]);
+    size_t pR = pRArr[myActiveGroup];
+    size_t rPart = pR / A;
+    size_t dPart = pDArr[myActiveGroup] / A;
+    int mi = configs[myActiveGroup].myActiveIndex;
+    if (rPart > 0) {
+      // Owner mi's R result sits at the final segOff (== bitReverse(mi)*rPart).
+      cudaMemcpyAsync(
+          outPtr,
+          W + segOff * elementSize,
+          rPart * elementSize,
+          cudaMemcpyDeviceToDevice,
+          stream);
+    }
+    if (dPart > 0) {
+      cudaMemcpyAsync(
+          outPtr + rPart * elementSize,
+          W + (pR + static_cast<size_t>(mi) * dPart) * elementSize,
+          dPart * elementSize,
+          cudaMemcpyDeviceToDevice,
+          stream);
+    }
+  }
+
+  return ncclSuccess;
+}
+
+/**
+ * Fused Multi-Group Sharded Relay Reduce-Scatter.
+ *
+ * Executes multiple sharded relay reduce-scatters in one fused call,
+ * phase-synced across all groups so XGMI links carry unidirectional traffic.
+ * Helpers are pure passthrough; reductions happen on the active ranks. Each
+ * rank is ACTIVE for exactly one group and a HELPER for the others.
+ *
+ * nActiveRanksPerGroup must be a power of two (2 or 4): A==2 uses the original
+ * 2-active path; A>2 uses the bandwidth-optimal recursive path.
+ */
+HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* recvCounts,
+    ncclDataType_t datatype,
+    ncclRedOp_t op,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const int* const* allActiveRanks,
+    int nActiveRanksPerGroup,
+    int nGroups) {
+  int nRanks, rank;
+  NCCLCHECK(ncclCommCount(comm, &nRanks));
+  NCCLCHECK(ncclCommUserRank(comm, &rank));
+
+  // Validate every argument before touching recvCounts: the all-zero scan
+  // below indexes recvCounts[0..nGroups), so a null pointer or an out-of-range
+  // nGroups has to be rejected first. Bounds-checking nGroups up here also
+  // means nGroups <= 0 reports ncclInvalidArgument rather than skipping the
+  // scan entirely and returning ncclSuccess.
+  if (nGroups < 1 || nGroups > SHARDED_RELAY_MAX_GROUPS) {
+    return ncclInvalidArgument;
+  }
+
+  if (recvBuffs == nullptr || allActiveRanks == nullptr ||
+      recvCounts == nullptr || sendBuffs == nullptr) {
+    return ncclInvalidArgument;
+  }
+
+  // Require a power-of-two active-rank count (>= 2) for the XOR schedule.
+  if (nActiveRanksPerGroup < 2 || !isPowerOfTwo(nActiveRanksPerGroup)) {
+    return ncclInvalidArgument;
+  }
+
+  // Validate operation - only SUM and AVG are supported
+  if (op != ncclSum && op != ncclAvg) {
+    return ncclInvalidArgument;
+  }
+
+  if (!isSupportedRelayDataType(datatype)) {
+    return ncclInvalidArgument;
+  }
+
+  // Check if all recvCounts are zero
+  bool allZero = true;
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] != 0) {
+      allZero = false;
+      break;
+    }
+  }
+  if (allZero) {
+    return ncclSuccess;
+  }
+
+  size_t elementSize = ncclTypeSize(datatype);
+
+  // Compute divisor for reduction: 1 for SUM, nActiveRanksPerGroup for AVG
+  int reductionDivisor = (op == ncclAvg) ? nActiveRanksPerGroup : 1;
+
+  // =========================================================================
+  // BUILD RANK CONFIGURATION FOR ALL GROUPS
+  // =========================================================================
+  ShardedRelayRankConfig configs[SHARDED_RELAY_MAX_GROUPS];
+  int myActiveGroup = -1; // Which group is this rank active for?
+
+  for (int g = 0; g < nGroups; g++) {
+    if (!buildShardedRelayRankConfig(
+            nRanks,
+            rank,
+            allActiveRanks[g],
+            nActiveRanksPerGroup,
+            configs[g])) {
+      return ncclInvalidArgument;
+    }
+    if (configs[g].isActiveRank) {
+      myActiveGroup = g;
+    }
+  }
+
+  // All groups should have the same number of helpers (same chunk structure)
+  int numHelpers = configs[0].numHelpers;
+
+  if (nActiveRanksPerGroup == 2) {
+    // 2-active path is unchanged internally; feed it per-group contiguous
+    // buffers. Helper groups use their scratch (recvBuffs[g]); the active
+    // group uses its caller input/output buffers directly.
+    const void* sendBuffs2[SHARDED_RELAY_MAX_GROUPS];
+    void* recvBuffs2[SHARDED_RELAY_MAX_GROUPS];
+    for (int g = 0; g < nGroups; g++) {
+      sendBuffs2[g] = sendBuffs[g];
+      recvBuffs2[g] = recvBuffs[g];
+    }
+    return shardedRelayReduceScatter2Active(
+        sendBuffs2,
+        recvBuffs2,
+        recvCounts,
+        datatype,
+        reductionDivisor,
+        comm,
+        stream,
+        configs,
+        myActiveGroup,
+        numHelpers,
+        nGroups,
+        elementSize);
+  }
+  // A>2: bandwidth-optimal recursive-halving relay + woven direct all-to-all.
+  return shardedRelayReduceScatterRecursive(
+      sendBuffs,
+      recvBuffs,
+      recvCounts,
+      datatype,
+      reductionDivisor,
+      comm,
+      stream,
+      configs,
+      myActiveGroup,
+      numHelpers,
+      nActiveRanksPerGroup,
+      nGroups,
+      elementSize);
 }

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -1,0 +1,911 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "sharded_relay_reduce_scatter.h"
+#include "comm.h"
+#include "sharded_relay_allreduce_kernels.h"
+
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_fp16.h>
+#include <mutex>
+#include <unordered_map>
+
+// GPU memory access alignment in elements for chunk size rounding.
+// Distinct from the CPU CACHE_LINE_SIZE (64 bytes) defined in comm.h
+// which is used for struct padding.
+static constexpr size_t CHUNK_ALIGN_ELEMENTS = 128;
+
+// Infra below (ScratchBufferCache, rank-config builder, DISPATCH macros) is a
+// deliberate copy of the file-local helpers in sharded_relay_allreduce.cc.
+// They are file-local (static / anonymous namespace) there, so they cannot be
+// linked across translation units; the reduce-scatter TU re-declares its own
+// copies in an anonymous namespace to keep them internal and ODR-safe. The
+// GPU kernels themselves are NOT duplicated — they are reused via
+// sharded_relay_allreduce_kernels.h (dtype-generic, collective-agnostic).
+namespace {
+
+/**
+ * Scratch Buffer Cache Singleton
+ *
+ * Amortizes cudaMalloc/cudaFree costs by caching and reusing scratch buffers.
+ * Thread-safe with per-device buffer management. See the allreduce copy for a
+ * full description; this is an independent cache scoped to reduce-scatter.
+ */
+class ScratchBufferCache {
+ public:
+  static ScratchBufferCache& getInstance() {
+    static ScratchBufferCache instance;
+    return instance;
+  }
+
+  void* get(int key, size_t requiredBytes, cudaStream_t stream) {
+    if (requiredBytes == 0) {
+      return nullptr;
+    }
+
+    int device;
+    cudaGetDevice(&device);
+
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // Create composite key from device and user key.
+    int64_t compositeKey = static_cast<int64_t>(device) * 4096 + key;
+    auto& entry = buffers_[compositeKey];
+
+    if (entry.buffer == nullptr || entry.size < requiredBytes) {
+      if (entry.buffer != nullptr) {
+        cudaFreeAsync(entry.buffer, stream);
+      }
+
+      size_t allocSize = requiredBytes;
+      if (allocSize >= 1024 * 1024) {
+        allocSize =
+            ((requiredBytes + 64 * 1024 * 1024 - 1) / (64 * 1024 * 1024)) *
+            (64 * 1024 * 1024);
+      }
+
+      cudaError_t err = cudaMallocAsync(&entry.buffer, allocSize, stream);
+      if (err != cudaSuccess) {
+        entry.buffer = nullptr;
+        entry.size = 0;
+        return nullptr;
+      }
+      entry.size = allocSize;
+    }
+
+    return entry.buffer;
+  }
+
+  void clear(cudaStream_t stream = nullptr) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto& pair : buffers_) {
+      if (pair.second.buffer != nullptr) {
+        cudaFreeAsync(pair.second.buffer, stream);
+        pair.second.buffer = nullptr;
+        pair.second.size = 0;
+      }
+    }
+    buffers_.clear();
+  }
+
+  ScratchBufferCache(const ScratchBufferCache&) = delete;
+  ScratchBufferCache& operator=(const ScratchBufferCache&) = delete;
+
+ private:
+  ScratchBufferCache() = default;
+  ~ScratchBufferCache() = default;
+
+  struct BufferEntry {
+    void* buffer = nullptr;
+    size_t size = 0;
+  };
+
+  std::mutex mutex_;
+  std::unordered_map<int64_t, BufferEntry> buffers_; // compositeKey -> buffer
+};
+
+// Maximum number of helper ranks supported per group.
+constexpr int SHARDED_RELAY_MAX_HELPERS = 8;
+
+/**
+ * Rank Configuration for Sharded Relay Reduce-Scatter
+ *
+ * Holds parsed active and helper rank information for a single group.
+ * NOTE: This implementation requires exactly 2 active ranks per group.
+ */
+struct ShardedRelayRankConfig {
+  int activeRanks[2]; // Active rank IDs (exactly 2 required)
+  int nActiveRanks; // Number of active ranks (must be 2)
+  int helperRanks[SHARDED_RELAY_MAX_HELPERS]; // Helper rank IDs
+  int numHelpers; // Number of helper ranks
+  bool isActiveRank; // Is current rank active?
+  int myActiveIndex; // Index in activeRanks array (-1 if helper)
+  int myHelperIndex; // Index in helperRanks array (-1 if active)
+};
+
+/**
+ * Build rank configuration from provided active ranks array.
+ * NOTE: This implementation requires exactly 2 active ranks per group.
+ */
+bool buildShardedRelayRankConfig(
+    int nRanks,
+    int rank,
+    const int* activeRanksInput,
+    int nActiveRanksInput,
+    ShardedRelayRankConfig& config) {
+  config.nActiveRanks = 0;
+  config.numHelpers = 0;
+  config.isActiveRank = false;
+  config.myActiveIndex = -1;
+  config.myHelperIndex = -1;
+
+  // Validate input - require EXACTLY 2 active ranks
+  if (activeRanksInput == nullptr || nActiveRanksInput != 2) {
+    return false;
+  }
+
+  // Copy active ranks and validate
+  for (int i = 0; i < 2; i++) {
+    int rankId = activeRanksInput[i];
+    if (rankId >= 0 && rankId < nRanks) {
+      config.activeRanks[config.nActiveRanks++] = rankId;
+    }
+  }
+
+  // Validate: need exactly 2 valid active ranks
+  if (config.nActiveRanks != 2) {
+    return false;
+  }
+
+  // Build list of helper ranks (all ranks NOT in activeRanks).
+  for (int r = 0; r < nRanks; r++) {
+    bool isActive = false;
+    for (int a = 0; a < config.nActiveRanks; a++) {
+      if (r == config.activeRanks[a]) {
+        isActive = true;
+        break;
+      }
+    }
+    if (!isActive) {
+      if (config.numHelpers >= SHARDED_RELAY_MAX_HELPERS) {
+        return false;
+      }
+      config.helperRanks[config.numHelpers++] = r;
+    }
+  }
+
+  // Validate: need at least 1 helper
+  if (config.numHelpers < 1) {
+    return false;
+  }
+
+  // Determine if this rank is active
+  for (int a = 0; a < config.nActiveRanks; a++) {
+    if (rank == config.activeRanks[a]) {
+      config.isActiveRank = true;
+      config.myActiveIndex = a;
+      break;
+    }
+  }
+
+  // For helpers, determine which chunk index this rank handles
+  if (!config.isActiveRank) {
+    for (int i = 0; i < config.numHelpers; i++) {
+      if (config.helperRanks[i] == rank) {
+        config.myHelperIndex = i;
+        break;
+      }
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+// Host-side dispatch macros for the reused generic kernels. These mirror the
+// file-local DISPATCH_* macros in sharded_relay_allreduce.cc (the kernels they
+// launch are declared in sharded_relay_allreduce_kernels.h).
+
+#define LAUNCH_INCREMENTAL_ADD_KERNEL(TYPE, output, input, count, stream) \
+  launchIncrementalAddKernel<TYPE>(output, input, count, stream)
+
+#define DISPATCH_INCREMENTAL_ADD(datatype, output, input, count, stream)       \
+  do {                                                                         \
+    switch (datatype) {                                                        \
+      case ncclInt8:                                                           \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(int8_t, output, input, count, stream);   \
+        break;                                                                 \
+      case ncclUint8:                                                          \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(uint8_t, output, input, count, stream);  \
+        break;                                                                 \
+      case ncclInt32:                                                          \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(int32_t, output, input, count, stream);  \
+        break;                                                                 \
+      case ncclUint32:                                                         \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(uint32_t, output, input, count, stream); \
+        break;                                                                 \
+      case ncclInt64:                                                          \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(int64_t, output, input, count, stream);  \
+        break;                                                                 \
+      case ncclUint64:                                                         \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(uint64_t, output, input, count, stream); \
+        break;                                                                 \
+      case ncclFloat16:                                                        \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(__half, output, input, count, stream);   \
+        break;                                                                 \
+      case ncclFloat:                                                          \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(float, output, input, count, stream);    \
+        break;                                                                 \
+      case ncclDouble:                                                         \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(double, output, input, count, stream);   \
+        break;                                                                 \
+      case ncclBfloat16:                                                       \
+        LAUNCH_INCREMENTAL_ADD_KERNEL(                                         \
+            __nv_bfloat16, output, input, count, stream);                      \
+        break;                                                                 \
+      default:                                                                 \
+        break;                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define LAUNCH_SCALE_KERNEL(TYPE, data, count, divisor, stream) \
+  launchScaleKernel<TYPE>(data, count, divisor, stream)
+
+#define DISPATCH_SCALE(datatype, data, count, divisor, stream)            \
+  do {                                                                    \
+    switch (datatype) {                                                   \
+      case ncclInt8:                                                      \
+        LAUNCH_SCALE_KERNEL(int8_t, data, count, divisor, stream);        \
+        break;                                                            \
+      case ncclUint8:                                                     \
+        LAUNCH_SCALE_KERNEL(uint8_t, data, count, divisor, stream);       \
+        break;                                                            \
+      case ncclInt32:                                                     \
+        LAUNCH_SCALE_KERNEL(int32_t, data, count, divisor, stream);       \
+        break;                                                            \
+      case ncclUint32:                                                    \
+        LAUNCH_SCALE_KERNEL(uint32_t, data, count, divisor, stream);      \
+        break;                                                            \
+      case ncclInt64:                                                     \
+        LAUNCH_SCALE_KERNEL(int64_t, data, count, divisor, stream);       \
+        break;                                                            \
+      case ncclUint64:                                                    \
+        LAUNCH_SCALE_KERNEL(uint64_t, data, count, divisor, stream);      \
+        break;                                                            \
+      case ncclFloat16:                                                   \
+        LAUNCH_SCALE_KERNEL(__half, data, count, divisor, stream);        \
+        break;                                                            \
+      case ncclFloat:                                                     \
+        LAUNCH_SCALE_KERNEL(float, data, count, divisor, stream);         \
+        break;                                                            \
+      case ncclDouble:                                                    \
+        LAUNCH_SCALE_KERNEL(double, data, count, divisor, stream);        \
+        break;                                                            \
+      case ncclBfloat16:                                                  \
+        LAUNCH_SCALE_KERNEL(__nv_bfloat16, data, count, divisor, stream); \
+        break;                                                            \
+      default:                                                            \
+        break;                                                            \
+    }                                                                     \
+  } while (0)
+
+#define LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL( \
+    TYPE, output, input, count, divisor, stream) \
+  launchIncrementalAddAndScaleKernel<TYPE>(      \
+      output, input, count, divisor, stream)
+
+#define DISPATCH_INCREMENTAL_ADD_AND_SCALE(                        \
+    datatype, output, input, count, divisor, stream)               \
+  do {                                                             \
+    switch (datatype) {                                            \
+      case ncclInt8:                                               \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            int8_t, output, input, count, divisor, stream);        \
+        break;                                                     \
+      case ncclUint8:                                              \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            uint8_t, output, input, count, divisor, stream);       \
+        break;                                                     \
+      case ncclInt32:                                              \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            int32_t, output, input, count, divisor, stream);       \
+        break;                                                     \
+      case ncclUint32:                                             \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            uint32_t, output, input, count, divisor, stream);      \
+        break;                                                     \
+      case ncclInt64:                                              \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            int64_t, output, input, count, divisor, stream);       \
+        break;                                                     \
+      case ncclUint64:                                             \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            uint64_t, output, input, count, divisor, stream);      \
+        break;                                                     \
+      case ncclFloat16:                                            \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            __half, output, input, count, divisor, stream);        \
+        break;                                                     \
+      case ncclFloat:                                              \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            float, output, input, count, divisor, stream);         \
+        break;                                                     \
+      case ncclDouble:                                             \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            double, output, input, count, divisor, stream);        \
+        break;                                                     \
+      case ncclBfloat16:                                           \
+        LAUNCH_INCREMENTAL_ADD_AND_SCALE_KERNEL(                   \
+            __nv_bfloat16, output, input, count, divisor, stream); \
+        break;                                                     \
+      default:                                                     \
+        break;                                                     \
+    }                                                              \
+  } while (0)
+
+#define LAUNCH_FUSED_REDUCE_KERNEL(                       \
+    TYPE, output, inputA, inputB, count, divisor, stream) \
+  launchFusedReduceKernel<TYPE>(output, inputA, inputB, count, divisor, stream)
+
+#define DISPATCH_FUSED_REDUCE(                                              \
+    datatype, output, inputA, inputB, count, divisor, stream)               \
+  do {                                                                      \
+    switch (datatype) {                                                     \
+      case ncclInt8:                                                        \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            int8_t, output, inputA, inputB, count, divisor, stream);        \
+        break;                                                              \
+      case ncclUint8:                                                       \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            uint8_t, output, inputA, inputB, count, divisor, stream);       \
+        break;                                                              \
+      case ncclInt32:                                                       \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            int32_t, output, inputA, inputB, count, divisor, stream);       \
+        break;                                                              \
+      case ncclUint32:                                                      \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            uint32_t, output, inputA, inputB, count, divisor, stream);      \
+        break;                                                              \
+      case ncclInt64:                                                       \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            int64_t, output, inputA, inputB, count, divisor, stream);       \
+        break;                                                              \
+      case ncclUint64:                                                      \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            uint64_t, output, inputA, inputB, count, divisor, stream);      \
+        break;                                                              \
+      case ncclFloat16:                                                     \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            __half, output, inputA, inputB, count, divisor, stream);        \
+        break;                                                              \
+      case ncclFloat:                                                       \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            float, output, inputA, inputB, count, divisor, stream);         \
+        break;                                                              \
+      case ncclDouble:                                                      \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            double, output, inputA, inputB, count, divisor, stream);        \
+        break;                                                              \
+      case ncclBfloat16:                                                    \
+        LAUNCH_FUSED_REDUCE_KERNEL(                                         \
+            __nv_bfloat16, output, inputA, inputB, count, divisor, stream); \
+        break;                                                              \
+      default:                                                              \
+        break;                                                              \
+    }                                                                       \
+  } while (0)
+
+namespace {
+
+// The DISPATCH_* macros above instantiate reduce kernels for exactly these
+// types and fall through silently (default: break) for anything else, so an
+// unsupported datatype would return ncclSuccess having never reduced anything.
+//
+// This is deliberately a supported-set test rather than the
+// `datatype < 0 || datatype >= ncclNumTypes` range test used by upstream
+// ArgsCheck: ncclFloat8e4m3 and ncclFloat8e5m2 are valid NCCL types that
+// ncclTypeSize() sizes at 1 byte, so they pass a range test but have no reduce
+// kernel here. Keep this list in sync with the DISPATCH_* macros above.
+bool isSupportedRelayDataType(ncclDataType_t datatype) {
+  switch (datatype) {
+    case ncclInt8:
+    case ncclUint8:
+    case ncclInt32:
+    case ncclUint32:
+    case ncclInt64:
+    case ncclUint64:
+    case ncclFloat16:
+    case ncclFloat:
+    case ncclDouble:
+    case ncclBfloat16:
+      return true;
+    default:
+      return false;
+  }
+}
+
+} // namespace
+
+/**
+ * Fused Multi-Group Sharded Relay Reduce-Scatter — Phase-Synchronized
+ * Passthrough.
+ *
+ * Reduce-scatter analogue of ncclShardedRelayMultiGroupAllReduceImpl. Each
+ * group has exactly 2 active ranks; the logical collective is a 2-rank
+ * reduce-scatter between them, accelerated by passthrough helpers that relay
+ * sharded chunks of a single block (recvCounts[g] elements).
+ *
+ * Per active rank (index myActiveIndex), with recvcount = recvCounts[g]:
+ *   - sendBuff holds 2 × recvcount elements; block[i] = sendBuff[i*recvcount].
+ *   - ownBlockOffset  = myActiveIndex    × recvcount (local contribution)
+ *   - sendBlockOffset = otherActiveIndex × recvcount (shipped to other rank)
+ *   - recvBuff[0..recvcount) = block[myActiveIndex](self) +
+ *                              block[myActiveIndex](other).
+ *
+ * The relay relays the sendBlockOffset block chunk-by-chunk; the output block
+ * (recvBuff) is seeded with the ownBlockOffset contribution then accumulates
+ * the relayed/direct-exchanged chunks from the other active rank.
+ *
+ * In-place is detected when recvBuff == sendBuff + ownBlockOffset (the NCCL
+ * reduce-scatter in-place convention). In that case recvBuff already holds the
+ * local contribution (no seeding copy) and the direct chunk is reduced via a
+ * scratch buffer to avoid overwriting the local data before it is read.
+ */
+HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* recvCounts,
+    ncclDataType_t datatype,
+    ncclRedOp_t op,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const int* const* allActiveRanks,
+    int nActiveRanksPerGroup,
+    int nGroups) {
+  int nRanks, rank;
+  NCCLCHECK(ncclCommCount(comm, &nRanks));
+  NCCLCHECK(ncclCommUserRank(comm, &rank));
+
+  // Validate every argument before touching recvCounts: the all-zero scan
+  // below indexes recvCounts[0..nGroups), so a null pointer or an out-of-range
+  // nGroups has to be rejected first. Bounds-checking nGroups up here also
+  // means nGroups <= 0 reports ncclInvalidArgument rather than skipping the
+  // scan entirely and returning ncclSuccess.
+  if (nGroups < 1 || nGroups > SHARDED_RELAY_MAX_GROUPS) {
+    return ncclInvalidArgument;
+  }
+
+  if (sendBuffs == nullptr || recvBuffs == nullptr ||
+      allActiveRanks == nullptr || recvCounts == nullptr) {
+    return ncclInvalidArgument;
+  }
+
+  // Require at least 2 active ranks per group
+  if (nActiveRanksPerGroup < 2) {
+    return ncclInvalidArgument;
+  }
+
+  // Validate operation - only SUM and AVG are supported
+  if (op != ncclSum && op != ncclAvg) {
+    return ncclInvalidArgument;
+  }
+
+  if (!isSupportedRelayDataType(datatype)) {
+    return ncclInvalidArgument;
+  }
+
+  // Check if all recvCounts are zero
+  bool allZero = true;
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] != 0) {
+      allZero = false;
+      break;
+    }
+  }
+  if (allZero) {
+    return ncclSuccess;
+  }
+
+  size_t elementSize = ncclTypeSize(datatype);
+
+  // Compute divisor for reduction: 1 for SUM, nActiveRanksPerGroup for AVG
+  int reductionDivisor = (op == ncclAvg) ? nActiveRanksPerGroup : 1;
+
+  // =========================================================================
+  // BUILD RANK CONFIGURATION FOR ALL GROUPS
+  // =========================================================================
+  ShardedRelayRankConfig configs[SHARDED_RELAY_MAX_GROUPS];
+  int myActiveGroup = -1; // Which group is this rank active for?
+
+  for (int g = 0; g < nGroups; g++) {
+    if (!buildShardedRelayRankConfig(
+            nRanks,
+            rank,
+            allActiveRanks[g],
+            nActiveRanksPerGroup,
+            configs[g])) {
+      return ncclInvalidArgument;
+    }
+    if (configs[g].isActiveRank) {
+      myActiveGroup = g;
+    }
+  }
+
+  // All groups should have the same number of helpers (same chunk structure)
+  int numHelpers = configs[0].numHelpers;
+  int numChunks = numHelpers + 1;
+
+  // =========================================================================
+  // CALCULATE PER-GROUP CHUNK SIZES (from the OUTPUT recvCount, i.e. one block)
+  // =========================================================================
+  size_t chunkSizes[SHARDED_RELAY_MAX_GROUPS];
+  size_t lastChunkSizes[SHARDED_RELAY_MAX_GROUPS];
+  size_t directChunkOffsets[SHARDED_RELAY_MAX_GROUPS];
+  size_t directChunkSizes[SHARDED_RELAY_MAX_GROUPS];
+
+  for (int g = 0; g < nGroups; g++) {
+    size_t count = recvCounts[g];
+
+    // Skip groups with recvCount == 0; the per-phase loops below already check
+    // recvCounts[g] == 0 and bypass NCCL ops for those groups.
+    if (count == 0) {
+      chunkSizes[g] = 0;
+      lastChunkSizes[g] = 0;
+      directChunkOffsets[g] = 0;
+      directChunkSizes[g] = 0;
+      continue;
+    }
+
+    // Calculate chunk size (aligned to CHUNK_ALIGN_ELEMENTS). When the
+    // per-chunk size rounded down to CHUNK_ALIGN_ELEMENTS is zero, the block
+    // is too small to scatter and the caller should fall back to a regular
+    // reduce-scatter.
+    size_t chunkSize = count / numChunks;
+    chunkSize = (chunkSize / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
+    if (chunkSize == 0) {
+      return ncclInvalidArgument;
+    }
+    chunkSizes[g] = chunkSize;
+
+    // Calculate the size of the last chunk (absorbs the remainder)
+    size_t totalChunkedElements = static_cast<size_t>(numChunks) * chunkSize;
+    size_t lastChunkSize = chunkSize;
+    if (totalChunkedElements < count) {
+      lastChunkSize = chunkSize + (count - totalChunkedElements);
+    }
+    lastChunkSizes[g] = lastChunkSize;
+
+    // Direct exchange chunk info (within the single output block)
+    int directChunkIndex = numHelpers;
+    directChunkOffsets[g] = static_cast<size_t>(directChunkIndex) * chunkSize;
+    directChunkSizes[g] = lastChunkSize;
+  }
+
+  // =========================================================================
+  // SCRATCH BUFFER ALLOCATION
+  // =========================================================================
+  // Relay scratch: numHelpers × chunkSize for batched passthrough recv.
+  // Direct-exchange scratch: (nActiveRanks-1) × directChunkSize (in-place).
+  void* relayScratch = nullptr;
+  void* directScratch = nullptr;
+
+  // For an active rank, compute its block offsets up-front.
+  size_t ownBlockOffset = 0;
+  size_t sendBlockOffset = 0;
+  bool isInPlace = false;
+  if (myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0) {
+    const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
+    size_t recvcount = recvCounts[myActiveGroup];
+    int otherActiveIndex = 1 - cfg.myActiveIndex;
+    ownBlockOffset = static_cast<size_t>(cfg.myActiveIndex) * recvcount;
+    sendBlockOffset = static_cast<size_t>(otherActiveIndex) * recvcount;
+
+    // In-place when recvBuff aliases the local contribution block of sendBuff.
+    const char* sendBlockStart =
+        static_cast<const char*>(sendBuffs[myActiveGroup]) +
+        ownBlockOffset * elementSize;
+    isInPlace =
+        (static_cast<const void*>(recvBuffs[myActiveGroup]) ==
+         static_cast<const void*>(sendBlockStart));
+
+    // Relay scratch sized to numHelpers × chunkSize.
+    size_t relayScratchBytes = static_cast<size_t>(numHelpers) *
+        chunkSizes[myActiveGroup] * elementSize;
+    relayScratch = ScratchBufferCache::getInstance().get(
+        SHARDED_RELAY_MAX_GROUPS, relayScratchBytes, stream);
+    if (relayScratch == nullptr) {
+      return ncclInternalError;
+    }
+
+    // Direct-exchange scratch (in-place only)
+    if (isInPlace) {
+      int nOtherActives = cfg.nActiveRanks - 1;
+      size_t directScratchBytes = static_cast<size_t>(nOtherActives) *
+          directChunkSizes[myActiveGroup] * elementSize;
+      directScratch = ScratchBufferCache::getInstance().get(
+          myActiveGroup, directScratchBytes, stream);
+      if (directScratch == nullptr) {
+        return ncclInternalError;
+      }
+    }
+  }
+
+  // =========================================================================
+  // PHASE 1 (active→helpers): Both active ranks scatter their sendBlock chunks
+  // =========================================================================
+  // Helpers receive from each active rank into offset-based slots:
+  //   slot a at offset (a × chunkSize) holds data from active rank a.
+  // Active ranks send chunks of the sendBlockOffset block (block destined for
+  // the OTHER active rank).
+  NCCLCHECK(ncclGroupStart());
+
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    const void* sendbuff = sendBuffs[g];
+    void* recvbuff = recvBuffs[g];
+    size_t chunkSize = chunkSizes[g];
+
+    if (cfg.isActiveRank) {
+      // Active rank: send chunk h of my sendBlock to helper h
+      for (int h = 0; h < cfg.numHelpers; h++) {
+        int helperRank = cfg.helperRanks[h];
+        size_t chunkOffset =
+            sendBlockOffset + static_cast<size_t>(h) * chunkSize;
+
+        NCCLCHECK(ncclSend(
+            static_cast<const char*>(sendbuff) + chunkOffset * elementSize,
+            chunkSize,
+            datatype,
+            helperRank,
+            comm,
+            stream));
+      }
+    } else {
+      // Helper rank: receive from each active rank into slot a
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        int activeRank = cfg.activeRanks[a];
+        size_t helperOffset = static_cast<size_t>(a) * chunkSize;
+
+        NCCLCHECK(ncclRecv(
+            static_cast<char*>(recvbuff) + helperOffset * elementSize,
+            chunkSize,
+            datatype,
+            activeRank,
+            comm,
+            stream));
+      }
+    }
+  }
+
+  NCCLCHECK(ncclGroupEnd());
+
+  // For out-of-place active groups: seed recvbuff's relay region with the
+  // local contribution (the ownBlockOffset block of sendbuff) so the
+  // incremental add in Phase 3 works uniformly. In-place already has it.
+  if (myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0 && !isInPlace) {
+    const void* sendbuff = sendBuffs[myActiveGroup];
+    void* recvbuff = recvBuffs[myActiveGroup];
+    size_t relayBytes = static_cast<size_t>(numHelpers) *
+        chunkSizes[myActiveGroup] * elementSize;
+    cudaMemcpyAsync(
+        recvbuff,
+        static_cast<const char*>(sendbuff) + ownBlockOffset * elementSize,
+        relayBytes,
+        cudaMemcpyDeviceToDevice,
+        stream);
+  }
+
+  // =========================================================================
+  // PHASE 2 (helpers→active, batched): Passthrough forward
+  // =========================================================================
+  // Each helper sends slot 0 (a0's data) → a1 and slot 1 (a1's data) → a0.
+  // Active rank receives all numHelpers chunks into relay scratch at offset
+  // h × chunkSize per helper h.
+  NCCLCHECK(ncclGroupStart());
+
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    void* recvbuff = recvBuffs[g];
+    size_t chunkSize = chunkSizes[g];
+
+    if (!cfg.isActiveRank) {
+      // Helper for group g: forward each slot to the OTHER active rank.
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        int targetActive = cfg.activeRanks[1 - a];
+        NCCLCHECK(ncclSend(
+            static_cast<const char*>(recvbuff) +
+                static_cast<size_t>(a) * chunkSize * elementSize,
+            chunkSize,
+            datatype,
+            targetActive,
+            comm,
+            stream));
+      }
+    } else {
+      // Active rank: receive ALL forwarded data from each helper into the
+      // relay scratch at offset h × chunkSize.
+      for (int h = 0; h < cfg.numHelpers; h++) {
+        int helperRank = cfg.helperRanks[h];
+        size_t scratchOffset = static_cast<size_t>(h) * chunkSize;
+        NCCLCHECK(ncclRecv(
+            static_cast<char*>(relayScratch) + scratchOffset * elementSize,
+            chunkSize,
+            datatype,
+            helperRank,
+            comm,
+            stream));
+      }
+    }
+  }
+
+  NCCLCHECK(ncclGroupEnd());
+
+  // =========================================================================
+  // PHASE 3 (active reduce): Fused add + scale on the relay region
+  // =========================================================================
+  // recvbuff[i] = (recvbuff[i] + relayScratch[i]) / divisor over the relay
+  // region (numHelpers × chunkSize). recvbuff was seeded with the local
+  // ownBlock contribution above.
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+    if (cfg.isActiveRank) {
+      void* recvbuff = recvBuffs[g];
+      size_t chunkSize = chunkSizes[g];
+      size_t relayTotal = static_cast<size_t>(numHelpers) * chunkSize;
+
+      if (reductionDivisor > 1) {
+        DISPATCH_INCREMENTAL_ADD_AND_SCALE(
+            datatype,
+            recvbuff,
+            relayScratch,
+            relayTotal,
+            reductionDivisor,
+            stream);
+      } else {
+        DISPATCH_INCREMENTAL_ADD(
+            datatype, recvbuff, relayScratch, relayTotal, stream);
+      }
+    }
+  }
+
+  // =========================================================================
+  // PHASE 4 (active↔active): Direct exchange of the last chunk
+  // =========================================================================
+  // Active ranks exchange the direct chunk of their sendBlock; it lands in the
+  // output block's direct-chunk slot (offset directChunkOffset in recvbuff).
+  NCCLCHECK(ncclGroupStart());
+
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+
+    if (cfg.isActiveRank) {
+      const void* sendbuff = sendBuffs[g];
+      void* recvbuff = recvBuffs[g];
+      size_t directChunkOffset = directChunkOffsets[g];
+      size_t directChunkSize = directChunkSizes[g];
+      // Source in sendbuff is within the sendBlock (shipped to other rank).
+      size_t sendDirectOffset = sendBlockOffset + directChunkOffset;
+
+      // Send my direct chunk to all other active ranks
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        if (a == cfg.myActiveIndex)
+          continue;
+        int otherActiveRank = cfg.activeRanks[a];
+
+        NCCLCHECK(ncclSend(
+            static_cast<const char*>(sendbuff) + sendDirectOffset * elementSize,
+            directChunkSize,
+            datatype,
+            otherActiveRank,
+            comm,
+            stream));
+      }
+
+      // Receive direct chunks from all other active ranks
+      int scratchIdx = 0;
+      for (int a = 0; a < cfg.nActiveRanks; a++) {
+        if (a == cfg.myActiveIndex)
+          continue;
+        int otherActiveRank = cfg.activeRanks[a];
+
+        if (isInPlace) {
+          size_t scratchOffset =
+              static_cast<size_t>(scratchIdx) * directChunkSize;
+          NCCLCHECK(ncclRecv(
+              static_cast<char*>(directScratch) + scratchOffset * elementSize,
+              directChunkSize,
+              datatype,
+              otherActiveRank,
+              comm,
+              stream));
+        } else {
+          NCCLCHECK(ncclRecv(
+              static_cast<char*>(recvbuff) + directChunkOffset * elementSize,
+              directChunkSize,
+              datatype,
+              otherActiveRank,
+              comm,
+              stream));
+        }
+        scratchIdx++;
+      }
+    }
+  }
+
+  NCCLCHECK(ncclGroupEnd());
+
+  // =========================================================================
+  // PHASE 5 (active reduce): Final reduction on the direct-exchange chunk
+  // =========================================================================
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] == 0)
+      continue;
+    const ShardedRelayRankConfig& cfg = configs[g];
+
+    if (cfg.isActiveRank) {
+      const void* sendbuff = sendBuffs[g];
+      void* recvbuff = recvBuffs[g];
+      size_t directChunkOffset = directChunkOffsets[g];
+      size_t directChunkSize = directChunkSizes[g];
+
+      void* directChunkDst =
+          static_cast<char*>(recvbuff) + directChunkOffset * elementSize;
+
+      if (isInPlace) {
+        // recvbuff direct slot already holds the local contribution.
+        int scratchIdx2 = 0;
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          if (a == cfg.myActiveIndex)
+            continue;
+          size_t scratchOffset =
+              static_cast<size_t>(scratchIdx2) * directChunkSize;
+          const void* received = static_cast<const char*>(directScratch) +
+              scratchOffset * elementSize;
+          DISPATCH_INCREMENTAL_ADD(
+              datatype, directChunkDst, received, directChunkSize, stream);
+          scratchIdx2++;
+        }
+
+        if (reductionDivisor > 1) {
+          DISPATCH_SCALE(
+              datatype,
+              directChunkDst,
+              directChunkSize,
+              reductionDivisor,
+              stream);
+        }
+      } else {
+        // Out-of-place: local contribution is in sendbuff's ownBlock; the
+        // received chunk is already in recvbuff's direct slot.
+        const void* localContribution = static_cast<const char*>(sendbuff) +
+            (ownBlockOffset + directChunkOffset) * elementSize;
+        const void* receivedContribution = directChunkDst;
+
+        DISPATCH_FUSED_REDUCE(
+            datatype,
+            directChunkDst,
+            localContribution,
+            receivedContribution,
+            directChunkSize,
+            reductionDivisor,
+            stream);
+      }
+    }
+  }
+
+  return ncclSuccess;
+}

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -674,6 +674,7 @@ static ncclResult_t shardedRelayReduceScatter2Active(
 
   size_t chunkSizes[SHARDED_RELAY_MAX_GROUPS];
   size_t relayTotals[SHARDED_RELAY_MAX_GROUPS]; // == direct chunk A's offset
+  size_t dirASizes[SHARDED_RELAY_MAX_GROUPS];
   size_t dirBOffsets[SHARDED_RELAY_MAX_GROUPS];
   size_t dirBSizes[SHARDED_RELAY_MAX_GROUPS]; // absorbs the remainder
 
@@ -684,21 +685,23 @@ static ncclResult_t shardedRelayReduceScatter2Active(
     if (count == 0) {
       chunkSizes[g] = 0;
       relayTotals[g] = 0;
+      dirASizes[g] = 0;
       dirBOffsets[g] = 0;
       dirBSizes[g] = 0;
       continue;
     }
 
-    // A chunk size that rounds down to zero means the block is too small to
-    // scatter; the caller should fall back to a regular reduce-scatter.
     size_t chunkSize = count / numChunks;
     chunkSize = (chunkSize / CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS;
-    if (chunkSize == 0) {
-      return ncclInvalidArgument;
-    }
     chunkSizes[g] = chunkSize;
     relayTotals[g] = static_cast<size_t>(numHelpers) * chunkSize;
-    dirBOffsets[g] = relayTotals[g] + chunkSize;
+    if (chunkSize == 0) {
+      dirASizes[g] = count / 2;
+      dirBOffsets[g] = dirASizes[g];
+    } else {
+      dirASizes[g] = chunkSize;
+      dirBOffsets[g] = relayTotals[g] + chunkSize;
+    }
     dirBSizes[g] = count - dirBOffsets[g];
   }
 
@@ -750,7 +753,7 @@ static ncclResult_t shardedRelayReduceScatter2Active(
       const char* sendBlock = static_cast<const char*>(sendBuffs[g]) +
           sendBlockOffset * elementSize;
 
-      for (int h = 0; h < cfg.numHelpers; h++) {
+      for (int h = 0; h < cfg.numHelpers && chunkSize > 0; h++) {
         NCCLCHECK(ncclSend(
             sendBlock + static_cast<size_t>(h) * chunkSize * elementSize,
             chunkSize,
@@ -762,21 +765,23 @@ static ncclResult_t shardedRelayReduceScatter2Active(
 
       // Direct chunk A over the otherwise-idle active<->active link.
       int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
-      NCCLCHECK(ncclSend(
-          sendBlock + relayTotals[g] * elementSize,
-          chunkSize,
-          datatype,
-          partner,
-          comm,
-          stream));
-      NCCLCHECK(ncclRecv(
-          static_cast<char*>(foreignScratch) + relayTotals[g] * elementSize,
-          chunkSize,
-          datatype,
-          partner,
-          comm,
-          stream));
-    } else {
+      if (dirASizes[g] > 0) {
+        NCCLCHECK(ncclSend(
+            sendBlock + relayTotals[g] * elementSize,
+            dirASizes[g],
+            datatype,
+            partner,
+            comm,
+            stream));
+        NCCLCHECK(ncclRecv(
+            static_cast<char*>(foreignScratch) + relayTotals[g] * elementSize,
+            dirASizes[g],
+            datatype,
+            partner,
+            comm,
+            stream));
+      }
+    } else if (chunkSize > 0) {
       // Helper: receive active rank a's chunk into slot a.
       char* helperBuf = static_cast<char*>(recvBuffs[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {
@@ -808,7 +813,7 @@ static ncclResult_t shardedRelayReduceScatter2Active(
     if (cfg.isActiveRank) {
       char* scratch = static_cast<char*>(foreignScratch);
 
-      for (int h = 0; h < cfg.numHelpers; h++) {
+      for (int h = 0; h < cfg.numHelpers && chunkSize > 0; h++) {
         NCCLCHECK(ncclRecv(
             scratch + static_cast<size_t>(h) * chunkSize * elementSize,
             chunkSize,
@@ -820,22 +825,24 @@ static ncclResult_t shardedRelayReduceScatter2Active(
 
       // Direct chunk B, again over the idle active<->active link.
       int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
-      NCCLCHECK(ncclSend(
-          static_cast<const char*>(sendBuffs[g]) +
-              (sendBlockOffset + dirBOffsets[g]) * elementSize,
-          dirBSizes[g],
-          datatype,
-          partner,
-          comm,
-          stream));
-      NCCLCHECK(ncclRecv(
-          scratch + dirBOffsets[g] * elementSize,
-          dirBSizes[g],
-          datatype,
-          partner,
-          comm,
-          stream));
-    } else {
+      if (dirBSizes[g] > 0) {
+        NCCLCHECK(ncclSend(
+            static_cast<const char*>(sendBuffs[g]) +
+                (sendBlockOffset + dirBOffsets[g]) * elementSize,
+            dirBSizes[g],
+            datatype,
+            partner,
+            comm,
+            stream));
+        NCCLCHECK(ncclRecv(
+            scratch + dirBOffsets[g] * elementSize,
+            dirBSizes[g],
+            datatype,
+            partner,
+            comm,
+            stream));
+      }
+    } else if (chunkSize > 0) {
       // Passthrough: slot a goes to the OTHER active rank, which owns it.
       const char* helperBuf = static_cast<const char*>(recvBuffs[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -563,6 +563,101 @@ static ncclResult_t shardedRelayReduceScatter2Active(
     size_t elementSize) {
   int numChunks = numHelpers + 1;
 
+  // ==========================================================================
+  // SIZE-ADAPTIVE PURE-DIRECT FAST PATH (A==2)
+  // ==========================================================================
+  // At small sizes the 2-hop helper relay (phases 1-2 = two group boundaries
+  // plus a helper HBM round trip) costs far more than the bandwidth it buys.
+  // Instead the two active ranks exchange their full foreign block directly in
+  // a single group (helpers idle) and reduce locally -- minimal latency, the
+  // same shape as all-to-all. maxBytes here (2*recvCount*elemSize) equals the
+  // bench's per-rank input label; crossover measured at 256 MB (same as the A>2
+  // path), above which the relay's helper cross links win on bandwidth.
+  size_t maxRc2 = 0;
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] > maxRc2) {
+      maxRc2 = recvCounts[g];
+    }
+  }
+  const size_t maxBytes2 = static_cast<size_t>(2) * maxRc2 * elementSize;
+  // A=2 relay is very efficient at large sizes (one group spread across all
+  // helpers -> up to ~1.9x), so the pure-direct crossover is low and scenario
+  // dependent (measured MI350X, bf16, 8 GPUs): fused relay overtakes at ~9 MB,
+  // independent at ~27 MB (independent has no cross-group contention, so direct
+  // holds on longer). Cross over just below each.
+  const size_t kA2PureDirectMaxBytes = (nGroups > 1)
+      ? (static_cast<size_t>(8) << 20) // fused: < 8 MB
+      : (static_cast<size_t>(16) << 20); // independent: < 16 MB
+  if (maxBytes2 < kA2PureDirectMaxBytes) {
+    void* pdScratch = nullptr;
+    size_t pdRecvcount = 0;
+    size_t pdOwnOff = 0;
+    bool pdInPlace = false;
+    if (myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0) {
+      const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
+      pdRecvcount = recvCounts[myActiveGroup];
+      pdOwnOff = static_cast<size_t>(cfg.myActiveIndex) * pdRecvcount;
+      const char* ownContrib =
+          static_cast<const char*>(sendBuffs[myActiveGroup]) +
+          pdOwnOff * elementSize;
+      pdInPlace =
+          (static_cast<const void*>(recvBuffs[myActiveGroup]) ==
+           static_cast<const void*>(ownContrib));
+      pdScratch = ScratchBufferCache::getInstance().get(
+          SHARDED_RELAY_MAX_GROUPS, pdRecvcount * elementSize, stream);
+      if (pdScratch == nullptr) {
+        return ncclInternalError;
+      }
+    }
+
+    NCCLCHECK(ncclGroupStart());
+    for (int g = 0; g < nGroups; g++) {
+      if (recvCounts[g] == 0) {
+        continue;
+      }
+      const ShardedRelayRankConfig& cfg = configs[g];
+      if (!cfg.isActiveRank) {
+        continue; // helpers idle in pure-direct mode
+      }
+      size_t rc = recvCounts[g];
+      int other = 1 - cfg.myActiveIndex;
+      int partner = cfg.activeRanks[other];
+      // Send my contribution to the partner's owned block; receive the
+      // partner's contribution to my owned block into scratch.
+      NCCLCHECK(ncclSend(
+          static_cast<const char*>(sendBuffs[g]) +
+              static_cast<size_t>(other) * rc * elementSize,
+          rc,
+          datatype,
+          partner,
+          comm,
+          stream));
+      NCCLCHECK(ncclRecv(
+          static_cast<char*>(pdScratch), rc, datatype, partner, comm, stream));
+    }
+    NCCLCHECK(ncclGroupEnd());
+
+    if (myActiveGroup >= 0 && pdRecvcount > 0) {
+      void* out = recvBuffs[myActiveGroup];
+      if (!pdInPlace) {
+        cudaMemcpyAsync(
+            out,
+            static_cast<const char*>(sendBuffs[myActiveGroup]) +
+                pdOwnOff * elementSize,
+            pdRecvcount * elementSize,
+            cudaMemcpyDeviceToDevice,
+            stream);
+      }
+      if (reductionDivisor > 1) {
+        DISPATCH_INCREMENTAL_ADD_AND_SCALE(
+            datatype, out, pdScratch, pdRecvcount, reductionDivisor, stream);
+      } else {
+        DISPATCH_INCREMENTAL_ADD(datatype, out, pdScratch, pdRecvcount, stream);
+      }
+    }
+    return ncclSuccess;
+  }
+
   // =========================================================================
   // CALCULATE PER-GROUP CHUNK SIZES (from the OUTPUT recvCount, i.e. one block)
   // =========================================================================
@@ -984,10 +1079,35 @@ static ncclResult_t shardedRelayReduceScatterRecursive(
   }
   const int nRsGroups = 2 * logA;
 
-  // Direct (intra) fraction = 60%. Balances per-link load: each intra link
-  // carries 0.5*D (1-hop), each cross link 0.75*R (2-hop); equal at
-  // D:R=0.6:0.4.
-  const size_t DIRECT_NUM = 60, DIRECT_DEN = 100;
+  // Largest per-group message drives the size-adaptive tuning. All groups march
+  // through the same superstep count to stay phase-synced, so tune off the max.
+  size_t maxRc = 0;
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] > maxRc) {
+      maxRc = recvCounts[g];
+    }
+  }
+  const size_t maxBytes = static_cast<size_t>(A) * maxRc * elementSize;
+
+  // Size-adaptive routing. The recursive-halving relay spreads traffic across
+  // helper cross links for bandwidth, but it costs 2*logA group boundaries
+  // (~25us each) plus 2-hop latency. Below the threshold that is pure overhead,
+  // so degenerate to a single-group pure-direct all-to-all reduce-scatter (each
+  // active rank swaps its foreign shards directly with the other A-1 owners and
+  // reduces locally; helpers idle) -- the same minimal-latency shape as
+  // all-to-all. Above it, keep the recursive relay with a 60% direct / 40%
+  // relay split (balances per-link load: intra links carry 0.5*D at 1 hop,
+  // cross links 0.75*R at 2 hops; equal at D:R = 0.6:0.4). The crossover is
+  // scenario-independent here (unlike all-gather): measured on MI350X (A=4,
+  // bf16, 8 GPUs) pure-direct wins or ties across the whole range up to 144 MB
+  // in both fused and independent modes (e.g. 4.5 MB 0.44x->0.99x, 72 MB
+  // 0.86x->0.98x fused), and the recursive relay only pulls ahead at
+  // >=256 MB where its helper-cross-link bandwidth beats intra-only direct. max
+  // bytes here (A*recvCount*elemSize) equals the bench's per-rank input label.
+  const size_t kFlatPureDirectMaxBytes = static_cast<size_t>(256)
+      << 20; // 256 MB
+  const bool pureDirect = (maxBytes < kFlatPureDirectMaxBytes);
+  const size_t DIRECT_NUM = pureDirect ? 100 : 60, DIRECT_DEN = 100;
 
   // Per-group working-buffer total count = A * recvCount (the full input), and
   // its R/D split. count is divisible by A by construction.
@@ -1126,9 +1246,23 @@ static ncclResult_t shardedRelayReduceScatterRecursive(
       int gi = giRs + phase;
       size_t dSliceLen = 0, dSliceOff = 0;
       if (myShardLen > 0) {
-        size_t base = myShardLen / nRsGroups;
-        dSliceOff = static_cast<size_t>(gi) * base;
-        dSliceLen = (gi == nRsGroups - 1) ? (myShardLen - dSliceOff) : base;
+        if (pureDirect) {
+          // No relay traffic to overlap against: carry the whole direct
+          // all-to-all in the first superstep and leave the rest empty.
+          dSliceOff = 0;
+          dSliceLen = (gi == 0) ? myShardLen : 0;
+        } else {
+          size_t base = myShardLen / nRsGroups;
+          dSliceOff = static_cast<size_t>(gi) * base;
+          dSliceLen = (gi == nRsGroups - 1) ? (myShardLen - dSliceOff) : base;
+        }
+      }
+
+      // Skip supersteps with no work: in pure-direct mode pR==0 (no relay) and
+      // all direct traffic is in gi==0, so gi>0 would be an empty group
+      // boundary.
+      if (pureDirect && gi > 0) {
+        continue;
       }
 
       NCCLCHECK(ncclGroupStart());

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -585,7 +585,7 @@ static ncclResult_t shardedRelayReduceScatter2Active(
   // holds on longer). Cross over just below each.
   const size_t kA2PureDirectMaxBytes = (nGroups > 1)
       ? (static_cast<size_t>(2) << 20) // fused: < 2 MB
-      : (static_cast<size_t>(6) << 20); // independent: < 6 MB
+      : (static_cast<size_t>(27) << 20); // independent: < 27 MB
   if (maxBytes2 < kA2PureDirectMaxBytes) {
     void* pdScratch = nullptr;
     size_t pdRecvcount = 0;

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.h
@@ -27,14 +27,19 @@
  * phase-synchronized passthrough-helper scheme; helpers perform no local
  * compute and all reductions happen on the active ranks per group.
  *
- * nActiveRanksPerGroup must be a power of two (2 or 4). A==2 uses the original
- * 2-active passthrough path (block-restricted 5-phase relay); A>2 uses the
- * bandwidth-optimal recursive path (recursive-halving relay woven with a direct
- * all-to-all, mirroring the merged allreduce). The direct all-to-all's owned
- * shard is reduced with a single fused multi-input reduce pass (owned shard +
- * all A-1 peer contributions read once, AVG divisor applied, written once)
- * instead of a loop of per-contribution add + scale passes. Both keep the same
- * per-helper buffer contract (nActiveRanksPerGroup x chunkSize).
+ * nActiveRanksPerGroup must be a power of two (2 or 4). A==2 uses the 2-active
+ * passthrough relay described below. A>2 uses a two-group flat relay with
+ * REDUCE-AT-HELPER: each helper owns one position slice of every block,
+ * collects that slice from the A-1 non-owner sources, sums them, and forwards a
+ * single reduced chunk to the owner, woven with a direct all-to-all
+ * reduce-scatter over the intra links. Both the direct region and the offload
+ * region are folded into the output with fused multi-input reduce passes rather
+ * than a loop of per-contribution add + scale passes.
+ *
+ * Because the A>2 helper reduces rather than forwards, it needs one chunk per
+ * (owner, source) pair -- A x (A-1) x chunk, i.e. 1.5 x recvCounts[g] on an
+ * 8-GPU node -- so its helper contract is larger than the A==2 two-slot one
+ * (see the Helper-Buffer Contract below).
  *
  * Reduce-Scatter Semantics (per group, 2 active ranks a0, a1):
  * ===========================================================
@@ -55,34 +60,48 @@
  *   - ownBlockOffset  = myActiveIndex    × recvCounts[g] (local contribution)
  *   - sendBlockOffset = otherActiveIndex × recvCounts[g] (shipped to other)
  *
- * Five Phases (mirroring allreduce, restricted to the relevant block):
- * ===================================================================
- *   Phase 1 (active→helpers): each active rank scatters numHelpers chunks of
- *            its sendBlockOffset block to helpers; each helper stores two
- *            slots (one per active rank) — same passthrough contract as
- *            allreduce.
- *   Phase 2 (helpers→active, batched): each helper forwards slot-from-a0 → a1
- *            and slot-from-a1 → a0; active rank receives numHelpers chunks
- *            into relay scratch (numHelpers × chunkSize).
- *   Phase 3 (active reduce): fused add (+scale for AVG) of relay scratch into
- *            the output block (recvBuff), seeded with the local ownBlockOffset
- *            contribution.
- *   Phase 4 (active↔active): direct exchange of the last (direct) chunk.
- *   Phase 5 (active reduce): final reduction of the direct chunk.
+ * Two Comm Groups (mirroring allreduce, restricted to the relevant block):
+ * ========================================================================
+ *   Group 1: each active rank scatters numHelpers chunks of its sendBlockOffset
+ *            block to helpers (each helper stores two slots, one per active
+ *            rank) AND the two active ranks directly exchange one chunk over
+ *            the otherwise-idle active<->active link.
+ *   Group 2: each helper forwards slot-from-a0 -> a1 and slot-from-a1 -> a0
+ * into the destination's scratch AND the active ranks directly exchange a
+ *            second chunk over the same idle link.
+ *   Reduce:  one fused pass folds the local ownBlockOffset contribution into
+ * the whole foreign-contribution scratch, which mirrors the output layout, so
+ * relayed and directly exchanged chunks reduce together.
+ *
+ * Unlike allreduce, the helper CANNOT reduce: its slot 0 holds a0's
+ * contribution to a1's output and slot 1 holds a1's contribution to a0's output
+ * -- different outputs. Helpers stay pure passthrough and the active rank
+ * reduces.
  *
  * Chunking:
  * =========
- *   chunkSize  = recvCounts[g] / numChunks rounded down to 128 elements,
- *   numChunks  = numHelpers + 1 (last chunk is the direct-exchange chunk).
- * Returns ncclInvalidArgument when recvCounts[g] < numChunks × 128 (too small
- * to scatter); callers should fall back to a plain reduce-scatter.
+ *   chunkSize = recvCounts[g] / numChunks rounded down to 128 elements,
+ *   numChunks = numHelpers + 2. The active<->active link is idle while the
+ * relay scatter and forward run on the cross links, so instead of a third comm
+ * group for one direct chunk, one direct chunk rides along with each relay
+ * group. Every link then carries exactly one chunk per direction per group and
+ * the critical path is 2 x chunkSize instead of 3 x
+ * recvCounts[g]/(numHelpers+1). Returns ncclInvalidArgument when recvCounts[g]
+ * < numChunks x 128 (too small to scatter); callers should fall back to a plain
+ * reduce-scatter.
  *
- * Helper-Buffer Contract (passthrough-at-helper):
- * ===============================================
- * Identical to allreduce. Caller MUST supply at least
+ * Helper-Buffer Contract:
+ * =======================
+ * A==2 path: identical to allreduce. Caller MUST supply at least
  *   nActiveRanksPerGroup × chunkSize_aligned
  * elements per helper group, where chunkSize_aligned is computed from
  * recvCounts[g] (NOT the doubled send count).
+ *
+ * A>2 path: the helper reduces rather than forwards, so it holds one chunk per
+ * (owner, contributing source) pair: A × (A-1) × cs, where cs is recvCounts[g]
+ * divided by (A + numHelpers) and 128-aligned. That is 1.5 × recvCounts[g] on
+ * an 8-GPU node, so allocating 2 × recvCounts[g] per helper group covers every
+ * supported (A, numHelpers) split.
  *
  * Memory Model:
  * =============

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.h
@@ -25,7 +25,16 @@
  * It is the reduce-scatter analogue of
  * `ncclShardedRelayMultiGroupAllReduceImpl` and reuses the same
  * phase-synchronized passthrough-helper scheme; helpers perform no local
- * compute and all reductions happen on the two active ranks per group.
+ * compute and all reductions happen on the active ranks per group.
+ *
+ * nActiveRanksPerGroup must be a power of two (2 or 4). A==2 uses the original
+ * 2-active passthrough path (block-restricted 5-phase relay); A>2 uses the
+ * bandwidth-optimal recursive path (recursive-halving relay woven with a direct
+ * all-to-all, mirroring the merged allreduce). The direct all-to-all's owned
+ * shard is reduced with a single fused multi-input reduce pass (owned shard +
+ * all A-1 peer contributions read once, AVG divisor applied, written once)
+ * instead of a loop of per-contribution add + scale passes. Both keep the same
+ * per-helper buffer contract (nActiveRanksPerGroup x chunkSize).
  *
  * Reduce-Scatter Semantics (per group, 2 active ranks a0, a1):
  * ===========================================================
@@ -106,7 +115,7 @@
  * @param stream CUDA stream
  * @param allActiveRanks 2D array of active ranks
  * [nGroups][nActiveRanksPerGroup]
- * @param nActiveRanksPerGroup Number of active ranks per group (typically 2)
+ * @param nActiveRanksPerGroup Number of active ranks per group (2 or 4)
  * @param nGroups Number of groups (typically 4 for 8-GPU node)
  * @return ncclResult_t Success or error code
  */

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "nccl.h"
+
+// Maximum number of groups supported in multi-group reduce-scatter.
+// Mirrors SHARDED_RELAY_MAX_GROUPS in sharded_relay_allreduce.h; redefined
+// here so this header is self-contained (the two values must stay in sync).
+#ifndef SHARDED_RELAY_MAX_GROUPS
+#define SHARDED_RELAY_MAX_GROUPS 8
+#endif
+
+/**
+ * Fused Multi-Group Sharded Relay Reduce-Scatter for 2D Sparse Parallelism.
+ *
+ * This API performs multiple sharded relay reduce-scatters in a single fused
+ * call, coordinating phases across all groups to prevent XGMI link contention.
+ * It is the reduce-scatter analogue of
+ * `ncclShardedRelayMultiGroupAllReduceImpl` and reuses the same
+ * phase-synchronized passthrough-helper scheme; helpers perform no local
+ * compute and all reductions happen on the two active ranks per group.
+ *
+ * Reduce-Scatter Semantics (per group, 2 active ranks a0, a1):
+ * ===========================================================
+ * NCCL reduce-scatter among the 2 active ranks:
+ *   - Each active rank's sendBuff holds nActiveRanksPerGroup × recvCounts[g]
+ *     (= 2 × recvCounts[g]) elements: logically block[i] is the slice
+ *     destined for active index i.
+ *   - Each active rank's recvBuff holds recvCounts[g] elements: active index
+ *     i receives sum_over_active_ranks( sendBuff[block i] ).
+ *
+ * So each active rank keeps its own block[myActiveIndex] and must receive the
+ * other rank's block[myActiveIndex]; equivalently each active rank ships
+ * block[otherActiveIndex] to the other rank. This is a single-block
+ * (recvCounts[g]-element) sharded exchange + local reduce — structurally
+ * identical to the allreduce relay but restricted to one block.
+ *
+ * Block offsets per active rank (in elements):
+ *   - ownBlockOffset  = myActiveIndex    × recvCounts[g] (local contribution)
+ *   - sendBlockOffset = otherActiveIndex × recvCounts[g] (shipped to other)
+ *
+ * Five Phases (mirroring allreduce, restricted to the relevant block):
+ * ===================================================================
+ *   Phase 1 (active→helpers): each active rank scatters numHelpers chunks of
+ *            its sendBlockOffset block to helpers; each helper stores two
+ *            slots (one per active rank) — same passthrough contract as
+ *            allreduce.
+ *   Phase 2 (helpers→active, batched): each helper forwards slot-from-a0 → a1
+ *            and slot-from-a1 → a0; active rank receives numHelpers chunks
+ *            into relay scratch (numHelpers × chunkSize).
+ *   Phase 3 (active reduce): fused add (+scale for AVG) of relay scratch into
+ *            the output block (recvBuff), seeded with the local ownBlockOffset
+ *            contribution.
+ *   Phase 4 (active↔active): direct exchange of the last (direct) chunk.
+ *   Phase 5 (active reduce): final reduction of the direct chunk.
+ *
+ * Chunking:
+ * =========
+ *   chunkSize  = recvCounts[g] / numChunks rounded down to 128 elements,
+ *   numChunks  = numHelpers + 1 (last chunk is the direct-exchange chunk).
+ * Returns ncclInvalidArgument when recvCounts[g] < numChunks × 128 (too small
+ * to scatter); callers should fall back to a plain reduce-scatter.
+ *
+ * Helper-Buffer Contract (passthrough-at-helper):
+ * ===============================================
+ * Identical to allreduce. Caller MUST supply at least
+ *   nActiveRanksPerGroup × chunkSize_aligned
+ * elements per helper group, where chunkSize_aligned is computed from
+ * recvCounts[g] (NOT the doubled send count).
+ *
+ * Memory Model:
+ * =============
+ * Each rank is ACTIVE for exactly ONE group (has real tensor data).
+ * For other groups, the rank is a HELPER (uses provided two-slot scratch).
+ * The caller must provide:
+ *   - sendBuffs[nGroups]: one contiguous input buffer per group. For the active
+ *     group it holds nActiveRanksPerGroup × recvCounts[g] elements (one
+ *     contribution block per active index); helper groups may pass the same
+ *     pointer as recvBuffs.
+ *   - recvBuffs[nGroups]: one base buffer per group. For helper groups this is
+ *     the two-slot passthrough scratch (>= nActiveRanks × chunkSize); for the
+ *     active group it is the output base (recvCounts[g] elements).
+ *   - In-place is detected when the active group's output aliases the owned
+ *     input block (recvBuffs[g] == sendBuffs[g] + ownBlockOffset).
+ *   - Each helper group MUST have its own buffer (no aliasing across groups)
+ *     because all groups are processed simultaneously under phase-sync.
+ *
+ * Op support: ncclSum and ncclAvg only (AVG divisor = nActiveRanksPerGroup).
+ *
+ * @param sendBuffs Array of per-group contiguous input buffer pointers (one per
+ *        group); the active group holds nActiveRanksPerGroup × recvCounts[g]
+ *        elements (one contribution block per active index)
+ * @param recvBuffs Array of per-group base buffer pointers (one per group);
+ *        helper groups pass two-slot passthrough scratch
+ * @param recvCounts Array of per-group OUTPUT element counts (one per group)
+ * @param datatype NCCL data type
+ * @param op Reduction operation (only ncclSum and ncclAvg supported)
+ * @param comm NCCL communicator
+ * @param stream CUDA stream
+ * @param allActiveRanks 2D array of active ranks
+ * [nGroups][nActiveRanksPerGroup]
+ * @param nActiveRanksPerGroup Number of active ranks per group (typically 2)
+ * @param nGroups Number of groups (typically 4 for 8-GPU node)
+ * @return ncclResult_t Success or error code
+ */
+ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* recvCounts,
+    ncclDataType_t datatype,
+    ncclRedOp_t op,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const int* const* allActiveRanks,
+    int nActiveRanksPerGroup,
+    int nGroups);

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
@@ -1,0 +1,1007 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/**
+ * Unit tests for Fused Multi-Group Sharded Relay All-Gather
+ *
+ * All-gather analogue of ShardedRelayReduceScatterTest.cu (and the dual of
+ * reduce-scatter). Tests the phase-synchronized execution of multiple sharded
+ * relay all-gathers with passthrough-at-helper design. All-gather performs NO
+ * reduction; helpers forward data and active ranks place it. Both in-place and
+ * out-of-place are supported.
+ *
+ * All-Gather Semantics (per group, 2 active ranks):
+ * =================================================
+ * Each active rank's sendBuff holds sendCount elements (its contribution);
+ * recvBuff holds nActiveRanksPerGroup x sendCount elements, where
+ * recvBuff[i x sendCount] receives the contribution from active index i.
+ *
+ * To verify the gather, each active rank fills its sendBuff with a distinct
+ * value rankFillValue(myActiveIndex). After the all-gather, every active rank's
+ * recvBuff slot i must equal rankFillValue(i). A wrong slot offset in the
+ * implementation produces a detectable mismatch.
+ *
+ * In-place is detected when sendBuff == recvBuff + myActiveIndex x sendCount.
+ *
+ * 2D Sparse Parallelism Configuration (8 GPUs, 4 groups):
+ *   Group 0: activeRanks = {0, 1}, helpers = {2,3,4,5,6,7}
+ *   Group 1: activeRanks = {2, 3}, helpers = {0,1,4,5,6,7}
+ *   Group 2: activeRanks = {4, 5}, helpers = {0,1,2,3,6,7}
+ *   Group 3: activeRanks = {6, 7}, helpers = {0,1,2,3,4,5}
+ *
+ * Each rank is ACTIVE for exactly ONE group, HELPER for the other 3.
+ */
+
+#include <folly/init/Init.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+#include "comm.h"
+#include "comms/rcclx/develop/meta/testinfra/TestUtils.h"
+#include "comms/rcclx/develop/meta/testinfra/TestsDistUtils.h"
+#include "nccl.h"
+
+#define HIPCHECK_TEST(cmd)                                          \
+  do {                                                              \
+    hipError_t error = cmd;                                         \
+    if (error != hipSuccess) {                                      \
+      FAIL() << "HIP error: " << hipGetErrorString(error) << " at " \
+             << __FILE__ << ":" << __LINE__;                        \
+    }                                                               \
+  } while (0)
+
+#define NCCLCHECK_TEST(cmd)                                            \
+  do {                                                                 \
+    ncclResult_t result = cmd;                                         \
+    if (result != ncclSuccess) {                                       \
+      FAIL() << "NCCL error: " << ncclGetErrorString(result) << " at " \
+             << __FILE__ << ":" << __LINE__;                           \
+    }                                                                  \
+  } while (0)
+
+struct ShardedBandwidthResult {
+  double algoBW_GBps;
+  double busBW_GBps;
+  double latency_us;
+};
+
+// Aggregate bandwidth for multi-group all-gather. The size metric is the
+// per-group per-rank contribution (sendCount) bytes. Bus BW for an n-rank
+// all-gather uses the (n-1)/n factor (for 2 ranks this is 0.5).
+ShardedBandwidthResult calculateMultiGroupAggregateBandwidth(
+    size_t sendBytesPerGroup,
+    double elapsedMs,
+    int numActiveRanks,
+    int numGroups) {
+  ShardedBandwidthResult result;
+  double elapsedSec = elapsedMs / 1000.0;
+  double totalDataSizeGB = static_cast<double>(sendBytesPerGroup) * numGroups /
+      (1024.0 * 1024.0 * 1024.0);
+  result.algoBW_GBps = totalDataSizeGB / elapsedSec;
+  result.busBW_GBps =
+      (numActiveRanks - 1.0) / numActiveRanks * totalDataSizeGB / elapsedSec;
+  result.latency_us = elapsedMs * 1000.0;
+  return result;
+}
+
+void printMultiGroupBandwidthResults(
+    const std::string& testName,
+    size_t sendBytesPerGroup,
+    int numRanks,
+    int numGroups,
+    int activeRanksPerGroup,
+    const ShardedBandwidthResult& aggregateResult,
+    bool isInPlace) {
+  double dataSizePerGroupGB =
+      static_cast<double>(sendBytesPerGroup) / (1024.0 * 1024.0 * 1024.0);
+  double totalDataSizeGB = dataSizePerGroupGB * numGroups;
+  double perGroupAlgoBW = aggregateResult.algoBW_GBps / numGroups;
+  double perGroupBusBW = aggregateResult.busBW_GBps / numGroups;
+
+  std::cout << "\n";
+  std::cout << "====================================================\n";
+  std::cout << "Multi-Group Sharded Relay All-Gather: " << testName << "\n";
+  std::cout << "====================================================\n";
+  std::cout << std::fixed << std::setprecision(2);
+  std::cout << "  Total Ranks (np):      " << numRanks << "\n";
+  std::cout << "  Number of Groups:      " << numGroups << "\n";
+  std::cout << "  Active Ranks/Group:    " << activeRanksPerGroup << "\n";
+  std::cout << "  Helper Ranks/Group:    " << (numRanks - activeRanksPerGroup)
+            << "\n";
+  std::cout << "  In-Place:              " << (isInPlace ? "YES" : "NO")
+            << "\n";
+  std::cout << "  Data Type:             int32\n";
+  std::cout << "  Send Size/Group:       " << dataSizePerGroupGB << " GB\n";
+  std::cout << "  Total Gathered (grps): " << totalDataSizeGB << " GB\n";
+  std::cout << "  Send Count/Group:      "
+            << (sendBytesPerGroup / sizeof(int32_t)) << "\n";
+  std::cout << "----------------------------------------------------\n";
+  std::cout << "  Latency:               " << std::setprecision(3)
+            << aggregateResult.latency_us << " us\n";
+  std::cout << "----------------------------------------------------\n";
+  std::cout << "  AGGREGATE BANDWIDTH (all " << numGroups << " groups):\n";
+  std::cout << "    Algorithm BW:        " << std::setprecision(2)
+            << aggregateResult.algoBW_GBps << " GB/s\n";
+  std::cout << "    Bus BW:              " << aggregateResult.busBW_GBps
+            << " GB/s\n";
+  std::cout << "----------------------------------------------------\n";
+  std::cout << "  PER-GROUP BANDWIDTH (derived):\n";
+  std::cout << "    Algorithm BW:        " << perGroupAlgoBW << " GB/s\n";
+  std::cout << "    Bus BW:              " << perGroupBusBW << " GB/s\n";
+  std::cout << "====================================================\n\n";
+}
+
+// Test helper: forwards one contiguous send/recv buffer per group to the
+// sharded-relay all-gather entry point. Active group input = sendCount; output
+// = nActiveRanks x sendCount. All-gather may be in-place
+// (sendPtrs[g] aliases recvPtrs[g] + myActiveIndex x sendCount) or
+// out-of-place.
+static ncclResult_t callAllGatherCompat(
+    const void* const* sendPtrs,
+    void* const* recvPtrs,
+    const size_t* sendCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    hipStream_t stream,
+    const int* const* allActiveRanks,
+    int nActiveRanksPerGroup,
+    int nGroups) {
+  return ncclShardedRelayMultiGroupAllGather(
+      sendPtrs,
+      recvPtrs,
+      sendCounts,
+      datatype,
+      comm,
+      stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+}
+
+class ShardedRelayMultiGroupAllGatherTest : public ::testing::Test {
+ public:
+  ShardedRelayMultiGroupAllGatherTest() = default;
+
+  void SetUp() override {
+    int localSize;
+    std::tie(this->localRank, this->globalRank, this->numRanks, localSize) =
+        getTcpStoreOrMpiInfo();
+    bool isServer = (this->globalRank == 0);
+    if (checkTcpStoreEnv()) {
+      server = createTcpStore(isServer);
+    } else if (isServer) {
+      server = createTcpStore(true);
+    }
+    this->comm = createNcclComm(
+        this->globalRank,
+        this->numRanks,
+        this->localRank,
+        false,
+        nullptr,
+        server.get());
+    CUDACHECK_TEST(cudaStreamCreate(&stream));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaStreamDestroy(this->stream));
+    if (server && checkTcpStoreEnv()) {
+      finalizeNcclComm(this->globalRank, server.get());
+    }
+    NCCLCHECK_TEST(ncclCommDestroy(this->comm));
+    server.reset();
+  }
+
+  // Standard 8-rank, 4-group, 2-active-per-group sparse parallelism layout.
+  struct Standard4GroupActiveRanks {
+    int storage[4][2] = {{0, 1}, {2, 3}, {4, 5}, {6, 7}};
+    const int* allActiveRanks[4] = {
+        storage[0],
+        storage[1],
+        storage[2],
+        storage[3]};
+  };
+
+  // Distinct per-active-rank fill value so that a wrong slot offset in the
+  // implementation produces a detectable mismatch.
+  static int32_t rankFillValue(int activeIndex) {
+    return (activeIndex + 1) * 100 + 7;
+  }
+
+  // Fill `count` int32_t elements of a device region with `value`.
+  void fillDeviceRegion(int32_t* devicePtr, size_t count, int32_t value) {
+    std::vector<int32_t> host(count, value);
+    HIPCHECK_TEST(hipMemcpy(
+        devicePtr,
+        host.data(),
+        count * sizeof(int32_t),
+        hipMemcpyHostToDevice));
+  }
+
+  // Run a 1-element ncclAllReduce on `scratchBuffer` to act as a cross-rank
+  // barrier.
+  void barrierSyncOn(int32_t* /*unused*/) {
+    // Run the barrier all-reduce on a dedicated scratch allocation rather than
+    // a caller buffer. Several tests pass a buffer that they immediately
+    // (re)initialize and feed to the collective under test; running the barrier
+    // all-reduce on that same buffer is a write-after-write hazard on element 0
+    // (the all-reduce's device write is not guaranteed to be retired before the
+    // subsequent host-side init), which can leave element 0 holding the barrier
+    // value (0) instead of the init value and produces flaky "expected X but
+    // got 0" mismatches.
+    int32_t* barrierScratch = nullptr;
+    HIPCHECK_TEST(hipMalloc(&barrierScratch, sizeof(int32_t)));
+    HIPCHECK_TEST(hipMemset(barrierScratch, 0, sizeof(int32_t)));
+    NCCLCHECK_TEST(ncclAllReduce(
+        barrierScratch,
+        barrierScratch,
+        1,
+        ncclInt32,
+        ncclSum,
+        this->comm,
+        this->stream));
+    HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+    HIPCHECK_TEST(hipFree(barrierScratch));
+  }
+
+  // Copy `count` int32_t elements from `deviceBuffer` to host and verify they
+  // all equal `expectedValue`. Returns the number of mismatches (0 on success).
+  int verifyDeviceBufferEquals(
+      const int32_t* deviceBuffer,
+      size_t count,
+      int32_t expectedValue,
+      int groupIndex,
+      const char* failureMessage) {
+    std::vector<int32_t> hostOutput(count);
+    hipError_t hipErr = hipMemcpy(
+        hostOutput.data(),
+        deviceBuffer,
+        count * sizeof(int32_t),
+        hipMemcpyDeviceToHost);
+    if (hipErr != hipSuccess) {
+      ADD_FAILURE() << "HIP error in verifyDeviceBufferEquals: "
+                    << hipGetErrorString(hipErr) << " at " << __FILE__ << ":"
+                    << __LINE__;
+      return -1;
+    }
+
+    int errorCount = 0;
+    for (size_t i = 0; i < count && errorCount < 10; ++i) {
+      if (hostOutput[i] != expectedValue) {
+        std::cout << "R" << this->globalRank << ": Group " << groupIndex
+                  << " Mismatch at index " << i << ": expected "
+                  << expectedValue << " but got " << hostOutput[i] << std::endl;
+        errorCount++;
+      }
+    }
+    EXPECT_EQ(errorCount, 0) << failureMessage;
+    return errorCount;
+  }
+
+  // Verify both gathered slots of an active rank's recvBuff:
+  //   recvBuff[i x sendCount] == rankFillValue(i).
+  void verifyAllGatherOutput(
+      const int32_t* recvBuff,
+      size_t sendCount,
+      int groupIndex) {
+    verifyDeviceBufferEquals(
+        recvBuff,
+        sendCount,
+        rankFillValue(0),
+        groupIndex,
+        "Found mismatches in all-gather slot[0]");
+    verifyDeviceBufferEquals(
+        recvBuff + sendCount,
+        sendCount,
+        rankFillValue(1),
+        groupIndex,
+        "Found mismatches in all-gather slot[1]");
+  }
+
+  int localRank{0};
+  int globalRank{0};
+  int numRanks{0};
+  ncclComm_t comm;
+  cudaStream_t stream;
+  std::unique_ptr<c10d::TCPStore> server{nullptr};
+};
+
+/**
+ * Test: Multi-Group Correctness with 4 groups (OUT-OF-PLACE)
+ *
+ * Active sendBuff holds sendCount elements filled with rankFillValue(m);
+ * recvBuff holds 2 x sendCount. Expected recvBuff slot i = rankFillValue(i).
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllGatherTest,
+    Correctness_4Groups_OutOfPlace_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t sendBytes = 64ULL * 1024 * 1024;
+  const size_t sendCount = sendBytes / sizeof(int32_t);
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], sendBytes)); // 1 segment
+      HIPCHECK_TEST(
+          hipMalloc(&recvBuffs[g], static_cast<size_t>(2) * sendBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g]; // helper: same buffer for send/recv
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      fillDeviceRegion(sendBuffs[g], sendCount, rankFillValue(myActiveIndex));
+      HIPCHECK_TEST(
+          hipMemset(recvBuffs[g], 0, static_cast<size_t>(2) * sendBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t sendCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+    sendCounts[g] = sendCount;
+  }
+
+  ncclResult_t result = callAllGatherCompat(
+      sendPtrs,
+      recvPtrs,
+      sendCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyAllGatherOutput(recvBuffs[myActiveGroup], sendCount, myActiveGroup);
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+/**
+ * Test: Multi-Group Correctness with 4 groups (IN-PLACE)
+ *
+ * In-place all-gather: sendBuff aliases recvBuff + myActiveIndex x sendCount.
+ */
+TEST_F(ShardedRelayMultiGroupAllGatherTest, Correctness_4Groups_InPlace_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t sendBytes = 64ULL * 1024 * 1024;
+  const size_t sendCount = sendBytes / sizeof(int32_t);
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  // Active rank: one recvBuff (2 x sendBytes); sendBuff aliases its own slot.
+  // Helpers: two-slot scratch buffer.
+  int32_t* recvBuffs[nGroups];
+
+  for (int g = 0; g < nGroups; g++) {
+    size_t bufSize = static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+    HIPCHECK_TEST(hipMalloc(&recvBuffs[g], bufSize));
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      // Zero the whole recvBuff, then fill my own slot in place.
+      HIPCHECK_TEST(
+          hipMemset(recvBuffs[g], 0, static_cast<size_t>(2) * sendBytes));
+      size_t ownSlotOffset = static_cast<size_t>(myActiveIndex) * sendCount;
+      fillDeviceRegion(
+          recvBuffs[g] + ownSlotOffset,
+          sendCount,
+          rankFillValue(myActiveIndex));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+      HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t sendCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    recvPtrs[g] = recvBuffs[g];
+    if (g == myActiveGroup) {
+      // In-place: sendBuff == recvBuff + myActiveIndex x sendCount
+      size_t ownSlotOffset = static_cast<size_t>(myActiveIndex) * sendCount;
+      sendPtrs[g] = recvBuffs[g] + ownSlotOffset;
+    } else {
+      sendPtrs[g] = recvBuffs[g];
+    }
+    sendCounts[g] = sendCount;
+  }
+
+  ncclResult_t result = callAllGatherCompat(
+      sendPtrs,
+      recvPtrs,
+      sendCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyAllGatherOutput(recvBuffs[myActiveGroup], sendCount, myActiveGroup);
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(recvBuffs[g]));
+  }
+}
+
+/**
+ * Test: Single group via multi-group API (OUT-OF-PLACE)
+ */
+TEST_F(ShardedRelayMultiGroupAllGatherTest, Correctness_SingleGroup_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 1;
+  const int nActiveRanksPerGroup = 2;
+  const size_t sendBytes = 64ULL * 1024 * 1024;
+  const size_t sendCount = sendBytes / sizeof(int32_t);
+
+  const int activeRanks[] = {0, 1};
+  const int* allActiveRanks[] = {activeRanks};
+
+  bool isActive = (this->globalRank == 0 || this->globalRank == 1);
+  int myActiveIndex = this->globalRank; // 0 or 1 for active ranks
+
+  int32_t* sendBuff = nullptr;
+  int32_t* recvBuff = nullptr;
+  if (isActive) {
+    HIPCHECK_TEST(hipMalloc(&sendBuff, sendBytes));
+    HIPCHECK_TEST(hipMalloc(&recvBuff, static_cast<size_t>(2) * sendBytes));
+  } else {
+    size_t helperBufferSize =
+        static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+    HIPCHECK_TEST(hipMalloc(&sendBuff, helperBufferSize));
+    recvBuff = sendBuff;
+  }
+
+  barrierSyncOn(sendBuff);
+
+  if (isActive) {
+    fillDeviceRegion(sendBuff, sendCount, rankFillValue(myActiveIndex));
+    HIPCHECK_TEST(hipMemset(recvBuff, 0, static_cast<size_t>(2) * sendBytes));
+  } else {
+    size_t helperBufferSize =
+        static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+    HIPCHECK_TEST(hipMemset(sendBuff, 0, helperBufferSize));
+  }
+
+  const void* sendPtrs[1];
+  void* recvPtrs[1];
+  size_t sendCounts[] = {sendCount};
+  sendPtrs[0] = sendBuff;
+  recvPtrs[0] = recvBuff;
+
+  ncclResult_t result = callAllGatherCompat(
+      sendPtrs,
+      recvPtrs,
+      sendCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  if (isActive) {
+    verifyAllGatherOutput(recvBuff, sendCount, 0);
+  }
+
+  HIPCHECK_TEST(hipFree(sendBuff));
+  if (isActive) {
+    HIPCHECK_TEST(hipFree(recvBuff));
+  }
+}
+
+/**
+ * Test: Correctness with minimum passthrough helper buffers (OUT-OF-PLACE)
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllGatherTest,
+    Correctness_4Groups_PassthroughHelperEquivalence) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t sendBytes = 64ULL * 1024 * 1024;
+  const size_t sendCount = sendBytes / sizeof(int32_t);
+  const int numHelpers = this->numRanks - nActiveRanksPerGroup;
+  const int numChunks = numHelpers + 1;
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  // Minimum passthrough helper buffer size from sendCount.
+  size_t chunkSize = sendCount / numChunks;
+  chunkSize = (chunkSize / 128) * 128; // CHUNK_ALIGN_ELEMENTS
+  if (chunkSize == 0) {
+    chunkSize = sendCount;
+  }
+  size_t minHelperElements = std::min(
+      sendCount, static_cast<size_t>(nActiveRanksPerGroup) * chunkSize);
+  size_t minHelperBytes = minHelperElements * sizeof(int32_t);
+
+  int32_t* activeSendBuffer = nullptr;
+  int32_t* activeRecvBuffer = nullptr;
+  int32_t* helperBuffers[nGroups];
+
+  HIPCHECK_TEST(hipMalloc(&activeSendBuffer, sendBytes));
+  HIPCHECK_TEST(
+      hipMalloc(&activeRecvBuffer, static_cast<size_t>(2) * sendBytes));
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      helperBuffers[g] = nullptr;
+    } else {
+      HIPCHECK_TEST(hipMalloc(&helperBuffers[g], minHelperBytes));
+    }
+  }
+
+  barrierSyncOn(activeSendBuffer);
+
+  fillDeviceRegion(activeSendBuffer, sendCount, rankFillValue(myActiveIndex));
+  HIPCHECK_TEST(
+      hipMemset(activeRecvBuffer, 0, static_cast<size_t>(2) * sendBytes));
+  for (int g = 0; g < nGroups; g++) {
+    if (g != myActiveGroup) {
+      HIPCHECK_TEST(hipMemset(helperBuffers[g], 0, minHelperBytes));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t sendCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      sendPtrs[g] = activeSendBuffer;
+      recvPtrs[g] = activeRecvBuffer;
+    } else {
+      sendPtrs[g] = helperBuffers[g];
+      recvPtrs[g] = helperBuffers[g];
+    }
+    sendCounts[g] = sendCount;
+  }
+
+  ncclResult_t result = callAllGatherCompat(
+      sendPtrs,
+      recvPtrs,
+      sendCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyAllGatherOutput(activeRecvBuffer, sendCount, myActiveGroup);
+
+  HIPCHECK_TEST(hipFree(activeSendBuffer));
+  HIPCHECK_TEST(hipFree(activeRecvBuffer));
+  for (int g = 0; g < nGroups; g++) {
+    if (g != myActiveGroup) {
+      HIPCHECK_TEST(hipFree(helperBuffers[g]));
+    }
+  }
+}
+
+/**
+ * Test: Correctness_PartialGroupsZeroCount (OUT-OF-PLACE)
+ *
+ * Groups 0 and 1 have data; groups 2 and 3 pass sendCount=0 and must be skipped
+ * without crash or corruption.
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllGatherTest,
+    Correctness_PartialGroupsZeroCount) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t sendBytes = 16ULL * 1024 * 1024;
+  const size_t sendCount = sendBytes / sizeof(int32_t);
+
+  const size_t sendCounts[nGroups] = {sendCount, sendCount, 0, 0};
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  const size_t placeholderBytes = sizeof(int32_t); // 1 element
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+
+  for (int g = 0; g < nGroups; g++) {
+    if (sendCounts[g] == 0) {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], placeholderBytes));
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, placeholderBytes));
+      recvBuffs[g] = sendBuffs[g];
+      continue;
+    }
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], sendBytes));
+      HIPCHECK_TEST(
+          hipMalloc(&recvBuffs[g], static_cast<size_t>(2) * sendBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(sendBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (sendCounts[g] == 0) {
+      continue;
+    }
+    if (g == myActiveGroup) {
+      fillDeviceRegion(sendBuffs[g], sendCount, rankFillValue(myActiveIndex));
+      HIPCHECK_TEST(
+          hipMemset(recvBuffs[g], 0, static_cast<size_t>(2) * sendBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+  }
+
+  ncclResult_t result = callAllGatherCompat(
+      sendPtrs,
+      recvPtrs,
+      sendCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess)
+      << "ncclShardedRelayMultiGroupAllGather failed with partial sendCount=0 groups";
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  if (myActiveGroup < 2) { // groups 0 and 1 had data
+    verifyAllGatherOutput(recvBuffs[myActiveGroup], sendCount, myActiveGroup);
+  }
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (sendCounts[g] != 0 && g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+/**
+ * Test: BusBW with 4-group Multi-Group All-Gather (1GB send, OUT-OF-PLACE)
+ */
+TEST_F(ShardedRelayMultiGroupAllGatherTest, Z_BusBW_4Groups_OutOfPlace_1GB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t sendBytes = 1ULL * 1024 * 1024 * 1024; // 1 GB send/group
+  const size_t sendCount = sendBytes / sizeof(int32_t);
+  const int nIters = 20;
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], sendBytes));
+      HIPCHECK_TEST(
+          hipMalloc(&recvBuffs[g], static_cast<size_t>(2) * sendBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 1, sendBytes));
+      HIPCHECK_TEST(
+          hipMemset(recvBuffs[g], 0, static_cast<size_t>(2) * sendBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t sendCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+    sendCounts[g] = sendCount;
+  }
+
+  hipEvent_t startEvent, stopEvent;
+  HIPCHECK_TEST(hipEventCreate(&startEvent));
+  HIPCHECK_TEST(hipEventCreate(&stopEvent));
+
+  float bestTimeMs = std::numeric_limits<float>::max();
+  float totalTimeMs = 0.0f;
+
+  if (this->globalRank == 0) {
+    std::cout << "[Benchmark] Running " << nIters << " iterations..."
+              << std::endl;
+  }
+
+  for (int iter = 0; iter < nIters; iter++) {
+    HIPCHECK_TEST(hipEventRecord(startEvent, this->stream));
+    ncclResult_t result = callAllGatherCompat(
+        sendPtrs,
+        recvPtrs,
+        sendCounts,
+        ncclInt32,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipEventRecord(stopEvent, this->stream));
+    HIPCHECK_TEST(hipEventSynchronize(stopEvent));
+
+    float elapsedMs = 0.0f;
+    HIPCHECK_TEST(hipEventElapsedTime(&elapsedMs, startEvent, stopEvent));
+
+    if (this->globalRank == 0) {
+      std::cout << "  Iteration " << (iter + 1) << ": " << elapsedMs << " ms"
+                << std::endl;
+    }
+
+    if (elapsedMs < bestTimeMs) {
+      bestTimeMs = elapsedMs;
+    }
+    totalTimeMs += elapsedMs;
+  }
+
+  float avgTimeMs = totalTimeMs / nIters;
+
+  if (this->globalRank == 0) {
+    std::cout << "\n[Benchmark] Best time: " << bestTimeMs << " ms, "
+              << "Avg time: " << avgTimeMs << " ms" << std::endl;
+
+    ShardedBandwidthResult bwResult = calculateMultiGroupAggregateBandwidth(
+        sendBytes, bestTimeMs, nActiveRanksPerGroup, nGroups);
+    printMultiGroupBandwidthResults(
+        "4-Group OUT-OF-PLACE 1GB",
+        sendBytes,
+        this->numRanks,
+        nGroups,
+        nActiveRanksPerGroup,
+        bwResult,
+        false);
+  }
+
+  HIPCHECK_TEST(hipEventDestroy(startEvent));
+  HIPCHECK_TEST(hipEventDestroy(stopEvent));
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+/**
+ * Test: BusBW with 4-group Multi-Group All-Gather (1GB send, IN-PLACE)
+ */
+TEST_F(ShardedRelayMultiGroupAllGatherTest, Z_BusBW_4Groups_InPlace_1GB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t sendBytes = 1ULL * 1024 * 1024 * 1024; // 1 GB send/group
+  const size_t sendCount = sendBytes / sizeof(int32_t);
+  const int nIters = 20;
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    size_t bufSize = static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+    HIPCHECK_TEST(hipMalloc(&recvBuffs[g], bufSize));
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    size_t bufSize = static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+    HIPCHECK_TEST(hipMemset(recvBuffs[g], 1, bufSize));
+  }
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t sendCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    recvPtrs[g] = recvBuffs[g];
+    if (g == myActiveGroup) {
+      size_t ownSlotOffset = static_cast<size_t>(myActiveIndex) * sendCount;
+      sendPtrs[g] = recvBuffs[g] + ownSlotOffset;
+    } else {
+      sendPtrs[g] = recvBuffs[g];
+    }
+    sendCounts[g] = sendCount;
+  }
+
+  hipEvent_t startEvent, stopEvent;
+  HIPCHECK_TEST(hipEventCreate(&startEvent));
+  HIPCHECK_TEST(hipEventCreate(&stopEvent));
+
+  float bestTimeMs = std::numeric_limits<float>::max();
+  float totalTimeMs = 0.0f;
+
+  if (this->globalRank == 0) {
+    std::cout << "[Benchmark] Running " << nIters << " iterations..."
+              << std::endl;
+  }
+
+  for (int iter = 0; iter < nIters; iter++) {
+    HIPCHECK_TEST(hipEventRecord(startEvent, this->stream));
+    ncclResult_t result = callAllGatherCompat(
+        sendPtrs,
+        recvPtrs,
+        sendCounts,
+        ncclInt32,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipEventRecord(stopEvent, this->stream));
+    HIPCHECK_TEST(hipEventSynchronize(stopEvent));
+
+    float elapsedMs = 0.0f;
+    HIPCHECK_TEST(hipEventElapsedTime(&elapsedMs, startEvent, stopEvent));
+
+    if (this->globalRank == 0) {
+      std::cout << "  Iteration " << (iter + 1) << ": " << elapsedMs << " ms"
+                << std::endl;
+    }
+
+    if (elapsedMs < bestTimeMs) {
+      bestTimeMs = elapsedMs;
+    }
+    totalTimeMs += elapsedMs;
+  }
+
+  float avgTimeMs = totalTimeMs / nIters;
+
+  if (this->globalRank == 0) {
+    std::cout << "\n[Benchmark] Best time: " << bestTimeMs << " ms, "
+              << "Avg time: " << avgTimeMs << " ms" << std::endl;
+
+    ShardedBandwidthResult bwResult = calculateMultiGroupAggregateBandwidth(
+        sendBytes, bestTimeMs, nActiveRanksPerGroup, nGroups);
+    printMultiGroupBandwidthResults(
+        "4-Group IN-PLACE 1GB",
+        sendBytes,
+        this->numRanks,
+        nGroups,
+        nActiveRanksPerGroup,
+        bwResult,
+        true);
+  }
+
+  HIPCHECK_TEST(hipEventDestroy(startEvent));
+  HIPCHECK_TEST(hipEventDestroy(stopEvent));
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(recvBuffs[g]));
+  }
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
@@ -309,6 +309,110 @@ class ShardedRelayMultiGroupAllGatherTest : public ::testing::Test {
     }
   }
 
+  void runOutOfPlaceRoutingCases(
+      const int* const* allActiveRanks,
+      int nActiveRanksPerGroup,
+      int nGroups,
+      const std::vector<size_t>& caseSendCounts,
+      size_t pureDirectMaxCount) {
+    int myActiveGroup = -1;
+    int myActiveIndex = -1;
+    for (int g = 0; g < nGroups; g++) {
+      for (int i = 0; i < nActiveRanksPerGroup; i++) {
+        if (allActiveRanks[g][i] == this->globalRank) {
+          myActiveGroup = g;
+          myActiveIndex = i;
+        }
+      }
+    }
+
+    constexpr int32_t kHelperSentinel = -1;
+    for (size_t sendCount : caseSendCounts) {
+      const size_t sendBytes = sendCount * sizeof(int32_t);
+      const size_t helperElements =
+          static_cast<size_t>(nActiveRanksPerGroup) * sendCount;
+      const bool expectPureDirect = sendCount < pureDirectMaxCount;
+      std::vector<int32_t*> sendBuffs(nGroups);
+      std::vector<int32_t*> recvBuffs(nGroups);
+
+      for (int g = 0; g < nGroups; g++) {
+        if (g == myActiveGroup) {
+          HIPCHECK_TEST(hipMalloc(&sendBuffs[g], sendBytes));
+          HIPCHECK_TEST(hipMalloc(
+              &recvBuffs[g],
+              static_cast<size_t>(nActiveRanksPerGroup) * sendBytes));
+        } else {
+          HIPCHECK_TEST(
+              hipMalloc(&sendBuffs[g], helperElements * sizeof(int32_t)));
+          recvBuffs[g] = sendBuffs[g];
+        }
+      }
+
+      barrierSyncOn(nullptr);
+
+      for (int g = 0; g < nGroups; g++) {
+        if (g == myActiveGroup) {
+          fillDeviceRegion(
+              sendBuffs[g], sendCount, rankFillValue(myActiveIndex));
+          HIPCHECK_TEST(hipMemset(
+              recvBuffs[g],
+              0,
+              static_cast<size_t>(nActiveRanksPerGroup) * sendBytes));
+        } else {
+          fillDeviceRegion(sendBuffs[g], helperElements, kHelperSentinel);
+        }
+      }
+
+      std::vector<const void*> sendPtrs(nGroups);
+      std::vector<void*> recvPtrs(nGroups);
+      std::vector<size_t> sendCounts(nGroups, sendCount);
+      for (int g = 0; g < nGroups; g++) {
+        sendPtrs[g] = sendBuffs[g];
+        recvPtrs[g] = recvBuffs[g];
+      }
+
+      ncclResult_t result = callAllGatherCompat(
+          sendPtrs.data(),
+          recvPtrs.data(),
+          sendCounts.data(),
+          ncclInt32,
+          this->comm,
+          this->stream,
+          allActiveRanks,
+          nActiveRanksPerGroup,
+          nGroups);
+      ASSERT_EQ(result, ncclSuccess) << "sendCount=" << sendCount;
+      HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+      if (myActiveGroup >= 0) {
+        verifyAllGatherOutput(
+            recvBuffs[myActiveGroup],
+            sendCount,
+            myActiveGroup,
+            nActiveRanksPerGroup);
+      }
+      for (int g = 0; g < nGroups; g++) {
+        if (g == myActiveGroup) {
+          continue;
+        }
+        verifyDeviceBufferEquals(
+            recvBuffs[g],
+            1,
+            expectPureDirect ? kHelperSentinel : rankFillValue(0),
+            g,
+            expectPureDirect ? "Pure-direct route modified helper storage"
+                             : "Relay route did not use helper storage");
+      }
+
+      for (int g = 0; g < nGroups; g++) {
+        HIPCHECK_TEST(hipFree(sendBuffs[g]));
+        if (g == myActiveGroup) {
+          HIPCHECK_TEST(hipFree(recvBuffs[g]));
+        }
+      }
+    }
+  }
+
   int localRank{0};
   int globalRank{0};
   int numRanks{0};
@@ -577,7 +681,7 @@ TEST_F(
   const size_t sendBytes = 64ULL * 1024 * 1024;
   const size_t sendCount = sendBytes / sizeof(int32_t);
   const int numHelpers = this->numRanks - nActiveRanksPerGroup;
-  const int numChunks = numHelpers + 1;
+  const int numChunks = numHelpers + 2;
 
   Standard4GroupActiveRanks groupConfig;
   const int* const* allActiveRanks = groupConfig.allActiveRanks;
@@ -655,6 +759,115 @@ TEST_F(
   for (int g = 0; g < nGroups; g++) {
     if (g != myActiveGroup) {
       HIPCHECK_TEST(hipFree(helperBuffers[g]));
+    }
+  }
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllGatherTest,
+    Correctness_4Groups_HeterogeneousRelayAndTiny) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t sendCounts[nGroups] = {
+      (4ULL * 1024 * 1024) / sizeof(int32_t), 511, 777, 1023};
+  const bool inPlace[nGroups] = {false, true, false, true};
+  const int numChunks = this->numRanks - nActiveRanksPerGroup + 2;
+  const int32_t helperSentinel = -1;
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    size_t sendBytes = sendCounts[g] * sizeof(int32_t);
+    size_t recvBytes = static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+    if (g != myActiveGroup) {
+      size_t chunkSize = sendCounts[g] / numChunks;
+      chunkSize = (chunkSize / 128) * 128;
+      size_t helperElements = chunkSize == 0
+          ? 1
+          : static_cast<size_t>(nActiveRanksPerGroup) * chunkSize;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperElements * sizeof(int32_t)));
+      recvBuffs[g] = sendBuffs[g];
+    } else if (inPlace[g]) {
+      HIPCHECK_TEST(hipMalloc(&recvBuffs[g], recvBytes));
+      sendBuffs[g] =
+          recvBuffs[g] + static_cast<size_t>(myActiveIndex) * sendCounts[g];
+    } else {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], sendBytes));
+      HIPCHECK_TEST(hipMalloc(&recvBuffs[g], recvBytes));
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      size_t recvBytes = static_cast<size_t>(nActiveRanksPerGroup) *
+          sendCounts[g] * sizeof(int32_t);
+      HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, recvBytes));
+      fillDeviceRegion(
+          sendBuffs[g], sendCounts[g], rankFillValue(myActiveIndex));
+      continue;
+    }
+
+    size_t chunkSize = sendCounts[g] / numChunks;
+    chunkSize = (chunkSize / 128) * 128;
+    size_t helperElements = chunkSize == 0
+        ? 1
+        : static_cast<size_t>(nActiveRanksPerGroup) * chunkSize;
+    fillDeviceRegion(
+        recvBuffs[g], helperElements, chunkSize == 0 ? helperSentinel : 0);
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+  }
+
+  ncclResult_t result = callAllGatherCompat(
+      sendPtrs,
+      recvPtrs,
+      sendCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyAllGatherOutput(
+      recvBuffs[myActiveGroup], sendCounts[myActiveGroup], myActiveGroup);
+  for (int g = 0; g < nGroups; g++) {
+    if (g != myActiveGroup && sendCounts[g] < 1024) {
+      verifyDeviceBufferEquals(
+          recvBuffs[g],
+          1,
+          helperSentinel,
+          g,
+          "Tiny-group helper buffer was modified");
+    }
+  }
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup && !inPlace[g]) {
+      HIPCHECK_TEST(hipFree(sendBuffs[g]));
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    } else {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
     }
   }
 }

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
@@ -421,6 +421,90 @@ class ShardedRelayMultiGroupAllGatherTest : public ::testing::Test {
   std::unique_ptr<c10d::TCPStore> server{nullptr};
 };
 
+TEST_F(
+    ShardedRelayMultiGroupAllGatherTest,
+    Correctness_4Groups_A2_SmallPureDirect_Unaligned) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  constexpr size_t kFusedA2ThresholdElements =
+      (2ULL * 1024 * 1024) / sizeof(int32_t);
+  Standard4GroupActiveRanks groupConfig;
+  runOutOfPlaceRoutingCases(
+      groupConfig.allActiveRanks, 2, 4, {1025}, kFusedA2ThresholdElements);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllGatherTest,
+    Correctness_4Groups_A2_FusedRoutingThresholds) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  constexpr size_t kThresholdElements = (2ULL * 1024 * 1024) / sizeof(int32_t);
+  Standard4GroupActiveRanks groupConfig;
+  runOutOfPlaceRoutingCases(
+      groupConfig.allActiveRanks,
+      2,
+      4,
+      {kThresholdElements - 1, kThresholdElements, kThresholdElements + 1},
+      kThresholdElements);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllGatherTest,
+    Correctness_SingleGroup_A2_RoutingThresholds) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  constexpr size_t kThresholdElements = (9ULL * 1024 * 1024) / sizeof(int32_t);
+  const int activeRanks[] = {0, 1};
+  const int* allActiveRanks[] = {activeRanks};
+  runOutOfPlaceRoutingCases(
+      allActiveRanks,
+      2,
+      1,
+      {kThresholdElements - 1, kThresholdElements, kThresholdElements + 1},
+      kThresholdElements);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllGatherTest,
+    Correctness_2Groups_A4_FusedRoutingThresholds) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  constexpr size_t kThresholdElements = (12ULL * 1024 * 1024) / sizeof(int32_t);
+  TwoGroupFourActiveRanks groupConfig;
+  runOutOfPlaceRoutingCases(
+      groupConfig.allActiveRanks,
+      4,
+      2,
+      {kThresholdElements - 1, kThresholdElements, kThresholdElements + 1},
+      kThresholdElements);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllGatherTest,
+    Correctness_SingleGroup_A4_RoutingThresholds) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  constexpr size_t kThresholdElements = (8ULL * 1024 * 1024) / sizeof(int32_t);
+  const int activeRanks[] = {0, 1, 2, 3};
+  const int* allActiveRanks[] = {activeRanks};
+  runOutOfPlaceRoutingCases(
+      allActiveRanks,
+      4,
+      1,
+      {kThresholdElements - 1, kThresholdElements, kThresholdElements + 1},
+      kThresholdElements);
+}
+
 /**
  * Test: Multi-Group Correctness with 4 groups (OUT-OF-PLACE)
  *

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
@@ -208,6 +208,14 @@ class ShardedRelayMultiGroupAllGatherTest : public ::testing::Test {
         storage[3]};
   };
 
+  // 8-rank, 2-group, 4-active-per-group layout for the 4-active recursive path:
+  //   Group 0: activeRanks = {0, 1, 2, 3}, helpers = {4, 5, 6, 7}
+  //   Group 1: activeRanks = {4, 5, 6, 7}, helpers = {0, 1, 2, 3}
+  struct TwoGroupFourActiveRanks {
+    int storage[2][4] = {{0, 1, 2, 3}, {4, 5, 6, 7}};
+    const int* allActiveRanks[2] = {storage[0], storage[1]};
+  };
+
   // Distinct per-active-rank fill value so that a wrong slot offset in the
   // implementation produces a detectable mismatch.
   static int32_t rankFillValue(int activeIndex) {
@@ -284,24 +292,21 @@ class ShardedRelayMultiGroupAllGatherTest : public ::testing::Test {
     return errorCount;
   }
 
-  // Verify both gathered slots of an active rank's recvBuff:
+  // Verify all gathered slots of an active rank's recvBuff:
   //   recvBuff[i x sendCount] == rankFillValue(i).
   void verifyAllGatherOutput(
       const int32_t* recvBuff,
       size_t sendCount,
-      int groupIndex) {
-    verifyDeviceBufferEquals(
-        recvBuff,
-        sendCount,
-        rankFillValue(0),
-        groupIndex,
-        "Found mismatches in all-gather slot[0]");
-    verifyDeviceBufferEquals(
-        recvBuff + sendCount,
-        sendCount,
-        rankFillValue(1),
-        groupIndex,
-        "Found mismatches in all-gather slot[1]");
+      int groupIndex,
+      int nActiveRanks = 2) {
+    for (int i = 0; i < nActiveRanks; i++) {
+      verifyDeviceBufferEquals(
+          recvBuff + static_cast<size_t>(i) * sendCount,
+          sendCount,
+          rankFillValue(i),
+          groupIndex,
+          "Found mismatches in all-gather slot[i]");
+    }
   }
 
   int localRank{0};
@@ -996,6 +1001,481 @@ TEST_F(ShardedRelayMultiGroupAllGatherTest, Z_BusBW_4Groups_InPlace_1GB) {
   HIPCHECK_TEST(hipEventDestroy(stopEvent));
   for (int g = 0; g < nGroups; g++) {
     HIPCHECK_TEST(hipFree(recvBuffs[g]));
+  }
+}
+
+/**
+ * 4-ACTIVE tests (2 groups of 4 active ranks each).
+ *   Group 0: active {0,1,2,3}, helpers {4,5,6,7}
+ *   Group 1: active {4,5,6,7}, helpers {0,1,2,3}
+ *
+ * Each active rank's sendBuff (sendCount) is filled with rankFillValue(mi);
+ * recvBuff holds A=4 slots of sendCount. After the all-gather, every active
+ * rank's recvBuff slot i must equal rankFillValue(i), so a wrong bit-reversal /
+ * slot mapping in the recursive-doubling path is detected.
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllGatherTest,
+    Correctness_4Active_2Groups_OutOfPlace) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t sendBytes = 64ULL * 1024 * 1024;
+  const size_t sendCount = sendBytes / sizeof(int32_t);
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], sendBytes)); // 1 segment
+      HIPCHECK_TEST(hipMalloc(
+          &recvBuffs[g],
+          static_cast<size_t>(nActiveRanksPerGroup) * sendBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      fillDeviceRegion(sendBuffs[g], sendCount, rankFillValue(myActiveIndex));
+      HIPCHECK_TEST(hipMemset(
+          recvBuffs[g],
+          0,
+          static_cast<size_t>(nActiveRanksPerGroup) * sendBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t sendCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+    sendCounts[g] = sendCount;
+  }
+
+  ncclResult_t result = callAllGatherCompat(
+      sendPtrs,
+      recvPtrs,
+      sendCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyAllGatherOutput(
+      recvBuffs[myActiveGroup], sendCount, myActiveGroup, nActiveRanksPerGroup);
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllGatherTest,
+    Correctness_4Active_2Groups_InPlace) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t sendBytes = 64ULL * 1024 * 1024;
+  const size_t sendCount = sendBytes / sizeof(int32_t);
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  // Active rank: one recvBuff (A x sendBytes); sendBuff aliases its own slot.
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    size_t bufSize = static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+    HIPCHECK_TEST(hipMalloc(&recvBuffs[g], bufSize));
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    size_t bufSize = static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, bufSize));
+      size_t ownSlotOffset = static_cast<size_t>(myActiveIndex) * sendCount;
+      fillDeviceRegion(
+          recvBuffs[g] + ownSlotOffset,
+          sendCount,
+          rankFillValue(myActiveIndex));
+    } else {
+      HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, bufSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t sendCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    recvPtrs[g] = recvBuffs[g];
+    if (g == myActiveGroup) {
+      // In-place: sendBuff == recvBuff + myActiveIndex x sendCount
+      size_t ownSlotOffset = static_cast<size_t>(myActiveIndex) * sendCount;
+      sendPtrs[g] = recvBuffs[g] + ownSlotOffset;
+    } else {
+      sendPtrs[g] = recvBuffs[g];
+    }
+    sendCounts[g] = sendCount;
+  }
+
+  ncclResult_t result = callAllGatherCompat(
+      sendPtrs,
+      recvPtrs,
+      sendCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyAllGatherOutput(
+      recvBuffs[myActiveGroup], sendCount, myActiveGroup, nActiveRanksPerGroup);
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(recvBuffs[g]));
+  }
+}
+
+/**
+ * Tiny-segment regression: forces the relay csz==0 path for 4 active ranks.
+ * With sendCount=512 the working buffer count = A*sendCount = 2048: pR=1024,
+ * the largest relay half xg=512, csz=align(512/5)=0, so each recursive-doubling
+ * step exchanges the whole half directly with the partner. The send and recv of
+ * that swap MUST share one ncclGroup or it deadlocks. The direct all-to-all D
+ * region (pD=1024) is also exercised.
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllGatherTest,
+    Correctness_4Active_2Groups_TinyCsz0_OutOfPlace) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t sendCount = 512; // count = A*sendCount = 2048 -> relay csz == 0
+  const size_t sendBytes = sendCount * sizeof(int32_t);
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    size_t helperBufferSize =
+        static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], sendBytes));
+      HIPCHECK_TEST(hipMalloc(&recvBuffs[g], helperBufferSize));
+    } else {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    size_t helperBufferSize =
+        static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+    if (g == myActiveGroup) {
+      fillDeviceRegion(sendBuffs[g], sendCount, rankFillValue(myActiveIndex));
+      HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, helperBufferSize));
+    } else {
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t sendCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+    sendCounts[g] = sendCount;
+  }
+
+  ncclResult_t result = callAllGatherCompat(
+      sendPtrs,
+      recvPtrs,
+      sendCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyAllGatherOutput(
+      recvBuffs[myActiveGroup], sendCount, myActiveGroup, nActiveRanksPerGroup);
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+/**
+ * Partial-zero-count regression for 4 active ranks: group 0 has data, group 1
+ * passes sendCount=0 and must be skipped without crash/corruption.
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllGatherTest,
+    Correctness_4Active_PartialGroupsZeroCount) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t sendBytes = 16ULL * 1024 * 1024;
+  const size_t sendCount = sendBytes / sizeof(int32_t);
+
+  const size_t sendCounts[nGroups] = {sendCount, 0};
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  const size_t placeholderBytes = sizeof(int32_t);
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (sendCounts[g] == 0) {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], placeholderBytes));
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, placeholderBytes));
+      recvBuffs[g] = sendBuffs[g];
+      continue;
+    }
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], sendBytes));
+      HIPCHECK_TEST(hipMalloc(
+          &recvBuffs[g],
+          static_cast<size_t>(nActiveRanksPerGroup) * sendBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(sendBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (sendCounts[g] == 0) {
+      continue;
+    }
+    if (g == myActiveGroup) {
+      fillDeviceRegion(sendBuffs[g], sendCount, rankFillValue(myActiveIndex));
+      HIPCHECK_TEST(hipMemset(
+          recvBuffs[g],
+          0,
+          static_cast<size_t>(nActiveRanksPerGroup) * sendBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+  }
+
+  ncclResult_t result = callAllGatherCompat(
+      sendPtrs,
+      recvPtrs,
+      sendCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess)
+      << "4-active all-gather failed with a partial sendCount=0 group";
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  if (myActiveGroup == 0) { // group 0 had data
+    verifyAllGatherOutput(
+        recvBuffs[myActiveGroup],
+        sendCount,
+        myActiveGroup,
+        nActiveRanksPerGroup);
+  }
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (sendCounts[g] != 0 && g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+/**
+ * BusBW with 4-active 2-group all-gather (1GB send, OUT-OF-PLACE).
+ *
+ * A 4-active all-gather active rank holds an A-slot recvBuff plus an A-slot
+ * working buffer; 1GB keeps the per-rank footprint inside a shared devgpu/CI
+ * memory budget.
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllGatherTest,
+    Z_BusBW_4Active_2Groups_OutOfPlace_1GB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t sendBytes = 1ULL * 1024 * 1024 * 1024; // 1 GB send/group
+  const size_t sendCount = sendBytes / sizeof(int32_t);
+  const int nIters = 20;
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    size_t helperBufferSize =
+        static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], sendBytes));
+      HIPCHECK_TEST(hipMalloc(&recvBuffs[g], helperBufferSize));
+    } else {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    size_t helperBufferSize =
+        static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 1, sendBytes));
+      HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, helperBufferSize));
+    } else {
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t sendCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+    sendCounts[g] = sendCount;
+  }
+
+  hipEvent_t startEvent, stopEvent;
+  HIPCHECK_TEST(hipEventCreate(&startEvent));
+  HIPCHECK_TEST(hipEventCreate(&stopEvent));
+
+  float bestTimeMs = std::numeric_limits<float>::max();
+  float totalTimeMs = 0.0f;
+
+  for (int iter = 0; iter < nIters; iter++) {
+    HIPCHECK_TEST(hipEventRecord(startEvent, this->stream));
+    ncclResult_t result = callAllGatherCompat(
+        sendPtrs,
+        recvPtrs,
+        sendCounts,
+        ncclInt32,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipEventRecord(stopEvent, this->stream));
+    HIPCHECK_TEST(hipEventSynchronize(stopEvent));
+
+    float elapsedMs = 0.0f;
+    HIPCHECK_TEST(hipEventElapsedTime(&elapsedMs, startEvent, stopEvent));
+    if (elapsedMs < bestTimeMs) {
+      bestTimeMs = elapsedMs;
+    }
+    totalTimeMs += elapsedMs;
+  }
+
+  if (this->globalRank == 0) {
+    ShardedBandwidthResult bwResult = calculateMultiGroupAggregateBandwidth(
+        sendBytes, bestTimeMs, nActiveRanksPerGroup, nGroups);
+    printMultiGroupBandwidthResults(
+        "4-Active 2-Group OUT-OF-PLACE 1GB",
+        sendBytes,
+        this->numRanks,
+        nGroups,
+        nActiveRanksPerGroup,
+        bwResult,
+        false);
+  }
+
+  HIPCHECK_TEST(hipEventDestroy(startEvent));
+  HIPCHECK_TEST(hipEventDestroy(stopEvent));
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
   }
 }
 

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
@@ -166,6 +166,33 @@ void printMultiGroupBandwidthResults(
   std::cout << "====================================================\n\n";
 }
 
+// Test helper: forwards one contiguous send/recv buffer per group to the
+// sharded-relay allreduce entry point. Allreduce may be in-place
+// (sendPtrs[g] == recvPtrs[g]) or out-of-place (distinct buffers).
+static ncclResult_t callAllReduceCompat(
+    const void* const* sendPtrs,
+    void* const* recvPtrs,
+    const size_t* counts,
+    ncclDataType_t datatype,
+    ncclRedOp_t op,
+    ncclComm_t comm,
+    hipStream_t stream,
+    const int* const* allActiveRanks,
+    int nActiveRanksPerGroup,
+    int nGroups) {
+  return ncclShardedRelayMultiGroupAllReduce(
+      sendPtrs,
+      recvPtrs,
+      counts,
+      datatype,
+      op,
+      comm,
+      stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+}
+
 class ShardedRelayMultiGroupAllReduceTest : public ::testing::Test {
  public:
   ShardedRelayMultiGroupAllReduceTest() = default;
@@ -216,20 +243,39 @@ class ShardedRelayMultiGroupAllReduceTest : public ::testing::Test {
         storage[3]};
   };
 
+  // 8-rank, 2-group, 4-active-per-group layout for the 4-active path:
+  //   Group 0: activeRanks = {0, 1, 2, 3}, helpers = {4, 5, 6, 7}
+  //   Group 1: activeRanks = {4, 5, 6, 7}, helpers = {0, 1, 2, 3}
+  struct TwoGroupFourActiveRanks {
+    int storage[2][4] = {{0, 1, 2, 3}, {4, 5, 6, 7}};
+    const int* allActiveRanks[2] = {storage[0], storage[1]};
+  };
+
   // Run a 1-element ncclAllReduce on `scratchBuffer` to act as a cross-rank
   // barrier (ensuring all ranks reach this point before proceeding with
   // benchmark / correctness work).
-  void barrierSyncOn(int32_t* scratchBuffer) {
-    HIPCHECK_TEST(hipMemset(scratchBuffer, 0, sizeof(int32_t)));
+  void barrierSyncOn(int32_t* /*unused*/) {
+    // Run the barrier all-reduce on a dedicated scratch allocation rather than
+    // a caller buffer. Several tests pass a buffer that they immediately
+    // (re)initialize and feed to the collective under test; running the barrier
+    // all-reduce on that same buffer is a write-after-write hazard on element 0
+    // (the all-reduce's device write is not guaranteed to be retired before the
+    // subsequent host-side init), which can leave element 0 holding the barrier
+    // value (0) instead of the init value and produces flaky "expected X but
+    // got 0" mismatches.
+    int32_t* barrierScratch = nullptr;
+    HIPCHECK_TEST(hipMalloc(&barrierScratch, sizeof(int32_t)));
+    HIPCHECK_TEST(hipMemset(barrierScratch, 0, sizeof(int32_t)));
     NCCLCHECK_TEST(ncclAllReduce(
-        scratchBuffer,
-        scratchBuffer,
+        barrierScratch,
+        barrierScratch,
         1,
         ncclInt32,
         ncclSum,
         this->comm,
         this->stream));
     HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+    HIPCHECK_TEST(hipFree(barrierScratch));
   }
 
   // Copy `count` int32_t elements from `deviceBuffer` to host and verify
@@ -1118,6 +1164,536 @@ TEST_F(
   }
   // Ranks 4-7 (active for groups 2,3 with count=0) have nothing to verify.
 
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(buffers[g]));
+  }
+}
+
+/**
+ * 4-ACTIVE tests (2 groups of 4 active ranks each).
+ *   Group 0: active {0,1,2,3}, helpers {4,5,6,7}
+ *   Group 1: active {4,5,6,7}, helpers {0,1,2,3}
+ * Each active rank fills its buffer with a distinct value (myActiveIndex+1) so
+ * the SUM (1+2+3+4 = 10) detects a missing partner / mis-routed contribution.
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllReduceTest,
+    Correctness_4Active_2Groups_InPlace) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t dataBytes = 64ULL * 1024 * 1024;
+  const size_t count = dataBytes / sizeof(int32_t);
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* buffers[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(&buffers[g], dataBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMalloc(&buffers[g], helperBufferSize));
+    }
+  }
+
+  barrierSyncOn(buffers[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      std::vector<int32_t> hostData(count, myActiveIndex + 1);
+      HIPCHECK_TEST(hipMemcpy(
+          buffers[g], hostData.data(), dataBytes, hipMemcpyHostToDevice));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMemset(buffers[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t counts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = buffers[g];
+    recvPtrs[g] = buffers[g];
+    counts[g] = count;
+  }
+
+  ncclResult_t result = callAllReduceCompat(
+      sendPtrs,
+      recvPtrs,
+      counts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  // Expected SUM across 4 active ranks = 1+2+3+4 = 10.
+  verifyDeviceBufferEquals(
+      buffers[myActiveGroup],
+      count,
+      10,
+      myActiveGroup,
+      "4-active in-place SUM mismatch (expected 10)");
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(buffers[g]));
+  }
+}
+
+/**
+ * Tiny-count regression: forces the relay csz==0 path (no helper sub-sharding)
+ * for 4 active ranks. At count=2048: pR=1024, xg=512, csz=align(512/5)=0, so
+ * the recursive-halving step exchanges the whole half directly with the
+ * partner. The send and recv of that swap MUST share one ncclGroup; a prior bug
+ * split them across phases (send in phase 0, recv in phase 1) and deadlocked on
+ * GPU.
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllReduceTest,
+    Correctness_4Active_2Groups_TinyCsz0_InPlace) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t count = 2048; // small enough that relay csz == 0
+  const size_t dataBytes = count * sizeof(int32_t);
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* buffers[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(&buffers[g], dataBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMalloc(&buffers[g], helperBufferSize));
+    }
+  }
+
+  barrierSyncOn(buffers[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      std::vector<int32_t> hostData(count, myActiveIndex + 1);
+      HIPCHECK_TEST(hipMemcpy(
+          buffers[g], hostData.data(), dataBytes, hipMemcpyHostToDevice));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMemset(buffers[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t counts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = buffers[g];
+    recvPtrs[g] = buffers[g];
+    counts[g] = count;
+  }
+
+  ncclResult_t result = callAllReduceCompat(
+      sendPtrs,
+      recvPtrs,
+      counts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  // SUM across 4 active ranks = 1+2+3+4 = 10.
+  verifyDeviceBufferEquals(
+      buffers[myActiveGroup],
+      count,
+      10,
+      myActiveGroup,
+      "4-active tiny csz==0 SUM mismatch (expected 10)");
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(buffers[g]));
+  }
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllReduceTest,
+    Correctness_4Active_2Groups_OutOfPlace) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t dataBytes = 64ULL * 1024 * 1024;
+  const size_t count = dataBytes / sizeof(int32_t);
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], dataBytes));
+      HIPCHECK_TEST(hipMalloc(&recvBuffs[g], dataBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      std::vector<int32_t> hostData(count, myActiveIndex + 1);
+      HIPCHECK_TEST(hipMemcpy(
+          sendBuffs[g], hostData.data(), dataBytes, hipMemcpyHostToDevice));
+      HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, dataBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t counts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+    counts[g] = count;
+  }
+
+  ncclResult_t result = callAllReduceCompat(
+      sendPtrs,
+      recvPtrs,
+      counts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyDeviceBufferEquals(
+      recvBuffs[myActiveGroup],
+      count,
+      10,
+      myActiveGroup,
+      "4-active out-of-place SUM mismatch (expected 10)");
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+TEST_F(ShardedRelayMultiGroupAllReduceTest, Correctness_4Active_2Groups_Avg) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t dataBytes = 64ULL * 1024 * 1024;
+  const size_t count = dataBytes / sizeof(int32_t);
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* buffers[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(&buffers[g], dataBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMalloc(&buffers[g], helperBufferSize));
+    }
+  }
+
+  barrierSyncOn(buffers[0]);
+
+  // Values 2,4,6,8 -> sum 20, AVG (divisor=4) = 5 (exact in int32). A wrong
+  // divisor (e.g. 2) would give 10, detecting that AVG uses nActiveRanks.
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      std::vector<int32_t> hostData(count, (myActiveIndex + 1) * 2);
+      HIPCHECK_TEST(hipMemcpy(
+          buffers[g], hostData.data(), dataBytes, hipMemcpyHostToDevice));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMemset(buffers[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t counts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = buffers[g];
+    recvPtrs[g] = buffers[g];
+    counts[g] = count;
+  }
+
+  ncclResult_t result = callAllReduceCompat(
+      sendPtrs,
+      recvPtrs,
+      counts,
+      ncclInt32,
+      ncclAvg,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyDeviceBufferEquals(
+      buffers[myActiveGroup],
+      count,
+      5,
+      myActiveGroup,
+      "4-active AVG mismatch (expected 5 = (2+4+6+8)/4)");
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(buffers[g]));
+  }
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllReduceTest,
+    Correctness_4Active_PartialGroupsZeroCount) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t dataBytes = 16ULL * 1024 * 1024;
+  const size_t count = dataBytes / sizeof(int32_t);
+
+  // Group 0 has data; group 1 has count = 0 (skipped).
+  const size_t counts[nGroups] = {count, 0};
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  const size_t placeholderBytes = sizeof(int32_t);
+  int32_t* buffers[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] == 0) {
+      HIPCHECK_TEST(hipMalloc(&buffers[g], placeholderBytes));
+      HIPCHECK_TEST(hipMemset(buffers[g], 0, placeholderBytes));
+      continue;
+    }
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(&buffers[g], dataBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMalloc(&buffers[g], helperBufferSize));
+    }
+  }
+
+  barrierSyncOn(buffers[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] == 0) {
+      continue;
+    }
+    if (g == myActiveGroup) {
+      std::vector<int32_t> hostData(count, myActiveIndex + 1);
+      HIPCHECK_TEST(hipMemcpy(
+          buffers[g], hostData.data(), dataBytes, hipMemcpyHostToDevice));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMemset(buffers[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = buffers[g];
+    recvPtrs[g] = buffers[g];
+  }
+
+  ncclResult_t result = callAllReduceCompat(
+      sendPtrs,
+      recvPtrs,
+      counts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess)
+      << "4-active allreduce failed with a partial count=0 group";
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  if (myActiveGroup == 0) { // group 0 had data
+    verifyDeviceBufferEquals(
+        buffers[myActiveGroup],
+        count,
+        10,
+        myActiveGroup,
+        "4-active partial-zero SUM mismatch (expected 10)");
+  }
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(buffers[g]));
+  }
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllReduceTest,
+    Z_BusBW_4Active_2Groups_InPlace_1GB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t dataBytes = 1ULL * 1024 * 1024 * 1024; // 1 GB per group
+  const size_t count = dataBytes / sizeof(int32_t);
+  const int nIters = 20;
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+
+  int32_t* buffers[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(&buffers[g], dataBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMalloc(&buffers[g], helperBufferSize));
+    }
+  }
+
+  barrierSyncOn(buffers[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMemset(buffers[g], 1, dataBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMemset(buffers[g], 0, helperBufferSize));
+    }
+  }
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t counts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = buffers[g];
+    recvPtrs[g] = buffers[g];
+    counts[g] = count;
+  }
+
+  hipEvent_t startEvent, stopEvent;
+  HIPCHECK_TEST(hipEventCreate(&startEvent));
+  HIPCHECK_TEST(hipEventCreate(&stopEvent));
+
+  float bestTimeMs = std::numeric_limits<float>::max();
+  float totalTimeMs = 0.0f;
+
+  for (int iter = 0; iter < nIters; iter++) {
+    HIPCHECK_TEST(hipEventRecord(startEvent, this->stream));
+    ncclResult_t result = callAllReduceCompat(
+        sendPtrs,
+        recvPtrs,
+        counts,
+        ncclInt32,
+        ncclSum,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipEventRecord(stopEvent, this->stream));
+    HIPCHECK_TEST(hipEventSynchronize(stopEvent));
+
+    float elapsedMs = 0.0f;
+    HIPCHECK_TEST(hipEventElapsedTime(&elapsedMs, startEvent, stopEvent));
+    if (elapsedMs < bestTimeMs) {
+      bestTimeMs = elapsedMs;
+    }
+    totalTimeMs += elapsedMs;
+  }
+
+  if (this->globalRank == 0) {
+    ShardedBandwidthResult bwResult = calculateMultiGroupAggregateBandwidth(
+        dataBytes, bestTimeMs, nActiveRanksPerGroup, nGroups);
+    printMultiGroupBandwidthResults(
+        "4-Active 2-Group IN-PLACE 1GB",
+        dataBytes,
+        this->numRanks,
+        nGroups,
+        nActiveRanksPerGroup,
+        bwResult,
+        true);
+  }
+
+  HIPCHECK_TEST(hipEventDestroy(startEvent));
+  HIPCHECK_TEST(hipEventDestroy(stopEvent));
   for (int g = 0; g < nGroups; g++) {
     HIPCHECK_TEST(hipFree(buffers[g]));
   }

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
@@ -43,8 +43,10 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <hip/hip_runtime.h>
+#include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -251,6 +253,18 @@ class ShardedRelayMultiGroupAllReduceTest : public ::testing::Test {
     const int* allActiveRanks[2] = {storage[0], storage[1]};
   };
 
+  struct PermutedTwoGroupFourActiveRanks {
+    int storage[2][4] = {{0, 2, 5, 7}, {1, 3, 4, 6}};
+    const int* allActiveRanks[2] = {storage[0], storage[1]};
+  };
+
+  struct Bfloat16AllReduceCase {
+    size_t count;
+    ncclRedOp_t op;
+    const char* description;
+    bool useShardPattern{false};
+  };
+
   // Run a 1-element ncclAllReduce on `scratchBuffer` to act as a cross-rank
   // barrier (ensuring all ranks reach this point before proceeding with
   // benchmark / correctness work).
@@ -313,6 +327,167 @@ class ShardedRelayMultiGroupAllReduceTest : public ::testing::Test {
     }
     EXPECT_EQ(errorCount, 0) << failureMessage;
     return errorCount;
+  }
+
+  static uint16_t floatToBfloat16(float value) {
+    uint32_t bits;
+    std::memcpy(&bits, &value, sizeof(bits));
+    return static_cast<uint16_t>(bits >> 16);
+  }
+
+  static float bfloat16ShardPatternValue(
+      int activeIndex,
+      size_t elementIndex,
+      size_t count,
+      int nActiveRanks) {
+    const size_t shardSize = count / static_cast<size_t>(nActiveRanks);
+    const size_t shardIndex = elementIndex / shardSize;
+    const size_t offsetLane = (elementIndex % shardSize) % 11;
+    return static_cast<float>(
+        1 + (activeIndex + 1) * (shardIndex + 1) + 4 * offsetLane);
+  }
+
+  static float expectedBfloat16ShardPatternValue(
+      size_t elementIndex,
+      size_t count,
+      int nActiveRanks,
+      ncclRedOp_t op) {
+    const size_t shardSize = count / static_cast<size_t>(nActiveRanks);
+    const size_t shardIndex = elementIndex / shardSize;
+    const size_t offsetLane = (elementIndex % shardSize) % 11;
+    const int activeIndexSum = nActiveRanks * (nActiveRanks + 1) / 2;
+    const float expectedSum = static_cast<float>(
+        nActiveRanks * (1 + 4 * offsetLane) +
+        (shardIndex + 1) * activeIndexSum);
+    return op == ncclAvg ? expectedSum / nActiveRanks : expectedSum;
+  }
+
+  void verifyBfloat16DeviceBufferEquals(
+      const uint16_t* deviceBuffer,
+      size_t count,
+      float expectedValue,
+      int nActiveRanks,
+      int groupIndex,
+      const Bfloat16AllReduceCase& testCase) {
+    std::vector<uint16_t> hostOutput(count);
+    HIPCHECK_TEST(hipMemcpy(
+        hostOutput.data(),
+        deviceBuffer,
+        count * sizeof(uint16_t),
+        hipMemcpyDeviceToHost));
+
+    int errorCount = 0;
+    for (size_t i = 0; i < count && errorCount < 10; ++i) {
+      const float expected = testCase.useShardPattern
+          ? expectedBfloat16ShardPatternValue(
+                i, count, nActiveRanks, testCase.op)
+          : expectedValue;
+      const uint16_t expectedBits = floatToBfloat16(expected);
+      if (hostOutput[i] != expectedBits) {
+        std::cout << "R" << this->globalRank << ": Group " << groupIndex
+                  << " BF16 mismatch for " << testCase.description
+                  << " at index " << i << ": expected bits " << expectedBits
+                  << " but got " << hostOutput[i] << std::endl;
+        errorCount++;
+      }
+    }
+    EXPECT_EQ(errorCount, 0) << testCase.description;
+  }
+
+  void runBfloat16AllReduceCases(
+      const int* const* allActiveRanks,
+      int nActiveRanksPerGroup,
+      int nGroups,
+      const std::vector<Bfloat16AllReduceCase>& cases) {
+    int myActiveGroup = -1;
+    int myActiveIndex = -1;
+    for (int g = 0; g < nGroups; ++g) {
+      for (int a = 0; a < nActiveRanksPerGroup; ++a) {
+        if (allActiveRanks[g][a] == this->globalRank) {
+          myActiveGroup = g;
+          myActiveIndex = a;
+        }
+      }
+    }
+
+    for (const auto& testCase : cases) {
+      const size_t dataBytes = testCase.count * sizeof(uint16_t);
+      uint16_t* buffers[4] = {};
+      const void* sendPtrs[4] = {};
+      void* recvPtrs[4] = {};
+      size_t counts[4] = {};
+
+      for (int g = 0; g < nGroups; ++g) {
+        const bool isActive = g == myActiveGroup;
+        const size_t allocationBytes =
+            isActive ? dataBytes : std::max(sizeof(uint16_t), 2 * dataBytes);
+        HIPCHECK_TEST(hipMalloc(&buffers[g], allocationBytes));
+        sendPtrs[g] = buffers[g];
+        recvPtrs[g] = buffers[g];
+        counts[g] = testCase.count;
+      }
+
+      barrierSyncOn(nullptr);
+
+      for (int g = 0; g < nGroups; ++g) {
+        if (g == myActiveGroup) {
+          std::vector<uint16_t> hostInput(testCase.count);
+          if (testCase.useShardPattern) {
+            // The configured active index and logical output offset jointly
+            // fingerprint each contribution. This exposes implementations that
+            // infer the index from global rank or place a shard at a wrong
+            // offset.
+            for (size_t i = 0; i < testCase.count; ++i) {
+              hostInput[i] = floatToBfloat16(bfloat16ShardPatternValue(
+                  myActiveIndex, i, testCase.count, nActiveRanksPerGroup));
+            }
+          } else {
+            // Active index a contributes 2a+1, so SUM=A^2 and AVG=A exactly.
+            const float inputValue = static_cast<float>(2 * myActiveIndex + 1);
+            std::fill(
+                hostInput.begin(),
+                hostInput.end(),
+                floatToBfloat16(inputValue));
+          }
+          HIPCHECK_TEST(hipMemcpy(
+              buffers[g], hostInput.data(), dataBytes, hipMemcpyHostToDevice));
+        } else {
+          HIPCHECK_TEST(hipMemset(
+              buffers[g], 0, std::max(sizeof(uint16_t), 2 * dataBytes)));
+        }
+      }
+
+      const ncclResult_t result = callAllReduceCompat(
+          sendPtrs,
+          recvPtrs,
+          counts,
+          ncclBfloat16,
+          testCase.op,
+          this->comm,
+          this->stream,
+          allActiveRanks,
+          nActiveRanksPerGroup,
+          nGroups);
+      ASSERT_EQ(result, ncclSuccess) << testCase.description;
+      HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+      if (myActiveGroup >= 0) {
+        const float expectedValue = testCase.op == ncclAvg
+            ? static_cast<float>(nActiveRanksPerGroup)
+            : static_cast<float>(nActiveRanksPerGroup * nActiveRanksPerGroup);
+        verifyBfloat16DeviceBufferEquals(
+            buffers[myActiveGroup],
+            testCase.count,
+            expectedValue,
+            nActiveRanksPerGroup,
+            myActiveGroup,
+            testCase);
+      }
+
+      for (int g = 0; g < nGroups; ++g) {
+        HIPCHECK_TEST(hipFree(buffers[g]));
+      }
+    }
   }
 
   int localRank{0};
@@ -548,6 +723,99 @@ TEST_F(
       // Only free recvBuffs for active groups (helpers share the buffer)
       HIPCHECK_TEST(hipFree(recvBuffs[g]));
     }
+  }
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllReduceTest,
+    Correctness_4Groups_HeterogeneousPositiveSizes) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t largeCount = (4ULL * 1024 * 1024) / sizeof(int32_t);
+  const size_t counts[nGroups] = {largeCount, 513, largeCount, 1023};
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+  const int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  const int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    const size_t dataBytes = counts[g] * sizeof(int32_t);
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], dataBytes));
+      if (g < 2) {
+        recvBuffs[g] = sendBuffs[g];
+      } else {
+        HIPCHECK_TEST(hipMalloc(&recvBuffs[g], dataBytes));
+      }
+    } else {
+      const size_t helperBytes = counts[g] < 1024
+          ? sizeof(int32_t)
+          : static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBytes));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    const size_t dataBytes = counts[g] * sizeof(int32_t);
+    if (g == myActiveGroup) {
+      std::vector<int32_t> hostData(counts[g], myActiveIndex + 1);
+      HIPCHECK_TEST(hipMemcpy(
+          sendBuffs[g], hostData.data(), dataBytes, hipMemcpyHostToDevice));
+      if (recvBuffs[g] != sendBuffs[g]) {
+        HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, dataBytes));
+      }
+    } else {
+      const size_t helperBytes = counts[g] < 1024
+          ? sizeof(int32_t)
+          : static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBytes));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+  }
+
+  ncclResult_t result = callAllReduceCompat(
+      sendPtrs,
+      recvPtrs,
+      counts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyDeviceBufferEquals(
+      recvBuffs[myActiveGroup],
+      counts[myActiveGroup],
+      3,
+      myActiveGroup,
+      "Heterogeneous positive-size SUM mismatch (expected 3)");
+
+  for (int g = 0; g < nGroups; g++) {
+    if (recvBuffs[g] != sendBuffs[g]) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
   }
 }
 
@@ -952,7 +1220,7 @@ TEST_F(
   const size_t dataBytes = 64ULL * 1024 * 1024;
   const size_t count = dataBytes / sizeof(int32_t);
   const int numHelpers = this->numRanks - nActiveRanksPerGroup;
-  const int numChunks = numHelpers + 1;
+  const int numChunks = numHelpers + 2;
 
   Standard4GroupActiveRanks groupConfig;
   const int* const* allActiveRanks = groupConfig.allActiveRanks;

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
@@ -1866,6 +1866,73 @@ TEST_F(
 
 TEST_F(
     ShardedRelayMultiGroupAllReduceTest,
+    Correctness_Phase2C02_BFloat16_A2_Independent6MiBBoundary) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  constexpr size_t thresholdCount = (6ULL * 1024 * 1024) / sizeof(uint16_t);
+  const int activeRanks[2] = {0, 1};
+  const int* allActiveRanks[1] = {activeRanks};
+  const std::vector<Bfloat16AllReduceCase> cases = {
+      {thresholdCount - 1, ncclSum, "A=2 6 MiB below-threshold BF16 SUM"},
+      {thresholdCount - 1, ncclAvg, "A=2 6 MiB below-threshold BF16 AVG"},
+      {thresholdCount, ncclSum, "A=2 6 MiB at-threshold BF16 SUM"},
+      {thresholdCount, ncclAvg, "A=2 6 MiB at-threshold BF16 AVG"},
+      {thresholdCount + 1, ncclSum, "A=2 6 MiB above-threshold BF16 SUM"},
+  };
+
+  runBfloat16AllReduceCases(allActiveRanks, 2, 1, cases);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllReduceTest,
+    Correctness_Phase2C02_BFloat16_A4_PermutedFused2MiBBoundary) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  constexpr size_t thresholdCount = (2ULL * 1024 * 1024) / sizeof(uint16_t);
+  PermutedTwoGroupFourActiveRanks groupConfig;
+  const std::vector<Bfloat16AllReduceCase> cases = {
+      {thresholdCount - 4,
+       ncclSum,
+       "A=4 2 MiB below-threshold permuted patterned SUM",
+       true},
+      {thresholdCount,
+       ncclSum,
+       "A=4 2 MiB at-threshold permuted patterned SUM",
+       true},
+      {thresholdCount + 4,
+       ncclSum,
+       "A=4 2 MiB above-threshold permuted patterned SUM",
+       true},
+  };
+
+  runBfloat16AllReduceCases(groupConfig.allActiveRanks, 4, 2, cases);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllReduceTest,
+    Correctness_Phase2C02_BFloat16_A4_Independent9MiBBoundary) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  constexpr size_t thresholdCount = (9ULL * 1024 * 1024) / sizeof(uint16_t);
+  const int activeRanks[4] = {0, 1, 2, 3};
+  const int* allActiveRanks[1] = {activeRanks};
+  const std::vector<Bfloat16AllReduceCase> cases = {
+      {thresholdCount - 4, ncclSum, "A=4 9 MiB below-threshold BF16 SUM"},
+      {thresholdCount, ncclSum, "A=4 9 MiB at-threshold BF16 SUM"},
+      {thresholdCount + 4, ncclSum, "A=4 9 MiB above-threshold BF16 SUM"},
+  };
+
+  runBfloat16AllReduceCases(allActiveRanks, 4, 1, cases);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllReduceTest,
     Z_BusBW_4Active_2Groups_InPlace_1GB) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
@@ -490,6 +490,75 @@ class ShardedRelayMultiGroupAllReduceTest : public ::testing::Test {
     }
   }
 
+  // Single-group (nGroups=1) A=4 allreduce (in-place). Ranks {0,1,2,3} are
+  // active and {4,5,6,7} are passthrough helpers, exercising the A=4 kernel
+  // path WITHOUT the multi-group fusion the 4Active_2Groups tests cover.
+  // Active rank myActiveIndex fills (myActiveIndex+1)*scale so the reduction
+  // detects a missing partner or mis-routed contribution.
+  void runAllReduceA4SingleGroup(ncclRedOp_t op) {
+    constexpr int nGroups = 1;
+    constexpr int nActiveRanksPerGroup = 4;
+    const size_t dataBytes = 64ULL * 1024 * 1024;
+    const size_t count = dataBytes / sizeof(int32_t);
+
+    const int activeRanks[] = {0, 1, 2, 3};
+    const int* allActiveRanks[] = {activeRanks};
+
+    const bool isActive = this->globalRank < nActiveRanksPerGroup;
+    const int myActiveIndex = this->globalRank; // 0..3 for active ranks
+    const size_t helperBytes =
+        static_cast<size_t>(nActiveRanksPerGroup) * dataBytes;
+
+    // SUM: fill (m+1) -> 1+2+3+4 = 10. AVG: fill (m+1)*2 -> 20/4 = 5 (exact in
+    // int32). A wrong AVG divisor (e.g. 2) would give 10, so this also checks
+    // that AVG uses nActiveRanks rather than a hardcoded 2.
+    const int32_t fill =
+        op == ncclAvg ? (myActiveIndex + 1) * 2 : myActiveIndex + 1;
+    const int32_t expected = op == ncclAvg ? 5 : 10;
+
+    int32_t* buff = nullptr;
+    if (isActive) {
+      HIPCHECK_TEST(hipMalloc(&buff, dataBytes));
+    } else {
+      HIPCHECK_TEST(hipMalloc(&buff, helperBytes));
+    }
+
+    barrierSyncOn(buff);
+
+    if (isActive) {
+      std::vector<int32_t> hostData(count, fill);
+      HIPCHECK_TEST(
+          hipMemcpy(buff, hostData.data(), dataBytes, hipMemcpyHostToDevice));
+    } else {
+      HIPCHECK_TEST(hipMemset(buff, 0, helperBytes));
+    }
+
+    const void* sendPtrs[1] = {buff};
+    void* recvPtrs[1] = {buff};
+    size_t counts[1] = {count};
+
+    ncclResult_t result = callAllReduceCompat(
+        sendPtrs,
+        recvPtrs,
+        counts,
+        ncclInt32,
+        op,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+    if (isActive) {
+      verifyDeviceBufferEquals(
+          buff, count, expected, 0, "4-active single-group allreduce mismatch");
+    }
+
+    HIPCHECK_TEST(hipFree(buff));
+  }
+
   int localRank{0};
   int globalRank{0};
   int numRanks{0};
@@ -1771,6 +1840,29 @@ TEST_F(ShardedRelayMultiGroupAllReduceTest, Correctness_4Active_2Groups_Avg) {
   for (int g = 0; g < nGroups; g++) {
     HIPCHECK_TEST(hipFree(buffers[g]));
   }
+}
+
+// Single-group (nGroups=1) A=4 allreduce: ranks {0,1,2,3} active, {4,5,6,7}
+// helpers. Exercises the A=4 path without the multi-group fusion the
+// 4Active_2Groups tests cover.
+TEST_F(
+    ShardedRelayMultiGroupAllReduceTest,
+    Correctness_4Active_SingleGroup_InPlace) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  runAllReduceA4SingleGroup(ncclSum);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllReduceTest,
+    Correctness_4Active_SingleGroup_Avg) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  runAllReduceA4SingleGroup(ncclAvg);
 }
 
 TEST_F(

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
@@ -506,12 +506,12 @@ TEST_F(
 }
 
 /**
- * Test: BusBW with 4-group Multi-Group AllReduce (24GB per group, IN-PLACE)
+ * Test: BusBW with 4-group Multi-Group AllReduce (1GB per group, IN-PLACE)
  *
  * This is the key benchmark for 2D sparse parallelism performance.
  * All 4 groups execute in parallel with phase synchronization.
  */
-TEST_F(ShardedRelayMultiGroupAllReduceTest, Z_BusBW_4Groups_InPlace_24GB) {
+TEST_F(ShardedRelayMultiGroupAllReduceTest, Z_BusBW_4Groups_InPlace_1GB) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
                  << " available";
@@ -519,7 +519,10 @@ TEST_F(ShardedRelayMultiGroupAllReduceTest, Z_BusBW_4Groups_InPlace_24GB) {
 
   const int nGroups = 4;
   const int nActiveRanksPerGroup = 2;
-  const size_t dataBytes = 24ULL * 1024 * 1024 * 1024; // 24 GB per group
+  // 1 GB per group keeps the whole 8-rank suite inside a shared devgpu/CI
+  // memory budget: a rank is active for one group and a helper for the other
+  // three, so it holds dataBytes + 3 x (nActiveRanksPerGroup x dataBytes).
+  const size_t dataBytes = 1ULL * 1024 * 1024 * 1024; // 1 GB per group
   const size_t count = dataBytes / sizeof(int32_t);
 
   // Benchmark configuration: Run 20 iterations total, take the best time.
@@ -628,7 +631,7 @@ TEST_F(ShardedRelayMultiGroupAllReduceTest, Z_BusBW_4Groups_InPlace_24GB) {
     ShardedBandwidthResult bwResult = calculateMultiGroupAggregateBandwidth(
         dataBytes, bestTimeMs, nActiveRanksPerGroup, nGroups);
     printMultiGroupBandwidthResults(
-        "4-Group IN-PLACE 24GB",
+        "4-Group IN-PLACE 1GB",
         dataBytes,
         this->numRanks,
         nGroups,
@@ -645,9 +648,9 @@ TEST_F(ShardedRelayMultiGroupAllReduceTest, Z_BusBW_4Groups_InPlace_24GB) {
 }
 
 /**
- * Test: BusBW with 4-group Multi-Group AllReduce (24GB per group, OUT-OF-PLACE)
+ * Test: BusBW with 4-group Multi-Group AllReduce (1GB per group, OUT-OF-PLACE)
  */
-TEST_F(ShardedRelayMultiGroupAllReduceTest, Z_BusBW_4Groups_OutOfPlace_24GB) {
+TEST_F(ShardedRelayMultiGroupAllReduceTest, Z_BusBW_4Groups_OutOfPlace_1GB) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
                  << " available";
@@ -655,7 +658,7 @@ TEST_F(ShardedRelayMultiGroupAllReduceTest, Z_BusBW_4Groups_OutOfPlace_24GB) {
 
   const int nGroups = 4;
   const int nActiveRanksPerGroup = 2;
-  const size_t dataBytes = 24ULL * 1024 * 1024 * 1024; // 24 GB per group
+  const size_t dataBytes = 1ULL * 1024 * 1024 * 1024; // 1 GB per group
   const size_t count = dataBytes / sizeof(int32_t);
 
   // Benchmark configuration: Run 20 iterations total, take the best time.
@@ -765,7 +768,7 @@ TEST_F(ShardedRelayMultiGroupAllReduceTest, Z_BusBW_4Groups_OutOfPlace_24GB) {
     ShardedBandwidthResult bwResult = calculateMultiGroupAggregateBandwidth(
         dataBytes, bestTimeMs, nActiveRanksPerGroup, nGroups);
     printMultiGroupBandwidthResults(
-        "4-Group OUT-OF-PLACE 24GB",
+        "4-Group OUT-OF-PLACE 1GB",
         dataBytes,
         this->numRanks,
         nGroups,

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
@@ -409,7 +409,7 @@ TEST_F(ShardedRelayMultiGroupAllReduceTest, Correctness_4Groups_InPlace_64MB) {
     counts[g] = count; // Same count for all groups in this test
   }
 
-  ncclResult_t result = ncclShardedRelayMultiGroupAllReduce(
+  ncclResult_t result = callAllReduceCompat(
       sendPtrs,
       recvPtrs,
       counts,
@@ -516,7 +516,7 @@ TEST_F(
     counts[g] = count;
   }
 
-  ncclResult_t result = ncclShardedRelayMultiGroupAllReduce(
+  ncclResult_t result = callAllReduceCompat(
       sendPtrs,
       recvPtrs,
       counts,
@@ -637,7 +637,7 @@ TEST_F(ShardedRelayMultiGroupAllReduceTest, Z_BusBW_4Groups_InPlace_1GB) {
 
   for (int iter = 0; iter < nIters; iter++) {
     HIPCHECK_TEST(hipEventRecord(startEvent, this->stream));
-    ncclResult_t result = ncclShardedRelayMultiGroupAllReduce(
+    ncclResult_t result = callAllReduceCompat(
         sendPtrs,
         recvPtrs,
         counts,
@@ -776,7 +776,7 @@ TEST_F(ShardedRelayMultiGroupAllReduceTest, Z_BusBW_4Groups_OutOfPlace_1GB) {
 
   for (int iter = 0; iter < nIters; iter++) {
     HIPCHECK_TEST(hipEventRecord(startEvent, this->stream));
-    ncclResult_t result = ncclShardedRelayMultiGroupAllReduce(
+    ncclResult_t result = callAllReduceCompat(
         sendPtrs,
         recvPtrs,
         counts,
@@ -895,7 +895,7 @@ TEST_F(ShardedRelayMultiGroupAllReduceTest, Correctness_SingleGroup_64MB) {
   sendPtrs[0] = buff;
   recvPtrs[0] = buff;
 
-  ncclResult_t result = ncclShardedRelayMultiGroupAllReduce(
+  ncclResult_t result = callAllReduceCompat(
       sendPtrs,
       recvPtrs,
       counts,
@@ -1009,7 +1009,7 @@ TEST_F(
     counts[g] = count;
   }
 
-  ncclResult_t result = ncclShardedRelayMultiGroupAllReduce(
+  ncclResult_t result = callAllReduceCompat(
       sendPtrs,
       recvPtrs,
       counts,
@@ -1138,7 +1138,7 @@ TEST_F(
   }
 
   // Execute — must succeed and not trigger internal error for count=0 groups
-  ncclResult_t result = ncclShardedRelayMultiGroupAllReduce(
+  ncclResult_t result = callAllReduceCompat(
       sendPtrs,
       recvPtrs,
       counts,

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
@@ -205,6 +205,14 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
         storage[3]};
   };
 
+  // 8-rank, 2-group, 4-active-per-group layout for the 4-active flat path:
+  //   Group 0: activeRanks = {0, 1, 2, 3}, helpers = {4, 5, 6, 7}
+  //   Group 1: activeRanks = {4, 5, 6, 7}, helpers = {0, 1, 2, 3}
+  struct TwoGroupFourActiveRanks {
+    int storage[2][4] = {{0, 1, 2, 3}, {4, 5, 6, 7}};
+    const int* allActiveRanks[2] = {storage[0], storage[1]};
+  };
+
   // Distinct per-(activeIndex, segment) fill value so that a wrong segment
   // offset in the implementation produces a detectable mismatch.
   static int32_t segFillValue(int activeIndex, int segIndex) {
@@ -217,14 +225,16 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
     return segFillValue(senderActiveIndex, myActiveIndex);
   }
 
-  // Initialize an active rank's send buffer (2 x segmentCount elements) so that
-  // segment j is uniformly filled with segFillValue(myActiveIndex, j).
+  // Initialize an active rank's send buffer (nActiveRanks x segmentCount
+  // elements) so that segment j is uniformly filled with
+  // segFillValue(myActiveIndex, j).
   void initActiveSendBuffer(
       int32_t* deviceBuf,
       size_t segmentCount,
-      int myActiveIndex) {
-    std::vector<int32_t> host(static_cast<size_t>(2) * segmentCount);
-    for (int j = 0; j < 2; j++) {
+      int myActiveIndex,
+      int nActiveRanks = 2) {
+    std::vector<int32_t> host(static_cast<size_t>(nActiveRanks) * segmentCount);
+    for (int j = 0; j < nActiveRanks; j++) {
       int32_t v = segFillValue(myActiveIndex, j);
       std::fill_n(
           host.data() + static_cast<size_t>(j) * segmentCount, segmentCount, v);
@@ -232,7 +242,7 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
     HIPCHECK_TEST(hipMemcpy(
         deviceBuf,
         host.data(),
-        static_cast<size_t>(2) * segmentCount * sizeof(int32_t),
+        static_cast<size_t>(nActiveRanks) * segmentCount * sizeof(int32_t),
         hipMemcpyHostToDevice));
   }
 
@@ -296,24 +306,22 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
     return errorCount;
   }
 
-  // Verify both received segments of an active rank's recvBuff.
+  // Verify all received segments of an active rank's recvBuff. For active index
+  // m, recvSeg[i] (the segment from source i) must equal segFillValue(i, m).
   void verifyAllToAllOutput(
       const int32_t* recvBuff,
       size_t segmentCount,
       int myActiveIndex,
-      int groupIndex) {
-    verifyDeviceBufferEquals(
-        recvBuff,
-        segmentCount,
-        expectedRecvSeg(0, myActiveIndex),
-        groupIndex,
-        "Found mismatches in all-to-all recvSeg[0]");
-    verifyDeviceBufferEquals(
-        recvBuff + segmentCount,
-        segmentCount,
-        expectedRecvSeg(1, myActiveIndex),
-        groupIndex,
-        "Found mismatches in all-to-all recvSeg[1]");
+      int groupIndex,
+      int nActiveRanks = 2) {
+    for (int i = 0; i < nActiveRanks; i++) {
+      verifyDeviceBufferEquals(
+          recvBuff + static_cast<size_t>(i) * segmentCount,
+          segmentCount,
+          expectedRecvSeg(i, myActiveIndex),
+          groupIndex,
+          "Found mismatches in all-to-all recvSeg[i]");
+    }
   }
 
   int localRank{0};
@@ -868,6 +876,473 @@ TEST_F(ShardedRelayMultiGroupAllToAllTest, Z_BusBW_4Groups_OutOfPlace_1GB) {
         segmentBytes, bestTimeMs, nActiveRanksPerGroup, nGroups);
     printMultiGroupBandwidthResults(
         "4-Group OUT-OF-PLACE 1GB",
+        segmentBytes,
+        this->numRanks,
+        nGroups,
+        nActiveRanksPerGroup,
+        bwResult);
+  }
+
+  HIPCHECK_TEST(hipEventDestroy(startEvent));
+  HIPCHECK_TEST(hipEventDestroy(stopEvent));
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+/**
+ * 4-ACTIVE tests (2 groups of 4 active ranks each).
+ *   Group 0: active {0,1,2,3}, helpers {4,5,6,7}
+ *   Group 1: active {4,5,6,7}, helpers {0,1,2,3}
+ *
+ * Each active rank's sendBuff holds A=4 segments of segmentCount; segment j is
+ * filled with segFillValue(myActiveIndex, j). After the all-to-all, owner m's
+ * recvSeg[i] must equal segFillValue(i, m), so a wrong round/partner mapping in
+ * the flat 2-hop relay is detectable per segment.
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_4Active_2Groups_OutOfPlace) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t segmentBytes = 64ULL * 1024 * 1024;
+  const size_t segmentCount = segmentBytes / sizeof(int32_t);
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(
+          &sendBuffs[g],
+          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes));
+      HIPCHECK_TEST(hipMalloc(
+          &recvBuffs[g],
+          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      initActiveSendBuffer(
+          sendBuffs[g], segmentCount, myActiveIndex, nActiveRanksPerGroup);
+      HIPCHECK_TEST(hipMemset(
+          recvBuffs[g],
+          0,
+          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t segmentCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+    segmentCounts[g] = segmentCount;
+  }
+
+  ncclResult_t result = callAllToAllCompat(
+      sendPtrs,
+      recvPtrs,
+      segmentCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyAllToAllOutput(
+      recvBuffs[myActiveGroup],
+      segmentCount,
+      myActiveIndex,
+      myActiveGroup,
+      nActiveRanksPerGroup);
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+/**
+ * Tiny-segment regression: forces the relay csz==0 path for 4 active ranks.
+ * With segmentCount=512, csz = align(512 / 5) = 0, so each round's exchange is
+ * a full whole-segment direct partner swap (no helper hops). The send and recv
+ * of that swap MUST share one ncclGroup; splitting them across the two hops
+ * would deadlock. All A-1 XOR rounds are exercised.
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_4Active_2Groups_TinyCsz0_OutOfPlace) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t segmentCount = 512; // align(512 / 5) == 0 -> relay csz == 0
+  const size_t segmentBytes = segmentCount * sizeof(int32_t);
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    size_t bytes = static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], bytes));
+      HIPCHECK_TEST(hipMalloc(&recvBuffs[g], bytes));
+    } else {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], bytes));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    size_t bytes = static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
+    if (g == myActiveGroup) {
+      initActiveSendBuffer(
+          sendBuffs[g], segmentCount, myActiveIndex, nActiveRanksPerGroup);
+      HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, bytes));
+    } else {
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, bytes));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t segmentCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+    segmentCounts[g] = segmentCount;
+  }
+
+  ncclResult_t result = callAllToAllCompat(
+      sendPtrs,
+      recvPtrs,
+      segmentCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyAllToAllOutput(
+      recvBuffs[myActiveGroup],
+      segmentCount,
+      myActiveIndex,
+      myActiveGroup,
+      nActiveRanksPerGroup);
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+/**
+ * In-place is rejected at 4 active ranks too (sendBuff == recvBuff returns
+ * ncclInvalidArgument).
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_4Active_2Groups_InPlace_Rejected) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t segmentBytes = 16ULL * 1024 * 1024;
+  const size_t segmentCount = segmentBytes / sizeof(int32_t);
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* buffers[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipMalloc(
+        &buffers[g], static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes));
+  }
+
+  barrierSyncOn(buffers[0]);
+  initActiveSendBuffer(
+      buffers[myActiveGroup],
+      segmentCount,
+      myActiveIndex,
+      nActiveRanksPerGroup);
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t segmentCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = buffers[g];
+    recvPtrs[g] = buffers[g]; // in-place
+    segmentCounts[g] = segmentCount;
+  }
+
+  ncclResult_t result = callAllToAllCompat(
+      sendPtrs,
+      recvPtrs,
+      segmentCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  EXPECT_EQ(result, ncclInvalidArgument)
+      << "In-place 4-active all-to-all should be rejected with ncclInvalidArgument";
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(buffers[g]));
+  }
+}
+
+/**
+ * Partial-zero-count regression for 4 active ranks: group 0 has data, group 1
+ * passes segmentCount=0 and must be skipped without crash/corruption.
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_4Active_PartialGroupsZeroCount) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t segmentBytes = 16ULL * 1024 * 1024;
+  const size_t segmentCount = segmentBytes / sizeof(int32_t);
+
+  const size_t segmentCounts[nGroups] = {segmentCount, 0};
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  const size_t placeholderBytes = sizeof(int32_t);
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (segmentCounts[g] == 0) {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], placeholderBytes));
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, placeholderBytes));
+      recvBuffs[g] = sendBuffs[g];
+      continue;
+    }
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(
+          &sendBuffs[g],
+          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes));
+      HIPCHECK_TEST(hipMalloc(
+          &recvBuffs[g],
+          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(sendBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (segmentCounts[g] == 0) {
+      continue;
+    }
+    if (g == myActiveGroup) {
+      initActiveSendBuffer(
+          sendBuffs[g], segmentCount, myActiveIndex, nActiveRanksPerGroup);
+      HIPCHECK_TEST(hipMemset(
+          recvBuffs[g],
+          0,
+          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+  }
+
+  ncclResult_t result = callAllToAllCompat(
+      sendPtrs,
+      recvPtrs,
+      segmentCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess)
+      << "4-active all-to-all failed with a partial segmentCount=0 group";
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  if (myActiveGroup == 0) { // group 0 had data
+    verifyAllToAllOutput(
+        recvBuffs[myActiveGroup],
+        segmentCount,
+        myActiveIndex,
+        myActiveGroup,
+        nActiveRanksPerGroup);
+  }
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (segmentCounts[g] != 0 && g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+/**
+ * BusBW with 4-active 2-group all-to-all (1GB segment, OUT-OF-PLACE).
+ *
+ * A 4-active all-to-all active rank holds A=4 send + A=4 recv segments; 1GB
+ * keeps the per-rank footprint inside a shared devgpu/CI memory budget.
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Z_BusBW_4Active_2Groups_OutOfPlace_1GB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t segmentBytes = 1ULL * 1024 * 1024 * 1024; // 1 GB segment/group
+  const size_t segmentCount = segmentBytes / sizeof(int32_t);
+  const int nIters = 20;
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    size_t bytes = static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], bytes));
+      HIPCHECK_TEST(hipMalloc(&recvBuffs[g], bytes));
+    } else {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], bytes));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    size_t bytes = static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
+    HIPCHECK_TEST(hipMemset(sendBuffs[g], (g == myActiveGroup) ? 1 : 0, bytes));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, bytes));
+    }
+  }
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t segmentCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+    segmentCounts[g] = segmentCount;
+  }
+
+  hipEvent_t startEvent, stopEvent;
+  HIPCHECK_TEST(hipEventCreate(&startEvent));
+  HIPCHECK_TEST(hipEventCreate(&stopEvent));
+
+  float bestTimeMs = std::numeric_limits<float>::max();
+  float totalTimeMs = 0.0f;
+
+  for (int iter = 0; iter < nIters; iter++) {
+    HIPCHECK_TEST(hipEventRecord(startEvent, this->stream));
+    ncclResult_t result = callAllToAllCompat(
+        sendPtrs,
+        recvPtrs,
+        segmentCounts,
+        ncclInt32,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipEventRecord(stopEvent, this->stream));
+    HIPCHECK_TEST(hipEventSynchronize(stopEvent));
+
+    float elapsedMs = 0.0f;
+    HIPCHECK_TEST(hipEventElapsedTime(&elapsedMs, startEvent, stopEvent));
+    if (elapsedMs < bestTimeMs) {
+      bestTimeMs = elapsedMs;
+    }
+    totalTimeMs += elapsedMs;
+  }
+
+  if (this->globalRank == 0) {
+    ShardedBandwidthResult bwResult = calculateMultiGroupAggregateBandwidth(
+        segmentBytes, bestTimeMs, nActiveRanksPerGroup, nGroups);
+    printMultiGroupBandwidthResults(
+        "4-Active 2-Group OUT-OF-PLACE 1GB",
         segmentBytes,
         this->numRanks,
         nGroups,

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
@@ -225,6 +225,11 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
     return segFillValue(senderActiveIndex, myActiveIndex);
   }
 
+  static int32_t
+  boundaryFillValue(int sourceIndex, int destIndex, int boundaryIndex) {
+    return 1000 + sourceIndex * 100 + destIndex * 10 + boundaryIndex;
+  }
+
   // Initialize an active rank's send buffer (nActiveRanks x segmentCount
   // elements) so that segment j is uniformly filled with
   // segFillValue(myActiveIndex, j).
@@ -321,6 +326,247 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
           expectedRecvSeg(i, myActiveIndex),
           groupIndex,
           "Found mismatches in all-to-all recvSeg[i]");
+    }
+  }
+
+  void runA2CorrectnessCase(
+      const std::vector<size_t>& segmentCounts,
+      const int* const* allActiveRanks,
+      bool expectRelay) {
+    constexpr int nActiveRanksPerGroup = 2;
+    const int nGroups = static_cast<int>(segmentCounts.size());
+    ASSERT_GT(nGroups, 0);
+
+    int myActiveGroup = -1;
+    int myActiveIndex = -1;
+    for (int g = 0; g < nGroups; g++) {
+      for (int a = 0; a < nActiveRanksPerGroup; a++) {
+        if (allActiveRanks[g][a] == this->globalRank) {
+          myActiveGroup = g;
+          myActiveIndex = a;
+        }
+      }
+    }
+
+    std::vector<int32_t*> sendBuffs(nGroups);
+    std::vector<int32_t*> recvBuffs(nGroups);
+    for (int g = 0; g < nGroups; g++) {
+      const size_t bufferBytes = static_cast<size_t>(nActiveRanksPerGroup) *
+          segmentCounts[g] * sizeof(int32_t);
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], bufferBytes));
+      if (g == myActiveGroup) {
+        HIPCHECK_TEST(hipMalloc(&recvBuffs[g], bufferBytes));
+      } else {
+        recvBuffs[g] = sendBuffs[g];
+      }
+    }
+
+    barrierSyncOn(sendBuffs[0]);
+
+    for (int g = 0; g < nGroups; g++) {
+      const size_t bufferBytes = static_cast<size_t>(nActiveRanksPerGroup) *
+          segmentCounts[g] * sizeof(int32_t);
+      if (g == myActiveGroup) {
+        initActiveSendBuffer(sendBuffs[g], segmentCounts[g], myActiveIndex);
+        HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, bufferBytes));
+      } else {
+        HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, bufferBytes));
+      }
+    }
+
+    std::vector<const void*> sendPtrs(nGroups);
+    std::vector<void*> recvPtrs(nGroups);
+    for (int g = 0; g < nGroups; g++) {
+      sendPtrs[g] = sendBuffs[g];
+      recvPtrs[g] = recvBuffs[g];
+    }
+
+    const ncclResult_t result = callAllToAllCompat(
+        sendPtrs.data(),
+        recvPtrs.data(),
+        segmentCounts.data(),
+        ncclInt32,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+    if (myActiveGroup >= 0) {
+      verifyAllToAllOutput(
+          recvBuffs[myActiveGroup],
+          segmentCounts[myActiveGroup],
+          myActiveIndex,
+          myActiveGroup);
+    }
+    for (int g = 0; g < nGroups; g++) {
+      if (g != myActiveGroup) {
+        const int32_t expectedHelperFirstElement =
+            expectRelay ? segFillValue(0, 1) : 0;
+        verifyDeviceBufferEquals(
+            sendBuffs[g],
+            1,
+            expectedHelperFirstElement,
+            g,
+            expectRelay ? "Relay route did not use helper storage"
+                        : "Pure-direct route modified helper storage");
+      }
+    }
+
+    for (int g = 0; g < nGroups; g++) {
+      HIPCHECK_TEST(hipFree(sendBuffs[g]));
+      if (g == myActiveGroup) {
+        HIPCHECK_TEST(hipFree(recvBuffs[g]));
+      }
+    }
+  }
+
+  void runA4CorrectnessCase(
+      size_t segmentCount,
+      bool expectRelay,
+      bool checkRegionBoundaries = false) {
+    constexpr int nGroups = 2;
+    constexpr int nActiveRanksPerGroup = 4;
+    constexpr int32_t helperSentinel = 0;
+    const size_t segmentBytes = segmentCount * sizeof(int32_t);
+    const size_t activeBufferBytes =
+        static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
+    const size_t relayCount = (segmentCount / 3 / 128) * 128;
+    const size_t helperElements = expectRelay ? 3 * relayCount : segmentCount;
+    const size_t helperBufferBytes = (helperElements + 1) * sizeof(int32_t);
+
+    TwoGroupFourActiveRanks groupConfig;
+    const int* const* allActiveRanks = groupConfig.allActiveRanks;
+    const int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+    const int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+    int32_t* sendBuffs[nGroups];
+    int32_t* recvBuffs[nGroups];
+    for (int g = 0; g < nGroups; g++) {
+      if (g == myActiveGroup) {
+        HIPCHECK_TEST(hipMalloc(&sendBuffs[g], activeBufferBytes));
+        HIPCHECK_TEST(hipMalloc(&recvBuffs[g], activeBufferBytes));
+      } else {
+        HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferBytes));
+        recvBuffs[g] = sendBuffs[g];
+      }
+    }
+
+    barrierSyncOn(sendBuffs[0]);
+
+    for (int g = 0; g < nGroups; g++) {
+      if (g == myActiveGroup) {
+        initActiveSendBuffer(
+            sendBuffs[g], segmentCount, myActiveIndex, nActiveRanksPerGroup);
+        if (checkRegionBoundaries) {
+          const size_t directA = segmentCount / 3;
+          const size_t regionOffsets[5] = {
+              directA - 1,
+              directA,
+              directA + relayCount - 1,
+              directA + relayCount,
+              segmentCount - 1};
+          for (int dest = 0; dest < nActiveRanksPerGroup; dest++) {
+            for (int boundary = 0; boundary < 5; boundary++) {
+              const int32_t value =
+                  boundaryFillValue(myActiveIndex, dest, boundary);
+              HIPCHECK_TEST(hipMemcpy(
+                  sendBuffs[g] + static_cast<size_t>(dest) * segmentCount +
+                      regionOffsets[boundary],
+                  &value,
+                  sizeof(value),
+                  hipMemcpyHostToDevice));
+            }
+          }
+        }
+        HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, activeBufferBytes));
+      } else {
+        HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferBytes));
+      }
+    }
+
+    const void* sendPtrs[nGroups] = {sendBuffs[0], sendBuffs[1]};
+    void* recvPtrs[nGroups] = {recvBuffs[0], recvBuffs[1]};
+    const size_t segmentCounts[nGroups] = {segmentCount, segmentCount};
+    const ncclResult_t result = callAllToAllCompat(
+        sendPtrs,
+        recvPtrs,
+        segmentCounts,
+        ncclInt32,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+    if (checkRegionBoundaries) {
+      const size_t directA = segmentCount / 3;
+      const size_t regionOffsets[5] = {
+          directA - 1,
+          directA,
+          directA + relayCount - 1,
+          directA + relayCount,
+          segmentCount - 1};
+      for (int source = 0; source < nActiveRanksPerGroup; source++) {
+        for (int boundary = 0; boundary < 5; boundary++) {
+          verifyDeviceBufferEquals(
+              recvBuffs[myActiveGroup] +
+                  static_cast<size_t>(source) * segmentCount +
+                  regionOffsets[boundary],
+              1,
+              boundaryFillValue(source, myActiveIndex, boundary),
+              myActiveGroup,
+              "A=4 XOR route misplaced a region boundary or tail element");
+        }
+      }
+    } else {
+      verifyAllToAllOutput(
+          recvBuffs[myActiveGroup],
+          segmentCount,
+          myActiveIndex,
+          myActiveGroup,
+          nActiveRanksPerGroup);
+    }
+
+    const int helperGroup = 1 - myActiveGroup;
+    if (expectRelay) {
+      constexpr int firstSlotSource[4] = {1, 0, 0, 0};
+      constexpr int firstSlotDest[4] = {3, 3, 1, 2};
+      const int32_t expectedFirstSlot = checkRegionBoundaries
+          ? boundaryFillValue(
+                firstSlotSource[myActiveIndex], firstSlotDest[myActiveIndex], 1)
+          : segFillValue(
+                firstSlotSource[myActiveIndex], firstSlotDest[myActiveIndex]);
+      verifyDeviceBufferEquals(
+          recvBuffs[helperGroup],
+          1,
+          expectedFirstSlot,
+          helperGroup,
+          "A=4 XOR route did not populate the expected first helper slot");
+    } else {
+      verifyDeviceBufferEquals(
+          recvBuffs[helperGroup],
+          1,
+          helperSentinel,
+          helperGroup,
+          "A=4 direct route unexpectedly modified helper scratch");
+    }
+    verifyDeviceBufferEquals(
+        recvBuffs[helperGroup] + helperElements,
+        1,
+        helperSentinel,
+        helperGroup,
+        "A=4 all-to-all wrote past the helper scratch contract");
+
+    for (int g = 0; g < nGroups; g++) {
+      HIPCHECK_TEST(hipFree(sendBuffs[g]));
+      if (g == myActiveGroup) {
+        HIPCHECK_TEST(hipFree(recvBuffs[g]));
+      }
     }
   }
 
@@ -575,7 +821,7 @@ TEST_F(
   const size_t segmentBytes = 64ULL * 1024 * 1024;
   const size_t segmentCount = segmentBytes / sizeof(int32_t);
   const int numHelpers = this->numRanks - nActiveRanksPerGroup;
-  const int numChunks = numHelpers + 1;
+  const int numChunks = numHelpers + 2;
 
   Standard4GroupActiveRanks groupConfig;
   const int* const* allActiveRanks = groupConfig.allActiveRanks;

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
@@ -570,6 +570,127 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
     }
   }
 
+  // Single-group (nGroups=1) A=4 all-to-all. Ranks {0,1,2,3} are active and
+  // {4,5,6,7} are passthrough helpers, exercising the A=4 route WITHOUT the
+  // multi-group fusion the 4Active (2-group) tests cover. All-to-all is
+  // out-of-place only. Verifies active-rank output (optionally at region
+  // boundaries) and that helpers never write past their scratch contract.
+  void runA4SingleGroupCorrectnessCase(
+      size_t segmentCount,
+      bool expectRelay,
+      bool checkRegionBoundaries = false) {
+    constexpr int nGroups = 1;
+    constexpr int nActiveRanksPerGroup = 4;
+    constexpr int32_t helperSentinel = 0;
+    const size_t segmentBytes = segmentCount * sizeof(int32_t);
+    const size_t activeBufferBytes =
+        static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
+    const size_t relayCount = (segmentCount / 3 / 128) * 128;
+    const size_t helperElements = expectRelay ? 3 * relayCount : segmentCount;
+    const size_t helperBufferBytes = (helperElements + 1) * sizeof(int32_t);
+
+    const int activeRanks[] = {0, 1, 2, 3};
+    const int* allActiveRanks[] = {activeRanks};
+    const bool isActive = this->globalRank < nActiveRanksPerGroup;
+    const int myActiveIndex = this->globalRank; // 0..3 for active ranks
+
+    int32_t* sendBuff = nullptr;
+    int32_t* recvBuff = nullptr;
+    if (isActive) {
+      HIPCHECK_TEST(hipMalloc(&sendBuff, activeBufferBytes));
+      HIPCHECK_TEST(hipMalloc(&recvBuff, activeBufferBytes));
+    } else {
+      HIPCHECK_TEST(hipMalloc(&sendBuff, helperBufferBytes));
+      recvBuff = sendBuff;
+    }
+
+    barrierSyncOn(sendBuff);
+
+    if (isActive) {
+      initActiveSendBuffer(
+          sendBuff, segmentCount, myActiveIndex, nActiveRanksPerGroup);
+      if (checkRegionBoundaries) {
+        const size_t directA = segmentCount / 3;
+        const size_t regionOffsets[5] = {
+            directA - 1,
+            directA,
+            directA + relayCount - 1,
+            directA + relayCount,
+            segmentCount - 1};
+        for (int dest = 0; dest < nActiveRanksPerGroup; dest++) {
+          for (int boundary = 0; boundary < 5; boundary++) {
+            const int32_t value =
+                boundaryFillValue(myActiveIndex, dest, boundary);
+            HIPCHECK_TEST(hipMemcpy(
+                sendBuff + static_cast<size_t>(dest) * segmentCount +
+                    regionOffsets[boundary],
+                &value,
+                sizeof(value),
+                hipMemcpyHostToDevice));
+          }
+        }
+      }
+      HIPCHECK_TEST(hipMemset(recvBuff, 0, activeBufferBytes));
+    } else {
+      HIPCHECK_TEST(hipMemset(sendBuff, 0, helperBufferBytes));
+    }
+
+    const void* sendPtrs[1] = {sendBuff};
+    void* recvPtrs[1] = {recvBuff};
+    const size_t segmentCounts[1] = {segmentCount};
+    const ncclResult_t result = callAllToAllCompat(
+        sendPtrs,
+        recvPtrs,
+        segmentCounts,
+        ncclInt32,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+    if (isActive) {
+      if (checkRegionBoundaries) {
+        const size_t directA = segmentCount / 3;
+        const size_t regionOffsets[5] = {
+            directA - 1,
+            directA,
+            directA + relayCount - 1,
+            directA + relayCount,
+            segmentCount - 1};
+        for (int source = 0; source < nActiveRanksPerGroup; source++) {
+          for (int boundary = 0; boundary < 5; boundary++) {
+            verifyDeviceBufferEquals(
+                recvBuff + static_cast<size_t>(source) * segmentCount +
+                    regionOffsets[boundary],
+                1,
+                boundaryFillValue(source, myActiveIndex, boundary),
+                0,
+                "A=4 single-group XOR route misplaced a boundary element");
+          }
+        }
+      } else {
+        verifyAllToAllOutput(
+            recvBuff, segmentCount, myActiveIndex, 0, nActiveRanksPerGroup);
+      }
+    } else {
+      // Helper ranks must never write past their scratch contract.
+      verifyDeviceBufferEquals(
+          sendBuff + helperElements,
+          1,
+          helperSentinel,
+          0,
+          "A=4 single-group all-to-all wrote past the helper scratch contract");
+    }
+
+    HIPCHECK_TEST(hipFree(sendBuff));
+    if (isActive) {
+      HIPCHECK_TEST(hipFree(recvBuff));
+    }
+  }
+
   int localRank{0};
   int globalRank{0};
   int numRanks{0};
@@ -1381,6 +1502,45 @@ TEST_F(
   constexpr size_t perActiveBytes = 256ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t));
   runA4CorrectnessCase(segmentCount, false);
+}
+
+// Single-group (nGroups=1) A=4 all-to-all: ranks {0,1,2,3} active, {4,5,6,7}
+// helpers. Exercises the A=4 route without the multi-group fusion the 2-group
+// tests cover, across the routed and direct regimes.
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_4Active_SingleGroup_Routed_63MiB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t));
+  runA4SingleGroupCorrectnessCase(segmentCount, true);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_4Active_SingleGroup_DirectBelowLowerBoundary) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t)) - 1;
+  runA4SingleGroupCorrectnessCase(segmentCount, false);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_4Active_SingleGroup_RoutedUnalignedTail) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t)) + 1;
+  runA4SingleGroupCorrectnessCase(segmentCount, true, true);
 }
 
 /**

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
@@ -668,6 +668,192 @@ TEST_F(
   }
 }
 
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_A2_PureDirect_UnalignedTail) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  Standard4GroupActiveRanks groupConfig;
+  runA2CorrectnessCase(
+      std::vector<size_t>(4, 1025), groupConfig.allActiveRanks, false);
+}
+
+// A=2 route selection uses A * max(segmentCount) * elementSize. For int32,
+// the fused cutoff is 2 MiB, or 262144 elements per segment. Equality selects
+// the relay path; the adjacent counts exercise one-element unaligned tails.
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_A2_FusedThreshold_Below_UnalignedTail) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  Standard4GroupActiveRanks groupConfig;
+  runA2CorrectnessCase(
+      std::vector<size_t>(4, 262143), groupConfig.allActiveRanks, false);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_A2_FusedThreshold_At_WithUnalignedGroupTail) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  Standard4GroupActiveRanks groupConfig;
+  const std::vector<size_t> segmentCounts = {262144, 262143, 262144, 262143};
+  runA2CorrectnessCase(segmentCounts, groupConfig.allActiveRanks, true);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_A2_FusedThreshold_Above_UnalignedTail) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  Standard4GroupActiveRanks groupConfig;
+  runA2CorrectnessCase(
+      std::vector<size_t>(4, 262145), groupConfig.allActiveRanks, true);
+}
+
+// The independent A=2 cutoff is 27 MiB, or 3538944 int32 elements per segment.
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_A2_IndependentThreshold_Below_UnalignedTail) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int activeRanks[] = {0, 1};
+  const int* allActiveRanks[] = {activeRanks};
+  runA2CorrectnessCase({3538943}, allActiveRanks, false);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_A2_IndependentThreshold_At) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int activeRanks[] = {0, 1};
+  const int* allActiveRanks[] = {activeRanks};
+  runA2CorrectnessCase({3538944}, allActiveRanks, true);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_A2_IndependentThreshold_Above_UnalignedTail) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int activeRanks[] = {0, 1};
+  const int* allActiveRanks[] = {activeRanks};
+  runA2CorrectnessCase({3538945}, allActiveRanks, true);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_4Groups_HeterogeneousRelayAndTinyDirect) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t largeSegmentBytes = 16ULL * 1024 * 1024;
+  const size_t largeSegmentCount = largeSegmentBytes / sizeof(int32_t);
+  const size_t tinySegmentCount = 513;
+  const size_t segmentCounts[nGroups] = {
+      largeSegmentCount, tinySegmentCount, largeSegmentCount, tinySegmentCount};
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    size_t segmentBytes = segmentCounts[g] * sizeof(int32_t);
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(
+          hipMalloc(&sendBuffs[g], static_cast<size_t>(2) * segmentBytes));
+      HIPCHECK_TEST(
+          hipMalloc(&recvBuffs[g], static_cast<size_t>(2) * segmentBytes));
+    } else if (segmentCounts[g] == tinySegmentCount) {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], sizeof(int32_t)));
+      recvBuffs[g] = sendBuffs[g];
+    } else {
+      HIPCHECK_TEST(
+          hipMalloc(&sendBuffs[g], static_cast<size_t>(2) * segmentBytes));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(sendBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    size_t segmentBytes = segmentCounts[g] * sizeof(int32_t);
+    if (g == myActiveGroup) {
+      initActiveSendBuffer(sendBuffs[g], segmentCounts[g], myActiveIndex);
+      HIPCHECK_TEST(
+          hipMemset(recvBuffs[g], 0, static_cast<size_t>(2) * segmentBytes));
+    } else if (segmentCounts[g] == tinySegmentCount) {
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, sizeof(int32_t)));
+    } else {
+      HIPCHECK_TEST(
+          hipMemset(sendBuffs[g], 0, static_cast<size_t>(2) * segmentBytes));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+  }
+
+  ncclResult_t result = callAllToAllCompat(
+      sendPtrs,
+      recvPtrs,
+      segmentCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyAllToAllOutput(
+      recvBuffs[myActiveGroup],
+      segmentCounts[myActiveGroup],
+      myActiveIndex,
+      myActiveGroup);
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
 /**
  * Test: In-place is rejected.
  *

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
@@ -1,0 +1,893 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/**
+ * Unit tests for Fused Multi-Group Sharded Relay All-to-All
+ *
+ * All-to-all analogue of ShardedRelayReduceScatterTest.cu. Tests the
+ * phase-synchronized execution of multiple sharded relay all-to-alls with
+ * passthrough-at-helper design. All-to-all performs NO reduction; helpers
+ * forward data and active ranks place it. IN-PLACE IS NOT SUPPORTED, so all
+ * correctness tests are out-of-place (plus an in-place-rejection test).
+ *
+ * All-to-All Semantics (per group, 2 active ranks):
+ * =================================================
+ * Each active rank's sendBuff/recvBuff hold nActiveRanksPerGroup x
+ * segmentCount elements:
+ *   - sendBuff = [sendSeg[0] | sendSeg[1]]; sendSeg[j] is destined for active
+ *     index j.
+ *   - recvBuff = [recvSeg[0] | recvSeg[1]]; recvSeg[i] receives from active
+ *     index i.
+ *
+ * To verify the segment transpose, each active rank fills sendSeg[j] with a
+ * distinct value segFillValue(myActiveIndex, j). The expected output for the
+ * rank with active index m is then recvSeg[i] = segFillValue(i, m). A wrong
+ * segment offset in the implementation produces a detectable mismatch.
+ *
+ * 2D Sparse Parallelism Configuration (8 GPUs, 4 groups):
+ *   Group 0: activeRanks = {0, 1}, helpers = {2,3,4,5,6,7}
+ *   Group 1: activeRanks = {2, 3}, helpers = {0,1,4,5,6,7}
+ *   Group 2: activeRanks = {4, 5}, helpers = {0,1,2,3,6,7}
+ *   Group 3: activeRanks = {6, 7}, helpers = {0,1,2,3,4,5}
+ *
+ * Each rank is ACTIVE for exactly ONE group, HELPER for the other 3.
+ */
+
+#include <folly/init/Init.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+#include "comm.h"
+#include "comms/rcclx/develop/meta/testinfra/TestUtils.h"
+#include "comms/rcclx/develop/meta/testinfra/TestsDistUtils.h"
+#include "nccl.h"
+
+#define HIPCHECK_TEST(cmd)                                          \
+  do {                                                              \
+    hipError_t error = cmd;                                         \
+    if (error != hipSuccess) {                                      \
+      FAIL() << "HIP error: " << hipGetErrorString(error) << " at " \
+             << __FILE__ << ":" << __LINE__;                        \
+    }                                                               \
+  } while (0)
+
+#define NCCLCHECK_TEST(cmd)                                            \
+  do {                                                                 \
+    ncclResult_t result = cmd;                                         \
+    if (result != ncclSuccess) {                                       \
+      FAIL() << "NCCL error: " << ncclGetErrorString(result) << " at " \
+             << __FILE__ << ":" << __LINE__;                           \
+    }                                                                  \
+  } while (0)
+
+struct ShardedBandwidthResult {
+  double algoBW_GBps;
+  double busBW_GBps;
+  double latency_us;
+};
+
+// Aggregate bandwidth for multi-group all-to-all. The size metric is the
+// per-group exchanged-segment (segmentCount) bytes. Bus BW for an n-rank
+// all-to-all uses the (n-1)/n factor (for 2 ranks this is 0.5).
+ShardedBandwidthResult calculateMultiGroupAggregateBandwidth(
+    size_t segmentBytesPerGroup,
+    double elapsedMs,
+    int numActiveRanks,
+    int numGroups) {
+  ShardedBandwidthResult result;
+  double elapsedSec = elapsedMs / 1000.0;
+  double totalDataSizeGB = static_cast<double>(segmentBytesPerGroup) *
+      numGroups / (1024.0 * 1024.0 * 1024.0);
+  result.algoBW_GBps = totalDataSizeGB / elapsedSec;
+  result.busBW_GBps =
+      (numActiveRanks - 1.0) / numActiveRanks * totalDataSizeGB / elapsedSec;
+  result.latency_us = elapsedMs * 1000.0;
+  return result;
+}
+
+void printMultiGroupBandwidthResults(
+    const std::string& testName,
+    size_t segmentBytesPerGroup,
+    int numRanks,
+    int numGroups,
+    int activeRanksPerGroup,
+    const ShardedBandwidthResult& aggregateResult) {
+  double dataSizePerGroupGB =
+      static_cast<double>(segmentBytesPerGroup) / (1024.0 * 1024.0 * 1024.0);
+  double totalDataSizeGB = dataSizePerGroupGB * numGroups;
+  double perGroupAlgoBW = aggregateResult.algoBW_GBps / numGroups;
+  double perGroupBusBW = aggregateResult.busBW_GBps / numGroups;
+
+  std::cout << "\n";
+  std::cout << "====================================================\n";
+  std::cout << "Multi-Group Sharded Relay All-to-All: " << testName << "\n";
+  std::cout << "====================================================\n";
+  std::cout << std::fixed << std::setprecision(2);
+  std::cout << "  Total Ranks (np):      " << numRanks << "\n";
+  std::cout << "  Number of Groups:      " << numGroups << "\n";
+  std::cout << "  Active Ranks/Group:    " << activeRanksPerGroup << "\n";
+  std::cout << "  Helper Ranks/Group:    " << (numRanks - activeRanksPerGroup)
+            << "\n";
+  std::cout << "  In-Place:              NO (unsupported)\n";
+  std::cout << "  Data Type:             int32\n";
+  std::cout << "  Segment Size/Group:    " << dataSizePerGroupGB << " GB\n";
+  std::cout << "  Total Exch (all grps): " << totalDataSizeGB << " GB\n";
+  std::cout << "  Segment Count/Group:   "
+            << (segmentBytesPerGroup / sizeof(int32_t)) << "\n";
+  std::cout << "----------------------------------------------------\n";
+  std::cout << "  Latency:               " << std::setprecision(3)
+            << aggregateResult.latency_us << " us\n";
+  std::cout << "----------------------------------------------------\n";
+  std::cout << "  AGGREGATE BANDWIDTH (all " << numGroups << " groups):\n";
+  std::cout << "    Algorithm BW:        " << std::setprecision(2)
+            << aggregateResult.algoBW_GBps << " GB/s\n";
+  std::cout << "    Bus BW:              " << aggregateResult.busBW_GBps
+            << " GB/s\n";
+  std::cout << "----------------------------------------------------\n";
+  std::cout << "  PER-GROUP BANDWIDTH (derived):\n";
+  std::cout << "    Algorithm BW:        " << perGroupAlgoBW << " GB/s\n";
+  std::cout << "    Bus BW:              " << perGroupBusBW << " GB/s\n";
+  std::cout << "====================================================\n\n";
+}
+
+// Test helper: forwards one contiguous send/recv buffer per group to the
+// sharded-relay all-to-all entry point. All-to-all is out-of-place only
+// (sendPtrs[g] must differ from recvPtrs[g] for the active group).
+static ncclResult_t callAllToAllCompat(
+    const void* const* sendPtrs,
+    void* const* recvPtrs,
+    const size_t* segmentCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    hipStream_t stream,
+    const int* const* allActiveRanks,
+    int nActiveRanksPerGroup,
+    int nGroups) {
+  return ncclShardedRelayMultiGroupAllToAll(
+      sendPtrs,
+      recvPtrs,
+      segmentCounts,
+      datatype,
+      comm,
+      stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+}
+
+class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
+ public:
+  ShardedRelayMultiGroupAllToAllTest() = default;
+
+  void SetUp() override {
+    int localSize;
+    std::tie(this->localRank, this->globalRank, this->numRanks, localSize) =
+        getTcpStoreOrMpiInfo();
+    bool isServer = (this->globalRank == 0);
+    if (checkTcpStoreEnv()) {
+      server = createTcpStore(isServer);
+    } else if (isServer) {
+      server = createTcpStore(true);
+    }
+    this->comm = createNcclComm(
+        this->globalRank,
+        this->numRanks,
+        this->localRank,
+        false,
+        nullptr,
+        server.get());
+    CUDACHECK_TEST(cudaStreamCreate(&stream));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaStreamDestroy(this->stream));
+    if (server && checkTcpStoreEnv()) {
+      finalizeNcclComm(this->globalRank, server.get());
+    }
+    NCCLCHECK_TEST(ncclCommDestroy(this->comm));
+    server.reset();
+  }
+
+  // Standard 8-rank, 4-group, 2-active-per-group sparse parallelism layout.
+  struct Standard4GroupActiveRanks {
+    int storage[4][2] = {{0, 1}, {2, 3}, {4, 5}, {6, 7}};
+    const int* allActiveRanks[4] = {
+        storage[0],
+        storage[1],
+        storage[2],
+        storage[3]};
+  };
+
+  // Distinct per-(activeIndex, segment) fill value so that a wrong segment
+  // offset in the implementation produces a detectable mismatch.
+  static int32_t segFillValue(int activeIndex, int segIndex) {
+    return (activeIndex + 1) * 10 + (segIndex + 1);
+  }
+
+  // Expected all-to-all output for the rank with active index m:
+  //   recvSeg[i] = segFillValue(i, m)  (the segment sent by active index i)
+  static int32_t expectedRecvSeg(int senderActiveIndex, int myActiveIndex) {
+    return segFillValue(senderActiveIndex, myActiveIndex);
+  }
+
+  // Initialize an active rank's send buffer (2 x segmentCount elements) so that
+  // segment j is uniformly filled with segFillValue(myActiveIndex, j).
+  void initActiveSendBuffer(
+      int32_t* deviceBuf,
+      size_t segmentCount,
+      int myActiveIndex) {
+    std::vector<int32_t> host(static_cast<size_t>(2) * segmentCount);
+    for (int j = 0; j < 2; j++) {
+      int32_t v = segFillValue(myActiveIndex, j);
+      std::fill_n(
+          host.data() + static_cast<size_t>(j) * segmentCount, segmentCount, v);
+    }
+    HIPCHECK_TEST(hipMemcpy(
+        deviceBuf,
+        host.data(),
+        static_cast<size_t>(2) * segmentCount * sizeof(int32_t),
+        hipMemcpyHostToDevice));
+  }
+
+  // Run a 1-element ncclAllReduce on `scratchBuffer` to act as a cross-rank
+  // barrier.
+  void barrierSyncOn(int32_t* /*unused*/) {
+    // Run the barrier all-reduce on a dedicated scratch allocation rather than
+    // a caller buffer. Several tests pass a buffer that they immediately
+    // (re)initialize and feed to the collective under test; running the barrier
+    // all-reduce on that same buffer is a write-after-write hazard on element 0
+    // (the all-reduce's device write is not guaranteed to be retired before the
+    // subsequent host-side init), which can leave element 0 holding the barrier
+    // value (0) instead of the init value and produces flaky "expected X but
+    // got 0" mismatches.
+    int32_t* barrierScratch = nullptr;
+    HIPCHECK_TEST(hipMalloc(&barrierScratch, sizeof(int32_t)));
+    HIPCHECK_TEST(hipMemset(barrierScratch, 0, sizeof(int32_t)));
+    NCCLCHECK_TEST(ncclAllReduce(
+        barrierScratch,
+        barrierScratch,
+        1,
+        ncclInt32,
+        ncclSum,
+        this->comm,
+        this->stream));
+    HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+    HIPCHECK_TEST(hipFree(barrierScratch));
+  }
+
+  // Copy `count` int32_t elements from `deviceBuffer` to host and verify they
+  // all equal `expectedValue`. Returns the number of mismatches (0 on success).
+  int verifyDeviceBufferEquals(
+      const int32_t* deviceBuffer,
+      size_t count,
+      int32_t expectedValue,
+      int groupIndex,
+      const char* failureMessage) {
+    std::vector<int32_t> hostOutput(count);
+    hipError_t hipErr = hipMemcpy(
+        hostOutput.data(),
+        deviceBuffer,
+        count * sizeof(int32_t),
+        hipMemcpyDeviceToHost);
+    if (hipErr != hipSuccess) {
+      ADD_FAILURE() << "HIP error in verifyDeviceBufferEquals: "
+                    << hipGetErrorString(hipErr) << " at " << __FILE__ << ":"
+                    << __LINE__;
+      return -1;
+    }
+
+    int errorCount = 0;
+    for (size_t i = 0; i < count && errorCount < 10; ++i) {
+      if (hostOutput[i] != expectedValue) {
+        std::cout << "R" << this->globalRank << ": Group " << groupIndex
+                  << " Mismatch at index " << i << ": expected "
+                  << expectedValue << " but got " << hostOutput[i] << std::endl;
+        errorCount++;
+      }
+    }
+    EXPECT_EQ(errorCount, 0) << failureMessage;
+    return errorCount;
+  }
+
+  // Verify both received segments of an active rank's recvBuff.
+  void verifyAllToAllOutput(
+      const int32_t* recvBuff,
+      size_t segmentCount,
+      int myActiveIndex,
+      int groupIndex) {
+    verifyDeviceBufferEquals(
+        recvBuff,
+        segmentCount,
+        expectedRecvSeg(0, myActiveIndex),
+        groupIndex,
+        "Found mismatches in all-to-all recvSeg[0]");
+    verifyDeviceBufferEquals(
+        recvBuff + segmentCount,
+        segmentCount,
+        expectedRecvSeg(1, myActiveIndex),
+        groupIndex,
+        "Found mismatches in all-to-all recvSeg[1]");
+  }
+
+  int localRank{0};
+  int globalRank{0};
+  int numRanks{0};
+  ncclComm_t comm;
+  cudaStream_t stream;
+  std::unique_ptr<c10d::TCPStore> server{nullptr};
+};
+
+/**
+ * Test: Multi-Group Correctness with 4 groups (OUT-OF-PLACE)
+ *
+ * Active sendBuff holds 2 x segmentCount elements with distinct per-segment
+ * fill. Expected recvSeg[i] for active index m = segFillValue(i, m).
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_4Groups_OutOfPlace_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t segmentBytes = 64ULL * 1024 * 1024;
+  const size_t segmentCount = segmentBytes / sizeof(int32_t);
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      // Active rank: sendBuff and recvBuff each hold 2 segments (out-of-place).
+      HIPCHECK_TEST(
+          hipMalloc(&sendBuffs[g], static_cast<size_t>(2) * segmentBytes));
+      HIPCHECK_TEST(
+          hipMalloc(&recvBuffs[g], static_cast<size_t>(2) * segmentBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g]; // helper: same buffer for send/recv
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      initActiveSendBuffer(sendBuffs[g], segmentCount, myActiveIndex);
+      HIPCHECK_TEST(
+          hipMemset(recvBuffs[g], 0, static_cast<size_t>(2) * segmentBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t segmentCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+    segmentCounts[g] = segmentCount;
+  }
+
+  ncclResult_t result = callAllToAllCompat(
+      sendPtrs,
+      recvPtrs,
+      segmentCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyAllToAllOutput(
+      recvBuffs[myActiveGroup], segmentCount, myActiveIndex, myActiveGroup);
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+/**
+ * Test: In-place is rejected.
+ *
+ * Passing sendBuff == recvBuff for the active group must return
+ * ncclInvalidArgument (all-to-all does not support in-place).
+ */
+TEST_F(ShardedRelayMultiGroupAllToAllTest, InPlace_Rejected) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t segmentBytes = 16ULL * 1024 * 1024;
+  const size_t segmentCount = segmentBytes / sizeof(int32_t);
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  // All groups use a single buffer for send and recv (in-place).
+  int32_t* buffers[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(
+        hipMalloc(&buffers[g], static_cast<size_t>(2) * segmentBytes));
+  }
+
+  barrierSyncOn(buffers[0]);
+
+  if (myActiveIndex >= 0) {
+    initActiveSendBuffer(buffers[myActiveGroup], segmentCount, myActiveIndex);
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t segmentCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = buffers[g];
+    recvPtrs[g] = buffers[g]; // in-place
+    segmentCounts[g] = segmentCount;
+  }
+
+  ncclResult_t result = callAllToAllCompat(
+      sendPtrs,
+      recvPtrs,
+      segmentCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  // Active ranks must observe the in-place rejection.
+  EXPECT_EQ(result, ncclInvalidArgument)
+      << "In-place all-to-all should be rejected with ncclInvalidArgument";
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(buffers[g]));
+  }
+}
+
+/**
+ * Test: Single group via multi-group API (OUT-OF-PLACE)
+ */
+TEST_F(ShardedRelayMultiGroupAllToAllTest, Correctness_SingleGroup_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 1;
+  const int nActiveRanksPerGroup = 2;
+  const size_t segmentBytes = 64ULL * 1024 * 1024;
+  const size_t segmentCount = segmentBytes / sizeof(int32_t);
+
+  const int activeRanks[] = {0, 1};
+  const int* allActiveRanks[] = {activeRanks};
+
+  bool isActive = (this->globalRank == 0 || this->globalRank == 1);
+  int myActiveIndex = this->globalRank; // 0 or 1 for active ranks
+
+  int32_t* sendBuff = nullptr;
+  int32_t* recvBuff = nullptr;
+  if (isActive) {
+    HIPCHECK_TEST(hipMalloc(&sendBuff, static_cast<size_t>(2) * segmentBytes));
+    HIPCHECK_TEST(hipMalloc(&recvBuff, static_cast<size_t>(2) * segmentBytes));
+  } else {
+    size_t helperBufferSize =
+        static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
+    HIPCHECK_TEST(hipMalloc(&sendBuff, helperBufferSize));
+    recvBuff = sendBuff;
+  }
+
+  barrierSyncOn(sendBuff);
+
+  if (isActive) {
+    initActiveSendBuffer(sendBuff, segmentCount, myActiveIndex);
+    HIPCHECK_TEST(
+        hipMemset(recvBuff, 0, static_cast<size_t>(2) * segmentBytes));
+  } else {
+    size_t helperBufferSize =
+        static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
+    HIPCHECK_TEST(hipMemset(sendBuff, 0, helperBufferSize));
+  }
+
+  const void* sendPtrs[1];
+  void* recvPtrs[1];
+  size_t segmentCounts[] = {segmentCount};
+  sendPtrs[0] = sendBuff;
+  recvPtrs[0] = recvBuff;
+
+  ncclResult_t result = callAllToAllCompat(
+      sendPtrs,
+      recvPtrs,
+      segmentCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  if (isActive) {
+    verifyAllToAllOutput(recvBuff, segmentCount, myActiveIndex, 0);
+  }
+
+  HIPCHECK_TEST(hipFree(sendBuff));
+  if (isActive) {
+    HIPCHECK_TEST(hipFree(recvBuff));
+  }
+}
+
+/**
+ * Test: Correctness with minimum passthrough helper buffers (OUT-OF-PLACE)
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_4Groups_PassthroughHelperEquivalence) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t segmentBytes = 64ULL * 1024 * 1024;
+  const size_t segmentCount = segmentBytes / sizeof(int32_t);
+  const int numHelpers = this->numRanks - nActiveRanksPerGroup;
+  const int numChunks = numHelpers + 1;
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  // Minimum passthrough helper buffer size from segmentCount.
+  size_t chunkSize = segmentCount / numChunks;
+  chunkSize = (chunkSize / 128) * 128; // CHUNK_ALIGN_ELEMENTS
+  if (chunkSize == 0) {
+    chunkSize = segmentCount;
+  }
+  size_t minHelperElements = std::min(
+      segmentCount, static_cast<size_t>(nActiveRanksPerGroup) * chunkSize);
+  size_t minHelperBytes = minHelperElements * sizeof(int32_t);
+
+  int32_t* activeSendBuffer = nullptr;
+  int32_t* activeRecvBuffer = nullptr;
+  int32_t* helperBuffers[nGroups];
+
+  HIPCHECK_TEST(
+      hipMalloc(&activeSendBuffer, static_cast<size_t>(2) * segmentBytes));
+  HIPCHECK_TEST(
+      hipMalloc(&activeRecvBuffer, static_cast<size_t>(2) * segmentBytes));
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      helperBuffers[g] = nullptr;
+    } else {
+      HIPCHECK_TEST(hipMalloc(&helperBuffers[g], minHelperBytes));
+    }
+  }
+
+  barrierSyncOn(activeSendBuffer);
+
+  initActiveSendBuffer(activeSendBuffer, segmentCount, myActiveIndex);
+  HIPCHECK_TEST(
+      hipMemset(activeRecvBuffer, 0, static_cast<size_t>(2) * segmentBytes));
+  for (int g = 0; g < nGroups; g++) {
+    if (g != myActiveGroup) {
+      HIPCHECK_TEST(hipMemset(helperBuffers[g], 0, minHelperBytes));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t segmentCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      sendPtrs[g] = activeSendBuffer;
+      recvPtrs[g] = activeRecvBuffer;
+    } else {
+      sendPtrs[g] = helperBuffers[g];
+      recvPtrs[g] = helperBuffers[g];
+    }
+    segmentCounts[g] = segmentCount;
+  }
+
+  ncclResult_t result = callAllToAllCompat(
+      sendPtrs,
+      recvPtrs,
+      segmentCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyAllToAllOutput(
+      activeRecvBuffer, segmentCount, myActiveIndex, myActiveGroup);
+
+  HIPCHECK_TEST(hipFree(activeSendBuffer));
+  HIPCHECK_TEST(hipFree(activeRecvBuffer));
+  for (int g = 0; g < nGroups; g++) {
+    if (g != myActiveGroup) {
+      HIPCHECK_TEST(hipFree(helperBuffers[g]));
+    }
+  }
+}
+
+/**
+ * Test: Correctness_PartialGroupsZeroCount (OUT-OF-PLACE)
+ *
+ * Groups 0 and 1 have data; groups 2 and 3 pass segmentCount=0 and must be
+ * skipped without crash or corruption.
+ */
+TEST_F(ShardedRelayMultiGroupAllToAllTest, Correctness_PartialGroupsZeroCount) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t segmentBytes = 16ULL * 1024 * 1024;
+  const size_t segmentCount = segmentBytes / sizeof(int32_t);
+
+  const size_t segmentCounts[nGroups] = {segmentCount, segmentCount, 0, 0};
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  const size_t placeholderBytes = sizeof(int32_t); // 1 element
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+
+  for (int g = 0; g < nGroups; g++) {
+    if (segmentCounts[g] == 0) {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], placeholderBytes));
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, placeholderBytes));
+      recvBuffs[g] = sendBuffs[g];
+      continue;
+    }
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(
+          hipMalloc(&sendBuffs[g], static_cast<size_t>(2) * segmentBytes));
+      HIPCHECK_TEST(
+          hipMalloc(&recvBuffs[g], static_cast<size_t>(2) * segmentBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(sendBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (segmentCounts[g] == 0) {
+      continue;
+    }
+    if (g == myActiveGroup) {
+      initActiveSendBuffer(sendBuffs[g], segmentCount, myActiveIndex);
+      HIPCHECK_TEST(
+          hipMemset(recvBuffs[g], 0, static_cast<size_t>(2) * segmentBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+  }
+
+  ncclResult_t result = callAllToAllCompat(
+      sendPtrs,
+      recvPtrs,
+      segmentCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess)
+      << "ncclShardedRelayMultiGroupAllToAll failed with partial segmentCount=0 groups";
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  if (myActiveGroup < 2) { // groups 0 and 1 had data
+    verifyAllToAllOutput(
+        recvBuffs[myActiveGroup], segmentCount, myActiveIndex, myActiveGroup);
+  }
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (segmentCounts[g] != 0 && g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+/**
+ * Test: BusBW with 4-group Multi-Group All-to-All (1GB segment, OUT-OF-PLACE)
+ *
+ * Segment size is 1GB: an all-to-all active rank's sendBuff and recvBuff each
+ * hold 2 x segmentBytes, so the per-rank footprint is larger than allreduce's.
+ * 1GB keeps the suite inside a shared devgpu/CI memory budget.
+ */
+TEST_F(ShardedRelayMultiGroupAllToAllTest, Z_BusBW_4Groups_OutOfPlace_1GB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t segmentBytes = 1ULL * 1024 * 1024 * 1024; // 1 GB segment/group
+  const size_t segmentCount = segmentBytes / sizeof(int32_t);
+  const int nIters = 20;
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(
+          hipMalloc(&sendBuffs[g], static_cast<size_t>(2) * segmentBytes));
+      HIPCHECK_TEST(
+          hipMalloc(&recvBuffs[g], static_cast<size_t>(2) * segmentBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(
+          hipMemset(sendBuffs[g], 1, static_cast<size_t>(2) * segmentBytes));
+      HIPCHECK_TEST(
+          hipMemset(recvBuffs[g], 0, static_cast<size_t>(2) * segmentBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t segmentCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+    segmentCounts[g] = segmentCount;
+  }
+
+  hipEvent_t startEvent, stopEvent;
+  HIPCHECK_TEST(hipEventCreate(&startEvent));
+  HIPCHECK_TEST(hipEventCreate(&stopEvent));
+
+  float bestTimeMs = std::numeric_limits<float>::max();
+  float totalTimeMs = 0.0f;
+
+  if (this->globalRank == 0) {
+    std::cout << "[Benchmark] Running " << nIters << " iterations..."
+              << std::endl;
+  }
+
+  for (int iter = 0; iter < nIters; iter++) {
+    HIPCHECK_TEST(hipEventRecord(startEvent, this->stream));
+    ncclResult_t result = callAllToAllCompat(
+        sendPtrs,
+        recvPtrs,
+        segmentCounts,
+        ncclInt32,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipEventRecord(stopEvent, this->stream));
+    HIPCHECK_TEST(hipEventSynchronize(stopEvent));
+
+    float elapsedMs = 0.0f;
+    HIPCHECK_TEST(hipEventElapsedTime(&elapsedMs, startEvent, stopEvent));
+
+    if (this->globalRank == 0) {
+      std::cout << "  Iteration " << (iter + 1) << ": " << elapsedMs << " ms"
+                << std::endl;
+    }
+
+    if (elapsedMs < bestTimeMs) {
+      bestTimeMs = elapsedMs;
+    }
+    totalTimeMs += elapsedMs;
+  }
+
+  float avgTimeMs = totalTimeMs / nIters;
+
+  if (this->globalRank == 0) {
+    std::cout << "\n[Benchmark] Best time: " << bestTimeMs << " ms, "
+              << "Avg time: " << avgTimeMs << " ms" << std::endl;
+
+    ShardedBandwidthResult bwResult = calculateMultiGroupAggregateBandwidth(
+        segmentBytes, bestTimeMs, nActiveRanksPerGroup, nGroups);
+    printMultiGroupBandwidthResults(
+        "4-Group OUT-OF-PLACE 1GB",
+        segmentBytes,
+        this->numRanks,
+        nGroups,
+        nActiveRanksPerGroup,
+        bwResult);
+  }
+
+  HIPCHECK_TEST(hipEventDestroy(startEvent));
+  HIPCHECK_TEST(hipEventDestroy(stopEvent));
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
@@ -1333,115 +1333,70 @@ TEST_F(ShardedRelayMultiGroupAllToAllTest, Z_BusBW_4Groups_OutOfPlace_1GB) {
  * Each active rank's sendBuff holds A=4 segments of segmentCount; segment j is
  * filled with segFillValue(myActiveIndex, j). After the all-to-all, owner m's
  * recvSeg[i] must equal segFillValue(i, m), so a wrong round/partner mapping in
- * the flat 2-hop relay is detectable per segment.
+ * either the exact direct or XOR/Latin route is detectable per segment.
  */
 TEST_F(
     ShardedRelayMultiGroupAllToAllTest,
-    Correctness_4Active_2Groups_OutOfPlace) {
+    Correctness_4Active_RoutedLowerBoundary_63MiB) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  const int nGroups = 2;
-  const int nActiveRanksPerGroup = 4;
-  const size_t segmentBytes = 64ULL * 1024 * 1024;
-  const size_t segmentCount = segmentBytes / sizeof(int32_t);
+  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t));
+  runA4CorrectnessCase(segmentCount, true);
+}
 
-  TwoGroupFourActiveRanks groupConfig;
-  const int* const* allActiveRanks = groupConfig.allActiveRanks;
-
-  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
-  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
-
-  int32_t* sendBuffs[nGroups];
-  int32_t* recvBuffs[nGroups];
-  for (int g = 0; g < nGroups; g++) {
-    if (g == myActiveGroup) {
-      HIPCHECK_TEST(hipMalloc(
-          &sendBuffs[g],
-          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes));
-      HIPCHECK_TEST(hipMalloc(
-          &recvBuffs[g],
-          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes));
-    } else {
-      size_t helperBufferSize =
-          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
-      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
-      recvBuffs[g] = sendBuffs[g];
-    }
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_4Active_DirectBelowLowerBoundary) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  barrierSyncOn(recvBuffs[0]);
+  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t)) - 1;
+  runA4CorrectnessCase(segmentCount, false);
+}
 
-  for (int g = 0; g < nGroups; g++) {
-    if (g == myActiveGroup) {
-      initActiveSendBuffer(
-          sendBuffs[g], segmentCount, myActiveIndex, nActiveRanksPerGroup);
-      HIPCHECK_TEST(hipMemset(
-          recvBuffs[g],
-          0,
-          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes));
-    } else {
-      size_t helperBufferSize =
-          static_cast<size_t>(nActiveRanksPerGroup) * segmentBytes;
-      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
-    }
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_4Active_RoutedUnalignedTail) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  const void* sendPtrs[nGroups];
-  void* recvPtrs[nGroups];
-  size_t segmentCounts[nGroups];
-  for (int g = 0; g < nGroups; g++) {
-    sendPtrs[g] = sendBuffs[g];
-    recvPtrs[g] = recvBuffs[g];
-    segmentCounts[g] = segmentCount;
+  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t)) + 1;
+  runA4CorrectnessCase(segmentCount, true, true);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_4Active_DirectUpperBoundary_256MiB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  ncclResult_t result = callAllToAllCompat(
-      sendPtrs,
-      recvPtrs,
-      segmentCounts,
-      ncclInt32,
-      this->comm,
-      this->stream,
-      allActiveRanks,
-      nActiveRanksPerGroup,
-      nGroups);
-  ASSERT_EQ(result, ncclSuccess);
-  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
-
-  verifyAllToAllOutput(
-      recvBuffs[myActiveGroup],
-      segmentCount,
-      myActiveIndex,
-      myActiveGroup,
-      nActiveRanksPerGroup);
-
-  for (int g = 0; g < nGroups; g++) {
-    HIPCHECK_TEST(hipFree(sendBuffs[g]));
-    if (g == myActiveGroup) {
-      HIPCHECK_TEST(hipFree(recvBuffs[g]));
-    }
-  }
+  constexpr size_t perActiveBytes = 256ULL * 1024 * 1024;
+  constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t));
+  runA4CorrectnessCase(segmentCount, false);
 }
 
 /**
- * Tiny-segment regression: forces the relay csz==0 path for 4 active ranks.
- * With segmentCount=512, csz = align(512 / 5) = 0, so each round's exchange is
- * a full whole-segment direct partner swap (no helper hops). The send and recv
- * of that swap MUST share one ncclGroup; splitting them across the two hops
- * would deadlock. All A-1 XOR rounds are exercised.
+ * Tiny-segment regression for the exact direct fallback below the retained
+ * A=4 XOR/Latin routing window.
  */
 TEST_F(
     ShardedRelayMultiGroupAllToAllTest,
-    Correctness_4Active_2Groups_TinyCsz0_OutOfPlace) {
+    Correctness_4Active_TinyDirect_OutOfPlace) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
   const int nGroups = 2;
   const int nActiveRanksPerGroup = 4;
-  const size_t segmentCount = 512; // align(512 / 5) == 0 -> relay csz == 0
+  const size_t segmentCount = 512;
   const size_t segmentBytes = segmentCount * sizeof(int32_t);
 
   TwoGroupFourActiveRanks groupConfig;

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
@@ -1748,6 +1748,26 @@ TEST_F(
 
 TEST_F(
     ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_4Active_2Groups_Bfloat16_SeededDirect_Sum) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  runBfloat16A4SeededDirect(ncclSum);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_4Active_2Groups_Bfloat16_SeededDirect_Avg) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  runBfloat16A4SeededDirect(ncclAvg);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
     Correctness_4Active_2Groups_OutOfPlace) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
@@ -486,6 +486,87 @@ class ShardedRelayMultiGroupReduceScatterTest : public ::testing::Test {
     }
   }
 
+  // Single-group (nGroups=1) reduce-scatter with 4 active ranks {0,1,2,3} and
+  // ranks {4,5,6,7} acting as passthrough helpers. Exercises the A=4 kernel
+  // path WITHOUT multi-group fusion (the single-group counterpart to the
+  // 4Active_2Groups tests). Covers SUM/AVG and in-place/out-of-place.
+  void runReduceScatterA4SingleGroup(ncclRedOp_t op, bool inPlace) {
+    constexpr int nGroups = 1;
+    constexpr int nActiveRanksPerGroup = 4;
+    const size_t recvBytes = 64ULL * 1024 * 1024;
+    const size_t recvCount = recvBytes / sizeof(int32_t);
+
+    const int activeRanks[] = {0, 1, 2, 3};
+    const int* allActiveRanks[] = {activeRanks};
+
+    const bool isActive = this->globalRank < nActiveRanksPerGroup;
+    const int myActiveIndex = this->globalRank; // 0..3 for active ranks
+    const size_t helperBytes =
+        static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+
+    int32_t* sendBuff = nullptr;
+    int32_t* recvBuff = nullptr;
+    if (isActive) {
+      HIPCHECK_TEST(hipMalloc(&sendBuff, helperBytes)); // A blocks
+      if (inPlace) {
+        // In-place: recvBuff aliases the owner's block inside sendBuff.
+        recvBuff = sendBuff + static_cast<size_t>(myActiveIndex) * recvCount;
+      } else {
+        HIPCHECK_TEST(hipMalloc(&recvBuff, recvBytes));
+      }
+    } else {
+      HIPCHECK_TEST(hipMalloc(&sendBuff, helperBytes));
+      recvBuff = sendBuff;
+    }
+
+    barrierSyncOn(sendBuff);
+
+    if (isActive) {
+      initActiveSendBuffer(
+          sendBuff, recvCount, myActiveIndex, nActiveRanksPerGroup);
+      if (!inPlace) {
+        HIPCHECK_TEST(hipMemset(recvBuff, 0, recvBytes));
+      }
+    } else {
+      HIPCHECK_TEST(hipMemset(sendBuff, 0, helperBytes));
+    }
+
+    const void* sendPtrs[1] = {sendBuff};
+    void* recvPtrs[1] = {recvBuff};
+    size_t recvCounts[1] = {recvCount};
+
+    ncclResult_t result = callReduceScatterCompat(
+        sendPtrs,
+        recvPtrs,
+        recvCounts,
+        ncclInt32,
+        op,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+    if (isActive) {
+      const int32_t sum =
+          expectedReduceScatterSum(myActiveIndex, nActiveRanksPerGroup);
+      const int32_t expected = op == ncclAvg ? sum / nActiveRanksPerGroup : sum;
+      verifyDeviceBufferEquals(
+          recvBuff,
+          recvCount,
+          expected,
+          0,
+          "4-active single-group reduce-scatter mismatch");
+    }
+
+    HIPCHECK_TEST(hipFree(sendBuff));
+    if (isActive && !inPlace) {
+      HIPCHECK_TEST(hipFree(recvBuff));
+    }
+  }
+
   void runBfloat16A4SeededDirect(ncclRedOp_t op) {
     constexpr int nGroups = 2;
     constexpr int nActiveRanksPerGroup = 4;
@@ -1946,6 +2027,39 @@ TEST_F(
       HIPCHECK_TEST(hipFree(recvBuffs[g]));
     }
   }
+}
+
+// Single-group (nGroups=1) A=4 reduce-scatter. Ranks {0,1,2,3} are active and
+// {4,5,6,7} are passthrough helpers, exercising the A=4 path without the
+// multi-group fusion the 4Active_2Groups tests cover.
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_4Active_SingleGroup_InPlace) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  runReduceScatterA4SingleGroup(ncclSum, /*inPlace=*/true);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_4Active_SingleGroup_OutOfPlace) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  runReduceScatterA4SingleGroup(ncclSum, /*inPlace=*/false);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_4Active_SingleGroup_Avg) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  runReduceScatterA4SingleGroup(ncclAvg, /*inPlace=*/false);
 }
 
 /**

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
@@ -54,6 +54,8 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -271,6 +273,320 @@ class ShardedRelayMultiGroupReduceScatterTest : public ::testing::Test {
         host.data(),
         static_cast<size_t>(nActiveRanks) * recvCount * sizeof(int32_t),
         hipMemcpyHostToDevice));
+  }
+
+  static uint16_t bfloat16Bits(float value) {
+    uint32_t bits;
+    std::memcpy(&bits, &value, sizeof(bits));
+    return static_cast<uint16_t>(bits >> 16);
+  }
+
+  void initActiveBfloat16SendBuffer(
+      uint16_t* deviceBuf,
+      size_t recvCount,
+      int myActiveIndex) {
+    constexpr int nActiveRanks = 2;
+    std::vector<uint16_t> host(nActiveRanks * recvCount);
+    for (int block = 0; block < nActiveRanks; block++) {
+      const uint16_t value = bfloat16Bits(
+          static_cast<float>(blockFillValue(myActiveIndex, block)));
+      std::fill_n(host.data() + block * recvCount, recvCount, value);
+    }
+    HIPCHECK_TEST(hipMemcpy(
+        deviceBuf,
+        host.data(),
+        host.size() * sizeof(uint16_t),
+        hipMemcpyHostToDevice));
+  }
+
+  void verifyBfloat16BufferEquals(
+      const uint16_t* deviceBuffer,
+      size_t count,
+      uint16_t expectedValue,
+      int groupIndex,
+      const char* boundary) {
+    std::vector<uint16_t> hostOutput(count);
+    HIPCHECK_TEST(hipMemcpy(
+        hostOutput.data(),
+        deviceBuffer,
+        count * sizeof(uint16_t),
+        hipMemcpyDeviceToHost));
+
+    int errorCount = 0;
+    for (size_t i = 0; i < count && errorCount < 10; ++i) {
+      if (hostOutput[i] != expectedValue) {
+        std::cout << "R" << this->globalRank << ": Group " << groupIndex
+                  << " BF16 mismatch at index " << i << ": expected bits "
+                  << expectedValue << " but got " << hostOutput[i] << std::endl;
+        errorCount++;
+      }
+    }
+    EXPECT_EQ(errorCount, 0) << "BF16 reduce-scatter mismatch at the "
+                             << boundary << " routing-threshold case";
+  }
+
+  void verifyBfloat16BufferEquals(
+      const uint16_t* deviceBuffer,
+      const std::vector<uint16_t>& expected,
+      const char* context) {
+    std::vector<uint16_t> actual(expected.size());
+    HIPCHECK_TEST(hipMemcpy(
+        actual.data(),
+        deviceBuffer,
+        actual.size() * sizeof(uint16_t),
+        hipMemcpyDeviceToHost));
+
+    int errorCount = 0;
+    for (size_t i = 0; i < actual.size() && errorCount < 10; ++i) {
+      if (actual[i] != expected[i]) {
+        std::cout << "R" << this->globalRank << ": " << context << " at index "
+                  << i << ": expected bits " << expected[i] << " but got "
+                  << actual[i] << std::endl;
+        errorCount++;
+      }
+    }
+    EXPECT_EQ(errorCount, 0) << context;
+  }
+
+  bool bfloat16BufferContainsNonSentinel(
+      const uint16_t* deviceBuffer,
+      size_t count,
+      uint16_t sentinel) {
+    std::vector<uint16_t> hostBuffer(count);
+    const hipError_t error = hipMemcpy(
+        hostBuffer.data(),
+        deviceBuffer,
+        count * sizeof(uint16_t),
+        hipMemcpyDeviceToHost);
+    if (error != hipSuccess) {
+      ADD_FAILURE() << "HIP error: " << hipGetErrorString(error);
+      return false;
+    }
+    return std::any_of(
+        hostBuffer.begin(), hostBuffer.end(), [sentinel](uint16_t value) {
+          return value != sentinel;
+        });
+  }
+
+  void runBfloat16A2RoutingThreshold(
+      int nGroups,
+      size_t thresholdBytes,
+      ncclRedOp_t op) {
+    constexpr int nActiveRanksPerGroup = 2;
+    constexpr uint16_t helperSentinel = 0xffff;
+    const size_t thresholdCount =
+        thresholdBytes / nActiveRanksPerGroup / sizeof(uint16_t);
+    const size_t boundaryCounts[] = {
+        thresholdCount - 1, thresholdCount, thresholdCount + 1};
+    const char* boundaries[] = {"below", "at", "above"};
+
+    Standard4GroupActiveRanks fourGroupConfig;
+    const int singleGroupStorage[] = {0, 1};
+    const int* singleGroupActiveRanks[] = {singleGroupStorage};
+    const int* const* allActiveRanks =
+        nGroups == 1 ? singleGroupActiveRanks : fourGroupConfig.allActiveRanks;
+
+    const int myActiveGroup = nGroups == 1
+        ? (this->globalRank < nActiveRanksPerGroup ? 0 : -1)
+        : this->globalRank / nActiveRanksPerGroup;
+    const int myActiveIndex = nGroups == 1
+        ? this->globalRank
+        : this->globalRank % nActiveRanksPerGroup;
+
+    for (int boundaryIndex = 0; boundaryIndex < 3; boundaryIndex++) {
+      const size_t recvCount = boundaryCounts[boundaryIndex];
+      const size_t recvBytes = recvCount * sizeof(uint16_t);
+      std::vector<uint16_t*> sendBuffs(nGroups);
+      std::vector<uint16_t*> recvBuffs(nGroups);
+
+      for (int g = 0; g < nGroups; g++) {
+        HIPCHECK_TEST(
+            hipMalloc(&sendBuffs[g], nActiveRanksPerGroup * recvBytes));
+        if (g == myActiveGroup) {
+          HIPCHECK_TEST(hipMalloc(&recvBuffs[g], recvBytes));
+        } else {
+          recvBuffs[g] = sendBuffs[g];
+        }
+      }
+
+      barrierSyncOn(reinterpret_cast<int32_t*>(sendBuffs[0]));
+
+      const std::vector<uint16_t> helperSentinels(
+          nActiveRanksPerGroup * recvCount, helperSentinel);
+      for (int g = 0; g < nGroups; g++) {
+        if (g == myActiveGroup) {
+          initActiveBfloat16SendBuffer(sendBuffs[g], recvCount, myActiveIndex);
+          HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, recvBytes));
+        } else {
+          HIPCHECK_TEST(hipMemcpy(
+              sendBuffs[g],
+              helperSentinels.data(),
+              nActiveRanksPerGroup * recvBytes,
+              hipMemcpyHostToDevice));
+        }
+      }
+      HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+      std::vector<const void*> sendPtrs(nGroups);
+      std::vector<void*> recvPtrs(nGroups);
+      std::vector<size_t> recvCounts(nGroups, recvCount);
+      for (int g = 0; g < nGroups; g++) {
+        sendPtrs[g] = sendBuffs[g];
+        recvPtrs[g] = recvBuffs[g];
+      }
+
+      const ncclResult_t result = callReduceScatterCompat(
+          sendPtrs.data(),
+          recvPtrs.data(),
+          recvCounts.data(),
+          ncclBfloat16,
+          op,
+          this->comm,
+          this->stream,
+          allActiveRanks,
+          nActiveRanksPerGroup,
+          nGroups);
+      ASSERT_EQ(result, ncclSuccess)
+          << "BF16 reduce-scatter failed at the " << boundaries[boundaryIndex]
+          << " routing-threshold case";
+      HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+      if (myActiveGroup >= 0) {
+        const int32_t expectedSum =
+            expectedReduceScatterSum(myActiveIndex, nActiveRanksPerGroup);
+        const float expected = op == ncclAvg
+            ? static_cast<float>(expectedSum) / nActiveRanksPerGroup
+            : static_cast<float>(expectedSum);
+        verifyBfloat16BufferEquals(
+            recvBuffs[myActiveGroup],
+            recvCount,
+            bfloat16Bits(expected),
+            myActiveGroup,
+            boundaries[boundaryIndex]);
+      }
+
+      for (int g = 0; g < nGroups; g++) {
+        if (g == myActiveGroup) {
+          continue;
+        }
+        const bool helperParticipated = bfloat16BufferContainsNonSentinel(
+            sendBuffs[g], nActiveRanksPerGroup * recvCount, helperSentinel);
+        EXPECT_EQ(helperParticipated, boundaryIndex != 0)
+            << "Group " << g << " helper buffer on rank " << this->globalRank
+            << " did not witness the expected route at the "
+            << boundaries[boundaryIndex] << " routing-threshold case";
+      }
+
+      for (int g = 0; g < nGroups; g++) {
+        HIPCHECK_TEST(hipFree(sendBuffs[g]));
+        if (g == myActiveGroup) {
+          HIPCHECK_TEST(hipFree(recvBuffs[g]));
+        }
+      }
+    }
+  }
+
+  void runBfloat16A4SeededDirect(ncclRedOp_t op) {
+    constexpr int nGroups = 2;
+    constexpr int nActiveRanksPerGroup = 4;
+    constexpr size_t recvCount = 4099;
+    const size_t recvBytes = recvCount * sizeof(uint16_t);
+    const size_t inputCount = nActiveRanksPerGroup * recvCount;
+
+    TwoGroupFourActiveRanks groupConfig;
+    const int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+    const int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+    uint16_t* sendBuffs[nGroups];
+    uint16_t* recvBuffs[nGroups];
+    for (int g = 0; g < nGroups; g++) {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], inputCount * sizeof(uint16_t)));
+      if (g == myActiveGroup) {
+        HIPCHECK_TEST(hipMalloc(&recvBuffs[g], recvBytes));
+      } else {
+        recvBuffs[g] = sendBuffs[g];
+      }
+    }
+
+    barrierSyncOn(reinterpret_cast<int32_t*>(sendBuffs[0]));
+
+    std::vector<uint16_t> expectedInput(inputCount);
+    for (int owner = 0; owner < nActiveRanksPerGroup; owner++) {
+      for (size_t i = 0; i < recvCount; i++) {
+        // At this magnitude BF16 has a 2-unit ULP. The even-mantissa seed
+        // rounds each subsequent +1 back to itself, while reassociating the
+        // three peer contributions would produce seed + 4.
+        const float seed =
+            256.0f + owner * 16.0f + static_cast<float>(i % 2) * 4.0f;
+        const float value = myActiveIndex == 0 ? seed : 1.0f;
+        expectedInput[static_cast<size_t>(owner) * recvCount + i] =
+            bfloat16Bits(value);
+      }
+    }
+
+    for (int g = 0; g < nGroups; g++) {
+      if (g == myActiveGroup) {
+        HIPCHECK_TEST(hipMemcpy(
+            sendBuffs[g],
+            expectedInput.data(),
+            expectedInput.size() * sizeof(uint16_t),
+            hipMemcpyHostToDevice));
+        HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, recvBytes));
+      } else {
+        HIPCHECK_TEST(
+            hipMemset(sendBuffs[g], 0, inputCount * sizeof(uint16_t)));
+      }
+    }
+
+    const void* sendPtrs[nGroups];
+    void* recvPtrs[nGroups];
+    size_t recvCounts[nGroups];
+    for (int g = 0; g < nGroups; g++) {
+      sendPtrs[g] = sendBuffs[g];
+      recvPtrs[g] = recvBuffs[g];
+      recvCounts[g] = recvCount;
+    }
+
+    const ncclResult_t result = callReduceScatterCompat(
+        sendPtrs,
+        recvPtrs,
+        recvCounts,
+        ncclBfloat16,
+        op,
+        this->comm,
+        this->stream,
+        groupConfig.allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+    std::vector<uint16_t> expectedOutput(recvCount);
+    for (size_t i = 0; i < recvCount; i++) {
+      float expected =
+          256.0f + myActiveIndex * 16.0f + static_cast<float>(i % 2) * 4.0f;
+      if (op == ncclAvg) {
+        expected /= nActiveRanksPerGroup;
+      }
+      expectedOutput[i] = bfloat16Bits(expected);
+    }
+
+    verifyBfloat16BufferEquals(
+        recvBuffs[myActiveGroup],
+        expectedOutput,
+        op == ncclAvg ? "A=4 seeded direct BF16 AVG mismatch"
+                      : "A=4 seeded direct BF16 SUM mismatch");
+    verifyBfloat16BufferEquals(
+        sendBuffs[myActiveGroup],
+        expectedInput,
+        "A=4 seeded direct modified the out-of-place input");
+
+    for (int g = 0; g < nGroups; g++) {
+      HIPCHECK_TEST(hipFree(sendBuffs[g]));
+      if (g == myActiveGroup) {
+        HIPCHECK_TEST(hipFree(recvBuffs[g]));
+      }
+    }
   }
 
   // Run a 1-element ncclAllReduce on `scratchBuffer` to act as a cross-rank
@@ -1001,7 +1317,7 @@ TEST_F(
   const size_t recvBytes = 64ULL * 1024 * 1024;
   const size_t recvCount = recvBytes / sizeof(int32_t);
   const int numHelpers = this->numRanks - nActiveRanksPerGroup;
-  const int numChunks = numHelpers + 1;
+  const int numChunks = numHelpers + 2;
 
   Standard4GroupActiveRanks groupConfig;
   const int* const* allActiveRanks = groupConfig.allActiveRanks;

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
@@ -1,0 +1,1200 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/**
+ * Unit tests for Fused Multi-Group Sharded Relay Reduce-Scatter
+ *
+ * Reduce-scatter analogue of ShardedRelayAllReduceTest.cu. Tests the
+ * phase-synchronized execution of multiple sharded relay reduce-scatters with
+ * passthrough-at-helper design. All groups execute in lockstep phases; helpers
+ * forward data without local reduction.
+ *
+ * Reduce-Scatter Semantics (per group, 2 active ranks):
+ * =====================================================
+ * Each active rank's sendBuff holds nActiveRanksPerGroup x recvCount elements:
+ * block[i] is the slice destined for active index i. Each active recvBuff holds
+ * recvCount elements and receives sum_over_active_ranks(sendBuff[block i]).
+ *
+ * To verify correct block selection, each active rank fills block j with a
+ * distinct value blockFillValue(myActiveIndex, j). The expected output for the
+ * rank with active index m is then:
+ *   blockFillValue(0, m) + blockFillValue(1, m)
+ * A wrong block offset in the implementation produces a detectable mismatch.
+ *
+ * Algorithm Design (Phase-Synchronized, Passthrough Helpers):
+ * ===========================================================
+ * Phase 1 (active->helpers): Both active ranks send chunks of their sendBlock
+ *         (the block destined for the OTHER active rank) to helpers. Helpers
+ *         receive into two slots (slot a = data from active rank a).
+ * Phase 2 (helpers->active): each helper forwards slot 0 -> a1, slot 1 -> a0.
+ * Phase 3 (active reduce): add relay scratch into the seeded output block.
+ * Phase 4 (active<->active): direct exchange of the last chunk.
+ * Phase 5 (active reduce): final reduction of the direct chunk.
+ *
+ * Buffer Requirements:
+ * ====================
+ * ACTIVE ranks: sendBuff holds 2 x recvCount elements. recvBuff holds
+ * recvCount elements; in-place is recvBuff == sendBuff + ownBlockOffset.
+ * HELPER ranks: two-slot buffer of nActiveRanks x chunkSize elements
+ * (chunkSize derived from recvCount). Each helper group MUST have its own
+ * buffer (no aliasing across groups).
+ *
+ * 2D Sparse Parallelism Configuration (8 GPUs, 4 groups):
+ *   Group 0: activeRanks = {0, 1}, helpers = {2,3,4,5,6,7}
+ *   Group 1: activeRanks = {2, 3}, helpers = {0,1,4,5,6,7}
+ *   Group 2: activeRanks = {4, 5}, helpers = {0,1,2,3,6,7}
+ *   Group 3: activeRanks = {6, 7}, helpers = {0,1,2,3,4,5}
+ *
+ * Each rank is ACTIVE for exactly ONE group, HELPER for the other 3.
+ */
+
+#include <folly/init/Init.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+#include "comm.h"
+#include "comms/rcclx/develop/meta/testinfra/TestUtils.h"
+#include "comms/rcclx/develop/meta/testinfra/TestsDistUtils.h"
+#include "nccl.h"
+
+#define HIPCHECK_TEST(cmd)                                          \
+  do {                                                              \
+    hipError_t error = cmd;                                         \
+    if (error != hipSuccess) {                                      \
+      FAIL() << "HIP error: " << hipGetErrorString(error) << " at " \
+             << __FILE__ << ":" << __LINE__;                        \
+    }                                                               \
+  } while (0)
+
+#define NCCLCHECK_TEST(cmd)                                            \
+  do {                                                                 \
+    ncclResult_t result = cmd;                                         \
+    if (result != ncclSuccess) {                                       \
+      FAIL() << "NCCL error: " << ncclGetErrorString(result) << " at " \
+             << __FILE__ << ":" << __LINE__;                           \
+    }                                                                  \
+  } while (0)
+
+struct ShardedBandwidthResult {
+  double algoBW_GBps;
+  double busBW_GBps;
+  double latency_us;
+};
+
+// Aggregate bandwidth for multi-group reduce-scatter. The size metric is the
+// per-group OUTPUT (recvCount) bytes. Bus BW for an n-rank reduce-scatter uses
+// the (n-1)/n factor (for 2 ranks this is 0.5).
+ShardedBandwidthResult calculateMultiGroupAggregateBandwidth(
+    size_t recvBytesPerGroup,
+    double elapsedMs,
+    int numActiveRanks,
+    int numGroups) {
+  ShardedBandwidthResult result;
+  double elapsedSec = elapsedMs / 1000.0;
+  double totalDataSizeGB = static_cast<double>(recvBytesPerGroup) * numGroups /
+      (1024.0 * 1024.0 * 1024.0);
+  result.algoBW_GBps = totalDataSizeGB / elapsedSec;
+  result.busBW_GBps =
+      (numActiveRanks - 1.0) / numActiveRanks * totalDataSizeGB / elapsedSec;
+  result.latency_us = elapsedMs * 1000.0;
+  return result;
+}
+
+void printMultiGroupBandwidthResults(
+    const std::string& testName,
+    size_t recvBytesPerGroup,
+    int numRanks,
+    int numGroups,
+    int activeRanksPerGroup,
+    const ShardedBandwidthResult& aggregateResult,
+    bool isInPlace) {
+  double dataSizePerGroupGB =
+      static_cast<double>(recvBytesPerGroup) / (1024.0 * 1024.0 * 1024.0);
+
+  double totalDataSizeGB = dataSizePerGroupGB * numGroups;
+
+  double perGroupAlgoBW = aggregateResult.algoBW_GBps / numGroups;
+  double perGroupBusBW = aggregateResult.busBW_GBps / numGroups;
+
+  std::cout << "\n";
+  std::cout << "====================================================\n";
+  std::cout << "Multi-Group Sharded Relay Reduce-Scatter: " << testName << "\n";
+  std::cout << "====================================================\n";
+  std::cout << std::fixed << std::setprecision(2);
+  std::cout << "  Total Ranks (np):      " << numRanks << "\n";
+  std::cout << "  Number of Groups:      " << numGroups << "\n";
+  std::cout << "  Active Ranks/Group:    " << activeRanksPerGroup << "\n";
+  std::cout << "  Helper Ranks/Group:    " << (numRanks - activeRanksPerGroup)
+            << "\n";
+  std::cout << "  In-Place:              " << (isInPlace ? "YES" : "NO")
+            << "\n";
+  std::cout << "  Data Type:             int32\n";
+  std::cout << "  Output Size per Group: " << dataSizePerGroupGB << " GB\n";
+  std::cout << "  Total Output (all groups): " << totalDataSizeGB << " GB\n";
+  std::cout << "  Recv Count/Group:      "
+            << (recvBytesPerGroup / sizeof(int32_t)) << "\n";
+  std::cout << "----------------------------------------------------\n";
+  std::cout << "  Latency:               " << std::setprecision(3)
+            << aggregateResult.latency_us << " us\n";
+  std::cout << "----------------------------------------------------\n";
+  std::cout << "  AGGREGATE BANDWIDTH (all " << numGroups << " groups):\n";
+  std::cout << "    Algorithm BW:        " << std::setprecision(2)
+            << aggregateResult.algoBW_GBps << " GB/s\n";
+  std::cout << "    Bus BW:              " << aggregateResult.busBW_GBps
+            << " GB/s\n";
+  std::cout << "----------------------------------------------------\n";
+  std::cout << "  PER-GROUP BANDWIDTH (derived):\n";
+  std::cout << "    Algorithm BW:        " << perGroupAlgoBW << " GB/s\n";
+  std::cout << "    Bus BW:              " << perGroupBusBW << " GB/s\n";
+  std::cout << "====================================================\n\n";
+}
+
+// Test helper: forwards one contiguous send/recv buffer per group to the
+// sharded-relay reduce-scatter entry point. The active group's input holds
+// nActiveRanks x recvCount elements; its output holds recvCount elements.
+static ncclResult_t callReduceScatterCompat(
+    const void* const* sendPtrs,
+    void* const* recvPtrs,
+    const size_t* recvCounts,
+    ncclDataType_t datatype,
+    ncclRedOp_t op,
+    ncclComm_t comm,
+    hipStream_t stream,
+    const int* const* allActiveRanks,
+    int nActiveRanksPerGroup,
+    int nGroups) {
+  return ncclShardedRelayMultiGroupReduceScatter(
+      sendPtrs,
+      recvPtrs,
+      recvCounts,
+      datatype,
+      op,
+      comm,
+      stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+}
+
+class ShardedRelayMultiGroupReduceScatterTest : public ::testing::Test {
+ public:
+  ShardedRelayMultiGroupReduceScatterTest() = default;
+
+  void SetUp() override {
+    int localSize;
+    std::tie(this->localRank, this->globalRank, this->numRanks, localSize) =
+        getTcpStoreOrMpiInfo();
+    bool isServer = (this->globalRank == 0);
+    if (checkTcpStoreEnv()) {
+      server = createTcpStore(isServer);
+    } else if (isServer) {
+      server = createTcpStore(true);
+    }
+    this->comm = createNcclComm(
+        this->globalRank,
+        this->numRanks,
+        this->localRank,
+        false,
+        nullptr,
+        server.get());
+    CUDACHECK_TEST(cudaStreamCreate(&stream));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaStreamDestroy(this->stream));
+    if (server && checkTcpStoreEnv()) {
+      finalizeNcclComm(this->globalRank, server.get());
+    }
+    NCCLCHECK_TEST(ncclCommDestroy(this->comm));
+    server.reset();
+  }
+
+  // Standard 8-rank, 4-group, 2-active-per-group sparse parallelism layout.
+  struct Standard4GroupActiveRanks {
+    int storage[4][2] = {{0, 1}, {2, 3}, {4, 5}, {6, 7}};
+    const int* allActiveRanks[4] = {
+        storage[0],
+        storage[1],
+        storage[2],
+        storage[3]};
+  };
+
+  // Distinct per-(activeIndex, block) fill value so that a wrong block offset
+  // in the implementation produces a detectable mismatch.
+  static int32_t blockFillValue(int activeIndex, int blockIndex) {
+    return (activeIndex + 1) * 10 + (blockIndex + 1);
+  }
+
+  // Expected reduce-scatter output for the rank with the given active index:
+  //   recvBuff[i] = sum over active ranks of block[myActiveIndex]
+  static int32_t expectedReduceScatterSum(int myActiveIndex) {
+    return blockFillValue(0, myActiveIndex) + blockFillValue(1, myActiveIndex);
+  }
+
+  // Initialize an active rank's send buffer (2 x recvCount elements) so that
+  // block j is uniformly filled with blockFillValue(myActiveIndex, j).
+  void initActiveSendBuffer(
+      int32_t* deviceBuf,
+      size_t recvCount,
+      int myActiveIndex) {
+    std::vector<int32_t> host(static_cast<size_t>(2) * recvCount);
+    for (int j = 0; j < 2; j++) {
+      int32_t v = blockFillValue(myActiveIndex, j);
+      std::fill_n(
+          host.data() + static_cast<size_t>(j) * recvCount, recvCount, v);
+    }
+    HIPCHECK_TEST(hipMemcpy(
+        deviceBuf,
+        host.data(),
+        static_cast<size_t>(2) * recvCount * sizeof(int32_t),
+        hipMemcpyHostToDevice));
+  }
+
+  // Run a 1-element ncclAllReduce on `scratchBuffer` to act as a cross-rank
+  // barrier.
+  void barrierSyncOn(int32_t* /*unused*/) {
+    // Run the barrier all-reduce on a dedicated scratch allocation rather than
+    // a caller buffer. Several tests pass a buffer that they immediately
+    // (re)initialize and feed to the collective under test; running the barrier
+    // all-reduce on that same buffer is a write-after-write hazard on element 0
+    // (the all-reduce's device write is not guaranteed to be retired before the
+    // subsequent host-side init), which can leave element 0 holding the barrier
+    // value (0) instead of the init value and produces flaky "expected X but
+    // got 0" mismatches.
+    int32_t* barrierScratch = nullptr;
+    HIPCHECK_TEST(hipMalloc(&barrierScratch, sizeof(int32_t)));
+    HIPCHECK_TEST(hipMemset(barrierScratch, 0, sizeof(int32_t)));
+    NCCLCHECK_TEST(ncclAllReduce(
+        barrierScratch,
+        barrierScratch,
+        1,
+        ncclInt32,
+        ncclSum,
+        this->comm,
+        this->stream));
+    HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+    HIPCHECK_TEST(hipFree(barrierScratch));
+  }
+
+  // Copy `count` int32_t elements from `deviceBuffer` to host and verify they
+  // all equal `expectedValue`. Returns the number of mismatches (0 on success).
+  int verifyDeviceBufferEquals(
+      const int32_t* deviceBuffer,
+      size_t count,
+      int32_t expectedValue,
+      int groupIndex,
+      const char* failureMessage) {
+    std::vector<int32_t> hostOutput(count);
+    hipError_t hipErr = hipMemcpy(
+        hostOutput.data(),
+        deviceBuffer,
+        count * sizeof(int32_t),
+        hipMemcpyDeviceToHost);
+    if (hipErr != hipSuccess) {
+      ADD_FAILURE() << "HIP error in verifyDeviceBufferEquals: "
+                    << hipGetErrorString(hipErr) << " at " << __FILE__ << ":"
+                    << __LINE__;
+      return -1;
+    }
+
+    int errorCount = 0;
+    for (size_t i = 0; i < count && errorCount < 10; ++i) {
+      if (hostOutput[i] != expectedValue) {
+        std::cout << "R" << this->globalRank << ": Group " << groupIndex
+                  << " Mismatch at index " << i << ": expected "
+                  << expectedValue << " but got " << hostOutput[i] << std::endl;
+        errorCount++;
+      }
+    }
+    EXPECT_EQ(errorCount, 0) << failureMessage;
+    return errorCount;
+  }
+
+  int localRank{0};
+  int globalRank{0};
+  int numRanks{0};
+  ncclComm_t comm;
+  cudaStream_t stream;
+  std::unique_ptr<c10d::TCPStore> server{nullptr};
+};
+
+/**
+ * Test: Multi-Group Correctness with 4 groups (IN-PLACE)
+ *
+ * In-place reduce-scatter: recvBuff aliases sendBuff + ownBlockOffset.
+ * Active sendBuff holds 2 x recvCount elements with distinct per-block fill.
+ * Expected output for active index m: blockFillValue(0,m)+blockFillValue(1,m).
+ */
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_4Groups_InPlace_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t recvBytes = 64ULL * 1024 * 1024;
+  const size_t recvCount = recvBytes / sizeof(int32_t);
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  // Active rank: sendBuff holds 2 x recvCount elements; recvBuff aliases the
+  // ownBlock region (in-place). Helpers: two-slot buffer of 2 x recvCount.
+  int32_t* sendBuffs[nGroups];
+  void* recvPtrs[nGroups];
+  const void* sendPtrs[nGroups];
+  size_t recvCounts[nGroups];
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(
+          &sendBuffs[g], static_cast<size_t>(2) * recvBytes)); // 2 blocks
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+    }
+  }
+
+  barrierSyncOn(sendBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      initActiveSendBuffer(sendBuffs[g], recvCount, myActiveIndex);
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    if (g == myActiveGroup) {
+      // In-place: recvBuff == sendBuff + ownBlockOffset
+      size_t ownBlockOffset = static_cast<size_t>(myActiveIndex) * recvCount;
+      recvPtrs[g] = sendBuffs[g] + ownBlockOffset;
+    } else {
+      recvPtrs[g] = sendBuffs[g];
+    }
+    recvCounts[g] = recvCount;
+  }
+
+  ncclResult_t result = callReduceScatterCompat(
+      sendPtrs,
+      recvPtrs,
+      recvCounts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  {
+    int g = myActiveGroup;
+    int errorCount = verifyDeviceBufferEquals(
+        static_cast<const int32_t*>(recvPtrs[g]),
+        recvCount,
+        expectedReduceScatterSum(myActiveIndex),
+        g,
+        "Found mismatches in in-place reduce-scatter output");
+
+    if (errorCount == 0) {
+      std::cout << "R" << this->globalRank << ": Group " << g << " - All "
+                << recvCount << " elements verified correctly!" << std::endl;
+    }
+  }
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+  }
+}
+
+/**
+ * Test: Multi-Group Correctness with 4 groups (OUT-OF-PLACE)
+ */
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_4Groups_OutOfPlace_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t recvBytes = 64ULL * 1024 * 1024;
+  const size_t recvCount = recvBytes / sizeof(int32_t);
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      // Active rank: sendBuff is 2 blocks, recvBuff is 1 block (separate)
+      HIPCHECK_TEST(
+          hipMalloc(&sendBuffs[g], static_cast<size_t>(2) * recvBytes));
+      HIPCHECK_TEST(hipMalloc(&recvBuffs[g], recvBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g]; // helper: same buffer for send/recv
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      initActiveSendBuffer(sendBuffs[g], recvCount, myActiveIndex);
+      HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, recvBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t recvCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+    recvCounts[g] = recvCount;
+  }
+
+  ncclResult_t result = callReduceScatterCompat(
+      sendPtrs,
+      recvPtrs,
+      recvCounts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  {
+    int g = myActiveGroup;
+    verifyDeviceBufferEquals(
+        recvBuffs[g],
+        recvCount,
+        expectedReduceScatterSum(myActiveIndex),
+        g,
+        "Found mismatches in out-of-place reduce-scatter output");
+  }
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+/**
+ * Test: AVG correctness with 4 groups (OUT-OF-PLACE)
+ *
+ * Uses ncclAvg so the output is the average of the two active ranks' blocks.
+ * Fill values are chosen so the average is exact in integer arithmetic.
+ */
+TEST_F(ShardedRelayMultiGroupReduceScatterTest, Correctness_4Groups_Avg_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t recvBytes = 64ULL * 1024 * 1024;
+  const size_t recvCount = recvBytes / sizeof(int32_t);
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(
+          hipMalloc(&sendBuffs[g], static_cast<size_t>(2) * recvBytes));
+      HIPCHECK_TEST(hipMalloc(&recvBuffs[g], recvBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      initActiveSendBuffer(sendBuffs[g], recvCount, myActiveIndex);
+      HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, recvBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t recvCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+    recvCounts[g] = recvCount;
+  }
+
+  ncclResult_t result = callReduceScatterCompat(
+      sendPtrs,
+      recvPtrs,
+      recvCounts,
+      ncclInt32,
+      ncclAvg,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  {
+    int g = myActiveGroup;
+    // AVG = sum / nActiveRanksPerGroup
+    int32_t expectedAvg =
+        expectedReduceScatterSum(myActiveIndex) / nActiveRanksPerGroup;
+    verifyDeviceBufferEquals(
+        recvBuffs[g],
+        recvCount,
+        expectedAvg,
+        g,
+        "Found mismatches in AVG reduce-scatter output");
+  }
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+/**
+ * Test: BusBW with 4-group Multi-Group Reduce-Scatter (1GB output, IN-PLACE)
+ *
+ * A reduce-scatter active rank's sendBuff holds 2 x recvBytes (two blocks), so
+ * the per-rank footprint (active 2S + helper groups + relay scratch) is ~9x the
+ * per-group output S. 1GB keeps the suite inside a shared devgpu/CI budget.
+ */
+TEST_F(ShardedRelayMultiGroupReduceScatterTest, Z_BusBW_4Groups_InPlace_1GB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t recvBytes = 1ULL * 1024 * 1024 * 1024; // 1 GB output per group
+  const size_t recvCount = recvBytes / sizeof(int32_t);
+  const int nIters = 20;
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(
+          &sendBuffs[g], static_cast<size_t>(2) * recvBytes)); // 2 blocks
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+    }
+  }
+
+  barrierSyncOn(sendBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(
+          hipMemset(sendBuffs[g], 1, static_cast<size_t>(2) * recvBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t recvCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    if (g == myActiveGroup) {
+      size_t ownBlockOffset = static_cast<size_t>(myActiveIndex) * recvCount;
+      recvPtrs[g] = sendBuffs[g] + ownBlockOffset;
+    } else {
+      recvPtrs[g] = sendBuffs[g];
+    }
+    recvCounts[g] = recvCount;
+  }
+
+  hipEvent_t startEvent, stopEvent;
+  HIPCHECK_TEST(hipEventCreate(&startEvent));
+  HIPCHECK_TEST(hipEventCreate(&stopEvent));
+
+  float bestTimeMs = std::numeric_limits<float>::max();
+  float totalTimeMs = 0.0f;
+
+  if (this->globalRank == 0) {
+    std::cout << "[Benchmark] Running " << nIters << " iterations..."
+              << std::endl;
+  }
+
+  for (int iter = 0; iter < nIters; iter++) {
+    HIPCHECK_TEST(hipEventRecord(startEvent, this->stream));
+    ncclResult_t result = callReduceScatterCompat(
+        sendPtrs,
+        recvPtrs,
+        recvCounts,
+        ncclInt32,
+        ncclSum,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipEventRecord(stopEvent, this->stream));
+    HIPCHECK_TEST(hipEventSynchronize(stopEvent));
+
+    float elapsedMs = 0.0f;
+    HIPCHECK_TEST(hipEventElapsedTime(&elapsedMs, startEvent, stopEvent));
+
+    if (this->globalRank == 0) {
+      std::cout << "  Iteration " << (iter + 1) << ": " << elapsedMs << " ms"
+                << std::endl;
+    }
+
+    if (elapsedMs < bestTimeMs) {
+      bestTimeMs = elapsedMs;
+    }
+    totalTimeMs += elapsedMs;
+  }
+
+  float avgTimeMs = totalTimeMs / nIters;
+
+  if (this->globalRank == 0) {
+    std::cout << "\n[Benchmark] Best time: " << bestTimeMs << " ms, "
+              << "Avg time: " << avgTimeMs << " ms" << std::endl;
+
+    ShardedBandwidthResult bwResult = calculateMultiGroupAggregateBandwidth(
+        recvBytes, bestTimeMs, nActiveRanksPerGroup, nGroups);
+    printMultiGroupBandwidthResults(
+        "4-Group IN-PLACE 1GB",
+        recvBytes,
+        this->numRanks,
+        nGroups,
+        nActiveRanksPerGroup,
+        bwResult,
+        true);
+  }
+
+  HIPCHECK_TEST(hipEventDestroy(startEvent));
+  HIPCHECK_TEST(hipEventDestroy(stopEvent));
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+  }
+}
+
+/**
+ * Test: BusBW with 4-group Multi-Group Reduce-Scatter (1GB, OUT-OF-PLACE)
+ *
+ * See the in-place benchmark above for why the output size is 1GB (the
+ * reduce-scatter send buffer is doubled relative to allreduce).
+ */
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Z_BusBW_4Groups_OutOfPlace_1GB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t recvBytes = 1ULL * 1024 * 1024 * 1024; // 1 GB output per group
+  const size_t recvCount = recvBytes / sizeof(int32_t);
+  const int nIters = 20;
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(
+          hipMalloc(&sendBuffs[g], static_cast<size_t>(2) * recvBytes));
+      HIPCHECK_TEST(hipMalloc(&recvBuffs[g], recvBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(
+          hipMemset(sendBuffs[g], 1, static_cast<size_t>(2) * recvBytes));
+      HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, recvBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t recvCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+    recvCounts[g] = recvCount;
+  }
+
+  hipEvent_t startEvent, stopEvent;
+  HIPCHECK_TEST(hipEventCreate(&startEvent));
+  HIPCHECK_TEST(hipEventCreate(&stopEvent));
+
+  float bestTimeMs = std::numeric_limits<float>::max();
+  float totalTimeMs = 0.0f;
+
+  if (this->globalRank == 0) {
+    std::cout << "[Benchmark] Running " << nIters << " iterations..."
+              << std::endl;
+  }
+
+  for (int iter = 0; iter < nIters; iter++) {
+    HIPCHECK_TEST(hipEventRecord(startEvent, this->stream));
+    ncclResult_t result = callReduceScatterCompat(
+        sendPtrs,
+        recvPtrs,
+        recvCounts,
+        ncclInt32,
+        ncclSum,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipEventRecord(stopEvent, this->stream));
+    HIPCHECK_TEST(hipEventSynchronize(stopEvent));
+
+    float elapsedMs = 0.0f;
+    HIPCHECK_TEST(hipEventElapsedTime(&elapsedMs, startEvent, stopEvent));
+
+    if (this->globalRank == 0) {
+      std::cout << "  Iteration " << (iter + 1) << ": " << elapsedMs << " ms"
+                << std::endl;
+    }
+
+    if (elapsedMs < bestTimeMs) {
+      bestTimeMs = elapsedMs;
+    }
+    totalTimeMs += elapsedMs;
+  }
+
+  float avgTimeMs = totalTimeMs / nIters;
+
+  if (this->globalRank == 0) {
+    std::cout << "\n[Benchmark] Best time: " << bestTimeMs << " ms, "
+              << "Avg time: " << avgTimeMs << " ms" << std::endl;
+
+    ShardedBandwidthResult bwResult = calculateMultiGroupAggregateBandwidth(
+        recvBytes, bestTimeMs, nActiveRanksPerGroup, nGroups);
+    printMultiGroupBandwidthResults(
+        "4-Group OUT-OF-PLACE 1GB",
+        recvBytes,
+        this->numRanks,
+        nGroups,
+        nActiveRanksPerGroup,
+        bwResult,
+        false);
+  }
+
+  HIPCHECK_TEST(hipEventDestroy(startEvent));
+  HIPCHECK_TEST(hipEventDestroy(stopEvent));
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+/**
+ * Test: Single group via multi-group API (backward compatibility check)
+ */
+TEST_F(ShardedRelayMultiGroupReduceScatterTest, Correctness_SingleGroup_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 1;
+  const int nActiveRanksPerGroup = 2;
+  const size_t recvBytes = 64ULL * 1024 * 1024;
+  const size_t recvCount = recvBytes / sizeof(int32_t);
+
+  const int activeRanks[] = {0, 1};
+  const int* allActiveRanks[] = {activeRanks};
+
+  bool isActive = (this->globalRank == 0 || this->globalRank == 1);
+  int myActiveIndex = this->globalRank; // 0 or 1 for the active ranks
+
+  int32_t* sendBuff = nullptr;
+  int32_t* recvBuff = nullptr;
+  if (isActive) {
+    HIPCHECK_TEST(
+        hipMalloc(&sendBuff, static_cast<size_t>(2) * recvBytes)); // 2 blocks
+    HIPCHECK_TEST(hipMalloc(&recvBuff, recvBytes));
+  } else {
+    size_t helperBufferSize =
+        static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+    HIPCHECK_TEST(hipMalloc(&sendBuff, helperBufferSize));
+    recvBuff = sendBuff;
+  }
+
+  barrierSyncOn(sendBuff);
+
+  if (isActive) {
+    initActiveSendBuffer(sendBuff, recvCount, myActiveIndex);
+    HIPCHECK_TEST(hipMemset(recvBuff, 0, recvBytes));
+  } else {
+    size_t helperBufferSize =
+        static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+    HIPCHECK_TEST(hipMemset(sendBuff, 0, helperBufferSize));
+  }
+
+  const void* sendPtrs[1];
+  void* recvPtrs[1];
+  size_t recvCounts[] = {recvCount};
+
+  sendPtrs[0] = sendBuff;
+  recvPtrs[0] = recvBuff;
+
+  ncclResult_t result = callReduceScatterCompat(
+      sendPtrs,
+      recvPtrs,
+      recvCounts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  if (isActive) {
+    verifyDeviceBufferEquals(
+        recvBuff,
+        recvCount,
+        expectedReduceScatterSum(myActiveIndex),
+        0,
+        "Single group via multi-group API failed");
+  }
+
+  HIPCHECK_TEST(hipFree(sendBuff));
+  if (isActive) {
+    HIPCHECK_TEST(hipFree(recvBuff));
+  }
+}
+
+/**
+ * Test: Correctness with minimum passthrough helper buffers (4 groups,
+ * OUT-OF-PLACE)
+ *
+ * Validates correctness when each helper group's buffer is allocated at the
+ * MINIMUM size required by the passthrough design: nActiveRanks x chunkSize
+ * elements (chunkSize derived from recvCount).
+ */
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_4Groups_PassthroughHelperEquivalence) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t recvBytes = 64ULL * 1024 * 1024;
+  const size_t recvCount = recvBytes / sizeof(int32_t);
+  const int numHelpers = this->numRanks - nActiveRanksPerGroup;
+  const int numChunks = numHelpers + 1;
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  // Compute the MINIMUM passthrough helper buffer size from recvCount.
+  size_t chunkSize = recvCount / numChunks;
+  chunkSize = (chunkSize / 128) * 128; // CHUNK_ALIGN_ELEMENTS
+  if (chunkSize == 0) {
+    chunkSize = recvCount;
+  }
+  size_t minHelperElements = std::min(
+      recvCount, static_cast<size_t>(nActiveRanksPerGroup) * chunkSize);
+  size_t minHelperBytes = minHelperElements * sizeof(int32_t);
+
+  // 1 active send buffer (2 blocks) + separate recv buffer; 3 minimal helpers.
+  int32_t* activeSendBuffer = nullptr;
+  int32_t* activeRecvBuffer = nullptr;
+  int32_t* helperBuffers[nGroups];
+
+  HIPCHECK_TEST(
+      hipMalloc(&activeSendBuffer, static_cast<size_t>(2) * recvBytes));
+  HIPCHECK_TEST(hipMalloc(&activeRecvBuffer, recvBytes));
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      helperBuffers[g] = nullptr;
+    } else {
+      HIPCHECK_TEST(hipMalloc(&helperBuffers[g], minHelperBytes));
+    }
+  }
+
+  barrierSyncOn(activeSendBuffer);
+
+  initActiveSendBuffer(activeSendBuffer, recvCount, myActiveIndex);
+  HIPCHECK_TEST(hipMemset(activeRecvBuffer, 0, recvBytes));
+  for (int g = 0; g < nGroups; g++) {
+    if (g != myActiveGroup) {
+      HIPCHECK_TEST(hipMemset(helperBuffers[g], 0, minHelperBytes));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t recvCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      sendPtrs[g] = activeSendBuffer;
+      recvPtrs[g] = activeRecvBuffer;
+    } else {
+      sendPtrs[g] = helperBuffers[g];
+      recvPtrs[g] = helperBuffers[g];
+    }
+    recvCounts[g] = recvCount;
+  }
+
+  ncclResult_t result = callReduceScatterCompat(
+      sendPtrs,
+      recvPtrs,
+      recvCounts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  {
+    int errorCount = verifyDeviceBufferEquals(
+        activeRecvBuffer,
+        recvCount,
+        expectedReduceScatterSum(myActiveIndex),
+        myActiveGroup,
+        "Found mismatches in passthrough-helper-equivalence output");
+
+    if (errorCount == 0) {
+      std::cout << "R" << this->globalRank << ": Group " << myActiveGroup
+                << " - All " << recvCount
+                << " elements verified correctly (min passthrough helper)!"
+                << std::endl;
+    }
+  }
+
+  HIPCHECK_TEST(hipFree(activeSendBuffer));
+  HIPCHECK_TEST(hipFree(activeRecvBuffer));
+  for (int g = 0; g < nGroups; g++) {
+    if (g != myActiveGroup) {
+      HIPCHECK_TEST(hipFree(helperBuffers[g]));
+    }
+  }
+}
+
+/**
+ * Test: Correctness_PartialGroupsZeroCount
+ *
+ * Reduce-scatter analogue of the allreduce partial-zero-count regression: when
+ * different sparse groups have different numbers of tensors, exhausted groups
+ * pass recvCount=0. The kernel must skip those groups in every phase instead
+ * of attempting NCCL ops with zero-element buffers.
+ *
+ * Setup: 4 groups (8 ranks), 2 active ranks per group.
+ *   - Groups 0 and 1: recvCount = 16MB (must produce correct sum)
+ *   - Groups 2 and 3: recvCount = 0    (must not corrupt or crash)
+ */
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_PartialGroupsZeroCount) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t recvBytes = 16ULL * 1024 * 1024; // 16MB for groups with data
+  const size_t recvCount = recvBytes / sizeof(int32_t);
+
+  const size_t recvCounts[nGroups] = {recvCount, recvCount, 0, 0};
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  const size_t placeholderBytes = sizeof(int32_t); // 1 element
+  int32_t* buffers[nGroups];
+
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] == 0) {
+      HIPCHECK_TEST(hipMalloc(&buffers[g], placeholderBytes));
+      HIPCHECK_TEST(hipMemset(buffers[g], 0, placeholderBytes));
+      continue;
+    }
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(
+          &buffers[g], static_cast<size_t>(2) * recvBytes)); // 2 blocks
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMalloc(&buffers[g], helperBufferSize));
+    }
+  }
+
+  barrierSyncOn(buffers[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] == 0) {
+      continue; // placeholder already zeroed
+    }
+    if (g == myActiveGroup) {
+      initActiveSendBuffer(buffers[g], recvCount, myActiveIndex);
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMemset(buffers[g], 0, helperBufferSize));
+    }
+  }
+
+  // In-place: recvBuff == sendBuff + ownBlockOffset for active groups.
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = buffers[g];
+    if (recvCounts[g] != 0 && g == myActiveGroup) {
+      size_t ownBlockOffset = static_cast<size_t>(myActiveIndex) * recvCount;
+      recvPtrs[g] = buffers[g] + ownBlockOffset;
+    } else {
+      recvPtrs[g] = buffers[g];
+    }
+  }
+
+  ncclResult_t result = callReduceScatterCompat(
+      sendPtrs,
+      recvPtrs,
+      recvCounts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess)
+      << "ncclShardedRelayMultiGroupReduceScatter failed with partial recvCount=0 groups";
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  // Verify groups with recvCount>0 produced the correct reduce-scatter output.
+  if (myActiveGroup < 2) { // groups 0 and 1 had data
+    verifyDeviceBufferEquals(
+        static_cast<const int32_t*>(recvPtrs[myActiveGroup]),
+        recvCount,
+        expectedReduceScatterSum(myActiveIndex),
+        myActiveGroup,
+        "Correctness failed for groups with recvCount>0 when other groups have recvCount=0");
+  }
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(buffers[g]));
+  }
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
@@ -226,6 +226,14 @@ class ShardedRelayMultiGroupReduceScatterTest : public ::testing::Test {
         storage[3]};
   };
 
+  // 8-rank, 2-group, 4-active-per-group layout for the 4-active path:
+  //   Group 0: activeRanks = {0, 1, 2, 3}, helpers = {4, 5, 6, 7}
+  //   Group 1: activeRanks = {4, 5, 6, 7}, helpers = {0, 1, 2, 3}
+  struct TwoGroupFourActiveRanks {
+    int storage[2][4] = {{0, 1, 2, 3}, {4, 5, 6, 7}};
+    const int* allActiveRanks[2] = {storage[0], storage[1]};
+  };
+
   // Distinct per-(activeIndex, block) fill value so that a wrong block offset
   // in the implementation produces a detectable mismatch.
   static int32_t blockFillValue(int activeIndex, int blockIndex) {
@@ -233,19 +241,27 @@ class ShardedRelayMultiGroupReduceScatterTest : public ::testing::Test {
   }
 
   // Expected reduce-scatter output for the rank with the given active index:
-  //   recvBuff[i] = sum over active ranks of block[myActiveIndex]
-  static int32_t expectedReduceScatterSum(int myActiveIndex) {
-    return blockFillValue(0, myActiveIndex) + blockFillValue(1, myActiveIndex);
+  //   recvBuff[i] = sum over all active ranks r of block[myActiveIndex] from r
+  //              = sum_r blockFillValue(r, myActiveIndex)
+  static int32_t expectedReduceScatterSum(
+      int myActiveIndex,
+      int nActiveRanks = 2) {
+    int32_t sum = 0;
+    for (int r = 0; r < nActiveRanks; r++) {
+      sum += blockFillValue(r, myActiveIndex);
+    }
+    return sum;
   }
 
-  // Initialize an active rank's send buffer (2 x recvCount elements) so that
-  // block j is uniformly filled with blockFillValue(myActiveIndex, j).
+  // Initialize an active rank's send buffer (nActiveRanks x recvCount elements)
+  // so that block j is uniformly filled with blockFillValue(myActiveIndex, j).
   void initActiveSendBuffer(
       int32_t* deviceBuf,
       size_t recvCount,
-      int myActiveIndex) {
-    std::vector<int32_t> host(static_cast<size_t>(2) * recvCount);
-    for (int j = 0; j < 2; j++) {
+      int myActiveIndex,
+      int nActiveRanks = 2) {
+    std::vector<int32_t> host(static_cast<size_t>(nActiveRanks) * recvCount);
+    for (int j = 0; j < nActiveRanks; j++) {
       int32_t v = blockFillValue(myActiveIndex, j);
       std::fill_n(
           host.data() + static_cast<size_t>(j) * recvCount, recvCount, v);
@@ -253,7 +269,7 @@ class ShardedRelayMultiGroupReduceScatterTest : public ::testing::Test {
     HIPCHECK_TEST(hipMemcpy(
         deviceBuf,
         host.data(),
-        static_cast<size_t>(2) * recvCount * sizeof(int32_t),
+        static_cast<size_t>(nActiveRanks) * recvCount * sizeof(int32_t),
         hipMemcpyHostToDevice));
   }
 
@@ -1189,6 +1205,573 @@ TEST_F(
 
   for (int g = 0; g < nGroups; g++) {
     HIPCHECK_TEST(hipFree(buffers[g]));
+  }
+}
+
+/**
+ * 4-ACTIVE tests (2 groups of 4 active ranks each).
+ *   Group 0: active {0,1,2,3}, helpers {4,5,6,7}
+ *   Group 1: active {4,5,6,7}, helpers {0,1,2,3}
+ *
+ * Each active rank's sendBuff holds A=4 blocks of recvCount; block j is filled
+ * with blockFillValue(myActiveIndex, j). The reduce-scatter output for owner mi
+ * is sum over the 4 active ranks r of blockFillValue(r, mi), so a wrong block
+ * mapping (e.g. the bit-reversed-permutation bug) is detectable.
+ */
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_4Active_2Groups_InPlace) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t recvBytes = 64ULL * 1024 * 1024;
+  const size_t recvCount = recvBytes / sizeof(int32_t);
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(
+          &sendBuffs[g],
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes)); // A blocks
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+    }
+  }
+
+  barrierSyncOn(sendBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      initActiveSendBuffer(
+          sendBuffs[g], recvCount, myActiveIndex, nActiveRanksPerGroup);
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t recvCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    if (g == myActiveGroup) {
+      // In-place: recvBuff == sendBuff + ownBlockOffset.
+      size_t ownBlockOffset = static_cast<size_t>(myActiveIndex) * recvCount;
+      recvPtrs[g] = sendBuffs[g] + ownBlockOffset;
+    } else {
+      recvPtrs[g] = sendBuffs[g];
+    }
+    recvCounts[g] = recvCount;
+  }
+
+  ncclResult_t result = callReduceScatterCompat(
+      sendPtrs,
+      recvPtrs,
+      recvCounts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyDeviceBufferEquals(
+      static_cast<const int32_t*>(recvPtrs[myActiveGroup]),
+      recvCount,
+      expectedReduceScatterSum(myActiveIndex, nActiveRanksPerGroup),
+      myActiveGroup,
+      "4-active in-place reduce-scatter SUM mismatch");
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+  }
+}
+
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_4Active_2Groups_OutOfPlace) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t recvBytes = 64ULL * 1024 * 1024;
+  const size_t recvCount = recvBytes / sizeof(int32_t);
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(
+          &sendBuffs[g],
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes));
+      HIPCHECK_TEST(hipMalloc(&recvBuffs[g], recvBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      initActiveSendBuffer(
+          sendBuffs[g], recvCount, myActiveIndex, nActiveRanksPerGroup);
+      HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, recvBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t recvCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+    recvCounts[g] = recvCount;
+  }
+
+  ncclResult_t result = callReduceScatterCompat(
+      sendPtrs,
+      recvPtrs,
+      recvCounts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyDeviceBufferEquals(
+      recvBuffs[myActiveGroup],
+      recvCount,
+      expectedReduceScatterSum(myActiveIndex, nActiveRanksPerGroup),
+      myActiveGroup,
+      "4-active out-of-place reduce-scatter SUM mismatch");
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+/**
+ * AVG correctness with 4 active ranks. block j of rank r holds
+ * blockFillValue(r, j) = (r+1)*10 + (j+1). For owner mi the sum over r=0..3 is
+ * 100 + 4*(mi+1), so AVG (divisor = nActiveRanks = 4) = 25 + (mi+1), exact in
+ * int32. A wrong divisor (e.g. 2) would give 50 + 2*(mi+1), detecting that AVG
+ * uses nActiveRanks rather than a hardcoded 2.
+ */
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_4Active_2Groups_Avg) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t recvBytes = 64ULL * 1024 * 1024;
+  const size_t recvCount = recvBytes / sizeof(int32_t);
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(
+          &sendBuffs[g],
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes));
+      HIPCHECK_TEST(hipMalloc(&recvBuffs[g], recvBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], helperBufferSize));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(recvBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      initActiveSendBuffer(
+          sendBuffs[g], recvCount, myActiveIndex, nActiveRanksPerGroup);
+      HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, recvBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t recvCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+    recvCounts[g] = recvCount;
+  }
+
+  ncclResult_t result = callReduceScatterCompat(
+      sendPtrs,
+      recvPtrs,
+      recvCounts,
+      ncclInt32,
+      ncclAvg,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  int32_t expectedAvg =
+      expectedReduceScatterSum(myActiveIndex, nActiveRanksPerGroup) /
+      nActiveRanksPerGroup;
+  verifyDeviceBufferEquals(
+      recvBuffs[myActiveGroup],
+      recvCount,
+      expectedAvg,
+      myActiveGroup,
+      "4-active AVG reduce-scatter mismatch");
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
+/**
+ * Tiny-count regression: forces the relay csz==0 path for 4 active ranks. With
+ * recvCount=512 the working buffer count = A*recvCount = 2048: pR=1024, the
+ * first relay half xg=512, csz=align(512/5)=0, so the recursive-halving step
+ * exchanges the whole half directly with the partner. The send and recv of that
+ * swap MUST share one ncclGroup; splitting them across phases would deadlock.
+ * The direct all-to-all D region (pD=1024) is also exercised.
+ */
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_4Active_2Groups_TinyCsz0_InPlace) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t recvCount = 512; // count = A*recvCount = 2048 -> relay csz == 0
+  const size_t recvBytes = recvCount * sizeof(int32_t);
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    size_t bytes = static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+    HIPCHECK_TEST(hipMalloc(&sendBuffs[g], bytes));
+  }
+
+  barrierSyncOn(sendBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (g == myActiveGroup) {
+      initActiveSendBuffer(
+          sendBuffs[g], recvCount, myActiveIndex, nActiveRanksPerGroup);
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMemset(sendBuffs[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t recvCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    if (g == myActiveGroup) {
+      size_t ownBlockOffset = static_cast<size_t>(myActiveIndex) * recvCount;
+      recvPtrs[g] = sendBuffs[g] + ownBlockOffset;
+    } else {
+      recvPtrs[g] = sendBuffs[g];
+    }
+    recvCounts[g] = recvCount;
+  }
+
+  ncclResult_t result = callReduceScatterCompat(
+      sendPtrs,
+      recvPtrs,
+      recvCounts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyDeviceBufferEquals(
+      static_cast<const int32_t*>(recvPtrs[myActiveGroup]),
+      recvCount,
+      expectedReduceScatterSum(myActiveIndex, nActiveRanksPerGroup),
+      myActiveGroup,
+      "4-active tiny csz==0 reduce-scatter SUM mismatch");
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+  }
+}
+
+/**
+ * Partial-zero-count regression for 4 active ranks: group 0 has data, group 1
+ * passes recvCount=0 and must be skipped without crash/corruption.
+ */
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_4Active_PartialGroupsZeroCount) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t recvBytes = 16ULL * 1024 * 1024;
+  const size_t recvCount = recvBytes / sizeof(int32_t);
+
+  const size_t recvCounts[nGroups] = {recvCount, 0};
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  const size_t placeholderBytes = sizeof(int32_t);
+  int32_t* buffers[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] == 0) {
+      HIPCHECK_TEST(hipMalloc(&buffers[g], placeholderBytes));
+      HIPCHECK_TEST(hipMemset(buffers[g], 0, placeholderBytes));
+      continue;
+    }
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(
+          &buffers[g], static_cast<size_t>(nActiveRanksPerGroup) * recvBytes));
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMalloc(&buffers[g], helperBufferSize));
+    }
+  }
+
+  barrierSyncOn(buffers[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] == 0) {
+      continue;
+    }
+    if (g == myActiveGroup) {
+      initActiveSendBuffer(
+          buffers[g], recvCount, myActiveIndex, nActiveRanksPerGroup);
+    } else {
+      size_t helperBufferSize =
+          static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+      HIPCHECK_TEST(hipMemset(buffers[g], 0, helperBufferSize));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = buffers[g];
+    if (recvCounts[g] != 0 && g == myActiveGroup) {
+      size_t ownBlockOffset = static_cast<size_t>(myActiveIndex) * recvCount;
+      recvPtrs[g] = buffers[g] + ownBlockOffset;
+    } else {
+      recvPtrs[g] = buffers[g];
+    }
+  }
+
+  ncclResult_t result = callReduceScatterCompat(
+      sendPtrs,
+      recvPtrs,
+      recvCounts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess)
+      << "4-active reduce-scatter failed with a partial recvCount=0 group";
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  if (myActiveGroup == 0) { // group 0 had data
+    verifyDeviceBufferEquals(
+        static_cast<const int32_t*>(recvPtrs[myActiveGroup]),
+        recvCount,
+        expectedReduceScatterSum(myActiveIndex, nActiveRanksPerGroup),
+        myActiveGroup,
+        "4-active partial-zero reduce-scatter SUM mismatch");
+  }
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(buffers[g]));
+  }
+}
+
+/**
+ * BusBW with 4-active 2-group reduce-scatter (1GB output, IN-PLACE).
+ *
+ * The reduce-scatter active rank holds A=4 blocks (A x recvBytes send buffer)
+ * plus a working buffer of A x recvBytes; 1GB keeps the per-rank footprint
+ * inside a shared devgpu/CI memory budget.
+ */
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Z_BusBW_4Active_2Groups_InPlace_1GB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int nGroups = 2;
+  const int nActiveRanksPerGroup = 4;
+  const size_t recvBytes = 1ULL * 1024 * 1024 * 1024; // 1 GB output per group
+  const size_t recvCount = recvBytes / sizeof(int32_t);
+  const int nIters = 20;
+
+  TwoGroupFourActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    size_t bytes = static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+    HIPCHECK_TEST(hipMalloc(&sendBuffs[g], bytes));
+  }
+
+  barrierSyncOn(sendBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    size_t bytes = static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+    HIPCHECK_TEST(hipMemset(sendBuffs[g], (g == myActiveGroup) ? 1 : 0, bytes));
+  }
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  size_t recvCounts[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    if (g == myActiveGroup) {
+      size_t ownBlockOffset = static_cast<size_t>(myActiveIndex) * recvCount;
+      recvPtrs[g] = sendBuffs[g] + ownBlockOffset;
+    } else {
+      recvPtrs[g] = sendBuffs[g];
+    }
+    recvCounts[g] = recvCount;
+  }
+
+  hipEvent_t startEvent, stopEvent;
+  HIPCHECK_TEST(hipEventCreate(&startEvent));
+  HIPCHECK_TEST(hipEventCreate(&stopEvent));
+
+  float bestTimeMs = std::numeric_limits<float>::max();
+  float totalTimeMs = 0.0f;
+
+  for (int iter = 0; iter < nIters; iter++) {
+    HIPCHECK_TEST(hipEventRecord(startEvent, this->stream));
+    ncclResult_t result = callReduceScatterCompat(
+        sendPtrs,
+        recvPtrs,
+        recvCounts,
+        ncclInt32,
+        ncclSum,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipEventRecord(stopEvent, this->stream));
+    HIPCHECK_TEST(hipEventSynchronize(stopEvent));
+
+    float elapsedMs = 0.0f;
+    HIPCHECK_TEST(hipEventElapsedTime(&elapsedMs, startEvent, stopEvent));
+    if (elapsedMs < bestTimeMs) {
+      bestTimeMs = elapsedMs;
+    }
+    totalTimeMs += elapsedMs;
+  }
+
+  if (this->globalRank == 0) {
+    ShardedBandwidthResult bwResult = calculateMultiGroupAggregateBandwidth(
+        recvBytes, bestTimeMs, nActiveRanksPerGroup, nGroups);
+    printMultiGroupBandwidthResults(
+        "4-Active 2-Group IN-PLACE 1GB",
+        recvBytes,
+        this->numRanks,
+        nGroups,
+        nActiveRanksPerGroup,
+        bwResult,
+        true);
+  }
+
+  HIPCHECK_TEST(hipEventDestroy(startEvent));
+  HIPCHECK_TEST(hipEventDestroy(stopEvent));
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
   }
 }
 

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
@@ -1414,6 +1414,133 @@ TEST_F(
   }
 }
 
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_4Groups_Bfloat16_Sum_FusedRoutingThreshold) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  runBfloat16A2RoutingThreshold(4, static_cast<size_t>(2) << 20, ncclSum);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_4Groups_Bfloat16_Avg_FusedRoutingThreshold) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  runBfloat16A2RoutingThreshold(4, static_cast<size_t>(2) << 20, ncclAvg);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_SingleGroup_Bfloat16_Sum_IndependentRoutingThreshold) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  runBfloat16A2RoutingThreshold(1, static_cast<size_t>(27) << 20, ncclSum);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_SingleGroup_Bfloat16_Avg_IndependentRoutingThreshold) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  runBfloat16A2RoutingThreshold(1, static_cast<size_t>(27) << 20, ncclAvg);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupReduceScatterTest,
+    Correctness_4Groups_HeterogeneousRelayAndSmallPositive) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 4;
+  const int nActiveRanksPerGroup = 2;
+  const size_t relayThresholdCount =
+      (static_cast<size_t>(2) << 20) / nActiveRanksPerGroup / sizeof(int32_t);
+  const size_t recvCounts[nGroups] = {
+      relayThresholdCount, relayThresholdCount, 513, 1023};
+
+  Standard4GroupActiveRanks groupConfig;
+  const int* const* allActiveRanks = groupConfig.allActiveRanks;
+
+  const int myActiveGroup = this->globalRank / nActiveRanksPerGroup;
+  const int myActiveIndex = this->globalRank % nActiveRanksPerGroup;
+
+  int32_t* sendBuffs[nGroups];
+  int32_t* recvBuffs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    const size_t recvBytes = recvCounts[g] * sizeof(int32_t);
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], nActiveRanksPerGroup * recvBytes));
+      HIPCHECK_TEST(hipMalloc(&recvBuffs[g], recvBytes));
+    } else {
+      HIPCHECK_TEST(hipMalloc(&sendBuffs[g], nActiveRanksPerGroup * recvBytes));
+      recvBuffs[g] = sendBuffs[g];
+    }
+  }
+
+  barrierSyncOn(sendBuffs[0]);
+
+  for (int g = 0; g < nGroups; g++) {
+    const size_t recvBytes = recvCounts[g] * sizeof(int32_t);
+    if (g == myActiveGroup) {
+      initActiveSendBuffer(sendBuffs[g], recvCounts[g], myActiveIndex);
+      HIPCHECK_TEST(hipMemset(recvBuffs[g], 0, recvBytes));
+    } else {
+      HIPCHECK_TEST(
+          hipMemset(sendBuffs[g], 0, nActiveRanksPerGroup * recvBytes));
+    }
+  }
+
+  const void* sendPtrs[nGroups];
+  void* recvPtrs[nGroups];
+  for (int g = 0; g < nGroups; g++) {
+    sendPtrs[g] = sendBuffs[g];
+    recvPtrs[g] = recvBuffs[g];
+  }
+
+  ncclResult_t result = callReduceScatterCompat(
+      sendPtrs,
+      recvPtrs,
+      recvCounts,
+      ncclInt32,
+      ncclSum,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  verifyDeviceBufferEquals(
+      recvBuffs[myActiveGroup],
+      recvCounts[myActiveGroup],
+      expectedReduceScatterSum(myActiveIndex),
+      myActiveGroup,
+      "Heterogeneous relay/direct reduce-scatter SUM mismatch");
+
+  for (int g = 0; g < nGroups; g++) {
+    HIPCHECK_TEST(hipFree(sendBuffs[g]));
+    if (g == myActiveGroup) {
+      HIPCHECK_TEST(hipFree(recvBuffs[g]));
+    }
+  }
+}
+
 /**
  * Test: Correctness_PartialGroupsZeroCount
  *

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -959,10 +959,16 @@ set(RCCLX_LIB_FILES
   comms/rcclx/develop/meta/lpcoll/p2p_allgather.cc
   comms/rcclx/develop/meta/lpcoll/p2p_allgather.h
   # find comms/rcclx/develop/meta -type f ! -path "*/tests/*" -path "*/relay/*" \( -name "*.cc" -o -name "*.h" -o -name "*.cu" \) | sort
+  comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+  comms/rcclx/develop/meta/relay/sharded_relay_all_gather.h
+  comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
+  comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.h
   comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
   comms/rcclx/develop/meta/relay/sharded_relay_allreduce.h
   comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.cu
   comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.h
+  comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+  comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.h
 )
 
 # find comms/ctran/ -type f ! -path "*/tests/*" ! -path "*/benchmarks/*" ! -path "*/examples/*" \( -name "*.cc" -o -name "*.h" -o -name "*.hpp" -o -name "*.cuh" -o -name "*.cu" \) | sort

--- a/comms/rcclx/develop/projects/rccl/src/collectives.cc
+++ b/comms/rcclx/develop/projects/rccl/src/collectives.cc
@@ -583,8 +583,8 @@ ncclResult_t ncclShardedRelayMultiGroupAllToAll_impl(
     return ncclInvalidArgument;
   }
 
-  if (nActiveRanksPerGroup != 2) {
-    WARN("ncclShardedRelayMultiGroupAllToAll: nActiveRanksPerGroup must be 2, got %d",
+  if (nActiveRanksPerGroup != 2 && nActiveRanksPerGroup != 4) {
+    WARN("ncclShardedRelayMultiGroupAllToAll: nActiveRanksPerGroup must be 2 or 4, got %d",
          nActiveRanksPerGroup);
     return ncclInvalidArgument;
   }

--- a/comms/rcclx/develop/projects/rccl/src/collectives.cc
+++ b/comms/rcclx/develop/projects/rccl/src/collectives.cc
@@ -637,8 +637,8 @@ ncclResult_t ncclShardedRelayMultiGroupAllGather_impl(
     return ncclInvalidArgument;
   }
 
-  if (nActiveRanksPerGroup != 2) {
-    WARN("ncclShardedRelayMultiGroupAllGather: nActiveRanksPerGroup must be 2, got %d",
+  if (nActiveRanksPerGroup != 2 && nActiveRanksPerGroup != 4) {
+    WARN("ncclShardedRelayMultiGroupAllGather: nActiveRanksPerGroup must be 2 or 4, got %d",
          nActiveRanksPerGroup);
     return ncclInvalidArgument;
   }

--- a/comms/rcclx/develop/projects/rccl/src/collectives.cc
+++ b/comms/rcclx/develop/projects/rccl/src/collectives.cc
@@ -21,6 +21,7 @@
 #include "meta/relay/sharded_relay_allreduce.h"
 #include "meta/relay/sharded_relay_reduce_scatter.h"
 #include "meta/relay/sharded_relay_all_to_all.h"
+#include "meta/relay/sharded_relay_all_gather.h"
 #include "comms/ctran/Ctran.h"
 #include "MetaFactory.h"
 
@@ -611,6 +612,60 @@ ncclResult_t ncclShardedRelayMultiGroupAllToAll(
     const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
   return ncclShardedRelayMultiGroupAllToAll_impl(
       sendBuffs, recvBuffs, segmentCounts,
+      datatype, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
+}
+
+NCCL_API(ncclResult_t, ncclShardedRelayMultiGroupAllGather,
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* sendCounts,
+    ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+
+ncclResult_t ncclShardedRelayMultiGroupAllGather_impl(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* sendCounts,
+    ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
+  // Validate buffer pointers
+  if (recvBuffs == nullptr || allActiveRanks == nullptr || sendCounts == nullptr ||
+      sendBuffs == nullptr) {
+    WARN("ncclShardedRelayMultiGroupAllGather: buffer, sendCounts, and activeRanks pointers must be non-null");
+    return ncclInvalidArgument;
+  }
+
+  // Validate group parameters
+  if (nGroups < 1 || nGroups > 8) {
+    WARN("ncclShardedRelayMultiGroupAllGather: nGroups must be between 1 and 8, got %d", nGroups);
+    return ncclInvalidArgument;
+  }
+
+  if (nActiveRanksPerGroup != 2) {
+    WARN("ncclShardedRelayMultiGroupAllGather: nActiveRanksPerGroup must be 2, got %d",
+         nActiveRanksPerGroup);
+    return ncclInvalidArgument;
+  }
+
+  int nRanks;
+  NCCLCHECK(ncclCommCount(comm, &nRanks));
+
+  // Validate we have enough ranks for sharded relay (need helpers)
+  if (nRanks < nActiveRanksPerGroup + 1) {
+    WARN("ncclShardedRelayMultiGroupAllGather: need at least %d ranks for %d active ranks (need helpers)",
+         nActiveRanksPerGroup + 1, nActiveRanksPerGroup);
+    return ncclInvalidArgument;
+  }
+
+  TRACE(NCCL_COLL, "Using Sharded Relay Multi-Group AllGather (nRanks=%d, nActiveRanksPerGroup=%d, nGroups=%d)",
+        nRanks, nActiveRanksPerGroup, nGroups);
+  return ncclShardedRelayMultiGroupAllGatherImpl(
+      sendBuffs, recvBuffs, sendCounts,
+      datatype, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
+}
+
+ncclResult_t ncclShardedRelayMultiGroupAllGather(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* sendCounts,
+    ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
+  return ncclShardedRelayMultiGroupAllGather_impl(
+      sendBuffs, recvBuffs, sendCounts,
       datatype, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
 }
 

--- a/comms/rcclx/develop/projects/rccl/src/collectives.cc
+++ b/comms/rcclx/develop/projects/rccl/src/collectives.cc
@@ -471,8 +471,8 @@ ncclResult_t ncclShardedRelayMultiGroupAllReduce_impl(
     return ncclInvalidArgument;
   }
 
-  if (nActiveRanksPerGroup != 2) {
-    WARN("ncclShardedRelayMultiGroupAllReduce: nActiveRanksPerGroup must be 2, got %d", 
+  if (nActiveRanksPerGroup != 2 && nActiveRanksPerGroup != 4) {
+    WARN("ncclShardedRelayMultiGroupAllReduce: nActiveRanksPerGroup must be 2 or 4, got %d", 
          nActiveRanksPerGroup);
     return ncclInvalidArgument;
   }

--- a/comms/rcclx/develop/projects/rccl/src/collectives.cc
+++ b/comms/rcclx/develop/projects/rccl/src/collectives.cc
@@ -529,8 +529,8 @@ ncclResult_t ncclShardedRelayMultiGroupReduceScatter_impl(
     return ncclInvalidArgument;
   }
 
-  if (nActiveRanksPerGroup != 2) {
-    WARN("ncclShardedRelayMultiGroupReduceScatter: nActiveRanksPerGroup must be 2, got %d",
+  if (nActiveRanksPerGroup != 2 && nActiveRanksPerGroup != 4) {
+    WARN("ncclShardedRelayMultiGroupReduceScatter: nActiveRanksPerGroup must be 2 or 4, got %d",
          nActiveRanksPerGroup);
     return ncclInvalidArgument;
   }

--- a/comms/rcclx/develop/projects/rccl/src/collectives.cc
+++ b/comms/rcclx/develop/projects/rccl/src/collectives.cc
@@ -19,6 +19,7 @@
 #include "meta/lpcoll/low_precision_reduce_scatter.h"
 #include "meta/lpcoll/p2p_allgather.h"
 #include "meta/relay/sharded_relay_allreduce.h"
+#include "meta/relay/sharded_relay_reduce_scatter.h"
 #include "comms/ctran/Ctran.h"
 #include "MetaFactory.h"
 
@@ -496,6 +497,66 @@ ncclResult_t ncclShardedRelayMultiGroupAllReduce(
     const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
   return ncclShardedRelayMultiGroupAllReduce_impl(sendBuffs, recvBuffs, counts, datatype, op, comm, stream,
                                                    allActiveRanks, nActiveRanksPerGroup, nGroups);
+}
+
+NCCL_API(ncclResult_t, ncclShardedRelayMultiGroupReduceScatter,
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* recvCounts,
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+
+ncclResult_t ncclShardedRelayMultiGroupReduceScatter_impl(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* recvCounts,
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
+  // Validate operation - only SUM and AVG are supported
+  if (op != ncclSum && op != ncclAvg) {
+    WARN("ncclShardedRelayMultiGroupReduceScatter: only ncclSum and ncclAvg operations are supported");
+    return ncclInvalidArgument;
+  }
+
+  // Validate buffer pointers
+  if (recvBuffs == nullptr || allActiveRanks == nullptr || recvCounts == nullptr ||
+      sendBuffs == nullptr) {
+    WARN("ncclShardedRelayMultiGroupReduceScatter: buffer, recvCounts, and activeRanks pointers must be non-null");
+    return ncclInvalidArgument;
+  }
+
+  // Validate group parameters
+  if (nGroups < 1 || nGroups > 8) {
+    WARN("ncclShardedRelayMultiGroupReduceScatter: nGroups must be between 1 and 8, got %d", nGroups);
+    return ncclInvalidArgument;
+  }
+
+  if (nActiveRanksPerGroup != 2) {
+    WARN("ncclShardedRelayMultiGroupReduceScatter: nActiveRanksPerGroup must be 2, got %d",
+         nActiveRanksPerGroup);
+    return ncclInvalidArgument;
+  }
+
+  int nRanks;
+  NCCLCHECK(ncclCommCount(comm, &nRanks));
+
+  // Validate we have enough ranks for sharded relay (need helpers)
+  if (nRanks < nActiveRanksPerGroup + 1) {
+    WARN("ncclShardedRelayMultiGroupReduceScatter: need at least %d ranks for %d active ranks (need helpers)",
+         nActiveRanksPerGroup + 1, nActiveRanksPerGroup);
+    return ncclInvalidArgument;
+  }
+
+  TRACE(NCCL_COLL, "Using Sharded Relay Multi-Group ReduceScatter (nRanks=%d, nActiveRanksPerGroup=%d, nGroups=%d)",
+        nRanks, nActiveRanksPerGroup, nGroups);
+  return ncclShardedRelayMultiGroupReduceScatterImpl(
+      sendBuffs, recvBuffs, recvCounts,
+      datatype, op, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
+}
+
+ncclResult_t ncclShardedRelayMultiGroupReduceScatter(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* recvCounts,
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
+  return ncclShardedRelayMultiGroupReduceScatter_impl(
+      sendBuffs, recvBuffs, recvCounts,
+      datatype, op, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
 }
 
 NCCL_API(ncclResult_t, ncclBroadcast, const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root,

--- a/comms/rcclx/develop/projects/rccl/src/collectives.cc
+++ b/comms/rcclx/develop/projects/rccl/src/collectives.cc
@@ -20,6 +20,7 @@
 #include "meta/lpcoll/p2p_allgather.h"
 #include "meta/relay/sharded_relay_allreduce.h"
 #include "meta/relay/sharded_relay_reduce_scatter.h"
+#include "meta/relay/sharded_relay_all_to_all.h"
 #include "comms/ctran/Ctran.h"
 #include "MetaFactory.h"
 
@@ -557,6 +558,60 @@ ncclResult_t ncclShardedRelayMultiGroupReduceScatter(
   return ncclShardedRelayMultiGroupReduceScatter_impl(
       sendBuffs, recvBuffs, recvCounts,
       datatype, op, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
+}
+
+NCCL_API(ncclResult_t, ncclShardedRelayMultiGroupAllToAll,
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
+    ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+
+ncclResult_t ncclShardedRelayMultiGroupAllToAll_impl(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
+    ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
+  // Validate buffer pointers
+  if (recvBuffs == nullptr || allActiveRanks == nullptr || segmentCounts == nullptr ||
+      sendBuffs == nullptr) {
+    WARN("ncclShardedRelayMultiGroupAllToAll: buffer, segmentCounts, and activeRanks pointers must be non-null");
+    return ncclInvalidArgument;
+  }
+
+  // Validate group parameters
+  if (nGroups < 1 || nGroups > 8) {
+    WARN("ncclShardedRelayMultiGroupAllToAll: nGroups must be between 1 and 8, got %d", nGroups);
+    return ncclInvalidArgument;
+  }
+
+  if (nActiveRanksPerGroup != 2) {
+    WARN("ncclShardedRelayMultiGroupAllToAll: nActiveRanksPerGroup must be 2, got %d",
+         nActiveRanksPerGroup);
+    return ncclInvalidArgument;
+  }
+
+  int nRanks;
+  NCCLCHECK(ncclCommCount(comm, &nRanks));
+
+  // Validate we have enough ranks for sharded relay (need helpers)
+  if (nRanks < nActiveRanksPerGroup + 1) {
+    WARN("ncclShardedRelayMultiGroupAllToAll: need at least %d ranks for %d active ranks (need helpers)",
+         nActiveRanksPerGroup + 1, nActiveRanksPerGroup);
+    return ncclInvalidArgument;
+  }
+
+  TRACE(NCCL_COLL, "Using Sharded Relay Multi-Group AllToAll (nRanks=%d, nActiveRanksPerGroup=%d, nGroups=%d)",
+        nRanks, nActiveRanksPerGroup, nGroups);
+  return ncclShardedRelayMultiGroupAllToAllImpl(
+      sendBuffs, recvBuffs, segmentCounts,
+      datatype, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
+}
+
+ncclResult_t ncclShardedRelayMultiGroupAllToAll(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
+    ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
+  return ncclShardedRelayMultiGroupAllToAll_impl(
+      sendBuffs, recvBuffs, segmentCounts,
+      datatype, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
 }
 
 NCCL_API(ncclResult_t, ncclBroadcast, const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root,

--- a/comms/rcclx/develop/projects/rccl/src/collectives.cc
+++ b/comms/rcclx/develop/projects/rccl/src/collectives.cc
@@ -460,7 +460,8 @@ ncclResult_t ncclShardedRelayMultiGroupAllReduce_impl(
   }
 
   // Validate buffer pointers
-  if (sendBuffs == nullptr || recvBuffs == nullptr || allActiveRanks == nullptr || counts == nullptr) {
+  if (recvBuffs == nullptr || allActiveRanks == nullptr || counts == nullptr ||
+      sendBuffs == nullptr) {
     WARN("ncclShardedRelayMultiGroupAllReduce: buffer, counts, and activeRanks pointers must be non-null");
     return ncclInvalidArgument;
   }
@@ -489,16 +490,18 @@ ncclResult_t ncclShardedRelayMultiGroupAllReduce_impl(
 
   TRACE(NCCL_COLL, "Using Sharded Relay Multi-Group AllReduce (nRanks=%d, nActiveRanksPerGroup=%d, nGroups=%d)", 
         nRanks, nActiveRanksPerGroup, nGroups);
-  return ncclShardedRelayMultiGroupAllReduceImpl(sendBuffs, recvBuffs, counts, datatype, op, comm, stream, 
-                                                  allActiveRanks, nActiveRanksPerGroup, nGroups);
+  return ncclShardedRelayMultiGroupAllReduceImpl(
+      sendBuffs, recvBuffs, counts,
+      datatype, op, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
 }
 
 ncclResult_t ncclShardedRelayMultiGroupAllReduce(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* counts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream,
     const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
-  return ncclShardedRelayMultiGroupAllReduce_impl(sendBuffs, recvBuffs, counts, datatype, op, comm, stream,
-                                                   allActiveRanks, nActiveRanksPerGroup, nGroups);
+  return ncclShardedRelayMultiGroupAllReduce_impl(
+      sendBuffs, recvBuffs, counts,
+      datatype, op, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
 }
 
 NCCL_API(ncclResult_t, ncclShardedRelayMultiGroupReduceScatter,

--- a/comms/rcclx/develop/projects/rccl/src/nccl.h
+++ b/comms/rcclx/develop/projects/rccl/src/nccl.h
@@ -692,6 +692,54 @@ ncclResult_t pncclShardedRelayMultiGroupAllReduce(
     const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
 /*! @endcond */
 
+/*! @brief      Fused Multi-Group Sharded Relay Reduce-Scatter for 2D Sparse Parallelism
+    @details    Performs multiple sharded relay reduce-scatters in a single fused call, coordinating
+                phases across ALL groups to prevent XGMI link contention. This is the reduce-scatter
+                analogue of ncclShardedRelayMultiGroupAllReduce and uses the same phase-synchronized
+                passthrough-helper scheme.
+
+                Each group has exactly 2 active ranks. Each active sendBuff holds
+                nActiveRanksPerGroup x recvCounts[g] elements (block[i] is the slice destined for
+                active index i); each active recvBuff holds recvCounts[g] elements and receives
+                sum_over_active_ranks(sendBuff[block i]). The relay ships block[otherActiveIndex] to
+                the other active rank, sharded across helpers, then reduces it into the output block.
+
+                  Phase 1: ALL groups scatter sendBlock chunks (active->helpers) - unidirectional
+                  Phase 2: ALL groups forward (helpers->other active) - unidirectional
+                  Phase 3: ALL active ranks reduce the relayed chunks into the output block
+                  Phase 4: ALL groups direct-exchange last chunk between active ranks
+                  Phase 5: Final reduction on the exchanged chunk - compute only
+
+                Helpers act as pure passthrough relays (no local reduction). All
+                reductions happen on active ranks only.
+
+              Memory model: Each rank is ACTIVE for exactly ONE group (has real tensor data).
+              For other groups, the rank is a HELPER (uses provided scratch buffer).
+
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendBuffs           Array of send buffer pointers (one per group); each active buffer
+                                    holds nActiveRanksPerGroup x recvCounts[g] elements
+    @param[out] recvBuffs           Array of receive buffer pointers (one per group)
+    @param[in]  recvCounts          Array of per-group OUTPUT element counts (one per group)
+    @param[in]  datatype            Data buffer element datatype
+    @param[in]  op                  Reduction operator (ncclSum and ncclAvg supported)
+    @param[in]  comm                Communicator group object to execute on
+    @param[in]  stream              HIP stream to execute collective on
+    @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
+    @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+ncclResult_t  ncclShardedRelayMultiGroupReduceScatter(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* recvCounts,
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @cond       include_hidden */
+ncclResult_t pncclShardedRelayMultiGroupReduceScatter(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* recvCounts,
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @endcond */
+
 /*! @brief      Reduce-Scatter
     @details    Reduces data in *sendbuff* using *op* operation and leaves reduced result
                 scattered over the devices so that *recvbuff* on rank i will contain the i-th

--- a/comms/rcclx/develop/projects/rccl/src/nccl.h
+++ b/comms/rcclx/develop/projects/rccl/src/nccl.h
@@ -740,6 +740,57 @@ ncclResult_t pncclShardedRelayMultiGroupReduceScatter(
     const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
 /*! @endcond */
 
+/*! @brief      Fused Multi-Group Sharded Relay All-to-All for 2D Sparse Parallelism
+    @details    Performs multiple sharded relay all-to-alls in a single fused call, coordinating
+                phases across ALL groups to prevent XGMI link contention. This is the all-to-all
+                analogue of ncclShardedRelayMultiGroupAllReduce and uses the same phase-synchronized
+                passthrough-helper scheme. All-to-all performs NO reduction (pure data movement), so
+                there is no reduction op parameter and no reduction kernels.
+
+                Each group has exactly 2 active ranks. Each active sendBuff/recvBuff holds
+                nActiveRanksPerGroup x segmentCounts[g] elements: sendBuff = [sendSeg[0]|sendSeg[1]]
+                where sendSeg[j] is destined for active index j, and recvBuff = [recvSeg[0]|recvSeg[1]]
+                where recvSeg[i] receives from active index i. The diagonal segment is copied locally
+                and the off-diagonal segment is exchanged with the other active rank, sharded across
+                helpers.
+
+                  Phase 1: ALL groups scatter sendSeg[o] chunks (active->helpers) - unidirectional
+                  Phase 2: ALL groups forward (helpers->other active), received into recvSeg[o]
+                  Phase 3: diagonal copy recvSeg[m] = sendSeg[m]
+                  Phase 4: ALL groups direct-exchange the last chunk between active ranks
+                  Phase 5: none (no reduction)
+
+                Helpers act as pure passthrough relays. IN-PLACE IS NOT SUPPORTED: sendBuff and
+                recvBuff must be distinct (matches native ncclAllToAll); passing equal buffers
+                returns ncclInvalidArgument.
+
+              Memory model: Each rank is ACTIVE for exactly ONE group (has real tensor data).
+              For other groups, the rank is a HELPER (uses provided scratch buffer).
+
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendBuffs           Array of send buffer pointers (one per group); each active buffer
+                                    holds nActiveRanksPerGroup x segmentCounts[g] elements
+    @param[out] recvBuffs           Array of receive buffer pointers (one per group); each active
+                                    buffer holds nActiveRanksPerGroup x segmentCounts[g] elements
+    @param[in]  segmentCounts       Array of per-group per-segment element counts (one per group)
+    @param[in]  datatype            Data buffer element datatype
+    @param[in]  comm                Communicator group object to execute on
+    @param[in]  stream              HIP stream to execute collective on
+    @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
+    @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+ncclResult_t  ncclShardedRelayMultiGroupAllToAll(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
+    ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @cond       include_hidden */
+ncclResult_t pncclShardedRelayMultiGroupAllToAll(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
+    ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @endcond */
+
 /*! @brief      Reduce-Scatter
     @details    Reduces data in *sendbuff* using *op* operation and leaves reduced result
                 scattered over the devices so that *recvbuff* on rank i will contain the i-th

--- a/comms/rcclx/develop/projects/rccl/src/nccl.h
+++ b/comms/rcclx/develop/projects/rccl/src/nccl.h
@@ -791,6 +791,56 @@ ncclResult_t pncclShardedRelayMultiGroupAllToAll(
     const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
 /*! @endcond */
 
+/*! @brief      Fused Multi-Group Sharded Relay All-Gather for 2D Sparse Parallelism
+    @details    Performs multiple sharded relay all-gathers in a single fused call, coordinating
+                phases across ALL groups to prevent XGMI link contention. This is the all-gather
+                analogue of ncclShardedRelayMultiGroupAllReduce and the dual of the reduce-scatter
+                relay. All-gather performs NO reduction (pure data movement), so there is no
+                reduction op parameter and no reduction kernels.
+
+                Each group has exactly 2 active ranks. Each active sendBuff holds sendCounts[g]
+                elements (its contribution); each active recvBuff holds nActiveRanksPerGroup x
+                sendCounts[g] elements, where recvBuff[i x sendCount] receives the contribution from
+                active index i. The diagonal slot is filled with this rank's own data and the other
+                slot is gathered from the other active rank, sharded across helpers.
+
+                  Phase 1: ALL groups scatter sendBuff chunks (active->helpers) - unidirectional
+                  Phase 2: ALL groups forward (helpers->other active), received into recvBuff[o]
+                  Phase 3: diagonal copy recvBuff[m x sendCount] = sendBuff (no-op when in-place)
+                  Phase 4: ALL groups direct-exchange the last chunk between active ranks
+                  Phase 5: none (no reduction)
+
+                Helpers act as pure passthrough relays. Both in-place and out-of-place are
+                supported: in-place is detected when sendBuff == recvBuff + rank x sendCount
+                (standard NCCL all-gather in-place convention). No scratch buffers are needed.
+
+              Memory model: Each rank is ACTIVE for exactly ONE group (has real tensor data).
+              For other groups, the rank is a HELPER (uses provided scratch buffer).
+
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendBuffs           Array of send buffer pointers (one per group); each active buffer
+                                    holds sendCounts[g] elements
+    @param[out] recvBuffs           Array of receive buffer pointers (one per group); each active
+                                    buffer holds nActiveRanksPerGroup x sendCounts[g] elements
+    @param[in]  sendCounts          Array of per-group per-rank contribution counts (one per group)
+    @param[in]  datatype            Data buffer element datatype
+    @param[in]  comm                Communicator group object to execute on
+    @param[in]  stream              HIP stream to execute collective on
+    @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
+    @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+ncclResult_t  ncclShardedRelayMultiGroupAllGather(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* sendCounts,
+    ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @cond       include_hidden */
+ncclResult_t pncclShardedRelayMultiGroupAllGather(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* sendCounts,
+    ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @endcond */
+
 /*! @brief      Reduce-Scatter
     @details    Reduces data in *sendbuff* using *op* operation and leaves reduced result
                 scattered over the devices so that *recvbuff* on rank i will contain the i-th

--- a/comms/rcclx/develop/projects/rccl/src/rccl.h
+++ b/comms/rcclx/develop/projects/rccl/src/rccl.h
@@ -692,6 +692,54 @@ ncclResult_t pncclShardedRelayMultiGroupAllReduce(
     const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
 /*! @endcond */
 
+/*! @brief      Fused Multi-Group Sharded Relay Reduce-Scatter for 2D Sparse Parallelism
+    @details    Performs multiple sharded relay reduce-scatters in a single fused call, coordinating
+                phases across ALL groups to prevent XGMI link contention. This is the reduce-scatter
+                analogue of ncclShardedRelayMultiGroupAllReduce and uses the same phase-synchronized
+                passthrough-helper scheme.
+
+                Each group has exactly 2 active ranks. Each active sendBuff holds
+                nActiveRanksPerGroup x recvCounts[g] elements (block[i] is the slice destined for
+                active index i); each active recvBuff holds recvCounts[g] elements and receives
+                sum_over_active_ranks(sendBuff[block i]). The relay ships block[otherActiveIndex] to
+                the other active rank, sharded across helpers, then reduces it into the output block.
+
+                  Phase 1: ALL groups scatter sendBlock chunks (active->helpers) - unidirectional
+                  Phase 2: ALL groups forward (helpers->other active) - unidirectional
+                  Phase 3: ALL active ranks reduce the relayed chunks into the output block
+                  Phase 4: ALL groups direct-exchange last chunk between active ranks
+                  Phase 5: Final reduction on the exchanged chunk - compute only
+
+                Helpers act as pure passthrough relays (no local reduction). All
+                reductions happen on active ranks only.
+
+              Memory model: Each rank is ACTIVE for exactly ONE group (has real tensor data).
+              For other groups, the rank is a HELPER (uses provided scratch buffer).
+
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendBuffs           Array of send buffer pointers (one per group); each active buffer
+                                    holds nActiveRanksPerGroup x recvCounts[g] elements
+    @param[out] recvBuffs           Array of receive buffer pointers (one per group)
+    @param[in]  recvCounts          Array of per-group OUTPUT element counts (one per group)
+    @param[in]  datatype            Data buffer element datatype
+    @param[in]  op                  Reduction operator (ncclSum and ncclAvg supported)
+    @param[in]  comm                Communicator group object to execute on
+    @param[in]  stream              HIP stream to execute collective on
+    @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
+    @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+ncclResult_t  ncclShardedRelayMultiGroupReduceScatter(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* recvCounts,
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @cond       include_hidden */
+ncclResult_t pncclShardedRelayMultiGroupReduceScatter(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* recvCounts,
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @endcond */
+
 /*! @brief      Reduce-Scatter
     @details    Reduces data in *sendbuff* using *op* operation and leaves reduced result
                 scattered over the devices so that *recvbuff* on rank i will contain the i-th

--- a/comms/rcclx/develop/projects/rccl/src/rccl.h
+++ b/comms/rcclx/develop/projects/rccl/src/rccl.h
@@ -740,6 +740,57 @@ ncclResult_t pncclShardedRelayMultiGroupReduceScatter(
     const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
 /*! @endcond */
 
+/*! @brief      Fused Multi-Group Sharded Relay All-to-All for 2D Sparse Parallelism
+    @details    Performs multiple sharded relay all-to-alls in a single fused call, coordinating
+                phases across ALL groups to prevent XGMI link contention. This is the all-to-all
+                analogue of ncclShardedRelayMultiGroupAllReduce and uses the same phase-synchronized
+                passthrough-helper scheme. All-to-all performs NO reduction (pure data movement), so
+                there is no reduction op parameter and no reduction kernels.
+
+                Each group has exactly 2 active ranks. Each active sendBuff/recvBuff holds
+                nActiveRanksPerGroup x segmentCounts[g] elements: sendBuff = [sendSeg[0]|sendSeg[1]]
+                where sendSeg[j] is destined for active index j, and recvBuff = [recvSeg[0]|recvSeg[1]]
+                where recvSeg[i] receives from active index i. The diagonal segment is copied locally
+                and the off-diagonal segment is exchanged with the other active rank, sharded across
+                helpers.
+
+                  Phase 1: ALL groups scatter sendSeg[o] chunks (active->helpers) - unidirectional
+                  Phase 2: ALL groups forward (helpers->other active), received into recvSeg[o]
+                  Phase 3: diagonal copy recvSeg[m] = sendSeg[m]
+                  Phase 4: ALL groups direct-exchange the last chunk between active ranks
+                  Phase 5: none (no reduction)
+
+                Helpers act as pure passthrough relays. IN-PLACE IS NOT SUPPORTED: sendBuff and
+                recvBuff must be distinct (matches native ncclAllToAll); passing equal buffers
+                returns ncclInvalidArgument.
+
+              Memory model: Each rank is ACTIVE for exactly ONE group (has real tensor data).
+              For other groups, the rank is a HELPER (uses provided scratch buffer).
+
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendBuffs           Array of send buffer pointers (one per group); each active buffer
+                                    holds nActiveRanksPerGroup x segmentCounts[g] elements
+    @param[out] recvBuffs           Array of receive buffer pointers (one per group); each active
+                                    buffer holds nActiveRanksPerGroup x segmentCounts[g] elements
+    @param[in]  segmentCounts       Array of per-group per-segment element counts (one per group)
+    @param[in]  datatype            Data buffer element datatype
+    @param[in]  comm                Communicator group object to execute on
+    @param[in]  stream              HIP stream to execute collective on
+    @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
+    @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+ncclResult_t  ncclShardedRelayMultiGroupAllToAll(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
+    ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @cond       include_hidden */
+ncclResult_t pncclShardedRelayMultiGroupAllToAll(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
+    ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @endcond */
+
 /*! @brief      Reduce-Scatter
     @details    Reduces data in *sendbuff* using *op* operation and leaves reduced result
                 scattered over the devices so that *recvbuff* on rank i will contain the i-th

--- a/comms/rcclx/develop/projects/rccl/src/rccl.h
+++ b/comms/rcclx/develop/projects/rccl/src/rccl.h
@@ -791,6 +791,56 @@ ncclResult_t pncclShardedRelayMultiGroupAllToAll(
     const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
 /*! @endcond */
 
+/*! @brief      Fused Multi-Group Sharded Relay All-Gather for 2D Sparse Parallelism
+    @details    Performs multiple sharded relay all-gathers in a single fused call, coordinating
+                phases across ALL groups to prevent XGMI link contention. This is the all-gather
+                analogue of ncclShardedRelayMultiGroupAllReduce and the dual of the reduce-scatter
+                relay. All-gather performs NO reduction (pure data movement), so there is no
+                reduction op parameter and no reduction kernels.
+
+                Each group has exactly 2 active ranks. Each active sendBuff holds sendCounts[g]
+                elements (its contribution); each active recvBuff holds nActiveRanksPerGroup x
+                sendCounts[g] elements, where recvBuff[i x sendCount] receives the contribution from
+                active index i. The diagonal slot is filled with this rank's own data and the other
+                slot is gathered from the other active rank, sharded across helpers.
+
+                  Phase 1: ALL groups scatter sendBuff chunks (active->helpers) - unidirectional
+                  Phase 2: ALL groups forward (helpers->other active), received into recvBuff[o]
+                  Phase 3: diagonal copy recvBuff[m x sendCount] = sendBuff (no-op when in-place)
+                  Phase 4: ALL groups direct-exchange the last chunk between active ranks
+                  Phase 5: none (no reduction)
+
+                Helpers act as pure passthrough relays. Both in-place and out-of-place are
+                supported: in-place is detected when sendBuff == recvBuff + rank x sendCount
+                (standard NCCL all-gather in-place convention). No scratch buffers are needed.
+
+              Memory model: Each rank is ACTIVE for exactly ONE group (has real tensor data).
+              For other groups, the rank is a HELPER (uses provided scratch buffer).
+
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendBuffs           Array of send buffer pointers (one per group); each active buffer
+                                    holds sendCounts[g] elements
+    @param[out] recvBuffs           Array of receive buffer pointers (one per group); each active
+                                    buffer holds nActiveRanksPerGroup x sendCounts[g] elements
+    @param[in]  sendCounts          Array of per-group per-rank contribution counts (one per group)
+    @param[in]  datatype            Data buffer element datatype
+    @param[in]  comm                Communicator group object to execute on
+    @param[in]  stream              HIP stream to execute collective on
+    @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
+    @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+ncclResult_t  ncclShardedRelayMultiGroupAllGather(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* sendCounts,
+    ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @cond       include_hidden */
+ncclResult_t pncclShardedRelayMultiGroupAllGather(
+    const void* const* sendBuffs, void* const* recvBuffs, const size_t* sendCounts,
+    ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @endcond */
+
 /*! @brief      Reduce-Scatter
     @details    Reduces data in *sendbuff* using *op* operation and leaves reduced result
                 scattered over the devices so that *recvbuff* on rank i will contain the i-th

--- a/comms/torchcomms/rcclx/RcclxApi.cpp
+++ b/comms/torchcomms/rcclx/RcclxApi.cpp
@@ -426,6 +426,7 @@ ncclResult_t DefaultRcclxApi::redOpDestroy(ncclRedOp_t op, ncclComm_t comm) {
 //     - DefaultRcclxApi::shardedRelayMultiGroupAllReduce
 //     - DefaultRcclxApi::shardedRelayMultiGroupReduceScatter
 //     - DefaultRcclxApi::shardedRelayMultiGroupAllToAll
+//     - DefaultRcclxApi::shardedRelayMultiGroupAllGather
 
 ncclResult_t DefaultRcclxApi::memAlloc(void** ptr, size_t size) {
   return ncclMemAlloc(ptr, size);

--- a/comms/torchcomms/rcclx/RcclxApi.cpp
+++ b/comms/torchcomms/rcclx/RcclxApi.cpp
@@ -424,6 +424,7 @@ ncclResult_t DefaultRcclxApi::redOpDestroy(ncclRedOp_t op, ncclComm_t comm) {
 //     - DefaultRcclxApi::allGatherExec
 //     - DefaultRcclxApi::pFree
 //     - DefaultRcclxApi::shardedRelayMultiGroupAllReduce
+//     - DefaultRcclxApi::shardedRelayMultiGroupReduceScatter
 
 ncclResult_t DefaultRcclxApi::memAlloc(void** ptr, size_t size) {
   return ncclMemAlloc(ptr, size);

--- a/comms/torchcomms/rcclx/RcclxApi.cpp
+++ b/comms/torchcomms/rcclx/RcclxApi.cpp
@@ -425,6 +425,7 @@ ncclResult_t DefaultRcclxApi::redOpDestroy(ncclRedOp_t op, ncclComm_t comm) {
 //     - DefaultRcclxApi::pFree
 //     - DefaultRcclxApi::shardedRelayMultiGroupAllReduce
 //     - DefaultRcclxApi::shardedRelayMultiGroupReduceScatter
+//     - DefaultRcclxApi::shardedRelayMultiGroupAllToAll
 
 ncclResult_t DefaultRcclxApi::memAlloc(void** ptr, size_t size) {
   return ncclMemAlloc(ptr, size);

--- a/comms/torchcomms/rcclx/RcclxApi.hpp
+++ b/comms/torchcomms/rcclx/RcclxApi.hpp
@@ -301,6 +301,19 @@ class RcclxApi {
       const int* const* allActiveRanks,
       int nActiveRanksPerGroup,
       int nGroups) = 0;
+
+  // Fused multi-group sharded relay all-gather for 2D sparse parallelism.
+  // No reduction op (pure data movement); supports in-place and out-of-place.
+  virtual ncclResult_t shardedRelayMultiGroupAllGather(
+      const void* const* sendBuffs,
+      void* const* recvBuffs,
+      const size_t* sendCounts,
+      ncclDataType_t datatype,
+      ncclComm_t comm,
+      hipStream_t stream,
+      const int* const* allActiveRanks,
+      int nActiveRanksPerGroup,
+      int nGroups) = 0;
 };
 
 /**
@@ -573,6 +586,19 @@ class DefaultRcclxApi : public RcclxApi {
       const void* const* sendBuffs,
       void* const* recvBuffs,
       const size_t* segmentCounts,
+      ncclDataType_t datatype,
+      ncclComm_t comm,
+      hipStream_t stream,
+      const int* const* allActiveRanks,
+      int nActiveRanksPerGroup,
+      int nGroups) override;
+
+  // Fused multi-group sharded relay all-gather for 2D sparse parallelism.
+  // No reduction op (pure data movement); supports in-place and out-of-place.
+  ncclResult_t shardedRelayMultiGroupAllGather(
+      const void* const* sendBuffs,
+      void* const* recvBuffs,
+      const size_t* sendCounts,
       ncclDataType_t datatype,
       ncclComm_t comm,
       hipStream_t stream,

--- a/comms/torchcomms/rcclx/RcclxApi.hpp
+++ b/comms/torchcomms/rcclx/RcclxApi.hpp
@@ -288,6 +288,19 @@ class RcclxApi {
       const int* const* allActiveRanks,
       int nActiveRanksPerGroup,
       int nGroups) = 0;
+
+  // Fused multi-group sharded relay all-to-all for 2D sparse parallelism.
+  // No reduction op (pure data movement); out-of-place only.
+  virtual ncclResult_t shardedRelayMultiGroupAllToAll(
+      const void* const* sendBuffs,
+      void* const* recvBuffs,
+      const size_t* segmentCounts,
+      ncclDataType_t datatype,
+      ncclComm_t comm,
+      hipStream_t stream,
+      const int* const* allActiveRanks,
+      int nActiveRanksPerGroup,
+      int nGroups) = 0;
 };
 
 /**
@@ -548,6 +561,19 @@ class DefaultRcclxApi : public RcclxApi {
       const size_t* recvCounts,
       ncclDataType_t datatype,
       ncclRedOp_t op,
+      ncclComm_t comm,
+      hipStream_t stream,
+      const int* const* allActiveRanks,
+      int nActiveRanksPerGroup,
+      int nGroups) override;
+
+  // Fused multi-group sharded relay all-to-all for 2D sparse parallelism.
+  // No reduction op (pure data movement); out-of-place only.
+  ncclResult_t shardedRelayMultiGroupAllToAll(
+      const void* const* sendBuffs,
+      void* const* recvBuffs,
+      const size_t* segmentCounts,
+      ncclDataType_t datatype,
       ncclComm_t comm,
       hipStream_t stream,
       const int* const* allActiveRanks,

--- a/comms/torchcomms/rcclx/RcclxApi.hpp
+++ b/comms/torchcomms/rcclx/RcclxApi.hpp
@@ -275,6 +275,19 @@ class RcclxApi {
       const int* const* allActiveRanks,
       int nActiveRanksPerGroup,
       int nGroups) = 0;
+
+  // Fused multi-group sharded relay reduce-scatter for 2D sparse parallelism
+  virtual ncclResult_t shardedRelayMultiGroupReduceScatter(
+      const void* const* sendBuffs,
+      void* const* recvBuffs,
+      const size_t* recvCounts,
+      ncclDataType_t datatype,
+      ncclRedOp_t op,
+      ncclComm_t comm,
+      hipStream_t stream,
+      const int* const* allActiveRanks,
+      int nActiveRanksPerGroup,
+      int nGroups) = 0;
 };
 
 /**
@@ -520,6 +533,19 @@ class DefaultRcclxApi : public RcclxApi {
       const void* const* sendBuffs,
       void* const* recvBuffs,
       const size_t* counts,
+      ncclDataType_t datatype,
+      ncclRedOp_t op,
+      ncclComm_t comm,
+      hipStream_t stream,
+      const int* const* allActiveRanks,
+      int nActiveRanksPerGroup,
+      int nGroups) override;
+
+  // Fused multi-group sharded relay reduce-scatter for 2D sparse parallelism
+  ncclResult_t shardedRelayMultiGroupReduceScatter(
+      const void* const* sendBuffs,
+      void* const* recvBuffs,
+      const size_t* recvCounts,
       ncclDataType_t datatype,
       ncclRedOp_t op,
       ncclComm_t comm,

--- a/comms/torchcomms/rcclx/RcclxApiShardedRelay.cpp
+++ b/comms/torchcomms/rcclx/RcclxApiShardedRelay.cpp
@@ -71,4 +71,28 @@ ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllReduce(
       nGroups);
 }
 
+ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupReduceScatter(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* recvCounts,
+    ncclDataType_t datatype,
+    ncclRedOp_t op,
+    ncclComm_t comm,
+    hipStream_t stream,
+    const int* const* allActiveRanks,
+    int nActiveRanksPerGroup,
+    int nGroups) {
+  return ncclShardedRelayMultiGroupReduceScatter(
+      sendBuffs,
+      recvBuffs,
+      recvCounts,
+      datatype,
+      op,
+      comm,
+      stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+}
+
 } // namespace torch::comms

--- a/comms/torchcomms/rcclx/RcclxApiShardedRelay.cpp
+++ b/comms/torchcomms/rcclx/RcclxApiShardedRelay.cpp
@@ -117,4 +117,26 @@ ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllToAll(
       nGroups);
 }
 
+ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllGather(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* sendCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    hipStream_t stream,
+    const int* const* allActiveRanks,
+    int nActiveRanksPerGroup,
+    int nGroups) {
+  return ncclShardedRelayMultiGroupAllGather(
+      sendBuffs,
+      recvBuffs,
+      sendCounts,
+      datatype,
+      comm,
+      stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+}
+
 } // namespace torch::comms

--- a/comms/torchcomms/rcclx/RcclxApiShardedRelay.cpp
+++ b/comms/torchcomms/rcclx/RcclxApiShardedRelay.cpp
@@ -95,4 +95,26 @@ ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupReduceScatter(
       nGroups);
 }
 
+ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllToAll(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* segmentCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    hipStream_t stream,
+    const int* const* allActiveRanks,
+    int nActiveRanksPerGroup,
+    int nGroups) {
+  return ncclShardedRelayMultiGroupAllToAll(
+      sendBuffs,
+      recvBuffs,
+      segmentCounts,
+      datatype,
+      comm,
+      stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+}
+
 } // namespace torch::comms

--- a/comms/torchcomms/rcclx/RcclxApiShardedRelayStub.cpp
+++ b/comms/torchcomms/rcclx/RcclxApiShardedRelayStub.cpp
@@ -56,4 +56,18 @@ ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllReduce(
   return ncclInternalError;
 }
 
+ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupReduceScatter(
+    const void* const* /*sendBuffs*/,
+    void* const* /*recvBuffs*/,
+    const size_t* /*recvCounts*/,
+    ncclDataType_t /*datatype*/,
+    ncclRedOp_t /*op*/,
+    ncclComm_t /*comm*/,
+    hipStream_t /*stream*/,
+    const int* const* /*allActiveRanks*/,
+    int /*nActiveRanksPerGroup*/,
+    int /*nGroups*/) {
+  return ncclInternalError;
+}
+
 } // namespace torch::comms

--- a/comms/torchcomms/rcclx/RcclxApiShardedRelayStub.cpp
+++ b/comms/torchcomms/rcclx/RcclxApiShardedRelayStub.cpp
@@ -83,4 +83,17 @@ ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllToAll(
   return ncclInternalError;
 }
 
+ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllGather(
+    const void* const* /*sendBuffs*/,
+    void* const* /*recvBuffs*/,
+    const size_t* /*sendCounts*/,
+    ncclDataType_t /*datatype*/,
+    ncclComm_t /*comm*/,
+    hipStream_t /*stream*/,
+    const int* const* /*allActiveRanks*/,
+    int /*nActiveRanksPerGroup*/,
+    int /*nGroups*/) {
+  return ncclInternalError;
+}
+
 } // namespace torch::comms

--- a/comms/torchcomms/rcclx/RcclxApiShardedRelayStub.cpp
+++ b/comms/torchcomms/rcclx/RcclxApiShardedRelayStub.cpp
@@ -70,4 +70,17 @@ ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupReduceScatter(
   return ncclInternalError;
 }
 
+ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllToAll(
+    const void* const* /*sendBuffs*/,
+    void* const* /*recvBuffs*/,
+    const size_t* /*segmentCounts*/,
+    ncclDataType_t /*datatype*/,
+    ncclComm_t /*comm*/,
+    hipStream_t /*stream*/,
+    const int* const* /*allActiveRanks*/,
+    int /*nActiveRanksPerGroup*/,
+    int /*nGroups*/) {
+  return ncclInternalError;
+}
+
 } // namespace torch::comms

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
@@ -867,6 +867,184 @@ TorchCommRCCLX::sharded_relay_multi_group_all_reduce(
   return work;
 }
 
+c10::intrusive_ptr<TorchWork>
+TorchCommRCCLX::sharded_relay_multi_group_reduce_scatter(
+    std::vector<at::Tensor>& input_tensors,
+    std::vector<at::Tensor>& output_tensors,
+    const ReduceOp& op,
+    const std::vector<std::vector<int64_t>>& all_active_ranks,
+    const std::vector<int64_t>& per_group_recv_counts,
+    bool async_op) {
+  checkInitialized();
+  checkAndAbortIfTimedOutOrError();
+
+  int nGroups = static_cast<int>(input_tensors.size());
+  if (nGroups == 0) {
+    throw std::runtime_error(
+        "sharded_relay_multi_group_reduce_scatter: input_tensors list cannot be empty");
+  }
+  if (output_tensors.size() != static_cast<size_t>(nGroups) ||
+      all_active_ranks.size() != static_cast<size_t>(nGroups) ||
+      per_group_recv_counts.size() != static_cast<size_t>(nGroups)) {
+    throw std::runtime_error(
+        "sharded_relay_multi_group_reduce_scatter: output_tensors, all_active_ranks, and per_group_recv_counts sizes must match input_tensors size");
+  }
+
+  int nActiveRanksPerGroup = static_cast<int>(all_active_ranks[0].size());
+
+  // Determine which group this rank is active for (each rank is active for
+  // exactly one group in the 2D layout).
+  int myActiveGroup = -1;
+  for (int g = 0; g < nGroups && myActiveGroup < 0; g++) {
+    for (int a = 0; a < static_cast<int>(all_active_ranks[g].size()); a++) {
+      if (all_active_ranks[g][a] == rank_) {
+        myActiveGroup = g;
+        break;
+      }
+    }
+  }
+
+  // One contiguous send / recv buffer per group. Helper groups pass a single
+  // scratch tensor as both input and output.
+  std::vector<const void*> sendBuffs(nGroups);
+  std::vector<void*> recvBuffs(nGroups);
+  std::vector<size_t> recvCounts(nGroups);
+  std::vector<at::Tensor> all_tensors;
+  for (int g = 0; g < nGroups; g++) {
+    ensureTensorContiguous(input_tensors[g]);
+    ensureTensorContiguous(output_tensors[g]);
+    sendBuffs[g] = input_tensors[g].data_ptr();
+    recvBuffs[g] = output_tensors[g].data_ptr();
+    recvCounts[g] = static_cast<size_t>(per_group_recv_counts[g]);
+    all_tensors.push_back(input_tensors[g]);
+    all_tensors.push_back(output_tensors[g]);
+  }
+
+  // Check this rank's active group against the buffer contract documented in
+  // sharded_relay_reduce_scatter.h: the input holds one contribution block per
+  // active index (nActiveRanks x recvCount) and the output holds a single
+  // reduced block (recvCount). The kernel only receives raw pointers, so an
+  // undersized tensor here becomes an out-of-bounds device access there.
+  // Helper groups are deliberately not size-checked: their buffers are scratch
+  // whose required size comes from the kernel's own chunk geometry rather than
+  // from per_group_recv_counts, so it cannot be recomputed here without
+  // duplicating that math.
+  if (myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0) {
+    const size_t recvCount = recvCounts[myActiveGroup];
+    const size_t expectedInput =
+        static_cast<size_t>(nActiveRanksPerGroup) * recvCount;
+    if (static_cast<size_t>(input_tensors[myActiveGroup].numel()) !=
+        expectedInput) {
+      throw std::runtime_error(
+          fmt::format(
+              "sharded_relay_multi_group_reduce_scatter: active group {} input has {} elements, expected {} (nActiveRanks={} x recvCount={})",
+              myActiveGroup,
+              input_tensors[myActiveGroup].numel(),
+              expectedInput,
+              nActiveRanksPerGroup,
+              recvCount));
+    }
+    if (static_cast<size_t>(output_tensors[myActiveGroup].numel()) !=
+        recvCount) {
+      throw std::runtime_error(
+          fmt::format(
+              "sharded_relay_multi_group_reduce_scatter: active group {} output has {} elements, expected recvCount={}",
+              myActiveGroup,
+              output_tensors[myActiveGroup].numel(),
+              recvCount));
+    }
+  }
+
+  int segGroup = (myActiveGroup >= 0) ? myActiveGroup : 0;
+
+  // Convert int64_t active-ranks vectors to int arrays for the C API.
+  std::vector<std::vector<int>> active_ranks_int(nGroups);
+  std::vector<const int*> allActiveRanksPtr(nGroups);
+  for (int g = 0; g < nGroups; g++) {
+    active_ranks_int[g].assign(
+        all_active_ranks[g].begin(), all_active_ranks[g].end());
+    allActiveRanksPtr[g] = active_ranks_int[g].data();
+  }
+
+  TracingGuard tracingGuard(
+      name_,
+      comm_size_,
+      "sharded_relay_multi_group_reduce_scatter",
+      rank_,
+      input_tensors[segGroup],
+      output_tensors[segGroup]);
+  hipStream_t stream = getOperationStream(async_op);
+  auto work = createWork(stream, options_.timeout, all_tensors);
+
+  work->recordStart("sharded_relay_multi_group_reduce_scatter");
+
+  // Derive dtype from the active group's input tensor.
+  // The kernel takes ONE ncclDataType_t for every group, so the dtype has to
+  // come from a group that actually carries data. A count-0 group holds a
+  // 1-element placeholder that the kernel ignores, and nothing requires that
+  // placeholder to share the payload's dtype, so reading the dtype off one
+  // would hand every group the wrong ncclDataType_t. Prefer this rank's own
+  // active group; fall back to the first group with data. All data-carrying
+  // groups share a dtype, so which one is immaterial. If every count is 0 there
+  // is no data to type.
+  int dtypeGroup = segGroup;
+  if (per_group_recv_counts[dtypeGroup] == 0) {
+    for (int g = 0; g < nGroups; g++) {
+      if (per_group_recv_counts[g] > 0) {
+        dtypeGroup = g;
+        break;
+      }
+    }
+  }
+  // Every group that carries data must agree on dtype: the kernel is handed ONE
+  // ncclDataType_t for all of them, so a mismatch would silently reinterpret
+  // another group's buffer with the wrong element size. Count-0 groups are
+  // exempt -- their placeholder is never read or written.
+  const auto relayScalarType = input_tensors[dtypeGroup].scalar_type();
+  for (int g = 0; g < nGroups; g++) {
+    if (per_group_recv_counts[g] == 0) {
+      continue;
+    }
+    if (input_tensors[g].scalar_type() != relayScalarType ||
+        output_tensors[g].scalar_type() != relayScalarType) {
+      throw std::runtime_error(
+          fmt::format(
+              "sharded_relay_multi_group_reduce_scatter: every group with a non-zero count must share one dtype; group {} has in={}/out={} but group {} has {}",
+              g,
+              c10::toString(input_tensors[g].scalar_type()),
+              c10::toString(output_tensors[g].scalar_type()),
+              dtypeGroup,
+              c10::toString(relayScalarType)));
+    }
+  }
+  auto dataType = getNcclDataType(input_tensors[dtypeGroup]);
+  ncclResult_t result = rcclx_api_->shardedRelayMultiGroupReduceScatter(
+      sendBuffs.data(),
+      recvBuffs.data(),
+      recvCounts.data(),
+      dataType,
+      getNcclReduceOp(op, nccl_comm_, dataType),
+      nccl_comm_,
+      stream,
+      allActiveRanksPtr.data(),
+      nActiveRanksPerGroup,
+      nGroups);
+
+  if (result != ncclSuccess) {
+    throw RCCLXException(
+        *rcclx_api_,
+        "RCCLX Sharded Relay Multi-Group ReduceScatter failed",
+        result,
+        nccl_comm_);
+  }
+
+  work->recordEnd();
+
+  enqueueWork(work, stream);
+
+  return work;
+}
+
 c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reduce(
     const at::Tensor& tensor,
     int root,

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
@@ -729,7 +729,8 @@ TorchCommRCCLX::sharded_relay_multi_group_all_reduce(
     const ReduceOp& op,
     const std::vector<std::vector<int64_t>>& all_active_ranks,
     const std::vector<int64_t>& per_group_counts,
-    bool async_op) {
+    bool async_op,
+    std::optional<std::vector<at::Tensor>> output_tensors) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
 
@@ -766,7 +767,16 @@ TorchCommRCCLX::sharded_relay_multi_group_all_reduce(
     }
   }
 
-  // Allreduce is in-place (sendBuffs[g] == recvBuffs[g]).
+  // Allreduce defaults to in-place (sendBuffs[g] == recvBuffs[g]). When
+  // output_tensors is provided, the active group writes its reduced result
+  // out-of-place into the caller-provided output tensor while the input is
+  // preserved.
+  const bool hasOutput = output_tensors.has_value() && !output_tensors->empty();
+  if (hasOutput && output_tensors->size() != static_cast<size_t>(nGroups)) {
+    throw std::runtime_error(
+        "sharded_relay_multi_group_all_reduce: output_tensors size must match tensors size");
+  }
+
   std::vector<const void*> sendBuffs(nGroups);
   std::vector<void*> recvBuffs(nGroups);
   std::vector<size_t> counts(nGroups);
@@ -801,6 +811,18 @@ TorchCommRCCLX::sharded_relay_multi_group_all_reduce(
   }
 
   int segGroup = (myActiveGroup >= 0) ? myActiveGroup : 0;
+  if (hasOutput) {
+    // Out-of-place: the active group's reduced result is written to the
+    // caller-provided output tensor; sendBuffs stays the (preserved) input.
+    auto& outTensor = (*output_tensors)[segGroup];
+    ensureTensorContiguous(outTensor);
+    if (static_cast<size_t>(outTensor.numel()) != counts[segGroup]) {
+      throw std::runtime_error(
+          "sharded_relay_multi_group_all_reduce: active output numel must match input numel");
+    }
+    all_tensors.push_back(outTensor);
+    recvBuffs[segGroup] = outTensor.data_ptr();
+  }
 
   std::vector<std::vector<int>> active_ranks_int(nGroups);
   std::vector<const int*> allActiveRanksPtr(nGroups);
@@ -857,6 +879,16 @@ TorchCommRCCLX::sharded_relay_multi_group_all_reduce(
               dtypeGroup,
               c10::toString(relayScalarType)));
     }
+  }
+  // The out-of-place output is the buffer the kernel writes the active group's
+  // result into, so it has to carry the same dtype as the input it reduces.
+  if (hasOutput && per_group_counts[segGroup] > 0 &&
+      (*output_tensors)[segGroup].scalar_type() != relayScalarType) {
+    throw std::runtime_error(
+        fmt::format(
+            "sharded_relay_multi_group_all_reduce: out-of-place output dtype {} does not match the input dtype {}",
+            c10::toString((*output_tensors)[segGroup].scalar_type()),
+            c10::toString(relayScalarType)));
   }
   auto dataType = getNcclDataType(tensors[dtypeGroup]);
   ncclResult_t result = rcclx_api_->shardedRelayMultiGroupAllReduce(

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
@@ -738,17 +738,16 @@ TorchCommRCCLX::sharded_relay_multi_group_all_reduce(
     throw std::runtime_error(
         "sharded_relay_multi_group_all_reduce: tensors list cannot be empty");
   }
-  if (all_active_ranks.size() != static_cast<size_t>(nGroups)) {
+  if (all_active_ranks.size() != static_cast<size_t>(nGroups) ||
+      per_group_counts.size() != static_cast<size_t>(nGroups)) {
     throw std::runtime_error(
-        "sharded_relay_multi_group_all_reduce: all_active_ranks size must match tensors size");
-  }
-  if (per_group_counts.size() != static_cast<size_t>(nGroups)) {
-    throw std::runtime_error(
-        "sharded_relay_multi_group_all_reduce: per_group_counts size must match tensors size");
+        "sharded_relay_multi_group_all_reduce: all_active_ranks and per_group_counts sizes must match tensors size");
   }
 
-  // Verify all groups have the same number of active ranks (needed to compute
-  // the minimum valid helper-buffer size in the validation loop below).
+  // The kernel takes a single nActiveRanksPerGroup and applies it to every
+  // group, and the active-group size check below derives its expected element
+  // count from it, so a group with a different width would be silently
+  // mis-handled.
   int nActiveRanksPerGroup = static_cast<int>(all_active_ranks[0].size());
   for (int g = 1; g < nGroups; g++) {
     if (static_cast<int>(all_active_ranks[g].size()) != nActiveRanksPerGroup) {
@@ -757,64 +756,52 @@ TorchCommRCCLX::sharded_relay_multi_group_all_reduce(
     }
   }
 
-  // Verify tensors are contiguous and meet the minimum required size.
-  // Active ranks need the full per_group_counts[g] elements.
-  // Helper ranks need nActiveRanksPerGroup * chunkSize elements (two-slot
-  // passthrough buffer: slot a holds data from active rank a, forwarded
-  // to the other active without local compute).
-  // Cap minRequired at per_group_counts[g] so the active rank's buffer (which
-  // is exactly per_group_counts[g]) always passes, including the edge case
-  // where count < numChunks * CACHE_LINE_SIZE and chunkSize falls back to
-  // count.
-  int numChunks = (comm_size_ - nActiveRanksPerGroup) + 1;
-  for (int g = 0; g < nGroups; g++) {
-    if (per_group_counts[g] == 0) {
-      continue;
-    }
-    ensureTensorContiguous(tensors[g]);
-    size_t chunkSize = static_cast<size_t>(per_group_counts[g]) /
-        static_cast<size_t>(numChunks);
-    chunkSize = (chunkSize / 128) * 128; // CHUNK_ALIGN_ELEMENTS (128 elements)
-    if (chunkSize == 0) {
-      chunkSize = static_cast<size_t>(per_group_counts[g]);
-    }
-    // For the fallback case (chunkSize == count), nActiveRanks * chunkSize >
-    // count which would incorrectly reject the active rank's full-sized buffer.
-    // Cap at count.
-    size_t minRequired = std::min(
-        static_cast<size_t>(per_group_counts[g]),
-        static_cast<size_t>(nActiveRanksPerGroup) * chunkSize);
-    if (static_cast<size_t>(tensors[g].numel()) < minRequired) {
-      throw std::runtime_error(
-          "sharded_relay_multi_group_all_reduce: tensor[" + std::to_string(g) +
-          "] has " + std::to_string(tensors[g].numel()) +
-          " elements, minimum required is " + std::to_string(minRequired) +
-          " (nActiveRanks=" + std::to_string(nActiveRanksPerGroup) +
-          " x chunkSize=" + std::to_string(chunkSize) + ")");
+  int myActiveGroup = -1;
+  for (int g = 0; g < nGroups && myActiveGroup < 0; g++) {
+    for (int a = 0; a < static_cast<int>(all_active_ranks[g].size()); a++) {
+      if (all_active_ranks[g][a] == rank_) {
+        myActiveGroup = g;
+        break;
+      }
     }
   }
 
-  TracingGuard tracingGuard(
-      name_,
-      comm_size_,
-      "sharded_relay_multi_group_all_reduce",
-      rank_,
-      tensors,
-      tensors);
-  hipStream_t stream = getOperationStream(async_op);
-  auto work = createWork(stream, options_.timeout, tensors);
-
-  work->recordStart("sharded_relay_multi_group_all_reduce");
-
-  // Build arrays of buffer pointers for the C API
+  // Allreduce is in-place (sendBuffs[g] == recvBuffs[g]).
   std::vector<const void*> sendBuffs(nGroups);
   std::vector<void*> recvBuffs(nGroups);
+  std::vector<size_t> counts(nGroups);
+  std::vector<at::Tensor> all_tensors;
   for (int g = 0; g < nGroups; g++) {
+    ensureTensorContiguous(tensors[g]);
     sendBuffs[g] = tensors[g].data_ptr();
     recvBuffs[g] = tensors[g].data_ptr(); // In-place operation
+    counts[g] = static_cast<size_t>(per_group_counts[g]);
+    all_tensors.push_back(tensors[g]);
   }
 
-  // Convert int64_t vectors to int arrays for the C API
+  // Check this rank's active group against the buffer contract documented in
+  // sharded_relay_allreduce.h: the active group's tensor holds exactly
+  // counts[g] elements. This replaces the lower-bound helper-size check that
+  // used to sit above with an exact check on the one group whose size is fully
+  // determined by per_group_counts. The kernel only receives raw pointers, so
+  // an undersized tensor here becomes an out-of-bounds device access there.
+  // Helper groups are deliberately not size-checked: their buffers are scratch
+  // whose required size comes from the kernel's own chunk geometry rather than
+  // from per_group_counts, so it cannot be recomputed here without duplicating
+  // that math.
+  if (myActiveGroup >= 0 && counts[myActiveGroup] > 0 &&
+      static_cast<size_t>(tensors[myActiveGroup].numel()) !=
+          counts[myActiveGroup]) {
+    throw std::runtime_error(
+        fmt::format(
+            "sharded_relay_multi_group_all_reduce: active group {} tensor has {} elements, expected count={}",
+            myActiveGroup,
+            tensors[myActiveGroup].numel(),
+            counts[myActiveGroup]));
+  }
+
+  int segGroup = (myActiveGroup >= 0) ? myActiveGroup : 0;
+
   std::vector<std::vector<int>> active_ranks_int(nGroups);
   std::vector<const int*> allActiveRanksPtr(nGroups);
   for (int g = 0; g < nGroups; g++) {
@@ -823,23 +810,55 @@ TorchCommRCCLX::sharded_relay_multi_group_all_reduce(
     allActiveRanksPtr[g] = active_ranks_int[g].data();
   }
 
-  // Convert per_group_counts to size_t array
-  std::vector<size_t> counts(nGroups);
-  for (int g = 0; g < nGroups; g++) {
-    counts[g] = static_cast<size_t>(per_group_counts[g]);
-  }
+  TracingGuard tracingGuard(
+      name_,
+      comm_size_,
+      "sharded_relay_multi_group_all_reduce",
+      rank_,
+      tensors[segGroup],
+      tensors[segGroup]);
+  hipStream_t stream = getOperationStream(async_op);
+  auto work = createWork(stream, options_.timeout, all_tensors);
 
-  // Derive dtype from the first group with count > 0.  All non-zero groups
-  // share the same dtype; count-0 groups hold a float32 placeholder and must
-  // be excluded so we don't pass the wrong ncclDataType_t to the kernel.
-  int firstNonZeroGroup = 0;
-  for (int g = 0; g < nGroups; g++) {
-    if (per_group_counts[g] > 0) {
-      firstNonZeroGroup = g;
-      break;
+  work->recordStart("sharded_relay_multi_group_all_reduce");
+
+  // The kernel takes ONE ncclDataType_t for every group, so the dtype has to
+  // come from a group that actually carries data. A count-0 group holds a
+  // 1-element placeholder that the kernel ignores, and nothing requires that
+  // placeholder to share the payload's dtype, so reading the dtype off one
+  // would hand every group the wrong ncclDataType_t. Prefer this rank's own
+  // active group; fall back to the first group with data. All data-carrying
+  // groups share a dtype, so which one is immaterial. If every count is 0 there
+  // is no data to type.
+  int dtypeGroup = segGroup;
+  if (per_group_counts[dtypeGroup] == 0) {
+    for (int g = 0; g < nGroups; g++) {
+      if (per_group_counts[g] > 0) {
+        dtypeGroup = g;
+        break;
+      }
     }
   }
-  auto dataType = getNcclDataType(tensors[firstNonZeroGroup]);
+  // Every group that carries data must agree on dtype: the kernel is handed ONE
+  // ncclDataType_t for all of them, so a mismatch would silently reinterpret
+  // another group's buffer with the wrong element size. Count-0 groups are
+  // exempt -- their placeholder is never read or written.
+  const auto relayScalarType = tensors[dtypeGroup].scalar_type();
+  for (int g = 0; g < nGroups; g++) {
+    if (per_group_counts[g] == 0) {
+      continue;
+    }
+    if (tensors[g].scalar_type() != relayScalarType) {
+      throw std::runtime_error(
+          fmt::format(
+              "sharded_relay_multi_group_all_reduce: every group with a non-zero count must share one dtype; group {} has {} but group {} has {}",
+              g,
+              c10::toString(tensors[g].scalar_type()),
+              dtypeGroup,
+              c10::toString(relayScalarType)));
+    }
+  }
+  auto dataType = getNcclDataType(tensors[dtypeGroup]);
   ncclResult_t result = rcclx_api_->shardedRelayMultiGroupAllReduce(
       sendBuffs.data(),
       recvBuffs.data(),

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
@@ -1045,6 +1045,177 @@ TorchCommRCCLX::sharded_relay_multi_group_reduce_scatter(
   return work;
 }
 
+c10::intrusive_ptr<TorchWork>
+TorchCommRCCLX::sharded_relay_multi_group_all_to_all(
+    std::vector<at::Tensor>& input_tensors,
+    std::vector<at::Tensor>& output_tensors,
+    const std::vector<std::vector<int64_t>>& all_active_ranks,
+    const std::vector<int64_t>& per_group_segment_counts,
+    bool async_op) {
+  checkInitialized();
+  checkAndAbortIfTimedOutOrError();
+
+  int nGroups = static_cast<int>(input_tensors.size());
+  if (nGroups == 0) {
+    throw std::runtime_error(
+        "sharded_relay_multi_group_all_to_all: input_tensors list cannot be empty");
+  }
+  if (output_tensors.size() != static_cast<size_t>(nGroups) ||
+      all_active_ranks.size() != static_cast<size_t>(nGroups) ||
+      per_group_segment_counts.size() != static_cast<size_t>(nGroups)) {
+    throw std::runtime_error(
+        "sharded_relay_multi_group_all_to_all: output_tensors, all_active_ranks, and per_group_segment_counts sizes must match input_tensors size");
+  }
+
+  int nActiveRanksPerGroup = static_cast<int>(all_active_ranks[0].size());
+
+  int myActiveGroup = -1;
+  for (int g = 0; g < nGroups && myActiveGroup < 0; g++) {
+    for (int a = 0; a < static_cast<int>(all_active_ranks[g].size()); a++) {
+      if (all_active_ranks[g][a] == rank_) {
+        myActiveGroup = g;
+        break;
+      }
+    }
+  }
+
+  // One contiguous send / recv buffer per group. Helper groups pass a single
+  // scratch tensor as both input and output.
+  std::vector<const void*> sendBuffs(nGroups);
+  std::vector<void*> recvBuffs(nGroups);
+  std::vector<size_t> segmentCounts(nGroups);
+  std::vector<at::Tensor> all_tensors;
+  for (int g = 0; g < nGroups; g++) {
+    ensureTensorContiguous(input_tensors[g]);
+    ensureTensorContiguous(output_tensors[g]);
+    sendBuffs[g] = input_tensors[g].data_ptr();
+    recvBuffs[g] = output_tensors[g].data_ptr();
+    segmentCounts[g] = static_cast<size_t>(per_group_segment_counts[g]);
+    all_tensors.push_back(input_tensors[g]);
+    all_tensors.push_back(output_tensors[g]);
+  }
+
+  // Check this rank's active group against the buffer contract documented in
+  // sharded_relay_all_to_all.h: input and output each hold one segment per
+  // active index (nActiveRanks x segmentCount). The kernel only receives raw
+  // pointers, so an undersized tensor here becomes an out-of-bounds device
+  // access there. Helper groups are deliberately not size-checked: their
+  // buffers are scratch sized by the route the kernel selects, which cannot be
+  // recomputed here without duplicating that math.
+  if (myActiveGroup >= 0 && segmentCounts[myActiveGroup] > 0) {
+    const size_t segmentCount = segmentCounts[myActiveGroup];
+    const size_t expected =
+        static_cast<size_t>(nActiveRanksPerGroup) * segmentCount;
+    if (static_cast<size_t>(input_tensors[myActiveGroup].numel()) != expected) {
+      throw std::runtime_error(
+          fmt::format(
+              "sharded_relay_multi_group_all_to_all: active group {} input has {} elements, expected {} (nActiveRanks={} x segmentCount={})",
+              myActiveGroup,
+              input_tensors[myActiveGroup].numel(),
+              expected,
+              nActiveRanksPerGroup,
+              segmentCount));
+    }
+    if (static_cast<size_t>(output_tensors[myActiveGroup].numel()) !=
+        expected) {
+      throw std::runtime_error(
+          fmt::format(
+              "sharded_relay_multi_group_all_to_all: active group {} output has {} elements, expected {} (nActiveRanks={} x segmentCount={})",
+              myActiveGroup,
+              output_tensors[myActiveGroup].numel(),
+              expected,
+              nActiveRanksPerGroup,
+              segmentCount));
+    }
+  }
+
+  int segGroup = (myActiveGroup >= 0) ? myActiveGroup : 0;
+
+  std::vector<std::vector<int>> active_ranks_int(nGroups);
+  std::vector<const int*> allActiveRanksPtr(nGroups);
+  for (int g = 0; g < nGroups; g++) {
+    active_ranks_int[g].assign(
+        all_active_ranks[g].begin(), all_active_ranks[g].end());
+    allActiveRanksPtr[g] = active_ranks_int[g].data();
+  }
+
+  TracingGuard tracingGuard(
+      name_,
+      comm_size_,
+      "sharded_relay_multi_group_all_to_all",
+      rank_,
+      input_tensors[segGroup],
+      output_tensors[segGroup]);
+  hipStream_t stream = getOperationStream(async_op);
+  auto work = createWork(stream, options_.timeout, all_tensors);
+
+  work->recordStart("sharded_relay_multi_group_all_to_all");
+
+  // The kernel takes ONE ncclDataType_t for every group, so the dtype has to
+  // come from a group that actually carries data. A count-0 group holds a
+  // 1-element placeholder that the kernel ignores, and nothing requires that
+  // placeholder to share the payload's dtype, so reading the dtype off one
+  // would hand every group the wrong ncclDataType_t. Prefer this rank's own
+  // active group; fall back to the first group with data. All data-carrying
+  // groups share a dtype, so which one is immaterial. If every count is 0 there
+  // is no data to type.
+  int dtypeGroup = segGroup;
+  if (per_group_segment_counts[dtypeGroup] == 0) {
+    for (int g = 0; g < nGroups; g++) {
+      if (per_group_segment_counts[g] > 0) {
+        dtypeGroup = g;
+        break;
+      }
+    }
+  }
+  // Every group that carries data must agree on dtype: the kernel is handed ONE
+  // ncclDataType_t for all of them, so a mismatch would silently reinterpret
+  // another group's buffer with the wrong element size. Count-0 groups are
+  // exempt -- their placeholder is never read or written.
+  const auto relayScalarType = input_tensors[dtypeGroup].scalar_type();
+  for (int g = 0; g < nGroups; g++) {
+    if (per_group_segment_counts[g] == 0) {
+      continue;
+    }
+    if (input_tensors[g].scalar_type() != relayScalarType ||
+        output_tensors[g].scalar_type() != relayScalarType) {
+      throw std::runtime_error(
+          fmt::format(
+              "sharded_relay_multi_group_all_to_all: every group with a non-zero count must share one dtype; group {} has in={}/out={} but group {} has {}",
+              g,
+              c10::toString(input_tensors[g].scalar_type()),
+              c10::toString(output_tensors[g].scalar_type()),
+              dtypeGroup,
+              c10::toString(relayScalarType)));
+    }
+  }
+  auto dataType = getNcclDataType(input_tensors[dtypeGroup]);
+  ncclResult_t result = rcclx_api_->shardedRelayMultiGroupAllToAll(
+      sendBuffs.data(),
+      recvBuffs.data(),
+      segmentCounts.data(),
+      dataType,
+      nccl_comm_,
+      stream,
+      allActiveRanksPtr.data(),
+      nActiveRanksPerGroup,
+      nGroups);
+
+  if (result != ncclSuccess) {
+    throw RCCLXException(
+        *rcclx_api_,
+        "RCCLX Sharded Relay Multi-Group AllToAll failed",
+        result,
+        nccl_comm_);
+  }
+
+  work->recordEnd();
+
+  enqueueWork(work, stream);
+
+  return work;
+}
+
 c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reduce(
     const at::Tensor& tensor,
     int root,

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
@@ -1216,6 +1216,178 @@ TorchCommRCCLX::sharded_relay_multi_group_all_to_all(
   return work;
 }
 
+c10::intrusive_ptr<TorchWork>
+TorchCommRCCLX::sharded_relay_multi_group_all_gather(
+    std::vector<at::Tensor>& input_tensors,
+    std::vector<at::Tensor>& output_tensors,
+    const std::vector<std::vector<int64_t>>& all_active_ranks,
+    const std::vector<int64_t>& per_group_send_counts,
+    bool async_op) {
+  checkInitialized();
+  checkAndAbortIfTimedOutOrError();
+
+  int nGroups = static_cast<int>(input_tensors.size());
+  if (nGroups == 0) {
+    throw std::runtime_error(
+        "sharded_relay_multi_group_all_gather: input_tensors list cannot be empty");
+  }
+  if (output_tensors.size() != static_cast<size_t>(nGroups) ||
+      all_active_ranks.size() != static_cast<size_t>(nGroups) ||
+      per_group_send_counts.size() != static_cast<size_t>(nGroups)) {
+    throw std::runtime_error(
+        "sharded_relay_multi_group_all_gather: output_tensors, all_active_ranks, and per_group_send_counts sizes must match input_tensors size");
+  }
+
+  int nActiveRanksPerGroup = static_cast<int>(all_active_ranks[0].size());
+
+  int myActiveGroup = -1;
+  for (int g = 0; g < nGroups && myActiveGroup < 0; g++) {
+    for (int a = 0; a < static_cast<int>(all_active_ranks[g].size()); a++) {
+      if (all_active_ranks[g][a] == rank_) {
+        myActiveGroup = g;
+        break;
+      }
+    }
+  }
+
+  // One contiguous send / recv buffer per group. Helper groups pass a single
+  // scratch tensor as both input and output.
+  std::vector<const void*> sendBuffs(nGroups);
+  std::vector<void*> recvBuffs(nGroups);
+  std::vector<size_t> sendCounts(nGroups);
+  std::vector<at::Tensor> all_tensors;
+  for (int g = 0; g < nGroups; g++) {
+    ensureTensorContiguous(input_tensors[g]);
+    ensureTensorContiguous(output_tensors[g]);
+    sendBuffs[g] = input_tensors[g].data_ptr();
+    recvBuffs[g] = output_tensors[g].data_ptr();
+    sendCounts[g] = static_cast<size_t>(per_group_send_counts[g]);
+    all_tensors.push_back(input_tensors[g]);
+    all_tensors.push_back(output_tensors[g]);
+  }
+
+  // Check this rank's active group against the buffer contract documented in
+  // sharded_relay_all_gather.h: the input holds this rank's contribution
+  // (sendCount) and the output holds one slot per active index (nActiveRanks x
+  // sendCount). The kernel only receives raw pointers, so an undersized tensor
+  // here becomes an out-of-bounds device access there. Helper groups are
+  // deliberately not size-checked: their buffers are scratch whose required
+  // size comes from the kernel's own chunk geometry rather than from
+  // per_group_send_counts, so it cannot be recomputed here without duplicating
+  // that math.
+  if (myActiveGroup >= 0 && sendCounts[myActiveGroup] > 0) {
+    const size_t sendCount = sendCounts[myActiveGroup];
+    const size_t expectedOutput =
+        static_cast<size_t>(nActiveRanksPerGroup) * sendCount;
+    if (static_cast<size_t>(input_tensors[myActiveGroup].numel()) !=
+        sendCount) {
+      throw std::runtime_error(
+          fmt::format(
+              "sharded_relay_multi_group_all_gather: active group {} input has {} elements, expected sendCount={}",
+              myActiveGroup,
+              input_tensors[myActiveGroup].numel(),
+              sendCount));
+    }
+    if (static_cast<size_t>(output_tensors[myActiveGroup].numel()) !=
+        expectedOutput) {
+      throw std::runtime_error(
+          fmt::format(
+              "sharded_relay_multi_group_all_gather: active group {} output has {} elements, expected {} (nActiveRanks={} x sendCount={})",
+              myActiveGroup,
+              output_tensors[myActiveGroup].numel(),
+              expectedOutput,
+              nActiveRanksPerGroup,
+              sendCount));
+    }
+  }
+
+  int segGroup = (myActiveGroup >= 0) ? myActiveGroup : 0;
+
+  std::vector<std::vector<int>> active_ranks_int(nGroups);
+  std::vector<const int*> allActiveRanksPtr(nGroups);
+  for (int g = 0; g < nGroups; g++) {
+    active_ranks_int[g].assign(
+        all_active_ranks[g].begin(), all_active_ranks[g].end());
+    allActiveRanksPtr[g] = active_ranks_int[g].data();
+  }
+
+  TracingGuard tracingGuard(
+      name_,
+      comm_size_,
+      "sharded_relay_multi_group_all_gather",
+      rank_,
+      input_tensors[segGroup],
+      output_tensors[segGroup]);
+  hipStream_t stream = getOperationStream(async_op);
+  auto work = createWork(stream, options_.timeout, all_tensors);
+
+  work->recordStart("sharded_relay_multi_group_all_gather");
+
+  // The kernel takes ONE ncclDataType_t for every group, so the dtype has to
+  // come from a group that actually carries data. A count-0 group holds a
+  // 1-element placeholder that the kernel ignores, and nothing requires that
+  // placeholder to share the payload's dtype, so reading the dtype off one
+  // would hand every group the wrong ncclDataType_t. Prefer this rank's own
+  // active group; fall back to the first group with data. All data-carrying
+  // groups share a dtype, so which one is immaterial. If every count is 0 there
+  // is no data to type.
+  int dtypeGroup = segGroup;
+  if (per_group_send_counts[dtypeGroup] == 0) {
+    for (int g = 0; g < nGroups; g++) {
+      if (per_group_send_counts[g] > 0) {
+        dtypeGroup = g;
+        break;
+      }
+    }
+  }
+  // Every group that carries data must agree on dtype: the kernel is handed ONE
+  // ncclDataType_t for all of them, so a mismatch would silently reinterpret
+  // another group's buffer with the wrong element size. Count-0 groups are
+  // exempt -- their placeholder is never read or written.
+  const auto relayScalarType = input_tensors[dtypeGroup].scalar_type();
+  for (int g = 0; g < nGroups; g++) {
+    if (per_group_send_counts[g] == 0) {
+      continue;
+    }
+    if (input_tensors[g].scalar_type() != relayScalarType ||
+        output_tensors[g].scalar_type() != relayScalarType) {
+      throw std::runtime_error(
+          fmt::format(
+              "sharded_relay_multi_group_all_gather: every group with a non-zero count must share one dtype; group {} has in={}/out={} but group {} has {}",
+              g,
+              c10::toString(input_tensors[g].scalar_type()),
+              c10::toString(output_tensors[g].scalar_type()),
+              dtypeGroup,
+              c10::toString(relayScalarType)));
+    }
+  }
+  auto dataType = getNcclDataType(input_tensors[dtypeGroup]);
+  ncclResult_t result = rcclx_api_->shardedRelayMultiGroupAllGather(
+      sendBuffs.data(),
+      recvBuffs.data(),
+      sendCounts.data(),
+      dataType,
+      nccl_comm_,
+      stream,
+      allActiveRanksPtr.data(),
+      nActiveRanksPerGroup,
+      nGroups);
+
+  if (result != ncclSuccess) {
+    throw RCCLXException(
+        *rcclx_api_,
+        "RCCLX Sharded Relay Multi-Group AllGather failed",
+        result,
+        nccl_comm_);
+  }
+
+  work->recordEnd();
+
+  enqueueWork(work, stream);
+
+  return work;
+}
+
 c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reduce(
     const at::Tensor& tensor,
     int root,

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
@@ -223,6 +223,20 @@ class TorchCommRCCLX : public TorchCommBackend,
       const std::vector<int64_t>& per_group_segment_counts,
       bool async_op);
 
+  // Fused multi-group sharded relay all-gather for 2D sparse parallelism.
+  // Each active rank's input holds per_group_send_counts[g] elements (its
+  // contribution); its output holds nActiveRanks x per_group_send_counts[g]
+  // elements (output[i x sendCount] from active index i). No reduction op.
+  // Supports in-place (input aliases output + myActiveIndex x sendCount) and
+  // out-of-place. Helper ranks pass a two-slot scratch tensor as both input
+  // and output.
+  c10::intrusive_ptr<TorchWork> sharded_relay_multi_group_all_gather(
+      std::vector<at::Tensor>& input_tensors,
+      std::vector<at::Tensor>& output_tensors,
+      const std::vector<std::vector<int64_t>>& all_active_ranks,
+      const std::vector<int64_t>& per_group_send_counts,
+      bool async_op);
+
   // Scatter and Gather Operations
   c10::intrusive_ptr<TorchWork> scatter(
       at::Tensor& output_tensor,

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
@@ -197,7 +197,8 @@ class TorchCommRCCLX : public TorchCommBackend,
       const ReduceOp& op,
       const std::vector<std::vector<int64_t>>& all_active_ranks,
       const std::vector<int64_t>& per_group_counts,
-      bool async_op);
+      bool async_op,
+      std::optional<std::vector<at::Tensor>> output_tensors = std::nullopt);
 
   // Fused multi-group sharded relay reduce-scatter for 2D sparse parallelism.
   // input_tensors[g] / output_tensors[g] are the contiguous send / recv buffer

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
@@ -210,6 +210,19 @@ class TorchCommRCCLX : public TorchCommBackend,
       const std::vector<int64_t>& per_group_recv_counts,
       bool async_op);
 
+  // Fused multi-group sharded relay all-to-all for 2D sparse parallelism.
+  // Each active rank's input/output hold nActiveRanks x
+  // per_group_segment_counts[g] elements (input = [sendSeg[0]|sendSeg[1]],
+  // output = [recvSeg[0]|recvSeg[1]]). No reduction op. OUT-OF-PLACE ONLY:
+  // input and output must be distinct tensors (matches native ncclAllToAll).
+  // Helper ranks pass a two-slot scratch tensor as both input and output.
+  c10::intrusive_ptr<TorchWork> sharded_relay_multi_group_all_to_all(
+      std::vector<at::Tensor>& input_tensors,
+      std::vector<at::Tensor>& output_tensors,
+      const std::vector<std::vector<int64_t>>& all_active_ranks,
+      const std::vector<int64_t>& per_group_segment_counts,
+      bool async_op);
+
   // Scatter and Gather Operations
   c10::intrusive_ptr<TorchWork> scatter(
       at::Tensor& output_tensor,

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
@@ -199,6 +199,17 @@ class TorchCommRCCLX : public TorchCommBackend,
       const std::vector<int64_t>& per_group_counts,
       bool async_op);
 
+  // Fused multi-group sharded relay reduce-scatter for 2D sparse parallelism.
+  // input_tensors[g] / output_tensors[g] are the contiguous send / recv buffer
+  // for group g. Helper groups pass a single scratch tensor as both.
+  c10::intrusive_ptr<TorchWork> sharded_relay_multi_group_reduce_scatter(
+      std::vector<at::Tensor>& input_tensors,
+      std::vector<at::Tensor>& output_tensors,
+      const ReduceOp& op,
+      const std::vector<std::vector<int64_t>>& all_active_ranks,
+      const std::vector<int64_t>& per_group_recv_counts,
+      bool async_op);
+
   // Scatter and Gather Operations
   c10::intrusive_ptr<TorchWork> scatter(
       at::Tensor& output_tensor,

--- a/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
@@ -207,9 +207,13 @@ Fused multi-group sharded relay all-gather for 2D sparse parallelism.
 
 All-gather analogue of sharded_relay_multi_group_reduce_scatter (and the dual of
 it). Executes multiple all-gather groups in lockstep phases to eliminate XGMI
-link contention on MI300x GPUs. Each group has exactly 2 active ranks; the
-logical collective is a 2-rank all-gather between them, accelerated by
-passthrough helpers. There is NO reduction (pure data movement) and NO op.
+link contention on MI300x GPUs. Each group has a power-of-two number of active
+ranks (2 or 4); the logical collective is an all-gather among them, accelerated
+by passthrough helpers (A==2 uses the original 2-active passthrough path; A>2
+uses the bandwidth-optimal flat scatter->forward relay -- the dual of the
+reduce-scatter -- i.e. a direct intra all-to-all woven with a 2-hop offload
+through the idle helper GPUs). There is NO reduction (pure data movement) and
+NO op.
 
 For each active rank, the input holds per_group_send_counts[g] elements (its
 contribution) and the output holds nActiveRanks x per_group_send_counts[g]
@@ -221,8 +225,8 @@ in-place convention).
 
 Args:
     input_tensors: List of send tensors (one per group). Active rank: holds
-        per_group_send_counts[g] elements. Helper rank: a two-slot scratch
-        tensor.
+        per_group_send_counts[g] elements. Helper rank: an nActiveRanks-slot
+        scratch tensor.
     output_tensors: List of receive tensors (one per group). Active rank: holds
         nActiveRanks x per_group_send_counts[g] elements. Helper rank: the same
         scratch tensor as the input.

--- a/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
@@ -91,9 +91,9 @@ Fused multi-group sharded relay reduce-scatter for 2D sparse parallelism.
 
 Reduce-scatter analogue of sharded_relay_multi_group_all_reduce. Executes
 multiple reduce-scatter groups in lockstep phases to eliminate XGMI link
-contention on MI300x GPUs. Each group has exactly 2 active ranks; the logical
-collective is a 2-rank reduce-scatter between them, accelerated by passthrough
-helpers that relay sharded chunks of a single output block.
+contention on MI300x GPUs. Each group has a power-of-two number of active ranks
+(2 or 4); the logical collective is a reduce-scatter among them, accelerated by
+passthrough helpers that relay sharded chunks of a single output block.
 
 For each active rank, the input holds nActiveRanks x per_group_recv_counts[g]
 elements (block[i] is the slice destined for active index i) and the output
@@ -102,7 +102,7 @@ holds per_group_recv_counts[g] elements receiving the reduced block[myIndex].
 Args:
     input_tensors: List of send tensors (one per group). For an active rank,
         holds nActiveRanks x per_group_recv_counts[g] elements. For a helper
-        rank, a two-slot scratch tensor.
+        rank, an nActiveRanks-slot scratch tensor (nActiveRanks x chunkSize).
     output_tensors: List of receive tensors (one per group). For an active
         rank, holds per_group_recv_counts[g] elements. Pass the
         local-contribution block of the input tensor for in-place operation.

--- a/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
@@ -68,5 +68,70 @@ Example:
           py::arg("all_active_ranks"),
           py::arg("per_group_counts"),
           py::arg("async_op") = false,
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "sharded_relay_multi_group_reduce_scatter",
+          [](TorchCommRCCLX& self,
+             std::vector<at::Tensor>& input_tensors,
+             std::vector<at::Tensor>& output_tensors,
+             const ReduceOp& op,
+             const std::vector<std::vector<int64_t>>& all_active_ranks,
+             const std::vector<int64_t>& per_group_recv_counts,
+             bool async_op) {
+            return self.sharded_relay_multi_group_reduce_scatter(
+                input_tensors,
+                output_tensors,
+                op,
+                all_active_ranks,
+                per_group_recv_counts,
+                async_op);
+          },
+          R"(
+Fused multi-group sharded relay reduce-scatter for 2D sparse parallelism.
+
+Reduce-scatter analogue of sharded_relay_multi_group_all_reduce. Executes
+multiple reduce-scatter groups in lockstep phases to eliminate XGMI link
+contention on MI300x GPUs. Each group has exactly 2 active ranks; the logical
+collective is a 2-rank reduce-scatter between them, accelerated by passthrough
+helpers that relay sharded chunks of a single output block.
+
+For each active rank, the input holds nActiveRanks x per_group_recv_counts[g]
+elements (block[i] is the slice destined for active index i) and the output
+holds per_group_recv_counts[g] elements receiving the reduced block[myIndex].
+
+Args:
+    input_tensors: List of send tensors (one per group). For an active rank,
+        holds nActiveRanks x per_group_recv_counts[g] elements. For a helper
+        rank, a two-slot scratch tensor.
+    output_tensors: List of receive tensors (one per group). For an active
+        rank, holds per_group_recv_counts[g] elements. Pass the
+        local-contribution block of the input tensor for in-place operation.
+        For a helper rank, the same scratch tensor as the input.
+    op: Reduction operation (ReduceOp.SUM or ReduceOp.AVG)
+    all_active_ranks: List of lists, where each inner list contains the active
+        rank IDs for one sparse group. All groups must have the same number of
+        active ranks.
+    per_group_recv_counts: List of OUTPUT element counts (one per group).
+    async_op: If True, returns a TorchWork handle for async operation
+
+Returns:
+    TorchWork object for operation completion if async_op=True
+
+Example:
+    # 2D sparse parallelism with 4 groups on 8 GPUs
+    input_tensors = [in0, in1, in2, in3]    # active: 2 x recvCount elements
+    output_tensors = [out0, out1, out2, out3]  # active: recvCount elements
+    all_active_ranks = [[0, 1], [2, 3], [4, 5], [6, 7]]
+    per_group_recv_counts = [1000000, 2000000, 500000, 1500000]
+    comm.sharded_relay_multi_group_reduce_scatter(
+        input_tensors, output_tensors, ReduceOp.SUM, all_active_ranks,
+        per_group_recv_counts, async_op=True)
+)",
+          py::arg("input_tensors"),
+          py::arg("output_tensors"),
+          py::arg("op"),
+          py::arg("all_active_ranks"),
+          py::arg("per_group_recv_counts"),
+          py::arg("async_op") = false,
           py::call_guard<py::gil_scoped_release>());
 }

--- a/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
@@ -185,5 +185,57 @@ Returns:
           py::arg("all_active_ranks"),
           py::arg("per_group_segment_counts"),
           py::arg("async_op") = false,
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "sharded_relay_multi_group_all_gather",
+          [](TorchCommRCCLX& self,
+             std::vector<at::Tensor>& input_tensors,
+             std::vector<at::Tensor>& output_tensors,
+             const std::vector<std::vector<int64_t>>& all_active_ranks,
+             const std::vector<int64_t>& per_group_send_counts,
+             bool async_op) {
+            return self.sharded_relay_multi_group_all_gather(
+                input_tensors,
+                output_tensors,
+                all_active_ranks,
+                per_group_send_counts,
+                async_op);
+          },
+          R"(
+Fused multi-group sharded relay all-gather for 2D sparse parallelism.
+
+All-gather analogue of sharded_relay_multi_group_reduce_scatter (and the dual of
+it). Executes multiple all-gather groups in lockstep phases to eliminate XGMI
+link contention on MI300x GPUs. Each group has exactly 2 active ranks; the
+logical collective is a 2-rank all-gather between them, accelerated by
+passthrough helpers. There is NO reduction (pure data movement) and NO op.
+
+For each active rank, the input holds per_group_send_counts[g] elements (its
+contribution) and the output holds nActiveRanks x per_group_send_counts[g]
+elements (output[i x sendCount] receives active index i's contribution).
+
+Supports both in-place and out-of-place. In-place is detected when the active
+input aliases output + myActiveIndex x sendCount (standard NCCL all-gather
+in-place convention).
+
+Args:
+    input_tensors: List of send tensors (one per group). Active rank: holds
+        per_group_send_counts[g] elements. Helper rank: a two-slot scratch
+        tensor.
+    output_tensors: List of receive tensors (one per group). Active rank: holds
+        nActiveRanks x per_group_send_counts[g] elements. Helper rank: the same
+        scratch tensor as the input.
+    all_active_ranks: List of lists of active rank IDs per sparse group.
+    per_group_send_counts: List of per-rank contribution counts (one per group).
+    async_op: If True, returns a TorchWork handle for async operation
+
+Returns:
+    TorchWork object for operation completion if async_op=True
+)",
+          py::arg("input_tensors"),
+          py::arg("output_tensors"),
+          py::arg("all_active_ranks"),
+          py::arg("per_group_send_counts"),
+          py::arg("async_op") = false,
           py::call_guard<py::gil_scoped_release>());
 }

--- a/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
@@ -154,22 +154,23 @@ Fused multi-group sharded relay all-to-all for 2D sparse parallelism.
 
 All-to-all analogue of sharded_relay_multi_group_reduce_scatter. Executes
 multiple all-to-all groups in lockstep phases to eliminate XGMI link contention
-on MI300x GPUs. Each group has exactly 2 active ranks; the logical collective is
-a 2-rank all-to-all between them, accelerated by passthrough helpers. There is
-NO reduction (pure data movement) and NO reduction op.
+on MI300x GPUs. Each group has a power-of-two number of active ranks (2 or 4);
+the logical collective is an all-to-all among them, accelerated by passthrough
+helpers (A==2 uses the original path; A>2 uses a flat all-to-all + 2-hop relay).
+There is NO reduction (pure data movement) and NO reduction op.
 
 For each active rank, the input holds nActiveRanks x per_group_segment_counts[g]
-elements (input = [sendSeg[0]|sendSeg[1]], sendSeg[j] destined for active index
-j) and the output holds the same number of elements (output =
-[recvSeg[0]|recvSeg[1]], recvSeg[i] from active index i).
+elements (input = [sendSeg[0]|...|sendSeg[A-1]], sendSeg[j] destined for active
+index j) and the output holds the same number of elements (output =
+[recvSeg[0]|...|recvSeg[A-1]], recvSeg[i] from active index i).
 
 OUT-OF-PLACE ONLY: input_tensors[g] and output_tensors[g] must be distinct for
 the active group (matches native ncclAllToAll); passing aliasing buffers raises.
 
 Args:
     input_tensors: List of send tensors (one per group). Active rank: holds
-        nActiveRanks x per_group_segment_counts[g] elements. Helper rank: a
-        two-slot scratch tensor.
+        nActiveRanks x per_group_segment_counts[g] elements. Helper rank: an
+        nActiveRanks-slot scratch tensor.
     output_tensors: List of receive tensors (one per group). Active rank: holds
         nActiveRanks x per_group_segment_counts[g] elements (distinct from
         input). Helper rank: the same scratch tensor as the input.

--- a/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
@@ -133,5 +133,57 @@ Example:
           py::arg("all_active_ranks"),
           py::arg("per_group_recv_counts"),
           py::arg("async_op") = false,
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "sharded_relay_multi_group_all_to_all",
+          [](TorchCommRCCLX& self,
+             std::vector<at::Tensor>& input_tensors,
+             std::vector<at::Tensor>& output_tensors,
+             const std::vector<std::vector<int64_t>>& all_active_ranks,
+             const std::vector<int64_t>& per_group_segment_counts,
+             bool async_op) {
+            return self.sharded_relay_multi_group_all_to_all(
+                input_tensors,
+                output_tensors,
+                all_active_ranks,
+                per_group_segment_counts,
+                async_op);
+          },
+          R"(
+Fused multi-group sharded relay all-to-all for 2D sparse parallelism.
+
+All-to-all analogue of sharded_relay_multi_group_reduce_scatter. Executes
+multiple all-to-all groups in lockstep phases to eliminate XGMI link contention
+on MI300x GPUs. Each group has exactly 2 active ranks; the logical collective is
+a 2-rank all-to-all between them, accelerated by passthrough helpers. There is
+NO reduction (pure data movement) and NO reduction op.
+
+For each active rank, the input holds nActiveRanks x per_group_segment_counts[g]
+elements (input = [sendSeg[0]|sendSeg[1]], sendSeg[j] destined for active index
+j) and the output holds the same number of elements (output =
+[recvSeg[0]|recvSeg[1]], recvSeg[i] from active index i).
+
+OUT-OF-PLACE ONLY: input_tensors[g] and output_tensors[g] must be distinct for
+the active group (matches native ncclAllToAll); passing aliasing buffers raises.
+
+Args:
+    input_tensors: List of send tensors (one per group). Active rank: holds
+        nActiveRanks x per_group_segment_counts[g] elements. Helper rank: a
+        two-slot scratch tensor.
+    output_tensors: List of receive tensors (one per group). Active rank: holds
+        nActiveRanks x per_group_segment_counts[g] elements (distinct from
+        input). Helper rank: the same scratch tensor as the input.
+    all_active_ranks: List of lists of active rank IDs per sparse group.
+    per_group_segment_counts: List of per-segment element counts (one per group).
+    async_op: If True, returns a TorchWork handle for async operation
+
+Returns:
+    TorchWork object for operation completion if async_op=True
+)",
+          py::arg("input_tensors"),
+          py::arg("output_tensors"),
+          py::arg("all_active_ranks"),
+          py::arg("per_group_segment_counts"),
+          py::arg("async_op") = false,
           py::call_guard<py::gil_scoped_release>());
 }

--- a/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
@@ -23,9 +23,15 @@ PYBIND11_MODULE(_comms_rcclx, m, py::mod_gil_not_used()) {
              const ReduceOp& op,
              const std::vector<std::vector<int64_t>>& all_active_ranks,
              const std::vector<int64_t>& per_group_counts,
-             bool async_op) {
+             bool async_op,
+             std::optional<std::vector<at::Tensor>> output_tensors) {
             return self.sharded_relay_multi_group_all_reduce(
-                tensors, op, all_active_ranks, per_group_counts, async_op);
+                tensors,
+                op,
+                all_active_ranks,
+                per_group_counts,
+                async_op,
+                output_tensors);
           },
           R"(
 Fused multi-group sharded relay allreduce for 2D sparse parallelism.
@@ -51,6 +57,12 @@ Args:
         different groups to have different tensor sizes. Each tensor's
         numel() must match the corresponding count.
     async_op: If True, returns a TorchWork handle for async operation
+    output_tensors: Optional list of output segment tensors (one list per
+        group), parallel to `tensors`. When None (default) the allreduce is
+        in-place. When provided, the active group's reduced result is written
+        out-of-place into these output tensors while the inputs are preserved;
+        the active group's output segments must mirror its input segments in
+        count and per-segment numel().
 
 Returns:
     TorchWork object for operation completion if async_op=True
@@ -68,6 +80,7 @@ Example:
           py::arg("all_active_ranks"),
           py::arg("per_group_counts"),
           py::arg("async_op") = false,
+          py::arg("output_tensors") = py::none(),
           py::call_guard<py::gil_scoped_release>())
       .def(
           "sharded_relay_multi_group_reduce_scatter",

--- a/comms/torchcomms/rcclx/_comms_rcclx.pyi
+++ b/comms/torchcomms/rcclx/_comms_rcclx.pyi
@@ -106,3 +106,39 @@ class TorchCommRCCLX:
             TorchWork handle if async_op=True, else None
         """
         ...
+
+    def sharded_relay_multi_group_all_gather(
+        self,
+        input_tensors: list[torch.Tensor],
+        output_tensors: list[torch.Tensor],
+        all_active_ranks: list[list[int]],
+        per_group_send_counts: list[int],
+        async_op: bool = False,
+    ) -> TorchWork | None:
+        """
+        Fused multi-group sharded relay all-gather for 2D sparse parallelism.
+
+        All-gather analogue of sharded_relay_multi_group_reduce_scatter (its
+        dual). No reduction (pure data movement) and no reduction op. Each
+        active rank's input holds per_group_send_counts[g] elements and its
+        output holds nActiveRanks x per_group_send_counts[g] elements
+        (output[i x sendCount] from active index i).
+
+        Supports both in-place and out-of-place. In-place is detected when the
+        active input aliases output + myActiveIndex x sendCount.
+
+        Args:
+            input_tensors: List of send tensors (one per group). Active rank:
+                per_group_send_counts[g] elements. Helper rank: two-slot scratch
+                tensor.
+            output_tensors: List of receive tensors (one per group). Active rank:
+                nActiveRanks x per_group_send_counts[g] elements. Helper rank:
+                same scratch as input.
+            all_active_ranks: List of lists of active rank IDs per sparse group
+            per_group_send_counts: List of per-rank contribution counts
+            async_op: If True, returns a TorchWork handle for async operation
+
+        Returns:
+            TorchWork handle if async_op=True, else None
+        """
+        ...

--- a/comms/torchcomms/rcclx/_comms_rcclx.pyi
+++ b/comms/torchcomms/rcclx/_comms_rcclx.pyi
@@ -57,7 +57,7 @@ class TorchCommRCCLX:
         Args:
             input_tensors: List of send tensors (one per group). Active rank:
                 nActiveRanks x per_group_recv_counts[g] elements. Helper rank:
-                two-slot scratch tensor.
+                nActiveRanks-slot scratch tensor.
             output_tensors: List of receive tensors (one per group). Active
                 rank: per_group_recv_counts[g] elements (pass the local block of
                 the input for in-place). Helper rank: same scratch as input.

--- a/comms/torchcomms/rcclx/_comms_rcclx.pyi
+++ b/comms/torchcomms/rcclx/_comms_rcclx.pyi
@@ -71,3 +71,38 @@ class TorchCommRCCLX:
             TorchWork handle if async_op=True, else None
         """
         ...
+
+    def sharded_relay_multi_group_all_to_all(
+        self,
+        input_tensors: list[torch.Tensor],
+        output_tensors: list[torch.Tensor],
+        all_active_ranks: list[list[int]],
+        per_group_segment_counts: list[int],
+        async_op: bool = False,
+    ) -> TorchWork | None:
+        """
+        Fused multi-group sharded relay all-to-all for 2D sparse parallelism.
+
+        All-to-all analogue of sharded_relay_multi_group_reduce_scatter. No
+        reduction (pure data movement) and no reduction op. Each active rank's
+        input/output hold nActiveRanks x per_group_segment_counts[g] elements
+        (input = [sendSeg[0]|sendSeg[1]], output = [recvSeg[0]|recvSeg[1]]).
+
+        OUT-OF-PLACE ONLY: input and output tensors for the active group must be
+        distinct (matches native ncclAllToAll); aliasing raises.
+
+        Args:
+            input_tensors: List of send tensors (one per group). Active rank:
+                nActiveRanks x per_group_segment_counts[g] elements. Helper rank:
+                two-slot scratch tensor.
+            output_tensors: List of receive tensors (one per group). Active rank:
+                nActiveRanks x per_group_segment_counts[g] elements (distinct
+                from input). Helper rank: same scratch as input.
+            all_active_ranks: List of lists of active rank IDs per sparse group
+            per_group_segment_counts: List of per-segment element counts
+            async_op: If True, returns a TorchWork handle for async operation
+
+        Returns:
+            TorchWork handle if async_op=True, else None
+        """
+        ...

--- a/comms/torchcomms/rcclx/_comms_rcclx.pyi
+++ b/comms/torchcomms/rcclx/_comms_rcclx.pyi
@@ -121,18 +121,21 @@ class TorchCommRCCLX:
         Fused multi-group sharded relay all-gather for 2D sparse parallelism.
 
         All-gather analogue of sharded_relay_multi_group_reduce_scatter (its
-        dual). No reduction (pure data movement) and no reduction op. Each
-        active rank's input holds per_group_send_counts[g] elements and its
-        output holds nActiveRanks x per_group_send_counts[g] elements
-        (output[i x sendCount] from active index i).
+        dual). No reduction (pure data movement) and no reduction op.
+        nActiveRanks must be a power of two (2 or 4); A>2 uses the flat
+        scatter->forward relay: a direct intra all-to-all woven with a 2-hop
+        offload through the idle helper GPUs. Each active rank's input
+        holds per_group_send_counts[g] elements and its output holds
+        nActiveRanks x per_group_send_counts[g] elements (output[i x sendCount]
+        from active index i).
 
         Supports both in-place and out-of-place. In-place is detected when the
         active input aliases output + myActiveIndex x sendCount.
 
         Args:
             input_tensors: List of send tensors (one per group). Active rank:
-                per_group_send_counts[g] elements. Helper rank: two-slot scratch
-                tensor.
+                per_group_send_counts[g] elements. Helper rank:
+                nActiveRanks-slot scratch tensor.
             output_tensors: List of receive tensors (one per group). Active rank:
                 nActiveRanks x per_group_send_counts[g] elements. Helper rank:
                 same scratch as input.

--- a/comms/torchcomms/rcclx/_comms_rcclx.pyi
+++ b/comms/torchcomms/rcclx/_comms_rcclx.pyi
@@ -36,3 +36,38 @@ class TorchCommRCCLX:
             TorchWork handle if async_op=True, else None
         """
         ...
+
+    def sharded_relay_multi_group_reduce_scatter(
+        self,
+        input_tensors: list[torch.Tensor],
+        output_tensors: list[torch.Tensor],
+        op: torch.distributed.ReduceOp,
+        all_active_ranks: list[list[int]],
+        per_group_recv_counts: list[int],
+        async_op: bool = False,
+    ) -> TorchWork | None:
+        """
+        Fused multi-group sharded relay reduce-scatter for 2D sparse parallelism.
+
+        Reduce-scatter analogue of sharded_relay_multi_group_all_reduce. Each
+        active rank's input holds nActiveRanks x per_group_recv_counts[g]
+        elements (block[i] is the slice destined for active index i) and its
+        output holds per_group_recv_counts[g] elements.
+
+        Args:
+            input_tensors: List of send tensors (one per group). Active rank:
+                nActiveRanks x per_group_recv_counts[g] elements. Helper rank:
+                two-slot scratch tensor.
+            output_tensors: List of receive tensors (one per group). Active
+                rank: per_group_recv_counts[g] elements (pass the local block of
+                the input for in-place). Helper rank: same scratch as input.
+            op: Reduction operation (ReduceOp.SUM or ReduceOp.AVG)
+            all_active_ranks: List of lists, where each inner list contains the
+                active rank IDs for one sparse group
+            per_group_recv_counts: List of OUTPUT element counts (one per group)
+            async_op: If True, returns a TorchWork handle for async operation
+
+        Returns:
+            TorchWork handle if async_op=True, else None
+        """
+        ...

--- a/comms/torchcomms/rcclx/_comms_rcclx.pyi
+++ b/comms/torchcomms/rcclx/_comms_rcclx.pyi
@@ -16,6 +16,7 @@ class TorchCommRCCLX:
         all_active_ranks: list[list[int]],
         per_group_counts: list[int],
         async_op: bool = False,
+        output_tensors: list[torch.Tensor] | None = None,
     ) -> TorchWork | None:
         """
         Fused multi-group sharded relay allreduce for 2D sparse parallelism.
@@ -31,6 +32,11 @@ class TorchCommRCCLX:
             per_group_counts: List of element counts (one per group). This allows
                 different groups to have different tensor sizes.
             async_op: If True, returns a TorchWork handle for async operation
+            output_tensors: Optional list of output segment tensors (one list
+                per group), parallel to `tensors`. When None (default) the
+                allreduce is in-place. When provided, the active group's
+                reduced result is written out-of-place into these tensors
+                while the inputs are preserved.
 
         Returns:
             TorchWork handle if async_op=True, else None

--- a/comms/torchcomms/rcclx/_comms_rcclx.pyi
+++ b/comms/torchcomms/rcclx/_comms_rcclx.pyi
@@ -86,7 +86,9 @@ class TorchCommRCCLX:
         All-to-all analogue of sharded_relay_multi_group_reduce_scatter. No
         reduction (pure data movement) and no reduction op. Each active rank's
         input/output hold nActiveRanks x per_group_segment_counts[g] elements
-        (input = [sendSeg[0]|sendSeg[1]], output = [recvSeg[0]|recvSeg[1]]).
+        (input = [sendSeg[0]|...|sendSeg[A-1]], output =
+        [recvSeg[0]|...|recvSeg[A-1]]). nActiveRanks must be a power of two (2 or
+        4); A>2 uses a flat all-to-all + 2-hop relay.
 
         OUT-OF-PLACE ONLY: input and output tensors for the active group must be
         distinct (matches native ncclAllToAll); aliasing raises.
@@ -94,7 +96,7 @@ class TorchCommRCCLX:
         Args:
             input_tensors: List of send tensors (one per group). Active rank:
                 nActiveRanks x per_group_segment_counts[g] elements. Helper rank:
-                two-slot scratch tensor.
+                nActiveRanks-slot scratch tensor.
             output_tensors: List of receive tensors (one per group). Active rank:
                 nActiveRanks x per_group_segment_counts[g] elements (distinct
                 from input). Helper rank: same scratch as input.


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/torchrec/pull/4573


The sharded-relay collective suites covered the single-group (nGroups=1) path
well for A=2, and the fused multi-group path for both A=2 and A=4, but A=4 with
a single group (nGroups=1) was under-tested: all-gather had it, allreduce only
exercised it for bf16 SUM, and reduce-scatter and all-to-all had no A=4
single-group coverage at all. nGroups=1 removes the cross-group lockstep and
A=4 selects the separate direct+offload kernels, so "A=4, single group" is a
distinct, supported configuration (ranks {0,1,2,3} active, {4,5,6,7} helpers)
that a caller can pass.

Add A=4 single-group correctness tests, modeled on all-gather's existing
Correctness_SingleGroup_A4 test and the sibling 4Active_2Groups tests:

- ReduceScatter: Correctness_4Active_SingleGroup_{InPlace, OutOfPlace, Avg} via
  a new runReduceScatterA4SingleGroup(op, inPlace) helper.
- AllToAll: Correctness_4Active_SingleGroup_{Routed_63MiB,
  DirectBelowLowerBoundary, RoutedUnalignedTail} via a new
  runA4SingleGroupCorrectnessCase(...) helper (the existing runA4CorrectnessCase
  is intrinsically 2-group). Verifies active-rank output at the region
  boundaries and that helpers never write past their scratch contract.
- AllReduce: Correctness_4Active_SingleGroup_{InPlace (SUM), Avg} via a new
  runAllReduceA4SingleGroup(op) helper, complementing the existing bf16 A=4
  single-group boundary test with int32 SUM/AVG.

Also fix a crash in the Python perf benchmark (bench_sharded_relay_perf.py) at
A=4. _benchmark_worker sized the reduce-scatter helper buffer with the A=2
_passthrough_helper_size() formula regardless of active-rank count. For A>2 the
reduce-scatter reduces at the helper and needs 2 x recv_count (as the allreduce
benches and _relay_helper_size already do); the A=2 size under-allocates for
A=4, so the kernel writes past the helper buffer and the run dies with a GPU
"Memory access fault". The bug is independent of message size and dtype (it
reproduced at 64 MiB and 24 GiB, in both fp16 and bf16), which is why the
fixed-size msg-size sweep -- which sizes A=4 helpers correctly -- was
unaffected. Size the reduce-scatter helper to 2 x recv_count for A>2, matching
the other benches.

Reviewed By: JinghanHuang

Differential Revision: D115998374
