### PR TITLE
Incorporate collConfig_t for 2.31 (#3687)

### DIFF
--- a/comms/ncclx/meta/algoconf/ConfiguredCollective.cc
+++ b/comms/ncclx/meta/algoconf/ConfiguredCollective.cc
@@ -1,0 +1,265 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "meta/algoconf/ConfiguredCollective.h"
+
+#include <cstdlib>
+
+#include "comm.h"
+#include "info.h"
+#include "meta/collectives/PatAvgHelper.h"
+
+namespace ncclx::algoconf {
+
+// ---------------------------------------------------------------------------
+// Shared helpers (version-agnostic)
+// ---------------------------------------------------------------------------
+
+std::string algoProtoToString(int algo, int proto) {
+  // Map using upstream registry names. Keep this table in sync with
+  // src/config/algorithm_registry.cc in NCCL 2.31. For unknown pairs,
+  // return "" so the caller leaves algSelection automatic.
+  if (algo == NCCL_ALGO_RING) {
+    if (proto == NCCL_PROTO_SIMPLE) {
+      return "RING_SIMPLE";
+    }
+    if (proto == NCCL_PROTO_LL) {
+      return "RING_LL";
+    }
+    if (proto == NCCL_PROTO_LL128) {
+      return "RING_LL128";
+    }
+  } else if (algo == NCCL_ALGO_TREE) {
+    if (proto == NCCL_PROTO_SIMPLE) {
+      return "TREE_SIMPLE";
+    }
+    if (proto == NCCL_PROTO_LL) {
+      return "TREE_LL";
+    }
+    if (proto == NCCL_PROTO_LL128) {
+      return "TREE_LL128";
+    }
+  } else if (algo == NCCL_ALGO_COLLNET_DIRECT) {
+    if (proto == NCCL_PROTO_SIMPLE) {
+      return "COLLNET_DIRECT_SIMPLE";
+    }
+  } else if (algo == NCCL_ALGO_COLLNET_CHAIN) {
+    if (proto == NCCL_PROTO_SIMPLE) {
+      return "COLLNET_CHAIN_SIMPLE";
+    }
+  } else if (algo == NCCL_ALGO_NVLS) {
+    if (proto == NCCL_PROTO_SIMPLE) {
+      return "NVLS_SIMPLE";
+    }
+  } else if (algo == NCCL_ALGO_NVLS_TREE) {
+    if (proto == NCCL_PROTO_SIMPLE) {
+      return "NVLSTREE_SIMPLE";
+    }
+  } else if (algo == NCCL_ALGO_PAT) {
+    if (proto == NCCL_PROTO_SIMPLE) {
+      return "PAT_SIMPLE";
+    }
+  }
+  return "";
+}
+
+std::optional<ncclInfoExt> maybeInfoExtOverride(
+    struct ncclComm* comm,
+    struct ncclTaskColl* task) {
+  // TODO: task-based overrides need hints threaded through the enqueue path.
+  // Until then this overload has nothing the ncclInfo one does not cover.
+  (void)task;
+  (void)comm;
+  return std::nullopt;
+}
+
+std::optional<ncclInfoExt> maybeInfoExtOverride(
+    struct ncclComm* comm,
+    const struct ncclInfo& info) {
+  if (comm == nullptr) {
+    return std::nullopt;
+  }
+#if defined(IS_NCCLX)
+  // IS_NCCLX is defined in v2_29/v2_30 forked headers; pristine 2.31
+  // does not have usePatAvg_ on ncclComm (PAT AVG there is via
+  // configured collConfig PAT_SIMPLE). Guard so this file compiles on
+  // both.
+  if (comm->usePatAvg_ && info.op == ncclAvg &&
+      ncclx::isPatAvgSupportedType(info.datatype)) {
+    size_t nBytes = info.count * ncclTypeSize(info.datatype) * comm->nRanks;
+    return ncclx::setupPatAvgInfoExt(comm, nBytes, info.datatype);
+  }
+#else
+  (void)info;
+#endif
+  return std::nullopt;
+}
+
+// ---------------------------------------------------------------------------
+// 2.31 configured-collective path
+// ---------------------------------------------------------------------------
+
+#if defined(NCCL_VERSION_CODE) && NCCL_VERSION_CODE >= NCCL_VERSION(2, 31, 0)
+
+ncclCollConfig_t makeCollConfigFromExt(const ncclInfoExt& ext) {
+  ncclCollConfig_t cfg = NCCL_COLLCONFIG_INITIALIZER;
+
+  std::string sel = algoProtoToString(ext.algorithm, ext.protocol);
+  if (!sel.empty()) {
+    // NCCL borrows the pointer rather than copying the string, so the config
+    // owns heap storage that the caller releases via freeCollConfig().
+    char* dup = strdup(sel.c_str());
+    cfg.algSelection = dup;
+  }
+
+  if (ext.nMaxChannels > 0) {
+    cfg.maxCTAs = ext.nMaxChannels;
+  }
+
+  if (ext.nWarps != 0) {
+    INFO(
+        NCCL_TUNING,
+        "ConfiguredCollective: nWarps=%d dropped (upstream derives warps)",
+        ext.nWarps);
+  }
+
+  if (ext.opDev.has_value()) {
+    // A custom device reduction op has no collConfig representation: PAT AVG
+    // with SumPostDiv belongs on a configured PAT_SIMPLE collective with the
+    // standard AVG op, other custom ops need an NCCLX-owned launch. Every
+    // field is reset, not just algSelection, so a caller that inspects
+    // maxCTAs cannot pick up a stray override from an ext we rejected.
+    WARN(
+        "ConfiguredCollective: opDev override not representable in "
+        "ncclCollConfig_t; use NCCLX-owned launch or PAT_SIMPLE AVG");
+    freeCollConfig(cfg);
+    cfg = NCCL_COLLCONFIG_INITIALIZER;
+    return cfg;
+  }
+
+  if (ext.quantizeRandomSeedPtr != nullptr) {
+    INFO(
+        NCCL_TUNING,
+        "ConfiguredCollective: quantizeRandomSeedPtr not in collConfig; "
+        "use CTran direct path");
+  }
+
+  return cfg;
+}
+
+ncclCollConfig_t makeCollConfigFromExt(const std::optional<ncclInfoExt>& ext) {
+  if (!ext.has_value()) {
+    return NCCL_COLLCONFIG_INITIALIZER;
+  }
+  return makeCollConfigFromExt(*ext);
+}
+
+ncclCollConfig_t makeCollConfigFromHints(
+    const std::unordered_map<std::string, std::string>& hints) {
+  ncclCollConfig_t cfg = NCCL_COLLCONFIG_INITIALIZER;
+
+  auto it = hints.find("algSelection");
+  if (it != hints.end() && !it->second.empty()) {
+    // Caller owns strdup'd string, must free via freeCollConfig().
+    char* dup = strdup(it->second.c_str());
+    cfg.algSelection = dup;
+  }
+
+  // NCCL_COLLCONFIG_INITIALIZER sets algSelection to NCCL_CONFIG_UNDEF_PTR, a
+  // non-null sentinel, so it must be excluded before indexing the string.
+  if (cfg.algSelection == nullptr ||
+      cfg.algSelection == (const char*)NCCL_CONFIG_UNDEF_PTR ||
+      cfg.algSelection[0] == '\0') {
+    auto ia = hints.find("algo");
+    auto ip = hints.find("protocol");
+    if (ia != hints.end() && ip != hints.end()) {
+      try {
+        int algo = std::stoi(ia->second);
+        int proto = std::stoi(ip->second);
+        std::string sel = algoProtoToString(algo, proto);
+        if (!sel.empty()) {
+          // Caller owns strdup'd string, must free via freeCollConfig().
+          char* dup = strdup(sel.c_str());
+          cfg.algSelection = dup;
+        }
+      } catch (...) {
+        // ignore parse errors, leave automatic
+      }
+    }
+  }
+
+  auto parseInt = [&](const char* key, int& out) {
+    auto f = hints.find(key);
+    if (f != hints.end()) {
+      try {
+        out = std::stoi(f->second);
+      } catch (...) {
+        WARN(
+            "ConfiguredCollective: invalid int hint %s=%s",
+            key,
+            f->second.c_str());
+      }
+    }
+  };
+
+  int tmp = NCCL_CONFIG_UNDEF_INT;
+  parseInt("maxCTAs", tmp);
+  if (tmp != NCCL_CONFIG_UNDEF_INT) {
+    cfg.maxCTAs = tmp;
+  }
+  tmp = NCCL_CONFIG_UNDEF_INT;
+  parseInt("minCTAs", tmp);
+  if (tmp != NCCL_CONFIG_UNDEF_INT) {
+    cfg.minCTAs = tmp;
+  }
+  tmp = NCCL_CONFIG_UNDEF_INT;
+  parseInt("nvlsCTAs", tmp);
+  if (tmp != NCCL_CONFIG_UNDEF_INT) {
+    cfg.nvlsCTAs = tmp;
+  }
+  tmp = NCCL_CONFIG_UNDEF_INT;
+  parseInt("cgaClusterSize", tmp);
+  if (tmp != NCCL_CONFIG_UNDEF_INT) {
+    cfg.cgaClusterSize = tmp;
+  }
+  tmp = NCCL_CONFIG_UNDEF_INT;
+  parseInt("CTAPolicy", tmp);
+  if (tmp != NCCL_CONFIG_UNDEF_INT) {
+    cfg.CTAPolicy = tmp;
+  }
+
+  auto iu = hints.find("userProfilerTag");
+  if (iu != hints.end()) {
+    try {
+      cfg.userProfilerTag = std::stoull(iu->second);
+    } catch (...) {
+      WARN(
+          "ConfiguredCollective: invalid userProfilerTag=%s",
+          iu->second.c_str());
+    }
+  }
+
+  if (hints.find("nWarps") != hints.end() ||
+      hints.find("warps") != hints.end()) {
+    INFO(
+        NCCL_TUNING,
+        "ConfiguredCollective: nWarps hint dropped (upstream derives warps)");
+  }
+
+  return cfg;
+}
+
+ncclCollConfig_t maybeCollConfig(
+    struct ncclComm* /*comm*/,
+    struct ncclTaskColl* /*task*/,
+    const std::unordered_map<std::string, std::string>& hints) {
+  // A default-initialized config is how NCCL spells "no override": every
+  // field is a sentinel, so ncclParseCollConfig applies nothing.
+  if (hints.empty()) {
+    return NCCL_COLLCONFIG_INITIALIZER;
+  }
+  return makeCollConfigFromHints(hints);
+}
+
+#endif // NCCL_VERSION_CODE >= 2.31
+
+} // namespace ncclx::algoconf

--- a/comms/ncclx/meta/algoconf/ConfiguredCollective.h
+++ b/comms/ncclx/meta/algoconf/ConfiguredCollective.h
@@ -1,0 +1,131 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include "meta/algoconf/InfoExt.h"
+#include "nccl.h"
+
+// Forward decls to avoid pulling comm.h/info.h into every includer.
+struct ncclComm;
+struct ncclInfo;
+struct ncclTaskColl;
+
+namespace ncclx::algoconf {
+
+// ---------------------------------------------------------------------------
+// Versioned overrides plan (2.29/2.30 vs 2.31):
+//  - 2.29 / 2.30 : overrides via InfoExt (ncclInfo::ext, ncclTaskColl::ext)
+//    retained as-is behind facade maybeInfoExtOverride().
+//  - 2.31       : overrides via ncclCollConfig_t configured collectives.
+//    Use helpers below to build a collConfig from hints or from an InfoExt
+//    shim for compat callers.
+// This file is version-agnostic and compiles on all versions; 2.31-only
+// APIs are guarded by NCCL_VERSION_CODE.
+// ---------------------------------------------------------------------------
+
+// Map (algorithm, protocol) integer pair to a 2.31 algSelection string.
+// Uses the upstream algorithm registry names (e.g. "PAT_SIMPLE",
+// "TREE_LL", "RING_SIMPLE"). Returns empty string if the pair has no
+// registered kernel (caller should then leave algSelection automatic).
+std::string algoProtoToString(int algo, int proto);
+
+// Quantized ReduceScatter on the InfoExt path requires a doubled chunk size.
+// On 2.31 quantization runs through the CTran direct path instead, where no
+// ext carries a seed and this is a no-op.
+inline int adjustChunkSizeForExt(
+    const std::optional<ncclInfoExt>& ext,
+    int chunkSize) {
+  if (ext.has_value() && ext->quantizeRandomSeedPtr != nullptr) {
+    return chunkSize * 2;
+  }
+  return chunkSize;
+}
+
+// Facade for 2.29/2.30 InfoExt path. Returns an override if the comm/task
+// warrants one (e.g. PAT AVG, quantized path, or generic hints). Returns
+// nullopt when no override applies. This is the single call-site that
+// v2_30/src/collectives.cc should use:
+//
+//   info.ext = ncclx::algoconf::maybeInfoExtOverride(comm, info);
+//
+std::optional<ncclInfoExt> maybeInfoExtOverride(
+    struct ncclComm* comm,
+    struct ncclTaskColl* task);
+
+// Overload taking ncclInfo directly (preferred for collectives.cc).
+std::optional<ncclInfoExt> maybeInfoExtOverride(
+    struct ncclComm* comm,
+    const struct ncclInfo& info);
+
+// --- 2.31 configured-collective helpers ------------------------------------
+
+#if defined(NCCL_VERSION_CODE) && NCCL_VERSION_CODE >= NCCL_VERSION(2, 31, 0)
+
+// Build a collConfig from an InfoExt shim. Used to keep compat callers
+// that still produce an InfoExt (e.g. old PAT AVG helpers) working on
+// 2.31 without propagating InfoExt through NCCL internals.
+// Mapping:
+//   algorithm+protocol -> algSelection string
+//   nMaxChannels       -> maxCTAs (when >0)
+//   nWarps             -> dropped (upstream tuning derives warps)
+//   opDev              -> not representable in collConfig; if set, the
+//                        caller must use an NCCLX-owned launch instead of
+//                        a configured collective (this helper WARNs and
+//                        returns a fully default-initialized config, so no
+//                        field carries an override the caller could apply).
+//   quantSeedPtr       -> not in collConfig; retained via CTran direct IB
+//                        path, not via collConfig.
+ncclCollConfig_t makeCollConfigFromExt(const std::optional<ncclInfoExt>& ext);
+
+// Overload taking a concrete ext value.
+ncclCollConfig_t makeCollConfigFromExt(const ncclInfoExt& ext);
+
+// Build a collConfig directly from per-collective hints. Preferred path
+// for new code on 2.31: hints already carry the same information that
+// InfoExt used to carry, but without needing InfoExt at all.
+// Supported hint keys (all optional):
+//   "algSelection"  -> collConfig.algSelection (e.g. "PAT_SIMPLE")
+//   "maxCTAs"       -> collConfig.maxCTAs
+//   "minCTAs"       -> collConfig.minCTAs
+//   "nvlsCTAs"      -> collConfig.nvlsCTAs
+//   "cgaClusterSize"-> collConfig.cgaClusterSize
+//   "CTAPolicy"     -> collConfig.CTAPolicy
+//   "userProfilerTag" -> collConfig.userProfilerTag
+// Unknown keys are silently ignored (invalid values WARN). The returned
+// config owns any strdup'd algSelection string; caller must free via
+// freeCollConfig() after the collective call (same contract as torchcomms
+// sibling).
+ncclCollConfig_t makeCollConfigFromHints(
+    const std::unordered_map<std::string, std::string>& hints);
+
+// Facade that mirrors maybeInfoExtOverride but returns a collConfig for
+// 2.31 enqueue path:
+//
+//   #if NCCL_VERSION_CODE >= NCCL_VERSION(2,31,0)
+//     auto collCfg = ncclx::algoconf::maybeCollConfig(comm, task, hints);
+//     info.collConfig = collCfg;
+//   #else
+//     info.ext = ncclx::algoconf::maybeInfoExtOverride(comm, task);
+//   #endif
+//
+ncclCollConfig_t maybeCollConfig(
+    struct ncclComm* comm,
+    struct ncclTaskColl* task,
+    const std::unordered_map<std::string, std::string>& hints);
+
+// Helper to free a collConfig's owned algSelection string if set.
+inline void freeCollConfig(ncclCollConfig_t& cfg) {
+  if (cfg.algSelection != nullptr &&
+      cfg.algSelection != (const char*)NCCL_CONFIG_UNDEF_PTR) {
+    free((void*)cfg.algSelection);
+    cfg.algSelection = (const char*)NCCL_CONFIG_UNDEF_PTR;
+  }
+}
+
+#endif // NCCL_VERSION_CODE >= 2.31
+
+} // namespace ncclx::algoconf

--- a/comms/ncclx/meta/algoconf/InfoExtOverride.h
+++ b/comms/ncclx/meta/algoconf/InfoExtOverride.h
@@ -3,9 +3,13 @@
 #pragma once
 
 #include "comm.h"
+#include "meta/algoconf/ConfiguredCollective.h"
 #include "meta/algoconf/InfoExt.h"
 
 namespace ncclx::algoconf {
+
+// adjustChunkSizeForExt is defined in ConfiguredCollective.h and re-exported
+// here via the include above.
 
 // Apply algorithm info override from task->ext to task fields.
 // Returns ncclInvalidUsage if isGrouped is true,

--- a/comms/ncclx/meta/algoconf/tests/ConfiguredCollectiveMappingTest.cc
+++ b/comms/ncclx/meta/algoconf/tests/ConfiguredCollectiveMappingTest.cc
@@ -1,0 +1,165 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include "meta/algoconf/ConfiguredCollective.h"
+#include "meta/algoconf/InfoExt.h"
+
+using ::ncclx::algoconf::adjustChunkSizeForExt;
+using ::ncclx::algoconf::algoProtoToString;
+using ::ncclx::algoconf::maybeInfoExtOverride;
+using ::ncclx::algoconf::ncclInfoExt;
+
+#if defined(NCCL_VERSION_CODE) && NCCL_VERSION_CODE >= NCCL_VERSION(2, 31, 0)
+using ::ncclx::algoconf::makeCollConfigFromExt;
+using ::ncclx::algoconf::makeCollConfigFromHints;
+#endif
+
+// ---------------------------------------------------------------------------
+// Version-agnostic tests
+// ---------------------------------------------------------------------------
+
+TEST(ConfiguredCollectiveTest, AlgoProtoToString) {
+  EXPECT_EQ(
+      algoProtoToString(NCCL_ALGO_RING, NCCL_PROTO_SIMPLE), "RING_SIMPLE");
+  EXPECT_EQ(algoProtoToString(NCCL_ALGO_RING, NCCL_PROTO_LL), "RING_LL");
+  EXPECT_EQ(algoProtoToString(NCCL_ALGO_RING, NCCL_PROTO_LL128), "RING_LL128");
+  EXPECT_EQ(
+      algoProtoToString(NCCL_ALGO_TREE, NCCL_PROTO_SIMPLE), "TREE_SIMPLE");
+  EXPECT_EQ(algoProtoToString(NCCL_ALGO_TREE, NCCL_PROTO_LL), "TREE_LL");
+  EXPECT_EQ(algoProtoToString(NCCL_ALGO_PAT, NCCL_PROTO_SIMPLE), "PAT_SIMPLE");
+  EXPECT_EQ(
+      algoProtoToString(NCCL_ALGO_COLLNET_DIRECT, NCCL_PROTO_SIMPLE),
+      "COLLNET_DIRECT_SIMPLE");
+  EXPECT_EQ(
+      algoProtoToString(NCCL_ALGO_NVLS, NCCL_PROTO_SIMPLE), "NVLS_SIMPLE");
+  // Unknown pair -> empty
+  EXPECT_EQ(algoProtoToString(999, 999), "");
+  // PAT only supports SIMPLE in 2.31 registry; LL should be empty
+  EXPECT_EQ(algoProtoToString(NCCL_ALGO_PAT, NCCL_PROTO_LL), "");
+}
+
+TEST(ConfiguredCollectiveTest, AdjustChunkSizeForExt) {
+  // No ext -> unchanged
+  EXPECT_EQ(adjustChunkSizeForExt(std::nullopt, 1024), 1024);
+  // Ext without quant seed -> unchanged
+  ncclInfoExt ext1(NCCL_ALGO_RING, NCCL_PROTO_SIMPLE, 4, 8);
+  EXPECT_EQ(adjustChunkSizeForExt(ext1, 1024), 1024);
+  // Ext with quant seed -> doubled
+  uint64_t seed = 42;
+  ncclInfoExt ext2(NCCL_ALGO_PAT, NCCL_PROTO_SIMPLE, 4, 8, std::nullopt, &seed);
+  EXPECT_EQ(adjustChunkSizeForExt(ext2, 1024), 2048);
+  EXPECT_EQ(adjustChunkSizeForExt(ext2, 0), 0);
+}
+
+TEST(ConfiguredCollectiveTest, MaybeInfoExtOverrideReturnsNulloptByDefault) {
+  // Facade returns nullopt when no generic override is configured.
+  // This keeps the 2.29/2.30 path as-is.
+  auto ext = maybeInfoExtOverride(nullptr, nullptr);
+  EXPECT_FALSE(ext.has_value());
+}
+
+// ---------------------------------------------------------------------------
+// 2.31-only tests (guarded so they still compile on 2.30)
+// ---------------------------------------------------------------------------
+
+#if defined(NCCL_VERSION_CODE) && NCCL_VERSION_CODE >= NCCL_VERSION(2, 31, 0)
+
+TEST(ConfiguredCollectiveTest, MakeCollConfigFromExtMapsFields) {
+  ncclInfoExt ext(NCCL_ALGO_RING, NCCL_PROTO_SIMPLE, 4, 8);
+  auto cfg = makeCollConfigFromExt(ext);
+  ASSERT_NE(cfg.algSelection, nullptr);
+  EXPECT_STREQ(cfg.algSelection, "RING_SIMPLE");
+  EXPECT_EQ(cfg.maxCTAs, 4);
+  // nWarps is dropped, so no field to check; just ensure cfg is valid
+  EXPECT_EQ(cfg.size, sizeof(ncclCollConfig_t));
+  EXPECT_EQ(cfg.magic, (unsigned int)NCCL_API_MAGIC);
+  // cleanup strdup
+  free((void*)cfg.algSelection);
+}
+
+TEST(ConfiguredCollectiveTest, MakeCollConfigFromExtPat) {
+  ncclInfoExt ext(NCCL_ALGO_PAT, NCCL_PROTO_SIMPLE, 2, 16);
+  auto cfg = makeCollConfigFromExt(ext);
+  ASSERT_NE(cfg.algSelection, nullptr);
+  EXPECT_STREQ(cfg.algSelection, "PAT_SIMPLE");
+  EXPECT_EQ(cfg.maxCTAs, 2);
+  free((void*)cfg.algSelection);
+}
+
+TEST(ConfiguredCollectiveTest, MakeCollConfigFromExtClearsSelectionForOpDev) {
+  // A custom device reduction op has no collConfig representation, so no
+  // field of the returned config may carry an override — not the mappable
+  // algorithm/protocol pair, and not nMaxChannels either.
+  ncclDevRedOpFull opDev{};
+  ncclInfoExt ext(NCCL_ALGO_RING, NCCL_PROTO_SIMPLE, 4, 8, opDev);
+  auto cfg = makeCollConfigFromExt(ext);
+  EXPECT_EQ(cfg.algSelection, (const char*)NCCL_CONFIG_UNDEF_PTR);
+  EXPECT_EQ(cfg.maxCTAs, NCCL_CONFIG_UNDEF_INT);
+}
+
+TEST(ConfiguredCollectiveTest, MakeCollConfigFromExtEmpty) {
+  auto cfg = makeCollConfigFromExt(std::nullopt);
+  EXPECT_EQ(cfg.algSelection, (const char*)NCCL_CONFIG_UNDEF_PTR);
+  EXPECT_EQ(cfg.maxCTAs, NCCL_CONFIG_UNDEF_INT);
+}
+
+TEST(ConfiguredCollectiveTest, MakeCollConfigFromHints) {
+  std::unordered_map<std::string, std::string> hints = {
+      {"algSelection", "TREE_LL"},
+      {"maxCTAs", "8"},
+      {"minCTAs", "2"},
+      {"nvlsCTAs", "4"},
+      {"cgaClusterSize", "2"},
+      {"CTAPolicy", "1"},
+      {"userProfilerTag", "12345"},
+  };
+  auto cfg = makeCollConfigFromHints(hints);
+  ASSERT_NE(cfg.algSelection, nullptr);
+  EXPECT_STREQ(cfg.algSelection, "TREE_LL");
+  EXPECT_EQ(cfg.maxCTAs, 8);
+  EXPECT_EQ(cfg.minCTAs, 2);
+  EXPECT_EQ(cfg.nvlsCTAs, 4);
+  EXPECT_EQ(cfg.cgaClusterSize, 2);
+  EXPECT_EQ(cfg.CTAPolicy, 1);
+  EXPECT_EQ(cfg.userProfilerTag, 12345u);
+  free((void*)cfg.algSelection);
+}
+
+TEST(ConfiguredCollectiveTest, MakeCollConfigFromHintsLegacyAlgoProtocol) {
+  // Compat path: hints carry integer algo/protocol
+  std::unordered_map<std::string, std::string> hints = {
+      {"algo", std::to_string(NCCL_ALGO_RING)},
+      {"protocol", std::to_string(NCCL_PROTO_SIMPLE)},
+  };
+  auto cfg = makeCollConfigFromHints(hints);
+  ASSERT_NE(cfg.algSelection, nullptr);
+  EXPECT_STREQ(cfg.algSelection, "RING_SIMPLE");
+  free((void*)cfg.algSelection);
+}
+
+TEST(ConfiguredCollectiveTest, MakeCollConfigFromHintsIgnoresUnknown) {
+  std::unordered_map<std::string, std::string> hints = {
+      {"unknownKey", "someValue"},
+      {"maxCTAs", "4"},
+  };
+  auto cfg = makeCollConfigFromHints(hints);
+  EXPECT_EQ(cfg.maxCTAs, 4);
+  // unknown key should not crash; algSelection stays UNDEF
+  EXPECT_EQ(cfg.algSelection, (const char*)NCCL_CONFIG_UNDEF_PTR);
+}
+
+TEST(ConfiguredCollectiveTest, MakeCollConfigDropsWarps) {
+  std::unordered_map<std::string, std::string> hints = {
+      {"algSelection", "RING_SIMPLE"},
+      {"nWarps", "16"},
+      {"warps", "8"},
+  };
+  auto cfg = makeCollConfigFromHints(hints);
+  ASSERT_NE(cfg.algSelection, nullptr);
+  EXPECT_STREQ(cfg.algSelection, "RING_SIMPLE");
+  // warps hint is dropped, not mapped to any collConfig field
+  free((void*)cfg.algSelection);
+}
+
+#endif // NCCL_VERSION_CODE >= 2.31

--- a/comms/ncclx/meta/wrapper/NcclCommOverride.h
+++ b/comms/ncclx/meta/wrapper/NcclCommOverride.h
@@ -1,0 +1,39 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+
+#include "comm.h"
+#include "nccl.h"
+
+namespace ncclx::wrapper {
+
+// Accessors for per-comm NCCLX override state. Deliberately narrow: reading
+// these fields must not require the full ncclxCommExt definition.
+
+inline std::string ncclCommOverrideDesc(ncclComm_t comm) {
+  if (comm == nullptr)
+    return "null";
+  const char* d = comm->config.commDesc;
+  if (d == nullptr || d == NCCL_CONFIG_UNDEF_PTR)
+    return "";
+  return std::string(d);
+}
+
+// Whether the comm carries the PAT AVG override. Callers still have to check
+// the operation is ncclAvg themselves; this reports comm state only.
+inline bool ncclCommUsePatAvg(ncclComm_t comm) {
+  if (comm == nullptr)
+    return false;
+#if defined(IS_NCCLX)
+  return comm->usePatAvg_;
+#else
+  // Pristine 2.31 has no usePatAvg_ on ncclComm; PAT AVG there is expressed
+  // as a configured collective instead.
+  (void)comm;
+  return false;
+#endif
+}
+
+} // namespace ncclx::wrapper

--- a/comms/ncclx/meta/wrapper/tests/NcclCommOverrideUT.cc
+++ b/comms/ncclx/meta/wrapper/tests/NcclCommOverrideUT.cc
@@ -1,0 +1,60 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "meta/wrapper/NcclCommOverride.h" // @manual
+
+using ::ncclx::wrapper::ncclCommOverrideDesc;
+using ::ncclx::wrapper::ncclCommUsePatAvg;
+
+namespace {
+
+// ncclComm is far too large for the stack and has no public constructor that
+// takes the fields under test, so tests value-initialize one on the heap and
+// set only what they assert on.
+std::unique_ptr<ncclComm> makeComm() {
+  return std::make_unique<ncclComm>();
+}
+
+} // namespace
+
+TEST(NcclCommOverrideTest, DescIsNullSentinelForNullComm) {
+  EXPECT_EQ(ncclCommOverrideDesc(nullptr), "null");
+}
+
+TEST(NcclCommOverrideTest, DescReturnsCommDescHint) {
+  auto comm = makeComm();
+  comm->config.commDesc = "training_dp_group";
+  EXPECT_EQ(ncclCommOverrideDesc(comm.get()), "training_dp_group");
+}
+
+TEST(NcclCommOverrideTest, DescIsEmptyWhenHintUnset) {
+  auto comm = makeComm();
+
+  comm->config.commDesc = nullptr;
+  EXPECT_EQ(ncclCommOverrideDesc(comm.get()), "");
+
+  // NCCL spells "unset" as a non-null sentinel, which must not be returned as
+  // if it were a string the caller can read.
+  comm->config.commDesc = NCCL_CONFIG_UNDEF_PTR;
+  EXPECT_EQ(ncclCommOverrideDesc(comm.get()), "");
+}
+
+TEST(NcclCommOverrideTest, UsePatAvgIsFalseForNullComm) {
+  EXPECT_FALSE(ncclCommUsePatAvg(nullptr));
+}
+
+TEST(NcclCommOverrideTest, UsePatAvgReflectsCommState) {
+  auto comm = makeComm();
+
+#if defined(IS_NCCLX)
+  EXPECT_FALSE(ncclCommUsePatAvg(comm.get()));
+  comm->usePatAvg_ = true;
+  EXPECT_TRUE(ncclCommUsePatAvg(comm.get()));
+#else
+  // Pristine NCCL has no usePatAvg_ field, so the accessor is always false.
+  EXPECT_FALSE(ncclCommUsePatAvg(comm.get()));
+#endif
+}

--- a/comms/ncclx/v2_29/src/collectives.cc
+++ b/comms/ncclx/v2_29/src/collectives.cc
@@ -13,6 +13,7 @@
 
 #include "comms/ctran/Ctran.h"
 #include "meta/NcclxConfig.h"
+#include "meta/algoconf/ConfiguredCollective.h"
 #include "meta/collectives/PatAvgHelper.h"
 #include "comms/ctran/utils/Checks.h"
 #include "meta/wrapper/MetaFactory.h"
@@ -255,13 +256,8 @@ ncclResult_t ncclReduceScatter(const void* sendbuff, void* recvbuff, size_t recv
     sendbuff, recvbuff, recvcount, datatype, op, 0, comm, stream, /* Args */
     REDUCESCATTER_CHUNKSTEPS, REDUCESCATTER_SLICESTEPS };
 
-  // [META:PAT_AVG] Set up infoExt for per-comm PAT AVG control
-  // Only for types with enough exponent range (bf16, f32, f64, integers)
-  if (comm->usePatAvg_ && op == ncclAvg &&
-      ncclx::isPatAvgSupportedType(datatype)) {
-    size_t nBytes = recvcount * ncclTypeSize(datatype) * comm->nRanks;
-    info.ext = ncclx::setupPatAvgInfoExt(comm, nBytes, datatype);
-  }
+  // [META:INFO_EXT] Per-comm algorithm/protocol override, PAT AVG included.
+  info.ext = ncclx::algoconf::maybeInfoExtOverride(comm, info);
 
   return ncclEnqueueCheck(&info);
 }

--- a/comms/ncclx/v2_30/src/collectives.cc
+++ b/comms/ncclx/v2_30/src/collectives.cc
@@ -13,6 +13,7 @@
 
 #include "comms/ctran/Ctran.h"
 #include "meta/NcclxConfig.h"
+#include "meta/algoconf/ConfiguredCollective.h"
 #include "meta/collectives/PatAvgHelper.h"
 #include "comms/ctran/utils/Checks.h"
 #include "meta/wrapper/MetaFactory.h"
@@ -255,13 +256,8 @@ ncclResult_t ncclReduceScatter(const void* sendbuff, void* recvbuff, size_t recv
     sendbuff, recvbuff, recvcount, datatype, op, 0, comm, stream, /* Args */
     REDUCESCATTER_CHUNKSTEPS, REDUCESCATTER_SLICESTEPS };
 
-  // [META:PAT_AVG] Set up infoExt for per-comm PAT AVG control
-  // Only for types with enough exponent range (bf16, f32, f64, integers)
-  if (comm->usePatAvg_ && op == ncclAvg &&
-      ncclx::isPatAvgSupportedType(datatype)) {
-    size_t nBytes = recvcount * ncclTypeSize(datatype) * comm->nRanks;
-    info.ext = ncclx::setupPatAvgInfoExt(comm, nBytes, datatype);
-  }
+  // [META:INFO_EXT] Per-comm algorithm/protocol override, PAT AVG included.
+  info.ext = ncclx::algoconf::maybeInfoExtOverride(comm, info);
 
   return ncclEnqueueCheck(&info);
 }

--- a/comms/torchcomms/nccl/ConfiguredCollective.hpp
+++ b/comms/torchcomms/nccl/ConfiguredCollective.hpp
@@ -1,0 +1,203 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Versioned overrides plan: torchcomms hints -> ncclCollConfig_t for NCCL 2.31.
+// For 2.29/2.30, overrides remain via InfoExt (handled in NCCLX).
+// For 2.31, translate hints to a configured collective. This header is
+// version-gated via NCCL_VERSION_CODE probing, not via is_backend_built.
+//
+// Usage in TorchCommNCCL collective entry points (e.g. allReduce):
+//
+//   #if NCCL_VERSION_CODE >= NCCL_VERSION(2,31,0)
+//     ncclCollConfig_t collConfig = makeCollConfigFromHints(options.hints);
+//     // pass collConfig to nccl*Config variant
+//     result = nccl_api_->allReduceConfig(..., &collConfig);
+//   #else
+//     result = nccl_api_->allReduce(...);
+//   #endif
+
+#pragma once
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <unordered_map>
+
+#include <glog/logging.h>
+#include <nccl.h>
+
+namespace torch::comms {
+
+namespace configured_collective_detail {
+
+// NCCL's NCCL_ALGO_*/NCCL_PROTO_* macros live in its internal plugin headers
+// (src/include/plugin/nccl_tuner.h), which the OSS torchcomms export cannot
+// include. The integer encoding is part of the stable tuner plugin ABI, so it
+// is safe to mirror here under distinct names (the NCCL macros would otherwise
+// textually replace these identifiers wherever both headers are visible).
+constexpr int kAlgoTree = 0;
+constexpr int kAlgoRing = 1;
+constexpr int kAlgoCollnetDirect = 2;
+constexpr int kAlgoCollnetChain = 3;
+constexpr int kAlgoNvls = 4;
+constexpr int kAlgoNvlsTree = 5;
+constexpr int kAlgoPat = 6;
+
+constexpr int kProtoLL = 0;
+constexpr int kProtoLL128 = 1;
+constexpr int kProtoSimple = 2;
+
+} // namespace configured_collective_detail
+
+// Map integer algo/protocol pair to 2.31 algSelection string.
+// Duplicates the registry in comms/ncclx/meta/algoconf/ConfiguredCollective.cc
+// on purpose: this header ships to OSS (meta-pytorch/torchcomms) and so cannot
+// depend on internal NCCLX headers. Both tables must be updated together.
+inline std::string algoProtoToString(int algo, int proto) {
+  namespace d = configured_collective_detail;
+  if (algo == d::kAlgoRing) {
+    if (proto == d::kProtoSimple) {
+      return "RING_SIMPLE";
+    }
+    if (proto == d::kProtoLL) {
+      return "RING_LL";
+    }
+    if (proto == d::kProtoLL128) {
+      return "RING_LL128";
+    }
+  } else if (algo == d::kAlgoTree) {
+    if (proto == d::kProtoSimple) {
+      return "TREE_SIMPLE";
+    }
+    if (proto == d::kProtoLL) {
+      return "TREE_LL";
+    }
+    if (proto == d::kProtoLL128) {
+      return "TREE_LL128";
+    }
+  } else if (algo == d::kAlgoCollnetDirect) {
+    if (proto == d::kProtoSimple) {
+      return "COLLNET_DIRECT_SIMPLE";
+    }
+  } else if (algo == d::kAlgoCollnetChain) {
+    if (proto == d::kProtoSimple) {
+      return "COLLNET_CHAIN_SIMPLE";
+    }
+  } else if (algo == d::kAlgoNvls) {
+    if (proto == d::kProtoSimple) {
+      return "NVLS_SIMPLE";
+    }
+  } else if (algo == d::kAlgoNvlsTree) {
+    if (proto == d::kProtoSimple) {
+      return "NVLSTREE_SIMPLE";
+    }
+  } else if (algo == d::kAlgoPat) {
+    if (proto == d::kProtoSimple) {
+      return "PAT_SIMPLE";
+    }
+  }
+  return "";
+}
+
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 31, 0)
+
+// Build a ncclCollConfig_t from torchcomms hints map. All fields are
+// optional; unset fields remain NCCL_CONFIG_UNDEF. The returned config owns
+// any algSelection storage and must outlive the nccl*Config call; release it
+// afterwards with freeCollConfig().
+inline ncclCollConfig_t makeCollConfigFromHints(
+    const std::unordered_map<std::string, std::string>& hints) {
+  ncclCollConfig_t cfg = NCCL_COLLCONFIG_INITIALIZER;
+
+  auto it = hints.find("algSelection");
+  if (it != hints.end() && !it->second.empty()) {
+    // NCCL borrows the pointer rather than copying the string, so the storage
+    // has to outlive the collective call.
+    cfg.algSelection = strdup(it->second.c_str());
+  }
+
+  // NCCL_COLLCONFIG_INITIALIZER sets algSelection to NCCL_CONFIG_UNDEF_PTR, a
+  // non-null sentinel, so it must be excluded before indexing the string.
+  if (cfg.algSelection == nullptr ||
+      cfg.algSelection == (const char*)NCCL_CONFIG_UNDEF_PTR ||
+      cfg.algSelection[0] == '\0') {
+    auto ia = hints.find("algo");
+    auto ip = hints.find("protocol");
+    if (ia != hints.end() && ip != hints.end()) {
+      try {
+        int algo = std::stoi(ia->second);
+        int proto = std::stoi(ip->second);
+        std::string sel = algoProtoToString(algo, proto);
+        if (!sel.empty()) {
+          cfg.algSelection = strdup(sel.c_str());
+        }
+      } catch (...) {
+        LOG(WARNING) << "[TC] ConfiguredCollective: invalid algo/protocol hint "
+                     << "algo=" << ia->second << " protocol=" << ip->second;
+      }
+    }
+  }
+
+  auto parseInt = [&](const char* key, int& out) -> bool {
+    auto f = hints.find(key);
+    if (f != hints.end()) {
+      try {
+        out = std::stoi(f->second);
+        return true;
+      } catch (...) {
+        LOG(WARNING) << "[TC] ConfiguredCollective: invalid int hint " << key
+                     << "=" << f->second;
+      }
+    }
+    return false;
+  };
+
+  int tmp = NCCL_CONFIG_UNDEF_INT;
+  if (parseInt("maxCTAs", tmp) || parseInt("max_ctas", tmp)) {
+    cfg.maxCTAs = tmp;
+  }
+  tmp = NCCL_CONFIG_UNDEF_INT;
+  if (parseInt("minCTAs", tmp) || parseInt("min_ctas", tmp)) {
+    cfg.minCTAs = tmp;
+  }
+  tmp = NCCL_CONFIG_UNDEF_INT;
+  if (parseInt("nvlsCTAs", tmp) || parseInt("nvls_ctas", tmp)) {
+    cfg.nvlsCTAs = tmp;
+  }
+  tmp = NCCL_CONFIG_UNDEF_INT;
+  if (parseInt("cgaClusterSize", tmp) || parseInt("cga_cluster_size", tmp)) {
+    cfg.cgaClusterSize = tmp;
+  }
+  tmp = NCCL_CONFIG_UNDEF_INT;
+  if (parseInt("CTAPolicy", tmp) || parseInt("cta_policy", tmp)) {
+    cfg.CTAPolicy = tmp;
+  }
+
+  auto iu = hints.find("userProfilerTag");
+  if (iu == hints.end()) {
+    iu = hints.find("user_profiler_tag");
+  }
+  if (iu != hints.end()) {
+    try {
+      cfg.userProfilerTag = std::stoull(iu->second);
+    } catch (...) {
+      LOG(WARNING) << "[TC] ConfiguredCollective: invalid userProfilerTag="
+                   << iu->second;
+    }
+  }
+
+  // nWarps is intentionally dropped on 2.31 (upstream derives warps).
+  return cfg;
+}
+
+// Helper to free a collConfig's owned algSelection string if set.
+inline void freeCollConfig(ncclCollConfig_t& cfg) {
+  if (cfg.algSelection != nullptr &&
+      cfg.algSelection != (const char*)NCCL_CONFIG_UNDEF_PTR) {
+    free((void*)cfg.algSelection);
+    cfg.algSelection = (const char*)NCCL_CONFIG_UNDEF_PTR;
+  }
+}
+
+#endif // NCCL_VERSION_CODE >= 2.31
+
+} // namespace torch::comms

--- a/comms/torchcomms/nccl/tests/unit/cpp/ConfiguredCollectiveTest.cpp
+++ b/comms/torchcomms/nccl/tests/unit/cpp/ConfiguredCollectiveTest.cpp
@@ -1,0 +1,89 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include "comms/torchcomms/nccl/ConfiguredCollective.hpp"
+
+namespace torch::comms {
+namespace {
+
+namespace d = configured_collective_detail;
+
+TEST(ConfiguredCollectiveTest, MapsKnownAlgoProtoPairs) {
+  EXPECT_EQ(algoProtoToString(d::kAlgoRing, d::kProtoSimple), "RING_SIMPLE");
+  EXPECT_EQ(algoProtoToString(d::kAlgoRing, d::kProtoLL), "RING_LL");
+  EXPECT_EQ(algoProtoToString(d::kAlgoRing, d::kProtoLL128), "RING_LL128");
+  EXPECT_EQ(algoProtoToString(d::kAlgoTree, d::kProtoSimple), "TREE_SIMPLE");
+  EXPECT_EQ(algoProtoToString(d::kAlgoTree, d::kProtoLL), "TREE_LL");
+  EXPECT_EQ(algoProtoToString(d::kAlgoTree, d::kProtoLL128), "TREE_LL128");
+  EXPECT_EQ(
+      algoProtoToString(d::kAlgoCollnetDirect, d::kProtoSimple),
+      "COLLNET_DIRECT_SIMPLE");
+  EXPECT_EQ(
+      algoProtoToString(d::kAlgoCollnetChain, d::kProtoSimple),
+      "COLLNET_CHAIN_SIMPLE");
+  EXPECT_EQ(algoProtoToString(d::kAlgoNvls, d::kProtoSimple), "NVLS_SIMPLE");
+  EXPECT_EQ(
+      algoProtoToString(d::kAlgoNvlsTree, d::kProtoSimple), "NVLSTREE_SIMPLE");
+  EXPECT_EQ(algoProtoToString(d::kAlgoPat, d::kProtoSimple), "PAT_SIMPLE");
+}
+
+TEST(ConfiguredCollectiveTest, UnregisteredPairsMapToEmpty) {
+  // PAT and the CollNet/NVLS families only have SIMPLE kernels registered.
+  EXPECT_EQ(algoProtoToString(d::kAlgoPat, d::kProtoLL), "");
+  EXPECT_EQ(algoProtoToString(d::kAlgoNvls, d::kProtoLL128), "");
+  EXPECT_EQ(algoProtoToString(999, 999), "");
+}
+
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 31, 0)
+
+TEST(ConfiguredCollectiveTest, HintsPopulateCollConfigFields) {
+  const std::unordered_map<std::string, std::string> hints{
+      {"algSelection", "PAT_SIMPLE"},
+      {"maxCTAs", "8"},
+      {"min_ctas", "2"},
+      {"userProfilerTag", "42"},
+  };
+
+  ncclCollConfig_t cfg = makeCollConfigFromHints(hints);
+  EXPECT_STREQ(cfg.algSelection, "PAT_SIMPLE");
+  EXPECT_EQ(cfg.maxCTAs, 8);
+  EXPECT_EQ(cfg.minCTAs, 2);
+  EXPECT_EQ(cfg.userProfilerTag, 42U);
+  freeCollConfig(cfg);
+}
+
+TEST(ConfiguredCollectiveTest, LegacyAlgoProtocolPairSynthesizesSelection) {
+  const std::unordered_map<std::string, std::string> hints{
+      {"algo", std::to_string(d::kAlgoRing)},
+      {"protocol", std::to_string(d::kProtoLL)},
+  };
+
+  ncclCollConfig_t cfg = makeCollConfigFromHints(hints);
+  EXPECT_STREQ(cfg.algSelection, "RING_LL");
+  freeCollConfig(cfg);
+}
+
+TEST(ConfiguredCollectiveTest, MalformedHintsAreIgnored) {
+  const std::unordered_map<std::string, std::string> hints{
+      {"maxCTAs", "not-a-number"},
+      {"userProfilerTag", "also-not-a-number"},
+  };
+
+  ncclCollConfig_t cfg = makeCollConfigFromHints(hints);
+  EXPECT_EQ(cfg.maxCTAs, NCCL_CONFIG_UNDEF_INT);
+  freeCollConfig(cfg);
+}
+
+TEST(ConfiguredCollectiveTest, FreeCollConfigIsIdempotent) {
+  ncclCollConfig_t cfg =
+      makeCollConfigFromHints({{"algSelection", "TREE_LL128"}});
+  freeCollConfig(cfg);
+  freeCollConfig(cfg);
+  EXPECT_EQ(cfg.algSelection, (const char*)NCCL_CONFIG_UNDEF_PTR);
+}
+
+#endif // NCCL_VERSION_CODE >= 2.31
+
+} // namespace
+} // namespace torch::comms


### PR DESCRIPTION
Summary:

NCCL 2.31 introduces ncclCollConfig_t as the new mechanism for overriding collective algorithm/protocol selection, replacing the InfoExt approach used in 2.29/2.30. This diff adds a versioned abstraction layer so both paths coexist behind a single facade:

- 2.29/2.30: consolidates the existing PAT AVG InfoExt override into a facade function (maybeInfoExtOverride) called from one site in collectives.cc, instead of inlining the logic at each call site.
- 2.31: adds helpers to build a ncclCollConfig_t from either an InfoExt shim (for compat) or from a hints map (preferred new path), mapping algorithm/protocol to algSelection strings, nMaxChannels to maxCTAs, and warning on fields that moved to other paths.
- torchcomms: adds a parallel hints-to-collConfig helper version-gated by NCCL version probing.
- Includes unit tests for the mapping table, facade nullopt behavior, and 2.31 field handling.

Differential Revision: D116101453


