### PR TITLE
Migrate NCCLX test logging (#3733)

### DIFF
--- a/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogIbMockTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogIbMockTest.cc
@@ -12,6 +12,7 @@
 #include "comms/mccl/tests/CudaStream.h"
 #include "comms/mccl/tests/CudaTestUtil.h"
 #include "comms/testinfra/IbverbMockTestUtils.h"
+#include "meta/NcclxLogger.h"
 
 namespace {
 struct GpuBuffer {
@@ -33,20 +34,20 @@ struct GpuBuffer {
 };
 } // namespace
 
-#define NCCLCHECK_FATAL(cmd)                                            \
-  do {                                                                  \
-    ncclResult_t res = cmd;                                             \
-    if (res != ncclSuccess) {                                           \
-      XLOGF(FATAL, "NCCL error {} '{}'", res, ncclGetErrorString(res)); \
-    }                                                                   \
+#define NCCLCHECK_FATAL(cmd)                                                \
+  do {                                                                      \
+    ncclResult_t res = cmd;                                                 \
+    if (res != ncclSuccess) {                                               \
+      NCCLX_LOG(FATAL, "NCCL error {} '{}'", res, ncclGetErrorString(res)); \
+    }                                                                       \
   } while (0)
 
-#define CUDACHECK_FATAL(cmd)                                            \
-  do {                                                                  \
-    cudaError_t err = cmd;                                              \
-    if (err != cudaSuccess) {                                           \
-      XLOGF(FATAL, "CUDA error {} '{}'", err, cudaGetErrorString(err)); \
-    }                                                                   \
+#define CUDACHECK_FATAL(cmd)                                                \
+  do {                                                                      \
+    cudaError_t err = cmd;                                                  \
+    if (err != cudaSuccess) {                                               \
+      NCCLX_LOG(FATAL, "CUDA error {} '{}'", err, cudaGetErrorString(err)); \
+    }                                                                       \
   } while (0)
 
 // RAII for NCCL Communicator
@@ -168,7 +169,7 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorWithIbVerbMock) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
   mccl::cuda::CudaStream stream;
 
   // Initialize NCCL communicator

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
@@ -12,10 +12,12 @@
 #include "comms/mccl/integration_tests/McclIntegrationTestUtil.h"
 #include "comms/mccl/tests/CudaStream.h"
 #include "comms/mccl/tests/CudaTestUtil.h"
-#include "comms/ncclx/meta/NcclxLogger.h"
 #include "comms/utils/colltrace/tests/nvidia-only/CPUControlledKernel.h"
+#include "meta/NcclxLogger.h"
 
 namespace {
+constexpr std::string_view kLogFilePrefix{"logfile"};
+
 struct GpuBuffer {
   explicit GpuBuffer(size_t size) : size_(size) {
     cudaMalloc(&ptr_, size);
@@ -35,20 +37,20 @@ struct GpuBuffer {
 };
 } // namespace
 
-#define NCCLCHECK_FATAL(cmd)                                            \
-  do {                                                                  \
-    ncclResult_t res = cmd;                                             \
-    if (res != ncclSuccess) {                                           \
-      XLOGF(FATAL, "NCCL error {} '{}'", res, ncclGetErrorString(res)); \
-    }                                                                   \
+#define NCCLCHECK_FATAL(cmd)                                                \
+  do {                                                                      \
+    ncclResult_t res = cmd;                                                 \
+    if (res != ncclSuccess) {                                               \
+      NCCLX_LOG(FATAL, "NCCL error {} '{}'", res, ncclGetErrorString(res)); \
+    }                                                                       \
   } while (0)
 
-#define CUDACHECK_FATAL(cmd)                                            \
-  do {                                                                  \
-    cudaError_t err = cmd;                                              \
-    if (err != cudaSuccess) {                                           \
-      XLOGF(FATAL, "CUDA error {} '{}'", err, cudaGetErrorString(err)); \
-    }                                                                   \
+#define CUDACHECK_FATAL(cmd)                                                \
+  do {                                                                      \
+    cudaError_t err = cmd;                                                  \
+    if (err != cudaSuccess) {                                               \
+      NCCLX_LOG(FATAL, "CUDA error {} '{}'", err, cudaGetErrorString(err)); \
+    }                                                                       \
   } while (0)
 
 // RAII for NCCL Communicator
@@ -102,7 +104,7 @@ void waitStreamWithTimeout(
       return;
     }
     if (res != cudaErrorNotReady) {
-      XLOGF(
+      NCCLX_LOG(
           FATAL, "Unexpected CUDA error {} '{}'", res, cudaGetErrorString(res));
     }
     std::this_thread::sleep_for(std::chrono::milliseconds{100});
@@ -139,7 +141,8 @@ class CollTraceWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
                     "NCCL_DEBUG=INFO",
                     fmt::format(
                         "NCCL_DEBUG_FILE={}",
-                        (tmpDir_.path() / "logfile%p").string()),
+                        (tmpDir_.path() / (std::string{kLogFilePrefix} + "%p"))
+                            .string()),
                 },
         });
   }
@@ -160,7 +163,7 @@ class CollTraceWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
         testDriverState.workerExitCodes, ::testing::Each(::testing::Eq(0)));
   }
 
-  void testDriverCheckCrashedWithWatchdog() {
+  void testDriverCheckCrashedWithWatchdog(bool expectPeerTerminations = false) {
     ASSERT_TRUE(
         std::holds_alternative<
             mccl::CollectiveIntegrationTestMixin::TestDriverState>(
@@ -172,14 +175,41 @@ class CollTraceWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
     EXPECT_THAT(
         testDriverState.workerExitCodes, ::testing::Each(::testing::Ne(0)));
 
-    int count = 0;
+    const auto expectedFileCount = testDriverState.workerExitCodes.size();
+    ASSERT_GT(expectedFileCount, 0);
+    size_t fileCount = 0;
+    size_t nonEmptyFileCount = 0;
+    size_t watchdogFatalCount = 0;
+    size_t peerFatalCount = 0;
     for (const auto& entry : folly::fs::directory_iterator(tmpDir_.path())) {
+      const auto fileName = entry.path().filename().string();
+      if (fileName.compare(0, kLogFilePrefix.size(), kLogFilePrefix) != 0) {
+        continue;
+      }
       std::string fileContents;
       ASSERT_TRUE(folly::readFile(entry.path().c_str(), fileContents));
-      EXPECT_THAT(fileContents, ::testing::HasSubstr("COMM FATAL"));
-      count++;
+      if (!fileContents.empty()) {
+        ++nonEmptyFileCount;
+      }
+      if (fileContents.find("COMM FATAL: FatalError: Collective") !=
+          std::string::npos) {
+        ++watchdogFatalCount;
+      }
+      if (fileContents.find("Peer terminated after rank 0 watchdog timeout") !=
+          std::string::npos) {
+        ++peerFatalCount;
+      }
+      ++fileCount;
     }
-    EXPECT_EQ(count, 4);
+    EXPECT_EQ(fileCount, expectedFileCount);
+    EXPECT_EQ(nonEmptyFileCount, expectedFileCount);
+    if (expectPeerTerminations) {
+      EXPECT_GE(watchdogFatalCount, 1);
+      EXPECT_EQ(peerFatalCount, expectedFileCount - 1);
+    } else {
+      EXPECT_GT(watchdogFatalCount, 0);
+      EXPECT_EQ(peerFatalCount, 0);
+    }
   }
 };
 
@@ -217,7 +247,7 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorFromGPE) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
   mccl::cuda::CudaStream stream;
 
   // Initialize NCCL communicator
@@ -272,7 +302,7 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorWithGenericAsyncError) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
@@ -313,7 +343,7 @@ TEST_F(CollTraceWatchdogTest, TestTimeoutBeforeColl) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
@@ -344,7 +374,7 @@ TEST_F(CollTraceWatchdogTest, TestTimeoutBeforeColl) {
 
 TEST_F(CollTraceWatchdogTest, TestTimeoutInColl) {
   if (isTestDriverProcess()) {
-    testDriverCheckCrashedWithWatchdog();
+    testDriverCheckCrashedWithWatchdog(true /*expectPeerTerminations*/);
     return;
   }
 
@@ -364,7 +394,7 @@ TEST_F(CollTraceWatchdogTest, TestTimeoutInColl) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
@@ -381,8 +411,9 @@ TEST_F(CollTraceWatchdogTest, TestTimeoutInColl) {
   if (rank != 0) {
     // Sleep long enough to make other ranks timeout
     std::this_thread::sleep_for(timeoutSec + std::chrono::seconds{3});
-    // Hacky way to make the driver process believe rank 0 is faulty as well.
-    NCCLX_LOG(FATAL, "COMM FATAL");
+    // Rank 0 owns the collective that times out. Terminate the peer ranks after
+    // it has had enough time to emit the production watchdog diagnostic.
+    NCCLX_LOG(FATAL, "Peer terminated after rank 0 watchdog timeout");
   } else {
     NcclAllReduce allReduce(comm.raw(), stream, 32);
     std::this_thread::sleep_for(timeoutSec + std::chrono::seconds{3});
@@ -413,7 +444,7 @@ TEST_F(CollTraceWatchdogTest, TestBelowTimeoutInColl) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
@@ -461,7 +492,7 @@ TEST_F(CollTraceWatchdogTest, TestBelowTimeoutBeforeColl) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWrapperUT.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWrapperUT.cc
@@ -18,6 +18,7 @@
 #include "comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.h"
 #include "comms/utils/colltrace/tests/MockTypes.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/NcclxLogger.h"
 #include "meta/colltrace/CollTraceWrapper.h"
 
 using namespace meta::comms::ncclx;
@@ -123,7 +124,7 @@ class CollTraceWrapperUT : public ::testing::Test {
     // Create a mock collective task
     auto* collTask = createNewCollTask();
     if (collTask == nullptr) {
-      XLOG(FATAL) << "Failed to create new collective task" << std::endl;
+      NCCLX_LOG_STREAM(FATAL) << "Failed to create new collective task";
     }
     collTask->func = ncclFuncAllReduce;
     collTask->algorithm = NCCL_ALGO_RING;

--- a/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -25,6 +25,7 @@
 #include "comms/utils/colltrace/tests/nvidia-only/CPUControlledKernel.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/Logger.h"
+#include "meta/NcclxLogger.h"
 #include "meta/commDump.h"
 
 using ::meta::comms::colltrace::CollTraceConfig;
@@ -604,7 +605,7 @@ TEST_F(CollTraceTest, winPutWait) {
   EXPECT_EQ(pastCollsJson.size(), 3 * kNumIters);
 
   for (int i = 0; i < pastCollsJson.size(); i++) {
-    XLOGF(DBG, "coll {}: {}", i, pastCollsJson[i]["opName"].asString());
+    NCCLX_LOG(DBG, "coll {}: {}", i, pastCollsJson[i]["opName"].asString());
   }
 
   for (int i = 0; i < kNumIters; i++) {

--- a/comms/ncclx/meta/tests/CommDumpTest.cc
+++ b/comms/ncclx/meta/tests/CommDumpTest.cc
@@ -17,6 +17,7 @@
 #include "comms/testinfra/TestUtils.h"
 #include "comms/utils/StrUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/NcclxLogger.h"
 
 #include "meta/NcclxConfig.h"
 #include "meta/colltrace/ProxyMock.h"
@@ -810,7 +811,7 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTrace) {
   // Check past collectives are dumped correctly and simply check if can be
   // parsed as json entries.
   if (dump.count("CT_pastColls")) {
-    XLOG(DBG1) << "Entered CT_pastColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered CT_pastColls if statement";
     auto ctPastCollsObjs = folly::parseJson(dump["CT_pastColls"]);
     EXPECT_EQ(ctPastCollsObjs.size(), numColls);
     for (int i = 0; i < numColls; i++) {
@@ -821,7 +822,7 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTrace) {
 
   // Proxy trace would be empty if nNodes == 1
   if (dump.count("PT_pastColls") && comm->nNodes > 1) {
-    XLOG(DBG1) << "Entered PT_pastColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered PT_pastColls if statement";
     auto ptPastCollsObjs = folly::parseJson(dump["PT_pastColls"]);
     EXPECT_EQ(ptPastCollsObjs.size(), numColls);
     for (int i = 0; i < numColls; i++) {
@@ -832,18 +833,18 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTrace) {
 
   // Check no pending/current entries
   if (dump.count("CT_pendingColls")) {
-    XLOG(DBG1) << "Entered CT_pendingColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered CT_pendingColls if statement";
     auto ctPendingCollsObjs = folly::parseJson(dump["CT_pendingColls"]);
     EXPECT_EQ(ctPendingCollsObjs.size(), 0);
   }
 
   if (dump.count("CT_currentColls")) {
-    XLOG(DBG1) << "Entered CT_currentColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered CT_currentColls if statement";
     EXPECT_EQ(dump["CT_currentColls"], "[]");
   }
 
   if (dump.count("PT_activeOps")) {
-    XLOG(DBG1) << "Entered PT_activeOps if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered PT_activeOps if statement";
     auto ptActiveOpsObjs = folly::parseJson(dump["PT_activeOps"]);
     EXPECT_EQ(ptActiveOpsObjs.size(), 0);
   }
@@ -905,7 +906,7 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTraceWithCommsMonitor) {
   // Check past collectives are dumped correctly and simply check if can be
   // parsed as json entries.
   if (dump.count("CT_pastColls")) {
-    XLOG(DBG1) << "Entered CT_pastColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered CT_pastColls if statement";
     auto ctPastCollsObjs = folly::parseJson(dump["CT_pastColls"]);
     EXPECT_EQ(ctPastCollsObjs.size(), numColls);
     for (int i = 0; i < numColls; i++) {
@@ -919,7 +920,7 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTraceWithCommsMonitor) {
 
   // Proxy trace would be empty if nNodes == 1
   if (dump.count("PT_pastColls") && comm->nNodes > 1) {
-    XLOG(DBG1) << "Entered PT_pastColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered PT_pastColls if statement";
     auto ptPastCollsObjs = folly::parseJson(dump["PT_pastColls"]);
     EXPECT_EQ(ptPastCollsObjs.size(), numColls);
     for (int i = 0; i < numColls; i++) {
@@ -930,18 +931,18 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTraceWithCommsMonitor) {
 
   // Check no pending/current entries
   if (dump.count("CT_pendingColls")) {
-    XLOG(DBG1) << "Entered CT_pendingColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered CT_pendingColls if statement";
     auto ctPendingCollsObjs = folly::parseJson(dump["CT_pendingColls"]);
     EXPECT_EQ(ctPendingCollsObjs.size(), 0);
   }
 
   if (dump.count("CT_currentColls")) {
-    XLOG(DBG1) << "Entered CT_currentColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered CT_currentColls if statement";
     EXPECT_EQ(dump["CT_currentColls"], "[]");
   }
 
   if (dump.count("PT_activeOps")) {
-    XLOG(DBG1) << "Entered PT_activeOps if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered PT_activeOps if statement";
     auto ptActiveOpsObjs = folly::parseJson(dump["PT_activeOps"]);
     EXPECT_EQ(ptActiveOpsObjs.size(), 0);
   }

--- a/comms/ncclx/meta/tests/LogTest.cc
+++ b/comms/ncclx/meta/tests/LogTest.cc
@@ -11,6 +11,7 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/Logger.h"
 #include "debug.h"
+#include "meta/NcclxLogger.h"
 
 class LogTest : public ::testing::Test {
  public:
@@ -126,7 +127,7 @@ TEST_F(LogTest, InfoWarnToFile) {
   const std::string kTestInfoStr = "Testing INFO to FILE";
   const std::string kTestWarnStr = "Testing WARN to FILE";
 
-  XLOG(WARN) << kDebugFile;
+  NCCLX_LOG_STREAM(WARN) << kDebugFile;
   auto envGuard0 = EnvRAII(NCCL_DEBUG_FILE, kDebugFile);
   SysEnvRAII sysDebugFileGuard("NCCL_DEBUG_FILE", kDebugFile);
   auto envGuard1 = EnvRAII(NCCL_DEBUG, std::string("INFO"));


### PR DESCRIPTION
Summary:

Migrate NCCLX logger, CollTrace, memory trace, comm dump, and parameter tests to the NCCLX and shared spdlog paths.

Remove legacy Folly test logger setup while preserving debug-file coverage, log levels, source metadata, stream behavior, last-error reporting, and watchdog fatal routing.

Hot-path impact:
This diff changes test code and test dependencies only. It adds no work to production NCCLX collective, proxy, transport, or kernel paths.

Reviewed By: shr

Differential Revision: D116694644


