### PR TITLE
Record kernel launch geometry in collective stats

### DIFF
--- a/comms/common/CollectiveStats.h
+++ b/comms/common/CollectiveStats.h
@@ -23,7 +23,21 @@ struct CollectiveStat {
   uint64_t min_us{0};
   uint64_t max_us{0};
 
-  void add(uint64_t durationUs) {
+  // Launch geometry; 0 means unknown. Per-SM utilisation is
+  // blocks_per_sm * block_size / maxThreadsPerSM.
+  uint32_t num_blocks{0};
+  uint32_t block_size{0};
+  uint32_t blocks_per_sm{0};
+
+  // SM residency: sum of ceil(num_blocks / blocks_per_sm) * duration. Survives
+  // roll-ups where the geometry above collapses to unknown.
+  uint64_t total_sm_us{0};
+
+  void add(
+      uint64_t durationUs,
+      uint32_t numBlocks = 0,
+      uint32_t blockSize = 0,
+      uint32_t blocksPerSm = 0) {
     if (count == 0) {
       min_us = max_us = durationUs;
     } else {
@@ -32,6 +46,33 @@ struct CollectiveStat {
     }
     total_us += durationUs;
     ++count;
+
+    if (blockSize == 0) {
+      return; // no geometry reported; keep whatever another backend recorded
+    }
+    if (count > 1 &&
+        (num_blocks != numBlocks || block_size != blockSize ||
+         blocks_per_sm != blocksPerSm)) {
+      // Not every key is geometry-constant: variable-size ops share a
+      // "<op>.<algo>.0" bucket, and grouped submits are keyed off the first op.
+      num_blocks = block_size = blocks_per_sm = 0;
+    } else {
+      num_blocks = numBlocks;
+      block_size = blockSize;
+      blocks_per_sm = blocksPerSm;
+    }
+    total_sm_us += smUs(numBlocks, blocksPerSm, durationUs);
+  }
+
+  // Falls back to the grid size when occupancy is unknown.
+  static uint64_t
+  smUs(uint32_t numBlocks, uint32_t blocksPerSm, uint64_t durationUs) {
+    if (numBlocks == 0) {
+      return 0;
+    }
+    const uint32_t perSm = blocksPerSm > 0 ? blocksPerSm : 1;
+    const uint64_t sms = (numBlocks + perSm - 1) / perSm;
+    return sms * durationUs;
   }
 
   void merge(const CollectiveStat& other) {
@@ -46,6 +87,13 @@ struct CollectiveStat {
     max_us = std::max(max_us, other.max_us);
     total_us += other.total_us;
     count += other.count;
+    total_sm_us += other.total_sm_us;
+
+    // Roll-ups span buckets whose geometry differs.
+    if (num_blocks != other.num_blocks || block_size != other.block_size ||
+        blocks_per_sm != other.blocks_per_sm) {
+      num_blocks = block_size = blocks_per_sm = 0;
+    }
   }
 
   bool operator==(const CollectiveStat&) const = default;
@@ -70,14 +118,17 @@ class CollectiveStats {
   void record(
       std::string_view collective,
       std::string_view key,
-      uint64_t durationUs) {
+      uint64_t durationUs,
+      uint32_t numBlocks = 0,
+      uint32_t blockSize = 0,
+      uint32_t blocksPerSm = 0) {
     stats_.withWLock([&](auto& m) {
       auto it = m.find(key);
       if (it == m.end()) {
         it = m.emplace(std::string(key), Entry{std::string(collective), {}})
                  .first;
       }
-      it->second.stat.add(durationUs);
+      it->second.stat.add(durationUs, numBlocks, blockSize, blocksPerSm);
     });
   }
 
@@ -120,12 +171,21 @@ class CollectiveStats {
 };
 
 inline std::ostream& operator<<(std::ostream& os, const CollectiveStat& s) {
-  return os << fmt::format(
-             "count={} total_us={} min_us={} max_us={}",
-             s.count,
-             s.total_us,
-             s.min_us,
-             s.max_us);
+  os << fmt::format(
+      "count={} total_us={} min_us={} max_us={} total_sm_us={}",
+      s.count,
+      s.total_us,
+      s.min_us,
+      s.max_us,
+      s.total_sm_us);
+  if (s.block_size != 0) {
+    os << fmt::format(
+        " num_blocks={} block_size={} blocks_per_sm={}",
+        s.num_blocks,
+        s.block_size,
+        s.blocks_per_sm);
+  }
+  return os;
 }
 
 } // namespace comms

--- a/comms/common/tests/CollectiveStatsUT.cc
+++ b/comms/common/tests/CollectiveStatsUT.cc
@@ -90,5 +90,119 @@ TEST(CollectiveStatsTest, ConcurrentRecordIsThreadSafe) {
   EXPECT_EQ(out.at("all"), expected);
 }
 
+TEST(CollectiveStatsTest, RecordsLaunchGeometry) {
+  CollectiveStats stats;
+  stats.record(
+      "allreduce",
+      "allreduce.ctring.1024",
+      10,
+      /*numBlocks=*/8,
+      /*blockSize=*/512,
+      /*blocksPerSm=*/4);
+
+  const auto out = stats.getAndClear();
+  const CollectiveStat expected{
+      .count = 1,
+      .total_us = 10,
+      .min_us = 10,
+      .max_us = 10,
+      .num_blocks = 8,
+      .block_size = 512,
+      .blocks_per_sm = 4,
+      .total_sm_us = 20}; // ceil(8/4) * 10
+  EXPECT_EQ(out.at("allreduce.ctring.1024"), expected);
+}
+
+TEST(CollectiveStatsTest, GeometryDefaultsToUnknown) {
+  CollectiveStats stats;
+  stats.record("allreduce", "allreduce.ctring.1024", 10);
+
+  const auto out = stats.getAndClear();
+  const CollectiveStat expected{
+      .count = 1, .total_us = 10, .min_us = 10, .max_us = 10};
+  EXPECT_EQ(out.at("allreduce.ctring.1024"), expected);
+}
+
+TEST(CollectiveStatsTest, RollUpOverMatchingGeometryKeepsIt) {
+  CollectiveStats stats;
+  stats.record("allreduce", "allreduce.ctring.1024", 10, 8, 512, 4);
+  stats.record("allreduce", "allreduce.ctring.2048", 20, 8, 512, 4);
+
+  const auto out = stats.getAndClear();
+  const CollectiveStat expected{
+      .count = 2,
+      .total_us = 30,
+      .min_us = 10,
+      .max_us = 20,
+      .num_blocks = 8,
+      .block_size = 512,
+      .blocks_per_sm = 4,
+      .total_sm_us = 60};
+  EXPECT_EQ(out.at("allreduce.all"), expected);
+}
+
+TEST(CollectiveStatsTest, RollUpOverDifferingGeometryReportsUnknown) {
+  CollectiveStats stats;
+  stats.record("allreduce", "allreduce.ctring.1024", 10, 1, 512, 4);
+  stats.record("allreduce", "allreduce.ctring.1048576", 20, 8, 512, 4);
+
+  const auto out = stats.getAndClear();
+  const CollectiveStat expected{
+      .count = 2,
+      .total_us = 30,
+      .min_us = 10,
+      .max_us = 20,
+      .num_blocks = 0,
+      .block_size = 0,
+      .blocks_per_sm = 0,
+      .total_sm_us = 50}; // ceil(1/4)*10 + ceil(8/4)*20
+  EXPECT_EQ(out.at("allreduce.all"), expected);
+}
+
+TEST(CollectiveStatsTest, GeometrylessRecordDoesNotClearReportedGeometry) {
+  CollectiveStats stats;
+  stats.record("allreduce", "allreduce.ctring.1024", 10, 8, 512, 4);
+  stats.record("allreduce", "allreduce.ctring.1024", 20);
+
+  const auto out = stats.getAndClear();
+  const CollectiveStat expected{
+      .count = 2,
+      .total_us = 30,
+      .min_us = 10,
+      .max_us = 20,
+      .num_blocks = 8,
+      .block_size = 512,
+      .blocks_per_sm = 4,
+      .total_sm_us = 20}; // only the geometry-bearing record counts
+  EXPECT_EQ(out.at("allreduce.ctring.1024"), expected);
+}
+
+TEST(CollectiveStatsTest, DisagreeingGeometryWithinOneBucketReportsUnknown) {
+  CollectiveStats stats;
+  // Variable-size ops share a "<op>.<algo>.0" bucket.
+  stats.record("alltoallv", "alltoallv.ctran.0", 10, 4, 512, 2);
+  stats.record("alltoallv", "alltoallv.ctran.0", 20, 16, 512, 2);
+
+  const auto out = stats.getAndClear();
+  const CollectiveStat expected{
+      .count = 2,
+      .total_us = 30,
+      .min_us = 10,
+      .max_us = 20,
+      .num_blocks = 0,
+      .block_size = 0,
+      .blocks_per_sm = 0,
+      .total_sm_us = 180}; // ceil(4/2)*10 + ceil(16/2)*20
+  EXPECT_EQ(out.at("alltoallv.ctran.0"), expected);
+}
+
+TEST(CollectiveStatsTest, SmTimeFallsBackToGridWhenOccupancyUnknown) {
+  CollectiveStats stats;
+  stats.record("allreduce", "allreduce.ctdirect.8", 10, 32, 640, 0);
+
+  const auto out = stats.getAndClear();
+  EXPECT_EQ(out.at("allreduce.ctdirect.8").total_sm_us, 320u);
+}
+
 } // namespace
 } // namespace comms

--- a/comms/ctran/algos/AllReduce/AllReduceDirect.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceDirect.cc
@@ -7,6 +7,7 @@
 
 #include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
 #include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/algos/common/OccupancyUtils.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/commSpecs.h"
@@ -665,6 +666,12 @@ commResult_t ctranAllReduceDirect(
   if (config.numThreads > NCCL_CTRAN_ALLREDUCE_DIRECT_THREAD_BLOCK_SIZE) {
     config.numThreads = NCCL_CTRAN_ALLREDUCE_DIRECT_THREAD_BLOCK_SIZE;
   }
+  config.blocksPerSM = MCCL_COLLECTIVE_STATS_ENABLE
+      ? ctran::algos::getBlocksPerSM(
+            func,
+            static_cast<int>(config.numThreads),
+            config.launchSharedMemBytes())
+      : 0;
 
   // Prepare kElems for first segment symmetrically handled by each rank
   if (nSteps > 0) {

--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -23,6 +23,7 @@
 #include "comms/ctran/algos/AllReduce/Types.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/algos/CtranAlgoConsts.h"
+#include "comms/ctran/algos/common/OccupancyUtils.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/CtranLogUtils.h"
@@ -1478,6 +1479,10 @@ commResult_t ctranAllReduceRing(
       opCount);
   config.numBlocks = numBlocks;
   config.numThreads = numThreads;
+  config.blocksPerSM = MCCL_COLLECTIVE_STATS_ENABLE
+      ? ctran::algos::getBlocksPerSM(
+            func, numThreads, config.launchSharedMemBytes())
+      : 0;
   config.args.devState_d = comm->ctran_->algo->getDevState();
   ctran::allreduce::ring::KernArgs kernArgs{
       .sendbuff = sendbuff,

--- a/comms/ctran/algos/common/OccupancyUtils.h
+++ b/comms/ctran/algos/common/OccupancyUtils.h
@@ -1,0 +1,31 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace ctran::algos {
+
+// Blocks co-resident on one SM. dynamicSMemSize must match the launch, or the
+// answer describes a launch that never happens. Returns 0 on failure: callers
+// only report this in stats.
+inline int
+getBlocksPerSM(const void* func, int blockSize, size_t dynamicSMemSize) {
+  if (func == nullptr || blockSize <= 0) {
+    return 0;
+  }
+
+  int blocksPerSM = 0;
+  const cudaError_t err = cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+      &blocksPerSM, func, blockSize, dynamicSMemSize);
+  if (err != cudaSuccess) {
+    // Consume only our own error; an unconditional clear would hide a sticky
+    // async fault from the next FB_CUDACHECK.
+    if (cudaPeekAtLastError() == err) {
+      (void)cudaGetLastError();
+    }
+    return 0;
+  }
+  return blocksPerSM;
+}
+
+} // namespace ctran::algos

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -286,6 +286,8 @@ struct KernelConfig {
   } type;
   unsigned int numBlocks{1};
   unsigned int numThreads{1};
+  // Occupancy for the stats bucket; the GPE has no kernel pointer of its own.
+  unsigned int blocksPerSM{0};
 
   cudaStream_t stream;
   CtranKernelArgs args;
@@ -313,6 +315,13 @@ struct KernelConfig {
 
   // Dynamic shared memory size override. 0 = use sizeof(CtranAlgoDeviceState).
   size_t dynamicSharedMemBytes{0};
+
+  // The size the kernel is launched with. Anything reasoning about the launch
+  // (occupancy, the opt-in shared memory limit) must agree with it.
+  size_t launchSharedMemBytes() const {
+    return dynamicSharedMemBytes > 0 ? dynamicSharedMemBytes
+                                     : sizeof(CtranAlgoDeviceState);
+  }
 
   // Experimental: allows one-sided communications, waitSignal and
   // multiWaitSignal, to run in parallel with other kernels when
@@ -433,6 +442,10 @@ struct CtranCollectiveStatsKey {
   std::string collective;
   // "<collective>.<algo>.<bytes>", e.g. "allreduce.ctring.1048576".
   std::string key;
+  // Captured at submit; the GPE thread has no KernelConfig.
+  uint32_t numBlocks{0};
+  uint32_t blockSize{0};
+  uint32_t blocksPerSM{0};
 };
 
 // Built once at submit and cached on the cmd: the GPE thread re-runs on every
@@ -440,12 +453,13 @@ struct CtranCollectiveStatsKey {
 // A grouped submit is attributed to opGroup.front() and timed as a whole.
 inline CtranCollectiveStatsKey ctranCollectiveStatsKey(
     const std::vector<std::unique_ptr<struct OpElem>>& opGroup,
-    std::string_view algoName) {
+    const KernelConfig& kernelConfig) {
   if (opGroup.empty()) {
     return {};
   }
   const auto& op = *opGroup.front();
   const char* collective = ctranCollectiveOpName(op.type);
+  const std::string_view algoName = kernelConfig.algoName;
   return {
       collective,
       fmt::format(
@@ -453,7 +467,10 @@ inline CtranCollectiveStatsKey ctranCollectiveStatsKey(
           collective,
           algoName.empty() ? std::string_view{"unknown"}
                            : ctran::algoShortName(algoName),
-          ctranCollectiveMsgSize(op))};
+          ctranCollectiveMsgSize(op)),
+      kernelConfig.numBlocks,
+      kernelConfig.numThreads,
+      kernelConfig.blocksPerSM};
 }
 
 class CtranGpe {

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -301,7 +301,7 @@ commResult_t CtranGpe::Impl::submit(
       cmd->coll.comm = comm;
       if (MCCL_COLLECTIVE_STATS_ENABLE) {
         cmd->coll.statsKey =
-            ctranCollectiveStatsKey(cmd->coll.opGroup, kernelConfig.algoName);
+            ctranCollectiveStatsKey(cmd->coll.opGroup, kernelConfig);
       }
     }
 
@@ -480,11 +480,10 @@ commResult_t CtranGpe::Impl::submit(
           CollTraceHandleTriggerState::BeforeEnqueueKernel);
     }
 
-    // Set the maximum dynamic shared memory size since CtranAlgoDeviceState
-    // (~67KB) exceeds the default limit (48KB)
-    size_t sharedMemBytes = kernelConfig.dynamicSharedMemBytes > 0
-        ? kernelConfig.dynamicSharedMemBytes
-        : sizeof(CtranAlgoDeviceState);
+    // Raise the opt-in dynamic shared memory limit: the 48KB default covers
+    // sizeof(CtranAlgoDeviceState), but a dynamicSharedMemBytes override
+    // need not.
+    const size_t sharedMemBytes = kernelConfig.launchSharedMemBytes();
     FB_CUDACHECKGOTO(
         cudaFuncSetAttribute(
             ncclKernel,
@@ -637,7 +636,7 @@ commResult_t CtranGpe::Impl::submitHost(
       cmd->coll.comm = comm;
       if (MCCL_COLLECTIVE_STATS_ENABLE) {
         cmd->coll.statsKey =
-            ctranCollectiveStatsKey(cmd->coll.opGroup, kernelConfig.algoName);
+            ctranCollectiveStatsKey(cmd->coll.opGroup, kernelConfig);
       }
       auto colltraceHandle = meta::comms::colltrace::getCollTraceHandle(
           comm, cmd->coll.opGroup, kernelConfig, false /* ifChecksum */);
@@ -940,7 +939,10 @@ void CtranGpe::Impl::gpeThreadFn() {
           collectiveStats_.record(
               cmd->coll.statsKey.collective,
               cmd->coll.statsKey.key,
-              static_cast<uint64_t>(durationUs));
+              static_cast<uint64_t>(durationUs),
+              cmd->coll.statsKey.numBlocks,
+              cmd->coll.statsKey.blockSize,
+              cmd->coll.statsKey.blocksPerSM);
         }
 
         if (cmd->persistent) {


### PR DESCRIPTION
Summary:
Per-collective stats carried timing only, so a run could show that an AllReduce took 9.6 ms without showing what it was given to run on. This records the launch geometry alongside the timing, which is what makes an SM sweep interpretable after the fact.

Four fields on `comms::CollectiveStat`:

| field | meaning |
|---|---|
| `num_blocks` | grid size; also the SM count while the grid stays under the device SM count |
| `block_size` | threads per block |
| `blocks_per_sm` | `cudaOccupancyMaxActiveBlocksPerMultiprocessor()` for that kernel at that block size |
| `total_sm_us` | SM-weighted duration, accumulated per record: `ceil(num_blocks / blocks_per_sm) * duration_us` |

Per-SM utilisation is then `blocks_per_sm * block_size / maxThreadsPerSM`, which the block count alone cannot express: on GB200 the ring kernel runs 8 blocks of 640 threads with `blocks_per_sm=1`, so it touches 8 SMs but uses **31%** of each. That ceiling comes from the kernel's own footprint -- `cuobjdump -res-usage` reports REG:96, so `65536/96 = 682` resident threads per SM, and only one 640-thread block fits. It is not reachable by tuning: `cudaOccupancyMaxPotentialBlockSize` already returns 640 as the occupancy-maximising size, and `THREAD_BLOCK_SIZE` can only lower it.

# Where the numbers come from

`num_blocks` and `block_size` are already on `KernelConfig`; the GPE thread has no `KernelConfig`, so they ride along on `CtranCollectiveStatsKey`, which is built at submit and cached on the cmd. `ctranCollectiveStatsKey()` now takes the whole `KernelConfig` rather than just `algoName`, so both submit paths pick geometry up identically.

`blocks_per_sm` needs the device kernel pointer, which only the algorithm has, so `ctran::algos::getBlocksPerSM()` (new, in `algos/common/OccupancyUtils.h`) is called there and the result handed over on `KernelConfig::blocksPerSM`. It returns 0 rather than failing, since a stats field must not be able to abort a collective.

The query is **not** cached. An earlier version of this diff memoised it on `(func, blockSize)`; measured on GB200 the call costs 91 ns (100k-call loop), the same order as the locked map lookup a cache would add, so the cache was removed rather than kept on the assumption that a CUDA query must be expensive.

# The shared-memory size the query is asked about

An occupancy answer is only valid for the dynamic shared-memory size the kernel is actually launched with. That size now has one definition, `KernelConfig::launchSharedMemBytes()`, used by both call sites and by `CtranGpeImpl`, each of which previously recomputed `dynamicSharedMemBytes > 0 ? dynamicSharedMemBytes : sizeof(CtranAlgoDeviceState)` for itself.

Getting it wrong is quiet rather than loud, which is why it is worth pinning down: `cudaOccupancyMaxActiveBlocksPerMultiprocessor()` returns 0 blocks **and** `cudaSuccess` when the requested shared memory exceeds the kernel's opt-in limit, so there is no error for `getBlocksPerSM()` to catch. Measured on GB200:

| query | dynamic smem | result |
|---|---|---|
| cold, the size ctran launches with | 2960 B | `blocksPerSM=3`, `cudaSuccess` |
| cold, just over the default opt-in limit | 48 KB + 1 | `blocksPerSM=0`, `cudaSuccess` |

`sizeof(CtranAlgoDeviceState)` is 2960 B, comfortably under the 48 KB default, so the submit-time query is answered on the first submit too -- before the launch raises the limit via `cudaFuncSetAttribute`. Nothing currently sets `dynamicSharedMemBytes`, so no path exceeds the default today. The `CtranGpeImpl` comment claiming `CtranAlgoDeviceState` is `~67KB` and over the limit was wrong on both counts and is corrected here.

# SM-weighted duration

The geometry fields describe one bucket and cannot describe a roll-up: auto-tune picks a different grid per message size, so `merge()` reports unknown whenever constituents disagree. `total_sm_us` is what survives aggregation -- each record contributes `ceil(num_blocks / blocks_per_sm) * duration_us`, the SM-time the collective occupied, and merging sums it. So `allreduce.all` and `all` carry a meaningful SM cost even where their geometry fields read 0. When occupancy is unknown it falls back to the grid size, i.e. one block per SM.

# Roll-ups report unknown, deliberately

`getAndClear()` publishes `<collective>.all` and `all` by merging buckets whose geometry differs -- auto-tune picks a different grid per message size. `merge()` therefore zeroes geometry on disagreement rather than reporting one bucket's value for all of them. A geometry-less `record()` also will not clear geometry another backend reported.

`add()` and `record()` take the new values as defaulted arguments, so existing callers are unchanged.

Reviewed By: saifhhasan

Differential Revision: D115847094


