### PR TITLE
Migrate NCCLX check logs

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -15,7 +15,6 @@
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 
 bool ctranPrimsEnabled(const CtranComm* comm) {
   const auto enablePrims = comm->config_.primsConfig.enablePrims;
@@ -177,7 +176,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     config.nvlConfig.perChannelSize = alignedPerChannelSize(
         nvlSharedDevbufSize, nvlMaxNumChannels, config.nvlConfig.pipelineDepth);
     if (config.nvlConfig.perChannelSize == 0) {
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "CTRAN-PRIMS: invalid NVL config; sharedDevbufSize={} maxNumChannels={} pipelineDepth={} cannot produce aligned perChannelSize",
           nvlSharedDevbufSize,
@@ -215,7 +214,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         config.nvlConfig.ll128BufferSize =
             comms::prims::ll128_buffer_size(256 * 1024);
       }
-      CLOGF(
+      CTRAN_LOG(
           INFO,
           "Prims LL128 buffer size configured (size={} per peer)",
           config.nvlConfig.ll128BufferSize);
@@ -250,7 +249,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     if (requestedMaxChannels <= 0 ||
         requestedMaxChannels >
             static_cast<int64_t>(std::numeric_limits<int>::max())) {
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "max channels must be in [1, {}], got {} (from {})",
           std::numeric_limits<int>::max(),
@@ -275,7 +274,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     if (requestedPipelineDepth <= 0 ||
         requestedPipelineDepth >
             static_cast<int64_t>(std::numeric_limits<int>::max())) {
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "channel pipeline depth must be in [1, {}], got {} (from {})",
           std::numeric_limits<int>::max(),
@@ -296,7 +295,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         : static_cast<size_t>(MCCL_CHANNEL_BUFFER_SIZE);
     if (perDirectionChannelBuffer >
         std::numeric_limits<size_t>::max() / static_cast<size_t>(maxChannels)) {
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "channel buffer size {} (from {}) overflows total size for {} channels (from {})",
           perDirectionChannelBuffer,
@@ -332,7 +331,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     }
     config.ibConfig.ibLazyConnect = pc.ibLazyConnect;
     if (NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC <= 0) {
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC must be positive, got {}",
           NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC);
@@ -353,14 +352,14 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     }
 
     if (config.ibConfig.dataBufferSize == 0) {
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "send/recv requires a positive staging size via MCCL_CHANNEL_BUFFER_SIZE or primsConfig.channelBufferSize");
       return commInvalidArgument;
     }
     const auto pipelineDepth = static_cast<size_t>(channelPipelineDepth);
     if (perDirectionChannelBuffer % pipelineDepth != 0) {
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "IB per-direction channel buffer {} (from {}) must be divisible by pipeline depth {}",
           perDirectionChannelBuffer,
@@ -379,7 +378,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
           if (value >= 16 && value % 16 == 0) {
             return true;
           }
-          CLOGF(
+          CTRAN_LOG(
               ERR,
               "IB {} must be >= 16 and 16-byte aligned, got {} (from {})",
               what,
@@ -403,7 +402,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     config.ibConfig.perChannelSize = perDirectionChannelBuffer;
     config.ibConfig.max_num_channels = config.ibConfig.maxGroups;
     config.ibConfig.pipelineDepth = channelPipelineDepth;
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "Prims IB sendRecv configured: rank={}, commDesc={}, perChannelSize={} (from {}), channelChunkSize={}, maxNumChannels={}, pipelineDepth={} (from {}), dataBufferSize={}",
         comm->statex_->rank(),
@@ -428,7 +427,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         static_cast<comms::prims::MnnvlMode>(NCCL_MNNVL_ENABLE);
     config.topoConfig.logicalNvlRanks = comm->statex_->localRankToRanks();
 
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} enableMultimem={} multimemPerChannelSize={} multimemPipelineDepth={} multimemMaxChannels={} multimemMaxBlocks={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={}",
         comm->statex_->rank(),
@@ -456,7 +455,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         config.ibConfig.qpDepth,
         config.ibConfig.ibLazyConnect);
 
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: full config prepared rank={} logicalNvlRanks={}",
         comm->statex_->rank(),
@@ -471,7 +470,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     // reliable way to distinguish real MNNVL (GB200) from false positives.
     if (config.topoConfig.mnnvlMode != comms::prims::MnnvlMode::kDisabled &&
         !ctran::utils::isCuMemFabricEnabled()) {
-      CLOGF(
+      CTRAN_LOG(
           INFO,
           "CTRAN-PRIMS: FABRIC handle probe failed — disabling MNNVL Tier 1 "
           "topology detection (falling back to same-host peer access)");
@@ -510,7 +509,8 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         comm->multiPeerTransport_->ib_peer_ranks().size(),
         config.topoConfig.p2pDisable);
   } catch (const std::exception& e) {
-    CLOGF(ERR, "Failed to initialize Prims MultiPeerTransport: {}", e.what());
+    CTRAN_LOG(
+        ERR, "Failed to initialize Prims MultiPeerTransport: {}", e.what());
     return commInternalError;
   }
 
@@ -601,7 +601,7 @@ void validatePipesCtranConsistency(CtranComm* comm) {
 commResult_t ctranInitPipesResources(CtranAlgo* algo) {
   auto* comm = algo->comm_;
   if (!comm->multiPeerTransport_) {
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: resource initialization skipped; MultiPeerTransport is not initialized");
     return commSuccess;
@@ -609,7 +609,7 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo) {
 
   auto* statex = comm->statex_.get();
   int localRank = statex->localRank();
-  CLOGF(
+  CTRAN_LOG(
       INFO,
       "CTRAN-PRIMS: resource initialization started rank={} localRank={} nLocalRanks={} nRanks={} cudaDev={}",
       statex->rank(),
@@ -628,7 +628,7 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo) {
       "prims resource initialization");
 
   int nvlNRanks = comm->multiPeerTransport_->nvl_n_ranks();
-  CLOGF(
+  CTRAN_LOG(
       INFO,
       "CTRAN-PRIMS: resource topology rank={} nvlNRanks={} nvlPeers={} ibPeers={}",
       statex->rank(),
@@ -642,12 +642,12 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo) {
   const bool canUseExternalNvlBuffers =
       nvlNRanks > 1 && nvlNRanks == statex->nLocalRanks();
   if (canUseExternalNvlBuffers) {
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: validating ctran/prims consistency rank={}",
         statex->rank());
     validatePipesCtranConsistency(comm);
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: ctran/prims consistency validated rank={}",
         statex->rank());
@@ -655,7 +655,7 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo) {
     // Build per-NVL-rank buffer spans. DeviceSpan is non-assignable (const
     // pointer member), so we construct the vectors in NVL local rank order.
     const auto bufSize = static_cast<uint32_t>(algo->devState_.bufSize);
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: building external NVL staging spans rank={} bufSize={} nvlNRanks={}",
         statex->rank(),
@@ -674,7 +674,7 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo) {
       }
       // Map NVL local rank back to statex local rank index (same value since
       // both systems assign indices in sorted global rank order).
-      CLOGF(
+      CTRAN_LOG(
           INFO,
           "CTRAN-PRIMS: wiring NVL staging span rank={} nvlLocalRank={} localBuf={} remoteBuf={} size={}",
           statex->rank(),
@@ -694,23 +694,23 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo) {
     externalBufs.localBuffers = std::move(localSpans);
     externalBufs.remoteBuffers = std::move(remoteSpans);
 
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: setting external NVL data buffers rank={}",
         statex->rank());
     comm->multiPeerTransport_->setExternalNvlDataBuffers(
         std::move(externalBufs));
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: external NVL data buffers set rank={}",
         statex->rank());
   } else if (nvlNRanks <= 1) {
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: no NVL peers; skipping external staging buffer wiring rank={}",
         statex->rank());
   } else {
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: physical NVLink group size {} differs from Ctran local group size {}; using internal staging buffers rank={}",
         nvlNRanks,
@@ -718,17 +718,17 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo) {
         statex->rank());
   }
 
-  CLOGF(
+  CTRAN_LOG(
       INFO,
       "CTRAN-PRIMS: starting MultiPeerTransport exchange rank={}",
       statex->rank());
   comm->multiPeerTransport_->exchange();
-  CLOGF(
+  CTRAN_LOG(
       INFO,
       "CTRAN-PRIMS: MultiPeerTransport exchange finished rank={}",
       statex->rank());
 
-  CLOGF(
+  CTRAN_LOG(
       INFO,
       "CTRAN-PRIMS: resource initialization finished rank={}",
       statex->rank());

--- a/comms/ctran/algos/AllGather/AllGatherDirect.cc
+++ b/comms/ctran/algos/AllGather/AllGatherDirect.cc
@@ -210,8 +210,10 @@ static inline unsigned int getThreadBlockSize() {
   // If first time call, query cuda recommended blockSize
   if (bestThreadBlockSize == 0) {
     int minGridSize = 0;
-    XCHECK(kernFnMap.contains(commFloat32))
-        << "kernFnMap does not contain datatype";
+    CTRAN_LOG_IF(
+        FATAL,
+        !kernFnMap.contains(commFloat32),
+        "Check failed: kernFnMap.contains(commFloat32): kernFnMap does not contain datatype");
     FB_CUDACHECK(cudaOccupancyMaxPotentialBlockSize(
         &minGridSize,
         (int*)&bestThreadBlockSize,
@@ -304,8 +306,11 @@ commResult_t ctranAllGatherDirect(
       comm,
       stream));
   FB_COMMCHECK(setupPlan(comm, opGroup, config));
-  XCHECK(kernFnMap.contains(datatype))
-      << "kernFnMap does not contain datatype " << datatype;
+  CTRAN_LOG_IF(
+      FATAL,
+      !kernFnMap.contains(datatype),
+      "Check failed: kernFnMap.contains(datatype): kernFnMap does not contain datatype {}",
+      static_cast<int>(datatype));
   FB_COMMCHECK(comm->ctran_->gpe->submit(
       std::move(opGroup), impl, config, kernFnMap.at(datatype)));
   if (extraCopyBuff != nullptr) {

--- a/comms/ctran/algos/AllReduce/AllReduceDirect.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceDirect.cc
@@ -620,9 +620,12 @@ commResult_t ctranAllReduceDirect(
   op->allreduce.datatype = datatype;
   op->allreduce.op = redOp;
 
-  XCHECK(typeToFunc.contains(std::make_pair(datatype, redOp)))
-      << "typeToFunc does not contain datatype " << datatype << " with op "
-      << redOp;
+  CTRAN_LOG_IF(
+      FATAL,
+      !typeToFunc.contains(std::make_pair(datatype, redOp)),
+      "Check failed: typeToFunc.contains(std::make_pair(datatype, redOp)): typeToFunc does not contain datatype {} with op {}",
+      static_cast<int>(datatype),
+      static_cast<int>(redOp));
   const void* func = typeToFunc.at(std::make_pair(datatype, redOp));
 
   auto config = KernelConfig(

--- a/comms/ctran/backends/socket/CtranSocket.cc
+++ b/comms/ctran/backends/socket/CtranSocket.cc
@@ -132,7 +132,7 @@ void CtranSocket::init(const SocketServerAddr& serverAddr) {
           "CTRAN-SOCKET: No socket interfaces found (NCCL_SOCKET_IFNAME={}, NCCL_SOCKET_IPADDR_PREFIX={})",
           NCCL_SOCKET_IFNAME,
           NCCL_SOCKET_IPADDR_PREFIX);
-      CERR(commSystemError, "{}", msg);
+      CTRAN_ERR(commSystemError, "{}", msg);
       throw ctran::utils::Exception(
           msg, commSystemError, rank_, commHash_, commDesc_);
     } else {
@@ -304,7 +304,7 @@ commResult_t CtranSocket::updateSocket(
     int peerRank) {
   auto locked = socketMaps_.wlock();
   if (locked->rankToSocket.find(peerRank) != locked->rankToSocket.end()) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "CTRAN-SOCKET: socket already exists for peerRank {} in pimpl {} "
         "commHash {:x}, commDesc {}. It likely indicates a NCCL bug.",
@@ -429,7 +429,7 @@ commResult_t CtranSocket::progressInternal() {
     continueWhileLoop = false;
     int count = poll(fds.data(), fds.size(), NCCL_CTRAN_SOCKET_POLL_TIMEOUT);
     if (count < 0) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-SOCKET: polling error, errno {}",
           strerror(errno));
@@ -479,7 +479,7 @@ commResult_t CtranSocket::progressInternal() {
               bytes_read);
         }
       } else if (fds[fid].revents != 0) {
-        CERR(
+        CTRAN_ERR(
             commInternalError,
             "CTRAN-SOCKET: unexpected poll event {} rank {}",
             fds[fid].revents,

--- a/comms/ctran/backends/socket/CtranSocket.h
+++ b/comms/ctran/backends/socket/CtranSocket.h
@@ -10,6 +10,7 @@
 #include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/backends/socket/CtranSocketBase.h"
 #include "comms/ctran/bootstrap/Socket.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/ExtUtils.h"
 #include "comms/utils/commSpecs.h"
 
@@ -111,7 +112,7 @@ class CtranSocket {
 
   inline commResult_t checkValidPeer(int peerRank) {
     if (peerRank < 0 || (comm && peerRank >= comm->statex_->nRanks())) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "invalid peerRank ({}) < 0 or >= nRanks {}",
           peerRank,

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -66,7 +66,7 @@ commResult_t mapBootstrapSocketError(
     return commRemoteError;
   }
 
-  CERR(
+  CTRAN_ERR(
       commInternalError,
       "CTRAN-TCPDM: bootstrap {} failed with peer {} on rank {} commHash {:x} commDesc {} errno={}",
       op,

--- a/comms/ncclx/meta/NcclxChecks.h
+++ b/comms/ncclx/meta/NcclxChecks.h
@@ -1,0 +1,88 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <stdexcept>
+#include <string>
+
+#include <fmt/format.h>
+#include <folly/Expected.h>
+
+#include "comms/utils/Conversion.h"
+#include "comms/utils/commSpecs.h"
+#include "meta/NcclxLogUtils.h"
+
+namespace ncclx::logging::detail {
+
+inline ::meta::comms::CommsError getCommsErrorFromCudaError(
+    cudaError_t error,
+    const char* file,
+    int line,
+    const char* command) {
+  return ::meta::comms::CommsError(
+      fmt::format(
+          "CUDA error in {}:{} {}: {}",
+          file,
+          line,
+          command,
+          cudaGetErrorString(error)),
+      commUnhandledCudaError);
+}
+
+} // namespace ncclx::logging::detail
+
+#define NCCLX_CUDA_CHECK_EXPECTED(command)                               \
+  do {                                                                   \
+    const auto _ncclx_cuda_error = (command);                            \
+    if (_ncclx_cuda_error != cudaSuccess) {                              \
+      NCCLX_ERR(commUnhandledCudaError, "Call for {} failed", #command); \
+      return folly::makeUnexpected(                                      \
+          ::ncclx::logging::detail::getCommsErrorFromCudaError(          \
+              _ncclx_cuda_error, __FILE__, __LINE__, #command));         \
+    }                                                                    \
+  } while (false)
+
+#define NCCLX_CUDACHECKTHROW(command)             \
+  do {                                            \
+    const auto _ncclx_cuda_error = (command);     \
+    if (_ncclx_cuda_error != cudaSuccess) {       \
+      NCCLX_ERR(                                  \
+          commUnhandledCudaError,                 \
+          "{}:{} Cuda failure {}",                \
+          __FILE__,                               \
+          __LINE__,                               \
+          cudaGetErrorString(_ncclx_cuda_error)); \
+      (void)cudaGetLastError();                   \
+      throw std::runtime_error(                   \
+          std::string("Cuda failure: ") +         \
+          cudaGetErrorString(_ncclx_cuda_error)); \
+    }                                             \
+  } while (false)
+
+#define NCCLX_COMMCHECKTHROW(command)                           \
+  do {                                                          \
+    const commResult_t _ncclx_comm_result = (command);          \
+    if (_ncclx_comm_result != commSuccess &&                    \
+        _ncclx_comm_result != commInProgress) {                 \
+      NCCLX_LOG(                                                \
+          ERR,                                                  \
+          "{}:{} -> {} ({})",                                   \
+          __FILE__,                                             \
+          __LINE__,                                             \
+          _ncclx_comm_result,                                   \
+          ::meta::comms::commCodeToString(_ncclx_comm_result)); \
+      throw std::runtime_error(                                 \
+          std::string("COMM internal failure: ") +              \
+          ::meta::comms::commCodeToString(_ncclx_comm_result)); \
+    }                                                           \
+  } while (false)
+
+#define NCCLX_ERRORTHROW(error, ...)             \
+  do {                                           \
+    NCCLX_LOG(ERR, __VA_ARGS__);                 \
+    throw std::runtime_error(                    \
+        std::string("COMM internal failure: ") + \
+        ::meta::comms::commCodeToString(error)); \
+  } while (false)

--- a/comms/ncclx/meta/NcclxLogUtils.h
+++ b/comms/ncclx/meta/NcclxLogUtils.h
@@ -2,8 +2,17 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include "comms/utils/logger/LogUtils.h"
 #include "meta/NcclxLogger.h"
 
 #define NCCLX_LOG_SUBSYS(level, subsys, ...) \
   NCCLX_LOG_IF(level, CLOGF_ENABLED(subsys), __VA_ARGS__)
+
+#define NCCLX_ERR(code, ...)                                                  \
+  do {                                                                        \
+    const auto _ncclx_error_message = fmt::format(__VA_ARGS__);               \
+    NCCLX_LOG(ERR, "{}", _ncclx_error_message);                               \
+    ::meta::comms::logger::logCommErrorToScuba((code), _ncclx_error_message); \
+  } while (false)

--- a/comms/ncclx/meta/collectives/pCollectives.cc
+++ b/comms/ncclx/meta/collectives/pCollectives.cc
@@ -6,9 +6,8 @@
 #include "nccl.h"
 
 #include "comms/ctran/Ctran.h"
-#include "comms/utils/checks.h"
 
-#include "meta/NcclxLogUtils.h"
+#include "meta/NcclxChecks.h"
 #include "meta/wrapper/MetaFactory.h"
 
 namespace ncclx {
@@ -21,7 +20,7 @@ __attribute__((visibility("default"))) ncclResult_t allGatherInit(
     cudaStream_t stream,
     void** request) {
   if (!ctran::allGatherPSupport(comm->ctranComm_.get())) {
-    FB_ERRORTHROW(
+    NCCLX_ERRORTHROW(
         commInvalidUsage,
         "Persistent AllGather is not supported. Check whether CTRAN is enabled.");
   }

--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
@@ -9,7 +9,6 @@
 #include <folly/Synchronized.h>
 #include <folly/Unit.h>
 #include "comms/utils/RankUtils.h"
-#include "comms/utils/checks.h"
 #include "comms/utils/colltrace/CollMetadataImpl.h"
 #include "comms/utils/colltrace/CollTrace.h"
 #include "meta/logger/DebugExt.h"
@@ -22,7 +21,7 @@
 #include "comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.h"
 #include "comms/utils/colltrace/plugins/WatchdogPlugin.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "meta/NcclxLogger.h"
+#include "meta/NcclxChecks.h"
 #include "meta/hints/GlobalHints.h"
 #include "meta/wrapper/DataTypeConv.h"
 
@@ -443,11 +442,11 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
        cudaDev = comm->cudaDev]() -> CommsMaybeVoid {
         NCCL_NAMED_THREAD_START_EXT(
             "CollTrace", metadata.rank, metadata.commHash, metadata.commDesc);
-        CUDA_CHECK_EXPECTED(cudaSetDevice(cudaDev));
+        NCCLX_CUDA_CHECK_EXPECTED(cudaSetDevice(cudaDev));
         // Ensure we are using the thread local stream capture mode to avoid
         // getting error about stream capture mode.
         auto mode{cudaStreamCaptureMode::cudaStreamCaptureModeThreadLocal};
-        CUDA_CHECK_EXPECTED(cudaThreadExchangeStreamCaptureMode(&mode));
+        NCCLX_CUDA_CHECK_EXPECTED(cudaThreadExchangeStreamCaptureMode(&mode));
         return folly::unit;
       },
       std::move(plugins));

--- a/comms/ncclx/meta/logger/tests/LoggingUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggingUT.cc
@@ -14,7 +14,7 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/Logger.h"
 #include "comms/utils/logger/LoggingFormat.h"
-#include "meta/NcclxLogUtils.h"
+#include "meta/NcclxChecks.h"
 
 #include "debug.h" // @manual
 #include "param.h" // @manual
@@ -94,6 +94,46 @@ TEST_F(NcclLoggerTest, LogDisplay) {
   ERR(ncclInternalError, "%s", TestStr.c_str());
 
   finishLogging();
+}
+
+TEST_F(NcclLoggerTest, NcclxChecksPreserveResultsAndSingleEvaluation) {
+  auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"INFO"});
+  ncclResetDebugInitInternal();
+  initLogging();
+  auto loggingGuard = folly::makeGuard([&] { finishLogging(); });
+
+  int commEvaluations = 0;
+  EXPECT_NO_THROW(NCCLX_COMMCHECKTHROW((++commEvaluations, commSuccess)));
+  EXPECT_NO_THROW(NCCLX_COMMCHECKTHROW((++commEvaluations, commInProgress)));
+  EXPECT_THROW(
+      NCCLX_COMMCHECKTHROW((++commEvaluations, commInternalError)),
+      std::runtime_error);
+  EXPECT_EQ(commEvaluations, 3);
+
+  int messageEvaluations = 0;
+  EXPECT_THROW(
+      NCCLX_ERRORTHROW(
+          commInvalidUsage, "NCCLX error {}", ++messageEvaluations),
+      std::runtime_error);
+  EXPECT_EQ(messageEvaluations, 1);
+
+  int cudaEvaluations = 0;
+  EXPECT_NO_THROW(NCCLX_CUDACHECKTHROW((++cudaEvaluations, cudaSuccess)));
+  EXPECT_THROW(
+      NCCLX_CUDACHECKTHROW((++cudaEvaluations, cudaErrorInvalidValue)),
+      std::runtime_error);
+  EXPECT_EQ(cudaEvaluations, 2);
+
+  auto expectedCheck = [](cudaError_t error) -> meta::comms::CommsMaybeVoid {
+    NCCLX_CUDA_CHECK_EXPECTED(error);
+    return folly::unit;
+  };
+  EXPECT_TRUE(expectedCheck(cudaSuccess).hasValue());
+  const auto expectedError = expectedCheck(cudaErrorInvalidValue);
+  ASSERT_TRUE(expectedError.hasError());
+  EXPECT_EQ(expectedError.error().errorCode, commUnhandledCudaError);
+  EXPECT_THAT(
+      expectedError.error().message, testing::HasSubstr("CUDA error in"));
 }
 
 TEST_F(NcclLoggerTest, GetLastCommsErrorTest) {

--- a/comms/ncclx/meta/transport/transportProxy.cc
+++ b/comms/ncclx/meta/transport/transportProxy.cc
@@ -7,10 +7,9 @@
 
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/Utils.h"
-#include "comms/utils/checks.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/trainer/TrainerContext.h"
-#include "meta/NcclxLogUtils.h"
+#include "meta/NcclxChecks.h"
 #include "meta/transport/transportConnect.h"
 #include "meta/transport/transportExt.h"
 #include "meta/transport/transportProxy.h"
@@ -156,7 +155,7 @@ commResult_t TransportProxy::getNextChannelsReadyPtr(
     uint64_t** channelsReadyPtr) {
   std::unique_lock<std::mutex> lock(mutex_);
   if (syncFlagPool_.empty()) {
-    FB_ERRORTHROW(
+    NCCLX_ERRORTHROW(
         commInternalError, "No available sync flag in transport worker thread");
   }
   auto ptr = syncFlagPool_.front();
@@ -274,7 +273,7 @@ void TransportProxy::testAny() {
   for (const auto& req : activeOps_) {
     auto ptr = req->channelsReadyPtr;
     if (*ptr == 0) {
-      FB_COMMCHECKTHROW(req->comm->memCache->release(req->bufKeys));
+      NCCLX_COMMCHECKTHROW(req->comm->memCache->release(req->bufKeys));
       NCCLX_LOG_SUBSYS(
           INFO,
           COLL,
@@ -327,7 +326,7 @@ void TransportProxy::prepResources(std::shared_ptr<TransportRequest> req) {
           req->bufKeys,
           skipReconnect));
   if (req->state != commSuccess) {
-    FB_ERRORTHROW(
+    NCCLX_ERRORTHROW(
         commInternalError,
         "Failed to reconnect to peers in transport worker thread");
   }
@@ -359,7 +358,7 @@ void TransportProxy::workerThreadFn() {
       parentComm_->commHash,
       parentComm_->logMetaData.commDesc);
 
-  FB_CUDACHECKTHROW(cudaSetDevice(parentComm_->cudaDev));
+  NCCLX_CUDACHECKTHROW(cudaSetDevice(parentComm_->cudaDev));
 
   while (true) {
     // test if any collective is complected, and release the resources

--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -7,10 +7,9 @@
 #include "comms/ctran/interfaces/ICtran.h"
 #include "comms/ctran/memory/memCacheAllocator.h"
 #include "comms/ctran/window/WinHintUtils.h"
-#include "comms/utils/checks.h"
 #include "comms/utils/commSpecs.h"
+#include "meta/NcclxChecks.h"
 #include "meta/NcclxConfig.h" // @manual
-#include "meta/NcclxLogUtils.h"
 #include "meta/commstate/FactoryCommStateX.h"
 #include "meta/ctran-integration/BaselineBootstrap.h"
 #include "meta/wrapper/MetaFactory.h"
@@ -23,12 +22,12 @@ meta::comms::Hints ncclToMetaComm(const ncclx::Hints& hints) {
   meta::comms::Hints ret;
   std::string v;
   for (const auto& k : meta::comms::hints::AllToAllPHintUtils::keys()) {
-    FB_COMMCHECKTHROW(ncclToMetaComm(hints.get(k, v)));
-    FB_COMMCHECKTHROW(ret.set(k, v));
+    NCCLX_COMMCHECKTHROW(ncclToMetaComm(hints.get(k, v)));
+    NCCLX_COMMCHECKTHROW(ret.set(k, v));
   }
   for (const auto& k : meta::comms::hints::WinHintUtils::keys()) {
-    FB_COMMCHECKTHROW(ncclToMetaComm(hints.get(k, v)));
-    FB_COMMCHECKTHROW(ret.set(k, v));
+    NCCLX_COMMCHECKTHROW(ncclToMetaComm(hints.get(k, v)));
+    NCCLX_COMMCHECKTHROW(ret.set(k, v));
   }
   return ret;
 }


### PR DESCRIPTION
Summary: Eleven shipped NCCLX callsites still invoked shared check macros backed by Folly logging. Add NCCLX-specific wrappers that preserve single evaluation, error text, exception and Expected results, CUDA last-error clearing, and the existing observability semantics: CERR-backed paths still emit Scuba records, while the FB_COMMCHECKTHROW and FB_ERRORTHROW replacements remain log-only exactly as their original CLOGF-backed macros did. Route those log records to the canonical `comms.ncclx` logger. Replace only the affected persistent-collective, colltrace, transport-proxy, and MetaFactory callsites; leave the shared macros unchanged for their other consumers.

Differential Revision: D115642519


