### PR TITLE
Parameterize the copy-op roofline over six memory access shapes

### DIFF
--- a/comms/prims/benchmarks/CopyOpReduceBench.cc
+++ b/comms/prims/benchmarks/CopyOpReduceBench.cc
@@ -14,47 +14,102 @@
 namespace comms::prims::benchmark {
 namespace {
 
-void runPolicy(
+/*
+ * Cache-resident point: 4 MiB per operand, well inside B300's ~126 MB L2 and a
+ * whole multiple of every tile size in the sweep. A truly L1-resident run is
+ * not achievable at production tile widths -- one tile alone is 61 KiB per
+ * operand at vpt=6 and 123 KiB at vpt=12, so three operands already exceed the
+ * 256 KB L1 before any pipelining. The in-kernel repeat count keeps per-launch
+ * overhead out of the measurement.
+ */
+constexpr std::size_t kL2Bytes = 4194304;
+constexpr int kL2Repeats = 16;
+
+// HBM-resident point: far outside the ~126 MB L2.
+constexpr std::size_t kHbmBytes = 268435456;
+constexpr int kHbmRepeats = 1;
+
+void runPoint(
     unsigned int iters,
-    CopyOpReducePolicy policy,
+    CopyOpReduceShape shape,
+    int threads,
+    int vpt,
     std::size_t nbytes,
+    int repeats,
     folly::UserCounters& counters) {
   folly::BenchmarkSuspender suspender;
   suspender.dismiss();
-  const auto timing =
-      runCopyOpReduceBenchmark(policy, nbytes, static_cast<int>(iters));
+  const auto timing = runCopyOpReduceBenchmark(
+      shape, nbytes, static_cast<int>(iters), threads, vpt, repeats);
   suspender.rehire();
   counters["deviceTimeUs"] =
       folly::UserMetric(timing.timeUs, folly::UserMetric::Type::METRIC);
-  counters["payloadGBps"] =
-      folly::UserMetric(timing.payloadGBps, folly::UserMetric::Type::METRIC);
   counters["memoryGBps"] =
       folly::UserMetric(timing.memoryGBps, folly::UserMetric::Type::METRIC);
+  counters["payloadGBps"] =
+      folly::UserMetric(timing.payloadGBps, folly::UserMetric::Type::METRIC);
+  // Measured bytes/clock -- no assumed boost clock anywhere in this number.
+  counters["bytesPerClk"] =
+      folly::UserMetric(timing.bytesPerClock, folly::UserMetric::Type::METRIC);
 }
 
-void tileReduceStaged(
-    unsigned int iters,
-    std::size_t nbytes,
-    folly::UserCounters& counters) {
-  runPolicy(iters, CopyOpReducePolicy::TileReduceStaged, nbytes, counters);
-}
+/*
+ * Names encode shape / threads / vpt / residency:
+ *   unf|fus|rdo|pip  _  t<threads>  _  v<vpt>  _  l1|hbm
+ * Keep the (threads, vpt) pairs in sync with COPY_OP_REDUCE_CONFIGS in
+ * CopyOpReduceBench.cu -- an unlisted pair throws at launch.
+ */
+#define DEFINE_POINT(TAG, SHAPE, THREADS, VPT)                          \
+  void TAG##_t##THREADS##_v##VPT##_l2(                                  \
+      unsigned int iters, std::size_t, folly::UserCounters& counters) { \
+    runPoint(                                                           \
+        iters,                                                          \
+        CopyOpReduceShape::SHAPE,                                       \
+        THREADS,                                                        \
+        VPT,                                                            \
+        kL2Bytes,                                                       \
+        kL2Repeats,                                                     \
+        counters);                                                      \
+  }                                                                     \
+  void TAG##_t##THREADS##_v##VPT##_hbm(                                 \
+      unsigned int iters, std::size_t, folly::UserCounters& counters) { \
+    runPoint(                                                           \
+        iters,                                                          \
+        CopyOpReduceShape::SHAPE,                                       \
+        THREADS,                                                        \
+        VPT,                                                            \
+        kHbmBytes,                                                      \
+        kHbmRepeats,                                                    \
+        counters);                                                      \
+  }
 
-void cpAsyncSmemReduce(
-    unsigned int iters,
-    std::size_t nbytes,
-    folly::UserCounters& counters) {
-  runPolicy(iters, CopyOpReducePolicy::CpAsyncSmemReduce, nbytes, counters);
-}
+#define DEFINE_ALL_SHAPES(THREADS, VPT)      \
+  DEFINE_POINT(unf, Unfused, THREADS, VPT)   \
+  DEFINE_POINT(fus, Fused, THREADS, VPT)     \
+  DEFINE_POINT(rdo, ReadOnly, THREADS, VPT)  \
+  DEFINE_POINT(wro, WriteOnly, THREADS, VPT) \
+  DEFINE_POINT(cpy, Copy, THREADS, VPT)      \
+  DEFINE_POINT(pip, Pipelined, THREADS, VPT)
 
-#define REGISTER_SIZES(function)                        \
-  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 2097152);   \
-  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 8388608);   \
-  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 33554432);  \
-  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 134217728); \
-  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 268435456)
+DEFINE_ALL_SHAPES(640, 6)
+DEFINE_ALL_SHAPES(640, 12)
+DEFINE_ALL_SHAPES(1024, 6)
 
-REGISTER_SIZES(tileReduceStaged);
-REGISTER_SIZES(cpAsyncSmemReduce);
+#define REGISTER_POINT(TAG, THREADS, VPT)                             \
+  BENCHMARK_SINGLE_PARAM_COUNTERS(TAG##_t##THREADS##_v##VPT##_l2, 0); \
+  BENCHMARK_SINGLE_PARAM_COUNTERS(TAG##_t##THREADS##_v##VPT##_hbm, 0)
+
+#define REGISTER_ALL_SHAPES(THREADS, VPT) \
+  REGISTER_POINT(unf, THREADS, VPT);      \
+  REGISTER_POINT(fus, THREADS, VPT);      \
+  REGISTER_POINT(rdo, THREADS, VPT);      \
+  REGISTER_POINT(wro, THREADS, VPT);      \
+  REGISTER_POINT(cpy, THREADS, VPT);      \
+  REGISTER_POINT(pip, THREADS, VPT)
+
+REGISTER_ALL_SHAPES(640, 6);
+REGISTER_ALL_SHAPES(640, 12);
+REGISTER_ALL_SHAPES(1024, 6);
 
 } // namespace
 } // namespace comms::prims::benchmark

--- a/comms/prims/benchmarks/CopyOpReduceBench.cc
+++ b/comms/prims/benchmarks/CopyOpReduceBench.cc
@@ -46,11 +46,12 @@ void cpAsyncSmemReduce(
   runPolicy(iters, CopyOpReducePolicy::CpAsyncSmemReduce, nbytes, counters);
 }
 
-#define REGISTER_SIZES(function)                     \
-  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 32768);  \
-  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 131072); \
-  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 524288); \
-  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 2097152)
+#define REGISTER_SIZES(function)                        \
+  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 2097152);   \
+  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 8388608);   \
+  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 33554432);  \
+  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 134217728); \
+  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 268435456)
 
 REGISTER_SIZES(tileReduceStaged);
 REGISTER_SIZES(cpAsyncSmemReduce);

--- a/comms/prims/benchmarks/CopyOpReduceBench.cu
+++ b/comms/prims/benchmarks/CopyOpReduceBench.cu
@@ -14,119 +14,337 @@
 namespace comms::prims::benchmark {
 namespace {
 
-constexpr int kBlockSize = 640;
 constexpr int kBlocks = 1;
+// fp32 packed into 16-byte vectors.
+constexpr int kElemsPerVec = 4;
 
-using StagedPolicy = TileReduceStaged<float, SumOp, 15360, kBlockSize>;
-using SmemPolicy = CpAsyncSmemReduce<float, SumOp, 10240, kBlockSize, 2>;
+/*
+ * (threads, vectors-per-thread) points the sweep instantiates.
+ *
+ * vpt is the memory-level-parallelism knob. The unfused and pipelined shapes
+ * keep 2 * vpt sixteen-byte loads live, costing 8 * vpt registers against the
+ * 65536 / threads budget __launch_bounds__ grants -- 102 registers at 640
+ * threads, so vpt=12 (96) is the last point expected to fit.
+ */
+#define COPY_OP_REDUCE_CONFIGS(X) \
+  X(640, 6)                       \
+  X(640, 12)                      \
+  X(1024, 6)
 
-template <typename Policy>
-__global__ void reduceKernel(
-    float* output,
-    const float* staging,
-    const float* local,
-    std::size_t nbytes) {
-  auto group = make_block_group();
+// Nominal bytes of HBM traffic per payload byte, per shape. "Nominal" because
+// a store may cost more than one byte if the line is not already resident;
+// separating that from a store-port limit is what WriteOnly is for.
+__host__ __device__ inline float shape_multiplier(CopyOpReduceShape shape) {
+  switch (shape) {
+    // Stores only the final tile, so write traffic is ~0.
+    case CopyOpReduceShape::ReadOnly:
+      return 2.0f;
+    // One hoisted load, then stores only.
+    case CopyOpReduceShape::WriteOnly:
+      return 1.0f;
+    // One load + one store per payload byte.
+    case CopyOpReduceShape::Copy:
+      return 2.0f;
+    default:
+      return 3.0f;
+  }
+}
+
+// ---------------------------------------------------------------- shapes
+
+template <int kThreads, int kVpt>
+__device__ __forceinline__ void body_unfused(
+    float* out,
+    const float* a,
+    const float* b,
+    std::size_t nbytes,
+    ThreadGroup& group) {
+  constexpr int kTileElems = kThreads * kVpt * kElemsPerVec;
+  using Policy = TileReduceStaged<float, SumOp, kTileElems, kThreads>;
   Policy::recv(
-      reinterpret_cast<char*>(output),
-      reinterpret_cast<const char*>(staging),
+      reinterpret_cast<char*>(out),
+      reinterpret_cast<const char*>(a),
       nbytes,
       group,
       0,
-      reinterpret_cast<const char*>(local));
+      reinterpret_cast<const char*>(b));
 }
 
-void checkCuda(cudaError_t status, const char* operation) {
+/*
+ * Production shape. Full tiles use the UNMASKED tile_load overload, matching
+ * tileReduceCopy in AllReduceIbRingImpl.cuh; only the tail passes `valid`. An
+ * earlier revision of this benchmark passed `valid` on every tile, which made
+ * the fused numbers unusable on sm_103a.
+ */
+template <int kThreads, int kVpt>
+__device__ __forceinline__ void body_fused(
+    float* out,
+    const float* a,
+    const float* b,
+    std::size_t nbytes,
+    ThreadGroup& group) {
+  constexpr int kTileElems = kThreads * kVpt * kElemsPerVec;
+  const std::size_t nelems = nbytes / sizeof(float);
+  const std::size_t nFull = nelems / kTileElems;
+  const std::size_t rem = nelems % kTileElems;
+  for (std::size_t t = 0; t < nFull; t++) {
+    auto acc = tile_load<float, kTileElems, kThreads>(a, t, group);
+    tile_load_accumulate<float, SumOp, kTileElems, kThreads>(acc, b, t, group);
+    tile_store<float, kTileElems, kThreads>(out, t, acc, group);
+  }
+  if (rem > 0) {
+    auto acc = tile_load<float, kTileElems, kThreads>(a, nFull, group, rem);
+    tile_load_accumulate<float, SumOp, kTileElems, kThreads>(
+        acc, b, nFull, group, rem);
+    tile_store<float, kTileElems, kThreads>(out, nFull, acc, group, rem);
+  }
+}
+
+// Loads only; stores just the final tile so the loads cannot be eliminated.
+template <int kThreads, int kVpt>
+__device__ __forceinline__ void body_read_only(
+    float* out,
+    const float* a,
+    const float* b,
+    std::size_t nbytes,
+    ThreadGroup& group) {
+  constexpr int kTileElems = kThreads * kVpt * kElemsPerVec;
+  const std::size_t nelems = nbytes / sizeof(float);
+  const std::size_t nFull = nelems / kTileElems;
+  for (std::size_t t = 0; t < nFull; t++) {
+    auto acc = tile_load<float, kTileElems, kThreads>(a, t, group);
+    tile_load_accumulate<float, SumOp, kTileElems, kThreads>(acc, b, t, group);
+    if (t + 1 == nFull) {
+      tile_store<float, kTileElems, kThreads>(out, t, acc, group);
+    }
+  }
+}
+
+/*
+ * Stores only. One tile is loaded before the loop and restored to every tile
+ * position, so the load amortises to nothing and what remains is the store
+ * path in isolation. Addresses differ per iteration, so the store cannot be
+ * hoisted.
+ */
+template <int kThreads, int kVpt>
+__device__ __forceinline__ void body_write_only(
+    float* out,
+    const float* a,
+    const float* /*b*/,
+    std::size_t nbytes,
+    ThreadGroup& group) {
+  constexpr int kTileElems = kThreads * kVpt * kElemsPerVec;
+  const std::size_t nelems = nbytes / sizeof(float);
+  const std::size_t nFull = nelems / kTileElems;
+  if (nFull == 0) {
+    return;
+  }
+  auto acc = tile_load<float, kTileElems, kThreads>(a, 0, group);
+  for (std::size_t t = 0; t < nFull; t++) {
+    tile_store<float, kTileElems, kThreads>(out, t, acc, group);
+  }
+}
+
+/*
+ * Plain copy: one load, one store, no reduce. Its 1:1 load:store ratio is more
+ * store-heavy than the reduce shape's 2:1, so under the store-port model it
+ * should be SLOWER per byte despite doing less work.
+ */
+template <int kThreads, int kVpt>
+__device__ __forceinline__ void body_copy(
+    float* out,
+    const float* a,
+    const float* /*b*/,
+    std::size_t nbytes,
+    ThreadGroup& group) {
+  constexpr int kTileElems = kThreads * kVpt * kElemsPerVec;
+  const std::size_t nelems = nbytes / sizeof(float);
+  const std::size_t nFull = nelems / kTileElems;
+  for (std::size_t t = 0; t < nFull; t++) {
+    auto tile = tile_load<float, kTileElems, kThreads>(a, t, group);
+    tile_store<float, kTileElems, kThreads>(out, t, tile, group);
+  }
+}
+
+// Fused with the next tile's loads issued before the current tile's store.
+template <int kThreads, int kVpt>
+__device__ __forceinline__ void body_pipelined(
+    float* out,
+    const float* a,
+    const float* b,
+    std::size_t nbytes,
+    ThreadGroup& group) {
+  constexpr int kTileElems = kThreads * kVpt * kElemsPerVec;
+  const std::size_t nelems = nbytes / sizeof(float);
+  const std::size_t nFull = nelems / kTileElems;
+  if (nFull == 0) {
+    return;
+  }
+  auto acc = tile_load<float, kTileElems, kThreads>(a, 0, group);
+  tile_load_accumulate<float, SumOp, kTileElems, kThreads>(acc, b, 0, group);
+  for (std::size_t t = 0; t + 1 < nFull; t++) {
+    auto nxt = tile_load<float, kTileElems, kThreads>(a, t + 1, group);
+    tile_store<float, kTileElems, kThreads>(out, t, acc, group);
+    tile_load_accumulate<float, SumOp, kTileElems, kThreads>(
+        nxt, b, t + 1, group);
+    acc = nxt;
+  }
+  tile_store<float, kTileElems, kThreads>(out, nFull - 1, acc, group);
+}
+
+// ---------------------------------------------------------------- kernel
+
+template <CopyOpReduceShape kShape, int kThreads, int kVpt>
+__global__ __launch_bounds__(kThreads, 1) void roofline_kernel(
+    float* out,
+    const float* a,
+    const float* b,
+    std::size_t nbytes,
+    int repeats,
+    unsigned long long* cycles) {
+  auto group = make_block_group();
+  const bool timer = threadIdx.x == 0;
+  group.sync();
+  const unsigned long long begin = timer ? clock64() : 0ULL;
+
+  for (int r = 0; r < repeats; r++) {
+    if constexpr (kShape == CopyOpReduceShape::Unfused) {
+      body_unfused<kThreads, kVpt>(out, a, b, nbytes, group);
+    } else if constexpr (kShape == CopyOpReduceShape::Fused) {
+      body_fused<kThreads, kVpt>(out, a, b, nbytes, group);
+    } else if constexpr (kShape == CopyOpReduceShape::ReadOnly) {
+      body_read_only<kThreads, kVpt>(out, a, b, nbytes, group);
+    } else if constexpr (kShape == CopyOpReduceShape::WriteOnly) {
+      body_write_only<kThreads, kVpt>(out, a, b, nbytes, group);
+    } else if constexpr (kShape == CopyOpReduceShape::Copy) {
+      body_copy<kThreads, kVpt>(out, a, b, nbytes, group);
+    } else {
+      body_pipelined<kThreads, kVpt>(out, a, b, nbytes, group);
+    }
+  }
+
+  group.sync();
+  if (timer) {
+    *cycles = clock64() - begin;
+  }
+}
+
+void check_cuda(cudaError_t status, const char* operation) {
   if (status != cudaSuccess) {
     throw std::runtime_error(
         std::string(operation) + ": " + cudaGetErrorString(status));
   }
 }
 
-void launchPolicy(
-    CopyOpReducePolicy policy,
-    float* output,
-    const float* staging,
-    const float* local,
+void launch(
+    CopyOpReduceShape shape,
+    int threads,
+    int vpt,
+    float* out,
+    const float* a,
+    const float* b,
     std::size_t nbytes,
-    std::size_t dynamicSmem) {
-  switch (policy) {
-    case CopyOpReducePolicy::TileReduceStaged:
-      reduceKernel<StagedPolicy>
-          <<<kBlocks, kBlockSize>>>(output, staging, local, nbytes);
-      return;
-    case CopyOpReducePolicy::CpAsyncSmemReduce:
-      reduceKernel<SmemPolicy><<<kBlocks, kBlockSize, dynamicSmem>>>(
-          output, staging, local, nbytes);
-      return;
+    int repeats,
+    unsigned long long* cycles) {
+#define COPY_OP_REDUCE_SHAPE_CASE(SHAPE, T, V)                \
+  if (shape == CopyOpReduceShape::SHAPE) {                    \
+    roofline_kernel<CopyOpReduceShape::SHAPE, T, V>           \
+        <<<kBlocks, T>>>(out, a, b, nbytes, repeats, cycles); \
+    return;                                                   \
   }
-  throw std::invalid_argument("unknown CopyOp reduce policy");
-}
-
-std::size_t smemForPolicy(CopyOpReducePolicy policy) {
-  return policy == CopyOpReducePolicy::CpAsyncSmemReduce
-      ? SmemPolicy::smem_bytes()
-      : 0;
+#define COPY_OP_REDUCE_DISPATCH(T, V)          \
+  if (threads == (T) && vpt == (V)) {          \
+    COPY_OP_REDUCE_SHAPE_CASE(Unfused, T, V)   \
+    COPY_OP_REDUCE_SHAPE_CASE(Fused, T, V)     \
+    COPY_OP_REDUCE_SHAPE_CASE(ReadOnly, T, V)  \
+    COPY_OP_REDUCE_SHAPE_CASE(WriteOnly, T, V) \
+    COPY_OP_REDUCE_SHAPE_CASE(Copy, T, V)      \
+    COPY_OP_REDUCE_SHAPE_CASE(Pipelined, T, V) \
+  }
+  COPY_OP_REDUCE_CONFIGS(COPY_OP_REDUCE_DISPATCH)
+#undef COPY_OP_REDUCE_DISPATCH
+#undef COPY_OP_REDUCE_SHAPE_CASE
+  throw std::invalid_argument(
+      "unsupported (threads, vpt): " + std::to_string(threads) + ", " +
+      std::to_string(vpt));
 }
 
 } // namespace
 
 CopyOpReduceTiming runCopyOpReduceBenchmark(
-    CopyOpReducePolicy policy,
+    CopyOpReduceShape shape,
     std::size_t nbytes,
-    int iterations) {
-  const std::size_t allocationBytes = nbytes * kBlocks;
-  meta::comms::DeviceBuffer staging(allocationBytes);
-  meta::comms::DeviceBuffer local(allocationBytes);
-  meta::comms::DeviceBuffer output(allocationBytes);
-  checkCuda(
-      cudaMemset(staging.get(), 1, allocationBytes), "initialize staging");
-  checkCuda(cudaMemset(local.get(), 2, allocationBytes), "initialize local");
-
-  const std::size_t dynamicSmem = smemForPolicy(policy);
-  if (dynamicSmem > 0) {
-    checkCuda(
-        cudaFuncSetAttribute(
-            reduceKernel<SmemPolicy>,
-            cudaFuncAttributeMaxDynamicSharedMemorySize,
-            static_cast<int>(dynamicSmem)),
-        "set dynamic shared memory");
+    int iterations,
+    int threads,
+    int vpt,
+    int repeats) {
+  const int tileBytes =
+      threads * vpt * kElemsPerVec * static_cast<int>(sizeof(float));
+  if (nbytes < static_cast<std::size_t>(tileBytes)) {
+    throw std::invalid_argument(
+        "nbytes " + std::to_string(nbytes) + " is smaller than one tile (" +
+        std::to_string(tileBytes) + "); the kernel would measure nothing");
   }
 
-  auto* outputPtr = static_cast<float*>(output.get());
-  const auto* stagingPtr = static_cast<const float*>(staging.get());
-  const auto* localPtr = static_cast<const float*>(local.get());
+  meta::comms::DeviceBuffer a(nbytes);
+  meta::comms::DeviceBuffer b(nbytes);
+  meta::comms::DeviceBuffer out(nbytes);
+  meta::comms::DeviceBuffer cycleBuf(sizeof(unsigned long long));
+  check_cuda(cudaMemset(a.get(), 1, nbytes), "initialize a");
+  check_cuda(cudaMemset(b.get(), 2, nbytes), "initialize b");
+
+  auto* outPtr = static_cast<float*>(out.get());
+  const auto* aPtr = static_cast<const float*>(a.get());
+  const auto* bPtr = static_cast<const float*>(b.get());
+  auto* cyclePtr = static_cast<unsigned long long*>(cycleBuf.get());
 
   cudaEvent_t start{};
   cudaEvent_t stop{};
-  checkCuda(cudaEventCreate(&start), "create start event");
-  checkCuda(cudaEventCreate(&stop), "create stop event");
+  check_cuda(cudaEventCreate(&start), "create start event");
+  check_cuda(cudaEventCreate(&stop), "create stop event");
 
-  launchPolicy(policy, outputPtr, stagingPtr, localPtr, nbytes, dynamicSmem);
-  checkCuda(cudaGetLastError(), "warmup launch");
-  checkCuda(cudaDeviceSynchronize(), "warmup synchronize");
+  launch(shape, threads, vpt, outPtr, aPtr, bPtr, nbytes, repeats, cyclePtr);
+  check_cuda(cudaGetLastError(), "warmup launch");
+  check_cuda(cudaDeviceSynchronize(), "warmup synchronize");
 
-  checkCuda(cudaEventRecord(start), "record start");
+  check_cuda(cudaEventRecord(start), "record start");
   for (int iteration = 0; iteration < iterations; ++iteration) {
-    launchPolicy(policy, outputPtr, stagingPtr, localPtr, nbytes, dynamicSmem);
-    checkCuda(cudaGetLastError(), "benchmark launch");
+    launch(shape, threads, vpt, outPtr, aPtr, bPtr, nbytes, repeats, cyclePtr);
+    check_cuda(cudaGetLastError(), "benchmark launch");
   }
-  checkCuda(cudaEventRecord(stop), "record stop");
-  checkCuda(cudaEventSynchronize(stop), "benchmark synchronize");
+  check_cuda(cudaEventRecord(stop), "record stop");
+  check_cuda(cudaEventSynchronize(stop), "benchmark synchronize");
 
   float elapsedMs = 0;
-  checkCuda(cudaEventElapsedTime(&elapsedMs, start, stop), "measure elapsed");
-  checkCuda(cudaEventDestroy(stop), "destroy stop event");
-  checkCuda(cudaEventDestroy(start), "destroy start event");
+  check_cuda(cudaEventElapsedTime(&elapsedMs, start, stop), "measure elapsed");
+  check_cuda(cudaEventDestroy(stop), "destroy stop event");
+  check_cuda(cudaEventDestroy(start), "destroy start event");
 
-  const float operations = static_cast<float>(iterations);
-  const float timeUs = elapsedMs * 1000.0f / operations;
+  unsigned long long cycles = 0;
+  check_cuda(
+      cudaMemcpy(&cycles, cyclePtr, sizeof(cycles), cudaMemcpyDeviceToHost),
+      "read cycle counter");
+
+  const float timeUs = elapsedMs * 1000.0f / static_cast<float>(iterations);
+  // One launch touches nbytes * repeats of payload.
+  const double payloadBytes =
+      static_cast<double>(nbytes) * static_cast<double>(repeats);
   const float payloadGBps =
-      static_cast<float>(allocationBytes) / 1000.0f / timeUs;
+      static_cast<float>(payloadBytes / 1000.0 / static_cast<double>(timeUs));
+  const float memoryGBps = shape_multiplier(shape) * payloadGBps;
+  // Measured, not assumed: SM-issued bytes divided by SM cycles for one launch.
+  const float bytesPerClock = cycles == 0
+      ? 0.0f
+      : static_cast<float>(
+            payloadBytes * shape_multiplier(shape) /
+            static_cast<double>(cycles));
+
   return CopyOpReduceTiming{
       .timeUs = timeUs,
       .payloadGBps = payloadGBps,
-      .memoryGBps = 3.0f * payloadGBps,
+      .memoryGBps = memoryGBps,
+      .bytesPerClock = bytesPerClock,
+      .cycles = cycles,
   };
 }
 

--- a/comms/prims/benchmarks/CopyOpReduceBench.cu
+++ b/comms/prims/benchmarks/CopyOpReduceBench.cu
@@ -14,11 +14,11 @@
 namespace comms::prims::benchmark {
 namespace {
 
-constexpr int kBlockSize = 384;
+constexpr int kBlockSize = 640;
 constexpr int kBlocks = 1;
 
-using StagedPolicy = TileReduceStaged<float, SumOp, 24576, kBlockSize>;
-using SmemPolicy = CpAsyncSmemReduce<float, SumOp, 8192, kBlockSize, 2>;
+using StagedPolicy = TileReduceStaged<float, SumOp, 15360, kBlockSize>;
+using SmemPolicy = CpAsyncSmemReduce<float, SumOp, 10240, kBlockSize, 2>;
 
 template <typename Policy>
 __global__ void reduceKernel(

--- a/comms/prims/benchmarks/CopyOpReduceBench.cuh
+++ b/comms/prims/benchmarks/CopyOpReduceBench.cuh
@@ -6,20 +6,78 @@
 
 namespace comms::prims::benchmark {
 
-enum class CopyOpReducePolicy {
-  TileReduceStaged,
-  CpAsyncSmemReduce,
+/**
+ * Access shape of the single-CTA memory-roofline kernel.
+ *
+ * Unfused   two live tiles (TileReduceStaged::recv). 3 bytes moved per payload
+ *           byte: 2 reads + 1 write.
+ * Fused     one live tile plus a streaming tile_load_accumulate, matching
+ *           production's RingReduceForwardCopy -> tileReduceCopy. Full tiles
+ *           take the UNMASKED tile_load path exactly as production does; only
+ *           the remainder tile passes `valid`.
+ * ReadOnly  loads only, storing just the final tile so the compiler cannot
+ *           eliminate them. ~2 bytes per payload byte -- isolates load issue
+ *           rate from store-port contention and the load->add->store chain.
+ * WriteOnly One load hoisted out of the loop, then stores only. 1 byte per
+ *           payload byte. Together with ReadOnly this brackets the mixed shape:
+ *           if time splits across a load port L and a store port S, then
+ *           3/rate = 2/L + 1/S. With L = 120 B/clk and the mixed shape at
+ *           60 B/clk that predicts S ~= 30 B/clk. A materially higher S
+ *           (~60 B/clk) instead implicates write-allocate -- stores costing two
+ *           bytes of real traffic each -- rather than a narrow store port.
+ * Copy      One load, one store per element, no reduce. 2 bytes per payload
+ *           byte at a 1:1 load:store ratio -- more store-heavy than the 2:1
+ *           reduce shape. The port model (3/rate = 2/L + 1/S generalised to
+ *           n/rate = r/L + w/S) therefore predicts Copy lands BELOW the reduce
+ *           shape despite doing strictly less work per byte: ~50 B/clk against
+ *           the reduce's ~60. Confirming that inversion is the sharpest
+ *           available test of the store-port model.
+ * Pipelined Fused with the next tile's loads issued before the current tile's
+ *           store, i.e. the double-buffer idiom documented in CopyOp.cuh that
+ *           TileReduceStaged::recv does not use. Tests whether the per-tile
+ *           latency bubble, rather than issue rate, is what caps R_copy.
+ */
+enum class CopyOpReduceShape {
+  Unfused,
+  Fused,
+  ReadOnly,
+  WriteOnly,
+  Copy,
+  Pipelined,
 };
 
 struct CopyOpReduceTiming {
   float timeUs;
   float payloadGBps;
+  /** SM-issued HBM traffic, i.e. R_copy. Shape-dependent multiplier. */
   float memoryGBps;
+  /** memoryGBps divided by the MEASURED SM clock -- no assumed boost clock. */
+  float bytesPerClock;
+  /** SM cycles for one kernel launch, from in-kernel clock64(). */
+  unsigned long long cycles;
 };
 
+/**
+ * Single-CTA memory roofline.
+ *
+ * @param shape      access shape, see CopyOpReduceShape
+ * @param nbytes     payload bytes per operand buffer. Sized below ~85 KB the
+ *                   working set is L1-resident, which removes memory latency
+ *                   and leaves the pure issue-rate roof.
+ * @param iterations timed launches
+ * @param threads    threads per block; the launch is always <<<1, threads>>>
+ * @param vpt        16-byte vectors per thread per tile -- the memory-level
+ *                   parallelism knob. kTileElems = threads * vpt * 4 for fp32.
+ * @param repeats    in-kernel passes over the buffer. Needed at L1-resident
+ *                   sizes, where a single pass is short enough that per-launch
+ *                   overhead would dominate the measurement.
+ */
 CopyOpReduceTiming runCopyOpReduceBenchmark(
-    CopyOpReducePolicy policy,
+    CopyOpReduceShape shape,
     std::size_t nbytes,
-    int iterations);
+    int iterations,
+    int threads,
+    int vpt,
+    int repeats);
 
 } // namespace comms::prims::benchmark


### PR DESCRIPTION
Summary:
The benchmark measured one thing: a fused 2-read/1-write reduce, at a fixed
block size. That yields a single number (~124 GB/s on GB300) with no way to
attribute it. This diff turns it into an instrument that can say *why* a single
CTA stops where it does, by sweeping the access shape while holding everything
else fixed.

Six shapes, selected at run time, all launched as `<<<1, threads>>>`:

| Shape | Loads | Stores | Isolates |
|---|---|---|---|
| `Unfused` | 2N | 1N | separate load-then-reduce, two live tiles |
| `Fused` | 2N | 1N | production's `tileReduceCopy` inner loop |
| `ReadOnly` | 2N | 0 | the load path alone |
| `WriteOnly` | 0 | 1N | the store path alone |
| `Copy` | 1N | 1N | a more store-heavy mix than the reduce |
| `Pipelined` | 2N | 1N | whether a per-tile latency bubble exists |

`ReadOnly` and `WriteOnly` bracket the mixed shapes: if time splits across a
load port L and a store port S, an r:w mix satisfies `n/rate = r/L + w/S`.
`Copy` is the sharp test of that model — being 1:1 rather than 2:1 it is *more*
store-heavy than the reduce, so the model predicts it lands **below** the reduce
despite moving fewer bytes per payload byte. No model in which all bytes cost
the same can produce that inversion.

Also in this diff:

- **The fused body now matches production exactly.** Full tiles take the
  unmasked `tile_load` overload, as `tileReduceCopy` does; only the remainder
  tile passes `valid`. Passing `valid` on every tile costs roughly 2x and would
  have made the benchmark measure something production never executes.
- **`__launch_bounds__(kThreads, 1)`.** Without it the register budget is set
  for occupancy the launch never uses, capping in-flight loads and
  under-reporting the roof.
- **Thread count and vectors-per-thread are swept**, not hard-coded:
  (640, 6), (640, 12), (1024, 6). `vpt` is the memory-level-parallelism knob —
  each thread holds that many 16-byte vectors per tile in registers, so it sets
  how many independent loads a thread can have in flight.
- **Reported metrics.** Payload GB/s, nominal SM-issued GB/s, bytes per clock
  from the *measured* SM clock rather than an assumed boost clock, and raw
  cycles from in-kernel `clock64()`. `memoryGBps` is explicitly nominal —
  payload times a source-defined per-shape multiplier — since only time and
  cycles are measured.
- **Guard against measuring nothing.** The kernel throws if `nbytes` is smaller
  than a single tile; previously that produced `nFull == 0`, an empty loop, and
  a meaningless multi-TB/s result.

Differential Revision: D116319367


