### PR TITLE
Migrate virtual IB fatal checks

### DIFF
--- a/comms/ctran/ibverbx/IbvQp.h
+++ b/comms/ctran/ibverbx/IbvQp.h
@@ -3,11 +3,11 @@
 #pragma once
 
 #include <folly/Expected.h>
-#include <folly/logging/xlog.h>
 #include <deque>
 #include "comms/ctran/ibverbx/IbvCommon.h"
 #include "comms/ctran/ibverbx/Ibvcore.h"
 #include "comms/ctran/ibverbx/device/structs.h"
+#include "comms/ctran/utils/CtranLogger.h"
 
 namespace ibverbx {
 
@@ -75,7 +75,9 @@ class IbvQp {
 
 // IbvQp inline functions
 inline uint32_t IbvQp::getQpNum() const {
-  XCHECK_NE(qp_, nullptr);
+  if (qp_ == nullptr) {
+    CTRAN_LOG(FATAL, "Check failed: qp_ != nullptr");
+  }
   return qp_->qp_num;
 }
 

--- a/comms/ctran/ibverbx/IbvVirtualCq.cc
+++ b/comms/ctran/ibverbx/IbvVirtualCq.cc
@@ -26,8 +26,10 @@ IbvVirtualCq::IbvVirtualCq(IbvVirtualCq&& other) noexcept {
 
   // Update registered VirtualQp back-pointers to point to new location
   for (auto& [qpId, info] : registeredQps_) {
-    CHECK(info.vqp != nullptr)
-        << "Registered physical QP has no associated VirtualQp!";
+    CTRAN_LOG_IF(
+        FATAL,
+        info.vqp == nullptr,
+        "Check failed: info.vqp != nullptr: Registered physical QP has no associated VirtualQp!");
     info.vqp->virtualCq_ = this;
   }
 }
@@ -41,8 +43,10 @@ IbvVirtualCq& IbvVirtualCq::operator=(IbvVirtualCq&& other) noexcept {
 
     // Update registered VirtualQp back-pointers to point to new location
     for (auto& [qpId, info] : registeredQps_) {
-      CHECK(info.vqp != nullptr)
-          << "Registered physical QP has no associated VirtualQp!";
+      CTRAN_LOG_IF(
+          FATAL,
+          info.vqp == nullptr,
+          "Check failed: info.vqp != nullptr: Registered physical QP has no associated VirtualQp!");
       info.vqp->virtualCq_ = this;
     }
   }

--- a/comms/ctran/ibverbx/IbvVirtualCq.h
+++ b/comms/ctran/ibverbx/IbvVirtualCq.h
@@ -4,7 +4,6 @@
 
 #include <folly/Expected.h>
 #include <folly/container/F14Map.h>
-#include <folly/logging/xlog.h>
 #include <deque>
 #include <vector>
 
@@ -13,6 +12,7 @@
 #include "comms/ctran/ibverbx/IbvVirtualQp.h"
 #include "comms/ctran/ibverbx/IbvVirtualWr.h"
 #include "comms/ctran/ibverbx/Ibvcore.h"
+#include "comms/ctran/utils/CtranLogger.h"
 
 namespace ibverbx {
 
@@ -124,10 +124,13 @@ IbvVirtualCq::pollCq() {
         const RegisteredQpInfo* info =
             findRegisteredQpInfo(physicalWc.qp_num, deviceId);
 
-        CHECK(info != nullptr) << fmt::format(
-            "[Ibverbx]IbvVirtualCq::pollCq, unregistered QP: qpNum={}, deviceId={}",
-            physicalWc.qp_num,
-            deviceId);
+        if (info == nullptr) {
+          CTRAN_LOG(
+              FATAL,
+              "Check failed: info != nullptr: [Ibverbx]IbvVirtualCq::pollCq, unregistered QP: qpNum={}, deviceId={}",
+              physicalWc.qp_num,
+              deviceId);
+        }
 
         if (isUsingMultiQpLoadBalancing(info->isMultiQp, physicalWc.opcode)) {
           // Multi-QP RDMA: route to VirtualQp for fragment reassembly

--- a/comms/ctran/ibverbx/IbvVirtualQp.cc
+++ b/comms/ctran/ibverbx/IbvVirtualQp.cc
@@ -24,9 +24,14 @@ IbvVirtualQp::IbvVirtualQp(
       maxMsgSize_(maxMsgSize),
       loadBalancingScheme_(loadBalancingScheme),
       notifyQp_(std::move(notifyQp)) {
-  CHECK(!physicalQps_.empty()) << "At least one physical QP must be provided!";
-  CHECK(physicalQps_.size() == 1 || notifyQp_.has_value())
-      << "notifyQp must be provided when using multiple data QPs!";
+  CTRAN_LOG_IF(
+      FATAL,
+      physicalQps_.empty(),
+      "Check failed: !physicalQps_.empty(): At least one physical QP must be provided!");
+  CTRAN_LOG_IF(
+      FATAL,
+      physicalQps_.size() != 1 && !notifyQp_.has_value(),
+      "Check failed: physicalQps_.size() == 1 || notifyQp_.has_value(): notifyQp must be provided when using multiple data QPs!");
 
   virtualQpNum_ =
       nextVirtualQpNum_.fetch_add(1); // Assign unique virtual QP number
@@ -271,7 +276,10 @@ IbvVirtualQpBusinessCard::fromDynamic(const folly::dynamic& obj) {
     qpNums.reserve(qpNumsArray.size());
 
     for (const auto& qpNum : qpNumsArray) {
-      CHECK(qpNum.isString()) << "qp num is not string!";
+      CTRAN_LOG_IF(
+          FATAL,
+          !qpNum.isString(),
+          "Check failed: qpNum.isString(): qp num is not string!");
       try {
         uint32_t qpNumValue =
             static_cast<uint32_t>(std::stoul(qpNum.asString()));

--- a/comms/ctran/ibverbx/IbvVirtualQp.h
+++ b/comms/ctran/ibverbx/IbvVirtualQp.h
@@ -4,7 +4,6 @@
 
 #include <folly/Expected.h>
 #include <folly/dynamic.h>
-#include <folly/logging/xlog.h>
 #include <deque>
 #include <optional>
 #include <utility>
@@ -90,8 +89,10 @@ class IbvVirtualQp {
   const IbvQp& getNotifyQpRef() const;
   IbvQp& getNotifyQpRef();
   bool hasNotifyQp() const {
-    CHECK(physicalQps_.size() == 1 || notifyQp_.has_value())
-        << "notifyQp must be provided when using multiple data QPs!";
+    CTRAN_LOG_IF(
+        FATAL,
+        physicalQps_.size() != 1 && !notifyQp_.has_value(),
+        "Check failed: physicalQps_.size() == 1 || notifyQp_.has_value(): notifyQp must be provided when using multiple data QPs!");
     return notifyQp_.has_value();
   }
   bool isMultiQp() const {
@@ -544,7 +545,7 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::postRecv(
   }
 
   // SPRAY mode: Post zero-length recv to notifyQp
-  CHECK(hasNotifyQp());
+  CTRAN_LOG_IF(FATAL, !hasNotifyQp(), "Check failed: hasNotifyQp()");
 
   if (notifyQp_->physicalRecvWrStatus_.size() >=
       static_cast<size_t>(maxMsgCntPerQp_)) {
@@ -564,10 +565,11 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::postRecv(
 // Replenish a single DQPLB recv on the specified QP after consuming one
 inline folly::Expected<folly::Unit, Error> IbvVirtualQp::replenishDqplbRecv(
     int qpIdx) {
-  CHECK(qpIdx >= 0 && qpIdx < static_cast<int>(physicalQps_.size()))
-      << fmt::format(
-             "[Ibverbx]IbvVirtualQp::replenishDqplbRecv, invalid qpIdx={}",
-             qpIdx);
+  CTRAN_LOG_IF(
+      FATAL,
+      qpIdx < 0 || qpIdx >= static_cast<int>(physicalQps_.size()),
+      "Check failed: qpIdx >= 0 && qpIdx < static_cast<int>(physicalQps_.size()): [Ibverbx]IbvVirtualQp::replenishDqplbRecv, invalid qpIdx={}",
+      qpIdx);
 
   ibv_recv_wr recvWr{};
   ibv_recv_wr badWr{};
@@ -590,7 +592,7 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::replenishDqplbRecv(
 // Post zero-length recv to notifyQp (SPRAY mode)
 inline folly::Expected<folly::Unit, Error> IbvVirtualQp::postRecvToNotifyQp(
     uint64_t internalWrId) {
-  CHECK(hasNotifyQp());
+  CTRAN_LOG_IF(FATAL, !hasNotifyQp(), "Check failed: hasNotifyQp()");
 
   ibv_recv_wr recvWr{};
   ibv_recv_wr badWr{};
@@ -613,7 +615,7 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::postRecvToNotifyQp(
 // Flush pending recv notifications when notifyQp backpressure clears
 inline folly::Expected<folly::Unit, Error>
 IbvVirtualQp::flushPendingRecvNotifies() {
-  CHECK(hasNotifyQp());
+  CTRAN_LOG_IF(FATAL, !hasNotifyQp(), "Check failed: hasNotifyQp()");
 
   while (!pendingRecvNotifyQue_.empty()) {
     if (notifyQp_->physicalRecvWrStatus_.size() >=
@@ -643,8 +645,10 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::dispatchPendingSends(
     uint64_t internalId = sendTracker_.frontPendingPost();
 
     auto* pending = sendTracker_.find(internalId);
-    CHECK(pending) << fmt::format(
-        "[Ibverbx]IbvVirtualQp::dispatchPendingSends, WR {} in pendingPostQue_ but not found in activeVirtualWrs_",
+    CTRAN_LOG_IF(
+        FATAL,
+        pending == nullptr,
+        "Check failed: pending != nullptr: [Ibverbx]IbvVirtualQp::dispatchPendingSends, WR {} in pendingPostQue_ but not found in activeVirtualWrs_",
         internalId);
 
     while (pending->offset < pending->length) {
@@ -736,8 +740,10 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::reportSendCompletions(
   while (sendTracker_.hasPendingCompletion()) {
     uint64_t frontId = sendTracker_.frontPendingCompletion();
     auto* frontWr = sendTracker_.find(frontId);
-    CHECK(frontWr) << fmt::format(
-        "[Ibverbx]IbvVirtualQp::reportSendCompletions, WR {} in pendingCompletionQue_ but not found in activeVirtualWrs_",
+    CTRAN_LOG_IF(
+        FATAL,
+        frontWr == nullptr,
+        "Check failed: frontWr != nullptr: [Ibverbx]IbvVirtualQp::reportSendCompletions, WR {} in pendingCompletionQue_ but not found in activeVirtualWrs_",
         frontId);
 
     if (frontWr->needsNotify && !frontWr->notifyPosted) {
@@ -745,7 +751,7 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::reportSendCompletions(
         break;
       }
 
-      CHECK(hasNotifyQp());
+      CTRAN_LOG_IF(FATAL, !hasNotifyQp(), "Check failed: hasNotifyQp()");
       if (notifyQp_->physicalSendWrStatus_.size() >=
           static_cast<size_t>(maxMsgCntPerQp_)) {
         pendingSendNotifyQue_.push_back(frontId);
@@ -776,11 +782,13 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::reportSendCompletions(
 inline folly::Expected<folly::Unit, Error> IbvVirtualQp::postSendToNotifyQp(
     uint64_t internalWrId) {
   auto* pending = sendTracker_.find(internalWrId);
-  CHECK(pending) << fmt::format(
-      "[Ibverbx]IbvVirtualQp::postSendToNotifyQp, WR {} not found",
+  CTRAN_LOG_IF(
+      FATAL,
+      pending == nullptr,
+      "Check failed: pending != nullptr: [Ibverbx]IbvVirtualQp::postSendToNotifyQp, WR {} not found",
       internalWrId);
 
-  CHECK(hasNotifyQp());
+  CTRAN_LOG_IF(FATAL, !hasNotifyQp(), "Check failed: hasNotifyQp()");
 
   ibv_send_wr sendWr{};
   sendWr.wr_id = nextPhysicalWrId_++;
@@ -806,7 +814,7 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::postSendToNotifyQp(
 
 inline folly::Expected<folly::Unit, Error>
 IbvVirtualQp::flushPendingSendNotifies() {
-  CHECK(hasNotifyQp());
+  CTRAN_LOG_IF(FATAL, !hasNotifyQp(), "Check failed: hasNotifyQp()");
 
   while (!pendingSendNotifyQue_.empty()) {
     if (notifyQp_->physicalSendWrStatus_.size() >=
@@ -816,8 +824,10 @@ IbvVirtualQp::flushPendingSendNotifies() {
 
     uint64_t frontId = pendingSendNotifyQue_.front();
     auto* frontWr = sendTracker_.find(frontId);
-    CHECK(frontWr) << fmt::format(
-        "[Ibverbx]IbvVirtualQp::flushPendingSendNotifies, WR {} in pendingSendNotifyQue_ but not found in activeVirtualWrs_",
+    CTRAN_LOG_IF(
+        FATAL,
+        frontWr == nullptr,
+        "Check failed: frontWr != nullptr: [Ibverbx]IbvVirtualQp::flushPendingSendNotifies, WR {} in pendingSendNotifyQue_ but not found in activeVirtualWrs_",
         frontId);
 
     if (postSendToNotifyQp(frontId).hasError()) {
@@ -834,8 +844,10 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::reportRecvCompletions(
   while (recvTracker_.hasPendingCompletion()) {
     uint64_t frontId = recvTracker_.frontPendingCompletion();
     auto* frontWr = recvTracker_.find(frontId);
-    CHECK(frontWr) << fmt::format(
-        "[Ibverbx]IbvVirtualQp::reportRecvCompletions, WR {} in pendingCompletionQue_ but not found in activeVirtualWrs_",
+    CTRAN_LOG_IF(
+        FATAL,
+        frontWr == nullptr,
+        "Check failed: frontWr != nullptr: [Ibverbx]IbvVirtualQp::reportRecvCompletions, WR {} in pendingCompletionQue_ but not found in activeVirtualWrs_",
         frontId);
 
     if (frontWr->remainingMsgCnt > 0) {
@@ -866,8 +878,10 @@ inline folly::Expected<folly::Unit, Error> IbvVirtualQp::updateWrState(
     ibv_wc_status status,
     ibv_wc_opcode wcOpcode) {
   auto* wr = tracker.find(internalWrId);
-  CHECK(wr) << fmt::format(
-      "[Ibverbx] WR {} not found in tracker during updateWrState",
+  CTRAN_LOG_IF(
+      FATAL,
+      wr == nullptr,
+      "Check failed: wr != nullptr: [Ibverbx] WR {} not found in tracker during updateWrState",
       internalWrId);
 
   wr->remainingMsgCnt--;
@@ -906,13 +920,17 @@ inline folly::Expected<uint64_t, Error> IbvVirtualQp::popPhysicalQueueStatus(
     std::deque<IbvQp::PhysicalWrStatus>& queStatus,
     uint64_t expectedPhysicalWrId,
     const char* queueName) {
-  CHECK(!queStatus.empty()) << fmt::format(
-      "[Ibverbx]IbvVirtualQp::popPhysicalQueueStatus, no pending WR in {}",
+  CTRAN_LOG_IF(
+      FATAL,
+      queStatus.empty(),
+      "Check failed: !queStatus.empty(): [Ibverbx]IbvVirtualQp::popPhysicalQueueStatus, no pending WR in {}",
       queueName);
 
   auto& frontStatus = queStatus.front();
-  CHECK_EQ(frontStatus.physicalWrId, expectedPhysicalWrId) << fmt::format(
-      "[Ibverbx]IbvVirtualQp::popPhysicalQueueStatus, {} WR ID mismatch: expected {}, got {}",
+  CTRAN_LOG_IF(
+      FATAL,
+      frontStatus.physicalWrId != expectedPhysicalWrId,
+      "Check failed: frontStatus.physicalWrId == expectedPhysicalWrId: [Ibverbx]IbvVirtualQp::popPhysicalQueueStatus, {} WR ID mismatch: expected {}, got {}",
       queueName,
       frontStatus.physicalWrId,
       expectedPhysicalWrId);
@@ -943,8 +961,10 @@ IbvVirtualQp::processCompletion(const ibv_wc& physicalWc, int32_t deviceId) {
                   : processNotifyQpRecvCompletion(physicalWc, results);
   } else {
     auto qpIdxIt = qpNumToIdx_.find(QpId{deviceId, physicalWc.qp_num});
-    CHECK(qpIdxIt != qpNumToIdx_.end()) << fmt::format(
-        "[Ibverbx] unknown physical QP: qpNum={}, deviceId={}",
+    CTRAN_LOG_IF(
+        FATAL,
+        qpIdxIt == qpNumToIdx_.end(),
+        "Check failed: qpIdxIt != qpNumToIdx_.end(): [Ibverbx] unknown physical QP: qpNum={}, deviceId={}",
         physicalWc.qp_num,
         deviceId);
     int qpIdx = qpIdxIt->second;
@@ -1089,14 +1109,19 @@ IbvVirtualQp::processDataQpRecvCompletion(
   int notifyCount = dqplbSeqTracker_.processReceivedImm(physicalWc.imm_data);
 
   for (int i = 0; i < notifyCount; i++) {
-    CHECK(recvTracker_.hasPendingCompletion()) << fmt::format(
-        "[Ibverbx] DQPLB notifyCount={} exceeds outstanding recvs",
+    CTRAN_LOG_IF(
+        FATAL,
+        !recvTracker_.hasPendingCompletion(),
+        "Check failed: recvTracker_.hasPendingCompletion(): [Ibverbx] DQPLB notifyCount={} exceeds outstanding recvs",
         notifyCount);
 
     uint64_t frontId = recvTracker_.frontPendingCompletion();
     auto* frontWr = recvTracker_.find(frontId);
-    CHECK(frontWr) << fmt::format(
-        "[Ibverbx] DQPLB WR {} not found in recvTracker_", frontId);
+    CTRAN_LOG_IF(
+        FATAL,
+        frontWr == nullptr,
+        "Check failed: frontWr != nullptr: [Ibverbx] DQPLB WR {} not found in recvTracker_",
+        frontId);
 
     frontWr->remainingMsgCnt--;
     frontWr->wcOpcode = physicalWc.opcode;

--- a/comms/ctran/ibverbx/IbvVirtualQp.h
+++ b/comms/ctran/ibverbx/IbvVirtualQp.h
@@ -4,6 +4,7 @@
 
 #include <folly/Expected.h>
 #include <folly/dynamic.h>
+#include <folly/logging/xlog.h>
 #include <deque>
 #include <optional>
 #include <utility>

--- a/comms/ctran/ibverbx/tests/IbvVirtualQpTest.cc
+++ b/comms/ctran/ibverbx/tests/IbvVirtualQpTest.cc
@@ -8,6 +8,28 @@ FOLLY_INIT_LOGGING_CONFIG(
 
 namespace ibverbx {
 
+TEST_F(IbverbxTestFixture, IbvQpGetQpNumFailsAfterMove) {
+  auto devices = IbvDevice::ibvGetDeviceList({kNicPrefix});
+  ASSERT_TRUE(devices);
+  auto& device = devices->at(0);
+
+  auto maybeCq = device.createCq(1, nullptr, nullptr, 0);
+  ASSERT_TRUE(maybeCq);
+  auto pd = device.allocPd();
+  ASSERT_TRUE(pd);
+  auto initAttr = makeIbvQpInitAttr(maybeCq->cq());
+  auto maybeQp = pd->createQp(&initAttr);
+  ASSERT_TRUE(maybeQp);
+
+  auto qp = std::move(*maybeQp);
+  IbvQp movedQp(std::move(qp));
+  const auto deathTestStyle = ::testing::FLAGS_gtest_death_test_style;
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_DEATH(qp.getQpNum(), "Check failed: qp_ != nullptr");
+  ::testing::FLAGS_gtest_death_test_style = deathTestStyle;
+  EXPECT_NE(movedQp.qp(), nullptr);
+}
+
 TEST_F(IbverbxTestFixture, IbvVirtualQp) {
   auto devices = IbvDevice::ibvGetDeviceList({kNicPrefix});
   ASSERT_TRUE(devices);

--- a/comms/ctran/ibverbx/tests/IbvVirtualQpTest.cc
+++ b/comms/ctran/ibverbx/tests/IbvVirtualQpTest.cc
@@ -692,12 +692,15 @@ TEST_F(IbverbxTestFixture, IbvVirtualQpUpdateWrState) {
     virtualQp.sendTracker_.remove(id);
   }
 
-  // Test 3: Not-found WR triggers CHECK failure
+  // Test 3: Not-found WR triggers a fatal failure
   {
-    ASSERT_DEATH(
+    const auto deathTestStyle = ::testing::FLAGS_gtest_death_test_style;
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    EXPECT_DEATH(
         virtualQp.updateWrState(
             virtualQp.sendTracker_, 99999, IBV_WC_SUCCESS, IBV_WC_SEND),
         "not found in tracker");
+    ::testing::FLAGS_gtest_death_test_style = deathTestStyle;
   }
 }
 

--- a/comms/ncclx/meta/logger/NcclDebugLog.h
+++ b/comms/ncclx/meta/logger/NcclDebugLog.h
@@ -1,0 +1,44 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <string_view>
+
+#include "nccl_common.h"
+
+#include "meta/NcclxLogger.h"
+
+namespace ncclx::logging {
+
+inline constexpr spdlog::level::level_enum ncclLogLevelToSpdlogLevel(
+    ncclDebugLogLevel level) {
+  switch (level) {
+    case NCCL_LOG_ERROR:
+      return spdlog::level::err;
+    case NCCL_LOG_WARN:
+      return spdlog::level::warn;
+    case NCCL_LOG_TRACE:
+      return spdlog::level::debug;
+    case NCCL_LOG_NONE:
+    case NCCL_LOG_VERSION:
+    case NCCL_LOG_INFO:
+    case NCCL_LOG_ABORT:
+      return spdlog::level::info;
+  }
+  return spdlog::level::info;
+}
+
+inline void writeNcclLog(
+    ncclDebugLogLevel level,
+    const char* file,
+    const char* func,
+    int line,
+    std::string_view message) {
+  meta::comms::logger::getSpdlogLogger(kNcclxLoggerName)
+      .log(
+          spdlog::source_loc{file, line, func},
+          ncclLogLevelToSpdlogLevel(level),
+          message);
+}
+
+} // namespace ncclx::logging

--- a/comms/ncclx/meta/logger/tests/LoggingUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggingUT.cc
@@ -19,6 +19,8 @@
 #include "debug.h" // @manual
 #include "param.h" // @manual
 
+extern "C" void ncclResetDebugInitInternal();
+
 namespace {
 void inline checkStringHasLogging(
     std::string_view output,
@@ -348,6 +350,63 @@ TEST_F(NcclLoggerTest, InfoLogTest) {
   sleep(1);
   output = testing::internal::GetCapturedStdout();
   checkStringHasLogging(output, TestStr, "INFO");
+
+  finishLogging();
+}
+
+TEST_F(NcclLoggerTest, PluginDebugBridgePreservesSourceMetadata) {
+  auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"INFO"});
+  auto asyncGuard = EnvRAII(NCCL_DEBUG_LOGGING_ASYNC, false);
+  setenv("NCCL_DEBUG", "INFO", 1);
+  ncclResetDebugInitInternal();
+
+  initLogging();
+  constexpr std::string_view message = "PLUGIN DEBUG BRIDGE";
+
+  testing::internal::CaptureStdout();
+  ncclDebugLog(
+      NCCL_LOG_INFO,
+      NCCL_ALL,
+      "transport/plugin.cc:pluginFunc",
+      321,
+      "%s",
+      message.data());
+  auto& logger =
+      meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName);
+  logger.flush();
+  const auto output = testing::internal::GetCapturedStdout();
+
+  checkStringHasLogging(output, message, "INFO");
+  EXPECT_THAT(output, testing::HasSubstr("plugin.cc:pluginFunc:321]"));
+
+  finishLogging();
+}
+
+TEST_F(NcclLoggerTest, MetaDebugBridgePreservesTraceAndSourceMetadata) {
+  auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"TRACE"});
+  auto asyncGuard = EnvRAII(NCCL_DEBUG_LOGGING_ASYNC, false);
+  setenv("NCCL_DEBUG", "TRACE", 1);
+  ncclResetDebugInitInternal();
+
+  initLogging();
+  constexpr std::string_view message = "META DEBUG BRIDGE";
+
+  testing::internal::CaptureStdout();
+  ncclMetaDebugLog(
+      NCCL_LOG_TRACE,
+      NCCL_ALL,
+      "source.cc",
+      "sourceFunction",
+      654,
+      "%s",
+      message.data());
+  auto& logger =
+      meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName);
+  logger.flush();
+  const auto output = testing::internal::GetCapturedStdout();
+
+  checkStringHasLogging(output, message, "VERBOSE");
+  EXPECT_THAT(output, testing::HasSubstr("source.cc:654]"));
 
   finishLogging();
 }

--- a/comms/ncclx/v2_29/src/debug.cc
+++ b/comms/ncclx/v2_29/src/debug.cc
@@ -24,14 +24,11 @@
 #include <cstdio>
 #include <vector>
 #include <sstream>
-#include <folly/logging/LogLevel.h>
-#include <folly/logging/LogStreamProcessor.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/ErrorStackUtil.h"
-#include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/LoggingFormat.h"
+#include "meta/logger/NcclDebugLog.h"
 
 #define NCCL_DEBUG_RESET_TRIGGERED (-2)
 
@@ -369,17 +366,6 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
   }
 
   std::stringstream logStream;
-  auto logLevel = folly::LogLevel::INFO;
-  if (level == NCCL_LOG_WARN) {
-    logLevel = folly::LogLevel::WARN;
-  } else if (level == NCCL_LOG_INFO || level == NCCL_LOG_VERSION) {
-    logLevel = folly::LogLevel::INFO;
-  } else if (level == NCCL_LOG_TRACE) {
-    logLevel = folly::LogLevel::DBG;
-  } else if (level == NCCL_LOG_ERROR) {
-    logLevel = folly::LogLevel::ERR;
-  }
-
   size_t logLen = 0;
   va_list vargs;
   va_start(vargs, fmt);
@@ -394,16 +380,7 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
   logStream << buffer.data();
 
   auto logStr = logStream.str();
-  // logging to specified stdout/stderr/file
-  folly::LogStreamProcessor(
-    XLOG_GET_CATEGORY(),
-    logLevel,
-    filefunc,
-    line,
-    "",
-    folly::LogStreamProcessor::AppendType::APPEND)
-        .stream()
-    << logStr;
+  ncclx::logging::writeNcclLog(level, filefunc, "", line, logStr);
 }
 
 // Non-deprecated version for internal use.
@@ -480,9 +457,7 @@ void ncclMetaDebugLogWithScuba(ncclDebugLogLevel level, unsigned long flags, con
 
 /* Meta's logging function with separate file and func parameters.
  * Used by the VERSION, WARN, ERR, INFO, TRACE_CALL, and TRACE macros.
- * Unlike ncclDebugLog (which combines file/func into filefunc for OFI plugin
- * compatibility), this passes file and func separately to LogStreamProcessor
- * so that folly can correctly resolve log levels and categories.
+ * ncclDebugLog keeps file/func combined for OFI plugin compatibility.
  */
 
 void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file, const char *func, int line, const char *fmt, ...) {
@@ -514,17 +489,6 @@ void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *
   }
 
   std::stringstream logStream;
-  auto logLevel = folly::LogLevel::INFO;
-  if (level == NCCL_LOG_WARN) {
-    logLevel = folly::LogLevel::WARN;
-  } else if (level == NCCL_LOG_INFO || level == NCCL_LOG_VERSION) {
-    logLevel = folly::LogLevel::INFO;
-  } else if (level == NCCL_LOG_TRACE) {
-    logLevel = folly::LogLevel::DBG;
-  } else if (level == NCCL_LOG_ERROR) {
-    logLevel = folly::LogLevel::ERR;
-  }
-
   size_t logLen = 0;
   va_list vargs;
   va_start(vargs, fmt);
@@ -539,14 +503,5 @@ void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *
   logStream << buffer.data();
 
   auto logStr = logStream.str();
-  // logging to specified stdout/stderr/file
-  folly::LogStreamProcessor(
-    XLOG_GET_CATEGORY(),
-    logLevel,
-    file,
-    line,
-    func,
-    folly::LogStreamProcessor::AppendType::APPEND)
-        .stream()
-    << logStr;
+  ncclx::logging::writeNcclLog(level, file, func, line, logStr);
 }

--- a/comms/ncclx/v2_30/src/debug.cc
+++ b/comms/ncclx/v2_30/src/debug.cc
@@ -23,12 +23,9 @@
 #include <cstdio>
 #include <vector>
 #include <sstream>
-#include <folly/logging/LogLevel.h>
-#include <folly/logging/LogStreamProcessor.h>
-#include <folly/logging/xlog.h>
 
-#include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/LoggingFormat.h"
+#include "meta/logger/NcclDebugLog.h"
 
 #define NCCL_DEBUG_RESET_TRIGGERED (-2)
 
@@ -372,17 +369,6 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
   }
 
   std::stringstream logStream;
-  auto logLevel = folly::LogLevel::INFO;
-  if (level == NCCL_LOG_WARN) {
-    logLevel = folly::LogLevel::WARN;
-  } else if (level == NCCL_LOG_INFO || level == NCCL_LOG_VERSION) {
-    logLevel = folly::LogLevel::INFO;
-  } else if (level == NCCL_LOG_TRACE) {
-    logLevel = folly::LogLevel::DBG;
-  } else if (level == NCCL_LOG_ERROR) {
-    logLevel = folly::LogLevel::ERR;
-  }
-
   size_t logLen = 0;
   va_list vargs;
   va_start(vargs, fmt);
@@ -397,16 +383,7 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
   logStream << buffer.data();
 
   auto logStr = logStream.str();
-  // logging to specified stdout/stderr/file
-  folly::LogStreamProcessor(
-    XLOG_GET_CATEGORY(),
-    logLevel,
-    filefunc,
-    line,
-    "",
-    folly::LogStreamProcessor::AppendType::APPEND)
-        .stream()
-    << logStr;
+  ncclx::logging::writeNcclLog(level, filefunc, "", line, logStr);
 }
 
 // Non-deprecated version for internal use.
@@ -469,9 +446,7 @@ void ncclSetMyThreadLoggingName(std::string_view name) {
 
 /* Meta's logging function with separate file and func parameters.
  * Used by the VERSION, WARN, ERR, INFO, TRACE_CALL, and TRACE macros.
- * Unlike ncclDebugLog (which combines file/func into filefunc for OFI plugin
- * compatibility), this passes file and func separately to LogStreamProcessor
- * so that folly can correctly resolve log levels and categories.
+ * ncclDebugLog keeps file/func combined for OFI plugin compatibility.
  */
 
 void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file, const char *func, int line, const char *fmt, ...) {
@@ -503,17 +478,6 @@ void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *
   }
 
   std::stringstream logStream;
-  auto logLevel = folly::LogLevel::INFO;
-  if (level == NCCL_LOG_WARN) {
-    logLevel = folly::LogLevel::WARN;
-  } else if (level == NCCL_LOG_INFO || level == NCCL_LOG_VERSION) {
-    logLevel = folly::LogLevel::INFO;
-  } else if (level == NCCL_LOG_TRACE) {
-    logLevel = folly::LogLevel::DBG;
-  } else if (level == NCCL_LOG_ERROR) {
-    logLevel = folly::LogLevel::ERR;
-  }
-
   size_t logLen = 0;
   va_list vargs;
   va_start(vargs, fmt);
@@ -528,14 +492,5 @@ void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *
   logStream << buffer.data();
 
   auto logStr = logStream.str();
-  // logging to specified stdout/stderr/file
-  folly::LogStreamProcessor(
-    XLOG_GET_CATEGORY(),
-    logLevel,
-    file,
-    line,
-    func,
-    folly::LogStreamProcessor::AppendType::APPEND)
-        .stream()
-    << logStr;
+  ncclx::logging::writeNcclLog(level, file, func, line, logStr);
 }

--- a/comms/utils/logger/LogTypes.cc
+++ b/comms/utils/logger/LogTypes.cc
@@ -1,0 +1,23 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/LogTypes.h"
+
+namespace meta::comms::logger {
+namespace {
+
+uint64_t& getSubSystemMask() {
+  static uint64_t subSystemMask = 0;
+  return subSystemMask;
+}
+
+} // namespace
+
+void setSubSystemMask(uint64_t subSystemMaskValue) {
+  getSubSystemMask() = subSystemMaskValue;
+}
+
+bool isEnabledSubSystemBitwise(uint64_t subSystem) {
+  return getSubSystemMask() & subSystem;
+}
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/LogTypes.h
+++ b/comms/utils/logger/LogTypes.h
@@ -1,0 +1,49 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstdint>
+
+namespace meta::comms::logger {
+
+enum class LogLevel {
+  NONE = 0,
+  VERSION = 1,
+  ERROR = 2,
+  WARN = 3,
+  INFO = 4,
+  ABORT = 5,
+  TRACE = 6
+};
+
+#pragma push_macro("NET")
+#pragma push_macro("INIT")
+#undef NET
+#undef INIT
+enum SubSystem {
+  INIT = 0x1,
+  COLL = 0x2,
+  P2P = 0x4,
+  SHM = 0x8,
+  NET = 0x10,
+  GRAPH = 0x20,
+  TUNING = 0x40,
+  ENV = 0x80,
+  ALLOC = 0x100,
+  CALL = 0x200,
+  PROXY = 0x400,
+  NVLS = 0x800,
+  BOOTSTRAP = 0x1000,
+  REG = 0x2000,
+  PROFILE = 0x4000,
+  RAS = 0x8000,
+  ALL = ~0
+};
+#pragma pop_macro("INIT")
+#pragma pop_macro("NET")
+
+void setSubSystemMask(uint64_t subSystemMask);
+
+bool isEnabledSubSystemBitwise(uint64_t subSystem);
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/LogUtils.cc
+++ b/comms/utils/logger/LogUtils.cc
@@ -13,8 +13,6 @@
 namespace meta::comms::logger {
 
 namespace {
-static uint64_t subSystemMask = 0; // Bitmask of enabled subsystems
-
 folly::once_flag commLoggingInitOnceFlag;
 
 void initCommLoggingImpl() {
@@ -35,14 +33,6 @@ void initCommLoggingImpl() {
           }});
 }
 } // anonymous namespace
-
-void setSubSystemMask(uint64_t subSystemMask_) {
-  subSystemMask = subSystemMask_;
-}
-
-bool isEnabledSubSystemBitwise(uint64_t subSystem) {
-  return subSystemMask & subSystem;
-}
 
 void initCommLogging(bool alwaysInit) {
   if (alwaysInit) {

--- a/comms/utils/logger/LogUtils.h
+++ b/comms/utils/logger/LogUtils.h
@@ -7,6 +7,7 @@
 #include <folly/Format.h>
 #include <folly/logging/xlog.h>
 
+#include "comms/utils/logger/LogTypes.h"
 #include "comms/utils/logger/LoggingFormat.h"
 #include "comms/utils/logger/RateLimit.h"
 
@@ -22,13 +23,6 @@
 namespace meta::comms::logger {
 
 constexpr std::string_view kCommsUtilsCategory = "comms.utils";
-
-/**
- * Bitwise OR of all sub-systems that needs to be enabled.
- */
-void setSubSystemMask(uint64_t subSystemMask);
-
-bool isEnabledSubSystemBitwise(uint64_t subSystem);
 
 /**
  * Initialize logging for Comms. By default it only initializes once globlally

--- a/comms/utils/logger/LoggingFormat.h
+++ b/comms/utils/logger/LoggingFormat.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>
@@ -13,46 +12,9 @@
 #include <folly/logging/LogLevel.h>
 
 #include "comms/utils/commSpecs.h"
+#include "comms/utils/logger/LogTypes.h"
 
 namespace meta::comms::logger {
-
-enum class LogLevel {
-  NONE = 0,
-  VERSION = 1,
-  ERROR = 2,
-  WARN = 3,
-  INFO = 4,
-  ABORT = 5,
-  TRACE = 6
-};
-
-// Save and restore macros that collide with our enum values.
-// topo.h defines #define NET 5 which would expand inside the enum.
-#pragma push_macro("NET")
-#pragma push_macro("INIT")
-#undef NET
-#undef INIT
-enum SubSystem {
-  INIT = 0x1,
-  COLL = 0x2,
-  P2P = 0x4,
-  SHM = 0x8,
-  NET = 0x10,
-  GRAPH = 0x20,
-  TUNING = 0x40,
-  ENV = 0x80,
-  ALLOC = 0x100,
-  CALL = 0x200,
-  PROXY = 0x400,
-  NVLS = 0x800,
-  BOOTSTRAP = 0x1000,
-  REG = 0x2000,
-  PROFILE = 0x4000,
-  RAS = 0x8000,
-  ALL = ~0
-};
-#pragma pop_macro("INIT")
-#pragma pop_macro("NET")
 
 // TODO: Properly clean this up so that we directly parse NCCL logs to folly
 // levels.


### PR DESCRIPTION
Summary:
Replace the 24 remaining Folly-backed fatal checks in the `ibv-virtual-qp` target with `CTRAN_LOG_IF(FATAL, ...)`. Preserve each failure predicate, process-terminating behavior, and diagnostic values while removing the direct `folly/logging` header and BUCK dependency.

The source-file checks were previously receiving the Folly macros transitively from `IbvVirtualQp.h`; migrate them in the same target-scoped change. Run the existing fatal-path assertion in GTest's `threadsafe` death-test mode because the CTRAN logger can have worker threads active before the assertion.

Reviewed By: shr

Differential Revision: D115619900


