### PR TITLE
Add MCCL logger and migrate bootstrap (#3731)

### DIFF
--- a/comms/ctran/utils/LogInit.cc
+++ b/comms/ctran/utils/LogInit.cc
@@ -14,30 +14,6 @@
 namespace ctran::logging {
 
 namespace {
-spdlog::level::level_enum loggerLevelToSpdlogLevel(
-    meta::comms::logger::LogLevel level) {
-  switch (level) {
-    case meta::comms::logger::LogLevel::NONE:
-    case meta::comms::logger::LogLevel::VERSION:
-      // COMMS_LOG_FATAL bypasses this threshold; off suppresses only
-      // non-fatal messages for these modes.
-      return spdlog::level::off;
-    case meta::comms::logger::LogLevel::ERROR:
-      return spdlog::level::err;
-    case meta::comms::logger::LogLevel::WARN:
-      return spdlog::level::warn;
-    case meta::comms::logger::LogLevel::INFO:
-      return spdlog::level::info;
-    case meta::comms::logger::LogLevel::ABORT:
-    case meta::comms::logger::LogLevel::TRACE:
-      return spdlog::level::debug;
-  }
-  return spdlog::level::off;
-}
-
-} // namespace
-
-namespace {
 folly::once_flag ctranLoggingInitOnceFlag;
 
 void initCtranLoggingImpl() {
@@ -56,8 +32,9 @@ void initCtranLoggingImpl() {
       },
       NCCL_DEBUG_LOGGING_ASYNC);
   meta::comms::logger::getSpdlogLogger(kCtranLoggerName)
-      .set_level(loggerLevelToSpdlogLevel(
-          meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
+      .set_level(
+          meta::comms::logger::loggerLevelToSpdlogLevel(
+              meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
 }
 } // anonymous namespace
 

--- a/comms/ncclx/v2_29/src/misc/param.cc
+++ b/comms/ncclx/v2_29/src/misc/param.cc
@@ -31,29 +31,6 @@
 
 #include "cuda_runtime_api.h"
 
-namespace {
-
-spdlog::level::level_enum loggerLevelToSpdlogLevel(
-    meta::comms::logger::LogLevel level) {
-  switch (level) {
-    case meta::comms::logger::LogLevel::NONE:
-    case meta::comms::logger::LogLevel::VERSION:
-      return spdlog::level::off;
-    case meta::comms::logger::LogLevel::ERROR:
-      return spdlog::level::err;
-    case meta::comms::logger::LogLevel::WARN:
-      return spdlog::level::warn;
-    case meta::comms::logger::LogLevel::INFO:
-      return spdlog::level::info;
-    case meta::comms::logger::LogLevel::ABORT:
-    case meta::comms::logger::LogLevel::TRACE:
-      return spdlog::level::debug;
-  }
-  return spdlog::level::off;
-}
-
-} // namespace
-
 const char* userHomeDir() {
   struct passwd *pwUser = getpwuid(getuid());
   return pwUser == NULL ? NULL : pwUser->pw_dir;
@@ -198,6 +175,6 @@ void initNcclLogger() {
       },
       NCCL_DEBUG_LOGGING_ASYNC);
   meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName)
-      .set_level(loggerLevelToSpdlogLevel(
+      .set_level(meta::comms::logger::loggerLevelToSpdlogLevel(
           meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
 }

--- a/comms/ncclx/v2_30/src/misc/param.cc
+++ b/comms/ncclx/v2_30/src/misc/param.cc
@@ -28,29 +28,6 @@
 
 #include "cuda_runtime_api.h"
 
-namespace {
-
-spdlog::level::level_enum loggerLevelToSpdlogLevel(
-    meta::comms::logger::LogLevel level) {
-  switch (level) {
-    case meta::comms::logger::LogLevel::NONE:
-    case meta::comms::logger::LogLevel::VERSION:
-      return spdlog::level::off;
-    case meta::comms::logger::LogLevel::ERROR:
-      return spdlog::level::err;
-    case meta::comms::logger::LogLevel::WARN:
-      return spdlog::level::warn;
-    case meta::comms::logger::LogLevel::INFO:
-      return spdlog::level::info;
-    case meta::comms::logger::LogLevel::ABORT:
-    case meta::comms::logger::LogLevel::TRACE:
-      return spdlog::level::debug;
-  }
-  return spdlog::level::off;
-}
-
-} // namespace
-
 const char* userHomeDir() {
   return getenv("HOME");
 }
@@ -161,6 +138,6 @@ void initNcclLogger() {
       },
       NCCL_DEBUG_LOGGING_ASYNC);
   meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName)
-      .set_level(loggerLevelToSpdlogLevel(
+      .set_level(meta::comms::logger::loggerLevelToSpdlogLevel(
           meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
 }

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -26,6 +26,24 @@
 #include "comms/utils/logger/CommsLogFormatter.h"
 
 namespace meta::comms::logger {
+
+spdlog::level::level_enum loggerLevelToSpdlogLevel(LogLevel level) {
+  switch (level) {
+    case LogLevel::NONE:
+    case LogLevel::VERSION:
+      return spdlog::level::off;
+    case LogLevel::ERROR:
+      return spdlog::level::err;
+    case LogLevel::WARN:
+      return spdlog::level::warn;
+    case LogLevel::INFO:
+      return spdlog::level::info;
+    case LogLevel::ABORT:
+    case LogLevel::TRACE:
+      return spdlog::level::debug;
+  }
+  return spdlog::level::off;
+}
 namespace {
 
 constexpr std::string_view kLoggerName = "comms";

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -21,6 +21,8 @@
 #include <spdlog/sinks/dist_sink.h>
 #include <spdlog/spdlog.h>
 
+#include "comms/utils/logger/LogTypes.h"
+
 namespace meta::comms::logger {
 
 class CommsSpdlogLogger {
@@ -138,6 +140,8 @@ class CommsSpdlogLogger {
 CommsSpdlogLogger& getSpdlogLogger();
 CommsSpdlogLogger& getSpdlogLogger(std::string_view loggerName);
 
+spdlog::level::level_enum loggerLevelToSpdlogLevel(LogLevel level);
+
 void configureSpdlogLogger(
     std::string prefix,
     std::function<int(void)> threadContextFn);
@@ -167,6 +171,11 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
 #define COMMS_LOGGER_DEBUG(logger, ...) \
   SPDLOG_LOGGER_CALL(logger, ::spdlog::level::debug, __VA_ARGS__)
 
+/*
+ * shutdown() drains the async queue before the synchronous fatal message.
+ * CommsSpdlogLogger owns that synchronous logger and its output sinks outside
+ * spdlog's registry, so they remain valid after registry shutdown.
+ */
 #define COMMS_LOG_FATAL_IMPL(logger_expression, ...)               \
   do {                                                             \
     auto& _comms_logger = (logger_expression);                     \


### PR DESCRIPTION
Summary:

Add the MCCL spdlog facade and migrate MCCL utility, adapter, coroutine socket, and bootstrap logging to it.

Provide named stream logging, fixed-context formatting, rate-limited helpers, and the dependencies required by later MCCL production and test migrations while preserving bootstrap errors and last-error behavior.

Hot-path impact:
Disabled logs gate on the cached MCCL logger before formatting or rate-limit accounting. Adapter and bootstrap control flow is unchanged; logger configuration is initialization-only.

Reviewed By: shr

Differential Revision: D116694646


