### PR TITLE
Fix IB benchmark logging dependencies

### DIFF
--- a/comms/ctran/ibverbx/benchmarks/IbverbxIbEventBench.cc
+++ b/comms/ctran/ibverbx/benchmarks/IbverbxIbEventBench.cc
@@ -17,8 +17,10 @@
 
 #include <folly/init/Init.h>
 #include <folly/logging/Init.h>
+#include <glog/logging.h>
 
 #include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 using namespace ibverbx;
@@ -427,7 +429,7 @@ static void BM_Ibverbx_IbEvent_RdmaWriteWithImm(benchmark::State& state) {
         &setup.sender->cq,
         [&](const ibv_wc& wc) {
           if (wc.status != IBV_WC_SUCCESS) {
-            XLOGF(FATAL, "WC failed with status {}", wc.status);
+            CTRAN_LOG(FATAL, "WC failed with status {}", wc.status);
             return;
           }
           if (wc.opcode == IBV_WC_RDMA_WRITE) {
@@ -441,7 +443,7 @@ static void BM_Ibverbx_IbEvent_RdmaWriteWithImm(benchmark::State& state) {
         &setup.receiver->cq,
         [&](const ibv_wc& wc) {
           if (wc.status != IBV_WC_SUCCESS) {
-            XLOGF(FATAL, "WC failed with status {}", wc.status);
+            CTRAN_LOG(FATAL, "WC failed with status {}", wc.status);
             return;
           }
           if (wc.opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
@@ -468,7 +470,7 @@ static void BM_Ibverbx_IbEvent_RdmaWriteWithImm(benchmark::State& state) {
 
     state.SetBytesProcessed(state.iterations() * bufferSize);
   } catch (const std::exception& e) {
-    XLOGF(FATAL, "Benchmark setup failed: {}", e.what());
+    CTRAN_LOG(FATAL, "Benchmark setup failed: {}", e.what());
     return;
   }
 }

--- a/comms/ctran/ibverbx/benchmarks/IbverbxVirtualQpBench.cc
+++ b/comms/ctran/ibverbx/benchmarks/IbverbxVirtualQpBench.cc
@@ -8,8 +8,10 @@
 
 #include <folly/init/Init.h>
 #include <folly/logging/Init.h>
+#include <glog/logging.h>
 
 #include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 using namespace ibverbx;
@@ -319,12 +321,12 @@ struct BenchmarkSetup {
       } else if (numWc == 1) {
         const auto& wc = maybeWcsVector->at(0);
         if (wc.status != IBV_WC_SUCCESS) {
-          XLOGF(FATAL, "{} WC failed with status {}", cqName, wc.status);
+          CTRAN_LOG(FATAL, "{} WC failed with status {}", cqName, wc.status);
           return;
         }
         stop = true;
       } else {
-        XLOGF(FATAL, "{} got {} wc", cqName, numWc);
+        CTRAN_LOG(FATAL, "{} got {} wc", cqName, numWc);
       }
     }
   }
@@ -375,7 +377,7 @@ static void BM_Ibverbx_VirtualQp_RdmaRead(benchmark::State& state) {
     state.counters["BW_GBps"] =
         benchmark::Counter(totalBytes / 1e9, benchmark::Counter::kIsRate);
   } catch (const std::exception& e) {
-    XLOGF(FATAL, "Benchmark setup failed: {}", e.what());
+    CTRAN_LOG(FATAL, "Benchmark setup failed: {}", e.what());
     return;
   }
 }
@@ -415,7 +417,7 @@ static void BM_Ibverbx_VirtualQp_RdmaWrite(benchmark::State& state) {
     state.counters["BW_GBps"] =
         benchmark::Counter(totalBytes / 1e9, benchmark::Counter::kIsRate);
   } catch (const std::exception& e) {
-    XLOGF(FATAL, "Benchmark setup failed: {}", e.what());
+    CTRAN_LOG(FATAL, "Benchmark setup failed: {}", e.what());
     return;
   }
 }
@@ -466,7 +468,7 @@ static void BM_Ibverbx_VirtualQp_RdmaWriteWithImm(
     state.counters["BW_GBps"] =
         benchmark::Counter(totalBytes / 1e9, benchmark::Counter::kIsRate);
   } catch (const std::exception& e) {
-    XLOGF(FATAL, "Benchmark setup failed: {}", e.what());
+    CTRAN_LOG(FATAL, "Benchmark setup failed: {}", e.what());
     return;
   }
 }

--- a/comms/ctran/ibverbx/benchmarks/IbverbxVirtualQpBenchGb200.cc
+++ b/comms/ctran/ibverbx/benchmarks/IbverbxVirtualQpBenchGb200.cc
@@ -8,8 +8,10 @@
 
 #include <folly/init/Init.h>
 #include <folly/logging/Init.h>
+#include <glog/logging.h>
 
 #include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 using namespace ibverbx;
@@ -466,12 +468,12 @@ struct BenchmarkSetup {
       } else if (numWc == 1) {
         const auto& wc = maybeWcsVector->at(0);
         if (wc.status != IBV_WC_SUCCESS) {
-          XLOGF(FATAL, "{} WC failed with status {}", cqName, wc.status);
+          CTRAN_LOG(FATAL, "{} WC failed with status {}", cqName, wc.status);
           return;
         }
         stop = true;
       } else {
-        XLOGF(FATAL, "{} got {} wc", cqName, numWc);
+        CTRAN_LOG(FATAL, "{} got {} wc", cqName, numWc);
       }
     }
   }
@@ -522,7 +524,7 @@ static void BM_Ibverbx_VirtualQp_RdmaRead(benchmark::State& state) {
     state.counters["BW_GBps"] =
         benchmark::Counter(totalBytes / 1e9, benchmark::Counter::kIsRate);
   } catch (const std::exception& e) {
-    XLOGF(FATAL, "Benchmark setup failed: {}", e.what());
+    CTRAN_LOG(FATAL, "Benchmark setup failed: {}", e.what());
     return;
   }
 }
@@ -560,7 +562,7 @@ static void BM_Ibverbx_VirtualQp_RdmaWrite(benchmark::State& state) {
     state.counters["BW_GBps"] =
         benchmark::Counter(totalBytes / 1e9, benchmark::Counter::kIsRate);
   } catch (const std::exception& e) {
-    XLOGF(FATAL, "[BM_RdmaWrite] Benchmark setup failed: {}", e.what());
+    CTRAN_LOG(FATAL, "[BM_RdmaWrite] Benchmark setup failed: {}", e.what());
     return;
   }
 }
@@ -611,7 +613,7 @@ static void BM_Ibverbx_VirtualQp_RdmaWriteWithImm(
     state.counters["BW_GBps"] =
         benchmark::Counter(totalBytes / 1e9, benchmark::Counter::kIsRate);
   } catch (const std::exception& e) {
-    XLOGF(FATAL, "Benchmark setup failed: {}", e.what());
+    CTRAN_LOG(FATAL, "Benchmark setup failed: {}", e.what());
     return;
   }
 }


### PR DESCRIPTION
Summary:
D116352100 removed the stale Folly logging include from `Ibverbx.h`, exposing three benchmarks that relied on the public header to provide `XLOGF` and glog `CHECK_*` macros transitively.

Migrate their fatal logs to `CTRAN_LOG`, include glog directly for the remaining checks, and declare both dependencies on the owning benchmark targets.

Hot-path impact:
Benchmark-only source and build dependency changes. Production collective, transport-progress, polling, and kernel-launch paths are unchanged.

Differential Revision: D116701748


