### PR TITLE
Split Folly-free log types

### DIFF
--- a/comms/utils/logger/LogTypes.cc
+++ b/comms/utils/logger/LogTypes.cc
@@ -1,0 +1,23 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/LogTypes.h"
+
+namespace meta::comms::logger {
+namespace {
+
+uint64_t& getSubSystemMask() {
+  static uint64_t subSystemMask = 0;
+  return subSystemMask;
+}
+
+} // namespace
+
+void setSubSystemMask(uint64_t subSystemMaskValue) {
+  getSubSystemMask() = subSystemMaskValue;
+}
+
+bool isEnabledSubSystemBitwise(uint64_t subSystem) {
+  return getSubSystemMask() & subSystem;
+}
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/LogTypes.h
+++ b/comms/utils/logger/LogTypes.h
@@ -1,0 +1,49 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstdint>
+
+namespace meta::comms::logger {
+
+enum class LogLevel {
+  NONE = 0,
+  VERSION = 1,
+  ERROR = 2,
+  WARN = 3,
+  INFO = 4,
+  ABORT = 5,
+  TRACE = 6
+};
+
+#pragma push_macro("NET")
+#pragma push_macro("INIT")
+#undef NET
+#undef INIT
+enum SubSystem {
+  INIT = 0x1,
+  COLL = 0x2,
+  P2P = 0x4,
+  SHM = 0x8,
+  NET = 0x10,
+  GRAPH = 0x20,
+  TUNING = 0x40,
+  ENV = 0x80,
+  ALLOC = 0x100,
+  CALL = 0x200,
+  PROXY = 0x400,
+  NVLS = 0x800,
+  BOOTSTRAP = 0x1000,
+  REG = 0x2000,
+  PROFILE = 0x4000,
+  RAS = 0x8000,
+  ALL = ~0
+};
+#pragma pop_macro("INIT")
+#pragma pop_macro("NET")
+
+void setSubSystemMask(uint64_t subSystemMask);
+
+bool isEnabledSubSystemBitwise(uint64_t subSystem);
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/LogUtils.cc
+++ b/comms/utils/logger/LogUtils.cc
@@ -13,8 +13,6 @@
 namespace meta::comms::logger {
 
 namespace {
-static uint64_t subSystemMask = 0; // Bitmask of enabled subsystems
-
 folly::once_flag commLoggingInitOnceFlag;
 
 void initCommLoggingImpl() {
@@ -35,14 +33,6 @@ void initCommLoggingImpl() {
           }});
 }
 } // anonymous namespace
-
-void setSubSystemMask(uint64_t subSystemMask_) {
-  subSystemMask = subSystemMask_;
-}
-
-bool isEnabledSubSystemBitwise(uint64_t subSystem) {
-  return subSystemMask & subSystem;
-}
 
 void initCommLogging(bool alwaysInit) {
   if (alwaysInit) {

--- a/comms/utils/logger/LogUtils.h
+++ b/comms/utils/logger/LogUtils.h
@@ -7,6 +7,7 @@
 #include <folly/Format.h>
 #include <folly/logging/xlog.h>
 
+#include "comms/utils/logger/LogTypes.h"
 #include "comms/utils/logger/LoggingFormat.h"
 #include "comms/utils/logger/RateLimit.h"
 
@@ -22,13 +23,6 @@
 namespace meta::comms::logger {
 
 constexpr std::string_view kCommsUtilsCategory = "comms.utils";
-
-/**
- * Bitwise OR of all sub-systems that needs to be enabled.
- */
-void setSubSystemMask(uint64_t subSystemMask);
-
-bool isEnabledSubSystemBitwise(uint64_t subSystem);
 
 /**
  * Initialize logging for Comms. By default it only initializes once globlally

--- a/comms/utils/logger/LoggingFormat.h
+++ b/comms/utils/logger/LoggingFormat.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>
@@ -13,46 +12,9 @@
 #include <folly/logging/LogLevel.h>
 
 #include "comms/utils/commSpecs.h"
+#include "comms/utils/logger/LogTypes.h"
 
 namespace meta::comms::logger {
-
-enum class LogLevel {
-  NONE = 0,
-  VERSION = 1,
-  ERROR = 2,
-  WARN = 3,
-  INFO = 4,
-  ABORT = 5,
-  TRACE = 6
-};
-
-// Save and restore macros that collide with our enum values.
-// topo.h defines #define NET 5 which would expand inside the enum.
-#pragma push_macro("NET")
-#pragma push_macro("INIT")
-#undef NET
-#undef INIT
-enum SubSystem {
-  INIT = 0x1,
-  COLL = 0x2,
-  P2P = 0x4,
-  SHM = 0x8,
-  NET = 0x10,
-  GRAPH = 0x20,
-  TUNING = 0x40,
-  ENV = 0x80,
-  ALLOC = 0x100,
-  CALL = 0x200,
-  PROXY = 0x400,
-  NVLS = 0x800,
-  BOOTSTRAP = 0x1000,
-  REG = 0x2000,
-  PROFILE = 0x4000,
-  RAS = 0x8000,
-  ALL = ~0
-};
-#pragma pop_macro("INIT")
-#pragma pop_macro("NET")
 
 // TODO: Properly clean this up so that we directly parse NCCL logs to folly
 // levels.


### PR DESCRIPTION
Summary: Move `LogLevel`, `SubSystem`, and subsystem-mask state into a small Folly-free logger target. This lets the NCCLX debug bridge use shared logging types and subsystem filtering without inheriting `LogUtils.h` and its Folly logging includes. Preserve the existing enum values and mask behavior while keeping the dependency explicit in both supported NCCLX build definitions.

Reviewed By: shr

Differential Revision: D115616289


