### PR TITLE
Scope the side-stream pool so it never holds a HW queue during collectives

### DIFF
--- a/comms/rcclx/develop/projects/rccl/src/include/alloc.h
+++ b/comms/rcclx/develop/projects/rccl/src/include/alloc.h
@@ -53,77 +53,155 @@ constexpr size_t ncclSizeOfT() { return sizeof(T); }
 template<>
 constexpr size_t ncclSizeOfT<void>() { return 1; }
 
+// Side streams are cached per (busId, priority) and reference counted by the
+// number of active "allocation scopes" (comm init and P2P connect bursts,
+// including lazy connect). The stream is created on the first acquire of a
+// given (busId, priority) and destroyed - releasing its scarce GPU hardware
+// queue - when the last scope for that key exits. This keeps allocations within
+// a burst churn-free while ensuring no side stream persists (and holds a HW
+// queue) through the steady-state collective phase.
+struct ncclSideStreamKey {
+  int64_t busId;
+  int priority;
+  bool operator==(const ncclSideStreamKey& o) const {
+    return busId == o.busId && priority == o.priority;
+  }
+};
+struct ncclSideStreamKeyHash {
+  size_t operator()(const ncclSideStreamKey& k) const {
+    return std::hash<int64_t>()(k.busId) ^ (std::hash<int>()(k.priority) << 1);
+  }
+};
+
 struct ncclSideStream {
   cudaStream_t stream;
   uint64_t refCount;
 };
 
-inline std::unordered_map<int64_t, ncclSideStream> sideStream;
+inline std::unordered_map<ncclSideStreamKey, ncclSideStream, ncclSideStreamKeyHash> sideStream;
 inline pthread_mutex_t sideStreamLock = PTHREAD_MUTEX_INITIALIZER;
 extern ncclResult_t getBusId(int cudaDev, int64_t *busId);
 
-static inline ncclResult_t ncclCreateSideStream(int cudaDev) {
+// Clamp a requested stream priority into the device-supported range.
+// greatest is the most-prioritized (numerically smallest) value.
+static inline int ncclClampStreamPriority(int priority) {
+  int least = 0, greatest = 0;
+  cudaError_t err = cudaDeviceGetStreamPriorityRange(&least, &greatest);
+  if (err != cudaSuccess) {
+    // Fall back to priority 0 rather than leaving an out-of-range value. This
+    // path does not go through CUDACHECK/rcclCudaErrorHandler, so log here.
+    WARN("cudaDeviceGetStreamPriorityRange failed: '%s'; defaulting side-stream "
+         "priority clamp to 0",
+         cudaGetErrorString(err));
+    return 0;
+  }
+  if (priority < greatest) priority = greatest;
+  if (priority > least) priority = least;
+  return priority;
+}
+
+// Acquire a scoped, refcounted, priority-keyed side stream for this device.
+static inline ncclResult_t ncclSideStreamAcquire(int cudaDev, int priority = 0) {
   ncclResult_t res = ncclSuccess;
   int64_t busId;
   NCCLCHECK(getBusId(cudaDev, &busId));
+  priority = ncclClampStreamPriority(priority);
+  ncclSideStreamKey key{busId, priority};
   pthread_mutex_lock(&sideStreamLock);
-  if (auto it = sideStream.find(busId); it != sideStream.end()) {
+  if (auto it = sideStream.find(key); it != sideStream.end()) {
     it->second.refCount++;
-    INFO(NCCL_ALLOC, "Side stream %p of dev %d busid %lx inc count to %ld",
-      it->second.stream, cudaDev, busId, it->second.refCount);
+    INFO(NCCL_ALLOC, "Side stream %p dev %d busid %lx prio %d inc count to %ld", it->second.stream, cudaDev, busId,
+         priority, it->second.refCount);
   } else {
     cudaStream_t stream;
-    CUDACHECKGOTO(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), res, fail);
-    sideStream.emplace(busId, ncclSideStream{stream, 1});
-    INFO(NCCL_ALLOC, "Created side stream %p of dev %d busid %lx",
-      stream, cudaDev, busId);
+    // cudaStreamCreateWithPriority can fail for OOM, invalid value, init/driver
+    // errors, etc. — not only cudaErrorStreamCaptureInvalidated. CUDACHECKGOTO
+    // logs the HIP string via rcclCudaErrorHandler; add operation context here.
+    CUDACHECKGOTO(cudaStreamCreateWithPriority(&stream, cudaStreamNonBlocking, priority), res, fail);
+    sideStream.emplace(key, ncclSideStream{stream, 1});
+    INFO(NCCL_ALLOC, "Created side stream %p dev %d busid %lx prio %d", stream, cudaDev, busId, priority);
   }
 fail:
+  if (res != ncclSuccess)
+    WARN("ncclSideStreamAcquire: cudaStreamCreateWithPriority failed for "
+         "dev %d busid %lx prio %d (see HIP failure above)",
+         cudaDev, busId, priority);
   pthread_mutex_unlock(&sideStreamLock);
   return res;
-};
+}
 
-static inline ncclResult_t ncclDestroySideStream(int cudaDev) {
+// Release a previously-acquired side stream. Destroys it (freeing the HW queue)
+// when the last scope for this (busId, priority) exits.
+static inline ncclResult_t ncclSideStreamRelease(int cudaDev, int priority = 0) {
   ncclResult_t res = ncclSuccess;
   int64_t busId;
   NCCLCHECK(getBusId(cudaDev, &busId));
+  priority = ncclClampStreamPriority(priority);
+  ncclSideStreamKey key{busId, priority};
   pthread_mutex_lock(&sideStreamLock);
-  if (auto it = sideStream.find(busId); it != sideStream.end()) {
-    it->second.refCount--;
-    if (it->second.refCount== 0) {
-      INFO(NCCL_ALLOC, "Destroyed side stream %p of dev %d busid %lx",
-        it->second.stream, cudaDev, busId);
-      CUDACHECKGOTO(cudaStreamDestroy(it->second.stream), res, fail);
+  if (auto it = sideStream.find(key); it != sideStream.end()) {
+    if (--it->second.refCount == 0) {
+      // Drop the map entry before destroy so a CUDACHECKGOTO failure cannot
+      // leave a refCount==0 zombie that getSideStream would still return.
+      // If destroy itself fails, the HW queue may leak until process exit, but
+      // that is preferable to handing out a dead/half-released stream later.
+      cudaStream_t stream = it->second.stream;
+      INFO(NCCL_ALLOC, "Destroyed side stream %p dev %d busid %lx prio %d", stream, cudaDev, busId, priority);
       sideStream.erase(it);
+      CUDACHECKGOTO(cudaStreamDestroy(stream), res, fail);
     } else {
-      INFO(NCCL_ALLOC, "Side stream %p of dev %d busid %lx dec count to %ld",
-        it->second.stream, cudaDev, busId, it->second.refCount);
+      INFO(NCCL_ALLOC, "Side stream %p dev %d busid %lx prio %d dec count to %ld", it->second.stream, cudaDev, busId,
+           priority, it->second.refCount);
     }
   } else {
-    WARN("Side stream of dev %d busid %lx was not found for destroy", cudaDev, busId);
+    WARN("Side stream of dev %d busid %lx prio %d was not found for release", cudaDev, busId, priority);
   }
 fail:
+  if (res != ncclSuccess)
+    WARN("ncclSideStreamRelease: cudaStreamDestroy failed for "
+         "dev %d busid %lx prio %d (see HIP failure above)",
+         cudaDev, busId, priority);
   pthread_mutex_unlock(&sideStreamLock);
   return res;
-};
+}
 
-static inline ncclResult_t getSideStream(cudaStream_t *stream) {
+// Return the cached side stream for the current device+priority, or nullptr if
+// no scope is currently active (caller then uses a local fallback stream).
+static inline ncclResult_t getSideStream(cudaStream_t* stream, int priority = 0) {
   int cudaDev;
   int64_t busId;
   CUDACHECK(cudaGetDevice(&cudaDev));
   NCCLCHECK(getBusId(cudaDev, &busId));
+  priority = ncclClampStreamPriority(priority);
   pthread_mutex_lock(&sideStreamLock);
-  if (auto it = sideStream.find(busId); it != sideStream.end()) {
+  if (auto it = sideStream.find(ncclSideStreamKey{busId, priority}); it != sideStream.end()) {
     *stream = it->second.stream;
-    INFO(NCCL_ALLOC, "Found side stream %p of dev %d busid %lx count %ld",
-      it->second.stream, cudaDev, busId, it->second.refCount);
   } else {
-    *stream = 0;
-    WARN("Side stream of dev %d busid %lx was not found", cudaDev, busId);
+    *stream = nullptr;
   }
   pthread_mutex_unlock(&sideStreamLock);
   return ncclSuccess;
 }
+
+// RAII helper: hold a side-stream scope for the duration of an allocation-heavy
+// phase (e.g. transport pre-connect). All ncclCudaCalloc/ncclCudaMemcpy in the
+// phase - including those issued on the proxy thread for the same device while
+// the calling thread blocks - reuse the one pooled stream, then the HW queue is
+// freed on scope exit. The pool is keyed by (busId, priority), so cross-thread
+// reuse for the same device and priority works without merging priorities.
+struct ncclSideStreamScope {
+  int dev;
+  int prio;
+  bool active;
+  explicit ncclSideStreamScope(int cudaDev, int priority = 0) : dev(cudaDev), prio(priority), active(false) {
+    if (ncclSideStreamAcquire(dev, prio) == ncclSuccess) active = true;
+  }
+  ~ncclSideStreamScope() {
+    if (active) ncclSideStreamRelease(dev, prio);
+  }
+  ncclSideStreamScope(const ncclSideStreamScope&) = delete;
+  ncclSideStreamScope& operator=(const ncclSideStreamScope&) = delete;
+};
 
 #if CUDART_VERSION >= 12020
 

--- a/comms/rcclx/develop/projects/rccl/src/include/comm.h
+++ b/comms/rcclx/develop/projects/rccl/src/include/comm.h
@@ -528,6 +528,8 @@ struct ncclComm {
   int compCap; // compute capability of the GPU
   int minCompCap, maxCompCap; // min/max compute capability in the communicator
   int64_t busId;   // my PCI bus ID in int format
+  bool sideStreamAcquired; // whether this comm holds a side-stream scope ref
+  int sideStreamPriority;  // priority key of the side stream this comm acquired
   cpu_set_t cpuAffinity; // CPU affinity of the GPU
   int WarpSize;
   int cudaArch; // matches __CUDA_ARCH__ of device

--- a/comms/rcclx/develop/projects/rccl/src/init.cc
+++ b/comms/rcclx/develop/projects/rccl/src/init.cc
@@ -656,7 +656,12 @@ skip_profiling:
 
   NCCLCHECK(ncclRegCleanup(comm));
 
-  NCCLCHECK(ncclDestroySideStream(comm->cudaDev));
+  // Safety net: release the side stream if init failed/aborted before it was
+  // released on the normal init-completion path. No-op after normal success.
+  if (comm->sideStreamAcquired) {
+    NCCLCHECK(ncclSideStreamRelease(comm->cudaDev, comm->sideStreamPriority));
+    comm->sideStreamAcquired = false;
+  }
 
   INFO(NCCL_INIT,"comm %p rank %d nranks %d cudaDev %d busId %lx - %s COMPLETE", comm, comm->rank, comm->nRanks, comm->cudaDev, comm->busId, abort ? "Abort" : "Destroy");
 
@@ -764,8 +769,12 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   comm->lastStream = nullptr;
   CUDACHECK(cudaGetDevice(&comm->cudaDev));
 
-  // RCCL: create persistent stream for calloc
-  NCCLCHECK(ncclCreateSideStream(comm->cudaDev));
+  // RCCL: acquire a scoped side stream for init-time allocations. It is
+  // released once init completes (see ncclCommInitRankFunc) so it does not hold
+  // a scarce GPU hardware queue through the steady-state collective phase.
+  comm->sideStreamPriority = 0;
+  NCCLCHECK(ncclSideStreamAcquire(comm->cudaDev, comm->sideStreamPriority));
+  comm->sideStreamAcquired = true;
 
   // Disable until we validate NCCL_LAUNCH_IMPLICIT_ORDER support.
   // but can be enabled via environment variable
@@ -2473,6 +2482,14 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   NCCLCHECKGOTO(latency_profiler::collTraceInit(comm), res, fail);
   // update communicator state
   comm->initState = ncclSuccess;
+
+  // RCCL: init-time allocations are done; release the side stream now so its GPU
+  // hardware queue is freed before the steady-state collective phase begins.
+  if (comm->sideStreamAcquired) {
+    NCCLCHECKGOTO(ncclSideStreamRelease(comm->cudaDev, comm->sideStreamPriority), res, fail);
+    comm->sideStreamAcquired = false;
+  }
+
   timers[TIMER_INIT_TOTAL] = clockNano() - timers[TIMER_INIT_TOTAL];
 
   // Timestamp logging: init completion

--- a/comms/rcclx/develop/projects/rccl/src/transport.cc
+++ b/comms/rcclx/develop/projects/rccl/src/transport.cc
@@ -6,6 +6,7 @@
  ************************************************************************/
 
 #include "comm.h"
+#include "alloc.h"
 #include "info.h"
 #include "bootstrap.h"
 #define ENABLE_TIMER 0
@@ -135,6 +136,12 @@ ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* 
 
   int count = 0;
   int num = MAXCHANNELS/64;
+
+  // Pool a single side stream for all buffer allocations during this pre-connect
+  // phase (including proxy-thread ncclCudaCalloc for this device), avoiding
+  // transient per-connection stream create/destroy. Released when this returns
+  // so it does not persist into the steady-state collective phase.
+  ncclSideStreamScope sideScope(comm->cudaDev, comm->sideStreamPriority);
 
   NCCLCHECK(ncclCalloc(&data, maxPeers));
   NCCLCHECKGOTO(ncclCalloc(&recvData, maxPeers), ret, fail);

--- a/comms/rcclx/develop/projects/rccl/test/AllocTests.cpp
+++ b/comms/rcclx/develop/projects/rccl/test/AllocTests.cpp
@@ -7,6 +7,7 @@
 #include <alloc.h>
 #include <gtest/gtest.h>
 #include <rccl/rccl.h>
+#include <unordered_map>
 
 #include "TestBed.hpp"
 #include "common/ErrCode.hpp"
@@ -184,6 +185,198 @@ TEST(Alloc, MemcpyNullSrcOrDstPointer)
                 << "Expected ncclUnhandledCudaError when dst is nullptr";
 
             hipFree(d_valid);
+        }
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scoped side-stream pool (alloc.h: ncclSideStreamAcquire / ncclSideStreamRelease
+// / getSideStream / ncclClampStreamPriority / ncclSideStreamScope).
+//
+// The feature under test: side streams are created on first acquire and
+// destroyed on last release so that no side stream (and thus no scarce GPU
+// hardware queue) persists through the steady-state collective phase. These
+// whitebox tests drive the internal pool API directly and inspect its state
+// via getSideStream(), which returns the pooled stream only while a scope is
+// active and nullptr otherwise.
+// ---------------------------------------------------------------------------
+
+// Core guarantee: with no active scope the pool holds nothing, so a side stream
+// never lingers to occupy a HW queue during collectives. Acquiring makes the
+// pooled stream visible; releasing the last ref destroys it and getSideStream
+// reports nullptr again.
+TEST(Alloc, SideStreamScopeGatesPool)
+{
+    RUN_ISOLATED_TEST(
+        "SideStreamScopeGatesPool",
+        []()
+        {
+            ASSERT_EQ(hipSetDevice(0), hipSuccess);
+            constexpr int dev = 0;
+
+            // No scope active yet: pool must be empty.
+            hipStream_t stream = reinterpret_cast<hipStream_t>(0xdeadbeef);
+            ASSERT_EQ(getSideStream(&stream), ncclSuccess);
+            EXPECT_EQ(stream, nullptr) << "Side stream must not exist before any acquire";
+
+            // Acquire: stream is created and pooled.
+            ASSERT_EQ(ncclSideStreamAcquire(dev), ncclSuccess);
+            stream = nullptr;
+            ASSERT_EQ(getSideStream(&stream), ncclSuccess);
+            EXPECT_NE(stream, nullptr) << "Side stream must be available inside an active scope";
+
+            // Release the last ref: stream is destroyed, HW queue freed.
+            ASSERT_EQ(ncclSideStreamRelease(dev), ncclSuccess);
+            stream = reinterpret_cast<hipStream_t>(0xdeadbeef);
+            ASSERT_EQ(getSideStream(&stream), ncclSuccess);
+            EXPECT_EQ(stream, nullptr) << "Side stream must be destroyed after last release";
+        }
+    );
+}
+
+// Nested acquires for the same (dev, priority) share one pooled stream and it is
+// destroyed only when the final ref is released (reference counting).
+TEST(Alloc, SideStreamRefCountPooling)
+{
+    RUN_ISOLATED_TEST(
+        "SideStreamRefCountPooling",
+        []()
+        {
+            ASSERT_EQ(hipSetDevice(0), hipSuccess);
+            constexpr int dev = 0;
+
+            ASSERT_EQ(ncclSideStreamAcquire(dev), ncclSuccess);
+            hipStream_t first = nullptr;
+            ASSERT_EQ(getSideStream(&first), ncclSuccess);
+            ASSERT_NE(first, nullptr);
+
+            // Second acquire reuses the same stream (no churn), bumping the refcount.
+            ASSERT_EQ(ncclSideStreamAcquire(dev), ncclSuccess);
+            hipStream_t second = nullptr;
+            ASSERT_EQ(getSideStream(&second), ncclSuccess);
+            EXPECT_EQ(second, first) << "Overlapping scopes must reuse the pooled stream";
+
+            // First release: refcount drops to 1, stream still alive.
+            ASSERT_EQ(ncclSideStreamRelease(dev), ncclSuccess);
+            hipStream_t stillHere = nullptr;
+            ASSERT_EQ(getSideStream(&stillHere), ncclSuccess);
+            EXPECT_EQ(stillHere, first) << "Stream must survive while a ref remains";
+
+            // Final release: refcount hits 0, stream destroyed.
+            ASSERT_EQ(ncclSideStreamRelease(dev), ncclSuccess);
+            hipStream_t gone = reinterpret_cast<hipStream_t>(0xdeadbeef);
+            ASSERT_EQ(getSideStream(&gone), ncclSuccess);
+            EXPECT_EQ(gone, nullptr) << "Stream must be destroyed once all refs are released";
+        }
+    );
+}
+
+// The RAII ncclSideStreamScope holds a ref for its lifetime and releases it on
+// destruction, so allocations inside the scope share the pooled stream and the
+// HW queue is freed as soon as the scope exits.
+TEST(Alloc, SideStreamScopeRAII)
+{
+    RUN_ISOLATED_TEST(
+        "SideStreamScopeRAII",
+        []()
+        {
+            ASSERT_EQ(hipSetDevice(0), hipSuccess);
+            constexpr int dev = 0;
+
+            {
+                ncclSideStreamScope scope(dev);
+                hipStream_t         inScope = nullptr;
+                ASSERT_EQ(getSideStream(&inScope), ncclSuccess);
+                EXPECT_NE(inScope, nullptr) << "Scope must acquire the pooled stream on entry";
+            }
+
+            // Scope destroyed: pooled stream released and destroyed.
+            hipStream_t afterScope = reinterpret_cast<hipStream_t>(0xdeadbeef);
+            ASSERT_EQ(getSideStream(&afterScope), ncclSuccess);
+            EXPECT_EQ(afterScope, nullptr) << "Scope must release the pooled stream on exit";
+        }
+    );
+}
+
+// ncclClampStreamPriority folds an out-of-range priority into the device's
+// supported [greatest, least] window and leaves in-range values untouched.
+TEST(Alloc, ClampStreamPriority)
+{
+    RUN_ISOLATED_TEST(
+        "ClampStreamPriority",
+        []()
+        {
+            ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+            int least = 0, greatest = 0;
+            ASSERT_EQ(hipDeviceGetStreamPriorityRange(&least, &greatest), hipSuccess);
+            // Convention: 'greatest' is the most-prioritized (numerically smallest).
+            ASSERT_LE(greatest, least);
+
+            // Below range clamps up to greatest; above range clamps down to least.
+            EXPECT_EQ(ncclClampStreamPriority(greatest - 100), greatest);
+            EXPECT_EQ(ncclClampStreamPriority(least + 100), least);
+
+            // Endpoints and any in-range value are returned unchanged.
+            EXPECT_EQ(ncclClampStreamPriority(greatest), greatest);
+            EXPECT_EQ(ncclClampStreamPriority(least), least);
+            EXPECT_EQ(ncclClampStreamPriority((greatest + least) / 2), (greatest + least) / 2);
+        }
+    );
+}
+
+// Keys with the same busId but different priorities must remain distinct.
+TEST(Alloc, SideStreamKeySeparatesPriorities)
+{
+    constexpr int64_t                                                        busId = 0x1234;
+    std::unordered_map<ncclSideStreamKey, int, ncclSideStreamKeyHash> streams;
+    streams.emplace(ncclSideStreamKey{busId, -1}, 1);
+    streams.emplace(ncclSideStreamKey{busId, 0}, 2);
+    ASSERT_EQ(streams.size(), 2);
+    EXPECT_EQ(streams.at(ncclSideStreamKey{busId, -1}), 1);
+    EXPECT_EQ(streams.at(ncclSideStreamKey{busId, 0}), 2);
+}
+
+// When the device supports multiple priorities, the pool creates and returns
+// separate streams for the same device at each priority.
+TEST(Alloc, SideStreamPoolSeparatesPriorities)
+{
+    RUN_ISOLATED_TEST(
+        "SideStreamPoolSeparatesPriorities",
+        []()
+        {
+            ASSERT_EQ(hipSetDevice(0), hipSuccess);
+            constexpr int dev = 0;
+
+            int least = 0, greatest = 0;
+            ASSERT_EQ(hipDeviceGetStreamPriorityRange(&least, &greatest), hipSuccess);
+            ASSERT_LE(greatest, least);
+            if(greatest == least)
+            {
+                GTEST_SKIP() << "Device exposes only one stream priority";
+            }
+
+            ASSERT_EQ(ncclSideStreamAcquire(dev, greatest), ncclSuccess);
+            ASSERT_EQ(ncclSideStreamAcquire(dev, least), ncclSuccess);
+
+            hipStream_t greatestStream = nullptr;
+            hipStream_t leastStream    = nullptr;
+            ASSERT_EQ(getSideStream(&greatestStream, greatest), ncclSuccess);
+            ASSERT_EQ(getSideStream(&leastStream, least), ncclSuccess);
+            ASSERT_NE(greatestStream, nullptr);
+            ASSERT_NE(leastStream, nullptr);
+            EXPECT_NE(greatestStream, leastStream)
+                << "Same busId at different priorities must not share a stream";
+
+            ASSERT_EQ(ncclSideStreamRelease(dev, greatest), ncclSuccess);
+            ASSERT_EQ(ncclSideStreamRelease(dev, least), ncclSuccess);
+
+            greatestStream = reinterpret_cast<hipStream_t>(0xdeadbeef);
+            leastStream    = reinterpret_cast<hipStream_t>(0xdeadbeef);
+            ASSERT_EQ(getSideStream(&greatestStream, greatest), ncclSuccess);
+            ASSERT_EQ(getSideStream(&leastStream, least), ncclSuccess);
+            EXPECT_EQ(greatestStream, nullptr);
+            EXPECT_EQ(leastStream, nullptr);
         }
     );
 }


### PR DESCRIPTION
Summary:
Port of RCCL PR #10092 (7 upstream commits, squashed) into
`fbcode/comms/rcclx/develop/projects/rccl`.

The existing side-stream pool created one stream per busId in `commAlloc` and
kept it for the whole comm lifetime, so it permanently occupied one of the 4
scarce per-priority GPU hardware queues even during steady-state collectives.

The pool is now scoped, reference-counted, and keyed by `(busId, priority)`:

- `alloc.h`: streams are created on first acquire and destroyed when the last
  scope releases, freeing the HW queue. Adds `ncclClampStreamPriority()`,
  `cudaStreamCreateWithPriority`, and the RAII `ncclSideStreamScope` helper.
  `ncclCreateSideStream`/`ncclDestroySideStream` become
  `ncclSideStreamAcquire`/`ncclSideStreamRelease`, and `getSideStream()` now
  returns `nullptr` (no WARN) when no scope is active, which the existing
  `ncclCudaCalloc`/`ncclCudaMemcpy` fallback path already handles.
- `init.cc`: acquire the scope in `commAlloc`, release it right after init
  completes (`initState = ncclSuccess`), with a safety-net release in
  `commFree` for the fail/abort paths.
- `comm.h`: track per-comm scope ownership (`sideStreamAcquired`,
  `sideStreamPriority`).
- `transport.cc`: wrap `ncclTransportP2pSetup` in a side-stream scope so
  pre-connect buffer allocations (including proxy-thread `ncclCudaCalloc` for
  the same device) reuse one pooled stream instead of churning create/destroy
  per connection. This also covers the lazy first-collective connect for
  all-to-all.
- `AllocTests.cpp`: whitebox tests for scope gating, refcount pooling, the
  RAII scope, priority clamping, and priority-keyed separation.

Deviations from the upstream PR:

- Upstream commits 3/7 and 4/7 only add HIP link stubs in
  `projects/rccl/test/host/`, which this drop does not vendor, so they are
  dropped.
- The remaining hunks were re-anchored for our import: our
  `ncclTransportP2pSetup` uses `int num = MAXCHANNELS/64;` (not
  `MAXCHANNELS / CHANNELS_PER_MASK_WORD`), our `comm.h` uses `cpu_set_t
  cpuAffinity` (not `ncclAffinity`), and the `init.cc` release point is keyed
  off `comm->initState = ncclSuccess;`. Functional intent is unchanged.

Differential Revision: D116692069


