### PR TITLE
Build and ship the uniflow._core extension in OSS builds

### DIFF
--- a/.github/scripts/xpu_test.sh
+++ b/.github/scripts/xpu_test.sh
@@ -19,6 +19,7 @@ export USE_NCCL=OFF
 export USE_NCCLX=OFF
 export USE_GLOO=ON
 export USE_TRANSPORT=OFF
+export USE_UNIFLOW=OFF
 export USE_SYSTEM_LIBS=1
 ulimit -n 65535 # Increase the open file descriptor limit to avoid oneCCL/Level Zero
 # initialization failures ("pidfd_getfd failed: Too many open files")
@@ -27,7 +28,7 @@ python3 -m pip install --pre torch --index-url https://download.pytorch.org/whl/
 
 #Build and run XCCL C++ unit tests (mock-based, no XPU hardware required)
 cd torchcomms
-cmake -B build -G Ninja -DBUILD_TESTS=ON -DUSE_XCCL=ON -DUSE_NCCL=OFF -DUSE_NCCLX=OFF -DUSE_GLOO=ON -DUSE_TRANSPORT=OFF
+cmake -B build -G Ninja -DBUILD_TESTS=ON -DUSE_XCCL=ON -DUSE_NCCL=OFF -DUSE_NCCLX=OFF -DUSE_GLOO=ON -DUSE_TRANSPORT=OFF -DUSE_UNIFLOW=OFF
 cmake --build build
 ctest --test-dir build --output-on-failure -R "TorchCommXCCLTest|TorchWorkXCCLQueueTest|TorchCommXCCLBootstrapTest|HintParsingTest"
 cd ..

--- a/.github/workflows/build_test_rccl.yaml
+++ b/.github/workflows/build_test_rccl.yaml
@@ -63,7 +63,7 @@ jobs:
 
         ./build_rccl.sh
         pip install numpy
-        USE_SYSTEM_LIBS=1 USE_NCCL=0 USE_NCCLX=0 USE_GLOO=0 USE_RCCL=1 USE_TRANSPORT=OFF pip install --no-build-isolation -v -e .
+        USE_SYSTEM_LIBS=1 USE_NCCL=0 USE_NCCLX=0 USE_GLOO=0 USE_RCCL=1 USE_TRANSPORT=OFF USE_UNIFLOW=OFF pip install --no-build-isolation -v -e .
 
         # Verify installation - TODO re-enable this section after D90936340 stack lands
         #python -c "import torch; print(f'PyTorch version: {torch.__version__}')"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ Backend selection is controlled by environment variables (ON/OFF or 1/0) set bef
 | `USE_RCCLX` | OFF | Meta's extended RCCL |
 | `USE_XCCL` | OFF | Intel XPU |
 | `USE_TRANSPORT` | ON (OFF on ROCm) | RDMA transport layer |
+| `USE_UNIFLOW` | ON (OFF on ROCm) | UniFlow point-to-point transfers (`uniflow._core` extension) |
 | `USE_SYSTEM_LIBS` | unset | When set, uses conda/system libs instead of building from source |
 
 ### NCCL-only (fastest build — skips NCCLX third-party dep compilation)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ option(USE_RCCLX "Whether to build RCCLX or not" OFF)
 option(USE_XCCL "Whether to build XCCL or not" OFF)
 option(USE_TRANSPORT "Whether to build TRANSPORT or not" ON)
 option(USE_TRANSPORT_CCA_HOOK "Build the minimal RDMA CCA-hook extension" ON)
+option(USE_UNIFLOW "Whether to build the uniflow._core Python extension" ON)
 option(USE_TRITON "Whether to build Triton device bitcode or not" OFF)
 option(BUILD_TESTS "Whether to build tests or not" OFF)
 message(STATUS "  USE_NCCL : ${USE_NCCL}")
@@ -38,6 +39,7 @@ message(STATUS "  USE_RCCLX  : ${USE_RCCLX}")
 message(STATUS "  USE_XCCL  : ${USE_XCCL}")
 message(STATUS "  USE_TRANSPORT  : ${USE_TRANSPORT}")
 message(STATUS "  USE_TRANSPORT_CCA_HOOK : ${USE_TRANSPORT_CCA_HOOK}")
+message(STATUS "  USE_UNIFLOW    : ${USE_UNIFLOW}")
 message(STATUS "  USE_TRITON     : ${USE_TRITON}")
 message(STATUS "  BUILD_TESTS    : ${BUILD_TESTS}")
 
@@ -46,7 +48,7 @@ message(STATUS "  BUILD_TESTS    : ${BUILD_TESTS}")
 # GLOO and XCCL are the only backends that are neither CUDA nor ROCm.
 # If no CUDA-dependent backend is enabled we can skip CUDA-specific setup
 # like TORCH_CUDA_ARCH_LIST detection.
-if(USE_NCCL OR USE_NCCLX OR USE_TRANSPORT OR USE_TRANSPORT_CCA_HOOK OR USE_TRITON)
+if(USE_NCCL OR USE_NCCLX OR USE_TRANSPORT OR USE_TRANSPORT_CCA_HOOK OR USE_UNIFLOW OR USE_TRITON)
     set(NEEDS_CUDA TRUE)
 else()
     set(NEEDS_CUDA FALSE)
@@ -284,6 +286,12 @@ endif()
 # the NCCLX static lib (ctran::RegCache), so also gate on USE_NCCLX.
 if (USE_TRANSPORT_CCA_HOOK AND USE_NCCLX)
     include(comms/torchcomms/transport/cca_hook/CMakeLists.txt)
+endif()
+# uniflow uses a subdirectory-style CMakeLists (shared with its standalone
+# build), so add_subdirectory rather than include().
+if (USE_UNIFLOW)
+    set(UNIFLOW_BUILD_PYTHON_EXT ON)
+    add_subdirectory(comms/uniflow)
 endif()
 if (USE_TRITON)
     include(comms/torchcomms/triton/CMakeLists.txt)

--- a/README.md
+++ b/README.md
@@ -201,6 +201,9 @@ export USE_GLOO=ON    # Default: ON
 export USE_RCCL=OFF   # Default: OFF
 export USE_RCCLX=OFF  # Default: OFF
 export USE_XCCL=OFF   # Default: OFF
+
+# Enable/disable the uniflow._core Python extension (CUDA-only)
+export USE_UNIFLOW=ON  # Default: ON (OFF on ROCm)
 ```
 
 Then run:

--- a/comms/torchcomms/scripts/run_tests_unit_py.sh
+++ b/comms/torchcomms/scripts/run_tests_unit_py.sh
@@ -52,3 +52,10 @@ export TEST_BACKEND=gloo
 export TEST_DEVICE=cuda
 run_tests
 unset TEST_DEVICE
+
+# Uniflow (backend-independent, needs the uniflow._core extension)
+if [ "${USE_UNIFLOW}" = "0" ] || [ "${USE_UNIFLOW}" = "OFF" ]; then
+    echo "Skipping uniflow tests (USE_UNIFLOW=${USE_UNIFLOW})"
+else
+    pytest -v comms/uniflow/tests/py/test_uniflow.py
+fi

--- a/comms/uniflow/CMakeLists.txt
+++ b/comms/uniflow/CMakeLists.txt
@@ -18,7 +18,46 @@ else()
   set(UNIFLOW_STANDALONE OFF)
 endif()
 
+if(NOT UNIFLOW_STANDALONE)
+  # Intermediate static libs (uniflow, fetched spdlog) must not land in the
+  # parent's CMAKE_ARCHIVE_OUTPUT_DIRECTORY: setup.py points it at the
+  # packaged torchcomms/ dir and they would ship in the wheel.
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+endif()
+
 find_package(Threads REQUIRED)
+
+# libibverbs/libmlx5 are dlopen'd at runtime, but rdma-core headers are
+# needed at build time (mlx5dv.h includes verbs.h).
+include(CheckIncludeFileCXX)
+check_include_file_cxx("infiniband/mlx5dv.h" UNIFLOW_HAS_RDMA_HEADERS)
+if(NOT UNIFLOW_HAS_RDMA_HEADERS)
+  message(FATAL_ERROR
+      "uniflow requires rdma-core headers (infiniband/verbs.h, mlx5dv.h). "
+      "Install libibverbs-dev / rdma-core-devel, or build with USE_UNIFLOW=OFF.")
+endif()
+
+# Enable position-independent code for all targets (including fetched
+# spdlog) so uniflow can be linked into shared libraries (e.g., the
+# uniflow._core Python extension).
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# fmt: supplied by the parent torchcomms build (header-only); find or fetch
+# when building standalone. Must precede spdlog so a fetched spdlog uses the
+# same fmt (SPDLOG_FMT_EXTERNAL) instead of its bundled copy.
+if(NOT TARGET fmt::fmt)
+  find_package(fmt QUIET)
+  if(NOT fmt_FOUND)
+    message(STATUS "fmt not found on system, fetching from GitHub...")
+    include(FetchContent)
+    FetchContent_Declare(
+        fmt
+        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+        GIT_TAG 11.2.0
+    )
+    FetchContent_MakeAvailable(fmt)
+  endif()
+endif()
 
 # spdlog: use system install if available, otherwise fetch from GitHub.
 option(UNIFLOW_USE_SYSTEM_SPDLOG "Use system-installed spdlog instead of fetching" ON)
@@ -29,6 +68,7 @@ endif()
 
 if(NOT spdlog_FOUND)
   message(STATUS "spdlog not found on system, fetching from GitHub...")
+  set(SPDLOG_FMT_EXTERNAL ON)
   include(FetchContent)
   FetchContent_Declare(
       spdlog
@@ -44,10 +84,6 @@ message(STATUS "ROOT = ${ROOT}")
 message(STATUS "CMAKE_CURRENT_SOURCE_DIR = ${CMAKE_CURRENT_SOURCE_DIR}")
 include_directories(${ROOT})
 
-# Enable position-independent code for all targets so uniflow can be
-# linked into shared libraries (e.g., torchcomms _transport.so).
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
 # Add CUDA include path globally so all sub-targets can find cuda.h
 # and cuda_runtime_api.h, even when compiled via distcc.
 if(CUDAToolkit_FOUND)
@@ -55,7 +91,8 @@ if(CUDAToolkit_FOUND)
 endif()
 
 # Add spdlog include path globally for distcc compatibility.
-if(spdlog_FOUND)
+# Check the target, not spdlog_FOUND: fetched spdlog sets only the former.
+if(TARGET spdlog::spdlog)
   get_target_property(_spdlog_inc spdlog::spdlog INTERFACE_INCLUDE_DIRECTORIES)
   if(_spdlog_inc)
     include_directories(${_spdlog_inc})
@@ -106,6 +143,7 @@ add_library(uniflow ${UNIFLOW_LIB_TYPE}
     $<TARGET_OBJECTS:uniflow_nvml>
     $<TARGET_OBJECTS:uniflow_ibv>
     $<TARGET_OBJECTS:uniflow_sysfs>
+    $<TARGET_OBJECTS:uniflow_topology_discovery>
     $<TARGET_OBJECTS:uniflow_logging>
 )
 
@@ -118,11 +156,34 @@ target_include_directories(uniflow PUBLIC
 target_link_libraries(uniflow PUBLIC
     Threads::Threads
     spdlog::spdlog
+    fmt::fmt
     uniflow_executor
 )
 
 if(CUDAToolkit_FOUND)
     target_link_libraries(uniflow PUBLIC CUDA::cudart CUDA::cuda_driver)
+endif()
+
+# Extension: uniflow._core (built by the parent torchcomms build, which
+# provides the pybind11/Python helpers; the internal Buck build has its own
+# target)
+if(UNIFLOW_BUILD_PYTHON_EXT AND NOT UNIFLOW_STANDALONE)
+  add_library(uniflow_core MODULE
+      ${CMAKE_CURRENT_SOURCE_DIR}/UniflowPy.cpp
+  )
+  set_target_properties(uniflow_core PROPERTIES
+      PREFIX ""  # No 'lib' prefix for Python extension
+      OUTPUT_NAME "_core"
+      SUFFIX ".${Python3_SOABI}.so"
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  )
+  target_include_directories(uniflow_core PRIVATE ${Python3_INCLUDE_DIRS})
+  torchcomms_use_torch_pybind11(uniflow_core)
+  target_compile_features(uniflow_core PRIVATE cxx_std_20)
+  target_link_libraries(uniflow_core PRIVATE uniflow)
+  # CMAKE_INSTALL_PREFIX is the torchcomms package dir (see setup.py);
+  # the uniflow package is its sibling.
+  install(TARGETS uniflow_core LIBRARY DESTINATION ../uniflow)
 endif()
 
 # Tests (standalone builds or when BUILD_TESTING is ON)

--- a/comms/uniflow/__init__.py
+++ b/comms/uniflow/__init__.py
@@ -1,6 +1,10 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 # pyre-strict
 
+# Import torch first: it preloads the CUDA runtime libraries that _core
+# links against, so wheels work without a system-wide CUDA toolkit.
+import torch  # noqa: F401
+
 from uniflow._core import (
     Connection,
     CpuNicSelectionPolicy,

--- a/comms/uniflow/_core.pyi
+++ b/comms/uniflow/_core.pyi
@@ -10,7 +10,7 @@ class ErrCode:
     NotConnected: ErrCode
     TransportError: ErrCode
     ConnectionFailed: ErrCode
-    MemoryRegistrationFailed: ErrCode
+    MemoryRegistrationError: ErrCode
     Timeout: ErrCode
     ResourceExhausted: ErrCode
     @property

--- a/comms/uniflow/controller/CMakeLists.txt
+++ b/comms/uniflow/controller/CMakeLists.txt
@@ -25,4 +25,5 @@ target_include_directories(uniflow_controller PUBLIC
 target_link_libraries(uniflow_controller PRIVATE
     uniflow_executor
     uniflow_logging
+    fmt::fmt
 )

--- a/comms/uniflow/drivers/CMakeLists.txt
+++ b/comms/uniflow/drivers/CMakeLists.txt
@@ -4,3 +4,18 @@ add_subdirectory(cuda)
 add_subdirectory(ibverbs)
 add_subdirectory(nvml)
 add_subdirectory(sysfs)
+
+# Platform-neutral topology discovery; createDefaultDiscoveryBackend() comes
+# from the platform backend (CUDA here, selected via Buck internally).
+add_library(uniflow_topology_discovery OBJECT
+    ${CMAKE_CURRENT_SOURCE_DIR}/TopologyDiscovery.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/TopologyDiscovery.h
+)
+
+target_compile_features(uniflow_topology_discovery PUBLIC cxx_std_20)
+
+target_compile_options(uniflow_topology_discovery PRIVATE -fPIC)
+
+target_include_directories(uniflow_topology_discovery PUBLIC
+    ${ROOT}
+)

--- a/comms/uniflow/drivers/cuda/CMakeLists.txt
+++ b/comms/uniflow/drivers/cuda/CMakeLists.txt
@@ -4,12 +4,14 @@ set(UNIFLOW_CUDA_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/CudaApi.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CudaDriverApi.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CudaDeviceAdapter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CudaTopologyDiscovery.cpp
 )
 
 set(UNIFLOW_CUDA_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/CudaApi.h
     ${CMAKE_CURRENT_SOURCE_DIR}/CudaDriverApi.h
     ${CMAKE_CURRENT_SOURCE_DIR}/CudaDeviceAdapter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/CudaTopologyDiscovery.h
 )
 
 add_library(uniflow_cuda OBJECT

--- a/comms/uniflow/transport/TransportType.h
+++ b/comms/uniflow/transport/TransportType.h
@@ -31,4 +31,9 @@ constexpr std::string_view toStringView(TransportType t) noexcept {
   return "Unknown";
 }
 
+// ADL hook so fmt/spdlog (v10+) format TransportType by name.
+constexpr std::string_view format_as(TransportType t) noexcept {
+  return toStringView(t);
+}
+
 } // namespace uniflow

--- a/comms/uniflow/transport/rdma/CMakeLists.txt
+++ b/comms/uniflow/transport/rdma/CMakeLists.txt
@@ -1,8 +1,10 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 set(UNIFLOW_RDMA_TRANSPORT_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/CopyEngine.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RdmaTransport.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RdmaRegistrationHandle.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RdmaResources.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RdmaSlabPool.cpp
 )
 
@@ -23,4 +25,4 @@ target_include_directories(uniflow_rdma_transport PUBLIC
     ${ROOT}
 )
 
-target_link_libraries(uniflow_rdma_transport PUBLIC uniflow_ibv_api)
+target_link_libraries(uniflow_rdma_transport PUBLIC uniflow_ibv)

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -443,21 +443,25 @@ Status RdmaTransport::connect(std::span<const uint8_t> remoteInfo) {
   remoteDomainId_ = remote.header.domainId;
   remoteNumNics_ = remote.header.numNics;
 
-  if (remote.header.numQps != config_.numQps) {
+  // Copy packed fields to locals; GCC rejects binding them to references.
+  const uint32_t remoteNumQps = remote.header.numQps;
+  if (remoteNumQps != config_.numQps) {
     UNIFLOW_LOG_ERROR(
         "connect: QP count mismatch (local={}, remote={})",
         config_.numQps,
-        remote.header.numQps);
+        remoteNumQps);
     state_ = TransportState::Error;
     return Err(ErrCode::InvalidArgument, "QP count mismatch");
   }
-  if (remote.header.slabSize != info_.header.slabSize) {
+  const uint32_t localSlabSize = info_.header.slabSize;
+  const uint32_t remoteSlabSize = remote.header.slabSize;
+  if (remoteSlabSize != localSlabSize) {
     UNIFLOW_LOG_WARN(
         "connect: slab size mismatch (local={}, remote={})",
-        info_.header.slabSize,
-        remote.header.slabSize);
+        localSlabSize,
+        remoteSlabSize);
     remote.header.slabSize = info_.header.slabSize =
-        std::min(remote.header.slabSize, info_.header.slabSize);
+        std::min(remoteSlabSize, localSlabSize);
   }
 
   const uint32_t numNics = static_cast<uint32_t>(nics_.size());
@@ -2153,8 +2157,9 @@ RdmaTransportFactory::importSegment(
       rkeys.data(), payload.data() + offset, sizeof(uint32_t) * header.numMrs);
 
   uint64_t domainId = header.domainId;
+  uint64_t registrationBase = header.registrationBase;
   return std::make_unique<RdmaRemoteRegistrationHandle>(
-      std::move(rkeys), domainId, header.registrationBase, deviceAdapter_);
+      std::move(rkeys), domainId, registrationBase, deviceAdapter_);
 }
 
 Result<std::unique_ptr<Transport>> RdmaTransportFactory::createTransport(

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -5,4 +5,11 @@ DO NOT DELETE
 This file is used to test the build of the torchcomms package in CI.
 """
 
+import importlib.util
+
 import torchcomms  # noqa: F401
+
+# uniflow ships only in USE_UNIFLOW builds (not ROCm); when present it must
+# import (a stub-only package was the failure mode of #3168).
+if importlib.util.find_spec("uniflow") is not None:
+    import uniflow  # noqa: F401

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,8 @@ USE_TRANSPORT = flag_enabled("USE_TRANSPORT", not IS_ROCM)
 USE_TRANSPORT_CCA_HOOK = flag_enabled(
     "USE_TRANSPORT_CCA_HOOK", USE_NCCLX and not IS_ROCM
 )
+# uniflow._core extension. CUDA-only; disable by default on ROCm.
+USE_UNIFLOW = flag_enabled("USE_UNIFLOW", not IS_ROCM)
 USE_TRITON = flag_enabled("USE_TRITON", False)
 
 
@@ -193,6 +195,7 @@ class build_ext(build_ext_orig):
             f"-DUSE_XCCL={flag_str(USE_XCCL)}",
             f"-DUSE_TRANSPORT={flag_str(USE_TRANSPORT)}",
             f"-DUSE_TRANSPORT_CCA_HOOK={flag_str(USE_TRANSPORT_CCA_HOOK)}",
+            f"-DUSE_UNIFLOW={flag_str(USE_UNIFLOW)}",
             f"-DUSE_TRITON={flag_str(USE_TRITON)}",
         ]
         build_args = ["--", "-j"]
@@ -229,6 +232,13 @@ if USE_TRANSPORT:
     ext_modules.append(CMakeExtension("torchcomms._transport"))
 if USE_TRANSPORT_CCA_HOOK:
     ext_modules.append(CMakeExtension("torchcomms._transport_cca_hook"))
+if USE_UNIFLOW:
+    ext_modules.append(CMakeExtension("uniflow._core"))
+
+packages = find_packages("comms")
+if not USE_UNIFLOW:
+    # Don't ship a uniflow package whose _core extension was not built.
+    packages = [p for p in packages if p.split(".")[0] != "uniflow"]
 
 backend_entry_points = ["fake = torchcomms._comms"] + [
     f"{name} = torchcomms._comms_{name}" for name, enabled in BACKEND_FLAGS if enabled
@@ -242,10 +252,11 @@ if USE_NCCL:
 setup(
     name="torchcomms",
     version=get_version(),
-    packages=find_packages("comms"),
+    packages=packages,
     package_dir={"": "comms"},
     package_data={
         "torchcomms.triton.fb": ["*.bc"],
+        "uniflow": ["*.pyi"],
     },
     entry_points={
         "torchcomms.backends": backend_entry_points,


### PR DESCRIPTION
Fixes #3168

## Summary

Every torchcomms wheel ships the `uniflow` Python package, but the compiled `uniflow._core` pybind11 extension was only built by Meta's internal Buck build. The OSS CMake build had no target for it, so `import uniflow` fails with `ModuleNotFoundError` on every wheel and from-source install. (The `_core.pyi` stub was not shipping either; only `uniflow/__init__.py` made it into wheels.)

This PR builds and ships the extension behind a new `USE_UNIFLOW` flag, default `ON` and `OFF` on ROCm, following the `USE_TRANSPORT` convention:

- **`CMakeLists.txt`**: add the `USE_UNIFLOW` option and pull in `comms/uniflow` via `add_subdirectory` when enabled. uniflow's CMakeLists is subdirectory-style and shared with its standalone build, unlike the `include()`-style backend files. `USE_UNIFLOW` participates in `NEEDS_CUDA`.
- **`comms/uniflow/CMakeLists.txt`**: add a `uniflow_core` MODULE target for `UniflowPy.cpp`, gated on `UNIFLOW_BUILD_PYTHON_EXT`, which only the parent build sets, so standalone uniflow builds are untouched. Target properties mirror `_comms`/`_transport` (`PREFIX ""`, `SUFFIX .${Python3_SOABI}.so`, torch's bundled pybind11). The target installs to `../uniflow`, the sibling of the torchcomms package dir that `CMAKE_INSTALL_PREFIX` points at. A configure-time check for rdma-core headers gives a clear error; libibverbs/libmlx5 are dlopen'd at runtime, so only headers are needed to build.
- **`setup.py`**: add the `USE_UNIFLOW` env flag, pass it to CMake, declare `CMakeExtension("uniflow._core")`, and ship `uniflow/*.pyi` via `package_data`. When the flag is off (e.g. ROCm wheels), the `uniflow` package is excluded entirely instead of shipping a stub that cannot import.
- **`comms/uniflow/__init__.py`**: import torch before `uniflow._core`, so torch's bundled CUDA runtime satisfies the extension's `libcudart` dependency on machines without a system CUDA toolkit.

The OSS uniflow CMake had never been exercised, so wiring it up also meant fixing what had rotted:

- `transport/rdma` linked `uniflow_ibv_api`, a target that does not exist (the driver target is `uniflow_ibv`). Configuring uniflow failed immediately.
- The global spdlog include was gated on `spdlog_FOUND`, which only `find_package` sets, so a FetchContent'd spdlog left `uniflow_transport` and `uniflow_nvlink_transport` unable to find `spdlog/spdlog.h`. The gate now checks the `spdlog::spdlog` target. `CMAKE_POSITION_INDEPENDENT_CODE` moves above the fetch so the static spdlog can link into the extension, and a fetched spdlog builds with `SPDLOG_FMT_EXTERNAL` so one fmt serves the whole tree.
- `TcpController.cpp` uses `fmt::format` but nothing declared the dependency. The parent build's header-only `fmt::fmt` is now linked, with a standalone find/fetch fallback.
- Source lists were stale: `CopyEngine.cpp`, `RdmaResources.cpp`, and `CudaTopologyDiscovery.cpp` were missing, and `drivers/TopologyDiscovery.cpp` had no target at all (its Buck target `drivers:topology-discovery` had no CMake counterpart). These caused undefined symbols at import. `NvmlApiStub.cpp` is deliberately not added; it is the Buck `select()` alternative to `NvmlApi.cpp`.
- GCC rejects binding packed struct fields to references, which internal Clang builds allow. Three sites in `RdmaTransport.cpp` now copy the field to a local first, the pattern already used for `domainId` there.
- fmt v11 rejects formatting `TransportType` in the log macros. It gets a `format_as` hook reusing the existing `toStringView`, so logs now print the transport name instead of a number.
- Static libs (`libuniflow.a`, fetched `libspdlog.a`) leaked into the packaged torchcomms dir through the parent's `CMAKE_ARCHIVE_OUTPUT_DIRECTORY`, adding ~98MB per wheel. The uniflow subtree now keeps archives in its own binary dir.
- `_core.pyi` drift: the binding exposes `ErrCode.MemoryRegistrationError`, not `MemoryRegistrationFailed`.
- `comms/uniflow/tests/py/__init__.py` broke pytest collection (the module imported as `py.test_uniflow`, colliding with the third-party `py` package). No other `tests/py` dir in the repo has one, so it is removed.

CI:

- `run_tests_unit_py.sh` runs `comms/uniflow/tests/py/test_uniflow.py` once (backend-independent), with the same skip convention as transport. `test_uniflow_integration.py` is not wired in; it needs 2 GPUs and self-skips otherwise.
- `scripts/smoke_test.py` imports `uniflow` when the package is present, so the release smoke test catches this bug class.
- The XPU and RCCL workflows set `USE_UNIFLOW=OFF` (uniflow is CUDA-only), matching how they already handle `USE_TRANSPORT`.
- CUDA jobs and wheel images need nothing new: `ctran` already includes `infiniband/verbs.h` and `mlx5dv.h` on those images today.

Docs: `USE_UNIFLOW` is documented in README.md and CLAUDE.md.

## Why default ON

Default-ON is what fixes the shipped wheels, which is the reported bug. Everything uniflow needs at build time already exists wherever wheels and CUDA CI build today, and everything else is dlopen'd at runtime. `USE_UNIFLOW=OFF` remains a one-flag escape hatch, and the rdma-core preflight turns a missing header into an immediate, clear configure error.

## Validation

Linux x86_64, CUDA 13.2, RTX 5070 Ti, torch 2.13.0+cu130, Python 3.12, gcc 13, cmake 3.31.

- `python -m build --wheel --no-isolation` (the CI build command) with `USE_UNIFLOW=ON` succeeds from a clean tree. The wheel contains `uniflow/_core.cpython-312-x86_64-linux-gnu.so`, `__init__.py`, and `_core.pyi`, with no stray static libs.
- The issue's reproducer passes against the installed wheel: `import uniflow`, `import uniflow._core`, and `RegisteredSegment.span` all work.
- `pytest comms/uniflow/tests/py/test_uniflow.py`: 18/18 pass, including the GPU tests on a real GPU.
- `test_uniflow_integration.py` collects and self-skips cleanly on one GPU.
- The `USE_UNIFLOW=OFF` wheel builds and contains no uniflow files.
- `scripts/smoke_test.py` passes against the installed wheel; changed C++ is clang-format clean.

## Notes for reviewers

- The uniflow C++ unit tests (gtest) are not wired into `BUILD_TESTS` here; the Python suite covers the surface this PR ships. Happy to wire them in a follow-up.
- `UniflowPy.cpp` needs no torch link (it imports torch lazily in `Segment.from_tensor`), so `uniflow._core` links only the `uniflow` static lib.
- Several uniflow files carry "Confidential and proprietary" headers in this BSD-3 repo (pre-existing). Flagging in case you want to fix them before advertising the package.

Developed with [Claude Code](https://claude.com/claude-code) (Claude Fable 5).
