### PR TITLE
Fix cross-process get() on the XGMI/IPC intra-node transport

### DIFF
--- a/comms/uniflow/transport/p2p/P2pTransport.cpp
+++ b/comms/uniflow/transport/p2p/P2pTransport.cpp
@@ -160,16 +160,30 @@ Status P2pTransport::connect(std::span<const uint8_t> remoteInfo) {
   CHECK_RETURN(parsedPeer);
   const int32_t peer = parsedPeer.value();
 
-  // Enable this device to access the peer device (no-op for same device or if
-  // already enabled). Covers same-process cross-device P2P; cross-process
-  // imports also lazily enable peer access via ipcOpenMemHandle. Commit
-  // peerDeviceId_ / Connected only after this succeeds, so a failure leaves the
-  // transport in its prior (Initialized) state.
+  // Enable peer access in BOTH directions (no-op for same device or if already
+  // enabled). Commit peerDeviceId_ / Connected only after both succeed, so a
+  // failure leaves the transport Initialized.
+  //
+  // The reverse direction is the non-obvious one: get() reads the IPC-imported
+  // peer buffer, and ROCm runs that copy on the SOURCE agent, which writes into
+  // THIS device's memory. With only local->peer, put() works and get() faults
+  // once the two ranks are separate processes. PeerToPeerTransferTest enables
+  // both directions for the same reason.
+  //
+  // The helper keeps each edge paired with its own source device current.
+  auto enableOneDirection = [this](int32_t from, int32_t to) {
+    CudaDeviceGuard guard(*cudaApi_, from);
+    return cudaApi_->deviceEnablePeerAccess(to);
+  };
+
   if (peer != deviceId_) {
-    CudaDeviceGuard guard(*cudaApi_, deviceId_);
-    auto st = cudaApi_->deviceEnablePeerAccess(peer);
-    if (st.hasError()) {
-      return st;
+    auto forward = enableOneDirection(deviceId_, peer);
+    if (forward.hasError()) {
+      return forward;
+    }
+    auto reverse = enableOneDirection(peer, deviceId_);
+    if (reverse.hasError()) {
+      return reverse;
     }
   }
 

--- a/comms/uniflow/transport/p2p/tests/P2pTransportTest.cpp
+++ b/comms/uniflow/transport/p2p/tests/P2pTransportTest.cpp
@@ -241,7 +241,9 @@ TEST(P2pTransportTest, ConnectEnablesPeerAccessForDifferentDevice) {
   auto mock = std::make_shared<NiceMock<MockCudaApi>>();
   ON_CALL(*mock, getDevice()).WillByDefault(Return(Result<int>(0)));
   ON_CALL(*mock, setDevice(_)).WillByDefault(Return(Ok()));
+  // BOTH directions: local->peer for put, peer->local for get.
   EXPECT_CALL(*mock, deviceEnablePeerAccess(1)).WillOnce(Return(Ok()));
+  EXPECT_CALL(*mock, deviceEnablePeerAccess(0)).WillOnce(Return(Ok()));
 
   ScopedEventBaseThread ebt;
   P2pTransport transport(/*deviceId=*/0, ebt.getEventBase(), mock);
@@ -315,11 +317,60 @@ TEST(P2pTransportTest, ConnectRequiresBindFirst) {
   EXPECT_NE(transport.state(), TransportState::Connected);
 }
 
+// Regression test for a cross-process get() fault on AMD: with only
+// local->peer enabled, put() works and get() faults once the ranks are
+// separate processes.
+TEST(P2pTransportTest, ConnectEnablesPeerAccessInBothDirections) {
+  auto mock = std::make_shared<NiceMock<MockCudaApi>>();
+
+  int current = -1;
+  ON_CALL(*mock, setDevice(_)).WillByDefault([&current](int d) {
+    current = d;
+    return Ok();
+  });
+  ON_CALL(*mock, getDevice()).WillByDefault([&current]() {
+    return Result<int>(current);
+  });
+
+  EXPECT_CALL(*mock, deviceEnablePeerAccess(1)).WillOnce([&current](int) {
+    EXPECT_EQ(current, 0) << "local->peer must be enabled with LOCAL current";
+    return Ok();
+  });
+  EXPECT_CALL(*mock, deviceEnablePeerAccess(0)).WillOnce([&current](int) {
+    EXPECT_EQ(current, 1) << "peer->local must be enabled with PEER current";
+    return Ok();
+  });
+
+  ScopedEventBaseThread ebt;
+  P2pTransport transport(/*deviceId=*/0, ebt.getEventBase(), mock);
+  transport.bind();
+  EXPECT_FALSE(transport.connect(makeDeviceIdBytes(1)).hasError());
+  EXPECT_EQ(transport.state(), TransportState::Connected);
+}
+
+// A failure enabling the REVERSE direction must not leave the transport
+// half-connected: state stays Initialized so the caller can retry or fall back.
+TEST(P2pTransportTest, ConnectFailsClosedWhenReversePeerAccessFails) {
+  auto mock = std::make_shared<NiceMock<MockCudaApi>>();
+  ON_CALL(*mock, getDevice()).WillByDefault(Return(Result<int>(0)));
+  ON_CALL(*mock, setDevice(_)).WillByDefault(Return(Ok()));
+  EXPECT_CALL(*mock, deviceEnablePeerAccess(1)).WillOnce(Return(Ok()));
+  EXPECT_CALL(*mock, deviceEnablePeerAccess(0))
+      .WillOnce(Return(Err(ErrCode::DriverError, "no reverse peer access")));
+
+  ScopedEventBaseThread ebt;
+  P2pTransport transport(/*deviceId=*/0, ebt.getEventBase(), mock);
+  transport.bind();
+  EXPECT_TRUE(transport.connect(makeDeviceIdBytes(1)).hasError());
+  EXPECT_EQ(transport.state(), TransportState::Initialized);
+}
+
 TEST(P2pTransportTest, BindDoesNotRegressConnectedState) {
   auto mock = std::make_shared<NiceMock<MockCudaApi>>();
   ON_CALL(*mock, getDevice()).WillByDefault(Return(Result<int>(0)));
   ON_CALL(*mock, setDevice(_)).WillByDefault(Return(Ok()));
   EXPECT_CALL(*mock, deviceEnablePeerAccess(1)).WillOnce(Return(Ok()));
+  EXPECT_CALL(*mock, deviceEnablePeerAccess(0)).WillOnce(Return(Ok()));
 
   ScopedEventBaseThread ebt;
   P2pTransport transport(/*deviceId=*/0, ebt.getEventBase(), mock);


### PR DESCRIPTION
Summary:
`get()` on the AMD intra-node (HIP IPC over XGMI) transport faults as soon as
the two ranks are separate processes:

```
Memory access fault by GPU node-N (Agent handle: 0x...) on address 0x...
Reason: Write access to a read-only page.
```

`put()` is unaffected. Found while bringing up an XGMI bandwidth benchmark
(next diff in this stack), which is the first thing to drive this transport as
two real processes.

## Root cause

`get()` reads the IPC-imported peer buffer into local memory. ROCm runs that
copy on the **source (exporter) agent**, which then has to write into *this*
device's memory. That write needs peer access in the **peer -> local**
direction, enabled **in the importing process**.

`connect()` only ever enabled `local -> peer`:

```cpp
CudaDeviceGuard guard(*cudaApi_, deviceId_);
cudaApi_->deviceEnablePeerAccess(peer);
```

Each rank's process therefore had exactly one direction, which is enough for
put and not for get.

The comment above that call claimed "cross-process imports also lazily enable
peer access via ipcOpenMemHandle". That is **half true, and the half that is
true is the misleading one**: the lazy enable covers the *write* direction, so
put works and the claim looks validated. It has been corrected.

## Evidence (standalone repro, no uniflow involved)

A ~70-line two-process HIP IPC program (fork + pipe for the handle), gfx950:

| parentDev | childDev | op | result |
|---|---|---|---|
| 0 | 1 | write into imported mapping | PASS |
| 0 | 1 | read out of imported mapping | **FAULT** |
| 0 | 0 | write / read | PASS |
| 0 | 1 | read, **both** peer directions enabled | **PASS** |

Positive and negative control both present: the read fails with one direction
and passes with two, everything else held constant.

## Why no existing test caught this

Two independent structural reasons, either sufficient on its own:

1. `P2pSingleHostTest` builds **both** factories in **one process** ("uses two
   P2pTransportFactory instances on devices 0 and 1"). Device 0's connect()
   enables 0->1 and device 1's enables 1->0, so both directions end up live in
   that process -- the test accidentally supplies the missing precondition.
2. Same process means `importSegment()` takes the `ownerPid == getpid()`
   shortcut and **never calls ipcOpenMemHandle at all**, so the mapping that
   faults is never even constructed.

A single-process test cannot construct the failing configuration. Running it
more often, in CI, or on more hardware would never find this.

## Fix

Enable the reverse direction as well, with the peer device current. Both
enables are inside `if (peer != deviceId_)`, and a failure of either leaves the
transport in Initialized (fail-closed) as before.

Reviewed By: rmahidhar

Differential Revision: D116114953


