### PR TITLE
Restore MCCL_NVL_FABRIC_ENABLE default to true

### DIFF
--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -187,7 +187,17 @@ void CommStateX::setNvlFabricTopos(
   std::unordered_map<std::string, int> clusterIdToNvlDomainIndex;
   // cliqueIds might not be contiguous, within the same communicator.
   // CliqueIndex is contiguous fron 0 to nCliqueIds - 1.
-  std::unordered_map<int64_t, int> cliqueIdToCliqueIndex;
+  //
+  // Keyed on (clusterId, cliqueId), NOT cliqueId alone. A cliqueId is only
+  // meaningful WITHIN an NVL fabric cluster: it is a partition index, not a
+  // globally unique id, and GB200/GB300 hosts commonly report the same sentinel
+  // value (32766) across entirely unrelated racks. Keying on cliqueId alone
+  // therefore merges ranks from different clusters into one clique, which makes
+  // nLocalRanks span hosts that share no NVLink domain -- CTRAN then attempts a
+  // fabric IPC import across them and fails with CUDA_ERROR_INVALID_HANDLE.
+  // Observed in production: 3 ranks, 3 distinct clusterIds, collapsed into one
+  // 3-rank clique with nNodes=1.
+  std::unordered_map<std::string, int> clusterCliqueToCliqueIndex;
 
   nvlFabricRankStates_.resize(nRanks_);
   for (int i = 0; i < nRanks_; i++) {
@@ -210,12 +220,13 @@ void CommStateX::setNvlFabricTopos(
       nvlFabricRankStates_.at(i).nvlDomainRank = nvlDomainRank;
       if (nvlFabricCliqueEnabled_) {
         // update clique level info if clique is enabled
-        if (!cliqueIdToCliqueIndex.contains(cliqueId)) {
+        const auto cliqueKey = fmt::format("{}:{}", clusterId, cliqueId);
+        if (!clusterCliqueToCliqueIndex.contains(cliqueKey)) {
           // new clique found
-          cliqueIdToCliqueIndex[cliqueId] = cliqueRanks_.size();
+          clusterCliqueToCliqueIndex[cliqueKey] = cliqueRanks_.size();
           cliqueRanks_.emplace_back();
         }
-        int cliqueIndex = cliqueIdToCliqueIndex.at(cliqueId);
+        int cliqueIndex = clusterCliqueToCliqueIndex.at(cliqueKey);
         int cliqueRank = cliqueRanks_.at(cliqueIndex).size();
         cliqueRanks_.at(cliqueIndex).emplace_back(i);
 
@@ -252,9 +263,9 @@ void CommStateX::setNvlFabricTopos(
       nvlDomainRanks_.size());
 
   FB_CHECKABORT(
-      cliqueIdToCliqueIndex.size() == cliqueRanks_.size(),
-      "size of cliqueIdToCliqueIndex : {} not equal to size cliqueRanks_: {}",
-      cliqueIdToCliqueIndex.size(),
+      clusterCliqueToCliqueIndex.size() == cliqueRanks_.size(),
+      "size of clusterCliqueToCliqueIndex : {} not equal to size cliqueRanks_: {}",
+      clusterCliqueToCliqueIndex.size(),
       cliqueRanks_.size());
 
   // Step 2: noLocal is equivalent to vCliqueSize=1. When either is set,

--- a/comms/ctran/commstate/tests/CommStateXTest.cc
+++ b/comms/ctran/commstate/tests/CommStateXTest.cc
@@ -472,6 +472,68 @@ TEST(CommStateXTest, nvlFabricCliqueTest) {
   EXPECT_FALSE(commState->nvlFabricCliqueEnabled());
 }
 
+// Regression: a cliqueId is only meaningful WITHIN an NVL fabric cluster. It is
+// a partition index, not a globally unique id, and real GB200/GB300 hosts
+// commonly report the same sentinel value (32766) across unrelated racks.
+//
+// Keying clique membership on cliqueId alone merged ranks from DIFFERENT
+// clusters into one clique, making nLocalRanks span hosts that share no NVLink
+// domain. CTRAN then attempted a fabric IPC import across them and failed with
+// CUDA_ERROR_INVALID_HANDLE. Observed in production on nao GB200: 3 ranks,
+// 3 distinct clusterIds, collapsed into a single 3-rank clique with nNodes=1.
+//
+// Here two distinct clusters share ONE cliqueId. They must stay two separate
+// cliques of 2 ranks (nNodes=2), NOT merge into one 4-rank clique (nNodes=1).
+TEST(CommStateXTest, nvlFabricCliqueIdCollisionAcrossClusters) {
+  EnvRAII env1(NCCL_MNNVL_DETERMINISTIC_COLLECTIVE_ENABLE, true);
+  EnvRAII env2(NCCL_MNNVL_CLIQUE_SIZE, 2);
+  const int rank = 0;
+  const int nRanks = 4;
+
+  // Same cliqueId on every rank -- the sentinel-cliqueId case.
+  std::vector<NvlFabricTopology> nvlFabricTopologies{};
+  nvlFabricTopologies.emplace_back(
+      createNvlFabricTopology(0, kNvlFabricClusterId1, kNvlFabricCliqueId1));
+  nvlFabricTopologies.emplace_back(
+      createNvlFabricTopology(1, kNvlFabricClusterId1, kNvlFabricCliqueId1));
+  nvlFabricTopologies.emplace_back(
+      createNvlFabricTopology(2, kNvlFabricClusterId2, kNvlFabricCliqueId1));
+  nvlFabricTopologies.emplace_back(
+      createNvlFabricTopology(3, kNvlFabricClusterId2, kNvlFabricCliqueId1));
+
+  std::vector<RankTopology> rankTopologies{};
+  rankTopologies.emplace_back(createRankTopology(0, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(1, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(2, kDc, kZone, kHost1));
+  rankTopologies.emplace_back(createRankTopology(3, kDc, kZone, kHost1));
+
+  auto commState = std::make_unique<CommStateX>(
+      rank,
+      nRanks,
+      /*cudaDev=*/0,
+      /*cudaArch=*/90,
+      /*busId=*/25,
+      /*commHash=*/0,
+      rankTopologies,
+      std::vector<int>{});
+  commState->setNvlFabricTopos(std::move(nvlFabricTopologies), true);
+
+  ASSERT_TRUE(commState->nvlFabricEnabled());
+  ASSERT_TRUE(commState->nvlFabricCliqueEnabled());
+
+  // The load-bearing assertion: two clusters must not fuse into one group.
+  EXPECT_EQ(commState->nNodes(), 2);
+  for (int i = 0; i < nRanks; ++i) {
+    EXPECT_EQ(commState->nLocalRanks(i), 2) << "rank " << i;
+    EXPECT_EQ(commState->node(i), i / 2) << "rank " << i;
+  }
+  // Ranks 0,1 share cluster 1; ranks 2,3 are in cluster 2 and must not be
+  // reported as sharing an NVL fabric with rank 0.
+  EXPECT_TRUE(commState->isSameNvlFabric(0, 1));
+  EXPECT_FALSE(commState->isSameNvlFabric(0, 2));
+  EXPECT_FALSE(commState->isSameNvlFabric(0, 3));
+}
+
 TEST(CommStateXTest, nvlFabricVCliqueSizeHint) {
   const int rank = 0;
   const int nRanks = 8;

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2044,17 +2044,19 @@ cvars:
 
  - name        : MCCL_NVL_FABRIC_ENABLE
    type        : bool
-   default     : false
+   default     : true
    description : |-
      Recognize the MNNVL cross-host NVL fabric domain when initializing an MCCL
      communicator's topology. When true, ranks sharing an NVL fabric clusterUuid
      collapse into a single NVL domain, so nLocalRanks spans hosts and cross-host
      peers are classified as NVL rather than IB. When false, the NVL logical
      group is constrained to same-host ranks and cross-host peers route over IB.
-     Defaults to false because the collapse is only valid where fabric handles
-     are importable between the peers: a fleet that advertises fabric without a
-     shared IMEX domain fails communicator init outright. Set true on fleets
-     known to share an IMEX domain.
+
+     This defaulted to false as a temporary mitigation (D115317781): cliques
+     could be formed across unrelated NVL clusters, which made CTRAN attempt a
+     fabric IPC import between hosts sharing no NVLink domain and fail
+     communicator init outright. The parent diff fixes that grouping, so the
+     default is restored here. Set false to opt out.
 
  - name        : MCCL_ALLREDUCE_ZERO_COPY_MODE
    type        : enum


### PR DESCRIPTION
Summary:
Reverts the temporary mitigation from D115317781, which set this to false to
stop MNNVL fabric topology from being built at all.

That mitigation was needed because cliques could be formed across unrelated NVL
clusters: `setNvlFabricTopos` keyed clique membership on `cliqueId` alone, and
GB200/GB300 hosts report the sentinel `CliqueId 32766`, so ranks in different
`clusterId`s fused into one clique. `nLocalRanks` then spanned hosts sharing no
NVLink domain, CTRAN attempted a fabric IPC import across them, and communicator
init died with `CUDA_ERROR_INVALID_HANDLE` at `CtranIpc.cc:120`.

The parent diff (D115481766) keys cliques on `(clusterId, cliqueId)`, so the
grouping that made the mitigation necessary no longer occurs. Restoring the
default re-enables MNNVL fabric recognition, without which cross-host peers
fall back to IB and a single-NVL-domain algo cannot span an MNNVL clique.

**Must land after D115481766.** Restoring this default before the clique fix is
in would reintroduce the init failure the mitigation was suppressing.

Differential Revision: D115656933


