### PR TITLE
Remove unused type error suppressions - comms

### DIFF
--- a/comms/ncclx/meta/benchmarks/nccl_comm_memory_runner.py
+++ b/comms/ncclx/meta/benchmarks/nccl_comm_memory_runner.py
@@ -1,7 +1,5 @@
-from comms.testinfra.multiproc_benchmark_runner import (  # pyre-ignore
-    run_nccl_distributed_test,
-)
-from windtunnel.benchmarks.python_benchmark_runner.benchmark import (  # pyre-ignore
+from comms.testinfra.multiproc_benchmark_runner import run_nccl_distributed_test
+from windtunnel.benchmarks.python_benchmark_runner.benchmark import (
     main as servicelab_main,
     register_benchmark,
     UserCounters,
@@ -14,7 +12,7 @@ SEARCH_PATTERN = r"NCCL Comm Memory:\s*([\d.]+)\s*MB"
 
 
 @register_benchmark(use_counters=True)
-def ncclCommMemoryMB(counters: UserCounters) -> None:  # pyre-ignore
+def ncclCommMemoryMB(counters: UserCounters) -> None:
     for ppn in [1, 4]:
         target = f"{TARGET_PREFIX}{ppn}"
         memory_mb = run_nccl_distributed_test(target, SEARCH_PATTERN)

--- a/comms/ncclx/meta/tests/ReductionNumericalMastCompareLauncher.py
+++ b/comms/ncclx/meta/tests/ReductionNumericalMastCompareLauncher.py
@@ -23,9 +23,9 @@ from comms.ncclx.meta.tests.ReductionNumericalVersionCompare import (
     parse_actual_outputs,
     print_numerical_failure_summary,
 )
-from torchx.components.fb.dist import hpc as fb_dist_hpc  # pyre-ignore[21]
+from torchx.components.fb.dist import hpc as fb_dist_hpc
 from torchx.runner import get_runner  # pyre-ignore[21]
-from torchx.specs import CfgVal, named_resources  # pyre-ignore[21]
+from torchx.specs import CfgVal, named_resources
 
 logger: logging.Logger = logging.getLogger(__name__)
 

--- a/comms/prims/collectives/link_ep/link_ep/buffer.py
+++ b/comms/prims/collectives/link_ep/link_ep/buffer.py
@@ -127,7 +127,6 @@ class Buffer:
             self.group_size = group.size()
 
             def _all_gather_object_group(obj: object) -> list[object]:
-                # pyre-ignore[9]: None pre-fill, overwritten by all_gather_object
                 object_list: list[object] = [None] * self.group_size
                 dist.all_gather_object(object_list, obj, group)
                 return object_list
@@ -222,12 +221,10 @@ class Buffer:
                 "destroy() requires `explicitly_destroy=True` at construction"
             )
         self.runtime.destroy()
-        # pyre-ignore[8]: deliberately invalidate
         self.runtime = None
 
     @staticmethod
     def is_sm90_compiled() -> bool:
-        # pyre-ignore[16]
         return _cpp.is_sm90_compiled()
 
     @staticmethod
@@ -247,7 +244,6 @@ class Buffer:
         num_ranks: int,
         num_experts: int,
     ) -> int:
-        # pyre-ignore[16]
         return _cpp.get_low_latency_rdma_size_hint(
             num_max_dispatch_tokens_per_rank, hidden, num_ranks, num_experts
         )

--- a/comms/prims/collectives/link_ep/link_ep/utils.py
+++ b/comms/prims/collectives/link_ep/link_ep/utils.py
@@ -92,7 +92,6 @@ def check_nvlink_connections(group: dist.ProcessGroup) -> None:
         )
 
     try:
-        # pyre-ignore[21]: optional third-party
         import pynvml  # @manual
     except ImportError:
         logger.warning("pynvml not available; skipping NVLink connectivity check")

--- a/comms/prims/collectives/link_ep/tests/common_utils.py
+++ b/comms/prims/collectives/link_ep/tests/common_utils.py
@@ -74,7 +74,6 @@ def per_token_cast_to_fp8(x: torch.Tensor):
         fp8_max = 240
         fp8_dtype = torch.float8_e4m3fnuz
     x_amax = x_padded_view.abs().float().amax(dim=2).view(m, -1).clamp(1e-4)
-    # pyre-ignore[6]: int / Tensor dispatches to Tensor.__rtruediv__ at runtime
     return (x_padded_view * (fp8_max / x_amax.unsqueeze(2))).to(fp8_dtype).view(
         m, aligned_n
     )[:, :n].contiguous(), (x_amax / fp8_max).view(m, -1)
@@ -215,7 +214,6 @@ def bench_kineto(
     with suppress():
         schedule = torch.profiler.schedule(wait=1, warmup=0, active=1, repeat=1)
         with torch.profiler.profile(
-            # pyre-ignore[16]: ProfilerActivity missing from torch.profiler stubs
             activities=[torch.profiler.ProfilerActivity.CUDA],
             schedule=schedule,
         ) as prof:

--- a/comms/prims/triton/collectives/ib/put_bw_kernel.py
+++ b/comms/prims/triton/collectives/ib/put_bw_kernel.py
@@ -113,9 +113,7 @@ if has_triton():  # noqa: C901
                     staging_byte_offset,  # src_offset in our staging
                     peer_rank,
                     section_bytes,
-                    # pyrefly: ignore [bad-argument-type]
                     0,  # signal_id = DATA_READY
-                    # pyrefly: ignore [bad-argument-type]
                     0,  # counter_id = NIC_DONE
                 )
 
@@ -125,16 +123,13 @@ if has_triton():  # noqa: C901
             # ALL_DONE increments by 1 per iteration (not per step), so
             # use iteration+1, NOT base+1 (base = iteration * total_steps
             # would grow too fast and deadlock on iteration >= 1).
-            # pyrefly: ignore [bad-argument-type]
             wait_signal_from(win, peer_rank, 1, iteration + 1)
         else:
             # -- Recv block --
             # Wait for all data to arrive.
-            # pyrefly: ignore [bad-argument-type]
             wait_signal_from(win, peer_rank, 0, base + total_steps)
             # Signal sender that all data was delivered.
             fence(win)
-            # pyrefly: ignore [bad-argument-type]
             signal_block(win, peer_rank, 1, 1)  # ALL_DONE
 
     # ------------------------------------------------------------------
@@ -189,13 +184,10 @@ if has_triton():  # noqa: C901
 
                 # Wait for NIC + receiver to free the slot before reuse.
                 if step >= pipeline_depth:
-                    # pyrefly: ignore [bad-argument-type]
                     wait_counter(win, 0, base + step - pipeline_depth + 1)
                     wait_signal_from(
-                        # pyrefly: ignore [bad-argument-type]
                         win,
                         peer_rank,
-                        # pyrefly: ignore [bad-argument-type]
                         1,
                         base + step - pipeline_depth + 1,
                     )
@@ -218,20 +210,16 @@ if has_triton():  # noqa: C901
                     staging_byte_offset,  # src_offset in our staging
                     peer_rank,
                     section_bytes,
-                    # pyrefly: ignore [bad-argument-type]
                     0,  # signal_id = DATA_READY
-                    # pyrefly: ignore [bad-argument-type]
                     0,  # counter_id = NIC_DONE
                 )
         else:
             # -- Recv block --
             for step in range(total_steps):
                 # Wait for data to arrive for this step.
-                # pyrefly: ignore [bad-argument-type]
                 wait_signal_from(win, peer_rank, 0, base + step + 1)
                 fence(win)
                 # Signal sender that the slot is free for reuse.
-                # pyrefly: ignore [bad-argument-type]
                 signal_block(win, peer_rank, 1, 1)  # SLOT_FREE += 1
 
     # ------------------------------------------------------------------
@@ -336,7 +324,6 @@ if has_triton():  # noqa: C901
                 else:
                     # No data for this tile in the last (partial) section.
                     # Still signal DATA_READY so the receiver doesn't deadlock.
-                    # pyrefly: ignore [bad-argument-type]
                     signal_block(win, peer_rank, pid, 1)
         else:
             # -- Recv block --
@@ -347,5 +334,4 @@ if has_triton():  # noqa: C901
                 wait_signal_from(win, peer_rank, recv_pid, base + step + 1)
                 fence(win)
                 # Signal sender that my tile's slot is free.
-                # pyrefly: ignore [bad-argument-type]
                 signal_block(win, peer_rank, num_blocks + recv_pid, 1)

--- a/comms/prims/triton/collectives/ib/sendrecv.py
+++ b/comms/prims/triton/collectives/ib/sendrecv.py
@@ -180,7 +180,6 @@ if has_triton():  # noqa: C901
                     nic_counter,
                 )
             else:
-                # pyrefly: ignore [bad-argument-type]
                 signal_block(win, peer_rank, data_signal, 1)
 
         # -- Drain: SLOT_FREE only (implies NIC_DONE) --
@@ -259,7 +258,6 @@ if has_triton():  # noqa: C901
                     tl.store(dst_ptr + dst_start + offs, data, mask=mask)
 
             # -- Signal sender: this slot is free --
-            # pyrefly: ignore [bad-argument-type]
             signal_block(win, peer_rank, slot_free_signal, 1)
 
     @requires_torchcomms

--- a/comms/prims/triton/collectives/ib/sendrecv_cooperative_kernel.py
+++ b/comms/prims/triton/collectives/ib/sendrecv_cooperative_kernel.py
@@ -119,7 +119,6 @@ if has_triton():  # noqa: C901
 
             # -- Wait for slot reuse (NIC must have finished reading this slot) --
             if step >= pipeline_depth:
-                # pyrefly: ignore [bad-argument-type]
                 wait_counter(win, 0, base + step - pipeline_depth + 1)
 
             # -- Phase 1: Local copy src -> send_staging (all send blocks) --
@@ -148,10 +147,8 @@ if has_triton():  # noqa: C901
                 # Last block: wait for receiver to free recv_staging[slot].
                 if step >= pipeline_depth:
                     wait_signal_from(
-                        # pyrefly: ignore [bad-argument-type]
                         win,
                         peer_rank,
-                        # pyrefly: ignore [bad-argument-type]
                         1,
                         base + step - pipeline_depth + 1,
                     )
@@ -176,9 +173,7 @@ if has_triton():  # noqa: C901
                     staging_byte_offset,  # src_offset (bytes)
                     peer_rank,
                     actual_section_bytes,
-                    # pyrefly: ignore [bad-argument-type]
                     0,  # signal_id = DATA_READY
-                    # pyrefly: ignore [bad-argument-type]
                     0,  # counter_id = NIC_DONE
                 )
 
@@ -219,7 +214,6 @@ if has_triton():  # noqa: C901
             slot = step % pipeline_depth
 
             # -- Wait for data to arrive from sender --
-            # pyrefly: ignore [bad-argument-type]
             wait_signal_from(win, peer_rank, 0, base + step + 1)
 
             # -- Local copy: recv_staging[slot] -> dst (all recv blocks) --
@@ -244,7 +238,6 @@ if has_triton():  # noqa: C901
             expected = num_recv_blocks * (step // pipeline_depth + 1)
 
             if old_count + 1 == expected:
-                # pyrefly: ignore [bad-argument-type]
                 signal_block(win, peer_rank, 1, 1)  # SLOT_FREE += 1
 
     @requires_torchcomms

--- a/comms/prims/triton/collectives/nvl/sendrecv_op.py
+++ b/comms/prims/triton/collectives/nvl/sendrecv_op.py
@@ -310,7 +310,6 @@ def _launch(
 
     grid = (2 * num_blocks,) if mode == _MODE_BIDIRECTIONAL else (num_blocks,)
 
-    # pyre-ignore[28]: triton's `kernel[grid](...)` launcher accepts JIT-special
     # kwargs (`num_warps`, `num_stages`) that pyre can't see in the kernel
     # function's own signature. Not a real type error.
     triton_nvl_sendrecv_kernel[grid](

--- a/comms/torchcomms/device_mesh.py
+++ b/comms/torchcomms/device_mesh.py
@@ -198,7 +198,7 @@ def _flatten_with_comm(
     else:
         from torch.distributed._mesh_layout import _MeshLayout
 
-        coalesced_layout = _MeshLayout([layout.collapse()])  # pyre-ignore[19]
+        coalesced_layout = _MeshLayout([layout.collapse()])
 
     # Compatibility layer for DeviceMesh API changes. The new API uses _rank_map
     # while the older API requires passing mesh tensor directly. This conditional
@@ -235,11 +235,9 @@ def _flatten_with_comm(
                 "Flattening with torchcomm is not supported for device mesh without mesh layout."
             )
         root_mesh = _mesh_resources.get_root_mesh(mesh)
-        _mesh_resources.child_to_root_mapping[  # pyre-ignore[16]
-            flattened_device_mesh
-        ] = root_mesh
-        _mesh_resources.root_to_flatten_mapping.setdefault(  # pyre-ignore[16]
-            root_mesh, {}
-        )[mesh_dim_name] = flattened_device_mesh
+        _mesh_resources.child_to_root_mapping[flattened_device_mesh] = root_mesh
+        _mesh_resources.root_to_flatten_mapping.setdefault(root_mesh, {})[
+            mesh_dim_name
+        ] = flattened_device_mesh
 
     return flattened_device_mesh

--- a/comms/torchcomms/distwrap/__init__.py
+++ b/comms/torchcomms/distwrap/__init__.py
@@ -6,8 +6,6 @@ from typing import Any, Callable
 
 import torch
 import torch.distributed as dist
-
-# pyre-fixme[21]: Could not find name in module (ProcessGroup backends not in stubs)
 from torch.distributed import (  # noqa: F401
     get_process_group_ranks,
     get_rank,

--- a/comms/torchcomms/distwrap/fallback.py
+++ b/comms/torchcomms/distwrap/fallback.py
@@ -62,6 +62,7 @@ def fallback_split_group_new_group(
     if new_pg is None:
         raise AssertionError("Failed to create process group for this rank")
 
+    # pyrefly: ignore [bad-return]
     return new_pg
 
 

--- a/comms/torchcomms/distwrap/new_comm.py
+++ b/comms/torchcomms/distwrap/new_comm.py
@@ -193,11 +193,14 @@ def new_group(
     )
 
     # Register the new process group
+    # pyrefly: ignore [bad-argument-type]
     pg_info_create(new_pg, ranks, group_desc)
 
     # Store device_backends
+    # pyrefly: ignore [bad-argument-type]
     pg_info_set_data(new_pg, "device_backends", device_backends)
 
+    # pyrefly: ignore [bad-return]
     return new_pg
 
 
@@ -274,13 +277,16 @@ def split_group(  # noqa: C901
         )
 
         # Register the new process group
+        # pyrefly: ignore [bad-argument-type]
         pg_info_create(new_pg, my_group_ranks, group_desc)
 
         # Store device_backends
+        # pyrefly: ignore [bad-argument-type]
         pg_info_set_data(new_pg, "device_backends", device_backends)
 
         # Create torchcomms instances by splitting from the parent pg
         torchcomms_create_split_group(
+            # pyrefly: ignore [bad-argument-type]
             new_pg,
             parent_pg,
             split_ranks,
@@ -312,12 +318,9 @@ def split_group(  # noqa: C901
             # NCCL options, we set split_share=0 on them. If the user passes
             # non-NCCL options (e.g., Gloo), we pass them through unchanged.
             #
-            # pyre-fixme[16]: Module `torch.distributed` has no attribute `ProcessGroupNCCL`.
             if hasattr(dist, "ProcessGroupNCCL"):
                 if pg_options is None:
-                    # pyre-fixme[16]: Module `torch.distributed` has no attribute `ProcessGroupNCCL`.
                     pg_options = dist.ProcessGroupNCCL.Options()
-                # pyre-fixme[16]: Module `torch.distributed` has no attribute `ProcessGroupNCCL`.
                 if isinstance(pg_options, dist.ProcessGroupNCCL.Options):
                     if hasattr(pg_options, "config") and hasattr(
                         pg_options.config, "split_share"
@@ -341,9 +344,12 @@ def split_group(  # noqa: C901
 
         assert new_pg is not None
         # Register the new process group
+        # pyrefly: ignore [bad-argument-type]
         pg_info_create(new_pg, my_group_ranks, group_desc)
 
         # Store device_backends
+        # pyrefly: ignore [bad-argument-type]
         pg_info_set_data(new_pg, "device_backends", device_backends)
 
+    # pyrefly: ignore [bad-return]
     return new_pg

--- a/comms/torchcomms/distwrap/tests/integration/test_helpers.py
+++ b/comms/torchcomms/distwrap/tests/integration/test_helpers.py
@@ -98,7 +98,6 @@ def get_pg_options(backend: str) -> object | None:
     doesn't have a supported options class.
     """
     if backend in ["nccl", "ncclx"]:
-        # pyre-ignore[16]: ProcessGroupNCCL not in Pyre stubs
         return dist.ProcessGroupNCCL.Options()
     elif backend in ["gloo"]:
         # pyre-ignore[16]: ProcessGroupGloo not in Pyre stubs

--- a/comms/torchcomms/distwrap/utils.py
+++ b/comms/torchcomms/distwrap/utils.py
@@ -412,7 +412,6 @@ def _pg_options_to_hints(pg_options: Any | None) -> dict[str, str] | None:  # no
     if hasattr(pg_options, "config"):
         # Extract config attributes
         config = pg_options.config
-        # pyre-ignore[16]: ProcessGroupNCCL may not be available
         process_group_nccl = getattr(dist, "ProcessGroupNCCL", None)
         if process_group_nccl is not None:
             nccl_config_class = getattr(process_group_nccl, "NCCLConfig", None)

--- a/comms/torchcomms/hooks/nan_check/nan_check.py
+++ b/comms/torchcomms/hooks/nan_check/nan_check.py
@@ -28,7 +28,6 @@ from torchcomms._comms import OpName
 # The op is registered when torch.distributed is imported (which happens
 # before any communicator is created), so we resolve on first use to
 # avoid a circular import at module load time.
-# pyre-ignore[5]: Global has no type annotation.
 _check_for_nan = None
 
 

--- a/comms/torchcomms/objcol.py
+++ b/comms/torchcomms/objcol.py
@@ -561,9 +561,9 @@ def broadcast_object_list(
     # has only one element, we can skip the copy.
     if my_comm_rank == root:
         if len(tensor_list) == 1:  # type: ignore[possibly-undefined]
-            object_tensor = tensor_list[0]  # pyre-fixme[61]
+            object_tensor = tensor_list[0]
         else:
-            object_tensor = torch.cat(tensor_list)  # pyre-fixme[61]
+            object_tensor = torch.cat(tensor_list)
     else:
         object_tensor = torch.empty(  # type: ignore[call-overload]
             torch.sum(object_sizes_tensor).item(),  # type: ignore[arg-type]

--- a/comms/torchcomms/tests/helpers/py/cuda_graph_test_helpers.py
+++ b/comms/torchcomms/tests/helpers/py/cuda_graph_test_helpers.py
@@ -17,12 +17,10 @@ import pydot
 import torch
 import torchcomms
 
-# pyre-fixme[5]: Global annotation for skip decorator.
 skip_unless_ncclx = unittest.skipIf(
     os.getenv("TEST_BACKEND") != "ncclx", "Skipping NCCLX-only tests"
 )
 
-# pyre-fixme[21]: Could not find name `ProfilerActivity` in `torch.profiler`.
 from torch.profiler import profile, ProfilerActivity
 from torchcomms.tests.integration.helpers.TorchCommTestHelpers import get_rank_and_size
 
@@ -134,7 +132,7 @@ def probe_tensor_addr(
 
     assert probe.dtype == torch.int64 and probe.numel() >= 1
     stream = torch.cuda.current_stream().cuda_stream
-    _cpp_write_addr(buf.data_ptr(), probe.data_ptr(), stream)  # pyre-ignore[16]
+    _cpp_write_addr(buf.data_ptr(), probe.data_ptr(), stream)
 
 
 def _wait(work: object | None) -> None:
@@ -465,10 +463,8 @@ class GraphTestBuilder:
                 profile_ctx = (
                     profile(
                         activities=[
-                            # pyre-fixme[16]: Module `torch.profiler` has no
                             # attribute `ProfilerActivity`.
                             ProfilerActivity.CPU,
-                            # pyre-fixme[16]: Module `torch.profiler` has no
                             # attribute `ProfilerActivity`.
                             ProfilerActivity.CUDA,
                         ],

--- a/comms/torchcomms/tests/helpers/py/test_helpers.py
+++ b/comms/torchcomms/tests/helpers/py/test_helpers.py
@@ -6,7 +6,6 @@ import unittest
 
 from torchcomms.functional import is_torch_compile_supported_and_enabled
 
-# pyre-fixme[5]: Global annotation for skip decorator.
 skip_if_ncclx = unittest.skipIf(
     os.getenv("TEST_BACKEND") == "ncclx", "Skipping tests for NCCLX backend."
 )

--- a/comms/torchcomms/tests/integration/py/CudaGraphsWindowTest.py
+++ b/comms/torchcomms/tests/integration/py/CudaGraphsWindowTest.py
@@ -364,7 +364,7 @@ class TestWindowGraphCapture(CudaGraphTestBase):
             if has_device_api:
                 self.assertIsInstance(dev_win_ptr, int)  # pyre-ignore[61]
                 self.assertNotEqual(
-                    dev_win_ptr,  # pyre-ignore[61]
+                    dev_win_ptr,
                     0,
                     "Device window pointer should be non-zero",
                 )

--- a/comms/torchcomms/tests/unit/py/DebugServerFlightRecorderTest.py
+++ b/comms/torchcomms/tests/unit/py/DebugServerFlightRecorderTest.py
@@ -29,8 +29,6 @@ import torchcomms
 from requests.adapters import HTTPAdapter
 from torch.distributed.debug import start_debug_server, stop_debug_server
 from torchcomms.hooks import FlightRecorderHook
-
-# pyre-fixme[21]: Could not find module `urllib3.util.retry`.
 from urllib3.util.retry import Retry
 
 


### PR DESCRIPTION
Summary:
This diff was automatically generated by the Pyre per-target upgrade tool.

It removes `# pyre-fixme` or `pyrefly: ignore` comments that are no longer needed because the underlying type errors have been resolved.
Note that it will also aim to ensure type checking runs cleanly, and will add suppressions to existing type errors.

#pyreupgrade

Differential Revision: D116357814


