### PR TITLE
Share bind retry across 2.29 and 2.30 (#3697)

### DIFF
--- a/comms/ncclx/meta/nvls/NvlsBindRetry.cc
+++ b/comms/ncclx/meta/nvls/NvlsBindRetry.cc
@@ -1,0 +1,119 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "meta/nvls/NvlsBindRetry.h"
+
+#include <chrono>
+#include <thread>
+
+#include "bootstrap.h"
+#include "comm.h"
+#include "cudawrap.h"
+#include "param.h"
+#include "utils.h"
+
+#include "comms/utils/memtrace/MemoryTrace.h"
+
+namespace {
+
+NCCL_PARAM(NvlsBindRetryCount, "NVLS_BIND_RETRY_COUNT", 10);
+NCCL_PARAM(NvlsBindRetryBackoffMs, "NVLS_BIND_RETRY_BACKOFF_MS", 1000);
+
+} // namespace
+
+namespace ncclx::nvls {
+
+ncclResult_t collectiveBindResult(
+    const ncclComm* comm,
+    CUresult localResult,
+    CUresult* collectiveResult) {
+  CUresult localResults[NCCL_MAX_LOCAL_RANKS]{};
+  localResults[comm->localRank] = localResult;
+  NCCLCHECK(bootstrapIntraNodeAllGather(
+      comm->bootstrap,
+      comm->localRankToRank,
+      comm->localRank,
+      comm->localRanks,
+      localResults,
+      sizeof(CUresult)));
+
+  // Every rank selects the first fatal result in local-rank order; absent a
+  // fatal result, CUDA 802 dominates success so all ranks make the same choice.
+  *collectiveResult = CUDA_SUCCESS;
+  for (int i = 0; i < comm->localRanks; ++i) {
+    const CUresult result = localResults[i];
+    if (result != CUDA_SUCCESS && result != CUDA_ERROR_SYSTEM_NOT_READY) {
+      *collectiveResult = result;
+      break;
+    }
+    if (result == CUDA_ERROR_SYSTEM_NOT_READY) {
+      *collectiveResult = result;
+    }
+  }
+  return ncclSuccess;
+}
+
+ncclResult_t prepareBindRetry(
+    ncclComm* comm,
+    CUresult localResult,
+    CUresult collectiveResult,
+    int64_t bindAttempt,
+    size_t ucsize,
+    void** ucptr,
+    CUmemGenericAllocationHandle* ucHandle,
+    CUmemGenericAllocationHandle* mcHandle,
+    int* allocMcHandle,
+    bool* retried) {
+  *retried = false;
+  const int64_t retryCount = ncclParamNvlsBindRetryCount();
+  const int64_t retryBackoffMs = ncclParamNvlsBindRetryBackoffMs();
+  if (collectiveResult != CUDA_ERROR_SYSTEM_NOT_READY ||
+      bindAttempt >= retryCount) {
+    return ncclSuccess;
+  }
+
+  const char* localErrorString =
+      "success (a peer rank failed the multicast bind)";
+  if (localResult != CUDA_SUCCESS) {
+    (void)pfn_cuGetErrorString(localResult, &localErrorString);
+  }
+  WARN(
+      "NVLS multicast bind of size %ld did not succeed on all local ranks (this rank CUDA error %d '%s'); tearing down and retrying (attempt %lld/%lld) after %lldms. This is usually a transient Fabric Manager stall forming the NVSwitch multicast team.",
+      ucsize,
+      localResult,
+      localErrorString,
+      static_cast<long long>(bindAttempt + 1),
+      static_cast<long long>(retryCount),
+      static_cast<long long>(retryBackoffMs));
+
+  NCCLCHECK(ncclMemUntrack(comm->memManager, *ucptr, ucsize));
+  meta::comms::memtrace::recordFree(
+      comm->logMetaData,
+      "nvlsAllocateMem",
+      "cuMemRelease",
+      reinterpret_cast<uintptr_t>(*ucptr),
+      ucsize);
+  CUCHECK(cuMemUnmap(reinterpret_cast<CUdeviceptr>(*ucptr), ucsize));
+  CUCHECK(cuMemRelease(*ucHandle));
+  CUCHECK(cuMemAddressFree(reinterpret_cast<CUdeviceptr>(*ucptr), ucsize));
+  CUCHECK(cuMemRelease(*mcHandle));
+
+  // Clear ownership before the barrier so a later failure cannot send released
+  // resources through the caller's cleanup labels.
+  *ucptr = nullptr;
+  *allocMcHandle = 0;
+  NCCLCHECK(bootstrapIntraNodeBarrier(
+      comm->bootstrap,
+      comm->localRankToRank,
+      comm->localRank,
+      comm->localRanks,
+      comm->localRankToRank[0]));
+
+  if (retryBackoffMs > 0) {
+    // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+    std::this_thread::sleep_for(std::chrono::milliseconds(retryBackoffMs));
+  }
+  *retried = true;
+  return ncclSuccess;
+}
+
+} // namespace ncclx::nvls

--- a/comms/ncclx/meta/nvls/NvlsBindRetry.h
+++ b/comms/ncclx/meta/nvls/NvlsBindRetry.h
@@ -1,0 +1,33 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <cuda.h>
+
+#include "nccl.h"
+
+struct ncclComm;
+
+namespace ncclx::nvls {
+
+ncclResult_t collectiveBindResult(
+    const ncclComm* comm,
+    CUresult localResult,
+    CUresult* collectiveResult);
+
+ncclResult_t prepareBindRetry(
+    ncclComm* comm,
+    CUresult localResult,
+    CUresult collectiveResult,
+    int64_t bindAttempt,
+    size_t ucsize,
+    void** ucptr,
+    CUmemGenericAllocationHandle* ucHandle,
+    CUmemGenericAllocationHandle* mcHandle,
+    int* allocMcHandle,
+    bool* retried);
+
+} // namespace ncclx::nvls

--- a/comms/ncclx/v2_30/src/transport/nvls.cc
+++ b/comms/ncclx/v2_30/src/transport/nvls.cc
@@ -15,6 +15,7 @@
 #include "register.h"
 #include "transport.h"
 #include "register_inline.h"
+#include "meta/nvls/NvlsBindRetry.h"
 #include "meta/nvls/NvlsBindWatchdog.h"
 
 #if CUDART_VERSION >= 12010
@@ -289,11 +290,13 @@ static ncclResult_t nvlsAllocateMem(struct ncclComm* comm, const CUmemAccessDesc
   CUmulticastObjectProp mcprop;
   CUmemAllocationProp ucprop;
   CUresult err;
+  CUresult localErr;
   ncclResult_t ret = ncclSuccess;
   size_t mcsize;
   size_t ucsize;
   size_t ucgran, mcgran;
   int allocMcHandle = 0;
+  int64_t bindAttempt = 0;
 
   mcsize = ucsize = size;
   *ucptr = *mcptr = NULL;
@@ -307,6 +310,7 @@ static ncclResult_t nvlsAllocateMem(struct ncclComm* comm, const CUmemAccessDesc
   ALIGN_SIZE(mcsize, mcgran);
   mcprop.size = mcsize;
 
+retryNvlsBind:
   if (comm->localRank == 0) {
     NCCLCHECKGOTO(ncclNvlsGroupCreate(comm, &mcprop, comm->localRank, comm->localRanks, mcHandle, shareableHandle), ret, fail);
     allocMcHandle = 1;
@@ -349,9 +353,27 @@ static ncclResult_t nvlsAllocateMem(struct ncclComm* comm, const CUmemAccessDesc
   // NB: It will block until all ranks have been added to the Group
   // This is where we normally see issues if the system NVLS/Multicast support is broken
   err = ncclx::nvls::multicastBindMemWithWatchdog(comm, size, ucsize, mcsize, *mcHandle, *ucHandle);
+  localErr = err;
+  NCCLCHECKGOTO(ncclx::nvls::collectiveBindResult(comm, localErr, &err), ret, fail3);
   if (err != CUDA_SUCCESS) {
     const char *errStr;                                                 \
     (void) pfn_cuGetErrorString(err, &errStr);                          \
+    bool retried = false;
+    NCCLCHECK(ncclx::nvls::prepareBindRetry(
+        comm,
+        localErr,
+        err,
+        bindAttempt,
+        ucsize,
+        ucptr,
+        ucHandle,
+        mcHandle,
+        &allocMcHandle,
+        &retried));
+    if (retried) {
+      ++bindAttempt;
+      goto retryNvlsBind;
+    }
     // Fail the job as NVLS support is not functional
     ERR(ncclUnhandledCudaError, "Failed to bind NVLink SHARP (NVLS) Multicast memory of size %ld : CUDA error %d '%s'.\nThis is usually caused by a system or configuration error in the Fabric Manager or NVSwitches.\nDisable NVLS (NCCL_NVLS_ENABLE=0) if you wish to avoid this error in the future.", ucsize, err, errStr );
     ret = ncclUnhandledCudaError;


### PR DESCRIPTION
Summary:

Address the footprint feedback on D111292173 and bring the transient multicast-bind recovery to NCCLX 2.30.

Move the retry parameters, collective CUDA-result agreement, retry logging, ordered teardown, barrier, and backoff into a shared `meta/nvls` helper. The versioned 2.29 and 2.30 implementations retain only a small retry seam around their existing upstream control flow. In 2.29, keep the upstream allocation setup inside the retry path instead of moving that block, reducing future merge-conflict surface.

The shared agreement exchanges the actual `CUresult` from every local rank and deterministically prioritizes fatal errors over CUDA 802, and CUDA 802 over success. Only `CUDA_ERROR_SYSTEM_NOT_READY` retries; all local ranks release and rebuild the multicast resources in lockstep. The defaults remain ten retries with a one-second backoff, while a retry count of zero preserves the fail-fast behavior.

Reviewed By: snarayankh

Differential Revision: D116405772


