### PR TITLE
Migrate shared logger and CollTrace

### DIFF
--- a/comms/common/algorithms/AlgoFactory.cu
+++ b/comms/common/algorithms/AlgoFactory.cu
@@ -1,9 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #include <cuda.h>
 #include <cuda_runtime.h>
-#include <folly/logging/xlog.h>
 #include "comms/common/algorithms/AlgoFactory.cuh"
 #include "comms/utils/checks.h"
+#include "comms/utils/logger/CudaLog.h"
 
 namespace meta::comms {
 
@@ -14,7 +14,7 @@ AlgoFactory::AlgoFactory(
     int maxBlocks,
     const AllReduceOptions& allReduceOpts) {
   if (allReduceOpts.enableDda) {
-    XLOG(DBG) << "Initializing AllReduceAlgoManager";
+    COMMS_CUDA_LOG(DBG, "Initializing AllReduceAlgoManager");
     for (int i = 0; i < nRanks; ++i) {
       if (i == selfRank) {
         continue;
@@ -40,7 +40,7 @@ AlgoFactory::AlgoFactory(
         allReduceOpts.ddaSendbufSizeBytes,
         allReduceOpts.ddaFlatMaxThresholdBytes,
         allReduceOpts.ddaTreeMaxThresholdBytes);
-    XLOG(DBG) << "Successfully initialized AllReduceAlgoManager";
+    COMMS_CUDA_LOG(DBG, "Successfully initialized AllReduceAlgoManager");
   }
 }
 
@@ -60,8 +60,9 @@ AlgoFactoryDev::AlgoFactoryDev(
       ddaSendbufSizeBytes_(ddaSendbufSizeBytes) {
   if (allReduceOpts.enableDda || allGatherOpts.enableDda ||
       reduceScatterOpts.enableDda || allToAllOpts.enableDda) {
-    XLOG(DBG)
-        << "Initializing AllReduce / AllGather / ReduceScatter / AllToAll AlgoManager";
+    COMMS_CUDA_LOG(
+        DBG,
+        "Initializing AllReduce / AllGather / ReduceScatter / AllToAll AlgoManager");
 
     for (int i = 0; i < nRanks; ++i) {
       if (i == selfRank) {

--- a/comms/common/algorithms/all_gather/AllGatherAlgoManager.cu
+++ b/comms/common/algorithms/all_gather/AllGatherAlgoManager.cu
@@ -2,6 +2,8 @@
 
 #include "comms/common/algorithms/all_gather/AllGatherAlgoManager.h"
 
+#include "comms/utils/logger/CudaLog.h"
+
 namespace meta::comms {
 
 AllGatherAlgoManager::AllGatherAlgoManager(
@@ -19,7 +21,7 @@ AllGatherAlgoManager::AllGatherAlgoManager(
       ddaMaxThresholdBytes_(ddaMaxThresholdBytes),
       allRankDdaSendbuffs_(allRankDdaSendbuffs),
       barrier_(barrier) {
-  XLOG(DBG) << "Successfully initialized AllGatherAlgoManager";
+  COMMS_CUDA_LOG(DBG, "Successfully initialized AllGatherAlgoManager");
 }
 
 std::unique_ptr<AlgoAllGather> AllGatherAlgoManager::getAllGatherAlgo(
@@ -30,41 +32,48 @@ std::unique_ptr<AlgoAllGather> AllGatherAlgoManager::getAllGatherAlgo(
     cudaStream_t stream) {
   if ((nRanks_ * count * commTypeSize(datatype)) > ddaSendbufSizeBytes_) {
     // AG: msgSize = (nRanks_ x count x datatype) must fit into the dda sendbuf
-    XLOG(DBG) << "Not using custom all gather algo because message size "
-              << nRanks_ * count * commTypeSize(datatype)
-              << " is larger than ddaSendbufSizeBytes " << ddaSendbufSizeBytes_;
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all gather algo because message size %zu is larger than ddaSendbufSizeBytes %d",
+        nRanks_ * count * commTypeSize(datatype),
+        ddaSendbufSizeBytes_);
     return nullptr;
   }
 
   if (((uintptr_t)sendbuff % 16) || ((uintptr_t)recvbuff % 16) ||
       ((count * commTypeSize(datatype)) % 16)) {
     // 16 byte alignment as we do 16-byte loads in DDA kernel
-    XLOG(DBG) << "Not using custom all gather algo because send/recv buff "
-                 "or msg size is not 16-byte aligned";
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all gather algo because send/recv buff or msg size is not 16-byte aligned");
     return nullptr;
   }
 
   if (datatype != commBfloat16 && datatype != commFloat16 &&
       datatype != commFloat) {
     // we currently only support bf16, half, float
-    XLOG(DBG)
-        << "Not using custom all gather algo because cudaDataType_t datatype "
-        << static_cast<int>(datatype) << " is not supported";
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all gather algo because cudaDataType_t datatype %d is not supported",
+        static_cast<int>(datatype));
     return nullptr;
   }
 
   std::unique_ptr<AlgoAllGather> algo;
   if ((nRanks_ * count * commTypeSize(datatype)) > ddaMaxThresholdBytes_) {
     // AG: msgSize = (nRanks_ x count x datatype) must less than algo threshold
-    XLOG(DBG) << "Not using custom all gather algo because msg size "
-              << nRanks_ * count * commTypeSize(datatype)
-              << " is larger than DDA algo threshold " << ddaMaxThresholdBytes_;
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all gather algo because msg size %zu is larger than DDA algo threshold %d",
+        nRanks_ * count * commTypeSize(datatype),
+        ddaMaxThresholdBytes_);
     return nullptr;
   } else {
     if (((count * commTypeSize(datatype)) % 16) ||
         ((nRanks_ * count * commTypeSize(datatype)) % 16)) {
-      XLOG(DBG) << "Not using DDA all gather algo because send/recv buff "
-                   "or msg size is not 16-byte aligned for each rank";
+      COMMS_CUDA_LOG(
+          DBG,
+          "Not using DDA all gather algo because send/recv buff or msg size is not 16-byte aligned for each rank");
       return nullptr;
     }
     algo = std::make_unique<AlgoAllGatherDdaIpc>(

--- a/comms/common/algorithms/all_gather/tests/all_gather_dda_test.cu
+++ b/comms/common/algorithms/all_gather/tests/all_gather_dda_test.cu
@@ -3,13 +3,14 @@
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
+
 #include "comms/common/IpcGpuBarrier.cuh"
 #include "comms/common/algorithms/all_gather/all_gather_dda.cuh"
 #include "comms/common/tests/TestBaselineBootstrap.h"
 #include "comms/rcclx/develop/meta/lib/tests/RcclxTestUtils.h"
 #include "comms/utils/CudaRAII.h"
+#include "comms/utils/logger/CudaLog.h"
 
 using namespace meta::rcclx;
 using namespace meta::comms;
@@ -30,7 +31,8 @@ class AllGatherDdaTest : public RcclxBaseTestFixture {
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
     NCCL_CHECK(
         ncclCommInitRankConfig(&comm, numRanks, commId, globalRank, &config));
-    XLOGF(INFO, "rank {} init done; total ranks: {}", globalRank, numRanks);
+    COMMS_CUDA_LOG(
+        INFO, "rank %d init done; total ranks: %d", globalRank, numRanks);
 
     ASSERT_EQ(numRanks, NUMRANKS);
     CUDA_CHECK(cudaSetDevice(globalRank));

--- a/comms/common/algorithms/all_reduce/AllReduceAlgoManager.cu
+++ b/comms/common/algorithms/all_reduce/AllReduceAlgoManager.cu
@@ -2,6 +2,8 @@
 
 #include "comms/common/algorithms/all_reduce/AllReduceAlgoManager.h"
 
+#include "comms/utils/logger/CudaLog.h"
+
 namespace meta::comms {
 
 AllReduceAlgoManager::AllReduceAlgoManager(
@@ -40,7 +42,7 @@ AllReduceAlgoManager::AllReduceAlgoManager(
       ipcSendbufs.data(),
       sizeof(void*) * nRanks_,
       cudaMemcpyDefault));
-  XLOG(DBG) << "Successfully initialized AllReduceAlgoManager";
+  COMMS_CUDA_LOG(DBG, "Successfully initialized AllReduceAlgoManager");
 }
 
 std::unique_ptr<AlgoAllReduce> AllReduceAlgoManager::getAllReduceAlgo(
@@ -70,7 +72,7 @@ AllReduceAlgoManagerDev::AllReduceAlgoManagerDev(
       ddaTreeMaxThresholdBytes_(ddaTreeMaxThresholdBytes),
       allRankDdaSendbuffs_(allRankDdaSendbuffs),
       barrier_(barrier) {
-  XLOG(DBG) << "Successfully initialized AllReduceAlgoManager";
+  COMMS_CUDA_LOG(DBG, "Successfully initialized AllReduceAlgoManager");
 }
 
 std::unique_ptr<AlgoAllReduce> AllReduceAlgoManagerDev::getAllReduceAlgo(
@@ -82,42 +84,48 @@ std::unique_ptr<AlgoAllReduce> AllReduceAlgoManagerDev::getAllReduceAlgo(
     const void* acc) {
   if ((count * commTypeSize(datatype)) > ddaSendbufSizeBytes_) {
     // AllReduce: (count x datatype) size must fit into the dda sendbuf
-    XLOG(DBG) << "Not using custom all reduce algo because message size "
-              << count * commTypeSize(datatype)
-              << " is larger than ddaSendbufSizeBytes " << ddaSendbufSizeBytes_;
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all reduce algo because message size %zu is larger than ddaSendbufSizeBytes %d",
+        count * commTypeSize(datatype),
+        ddaSendbufSizeBytes_);
     return nullptr;
   }
 
   if (((uintptr_t)sendbuff % 16) || ((uintptr_t)recvbuff % 16) ||
       ((count * commTypeSize(datatype)) % 16)) {
     // 16 byte alignment as we do 16-byte loads in DDA kernel
-    XLOG(DBG) << "Not using custom all reduce algo because send/recv buff "
-                 "or msg size is not 16-byte aligned";
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all reduce algo because send/recv buff or msg size is not 16-byte aligned");
     return nullptr;
   }
 
   if (datatype != commBfloat16 && datatype != commFloat16 &&
       datatype != commFloat) {
     // we currently only support bf16, half, float
-    XLOG(DBG)
-        << "Not using custom all reduce algo because cudaDataType_t datatype "
-        << static_cast<int>(datatype) << " is not supported";
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all reduce algo because cudaDataType_t datatype %d is not supported",
+        static_cast<int>(datatype));
     return nullptr;
   }
 
   std::unique_ptr<AlgoAllReduce> algo;
   if (count * commTypeSize(datatype) > ddaTreeMaxThresholdBytes_) {
-    XLOG(DBG) << "Not using custom all reduce algo because msg size "
-              << count * commTypeSize(datatype)
-              << " is larger than DDA algo threshold "
-              << ddaTreeMaxThresholdBytes_;
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all reduce algo because msg size %zu is larger than DDA algo threshold %d",
+        count * commTypeSize(datatype),
+        ddaTreeMaxThresholdBytes_);
     return nullptr;
   } else if (count * commTypeSize(datatype) > ddaFlatMaxThresholdBytes_) {
     if (count % nRanks_ || ((count / nRanks_ * commTypeSize(datatype)) % 16)) {
       // In two-shot algo, each rank is reduces count/nRanks_ elements so we
       // need to make sure that is 16-byte aligned
-      XLOG(DBG) << "Not using DDA Tree all reduce algo because send/recv buff "
-                   "or msg size is not 16-byte aligned for each rank";
+      COMMS_CUDA_LOG(
+          DBG,
+          "Not using DDA Tree all reduce algo because send/recv buff or msg size is not 16-byte aligned for each rank");
       return nullptr;
     }
     algo = std::make_unique<AlgoAllReduceDdaTreeIpc>(

--- a/comms/common/algorithms/all_reduce/tests/all_reduce_dda_test.cu
+++ b/comms/common/algorithms/all_reduce/tests/all_reduce_dda_test.cu
@@ -4,13 +4,14 @@
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
+
 #include "comms/common/IpcGpuBarrier.cuh"
 #include "comms/common/algorithms/all_reduce/all_reduce_dda.cuh"
 #include "comms/common/tests/TestBaselineBootstrap.h"
 #include "comms/rcclx/develop/meta/lib/tests/RcclxTestUtils.h"
 #include "comms/utils/CudaRAII.h"
+#include "comms/utils/logger/CudaLog.h"
 
 using namespace meta::rcclx;
 using namespace meta::comms;
@@ -31,7 +32,8 @@ class AllReduceDdaTest : public RcclxBaseTestFixture {
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
     NCCL_CHECK(
         ncclCommInitRankConfig(&comm, numRanks, commId, globalRank, &config));
-    XLOGF(INFO, "rank {} init done; total ranks: {}", globalRank, numRanks);
+    COMMS_CUDA_LOG(
+        INFO, "rank %d init done; total ranks: %d", globalRank, numRanks);
 
     ASSERT_EQ(numRanks, NUMRANKS);
     CUDA_CHECK(cudaSetDevice(globalRank));

--- a/comms/common/algorithms/all_to_all/AllToAllAlgoManager.cu
+++ b/comms/common/algorithms/all_to_all/AllToAllAlgoManager.cu
@@ -2,6 +2,8 @@
 
 #include "comms/common/algorithms/all_to_all/AllToAllAlgoManager.h"
 
+#include "comms/utils/logger/CudaLog.h"
+
 namespace meta::comms {
 
 AllToAllAlgoManager::AllToAllAlgoManager(
@@ -19,7 +21,7 @@ AllToAllAlgoManager::AllToAllAlgoManager(
       ddaMaxThresholdBytes_(ddaMaxThresholdBytes),
       allRankDdaSendbuffs_(allRankDdaSendbuffs),
       barrier_(barrier) {
-  XLOG(DBG) << "Successfully initialized AllToAllAlgoManager";
+  COMMS_CUDA_LOG(DBG, "Successfully initialized AllToAllAlgoManager");
 }
 
 std::unique_ptr<AlgoAllToAll> AllToAllAlgoManager::getAllToAllAlgo(
@@ -30,41 +32,48 @@ std::unique_ptr<AlgoAllToAll> AllToAllAlgoManager::getAllToAllAlgo(
     cudaStream_t stream) {
   if ((nRanks_ * count * commTypeSize(datatype)) > ddaSendbufSizeBytes_) {
     // A2A: msgSize = (nRanks_ x count x datatype) must fit into the dda sendbuf
-    XLOG(DBG) << "Not using custom all-to-all algo because message size "
-              << count * commTypeSize(datatype)
-              << " is larger than ddaSendbufSizeBytes " << ddaSendbufSizeBytes_;
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all-to-all algo because message size %zu is larger than ddaSendbufSizeBytes %d",
+        count * commTypeSize(datatype),
+        ddaSendbufSizeBytes_);
     return nullptr;
   }
 
   if (((uintptr_t)sendbuff % 16) || ((uintptr_t)recvbuff % 16) ||
       ((count * commTypeSize(datatype)) % 16)) {
     // 16 byte alignment as we do 16-byte loads in DDA kernel
-    XLOG(DBG) << "Not using custom all-to-all algo because send/recv buff "
-                 "or msg size is not 16-byte aligned";
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all-to-all algo because send/recv buff or msg size is not 16-byte aligned");
     return nullptr;
   }
 
   if (datatype != commBfloat16 && datatype != commFloat16 &&
       datatype != commFloat) {
     // we currently only support bf16, half, float
-    XLOG(DBG)
-        << "Not using custom all-to-all algo because cudaDataType_t datatype "
-        << static_cast<int>(datatype) << " is not supported";
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all-to-all algo because cudaDataType_t datatype %d is not supported",
+        static_cast<int>(datatype));
     return nullptr;
   }
 
   std::unique_ptr<AlgoAllToAll> algo;
   if ((nRanks_ * count * commTypeSize(datatype)) > ddaMaxThresholdBytes_) {
     // A2A: msgSize = (nRanks_ x count x datatype) must less than algo threshold
-    XLOG(DBG) << "Not using custom all-to-all algo because msg size "
-              << nRanks_ * count * commTypeSize(datatype)
-              << " is larger than DDA algo threshold " << ddaMaxThresholdBytes_;
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all-to-all algo because msg size %zu is larger than DDA algo threshold %d",
+        nRanks_ * count * commTypeSize(datatype),
+        ddaMaxThresholdBytes_);
     return nullptr;
   } else {
     if (((count * commTypeSize(datatype)) % 16) ||
         ((nRanks_ * count * commTypeSize(datatype)) % 16)) {
-      XLOG(DBG) << "Not using DDA all-to-all algo because send/recv buff "
-                   "or msg size is not 16-byte aligned for each rank";
+      COMMS_CUDA_LOG(
+          DBG,
+          "Not using DDA all-to-all algo because send/recv buff or msg size is not 16-byte aligned for each rank");
       return nullptr;
     }
     algo = std::make_unique<AlgoAllToAllDdaIpc>(

--- a/comms/common/algorithms/all_to_all/tests/all_to_all_dda_test.cu
+++ b/comms/common/algorithms/all_to_all/tests/all_to_all_dda_test.cu
@@ -3,13 +3,14 @@
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
+
 #include "comms/common/IpcGpuBarrier.cuh"
 #include "comms/common/algorithms/all_to_all/all_to_all_dda.cuh"
 #include "comms/common/tests/TestBaselineBootstrap.h"
 #include "comms/rcclx/develop/meta/lib/tests/RcclxTestUtils.h"
 #include "comms/utils/CudaRAII.h"
+#include "comms/utils/logger/CudaLog.h"
 
 using namespace meta::rcclx;
 using namespace meta::comms;
@@ -30,7 +31,8 @@ class AllToAllDdaTest : public RcclxBaseTestFixture {
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
     NCCL_CHECK(
         ncclCommInitRankConfig(&comm, numRanks, commId, globalRank, &config));
-    XLOGF(INFO, "rank {} init done; total ranks: {}", globalRank, numRanks);
+    COMMS_CUDA_LOG(
+        INFO, "rank %d init done; total ranks: %d", globalRank, numRanks);
 
     ASSERT_EQ(numRanks, NUMRANKS);
     CUDA_CHECK(cudaSetDevice(globalRank));

--- a/comms/common/algorithms/reduce_scatter/ReduceScatterAlgoManager.cu
+++ b/comms/common/algorithms/reduce_scatter/ReduceScatterAlgoManager.cu
@@ -2,6 +2,8 @@
 
 #include "comms/common/algorithms/reduce_scatter/ReduceScatterAlgoManager.h"
 
+#include "comms/utils/logger/CudaLog.h"
+
 namespace meta::comms {
 
 ReduceScatterAlgoManager::ReduceScatterAlgoManager(
@@ -19,7 +21,7 @@ ReduceScatterAlgoManager::ReduceScatterAlgoManager(
       ddaMaxThresholdBytes_(ddaMaxThresholdBytes),
       allRankDdaSendbuffs_(allRankDdaSendbuffs),
       barrier_(barrier) {
-  XLOG(DBG) << "Successfully initialized ReduceScatterAlgoManager";
+  COMMS_CUDA_LOG(DBG, "Successfully initialized ReduceScatterAlgoManager");
 }
 
 std::unique_ptr<AlgoReduceScatter>
@@ -31,40 +33,47 @@ ReduceScatterAlgoManager::getReduceScatterAlgo(
     cudaStream_t stream) {
   if ((nRanks_ * count * commTypeSize(datatype)) > ddaSendbufSizeBytes_) {
     // RS: msgSize = (nRanks_ x count x datatype) must fit into the dda sendbuf
-    XLOG(DBG) << "Not using custom reduce scatter algo because message size "
-              << count * commTypeSize(datatype)
-              << " is larger than ddaSendbufSizeBytes " << ddaSendbufSizeBytes_;
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom reduce scatter algo because message size %zu is larger than ddaSendbufSizeBytes %d",
+        count * commTypeSize(datatype),
+        ddaSendbufSizeBytes_);
     return nullptr;
   }
   if (((uintptr_t)sendbuff % 16) || ((uintptr_t)recvbuff % 16) ||
       ((count * commTypeSize(datatype)) % 16)) {
     // 16 byte alignment as we do 16-byte loads in DDA kernel
-    XLOG(DBG) << "Not using custom reduce scatter algo because send/recv buff "
-                 "or msg size is not 16-byte aligned";
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom reduce scatter algo because send/recv buff or msg size is not 16-byte aligned");
     return nullptr;
   }
 
   if (datatype != commBfloat16 && datatype != commFloat16 &&
       datatype != commFloat) {
     // we currently only support bf16, half, float
-    XLOG(DBG)
-        << "Not using custom reduce scatter algo because cudaDataType_t datatype "
-        << static_cast<int>(datatype) << " is not supported";
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom reduce scatter algo because cudaDataType_t datatype %d is not supported",
+        static_cast<int>(datatype));
     return nullptr;
   }
 
   std::unique_ptr<AlgoReduceScatter> algo;
   if ((nRanks_ * count * commTypeSize(datatype)) > ddaMaxThresholdBytes_) {
     // RS: msgSize = (nRanks_ x count x datatype) must less than algo threshold
-    XLOG(DBG) << "Not using custom reduce scatter algo because msg size "
-              << nRanks_ * count * commTypeSize(datatype)
-              << " is larger than DDA algo threshold " << ddaMaxThresholdBytes_;
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom reduce scatter algo because msg size %zu is larger than DDA algo threshold %d",
+        nRanks_ * count * commTypeSize(datatype),
+        ddaMaxThresholdBytes_);
     return nullptr;
   } else {
     if (((count * commTypeSize(datatype)) % 16) ||
         ((nRanks_ * count * commTypeSize(datatype)) % 16)) {
-      XLOG(DBG) << "Not using DDA reduce scatter algo because send/recv buff "
-                   "or msg size is not 16-byte aligned for each rank";
+      COMMS_CUDA_LOG(
+          DBG,
+          "Not using DDA reduce scatter algo because send/recv buff or msg size is not 16-byte aligned for each rank");
       return nullptr;
     }
     algo = std::make_unique<AlgoReduceScatterDdaIpc>(

--- a/comms/common/algorithms/reduce_scatter/tests/reduce_scatter_dda_test.cu
+++ b/comms/common/algorithms/reduce_scatter/tests/reduce_scatter_dda_test.cu
@@ -3,13 +3,14 @@
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
+
 #include "comms/common/IpcGpuBarrier.cuh"
 #include "comms/common/algorithms/reduce_scatter/reduce_scatter_dda.cuh"
 #include "comms/common/tests/TestBaselineBootstrap.h"
 #include "comms/rcclx/develop/meta/lib/tests/RcclxTestUtils.h"
 #include "comms/utils/CudaRAII.h"
+#include "comms/utils/logger/CudaLog.h"
 
 using namespace meta::rcclx;
 using namespace meta::comms;
@@ -30,7 +31,8 @@ class ReduceScatterDdaTest : public RcclxBaseTestFixture {
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
     NCCL_CHECK(
         ncclCommInitRankConfig(&comm, numRanks, commId, globalRank, &config));
-    XLOGF(INFO, "rank {} init done; total ranks: {}", globalRank, numRanks);
+    COMMS_CUDA_LOG(
+        INFO, "rank %d init done; total ranks: %d", globalRank, numRanks);
 
     ASSERT_EQ(numRanks, NUMRANKS);
     CUDA_CHECK(cudaSetDevice(globalRank));

--- a/comms/common/algorithms/tests/AlgoFactoryTest.cu
+++ b/comms/common/algorithms/tests/AlgoFactoryTest.cu
@@ -1,10 +1,10 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include "comms/common/algorithms/AlgoFactory.cuh"
 #include "comms/common/tests/TestBaselineBootstrap.h"
 #include "comms/rcclx/develop/meta/lib/tests/RcclxTestUtils.h"
 #include "comms/utils/CudaRAII.h"
+#include "comms/utils/logger/CudaLog.h"
 
 using namespace meta::rcclx;
 using namespace meta::comms;
@@ -31,7 +31,8 @@ class AlgoFactoryTest : public RcclxBaseTestFixture {
     ncclComm_t comm{nullptr};
     NCCL_CHECK(
         ncclCommInitRankConfig(&comm, numRanks, commId, globalRank, &config));
-    XLOGF(INFO, "rank {} init done; total ranks: {}", globalRank, numRanks);
+    COMMS_CUDA_LOG(
+        INFO, "rank %d init done; total ranks: %d", globalRank, numRanks);
 
     ASSERT_EQ(numRanks, 8);
     CUDA_CHECK(cudaSetDevice(localRank));

--- a/comms/common/tests/IpcGpuBarrierTest.cu
+++ b/comms/common/tests/IpcGpuBarrierTest.cu
@@ -3,14 +3,15 @@
 #include <cuda_runtime.h>
 #include <folly/Random.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <folly/stop_watch.h>
 #include <gtest/gtest.h>
+
 #include "comms/common/IpcGpuBarrier.cuh"
 #include "comms/common/IpcMemHandler.h"
 #include "comms/common/tests/TestBaselineBootstrap.h"
 #include "comms/rcclx/develop/meta/lib/tests/RcclxTestUtils.h"
 #include "comms/utils/CudaRAII.h"
+#include "comms/utils/logger/CudaLog.h"
 
 using namespace meta::rcclx;
 using namespace meta::comms;
@@ -50,7 +51,8 @@ class DeviceMailboxTest : public RcclxBaseTestFixture,
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
     NCCL_CHECK(
         ncclCommInitRankConfig(&comm, numRanks, commId, localRank, &config));
-    XLOGF(INFO, "rank {} init done; total ranks: {}", localRank, numRanks);
+    COMMS_CUDA_LOG(
+        INFO, "rank %d init done; total ranks: %d", localRank, numRanks);
   }
 
   bool needMemFence;
@@ -143,7 +145,8 @@ class IpcGpuBarrierTest : public RcclxBaseTestFixture {
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
     NCCL_CHECK(
         ncclCommInitRankConfig(&comm, numRanks, commId, localRank, &config));
-    XLOGF(INFO, "rank {} init done; total ranks: {}", localRank, numRanks);
+    COMMS_CUDA_LOG(
+        INFO, "rank %d init done; total ranks: %d", localRank, numRanks);
   }
 
   bool needMemFence;

--- a/comms/common/tests/IpcMemHandlerTest.cc
+++ b/comms/common/tests/IpcMemHandlerTest.cc
@@ -3,11 +3,12 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
+
 #include "comms/common/tests/TestBaselineBootstrap.h"
 #include "comms/rcclx/develop/meta/lib/tests/RcclxTestUtils.h"
 #include "comms/utils/CudaRAII.h"
+#include "comms/utils/logger/CudaLog.h"
 
 using namespace meta::rcclx;
 using namespace meta::comms;
@@ -23,7 +24,8 @@ TEST_F(IpcMemHandlerTest, exchangeMemPtrs) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   NCCL_CHECK(
       ncclCommInitRankConfig(&comm, numRanks, commId, globalRank, &config));
-  XLOGF(INFO, "rank {} init done; total ranks: {}", globalRank, numRanks);
+  COMMS_CUDA_LOG(
+      INFO, "rank %d init done; total ranks: %d", globalRank, numRanks);
 
   int myValue = globalRank;
   DeviceBuffer myBuf(sizeof(myValue));

--- a/comms/ctran/algos/perftrace/examples/PerfTraceDistHelloWorld.cc
+++ b/comms/ctran/algos/perftrace/examples/PerfTraceDistHelloWorld.cc
@@ -8,6 +8,7 @@
 #include <folly/init/Init.h>
 
 #include "comms/ctran/algos/perftrace/examples/PerfTraceExampleHelper.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -46,12 +47,12 @@ TEST_F(PerfTraceDistTest, DistributedTracing) {
   ASSERT_GE(globalRank, 0) << "MPI rank not initialized";
   ASSERT_GT(numRanks, 0) << "MPI numRanks not initialized";
 
-  XLOG(INFO) << "Rank " << globalRank << ": starting PerfTrace example";
+  CTRAN_LOG(INFO, "Rank {}: starting PerfTrace example", globalRank);
 
   // Each rank traces its own algorithm execution
   traceAlgo(globalRank, numRanks);
 
-  XLOG(INFO) << "Rank " << globalRank << ": PerfTrace example completed";
+  CTRAN_LOG(INFO, "Rank {}: PerfTrace example completed", globalRank);
 }
 
 } // namespace ctran::perftrace

--- a/comms/ctran/commstate/Topology.cc
+++ b/comms/ctran/commstate/Topology.cc
@@ -3,6 +3,8 @@
 #include <cstring>
 #include <fstream>
 
+#include <folly/String.h>
+
 #include "comms/ctran/commstate/Topology.h"
 #include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"

--- a/comms/ctran/ibverbx/tests/IbverbxTest.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxTest.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/ctran/ibverbx/tests/IbverbxTestFixture.h"
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include <folly/ScopeGuard.h>
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
@@ -59,10 +60,10 @@ TEST_F(IbverbxTestFixture, IbvGetDeviceList) {
     ASSERT_GT(ibvDevices->size(), 0);
 
     // Print all found ibv device names
-    XLOGF(INFO, "Found {} InfiniBand devices:", ibvDevices->size());
+    CTRAN_LOG(INFO, "Found {} InfiniBand devices:", ibvDevices->size());
     for (size_t i = 0; i < ibvDevices->size(); ++i) {
       const auto& device = ibvDevices->at(i);
-      XLOGF(INFO, "  Device[{}]: {}", i, device.device()->name);
+      CTRAN_LOG(INFO, "  Device[{}]: {}", i, device.device()->name);
     }
   }
   {
@@ -87,7 +88,7 @@ TEST_F(IbverbxTestFixture, IbvGetDeviceList) {
           numDevicesToSelect,
           gen);
 
-      XLOGF(
+      CTRAN_LOG(
           INFO,
           "Testing exact match (in order) with {} randomly selected devices",
           numDevicesToSelect);
@@ -122,7 +123,7 @@ TEST_F(IbverbxTestFixture, IbvGetDeviceList) {
       // Shuffle to create out-of-order
       std::shuffle(selectedDevices.begin(), selectedDevices.end(), gen);
 
-      XLOGF(
+      CTRAN_LOG(
           INFO,
           "Testing exact match (out of order) with {} randomly selected and shuffled devices",
           numDevicesToSelect);
@@ -154,7 +155,7 @@ TEST_F(IbverbxTestFixture, IbvGetDeviceList) {
           numDevicesToExclude,
           gen);
 
-      XLOGF(
+      CTRAN_LOG(
           INFO,
           "Testing exclude (in order) with {} randomly selected devices to exclude",
           numDevicesToExclude);
@@ -197,7 +198,7 @@ TEST_F(IbverbxTestFixture, IbvGetDeviceList) {
       // Shuffle the exclusion list
       std::shuffle(devicesToExclude.begin(), devicesToExclude.end(), gen);
 
-      XLOGF(
+      CTRAN_LOG(
           INFO,
           "Testing exclude (out of order) with {} randomly selected and shuffled devices to exclude",
           numDevicesToExclude);
@@ -377,7 +378,7 @@ TEST_F(IbverbxTestFixture, regMr) {
 
   for (size_t size : sizes) {
     void* devBuf{nullptr};
-    XLOGF(INFO, "regMr testing with buffer size: {} bytes", size);
+    CTRAN_LOG(INFO, "regMr testing with buffer size: {} bytes", size);
     CUDA_CHECK(cudaMalloc(&devBuf, size));
     auto mr = pd->regMr(devBuf, size, access);
     EXPECT_TRUE(mr);
@@ -621,7 +622,7 @@ TEST_F(IbverbxTestFixture, IbvCqGetDeviceCq) {
   ASSERT_GE(deviceCq.ncqes, cqe);
   ASSERT_NE(deviceCq.cq_dbrec, nullptr);
 
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "Device CQ: cq_buf={}, ncqes={}, cq_dbrec={}",
       deviceCq.cq_buf,
@@ -677,7 +678,7 @@ TEST_F(IbverbxTestFixture, IbvQpGetDeviceQp) {
   ASSERT_EQ(deviceQp.producer_idx, 0);
   ASSERT_EQ(deviceQp.consumer_idx, 0);
 
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "Device QP: qp_num={}, wq_buf={}, nwqes={}, sq_dbrec={}, bf_reg={}, cq={}",
       deviceQp.qp_num,

--- a/comms/ctran/utils/CtranLogUtils.h
+++ b/comms/ctran/utils/CtranLogUtils.h
@@ -6,13 +6,23 @@
 
 #include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/LogTypes.h"
+#include "comms/utils/logger/LoggingFormat.h"
 
-#define CTRAN_LOG_SUBSYS(level, subsys, ...) \
-  CTRAN_LOG_IF(level, CLOGF_ENABLED(subsys), __VA_ARGS__)
+#define CTRAN_LOG_SUBSYS(level, subsys, ...)            \
+  CTRAN_LOG_IF(                                         \
+      level,                                            \
+      ::meta::comms::logger::isEnabledSubSystemBitwise( \
+          static_cast<uint64_t>([]() {                  \
+            using namespace ::meta::comms::logger;      \
+            return subsys;                              \
+          }())),                                        \
+      __VA_ARGS__)
 
-// The interval is fixed on first use at each expansion site, matching
-// CLOGF_EVERY_MS; callers must pass a call-site constant.
+/*
+ * The interval is fixed on first use at each expansion site, matching the
+ * legacy Comms logger; callers must pass a call-site constant.
+ */
 #define CTRAN_LOG_EVERY_MS(level, ms, ...)                          \
   CTRAN_LOG_IF(                                                     \
       level,                                                        \
@@ -23,6 +33,9 @@
         return ctran_log_rate_limiter.check();                      \
       }(),                                                          \
       __VA_ARGS__)
+
+#define CTRAN_LOG_STREAM_EVERY_MS(level, ms) \
+  COMMS_LOG_NAMED_STREAM_EVERY_MS(::ctran::logging::kCtranLoggerName, level, ms)
 
 #define CTRAN_LOG_TRACE(subsys, format, ...)                             \
   do {                                                                   \

--- a/comms/ctran/utils/CtranLogger.h
+++ b/comms/ctran/utils/CtranLogger.h
@@ -13,28 +13,57 @@ inline constexpr std::string_view kCtranLoggerName = "comms.ctran";
 
 } // namespace ctran::logging
 
-#define CTRAN_LOG(level, ...) \
-  COMMS_LOG_NAMED(::ctran::logging::kCtranLoggerName, level, __VA_ARGS__)
-
-#define CTRAN_LOG_SYNC_ERR(...)                                      \
-  do {                                                               \
-    auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger(    \
-        ::ctran::logging::kCtranLoggerName);                         \
-    if (_ctran_logger.should_log(::spdlog::level::err)) {            \
-      _ctran_logger.logSynchronous(                                  \
-          ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, \
-          ::spdlog::level::err,                                      \
-          __VA_ARGS__);                                              \
-    }                                                                \
+#define CTRAN_LOG_IMPL(spdlog_level, spdlog_macro, ...)                  \
+  do {                                                                   \
+    static auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger( \
+        ::ctran::logging::kCtranLoggerName);                             \
+    if (_ctran_logger.should_log(spdlog_level)) {                        \
+      spdlog_macro(&_ctran_logger, __VA_ARGS__);                         \
+    }                                                                    \
   } while (false)
 
-#define CTRAN_LOG_IF_IMPL(level, spdlog_level, condition, ...)    \
-  do {                                                            \
-    auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger( \
-        ::ctran::logging::kCtranLoggerName);                      \
-    if (_ctran_logger.should_log(spdlog_level) && (condition)) {  \
-      CTRAN_LOG(level, __VA_ARGS__);                              \
-    }                                                             \
+#define CTRAN_LOG_DBG(...) \
+  CTRAN_LOG_IMPL(::spdlog::level::debug, COMMS_LOGGER_DEBUG, __VA_ARGS__)
+#define CTRAN_LOG_INFO(...) \
+  CTRAN_LOG_IMPL(::spdlog::level::info, SPDLOG_LOGGER_INFO, __VA_ARGS__)
+#define CTRAN_LOG_WARN(...) \
+  CTRAN_LOG_IMPL(::spdlog::level::warn, SPDLOG_LOGGER_WARN, __VA_ARGS__)
+#define CTRAN_LOG_ERR(...) \
+  CTRAN_LOG_IMPL(::spdlog::level::err, SPDLOG_LOGGER_ERROR, __VA_ARGS__)
+#define CTRAN_LOG_CRITICAL(...) \
+  CTRAN_LOG_IMPL(::spdlog::level::critical, SPDLOG_LOGGER_CRITICAL, __VA_ARGS__)
+#define CTRAN_LOG_FATAL(...)                                             \
+  do {                                                                   \
+    static auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger( \
+        ::ctran::logging::kCtranLoggerName);                             \
+    COMMS_LOG_FATAL_IMPL(_ctran_logger, __VA_ARGS__);                    \
+  } while (false)
+#define CTRAN_LOG(level, ...) CTRAN_LOG_##level(__VA_ARGS__)
+#define CTRAN_LOG_STREAM_IF(level, condition) \
+  COMMS_LOG_NAMED_STREAM_IF(                  \
+      ::ctran::logging::kCtranLoggerName, level, condition)
+#define CTRAN_LOG_STREAM(level) \
+  COMMS_LOG_NAMED_STREAM(::ctran::logging::kCtranLoggerName, level)
+
+#define CTRAN_LOG_SYNC_ERR(...)                                          \
+  do {                                                                   \
+    static auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger( \
+        ::ctran::logging::kCtranLoggerName);                             \
+    if (_ctran_logger.should_log(::spdlog::level::err)) {                \
+      _ctran_logger.logSynchronous(                                      \
+          ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION},     \
+          ::spdlog::level::err,                                          \
+          __VA_ARGS__);                                                  \
+    }                                                                    \
+  } while (false)
+
+#define CTRAN_LOG_IF_IMPL(level, spdlog_level, condition, ...)           \
+  do {                                                                   \
+    static auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger( \
+        ::ctran::logging::kCtranLoggerName);                             \
+    if (_ctran_logger.should_log(spdlog_level) && (condition)) {         \
+      CTRAN_LOG(level, __VA_ARGS__);                                     \
+    }                                                                    \
   } while (false)
 
 #define CTRAN_LOG_IF_WARN(condition, ...) \
@@ -59,7 +88,7 @@ inline constexpr std::string_view kCtranLoggerName = "comms.ctran";
 
 #define CTRAN_LOG_FIRST_N_IMPL(level, spdlog_level, n, ...)                    \
   do {                                                                         \
-    auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger(              \
+    static auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger(       \
         ::ctran::logging::kCtranLoggerName);                                   \
     if (_ctran_logger.should_log(spdlog_level) && [&] {                        \
           struct ctran_log_first_n_tag {};                                     \

--- a/comms/ctran/utils/Debug.h
+++ b/comms/ctran/utils/Debug.h
@@ -4,6 +4,7 @@
 
 #include <sstream>
 
+#include <folly/String.h>
 #include <folly/system/ThreadName.h>
 
 #include "comms/ctran/utils/CtranLogUtils.h"

--- a/comms/ctran/utils/LogInit.cc
+++ b/comms/ctran/utils/LogInit.cc
@@ -18,23 +18,27 @@ folly::once_flag ctranLoggingInitOnceFlag;
 
 void initCtranLoggingImpl() {
   meta::comms::logger::initCommLogging();
-  meta::comms::logger::configureSpdlogLogger(
+  const auto logFilePath =
+      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str());
+  const auto threadContextFn = []() {
+    int cudaDev = -1;
+    (void)cudaGetDevice(&cudaDev);
+    return cudaDev;
+  };
+  const auto errorCallback = [](std::string_view message) {
+    meta::comms::logger::setLastError(std::string{message}, {});
+  };
+  const auto logLevel = meta::comms::logger::loggerLevelToSpdlogLevel(
+      meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG));
+
+  meta::comms::logger::configureCommsAndNamedSpdlogLoggers(
       kCtranLoggerName,
       "CTRAN",
-      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
-      []() {
-        int cudaDev = -1;
-        (void)cudaGetDevice(&cudaDev);
-        return cudaDev;
-      },
-      [](std::string_view message) {
-        meta::comms::logger::setLastError(std::string{message}, {});
-      },
-      NCCL_DEBUG_LOGGING_ASYNC);
-  meta::comms::logger::getSpdlogLogger(kCtranLoggerName)
-      .set_level(
-          meta::comms::logger::loggerLevelToSpdlogLevel(
-              meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
+      logFilePath,
+      threadContextFn,
+      errorCallback,
+      NCCL_DEBUG_LOGGING_ASYNC,
+      logLevel);
 }
 } // anonymous namespace
 

--- a/comms/ncclx/meta/NcclxLogUtils.h
+++ b/comms/ncclx/meta/NcclxLogUtils.h
@@ -4,11 +4,22 @@
 
 #include <fmt/format.h>
 
-#include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/LogTypes.h"
+#include "comms/utils/logger/LoggingFormat.h"
 #include "meta/NcclxLogger.h"
 
-#define NCCLX_LOG_SUBSYS(level, subsys, ...) \
-  NCCLX_LOG_IF(level, CLOGF_ENABLED(subsys), __VA_ARGS__)
+#define NCCLX_LOG_SUBSYS(level, subsys, ...)            \
+  NCCLX_LOG_IF(                                         \
+      level,                                            \
+      ::meta::comms::logger::isEnabledSubSystemBitwise( \
+          static_cast<uint64_t>([]() {                  \
+            using namespace ::meta::comms::logger;      \
+            return subsys;                              \
+          }())),                                        \
+      __VA_ARGS__)
+
+#define NCCLX_LOG_STREAM_EVERY_MS(level, ms) \
+  COMMS_LOG_NAMED_STREAM_EVERY_MS(::ncclx::logging::kNcclxLoggerName, level, ms)
 
 #define NCCLX_ERR(code, ...)                                                  \
   do {                                                                        \

--- a/comms/ncclx/meta/NcclxLogger.h
+++ b/comms/ncclx/meta/NcclxLogger.h
@@ -13,16 +13,45 @@ inline constexpr std::string_view kNcclxLoggerName = "comms.ncclx";
 
 } // namespace ncclx::logging
 
-#define NCCLX_LOG(level, ...) \
-  COMMS_LOG_NAMED(::ncclx::logging::kNcclxLoggerName, level, __VA_ARGS__)
+#define NCCLX_LOG_IMPL(spdlog_level, spdlog_macro, ...)                  \
+  do {                                                                   \
+    static auto& _ncclx_logger = ::meta::comms::logger::getSpdlogLogger( \
+        ::ncclx::logging::kNcclxLoggerName);                             \
+    if (_ncclx_logger.should_log(spdlog_level)) {                        \
+      spdlog_macro(&_ncclx_logger, __VA_ARGS__);                         \
+    }                                                                    \
+  } while (false)
 
-#define NCCLX_LOG_IF_IMPL(level, spdlog_level, condition, ...)    \
-  do {                                                            \
-    auto& _ncclx_logger = ::meta::comms::logger::getSpdlogLogger( \
-        ::ncclx::logging::kNcclxLoggerName);                      \
-    if (_ncclx_logger.should_log(spdlog_level) && (condition)) {  \
-      NCCLX_LOG(level, __VA_ARGS__);                              \
-    }                                                             \
+#define NCCLX_LOG_DBG(...) \
+  NCCLX_LOG_IMPL(::spdlog::level::debug, COMMS_LOGGER_DEBUG, __VA_ARGS__)
+#define NCCLX_LOG_INFO(...) \
+  NCCLX_LOG_IMPL(::spdlog::level::info, SPDLOG_LOGGER_INFO, __VA_ARGS__)
+#define NCCLX_LOG_WARN(...) \
+  NCCLX_LOG_IMPL(::spdlog::level::warn, SPDLOG_LOGGER_WARN, __VA_ARGS__)
+#define NCCLX_LOG_ERR(...) \
+  NCCLX_LOG_IMPL(::spdlog::level::err, SPDLOG_LOGGER_ERROR, __VA_ARGS__)
+#define NCCLX_LOG_CRITICAL(...) \
+  NCCLX_LOG_IMPL(::spdlog::level::critical, SPDLOG_LOGGER_CRITICAL, __VA_ARGS__)
+#define NCCLX_LOG_FATAL(...)                                             \
+  do {                                                                   \
+    static auto& _ncclx_logger = ::meta::comms::logger::getSpdlogLogger( \
+        ::ncclx::logging::kNcclxLoggerName);                             \
+    COMMS_LOG_FATAL_IMPL(_ncclx_logger, __VA_ARGS__);                    \
+  } while (false)
+#define NCCLX_LOG(level, ...) NCCLX_LOG_##level(__VA_ARGS__)
+#define NCCLX_LOG_STREAM_IF(level, condition) \
+  COMMS_LOG_NAMED_STREAM_IF(                  \
+      ::ncclx::logging::kNcclxLoggerName, level, condition)
+#define NCCLX_LOG_STREAM(level) \
+  COMMS_LOG_NAMED_STREAM(::ncclx::logging::kNcclxLoggerName, level)
+
+#define NCCLX_LOG_IF_IMPL(level, spdlog_level, condition, ...)           \
+  do {                                                                   \
+    static auto& _ncclx_logger = ::meta::comms::logger::getSpdlogLogger( \
+        ::ncclx::logging::kNcclxLoggerName);                             \
+    if (_ncclx_logger.should_log(spdlog_level) && (condition)) {         \
+      NCCLX_LOG(level, __VA_ARGS__);                                     \
+    }                                                                    \
   } while (false)
 
 #define NCCLX_LOG_IF_WARN(condition, ...) \
@@ -47,7 +76,7 @@ inline constexpr std::string_view kNcclxLoggerName = "comms.ncclx";
 
 #define NCCLX_LOG_FIRST_N_IMPL(level, spdlog_level, n, ...)                    \
   do {                                                                         \
-    auto& _ncclx_logger = ::meta::comms::logger::getSpdlogLogger(              \
+    static auto& _ncclx_logger = ::meta::comms::logger::getSpdlogLogger(       \
         ::ncclx::logging::kNcclxLoggerName);                                   \
     if (_ncclx_logger.should_log(spdlog_level) && [&] {                        \
           struct ncclx_log_first_n_tag {};                                     \

--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <string>
 
 #include <folly/Conv.h>
 #include <folly/Synchronized.h>
@@ -22,6 +23,7 @@
 #include "comms/utils/colltrace/plugins/WatchdogPlugin.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/NcclxChecks.h"
+#include "meta/NcclxLogger.h"
 #include "meta/hints/GlobalHints.h"
 #include "meta/wrapper/DataTypeConv.h"
 
@@ -388,6 +390,7 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
     auto commDumpPlugin =
         std::make_unique<meta::comms::colltrace::CommDumpPlugin>(
             meta::comms::colltrace::CommDumpConfig{
+                .loggerName = std::string{::ncclx::logging::kNcclxLoggerName},
                 .pastCollSize = NCCL_COLLTRACE_RECORD_MAX,
                 .pendingCollSize = NCCL_COLLTRACE_PENDING_QUEUE_SIZE,
             });
@@ -399,6 +402,7 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
         std::make_unique<meta::comms::colltrace::LifecycleEventFeedPlugin>(
             meta::comms::colltrace::LifecycleEventFeedConfig{
                 .commId = getNextLifecycleFeedCommId(),
+                .loggerName = std::string{::ncclx::logging::kNcclxLoggerName},
             }));
   }
 
@@ -415,6 +419,7 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
     auto watchdogPlugin =
         std::make_unique<meta::comms::colltrace::WatchdogPlugin>(
             meta::comms::colltrace::WatchdogPluginConfig{
+                .loggerName = std::string{::ncclx::logging::kNcclxLoggerName},
                 .checkAsyncError = ifCheckAsync,
                 .funcIfError =
                     [comm]() {
@@ -434,6 +439,7 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
 
   auto colltraceNew = std::make_shared<meta::comms::colltrace::CollTrace>(
       meta::comms::colltrace::CollTraceConfig{
+          .loggerName = std::string{::ncclx::logging::kNcclxLoggerName},
           .maxCheckCancelInterval =
               std::chrono::milliseconds{NCCL_COLLTRACE_WAKEUP_INTERVAL_MS},
       },

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
@@ -243,14 +243,16 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorFromGPE) {
   auto srcRank = (rank - 1 + worldSize) % worldSize;
   auto dstRank = (rank + 1) % worldSize;
 
-  NCCLCHECK_FATAL(
+  // These calls intentionally provoke a GPE failure. Do not terminate on an
+  // immediate API error; the behavior under test is the communicator's async
+  // error being observed and reported by the production watchdog.
 #if NCCL_MINOR >= 29
-      ncclx::ncclPutSignal(
-          sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw()));
-  NCCLCHECK_FATAL(ncclx::ncclWaitSignal(srcRank, win, stream.raw()));
+  (void)ncclx::ncclPutSignal(
+      sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw());
+  (void)ncclx::ncclWaitSignal(srcRank, win, stream.raw());
 #else
-      ncclPutSignal(sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw()));
-  NCCLCHECK_FATAL(ncclWaitSignal(srcRank, win, stream.raw()));
+  (void)ncclPutSignal(sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw());
+  (void)ncclWaitSignal(srcRank, win, stream.raw());
 #endif
   waitStreamWithTimeout(stream.raw(), std::chrono::seconds{80});
 }

--- a/comms/ncclx/meta/logger/tests/LoggingUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggingUT.cc
@@ -5,7 +5,6 @@
 #include <fmt/format.h>
 #include <folly/FileUtil.h>
 #include <folly/ScopeGuard.h>
-#include <folly/logging/LogMessage.h>
 #include <folly/testing/TestUtil.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -14,6 +13,7 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/Logger.h"
 #include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 #include "meta/NcclxChecks.h"
 
 #include "debug.h" // @manual
@@ -571,7 +571,7 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
   // tempFile lives in a TemporaryDirectory that is deleted at test end, so the
   // OS env var must be unset on scope exit (even on the ASSERT_TRUE
   // early-return below) or a later test's ncclCvarInit() would reload this
-  // stale path and NcclLogger would fail to open the deleted file.
+  // stale path and the next logger initialization would fail to open it.
   auto debugFileEnvGuard =
       folly::makeGuard([]() { unsetenv("NCCL_DEBUG_FILE"); });
   ncclResetDebugInit();
@@ -583,6 +583,7 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
   constexpr std::string_view TestStr = "RAW TESTING";
   constexpr std::string_view TestStr2 = "TESTING";
   constexpr std::string_view SpdlogTestStr = "SPDLOG TESTING";
+  constexpr std::string_view SharedSpdlogTestStr = "SHARED SPDLOG TESTING";
 
   testing::internal::CaptureStderr();
 
@@ -597,10 +598,16 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
   NCCLX_LOG(INFO, "{}", SpdlogTestStr);
   NCCLX_LOG(WARN, "{}", SpdlogTestStr);
   NCCLX_LOG(ERR, "{}", SpdlogTestStr);
+  COMMS_LOG(INFO, "{}", SharedSpdlogTestStr);
+  COMMS_LOG(WARN, "{}", SharedSpdlogTestStr);
+  COMMS_LOG(ERR, "{}", SharedSpdlogTestStr);
   auto& spdlogLogger =
       meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName);
+  auto& sharedSpdlogLogger = meta::comms::logger::getSpdlogLogger();
   EXPECT_EQ(spdlogLogger.usesAsyncLogging(), NCCL_DEBUG_LOGGING_ASYNC);
+  EXPECT_EQ(sharedSpdlogLogger.usesAsyncLogging(), NCCL_DEBUG_LOGGING_ASYNC);
   spdlogLogger.flush();
+  sharedSpdlogLogger.flush();
 
   auto stderrOutput = testing::internal::GetCapturedStderr();
 
@@ -617,6 +624,10 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
     EXPECT_THAT(
         fileContents,
         testing::HasSubstr(fmt::format("NCCL {} {}", level, SpdlogTestStr)));
+    EXPECT_THAT(
+        fileContents,
+        testing::HasSubstr(
+            fmt::format("COMM {} {}", level, SharedSpdlogTestStr)));
     if (level != "INFO") {
       // When logging to file, we should also log to stderr for WARN and ERROR
       EXPECT_THAT(
@@ -628,6 +639,10 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
       EXPECT_THAT(
           stderrOutput,
           testing::HasSubstr(fmt::format("NCCL {} {}", level, SpdlogTestStr)));
+      EXPECT_THAT(
+          stderrOutput,
+          testing::HasSubstr(
+              fmt::format("COMM {} {}", level, SharedSpdlogTestStr)));
     }
   }
 }
@@ -856,57 +871,3 @@ TEST_F(NcclLoggerTest, SecondErrorUpdatesMessageKeepsAppendedStack) {
 }
 
 #endif // NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
-
-TEST_F(NcclLoggerTest, PreservesSharedUtilsLogHandler) {
-  ncclResetDebugInit();
-
-  ncclCvarInit();
-  auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"INFO"});
-  setenv("NCCL_DEBUG", "INFO", 1);
-
-  initLogging();
-  auto utilsCategory = folly::LoggerDB::get().getCategory("comms.utils");
-  ASSERT_THAT(utilsCategory, ::testing::NotNull());
-  EXPECT_EQ(utilsCategory->getHandlers().size(), 1);
-
-  NcclLogger::init(
-      // TODO: Change the context name when ctran is refactored out of NCCLX
-      // Otherwise the logging will no longer work as intended.
-      {.contextName = "comms.ncclx.v2_25.meta.logger.tests",
-       .logPrefix = "LOGGER",
-       .logFilePath =
-           meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
-       .logLevel = meta::comms::logger::loggerLevelToFollyLogLevel(
-           meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
-       .threadContextFn = []() {
-         int cudaDev = -1;
-         cudaGetDevice(&cudaDev);
-         return cudaDev;
-       }});
-  auto utilsCategory2 = folly::LoggerDB::get().getCategory("comms.utils");
-  ASSERT_THAT(utilsCategory, ::testing::NotNull());
-  EXPECT_EQ(utilsCategory, utilsCategory2);
-  EXPECT_EQ(utilsCategory->getHandlers().size(), 1);
-
-  utilsCategory->admitMessage(
-      folly::LogMessage(
-          utilsCategory,
-          folly::LogLevel::INFO,
-          std::chrono::system_clock::now(),
-          "test",
-          123,
-          "UtilsTest",
-          "testing testing 123"));
-
-  std::string TestStr = "TESTING";
-
-  XLOG(INFO) << "RAW LOG TEST";
-  XLOG(WARN) << "RAW LOG TEST";
-  XLOG(ERR) << "RAW LOG TEST";
-
-  INFO(NCCL_ALL, "%s", TestStr.c_str());
-  WARN("%s", TestStr.c_str());
-  ERR(ncclInternalError, "%s", TestStr.c_str());
-
-  finishLogging();
-}

--- a/comms/ncclx/v2_29/src/misc/param.cc
+++ b/comms/ncclx/v2_29/src/misc/param.cc
@@ -23,8 +23,8 @@
 #include <unordered_set>
 #include "os.h"
 
-#include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/LoggerRuntime.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/InitFolly.h"
 #include "meta/NcclxLogger.h"
@@ -159,22 +159,26 @@ const char* ncclGetEnv(const char* name) {
 }
 
 void initNcclLogger() {
-  // Shared CollTrace code still emits raw XLOG under comms.utils.
-  meta::comms::logger::initCommLogging();
-  meta::comms::logger::configureSpdlogLogger(
+  meta::comms::logger::initCommLoggerRuntime();
+  const auto logFilePath =
+      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str());
+  const auto threadContextFn = []() {
+    int cudaDev = -1;
+    (void)cudaGetDevice(&cudaDev);
+    return cudaDev;
+  };
+  const auto errorCallback = [](std::string_view message) {
+    meta::comms::logger::setLastError(std::string{message}, {});
+  };
+  const auto logLevel = meta::comms::logger::loggerLevelToSpdlogLevel(
+      meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG));
+
+  meta::comms::logger::configureCommsAndNamedSpdlogLoggers(
       ncclx::logging::kNcclxLoggerName,
       "NCCL",
-      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
-      []() {
-        int cudaDev = -1;
-        (void)cudaGetDevice(&cudaDev);
-        return cudaDev;
-      },
-      [](std::string_view message) {
-        meta::comms::logger::setLastError(std::string{message}, {});
-      },
-      NCCL_DEBUG_LOGGING_ASYNC);
-  meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName)
-      .set_level(meta::comms::logger::loggerLevelToSpdlogLevel(
-          meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
+      logFilePath,
+      threadContextFn,
+      errorCallback,
+      NCCL_DEBUG_LOGGING_ASYNC,
+      logLevel);
 }

--- a/comms/ncclx/v2_30/src/misc/param.cc
+++ b/comms/ncclx/v2_30/src/misc/param.cc
@@ -20,8 +20,8 @@
 #include <unordered_set>
 #include "os.h"
 
-#include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/LoggerRuntime.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/InitFolly.h"
 #include "meta/NcclxLogger.h"
@@ -122,22 +122,26 @@ const char* ncclGetEnv(const char* name) {
 }
 
 void initNcclLogger() {
-  // Shared CollTrace code still emits raw XLOG under comms.utils.
-  meta::comms::logger::initCommLogging();
-  meta::comms::logger::configureSpdlogLogger(
+  meta::comms::logger::initCommLoggerRuntime();
+  const auto logFilePath =
+      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str());
+  const auto threadContextFn = []() {
+    int cudaDev = -1;
+    (void)cudaGetDevice(&cudaDev);
+    return cudaDev;
+  };
+  const auto errorCallback = [](std::string_view message) {
+    meta::comms::logger::setLastError(std::string{message}, {});
+  };
+  const auto logLevel = meta::comms::logger::loggerLevelToSpdlogLevel(
+      meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG));
+
+  meta::comms::logger::configureCommsAndNamedSpdlogLoggers(
       ncclx::logging::kNcclxLoggerName,
       "NCCL",
-      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
-      []() {
-        int cudaDev = -1;
-        (void)cudaGetDevice(&cudaDev);
-        return cudaDev;
-      },
-      [](std::string_view message) {
-        meta::comms::logger::setLastError(std::string{message}, {});
-      },
-      NCCL_DEBUG_LOGGING_ASYNC);
-  meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName)
-      .set_level(meta::comms::logger::loggerLevelToSpdlogLevel(
-          meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
+      logFilePath,
+      threadContextFn,
+      errorCallback,
+      NCCL_DEBUG_LOGGING_ASYNC,
+      logLevel);
 }

--- a/comms/torchcomms/ncclx/CMakeLists.txt
+++ b/comms/torchcomms/ncclx/CMakeLists.txt
@@ -124,6 +124,12 @@ target_include_directories(torchcomms_comms_ncclx PRIVATE
 )
 torchcomms_use_torch_pybind11(torchcomms_comms_ncclx)
 target_compile_features(torchcomms_comms_ncclx PRIVATE cxx_std_20)
+# CudaRAII.cc includes SpdlogLogger.h directly, so this target must carry
+# the logger's compile-time configuration instead of relying on CTRAN.
+target_compile_definitions(torchcomms_comms_ncclx PRIVATE
+    SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO
+    SPDLOG_FMT_EXTERNAL
+)
 
 # Add device API compile definition if headers are available
 if(TORCHCOMMS_HAS_NCCL_DEVICE_API)

--- a/comms/utils/CommsMaybeChecks.h
+++ b/comms/utils/CommsMaybeChecks.h
@@ -2,48 +2,45 @@
 
 #pragma once
 
-#include <fmt/format.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
-#define EXPECT_CHECK_ALWAYS_RETURN(cmd)                             \
-  {                                                                 \
-    const auto res = cmd;                                           \
-    if (res.hasError()) {                                           \
-      XLOG(ERR) << fmt::format(                                     \
-          "Call for {} failed with {}", #cmd, res.error().message); \
-      return folly::makeUnexpected(std::move(res.error()));         \
-    }                                                               \
-    return res;                                                     \
+#define EXPECT_CHECK_ALWAYS_RETURN(cmd)                                        \
+  {                                                                            \
+    const auto res = cmd;                                                      \
+    if (res.hasError()) {                                                      \
+      COMMS_LOG(ERR, "Call for {} failed with {}", #cmd, res.error().message); \
+      return folly::makeUnexpected(std::move(res.error()));                    \
+    }                                                                          \
+    return res;                                                                \
   }
 
-#define EXPECT_CHECK(cmd)                                           \
-  {                                                                 \
-    const auto res = cmd;                                           \
-    if (res.hasError()) {                                           \
-      XLOG(ERR) << fmt::format(                                     \
-          "Call for {} failed with {}", #cmd, res.error().message); \
-      return folly::makeUnexpected(std::move(res.error()));         \
-    }                                                               \
+#define EXPECT_CHECK(cmd)                                                      \
+  {                                                                            \
+    const auto res = cmd;                                                      \
+    if (res.hasError()) {                                                      \
+      COMMS_LOG(ERR, "Call for {} failed with {}", #cmd, res.error().message); \
+      return folly::makeUnexpected(std::move(res.error()));                    \
+    }                                                                          \
   }
 
-#define EXPECT_CHECK_LOG_FIRST_N(n, cmd)                            \
-  {                                                                 \
-    const auto res = cmd;                                           \
-    if (res.hasError()) {                                           \
-      XLOG_FIRST_N(ERR, n) << fmt::format(                          \
-          "Call for {} failed with {}", #cmd, res.error().message); \
-      return folly::makeUnexpected(std::move(res.error()));         \
-    }                                                               \
+#define EXPECT_CHECK_LOG_FIRST_N(n, cmd)                                    \
+  {                                                                         \
+    const auto res = cmd;                                                   \
+    if (res.hasError()) {                                                   \
+      COMMS_LOG_STREAM_FIRST_N(ERR, n)                                      \
+          << "Call for " << #cmd << " failed with " << res.error().message; \
+      return folly::makeUnexpected(std::move(res.error()));                 \
+    }                                                                       \
   }
 
-#define EXPECT_CHECK_CONTINUE_LOG_FIRST_N(cmd, n)                   \
-  {                                                                 \
-    const auto res = cmd;                                           \
-    if (res.hasError()) {                                           \
-      XLOG_FIRST_N(ERR, n) << fmt::format(                          \
-          "Call for {} failed with {}", #cmd, res.error().message); \
-      continue;                                                     \
-    }                                                               \
+#define EXPECT_CHECK_CONTINUE_LOG_FIRST_N(cmd, n)                           \
+  {                                                                         \
+    const auto res = cmd;                                                   \
+    if (res.hasError()) {                                                   \
+      COMMS_LOG_STREAM_FIRST_N(ERR, n)                                      \
+          << "Call for " << #cmd << " failed with " << res.error().message; \
+      continue;                                                             \
+    }                                                                       \
   }
 
 #define EXPECT_CHECK_RES(res)                               \

--- a/comms/utils/CudaChecks.h
+++ b/comms/utils/CudaChecks.h
@@ -8,7 +8,7 @@
 
 #include <fmt/format.h>
 
-#include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #if CUDART_VERSION >= 11030
 #include <cudaTypedefs.h>
@@ -36,7 +36,7 @@ inline FuncPtr loadDriverFunction(const char* funcName, int version) {
       cudaEnableDefault,
       &driverStatus);
   if (res != cudaSuccess || driverStatus != cudaDriverEntryPointSuccess) {
-    CLOGF(
+    COMMS_LOG(
         WARN,
         "Failed to load CUDA driver symbol {} version {} (cudaError={}, status={})",
         funcName,
@@ -54,7 +54,7 @@ inline FuncPtr loadDriverFunction(const char* funcName, int version) {
       cudaEnableDefault,
       &driverStatus);
   if (res != cudaSuccess || driverStatus != cudaDriverEntryPointSuccess) {
-    CLOGF(
+    COMMS_LOG(
         WARN,
         "Failed to load CUDA driver symbol {} version {} (cudaError={}, status={})",
         funcName,
@@ -67,7 +67,7 @@ inline FuncPtr loadDriverFunction(const char* funcName, int version) {
   cudaError_t res = cudaGetDriverEntryPoint(
       funcName, reinterpret_cast<void**>(&func), cudaEnableDefault);
   if (res != cudaSuccess) {
-    CLOGF(
+    COMMS_LOG(
         WARN,
         "Failed to load CUDA driver symbol {} version {} (cudaError={})",
         funcName,
@@ -144,7 +144,7 @@ inline CUresult cuMemGetAddressRangeDynamic(
     CUresult err = cmd;                                                        \
     if (err != CUDA_SUCCESS) {                                                 \
       const char* errStr = ::comms::utils::cuda::getCuErrorString(err);        \
-      CLOGF(ERR, "Cuda failure {} '{}'", static_cast<int>(err), errStr);       \
+      COMMS_LOG(ERR, "Cuda failure {} '{}'", static_cast<int>(err), errStr);   \
       throw std::runtime_error(                                                \
           fmt::format("Cuda failure {} '{}'", static_cast<int>(err), errStr)); \
     }                                                                          \

--- a/comms/utils/CudaRAII.cc
+++ b/comms/utils/CudaRAII.cc
@@ -2,6 +2,7 @@
 
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/checks.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <stdexcept>
 #include <string>
@@ -136,8 +137,9 @@ CudaDeviceGuard::~CudaDeviceGuard() {
   }
   const auto status = cudaSetDevice(previousDevice_);
   if (status != cudaSuccess) {
-    XLOG(ERR) << "CudaDeviceGuard: failed to restore CUDA device "
-              << previousDevice_ << ": " << cudaGetErrorString(status);
+    COMMS_LOG_STREAM(ERR) << "CudaDeviceGuard: failed to restore CUDA device "
+                          << previousDevice_ << ": "
+                          << cudaGetErrorString(status);
   }
 }
 

--- a/comms/utils/checks.h
+++ b/comms/utils/checks.h
@@ -7,12 +7,10 @@
 #include <stdexcept>
 
 #include <fmt/format.h>
-#include <folly/String.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/utils/Conversion.h"
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/LoggingFormat.h"
 
 // Base case
 template <typename... ErrorCodes>
@@ -49,7 +47,8 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
   {                                                         \
     const auto res = cmd;                                   \
     if (!inCudaErrorCodes(res, cudaSuccess, __VA_ARGS__)) { \
-      XLOG(FATAL) << fmt::format(                           \
+      COMMS_LOG(                                            \
+          FATAL,                                            \
           "CUDA error: {}:{} {}",                           \
           __FILE__,                                         \
           __LINE__,                                         \
@@ -61,7 +60,8 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
   {                                 \
     const auto err = cmd;           \
     if (err != cudaSuccess) {       \
-      XLOG(FATAL) << fmt::format(   \
+      COMMS_LOG(                    \
+          FATAL,                    \
           "CUDA error: {}:{} {}",   \
           __FILE__,                 \
           __LINE__,                 \
@@ -73,7 +73,7 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
   {                                                                   \
     const auto err = cmd;                                             \
     if (err != cudaSuccess) {                                         \
-      CERR(commUnhandledCudaError, "Call for {} failed", #cmd);       \
+      COMMS_ERR(commUnhandledCudaError, "Call for {} failed", #cmd);  \
       return folly::makeUnexpected(                                   \
           getCommsErrorFromCudaError(err, __FILE__, __LINE__, #cmd)); \
     }                                                                 \
@@ -83,7 +83,8 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
   {                                 \
     const auto err = cmd;           \
     if (err != ncclSuccess) {       \
-      XLOG(FATAL) << fmt::format(   \
+      COMMS_LOG(                    \
+          FATAL,                    \
           "NCCL error: {}:{} {}",   \
           __FILE__,                 \
           __LINE__,                 \
@@ -101,7 +102,7 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
   do {                                                              \
     cudaError_t err = cmd;                                          \
     if (err != cudaSuccess) {                                       \
-      CERR(                                                         \
+      COMMS_ERR(                                                    \
           commUnhandledCudaError,                                   \
           "{}:{} Cuda failure {}",                                  \
           __FILE__,                                                 \
@@ -123,7 +124,7 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
 #define FOLLY_EXPECTED_CHECKTHROW(RES)                                  \
   do {                                                                  \
     if (RES.hasError()) {                                               \
-      CLOGF(                                                            \
+      COMMS_LOG(                                                        \
           ERR,                                                          \
           "{}:{} -> {} ({})",                                           \
           __FILE__,                                                     \
@@ -145,7 +146,7 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
   do {                                                 \
     commResult_t RES = cmd;                            \
     if (RES != commSuccess && RES != commInProgress) { \
-      CLOGF(                                           \
+      COMMS_LOG(                                       \
           ERR,                                         \
           "{}:{} -> {} ({})",                          \
           __FILE__,                                    \
@@ -170,7 +171,7 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
     if (!(statement)) {                                                        \
       auto errorMsg =                                                          \
           fmt::format("Check failed: {} - {}", #statement, __VA_ARGS__);       \
-      CERR(commInternalError, "{}", errorMsg);                                 \
+      COMMS_ERR(commInternalError, "{}", errorMsg);                            \
       throw std::runtime_error(                                                \
           fmt::format(                                                         \
               "Check failed: {} - {}", #statement, fmt::format(__VA_ARGS__))); \
@@ -185,7 +186,7 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
  */
 #define FB_ERRORTHROW(error, ...)                \
   do {                                           \
-    CLOGF(ERR, ##__VA_ARGS__);                   \
+    COMMS_LOG(ERR, ##__VA_ARGS__);               \
     throw std::runtime_error(                    \
         std::string("COMM internal failure: ") + \
         ::meta::comms::commCodeToString(error)); \

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -6,7 +6,6 @@
 
 #include <fmt/core.h>
 #include <folly/json.h>
-#include <folly/logging/xlog.h>
 #include <folly/stop_watch.h>
 
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
@@ -20,6 +19,7 @@
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace meta::comms::colltrace {
 
@@ -76,30 +76,31 @@ const std::string& graphColltraceUnsupportedReason() {
 
 } // namespace
 
-bool graphColltraceSupported(std::string_view logPrefix) {
+bool graphColltraceSupported(
+    std::string_view logPrefix,
+    std::string_view loggerName) {
   const auto& reason = graphColltraceUnsupportedReason();
   if (reason.empty()) {
     return true;
   }
-  XLOG_FIRST_N(WARNING, 1) << logPrefix << ": graph colltrace disabled -- "
-                           << reason;
+  auto& logger = logger::getSpdlogLogger(loggerName);
+  COMMS_LOGGER_STREAM_FIRST_N(logger, WARNING, 1)
+      << logPrefix << ": graph colltrace disabled -- " << reason;
   return false;
 }
 
 template <auto Method>
 void triggerPlugins(
+    logger::CommsSpdlogLogger& logger,
     std::vector<std::unique_ptr<ICollTracePlugin>>& plugins,
     CollTraceEvent& curEvent) noexcept {
   for (auto& plugin : plugins) {
     CommsMaybeVoid res = ((*plugin).*Method)(curEvent);
     if (res.hasError()) {
-      XLOG_FIRST_N(
-          ERR,
-          10,
-          "Exception thrown in plugin {} when calling method {}: {}",
-          plugin->getName(),
-          typeid(Method).name(),
-          res.error().message);
+      COMMS_LOGGER_STREAM_FIRST_N(logger, ERR, 10)
+          << "Exception thrown in plugin " << plugin->getName()
+          << " when calling method " << typeid(Method).name() << ": "
+          << res.error().message;
     }
   }
 }
@@ -110,6 +111,7 @@ CollTrace::CollTrace(
     std::function<CommsMaybeVoid(void)> threadSetupFunc,
     std::vector<std::unique_ptr<ICollTracePlugin>> plugins)
     : config_(std::move(config)),
+      logger_(&logger::getSpdlogLogger(config_.loggerName)),
       logMetaData_(std::move(logMetaData)),
       logPrefix_(
           fmt::format(
@@ -121,7 +123,8 @@ CollTrace::CollTrace(
           folly::MPMCQueue<std::unique_ptr<CollTraceEvent>>{
               config_.maxPendingQueueSize}),
       plugins_(std::move(plugins)) {
-  if (NCCL_COLLTRACE_TRACE_CUDA_GRAPH && graphColltraceSupported(logPrefix_)) {
+  if (NCCL_COLLTRACE_TRACE_CUDA_GRAPH &&
+      graphColltraceSupported(logPrefix_, config_.loggerName)) {
     // Eagerly initialize the globaltimer calibration singleton now (outside
     // graph capture) so it is ready when GraphCudaWaitEvent is constructed
     // during capture.
@@ -136,8 +139,10 @@ CollTrace::CollTrace(
     }
     uint32_t ringSize =
         std::max(kDefaultRingSize, static_cast<uint32_t>(maxRetention) * 2);
-    XLOGF(
-        DBG0,
+    COMMS_LOG_IMPL(
+        *logger_,
+        ::spdlog::level::debug,
+        COMMS_LOGGER_DEBUG,
         "{}: graph ring buffer sized to {} entries (max plugin retention={}, "
         "default={})",
         logPrefix_,
@@ -149,8 +154,8 @@ CollTrace::CollTrace(
     if (ringBuffer_->valid()) {
       ringReader_.emplace(*ringBuffer_);
     } else {
-      XLOG_FIRST_N(ERR, 1) << logPrefix_
-                           << ": Failed to allocate shared ring buffer";
+      COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 1)
+          << logPrefix_ << ": Failed to allocate shared ring buffer";
       ringBuffer_.reset();
     }
   }
@@ -158,7 +163,8 @@ CollTrace::CollTrace(
   // pluginByName_ is not used in the colltrace thread. It is okay to initialize
   // it after the colltrace thread starts
   for (const auto& plugin : plugins_) {
-    XLOG(DBG0) << "Registering plugin " << plugin->getName();
+    COMMS_LOGGER_STREAM(*logger_, DBG)
+        << "Registering plugin " << plugin->getName();
     pluginByName_.emplace(plugin->getName(), *plugin);
   }
 
@@ -250,8 +256,9 @@ std::shared_ptr<GraphCollTraceState> CollTrace::getOrCreateGraphState(
 
   if (createRes != cudaSuccess) {
     delete prevent_free;
-    XLOG_FIRST_N(WARN, 1) << "Failed to create graph cleanup user object: "
-                          << cudaGetErrorString(createRes);
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, WARN, 1)
+        << "Failed to create graph cleanup user object: "
+        << cudaGetErrorString(createRes);
     return nullptr;
   }
 
@@ -262,8 +269,9 @@ std::shared_ptr<GraphCollTraceState> CollTrace::getOrCreateGraphState(
         cudaUserObjectRelease(userObject, 1),
         cudaErrorCudartUnloading,
         cudaErrorContextIsDestroyed);
-    XLOG_FIRST_N(WARN, 1) << "Failed to retain graph user object: "
-                          << cudaGetErrorString(retainRes);
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, WARN, 1)
+        << "Failed to retain graph user object: "
+        << cudaGetErrorString(retainRes);
     return nullptr;
   }
 
@@ -291,14 +299,11 @@ CommsMaybe<std::shared_ptr<ICollTraceHandle>> CollTrace::recordCollective(
   }
 
   if (pendingEnqueueColl_ != nullptr) {
-    XLOG_FIRST_N(
-        ERR,
-        1,
-        fmt::format(
-            "{}: Got another collective enqueued when a previous one haven't finished, colltrace result would be inaccurate. Previous: {}, Next:{}",
-            logPrefix_,
-            folly::toJson(pendingEnqueueColl_->collRecord->toDynamic()),
-            folly::toJson(metadata->toDynamic())));
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 1) << fmt::format(
+        "{}: Got another collective enqueued when a previous one haven't finished, colltrace result would be inaccurate. Previous: {}, Next:{}",
+        logPrefix_,
+        folly::toJson(pendingEnqueueColl_->collRecord->toDynamic()),
+        folly::toJson(metadata->toDynamic()));
     auto handlePtr = eventToHandleMap_.find(pendingEnqueueColl_.get());
     if (handlePtr != eventToHandleMap_.end()) {
       handlePtr->second->invalidate();
@@ -315,7 +320,7 @@ CommsMaybe<std::shared_ptr<ICollTraceHandle>> CollTrace::recordCollective(
       std::make_shared<CollTraceHandle>(this, pendingEnqueueColl_.get());
   eventToHandleMap_.emplace(pendingEnqueueColl_.get(), handle);
   triggerPlugins<&ICollTracePlugin::afterCollRecorded>(
-      plugins_, *pendingEnqueueColl_);
+      *logger_, plugins_, *pendingEnqueueColl_);
   return handle;
 }
 
@@ -335,7 +340,7 @@ CommsMaybeVoid CollTrace::triggerEventState(
       }
       auto beforeKernelRes = collEvent.waitEvent->beforeCollKernelScheduled();
       triggerPlugins<&ICollTracePlugin::beforeCollKernelScheduled>(
-          plugins_, collEvent); // Trigger plugins after calling waitEvent
+          *logger_, plugins_, collEvent); // Trigger after calling waitEvent
       EXPECT_CHECK_ALWAYS_RETURN(beforeKernelRes);
     }
     case CollTraceHandleTriggerState::AfterEnqueueKernel: {
@@ -345,7 +350,7 @@ CommsMaybeVoid CollTrace::triggerEventState(
             commInvalidUsage));
       }
       triggerPlugins<&ICollTracePlugin::afterCollKernelScheduled>(
-          plugins_, collEvent); // Trigger plugins before calling waitEvent
+          *logger_, plugins_, collEvent); // Trigger before calling waitEvent
       EXPECT_CHECK(collEvent.waitEvent->afterCollKernelScheduled());
       collEvent.collRecord->getTimingInfo().setCollEnqueueTs(precisionNow());
       if (pendingTraceColls_.write(std::move(pendingEnqueueColl_))) {
@@ -363,10 +368,8 @@ CommsMaybeVoid CollTrace::triggerEventState(
             "Failed to write to pendingTraceColls_ queue", commInternalError));
       } else {
         // This code should not be reached
-        XLOG_FIRST_N(
-            DBG,
-            1,
-            "pendingEnqueueColl_ is nullptr after write to queue failed");
+        COMMS_LOGGER_STREAM_FIRST_N(*logger_, DBG, 1)
+            << "pendingEnqueueColl_ is nullptr after write to queue failed";
         return folly::makeUnexpected(CommsError(
             "pendingEnqueueColl_ is nullptr after write to pendingTraceColls_ queue",
             commInternalError));
@@ -399,6 +402,7 @@ CollTrace::recordGraphCollectiveImpl(
   // Assign a unique collId for this collective — used to tag entries in
   // the shared ring buffer so the poll thread can dispatch by collective.
   auto collIdVal = collId_.fetch_add(1);
+  rawWaitEvent->setLogger(*logger_);
   rawWaitEvent->setCollId(collIdVal);
 
   if (!ringBuffer_.has_value()) {
@@ -448,7 +452,7 @@ CollTrace::recordGraphCollectiveImpl(
     graphState->collectives.emplace(collId, std::move(collectiveEntry));
   }
   triggerPlugins<&ICollTracePlugin::afterCollRecorded>(
-      plugins_, *registrationEvent);
+      *logger_, plugins_, *registrationEvent);
 
   return handle;
 }
@@ -551,7 +555,7 @@ void CollTrace::pollGraphEvents(
           // start timestamp and resets its timer automatically).
           if (auto [_, inserted] = progressingGraphCollectives_.insert(collId);
               !inserted) {
-            XLOG_EVERY_MS(WARN, 5000)
+            COMMS_LOGGER_STREAM_EVERY_MS(*logger_, WARN, 5000)
                 << logPrefix_ << ": graph collective " << collId
                 << " saw a new start event before the previous end event"
                    " — the end event was likely overwritten (ring too small)";
@@ -595,7 +599,7 @@ void CollTrace::pollGraphEvents(
             graphReplayEvents_.push_back(std::move(replayIt->second));
             inFlightReplays_.erase(replayIt);
           } else {
-            XLOG_EVERY_MS(WARN, 5000)
+            COMMS_LOGGER_STREAM_EVERY_MS(*logger_, WARN, 5000)
                 << logPrefix_ << ": graph collective " << collId
                 << " end event without matching start — dropped";
           }
@@ -604,7 +608,7 @@ void CollTrace::pollGraphEvents(
       /*timeout=*/config_.maxCheckCancelInterval);
 
   if (pollResult.entriesLost > 0) {
-    XLOG_EVERY_MS(WARN, 5000)
+    COMMS_LOGGER_STREAM_EVERY_MS(*logger_, WARN, 5000)
         << logPrefix_ << ": missed " << pollResult.entriesLost
         << " graph replay timestamp(s) (overwritten)";
   }
@@ -693,9 +697,9 @@ void CollTrace::processCompletedEvents(
         // so we just fire the before/after callbacks here
         // in-case plugins depend on them
         triggerPlugins<&ICollTracePlugin::beforeCollKernelScheduled>(
-            plugins_, *action.event);
+            *logger_, plugins_, *action.event);
         triggerPlugins<&ICollTracePlugin::afterCollKernelScheduled>(
-            plugins_, *action.event);
+            *logger_, plugins_, *action.event);
         [[fallthrough]];
       }
       case PendingActionType::kStart: {
@@ -704,7 +708,7 @@ void CollTrace::processCompletedEvents(
               lastCollEndTime_.value());
         }
         triggerPlugins<&ICollTracePlugin::afterCollKernelStart>(
-            plugins_, *action.event);
+            *logger_, plugins_, *action.event);
         break;
       }
       case PendingActionType::kEnd: {
@@ -714,16 +718,16 @@ void CollTrace::processCompletedEvents(
         // collEventProgressing was called unconditionally inside the
         // waitCollEnd loop.
         triggerPlugins<&ICollTracePlugin::collEventProgressing>(
-            plugins_, *action.event);
+            *logger_, plugins_, *action.event);
         triggerPlugins<&ICollTracePlugin::afterCollKernelEnd>(
-            plugins_, *action.event);
+            *logger_, plugins_, *action.event);
         lastCollEndTime_ =
             action.event->collRecord->getTimingInfo().getCollEndTs();
         break;
       }
       case PendingActionType::kProgressing: {
         triggerPlugins<&ICollTracePlugin::collEventProgressing>(
-            plugins_, *action.event);
+            *logger_, plugins_, *action.event);
         break;
       }
     }
@@ -752,11 +756,18 @@ void CollTrace::processCompletedEvents(
 
 void CollTrace::collTraceThread(
     const std::function<CommsMaybeVoid(void)>& threadSetupFunc) {
-  XLOGF(INFO, "{}: Colltrace thread INIT", logPrefix_);
+  COMMS_LOG_IMPL(
+      *logger_,
+      ::spdlog::level::info,
+      SPDLOG_LOGGER_INFO,
+      "{}: Colltrace thread INIT",
+      logPrefix_);
   auto res = threadSetupFunc();
   if (res.hasError()) {
-    XLOGF(
-        ERR,
+    COMMS_LOG_IMPL(
+        *logger_,
+        ::spdlog::level::err,
+        SPDLOG_LOGGER_ERROR,
         "{}: Error in calling colltrace thread setup function: {}",
         logPrefix_,
         res.error().message);
@@ -769,7 +780,12 @@ void CollTrace::collTraceThread(
     return;
   }
 
-  XLOGF(INFO, "{}: CollTrace thread STARTED", logPrefix_);
+  COMMS_LOG_IMPL(
+      *logger_,
+      ::spdlog::level::info,
+      SPDLOG_LOGGER_INFO,
+      "{}: CollTrace thread STARTED",
+      logPrefix_);
 
   bool initialized = false;
 
@@ -797,7 +813,7 @@ void CollTrace::collTraceThread(
           ::hrdw_ring_buffer::GlobaltimerCalibration::get().refresh();
         }
         if (auto* refpt = CudaReferencePoint::tryGet()) {
-          refpt->refresh();
+          refpt->refresh(*logger_);
         }
         lastReanchor = now;
       }

--- a/comms/utils/colltrace/CollTrace.h
+++ b/comms/utils/colltrace/CollTrace.h
@@ -6,6 +6,7 @@
 #include <latch>
 #include <mutex>
 #include <set>
+#include <string>
 #include <string_view>
 #include <thread>
 #include <unordered_map>
@@ -26,6 +27,10 @@
 
 struct CUstream_st;
 
+namespace meta::comms::logger {
+class CommsSpdlogLogger;
+}
+
 namespace meta::comms::colltrace {
 
 struct GraphCollTraceState;
@@ -44,10 +49,13 @@ class GraphCudaWaitEvent;
 // the poll thread on drain. Both inputs are fixed for the process, so the
 // verdict is computed once and cached (this assumes a homogeneous-GPU host).
 // Exposed so tests can skip on hosts where graph timing cannot work.
-bool graphColltraceSupported(std::string_view logPrefix);
+bool graphColltraceSupported(
+    std::string_view logPrefix,
+    std::string_view loggerName = "comms");
 
 struct CollTraceConfig {
   static constexpr ::size_t kDefaultMaxPendingQueueSize{1024};
+  std::string loggerName{"comms"};
   // The max time CollTrace thread will be waiting before it can respond to
   // a cancellation request. This is to ensure that we don't wait forever and
   // will respond reasonably quickly during teardown. Default to 1 second.
@@ -164,6 +172,7 @@ class CollTrace : public ICollTrace {
 
   // **** Start of Private Member Variables ****
   CollTraceConfig config_;
+  logger::CommsSpdlogLogger* logger_{nullptr};
 
   // Represents the metadata of the communicator that is being traced.
   // This is used for logging purposes.

--- a/comms/utils/colltrace/CudaWaitEvent.cc
+++ b/comms/utils/colltrace/CudaWaitEvent.cc
@@ -8,7 +8,7 @@
 #include <folly/Unit.h>
 #include <folly/stop_watch.h>
 
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/PrecisionClock.h"
@@ -71,7 +71,7 @@ CudaReferencePoint::CudaReferencePoint() {
   return g_referencePointInstance.load(std::memory_order_acquire);
 }
 
-void CudaReferencePoint::refresh() {
+void CudaReferencePoint::refresh(logger::CommsSpdlogLogger& logger) {
   // Try-and-skip: if another thread is already refreshing, short-circuit
   // without touching the dedicated CUDA stream. Multiple CollTrace
   // instances exist per process (one per NCCL communicator) and each calls
@@ -85,14 +85,14 @@ void CudaReferencePoint::refresh() {
 
   cudaEvent_t newEvent = nullptr;
   if (auto err = cudaEventCreate(&newEvent); err != cudaSuccess) {
-    XLOG_EVERY_MS(WARN, 5000)
+    COMMS_LOGGER_STREAM_EVERY_MS(logger, WARN, 5000)
         << "CudaReferencePoint::refresh: cudaEventCreate failed: "
         << cudaGetErrorString(err) << " — keeping previous anchor";
     return;
   }
   CHECK(newEvent != nullptr);
   if (auto err = cudaEventRecord(newEvent, stream_); err != cudaSuccess) {
-    XLOG_EVERY_MS(WARN, 5000)
+    COMMS_LOGGER_STREAM_EVERY_MS(logger, WARN, 5000)
         << "CudaReferencePoint::refresh: cudaEventRecord failed: "
         << cudaGetErrorString(err) << " — keeping previous anchor";
     // Best-effort cleanup of an event we just created; any destroy error
@@ -102,7 +102,7 @@ void CudaReferencePoint::refresh() {
     return;
   }
   if (auto err = cudaStreamSynchronize(stream_); err != cudaSuccess) {
-    XLOG_EVERY_MS(WARN, 5000)
+    COMMS_LOGGER_STREAM_EVERY_MS(logger, WARN, 5000)
         << "CudaReferencePoint::refresh: cudaStreamSynchronize failed: "
         << cudaGetErrorString(err) << " — keeping previous anchor";
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)

--- a/comms/utils/colltrace/CudaWaitEvent.h
+++ b/comms/utils/colltrace/CudaWaitEvent.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <atomic>
+#include <string_view>
 
 #include <cuda_runtime.h> // @manual
 
@@ -12,6 +13,10 @@
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/colltrace/CollWaitEvent.h"
 #include "comms/utils/colltrace/CudaEventPool.h"
+
+namespace meta::comms::logger {
+class CommsSpdlogLogger;
+}
 
 namespace meta::comms::colltrace {
 
@@ -46,7 +51,7 @@ class CudaReferencePoint {
   // anchor is kept. Caller is responsible for rate-limiting; the colltrace
   // poll thread invokes this at ~1 Hz, bounding residual drift between
   // anchors below 100 ns at 100 ppm oscillator tolerance.
-  void refresh();
+  void refresh(logger::CommsSpdlogLogger& logger);
 
   // Returns the singleton if it has been constructed, otherwise nullptr.
   // Safe to call from any thread; never triggers construction. Used by the

--- a/comms/utils/colltrace/GenericMetadata.cc
+++ b/comms/utils/colltrace/GenericMetadata.cc
@@ -2,9 +2,8 @@
 
 #include "comms/utils/colltrace/GenericMetadata.h"
 
-#include <folly/logging/xlog.h>
-
 #include "comms/utils/Conversion.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace meta::comms::colltrace {
 
@@ -177,7 +176,7 @@ GroupedCollP2PMetaData GroupedCollP2PMetaData::fromDynamic(
   // TODO: Currently the from dynamic function is not functioning as expected.
   GroupedCollP2PMetaData metadata;
 
-  XLOG_FIRST_N(ERR, 1)
+  COMMS_LOGGER_STREAM_FIRST_N(logger::getSpdlogLogger(), ERR, 1)
       << "GroupedCollP2PMetaData::fromDynamic is not supported yet";
 
   return metadata;

--- a/comms/utils/colltrace/GraphCudaWaitEvent.cc
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.cc
@@ -5,11 +5,11 @@
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
 
 #include <folly/Unit.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/utils/PrecisionClock.h"
 #include "comms/utils/checks.h"
 #include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace meta::comms::colltrace {
 
@@ -32,7 +32,8 @@ CommsMaybeVoid GraphCudaWaitEvent::beforeCollKernelScheduled() noexcept {
   // collective goes untimed. Warn a few times so that silent timing loss is
   // detectable rather than invisible, without spamming the log per collective.
   if (ringBuffer_ == nullptr) {
-    XLOG_FIRST_N(WARNING, 8)
+    auto& logger = logger_ != nullptr ? *logger_ : logger::getSpdlogLogger();
+    COMMS_LOGGER_STREAM_FIRST_N(logger, WARNING, 8)
         << "GraphCudaWaitEvent: no in-kernel colltrace ring attached (collId="
         << collId_
         << "); graph-captured collective timing is unavailable on this device.";

--- a/comms/utils/colltrace/GraphCudaWaitEvent.h
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.h
@@ -9,6 +9,10 @@
 #include "comms/utils/colltrace/GraphCollTraceState.h"
 #include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
+namespace meta::comms::logger {
+class CommsSpdlogLogger;
+}
+
 namespace meta::comms::colltrace {
 
 // Default shared ring buffer size — must be a power of 2.
@@ -57,6 +61,10 @@ class GraphCudaWaitEvent : public ICollWaitEvent {
       ::hrdw_ring_buffer::HRDWRingBuffer<GraphCollTraceEvent>*
           ringBuffer) noexcept;
 
+  void setLogger(logger::CommsSpdlogLogger& logger) noexcept {
+    logger_ = &logger;
+  }
+
   cudaStream_t getStream() const noexcept {
     return stream_;
   }
@@ -89,6 +97,7 @@ class GraphCudaWaitEvent : public ICollWaitEvent {
   cudaStream_t stream_;
   uint32_t collId_;
   system_clock_time_point enqueueTime_;
+  logger::CommsSpdlogLogger* logger_{nullptr};
 
   // owned by CollTrace, shared across ALL graphs. set via attachRingBuffer().
   ::hrdw_ring_buffer::HRDWRingBuffer<GraphCollTraceEvent>* ringBuffer_{nullptr};

--- a/comms/utils/colltrace/plugins/CommDumpPlugin.cc
+++ b/comms/utils/colltrace/plugins/CommDumpPlugin.cc
@@ -3,12 +3,13 @@
 #include "comms/utils/colltrace/plugins/CommDumpPlugin.h"
 
 #include <algorithm>
+#include <utility>
 
 #include <folly/Unit.h>
 #include <folly/json.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/utils/CommsMaybeChecks.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 #include "comms/utils/trainer/TrainerContext.h"
 
 namespace meta::comms::colltrace {
@@ -17,7 +18,8 @@ namespace {
 CommsMaybeVoid enqueuePendingColls(
     folly::MPMCQueue<std::shared_ptr<CollRecord>>& mpmcQueue,
     std::deque<std::shared_ptr<CollRecord>>& pendingQueue,
-    int64_t maxReadCount) noexcept {
+    int64_t maxReadCount,
+    logger::CommsSpdlogLogger& logger) noexcept {
   std::shared_ptr<CollRecord> nextEnqueue;
   int readCount{0};
   while (readCount < maxReadCount && mpmcQueue.read(nextEnqueue)) {
@@ -25,12 +27,9 @@ CommsMaybeVoid enqueuePendingColls(
     ++readCount;
   }
   if (readCount == maxReadCount) {
-    XLOG_FIRST_N(
-        ERR,
-        2,
-        "CommDumpPlugin: Read ",
-        readCount,
-        " pending colls, but queue is still not empty");
+    COMMS_LOGGER_STREAM_FIRST_N(logger, ERR, 2)
+        << "CommDumpPlugin: Read " << readCount
+        << " pending colls, but queue is still not empty";
     return folly::makeUnexpected(CommsError(
         "CommDumpPlugin: Read " + std::to_string(readCount) +
             " pending colls, but queue is still not empty",
@@ -41,7 +40,9 @@ CommsMaybeVoid enqueuePendingColls(
 } // namespace
 
 CommDumpPlugin::CommDumpPlugin(CommDumpConfig config)
-    : config_(config), newPendingColls_(config_.pendingCollSize) {}
+    : config_(std::move(config)),
+      logger_(&logger::getSpdlogLogger(config_.loggerName)),
+      newPendingColls_(config_.pendingCollSize) {}
 
 std::string_view CommDumpPlugin::getName() const noexcept {
   return kCommDumpPluginName;
@@ -56,7 +57,8 @@ CommsMaybeVoid CommDumpPlugin::beforeCollKernelScheduled(
 CommsMaybeVoid CommDumpPlugin::afterCollKernelScheduled(
     CollTraceEvent& curEvent) noexcept {
   if (curEvent.collRecord == nullptr) [[unlikely]] {
-    XLOG_FIRST_N(ERR, 2, "Got event with null collRecord in CommDumpPlugin");
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 2)
+        << "Got event with null collRecord in CommDumpPlugin";
     return folly::makeUnexpected(CommsError(
         "CollTraceEvent does not contain valid record", commInternalError));
   }
@@ -65,7 +67,8 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelScheduled(
   auto success = newPendingColls_.write(curEvent.collRecord);
 
   if (!success) [[unlikely]] {
-    XLOG_FIRST_N(ERR, 2, "Failed to enqueue event in CommDumpPlugin");
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 2)
+        << "Failed to enqueue event in CommDumpPlugin";
     return folly::makeUnexpected(CommsError(
         "Failed to enqueue event in CommDumpPlugin", commInternalError));
   }
@@ -76,7 +79,8 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelScheduled(
 CommsMaybeVoid CommDumpPlugin::afterCollKernelStart(
     CollTraceEvent& curEvent) noexcept {
   if (curEvent.collRecord == nullptr) [[unlikely]] {
-    XLOG_FIRST_N(ERR, 2, "Got event with null collRecord in CommDumpPlugin");
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 2)
+        << "Got event with null collRecord in CommDumpPlugin";
     return folly::makeUnexpected(CommsError(
         "CollTraceEvent does not contain valid record", commInternalError));
   }
@@ -88,7 +92,8 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelStart(
       enqueuePendingColls(
           newPendingColls_,
           lockedCollTraceDump->pendingColls,
-          config_.pendingCollSize + 1));
+          config_.pendingCollSize + 1,
+          *logger_));
 
   // Find the matching pending collective.
   // With deferred graph polling, completions may arrive out of enqueue order
@@ -100,10 +105,8 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelStart(
       });
 
   if (it == lockedCollTraceDump->pendingColls.end()) [[unlikely]] {
-    XLOG_FIRST_N(
-        ERR,
-        2,
-        "Could not find matching collRecord in pendingColls in CommDumpPlugin");
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 2)
+        << "Could not find matching collRecord in pendingColls in CommDumpPlugin";
     return folly::makeUnexpected(CommsError(
         "Could not find matching collRecord in pendingColls in CommDumpPlugin",
         commInternalError));
@@ -124,7 +127,8 @@ CommsMaybeVoid CommDumpPlugin::collEventProgressing(
 CommsMaybeVoid CommDumpPlugin::afterCollKernelEnd(
     CollTraceEvent& curEvent) noexcept {
   if (curEvent.collRecord == nullptr) [[unlikely]] {
-    XLOG_FIRST_N(ERR, 2, "Got event with null collRecord in CommDumpPlugin");
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 2)
+        << "Got event with null collRecord in CommDumpPlugin";
     return folly::makeUnexpected(CommsError(
         "CollTraceEvent does not contain valid record", commInternalError));
   }
@@ -136,7 +140,8 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelEnd(
       enqueuePendingColls(
           newPendingColls_,
           lockedCollTraceDump->pendingColls,
-          config_.pendingCollSize + 1));
+          config_.pendingCollSize + 1,
+          *logger_));
 
   // ----- Find and move from currentColls to pastColls -----
   auto it = std::find_if(
@@ -147,10 +152,8 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelEnd(
       });
 
   if (it == lockedCollTraceDump->currentColls.end()) [[unlikely]] {
-    XLOG_FIRST_N(
-        ERR,
-        2,
-        "Could not find matching collRecord in currentColls during coll end");
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 2)
+        << "Could not find matching collRecord in currentColls during coll end";
     return folly::makeUnexpected(CommsError(
         "Could not find matching collRecord in currentColls during coll end",
         commInternalError));
@@ -198,10 +201,8 @@ CommsMaybe<CollTraceDump> CommDumpPlugin::dump() noexcept {
         collTraceDump_.wlock(config_.dumpLockAcquireTimeout);
 
     if (lockedCollTraceDump.isNull()) {
-      XLOG_FIRST_N(
-          ERR,
-          2,
-          "Failed to acquire lock for collTraceDump_ in CommDumpPlugin dump");
+      COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 2)
+          << "Failed to acquire lock for collTraceDump_ in CommDumpPlugin dump";
       return folly::makeUnexpected(CommsError(
           "Failed to acquire lock for collTraceDump_ in CommDumpPlugin dump",
           commInternalError));
@@ -212,17 +213,16 @@ CommsMaybe<CollTraceDump> CommDumpPlugin::dump() noexcept {
         enqueuePendingColls(
             newPendingColls_,
             lockedCollTraceDump->pendingColls,
-            config_.pendingCollSize + 1));
+            config_.pendingCollSize + 1,
+            *logger_));
   }
 
   auto readLockedCollTraceDump =
       collTraceDump_.rlock(config_.dumpLockAcquireTimeout);
 
   if (readLockedCollTraceDump.isNull()) {
-    XLOG_FIRST_N(
-        ERR,
-        2,
-        "Failed to acquire read lock for collTraceDump_ in CommDumpPlugin dump");
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 2)
+        << "Failed to acquire read lock for collTraceDump_ in CommDumpPlugin dump";
     return folly::makeUnexpected(CommsError(
         "Failed to acquire read lock for collTraceDump_ in CommDumpPlugin dump",
         commInternalError));

--- a/comms/utils/colltrace/plugins/CommDumpPlugin.h
+++ b/comms/utils/colltrace/plugins/CommDumpPlugin.h
@@ -5,6 +5,8 @@
 #include <deque>
 #include <memory>
 #include <queue>
+#include <string>
+#include <string_view>
 #include <unordered_set>
 #include <vector>
 
@@ -12,6 +14,10 @@
 #include <folly/Synchronized.h>
 
 #include "comms/utils/colltrace/CollTracePlugin.h"
+
+namespace meta::comms::logger {
+class CommsSpdlogLogger;
+}
 
 namespace meta::comms::colltrace {
 
@@ -26,6 +32,8 @@ struct CommDumpConfig {
   // Default timeout for waiting for the lock to be acquired for dump. We don't
   // want to block the dump thread if there is any issue with the lock.
   static constexpr auto kDumpLockAcquireTimeout = std::chrono::seconds(1);
+
+  std::string loggerName{"comms"};
 
   // Configures the size of the queue for past collective operations
   // (defaults to kDefaultPastQueueSize). They will be dumped as pastColls when
@@ -105,6 +113,7 @@ class CommDumpPlugin : public ICollTracePlugin {
   void evictPastColls(CollTraceDump& dump);
 
   CommDumpConfig config_;
+  logger::CommsSpdlogLogger* logger_{nullptr};
 
   folly::Synchronized<CollTraceDump> collTraceDump_;
 

--- a/comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.cc
+++ b/comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.cc
@@ -7,7 +7,8 @@
 #include <cstdint>
 
 #include <folly/Unit.h>
-#include <folly/logging/xlog.h>
+
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace meta::comms::colltrace {
 
@@ -20,8 +21,9 @@ constexpr uint32_t kBacklogCheckPeriod = 256;
 } // namespace
 
 LifecycleEventFeedPlugin::LifecycleEventFeedPlugin(
-    LifecycleEventFeedConfig config)
-    : commId_(config.commId) {}
+    const LifecycleEventFeedConfig& config)
+    : commId_(config.commId),
+      logger_(&logger::getSpdlogLogger(config.loggerName)) {}
 
 std::string_view LifecycleEventFeedPlugin::getName() const noexcept {
   return kLifecycleEventFeedPluginName;
@@ -118,7 +120,7 @@ CommsMaybeVoid LifecycleEventFeedPlugin::recordEvent(
   if (++backlogCheckCounter % kBacklogCheckPeriod == 0) {
     const auto backlog = unreadEvents_.size();
     if (backlog >= kBacklogWarningThreshold) [[unlikely]] {
-      XLOG_EVERY_MS(WARN, 60000)
+      COMMS_LOGGER_STREAM_EVERY_MS(*logger_, WARN, 60000)
           << "LifecycleEventFeedPlugin estimated unread backlog is " << backlog
           << " events for comm " << commId_
           << "; consumer may be stalled and memory will continue to grow";

--- a/comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.h
+++ b/comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.h
@@ -5,12 +5,17 @@
 #include <atomic>
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <vector>
 
 #include <folly/concurrency/UnboundedQueue.h>
 
 #include "comms/utils/colltrace/CollTracePlugin.h"
+
+namespace meta::comms::logger {
+class CommsSpdlogLogger;
+}
 
 namespace meta::comms::colltrace {
 
@@ -33,11 +38,13 @@ struct LifecycleEventRecord {
 
 struct LifecycleEventFeedConfig {
   uint64_t commId{0};
+  std::string loggerName{"comms"};
 };
 
 class LifecycleEventFeedPlugin : public ICollTracePlugin {
  public:
-  explicit LifecycleEventFeedPlugin(LifecycleEventFeedConfig config = {});
+  explicit LifecycleEventFeedPlugin(
+      const LifecycleEventFeedConfig& config = {});
 
   std::string_view getName() const noexcept override;
 
@@ -64,6 +71,7 @@ class LifecycleEventFeedPlugin : public ICollTracePlugin {
       LifecycleEventType eventType) noexcept;
 
   uint64_t commId_{0};
+  logger::CommsSpdlogLogger* logger_{nullptr};
   folly::UMPMCQueue<LifecycleEventRecord, false> unreadEvents_;
   std::atomic<uint64_t> latestCollId_{0};
 };

--- a/comms/utils/colltrace/plugins/WatchdogPlugin.cc
+++ b/comms/utils/colltrace/plugins/WatchdogPlugin.cc
@@ -2,9 +2,13 @@
 
 #include "comms/utils/colltrace/plugins/WatchdogPlugin.h"
 
+#include <string>
+#include <thread>
+
 #include <folly/Unit.h>
 #include <folly/json.h>
-#include <folly/logging/xlog.h>
+
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace meta::comms::colltrace {
 
@@ -24,12 +28,38 @@ std::string_view getCollectiveStateStr(CollTraceEvent& curEvent) {
   // This should not happen... Just for completeness
   return "Not Scheduled";
 }
+
+WatchdogPluginConfig normalizeWatchdogConfig(WatchdogPluginConfig config) {
+  if (!config.funcTriggerOnError) {
+    config.funcTriggerOnError =
+        [loggerName = std::string{config.loggerName}](CollTraceEvent& event) {
+          /* Give Analyzer time to collect the error state before aborting. */
+          // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+          std::this_thread::sleep_for(std::chrono::seconds(60));
+          logFatalError(event, "AsyncError", loggerName);
+        };
+  }
+  if (!config.funcTriggerOnTimeout) {
+    config.funcTriggerOnTimeout =
+        [loggerName = std::string{config.loggerName}](CollTraceEvent& event) {
+          logFatalError(event, "watchdog timeout", loggerName);
+        };
+  }
+  return config;
+}
 } // namespace
 
-void logFatalError(CollTraceEvent& curEvent, std::string_view errorType) {
-  auto metadataDynamic = curEvent.collRecord->toDynamic();
-  auto errorString = fmt::format(
-      "FatalError: Collective (OpCount={}, OpType={}, Count={}, DataType={} CurrentState={}) for Comm {} raised {}",
+[[noreturn]] void logFatalError(
+    CollTraceEvent& curEvent,
+    std::string_view errorType,
+    std::string_view loggerName) {
+  const auto metadataDynamic = curEvent.collRecord->toDynamic();
+  /*
+   * Watchdog diagnostics consume this marker from NCCL_DEBUG_FILE. Keep it in
+   * the payload because the owner logger's prefix is backend-specific.
+   */
+  const auto errorString = fmt::format(
+      "COMM FATAL: FatalError: Collective (OpCount={}, OpType={}, Count={}, DataType={} CurrentState={}) for Comm {} raised {}",
       metadataDynamic.getDefault("opCount", "Unknown").asString(),
       metadataDynamic.getDefault("opName", "Unknown").asString(),
       metadataDynamic.getDefault("count", "N/A").asString(),
@@ -37,40 +67,42 @@ void logFatalError(CollTraceEvent& curEvent, std::string_view errorType) {
       getCollectiveStateStr(curEvent),
       metadataDynamic.getDefault("commDesc", "Unknown").asString(),
       errorType);
-  XLOG(FATAL, errorString);
+  COMMS_LOG_NAMED(loggerName, FATAL, "{}", errorString);
 }
 
 WatchdogPlugin::WatchdogPlugin(WatchdogPluginConfig config)
-    : config_(std::move(config)) {}
+    : config_(normalizeWatchdogConfig(std::move(config))),
+      logger_(&logger::getSpdlogLogger(config_.loggerName)) {}
 
 std::string_view WatchdogPlugin::getName() const noexcept {
   return kWatchdogPluginName;
 }
 
 CommsMaybeVoid WatchdogPlugin::beforeCollKernelScheduled(
-    CollTraceEvent& curEvent) noexcept {
+    CollTraceEvent&) noexcept {
   return folly::unit;
 }
 
 CommsMaybeVoid WatchdogPlugin::afterCollKernelScheduled(
-    CollTraceEvent& curEvent) noexcept {
+    CollTraceEvent&) noexcept {
   return folly::unit;
 }
 
-CommsMaybeVoid WatchdogPlugin::afterCollKernelStart(
-    CollTraceEvent& curEvent) noexcept {
+CommsMaybeVoid WatchdogPlugin::afterCollKernelStart(CollTraceEvent&) noexcept {
   return folly::unit;
 }
 
 CommsMaybeVoid WatchdogPlugin::collEventProgressing(
     CollTraceEvent& curEvent) noexcept {
-  XLOGF(
-      DBG0,
+  COMMS_LOG_IMPL(
+      *logger_,
+      ::spdlog::level::debug,
+      COMMS_LOGGER_DEBUG,
       "WatchdogPlugin::collEventProgressing for CollTraceEvent {}",
       folly::toJson(curEvent.collRecord->toDynamic()));
 
   if (config_.checkAsyncError && config_.funcIfError()) {
-    XLOG(DBG)
+    COMMS_LOGGER_STREAM(*logger_, DBG)
         << "WatchdogPlugin::collEventProgressing: triggering async error handling";
 
     config_.funcTriggerOnError(curEvent);

--- a/comms/utils/colltrace/plugins/WatchdogPlugin.h
+++ b/comms/utils/colltrace/plugins/WatchdogPlugin.h
@@ -4,36 +4,40 @@
 
 #include "comms/utils/colltrace/CollTracePlugin.h"
 
-#include <thread>
+#include <string>
 #include <unordered_map>
 
 #include <folly/stop_watch.h>
 
+namespace meta::comms::logger {
+class CommsSpdlogLogger;
+}
+
 namespace meta::comms::colltrace {
 
-void logFatalError(CollTraceEvent& curEvent, std::string_view errorType);
+[[noreturn]] void logFatalError(
+    CollTraceEvent& curEvent,
+    std::string_view errorType,
+    std::string_view loggerName = "comms");
 
 struct WatchdogPluginConfig {
+  std::string loggerName{"comms"};
+  // Empty trigger callbacks are replaced by logger-aware defaults when the
+  // WatchdogPlugin is constructed.
   // Async error config
   bool checkAsyncError{true};
   std::function<bool(void)> funcIfError{[]() { return false; }};
-  std::function<void(CollTraceEvent&)> funcTriggerOnError{
-      [](CollTraceEvent& event) {
-        // Sleep for 60 seconds to allow Analyzer to collect the error.
-        std::this_thread::sleep_for(std::chrono::seconds(60));
-        logFatalError(event, "AsyncError");
-      }};
+  std::function<void(CollTraceEvent&)> funcTriggerOnError;
 
   // Timeout config
   bool checkTimeout{false};
   std::chrono::milliseconds timeout{std::chrono::minutes{10}};
-  std::function<void(CollTraceEvent&)> funcTriggerOnTimeout{
-      [](CollTraceEvent& event) { logFatalError(event, "watchdog timeout"); }};
+  std::function<void(CollTraceEvent&)> funcTriggerOnTimeout;
 };
 
 class WatchdogPlugin : public ICollTracePlugin {
  public:
-  WatchdogPlugin(WatchdogPluginConfig config);
+  explicit WatchdogPlugin(WatchdogPluginConfig config);
 
   std::string_view getName() const noexcept override;
 
@@ -55,6 +59,7 @@ class WatchdogPlugin : public ICollTracePlugin {
 
  private:
   const WatchdogPluginConfig config_;
+  logger::CommsSpdlogLogger* logger_{nullptr};
 
   // Per-event timeout tracking. Each in-flight event gets its own timer
   // so a stuck collective is detected even when others progress normally.

--- a/comms/utils/cvars/nccl_baseline_adapter.cc
+++ b/comms/utils/cvars/nccl_baseline_adapter.cc
@@ -8,20 +8,18 @@
 #include <cstring>
 #include <string>
 
-#include <cuda_runtime.h>
-
 #include <folly/String.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/utils/cvars/nccl_baseline_adapter.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
-#define NCCL_ADAPTER_INFO(fmt, ...)          \
-  XLOGF_IF(                                  \
-      INFO,                                  \
-      logNcclBaselineAdapterInfo,            \
-      "NcclBaselineAdapter INFO CVAR: " fmt, \
-      __VA_ARGS__);
+#define NCCL_ADAPTER_INFO(format, ...)                                        \
+  do {                                                                        \
+    if (logNcclBaselineAdapterInfo) {                                         \
+      COMMS_LOG(INFO, "NcclBaselineAdapter INFO CVAR: " format, __VA_ARGS__); \
+    }                                                                         \
+  } while (false)
 
 namespace nccl_baseline_adapter {
 int64_t ncclLoadParam(
@@ -90,9 +88,9 @@ int64_t ncclLoadParam(
     value = strtoll(strValue, &endptr, 0);
     if (errno || endptr == strValue) {
       value = deftVal;
-      XLOG(WARN) << "NcclBaselineAdapter WARN CVAR: Invalid value \""
-                 << strValue << "\" for CVAR " << env << ", using default \""
-                 << deftVal << "\".";
+      COMMS_LOG_STREAM(WARN)
+          << "NcclBaselineAdapter WARN CVAR: Invalid value \"" << strValue
+          << "\" for CVAR " << env << ", using default \"" << deftVal << "\".";
     } else {
       NCCL_ADAPTER_INFO(
           "{} set by string CVAR map to {}.", env, (long long)value);
@@ -103,7 +101,7 @@ int64_t ncclLoadParam(
   return value;
 }
 
-const char* ncclGetEnvImpl(const char* name) {
+const char* FOLLY_NULLABLE ncclGetEnvImpl(const char* name) {
   // Note: we omit the initEnv() call here (which is present in the baseline
   // NCCL implementation) because calling initEnv() breaks a large number of
   // unit tests. This is because the unit tests temporarily set values for

--- a/comms/utils/cvars/nccl_baseline_adapter.h
+++ b/comms/utils/cvars/nccl_baseline_adapter.h
@@ -9,6 +9,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <folly/CppAttributes.h>
+
 namespace nccl_baseline_adapter {
 
 /**
@@ -23,7 +25,7 @@ int64_t ncclLoadParam(
 /**
  * Load a string-based CVAR.
  */
-const char* ncclGetEnvImpl(const char* name);
+const char* FOLLY_NULLABLE ncclGetEnvImpl(const char* name);
 } // namespace nccl_baseline_adapter
 
 #endif // NCCL_BASELINE_ADAPTER_H_INCLUDED

--- a/comms/utils/cvars/nccl_cvars.cc.in
+++ b/comms/utils/cvars/nccl_cvars.cc.in
@@ -15,7 +15,8 @@
 #include <cuda_runtime.h>
 
 #include <folly/String.h>
-#include <folly/logging/xlog.h>
+
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #if defined(__HIP_PLATFORM_AMD__)
 static const std::string ncclConfigFileName = "rccl.conf";
@@ -35,19 +36,21 @@ static std::unordered_map<std::string, std::string>& nccl_config() {
 static void initEnvSet(std::unordered_set<std::string>& env);
 static void readCvarEnv();
 
-#define CVAR_INFO(fmt, ...)                 \
-  XLOGF_IF(                                 \
-      INFO,                                 \
-      logInfoLog,                           \
-      "[CudaDev: {}] NCCL INFO CVAR: " fmt, \
-      cudaDev,                              \
-      __VA_ARGS__);
+#define CVAR_INFO(format, ...)                                        \
+  do {                                                                \
+    if (logInfoLog) {                                                 \
+      COMMS_LOG(                                                      \
+          INFO, "[CudaDev: {}] NCCL INFO CVAR: " format, cudaDev, __VA_ARGS__); \
+    }                                                                 \
+  } while (false)
 
-#define CVAR_WARN(fmt, ...) \
-  XLOGF(WARN, "[CudaDev: {}] NCCL WARN CVAR: " fmt, cudaDev, __VA_ARGS__);
+#define CVAR_WARN(format, ...)                                        \
+  COMMS_LOG(                                                          \
+      WARN, "[CudaDev: {}] NCCL WARN CVAR: " format, cudaDev, __VA_ARGS__)
 
-#define CVAR_ERROR(fmt, ...) \
-  XLOGF(FATAL, "[CudaDev: {}] NCCL ERROR CVAR: " fmt, cudaDev, __VA_ARGS__);
+#define CVAR_ERROR(format, ...)                                       \
+  COMMS_LOG(                                                          \
+      FATAL, "[CudaDev: {}] NCCL ERROR CVAR: " format, cudaDev, __VA_ARGS__)
 
 #define CVAR_WARN_UNKNOWN_VALUE(name, value)               \
   do {                                                     \

--- a/comms/utils/logger/BackendTopologyUtil.cc
+++ b/comms/utils/logger/BackendTopologyUtil.cc
@@ -7,7 +7,8 @@
 #include <folly/FileUtil.h>
 #include <folly/MapUtil.h>
 #include <folly/String.h>
-#include <folly/logging/xlog.h>
+
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace {
 std::unordered_map<std::string, std::string> getKeyValuePairsFromFile(
@@ -15,7 +16,7 @@ std::unordered_map<std::string, std::string> getKeyValuePairsFromFile(
   std::unordered_map<std::string, std::string> keyValuePairs;
   std::string fileContents;
   if (!folly::readFile(fileName.c_str(), fileContents)) {
-    XLOG(ERR) << "Failed to read file: " << fileName;
+    COMMS_LOG_STREAM(ERR) << "Failed to read file: " << fileName;
     return keyValuePairs;
   }
 
@@ -28,7 +29,8 @@ std::unordered_map<std::string, std::string> getKeyValuePairsFromFile(
     std::vector<std::string> keyValuePair;
     folly::split('=', line, keyValuePair);
     if (keyValuePair.size() != 2) {
-      XLOG(ERR) << "Invalid line in file: " << fileName << ", line: " << line;
+      COMMS_LOG_STREAM(ERR)
+          << "Invalid line in file: " << fileName << ", line: " << line;
       continue;
     }
     keyValuePairs[keyValuePair[0]] = keyValuePair[1];
@@ -69,7 +71,8 @@ std::optional<BackendTopologyUtil::Topology>
 BackendTopologyUtil::getBackendTopology(const std::string& fileName) {
   auto keyValuePairs = getKeyValuePairsFromFile(fileName);
   if (keyValuePairs.empty()) {
-    XLOG(ERR) << "Failed to get backend topology from file: " << fileName;
+    COMMS_LOG_STREAM(ERR) << "Failed to get backend topology from file: "
+                          << fileName;
     return std::nullopt;
   }
 

--- a/comms/utils/logger/CudaLog.cc
+++ b/comms/utils/logger/CudaLog.cc
@@ -1,0 +1,98 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/CudaLog.h"
+
+#include <array>
+#include <cstdarg>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "comms/utils/logger/SpdlogLogger.h"
+
+namespace meta::comms::logger {
+namespace {
+
+spdlog::level::level_enum toSpdlogLevel(CudaLogLevel level) {
+  switch (level) {
+    case CudaLogLevel::DBG:
+      return spdlog::level::debug;
+    case CudaLogLevel::INFO:
+      return spdlog::level::info;
+    case CudaLogLevel::WARN:
+      return spdlog::level::warn;
+    case CudaLogLevel::ERR:
+      return spdlog::level::err;
+  }
+  return spdlog::level::off;
+}
+
+} // namespace
+
+CommsSpdlogLogger* tryGetSpdlogLoggerForCuda() noexcept {
+  try {
+    return &getSpdlogLogger();
+  } catch (...) {
+    reportCommsLoggingFailureToStderr("ERROR");
+    return nullptr;
+  }
+}
+
+bool shouldLogFromCuda(
+    const CommsSpdlogLogger& logger,
+    CudaLogLevel level) noexcept {
+  try {
+    return logger.should_log(toSpdlogLevel(level));
+  } catch (...) {
+    reportCommsLoggingFailureToStderr("ERROR");
+    return false;
+  }
+}
+
+void logFromCuda(
+    CommsSpdlogLogger& logger,
+    CudaLogLevel level,
+    const char* filename,
+    int line,
+    const char* function,
+    const char* format,
+    ...) noexcept {
+  try {
+    constexpr std::size_t kStackBufferSize = 512;
+    std::array<char, kStackBufferSize> stackBuffer{};
+    va_list args;
+    va_start(args, format);
+    const int required =
+        std::vsnprintf(stackBuffer.data(), stackBuffer.size(), format, args);
+    va_end(args);
+    if (required < 0) {
+      reportCommsLoggingFailureToStderr("ERROR");
+      return;
+    }
+
+    std::string message;
+    if (static_cast<std::size_t>(required) < stackBuffer.size()) {
+      message.assign(stackBuffer.data(), static_cast<std::size_t>(required));
+    } else {
+      std::vector<char> buffer(static_cast<std::size_t>(required) + 1);
+      va_start(args, format);
+      const int written =
+          std::vsnprintf(buffer.data(), buffer.size(), format, args);
+      va_end(args);
+      if (written != required) {
+        reportCommsLoggingFailureToStderr("ERROR");
+        return;
+      }
+      message.assign(buffer.data(), static_cast<std::size_t>(required));
+    }
+
+    logger.log(
+        spdlog::source_loc{filename, line, function},
+        toSpdlogLevel(level),
+        message);
+  } catch (...) {
+    reportCommsLoggingFailureToStderr("ERROR");
+  }
+}
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/CudaLog.h
+++ b/comms/utils/logger/CudaLog.h
@@ -1,0 +1,53 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+namespace meta::comms::logger {
+
+class CommsSpdlogLogger;
+
+enum class CudaLogLevel : unsigned char {
+  DBG,
+  INFO,
+  WARN,
+  ERR,
+};
+
+CommsSpdlogLogger* tryGetSpdlogLoggerForCuda() noexcept;
+
+bool shouldLogFromCuda(
+    const CommsSpdlogLogger& logger,
+    CudaLogLevel level) noexcept;
+
+void logFromCuda(
+    CommsSpdlogLogger& logger,
+    CudaLogLevel level,
+    const char* filename,
+    int line,
+    const char* function,
+    const char* format,
+    ...) noexcept __attribute__((format(printf, 6, 7)));
+
+} // namespace meta::comms::logger
+
+/*
+ * Keep this facade free of C++ standard-library and spdlog headers because
+ * cudafe parses it when compiling host logging statements in .cu files.
+ */
+#define COMMS_CUDA_LOG(level, ...)                          \
+  do {                                                      \
+    static auto* const _comms_cuda_logger =                 \
+        ::meta::comms::logger::tryGetSpdlogLoggerForCuda(); \
+    if (_comms_cuda_logger != nullptr &&                    \
+        ::meta::comms::logger::shouldLogFromCuda(           \
+            *_comms_cuda_logger,                            \
+            ::meta::comms::logger::CudaLogLevel::level)) {  \
+      ::meta::comms::logger::logFromCuda(                   \
+          *_comms_cuda_logger,                              \
+          ::meta::comms::logger::CudaLogLevel::level,       \
+          __FILE__,                                         \
+          __LINE__,                                         \
+          static_cast<const char*>(__FUNCTION__),           \
+          __VA_ARGS__);                                     \
+    }                                                       \
+  } while (false)

--- a/comms/utils/logger/DataSink.h
+++ b/comms/utils/logger/DataSink.h
@@ -7,7 +7,8 @@
 
 #include <folly/Optional.h>
 #include <folly/Range.h>
-#include <folly/logging/xlog.h>
+
+#include "comms/utils/logger/SpdlogLogger.h"
 
 /**
  * FB Infra is not fully in conda environment and we build NCCLX in conda
@@ -23,8 +24,8 @@
 class DataSink {
  public:
   explicit DataSink(folly::StringPiece dataset) {
-    XLOG(WARNING) << "Empty sink for dataset: " << dataset << ". "
-                  << "No logging will be done.";
+    COMMS_LOG_STREAM(WARN) << "Empty sink for dataset: " << dataset << ". "
+                           << "No logging will be done.";
   }
 
   size_t addRawData(

--- a/comms/utils/logger/DataTableWrapper.cc
+++ b/comms/utils/logger/DataTableWrapper.cc
@@ -6,9 +6,9 @@
 
 #include <folly/Singleton.h>
 #include <folly/String.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace {
 constexpr std::string_view k_nccl_memory_logging = "nccl_memory_logging";
@@ -36,15 +36,15 @@ DataTableAllTables createAllTables() {
     std::vector<std::string> tokens;
     folly::split(':', tableTypeName, tokens, true /* ignoreEmpty */);
     if (tokens.size() != 2) {
-      XLOG(ERR) << "Invalid table type and name: " << tableTypeName
-                << ". Ignoring";
+      COMMS_LOG_STREAM(ERR)
+          << "Invalid table type and name: " << tableTypeName << ". Ignoring";
       continue;
     }
     auto& tableType = tokens.at(0);
     auto& tableName = tokens.at(1);
     if (tableType != "pipe" && tableType != "scuba") {
-      XLOG(ERR) << "Invalid table type: " << tableType
-                << " for table: " << tableName << ". Ignoring";
+      COMMS_LOG_STREAM(ERR) << "Invalid table type: " << tableType
+                            << " for table: " << tableName << ". Ignoring";
       continue;
     }
 
@@ -88,7 +88,7 @@ void DataTableWrapper::addSample(NcclScubaSample sample) {
     table_ = folly::get_default(allTables->tables, tableName_, nullptr);
 
     if (!table_) {
-      XLOG(WARNING) << "Could not find table name: " << tableName_ << std::endl;
+      COMMS_LOG_STREAM(WARN) << "Could not find table name: " << tableName_;
     }
   });
 

--- a/comms/utils/logger/EventMgrHelperTypes.cc
+++ b/comms/utils/logger/EventMgrHelperTypes.cc
@@ -4,7 +4,8 @@
 
 #include <folly/String.h>
 #include <folly/json/json.h>
-#include <folly/logging/xlog.h>
+
+#include "comms/utils/logger/SpdlogLogger.h"
 
 void EventGlobalRankFilter::initialize(
     const std::vector<std::string>& rankListCvar,
@@ -14,7 +15,7 @@ void EventGlobalRankFilter::initialize(
 
   // If the rank list is empty, then allow all ranks.
   if (rankListCvar.empty()) {
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Empty rank list, skip {} initialization. isAllowed: {}",
         filterName_,
@@ -28,13 +29,13 @@ void EventGlobalRankFilter::initialize(
     try {
       globalRank_ = std::stoi(std::string(rankEnv));
     } catch (const std::exception& e) {
-      XLOGF(WARN, "Invalid RANK env: {}, error: {}", rankEnv, e.what());
+      COMMS_LOG(WARN, "Invalid RANK env: {}, error: {}", rankEnv, e.what());
       // Do not throw exception here, just skip this invalid RANK env.
     }
   }
 
   if (globalRank_ < 0) {
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Cannot get global rank, skip {} initialization. isAllowed: {}",
         filterName_,
@@ -53,12 +54,12 @@ void EventGlobalRankFilter::initialize(
         break;
       }
     } catch (const std::exception& e) {
-      XLOGF(WARN, "Invalid rank string: {}, error: {}", rankStr, e.what());
+      COMMS_LOG(WARN, "Invalid rank string: {}, error: {}", rankStr, e.what());
       // Do not throw exception here, just skip this invalid rank string.
     }
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Initialized {}, globalRank: {}, isAllowed: {}",
       filterName_,

--- a/comms/utils/logger/LogUtils.cc
+++ b/comms/utils/logger/LogUtils.cc
@@ -16,8 +16,6 @@ namespace {
 folly::once_flag commLoggingInitOnceFlag;
 
 void initCommLoggingImpl() {
-  setSubSystemMask(
-      meta::comms::logger::parseDebugSubsysMask(NCCL_DEBUG_SUBSYS.c_str()));
   NcclLogger::init(
       NcclLoggerInitConfig{
           .contextName = std::string{kCommsUtilsCategory},

--- a/comms/utils/logger/Logger.cc
+++ b/comms/utils/logger/Logger.cc
@@ -10,6 +10,7 @@
 #include <folly/logging/xlog.h>
 
 #include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
+#include "comms/utils/logger/LoggerRuntime.h"
 #include "comms/utils/logger/LoggingFormat.h"
 #include "comms/utils/logger/NcclWriterWrapper.h"
 #include "comms/utils/logger/ScubaLogger.h"
@@ -28,7 +29,7 @@ std::string getHandlerNameWithCategory(
 void NcclLogger::init(const NcclLoggerInitConfig& config) {
   if (!firstInit_.test_and_set()) {
     folly::initLoggingOrDie();
-    DataTableWrapper::init();
+    meta::comms::logger::initCommLoggerRuntime();
     NcclLogFormatterFactory::registerThreadContextFn(
         config.logPrefix, config.threadContextFn);
     NcclLogger::registerHandler(
@@ -86,7 +87,7 @@ void NcclLogger::close() noexcept {
     NcclLogHandlerFactory::close();
     firstInit_.clear();
   }
-  DataTableWrapper::shutdown();
+  meta::comms::logger::shutdownCommLoggerRuntime();
 }
 
 std::shared_ptr<folly::LogWriter>

--- a/comms/utils/logger/LoggerRuntime.cc
+++ b/comms/utils/logger/LoggerRuntime.cc
@@ -1,0 +1,49 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/LoggerRuntime.h"
+
+#include <mutex>
+
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/DataTableWrapper.h"
+#include "comms/utils/logger/LoggingFormat.h"
+
+namespace meta::comms::logger {
+namespace {
+
+struct RuntimeState {
+  std::mutex mutex;
+  bool initialized{false};
+};
+
+RuntimeState& getRuntimeState() {
+  static RuntimeState state;
+  return state;
+}
+
+} // namespace
+
+void initCommLoggerRuntime() {
+  auto& state = getRuntimeState();
+  std::lock_guard lock{state.mutex};
+  if (state.initialized) {
+    return;
+  }
+
+  setSubSystemMask(parseDebugSubsysMask(NCCL_DEBUG_SUBSYS.c_str()));
+  DataTableWrapper::init();
+  state.initialized = true;
+}
+
+void shutdownCommLoggerRuntime() {
+  auto& state = getRuntimeState();
+  std::lock_guard lock{state.mutex};
+  if (!state.initialized) {
+    return;
+  }
+
+  DataTableWrapper::shutdown();
+  state.initialized = false;
+}
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/LoggerRuntime.h
+++ b/comms/utils/logger/LoggerRuntime.h
@@ -1,0 +1,12 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+namespace meta::comms::logger {
+
+// Initializes process-global logging state once. Calls before shutdown keep the
+// subsystem mask and structured-event configuration from the first call.
+void initCommLoggerRuntime();
+void shutdownCommLoggerRuntime();
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/LoggingFormat.h
+++ b/comms/utils/logger/LoggingFormat.h
@@ -13,6 +13,7 @@
 
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/logger/LogTypes.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace meta::comms::logger {
 
@@ -80,10 +81,17 @@ class NcclLogFormatter : public folly::LogFormatter {
 
 } // namespace meta::comms::logger
 
+#define COMMS_ERR(code, ...)                                                  \
+  do {                                                                        \
+    const auto _comms_error_message = fmt::format(__VA_ARGS__);               \
+    COMMS_LOG(ERR, "{}", _comms_error_message);                               \
+    ::meta::comms::logger::logCommErrorToScuba((code), _comms_error_message); \
+  } while (false)
+
 #define COMMS_NAMED_THREAD_START_EXT(threadName, rank, commHash, commDesc)                \
   do {                                                                                    \
     meta::comms::logger::initThreadMetaData(threadName);                                  \
-    XLOGF(                                                                                \
+    COMMS_LOG(                                                                            \
         INFO,                                                                             \
         "[COMMS THREAD] Starting {} thread for rank {} commHash {:#x} commDesc {} at {}", \
         threadName,                                                                       \

--- a/comms/utils/logger/ScubaFileUtils.cc
+++ b/comms/utils/logger/ScubaFileUtils.cc
@@ -6,10 +6,10 @@
 #include <filesystem>
 
 #include <fmt/format.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/utils/RankUtils.h"
 #include "comms/utils/StrUtils.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace comms::logger {
 
@@ -36,8 +36,8 @@ std::optional<folly::File> createScubaFile(
     int flags = O_CREAT | O_WRONLY | (appendMode ? O_APPEND : 0);
     return folly::File(fileName, flags, 0644);
   } catch (const std::exception& e) {
-    XLOG(WARNING) << "Failed to create scuba file " << fileName << ": "
-                  << e.what();
+    COMMS_LOG_STREAM(WARN) << "Failed to create scuba file " << fileName << ": "
+                           << e.what();
   }
   return std::nullopt;
 }

--- a/comms/utils/logger/ScubaLogger.cc
+++ b/comms/utils/logger/ScubaLogger.cc
@@ -4,7 +4,7 @@
 
 #include <chrono>
 
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 DataTableWrapper* getTablePtrFromEvent(LoggerEventType event) {
   switch (event) {
@@ -25,7 +25,7 @@ DataTableWrapper* getTablePtrFromEvent(LoggerEventType event) {
     case LoggerEventType::CommEventType:
       return SCUBA_nccl_structured_logging_ptr.get();
     default:
-      XLOG(ERR) << "Invalid event type";
+      COMMS_LOG_STREAM(ERR) << "Invalid event type";
       break;
   }
   throw std::runtime_error("Invalid event type");

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <chrono>
 #include <cstddef>
+#include <cstdio>
 #include <cstring>
 #include <map>
 #include <memory>
@@ -27,6 +28,16 @@
 
 namespace meta::comms::logger {
 
+void reportCommsLoggingFailureToStderr(const char* level) noexcept {
+  std::fprintf(stderr, "%s: communications logging failed\n", level);
+  std::fflush(stderr);
+}
+
+[[noreturn]] void abortAfterCommsLoggingFailure() noexcept {
+  reportCommsLoggingFailureToStderr("FATAL");
+  std::abort();
+}
+
 spdlog::level::level_enum loggerLevelToSpdlogLevel(LogLevel level) {
   switch (level) {
     case LogLevel::NONE:
@@ -46,7 +57,6 @@ spdlog::level::level_enum loggerLevelToSpdlogLevel(LogLevel level) {
 }
 namespace {
 
-constexpr std::string_view kLoggerName = "comms";
 constexpr size_t kAsyncQueueSize = 8192;
 constexpr size_t kAsyncThreadCount = 1;
 /*
@@ -243,7 +253,7 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage) {
 }
 
 CommsSpdlogLogger::CommsSpdlogLogger()
-    : CommsSpdlogLogger(std::string{kLoggerName}) {}
+    : CommsSpdlogLogger(std::string{kCommsLoggerName}) {}
 
 CommsSpdlogLogger::CommsSpdlogLogger(std::string name)
     : logger_(createLogger(std::move(name))),
@@ -254,6 +264,54 @@ CommsSpdlogLogger::CommsSpdlogLogger(std::string name)
       std::make_shared<spdlog::logger>(logger_->name(), outputSink_);
   synchronousLogger_->set_level(spdlog::level::trace);
   storeConfiguration(std::make_shared<const Configuration>());
+}
+
+CommsLogStreamBase::CommsLogStreamBase(
+    CommsSpdlogLogger& logger,
+    spdlog::source_loc location,
+    spdlog::level::level_enum level)
+    : logger_(logger), location_(location), level_(level) {}
+
+std::ostream& CommsLogStreamBase::stream() {
+  return stream_;
+}
+
+void CommsLogStreamBase::log() {
+  logger_.log(location_, level_, stream_.str());
+}
+
+[[noreturn]] void CommsLogStreamBase::logFatalAndAbort() noexcept {
+  try {
+    logger_.flush();
+    spdlog::shutdown();
+    logger_.logFatal(location_, stream_.str());
+  } catch (...) {
+    abortAfterCommsLoggingFailure();
+  }
+  std::abort();
+}
+
+CommsLogStream::CommsLogStream(
+    CommsSpdlogLogger& logger,
+    spdlog::source_loc location,
+    spdlog::level::level_enum level)
+    : CommsLogStreamBase(logger, location, level) {}
+
+CommsLogStream::~CommsLogStream() noexcept {
+  try {
+    log();
+  } catch (...) {
+    reportCommsLoggingFailureToStderr("ERROR");
+  }
+}
+
+CommsFatalLogStream::CommsFatalLogStream(
+    CommsSpdlogLogger& logger,
+    spdlog::source_loc location)
+    : CommsLogStreamBase(logger, location, spdlog::level::critical) {}
+
+[[noreturn]] CommsFatalLogStream::~CommsFatalLogStream() noexcept {
+  logFatalAndAbort();
 }
 
 std::string_view CommsSpdlogLogger::getLevelName(
@@ -428,7 +486,7 @@ CommsSpdlogLogger& getSpdlogLogger() {
 }
 
 CommsSpdlogLogger& getSpdlogLogger(std::string_view loggerName) {
-  if (loggerName == kLoggerName) {
+  if (loggerName == kCommsLoggerName) {
     return getSpdlogLogger();
   }
   static std::shared_mutex mutex;
@@ -448,6 +506,15 @@ CommsSpdlogLogger& getSpdlogLogger(std::string_view loggerName) {
   auto logger = std::make_unique<CommsSpdlogLogger>(name);
   const auto it = loggers.emplace(std::move(name), std::move(logger)).first;
   return *it->second;
+}
+
+CommsSpdlogLogger& getSpdlogLoggerForFatal(
+    std::string_view loggerName) noexcept {
+  try {
+    return getSpdlogLogger(loggerName);
+  } catch (...) {
+    abortAfterCommsLoggingFailure();
+  }
 }
 
 void configureSpdlogLogger(
@@ -470,6 +537,38 @@ void configureSpdlogLogger(
       std::move(errorCallback),
       asyncLogging);
   logger.configureOutput(logFilePath);
+}
+
+void configureCommsAndNamedSpdlogLoggers(
+    std::string_view loggerName,
+    std::string logPrefix,
+    std::string_view logFilePath,
+    std::function<int(void)> threadContextFn,
+    std::function<void(std::string_view)> errorCallback,
+    bool asyncLogging,
+    spdlog::level::level_enum logLevel,
+    bool configureCommsLogger) {
+  if (configureCommsLogger || loggerName == kCommsLoggerName) {
+    configureSpdlogLogger(
+        kCommsLoggerName,
+        "COMM",
+        logFilePath,
+        threadContextFn,
+        errorCallback,
+        asyncLogging);
+    getSpdlogLogger().set_level(logLevel);
+  }
+
+  if (loggerName != kCommsLoggerName) {
+    configureSpdlogLogger(
+        loggerName,
+        std::move(logPrefix),
+        logFilePath,
+        std::move(threadContextFn),
+        std::move(errorCallback),
+        asyncLogging);
+    getSpdlogLogger(loggerName).set_level(logLevel);
+  }
 }
 
 void setSpdlogThreadName(std::string_view name) {

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -3,9 +3,12 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <cstdlib>
 #include <functional>
 #include <memory>
+#include <ostream>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -22,8 +25,11 @@
 #include <spdlog/spdlog.h>
 
 #include "comms/utils/logger/LogTypes.h"
+#include "comms/utils/logger/RateLimit.h"
 
 namespace meta::comms::logger {
+
+inline constexpr std::string_view kCommsLoggerName{"comms"};
 
 class CommsSpdlogLogger {
  public:
@@ -137,8 +143,57 @@ class CommsSpdlogLogger {
   ConfigurationStorage configuration_;
 };
 
+class CommsLogStreamBase {
+ public:
+  std::ostream& stream();
+
+ protected:
+  CommsLogStreamBase(
+      CommsSpdlogLogger& logger,
+      spdlog::source_loc location,
+      spdlog::level::level_enum level);
+  ~CommsLogStreamBase() = default;
+
+  void log();
+  [[noreturn]] void logFatalAndAbort() noexcept;
+
+ private:
+  CommsSpdlogLogger& logger_;
+  spdlog::source_loc location_;
+  spdlog::level::level_enum level_;
+  std::ostringstream stream_;
+};
+
+class CommsLogStream final : public CommsLogStreamBase {
+ public:
+  CommsLogStream(
+      CommsSpdlogLogger& logger,
+      spdlog::source_loc location,
+      spdlog::level::level_enum level);
+  ~CommsLogStream() noexcept;
+  CommsLogStream(const CommsLogStream&) = delete;
+  CommsLogStream& operator=(const CommsLogStream&) = delete;
+  CommsLogStream(CommsLogStream&&) = delete;
+  CommsLogStream& operator=(CommsLogStream&&) = delete;
+};
+
+class CommsFatalLogStream final : public CommsLogStreamBase {
+ public:
+  CommsFatalLogStream(CommsSpdlogLogger& logger, spdlog::source_loc location);
+  [[noreturn]] ~CommsFatalLogStream() noexcept;
+  CommsFatalLogStream(const CommsFatalLogStream&) = delete;
+  CommsFatalLogStream& operator=(const CommsFatalLogStream&) = delete;
+  CommsFatalLogStream(CommsFatalLogStream&&) = delete;
+  CommsFatalLogStream& operator=(CommsFatalLogStream&&) = delete;
+};
+
 CommsSpdlogLogger& getSpdlogLogger();
 CommsSpdlogLogger& getSpdlogLogger(std::string_view loggerName);
+
+void reportCommsLoggingFailureToStderr(const char* level) noexcept;
+[[noreturn]] void abortAfterCommsLoggingFailure() noexcept;
+CommsSpdlogLogger& getSpdlogLoggerForFatal(
+    std::string_view loggerName) noexcept;
 
 spdlog::level::level_enum loggerLevelToSpdlogLevel(LogLevel level);
 
@@ -153,6 +208,16 @@ void configureSpdlogLogger(
     std::function<int(void)> threadContextFn,
     std::function<void(std::string_view)> errorCallback,
     bool asyncLogging = true);
+
+void configureCommsAndNamedSpdlogLoggers(
+    std::string_view loggerName,
+    std::string logPrefix,
+    std::string_view logFilePath,
+    std::function<int(void)> threadContextFn,
+    std::function<void(std::string_view)> errorCallback,
+    bool asyncLogging,
+    spdlog::level::level_enum logLevel,
+    bool configureCommsLogger = true);
 
 void setSpdlogThreadName(std::string_view threadName);
 
@@ -176,15 +241,19 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
  * CommsSpdlogLogger owns that synchronous logger and its output sinks outside
  * spdlog's registry, so they remain valid after registry shutdown.
  */
-#define COMMS_LOG_FATAL_IMPL(logger_expression, ...)               \
-  do {                                                             \
-    auto& _comms_logger = (logger_expression);                     \
-    _comms_logger.flush();                                         \
-    ::spdlog::shutdown();                                          \
-    _comms_logger.logFatal(                                        \
-        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, \
-        __VA_ARGS__);                                              \
-    std::abort();                                                  \
+#define COMMS_LOG_FATAL_IMPL(logger_expression, ...)                 \
+  do {                                                               \
+    try {                                                            \
+      auto& _comms_logger = (logger_expression);                     \
+      _comms_logger.flush();                                         \
+      ::spdlog::shutdown();                                          \
+      _comms_logger.logFatal(                                        \
+          ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, \
+          __VA_ARGS__);                                              \
+    } catch (...) {                                                  \
+      ::meta::comms::logger::abortAfterCommsLoggingFailure();        \
+    }                                                                \
+    std::abort();                                                    \
   } while (false)
 
 #define COMMS_LOG_DBG(...)                      \
@@ -258,3 +327,146 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
 #define COMMS_LOG(level, ...) COMMS_LOG_##level(__VA_ARGS__)
 #define COMMS_LOG_NAMED(logger_name, level, ...) \
   COMMS_LOG_NAMED_##level(logger_name, __VA_ARGS__)
+
+#define COMMS_LOG_NAMED_STREAM_IMPL(logger_name, spdlog_level, condition) \
+  if (static auto& _comms_stream_logger =                                 \
+          ::meta::comms::logger::getSpdlogLogger(logger_name);            \
+      !_comms_stream_logger.should_log(spdlog_level) || !(condition)) {   \
+  } else                                                                  \
+    ::meta::comms::logger::CommsLogStream(                                \
+        _comms_stream_logger,                                             \
+        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION},        \
+        spdlog_level)                                                     \
+        .stream()
+
+#define COMMS_LOG_NAMED_FATAL_STREAM_IMPL(logger_name, condition)      \
+  if (static auto& _comms_stream_logger =                              \
+          ::meta::comms::logger::getSpdlogLoggerForFatal(logger_name); \
+      !(condition)) {                                                  \
+  } else                                                               \
+    ::meta::comms::logger::CommsFatalLogStream(                        \
+        _comms_stream_logger,                                          \
+        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION})     \
+        .stream()
+
+#define COMMS_LOG_NAMED_STREAM_DBG_IF(logger_name, condition) \
+  COMMS_LOG_NAMED_STREAM_IMPL(logger_name, ::spdlog::level::debug, condition)
+#define COMMS_LOG_NAMED_STREAM_DBG5_IF(logger_name, condition) \
+  COMMS_LOG_NAMED_STREAM_IMPL(logger_name, ::spdlog::level::trace, condition)
+#define COMMS_LOG_NAMED_STREAM_INFO_IF(logger_name, condition) \
+  COMMS_LOG_NAMED_STREAM_IMPL(logger_name, ::spdlog::level::info, condition)
+#define COMMS_LOG_NAMED_STREAM_WARN_IF(logger_name, condition) \
+  COMMS_LOG_NAMED_STREAM_IMPL(logger_name, ::spdlog::level::warn, condition)
+#define COMMS_LOG_NAMED_STREAM_WARNING_IF(logger_name, condition) \
+  COMMS_LOG_NAMED_STREAM_WARN_IF(logger_name, condition)
+#define COMMS_LOG_NAMED_STREAM_ERR_IF(logger_name, condition) \
+  COMMS_LOG_NAMED_STREAM_IMPL(logger_name, ::spdlog::level::err, condition)
+#define COMMS_LOG_NAMED_STREAM_CRITICAL_IF(logger_name, condition) \
+  COMMS_LOG_NAMED_STREAM_IMPL(logger_name, ::spdlog::level::critical, condition)
+#define COMMS_LOG_NAMED_STREAM_FATAL_IF(logger_name, condition) \
+  COMMS_LOG_NAMED_FATAL_STREAM_IMPL(logger_name, condition)
+
+#define COMMS_LOG_NAMED_STREAM_IF_IMPL(logger_name, level, condition) \
+  COMMS_LOG_NAMED_STREAM_##level##_IF(logger_name, condition)
+#define COMMS_LOG_NAMED_STREAM_IF(logger_name, level, condition) \
+  COMMS_LOG_NAMED_STREAM_IF_IMPL(logger_name, level, condition)
+#define COMMS_LOG_NAMED_STREAM(logger_name, level) \
+  COMMS_LOG_NAMED_STREAM_IF(logger_name, level, true)
+#define COMMS_LOG_STREAM(level) \
+  COMMS_LOG_NAMED_STREAM(::meta::comms::logger::kCommsLoggerName, level)
+
+#define COMMS_LOG_RATE_LIMITABLE_DBG true
+#define COMMS_LOG_RATE_LIMITABLE_DBG5 true
+#define COMMS_LOG_RATE_LIMITABLE_INFO true
+#define COMMS_LOG_RATE_LIMITABLE_WARN true
+#define COMMS_LOG_RATE_LIMITABLE_WARNING true
+#define COMMS_LOG_RATE_LIMITABLE_ERR true
+#define COMMS_LOG_RATE_LIMITABLE_CRITICAL true
+#define COMMS_LOG_RATE_LIMITABLE_FATAL false
+
+/*
+ * The interval is fixed on first use at each expansion site. Disabled levels
+ * do not consume the rate-limit budget.
+ */
+#define COMMS_LOG_NAMED_STREAM_EVERY_MS(logger_name, level, ms)            \
+  COMMS_LOG_NAMED_STREAM_IF(                                               \
+      logger_name, level, [_comms_log_stream_every_ms = (ms)] {            \
+        static_assert(                                                     \
+            COMMS_LOG_RATE_LIMITABLE_##level,                              \
+            "FATAL logging cannot be rate limited");                       \
+        static ::meta::comms::logger::IntervalRateLimiter                  \
+            comms_log_stream_rate_limiter(                                 \
+                1, std::chrono::milliseconds(_comms_log_stream_every_ms)); \
+        return comms_log_stream_rate_limiter.check();                      \
+      }())
+#define COMMS_LOG_STREAM_EVERY_MS(level, ms) \
+  COMMS_LOG_NAMED_STREAM_EVERY_MS(           \
+      ::meta::comms::logger::kCommsLoggerName, level, ms)
+
+#define COMMS_LOGGER_STREAM_IMPL(logger_expression, spdlog_level, condition) \
+  if (auto& _comms_stream_logger = (logger_expression);                      \
+      !_comms_stream_logger.should_log(spdlog_level) || !(condition)) {      \
+  } else                                                                     \
+    ::meta::comms::logger::CommsLogStream(                                   \
+        _comms_stream_logger,                                                \
+        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION},           \
+        spdlog_level)                                                        \
+        .stream()
+
+#define COMMS_LOGGER_FATAL_STREAM_IMPL(logger_expression, condition)    \
+  if (auto& _comms_stream_logger = (logger_expression); !(condition)) { \
+  } else                                                                \
+    ::meta::comms::logger::CommsFatalLogStream(                         \
+        _comms_stream_logger,                                           \
+        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION})      \
+        .stream()
+
+#define COMMS_LOGGER_STREAM_DBG_IF(logger_expression, condition) \
+  COMMS_LOGGER_STREAM_IMPL(logger_expression, ::spdlog::level::debug, condition)
+#define COMMS_LOGGER_STREAM_DBG5_IF(logger_expression, condition) \
+  COMMS_LOGGER_STREAM_IMPL(logger_expression, ::spdlog::level::trace, condition)
+#define COMMS_LOGGER_STREAM_INFO_IF(logger_expression, condition) \
+  COMMS_LOGGER_STREAM_IMPL(logger_expression, ::spdlog::level::info, condition)
+#define COMMS_LOGGER_STREAM_WARN_IF(logger_expression, condition) \
+  COMMS_LOGGER_STREAM_IMPL(logger_expression, ::spdlog::level::warn, condition)
+#define COMMS_LOGGER_STREAM_WARNING_IF(logger_expression, condition) \
+  COMMS_LOGGER_STREAM_WARN_IF(logger_expression, condition)
+#define COMMS_LOGGER_STREAM_ERR_IF(logger_expression, condition) \
+  COMMS_LOGGER_STREAM_IMPL(logger_expression, ::spdlog::level::err, condition)
+#define COMMS_LOGGER_STREAM_CRITICAL_IF(logger_expression, condition) \
+  COMMS_LOGGER_STREAM_IMPL(                                           \
+      logger_expression, ::spdlog::level::critical, condition)
+#define COMMS_LOGGER_STREAM_FATAL_IF(logger_expression, condition) \
+  COMMS_LOGGER_FATAL_STREAM_IMPL(logger_expression, condition)
+
+#define COMMS_LOGGER_STREAM_IF_IMPL(logger_expression, level, condition) \
+  COMMS_LOGGER_STREAM_##level##_IF(logger_expression, condition)
+#define COMMS_LOGGER_STREAM_IF(logger_expression, level, condition) \
+  COMMS_LOGGER_STREAM_IF_IMPL(logger_expression, level, condition)
+#define COMMS_LOGGER_STREAM(logger_expression, level) \
+  COMMS_LOGGER_STREAM_IF(logger_expression, level, true)
+
+#define COMMS_LOGGER_STREAM_EVERY_MS(logger_expression, level, ms)            \
+  COMMS_LOGGER_STREAM_IF(                                                     \
+      logger_expression, level, [_comms_logger_stream_every_ms = (ms)] {      \
+        static_assert(                                                        \
+            COMMS_LOG_RATE_LIMITABLE_##level,                                 \
+            "FATAL logging cannot be rate limited");                          \
+        static ::meta::comms::logger::IntervalRateLimiter                     \
+            comms_logger_stream_rate_limiter(                                 \
+                1, std::chrono::milliseconds(_comms_logger_stream_every_ms)); \
+        return comms_logger_stream_rate_limiter.check();                      \
+      }())
+
+#define COMMS_LOGGER_STREAM_FIRST_N(logger_expression, level, n)              \
+  COMMS_LOGGER_STREAM_IF(logger_expression, level, [&] {                      \
+    static_assert(                                                            \
+        COMMS_LOG_RATE_LIMITABLE_##level, "FATAL logging cannot be sampled"); \
+    struct comms_logger_stream_first_n_tag {};                                \
+    return ::meta::comms::logger::firstNExact<                                \
+        comms_logger_stream_first_n_tag>(n);                                  \
+  }())
+
+#define COMMS_LOG_STREAM_FIRST_N(level, n) \
+  COMMS_LOGGER_STREAM_FIRST_N(             \
+      ::meta::comms::logger::getSpdlogLogger(), level, n)

--- a/comms/utils/logger/tests/LoggerRuntimeUT.cc
+++ b/comms/utils/logger/tests/LoggerRuntimeUT.cc
@@ -1,0 +1,62 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/LoggerRuntime.h"
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/DataTableWrapper.h"
+#include "comms/utils/logger/LogTypes.h"
+
+namespace meta::comms::logger {
+namespace {
+
+class LoggerRuntimeTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    originalDebugSubsys_ = NCCL_DEBUG_SUBSYS;
+    shutdownCommLoggerRuntime();
+  }
+
+  void TearDown() override {
+    shutdownCommLoggerRuntime();
+    NCCL_DEBUG_SUBSYS = originalDebugSubsys_;
+  }
+
+ private:
+  std::string originalDebugSubsys_;
+};
+
+TEST_F(LoggerRuntimeTest, ShutdownBeforeInitializationIsNoOp) {
+  shutdownCommLoggerRuntime();
+
+  EXPECT_EQ(SCUBA_nccl_structured_logging_ptr, nullptr);
+  EXPECT_EQ(SCUBA_nccl_error_logging_ptr, nullptr);
+}
+
+TEST_F(LoggerRuntimeTest, OwnsSharedStateLifecycle) {
+  NCCL_DEBUG_SUBSYS = "INIT";
+  initCommLoggerRuntime();
+
+  EXPECT_TRUE(isEnabledSubSystemBitwise(INIT));
+  EXPECT_FALSE(isEnabledSubSystemBitwise(COLL));
+  ASSERT_NE(SCUBA_nccl_structured_logging_ptr, nullptr);
+  ASSERT_NE(SCUBA_nccl_error_logging_ptr, nullptr);
+
+  NCCL_DEBUG_SUBSYS = "COLL";
+  initCommLoggerRuntime();
+  EXPECT_TRUE(isEnabledSubSystemBitwise(INIT));
+  EXPECT_FALSE(isEnabledSubSystemBitwise(COLL));
+
+  shutdownCommLoggerRuntime();
+  initCommLoggerRuntime();
+  EXPECT_FALSE(isEnabledSubSystemBitwise(INIT));
+  EXPECT_TRUE(isEnabledSubSystemBitwise(COLL));
+  ASSERT_NE(SCUBA_nccl_structured_logging_ptr, nullptr);
+  ASSERT_NE(SCUBA_nccl_error_logging_ptr, nullptr);
+}
+
+} // namespace
+} // namespace meta::comms::logger

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -17,6 +17,8 @@
 
 #include <gtest/gtest.h>
 
+#include "comms/utils/logger/CudaLog.h"
+
 using meta::comms::logger::getSpdlogLogger;
 
 class ScopedTestFile {
@@ -67,7 +69,13 @@ bool waitForFileToContain(
 class LogLevelRestoringTest : public testing::Test {
  protected:
   void TearDown() override {
-    getSpdlogLogger().set_level(spdlog::level::info);
+    const auto resetLogger = [](auto& logger, std::string prefix) {
+      logger.configure(std::move(prefix), []() { return 0; }, {}, false);
+      logger.set_level(spdlog::level::info);
+    };
+    resetLogger(getSpdlogLogger(), "COMMS");
+    resetLogger(getSpdlogLogger("comms.paired_test"), "PAIRED");
+    resetLogger(getSpdlogLogger("comms.named_only_test"), "NAMED_ONLY");
   }
 };
 
@@ -81,6 +89,60 @@ TEST(SpdlogLoggerTest, ReturnsStableLoggerPerContext) {
   EXPECT_EQ(&ctranLogger, &getSpdlogLogger("comms.ctran"));
   EXPECT_NE(&ctranLogger, &getSpdlogLogger("comms.ncclx"));
   EXPECT_EQ(ctranLogger.name(), "comms.ctran");
+}
+
+TEST(SpdlogLoggerTest, SupportsLoggerExpressionDbg5Stream) {
+  auto& logger = getSpdlogLogger("comms.dbg5_stream_test");
+  logger.set_level(spdlog::level::off);
+
+  COMMS_LOGGER_STREAM(logger, DBG5) << "suppressed trace message";
+}
+
+TEST_F(LogLevelRestoringTest, ConfiguresSharedAndNamedLoggersTogether) {
+  constexpr std::string_view kNamedLoggerName{"comms.paired_test"};
+  std::vector<std::string> errors;
+
+  meta::comms::logger::configureCommsAndNamedSpdlogLoggers(
+      kNamedLoggerName,
+      "NAMED",
+      "",
+      []() { return 0; },
+      [&](std::string_view message) { errors.emplace_back(message); },
+      false,
+      spdlog::level::err);
+
+  COMMS_LOG(ERR, "shared error");
+  COMMS_LOG_NAMED(kNamedLoggerName, ERR, "named error");
+
+  EXPECT_EQ(errors, (std::vector<std::string>{"shared error", "named error"}));
+}
+
+TEST_F(LogLevelRestoringTest, ConfiguresOnlyNamedLoggerWhenRequested) {
+  constexpr std::string_view kNamedLoggerName{"comms.named_only_test"};
+  std::vector<std::string> sharedErrors;
+  std::vector<std::string> namedErrors;
+  getSpdlogLogger().configure(
+      "SHARED",
+      []() { return 0; },
+      [&](std::string_view message) { sharedErrors.emplace_back(message); },
+      false);
+  getSpdlogLogger().set_level(spdlog::level::err);
+
+  meta::comms::logger::configureCommsAndNamedSpdlogLoggers(
+      kNamedLoggerName,
+      "NAMED_ONLY",
+      "",
+      []() { return 0; },
+      [&](std::string_view message) { namedErrors.emplace_back(message); },
+      false,
+      spdlog::level::err,
+      false);
+
+  COMMS_LOG(ERR, "shared error");
+  COMMS_LOG_NAMED(kNamedLoggerName, ERR, "named error");
+
+  EXPECT_EQ(sharedErrors, (std::vector<std::string>{"shared error"}));
+  EXPECT_EQ(namedErrors, (std::vector<std::string>{"named error"}));
 }
 
 TEST(SpdlogLoggerTest, MatchesLegacyStderrRouting) {
@@ -218,6 +280,31 @@ TEST_F(LogLevelRestoringTest, RuntimeGateSkipsArguments) {
 
   COMMS_LOG(WARN, "enabled at runtime: {}", ++evaluationCount);
   EXPECT_EQ(evaluationCount, 1);
+}
+
+TEST_F(LogLevelRestoringTest, CudaFacadeFormatsAndGatesMessages) {
+  const ScopedTestFile scopedLogFile{"comms_cuda_log.log"};
+  auto& logger = getSpdlogLogger();
+  logger.configureOutput(scopedLogFile.path().string());
+  logger.configure("TEST", []() { return 0; }, {}, false);
+  logger.set_level(spdlog::level::warn);
+
+  int evaluationCount = 0;
+  COMMS_CUDA_LOG(INFO, "filtered value %d", ++evaluationCount);
+  COMMS_CUDA_LOG(WARN, "cuda facade value %d", 7);
+  const std::string largeMessage(600, 'x');
+  COMMS_CUDA_LOG(WARN, "large cuda facade value %s", largeMessage.c_str());
+  logger.flush();
+
+  const auto output = readFile(scopedLogFile.path());
+  EXPECT_EQ(evaluationCount, 0);
+  EXPECT_NE(output.find("cuda facade value 7"), std::string::npos);
+  EXPECT_NE(
+      output.find("large cuda facade value " + largeMessage),
+      std::string::npos);
+
+  logger.configureOutput({});
+  logger.configure("COMMS", []() { return 0; });
 }
 
 TEST_F(LogLevelRestoringTest, EmptyThreadContextUsesDefault) {

--- a/comms/utils/test_utils/CMakeLists.txt
+++ b/comms/utils/test_utils/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 find_package(CUDA REQUIRED)
+find_package(spdlog 1.16.0 CONFIG REQUIRED)
 
 file(GLOB TEST_UTILS_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cc"
@@ -12,9 +13,14 @@ add_library(test_utils OBJECT
 
 target_compile_features(test_utils PRIVATE cxx_std_20)
 target_compile_options(test_utils PRIVATE -fPIC)
+target_compile_definitions(test_utils PRIVATE
+    SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO
+    SPDLOG_FMT_EXTERNAL
+)
 target_include_directories(test_utils PUBLIC
     ${ROOT}
     ${CONDA_INCLUDE}
     ${CUDA_INCLUDE_DIRS}
 )
 target_link_libraries(test_utils PUBLIC fmt::fmt)
+target_link_libraries(test_utils PRIVATE spdlog::spdlog)


### PR DESCRIPTION
Summary:
Complete the shared logging migration by adding named spdlog stream support, initializing the shared logger, routing CollTrace diagnostics through caller-owned loggers, and migrating common check and logger utilities.

Preserve source locations, subsystem masks, rate limits, last-error propagation, structured-event initialization, and synchronous fatal termination while removing legacy compatibility dependencies no longer needed by migrated consumers.

Cvar diagnostics and DDA algorithm logs intentionally move from the NCCL line prefix to the shared COMM prefix in NCCL_DEBUG_FILE. Their payload text remains unchanged, including NCCL WARN CVAR markers, so message-based consumers continue to work; prefix-anchored consumers must recognize COMM.

Hot-path impact:
Disabled logs gate on the cached logger before condition evaluation, formatting, or rate-limit accounting. CollTrace callback dispatch replaces existing logging work and adds no polling, kernel-launch, or transport-progress work.

Reviewed By: shr

Differential Revision: D116694639
