### PR TITLE
Fix split recv acquire readiness call

### DIFF
--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -1534,6 +1534,8 @@ progress_recv_acquire_once(
           Proto{},
           transport,
           group,
+          channelLayout,
+          chunk,
           ch.channel,
           ch.local.dataReady,
           protocolBytesThis,


### PR DESCRIPTION
Summary: Pass the receive channel layout and chunk geometry into the split receive-acquire readiness check. The readiness overloads gained these parameters for LL support, but this call site retained the old argument list, breaking every instantiation of ReduceScatterDirectIbV2.

Reviewed By: Scusemua

Differential Revision: D116293206


