### PR TITLE
Align iter NCCLX build with feedstock C++20

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -289,6 +289,17 @@ if [[ -z "${NCCL_SKIP_CONDA_INSTALL}" ]]; then
   conda install pyyaml --yes
 fi
 
+if [[ "${NCCL_PATCH_FMT_NVCC_CXX20:-0}" == "1" ]]; then
+  # fmt 9.1.0 disables relaxed constexpr under NVCC, which conflicts with its
+  # C++20-only constexpr APIs. This mirrors fmtlib PR #3544 and must run after
+  # dependency installation because conda may replace fmt/core.h above.
+  sed -i 's#!FMT_ICC_VERSION && !defined(__NVCC__)$#!FMT_ICC_VERSION \&\& (!defined(__NVCC__) || FMT_CPLUSPLUS >= 202002L)#' "${CONDA_PREFIX}/include/fmt/core.h"
+  grep -qF '!FMT_ICC_VERSION && (!defined(__NVCC__) || FMT_CPLUSPLUS >= 202002L)' "${CONDA_PREFIX}/include/fmt/core.h" || {
+    echo "ERROR: fmt PR#3544 patch did not apply to ${CONDA_PREFIX}/include/fmt/core.h" >&2
+    exit 1
+  }
+fi
+
 # Run the extractcvars.py script directly to generate the files
 export NCCL_CVARS_OUTPUT_DIR="$CVARS_DIR"
 python3 "$CVARS_DIR/extractcvars.py"


### PR DESCRIPTION
Summary:
The TorchComms iter build rebuilds NCCLX inside a fetched conda environment but did not carry over the NCCLX feedstock C++20 compatibility setup. The recursive device Makefile therefore fell back to C++17, causing C++20-only headers such as defaulted comparisons to fail.

Match the feedstock by exporting CXXSTD=-std=c++20 and applying fmt PR #3544 after build_ncclx.sh finishes all Conda dependency transactions. Keeping dependency installation is necessary for clean iter environments, which do not contain Folly; applying the fmt patch afterward prevents Conda from overwriting it.

Reviewed By: function47

Differential Revision: D116070159


