### PR TITLE
Migrate IB fatal checks

### DIFF
--- a/comms/ctran/ibverbx/IbvQp.h
+++ b/comms/ctran/ibverbx/IbvQp.h
@@ -3,11 +3,11 @@
 #pragma once
 
 #include <folly/Expected.h>
-#include <folly/logging/xlog.h>
 #include <deque>
 #include "comms/ctran/ibverbx/IbvCommon.h"
 #include "comms/ctran/ibverbx/Ibvcore.h"
 #include "comms/ctran/ibverbx/device/structs.h"
+#include "comms/ctran/utils/CtranLogger.h"
 
 namespace ibverbx {
 
@@ -75,7 +75,9 @@ class IbvQp {
 
 // IbvQp inline functions
 inline uint32_t IbvQp::getQpNum() const {
-  XCHECK_NE(qp_, nullptr);
+  if (qp_ == nullptr) {
+    CTRAN_LOG(FATAL, "Check failed: qp_ != nullptr");
+  }
   return qp_->qp_num;
 }
 

--- a/comms/ctran/ibverbx/IbvVirtualCq.h
+++ b/comms/ctran/ibverbx/IbvVirtualCq.h
@@ -4,7 +4,6 @@
 
 #include <folly/Expected.h>
 #include <folly/container/F14Map.h>
-#include <folly/logging/xlog.h>
 #include <deque>
 #include <vector>
 
@@ -13,6 +12,7 @@
 #include "comms/ctran/ibverbx/IbvVirtualQp.h"
 #include "comms/ctran/ibverbx/IbvVirtualWr.h"
 #include "comms/ctran/ibverbx/Ibvcore.h"
+#include "comms/ctran/utils/CtranLogger.h"
 
 namespace ibverbx {
 
@@ -124,10 +124,13 @@ IbvVirtualCq::pollCq() {
         const RegisteredQpInfo* info =
             findRegisteredQpInfo(physicalWc.qp_num, deviceId);
 
-        CHECK(info != nullptr) << fmt::format(
-            "[Ibverbx]IbvVirtualCq::pollCq, unregistered QP: qpNum={}, deviceId={}",
-            physicalWc.qp_num,
-            deviceId);
+        if (info == nullptr) {
+          CTRAN_LOG(
+              FATAL,
+              "Check failed: info != nullptr: [Ibverbx]IbvVirtualCq::pollCq, unregistered QP: qpNum={}, deviceId={}",
+              physicalWc.qp_num,
+              deviceId);
+        }
 
         if (isUsingMultiQpLoadBalancing(info->isMultiQp, physicalWc.opcode)) {
           // Multi-QP RDMA: route to VirtualQp for fragment reassembly

--- a/comms/ctran/ibverbx/IbvVirtualQp.h
+++ b/comms/ctran/ibverbx/IbvVirtualQp.h
@@ -4,6 +4,7 @@
 
 #include <folly/Expected.h>
 #include <folly/dynamic.h>
+#include <folly/logging/xlog.h>
 #include <deque>
 #include <optional>
 #include <utility>

--- a/comms/ctran/ibverbx/tests/IbvVirtualQpTest.cc
+++ b/comms/ctran/ibverbx/tests/IbvVirtualQpTest.cc
@@ -8,6 +8,28 @@ FOLLY_INIT_LOGGING_CONFIG(
 
 namespace ibverbx {
 
+TEST_F(IbverbxTestFixture, IbvQpGetQpNumFailsAfterMove) {
+  auto devices = IbvDevice::ibvGetDeviceList({kNicPrefix});
+  ASSERT_TRUE(devices);
+  auto& device = devices->at(0);
+
+  auto maybeCq = device.createCq(1, nullptr, nullptr, 0);
+  ASSERT_TRUE(maybeCq);
+  auto pd = device.allocPd();
+  ASSERT_TRUE(pd);
+  auto initAttr = makeIbvQpInitAttr(maybeCq->cq());
+  auto maybeQp = pd->createQp(&initAttr);
+  ASSERT_TRUE(maybeQp);
+
+  auto qp = std::move(*maybeQp);
+  IbvQp movedQp(std::move(qp));
+  const auto deathTestStyle = ::testing::FLAGS_gtest_death_test_style;
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_DEATH(qp.getQpNum(), "Check failed: qp_ != nullptr");
+  ::testing::FLAGS_gtest_death_test_style = deathTestStyle;
+  EXPECT_NE(movedQp.qp(), nullptr);
+}
+
 TEST_F(IbverbxTestFixture, IbvVirtualQp) {
   auto devices = IbvDevice::ibvGetDeviceList({kNicPrefix});
   ASSERT_TRUE(devices);

--- a/comms/ncclx/meta/logger/NcclDebugLog.h
+++ b/comms/ncclx/meta/logger/NcclDebugLog.h
@@ -1,0 +1,44 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <string_view>
+
+#include "nccl_common.h"
+
+#include "meta/NcclxLogger.h"
+
+namespace ncclx::logging {
+
+inline constexpr spdlog::level::level_enum ncclLogLevelToSpdlogLevel(
+    ncclDebugLogLevel level) {
+  switch (level) {
+    case NCCL_LOG_ERROR:
+      return spdlog::level::err;
+    case NCCL_LOG_WARN:
+      return spdlog::level::warn;
+    case NCCL_LOG_TRACE:
+      return spdlog::level::debug;
+    case NCCL_LOG_NONE:
+    case NCCL_LOG_VERSION:
+    case NCCL_LOG_INFO:
+    case NCCL_LOG_ABORT:
+      return spdlog::level::info;
+  }
+  return spdlog::level::info;
+}
+
+inline void writeNcclLog(
+    ncclDebugLogLevel level,
+    const char* file,
+    const char* func,
+    int line,
+    std::string_view message) {
+  meta::comms::logger::getSpdlogLogger(kNcclxLoggerName)
+      .log(
+          spdlog::source_loc{file, line, func},
+          ncclLogLevelToSpdlogLevel(level),
+          message);
+}
+
+} // namespace ncclx::logging

--- a/comms/ncclx/meta/logger/tests/LoggingUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggingUT.cc
@@ -19,6 +19,8 @@
 #include "debug.h" // @manual
 #include "param.h" // @manual
 
+extern "C" void ncclResetDebugInitInternal();
+
 namespace {
 void inline checkStringHasLogging(
     std::string_view output,
@@ -348,6 +350,63 @@ TEST_F(NcclLoggerTest, InfoLogTest) {
   sleep(1);
   output = testing::internal::GetCapturedStdout();
   checkStringHasLogging(output, TestStr, "INFO");
+
+  finishLogging();
+}
+
+TEST_F(NcclLoggerTest, PluginDebugBridgePreservesSourceMetadata) {
+  auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"INFO"});
+  auto asyncGuard = EnvRAII(NCCL_DEBUG_LOGGING_ASYNC, false);
+  setenv("NCCL_DEBUG", "INFO", 1);
+  ncclResetDebugInitInternal();
+
+  initLogging();
+  constexpr std::string_view message = "PLUGIN DEBUG BRIDGE";
+
+  testing::internal::CaptureStdout();
+  ncclDebugLog(
+      NCCL_LOG_INFO,
+      NCCL_ALL,
+      "transport/plugin.cc:pluginFunc",
+      321,
+      "%s",
+      message.data());
+  auto& logger =
+      meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName);
+  logger.flush();
+  const auto output = testing::internal::GetCapturedStdout();
+
+  checkStringHasLogging(output, message, "INFO");
+  EXPECT_THAT(output, testing::HasSubstr("plugin.cc:pluginFunc:321]"));
+
+  finishLogging();
+}
+
+TEST_F(NcclLoggerTest, MetaDebugBridgePreservesTraceAndSourceMetadata) {
+  auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"TRACE"});
+  auto asyncGuard = EnvRAII(NCCL_DEBUG_LOGGING_ASYNC, false);
+  setenv("NCCL_DEBUG", "TRACE", 1);
+  ncclResetDebugInitInternal();
+
+  initLogging();
+  constexpr std::string_view message = "META DEBUG BRIDGE";
+
+  testing::internal::CaptureStdout();
+  ncclMetaDebugLog(
+      NCCL_LOG_TRACE,
+      NCCL_ALL,
+      "source.cc",
+      "sourceFunction",
+      654,
+      "%s",
+      message.data());
+  auto& logger =
+      meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName);
+  logger.flush();
+  const auto output = testing::internal::GetCapturedStdout();
+
+  checkStringHasLogging(output, message, "VERBOSE");
+  EXPECT_THAT(output, testing::HasSubstr("source.cc:654]"));
 
   finishLogging();
 }

--- a/comms/ncclx/v2_29/src/debug.cc
+++ b/comms/ncclx/v2_29/src/debug.cc
@@ -24,14 +24,11 @@
 #include <cstdio>
 #include <vector>
 #include <sstream>
-#include <folly/logging/LogLevel.h>
-#include <folly/logging/LogStreamProcessor.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/ErrorStackUtil.h"
-#include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/LoggingFormat.h"
+#include "meta/logger/NcclDebugLog.h"
 
 #define NCCL_DEBUG_RESET_TRIGGERED (-2)
 
@@ -369,17 +366,6 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
   }
 
   std::stringstream logStream;
-  auto logLevel = folly::LogLevel::INFO;
-  if (level == NCCL_LOG_WARN) {
-    logLevel = folly::LogLevel::WARN;
-  } else if (level == NCCL_LOG_INFO || level == NCCL_LOG_VERSION) {
-    logLevel = folly::LogLevel::INFO;
-  } else if (level == NCCL_LOG_TRACE) {
-    logLevel = folly::LogLevel::DBG;
-  } else if (level == NCCL_LOG_ERROR) {
-    logLevel = folly::LogLevel::ERR;
-  }
-
   size_t logLen = 0;
   va_list vargs;
   va_start(vargs, fmt);
@@ -394,16 +380,7 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
   logStream << buffer.data();
 
   auto logStr = logStream.str();
-  // logging to specified stdout/stderr/file
-  folly::LogStreamProcessor(
-    XLOG_GET_CATEGORY(),
-    logLevel,
-    filefunc,
-    line,
-    "",
-    folly::LogStreamProcessor::AppendType::APPEND)
-        .stream()
-    << logStr;
+  ncclx::logging::writeNcclLog(level, filefunc, "", line, logStr);
 }
 
 // Non-deprecated version for internal use.
@@ -480,9 +457,7 @@ void ncclMetaDebugLogWithScuba(ncclDebugLogLevel level, unsigned long flags, con
 
 /* Meta's logging function with separate file and func parameters.
  * Used by the VERSION, WARN, ERR, INFO, TRACE_CALL, and TRACE macros.
- * Unlike ncclDebugLog (which combines file/func into filefunc for OFI plugin
- * compatibility), this passes file and func separately to LogStreamProcessor
- * so that folly can correctly resolve log levels and categories.
+ * ncclDebugLog keeps file/func combined for OFI plugin compatibility.
  */
 
 void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file, const char *func, int line, const char *fmt, ...) {
@@ -514,17 +489,6 @@ void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *
   }
 
   std::stringstream logStream;
-  auto logLevel = folly::LogLevel::INFO;
-  if (level == NCCL_LOG_WARN) {
-    logLevel = folly::LogLevel::WARN;
-  } else if (level == NCCL_LOG_INFO || level == NCCL_LOG_VERSION) {
-    logLevel = folly::LogLevel::INFO;
-  } else if (level == NCCL_LOG_TRACE) {
-    logLevel = folly::LogLevel::DBG;
-  } else if (level == NCCL_LOG_ERROR) {
-    logLevel = folly::LogLevel::ERR;
-  }
-
   size_t logLen = 0;
   va_list vargs;
   va_start(vargs, fmt);
@@ -539,14 +503,5 @@ void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *
   logStream << buffer.data();
 
   auto logStr = logStream.str();
-  // logging to specified stdout/stderr/file
-  folly::LogStreamProcessor(
-    XLOG_GET_CATEGORY(),
-    logLevel,
-    file,
-    line,
-    func,
-    folly::LogStreamProcessor::AppendType::APPEND)
-        .stream()
-    << logStr;
+  ncclx::logging::writeNcclLog(level, file, func, line, logStr);
 }

--- a/comms/ncclx/v2_30/src/debug.cc
+++ b/comms/ncclx/v2_30/src/debug.cc
@@ -23,12 +23,9 @@
 #include <cstdio>
 #include <vector>
 #include <sstream>
-#include <folly/logging/LogLevel.h>
-#include <folly/logging/LogStreamProcessor.h>
-#include <folly/logging/xlog.h>
 
-#include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/LoggingFormat.h"
+#include "meta/logger/NcclDebugLog.h"
 
 #define NCCL_DEBUG_RESET_TRIGGERED (-2)
 
@@ -372,17 +369,6 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
   }
 
   std::stringstream logStream;
-  auto logLevel = folly::LogLevel::INFO;
-  if (level == NCCL_LOG_WARN) {
-    logLevel = folly::LogLevel::WARN;
-  } else if (level == NCCL_LOG_INFO || level == NCCL_LOG_VERSION) {
-    logLevel = folly::LogLevel::INFO;
-  } else if (level == NCCL_LOG_TRACE) {
-    logLevel = folly::LogLevel::DBG;
-  } else if (level == NCCL_LOG_ERROR) {
-    logLevel = folly::LogLevel::ERR;
-  }
-
   size_t logLen = 0;
   va_list vargs;
   va_start(vargs, fmt);
@@ -397,16 +383,7 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
   logStream << buffer.data();
 
   auto logStr = logStream.str();
-  // logging to specified stdout/stderr/file
-  folly::LogStreamProcessor(
-    XLOG_GET_CATEGORY(),
-    logLevel,
-    filefunc,
-    line,
-    "",
-    folly::LogStreamProcessor::AppendType::APPEND)
-        .stream()
-    << logStr;
+  ncclx::logging::writeNcclLog(level, filefunc, "", line, logStr);
 }
 
 // Non-deprecated version for internal use.
@@ -469,9 +446,7 @@ void ncclSetMyThreadLoggingName(std::string_view name) {
 
 /* Meta's logging function with separate file and func parameters.
  * Used by the VERSION, WARN, ERR, INFO, TRACE_CALL, and TRACE macros.
- * Unlike ncclDebugLog (which combines file/func into filefunc for OFI plugin
- * compatibility), this passes file and func separately to LogStreamProcessor
- * so that folly can correctly resolve log levels and categories.
+ * ncclDebugLog keeps file/func combined for OFI plugin compatibility.
  */
 
 void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file, const char *func, int line, const char *fmt, ...) {
@@ -503,17 +478,6 @@ void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *
   }
 
   std::stringstream logStream;
-  auto logLevel = folly::LogLevel::INFO;
-  if (level == NCCL_LOG_WARN) {
-    logLevel = folly::LogLevel::WARN;
-  } else if (level == NCCL_LOG_INFO || level == NCCL_LOG_VERSION) {
-    logLevel = folly::LogLevel::INFO;
-  } else if (level == NCCL_LOG_TRACE) {
-    logLevel = folly::LogLevel::DBG;
-  } else if (level == NCCL_LOG_ERROR) {
-    logLevel = folly::LogLevel::ERR;
-  }
-
   size_t logLen = 0;
   va_list vargs;
   va_start(vargs, fmt);
@@ -528,14 +492,5 @@ void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *
   logStream << buffer.data();
 
   auto logStr = logStream.str();
-  // logging to specified stdout/stderr/file
-  folly::LogStreamProcessor(
-    XLOG_GET_CATEGORY(),
-    logLevel,
-    file,
-    line,
-    func,
-    folly::LogStreamProcessor::AppendType::APPEND)
-        .stream()
-    << logStr;
+  ncclx::logging::writeNcclLog(level, file, func, line, logStr);
 }

--- a/comms/utils/logger/LogTypes.cc
+++ b/comms/utils/logger/LogTypes.cc
@@ -1,0 +1,23 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/LogTypes.h"
+
+namespace meta::comms::logger {
+namespace {
+
+uint64_t& getSubSystemMask() {
+  static uint64_t subSystemMask = 0;
+  return subSystemMask;
+}
+
+} // namespace
+
+void setSubSystemMask(uint64_t subSystemMaskValue) {
+  getSubSystemMask() = subSystemMaskValue;
+}
+
+bool isEnabledSubSystemBitwise(uint64_t subSystem) {
+  return getSubSystemMask() & subSystem;
+}
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/LogTypes.h
+++ b/comms/utils/logger/LogTypes.h
@@ -1,0 +1,49 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstdint>
+
+namespace meta::comms::logger {
+
+enum class LogLevel {
+  NONE = 0,
+  VERSION = 1,
+  ERROR = 2,
+  WARN = 3,
+  INFO = 4,
+  ABORT = 5,
+  TRACE = 6
+};
+
+#pragma push_macro("NET")
+#pragma push_macro("INIT")
+#undef NET
+#undef INIT
+enum SubSystem {
+  INIT = 0x1,
+  COLL = 0x2,
+  P2P = 0x4,
+  SHM = 0x8,
+  NET = 0x10,
+  GRAPH = 0x20,
+  TUNING = 0x40,
+  ENV = 0x80,
+  ALLOC = 0x100,
+  CALL = 0x200,
+  PROXY = 0x400,
+  NVLS = 0x800,
+  BOOTSTRAP = 0x1000,
+  REG = 0x2000,
+  PROFILE = 0x4000,
+  RAS = 0x8000,
+  ALL = ~0
+};
+#pragma pop_macro("INIT")
+#pragma pop_macro("NET")
+
+void setSubSystemMask(uint64_t subSystemMask);
+
+bool isEnabledSubSystemBitwise(uint64_t subSystem);
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/LogUtils.cc
+++ b/comms/utils/logger/LogUtils.cc
@@ -13,8 +13,6 @@
 namespace meta::comms::logger {
 
 namespace {
-static uint64_t subSystemMask = 0; // Bitmask of enabled subsystems
-
 folly::once_flag commLoggingInitOnceFlag;
 
 void initCommLoggingImpl() {
@@ -35,14 +33,6 @@ void initCommLoggingImpl() {
           }});
 }
 } // anonymous namespace
-
-void setSubSystemMask(uint64_t subSystemMask_) {
-  subSystemMask = subSystemMask_;
-}
-
-bool isEnabledSubSystemBitwise(uint64_t subSystem) {
-  return subSystemMask & subSystem;
-}
 
 void initCommLogging(bool alwaysInit) {
   if (alwaysInit) {

--- a/comms/utils/logger/LogUtils.h
+++ b/comms/utils/logger/LogUtils.h
@@ -7,6 +7,7 @@
 #include <folly/Format.h>
 #include <folly/logging/xlog.h>
 
+#include "comms/utils/logger/LogTypes.h"
 #include "comms/utils/logger/LoggingFormat.h"
 #include "comms/utils/logger/RateLimit.h"
 
@@ -22,13 +23,6 @@
 namespace meta::comms::logger {
 
 constexpr std::string_view kCommsUtilsCategory = "comms.utils";
-
-/**
- * Bitwise OR of all sub-systems that needs to be enabled.
- */
-void setSubSystemMask(uint64_t subSystemMask);
-
-bool isEnabledSubSystemBitwise(uint64_t subSystem);
 
 /**
  * Initialize logging for Comms. By default it only initializes once globlally

--- a/comms/utils/logger/LoggingFormat.h
+++ b/comms/utils/logger/LoggingFormat.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>
@@ -13,46 +12,9 @@
 #include <folly/logging/LogLevel.h>
 
 #include "comms/utils/commSpecs.h"
+#include "comms/utils/logger/LogTypes.h"
 
 namespace meta::comms::logger {
-
-enum class LogLevel {
-  NONE = 0,
-  VERSION = 1,
-  ERROR = 2,
-  WARN = 3,
-  INFO = 4,
-  ABORT = 5,
-  TRACE = 6
-};
-
-// Save and restore macros that collide with our enum values.
-// topo.h defines #define NET 5 which would expand inside the enum.
-#pragma push_macro("NET")
-#pragma push_macro("INIT")
-#undef NET
-#undef INIT
-enum SubSystem {
-  INIT = 0x1,
-  COLL = 0x2,
-  P2P = 0x4,
-  SHM = 0x8,
-  NET = 0x10,
-  GRAPH = 0x20,
-  TUNING = 0x40,
-  ENV = 0x80,
-  ALLOC = 0x100,
-  CALL = 0x200,
-  PROXY = 0x400,
-  NVLS = 0x800,
-  BOOTSTRAP = 0x1000,
-  REG = 0x2000,
-  PROFILE = 0x4000,
-  RAS = 0x8000,
-  ALL = ~0
-};
-#pragma pop_macro("INIT")
-#pragma pop_macro("NET")
 
 // TODO: Properly clean this up so that we directly parse NCCL logs to folly
 // levels.


### PR DESCRIPTION
Summary:
Replace two Folly-backed fatal checks in the IB headers with the CTRAN logger while preserving process termination and diagnostic context.

Export the CTRAN logger dependency from `ibv-qp` because its public header now uses that interface, and remove the exported Folly logging dependency. Add the Folly logging include directly to `IbvVirtualQp.h`; its remaining `CHECK`/`CHECK_EQ` uses previously depended on the removed transitive include and will be migrated separately.

Add a death test for the moved-from `IbvQp` invariant. Scope GTest's `threadsafe` death-test mode to this test because the IB fixture starts worker threads before the assertion.

Reviewed By: shr

Differential Revision: D115618591


