### PR TITLE
Migrate MCCL test logging (#3734)

### DIFF
--- a/comms/common/algorithms/AlgoFactory.cu
+++ b/comms/common/algorithms/AlgoFactory.cu
@@ -1,9 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #include <cuda.h>
 #include <cuda_runtime.h>
-#include <folly/logging/xlog.h>
 #include "comms/common/algorithms/AlgoFactory.cuh"
 #include "comms/utils/checks.h"
+#include "comms/utils/logger/CudaLog.h"
 
 namespace meta::comms {
 
@@ -14,7 +14,7 @@ AlgoFactory::AlgoFactory(
     int maxBlocks,
     const AllReduceOptions& allReduceOpts) {
   if (allReduceOpts.enableDda) {
-    XLOG(DBG) << "Initializing AllReduceAlgoManager";
+    COMMS_CUDA_LOG(DBG, "Initializing AllReduceAlgoManager");
     for (int i = 0; i < nRanks; ++i) {
       if (i == selfRank) {
         continue;
@@ -40,7 +40,7 @@ AlgoFactory::AlgoFactory(
         allReduceOpts.ddaSendbufSizeBytes,
         allReduceOpts.ddaFlatMaxThresholdBytes,
         allReduceOpts.ddaTreeMaxThresholdBytes);
-    XLOG(DBG) << "Successfully initialized AllReduceAlgoManager";
+    COMMS_CUDA_LOG(DBG, "Successfully initialized AllReduceAlgoManager");
   }
 }
 
@@ -60,8 +60,9 @@ AlgoFactoryDev::AlgoFactoryDev(
       ddaSendbufSizeBytes_(ddaSendbufSizeBytes) {
   if (allReduceOpts.enableDda || allGatherOpts.enableDda ||
       reduceScatterOpts.enableDda || allToAllOpts.enableDda) {
-    XLOG(DBG)
-        << "Initializing AllReduce / AllGather / ReduceScatter / AllToAll AlgoManager";
+    COMMS_CUDA_LOG(
+        DBG,
+        "Initializing AllReduce / AllGather / ReduceScatter / AllToAll AlgoManager");
 
     for (int i = 0; i < nRanks; ++i) {
       if (i == selfRank) {

--- a/comms/common/algorithms/all_gather/AllGatherAlgoManager.cu
+++ b/comms/common/algorithms/all_gather/AllGatherAlgoManager.cu
@@ -2,6 +2,8 @@
 
 #include "comms/common/algorithms/all_gather/AllGatherAlgoManager.h"
 
+#include "comms/utils/logger/CudaLog.h"
+
 namespace meta::comms {
 
 AllGatherAlgoManager::AllGatherAlgoManager(
@@ -19,7 +21,7 @@ AllGatherAlgoManager::AllGatherAlgoManager(
       ddaMaxThresholdBytes_(ddaMaxThresholdBytes),
       allRankDdaSendbuffs_(allRankDdaSendbuffs),
       barrier_(barrier) {
-  XLOG(DBG) << "Successfully initialized AllGatherAlgoManager";
+  COMMS_CUDA_LOG(DBG, "Successfully initialized AllGatherAlgoManager");
 }
 
 std::unique_ptr<AlgoAllGather> AllGatherAlgoManager::getAllGatherAlgo(
@@ -30,41 +32,48 @@ std::unique_ptr<AlgoAllGather> AllGatherAlgoManager::getAllGatherAlgo(
     cudaStream_t stream) {
   if ((nRanks_ * count * commTypeSize(datatype)) > ddaSendbufSizeBytes_) {
     // AG: msgSize = (nRanks_ x count x datatype) must fit into the dda sendbuf
-    XLOG(DBG) << "Not using custom all gather algo because message size "
-              << nRanks_ * count * commTypeSize(datatype)
-              << " is larger than ddaSendbufSizeBytes " << ddaSendbufSizeBytes_;
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all gather algo because message size %zu is larger than ddaSendbufSizeBytes %d",
+        nRanks_ * count * commTypeSize(datatype),
+        ddaSendbufSizeBytes_);
     return nullptr;
   }
 
   if (((uintptr_t)sendbuff % 16) || ((uintptr_t)recvbuff % 16) ||
       ((count * commTypeSize(datatype)) % 16)) {
     // 16 byte alignment as we do 16-byte loads in DDA kernel
-    XLOG(DBG) << "Not using custom all gather algo because send/recv buff "
-                 "or msg size is not 16-byte aligned";
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all gather algo because send/recv buff or msg size is not 16-byte aligned");
     return nullptr;
   }
 
   if (datatype != commBfloat16 && datatype != commFloat16 &&
       datatype != commFloat) {
     // we currently only support bf16, half, float
-    XLOG(DBG)
-        << "Not using custom all gather algo because cudaDataType_t datatype "
-        << static_cast<int>(datatype) << " is not supported";
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all gather algo because cudaDataType_t datatype %d is not supported",
+        static_cast<int>(datatype));
     return nullptr;
   }
 
   std::unique_ptr<AlgoAllGather> algo;
   if ((nRanks_ * count * commTypeSize(datatype)) > ddaMaxThresholdBytes_) {
     // AG: msgSize = (nRanks_ x count x datatype) must less than algo threshold
-    XLOG(DBG) << "Not using custom all gather algo because msg size "
-              << nRanks_ * count * commTypeSize(datatype)
-              << " is larger than DDA algo threshold " << ddaMaxThresholdBytes_;
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all gather algo because msg size %zu is larger than DDA algo threshold %d",
+        nRanks_ * count * commTypeSize(datatype),
+        ddaMaxThresholdBytes_);
     return nullptr;
   } else {
     if (((count * commTypeSize(datatype)) % 16) ||
         ((nRanks_ * count * commTypeSize(datatype)) % 16)) {
-      XLOG(DBG) << "Not using DDA all gather algo because send/recv buff "
-                   "or msg size is not 16-byte aligned for each rank";
+      COMMS_CUDA_LOG(
+          DBG,
+          "Not using DDA all gather algo because send/recv buff or msg size is not 16-byte aligned for each rank");
       return nullptr;
     }
     algo = std::make_unique<AlgoAllGatherDdaIpc>(

--- a/comms/common/algorithms/all_gather/tests/all_gather_dda_test.cu
+++ b/comms/common/algorithms/all_gather/tests/all_gather_dda_test.cu
@@ -3,13 +3,14 @@
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
+
 #include "comms/common/IpcGpuBarrier.cuh"
 #include "comms/common/algorithms/all_gather/all_gather_dda.cuh"
 #include "comms/common/tests/TestBaselineBootstrap.h"
 #include "comms/rcclx/develop/meta/lib/tests/RcclxTestUtils.h"
 #include "comms/utils/CudaRAII.h"
+#include "comms/utils/logger/CudaLog.h"
 
 using namespace meta::rcclx;
 using namespace meta::comms;
@@ -30,7 +31,8 @@ class AllGatherDdaTest : public RcclxBaseTestFixture {
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
     NCCL_CHECK(
         ncclCommInitRankConfig(&comm, numRanks, commId, globalRank, &config));
-    XLOGF(INFO, "rank {} init done; total ranks: {}", globalRank, numRanks);
+    COMMS_CUDA_LOG(
+        INFO, "rank %d init done; total ranks: %d", globalRank, numRanks);
 
     ASSERT_EQ(numRanks, NUMRANKS);
     CUDA_CHECK(cudaSetDevice(globalRank));

--- a/comms/common/algorithms/all_reduce/AllReduceAlgoManager.cu
+++ b/comms/common/algorithms/all_reduce/AllReduceAlgoManager.cu
@@ -2,6 +2,8 @@
 
 #include "comms/common/algorithms/all_reduce/AllReduceAlgoManager.h"
 
+#include "comms/utils/logger/CudaLog.h"
+
 namespace meta::comms {
 
 AllReduceAlgoManager::AllReduceAlgoManager(
@@ -40,7 +42,7 @@ AllReduceAlgoManager::AllReduceAlgoManager(
       ipcSendbufs.data(),
       sizeof(void*) * nRanks_,
       cudaMemcpyDefault));
-  XLOG(DBG) << "Successfully initialized AllReduceAlgoManager";
+  COMMS_CUDA_LOG(DBG, "Successfully initialized AllReduceAlgoManager");
 }
 
 std::unique_ptr<AlgoAllReduce> AllReduceAlgoManager::getAllReduceAlgo(
@@ -70,7 +72,7 @@ AllReduceAlgoManagerDev::AllReduceAlgoManagerDev(
       ddaTreeMaxThresholdBytes_(ddaTreeMaxThresholdBytes),
       allRankDdaSendbuffs_(allRankDdaSendbuffs),
       barrier_(barrier) {
-  XLOG(DBG) << "Successfully initialized AllReduceAlgoManager";
+  COMMS_CUDA_LOG(DBG, "Successfully initialized AllReduceAlgoManager");
 }
 
 std::unique_ptr<AlgoAllReduce> AllReduceAlgoManagerDev::getAllReduceAlgo(
@@ -82,42 +84,48 @@ std::unique_ptr<AlgoAllReduce> AllReduceAlgoManagerDev::getAllReduceAlgo(
     const void* acc) {
   if ((count * commTypeSize(datatype)) > ddaSendbufSizeBytes_) {
     // AllReduce: (count x datatype) size must fit into the dda sendbuf
-    XLOG(DBG) << "Not using custom all reduce algo because message size "
-              << count * commTypeSize(datatype)
-              << " is larger than ddaSendbufSizeBytes " << ddaSendbufSizeBytes_;
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all reduce algo because message size %zu is larger than ddaSendbufSizeBytes %d",
+        count * commTypeSize(datatype),
+        ddaSendbufSizeBytes_);
     return nullptr;
   }
 
   if (((uintptr_t)sendbuff % 16) || ((uintptr_t)recvbuff % 16) ||
       ((count * commTypeSize(datatype)) % 16)) {
     // 16 byte alignment as we do 16-byte loads in DDA kernel
-    XLOG(DBG) << "Not using custom all reduce algo because send/recv buff "
-                 "or msg size is not 16-byte aligned";
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all reduce algo because send/recv buff or msg size is not 16-byte aligned");
     return nullptr;
   }
 
   if (datatype != commBfloat16 && datatype != commFloat16 &&
       datatype != commFloat) {
     // we currently only support bf16, half, float
-    XLOG(DBG)
-        << "Not using custom all reduce algo because cudaDataType_t datatype "
-        << static_cast<int>(datatype) << " is not supported";
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all reduce algo because cudaDataType_t datatype %d is not supported",
+        static_cast<int>(datatype));
     return nullptr;
   }
 
   std::unique_ptr<AlgoAllReduce> algo;
   if (count * commTypeSize(datatype) > ddaTreeMaxThresholdBytes_) {
-    XLOG(DBG) << "Not using custom all reduce algo because msg size "
-              << count * commTypeSize(datatype)
-              << " is larger than DDA algo threshold "
-              << ddaTreeMaxThresholdBytes_;
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all reduce algo because msg size %zu is larger than DDA algo threshold %d",
+        count * commTypeSize(datatype),
+        ddaTreeMaxThresholdBytes_);
     return nullptr;
   } else if (count * commTypeSize(datatype) > ddaFlatMaxThresholdBytes_) {
     if (count % nRanks_ || ((count / nRanks_ * commTypeSize(datatype)) % 16)) {
       // In two-shot algo, each rank is reduces count/nRanks_ elements so we
       // need to make sure that is 16-byte aligned
-      XLOG(DBG) << "Not using DDA Tree all reduce algo because send/recv buff "
-                   "or msg size is not 16-byte aligned for each rank";
+      COMMS_CUDA_LOG(
+          DBG,
+          "Not using DDA Tree all reduce algo because send/recv buff or msg size is not 16-byte aligned for each rank");
       return nullptr;
     }
     algo = std::make_unique<AlgoAllReduceDdaTreeIpc>(

--- a/comms/common/algorithms/all_reduce/tests/all_reduce_dda_test.cu
+++ b/comms/common/algorithms/all_reduce/tests/all_reduce_dda_test.cu
@@ -4,13 +4,14 @@
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
+
 #include "comms/common/IpcGpuBarrier.cuh"
 #include "comms/common/algorithms/all_reduce/all_reduce_dda.cuh"
 #include "comms/common/tests/TestBaselineBootstrap.h"
 #include "comms/rcclx/develop/meta/lib/tests/RcclxTestUtils.h"
 #include "comms/utils/CudaRAII.h"
+#include "comms/utils/logger/CudaLog.h"
 
 using namespace meta::rcclx;
 using namespace meta::comms;
@@ -31,7 +32,8 @@ class AllReduceDdaTest : public RcclxBaseTestFixture {
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
     NCCL_CHECK(
         ncclCommInitRankConfig(&comm, numRanks, commId, globalRank, &config));
-    XLOGF(INFO, "rank {} init done; total ranks: {}", globalRank, numRanks);
+    COMMS_CUDA_LOG(
+        INFO, "rank %d init done; total ranks: %d", globalRank, numRanks);
 
     ASSERT_EQ(numRanks, NUMRANKS);
     CUDA_CHECK(cudaSetDevice(globalRank));

--- a/comms/common/algorithms/all_to_all/AllToAllAlgoManager.cu
+++ b/comms/common/algorithms/all_to_all/AllToAllAlgoManager.cu
@@ -2,6 +2,8 @@
 
 #include "comms/common/algorithms/all_to_all/AllToAllAlgoManager.h"
 
+#include "comms/utils/logger/CudaLog.h"
+
 namespace meta::comms {
 
 AllToAllAlgoManager::AllToAllAlgoManager(
@@ -19,7 +21,7 @@ AllToAllAlgoManager::AllToAllAlgoManager(
       ddaMaxThresholdBytes_(ddaMaxThresholdBytes),
       allRankDdaSendbuffs_(allRankDdaSendbuffs),
       barrier_(barrier) {
-  XLOG(DBG) << "Successfully initialized AllToAllAlgoManager";
+  COMMS_CUDA_LOG(DBG, "Successfully initialized AllToAllAlgoManager");
 }
 
 std::unique_ptr<AlgoAllToAll> AllToAllAlgoManager::getAllToAllAlgo(
@@ -30,41 +32,48 @@ std::unique_ptr<AlgoAllToAll> AllToAllAlgoManager::getAllToAllAlgo(
     cudaStream_t stream) {
   if ((nRanks_ * count * commTypeSize(datatype)) > ddaSendbufSizeBytes_) {
     // A2A: msgSize = (nRanks_ x count x datatype) must fit into the dda sendbuf
-    XLOG(DBG) << "Not using custom all-to-all algo because message size "
-              << count * commTypeSize(datatype)
-              << " is larger than ddaSendbufSizeBytes " << ddaSendbufSizeBytes_;
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all-to-all algo because message size %zu is larger than ddaSendbufSizeBytes %d",
+        count * commTypeSize(datatype),
+        ddaSendbufSizeBytes_);
     return nullptr;
   }
 
   if (((uintptr_t)sendbuff % 16) || ((uintptr_t)recvbuff % 16) ||
       ((count * commTypeSize(datatype)) % 16)) {
     // 16 byte alignment as we do 16-byte loads in DDA kernel
-    XLOG(DBG) << "Not using custom all-to-all algo because send/recv buff "
-                 "or msg size is not 16-byte aligned";
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all-to-all algo because send/recv buff or msg size is not 16-byte aligned");
     return nullptr;
   }
 
   if (datatype != commBfloat16 && datatype != commFloat16 &&
       datatype != commFloat) {
     // we currently only support bf16, half, float
-    XLOG(DBG)
-        << "Not using custom all-to-all algo because cudaDataType_t datatype "
-        << static_cast<int>(datatype) << " is not supported";
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all-to-all algo because cudaDataType_t datatype %d is not supported",
+        static_cast<int>(datatype));
     return nullptr;
   }
 
   std::unique_ptr<AlgoAllToAll> algo;
   if ((nRanks_ * count * commTypeSize(datatype)) > ddaMaxThresholdBytes_) {
     // A2A: msgSize = (nRanks_ x count x datatype) must less than algo threshold
-    XLOG(DBG) << "Not using custom all-to-all algo because msg size "
-              << nRanks_ * count * commTypeSize(datatype)
-              << " is larger than DDA algo threshold " << ddaMaxThresholdBytes_;
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom all-to-all algo because msg size %zu is larger than DDA algo threshold %d",
+        nRanks_ * count * commTypeSize(datatype),
+        ddaMaxThresholdBytes_);
     return nullptr;
   } else {
     if (((count * commTypeSize(datatype)) % 16) ||
         ((nRanks_ * count * commTypeSize(datatype)) % 16)) {
-      XLOG(DBG) << "Not using DDA all-to-all algo because send/recv buff "
-                   "or msg size is not 16-byte aligned for each rank";
+      COMMS_CUDA_LOG(
+          DBG,
+          "Not using DDA all-to-all algo because send/recv buff or msg size is not 16-byte aligned for each rank");
       return nullptr;
     }
     algo = std::make_unique<AlgoAllToAllDdaIpc>(

--- a/comms/common/algorithms/all_to_all/tests/all_to_all_dda_test.cu
+++ b/comms/common/algorithms/all_to_all/tests/all_to_all_dda_test.cu
@@ -3,13 +3,14 @@
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
+
 #include "comms/common/IpcGpuBarrier.cuh"
 #include "comms/common/algorithms/all_to_all/all_to_all_dda.cuh"
 #include "comms/common/tests/TestBaselineBootstrap.h"
 #include "comms/rcclx/develop/meta/lib/tests/RcclxTestUtils.h"
 #include "comms/utils/CudaRAII.h"
+#include "comms/utils/logger/CudaLog.h"
 
 using namespace meta::rcclx;
 using namespace meta::comms;
@@ -30,7 +31,8 @@ class AllToAllDdaTest : public RcclxBaseTestFixture {
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
     NCCL_CHECK(
         ncclCommInitRankConfig(&comm, numRanks, commId, globalRank, &config));
-    XLOGF(INFO, "rank {} init done; total ranks: {}", globalRank, numRanks);
+    COMMS_CUDA_LOG(
+        INFO, "rank %d init done; total ranks: %d", globalRank, numRanks);
 
     ASSERT_EQ(numRanks, NUMRANKS);
     CUDA_CHECK(cudaSetDevice(globalRank));

--- a/comms/common/algorithms/reduce_scatter/ReduceScatterAlgoManager.cu
+++ b/comms/common/algorithms/reduce_scatter/ReduceScatterAlgoManager.cu
@@ -2,6 +2,8 @@
 
 #include "comms/common/algorithms/reduce_scatter/ReduceScatterAlgoManager.h"
 
+#include "comms/utils/logger/CudaLog.h"
+
 namespace meta::comms {
 
 ReduceScatterAlgoManager::ReduceScatterAlgoManager(
@@ -19,7 +21,7 @@ ReduceScatterAlgoManager::ReduceScatterAlgoManager(
       ddaMaxThresholdBytes_(ddaMaxThresholdBytes),
       allRankDdaSendbuffs_(allRankDdaSendbuffs),
       barrier_(barrier) {
-  XLOG(DBG) << "Successfully initialized ReduceScatterAlgoManager";
+  COMMS_CUDA_LOG(DBG, "Successfully initialized ReduceScatterAlgoManager");
 }
 
 std::unique_ptr<AlgoReduceScatter>
@@ -31,40 +33,47 @@ ReduceScatterAlgoManager::getReduceScatterAlgo(
     cudaStream_t stream) {
   if ((nRanks_ * count * commTypeSize(datatype)) > ddaSendbufSizeBytes_) {
     // RS: msgSize = (nRanks_ x count x datatype) must fit into the dda sendbuf
-    XLOG(DBG) << "Not using custom reduce scatter algo because message size "
-              << count * commTypeSize(datatype)
-              << " is larger than ddaSendbufSizeBytes " << ddaSendbufSizeBytes_;
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom reduce scatter algo because message size %zu is larger than ddaSendbufSizeBytes %d",
+        count * commTypeSize(datatype),
+        ddaSendbufSizeBytes_);
     return nullptr;
   }
   if (((uintptr_t)sendbuff % 16) || ((uintptr_t)recvbuff % 16) ||
       ((count * commTypeSize(datatype)) % 16)) {
     // 16 byte alignment as we do 16-byte loads in DDA kernel
-    XLOG(DBG) << "Not using custom reduce scatter algo because send/recv buff "
-                 "or msg size is not 16-byte aligned";
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom reduce scatter algo because send/recv buff or msg size is not 16-byte aligned");
     return nullptr;
   }
 
   if (datatype != commBfloat16 && datatype != commFloat16 &&
       datatype != commFloat) {
     // we currently only support bf16, half, float
-    XLOG(DBG)
-        << "Not using custom reduce scatter algo because cudaDataType_t datatype "
-        << static_cast<int>(datatype) << " is not supported";
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom reduce scatter algo because cudaDataType_t datatype %d is not supported",
+        static_cast<int>(datatype));
     return nullptr;
   }
 
   std::unique_ptr<AlgoReduceScatter> algo;
   if ((nRanks_ * count * commTypeSize(datatype)) > ddaMaxThresholdBytes_) {
     // RS: msgSize = (nRanks_ x count x datatype) must less than algo threshold
-    XLOG(DBG) << "Not using custom reduce scatter algo because msg size "
-              << nRanks_ * count * commTypeSize(datatype)
-              << " is larger than DDA algo threshold " << ddaMaxThresholdBytes_;
+    COMMS_CUDA_LOG(
+        DBG,
+        "Not using custom reduce scatter algo because msg size %zu is larger than DDA algo threshold %d",
+        nRanks_ * count * commTypeSize(datatype),
+        ddaMaxThresholdBytes_);
     return nullptr;
   } else {
     if (((count * commTypeSize(datatype)) % 16) ||
         ((nRanks_ * count * commTypeSize(datatype)) % 16)) {
-      XLOG(DBG) << "Not using DDA reduce scatter algo because send/recv buff "
-                   "or msg size is not 16-byte aligned for each rank";
+      COMMS_CUDA_LOG(
+          DBG,
+          "Not using DDA reduce scatter algo because send/recv buff or msg size is not 16-byte aligned for each rank");
       return nullptr;
     }
     algo = std::make_unique<AlgoReduceScatterDdaIpc>(

--- a/comms/common/algorithms/reduce_scatter/tests/reduce_scatter_dda_test.cu
+++ b/comms/common/algorithms/reduce_scatter/tests/reduce_scatter_dda_test.cu
@@ -3,13 +3,14 @@
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
+
 #include "comms/common/IpcGpuBarrier.cuh"
 #include "comms/common/algorithms/reduce_scatter/reduce_scatter_dda.cuh"
 #include "comms/common/tests/TestBaselineBootstrap.h"
 #include "comms/rcclx/develop/meta/lib/tests/RcclxTestUtils.h"
 #include "comms/utils/CudaRAII.h"
+#include "comms/utils/logger/CudaLog.h"
 
 using namespace meta::rcclx;
 using namespace meta::comms;
@@ -30,7 +31,8 @@ class ReduceScatterDdaTest : public RcclxBaseTestFixture {
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
     NCCL_CHECK(
         ncclCommInitRankConfig(&comm, numRanks, commId, globalRank, &config));
-    XLOGF(INFO, "rank {} init done; total ranks: {}", globalRank, numRanks);
+    COMMS_CUDA_LOG(
+        INFO, "rank %d init done; total ranks: %d", globalRank, numRanks);
 
     ASSERT_EQ(numRanks, NUMRANKS);
     CUDA_CHECK(cudaSetDevice(globalRank));

--- a/comms/common/algorithms/tests/AlgoFactoryTest.cu
+++ b/comms/common/algorithms/tests/AlgoFactoryTest.cu
@@ -1,10 +1,10 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include "comms/common/algorithms/AlgoFactory.cuh"
 #include "comms/common/tests/TestBaselineBootstrap.h"
 #include "comms/rcclx/develop/meta/lib/tests/RcclxTestUtils.h"
 #include "comms/utils/CudaRAII.h"
+#include "comms/utils/logger/CudaLog.h"
 
 using namespace meta::rcclx;
 using namespace meta::comms;
@@ -31,7 +31,8 @@ class AlgoFactoryTest : public RcclxBaseTestFixture {
     ncclComm_t comm{nullptr};
     NCCL_CHECK(
         ncclCommInitRankConfig(&comm, numRanks, commId, globalRank, &config));
-    XLOGF(INFO, "rank {} init done; total ranks: {}", globalRank, numRanks);
+    COMMS_CUDA_LOG(
+        INFO, "rank %d init done; total ranks: %d", globalRank, numRanks);
 
     ASSERT_EQ(numRanks, 8);
     CUDA_CHECK(cudaSetDevice(localRank));

--- a/comms/common/tests/IpcGpuBarrierTest.cu
+++ b/comms/common/tests/IpcGpuBarrierTest.cu
@@ -3,14 +3,15 @@
 #include <cuda_runtime.h>
 #include <folly/Random.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <folly/stop_watch.h>
 #include <gtest/gtest.h>
+
 #include "comms/common/IpcGpuBarrier.cuh"
 #include "comms/common/IpcMemHandler.h"
 #include "comms/common/tests/TestBaselineBootstrap.h"
 #include "comms/rcclx/develop/meta/lib/tests/RcclxTestUtils.h"
 #include "comms/utils/CudaRAII.h"
+#include "comms/utils/logger/CudaLog.h"
 
 using namespace meta::rcclx;
 using namespace meta::comms;
@@ -50,7 +51,8 @@ class DeviceMailboxTest : public RcclxBaseTestFixture,
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
     NCCL_CHECK(
         ncclCommInitRankConfig(&comm, numRanks, commId, localRank, &config));
-    XLOGF(INFO, "rank {} init done; total ranks: {}", localRank, numRanks);
+    COMMS_CUDA_LOG(
+        INFO, "rank %d init done; total ranks: %d", localRank, numRanks);
   }
 
   bool needMemFence;
@@ -143,7 +145,8 @@ class IpcGpuBarrierTest : public RcclxBaseTestFixture {
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
     NCCL_CHECK(
         ncclCommInitRankConfig(&comm, numRanks, commId, localRank, &config));
-    XLOGF(INFO, "rank {} init done; total ranks: {}", localRank, numRanks);
+    COMMS_CUDA_LOG(
+        INFO, "rank %d init done; total ranks: %d", localRank, numRanks);
   }
 
   bool needMemFence;

--- a/comms/common/tests/IpcMemHandlerTest.cc
+++ b/comms/common/tests/IpcMemHandlerTest.cc
@@ -3,11 +3,12 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
+
 #include "comms/common/tests/TestBaselineBootstrap.h"
 #include "comms/rcclx/develop/meta/lib/tests/RcclxTestUtils.h"
 #include "comms/utils/CudaRAII.h"
+#include "comms/utils/logger/CudaLog.h"
 
 using namespace meta::rcclx;
 using namespace meta::comms;
@@ -23,7 +24,8 @@ TEST_F(IpcMemHandlerTest, exchangeMemPtrs) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   NCCL_CHECK(
       ncclCommInitRankConfig(&comm, numRanks, commId, globalRank, &config));
-  XLOGF(INFO, "rank {} init done; total ranks: {}", globalRank, numRanks);
+  COMMS_CUDA_LOG(
+      INFO, "rank %d init done; total ranks: %d", globalRank, numRanks);
 
   int myValue = globalRank;
   DeviceBuffer myBuf(sizeof(myValue));

--- a/comms/ctran/algos/perftrace/examples/PerfTraceDistHelloWorld.cc
+++ b/comms/ctran/algos/perftrace/examples/PerfTraceDistHelloWorld.cc
@@ -8,6 +8,7 @@
 #include <folly/init/Init.h>
 
 #include "comms/ctran/algos/perftrace/examples/PerfTraceExampleHelper.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -46,12 +47,12 @@ TEST_F(PerfTraceDistTest, DistributedTracing) {
   ASSERT_GE(globalRank, 0) << "MPI rank not initialized";
   ASSERT_GT(numRanks, 0) << "MPI numRanks not initialized";
 
-  XLOG(INFO) << "Rank " << globalRank << ": starting PerfTrace example";
+  CTRAN_LOG(INFO, "Rank {}: starting PerfTrace example", globalRank);
 
   // Each rank traces its own algorithm execution
   traceAlgo(globalRank, numRanks);
 
-  XLOG(INFO) << "Rank " << globalRank << ": PerfTrace example completed";
+  CTRAN_LOG(INFO, "Rank {}: PerfTrace example completed", globalRank);
 }
 
 } // namespace ctran::perftrace

--- a/comms/ctran/commstate/Topology.cc
+++ b/comms/ctran/commstate/Topology.cc
@@ -3,6 +3,8 @@
 #include <cstring>
 #include <fstream>
 
+#include <folly/String.h>
+
 #include "comms/ctran/commstate/Topology.h"
 #include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"

--- a/comms/ctran/ibverbx/tests/IbverbxTest.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxTest.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/ctran/ibverbx/tests/IbverbxTestFixture.h"
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include <folly/ScopeGuard.h>
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
@@ -59,10 +60,10 @@ TEST_F(IbverbxTestFixture, IbvGetDeviceList) {
     ASSERT_GT(ibvDevices->size(), 0);
 
     // Print all found ibv device names
-    XLOGF(INFO, "Found {} InfiniBand devices:", ibvDevices->size());
+    CTRAN_LOG(INFO, "Found {} InfiniBand devices:", ibvDevices->size());
     for (size_t i = 0; i < ibvDevices->size(); ++i) {
       const auto& device = ibvDevices->at(i);
-      XLOGF(INFO, "  Device[{}]: {}", i, device.device()->name);
+      CTRAN_LOG(INFO, "  Device[{}]: {}", i, device.device()->name);
     }
   }
   {
@@ -87,7 +88,7 @@ TEST_F(IbverbxTestFixture, IbvGetDeviceList) {
           numDevicesToSelect,
           gen);
 
-      XLOGF(
+      CTRAN_LOG(
           INFO,
           "Testing exact match (in order) with {} randomly selected devices",
           numDevicesToSelect);
@@ -122,7 +123,7 @@ TEST_F(IbverbxTestFixture, IbvGetDeviceList) {
       // Shuffle to create out-of-order
       std::shuffle(selectedDevices.begin(), selectedDevices.end(), gen);
 
-      XLOGF(
+      CTRAN_LOG(
           INFO,
           "Testing exact match (out of order) with {} randomly selected and shuffled devices",
           numDevicesToSelect);
@@ -154,7 +155,7 @@ TEST_F(IbverbxTestFixture, IbvGetDeviceList) {
           numDevicesToExclude,
           gen);
 
-      XLOGF(
+      CTRAN_LOG(
           INFO,
           "Testing exclude (in order) with {} randomly selected devices to exclude",
           numDevicesToExclude);
@@ -197,7 +198,7 @@ TEST_F(IbverbxTestFixture, IbvGetDeviceList) {
       // Shuffle the exclusion list
       std::shuffle(devicesToExclude.begin(), devicesToExclude.end(), gen);
 
-      XLOGF(
+      CTRAN_LOG(
           INFO,
           "Testing exclude (out of order) with {} randomly selected and shuffled devices to exclude",
           numDevicesToExclude);
@@ -377,7 +378,7 @@ TEST_F(IbverbxTestFixture, regMr) {
 
   for (size_t size : sizes) {
     void* devBuf{nullptr};
-    XLOGF(INFO, "regMr testing with buffer size: {} bytes", size);
+    CTRAN_LOG(INFO, "regMr testing with buffer size: {} bytes", size);
     CUDA_CHECK(cudaMalloc(&devBuf, size));
     auto mr = pd->regMr(devBuf, size, access);
     EXPECT_TRUE(mr);
@@ -621,7 +622,7 @@ TEST_F(IbverbxTestFixture, IbvCqGetDeviceCq) {
   ASSERT_GE(deviceCq.ncqes, cqe);
   ASSERT_NE(deviceCq.cq_dbrec, nullptr);
 
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "Device CQ: cq_buf={}, ncqes={}, cq_dbrec={}",
       deviceCq.cq_buf,
@@ -677,7 +678,7 @@ TEST_F(IbverbxTestFixture, IbvQpGetDeviceQp) {
   ASSERT_EQ(deviceQp.producer_idx, 0);
   ASSERT_EQ(deviceQp.consumer_idx, 0);
 
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "Device QP: qp_num={}, wq_buf={}, nwqes={}, sq_dbrec={}, bf_reg={}, cq={}",
       deviceQp.qp_num,

--- a/comms/ctran/utils/CtranLogUtils.h
+++ b/comms/ctran/utils/CtranLogUtils.h
@@ -6,13 +6,23 @@
 
 #include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/LogTypes.h"
+#include "comms/utils/logger/LoggingFormat.h"
 
-#define CTRAN_LOG_SUBSYS(level, subsys, ...) \
-  CTRAN_LOG_IF(level, CLOGF_ENABLED(subsys), __VA_ARGS__)
+#define CTRAN_LOG_SUBSYS(level, subsys, ...)            \
+  CTRAN_LOG_IF(                                         \
+      level,                                            \
+      ::meta::comms::logger::isEnabledSubSystemBitwise( \
+          static_cast<uint64_t>([]() {                  \
+            using namespace ::meta::comms::logger;      \
+            return subsys;                              \
+          }())),                                        \
+      __VA_ARGS__)
 
-// The interval is fixed on first use at each expansion site, matching
-// CLOGF_EVERY_MS; callers must pass a call-site constant.
+/*
+ * The interval is fixed on first use at each expansion site, matching the
+ * legacy Comms logger; callers must pass a call-site constant.
+ */
 #define CTRAN_LOG_EVERY_MS(level, ms, ...)                          \
   CTRAN_LOG_IF(                                                     \
       level,                                                        \
@@ -23,6 +33,9 @@
         return ctran_log_rate_limiter.check();                      \
       }(),                                                          \
       __VA_ARGS__)
+
+#define CTRAN_LOG_STREAM_EVERY_MS(level, ms) \
+  COMMS_LOG_NAMED_STREAM_EVERY_MS(::ctran::logging::kCtranLoggerName, level, ms)
 
 #define CTRAN_LOG_TRACE(subsys, format, ...)                             \
   do {                                                                   \

--- a/comms/ctran/utils/CtranLogger.h
+++ b/comms/ctran/utils/CtranLogger.h
@@ -13,28 +13,57 @@ inline constexpr std::string_view kCtranLoggerName = "comms.ctran";
 
 } // namespace ctran::logging
 
-#define CTRAN_LOG(level, ...) \
-  COMMS_LOG_NAMED(::ctran::logging::kCtranLoggerName, level, __VA_ARGS__)
-
-#define CTRAN_LOG_SYNC_ERR(...)                                      \
-  do {                                                               \
-    auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger(    \
-        ::ctran::logging::kCtranLoggerName);                         \
-    if (_ctran_logger.should_log(::spdlog::level::err)) {            \
-      _ctran_logger.logSynchronous(                                  \
-          ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, \
-          ::spdlog::level::err,                                      \
-          __VA_ARGS__);                                              \
-    }                                                                \
+#define CTRAN_LOG_IMPL(spdlog_level, spdlog_macro, ...)                  \
+  do {                                                                   \
+    static auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger( \
+        ::ctran::logging::kCtranLoggerName);                             \
+    if (_ctran_logger.should_log(spdlog_level)) {                        \
+      spdlog_macro(&_ctran_logger, __VA_ARGS__);                         \
+    }                                                                    \
   } while (false)
 
-#define CTRAN_LOG_IF_IMPL(level, spdlog_level, condition, ...)    \
-  do {                                                            \
-    auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger( \
-        ::ctran::logging::kCtranLoggerName);                      \
-    if (_ctran_logger.should_log(spdlog_level) && (condition)) {  \
-      CTRAN_LOG(level, __VA_ARGS__);                              \
-    }                                                             \
+#define CTRAN_LOG_DBG(...) \
+  CTRAN_LOG_IMPL(::spdlog::level::debug, COMMS_LOGGER_DEBUG, __VA_ARGS__)
+#define CTRAN_LOG_INFO(...) \
+  CTRAN_LOG_IMPL(::spdlog::level::info, SPDLOG_LOGGER_INFO, __VA_ARGS__)
+#define CTRAN_LOG_WARN(...) \
+  CTRAN_LOG_IMPL(::spdlog::level::warn, SPDLOG_LOGGER_WARN, __VA_ARGS__)
+#define CTRAN_LOG_ERR(...) \
+  CTRAN_LOG_IMPL(::spdlog::level::err, SPDLOG_LOGGER_ERROR, __VA_ARGS__)
+#define CTRAN_LOG_CRITICAL(...) \
+  CTRAN_LOG_IMPL(::spdlog::level::critical, SPDLOG_LOGGER_CRITICAL, __VA_ARGS__)
+#define CTRAN_LOG_FATAL(...)                                             \
+  do {                                                                   \
+    static auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger( \
+        ::ctran::logging::kCtranLoggerName);                             \
+    COMMS_LOG_FATAL_IMPL(_ctran_logger, __VA_ARGS__);                    \
+  } while (false)
+#define CTRAN_LOG(level, ...) CTRAN_LOG_##level(__VA_ARGS__)
+#define CTRAN_LOG_STREAM_IF(level, condition) \
+  COMMS_LOG_NAMED_STREAM_IF(                  \
+      ::ctran::logging::kCtranLoggerName, level, condition)
+#define CTRAN_LOG_STREAM(level) \
+  COMMS_LOG_NAMED_STREAM(::ctran::logging::kCtranLoggerName, level)
+
+#define CTRAN_LOG_SYNC_ERR(...)                                          \
+  do {                                                                   \
+    static auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger( \
+        ::ctran::logging::kCtranLoggerName);                             \
+    if (_ctran_logger.should_log(::spdlog::level::err)) {                \
+      _ctran_logger.logSynchronous(                                      \
+          ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION},     \
+          ::spdlog::level::err,                                          \
+          __VA_ARGS__);                                                  \
+    }                                                                    \
+  } while (false)
+
+#define CTRAN_LOG_IF_IMPL(level, spdlog_level, condition, ...)           \
+  do {                                                                   \
+    static auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger( \
+        ::ctran::logging::kCtranLoggerName);                             \
+    if (_ctran_logger.should_log(spdlog_level) && (condition)) {         \
+      CTRAN_LOG(level, __VA_ARGS__);                                     \
+    }                                                                    \
   } while (false)
 
 #define CTRAN_LOG_IF_WARN(condition, ...) \
@@ -59,7 +88,7 @@ inline constexpr std::string_view kCtranLoggerName = "comms.ctran";
 
 #define CTRAN_LOG_FIRST_N_IMPL(level, spdlog_level, n, ...)                    \
   do {                                                                         \
-    auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger(              \
+    static auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger(       \
         ::ctran::logging::kCtranLoggerName);                                   \
     if (_ctran_logger.should_log(spdlog_level) && [&] {                        \
           struct ctran_log_first_n_tag {};                                     \

--- a/comms/ctran/utils/Debug.h
+++ b/comms/ctran/utils/Debug.h
@@ -4,6 +4,7 @@
 
 #include <sstream>
 
+#include <folly/String.h>
 #include <folly/system/ThreadName.h>
 
 #include "comms/ctran/utils/CtranLogUtils.h"

--- a/comms/ctran/utils/LogInit.cc
+++ b/comms/ctran/utils/LogInit.cc
@@ -18,23 +18,27 @@ folly::once_flag ctranLoggingInitOnceFlag;
 
 void initCtranLoggingImpl() {
   meta::comms::logger::initCommLogging();
-  meta::comms::logger::configureSpdlogLogger(
+  const auto logFilePath =
+      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str());
+  const auto threadContextFn = []() {
+    int cudaDev = -1;
+    (void)cudaGetDevice(&cudaDev);
+    return cudaDev;
+  };
+  const auto errorCallback = [](std::string_view message) {
+    meta::comms::logger::setLastError(std::string{message}, {});
+  };
+  const auto logLevel = meta::comms::logger::loggerLevelToSpdlogLevel(
+      meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG));
+
+  meta::comms::logger::configureCommsAndNamedSpdlogLoggers(
       kCtranLoggerName,
       "CTRAN",
-      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
-      []() {
-        int cudaDev = -1;
-        (void)cudaGetDevice(&cudaDev);
-        return cudaDev;
-      },
-      [](std::string_view message) {
-        meta::comms::logger::setLastError(std::string{message}, {});
-      },
-      NCCL_DEBUG_LOGGING_ASYNC);
-  meta::comms::logger::getSpdlogLogger(kCtranLoggerName)
-      .set_level(
-          meta::comms::logger::loggerLevelToSpdlogLevel(
-              meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
+      logFilePath,
+      threadContextFn,
+      errorCallback,
+      NCCL_DEBUG_LOGGING_ASYNC,
+      logLevel);
 }
 } // anonymous namespace
 

--- a/comms/ncclx/meta/NcclxLogUtils.h
+++ b/comms/ncclx/meta/NcclxLogUtils.h
@@ -4,11 +4,22 @@
 
 #include <fmt/format.h>
 
-#include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/LogTypes.h"
+#include "comms/utils/logger/LoggingFormat.h"
 #include "meta/NcclxLogger.h"
 
-#define NCCLX_LOG_SUBSYS(level, subsys, ...) \
-  NCCLX_LOG_IF(level, CLOGF_ENABLED(subsys), __VA_ARGS__)
+#define NCCLX_LOG_SUBSYS(level, subsys, ...)            \
+  NCCLX_LOG_IF(                                         \
+      level,                                            \
+      ::meta::comms::logger::isEnabledSubSystemBitwise( \
+          static_cast<uint64_t>([]() {                  \
+            using namespace ::meta::comms::logger;      \
+            return subsys;                              \
+          }())),                                        \
+      __VA_ARGS__)
+
+#define NCCLX_LOG_STREAM_EVERY_MS(level, ms) \
+  COMMS_LOG_NAMED_STREAM_EVERY_MS(::ncclx::logging::kNcclxLoggerName, level, ms)
 
 #define NCCLX_ERR(code, ...)                                                  \
   do {                                                                        \

--- a/comms/ncclx/meta/NcclxLogger.h
+++ b/comms/ncclx/meta/NcclxLogger.h
@@ -13,16 +13,45 @@ inline constexpr std::string_view kNcclxLoggerName = "comms.ncclx";
 
 } // namespace ncclx::logging
 
-#define NCCLX_LOG(level, ...) \
-  COMMS_LOG_NAMED(::ncclx::logging::kNcclxLoggerName, level, __VA_ARGS__)
+#define NCCLX_LOG_IMPL(spdlog_level, spdlog_macro, ...)                  \
+  do {                                                                   \
+    static auto& _ncclx_logger = ::meta::comms::logger::getSpdlogLogger( \
+        ::ncclx::logging::kNcclxLoggerName);                             \
+    if (_ncclx_logger.should_log(spdlog_level)) {                        \
+      spdlog_macro(&_ncclx_logger, __VA_ARGS__);                         \
+    }                                                                    \
+  } while (false)
 
-#define NCCLX_LOG_IF_IMPL(level, spdlog_level, condition, ...)    \
-  do {                                                            \
-    auto& _ncclx_logger = ::meta::comms::logger::getSpdlogLogger( \
-        ::ncclx::logging::kNcclxLoggerName);                      \
-    if (_ncclx_logger.should_log(spdlog_level) && (condition)) {  \
-      NCCLX_LOG(level, __VA_ARGS__);                              \
-    }                                                             \
+#define NCCLX_LOG_DBG(...) \
+  NCCLX_LOG_IMPL(::spdlog::level::debug, COMMS_LOGGER_DEBUG, __VA_ARGS__)
+#define NCCLX_LOG_INFO(...) \
+  NCCLX_LOG_IMPL(::spdlog::level::info, SPDLOG_LOGGER_INFO, __VA_ARGS__)
+#define NCCLX_LOG_WARN(...) \
+  NCCLX_LOG_IMPL(::spdlog::level::warn, SPDLOG_LOGGER_WARN, __VA_ARGS__)
+#define NCCLX_LOG_ERR(...) \
+  NCCLX_LOG_IMPL(::spdlog::level::err, SPDLOG_LOGGER_ERROR, __VA_ARGS__)
+#define NCCLX_LOG_CRITICAL(...) \
+  NCCLX_LOG_IMPL(::spdlog::level::critical, SPDLOG_LOGGER_CRITICAL, __VA_ARGS__)
+#define NCCLX_LOG_FATAL(...)                                             \
+  do {                                                                   \
+    static auto& _ncclx_logger = ::meta::comms::logger::getSpdlogLogger( \
+        ::ncclx::logging::kNcclxLoggerName);                             \
+    COMMS_LOG_FATAL_IMPL(_ncclx_logger, __VA_ARGS__);                    \
+  } while (false)
+#define NCCLX_LOG(level, ...) NCCLX_LOG_##level(__VA_ARGS__)
+#define NCCLX_LOG_STREAM_IF(level, condition) \
+  COMMS_LOG_NAMED_STREAM_IF(                  \
+      ::ncclx::logging::kNcclxLoggerName, level, condition)
+#define NCCLX_LOG_STREAM(level) \
+  COMMS_LOG_NAMED_STREAM(::ncclx::logging::kNcclxLoggerName, level)
+
+#define NCCLX_LOG_IF_IMPL(level, spdlog_level, condition, ...)           \
+  do {                                                                   \
+    static auto& _ncclx_logger = ::meta::comms::logger::getSpdlogLogger( \
+        ::ncclx::logging::kNcclxLoggerName);                             \
+    if (_ncclx_logger.should_log(spdlog_level) && (condition)) {         \
+      NCCLX_LOG(level, __VA_ARGS__);                                     \
+    }                                                                    \
   } while (false)
 
 #define NCCLX_LOG_IF_WARN(condition, ...) \
@@ -47,7 +76,7 @@ inline constexpr std::string_view kNcclxLoggerName = "comms.ncclx";
 
 #define NCCLX_LOG_FIRST_N_IMPL(level, spdlog_level, n, ...)                    \
   do {                                                                         \
-    auto& _ncclx_logger = ::meta::comms::logger::getSpdlogLogger(              \
+    static auto& _ncclx_logger = ::meta::comms::logger::getSpdlogLogger(       \
         ::ncclx::logging::kNcclxLoggerName);                                   \
     if (_ncclx_logger.should_log(spdlog_level) && [&] {                        \
           struct ncclx_log_first_n_tag {};                                     \

--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <string>
 
 #include <folly/Conv.h>
 #include <folly/Synchronized.h>
@@ -22,6 +23,7 @@
 #include "comms/utils/colltrace/plugins/WatchdogPlugin.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/NcclxChecks.h"
+#include "meta/NcclxLogger.h"
 #include "meta/hints/GlobalHints.h"
 #include "meta/wrapper/DataTypeConv.h"
 
@@ -388,6 +390,7 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
     auto commDumpPlugin =
         std::make_unique<meta::comms::colltrace::CommDumpPlugin>(
             meta::comms::colltrace::CommDumpConfig{
+                .loggerName = std::string{::ncclx::logging::kNcclxLoggerName},
                 .pastCollSize = NCCL_COLLTRACE_RECORD_MAX,
                 .pendingCollSize = NCCL_COLLTRACE_PENDING_QUEUE_SIZE,
             });
@@ -399,6 +402,7 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
         std::make_unique<meta::comms::colltrace::LifecycleEventFeedPlugin>(
             meta::comms::colltrace::LifecycleEventFeedConfig{
                 .commId = getNextLifecycleFeedCommId(),
+                .loggerName = std::string{::ncclx::logging::kNcclxLoggerName},
             }));
   }
 
@@ -415,6 +419,7 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
     auto watchdogPlugin =
         std::make_unique<meta::comms::colltrace::WatchdogPlugin>(
             meta::comms::colltrace::WatchdogPluginConfig{
+                .loggerName = std::string{::ncclx::logging::kNcclxLoggerName},
                 .checkAsyncError = ifCheckAsync,
                 .funcIfError =
                     [comm]() {
@@ -434,6 +439,7 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
 
   auto colltraceNew = std::make_shared<meta::comms::colltrace::CollTrace>(
       meta::comms::colltrace::CollTraceConfig{
+          .loggerName = std::string{::ncclx::logging::kNcclxLoggerName},
           .maxCheckCancelInterval =
               std::chrono::milliseconds{NCCL_COLLTRACE_WAKEUP_INTERVAL_MS},
       },

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogIbMockTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogIbMockTest.cc
@@ -12,6 +12,7 @@
 #include "comms/mccl/tests/CudaStream.h"
 #include "comms/mccl/tests/CudaTestUtil.h"
 #include "comms/testinfra/IbverbMockTestUtils.h"
+#include "meta/NcclxLogger.h"
 
 namespace {
 struct GpuBuffer {
@@ -33,20 +34,20 @@ struct GpuBuffer {
 };
 } // namespace
 
-#define NCCLCHECK_FATAL(cmd)                                            \
-  do {                                                                  \
-    ncclResult_t res = cmd;                                             \
-    if (res != ncclSuccess) {                                           \
-      XLOGF(FATAL, "NCCL error {} '{}'", res, ncclGetErrorString(res)); \
-    }                                                                   \
+#define NCCLCHECK_FATAL(cmd)                                                \
+  do {                                                                      \
+    ncclResult_t res = cmd;                                                 \
+    if (res != ncclSuccess) {                                               \
+      NCCLX_LOG(FATAL, "NCCL error {} '{}'", res, ncclGetErrorString(res)); \
+    }                                                                       \
   } while (0)
 
-#define CUDACHECK_FATAL(cmd)                                            \
-  do {                                                                  \
-    cudaError_t err = cmd;                                              \
-    if (err != cudaSuccess) {                                           \
-      XLOGF(FATAL, "CUDA error {} '{}'", err, cudaGetErrorString(err)); \
-    }                                                                   \
+#define CUDACHECK_FATAL(cmd)                                                \
+  do {                                                                      \
+    cudaError_t err = cmd;                                                  \
+    if (err != cudaSuccess) {                                               \
+      NCCLX_LOG(FATAL, "CUDA error {} '{}'", err, cudaGetErrorString(err)); \
+    }                                                                       \
   } while (0)
 
 // RAII for NCCL Communicator
@@ -168,7 +169,7 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorWithIbVerbMock) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
   mccl::cuda::CudaStream stream;
 
   // Initialize NCCL communicator

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
@@ -273,16 +273,20 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorFromGPE) {
   auto srcRank = (rank - 1 + worldSize) % worldSize;
   auto dstRank = (rank + 1) % worldSize;
 
-  // These calls intentionally provoke a GPE failure. Do not terminate on an
-  // immediate API error; the behavior under test is the communicator's async
-  // error being observed and reported by the production watchdog.
+  // These calls intentionally provoke a GPE failure after successful enqueue.
+  // An immediate API failure is a different regression and must not be
+  // mistaken for the watchdog's asynchronous error path.
 #if NCCL_MINOR >= 29
-  (void)ncclx::ncclPutSignal(
-      sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw());
-  (void)ncclx::ncclWaitSignal(srcRank, win, stream.raw());
+  ASSERT_EQ(
+      ncclSuccess,
+      ncclx::ncclPutSignal(
+          sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw()));
+  ASSERT_EQ(ncclSuccess, ncclx::ncclWaitSignal(srcRank, win, stream.raw()));
 #else
-  (void)ncclPutSignal(sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw());
-  (void)ncclWaitSignal(srcRank, win, stream.raw());
+  ASSERT_EQ(
+      ncclSuccess,
+      ncclPutSignal(sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw()));
+  ASSERT_EQ(ncclSuccess, ncclWaitSignal(srcRank, win, stream.raw()));
 #endif
   waitStreamWithTimeout(stream.raw(), std::chrono::seconds{80});
 }

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
@@ -243,14 +243,16 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorFromGPE) {
   auto srcRank = (rank - 1 + worldSize) % worldSize;
   auto dstRank = (rank + 1) % worldSize;
 
-  NCCLCHECK_FATAL(
+  // These calls intentionally provoke a GPE failure. Do not terminate on an
+  // immediate API error; the behavior under test is the communicator's async
+  // error being observed and reported by the production watchdog.
 #if NCCL_MINOR >= 29
-      ncclx::ncclPutSignal(
-          sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw()));
-  NCCLCHECK_FATAL(ncclx::ncclWaitSignal(srcRank, win, stream.raw()));
+  (void)ncclx::ncclPutSignal(
+      sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw());
+  (void)ncclx::ncclWaitSignal(srcRank, win, stream.raw());
 #else
-      ncclPutSignal(sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw()));
-  NCCLCHECK_FATAL(ncclWaitSignal(srcRank, win, stream.raw()));
+  (void)ncclPutSignal(sendBuff, 32, ncclFloat, dstRank, 0, win, stream.raw());
+  (void)ncclWaitSignal(srcRank, win, stream.raw());
 #endif
   waitStreamWithTimeout(stream.raw(), std::chrono::seconds{80});
 }

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
@@ -12,10 +12,12 @@
 #include "comms/mccl/integration_tests/McclIntegrationTestUtil.h"
 #include "comms/mccl/tests/CudaStream.h"
 #include "comms/mccl/tests/CudaTestUtil.h"
-#include "comms/ncclx/meta/NcclxLogger.h"
 #include "comms/utils/colltrace/tests/nvidia-only/CPUControlledKernel.h"
+#include "meta/NcclxLogger.h"
 
 namespace {
+constexpr std::string_view kLogFilePrefix{"logfile"};
+
 struct GpuBuffer {
   explicit GpuBuffer(size_t size) : size_(size) {
     cudaMalloc(&ptr_, size);
@@ -35,20 +37,20 @@ struct GpuBuffer {
 };
 } // namespace
 
-#define NCCLCHECK_FATAL(cmd)                                            \
-  do {                                                                  \
-    ncclResult_t res = cmd;                                             \
-    if (res != ncclSuccess) {                                           \
-      XLOGF(FATAL, "NCCL error {} '{}'", res, ncclGetErrorString(res)); \
-    }                                                                   \
+#define NCCLCHECK_FATAL(cmd)                                                \
+  do {                                                                      \
+    ncclResult_t res = cmd;                                                 \
+    if (res != ncclSuccess) {                                               \
+      NCCLX_LOG(FATAL, "NCCL error {} '{}'", res, ncclGetErrorString(res)); \
+    }                                                                       \
   } while (0)
 
-#define CUDACHECK_FATAL(cmd)                                            \
-  do {                                                                  \
-    cudaError_t err = cmd;                                              \
-    if (err != cudaSuccess) {                                           \
-      XLOGF(FATAL, "CUDA error {} '{}'", err, cudaGetErrorString(err)); \
-    }                                                                   \
+#define CUDACHECK_FATAL(cmd)                                                \
+  do {                                                                      \
+    cudaError_t err = cmd;                                                  \
+    if (err != cudaSuccess) {                                               \
+      NCCLX_LOG(FATAL, "CUDA error {} '{}'", err, cudaGetErrorString(err)); \
+    }                                                                       \
   } while (0)
 
 // RAII for NCCL Communicator
@@ -102,7 +104,7 @@ void waitStreamWithTimeout(
       return;
     }
     if (res != cudaErrorNotReady) {
-      XLOGF(
+      NCCLX_LOG(
           FATAL, "Unexpected CUDA error {} '{}'", res, cudaGetErrorString(res));
     }
     std::this_thread::sleep_for(std::chrono::milliseconds{100});
@@ -139,7 +141,8 @@ class CollTraceWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
                     "NCCL_DEBUG=INFO",
                     fmt::format(
                         "NCCL_DEBUG_FILE={}",
-                        (tmpDir_.path() / "logfile%p").string()),
+                        (tmpDir_.path() / (std::string{kLogFilePrefix} + "%p"))
+                            .string()),
                 },
         });
   }
@@ -160,7 +163,7 @@ class CollTraceWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
         testDriverState.workerExitCodes, ::testing::Each(::testing::Eq(0)));
   }
 
-  void testDriverCheckCrashedWithWatchdog() {
+  void testDriverCheckCrashedWithWatchdog(bool expectPeerTerminations = false) {
     ASSERT_TRUE(
         std::holds_alternative<
             mccl::CollectiveIntegrationTestMixin::TestDriverState>(
@@ -172,14 +175,41 @@ class CollTraceWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
     EXPECT_THAT(
         testDriverState.workerExitCodes, ::testing::Each(::testing::Ne(0)));
 
-    int count = 0;
+    const auto expectedFileCount = testDriverState.workerExitCodes.size();
+    ASSERT_GT(expectedFileCount, 0);
+    size_t fileCount = 0;
+    size_t nonEmptyFileCount = 0;
+    size_t watchdogFatalCount = 0;
+    size_t peerFatalCount = 0;
     for (const auto& entry : folly::fs::directory_iterator(tmpDir_.path())) {
+      const auto fileName = entry.path().filename().string();
+      if (fileName.compare(0, kLogFilePrefix.size(), kLogFilePrefix) != 0) {
+        continue;
+      }
       std::string fileContents;
       ASSERT_TRUE(folly::readFile(entry.path().c_str(), fileContents));
-      EXPECT_THAT(fileContents, ::testing::HasSubstr("COMM FATAL"));
-      count++;
+      if (!fileContents.empty()) {
+        ++nonEmptyFileCount;
+      }
+      if (fileContents.find("COMM FATAL: FatalError: Collective") !=
+          std::string::npos) {
+        ++watchdogFatalCount;
+      }
+      if (fileContents.find("Peer terminated after rank 0 watchdog timeout") !=
+          std::string::npos) {
+        ++peerFatalCount;
+      }
+      ++fileCount;
     }
-    EXPECT_EQ(count, 4);
+    EXPECT_EQ(fileCount, expectedFileCount);
+    EXPECT_EQ(nonEmptyFileCount, expectedFileCount);
+    if (expectPeerTerminations) {
+      EXPECT_GE(watchdogFatalCount, 1);
+      EXPECT_EQ(peerFatalCount, expectedFileCount - 1);
+    } else {
+      EXPECT_GT(watchdogFatalCount, 0);
+      EXPECT_EQ(peerFatalCount, 0);
+    }
   }
 };
 
@@ -217,7 +247,7 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorFromGPE) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
   mccl::cuda::CudaStream stream;
 
   // Initialize NCCL communicator
@@ -272,7 +302,7 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorWithGenericAsyncError) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
@@ -313,7 +343,7 @@ TEST_F(CollTraceWatchdogTest, TestTimeoutBeforeColl) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
@@ -344,7 +374,7 @@ TEST_F(CollTraceWatchdogTest, TestTimeoutBeforeColl) {
 
 TEST_F(CollTraceWatchdogTest, TestTimeoutInColl) {
   if (isTestDriverProcess()) {
-    testDriverCheckCrashedWithWatchdog();
+    testDriverCheckCrashedWithWatchdog(true /*expectPeerTerminations*/);
     return;
   }
 
@@ -364,7 +394,7 @@ TEST_F(CollTraceWatchdogTest, TestTimeoutInColl) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
@@ -381,8 +411,9 @@ TEST_F(CollTraceWatchdogTest, TestTimeoutInColl) {
   if (rank != 0) {
     // Sleep long enough to make other ranks timeout
     std::this_thread::sleep_for(timeoutSec + std::chrono::seconds{3});
-    // Hacky way to make the driver process believe rank 0 is faulty as well.
-    NCCLX_LOG(FATAL, "COMM FATAL");
+    // Rank 0 owns the collective that times out. Terminate the peer ranks after
+    // it has had enough time to emit the production watchdog diagnostic.
+    NCCLX_LOG(FATAL, "Peer terminated after rank 0 watchdog timeout");
   } else {
     NcclAllReduce allReduce(comm.raw(), stream, 32);
     std::this_thread::sleep_for(timeoutSec + std::chrono::seconds{3});
@@ -413,7 +444,7 @@ TEST_F(CollTraceWatchdogTest, TestBelowTimeoutInColl) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
@@ -461,7 +492,7 @@ TEST_F(CollTraceWatchdogTest, TestBelowTimeoutBeforeColl) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWrapperUT.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWrapperUT.cc
@@ -18,6 +18,7 @@
 #include "comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.h"
 #include "comms/utils/colltrace/tests/MockTypes.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/NcclxLogger.h"
 #include "meta/colltrace/CollTraceWrapper.h"
 
 using namespace meta::comms::ncclx;
@@ -123,7 +124,7 @@ class CollTraceWrapperUT : public ::testing::Test {
     // Create a mock collective task
     auto* collTask = createNewCollTask();
     if (collTask == nullptr) {
-      XLOG(FATAL) << "Failed to create new collective task" << std::endl;
+      NCCLX_LOG_STREAM(FATAL) << "Failed to create new collective task";
     }
     collTask->func = ncclFuncAllReduce;
     collTask->algorithm = NCCL_ALGO_RING;

--- a/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -25,6 +25,7 @@
 #include "comms/utils/colltrace/tests/nvidia-only/CPUControlledKernel.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/Logger.h"
+#include "meta/NcclxLogger.h"
 #include "meta/commDump.h"
 
 using ::meta::comms::colltrace::CollTraceConfig;
@@ -604,7 +605,7 @@ TEST_F(CollTraceTest, winPutWait) {
   EXPECT_EQ(pastCollsJson.size(), 3 * kNumIters);
 
   for (int i = 0; i < pastCollsJson.size(); i++) {
-    XLOGF(DBG, "coll {}: {}", i, pastCollsJson[i]["opName"].asString());
+    NCCLX_LOG(DBG, "coll {}: {}", i, pastCollsJson[i]["opName"].asString());
   }
 
   for (int i = 0; i < kNumIters; i++) {

--- a/comms/ncclx/meta/logger/tests/LoggingUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggingUT.cc
@@ -5,7 +5,6 @@
 #include <fmt/format.h>
 #include <folly/FileUtil.h>
 #include <folly/ScopeGuard.h>
-#include <folly/logging/LogMessage.h>
 #include <folly/testing/TestUtil.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -14,6 +13,7 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/Logger.h"
 #include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 #include "meta/NcclxChecks.h"
 
 #include "debug.h" // @manual
@@ -571,7 +571,7 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
   // tempFile lives in a TemporaryDirectory that is deleted at test end, so the
   // OS env var must be unset on scope exit (even on the ASSERT_TRUE
   // early-return below) or a later test's ncclCvarInit() would reload this
-  // stale path and NcclLogger would fail to open the deleted file.
+  // stale path and the next logger initialization would fail to open it.
   auto debugFileEnvGuard =
       folly::makeGuard([]() { unsetenv("NCCL_DEBUG_FILE"); });
   ncclResetDebugInit();
@@ -583,6 +583,7 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
   constexpr std::string_view TestStr = "RAW TESTING";
   constexpr std::string_view TestStr2 = "TESTING";
   constexpr std::string_view SpdlogTestStr = "SPDLOG TESTING";
+  constexpr std::string_view SharedSpdlogTestStr = "SHARED SPDLOG TESTING";
 
   testing::internal::CaptureStderr();
 
@@ -597,10 +598,16 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
   NCCLX_LOG(INFO, "{}", SpdlogTestStr);
   NCCLX_LOG(WARN, "{}", SpdlogTestStr);
   NCCLX_LOG(ERR, "{}", SpdlogTestStr);
+  COMMS_LOG(INFO, "{}", SharedSpdlogTestStr);
+  COMMS_LOG(WARN, "{}", SharedSpdlogTestStr);
+  COMMS_LOG(ERR, "{}", SharedSpdlogTestStr);
   auto& spdlogLogger =
       meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName);
+  auto& sharedSpdlogLogger = meta::comms::logger::getSpdlogLogger();
   EXPECT_EQ(spdlogLogger.usesAsyncLogging(), NCCL_DEBUG_LOGGING_ASYNC);
+  EXPECT_EQ(sharedSpdlogLogger.usesAsyncLogging(), NCCL_DEBUG_LOGGING_ASYNC);
   spdlogLogger.flush();
+  sharedSpdlogLogger.flush();
 
   auto stderrOutput = testing::internal::GetCapturedStderr();
 
@@ -617,6 +624,10 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
     EXPECT_THAT(
         fileContents,
         testing::HasSubstr(fmt::format("NCCL {} {}", level, SpdlogTestStr)));
+    EXPECT_THAT(
+        fileContents,
+        testing::HasSubstr(
+            fmt::format("COMM {} {}", level, SharedSpdlogTestStr)));
     if (level != "INFO") {
       // When logging to file, we should also log to stderr for WARN and ERROR
       EXPECT_THAT(
@@ -628,6 +639,10 @@ TEST_F(NcclLoggerTest, DebugFileLoggingTest) {
       EXPECT_THAT(
           stderrOutput,
           testing::HasSubstr(fmt::format("NCCL {} {}", level, SpdlogTestStr)));
+      EXPECT_THAT(
+          stderrOutput,
+          testing::HasSubstr(
+              fmt::format("COMM {} {}", level, SharedSpdlogTestStr)));
     }
   }
 }
@@ -856,57 +871,3 @@ TEST_F(NcclLoggerTest, SecondErrorUpdatesMessageKeepsAppendedStack) {
 }
 
 #endif // NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
-
-TEST_F(NcclLoggerTest, PreservesSharedUtilsLogHandler) {
-  ncclResetDebugInit();
-
-  ncclCvarInit();
-  auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"INFO"});
-  setenv("NCCL_DEBUG", "INFO", 1);
-
-  initLogging();
-  auto utilsCategory = folly::LoggerDB::get().getCategory("comms.utils");
-  ASSERT_THAT(utilsCategory, ::testing::NotNull());
-  EXPECT_EQ(utilsCategory->getHandlers().size(), 1);
-
-  NcclLogger::init(
-      // TODO: Change the context name when ctran is refactored out of NCCLX
-      // Otherwise the logging will no longer work as intended.
-      {.contextName = "comms.ncclx.v2_25.meta.logger.tests",
-       .logPrefix = "LOGGER",
-       .logFilePath =
-           meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
-       .logLevel = meta::comms::logger::loggerLevelToFollyLogLevel(
-           meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
-       .threadContextFn = []() {
-         int cudaDev = -1;
-         cudaGetDevice(&cudaDev);
-         return cudaDev;
-       }});
-  auto utilsCategory2 = folly::LoggerDB::get().getCategory("comms.utils");
-  ASSERT_THAT(utilsCategory, ::testing::NotNull());
-  EXPECT_EQ(utilsCategory, utilsCategory2);
-  EXPECT_EQ(utilsCategory->getHandlers().size(), 1);
-
-  utilsCategory->admitMessage(
-      folly::LogMessage(
-          utilsCategory,
-          folly::LogLevel::INFO,
-          std::chrono::system_clock::now(),
-          "test",
-          123,
-          "UtilsTest",
-          "testing testing 123"));
-
-  std::string TestStr = "TESTING";
-
-  XLOG(INFO) << "RAW LOG TEST";
-  XLOG(WARN) << "RAW LOG TEST";
-  XLOG(ERR) << "RAW LOG TEST";
-
-  INFO(NCCL_ALL, "%s", TestStr.c_str());
-  WARN("%s", TestStr.c_str());
-  ERR(ncclInternalError, "%s", TestStr.c_str());
-
-  finishLogging();
-}

--- a/comms/ncclx/meta/tests/CommDumpTest.cc
+++ b/comms/ncclx/meta/tests/CommDumpTest.cc
@@ -17,6 +17,7 @@
 #include "comms/testinfra/TestUtils.h"
 #include "comms/utils/StrUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/NcclxLogger.h"
 
 #include "meta/NcclxConfig.h"
 #include "meta/colltrace/ProxyMock.h"
@@ -810,7 +811,7 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTrace) {
   // Check past collectives are dumped correctly and simply check if can be
   // parsed as json entries.
   if (dump.count("CT_pastColls")) {
-    XLOG(DBG1) << "Entered CT_pastColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered CT_pastColls if statement";
     auto ctPastCollsObjs = folly::parseJson(dump["CT_pastColls"]);
     EXPECT_EQ(ctPastCollsObjs.size(), numColls);
     for (int i = 0; i < numColls; i++) {
@@ -821,7 +822,7 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTrace) {
 
   // Proxy trace would be empty if nNodes == 1
   if (dump.count("PT_pastColls") && comm->nNodes > 1) {
-    XLOG(DBG1) << "Entered PT_pastColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered PT_pastColls if statement";
     auto ptPastCollsObjs = folly::parseJson(dump["PT_pastColls"]);
     EXPECT_EQ(ptPastCollsObjs.size(), numColls);
     for (int i = 0; i < numColls; i++) {
@@ -832,18 +833,18 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTrace) {
 
   // Check no pending/current entries
   if (dump.count("CT_pendingColls")) {
-    XLOG(DBG1) << "Entered CT_pendingColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered CT_pendingColls if statement";
     auto ctPendingCollsObjs = folly::parseJson(dump["CT_pendingColls"]);
     EXPECT_EQ(ctPendingCollsObjs.size(), 0);
   }
 
   if (dump.count("CT_currentColls")) {
-    XLOG(DBG1) << "Entered CT_currentColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered CT_currentColls if statement";
     EXPECT_EQ(dump["CT_currentColls"], "[]");
   }
 
   if (dump.count("PT_activeOps")) {
-    XLOG(DBG1) << "Entered PT_activeOps if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered PT_activeOps if statement";
     auto ptActiveOpsObjs = folly::parseJson(dump["PT_activeOps"]);
     EXPECT_EQ(ptActiveOpsObjs.size(), 0);
   }
@@ -905,7 +906,7 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTraceWithCommsMonitor) {
   // Check past collectives are dumped correctly and simply check if can be
   // parsed as json entries.
   if (dump.count("CT_pastColls")) {
-    XLOG(DBG1) << "Entered CT_pastColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered CT_pastColls if statement";
     auto ctPastCollsObjs = folly::parseJson(dump["CT_pastColls"]);
     EXPECT_EQ(ctPastCollsObjs.size(), numColls);
     for (int i = 0; i < numColls; i++) {
@@ -919,7 +920,7 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTraceWithCommsMonitor) {
 
   // Proxy trace would be empty if nNodes == 1
   if (dump.count("PT_pastColls") && comm->nNodes > 1) {
-    XLOG(DBG1) << "Entered PT_pastColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered PT_pastColls if statement";
     auto ptPastCollsObjs = folly::parseJson(dump["PT_pastColls"]);
     EXPECT_EQ(ptPastCollsObjs.size(), numColls);
     for (int i = 0; i < numColls; i++) {
@@ -930,18 +931,18 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTraceWithCommsMonitor) {
 
   // Check no pending/current entries
   if (dump.count("CT_pendingColls")) {
-    XLOG(DBG1) << "Entered CT_pendingColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered CT_pendingColls if statement";
     auto ctPendingCollsObjs = folly::parseJson(dump["CT_pendingColls"]);
     EXPECT_EQ(ctPendingCollsObjs.size(), 0);
   }
 
   if (dump.count("CT_currentColls")) {
-    XLOG(DBG1) << "Entered CT_currentColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered CT_currentColls if statement";
     EXPECT_EQ(dump["CT_currentColls"], "[]");
   }
 
   if (dump.count("PT_activeOps")) {
-    XLOG(DBG1) << "Entered PT_activeOps if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered PT_activeOps if statement";
     auto ptActiveOpsObjs = folly::parseJson(dump["PT_activeOps"]);
     EXPECT_EQ(ptActiveOpsObjs.size(), 0);
   }

--- a/comms/ncclx/meta/tests/LogTest.cc
+++ b/comms/ncclx/meta/tests/LogTest.cc
@@ -11,6 +11,7 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/Logger.h"
 #include "debug.h"
+#include "meta/NcclxLogger.h"
 
 class LogTest : public ::testing::Test {
  public:
@@ -126,7 +127,7 @@ TEST_F(LogTest, InfoWarnToFile) {
   const std::string kTestInfoStr = "Testing INFO to FILE";
   const std::string kTestWarnStr = "Testing WARN to FILE";
 
-  XLOG(WARN) << kDebugFile;
+  NCCLX_LOG_STREAM(WARN) << kDebugFile;
   auto envGuard0 = EnvRAII(NCCL_DEBUG_FILE, kDebugFile);
   SysEnvRAII sysDebugFileGuard("NCCL_DEBUG_FILE", kDebugFile);
   auto envGuard1 = EnvRAII(NCCL_DEBUG, std::string("INFO"));

--- a/comms/ncclx/v2_29/src/misc/param.cc
+++ b/comms/ncclx/v2_29/src/misc/param.cc
@@ -23,8 +23,8 @@
 #include <unordered_set>
 #include "os.h"
 
-#include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/LoggerRuntime.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/InitFolly.h"
 #include "meta/NcclxLogger.h"
@@ -159,22 +159,26 @@ const char* ncclGetEnv(const char* name) {
 }
 
 void initNcclLogger() {
-  // Shared CollTrace code still emits raw XLOG under comms.utils.
-  meta::comms::logger::initCommLogging();
-  meta::comms::logger::configureSpdlogLogger(
+  meta::comms::logger::initCommLoggerRuntime();
+  const auto logFilePath =
+      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str());
+  const auto threadContextFn = []() {
+    int cudaDev = -1;
+    (void)cudaGetDevice(&cudaDev);
+    return cudaDev;
+  };
+  const auto errorCallback = [](std::string_view message) {
+    meta::comms::logger::setLastError(std::string{message}, {});
+  };
+  const auto logLevel = meta::comms::logger::loggerLevelToSpdlogLevel(
+      meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG));
+
+  meta::comms::logger::configureCommsAndNamedSpdlogLoggers(
       ncclx::logging::kNcclxLoggerName,
       "NCCL",
-      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
-      []() {
-        int cudaDev = -1;
-        (void)cudaGetDevice(&cudaDev);
-        return cudaDev;
-      },
-      [](std::string_view message) {
-        meta::comms::logger::setLastError(std::string{message}, {});
-      },
-      NCCL_DEBUG_LOGGING_ASYNC);
-  meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName)
-      .set_level(meta::comms::logger::loggerLevelToSpdlogLevel(
-          meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
+      logFilePath,
+      threadContextFn,
+      errorCallback,
+      NCCL_DEBUG_LOGGING_ASYNC,
+      logLevel);
 }

--- a/comms/ncclx/v2_30/src/misc/param.cc
+++ b/comms/ncclx/v2_30/src/misc/param.cc
@@ -20,8 +20,8 @@
 #include <unordered_set>
 #include "os.h"
 
-#include "comms/utils/logger/LogUtils.h"
 #include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/LoggerRuntime.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/InitFolly.h"
 #include "meta/NcclxLogger.h"
@@ -122,22 +122,26 @@ const char* ncclGetEnv(const char* name) {
 }
 
 void initNcclLogger() {
-  // Shared CollTrace code still emits raw XLOG under comms.utils.
-  meta::comms::logger::initCommLogging();
-  meta::comms::logger::configureSpdlogLogger(
+  meta::comms::logger::initCommLoggerRuntime();
+  const auto logFilePath =
+      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str());
+  const auto threadContextFn = []() {
+    int cudaDev = -1;
+    (void)cudaGetDevice(&cudaDev);
+    return cudaDev;
+  };
+  const auto errorCallback = [](std::string_view message) {
+    meta::comms::logger::setLastError(std::string{message}, {});
+  };
+  const auto logLevel = meta::comms::logger::loggerLevelToSpdlogLevel(
+      meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG));
+
+  meta::comms::logger::configureCommsAndNamedSpdlogLoggers(
       ncclx::logging::kNcclxLoggerName,
       "NCCL",
-      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
-      []() {
-        int cudaDev = -1;
-        (void)cudaGetDevice(&cudaDev);
-        return cudaDev;
-      },
-      [](std::string_view message) {
-        meta::comms::logger::setLastError(std::string{message}, {});
-      },
-      NCCL_DEBUG_LOGGING_ASYNC);
-  meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName)
-      .set_level(meta::comms::logger::loggerLevelToSpdlogLevel(
-          meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
+      logFilePath,
+      threadContextFn,
+      errorCallback,
+      NCCL_DEBUG_LOGGING_ASYNC,
+      logLevel);
 }

--- a/comms/prims/benchmarks/BenchmarkMacros.h
+++ b/comms/prims/benchmarks/BenchmarkMacros.h
@@ -3,8 +3,8 @@
 #pragma once
 
 #include <cuda_runtime.h>
-#include <folly/logging/xlog.h>
 #include <nccl.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace comms::prims::benchmark {
 
@@ -24,7 +24,7 @@ constexpr std::size_t kDefaultDataBufferSize = 8 * 1024 * 1024;
   do {                               \
     cudaError_t err = call;          \
     if (err != cudaSuccess) {        \
-      XLOGF(                         \
+      COMMS_LOG(                     \
           ERR,                       \
           "CUDA error at {}:{}: {}", \
           __FILE__,                  \
@@ -39,7 +39,7 @@ constexpr std::size_t kDefaultDataBufferSize = 8 * 1024 * 1024;
   do {                               \
     ncclResult_t res = call;         \
     if (res != ncclSuccess) {        \
-      XLOGF(                         \
+      COMMS_LOG(                     \
           ERR,                       \
           "NCCL error at {}:{}: {}", \
           __FILE__,                  \
@@ -54,7 +54,7 @@ constexpr std::size_t kDefaultDataBufferSize = 8 * 1024 * 1024;
   do {                               \
     cudaError_t err = call;          \
     if (err != cudaSuccess) {        \
-      XLOGF(                         \
+      COMMS_LOG(                     \
           ERR,                       \
           "CUDA error at {}:{}: {}", \
           __FILE__,                  \
@@ -69,7 +69,7 @@ constexpr std::size_t kDefaultDataBufferSize = 8 * 1024 * 1024;
   do {                               \
     ncclResult_t res = call;         \
     if (res != ncclSuccess) {        \
-      XLOGF(                         \
+      COMMS_LOG(                     \
           ERR,                       \
           "NCCL error at {}:{}: {}", \
           __FILE__,                  \
@@ -84,7 +84,7 @@ constexpr std::size_t kDefaultDataBufferSize = 8 * 1024 * 1024;
   do {                               \
     cudaError_t err = call;          \
     if (err != cudaSuccess) {        \
-      XLOGF(                         \
+      COMMS_LOG(                     \
           ERR,                       \
           "CUDA error at {}:{}: {}", \
           __FILE__,                  \

--- a/comms/prims/benchmarks/IbgdaBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cc
@@ -4,7 +4,7 @@
 
 #include <cuda_runtime.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <cstdlib>
 #include <iomanip>
@@ -85,7 +85,8 @@ class BenchIbTransport {
       int numRanks,
       const std::shared_ptr<meta::comms::IBootstrap>& bootstrap,
       const MultipeerIbTransportConfig& config) {
-    XLOGF(INFO, "BenchIbTransport: backend={}", benchIbBackendName(backend));
+    COMMS_LOG(
+        INFO, "BenchIbTransport: backend={}", benchIbBackendName(backend));
     if (backend == BenchIbBackend::IBRC) {
       ibrc_ = std::make_unique<MultipeerIbrcTransport>(
           globalRank, numRanks, bootstrap, config);
@@ -128,7 +129,7 @@ class BenchIbTransport {
   do {                               \
     cudaError_t err = call;          \
     if (err != cudaSuccess) {        \
-      XLOGF(                         \
+      COMMS_LOG(                     \
           ERR,                       \
           "CUDA error at {}:{}: {}", \
           __FILE__,                  \
@@ -143,7 +144,7 @@ class BenchIbTransport {
   do {                               \
     cudaError_t err = call;          \
     if (err != cudaSuccess) {        \
-      XLOGF(                         \
+      COMMS_LOG(                     \
           ERR,                       \
           "CUDA error at {}:{}: {}", \
           __FILE__,                  \
@@ -306,7 +307,7 @@ class IbgdaBenchmarkFixture
        << ", GPU clock: " << clockRateGHz_ << " GHz\n";
     ss << "================================================================================\n\n";
 
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 
   // Standard message size configurations
@@ -391,7 +392,7 @@ class IbgdaBenchmarkFixture
       bool correct = true;
       for (std::size_t i = 0; i < nbytes; i++) {
         if (hostBuf[i] != fillPattern) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "{}: data mismatch at byte {}: expected 0x{:02X}, got 0x{:02X}",
               methodName,
@@ -405,7 +406,8 @@ class IbgdaBenchmarkFixture
       EXPECT_TRUE(correct) << methodName
                            << ": put data correctness check failed";
       if (correct) {
-        XLOGF(INFO, "{}: data correctness OK ({} bytes)", methodName, nbytes);
+        COMMS_LOG(
+            INFO, "{}: data correctness OK ({} bytes)", methodName, nbytes);
       }
     }
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -415,7 +417,8 @@ class IbgdaBenchmarkFixture
 TEST_P(IbgdaBenchmarkFixture, PutFlush) {
   // Measures raw RDMA Write latency as put + flush.
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -459,7 +462,7 @@ TEST_P(IbgdaBenchmarkFixture, PutFlush) {
     unsigned long long* d_totalCycles;
     CUDA_CHECK_VOID(cudaMalloc(&d_totalCycles, sizeof(unsigned long long)));
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: GPU clock rate = {:.2f} GHz",
         globalRank,
@@ -494,7 +497,7 @@ TEST_P(IbgdaBenchmarkFixture, PutFlush) {
 
         results.push_back(result);
 
-        XLOGF(
+        COMMS_LOG(
             INFO,
             "Rank {}: {} - Latency: {:.2f} us, BW: {:.2f} GB/s",
             globalRank,
@@ -520,7 +523,8 @@ TEST_P(IbgdaBenchmarkFixture, ThreadScopeMultiBlockPutFlush) {
   // block-private slice. This checks that thread-scope wrappers inherit the
   // physical block id instead of routing all blocks through block 0's QPs.
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -644,7 +648,8 @@ TEST_P(IbgdaBenchmarkFixture, PutCompletionComparison) {
   // Serialize every put with its completion wait to isolate the primitive
   // completion cost. This does not model pipelined send/recv overlap.
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -692,7 +697,7 @@ TEST_P(IbgdaBenchmarkFixture, PutCompletionComparison) {
     unsigned long long* d_totalCycles;
     CUDA_CHECK_VOID(cudaMalloc(&d_totalCycles, sizeof(unsigned long long)));
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: GPU clock rate = {:.2f} GHz",
         globalRank,
@@ -729,7 +734,7 @@ TEST_P(IbgdaBenchmarkFixture, PutCompletionComparison) {
 
         counterResults.push_back(result);
 
-        XLOGF(
+        COMMS_LOG(
             INFO,
             "Rank {}: {} - Latency: {:.2f} us, BW: {:.2f} GB/s",
             globalRank,
@@ -760,7 +765,7 @@ TEST_P(IbgdaBenchmarkFixture, PutCompletionComparison) {
             (config.nBytes / 1e9f) / (localResult.latency / 1e6f);
         localResults.push_back(localResult);
 
-        XLOGF(
+        COMMS_LOG(
             INFO,
             "Rank {}: {} wait_local - Latency: {:.2f} us, BW: {:.2f} GB/s",
             globalRank,
@@ -786,7 +791,8 @@ TEST_P(IbgdaBenchmarkFixture, PutCompletionComparison) {
 TEST_P(IbgdaBenchmarkFixture, PutSignalWaitCounter) {
   // Measures RDMA Write + atomic signal latency (put + signal + counter wait)
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -835,7 +841,7 @@ TEST_P(IbgdaBenchmarkFixture, PutSignalWaitCounter) {
     unsigned long long* d_totalCycles;
     CUDA_CHECK_VOID(cudaMalloc(&d_totalCycles, sizeof(unsigned long long)));
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: GPU clock rate = {:.2f} GHz",
         globalRank,
@@ -873,7 +879,7 @@ TEST_P(IbgdaBenchmarkFixture, PutSignalWaitCounter) {
 
         results.push_back(result);
 
-        XLOGF(
+        COMMS_LOG(
             INFO,
             "Rank {}: {} - Latency: {:.2f} us, BW: {:.2f} GB/s",
             globalRank,
@@ -898,7 +904,8 @@ TEST_P(IbgdaBenchmarkFixture, PutSignalWaitCounter) {
 TEST_P(IbgdaBenchmarkFixture, SignalOnly) {
   // Measures atomic signal-only latency (no data transfer)
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -934,7 +941,7 @@ TEST_P(IbgdaBenchmarkFixture, SignalOnly) {
     unsigned long long* d_totalCycles;
     CUDA_CHECK_VOID(cudaMalloc(&d_totalCycles, sizeof(unsigned long long)));
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: GPU clock rate = {:.2f} GHz",
         globalRank,
@@ -964,13 +971,13 @@ TEST_P(IbgdaBenchmarkFixture, SignalOnly) {
 
       latencyUs = cyclesToUs(totalCycles) / kIbgdaBatchIters;
 
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "\n=== {} Signal-Only Latency (Raw, no kernel launch overhead) ===",
           backendName());
-      XLOGF(INFO, "Average latency: {:.2f} us", latencyUs);
-      XLOGF(INFO, "Batch iterations: {}", kIbgdaBatchIters);
-      XLOGF(
+      COMMS_LOG(INFO, "Average latency: {:.2f} us", latencyUs);
+      COMMS_LOG(INFO, "Batch iterations: {}", kIbgdaBatchIters);
+      COMMS_LOG(
           INFO,
           "===========================================================\n");
     }
@@ -988,7 +995,8 @@ TEST_P(IbgdaBenchmarkFixture, SignalOnly) {
 // Counter = put + signal + transport counter-slot completion + local poll.
 TEST_P(IbgdaBenchmarkFixture, PutSignalComparison) {
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1056,7 +1064,7 @@ TEST_P(IbgdaBenchmarkFixture, PutSignalComparison) {
       uint8_t basePattern = static_cast<uint8_t>((ci + 1) * 3);
 
       if (globalRank == 0) {
-        XLOGF(INFO, "Verifying put data correctness ({})...", cfg.name);
+        COMMS_LOG(INFO, "Verifying put data correctness ({})...", cfg.name);
       }
 
       verifyPutDataCorrectness(
@@ -1071,16 +1079,17 @@ TEST_P(IbgdaBenchmarkFixture, PutSignalComparison) {
     }
 
     if (globalRank == 0) {
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "\n================================================================================");
-      XLOGF(INFO, "    {} put+signal+counter latency", backendName());
-      XLOGF(INFO, "    (Using batched kernels - no kernel launch overhead)");
-      XLOGF(
+      COMMS_LOG(INFO, "    {} put+signal+counter latency", backendName());
+      COMMS_LOG(
+          INFO, "    (Using batched kernels - no kernel launch overhead)");
+      COMMS_LOG(
           INFO,
           "================================================================================");
-      XLOGF(INFO, "{:>10} {:>18}", "Size", "Counter Lat (us)");
-      XLOGF(
+      COMMS_LOG(INFO, "{:>10} {:>18}", "Size", "Counter Lat (us)");
+      COMMS_LOG(
           INFO,
           "--------------------------------------------------------------------------------");
     }
@@ -1097,18 +1106,18 @@ TEST_P(IbgdaBenchmarkFixture, PutSignalComparison) {
           counterLatency);
 
       if (globalRank == 0) {
-        XLOGF(INFO, "{:>10} {:>18.2f}", config.name, counterLatency);
+        COMMS_LOG(INFO, "{:>10} {:>18.2f}", config.name, counterLatency);
       }
     }
 
     if (globalRank == 0) {
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "================================================================================");
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "Counter = put + signal + transport counter-slot completion + local poll");
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "================================================================================\n");
     }
@@ -1134,7 +1143,7 @@ TEST_P(IbgdaBenchmarkFixture, PutSignalComparison) {
 TEST_P(IbgdaBenchmarkFixture, MultiPeerCounterFanOut) {
   const int numPeers = numRanks - 1;
   if (numPeers < 1) {
-    XLOGF(INFO, "Skipping test: requires >= 2 ranks, got {}", numRanks);
+    COMMS_LOG(INFO, "Skipping test: requires >= 2 ranks, got {}", numRanks);
     return;
   }
   if (backend() == BenchIbBackend::IBRC) {
@@ -1285,46 +1294,46 @@ TEST_P(IbgdaBenchmarkFixture, MultiPeerCounterFanOut) {
 
     if (globalRank == 0) {
       float delta = fanOutLatency - serialLatency;
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "\n================================================================================");
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "    {} Multi-Peer Counter Fan-Out ({} peers, {} per peer)",
           backendName(),
           numPeers,
           formatSize(kDataSize));
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "================================================================================");
-      XLOGF(
+      COMMS_LOG(
           INFO, "  Serial (N wait_counter calls): {:>8.2f} us", serialLatency);
-      XLOGF(
+      COMMS_LOG(
           INFO, "  FanOut (1 wait_counter call):  {:>8.2f} us", fanOutLatency);
-      XLOGF(INFO, "  Delta (FanOut - Serial):       {:>+8.2f} us", delta);
-      XLOGF(
+      COMMS_LOG(INFO, "  Delta (FanOut - Serial):       {:>+8.2f} us", delta);
+      COMMS_LOG(
           INFO,
           "  Serial / peer:                 {:>8.2f} us",
           serialLatency / numPeers);
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "  FanOut / peer (amortized):     {:>8.2f} us",
           fanOutLatency / numPeers);
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "--------------------------------------------------------------------------------");
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "  Serial:  put+signal+counter (per-peer slot) + wait_counter per peer (O(N))");
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "  FanOut:  put+signal+counter (shared slot) + single wait_counter (O(1))");
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "  Batch iterations: {}, GPU clock: {:.2f} GHz",
           kIbgdaBatchIters,
           clockRateGHz_);
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "================================================================================\n");
     }
@@ -1349,5 +1358,7 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
   folly::Init init(&argc, &argv);
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/benchmarks/IbgdaForwardBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaForwardBenchmark.cc
@@ -4,7 +4,7 @@
 
 #include <cuda_runtime.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <cstdint>
 #include <memory>
@@ -39,7 +39,7 @@ class IbgdaForwardBenchmarkTest : public BenchmarkTestFixture {
 
 TEST_F(IbgdaForwardBenchmarkTest, Correctness) {
   if (worldSize != 3) {
-    XLOGF(INFO, "Skipping: requires exactly 3 ranks, got {}", worldSize);
+    COMMS_LOG(INFO, "Skipping: requires exactly 3 ranks, got {}", worldSize);
     return;
   }
 
@@ -101,7 +101,7 @@ TEST_F(IbgdaForwardBenchmarkTest, Correctness) {
     for (std::size_t i = 0; i < kDataBytes; ++i) {
       if (hostBuf[i] != fillPattern) {
         if (errors < 10) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: byte {} expected 0x{:02X} got 0x{:02X}",
               globalRank,
@@ -119,7 +119,7 @@ TEST_F(IbgdaForwardBenchmarkTest, Correctness) {
 
 TEST_F(IbgdaForwardBenchmarkTest, Bandwidth) {
   if (worldSize != 3) {
-    XLOGF(INFO, "Skipping: requires exactly 3 ranks, got {}", worldSize);
+    COMMS_LOG(INFO, "Skipping: requires exactly 3 ranks, got {}", worldSize);
     return;
   }
 
@@ -165,29 +165,29 @@ TEST_F(IbgdaForwardBenchmarkTest, Bandwidth) {
   cudaEventCreate(&stop);
 
   if (globalRank == 0) {
-    XLOGF(INFO, "");
-    XLOGF(
+    COMMS_LOG(INFO, "");
+    COMMS_LOG(
         INFO,
         "================================================================");
-    XLOGF(
+    COMMS_LOG(
         INFO, "  recv_forward vs recv+send (3-rank chain: rank0→rank1→rank2)");
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "  numBlocks={}, slotSize={}MB, pipelineDepth={}",
         kNumBlocks,
         kSlotSize / (1024 * 1024),
         kPipelineDepth);
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "================================================================");
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "{:>10s}  {:>14s}  {:>14s}  {:>10s}",
         "MsgSize",
         "recv_fwd GB/s",
         "recv+snd GB/s",
         "Speedup");
-    XLOGF(
+    COMMS_LOG(
         INFO, "--------------------------------------------------------------");
   }
 
@@ -293,7 +293,7 @@ TEST_F(IbgdaForwardBenchmarkTest, Bandwidth) {
         sizeStr = fmt::format("{}MB", nBytes >> 20);
       }
       float speedup = (recvSndBw > 0) ? (recvFwdBw / recvSndBw) : 0;
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "{:>10s}  {:>14.2f}  {:>14.2f}  {:>9.2f}x",
           sizeStr,
@@ -304,7 +304,7 @@ TEST_F(IbgdaForwardBenchmarkTest, Bandwidth) {
   }
 
   if (globalRank == 0) {
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "================================================================");
   }
@@ -321,5 +321,7 @@ int main(int argc, char* argv[]) {
   if (!meta::comms::isTcpEnvironment()) {
     ::testing::AddGlobalTestEnvironment(new BenchmarkEnvironment());
   }
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/benchmarks/MultiPeerBenchmark.cc
+++ b/comms/prims/benchmarks/MultiPeerBenchmark.cc
@@ -3,9 +3,9 @@
 #include <cuda_runtime.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <algorithm>
 #include <iomanip>
@@ -177,7 +177,7 @@ class MultiPeerBenchmarkFixture : public MpiBaseTestFixture {
     for (int i = 0; i < warmupIters; ++i) {
       cudaError_t err = launchKernel();
       if (err != cudaSuccess) {
-        XLOGF(
+        COMMS_LOG(
             ERR,
             "Kernel launch failed during warmup: {}",
             cudaGetErrorString(err));
@@ -186,7 +186,7 @@ class MultiPeerBenchmarkFixture : public MpiBaseTestFixture {
       }
       err = cudaStreamSynchronize(stream_);
       if (err != cudaSuccess) {
-        XLOGF(
+        COMMS_LOG(
             ERR,
             "Stream sync failed during warmup: {}",
             cudaGetErrorString(err));
@@ -198,7 +198,7 @@ class MultiPeerBenchmarkFixture : public MpiBaseTestFixture {
     // Verify no CUDA errors accumulated after warmup
     cudaError_t lastErr = cudaGetLastError();
     if (lastErr != cudaSuccess) {
-      XLOGF(
+      COMMS_LOG(
           ERR,
           "CUDA error detected after warmup: {}",
           cudaGetErrorString(lastErr));
@@ -302,7 +302,7 @@ class MultiPeerBenchmarkFixture : public MpiBaseTestFixture {
        << getStepsPerIter() << " steps/iter\n";
     ss << "========================================================================\n\n";
 
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 
   cudaStream_t stream_{};
@@ -522,5 +522,7 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
   folly::Init init(&argc, &argv);
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/benchmarks/P2pNvlLl128Benchmark.cc
+++ b/comms/prims/benchmarks/P2pNvlLl128Benchmark.cc
@@ -1,8 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <nccl.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/common/CudaWrap.h"
 #include "comms/prims/benchmarks/BenchmarkKernel.cuh"
@@ -98,7 +98,7 @@ class P2pLl128BenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     if (globalRank == 0) {
       ncclResult_t res = ncclGetUniqueId(&id);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
         std::abort();
       }
     }
@@ -111,7 +111,7 @@ class P2pLl128BenchmarkFixture : public meta::comms::BenchmarkTestFixture {
                 allIds.data(), sizeof(ncclUniqueId), globalRank, worldSize)
             .get();
     if (result != 0) {
-      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      COMMS_LOG_STREAM(ERR) << "Bootstrap allGather for NCCL ID failed";
       std::abort();
     }
     id = allIds[0];
@@ -827,7 +827,8 @@ class P2pLl128BenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
 TEST_F(P2pLl128BenchmarkFixture, UnidirectionalBenchmark) {
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -935,7 +936,8 @@ TEST_F(P2pLl128BenchmarkFixture, UnidirectionalBenchmark) {
 
 TEST_F(P2pLl128BenchmarkFixture, BidirectionalBenchmark) {
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -1055,7 +1057,8 @@ TEST_F(P2pLl128BenchmarkFixture, BidirectionalBenchmark) {
 
 TEST_F(P2pLl128BenchmarkFixture, ChunkedUnidirectionalBenchmark) {
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
   int peerRank = (globalRank == 0) ? 1 : 0;
@@ -1088,7 +1091,8 @@ TEST_F(P2pLl128BenchmarkFixture, ChunkedUnidirectionalBenchmark) {
 
 TEST_F(P2pLl128BenchmarkFixture, ChunkedBidirectionalBenchmark) {
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
   int peerRank = (globalRank == 0) ? 1 : 0;
@@ -1121,7 +1125,8 @@ TEST_F(P2pLl128BenchmarkFixture, ChunkedBidirectionalBenchmark) {
 
 TEST_F(P2pLl128BenchmarkFixture, AutoTunedBenchmark) {
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -1140,7 +1145,8 @@ TEST_F(P2pLl128BenchmarkFixture, AutoTunedBenchmark) {
 
 TEST_F(P2pLl128BenchmarkFixture, AutoTunedBidirectionalBenchmark) {
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -1170,5 +1176,7 @@ int main(int argc, char* argv[]) {
         new meta::comms::BenchmarkEnvironment());
   }
 
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/benchmarks/P2pNvlLlBenchmark.cc
+++ b/comms/prims/benchmarks/P2pNvlLlBenchmark.cc
@@ -1,8 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <nccl.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/common/CudaWrap.h"
 #include "comms/prims/benchmarks/BenchmarkKernel.cuh"
@@ -63,13 +63,13 @@ class P2pLlBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     if (ncclComm_ != nullptr) {
       ncclResult_t res = ncclCommDestroy(ncclComm_);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclCommDestroy failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclCommDestroy failed: {}", ncclGetErrorString(res));
       }
     }
     if (stream_ != nullptr) {
       cudaError_t err = cudaStreamDestroy(stream_);
       if (err != cudaSuccess) {
-        XLOGF(ERR, "cudaStreamDestroy failed: {}", cudaGetErrorString(err));
+        COMMS_LOG(ERR, "cudaStreamDestroy failed: {}", cudaGetErrorString(err));
       }
     }
     BenchmarkTestFixture::TearDown();
@@ -80,7 +80,7 @@ class P2pLlBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     if (globalRank == 0) {
       ncclResult_t res = ncclGetUniqueId(&id);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
         std::abort();
       }
     }
@@ -93,7 +93,7 @@ class P2pLlBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
                 allIds.data(), sizeof(ncclUniqueId), globalRank, worldSize)
             .get();
     if (result != 0) {
-      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      COMMS_LOG_STREAM(ERR) << "Bootstrap allGather for NCCL ID failed";
       std::abort();
     }
     id = allIds[0];
@@ -695,5 +695,7 @@ int main(int argc, char* argv[]) {
         new meta::comms::BenchmarkEnvironment());
   }
 
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/benchmarks/P2pNvlSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/P2pNvlSendRecvBenchmark.cc
@@ -1,8 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <nccl.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/common/CudaWrap.h"
 #include "comms/prims/benchmarks/BenchmarkKernel.cuh"
@@ -53,7 +53,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     if (globalRank == 0) {
       ncclResult_t res = ncclGetUniqueId(&id);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
         std::abort();
       }
     }
@@ -67,7 +67,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
                 allIds.data(), sizeof(ncclUniqueId), globalRank, worldSize)
             .get();
     if (result != 0) {
-      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      COMMS_LOG_STREAM(ERR) << "Bootstrap allGather for NCCL ID failed";
       std::abort();
     }
     id = allIds[0]; // Take rank 0's ID
@@ -76,7 +76,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
   // Helper function to run NCCL benchmark - returns bandwidth
   float runNcclBenchmark(const BenchmarkConfig& config, float& timeUs) {
-    XLOGF(DBG1, "=== Running NCCL benchmark: {} ===", config.name);
+    COMMS_LOG(DBG, "=== Running NCCL benchmark: {} ===", config.name);
 
     DeviceBuffer sendBuff(config.nBytes);
     DeviceBuffer recvBuff(config.nBytes);
@@ -176,7 +176,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
           cudaMemcpyDeviceToHost));
       for (size_t i = 0; i < config.nBytes; i++) {
         if (static_cast<unsigned char>(hostBuf[i]) != testValue) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "VERIFY FAILED {}: byte {} expected 0x{:02X} got 0x{:02X}",
               config.name,
@@ -198,7 +198,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
       comms::prims::P2pNvlTransportDevice* p2pDevicePtr,
       const BenchmarkConfig& config,
       float& timeUs) {
-    XLOGF(DBG1, "=== Running P2P NVL benchmark: {} ===", config.name);
+    COMMS_LOG(DBG, "=== Running P2P NVL benchmark: {} ===", config.name);
 
     DeviceBuffer sendBuff(config.nBytes);
     DeviceBuffer recvBuff(config.nBytes);
@@ -275,7 +275,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
       comms::prims::P2pNvlTransportDevice* p2pDevicePtr,
       const BenchmarkConfig& config,
       float& timeUs) {
-    XLOGF(DBG1, "=== Running Tile benchmark: {} ===", config.name);
+    COMMS_LOG(DBG, "=== Running Tile benchmark: {} ===", config.name);
 
     DeviceBuffer sendBuff(config.nBytes);
     DeviceBuffer recvBuff(config.nBytes);
@@ -337,7 +337,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
       for (size_t i = 0; i < config.nBytes; i++) {
         if (static_cast<unsigned char>(hostBuf[i]) !=
             static_cast<unsigned char>(peerPattern)) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "TILE VERIFY FAILED {}: byte {} expected 0x{:02X} got 0x{:02X}",
               config.name,
@@ -391,8 +391,8 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
   float runNcclBidirectionalBenchmark(
       const BenchmarkConfig& config,
       float& timeUs) {
-    XLOGF(
-        DBG1,
+    COMMS_LOG(
+        DBG,
         "Rank {}: Starting NCCL bidirectional benchmark: {}",
         globalRank,
         config.name);
@@ -409,7 +409,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     CudaEvent start, stop;
 
     // Warmup
-    XLOGF(DBG1, "Rank {}: NCCL bidi warmup starting", globalRank);
+    COMMS_LOG(DBG, "Rank {}: NCCL bidi warmup starting", globalRank);
     bootstrap->barrierAll();
     for (int i = 0; i < kWarmupIters; i++) {
       NCCL_CHECK(ncclGroupStart());
@@ -430,7 +430,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
       NCCL_CHECK(ncclGroupEnd());
       CUDA_CHECK(cudaStreamSynchronize(stream_));
     }
-    XLOGF(DBG1, "Rank {}: NCCL bidi warmup complete", globalRank);
+    COMMS_LOG(DBG, "Rank {}: NCCL bidi warmup complete", globalRank);
 
     // Benchmark - measure time across all iterations
     // No barrier between iterations - rely on NCCL's internal synchronization
@@ -476,8 +476,8 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
       comms::prims::P2pNvlTransportDevice* p2pDevicePtr,
       const BenchmarkConfig& config,
       float& timeUs) {
-    XLOGF(
-        DBG1,
+    COMMS_LOG(
+        DBG,
         "Rank {}: Starting P2P NVL bidirectional benchmark: {}",
         globalRank,
         config.name);
@@ -616,7 +616,8 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 TEST_F(P2pSendRecvBenchmarkFixture, UnidirectionalBenchmark) {
   // Only test with 2 ranks
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -718,7 +719,7 @@ TEST_F(P2pSendRecvBenchmarkFixture, UnidirectionalBenchmark) {
 
     // Verify correctness before benchmarking
     if (!verifyP2pCorrectness(&p2pHost, config)) {
-      XLOGF(ERR, "CORRECTNESS CHECK FAILED for config: {}", config.name);
+      COMMS_LOG(ERR, "CORRECTNESS CHECK FAILED for config: {}", config.name);
       if (globalRank == 0) {
         std::cout << "*** VERIFY FAILED: " << config.name << " ***\n";
       }
@@ -746,7 +747,8 @@ TEST_F(P2pSendRecvBenchmarkFixture, UnidirectionalBenchmark) {
 TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
   // Only test with 2 ranks
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -1015,7 +1017,8 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
 
 TEST_F(P2pSendRecvBenchmarkFixture, MatchedBidirCtaBenchmark) {
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -1118,5 +1121,7 @@ int main(int argc, char* argv[]) {
         new meta::comms::BenchmarkEnvironment());
   }
 
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/benchmarks/P2pNvlSignalBenchmark.cc
+++ b/comms/prims/benchmarks/P2pNvlSignalBenchmark.cc
@@ -1,8 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <nccl.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/common/CudaWrap.h"
 #include "comms/prims/benchmarks/BenchmarkKernel.cuh"
@@ -50,7 +50,7 @@ class P2pSignalBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     if (globalRank == 0) {
       ncclResult_t res = ncclGetUniqueId(&id);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
         std::abort();
       }
     }
@@ -64,7 +64,7 @@ class P2pSignalBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
                 allIds.data(), sizeof(ncclUniqueId), globalRank, worldSize)
             .get();
     if (result != 0) {
-      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      COMMS_LOG_STREAM(ERR) << "Bootstrap allGather for NCCL ID failed";
       std::abort();
     }
     id = allIds[0]; // Take rank 0's ID
@@ -77,7 +77,7 @@ class P2pSignalBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
       comms::prims::P2pNvlTransportDevice* p2p,
       const BenchmarkConfig& config,
       int nSteps = 1000) {
-    XLOGF(DBG1, "=== Running Signal benchmark: {} ===", config.name);
+    COMMS_LOG(DBG, "=== Running Signal benchmark: {} ===", config.name);
 
     dim3 gridDim(config.numBlocks);
     dim3 blockDim(config.numThreads);
@@ -118,7 +118,8 @@ class P2pSignalBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 TEST_F(P2pSignalBenchmarkFixture, SignalBenchmark) {
   // Only test with 2 ranks
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -270,5 +271,7 @@ int main(int argc, char* argv[]) {
         new meta::comms::BenchmarkEnvironment());
   }
 
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/bootstrap/tests/NvlBootstrapAdapterTest.cc
+++ b/comms/prims/bootstrap/tests/NvlBootstrapAdapterTest.cc
@@ -3,7 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/prims/bootstrap/NvlBootstrapAdapter.h"
 #include "comms/testinfra/mpi/MpiBootstrap.h"
@@ -63,8 +63,8 @@ TEST_F(NvlBootstrapAdapterTest, AllGatherNvlDomainAllRanks) {
  */
 TEST_F(NvlBootstrapAdapterTest, AllGatherNvlDomainSubset) {
   if (numRanks < 4) {
-    XLOGF(
-        WARNING, "Skipping subset test: requires >= 4 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping subset test: requires >= 4 ranks, got {}", numRanks);
     return;
   }
 
@@ -84,7 +84,7 @@ TEST_F(NvlBootstrapAdapterTest, AllGatherNvlDomainSubset) {
   }
 
   if (nvlLocalRank < 0) {
-    XLOGF(INFO, "Rank {} not in NVL domain, skipping", globalRank);
+    COMMS_LOG(INFO, "Rank {} not in NVL domain, skipping", globalRank);
     return;
   }
 
@@ -227,8 +227,8 @@ TEST_F(NvlBootstrapAdapterTest, AdapterSendRecvMapping) {
  */
 TEST_F(NvlBootstrapAdapterTest, AdapterSubsetMapping) {
   if (numRanks < 4) {
-    XLOGF(
-        WARNING,
+    COMMS_LOG(
+        WARN,
         "Skipping subset mapping test: requires >= 4 ranks, got {}",
         numRanks);
     return;
@@ -250,7 +250,7 @@ TEST_F(NvlBootstrapAdapterTest, AdapterSubsetMapping) {
   }
 
   if (nvlLocalRank < 0) {
-    XLOGF(INFO, "Rank {} not in odd NVL domain, skipping", globalRank);
+    COMMS_LOG(INFO, "Rank {} not in odd NVL domain, skipping", globalRank);
     return;
   }
 

--- a/comms/prims/collectives/benchmarks/AllGatherBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/AllGatherBenchmark.cc
@@ -1,8 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <nccl.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/common/CudaWrap.h"
 #include "comms/prims/benchmarks/BenchmarkMacros.h"
@@ -76,7 +76,7 @@ class AllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     if (globalRank == 0) {
       ncclResult_t res = ncclGetUniqueId(&id);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
         std::abort();
       }
     }
@@ -89,7 +89,7 @@ class AllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
                 allIds.data(), sizeof(ncclUniqueId), globalRank, worldSize)
             .get();
     if (result != 0) {
-      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      COMMS_LOG_STREAM(ERR) << "Bootstrap allGather for NCCL ID failed";
       std::abort();
     }
     id = allIds[0]; // Take rank 0's ID
@@ -103,8 +103,8 @@ class AllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
   float runNcclAllGatherBenchmark(
       const AllGatherBenchmarkConfig& config,
       float& latencyUs) {
-    XLOGF(
-        DBG1,
+    COMMS_LOG(
+        DBG,
         "Rank {}: Running NCCL AllGather benchmark: {}",
         globalRank,
         config.name);
@@ -180,8 +180,8 @@ class AllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
   float runAllGatherBenchmark(
       const AllGatherBenchmarkConfig& config,
       float& latencyUs) {
-    XLOGF(
-        DBG1,
+    COMMS_LOG(
+        DBG,
         "Rank {}: Running AllGather benchmark: {}",
         globalRank,
         config.name);
@@ -377,7 +377,7 @@ class AllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     ss << "================================================================================\n";
     ss << "\n";
 
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 
   ncclComm_t ncclComm_{};
@@ -386,7 +386,7 @@ class AllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
 TEST_F(AllGatherBenchmarkFixture, OptimalConfigs) {
   if (globalRank == 0) {
-    XLOG(INFO)
+    COMMS_LOG_STREAM(INFO)
         << "\n=== OPTIMAL AllGather vs NCCL Comparison (All Message Sizes) ===\n";
   }
 
@@ -611,5 +611,7 @@ int main(int argc, char* argv[]) {
   // Set up distributed environment
   ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
 
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/collectives/benchmarks/AllToAllvBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/AllToAllvBenchmark.cc
@@ -1,8 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <chrono>
+#include "comms/utils/logger/SpdlogLogger.h"
 #ifndef __HIP_PLATFORM_AMD__
 #include <nccl.h>
 #endif
@@ -92,7 +92,7 @@ class AllToAllvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     if (globalRank == 0) {
       ncclResult_t res = ncclGetUniqueId(&id);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
         std::abort();
       }
     }
@@ -106,7 +106,7 @@ class AllToAllvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
                 allIds.data(), sizeof(ncclUniqueId), globalRank, worldSize)
             .get();
     if (result != 0) {
-      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      COMMS_LOG_STREAM(ERR) << "Bootstrap allGather for NCCL ID failed";
       std::abort();
     }
     id = allIds[0]; // Take rank 0's ID
@@ -120,8 +120,8 @@ class AllToAllvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
   float runNcclAllToAllvBenchmark(
       const AllToAllvBenchmarkConfig& config,
       float& latencyUs) {
-    XLOGF(
-        DBG1,
+    COMMS_LOG(
+        DBG,
         "Rank {}: Running NCCL AllToAllv benchmark: {}",
         globalRank,
         config.name);
@@ -218,8 +218,8 @@ class AllToAllvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
   float runAllToAllvBenchmark(
       const AllToAllvBenchmarkConfig& config,
       float& latencyUs) {
-    XLOGF(
-        DBG1,
+    COMMS_LOG(
+        DBG,
         "Rank {}: Running AllToAllv benchmark: {}",
         globalRank,
         config.name);
@@ -420,7 +420,7 @@ class AllToAllvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     ss << "================================================================================================================\n";
     ss << "\n";
 
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 
 #ifndef __HIP_PLATFORM_AMD__
@@ -460,7 +460,7 @@ TEST_F(AllToAllvBenchmarkFixture, OptimalConfigs) {
   // Optimal configurations for multiple message sizes
 
   if (globalRank == 0) {
-    XLOG(INFO)
+    COMMS_LOG_STREAM(INFO)
         << "\n=== OPTIMAL AllToAllv vs NCCL Comparison (All Message Sizes) ===\n";
   }
 
@@ -674,5 +674,7 @@ int main(int argc, char* argv[]) {
   // Set up distributed environment
   ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
 
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/collectives/benchmarks/AllToAllvLl128Benchmark.cc
+++ b/comms/prims/collectives/benchmarks/AllToAllvLl128Benchmark.cc
@@ -1,9 +1,9 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <nccl.h>
 #include <chrono>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/common/CudaWrap.h"
 #include "comms/common/fault_tolerance/Abort.h"
@@ -78,7 +78,7 @@ class AllToAllvLl128BenchmarkFixture
     if (globalRank == 0) {
       ncclResult_t res = ncclGetUniqueId(&id);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
         std::abort();
       }
     }
@@ -90,7 +90,7 @@ class AllToAllvLl128BenchmarkFixture
                 allIds.data(), sizeof(ncclUniqueId), globalRank, worldSize)
             .get();
     if (result != 0) {
-      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      COMMS_LOG_STREAM(ERR) << "Bootstrap allGather for NCCL ID failed";
       std::abort();
     }
     id = allIds[0];
@@ -135,8 +135,9 @@ class AllToAllvLl128BenchmarkFixture
       bootstrap->barrierAll();
 
       if (globalRank == 0) {
-        XLOG(INFO) << "Global warmup complete (" << kGlobalWarmupIters
-                   << " NCCL iterations at 16KB/peer)";
+        COMMS_LOG_STREAM(INFO)
+            << "Global warmup complete (" << kGlobalWarmupIters
+            << " NCCL iterations at 16KB/peer)";
       }
     }
   }
@@ -490,7 +491,7 @@ class AllToAllvLl128BenchmarkFixture
     ss << "LL128/NCCL = LL128 BW / NCCL BW, LL128/Simp = LL128 BW / Simple BW\n";
     ss << std::string(125, '=') << "\n";
 
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 
   ncclComm_t ncclComm_{};
@@ -499,7 +500,8 @@ class AllToAllvLl128BenchmarkFixture
 
 TEST_F(AllToAllvLl128BenchmarkFixture, Ll128VsSimpleVsNccl) {
   if (globalRank == 0) {
-    XLOG(INFO) << "\n=== LL128 vs Simple vs NCCL AllToAllv Comparison ===\n";
+    COMMS_LOG_STREAM(INFO)
+        << "\n=== LL128 vs Simple vs NCCL AllToAllv Comparison ===\n";
   }
 
   std::vector<Ll128BenchmarkConfig> configs;
@@ -674,7 +676,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128VsSimpleVsNccl) {
 
 TEST_F(AllToAllvLl128BenchmarkFixture, LatencySweep) {
   if (globalRank == 0) {
-    XLOG(INFO)
+    COMMS_LOG_STREAM(INFO)
         << "\n=== LL128 vs Simple vs NCCL Latency Sweep (for Triton comparison) ===\n";
   }
 
@@ -815,7 +817,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, LatencySweep) {
     ss << "LL128/NCCL and LL128/Simple are speedup ratios (higher is better)\n";
     ss << std::string(90, '=') << "\n";
 
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
 
     // CSV output to file if BENCH_CSV_OUTPUT is set
     const char* csvPath = std::getenv("BENCH_CSV_OUTPUT");
@@ -832,9 +834,9 @@ TEST_F(AllToAllvLl128BenchmarkFixture, LatencySweep) {
           csvFile << "\n";
         }
         csvFile.close();
-        XLOG(INFO) << "CSV results written to: " << csvPath;
+        COMMS_LOG_STREAM(INFO) << "CSV results written to: " << csvPath;
       } else {
-        XLOG(ERR) << "Failed to open CSV output file: " << csvPath;
+        COMMS_LOG_STREAM(ERR) << "Failed to open CSV output file: " << csvPath;
       }
     }
 
@@ -851,13 +853,14 @@ TEST_F(AllToAllvLl128BenchmarkFixture, LatencySweep) {
       ss << "\n";
     }
     ss << "--- CSV END ---";
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 }
 
 TEST_F(AllToAllvLl128BenchmarkFixture, Ll128BlockThreadSweep) {
   if (globalRank == 0) {
-    XLOG(INFO) << "\n=== LL128 AllToAllv Block Count Sweep (threads=512) ===\n";
+    COMMS_LOG_STREAM(INFO)
+        << "\n=== LL128 AllToAllv Block Count Sweep (threads=512) ===\n";
   }
 
   // Message sizes that span medium-to-large range where block count matters
@@ -952,13 +955,13 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128BlockThreadSweep) {
     }
 
     ss << std::string(80, '=') << "\n";
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 }
 
 TEST_F(AllToAllvLl128BenchmarkFixture, Ll128ThreadSweep) {
   if (globalRank == 0) {
-    XLOG(INFO)
+    COMMS_LOG_STREAM(INFO)
         << "\n=== LL128 AllToAllv Thread Count Sweep (256 vs 512 threads) ===\n";
   }
 
@@ -1047,7 +1050,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128ThreadSweep) {
     }
 
     ss << std::string(80, '=') << "\n";
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 }
 
@@ -1059,5 +1062,7 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   folly::Init init(&argc, &argv);
   ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/collectives/benchmarks/AnsCopyOpBench.cc
+++ b/comms/prims/collectives/benchmarks/AnsCopyOpBench.cc
@@ -8,11 +8,11 @@
 // AllToAllv-tile collective.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <algorithm>
 #include <cstdint>
 #include <string>
 #include <vector>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <cuda.h> // driver API: green contexts for SM partitioning
 
@@ -39,15 +39,16 @@ struct LocalCompStats {
 };
 
 // Driver-API error check (runtime calls use PIPES_CUDA_CHECK).
-#define PIPES_CU_CHECK(expr)                                           \
-  do {                                                                 \
-    CUresult _res = (expr);                                            \
-    if (_res != CUDA_SUCCESS) {                                        \
-      const char* _msg = nullptr;                                      \
-      cuGetErrorString(_res, &_msg);                                   \
-      XLOG(FATAL) << "[AnsCopyOpStandalone] CUDA driver error: " #expr \
-                  << " -> " << (_msg ? _msg : "unknown");              \
-    }                                                                  \
+#define PIPES_CU_CHECK(expr)                                             \
+  do {                                                                   \
+    CUresult _res = (expr);                                              \
+    if (_res != CUDA_SUCCESS) {                                          \
+      const char* _msg = nullptr;                                        \
+      cuGetErrorString(_res, &_msg);                                     \
+      COMMS_LOG_STREAM(FATAL)                                            \
+          << "[AnsCopyOpStandalone] CUDA driver error: " #expr << " -> " \
+          << (_msg ? _msg : "unknown");                                  \
+    }                                                                    \
   } while (0)
 
 // A stream confined to a green context spanning >= `numSms` SMs of the
@@ -78,7 +79,7 @@ GreenCtxStream makeGreenCtxStream(int numSms) {
   if (smRes != CUDA_SUCCESS) {
     const char* nm = nullptr;
     cuGetErrorName(smRes, &nm);
-    XLOG(FATAL)
+    COMMS_LOG_STREAM(FATAL)
         << "[AnsCopyOpStandalone] green-context SM partitioning unavailable "
         << "(cuDeviceGetDevResource -> " << (nm ? nm : "?") << "). "
         << "PIPES_COPYOP_BENCH_NUM_SMS requires CUDA driver >= 12.4 (R550); "
@@ -241,26 +242,26 @@ TEST_F(AnsCopyOpBenchFixture, AnsCopyOpStandalone) {
   const cudaStream_t benchStream =
       gctx.stream; // nullptr => default stream (whole GPU)
 
-  XLOG(INFO) << "\n=== ANS CopyOp Standalone Microbenchmark "
-             << "(single GPU) ===\n"
-             << "PIPES_COPYOP_BENCH_BLOCKS=" << kCopyOpBlocks
-             << " PIPES_COPYOP_BENCH_THREADS=" << kCopyOpThreads
-             << " PIPES_COPYOP_BENCH_MIN_BLOCKS_PER_SM="
-             << kCopyOpMinBlocksPerSM
-             << " PIPES_COPYOP_BENCH_NUM_SMS=" << kCopyOpNumSms
-             << (kCopyOpNumSms > 0 ? " (green-ctx SM-limited)" : " (full GPU)")
-             << "\n"
-             << kCopyOpBlocks << " threadblocks × " << kCopyOpThreads
-             << " threads/block, " << kCopyOpWarmupIter << " warmup + "
-             << kCopyOpMeasureIter << " timed iterations per cell\n"
-             << "Sweep: sizes {256KB, 512KB, 1MB, 2MB, 4MB} × "
-             << "sparsity 0%→100% step 10%\n"
-             << "BW = aggregate uncompressed bytes / measured kernel "
-             << "time (sum over all " << kCopyOpBlocks << " blocks)\n";
+  COMMS_LOG_STREAM(INFO)
+      << "\n=== ANS CopyOp Standalone Microbenchmark "
+      << "(single GPU) ===\n"
+      << "PIPES_COPYOP_BENCH_BLOCKS=" << kCopyOpBlocks
+      << " PIPES_COPYOP_BENCH_THREADS=" << kCopyOpThreads
+      << " PIPES_COPYOP_BENCH_MIN_BLOCKS_PER_SM=" << kCopyOpMinBlocksPerSM
+      << " PIPES_COPYOP_BENCH_NUM_SMS=" << kCopyOpNumSms
+      << (kCopyOpNumSms > 0 ? " (green-ctx SM-limited)" : " (full GPU)") << "\n"
+      << kCopyOpBlocks << " threadblocks × " << kCopyOpThreads
+      << " threads/block, " << kCopyOpWarmupIter << " warmup + "
+      << kCopyOpMeasureIter << " timed iterations per cell\n"
+      << "Sweep: sizes {256KB, 512KB, 1MB, 2MB, 4MB} × "
+      << "sparsity 0%→100% step 10%\n"
+      << "BW = aggregate uncompressed bytes / measured kernel "
+      << "time (sum over all " << kCopyOpBlocks << " blocks)\n";
 
   for (int sparsityPct = 0; sparsityPct <= 100; sparsityPct += 10) {
-    XLOG(INFO) << "\n--- Sparsity " << sparsityPct
-               << "% (zero-byte prefix of each block's input region) ---";
+    COMMS_LOG_STREAM(INFO)
+        << "\n--- Sparsity " << sparsityPct
+        << "% (zero-byte prefix of each block's input region) ---";
     printf(
         "%-10s  %14s  %16s  %10s  %11s\n",
         "Size",
@@ -327,23 +328,23 @@ TEST_F(AnsCopyOpBenchFixture, AnsCopyOpStandalone) {
       auto sync_check = [&](const char* phase) {
         const cudaError_t launchErr = cudaGetLastError();
         if (launchErr != cudaSuccess) {
-          XLOG(FATAL) << "[AnsCopyOpStandalone] launch error in " << phase
-                      << " sparsity=" << sparsityPct
-                      << "% size=" << format_bytes(inputBytes)
-                      << " blocks=" << kCopyOpBlocks
-                      << " threads=" << kCopyOpThreads
-                      << " stagingStride=" << stagingStride
-                      << " err=" << cudaGetErrorString(launchErr);
+          COMMS_LOG_STREAM(FATAL)
+              << "[AnsCopyOpStandalone] launch error in " << phase
+              << " sparsity=" << sparsityPct
+              << "% size=" << format_bytes(inputBytes)
+              << " blocks=" << kCopyOpBlocks << " threads=" << kCopyOpThreads
+              << " stagingStride=" << stagingStride
+              << " err=" << cudaGetErrorString(launchErr);
         }
         const cudaError_t syncErr = cudaDeviceSynchronize();
         if (syncErr != cudaSuccess) {
-          XLOG(FATAL) << "[AnsCopyOpStandalone] async error in " << phase
-                      << " sparsity=" << sparsityPct
-                      << "% size=" << format_bytes(inputBytes)
-                      << " blocks=" << kCopyOpBlocks
-                      << " threads=" << kCopyOpThreads
-                      << " stagingStride=" << stagingStride
-                      << " err=" << cudaGetErrorString(syncErr);
+          COMMS_LOG_STREAM(FATAL)
+              << "[AnsCopyOpStandalone] async error in " << phase
+              << " sparsity=" << sparsityPct
+              << "% size=" << format_bytes(inputBytes)
+              << " blocks=" << kCopyOpBlocks << " threads=" << kCopyOpThreads
+              << " stagingStride=" << stagingStride
+              << " err=" << cudaGetErrorString(syncErr);
         }
       };
 
@@ -499,12 +500,12 @@ TEST_F(AnsCopyOpBenchFixture, AnsCopyOpStandalone) {
           // row in the table makes clear which cell crashed.
           printf("%11s\n", "FAIL");
           fflush(stdout);
-          XLOG(FATAL) << "[AnsCopyOpStandalone] round-trip mismatch sparsity="
-                      << sparsityPct << "% size=" << format_bytes(inputBytes)
-                      << " block=" << b << " firstMismatch=" << firstMismatch
-                      << " in=" << static_cast<int>(host_input[firstMismatch])
-                      << " out="
-                      << static_cast<int>(host_output[firstMismatch]);
+          COMMS_LOG_STREAM(FATAL)
+              << "[AnsCopyOpStandalone] round-trip mismatch sparsity="
+              << sparsityPct << "% size=" << format_bytes(inputBytes)
+              << " block=" << b << " firstMismatch=" << firstMismatch
+              << " in=" << static_cast<int>(host_input[firstMismatch])
+              << " out=" << static_cast<int>(host_output[firstMismatch]);
         }
       }
       printf("%11s\n", "OK");
@@ -524,5 +525,7 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   folly::Init init(&argc, &argv);
   ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/collectives/benchmarks/HierarchicalAllGatherBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/HierarchicalAllGatherBenchmark.cc
@@ -1,8 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <nccl.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -245,7 +245,7 @@ class HierarchicalAllGatherBenchmarkFixture
     if (globalRank == 0) {
       ncclResult_t res = ncclGetUniqueId(&id);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
         std::abort();
       }
     }
@@ -257,7 +257,7 @@ class HierarchicalAllGatherBenchmarkFixture
                 all_ids.data(), sizeof(ncclUniqueId), globalRank, worldSize)
             .get();
     if (result != 0) {
-      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      COMMS_LOG_STREAM(ERR) << "Bootstrap allGather for NCCL ID failed";
       std::abort();
     }
     return all_ids[0];
@@ -341,7 +341,7 @@ class HierarchicalAllGatherBenchmarkFixture
       ib_transport->exchange();
       ib_nics = ib_transport->numNics();
     } catch (const std::exception& e) {
-      XLOGF(ERR, "IBGDA transport not available: {}", e.what());
+      COMMS_LOG(ERR, "IBGDA transport not available: {}", e.what());
       latency_us = 0.0f;
       return 0.0f;
     }
@@ -367,7 +367,7 @@ class HierarchicalAllGatherBenchmarkFixture
             nvl_rank, config.nvl_size, nvl_bootstrap, transport_config);
         nvl_transport->exchange();
       } catch (const std::exception& e) {
-        XLOGF(ERR, "NVLink transport not available: {}", e.what());
+        COMMS_LOG(ERR, "NVLink transport not available: {}", e.what());
         latency_us = 0.0f;
         return 0.0f;
       }
@@ -390,7 +390,8 @@ class HierarchicalAllGatherBenchmarkFixture
     if (config.ib_size > 1) {
       auto ib_rings_opt = make_standard_rings(config.ib_size, ib_rank, 1);
       if (!ib_rings_opt) {
-        XLOGF(ERR, "Cannot construct IB ring for {} IB ranks", config.ib_size);
+        COMMS_LOG(
+            ERR, "Cannot construct IB ring for {} IB ranks", config.ib_size);
         latency_us = 0.0f;
         return 0.0f;
       }
@@ -509,7 +510,7 @@ class HierarchicalAllGatherBenchmarkFixture
     }
     ss << "================================================================================\n";
 
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 
   ncclComm_t nccl_comm_{};
@@ -520,7 +521,7 @@ TEST_F(HierarchicalAllGatherBenchmarkFixture, VsNccl) {
   const int nvl_size = benchmark_nvl_size(worldSize);
   if (nvl_size <= 0 || nvl_size > kDirectNvlMaxRanks ||
       worldSize % nvl_size != 0) {
-    XLOGF(
+    COMMS_LOG(
         ERR,
         "Invalid HIER_AG_BENCH_NVL_SIZE={} for worldSize={}",
         nvl_size,
@@ -529,7 +530,7 @@ TEST_F(HierarchicalAllGatherBenchmarkFixture, VsNccl) {
   }
 
   if (globalRank == 0) {
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "\n=== Hierarchical AllGather vs NCCL Comparison (IB groups={}, NVL groups={}) ===\n",
         worldSize / nvl_size,
@@ -543,15 +544,15 @@ TEST_F(HierarchicalAllGatherBenchmarkFixture, VsNccl) {
   const int pipeline_depth = benchmark_pipeline_depth();
   const std::string ib_hca = benchmark_ib_hca();
   if (ib_links <= 0) {
-    XLOGF(ERR, "Invalid HIER_AG_BENCH_IB_LINKS={}", ib_links);
+    COMMS_LOG(ERR, "Invalid HIER_AG_BENCH_IB_LINKS={}", ib_links);
     std::abort();
   }
   if (data_buffer_size == 0) {
-    XLOG(ERR, "Invalid HIER_AG_BENCH_DATA_BUFFER_SIZE=0");
+    COMMS_LOG(ERR, "Invalid HIER_AG_BENCH_DATA_BUFFER_SIZE=0");
     std::abort();
   }
   if (pipeline_depth <= 0) {
-    XLOGF(ERR, "Invalid HIER_AG_BENCH_PIPELINE_DEPTH={}", pipeline_depth);
+    COMMS_LOG(ERR, "Invalid HIER_AG_BENCH_PIPELINE_DEPTH={}", pipeline_depth);
     std::abort();
   }
   const std::size_t ib_signal_bytes =
@@ -562,7 +563,7 @@ TEST_F(HierarchicalAllGatherBenchmarkFixture, VsNccl) {
   const bool skip_nccl = benchmark_skip_nccl();
   for (std::size_t total_bytes : configured_benchmark_sizes()) {
     if (total_bytes % static_cast<std::size_t>(worldSize) != 0) {
-      XLOGF(
+      COMMS_LOG(
           ERR,
           "AllGather size {} is not divisible by {} ranks",
           total_bytes,
@@ -591,7 +592,7 @@ TEST_F(HierarchicalAllGatherBenchmarkFixture, VsNccl) {
 
   for (const auto& config : configs) {
     if (globalRank == 0) {
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "Running hierarchical AllGather {}: size={}, chunk={}, blocks={}, ib_size={}, nvl_size={}, ib_links_per_nic={}, ib_signal_bytes={}, nvl_signal_bytes={}",
           config.name,
@@ -617,7 +618,7 @@ TEST_F(HierarchicalAllGatherBenchmarkFixture, VsNccl) {
         run_hierarchical_benchmark(config, ib_nics, hierarchical_lat);
 
     if (globalRank == 0) {
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "AllGather {} result: NCCL={:.2f} GB/s ({:.1f} us), Hier={:.2f} GB/s ({:.1f} us), Hier/NCCL={:.2f}x",
           config.name,
@@ -661,5 +662,7 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   folly::Init init(&argc, &argv);
   ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/collectives/benchmarks/RingAllGatherBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/RingAllGatherBenchmark.cc
@@ -2,9 +2,9 @@
 
 #include <folly/ScopeGuard.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <glog/logging.h>
 #include <nccl.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <cstdlib>
 #include <iomanip>
@@ -69,7 +69,7 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     if (globalRank == 0) {
       ncclResult_t res = ncclGetUniqueId(&id);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
         std::abort();
       }
     }
@@ -81,7 +81,7 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
                 all_ids.data(), sizeof(ncclUniqueId), globalRank, worldSize)
             .get();
     if (result != 0) {
-      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      COMMS_LOG_STREAM(ERR) << "Bootstrap allGather for NCCL ID failed";
       std::abort();
     }
     return all_ids[0];
@@ -103,7 +103,7 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     auto ncclCommGuard = folly::makeGuard([&] {
       const ncclResult_t res = ncclCommDestroy(nccl_comm);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclCommDestroy failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclCommDestroy failed: {}", ncclGetErrorString(res));
       }
     });
 
@@ -190,7 +190,7 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     auto rings_opt =
         make_standard_rings(worldSize, globalRank, config.num_rings);
     if (!rings_opt) {
-      XLOGF(
+      COMMS_LOG(
           ERR,
           "Cannot construct {} distinct rings for {} ranks",
           config.num_rings,
@@ -318,7 +318,7 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     ss << worldSize << " ranks, sendcount = per-rank message size\n";
     ss << "================================================================================\n";
 
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 
   std::vector<RingAllGatherBenchmarkConfig> make_benchmark_configs(
@@ -441,7 +441,8 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
   void run_ibgda_vs_nccl_benchmark_suite() {
     if (globalRank == 0) {
-      XLOG(INFO) << "\n=== Ring AllGather (IBGDA) vs NCCL Comparison ===\n";
+      COMMS_LOG_STREAM(INFO)
+          << "\n=== Ring AllGather (IBGDA) vs NCCL Comparison ===\n";
     }
 
     std::vector<RingAllGatherBenchmarkResult> results;
@@ -462,7 +463,8 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
   void run_ibrc_vs_ibgda_benchmark_suite() {
     if (globalRank == 0) {
-      XLOG(INFO) << "\n=== Ring AllGather (IBRC) vs IBGDA Comparison ===\n";
+      COMMS_LOG_STREAM(INFO)
+          << "\n=== Ring AllGather (IBRC) vs IBGDA Comparison ===\n";
     }
 
     std::vector<RingAllGatherBenchmarkResult> results;
@@ -508,5 +510,7 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   folly::Init init(&argc, &argv);
   ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/collectives/tests/AllToAllvLl128Test.cc
+++ b/comms/prims/collectives/tests/AllToAllvLl128Test.cc
@@ -6,7 +6,7 @@
 #include <cstddef>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <algorithm>
 
@@ -64,8 +64,8 @@ TEST_P(AllToAllvLl128EqualSizeTest, AllToAllvLl128EqualSize) {
   const int numBlocks = params.numBlocks;
   const int blockSize = params.blockSize;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: Running {} with numBlocks={}, blockSize={}, numIntsPerRank={}",
       globalRank,
       params.testName,
@@ -93,7 +93,7 @@ TEST_P(AllToAllvLl128EqualSizeTest, AllToAllvLl128EqualSize) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -178,7 +178,7 @@ TEST_P(AllToAllvLl128EqualSizeTest, AllToAllvLl128EqualSize) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: Error at peer {} position {}: expected {}, got {}",
               globalRank,
@@ -469,8 +469,8 @@ TEST_P(AllToAllvLl128UnequalSizeTest, AllToAllvLl128UnequalSize) {
   const int blockSize = params.blockSize;
   const size_t base_ints = params.base_ints;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: Running {} with numBlocks={}, blockSize={}, base_ints={}",
       globalRank,
       params.testName,
@@ -496,7 +496,7 @@ TEST_P(AllToAllvLl128UnequalSizeTest, AllToAllvLl128UnequalSize) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -603,7 +603,7 @@ TEST_P(AllToAllvLl128UnequalSizeTest, AllToAllvLl128UnequalSize) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: Error at peer {} position {}: expected {}, got {}",
               globalRank,
@@ -676,8 +676,8 @@ TEST_P(AllToAllvLl128ZeroPeerTest, AllToAllvLl128ZeroPeer) {
   const int blockSize = params.blockSize;
   const size_t base_ints = params.base_ints;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: Running {} with zero-byte peers",
       globalRank,
       params.testName);
@@ -702,7 +702,7 @@ TEST_P(AllToAllvLl128ZeroPeerTest, AllToAllvLl128ZeroPeer) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -815,7 +815,7 @@ TEST_P(AllToAllvLl128ZeroPeerTest, AllToAllvLl128ZeroPeer) {
         if (expected != actual) {
           h_errorCount++;
           if (h_errorCount <= 10) {
-            XLOGF(
+            COMMS_LOG(
                 ERR,
                 "Rank {}: Error at peer {} position {}: expected {}, got {}",
                 globalRank,
@@ -878,7 +878,7 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedMultiCall) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -958,7 +958,7 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedMultiCall) {
         if (expected != actual) {
           h_errorCount++;
           if (h_errorCount <= 5) {
-            XLOGF(
+            COMMS_LOG(
                 ERR,
                 "Rank {}: Iter {} error at peer {} pos {}: expected {}, got {}",
                 globalRank,
@@ -1014,7 +1014,7 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedMultiCallChunked) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -1095,7 +1095,7 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedMultiCallChunked) {
         if (expected != actual) {
           h_errorCount++;
           if (h_errorCount <= 5) {
-            XLOGF(
+            COMMS_LOG(
                 ERR,
                 "Rank {}: Iter {} error at peer {} pos {}: expected {}, got {}",
                 globalRank,
@@ -1138,7 +1138,7 @@ TEST_F(AllToAllvLl128TestFixture, ChunkedBlockCountSweep) {
   const std::vector<int> blockCounts = {8, 16, 32, 64, 128, 256};
 
   for (int numBlocks : blockCounts) {
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: ChunkedBlockCountSweep numBlocks={}",
         globalRank,
@@ -1157,7 +1157,8 @@ TEST_F(AllToAllvLl128TestFixture, ChunkedBlockCountSweep) {
           globalRank, worldSize, bootstrap, config);
       transport->exchange();
     } catch (const std::runtime_error& e) {
-      XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+      COMMS_LOG(
+          ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
       std::abort();
     }
 
@@ -1233,7 +1234,7 @@ TEST_F(AllToAllvLl128TestFixture, ChunkedBlockCountSweep) {
         if (expected != actual) {
           h_errorCount++;
           if (h_errorCount <= 5) {
-            XLOGF(
+            COMMS_LOG(
                 ERR,
                 "Rank {}: numBlocks={} error at peer {} pos {}: expected {}, got {}",
                 globalRank,
@@ -1316,7 +1317,7 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedVaryingSizes) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -1400,7 +1401,7 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedVaryingSizes) {
         if (expected != actual) {
           h_errorCount++;
           if (h_errorCount <= 5) {
-            XLOGF(
+            COMMS_LOG(
                 ERR,
                 "Rank {}: Iter {} ({}KB) error at peer {} pos {}: expected {}, got {}",
                 globalRank,
@@ -1456,7 +1457,7 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedVaryingSizes_Chunked) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -1537,7 +1538,7 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedVaryingSizes_Chunked) {
         if (expected != actual) {
           h_errorCount++;
           if (h_errorCount <= 5) {
-            XLOGF(
+            COMMS_LOG(
                 ERR,
                 "Rank {}: Iter {} ({}KB chunked) error at peer {} pos {}: expected {}, got {}",
                 globalRank,
@@ -1586,7 +1587,7 @@ TEST_F(AllToAllvLl128TestFixture, AutoDispatch_1KB_UsesLl128) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -1660,7 +1661,7 @@ TEST_F(AllToAllvLl128TestFixture, AutoDispatch_1KB_UsesLl128) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: AutoDispatch 1KB error at peer {} pos {}: expected {}, got {}",
               globalRank,
@@ -1699,7 +1700,7 @@ TEST_F(AllToAllvLl128TestFixture, AutoDispatch_256KB_UsesLl128) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -1773,7 +1774,7 @@ TEST_F(AllToAllvLl128TestFixture, AutoDispatch_256KB_UsesLl128) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: AutoDispatch 256KB error at peer {} pos {}: expected {}, got {}",
               globalRank,
@@ -1812,7 +1813,7 @@ TEST_F(AllToAllvLl128TestFixture, AutoDispatch_512KB_UsesSimple) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -1886,7 +1887,7 @@ TEST_F(AllToAllvLl128TestFixture, AutoDispatch_512KB_UsesSimple) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: AutoDispatch 512KB error at peer {} pos {}: expected {}, got {}",
               globalRank,

--- a/comms/prims/collectives/tests/AllToAllvLl128_2GpuTest.cc
+++ b/comms/prims/collectives/tests/AllToAllvLl128_2GpuTest.cc
@@ -5,7 +5,7 @@
 #include <cstddef>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/prims/collectives/AllToAllvLl128.cuh"
 #include "comms/prims/collectives/tests/AllToAllvLl128Test.cuh"
@@ -46,8 +46,8 @@ TEST_F(AllToAllvLl128_2GpuTestFixture, EqualSize_2GPU_4KB) {
   const int numBlocks = 18;
   const int blockSize = 512;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: Running EqualSize_2GPU_4KB with worldSize={}",
       globalRank,
       worldSize);
@@ -69,7 +69,7 @@ TEST_F(AllToAllvLl128_2GpuTestFixture, EqualSize_2GPU_4KB) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -150,7 +150,7 @@ TEST_F(AllToAllvLl128_2GpuTestFixture, EqualSize_2GPU_4KB) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: Error at peer {} position {}: expected {}, got {}",
               globalRank,
@@ -173,8 +173,8 @@ TEST_F(AllToAllvLl128_2GpuTestFixture, EqualSize_2GPU_64KB) {
   const int numBlocks = 18;
   const int blockSize = 512;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: Running EqualSize_2GPU_64KB with worldSize={}",
       globalRank,
       worldSize);
@@ -196,7 +196,7 @@ TEST_F(AllToAllvLl128_2GpuTestFixture, EqualSize_2GPU_64KB) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -277,7 +277,7 @@ TEST_F(AllToAllvLl128_2GpuTestFixture, EqualSize_2GPU_64KB) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: Error at peer {} position {}: expected {}, got {}",
               globalRank,

--- a/comms/prims/collectives/tests/DirectIbReduceScatterTest.cc
+++ b/comms/prims/collectives/tests/DirectIbReduceScatterTest.cc
@@ -1,7 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 
 #include <memory>
 #include <string>

--- a/comms/prims/collectives/tests/RingAllGatherTest.cc
+++ b/comms/prims/collectives/tests/RingAllGatherTest.cc
@@ -1,7 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/prims/collectives/RingAllgatherLauncher.h"
 #include "comms/prims/collectives/RingUtils.h"

--- a/comms/prims/tests/AllGatherTest.cc
+++ b/comms/prims/tests/AllGatherTest.cc
@@ -3,7 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/prims/collectives/AllGather.cuh"
 #include "comms/prims/tests/AllGatherTest.cuh"
@@ -35,8 +35,8 @@ void printDeviceBuffer(
       totalInts * sizeof(int32_t),
       cudaMemcpyDeviceToHost));
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: {} (showing {} values for each peer):",
       rank,
       label,
@@ -52,7 +52,7 @@ void printDeviceBuffer(
     if (!showAll && numIntsPerRank > 8) {
       line += "...";
     }
-    XLOG(DBG1) << line;
+    COMMS_LOG_STREAM(DBG) << line;
   }
 }
 } // namespace
@@ -85,8 +85,8 @@ TEST_P(AllGatherTest, AllGatherBasic) {
   const int numBlocks = params.numBlocks;
   const int blockSize = params.blockSize;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: Running {} with numBlocks={}, blockSize={}, numIntsPerRank={}",
       globalRank,
       params.testName,
@@ -115,7 +115,7 @@ TEST_P(AllGatherTest, AllGatherBasic) {
   // Create transport and exchange IPC handles
   MultiPeerNvlTransport transport(globalRank, worldSize, bootstrap, config);
   transport.exchange();
-  XLOGF(DBG1, "Rank {} created transport and exchanged IPC", globalRank);
+  COMMS_LOG(DBG, "Rank {} created transport and exchanged IPC", globalRank);
 
   auto transports_span = transport.getDeviceTransports();
 
@@ -144,7 +144,7 @@ TEST_P(AllGatherTest, AllGatherBasic) {
   bootstrap->barrierAll();
 
   // Debug: Print send buffer before all_gather
-  XLOGF(DBG1, "Rank {}: Send buffer (my data): ", globalRank);
+  COMMS_LOG(DBG, "Rank {}: Send buffer (my data): ", globalRank);
   std::vector<int32_t> h_send_debug(numIntsPerRank);
   CUDACHECK_TEST(cudaMemcpy(
       h_send_debug.data(),
@@ -158,7 +158,7 @@ TEST_P(AllGatherTest, AllGatherBasic) {
   if (numIntsPerRank > 8) {
     sendLine += "...";
   }
-  XLOG(DBG1) << sendLine;
+  COMMS_LOG_STREAM(DBG) << sendLine;
 
   // Debug: Print recv buffer before all_gather
   printDeviceBuffer(
@@ -168,7 +168,7 @@ TEST_P(AllGatherTest, AllGatherBasic) {
       worldSize,
       numIntsPerRank);
 
-  XLOGF(DBG1, "Rank {}: calling all_gather", globalRank);
+  COMMS_LOG(DBG, "Rank {}: calling all_gather", globalRank);
 
   // Call all_gather with actual data transfer
   test::testAllGather(
@@ -212,7 +212,7 @@ TEST_P(AllGatherTest, AllGatherBasic) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) { // Only print first 10 errors
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: Error at source_rank {} position {}: expected {}, got {}",
               globalRank,
@@ -225,8 +225,8 @@ TEST_P(AllGatherTest, AllGatherBasic) {
     }
   }
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: verification completed, errors = {}",
       globalRank,
       h_errorCount);
@@ -287,8 +287,8 @@ TEST_P(AllGatherLargeTest, AllGatherLarge) {
   const int numBlocks = params.numBlocks;
   const int blockSize = params.blockSize;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: Running {} with numBlocks={}, blockSize={}, numIntsPerRank={}",
       globalRank,
       params.testName,
@@ -355,7 +355,7 @@ TEST_P(AllGatherLargeTest, AllGatherLarge) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: Error at source_rank {} position {}: expected {}, got {}",
               globalRank,

--- a/comms/prims/tests/AllToAllvTest.cc
+++ b/comms/prims/tests/AllToAllvTest.cc
@@ -3,7 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #ifdef __HIP_PLATFORM_AMD__
 #include "comms/prims/transport/amd/HipHostCompat.h"
@@ -42,8 +42,8 @@ void printDeviceBuffer(
       totalInts * sizeof(int32_t),
       cudaMemcpyDeviceToHost));
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: {} (showing {} values for each peer):",
       rank,
       label,
@@ -59,7 +59,7 @@ void printDeviceBuffer(
     if (!showAll && numIntsPerRank > 8) {
       line += "...";
     }
-    XLOG(DBG1) << line;
+    COMMS_LOG_STREAM(DBG) << line;
   }
 }
 } // namespace
@@ -92,8 +92,8 @@ TEST_P(AllToAllvEqualSizeTest, AllToAllvEqualSize) {
   const int numBlocks = params.numBlocks;
   const int blockSize = params.blockSize;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: Running {} with numBlocks={}, blockSize={}, numIntsPerRank={}",
       globalRank,
       params.testName,
@@ -114,7 +114,7 @@ TEST_P(AllToAllvEqualSizeTest, AllToAllvEqualSize) {
   // Create transport and exchange IPC handles
   MultiPeerNvlTransport transport(globalRank, worldSize, bootstrap, config);
   transport.exchange();
-  XLOGF(DBG1, "Rank {} created transport and exchanged IPC", globalRank);
+  COMMS_LOG(DBG, "Rank {} created transport and exchanged IPC", globalRank);
 
   auto transports_span = transport.getDeviceTransports();
 
@@ -192,7 +192,7 @@ TEST_P(AllToAllvEqualSizeTest, AllToAllvEqualSize) {
       worldSize,
       numIntsPerRank);
 
-  XLOGF(DBG1, "Rank {}: calling all_to_allv", globalRank);
+  COMMS_LOG(DBG, "Rank {}: calling all_to_allv", globalRank);
 
   // Call all_to_allv with actual data transfer
   test::testAllToAllv(
@@ -237,7 +237,7 @@ TEST_P(AllToAllvEqualSizeTest, AllToAllvEqualSize) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) { // Only print first 10 errors
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: Error at peer {} position {}: expected {}, got {}",
               globalRank,
@@ -250,8 +250,8 @@ TEST_P(AllToAllvEqualSizeTest, AllToAllvEqualSize) {
     }
   }
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: verification completed, errors = {}",
       globalRank,
       h_errorCount);
@@ -312,8 +312,8 @@ TEST_P(AllToAllvUnequalSizeTest, AllToAllvUnequalSize) {
   const int blockSize = params.blockSize;
   const size_t base_ints = params.base_ints;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: Running {} with numBlocks={}, blockSize={}, base_ints={}",
       globalRank,
       params.testName,
@@ -330,7 +330,7 @@ TEST_P(AllToAllvUnequalSizeTest, AllToAllvUnequalSize) {
   // Create transport and exchange IPC handles
   MultiPeerNvlTransport transport(globalRank, worldSize, bootstrap, config);
   transport.exchange();
-  XLOGF(DBG1, "Rank {} created transport and exchanged IPC", globalRank);
+  COMMS_LOG(DBG, "Rank {} created transport and exchanged IPC", globalRank);
 
   auto transports_span = transport.getDeviceTransports();
 
@@ -358,8 +358,8 @@ TEST_P(AllToAllvUnequalSizeTest, AllToAllvUnequalSize) {
   const size_t sendBufferSize = send_offset;
   const size_t recvBufferSize = recv_offset;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: sendBufferSize = {}, recvBufferSize = {}",
       globalRank,
       sendBufferSize,
@@ -415,7 +415,8 @@ TEST_P(AllToAllvUnequalSizeTest, AllToAllvUnequalSize) {
   // Barrier to ensure all ranks are ready
   bootstrap->barrierAll();
 
-  XLOGF(DBG1, "Rank {}: calling all_to_allv with variable sizes", globalRank);
+  COMMS_LOG(
+      DBG, "Rank {}: calling all_to_allv with variable sizes", globalRank);
 
   // Call all_to_allv with variable sizes
   test::testAllToAllv(
@@ -452,7 +453,7 @@ TEST_P(AllToAllvUnequalSizeTest, AllToAllvUnequalSize) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) { // Only print first 10 errors
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: Error at peer {} position {}: expected {}, got {}",
               globalRank,
@@ -466,8 +467,8 @@ TEST_P(AllToAllvUnequalSizeTest, AllToAllvUnequalSize) {
     int_offset += num_ints;
   }
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: verification completed, errors = {}",
       globalRank,
       h_errorCount);

--- a/comms/prims/tests/BarrierTest.cc
+++ b/comms/prims/tests/BarrierTest.cc
@@ -3,7 +3,6 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 
 #include <vector>
 

--- a/comms/prims/tests/ExternalStagingBuffersTest.cc
+++ b/comms/prims/tests/ExternalStagingBuffersTest.cc
@@ -4,7 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <memory>
 #include <vector>
@@ -192,7 +192,7 @@ TEST_F(ExternalStagingBuffersTestFixture, IpcMemAccessThroughExternalBuffers) {
   auto remoteAddr =
       static_cast<int*>(static_cast<void*>(p2p.getRemoteState().dataBuffer));
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: localAddr={}, remoteAddr={}",
       globalRank,

--- a/comms/prims/tests/GpuMemHandlerTest.cc
+++ b/comms/prims/tests/GpuMemHandlerTest.cc
@@ -4,7 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <cstddef>
 #include <cstring>
@@ -51,7 +51,8 @@ class GpuMemHandlerTestFixture : public MpiBaseTestFixture {
 TEST_F(GpuMemHandlerTestFixture, RemoteWriteLocalRead) {
   // Only test with 2 ranks
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -63,19 +64,19 @@ TEST_F(GpuMemHandlerTestFixture, RemoteWriteLocalRead) {
   auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
   GpuMemHandler handler(bootstrap, globalRank, numRanks, bufferSize);
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {} created handler in {} mode",
       globalRank,
       handler.getMode() == MemSharingMode::kFabric ? "fabric" : "cudaIpc");
 
   handler.exchangeMemPtrs();
-  XLOGF(INFO, "Rank {} exchanged memory handles", globalRank);
+  COMMS_LOG(INFO, "Rank {} exchanged memory handles", globalRank);
 
   auto localAddr = static_cast<int*>(handler.getLocalDeviceMemPtr());
   auto remoteAddr = static_cast<int*>(handler.getPeerDeviceMemPtr(peerRank));
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: localAddr: {}, remoteAddr: {}",
       globalRank,
@@ -87,11 +88,12 @@ TEST_F(GpuMemHandlerTestFixture, RemoteWriteLocalRead) {
   int writeValue = globalRank;
   test::fillBuffer(localAddr, writeValue, numElements);
   CUDACHECK_TEST(cudaDeviceSynchronize());
-  XLOGF(INFO, "Rank {} filled local buffer with {}", globalRank, writeValue);
+  COMMS_LOG(
+      INFO, "Rank {} filled local buffer with {}", globalRank, writeValue);
 
   // Barrier to ensure both ranks have written their data
   MPI_Barrier(MPI_COMM_WORLD);
-  XLOGF(INFO, "Rank {} passed barrier", globalRank);
+  COMMS_LOG(INFO, "Rank {} passed barrier", globalRank);
 
   // Each rank reads from peer's buffer and verifies
   // rank0 should read all 1s from rank1
@@ -111,7 +113,7 @@ TEST_F(GpuMemHandlerTestFixture, RemoteWriteLocalRead) {
   CUDACHECK_TEST(cudaMemcpy(
       &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {} verified peer buffer, errors: {}",
       globalRank,
@@ -129,7 +131,8 @@ TEST_F(GpuMemHandlerTestFixture, RemoteWriteLocalRead) {
 TEST_F(GpuMemHandlerTestFixture, SelfRankReturnsLocalPtr) {
   // Only test with 2 ranks
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -153,7 +156,8 @@ TEST_F(GpuMemHandlerTestFixture, SelfRankReturnsLocalPtr) {
 TEST_F(GpuMemHandlerTestFixture, ExplicitCudaIpcMode) {
   // Only test with 2 ranks
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -168,7 +172,8 @@ TEST_F(GpuMemHandlerTestFixture, ExplicitCudaIpcMode) {
       bootstrap, globalRank, numRanks, bufferSize, MemSharingMode::kCudaIpc);
 
   EXPECT_EQ(handler.getMode(), MemSharingMode::kCudaIpc);
-  XLOGF(INFO, "Rank {} created handler with explicit cudaIpc mode", globalRank);
+  COMMS_LOG(
+      INFO, "Rank {} created handler with explicit cudaIpc mode", globalRank);
 
   handler.exchangeMemPtrs();
 
@@ -216,14 +221,14 @@ TEST_F(GpuMemHandlerTestFixture, SingleRankExchange) {
   GpuMemHandler handler(
       bootstrap, 0 /* selfRank */, 1 /* nRanks */, bufferSize);
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "MPI Rank {} testing single-rank exchange in {} mode",
       globalRank,
       handler.getMode() == MemSharingMode::kFabric ? "fabric" : "cudaIpc");
 
   handler.exchangeMemPtrs();
-  XLOGF(INFO, "MPI Rank {} completed single-rank exchange", globalRank);
+  COMMS_LOG(INFO, "MPI Rank {} completed single-rank exchange", globalRank);
 
   // Get local pointer
   auto localAddr = static_cast<int*>(handler.getLocalDeviceMemPtr());
@@ -254,7 +259,7 @@ TEST_F(GpuMemHandlerTestFixture, SingleRankExchange) {
 
   ASSERT_EQ(h_errorCount, 0) << "Single-rank exchange verification failed";
 
-  XLOGF(INFO, "MPI Rank {} single-rank exchange test passed", globalRank);
+  COMMS_LOG(INFO, "MPI Rank {} single-rank exchange test passed", globalRank);
 }
 
 TEST_F(GpuMemHandlerTestFixture, VmmImportFailurePropagatesToEveryRank) {

--- a/comms/prims/tests/HostWindowTest.cc
+++ b/comms/prims/tests/HostWindowTest.cc
@@ -3,7 +3,6 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/prims/transport/MultiPeerTransport.h"
 #include "comms/prims/window/HostWindow.h"

--- a/comms/prims/tests/MultiPeerNvlTransportIntegrationTest.cc
+++ b/comms/prims/tests/MultiPeerNvlTransportIntegrationTest.cc
@@ -4,7 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <optional>
 #include <string>
@@ -153,7 +153,7 @@ class MultiPeerNvlTransportIntegrationTestFixture : public MpiBaseTestFixture {
 
     EXPECT_EQ(result_h, 1) << label << " Signal/Wait operation failed";
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: {} Signal/Wait test completed (isSignaler={})",
         globalRank,
@@ -263,7 +263,7 @@ class MultiPeerNvlTransportIntegrationTestFixture : public MpiBaseTestFixture {
           << label << " data mismatch after put_signal";
     }
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: {} Put/Signal operation test completed (isWriter={})",
         globalRank,
@@ -309,7 +309,7 @@ TEST_F(
   EXPECT_EQ(results_h[2], numRanks - 1)
       << "numPeers() should return " << (numRanks - 1);
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: MultiPeerDeviceTransport construction test completed (rank={}, nRanks={}, numPeers={})",
       globalRank,
@@ -377,7 +377,7 @@ TEST_F(
   EXPECT_EQ(results1_h, results3_h)
       << "Repeated DeviceWindow constructions returned different values";
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Repeated DeviceWindow construction test completed",
       globalRank);
@@ -451,7 +451,8 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BidirectionalSignalWait) {
   EXPECT_EQ(result1_h, 1) << "Phase 1 Signal/Wait failed";
   EXPECT_EQ(result2_h, 1) << "Phase 2 Signal/Wait failed";
 
-  XLOGF(INFO, "Rank {}: Bidirectional Signal/Wait test completed", globalRank);
+  COMMS_LOG(
+      INFO, "Rank {}: Bidirectional Signal/Wait test completed", globalRank);
 }
 
 // =============================================================================
@@ -488,7 +489,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, Barrier) {
 
   EXPECT_EQ(result_h, 1) << "Barrier operation failed";
 
-  XLOGF(INFO, "Rank {}: Barrier test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: Barrier test completed", globalRank);
 }
 
 // =============================================================================
@@ -533,7 +534,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierPeer) {
   EXPECT_EQ(result_h, 1) << "barrier_peer() operation failed on rank "
                          << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: BarrierPeer test completed (peerRank={})",
       globalRank,
@@ -586,7 +587,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MultipleBarriers) {
                            << slotIdx << ") failed on rank " << globalRank;
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Multiple Barriers test completed ({} iterations, {} slots)",
       globalRank,
@@ -641,7 +642,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MultipleSignalSlots) {
                            << globalRank;
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Multiple signal slots test completed ({} slots)",
       globalRank,
@@ -698,7 +699,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, ConcurrentSignalSlots) {
                            << " failed on rank " << globalRank;
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Concurrent signal slots test completed ({} slots)",
       globalRank,
@@ -744,7 +745,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MultipleBarrierSlots) {
                            << globalRank;
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Multiple barrier slots test completed ({} slots)",
       globalRank,
@@ -789,7 +790,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierSlotStress) {
                            << slotIdx << ") failed on rank " << globalRank;
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Barrier slot stress test completed ({} iterations, {} slots)",
       globalRank,
@@ -835,7 +836,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierMonotonicCounters) {
   EXPECT_EQ(result_h, 1) << "Barrier monotonic counters test failed on rank "
                          << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Barrier monotonic counters test completed ({} phases)",
       globalRank,
@@ -886,7 +887,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierMultiBlockStress) {
   EXPECT_EQ(results_h, expected)
       << "Not all blocks completed barrier successfully on rank " << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Barrier multi-block stress test completed ({} blocks, {} slots)",
       globalRank,
@@ -999,7 +1000,7 @@ TEST_F(
     EXPECT_EQ(result_h, 1) << "Phase 4 barrier failed";
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Combined signal/barrier config test completed ({} signal slots, {} barrier slots)",
       globalRank,
@@ -1056,7 +1057,7 @@ TEST_F(
 
   EXPECT_EQ(results_h, std::vector<int>(kNumBlocks, 1));
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Concurrent signal multi-block test completed ({} blocks)",
       globalRank,
@@ -1115,7 +1116,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalResetBetweenPhases) {
     // testSignalWait For explicit reset testing, we would call resetSignalFrom
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Signal reset between phases test completed ({} phases)",
       globalRank,
@@ -1179,7 +1180,7 @@ TEST_F(
         << "Iteration " << iter << " failed on rank " << globalRank;
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Concurrent signal stress extended test completed ({} iterations, {} blocks)",
       globalRank,
@@ -1241,7 +1242,7 @@ TEST_F(
   EXPECT_EQ(results_h, expected)
       << "Not all warps completed successfully on rank " << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Concurrent signal multi-warp test completed ({} warps)",
       globalRank,
@@ -1287,7 +1288,8 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, TransportAccessorTypes) {
         << "Transport type mismatch for peer " << peer;
   }
 
-  XLOGF(INFO, "Rank {}: Transport accessor types test completed", globalRank);
+  COMMS_LOG(
+      INFO, "Rank {}: Transport accessor types test completed", globalRank);
 }
 
 // =============================================================================
@@ -1362,7 +1364,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalAll) {
   EXPECT_EQ(result_h, 1) << "signal_all() operation failed on rank "
                          << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: signal_all() test completed (signalerRank={})",
       globalRank,
@@ -1413,7 +1415,7 @@ TEST_F(
       << "read_signal() aggregate on rank " << globalRank
       << " should equal numRanks-1 (" << (numRanks - 1) << ")";
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: signal_all() aggregate test completed (aggregate={}, expected={})",
       globalRank,
@@ -1463,7 +1465,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, WaitSignalFromAll) {
   EXPECT_EQ(result_h, 1) << "wait_signal_from_all() operation failed on rank "
                          << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: wait_signal_from_all() test completed (targetRank={})",
       globalRank,
@@ -1515,7 +1517,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, WaitWithCmpEq) {
   EXPECT_EQ(result_h, 1) << "CMP_EQ wait operation failed on rank "
                          << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: WaitWithCmpEq test completed (expectedValue={})",
       globalRank,
@@ -1568,7 +1570,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MonotonicWaitValues) {
   EXPECT_EQ(result_h, 1) << "Monotonic wait values test failed on rank "
                          << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: MonotonicWaitValues test completed ({} iterations)",
       globalRank,
@@ -1620,7 +1622,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalWithSet) {
   EXPECT_EQ(result_h, 1) << "SIGNAL_SET operation failed on rank "
                          << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: SignalWithSet test completed (setValue={})",
       globalRank,
@@ -1677,7 +1679,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, WaitSignalFromPeer) {
 
   EXPECT_EQ(result_h, 1) << "wait_signal_from() failed on rank " << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: WaitSignalFromPeer test completed (isSignaler={})",
       globalRank,
@@ -1729,7 +1731,7 @@ TEST_F(
   EXPECT_EQ(result_h, 1) << "WaitSignalFromMultiPeerIsolation failed on rank "
                          << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: WaitSignalFromMultiPeerIsolation test completed (targetRank={})",
       globalRank,
@@ -1781,7 +1783,7 @@ TEST_F(
   EXPECT_EQ(result_h, 1)
       << "WaitSignalAndWaitSignalFromBothWork failed on rank " << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: WaitSignalAndWaitSignalFromBothWork test completed (targetRank={})",
       globalRank,
@@ -1832,7 +1834,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalWaitBlockScope) {
 
   EXPECT_EQ(result_h, 1) << "Signal/Wait (BLOCK scope) operation failed";
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Signal/Wait (BLOCK scope) test completed (isSignaler={})",
       globalRank,

--- a/comms/prims/tests/MultiPeerTransportIntegrationTest.cc
+++ b/comms/prims/tests/MultiPeerTransportIntegrationTest.cc
@@ -4,7 +4,6 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/common/fault_tolerance/Abort.h"
 #include "comms/prims/tests/MultiPeerTransportKernelTest.cuh"

--- a/comms/prims/tests/MultiPeerTransportMultiNodeTest.cc
+++ b/comms/prims/tests/MultiPeerTransportMultiNodeTest.cc
@@ -10,7 +10,7 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/prims/topology/NvmlFabricInfo.h"
 #include "comms/prims/transport/MultiPeerDeviceHandle.cuh"
@@ -99,7 +99,7 @@ class MultiPeerTransportMultiNodeFixture : public MpiBaseTestFixture {
       }
     }
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {} platform detection: isMnnvl={}, localSize={}",
         globalRank,
@@ -169,7 +169,7 @@ TEST_F(MultiPeerTransportMultiNodeFixture, TopologyDiscoveryMultiNode) {
   // Invariant: NVL peers are a subset of IBGDA peers.
   EXPECT_LE(nvlCount, ibgdaCount);
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {} (localRank {}): isMnnvl={}, {} NVL peers, {} IBGDA peers",
       globalRank,
@@ -298,7 +298,7 @@ TEST_F(MultiPeerTransportMultiNodeFixture, HostAccessorsMultiNode) {
     EXPECT_NE(p2p, nullptr) << "IBGDA transport device null for peer " << r;
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: isMnnvl={}, validated {} NVL peers, {} IBGDA peers",
       globalRank,

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -3,9 +3,9 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <array>
 #include <chrono>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <memory>
 #include <string>
@@ -252,8 +252,8 @@ class MultipeerIbgdaTransportTestFixture : public MpiBaseTestFixture {
 
 TEST_P(MultipeerIbTransportTestFixture, ConstructAndExchange) {
   if (numRanks < 2) {
-    XLOGF(
-        WARNING, "Skipping test: requires at least 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires at least 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -265,7 +265,7 @@ TEST_P(MultipeerIbTransportTestFixture, ConstructAndExchange) {
     EXPECT_EQ(transport->numPeers(), numRanks - 1);
     EXPECT_NE(transport->getDeviceTransportPtr(), nullptr);
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: Transport created with GID index {}",
         globalRank,
@@ -276,7 +276,7 @@ TEST_P(MultipeerIbTransportTestFixture, ConstructAndExchange) {
   }
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
-  XLOGF(INFO, "Rank {}: ConstructAndExchange test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: ConstructAndExchange test completed", globalRank);
 }
 
 TEST_P(MultipeerIbTransportTestFixture, PipelineGeometry) {
@@ -339,7 +339,8 @@ TEST_P(MultipeerIbTransportTestFixture, PipelineGeometry) {
 
 TEST_P(MultipeerIbTransportTestFixture, PutSignalBasic) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -364,7 +365,7 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalBasic) {
     // Signal/counter buffers are transport-owned (numSignalSlots=1,
     // numCounterSlots=1)
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: localDataBuf ptr={} lkey={}, remoteDataBuf ptr={} rkey={}",
         globalRank,
@@ -442,7 +443,7 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalBasic) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(INFO, "Rank {}: PutSignalBasic test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: PutSignalBasic test completed", globalRank);
 }
 
 // =============================================================================
@@ -451,7 +452,8 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalBasic) {
 
 TEST_P(MultipeerIbTransportTestFixture, PutSignalGroupBasic) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -528,7 +530,7 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalGroupBasic) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(INFO, "Rank {}: PutSignalGroupBasic test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: PutSignalGroupBasic test completed", globalRank);
 }
 
 // =============================================================================
@@ -537,7 +539,8 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalGroupBasic) {
 
 TEST_P(MultipeerIbTransportTestFixture, PutSignalGroupMultiWarp) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -622,7 +625,8 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalGroupMultiWarp) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(INFO, "Rank {}: PutSignalGroupMultiWarp test completed", globalRank);
+  COMMS_LOG(
+      INFO, "Rank {}: PutSignalGroupMultiWarp test completed", globalRank);
 }
 
 // =============================================================================
@@ -631,7 +635,8 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalGroupMultiWarp) {
 
 TEST_P(MultipeerIbTransportTestFixture, PutSignalGroupBlock) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -715,7 +720,7 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalGroupBlock) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(INFO, "Rank {}: PutSignalGroupBlock test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: PutSignalGroupBlock test completed", globalRank);
 }
 
 // =============================================================================
@@ -740,7 +745,8 @@ class TransferSizeTestFixture
 
 TEST_P(TransferSizeTestFixture, PutSignal) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -751,7 +757,7 @@ TEST_P(TransferSizeTestFixture, PutSignal) {
   const int peerRank = (globalRank == 0) ? 1 : 0;
   const uint8_t testPattern = static_cast<uint8_t>(globalRank + 0x10);
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Running {} transfer size test {} with {} bytes",
       globalRank,
@@ -823,7 +829,7 @@ TEST_P(TransferSizeTestFixture, PutSignal) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Transfer size test {} completed",
       globalRank,
@@ -903,7 +909,8 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(MultipeerIbTransportTestFixture, Bidirectional) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1028,7 +1035,7 @@ TEST_P(MultipeerIbTransportTestFixture, Bidirectional) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(INFO, "Rank {}: Bidirectional test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: Bidirectional test completed", globalRank);
 }
 
 // =============================================================================
@@ -1037,7 +1044,8 @@ TEST_P(MultipeerIbTransportTestFixture, Bidirectional) {
 
 TEST_P(MultipeerIbTransportTestFixture, StressTest) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1114,7 +1122,7 @@ TEST_P(MultipeerIbTransportTestFixture, StressTest) {
 
         if (h_errorCount > 0) {
           totalErrors += h_errorCount;
-          XLOGF(ERR, "Iteration {}: Found {} errors", iter, h_errorCount);
+          COMMS_LOG(ERR, "Iteration {}: Found {} errors", iter, h_errorCount);
         }
       }
     }
@@ -1129,7 +1137,7 @@ TEST_P(MultipeerIbTransportTestFixture, StressTest) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Stress test completed ({} iterations)",
       globalRank,
@@ -1142,7 +1150,8 @@ TEST_P(MultipeerIbTransportTestFixture, StressTest) {
 
 TEST_P(MultipeerIbTransportTestFixture, SignalOnly) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1176,7 +1185,7 @@ TEST_P(MultipeerIbTransportTestFixture, SignalOnly) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(INFO, "Rank {}: SignalOnly test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: SignalOnly test completed", globalRank);
 }
 
 // =============================================================================
@@ -1185,7 +1194,8 @@ TEST_P(MultipeerIbTransportTestFixture, SignalOnly) {
 
 TEST_P(MultipeerIbTransportTestFixture, PutSignalCounter) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2737,7 +2747,8 @@ TEST_F(
 
 TEST_P(MultipeerIbTransportTestFixture, ResetSignal) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2786,7 +2797,7 @@ TEST_P(MultipeerIbTransportTestFixture, ResetSignal) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: ResetSignal test completed ({} iterations)",
       globalRank,
@@ -2799,7 +2810,8 @@ TEST_P(MultipeerIbTransportTestFixture, ResetSignal) {
 
 TEST_P(MultipeerIbTransportTestFixture, MultipleSignalSlots) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2848,7 +2860,7 @@ TEST_P(MultipeerIbTransportTestFixture, MultipleSignalSlots) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(INFO, "Rank {}: MultipleSignalSlots test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: MultipleSignalSlots test completed", globalRank);
 }
 
 // =============================================================================
@@ -2857,7 +2869,8 @@ TEST_P(MultipeerIbTransportTestFixture, MultipleSignalSlots) {
 
 TEST_P(MultipeerIbTransportTestFixture, PutSignalWaitForReady) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2946,7 +2959,7 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalWaitForReady) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(INFO, "Rank {}: PutSignalWaitForReady test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: PutSignalWaitForReady test completed", globalRank);
 }
 
 // =============================================================================
@@ -2955,7 +2968,8 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalWaitForReady) {
 
 TEST_P(MultipeerIbTransportTestFixture, BidirectionalConcurrent) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -3028,7 +3042,8 @@ TEST_P(MultipeerIbTransportTestFixture, BidirectionalConcurrent) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(INFO, "Rank {}: BidirectionalConcurrent test completed", globalRank);
+  COMMS_LOG(
+      INFO, "Rank {}: BidirectionalConcurrent test completed", globalRank);
 }
 
 // =============================================================================
@@ -3037,8 +3052,8 @@ TEST_P(MultipeerIbTransportTestFixture, BidirectionalConcurrent) {
 
 TEST_P(MultipeerIbTransportTestFixture, AllToAll) {
   if (numRanks < 2) {
-    XLOGF(
-        WARNING, "Skipping test: requires at least 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires at least 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -3143,7 +3158,7 @@ TEST_P(MultipeerIbTransportTestFixture, AllToAll) {
 
       if (h_errorCount > 0) {
         totalErrors += h_errorCount;
-        XLOGF(
+        COMMS_LOG(
             ERR,
             "Rank {}: {} byte mismatches receiving from rank {}",
             globalRank,
@@ -3161,7 +3176,7 @@ TEST_P(MultipeerIbTransportTestFixture, AllToAll) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: AllToAll test completed with {} peers",
       globalRank,
@@ -3174,8 +3189,8 @@ TEST_P(MultipeerIbTransportTestFixture, AllToAll) {
 
 TEST_P(MultipeerIbTransportTestFixture, MultiQpConstructAndExchange) {
   if (numRanks < 2) {
-    XLOGF(
-        WARNING, "Skipping test: requires at least 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires at least 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -3193,7 +3208,7 @@ TEST_P(MultipeerIbTransportTestFixture, MultiQpConstructAndExchange) {
           << "getP2pTransportDevice(" << r << ") returned null";
     }
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: Multi-QP transport created with {} QPs/block/NIC",
         globalRank,
@@ -3225,7 +3240,8 @@ TEST_P(MultipeerIbTransportTestFixture, MultiQpConstructAndExchange) {
 
 TEST_P(MultipeerIbTransportTestFixture, MultiNicAggregateBandwidth) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -3310,20 +3326,20 @@ TEST_P(MultipeerIbTransportTestFixture, MultiNicAggregateBandwidth) {
         static_cast<double>(nbytes) * static_cast<double>(measureIters);
     const double bwGbps = (totalBytes / elapsedSec) / 1e9;
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "MultiNicAggregateBandwidth: numNics={} qpsPerBlockPerNic={} numBlocks={}",
         detectedNics,
         numQps,
         numBlocks);
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "  transferred {:.2f} GB in {:.2f} ms ({} iters × {} MiB)",
         totalBytes / 1e9,
         elapsedSec * 1000.0,
         measureIters,
         nbytes >> 20);
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "  aggregate BW = {:.2f} GB/s (min expected = {:.0f} GB/s)",
         bwGbps,
@@ -3342,7 +3358,8 @@ TEST_P(MultipeerIbTransportTestFixture, MultiNicAggregateBandwidth) {
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
   }
 
-  XLOGF(INFO, "Rank {}: MultiNicAggregateBandwidth test completed", globalRank);
+  COMMS_LOG(
+      INFO, "Rank {}: MultiNicAggregateBandwidth test completed", globalRank);
 }
 
 // =============================================================================

--- a/comms/prims/tests/P2pNvlTransportDeviceTest.cc
+++ b/comms/prims/tests/P2pNvlTransportDeviceTest.cc
@@ -3,7 +3,6 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 
 #include <vector>
 

--- a/comms/prims/tests/P2pNvlTransportTest.cc
+++ b/comms/prims/tests/P2pNvlTransportTest.cc
@@ -3,7 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <algorithm>
 #include <chrono>
@@ -99,7 +99,8 @@ TEST_F(P2pNvlTransportTestFixture, PipelineGeometry) {
 TEST_F(P2pNvlTransportTestFixture, IpcMemAccess) {
   // Only test with 2 ranks
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -111,7 +112,7 @@ TEST_F(P2pNvlTransportTestFixture, IpcMemAccess) {
   auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
-  XLOGF(INFO, "Rank {} created transport and exchanged IPC", globalRank);
+  COMMS_LOG(INFO, "Rank {} created transport and exchanged IPC", globalRank);
 
   // Get host-side copy to access buffer pointers from host
   auto p2p = transport.buildP2pTransportDevice(peerRank);
@@ -120,7 +121,7 @@ TEST_F(P2pNvlTransportTestFixture, IpcMemAccess) {
       static_cast<int*>(static_cast<void*>(p2p.getLocalState().dataBuffer));
   auto remoteAddr =
       static_cast<int*>(static_cast<void*>(p2p.getRemoteState().dataBuffer));
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: localAddr: {}, remoteAddr: {}",
       globalRank,
@@ -132,11 +133,12 @@ TEST_F(P2pNvlTransportTestFixture, IpcMemAccess) {
   int writeValue = globalRank;
   test::fillBuffer(localAddr, writeValue, numElements);
   CUDACHECK_TEST(cudaDeviceSynchronize());
-  XLOGF(INFO, "Rank {} filled local buffer with {}", globalRank, writeValue);
+  COMMS_LOG(
+      INFO, "Rank {} filled local buffer with {}", globalRank, writeValue);
 
   // Barrier to ensure both ranks have written their data
   MPI_Barrier(MPI_COMM_WORLD);
-  XLOGF(INFO, "Rank {} passed barrier", globalRank);
+  COMMS_LOG(INFO, "Rank {} passed barrier", globalRank);
 
   // Now each rank reads from peer buffer and verifies
   // rank0 should read all 1s from rank1
@@ -156,7 +158,7 @@ TEST_F(P2pNvlTransportTestFixture, IpcMemAccess) {
   CUDACHECK_TEST(cudaMemcpy(
       &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {} verified peer buffer, errors: {}",
       globalRank,
@@ -242,7 +244,7 @@ class TransportTestHelper {
 
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCall) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping: requires 2 ranks, got {}", numRanks);
+    COMMS_LOG(WARN, "Skipping: requires 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -380,7 +382,7 @@ TEST_F(
 
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvCudaGraphReplay) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping: requires 2 ranks, got {}", numRanks);
+    COMMS_LOG(WARN, "Skipping: requires 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1502,7 +1504,7 @@ TEST_F(
     P2pNvlTransportTestFixture,
     TileSendRecvChangingLaunchedBlocksWithSameActiveBlocks) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping: requires 2 ranks, got {}", numRanks);
+    COMMS_LOG(WARN, "Skipping: requires 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2022,7 +2024,7 @@ void runPutTest(
       if (hostBuffer[i] != testValue) {
         ++errorCount;
         if (errorCount <= 5) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "{}: Mismatch at index {}: expected 0x{:02x}, got 0x{:02x}",
               testName,
@@ -2041,7 +2043,8 @@ void runPutTest(
 // Basic write() test with aligned pointers
 TEST_F(P2pNvlTransportTestFixture, PutBasic) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2058,7 +2061,7 @@ TEST_F(P2pNvlTransportTestFixture, PutBasic) {
 
   runPutTest(globalRank, p2p, localSrc, remoteDst, nbytes, 4, 128, "PutBasic");
 
-  XLOGF(INFO, "Rank {}: PutBasic test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: PutBasic test completed", globalRank);
 }
 
 // Parameterized test for write() with various transfer sizes
@@ -2079,12 +2082,13 @@ class PutTransferSizeTestFixture
 
 TEST_P(PutTransferSizeTestFixture, Put) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
   const auto& params = GetParam();
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Running write transfer size test: {} (nbytes={})",
       params.name,
@@ -2102,7 +2106,7 @@ TEST_P(PutTransferSizeTestFixture, Put) {
   runPutTest(
       globalRank, p2p, localSrc, remoteDst, params.nbytes, 4, 128, params.name);
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Put transfer size test '{}' completed",
       globalRank,
@@ -2161,12 +2165,13 @@ class PutUnalignedTestFixture
 
 TEST_P(PutUnalignedTestFixture, Put) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
   const auto& params = GetParam();
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Running write unaligned test: {} (srcOffset={}, dstOffset={}, nbytes={})",
       params.name,
@@ -2197,7 +2202,7 @@ TEST_P(PutUnalignedTestFixture, Put) {
   runPutTest(
       globalRank, p2p, localSrc, remoteDst, params.nbytes, 4, 128, params.name);
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Put unaligned test '{}' completed",
       globalRank,
@@ -2290,7 +2295,8 @@ INSTANTIATE_TEST_SUITE_P(
 // buffer overflows and data corruption.
 TEST_F(P2pNvlTransportTestFixture, PutMultiChunkAccumulationRegression) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2367,7 +2373,8 @@ TEST_F(P2pNvlTransportTestFixture, PutMultiChunkAccumulationRegression) {
 
 TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Enabled) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2392,12 +2399,14 @@ TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Enabled) {
       << "Rank " << globalRank
       << ": local and remote ll128Buffer should point to different ranks' buffers";
 
-  XLOGF(INFO, "Rank {}: Ll128BufferWiring_Enabled test completed", globalRank);
+  COMMS_LOG(
+      INFO, "Rank {}: Ll128BufferWiring_Enabled test completed", globalRank);
 }
 
 TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Disabled) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2424,7 +2433,8 @@ TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Disabled) {
       << "Rank " << globalRank
       << ": remoteState.llBuffer should be null when llBufferSize == 0";
 
-  XLOGF(INFO, "Rank {}: Ll128BufferWiring_Disabled test completed", globalRank);
+  COMMS_LOG(
+      INFO, "Rank {}: Ll128BufferWiring_Disabled test completed", globalRank);
 }
 
 // =============================================================================
@@ -2435,7 +2445,7 @@ TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Disabled) {
 
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvDynamicBlockCount) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping: requires 2 ranks, got {}", numRanks);
+    COMMS_LOG(WARN, "Skipping: requires 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2689,7 +2699,7 @@ static void runTileForwardTest(
 // Basic single-call test
 TEST_F(P2pNvlTransportTestFixture, TileForwardBasic) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping: requires 2 ranks, got {}", numRanks);
+    COMMS_LOG(WARN, "Skipping: requires 2 ranks, got {}", numRanks);
     return;
   }
   auto bs = std::make_shared<meta::comms::MpiBootstrap>();
@@ -3176,12 +3186,13 @@ class TileForwardUnalignedTestFixture
 
 TEST_P(TileForwardUnalignedTestFixture, TileForward) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
   const auto& params = GetParam();
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Running tile forward unaligned test: {} (nbytes={}, dstOffset={})",
       params.name,
@@ -3251,7 +3262,8 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_F(P2pNvlTransportTestFixture, LlBufferWiring_Enabled) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -3276,12 +3288,13 @@ TEST_F(P2pNvlTransportTestFixture, LlBufferWiring_Enabled) {
       << "Rank " << globalRank
       << ": local and remote llBuffer should point to different ranks' buffers";
 
-  XLOGF(INFO, "Rank {}: LlBufferWiring_Enabled test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: LlBufferWiring_Enabled test completed", globalRank);
 }
 
 TEST_F(P2pNvlTransportTestFixture, LlBufferWiring_Disabled) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -3302,7 +3315,8 @@ TEST_F(P2pNvlTransportTestFixture, LlBufferWiring_Disabled) {
       << "Rank " << globalRank
       << ": remoteState.llBuffer should be null when llBufferSize == 0";
 
-  XLOGF(INFO, "Rank {}: LlBufferWiring_Disabled test completed", globalRank);
+  COMMS_LOG(
+      INFO, "Rank {}: LlBufferWiring_Disabled test completed", globalRank);
 }
 
 } // namespace comms::prims::tests

--- a/comms/prims/tests/P2pSelfTransportDeviceTest.cc
+++ b/comms/prims/tests/P2pSelfTransportDeviceTest.cc
@@ -3,7 +3,6 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 
 #include <algorithm>
 #include <string>

--- a/comms/prims/tests/RecvForwardChainTest.cc
+++ b/comms/prims/tests/RecvForwardChainTest.cc
@@ -4,9 +4,8 @@
 
 #include <cuda_runtime.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
-#include <array>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -60,7 +59,7 @@ class RecvForwardChainTest : public BenchmarkTestFixture {
 // Verify all ranks that receive data see the correct pattern.
 TEST_F(RecvForwardChainTest, ForwardWithCopy) {
   if (worldSize < 2) {
-    XLOGF(INFO, "Skipping: requires >= 2 ranks, got {}", worldSize);
+    COMMS_LOG(INFO, "Skipping: requires >= 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -119,7 +118,7 @@ TEST_F(RecvForwardChainTest, ForwardWithCopy) {
       for (std::size_t i = 0; i < kDataBytes; ++i) {
         if (hostBuf[i] != fillPattern) {
           if (errors < 10) {
-            XLOGF(
+            COMMS_LOG(
                 ERR,
                 "Rank {}: byte {} expected 0x{:02X} got 0x{:02X}",
                 globalRank,
@@ -142,7 +141,7 @@ TEST_F(RecvForwardChainTest, ForwardWithCopy) {
 // Only the last rank should have the data.
 TEST_F(RecvForwardChainTest, ForwardOnly) {
   if (worldSize < 3) {
-    XLOGF(INFO, "Skipping: requires >= 3 ranks for forward-only test");
+    COMMS_LOG(INFO, "Skipping: requires >= 3 ranks for forward-only test");
     return;
   }
 
@@ -213,7 +212,7 @@ TEST_F(RecvForwardChainTest, ForwardOnly) {
 // is compatible when recv_forward is not involved — just send + recv.
 TEST_F(RecvForwardChainTest, SendRecvDirect) {
   if (worldSize != 2) {
-    XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -283,7 +282,7 @@ TEST_F(RecvForwardChainTest, SendRecvDirect) {
 // Multi-section test: transfer more data than one slot to exercise pipelining.
 TEST_F(RecvForwardChainTest, MultiSection) {
   if (worldSize < 2) {
-    XLOGF(INFO, "Skipping: requires >= 2 ranks, got {}", worldSize);
+    COMMS_LOG(INFO, "Skipping: requires >= 2 ranks, got {}", worldSize);
     return;
   }
 

--- a/comms/prims/tests/TopologyDiscoveryE2eTest.cc
+++ b/comms/prims/tests/TopologyDiscoveryE2eTest.cc
@@ -9,9 +9,9 @@
 
 #include <cuda_runtime.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
 #include <mpi.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/prims/topology/NvmlFabricInfo.h"
 #include "comms/prims/topology/TopologyDiscovery.h"
@@ -86,7 +86,7 @@ class TopologyDiscoveryE2eFixture : public MpiBaseTestFixture {
       }
     }
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {} platform detection: isMnnvl={}, localSize={}",
         globalRank,
@@ -122,7 +122,7 @@ TEST_F(TopologyDiscoveryE2eFixture, BasicTopologyClassification) {
   int nvlNRanks = static_cast<int>(result.nvlPeerRanks.size()) + 1;
   EXPECT_EQ(static_cast<int>(result.globalToNvlLocal.size()), nvlNRanks);
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: {} NVL peers, fabricAvailable={}",
       globalRank,
@@ -197,7 +197,7 @@ TEST_F(TopologyDiscoveryE2eFixture, PlatformNvlPeerCount) {
         << "Non-MNNVL: NVL peers should be same-host only";
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {} (localRank {}): isMnnvl={}, {} NVL peers (expected {})",
       globalRank,

--- a/comms/torchcomms/ncclx/CMakeLists.txt
+++ b/comms/torchcomms/ncclx/CMakeLists.txt
@@ -124,6 +124,12 @@ target_include_directories(torchcomms_comms_ncclx PRIVATE
 )
 torchcomms_use_torch_pybind11(torchcomms_comms_ncclx)
 target_compile_features(torchcomms_comms_ncclx PRIVATE cxx_std_20)
+# CudaRAII.cc includes SpdlogLogger.h directly, so this target must carry
+# the logger's compile-time configuration instead of relying on CTRAN.
+target_compile_definitions(torchcomms_comms_ncclx PRIVATE
+    SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO
+    SPDLOG_FMT_EXTERNAL
+)
 
 # Add device API compile definition if headers are available
 if(TORCHCOMMS_HAS_NCCL_DEVICE_API)

--- a/comms/torchcomms/ncclx/tests/integration/cpp/ColltraceGraphWatchdogTest.cpp
+++ b/comms/torchcomms/ncclx/tests/integration/cpp/ColltraceGraphWatchdogTest.cpp
@@ -7,6 +7,8 @@
 // colltrace watchdog plugin via tryEnableColltraceTimeoutWatchdog() and detects
 // timeouts.
 
+#include <cstdlib>
+
 #include <folly/FileUtil.h>
 #include <folly/Random.h>
 #include <folly/stop_watch.h>
@@ -122,9 +124,8 @@ class ColltraceGraphWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
     EXPECT_THAT(
         testDriverState.workerExitCodes, ::testing::Each(::testing::Ne(0)));
 
-    // Verify at least one NCCL debug log contains the colltrace watchdog
-    // timeout. Ranks 1-3 crash via XLOG(FATAL) in the test body (goes to
-    // stderr), so only rank 0's NCCL log will have the watchdog message.
+    // Verify at least one NCCL debug log contains the production colltrace
+    // watchdog timeout rather than only a peer-termination marker.
     bool foundWatchdogTimeout = false;
     for (const auto& entry : folly::fs::directory_iterator(tmpDir_.path())) {
       std::string fileContents;
@@ -173,7 +174,7 @@ TEST_F(ColltraceGraphWatchdogTest, TestTimeoutViaTorchCommsInit) {
   // Trigger timeout: ranks 1-3 sleep while rank 0 issues AllReduce
   if (rank != 0) {
     std::this_thread::sleep_for(timeout + std::chrono::seconds{3});
-    XLOG(FATAL, "COMM FATAL");
+    std::abort();
   } else {
     torchcomm->all_reduce(
         tensor, torch::comms::ReduceOp::SUM, /*async_op=*/false);
@@ -239,7 +240,7 @@ TEST_F(ColltraceGraphWatchdogTest, TestGraphReplayTimeout) {
   // Timeout replay — ranks 1-3 sleep while rank 0 replays
   if (rank != 0) {
     std::this_thread::sleep_for(timeout + std::chrono::seconds{3});
-    XLOG(FATAL, "COMM FATAL");
+    std::abort();
   } else {
     ASSERT_EQ(cudaGraphLaunch(graphExec, captureStream.stream()), cudaSuccess);
     std::this_thread::sleep_for(timeout + std::chrono::seconds{3});
@@ -309,7 +310,7 @@ TEST_F(
   // N+1th replay: ranks 1-3 sleep, rank 0 replays → timeout
   if (rank != 0) {
     std::this_thread::sleep_for(timeout + std::chrono::seconds{3});
-    XLOG(FATAL, "COMM FATAL");
+    std::abort();
   } else {
     ASSERT_EQ(cudaGraphLaunch(graphExec, captureStream.stream()), cudaSuccess);
     std::this_thread::sleep_for(timeout + std::chrono::seconds{3});

--- a/comms/utils/CommsMaybeChecks.h
+++ b/comms/utils/CommsMaybeChecks.h
@@ -2,48 +2,45 @@
 
 #pragma once
 
-#include <fmt/format.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
-#define EXPECT_CHECK_ALWAYS_RETURN(cmd)                             \
-  {                                                                 \
-    const auto res = cmd;                                           \
-    if (res.hasError()) {                                           \
-      XLOG(ERR) << fmt::format(                                     \
-          "Call for {} failed with {}", #cmd, res.error().message); \
-      return folly::makeUnexpected(std::move(res.error()));         \
-    }                                                               \
-    return res;                                                     \
+#define EXPECT_CHECK_ALWAYS_RETURN(cmd)                                        \
+  {                                                                            \
+    const auto res = cmd;                                                      \
+    if (res.hasError()) {                                                      \
+      COMMS_LOG(ERR, "Call for {} failed with {}", #cmd, res.error().message); \
+      return folly::makeUnexpected(std::move(res.error()));                    \
+    }                                                                          \
+    return res;                                                                \
   }
 
-#define EXPECT_CHECK(cmd)                                           \
-  {                                                                 \
-    const auto res = cmd;                                           \
-    if (res.hasError()) {                                           \
-      XLOG(ERR) << fmt::format(                                     \
-          "Call for {} failed with {}", #cmd, res.error().message); \
-      return folly::makeUnexpected(std::move(res.error()));         \
-    }                                                               \
+#define EXPECT_CHECK(cmd)                                                      \
+  {                                                                            \
+    const auto res = cmd;                                                      \
+    if (res.hasError()) {                                                      \
+      COMMS_LOG(ERR, "Call for {} failed with {}", #cmd, res.error().message); \
+      return folly::makeUnexpected(std::move(res.error()));                    \
+    }                                                                          \
   }
 
-#define EXPECT_CHECK_LOG_FIRST_N(n, cmd)                            \
-  {                                                                 \
-    const auto res = cmd;                                           \
-    if (res.hasError()) {                                           \
-      XLOG_FIRST_N(ERR, n) << fmt::format(                          \
-          "Call for {} failed with {}", #cmd, res.error().message); \
-      return folly::makeUnexpected(std::move(res.error()));         \
-    }                                                               \
+#define EXPECT_CHECK_LOG_FIRST_N(n, cmd)                                    \
+  {                                                                         \
+    const auto res = cmd;                                                   \
+    if (res.hasError()) {                                                   \
+      COMMS_LOG_STREAM_FIRST_N(ERR, n)                                      \
+          << "Call for " << #cmd << " failed with " << res.error().message; \
+      return folly::makeUnexpected(std::move(res.error()));                 \
+    }                                                                       \
   }
 
-#define EXPECT_CHECK_CONTINUE_LOG_FIRST_N(cmd, n)                   \
-  {                                                                 \
-    const auto res = cmd;                                           \
-    if (res.hasError()) {                                           \
-      XLOG_FIRST_N(ERR, n) << fmt::format(                          \
-          "Call for {} failed with {}", #cmd, res.error().message); \
-      continue;                                                     \
-    }                                                               \
+#define EXPECT_CHECK_CONTINUE_LOG_FIRST_N(cmd, n)                           \
+  {                                                                         \
+    const auto res = cmd;                                                   \
+    if (res.hasError()) {                                                   \
+      COMMS_LOG_STREAM_FIRST_N(ERR, n)                                      \
+          << "Call for " << #cmd << " failed with " << res.error().message; \
+      continue;                                                             \
+    }                                                                       \
   }
 
 #define EXPECT_CHECK_RES(res)                               \

--- a/comms/utils/CudaChecks.h
+++ b/comms/utils/CudaChecks.h
@@ -8,7 +8,7 @@
 
 #include <fmt/format.h>
 
-#include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #if CUDART_VERSION >= 11030
 #include <cudaTypedefs.h>
@@ -36,7 +36,7 @@ inline FuncPtr loadDriverFunction(const char* funcName, int version) {
       cudaEnableDefault,
       &driverStatus);
   if (res != cudaSuccess || driverStatus != cudaDriverEntryPointSuccess) {
-    CLOGF(
+    COMMS_LOG(
         WARN,
         "Failed to load CUDA driver symbol {} version {} (cudaError={}, status={})",
         funcName,
@@ -54,7 +54,7 @@ inline FuncPtr loadDriverFunction(const char* funcName, int version) {
       cudaEnableDefault,
       &driverStatus);
   if (res != cudaSuccess || driverStatus != cudaDriverEntryPointSuccess) {
-    CLOGF(
+    COMMS_LOG(
         WARN,
         "Failed to load CUDA driver symbol {} version {} (cudaError={}, status={})",
         funcName,
@@ -67,7 +67,7 @@ inline FuncPtr loadDriverFunction(const char* funcName, int version) {
   cudaError_t res = cudaGetDriverEntryPoint(
       funcName, reinterpret_cast<void**>(&func), cudaEnableDefault);
   if (res != cudaSuccess) {
-    CLOGF(
+    COMMS_LOG(
         WARN,
         "Failed to load CUDA driver symbol {} version {} (cudaError={})",
         funcName,
@@ -144,7 +144,7 @@ inline CUresult cuMemGetAddressRangeDynamic(
     CUresult err = cmd;                                                        \
     if (err != CUDA_SUCCESS) {                                                 \
       const char* errStr = ::comms::utils::cuda::getCuErrorString(err);        \
-      CLOGF(ERR, "Cuda failure {} '{}'", static_cast<int>(err), errStr);       \
+      COMMS_LOG(ERR, "Cuda failure {} '{}'", static_cast<int>(err), errStr);   \
       throw std::runtime_error(                                                \
           fmt::format("Cuda failure {} '{}'", static_cast<int>(err), errStr)); \
     }                                                                          \

--- a/comms/utils/CudaRAII.cc
+++ b/comms/utils/CudaRAII.cc
@@ -2,6 +2,7 @@
 
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/checks.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <stdexcept>
 #include <string>
@@ -136,8 +137,9 @@ CudaDeviceGuard::~CudaDeviceGuard() {
   }
   const auto status = cudaSetDevice(previousDevice_);
   if (status != cudaSuccess) {
-    XLOG(ERR) << "CudaDeviceGuard: failed to restore CUDA device "
-              << previousDevice_ << ": " << cudaGetErrorString(status);
+    COMMS_LOG_STREAM(ERR) << "CudaDeviceGuard: failed to restore CUDA device "
+                          << previousDevice_ << ": "
+                          << cudaGetErrorString(status);
   }
 }
 

--- a/comms/utils/checks.h
+++ b/comms/utils/checks.h
@@ -7,12 +7,10 @@
 #include <stdexcept>
 
 #include <fmt/format.h>
-#include <folly/String.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/utils/Conversion.h"
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/LoggingFormat.h"
 
 // Base case
 template <typename... ErrorCodes>
@@ -49,7 +47,8 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
   {                                                         \
     const auto res = cmd;                                   \
     if (!inCudaErrorCodes(res, cudaSuccess, __VA_ARGS__)) { \
-      XLOG(FATAL) << fmt::format(                           \
+      COMMS_LOG(                                            \
+          FATAL,                                            \
           "CUDA error: {}:{} {}",                           \
           __FILE__,                                         \
           __LINE__,                                         \
@@ -61,7 +60,8 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
   {                                 \
     const auto err = cmd;           \
     if (err != cudaSuccess) {       \
-      XLOG(FATAL) << fmt::format(   \
+      COMMS_LOG(                    \
+          FATAL,                    \
           "CUDA error: {}:{} {}",   \
           __FILE__,                 \
           __LINE__,                 \
@@ -73,7 +73,7 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
   {                                                                   \
     const auto err = cmd;                                             \
     if (err != cudaSuccess) {                                         \
-      CERR(commUnhandledCudaError, "Call for {} failed", #cmd);       \
+      COMMS_ERR(commUnhandledCudaError, "Call for {} failed", #cmd);  \
       return folly::makeUnexpected(                                   \
           getCommsErrorFromCudaError(err, __FILE__, __LINE__, #cmd)); \
     }                                                                 \
@@ -83,7 +83,8 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
   {                                 \
     const auto err = cmd;           \
     if (err != ncclSuccess) {       \
-      XLOG(FATAL) << fmt::format(   \
+      COMMS_LOG(                    \
+          FATAL,                    \
           "NCCL error: {}:{} {}",   \
           __FILE__,                 \
           __LINE__,                 \
@@ -101,7 +102,7 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
   do {                                                              \
     cudaError_t err = cmd;                                          \
     if (err != cudaSuccess) {                                       \
-      CERR(                                                         \
+      COMMS_ERR(                                                    \
           commUnhandledCudaError,                                   \
           "{}:{} Cuda failure {}",                                  \
           __FILE__,                                                 \
@@ -123,7 +124,7 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
 #define FOLLY_EXPECTED_CHECKTHROW(RES)                                  \
   do {                                                                  \
     if (RES.hasError()) {                                               \
-      CLOGF(                                                            \
+      COMMS_LOG(                                                        \
           ERR,                                                          \
           "{}:{} -> {} ({})",                                           \
           __FILE__,                                                     \
@@ -145,7 +146,7 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
   do {                                                 \
     commResult_t RES = cmd;                            \
     if (RES != commSuccess && RES != commInProgress) { \
-      CLOGF(                                           \
+      COMMS_LOG(                                       \
           ERR,                                         \
           "{}:{} -> {} ({})",                          \
           __FILE__,                                    \
@@ -170,7 +171,7 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
     if (!(statement)) {                                                        \
       auto errorMsg =                                                          \
           fmt::format("Check failed: {} - {}", #statement, __VA_ARGS__);       \
-      CERR(commInternalError, "{}", errorMsg);                                 \
+      COMMS_ERR(commInternalError, "{}", errorMsg);                            \
       throw std::runtime_error(                                                \
           fmt::format(                                                         \
               "Check failed: {} - {}", #statement, fmt::format(__VA_ARGS__))); \
@@ -185,7 +186,7 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
  */
 #define FB_ERRORTHROW(error, ...)                \
   do {                                           \
-    CLOGF(ERR, ##__VA_ARGS__);                   \
+    COMMS_LOG(ERR, ##__VA_ARGS__);               \
     throw std::runtime_error(                    \
         std::string("COMM internal failure: ") + \
         ::meta::comms::commCodeToString(error)); \

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -6,7 +6,6 @@
 
 #include <fmt/core.h>
 #include <folly/json.h>
-#include <folly/logging/xlog.h>
 #include <folly/stop_watch.h>
 
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
@@ -20,6 +19,7 @@
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace meta::comms::colltrace {
 
@@ -76,30 +76,31 @@ const std::string& graphColltraceUnsupportedReason() {
 
 } // namespace
 
-bool graphColltraceSupported(std::string_view logPrefix) {
+bool graphColltraceSupported(
+    std::string_view logPrefix,
+    std::string_view loggerName) {
   const auto& reason = graphColltraceUnsupportedReason();
   if (reason.empty()) {
     return true;
   }
-  XLOG_FIRST_N(WARNING, 1) << logPrefix << ": graph colltrace disabled -- "
-                           << reason;
+  auto& logger = logger::getSpdlogLogger(loggerName);
+  COMMS_LOGGER_STREAM_FIRST_N(logger, WARNING, 1)
+      << logPrefix << ": graph colltrace disabled -- " << reason;
   return false;
 }
 
 template <auto Method>
 void triggerPlugins(
+    logger::CommsSpdlogLogger& logger,
     std::vector<std::unique_ptr<ICollTracePlugin>>& plugins,
     CollTraceEvent& curEvent) noexcept {
   for (auto& plugin : plugins) {
     CommsMaybeVoid res = ((*plugin).*Method)(curEvent);
     if (res.hasError()) {
-      XLOG_FIRST_N(
-          ERR,
-          10,
-          "Exception thrown in plugin {} when calling method {}: {}",
-          plugin->getName(),
-          typeid(Method).name(),
-          res.error().message);
+      COMMS_LOGGER_STREAM_FIRST_N(logger, ERR, 10)
+          << "Exception thrown in plugin " << plugin->getName()
+          << " when calling method " << typeid(Method).name() << ": "
+          << res.error().message;
     }
   }
 }
@@ -110,6 +111,7 @@ CollTrace::CollTrace(
     std::function<CommsMaybeVoid(void)> threadSetupFunc,
     std::vector<std::unique_ptr<ICollTracePlugin>> plugins)
     : config_(std::move(config)),
+      logger_(&logger::getSpdlogLogger(config_.loggerName)),
       logMetaData_(std::move(logMetaData)),
       logPrefix_(
           fmt::format(
@@ -121,7 +123,8 @@ CollTrace::CollTrace(
           folly::MPMCQueue<std::unique_ptr<CollTraceEvent>>{
               config_.maxPendingQueueSize}),
       plugins_(std::move(plugins)) {
-  if (NCCL_COLLTRACE_TRACE_CUDA_GRAPH && graphColltraceSupported(logPrefix_)) {
+  if (NCCL_COLLTRACE_TRACE_CUDA_GRAPH &&
+      graphColltraceSupported(logPrefix_, config_.loggerName)) {
     // Eagerly initialize the globaltimer calibration singleton now (outside
     // graph capture) so it is ready when GraphCudaWaitEvent is constructed
     // during capture.
@@ -136,8 +139,10 @@ CollTrace::CollTrace(
     }
     uint32_t ringSize =
         std::max(kDefaultRingSize, static_cast<uint32_t>(maxRetention) * 2);
-    XLOGF(
-        DBG0,
+    COMMS_LOG_IMPL(
+        *logger_,
+        ::spdlog::level::debug,
+        COMMS_LOGGER_DEBUG,
         "{}: graph ring buffer sized to {} entries (max plugin retention={}, "
         "default={})",
         logPrefix_,
@@ -149,8 +154,8 @@ CollTrace::CollTrace(
     if (ringBuffer_->valid()) {
       ringReader_.emplace(*ringBuffer_);
     } else {
-      XLOG_FIRST_N(ERR, 1) << logPrefix_
-                           << ": Failed to allocate shared ring buffer";
+      COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 1)
+          << logPrefix_ << ": Failed to allocate shared ring buffer";
       ringBuffer_.reset();
     }
   }
@@ -158,7 +163,8 @@ CollTrace::CollTrace(
   // pluginByName_ is not used in the colltrace thread. It is okay to initialize
   // it after the colltrace thread starts
   for (const auto& plugin : plugins_) {
-    XLOG(DBG0) << "Registering plugin " << plugin->getName();
+    COMMS_LOGGER_STREAM(*logger_, DBG)
+        << "Registering plugin " << plugin->getName();
     pluginByName_.emplace(plugin->getName(), *plugin);
   }
 
@@ -250,8 +256,9 @@ std::shared_ptr<GraphCollTraceState> CollTrace::getOrCreateGraphState(
 
   if (createRes != cudaSuccess) {
     delete prevent_free;
-    XLOG_FIRST_N(WARN, 1) << "Failed to create graph cleanup user object: "
-                          << cudaGetErrorString(createRes);
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, WARN, 1)
+        << "Failed to create graph cleanup user object: "
+        << cudaGetErrorString(createRes);
     return nullptr;
   }
 
@@ -262,8 +269,9 @@ std::shared_ptr<GraphCollTraceState> CollTrace::getOrCreateGraphState(
         cudaUserObjectRelease(userObject, 1),
         cudaErrorCudartUnloading,
         cudaErrorContextIsDestroyed);
-    XLOG_FIRST_N(WARN, 1) << "Failed to retain graph user object: "
-                          << cudaGetErrorString(retainRes);
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, WARN, 1)
+        << "Failed to retain graph user object: "
+        << cudaGetErrorString(retainRes);
     return nullptr;
   }
 
@@ -291,14 +299,11 @@ CommsMaybe<std::shared_ptr<ICollTraceHandle>> CollTrace::recordCollective(
   }
 
   if (pendingEnqueueColl_ != nullptr) {
-    XLOG_FIRST_N(
-        ERR,
-        1,
-        fmt::format(
-            "{}: Got another collective enqueued when a previous one haven't finished, colltrace result would be inaccurate. Previous: {}, Next:{}",
-            logPrefix_,
-            folly::toJson(pendingEnqueueColl_->collRecord->toDynamic()),
-            folly::toJson(metadata->toDynamic())));
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 1) << fmt::format(
+        "{}: Got another collective enqueued when a previous one haven't finished, colltrace result would be inaccurate. Previous: {}, Next:{}",
+        logPrefix_,
+        folly::toJson(pendingEnqueueColl_->collRecord->toDynamic()),
+        folly::toJson(metadata->toDynamic()));
     auto handlePtr = eventToHandleMap_.find(pendingEnqueueColl_.get());
     if (handlePtr != eventToHandleMap_.end()) {
       handlePtr->second->invalidate();
@@ -315,7 +320,7 @@ CommsMaybe<std::shared_ptr<ICollTraceHandle>> CollTrace::recordCollective(
       std::make_shared<CollTraceHandle>(this, pendingEnqueueColl_.get());
   eventToHandleMap_.emplace(pendingEnqueueColl_.get(), handle);
   triggerPlugins<&ICollTracePlugin::afterCollRecorded>(
-      plugins_, *pendingEnqueueColl_);
+      *logger_, plugins_, *pendingEnqueueColl_);
   return handle;
 }
 
@@ -335,7 +340,7 @@ CommsMaybeVoid CollTrace::triggerEventState(
       }
       auto beforeKernelRes = collEvent.waitEvent->beforeCollKernelScheduled();
       triggerPlugins<&ICollTracePlugin::beforeCollKernelScheduled>(
-          plugins_, collEvent); // Trigger plugins after calling waitEvent
+          *logger_, plugins_, collEvent); // Trigger after calling waitEvent
       EXPECT_CHECK_ALWAYS_RETURN(beforeKernelRes);
     }
     case CollTraceHandleTriggerState::AfterEnqueueKernel: {
@@ -345,7 +350,7 @@ CommsMaybeVoid CollTrace::triggerEventState(
             commInvalidUsage));
       }
       triggerPlugins<&ICollTracePlugin::afterCollKernelScheduled>(
-          plugins_, collEvent); // Trigger plugins before calling waitEvent
+          *logger_, plugins_, collEvent); // Trigger before calling waitEvent
       EXPECT_CHECK(collEvent.waitEvent->afterCollKernelScheduled());
       collEvent.collRecord->getTimingInfo().setCollEnqueueTs(precisionNow());
       if (pendingTraceColls_.write(std::move(pendingEnqueueColl_))) {
@@ -363,10 +368,8 @@ CommsMaybeVoid CollTrace::triggerEventState(
             "Failed to write to pendingTraceColls_ queue", commInternalError));
       } else {
         // This code should not be reached
-        XLOG_FIRST_N(
-            DBG,
-            1,
-            "pendingEnqueueColl_ is nullptr after write to queue failed");
+        COMMS_LOGGER_STREAM_FIRST_N(*logger_, DBG, 1)
+            << "pendingEnqueueColl_ is nullptr after write to queue failed";
         return folly::makeUnexpected(CommsError(
             "pendingEnqueueColl_ is nullptr after write to pendingTraceColls_ queue",
             commInternalError));
@@ -399,6 +402,7 @@ CollTrace::recordGraphCollectiveImpl(
   // Assign a unique collId for this collective — used to tag entries in
   // the shared ring buffer so the poll thread can dispatch by collective.
   auto collIdVal = collId_.fetch_add(1);
+  rawWaitEvent->setLogger(*logger_);
   rawWaitEvent->setCollId(collIdVal);
 
   if (!ringBuffer_.has_value()) {
@@ -448,7 +452,7 @@ CollTrace::recordGraphCollectiveImpl(
     graphState->collectives.emplace(collId, std::move(collectiveEntry));
   }
   triggerPlugins<&ICollTracePlugin::afterCollRecorded>(
-      plugins_, *registrationEvent);
+      *logger_, plugins_, *registrationEvent);
 
   return handle;
 }
@@ -551,7 +555,7 @@ void CollTrace::pollGraphEvents(
           // start timestamp and resets its timer automatically).
           if (auto [_, inserted] = progressingGraphCollectives_.insert(collId);
               !inserted) {
-            XLOG_EVERY_MS(WARN, 5000)
+            COMMS_LOGGER_STREAM_EVERY_MS(*logger_, WARN, 5000)
                 << logPrefix_ << ": graph collective " << collId
                 << " saw a new start event before the previous end event"
                    " — the end event was likely overwritten (ring too small)";
@@ -595,7 +599,7 @@ void CollTrace::pollGraphEvents(
             graphReplayEvents_.push_back(std::move(replayIt->second));
             inFlightReplays_.erase(replayIt);
           } else {
-            XLOG_EVERY_MS(WARN, 5000)
+            COMMS_LOGGER_STREAM_EVERY_MS(*logger_, WARN, 5000)
                 << logPrefix_ << ": graph collective " << collId
                 << " end event without matching start — dropped";
           }
@@ -604,7 +608,7 @@ void CollTrace::pollGraphEvents(
       /*timeout=*/config_.maxCheckCancelInterval);
 
   if (pollResult.entriesLost > 0) {
-    XLOG_EVERY_MS(WARN, 5000)
+    COMMS_LOGGER_STREAM_EVERY_MS(*logger_, WARN, 5000)
         << logPrefix_ << ": missed " << pollResult.entriesLost
         << " graph replay timestamp(s) (overwritten)";
   }
@@ -693,9 +697,9 @@ void CollTrace::processCompletedEvents(
         // so we just fire the before/after callbacks here
         // in-case plugins depend on them
         triggerPlugins<&ICollTracePlugin::beforeCollKernelScheduled>(
-            plugins_, *action.event);
+            *logger_, plugins_, *action.event);
         triggerPlugins<&ICollTracePlugin::afterCollKernelScheduled>(
-            plugins_, *action.event);
+            *logger_, plugins_, *action.event);
         [[fallthrough]];
       }
       case PendingActionType::kStart: {
@@ -704,7 +708,7 @@ void CollTrace::processCompletedEvents(
               lastCollEndTime_.value());
         }
         triggerPlugins<&ICollTracePlugin::afterCollKernelStart>(
-            plugins_, *action.event);
+            *logger_, plugins_, *action.event);
         break;
       }
       case PendingActionType::kEnd: {
@@ -714,16 +718,16 @@ void CollTrace::processCompletedEvents(
         // collEventProgressing was called unconditionally inside the
         // waitCollEnd loop.
         triggerPlugins<&ICollTracePlugin::collEventProgressing>(
-            plugins_, *action.event);
+            *logger_, plugins_, *action.event);
         triggerPlugins<&ICollTracePlugin::afterCollKernelEnd>(
-            plugins_, *action.event);
+            *logger_, plugins_, *action.event);
         lastCollEndTime_ =
             action.event->collRecord->getTimingInfo().getCollEndTs();
         break;
       }
       case PendingActionType::kProgressing: {
         triggerPlugins<&ICollTracePlugin::collEventProgressing>(
-            plugins_, *action.event);
+            *logger_, plugins_, *action.event);
         break;
       }
     }
@@ -752,11 +756,18 @@ void CollTrace::processCompletedEvents(
 
 void CollTrace::collTraceThread(
     const std::function<CommsMaybeVoid(void)>& threadSetupFunc) {
-  XLOGF(INFO, "{}: Colltrace thread INIT", logPrefix_);
+  COMMS_LOG_IMPL(
+      *logger_,
+      ::spdlog::level::info,
+      SPDLOG_LOGGER_INFO,
+      "{}: Colltrace thread INIT",
+      logPrefix_);
   auto res = threadSetupFunc();
   if (res.hasError()) {
-    XLOGF(
-        ERR,
+    COMMS_LOG_IMPL(
+        *logger_,
+        ::spdlog::level::err,
+        SPDLOG_LOGGER_ERROR,
         "{}: Error in calling colltrace thread setup function: {}",
         logPrefix_,
         res.error().message);
@@ -769,7 +780,12 @@ void CollTrace::collTraceThread(
     return;
   }
 
-  XLOGF(INFO, "{}: CollTrace thread STARTED", logPrefix_);
+  COMMS_LOG_IMPL(
+      *logger_,
+      ::spdlog::level::info,
+      SPDLOG_LOGGER_INFO,
+      "{}: CollTrace thread STARTED",
+      logPrefix_);
 
   bool initialized = false;
 
@@ -797,7 +813,7 @@ void CollTrace::collTraceThread(
           ::hrdw_ring_buffer::GlobaltimerCalibration::get().refresh();
         }
         if (auto* refpt = CudaReferencePoint::tryGet()) {
-          refpt->refresh();
+          refpt->refresh(*logger_);
         }
         lastReanchor = now;
       }

--- a/comms/utils/colltrace/CollTrace.h
+++ b/comms/utils/colltrace/CollTrace.h
@@ -6,6 +6,7 @@
 #include <latch>
 #include <mutex>
 #include <set>
+#include <string>
 #include <string_view>
 #include <thread>
 #include <unordered_map>
@@ -26,6 +27,10 @@
 
 struct CUstream_st;
 
+namespace meta::comms::logger {
+class CommsSpdlogLogger;
+}
+
 namespace meta::comms::colltrace {
 
 struct GraphCollTraceState;
@@ -44,10 +49,13 @@ class GraphCudaWaitEvent;
 // the poll thread on drain. Both inputs are fixed for the process, so the
 // verdict is computed once and cached (this assumes a homogeneous-GPU host).
 // Exposed so tests can skip on hosts where graph timing cannot work.
-bool graphColltraceSupported(std::string_view logPrefix);
+bool graphColltraceSupported(
+    std::string_view logPrefix,
+    std::string_view loggerName = "comms");
 
 struct CollTraceConfig {
   static constexpr ::size_t kDefaultMaxPendingQueueSize{1024};
+  std::string loggerName{"comms"};
   // The max time CollTrace thread will be waiting before it can respond to
   // a cancellation request. This is to ensure that we don't wait forever and
   // will respond reasonably quickly during teardown. Default to 1 second.
@@ -164,6 +172,7 @@ class CollTrace : public ICollTrace {
 
   // **** Start of Private Member Variables ****
   CollTraceConfig config_;
+  logger::CommsSpdlogLogger* logger_{nullptr};
 
   // Represents the metadata of the communicator that is being traced.
   // This is used for logging purposes.

--- a/comms/utils/colltrace/CudaWaitEvent.cc
+++ b/comms/utils/colltrace/CudaWaitEvent.cc
@@ -8,7 +8,7 @@
 #include <folly/Unit.h>
 #include <folly/stop_watch.h>
 
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/PrecisionClock.h"
@@ -71,7 +71,7 @@ CudaReferencePoint::CudaReferencePoint() {
   return g_referencePointInstance.load(std::memory_order_acquire);
 }
 
-void CudaReferencePoint::refresh() {
+void CudaReferencePoint::refresh(logger::CommsSpdlogLogger& logger) {
   // Try-and-skip: if another thread is already refreshing, short-circuit
   // without touching the dedicated CUDA stream. Multiple CollTrace
   // instances exist per process (one per NCCL communicator) and each calls
@@ -85,14 +85,14 @@ void CudaReferencePoint::refresh() {
 
   cudaEvent_t newEvent = nullptr;
   if (auto err = cudaEventCreate(&newEvent); err != cudaSuccess) {
-    XLOG_EVERY_MS(WARN, 5000)
+    COMMS_LOGGER_STREAM_EVERY_MS(logger, WARN, 5000)
         << "CudaReferencePoint::refresh: cudaEventCreate failed: "
         << cudaGetErrorString(err) << " — keeping previous anchor";
     return;
   }
   CHECK(newEvent != nullptr);
   if (auto err = cudaEventRecord(newEvent, stream_); err != cudaSuccess) {
-    XLOG_EVERY_MS(WARN, 5000)
+    COMMS_LOGGER_STREAM_EVERY_MS(logger, WARN, 5000)
         << "CudaReferencePoint::refresh: cudaEventRecord failed: "
         << cudaGetErrorString(err) << " — keeping previous anchor";
     // Best-effort cleanup of an event we just created; any destroy error
@@ -102,7 +102,7 @@ void CudaReferencePoint::refresh() {
     return;
   }
   if (auto err = cudaStreamSynchronize(stream_); err != cudaSuccess) {
-    XLOG_EVERY_MS(WARN, 5000)
+    COMMS_LOGGER_STREAM_EVERY_MS(logger, WARN, 5000)
         << "CudaReferencePoint::refresh: cudaStreamSynchronize failed: "
         << cudaGetErrorString(err) << " — keeping previous anchor";
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)

--- a/comms/utils/colltrace/CudaWaitEvent.h
+++ b/comms/utils/colltrace/CudaWaitEvent.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <atomic>
+#include <string_view>
 
 #include <cuda_runtime.h> // @manual
 
@@ -12,6 +13,10 @@
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/colltrace/CollWaitEvent.h"
 #include "comms/utils/colltrace/CudaEventPool.h"
+
+namespace meta::comms::logger {
+class CommsSpdlogLogger;
+}
 
 namespace meta::comms::colltrace {
 
@@ -46,7 +51,7 @@ class CudaReferencePoint {
   // anchor is kept. Caller is responsible for rate-limiting; the colltrace
   // poll thread invokes this at ~1 Hz, bounding residual drift between
   // anchors below 100 ns at 100 ppm oscillator tolerance.
-  void refresh();
+  void refresh(logger::CommsSpdlogLogger& logger);
 
   // Returns the singleton if it has been constructed, otherwise nullptr.
   // Safe to call from any thread; never triggers construction. Used by the

--- a/comms/utils/colltrace/GenericMetadata.cc
+++ b/comms/utils/colltrace/GenericMetadata.cc
@@ -2,9 +2,8 @@
 
 #include "comms/utils/colltrace/GenericMetadata.h"
 
-#include <folly/logging/xlog.h>
-
 #include "comms/utils/Conversion.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace meta::comms::colltrace {
 
@@ -177,7 +176,7 @@ GroupedCollP2PMetaData GroupedCollP2PMetaData::fromDynamic(
   // TODO: Currently the from dynamic function is not functioning as expected.
   GroupedCollP2PMetaData metadata;
 
-  XLOG_FIRST_N(ERR, 1)
+  COMMS_LOGGER_STREAM_FIRST_N(logger::getSpdlogLogger(), ERR, 1)
       << "GroupedCollP2PMetaData::fromDynamic is not supported yet";
 
   return metadata;

--- a/comms/utils/colltrace/GraphCudaWaitEvent.cc
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.cc
@@ -5,11 +5,11 @@
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
 
 #include <folly/Unit.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/utils/PrecisionClock.h"
 #include "comms/utils/checks.h"
 #include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace meta::comms::colltrace {
 
@@ -32,7 +32,8 @@ CommsMaybeVoid GraphCudaWaitEvent::beforeCollKernelScheduled() noexcept {
   // collective goes untimed. Warn a few times so that silent timing loss is
   // detectable rather than invisible, without spamming the log per collective.
   if (ringBuffer_ == nullptr) {
-    XLOG_FIRST_N(WARNING, 8)
+    auto& logger = logger_ != nullptr ? *logger_ : logger::getSpdlogLogger();
+    COMMS_LOGGER_STREAM_FIRST_N(logger, WARNING, 8)
         << "GraphCudaWaitEvent: no in-kernel colltrace ring attached (collId="
         << collId_
         << "); graph-captured collective timing is unavailable on this device.";

--- a/comms/utils/colltrace/GraphCudaWaitEvent.h
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.h
@@ -9,6 +9,10 @@
 #include "comms/utils/colltrace/GraphCollTraceState.h"
 #include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
+namespace meta::comms::logger {
+class CommsSpdlogLogger;
+}
+
 namespace meta::comms::colltrace {
 
 // Default shared ring buffer size — must be a power of 2.
@@ -57,6 +61,10 @@ class GraphCudaWaitEvent : public ICollWaitEvent {
       ::hrdw_ring_buffer::HRDWRingBuffer<GraphCollTraceEvent>*
           ringBuffer) noexcept;
 
+  void setLogger(logger::CommsSpdlogLogger& logger) noexcept {
+    logger_ = &logger;
+  }
+
   cudaStream_t getStream() const noexcept {
     return stream_;
   }
@@ -89,6 +97,7 @@ class GraphCudaWaitEvent : public ICollWaitEvent {
   cudaStream_t stream_;
   uint32_t collId_;
   system_clock_time_point enqueueTime_;
+  logger::CommsSpdlogLogger* logger_{nullptr};
 
   // owned by CollTrace, shared across ALL graphs. set via attachRingBuffer().
   ::hrdw_ring_buffer::HRDWRingBuffer<GraphCollTraceEvent>* ringBuffer_{nullptr};

--- a/comms/utils/colltrace/plugins/CommDumpPlugin.cc
+++ b/comms/utils/colltrace/plugins/CommDumpPlugin.cc
@@ -3,12 +3,13 @@
 #include "comms/utils/colltrace/plugins/CommDumpPlugin.h"
 
 #include <algorithm>
+#include <utility>
 
 #include <folly/Unit.h>
 #include <folly/json.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/utils/CommsMaybeChecks.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 #include "comms/utils/trainer/TrainerContext.h"
 
 namespace meta::comms::colltrace {
@@ -17,7 +18,8 @@ namespace {
 CommsMaybeVoid enqueuePendingColls(
     folly::MPMCQueue<std::shared_ptr<CollRecord>>& mpmcQueue,
     std::deque<std::shared_ptr<CollRecord>>& pendingQueue,
-    int64_t maxReadCount) noexcept {
+    int64_t maxReadCount,
+    logger::CommsSpdlogLogger& logger) noexcept {
   std::shared_ptr<CollRecord> nextEnqueue;
   int readCount{0};
   while (readCount < maxReadCount && mpmcQueue.read(nextEnqueue)) {
@@ -25,12 +27,9 @@ CommsMaybeVoid enqueuePendingColls(
     ++readCount;
   }
   if (readCount == maxReadCount) {
-    XLOG_FIRST_N(
-        ERR,
-        2,
-        "CommDumpPlugin: Read ",
-        readCount,
-        " pending colls, but queue is still not empty");
+    COMMS_LOGGER_STREAM_FIRST_N(logger, ERR, 2)
+        << "CommDumpPlugin: Read " << readCount
+        << " pending colls, but queue is still not empty";
     return folly::makeUnexpected(CommsError(
         "CommDumpPlugin: Read " + std::to_string(readCount) +
             " pending colls, but queue is still not empty",
@@ -41,7 +40,9 @@ CommsMaybeVoid enqueuePendingColls(
 } // namespace
 
 CommDumpPlugin::CommDumpPlugin(CommDumpConfig config)
-    : config_(config), newPendingColls_(config_.pendingCollSize) {}
+    : config_(std::move(config)),
+      logger_(&logger::getSpdlogLogger(config_.loggerName)),
+      newPendingColls_(config_.pendingCollSize) {}
 
 std::string_view CommDumpPlugin::getName() const noexcept {
   return kCommDumpPluginName;
@@ -56,7 +57,8 @@ CommsMaybeVoid CommDumpPlugin::beforeCollKernelScheduled(
 CommsMaybeVoid CommDumpPlugin::afterCollKernelScheduled(
     CollTraceEvent& curEvent) noexcept {
   if (curEvent.collRecord == nullptr) [[unlikely]] {
-    XLOG_FIRST_N(ERR, 2, "Got event with null collRecord in CommDumpPlugin");
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 2)
+        << "Got event with null collRecord in CommDumpPlugin";
     return folly::makeUnexpected(CommsError(
         "CollTraceEvent does not contain valid record", commInternalError));
   }
@@ -65,7 +67,8 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelScheduled(
   auto success = newPendingColls_.write(curEvent.collRecord);
 
   if (!success) [[unlikely]] {
-    XLOG_FIRST_N(ERR, 2, "Failed to enqueue event in CommDumpPlugin");
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 2)
+        << "Failed to enqueue event in CommDumpPlugin";
     return folly::makeUnexpected(CommsError(
         "Failed to enqueue event in CommDumpPlugin", commInternalError));
   }
@@ -76,7 +79,8 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelScheduled(
 CommsMaybeVoid CommDumpPlugin::afterCollKernelStart(
     CollTraceEvent& curEvent) noexcept {
   if (curEvent.collRecord == nullptr) [[unlikely]] {
-    XLOG_FIRST_N(ERR, 2, "Got event with null collRecord in CommDumpPlugin");
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 2)
+        << "Got event with null collRecord in CommDumpPlugin";
     return folly::makeUnexpected(CommsError(
         "CollTraceEvent does not contain valid record", commInternalError));
   }
@@ -88,7 +92,8 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelStart(
       enqueuePendingColls(
           newPendingColls_,
           lockedCollTraceDump->pendingColls,
-          config_.pendingCollSize + 1));
+          config_.pendingCollSize + 1,
+          *logger_));
 
   // Find the matching pending collective.
   // With deferred graph polling, completions may arrive out of enqueue order
@@ -100,10 +105,8 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelStart(
       });
 
   if (it == lockedCollTraceDump->pendingColls.end()) [[unlikely]] {
-    XLOG_FIRST_N(
-        ERR,
-        2,
-        "Could not find matching collRecord in pendingColls in CommDumpPlugin");
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 2)
+        << "Could not find matching collRecord in pendingColls in CommDumpPlugin";
     return folly::makeUnexpected(CommsError(
         "Could not find matching collRecord in pendingColls in CommDumpPlugin",
         commInternalError));
@@ -124,7 +127,8 @@ CommsMaybeVoid CommDumpPlugin::collEventProgressing(
 CommsMaybeVoid CommDumpPlugin::afterCollKernelEnd(
     CollTraceEvent& curEvent) noexcept {
   if (curEvent.collRecord == nullptr) [[unlikely]] {
-    XLOG_FIRST_N(ERR, 2, "Got event with null collRecord in CommDumpPlugin");
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 2)
+        << "Got event with null collRecord in CommDumpPlugin";
     return folly::makeUnexpected(CommsError(
         "CollTraceEvent does not contain valid record", commInternalError));
   }
@@ -136,7 +140,8 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelEnd(
       enqueuePendingColls(
           newPendingColls_,
           lockedCollTraceDump->pendingColls,
-          config_.pendingCollSize + 1));
+          config_.pendingCollSize + 1,
+          *logger_));
 
   // ----- Find and move from currentColls to pastColls -----
   auto it = std::find_if(
@@ -147,10 +152,8 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelEnd(
       });
 
   if (it == lockedCollTraceDump->currentColls.end()) [[unlikely]] {
-    XLOG_FIRST_N(
-        ERR,
-        2,
-        "Could not find matching collRecord in currentColls during coll end");
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 2)
+        << "Could not find matching collRecord in currentColls during coll end";
     return folly::makeUnexpected(CommsError(
         "Could not find matching collRecord in currentColls during coll end",
         commInternalError));
@@ -198,10 +201,8 @@ CommsMaybe<CollTraceDump> CommDumpPlugin::dump() noexcept {
         collTraceDump_.wlock(config_.dumpLockAcquireTimeout);
 
     if (lockedCollTraceDump.isNull()) {
-      XLOG_FIRST_N(
-          ERR,
-          2,
-          "Failed to acquire lock for collTraceDump_ in CommDumpPlugin dump");
+      COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 2)
+          << "Failed to acquire lock for collTraceDump_ in CommDumpPlugin dump";
       return folly::makeUnexpected(CommsError(
           "Failed to acquire lock for collTraceDump_ in CommDumpPlugin dump",
           commInternalError));
@@ -212,17 +213,16 @@ CommsMaybe<CollTraceDump> CommDumpPlugin::dump() noexcept {
         enqueuePendingColls(
             newPendingColls_,
             lockedCollTraceDump->pendingColls,
-            config_.pendingCollSize + 1));
+            config_.pendingCollSize + 1,
+            *logger_));
   }
 
   auto readLockedCollTraceDump =
       collTraceDump_.rlock(config_.dumpLockAcquireTimeout);
 
   if (readLockedCollTraceDump.isNull()) {
-    XLOG_FIRST_N(
-        ERR,
-        2,
-        "Failed to acquire read lock for collTraceDump_ in CommDumpPlugin dump");
+    COMMS_LOGGER_STREAM_FIRST_N(*logger_, ERR, 2)
+        << "Failed to acquire read lock for collTraceDump_ in CommDumpPlugin dump";
     return folly::makeUnexpected(CommsError(
         "Failed to acquire read lock for collTraceDump_ in CommDumpPlugin dump",
         commInternalError));

--- a/comms/utils/colltrace/plugins/CommDumpPlugin.h
+++ b/comms/utils/colltrace/plugins/CommDumpPlugin.h
@@ -5,6 +5,8 @@
 #include <deque>
 #include <memory>
 #include <queue>
+#include <string>
+#include <string_view>
 #include <unordered_set>
 #include <vector>
 
@@ -12,6 +14,10 @@
 #include <folly/Synchronized.h>
 
 #include "comms/utils/colltrace/CollTracePlugin.h"
+
+namespace meta::comms::logger {
+class CommsSpdlogLogger;
+}
 
 namespace meta::comms::colltrace {
 
@@ -26,6 +32,8 @@ struct CommDumpConfig {
   // Default timeout for waiting for the lock to be acquired for dump. We don't
   // want to block the dump thread if there is any issue with the lock.
   static constexpr auto kDumpLockAcquireTimeout = std::chrono::seconds(1);
+
+  std::string loggerName{"comms"};
 
   // Configures the size of the queue for past collective operations
   // (defaults to kDefaultPastQueueSize). They will be dumped as pastColls when
@@ -105,6 +113,7 @@ class CommDumpPlugin : public ICollTracePlugin {
   void evictPastColls(CollTraceDump& dump);
 
   CommDumpConfig config_;
+  logger::CommsSpdlogLogger* logger_{nullptr};
 
   folly::Synchronized<CollTraceDump> collTraceDump_;
 

--- a/comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.cc
+++ b/comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.cc
@@ -7,7 +7,8 @@
 #include <cstdint>
 
 #include <folly/Unit.h>
-#include <folly/logging/xlog.h>
+
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace meta::comms::colltrace {
 
@@ -20,8 +21,9 @@ constexpr uint32_t kBacklogCheckPeriod = 256;
 } // namespace
 
 LifecycleEventFeedPlugin::LifecycleEventFeedPlugin(
-    LifecycleEventFeedConfig config)
-    : commId_(config.commId) {}
+    const LifecycleEventFeedConfig& config)
+    : commId_(config.commId),
+      logger_(&logger::getSpdlogLogger(config.loggerName)) {}
 
 std::string_view LifecycleEventFeedPlugin::getName() const noexcept {
   return kLifecycleEventFeedPluginName;
@@ -118,7 +120,7 @@ CommsMaybeVoid LifecycleEventFeedPlugin::recordEvent(
   if (++backlogCheckCounter % kBacklogCheckPeriod == 0) {
     const auto backlog = unreadEvents_.size();
     if (backlog >= kBacklogWarningThreshold) [[unlikely]] {
-      XLOG_EVERY_MS(WARN, 60000)
+      COMMS_LOGGER_STREAM_EVERY_MS(*logger_, WARN, 60000)
           << "LifecycleEventFeedPlugin estimated unread backlog is " << backlog
           << " events for comm " << commId_
           << "; consumer may be stalled and memory will continue to grow";

--- a/comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.h
+++ b/comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.h
@@ -5,12 +5,17 @@
 #include <atomic>
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <vector>
 
 #include <folly/concurrency/UnboundedQueue.h>
 
 #include "comms/utils/colltrace/CollTracePlugin.h"
+
+namespace meta::comms::logger {
+class CommsSpdlogLogger;
+}
 
 namespace meta::comms::colltrace {
 
@@ -33,11 +38,13 @@ struct LifecycleEventRecord {
 
 struct LifecycleEventFeedConfig {
   uint64_t commId{0};
+  std::string loggerName{"comms"};
 };
 
 class LifecycleEventFeedPlugin : public ICollTracePlugin {
  public:
-  explicit LifecycleEventFeedPlugin(LifecycleEventFeedConfig config = {});
+  explicit LifecycleEventFeedPlugin(
+      const LifecycleEventFeedConfig& config = {});
 
   std::string_view getName() const noexcept override;
 
@@ -64,6 +71,7 @@ class LifecycleEventFeedPlugin : public ICollTracePlugin {
       LifecycleEventType eventType) noexcept;
 
   uint64_t commId_{0};
+  logger::CommsSpdlogLogger* logger_{nullptr};
   folly::UMPMCQueue<LifecycleEventRecord, false> unreadEvents_;
   std::atomic<uint64_t> latestCollId_{0};
 };

--- a/comms/utils/colltrace/plugins/WatchdogPlugin.cc
+++ b/comms/utils/colltrace/plugins/WatchdogPlugin.cc
@@ -2,9 +2,13 @@
 
 #include "comms/utils/colltrace/plugins/WatchdogPlugin.h"
 
+#include <string>
+#include <thread>
+
 #include <folly/Unit.h>
 #include <folly/json.h>
-#include <folly/logging/xlog.h>
+
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace meta::comms::colltrace {
 
@@ -24,12 +28,38 @@ std::string_view getCollectiveStateStr(CollTraceEvent& curEvent) {
   // This should not happen... Just for completeness
   return "Not Scheduled";
 }
+
+WatchdogPluginConfig normalizeWatchdogConfig(WatchdogPluginConfig config) {
+  if (!config.funcTriggerOnError) {
+    config.funcTriggerOnError =
+        [loggerName = std::string{config.loggerName}](CollTraceEvent& event) {
+          /* Give Analyzer time to collect the error state before aborting. */
+          // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+          std::this_thread::sleep_for(std::chrono::seconds(60));
+          logFatalError(event, "AsyncError", loggerName);
+        };
+  }
+  if (!config.funcTriggerOnTimeout) {
+    config.funcTriggerOnTimeout =
+        [loggerName = std::string{config.loggerName}](CollTraceEvent& event) {
+          logFatalError(event, "watchdog timeout", loggerName);
+        };
+  }
+  return config;
+}
 } // namespace
 
-void logFatalError(CollTraceEvent& curEvent, std::string_view errorType) {
-  auto metadataDynamic = curEvent.collRecord->toDynamic();
-  auto errorString = fmt::format(
-      "FatalError: Collective (OpCount={}, OpType={}, Count={}, DataType={} CurrentState={}) for Comm {} raised {}",
+[[noreturn]] void logFatalError(
+    CollTraceEvent& curEvent,
+    std::string_view errorType,
+    std::string_view loggerName) {
+  const auto metadataDynamic = curEvent.collRecord->toDynamic();
+  /*
+   * Watchdog diagnostics consume this marker from NCCL_DEBUG_FILE. Keep it in
+   * the payload because the owner logger's prefix is backend-specific.
+   */
+  const auto errorString = fmt::format(
+      "COMM FATAL: FatalError: Collective (OpCount={}, OpType={}, Count={}, DataType={} CurrentState={}) for Comm {} raised {}",
       metadataDynamic.getDefault("opCount", "Unknown").asString(),
       metadataDynamic.getDefault("opName", "Unknown").asString(),
       metadataDynamic.getDefault("count", "N/A").asString(),
@@ -37,40 +67,42 @@ void logFatalError(CollTraceEvent& curEvent, std::string_view errorType) {
       getCollectiveStateStr(curEvent),
       metadataDynamic.getDefault("commDesc", "Unknown").asString(),
       errorType);
-  XLOG(FATAL, errorString);
+  COMMS_LOG_NAMED(loggerName, FATAL, "{}", errorString);
 }
 
 WatchdogPlugin::WatchdogPlugin(WatchdogPluginConfig config)
-    : config_(std::move(config)) {}
+    : config_(normalizeWatchdogConfig(std::move(config))),
+      logger_(&logger::getSpdlogLogger(config_.loggerName)) {}
 
 std::string_view WatchdogPlugin::getName() const noexcept {
   return kWatchdogPluginName;
 }
 
 CommsMaybeVoid WatchdogPlugin::beforeCollKernelScheduled(
-    CollTraceEvent& curEvent) noexcept {
+    CollTraceEvent&) noexcept {
   return folly::unit;
 }
 
 CommsMaybeVoid WatchdogPlugin::afterCollKernelScheduled(
-    CollTraceEvent& curEvent) noexcept {
+    CollTraceEvent&) noexcept {
   return folly::unit;
 }
 
-CommsMaybeVoid WatchdogPlugin::afterCollKernelStart(
-    CollTraceEvent& curEvent) noexcept {
+CommsMaybeVoid WatchdogPlugin::afterCollKernelStart(CollTraceEvent&) noexcept {
   return folly::unit;
 }
 
 CommsMaybeVoid WatchdogPlugin::collEventProgressing(
     CollTraceEvent& curEvent) noexcept {
-  XLOGF(
-      DBG0,
+  COMMS_LOG_IMPL(
+      *logger_,
+      ::spdlog::level::debug,
+      COMMS_LOGGER_DEBUG,
       "WatchdogPlugin::collEventProgressing for CollTraceEvent {}",
       folly::toJson(curEvent.collRecord->toDynamic()));
 
   if (config_.checkAsyncError && config_.funcIfError()) {
-    XLOG(DBG)
+    COMMS_LOGGER_STREAM(*logger_, DBG)
         << "WatchdogPlugin::collEventProgressing: triggering async error handling";
 
     config_.funcTriggerOnError(curEvent);

--- a/comms/utils/colltrace/plugins/WatchdogPlugin.h
+++ b/comms/utils/colltrace/plugins/WatchdogPlugin.h
@@ -4,36 +4,40 @@
 
 #include "comms/utils/colltrace/CollTracePlugin.h"
 
-#include <thread>
+#include <string>
 #include <unordered_map>
 
 #include <folly/stop_watch.h>
 
+namespace meta::comms::logger {
+class CommsSpdlogLogger;
+}
+
 namespace meta::comms::colltrace {
 
-void logFatalError(CollTraceEvent& curEvent, std::string_view errorType);
+[[noreturn]] void logFatalError(
+    CollTraceEvent& curEvent,
+    std::string_view errorType,
+    std::string_view loggerName = "comms");
 
 struct WatchdogPluginConfig {
+  std::string loggerName{"comms"};
+  // Empty trigger callbacks are replaced by logger-aware defaults when the
+  // WatchdogPlugin is constructed.
   // Async error config
   bool checkAsyncError{true};
   std::function<bool(void)> funcIfError{[]() { return false; }};
-  std::function<void(CollTraceEvent&)> funcTriggerOnError{
-      [](CollTraceEvent& event) {
-        // Sleep for 60 seconds to allow Analyzer to collect the error.
-        std::this_thread::sleep_for(std::chrono::seconds(60));
-        logFatalError(event, "AsyncError");
-      }};
+  std::function<void(CollTraceEvent&)> funcTriggerOnError;
 
   // Timeout config
   bool checkTimeout{false};
   std::chrono::milliseconds timeout{std::chrono::minutes{10}};
-  std::function<void(CollTraceEvent&)> funcTriggerOnTimeout{
-      [](CollTraceEvent& event) { logFatalError(event, "watchdog timeout"); }};
+  std::function<void(CollTraceEvent&)> funcTriggerOnTimeout;
 };
 
 class WatchdogPlugin : public ICollTracePlugin {
  public:
-  WatchdogPlugin(WatchdogPluginConfig config);
+  explicit WatchdogPlugin(WatchdogPluginConfig config);
 
   std::string_view getName() const noexcept override;
 
@@ -55,6 +59,7 @@ class WatchdogPlugin : public ICollTracePlugin {
 
  private:
   const WatchdogPluginConfig config_;
+  logger::CommsSpdlogLogger* logger_{nullptr};
 
   // Per-event timeout tracking. Each in-flight event gets its own timer
   // so a stuck collective is detected even when others progress normally.

--- a/comms/utils/cvars/nccl_baseline_adapter.cc
+++ b/comms/utils/cvars/nccl_baseline_adapter.cc
@@ -8,20 +8,18 @@
 #include <cstring>
 #include <string>
 
-#include <cuda_runtime.h>
-
 #include <folly/String.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/utils/cvars/nccl_baseline_adapter.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
-#define NCCL_ADAPTER_INFO(fmt, ...)          \
-  XLOGF_IF(                                  \
-      INFO,                                  \
-      logNcclBaselineAdapterInfo,            \
-      "NcclBaselineAdapter INFO CVAR: " fmt, \
-      __VA_ARGS__);
+#define NCCL_ADAPTER_INFO(format, ...)                                        \
+  do {                                                                        \
+    if (logNcclBaselineAdapterInfo) {                                         \
+      COMMS_LOG(INFO, "NcclBaselineAdapter INFO CVAR: " format, __VA_ARGS__); \
+    }                                                                         \
+  } while (false)
 
 namespace nccl_baseline_adapter {
 int64_t ncclLoadParam(
@@ -90,9 +88,9 @@ int64_t ncclLoadParam(
     value = strtoll(strValue, &endptr, 0);
     if (errno || endptr == strValue) {
       value = deftVal;
-      XLOG(WARN) << "NcclBaselineAdapter WARN CVAR: Invalid value \""
-                 << strValue << "\" for CVAR " << env << ", using default \""
-                 << deftVal << "\".";
+      COMMS_LOG_STREAM(WARN)
+          << "NcclBaselineAdapter WARN CVAR: Invalid value \"" << strValue
+          << "\" for CVAR " << env << ", using default \"" << deftVal << "\".";
     } else {
       NCCL_ADAPTER_INFO(
           "{} set by string CVAR map to {}.", env, (long long)value);
@@ -103,7 +101,7 @@ int64_t ncclLoadParam(
   return value;
 }
 
-const char* ncclGetEnvImpl(const char* name) {
+const char* FOLLY_NULLABLE ncclGetEnvImpl(const char* name) {
   // Note: we omit the initEnv() call here (which is present in the baseline
   // NCCL implementation) because calling initEnv() breaks a large number of
   // unit tests. This is because the unit tests temporarily set values for

--- a/comms/utils/cvars/nccl_baseline_adapter.h
+++ b/comms/utils/cvars/nccl_baseline_adapter.h
@@ -9,6 +9,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <folly/CppAttributes.h>
+
 namespace nccl_baseline_adapter {
 
 /**
@@ -23,7 +25,7 @@ int64_t ncclLoadParam(
 /**
  * Load a string-based CVAR.
  */
-const char* ncclGetEnvImpl(const char* name);
+const char* FOLLY_NULLABLE ncclGetEnvImpl(const char* name);
 } // namespace nccl_baseline_adapter
 
 #endif // NCCL_BASELINE_ADAPTER_H_INCLUDED

--- a/comms/utils/cvars/nccl_cvars.cc.in
+++ b/comms/utils/cvars/nccl_cvars.cc.in
@@ -15,7 +15,8 @@
 #include <cuda_runtime.h>
 
 #include <folly/String.h>
-#include <folly/logging/xlog.h>
+
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #if defined(__HIP_PLATFORM_AMD__)
 static const std::string ncclConfigFileName = "rccl.conf";
@@ -35,19 +36,21 @@ static std::unordered_map<std::string, std::string>& nccl_config() {
 static void initEnvSet(std::unordered_set<std::string>& env);
 static void readCvarEnv();
 
-#define CVAR_INFO(fmt, ...)                 \
-  XLOGF_IF(                                 \
-      INFO,                                 \
-      logInfoLog,                           \
-      "[CudaDev: {}] NCCL INFO CVAR: " fmt, \
-      cudaDev,                              \
-      __VA_ARGS__);
+#define CVAR_INFO(format, ...)                                        \
+  do {                                                                \
+    if (logInfoLog) {                                                 \
+      COMMS_LOG(                                                      \
+          INFO, "[CudaDev: {}] NCCL INFO CVAR: " format, cudaDev, __VA_ARGS__); \
+    }                                                                 \
+  } while (false)
 
-#define CVAR_WARN(fmt, ...) \
-  XLOGF(WARN, "[CudaDev: {}] NCCL WARN CVAR: " fmt, cudaDev, __VA_ARGS__);
+#define CVAR_WARN(format, ...)                                        \
+  COMMS_LOG(                                                          \
+      WARN, "[CudaDev: {}] NCCL WARN CVAR: " format, cudaDev, __VA_ARGS__)
 
-#define CVAR_ERROR(fmt, ...) \
-  XLOGF(FATAL, "[CudaDev: {}] NCCL ERROR CVAR: " fmt, cudaDev, __VA_ARGS__);
+#define CVAR_ERROR(format, ...)                                       \
+  COMMS_LOG(                                                          \
+      FATAL, "[CudaDev: {}] NCCL ERROR CVAR: " format, cudaDev, __VA_ARGS__)
 
 #define CVAR_WARN_UNKNOWN_VALUE(name, value)               \
   do {                                                     \

--- a/comms/utils/logger/BackendTopologyUtil.cc
+++ b/comms/utils/logger/BackendTopologyUtil.cc
@@ -7,7 +7,8 @@
 #include <folly/FileUtil.h>
 #include <folly/MapUtil.h>
 #include <folly/String.h>
-#include <folly/logging/xlog.h>
+
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace {
 std::unordered_map<std::string, std::string> getKeyValuePairsFromFile(
@@ -15,7 +16,7 @@ std::unordered_map<std::string, std::string> getKeyValuePairsFromFile(
   std::unordered_map<std::string, std::string> keyValuePairs;
   std::string fileContents;
   if (!folly::readFile(fileName.c_str(), fileContents)) {
-    XLOG(ERR) << "Failed to read file: " << fileName;
+    COMMS_LOG_STREAM(ERR) << "Failed to read file: " << fileName;
     return keyValuePairs;
   }
 
@@ -28,7 +29,8 @@ std::unordered_map<std::string, std::string> getKeyValuePairsFromFile(
     std::vector<std::string> keyValuePair;
     folly::split('=', line, keyValuePair);
     if (keyValuePair.size() != 2) {
-      XLOG(ERR) << "Invalid line in file: " << fileName << ", line: " << line;
+      COMMS_LOG_STREAM(ERR)
+          << "Invalid line in file: " << fileName << ", line: " << line;
       continue;
     }
     keyValuePairs[keyValuePair[0]] = keyValuePair[1];
@@ -69,7 +71,8 @@ std::optional<BackendTopologyUtil::Topology>
 BackendTopologyUtil::getBackendTopology(const std::string& fileName) {
   auto keyValuePairs = getKeyValuePairsFromFile(fileName);
   if (keyValuePairs.empty()) {
-    XLOG(ERR) << "Failed to get backend topology from file: " << fileName;
+    COMMS_LOG_STREAM(ERR) << "Failed to get backend topology from file: "
+                          << fileName;
     return std::nullopt;
   }
 

--- a/comms/utils/logger/CudaLog.cc
+++ b/comms/utils/logger/CudaLog.cc
@@ -1,0 +1,98 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/CudaLog.h"
+
+#include <array>
+#include <cstdarg>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "comms/utils/logger/SpdlogLogger.h"
+
+namespace meta::comms::logger {
+namespace {
+
+spdlog::level::level_enum toSpdlogLevel(CudaLogLevel level) {
+  switch (level) {
+    case CudaLogLevel::DBG:
+      return spdlog::level::debug;
+    case CudaLogLevel::INFO:
+      return spdlog::level::info;
+    case CudaLogLevel::WARN:
+      return spdlog::level::warn;
+    case CudaLogLevel::ERR:
+      return spdlog::level::err;
+  }
+  return spdlog::level::off;
+}
+
+} // namespace
+
+CommsSpdlogLogger* tryGetSpdlogLoggerForCuda() noexcept {
+  try {
+    return &getSpdlogLogger();
+  } catch (...) {
+    reportCommsLoggingFailureToStderr("ERROR");
+    return nullptr;
+  }
+}
+
+bool shouldLogFromCuda(
+    const CommsSpdlogLogger& logger,
+    CudaLogLevel level) noexcept {
+  try {
+    return logger.should_log(toSpdlogLevel(level));
+  } catch (...) {
+    reportCommsLoggingFailureToStderr("ERROR");
+    return false;
+  }
+}
+
+void logFromCuda(
+    CommsSpdlogLogger& logger,
+    CudaLogLevel level,
+    const char* filename,
+    int line,
+    const char* function,
+    const char* format,
+    ...) noexcept {
+  try {
+    constexpr std::size_t kStackBufferSize = 512;
+    std::array<char, kStackBufferSize> stackBuffer{};
+    va_list args;
+    va_start(args, format);
+    const int required =
+        std::vsnprintf(stackBuffer.data(), stackBuffer.size(), format, args);
+    va_end(args);
+    if (required < 0) {
+      reportCommsLoggingFailureToStderr("ERROR");
+      return;
+    }
+
+    std::string message;
+    if (static_cast<std::size_t>(required) < stackBuffer.size()) {
+      message.assign(stackBuffer.data(), static_cast<std::size_t>(required));
+    } else {
+      std::vector<char> buffer(static_cast<std::size_t>(required) + 1);
+      va_start(args, format);
+      const int written =
+          std::vsnprintf(buffer.data(), buffer.size(), format, args);
+      va_end(args);
+      if (written != required) {
+        reportCommsLoggingFailureToStderr("ERROR");
+        return;
+      }
+      message.assign(buffer.data(), static_cast<std::size_t>(required));
+    }
+
+    logger.log(
+        spdlog::source_loc{filename, line, function},
+        toSpdlogLevel(level),
+        message);
+  } catch (...) {
+    reportCommsLoggingFailureToStderr("ERROR");
+  }
+}
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/CudaLog.h
+++ b/comms/utils/logger/CudaLog.h
@@ -1,0 +1,53 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+namespace meta::comms::logger {
+
+class CommsSpdlogLogger;
+
+enum class CudaLogLevel : unsigned char {
+  DBG,
+  INFO,
+  WARN,
+  ERR,
+};
+
+CommsSpdlogLogger* tryGetSpdlogLoggerForCuda() noexcept;
+
+bool shouldLogFromCuda(
+    const CommsSpdlogLogger& logger,
+    CudaLogLevel level) noexcept;
+
+void logFromCuda(
+    CommsSpdlogLogger& logger,
+    CudaLogLevel level,
+    const char* filename,
+    int line,
+    const char* function,
+    const char* format,
+    ...) noexcept __attribute__((format(printf, 6, 7)));
+
+} // namespace meta::comms::logger
+
+/*
+ * Keep this facade free of C++ standard-library and spdlog headers because
+ * cudafe parses it when compiling host logging statements in .cu files.
+ */
+#define COMMS_CUDA_LOG(level, ...)                          \
+  do {                                                      \
+    static auto* const _comms_cuda_logger =                 \
+        ::meta::comms::logger::tryGetSpdlogLoggerForCuda(); \
+    if (_comms_cuda_logger != nullptr &&                    \
+        ::meta::comms::logger::shouldLogFromCuda(           \
+            *_comms_cuda_logger,                            \
+            ::meta::comms::logger::CudaLogLevel::level)) {  \
+      ::meta::comms::logger::logFromCuda(                   \
+          *_comms_cuda_logger,                              \
+          ::meta::comms::logger::CudaLogLevel::level,       \
+          __FILE__,                                         \
+          __LINE__,                                         \
+          static_cast<const char*>(__FUNCTION__),           \
+          __VA_ARGS__);                                     \
+    }                                                       \
+  } while (false)

--- a/comms/utils/logger/DataSink.h
+++ b/comms/utils/logger/DataSink.h
@@ -7,7 +7,8 @@
 
 #include <folly/Optional.h>
 #include <folly/Range.h>
-#include <folly/logging/xlog.h>
+
+#include "comms/utils/logger/SpdlogLogger.h"
 
 /**
  * FB Infra is not fully in conda environment and we build NCCLX in conda
@@ -23,8 +24,8 @@
 class DataSink {
  public:
   explicit DataSink(folly::StringPiece dataset) {
-    XLOG(WARNING) << "Empty sink for dataset: " << dataset << ". "
-                  << "No logging will be done.";
+    COMMS_LOG_STREAM(WARN) << "Empty sink for dataset: " << dataset << ". "
+                           << "No logging will be done.";
   }
 
   size_t addRawData(

--- a/comms/utils/logger/DataTableWrapper.cc
+++ b/comms/utils/logger/DataTableWrapper.cc
@@ -6,9 +6,9 @@
 
 #include <folly/Singleton.h>
 #include <folly/String.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace {
 constexpr std::string_view k_nccl_memory_logging = "nccl_memory_logging";
@@ -36,15 +36,15 @@ DataTableAllTables createAllTables() {
     std::vector<std::string> tokens;
     folly::split(':', tableTypeName, tokens, true /* ignoreEmpty */);
     if (tokens.size() != 2) {
-      XLOG(ERR) << "Invalid table type and name: " << tableTypeName
-                << ". Ignoring";
+      COMMS_LOG_STREAM(ERR)
+          << "Invalid table type and name: " << tableTypeName << ". Ignoring";
       continue;
     }
     auto& tableType = tokens.at(0);
     auto& tableName = tokens.at(1);
     if (tableType != "pipe" && tableType != "scuba") {
-      XLOG(ERR) << "Invalid table type: " << tableType
-                << " for table: " << tableName << ". Ignoring";
+      COMMS_LOG_STREAM(ERR) << "Invalid table type: " << tableType
+                            << " for table: " << tableName << ". Ignoring";
       continue;
     }
 
@@ -88,7 +88,7 @@ void DataTableWrapper::addSample(NcclScubaSample sample) {
     table_ = folly::get_default(allTables->tables, tableName_, nullptr);
 
     if (!table_) {
-      XLOG(WARNING) << "Could not find table name: " << tableName_ << std::endl;
+      COMMS_LOG_STREAM(WARN) << "Could not find table name: " << tableName_;
     }
   });
 

--- a/comms/utils/logger/EventMgrHelperTypes.cc
+++ b/comms/utils/logger/EventMgrHelperTypes.cc
@@ -4,7 +4,8 @@
 
 #include <folly/String.h>
 #include <folly/json/json.h>
-#include <folly/logging/xlog.h>
+
+#include "comms/utils/logger/SpdlogLogger.h"
 
 void EventGlobalRankFilter::initialize(
     const std::vector<std::string>& rankListCvar,
@@ -14,7 +15,7 @@ void EventGlobalRankFilter::initialize(
 
   // If the rank list is empty, then allow all ranks.
   if (rankListCvar.empty()) {
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Empty rank list, skip {} initialization. isAllowed: {}",
         filterName_,
@@ -28,13 +29,13 @@ void EventGlobalRankFilter::initialize(
     try {
       globalRank_ = std::stoi(std::string(rankEnv));
     } catch (const std::exception& e) {
-      XLOGF(WARN, "Invalid RANK env: {}, error: {}", rankEnv, e.what());
+      COMMS_LOG(WARN, "Invalid RANK env: {}, error: {}", rankEnv, e.what());
       // Do not throw exception here, just skip this invalid RANK env.
     }
   }
 
   if (globalRank_ < 0) {
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Cannot get global rank, skip {} initialization. isAllowed: {}",
         filterName_,
@@ -53,12 +54,12 @@ void EventGlobalRankFilter::initialize(
         break;
       }
     } catch (const std::exception& e) {
-      XLOGF(WARN, "Invalid rank string: {}, error: {}", rankStr, e.what());
+      COMMS_LOG(WARN, "Invalid rank string: {}, error: {}", rankStr, e.what());
       // Do not throw exception here, just skip this invalid rank string.
     }
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Initialized {}, globalRank: {}, isAllowed: {}",
       filterName_,

--- a/comms/utils/logger/LogUtils.cc
+++ b/comms/utils/logger/LogUtils.cc
@@ -16,8 +16,6 @@ namespace {
 folly::once_flag commLoggingInitOnceFlag;
 
 void initCommLoggingImpl() {
-  setSubSystemMask(
-      meta::comms::logger::parseDebugSubsysMask(NCCL_DEBUG_SUBSYS.c_str()));
   NcclLogger::init(
       NcclLoggerInitConfig{
           .contextName = std::string{kCommsUtilsCategory},

--- a/comms/utils/logger/Logger.cc
+++ b/comms/utils/logger/Logger.cc
@@ -10,6 +10,7 @@
 #include <folly/logging/xlog.h>
 
 #include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
+#include "comms/utils/logger/LoggerRuntime.h"
 #include "comms/utils/logger/LoggingFormat.h"
 #include "comms/utils/logger/NcclWriterWrapper.h"
 #include "comms/utils/logger/ScubaLogger.h"
@@ -28,7 +29,7 @@ std::string getHandlerNameWithCategory(
 void NcclLogger::init(const NcclLoggerInitConfig& config) {
   if (!firstInit_.test_and_set()) {
     folly::initLoggingOrDie();
-    DataTableWrapper::init();
+    meta::comms::logger::initCommLoggerRuntime();
     NcclLogFormatterFactory::registerThreadContextFn(
         config.logPrefix, config.threadContextFn);
     NcclLogger::registerHandler(
@@ -86,7 +87,7 @@ void NcclLogger::close() noexcept {
     NcclLogHandlerFactory::close();
     firstInit_.clear();
   }
-  DataTableWrapper::shutdown();
+  meta::comms::logger::shutdownCommLoggerRuntime();
 }
 
 std::shared_ptr<folly::LogWriter>

--- a/comms/utils/logger/LoggerRuntime.cc
+++ b/comms/utils/logger/LoggerRuntime.cc
@@ -1,0 +1,49 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/LoggerRuntime.h"
+
+#include <mutex>
+
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/DataTableWrapper.h"
+#include "comms/utils/logger/LoggingFormat.h"
+
+namespace meta::comms::logger {
+namespace {
+
+struct RuntimeState {
+  std::mutex mutex;
+  bool initialized{false};
+};
+
+RuntimeState& getRuntimeState() {
+  static RuntimeState state;
+  return state;
+}
+
+} // namespace
+
+void initCommLoggerRuntime() {
+  auto& state = getRuntimeState();
+  std::lock_guard lock{state.mutex};
+  if (state.initialized) {
+    return;
+  }
+
+  setSubSystemMask(parseDebugSubsysMask(NCCL_DEBUG_SUBSYS.c_str()));
+  DataTableWrapper::init();
+  state.initialized = true;
+}
+
+void shutdownCommLoggerRuntime() {
+  auto& state = getRuntimeState();
+  std::lock_guard lock{state.mutex};
+  if (!state.initialized) {
+    return;
+  }
+
+  DataTableWrapper::shutdown();
+  state.initialized = false;
+}
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/LoggerRuntime.h
+++ b/comms/utils/logger/LoggerRuntime.h
@@ -1,0 +1,12 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+namespace meta::comms::logger {
+
+// Initializes process-global logging state once. Calls before shutdown keep the
+// subsystem mask and structured-event configuration from the first call.
+void initCommLoggerRuntime();
+void shutdownCommLoggerRuntime();
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/LoggingFormat.h
+++ b/comms/utils/logger/LoggingFormat.h
@@ -13,6 +13,7 @@
 
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/logger/LogTypes.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace meta::comms::logger {
 
@@ -80,10 +81,17 @@ class NcclLogFormatter : public folly::LogFormatter {
 
 } // namespace meta::comms::logger
 
+#define COMMS_ERR(code, ...)                                                  \
+  do {                                                                        \
+    const auto _comms_error_message = fmt::format(__VA_ARGS__);               \
+    COMMS_LOG(ERR, "{}", _comms_error_message);                               \
+    ::meta::comms::logger::logCommErrorToScuba((code), _comms_error_message); \
+  } while (false)
+
 #define COMMS_NAMED_THREAD_START_EXT(threadName, rank, commHash, commDesc)                \
   do {                                                                                    \
     meta::comms::logger::initThreadMetaData(threadName);                                  \
-    XLOGF(                                                                                \
+    COMMS_LOG(                                                                            \
         INFO,                                                                             \
         "[COMMS THREAD] Starting {} thread for rank {} commHash {:#x} commDesc {} at {}", \
         threadName,                                                                       \

--- a/comms/utils/logger/ScubaFileUtils.cc
+++ b/comms/utils/logger/ScubaFileUtils.cc
@@ -6,10 +6,10 @@
 #include <filesystem>
 
 #include <fmt/format.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/utils/RankUtils.h"
 #include "comms/utils/StrUtils.h"
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace comms::logger {
 
@@ -36,8 +36,8 @@ std::optional<folly::File> createScubaFile(
     int flags = O_CREAT | O_WRONLY | (appendMode ? O_APPEND : 0);
     return folly::File(fileName, flags, 0644);
   } catch (const std::exception& e) {
-    XLOG(WARNING) << "Failed to create scuba file " << fileName << ": "
-                  << e.what();
+    COMMS_LOG_STREAM(WARN) << "Failed to create scuba file " << fileName << ": "
+                           << e.what();
   }
   return std::nullopt;
 }

--- a/comms/utils/logger/ScubaLogger.cc
+++ b/comms/utils/logger/ScubaLogger.cc
@@ -4,7 +4,7 @@
 
 #include <chrono>
 
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 DataTableWrapper* getTablePtrFromEvent(LoggerEventType event) {
   switch (event) {
@@ -25,7 +25,7 @@ DataTableWrapper* getTablePtrFromEvent(LoggerEventType event) {
     case LoggerEventType::CommEventType:
       return SCUBA_nccl_structured_logging_ptr.get();
     default:
-      XLOG(ERR) << "Invalid event type";
+      COMMS_LOG_STREAM(ERR) << "Invalid event type";
       break;
   }
   throw std::runtime_error("Invalid event type");

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <chrono>
 #include <cstddef>
+#include <cstdio>
 #include <cstring>
 #include <map>
 #include <memory>
@@ -27,6 +28,16 @@
 
 namespace meta::comms::logger {
 
+void reportCommsLoggingFailureToStderr(const char* level) noexcept {
+  std::fprintf(stderr, "%s: communications logging failed\n", level);
+  std::fflush(stderr);
+}
+
+[[noreturn]] void abortAfterCommsLoggingFailure() noexcept {
+  reportCommsLoggingFailureToStderr("FATAL");
+  std::abort();
+}
+
 spdlog::level::level_enum loggerLevelToSpdlogLevel(LogLevel level) {
   switch (level) {
     case LogLevel::NONE:
@@ -46,7 +57,6 @@ spdlog::level::level_enum loggerLevelToSpdlogLevel(LogLevel level) {
 }
 namespace {
 
-constexpr std::string_view kLoggerName = "comms";
 constexpr size_t kAsyncQueueSize = 8192;
 constexpr size_t kAsyncThreadCount = 1;
 /*
@@ -243,7 +253,7 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage) {
 }
 
 CommsSpdlogLogger::CommsSpdlogLogger()
-    : CommsSpdlogLogger(std::string{kLoggerName}) {}
+    : CommsSpdlogLogger(std::string{kCommsLoggerName}) {}
 
 CommsSpdlogLogger::CommsSpdlogLogger(std::string name)
     : logger_(createLogger(std::move(name))),
@@ -254,6 +264,54 @@ CommsSpdlogLogger::CommsSpdlogLogger(std::string name)
       std::make_shared<spdlog::logger>(logger_->name(), outputSink_);
   synchronousLogger_->set_level(spdlog::level::trace);
   storeConfiguration(std::make_shared<const Configuration>());
+}
+
+CommsLogStreamBase::CommsLogStreamBase(
+    CommsSpdlogLogger& logger,
+    spdlog::source_loc location,
+    spdlog::level::level_enum level)
+    : logger_(logger), location_(location), level_(level) {}
+
+std::ostream& CommsLogStreamBase::stream() {
+  return stream_;
+}
+
+void CommsLogStreamBase::log() {
+  logger_.log(location_, level_, stream_.str());
+}
+
+[[noreturn]] void CommsLogStreamBase::logFatalAndAbort() noexcept {
+  try {
+    logger_.flush();
+    spdlog::shutdown();
+    logger_.logFatal(location_, stream_.str());
+  } catch (...) {
+    abortAfterCommsLoggingFailure();
+  }
+  std::abort();
+}
+
+CommsLogStream::CommsLogStream(
+    CommsSpdlogLogger& logger,
+    spdlog::source_loc location,
+    spdlog::level::level_enum level)
+    : CommsLogStreamBase(logger, location, level) {}
+
+CommsLogStream::~CommsLogStream() noexcept {
+  try {
+    log();
+  } catch (...) {
+    reportCommsLoggingFailureToStderr("ERROR");
+  }
+}
+
+CommsFatalLogStream::CommsFatalLogStream(
+    CommsSpdlogLogger& logger,
+    spdlog::source_loc location)
+    : CommsLogStreamBase(logger, location, spdlog::level::critical) {}
+
+[[noreturn]] CommsFatalLogStream::~CommsFatalLogStream() noexcept {
+  logFatalAndAbort();
 }
 
 std::string_view CommsSpdlogLogger::getLevelName(
@@ -428,7 +486,7 @@ CommsSpdlogLogger& getSpdlogLogger() {
 }
 
 CommsSpdlogLogger& getSpdlogLogger(std::string_view loggerName) {
-  if (loggerName == kLoggerName) {
+  if (loggerName == kCommsLoggerName) {
     return getSpdlogLogger();
   }
   static std::shared_mutex mutex;
@@ -448,6 +506,15 @@ CommsSpdlogLogger& getSpdlogLogger(std::string_view loggerName) {
   auto logger = std::make_unique<CommsSpdlogLogger>(name);
   const auto it = loggers.emplace(std::move(name), std::move(logger)).first;
   return *it->second;
+}
+
+CommsSpdlogLogger& getSpdlogLoggerForFatal(
+    std::string_view loggerName) noexcept {
+  try {
+    return getSpdlogLogger(loggerName);
+  } catch (...) {
+    abortAfterCommsLoggingFailure();
+  }
 }
 
 void configureSpdlogLogger(
@@ -470,6 +537,38 @@ void configureSpdlogLogger(
       std::move(errorCallback),
       asyncLogging);
   logger.configureOutput(logFilePath);
+}
+
+void configureCommsAndNamedSpdlogLoggers(
+    std::string_view loggerName,
+    std::string logPrefix,
+    std::string_view logFilePath,
+    std::function<int(void)> threadContextFn,
+    std::function<void(std::string_view)> errorCallback,
+    bool asyncLogging,
+    spdlog::level::level_enum logLevel,
+    bool configureCommsLogger) {
+  if (configureCommsLogger || loggerName == kCommsLoggerName) {
+    configureSpdlogLogger(
+        kCommsLoggerName,
+        "COMM",
+        logFilePath,
+        threadContextFn,
+        errorCallback,
+        asyncLogging);
+    getSpdlogLogger().set_level(logLevel);
+  }
+
+  if (loggerName != kCommsLoggerName) {
+    configureSpdlogLogger(
+        loggerName,
+        std::move(logPrefix),
+        logFilePath,
+        std::move(threadContextFn),
+        std::move(errorCallback),
+        asyncLogging);
+    getSpdlogLogger(loggerName).set_level(logLevel);
+  }
 }
 
 void setSpdlogThreadName(std::string_view name) {

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -3,9 +3,12 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <cstdlib>
 #include <functional>
 #include <memory>
+#include <ostream>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -22,8 +25,11 @@
 #include <spdlog/spdlog.h>
 
 #include "comms/utils/logger/LogTypes.h"
+#include "comms/utils/logger/RateLimit.h"
 
 namespace meta::comms::logger {
+
+inline constexpr std::string_view kCommsLoggerName{"comms"};
 
 class CommsSpdlogLogger {
  public:
@@ -137,8 +143,57 @@ class CommsSpdlogLogger {
   ConfigurationStorage configuration_;
 };
 
+class CommsLogStreamBase {
+ public:
+  std::ostream& stream();
+
+ protected:
+  CommsLogStreamBase(
+      CommsSpdlogLogger& logger,
+      spdlog::source_loc location,
+      spdlog::level::level_enum level);
+  ~CommsLogStreamBase() = default;
+
+  void log();
+  [[noreturn]] void logFatalAndAbort() noexcept;
+
+ private:
+  CommsSpdlogLogger& logger_;
+  spdlog::source_loc location_;
+  spdlog::level::level_enum level_;
+  std::ostringstream stream_;
+};
+
+class CommsLogStream final : public CommsLogStreamBase {
+ public:
+  CommsLogStream(
+      CommsSpdlogLogger& logger,
+      spdlog::source_loc location,
+      spdlog::level::level_enum level);
+  ~CommsLogStream() noexcept;
+  CommsLogStream(const CommsLogStream&) = delete;
+  CommsLogStream& operator=(const CommsLogStream&) = delete;
+  CommsLogStream(CommsLogStream&&) = delete;
+  CommsLogStream& operator=(CommsLogStream&&) = delete;
+};
+
+class CommsFatalLogStream final : public CommsLogStreamBase {
+ public:
+  CommsFatalLogStream(CommsSpdlogLogger& logger, spdlog::source_loc location);
+  [[noreturn]] ~CommsFatalLogStream() noexcept;
+  CommsFatalLogStream(const CommsFatalLogStream&) = delete;
+  CommsFatalLogStream& operator=(const CommsFatalLogStream&) = delete;
+  CommsFatalLogStream(CommsFatalLogStream&&) = delete;
+  CommsFatalLogStream& operator=(CommsFatalLogStream&&) = delete;
+};
+
 CommsSpdlogLogger& getSpdlogLogger();
 CommsSpdlogLogger& getSpdlogLogger(std::string_view loggerName);
+
+void reportCommsLoggingFailureToStderr(const char* level) noexcept;
+[[noreturn]] void abortAfterCommsLoggingFailure() noexcept;
+CommsSpdlogLogger& getSpdlogLoggerForFatal(
+    std::string_view loggerName) noexcept;
 
 spdlog::level::level_enum loggerLevelToSpdlogLevel(LogLevel level);
 
@@ -153,6 +208,16 @@ void configureSpdlogLogger(
     std::function<int(void)> threadContextFn,
     std::function<void(std::string_view)> errorCallback,
     bool asyncLogging = true);
+
+void configureCommsAndNamedSpdlogLoggers(
+    std::string_view loggerName,
+    std::string logPrefix,
+    std::string_view logFilePath,
+    std::function<int(void)> threadContextFn,
+    std::function<void(std::string_view)> errorCallback,
+    bool asyncLogging,
+    spdlog::level::level_enum logLevel,
+    bool configureCommsLogger = true);
 
 void setSpdlogThreadName(std::string_view threadName);
 
@@ -176,15 +241,19 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
  * CommsSpdlogLogger owns that synchronous logger and its output sinks outside
  * spdlog's registry, so they remain valid after registry shutdown.
  */
-#define COMMS_LOG_FATAL_IMPL(logger_expression, ...)               \
-  do {                                                             \
-    auto& _comms_logger = (logger_expression);                     \
-    _comms_logger.flush();                                         \
-    ::spdlog::shutdown();                                          \
-    _comms_logger.logFatal(                                        \
-        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, \
-        __VA_ARGS__);                                              \
-    std::abort();                                                  \
+#define COMMS_LOG_FATAL_IMPL(logger_expression, ...)                 \
+  do {                                                               \
+    try {                                                            \
+      auto& _comms_logger = (logger_expression);                     \
+      _comms_logger.flush();                                         \
+      ::spdlog::shutdown();                                          \
+      _comms_logger.logFatal(                                        \
+          ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, \
+          __VA_ARGS__);                                              \
+    } catch (...) {                                                  \
+      ::meta::comms::logger::abortAfterCommsLoggingFailure();        \
+    }                                                                \
+    std::abort();                                                    \
   } while (false)
 
 #define COMMS_LOG_DBG(...)                      \
@@ -258,3 +327,146 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
 #define COMMS_LOG(level, ...) COMMS_LOG_##level(__VA_ARGS__)
 #define COMMS_LOG_NAMED(logger_name, level, ...) \
   COMMS_LOG_NAMED_##level(logger_name, __VA_ARGS__)
+
+#define COMMS_LOG_NAMED_STREAM_IMPL(logger_name, spdlog_level, condition) \
+  if (static auto& _comms_stream_logger =                                 \
+          ::meta::comms::logger::getSpdlogLogger(logger_name);            \
+      !_comms_stream_logger.should_log(spdlog_level) || !(condition)) {   \
+  } else                                                                  \
+    ::meta::comms::logger::CommsLogStream(                                \
+        _comms_stream_logger,                                             \
+        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION},        \
+        spdlog_level)                                                     \
+        .stream()
+
+#define COMMS_LOG_NAMED_FATAL_STREAM_IMPL(logger_name, condition)      \
+  if (static auto& _comms_stream_logger =                              \
+          ::meta::comms::logger::getSpdlogLoggerForFatal(logger_name); \
+      !(condition)) {                                                  \
+  } else                                                               \
+    ::meta::comms::logger::CommsFatalLogStream(                        \
+        _comms_stream_logger,                                          \
+        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION})     \
+        .stream()
+
+#define COMMS_LOG_NAMED_STREAM_DBG_IF(logger_name, condition) \
+  COMMS_LOG_NAMED_STREAM_IMPL(logger_name, ::spdlog::level::debug, condition)
+#define COMMS_LOG_NAMED_STREAM_DBG5_IF(logger_name, condition) \
+  COMMS_LOG_NAMED_STREAM_IMPL(logger_name, ::spdlog::level::trace, condition)
+#define COMMS_LOG_NAMED_STREAM_INFO_IF(logger_name, condition) \
+  COMMS_LOG_NAMED_STREAM_IMPL(logger_name, ::spdlog::level::info, condition)
+#define COMMS_LOG_NAMED_STREAM_WARN_IF(logger_name, condition) \
+  COMMS_LOG_NAMED_STREAM_IMPL(logger_name, ::spdlog::level::warn, condition)
+#define COMMS_LOG_NAMED_STREAM_WARNING_IF(logger_name, condition) \
+  COMMS_LOG_NAMED_STREAM_WARN_IF(logger_name, condition)
+#define COMMS_LOG_NAMED_STREAM_ERR_IF(logger_name, condition) \
+  COMMS_LOG_NAMED_STREAM_IMPL(logger_name, ::spdlog::level::err, condition)
+#define COMMS_LOG_NAMED_STREAM_CRITICAL_IF(logger_name, condition) \
+  COMMS_LOG_NAMED_STREAM_IMPL(logger_name, ::spdlog::level::critical, condition)
+#define COMMS_LOG_NAMED_STREAM_FATAL_IF(logger_name, condition) \
+  COMMS_LOG_NAMED_FATAL_STREAM_IMPL(logger_name, condition)
+
+#define COMMS_LOG_NAMED_STREAM_IF_IMPL(logger_name, level, condition) \
+  COMMS_LOG_NAMED_STREAM_##level##_IF(logger_name, condition)
+#define COMMS_LOG_NAMED_STREAM_IF(logger_name, level, condition) \
+  COMMS_LOG_NAMED_STREAM_IF_IMPL(logger_name, level, condition)
+#define COMMS_LOG_NAMED_STREAM(logger_name, level) \
+  COMMS_LOG_NAMED_STREAM_IF(logger_name, level, true)
+#define COMMS_LOG_STREAM(level) \
+  COMMS_LOG_NAMED_STREAM(::meta::comms::logger::kCommsLoggerName, level)
+
+#define COMMS_LOG_RATE_LIMITABLE_DBG true
+#define COMMS_LOG_RATE_LIMITABLE_DBG5 true
+#define COMMS_LOG_RATE_LIMITABLE_INFO true
+#define COMMS_LOG_RATE_LIMITABLE_WARN true
+#define COMMS_LOG_RATE_LIMITABLE_WARNING true
+#define COMMS_LOG_RATE_LIMITABLE_ERR true
+#define COMMS_LOG_RATE_LIMITABLE_CRITICAL true
+#define COMMS_LOG_RATE_LIMITABLE_FATAL false
+
+/*
+ * The interval is fixed on first use at each expansion site. Disabled levels
+ * do not consume the rate-limit budget.
+ */
+#define COMMS_LOG_NAMED_STREAM_EVERY_MS(logger_name, level, ms)            \
+  COMMS_LOG_NAMED_STREAM_IF(                                               \
+      logger_name, level, [_comms_log_stream_every_ms = (ms)] {            \
+        static_assert(                                                     \
+            COMMS_LOG_RATE_LIMITABLE_##level,                              \
+            "FATAL logging cannot be rate limited");                       \
+        static ::meta::comms::logger::IntervalRateLimiter                  \
+            comms_log_stream_rate_limiter(                                 \
+                1, std::chrono::milliseconds(_comms_log_stream_every_ms)); \
+        return comms_log_stream_rate_limiter.check();                      \
+      }())
+#define COMMS_LOG_STREAM_EVERY_MS(level, ms) \
+  COMMS_LOG_NAMED_STREAM_EVERY_MS(           \
+      ::meta::comms::logger::kCommsLoggerName, level, ms)
+
+#define COMMS_LOGGER_STREAM_IMPL(logger_expression, spdlog_level, condition) \
+  if (auto& _comms_stream_logger = (logger_expression);                      \
+      !_comms_stream_logger.should_log(spdlog_level) || !(condition)) {      \
+  } else                                                                     \
+    ::meta::comms::logger::CommsLogStream(                                   \
+        _comms_stream_logger,                                                \
+        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION},           \
+        spdlog_level)                                                        \
+        .stream()
+
+#define COMMS_LOGGER_FATAL_STREAM_IMPL(logger_expression, condition)    \
+  if (auto& _comms_stream_logger = (logger_expression); !(condition)) { \
+  } else                                                                \
+    ::meta::comms::logger::CommsFatalLogStream(                         \
+        _comms_stream_logger,                                           \
+        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION})      \
+        .stream()
+
+#define COMMS_LOGGER_STREAM_DBG_IF(logger_expression, condition) \
+  COMMS_LOGGER_STREAM_IMPL(logger_expression, ::spdlog::level::debug, condition)
+#define COMMS_LOGGER_STREAM_DBG5_IF(logger_expression, condition) \
+  COMMS_LOGGER_STREAM_IMPL(logger_expression, ::spdlog::level::trace, condition)
+#define COMMS_LOGGER_STREAM_INFO_IF(logger_expression, condition) \
+  COMMS_LOGGER_STREAM_IMPL(logger_expression, ::spdlog::level::info, condition)
+#define COMMS_LOGGER_STREAM_WARN_IF(logger_expression, condition) \
+  COMMS_LOGGER_STREAM_IMPL(logger_expression, ::spdlog::level::warn, condition)
+#define COMMS_LOGGER_STREAM_WARNING_IF(logger_expression, condition) \
+  COMMS_LOGGER_STREAM_WARN_IF(logger_expression, condition)
+#define COMMS_LOGGER_STREAM_ERR_IF(logger_expression, condition) \
+  COMMS_LOGGER_STREAM_IMPL(logger_expression, ::spdlog::level::err, condition)
+#define COMMS_LOGGER_STREAM_CRITICAL_IF(logger_expression, condition) \
+  COMMS_LOGGER_STREAM_IMPL(                                           \
+      logger_expression, ::spdlog::level::critical, condition)
+#define COMMS_LOGGER_STREAM_FATAL_IF(logger_expression, condition) \
+  COMMS_LOGGER_FATAL_STREAM_IMPL(logger_expression, condition)
+
+#define COMMS_LOGGER_STREAM_IF_IMPL(logger_expression, level, condition) \
+  COMMS_LOGGER_STREAM_##level##_IF(logger_expression, condition)
+#define COMMS_LOGGER_STREAM_IF(logger_expression, level, condition) \
+  COMMS_LOGGER_STREAM_IF_IMPL(logger_expression, level, condition)
+#define COMMS_LOGGER_STREAM(logger_expression, level) \
+  COMMS_LOGGER_STREAM_IF(logger_expression, level, true)
+
+#define COMMS_LOGGER_STREAM_EVERY_MS(logger_expression, level, ms)            \
+  COMMS_LOGGER_STREAM_IF(                                                     \
+      logger_expression, level, [_comms_logger_stream_every_ms = (ms)] {      \
+        static_assert(                                                        \
+            COMMS_LOG_RATE_LIMITABLE_##level,                                 \
+            "FATAL logging cannot be rate limited");                          \
+        static ::meta::comms::logger::IntervalRateLimiter                     \
+            comms_logger_stream_rate_limiter(                                 \
+                1, std::chrono::milliseconds(_comms_logger_stream_every_ms)); \
+        return comms_logger_stream_rate_limiter.check();                      \
+      }())
+
+#define COMMS_LOGGER_STREAM_FIRST_N(logger_expression, level, n)              \
+  COMMS_LOGGER_STREAM_IF(logger_expression, level, [&] {                      \
+    static_assert(                                                            \
+        COMMS_LOG_RATE_LIMITABLE_##level, "FATAL logging cannot be sampled"); \
+    struct comms_logger_stream_first_n_tag {};                                \
+    return ::meta::comms::logger::firstNExact<                                \
+        comms_logger_stream_first_n_tag>(n);                                  \
+  }())
+
+#define COMMS_LOG_STREAM_FIRST_N(level, n) \
+  COMMS_LOGGER_STREAM_FIRST_N(             \
+      ::meta::comms::logger::getSpdlogLogger(), level, n)

--- a/comms/utils/logger/tests/LoggerRuntimeUT.cc
+++ b/comms/utils/logger/tests/LoggerRuntimeUT.cc
@@ -1,0 +1,62 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/LoggerRuntime.h"
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/DataTableWrapper.h"
+#include "comms/utils/logger/LogTypes.h"
+
+namespace meta::comms::logger {
+namespace {
+
+class LoggerRuntimeTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    originalDebugSubsys_ = NCCL_DEBUG_SUBSYS;
+    shutdownCommLoggerRuntime();
+  }
+
+  void TearDown() override {
+    shutdownCommLoggerRuntime();
+    NCCL_DEBUG_SUBSYS = originalDebugSubsys_;
+  }
+
+ private:
+  std::string originalDebugSubsys_;
+};
+
+TEST_F(LoggerRuntimeTest, ShutdownBeforeInitializationIsNoOp) {
+  shutdownCommLoggerRuntime();
+
+  EXPECT_EQ(SCUBA_nccl_structured_logging_ptr, nullptr);
+  EXPECT_EQ(SCUBA_nccl_error_logging_ptr, nullptr);
+}
+
+TEST_F(LoggerRuntimeTest, OwnsSharedStateLifecycle) {
+  NCCL_DEBUG_SUBSYS = "INIT";
+  initCommLoggerRuntime();
+
+  EXPECT_TRUE(isEnabledSubSystemBitwise(INIT));
+  EXPECT_FALSE(isEnabledSubSystemBitwise(COLL));
+  ASSERT_NE(SCUBA_nccl_structured_logging_ptr, nullptr);
+  ASSERT_NE(SCUBA_nccl_error_logging_ptr, nullptr);
+
+  NCCL_DEBUG_SUBSYS = "COLL";
+  initCommLoggerRuntime();
+  EXPECT_TRUE(isEnabledSubSystemBitwise(INIT));
+  EXPECT_FALSE(isEnabledSubSystemBitwise(COLL));
+
+  shutdownCommLoggerRuntime();
+  initCommLoggerRuntime();
+  EXPECT_FALSE(isEnabledSubSystemBitwise(INIT));
+  EXPECT_TRUE(isEnabledSubSystemBitwise(COLL));
+  ASSERT_NE(SCUBA_nccl_structured_logging_ptr, nullptr);
+  ASSERT_NE(SCUBA_nccl_error_logging_ptr, nullptr);
+}
+
+} // namespace
+} // namespace meta::comms::logger

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -17,6 +17,8 @@
 
 #include <gtest/gtest.h>
 
+#include "comms/utils/logger/CudaLog.h"
+
 using meta::comms::logger::getSpdlogLogger;
 
 class ScopedTestFile {
@@ -67,7 +69,13 @@ bool waitForFileToContain(
 class LogLevelRestoringTest : public testing::Test {
  protected:
   void TearDown() override {
-    getSpdlogLogger().set_level(spdlog::level::info);
+    const auto resetLogger = [](auto& logger, std::string prefix) {
+      logger.configure(std::move(prefix), []() { return 0; }, {}, false);
+      logger.set_level(spdlog::level::info);
+    };
+    resetLogger(getSpdlogLogger(), "COMMS");
+    resetLogger(getSpdlogLogger("comms.paired_test"), "PAIRED");
+    resetLogger(getSpdlogLogger("comms.named_only_test"), "NAMED_ONLY");
   }
 };
 
@@ -81,6 +89,60 @@ TEST(SpdlogLoggerTest, ReturnsStableLoggerPerContext) {
   EXPECT_EQ(&ctranLogger, &getSpdlogLogger("comms.ctran"));
   EXPECT_NE(&ctranLogger, &getSpdlogLogger("comms.ncclx"));
   EXPECT_EQ(ctranLogger.name(), "comms.ctran");
+}
+
+TEST(SpdlogLoggerTest, SupportsLoggerExpressionDbg5Stream) {
+  auto& logger = getSpdlogLogger("comms.dbg5_stream_test");
+  logger.set_level(spdlog::level::off);
+
+  COMMS_LOGGER_STREAM(logger, DBG5) << "suppressed trace message";
+}
+
+TEST_F(LogLevelRestoringTest, ConfiguresSharedAndNamedLoggersTogether) {
+  constexpr std::string_view kNamedLoggerName{"comms.paired_test"};
+  std::vector<std::string> errors;
+
+  meta::comms::logger::configureCommsAndNamedSpdlogLoggers(
+      kNamedLoggerName,
+      "NAMED",
+      "",
+      []() { return 0; },
+      [&](std::string_view message) { errors.emplace_back(message); },
+      false,
+      spdlog::level::err);
+
+  COMMS_LOG(ERR, "shared error");
+  COMMS_LOG_NAMED(kNamedLoggerName, ERR, "named error");
+
+  EXPECT_EQ(errors, (std::vector<std::string>{"shared error", "named error"}));
+}
+
+TEST_F(LogLevelRestoringTest, ConfiguresOnlyNamedLoggerWhenRequested) {
+  constexpr std::string_view kNamedLoggerName{"comms.named_only_test"};
+  std::vector<std::string> sharedErrors;
+  std::vector<std::string> namedErrors;
+  getSpdlogLogger().configure(
+      "SHARED",
+      []() { return 0; },
+      [&](std::string_view message) { sharedErrors.emplace_back(message); },
+      false);
+  getSpdlogLogger().set_level(spdlog::level::err);
+
+  meta::comms::logger::configureCommsAndNamedSpdlogLoggers(
+      kNamedLoggerName,
+      "NAMED_ONLY",
+      "",
+      []() { return 0; },
+      [&](std::string_view message) { namedErrors.emplace_back(message); },
+      false,
+      spdlog::level::err,
+      false);
+
+  COMMS_LOG(ERR, "shared error");
+  COMMS_LOG_NAMED(kNamedLoggerName, ERR, "named error");
+
+  EXPECT_EQ(sharedErrors, (std::vector<std::string>{"shared error"}));
+  EXPECT_EQ(namedErrors, (std::vector<std::string>{"named error"}));
 }
 
 TEST(SpdlogLoggerTest, MatchesLegacyStderrRouting) {
@@ -218,6 +280,31 @@ TEST_F(LogLevelRestoringTest, RuntimeGateSkipsArguments) {
 
   COMMS_LOG(WARN, "enabled at runtime: {}", ++evaluationCount);
   EXPECT_EQ(evaluationCount, 1);
+}
+
+TEST_F(LogLevelRestoringTest, CudaFacadeFormatsAndGatesMessages) {
+  const ScopedTestFile scopedLogFile{"comms_cuda_log.log"};
+  auto& logger = getSpdlogLogger();
+  logger.configureOutput(scopedLogFile.path().string());
+  logger.configure("TEST", []() { return 0; }, {}, false);
+  logger.set_level(spdlog::level::warn);
+
+  int evaluationCount = 0;
+  COMMS_CUDA_LOG(INFO, "filtered value %d", ++evaluationCount);
+  COMMS_CUDA_LOG(WARN, "cuda facade value %d", 7);
+  const std::string largeMessage(600, 'x');
+  COMMS_CUDA_LOG(WARN, "large cuda facade value %s", largeMessage.c_str());
+  logger.flush();
+
+  const auto output = readFile(scopedLogFile.path());
+  EXPECT_EQ(evaluationCount, 0);
+  EXPECT_NE(output.find("cuda facade value 7"), std::string::npos);
+  EXPECT_NE(
+      output.find("large cuda facade value " + largeMessage),
+      std::string::npos);
+
+  logger.configureOutput({});
+  logger.configure("COMMS", []() { return 0; });
 }
 
 TEST_F(LogLevelRestoringTest, EmptyThreadContextUsesDefault) {

--- a/comms/utils/test_utils/CMakeLists.txt
+++ b/comms/utils/test_utils/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 find_package(CUDA REQUIRED)
+find_package(spdlog 1.16.0 CONFIG REQUIRED)
 
 file(GLOB TEST_UTILS_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cc"
@@ -12,9 +13,14 @@ add_library(test_utils OBJECT
 
 target_compile_features(test_utils PRIVATE cxx_std_20)
 target_compile_options(test_utils PRIVATE -fPIC)
+target_compile_definitions(test_utils PRIVATE
+    SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO
+    SPDLOG_FMT_EXTERNAL
+)
 target_include_directories(test_utils PUBLIC
     ${ROOT}
     ${CONDA_INCLUDE}
     ${CUDA_INCLUDE_DIRS}
 )
 target_link_libraries(test_utils PUBLIC fmt::fmt)
+target_link_libraries(test_utils PRIVATE spdlog::spdlog)


### PR DESCRIPTION
Summary:

Migrate MCCL benchmarks, unit tests, integration tests, bootstrap tests, and collective tests to the MCCL spdlog facade.

Keep test assertions paired with the production behavior they validate, including log prefixes, level gates, source metadata, stream formatting, and structured telemetry initialization.

Hot-path impact:
This diff changes benchmark and test code only. It adds no work to production communicator, collective, bootstrap, or transport paths.

Reviewed By: shr

Differential Revision: D116694645
