### PR TITLE
Abort check macros and contract doc (#3690)

### DIFF
--- a/comms/common/fault_tolerance/AbortMacros.cuh
+++ b/comms/common/fault_tolerance/AbortMacros.cuh
@@ -1,0 +1,136 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstdio>
+
+#include "comms/common/fault_tolerance/AbortDevice.cuh"
+
+/*
+ * Abort checks for device wait loops.
+ *
+ * `FT_ABORT_CHECK` is the primitive: it evaluates the handle once and reports
+ * whether the caller must stop. `FT_ABORT_BREAK` and `FT_ABORT_RETURN` are the
+ * two common shapes on top of it.
+ *
+ * Under `AbortBehavior::TRAP` all three log the *site* -- file, line and
+ * function -- alongside the caller's message, so a log line says where the
+ * abort or the timeout was observed rather than only that one happened. Under
+ * the default `AbortBehavior::SKIP` they stay silent: a wait that aborts does
+ * so on every thread that reached it, and one printf per thread per site would
+ * bury the host-side diagnosis under device output. SKIP is the production
+ * path; the reason is already recorded on the `Abort` for the host to report.
+ *
+ * These live in the fault-tolerance module and deliberately depend on nothing
+ * from Prims, so CTRAN and MCCL device code can use the same checks.
+ */
+
+// True during the CUDA or HIP device pass. HIP parses `__device__` bodies in
+// the host pass too, so device-only intrinsics have to be gated.
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#define FT_IS_DEVICE_COMPILE 1
+#else
+#define FT_IS_DEVICE_COMPILE 0
+#endif
+
+#if FT_IS_DEVICE_COMPILE
+#define FT_DEVICE_TRAP() __trap()
+#else
+#define FT_DEVICE_TRAP() ((void)0)
+#endif
+
+namespace comms::fault_tolerance::detail {
+
+/*
+ * Shared body behind the macros. `fmt` already carries the caller's message
+ * plus the source location; the function name arrives as the last argument and
+ * is consumed by the trailing `%s`.
+ */
+template <typename... Args>
+__device__ __forceinline__ bool
+abortCheckAndLog(const AbortDevice& abort, const char* fmt, Args... args) {
+#if FT_IS_DEVICE_COMPILE
+  const auto result = abort.check();
+  if (result == AbortCheckResult::CONTINUE) {
+    return false;
+  }
+  if (result == AbortCheckResult::TRAP) {
+    // NOLINTNEXTLINE(facebook-security-vulnerable-printf)
+    printf(fmt, args...);
+    FT_DEVICE_TRAP();
+  }
+  return true;
+#else
+  (void)abort;
+  (void)fmt;
+  ((void)args, ...);
+  return false;
+#endif
+}
+
+} // namespace comms::fault_tolerance::detail
+
+#define FT_ABORT_STRINGIFY_(x) #x
+#define FT_ABORT_STRINGIFY(x) FT_ABORT_STRINGIFY_(x)
+
+// Source location, baked into the format string at compile time. Only the
+// function name needs a runtime argument, so it is passed last.
+#define FT_ABORT_SITE_SUFFIX_ \
+  " [" __FILE__ ":" FT_ABORT_STRINGIFY(__LINE__) " %s]\n"
+
+/*
+ * Returns true when the caller must stop.
+ *
+ * `fmt` must be a string literal -- the source location is concatenated onto
+ * it at compile time. `__func__` is expanded here, at the call site, so it
+ * names the function containing the wait.
+ *
+ * Under `AbortBehavior::TRAP` this prints the message and the site, traps, and
+ * still reports true, so a caller that survives the trap still terminates.
+ * Under the default `AbortBehavior::SKIP` it reports true without printing.
+ *
+ * Use this where the exit needs more than a bare `break` or `return` -- for
+ * example when the decision must be made warp-uniform before a barrier:
+ *
+ *     const bool stop = FT_ABORT_CHECK(abort, "waiting for peer %d", peer);
+ *     if (__any_sync(0xFFFFFFFFU, stop)) {
+ *       break;
+ *     }
+ */
+#define FT_ABORT_CHECK(abort, fmt, ...)               \
+  ::comms::fault_tolerance::detail::abortCheckAndLog( \
+      (abort),                                        \
+      "CUDA ABORT ERROR: " fmt FT_ABORT_SITE_SUFFIX_, \
+      ##__VA_ARGS__,                                  \
+      __func__)
+
+/*
+ * Leaves the enclosing loop when an abort is visible.
+ *
+ * Deliberately not wrapped in do/while(0): the `break` has to belong to the
+ * caller's loop. Only valid inside a loop -- outside one it would bind to the
+ * nearest enclosing switch. Use FT_ABORT_RETURN there.
+ *
+ * The trailing `else (void)0` is what makes the expansion safe in an unbraced
+ * `if`. Without it the macro is a naked `if`, so `if (c) FT_ABORT_BREAK(...);
+ * else fallback();` binds the caller's `else` to the macro's `if` -- and the
+ * misbinding is silent, running `fallback()` exactly when `c` held and nothing
+ * had aborted. Consuming the `else` here completes the macro's own `if`, so the
+ * caller's `else` binds to the caller's `if`, which is what the caller wrote.
+ * Note this is a silent repair, not a diagnostic: the misbinding shape still
+ * compiles either way, so `BreakDoesNotCaptureACallerElse` has to catch a
+ * regression at runtime rather than at build time.
+ */
+#define FT_ABORT_BREAK(abort, fmt, ...)            \
+  if (FT_ABORT_CHECK(abort, fmt, ##__VA_ARGS__)) { \
+    break;                                         \
+  } else                                           \
+    (void)0
+
+/* Returns `value` from the enclosing function when an abort is visible. */
+#define FT_ABORT_RETURN(abort, value, fmt, ...)      \
+  do {                                               \
+    if (FT_ABORT_CHECK(abort, fmt, ##__VA_ARGS__)) { \
+      return value;                                  \
+    }                                                \
+  } while (0)

--- a/comms/common/fault_tolerance/FAULT_TOLERANCE.md
+++ b/comms/common/fault_tolerance/FAULT_TOLERANCE.md
@@ -3,6 +3,49 @@
 This document describes the shared abort contract used by MCCL, CTRAN, and
 Prims device code.
 
+## Principles
+
+Read these before adding or changing a wait loop, a device timeout, or a
+collective's abort wiring. The sections below are the detail; these are the
+rules the detail exists to serve.
+
+1. **Liveness, not error propagation.** A wait terminates itself once abort is
+   visible. Returning a status is optional and must never be the thing that
+   prevents a hang. A collective on an aborted communicator completes quickly;
+   it does not promise a meaningful result.
+2. **Prefer `break` over an early `return`.** Falling through keeps every
+   thread on the path to the same barriers. A subset returning early strands
+   its peers at `group.sync()`, which is undefined behavior. If you must return
+   early, make the decision group-uniform first.
+3. **The abort exit belongs in the macro, not in the signature.** Use
+   `FT_ABORT_BREAK` / `FT_ABORT_RETURN` (`AbortMacros.cuh`); they terminate the
+   loop themselves. Do not convert a `void` wait to `bool` just to report that
+   it aborted.
+4. **Group uniformity idiom: leader polls, then broadcasts.** Use the existing
+   leader + `broadcast<uint32_t>` shape rather than adding a new reduction
+   primitive for one call site.
+5. **Never derive a loop bound or an index from peer-written data.** Bounds come
+   from local geometry or parameters. This is the assumption that lets a wait
+   give up without unwinding the caller.
+6. **Do not store started deadline state in a transport object.** Transport
+   handles outlive operations and are shared across blocks; copy the handle per
+   block and call `startTimeout()` on the copy.
+7. **Keep abort polling off hot paths.** Gate the check behind a spin count so
+   it only engages once actually stalled, and prefer one poller per group over
+   one per thread when the loop is per-thread.
+8. **Onboard every new or in-flight wait as it lands**, including
+   work-in-progress paths. A spin loop that reaches main without an abort check
+   is a hang waiting to happen.
+9. **Per-operation timeouts come only from the collective API.** The
+   communicator deadline stays late-bound in shared state so `setTimeout()` is
+   observed by already-created device handles.
+10. **Validate a timeout's sign, not its size.** Choosing a sane magnitude is
+    the caller's job; `std::chrono` types already make unit mistakes unlikely.
+    A negative value must be rejected, because at the `AbortDevice` layer it
+    silently means "no override".
+11. **Fault tolerance is an MCCL-communicator feature.** Communicators created
+    through the NCCLX/CTRAN factory get a disabled `Abort`; see *Scope*.
+
 ## Host `Abort`
 
 `Abort` is a communicator-scoped controller. MCCL creates the host object and
@@ -93,6 +136,20 @@ kernel.
 MCCL and CTRAN already share the same host `Abort`. MCCL collective code should
 not add a second host abort pointer to `CommContext`.
 
+MCCL creates enabled abort controllers with `AbortBehavior::SKIP` by default.
+`McclCommCreateOpts::trapOnDeviceAbort` opts into `AbortBehavior::TRAP` for
+callers that need the legacy device trap behavior. `MCCL_ABORT_MODE`
+(`skip`/`trap`/`none`) overrides both at runtime; `none` disables abort support
+for the communicator entirely.
+
+The device-side abort deadline comes from `McclCommCreateOpts::abortTimeout`
+when set, otherwise from a positive `MCCL_ABORT_TIMEOUT_MS`. It is deliberately
+**not** derived from `InitOpts::timeout`: that value bounds bootstrap, and
+reusing it as a per-collective watchdog would let a short init budget abort
+healthy long collectives, or a long one silently remove the 30 s floor.
+`commSplit()` carries the resolved deadline to the child communicator, matching
+`reconfigure()`.
+
 For Prims-backed collectives:
 
 1. Host orchestration gets a `MultiPeerDeviceHandle` from MPT.
@@ -101,8 +158,148 @@ For Prims-backed collectives:
 3. Kernel entry creates a local per-block copy and calls `startTimeout()`.
 4. Transport and synchronization waits poll that local abort handle.
 
-The long-term target is to remove the separate Prims `Timeout` type and use
-`AbortDevice` for both explicit abort and abort-based timeout checks.
+## Prims `Timeout` Compatibility
+
+Prims `Timeout` is a source-compatible alias to `AbortDevice` during the
+migration:
+
+```cpp
+using Timeout = comms::fault_tolerance::AbortDevice;
+```
+
+This preserves existing kernel signatures while removing the old standalone
+`Timeout` implementation. There is no per-launch GPU-cycle timeout object and
+no `makeTimeout()` helper. Timeout duration comes from the communicator-owned
+host `Abort` default timeout and is read by `AbortDevice::startTimeout()`.
+
+The behavior change is intentional:
+
+- Default-constructed `Timeout`/`AbortDevice` is disabled and behaves like the
+  previous no-timeout default.
+- Handles borrowed from MPT observe explicit host aborts and timeout-triggered
+  aborts through shared state.
+- Timeout expiry records `AbortReason::TIMED_OUT` once in shared abort state,
+  making the result visible to host code and other device consumers.
+
+New code should name the concrete type `AbortDevice`. `Timeout` spelling is
+only for migration compatibility and should not be used in new Prims APIs.
+
+### Per-operation timeouts
+
+A collective may override the deadline for a single operation by passing
+`timeout` on its options struct. The launcher copies the communicator device
+handle, calls `AbortDevice::setOpTimeoutMs()` on that copy, and stores it in the
+kernel arguments, so the override travels by value and costs no shared-state
+read.
+
+When no per-operation timeout is supplied the override stays unset and the
+device reads the communicator timeout from shared state on every
+`startTimeout()`. That keeps it late-bound, so `IComm::setTimeout()` is observed
+even by transports that cache one device handle for the communicator's lifetime.
+
+`MCCL_ABORT_TIMEOUT_MS` seeds only the communicator timeout. It is never turned
+into a per-operation override: doing so would snapshot it at launch and defeat
+that late-binding.
+
+## Integration Notes
+
+What fault tolerance guarantees here, and what you must do to get it.
+
+**The guarantee is liveness, not error propagation.** A collective on an aborted
+communicator **completes quickly** rather than hanging. It does not promise a
+meaningful result, and it does not promise that every layer forwards an error
+code. Device waits stop waiting once an abort is visible; the collective then
+runs to completion over whatever is in its buffers.
+
+This is deliberate. Requiring every caller of every wait to consume and forward
+an abort result is a large, easily-broken obligation: one missed call site is
+either a hang or a silent wrong result. Making the *waits* self-terminating puts
+the obligation in one place per loop instead.
+
+It also matches the documented `IComm::abort` contract: results from work that
+completes after an abort "should be treated as the reason for abort. In the
+unlikely case of a `commSuccess`, the comm result data should still be ignored."
+
+### Transport Foundation — adding or changing a wait
+
+1. **Never block indefinitely.** Every unbounded loop must consult the
+   `AbortDevice` and stop waiting once it reports abort. This is the whole
+   correctness surface: a loop without a check is a hang.
+2. **Prefer `break` over early `return`.** Falling through keeps every thread on
+   the same path to the same barriers. An early `return` from a subset of a
+   group leaves the rest at `group.sync()` / `__syncwarp()` naming threads that
+   have exited, which is undefined behavior.
+3. **If you must return early, make the decision group-uniform first.**
+   `ThreadGroup` (`comms/prims/core/ThreadGroup.cuh`) offers exactly two
+   reductions, and both barrier, so every thread in the group must reach them:
+   - Leader-owned decision — the leader computes, then publishes with
+     `group.broadcast<uint32_t>(stop)`. This is the preferred shape (principle
+     4); it is also the cheaper one when only the leader polls.
+   - Per-thread predicate — `group.all(pred)` is a group-wide AND, so
+     "any thread saw it" is `!group.all(!pred)`. There is no `any()`.
+
+   Do not add a new reduction primitive for a single call site.
+4. **Never derive a loop bound or an index from peer-written data.** Bounds must
+   come from local geometry or parameters. If garbage could extend a loop or
+   move an index, "proceed on data that never arrived" stops being safe — this
+   assumption is what lets a wait give up without unwinding the caller.
+5. **Do not store started deadline state in a transport object.** Transport
+   handles outlive individual operations and are shared across blocks. Copy the
+   handle per block and call `startTimeout()` on the copy.
+6. **Returning a status is welcome, not required.** Several waits return `bool`
+   and the IB progress path returns `Aborted`; that lets callers stop sooner and
+   more precisely. Callers are not *obliged* to consume it, so never rely on
+   propagation for liveness.
+
+### Collective Enablement — onboarding a collective
+
+1. Take the communicator handle from the device handle you already fetch:
+   `mpt->get_device_handle(peers).abort`, and store it in your launch params /
+   kernel arguments.
+2. In the kernel, copy it per block and call `startTimeout()` once near entry.
+3. Pass that local copy into every transport wait you call.
+4. Optionally set a per-operation deadline with `setOpTimeoutMs()` on the copy —
+   **only** from a timeout the caller supplied on the collective API. Never seed
+   it from the communicator default; see *Per-operation timeouts*.
+5. You do **not** need to check the return value of any wait to be hang-safe.
+
+Steps 1–3 are the entire integration. Forgetting them means the collective runs
+with a disabled handle and silently has no fault tolerance.
+
+To catch that, call `debugCheckAbortWired()` on the host where you build your
+launch parameters. It logs once when the communicator has fault tolerance
+enabled but the handle you are about to pass is disabled — the signature of a
+missing step 1 — and is compiled out in optimized builds.
+
+> This document describes the end state of the abort migration and lands ahead
+> of parts of it. `debugCheckAbortWired()` arrives with the Prims migration in
+> D115656601; until then the diagnostic above is guidance, not an available
+> call.
+
+The check must be host-side: on the device a disabled handle is just
+`state_ == nullptr`, which is identical for "fault tolerance is off for this
+communicator" and "the collective forgot to pass the handle". Only the host can
+see both the communicator's `Abort` and the handle being launched, so only the
+host can tell those apart.
+
+### What the caller sees
+
+- The collective completes; **output buffers are undefined** after an abort.
+- Check `IComm::isAborted()`, `getAbortReason()` and `getAbortReasonStr()`.
+- Where the host can determine it cheaply, the work handle also reports a
+  non-success result — but a `commSuccess` after an abort is contract-legal and
+  its data must still be ignored.
+
+### Scope
+
+Fault tolerance is a **MCCL-communicator** feature. Communicators created
+through the NCCLX/CTRAN factory get a disabled `Abort`, so they have no device
+deadline and no abort observation; the `ctdirect_ib` ReduceScatter path is
+unbounded on those comms. This is an accepted limitation, not an oversight, and
+it is a regression against the pre-migration code, which applied
+`MCCL_ABORT_TIMEOUT_MS` unconditionally on that path. The debug diagnostic above
+is scoped to FT-enabled communicators so it stays silent here and under
+`MCCL_ABORT_MODE=none`.
 
 ## Usage Examples
 

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
@@ -2,6 +2,8 @@
 
 #include "comms/common/fault_tolerance/tests/AbortDeviceTest.cuh"
 
+#include "comms/common/fault_tolerance/AbortMacros.cuh"
+
 #include <cuda_runtime.h>
 
 #include <cstdint>
@@ -259,6 +261,148 @@ cudaError_t launchDeviceCancelAndRestartTimeout(
     cudaStream_t stream) {
   deviceCancelAndRestartTimeoutKernel<<<1, 1, 0, stream>>>(
       abort, observedAfterCancel, observedMode, maxIterations);
+  return cudaGetLastError();
+}
+
+// --- FT_ABORT_* macro coverage -------------------------------------------
+//
+// Every loop below is bounded by maxIterations so a macro that never
+// terminates fails as "ran to the bound" instead of hanging the suite.
+
+namespace {
+
+__global__ void macroBreakLoopKernel(
+    AbortDevice abort,
+    int* observedIterations,
+    int maxIterations) {
+  int iterations = 0;
+  while (iterations < maxIterations) {
+    ++iterations;
+    FT_ABORT_BREAK(abort, "macroBreakLoop iteration %d", iterations);
+  }
+  *observedIterations = iterations;
+}
+
+// Guards the `else`-binding of FT_ABORT_BREAK. The macro expands to an `if`,
+// so without the trailing `else (void)0` the caller's `else` below would bind
+// to the macro instead, and `fallback` would run on the healthy path -- exactly
+// when the caller wrote it not to. Braces are omitted deliberately: this is the
+// shape that misbinds, so the test is only meaningful unbraced.
+__global__ void macroBreakInIfElseKernel(
+    AbortDevice abort,
+    int* observedIterations,
+    int* observedFallback,
+    int maxIterations) {
+  int iterations = 0;
+  int fallback = 0;
+  while (iterations < maxIterations) {
+    ++iterations;
+    if (iterations > 0)
+      FT_ABORT_BREAK(abort, "macroBreakInIfElse iteration %d", iterations);
+    else
+      fallback = 1;
+  }
+  *observedIterations = iterations;
+  *observedFallback = fallback;
+}
+
+__global__ void macroCheckLoopKernel(
+    AbortDevice abort,
+    int* observedIterations,
+    int* observedStop,
+    int maxIterations) {
+  int iterations = 0;
+  bool stop = false;
+  while (iterations < maxIterations) {
+    ++iterations;
+    // The CHECK form: the caller decides what to do with the result.
+    stop = FT_ABORT_CHECK(abort, "macroCheckLoop iteration %d", iterations);
+    if (stop) {
+      break;
+    }
+  }
+  *observedIterations = iterations;
+  *observedStop = stop ? 1 : 0;
+}
+
+// Arms the deadline on the device. `startTimeout()` is `__device__`-only and
+// reads the device clock, so arming it from the host would derive the deadline
+// from a clock the kernel never sees and the very first check would report it
+// expired -- the loop would end for the wrong reason.
+__global__ void macroTimeoutLoopKernel(
+    AbortDevice abort,
+    int* observedIterations,
+    int maxIterations) {
+  abort.startTimeout();
+  int iterations = 0;
+  while (iterations < maxIterations) {
+    ++iterations;
+    FT_ABORT_BREAK(abort, "macroTimeoutLoop iteration %d", iterations);
+    // Paces the loop so the bound is reached well after the deadline rather
+    // than spinning past it.
+    __nanosleep(1000);
+  }
+  *observedIterations = iterations;
+}
+
+__global__ void macroReturnValueKernel(AbortDevice abort, int* observedReturn) {
+  // Wrapped so RETURN has a function to leave; -1 marks "aborted".
+  auto body = [&]() -> int {
+    FT_ABORT_RETURN(abort, -1, "macroReturnValue");
+    return 7;
+  };
+  *observedReturn = body();
+}
+
+} // namespace
+
+cudaError_t launchMacroBreakLoop(
+    AbortDevice abort,
+    int* observedIterations,
+    int maxIterations,
+    cudaStream_t stream) {
+  macroBreakLoopKernel<<<1, 1, 0, stream>>>(
+      abort, observedIterations, maxIterations);
+  return cudaGetLastError();
+}
+
+cudaError_t launchMacroCheckLoop(
+    AbortDevice abort,
+    int* observedIterations,
+    int* observedStop,
+    int maxIterations,
+    cudaStream_t stream) {
+  macroCheckLoopKernel<<<1, 1, 0, stream>>>(
+      abort, observedIterations, observedStop, maxIterations);
+  return cudaGetLastError();
+}
+
+cudaError_t launchMacroTimeoutLoop(
+    AbortDevice abort,
+    int* observedIterations,
+    int maxIterations,
+    cudaStream_t stream) {
+  macroTimeoutLoopKernel<<<1, 1, 0, stream>>>(
+      abort, observedIterations, maxIterations);
+  return cudaGetLastError();
+}
+
+cudaError_t launchMacroReturnValue(
+    AbortDevice abort,
+    int* observedReturn,
+    cudaStream_t stream) {
+  macroReturnValueKernel<<<1, 1, 0, stream>>>(abort, observedReturn);
+  return cudaGetLastError();
+}
+
+cudaError_t launchMacroBreakInIfElse(
+    AbortDevice abort,
+    int* observedIterations,
+    int* observedFallback,
+    int maxIterations,
+    cudaStream_t stream) {
+  macroBreakInIfElseKernel<<<1, 1, 0, stream>>>(
+      abort, observedIterations, observedFallback, maxIterations);
   return cudaGetLastError();
 }
 

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
@@ -71,4 +71,44 @@ cudaError_t launchDeviceCancelAndRestartTimeout(
     int maxIterations,
     cudaStream_t stream);
 
+// FT_ABORT_* macro coverage. Each kernel runs a bounded spin loop that can only
+// end through the macro under test, and reports how many iterations it took, so
+// a macro that fails to terminate shows up as the loop bound rather than a
+// hang.
+cudaError_t launchMacroBreakLoop(
+    AbortDevice abort,
+    int* observedIterations,
+    int maxIterations,
+    cudaStream_t stream);
+
+// Same loop, but the kernel arms the deadline itself so the timeout is measured
+// against the device clock the checks read.
+cudaError_t launchMacroTimeoutLoop(
+    AbortDevice abort,
+    int* observedIterations,
+    int maxIterations,
+    cudaStream_t stream);
+
+cudaError_t launchMacroCheckLoop(
+    AbortDevice abort,
+    int* observedIterations,
+    int* observedStop,
+    int maxIterations,
+    cudaStream_t stream);
+
+cudaError_t launchMacroReturnValue(
+    AbortDevice abort,
+    int* observedReturn,
+    cudaStream_t stream);
+
+// Runs FT_ABORT_BREAK as the unbraced body of an `if` that has an `else`, so a
+// macro whose `if` swallows that `else` shows up as `observedFallback == 1`
+// rather than as a silent behavior change at some future call site.
+cudaError_t launchMacroBreakInIfElse(
+    AbortDevice abort,
+    int* observedIterations,
+    int* observedFallback,
+    int maxIterations,
+    cudaStream_t stream);
+
 } // namespace comms::fault_tolerance::testing

--- a/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
@@ -642,4 +642,229 @@ TEST(AbortDeviceTest, defaultConstructedHandleIsDisabledNoop) {
   EXPECT_EQ(readDeviceValue(observedMode), static_cast<int>(AbortReason::NONE));
 }
 
+// --- FT_ABORT_* macros ----------------------------------------------------
+//
+// Each case bounds its loop, so a macro that fails to terminate reports the
+// bound rather than hanging.
+
+constexpr int kMacroLoopBound = 1000;
+
+// The timeout case paces itself at roughly a microsecond per iteration, so the
+// bound has to outlast the deadline by a wide margin for "ended early" to mean
+// the deadline ended it. Reaching the bound caps the kernel at about a second.
+constexpr auto kMacroTimeoutMs = std::chrono::milliseconds{20};
+constexpr int kMacroTimeoutLoopBound = 1'000'000;
+// A correctly armed 20 ms deadline takes thousands of iterations to reach, so
+// anything this small means the deadline was already expired on entry.
+constexpr int kMacroTimeoutMinIterations = 100;
+
+TEST(AbortMacrosTest, BreakLeavesLoopWhenAborted) {
+  Abort abort{/*enabled=*/true};
+  abort.setAbort();
+
+  auto iterations = makeDeviceValue<int>();
+  ASSERT_NE(iterations, nullptr);
+  EXPECT_EQ(
+      launchMacroBreakLoop(
+          abort.getDeviceHandle(),
+          iterations.get(),
+          kMacroLoopBound,
+          /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(iterations), 1)
+      << "FT_ABORT_BREAK must leave the loop on its first check";
+}
+
+TEST(AbortMacrosTest, BreakRunsToCompletionWhenNotAborted) {
+  Abort abort{/*enabled=*/true};
+
+  auto iterations = makeDeviceValue<int>();
+  ASSERT_NE(iterations, nullptr);
+  EXPECT_EQ(
+      launchMacroBreakLoop(
+          abort.getDeviceHandle(),
+          iterations.get(),
+          kMacroLoopBound,
+          /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(iterations), kMacroLoopBound)
+      << "a healthy handle must not terminate the loop";
+}
+
+TEST(AbortMacrosTest, BreakIsANoOpForDisabledHandle) {
+  AbortDevice disabled;
+
+  auto iterations = makeDeviceValue<int>();
+  ASSERT_NE(iterations, nullptr);
+  EXPECT_EQ(
+      launchMacroBreakLoop(
+          disabled, iterations.get(), kMacroLoopBound, /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(iterations), kMacroLoopBound);
+}
+
+// FT_ABORT_BREAK expands to an `if`. If it does not consume a trailing `else`,
+// the caller's `else` binds to the macro, and the damage is silent: `fallback`
+// runs precisely when the guard held and nothing had aborted.
+//
+// The healthy case is the one that discriminates. With a pre-aborted handle the
+// macro's check is true on the first iteration, so the loop breaks and
+// `fallback` stays 0 under either expansion -- that case only pins the break
+// itself. Reaching the caller's `else` at all requires the check to be false,
+// which is why both cases are here.
+TEST(AbortMacrosTest, BreakDoesNotCaptureACallerElseWhenHealthy) {
+  Abort abort{/*enabled=*/true};
+
+  auto iterations = makeDeviceValue<int>();
+  auto fallback = makeDeviceValue<int>();
+  ASSERT_NE(iterations, nullptr);
+  ASSERT_NE(fallback, nullptr);
+  EXPECT_EQ(
+      launchMacroBreakInIfElse(
+          abort.getDeviceHandle(),
+          iterations.get(),
+          fallback.get(),
+          kMacroLoopBound,
+          /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(iterations), kMacroLoopBound)
+      << "a healthy handle must not terminate the caller's loop";
+  EXPECT_EQ(readDeviceValue(fallback), 0)
+      << "the caller's else belongs to the caller's if, not to the macro; a "
+         "naked-if expansion sets this to 1";
+}
+
+TEST(AbortMacrosTest, BreakDoesNotCaptureACallerElseWhenAborted) {
+  Abort abort{/*enabled=*/true};
+  abort.setAbort();
+
+  auto iterations = makeDeviceValue<int>();
+  auto fallback = makeDeviceValue<int>();
+  ASSERT_NE(iterations, nullptr);
+  ASSERT_NE(fallback, nullptr);
+  EXPECT_EQ(
+      launchMacroBreakInIfElse(
+          abort.getDeviceHandle(),
+          iterations.get(),
+          fallback.get(),
+          kMacroLoopBound,
+          /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(iterations), 1)
+      << "the break must still leave the caller's loop on the first check";
+  EXPECT_EQ(readDeviceValue(fallback), 0);
+}
+
+TEST(AbortMacrosTest, CheckReportsStopToTheCaller) {
+  Abort abort{/*enabled=*/true};
+  abort.setAbort();
+
+  auto iterations = makeDeviceValue<int>();
+  auto stop = makeDeviceValue<int>();
+  ASSERT_NE(iterations, nullptr);
+  ASSERT_NE(stop, nullptr);
+  EXPECT_EQ(
+      launchMacroCheckLoop(
+          abort.getDeviceHandle(),
+          iterations.get(),
+          stop.get(),
+          kMacroLoopBound,
+          /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(stop), 1)
+      << "FT_ABORT_CHECK must report the terminal result";
+  EXPECT_EQ(readDeviceValue(iterations), 1);
+}
+
+TEST(AbortMacrosTest, CheckReportsContinueWhenHealthy) {
+  Abort abort{/*enabled=*/true};
+
+  auto iterations = makeDeviceValue<int>();
+  auto stop = makeDeviceValue<int>();
+  ASSERT_NE(iterations, nullptr);
+  ASSERT_NE(stop, nullptr);
+  EXPECT_EQ(
+      launchMacroCheckLoop(
+          abort.getDeviceHandle(),
+          iterations.get(),
+          stop.get(),
+          kMacroLoopBound,
+          /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(stop), 0);
+  EXPECT_EQ(readDeviceValue(iterations), kMacroLoopBound);
+}
+
+TEST(AbortMacrosTest, ReturnYieldsTheCallerSuppliedValue) {
+  Abort abort{/*enabled=*/true};
+  abort.setAbort();
+
+  auto observed = makeDeviceValue<int>(0);
+  ASSERT_NE(observed, nullptr);
+  EXPECT_EQ(
+      launchMacroReturnValue(
+          abort.getDeviceHandle(), observed.get(), /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(observed), -1)
+      << "FT_ABORT_RETURN must return the value the caller supplied";
+}
+
+TEST(AbortMacrosTest, ReturnFallsThroughWhenHealthy) {
+  Abort abort{/*enabled=*/true};
+
+  auto observed = makeDeviceValue<int>(0);
+  ASSERT_NE(observed, nullptr);
+  EXPECT_EQ(
+      launchMacroReturnValue(
+          abort.getDeviceHandle(), observed.get(), /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(observed), 7);
+}
+
+TEST(AbortMacrosTest, TimeoutTerminatesTheLoop) {
+  Abort abort{/*enabled=*/true};
+  abort.setDefaultTimeout(kMacroTimeoutMs);
+  auto handle = abort.getDeviceHandle();
+
+  auto iterations = makeDeviceValue<int>();
+  ASSERT_NE(iterations, nullptr);
+  // The kernel arms the deadline itself: startTimeout() is device-only and
+  // reads the device clock, so arming it here would make the first check see
+  // an already-expired deadline and the loop would end for the wrong reason.
+  EXPECT_EQ(
+      launchMacroTimeoutLoop(
+          handle, iterations.get(), kMacroTimeoutLoopBound, /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  // The deadline is what ends it, so the exact iteration is timing dependent.
+  // Both bounds matter: reaching kMacroTimeoutLoopBound means the macro never
+  // observed the timeout, while stopping in the first few iterations means the
+  // deadline was already expired when the kernel started -- which is what an
+  // accidental host-side startTimeout() produces, and it would otherwise pass
+  // every assertion here.
+  const int observed = readDeviceValue(iterations);
+  EXPECT_LT(observed, kMacroTimeoutLoopBound);
+  EXPECT_GT(observed, kMacroTimeoutMinIterations);
+  EXPECT_TRUE(abort.isTimedOut());
+}
+
 } // namespace comms::fault_tolerance::testing


### PR DESCRIPTION
Summary:

Puts the device-side abort checks and the fault-tolerance contract in one place, at the bottom of the stack, so everything above shares them.

**`FT_ABORT_CHECK` / `FT_ABORT_BREAK` / `FT_ABORT_RETURN`** (`comms/common/fault_tolerance/AbortMacros.cuh`).

`FT_ABORT_CHECK` is the primitive: it evaluates the handle once and returns whether the caller must stop, so a site that needs more than a bare exit can integrate it -- for example making the decision warp-uniform before a barrier:

```cpp
const bool stop = FT_ABORT_CHECK(abort, "waiting for peer %d", peer);
if (__any_sync(0xFFFFFFFFU, stop)) {
  break;
}
```

`FT_ABORT_BREAK` and `FT_ABORT_RETURN` are the two common shapes over it. They replace a family of macros that only *set a flag*, leaving each caller to declare `bool aborted`, test it, and `break`. That pattern does not compose through a helper, which is why several diffs in this stack grew `void`->`bool` conversions purely to report "I aborted"; the macro now owns the exit.

Three things worth calling out:

- **They log where.** On the terminal path each prints the caller's message plus `file:line` and the enclosing function, so a log line says where the abort or timeout was observed. The location is concatenated into the format string at compile time, so `fmt` must be a string literal; `__func__` expands at the call site, not inside the helper.
- **No Prims dependency.** These live in the fault-tolerance module with a self-contained device-pass detection and trap (mirroring `PIPES_IS_DEVICE_COMPILE` / `PIPES_DEVICE_TRAP` exactly), so CTRAN and MCCL device code can use them too, which they cannot today.
- **`FT_ABORT_BREAK` is not wrapped in `do/while(0)`** on purpose: the `break` has to belong to the caller's loop. It is therefore loop-only -- outside one it would bind to the nearest enclosing `switch`. `FT_ABORT_CHECK` and `FT_ABORT_RETURN` carry no such restriction.

Also moved here, out of `D115814486` and `D115656601`, so the contract is not spread across the stack: all of `FAULT_TOLERANCE.md` (Principles, Integration Notes, Scope, per-operation timeouts) and the pointer to it from `comms/.claude/CLAUDE.md`.

___

Reviewed By: Scusemua, arttianezhu

Differential Revision: D116107016


