### PR TITLE
Route same-host ctrl messages over socket instead of ib

### DIFF
--- a/comms/ctran/backends/CtranCtrl.h
+++ b/comms/ctran/backends/CtranCtrl.h
@@ -12,6 +12,11 @@
 #include "comms/ctran/regcache/IpcRegCacheBase.h"
 #include "comms/ctran/utils/CtranIpc.h"
 
+// Maximum payload any CTRAN control transport accepts. Shared by IB and Socket
+// so a control operation can be routed per peer without changing its wire-size
+// contract.
+constexpr std::size_t CTRAN_CTRL_MAX_PAYLOAD_SIZE{4096};
+
 /**
  * Define all control message types and packet format used in CTran backends.
  *

--- a/comms/ctran/backends/ib/CtranIbVc.h
+++ b/comms/ctran/backends/ib/CtranIbVc.h
@@ -27,8 +27,9 @@
 typedef std::pair<int, int> QpUniqueId;
 
 // Fix-sized payload buffer for IB transport to prepare and register the
-// temporary buffers for control messages
-constexpr int MAX_PAYLOAD_SIZE{4096};
+// temporary buffers for control messages. Aliases the transport-shared limit so
+// IB and Socket stay in lockstep when a control op is routed per peer.
+constexpr int MAX_PAYLOAD_SIZE{static_cast<int>(CTRAN_CTRL_MAX_PAYLOAD_SIZE)};
 constexpr int MAX_SEND_WR{256};
 constexpr int MAX_RECV_WR{128};
 struct CtrlPacket {

--- a/comms/ctran/backends/socket/CtranSocket.cc
+++ b/comms/ctran/backends/socket/CtranSocket.cc
@@ -132,7 +132,7 @@ void CtranSocket::init(const SocketServerAddr& serverAddr) {
           "CTRAN-SOCKET: No socket interfaces found (NCCL_SOCKET_IFNAME={}, NCCL_SOCKET_IPADDR_PREFIX={})",
           NCCL_SOCKET_IFNAME,
           NCCL_SOCKET_IPADDR_PREFIX);
-      CERR(commSystemError, "{}", msg);
+      CTRAN_ERR(commSystemError, "{}", msg);
       throw ctran::utils::Exception(
           msg, commSystemError, rank_, commHash_, commDesc_);
     } else {
@@ -304,7 +304,7 @@ commResult_t CtranSocket::updateSocket(
     int peerRank) {
   auto locked = socketMaps_.wlock();
   if (locked->rankToSocket.find(peerRank) != locked->rankToSocket.end()) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "CTRAN-SOCKET: socket already exists for peerRank {} in pimpl {} "
         "commHash {:x}, commDesc {}. It likely indicates a NCCL bug.",
@@ -319,7 +319,8 @@ commResult_t CtranSocket::updateSocket(
 }
 
 bool CtranSocket::addToPendingOpsIfRequired(
-    const ControlMsg& msg,
+    void* payload,
+    std::size_t size,
     int peerRank,
     CtranSocketRequest& req,
     SockPendingOp::OpType opType,
@@ -332,13 +333,13 @@ bool CtranSocket::addToPendingOpsIfRequired(
     // pending queue, because we must issue all ops in order.
     // Otherwise, ctrlMsg may mismatch.
     if (!sock || it != locked->end()) {
-      auto pendingOp = std::make_unique<SockPendingOp>(
-          opType, const_cast<ControlMsg&>(msg), peerRank, req);
+      auto pendingOp =
+          std::make_unique<SockPendingOp>(opType, payload, size, peerRank, req);
       CTRAN_LOG_TRACE(
           COLL,
-          "Enqueue pendingOp {} [{}], peer {}",
+          "CTRAN-SOCKET: enqueue pendingOp {} size {} peer {}",
           opType,
-          msg.toString(),
+          size,
           peerRank);
 
       if (it == locked->end()) {
@@ -396,7 +397,7 @@ commResult_t CtranSocket::progressPendingOps(void) {
         CTRAN_LOG_TRACE(
             COLL, "CTRAN-SOCKET: socket {} send to {}", (void*)sock, peerRank);
         FB_SYSCHECKRETURN(
-            sock->send((void*)&op->msg, sizeof(ControlMsg)), commInternalError);
+            sock->send(&op->packet, op->packet.wireSize()), commInternalError);
         op->req.complete();
       } else {
         postRecvOp(peerRank, std::move(op));
@@ -429,7 +430,7 @@ commResult_t CtranSocket::progressInternal() {
     continueWhileLoop = false;
     int count = poll(fds.data(), fds.size(), NCCL_CTRAN_SOCKET_POLL_TIMEOUT);
     if (count < 0) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-SOCKET: polling error, errno {}",
           strerror(errno));
@@ -446,11 +447,11 @@ commResult_t CtranSocket::progressInternal() {
         // let's read it, and dequeue a posted recv from the queue
         ctran::bootstrap::Socket* socket = getSocket(peerRanks[fid]);
         auto& recvQueue = getRecvCtrlQueue(peerRanks[fid]);
-        std::unique_ptr<ControlMsg> msg = std::make_unique<ControlMsg>();
-        int bytes_read = doRecvMsg(socket, peerRanks[fid], msg.get());
-        if (bytes_read < 0) {
-          return commInternalError;
-        } else if (bytes_read == 0) {
+        std::optional<SocketCtrlPacket> packet;
+        bool connectionClosed = false;
+        FB_COMMCHECK(
+            doRecvMsg(socket, peerRanks[fid], packet, &connectionClosed));
+        if (connectionClosed) {
           // If any peer closes the connection and the socket is removed, we
           // will break the outer loop since the vector of pollfds has to be
           // re-constructed. However, we'll continue the inner loop to receive
@@ -458,28 +459,32 @@ commResult_t CtranSocket::progressInternal() {
           continueWhileLoop = false;
           continue;
         }
+        if (!packet) {
+          // Frame arrived in pieces; the remainder is picked up on a later
+          // poll.
+          continue;
+        }
         if (recvQueue.postedOps_.empty()) {
           // no posted op, let's read it and store as unexpected msg
           CTRAN_LOG_TRACE(
               COLL,
-              "CTRAN-SOCKET: Received ctrl-msg {} from peer {}, size {}, add to unexpected msg queue",
-              msg->toString(),
+              "CTRAN-SOCKET: received control packet from peer {}, size {}, add to unexpected msg queue",
               peerRanks[fid],
-              bytes_read);
-          recvQueue.unexpMsgs_.push_back(std::move(msg));
+              packet->payloadSize);
+          recvQueue.unexpMsgs_.push_back(
+              std::make_unique<SocketCtrlPacket>(std::move(*packet)));
         } else {
           auto op = dequeFront(recvQueue.postedOps_);
-          op->msg = *msg;
+          FB_COMMCHECK(copyPacketToRecvOp(*packet, *op, peerRanks[fid]));
           op->req.complete();
           CTRAN_LOG_TRACE(
               COLL,
-              "CTRAN-SOCKET: Received ctrl-msg {} from peer {}, size {}, complete a posted recv",
-              op->msg.toString(),
+              "CTRAN-SOCKET: received control packet from peer {}, size {}, complete a posted recv",
               peerRanks[fid],
-              bytes_read);
+              packet->payloadSize);
         }
       } else if (fds[fid].revents != 0) {
-        CERR(
+        CTRAN_ERR(
             commInternalError,
             "CTRAN-SOCKET: unexpected poll event {} rank {}",
             fds[fid].revents,
@@ -491,12 +496,31 @@ commResult_t CtranSocket::progressInternal() {
   return commSuccess;
 }
 
+commResult_t CtranSocket::checkCtrlPayload(
+    const void* payload,
+    std::size_t size,
+    const char* dir) {
+  if ((size > 0 && payload == nullptr) || size > CTRAN_CTRL_MAX_PAYLOAD_SIZE) {
+    CTRAN_ERR(
+        commInvalidArgument,
+        "CTRAN-SOCKET: invalid {} control payload {} size {} (max {})",
+        dir,
+        payload,
+        size,
+        CTRAN_CTRL_MAX_PAYLOAD_SIZE);
+    return commInvalidArgument;
+  }
+  return commSuccess;
+}
+
 commResult_t CtranSocket::isendCtrlMsgImpl(
-    const ControlMsg& msg,
+    const void* payload,
+    std::size_t size,
     int peerRank,
     const SocketServerAddr& peerServerAddr,
     CtranSocketRequest& req) {
   FB_COMMCHECK(checkValidPeer(peerRank));
+  FB_COMMCHECK(checkCtrlPayload(payload, size, "send"));
   ctran::bootstrap::Socket* sock = getSocket(peerRank);
 
   // nullptr socket indicates not yet established connection; try to connect.
@@ -516,11 +540,20 @@ commResult_t CtranSocket::isendCtrlMsgImpl(
       (void*)sock);
 
   if (!addToPendingOpsIfRequired(
-          msg, peerRank, req, SockPendingOp::OpType::ISEND_CTRL, sock)) {
+          const_cast<void*>(payload),
+          size,
+          peerRank,
+          req,
+          SockPendingOp::OpType::ISEND_CTRL,
+          sock)) {
+    SocketCtrlPacket packet;
+    FB_CHECKABORT(
+        packet.copyFrom(payload, size),
+        "validated Socket control payload must fit in a packet");
     CTRAN_LOG_TRACE(
         COLL, "CTRAN-SOCKET: socket {} send to {}", (void*)sock, peerRank);
     FB_SYSCHECKRETURN(
-        sock->send((void*)&msg, sizeof(ControlMsg)), commInternalError);
+        sock->send(&packet, packet.wireSize()), commInternalError);
     req.complete();
   }
 
@@ -528,11 +561,13 @@ commResult_t CtranSocket::isendCtrlMsgImpl(
 }
 
 commResult_t CtranSocket::irecvCtrlMsgImpl(
-    ControlMsg& msg,
+    void* payload,
+    std::size_t size,
     int peerRank,
     const SocketServerAddr& peerServerAddr,
     CtranSocketRequest& req) {
   FB_COMMCHECK(checkValidPeer(peerRank));
+  FB_COMMCHECK(checkCtrlPayload(payload, size, "receive"));
   ctran::bootstrap::Socket* sock = getSocket(peerRank);
 
   // nullptr socket indicates not yet established connection; try to connect.
@@ -552,36 +587,115 @@ commResult_t CtranSocket::irecvCtrlMsgImpl(
       (void*)sock);
 
   if (!addToPendingOpsIfRequired(
-          msg, peerRank, req, SockPendingOp::OpType::IRECV_CTRL, sock)) {
+          payload,
+          size,
+          peerRank,
+          req,
+          SockPendingOp::OpType::IRECV_CTRL,
+          sock)) {
     auto recvop = std::make_unique<SockPendingOp>(
-        SockPendingOp::OpType::IRECV_CTRL, msg, peerRank, req);
+        SockPendingOp::OpType::IRECV_CTRL, payload, size, peerRank, req);
     postRecvOp(peerRank, std::move(recvop));
   }
 
   return commSuccess;
 }
 
-int CtranSocket::doRecvMsg(
+commResult_t CtranSocket::doRecvMsg(
     ctran::bootstrap::Socket* socket,
     int peerRank,
-    ControlMsg* msg) {
-  int bytes_read = socket->recvAsync((void*)msg, sizeof(ControlMsg));
-  if (bytes_read < 0) {
-    CTRAN_LOG_SUBSYS(
-        ERR,
-        COLL,
+    std::optional<SocketCtrlPacket>& packet,
+    bool* closed) {
+  packet.reset();
+  *closed = false;
+  auto& state = rankToRecvFrameMap_[peerRank];
+
+  // recvAsync returns -1 both for a real failure and for a would-block, so the
+  // two are separated on errno here. A would-block just means the rest of the
+  // frame has not arrived; state carries the progress to the next poll.
+  auto recvStage = [&](void* dst, std::size_t remaining, std::size_t* done) {
+    int bytesRead = socket->recvAsync(dst, remaining);
+    if (bytesRead > 0) {
+      *done += static_cast<std::size_t>(bytesRead);
+      return commSuccess;
+    }
+    if (bytesRead == 0) {
+      *closed = true;
+      return commSuccess;
+    }
+    if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+      return commSuccess;
+    }
+    CTRAN_ERR(
+        commInternalError,
         "CTRAN-SOCKET: peer {} socket recvAsync failure, errno {}",
         peerRank,
         strerror(errno));
-  } else if (bytes_read == 0) {
-    CTRAN_LOG_SUBSYS(
-        WARN,
-        COLL,
-        "CTRAN-SOCKET: peer {} closed connection, remove socket",
-        peerRank);
-    removeSocket(peerRank);
+    return commInternalError;
+  };
+
+  auto finishPartialRead = [&]() {
+    if (*closed) {
+      CTRAN_LOG_SUBSYS(
+          WARN,
+          COLL,
+          "CTRAN-SOCKET: peer {} closed connection, remove socket",
+          peerRank);
+      rankToRecvFrameMap_.erase(peerRank);
+      removeSocket(peerRank);
+    }
+    return commSuccess;
+  };
+
+  if (state.headerBytes < sizeof(state.packet.payloadSize)) {
+    auto* header = reinterpret_cast<char*>(&state.packet.payloadSize);
+    FB_COMMCHECK(recvStage(
+        header + state.headerBytes,
+        sizeof(state.packet.payloadSize) - state.headerBytes,
+        &state.headerBytes));
+    if (*closed || state.headerBytes < sizeof(state.packet.payloadSize)) {
+      return finishPartialRead();
+    }
+    if (state.packet.payloadSize > CTRAN_CTRL_MAX_PAYLOAD_SIZE) {
+      CTRAN_ERR(
+          commInternalError,
+          "CTRAN-SOCKET: peer {} sent oversized control payload {} (max {})",
+          peerRank,
+          state.packet.payloadSize,
+          CTRAN_CTRL_MAX_PAYLOAD_SIZE);
+      return commInternalError;
+    }
   }
-  return bytes_read;
+
+  if (state.payloadBytes < state.packet.payloadSize) {
+    FB_COMMCHECK(recvStage(
+        state.packet.payload.data() + state.payloadBytes,
+        state.packet.payloadSize - state.payloadBytes,
+        &state.payloadBytes));
+    if (*closed || state.payloadBytes < state.packet.payloadSize) {
+      return finishPartialRead();
+    }
+  }
+
+  packet = state.packet;
+  rankToRecvFrameMap_.erase(peerRank);
+  return commSuccess;
+}
+
+commResult_t CtranSocket::copyPacketToRecvOp(
+    const SocketCtrlPacket& packet,
+    SockPendingOp& recvOp,
+    int peerRank) {
+  if (!packet.copyTo(recvOp.payload, recvOp.size)) {
+    CTRAN_ERR(
+        commInternalError,
+        "CTRAN-SOCKET: control payload size mismatch from peer {}: received {}, expected {}",
+        peerRank,
+        packet.payloadSize,
+        recvOp.size);
+    return commInternalError;
+  }
+  return commSuccess;
 }
 
 commResult_t CtranSocket::postRecvOp(
@@ -593,13 +707,13 @@ commResult_t CtranSocket::postRecvOp(
     recvQueue.postedOps_.push_back(std::move(recvop));
   } else {
     auto unexpMsg = dequeFront(recvQueue.unexpMsgs_);
-    recvop->msg = *unexpMsg;
+    FB_COMMCHECK(copyPacketToRecvOp(*unexpMsg, *recvop, peerRank));
     FB_COMMCHECK(recvop->req.complete());
     CTRAN_LOG_TRACE(
         COLL,
-        "CTRAN-SOCKET: Received ctrl-msg {} from peer {}, complete a posted recv",
-        recvop->msg.toString(),
-        peerRank);
+        "CTRAN-SOCKET: received control packet from peer {}, size {}, complete a posted recv",
+        peerRank,
+        unexpMsg->payloadSize);
   }
   return commSuccess;
 }

--- a/comms/ctran/backends/socket/CtranSocket.h
+++ b/comms/ctran/backends/socket/CtranSocket.h
@@ -6,6 +6,7 @@
 #include <folly/SocketAddress.h>
 #include <folly/Synchronized.h>
 #include <memory>
+#include <optional>
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/backends/socket/CtranSocketBase.h"
@@ -46,7 +47,17 @@ class CtranSocket {
   // Only call this function when the peer's ListenSocket address is available
   inline commResult_t
   isendCtrlMsg(const ControlMsg& msg, int peerRank, CtranSocketRequest& req) {
-    return isendCtrlMsg(msg, peerRank, SocketServerAddr(), req);
+    return isendCtrlMsg(&msg, sizeof(msg), peerRank, req);
+  }
+
+  // Raw-payload form. The mapper exchanges registration descriptor batches
+  // that are not a ControlMsg; both forms share one length-delimited frame.
+  inline commResult_t isendCtrlMsg(
+      const void* payload,
+      std::size_t size,
+      int peerRank,
+      CtranSocketRequest& req) {
+    return isendCtrlMsgImpl(payload, size, peerRank, SocketServerAddr(), req);
   }
 
   // Send control message packet to a remote address over the Socket
@@ -61,14 +72,22 @@ class CtranSocket {
       int peerRank,
       const SocketServerAddr& peerServerAddr,
       CtranSocketRequest& req) {
-    return isendCtrlMsgImpl(msg, peerRank, peerServerAddr, req);
+    return isendCtrlMsgImpl(&msg, sizeof(msg), peerRank, peerServerAddr, req);
   }
 
   // Receive control message packet over the Socket connection.
   // Only call this function when the peer's ListenSocket address is available
   inline commResult_t
   irecvCtrlMsg(ControlMsg& msg, int peerRank, CtranSocketRequest& req) {
-    return irecvCtrlMsg(msg, peerRank, SocketServerAddr(), req);
+    return irecvCtrlMsg(&msg, sizeof(msg), peerRank, req);
+  }
+
+  inline commResult_t irecvCtrlMsg(
+      void* payload,
+      std::size_t size,
+      int peerRank,
+      CtranSocketRequest& req) {
+    return irecvCtrlMsgImpl(payload, size, peerRank, SocketServerAddr(), req);
   }
 
   // Receive control message packet from a remote address over the Socket
@@ -83,7 +102,7 @@ class CtranSocket {
       int peerRank,
       const SocketServerAddr& peerServerAddr,
       CtranSocketRequest& req) {
-    return irecvCtrlMsgImpl(msg, peerRank, peerServerAddr, req);
+    return irecvCtrlMsgImpl(&msg, sizeof(msg), peerRank, peerServerAddr, req);
   }
 
   CtranComm* comm{nullptr};
@@ -91,7 +110,7 @@ class CtranSocket {
  private:
   struct recvCtrlQueue {
     std::deque<std::unique_ptr<SockPendingOp>> postedOps_;
-    std::deque<std::unique_ptr<ControlMsg>> unexpMsgs_;
+    std::deque<std::unique_ptr<SocketCtrlPacket>> unexpMsgs_;
 
     recvCtrlQueue() = default;
     recvCtrlQueue(recvCtrlQueue&& other) noexcept = default;
@@ -111,7 +130,7 @@ class CtranSocket {
 
   inline commResult_t checkValidPeer(int peerRank) {
     if (peerRank < 0 || (comm && peerRank >= comm->statex_->nRanks())) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "invalid peerRank ({}) < 0 or >= nRanks {}",
           peerRank,
@@ -123,7 +142,8 @@ class CtranSocket {
 
   // Check whether vc is ready and no outstanding pending ops
   bool addToPendingOpsIfRequired(
-      const ControlMsg& msg,
+      void* payload,
+      std::size_t size,
       int peerRank,
       CtranSocketRequest& req,
       SockPendingOp::OpType opType,
@@ -134,21 +154,37 @@ class CtranSocket {
   commResult_t progressInternal();
 
   commResult_t isendCtrlMsgImpl(
-      const ControlMsg& msg,
+      const void* payload,
+      std::size_t size,
       int peerRank,
       const SocketServerAddr& peerServerAddr,
       CtranSocketRequest& req);
 
   commResult_t irecvCtrlMsgImpl(
-      ControlMsg& msg,
+      void* payload,
+      std::size_t size,
       int peerRank,
       const SocketServerAddr& peerServerAddr,
       CtranSocketRequest& req);
 
-  int doRecvMsg(
+  // Reject a null or oversized control payload before it reaches the wire.
+  // dir is "send" or "receive", for the error message only.
+  commResult_t
+  checkCtrlPayload(const void* payload, std::size_t size, const char* dir);
+
+  // Resumable frame read. A non-blocking socket can deliver a frame in pieces,
+  // so per-peer progress is kept in rankToRecvFrameMap_ and the caller retries
+  // until packet holds a value. Sets *closed when the peer hung up.
+  commResult_t doRecvMsg(
       ctran::bootstrap::Socket* socket,
       int peerRank,
-      ControlMsg* msg);
+      std::optional<SocketCtrlPacket>& packet,
+      bool* closed);
+
+  commResult_t copyPacketToRecvOp(
+      const SocketCtrlPacket& packet,
+      SockPendingOp& recvOp,
+      int peerRank);
 
   commResult_t postRecvOp(int peerRank, std::unique_ptr<SockPendingOp> recvop);
 
@@ -206,6 +242,16 @@ class CtranSocket {
 
   folly::Synchronized<folly::F14FastMap<int, PendingOpQueue>>
       rankToPendingOpsMap_;
+
+  // Partially-read inbound frame per peer. Cleared once the frame completes or
+  // the connection closes.
+  struct RecvFrameState {
+    SocketCtrlPacket packet;
+    std::size_t headerBytes{0};
+    std::size_t payloadBytes{0};
+  };
+
+  folly::F14FastMap<int, RecvFrameState> rankToRecvFrameMap_;
 
   // every rank maintains a postedrecv queue and unexpected msg queue
   folly::F14FastMap<int, recvCtrlQueue> rankToRecvCtrlMap_;

--- a/comms/ctran/backends/socket/CtranSocketBase.h
+++ b/comms/ctran/backends/socket/CtranSocketBase.h
@@ -2,6 +2,10 @@
 
 #pragma once
 #include <fmt/format.h>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
 
 #include "comms/ctran/backends/CtranCtrl.h"
 
@@ -25,6 +29,41 @@ class CtranSocketRequest {
   } state_{INCOMPLETE};
 };
 
+// Length-delimited Socket control frame. The Socket path used to carry only a
+// fixed-size ControlMsg, but the mapper also exchanges raw registration
+// descriptor batches. One framing format lets a control op be routed to Socket
+// per peer regardless of which of the two forms it carries. Only
+// header + payloadSize bytes go on the wire, not the full buffer.
+struct SocketCtrlPacket {
+  uint32_t payloadSize{0};
+  std::array<char, CTRAN_CTRL_MAX_PAYLOAD_SIZE> payload{};
+
+  bool copyFrom(const void* src, std::size_t size) {
+    if ((size > 0 && src == nullptr) || size > payload.size()) {
+      return false;
+    }
+    payloadSize = static_cast<uint32_t>(size);
+    if (size > 0) {
+      std::memcpy(payload.data(), src, size);
+    }
+    return true;
+  }
+
+  bool copyTo(void* dst, std::size_t size) const {
+    if ((size > 0 && dst == nullptr) || size != payloadSize) {
+      return false;
+    }
+    if (size > 0) {
+      std::memcpy(dst, payload.data(), size);
+    }
+    return true;
+  }
+
+  std::size_t wireSize() const {
+    return offsetof(SocketCtrlPacket, payload) + payloadSize;
+  }
+};
+
 struct SockPendingOp {
   enum OpType {
     UNDEFINED,
@@ -35,15 +74,25 @@ struct SockPendingOp {
  public:
   SockPendingOp(
       SockPendingOp::OpType type,
-      ControlMsg& msg,
+      void* payload,
+      std::size_t size,
       int peerRank,
       CtranSocketRequest& req)
-      : type(type), msg(msg), peerRank(peerRank), req(req) {}
+      : type(type), payload(payload), size(size), peerRank(peerRank), req(req) {
+    // Snapshot sends: a queued op is drained later, by which point the
+    // caller's buffer may be gone. Receives write into payload on completion,
+    // so the caller owns it until the request completes.
+    if (type == ISEND_CTRL) {
+      packet.copyFrom(payload, size);
+    }
+  }
   ~SockPendingOp() {}
 
   OpType type{UNDEFINED};
 
-  ControlMsg& msg;
+  void* payload{nullptr};
+  std::size_t size{0};
+  SocketCtrlPacket packet;
   int peerRank{-1};
   CtranSocketRequest& req;
 };

--- a/comms/ctran/backends/socket/tests/CtranSocketRequestUT.cc
+++ b/comms/ctran/backends/socket/tests/CtranSocketRequestUT.cc
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <array>
+
 #include <gtest/gtest.h>
 
 #include "comms/ctran/backends/socket/CtranSocketBase.h"
@@ -17,4 +19,55 @@ TEST_F(CtranSocketRequestTest, Complete) {
   auto res = req.complete();
   EXPECT_EQ(res, commSuccess);
   EXPECT_TRUE(req.isComplete());
+}
+
+// A maximum-size raw payload must survive the frame round trip. wireSize is
+// checked by WireSizeTracksPayload -- at max size it cannot distinguish
+// "tracks the payload" from "sends the whole buffer", so it is not asserted
+// here.
+TEST_F(CtranSocketRequestTest, MaxPayloadRoundTrip) {
+  std::array<unsigned char, CTRAN_CTRL_MAX_PAYLOAD_SIZE> input{};
+  std::array<unsigned char, CTRAN_CTRL_MAX_PAYLOAD_SIZE> output{};
+  for (std::size_t i = 0; i < input.size(); ++i) {
+    input[i] = static_cast<unsigned char>(i % 251);
+  }
+
+  SocketCtrlPacket packet;
+  EXPECT_TRUE(packet.copyFrom(input.data(), input.size()));
+  EXPECT_EQ(packet.payloadSize, input.size());
+  EXPECT_TRUE(packet.copyTo(output.data(), output.size()));
+  EXPECT_EQ(output, input);
+}
+
+// A short payload must not put the full buffer on the wire.
+TEST_F(CtranSocketRequestTest, WireSizeTracksPayload) {
+  SocketCtrlPacket packet;
+  const unsigned char value = 7;
+  ASSERT_TRUE(packet.copyFrom(&value, sizeof(value)));
+  EXPECT_EQ(
+      packet.wireSize(), offsetof(SocketCtrlPacket, payload) + sizeof(value));
+  EXPECT_LT(packet.wireSize(), sizeof(SocketCtrlPacket));
+}
+
+TEST_F(CtranSocketRequestTest, PayloadValidation) {
+  std::array<unsigned char, CTRAN_CTRL_MAX_PAYLOAD_SIZE + 1> oversized{};
+  SocketCtrlPacket packet;
+  EXPECT_FALSE(packet.copyFrom(oversized.data(), oversized.size()));
+  EXPECT_FALSE(packet.copyFrom(nullptr, 1));
+
+  const unsigned char value = 42;
+  unsigned char output = 0;
+  ASSERT_TRUE(packet.copyFrom(&value, sizeof(value)));
+  // Size mismatch on receive must be rejected, not silently truncated.
+  EXPECT_FALSE(packet.copyTo(&output, 0));
+  EXPECT_FALSE(packet.copyTo(nullptr, sizeof(output)));
+  EXPECT_TRUE(packet.copyTo(&output, sizeof(output)));
+  EXPECT_EQ(output, value);
+}
+
+TEST_F(CtranSocketRequestTest, EmptyPayload) {
+  SocketCtrlPacket packet;
+  EXPECT_TRUE(packet.copyFrom(nullptr, 0));
+  EXPECT_EQ(packet.wireSize(), offsetof(SocketCtrlPacket, payload));
+  EXPECT_TRUE(packet.copyTo(nullptr, 0));
 }

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -136,6 +136,12 @@ CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
 
   iPutCount = std::vector<int>(CtranMapperBackend::NUM_BACKENDS, 0);
   iGetCount = std::vector<int>(CtranMapperBackend::NUM_BACKENDS, 0);
+  ctrlMsgCount = std::vector<int>(CtranMapperBackend::NUM_BACKENDS, 0);
+
+  // Sized up front and left all-false when same-host socket ctrl is disabled,
+  // so "no peer is routed to socket" is an explicit state rather than an empty
+  // vector that useSocketCtrl() has to interpret.
+  sameHostPeers_.assign(statex->nRanks(), false);
 
   std::vector<std::string> enableBackendsStrs;
   for (auto b : backendsToEnable) {
@@ -178,6 +184,34 @@ CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
           INFO,
           INIT,
           "CTRAN-MAPPER: SOCKET backend not enabled, since IB backend is enabled");
+    }
+  }
+
+  // Same-host ctrl over the frontend NIC. Stand up a socket alongside ib and
+  // mark which peers it serves; enableBackends_[SOCKET] stays false so socket
+  // remains out of the data path and getBackend() is unchanged.
+  if (NCCL_CTRAN_LOCAL_CTRL_BACKEND == NCCL_CTRAN_LOCAL_CTRL_BACKEND::socket &&
+      this->ctranIb) {
+    const int nRanks = statex->nRanks();
+    const int myRank = statex->rank();
+    const std::string myHost = statex->host(myRank);
+    int nSameHost = 0;
+    for (int peer = 0; peer < nRanks; peer++) {
+      if (peer != myRank && statex->host(peer) == myHost) {
+        sameHostPeers_[peer] = true;
+        nSameHost++;
+      }
+    }
+    if (nSameHost > 0) {
+      if (!this->ctranSock) {
+        this->ctranSock = std::make_unique<class CtranSocket>(comm);
+      }
+      CTRAN_LOG_SUBSYS(
+          INFO,
+          INIT,
+          "CTRAN-MAPPER: NCCL_CTRAN_LOCAL_CTRL_BACKEND=socket, routing ctrl for {} same-host peer(s) on {} over SOCKET",
+          nSameHost,
+          myHost);
     }
   }
   if (enableBackends_[CtranMapperBackend::TCPDM]) {
@@ -890,7 +924,17 @@ commResult_t CtranMapper::icopy(
 
 commResult_t CtranMapper::preConnect(const std::unordered_set<int>& peerRanks) {
   if (this->ctranIb != nullptr) {
-    FB_COMMCHECK(this->ctranIb->preConnect(peerRanks));
+    // Split by the same control-backend rule the send/recv paths use, so a
+    // same-host peer does not also stand up an ib QP it will never send on.
+    std::unordered_set<int> ibPeers;
+    std::unordered_set<int> sockPeers;
+    for (int peer : peerRanks) {
+      (useSocketCtrl(peer) ? sockPeers : ibPeers).insert(peer);
+    }
+    FB_COMMCHECK(this->ctranIb->preConnect(ibPeers));
+    if (!sockPeers.empty() && this->ctranSock != nullptr) {
+      FB_COMMCHECK(this->ctranSock->preConnect(sockPeers));
+    }
   } else if (ctranSock != nullptr) {
     FB_COMMCHECK(this->ctranSock->preConnect(peerRanks));
   } else if (this->ctranTcpDm != nullptr) {

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -1027,6 +1027,22 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    */
   std::vector<bool> getBackends();
 
+  /* Whether control traffic to peerRank bypasses ib for the frontend-NIC
+   * socket path. True only under NCCL_CTRAN_LOCAL_CTRL_BACKEND=socket for a
+   * peer sharing this rank's physical host.
+   *
+   * The mask is built from statex->host(), deliberately not from
+   * statex->node() or statex->localRankToRanks(): under nvl fabric both of
+   * those mean the clique, which spans hosts (32 ranks over 8 hosts on GB300).
+   * Widening this predicate to the clique would push ctrl for off-host peers
+   * onto the frontend network, which is not provisioned for it.
+   */
+  inline bool useSocketCtrl(int peerRank) const {
+    return this->ctranSock != nullptr && peerRank >= 0 &&
+        peerRank < static_cast<int>(sameHostPeers_.size()) &&
+        sameHostPeers_[peerRank];
+  }
+
   /* Some backends, notably NVL and TCPDM, require notifiers on the receiver
    * side. This method indicates whether the notifier is needed for
    * the specified peer rank.
@@ -1085,6 +1101,11 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
   std::vector<int> iPutCount;
   std::vector<int> iGetCount;
 
+  // number of control messages posted for each backend. Lets a caller (and the
+  // tests) confirm which transport a control op actually took, rather than
+  // inferring it from the op completing.
+  std::vector<int> ctrlMsgCount;
+
   // number of iCopy
   int iCopyCount{0};
 
@@ -1119,11 +1140,16 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
  protected:
   template <typename PerfConfig = DefaultPerfCollConfig>
   inline commResult_t progress() {
+    // Independent, not else-if: with NCCL_CTRAN_LOCAL_CTRL_BACKEND=socket both
+    // ctranIb and ctranSock are live, and a socket ctrl request whose backend
+    // is never progressed hangs rather than errors.
     if (this->ctranIb != nullptr) {
       FB_COMMCHECK(this->ctranIb->progress<PerfConfig>());
-    } else if (this->ctranSock != nullptr) {
+    }
+    if (this->ctranSock != nullptr) {
       FB_COMMCHECK(this->ctranSock->progress());
-    } else if (this->ctranTcpDm != nullptr) {
+    }
+    if (this->ctranTcpDm != nullptr) {
       FB_COMMCHECK(this->ctranTcpDm->progress());
     }
 
@@ -1501,9 +1527,14 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
   }
 
   inline CtranMapperBackend getCtrlBackend(
+      int peerRank,
       CtranMapperBackend backend = CtranMapperBackend::UNSET) {
     if (backend != CtranMapperBackend::UNSET) {
       return backend;
+    }
+
+    if (useSocketCtrl(peerRank)) {
+      return CtranMapperBackend::SOCKET;
     }
 
     if (this->ctranIb) {
@@ -1529,10 +1560,12 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperBackend backend = CtranMapperBackend::UNSET) {
     req->type = CtranMapperRequest::ReqType::SEND_CTRL;
     req->peer = peerRank;
-    req->backend = getCtrlBackend();
+    req->backend = getCtrlBackend(peerRank);
+    ctrlMsgCount[req->backend]++;
     FB_COMMCHECK(
         this->exportMem(peerRank, buf, hdl, req->sendCtrl.msg, backend));
     auto& msg = req->sendCtrl.msg;
+    const bool onIb = req->backend == CtranMapperBackend::IB;
     if (this->mapperTrace) {
       this->mapperTrace->recordMapperEvent(
           ncclx::colltrace::SendCtrlStart{
@@ -1544,16 +1577,16 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-MAPPER: Post {} SEND ctrlmsg to rank {} with req {} {} {}: {}",
-        ctranIb ? "IB" : "SOCKET",
+        backendToStr(req->backend),
         peerRank,
         (void*)req,
-        ctranIb ? "ibReq " : "sockReq ",
-        ctranIb ? (void*)&req->ibReq : (void*)&req->sockReq,
+        onIb ? "ibReq " : "sockReq ",
+        onIb ? (void*)&req->ibReq : (void*)&req->sockReq,
         msg.toString());
-    if (ctranIb) {
+    if (onIb) {
       return ctranIb->isendCtrlMsg<PerfConfig>(
           msg.type, &msg, sizeof(ControlMsg), peerRank, req->ibReq);
-    } else if (ctranSock) {
+    } else if (req->backend == CtranMapperBackend::SOCKET) {
       return ctranSock->isendCtrlMsg(msg, peerRank, req->sockReq);
     } else {
       return ctranTcpDm->isendCtrlMsg(msg, peerRank, req->tcpDmReq);
@@ -1568,11 +1601,13 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperRequest* req) {
     req->type = CtranMapperRequest::ReqType::RECV_CTRL;
     req->peer = peerRank;
-    req->backend = getCtrlBackend();
+    req->backend = getCtrlBackend(peerRank);
+    ctrlMsgCount[req->backend]++;
     req->recvCtrl.msg.setType(ControlMsgType::UNSPECIFIED);
     req->recvCtrl.buf = buf;
     req->recvCtrl.key = key;
     auto& msg = req->recvCtrl.msg;
+    const bool onIb = req->backend == CtranMapperBackend::IB;
     if (this->mapperTrace) {
       this->mapperTrace->recordMapperEvent(
           ncclx::colltrace::RecvCtrlStart{
@@ -1584,16 +1619,16 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-MAPPER: Post {} RECV ctrlmsg from rank {} with req {} {} {}: {}",
-        ctranIb ? "IB" : "SOCKET",
+        backendToStr(req->backend),
         peerRank,
         (void*)req,
-        ctranIb ? "ibReq " : "sockReq ",
-        ctranIb ? (void*)&req->ibReq : (void*)&req->sockReq,
+        onIb ? "ibReq " : "sockReq ",
+        onIb ? (void*)&req->ibReq : (void*)&req->sockReq,
         msg.toString());
-    if (ctranIb) {
+    if (onIb) {
       return ctranIb->irecvCtrlMsg<PerfConfig>(
           &msg, sizeof(msg), peerRank, req->ibReq);
-    } else if (ctranSock) {
+    } else if (req->backend == CtranMapperBackend::SOCKET) {
       return ctranSock->irecvCtrlMsg(msg, peerRank, req->sockReq);
     } else {
       return ctranTcpDm->irecvCtrlMsg(msg, peerRank, req->tcpDmReq);
@@ -1609,8 +1644,9 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperBackend backend = CtranMapperBackend::UNSET) {
     req->type = CtranMapperRequest::ReqType::SEND_CTRL_MSG;
     req->peer = peerRank;
-    req->backend =
-        ctranIb ? CtranMapperBackend::IB : CtranMapperBackend::SOCKET;
+    req->backend = getCtrlBackend(peerRank, backend);
+    ctrlMsgCount[req->backend]++;
+    const bool onIb = req->backend == CtranMapperBackend::IB;
     if (this->mapperTrace) {
       this->mapperTrace->recordMapperEvent(
           ncclx::colltrace::SendCtrlStart{
@@ -1621,20 +1657,22 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-MAPPER: Post {} SEND msg to rank {} with req {} {} {}: {}",
-        ctranIb ? "IB" : "SOCKET",
+        backendToStr(req->backend),
         peerRank,
         (void*)req,
-        ctranIb ? "ibReq " : "sockReq ",
-        ctranIb ? (void*)&req->ibReq : (void*)&req->sockReq,
+        onIb ? "ibReq " : "sockReq ",
+        onIb ? (void*)&req->ibReq : (void*)&req->sockReq,
         payload);
-    if (ctranIb) {
+    if (onIb) {
       return ctranIb->isendCtrlMsg(
           ControlMsgType::SYNC, payload, size, peerRank, req->ibReq);
     }
-    // only support ib for now
+    if (req->backend == CtranMapperBackend::SOCKET && ctranSock) {
+      return ctranSock->isendCtrlMsg(payload, size, peerRank, req->sockReq);
+    }
     CTRAN_ERR(
         commInvalidArgument,
-        "CTRAN-MAPPER: isendCtrlMsg only supports the IB backend for peerRank {}",
+        "CTRAN-MAPPER: isendCtrlMsg supports only the IB and Socket backends for peerRank {}",
         peerRank);
     return commInvalidArgument;
   }
@@ -1648,8 +1686,9 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperBackend backend = CtranMapperBackend::UNSET) {
     req->type = CtranMapperRequest::ReqType::RECV_CTRL_MSG;
     req->peer = peerRank;
-    req->backend =
-        ctranIb ? CtranMapperBackend::IB : CtranMapperBackend::SOCKET;
+    req->backend = getCtrlBackend(peerRank, backend);
+    ctrlMsgCount[req->backend]++;
+    const bool onIb = req->backend == CtranMapperBackend::IB;
     if (this->mapperTrace) {
       this->mapperTrace->recordMapperEvent(
           ncclx::colltrace::RecvCtrlStart{
@@ -1660,19 +1699,22 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-MAPPER: Post {} RECV msg from rank {} with req {} {} {}: {}",
-        ctranIb ? "IB" : "SOCKET",
+        backendToStr(req->backend),
         peerRank,
         (void*)req,
-        ctranIb ? "ibReq " : "sockReq ",
-        ctranIb ? (void*)&req->ibReq : (void*)&req->sockReq,
+        onIb ? "ibReq " : "sockReq ",
+        onIb ? (void*)&req->ibReq : (void*)&req->sockReq,
         payload);
-    if (ctranIb) {
+    if (onIb) {
       return ctranIb->irecvCtrlMsg<PerfConfig>(
           payload, size, peerRank, req->ibReq);
     }
+    if (req->backend == CtranMapperBackend::SOCKET && ctranSock) {
+      return ctranSock->irecvCtrlMsg(payload, size, peerRank, req->sockReq);
+    }
     CTRAN_ERR(
         commInvalidArgument,
-        "CTRAN-MAPPER: irecvCtrlMsg only supports the IB backend for peerRank {}",
+        "CTRAN-MAPPER: irecvCtrlMsg supports only the IB and Socket backends for peerRank {}",
         peerRank);
     return commInvalidArgument;
   }
@@ -1724,11 +1766,11 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
   inline commResult_t isendCtrlImpl(int peerRank, CtranMapperRequest* req) {
     req->type = CtranMapperRequest::ReqType::SEND_SYNC_CTRL;
     req->peer = peerRank;
-    req->backend = ctranIb ? CtranMapperBackend::IB
-        : ctranSock        ? CtranMapperBackend::SOCKET
-                           : CtranMapperBackend::TCPDM;
+    req->backend = getCtrlBackend(peerRank);
+    ctrlMsgCount[req->backend]++;
     auto& msg = req->sendSyncCtrl.msg;
     msg.setType(ControlMsgType::SYNC);
+    const bool onIb = req->backend == CtranMapperBackend::IB;
 
     if (this->mapperTrace) {
       this->mapperTrace->recordMapperEvent(
@@ -1738,16 +1780,16 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-MAPPER: Post {} SEND(SYNC) ctrlmsg to rank {} with req {} {} {}: {}",
-        ctranIb ? "IB" : "SOCKET",
+        backendToStr(req->backend),
         peerRank,
         (void*)req,
-        ctranIb ? "ibReq " : "sockReq ",
-        ctranIb ? (void*)&req->ibReq : (void*)&req->sockReq,
+        onIb ? "ibReq " : "sockReq ",
+        onIb ? (void*)&req->ibReq : (void*)&req->sockReq,
         msg.toString());
-    if (ctranIb) {
+    if (onIb) {
       return ctranIb->isendCtrlMsg(
           msg.type, &msg, sizeof(ControlMsg), peerRank, req->ibReq);
-    } else if (ctranSock) {
+    } else if (req->backend == CtranMapperBackend::SOCKET && ctranSock) {
       return ctranSock->isendCtrlMsg(msg, peerRank, req->sockReq);
     } else if (ctranTcpDm) {
       return ctranTcpDm->isendCtrlMsg(msg, peerRank, req->tcpDmReq);
@@ -1762,11 +1804,11 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
   inline commResult_t irecvCtrlImpl(int peerRank, CtranMapperRequest* req) {
     req->type = CtranMapperRequest::ReqType::RECV_SYNC_CTRL;
     req->peer = peerRank;
-    req->backend = ctranIb ? CtranMapperBackend::IB
-        : ctranSock        ? CtranMapperBackend::SOCKET
-                           : CtranMapperBackend::TCPDM;
+    req->backend = getCtrlBackend(peerRank);
+    ctrlMsgCount[req->backend]++;
     auto& msg = req->recvSyncCtrl.msg;
     msg.setType(ControlMsgType::SYNC);
+    const bool onIb = req->backend == CtranMapperBackend::IB;
 
     if (this->mapperTrace) {
       this->mapperTrace->recordMapperEvent(
@@ -1776,15 +1818,15 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-MAPPER: Post {} RECV(SYNC) ctrlmsg from rank {} with req {} {} {}: {}",
-        ctranIb ? "IB" : "SOCKET",
+        backendToStr(req->backend),
         peerRank,
         (void*)req,
-        ctranIb ? "ibReq " : "sockReq ",
-        ctranIb ? (void*)&req->ibReq : (void*)&req->sockReq,
+        onIb ? "ibReq " : "sockReq ",
+        onIb ? (void*)&req->ibReq : (void*)&req->sockReq,
         msg.toString());
-    if (ctranIb) {
+    if (onIb) {
       return ctranIb->irecvCtrlMsg(&msg, sizeof(msg), peerRank, req->ibReq);
-    } else if (ctranSock) {
+    } else if (req->backend == CtranMapperBackend::SOCKET && ctranSock) {
       return ctranSock->irecvCtrlMsg(msg, peerRank, req->sockReq);
     } else if (ctranTcpDm) {
       return ctranTcpDm->irecvCtrlMsg(msg, peerRank, req->tcpDmReq);
@@ -2356,6 +2398,10 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
   // A unified struct for holding all available backends.
   std::vector<bool> enableBackends_{
       std::vector<bool>(CtranMapperBackend::NUM_BACKENDS, false)};
+
+  // Indexed by rank: peer shares this rank's physical host. Empty unless
+  // NCCL_CTRAN_LOCAL_CTRL_BACKEND=socket. Read by useSocketCtrl().
+  std::vector<bool> sameHostPeers_;
 
   // List of outstanding internal IPC release requests to be processed
   // when polling progress. We need to temporarily hold the request

--- a/comms/ctran/mapper/tests/CtranDistMapperUT.cc
+++ b/comms/ctran/mapper/tests/CtranDistMapperUT.cc
@@ -343,6 +343,188 @@ TEST_F(CtranDistMapperTest, allGatherCtrlNRanks) {
   NCCLCHECK_TEST(ncclMemFree(buf));
 }
 
+// Arbitrary recognizable base so a mis-delivered ctrl payload is obvious.
+constexpr uint64_t kCtrlProbeBase{0xC0DE0000ull};
+
+// NCCL_CTRAN_LOCAL_CTRL_BACKEND must be set before the mapper is constructed:
+// the same-host mask and the extra CtranSocket are built in its ctor.
+class CtranDistMapperLocalCtrlSocketTest : public CtranDistMapperTest {
+  void SetUp() override {
+    setenv("NCCL_CTRAN_LOCAL_CTRL_BACKEND", "socket", 1);
+    ncclCvarInit();
+    CtranDistMapperTest::SetUp();
+  }
+  void TearDown() override {
+    CtranDistMapperTest::TearDown();
+    unsetenv("NCCL_CTRAN_LOCAL_CTRL_BACKEND");
+    ncclCvarInit();
+  }
+};
+
+// Same-host peers must route ctrl over SOCKET while remote peers stay on IB,
+// and the exchange must still complete with both backends live. Guards
+// CtranMapper::progress(), which hangs rather than errors if only the first
+// non-null backend is progressed.
+TEST_F(CtranDistMapperLocalCtrlSocketTest, allGatherCtrlSameHostOverSocket) {
+  void* buf = nullptr;
+  void* handle = nullptr;
+  constexpr size_t bufSize = 8192;
+  auto mapper = comm_->ctran_->mapper.get();
+  const auto& statex = comm_->statex_.get();
+
+  if (statex->nLocalRanks() < 2) {
+    GTEST_SKIP()
+        << "Test requires at least 2 localRanks on each node.  Skip test.";
+  }
+  if (!mapper->hasBackend(statex->rank(), CtranMapperBackend::IB)) {
+    GTEST_SKIP() << "Test requires the IB backend to be enabled.  Skip test.";
+  }
+
+  const std::string myHost = statex->host(statex->rank());
+  int nSameHost = 0;
+  for (int peer = 0; peer < statex->nRanks(); peer++) {
+    if (peer == statex->rank()) {
+      continue;
+    }
+    const bool sameHost = statex->host(peer) == myHost;
+    EXPECT_EQ(mapper->useSocketCtrl(peer), sameHost)
+        << "peer " << peer << " host " << statex->host(peer) << " vs "
+        << myHost;
+    nSameHost += sameHost;
+  }
+  ASSERT_GT(nSameHost, 0) << "Expected at least one same-host peer.";
+
+  NCCLCHECK_TEST(ncclMemAlloc(&buf, bufSize));
+  COMMCHECK_TEST(comm_->ctran_->commRegister(buf, bufSize, &handle));
+
+  void* sendHdl = nullptr;
+  bool localReg = false;
+  COMMCHECK_TEST(mapper->searchRegHandle(buf, bufSize, &sendHdl, &localReg));
+  ASSERT_NE(sendHdl, nullptr);
+
+  std::vector<void*> remoteBufs(statex->nRanks(), nullptr);
+  std::vector<struct CtranMapperRemoteAccessKey> remoteAccessKeys(
+      statex->nRanks());
+
+  const int socketBefore = mapper->ctrlMsgCount[CtranMapperBackend::SOCKET];
+
+  {
+    CtranMapperEpochRAII epochRAII(mapper);
+
+    auto res =
+        mapper->allGatherCtrl(buf, sendHdl, remoteBufs, remoteAccessKeys);
+    ASSERT_EQ(res, commSuccess);
+  }
+
+  // Some ctrl traffic must have gone over socket. IB is not asserted to be
+  // zero here: this allgather spans the whole comm, so remote peers use IB by
+  // design. sameHostCtrlUsesSocketNotIb makes the exclusive assertion.
+  EXPECT_GT(mapper->ctrlMsgCount[CtranMapperBackend::SOCKET] - socketBefore, 0);
+
+  for (int peer = 0; peer < statex->nRanks(); peer++) {
+    if (peer != statex->rank()) {
+      ASSERT_NE(remoteBufs[peer], nullptr) << "peer " << peer;
+    }
+  }
+
+  barrierNvlDomain(comm_.get());
+
+  COMMCHECK_TEST(comm_->ctran_->commDeregister(handle));
+  NCCLCHECK_TEST(ncclMemFree(buf));
+}
+
+// intraNvlDomainAllGather runs the raw-payload ctrl path
+// (isendCtrlMsg/irecvCtrlMsg), which was IB-only before this change, over a
+// peer set that includes same-host ranks. With those routed to Socket it must
+// still deliver every domain rank's value.
+TEST_F(CtranDistMapperLocalCtrlSocketTest, intraNvlDomainAllGatherOverSocket) {
+  auto mapper = comm_->ctran_->mapper.get();
+  const auto& statex = comm_->statex_.get();
+
+  if (statex->nLocalRanks() < 2) {
+    GTEST_SKIP()
+        << "Test requires at least 2 localRanks on each node.  Skip test.";
+  }
+  if (!mapper->hasBackend(statex->rank(), CtranMapperBackend::IB)) {
+    GTEST_SKIP() << "Test requires the IB backend to be enabled.  Skip test.";
+  }
+
+  const int nLocalRanks = statex->nLocalRanks();
+  const uint64_t sendVal = kCtrlProbeBase + statex->rank();
+  std::vector<uint64_t> recvVals(nLocalRanks, 0);
+
+  const int socketBefore = mapper->ctrlMsgCount[CtranMapperBackend::SOCKET];
+
+  {
+    CtranMapperEpochRAII epochRAII(mapper);
+    ASSERT_EQ(
+        mapper->intraNvlDomainAllGather(
+            &sendVal, recvVals.data(), sizeof(uint64_t)),
+        commSuccess);
+  }
+
+  // The raw-payload path reached socket for the same-host members of the
+  // clique. IB is not asserted zero: the clique spans hosts.
+  EXPECT_GT(mapper->ctrlMsgCount[CtranMapperBackend::SOCKET] - socketBefore, 0);
+
+  std::vector<uint64_t> expected(nLocalRanks);
+  for (int i = 0; i < nLocalRanks; i++) {
+    expected[i] = kCtrlProbeBase + statex->localRankToRank(i);
+  }
+  EXPECT_EQ(recvVals, expected);
+}
+
+// The two tests above show that same-host ctrl exchanges complete, but a silent
+// fallback to IB would complete too. Assert the transport directly: exchange
+// ctrl messages with same-host peers ONLY, and require that the socket counter
+// moves by exactly one send plus one recv per peer while the IB counter does
+// not move at all. Scoped to same-host peers because the whole-comm exchanges
+// legitimately use IB for everyone else.
+TEST_F(CtranDistMapperLocalCtrlSocketTest, sameHostCtrlUsesSocketNotIb) {
+  auto mapper = comm_->ctran_->mapper.get();
+  const auto& statex = comm_->statex_.get();
+
+  if (statex->nLocalRanks() < 2) {
+    GTEST_SKIP()
+        << "Test requires at least 2 localRanks on each node.  Skip test.";
+  }
+  if (!mapper->hasBackend(statex->rank(), CtranMapperBackend::IB)) {
+    GTEST_SKIP() << "Test requires the IB backend to be enabled.  Skip test.";
+  }
+
+  std::vector<int> sameHostPeers;
+  for (int peer = 0; peer < statex->nRanks(); peer++) {
+    if (peer != statex->rank() && mapper->useSocketCtrl(peer)) {
+      sameHostPeers.push_back(peer);
+    }
+  }
+  ASSERT_FALSE(sameHostPeers.empty())
+      << "Expected at least one same-host peer routed to SOCKET.";
+
+  const int socketBefore = mapper->ctrlMsgCount[CtranMapperBackend::SOCKET];
+  const int ibBefore = mapper->ctrlMsgCount[CtranMapperBackend::IB];
+
+  {
+    CtranMapperEpochRAII epochRAII(mapper);
+    // Pre-sized: the IB layer holds references into each request's ibReq, so
+    // the vector must not reallocate.
+    std::vector<CtranMapperRequest> reqs(sameHostPeers.size() * 2);
+    int idx = 0;
+    for (const int peer : sameHostPeers) {
+      ASSERT_EQ(mapper->irecvCtrl(peer, &reqs[idx++]), commSuccess);
+      ASSERT_EQ(mapper->isendCtrl(peer, &reqs[idx++]), commSuccess);
+    }
+    for (auto& req : reqs) {
+      ASSERT_EQ(mapper->waitRequest(&req), commSuccess);
+    }
+  }
+
+  EXPECT_EQ(
+      mapper->ctrlMsgCount[CtranMapperBackend::SOCKET] - socketBefore,
+      static_cast<int>(sameHostPeers.size()) * 2);
+  EXPECT_EQ(mapper->ctrlMsgCount[CtranMapperBackend::IB] - ibBefore, 0);
+}
+
 class CtranDistMapperPerfConfigTestParam
     : public CtranDistMapperTest,
       public ::testing::WithParamInterface<bool> {};

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2165,6 +2165,26 @@ cvars:
      Usage: If the config is "ib, nvl, socket", the backend tries to enable
      ib first. If the ib initialization fails, the backend will enable socket.
 
+ - name        : NCCL_CTRAN_LOCAL_CTRL_BACKEND
+   type        : enum
+   default     : ib
+   choices     : ib, socket
+   description : |-
+     Transport used for control messages to peers on the same physical host.
+     Control messages always went over ib, even for a peer whose data path is
+     NVL. On a platform where host-local RDMA between NICs is unavailable --
+     GCP GB300, where two ranks on one host cannot reach each other through
+     their own HCAs even on the same plane -- those handshakes never complete
+     and communicator setup dies with 'transport retry counter exceeded'.
+     Set to "socket" to route same-host control traffic over the interface
+     NCCL_SOCKET_IFNAME resolves to instead. Peers on other hosts still use ib
+     and the data path is unchanged, so this only affects peers that ib cannot
+     serve anyway. Both the fixed-size ControlMsg path and the raw-payload path
+     (isendCtrlMsg/irecvCtrlMsg, used by intraNvlDomainAllGather and the
+     allGatherCtrl overflow segments) are routed.
+     Socket control is a TCP round trip rather than an RDMA one; the added
+     per-message latency has not been measured.
+
  - name        : NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET
    type        : bool
    default     : true


### PR DESCRIPTION
Summary:
Ctran picks its transport per peer for the data path -- `CtranMapper::getBackend(rank)`
returns `NVL` for any peer `CtranNvl::isSupported()` covers and falls back to `IB`. The
control path did not: `getCtrlBackend()` took no rank and returned `IB` whenever
`ctranIb` existed, so handle exchange went over InfiniBand even to a peer on the same
motherboard inside the same NVLink clique.

That is fatal on platforms, where host-local RDMA between two NIC/HCA interfaces is not
available -- two same-host ranks cannot reach each other over their GPU-local HCAs even
when both NICs sit on the same plane. A same-host peer pair therefore created control
QPs it could never complete on. Observed on a 256-GPU run (TP=2, ctran allgather on the
FSDP DP groups) as `CTRAN-IB: wrap_ibv_poll_cq failed, commHash d436957a9d3d670d peer 0
... status=12, 'transport retry counter exceeded'` during `commWindowRegister`, where
`peer 0` and the reporting rank are both on same host and both in the same
32-rank nvl clique. The remote-peer errors that follow are cascade from the aborted
comm, not independent failures.

Adds `NCCL_CTRAN_LOCAL_CTRL_BACKEND` (enum `ib`|`socket`, default `ib`, so behavior is
unchanged until opted in). When set to `socket`, `CtranMapper` stands up a `CtranSocket`
alongside `CtranIb` and routes control messages for same-host peers over the existing
`NCCL_SOCKET_IFNAME` interface. `enableBackends_[SOCKET]` deliberately stays false so
socket stays out of the data path and `getBackend()` is unchanged.

Reviewed By: minsii, saifhhasan

Differential Revision: D115922901


