### PR TITLE
Migrate prims PipesTrace logging

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -15,7 +15,6 @@
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 
 bool ctranPrimsEnabled(const CtranComm* comm) {
   const auto enablePrims = comm->config_.primsConfig.enablePrims;
@@ -72,7 +71,7 @@ commResult_t ctran::ctranBuildMultimemNvlTransportConfig(
       static_cast<size_t>(std::numeric_limits<uint32_t>::max()),
       std::numeric_limits<size_t>::max() / 16);
   if (pipelineDepth == 0 || pipelineDepth > kMaxPipelineDepth) {
-    CLOGF(
+    CTRAN_LOG(
         ERR,
         "MCCL_NVL_MULTIMEM_PIPELINE_DEPTH must be in [1, {}], got {}",
         kMaxPipelineDepth,
@@ -98,7 +97,7 @@ commResult_t ctran::ctranBuildMultimemNvlTransportConfig(
   const auto validation = comms::prims::validate_multimem_nvl_transport_config(
       candidate, nLocalRanks);
   if (!validation) {
-    CLOGF(
+    CTRAN_LOG(
         ERR,
         "CTRAN-PRIMS: invalid NVL multimem config: {} (bufferSize={} perChannelSize={} pipelineDepth={} maxChannels={} maxBlocks={})",
         validation.errorMessage,
@@ -177,7 +176,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     config.nvlConfig.perChannelSize = alignedPerChannelSize(
         nvlSharedDevbufSize, nvlMaxNumChannels, config.nvlConfig.pipelineDepth);
     if (config.nvlConfig.perChannelSize == 0) {
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "CTRAN-PRIMS: invalid NVL config; sharedDevbufSize={} maxNumChannels={} pipelineDepth={} cannot produce aligned perChannelSize",
           nvlSharedDevbufSize,
@@ -215,7 +214,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         config.nvlConfig.ll128BufferSize =
             comms::prims::ll128_buffer_size(256 * 1024);
       }
-      CLOGF(
+      CTRAN_LOG(
           INFO,
           "Prims LL128 buffer size configured (size={} per peer)",
           config.nvlConfig.ll128BufferSize);
@@ -250,7 +249,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     if (requestedMaxChannels <= 0 ||
         requestedMaxChannels >
             static_cast<int64_t>(std::numeric_limits<int>::max())) {
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "max channels must be in [1, {}], got {} (from {})",
           std::numeric_limits<int>::max(),
@@ -275,7 +274,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     if (requestedPipelineDepth <= 0 ||
         requestedPipelineDepth >
             static_cast<int64_t>(std::numeric_limits<int>::max())) {
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "channel pipeline depth must be in [1, {}], got {} (from {})",
           std::numeric_limits<int>::max(),
@@ -296,7 +295,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         : static_cast<size_t>(MCCL_CHANNEL_BUFFER_SIZE);
     if (perDirectionChannelBuffer >
         std::numeric_limits<size_t>::max() / static_cast<size_t>(maxChannels)) {
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "channel buffer size {} (from {}) overflows total size for {} channels (from {})",
           perDirectionChannelBuffer,
@@ -332,7 +331,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     }
     config.ibConfig.ibLazyConnect = pc.ibLazyConnect;
     if (NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC <= 0) {
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC must be positive, got {}",
           NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC);
@@ -353,14 +352,14 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     }
 
     if (config.ibConfig.dataBufferSize == 0) {
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "send/recv requires a positive staging size via MCCL_CHANNEL_BUFFER_SIZE or primsConfig.channelBufferSize");
       return commInvalidArgument;
     }
     const auto pipelineDepth = static_cast<size_t>(channelPipelineDepth);
     if (perDirectionChannelBuffer % pipelineDepth != 0) {
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "IB per-direction channel buffer {} (from {}) must be divisible by pipeline depth {}",
           perDirectionChannelBuffer,
@@ -379,7 +378,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
           if (value >= 16 && value % 16 == 0) {
             return true;
           }
-          CLOGF(
+          CTRAN_LOG(
               ERR,
               "IB {} must be >= 16 and 16-byte aligned, got {} (from {})",
               what,
@@ -403,7 +402,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     config.ibConfig.perChannelSize = perDirectionChannelBuffer;
     config.ibConfig.max_num_channels = config.ibConfig.maxGroups;
     config.ibConfig.pipelineDepth = channelPipelineDepth;
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "Prims IB sendRecv configured: rank={}, commDesc={}, perChannelSize={} (from {}), channelChunkSize={}, maxNumChannels={}, pipelineDepth={} (from {}), dataBufferSize={}",
         comm->statex_->rank(),
@@ -428,7 +427,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         static_cast<comms::prims::MnnvlMode>(NCCL_MNNVL_ENABLE);
     config.topoConfig.logicalNvlRanks = comm->statex_->localRankToRanks();
 
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} enableMultimem={} multimemPerChannelSize={} multimemPipelineDepth={} multimemMaxChannels={} multimemMaxBlocks={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={}",
         comm->statex_->rank(),
@@ -456,7 +455,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         config.ibConfig.qpDepth,
         config.ibConfig.ibLazyConnect);
 
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: full config prepared rank={} logicalNvlRanks={}",
         comm->statex_->rank(),
@@ -471,7 +470,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     // reliable way to distinguish real MNNVL (GB200) from false positives.
     if (config.topoConfig.mnnvlMode != comms::prims::MnnvlMode::kDisabled &&
         !ctran::utils::isCuMemFabricEnabled()) {
-      CLOGF(
+      CTRAN_LOG(
           INFO,
           "CTRAN-PRIMS: FABRIC handle probe failed — disabling MNNVL Tier 1 "
           "topology detection (falling back to same-host peer access)");
@@ -510,7 +509,8 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         comm->multiPeerTransport_->ib_peer_ranks().size(),
         config.topoConfig.p2pDisable);
   } catch (const std::exception& e) {
-    CLOGF(ERR, "Failed to initialize Prims MultiPeerTransport: {}", e.what());
+    CTRAN_LOG(
+        ERR, "Failed to initialize Prims MultiPeerTransport: {}", e.what());
     return commInternalError;
   }
 
@@ -601,7 +601,7 @@ void validatePipesCtranConsistency(CtranComm* comm) {
 commResult_t ctranInitPipesResources(CtranAlgo* algo) {
   auto* comm = algo->comm_;
   if (!comm->multiPeerTransport_) {
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: resource initialization skipped; MultiPeerTransport is not initialized");
     return commSuccess;
@@ -609,7 +609,7 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo) {
 
   auto* statex = comm->statex_.get();
   int localRank = statex->localRank();
-  CLOGF(
+  CTRAN_LOG(
       INFO,
       "CTRAN-PRIMS: resource initialization started rank={} localRank={} nLocalRanks={} nRanks={} cudaDev={}",
       statex->rank(),
@@ -628,7 +628,7 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo) {
       "prims resource initialization");
 
   int nvlNRanks = comm->multiPeerTransport_->nvl_n_ranks();
-  CLOGF(
+  CTRAN_LOG(
       INFO,
       "CTRAN-PRIMS: resource topology rank={} nvlNRanks={} nvlPeers={} ibPeers={}",
       statex->rank(),
@@ -642,12 +642,12 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo) {
   const bool canUseExternalNvlBuffers =
       nvlNRanks > 1 && nvlNRanks == statex->nLocalRanks();
   if (canUseExternalNvlBuffers) {
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: validating ctran/prims consistency rank={}",
         statex->rank());
     validatePipesCtranConsistency(comm);
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: ctran/prims consistency validated rank={}",
         statex->rank());
@@ -655,7 +655,7 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo) {
     // Build per-NVL-rank buffer spans. DeviceSpan is non-assignable (const
     // pointer member), so we construct the vectors in NVL local rank order.
     const auto bufSize = static_cast<uint32_t>(algo->devState_.bufSize);
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: building external NVL staging spans rank={} bufSize={} nvlNRanks={}",
         statex->rank(),
@@ -674,7 +674,7 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo) {
       }
       // Map NVL local rank back to statex local rank index (same value since
       // both systems assign indices in sorted global rank order).
-      CLOGF(
+      CTRAN_LOG(
           INFO,
           "CTRAN-PRIMS: wiring NVL staging span rank={} nvlLocalRank={} localBuf={} remoteBuf={} size={}",
           statex->rank(),
@@ -694,23 +694,23 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo) {
     externalBufs.localBuffers = std::move(localSpans);
     externalBufs.remoteBuffers = std::move(remoteSpans);
 
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: setting external NVL data buffers rank={}",
         statex->rank());
     comm->multiPeerTransport_->setExternalNvlDataBuffers(
         std::move(externalBufs));
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: external NVL data buffers set rank={}",
         statex->rank());
   } else if (nvlNRanks <= 1) {
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: no NVL peers; skipping external staging buffer wiring rank={}",
         statex->rank());
   } else {
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-PRIMS: physical NVLink group size {} differs from Ctran local group size {}; using internal staging buffers rank={}",
         nvlNRanks,
@@ -718,17 +718,17 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo) {
         statex->rank());
   }
 
-  CLOGF(
+  CTRAN_LOG(
       INFO,
       "CTRAN-PRIMS: starting MultiPeerTransport exchange rank={}",
       statex->rank());
   comm->multiPeerTransport_->exchange();
-  CLOGF(
+  CTRAN_LOG(
       INFO,
       "CTRAN-PRIMS: MultiPeerTransport exchange finished rank={}",
       statex->rank());
 
-  CLOGF(
+  CTRAN_LOG(
       INFO,
       "CTRAN-PRIMS: resource initialization finished rank={}",
       statex->rank());

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -7,6 +7,7 @@
 #include <limits>
 #include <memory>
 #include <set>
+#include <string_view>
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/CtranAlgo.h"
@@ -31,6 +32,10 @@ namespace {
 
 bool ctranPipesTraceEnabled() {
   return NCCL_CTRAN_PIPES_TRACE_ENABLE;
+}
+
+void logPipesTraceWarning(std::string_view message) {
+  CTRAN_LOG(WARN, "{}", message);
 }
 
 // Resolves the per-communicator override first, MCCL_MAX_NBLOCKS second. As
@@ -121,13 +126,14 @@ commResult_t ctran::ctranPreparePipesTrace(
     return commSuccess;
   }
   const uint32_t ringSize = comms::prims::PipesTrace::normalizeRingSize(
-      NCCL_CTRAN_PIPES_TRACE_RING_SIZE);
+      NCCL_CTRAN_PIPES_TRACE_RING_SIZE, logPipesTraceWarning);
   if (ringSize == 0) {
     return commSuccess;
   }
 
   if (comm->pipesTrace_ == nullptr) {
-    comm->pipesTrace_ = std::make_unique<comms::prims::PipesTrace>();
+    comm->pipesTrace_ =
+        std::make_unique<comms::prims::PipesTrace>(logPipesTraceWarning);
   }
   comm->pipesTrace_->ensure(
       ringSize,

--- a/comms/ctran/algos/AllGather/AllGatherDirect.cc
+++ b/comms/ctran/algos/AllGather/AllGatherDirect.cc
@@ -210,8 +210,10 @@ static inline unsigned int getThreadBlockSize() {
   // If first time call, query cuda recommended blockSize
   if (bestThreadBlockSize == 0) {
     int minGridSize = 0;
-    XCHECK(kernFnMap.contains(commFloat32))
-        << "kernFnMap does not contain datatype";
+    CTRAN_LOG_IF(
+        FATAL,
+        !kernFnMap.contains(commFloat32),
+        "Check failed: kernFnMap.contains(commFloat32): kernFnMap does not contain datatype");
     FB_CUDACHECK(cudaOccupancyMaxPotentialBlockSize(
         &minGridSize,
         (int*)&bestThreadBlockSize,
@@ -304,8 +306,11 @@ commResult_t ctranAllGatherDirect(
       comm,
       stream));
   FB_COMMCHECK(setupPlan(comm, opGroup, config));
-  XCHECK(kernFnMap.contains(datatype))
-      << "kernFnMap does not contain datatype " << datatype;
+  CTRAN_LOG_IF(
+      FATAL,
+      !kernFnMap.contains(datatype),
+      "Check failed: kernFnMap.contains(datatype): kernFnMap does not contain datatype {}",
+      datatype);
   FB_COMMCHECK(comm->ctran_->gpe->submit(
       std::move(opGroup), impl, config, kernFnMap.at(datatype)));
   if (extraCopyBuff != nullptr) {

--- a/comms/ctran/algos/AllReduce/AllReduceDirect.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceDirect.cc
@@ -621,9 +621,12 @@ commResult_t ctranAllReduceDirect(
   op->allreduce.datatype = datatype;
   op->allreduce.op = redOp;
 
-  XCHECK(typeToFunc.contains(std::make_pair(datatype, redOp)))
-      << "typeToFunc does not contain datatype " << datatype << " with op "
-      << redOp;
+  CTRAN_LOG_IF(
+      FATAL,
+      !typeToFunc.contains(std::make_pair(datatype, redOp)),
+      "Check failed: typeToFunc.contains(std::make_pair(datatype, redOp)): typeToFunc does not contain datatype {} with op {}",
+      datatype,
+      redOp);
   const void* func = typeToFunc.at(std::make_pair(datatype, redOp));
 
   auto config = KernelConfig(

--- a/comms/ctran/algos/CtranAlgo.h
+++ b/comms/ctran/algos/CtranAlgo.h
@@ -24,8 +24,6 @@ namespace comms::prims {
 class P2pNvlTransportDevice;
 } // namespace comms::prims
 #endif // defined(ENABLE_PRIMS)
-#include "comms/utils/logger/Logger.h"
-
 #include <folly/Synchronized.h>
 
 #include "comms/ctran/algos/IPersistPlan.h"

--- a/comms/ctran/backends/socket/CtranSocket.cc
+++ b/comms/ctran/backends/socket/CtranSocket.cc
@@ -132,7 +132,7 @@ void CtranSocket::init(const SocketServerAddr& serverAddr) {
           "CTRAN-SOCKET: No socket interfaces found (NCCL_SOCKET_IFNAME={}, NCCL_SOCKET_IPADDR_PREFIX={})",
           NCCL_SOCKET_IFNAME,
           NCCL_SOCKET_IPADDR_PREFIX);
-      CERR(commSystemError, "{}", msg);
+      CTRAN_ERR(commSystemError, "{}", msg);
       throw ctran::utils::Exception(
           msg, commSystemError, rank_, commHash_, commDesc_);
     } else {
@@ -304,7 +304,7 @@ commResult_t CtranSocket::updateSocket(
     int peerRank) {
   auto locked = socketMaps_.wlock();
   if (locked->rankToSocket.find(peerRank) != locked->rankToSocket.end()) {
-    CERR(
+    CTRAN_ERR(
         commInternalError,
         "CTRAN-SOCKET: socket already exists for peerRank {} in pimpl {} "
         "commHash {:x}, commDesc {}. It likely indicates a NCCL bug.",
@@ -429,7 +429,7 @@ commResult_t CtranSocket::progressInternal() {
     continueWhileLoop = false;
     int count = poll(fds.data(), fds.size(), NCCL_CTRAN_SOCKET_POLL_TIMEOUT);
     if (count < 0) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "CTRAN-SOCKET: polling error, errno {}",
           strerror(errno));
@@ -479,7 +479,7 @@ commResult_t CtranSocket::progressInternal() {
               bytes_read);
         }
       } else if (fds[fid].revents != 0) {
-        CERR(
+        CTRAN_ERR(
             commInternalError,
             "CTRAN-SOCKET: unexpected poll event {} rank {}",
             fds[fid].revents,

--- a/comms/ctran/backends/socket/CtranSocket.h
+++ b/comms/ctran/backends/socket/CtranSocket.h
@@ -10,6 +10,7 @@
 #include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/backends/socket/CtranSocketBase.h"
 #include "comms/ctran/bootstrap/Socket.h"
+#include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/ctran/utils/ExtUtils.h"
 #include "comms/utils/commSpecs.h"
 
@@ -111,7 +112,7 @@ class CtranSocket {
 
   inline commResult_t checkValidPeer(int peerRank) {
     if (peerRank < 0 || (comm && peerRank >= comm->statex_->nRanks())) {
-      CERR(
+      CTRAN_ERR(
           commInternalError,
           "invalid peerRank ({}) < 0 or >= nRanks {}",
           peerRank,

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -66,7 +66,7 @@ commResult_t mapBootstrapSocketError(
     return commRemoteError;
   }
 
-  CERR(
+  CTRAN_ERR(
       commInternalError,
       "CTRAN-TCPDM: bootstrap {} failed with peer {} on rank {} commHash {:x} commDesc {} errno={}",
       op,

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -57,7 +57,7 @@ static bool hostNodeSideStreamEnabled() {
     return false;
   }
   if (NCCL_CTRAN_GRAPH_MIXING_SUPPORT != 0) {
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "CTRAN-GPE: NCCL_CTRAN_GPE_HOST_NODE_SIDE_STREAM ignored because "
         "NCCL_CTRAN_GRAPH_MIXING_SUPPORT={} (requires 0)",

--- a/comms/ctran/ibverbx/Ibverbx.cc
+++ b/comms/ctran/ibverbx/Ibverbx.cc
@@ -12,7 +12,6 @@
 #include <folly/ScopeGuard.h>
 #include <folly/Singleton.h>
 #include <folly/String.h>
-#include <folly/logging/xlog.h>
 #include <folly/synchronization/CallOnce.h>
 #include "comms/utils/cvars/nccl_cvars.h"
 

--- a/comms/ctran/ibverbx/Ibverbx.h
+++ b/comms/ctran/ibverbx/Ibverbx.h
@@ -5,7 +5,6 @@
 #include <folly/Expected.h>
 #include <folly/dynamic.h>
 #include <folly/json.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/ctran/ibverbx/IbvCommon.h"
 #include "comms/ctran/ibverbx/IbvDevice.h" // IWYU pragma: keep

--- a/comms/ctran/utils/LogInit.cc
+++ b/comms/ctran/utils/LogInit.cc
@@ -9,27 +9,11 @@
 #include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
 #include "comms/utils/logger/LogUtils.h"
-#include "comms/utils/logger/Logger.h"
 #include "comms/utils/logger/LoggingFormat.h"
 
 namespace ctran::logging {
 
 namespace {
-
-/*
- * On AMD, after hipification, the file path has format:
- * buck-out/v2/gen/fbcode/{hash}/comms/ctran/dir1/dir2/__{ori_file_name}_hipify_gen__/out/{ori_file_name},
- * The XLOG stripBuckV2Prefix https://fburl.com/code/utkyckpn doesn't handle the
- * hipified file path, so we do our own work to find the correct ctran component
- * prefix here.
- */
-std::string getHipCtranCategory() {
-  std::string fullFilePath = XLOG_FILENAME;
-  static constexpr std::string_view kCtranComponent{"comms/ctran"};
-  auto ctranComponentIdx = fullFilePath.find(kCtranComponent);
-  return fullFilePath.substr(0, ctranComponentIdx + kCtranComponent.size());
-};
-
 spdlog::level::level_enum loggerLevelToSpdlogLevel(
     meta::comms::logger::LogLevel level) {
   switch (level) {
@@ -58,48 +42,6 @@ folly::once_flag ctranLoggingInitOnceFlag;
 
 void initCtranLoggingImpl() {
   meta::comms::logger::initCommLogging();
-  NcclLogger::init(
-      NcclLoggerInitConfig{
-          .contextName = std::string{kCtranCategory},
-          .logPrefix = "CTRAN",
-          .logFilePath =
-              meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
-          .logLevel = meta::comms::logger::loggerLevelToFollyLogLevel(
-              meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
-          .threadContextFn = []() {
-            int cudaDev = -1;
-            (void)cudaGetDevice(&cudaDev);
-            return cudaDev;
-          }});
-  // Init logging for CTRAN header
-  NcclLogger::init(
-      NcclLoggerInitConfig{
-          .contextName = std::string{kCtranHeaderCategory},
-          .logPrefix = "CTRAN",
-          .logFilePath =
-              meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
-          .logLevel = meta::comms::logger::loggerLevelToFollyLogLevel(
-              meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
-          .threadContextFn = []() {
-            int cudaDev = -1;
-            (void)cudaGetDevice(&cudaDev);
-            return cudaDev;
-          }});
-#if defined(USE_ROCM)
-  NcclLogger::init(
-      NcclLoggerInitConfig{
-          .contextName = getHipCtranCategory(),
-          .logPrefix = "CTRAN",
-          .logFilePath =
-              meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
-          .logLevel = meta::comms::logger::loggerLevelToFollyLogLevel(
-              meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
-          .threadContextFn = []() {
-            int cudaDev = -1;
-            (void)cudaGetDevice(&cudaDev);
-            return cudaDev;
-          }});
-#endif
   meta::comms::logger::configureSpdlogLogger(
       kCtranLoggerName,
       "CTRAN",

--- a/comms/ctran/utils/LogInit.h
+++ b/comms/ctran/utils/LogInit.h
@@ -2,24 +2,7 @@
 
 #pragma once
 
-#include <string_view>
-
 namespace ctran::logging {
-
-// AKA Ctran file path. This needs to be changed in refactoring
-constexpr std::string_view kCtranCategory = "comms.ncclx.v2_25.comms.ctran";
-/**
- * buck2 copies header files from their original location in the source tree
- * and places them under buck-out/ with a path like
- * buck-out/v2/gen/cell/hash/dirA/dirB/__rule_name__/buck-headers/dirA/dirB/Foo.h
- * For nccl it is even worse -- for some weird reason, the buck-out path is
- * something like
- * buck-out/v2/gen/fbcode/hash/comms/ncclx/__nccl2.25-internal__/buck-headers/comms/ctran/...
- * So there is no way we can make it consistent with other ctran source files.
- * Currently, XLOG will strip the last part after buck-headers, so the category
- * would be comms.ctran..., which is what we are going to use for header files.
- */
-constexpr std::string_view kCtranHeaderCategory = "comms.ctran";
 
 /**
  * Initialize logging for Ctran. By default it only initializes once globlally

--- a/comms/ctran/utils/tests/LogUT.cc
+++ b/comms/ctran/utils/tests/LogUT.cc
@@ -25,6 +25,14 @@ class CtranUtilsLogTest : public ::testing::Test {
 
   void SetUp() {
     ctran::logging::initCtranLogging(true /*alwaysInit*/);
+    NcclLogger::init(
+        {.contextName = XLOG_GET_CATEGORY_NAME().str(),
+         .logPrefix = "CTRAN",
+         .threadContextFn = []() {
+           int cudaDev = -1;
+           (void)cudaGetDevice(&cudaDev);
+           return cudaDev;
+         }});
 
     // Set up a test category
     auto* category =

--- a/comms/ctran/utils/tests/TestLogCategory.h
+++ b/comms/ctran/utils/tests/TestLogCategory.h
@@ -13,7 +13,6 @@
 #include <folly/logging/LoggerDB.h>
 #include <folly/logging/StandardLogHandler.h>
 #include <folly/logging/StandardLogHandlerFactory.h>
-#include <folly/logging/xlog.h>
 
 // Custom log handler to capture log messages for testing
 class CaptureLogHandler : public folly::LogHandler {
@@ -58,17 +57,12 @@ class TestLogCategory {
   TestLogCategory() = default;
 
   bool setup(folly::LogCategory* category) {
-    // Using the same formatter Ctran logging used
-    const auto ctranCategory = getCtranCategory();
-    if (!ctranCategory) {
-      return false;
-    }
-    if (ctranCategory->getHandlers().size() <= 0) {
+    if (category->getHandlers().empty()) {
       return false;
     }
 
     std::shared_ptr<folly::LogFormatter> formatter = nullptr;
-    auto& handler = *ctranCategory->getHandlers().front();
+    auto& handler = *category->getHandlers().front();
     if (typeid(handler) == typeid(folly::StandardLogHandler)) {
       formatter =
           static_cast<folly::StandardLogHandler&>(handler).getFormatter();
@@ -102,22 +96,6 @@ class TestLogCategory {
   }
 
  private:
-  folly::LogCategory* getCtranCategory() {
-    auto categoryName = XLOG_GET_CATEGORY_NAME();
-    while (true) {
-      auto category = folly::LoggerDB::get().getCategory(categoryName);
-      if (category->getHandlers().size() > 0) {
-        return category;
-      }
-      auto newCategoryName = folly::LogName::getParent(categoryName);
-      if (categoryName == newCategoryName) {
-        return nullptr;
-      }
-      categoryName = newCategoryName;
-    }
-    return nullptr;
-  }
-
   folly::LogCategory* category_{nullptr};
   std::shared_ptr<CaptureLogHandler> captureHandler_{nullptr};
   folly::LogLevel oldLevel_;

--- a/comms/ncclx/meta/NcclxChecks.h
+++ b/comms/ncclx/meta/NcclxChecks.h
@@ -1,0 +1,88 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <stdexcept>
+#include <string>
+
+#include <fmt/format.h>
+#include <folly/Expected.h>
+
+#include "comms/utils/Conversion.h"
+#include "comms/utils/commSpecs.h"
+#include "meta/NcclxLogUtils.h"
+
+namespace ncclx::logging::detail {
+
+inline ::meta::comms::CommsError getCommsErrorFromCudaError(
+    cudaError_t error,
+    const char* file,
+    int line,
+    const char* command) {
+  return ::meta::comms::CommsError(
+      fmt::format(
+          "CUDA error in {}:{} {}: {}",
+          file,
+          line,
+          command,
+          cudaGetErrorString(error)),
+      commUnhandledCudaError);
+}
+
+} // namespace ncclx::logging::detail
+
+#define NCCLX_CUDA_CHECK_EXPECTED(command)                               \
+  do {                                                                   \
+    const auto _ncclx_cuda_error = (command);                            \
+    if (_ncclx_cuda_error != cudaSuccess) {                              \
+      NCCLX_ERR(commUnhandledCudaError, "Call for {} failed", #command); \
+      return folly::makeUnexpected(                                      \
+          ::ncclx::logging::detail::getCommsErrorFromCudaError(          \
+              _ncclx_cuda_error, __FILE__, __LINE__, #command));         \
+    }                                                                    \
+  } while (false)
+
+#define NCCLX_CUDACHECKTHROW(command)             \
+  do {                                            \
+    const auto _ncclx_cuda_error = (command);     \
+    if (_ncclx_cuda_error != cudaSuccess) {       \
+      NCCLX_ERR(                                  \
+          commUnhandledCudaError,                 \
+          "{}:{} Cuda failure {}",                \
+          __FILE__,                               \
+          __LINE__,                               \
+          cudaGetErrorString(_ncclx_cuda_error)); \
+      (void)cudaGetLastError();                   \
+      throw std::runtime_error(                   \
+          std::string("Cuda failure: ") +         \
+          cudaGetErrorString(_ncclx_cuda_error)); \
+    }                                             \
+  } while (false)
+
+#define NCCLX_COMMCHECKTHROW(command)                           \
+  do {                                                          \
+    const commResult_t _ncclx_comm_result = (command);          \
+    if (_ncclx_comm_result != commSuccess &&                    \
+        _ncclx_comm_result != commInProgress) {                 \
+      NCCLX_LOG(                                                \
+          ERR,                                                  \
+          "{}:{} -> {} ({})",                                   \
+          __FILE__,                                             \
+          __LINE__,                                             \
+          _ncclx_comm_result,                                   \
+          ::meta::comms::commCodeToString(_ncclx_comm_result)); \
+      throw std::runtime_error(                                 \
+          std::string("COMM internal failure: ") +              \
+          ::meta::comms::commCodeToString(_ncclx_comm_result)); \
+    }                                                           \
+  } while (false)
+
+#define NCCLX_ERRORTHROW(error, ...)             \
+  do {                                           \
+    NCCLX_LOG(ERR, __VA_ARGS__);                 \
+    throw std::runtime_error(                    \
+        std::string("COMM internal failure: ") + \
+        ::meta::comms::commCodeToString(error)); \
+  } while (false)

--- a/comms/ncclx/meta/NcclxLogUtils.h
+++ b/comms/ncclx/meta/NcclxLogUtils.h
@@ -2,8 +2,17 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include "comms/utils/logger/LogUtils.h"
 #include "meta/NcclxLogger.h"
 
 #define NCCLX_LOG_SUBSYS(level, subsys, ...) \
   NCCLX_LOG_IF(level, CLOGF_ENABLED(subsys), __VA_ARGS__)
+
+#define NCCLX_ERR(code, ...)                                                  \
+  do {                                                                        \
+    const auto _ncclx_error_message = fmt::format(__VA_ARGS__);               \
+    NCCLX_LOG(ERR, "{}", _ncclx_error_message);                               \
+    ::meta::comms::logger::logCommErrorToScuba((code), _ncclx_error_message); \
+  } while (false)

--- a/comms/ncclx/meta/collectives/pCollectives.cc
+++ b/comms/ncclx/meta/collectives/pCollectives.cc
@@ -6,9 +6,8 @@
 #include "nccl.h"
 
 #include "comms/ctran/Ctran.h"
-#include "comms/utils/checks.h"
 
-#include "meta/NcclxLogUtils.h"
+#include "meta/NcclxChecks.h"
 #include "meta/wrapper/MetaFactory.h"
 
 namespace ncclx {
@@ -21,7 +20,7 @@ __attribute__((visibility("default"))) ncclResult_t allGatherInit(
     cudaStream_t stream,
     void** request) {
   if (!ctran::allGatherPSupport(comm->ctranComm_.get())) {
-    FB_ERRORTHROW(
+    NCCLX_ERRORTHROW(
         commInvalidUsage,
         "Persistent AllGather is not supported. Check whether CTRAN is enabled.");
   }

--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
@@ -9,7 +9,6 @@
 #include <folly/Synchronized.h>
 #include <folly/Unit.h>
 #include "comms/utils/RankUtils.h"
-#include "comms/utils/checks.h"
 #include "comms/utils/colltrace/CollMetadataImpl.h"
 #include "comms/utils/colltrace/CollTrace.h"
 #include "meta/logger/DebugExt.h"
@@ -22,7 +21,7 @@
 #include "comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.h"
 #include "comms/utils/colltrace/plugins/WatchdogPlugin.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "meta/NcclxLogger.h"
+#include "meta/NcclxChecks.h"
 #include "meta/hints/GlobalHints.h"
 #include "meta/wrapper/DataTypeConv.h"
 
@@ -443,11 +442,11 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
        cudaDev = comm->cudaDev]() -> CommsMaybeVoid {
         NCCL_NAMED_THREAD_START_EXT(
             "CollTrace", metadata.rank, metadata.commHash, metadata.commDesc);
-        CUDA_CHECK_EXPECTED(cudaSetDevice(cudaDev));
+        NCCLX_CUDA_CHECK_EXPECTED(cudaSetDevice(cudaDev));
         // Ensure we are using the thread local stream capture mode to avoid
         // getting error about stream capture mode.
         auto mode{cudaStreamCaptureMode::cudaStreamCaptureModeThreadLocal};
-        CUDA_CHECK_EXPECTED(cudaThreadExchangeStreamCaptureMode(&mode));
+        NCCLX_CUDA_CHECK_EXPECTED(cudaThreadExchangeStreamCaptureMode(&mode));
         return folly::unit;
       },
       std::move(plugins));

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
@@ -12,6 +12,7 @@
 #include "comms/mccl/integration_tests/McclIntegrationTestUtil.h"
 #include "comms/mccl/tests/CudaStream.h"
 #include "comms/mccl/tests/CudaTestUtil.h"
+#include "comms/ncclx/meta/NcclxLogger.h"
 #include "comms/utils/colltrace/tests/nvidia-only/CPUControlledKernel.h"
 
 namespace {
@@ -378,8 +379,8 @@ TEST_F(CollTraceWatchdogTest, TestTimeoutInColl) {
   if (rank != 0) {
     // Sleep long enough to make other ranks timeout
     std::this_thread::sleep_for(timeoutSec + std::chrono::seconds{3});
-    // Hacky way to make the driver process believe rank 0 is faulty as well
-    XLOG(FATAL, "COMM FATAL");
+    // Hacky way to make the driver process believe rank 0 is faulty as well.
+    NCCLX_LOG(FATAL, "COMM FATAL");
   } else {
     NcclAllReduce allReduce(comm.raw(), stream, 32);
     std::this_thread::sleep_for(timeoutSec + std::chrono::seconds{3});

--- a/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -24,6 +24,7 @@
 #include "comms/utils/colltrace/CollTrace.h"
 #include "comms/utils/colltrace/tests/nvidia-only/CPUControlledKernel.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/Logger.h"
 #include "meta/commDump.h"
 
 using ::meta::comms::colltrace::CollTraceConfig;

--- a/comms/ncclx/meta/logger/tests/LoggingUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggingUT.cc
@@ -55,7 +55,26 @@ class NcclLoggerTest : public ::testing::Test {
     ncclDebugLevel = -1;
     initNcclLogger();
   }
+
+  void initLegacyLogging() {
+    NcclLogger::init(
+        {.contextName = "comms.ncclx",
+         .logPrefix = "NCCL",
+         .logFilePath =
+             meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
+         .logLevel = meta::comms::logger::loggerLevelToFollyLogLevel(
+             meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
+         .threadContextFn = []() {
+           int cudaDev = -1;
+           (void)cudaGetDevice(&cudaDev);
+           return cudaDev;
+         }});
+  }
 };
+
+TEST_F(NcclLoggerTest, LegacyCloseIsSafeWhenNotInitialized) {
+  NcclLogger::close();
+}
 
 // Just for remembering the test format. Current test format example:
 // P1783645719
@@ -68,6 +87,7 @@ TEST_F(NcclLoggerTest, LogDisplay) {
   // auto fileGuard = EnvRAII(NCCL_DEBUG_FILE, std::string{"/tmp/debug.test3"});
 
   initLogging();
+  initLegacyLogging();
   NcclLogger::init(
       // TODO: Change the context name when ctran is refactored out of NCCLX
       // Otherwise the logging will no longer work as intended.
@@ -236,6 +256,7 @@ TEST_F(NcclLoggerTest, GetLastCommsErrorLongMessageTestXLOG) {
   ncclResetDebugInit();
 
   initLogging();
+  initLegacyLogging();
 
   // Create a long error message (but within the 1024 char buffer)
   std::string longError(500, 'X');
@@ -456,6 +477,7 @@ TEST_F(NcclLoggerTest, SpdlogDebugMatchesLegacyDbg2) {
   auto asyncGuard = EnvRAII(NCCL_DEBUG_LOGGING_ASYNC, false);
 
   initLogging();
+  initLegacyLogging();
   auto& logger =
       meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName);
   EXPECT_TRUE(logger.should_log(spdlog::level::debug));
@@ -554,6 +576,7 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
       folly::makeGuard([]() { unsetenv("NCCL_DEBUG_FILE"); });
   ncclResetDebugInit();
   initLogging();
+  initLegacyLogging();
 
   INFO(NCCL_ALL, "Trigger DebugInit");
 
@@ -834,7 +857,7 @@ TEST_F(NcclLoggerTest, SecondErrorUpdatesMessageKeepsAppendedStack) {
 
 #endif // NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
 
-TEST_F(NcclLoggerTest, TestUtilsLogHandler) {
+TEST_F(NcclLoggerTest, PreservesSharedUtilsLogHandler) {
   ncclResetDebugInit();
 
   ncclCvarInit();

--- a/comms/ncclx/meta/logger/tests/LoggingUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggingUT.cc
@@ -14,7 +14,7 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/Logger.h"
 #include "comms/utils/logger/LoggingFormat.h"
-#include "meta/NcclxLogUtils.h"
+#include "meta/NcclxChecks.h"
 
 #include "debug.h" // @manual
 #include "param.h" // @manual
@@ -94,6 +94,46 @@ TEST_F(NcclLoggerTest, LogDisplay) {
   ERR(ncclInternalError, "%s", TestStr.c_str());
 
   finishLogging();
+}
+
+TEST_F(NcclLoggerTest, NcclxChecksPreserveResultsAndSingleEvaluation) {
+  auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"INFO"});
+  ncclResetDebugInitInternal();
+  initLogging();
+  auto loggingGuard = folly::makeGuard([&] { finishLogging(); });
+
+  int commEvaluations = 0;
+  EXPECT_NO_THROW(NCCLX_COMMCHECKTHROW((++commEvaluations, commSuccess)));
+  EXPECT_NO_THROW(NCCLX_COMMCHECKTHROW((++commEvaluations, commInProgress)));
+  EXPECT_THROW(
+      NCCLX_COMMCHECKTHROW((++commEvaluations, commInternalError)),
+      std::runtime_error);
+  EXPECT_EQ(commEvaluations, 3);
+
+  int messageEvaluations = 0;
+  EXPECT_THROW(
+      NCCLX_ERRORTHROW(
+          commInvalidUsage, "NCCLX error {}", ++messageEvaluations),
+      std::runtime_error);
+  EXPECT_EQ(messageEvaluations, 1);
+
+  int cudaEvaluations = 0;
+  EXPECT_NO_THROW(NCCLX_CUDACHECKTHROW((++cudaEvaluations, cudaSuccess)));
+  EXPECT_THROW(
+      NCCLX_CUDACHECKTHROW((++cudaEvaluations, cudaErrorInvalidValue)),
+      std::runtime_error);
+  EXPECT_EQ(cudaEvaluations, 2);
+
+  auto expectedCheck = [](cudaError_t error) -> meta::comms::CommsMaybeVoid {
+    NCCLX_CUDA_CHECK_EXPECTED(error);
+    return folly::unit;
+  };
+  EXPECT_TRUE(expectedCheck(cudaSuccess).hasValue());
+  const auto expectedError = expectedCheck(cudaErrorInvalidValue);
+  ASSERT_TRUE(expectedError.hasError());
+  EXPECT_EQ(expectedError.error().errorCode, commUnhandledCudaError);
+  EXPECT_THAT(
+      expectedError.error().message, testing::HasSubstr("CUDA error in"));
 }
 
 TEST_F(NcclLoggerTest, GetLastCommsErrorTest) {

--- a/comms/ncclx/meta/transport/transportProxy.cc
+++ b/comms/ncclx/meta/transport/transportProxy.cc
@@ -7,10 +7,9 @@
 
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/Utils.h"
-#include "comms/utils/checks.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/trainer/TrainerContext.h"
-#include "meta/NcclxLogUtils.h"
+#include "meta/NcclxChecks.h"
 #include "meta/transport/transportConnect.h"
 #include "meta/transport/transportExt.h"
 #include "meta/transport/transportProxy.h"
@@ -156,7 +155,7 @@ commResult_t TransportProxy::getNextChannelsReadyPtr(
     uint64_t** channelsReadyPtr) {
   std::unique_lock<std::mutex> lock(mutex_);
   if (syncFlagPool_.empty()) {
-    FB_ERRORTHROW(
+    NCCLX_ERRORTHROW(
         commInternalError, "No available sync flag in transport worker thread");
   }
   auto ptr = syncFlagPool_.front();
@@ -274,7 +273,7 @@ void TransportProxy::testAny() {
   for (const auto& req : activeOps_) {
     auto ptr = req->channelsReadyPtr;
     if (*ptr == 0) {
-      FB_COMMCHECKTHROW(req->comm->memCache->release(req->bufKeys));
+      NCCLX_COMMCHECKTHROW(req->comm->memCache->release(req->bufKeys));
       NCCLX_LOG_SUBSYS(
           INFO,
           COLL,
@@ -327,7 +326,7 @@ void TransportProxy::prepResources(std::shared_ptr<TransportRequest> req) {
           req->bufKeys,
           skipReconnect));
   if (req->state != commSuccess) {
-    FB_ERRORTHROW(
+    NCCLX_ERRORTHROW(
         commInternalError,
         "Failed to reconnect to peers in transport worker thread");
   }
@@ -359,7 +358,7 @@ void TransportProxy::workerThreadFn() {
       parentComm_->commHash,
       parentComm_->logMetaData.commDesc);
 
-  FB_CUDACHECKTHROW(cudaSetDevice(parentComm_->cudaDev));
+  NCCLX_CUDACHECKTHROW(cudaSetDevice(parentComm_->cudaDev));
 
   while (true) {
     // test if any collective is complected, and release the resources

--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -7,10 +7,9 @@
 #include "comms/ctran/interfaces/ICtran.h"
 #include "comms/ctran/memory/memCacheAllocator.h"
 #include "comms/ctran/window/WinHintUtils.h"
-#include "comms/utils/checks.h"
 #include "comms/utils/commSpecs.h"
+#include "meta/NcclxChecks.h"
 #include "meta/NcclxConfig.h" // @manual
-#include "meta/NcclxLogUtils.h"
 #include "meta/commstate/FactoryCommStateX.h"
 #include "meta/ctran-integration/BaselineBootstrap.h"
 #include "meta/wrapper/MetaFactory.h"
@@ -23,12 +22,12 @@ meta::comms::Hints ncclToMetaComm(const ncclx::Hints& hints) {
   meta::comms::Hints ret;
   std::string v;
   for (const auto& k : meta::comms::hints::AllToAllPHintUtils::keys()) {
-    FB_COMMCHECKTHROW(ncclToMetaComm(hints.get(k, v)));
-    FB_COMMCHECKTHROW(ret.set(k, v));
+    NCCLX_COMMCHECKTHROW(ncclToMetaComm(hints.get(k, v)));
+    NCCLX_COMMCHECKTHROW(ret.set(k, v));
   }
   for (const auto& k : meta::comms::hints::WinHintUtils::keys()) {
-    FB_COMMCHECKTHROW(ncclToMetaComm(hints.get(k, v)));
-    FB_COMMCHECKTHROW(ret.set(k, v));
+    NCCLX_COMMCHECKTHROW(ncclToMetaComm(hints.get(k, v)));
+    NCCLX_COMMCHECKTHROW(ret.set(k, v));
   }
   return ret;
 }

--- a/comms/ncclx/v2_29/src/bootstrap.cc
+++ b/comms/ncclx/v2_29/src/bootstrap.cc
@@ -29,7 +29,6 @@
 #include "comms/utils/logger/EventsScubaUtil.h"
 #include "meta/tcpstore/TCPStore.h"
 
-#include "comms/utils/logger/Logger.h"
 #include <fstream>
 
 #define BOOTSTRAP_N_CHECK_ABORT           10000

--- a/comms/ncclx/v2_29/src/misc/param.cc
+++ b/comms/ncclx/v2_29/src/misc/param.cc
@@ -23,7 +23,7 @@
 #include <unordered_set>
 #include "os.h"
 
-#include "comms/utils/logger/Logger.h"
+#include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/LoggingFormat.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/InitFolly.h"
@@ -182,33 +182,8 @@ const char* ncclGetEnv(const char* name) {
 }
 
 void initNcclLogger() {
-  NcclLogger::init(NcclLoggerInitConfig{
-    .contextName = "comms.ncclx",
-    .logPrefix = "NCCL",
-    .logFilePath = meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
-    .logLevel = meta::comms::logger::loggerLevelToFollyLogLevel(
-        meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
-    .threadContextFn = []() {
-      int cudaDev = -1;
-      cudaGetDevice(&cudaDev);
-      return cudaDev;
-    }});
-    // Init logging for NCCL header inside meta directory.
-    // This is due to the buck2 behavior of copying the header files to the
-    // buck-out directory.
-    // For logging in src/include headers, they are using NCCL logging
-    // (INFO/WARN/ERROR) which will inherit the loggging category from debug.cc
-    NcclLogger::init(NcclLoggerInitConfig{
-      .contextName = "meta",
-      .logPrefix = "NCCL",
-      .logFilePath = meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
-      .logLevel = meta::comms::logger::loggerLevelToFollyLogLevel(
-          meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
-      .threadContextFn = []() {
-        int cudaDev = -1;
-        cudaGetDevice(&cudaDev);
-        return cudaDev;
-      }});
+  // Shared CollTrace code still emits raw XLOG under comms.utils.
+  meta::comms::logger::initCommLogging();
   meta::comms::logger::configureSpdlogLogger(
       ncclx::logging::kNcclxLoggerName,
       "NCCL",

--- a/comms/ncclx/v2_29/src/transport/nvls.cc
+++ b/comms/ncclx/v2_29/src/transport/nvls.cc
@@ -20,7 +20,6 @@
 #include "register_inline.h"
 #include "meta/nvls/NvlsBindWatchdog.h"
 
-#include "comms/utils/logger/Logger.h"
 #include "comms/ctran/memory/Utils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/memtrace/MemoryTrace.h"

--- a/comms/ncclx/v2_30/src/bootstrap.cc
+++ b/comms/ncclx/v2_30/src/bootstrap.cc
@@ -23,7 +23,6 @@
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/EventsScubaUtil.h"
-#include "comms/utils/logger/Logger.h"
 #include "meta/tcpstore/TCPStore.h"
 
 #define BOOTSTRAP_N_CHECK_ABORT           10000

--- a/comms/ncclx/v2_30/src/misc/param.cc
+++ b/comms/ncclx/v2_30/src/misc/param.cc
@@ -20,7 +20,7 @@
 #include <unordered_set>
 #include "os.h"
 
-#include "comms/utils/logger/Logger.h"
+#include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/LoggingFormat.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/InitFolly.h"
@@ -145,33 +145,8 @@ const char* ncclGetEnv(const char* name) {
 }
 
 void initNcclLogger() {
-  NcclLogger::init(NcclLoggerInitConfig{
-    .contextName = "comms.ncclx",
-    .logPrefix = "NCCL",
-    .logFilePath = meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
-    .logLevel = meta::comms::logger::loggerLevelToFollyLogLevel(
-        meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
-    .threadContextFn = []() {
-      int cudaDev = -1;
-      cudaGetDevice(&cudaDev);
-      return cudaDev;
-    }});
-    // Init logging for NCCL header inside meta directory.
-    // This is due to the buck2 behavior of copying the header files to the
-    // buck-out directory.
-    // For logging in src/include headers, they are using NCCL logging
-    // (INFO/WARN/ERROR) which will inherit the loggging category from debug.cc
-    NcclLogger::init(NcclLoggerInitConfig{
-      .contextName = "meta",
-      .logPrefix = "NCCL",
-      .logFilePath = meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
-      .logLevel = meta::comms::logger::loggerLevelToFollyLogLevel(
-          meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
-      .threadContextFn = []() {
-        int cudaDev = -1;
-        cudaGetDevice(&cudaDev);
-        return cudaDev;
-      }});
+  // Shared CollTrace code still emits raw XLOG under comms.utils.
+  meta::comms::logger::initCommLogging();
   meta::comms::logger::configureSpdlogLogger(
       ncclx::logging::kNcclxLoggerName,
       "NCCL",

--- a/comms/ncclx/v2_30/src/transport/nvls.cc
+++ b/comms/ncclx/v2_30/src/transport/nvls.cc
@@ -17,8 +17,6 @@
 #include "register_inline.h"
 #include "meta/nvls/NvlsBindWatchdog.h"
 
-#include "comms/utils/logger/Logger.h"
-
 #if CUDART_VERSION >= 12010
 
 struct graphRegData {

--- a/comms/prims/tests/PipesTraceTest.cc
+++ b/comms/prims/tests/PipesTraceTest.cc
@@ -7,6 +7,9 @@
 #include <memory>
 #include <mutex>
 #include <set>
+#include <stdexcept>
+#include <string>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -27,6 +30,11 @@ namespace {
 
 constexpr auto kPollInterval = std::chrono::milliseconds{1};
 constexpr auto kWaitTimeout = std::chrono::seconds{10};
+const PipesTrace::WarningCallback kIgnoreWarnings = [](std::string_view) {};
+
+[[noreturn]] void throwWarningCallback(std::string_view) {
+  throw std::runtime_error("callback failure");
+}
 
 template <typename DeviceHandle>
 PipesTraceHandle toPipesTraceHandle(const DeviceHandle& handle) {
@@ -144,21 +152,37 @@ void waitForReceivedEvents(
 } // namespace
 
 TEST(PipesTraceTest, NormalizeRingSizeZero) {
-  EXPECT_EQ(PipesTrace::normalizeRingSize(0), 0u);
+  EXPECT_EQ(PipesTrace::normalizeRingSize(0, kIgnoreWarnings), 0u);
 }
 
 TEST(PipesTraceTest, NormalizeRingSizeClampsLarge) {
+  std::string warning;
   EXPECT_EQ(
-      PipesTrace::normalizeRingSize(1ULL << 32),
+      PipesTrace::normalizeRingSize(
+          1ULL << 32, [&](std::string_view message) { warning = message; }),
       static_cast<uint32_t>(1ULL << 31));
+  EXPECT_EQ(warning, "Prims trace clamps ring size 4294967296 to 2147483648");
+}
+
+TEST(PipesTraceTest, WarningCallbackFailureFallsBackToStderr) {
+  testing::internal::CaptureStderr();
+  EXPECT_EQ(
+      PipesTrace::normalizeRingSize(1ULL << 32, throwWarningCallback),
+      static_cast<uint32_t>(1ULL << 31));
+  const auto output = testing::internal::GetCapturedStderr();
+
+  EXPECT_NE(
+      output.find(
+          "Prims trace warning: Prims trace clamps ring size 4294967296 to 2147483648"),
+      std::string::npos);
 }
 
 TEST(PipesTraceTest, NormalizeRingSizePassthrough) {
-  EXPECT_EQ(PipesTrace::normalizeRingSize(1024), 1024u);
+  EXPECT_EQ(PipesTrace::normalizeRingSize(1024, kIgnoreWarnings), 1024u);
 }
 
 TEST_F(PipesTraceCudaTest, EnsureCreatesBuffer) {
-  PipesTrace trace;
+  PipesTrace trace{kIgnoreWarnings};
   trace.ensure(64, kPollInterval);
   auto handle = trace.deviceHandle();
   EXPECT_NE(handle.ring, nullptr);
@@ -166,20 +190,20 @@ TEST_F(PipesTraceCudaTest, EnsureCreatesBuffer) {
 }
 
 TEST_F(PipesTraceCudaTest, EnsureZeroSizeIsNoOp) {
-  PipesTrace trace;
+  PipesTrace trace{kIgnoreWarnings};
   trace.ensure(0, kPollInterval);
   auto handle = trace.deviceHandle();
   EXPECT_EQ(handle.ring, nullptr);
 }
 
 TEST_F(PipesTraceCudaTest, DeviceHandleNullBeforeEnsure) {
-  PipesTrace trace;
+  PipesTrace trace{kIgnoreWarnings};
   auto handle = trace.deviceHandle();
   EXPECT_EQ(handle.ring, nullptr);
 }
 
 TEST_F(PipesTraceCudaTest, DestructionAfterEnsure) {
-  auto trace = std::make_unique<PipesTrace>();
+  auto trace = std::make_unique<PipesTrace>(kIgnoreWarnings);
   trace->ensure(64, kPollInterval);
   auto handle = trace->deviceHandle();
   EXPECT_NE(handle.ring, nullptr);
@@ -187,7 +211,7 @@ TEST_F(PipesTraceCudaTest, DestructionAfterEnsure) {
 }
 
 TEST_F(PipesTraceCudaTest, EnsureIdempotent) {
-  PipesTrace trace;
+  PipesTrace trace{kIgnoreWarnings};
   trace.ensure(64, kPollInterval);
   auto handle1 = trace.deviceHandle();
 
@@ -196,6 +220,51 @@ TEST_F(PipesTraceCudaTest, EnsureIdempotent) {
 
   EXPECT_EQ(handle1.ring, handle2.ring);
   EXPECT_EQ(handle1.writeIndex, handle2.writeIndex);
+}
+
+TEST_F(PipesTraceCudaTest, ReportsWarningThroughCallback) {
+  std::vector<std::string> warnings;
+  PipesTrace trace{
+      [&](std::string_view message) { warnings.emplace_back(message); }};
+  trace.ensure(64, kPollInterval);
+
+  trace.ensure(128, kPollInterval);
+
+  ASSERT_EQ(warnings.size(), 1u);
+  EXPECT_EQ(
+      warnings.front(),
+      "Prims trace keeps existing ring_size=64 despite requested_ring_size=128 because device handles may be in flight");
+}
+
+TEST_F(PipesTraceCudaTest, WarningCallbackFailureFallsBackOnInstancePath) {
+  PipesTrace trace{throwWarningCallback};
+  trace.ensure(64, kPollInterval);
+
+  testing::internal::CaptureStderr();
+  trace.ensure(128, kPollInterval);
+  const auto output = testing::internal::GetCapturedStderr();
+
+  EXPECT_NE(
+      output.find(
+          "Prims trace warning: Prims trace keeps existing ring_size=64 despite requested_ring_size=128 because device handles may be in flight"),
+      std::string::npos);
+}
+
+TEST_F(PipesTraceCudaTest, DestructionReportsDroppedEntriesThroughCallback) {
+  std::vector<std::string> warnings;
+  {
+    PipesTrace trace{
+        [&](std::string_view message) { warnings.emplace_back(message); }};
+    trace.ensure(2, std::chrono::hours{1});
+    auto handle = trace.deviceHandle();
+    ASSERT_NE(handle.ring, nullptr);
+
+    comms::prims::test::launchWriteEvents(handle, 10, stream_);
+    ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+  }
+
+  ASSERT_EQ(warnings.size(), 1u);
+  EXPECT_NE(warnings.front().find("Prims trace lost "), std::string::npos);
 }
 
 TEST_F(PipesTraceCudaTest, WriteAndReadEvents) {
@@ -270,7 +339,7 @@ TEST_F(PipesTraceCudaTest, PollThreadPicksUpEventsBeforeKernelEnds) {
   std::mutex mu;
   std::vector<PipesTraceEvent> received;
 
-  PipesTrace trace;
+  PipesTrace trace{kIgnoreWarnings};
   trace.ensure(64, kPollInterval, [&](const PipesTraceEvent& event, uint64_t) {
     std::lock_guard<std::mutex> lock(mu);
     received.push_back(event);
@@ -313,7 +382,7 @@ TEST_F(PipesTraceCudaTest, PollThreadConsumesEagerEvents) {
   std::mutex mu;
   std::vector<PipesTraceEvent> received;
 
-  PipesTrace trace;
+  PipesTrace trace{kIgnoreWarnings};
   trace.ensure(64, kPollInterval, [&](const PipesTraceEvent& event, uint64_t) {
     std::lock_guard<std::mutex> lock(mu);
     received.push_back(event);
@@ -468,7 +537,7 @@ TEST_F(PipesTraceCudaTest, PollThreadWithGraphReplay) {
   std::mutex mu;
   std::vector<PipesTraceEvent> received;
 
-  PipesTrace trace;
+  PipesTrace trace{kIgnoreWarnings};
   trace.ensure(256, kPollInterval, [&](const PipesTraceEvent& event, uint64_t) {
     std::lock_guard<std::mutex> lock(mu);
     received.push_back(event);
@@ -562,7 +631,7 @@ TEST_F(PipesTraceCudaTest, PollThreadMultiBlockEvents) {
   std::mutex mu;
   std::vector<PipesTraceEvent> received;
 
-  PipesTrace trace;
+  PipesTrace trace{kIgnoreWarnings};
   trace.ensure(256, kPollInterval, [&](const PipesTraceEvent& event, uint64_t) {
     std::lock_guard<std::mutex> lock(mu);
     received.push_back(event);

--- a/comms/prims/trace/PipesTrace.cc
+++ b/comms/prims/trace/PipesTrace.cc
@@ -12,8 +12,9 @@
 #include <mutex>
 #include <utility>
 
+#include <fmt/format.h>
+
 #include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
-#include "comms/utils/logger/LogUtils.h"
 
 namespace comms::prims {
 namespace {
@@ -166,9 +167,30 @@ uint64_t allocatePipesTraceSessionId() {
   return nextPipesTraceSessionId.fetch_add(1, std::memory_order_relaxed);
 }
 
+void emitWarning(
+    const PipesTrace::WarningCallback& warningCallback,
+    std::string_view message) noexcept {
+  try {
+    if (warningCallback) {
+      warningCallback(message);
+      return;
+    }
+  } catch (...) {
+  }
+
+  flockfile(stderr);
+  std::fputs("Prims trace warning: ", stderr);
+  std::fwrite(message.data(), sizeof(char), message.size(), stderr);
+  std::fputc('\n', stderr);
+  std::fflush(stderr);
+  funlockfile(stderr);
+}
+
 } // namespace
 
-PipesTrace::PipesTrace() : sessionId_(allocatePipesTraceSessionId()) {}
+PipesTrace::PipesTrace(WarningCallback warningCallback)
+    : warningCallback_(std::move(warningCallback)),
+      sessionId_(allocatePipesTraceSessionId()) {}
 
 PipesTrace::~PipesTrace() {
   // CTRAN teardown relies on the same lifetime contract as other comm-owned
@@ -181,24 +203,27 @@ PipesTrace::~PipesTrace() {
   try {
     drain();
   } catch (const std::exception& ex) {
-    CLOGF(WARN, "Prims trace final drain failed: {}", ex.what());
+    warn(fmt::format("Prims trace final drain failed: {}", ex.what()));
   } catch (...) {
-    CLOGF(WARN, "Prims trace final drain failed with unknown exception");
+    warn("Prims trace final drain failed with unknown exception");
   }
 }
 
-uint32_t PipesTrace::normalizeRingSize(uint64_t ringSize) {
+uint32_t PipesTrace::normalizeRingSize(
+    uint64_t ringSize,
+    const WarningCallback& warningCallback) {
   if (ringSize == 0) {
     return 0;
   }
 
   constexpr uint64_t kMaxRingEntries = 1ULL << 31;
   if (ringSize > kMaxRingEntries) {
-    CLOGF(
-        WARN,
-        "Prims trace clamps ring size {} to {}",
-        ringSize,
-        kMaxRingEntries);
+    emitWarning(
+        warningCallback,
+        fmt::format(
+            "Prims trace clamps ring size {} to {}",
+            ringSize,
+            kMaxRingEntries));
     return static_cast<uint32_t>(kMaxRingEntries);
   }
   return static_cast<uint32_t>(ringSize);
@@ -213,15 +238,16 @@ void PipesTrace::ensure(
     return;
   }
 
-  std::lock_guard<std::mutex> lock(drainMutex_);
+  std::unique_lock<std::mutex> lock(drainMutex_);
   rank_ = rank;
   if (buffer_ != nullptr && reader_ != nullptr) {
     if (buffer_->size() < ringSize) {
-      CLOGF(
-          WARN,
+      const auto warning = fmt::format(
           "Prims trace keeps existing ring_size={} despite requested_ring_size={} because device handles may be in flight",
           buffer_->size(),
           ringSize);
+      lock.unlock();
+      warn(warning);
     }
     return;
   }
@@ -229,9 +255,11 @@ void PipesTrace::ensure(
   reader_.reset();
   buffer_ = std::make_unique<Buffer>(ringSize);
   if (!buffer_->valid()) {
-    CLOGF(
-        WARN, "Prims trace failed to allocate ring with {} entries", ringSize);
+    const auto warning = fmt::format(
+        "Prims trace failed to allocate ring with {} entries", ringSize);
     buffer_.reset();
+    lock.unlock();
+    warn(warning);
     return;
   }
 
@@ -342,7 +370,7 @@ void PipesTrace::logBatch(const PendingLogBatch& batch) const {
   }
 
   if (batch.entriesLost != 0) {
-    CLOGF(WARN, "Prims trace lost {} entries", batch.entriesLost);
+    warn(fmt::format("Prims trace lost {} entries", batch.entriesLost));
   }
   if (!batch.entries.empty()) {
     std::fflush(stderr);
@@ -363,9 +391,9 @@ void PipesTrace::pollLoop() {
     try {
       drain();
     } catch (const std::exception& ex) {
-      CLOGF(WARN, "Prims trace poll drain failed: {}", ex.what());
+      warn(fmt::format("Prims trace poll drain failed: {}", ex.what()));
     } catch (...) {
-      CLOGF(WARN, "Prims trace poll drain failed with unknown exception");
+      warn("Prims trace poll drain failed with unknown exception");
     }
   }
 }
@@ -391,6 +419,10 @@ void PipesTrace::stopPollThread() {
   if (pollThread_.joinable()) {
     pollThread_.join();
   }
+}
+
+void PipesTrace::warn(std::string_view message) const noexcept {
+  emitWarning(warningCallback_, message);
 }
 
 } // namespace comms::prims

--- a/comms/prims/trace/PipesTrace.h
+++ b/comms/prims/trace/PipesTrace.h
@@ -11,6 +11,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -27,15 +28,22 @@ class PipesTrace {
   using Entry = typename Buffer::Entry;
   using Reader =
       ::hrdw_ring_buffer::HRDWRingBufferReader<comms::prims::PipesTraceEvent>;
+  // May run on the internal poll thread; captured state must remain valid for
+  // the lifetime of this object and support concurrent invocation. Exceptions
+  // are contained and reported to stderr rather than escaping a worker thread
+  // or destructor.
+  using WarningCallback = std::function<void(std::string_view message)>;
 
-  PipesTrace();
+  explicit PipesTrace(WarningCallback warningCallback);
   ~PipesTrace();
   PipesTrace(const PipesTrace&) = delete;
   PipesTrace& operator=(const PipesTrace&) = delete;
   PipesTrace(PipesTrace&&) = delete;
   PipesTrace& operator=(PipesTrace&&) = delete;
 
-  static uint32_t normalizeRingSize(uint64_t ringSize);
+  static uint32_t normalizeRingSize(
+      uint64_t ringSize,
+      const WarningCallback& warningCallback);
 
   using EventCallback =
       std::function<void(const PipesTraceEvent& event, uint64_t slot)>;
@@ -74,7 +82,9 @@ class PipesTrace {
   void pollLoop();
   void startPollThread();
   void stopPollThread();
+  void warn(std::string_view message) const noexcept;
 
+  WarningCallback warningCallback_;
   std::unique_ptr<Buffer> buffer_;
   std::unique_ptr<Reader> reader_;
   mutable std::mutex drainMutex_;

--- a/comms/utils/logger/Logger.cc
+++ b/comms/utils/logger/Logger.cc
@@ -82,9 +82,11 @@ void NcclLogger::registerHandler(const NcclLoggerInitConfig& config) {
 }
 
 void NcclLogger::close() noexcept {
-  NcclLogHandlerFactory::close();
+  if (firstInit_.test()) {
+    NcclLogHandlerFactory::close();
+    firstInit_.clear();
+  }
   DataTableWrapper::shutdown();
-  firstInit_.clear();
 }
 
 std::shared_ptr<folly::LogWriter>


### PR DESCRIPTION
Summary:
Remove the Folly-backed CLOGF calls from the production PipesTrace implementation without making prims own a global logger. PipesTrace now accepts an explicit warning callback, and CTRAN wires it to CTRAN_LOG so warnings use the configured CTRAN NCCL_DEBUG_FILE and stderr routing.

Warning delivery is non-throwing, releases drainMutex_ before invoking external code, and falls back to serialized stderr output if the callback is empty or throws. The change replaces the log_utils dependency with a direct fmt dependency. The device path, ring polling loop, per-entry processing, mutex-protected copy, and normal event callback path are unchanged, so this adds no steady-state hot-path work.

Differential Revision: D116565821
