### PR TITLE
Batched multi-peer send/recv over the prims progress API

### DIFF
--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -544,6 +544,14 @@ class MultiPeerIbTransportBase {
   }
 
   /**
+   * @return Logical IB channels per peer; device code requires
+   * group_id < this. Cross-validated across ranks at materialization.
+   */
+  int maxNumChannels() const {
+    return config_.max_num_channels;
+  }
+
+  /**
    * registerBuffer - Register a user GPU buffer for RDMA, refcounted per
    * allocation. Containment fast-path returns cached per-NIC lkeys without any
    * driver call; on a miss it resolves the allocation, exports a DMA-BUF, and

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -225,6 +225,16 @@ std::optional<int> MultiPeerTransport::ibgda_pipeline_depth() const {
   return ibgdaTransport_->pipelineDepth();
 }
 
+std::optional<int> MultiPeerTransport::ib_max_num_channels() const {
+  if (ibgdaTransport_) {
+    return ibgdaTransport_->maxNumChannels();
+  }
+  if (ibrcTransport_) {
+    return ibrcTransport_->maxNumChannels();
+  }
+  return std::nullopt;
+}
+
 void MultiPeerTransport::setExternalNvlDataBuffers(
     ExternalStagingBuffers externalStagingBuffers) {
   if (nvlTransport_) {

--- a/comms/prims/transport/MultiPeerTransport.h
+++ b/comms/prims/transport/MultiPeerTransport.h
@@ -264,6 +264,12 @@ class MultiPeerTransport {
   std::optional<int> ibgda_pipeline_depth() const;
 
   /*
+   * Channel capacity of whichever IB backend is configured. Empty when this
+   * rank has no IB peers.
+   */
+  std::optional<int> ib_max_num_channels() const;
+
+  /*
    * Every requested edge must be requested by both endpoint ranks in the same
    * connect round. Peer-vector order may differ between ranks.
    */

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2042,6 +2042,15 @@ cvars:
      NCCLX or standalone Ctran users. Set false to roll MCCL communicators back
      to the legacy transport policy.
 
+ - name        : MCCL_SENDRECV_ASYNC
+   type        : bool
+   default     : false
+   description : |-
+     Within an all-IB communicator, also use the batched path for the two-rank
+     case that normally takes the pair path. Has no effect when the
+     communicator has any NVLink peer. Must be set identically on every rank.
+     For benchmarking only.
+
  - name        : MCCL_NVL_FABRIC_ENABLE
    type        : bool
    default     : false


### PR DESCRIPTION
Summary:
**Problem:** `McclComm::batchSendRecv` takes a list of send/recv ops but only ever executes one send
and one recv, rejecting anything larger. The layers above already build the full list, so the cap is
purely in the executor, and it means AllToAll, Scatter, Gather and Broadcast cannot be expressed as
point-to-point.

**This diff** adds a batched path that executes N ops across multiple peers in one launch. It is taken
when the communicator has one rank per node, so every peer is remote and therefore on IB, and the rank
count is above two; `MCCL_SENDRECV_ASYNC` forces it on for comparison. Everything else,
including all NVLink traffic, keeps the existing pair path unchanged, since only the IB transports
expose the progress API.

**How:** the kernel drives peers with the async `init_send_progress` + `progress_send_once` pair
instead of blocking `send()`/`recv()`,so a block is never stuck on one peer and instead holds every
op in flight,cycling between them until all are done. **Blocks are therefore shared across all ops**
rather than dedicated one per op,which gives two design points:

- **Block count is per op**, computed from that op alone:
`min(ceil(nbytes / kBytesPerBlock), kBlocksToSaturateIB, blockCap)`, where
`blockCap = min(channels, MCCL_MAX_NBLOCKS)`. `kBytesPerBlock` (64 KiB) is the bytes one block
handles per op; `kBlocksToSaturateIB` (8) caps the result, since past some count extra blocks no
longer help; `channels` is the transport's configured IB channel count, since a block index past it
traps on the device; `MCCL_MAX_NBLOCKS` is the documented cap for message-size-based block tuning.
- **Each op's data is partitioned over its own blocks.** The launch width is the max over the
batch's ops, and each op carries a `ThreadGroup` scoped to its own count so a narrower op is not
split more ways than its peer expects.

**Limitation:** at most 256 remote ops in total across both directions, since the op array is passed
inline in the CUDA kernel parameters. That covers a full-fanout all-to-all on 128 ranks.

**Limitation:** the gate is `nRanks() == nNodes() && (nRanks() > 2 || MCCL_SENDRECV_ASYNC)`.
`nRanks() == nNodes()` is how we check that every peer is on IB: one rank per topology group means no
two ranks share a node, so no pair is an NVL peer. A consumer wanting this path should build the
communicator to hold only the participating ranks that communicate over IB; PAFT's
`McclInterReplicaComm` already does, so it qualifies.

Reviewed By: Scusemua, saifhhasan

Differential Revision: D116438928


