### PR TITLE
Restore async logging durability

### DIFF
--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include <spdlog/async.h>
+#include <spdlog/details/periodic_worker.h>
 #include <spdlog/pattern_formatter.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/sink.h>
@@ -30,10 +31,78 @@ namespace {
 constexpr std::string_view kLoggerName = "comms";
 constexpr size_t kAsyncQueueSize = 8192;
 constexpr size_t kAsyncThreadCount = 1;
+/*
+ * Bounds how much buffered file output an abnormal exit can lose. Folly wrote
+ * through to the fd, so without a periodic flush the migrated path would keep
+ * recent lines only in the stdio buffer.
+ */
+constexpr auto kPeriodicFlushInterval = std::chrono::seconds{1};
 thread_local std::string threadName = "main";
 // Guard the full callback chain so it cannot recurse through another context
 // logger and eventually re-enter the originating callback.
 thread_local bool errorCallbackInProgress = false;
+
+class PeriodicSinkFlusher final {
+ public:
+  PeriodicSinkFlusher()
+      : worker_{
+            [this]() noexcept { flushRegisteredSinks(); },
+            kPeriodicFlushInterval} {}
+  ~PeriodicSinkFlusher() = default;
+
+  void registerSink(const std::shared_ptr<spdlog::sinks::sink>& sink) {
+    std::lock_guard lock{mutex_};
+    for (auto it = sinks_.begin(); it != sinks_.end();) {
+      if (const auto registered = it->lock()) {
+        if (registered == sink) {
+          return;
+        }
+        ++it;
+      } else {
+        it = sinks_.erase(it);
+      }
+    }
+    sinks_.push_back(sink);
+  }
+
+  PeriodicSinkFlusher(const PeriodicSinkFlusher&) = delete;
+  PeriodicSinkFlusher& operator=(const PeriodicSinkFlusher&) = delete;
+  PeriodicSinkFlusher(PeriodicSinkFlusher&&) = delete;
+  PeriodicSinkFlusher& operator=(PeriodicSinkFlusher&&) = delete;
+
+ private:
+  void flushRegisteredSinks() noexcept {
+    std::vector<std::shared_ptr<spdlog::sinks::sink>> sinks;
+    {
+      std::lock_guard lock{mutex_};
+      for (auto it = sinks_.begin(); it != sinks_.end();) {
+        if (auto sink = it->lock()) {
+          sinks.push_back(std::move(sink));
+          ++it;
+        } else {
+          it = sinks_.erase(it);
+        }
+      }
+    }
+
+    for (const auto& sink : sinks) {
+      try {
+        sink->flush();
+      } catch (...) {
+        // A sink failure must not terminate the process from this worker.
+      }
+    }
+  }
+
+  std::mutex mutex_;
+  std::vector<std::weak_ptr<spdlog::sinks::sink>> sinks_;
+  spdlog::details::periodic_worker worker_;
+};
+
+PeriodicSinkFlusher& getPeriodicSinkFlusher() {
+  static PeriodicSinkFlusher flusher;
+  return flusher;
+}
 
 class ErrorCallbackGuard {
  public:
@@ -163,8 +232,8 @@ CommsSpdlogLogger::CommsSpdlogLogger(std::string name)
       outputSink_(
           std::make_shared<spdlog::sinks::dist_sink_mt>(logger_->sinks())) {
   logger_->sinks() = {outputSink_};
-  synchronousLogger_ = std::make_shared<spdlog::logger>(
-      logger_->name(), logger_->sinks().begin(), logger_->sinks().end());
+  synchronousLogger_ =
+      std::make_shared<spdlog::logger>(logger_->name(), outputSink_);
   synchronousLogger_->set_level(spdlog::level::trace);
   storeConfiguration(std::make_shared<const Configuration>());
 }
@@ -241,6 +310,17 @@ void CommsSpdlogLogger::configure(
           std::move(errorCallback),
           asyncLogging});
   storeConfiguration(std::move(configuration));
+
+  /*
+   * The file sink buffers in user space and spdlog does not flush by default,
+   * so errors would otherwise reach the log file only once the buffer filled.
+   * Set unconditionally: configure() is public and may switch a logger back to
+   * synchronous, which must not inherit the previous flush level.
+   */
+  logger_->flush_on(asyncLogging ? spdlog::level::err : spdlog::level::off);
+  if (asyncLogging) {
+    getPeriodicSinkFlusher().registerSink(outputSink_);
+  }
 }
 
 std::shared_ptr<const CommsSpdlogLogger::Configuration>

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -5,11 +5,14 @@
 
 #include "comms/utils/logger/SpdlogLogger.h"
 
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
 #include <stdexcept>
 #include <string>
+#include <string_view>
+#include <thread>
 #include <utility>
 
 #include <gtest/gtest.h>
@@ -39,6 +42,27 @@ class ScopedTestFile {
 
   std::filesystem::path path_;
 };
+
+std::string readFile(const std::filesystem::path& path) {
+  std::ifstream file{path};
+  return {
+      std::istreambuf_iterator<char>{file}, std::istreambuf_iterator<char>{}};
+}
+
+bool waitForFileToContain(
+    const std::filesystem::path& path,
+    std::string_view message) {
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds{5};
+  do {
+    if (readFile(path).find(message) != std::string::npos) {
+      return true;
+    }
+    /* sleep override */
+    std::this_thread::sleep_for(std::chrono::milliseconds{10});
+  } while (std::chrono::steady_clock::now() < deadline);
+  return false;
+}
 
 class LogLevelRestoringTest : public testing::Test {
  protected:
@@ -70,6 +94,44 @@ TEST(SpdlogLoggerTest, MatchesLegacyStderrRouting) {
   EXPECT_FALSE(
       meta::comms::logger::shouldWriteCommsLogToStderr("INFO message"));
   EXPECT_FALSE(meta::comms::logger::shouldWriteCommsLogToStderr(""));
+}
+
+TEST(SpdlogLoggerTest, AsyncErrorReachesFileWithoutExplicitFlush) {
+  constexpr std::string_view kContext = "comms.async_flush_test";
+  const ScopedTestFile scopedLogFile{"comms_spdlog_async_flush.log"};
+  meta::comms::logger::configureSpdlogLogger(
+      kContext,
+      "TEST",
+      scopedLogFile.path().string(),
+      []() { return 0; },
+      {},
+      true);
+  auto& logger = getSpdlogLogger(kContext);
+  logger.set_level(spdlog::level::info);
+
+  COMMS_LOG_NAMED(kContext, ERR, "asynchronous error flush");
+
+  EXPECT_TRUE(
+      waitForFileToContain(scopedLogFile.path(), "asynchronous error flush"));
+}
+
+TEST(SpdlogLoggerTest, AsyncInfoReachesFileViaPeriodicFlush) {
+  constexpr std::string_view kContext = "comms.periodic_flush_test";
+  const ScopedTestFile scopedLogFile{"comms_spdlog_periodic_flush.log"};
+  meta::comms::logger::configureSpdlogLogger(
+      kContext,
+      "TEST",
+      scopedLogFile.path().string(),
+      []() { return 0; },
+      {},
+      true);
+  auto& logger = getSpdlogLogger(kContext);
+  logger.set_level(spdlog::level::info);
+
+  COMMS_LOG_NAMED(kContext, INFO, "asynchronous periodic flush");
+
+  EXPECT_TRUE(waitForFileToContain(
+      scopedLogFile.path(), "asynchronous periodic flush"));
 }
 
 TEST(SpdlogLoggerTest, SynchronousFileDeliveryMatchesLegacyRouting) {


### PR DESCRIPTION
Summary:
The spdlog migration moved CTRAN and NCCLX production logging off Folly's writer, but `basic_file_sink` buffers output and spdlog defaults to never flushing. A dequeued message could therefore remain only in the stdio buffer until it filled, so an abnormal exit could lose recent logs.

Set `flush_on(err)` for asynchronous configurations so errors reach the file immediately, and reset it when a logger is reconfigured synchronously. Add a comms-owned periodic worker that flushes only registered comms output sinks once per second, bounding buffered `INFO` and `TRACE` loss without replacing spdlog's process-wide periodic flusher or touching unrelated loggers.

The worker tracks sinks with weak references, copies live sinks under its mutex, and performs I/O after releasing the mutex. The synchronous and fatal paths continue to use the unwrapped output sink.

Drop reporting is intentionally excluded. Spdlog exposes only a process-wide overrun counter, so a sink-level sampler cannot identify which logger lost records and can write the count to the wrong file. Correct per-logger accounting requires a separate queue-level design.

Reviewed By: shr

Differential Revision: D116380706


