### PR TITLE
Package the copy-op roofline benchmark for GB300 MAST runs

### DIFF
--- a/comms/prims/benchmarks/CopyOpReduceBench.cc
+++ b/comms/prims/benchmarks/CopyOpReduceBench.cc
@@ -46,11 +46,12 @@ void cpAsyncSmemReduce(
   runPolicy(iters, CopyOpReducePolicy::CpAsyncSmemReduce, nbytes, counters);
 }
 
-#define REGISTER_SIZES(function)                     \
-  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 32768);  \
-  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 131072); \
-  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 524288); \
-  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 2097152)
+#define REGISTER_SIZES(function)                        \
+  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 2097152);   \
+  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 8388608);   \
+  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 33554432);  \
+  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 134217728); \
+  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 268435456)
 
 REGISTER_SIZES(tileReduceStaged);
 REGISTER_SIZES(cpAsyncSmemReduce);

--- a/comms/prims/benchmarks/CopyOpReduceBench.cu
+++ b/comms/prims/benchmarks/CopyOpReduceBench.cu
@@ -14,11 +14,11 @@
 namespace comms::prims::benchmark {
 namespace {
 
-constexpr int kBlockSize = 384;
+constexpr int kBlockSize = 640;
 constexpr int kBlocks = 1;
 
-using StagedPolicy = TileReduceStaged<float, SumOp, 24576, kBlockSize>;
-using SmemPolicy = CpAsyncSmemReduce<float, SumOp, 8192, kBlockSize, 2>;
+using StagedPolicy = TileReduceStaged<float, SumOp, 15360, kBlockSize>;
+using SmemPolicy = CpAsyncSmemReduce<float, SumOp, 10240, kBlockSize, 2>;
 
 template <typename Policy>
 __global__ void reduceKernel(


### PR DESCRIPTION
Summary:
`copy_op_reduce_bench` measures the memory roofline of a single CTA — the
ceiling that bounds every 1-SM collective. It could only be run on a local
devgpu, so there was no way to get the number on GB300, which is where the
1-SM AllReduce work is targeted. This makes the benchmark launchable on GB300
through MAST.

Four changes:

- **Register the benchmark with the pipes launcher.** Adds `copy_op_reduce` to
  `ALL_BENCHMARKS` in `pipes_benchmark_def_build.bzl` and to the `BENCHMARKS`
  resource map in `pipes_benchmark_launcher.py`. These two registries must stay
  in sync — the launcher resolves the resource name as `<key> + "_benchmark"`,
  so a key present in one and absent from the other fails at run time rather
  than build time.

- **Correct the GB300 launcher's nvcc arch.** `pipes_benchmark_launcher_gb300`
  built with `fbcode.nvcc_arch=b300`; GB300 needs `b300a`.

- **Gate the run on an idle host, via NVML directly.** A roofline measurement
  is only meaningful on a quiet GPU, and a benchmark that silently reports a
  contended number is worse than one that refuses to run. The MAST image has no
  `nvidia-smi`, so the check goes through `libnvidia-ml.so.1` with `ctypes`: it
  logs every physical GPU's index, name, utilization and memory, enumerates
  compute processes, and requires utilization <= 1% with no compute processes,
  waiting up to ~30s for the host to settle before aborting.

- **Move the default message sizes above L2.** The registered sizes were 32 KiB
  to 2 MiB, which on GB300 sit inside L2 and measure cache bandwidth rather than
  the HBM roof. They now run 2 MiB to 256 MiB. Block size moves 384 -> 640
  threads with the tile sizes retuned to match (`TileReduceStaged` 24576 ->
  15360 elements, `CpAsyncSmemReduce` 8192 -> 10240), which is where throughput
  plateaus on this part.

Reviewer note: `verify_gpus_idle_with_nvml()` is currently called
unconditionally on every rank. That is correct for the single-rank roofline runs
this diff enables, but it will abort a legitimate multi-rank benchmark
(`--ppn 8`) where sibling ranks already hold GPUs, and ranks racing the check
against each other's CUDA init can trip it. If we intend other benchmarks to
keep using this launcher unchanged, the gate should become opt-in
(`--require-idle-gpus`) before this lands. Happy to make that change — flagging
rather than assuming.

Differential Revision: D116319368


