### PR TITLE
Add the accumulate path and the double-buffered bank (#3692)

### DIFF
--- a/comms/utils/collstats/CollStatsAtomics.h
+++ b/comms/utils/collstats/CollStatsAtomics.h
@@ -1,0 +1,66 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <cstdint>
+
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+// Portable atomics for the finalizer and the bank's epoch read: CUDA/HIP
+// intrinsics on device, compiler builtins on host. One home so the device path
+// and the host-tested path can never diverge.
+//
+// Two widths, because CollStatValue mixes them: u64 for durations and byte
+// counts, u32 for the histogram buckets and threshold counters. Overload
+// resolution on the pointer type selects the right one.
+
+namespace meta::comms::collstats {
+
+COLLSTATS_HD inline uint64_t collStatAtomicLoad(const uint64_t* addr) {
+#if defined(__CUDA_ARCH__)
+  return *static_cast<const volatile uint64_t*>(addr);
+#else
+  return __atomic_load_n(addr, __ATOMIC_ACQUIRE);
+#endif
+}
+
+COLLSTATS_HD inline void collStatAtomicAdd(uint64_t* addr, uint64_t val) {
+#if defined(__CUDA_ARCH__)
+  atomicAdd(
+      reinterpret_cast<unsigned long long*>(addr),
+      static_cast<unsigned long long>(val));
+#else
+  __atomic_fetch_add(addr, val, __ATOMIC_RELAXED);
+#endif
+}
+
+COLLSTATS_HD inline void collStatAtomicAdd(uint32_t* addr, uint32_t val) {
+#if defined(__CUDA_ARCH__)
+  atomicAdd(reinterpret_cast<unsigned int*>(addr), val);
+#else
+  __atomic_fetch_add(addr, val, __ATOMIC_RELAXED);
+#endif
+}
+
+COLLSTATS_HD inline void collStatAtomicInc(uint64_t* addr) {
+  collStatAtomicAdd(addr, 1ull);
+}
+
+COLLSTATS_HD inline void collStatAtomicInc(uint32_t* addr) {
+  collStatAtomicAdd(addr, 1u);
+}
+
+COLLSTATS_HD inline void collStatAtomicMax(uint64_t* addr, uint64_t val) {
+#if defined(__CUDA_ARCH__)
+  atomicMax(
+      reinterpret_cast<unsigned long long*>(addr),
+      static_cast<unsigned long long>(val));
+#else
+  uint64_t cur = __atomic_load_n(addr, __ATOMIC_RELAXED);
+  while (val > cur &&
+         !__atomic_compare_exchange_n(
+             addr, &cur, val, true, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)) {
+  }
+#endif
+}
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsBank.h
+++ b/comms/utils/collstats/CollStatsBank.h
@@ -1,0 +1,52 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <cstdint>
+
+#include "comms/utils/collstats/CollStatsAtomics.h"
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+// The per-communicator, double-buffered aggregate. Two banks of per-key values
+// and one atomic epoch word: finalizers write bank[epoch]; at the readout
+// boundary the reader flips the epoch, then copies and zeroes the retired bank.
+// Each bank holds exactly one window's totals, so the reader needs no host
+// delta subtraction. Key identity lives on the host, in the registry that
+// assigned the slots; only the values are double-buffered.
+//
+// The flip and the zeroing live in CollStatsReader.cu, not here: the banks are
+// device memory, so the flip is a one-thread kernel on the reader stream and
+// the reset is a cudaMemsetAsync. There is deliberately no host-side helper for
+// either -- one taking a bare CollStatValue* would invite a host memset of a
+// device pointer.
+//
+// One value slot is reserved past the key capacity for the catch-all, so
+// observations whose key did not fit the registry still contribute a
+// distribution rather than vanishing.
+
+namespace meta::comms::collstats {
+
+struct CollStatDoubleBank {
+  uint32_t numKeys; // key-index capacity; catch-all lives at index numKeys
+  uint64_t epoch; // finalizers read it, the reader flips it; see below
+  CollStatValue* values[2]; // each [numKeys + 1]; [numKeys] is the catch-all
+};
+
+// The value array finalizers must write for the current epoch.
+//
+// This load carries no ordering of its own, and deliberately so: what keeps a
+// finalizer out of the bank being retired is CUDA stream gating, not the
+// memory model. The reader records an event on every instrumented stream
+// before flipping and makes those streams wait on the flip afterwards, so a
+// finalizer either ran entirely before the flip or launches entirely after it
+// (see gateOldFinalizers/gateNewLaunches in CollStatsReader.cu). Adding an
+// acquire fence per finalize would cost the hot path and buy nothing.
+//
+// The one ungated path -- the teardown flush -- device-synchronizes first,
+// which gives the same guarantee.
+COLLSTATS_HD inline CollStatValue* collStatCurrentValues(
+    CollStatDoubleBank* bank) {
+  const uint64_t e = collStatAtomicLoad(&bank->epoch);
+  return bank->values[e & 1u];
+}
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsFinalize.h
+++ b/comms/utils/collstats/CollStatsFinalize.h
@@ -1,0 +1,64 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <cstdint>
+
+#include "comms/utils/collstats/CollStatsAtomics.h"
+#include "comms/utils/collstats/CollStatsHistogram.h"
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+// The finalize update: one completed observation folded into a per-key value.
+// The device finalizer (the collective's last block) calls this once per launch
+// after computing dur = end - start in nanoseconds; many finalizers update one
+// bank concurrently, so every field is touched with an atomic. Written
+// host/device-shared so a host test drives the exact accumulation the kernel
+// runs.
+
+namespace meta::comms::collstats {
+
+/* Fold one observation into `v`. `logicalBytes` is the collective's logical
+ * message size (count x dtype), added once per finalize -- not accumulated at
+ * send boundaries -- so Sum(logicalBytes) over the window is the bus-bandwidth
+ * numerator. durMaxNs is an atomicMax and the minimum rides an atomicMax on the
+ * complement, so both are exact per-window extremes. */
+COLLSTATS_HD inline void collStatAccumulate(
+    CollStatValue* v,
+    uint64_t durNs,
+    uint64_t logicalBytes,
+    const CollStatHistGeometry& geom,
+    const uint64_t* thresholdsNs,
+    uint32_t numThresholds) {
+  collStatAtomicAdd(&v->logicalBytes, logicalBytes);
+  collStatAtomicAdd(&v->durationSumNs, durNs);
+  collStatAtomicMax(&v->durMaxNs, durNs);
+  // max of complements is the complement of the min; see CollStatValue.
+  collStatAtomicMax(&v->durMinNsComplement, ~durNs);
+  collStatAtomicInc(&v->histogram[logBucketNs(geom, durNs)]);
+  for (uint32_t i = 0; i < numThresholds; ++i) {
+    if (durNs >= thresholdsNs[i]) {
+      collStatAtomicInc(&v->thresholdCounts[i]);
+    }
+  }
+  // count last, because it is the published-ness flag: collStatDurMinNs gates
+  // on it, so anyone who observes a non-zero count has already observed the
+  // minimum it un-complements. The reader only touches a retired bank, so this
+  // costs nothing today and keeps a live-bank peek (a debugger, a future
+  // in-flight dump) from reading UINT64_MAX as the minimum.
+  collStatAtomicInc(&v->count);
+}
+
+/* Host-only convenience wrapper using the default geometry and cut-points.
+ * Device code passes the comm's device-resident configuration explicitly, since
+ * a host constexpr array is not addressable from the device. */
+inline void
+collStatAccumulate(CollStatValue* v, uint64_t durNs, uint64_t logicalBytes) {
+  collStatAccumulate(
+      v,
+      durNs,
+      logicalBytes,
+      collStatDefaultHistGeometry(),
+      kDefaultThresholdsNs,
+      kMaxThresholds);
+}
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/tests/CollStatsFinalizeTest.cpp
+++ b/comms/utils/collstats/tests/CollStatsFinalizeTest.cpp
@@ -1,0 +1,131 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/collstats/CollStatsFinalize.h"
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/collstats/CollStatsBank.h"
+#include "comms/utils/collstats/CollStatsHistogram.h"
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+namespace meta::comms::collstats {
+
+/* The tests assert against the cvar defaults explicitly, rather than against
+ * whatever the compiled-in constants happen to be. */
+const CollStatHistGeometry kTestGeom = collStatDefaultHistGeometry();
+namespace {
+
+constexpr uint64_t kSec = 1'000'000'000ull;
+
+uint64_t histogramTotal(const CollStatValue& v) {
+  uint64_t total = 0;
+  for (uint32_t b = 0; b < kHistMaxBuckets; ++b) {
+    total += v.histogram[b];
+  }
+  return total;
+}
+
+/* Host models of the two readout steps. Production runs both against device
+ * memory from CollStatsReader.cu -- the flip is a one-thread kernel on the
+ * reader stream, the reset a cudaMemsetAsync -- so neither has a callable host
+ * form, and deliberately so: a host helper taking a bare CollStatValue* would
+ * invite a host memset of a device pointer. These stand in for them so the
+ * bank-independence contract can be exercised without a GPU. Single-threaded,
+ * so plain arithmetic is enough. */
+uint32_t flipEpochLikeReader(CollStatDoubleBank& bank) {
+  const uint32_t retired = static_cast<uint32_t>(bank.epoch & 1u);
+  ++bank.epoch;
+  return retired;
+}
+
+void zeroBankLikeReader(CollStatValue* values, uint32_t slots) {
+  std::memset(
+      values, 0, static_cast<std::size_t>(slots) * sizeof(CollStatValue));
+}
+
+// The minimum rides an atomicMax on the complement so a zeroed bank reads as
+// unset; check both the unset case and that it tracks the smallest duration.
+TEST(CollStatsFinalizeTest, MinimumIsExactAndUnsetOnAZeroedValue) {
+  CollStatValue v{};
+  EXPECT_EQ(collStatDurMinNs(v), 0ull) << "zeroed bank must read as no data";
+
+  collStatAccumulate(&v, 5'000ull, 128);
+  collStatAccumulate(&v, 900ull, 128);
+  collStatAccumulate(&v, 70'000ull, 128);
+
+  EXPECT_EQ(collStatDurMinNs(v), 900ull);
+  EXPECT_EQ(v.durMaxNs, 70'000ull);
+}
+
+TEST(CollStatsFinalizeTest, AccumulateAggregatesScalarsAndThresholds) {
+  CollStatValue v{};
+  // Durations chosen so the exceed-counts are hand-derivable against the
+  // default thresholds {1s, 10s, 60s, 600s}.
+  const std::vector<uint64_t> durs = {
+      kSec / 2, 2 * kSec, 15 * kSec, 70 * kSec, 700 * kSec};
+  const uint64_t bytesEach = 1000;
+  uint64_t expectedSum = 0;
+  for (uint64_t d : durs) {
+    collStatAccumulate(&v, d, bytesEach);
+    expectedSum += d;
+  }
+
+  EXPECT_EQ(v.count, durs.size());
+  EXPECT_EQ(v.logicalBytes, bytesEach * durs.size());
+  EXPECT_EQ(v.durationSumNs, expectedSum);
+  EXPECT_EQ(v.durMaxNs, 700 * kSec);
+  EXPECT_EQ(histogramTotal(v), durs.size());
+
+  // Exceed-counts: >=1s -> 4, >=10s -> 3, >=60s -> 2, >=600s -> 1.
+  const std::vector<uint64_t> expectedThresholds = {4, 3, 2, 1};
+  std::vector<uint64_t> actual(
+      v.thresholdCounts, v.thresholdCounts + kMaxThresholds);
+  EXPECT_EQ(actual, expectedThresholds);
+}
+
+TEST(CollStatsFinalizeTest, HistogramBucketMatchesLogBucket) {
+  CollStatValue v{};
+  const uint64_t dur = 42 * kSec;
+  collStatAccumulate(&v, dur, 0);
+  EXPECT_EQ(v.histogram[logBucketNs(kTestGeom, dur)], 1u);
+}
+
+// Each window gets its own totals: a flip must leave the retired bank intact
+// for the reader and start the new one clean. The flip and the reset here are
+// host models of the reader's device steps (see above), so what this pins is
+// the bank/epoch contract in CollStatsBank.h, not the reader's CUDA sequence --
+// that is covered by CollStatsReaderGpuTest.
+TEST(CollStatsFinalizeTest, BanksStayIndependentAcrossAnEpochFlip) {
+  const uint32_t numKeys = 4;
+  std::vector<CollStatValue> bankA(numKeys + 1);
+  std::vector<CollStatValue> bankB(numKeys + 1);
+  CollStatDoubleBank bank{};
+  bank.numKeys = numKeys;
+  bank.epoch = 0;
+  bank.values[0] = bankA.data();
+  bank.values[1] = bankB.data();
+
+  // Window 0 writes bank A.
+  collStatAccumulate(&collStatCurrentValues(&bank)[0], 5 * kSec, 100);
+  EXPECT_EQ(bankA[0].count, 1u);
+  EXPECT_EQ(bankB[0].count, 0u);
+
+  // Flip: A retires, B becomes current.
+  const uint32_t retired = flipEpochLikeReader(bank);
+  EXPECT_EQ(retired, 0u);
+  collStatAccumulate(&collStatCurrentValues(&bank)[0], 9 * kSec, 200);
+  EXPECT_EQ(bankB[0].count, 1u);
+  EXPECT_EQ(bankA[0].count, 1u); // untouched by the new window
+
+  // Reader zeroes the retired bank; the live bank is unaffected.
+  zeroBankLikeReader(bank.values[retired], numKeys + 1);
+  EXPECT_EQ(bankA[0].count, 0u);
+  EXPECT_EQ(bankB[0].count, 1u);
+}
+
+} // namespace
+} // namespace meta::comms::collstats


### PR DESCRIPTION
Summary:

`CollStatsTypes.h` already declares the per-key `CollStatValue` layout, but nothing folds a finished collective into one and nothing holds the values across a window. This adds both.

- `collStatAccumulate` folds one observation (duration, logical bytes) into a value slot: adds for bytes and duration sum, an `atomicMax` for the per-window maximum, a second `atomicMax` on the complemented minimum, one log histogram bucket, exact counts past each threshold cut-point, and the observation count itself. Every field but the two extremes is add-only, so many device finalizers can update one bank without coordinating. The minimum is maintained with a max because it is stored bitwise-complemented -- see `CollStatValue` -- which is what lets a zero-filled bank read as "no observation" and keeps the reset a single zero fill. `count` is written last, because it is what marks a slot as populated: `collStatDurMinNs` gates on it, so anything observing a non-zero count has already observed the minimum it un-complements.
- The atomics live in one host/device header, so a host test drives the same accumulation the kernel runs. Both u64 and u32 overloads exist because `CollStatValue` mixes u64 scalars with u32 histogram and threshold arrays.
- The aggregate is two value banks plus an atomic epoch word. Finalizers write `bank[epoch]`; the readout flips the epoch and copies the retired bank. One bank has no snapshot consistency -- an async copy would race the next window's atomics. Two banks give each window its own totals, so the host never subtracts cumulative counters, and the per-window extremes stay exact because the retired bank is zeroed after copy-out.
- The flip and the reset belong to the readout and are deliberately not offered here as host helpers. The banks are device memory, so both have to run on the stream the reader owns, and a host-side reset taking a bare `CollStatValue*` would read as something callable on a live bank pointer. Selecting the current bank needs no ordering of its own either: what keeps a finalizer out of the bank being retired is the stream gating around the flip, not the memory model, so the epoch load carries no fence and costs the finalize path nothing.

Differential Revision: D113661115


