### PR TITLE
Add LogTypes.cc to the rccl OSS CMake src list (#3722)

### DIFF
--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -1107,6 +1107,8 @@ set(COMMON_FILES
   comms/utils/logger/Logger.h
   comms/utils/logger/LoggingFormat.cc
   comms/utils/logger/LoggingFormat.h
+  comms/utils/logger/LogTypes.cc
+  comms/utils/logger/LogTypes.h
   comms/utils/logger/LogUtils.cc
   comms/utils/logger/LogUtils.h
   comms/utils/logger/NcclScubaSample.cc


### PR DESCRIPTION
Summary:

D115616289 split the Folly-free log types out into
comms/utils/logger/LogTypes.cc, but did not add the new file to the src
list in rcclx/develop/projects/rccl/CMakeLists.txt. LogUtils.cc (which
IS in the list) calls into it, so librccl.so builds with two dangling
symbols:

  U meta::comms::logger::setSubSystemMask(unsigned long)
  U meta::comms::logger::isEnabledSubSystemBitwise(unsigned long)

The link does not fail because rccl links with -Wl,--allow-shlib-undefined,
so the breakage only surfaces at dlopen time. Any consumer that loads the
OSS librccl.so dies with:

  ImportError: librccl.so: undefined symbol:
  _ZN4meta5comms6logger16setSubSystemMaskEm

___

Differential Revision: D116663998


