### PR TITLE
Fix the split recv acquire call into progress_recv_ready

### DIFF
--- a/comms/prims/tests/ProgressRecvAcquireInstantiationTest.cc
+++ b/comms/prims/tests/ProgressRecvAcquireInstantiationTest.cc
@@ -1,0 +1,15 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include "comms/prims/tests/ProgressRecvAcquireInstantiationTest.cuh"
+
+// This is a compile-and-link guard, not a behavioral test: the acquire/release
+// recv seam is device-only template code, so the failure mode it protects
+// against (an argument list that no longer matches progress_recv_ready) is a
+// build break, and the build of the kernel TU is the assertion. Behavioral
+// coverage of the same path lives in the multi-GPU transport tests.
+TEST(ProgressRecvAcquireInstantiationTest, AllTransportProtocolPairsCompile) {
+  EXPECT_TRUE(
+      comms::prims::test::progress_recv_acquire_instantiations_linked());
+}

--- a/comms/prims/tests/ProgressRecvAcquireInstantiationTest.cu
+++ b/comms/prims/tests/ProgressRecvAcquireInstantiationTest.cu
@@ -1,0 +1,123 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// The split acquire/release recv path reaches progress_recv_ready() through a
+// call site that no NVIDIA-side target instantiated for every protocol: only
+// ReduceScatterDirectIbV2.cu pulls it in, and only for protocol::Simple. When
+// the progress_recv_ready() overloads gained channelLayout/chunk parameters,
+// the acquire call site kept passing the old argument list and nothing in the
+// package caught it until a downstream collective failed to compile.
+//
+// These explicit instantiations force the bodies to be compiled for every
+// transport/protocol pair the seam claims to support, so signature drift fails
+// here instead of in whichever collective happens to instantiate it next.
+
+#include "comms/prims/tests/ProgressRecvAcquireInstantiationTest.cuh"
+
+#include "comms/prims/transport/P2pIbTransportDevice.cuh"
+#include "comms/prims/transport/P2pIbTransportProgressImpl.cuh"
+
+namespace comms::prims::detail {
+
+template __device__ IbgdaSendRecvProgressStatus
+progress_recv_acquire_once<P2pIbrcTransportDevice, protocol::Simple>(
+    P2pIbrcTransportDevice&,
+    ThreadGroup&,
+    std::size_t,
+    std::size_t,
+    const Timeout&,
+    RecvChunkAcquisition&);
+
+template __device__ IbgdaSendRecvProgressStatus
+progress_recv_acquire_once<P2pIbrcTransportDevice, protocol::LL>(
+    P2pIbrcTransportDevice&,
+    ThreadGroup&,
+    std::size_t,
+    std::size_t,
+    const Timeout&,
+    RecvChunkAcquisition&);
+
+template __device__ IbgdaSendRecvProgressStatus
+progress_recv_acquire_once<P2pIbgdaTransportDevice, protocol::Simple>(
+    P2pIbgdaTransportDevice&,
+    ThreadGroup&,
+    std::size_t,
+    std::size_t,
+    const Timeout&,
+    RecvChunkAcquisition&);
+
+template __device__ IbgdaSendRecvProgressStatus
+progress_recv_acquire_once<P2pIbgdaTransportDevice, protocol::LL>(
+    P2pIbgdaTransportDevice&,
+    ThreadGroup&,
+    std::size_t,
+    std::size_t,
+    const Timeout&,
+    RecvChunkAcquisition&);
+
+template __device__ void
+progress_recv_release_once<P2pIbrcTransportDevice, protocol::Simple>(
+    P2pIbrcTransportDevice&,
+    ThreadGroup&,
+    const RecvChunkAcquisition&);
+
+template __device__ void
+progress_recv_release_once<P2pIbrcTransportDevice, protocol::LL>(
+    P2pIbrcTransportDevice&,
+    ThreadGroup&,
+    const RecvChunkAcquisition&);
+
+template __device__ void
+progress_recv_release_once<P2pIbgdaTransportDevice, protocol::Simple>(
+    P2pIbgdaTransportDevice&,
+    ThreadGroup&,
+    const RecvChunkAcquisition&);
+
+template __device__ void
+progress_recv_release_once<P2pIbgdaTransportDevice, protocol::LL>(
+    P2pIbgdaTransportDevice&,
+    ThreadGroup&,
+    const RecvChunkAcquisition&);
+
+} // namespace comms::prims::detail
+
+namespace comms::prims::test {
+
+namespace {
+
+// Covers the dispatching wrappers as well: the backend-agnostic facade and both
+// concrete transports, which is how every collective actually reaches the seam.
+__global__ void acquireReleaseInstantiationProbe(
+    P2pIbTransportDevice transport,
+    P2pIbrcTransportDevice ibrc,
+    P2pIbgdaTransportDevice ibgda,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes) {
+  ThreadGroup group = make_block_group();
+  const Timeout timeout;
+  detail::RecvChunkAcquisition view{};
+
+  if (transport.progress_recv_acquire_once(
+          group, nbytes, maxSignalBytes, timeout, view) ==
+      IbgdaSendRecvProgressStatus::Progressed) {
+    transport.progress_recv_release_once(group, view);
+  }
+  if (ibrc.progress_recv_acquire_once(
+          group, nbytes, maxSignalBytes, timeout, view) ==
+      IbgdaSendRecvProgressStatus::Progressed) {
+    ibrc.progress_recv_release_once(group, view);
+  }
+  if (ibgda.progress_recv_acquire_once(
+          group, nbytes, maxSignalBytes, timeout, view) ==
+      IbgdaSendRecvProgressStatus::Progressed) {
+    ibgda.progress_recv_release_once(group, view);
+  }
+}
+
+} // namespace
+
+bool progress_recv_acquire_instantiations_linked() {
+  return reinterpret_cast<const void*>(&acquireReleaseInstantiationProbe) !=
+      nullptr;
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/ProgressRecvAcquireInstantiationTest.cuh
+++ b/comms/prims/tests/ProgressRecvAcquireInstantiationTest.cuh
@@ -1,0 +1,11 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+namespace comms::prims::test {
+
+// Returns true once the translation unit holding the acquire/release
+// instantiations has linked in. See the .cu for what it covers.
+bool progress_recv_acquire_instantiations_linked();
+
+} // namespace comms::prims::test

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -1534,6 +1534,8 @@ progress_recv_acquire_once(
           Proto{},
           transport,
           group,
+          channelLayout,
+          chunk,
           ch.channel,
           ch.local.dataReady,
           protocolBytesThis,


### PR DESCRIPTION
Summary:
- Unbreaks the build: `progress_recv_acquire_once()` still passes the pre-LL 10-argument list to `progress_recv_ready()`, which now takes 12. D115666430 added the split acquire/release call site and D112334774 gave the readiness helpers their `channelLayout`/`chunk` parameters on the same day; neither diff saw the other, so every instantiation of the acquire path fails to compile on master.
- Passes `channelLayout` and `chunk` through in the same positions the fused `progress_recv_once_impl()` call site uses, so both paths hand the helper identical geometry. Simple ignores the two arguments; LL polls the recv staging packets through them.
- Adds `progress_recv_acquire_instantiation_test`, which explicitly instantiates the acquire and release seams for `{P2pIbrc, P2pIbgda} x {Simple, LL}` plus the `P2pIbTransportDevice` facade. Only `ReduceScatterDirectIbV2.cu` reached this code before, and only for `Simple`, so a signature change was caught by whichever downstream collective happened to instantiate it rather than by the transport package itself.

Differential Revision: D116240995


