### PR TITLE
Add xgmi_bandwidth: intra-node P2P benchmark for AMD

### DIFF
--- a/comms/uniflow/benchmarks/bench/XgmiBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/XgmiBandwidthBenchmark.cpp
@@ -1,0 +1,610 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/benchmarks/bench/XgmiBandwidthBenchmark.h"
+
+#include <algorithm>
+#include <chrono>
+
+#include <cuda_runtime_api.h> // @manual=third-party//cuda:cuda-lazy
+
+#include "comms/uniflow/Segment.h"
+#include "comms/uniflow/benchmarks/Rendezvous.h"
+#include "comms/uniflow/benchmarks/SegmentHelper.h"
+#include "comms/uniflow/benchmarks/Stats.h"
+#include "comms/uniflow/drivers/cuda/CudaApi.h"
+#include "comms/uniflow/executor/ScopedEventBaseThread.h"
+#include "comms/uniflow/logging/Logger.h"
+#include "comms/uniflow/transport/p2p/P2pRegistrationHandle.h"
+#include "comms/uniflow/transport/p2p/P2pTransport.h"
+
+namespace uniflow::benchmark {
+
+namespace {
+
+constexpr uint8_t kFillByte = 0xAB;
+
+/// RAII wrapper for a plain device allocation.
+class DeviceAllocation {
+ public:
+  DeviceAllocation() = default;
+  DeviceAllocation(const DeviceAllocation&) = delete;
+  DeviceAllocation& operator=(const DeviceAllocation&) = delete;
+  DeviceAllocation(DeviceAllocation&&) = delete;
+  DeviceAllocation& operator=(DeviceAllocation&&) = delete;
+
+  ~DeviceAllocation() {
+    if (ptr_ != nullptr) {
+      (void)cudaFree(ptr_);
+    }
+  }
+
+  Status init(size_t size) {
+    auto err = cudaMalloc(&ptr_, size);
+    if (err != cudaSuccess) {
+      ptr_ = nullptr;
+      return Err(
+          ErrCode::MemoryRegistrationError,
+          fmt::format(
+              "cudaMalloc({}) failed: {}", size, cudaGetErrorString(err)));
+    }
+    size_ = size;
+    return Ok();
+  }
+
+  void* ptr() const {
+    return ptr_;
+  }
+  size_t size() const {
+    return size_;
+  }
+
+ private:
+  void* ptr_{nullptr};
+  size_t size_{0};
+};
+
+/// Holds all resources for a benchmark transport session.
+struct TransportSession {
+  TransportSession() = default;
+  ~TransportSession() {
+    if (transport) {
+      transport->shutdown();
+    }
+  }
+  TransportSession(const TransportSession&) = delete;
+  TransportSession& operator=(const TransportSession&) = delete;
+  TransportSession(TransportSession&&) = delete;
+  TransportSession& operator=(TransportSession&&) = delete;
+
+  std::unique_ptr<ScopedEventBaseThread> evbThread;
+  std::unique_ptr<P2pTransportFactory> factory;
+  std::unique_ptr<DeviceAllocation> srcAlloc;
+  std::unique_ptr<DeviceAllocation> dstAlloc;
+  std::unique_ptr<Transport> transport;
+  std::unique_ptr<RegisteredSegment> localReg;
+  std::unique_ptr<RemoteRegisteredSegment> remoteReg;
+};
+
+/// Create factory, create transport, and connect to peer.
+///
+/// Mirrors NVLinkBandwidthBenchmark's setup, against the AMD P2P factory:
+/// getTopology -> exchange -> createTransport -> bind -> exchange -> connect.
+std::unique_ptr<TransportSession> setupConnection(
+    std::vector<PeerConnection>& peers,
+    const BootstrapConfig& bootstrap) {
+  if (peers.empty()) {
+    UNIFLOW_LOG_ERROR("XgmiBandwidthBenchmark: setupConnection: no peers");
+    return nullptr;
+  }
+
+  auto session = std::make_unique<TransportSession>();
+
+  CudaApi cudaApi;
+  auto setDevStatus = cudaApi.setDevice(bootstrap.localRank);
+  if (!setDevStatus) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: setDevice failed: {}",
+        setDevStatus.error().toString());
+    return nullptr;
+  }
+
+  session->evbThread = std::make_unique<ScopedEventBaseThread>("bench-evb");
+  session->factory = std::make_unique<P2pTransportFactory>(
+      bootstrap.localRank, session->evbThread->getEventBase());
+
+  auto localTopology = session->factory->getTopology();
+  auto remoteTopologyResult =
+      exchangeMetadata(*peers[0].ctrl, localTopology, bootstrap.isRank0());
+  if (!remoteTopologyResult) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: topology exchange failed: {}",
+        remoteTopologyResult.error().toString());
+    return nullptr;
+  }
+
+  auto transportResult = session->factory->createTransport(
+      std::move(remoteTopologyResult).value());
+  if (!transportResult) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: createTransport failed: {}",
+        transportResult.error().toString());
+    return nullptr;
+  }
+  session->transport = std::move(transportResult).value();
+
+  auto localInfo = session->transport->bind();
+  auto remoteInfoResult =
+      exchangeMetadata(*peers[0].ctrl, localInfo, bootstrap.isRank0());
+  if (!remoteInfoResult) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: transport info exchange failed: {}",
+        remoteInfoResult.error().toString());
+    return nullptr;
+  }
+
+  auto connectStatus =
+      session->transport->connect(std::move(remoteInfoResult).value());
+  if (!connectStatus) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: connect failed: {}",
+        connectStatus.error().toString());
+    return nullptr;
+  }
+
+  return session;
+}
+
+/// Allocate device buffers of the given size, register segments, and exchange
+/// handles with the peer. Re-done per message size so the registered extent
+/// matches the transfer size, as the NVIDIA benchmark does.
+bool setupBuffersForSize(
+    TransportSession& session,
+    size_t bufferSize,
+    std::vector<PeerConnection>& peers,
+    const BootstrapConfig& bootstrap) {
+  if (peers.empty()) {
+    UNIFLOW_LOG_ERROR("XgmiBandwidthBenchmark: setupBuffersForSize: no peers");
+    return false;
+  }
+
+  session.localReg.reset();
+  session.remoteReg.reset();
+  session.srcAlloc.reset();
+  session.dstAlloc.reset();
+
+  session.srcAlloc = std::make_unique<DeviceAllocation>();
+  auto srcStatus = session.srcAlloc->init(bufferSize);
+  if (srcStatus.hasError()) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: src allocation failed: {}",
+        srcStatus.error().message());
+    return false;
+  }
+
+  session.dstAlloc = std::make_unique<DeviceAllocation>();
+  auto dstStatus = session.dstAlloc->init(bufferSize);
+  if (dstStatus.hasError()) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: dst allocation failed: {}",
+        dstStatus.error().message());
+    return false;
+  }
+
+  auto srcMemsetErr =
+      cudaMemset(session.srcAlloc->ptr(), kFillByte, session.srcAlloc->size());
+  if (srcMemsetErr != cudaSuccess) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: memset(src) failed: {}",
+        cudaGetErrorString(srcMemsetErr));
+    return false;
+  }
+  auto dstMemsetErr =
+      cudaMemset(session.dstAlloc->ptr(), 0, session.dstAlloc->size());
+  if (dstMemsetErr != cudaSuccess) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: memset(dst) failed: {}",
+        cudaGetErrorString(dstMemsetErr));
+    return false;
+  }
+  auto syncErr = cudaDeviceSynchronize();
+  if (syncErr != cudaSuccess) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: deviceSynchronize failed: {}",
+        cudaGetErrorString(syncErr));
+    return false;
+  }
+
+  Segment srcSeg(
+      session.srcAlloc->ptr(),
+      session.srcAlloc->size(),
+      MemoryType::VRAM,
+      bootstrap.localRank);
+  auto srcRegResult = session.factory->registerSegment(srcSeg);
+  if (!srcRegResult) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: registerSegment(src) failed: {}",
+        srcRegResult.error().toString());
+    return false;
+  }
+
+  Segment dstSeg(
+      session.dstAlloc->ptr(),
+      session.dstAlloc->size(),
+      MemoryType::VRAM,
+      bootstrap.localRank);
+  auto dstRegResult = session.factory->registerSegment(dstSeg);
+  if (!dstRegResult) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: registerSegment(dst) failed: {}",
+        dstRegResult.error().toString());
+    return false;
+  }
+
+  auto dstPayload = dstRegResult.value()->serialize();
+  auto remotePayloadResult =
+      exchangeMetadata(*peers[0].ctrl, dstPayload, bootstrap.isRank0());
+  if (!remotePayloadResult) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: handle exchange failed: {}",
+        remotePayloadResult.error().toString());
+    return false;
+  }
+
+  // Cross-process: the peer's payload names a different PID, so this is the
+  // real ipcOpenMemHandle path rather than the same-process shortcut. That is
+  // the whole reason this benchmark runs as two ranks.
+  auto remoteHandleResult = session.factory->importSegment(
+      session.dstAlloc->size(), std::move(remotePayloadResult).value());
+  if (!remoteHandleResult) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: importSegment failed: {}",
+        remoteHandleResult.error().toString());
+    return false;
+  }
+
+  session.localReg = std::make_unique<RegisteredSegment>(
+      SegmentTest::makeRegistered(srcSeg, std::move(srcRegResult.value())));
+
+  auto* p2pRemote = dynamic_cast<P2pRemoteRegistrationHandle*>(
+      remoteHandleResult.value().get());
+  if (!p2pRemote) {
+    UNIFLOW_LOG_ERROR("XgmiBandwidthBenchmark: failed to cast remote handle");
+    return false;
+  }
+
+  session.remoteReg =
+      std::make_unique<RemoteRegisteredSegment>(SegmentTest::makeRemote(
+          p2pRemote->mappedPtr(),
+          p2pRemote->mappedSize(),
+          std::move(remoteHandleResult.value())));
+
+  return true;
+}
+
+/// Full-size put+get before timing, then verify the bytes actually moved.
+///
+/// This is correctness insurance, not warmup: a transport that silently moved
+/// nothing would otherwise report excellent bandwidth.
+bool prefaultAndVerify(TransportSession& session, size_t maxSize) {
+  TransferRequest req{
+      .local = session.localReg->span(size_t{0}, maxSize),
+      .remote = session.remoteReg->span(size_t{0}, maxSize),
+  };
+
+  // 1. Put: src (0xAB) -> peer's mapped buffer.
+  auto putStatus = session.transport->put({&req, 1}).get();
+  if (putStatus.hasError()) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: put pre-fault failed: {}",
+        putStatus.error().message());
+    return false;
+  }
+
+  // 2. Zero src so the get below has to overwrite it to pass.
+  auto memsetErr = cudaMemset(session.srcAlloc->ptr(), 0, maxSize);
+  if (memsetErr != cudaSuccess) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: verification memset failed: {}",
+        cudaGetErrorString(memsetErr));
+    return false;
+  }
+  // Must complete before the get below, or the verification races the zeroing
+  // and can pass on stale 0xAB rather than on bytes the get actually moved.
+  auto zeroSyncErr = cudaDeviceSynchronize();
+  if (zeroSyncErr != cudaSuccess) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: verification deviceSynchronize failed: {}",
+        cudaGetErrorString(zeroSyncErr));
+    return false;
+  }
+
+  // 3. Get: peer's buffer (holds 0xAB) -> src.
+  auto getStatus = session.transport->get({&req, 1}).get();
+  if (getStatus.hasError()) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: get pre-fault failed: {}",
+        getStatus.error().message());
+    return false;
+  }
+
+  // 4. Read back and verify.
+  constexpr size_t kCheckSize = 64;
+  const size_t checkSize = std::min(maxSize, kCheckSize);
+  uint8_t hostBuf[kCheckSize] = {};
+  auto copyErr = cudaMemcpy(
+      hostBuf, session.srcAlloc->ptr(), checkSize, cudaMemcpyDeviceToHost);
+  if (copyErr != cudaSuccess) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: verification memcpy failed: {}",
+        cudaGetErrorString(copyErr));
+    return false;
+  }
+
+  for (size_t i = 0; i < checkSize; ++i) {
+    if (hostBuf[i] != kFillByte) {
+      UNIFLOW_LOG_ERROR(
+          "XgmiBandwidthBenchmark: data verification failed at byte {}: "
+          "expected {:#x}, got {:#x}",
+          i,
+          kFillByte,
+          hostBuf[i]);
+      return false;
+    }
+  }
+
+  // Check the tail too. A head-only check cannot see a short copy or an
+  // undersized mapping, and would report full bandwidth for it. That matters
+  // more on this path than on the NVIDIA one: importSegment cannot bounds-check
+  // (ipcOpenMemHandle does not report the mapping size) and registerSegment
+  // does allocBase + offset math the VMM path does not have.
+  if (maxSize > kCheckSize) {
+    uint8_t tailBuf[kCheckSize] = {};
+    auto* tail =
+        static_cast<uint8_t*>(session.srcAlloc->ptr()) + maxSize - kCheckSize;
+    auto tailErr =
+        cudaMemcpy(tailBuf, tail, kCheckSize, cudaMemcpyDeviceToHost);
+    if (tailErr != cudaSuccess) {
+      UNIFLOW_LOG_ERROR(
+          "XgmiBandwidthBenchmark: tail verification memcpy failed: {}",
+          cudaGetErrorString(tailErr));
+      return false;
+    }
+    for (size_t i = 0; i < kCheckSize; ++i) {
+      if (tailBuf[i] != kFillByte) {
+        UNIFLOW_LOG_ERROR(
+            "XgmiBandwidthBenchmark: tail verification failed at offset {}: "
+            "expected {:#x}, got {:#x}",
+            maxSize - kCheckSize + i,
+            kFillByte,
+            tailBuf[i]);
+        return false;
+      }
+    }
+  }
+
+  // Refill src for the timed loop.
+  auto refillErr =
+      cudaMemset(session.srcAlloc->ptr(), kFillByte, session.srcAlloc->size());
+  if (refillErr != cudaSuccess) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: refill memset failed: {}",
+        cudaGetErrorString(refillErr));
+    return false;
+  }
+  auto refillSyncErr = cudaDeviceSynchronize();
+  if (refillSyncErr != cudaSuccess) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: refill deviceSynchronize failed: {}",
+        cudaGetErrorString(refillSyncErr));
+    return false;
+  }
+
+  UNIFLOW_LOG_INFO("XgmiBandwidthBenchmark: pre-faulted, data verified");
+  return true;
+}
+
+/// Sweep message sizes, measure put/get bandwidth, collect results.
+std::vector<BenchmarkResult> runBenchmarkLoop(
+    const BenchmarkConfig& config,
+    std::vector<PeerConnection>& peers,
+    const BootstrapConfig& bootstrap,
+    TransportSession& session,
+    const std::string& benchmarkName,
+    bool isActiveRank) {
+  auto sizes = generateSizes(config.minSize, config.maxSize);
+  std::vector<BenchmarkResult> results;
+
+  // Latch rather than return: the peer is already entering the sweep.
+  bool setupFailed = false;
+
+  cudaStream_t benchStream = nullptr;
+  if (isActiveRank) {
+    auto streamErr =
+        cudaStreamCreateWithFlags(&benchStream, cudaStreamNonBlocking);
+    if (streamErr != cudaSuccess) {
+      UNIFLOW_LOG_ERROR(
+          "XgmiBandwidthBenchmark: streamCreate failed: {}",
+          cudaGetErrorString(streamErr));
+      setupFailed = true;
+    }
+  }
+
+  auto runDirection = [&](const std::string& dir) {
+    // A rank that gives up on its own work latches this and keeps meeting the
+    // peer at every rendezvous below, doing no work and recording no results.
+    // Returning instead would leave the peer waiting at one.
+    //
+    // A failing barrier() is the exception and does return: the rendezvous
+    // channel is gone, and every later one would only time out in turn.
+    bool aborted = setupFailed;
+
+    for (auto size : sizes) {
+      // Called even when aborted: this does an exchangeMetadata, so skipping
+      // it on one rank desynchronizes exactly like skipping a barrier.
+      if (!setupBuffersForSize(session, size, peers, bootstrap)) {
+        UNIFLOW_LOG_ERROR(
+            "XgmiBandwidthBenchmark: setupBuffersForSize failed for size {}",
+            size);
+        aborted = true;
+      }
+
+      if (!aborted && isActiveRank && !prefaultAndVerify(session, size)) {
+        UNIFLOW_LOG_ERROR(
+            "XgmiBandwidthBenchmark: prefault failed for size {}", size);
+        aborted = true;
+      }
+
+      const int totalIterations = config.warmupIterations + config.iterations;
+      std::vector<double> latenciesUs;
+      latenciesUs.reserve(config.iterations);
+
+      auto barrierStatus = barrier(peers, bootstrap);
+      if (!barrierStatus) {
+        UNIFLOW_LOG_ERROR(
+            "XgmiBandwidthBenchmark: barrier failed: {}",
+            barrierStatus.error().toString());
+        return;
+      }
+
+      if (!aborted && isActiveRank) {
+        TransferRequest singleReq{
+            .local = session.localReg->span(size_t{0}, size),
+            .remote = session.remoteReg->span(size_t{0}, size),
+        };
+        std::vector<TransferRequest> batchReqs(config.loopCount, singleReq);
+
+        for (int iter = 0; iter < totalIterations; ++iter) {
+          auto start = std::chrono::steady_clock::now();
+
+          RequestOptions opts;
+          opts.stream = benchStream;
+          Status opStatus;
+          if (dir == "put") {
+            opStatus = session.transport->put(batchReqs, opts).get();
+          } else {
+            opStatus = session.transport->get(batchReqs, opts).get();
+          }
+
+          if (opStatus.hasError()) {
+            UNIFLOW_LOG_ERROR(
+                "XgmiBandwidthBenchmark: {} failed at size {}: {}",
+                dir,
+                size,
+                opStatus.error().message());
+            aborted = true;
+            break;
+          }
+
+          auto end = std::chrono::steady_clock::now();
+
+          if (iter >= config.warmupIterations) {
+            double elapsedUs =
+                std::chrono::duration<double, std::micro>(end - start).count();
+            latenciesUs.push_back(elapsedUs / config.loopCount);
+          }
+        }
+      } // isActiveRank
+
+      // Teardown barrier: nobody frees this size's buffers until both ranks are
+      // done with them.
+      auto teardownBarrier = barrier(peers, bootstrap);
+      if (!teardownBarrier) {
+        UNIFLOW_LOG_ERROR(
+            "XgmiBandwidthBenchmark: teardown barrier failed: {}",
+            teardownBarrier.error().toString());
+        return;
+      }
+
+      if (aborted || !isActiveRank) {
+        continue;
+      }
+
+      auto stats = Stats::compute(std::move(latenciesUs));
+      double bandwidthGBs = (stats.avg > 0)
+          ? (static_cast<double>(size) / (stats.avg * 1e-6)) / 1e9
+          : 0;
+
+      BenchmarkResult result{
+          .benchmarkName = benchmarkName,
+          .transport = "xgmi",
+          .direction = dir,
+          .messageSize = size,
+          .iterations = config.iterations,
+          .bandwidthGBs = bandwidthGBs,
+          .latency = stats,
+      };
+      results.push_back(result);
+
+      UNIFLOW_LOG_INFO(
+          "XgmiBandwidthBenchmark: {} size={} avg={:.1f}us bw={:.2f}GB/s",
+          dir,
+          size,
+          stats.avg,
+          bandwidthGBs);
+    }
+  };
+
+  if (config.direction == "put" || config.direction == "both") {
+    runDirection("put");
+  }
+  if (config.direction == "get" || config.direction == "both") {
+    runDirection("get");
+  }
+
+  if (benchStream) {
+    (void)cudaStreamDestroy(benchStream); // [[nodiscard]] under HIP
+  }
+
+  return results;
+}
+
+} // namespace
+
+std::vector<BenchmarkResult> XgmiBandwidthBenchmark::run(
+    const BenchmarkConfig& config,
+    std::vector<PeerConnection>& peers,
+    const BootstrapConfig& bootstrap) {
+  if (peers.empty()) {
+    UNIFLOW_LOG_WARN("XgmiBandwidthBenchmark: no peers, skipping");
+    return {};
+  }
+
+  if (config.loopCount < 1) {
+    UNIFLOW_LOG_ERROR(
+        "XgmiBandwidthBenchmark: loopCount must be >= 1, got {}",
+        config.loopCount);
+    return {};
+  }
+
+  auto session = setupConnection(peers, bootstrap);
+  if (!session) {
+    return {};
+  }
+
+  const bool isActiveRank = config.bidirectional || bootstrap.isRank0();
+
+  UNIFLOW_LOG_INFO(
+      "XgmiBandwidthBenchmark: rank {} setup complete, sweeping sizes {}-{}"
+      " (loopCount={}, {}directional, active={})",
+      bootstrap.rank,
+      config.minSize,
+      config.maxSize,
+      config.loopCount,
+      config.bidirectional ? "bi" : "uni",
+      isActiveRank);
+
+  auto results = runBenchmarkLoop(
+      config, peers, bootstrap, *session, name(), isActiveRank);
+
+  auto shutdownBarrier = barrier(peers, bootstrap);
+  if (!shutdownBarrier) {
+    UNIFLOW_LOG_WARN(
+        "XgmiBandwidthBenchmark: shutdown barrier failed: {}",
+        shutdownBarrier.error().toString());
+  }
+  // No explicit shutdown(): ~TransportSession does it, and its body runs before
+  // any member is destroyed. Calling both only duplicated the log line.
+  return results;
+}
+
+} // namespace uniflow::benchmark

--- a/comms/uniflow/benchmarks/bench/XgmiBandwidthBenchmark.h
+++ b/comms/uniflow/benchmarks/bench/XgmiBandwidthBenchmark.h
@@ -1,0 +1,36 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "comms/uniflow/benchmarks/BenchmarkRunner.h"
+
+namespace uniflow::benchmark {
+
+/// Measures intra-node put/get bandwidth across message sizes on AMD, where the
+/// intra-node tier is served by HIP IPC over XGMI.
+///
+/// This is the AMD counterpart of NVLinkBandwidthBenchmark: same tier, same
+/// shared IntraNodeTransport, same measurement method -- the difference is the
+/// registration backend (IPC instead of CUDA VMM) and therefore the allocator
+/// (plain device allocation instead of a cuMem VMM mapping, since IPC exports
+/// an ordinary allocation).
+///
+/// AMD-only: on NVIDIA the intra-node tier is the VMM path and
+/// nvlink_bandwidth already covers it, so main.cpp registers this benchmark
+/// only under __HIP_PLATFORM_AMD__.
+class XgmiBandwidthBenchmark : public Benchmark {
+ public:
+  std::string name() const override {
+    return "xgmi_bandwidth";
+  }
+
+  std::vector<BenchmarkResult> run(
+      const BenchmarkConfig& config,
+      std::vector<PeerConnection>& peers,
+      const BootstrapConfig& bootstrap) override;
+};
+
+} // namespace uniflow::benchmark

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -23,6 +23,12 @@
 #include "comms/uniflow/benchmarks/bench/ConnectionSetupBenchmark.h"
 #include "comms/uniflow/benchmarks/bench/NVLinkBandwidthBenchmark.h"
 #include "comms/uniflow/benchmarks/bench/NcclSendRecvBenchmark.h"
+#else
+// AMD intra-node tier (HIP IPC over XGMI). Its target is only in
+// uniflow_bench's deps under ovr_config//gpu:amd, so the include must be
+// guarded to match -- unguarded it breaks the NVIDIA build with a missing
+// header.
+#include "comms/uniflow/benchmarks/bench/XgmiBandwidthBenchmark.h"
 #endif
 
 namespace {
@@ -406,6 +412,9 @@ int main(int argc, char** argv) {
       std::make_unique<uniflow::benchmark::NVLinkBandwidthBenchmark>());
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::NcclSendRecvBenchmark>());
+#else
+  runner.registerBenchmark(
+      std::make_unique<uniflow::benchmark::XgmiBandwidthBenchmark>());
 #endif
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::SendRecvBandwidthBenchmark>(

--- a/comms/uniflow/transport/p2p/P2pTransport.cpp
+++ b/comms/uniflow/transport/p2p/P2pTransport.cpp
@@ -160,16 +160,30 @@ Status P2pTransport::connect(std::span<const uint8_t> remoteInfo) {
   CHECK_RETURN(parsedPeer);
   const int32_t peer = parsedPeer.value();
 
-  // Enable this device to access the peer device (no-op for same device or if
-  // already enabled). Covers same-process cross-device P2P; cross-process
-  // imports also lazily enable peer access via ipcOpenMemHandle. Commit
-  // peerDeviceId_ / Connected only after this succeeds, so a failure leaves the
-  // transport in its prior (Initialized) state.
+  // Enable peer access in BOTH directions (no-op for same device or if already
+  // enabled). Commit peerDeviceId_ / Connected only after both succeed, so a
+  // failure leaves the transport Initialized.
+  //
+  // The reverse direction is the non-obvious one: get() reads the IPC-imported
+  // peer buffer, and ROCm runs that copy on the SOURCE agent, which writes into
+  // THIS device's memory. With only local->peer, put() works and get() faults
+  // once the two ranks are separate processes. PeerToPeerTransferTest enables
+  // both directions for the same reason.
+  //
+  // The helper keeps each edge paired with its own source device current.
+  auto enableOneDirection = [this](int32_t from, int32_t to) {
+    CudaDeviceGuard guard(*cudaApi_, from);
+    return cudaApi_->deviceEnablePeerAccess(to);
+  };
+
   if (peer != deviceId_) {
-    CudaDeviceGuard guard(*cudaApi_, deviceId_);
-    auto st = cudaApi_->deviceEnablePeerAccess(peer);
-    if (st.hasError()) {
-      return st;
+    auto forward = enableOneDirection(deviceId_, peer);
+    if (forward.hasError()) {
+      return forward;
+    }
+    auto reverse = enableOneDirection(peer, deviceId_);
+    if (reverse.hasError()) {
+      return reverse;
     }
   }
 

--- a/comms/uniflow/transport/p2p/tests/P2pTransportTest.cpp
+++ b/comms/uniflow/transport/p2p/tests/P2pTransportTest.cpp
@@ -241,7 +241,9 @@ TEST(P2pTransportTest, ConnectEnablesPeerAccessForDifferentDevice) {
   auto mock = std::make_shared<NiceMock<MockCudaApi>>();
   ON_CALL(*mock, getDevice()).WillByDefault(Return(Result<int>(0)));
   ON_CALL(*mock, setDevice(_)).WillByDefault(Return(Ok()));
+  // BOTH directions: local->peer for put, peer->local for get.
   EXPECT_CALL(*mock, deviceEnablePeerAccess(1)).WillOnce(Return(Ok()));
+  EXPECT_CALL(*mock, deviceEnablePeerAccess(0)).WillOnce(Return(Ok()));
 
   ScopedEventBaseThread ebt;
   P2pTransport transport(/*deviceId=*/0, ebt.getEventBase(), mock);
@@ -315,11 +317,60 @@ TEST(P2pTransportTest, ConnectRequiresBindFirst) {
   EXPECT_NE(transport.state(), TransportState::Connected);
 }
 
+// Regression test for a cross-process get() fault on AMD: with only
+// local->peer enabled, put() works and get() faults once the ranks are
+// separate processes.
+TEST(P2pTransportTest, ConnectEnablesPeerAccessInBothDirections) {
+  auto mock = std::make_shared<NiceMock<MockCudaApi>>();
+
+  int current = -1;
+  ON_CALL(*mock, setDevice(_)).WillByDefault([&current](int d) {
+    current = d;
+    return Ok();
+  });
+  ON_CALL(*mock, getDevice()).WillByDefault([&current]() {
+    return Result<int>(current);
+  });
+
+  EXPECT_CALL(*mock, deviceEnablePeerAccess(1)).WillOnce([&current](int) {
+    EXPECT_EQ(current, 0) << "local->peer must be enabled with LOCAL current";
+    return Ok();
+  });
+  EXPECT_CALL(*mock, deviceEnablePeerAccess(0)).WillOnce([&current](int) {
+    EXPECT_EQ(current, 1) << "peer->local must be enabled with PEER current";
+    return Ok();
+  });
+
+  ScopedEventBaseThread ebt;
+  P2pTransport transport(/*deviceId=*/0, ebt.getEventBase(), mock);
+  transport.bind();
+  EXPECT_FALSE(transport.connect(makeDeviceIdBytes(1)).hasError());
+  EXPECT_EQ(transport.state(), TransportState::Connected);
+}
+
+// A failure enabling the REVERSE direction must not leave the transport
+// half-connected: state stays Initialized so the caller can retry or fall back.
+TEST(P2pTransportTest, ConnectFailsClosedWhenReversePeerAccessFails) {
+  auto mock = std::make_shared<NiceMock<MockCudaApi>>();
+  ON_CALL(*mock, getDevice()).WillByDefault(Return(Result<int>(0)));
+  ON_CALL(*mock, setDevice(_)).WillByDefault(Return(Ok()));
+  EXPECT_CALL(*mock, deviceEnablePeerAccess(1)).WillOnce(Return(Ok()));
+  EXPECT_CALL(*mock, deviceEnablePeerAccess(0))
+      .WillOnce(Return(Err(ErrCode::DriverError, "no reverse peer access")));
+
+  ScopedEventBaseThread ebt;
+  P2pTransport transport(/*deviceId=*/0, ebt.getEventBase(), mock);
+  transport.bind();
+  EXPECT_TRUE(transport.connect(makeDeviceIdBytes(1)).hasError());
+  EXPECT_EQ(transport.state(), TransportState::Initialized);
+}
+
 TEST(P2pTransportTest, BindDoesNotRegressConnectedState) {
   auto mock = std::make_shared<NiceMock<MockCudaApi>>();
   ON_CALL(*mock, getDevice()).WillByDefault(Return(Result<int>(0)));
   ON_CALL(*mock, setDevice(_)).WillByDefault(Return(Ok()));
   EXPECT_CALL(*mock, deviceEnablePeerAccess(1)).WillOnce(Return(Ok()));
+  EXPECT_CALL(*mock, deviceEnablePeerAccess(0)).WillOnce(Return(Ok()));
 
   ScopedEventBaseThread ebt;
   P2pTransport transport(/*deviceId=*/0, ebt.getEventBase(), mock);


### PR DESCRIPTION
Summary:
Adds `xgmi_bandwidth` to `uniflow_bench`: an intra-node put/get bandwidth
benchmark for AMD, where the intra-node tier is HIP IPC over XGMI. It is the
AMD counterpart of the existing NVIDIA-only `nvlink_bandwidth`.

## Why

uniflow had **no** intra-node P2P benchmark on AMD at all. Measured, not
inferred -- `--benchmark __list__` from each build:

```
NVIDIA (mode/opt)              rdma_bandwidth  connection_setup
                                nvlink_bandwidth  nccl_sendrecv  sendrecv_bandwidth
AMD (mode/opt-amd-gpu)         rdma_bandwidth  sendrecv_bandwidth
```

`nvlink_bandwidth` is NVIDIA-only by construction: `no_amd_ci()` on the target
plus a `#ifndef __HIP_PLATFORM_AMD__` around its registration. The two that do
build on AMD are both RDMA-based, so on a host without RDMA devices the number
of intra-node P2P figures obtainable on AMD was exactly zero.

This is not a regression from any recent work -- the AMD path has never had
one.

## Design

Mirrors `NVLinkBandwidthBenchmark` deliberately, so results are comparable and
reviewers can diff the two files. The `TransportFactory` / `Transport`
interfaces are already vendor-neutral, so the whole handshake is reused
verbatim against `P2pTransportFactory`:

    setDevice -> getTopology -> exchangeMetadata -> createTransport
              -> bind -> exchangeMetadata -> connect

Process model is identical to `nvlink_bandwidth` -- two ranks, two processes,
TCP rendezvous via `MASTER_ADDR/PORT` + `RANK`/`WORLD_SIZE`/`LOCAL_RANK`.
Verified by direct comparison rather than assumption:

| | nvlink_bandwidth | xgmi_bandwidth |
|---|---|---|
| `peers.empty()` guard | 1 | 1 |
| `exchangeMetadata` calls | 3 | 3 |
| `barrier(peers, bootstrap)` | 2 | 2 |
| `bootstrap.isRank0()` | 4 | 4 |
| `setDevice` calls | 1 | 1 |

Note `nvlink_bandwidth` **cannot** run single-process: with `WORLD_SIZE=1` there
are no peers and it returns immediately. Two processes is the existing
convention, not a choice made here. Two processes also matters for correctness
of the measurement: a single process would hit `importSegment`'s
`ownerPid == getpid()` shortcut and never exercise `ipcOpenMemHandle`, i.e. it
would not measure the real cross-process import path at all.

The only substantive difference from the NVIDIA version is allocation. NVLink
uses a cuMem VMM mapping (reserve / map / setAccess); HIP IPC exports an
ordinary device allocation, so this uses a plain `cudaMalloc` wrapper. The
`getCuMemHandleType()` probe has no IPC counterpart and is simply absent.

Buffers are re-allocated and re-registered per message size, as in the NVIDIA
version, so the registered extent matches the transfer size.

Wiring follows the existing symmetry: the target is added to the `hipify` srcs
and to the `ovr_config//gpu:amd` branch of `uniflow_bench`'s deps `select()`,
which until now was the empty side; `main.cpp` registers it under `#else` of
the existing `#ifndef __HIP_PLATFORM_AMD__`. The include is guarded too -- the
target is only a dep on AMD, so an unguarded include breaks the NVIDIA build.

Correctness is checked before timing: a full-size put, zero the source, get it
back, and verify the bytes. Without that a transport that silently moved
nothing would report excellent bandwidth.

## Depends on

The `get()` fix below it in this stack. Without it the first transfer faults;
the bug is pre-existing on main and independent of this benchmark.

Reviewed By: rmahidhar

Differential Revision: D116114952


